### PR TITLE
DOC: Fix typos

### DIFF
--- a/contrib/proguard/src/Proguard.scala
+++ b/contrib/proguard/src/Proguard.scala
@@ -112,7 +112,7 @@ trait Proguard extends ScalaModule {
   /** The default `entrypoint` to proguard.
    *
    * Defaults to the `main` method of `finalMainClass`.
-   * Can be overriden to specify a different entrypoint,
+   * Can be overridden to specify a different entrypoint,
    * or additional entrypoints can be specified with `additionalOptions`. */
   def entryPoint: T[String] = T {
     s"""|-keep public class ${finalMainClass()} {

--- a/docs/pages/3 - Common Project Layouts.md
+++ b/docs/pages/3 - Common Project Layouts.md
@@ -281,7 +281,7 @@ You can make a module publishable by extending `PublishModule`.
 
 `PublishModule` then needs you to define a `publishVersion` and `pomSettings`.
 The `artifactName` defaults to the name of your module (in this case `foo`) but
-can be overriden. The `organization` is defined in `pomSettings`.
+can be overridden. The `organization` is defined in `pomSettings`.
 
 Once you've mixed in `PublishModule`, you can publish your libraries to maven
 central via:

--- a/docs/pages/5 - Modules.md
+++ b/docs/pages/5 - Modules.md
@@ -77,7 +77,7 @@ object canOverrideSuper with BaseModule {
 ```
 
 You can override targets and commands to customize them or change what they do.
-The overriden version is available via `super`. You can omit the `override`
+The overridden version is available via `super`. You can omit the `override`
 keyword in Mill builds.
 
 ## millSourcePath
@@ -169,7 +169,7 @@ This allows, for instance, to depend on other projects' sources, or split
 your build logic into smaller files.
      
 
-For instance, assuming the following stucture : 
+For instance, assuming the following structure : 
 
 ```text
 foo/

--- a/docs/pages/9 - Contrib Modules.md
+++ b/docs/pages/9 - Contrib Modules.md
@@ -782,7 +782,7 @@ and the xml report is saved in `out/foo/scoverage/xmlReport/dest/`.
 
 ### Multi-module projects
 
-If you're using Scoverage on a project with multiple modules then an additonal
+If you're using Scoverage on a project with multiple modules then an additional
 module, `ScoverageReport`, is available to help aggregate the reports from all
 `ScoverageModule`s.
 
@@ -1045,7 +1045,7 @@ object versionFile extends VersionFileModule
 The module will read and write to the file `version` located at the module's `millSourcePath`.
 In the example above, that would be `/versionFile/version` relative to the `build.sc` file.
 
-Create the version file with the intial version number:
+Create the version file with the initial version number:
 ```bash
 $ 0.1.0-SNAPSHOT > versionFile/version
 ```

--- a/main/api/src/mill/api/IO.scala
+++ b/main/api/src/mill/api/IO.scala
@@ -11,7 +11,7 @@ object IO extends StreamSupport {
   /**
    * Unpacks the given `src` path into the context specific destination directory.
    * @param src The ZIP file
-   * @param dest The relative ouput folder under the context specifix destination directory.
+   * @param dest The relative output folder under the context specifix destination directory.
    * @param ctx The target context
    * @return The [[PathRef]] to the unpacked folder.
    */

--- a/main/test/src/eval/EvaluationTests.scala
+++ b/main/test/src/eval/EvaluationTests.scala
@@ -217,7 +217,7 @@ class EvaluationTests(threadCount: Option[Int]) extends TestSuite {
       'overrideSuperTask - {
         // Make sure you can override targets, call their supers, and have the
         // overriden target be allocated a spot within the overriden/ folder of
-        // the main publically-available target
+        // the main publicly-available target
         import canOverrideSuper._
 
         val checker = new Checker(canOverrideSuper)
@@ -239,7 +239,7 @@ class EvaluationTests(threadCount: Option[Int]) extends TestSuite {
       'overrideSuperCommand - {
         // Make sure you can override commands, call their supers, and have the
         // overriden command be allocated a spot within the overriden/ folder of
-        // the main publically-available command
+        // the main publicly-available command
         import canOverrideSuper._
 
         val checker = new Checker(canOverrideSuper)

--- a/readme.md
+++ b/readme.md
@@ -384,7 +384,7 @@ and the [list of commits](https://github.com/lihaoyi/mill/compare/0.5.9...0.6.0)
 *For details refer to
 the [list of commits](https://github.com/lihaoyi/mill/compare/0.5.7...0.5.9).*
 
-**Verison 0.5.8 has some binary compatibility issues in requests-scala/geny and should not be used.**
+**Version 0.5.8 has some binary compatibility issues in requests-scala/geny and should not be used.**
 
 ### 0.5.7 - 2019-12-28
 

--- a/scalalib/src/JavaModule.scala
+++ b/scalalib/src/JavaModule.scala
@@ -285,7 +285,7 @@ trait JavaModule extends mill.Module
   }
 
   /**
-    * Creates a manifest representation which can be modifed or replaced
+    * Creates a manifest representation which can be modified or replaced
     * The default implementation just adds the `Manifest-Version`, `Main-Class` and `Created-By` attributes
     */
   def manifest: T[Jvm.JarManifest] = T{


### PR DESCRIPTION
All changes should be non-semantic.