### PR TITLE
Windows client-server fixes

### DIFF
--- a/main/client/src/mill/main/client/InputPumper.java
+++ b/main/client/src/mill/main/client/InputPumper.java
@@ -31,7 +31,6 @@ public class InputPumper implements Runnable{
                 }
             }
         }catch(Exception e){
-            //if (e.getMessage().matches(".+(6)")) return;
             throw new RuntimeException(e);
         }
     }

--- a/main/client/src/mill/main/client/InputPumper.java
+++ b/main/client/src/mill/main/client/InputPumper.java
@@ -31,6 +31,7 @@ public class InputPumper implements Runnable{
                 }
             }
         }catch(Exception e){
+            //if (e.getMessage().matches(".+(6)")) return;
             throw new RuntimeException(e);
         }
     }

--- a/main/client/src/mill/main/client/Lock.java
+++ b/main/client/src/mill/main/client/Lock.java
@@ -1,14 +1,17 @@
 package mill.main.client;
-public abstract class Lock implements AutoCloseable{
-    abstract public Locked lock() throws Exception;
-    abstract public Locked tryLock() throws Exception;
 
-    public void await() throws Exception{
+public abstract class Lock implements AutoCloseable {
+
+    public abstract Locked lock() throws Exception;
+
+    public abstract Locked tryLock() throws Exception;
+
+    public void await() throws Exception {
         lock().release();
     }
 
     /**
      * Returns `true` if the lock is *available for taking*
      */
-    abstract public boolean probe() throws Exception;
+    public abstract boolean probe() throws Exception;
 }

--- a/main/client/src/mill/main/client/Locked.java
+++ b/main/client/src/mill/main/client/Locked.java
@@ -1,10 +1,6 @@
 package mill.main.client;
 
-import java.io.RandomAccessFile;
-import java.nio.channels.FileChannel;
-import java.util.concurrent.locks.ReentrantLock;
+public interface Locked {
 
-
-public interface Locked{
     public void release() throws Exception;
 }

--- a/main/client/src/mill/main/client/Locks.java
+++ b/main/client/src/mill/main/client/Locks.java
@@ -6,7 +6,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 public class Locks implements AutoCloseable {
 
-    public Lock processLock;
+    public Lock processLock; // running server lock
     public Lock serverLock;
     public Lock clientLock;
 
@@ -98,10 +98,10 @@ class MemoryLocked implements Locked {
 
 class MemoryLock extends Lock {
 
-    private ReentrantLock innerLock = new ReentrantLock(true);
+    private ReentrantLock innerLock = new ReentrantLock();
 
     public boolean probe() {
-          return !innerLock.isLocked();
+        return !innerLock.isLocked();
     }
 
     public Locked lock() {

--- a/main/client/src/mill/main/client/Locks.java
+++ b/main/client/src/mill/main/client/Locks.java
@@ -4,20 +4,21 @@ import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
 import java.util.concurrent.locks.ReentrantLock;
 
-public class Locks implements AutoCloseable{
+public class Locks implements AutoCloseable {
+
     public Lock processLock;
     public Lock serverLock;
     public Lock clientLock;
-    public static Locks files(String lockBase) throws Exception{
+
+    public static Locks files(String lockBase) throws Exception {
         return new Locks(){{
             processLock = new FileLock(lockBase + "/pid");
-
             serverLock = new FileLock(lockBase + "/serverLock");
-
             clientLock = new FileLock(lockBase + "/clientLock");
         }};
     }
-    public static Locks memory(){
+
+    public static Locks memory() {
         return new Locks(){{
             this.processLock = new MemoryLock();
             this.serverLock = new MemoryLock();
@@ -32,35 +33,41 @@ public class Locks implements AutoCloseable{
         clientLock.close();
     }
 }
-class FileLocked implements Locked{
+
+class FileLocked implements Locked {
+
     private java.nio.channels.FileLock lock;
-    public FileLocked(java.nio.channels.FileLock lock){
+
+    public FileLocked(java.nio.channels.FileLock lock) {
         this.lock = lock;
     }
-    public void release() throws Exception{
+
+    public void release() throws Exception {
         this.lock.release();
     }
 }
 
-class FileLock extends Lock{
-    String path;
-    RandomAccessFile raf;
-    FileChannel chan;
-    public FileLock(String path) throws Exception{
-        this.path = path;
+class FileLock extends Lock {
+
+    private RandomAccessFile raf;
+    private FileChannel chan;
+
+    public FileLock(String path) throws Exception {
         raf = new RandomAccessFile(path, "rw");
         chan = raf.getChannel();
     }
 
-    public Locked lock() throws Exception{
+    public Locked lock() throws Exception {
         return new FileLocked(chan.lock());
     }
-    public Locked tryLock() throws Exception{
+
+    public Locked tryLock() throws Exception {
         java.nio.channels.FileLock l = chan.tryLock();
         if (l == null) return null;
         else return new FileLocked(l);
     }
-    public boolean probe()throws Exception{
+
+    public boolean probe() throws Exception {
         java.nio.channels.FileLock l = chan.tryLock();
         if (l == null) return false;
         else {
@@ -71,30 +78,37 @@ class FileLock extends Lock{
 
     @Override
     public void close() throws Exception {
-        raf.close();
         chan.close();
+        raf.close();
     }
 }
-class MemoryLocked implements Locked{
-    java.util.concurrent.locks.Lock l;
-    public MemoryLocked(java.util.concurrent.locks.Lock l){
+
+class MemoryLocked implements Locked {
+
+    private java.util.concurrent.locks.Lock l;
+
+    public MemoryLocked(java.util.concurrent.locks.Lock l) {
         this.l = l;
     }
-    public void release() throws Exception{
+
+    public void release() throws Exception {
         l.unlock();
     }
 }
 
-class MemoryLock extends Lock{
-    ReentrantLock innerLock = new ReentrantLock(true);
+class MemoryLock extends Lock {
 
-    public boolean probe(){
+    private ReentrantLock innerLock = new ReentrantLock(true);
+
+    public boolean probe() {
           return !innerLock.isLocked();
     }
+
     public Locked lock() {
         innerLock.lock();
         return new MemoryLocked(innerLock);
     }
+
     public Locked tryLock() {
         if (innerLock.tryLock()) return new MemoryLocked(innerLock);
         else return null;

--- a/main/client/src/mill/main/client/Locks.java
+++ b/main/client/src/mill/main/client/Locks.java
@@ -6,7 +6,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 public class Locks implements AutoCloseable {
 
-    public Lock processLock; // running server lock
+    public Lock processLock;
     public Lock serverLock;
     public Lock clientLock;
 

--- a/main/client/src/mill/main/client/MillClientMain.java
+++ b/main/client/src/mill/main/client/MillClientMain.java
@@ -1,6 +1,7 @@
 package mill.main.client;
 
-import org.scalasbt.ipcsocket.*;
+import org.scalasbt.ipcsocket.UnixDomainSocket;
+import org.scalasbt.ipcsocket.Win32NamedPipeSocket;
 
 import java.io.*;
 import java.net.Socket;
@@ -197,7 +198,8 @@ public class MillClientMain {
         while (ioSocket == null && System.currentTimeMillis() - retryStart < 5000) {
             try {
                 ioSocket = Util.isWindows?
-                        new Win32NamedPipeSocket(Util.WIN32_PIPE_PREFIX + new File(lockBase).getName())
+                        //new Win32NamedPipeClientSocket(Util.WIN32_PIPE_PREFIX + "mill." + new File(lockBase).getName())
+                        new Win32NamedPipeSocket(Util.WIN32_PIPE_PREFIX + "mill." + new File(lockBase).getName())
                         : new UnixDomainSocket(lockBase + "/io");
             } catch (Throwable e){
                 socketThrowable = e;

--- a/main/client/src/mill/main/client/MillClientMain.java
+++ b/main/client/src/mill/main/client/MillClientMain.java
@@ -6,6 +6,8 @@ import java.io.*;
 import java.net.Socket;
 import java.net.URISyntaxException;
 import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.*;
@@ -18,18 +20,18 @@ public class MillClientMain {
 	public static final int ExitServerCodeWhenIdle() { return 0; }
 	public static final int ExitServerCodeWhenVersionMismatch() { return 101; }
 
-    static void initServer(String lockBase, boolean setJnaNoSys) throws IOException,URISyntaxException{
+    static void initServer(String lockBase, boolean setJnaNoSys) throws IOException, URISyntaxException {
 
         String selfJars = "";
         List<String> vmOptions = new ArrayList<>();
         String millOptionsPath = System.getProperty("MILL_OPTIONS_PATH");
-        if(millOptionsPath != null) {
+        if (millOptionsPath != null) {
             // read MILL_CLASSPATH from file MILL_OPTIONS_PATH
             Properties millProps = new Properties();
             millProps.load(new FileInputStream(millOptionsPath));
             for(final String k: millProps.stringPropertyNames()){
                 String propValue = millProps.getProperty(k);
-                if("MILL_CLASSPATH".equals(k)){
+                if ("MILL_CLASSPATH".equals(k)){
                     selfJars = propValue;
                 }
             }
@@ -39,12 +41,12 @@ public class MillClientMain {
         }
 
         final Properties sysProps = System.getProperties();
-        for(final String k: sysProps.stringPropertyNames()){
+        for (final String k: sysProps.stringPropertyNames()){
             if (k.startsWith("MILL_") && !"MILL_CLASSPATH".equals(k)) {
                 vmOptions.add("-D" + k + "=" + sysProps.getProperty(k));
             }
         }
-        if(selfJars == null || selfJars.trim().isEmpty()) {
+        if (selfJars == null || selfJars.trim().isEmpty()) {
             throw new RuntimeException("MILL_CLASSPATH is empty!");
         }
         if (setJnaNoSys) {
@@ -97,80 +99,68 @@ public class MillClientMain {
 
     public static void main(String[] args) throws Exception{
         int exitCode = main0(args);
-        if(exitCode == ExitServerCodeWhenVersionMismatch()) {
+        if (exitCode == ExitServerCodeWhenVersionMismatch()) {
             exitCode = main0(args);
         }
         System.exit(exitCode);
     }
-    public static int main0(String[] args) throws Exception{
+
+    public static int main0(String[] args) throws Exception {
+
         boolean setJnaNoSys = System.getProperty("jna.nosys") == null;
-        Map<String, String> env = System.getenv();
         if (setJnaNoSys) {
             System.setProperty("jna.nosys", "true");
         }
-        int index = 0;
+        
         String jvmHomeEncoding = sha1HashPath(System.getProperty("java.home"));
-        File outFolder = new File("out");
-        String[] totalProcesses = outFolder.list((dir,name) -> name.startsWith("mill-worker-"));
-        String[] thisJdkProcesses = outFolder.list((dir,name) -> name.startsWith("mill-worker-" + jvmHomeEncoding));
+        int serverProcessesLimit = getServerProcessesLimit(jvmHomeEncoding);
 
-        int processLimit = 5;
-        if(totalProcesses != null) {
-            if(thisJdkProcesses != null) {
-                processLimit -= Math.min(totalProcesses.length - thisJdkProcesses.length, 5);
-            } else {
-                processLimit -= Math.min(totalProcesses.length, 5);
-            }
-        }
-        while (index < processLimit) {
+        int index = 0;
+        while (index < serverProcessesLimit) {
             index += 1;
             String lockBase = "out/mill-worker-" + jvmHomeEncoding + "-" + index;
             new java.io.File(lockBase).mkdirs();
 
             File stdout = new java.io.File(lockBase + "/stdout");
             File stderr = new java.io.File(lockBase + "/stderr");
-            int refeshIntervalMsec = 2;
+            int refeshIntervalMillis = 2;
 
-            try(
-                    RandomAccessFile lockFile = new RandomAccessFile(lockBase + "/clientLock", "rw");
-                    FileChannel channel = lockFile.getChannel();
-                    java.nio.channels.FileLock tryLock = channel.tryLock();
-                    Locks locks = Locks.files(lockBase);
-                    FileToStreamTailer stdoutTailer = new FileToStreamTailer(stdout, System.out, refeshIntervalMsec);
-                    FileToStreamTailer stderrTailer = new FileToStreamTailer(stderr, System.err, refeshIntervalMsec);
-            ){
-                if (tryLock != null) {
+            try (
+                Locks locks = Locks.files(lockBase);
+                FileToStreamTailer stdoutTailer = new FileToStreamTailer(stdout, System.out, refeshIntervalMillis);
+                FileToStreamTailer stderrTailer = new FileToStreamTailer(stderr, System.err, refeshIntervalMillis);
+            ) {
+                Locked clientLock = locks.clientLock.tryLock();
+                if (clientLock != null) {
                     stdoutTailer.start();
                     stderrTailer.start();
 
-                    int exitCode = MillClientMain.run(
-                            lockBase,
-                            new Runnable() {
-                                @Override
-                                public void run() {
-                                    try{
-                                        initServer(lockBase, setJnaNoSys);
-                                    }catch(Exception e){
-                                        throw new RuntimeException(e);
-                                    }
-                                }
-                            },
-                            locks,
-                            System.in,
-                            System.out,
-                            System.err,
-                            args,
-                            env
+                    int exitCode = run(
+                        lockBase,
+                        () -> {
+                            try {
+                                initServer(lockBase, setJnaNoSys);
+                            } catch (Exception e) {
+                                throw new RuntimeException(e);
+                            }
+                        },
+                        locks,
+                        System.in,
+                        System.out,
+                        System.err,
+                        args,
+                        System.getenv()
                     );
 
                     // Here, we ensure we process the tails of the output files before interrupting the threads
                     stdoutTailer.flush();
                     stderrTailer.flush();
+                    clientLock.release();
                     return exitCode;
                 }
             }
         }
-        throw new Exception("Reached max process limit: " + processLimit);
+        throw new Exception("Reached max server processes limit: " + serverProcessesLimit);
     }
 
     public static int run(String lockBase,
@@ -182,7 +172,7 @@ public class MillClientMain {
                           String[] args,
                           Map<String, String> env) throws Exception{
 
-        try(FileOutputStream f = new FileOutputStream(lockBase + "/run")){
+        try (FileOutputStream f = new FileOutputStream(lockBase + "/run")) {
             f.write(System.console() != null ? 1 : 0);
             Util.writeString(f, System.getProperty("MILL_VERSION"));
             Util.writeArgs(args, f);
@@ -194,7 +184,7 @@ public class MillClientMain {
             serverInit = true;
             initServer.run();
         }
-        while(locks.processLock.probe()) Thread.sleep(3);
+        while (locks.processLock.probe()) Thread.sleep(3);
 
         // Need to give sometime for Win32NamedPipeSocket to work
         // if the server is just initialized
@@ -204,17 +194,17 @@ public class MillClientMain {
         Throwable socketThrowable = null;
         long retryStart = System.currentTimeMillis();
 
-        while(ioSocket == null && System.currentTimeMillis() - retryStart < 5000){
-            try{
+        while (ioSocket == null && System.currentTimeMillis() - retryStart < 5000) {
+            try {
                 ioSocket = Util.isWindows?
                         new Win32NamedPipeSocket(Util.WIN32_PIPE_PREFIX + new File(lockBase).getName())
                         : new UnixDomainSocket(lockBase + "/io");
-            }catch(Throwable e){
+            } catch (Throwable e){
                 socketThrowable = e;
                 Thread.sleep(1);
             }
         }
-        if (ioSocket == null){
+        if (ioSocket == null) {
             throw new Exception("Failed to connect to server", socketThrowable);
         }
 
@@ -231,12 +221,29 @@ public class MillClientMain {
 
         locks.serverLock.await();
 
-        try(FileInputStream fis = new FileInputStream(lockBase + "/exitCode")){
-            return Integer.parseInt(new BufferedReader(new InputStreamReader(fis)).readLine());
-        } catch(Throwable e){
+        try {
+            return Integer.parseInt(Files.readString(Paths.get(lockBase + "/exitCode")));
+        } catch (Throwable e) {
             return ExitClientCodeCannotReadFromExitCodeFile();
-        } finally{
+        } finally {
             ioSocket.close();
         }
+    }
+
+    // 5 processes max
+    private static int getServerProcessesLimit(String jvmHomeEncoding) {
+        File outFolder = new File("out");
+        String[] totalProcesses = outFolder.list((dir,name) -> name.startsWith("mill-worker-"));
+        String[] thisJdkProcesses = outFolder.list((dir,name) -> name.startsWith("mill-worker-" + jvmHomeEncoding));
+
+        int processLimit = 5;
+        if (totalProcesses != null) {
+            if (thisJdkProcesses != null) {
+                processLimit -= Math.min(totalProcesses.length - thisJdkProcesses.length, 5);
+            } else {
+                processLimit -= Math.min(totalProcesses.length, 5);
+            }
+        }
+        return processLimit;
     }
 }

--- a/main/client/src/mill/main/client/MillClientMain.java
+++ b/main/client/src/mill/main/client/MillClientMain.java
@@ -222,7 +222,7 @@ public class MillClientMain {
         locks.serverLock.await();
 
         try {
-            return Integer.parseInt(Files.readString(Paths.get(lockBase + "/exitCode")));
+            return Integer.parseInt(Files.readAllLines(Paths.get(lockBase + "/exitCode")).get(0));
         } catch (Throwable e) {
             return ExitClientCodeCannotReadFromExitCodeFile();
         } finally {

--- a/main/client/src/mill/main/client/MillClientMain.java
+++ b/main/client/src/mill/main/client/MillClientMain.java
@@ -198,7 +198,6 @@ public class MillClientMain {
         while (ioSocket == null && System.currentTimeMillis() - retryStart < 5000) {
             try {
                 ioSocket = Util.isWindows?
-                        //new Win32NamedPipeClientSocket(Util.WIN32_PIPE_PREFIX + "mill." + new File(lockBase).getName())
                         new Win32NamedPipeSocket(Util.WIN32_PIPE_PREFIX + "mill." + new File(lockBase).getName())
                         : new UnixDomainSocket(lockBase + "/io");
             } catch (Throwable e){

--- a/main/src/main/MillServerMain.scala
+++ b/main/src/main/MillServerMain.scala
@@ -183,6 +183,16 @@ class Server[T](lockBase: String,
     // flush before closing the socket
     System.out.flush()
     System.err.flush()
+    
+    if (Util.isWindows) {
+      // Closing Win32NamedPipeSocket can often take ~5s
+      // It seems OK to exit the client early and subsequently
+      // start up mill client again (perhaps closing the server
+      // socket helps speed up the process).
+      val t = new Thread(() => clientSocket.close())
+      t.setDaemon(true)
+      t.start()
+    } else clientSocket.close()
   }
 }
 

--- a/main/test/src/main/ClientServerTests.scala
+++ b/main/test/src/main/ClientServerTests.scala
@@ -37,8 +37,10 @@ class EchoServer extends MillServerMain[Int]{
 }
 
 object ClientServerTests extends TestSuite{
+  val ENDL = System.lineSeparator()
+
   def initStreams() = {
-    val in = new ByteArrayInputStream("hello\n".getBytes())
+    val in = new ByteArrayInputStream(s"hello${ENDL}".getBytes())
     val out = new ByteArrayOutputStream()
     val err = new ByteArrayOutputStream()
     (in, out, err)
@@ -81,62 +83,61 @@ object ClientServerTests extends TestSuite{
 
   def tests = Tests{
     'hello - {
-      if (!Util.isWindows){
-        val (tmpDir, locks) = init()
-        def runClient(s: String) = runClientAux(tmpDir, locks)(Map.empty, Array(s))
+      val (tmpDir, locks) = init()
+      def runClient(s: String) = runClientAux(tmpDir, locks)(Map.empty, Array(s))
 
-        // Make sure the simple "have the client start a server and
-        // exchange one message" workflow works from end to end.
+      // Make sure the simple "have the client start a server and
+      // exchange one message" workflow works from end to end.
 
-        assert(
-          locks.clientLock.probe(),
-          locks.serverLock.probe(),
-          locks.processLock.probe()
-        )
+      assert(
+        locks.clientLock.probe(),
+        locks.serverLock.probe(),
+        locks.processLock.probe()
+      )
 
-        val (out1, err1) = runClient("world")
+      val (out1, err1) = runClient("world")
 
-        assert(
-          out1 == "helloworld\n",
-          err1 == "HELLOworld\n"
-        )
+      assert(
+        out1 == s"helloworld${ENDL}",
+        err1 == s"HELLOworld${ENDL}"
+      )
 
-        // Give a bit of time for the server to release the lock and
-        // re-acquire it to signal to the client that it's done
-        Thread.sleep(100)
+      // Give a bit of time for the server to release the lock and
+      // re-acquire it to signal to the client that it's done
+      Thread.sleep(100)
 
-        assert(
-          locks.clientLock.probe(),
-          !locks.serverLock.probe(),
-          !locks.processLock.probe()
-        )
+      assert(
+        locks.clientLock.probe(),
+        !locks.serverLock.probe(),
+        !locks.processLock.probe()
+      )
 
-        // A seecond client in sequence connect to the same server
-        val (out2, err2) = runClient(" WORLD")
+      // A seecond client in sequence connect to the same server
+      val (out2, err2) = runClient(" WORLD")
 
-        assert(
-          out2 == "hello WORLD\n",
-          err2 == "HELLO WORLD\n"
-        )
+      assert(
+        out2 == s"hello WORLD${ENDL}",
+        err2 == s"HELLO WORLD${ENDL}"
+      )
 
-        // Make sure the server times out of not used for a while
-        Thread.sleep(2000)
-        assert(
-          locks.clientLock.probe(),
-          locks.serverLock.probe(),
-          locks.processLock.probe()
-        )
+      // Make sure the server times out of not used for a while
+      Thread.sleep(2000)
+      assert(
+        locks.clientLock.probe(),
+        locks.serverLock.probe(),
+        locks.processLock.probe()
+      )
 
-        // Have a third client spawn/connect-to a new server at the same path
-        val (out3, err3) = runClient(" World")
-        assert(
-          out3 == "hello World\n",
-          err3 == "HELLO World\n"
-        )
-      }
+      // Have a third client spawn/connect-to a new server at the same path
+      val (out3, err3) = runClient(" World")
+      assert(
+        out3 == s"hello World${ENDL}",
+        err3 == s"HELLO World${ENDL}"
+      )
+      
 
       'envVars - retry(3) {
-        if (!Util.isWindows){
+        if (true){
           val (tmpDir, locks) = init()
 
           def runClient(env : Map[String, String]) = runClientAux(tmpDir, locks)(env, Array())
@@ -163,7 +164,7 @@ object ClientServerTests extends TestSuite{
 
 
           val (out1, err1) = runClient(env)
-          val expected = s"a=$a1000\nb=$b1000\nc=$c1000\n"
+          val expected = s"a=$a1000${ENDL}b=$b1000${ENDL}c=$c1000${ENDL}"
 
           assert(
             out1 == expected,
@@ -205,7 +206,7 @@ object ClientServerTests extends TestSuite{
           val pathEnvVar = path.mkString(":")
           val (out2, err2) = runClient(Map("PATH" -> pathEnvVar))
 
-          val expected2 = s"PATH=$pathEnvVar\n"
+          val expected2 = s"PATH=$pathEnvVar${ENDL}"
 
           assert(
             out2 == expected2,


### PR DESCRIPTION
Only one thing in `ClientServerTests` doesn't work currently.  
Maybe someone will find a fix in the future... 😄 

I tried many things, even reimplementing the whole named pipes thing with JNA...  
But it boils down to `read/write` throwing an exception instead of returning `-1`...  
Since the read is done infinitely in a separate thread, it doesn't know when the output from server is done.  
So when a connection breaks, we should just ignore it, and not `System.exit(1);` as currently.