### PR TITLE
Ensure `-D` property passing correctly resets when `-D` is later removed

### DIFF
--- a/main/core/src/eval/Evaluator.scala
+++ b/main/core/src/eval/Evaluator.scala
@@ -605,7 +605,8 @@ object Evaluator {
       rootModule: mill.define.BaseModule,
       classLoaderSig: Seq[(Either[String, java.net.URL], Long)],
       workerCache: mutable.Map[Segments, (Int, Any)],
-      watched: Seq[(ammonite.interp.Watchable, Long)]
+      watched: Seq[(ammonite.interp.Watchable, Long)],
+      setSystemProperties: Set[String]
   )
   // This needs to be a ThreadLocal because we need to pass it into the body of
   // the TargetScopt#read call, which does not accept additional parameters.

--- a/main/src/MillMain.scala
+++ b/main/src/MillMain.scala
@@ -271,7 +271,8 @@ object MillMain {
                   systemProperties = systemProps,
                   threadCount = threadCount,
                   ringBell = config.ringBell.value,
-                  wd = os.pwd
+                  wd = os.pwd,
+                  initialSystemProperties = initialSystemProperties
                 )
 
                 if (mill.main.client.Util.isJava9OrAbove) {

--- a/main/src/main/MainRunner.scala
+++ b/main/src/main/MainRunner.scala
@@ -34,7 +34,8 @@ class MainRunner(
     systemProperties: Map[String, String],
     threadCount: Option[Int],
     ringBell: Boolean,
-    wd: os.Path
+    wd: os.Path,
+    initialSystemProperties: Map[String, String]
 ) extends ammonite.MainRunner(
       cliConfig = config,
       outprintStream = outprintStream,
@@ -125,7 +126,8 @@ class MainRunner(
           env = env,
           keepGoing = keepGoing,
           systemProperties = systemProperties,
-          threadCount = threadCount
+          threadCount = threadCount,
+          initialSystemProperties = initialSystemProperties
         )
 
         result match {
@@ -136,7 +138,8 @@ class MainRunner(
               rootModule = eval.rootModule,
               classLoaderSig = eval.classLoaderSig,
               workerCache = eval.workerCache,
-              watched = interpWatched
+              watched = interpWatched,
+              setSystemProperties = systemProperties.keySet
             ))
             val watched = () => {
               val alreadyStale = evalWatches.exists(p => p.sig != PathRef(p.path, p.quick).sig)


### PR DESCRIPTION
The issue here is that we were not properly resetting the system property when `-D` was removed, resulting in it incorrectly hanging around with the last set value. 

This PR stores the initial value of every system property, along with the keys for the system properties set with `-D` for each run. Now when a `-D` key-value pair is removed, we can compare the key against the `initialSystemProperties` to decide whether we need to either remove the key value or to restore it to its original value

Tested manually using a simple `build.sc`:

```scala
val foo = interp.watchValue(sys.props.get("foo"))

val osname = interp.watchValue(sys.props.get("os.name"))

def bar() = T.command{ println(s"$foo $osname") }
```

On main, removing `-D` flags leaves the properties hanging around with the last set value:

```bash
lihaoyi mill$ ./mill -i dev.run ../test -D foo=a -D os.name=lols bar
...
Some(a) Some(lols)

lihaoyi mill$ ./mill -i dev.run ../test  bar
...
Some(a) Some(lols)
```

With this PR, removing the `-D flags has the properties either cleared or reset to their initial value:

```bash
lihaoyi mill$ ./mill -i dev.run ../test -D foo=a -D os.name=lols bar
...
Some(a) Some(lols)

lihaoyi mill$ ./mill -i dev.run ../test  bar
...
None Some(Mac OS X)
```

Review by @lefou 