### PR TITLE
Fixed bootstrap tests

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -858,7 +858,7 @@ object dev extends MillModule {
   override def assembly = T{
     val isWin = scala.util.Properties.isWin
     val millPath = T.ctx.dest / (if (isWin) "mill.bat" else "mill")
-    os.move(super.assembly().path, millPath)
+    os.copy(super.assembly().path, millPath)
     PathRef(millPath)
   }
 

--- a/ci/test-mill-bootstrap-0.sh
+++ b/ci/test-mill-bootstrap-0.sh
@@ -8,8 +8,7 @@ git stash -a
 
 # First build
 ./mill -i "{__.publishLocal,dev.assembly}"
-mkdir -p target
-cp out/dev/assembly/dest/mill target/mill-1
+cp out/dev/assembly/dest/mill ~/mill-1
 
 # Clean up
 git stash -u
@@ -25,9 +24,8 @@ echo "Build 2" > info.txt && git add info.txt && git commit -m "Add info.txt"
 ci/patch-mill-bootstrap.sh
 
 # Second build
-target/mill-1 -i "{__.publishLocal,dev.assembly}"
-mkdir -p target
-cp out/dev/assembly/dest/mill target/mill-2
+~/mill-1 -i "{__.publishLocal,dev.assembly}"
+cp out/dev/assembly/dest/mill ~/mill-2
 
 # Clean up
 git stash -u
@@ -39,4 +37,4 @@ rm -rf ~/.mill/ammonite
 ci/patch-mill-bootstrap.sh
 
 # Use second build to run tests using Mill
-target/mill-2 -i all {main,scalalib,scalajslib,scalanativelib,bsp}.__.test
+~/mill-2 -i all {main,scalalib,scalajslib,scalanativelib,bsp}.__.test

--- a/ci/test-mill-bootstrap-0.sh
+++ b/ci/test-mill-bootstrap-0.sh
@@ -8,7 +8,7 @@ git stash -a
 
 # First build
 ./mill -i "{__.publishLocal,dev.assembly}"
-cp out/dev/assembly/dest/mill ~/mill-1
+cp -v out/dev/assembly/dest/mill ~/mill-1
 
 # Clean up
 git stash -u
@@ -25,7 +25,7 @@ ci/patch-mill-bootstrap.sh
 
 # Second build
 ~/mill-1 -i "{__.publishLocal,dev.assembly}"
-cp out/dev/assembly/dest/mill ~/mill-2
+cp -v out/dev/assembly/dest/mill ~/mill-2
 
 # Clean up
 git stash -u

--- a/ci/test-mill-bootstrap-0.sh
+++ b/ci/test-mill-bootstrap-0.sh
@@ -7,14 +7,14 @@ git stash -u
 git stash -a
 
 # First build
-./mill -i all __.publishLocal launcher
-cp out/launcher/dest/mill ~/mill-1
+./mill -i "{__.publishLocal,dev.assembly}"
+cp out/dev/assembly/dest/mill target/mill-1
 
 # Clean up
 git stash -u
 git stash -a
 
-rm -rf ~/.mill
+rm -rf ~/.mill/ammonite
 
 # Differentiate first and second builds
 git config --global user.name "Your Name"
@@ -24,17 +24,17 @@ echo "Build 2" > info.txt && git add info.txt && git commit -m "Add info.txt"
 ci/patch-mill-bootstrap.sh
 
 # Second build
-~/mill-1 -i all __.publishLocal launcher
-cp out/launcher/dest/mill ~/mill-2
+target/mill-1 -i "{__.publishLocal,dev.assembly}"
+cp out/dev/assembly/dest/mill target/mill-2
 
 # Clean up
 git stash -u
 git stash -a
 
-rm -rf ~/.mill
+rm -rf ~/.mill/ammonite
 
 # Patch local build
 ci/patch-mill-bootstrap.sh
 
 # Use second build to run tests using Mill
-~/mill-2 -i all {main,scalalib,scalajslib,scalanativelib,bsp}.__.test
+target/mill-2 -i all {main,scalalib,scalajslib,scalanativelib,bsp}.__.test

--- a/ci/test-mill-bootstrap-0.sh
+++ b/ci/test-mill-bootstrap-0.sh
@@ -7,8 +7,8 @@ git stash -u
 git stash -a
 
 # First build
-./mill -i "{__.publishLocal,dev.assembly}"
-cp -v out/dev/assembly/dest/mill ~/mill-1
+./mill -i "{__.publishLocal,assembly}"
+cp out/assembly/dest/mill ~/mill-1
 
 # Clean up
 git stash -u
@@ -24,8 +24,8 @@ echo "Build 2" > info.txt && git add info.txt && git commit -m "Add info.txt"
 ci/patch-mill-bootstrap.sh
 
 # Second build
-~/mill-1 -i "{__.publishLocal,dev.assembly}"
-cp -v out/dev/assembly/dest/mill ~/mill-2
+~/mill-1 -i "{__.publishLocal,assembly}"
+cp out/assembly/dest/mill ~/mill-2
 
 # Clean up
 git stash -u

--- a/ci/test-mill-bootstrap-0.sh
+++ b/ci/test-mill-bootstrap-0.sh
@@ -8,6 +8,7 @@ git stash -a
 
 # First build
 ./mill -i "{__.publishLocal,dev.assembly}"
+mkdir -p target
 cp out/dev/assembly/dest/mill target/mill-1
 
 # Clean up
@@ -25,6 +26,7 @@ ci/patch-mill-bootstrap.sh
 
 # Second build
 target/mill-1 -i "{__.publishLocal,dev.assembly}"
+mkdir -p target
 cp out/dev/assembly/dest/mill target/mill-2
 
 # Clean up

--- a/ci/test-mill-bootstrap-1.sh
+++ b/ci/test-mill-bootstrap-1.sh
@@ -8,8 +8,7 @@ git stash -a
 
 # First build
 ./mill -i "{__.publishLocal,dev.assembly}"
-mkdir -p target
-cp out/dev/assembly/dest/mill target/mill-1
+cp out/dev/assembly/dest/mill ~/mill-1
 
 # Clean up
 git stash -u
@@ -25,9 +24,8 @@ echo "Build 2" > info.txt && git add info.txt && git commit -m "Add info.txt"
 ci/patch-mill-bootstrap.sh
 
 # Second build
-target/mill-1 -i "{__.publishLocal,dev.assembly}"
-mkdir -p target
-cp out/dev/assembly/dest/mill target/mill-2
+~/mill-1 -i "{__.publishLocal,dev.assembly}"
+cp out/dev/assembly/dest/mill ~/mill-2
 
 # Clean up
 git stash -u
@@ -39,4 +37,4 @@ rm -rf ~/.mill/ammonite
 ci/patch-mill-bootstrap.sh
 
 # Use second build to run tests using Mill
-target/mill-2 -i all contrib.__.test
+~/mill-2 -i all contrib.__.test

--- a/ci/test-mill-bootstrap-1.sh
+++ b/ci/test-mill-bootstrap-1.sh
@@ -7,8 +7,8 @@ git stash -u
 git stash -a
 
 # First build
-./mill -i "{__.publishLocal,dev.assembly}"
-cp out/dev/assembly/dest/mill ~/mill-1
+./mill -i "{__.publishLocal,assembly}"
+cp out/assembly/dest/mill ~/mill-1
 
 # Clean up
 git stash -u
@@ -24,8 +24,8 @@ echo "Build 2" > info.txt && git add info.txt && git commit -m "Add info.txt"
 ci/patch-mill-bootstrap.sh
 
 # Second build
-~/mill-1 -i "{__.publishLocal,dev.assembly}"
-cp out/dev/assembly/dest/mill ~/mill-2
+~/mill-1 -i "{__.publishLocal,assembly}"
+cp out/assembly/dest/mill ~/mill-2
 
 # Clean up
 git stash -u

--- a/ci/test-mill-bootstrap-1.sh
+++ b/ci/test-mill-bootstrap-1.sh
@@ -8,6 +8,7 @@ git stash -a
 
 # First build
 ./mill -i "{__.publishLocal,dev.assembly}"
+mkdir -p target
 cp out/dev/assembly/dest/mill target/mill-1
 
 # Clean up
@@ -25,6 +26,7 @@ ci/patch-mill-bootstrap.sh
 
 # Second build
 target/mill-1 -i "{__.publishLocal,dev.assembly}"
+mkdir -p target
 cp out/dev/assembly/dest/mill target/mill-2
 
 # Clean up

--- a/ci/test-mill-bootstrap-1.sh
+++ b/ci/test-mill-bootstrap-1.sh
@@ -7,14 +7,14 @@ git stash -u
 git stash -a
 
 # First build
-./mill -i all __.publishLocal launcher
-cp out/launcher/dest/mill ~/mill-1
+./mill -i "{__.publishLocal,dev.assembly}"
+cp out/dev/assembly/dest/mill target/mill-1
 
 # Clean up
 git stash -u
 git stash -a
 
-rm -rf ~/.mill
+rm -rf ~/.mill/ammonite
 
 # Differentiate first and second builds
 git config --global user.name "Your Name"
@@ -24,17 +24,17 @@ echo "Build 2" > info.txt && git add info.txt && git commit -m "Add info.txt"
 ci/patch-mill-bootstrap.sh
 
 # Second build
-~/mill-1 -i all __.publishLocal launcher
-cp out/launcher/dest/mill ~/mill-2
+target/mill-1 -i "{__.publishLocal,dev.assembly}"
+cp out/dev/assembly/dest/mill target/mill-2
 
 # Clean up
 git stash -u
 git stash -a
 
-rm -rf ~/.mill
+rm -rf ~/.mill/ammonite
 
 # Patch local build
 ci/patch-mill-bootstrap.sh
 
 # Use second build to run tests using Mill
-~/mill-2 -i all contrib.__.test
+target/mill-2 -i all contrib.__.test

--- a/ci/test-mill-dev.sh
+++ b/ci/test-mill-dev.sh
@@ -9,7 +9,7 @@ git stash -a
 # Build Mill
 ./mill -i dev.assembly
 
-rm -rf ~/.mill
+rm -rf ~/.mill/ammonite
 
 # Patch local build
 ci/patch-mill-bootstrap.sh

--- a/ci/test-mill-release.sh
+++ b/ci/test-mill-release.sh
@@ -13,7 +13,7 @@ ci/publish-local.sh
 git stash -u
 git stash -a
 
-rm -rf ~/.mill
+rm -rf ~/.mill/ammonite
 
 # Patch local build
 ci/patch-mill-bootstrap.sh

--- a/scalalib/src/ScalaModule.scala
+++ b/scalalib/src/ScalaModule.scala
@@ -291,6 +291,7 @@ trait ScalaModule extends JavaModule { outer =>
         ),
         docSources()
           .map(_.path)
+          .filter(os.exists)
           .flatMap(os.walk(_))
           .filter(_.ext == "tasty")
           .map(_.toString),
@@ -304,6 +305,7 @@ trait ScalaModule extends JavaModule { outer =>
         Seq("-d", javadocDir.toNIO.toString),
         docSources()
           .map(_.path)
+          .filter(os.exists)
           .flatMap(os.walk(_))
           .filter(os.isFile)
           .map(_.toString),


### PR DESCRIPTION
We need to use the assembly instead of the script.
If we use the script, it will read the `.mill-version` file and run with the wrong version.

Fix an potential issue with non-existant paths in `ScalaModule.docJar` target.