### PR TITLE
Main class

### DIFF
--- a/scalaplugin/src/main/scala/mill/scalaplugin/ScalaModule.scala
+++ b/scalaplugin/src/main/scala/mill/scalaplugin/ScalaModule.scala
@@ -354,12 +354,12 @@ trait ScalaModule extends Module with TaskModule{ outer =>
     PathRef(dest)
   }
 
-  def runMain() = T.command{
+  def run() = T.command{
     val main = mainClass().getOrElse(throw new RuntimeException("No mainClass provided!"))
     subprocess(main, runDepClasspath().map(_.path) :+ compile().path)
   }
 
-  def run(mainClass: String) = T.command{
+  def runMain(mainClass: String) = T.command{
     subprocess(mainClass, runDepClasspath().map(_.path) :+ compile().path)
   }
 

--- a/scalaplugin/src/test/scala/mill/scalaplugin/HelloWorldTests.scala
+++ b/scalaplugin/src/test/scala/mill/scalaplugin/HelloWorldTests.scala
@@ -147,10 +147,10 @@ object HelloWorldTests extends TestSuite {
         assert(err.isInstanceOf[CompileFailed])
       }
     }
-    'run - {
+    'runMain - {
       'runMainObject - {
         val Right((_, evalCount)) =
-          eval(HelloWorld.run("Main"), helloWorldMapping)
+          eval(HelloWorld.runMain("Main"), helloWorldMapping)
 
         assert(evalCount > 0)
 
@@ -162,7 +162,7 @@ object HelloWorldTests extends TestSuite {
       }
       'notRunInvalidMainObject - {
         val Left(Result.Exception(err)) =
-          eval(HelloWorld.run("Invalid"), helloWorldMapping)
+          eval(HelloWorld.runMain("Invalid"), helloWorldMapping)
 
         assert(
           err.isInstanceOf[InteractiveShelloutException]
@@ -172,17 +172,17 @@ object HelloWorldTests extends TestSuite {
         write.append(mainObject, "val x: ")
 
         val Left(Result.Exception(err)) =
-          eval(HelloWorld.run("Main"), helloWorldMapping)
+          eval(HelloWorld.runMain("Main"), helloWorldMapping)
 
         assert(
           err.isInstanceOf[CompileFailed]
         )
       }
     }
-    'runMain - {
+    'run - {
       'runIfMainClassProvided - {
         val Right((_, evalCount)) =
-          eval(HelloWorldWithMain.runMain(), helloWorldWithMainMapping)
+          eval(HelloWorldWithMain.run(), helloWorldWithMainMapping)
 
         assert(evalCount > 0)
 
@@ -194,7 +194,7 @@ object HelloWorldTests extends TestSuite {
       }
       'notRunWithoutMainClass - {
         val Left(Result.Exception(err)) =
-          eval(HelloWorld.runMain(), helloWorldMapping)
+          eval(HelloWorld.run(), helloWorldMapping)
 
         assert(
           err.isInstanceOf[RuntimeException]


### PR DESCRIPTION
This PR implements `mainClass` target, and `runMain` command
When `mainClass` is provided, `jar` target includes `mainClass` in manifest's Main-Class. 
Also, if `mainClass` is provided, `runMain` command allows you to run project without additional arguments