### PR TITLE
Clean up BSP logging output.

### DIFF
--- a/bsp/src/mill/bsp/MillBspLogger.scala
+++ b/bsp/src/mill/bsp/MillBspLogger.scala
@@ -1,57 +1,86 @@
 package mill.bsp
 
+import ammonite.util.Colors
 import ch.epfl.scala.bsp4j._
-import mill.api.Logger
-import mill.util.{ColorLogger, ProxyLogger}
+import java.io.{ ByteArrayOutputStream, InputStream, PrintStream }
+import java.nio.charset.Charset
+import mill.bsp.MillBspLogger.tickerPattern
+import mill.util.ColorLogger
 
+object MillBspLogger {
+  /**
+   * Creates a BSP-specialized logger class which sends `task-progress`
+   * notifications ( upon the invocation of the `ticker` method ) and
+   * `show-message` notifications ( for each error or information
+   * being logged ).
+   *
+   * @param client the client to send notifications to, also the
+   *               client that initiated a request which triggered
+   *               a mill task evaluation
+   * @param taskId unique ID of the task being evaluated
+   * @param inputStream The input stream to read input from
+   */
+  def createBspLogger(client: BuildClient, taskId: Int, inputStream: InputStream): ColorLogger = {
+    val bspErrorStream = new MillBspClientPrintStream(client, MessageType.INFORMATION, new ByteArrayOutputStream())
+    val bspOutputStream = new MillBspClientPrintStream(client, MessageType.INFORMATION, new ByteArrayOutputStream())
+    new MillBspLogger(client, taskId, inputStream, bspOutputStream, bspErrorStream)
+  }
 
-/**
-  * BSP-specialized logger class which sends `task-progress`
-  * notifications ( upon the invocation of the `ticker` method ) and
-  * `show-message` notifications ( for each error or information
-  * being logged ).
-  *
-  * @param client the client to send notifications to, also the
-  *               client that initiated a request which triggered
-  *               a mill task evaluation
-  * @param taskId unique ID of the task being evaluated
-  * @param logger the logger to which the messages received by this
-  *               MillBspLogger are being redirected
-  */
-class MillBspLogger(client: BuildClient, taskId: Int, logger: Logger)
-  extends ProxyLogger(logger)  with ColorLogger {
-  def colors = ammonite.util.Colors.BlackWhite
+  private val tickerPattern = """\[(?<progress>\d+)/(?<total>\d+)] (?<unit>.\S+)\s+$""".r
+}
+
+private class MillBspLogger(
+                      client: BuildClient,
+                      taskId: Int,
+                      inputStream: InputStream,
+                      outStream: PrintStream,
+                      errStream: PrintStream) extends ColorLogger {
+
+  override def colored: Boolean = false
+
+  override def colors: Colors = Colors.BlackWhite
+
+  override def errorStream: PrintStream = errStream
+
+  override def outputStream: PrintStream = outStream
+
+  override def inStream: InputStream = inputStream
+
+  override def info(s: String): Unit = {
+    client.onBuildShowMessage(new ShowMessageParams(MessageType.INFORMATION, s))
+  }
+
+  override def error(s: String): Unit = {
+    client.onBuildShowMessage(new ShowMessageParams(MessageType.ERROR, s))
+  }
 
   override def ticker(s: String): Unit = {
     try {
-      val progressString = s.split(" ")(0)
-      val progress = progressString.substring(1, progressString.length - 1).split("/")
-      val params = new TaskProgressParams(new TaskId(taskId.toString))
-      params.setEventTime(System.currentTimeMillis())
-      params.setMessage(s)
-      params.setUnit(s.split(" ")(1))
-      params.setProgress(progress(0).toLong)
-      params.setTotal(progress(1).toLong)
-      client.onBuildTaskProgress(params)
-      super.ticker(s)
+      client.onBuildShowMessage(new ShowMessageParams(MessageType.INFORMATION, s))
+      tickerPattern.findFirstMatchIn(s).foreach { ticker =>
+        val params = new TaskProgressParams(new TaskId(taskId.toString))
+        params.setEventTime(System.currentTimeMillis())
+        params.setMessage(s)
+        params.setUnit(ticker.group("unit"))
+        params.setProgress(ticker.group("progress").toLong)
+        params.setTotal(ticker.group("total").toLong)
+        client.onBuildTaskProgress(params)
+      }
     } catch {
       case e: Exception =>
     }
   }
 
-  override def error(s: String): Unit = {
-    super.error(s)
-    client.onBuildShowMessage(new ShowMessageParams(MessageType.ERROR, s))
-  }
-
-  override def info(s: String): Unit = {
-    super.info(s)
-    client.onBuildShowMessage(new ShowMessageParams(MessageType.INFORMATION, s))
-  }
-
   override def debug(s: String): Unit = {
-    super.debug(s)
     client.onBuildShowMessage(new ShowMessageParams(MessageType.LOG, s))
   }
+}
 
+class MillBspClientPrintStream(client: BuildClient, messageType: MessageType, val byteOutput: ByteArrayOutputStream) extends PrintStream(byteOutput, true, Charset.defaultCharset().name()) {
+  override def flush(): Unit = synchronized {
+    super.flush()
+    val message = byteOutput.toString(Charset.defaultCharset().name())
+    byteOutput.reset()
+    client.onBuildShowMessage(new ShowMessageParams(messageType, message))
+  }
 }

--- a/bsp/src/mill/bsp/MillBuildServer.scala
+++ b/bsp/src/mill/bsp/MillBuildServer.scala
@@ -188,7 +188,7 @@ class MillBuildServer(evaluator: Evaluator, bspVersion: String, serverVersion: S
         compileTasks,
         getBspLoggedReporterPool(params, modules, evaluator, client),
         DummyTestReporter,
-        new MillBspLogger(client, taskId, evaluator.baseLogger)
+        MillBspLogger.createBspLogger(client, taskId, evaluator.baseLogger.inStream)
       )
       val compileResult = new CompileResult(getStatusCode(result))
       compileResult.setOriginId(compileParams.getOriginId)
@@ -206,7 +206,7 @@ class MillBuildServer(evaluator: Evaluator, bspVersion: String, serverVersion: S
       val runResult = evaluator.evaluate(
         Strict.Agg(runTask),
         getBspLoggedReporterPool(params, modules, evaluator, client),
-        logger = new MillBspLogger(client, runTask.hashCode(), evaluator.baseLogger)
+        logger = MillBspLogger.createBspLogger(client, runTask.hashCode(), evaluator.baseLogger.inStream)
       )
       val response = runResult.results(runTask) match {
         case _: Result.Success[Any] => new RunResult(StatusCode.OK)
@@ -263,7 +263,7 @@ class MillBuildServer(evaluator: Evaluator, bspVersion: String, serverVersion: S
                 Strict.Agg(testTask),
                 getBspLoggedReporterPool(params, modules, evaluator, client),
                 testReporter,
-                new MillBspLogger(client, testTask.hashCode, evaluator.baseLogger)
+                MillBspLogger.createBspLogger(client, testTask.hashCode, evaluator.baseLogger.inStream)
               )
               val statusCode = getStatusCode(results)
 
@@ -311,7 +311,7 @@ class MillBuildServer(evaluator: Evaluator, bspVersion: String, serverVersion: S
           val cleanTask = mainModule.clean(evaluator, Seq(s"${module.millModuleSegments.render}.compile"): _*)
           val cleanResult = evaluator.evaluate(
             Strict.Agg(cleanTask),
-            logger = new MillBspLogger(client, cleanTask.hashCode, evaluator.baseLogger)
+            logger = MillBspLogger.createBspLogger(client, cleanTask.hashCode, evaluator.baseLogger.inStream)
           )
           if (cleanResult.failing.keyCount > 0) (
             msg + s" Target ${module.millModuleSegments.render} could not be cleaned. See message from mill: \n" +

--- a/main/core/src/util/Loggers.scala
+++ b/main/core/src/util/Loggers.scala
@@ -239,7 +239,7 @@ case class MultiLogger(colored: Boolean, logger1: Logger, logger2: Logger, inStr
   * A Logger that forwards all logging to another Logger.  Intended to be
   * used as a base class for wrappers that modify logging behavior.
   */
-case class ProxyLogger(logger: Logger) extends Logger {
+class ProxyLogger(logger: Logger) extends Logger {
   def colored = logger.colored
 
   lazy val outputStream = logger.outputStream


### PR DESCRIPTION
Previously, the MillBspLogger proxied the evaluator logger, which meant all
output went twice to stdout, once through the proxy and once through the BSP client
messages.
    
MillBspLogger now does not proxy a logger, instead it only writes to the BSP
client. It will write whatever is emitted to its streams, or written
via the Logger methods on it.
    
The logger no longer uses the ticker formatting or colors offered by PrintLogger.
This decoration is only suitable for the terminal, since e.g. color codes and navigation codes
are unlikely to be supported in an editor's log output.
    
To debug this, I've added a log file that logs the raw json output from
BSP/start. I've also moved the BSP client logging to the BSP/start dest
directory, so it no longer goes in .bsp/mill.log.
    
ProxyLogger is no longer a case class. It is intended for subclassing,
so it not suitable as a case class.