### PR TITLE
Proof of concept: Remote Caching

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -53,6 +53,13 @@ object Deps {
   val upickle = ivy"com.lihaoyi::upickle:0.7.1"
   val utest = ivy"com.lihaoyi::utest:0.6.4"
   val zinc = ivy"org.scala-sbt::zinc:1.2.5"
+
+  //Just here temporarily for prototyping
+  val http4sVersion = "0.21.0-M5"
+  val http4sBlazeClient = ivy"org.http4s::http4s-blaze-client:$http4sVersion"
+  val http4sBlazeServer = ivy"org.http4s::http4s-blaze-server:$http4sVersion"
+  val http4sDSL = ivy"org.http4s::http4s-dsl:$http4sVersion"
+
 }
 
 trait MillPublishModule extends PublishModule{
@@ -141,7 +148,10 @@ object main extends MillModule {
       Deps.ammonite,
       // Necessary so we can share the JNA classes throughout the build process
       Deps.jna,
-      Deps.jnaPlatform
+      Deps.jnaPlatform,
+      Deps.http4sBlazeClient,
+      Deps.http4sBlazeServer,
+      Deps.http4sDSL
     )
 
     def generatedSources = T {

--- a/build.sc
+++ b/build.sc
@@ -60,6 +60,7 @@ object Deps {
   val http4sBlazeServer = ivy"org.http4s::http4s-blaze-server:$http4sVersion"
   val http4sDSL = ivy"org.http4s::http4s-dsl:$http4sVersion"
   val http4sArgonaut = ivy"org.http4s::http4s-argonaut:$http4sVersion"
+  val apacheCommonsCompress = ivy"org.apache.commons:commons-compress:1.19"
 
 }
 
@@ -153,7 +154,8 @@ object main extends MillModule {
       Deps.http4sBlazeClient,
       Deps.http4sBlazeServer,
       Deps.http4sDSL,
-      Deps.http4sArgonaut
+      Deps.http4sArgonaut,
+      Deps.apacheCommonsCompress
     )
 
     def generatedSources = T {

--- a/build.sc
+++ b/build.sc
@@ -59,6 +59,7 @@ object Deps {
   val http4sBlazeClient = ivy"org.http4s::http4s-blaze-client:$http4sVersion"
   val http4sBlazeServer = ivy"org.http4s::http4s-blaze-server:$http4sVersion"
   val http4sDSL = ivy"org.http4s::http4s-dsl:$http4sVersion"
+  val http4sArgonaut = ivy"org.http4s::http4s-argonaut:$http4sVersion"
 
 }
 
@@ -151,7 +152,8 @@ object main extends MillModule {
       Deps.jnaPlatform,
       Deps.http4sBlazeClient,
       Deps.http4sBlazeServer,
-      Deps.http4sDSL
+      Deps.http4sDSL,
+      Deps.http4sArgonaut
     )
 
     def generatedSources = T {

--- a/main/api/src/mill/api/PathRef.scala
+++ b/main/api/src/mill/api/PathRef.scala
@@ -23,7 +23,6 @@ object PathRef {
    * @return
    */
   def apply(path: os.Path, quick: Boolean = false): PathRef = {
-    println(s"Given path $path")
     val sig = {
       val digest = MessageDigest.getInstance("MD5")
       val digestOut = new DigestOutputStream(DummyOutputStream, digest)
@@ -62,7 +61,6 @@ object PathRef {
         p.path.toString()
     },
     s => {
-      print(s)
       val Array(prefix, hex, path) = s.split(":", 3)
       PathRef(
         os.Path(path),

--- a/main/api/src/mill/api/PathRef.scala
+++ b/main/api/src/mill/api/PathRef.scala
@@ -23,6 +23,7 @@ object PathRef {
    * @return
    */
   def apply(path: os.Path, quick: Boolean = false): PathRef = {
+    println(s"Given path $path")
     val sig = {
       val digest = MessageDigest.getInstance("MD5")
       val digestOut = new DigestOutputStream(DummyOutputStream, digest)
@@ -61,6 +62,7 @@ object PathRef {
         p.path.toString()
     },
     s => {
+      print(s)
       val Array(prefix, hex, path) = s.split(":", 3)
       PathRef(
         os.Path(path),

--- a/main/core/src/eval/Evaluator.scala
+++ b/main/core/src/eval/Evaluator.scala
@@ -14,7 +14,6 @@ import mill.util
 import mill.util._
 import mill.api.Strict.Agg
 
-
 case class Labelled[T](task: NamedTask[T],
                        segments: Segments){
   def format = task match{
@@ -51,7 +50,7 @@ case class Evaluator(home: os.Path,
     val evaluated = new Agg.Mutable[Task[_]]
     val results = mutable.LinkedHashMap.empty[Task[_], Result[(Any, Int)]]
     var someTaskFailed: Boolean = false
-    val remoteCache = if (remoteCaching) Some(RemoteCacher.getCached(log)) else None
+    val remotelyCached: Option[RemoteCacher.Cached] = if (remoteCaching) Some(RemoteCacher.getCached(log)) else None
 
     val timings = mutable.ArrayBuffer.empty[(Either[Task[_], Labelled[_]], Int, Boolean)]
     for (((terminal, group), i) <- sortedGroups.items().zipWithIndex)
@@ -73,7 +72,7 @@ case class Evaluator(home: os.Path,
         group,
         results,
         counterMsg,
-        remoteCache
+        remotelyCached
       )
 
       someTaskFailed = someTaskFailed || newResults.exists(task => !task._2.isInstanceOf[Success[_]])

--- a/main/core/src/eval/Evaluator.scala
+++ b/main/core/src/eval/Evaluator.scala
@@ -14,7 +14,6 @@ import mill.util
 import mill.util._
 import mill.api.Strict.Agg
 
-import scala.concurrent.Future
 
 case class Labelled[T](task: NamedTask[T],
                        segments: Segments){
@@ -139,7 +138,7 @@ case class Evaluator(home: os.Path,
       group.toIterator.map(_.sideHash)
     )
 
-    val inputsHash = externalInputsHash + sideHashes //TODO this is messing with me add back in later+ classLoaderSignHash
+    val inputsHash = externalInputsHash + sideHashes //+ classLoaderSignHash TODO add this back in. It changes when I change anything in the directory making it hard to test
 
     terminal match{
       case Left(task) =>
@@ -262,8 +261,6 @@ case class Evaluator(home: os.Path,
     } else labelledTask.segments
   }
 
-
-  //TODO would handle remote cache as well here
   def handleTaskResult(v: Any,
                        hashCode: Int,
                        metaPath: os.Path,

--- a/main/core/src/eval/RemoteCacher.scala
+++ b/main/core/src/eval/RemoteCacher.scala
@@ -1,0 +1,155 @@
+package eval
+
+import java.lang
+
+import ammonite.ops.{Path, cp, ls, mkdir, pwd, rm}
+import ammonite.util.Colors
+import cats.effect.{Blocker, IO}
+import cats.effect.IO.contextShift
+import org.http4s.client.blaze.BlazeClientBuilder
+import org.http4s.{EntityDecoder, Method, Request, Uri}
+import ujson.{Arr, Obj, Str, Value}
+
+import scala.util.Try
+import scala.util.matching.Regex
+import mill.define.Task
+import cats.instances.list._
+import cats.syntax.parallel._
+import mill.eval.Logger
+import mill.util.PrintLogger
+
+import scala.concurrent.ExecutionContext
+
+object RemoteCacher {
+  var log: Logger = _ //sneakily injecting a log
+//  var log = PrintLogger(
+//    true,
+//    true,
+//    Colors.Default,
+//    System.out,
+//    System.err,
+//    System.err,
+//    System.in,
+//    debugEnabled = false
+//  )
+
+  implicit val ec = scala.concurrent.ExecutionContext.global
+  implicit val cs = contextShift(ec)
+  val clientResource = BlazeClientBuilder[IO](ec).resource
+
+  val outDir: Path = pwd / 'out
+  val newOutDir: Path = pwd / 'tmpOut
+
+  /**
+    * Uploads tasks to specified remote caching server
+    */
+  def uploadTasks(tasks: Seq[Task[_]], evilLog: Logger): Unit = {
+    log = evilLog
+    log.info("Uploading attempt")
+    rm(newOutDir)
+    mkdir(newOutDir)
+    //TODO use Tasks. Hardcoding for now
+    uploadTask("foo")
+    uploadTask("bar")
+    rm(newOutDir)
+  }
+
+  private def uploadIO(compressedPath: Path, pathFrom: Path, hash: Int): IO[Unit] = {
+//    fs2.io.readInputStream[IO](, 1000, Blocker.liftExecutionContext(ExecutionContext.global))
+    log.info(s"upload attempt for $compressedPath with hash $hash")
+    implicit val decoder = EntityDecoder.void[IO]
+    clientResource.use[Unit](client => {
+      val request = Request[IO](
+        method = Method.PUT,
+        uri = Uri.unsafeFromString(s"https:localhost:7000/cache/$pathFrom?hash=$hash"),
+        body = fs2.io.file.readAll[IO](compressedPath.toNIO, Blocker.liftExecutionContext(ExecutionContext.global), 1000)
+      )
+      log.info(request.toString())
+      client.expect(
+        request
+      )
+    }
+    )
+  }
+
+  val metaPathWithRef: Regex = "(q?ref:[0-9a-fA-F]+:)(.*)".r
+  val maybePathRegex: Regex = "(/.*)".r //TODO better regex?
+  private def convertIfPath(relativeTo: Path): Value => Option[String] = {
+    case Str(metaPathWithRef(ref, path)) => Some(s"$ref${
+      Path(path).relativeTo(relativeTo)
+    } ")
+    case Str(maybePathRegex(maybePath)) =>
+      Try {
+        Path(maybePath).relativeTo(relativeTo).toString()
+      } toOption
+    case _ => None
+  }
+
+
+  /**
+    * Uploads the task. Anything associated with an input hash will be uploaded.
+    * Some tasks like T {10} just have one directory to upload.
+    * But a Task using ScalaModule would have allSources, compile, etc. Each of those directories would be uploaded with it's hash.
+    *
+    * @param taskName
+    */
+  private def uploadTask(taskName: String): Unit = {
+
+    val taskDir: Path = outDir / taskName
+    val newTaskDir: Path = newOutDir / taskName
+    cp(taskDir, newTaskDir)
+
+    val directoriesWithHash = if (ammonite.ops.exists(newTaskDir / "meta.json")) {
+      List(newTaskDir)
+    } else {
+      ls ! newTaskDir toList
+    }
+
+    directoriesWithHash.map(p => {
+      rewriteMeta(p)
+      val compressedPath = Path(s"$p.tar.gz")
+      ammonite.ops.%%('tar, "-zcvf", compressedPath, p)(p)
+
+      uploadIO(compressedPath, p, 3) //TODO rewrite some of this to get hash above
+    }).parSequence.unsafeRunAsyncAndForget()
+
+
+    /**
+      * Rewrite metaJson so if there are any absolute paths then convert them to relative paths.
+      *
+      * @param baseDir
+      */
+    def rewriteMeta(baseDir: Path): Unit = {
+      val metaDir = baseDir / "meta.json"
+      val metaJson = ujson.read(metaDir toIO)
+
+      metaJson.obj.get("value").foreach {
+        case Obj(obj) =>
+          obj.foreach({
+            case (k, v) =>
+              convertIfPath(baseDir)(v).foreach(s => {
+                println(s);
+                obj.update(k, s)
+              })
+          })
+        case Arr(arr) =>
+          metaJson.obj.put("value",
+            Arr(
+              arr.map(v =>
+                convertIfPath(baseDir)(v).map({
+                  s => Str(s)
+                }).getOrElse(v)
+              )
+            )
+          )
+        case Str(str) =>
+          convertIfPath(baseDir)(str).foreach(s =>
+            metaJson.obj.put("value", Str(s))
+          )
+        case _ => ()
+      }
+
+      ammonite.ops.write.over(baseDir / "meta.json", ujson.write(metaJson, 4))
+    }
+  }
+}

--- a/main/core/src/eval/RemoteCacher.scala
+++ b/main/core/src/eval/RemoteCacher.scala
@@ -91,7 +91,6 @@ object RemoteCacher {
       tmpFOS.close()
 
       ammonite.ops.%%('tar, "xvzf", tmpFile.getPath.toString)(path)
-      //        ammonite.ops.%%(s"tar -xvzf ${tmpFile.getPath}")(parentDir(path))
 
       true
     } else {
@@ -191,7 +190,7 @@ object RemoteCacher {
       }
     })
     tos.close()
-    uploadIO(compressedPath, taskDir.relativeTo(outDir).toString, hashCode) //TODO rewrite some of this to get hash above
+    uploadIO(compressedPath, taskDir.relativeTo(outDir).toString, hashCode)
 
   }
 

--- a/main/test/src/eval/EvaluationTests.scala
+++ b/main/test/src/eval/EvaluationTests.scala
@@ -321,11 +321,13 @@ object EvaluationTests extends TestSuite{
         // cached target
         val check = new Checker(build)
         assert(leftCount == 0, rightCount == 0)
+        println("first eval")
         check(down, expValue = 10101, expEvaled = Agg(up, right, down), extraEvaled = 8)
         assert(leftCount == 1, middleCount == 1, rightCount == 1)
 
         // If the upstream `up` doesn't change, the entire block of tasks
         // doesn't need to recompute
+        println("second eval. No changes should be cached")
         check(down, expValue = 10101, expEvaled = Agg())
         assert(leftCount == 1, middleCount == 1, rightCount == 1)
 
@@ -334,6 +336,7 @@ object EvaluationTests extends TestSuite{
         // because tasks have no cached value that can be used. `right`, which
         // is a cached Target, does not recompute
         up.inputs(0).asInstanceOf[Test].counter += 1
+        println("third eval. Up has changed. Right should stay cached I believe. But also middle because it has no cached value.")
         check(down, expValue = 10102, expEvaled = Agg(up, down), extraEvaled = 6)
         assert(leftCount == 2, middleCount == 2, rightCount == 1)
 

--- a/scalalib/src/JavaModule.scala
+++ b/scalalib/src/JavaModule.scala
@@ -48,6 +48,8 @@ trait JavaModule extends mill.Module with TaskModule with GenIdeaModule { outer 
       case None =>
         zincWorker.worker().discoverMainClasses(compile())match {
           case Seq() => Left("No main class specified or found")
+          //Unrelated: Could make a better warning message here. I had class S extends IOApp (which has main) but is not static.
+          //Had to make it object S extends IOApp and it made a static main that was discovered.
           case Seq(main) => Right(main)
           case mains =>
             Left(

--- a/scratch/bar/src/Main.scala
+++ b/scratch/bar/src/Main.scala
@@ -1,0 +1,5 @@
+object HelloWorld {
+  def main(args: Array[String]): Unit = {
+    println("Hello, world!")
+  }
+}

--- a/scratch/bar/src/Main.scala
+++ b/scratch/bar/src/Main.scala
@@ -1,5 +1,7 @@
+import foo.Library
+
 object HelloWorld {
   def main(args: Array[String]): Unit = {
-    println("Hello, world!")
+    println(s"Hello, world! ${Library.fancyLibrary}")
   }
 }

--- a/scratch/build.sc
+++ b/scratch/build.sc
@@ -1,12 +1,10 @@
-import mill.Agg
-import mill.scalalib._
+import mill._, scalalib._
 
-object core extends ScalaModule{
+object foo extends ScalaModule {
   def scalaVersion = "2.12.8"
-  def ivyDeps = Agg(
-    ivy"org.eclipse.jetty:jetty-websocket:8.1.16.v20140903",
-    ivy"org.eclipse.jetty:jetty-server:8.1.16.v20140903"
-  )
 }
 
-def thingy = T{ Seq("hello", "world") }
+object bar extends ScalaModule {
+  def scalaVersion = "2.12.8"
+  override def moduleDeps = Seq(foo)
+}

--- a/scratch/foo/src/Library.scala
+++ b/scratch/foo/src/Library.scala
@@ -1,3 +1,5 @@
-class Library() {
-  val fancyLibrary = 2
+package foo
+
+object Library {
+  val fancyLibrary = 42
 }

--- a/scratch/foo/src/Library.scala
+++ b/scratch/foo/src/Library.scala
@@ -1,0 +1,3 @@
+class Library() {
+  val fancyLibrary = 2
+}


### PR DESCRIPTION
Hey @lihaoyi,

I spoke to you on gitter about remote caching maybe a month or so ago and here's my attempt.
I have a remote caching server implementation and a write up here: https://github.com/psilospore/mill-remote-cache-server

This was a fun exercise! Let me know how I could improve this.

In addition to the information found in the readme linked above, on the mill front I wrote:
* A remote caching client that talks to my remote caching server RemoteCacher
* It uses some dependencies that are only there for the proof of concept I could do it differently if you'd like.
* It checks what tasks are cached, uploads tasks in a gzipped tar, and fetches tasks by uncompressing them and moving artifacts to their proper place in `out`.
* You mentioned I should first make mill work with relative paths. I did struggle with that a bit but another method I thought about was just making it relative when I upload it. There are probably some problems with that approach I'll mention it later.
* Not sure if I should use apache commons compress or call out to `tar` with `ammonite.ops.%%`.