### PR TITLE
Update Ammonite and upickle to support newer Scala versions

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -56,7 +56,7 @@ object Deps {
   }
 
   val acyclic = ivy"com.lihaoyi::acyclic:0.2.0"
-  val ammonite = ivy"com.lihaoyi:::ammonite:2.3.8-65-0f0d597f"
+  val ammonite = ivy"com.lihaoyi:::ammonite:2.4.0"
   // Exclude trees here to force the version of we have defined. We use this
   // here instead of a `forceVersion()` on scalametaTrees since it's not
   // respected in the POM causing issues for Coursier Mill users.
@@ -97,7 +97,7 @@ object Deps {
   def scalaReflect(scalaVersion: String) = ivy"org.scala-lang:scala-reflect:${scalaVersion}"
   def scalacScoveragePlugin = ivy"org.scoverage::scalac-scoverage-plugin:1.4.1"
   val sourcecode = ivy"com.lihaoyi::sourcecode:0.2.7"
-  val upickle = ivy"com.lihaoyi::upickle:1.3.13"
+  val upickle = ivy"com.lihaoyi::upickle:1.4.0"
   val utest = ivy"com.lihaoyi::utest:0.7.10"
   val windowsAnsi = ivy"io.github.alexarchambault.windows-ansi:windows-ansi:0.0.3"
   val zinc = ivy"org.scala-sbt::zinc:1.5.5"

--- a/ci/mill-bootstrap.patch
+++ b/ci/mill-bootstrap.patch
@@ -1,0 +1,18 @@
+# We broke binary compatibility by bumping upickle over >= 1.3.14
+# which will break loading of mill plugins, so we can't use mill-vcs-version plugin
+
+diff --git a/build.sc b/build.sc
+index c0164584..6caab881 100755
+--- a/build.sc
++++ b/build.sc
+@@ -105,8 +105,8 @@ object Deps {
+   val jarjarabrams = ivy"com.eed3si9n.jarjarabrams::jarjar-abrams-core:0.3.1"
+ }
+ 
+-def millVersion = T { VcsVersion.vcsState().format() }
+-def millLastTag = T { VcsVersion.vcsState().lastTag.get }
++def millVersion = T { "0.0.0.test" }
++def millLastTag = T { "0.0.0.test" }
+ def baseDir = build.millSourcePath
+ 
+ trait MillPublishModule extends PublishModule {

--- a/ci/patch-mill-bootstrap.sh
+++ b/ci/patch-mill-bootstrap.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+# Apply a patch, if present, before bootstrapping
+
+set -eux
+
+# Patch local build
+if [ -f ci/mill-bootstrap.patch ] ; then
+  patch -p1 < ci/mill-bootstrap.patch
+fi

--- a/ci/test-mill-bootstrap-0.sh
+++ b/ci/test-mill-bootstrap-0.sh
@@ -20,6 +20,9 @@ rm -rf ~/.mill
 git config --global user.name "Your Name"
 echo "Build 2" > info.txt && git add info.txt && git commit -m "Add info.txt"
 
+# Patch local build
+ci/patch-mill-bootstrap.sh
+
 # Second build
 ~/mill-1 -i all __.publishLocal launcher
 cp out/launcher/dest/mill ~/mill-2
@@ -29,6 +32,9 @@ git stash -u
 git stash -a
 
 rm -rf ~/.mill
+
+# Patch local build
+ci/patch-mill-bootstrap.sh
 
 # Use second build to run tests using Mill
 ~/mill-2 -i all {main,scalalib,scalajslib,scalanativelib,bsp}.__.test

--- a/ci/test-mill-bootstrap-1.sh
+++ b/ci/test-mill-bootstrap-1.sh
@@ -20,6 +20,9 @@ rm -rf ~/.mill
 git config --global user.name "Your Name"
 echo "Build 2" > info.txt && git add info.txt && git commit -m "Add info.txt"
 
+# Patch local build
+ci/patch-mill-bootstrap.sh
+
 # Second build
 ~/mill-1 -i all __.publishLocal launcher
 cp out/launcher/dest/mill ~/mill-2
@@ -29,6 +32,9 @@ git stash -u
 git stash -a
 
 rm -rf ~/.mill
+
+# Patch local build
+ci/patch-mill-bootstrap.sh
 
 # Use second build to run tests using Mill
 ~/mill-2 -i all contrib.__.test

--- a/ci/test-mill-dev.sh
+++ b/ci/test-mill-dev.sh
@@ -11,6 +11,9 @@ git stash -a
 
 rm -rf ~/.mill
 
+# Patch local build
+ci/patch-mill-bootstrap.sh
+
 # Second build & run tests
 out/dev/assembly/dest/mill -i main.test.compile
 

--- a/ci/test-mill-release.sh
+++ b/ci/test-mill-release.sh
@@ -15,6 +15,9 @@ git stash -a
 
 rm -rf ~/.mill
 
+# Patch local build
+ci/patch-mill-bootstrap.sh
+
 # Run tests
 ~/mill-release -i integration.test "mill.integration.forked.{AcyclicTests,UpickleTests,PlayJsonTests}"
 


### PR DESCRIPTION
Warning: This update introduces binary incompatibilities!

While bootstrap testing, we have the issue, that because of binary incompatibilities, the `build.sc` will no longer work as is. This is in this case, because we use external plugins. So when testing, we apply a temporary patch to `build.sc` to allow building with bootstrapped mill. This allows us to succeed in CI and continue to automatically release snapshot builds, which is needed, to update external plugins later.