### PR TITLE
Fix Scala Native env variables values to match sbt

### DIFF
--- a/scalanativelib/src/ScalaNativeModule.scala
+++ b/scalanativelib/src/ScalaNativeModule.scala
@@ -87,7 +87,7 @@ trait ScalaNativeModule extends ScalaModule { outer =>
 
   def logLevel: Target[NativeLogLevel] = T{ NativeLogLevel.Info }
 
-  private def releaseModeInput = T.input(
+  protected def releaseModeInput = T.input(
     sys.env.get("SCALANATIVE_MODE").map(v =>
       ReleaseMode
         .values
@@ -108,7 +108,7 @@ trait ScalaNativeModule extends ScalaModule { outer =>
   def nativeClangPP = T{ os.Path(scalaNativeWorker().discoverClangPP) }
 
   // GC choice, either "none", "boehm", "immix" or "commix"
-  private def nativeGCInput = T.input(sys.env.get("SCALANATIVE_GC"))
+  protected def nativeGCInput = T.input(sys.env.get("SCALANATIVE_GC"))
   def nativeGC = T{
     nativeGCInput().getOrElse(scalaNativeWorker().defaultGarbageCollector)
   }
@@ -125,7 +125,7 @@ trait ScalaNativeModule extends ScalaModule { outer =>
   def nativeLinkStubs = T { false }
 
   // The LTO mode to use used during a release build
-  private def nativeLTOInput = T.input(
+  protected def nativeLTOInput = T.input(
     sys.env.get("SCALANATIVE_LTO").map(v =>
       LTO
         .values
@@ -136,7 +136,7 @@ trait ScalaNativeModule extends ScalaModule { outer =>
   def nativeLTO: Target[LTO] = T { nativeLTOInput().getOrElse(LTO.None) }
 
   // Shall we optimize the resulting NIR code?
-  private def nativeOptimizeInput = T.input(sys.env.get("SCALANATIVE_OPTIMIZE").map(_.toBoolean))
+  protected def nativeOptimizeInput = T.input(sys.env.get("SCALANATIVE_OPTIMIZE").map(_.toBoolean))
   def nativeOptimize: Target[Boolean] = T { nativeOptimizeInput().getOrElse(true) }
 
   def nativeConfig = T.task {

--- a/scalanativelib/src/ScalaNativeModule.scala
+++ b/scalanativelib/src/ScalaNativeModule.scala
@@ -87,7 +87,14 @@ trait ScalaNativeModule extends ScalaModule { outer =>
 
   def logLevel: Target[NativeLogLevel] = T{ NativeLogLevel.Info }
 
-  private def releaseModeInput = T.input(sys.env.get("SCALANATIVE_MODE").map(ReleaseMode.valueOf))
+  private def releaseModeInput = T.input(
+    sys.env.get("SCALANATIVE_MODE").map(v =>
+      ReleaseMode
+        .values
+        .find(_.value == v)
+        .getOrElse(throw new Exception(s"SCALANATIVE_MODE=$v is not valid. Allowed values are: [${ReleaseMode.values.map(_.value).mkString(", ")}]"))
+    )
+  )
   def releaseMode: Target[ReleaseMode] = T {
     releaseModeInput().getOrElse(ReleaseMode.Debug)
   }
@@ -118,7 +125,14 @@ trait ScalaNativeModule extends ScalaModule { outer =>
   def nativeLinkStubs = T { false }
 
   // The LTO mode to use used during a release build
-  private def nativeLTOInput = T.input(sys.env.get("SCALANATIVE_LTO").map(LTO.valueOf))
+  private def nativeLTOInput = T.input(
+    sys.env.get("SCALANATIVE_LTO").map(v =>
+      LTO
+        .values
+        .find(_.value == v)
+        .getOrElse(throw new Exception(s"SCALANATIVE_LTO=$v is not valid. Allowed values are: [${LTO.values.map(_.value).mkString(", ")}]"))
+    )
+  )
   def nativeLTO: Target[LTO] = T { nativeLTOInput().getOrElse(LTO.None) }
 
   // Shall we optimize the resulting NIR code?


### PR DESCRIPTION
- https://github.com/com-lihaoyi/mill/pull/1253 used `valueOf` which
  given a Java `enum` it matches the name of the classes and not
  the string values that match the official Scala Native env variables
  values. This PR uses instead `.values` which returns all the values
  then matches based on the `String value` the enums define.