### PR TITLE
Support more mill-specifics in $ivy-import

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -108,8 +108,16 @@ object Deps {
   val jarjarabrams = ivy"com.eed3si9n.jarjarabrams::jarjar-abrams-core:1.8.0"
 }
 
-def millVersion = T { VcsVersion.vcsState().format() }
-def millLastTag = T { VcsVersion.vcsState().lastTag.get }
+def millVersion: T[String] = T { VcsVersion.vcsState().format() }
+def millLastTag: T[String] = T { VcsVersion.vcsState().lastTag.get }
+def millBinPlatform: T[String] = T {
+  val tag = millLastTag()
+  if(tag.contains("-M")) tag
+  else {
+    val pos = if(tag.startsWith("0.")) 2 else 1
+    tag.split("[.]", pos + 1).take(pos).mkString(".")
+  }
+}
 def baseDir = build.millSourcePath
 
 trait MillPublishModule extends PublishModule {
@@ -219,24 +227,34 @@ object main extends MillModule {
 
     override def generatedSources = T {
       val dest = T.ctx.dest
-      writeBuildInfo(dest, scalaVersion(), publishVersion(), T.traverse(dev.moduleDeps)(_.publishSelfDependency)())
+      writeBuildInfo(
+        dir = dest,
+        scalaVersion = scalaVersion(),
+        millVersion = publishVersion(),
+        millBinPlatform = millBinPlatform(),
+        artifacts = T.traverse(dev.moduleDeps)(_.publishSelfDependency)()
+      )
       shared.generateCoreSources(dest)
       Seq(PathRef(dest))
     }
 
-    def writeBuildInfo(dir : os.Path, scalaVersion: String, millVersion: String, artifacts: Seq[Artifact]) = {
+    def writeBuildInfo(dir : os.Path, scalaVersion: String, millVersion: String, millBinPlatform: String, artifacts: Seq[Artifact]) = {
       val code = s"""
         |package mill
         |
         |object BuildInfo {
+        |  /** Scala version used to compile mill core. */
         |  val scalaVersion = "$scalaVersion"
+        |  /** Mill version. */
         |  val millVersion = "$millVersion"
-        |  /** Dependency artifacts embedded in mill by default. */
+        |  /** Mill binary platform version. */
+        |  val millBinPlatform = "$millBinPlatform"
+        |  /** Dependency artifacts embedded in mill assembly by default. */
         |  val millEmbeddedDeps = ${artifacts.map(artifact => s""""${artifact.group}:${artifact.id}:${artifact.version}"""")}
         |}
       """.stripMargin.trim
 
-      os.write(dir / "BuildInfo.scala", code)
+      os.write(dir / "mill" / "BuildInfo.scala", code, createFolders = true)
     }
   }
 

--- a/docs/antora/modules/ROOT/nav.adoc
+++ b/docs/antora/modules/ROOT/nav.adoc
@@ -7,5 +7,5 @@
 * xref:Cross_Builds.adoc[]
 * xref:Extending_Mill.adoc[]
 * xref:Mill_Internals.adoc[]
-* xref:Contrib_Modules.adoc[]
-* xref:Thirdparty_Modules.adoc[]
+* xref:Contrib_Plugins.adoc[]
+* xref:Thirdparty_Plugins.adoc[]

--- a/docs/antora/modules/ROOT/pages/Contrib_Plugins.adoc
+++ b/docs/antora/modules/ROOT/pages/Contrib_Plugins.adoc
@@ -1,8 +1,14 @@
-= Contrib Modules / Plugins
+= Contrib Plugins
+:page-aliases: Contrib_Modules.adoc
 
 The ((plugins)) in this section are developed/maintained in the mill git tree.
 
-When using one of these contribution modules, it is important that the versions you load match your mill version. To facilitate this, Mill will automatically replace the `$MILL_VERSION` literal in your ivy imports with the correct value.
+For details about including plugins in your `build.sc` read xref:Extending_Mill.adoc#_using_mill_plugins_import_ivy[Using Mill Plugins].
+
+[CAUTION]
+--
+When using one of these contribution modules, it is important that the versions you load match your mill version.
+To facilitate this, Mill will automatically replace the `$MILL_VERSION` literal in your ivy imports with the correct value.
 
 For instance:
 
@@ -10,6 +16,7 @@ For instance:
 ----
 import $ivy.`com.lihaoyi::mill-contrib-bloop:$MILL_VERSION`
 ----
+--
 
 == Artifactory
 

--- a/docs/antora/modules/ROOT/pages/Extending_Mill.adoc
+++ b/docs/antora/modules/ROOT/pages/Extending_Mill.adoc
@@ -131,15 +131,16 @@ http://ammonite.io/#ScalaScripts[Ammonite Scripts]
 
 == import $ivy
 
-If you want to pull in artifacts from the public repositories (e.g. Maven Central) for use in your build, you can simply use `import $ivy`:
+If you want to pull in artifacts from the public repositories (e.g. Maven Central) for use in your build, you can simply use `import $ivy`.
 
-.`build.sc`
+
+.Example `build.sc`: Using `scalatags` library to generate HTML
 [source,scala]
 ----
-import $ivy.`com.lihaoyi::scalatags:0.6.2`
+import $ivy.`com.lihaoyi::scalatags:0.6.2` // <1>
 
 def generatedHtml = T {
-  import scalatags.Text.all._
+  import scalatags.Text.all._ // <2>
   html(
     head(),
     body(
@@ -149,13 +150,71 @@ def generatedHtml = T {
   ).render  
 }
 ----
+<1> Import the scalatags library from Mavel Central repository.
+<2> Creates the `generatedHtml` target which is used here to generate a simple Hello World HTML document. It can be used however you would like: written to a file, further processed, etc.
 
-This creates the `generatedHtml` target which can then be used however you would like: written to a file, further processed, etc.
-
-If you want to publish re-usable libraries that _other_ people can use in their builds, simply publish your code as a library to maven central.
+Please also read the next section xref:_using_mill_plugins_import_ivy[]].
 
 For more information, see Ammonite's
 http://ammonite.io/#import$ivy[Ivy Dependencies documentation].
+
+
+== Using Mill Plugins (`import $ivy`)
+
+Mill plugins are ordinary jars and are loaded as any other external dependency with xref:_import_ivy[`import $ivy`].
+
+Mill plugins are typically bound to a specific version or version range of Mill.
+To ease the use of the correct versions and avoid runtime issues (caused by binary incompatible plugins, which are hard to debug) you can apply one of the following techniques:
+
+=== Use the specific Mill Binary Platform notation
+
+[source,scala]
+----
+// for classic Scala dependencies
+import $ivy.`<group>::<plugin>::<version>` // <1>
+// for dependencies specific to the exact Scala version
+import $ivy.`<group>:::<plugin>::<version>` // <2>
+----
+<1> This is equivalent to
++
+[source,scala]
+----
+import $ivy.`<group>::<plugin>_mill$MILL_BIN_PLATFORM:<version>`
+----
+<1> This is equivalent to
++
+[source,scala]
+----
+import $ivy.`<group>:::<plugin>_mill$MILL_BIN_PLATFORM:<version>`
+----
+
+
+=== Use special placeholders in your `import $ivy`
+
+`$MILL_VERSION` ::
++
+--
+to substitute the currently used Mill version.
+This is typical required for Mill contrib modules, which are developed in the Mill repository and highly bound to the current Mill version.
+
+.Example: Use `mill-contrib-bloop` plugin matching the current Mill version
+----
+import $ivy:`com.lihaoyi:mill-contrib-bloop:$MILL_VERSION`
+----
+--
+
+`$MILL_BIN_PLATFORM` ::
++
+--
+to substitute the currently used Mill binary platform.
+
+.Example: Using `mill-vcs-version` plugin matching the current Mill Binary Platfrom
+----
+import $ivy:`de.tototec::de.tobiasroeser.mill.vcs.version::0.1.2`
+----
+--
+
+TIP: If you want to publish re-usable libraries that _other_ people can use in their builds, simply publish your code as a library to maven central.
 
 == Evaluator Commands (experimental)
 

--- a/docs/antora/modules/ROOT/pages/Thirdparty_Plugins.adoc
+++ b/docs/antora/modules/ROOT/pages/Thirdparty_Plugins.adoc
@@ -1,11 +1,15 @@
-= Thirdparty Modules / Plugins
+= Thirdparty Plugins
+:page-aliases: Thirdparty_Modules.adoc
 
-The modules (aka ((plugins))) in this section are developed/maintained outside the mill git tree.
+The Plugins in this section are developed/maintained outside the mill git tree.
+This list is most likely not complete.
+If you're missing an external plugin or developed one which is not listed here, please open a https://github.com/com-lihaoyi/mill/pulls[pull request] and add that plugin with a short description.
 
-Besides the documentation provided here, we urge you to consult the respective linked plugin documentation pages.
-The usage examples given here are most probably incomplete and sometimes outdated.
+For details about including plugins in your `build.sc` read xref:Extending_Mill.adoc#_using_mill_plugins_import_ivy[Using Mill Plugins].
 
-If you develop or maintain a mill plugin, please create a https://github.com/com-lihaoyi/mill/pulls[pull request] to get your plugin listed here.
+CAUTION: Besides the documentation provided here, we urge you to consult the respective linked plugin documentation pages.
+The usage examples given here are most probably incomplete and sometimes outdated!
+
 
 == Antlr
 
@@ -566,7 +570,7 @@ import mill._
 import mill.scalalib._
 
 // Load the plugin from Maven Central via ivy/coursier
-import $ivy.`de.tototec::de.tobiasroeser.mill.vcs.version_mill0.9:0.1.1`
+import $ivy.`de.tototec::de.tobiasroeser.mill.vcs.version::0.1.2`
 import de.tobiasroeser.mill.vcs.version.VcsVersion
 
 object main extends JavaModule with PublishModule {

--- a/main/src/main/MillIvyHook.scala
+++ b/main/src/main/MillIvyHook.scala
@@ -3,16 +3,47 @@ import ammonite.runtime.ImportHook.BaseIvy
 import ammonite.runtime.ImportHook
 import java.io.File
 
+import mill.BuildInfo
+
 /**
- * Overrides the ivy hook to interpret $MILL_VERSION as the version of mill
- * the user runs.
+ * Overrides the ivy hook to customize the `$ivy`-import with mill specifics:
  *
- * Can be used to ensure loaded contrib modules keep up to date.
+ * - interpret `$MILL_VERSION` as the mill version
+ *
+ * - interpret `$MILL_BIN_PLATFORM` as the mill binary platform version
+ *
+  * - supports the format `org::name::version` for mill plugins;
+  *   which is equivalent to `org::name_mill$MILL_BIN_PLATFORM:version`
+  *
+  * - supports the format `org:::name::version` for mill plugins;
+  *   which is equivalent to `org:::name_mill$MILL_BIN_PLATFORM:version`
+  *
  */
 object MillIvyHook extends BaseIvy(plugin = false) {
   override def resolve(
       interp: ImportHook.InterpreterInterface,
       signatures: Seq[String]
-  ): Either[String, (Seq[coursierapi.Dependency], Seq[File])] =
-    super.resolve(interp, signatures.map(_.replace("$MILL_VERSION", mill.BuildInfo.millVersion)))
+  ): Either[String, (Seq[coursierapi.Dependency], Seq[File])] = {
+
+    // replace platform notation
+    val millSigs: Seq[String] = for (signature <- signatures) yield {
+      signature.split("[:]") match {
+        case Array(org, "", pname, "", version)
+            if org.length > 0 && pname.length > 0 && version.length > 0 =>
+          s"${org}::${pname}_mill$$MILL_BIN_PLATFORM:${version}"
+        case Array(org, "", "", pname, "", version)
+            if org.length > 0 && pname.length > 0 && version.length > 0 =>
+          s"${org}:::${pname}_mill$$MILL_BIN_PLATFORM:${version}"
+        case _ => signature
+      }
+    }
+    // replace variables
+    val replaced = millSigs.map(_
+      .replace("$MILL_VERSION", mill.BuildInfo.millVersion)
+      .replace("${MILL_VERSION}", mill.BuildInfo.millVersion)
+      .replace("$MILL_BIN_PLATFORM", mill.BuildInfo.millBinPlatform)
+      .replace("${MILL_BIN_PLATFORM}", mill.BuildInfo.millBinPlatform))
+
+    super.resolve(interp, replaced)
+  }
 }


### PR DESCRIPTION
Support $MILL_BIN_PLATFORM placeholder and new $ivy.`g::a::v` syntax (borrowed from Scala JS/Native dependency notation)

Also updated Documentation and renamed two pages (Modules => Plugins).

With this PR I also try to establish the convention for mill plugins, to keep the mill binary platform version in the artrifact name as suffix: e.g. for Mill 0.9.x the suffix is `_mill0.9` and for Mill 0.10.x the suffix is `_mill0.10`.

Note: I plan to enforce binary compatibility in mill with the [mill-mima plugin](https://github.com/lolgab/mill-mima). This is come as separate PR.