### PR TITLE
Add support for scaladoc v.3

### DIFF
--- a/scalalib/api/src/ZincWorkerApi.scala
+++ b/scalalib/api/src/ZincWorkerApi.scala
@@ -53,6 +53,8 @@ case class CompilationResult(analysisFile: os.Path, classes: PathRef)
 object Util {
   def isDotty(scalaVersion: String) = scalaVersion.startsWith("0.")
   def isScala3(scalaVersion: String) = scalaVersion.startsWith("3.")
+  def useScaladocInScala3(scalaVersion: String) = 
+    isScala3(scalaVersion) && !Seq("M1", "M2", "M3").exists(mx => scalaVersion.startsWith(s"3.0.0-$mx"))
   def isDottyOrScala3(scalaVersion: String) = isDotty(scalaVersion) || isScala3(scalaVersion)
 
   // eg, grepJar(classPath, name = "scala-library", versionPrefix = "2.13.")

--- a/scalalib/src/Lib.scala
+++ b/scalalib/src/Lib.scala
@@ -89,11 +89,16 @@ object Lib{
       Agg(
         ivy"$scalaOrganization::dotty-doc:$scalaVersion".forceVersion()
       )
-    else if (mill.scalalib.api.Util.isScala3(scalaVersion))
-      Agg(
-        ivy"$scalaOrganization::scala3-doc:$scalaVersion".forceVersion()
-      )
-    else
+    else if (mill.scalalib.api.Util.isScala3(scalaVersion)){
+      if (mill.scalalib.api.Util.useScaladocInScala3(scalaVersion)) 
+        Agg(
+          ivy"$scalaOrganization::scaladoc:$scalaVersion".forceVersion()
+        )
+      else
+        Agg(
+          ivy"$scalaOrganization::scala3-doc:$scalaVersion".forceVersion()
+        )
+    } else
       // in Scala <= 2.13, the scaladoc tool is included in the compiler
       scalaCompilerIvyDeps(scalaOrganization, scalaVersion)
 

--- a/scalalib/test/src/HelloWorldTests.scala
+++ b/scalalib/test/src/HelloWorldTests.scala
@@ -169,7 +169,7 @@ object HelloWorldTests extends TestSuite {
 
   object HelloWorldOnlyDocVersion extends HelloBase {
     object core extends HelloWorldModule {
-      def scalacOptions = T(Seq("-Ywarn-unused", "-Xfatal-warnings"))
+      def scalacOptions = T(Seq("-Ywarn-unused"))
       def scalaDocOptions = T(Seq("-doc-version", "1.2.3"))
     }
   }
@@ -395,7 +395,7 @@ object HelloWorldTests extends TestSuite {
         resourcePath = os.pwd / 'scalalib / 'test / 'resources / "hello-world"
       ){ eval =>
         // scaladoc generation fails because of "-Xfatal-warnings" flag
-        val Left(Result.Failure("docJar generation failed", None)) = eval.apply(HelloWorldWithDocVersion.core.docJar)
+        val Left(Result.Failure("Compilation failed", None)) = eval.apply(HelloWorldWithDocVersion.core.docJar)
       }
       'docJarOnlyVersion - workspaceTest(
         HelloWorldOnlyDocVersion,


### PR DESCRIPTION
This PR adds support to scaladoc that will be released with Scala 3.0.0-RC1. The locally built version of this PR is was to test locally changes from https://github.com/lampepfl/dotty/pull/11349 - PR that removed scala3-doc (known as `dottydoc` as well).

Not heaving this PR is not a blocker for Scala 3.0.0-RC1 release however I would feel much better if I can merge https://github.com/lampepfl/dotty/pull/11349 without a pre-built version of mill.