### PR TITLE
Fix #1283, #1021: Windows BSP: request failed: buildTarget/dependencySources

### DIFF
--- a/bsp/src/mill/bsp/ModuleUtils.scala
+++ b/bsp/src/mill/bsp/ModuleUtils.scala
@@ -11,7 +11,11 @@ import mill.define._
 import mill.eval.{Evaluator, _}
 import mill.scalajslib.ScalaJSModule
 import mill.scalalib._
-import mill.scalalib.Lib.{depToDependency, resolveDependencies, scalaRuntimeIvyDeps}
+import mill.scalalib.Lib.{
+  depToDependency,
+  resolveDependencies,
+  scalaRuntimeIvyDeps
+}
 import mill.scalalib.api.Util
 import mill.scalanativelib._
 import mill.util.Ctx
@@ -36,10 +40,12 @@ object ModuleUtils {
   /**
    * Resolve a mill modules given a target identifier
    * */
-  def getModule(targetId: BuildTargetIdentifier, modules: Seq[JavaModule]): JavaModule =
+  def getModule(targetId: BuildTargetIdentifier,
+                modules: Seq[JavaModule]): JavaModule =
     modules
       .find(getTargetId(_) == targetId)
-      .getOrElse(throw new IllegalArgumentException(s"No module found for target id ${targetId.getUri}"))
+      .getOrElse(throw new IllegalArgumentException(
+        s"No module found for target id ${targetId.getUri}"))
 
   /**
    * Compute mapping between all the JavaModules contained in the
@@ -47,13 +53,14 @@ object ModuleUtils {
    * BSP BuildTargets ( mill modules correspond one-to-one to
    * bsp build targets ).
    *
-    * @param modules            All JavaModules contained in the working
+   * @param modules            All JavaModules contained in the working
    *                           directory of the mill project
    * @param evaluator          The mill evaluator that can resolve information
    *                           about the mill project
    * @return JavaModule -> BuildTarget mapping
    */
-  def getTargets(modules: Seq[JavaModule], evaluator: Evaluator)(implicit ctx: Ctx.Log): Seq[BuildTarget] = {
+  def getTargets(modules: Seq[JavaModule], evaluator: Evaluator)(
+      implicit ctx: Ctx.Log): Seq[BuildTarget] = {
     val targets = modules.map(module => getTarget(module, evaluator))
     val millBuildTarget = getMillBuildTarget(evaluator, modules)
 
@@ -61,7 +68,8 @@ object ModuleUtils {
   }
 
   def getMillBuildTargetId(evaluator: Evaluator): BuildTargetIdentifier =
-    new BuildTargetIdentifier(evaluator.rootModule.millSourcePath.toNIO.toUri.toString)
+    new BuildTargetIdentifier(
+      evaluator.rootModule.millSourcePath.toNIO.toUri.toString)
 
   /**
    * Compute the BuildTarget for the Mill build (build.sc files)
@@ -70,7 +78,8 @@ object ModuleUtils {
    *                    build information
    * @return the Mill BuildTarget
    */
-  def getMillBuildTarget(evaluator: Evaluator, modules: Seq[JavaModule])(implicit ctx: Ctx.Log): BuildTarget = {
+  def getMillBuildTarget(evaluator: Evaluator, modules: Seq[JavaModule])(
+      implicit ctx: Ctx.Log): BuildTarget = {
     val target = new BuildTarget(
       getMillBuildTargetId(evaluator),
       Seq.empty[String].asJava,
@@ -78,13 +87,16 @@ object ModuleUtils {
       Seq.empty[BuildTargetIdentifier].asJava,
       new BuildTargetCapabilities(false, false, false)
     )
-    target.setBaseDirectory(evaluator.rootModule.millSourcePath.toNIO.toUri.toString)
+    target.setBaseDirectory(
+      evaluator.rootModule.millSourcePath.toNIO.toUri.toString)
     target.setDataKind(BuildTargetDataKind.SCALA)
-    target.setTags(Seq(BuildTargetTag.LIBRARY, BuildTargetTag.APPLICATION).asJava)
+    target.setTags(
+      Seq(BuildTargetTag.LIBRARY, BuildTargetTag.APPLICATION).asJava)
     target.setDisplayName("mill-build")
 
     val scalaOrganization = "org.scala-lang"
-    val scalaLibDep = scalaRuntimeIvyDeps(scalaOrganization, BuildInfo.scalaVersion)
+    val scalaLibDep =
+      scalaRuntimeIvyDeps(scalaOrganization, BuildInfo.scalaVersion)
 
     val repos = Evaluator
       .evalOrElse(evaluator, T.traverse(modules)(_.repositoriesTask), Seq.empty)
@@ -111,24 +123,46 @@ object ModuleUtils {
     target
   }
 
-  def getMillBuildClasspath(evaluator: Evaluator, sources: Boolean): Seq[String] = {
-    val classpath = Try(evaluator.rootModule.getClass.getClassLoader.asInstanceOf[SpecialClassLoader]).fold(
-      _ => Seq.empty,
-      _.allJars
-    )
+  def getMillBuildClasspath(evaluator: Evaluator,
+                            sources: Boolean): Seq[String] = {
 
-    val millJars = resolveDependencies(
+    /** On Windows, URLs follow an peculiar representation in Java
+     * scala> java.nio.file.Paths.get(".").toAbsolutePath.toUri.toURL
+     * java.net.URL = file:/C:/Users/Developer/mill/./
+     *
+     * From this, we wish to get a Path back, and the way to do this is:
+     *
+     * scala> java.nio.file.Paths.get((java.nio.file.Paths.get(".").toAbsolutePath.toUri.toURL).toURI)
+     * java.nio.file.Path = C:\Users\Developer\mill\.
+     *
+     * Unit testing for this is more challenging because the WindowsFileSystem instance is a sun.nio.fs package,
+     * rather than a standard package.
+     *
+     * The solution here, compared to the previous code, is to reduce the number of conversions;
+     * the key loss happens when you do (URL).getFile.
+     * scala> java.nio.file.Paths.get(".").toAbsolutePath.toUri.toURL
+     * java.net.URL = file:/C:/Users/Developer/mill/./
+     * scala> java.nio.file.Paths.get(".").toAbsolutePath.toUri.toURL.getFile
+     * String = /C:/Users/Developer/mill/./
+     *  */
+    val classpath: Seq[Path] = Try(
+      evaluator.rootModule.getClass.getClassLoader
+        .asInstanceOf[SpecialClassLoader])
+      .fold(_ => Seq.empty, _.allJars)
+      .map(url => Path(java.nio.file.Paths.get(url.toURI)))
+
+    val millJars: Seq[Path] = resolveDependencies(
       Resolve.defaultRepositories,
       depToDependency(_, BuildInfo.scalaVersion),
       BuildInfo.millEmbeddedDeps.map(d => ivy"$d"),
       sources = sources
-    ).asSuccess.toSeq.flatMap(_.value).map(_.path.toNIO.toUri.toURL)
+    ).asSuccess.toSeq.flatMap(_.value).map(_.path)
 
     val all = classpath ++ millJars
     val binarySource =
-      if (sources) all.filter(url => isSourceJar(url))
-      else all.filter(url => !isSourceJar(url))
-    binarySource.filter(url => exists(Path(url.getFile))).map(_.toURI.toString)
+      if (sources) all.filter(url => isPathSourceJar(url))
+      else all.filter(url => !isPathSourceJar(url))
+    binarySource.filter(path => exists(path)).map(_.wrapped.toString)
   }
 
   /**
@@ -136,7 +170,7 @@ object ModuleUtils {
    * JavaModule, which is any module present in the working
    * directory, but it's not the root module itself.
    *
-    * @param module      any in-project mill module
+   * @param module      any in-project mill module
    * @param evaluator   mill evaluator
    * @return inner BuildTarget
    */
@@ -145,14 +179,18 @@ object ModuleUtils {
     val capabilities = getModuleCapabilities(module)
     val buildTargetTag = module match {
       case _: TestModule => Seq(BuildTargetTag.TEST)
-      case _: JavaModule => Seq(BuildTargetTag.LIBRARY, BuildTargetTag.APPLICATION)
+      case _: JavaModule =>
+        Seq(BuildTargetTag.LIBRARY, BuildTargetTag.APPLICATION)
     }
 
     val buildTarget = new BuildTarget(
       getTargetId(module),
       buildTargetTag.asJava,
       Seq("scala", "java").asJava,
-      (module.moduleDeps ++ module.compileModuleDeps).map(getTargetId).toList.asJava,
+      (module.moduleDeps ++ module.compileModuleDeps)
+        .map(getTargetId)
+        .toList
+        .asJava,
       capabilities
     )
     if (module.isInstanceOf[ScalaModule]) {
@@ -164,10 +202,11 @@ object ModuleUtils {
   }
 
   // obtain the capabilities of the given module ( ex: canCompile, canRun, canTest )
-  private[this] def getModuleCapabilities(module: JavaModule): BuildTargetCapabilities = {
+  private[this] def getModuleCapabilities(
+      module: JavaModule): BuildTargetCapabilities = {
     val canTest = module match {
       case _: TestModule => true
-      case _ => false
+      case _             => false
     }
 
     new BuildTargetCapabilities(true, canTest, true)
@@ -177,7 +216,7 @@ object ModuleUtils {
    * Evaluate the given task using the given mill evaluator and return
    * its result of type Result
    *
-    * @param evaluator mill evalautor
+   * @param evaluator mill evalautor
    * @param task      task to evaluate
    * @tparam T
    */
@@ -189,16 +228,18 @@ object ModuleUtils {
    * Evaluate the given task using the given mill evaluator and return
    * its result of type T, or the default value of the evaluation failed.
    *
-    * @param evaluator    mill evalautor
+   * @param evaluator    mill evalautor
    * @param task         task to evaluate
    * @param defaultValue default value to return in case of failure
    * @tparam T
    */
-  def evaluateInformativeTask[T](evaluator: Evaluator, task: Task[T], defaultValue: T): T = {
+  def evaluateInformativeTask[T](evaluator: Evaluator,
+                                 task: Task[T],
+                                 defaultValue: T): T = {
     val evaluated = evaluator.evaluate(Strict.Agg(task)).results(task)
     evaluated match {
       case Success(_) => evaluated.asSuccess.get.value.asInstanceOf[T]
-      case _ => defaultValue
+      case _          => defaultValue
     }
   }
 
@@ -207,19 +248,28 @@ object ModuleUtils {
       (module.millOuterCtx.millSourcePath / module.millModuleSegments.parts).toNIO.toUri.toString
     )
 
-  def getTarget(moduleHashCode: Int, modules: Seq[JavaModule], evaluator: Evaluator): Option[BuildTarget] =
+  def getTarget(moduleHashCode: Int,
+                modules: Seq[JavaModule],
+                evaluator: Evaluator): Option[BuildTarget] =
     modules.find(_.hashCode == moduleHashCode).map(getTarget(_, evaluator))
 
-  def getTargetId(moduleHashCode: Int, modules: Seq[JavaModule]): Option[BuildTargetIdentifier] =
+  def getTargetId(moduleHashCode: Int,
+                  modules: Seq[JavaModule]): Option[BuildTargetIdentifier] =
     modules.find(_.hashCode == moduleHashCode).map(getTargetId)
 
   def isSourceJar(url: URL): Boolean = url.getFile.endsWith("-sources.jar")
 
+  def isPathSourceJar(path: Path): Boolean =
+    path.wrapped.toString.endsWith("-sources.jar")
+
   // Compute the ScalaBuildTarget from information about the given JavaModule.
-  private[this] def computeBuildTargetData(module: JavaModule, evaluator: Evaluator): ScalaBuildTarget = {
+  private[this] def computeBuildTargetData(
+      module: JavaModule,
+      evaluator: Evaluator): ScalaBuildTarget = {
     module match {
       case m: ScalaModule =>
-        val scalaVersion = evaluateInformativeTask(evaluator, m.scalaVersion, "")
+        val scalaVersion =
+          evaluateInformativeTask(evaluator, m.scalaVersion, "")
         new ScalaBuildTarget(
           evaluateInformativeTask(evaluator, m.scalaOrganization, ""),
           scalaVersion,
@@ -240,28 +290,41 @@ object ModuleUtils {
           Seq.empty[String].asJava
         )
       case m =>
-        throw new IllegalStateException(s"Module type of ${m.millModuleSegments.render} not supported by BSP")
+        throw new IllegalStateException(
+          s"Module type of ${m.millModuleSegments.render} not supported by BSP")
     }
   }
 
   // Compute all relevant scala dependencies of `module`, like scala-library, scala-compiler,
   // and scala-reflect
-  private[this] def computeScalaLangDependencies(module: ScalaModule, evaluator: Evaluator): Agg[PathRef] = {
-    evaluateInformativeTask(evaluator, module.resolveDeps(module.scalaLibraryIvyDeps), Agg.empty[PathRef]) ++
-      evaluateInformativeTask(evaluator, module.scalacPluginClasspath, Agg.empty[PathRef]) ++
-      evaluateInformativeTask(evaluator, module.resolveDeps(module.ivyDeps), Agg.empty[PathRef]).filter(pathRef =>
-        pathRef.path.toNIO.toUri.toString.contains("scala-compiler") ||
-          pathRef.path.toNIO.toUri.toString.contains("scala-reflect") ||
-          pathRef.path.toNIO.toUri.toString.contains("scala-library")
-      )
+  private[this] def computeScalaLangDependencies(
+      module: ScalaModule,
+      evaluator: Evaluator): Agg[PathRef] = {
+    evaluateInformativeTask(
+      evaluator,
+      module.resolveDeps(module.scalaLibraryIvyDeps),
+      Agg.empty[PathRef]) ++
+      evaluateInformativeTask(
+        evaluator,
+        module.scalacPluginClasspath,
+        Agg.empty[PathRef]) ++
+      evaluateInformativeTask(
+        evaluator,
+        module.resolveDeps(module.ivyDeps),
+        Agg.empty[PathRef]).filter(
+        pathRef =>
+          pathRef.path.toNIO.toUri.toString.contains("scala-compiler") ||
+            pathRef.path.toNIO.toUri.toString.contains("scala-reflect") ||
+            pathRef.path.toNIO.toUri.toString.contains("scala-library"))
   }
 
   // Obtain the scala platform for `module`
-  private[this] def getScalaTargetPlatform(module: ScalaModule): ScalaPlatform = {
+  private[this] def getScalaTargetPlatform(
+      module: ScalaModule): ScalaPlatform = {
     module match {
       case _: ScalaNativeModule => ScalaPlatform.NATIVE
-      case _: ScalaJSModule => ScalaPlatform.JS
-      case _: ScalaModule => ScalaPlatform.JVM
+      case _: ScalaJSModule     => ScalaPlatform.JS
+      case _: ScalaModule       => ScalaPlatform.JVM
     }
   }
 }


### PR DESCRIPTION
… - cannot import into IDE

There is a PR already (#1092) but I am wary of dealing with Strings directly. Here is my approach.

On Windows, File URLs follow an peculiar representation in Java

```
scala> java.nio.file.Paths.get(".").toAbsolutePath.toUri.toURL
java.net.URL = file:/C:/Users/Developer/mill/./
```

From this, we wish to get a `Path` back, and the way to do this is:

```
scala> java.nio.file.Paths.get((java.nio.file.Paths.get(".").toAbsolutePath.toUri.toURL).toURI)
java.nio.file.Path = C:\Users\Developer\mill\.
```

Unit testing for this is more challenging because the `WindowsFileSystem` instance is a `sun.nio.fs` package, rather than a standard package.

The solution here, compared to the previous code, is to reduce the number of conversions; the key loss happens when you do `(URL).getFile`.

```
scala> java.nio.file.Paths.get(".").toAbsolutePath.toUri.toURL
java.net.URL = file:/C:/Users/Developer/mill/./
scala> java.nio.file.Paths.get(".").toAbsolutePath.toUri.toURL.getFile
String = /C:/Users/Developer/mill/./
```



**Other notes:**

I enabled edits by maintainers, and as such please feel free to modify.

**scalafmt**: I was not sure how to apply Scalafmt from Mill as I am very new to this, and my IntelliJ didn't have the option for this imported build to do a scalafmt.

**Testing**: Like #1092, I think unit testing this is very challenging. Are there instructions as to how you could test this, or are you able to do a test of this PR?

I am very pressed for time at the moment, but wanted to make a contribution however my knowledge on this tool is still very limited.

I tried `bsp.test` task, and then import the produced file however this did not work as expected (neither did the original version of mill), where the `mill.json` that is produced looked like:
```
{"name":"mill-bsp","argv":["C:\\Path\\to\\jar1.jar;C:\\Path\\to\jar2.jar...", "-i", ...] }
```

And when importing, it would say that the whole argument is not a file that can be found (rather than the individual files?)