### PR TITLE
Fixes #1. Don't log "Running" of skipped target 

### DIFF
--- a/core/src/main/scala/mill/eval/Evaluator.scala
+++ b/core/src/main/scala/mill/eval/Evaluator.scala
@@ -85,7 +85,6 @@ class Evaluator(workspacePath: Path,
 
           case _ =>
 
-            pprint.log(labelledTarget.segments)
             val Seq(first, rest @_*) = labelledTarget.segments
             val msgParts = Seq(first.asInstanceOf[Mirror.Segment.Label].value) ++ rest.map{
               case Mirror.Segment.Label(s) => "." + s


### PR DESCRIPTION
This PR fixes issue when `mill` logs "Running <task>" for tasks that really skiped because of upstream failure(s).