### PR TITLE
Version bump mill-vcs-version to 0.1.1-27-b3a696

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -1,7 +1,7 @@
 import $file.ci.shared
 import $file.ci.upload
 import $ivy.`org.scalaj::scalaj-http:2.4.2`
-import $ivy.`de.tototec::de.tobiasroeser.mill.vcs.version_mill0.9:0.1.1`
+import $ivy.`de.tototec::de.tobiasroeser.mill.vcs.version_mill0.9:0.1.1-27-b3a696`
 import $ivy.`net.sourceforge.htmlcleaner:htmlcleaner:2.24`
 import java.nio.file.attribute.PosixFilePermission
 

--- a/ci/mill-bootstrap.patch
+++ b/ci/mill-bootstrap.patch
@@ -1,14 +1,14 @@
 # We need to load a external plugins from another binary compatible slot
 
 diff --git a/build.sc b/build.sc
-index 39dd671f..2b1c53b7 100755
+index 2b1c53b7..a24465f2 100755
 --- a/build.sc
 +++ b/build.sc
 @@ -1,7 +1,7 @@
  import $file.ci.shared
  import $file.ci.upload
  import $ivy.`org.scalaj::scalaj-http:2.4.2`
--import $ivy.`de.tototec::de.tobiasroeser.mill.vcs.version_mill0.9:0.1.1`
+-import $ivy.`de.tototec::de.tobiasroeser.mill.vcs.version_mill0.9:0.1.1-27-b3a696`
 +import $ivy.`de.tototec::de.tobiasroeser.mill.vcs.version_mill0.10.0-M2:0.1.1-27-b3a696`
  import $ivy.`net.sourceforge.htmlcleaner:htmlcleaner:2.24`
  import java.nio.file.attribute.PosixFilePermission

--- a/ci/mill-bootstrap.patch
+++ b/ci/mill-bootstrap.patch
@@ -12,3 +12,4 @@ index 39dd671f..2b1c53b7 100755
 +import $ivy.`de.tototec::de.tobiasroeser.mill.vcs.version_mill0.10.0-M2:0.1.1-27-b3a696`
  import $ivy.`net.sourceforge.htmlcleaner:htmlcleaner:2.24`
  import java.nio.file.attribute.PosixFilePermission
+ 

--- a/ci/mill-bootstrap.patch
+++ b/ci/mill-bootstrap.patch
@@ -1,18 +1,14 @@
-# We broke binary compatibility by bumping upickle over >= 1.3.14
-# which will break loading of mill plugins, so we can't use mill-vcs-version plugin
+# We need to load a external plugins from another binary compatible slot
 
 diff --git a/build.sc b/build.sc
-index c0164584..6caab881 100755
+index 39dd671f..2b1c53b7 100755
 --- a/build.sc
 +++ b/build.sc
-@@ -105,8 +105,8 @@ object Deps {
-   val jarjarabrams = ivy"com.eed3si9n.jarjarabrams::jarjar-abrams-core:0.3.1"
- }
- 
--def millVersion = T { VcsVersion.vcsState().format() }
--def millLastTag = T { VcsVersion.vcsState().lastTag.get }
-+def millVersion = T { "0.0.0.test" }
-+def millLastTag = T { "0.0.0.test" }
- def baseDir = build.millSourcePath
- 
- trait MillPublishModule extends PublishModule {
+@@ -1,7 +1,7 @@
+ import $file.ci.shared
+ import $file.ci.upload
+ import $ivy.`org.scalaj::scalaj-http:2.4.2`
+-import $ivy.`de.tototec::de.tobiasroeser.mill.vcs.version_mill0.9:0.1.1`
++import $ivy.`de.tototec::de.tobiasroeser.mill.vcs.version_mill0.10.0-M2:0.1.1-27-b3a696`
+ import $ivy.`net.sourceforge.htmlcleaner:htmlcleaner:2.24`
+ import java.nio.file.attribute.PosixFilePermission


### PR DESCRIPTION
This version is also released for mill 0.10.0-M2.
