### PR TITLE
Allow Target creation from Result[T]

### DIFF
--- a/core/src/main/scala/mill/define/Task.scala
+++ b/core/src/main/scala/mill/define/Task.scala
@@ -40,7 +40,7 @@ object Target extends Applicative.Applyer[Task, Task, Result, Ctx]{
 
   implicit def apply[T](t: T): Target[T] = macro targetImpl[T]
 
-  implicit def apply[T](t: Result[T]): Target[T] = macro targetImpl[T]
+  implicit def apply[T](t: Result[T]): Target[T] = macro targetResultImpl[T]
 
   def apply[T](t: Task[T]): Target[T] = macro targetTaskImpl[T]
 
@@ -84,6 +84,15 @@ object Target extends Applicative.Applyer[Task, Task, Result, Ctx]{
     c.Expr[Target[T]](
       mill.plugin.Cacher.wrapCached(c)(
         q"new ${weakTypeOf[TargetImpl[T]]}(${Applicative.impl0[Task, T, Ctx](c)(q"mill.eval.Result.Success($t)").tree}, _root_.sourcecode.Enclosing())"
+      )
+    )
+  }
+
+  def targetResultImpl[T: c.WeakTypeTag](c: Context)(t: c.Expr[Result[T]]): c.Expr[Target[T]] = {
+    import c.universe._
+    c.Expr[Target[T]](
+      mill.plugin.Cacher.wrapCached(c)(
+        q"new ${weakTypeOf[TargetImpl[T]]}(${Applicative.impl0[Task, T, Ctx](c)(t.tree).tree}, _root_.sourcecode.Enclosing())"
       )
     )
   }

--- a/core/src/test/scala/mill/define/CacherTests.scala
+++ b/core/src/test/scala/mill/define/CacherTests.scala
@@ -4,6 +4,7 @@ import mill.discover.Discovered
 import mill.eval.Evaluator
 import mill.util.{DummyLogger, OSet}
 import mill.T
+import mill.eval.Result.Success
 import utest._
 import utest.framework.TestPath
 
@@ -11,6 +12,7 @@ object CacherTests extends TestSuite{
   object Base extends Base
   trait Base extends Task.Module{
     def value = T{ 1 }
+    def result = T{ Success(1) }
   }
   object Middle extends Middle
   trait Middle extends Base{
@@ -34,6 +36,11 @@ object CacherTests extends TestSuite{
     'simpleDefIsCached - assert(
       Base.value eq Base.value,
       eval(Discovered.mapping(Base), Base.value) == 1
+    )
+
+    'resultDefIsCached - assert(
+      Base.result eq Base.result,
+      eval(Discovered.mapping(Base), Base.result) == 1
     )
 
     val middleMapping = Discovered.mapping(Middle)


### PR DESCRIPTION
`apply[T](t: Result[T]): Target[T]` method existed, but didn't work after macro expansion because it produced `Success[Result[T]`