### PR TITLE
Fix #907 - mill-contrib-playlib: java.lang.NoClassDefFoundError

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -401,7 +401,10 @@ object contrib extends MillModule {
     object worker extends Cross[WorkerModule]( "2.6", "2.7")
 
     class WorkerModule(scalajsBinary: String) extends MillApiModule  {
-      def scalaVersion = T { "2.12.10" }
+      def scalaVersion = T { scalajsBinary match {
+        case "2.6"=>"2.12.10"
+        case _ => "2.13.2"
+      } }
       def moduleDeps = Seq(playlib.api)
       def ivyDeps = scalajsBinary match {
         case  "2.6"=>

--- a/contrib/playlib/src/mill/playlib/RouteCompilerWorkerApi.scala
+++ b/contrib/playlib/src/mill/playlib/RouteCompilerWorkerApi.scala
@@ -20,7 +20,7 @@ private[playlib] class RouteCompilerWorker {
         ctx.log.debug("Loading classes from\n"+toolsClassPath.mkString("\n"))
         val cl = mill.api.ClassLoader.create(
           toolsClassPath,
-          null,
+          getClass.getClassLoader,
           sharedPrefixes = Seq("mill.playlib.api.")
         )
         val bridge = cl

--- a/contrib/playlib/src/mill/playlib/RouterModule.scala
+++ b/contrib/playlib/src/mill/playlib/RouterModule.scala
@@ -47,14 +47,24 @@ trait RouterModule extends ScalaModule with Version {
   def generatorType: RouteCompilerType = RouteCompilerType.InjectedGenerator
 
   def routerClasspath: T[Agg[PathRef]] = T {
+    val routerScalaVersion = playMinorVersion() match {
+      case "2.7" => "2.13"
+      case _ => scalaVersion()
+    }
+
+    val routerPlayVersion = playMinorVersion() match {
+      case "2.7" => "2.7.9"
+      case _ => playVersion()
+    }
+
     resolveDependencies(
       Seq(
         coursier.LocalRepositories.ivy2Local,
         MavenRepository("https://repo1.maven.org/maven2")
       ),
-      Lib.depToDependency(_, scalaVersion()),
+      Lib.depToDependency(_, routerScalaVersion),
       Seq(
-        ivy"com.typesafe.play::routes-compiler:${playVersion()}"
+        ivy"com.typesafe.play::routes-compiler:${routerPlayVersion}"
       )
     )
   }
@@ -83,7 +93,7 @@ trait RouterModule extends ScalaModule with Version {
       s"mill-contrib-playlib-worker-${playMinorVersion()}",
       repositoriesTask(),
       resolveFilter = _.toString.contains("mill-contrib-playlib-worker"),
-      artifactSuffix = "_2.12"
+      artifactSuffix = "_2.13"
     )
   }
 


### PR DESCRIPTION
This PR fix mill/playlib/api/RouteCompilerWorkerApi Class not found.
Resolves #907