### PR TITLE
play-contrib: Fixed classloading of worker module and cleanups

### DIFF
--- a/contrib/playlib/src/mill/playlib/RouteCompilerWorkerApi.scala
+++ b/contrib/playlib/src/mill/playlib/RouteCompilerWorkerApi.scala
@@ -21,6 +21,7 @@ private[playlib] class RouteCompilerWorker {
         val cl = mill.api.ClassLoader.create(
           toolsClassPath,
           null,
+          sharedLoader = getClass().getClassLoader(),
           sharedPrefixes = Seq("mill.playlib.api.")
         )
         val bridge = cl

--- a/contrib/playlib/src/mill/playlib/RouterModule.scala
+++ b/contrib/playlib/src/mill/playlib/RouterModule.scala
@@ -79,7 +79,6 @@ trait RouterModule extends ScalaModule with Version {
       workerKey,
       s"mill-contrib-playlib-worker-${playMinorVersion()}",
       repositoriesTask(),
-      resolveFilter = _.toString.contains("mill-contrib-playlib-worker"),
       artifactSuffix = playMinorVersion() match {
         case "2.6" => "_2.12"
         case _ => "_2.13"


### PR DESCRIPTION
Fixed use of mills utility classloader by settings the correct parent classloader.
Using the classloader of the module as parent makes the shared API modules (which need to be already loaded by the mill build) visible.
The previously used default was using the classloader which loaded the mill build (and the ammonite script), which misses the play API module (loaded via `$ivy` import).

Fixed dependency resolution of worker classpath.
The collected classpath of the worker module was limited to only use the worker module.
But this misses all transitive dependencies of the worker.
This is probably because of older limitiations in mill builds, which also included the mill API itself.
Now, mill uses `compileModuleDeps` for the mill API and we have clean and usable transitive module and worker classpaths.


