### PR TITLE
Update coursier to 2.0.16+73-gddc6d9cc9

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -117,7 +117,7 @@ jobs:
 
       - uses: actions/setup-java@v1
         with:
-          java-version: 9
+          java-version: 8
 
       - run: ci/release-maven.sh
 
@@ -137,6 +137,6 @@ jobs:
 
       - uses: actions/setup-java@v1
         with:
-          java-version: 9
+          java-version: 8
 
       - run: ./mill -i uploadToGithub $REPO_ACCESS_TOKEN

--- a/build.sc
+++ b/build.sc
@@ -65,7 +65,7 @@ object Deps {
   )
   val asciidoctorj = ivy"org.asciidoctor:asciidoctorj:2.4.3"
   val bloopConfig = ivy"ch.epfl.scala::bloop-config:1.4.6-33-1c6f6712"
-  val coursier = ivy"io.get-coursier::coursier:2.0.16"
+  val coursier = ivy"io.get-coursier::coursier:2.0.16+73-gddc6d9cc9"
   val flywayCore = ivy"org.flywaydb:flyway-core:6.5.7"
   val graphvizJava = ivy"guru.nidi:graphviz-java:0.18.1"
   // Warning: Avoid ipcsocket version 1.3.0, as it caused many failures on CI


### PR DESCRIPTION
On Windows, this should fix some issues where trying to access the coursier cache blocks indefinitely.