### PR TITLE
scalapblib: support scalajs by default

### DIFF
--- a/contrib/scalapblib/src/ScalaPBModule.scala
+++ b/contrib/scalapblib/src/ScalaPBModule.scala
@@ -18,7 +18,7 @@ trait ScalaPBModule extends ScalaModule {
 
   override def ivyDeps = T {
     super.ivyDeps() ++
-      Agg(ivy"com.thesamet.scalapb::scalapb-runtime:${scalaPBVersion()}") ++
+      Agg(ivy"com.thesamet.scalapb::scalapb-runtime::${scalaPBVersion()}") ++
       (if (!scalaPBGrpc()) Agg()
        else Agg(ivy"com.thesamet.scalapb::scalapb-runtime-grpc:${scalaPBVersion()}"))
   }


### PR DESCRIPTION
ScalaJS can be supported if gRPC is not used.