### PR TITLE
Add More Config Options to Docker Contrib Module

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -579,9 +579,13 @@ object contrib extends MillModule {
     override def ivyDeps = Agg(Deps.flywayCore)
   }
 
-
   object docker extends MillModule {
     override def compileModuleDeps = Seq(scalalib)
+    override def testArgs = T {
+      Seq("-Djna.nosys=true") ++
+        scalalib.worker.testArgs() ++
+        scalalib.backgroundwrapper.testArgs()
+    }
   }
 
   object bloop extends MillModule {

--- a/contrib/docker/src/DockerModule.scala
+++ b/contrib/docker/src/DockerModule.scala
@@ -18,6 +18,56 @@ trait DockerModule { outer: JavaModule =>
     def labels: T[Map[String, String]] = Map.empty[String, String]
     def baseImage: T[String] = "gcr.io/distroless/java:latest"
     def pullBaseImage: T[Boolean] = T(baseImage().endsWith(":latest"))
+    /**
+      * TCP Ports the container will listen to at runtime.
+      * 
+      * See also the Docker docs on 
+      * [[https://docs.docker.com/engine/reference/builder/#expose ports]] for
+      * more information.
+      */
+    def exposedPorts: T[Seq[Int]] = Seq.empty[Int]
+    /**
+      * UDP Ports the container will listen to at runtime.
+      *
+      * See also the Docker docs on
+      * [[https://docs.docker.com/engine/reference/builder/#expose ports]] for
+      * more information.
+      */
+    def exposedUdpPorts: T[Seq[Int]] = Seq.empty[Int]
+    /**
+      * The names of mount points. 
+      * 
+      * See also the Docker docs on
+      * [[https://docs.docker.com/engine/reference/builder/#volume volumes]]
+      * for more information.
+      */
+    def volumes: T[Seq[String]] = Seq.empty[String]
+    /**
+      * Environment variables to be set in the container.  
+      * 
+      * See also the Docker docs on
+      * [[https://docs.docker.com/engine/reference/builder/#env ENV]]
+      * for more information.
+      */
+    def envVars: T[Map[String, String]] = Map.empty[String, String]
+    /**
+      * Commands to add as RUN instructions.
+      * 
+      * See also the Docker docs on
+      * [[https://docs.docker.com/engine/reference/builder/#run RUN]]
+      * for more information.
+      */
+    def run: T[Seq[String]] = Seq.empty[String]
+    /**
+      * Any applicable string to the USER instruction.
+      * 
+      * An empty string will be ignored and will result in USER not being
+      * specified.  See also the Docker docs on
+      * [[https://docs.docker.com/engine/reference/builder/#user USER]]
+      * for more information.
+      */
+    def user: T[String] = ""
+
     private def baseImageCacheBuster: T[(Boolean, Double)] = T.input {
       val pull = pullBaseImage()
       if (pull) (pull, Math.random()) else (pull, 0d)
@@ -35,14 +85,28 @@ trait DockerModule { outer: JavaModule =>
         }
         .mkString(" ")
 
-      val labelLine = if (labels().isEmpty) "" else s"LABEL $labelRhs"
+      val lines = List(
+        if (labels().isEmpty) "" else s"LABEL $labelRhs",
+        if (exposedPorts().isEmpty) ""
+        else exposedPorts().map(port => s"$port/tcp")
+          .mkString("EXPOSE ", " ", ""),
+        if (exposedUdpPorts().isEmpty) ""
+        else exposedUdpPorts().map(port => s"$port/udp")
+          .mkString("EXPOSE ", " ", ""),
+        envVars().map { case (env, value) =>
+          s"ENV $env=$value"
+        }.mkString("\n"),
+        if (volumes().isEmpty) ""
+        else volumes().map(v => s"\"$v\"").mkString("VOLUME [", ", ", "]"),
+        run().map(c => s"RUN $c").mkString("\n"),
+        if (user().isEmpty) "" else s"USER ${user()}"
+      ).filter(_.nonEmpty).mkString("\n")
 
       s"""
         |FROM ${baseImage()}
-        |$labelLine
+        |$lines
         |COPY $jarName /$jarName
-        |ENTRYPOINT ["java", "-jar", "/$jarName"]
-      """.stripMargin
+        |ENTRYPOINT ["java", "-jar", "/$jarName"]""".stripMargin
     }
 
     final def build = T {

--- a/contrib/docker/test/resources/docker/src/Main.scala
+++ b/contrib/docker/test/resources/docker/src/Main.scala
@@ -1,0 +1,1 @@
+object Main extends App

--- a/contrib/docker/test/src/DockerModuleTest.scala
+++ b/contrib/docker/test/src/DockerModuleTest.scala
@@ -1,0 +1,117 @@
+package mill
+package contrib.docker
+
+import mill.api.PathRef
+import mill.scalalib.JavaModule
+import mill.util.{TestEvaluator, TestUtil}
+import os.Path
+import utest._
+import utest.framework.TestPath
+
+object DockerModuleTest extends TestSuite {
+
+  object Docker extends TestUtil.BaseModule with JavaModule with DockerModule {
+
+    override def millSourcePath = TestUtil.getSrcPathStatic()
+    override def artifactName = testArtifactName
+
+    object dockerDefault extends DockerConfig
+
+    object dockerAll extends DockerConfig {
+      override def baseImage = "openjdk:11"
+      override def labels = Map("version" -> "1.0")
+      override def exposedPorts = Seq(8080, 443)
+      override def exposedUdpPorts = Seq(80)
+      override def volumes = Seq("/v1", "/v2")
+      override def envVars = Map("foo" -> "bar", "foobar" -> "barfoo")
+      override def run = Seq(
+        "/bin/bash -c 'echo Hello World!'",
+        "useradd -ms /bin/bash user1"
+      )
+      override def user = "user1"
+    }
+  }
+
+  val testArtifactName = "mill-docker-contrib-test"
+
+  val testModuleSourcesPath: Path =
+    os.pwd / "contrib" / "docker" / "test" / "resources" / "docker"
+
+  private def isInstalled(executable: String): Boolean = {
+    val getPathCmd = if (scala.util.Properties.isWin) "where" else "which"
+    os.proc(getPathCmd, executable).call(check = false).exitCode == 0
+  }
+
+  private def workspaceTest(m: TestUtil.BaseModule)(t: TestEvaluator => Unit)(
+      implicit tp: TestPath
+  ): Unit = {
+    if (isInstalled("docker")) {
+      val eval = new TestEvaluator(m)
+      os.remove.all(m.millSourcePath)
+      os.remove.all(eval.outPath)
+      os.makeDir.all(m.millSourcePath / os.up)
+      os.copy(testModuleSourcesPath, m.millSourcePath)
+      t(eval)
+    } else {
+      println(s"Skipping '${tp.value.head}' since no docker installation was found")
+      assert(true)
+    }
+  }
+
+  override def utestAfterAll(): Unit = {
+    if (isInstalled("docker"))
+      os
+        .proc("docker", "rmi", testArtifactName)
+        .call(stdout = os.Inherit, stderr = os.Inherit)
+    else ()
+  }
+
+  def tests = Tests {
+
+    test("docker build") {
+      "default options" - workspaceTest(Docker) { eval =>
+        val Right((imageName :: Nil, _)) = eval(Docker.dockerDefault.build)
+        assert(imageName == testArtifactName)
+      }
+
+      "all options" - workspaceTest(Docker) { eval =>
+        val Right((imageName :: Nil, _)) = eval(Docker.dockerAll.build)
+        assert(imageName == testArtifactName)
+      }
+    }
+
+    test("dockerfile contents") {
+      "default options" - {
+        val eval = new TestEvaluator(Docker)
+        val Right((dockerfileString, _)) = eval(Docker.dockerDefault.dockerfile)
+        val expected =
+          """
+            |FROM gcr.io/distroless/java:latest
+            |
+            |COPY out.jar /out.jar
+            |ENTRYPOINT ["java", "-jar", "/out.jar"]""".stripMargin
+        assert(dockerfileString == expected)
+      }
+
+      "all options" - {
+        val eval = new TestEvaluator(Docker)
+        val Right((dockerfileString, _)) = eval(Docker.dockerAll.dockerfile)
+        val expected =
+          """
+            |FROM openjdk:11
+            |LABEL "version"="1.0"
+            |EXPOSE 8080/tcp 443/tcp
+            |EXPOSE 80/udp
+            |ENV foo=bar
+            |ENV foobar=barfoo
+            |VOLUME ["/v1", "/v2"]
+            |RUN /bin/bash -c 'echo Hello World!'
+            |RUN useradd -ms /bin/bash user1
+            |USER user1
+            |COPY out.jar /out.jar
+            |ENTRYPOINT ["java", "-jar", "/out.jar"]""".stripMargin
+        assert(dockerfileString == expected)
+      }
+    }
+  }
+}

--- a/docs/antora/modules/ROOT/pages/Contrib_Modules.adoc
+++ b/docs/antora/modules/ROOT/pages/Contrib_Modules.adoc
@@ -296,6 +296,8 @@ object docker extends DockerConfig {
   )
   // User to use when running the image
   def user = "new-user"
+  // Optionally override the docker executable to use something else
+  def executable = "podman"
 }
 ----
 

--- a/docs/antora/modules/ROOT/pages/Contrib_Modules.adoc
+++ b/docs/antora/modules/ROOT/pages/Contrib_Modules.adoc
@@ -279,6 +279,23 @@ object docker extends DockerConfig {
   // Configure whether the docker build should check the remote registry for a new version of the base image before building.
   // By default this is true if the base image is using a latest tag
   def pullBaseImage = true
+  // Add container metadata via the LABEL instruction
+  def labels = Map("version" -> "1.0")
+  // TCP ports the container will listen to
+  def exposedPorts = Seq(8080, 443)
+  // UDP ports the container will listen to
+  def exposedUdpPorts = Seq(80)
+  // The names of mount points, these will be translated to VOLUME instructions
+  def volumes = Seq("/v1", "/v2")
+  // Environment variables to be set in the container (ENV instructions)
+  def envVars = Map("foo" -> "bar", "foobar" -> "barfoo")
+  // Add RUN instructions
+  def run = Seq(
+    "/bin/bash -c 'echo Hello World!'",
+    "useradd -ms /bin/bash new-user"
+  )
+  // User to use when running the image
+  def user = "new-user"
 }
 ----
 


### PR DESCRIPTION
Hi!  This PR adds some more options (pretty much correspond 1-1 with Dockerfile instructions) that can be used in `DockerConfig`.  It's not totally comprehensive, but hopefully it catches the most common ones so there's less of a need to override `DockerConfig.build`.

I've added some tests which validate the new options by calling `docker build` - I could possibly replace these with tests against the generated `Dockerfile` strings if you think this is too much.

Thanks, I hope this is helpful.