### PR TITLE
TestModule: add testOnly to select test suites in mill

### DIFF
--- a/scalajslib/src/ScalaJSModule.scala
+++ b/scalajslib/src/ScalaJSModule.scala
@@ -214,7 +214,9 @@ trait TestScalaJSModule extends ScalaJSModule with TestModule {
 
   override def testLocal(args: String*) = T.command { test(args:_*) }
 
-  override protected def testTask(args: Task[Seq[String]]): Task[(String, Seq[TestRunner.Result])] = T.task {
+  override protected def testTask(args: Task[Seq[String]],
+      globSeletors: Task[Seq[String]]): Task[(String, Seq[TestRunner.Result])] = T.task {
+
     val (close, framework) = mill.scalajslib.ScalaJSWorkerApi.scalaJSWorker().getFramework(
       toolsClasspath().map(_.path),
       jsEnvConfig(),
@@ -228,7 +230,8 @@ trait TestScalaJSModule extends ScalaJSModule with TestModule {
       runClasspath().map(_.path),
       Agg(compile().classes.path),
       args(),
-      T.testReporter
+      T.testReporter,
+      TestRunner.globFilter(globSeletors())
     )
     val res = TestModule.handleResults(doneMsg, results)
     // Hack to try and let the Node.js subprocess finish streaming it's stdout

--- a/scalalib/src/TestModule.scala
+++ b/scalalib/src/TestModule.scala
@@ -56,13 +56,40 @@ trait TestModule extends JavaModule with TaskModule {
     testTask(testCachedArgs)()
   }
 
+  /**
+   * Discovers and runs the module's tests in a subprocess, reporting the
+   * results to the console.
+   * Arguments before "--" will be used as wildcard selector to select
+   * test classes, arguments after "--" will be passed as regular arguments.
+   * `testOnly *foo foobar bar* -- arguments` will test only classes with name
+   * (includes package name) 1. end with "foo", 2. exactly "foobar", 3. start
+   * with "bar", with "arguments" as arguments passing to test framework.
+   */
+  def testOnly(args: String*): Command[(String, Seq[TestRunner.Result])] = {
+    val splitAt = args.indexOf("--")
+    val (selector, testArgs) =
+      if(splitAt == -1) (args, Seq.empty)
+      else {
+        val (s, t) = args.splitAt(splitAt)
+        (s, t.tail)
+      }
+    T.command {
+      testTask(T.task { testArgs }, T.task { selector } )()
+    }
+  }
+
   /** Controls whether the TestRunner should receive it's arguments via an args-file instead of a as long parameter list.
    * Defaults to `true` on Windows, as Windows has a rather short parameter length limit.
    * */
   def testUseArgsFile: T[Boolean] = T { runUseArgsFile() || scala.util.Properties.isWin }
 
   protected def testTask(
-      args: Task[Seq[String]]): Task[(String, Seq[TestRunner.Result])] =
+    args: Task[Seq[String]]): Task[(String, Seq[TestRunner.Result])] =
+    testTask(args, T.task{Seq.empty[String]})
+
+  protected def testTask(
+      args: Task[Seq[String]],
+      globSelectors: Task[Seq[String]]): Task[(String, Seq[TestRunner.Result])] =
     T.task {
       val outputPath = T.dest / "out.json"
       val useArgsFile = testUseArgsFile()
@@ -91,7 +118,8 @@ trait TestModule extends JavaModule with TaskModule {
         outputPath = outputPath.toString(),
         colored = T.log.colored,
         testCp = compile().classes.path.toString(),
-        homeStr = T.home.toString()
+        homeStr = T.home.toString(),
+        globSelectors = globSelectors()
       )
 
       val mainArgs = if (useArgsFile) {

--- a/scalalib/src/TestModule.scala
+++ b/scalalib/src/TestModule.scala
@@ -83,6 +83,7 @@ trait TestModule extends JavaModule with TaskModule {
    * */
   def testUseArgsFile: T[Boolean] = T { runUseArgsFile() || scala.util.Properties.isWin }
 
+  @deprecated("Use testTask(args, T.task{Seq.empty[String]}) instead.", "mill after 0.9.7")
   protected def testTask(
     args: Task[Seq[String]]): Task[(String, Seq[TestRunner.Result])] =
     testTask(args, T.task{Seq.empty[String]})

--- a/scalalib/test/resources/testrunner/test/src/BarTests.scala
+++ b/scalalib/test/resources/testrunner/test/src/BarTests.scala
@@ -1,0 +1,11 @@
+package mill.scalalib
+
+import utest._
+
+object BarTests extends TestSuite {
+  val tests = Tests{
+    test("test"){
+      true
+    }
+  }
+}

--- a/scalalib/test/resources/testrunner/test/src/FooTests.scala
+++ b/scalalib/test/resources/testrunner/test/src/FooTests.scala
@@ -1,0 +1,11 @@
+package mill.scalalib
+
+import utest._
+
+object FooTests extends TestSuite {
+  val tests = Tests{
+    test("test"){
+      true
+    }
+  }
+}

--- a/scalalib/test/resources/testrunner/test/src/FoobarTests.scala
+++ b/scalalib/test/resources/testrunner/test/src/FoobarTests.scala
@@ -1,0 +1,11 @@
+package mill.scalalib
+
+import utest._
+
+object FoobarTests extends TestSuite {
+  val tests = Tests{
+    test("test"){
+      true
+    }
+  }
+}

--- a/scalalib/test/src/TestRunnerTests.scala
+++ b/scalalib/test/src/TestRunnerTests.scala
@@ -40,31 +40,6 @@ object TestRunnerTests extends TestSuite {
   override def tests: Tests = Tests {
     'TestArgs - {
       test("args serialization") {
-        forAll {
-          (
-            frameworks: Seq[String],
-            classpath: Seq[String],
-            arguments: Seq[String],
-            sysProps: Map[String, String],
-            outputPath: String,
-            colored: Boolean,
-            testCp: String,
-            homeStr: String
-          ) =>
-            val testArgs = TestArgs(
-              frameworks,
-              classpath,
-              arguments,
-              sysProps,
-              outputPath,
-              colored,
-              testCp,
-              homeStr
-            )
-            TestArgs.parseArgs(testArgs.toArgsSeq.toArray) == Success(testArgs)
-        }.check
-      }
-      test("args serialization 2") {
         forAll { (globSelectors: Seq[String]) =>
           forAll {
             (

--- a/scalalib/test/src/TestRunnerTests.scala
+++ b/scalalib/test/src/TestRunnerTests.scala
@@ -38,7 +38,7 @@ object TestRunnerTests extends TestSuite {
   }
 
   override def tests: Tests = Tests {
-    'TestArgs - {
+    "TestArgs" - {
       test("args serialization") {
         forAll { (globSelectors: Seq[String]) =>
           forAll {
@@ -68,7 +68,7 @@ object TestRunnerTests extends TestSuite {
         }.check
       }
     }
-    'TestRunner - {
+    "TestRunner" - {
       "test case lookup" - workspaceTest(testrunner) { eval =>
         val Right((result, _)) = eval.apply(testrunner.test.test())
         val test = result.asInstanceOf[(String, Seq[mill.scalalib.TestRunner.Result])]
@@ -76,7 +76,7 @@ object TestRunnerTests extends TestSuite {
           test._2.size == 3
         )
       }
-      'testOnly - {
+      "testOnly" - {
         def testOnly(eval: TestEvaluator, args: Seq[String], size: Int) = {
           val Right((result1, _)) = eval.apply(testrunner.test.testOnly(args:_*))
           val testOnly = result1.asInstanceOf[(String, Seq[mill.scalalib.TestRunner.Result])]
@@ -84,16 +84,16 @@ object TestRunnerTests extends TestSuite {
             testOnly._2.size == size
           )
         }
-        'suffix - workspaceTest(testrunner) { eval =>
+        "suffix" - workspaceTest(testrunner) { eval =>
           testOnly(eval, Seq("*arTests"), 2)
         }
-        'prefix - workspaceTest(testrunner) { eval =>
+        "prefix" - workspaceTest(testrunner) { eval =>
           testOnly(eval, Seq("mill.scalalib.FooT*"), 1)
         }
-        'exactly - workspaceTest(testrunner) { eval =>
+        "exactly" - workspaceTest(testrunner) { eval =>
           testOnly(eval, Seq("mill.scalalib.FooTests"), 1)
         }
-        'multi - workspaceTest(testrunner) { eval =>
+        "multi" - workspaceTest(testrunner) { eval =>
           testOnly(eval, Seq("*Bar*", "*bar*"), 2)
         }
       }

--- a/scalalib/test/src/TestRunnerTests.scala
+++ b/scalalib/test/src/TestRunnerTests.scala
@@ -1,16 +1,47 @@
 package mill.scalalib
 
-import scala.util.Success
+import mill.{Agg, T}
 
+import scala.util.Success
 import mill.scalalib.TestRunner.TestArgs
+import mill.util.{TestEvaluator, TestUtil}
 import org.scalacheck.Prop.forAll
 import utest._
+import utest.framework.TestPath
 
 object TestRunnerTests extends TestSuite {
+  object testrunner extends TestUtil.BaseModule with ScalaModule{
+    override def millSourcePath =  TestUtil.getSrcPathBase() / millOuterCtx.enclosing.split('.')
+
+    def scalaVersion = "2.12.4"
+
+    object test extends super.Tests with TestModule.Utest {
+
+      override def ivyDeps = T{
+        super.ivyDeps() ++ Agg(ivy"com.lihaoyi::utest:0.7.10")
+      }
+    }
+  }
+
+  val resourcePath = os.pwd / 'scalalib / 'test / 'resources / 'testrunner
+
+  def workspaceTest[T](
+      m: TestUtil.BaseModule,
+      resourcePath: os.Path = resourcePath)(t: TestEvaluator => T)(
+      implicit tp: TestPath): T = {
+    val eval = new TestEvaluator(m)
+    os.remove.all(m.millSourcePath)
+    os.remove.all(eval.outPath)
+    os.makeDir.all(m.millSourcePath / os.up)
+    os.copy(resourcePath, m.millSourcePath)
+    t(eval)
+  }
+
   override def tests: Tests = Tests {
-    test("TestArgs args serialization") {
-      forAll {
-        (
+    'TestArgs - {
+      test("args serialization") {
+        forAll {
+          (
             frameworks: Seq[String],
             classpath: Seq[String],
             arguments: Seq[String],
@@ -19,19 +50,78 @@ object TestRunnerTests extends TestSuite {
             colored: Boolean,
             testCp: String,
             homeStr: String
-        ) =>
-          val testArgs = TestArgs(
-            frameworks,
-            classpath,
-            arguments,
-            sysProps,
-            outputPath,
-            colored,
-            testCp,
-            homeStr
+          ) =>
+            val testArgs = TestArgs(
+              frameworks,
+              classpath,
+              arguments,
+              sysProps,
+              outputPath,
+              colored,
+              testCp,
+              homeStr
+            )
+            TestArgs.parseArgs(testArgs.toArgsSeq.toArray) == Success(testArgs)
+        }.check
+      }
+      test("args serialization 2") {
+        forAll { (globSelectors: Seq[String]) =>
+          forAll {
+            (
+              framework: String,
+              classpath: Seq[String],
+              arguments: Seq[String],
+              sysProps: Map[String, String],
+              outputPath: String,
+              colored: Boolean,
+              testCp: String,
+              homeStr: String
+            ) =>
+              val testArgs = TestArgs(
+                framework,
+                classpath,
+                arguments,
+                sysProps,
+                outputPath,
+                colored,
+                testCp,
+                homeStr,
+                globSelectors
+              )
+              TestArgs.parseArgs(testArgs.toArgsSeq.toArray) == Success(testArgs)
+          }
+        }.check
+      }
+    }
+    'TestRunner - {
+      "test case lookup" - workspaceTest(testrunner) { eval =>
+        val Right((result, _)) = eval.apply(testrunner.test.test())
+        val test = result.asInstanceOf[(String, Seq[mill.scalalib.TestRunner.Result])]
+        assert(
+          test._2.size == 3
+        )
+      }
+      'testOnly - {
+        def testOnly(eval: TestEvaluator, args: Seq[String], size: Int) = {
+          val Right((result1, _)) = eval.apply(testrunner.test.testOnly(args:_*))
+          val testOnly = result1.asInstanceOf[(String, Seq[mill.scalalib.TestRunner.Result])]
+          assert(
+            testOnly._2.size == size
           )
-          TestArgs.parseArgs(testArgs.toArgsSeq.toArray) == Success(testArgs)
-      }.check
+        }
+        'suffix - workspaceTest(testrunner) { eval =>
+          testOnly(eval, Seq("*arTests"), 2)
+        }
+        'prefix - workspaceTest(testrunner) { eval =>
+          testOnly(eval, Seq("mill.scalalib.FooT*"), 1)
+        }
+        'exactly - workspaceTest(testrunner) { eval =>
+          testOnly(eval, Seq("mill.scalalib.FooTests"), 1)
+        }
+        'multi - workspaceTest(testrunner) { eval =>
+          testOnly(eval, Seq("*Bar*", "*bar*"), 2)
+        }
+      }
     }
   }
 }

--- a/scalanativelib/src/ScalaNativeModule.scala
+++ b/scalanativelib/src/ScalaNativeModule.scala
@@ -176,7 +176,8 @@ trait ScalaNativeModule extends ScalaModule { outer =>
 
 trait TestScalaNativeModule extends ScalaNativeModule with TestModule {
   override def testLocal(args: String*) = T.command { test(args:_*) }
-  override protected def testTask(args: Task[Seq[String]]): Task[(String, Seq[TestRunner.Result])] = T.task {
+  override protected def testTask(args: Task[Seq[String]],
+      globSeletors: Task[Seq[String]]): Task[(String, Seq[TestRunner.Result])] = T.task {
 
     val getFrameworkResult = scalaNativeWorker().getFramework(
       nativeLink().toIO,
@@ -192,7 +193,8 @@ trait TestScalaNativeModule extends ScalaNativeModule with TestModule {
       runClasspath().map(_.path),
       Agg(compile().classes.path),
       args(),
-      T.testReporter
+      T.testReporter,
+      TestRunner.globFilter(globSeletors())
     )
     val res = TestModule.handleResults(doneMsg, results)
     // Hack to try and let the Scala Native subprocess finish streaming it's stdout


### PR DESCRIPTION
this is to support test class selection for frameworks do not support selection through runner arguments (for example, ScalaTest does not support class selection when running from sbt runner interface)