### PR TITLE
Fix macro-hygiene in Discover macro

### DIFF
--- a/integration/test/resources/hygiene/build.sc
+++ b/integration/test/resources/hygiene/build.sc
@@ -1,0 +1,8 @@
+import _root_.mill._, scalalib._, publish._
+
+object scala extends Module {
+  def foo = T{
+    "fooValue"
+  }
+}
+

--- a/integration/test/src/HygieneTests.scala
+++ b/integration/test/src/HygieneTests.scala
@@ -1,0 +1,21 @@
+package mill.integration
+
+import mill.util.ScriptTestSuite
+import utest._
+
+class HygieneTests(fork: Boolean)
+  extends ScriptTestSuite(fork) {
+  def workspaceSlug: String = "hygiene"
+  def scriptSourcePath: os.Path = os.pwd / 'integration / 'test / 'resources / workspaceSlug
+
+  val tests = Tests {
+    initWorkspace()
+
+    test {
+      assert(eval("scala.foo"))
+      val output = meta("scala.foo")
+      assert(output.contains("\"fooValue\""))
+    }
+
+  }
+}

--- a/integration/test/src/local/Tests.scala
+++ b/integration/test/src/local/Tests.scala
@@ -3,6 +3,7 @@ package mill.integration.local
 object AcyclicTests extends mill.integration.AcyclicTests(fork = false)
 object AmmoniteTests extends mill.integration.AmmoniteTests(fork = false)
 object BetterFilesTests extends mill.integration.BetterFilesTests(fork = false)
+object HygieneTests extends mill.integration.HygieneTests(fork = false)
 object LargeProjectTests extends mill.integration.LargeProjectTests(fork = false)
 object JawnTests extends mill.integration.JawnTests(fork = false)
 object UpickleTests extends mill.integration.UpickleTests(fork = false)

--- a/main/core/src/util/Router.scala
+++ b/main/core/src/util/Router.scala
@@ -92,6 +92,6 @@ class Router(val ctx: Context) extends mainargs.Macros(ctx) {
       q"$lhs -> $overridesLambda"
     }
 
-    c.Expr[Discover[T]](q"mill.define.Discover(scala.collection.immutable.Map(..$mapping))")
+    c.Expr[Discover[T]](q"_root_.mill.define.Discover(_root_.scala.collection.immutable.Map(..$mapping))")
   }
 }


### PR DESCRIPTION
By prefixing its `scala` references with `_root_.`, so that users can name some of their own variables `scala`.