### PR TITLE
Initial work for scoverage 2.0

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -107,7 +107,7 @@ object Deps {
   val scalafmtDynamic = ivy"org.scalameta::scalafmt-dynamic:3.0.6"
   val scalametaTrees = ivy"org.scalameta::trees:4.4.29"
   def scalaReflect(scalaVersion: String) = ivy"org.scala-lang:scala-reflect:${scalaVersion}"
-  def scalacScoveragePlugin = ivy"org.scoverage:::scalac-scoverage-plugin:1.4.9"
+  def scalacScoverageReporter = ivy"org.scoverage::scalac-scoverage-reporter:2.0.0-M2"
   val sourcecode = ivy"com.lihaoyi::sourcecode:0.2.7"
   val upickle = ivy"com.lihaoyi::upickle:1.4.2"
   val utest = ivy"com.lihaoyi::utest:0.7.10"
@@ -573,7 +573,7 @@ object contrib extends MillModule {
       override def compileIvyDeps = T{
         Agg(
           // compile-time only, need to provide the correct scoverage version runtime
-          Deps.scalacScoveragePlugin,
+          Deps.scalacScoverageReporter,
           // provided by mill runtime
           Deps.osLib
         )

--- a/contrib/scoverage/api/src/ScoverageReportWorkerApi.scala
+++ b/contrib/scoverage/api/src/ScoverageReportWorkerApi.scala
@@ -5,7 +5,12 @@ import mill.api.Ctx
 trait ScoverageReportWorkerApi {
   import ScoverageReportWorkerApi._
 
-  def report(reportType: ReportType, sources: Seq[os.Path], dataDirs: Seq[os.Path])(implicit
+  def report(
+      reportType: ReportType,
+      sources: Seq[os.Path],
+      dataDirs: Seq[os.Path],
+      sourceRoot: os.Path
+  )(implicit
       ctx: Ctx
   ): Unit
 }

--- a/contrib/scoverage/src/ScoverageReport.scala
+++ b/contrib/scoverage/src/ScoverageReport.scala
@@ -106,7 +106,7 @@ trait ScoverageReport extends Module {
       scoverageReportWorkerModule
         .scoverageReportWorker()
         .bridge(workerModule.scoverageToolsClasspath().map(_.path))
-        .report(reportType, sourcePaths, dataPaths)
+        .report(reportType, sourcePaths, dataPaths, T.workspace)
       PathRef(T.dest)
     }
   }

--- a/contrib/scoverage/test/src/HelloWorldTests.scala
+++ b/contrib/scoverage/test/src/HelloWorldTests.scala
@@ -106,7 +106,11 @@ trait HelloWorldTests extends utest.TestSuite {
               eval.apply(HelloWorld.core.scoverage.scalacPluginIvyDeps)
 
             assert(
-              result == Agg(ivy"org.scoverage:::scalac-scoverage-plugin:${testScoverageVersion}"),
+              result == Agg(
+                ivy"org.scoverage:::scalac-scoverage-plugin:${testScoverageVersion}",
+                ivy"org.scoverage::scalac-scoverage-domain:${testScoverageVersion}",
+                ivy"org.scoverage::scalac-scoverage-serializer:${testScoverageVersion}"
+              ),
               evalCount > 0
             )
           }
@@ -190,21 +194,14 @@ trait HelloWorldTests extends utest.TestSuite {
 
 object HelloWorldTests_2_12 extends HelloWorldTests {
   override def threadCount = Some(1)
-  override def testScalaVersion: String = "2.12.14"
-  override def testScoverageVersion = "1.4.9"
+  override def testScalaVersion: String = "2.12.15"
+  override def testScoverageVersion = "2.0.0-M4"
   override def testScalatestVersion = "3.0.8"
 }
 
 object HelloWorldTests_2_13 extends HelloWorldTests {
   override def threadCount = Some(1)
-  override def testScalaVersion: String = "2.13.6"
-  override def testScoverageVersion = "1.4.9"
+  override def testScalaVersion: String = "2.13.7"
+  override def testScoverageVersion = "2.0.0-M4"
   override def testScalatestVersion = "3.0.8"
 }
-
-//object HelloWorldParTests_2_13 extends HelloWorldTests {
-//  override def threadCount: Some[Int] = Some(4)
-//  override def testScalaVersion: String = "2.13.6"
-//  override def testScoverageVersion = "1.4.8"
-//  override def testScalatestVersion = "3.0.8"
-//}


### PR DESCRIPTION
[scoverage 2.x](https://github.com/scoverage/scalac-scoverage-plugin/releases/tag/v2.0.0-M2) makes a few changes to the structure of the scoverage project, including the artifacts, and also will allow for Scala 3 support once https://github.com/lampepfl/dotty/pull/13880 gets merged. I wasn't super familiar with how mill was using it, so this was just me learning a bit and updating some of the things I saw. However, it introduces a few questions that I'd love to get your thoughts on.

This is a breaking change that won't easily allow for users to use 1.x anymore. Are you ok with that? Once scoverage bumps to 2.x it will be pretty much impossible to support both 1.x and 2.x for integrations since the structure is quite different, even some of the package names, method signatures etc. In the sbt plugin once I officially bump I'll error out if someone manually tries to use 1.x in the 2.x series of the plugin. What are you thoughts on something like that in Mill?

I'll ask the other question in the parts of the code to make them clearer.

I'll leave this as a draft for now but will iterate on it since there is a few things we'll need to update if you're ok with the 2.x approach listed above.

- [ ] Add some messages to make it clear to the user that once on 2.x they need to use 2.x
- [ ] Add in the logic to determine if the user is using Scala 2 or 3. If 3, then just set the `-coverage` flag and the datadir
- [ ] Add some stuff to the tests to cover both the Scala 2 and Scala 3 usecase