### PR TITLE
mill script: Support milestone versions in download URL

### DIFF
--- a/mill
+++ b/mill
@@ -34,7 +34,8 @@ if [ ! -s "$MILL_EXEC_PATH" ] ; then
     ASSEMBLY="-assembly"
   fi
   DOWNLOAD_FILE=$MILL_EXEC_PATH-tmp-download
-  MILL_DOWNLOAD_URL="https://github.com/lihaoyi/mill/releases/download/${MILL_VERSION%%-*}/$MILL_VERSION${ASSEMBLY}"
+  MILL_VERSION_TAG=$(echo $MILL_VERSION | sed 's/\([^-]+\)\(-M[0-9]+\)?\(-.*\)?/\1\2/')
+  MILL_DOWNLOAD_URL="https://github.com/lihaoyi/mill/releases/download/${MILL_VERSION_TAG}/$MILL_VERSION${ASSEMBLY}"
   curl --fail -L -o "$DOWNLOAD_FILE" "$MILL_DOWNLOAD_URL"
   chmod +x "$DOWNLOAD_FILE"
   mv "$DOWNLOAD_FILE" "$MILL_EXEC_PATH"


### PR DESCRIPTION
Mill milestone releases have an additional milestone part in the version, so that current version parser fails to get the right download URL (based on git tag).

This fixes #1503 and supersedes #1496.

FIx initially developed for millw: https://github.com/lefou/millw/pull/20