### PR TITLE
Enable ANSI output on Windows upon start-up

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -99,6 +99,7 @@ object Deps {
   val sourcecode = ivy"com.lihaoyi::sourcecode:0.2.6"
   val upickle = ivy"com.lihaoyi::upickle:1.3.12"
   val utest = ivy"com.lihaoyi::utest:0.7.9"
+  val windowsAnsi = ivy"io.github.alexarchambault.windows-ansi:windows-ansi:0.0.3"
   val zinc = ivy"org.scala-sbt::zinc:1.5.2"
   val bsp = ivy"ch.epfl.scala:bsp4j:2.0.0-M13"
   val jarjarabrams = ivy"com.eed3si9n.jarjarabrams::jarjar-abrams-core:0.3.1"
@@ -168,6 +169,9 @@ trait MillModule extends MillApiModule { outer =>
 
 object main extends MillModule {
   def moduleDeps = Seq(core, client)
+  def ivyDeps = Agg(
+    Deps.windowsAnsi
+  )
 
   def compileIvyDeps = Agg(
     Deps.scalaReflect(scalaVersion())

--- a/main/src/MillMain.scala
+++ b/main/src/MillMain.scala
@@ -4,6 +4,7 @@ import java.io.{InputStream, PrintStream}
 import java.util.Locale
 
 import scala.jdk.CollectionConverters._
+import scala.util.Properties
 import io.github.retronym.java9rtexport.Export
 import mainargs.{Flag, Leftover, arg}
 import mill.eval.Evaluator
@@ -71,6 +72,10 @@ case class MillConfig(
 object MillMain {
 
   def main(args: Array[String]): Unit = {
+
+    if (Properties.isWin && System.console() != null)
+      io.github.alexarchambault.windowsansi.WindowsAnsi.setup()
+
     val (result, _) = main0(
       args,
       None,


### PR DESCRIPTION
This fixes https://github.com/com-lihaoyi/mill/issues/1284 by enabling ["console virtual terminal sequences"](https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences) in the Windows console, which are basically ANSI escape codes. This is done using some JNI bindings of jline, via [windows-ansi](https://github.com/alexarchambault/windows-ansi).