### PR TITLE
Properly close resources to fix assembly on Windows

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -49,8 +49,8 @@ jobs:
       matrix:
         java-version: [8, 11]
         buildcmd:
-          - cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i "{__.publishLocal,assembly,__.compile}"
-          - cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i -d -k "{main,scalajslib,bsp}.__.test"
+          - cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i -d -k "{__.publishLocal,assembly,__.compile}"
+          - cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i -d -k "{main,scalalib,scalajslib,bsp}.__.test"
           - cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i -d integration.test "mill.integration.local.{AcyclicTests,AmmoniteTests,DocAnnotationsTests}"
 
     runs-on: windows-latest
@@ -73,7 +73,6 @@ jobs:
       matrix:
         java-version: [8, 11]
         buildcmd:
-          - cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i -d "scalalib.__.test"
           - cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i -d -k "contrib._.test"
 
     runs-on: windows-latest

--- a/main/src/modules/Assembly.scala
+++ b/main/src/modules/Assembly.scala
@@ -1,9 +1,10 @@
 package mill.modules
 
 import com.eed3si9n.jarjarabrams.{ShadePattern, Shader}
-import java.io.{ByteArrayInputStream, InputStream}
+import java.io.{ByteArrayInputStream, Closeable, InputStream}
 import java.util.jar.JarFile
 import java.util.regex.Pattern
+
 import mill.Agg
 import os.Generator
 import scala.jdk.CollectionConverters._
@@ -78,10 +79,12 @@ object Assembly {
     }
   }
 
+  type ResourceCloser = () => ()
+
   def loadShadedClasspath(
     inputPaths: Agg[os.Path],
     assemblyRules: Seq[Assembly.Rule]
-  ): Generator[(String, UnopenedInputStream)] = {
+  ): (Generator[(String, UnopenedInputStream)], ResourceCloser) = {
     val shadeRules = assemblyRules.collect {
       case Rule.Relocate(from, to) => ShadePattern.Rename(List(from -> to)).inAll
     }
@@ -96,19 +99,23 @@ object Assembly {
           }
       }
 
-    Generator.from(inputPaths).filter(os.exists).flatMap { path =>
-      if (os.isFile(path)) {
-        val jarFile = new JarFile(path.toIO)
+     val pathsWithResources = inputPaths.filter(os.exists).map { path =>
+       if (os.isFile(path)) path -> Some(new JarFile(path.toIO))
+       else path -> None
+     }
+
+    val generators = Generator.from(pathsWithResources).flatMap {
+      case (path, Some(jarFile)) =>
         Generator.from(jarFile.entries().asScala.filterNot(_.isDirectory))
           .flatMap(entry => shader(entry.getName, () => jarFile.getInputStream(entry)))
-      }
-      else {
+      case (path, None) =>
         os.walk
           .stream(path)
           .filter(os.isFile)
           .flatMap(subPath => shader(subPath.relativeTo(path).toString, () => os.read.inputStream(subPath)))
-      }
     }
+
+    (generators, () => pathsWithResources.flatMap(_._2).iterator.foreach(_.close()))
   }
 
   type UnopenedInputStream = () => InputStream

--- a/main/src/modules/Assembly.scala
+++ b/main/src/modules/Assembly.scala
@@ -92,11 +92,15 @@ object Assembly {
       if (shadeRules.isEmpty) (name: String, inputStream: UnopenedInputStream) => Some(name -> inputStream)
       else {
         val shader = Shader.bytecodeShader(shadeRules, verbose = false)
-        (name: String, inputStream: UnopenedInputStream) =>
-          shader(Streamable.bytes(inputStream()), name).map {
+        (name: String, inputStream: UnopenedInputStream) => {
+          val is = inputStream()
+          shader(Streamable.bytes(is), name).map {
             case (bytes, name) =>
-              name -> (() => new ByteArrayInputStream(bytes) { override def close(): Unit = inputStream().close() })
+              name -> (() => new ByteArrayInputStream(bytes) {
+                override def close(): Unit = is.close()
+              })
           }
+        }
       }
 
      val pathsWithResources = inputPaths.filter(os.exists).map { path =>

--- a/scalalib/test/src/HelloWorldTests.scala
+++ b/scalalib/test/src/HelloWorldTests.scala
@@ -17,7 +17,7 @@ import utest.framework.TestPath
 
 object HelloWorldTests extends TestSuite {
   trait HelloBase extends TestUtil.BaseModule{
-    def millSourcePath = TestUtil.getSrcPathBase() / millOuterCtx.enclosing.split('.')
+    override def millSourcePath: os.Path = TestUtil.getSrcPathBase() / millOuterCtx.enclosing.split('.')
   }
 
   trait HelloWorldModule extends scalalib.ScalaModule {
@@ -25,7 +25,7 @@ object HelloWorldTests extends TestSuite {
   }
 
   trait HelloWorldModuleWithMain extends HelloWorldModule {
-    def mainClass = Some("Main")
+    override def mainClass: T[Option[String]] = Some("Main")
   }
 
   object HelloWorld extends HelloBase {
@@ -42,7 +42,7 @@ object HelloWorldTests extends TestSuite {
 
   object HelloWorldWithoutMain extends HelloBase {
     object core extends HelloWorldModule{
-      def mainClass = None
+      override def mainClass = None
     }
   }
 
@@ -54,136 +54,123 @@ object HelloWorldTests extends TestSuite {
 
   object HelloWorldAkkaHttpAppend extends HelloBase {
     object core extends HelloWorldModuleWithMain {
-      def ivyDeps = akkaHttpDeps
-
-      def assemblyRules = Seq(Assembly.Rule.Append("reference.conf"))
+      override def ivyDeps = akkaHttpDeps
+      override def assemblyRules = Seq(Assembly.Rule.Append("reference.conf"))
     }
   }
 
   object HelloWorldAkkaHttpExclude extends HelloBase {
     object core extends HelloWorldModuleWithMain {
-      def ivyDeps = akkaHttpDeps
-
-      def assemblyRules = Seq(Assembly.Rule.Exclude("reference.conf"))
+      override def ivyDeps = akkaHttpDeps
+      override def assemblyRules = Seq(Assembly.Rule.Exclude("reference.conf"))
     }
   }
 
   object HelloWorldAkkaHttpAppendPattern extends HelloBase {
     object core extends HelloWorldModuleWithMain {
-      def ivyDeps = akkaHttpDeps
-
-      def assemblyRules = Seq(Assembly.Rule.AppendPattern(".*.conf"))
+      override def ivyDeps = akkaHttpDeps
+      override def assemblyRules = Seq(Assembly.Rule.AppendPattern(".*.conf"))
     }
   }
 
   object HelloWorldAkkaHttpExcludePattern extends HelloBase {
     object core extends HelloWorldModuleWithMain {
-      def ivyDeps = akkaHttpDeps
-
-      def assemblyRules = Seq(Assembly.Rule.ExcludePattern(".*.conf"))
+      override def ivyDeps = akkaHttpDeps
+      override def assemblyRules = Seq(Assembly.Rule.ExcludePattern(".*.conf"))
     }
   }
 
   object HelloWorldAkkaHttpRelocate extends HelloBase {
     object core extends HelloWorldModuleWithMain {
-      def ivyDeps = akkaHttpDeps
-
-      def assemblyRules = Seq(Assembly.Rule.Relocate("akka.**", "shaded.akka.@1"))
+      override def ivyDeps = akkaHttpDeps
+      override def assemblyRules = Seq(Assembly.Rule.Relocate("akka.**", "shaded.akka.@1"))
     }
   }
 
   object HelloWorldAkkaHttpNoRules extends HelloBase {
     object core extends HelloWorldModuleWithMain {
-      def ivyDeps = akkaHttpDeps
-
-      def assemblyRules = Seq.empty
+      override def ivyDeps = akkaHttpDeps
+      override def assemblyRules = Seq.empty
     }
   }
 
   object HelloWorldMultiAppend extends HelloBase {
     object core extends HelloWorldModuleWithMain {
-      def moduleDeps = Seq(model)
-
-      def assemblyRules = Seq(Assembly.Rule.Append("reference.conf"))
+      override def moduleDeps = Seq(model)
+      override def assemblyRules = Seq(Assembly.Rule.Append("reference.conf"))
     }
     object model extends HelloWorldModule
   }
 
   object HelloWorldMultiExclude extends HelloBase {
     object core extends HelloWorldModuleWithMain {
-      def moduleDeps = Seq(model)
-
-      def assemblyRules = Seq(Assembly.Rule.Exclude("reference.conf"))
+      override def moduleDeps = Seq(model)
+      override def assemblyRules = Seq(Assembly.Rule.Exclude("reference.conf"))
     }
     object model extends HelloWorldModule
   }
 
   object HelloWorldMultiAppendPattern extends HelloBase {
     object core extends HelloWorldModuleWithMain {
-      def moduleDeps = Seq(model)
-
-      def assemblyRules = Seq(Assembly.Rule.AppendPattern(".*.conf"))
+      override def moduleDeps = Seq(model)
+      override def assemblyRules = Seq(Assembly.Rule.AppendPattern(".*.conf"))
     }
     object model extends HelloWorldModule
   }
 
   object HelloWorldMultiExcludePattern extends HelloBase {
     object core extends HelloWorldModuleWithMain {
-      def moduleDeps = Seq(model)
-
-      def assemblyRules = Seq(Assembly.Rule.ExcludePattern(".*.conf"))
+      override def moduleDeps = Seq(model)
+      override def assemblyRules = Seq(Assembly.Rule.ExcludePattern(".*.conf"))
     }
     object model extends HelloWorldModule
   }
 
   object HelloWorldMultiNoRules extends HelloBase {
     object core extends HelloWorldModuleWithMain {
-      def moduleDeps = Seq(model)
-
-      def assemblyRules = Seq.empty
+      override def moduleDeps = Seq(model)
+      override def assemblyRules = Seq.empty
     }
     object model extends HelloWorldModule
   }
 
   object HelloWorldWarnUnused extends HelloBase {
     object core extends HelloWorldModule {
-      def scalacOptions = T(Seq("-Ywarn-unused"))
+      override def scalacOptions = T(Seq("-Ywarn-unused"))
     }
   }
 
   object HelloWorldFatalWarnings extends HelloBase {
     object core extends HelloWorldModule {
-      def scalacOptions = T(Seq("-Ywarn-unused", "-Xfatal-warnings"))
+      override def scalacOptions = T(Seq("-Ywarn-unused", "-Xfatal-warnings"))
     }
   }
 
   object HelloWorldWithDocVersion extends HelloBase {
     object core extends HelloWorldModule {
-      def scalacOptions = T(Seq("-Ywarn-unused", "-Xfatal-warnings"))
-      def scalaDocOptions = super.scalaDocOptions() ++ Seq("-doc-version", "1.2.3")
+      override def scalacOptions = T(Seq("-Ywarn-unused", "-Xfatal-warnings"))
+      override def scalaDocOptions = super.scalaDocOptions() ++ Seq("-doc-version", "1.2.3")
     }
   }
 
   object HelloWorldOnlyDocVersion extends HelloBase {
     object core extends HelloWorldModule {
-      def scalacOptions = T(Seq("-Ywarn-unused", "-Xfatal-warnings"))
-      def scalaDocOptions = T(Seq("-doc-version", "1.2.3"))
+      override def scalacOptions = T(Seq("-Ywarn-unused", "-Xfatal-warnings"))
+      override def scalaDocOptions = T(Seq("-doc-version", "1.2.3"))
     }
   }
 
   object HelloWorldDocTitle extends HelloBase {
     object core extends HelloWorldModule {
-      def scalaDocOptions = T(Seq("-doc-title", "Hello World"))
+      override def scalaDocOptions = T(Seq("-doc-title", "Hello World"))
     }
   }
 
   object HelloWorldWithPublish extends HelloBase{
     object core extends HelloWorldModule with PublishModule{
-
-      def artifactName = "hello-world"
-      def publishVersion = "0.0.1"
-
-      def pomSettings = PomSettings(
+      override def artifactName = "hello-world"
+      override def publishVersion = "0.0.1"
+      override def pomSettings = PomSettings(
         organization = "com.lihaoyi",
         description = "hello world ready for real world publishing",
         url = "https://github.com/lihaoyi/hello-world-publish",
@@ -197,14 +184,12 @@ object HelloWorldTests extends TestSuite {
 
   object HelloWorldScalaOverride extends HelloBase{
     object core extends HelloWorldModule {
-
       override def scalaVersion: Target[String] = "2.13.1"
     }
   }
 
   object HelloWorldIvyDeps extends HelloBase{
     object moduleA extends HelloWorldModule {
-
       override def ivyDeps = Agg(ivy"com.lihaoyi::sourcecode:0.1.3")
     }
     object moduleB extends HelloWorldModule {
@@ -215,17 +200,17 @@ object HelloWorldTests extends TestSuite {
 
   object HelloWorldTypeLevel extends HelloBase{
     object foo extends ScalaModule {
-      def scalaVersion = "2.11.8"
+      override def scalaVersion = "2.11.8"
       override def scalaOrganization = "org.typelevel"
       override def ammoniteVersion = "1.6.7"
 
-      def ivyDeps = Agg(
+      override def ivyDeps = Agg(
         ivy"com.github.julien-truffaut::monocle-macro::1.4.0"
       )
-      def scalacPluginIvyDeps = super.scalacPluginIvyDeps() ++ Agg(
+      override def scalacPluginIvyDeps = super.scalacPluginIvyDeps() ++ Agg(
         ivy"org.scalamacros:::paradise:2.1.0"
       )
-      def scalaDocPluginIvyDeps = super.scalaDocPluginIvyDeps() ++ Agg(
+      override def scalaDocPluginIvyDeps = super.scalaDocPluginIvyDeps() ++ Agg(
         ivy"com.typesafe.genjavadoc:::genjavadoc-plugin:0.11"
       )
     }
@@ -235,10 +220,10 @@ object HelloWorldTests extends TestSuite {
     object core extends ScalaModule {
       def scalaVersion = "2.12.4"
 
-      def ivyDeps = Agg(
+      override def ivyDeps = Agg(
         ivy"com.github.julien-truffaut::monocle-macro::1.4.0"
       )
-      def scalacPluginIvyDeps = super.scalacPluginIvyDeps() ++ Agg(
+      override def scalacPluginIvyDeps = super.scalacPluginIvyDeps() ++ Agg(
         ivy"org.scalamacros:::paradise:2.1.0"
       )
     }
@@ -248,7 +233,7 @@ object HelloWorldTests extends TestSuite {
     object core extends ScalaModule {
       def scalaVersion = "2.12.4"
 
-      def scalacOptions = super.scalacOptions() ++ Seq(
+      override def scalacOptions = super.scalacOptions() ++ Seq(
         "-Ypartial-unification"
       )
     }
@@ -258,8 +243,8 @@ object HelloWorldTests extends TestSuite {
     object foo extends ScalaModule {
       def scalaVersion = "2.12.4"
       object test extends Tests {
-        def ivyDeps     = Agg(ivy"org.scalacheck::scalacheck:1.13.5")
-        def testFrameworks = Seq("org.scalacheck.ScalaCheckFramework")
+        override def ivyDeps     = Agg(ivy"org.scalacheck::scalacheck:1.13.5")
+        override def testFramework = "org.scalacheck.ScalaCheckFramework"
       }
     }
   }
@@ -267,11 +252,11 @@ object HelloWorldTests extends TestSuite {
   object Dotty213 extends HelloBase {
     object foo extends ScalaModule {
       def scalaVersion = "0.18.1-RC1"
-      def ivyDeps = Agg(ivy"org.scala-lang.modules::scala-xml:1.2.0".withDottyCompat(scalaVersion()))
+      override def ivyDeps = Agg(ivy"org.scala-lang.modules::scala-xml:1.2.0".withDottyCompat(scalaVersion()))
     }
   }
 
-  val resourcePath = os.pwd / 'scalalib / 'test / 'resources / "hello-world"
+  val resourcePath = os.pwd / "scalalib" / "test" / "resources" / "hello-world"
 
   def jarMainClass(jar: JarFile): Option[String] = {
     import java.util.jar.Attributes._
@@ -316,9 +301,9 @@ object HelloWorldTests extends TestSuite {
 
 
   def tests: Tests = Tests {
-    'scalaVersion - {
+    "scalaVersion" - {
 
-      'fromBuild - workspaceTest(HelloWorld){eval =>
+      "fromBuild" - workspaceTest(HelloWorld){eval =>
         val Right((result, evalCount)) = eval.apply(HelloWorld.core.scalaVersion)
 
         assert(
@@ -326,7 +311,7 @@ object HelloWorldTests extends TestSuite {
           evalCount > 0
         )
       }
-      'override - workspaceTest(HelloWorldScalaOverride){eval =>
+      "override" - workspaceTest(HelloWorldScalaOverride){eval =>
         val Right((result, evalCount)) = eval.apply(HelloWorldScalaOverride.core.scalaVersion)
 
         assert(
@@ -336,8 +321,8 @@ object HelloWorldTests extends TestSuite {
       }
     }
 
-    'scalacOptions - {
-      'emptyByDefault - workspaceTest(HelloWorld){eval =>
+    "scalacOptions" - {
+      "emptyByDefault" - workspaceTest(HelloWorld){eval =>
         val Right((result, evalCount)) = eval.apply(HelloWorld.core.scalacOptions)
 
         assert(
@@ -345,7 +330,7 @@ object HelloWorldTests extends TestSuite {
           evalCount > 0
         )
       }
-      'override - workspaceTest(HelloWorldFatalWarnings){ eval =>
+      "override" - workspaceTest(HelloWorldFatalWarnings){ eval =>
         val Right((result, evalCount)) = eval.apply(HelloWorldFatalWarnings.core.scalacOptions)
 
         assert(
@@ -355,22 +340,22 @@ object HelloWorldTests extends TestSuite {
       }
     }
 
-    'scalaDocOptions - {
-      'emptyByDefault - workspaceTest(HelloWorld){eval =>
+    "scalaDocOptions" - {
+      "emptyByDefault" - workspaceTest(HelloWorld){eval =>
         val Right((result, evalCount)) = eval.apply(HelloWorld.core.scalaDocOptions)
         assert(
           result.isEmpty,
           evalCount > 0
         )
       }
-      'override - workspaceTest(HelloWorldDocTitle){ eval =>
+      "override" - workspaceTest(HelloWorldDocTitle){ eval =>
         val Right((result, evalCount)) = eval.apply(HelloWorldDocTitle.core.scalaDocOptions)
         assert(
           result == Seq("-doc-title", "Hello World"),
           evalCount > 0
         )
       }
-      'extend - workspaceTest(HelloWorldWithDocVersion){ eval =>
+      "extend" - workspaceTest(HelloWorldWithDocVersion){ eval =>
         val Right((result, evalCount)) = eval.apply(HelloWorldWithDocVersion.core.scalaDocOptions)
         assert(
           result == Seq("-Ywarn-unused", "-Xfatal-warnings", "-doc-version", "1.2.3"),
@@ -378,34 +363,34 @@ object HelloWorldTests extends TestSuite {
         )
       }
       // make sure options are passed during ScalaDoc generation
-      'docJarWithTitle - workspaceTest(
+      "docJarWithTitle" - workspaceTest(
         HelloWorldDocTitle,
-        resourcePath = os.pwd / 'scalalib / 'test / 'resources / "hello-world"
+        resourcePath = os.pwd / "scalalib" / "test" / "resources" / "hello-world"
       ){ eval =>
         val Right((_, evalCount)) = eval.apply(HelloWorldDocTitle.core.docJar)
         assert(
           evalCount > 0,
-          os.read(eval.outPath / 'core / 'docJar / 'dest / 'javadoc / "index.html").contains("<span id=\"doc-title\">Hello World")
+          os.read(eval.outPath / "core" / "docJar" / "dest" / "javadoc" / "index.html").contains("<span id=\"doc-title\">Hello World")
         )
       }
-      'docJarWithVersion - workspaceTest(
+      "docJarWithVersion" - workspaceTest(
         HelloWorldWithDocVersion,
-        resourcePath = os.pwd / 'scalalib / 'test / 'resources / "hello-world"
+        resourcePath = os.pwd / "scalalib" / "test" / "resources" / "hello-world"
       ){ eval =>
         // scaladoc generation fails because of "-Xfatal-warnings" flag
         val Left(Result.Failure(_, None)) = eval.apply(HelloWorldWithDocVersion.core.docJar)
       }
-      'docJarOnlyVersion - workspaceTest(
+      "docJarOnlyVersion" - workspaceTest(
         HelloWorldOnlyDocVersion,
-        resourcePath = os.pwd / 'scalalib / 'test / 'resources / "hello-world"
+        resourcePath = os.pwd / "scalalib" / "test" / "resources" / "hello-world"
       ){ eval =>
         // `docJar` requires the `compile` task to succeed (since the addition of Scaladoc 3)
         val Left(Result.Failure(_, None)) = eval.apply(HelloWorldOnlyDocVersion.core.docJar)
       }
     }
 
-    'scalacPluginClasspath - {
-      'withMacroParadise - workspaceTest(HelloWorldTypeLevel){eval =>
+    "scalacPluginClasspath" - {
+      "withMacroParadise" - workspaceTest(HelloWorldTypeLevel){eval =>
         val Right((result, evalCount)) = eval.apply(HelloWorldTypeLevel.foo.scalacPluginClasspath)
         assert(
           result.nonEmpty,
@@ -415,8 +400,8 @@ object HelloWorldTests extends TestSuite {
       }
     }
 
-    'scalaDocPluginClasspath - {
-      'extend - workspaceTest(HelloWorldTypeLevel){eval =>
+    "scalaDocPluginClasspath" - {
+      "extend" - workspaceTest(HelloWorldTypeLevel){eval =>
         val Right((result, evalCount)) = eval.apply(HelloWorldTypeLevel.foo.scalaDocPluginClasspath)
         assert(
           result.iterator.nonEmpty,
@@ -427,17 +412,17 @@ object HelloWorldTests extends TestSuite {
       }
     }
 
-    'compile - {
-      'fromScratch - workspaceTest(HelloWorld){eval =>
+    "compile" - {
+      "fromScratch" - workspaceTest(HelloWorld){eval =>
         val Right((result, evalCount)) = eval.apply(HelloWorld.core.compile)
 
         val analysisFile = result.analysisFile
         val outputFiles = os.walk(result.classes.path)
         val expectedClassfiles = compileClassfiles.map(
-          eval.outPath / 'core / 'compile / 'dest / 'classes / _
+          eval.outPath / "core" / "compile" / "dest" / "classes" / _
         )
         assert(
-          result.classes.path == eval.outPath / 'core / 'compile / 'dest / 'classes,
+          result.classes.path == eval.outPath / "core" / "compile" / "dest" / "classes",
           os.exists(analysisFile),
           outputFiles.nonEmpty,
           outputFiles.forall(expectedClassfiles.contains),
@@ -449,17 +434,17 @@ object HelloWorldTests extends TestSuite {
 
         assert(unchangedEvalCount == 0)
       }
-      'recompileOnChange - workspaceTest(HelloWorld){eval =>
+      "recompileOnChange" - workspaceTest(HelloWorld){eval =>
         val Right((_, freshCount)) = eval.apply(HelloWorld.core.compile)
         assert(freshCount > 0)
 
-        os.write.append(HelloWorld.millSourcePath / 'core / 'src / "Main.scala", "\n")
+        os.write.append(HelloWorld.millSourcePath / "core" / "src" / "Main.scala", "\n")
 
         val Right((_, incCompileCount)) = eval.apply(HelloWorld.core.compile)
         assert(incCompileCount > 0, incCompileCount < freshCount)
       }
-      'failOnError - workspaceTest(HelloWorld){eval =>
-        os.write.append(HelloWorld.millSourcePath / 'core / 'src / "Main.scala", "val x: ")
+      "failOnError" - workspaceTest(HelloWorld){eval =>
+        os.write.append(HelloWorld.millSourcePath / "core" / "src" / "Main.scala", "val x: ")
 
         val Left(Result.Failure("Compilation failed", _)) = eval.apply(HelloWorld.core.compile)
 
@@ -470,33 +455,33 @@ object HelloWorldTests extends TestSuite {
         )
 
         assert(
-          os.walk(paths.dest / 'classes).isEmpty,
+          os.walk(paths.dest / "classes").isEmpty,
           !os.exists(paths.meta)
         )
         // Works when fixed
         os.write.over(
-          HelloWorld.millSourcePath / 'core / 'src / "Main.scala",
-          os.read(HelloWorld.millSourcePath / 'core / 'src / "Main.scala").dropRight("val x: ".length)
+          HelloWorld.millSourcePath / "core" / "src" / "Main.scala",
+          os.read(HelloWorld.millSourcePath / "core" / "src" / "Main.scala").dropRight("val x: ".length)
         )
 
         val Right((result, evalCount)) = eval.apply(HelloWorld.core.compile)
       }
-      'passScalacOptions - workspaceTest(HelloWorldFatalWarnings){ eval =>
+      "passScalacOptions" - workspaceTest(HelloWorldFatalWarnings){ eval =>
         // compilation fails because of "-Xfatal-warnings" flag
         val Left(Result.Failure("Compilation failed", _)) = eval.apply(HelloWorldFatalWarnings.core.compile)
       }
     }
 
-    'artifactNameCross - {
+    "artifactNameCross" - {
       workspaceTest(CrossHelloWorld) { eval =>
         val Right((artifactName, _)) = eval.apply(CrossHelloWorld.core("2.13.1").artifactName)
         assert(artifactName == "core")
       }
     }
 
-    'runMain - {
-      'runMainObject - workspaceTest(HelloWorld){eval =>
-        val runResult = eval.outPath / 'core / 'runMain / 'dest / "hello-mill"
+    "runMain" - {
+      "runMainObject" - workspaceTest(HelloWorld){eval =>
+        val runResult = eval.outPath / "core" / "runMain" / "dest" / "hello-mill"
 
         val Right((_, evalCount)) = eval.apply(HelloWorld.core.runMain("Main", runResult.toString))
         assert(evalCount > 0)
@@ -506,7 +491,7 @@ object HelloWorldTests extends TestSuite {
           os.read(runResult) == "hello rockjam, your age is: 25"
         )
       }
-      'runCross - {
+      "runCross" - {
         def cross(eval: TestEvaluator, v: String, expectedOut: String): Unit = {
 
           val runResult = eval.outPath / "hello-mill"
@@ -523,28 +508,28 @@ object HelloWorldTests extends TestSuite {
             os.read(runResult) == expectedOut
           )
         }
-        'v210 - TestUtil.disableInJava9OrAbove(workspaceTest(CrossHelloWorld)(cross(_, "2.10.6", "2.10.6 rox")))
-        'v211 - TestUtil.disableInJava9OrAbove(workspaceTest(CrossHelloWorld)(cross(_, "2.11.11", "2.11.11 pwns")))
-        'v2123 - workspaceTest(CrossHelloWorld)(cross(_, "2.12.3", "2.12.3 leet"))
-        'v2124 - workspaceTest(CrossHelloWorld)(cross(_, "2.12.4", "2.12.4 leet"))
-        'v2131 - workspaceTest(CrossHelloWorld)(cross(_, "2.13.1", "2.13.1 idk"))
+        "v210" - TestUtil.disableInJava9OrAbove(workspaceTest(CrossHelloWorld)(cross(_, "2.10.6", "2.10.6 rox")))
+        "v211" - TestUtil.disableInJava9OrAbove(workspaceTest(CrossHelloWorld)(cross(_, "2.11.11", "2.11.11 pwns")))
+        "v2123" - workspaceTest(CrossHelloWorld)(cross(_, "2.12.3", "2.12.3 leet"))
+        "v2124" - workspaceTest(CrossHelloWorld)(cross(_, "2.12.4", "2.12.4 leet"))
+        "v2131" - workspaceTest(CrossHelloWorld)(cross(_, "2.13.1", "2.13.1 idk"))
       }
 
 
-      'notRunInvalidMainObject - workspaceTest(HelloWorld){eval =>
+      "notRunInvalidMainObject" - workspaceTest(HelloWorld){eval =>
         val Left(Result.Failure("subprocess failed", _)) = eval.apply(HelloWorld.core.runMain("Invalid"))
       }
-      'notRunWhenCompileFailed - workspaceTest(HelloWorld){eval =>
-        os.write.append(HelloWorld.millSourcePath / 'core / 'src / "Main.scala", "val x: ")
+      "notRunWhenCompileFailed" - workspaceTest(HelloWorld){eval =>
+        os.write.append(HelloWorld.millSourcePath / "core" / "src" / "Main.scala", "val x: ")
 
         val Left(Result.Failure("Compilation failed", _)) = eval.apply(HelloWorld.core.runMain("Main"))
 
       }
     }
 
-    'forkRun - {
-      'runIfMainClassProvided - workspaceTest(HelloWorldWithMain){eval =>
-        val runResult = eval.outPath / 'core / 'run / 'dest / "hello-mill"
+    "forkRun" - {
+      "runIfMainClassProvided" - workspaceTest(HelloWorldWithMain){eval =>
+        val runResult = eval.outPath / "core" / "run" / "dest" / "hello-mill"
         val Right((_, evalCount)) = eval.apply(
           HelloWorldWithMain.core.run(runResult.toString)
         )
@@ -557,17 +542,17 @@ object HelloWorldTests extends TestSuite {
           os.read(runResult) == "hello rockjam, your age is: 25"
         )
       }
-      'notRunWithoutMainClass - workspaceTest(
+      "notRunWithoutMainClass" - workspaceTest(
         HelloWorldWithoutMain,
-        os.pwd / 'scalalib / 'test / 'resources / "hello-world-no-main"
+        os.pwd / "scalalib" / "test" / "resources" / "hello-world-no-main"
       ){eval =>
         val Left(Result.Failure(_, None)) = eval.apply(HelloWorldWithoutMain.core.run())
       }
 
-      'runDiscoverMainClass - workspaceTest(HelloWorldWithoutMain){eval =>
+      "runDiscoverMainClass" - workspaceTest(HelloWorldWithoutMain){eval =>
         // Make sure even if there isn't a main class defined explicitly, it gets
         // discovered by Zinc and used
-        val runResult = eval.outPath / 'core / 'run / 'dest / "hello-mill"
+        val runResult = eval.outPath / "core" / "run" / "dest" / "hello-mill"
         val Right((_, evalCount)) = eval.apply(
           HelloWorldWithoutMain.core.run(runResult.toString)
         )
@@ -582,9 +567,9 @@ object HelloWorldTests extends TestSuite {
       }
     }
 
-    'run - {
-      'runIfMainClassProvided - workspaceTest(HelloWorldWithMain){eval =>
-        val runResult = eval.outPath / 'core / 'run / 'dest / "hello-mill"
+    "run" - {
+      "runIfMainClassProvided" - workspaceTest(HelloWorldWithMain){eval =>
+        val runResult = eval.outPath / "core" / "run" / "dest" / "hello-mill"
         val Right((_, evalCount)) = eval.apply(
           HelloWorldWithMain.core.runLocal(runResult.toString)
         )
@@ -597,8 +582,8 @@ object HelloWorldTests extends TestSuite {
           os.read(runResult) == "hello rockjam, your age is: 25"
         )
       }
-      'runWithDefaultMain - workspaceTest(HelloWorldDefaultMain){eval =>
-        val runResult = eval.outPath / 'core / 'run / 'dest / "hello-mill"
+      "runWithDefaultMain" - workspaceTest(HelloWorldDefaultMain){eval =>
+        val runResult = eval.outPath / "core" / "run" / "dest" / "hello-mill"
         val Right((_, evalCount)) = eval.apply(
           HelloWorldDefaultMain.core.runLocal(runResult.toString)
         )
@@ -611,17 +596,17 @@ object HelloWorldTests extends TestSuite {
           os.read(runResult) == "hello rockjam, your age is: 25"
         )
       }
-      'notRunWithoutMainClass - workspaceTest(
+      "notRunWithoutMainClass" - workspaceTest(
         HelloWorldWithoutMain,
-        os.pwd / 'scalalib / 'test / 'resources / "hello-world-no-main"
+        os.pwd / "scalalib" / "test" / "resources" / "hello-world-no-main"
       ){eval =>
         val Left(Result.Failure(_, None)) = eval.apply(HelloWorldWithoutMain.core.runLocal())
 
       }
     }
 
-    'jar - {
-      'nonEmpty - workspaceTest(HelloWorldWithMain){eval =>
+    "jar" - {
+      "nonEmpty" - workspaceTest(HelloWorldWithMain){eval =>
         val Right((result, evalCount)) = eval.apply(HelloWorldWithMain.core.jar)
 
         assert(
@@ -648,17 +633,17 @@ object HelloWorldTests extends TestSuite {
         }
       }
 
-      'logOutputToFile - workspaceTest(HelloWorld){eval =>
+      "logOutputToFile" - workspaceTest(HelloWorld){eval =>
         val outPath = eval.outPath
         eval.apply(HelloWorld.core.compile)
 
-        val logFile = outPath / 'core / 'compile / 'log
+        val logFile = outPath / "core" / "compile" / "log"
         assert(os.exists(logFile))
       }
     }
 
-    'assembly - {
-      'assembly - workspaceTest(HelloWorldWithMain){ eval =>
+    "assembly" - {
+      "assembly" - workspaceTest(HelloWorldWithMain){ eval =>
         val Right((result, evalCount)) = eval.apply(HelloWorldWithMain.core.assembly)
         assert(
           os.exists(result.path),
@@ -675,7 +660,7 @@ object HelloWorldTests extends TestSuite {
         assert(mainClass.contains("Main"))
       }
 
-      'assemblyRules - {
+      "assemblyRules" - {
         def checkAppend[M <: TestUtil.BaseModule](module: M,
                                                   target: Target[PathRef]) =
           workspaceTest(module) { eval =>
@@ -699,7 +684,7 @@ object HelloWorldTests extends TestSuite {
             }
           }
 
-        val helloWorldMultiResourcePath = os.pwd / 'scalalib / 'test / 'resources / "hello-world-multi"
+        val helloWorldMultiResourcePath = os.pwd / "scalalib" / "test" / "resources" / "hello-world-multi"
 
         def checkAppendMulti[M <: TestUtil.BaseModule](
             module: M,
@@ -728,19 +713,19 @@ object HelloWorldTests extends TestSuite {
             }
           }
 
-        'appendWithDeps - checkAppend(
+        "appendWithDeps" - checkAppend(
           HelloWorldAkkaHttpAppend,
           HelloWorldAkkaHttpAppend.core.assembly
         )
-        'appendMultiModule - checkAppendMulti(
+        "appendMultiModule" - checkAppendMulti(
           HelloWorldMultiAppend,
           HelloWorldMultiAppend.core.assembly
         )
-        'appendPatternWithDeps - checkAppend(
+        "appendPatternWithDeps" - checkAppend(
           HelloWorldAkkaHttpAppendPattern,
           HelloWorldAkkaHttpAppendPattern.core.assembly
         )
-        'appendPatternMultiModule - checkAppendMulti(
+        "appendPatternMultiModule" - checkAppendMulti(
           HelloWorldMultiAppendPattern,
           HelloWorldMultiAppendPattern.core.assembly
         )
@@ -757,21 +742,21 @@ object HelloWorldTests extends TestSuite {
             }
           }
 
-        'excludeWithDeps - checkExclude(
+        "excludeWithDeps" - checkExclude(
           HelloWorldAkkaHttpExclude,
           HelloWorldAkkaHttpExclude.core.assembly
         )
-        'excludeMultiModule - checkExclude(
+        "excludeMultiModule" - checkExclude(
           HelloWorldMultiExclude,
           HelloWorldMultiExclude.core.assembly,
           resourcePath = helloWorldMultiResourcePath
 
         )
-        'excludePatternWithDeps - checkExclude(
+        "excludePatternWithDeps" - checkExclude(
           HelloWorldAkkaHttpExcludePattern,
           HelloWorldAkkaHttpExcludePattern.core.assembly
         )
-        'excludePatternMultiModule - checkExclude(
+        "excludePatternMultiModule" - checkExclude(
           HelloWorldMultiExcludePattern,
           HelloWorldMultiExcludePattern.core.assembly,
           resourcePath = helloWorldMultiResourcePath
@@ -789,23 +774,23 @@ object HelloWorldTests extends TestSuite {
             }
           }
 
-        'relocate - {
-          'withDeps - checkRelocate(
+        "relocate" - {
+          "withDeps" - checkRelocate(
             HelloWorldAkkaHttpRelocate,
             HelloWorldAkkaHttpRelocate.core.assembly
           )
 
-          'run - workspaceTest(
+          "run" - workspaceTest(
             HelloWorldAkkaHttpRelocate,
-            resourcePath = os.pwd / 'scalalib / 'test / 'resources / "hello-world-deps"
+            resourcePath = os.pwd / "scalalib" / "test" / "resources" / "hello-world-deps"
           ) { eval =>
             val Right((_, evalCount)) = eval.apply(HelloWorldAkkaHttpRelocate.core.runMain("Main"))
             assert(evalCount > 0)
           }
         }
 
-        'writeDownstreamWhenNoRule - {
-          'withDeps - workspaceTest(HelloWorldAkkaHttpNoRules) { eval =>
+        "writeDownstreamWhenNoRule" - {
+          "withDeps" - workspaceTest(HelloWorldAkkaHttpNoRules) { eval =>
             val Right((result, _)) = eval.apply(HelloWorldAkkaHttpNoRules.core.assembly)
 
             Using.resource(new JarFile(result.path.toIO)) { jarFile =>
@@ -827,7 +812,7 @@ object HelloWorldTests extends TestSuite {
             }
           }
 
-          'multiModule - workspaceTest(
+          "multiModule" - workspaceTest(
             HelloWorldMultiNoRules,
             resourcePath = helloWorldMultiResourcePath
           ) { eval =>
@@ -850,7 +835,7 @@ object HelloWorldTests extends TestSuite {
         }
       }
 
-      'run - workspaceTest(HelloWorldWithMain){eval =>
+      "run" - workspaceTest(HelloWorldWithMain){eval =>
         val Right((result, evalCount)) = eval.apply(HelloWorldWithMain.core.assembly)
 
         assert(
@@ -868,7 +853,7 @@ object HelloWorldTests extends TestSuite {
       }
     }
 
-    'ivyDeps - workspaceTest(HelloWorldIvyDeps){ eval =>
+    "ivyDeps" - workspaceTest(HelloWorldIvyDeps){ eval =>
       val Right((result, _)) = eval.apply(HelloWorldIvyDeps.moduleA.runClasspath)
       assert(
         result.exists(_.path.last == "sourcecode_2.12-0.1.3.jar"),
@@ -882,7 +867,7 @@ object HelloWorldTests extends TestSuite {
       )
     }
 
-    'typeLevel - workspaceTest(HelloWorldTypeLevel){ eval =>
+    "typeLevel" - workspaceTest(HelloWorldTypeLevel){ eval =>
       val classPathsToCheck = Seq(
         HelloWorldTypeLevel.foo.runClasspath,
         HelloWorldTypeLevel.foo.ammoniteReplClasspath,
@@ -902,47 +887,47 @@ object HelloWorldTests extends TestSuite {
       }
     }
 
-    'macros - {
+    "macros" - {
       // make sure macros are applied when compiling/running
-      'runMain - workspaceTest(
+      "runMain" - workspaceTest(
         HelloWorldMacros,
-        resourcePath = os.pwd / 'scalalib / 'test / 'resources / "hello-world-macros"
+        resourcePath = os.pwd / "scalalib" / "test" / "resources" / "hello-world-macros"
       ){ eval =>
         val Right((_, evalCount)) = eval.apply(HelloWorldMacros.core.runMain("Main"))
         assert(evalCount > 0)
       }
       // make sure macros are applied when compiling during scaladoc generation
-      'docJar - workspaceTest(
+      "docJar" - workspaceTest(
         HelloWorldMacros,
-        resourcePath = os.pwd / 'scalalib / 'test / 'resources / "hello-world-macros"
+        resourcePath = os.pwd / "scalalib" / "test" / "resources" / "hello-world-macros"
       ){ eval =>
         val Right((_, evalCount)) = eval.apply(HelloWorldMacros.core.docJar)
         assert(evalCount > 0)
       }
     }
 
-    'flags - {
+    "flags" - {
       // make sure flags are passed when compiling/running
-      'runMain - workspaceTest(
+      "runMain" - workspaceTest(
         HelloWorldFlags,
-        resourcePath = os.pwd / 'scalalib / 'test / 'resources / "hello-world-flags"
+        resourcePath = os.pwd / "scalalib" / "test" / "resources" / "hello-world-flags"
       ){ eval =>
         val Right((_, evalCount)) = eval.apply(HelloWorldFlags.core.runMain("Main"))
         assert(evalCount > 0)
       }
       // make sure flags are passed during ScalaDoc generation
-      'docJar - workspaceTest(
+      "docJar" - workspaceTest(
         HelloWorldFlags,
-        resourcePath = os.pwd / 'scalalib / 'test / 'resources / "hello-world-flags"
+        resourcePath = os.pwd / "scalalib" / "test" / "resources" / "hello-world-flags"
       ){ eval =>
         val Right((_, evalCount)) = eval.apply(HelloWorldFlags.core.docJar)
         assert(evalCount > 0)
       }
     }
 
-    'scalacheck - workspaceTest(
+    "scalacheck" - workspaceTest(
       HelloScalacheck,
-      resourcePath = os.pwd / 'scalalib / 'test / 'resources / "hello-scalacheck"
+      resourcePath = os.pwd / "scalalib" / "test" / "resources" / "hello-scalacheck"
     ){ eval =>
       val Right((res, evalCount)) = eval.apply(HelloScalacheck.foo.test.test())
       assert(
@@ -956,9 +941,9 @@ object HelloWorldTests extends TestSuite {
       )
     }
 
-    'dotty213 - workspaceTest(
+    "dotty213" - workspaceTest(
       Dotty213,
-      resourcePath = os.pwd / 'scalalib / 'test / 'resources / "dotty213"
+      resourcePath = os.pwd / "scalalib" / "test" / "resources" / "dotty213"
     ){ eval =>
       val Right((_, evalCount)) = eval.apply(Dotty213.foo.run())
       assert(evalCount > 0)


### PR DESCRIPTION
All scalalib tests now pass on Windows, so I moved them back into the mandatory test set of GitHub Actions CI.

Fix #1158 