### PR TITLE
Check owner of method instead of linear search

### DIFF
--- a/core/src/main/scala/mill/discover/Router.scala
+++ b/core/src/main/scala/mill/discover/Router.scala
@@ -254,7 +254,9 @@ class Router [C <: Context](val c: C) {
   import c.universe._
   def getValsOrMeths(curCls: Type): Iterable[MethodSymbol] = {
     def isAMemberOfAnyRef(member: Symbol) = {
-      weakTypeOf[AnyRef].members.exists(_.name == member.name)
+      // AnyRef is an alias symbol, we go to the real "owner" of these methods
+      val anyRefSym = c.mirror.universe.definitions.ObjectClass
+      member.owner == anyRefSym
     }
     val extractableMembers = for {
       member <- curCls.members


### PR DESCRIPTION
Inherited methods from Object can be checked for owner instead of looking at the name of the method. This should be cleaner and faster, though probably below the margin of error at this point.