### PR TITLE
Update coursier version to 2.0.16-158-gbdc8669f9

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -72,7 +72,7 @@ object Deps {
   )
   val asciidoctorj = ivy"org.asciidoctor:asciidoctorj:2.4.3"
   val bloopConfig = ivy"ch.epfl.scala::bloop-config:1.4.9"
-  val coursier = ivy"io.get-coursier::coursier:2.0.16+73-gddc6d9cc9"
+  val coursier = ivy"io.get-coursier::coursier:2.0.16-158-gbdc8669f9"
   val flywayCore = ivy"org.flywaydb:flyway-core:6.5.7"
   val graphvizJava = ivy"guru.nidi:graphviz-java:0.18.1"
   // Warning: Avoid ipcsocket version 1.3.0, as it caused many failures on CI


### PR DESCRIPTION
This fixes some property activation for Maven dependencies, which may cause resolution failures for newer JavaFX dependencies.

See https://github.com/coursier/coursier/pull/2176
