### PR TITLE
Removed incorrect example about excluding scala-lib from assembly

### DIFF
--- a/docs/antora/modules/ROOT/pages/Configuring_Mill.adoc
+++ b/docs/antora/modules/ROOT/pages/Configuring_Mill.adoc
@@ -594,21 +594,6 @@ object foo extends ScalaModule {
 }
 ----
 
-To exclude Scala library from assembly
-
-.`build.sc`
-[source,scala]
-----
-import mill._, scalalib._
-import mill.modules.Assembly._
-
-object foo extends ScalaModule {
-  def scalaVersion = "2.12.4"
-
-  def scalaLibraryIvyDeps = T { Agg.empty }
-}
-----
-
 == Downloading Non-Maven Jars
 
 .`build.sc`


### PR DESCRIPTION
After fixing the documentation, we can also close #818