### PR TITLE
Use unique pipe for each project

### DIFF
--- a/main/client/src/mill/main/client/MillClientMain.java
+++ b/main/client/src/mill/main/client/MillClientMain.java
@@ -211,10 +211,10 @@ public class MillClientMain {
 
         while (ioSocket == null && System.currentTimeMillis() - retryStart < 5000) {
             try {
-                String socketBaseName = "mill." + md5hex(new File(lockBase).getCanonicalPath());
+                String socketBaseName = "mill-" + md5hex(new File(lockBase).getCanonicalPath());
                 ioSocket = Util.isWindows?
                         new Win32NamedPipeSocket(Util.WIN32_PIPE_PREFIX + socketBaseName)
-                        : new UnixDomainSocket(socketBaseName + "/io");
+                        : new UnixDomainSocket(lockBase + "/" + socketBaseName + "-io");
             } catch (Throwable e){
                 socketThrowable = e;
                 Thread.sleep(1);
@@ -263,7 +263,8 @@ public class MillClientMain {
         return processLimit;
     }
 
-    private static String md5hex(String str) throws NoSuchAlgorithmException {
+    /** @return Hex encoded MD5 hash of input string. */
+    public static String md5hex(String str) throws NoSuchAlgorithmException {
         return hexArray(MessageDigest.getInstance("md5").digest(str.getBytes(StandardCharsets.UTF_8)));
     }
 

--- a/main/client/src/mill/main/client/MillClientMain.java
+++ b/main/client/src/mill/main/client/MillClientMain.java
@@ -12,8 +12,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
+import java.math.BigInteger;
 import java.net.Socket;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
@@ -209,9 +211,10 @@ public class MillClientMain {
 
         while (ioSocket == null && System.currentTimeMillis() - retryStart < 5000) {
             try {
+                String socketBaseName = "mill." + md5hex(new File(lockBase).getCanonicalPath());
                 ioSocket = Util.isWindows?
-                        new Win32NamedPipeSocket(Util.WIN32_PIPE_PREFIX + "mill." + new File(lockBase).getName())
-                        : new UnixDomainSocket(lockBase + "/io");
+                        new Win32NamedPipeSocket(Util.WIN32_PIPE_PREFIX + socketBaseName)
+                        : new UnixDomainSocket(socketBaseName + "/io");
             } catch (Throwable e){
                 socketThrowable = e;
                 Thread.sleep(1);
@@ -258,5 +261,13 @@ public class MillClientMain {
             }
         }
         return processLimit;
+    }
+
+    private static String md5hex(String str) throws NoSuchAlgorithmException {
+        return hexArray(MessageDigest.getInstance("md5").digest(str.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    private static String hexArray(byte[] arr) {
+        return String.format("%0" + (arr.length << 1) + "x", new BigInteger(1, arr));
     }
 }

--- a/main/src/main/MillServerMain.scala
+++ b/main/src/main/MillServerMain.scala
@@ -96,7 +96,7 @@ class Server[T](
       var running = true
       while (running) {
         Server.lockBlock(locks.serverLock) {
-          val socketBaseName = "mill." + Server.md5hex(new File(lockBase).getCanonicalPath)
+          val socketBaseName = "mill-" + MillClientMain.md5hex(new File(lockBase).getCanonicalPath)
           val (serverSocket, socketClose) =
             if (Util.isWindows) {
               val socketName = Util.WIN32_PIPE_PREFIX + socketBaseName
@@ -105,7 +105,7 @@ class Server[T](
                 () => new Win32NamedPipeSocket(socketName).close()
               )
             } else {
-              val socketName = socketBaseName + "/io"
+              val socketName = lockBase + "/" + socketBaseName + "-io"
               new File(socketName).delete()
               (
                 new UnixDomainServerSocket(socketName),
@@ -268,10 +268,4 @@ object Server {
       interrupt = false
     }
   }
-
-  def md5hex(str: String): String =
-    hexArray(MessageDigest.getInstance("md5").digest(str.getBytes(StandardCharsets.UTF_8)))
-
-  private def hexArray(arr: Array[Byte]) =
-    String.format("%0" + (arr.length << 1) + "x", new BigInteger(1, arr))
 }


### PR DESCRIPTION
Closes #1447 

Now the pipe name takes the *full absolute path* of the project.  
Previously 2 server instances (for different projects) would use *same pipe name* and that would cause an issue...

https://docs.microsoft.com/en-us/windows/win32/ipc/pipe-names
> The pipe name string specified by PipeName can include any character other than a backslash, including numbers and special characters. The entire pipe name string can be up to 256 characters long. Pipe names are not case-sensitive.