### PR TITLE
strip whitespace from version file

### DIFF
--- a/contrib/versionfile/src/mill/contrib/versionfile/VersionFileModule.scala
+++ b/contrib/versionfile/src/mill/contrib/versionfile/VersionFileModule.scala
@@ -7,7 +7,7 @@ trait VersionFileModule extends Module {
   /** The file containing the current version. */
   def versionFile: define.Source = T.source(millSourcePath / "version")
   /** The current version. */
-  def currentVersion: T[Version] = T { Version.of(os.read(versionFile().path)) }
+  def currentVersion: T[Version] = T { Version.of(os.read(versionFile().path).strip) }
   /** The release version. */
   def releaseVersion = T { currentVersion().asRelease }
   /** The next snapshot version. */

--- a/contrib/versionfile/src/mill/contrib/versionfile/VersionFileModule.scala
+++ b/contrib/versionfile/src/mill/contrib/versionfile/VersionFileModule.scala
@@ -7,7 +7,7 @@ trait VersionFileModule extends Module {
   /** The file containing the current version. */
   def versionFile: define.Source = T.source(millSourcePath / "version")
   /** The current version. */
-  def currentVersion: T[Version] = T { Version.of(os.read(versionFile().path).strip) }
+  def currentVersion: T[Version] = T { Version.of(os.read(versionFile().path).trim) }
   /** The release version. */
   def releaseVersion = T { currentVersion().asRelease }
   /** The next snapshot version. */

--- a/contrib/versionfile/test/src/mill/contrib/versionfile/VersionFileModuleTests.scala
+++ b/contrib/versionfile/test/src/mill/contrib/versionfile/VersionFileModuleTests.scala
@@ -13,13 +13,13 @@ object VersionFileModuleTests extends TestSuite {
     case object versionFile extends VersionFileModule
   }
 
-  def evaluator[T, M <: TestUtil.BaseModule](m: M, vf: M => VersionFileModule, version: Version)
-                                            (implicit tp: TestPath): TestEvaluator = {
+  def evaluator[T, M <: TestUtil.BaseModule](m: M, vf: M => VersionFileModule, versionText: String)
+    (implicit tp: TestPath): TestEvaluator = {
     val eval = new TestEvaluator(m)
     rm(m.millSourcePath)
     rm(eval.outPath)
     write.over(
-      vf(m).millSourcePath / "version", version.toString, createFolders = true
+      vf(m).millSourcePath / "version", versionText, createFolders = true
     )
     eval
   }
@@ -28,11 +28,22 @@ object VersionFileModuleTests extends TestSuite {
          (test: TestEvaluator => Version => Any)
          (implicit tp: TestPath): Unit = {
     for (version <- versions)
-      test(evaluator(TestModule, (m: TestModule.type) => m.versionFile, version))(version)
+      test(evaluator(TestModule, (m: TestModule.type) => m.versionFile, version.toString))(version)
   }
 
   def workspaceTest(versions: Version*)(test: TestEvaluator => Any)(implicit tp: TestPath): Unit =
     workspaceTest0(versions: _*)(eval => _ => test(eval))
+
+  //  check version file ends with newline
+  def workspaceTestEndsWithNewline0(versions: Version*)
+    (test: TestEvaluator => Version => Any)
+    (implicit tp: TestPath): Unit = {
+    for (version <- versions)
+      test(evaluator(TestModule, (m: TestModule.type) => m.versionFile, version.toString + "\n"))(version)
+  }
+
+  def workspaceTestEndsWithNewline(versions: Version*)(test: TestEvaluator => Any)(implicit tp: TestPath): Unit =
+    workspaceTestEndsWithNewline0(versions: _*)(eval => _ => test(eval))
 
   implicit class ResultOps[A](result: Either[Result.Failing[A], (A, Int)]) {
     def value: Either[Result.Failing[A], A] = result.map(_._1)
@@ -66,6 +77,25 @@ object VersionFileModuleTests extends TestSuite {
         }
       }
 
+      test("currentVersion - file ends with newline") - workspaceTestEndsWithNewline0(versions: _*) { eval =>
+        expectedVersion =>
+          val out = eval(TestModule.versionFile.currentVersion)
+          assert(out.value == Right(expectedVersion))
+      }
+
+      test("releaseVersion - file ends with newline") - workspaceTestEndsWithNewline(versions: _*) { eval =>
+        val out = eval(TestModule.versionFile.releaseVersion)
+        assertMatch(out) {
+          case Right((Version.Release(1, 2, 3), _)) =>
+        }
+      }
+
+      test("nextVersion - file ends with newline") - workspaceTestEndsWithNewline(versions: _*) { eval =>
+        val out = eval(TestModule.versionFile.nextVersion(minor))
+        assertMatch(out) {
+          case Right((Version.Snapshot(1, 3, 0), _)) =>
+        }
+      }
     }
 
     test("writing") {


### PR DESCRIPTION
strip whitespace to avoid MatchError in `Version.of` when version file ends with newline character.

This fix #1294