### PR TITLE
Add support for Scaladoc 3

### DIFF
--- a/scalalib/api/src/ZincWorkerApi.scala
+++ b/scalalib/api/src/ZincWorkerApi.scala
@@ -53,6 +53,7 @@ case class CompilationResult(analysisFile: os.Path, classes: PathRef)
 object Util {
   def isDotty(scalaVersion: String) = scalaVersion.startsWith("0.")
   def isScala3(scalaVersion: String) = scalaVersion.startsWith("3.")
+  def isScala3Milestone(scalaVersion: String) = scalaVersion.startsWith("3.0.0-M")
   def isDottyOrScala3(scalaVersion: String) = isDotty(scalaVersion) || isScala3(scalaVersion)
 
   // eg, grepJar(classPath, name = "scala-library", versionPrefix = "2.13.")

--- a/scalalib/src/Lib.scala
+++ b/scalalib/src/Lib.scala
@@ -89,9 +89,15 @@ object Lib{
       Agg(
         ivy"$scalaOrganization::dotty-doc:$scalaVersion".forceVersion()
       )
+    else if (mill.scalalib.api.Util.isScala3Milestone(scalaVersion))
+      Agg(
+        // 3.0.0-RC1 > scalaVersion >= 3.0.0-M1 still uses dotty-doc, but under a different artifact name
+        ivy"$scalaOrganization::scala3-doc:$scalaVersion".forceVersion()
+      )
     else if (mill.scalalib.api.Util.isScala3(scalaVersion))
       Agg(
-        ivy"$scalaOrganization::scala3-doc:$scalaVersion".forceVersion()
+        // scalaVersion >= 3.0.0-RC1 uses scaladoc
+        ivy"$scalaOrganization::scaladoc:$scalaVersion".forceVersion()
       )
     else
       // in Scala <= 2.13, the scaladoc tool is included in the compiler

--- a/scalalib/src/ScalaModule.scala
+++ b/scalalib/src/ScalaModule.scala
@@ -235,7 +235,7 @@ trait ScalaModule extends JavaModule { outer =>
           "-d", javadocDir.toNIO.toString,
           "-siteroot", combinedStaticDir.toNIO.toString
         ),
-        Seq(jar()).map(_.path.toString), // scaladoc3 uses tasty to generate docs
+        os.walk(compile().classes.path).filter(_.ext == "tasty").map(_.toString),
         javadocDir
       )
     } else { // scaladoc 2

--- a/scalalib/src/ScalaModule.scala
+++ b/scalalib/src/ScalaModule.scala
@@ -6,7 +6,7 @@ import mill.define.{Command, Target, Task, TaskModule}
 import mill.eval.{PathRef, Result}
 import mill.modules.Jvm
 import mill.modules.Jvm.createJar
-import mill.scalalib.api.Util.{ isDotty, isDottyOrScala3, isScala3 }
+import mill.scalalib.api.Util.{ isDotty, isDottyOrScala3, isScala3, isScala3Milestone }
 import Lib._
 import mill.api.Loose.Agg
 import mill.api.DummyInputStream
@@ -166,13 +166,32 @@ trait ScalaModule extends JavaModule { outer =>
   }
 
   override def docJar = T {
-    val outDir = T.dest
+    val pluginOptions = scalaDocPluginClasspath().map(pluginPathRef => s"-Xplugin:${pluginPathRef.path}")
+    val compileCp = Seq(
+      "-classpath", compileClasspath().filter(_.path.ext != "pom").map(_.path).mkString(java.io.File.pathSeparator)
+    )
 
-    val javadocDir = outDir / 'javadoc
-    os.makeDir.all(javadocDir)
+    def packageWithZinc(options: Seq[String], files: Seq[String], javadocDir: os.Path) = {
+      if (files.isEmpty) Result.Success(createJar(Agg(javadocDir))(T.dest))
+      else {
+        zincWorker.worker().docJar(
+          scalaVersion(),
+          scalaOrganization(),
+          scalaDocClasspath().map(_.path),
+          scalacPluginClasspath().map(_.path),
+          files ++ options ++ pluginOptions ++ compileCp ++ scalaDocOptions()
+        ) match{
+          case true =>
+            Result.Success(createJar(Agg(javadocDir))(T.dest))
+          case false => Result.Failure("docJar generation failed")
+        }
+      }
+    }
 
-    if (isDottyOrScala3(scalaVersion())) {
-      // merge all docSources into one directory by copying all children
+    if (isDotty(scalaVersion()) || isScala3Milestone(scalaVersion())) { // dottydoc
+      val javadocDir =  T.dest / "javadoc"
+      os.makeDir.all(javadocDir)
+
       for {
         ref <- docSources()
         docSource = ref.path
@@ -183,42 +202,53 @@ trait ScalaModule extends JavaModule { outer =>
       } {
         os.copy.over(child, javadocDir / (child.subRelativeTo(docSource)), createFolders = true)
       }
-    }
+      packageWithZinc(
+        Seq("-siteroot", javadocDir.toNIO.toString),
+        allSourceFiles().map(_.path.toString),
+        javadocDir / "_site"
+      )
 
-    val files = allSourceFiles().map(_.path.toString)
+    } else if (isScala3(scalaVersion())) { // scaladoc 3
+      val javadocDir =  T.dest / "javadoc"
+      os.makeDir.all(javadocDir)
 
-    val outputOptions =
-      if (isDottyOrScala3(scalaVersion()))
-        Seq("-siteroot", javadocDir.toNIO.toString)
-      else
-        Seq("-d", javadocDir.toNIO.toString)
+      // Scaladoc 3 allows including static files in documentation, but it only
+      // supports one directory. Hence, to allow users to generate files
+      // dynamically, we consolidate all files from all `docSources` into one
+      // directory.
+      val combinedStaticDir = T.dest / "static"
+      os.makeDir.all(combinedStaticDir)
 
-    val pluginOptions = scalaDocPluginClasspath().map(pluginPathRef => s"-Xplugin:${pluginPathRef.path}")
-    val compileCp = compileClasspath().filter(_.path.ext != "pom").map(_.path)
-    val options = Seq(
-      "-classpath", compileCp.mkString(java.io.File.pathSeparator)
-    ) ++
-      outputOptions ++
-      pluginOptions ++
-      scalaDocOptions() // user options come last, so they can override any other settings
-
-    if (files.isEmpty) Result.Success(createJar(Agg(javadocDir))(outDir))
-    else {
-      zincWorker.worker().docJar(
-        scalaVersion(),
-        scalaOrganization(),
-        scalaDocClasspath().map(_.path),
-        scalacPluginClasspath().map(_.path),
-        files ++ options
-      ) match{
-        case true =>
-          val inputPath =
-            if (isDottyOrScala3(scalaVersion())) javadocDir / '_site
-            else javadocDir
-          Result.Success(createJar(Agg(inputPath))(outDir))
-        case false => Result.Failure("docJar generation failed")
+      for {
+        ref <- docSources()
+        docSource = ref.path
+        if os.exists(docSource) && os.isDir(docSource)
+        children = os.walk(docSource)
+        child <- children
+        if os.isFile(child)
+      } {
+        os.copy.over(child, combinedStaticDir / (child.subRelativeTo(docSource)), createFolders = true)
       }
+
+      packageWithZinc(
+        Seq(
+          "-d", javadocDir.toNIO.toString,
+          "-siteroot", combinedStaticDir.toNIO.toString
+        ),
+        Seq(jar()).map(_.path.toString), // scaladoc3 uses tasty to generate docs
+        javadocDir
+      )
+    } else { // scaladoc 2
+      val javadocDir = T.dest / "javadoc"
+      os.makeDir.all(javadocDir)
+
+      packageWithZinc(
+        Seq("-d", javadocDir.toNIO.toString),
+        allSourceFiles().map(_.path.toString),
+        javadocDir
+      )
     }
+
   }
 
   /**

--- a/scalalib/test/resources/scaladoc3/empty/src/Main.scala
+++ b/scalalib/test/resources/scaladoc3/empty/src/Main.scala
@@ -1,0 +1,8 @@
+package pkg
+
+@main
+def main() =
+  println("hello, world!")
+
+/** A doc comment. */
+case class SomeClass()

--- a/scalalib/test/resources/scaladoc3/multidocs/docs1/docs/nested/original.md
+++ b/scalalib/test/resources/scaladoc3/multidocs/docs1/docs/nested/original.md
@@ -1,0 +1,1 @@
+Extra docs

--- a/scalalib/test/resources/scaladoc3/multidocs/docs1/index.md
+++ b/scalalib/test/resources/scaladoc3/multidocs/docs1/index.md
@@ -1,0 +1,1 @@
+Hello, Scaladoc!

--- a/scalalib/test/resources/scaladoc3/multidocs/docs1/sidebar.yml
+++ b/scalalib/test/resources/scaladoc3/multidocs/docs1/sidebar.yml
@@ -1,0 +1,3 @@
+sidebar:
+  - title: Docs
+    url: docs/nested/extra.html

--- a/scalalib/test/resources/scaladoc3/multidocs/docs2/docs/nested/extra.md
+++ b/scalalib/test/resources/scaladoc3/multidocs/docs2/docs/nested/extra.md
@@ -1,0 +1,1 @@
+Extra docs

--- a/scalalib/test/resources/scaladoc3/multidocs/docs2/index.md
+++ b/scalalib/test/resources/scaladoc3/multidocs/docs2/index.md
@@ -1,0 +1,2 @@
+overwritten
+

--- a/scalalib/test/resources/scaladoc3/multidocs/src/Main.scala
+++ b/scalalib/test/resources/scaladoc3/multidocs/src/Main.scala
@@ -1,0 +1,8 @@
+package pkg
+
+@main
+def main() =
+  println("hello, world!")
+
+/** A doc comment. */
+case class SomeClass()

--- a/scalalib/test/resources/scaladoc3/static/docs/index.md
+++ b/scalalib/test/resources/scaladoc3/static/docs/index.md
@@ -1,0 +1,1 @@
+Hello, Scaladoc!

--- a/scalalib/test/resources/scaladoc3/static/docs/nested/extra.md
+++ b/scalalib/test/resources/scaladoc3/static/docs/nested/extra.md
@@ -1,0 +1,1 @@
+Extra docs

--- a/scalalib/test/resources/scaladoc3/static/docs/sidebar.yml
+++ b/scalalib/test/resources/scaladoc3/static/docs/sidebar.yml
@@ -1,0 +1,3 @@
+sidebar:
+  - title: Docs
+    url: nested/extra.html

--- a/scalalib/test/resources/scaladoc3/static/src/Main.scala
+++ b/scalalib/test/resources/scaladoc3/static/src/Main.scala
@@ -1,0 +1,8 @@
+package pkg
+
+@main
+def main() =
+  println("hello, world!")
+
+/** A doc comment. */
+case class SomeClass()

--- a/scalalib/test/src/HelloWorldTests.scala
+++ b/scalalib/test/src/HelloWorldTests.scala
@@ -395,17 +395,14 @@ object HelloWorldTests extends TestSuite {
         resourcePath = os.pwd / 'scalalib / 'test / 'resources / "hello-world"
       ){ eval =>
         // scaladoc generation fails because of "-Xfatal-warnings" flag
-        val Left(Result.Failure("docJar generation failed", None)) = eval.apply(HelloWorldWithDocVersion.core.docJar)
+        val Left(Result.Failure(_, None)) = eval.apply(HelloWorldWithDocVersion.core.docJar)
       }
       'docJarOnlyVersion - workspaceTest(
         HelloWorldOnlyDocVersion,
         resourcePath = os.pwd / 'scalalib / 'test / 'resources / "hello-world"
       ){ eval =>
-        val Right((_, evalCount)) = eval.apply(HelloWorldOnlyDocVersion.core.docJar)
-        assert(
-          evalCount > 0,
-          os.read(eval.outPath / 'core / 'docJar / 'dest / 'javadoc / "index.html").contains("<span id=\"doc-version\">1.2.3")
-        )
+        // `docJar` requires the `compile` task to succeed (since the addition of Scaladoc 3)
+        val Left(Result.Failure(_, None)) = eval.apply(HelloWorldOnlyDocVersion.core.docJar)
       }
     }
 

--- a/scalalib/test/src/ScalaDoc3Tests.scala
+++ b/scalalib/test/src/ScalaDoc3Tests.scala
@@ -1,0 +1,91 @@
+package mill.scalalib
+
+import mill._
+import utest._
+import utest.framework.TestPath
+import mill.util.{TestEvaluator, TestUtil}
+
+import scala.collection.JavaConverters._
+import scala.util.Properties.isJavaAtLeast
+
+object ScalaDoc3Tests extends TestSuite {
+  trait TestBase extends TestUtil.BaseModule{
+    def millSourcePath =  TestUtil.getSrcPathBase() / millOuterCtx.enclosing.split('.')
+  }
+
+  // a project with static docs
+  object StaticDocsModule extends TestBase {
+    object static extends ScalaModule {
+      def scalaVersion = "3.0.0-RC1"
+    }
+  }
+
+  // a project without static docs (i.e. only api docs, no markdown files)
+  object EmptyDocsModule extends TestBase {
+    object empty extends ScalaModule {
+      def scalaVersion = "3.0.0-RC1"
+    }
+  }
+
+  // a project with multiple static doc folders
+  object MultiDocsModule extends TestBase {
+    object multidocs extends ScalaModule {
+      def scalaVersion = "3.0.0-RC1"
+      def docSources = T.sources(
+        millSourcePath / "docs1",
+        millSourcePath / "docs2"
+      )
+    }
+  }
+
+  val resourcePath = os.pwd / "scalalib" / "test" / "resources" / "scaladoc3"
+
+  def workspaceTest[T](
+      m: TestUtil.BaseModule,
+      resourcePath: os.Path = resourcePath)(t: TestEvaluator => T)(
+      implicit tp: TestPath): T = {
+    val eval = new TestEvaluator(m)
+    os.remove.all(m.millSourcePath)
+    os.remove.all(eval.outPath)
+    os.makeDir.all(m.millSourcePath / os.up)
+    os.copy(resourcePath, m.millSourcePath)
+    t(eval)
+  }
+
+  def tests: Tests = Tests {
+    'static - workspaceTest(StaticDocsModule){ eval =>
+      val Right((_, _)) = eval.apply(StaticDocsModule.static.docJar)
+      val dest = eval.outPath / "static" / "docJar" / "dest"
+      assert(
+        os.exists(dest / "out.jar"), // final jar should exist
+        // check if extra markdown files have been included and translated to html
+        os.exists(dest / "javadoc" / "index.html"),
+        os.exists(dest / "javadoc" / "nested" / "extra.html"),
+        // also check that API docs have been generated
+        os.exists(dest / "javadoc" / "api" / "pkg" / "SomeClass.html")
+      )
+    }
+    'empty - workspaceTest(EmptyDocsModule){ eval =>
+      val Right((_, _)) = eval.apply(EmptyDocsModule.empty.docJar)
+      val dest = eval.outPath / "empty" / "docJar" / "dest"
+      assert(
+        os.exists(dest / "out.jar"),
+        os.exists(dest / "javadoc" / "api" / "pkg" / "SomeClass.html")
+      )
+    }
+    'multiple - workspaceTest(MultiDocsModule){ eval =>
+      val Right((_, _)) = eval.apply(MultiDocsModule.multidocs.docJar)
+      val dest = eval.outPath / "multidocs" / "docJar" / "dest"
+      assert(
+        os.exists(dest / "out.jar"), // final jar should exist
+        os.exists(dest / "javadoc" / "api" / "pkg" / "SomeClass.html"),
+        os.exists(dest / "javadoc" / "index.html"),
+        os.exists(dest / "javadoc" / "docs" / "nested" / "original.html"),
+        os.exists(dest / "javadoc" / "docs" / "nested" / "extra.html"),
+        // check that later doc sources overwrite earlier ones
+        os.read(dest / "javadoc" / "index.html").contains("overwritten")
+      )
+    }
+  }
+
+}


### PR DESCRIPTION
This adds support for docJar generation under Scala 3.0.0-RC1, which is currently broken[1].

I've tried to keep backwards compatibility as much as I could. However, there is one sort-of-breaking change with this: `docJar` now has a dependency on the `compile` task (because Scaladoc 3 uses tasty files, not source files anymore). This dependency prevents generating documentation for projects that would previously not compile but could still generate documentation.

[1]: See the [discussion on Gitter](https://gitter.im/lampepfl/dotty?at=603e29b5823b6654d27ad28b) if you're interested, but the gist of it is that Scaladoc 3 is really not compatible with dottydoc, yet dottydoc is no longer available for Scala >= 3.0.0-RC1.