### PR TITLE
Prevent compilation during bloop config generation

### DIFF
--- a/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
+++ b/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
@@ -196,6 +196,81 @@ class BloopImpl(ev: () => Evaluator, wd: Path) extends ExternalModule { outer =>
     }
 
     ////////////////////////////////////////////////////////////////////////////
+    // Platform (Jvm/Js/Native)
+    ////////////////////////////////////////////////////////////////////////////
+
+    def jsLinkerMode(m: JavaModule): Task[Config.LinkerMode] =
+      (m.asBloop match {
+        case Some(bm) => T.task(bm.linkerMode())
+        case None     => T.task(None)
+      }).map(_.getOrElse(Config.LinkerMode.Debug))
+
+    val platform: Task[BloopConfig.Platform] = module match {
+      case m: ScalaJSModule =>
+        T.task {
+          BloopConfig.Platform.Js(
+            BloopConfig.JsConfig.empty.copy(
+              version = m.scalaJSVersion(),
+              mode = jsLinkerMode(m)(),
+              kind = m.moduleKind() match {
+                case ModuleKind.NoModule => Config.ModuleKindJS.NoModule
+                case ModuleKind.CommonJSModule =>
+                  Config.ModuleKindJS.CommonJSModule
+                case ModuleKind.ESModule => Config.ModuleKindJS.ESModule
+              },
+              emitSourceMaps = m.jsEnvConfig() match{
+                case c: JsEnvConfig.NodeJs => c.sourceMap
+                case _ => false
+              },
+              jsdom = Some(false),
+            ),
+            mainClass = module.mainClass()
+          )
+        }
+      case m: ScalaNativeModule =>
+        T.task {
+          BloopConfig.Platform.Native(
+            BloopConfig.NativeConfig.empty.copy(
+              version = m.scalaNativeVersion(),
+              mode = m.releaseMode() match {
+                case ReleaseMode.Debug => BloopConfig.LinkerMode.Debug
+                case ReleaseMode.ReleaseFast => BloopConfig.LinkerMode.Release
+                case ReleaseMode.ReleaseFull => BloopConfig.LinkerMode.Release
+              },
+              gc = m.nativeGC(),
+              targetTriple = m.nativeTarget(),
+              clang = m.nativeClang().toNIO,
+              clangpp = m.nativeClangPP().toNIO,
+              options = Config.NativeOptions(
+                m.nativeLinkingOptions().toList,
+                m.nativeCompileOptions().toList
+              ),
+              linkStubs = m.nativeLinkStubs(),
+            ),
+            mainClass = module.mainClass()
+          )
+        }
+      case _ =>
+        T.task {
+          BloopConfig.Platform.Jvm(
+            BloopConfig.JvmConfig(
+              home = T.env.get("JAVA_HOME").map(s => Path(s).toNIO),
+              options = {
+                // See https://github.com/scalacenter/bloop/issues/1167
+                val forkArgs = module.forkArgs().toList
+                if (forkArgs.exists(_.startsWith("-Duser.dir="))) forkArgs
+                else s"-Duser.dir=$wd" :: forkArgs
+              }
+            ),
+            mainClass = module.mainClass(),
+            runtimeConfig = None,
+            classpath = None,
+            resources = Some(module.resources().map(_.path.toNIO).toList)
+          )
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
     // Tests
     ////////////////////////////////////////////////////////////////////////////
 
@@ -329,81 +404,6 @@ class BloopImpl(ev: () => Evaluator, wd: Path) extends ExternalModule { outer =>
       .task(transitiveClasspath(module)() ++ ivyDepsClasspath())
       .map(_.distinct)
     val resources = T.task(module.resources().map(_.path.toNIO).toList)
-
-    ////////////////////////////////////////////////////////////////////////////
-    // Platform (Jvm/Js/Native)
-    ////////////////////////////////////////////////////////////////////////////
-
-    def jsLinkerMode(m: JavaModule): Task[Config.LinkerMode] =
-      (m.asBloop match {
-        case Some(bm) => T.task(bm.linkerMode())
-        case None     => T.task(None)
-      }).map(_.getOrElse(Config.LinkerMode.Debug))
-
-    def platform: Task[BloopConfig.Platform] = module match {
-      case m: ScalaJSModule =>
-        T.task {
-          BloopConfig.Platform.Js(
-            BloopConfig.JsConfig.empty.copy(
-              version = m.scalaJSVersion(),
-              mode = jsLinkerMode(m)(),
-              kind = m.moduleKind() match {
-                case ModuleKind.NoModule => Config.ModuleKindJS.NoModule
-                case ModuleKind.CommonJSModule =>
-                  Config.ModuleKindJS.CommonJSModule
-                case ModuleKind.ESModule => Config.ModuleKindJS.ESModule
-              },
-              emitSourceMaps = m.jsEnvConfig() match {
-                case c: JsEnvConfig.NodeJs => c.sourceMap
-                case _                     => false
-              },
-              jsdom = Some(false)
-            ),
-            mainClass = module.mainClass()
-          )
-        }
-      case m: ScalaNativeModule =>
-        T.task {
-          BloopConfig.Platform.Native(
-            BloopConfig.NativeConfig.empty.copy(
-              version = m.scalaNativeVersion(),
-              mode = m.releaseMode() match {
-                case ReleaseMode.Debug       => BloopConfig.LinkerMode.Debug
-                case ReleaseMode.ReleaseFast => BloopConfig.LinkerMode.Release
-                case ReleaseMode.ReleaseFull => BloopConfig.LinkerMode.Release
-              },
-              gc = m.nativeGC(),
-              targetTriple = m.nativeTarget(),
-              clang = m.nativeClang().toNIO,
-              clangpp = m.nativeClangPP().toNIO,
-              options = Config.NativeOptions(
-                m.nativeLinkingOptions().toList,
-                m.nativeCompileOptions().toList
-              ),
-              linkStubs = m.nativeLinkStubs()
-            ),
-            mainClass = module.mainClass()
-          )
-        }
-      case _ =>
-        T.task {
-          BloopConfig.Platform.Jvm(
-            BloopConfig.JvmConfig(
-              home = T.env.get("JAVA_HOME").map(s => Path(s).toNIO),
-              options = {
-                // See https://github.com/scalacenter/bloop/issues/1167
-                val forkArgs = module.forkArgs().toList
-                if (forkArgs.exists(_.startsWith("-Duser.dir="))) forkArgs
-                else s"-Duser.dir=$wd" :: forkArgs
-              }
-            ),
-            mainClass = module.mainClass(),
-            runtimeConfig = None,
-            classpath = Some(classpath().map(_.toNIO).toList),
-            resources = Some(module.resources().map(_.path.toNIO).toList)
-          )
-        }
-    }
 
     ////////////////////////////////////////////////////////////////////////////
     //  Tying up

--- a/contrib/bloop/test/src/mill/contrib/bloop/BloopTests.scala
+++ b/contrib/bloop/test/src/mill/contrib/bloop/BloopTests.scala
@@ -80,6 +80,18 @@ object BloopTests extends TestSuite {
       // skipped on Windows
       val scalanativeModuleConfig = if(scala.util.Properties.isWin) None else Some(readBloopConf("scalanativeModule.json"))
 
+      "no-compilation" - {
+        val workspaceOut = os.pwd / "target" / "workspace" / "mill" / "contrib" / "bloop" / "BloopTests" / "testEvaluator"
+        val scalaModuleCompile = workspaceOut / "scalaModule" / "compile"
+        val scalaModule2Compile = workspaceOut / "scalaModule2" / "compile"
+
+        // Ensuring that bloop config generation didn't trigger compilation
+        assert(os.exists(workspaceOut / "scalaModule"))
+        assert(!os.exists(workspaceOut / "scalaModule" / "compile"))
+        assert(os.exists(workspaceOut / "scalaModule2"))
+        assert(!os.exists(workspaceOut / "scalaModule2" / "compile"))
+      }
+
       "scalaModule" - {
         val p = scalaModuleConfig.project
         val name = p.name

--- a/contrib/bloop/test/src/mill/contrib/bloop/BloopTests.scala
+++ b/contrib/bloop/test/src/mill/contrib/bloop/BloopTests.scala
@@ -82,8 +82,6 @@ object BloopTests extends TestSuite {
 
       "no-compilation" - {
         val workspaceOut = os.pwd / "target" / "workspace" / "mill" / "contrib" / "bloop" / "BloopTests" / "testEvaluator"
-        val scalaModuleCompile = workspaceOut / "scalaModule" / "compile"
-        val scalaModule2Compile = workspaceOut / "scalaModule2" / "compile"
 
         // Ensuring that bloop config generation didn't trigger compilation
         assert(os.exists(workspaceOut / "scalaModule"))


### PR DESCRIPTION
Compilation of a module and its upstreams should be avoided at all cost when generating bloop configuration. 

https://github.com/com-lihaoyi/mill/pull/1086 adds a reference to a task that depends on `compile`. This PR prevents that from happening, and adds a test to ensure that compilation isn't triggered by `Bloop/install` 

@tgodzik 
@lolgab 