### PR TITLE
Loosened the restriction to use T.dest only in one T.task

### DIFF
--- a/main/core/src/eval/package.scala
+++ b/main/core/src/eval/package.scala
@@ -2,16 +2,16 @@ package mill
 
 package object eval {
   // Backwards compatibility forwarders
-  @deprecated("Use mill.api.Result instead")
+  @deprecated("Use mill.api.Result instead", "mill after 0.9.6")
   val Result = mill.api.Result
-  @deprecated("Use mill.api.Result instead")
+  @deprecated("Use mill.api.Result instead", "mill after 0.9.6")
   type Result[+T] = mill.api.Result[T]
 
-  @deprecated("Use mill.api.PathRef instead")
+  @deprecated("Use mill.api.PathRef instead", "mill after 0.9.6")
   val PathRef = mill.api.PathRef
-  @deprecated("Use mill.api.PathRef instead")
+  @deprecated("Use mill.api.PathRef instead", "mill after 0.9.6")
   type PathRef = mill.api.PathRef
 
-  @deprecated("Use mill.api.Logger instead")
+  @deprecated("Use mill.api.Logger instead", "mill after 0.9.6")
   type Logger = mill.api.Logger
 }

--- a/main/core/src/util/package.scala
+++ b/main/core/src/util/package.scala
@@ -2,6 +2,8 @@ package mill
 
 package object util {
   // Backwards compat stubs
+  @deprecated("Use mill.api.Ctx instead", "mill after 0.9.6")
   val Ctx = mill.api.Ctx
+  @deprecated("Use mill.api.Ctx instead", "mill after 0.9.6")
   type Ctx = mill.api.Ctx
 }

--- a/main/test/src/eval/FailureTests.scala
+++ b/main/test/src/eval/FailureTests.scala
@@ -187,15 +187,15 @@ object FailureTests extends TestSuite{
         // Using `T.ctx(  ).dest` twice in a single task is ok
         def left = T{ + T.dest.toString.length + T.dest.toString.length }
 
-        // Using `T.ctx(  ).dest` once in two different tasks is not ok
+        // Using `T.ctx(  ).dest` once in two different tasks is ok
         val task = T.task{ T.dest.toString.length  }
         def right = T{ task() + left() + T.dest.toString().length }
       }
 
       val check = new TestEvaluator(build)
-      val Right(_) = check(build.left)
-      val Left(Result.Exception(e, _)) = check(build.right)
-      assert(e.getMessage.contains("`dest` can only be used in one place"))
+      assert(check(build.left).isRight)
+      assert(check(build.right).isRight)
+      // assert(e.getMessage.contains("`dest` can only be used in one place"))
     }
   }
 }


### PR DESCRIPTION
Also deprecated some more type aliases.

See also discussion: https://gitter.im/lihaoyi/mill?at=6051223bd71b6554cd4bf600

> Tobias Roeser @lefou März 16 22:25
> @lihaoyi I find the "dest can only be used in one place within each Target[T]" restriction when calling anonymous tasks quite limiting. Is there a good motivation for it ?
> Li Haoyi @lihaoyi März 17 02:08
> @lefou it was somewhat arbitrary, if we don't think the limitation is pulling its own weight we can probably remove it
> Tobias Roeser @lefou März 17 09:14
> @lihaoyi I'm all for it. I can clearly see that it allows me to better split my work into tasks, or let tasks better interact. But I haven't really thought about any downside of removing that limitation. But I assume there are none, as Tasks run per definition in the context of their calling Targets.
> Li Haoyi @lihaoyi März 17 11:09
> go for it then

