### PR TITLE
Fix #1487: Introduce `mandatoryIvyDeps` and add to pom

### DIFF
--- a/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
+++ b/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
@@ -299,11 +299,6 @@ class BloopImpl(ev: () => Evaluator, wd: Path) extends ExternalModule { outer =>
     //  Ivy dependencies + sources
     ////////////////////////////////////////////////////////////////////////////
 
-    val scalaLibraryIvyDeps = module match {
-      case x: ScalaModule => x.scalaLibraryIvyDeps
-      case _ => T.task { Loose.Agg.empty[Dep] }
-    }
-
     /**
      * Resolves artifacts using coursier and creates the corresponding
      * bloop config.
@@ -376,8 +371,7 @@ class BloopImpl(ev: () => Evaluator, wd: Path) extends ExternalModule { outer =>
     val bloopResolution: Task[BloopConfig.Resolution] = T.task {
       val repos = module.repositoriesTask()
       val allIvyDeps =
-        module
-          .transitiveIvyDeps() ++ scalaLibraryIvyDeps() ++ module.transitiveCompileIvyDeps()
+        module.transitiveIvyDeps() ++ module.transitiveCompileIvyDeps()
       val coursierDeps =
         allIvyDeps.map(module.resolveCoursierDependency()).toList
       BloopConfig.Resolution(artifacts(repos, coursierDeps))
@@ -387,16 +381,10 @@ class BloopImpl(ev: () => Evaluator, wd: Path) extends ExternalModule { outer =>
     //  Classpath
     ////////////////////////////////////////////////////////////////////////////
 
-    val scalaLibIvyDeps = module match {
-      case s: ScalaModule => s.scalaLibraryIvyDeps
-      case _ => T.task(Loose.Agg.empty[Dep])
-    }
-
     val ivyDepsClasspath = module
       .resolveDeps(T.task {
         module.transitiveCompileIvyDeps() ++
-          module.transitiveIvyDeps() ++
-          scalaLibIvyDeps()
+          module.transitiveIvyDeps()
       })
       .map(_.map(_.path).toSeq)
 

--- a/integration/test/resources/ammonite/build.sc
+++ b/integration/test/resources/ammonite/build.sc
@@ -22,9 +22,8 @@ trait AmmInternalModule extends mill.scalalib.CrossSbtModule{
     def testFrameworks = Seq("utest.runner.Framework")
     def forkArgs = Seq("-XX:MaxPermSize=2g", "-Xmx4g", "-Dfile.encoding=UTF8")
   }
-  def allIvyDeps = T{transitiveIvyDeps() ++ scalaLibraryIvyDeps()}
   def externalSources = T{
-    resolveDeps(allIvyDeps, sources = true)()
+    resolveDeps(transitiveIvyDeps, sources = true)()
   }
 }
 trait AmmModule extends AmmInternalModule with PublishModule{

--- a/scalalib/src/GenIdeaImpl.scala
+++ b/scalalib/src/GenIdeaImpl.scala
@@ -151,8 +151,7 @@ case class GenIdeaImpl(
         }
 
         val allIvyDeps = T.task {
-          mod.transitiveIvyDeps() ++ scalaLibraryIvyDeps() ++ mod
-            .transitiveCompileIvyDeps()
+          mod.transitiveIvyDeps() ++ mod.transitiveCompileIvyDeps()
         }
 
         val scalaCompilerClasspath = mod match {

--- a/scalalib/src/JavaModule.scala
+++ b/scalalib/src/JavaModule.scala
@@ -73,11 +73,23 @@ trait JavaModule
   }
 
   /**
+   * Mandatory ivy dependencies that shouldn't be removed by
+   * overriding `ivyDeps`
+   */
+  def mandatoryIvyDeps: T[Agg[Dep]] = T { Agg.empty[Dep] }
+
+  /**
    * Any ivy dependencies you want to add to this Module, in the format
    * ivy"org::name:version" for Scala dependencies or ivy"org:name:version"
    * for Java dependencies
    */
   def ivyDeps: T[Agg[Dep]] = T { Agg.empty[Dep] }
+
+  /**
+   * Aggregation of mandatoryIvyDeps and ivyDeps.
+   * In most cases, instead of overriding this Target you want to override `ivyDeps` instead.
+   */
+  def allIvyDeps: T[Agg[Dep]] = T { mandatoryIvyDeps() ++ ivyDeps() }
 
   /**
    * Same as `ivyDeps`, but only present at compile time. Useful for e.g.
@@ -155,7 +167,7 @@ trait JavaModule
    * The transitive ivy dependencies of this module and all it's upstream modules
    */
   def transitiveIvyDeps: T[Agg[Dep]] = T {
-    ivyDeps() ++ T.traverse(moduleDeps)(_.transitiveIvyDeps)().flatten
+    allIvyDeps() ++ T.traverse(moduleDeps)(_.transitiveIvyDeps)().flatten
   }
 
   /**

--- a/scalalib/src/PublishModule.scala
+++ b/scalalib/src/PublishModule.scala
@@ -23,7 +23,7 @@ trait PublishModule extends JavaModule { outer =>
   }
 
   def publishXmlDeps: Task[Agg[Dependency]] = T.task {
-    val ivyPomDeps = ivyDeps().map(resolvePublishDependency().apply(_))
+    val ivyPomDeps = allIvyDeps().map(resolvePublishDependency().apply(_))
 
     val compileIvyPomDeps = compileIvyDeps()
       .map(resolvePublishDependency().apply(_))

--- a/scalalib/src/ScalaModule.scala
+++ b/scalalib/src/ScalaModule.scala
@@ -159,6 +159,10 @@ trait ScalaModule extends JavaModule { outer =>
     scalaRuntimeIvyDeps(scalaOrganization(), scalaVersion())
   }
 
+  override def mandatoryIvyDeps = T {
+    super.mandatoryIvyDeps() ++ scalaLibraryIvyDeps()
+  }
+
   /**
    * Classpath of the Scala Compiler & any compiler plugins
    */
@@ -173,13 +177,13 @@ trait ScalaModule extends JavaModule { outer =>
 
   override def resolvedIvyDeps: T[Agg[PathRef]] = T {
     resolveDeps(T.task {
-      transitiveCompileIvyDeps() ++ scalaLibraryIvyDeps() ++ transitiveIvyDeps()
+      transitiveCompileIvyDeps() ++ transitiveIvyDeps()
     })()
   }
 
   override def resolvedRunIvyDeps: T[Agg[PathRef]] = T {
     resolveDeps(T.task {
-      runIvyDeps() ++ scalaLibraryIvyDeps() ++ transitiveIvyDeps()
+      runIvyDeps() ++ transitiveIvyDeps()
     })()
   }
 
@@ -366,7 +370,7 @@ trait ScalaModule extends JavaModule { outer =>
 
   def resolvedAmmoniteReplIvyDeps = T {
     resolveDeps(T.task {
-      runIvyDeps() ++ scalaLibraryIvyDeps() ++ transitiveIvyDeps() ++
+      runIvyDeps() ++ transitiveIvyDeps() ++
         Agg(ivy"com.lihaoyi:::ammonite:${ammoniteVersion()}")
     })()
   }

--- a/scalalib/test/src/HelloWorldTests.scala
+++ b/scalalib/test/src/HelloWorldTests.scala
@@ -961,5 +961,22 @@ object HelloWorldTests extends TestSuite {
       val Right((_, evalCount)) = eval.apply(Dotty213.foo.run())
       assert(evalCount > 0)
     }
+
+    "pom" - {
+      "should include scala-library dependency" - workspaceTest(HelloWorldWithPublish) { eval =>
+        val Right((result, evalCount)) = eval.apply(HelloWorldWithPublish.core.pom)
+
+        assert(
+          os.exists(result.path),
+          evalCount > 0
+        )
+
+        val pomXml = scala.xml.XML.loadFile(result.path.toString)
+
+        val scalaLibrary = (pomXml \ "dependencies" \ "dependency" \ "artifactId").text
+
+        assert (scalaLibrary == "scala-library")
+      }
+    }
   }
 }

--- a/scalanativelib/src/ScalaNativeModule.scala
+++ b/scalanativelib/src/ScalaNativeModule.scala
@@ -74,6 +74,10 @@ trait ScalaNativeModule extends ScalaModule { outer =>
       )
   }
 
+  override def mandatoryIvyDeps = T {
+    super.mandatoryIvyDeps() ++ nativeIvyDeps()
+  }
+
   def bridgeFullClassPath = T {
     Lib.resolveDependencies(
       Seq(coursier.LocalRepositories.ivy2Local, MavenRepository("https://repo1.maven.org/maven2")),


### PR DESCRIPTION
`PublishModule` extends JavaModule so doesn't know about
`scalaLibraryIvyDeps`. To make it insert the `scalaLibraryIvyDeps`
into the pom we introduce two new targets in `JavaModule`:
`mandatoryIvyDeps` which will contain libraries users unlikely will want
remove, like the content of `scalaLibraryIvyDeps`, and `alIvyDeps`,
which will be useful for consumers to get all the ivyDeps without missing
the mandatory ones.