### PR TITLE
fix sourceItem for mill-build

### DIFF
--- a/bsp/src/mill/bsp/MillBuildServer.scala
+++ b/bsp/src/mill/bsp/MillBuildServer.scala
@@ -87,7 +87,7 @@ class MillBuildServer(evaluator: Evaluator, bspVersion: String, serverVersion: S
           if (targetId == millBuildTargetId)
             new SourcesItem(
               targetId,
-              Seq(sourceItem(evaluator.rootModule.millSourcePath / "src", generated = false)).asJava // Intellij needs one
+              Seq(sourceItem(evaluator.rootModule.millSourcePath / "build.sc", generated = false)).asJava // Intellij needs one
             )
           else {
             val module = getModule(targetId, modules)


### PR DESCRIPTION
due to hardcode `sourceItem(evaluator.rootModule.millSourcePath / "src", generated = false)`,
Metals not recognize build.sc as source file when user choose mill-bsp build server,
no auto-complete and hover tooltips available

This commit fix #1159