### PR TITLE
Support customizing coursier dependency resolution (make OS specific classifiers work)

### DIFF
--- a/main/src/modules/Jvm.scala
+++ b/main/src/modules/Jvm.scala
@@ -570,6 +570,7 @@ object Jvm {
       .withRootDependencies(deps.map(mapDependencies.getOrElse(identity[Dependency](_))).toSeq)
       .withForceVersions(forceVersions)
       .withMapDependencies(mapDependencies)
+      .withOsInfo(coursier.core.Activation.Os.fromProperties(sys.props.toMap))
 
     val resolutionLogger = ctx.map(c => new TickerResolutionLogger(c))
     val cache = resolutionLogger match {

--- a/scalalib/src/CoursierModule.scala
+++ b/scalalib/src/CoursierModule.scala
@@ -48,6 +48,23 @@ trait CoursierModule extends mill.Module {
     */
   def repositoriesTask: Task[Seq[Repository]] = T.task { repositories }
 
+  /**
+    * Customize the coursier resolution resolution process.
+    * This is rarely needed to changed, as the default try to provide a
+    * highly reproducible resolution process. But sometime, you need
+    * more control, e.g. you want to add some OS or JDK specific resolution properties
+    * which are sometimes used by Maven and therefore found in dependency artifact metadata.
+    * For example, the JavaFX artifacts are known to use OS specific properties.
+    * To fix resolution for JavaFX, you could override this task like the following:
+    * {{{
+    *     override def resolutionCustomizer = T.task {
+    *       Some( (r: coursier.core.Resolution) =>
+    *         r.withOsInfo(coursier.core.Activation.Os.fromProperties(sys.props.toMap))
+    *       )
+    *     }
+    * }}}
+    * @return
+    */
   def resolutionCustomizer: Task[Option[Resolution => Resolution]] = T.task { None }
 
   /**

--- a/scalalib/src/JavaModule.scala
+++ b/scalalib/src/JavaModule.scala
@@ -444,7 +444,8 @@ trait JavaModule
         repositoriesTask(),
         resolveCoursierDependency().apply(_),
         additionalDeps() ++ transitiveIvyDeps(),
-        Some(mapDependencies())
+        Some(mapDependencies()),
+        customizer = resolutionCustomizer()
       )
 
       println(


### PR DESCRIPTION
This should fix #767.

TBH, I'm not sure we want this in mill. So I encourage a review and/or discussion.

On one side this fixes an issue with resolving transitive dependencies with os-specific classifiers (#767). But on the other side it makes dependency resolution less reproducible.

So a perfect outcome of this PR for me is also a rejection paired with some documentation how to deal with such situations.