### PR TITLE
Pass `$JAVA_OPTS` to the JVM in the generated assembly

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -54,5 +54,5 @@ object ScalaPlugin extends MillModule {
   def basePath = pwd / 'scalaplugin
   override def prependShellScript =
     "#!/usr/bin/env sh\n" +
-    """exec java -cp "$0" mill.Main "$@" """
+    """exec java $JAVA_OPTS -cp "$0" mill.Main "$@" """
 }


### PR DESCRIPTION
This allows an easy way to hook an external debugger via -agentlib. JAVA_OPTS is picked up by both Scala and Sbt, so it seems an easy win.