### PR TITLE
Replace Win32 named pipe with simple ServerSocket

### DIFF
--- a/main/client/src/mill/main/client/ProxyStreamPumper.java
+++ b/main/client/src/mill/main/client/ProxyStreamPumper.java
@@ -40,19 +40,8 @@ public class ProxyStreamPumper implements Runnable{
                     else dest2.write(buffer, 0, offset);
                 }
             } catch (IOException e) {
-                // Win32NamedPipeSocket input stream somehow doesn't return -1,
-                // instead it throws an IOException whose message contains "ReadFile()".
-                // However, if it throws an IOException before ever reading some bytes,
-                // it could not connect to the server, so exit.
-                if (Util.isWindows && e.getMessage().contains("ReadFile()")) {
-                    if (first) {
-                        System.err.println("Failed to connect to server");
-                        System.exit(1);
-                    } else running = false;
-                } else {
-                    e.printStackTrace();
-                    System.exit(1);
-                }
+                e.printStackTrace();
+                System.exit(1);
             }
         }
     }

--- a/main/client/src/mill/main/client/Util.java
+++ b/main/client/src/mill/main/client/Util.java
@@ -11,12 +11,6 @@ public class Util {
     public static boolean isWindows = System.getProperty("os.name").toLowerCase().startsWith("windows");
     public static boolean isJava9OrAbove = !System.getProperty("java.specification.version").startsWith("1.");
 
-    // Windows named pipe prefix (see https://github.com/sbt/ipcsocket/blob/v1.0.0/README.md)
-    // Win32NamedPipeServerSocket automatically adds this as a prefix (if it is not already is prefixed),
-    // but Win32NamedPipeSocket does not
-    // https://github.com/sbt/ipcsocket/blob/v1.0.0/src/main/java/org/scalasbt/ipcsocket/Win32NamedPipeServerSocket.java#L36
-    public static String WIN32_PIPE_PREFIX = "\\\\.\\pipe\\";
-
     public static String[] parseArgs(InputStream argStream) throws IOException {
 
         int argsLength = readInt(argStream);


### PR DESCRIPTION
This currently works fine, but spawns a new server on every invocation!?  
I'm not sure if this is a problem introduced by this change but I doubt it.  
Maybe I just don't understand the locks code in Mill well enough.. 😄 

Anyways, it runs a simple `ServerSocket` on a random port on localhost, and writes that port in a file.  
Client can then read the port and connect to the server.  

I also "tested" the security part of server, by running an Android app that scans the ports of my computer.  
It doesn't show the allocated port, so should be good.