### PR TITLE
Introduce `mandatoryScalacOptions` to keep system `scalacOptions`

### DIFF
--- a/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
+++ b/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
@@ -182,7 +182,7 @@ class BloopImpl(ev: () => Evaluator, wd: Path) extends ExternalModule { outer =>
           }
 
           val allScalacOptions =
-            (s.scalacOptions() ++ pluginOptions).toList
+            (s.allScalacOptions() ++ pluginOptions).toList
           Some(
             BloopConfig.Scala(
               organization = s.scalaOrganization(),

--- a/scalajslib/src/ScalaJSModule.scala
+++ b/scalajslib/src/ScalaJSModule.scala
@@ -150,7 +150,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
     ).map(PathRef(_))
   }
 
-  override def scalacOptions = super.scalacOptions() ++ {
+  override def internalScalacOptions = super.internalScalacOptions() ++ {
     if (isScala3(scalaVersion())) Seq("-scalajs")
     else Seq.empty
   }

--- a/scalajslib/src/ScalaJSModule.scala
+++ b/scalajslib/src/ScalaJSModule.scala
@@ -150,7 +150,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
     ).map(PathRef(_))
   }
 
-  override def internalScalacOptions = super.internalScalacOptions() ++ {
+  override def mandatoryScalacOptions = super.mandatoryScalacOptions() ++ {
     if (isScala3(scalaVersion())) Seq("-scalajs")
     else Seq.empty
   }

--- a/scalalib/src/GenIdeaImpl.scala
+++ b/scalalib/src/GenIdeaImpl.scala
@@ -178,12 +178,12 @@ case class GenIdeaImpl(
           mod.resolveDeps(allIvyDeps, sources = true)()
         }
 
-        val (scalacPluginsIvyDeps, scalacOptions) = mod match {
+        val (scalacPluginsIvyDeps, allScalacOptions) = mod match {
           case mod: ScalaModule =>
             T.task {
               mod.scalacPluginIvyDeps()
             } -> T.task {
-              mod.scalacOptions()
+              mod.allScalacOptions()
             }
           case _ => T.task(Loose.Agg[Dep]()) -> T.task(Seq())
         }
@@ -218,7 +218,7 @@ case class GenIdeaImpl(
             scalaCompilerClasspath()
           val resolvedLibraryCp: Loose.Agg[PathRef] =
             externalLibraryDependencies()
-          val scalacOpts: Seq[String] = scalacOptions()
+          val scalacOpts: Seq[String] = allScalacOptions()
           val resolvedFacets: Seq[JavaFacet] = facets()
           val resolvedConfigFileContributions: Seq[IdeaConfigFile] =
             configFileContributions()

--- a/scalalib/src/ScalaModule.scala
+++ b/scalalib/src/ScalaModule.scala
@@ -108,7 +108,7 @@ trait ScalaModule extends JavaModule { outer =>
   protected def mandatoryScalacOptions = T { Seq.empty[String] }
 
   /**
-   * Command-line options to pass to the Scala compiler defined by the user
+   * Command-line options to pass to the Scala compiler defined by the user.
    * Consumers should use `allScalacOptions` to read them.
    */
   def scalacOptions = T { Seq.empty[String] }

--- a/scalalib/src/ScalaModule.scala
+++ b/scalalib/src/ScalaModule.scala
@@ -22,7 +22,7 @@ trait ScalaModule extends JavaModule { outer =>
     override def scalacPluginIvyDeps = outer.scalacPluginIvyDeps
     override def scalacPluginClasspath = outer.scalacPluginClasspath
     override def scalacOptions = outer.scalacOptions
-    override def internalScalacOptions = outer.internalScalacOptions
+    override def mandatoryScalacOptions = outer.mandatoryScalacOptions
   }
 
   trait Tests extends ScalaModuleTests
@@ -105,7 +105,7 @@ trait ScalaModule extends JavaModule { outer =>
    * Mandatory command-line options to pass to the Scala compiler
    * that shouldn't be removed by overriding `scalacOptions`
    */
-  protected def internalScalacOptions = T { Seq.empty[String] }
+  protected def mandatoryScalacOptions = T { Seq.empty[String] }
 
   /**
    * Command-line options to pass to the Scala compiler defined by the user
@@ -117,7 +117,7 @@ trait ScalaModule extends JavaModule { outer =>
    * Aggregation of all the options passed to the Scala compiler
    * Do not override this Target. Override `scalacOptions` instead
    */
-  def allScalacOptions = T { internalScalacOptions() ++ scalacOptions() }
+  def allScalacOptions = T { mandatoryScalacOptions() ++ scalacOptions() }
 
   def scalaDocOptions: T[Seq[String]] = T {
     val defaults =

--- a/scalalib/src/ScalaModule.scala
+++ b/scalalib/src/ScalaModule.scala
@@ -109,13 +109,15 @@ trait ScalaModule extends JavaModule { outer =>
 
   /**
    * Command-line options to pass to the Scala compiler defined by the user
+   * Consumers should use `allScalacOptions` to read them.
    */
   def scalacOptions = T { Seq.empty[String] }
 
   /**
    * Aggregation of all the options passed to the Scala compiler
+   * Do not override this Target. Override `scalacOptions` instead
    */
-  protected def allScalacOptions = T { internalScalacOptions() ++ scalacOptions() }
+  def allScalacOptions = T { internalScalacOptions() ++ scalacOptions() }
 
   def scalaDocOptions: T[Seq[String]] = T {
     val defaults =

--- a/scalalib/src/ScalaModule.scala
+++ b/scalalib/src/ScalaModule.scala
@@ -114,8 +114,8 @@ trait ScalaModule extends JavaModule { outer =>
   def scalacOptions = T { Seq.empty[String] }
 
   /**
-   * Aggregation of all the options passed to the Scala compiler
-   * Do not override this Target. Override `scalacOptions` instead
+   * Aggregation of all the options passed to the Scala compiler.
+   * In most cases, instead of overriding this Target you want to override `scalacOptions` instead.
    */
   def allScalacOptions = T { mandatoryScalacOptions() ++ scalacOptions() }
 

--- a/scalalib/src/ScalaModule.scala
+++ b/scalalib/src/ScalaModule.scala
@@ -108,9 +108,14 @@ trait ScalaModule extends JavaModule { outer =>
   protected def internalScalacOptions = T { Seq.empty[String] }
 
   /**
-   * Command-line options to pass to the Scala compiler
+   * Command-line options to pass to the Scala compiler defined by the user
    */
   def scalacOptions = T { Seq.empty[String] }
+
+  /**
+   * Aggregation of all the options passed to the Scala compiler
+   */
+  protected def allScalacOptions = T { internalScalacOptions() ++ scalacOptions() }
 
   def scalaDocOptions: T[Seq[String]] = T {
     val defaults =
@@ -120,7 +125,7 @@ trait ScalaModule extends JavaModule { outer =>
           artifactName()
         )
       else Seq()
-    scalacOptions() ++ defaults
+    allScalacOptions() ++ defaults
   }
 
   /**
@@ -187,7 +192,7 @@ trait ScalaModule extends JavaModule { outer =>
         javacOptions(),
         scalaVersion(),
         scalaOrganization(),
-        internalScalacOptions() ++ scalacOptions(),
+        allScalacOptions(),
         scalaCompilerClasspath().map(_.path),
         scalacPluginClasspath().map(_.path),
         T.reporter.apply(hashCode)

--- a/scalalib/src/ScalaModule.scala
+++ b/scalalib/src/ScalaModule.scala
@@ -22,6 +22,7 @@ trait ScalaModule extends JavaModule { outer =>
     override def scalacPluginIvyDeps = outer.scalacPluginIvyDeps
     override def scalacPluginClasspath = outer.scalacPluginClasspath
     override def scalacOptions = outer.scalacOptions
+    override def internalScalacOptions = outer.internalScalacOptions
   }
 
   trait Tests extends ScalaModuleTests
@@ -99,6 +100,12 @@ trait ScalaModule extends JavaModule { outer =>
   def scalacPluginIvyDeps = T { Agg.empty[Dep] }
 
   def scalaDocPluginIvyDeps = T { scalacPluginIvyDeps() }
+
+  /**
+   * Mandatory command-line options to pass to the Scala compiler
+   * that shouldn't be removed by overriding `scalacOptions`
+   */
+  protected def internalScalacOptions = T { Seq.empty[String] }
 
   /**
    * Command-line options to pass to the Scala compiler
@@ -180,7 +187,7 @@ trait ScalaModule extends JavaModule { outer =>
         javacOptions(),
         scalaVersion(),
         scalaOrganization(),
-        scalacOptions(),
+        internalScalacOptions() ++ scalacOptions(),
         scalaCompilerClasspath().map(_.path),
         scalacPluginClasspath().map(_.path),
         T.reporter.apply(hashCode)


### PR DESCRIPTION
It's easy to override scalacOptions in a Scala.js + Scala 3 module.
When you do so, the compiler silently fails to compile Scala.js files.
This is a source of errors for Mill users that can be mitigated by
defining a separate list of compile options which is used internally
to add these mandatory flags.