### PR TITLE
Fix binary version computation of Scala nightly versions

### DIFF
--- a/scalalib/api/src/ZincWorkerApi.scala
+++ b/scalalib/api/src/ZincWorkerApi.scala
@@ -86,12 +86,14 @@ object Util {
   val DottyVersion = raw"""0\.(\d+)\.(\d+).*""".r
   val Scala3Version = raw"""3\.(\d+)\.(\d+)-(\w+).*""".r
   val DottyNightlyVersion = raw"""(0|3)\.(\d+)\.(\d+)-bin-(.*)-NIGHTLY""".r
+  val NightlyVersion = raw"""(\d+)\.(\d+)\.(\d+)-bin-[a-f0-9]*""".r
   val TypelevelVersion = raw"""(\d+)\.(\d+)\.(\d+)-bin-typelevel.*""".r
 
 
   def scalaBinaryVersion(scalaVersion: String) = scalaVersion match {
       case ReleaseVersion(major, minor, _) => s"$major.$minor"
       case MinorSnapshotVersion(major, minor, _) => s"$major.$minor"
+      case NightlyVersion(major, minor, _) => s"$major.$minor"
       case DottyVersion(minor, _) => s"0.$minor"
       case Scala3Version(minor, patch, milestone) => s"3.$minor.$patch-$milestone"
       case TypelevelVersion(major, minor, _) => s"$major.$minor"

--- a/scalalib/api/src/ZincWorkerApi.scala
+++ b/scalalib/api/src/ZincWorkerApi.scala
@@ -84,18 +84,20 @@ object Util {
   val ReleaseVersion = raw"""(\d+)\.(\d+)\.(\d+)""".r
   val MinorSnapshotVersion = raw"""(\d+)\.(\d+)\.([1-9]\d*)-SNAPSHOT""".r
   val DottyVersion = raw"""0\.(\d+)\.(\d+).*""".r
-  val Scala3Version = raw"""3\.(\d+)\.(\d+)-(\w+).*""".r
+  val Scala3EarlyVersion = raw"""3\.0\.0-(\w+).*""".r
+  val Scala3Version = raw"""3\.(\d+)\.(\d+).*""".r
   val DottyNightlyVersion = raw"""(0|3)\.(\d+)\.(\d+)-bin-(.*)-NIGHTLY""".r
   val NightlyVersion = raw"""(\d+)\.(\d+)\.(\d+)-bin-[a-f0-9]*""".r
   val TypelevelVersion = raw"""(\d+)\.(\d+)\.(\d+)-bin-typelevel.*""".r
 
 
   def scalaBinaryVersion(scalaVersion: String) = scalaVersion match {
+      case Scala3EarlyVersion(milestone) => s"3.0.0-$milestone"
+      case Scala3Version(_, _) => "3"
       case ReleaseVersion(major, minor, _) => s"$major.$minor"
       case MinorSnapshotVersion(major, minor, _) => s"$major.$minor"
       case NightlyVersion(major, minor, _) => s"$major.$minor"
       case DottyVersion(minor, _) => s"0.$minor"
-      case Scala3Version(minor, patch, milestone) => s"3.$minor.$patch-$milestone"
       case TypelevelVersion(major, minor, _) => s"$major.$minor"
       case _ => scalaVersion
   }

--- a/scalalib/test/src/dependency/versions/ScalaVersionTests.scala
+++ b/scalalib/test/src/dependency/versions/ScalaVersionTests.scala
@@ -1,0 +1,47 @@
+package mill.scalalib.dependency.versions
+
+import mill.scalalib.api.Util.scalaBinaryVersion
+import utest._
+
+object ScalaVersionTests extends TestSuite {
+
+  val tests = Tests {
+    test("release") {
+      val sv = "2.13.5"
+      val sbv = scalaBinaryVersion(sv)
+      val expectedSbv = "2.13"
+      assert(sbv == expectedSbv)
+    }
+    test("snapshot") {
+      val sv = "2.13.6-SNAPSHOT"
+      val sbv = scalaBinaryVersion(sv)
+      val expectedSbv = "2.13"
+      assert(sbv == expectedSbv)
+    }
+    test("nightly") {
+      val sv = "2.13.5-bin-aab85b1"
+      val sbv = scalaBinaryVersion(sv)
+      val expectedSbv = "2.13"
+      assert(sbv == expectedSbv)
+    }
+    test("dotty") {
+      val sv = "0.27.3"
+      val sbv = scalaBinaryVersion(sv)
+      val expectedSbv = "0.27"
+      assert(sbv == expectedSbv)
+    }
+    test("scala3") {
+      val sv = "3.0.0-RC2"
+      val sbv = scalaBinaryVersion(sv)
+      val expectedSbv = "3.0.0-RC2"
+      assert(sbv == expectedSbv)
+    }
+    test("typelevel") {
+      val sv = "2.11.12-bin-typelevel.foo"
+      val sbv = scalaBinaryVersion(sv)
+      val expectedSbv = "2.11"
+      assert(sbv == expectedSbv)
+    }
+  }
+
+}

--- a/scalalib/test/src/dependency/versions/ScalaVersionTests.scala
+++ b/scalalib/test/src/dependency/versions/ScalaVersionTests.scala
@@ -30,11 +30,24 @@ object ScalaVersionTests extends TestSuite {
       val expectedSbv = "0.27"
       assert(sbv == expectedSbv)
     }
-    test("scala3") {
+    test("earlyscala3") {
       val sv = "3.0.0-RC2"
       val sbv = scalaBinaryVersion(sv)
       val expectedSbv = "3.0.0-RC2"
       assert(sbv == expectedSbv)
+    }
+    test("scala3") {
+      val expectedSbv = "3"
+      test("release") {
+        val sv = "3.0.1"
+        val sbv = scalaBinaryVersion(sv)
+        assert(sbv == expectedSbv)
+      }
+      test("RC") {
+        val sv = "3.0.2-RC4"
+        val sbv = scalaBinaryVersion(sv)
+        assert(sbv == expectedSbv)
+      }
     }
     test("typelevel") {
       val sv = "2.11.12-bin-typelevel.foo"


### PR DESCRIPTION
The Scala nighly versions look like `2.13.5-bin-f956b11` for example, and can be downloaded from [here](https://scala-ci.typesafe.com/artifactory/scala-integration). AFAIU, their binary version should look like `X.Y`, just like stable versions, so that the binary version of `2.13.5-bin-f956b11` would be `2.13`. This PR fixes that.

This would be useful for https://github.com/lihaoyi/Ammonite/pull/1150, where using Scala 2 nightlies would allow to bump the Scala 3 version (from `3.0.0-M1` to `3.0.0-M3`).

I'm not really sure if / where I should add tests for that.