### PR TITLE
Backported support for a target separator (`+`) in the argument parser

### DIFF
--- a/contrib/scoverage/src/ScoverageReport.scala
+++ b/contrib/scoverage/src/ScoverageReport.scala
@@ -4,6 +4,7 @@ import mill.contrib.scoverage.api.ScoverageReportWorkerApi.ReportType
 import mill.define.{Command, Module, Task}
 import mill.eval.Evaluator
 import mill.main.RunScript
+import mill.util.SelectMode
 import mill.{PathRef, T}
 import os.Path
 
@@ -78,7 +79,7 @@ trait ScoverageReport extends Module {
       mill.main.ResolveTasks,
       evaluator,
       Seq(sources),
-      multiSelect = false
+      SelectMode.Single
     ) match {
       case Left(err)    => throw new Exception(err)
       case Right(tasks) => tasks.asInstanceOf[Seq[Task[Seq[PathRef]]]]
@@ -87,7 +88,7 @@ trait ScoverageReport extends Module {
       mill.main.ResolveTasks,
       evaluator,
       Seq(dataTargets),
-      multiSelect = false
+      SelectMode.Single
     ) match {
       case Left(err)    => throw new Exception(err)
       case Right(tasks) => tasks.asInstanceOf[Seq[Task[PathRef]]]

--- a/main/core/src/eval/Evaluator.scala
+++ b/main/core/src/eval/Evaluator.scala
@@ -7,7 +7,7 @@ import ammonite.runtime.SpecialClassLoader
 import mainargs.MainData
 import scala.util.DynamicVariable
 
-import mill.api.{BuildProblemReporter, DummyTestReporter, Strict, TestReporter}
+import mill.api.{BuildProblemReporter, DummyTestReporter, TestReporter}
 import mill.api.Result.{Aborted, OuterStack, Success}
 import mill.api.Strict.Agg
 import mill.define.{Ctx => _, _}
@@ -107,13 +107,13 @@ case class Evaluator(
         // Increment the counter message by 1 to go from 1/10 to 10/10 instead of 0/10 to 9/10
         val counterMsg = (i+1) + "/" + sortedGroups.keyCount
         val Evaluated(newResults, newEvaluated, cached) = evaluateGroupCached(
-          terminal,
-          group,
-          results,
-          counterMsg,
-          reporter,
-          testReporter,
-          contextLogger
+          terminal = terminal,
+          group = group,
+          results = results,
+          counterMsg = counterMsg,
+          zincProblemReporter = reporter,
+          testReporter = testReporter,
+          logger = contextLogger
         )
         someTaskFailed = someTaskFailed || newResults.exists(task => !task._2.isInstanceOf[Success[_]])
 
@@ -127,11 +127,11 @@ case class Evaluator(
 
     Evaluator.writeTimings(timings.toSeq, outPath)
     Evaluator.Results(
-      goals.indexed.map(results(_).map(_._1)),
-      evaluated,
-      transitive,
-      getFailing(sortedGroups, results),
-      results.map{case (k, v) => (k, v.map(_._1))}
+      rawValues = goals.indexed.map(results(_).map(_._1)),
+      evaluated = evaluated,
+      transitive = transitive,
+      failing = getFailing(sortedGroups, results),
+      results = results.map { case (k, v) => (k, v.map(_._1)) }
     )
   }
 
@@ -689,7 +689,11 @@ object Evaluator{
     (sortedGroups, transitive)
   }
 
-  case class Evaluated(newResults: collection.Map[Task[_], Result[(Any, Int)]], newEvaluated: Seq[Task[_]], cached: Boolean)
+  case class Evaluated(
+      newResults: collection.Map[Task[_], mill.api.Result[(Any, Int)]],
+      newEvaluated: Seq[Task[_]],
+      cached: Boolean
+  )
 
   // Increment the counter message by 1 to go from 1/10 to 10/10
   class NextCounterMsg(taskCount: Int) {

--- a/main/src/main/MainScopts.scala
+++ b/main/src/main/MainScopts.scala
@@ -1,6 +1,7 @@
 package mill.main
 
 import mill.eval.Evaluator
+import mill.util.SelectMode
 
 case class Tasks[T](value: Seq[mill.define.NamedTask[T]])
 
@@ -12,7 +13,7 @@ object Tasks{
       mill.main.ResolveTasks,
       Evaluator.currentEvaluator.get,
       s,
-      multiSelect = false
+      SelectMode.Single
     ).map(x => Tasks(x.asInstanceOf[Seq[mill.define.NamedTask[T]]])),
     alwaysRepeatable = false,
     allowEmpty  = false

--- a/main/src/main/Resolve.scala
+++ b/main/src/main/Resolve.scala
@@ -207,7 +207,7 @@ object ResolveTasks extends Resolve[NamedTask[Any]]{
 
         // Contents of `either` *must* be a `Task`, because we only select
         // methods returning `Task` in the discovery process
-        case Some(either) => either.right.map(Seq(_))
+        case Some(either) => either.map(Seq(_))
       }
   }
 }

--- a/main/src/main/RunScript.scala
+++ b/main/src/main/RunScript.scala
@@ -9,11 +9,13 @@ import ammonite.util.{Name, Res, Util}
 import mill.define
 import mill.define._
 import mill.eval.Evaluator
-import mill.util.{EitherOps, ParseArgs, PrintLogger, Watched}
+import mill.util.{EitherOps, ParseArgs, PrintLogger, SelectMode, Watched}
 import mill.api.{Logger, PathRef, Result}
 import mill.api.Strict.Agg
 import scala.collection.mutable
 import scala.reflect.ClassTag
+
+import mill.util.ParseArgs.TargetsWithParams
 
 /**
   * Custom version of ammonite.main.Scripts, letting us run the build.sc script
@@ -64,7 +66,7 @@ object RunScript{
 
     val evaluated = for{
       evaluator <- evalRes
-      (evalWatches, res) <- Res(evaluateTasks(evaluator, scriptArgs, multiSelect = false))
+      (evalWatches, res) <- Res(evaluateTasks(evaluator, scriptArgs, SelectMode.Separated))
     } yield {
       (evaluator, evalWatches, res.map(_.flatMap(_._2)))
     }
@@ -123,33 +125,71 @@ object RunScript{
     } yield module
   }
 
-  def resolveTasks[T, R: ClassTag](resolver: mill.main.Resolve[R],
-                                   evaluator: Evaluator,
-                                   scriptArgs: Seq[String],
-                                   multiSelect: Boolean) = {
+
+  def resolveTasks[T, R: ClassTag](
+    resolver: mill.main.Resolve[R],
+    evaluator: Evaluator,
+    scriptArgs: Seq[String],
+    selectMode: SelectMode
+  ): Either[String, List[R]] = {
+    val parsedGroups: Either[String, Seq[TargetsWithParams]] = ParseArgs(scriptArgs, selectMode)
+    val resolvedGroups = parsedGroups.flatMap { groups =>
+      val resolved = groups.map { parsed: TargetsWithParams =>
+        resolveTasks(resolver, evaluator, Right(parsed))
+      }
+      EitherOps.sequence(resolved)
+    }
+    resolvedGroups.map(_.flatten.toList)
+  }
+
+  @deprecated(
+    "Use resolveTasks[T, R](Resolve[R], Evaluator, Seq[String], SelectMode) instead",
+    "mill after 0.9.9"
+  )
+  def resolveTasks[T, R: ClassTag](
+    resolver: mill.main.Resolve[R],
+    evaluator: Evaluator,
+    scriptArgs: Seq[String],
+    multiSelect: Boolean
+  ): Either[String, List[R]] = {
+    val parsed: Either[String, TargetsWithParams] = ParseArgs(scriptArgs, multiSelect = multiSelect)
+    resolveTasks(resolver, evaluator, parsed)
+  }
+
+  private def resolveTasks[T, R: ClassTag](
+    resolver: mill.main.Resolve[R],
+    evaluator: Evaluator,
+    targetsWithParams: Either[String, TargetsWithParams]
+  ): Either[String, List[R]] = {
     for {
-      parsed <- ParseArgs(scriptArgs, multiSelect = multiSelect)
+      parsed <- targetsWithParams
       (selectors, args) = parsed
       taskss <- {
         val selected = selectors.map { case (scopedSel, sel) =>
-          for(res <- prepareResolve(evaluator, scopedSel, sel))
-          yield {
-            val (rootModule, crossSelectors) = res
+          for (res <- prepareResolve(evaluator, scopedSel, sel))
+            yield {
+              val (rootModule, crossSelectors) = res
 
-            try {
-              // We inject the `evaluator.rootModule` into the TargetScopt, rather
-              // than the `rootModule`, because even if you are running an external
-              // module we still want you to be able to resolve targets from your
-              // main build. Resolving targets from external builds as CLI arguments
-              // is not currently supported
-              mill.eval.Evaluator.currentEvaluator.set(evaluator)
-              resolver.resolve(sel.value.toList, rootModule, rootModule.millDiscover, args, crossSelectors.toList)
-            } finally {
-              mill.eval.Evaluator.currentEvaluator.set(null)
+              try {
+                // We inject the `evaluator.rootModule` into the TargetScopt, rather
+                // than the `rootModule`, because even if you are running an external
+                // module we still want you to be able to resolve targets from your
+                // main build. Resolving targets from external builds as CLI arguments
+                // is not currently supported
+                mill.eval.Evaluator.currentEvaluator.set(evaluator)
+                resolver.resolve(
+                  sel.value.toList,
+                  rootModule,
+                  rootModule.millDiscover,
+                  args,
+                  crossSelectors.toList
+                )
+              } finally {
+                mill.eval.Evaluator.currentEvaluator.set(null)
+              }
             }
-          }
         }
-        EitherOps.sequence(selected)
+        EitherOps.sequence(selected).map(_.toList)
       }
       res <- EitherOps.sequence(taskss)
     } yield res.flatten
@@ -182,22 +222,35 @@ object RunScript{
     }
   }
 
-  def evaluateTasks[T](evaluator: Evaluator,
-                       scriptArgs: Seq[String],
-                       multiSelect: Boolean) = {
-    for (targets <- resolveTasks(mill.main.ResolveTasks, evaluator, scriptArgs, multiSelect)) yield {
-      val (watched, res) = evaluate(evaluator, Agg.from(targets.distinct))
+  @deprecated(
+    "Use evaluateTasks[T](Evaluator, Seq[String], SelectMode) instead",
+    "mill after 0.10.0-M3"
+  )
+  def evaluateTasks[T](
+    evaluator: Evaluator,
+    scriptArgs: Seq[String],
+    multiSelect: Boolean
+  ): Either[String, (Seq[PathRef], Either[String, Seq[(Any, Option[ujson.Value])]])] =
+    evaluateTasks(evaluator, scriptArgs, if (multiSelect) SelectMode.Multi else SelectMode.Single)
 
-      val watched2 = for{
-        x <- res.right.toSeq
-        (Watched(_, extraWatched), _) <- x
-        w <- extraWatched
-      } yield w
+  def evaluateTasks[T](
+    evaluator: Evaluator,
+    scriptArgs: Seq[String],
+    selectMode: SelectMode
+  ): Either[String, (Seq[PathRef], Either[String, Seq[(Any, Option[ujson.Value])]])] = {
+    for (targets <- resolveTasks(mill.main.ResolveTasks, evaluator, scriptArgs, selectMode))
+      yield {
+        val (watched, res) = evaluate(evaluator, Agg.from(targets.distinct))
 
-      (watched ++ watched2, res)
-    }
+        val watched2 = for {
+          x <- res.toSeq
+          (Watched(_, extraWatched), _) <- x
+          w <- extraWatched
+        } yield w
+
+        (watched ++ watched2, res)
+      }
   }
-
   def evaluate(evaluator: Evaluator,
                targets: Agg[Task[Any]]): (Seq[PathRef], Either[String, Seq[(Any, Option[ujson.Value])]]) = {
     val evaluated = evaluator.evaluate(targets)


### PR DESCRIPTION
This adds support to specify arbitrary targets and target arguments in one mill run.

__Motivation:__ Current mill only supports the selection of one or multiple targets followed by an argument list which is applied to all targets. Providing different arguments is currently not supported.

__Solution:__ We introduce a new separator `+` which separates the target arguments from the next target. To pass the `+` as argument to a target, masking with `\+` is supported.

Example:

```bash
mill __.compile + core.testCached + itest.test fastTest slowTests + __.publishLocal
```

This command will:
* run `compile` for all modules
* run `testCached` for module `core`
* run `itest.test` command with arguments ` fastTest` and `slowTests`
* run `publishLocal` for all modules

The limitation, that a command can only run once is still present and not changed by this PR.

See pull request: https://github.com/com-lihaoyi/mill/pull/1521
