### PR TITLE
Pass relative paths to gpg

### DIFF
--- a/scalalib/src/publish/SonatypePublisher.scala
+++ b/scalalib/src/publish/SonatypePublisher.scala
@@ -153,12 +153,11 @@ class SonatypePublisher(uri: String,
 
   // http://central.sonatype.org/pages/working-with-pgp-signatures.html#signing-a-file
   private def gpgSigned(file: os.Path, args: Seq[String]): os.Path = {
-    val fileName = file.toString
-    val command = "gpg" +: args :+ fileName
+    val command = "gpg" +: args :+ file.relativeTo(os.pwd).toString
 
     os.proc(command.map(v => v: Shellable))
       .call(stdin = os.Inherit, stdout = os.Inherit, stderr = os.Inherit)
-    os.Path(fileName + ".asc")
+    os.Path(file.toString + ".asc")
   }
 
   private def md5hex(bytes: Array[Byte]): Array[Byte] =


### PR DESCRIPTION
On GitHub actions, this makes Sonatype publishing work from Windows workers (after a minimal setup such as [this script](https://github.com/coursier/apps/blob/f1d2bf568bf466a98569a85c3f23c5f3a8eb5360/.github/scripts/gpg-setup.sh)).