### PR TITLE
Fix broken link in shell script.

### DIFF
--- a/mill
+++ b/mill
@@ -34,7 +34,7 @@ if [ ! -s "$MILL_EXEC_PATH" ] ; then
     ASSEMBLY="-assembly"
   fi
   DOWNLOAD_FILE=$MILL_EXEC_PATH-tmp-download
-  MILL_DOWNLOAD_URL="https://github.com/lihaoyi/mill/releases/download/${MILL_VERSION%%-*}/$MILL_VERSION${ASSEMBLY}"
+  MILL_DOWNLOAD_URL="https://github.com/com-lihaoyi/mill/releases/download/${MILL_VERSION}/$MILL_VERSION${ASSEMBLY}"
   curl --fail -L -o "$DOWNLOAD_FILE" "$MILL_DOWNLOAD_URL"
   chmod +x "$DOWNLOAD_FILE"
   mv "$DOWNLOAD_FILE" "$MILL_EXEC_PATH"


### PR DESCRIPTION
Shell script was trying to download a file from a non-existing release (`0.10.0`) instead of `0.10.0-M2`.