### PR TITLE
fix console command in scala plugin

### DIFF
--- a/core/src/main/scala/mill/modules/Jvm.scala
+++ b/core/src/main/scala/mill/modules/Jvm.scala
@@ -15,9 +15,10 @@ import scala.collection.mutable
 object Jvm {
 
   def subprocess(mainClass: String,
-                 classPath: Seq[Path]) = {
+                 classPath: Seq[Path],
+                 options: Seq[String] = Seq.empty) = {
     import ammonite.ops.ImplicitWd._
-    %("java", "-cp", classPath.mkString(":"), mainClass)
+    %("java", "-cp", classPath.mkString(":"), mainClass, options)
   }
 
   private def createManifest(mainClass: Option[String]) = {

--- a/scalaplugin/src/main/scala/mill/scalaplugin/ScalaModule.scala
+++ b/scalaplugin/src/main/scala/mill/scalaplugin/ScalaModule.scala
@@ -8,9 +8,8 @@ import ammonite.ops._
 import coursier.{Cache, Fetch, MavenRepository, Repository, Resolution}
 import mill.define.Task
 import mill.define.Task.{Module, TaskModule}
-import mill.eval.{Evaluator, PathRef}
-import mill.modules.Jvm.{createAssembly, createJar}
-import mill.util.OSet
+import mill.eval.PathRef
+import mill.modules.Jvm.{createAssembly, createJar, subprocess}
 import sbt.internal.inc._
 import sbt.internal.util.{ConsoleOut, MainAppender}
 import sbt.util.{InterfaceUtil, LogExchange}
@@ -282,17 +281,14 @@ trait ScalaModule extends Module with TaskModule{ outer =>
   }
 
   def run(mainClass: String) = T.command{
-    import ammonite.ops._, ImplicitWd._
-    %('java, "-cp", (runDepClasspath().map(_.path) :+ compile().path).mkString(":"), mainClass)
+    subprocess(mainClass, runDepClasspath().map(_.path) :+ compile().path)
   }
 
   def console() = T.command{
-    import ammonite.ops._, ImplicitWd._
-    %('java,
-      "-cp",
-      (runDepClasspath().map(_.path) :+ compile().path).mkString(":"),
-      "scala.tools.nsc.MainGenericRunner",
-      "-usejavacp"
+    subprocess(
+      mainClass = "scala.tools.nsc.MainGenericRunner",
+      classPath = externalCompileDepClasspath().map(_.path) :+ compile().path,
+      options = Seq("-usejavacp")
     )
   }
 }


### PR DESCRIPTION
Previously `mill run Reproduce.console` failed with:
```
➜  mill-zinc mill run Reproduce.console
Error: Could not find or load main class scala.tools.nsc.MainGenericRunner
1 targets failed
mill.define.Command@41390b98 ammonite.ops.InteractiveShelloutException
```
Classpath didn't include `scala-compiler.jar` that contains `scala.tools.nsc.MainGenericRunner`. In this PR we include scala compiler jar to classpath, and now `console` command executes as expected:

```
➜  mill-zinc mill run Reproduce.console
Welcome to Scala 2.12.4 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_72).
Type in expressions for evaluation. Or try :help.

scala> Main.main(Array.empty)
hello world
result of x is: Result(33333)
result is: Result(hello)

scala>
```