### PR TITLE
Fix binary version computation of Scala nightly versions

### DIFF
--- a/scalalib/api/src/ZincWorkerApi.scala
+++ b/scalalib/api/src/ZincWorkerApi.scala
@@ -86,12 +86,14 @@ object Util {
   val DottyVersion = raw"""0\.(\d+)\.(\d+).*""".r
   val Scala3Version = raw"""3\.(\d+)\.(\d+)-(\w+).*""".r
   val DottyNightlyVersion = raw"""(0|3)\.(\d+)\.(\d+)-bin-(.*)-NIGHTLY""".r
+  val NightlyVersion = raw"""(\d+)\.(\d+)\.(\d+)-bin-[a-f0-9]*""".r
   val TypelevelVersion = raw"""(\d+)\.(\d+)\.(\d+)-bin-typelevel.*""".r
 
 
   def scalaBinaryVersion(scalaVersion: String) = scalaVersion match {
       case ReleaseVersion(major, minor, _) => s"$major.$minor"
       case MinorSnapshotVersion(major, minor, _) => s"$major.$minor"
+      case NightlyVersion(major, minor, _) => s"$major.$minor"
       case DottyVersion(minor, _) => s"0.$minor"
       case Scala3Version(minor, patch, milestone) => s"3.$minor.$patch-$milestone"
       case TypelevelVersion(major, minor, _) => s"$major.$minor"

--- a/scalalib/api/src/ZincWorkerApi.scala
+++ b/scalalib/api/src/ZincWorkerApi.scala
@@ -145,10 +145,11 @@ object Util {
   }
 
   /** @return true if the compiler bridge can be downloaded as an already compiled jar */
-  def isBinaryBridgeAvailable(scalaVersion: String) = scalaVersion match {
+  def isBinaryBridgeAvailable(scalaVersion: String) =
+    scalaVersion match {
       case DottyNightlyVersion(major, minor, _, _) => major.toInt > 0 || minor.toInt >= 14 // 0.14.0-bin or more (not 0.13.0-bin)
       case DottyVersion(minor, _) => minor.toInt >= 13 // 0.13.0-RC1 or more
-      case Scala3Version(_, _, _) => true
+      case Scala3EarlyVersion(_) |  Scala3Version(_, _) => true
       case _ => false
-  }
+    }
 }

--- a/scalalib/api/src/ZincWorkerApi.scala
+++ b/scalalib/api/src/ZincWorkerApi.scala
@@ -84,18 +84,20 @@ object Util {
   val ReleaseVersion = raw"""(\d+)\.(\d+)\.(\d+)""".r
   val MinorSnapshotVersion = raw"""(\d+)\.(\d+)\.([1-9]\d*)-SNAPSHOT""".r
   val DottyVersion = raw"""0\.(\d+)\.(\d+).*""".r
-  val Scala3Version = raw"""3\.(\d+)\.(\d+)-(\w+).*""".r
+  val Scala3EarlyVersion = raw"""3\.0\.0-(\w+).*""".r
+  val Scala3Version = raw"""3\.(\d+)\.(\d+).*""".r
   val DottyNightlyVersion = raw"""(0|3)\.(\d+)\.(\d+)-bin-(.*)-NIGHTLY""".r
   val NightlyVersion = raw"""(\d+)\.(\d+)\.(\d+)-bin-[a-f0-9]*""".r
   val TypelevelVersion = raw"""(\d+)\.(\d+)\.(\d+)-bin-typelevel.*""".r
 
 
   def scalaBinaryVersion(scalaVersion: String) = scalaVersion match {
+      case Scala3EarlyVersion(milestone) => s"3.0.0-$milestone"
+      case Scala3Version(_, _) => "3"
       case ReleaseVersion(major, minor, _) => s"$major.$minor"
       case MinorSnapshotVersion(major, minor, _) => s"$major.$minor"
       case NightlyVersion(major, minor, _) => s"$major.$minor"
       case DottyVersion(minor, _) => s"0.$minor"
-      case Scala3Version(minor, patch, milestone) => s"3.$minor.$patch-$milestone"
       case TypelevelVersion(major, minor, _) => s"$major.$minor"
       case _ => scalaVersion
   }

--- a/scalalib/src/Dep.scala
+++ b/scalalib/src/Dep.scala
@@ -1,8 +1,8 @@
 package mill.scalalib
 import mill.util.JsonFormatters._
 import upickle.default.{macroRW, ReadWriter => RW}
-
 import CrossVersion._
+import mill.scalalib.api.Util.Scala3EarlyVersion
 
 case class Dep(dep: coursier.Dependency, cross: CrossVersion, force: Boolean) {
   import mill.scalalib.api.Util.{isDottyOrScala3, DottyVersion, Scala3Version}
@@ -57,7 +57,7 @@ case class Dep(dep: coursier.Dependency, cross: CrossVersion, force: Boolean) {
       case cross: Binary if isDottyOrScala3(scalaVersion) =>
         val compatSuffix =
           scalaVersion match {
-            case Scala3Version(_, _, _) =>
+            case Scala3Version(_, _) | Scala3EarlyVersion(_) =>
               "_2.13"
             case DottyVersion(minor, patch) =>
               if (minor.toInt > 18 || minor.toInt == 18 && patch.toInt >= 1)

--- a/scalalib/test/src/dependency/versions/ScalaVersionTests.scala
+++ b/scalalib/test/src/dependency/versions/ScalaVersionTests.scala
@@ -1,0 +1,47 @@
+package mill.scalalib.dependency.versions
+
+import mill.scalalib.api.Util.scalaBinaryVersion
+import utest._
+
+object ScalaVersionTests extends TestSuite {
+
+  val tests = Tests {
+    test("release") {
+      val sv = "2.13.5"
+      val sbv = scalaBinaryVersion(sv)
+      val expectedSbv = "2.13"
+      assert(sbv == expectedSbv)
+    }
+    test("snapshot") {
+      val sv = "2.13.6-SNAPSHOT"
+      val sbv = scalaBinaryVersion(sv)
+      val expectedSbv = "2.13"
+      assert(sbv == expectedSbv)
+    }
+    test("nightly") {
+      val sv = "2.13.5-bin-aab85b1"
+      val sbv = scalaBinaryVersion(sv)
+      val expectedSbv = "2.13"
+      assert(sbv == expectedSbv)
+    }
+    test("dotty") {
+      val sv = "0.27.3"
+      val sbv = scalaBinaryVersion(sv)
+      val expectedSbv = "0.27"
+      assert(sbv == expectedSbv)
+    }
+    test("scala3") {
+      val sv = "3.0.0-RC2"
+      val sbv = scalaBinaryVersion(sv)
+      val expectedSbv = "3.0.0-RC2"
+      assert(sbv == expectedSbv)
+    }
+    test("typelevel") {
+      val sv = "2.11.12-bin-typelevel.foo"
+      val sbv = scalaBinaryVersion(sv)
+      val expectedSbv = "2.11"
+      assert(sbv == expectedSbv)
+    }
+  }
+
+}

--- a/scalalib/test/src/dependency/versions/ScalaVersionTests.scala
+++ b/scalalib/test/src/dependency/versions/ScalaVersionTests.scala
@@ -30,11 +30,24 @@ object ScalaVersionTests extends TestSuite {
       val expectedSbv = "0.27"
       assert(sbv == expectedSbv)
     }
-    test("scala3") {
+    test("earlyscala3") {
       val sv = "3.0.0-RC2"
       val sbv = scalaBinaryVersion(sv)
       val expectedSbv = "3.0.0-RC2"
       assert(sbv == expectedSbv)
+    }
+    test("scala3") {
+      val expectedSbv = "3"
+      test("release") {
+        val sv = "3.0.1"
+        val sbv = scalaBinaryVersion(sv)
+        assert(sbv == expectedSbv)
+      }
+      test("RC") {
+        val sv = "3.0.2-RC4"
+        val sbv = scalaBinaryVersion(sv)
+        assert(sbv == expectedSbv)
+      }
     }
     test("typelevel") {
       val sv = "2.11.12-bin-typelevel.foo"

--- a/scalalib/test/src/dependency/versions/ScalaVersionTests.scala
+++ b/scalalib/test/src/dependency/versions/ScalaVersionTests.scala
@@ -31,10 +31,17 @@ object ScalaVersionTests extends TestSuite {
       assert(sbv == expectedSbv)
     }
     test("earlyscala3") {
-      val sv = "3.0.0-RC2"
-      val sbv = scalaBinaryVersion(sv)
       val expectedSbv = "3.0.0-RC2"
-      assert(sbv == expectedSbv)
+      test("RC") {
+        val sv = "3.0.0-RC2"
+        val sbv = scalaBinaryVersion(sv)
+        assert(sbv == expectedSbv)
+      }
+      test("nightly") {
+        val sv = "3.0.0-RC2-bin-20210323-d4f1c26-NIGHTLY"
+        val sbv = scalaBinaryVersion(sv)
+        assert(sbv == expectedSbv)
+      }
     }
     test("scala3") {
       val expectedSbv = "3"
@@ -45,6 +52,11 @@ object ScalaVersionTests extends TestSuite {
       }
       test("RC") {
         val sv = "3.0.2-RC4"
+        val sbv = scalaBinaryVersion(sv)
+        assert(sbv == expectedSbv)
+      }
+      test("nightly") {
+        val sv = "3.0.1-RC1-bin-20210405-16776c8-NIGHTLY"
         val sbv = scalaBinaryVersion(sv)
         assert(sbv == expectedSbv)
       }


### PR DESCRIPTION
Continuation of #1139 

- Add more test on Scala 3 nightly versions.
- Fix `isBinaryBridgeAvailable`
- Fix `withDottyCompat`

@lefou this is ready for review