### PR TITLE
Refined mandatory ivy libs handling

### DIFF
--- a/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
+++ b/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
@@ -370,8 +370,8 @@ class BloopImpl(ev: () => Evaluator, wd: Path) extends ExternalModule { outer =>
 
     val bloopResolution: Task[BloopConfig.Resolution] = T.task {
       val repos = module.repositoriesTask()
-      val allIvyDeps =
-        module.transitiveIvyDeps() ++ module.transitiveCompileIvyDeps()
+      // same as input of resolvedIvyDeps
+      val allIvyDeps = module.transitiveIvyDeps() ++ module.transitiveCompileIvyDeps()
       val coursierDeps =
         allIvyDeps.map(module.resolveCoursierDependency()).toList
       BloopConfig.Resolution(artifacts(repos, coursierDeps))
@@ -381,12 +381,7 @@ class BloopImpl(ev: () => Evaluator, wd: Path) extends ExternalModule { outer =>
     //  Classpath
     ////////////////////////////////////////////////////////////////////////////
 
-    val ivyDepsClasspath = module
-      .resolveDeps(T.task {
-        module.transitiveCompileIvyDeps() ++
-          module.transitiveIvyDeps()
-      })
-      .map(_.map(_.path).toSeq)
+    val ivyDepsClasspath = module.resolvedIvyDeps.map(_.map(_.path).toSeq)
 
     def transitiveClasspath(m: JavaModule): Task[Seq[Path]] = T.task {
       (m.moduleDeps ++ m.compileModuleDeps).map(classes) ++

--- a/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
+++ b/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
@@ -299,11 +299,6 @@ class BloopImpl(ev: () => Evaluator, wd: Path) extends ExternalModule { outer =>
     //  Ivy dependencies + sources
     ////////////////////////////////////////////////////////////////////////////
 
-    val scalaLibraryIvyDeps = module match {
-      case x: ScalaModule => x.scalaLibraryIvyDeps
-      case _ => T.task { Loose.Agg.empty[Dep] }
-    }
-
     /**
      * Resolves artifacts using coursier and creates the corresponding
      * bloop config.
@@ -376,8 +371,7 @@ class BloopImpl(ev: () => Evaluator, wd: Path) extends ExternalModule { outer =>
     val bloopResolution: Task[BloopConfig.Resolution] = T.task {
       val repos = module.repositoriesTask()
       val allIvyDeps =
-        module
-          .transitiveIvyDeps() ++ scalaLibraryIvyDeps() ++ module.transitiveCompileIvyDeps()
+        module.transitiveIvyDeps() ++ module.transitiveCompileIvyDeps()
       val coursierDeps =
         allIvyDeps.map(module.resolveCoursierDependency()).toList
       BloopConfig.Resolution(artifacts(repos, coursierDeps))
@@ -387,16 +381,10 @@ class BloopImpl(ev: () => Evaluator, wd: Path) extends ExternalModule { outer =>
     //  Classpath
     ////////////////////////////////////////////////////////////////////////////
 
-    val scalaLibIvyDeps = module match {
-      case s: ScalaModule => s.scalaLibraryIvyDeps
-      case _ => T.task(Loose.Agg.empty[Dep])
-    }
-
     val ivyDepsClasspath = module
       .resolveDeps(T.task {
         module.transitiveCompileIvyDeps() ++
-          module.transitiveIvyDeps() ++
-          scalaLibIvyDeps()
+          module.transitiveIvyDeps()
       })
       .map(_.map(_.path).toSeq)
 

--- a/integration/test/resources/ammonite/build.sc
+++ b/integration/test/resources/ammonite/build.sc
@@ -22,9 +22,8 @@ trait AmmInternalModule extends mill.scalalib.CrossSbtModule{
     def testFrameworks = Seq("utest.runner.Framework")
     def forkArgs = Seq("-XX:MaxPermSize=2g", "-Xmx4g", "-Dfile.encoding=UTF8")
   }
-  def allIvyDeps = T{transitiveIvyDeps() ++ scalaLibraryIvyDeps()}
   def externalSources = T{
-    resolveDeps(allIvyDeps, sources = true)()
+    resolveDeps(transitiveIvyDeps, sources = true)()
   }
 }
 trait AmmModule extends AmmInternalModule with PublishModule{

--- a/readme.adoc
+++ b/readme.adoc
@@ -215,6 +215,9 @@ corresponding version of Mill.
 
 _Changes since {prev-version}:_
 
+* New `JavaModule.mandatoryIvyDeps` target to provide essential dependencies like scala-library without forcing the user to call `super.ivyDeps`
+* `ScalaJSModule.scalaLibraryIvyDeps` no longer contains the scala-js-library, but only the scala-library; if you need that, use `ScalaJSModule.mandatoryIvyDeps` instead.
+
 _For details refer to
 {link-milestone}/{milestone}?closed=1[milestone {milestone-name}]
 and the {link-compare}/{prev-version}\...{version}[list of commits]._

--- a/scalajslib/src/ScalaJSModule.scala
+++ b/scalajslib/src/ScalaJSModule.scala
@@ -169,8 +169,10 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
       }
     }
   }
-  override def scalaLibraryIvyDeps = T {
-    super.scalaLibraryIvyDeps() ++ Seq(
+
+  /** Adds the Scala.js Library as mandatory dependency. */
+  override def mandatoryIvyDeps = T {
+    super.mandatoryIvyDeps() ++ Seq(
       ivy"org.scala-js::scalajs-library:${scalaJSVersion()}".withDottyCompat(scalaVersion())
     )
   }

--- a/scalalib/src/GenIdeaImpl.scala
+++ b/scalalib/src/GenIdeaImpl.scala
@@ -151,8 +151,7 @@ case class GenIdeaImpl(
         }
 
         val allIvyDeps = T.task {
-          mod.transitiveIvyDeps() ++ scalaLibraryIvyDeps() ++ mod
-            .transitiveCompileIvyDeps()
+          mod.transitiveIvyDeps() ++ mod.transitiveCompileIvyDeps()
         }
 
         val scalaCompilerClasspath = mod match {

--- a/scalalib/src/GenIdeaImpl.scala
+++ b/scalalib/src/GenIdeaImpl.scala
@@ -128,28 +128,19 @@ case class GenIdeaImpl(
             res.items.toList.map(_.path)
         }
 
-    val buildDepsPaths = Try(
-      evaluator.rootModule.getClass.getClassLoader
-        .asInstanceOf[SpecialClassLoader]
-    )
-      .map {
-        _.allJars
-          .map(url => os.Path(url.getFile))
-          .filter(_.toIO.exists)
-      }
-      .getOrElse(Seq())
+    val buildDepsPaths =
+      Try(evaluator.rootModule.getClass.getClassLoader.asInstanceOf[SpecialClassLoader])
+        .map {
+          _.allJars
+            .map(url => os.Path(url.getFile))
+            .filter(_.toIO.exists)
+        }
+        .getOrElse(Seq())
 
     def resolveTasks: Seq[Task[ResolvedModule]] = modules.map {
       case (path, mod) => {
 
-        val scalaLibraryIvyDeps = mod match {
-          case x: ScalaModule => x.scalaLibraryIvyDeps
-          case _ =>
-            T.task {
-              Loose.Agg.empty[Dep]
-            }
-        }
-
+        // same as input of resolvedIvyDeps
         val allIvyDeps = T.task {
           mod.transitiveIvyDeps() ++ mod.transitiveCompileIvyDeps()
         }
@@ -163,11 +154,11 @@ case class GenIdeaImpl(
         }
 
         val externalLibraryDependencies = T.task {
-          mod.resolveDeps(scalaLibraryIvyDeps)()
+          mod.resolveDeps(mod.mandatoryIvyDeps)()
         }
 
         val externalDependencies = T.task {
-          mod.resolveDeps(allIvyDeps)() ++
+          mod.resolvedIvyDeps() ++
             T.traverse(mod.transitiveModuleDeps)(_.unmanagedClasspath)().flatten
         }
         val extCompileIvyDeps = mod.resolveDeps(mod.compileIvyDeps)
@@ -247,9 +238,9 @@ case class GenIdeaImpl(
     val moduleLabels = modules.map(_.swap).toMap
 
     val allResolved: Seq[Path] =
-      (resolved.flatMap(_.classpath).map(_.value) ++
-        buildLibraryPaths ++
-        buildDepsPaths).distinct
+      (resolved.flatMap(_.classpath).map(_.value) ++ buildLibraryPaths ++ buildDepsPaths)
+        .distinct
+        .sorted
 
     val librariesProperties = resolved
       .flatMap(x => x.libraryClasspath.map(_ -> x.compilerClasspath))

--- a/scalalib/src/JavaModule.scala
+++ b/scalalib/src/JavaModule.scala
@@ -73,11 +73,23 @@ trait JavaModule
   }
 
   /**
+   * Mandatory ivy dependencies that shouldn't be removed by
+   * overriding `ivyDeps`
+   */
+  def mandatoryIvyDeps: T[Agg[Dep]] = T { Agg.empty[Dep] }
+
+  /**
    * Any ivy dependencies you want to add to this Module, in the format
    * ivy"org::name:version" for Scala dependencies or ivy"org:name:version"
    * for Java dependencies
    */
   def ivyDeps: T[Agg[Dep]] = T { Agg.empty[Dep] }
+
+  /**
+   * Aggregation of mandatoryIvyDeps and ivyDeps.
+   * In most cases, instead of overriding this Target you want to override `ivyDeps` instead.
+   */
+  def allIvyDeps: T[Agg[Dep]] = T { mandatoryIvyDeps() ++ ivyDeps() }
 
   /**
    * Same as `ivyDeps`, but only present at compile time. Useful for e.g.
@@ -155,7 +167,7 @@ trait JavaModule
    * The transitive ivy dependencies of this module and all it's upstream modules
    */
   def transitiveIvyDeps: T[Agg[Dep]] = T {
-    ivyDeps() ++ T.traverse(moduleDeps)(_.transitiveIvyDeps)().flatten
+    allIvyDeps() ++ T.traverse(moduleDeps)(_.transitiveIvyDeps)().flatten
   }
 
   /**

--- a/scalalib/src/PublishModule.scala
+++ b/scalalib/src/PublishModule.scala
@@ -23,7 +23,7 @@ trait PublishModule extends JavaModule { outer =>
   }
 
   def publishXmlDeps: Task[Agg[Dependency]] = T.task {
-    val ivyPomDeps = ivyDeps().map(resolvePublishDependency().apply(_))
+    val ivyPomDeps = allIvyDeps().map(resolvePublishDependency().apply(_))
 
     val compileIvyPomDeps = compileIvyDeps()
       .map(resolvePublishDependency().apply(_))

--- a/scalalib/src/PublishModule.scala
+++ b/scalalib/src/PublishModule.scala
@@ -23,7 +23,7 @@ trait PublishModule extends JavaModule { outer =>
   }
 
   def publishXmlDeps: Task[Agg[Dependency]] = T.task {
-    val ivyPomDeps = allIvyDeps().map(resolvePublishDependency().apply(_))
+    val ivyPomDeps = (ivyDeps() ++ mandatoryIvyDeps()).map(resolvePublishDependency().apply(_))
 
     val compileIvyPomDeps = compileIvyDeps()
       .map(resolvePublishDependency().apply(_))

--- a/scalalib/src/ScalaModule.scala
+++ b/scalalib/src/ScalaModule.scala
@@ -3,13 +3,12 @@ package scalalib
 
 import coursier.{Dependency, Repository}
 import mill.define.{Command, Sources, Target, Task, TaskModule}
-import mill.api.{PathRef, Result}
+import mill.api.{DummyInputStream, Loose, PathRef, Result}
 import mill.modules.Jvm
 import mill.modules.Jvm.createJar
 import mill.scalalib.api.Util.{isDotty, isDottyOrScala3, isScala3, isScala3Milestone}
 import Lib._
 import mill.api.Loose.Agg
-import mill.api.DummyInputStream
 
 /**
  * Core configuration required to compile a single Scala compilation target
@@ -155,11 +154,12 @@ trait ScalaModule extends JavaModule { outer =>
     resolveDeps(scalaDocPluginIvyDeps)()
   }
 
-  def scalaLibraryIvyDeps = T {
+  def scalaLibraryIvyDeps: T[Agg[Dep]] = T {
     scalaRuntimeIvyDeps(scalaOrganization(), scalaVersion())
   }
 
-  override def mandatoryIvyDeps = T {
+  /** Adds the Scala Library is a mandatory dependency. */
+  override def mandatoryIvyDeps: T[Agg[Dep]] = T {
     super.mandatoryIvyDeps() ++ scalaLibraryIvyDeps()
   }
 
@@ -175,20 +175,7 @@ trait ScalaModule extends JavaModule { outer =>
     )()
   }
 
-  override def resolvedIvyDeps: T[Agg[PathRef]] = T {
-    resolveDeps(T.task {
-      transitiveCompileIvyDeps() ++ transitiveIvyDeps()
-    })()
-  }
-
-  override def resolvedRunIvyDeps: T[Agg[PathRef]] = T {
-    resolveDeps(T.task {
-      runIvyDeps() ++ transitiveIvyDeps()
-    })()
-  }
-
   override def compile: T[mill.scalalib.api.CompilationResult] = T.persistent {
-
     zincWorker
       .worker()
       .compileMixed(
@@ -207,7 +194,7 @@ trait ScalaModule extends JavaModule { outer =>
 
   override def docSources: Sources = T.sources {
     // Scaladoc 3.0.0 is consuming tasty files
-    if(isScala3(scalaVersion()) && !isScala3Milestone(scalaVersion())) Seq(compile().classes)
+    if (isScala3(scalaVersion()) && !isScala3Milestone(scalaVersion())) Seq(compile().classes)
     else allSources()
   }
 
@@ -424,7 +411,7 @@ trait ScalaModule extends JavaModule { outer =>
     ()
   }
 
-  override def manifest: T[Jvm.JarManifest] = T{
+  override def manifest: T[Jvm.JarManifest] = T {
     super.manifest().add("Scala-Version" -> scalaVersion())
   }
 }

--- a/scalalib/src/ScalaModule.scala
+++ b/scalalib/src/ScalaModule.scala
@@ -159,6 +159,10 @@ trait ScalaModule extends JavaModule { outer =>
     scalaRuntimeIvyDeps(scalaOrganization(), scalaVersion())
   }
 
+  override def mandatoryIvyDeps = T {
+    super.mandatoryIvyDeps() ++ scalaLibraryIvyDeps()
+  }
+
   /**
    * Classpath of the Scala Compiler & any compiler plugins
    */
@@ -173,13 +177,13 @@ trait ScalaModule extends JavaModule { outer =>
 
   override def resolvedIvyDeps: T[Agg[PathRef]] = T {
     resolveDeps(T.task {
-      transitiveCompileIvyDeps() ++ scalaLibraryIvyDeps() ++ transitiveIvyDeps()
+      transitiveCompileIvyDeps() ++ transitiveIvyDeps()
     })()
   }
 
   override def resolvedRunIvyDeps: T[Agg[PathRef]] = T {
     resolveDeps(T.task {
-      runIvyDeps() ++ scalaLibraryIvyDeps() ++ transitiveIvyDeps()
+      runIvyDeps() ++ transitiveIvyDeps()
     })()
   }
 
@@ -366,7 +370,7 @@ trait ScalaModule extends JavaModule { outer =>
 
   def resolvedAmmoniteReplIvyDeps = T {
     resolveDeps(T.task {
-      runIvyDeps() ++ scalaLibraryIvyDeps() ++ transitiveIvyDeps() ++
+      runIvyDeps() ++ transitiveIvyDeps() ++
         Agg(ivy"com.lihaoyi:::ammonite:${ammoniteVersion()}")
     })()
   }

--- a/scalalib/test/src/HelloWorldTests.scala
+++ b/scalalib/test/src/HelloWorldTests.scala
@@ -961,5 +961,22 @@ object HelloWorldTests extends TestSuite {
       val Right((_, evalCount)) = eval.apply(Dotty213.foo.run())
       assert(evalCount > 0)
     }
+
+    "pom" - {
+      "should include scala-library dependency" - workspaceTest(HelloWorldWithPublish) { eval =>
+        val Right((result, evalCount)) = eval.apply(HelloWorldWithPublish.core.pom)
+
+        assert(
+          os.exists(result.path),
+          evalCount > 0
+        )
+
+        val pomXml = scala.xml.XML.loadFile(result.path.toString)
+
+        val scalaLibrary = (pomXml \ "dependencies" \ "dependency" \ "artifactId").text
+
+        assert (scalaLibrary == "scala-library")
+      }
+    }
   }
 }

--- a/scalanativelib/src/ScalaNativeModule.scala
+++ b/scalanativelib/src/ScalaNativeModule.scala
@@ -74,6 +74,10 @@ trait ScalaNativeModule extends ScalaModule { outer =>
       )
   }
 
+  override def mandatoryIvyDeps = T {
+    super.mandatoryIvyDeps() ++ nativeIvyDeps()
+  }
+
   def bridgeFullClassPath = T {
     Lib.resolveDependencies(
       Seq(coursier.LocalRepositories.ivy2Local, MavenRepository("https://repo1.maven.org/maven2")),


### PR DESCRIPTION
Add `JavaModule.mandatoryIvyDeps` target to contain typical required ivy dependencies without the need to override and include `super.ivyDeps`.

This fixes #1487 and streamlines platform dependency handling for downstream modules like `ScalaModule`, `ScalaJSModule`, `ScalaNativeModule`. It's probably also useful for other modules which need to bring-in additional dependencies.

This PR includes and refines PR #1489.

