### PR TITLE
backport 1521

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -92,7 +92,8 @@ jobs:
         run: ${{ matrix.buildcmd }}
 
   publish-sonatype:
-    if: github.repository == 'com-lihaoyi/mill' && github.ref == 'refs/heads/main'
+    # when in master repo: all commits to main branch and all additional tags
+    if: github.repository == 'com-lihaoyi/mill' && ( github.ref == 'refs/heads/main' || (github.ref != 'refs/heads/main' && startsWith( github.ref, 'refs/tags/') ) )
     needs: [test, test-windows]
 
     runs-on: ubuntu-latest
@@ -118,7 +119,8 @@ jobs:
       - run: ci/release-maven.sh
 
   release-github:
-    if: github.repository == 'com-lihaoyi/mill' && github.ref == 'refs/heads/main'
+    # when in master repo: all commits to main branch and all additional tags
+    if: github.repository == 'com-lihaoyi/mill' && ( github.ref == 'refs/heads/main' || (github.ref != 'refs/heads/main' && startsWith( github.ref, 'refs/tags/') ) )
     needs: publish-sonatype
     runs-on: ubuntu-latest
 

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -92,7 +92,7 @@ jobs:
 
   publish-sonatype:
     # when in master repo: all commits to main branch and all additional tags
-    if: github.repository == 'com-lihaoyi/mill' && ( github.ref == 'refs/heads/main' || github.ref == 'refs/head/0.9.x' || startsWith( github.ref, 'refs/tags/' ) )
+    if: github.repository == 'com-lihaoyi/mill' && ( github.ref == 'refs/heads/main' || github.ref == 'refs/heads/0.9.x' || startsWith( github.ref, 'refs/tags/' ) )
     needs: [test, test-windows]
 
     runs-on: ubuntu-latest
@@ -119,7 +119,7 @@ jobs:
 
   release-github:
     # when in master repo: all commits to main branch and all additional tags
-    if: github.repository == 'com-lihaoyi/mill' && ( github.ref == 'refs/heads/main' || (github.ref != 'refs/heads/main' && startsWith( github.ref, 'refs/tags/') ) )
+    if: github.repository == 'com-lihaoyi/mill' && ( github.ref == 'refs/heads/main' || github.ref == 'refs/heads/0.9.x' || startsWith( github.ref, 'refs/tags/' ) )
     needs: publish-sonatype
     runs-on: ubuntu-latest
 

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -24,7 +24,8 @@ jobs:
           - ./mill -i docs.antora.githubPages
         include:
           - java-version: 8
-            buildcmd: ./mill -i integration.test "mill.integration.local.{BetterFilesTests,UpickleTests}"
+            # buildcmd: ./mill -i integration.test "mill.integration.local.{BetterFilesTests,UpickleTests}"
+            buildcmd: ./mill -i integration.test "mill.integration.local.UpickleTests"
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -92,7 +92,7 @@ jobs:
 
   publish-sonatype:
     # when in master repo: all commits to main branch and all additional tags
-    if: github.repository == 'com-lihaoyi/mill' && ( github.ref == 'refs/heads/main' || (github.ref != 'refs/heads/main' && startsWith( github.ref, 'refs/tags/') ) )
+    if: github.repository == 'com-lihaoyi/mill' && ( github.ref == 'refs/heads/main' || github.ref == 'refs/head/0.9.x' || startsWith( github.ref, 'refs/tags/' ) )
     needs: [test, test-windows]
 
     runs-on: ubuntu-latest

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -3,8 +3,7 @@ name: Build and Release
 on:
   push:
   pull_request:
-    branches:
-      - main
+
 jobs:
 
   test:

--- a/build.sc
+++ b/build.sc
@@ -24,7 +24,7 @@ object Settings {
   // the exact branches containing a doc root
   val docBranches = Seq()
   // the exact tags containing a doc root
-  val docTags = Seq("0.9.6", "0.9.7", "0.9.8")
+  val docTags = Seq("0.9.6", "0.9.7", "0.9.8", "0.9.9")
 }
 
 object Deps {

--- a/contrib/scoverage/src/ScoverageReport.scala
+++ b/contrib/scoverage/src/ScoverageReport.scala
@@ -4,6 +4,7 @@ import mill.contrib.scoverage.api.ScoverageReportWorkerApi.ReportType
 import mill.define.{Command, Module, Task}
 import mill.eval.Evaluator
 import mill.main.RunScript
+import mill.util.SelectMode
 import mill.{PathRef, T}
 import os.Path
 
@@ -78,7 +79,7 @@ trait ScoverageReport extends Module {
       mill.main.ResolveTasks,
       evaluator,
       Seq(sources),
-      multiSelect = false
+      SelectMode.Single
     ) match {
       case Left(err)    => throw new Exception(err)
       case Right(tasks) => tasks.asInstanceOf[Seq[Task[Seq[PathRef]]]]
@@ -87,7 +88,7 @@ trait ScoverageReport extends Module {
       mill.main.ResolveTasks,
       evaluator,
       Seq(dataTargets),
-      multiSelect = false
+      SelectMode.Single
     ) match {
       case Left(err)    => throw new Exception(err)
       case Right(tasks) => tasks.asInstanceOf[Seq[Task[PathRef]]]

--- a/docs/antora/antora.yml
+++ b/docs/antora/antora.yml
@@ -1,9 +1,9 @@
 name: mill
 title: Mill Documentation
-version: '0.9.8'
+version: '0.9.9'
 nav:
   - modules/ROOT/nav.adoc
 asciidoc:
   attributes:
-    mill-version: '0.9.8'
-    mill-last-tag: '0.9.8'
+    mill-version: '0.9.9'
+    mill-last-tag: '0.9.9'

--- a/docs/antora/modules/ROOT/nav.adoc
+++ b/docs/antora/modules/ROOT/nav.adoc
@@ -7,5 +7,5 @@
 * xref:Cross_Builds.adoc[]
 * xref:Extending_Mill.adoc[]
 * xref:Mill_Internals.adoc[]
-* xref:Contrib_Modules.adoc[]
-* xref:Thirdparty_Modules.adoc[]
+* xref:Contrib_Plugins.adoc[]
+* xref:Thirdparty_Plugins.adoc[]

--- a/docs/antora/modules/ROOT/pages/Contrib_Plugins.adoc
+++ b/docs/antora/modules/ROOT/pages/Contrib_Plugins.adoc
@@ -1,8 +1,13 @@
-= Contrib Modules
+= Contrib Plugins
 
 The plugins in this section are developed/maintained in the mill git tree.
 
-When using one of these contribution modules, it is important that the versions you load match your mill version. To facilitate this, Mill will automatically replace the `$MILL_VERSION` literal in your ivy imports with the correct value.
+For details about including plugins in your `build.sc` read xref:Extending_Mill.adoc#_using_mill_plugins_import_ivy[Using Mill Plugins].
+
+[CAUTION]
+--
+When using one of these contribution modules, it is important that the versions you load match your mill version.
+To facilitate this, Mill will automatically replace the `$MILL_VERSION` literal in your ivy imports with the correct value.
 
 For instance:
 
@@ -10,6 +15,7 @@ For instance:
 ----
 import $ivy.`com.lihaoyi::mill-contrib-bloop:$MILL_VERSION`
 ----
+--
 
 == Artifactory
 

--- a/docs/antora/modules/ROOT/pages/Contrib_Plugins.adoc
+++ b/docs/antora/modules/ROOT/pages/Contrib_Plugins.adoc
@@ -8,12 +8,20 @@ For details about including plugins in your `build.sc` read xref:Extending_Mill.
 --
 When using one of these contribution modules, it is important that the versions you load match your mill version.
 To facilitate this, Mill will automatically replace the `$MILL_VERSION` literal in your ivy imports with the correct value.
+You can also leave the version completely empty to default to the mill version (but don't forget to keep the trailing colon).
 
 For instance:
 
 [source,scala]
 ----
 import $ivy.`com.lihaoyi::mill-contrib-bloop:$MILL_VERSION`
+----
+
+or
+
+[source,scala]
+----
+import $ivy.`com.lihaoyi::mill-contrib-bloop:`
 ----
 --
 
@@ -25,7 +33,7 @@ This plugin allows publishing to Artifactory.
 
 [source,scala]
 ----
-import $ivy.`com.lihaoyi::mill-contrib-artifactory:$MILL_VERSION`
+import $ivy.`com.lihaoyi::mill-contrib-artifactory:`
 import mill.contrib.artifactory.ArtifactoryPublishModule
 
 object mymodule extends ArtifactoryPublishModule {
@@ -53,7 +61,7 @@ Make sure your module extends from `BintrayPublishModule`:
 
 [source,scala]
 ----
-import $ivy.`com.lihaoyi::mill-contrib-bintray:$MILL_VERSION`
+import $ivy.`com.lihaoyi::mill-contrib-bintray:`
 import mill.contrib.bintray.BintrayPublishModule
 
 object mymodule extends BintrayPublishModule {
@@ -72,7 +80,7 @@ the package used, you can do that like this:
 
 [source,scala]
 ----
-import $ivy.`com.lihaoyi::mill-contrib-bintray:$MILL_VERSION`
+import $ivy.`com.lihaoyi::mill-contrib-bintray:`
 import mill.contrib.bintray.BintrayPublishModule
 
 object mymodule extends BintrayPublishModule {
@@ -120,7 +128,7 @@ your scala code editable in https://scalameta.org/metals/[Metals]
 [source,scala]
 ----
 // build.sc (or any other .sc file it depends on, including predef)
-import $ivy.`com.lihaoyi::mill-contrib-bloop:$MILL_VERSION`
+import $ivy.`com.lihaoyi::mill-contrib-bloop:`
 ----
 
 Then in your terminal :
@@ -173,7 +181,7 @@ Quickstart:
 .`build.sc`
 [source,scala]
 ----
-import $ivy.`com.lihaoyi::mill-contrib-buildinfo:$MILL_VERSION`
+import $ivy.`com.lihaoyi::mill-contrib-buildinfo:`
 import mill.contrib.buildinfo.BuildInfo
 
 object project extends BuildInfo {
@@ -223,7 +231,7 @@ This plugin allows publishing to AWS Codeartifact.
 
 [source,scala]
 ----
-import $ivy.`com.lihaoyi::mill-contrib-codeartifact:$MILL_VERSION`
+import $ivy.`com.lihaoyi::mill-contrib-codeartifact:`
 import mill.contrib.codeartifact.CodeartifactPublishModule
 
 object mymodule extends CodeartifactPublishModule {
@@ -254,7 +262,7 @@ In the simplest configuration just extend `DockerModule` and declare a `DockerCo
 ----
 import mill._, scalalib._
 
-import $ivy.`com.lihaoyi::mill-contrib-docker:$MILL_VERSION`
+import $ivy.`com.lihaoyi::mill-contrib-docker:`
 import contrib.docker.DockerModule
 
 object foo extends JavaModule with DockerModule {
@@ -302,7 +310,7 @@ Configure flyway by overriding settings in your module. For example
 ----
 import mill._, scalalib._
 
-import $ivy.`com.lihaoyi::mill-contrib-flyway:$MILL_VERSION`
+import $ivy.`com.lihaoyi::mill-contrib-flyway:`
 import contrib.flyway.FlywayModule
 
 object foo extends ScalaModule with FlywayModule {
@@ -378,7 +386,7 @@ Twirl versions. You also need to define your own test object which extends the p
 [source,scala]
 ----
 import mill._
-import $ivy.`com.lihaoyi::mill-contrib-playlib:$MILL_VERSION`,  mill.playlib._
+import $ivy.`com.lihaoyi::mill-contrib-playlib:`,  mill.playlib._
 
 object core extends PlayModule {
     //config
@@ -448,7 +456,7 @@ The `PlayApiModule` trait behaves the same as the `PlayModule` trait but it won'
 [source,scala]
 ----
 import mill._
-import $ivy.`com.lihaoyi::mill-contrib-playlib:$MILL_VERSION`,  mill.playlib._
+import $ivy.`com.lihaoyi::mill-contrib-playlib:`,  mill.playlib._
 
 object core extends PlayApiModule {
     //config
@@ -485,7 +493,7 @@ like in the following example build:
 [source,scala]
 ----
 import mill._
-import $ivy.`com.lihaoyi::mill-contrib-playlib:$MILL_VERSION`, mill.playlib._
+import $ivy.`com.lihaoyi::mill-contrib-playlib:`, mill.playlib._
 
 object core extends PlayApiModule {
     //config
@@ -526,7 +534,7 @@ Looking back at the sample build definition in <<_using_playmodule>>:
 [source,scala]
 ----
 import mill._
-import $ivy.`com.lihaoyi::mill-contrib-playlib:$MILL_VERSION`, mill.playlib._
+import $ivy.`com.lihaoyi::mill-contrib-playlib:`, mill.playlib._
 
 object core extends PlayModule {
     //config
@@ -567,7 +575,7 @@ by mixing in the `SingleModule` trait in your build:
 [source,scala]
 ----
 import mill._
-import $ivy.`com.lihaoyi::mill-contrib-playlib:$MILL_VERSION`,  mill.playlib._
+import $ivy.`com.lihaoyi::mill-contrib-playlib:`,  mill.playlib._
 
 object core extends PlayModule with SingleModule {
 	//config
@@ -612,7 +620,7 @@ define `playVersion` and `scalaVersion`.
 [source,scala]
 ----
 import mill._
-import $ivy.`com.lihaoyi::mill-contrib-playlib:$MILL_VERSION`,  mill.playlib._
+import $ivy.`com.lihaoyi::mill-contrib-playlib:`,  mill.playlib._
 
 object app extends ScalaModule with RouterModule {
   def playVersion= T{"2.7.0"}
@@ -667,7 +675,7 @@ To add additional imports to all of the routes:
 ----
 import mill.scalalib._
 
-import $ivy.`com.lihaoyi::mill-contrib-playlib:$MILL_VERSION`,  mill.playlib._
+import $ivy.`com.lihaoyi::mill-contrib-playlib:`,  mill.playlib._
 
 object app extends ScalaModule with RouterModule {
   def playVersion = "2.7.0"
@@ -695,7 +703,7 @@ Here is a simple example:
 .`build.sc`
 [source,scala]
 ----
-import $ivy.`com.lihaoyi::mill-contrib-proguard:$MILL_VERSION`
+import $ivy.`com.lihaoyi::mill-contrib-proguard:`
 import contrib.proguard._
 
 object foo extends ScalaModule with Proguard {
@@ -720,7 +728,7 @@ This creates a Scala module which compiles `.proto` files in the `protobuf` fold
 .`build.sc`
 [source,scala]
 ----
-import $ivy.`com.lihaoyi::mill-contrib-scalapblib:$MILL_VERSION`
+import $ivy.`com.lihaoyi::mill-contrib-scalapblib:`
 import contrib.scalapblib._
 
 object example extends ScalaPBModule {
@@ -759,7 +767,7 @@ If you'd like to configure the https://scalapb.github.io/docs/scalapbc#passing-g
 .`build.sc`
 [source,scala]
 ----
-import $ivy.`com.lihaoyi::mill-contrib-scalapblib:$MILL_VERSION`
+import $ivy.`com.lihaoyi::mill-contrib-scalapblib:`
 import contrib.scalapblib._
 
 object example extends ScalaPBModule {
@@ -774,7 +782,7 @@ If you'd like to pass additional arguments to the ScalaPB compiler directly, you
 .`build.sc`
 [source,scala]
 ----
-import $ivy.`com.lihaoyi::mill-contrib-scalapblib:$MILL_VERSION`
+import $ivy.`com.lihaoyi::mill-contrib-scalapblib:`
 import contrib.scalapblib._
 
 object example extends ScalaPBModule {
@@ -799,7 +807,7 @@ module. Additionally, you must define a submodule that extends the
 .`build.sc`
 [source,scala]
 ----
-import $ivy.`com.lihaoyi::mill-contrib-scoverage:$MILL_VERSION`
+import $ivy.`com.lihaoyi::mill-contrib-scoverage:`
 import mill.contrib.scoverage.ScoverageModule
 
 object foo extends ScoverageModule  {
@@ -904,7 +912,7 @@ Also note that twirl templates get compiled into scala code, so you also need to
 ----
 import mill.scalalib._
 
-import $ivy.`com.lihaoyi::mill-contrib-twirllib:$MILL_VERSION`,  mill.twirllib._
+import $ivy.`com.lihaoyi::mill-contrib-twirllib:`,  mill.twirllib._
 
 object app extends ScalaModule with TwirlModule {
 // ...
@@ -941,7 +949,7 @@ directory. This directory must be added to the generated sources of the module t
 ----
 import mill.scalalib._
 
-import $ivy.`com.lihaoyi::mill-contrib-twirllib:$MILL_VERSION`,  mill.twirllib._
+import $ivy.`com.lihaoyi::mill-contrib-twirllib:`,  mill.twirllib._
 
 object app extends ScalaModule with TwirlModule {
   def twirlVersion = "1.3.15"
@@ -978,7 +986,7 @@ To add additional imports to all of the twirl templates, override `twirlImports`
 ----
 import mill.scalalib._
 
-import $ivy.`com.lihaoyi::mill-contrib-twirllib:$MILL_VERSION`,  mill.twirllib._
+import $ivy.`com.lihaoyi::mill-contrib-twirllib:`,  mill.twirllib._
 
 object app extends ScalaModule with TwirlModule {
   def twirlVersion = "1.3.15"
@@ -1020,7 +1028,7 @@ To add additional formats, override `twirlFormats` in your build:
 ----
 import mill.scalalib._
 
-import $ivy.`com.lihaoyi::mill-contrib-twirllib:$MILL_VERSION`,  mill.twirllib._
+import $ivy.`com.lihaoyi::mill-contrib-twirllib:`,  mill.twirllib._
 
 object app extends ScalaModule with TwirlModule {
   def twirlVersion = "1.3.15"
@@ -1058,7 +1066,7 @@ Add a `VersionFileModule` to the `build.sc` file:
 
 [source,scala]
 ----
-import $ivy.`com.lihaoyi::mill-contrib-versionfile:$MILL_VERSION`
+import $ivy.`com.lihaoyi::mill-contrib-versionfile:`
 import mill.contrib.versionfile.VersionFileModule
 
 object versionFile extends VersionFileModule
@@ -1095,7 +1103,7 @@ If you want to use the version file for publishing, you can do it like this:
 
 [source,scala]
 ----
-import $ivy.`com.lihaoyi::mill-contrib-versionfile:$MILL_VERSION`
+import $ivy.`com.lihaoyi::mill-contrib-versionfile:`
 import mill.contrib.versionfile.VersionFileModule
 
 object versionFile extends VersionFileModule
@@ -1115,7 +1123,7 @@ at the root of the project, you can override `millSourcePath`:
 
 [source,scala]
 ----
-import $ivy.`com.lihaoyi::mill-contrib-versionfile:$MILL_VERSION`
+import $ivy.`com.lihaoyi::mill-contrib-versionfile:`
 import mill.contrib.versionfile.VersionFileModule
 
 object versionFile extends VersionFileModule {

--- a/docs/antora/modules/ROOT/pages/Extending_Mill.adoc
+++ b/docs/antora/modules/ROOT/pages/Extending_Mill.adoc
@@ -131,15 +131,16 @@ http://ammonite.io/#ScalaScripts[Ammonite Scripts]
 
 == import $ivy
 
-If you want to pull in artifacts from the public repositories (e.g. Maven Central) for use in your build, you can simply use `import $ivy`:
+If you want to pull in artifacts from the public repositories (e.g. Maven Central) for use in your build, you can simply use `import $ivy`.
 
-.`build.sc`
+
+.Example `build.sc`: Using `scalatags` library to generate HTML
 [source,scala]
 ----
-import $ivy.`com.lihaoyi::scalatags:0.6.2`
+import $ivy.`com.lihaoyi::scalatags:0.6.2` // <1>
 
 def generatedHtml = T {
-  import scalatags.Text.all._
+  import scalatags.Text.all._ // <2>
   html(
     head(),
     body(
@@ -149,13 +150,71 @@ def generatedHtml = T {
   ).render  
 }
 ----
+<1> Import the scalatags library from Mavel Central repository.
+<2> Creates the `generatedHtml` target which is used here to generate a simple Hello World HTML document. It can be used however you would like: written to a file, further processed, etc.
 
-This creates the `generatedHtml` target which can then be used however you would like: written to a file, further processed, etc.
-
-If you want to publish re-usable libraries that _other_ people can use in their builds, simply publish your code as a library to maven central.
+Please also read the next section xref:_using_mill_plugins_import_ivy[]].
 
 For more information, see Ammonite's
 http://ammonite.io/#import$ivy[Ivy Dependencies documentation].
+
+
+== Using Mill Plugins (`import $ivy`)
+
+Mill plugins are ordinary jars and are loaded as any other external dependency with xref:_import_ivy[`import $ivy`].
+
+Mill plugins are typically bound to a specific version or version range of Mill.
+To ease the use of the correct versions and avoid runtime issues (caused by binary incompatible plugins, which are hard to debug) you can apply one of the following techniques:
+
+=== Use the specific Mill Binary Platform notation
+
+[source,scala]
+----
+// for classic Scala dependencies
+import $ivy.`<group>::<plugin>::<version>` // <1>
+// for dependencies specific to the exact Scala version
+import $ivy.`<group>:::<plugin>::<version>` // <2>
+----
+<1> This is equivalent to
++
+[source,scala]
+----
+import $ivy.`<group>::<plugin>_mill$MILL_BIN_PLATFORM:<version>`
+----
+<1> This is equivalent to
++
+[source,scala]
+----
+import $ivy.`<group>:::<plugin>_mill$MILL_BIN_PLATFORM:<version>`
+----
+
+
+=== Use special placeholders in your `import $ivy`
+
+`$MILL_VERSION` ::
++
+--
+to substitute the currently used Mill version.
+This is typical required for Mill contrib modules, which are developed in the Mill repository and highly bound to the current Mill version.
+
+.Example: Use `mill-contrib-bloop` plugin matching the current Mill version
+----
+import $ivy:`com.lihaoyi:mill-contrib-bloop:$MILL_VERSION`
+----
+--
+
+`$MILL_BIN_PLATFORM` ::
++
+--
+to substitute the currently used Mill binary platform.
+
+.Example: Using `mill-vcs-version` plugin matching the current Mill Binary Platfrom
+----
+import $ivy:`de.tototec::de.tobiasroeser.mill.vcs.version::0.1.2`
+----
+--
+
+TIP: If you want to publish re-usable libraries that _other_ people can use in their builds, simply publish your code as a library to maven central.
 
 == Evaluator Commands (experimental)
 

--- a/docs/antora/modules/ROOT/pages/Extending_Mill.adoc
+++ b/docs/antora/modules/ROOT/pages/Extending_Mill.adoc
@@ -199,9 +199,18 @@ This is typical required for Mill contrib modules, which are developed in the Mi
 
 .Example: Use `mill-contrib-bloop` plugin matching the current Mill version
 ----
-import $ivy:`com.lihaoyi:mill-contrib-bloop:$MILL_VERSION`
+import $ivy.`com.lihaoyi:mill-contrib-bloop:$MILL_VERSION`
 ----
---
+
+There is the even more convenient option to leave the version completely empty.
+Mill will substitute it with its current version.
+But don't forget to provide the trailing colon!
+
+.Example: Use `mill-contrib-bloop` plugin matching the current Mill version
+----
+import $ivy.`com.lihaoyi:mill-contrib-bloop:`
+----
+
 
 `$MILL_BIN_PLATFORM` ::
 +
@@ -210,7 +219,7 @@ to substitute the currently used Mill binary platform.
 
 .Example: Using `mill-vcs-version` plugin matching the current Mill Binary Platfrom
 ----
-import $ivy:`de.tototec::de.tobiasroeser.mill.vcs.version::0.1.2`
+import $ivy.`de.tototec::de.tobiasroeser.mill.vcs.version::0.1.2`
 ----
 --
 

--- a/docs/antora/modules/ROOT/pages/Thirdparty_Plugins.adoc
+++ b/docs/antora/modules/ROOT/pages/Thirdparty_Plugins.adoc
@@ -1,11 +1,14 @@
-= Thirdparty Modules
+= Thirdparty Plugins
 
-The modules (aka plugins) in this section are developed/maintained outside the mill git tree.
+The Plugins in this section are developed/maintained outside the mill git tree.
+This list is most likely not complete.
+If you're missing an external plugin or developed one which is not listed here, please open a https://github.com/com-lihaoyi/mill/pulls[pull request] and add that plugin with a short description.
 
-Besides the documentation provided here, we urge you to consult the respective linked plugin documentation pages.
-The usage examples given here are most probably incomplete and sometimes outdated.
+For details about including plugins in your `build.sc` read xref:Extending_Mill.adoc#_using_mill_plugins_import_ivy[Using Mill Plugins].
 
-If you develop or maintain a mill plugin, please create a https://github.com/com-lihaoyi/mill/pulls[pull request] to get your plugin listed here.
+CAUTION: Besides the documentation provided here, we urge you to consult the respective linked plugin documentation pages.
+The usage examples given here are most probably incomplete and sometimes outdated!
+
 
 == Antlr
 
@@ -529,7 +532,7 @@ import mill._
 import mill.scalalib._
 
 // Load the plugin from Maven Central via ivy/coursier
-import $ivy.`de.tototec::de.tobiasroeser.mill.vcs.version_mill0.9:0.1.1`
+import $ivy.`de.tototec::de.tobiasroeser.mill.vcs.version::0.1.2`
 import de.tobiasroeser.mill.vcs.version.VcsVersion
 
 object main extends JavaModule with PublishModule {

--- a/main/core/src/eval/Evaluator.scala
+++ b/main/core/src/eval/Evaluator.scala
@@ -7,7 +7,7 @@ import ammonite.runtime.SpecialClassLoader
 import mainargs.MainData
 import scala.util.DynamicVariable
 
-import mill.api.{BuildProblemReporter, DummyTestReporter, Strict, TestReporter}
+import mill.api.{BuildProblemReporter, DummyTestReporter, TestReporter}
 import mill.api.Result.{Aborted, OuterStack, Success}
 import mill.api.Strict.Agg
 import mill.define.{Ctx => _, _}
@@ -107,13 +107,13 @@ case class Evaluator(
         // Increment the counter message by 1 to go from 1/10 to 10/10 instead of 0/10 to 9/10
         val counterMsg = (i+1) + "/" + sortedGroups.keyCount
         val Evaluated(newResults, newEvaluated, cached) = evaluateGroupCached(
-          terminal,
-          group,
-          results,
-          counterMsg,
-          reporter,
-          testReporter,
-          contextLogger
+          terminal = terminal,
+          group = group,
+          results = results,
+          counterMsg = counterMsg,
+          zincProblemReporter = reporter,
+          testReporter = testReporter,
+          logger = contextLogger
         )
         someTaskFailed = someTaskFailed || newResults.exists(task => !task._2.isInstanceOf[Success[_]])
 
@@ -127,11 +127,11 @@ case class Evaluator(
 
     Evaluator.writeTimings(timings.toSeq, outPath)
     Evaluator.Results(
-      goals.indexed.map(results(_).map(_._1)),
-      evaluated,
-      transitive,
-      getFailing(sortedGroups, results),
-      results.map{case (k, v) => (k, v.map(_._1))}
+      rawValues = goals.indexed.map(results(_).map(_._1)),
+      evaluated = evaluated,
+      transitive = transitive,
+      failing = getFailing(sortedGroups, results),
+      results = results.map { case (k, v) => (k, v.map(_._1)) }
     )
   }
 
@@ -689,7 +689,11 @@ object Evaluator{
     (sortedGroups, transitive)
   }
 
-  case class Evaluated(newResults: collection.Map[Task[_], Result[(Any, Int)]], newEvaluated: Seq[Task[_]], cached: Boolean)
+  case class Evaluated(
+      newResults: collection.Map[Task[_], mill.api.Result[(Any, Int)]],
+      newEvaluated: Seq[Task[_]],
+      cached: Boolean
+  )
 
   // Increment the counter message by 1 to go from 1/10 to 10/10
   class NextCounterMsg(taskCount: Int) {

--- a/main/src/main/MainScopts.scala
+++ b/main/src/main/MainScopts.scala
@@ -1,6 +1,7 @@
 package mill.main
 
 import mill.eval.Evaluator
+import mill.util.SelectMode
 
 case class Tasks[T](value: Seq[mill.define.NamedTask[T]])
 
@@ -12,7 +13,7 @@ object Tasks{
       mill.main.ResolveTasks,
       Evaluator.currentEvaluator.get,
       s,
-      multiSelect = false
+      selectMode.Single
     ).map(x => Tasks(x.asInstanceOf[Seq[mill.define.NamedTask[T]]])),
     alwaysRepeatable = false,
     allowEmpty  = false

--- a/main/src/main/MillIvyHook.scala
+++ b/main/src/main/MillIvyHook.scala
@@ -3,15 +3,48 @@ import ammonite.runtime.ImportHook.BaseIvy
 import ammonite.runtime.ImportHook
 import java.io.File
 
+import mill.BuildInfo
+
 /**
- * Overrides the ivy hook to interpret $MILL_VERSION as the version of mill
- * the user runs.
+ * Overrides the ivy hook to customize the `$ivy`-import with mill specifics:
  *
- * Can be used to ensure loaded contrib modules keep up to date.
+ * - interpret `$MILL_VERSION` as the mill version
+ *
+ * - interpret `$MILL_BIN_PLATFORM` as the mill binary platform version
+ *
+  * - supports the format `org::name::version` for mill plugins;
+  *   which is equivalent to `org::name_mill$MILL_BIN_PLATFORM:version`
+  *
+  * - supports the format `org:::name::version` for mill plugins;
+  *   which is equivalent to `org:::name_mill$MILL_BIN_PLATFORM:version`
+  *
  */
-object MillIvyHook extends BaseIvy(plugin = false){
-  override def resolve(interp: ImportHook.InterpreterInterface,
-                       signatures: Seq[String])
-      : Either[String,(Seq[coursierapi.Dependency], Seq[File])] =
-    super.resolve(interp, signatures.map(_.replace("$MILL_VERSION", mill.BuildInfo.millVersion)))
+object MillIvyHook extends BaseIvy(plugin = false) {
+  override def resolve(
+      interp: ImportHook.InterpreterInterface,
+      signatures: Seq[String]
+  ): Either[String, (Seq[coursierapi.Dependency], Seq[File])] = {
+
+    // replace platform notation
+    val millSigs: Seq[String] = for (signature <- signatures) yield {
+      signature.split("[:]") match {
+        case Array(org, "", pname, "", version)
+            if org.length > 0 && pname.length > 0 && version.length > 0 =>
+          s"${org}::${pname}_mill$$MILL_BIN_PLATFORM:${version}"
+        case Array(org, "", "", pname, "", version)
+            if org.length > 0 && pname.length > 0 && version.length > 0 =>
+          s"${org}:::${pname}_mill$$MILL_BIN_PLATFORM:${version}"
+        case _ => signature
+      }
+    }
+    // replace variables
+    val replaced = millSigs.map(_
+      .replace("$MILL_VERSION", mill.BuildInfo.millVersion)
+      .replace("${MILL_VERSION}", mill.BuildInfo.millVersion)
+      .replace("$MILL_BIN_PLATFORM", mill.BuildInfo.millBinPlatform)
+      .replace("${MILL_BIN_PLATFORM}", mill.BuildInfo.millBinPlatform))
+
+    super.resolve(interp, replaced)
+  }
 }
+

--- a/main/src/main/Resolve.scala
+++ b/main/src/main/Resolve.scala
@@ -207,7 +207,7 @@ object ResolveTasks extends Resolve[NamedTask[Any]]{
 
         // Contents of `either` *must* be a `Task`, because we only select
         // methods returning `Task` in the discovery process
-        case Some(either) => either.right.map(Seq(_))
+        case Some(either) => either.map(Seq(_))
       }
   }
 }

--- a/main/src/main/RunScript.scala
+++ b/main/src/main/RunScript.scala
@@ -9,11 +9,13 @@ import ammonite.util.{Name, Res, Util}
 import mill.define
 import mill.define._
 import mill.eval.Evaluator
-import mill.util.{EitherOps, ParseArgs, PrintLogger, Watched}
+import mill.util.{EitherOps, ParseArgs, PrintLogger, SelectMode, Watched}
 import mill.api.{Logger, PathRef, Result}
 import mill.api.Strict.Agg
 import scala.collection.mutable
 import scala.reflect.ClassTag
+
+import mill.util.ParseArgs.TargetsWithParams
 
 /**
   * Custom version of ammonite.main.Scripts, letting us run the build.sc script
@@ -64,7 +66,7 @@ object RunScript{
 
     val evaluated = for{
       evaluator <- evalRes
-      (evalWatches, res) <- Res(evaluateTasks(evaluator, scriptArgs, multiSelect = false))
+      (evalWatches, res) <- Res(evaluateTasks(evaluator, scriptArgs, SelectMode.Separated))
     } yield {
       (evaluator, evalWatches, res.map(_.flatMap(_._2)))
     }
@@ -123,33 +125,71 @@ object RunScript{
     } yield module
   }
 
-  def resolveTasks[T, R: ClassTag](resolver: mill.main.Resolve[R],
-                                   evaluator: Evaluator,
-                                   scriptArgs: Seq[String],
-                                   multiSelect: Boolean) = {
+
+  def resolveTasks[T, R: ClassTag](
+    resolver: mill.main.Resolve[R],
+    evaluator: Evaluator,
+    scriptArgs: Seq[String],
+    selectMode: SelectMode
+  ): Either[String, List[R]] = {
+    val parsedGroups: Either[String, Seq[TargetsWithParams]] = ParseArgs(scriptArgs, selectMode)
+    val resolvedGroups = parsedGroups.flatMap { groups =>
+      val resolved = groups.map { parsed: TargetsWithParams =>
+        resolveTasks(resolver, evaluator, Right(parsed))
+      }
+      EitherOps.sequence(resolved)
+    }
+    resolvedGroups.map(_.flatten.toList)
+  }
+
+  @deprecated(
+    "Use resolveTasks[T, R](Resolve[R], Evaluator, Seq[String], SelectMode) instead",
+    "mill after 0.9.9"
+  )
+  def resolveTasks[T, R: ClassTag](
+    resolver: mill.main.Resolve[R],
+    evaluator: Evaluator,
+    scriptArgs: Seq[String],
+    multiSelect: Boolean
+  ): Either[String, List[R]] = {
+    val parsed: Either[String, TargetsWithParams] = ParseArgs(scriptArgs, multiSelect = multiSelect)
+    resolveTasks(resolver, evaluator, parsed)
+  }
+
+  private def resolveTasks[T, R: ClassTag](
+    resolver: mill.main.Resolve[R],
+    evaluator: Evaluator,
+    targetsWithParams: Either[String, TargetsWithParams]
+  ): Either[String, List[R]] = {
     for {
-      parsed <- ParseArgs(scriptArgs, multiSelect = multiSelect)
+      parsed <- targetsWithParams
       (selectors, args) = parsed
       taskss <- {
         val selected = selectors.map { case (scopedSel, sel) =>
-          for(res <- prepareResolve(evaluator, scopedSel, sel))
-          yield {
-            val (rootModule, crossSelectors) = res
+          for (res <- prepareResolve(evaluator, scopedSel, sel))
+            yield {
+              val (rootModule, crossSelectors) = res
 
-            try {
-              // We inject the `evaluator.rootModule` into the TargetScopt, rather
-              // than the `rootModule`, because even if you are running an external
-              // module we still want you to be able to resolve targets from your
-              // main build. Resolving targets from external builds as CLI arguments
-              // is not currently supported
-              mill.eval.Evaluator.currentEvaluator.set(evaluator)
-              resolver.resolve(sel.value.toList, rootModule, rootModule.millDiscover, args, crossSelectors.toList)
-            } finally {
-              mill.eval.Evaluator.currentEvaluator.set(null)
+              try {
+                // We inject the `evaluator.rootModule` into the TargetScopt, rather
+                // than the `rootModule`, because even if you are running an external
+                // module we still want you to be able to resolve targets from your
+                // main build. Resolving targets from external builds as CLI arguments
+                // is not currently supported
+                mill.eval.Evaluator.currentEvaluator.set(evaluator)
+                resolver.resolve(
+                  sel.value.toList,
+                  rootModule,
+                  rootModule.millDiscover,
+                  args,
+                  crossSelectors.toList
+                )
+              } finally {
+                mill.eval.Evaluator.currentEvaluator.set(null)
+              }
             }
-          }
         }
-        EitherOps.sequence(selected)
+        EitherOps.sequence(selected).map(_.toList)
       }
       res <- EitherOps.sequence(taskss)
     } yield res.flatten
@@ -182,22 +222,35 @@ object RunScript{
     }
   }
 
-  def evaluateTasks[T](evaluator: Evaluator,
-                       scriptArgs: Seq[String],
-                       multiSelect: Boolean) = {
-    for (targets <- resolveTasks(mill.main.ResolveTasks, evaluator, scriptArgs, multiSelect)) yield {
-      val (watched, res) = evaluate(evaluator, Agg.from(targets.distinct))
+  @deprecated(
+    "Use evaluateTasks[T](Evaluator, Seq[String], SelectMode) instead",
+    "mill after 0.10.0-M3"
+  )
+  def evaluateTasks[T](
+    evaluator: Evaluator,
+    scriptArgs: Seq[String],
+    multiSelect: Boolean
+  ): Either[String, (Seq[PathRef], Either[String, Seq[(Any, Option[ujson.Value])]])] =
+    evaluateTasks(evaluator, scriptArgs, if (multiSelect) SelectMode.Multi else SelectMode.Single)
 
-      val watched2 = for{
-        x <- res.right.toSeq
-        (Watched(_, extraWatched), _) <- x
-        w <- extraWatched
-      } yield w
+  def evaluateTasks[T](
+    evaluator: Evaluator,
+    scriptArgs: Seq[String],
+    selectMode: SelectMode
+  ): Either[String, (Seq[PathRef], Either[String, Seq[(Any, Option[ujson.Value])]])] = {
+    for (targets <- resolveTasks(mill.main.ResolveTasks, evaluator, scriptArgs, selectMode))
+      yield {
+        val (watched, res) = evaluate(evaluator, Agg.from(targets.distinct))
 
-      (watched ++ watched2, res)
-    }
+        val watched2 = for {
+          x <- res.toSeq
+          (Watched(_, extraWatched), _) <- x
+          w <- extraWatched
+        } yield w
+
+        (watched ++ watched2, res)
+      }
   }
-
   def evaluate(evaluator: Evaluator,
                targets: Agg[Task[Any]]): (Seq[PathRef], Either[String, Seq[(Any, Option[ujson.Value])]]) = {
     val evaluated = evaluator.evaluate(targets)

--- a/main/test/src/main/MillIvyHookTest.scala
+++ b/main/test/src/main/MillIvyHookTest.scala
@@ -1,0 +1,66 @@
+package mill.main
+
+import java.io.File
+
+import scala.util.Try
+
+import ammonite.runtime.ImportHook.InterpreterInterface
+import coursierapi.{Dependency => CDependency, Module => CModule, ScalaVersion => CScalaVersion}
+import utest.{TestSuite, Tests, _}
+
+object MillIvyHookTest extends TestSuite {
+  val wd = os.root / "tmp"
+  def mapDep(d: CDependency): Seq[File] =
+    Seq(
+      (wd / s"${d.getModule.getOrganization}__${d.getModule.getName}__${d.getVersion}__${d.getModule.getName}-${d.getVersion}.jar").toIO
+    )
+  override def tests: Tests = Tests {
+    val interp = new InterpreterInterface {
+      def loadIvy(coordinates: CDependency*): Either[String, Seq[File]] =
+        Right(coordinates.flatMap(mapDep))
+      def watch(p: os.Path): Unit = ???
+      def scalaVersion: String = "2.13.6"
+    }
+    test("simple") {
+      val deps = Seq(
+        ("a:b:c", CDependency.of("a", "b", "c"), wd / "a__b__c__b-c.jar"),
+        (
+          "a::b:c",
+          CDependency.of(CModule.parse("a::b", CScalaVersion.of("2.13.6")), "c"),
+            wd / "a__b_2.13__c__b_2.13-c.jar"
+        ),
+        (
+          "a::b::c",
+          CDependency.of(
+            CModule.parse(
+              s"a::b_mill${mill.BuildInfo.millBinPlatform}",
+              CScalaVersion.of("2.13.6")
+            ),
+            "c"
+          ),
+          wd / s"a__b_mill${mill.BuildInfo.millBinPlatform}_2.13__c__b_mill${mill.BuildInfo.millBinPlatform}_2.13-c.jar"
+        ),
+        (
+          s"a::b:",
+          CDependency.of(
+            CModule.parse("a::b", CScalaVersion.of("2.13.6")),
+            mill.BuildInfo.millVersion
+          ),
+          wd / s"a__b_2.13__${mill.BuildInfo.millVersion}__b_2.13-${mill.BuildInfo.millVersion}.jar"
+        )
+      )
+      val checks = deps.map { case (coord, dep, path) =>
+        Try {
+          val expected: Either[String, (Seq[CDependency], Seq[File])] =
+            Right(Seq(dep), Seq(path.toIO))
+          val resolved = MillIvyHook.resolve(interp, Seq(coord))
+          assert(
+            // first check only adds context to the exception message
+            coord.nonEmpty && dep.toString.nonEmpty && resolved == expected
+          )
+        }
+      }
+      assert(checks.forall(_.isSuccess))
+    }
+  }
+}

--- a/readme.adoc
+++ b/readme.adoc
@@ -209,10 +209,26 @@ corresponding version of Mill.
 
 === main
 :version: main
+:prev-version: 0.9.9
+:milestone: 51
+:milestone-name: after 0.9.9
+
+
+_For details refer to
+{link-milestone}/{milestone}?closed=1[milestone {milestone-name}]
+and the {link-compare}/{prev-version}\...{version}[list of commits]._
+
+
+=== 0.9.9 - 2021-07-15
+:version: 0.9.9
 :prev-version: 0.9.8
 :milestone: 50
-:milestone-name: after 0.9.8
+:milestone-name: 0.9.9
 
+* BSP: Fixed/improved source item for root project
+* Bloop: Prevent compilation during bloop config generation
+* GenIdea: Fix content path of root project (mill-build)
+* Various version bumps
 
 _For details refer to
 {link-milestone}/{milestone}?closed=1[milestone {milestone-name}]

--- a/scalalib/src/GenIdeaImpl.scala
+++ b/scalalib/src/GenIdeaImpl.scala
@@ -164,7 +164,7 @@ case class GenIdeaImpl(evaluator: Evaluator,
             T.traverse(mod.transitiveModuleDeps)(_.unmanagedClasspath)().flatten
         }
         val extCompileIvyDeps = mod.resolveDeps(mod.compileIvyDeps)
-        val extRunIvyDeps = mod.resolveDeps(mod.runIvyDeps)
+        val extRunIvyDeps = mod.resolvedRunIvyDeps
 
         val externalSources = T.task {
           mod.resolveDeps(allIvyDeps, sources = true)()


### PR DESCRIPTION
- Prepared release 0.9.9
- Disabled always failing integration test suite (#1397)
- Also release tagged commits regardless of their branch
- GenIdea: Improved calculation of runtime scoped dependencies (#1420)
- Enabled snapshot publishing for 0.9.x branch
- Fixed snapshot publishing for 0.9.x branch
- Backported support for more mill-specifics in $ivy-import (#1561)
- Backported --import cli option and support empty plugin versions (#1562)
- Backported support for a target separator (`+`) in the argument parser
