### PR TITLE
Bind cross-versions to the context of the originating module

### DIFF
--- a/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
+++ b/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
@@ -378,8 +378,7 @@ class BloopImpl(ev: () => Evaluator, wd: os.Path) extends ExternalModule { outer
       val repos = module.repositoriesTask()
       // same as input of resolvedIvyDeps
       val allIvyDeps = module.transitiveIvyDeps() ++ module.transitiveCompileIvyDeps()
-      val coursierDeps =
-        allIvyDeps.map(module.resolveCoursierDependency()).toList
+      val coursierDeps = allIvyDeps.map(_.dep).toList
       BloopConfig.Resolution(artifacts(repos, coursierDeps))
     }
 

--- a/contrib/flyway/src/FlywayModule.scala
+++ b/contrib/flyway/src/FlywayModule.scala
@@ -29,7 +29,10 @@ trait FlywayModule extends JavaModule {
   def flywayDriverDeps: T[Agg[Dep]]
 
   def jdbcClasspath = T {
-    resolveDeps(flywayDriverDeps)()
+    resolveDeps(T.task {
+      val bind = bindDependency()
+      flywayDriverDeps().map(bind)
+    })()
   }
 
   private def strToOptPair[A](key: String, v: String) =

--- a/contrib/jmh/src/mill/contrib/jmh/JmhModule.scala
+++ b/contrib/jmh/src/mill/contrib/jmh/JmhModule.scala
@@ -94,8 +94,12 @@ trait JmhModule extends JavaModule {
       (sourcesDir, resourcesDir)
     }
 
-  def generatorDeps =
+  def generatorDeps = T {
     resolveDeps(
-      T { Agg(ivy"org.openjdk.jmh:jmh-generator-bytecode:${jmhGeneratorByteCodeVersion()}") }
-    )
+      T.task {
+        val bind = bindDependency()
+        Agg(ivy"org.openjdk.jmh:jmh-generator-bytecode:${jmhGeneratorByteCodeVersion()}").map(bind)
+      }
+    )()
+  }
 }

--- a/contrib/playlib/src/mill/playlib/RouterModule.scala
+++ b/contrib/playlib/src/mill/playlib/RouterModule.scala
@@ -45,7 +45,10 @@ trait RouterModule extends ScalaModule with Version {
   def generatorType: RouteCompilerType = RouteCompilerType.InjectedGenerator
 
   def routerClasspath: T[Agg[PathRef]] = T {
-    resolveDeps(T.task { Agg(ivy"com.typesafe.play::routes-compiler:${playVersion()}") })()
+    resolveDeps(T.task {
+      val bind = bindDependency()
+      Agg(ivy"com.typesafe.play::routes-compiler:${playVersion()}").map(bind)
+    })()
   }
 
   protected val routeCompilerWorker: RouteCompilerWorkerModule = RouteCompilerWorkerModule

--- a/contrib/playlib/src/mill/playlib/Static.scala
+++ b/contrib/playlib/src/mill/playlib/Static.scala
@@ -56,7 +56,6 @@ trait Static extends ScalaModule {
   def webJars = T {
     Lib.resolveDependencies(
       repositoriesTask(),
-      Lib.depToDependency(_, scalaVersion()),
       webJarDeps()
     )
   }

--- a/contrib/proguard/src/Proguard.scala
+++ b/contrib/proguard/src/Proguard.scala
@@ -140,7 +140,9 @@ trait Proguard extends ScalaModule {
    * These are downloaded from JCenter and fed to `java -cp`
    */
   def proguardClasspath: T[Loose.Agg[PathRef]] = T {
-    resolveDeps(T.task { Agg(ivy"com.guardsquare:proguard-base:${proguardVersion()}") })()
+    resolveDeps(T.task {
+      Agg(ivy"com.guardsquare:proguard-base:${proguardVersion()}").map(bindDependency())
+    })()
   }
 
   private def steps: T[Seq[String]] = T {

--- a/contrib/scalapblib/src/ScalaPBModule.scala
+++ b/contrib/scalapblib/src/ScalaPBModule.scala
@@ -78,8 +78,8 @@ trait ScalaPBModule extends ScalaModule {
         coursier.LocalRepositories.ivy2Local,
         MavenRepository("https://repo1.maven.org/maven2")
       ),
-      Lib.depToDependency(_, "2.13.1"),
       Seq(ivy"com.thesamet.scalapb::scalapbc:${scalaPBVersion()}")
+        .map(Lib.depToBoundDep(_, "2.13.1"))
     )
   }
 

--- a/contrib/scoverage/src/ScoverageModule.scala
+++ b/contrib/scoverage/src/ScoverageModule.scala
@@ -168,18 +168,21 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
         val pluginDep =
           Agg(ivy"org.scoverage:scalac-scoverage-plugin_${scalaVersion}:${sv}")
 
-        if (isScala3() && isScoverage2()) {
+        val deps = if (isScala3() && isScoverage2()) {
           baseDeps
         } else if (isScoverage2()) {
           baseDeps ++ pluginDep
         } else {
           pluginDep
         }
+        deps.map(bindDependency())
       })()
   }
 
   def scoverageClasspath: T[Agg[PathRef]] = T {
-    resolveDeps(scoveragePluginDeps)()
+    resolveDeps(T.task {
+      scoveragePluginDeps().map(bindDependency())
+    })()
   }
 
   def scoverageReportWorkerClasspath: T[Agg[PathRef]] = T {
@@ -263,15 +266,21 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
   trait ScoverageTests extends outer.Tests {
     override def upstreamAssemblyClasspath = T {
       super.upstreamAssemblyClasspath() ++
-        resolveDeps(outer.scoverageRuntimeDeps)()
+        resolveDeps(T.task {
+          outer.scoverageRuntimeDeps().map(bindDependency())
+        })()
     }
     override def compileClasspath = T {
       super.compileClasspath() ++
-        resolveDeps(outer.scoverageRuntimeDeps)()
+        resolveDeps(T.task {
+          outer.scoverageRuntimeDeps().map(bindDependency())
+        })()
     }
     override def runClasspath = T {
       super.runClasspath() ++
-        resolveDeps(outer.scoverageRuntimeDeps)()
+        resolveDeps(T.task {
+          outer.scoverageRuntimeDeps().map(bindDependency())
+        })()
     }
 
     // Need the sources compiled with scoverage instrumentation to run.

--- a/contrib/twirllib/src/TwirlModule.scala
+++ b/contrib/twirllib/src/TwirlModule.scala
@@ -56,7 +56,10 @@ trait TwirlModule extends mill.Module { twirlModule =>
   val twirlCoursierResolver = new TwirlResolver()
 
   def twirlClasspath: T[Loose.Agg[PathRef]] = T {
-    twirlCoursierResolver.resolveDeps(twirlIvyDeps)
+    twirlCoursierResolver.resolveDeps(T.task {
+      val bind = twirlCoursierResolver.bindDependency()
+      twirlIvyDeps().map(bind)
+    })
   }
 
   def twirlImports: T[Seq[String]] = T {

--- a/integration/thirdparty/local/resources/ammonite/build.sc
+++ b/integration/thirdparty/local/resources/ammonite/build.sc
@@ -55,8 +55,8 @@ trait AmmDependenciesResourceFileModule extends JavaModule {
   def crossScalaVersion: String
   def dependencyResourceFileName: String
   override def resources = T.sources {
-    val binder = bindDependency()
-    val deps0 = T.task { compileIvyDeps().map(binder) ++ transitiveIvyDeps() }()
+    val deps0 = T.task {
+      compileIvyDeps().map(bindDependency()) ++ transitiveIvyDeps() }()
     val (_, res) = mill.modules.Jvm.resolveDependenciesMetadata(
       repositoriesTask(),
       deps0.map(_.dep),
@@ -159,7 +159,9 @@ object amm extends Cross[MainModule](fullCrossScalaVersions: _*) {
         (super.resources() ++
           ReplModule.this.sources() ++
           ReplModule.this.externalSources() ++
-          resolveDeps(ivyDeps, sources = true)()).distinct
+          resolveDeps(T.task{
+            ivyDeps().map(bindDependency())
+          }, sources = true)()).distinct
       }
       def ivyDeps = super.ivyDeps() ++ Agg(
         ivy"org.scalaz::scalaz-core:7.2.24"

--- a/integration/thirdparty/local/resources/ammonite/build.sc
+++ b/integration/thirdparty/local/resources/ammonite/build.sc
@@ -55,12 +55,12 @@ trait AmmDependenciesResourceFileModule extends JavaModule {
   def crossScalaVersion: String
   def dependencyResourceFileName: String
   override def resources = T.sources {
-
-    val deps0 = T.task { compileIvyDeps() ++ transitiveIvyDeps() }()
+    val binder = bindDependency()
+    val deps0 = T.task { compileIvyDeps().map(binder) ++ transitiveIvyDeps() }()
     val (_, res) = mill.modules.Jvm.resolveDependenciesMetadata(
       repositoriesTask(),
-      deps0.map(resolveCoursierDependency().apply(_)),
-      deps0.filter(_.force).map(resolveCoursierDependency().apply(_)),
+      deps0.map(_.dep),
+      deps0.filter(_.force).map(_.dep),
       mapDependencies = Some(mapDependencies())
     )
 

--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -85,8 +85,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
     // we need to use the scala-library of the currently running mill
     resolveDependencies(
       repositoriesTask(),
-      Lib.depToDependency(_, mill.BuildInfo.scalaVersion, ""),
-      commonDeps ++ envDeps,
+      (commonDeps ++ envDeps).map(Lib.depToBoundDep(_, mill.BuildInfo.scalaVersion, "")),
       ctx = Some(T.log)
     )
   }
@@ -253,13 +252,13 @@ trait TestScalaJSModule extends ScalaJSModule with TestModule {
 
   def scalaJSTestDeps = T {
     resolveDeps(T.task {
-      val bridgeOrInterface =
-        if (ZincWorkerUtil.scalaJSUsesTestBridge(scalaJSVersion())) "bridge"
-        else "interface"
+      val bind = bindDependency()
       Loose.Agg(
         ivy"org.scala-js::scalajs-library:${scalaJSVersion()}",
         ivy"org.scala-js::scalajs-test-bridge:${scalaJSVersion()}"
-      ).map(_.withDottyCompat(scalaVersion()))
+      )
+        .map(_.withDottyCompat(scalaVersion()))
+        .map(bind)
     })
   }
 

--- a/scalalib/src/CoursierModule.scala
+++ b/scalalib/src/CoursierModule.scala
@@ -23,7 +23,6 @@ trait CoursierModule extends mill.Module {
    * @return The [[BoundDep]]
    */
   def bindDependency: Task[Dep => BoundDep] = T.task { dep: Dep =>
-    assert(dep.cross.isConstant, s"Not valid Java dependency: $dep")
     BoundDep((resolveCoursierDependency() : @nowarn).apply(dep), dep.force)
   }
 

--- a/scalalib/src/CoursierModule.scala
+++ b/scalalib/src/CoursierModule.scala
@@ -16,17 +16,9 @@ import mill.api.PathRef
  */
 trait CoursierModule extends mill.Module {
 
-  def resolveCoursierDependency: Task[Dep => Dependency] = T.task {
+  def resolveCoursierDependency: Task[Dep => coursier.Dependency] = T.task {
     Lib.depToDependencyJava(_: Dep)
   }
-
-  /**
-   * Task that produces a resolver that replaces any non-constant cross-version
-    * (e.g. [[CrossVersion.Binary]] or [[CrossVersion.Full]]) by a constant version ([[CrossVersion.Constant]]).
-    * This needed, whenever a Dep is used in a different context. e.g. a JavaModule that depends on a ScalaModule,
-    * or a Scala 2.13 Module depends on a Scala 3 Module.
-   */
-  def resolveCrossVersion: Task[Dep => Dep] = T.task { dep: Dep => dep }
 
   /**
    * Task that resolves the given dependencies using the repositories defined with [[repositoriesTask]].

--- a/scalalib/src/CoursierModule.scala
+++ b/scalalib/src/CoursierModule.scala
@@ -1,12 +1,14 @@
 package mill.scalalib
 
 import coursier.cache.FileCache
-
 import coursier.{Dependency, Repository, Resolve}
 import coursier.core.Resolution
+import mil.scalalib.BoundDep
 import mill.{Agg, T}
 import mill.define.Task
 import mill.api.PathRef
+
+import scala.annotation.nowarn
 
 /**
  * This module provides the capability to resolve (transitive) dependencies from (remote) repositories.
@@ -16,6 +18,16 @@ import mill.api.PathRef
  */
 trait CoursierModule extends mill.Module {
 
+  /**
+   * Bind a dependency ([[Dep]]) to the actual module contetxt (e.g. the scala version and the platform suffix)
+   * @return The [[BoundDep]]
+   */
+  def bindDependency: Task[Dep => BoundDep] = T.task { dep: Dep =>
+    assert(dep.cross.isConstant, s"Not valid Java dependency: $dep")
+    BoundDep((resolveCoursierDependency() : @nowarn).apply(dep), dep.force)
+  }
+
+  @deprecated("To be replaced by bindDependency", "Mill after 0.11.0-M0")
   def resolveCoursierDependency: Task[Dep => coursier.Dependency] = T.task {
     Lib.depToDependencyJava(_: Dep)
   }
@@ -27,18 +39,18 @@ trait CoursierModule extends mill.Module {
    * @param sources If `true`, resolve source dependencies instead of binary dependencies (JARs).
    * @return The [[PathRef]]s to the resolved files.
    */
-  def resolveDeps(deps: Task[Agg[Dep]], sources: Boolean = false): Task[Agg[PathRef]] = T.task {
-    Lib.resolveDependencies(
-      repositories = repositoriesTask(),
-      depToDependency = resolveCoursierDependency().apply(_),
-      deps = deps(),
-      sources = sources,
-      mapDependencies = Some(mapDependencies()),
-      customizer = resolutionCustomizer(),
-      coursierCacheCustomizer = coursierCacheCustomizer(),
-      ctx = Some(implicitly[mill.api.Ctx.Log])
-    )
-  }
+  def resolveDeps(deps: Task[Agg[BoundDep]], sources: Boolean = false): Task[Agg[PathRef]] =
+    T.task {
+      Lib.resolveDependencies(
+        repositories = repositoriesTask(),
+        deps = deps(),
+        sources = sources,
+        mapDependencies = Some(mapDependencies()),
+        customizer = resolutionCustomizer(),
+        coursierCacheCustomizer = coursierCacheCustomizer(),
+        ctx = Some(implicitly[mill.api.Ctx.Log])
+      )
+    }
 
   /**
    * Map dependencies before resolving them.

--- a/scalalib/src/CoursierModule.scala
+++ b/scalalib/src/CoursierModule.scala
@@ -16,9 +16,17 @@ import mill.api.PathRef
  */
 trait CoursierModule extends mill.Module {
 
-  def resolveCoursierDependency: Task[Dep => coursier.Dependency] = T.task {
+  def resolveCoursierDependency: Task[Dep => Dependency] = T.task {
     Lib.depToDependencyJava(_: Dep)
   }
+
+  /**
+   * Task that produces a resolver that replaces any non-constant cross-version
+    * (e.g. [[CrossVersion.Binary]] or [[CrossVersion.Full]]) by a constant version ([[CrossVersion.Constant]]).
+    * This needed, whenever a Dep is used in a different context. e.g. a JavaModule that depends on a ScalaModule,
+    * or a Scala 2.13 Module depends on a Scala 3 Module.
+   */
+  def resolveCrossVersion: Task[Dep => Dep] = T.task { dep: Dep => dep }
 
   /**
    * Task that resolves the given dependencies using the repositories defined with [[repositoriesTask]].

--- a/scalalib/src/Dep.scala
+++ b/scalalib/src/Dep.scala
@@ -4,7 +4,6 @@ import JsonFormatters._
 import upickle.default.{macroRW, ReadWriter => RW}
 import CrossVersion._
 import mill.scalalib.api.ZincWorkerUtil
-import coursier.Dependency
 
 case class Dep(dep: coursier.Dependency, cross: CrossVersion, force: Boolean) {
   require(
@@ -28,7 +27,7 @@ case class Dep(dep: coursier.Dependency, cross: CrossVersion, force: Boolean) {
   )
   def excludeOrg(organizations: String*): Dep = exclude(organizations.map(_ -> "*"): _*)
   def excludeName(names: String*): Dep = exclude(names.map("*" -> _): _*)
-  def toDependency(binaryVersion: String, fullVersion: String, platformSuffix: String): Dependency =
+  def toDependency(binaryVersion: String, fullVersion: String, platformSuffix: String) =
     dep.withModule(
       dep.module.withName(
         coursier.ModuleName(artifactName(binaryVersion, fullVersion, platformSuffix))
@@ -81,16 +80,6 @@ case class Dep(dep: coursier.Dependency, cross: CrossVersion, force: Boolean) {
       case _ =>
         this
     }
-
-  def withScalaVersion(scalaVersion: String): Dep = cross match {
-    case CrossVersion.Binary(platformed) => copy(
-        cross = CrossVersion.Constant(s"_${ZincWorkerUtil.scalaBinaryVersion(scalaVersion)}", platformed)
-      )
-    case CrossVersion.Full(platformed) => copy(
-        cross = CrossVersion.Constant(s"_${scalaVersion}", platformed)
-      )
-    case _ => this
-  }
 }
 
 object Dep {

--- a/scalalib/src/Dep.scala
+++ b/scalalib/src/Dep.scala
@@ -1,6 +1,6 @@
 package mill.scalalib
 
-import JsonFormatters._
+import mill.scalalib.JsonFormatters._
 import upickle.default.{macroRW, ReadWriter => RW}
 import CrossVersion._
 import mil.scalalib.BoundDep
@@ -24,7 +24,7 @@ case class Dep(dep: coursier.Dependency, cross: CrossVersion, force: Boolean) {
   def forceVersion(): Dep = copy(force = true)
   def exclude(exclusions: (String, String)*) = copy(
     dep = dep.withExclusions(
-      dep.exclusions ++
+      dep.exclusions() ++
         exclusions.map { case (k, v) => (coursier.Organization(k), coursier.ModuleName(v)) }
     )
   )

--- a/scalalib/src/Dep.scala
+++ b/scalalib/src/Dep.scala
@@ -4,6 +4,7 @@ import JsonFormatters._
 import upickle.default.{macroRW, ReadWriter => RW}
 import CrossVersion._
 import mill.scalalib.api.ZincWorkerUtil
+import coursier.Dependency
 
 case class Dep(dep: coursier.Dependency, cross: CrossVersion, force: Boolean) {
   require(
@@ -27,7 +28,7 @@ case class Dep(dep: coursier.Dependency, cross: CrossVersion, force: Boolean) {
   )
   def excludeOrg(organizations: String*): Dep = exclude(organizations.map(_ -> "*"): _*)
   def excludeName(names: String*): Dep = exclude(names.map("*" -> _): _*)
-  def toDependency(binaryVersion: String, fullVersion: String, platformSuffix: String) =
+  def toDependency(binaryVersion: String, fullVersion: String, platformSuffix: String): Dependency =
     dep.withModule(
       dep.module.withName(
         coursier.ModuleName(artifactName(binaryVersion, fullVersion, platformSuffix))
@@ -80,6 +81,16 @@ case class Dep(dep: coursier.Dependency, cross: CrossVersion, force: Boolean) {
       case _ =>
         this
     }
+
+  def withScalaVersion(scalaVersion: String): Dep = cross match {
+    case CrossVersion.Binary(platformed) => copy(
+        cross = CrossVersion.Constant(s"_${ZincWorkerUtil.scalaBinaryVersion(scalaVersion)}", platformed)
+      )
+    case CrossVersion.Full(platformed) => copy(
+        cross = CrossVersion.Constant(s"_${scalaVersion}", platformed)
+      )
+    case _ => this
+  }
 }
 
 object Dep {

--- a/scalalib/src/Dep.scala
+++ b/scalalib/src/Dep.scala
@@ -3,7 +3,10 @@ package mill.scalalib
 import JsonFormatters._
 import upickle.default.{macroRW, ReadWriter => RW}
 import CrossVersion._
+import mil.scalalib.BoundDep
 import mill.scalalib.api.ZincWorkerUtil
+
+
 
 case class Dep(dep: coursier.Dependency, cross: CrossVersion, force: Boolean) {
   require(
@@ -33,12 +36,26 @@ case class Dep(dep: coursier.Dependency, cross: CrossVersion, force: Boolean) {
         coursier.ModuleName(artifactName(binaryVersion, fullVersion, platformSuffix))
       )
     )
+  def bindDep(binaryVersion: String, fullVersion: String, platformSuffix: String): BoundDep =
+    BoundDep(
+      dep.withModule(
+        dep.module.withName(
+          coursier.ModuleName(artifactName(binaryVersion, fullVersion, platformSuffix))
+        )
+      ),
+      force
+    )
+
   def withConfiguration(configuration: String): Dep = copy(
     dep = dep.withConfiguration(coursier.core.Configuration(configuration))
   )
   def optional(optional: Boolean = true): Dep = copy(
     dep = dep.withOptional(optional)
   )
+
+  def organization = dep.module.organization.value
+  def name = dep.module.name.value
+  def version = dep.version
 
   /**
    * If scalaVersion is a Dotty version, replace the cross-version suffix

--- a/scalalib/src/JavaModule.scala
+++ b/scalalib/src/JavaModule.scala
@@ -125,8 +125,9 @@ trait JavaModule
 
   /** The compile-only transitive ivy dependencies of this module and all it's upstream compile-only modules. */
   def transitiveCompileIvyDeps: T[Agg[Dep]] = T {
+    val crossResolver = resolveCrossVersion()
     // We never include compile-only dependencies transitively, but we must include normal transitive dependencies!
-    compileIvyDeps() ++ T
+    compileIvyDeps().map(crossResolver) ++ T
       .traverse(compileModuleDeps)(_.transitiveIvyDeps)()
       .flatten
   }
@@ -175,8 +176,9 @@ trait JavaModule
    * This is calculated from [[ivyDeps]], [[mandatoryIvyDeps]] and recursively from [[moduleDeps]].
    */
   def transitiveIvyDeps: T[Agg[Dep]] = T {
+    val crossResolver = resolveCrossVersion()
     // NOTE: If you update this, reflect the changes in ScalaNativeModule
-    ivyDeps() ++ mandatoryIvyDeps() ++ T.traverse(moduleDeps)(_.transitiveIvyDeps)().flatten
+    (ivyDeps() ++ mandatoryIvyDeps()).map(crossResolver) ++ T.traverse(moduleDeps)(_.transitiveIvyDeps)().flatten
   }
 
   /**

--- a/scalalib/src/JavaModule.scala
+++ b/scalalib/src/JavaModule.scala
@@ -374,7 +374,7 @@ trait JavaModule
 
   def resolvedRunIvyDeps: T[Agg[PathRef]] = T {
     resolveDeps(T.task {
-      runIvyDeps() ++ transitiveIvyDeps()
+      runIvyDeps().map(bindDependency()) ++ transitiveIvyDeps()
     })()
   }
 
@@ -853,7 +853,8 @@ trait JavaModule
         ),
         resolveDeps(
           T.task {
-            runIvyDeps() ++ transitiveIvyDeps()
+            val bind = bindDependency()
+            runIvyDeps().map(bind) ++ transitiveIvyDeps()
           },
           sources = true
         )

--- a/scalalib/src/JavaModule.scala
+++ b/scalalib/src/JavaModule.scala
@@ -125,9 +125,8 @@ trait JavaModule
 
   /** The compile-only transitive ivy dependencies of this module and all it's upstream compile-only modules. */
   def transitiveCompileIvyDeps: T[Agg[Dep]] = T {
-    val crossResolver = resolveCrossVersion()
     // We never include compile-only dependencies transitively, but we must include normal transitive dependencies!
-    compileIvyDeps().map(crossResolver) ++ T
+    compileIvyDeps() ++ T
       .traverse(compileModuleDeps)(_.transitiveIvyDeps)()
       .flatten
   }
@@ -176,9 +175,8 @@ trait JavaModule
    * This is calculated from [[ivyDeps]], [[mandatoryIvyDeps]] and recursively from [[moduleDeps]].
    */
   def transitiveIvyDeps: T[Agg[Dep]] = T {
-    val crossResolver = resolveCrossVersion()
     // NOTE: If you update this, reflect the changes in ScalaNativeModule
-    (ivyDeps() ++ mandatoryIvyDeps()).map(crossResolver) ++ T.traverse(moduleDeps)(_.transitiveIvyDeps)().flatten
+    ivyDeps() ++ mandatoryIvyDeps() ++ T.traverse(moduleDeps)(_.transitiveIvyDeps)().flatten
   }
 
   /**

--- a/scalalib/src/Lib.scala
+++ b/scalalib/src/Lib.scala
@@ -3,6 +3,7 @@ package scalalib
 
 import coursier.util.Task
 import coursier.{Dependency, Repository, Resolution}
+import mil.scalalib.BoundDep
 import mill.api.{Ctx, Loose, PathRef, Result}
 import mill.scalalib.api.ZincWorkerUtil
 
@@ -21,8 +22,7 @@ object Lib {
 
   def resolveDependenciesMetadata(
       repositories: Seq[Repository],
-      depToDependency: Dep => coursier.Dependency,
-      deps: IterableOnce[Dep],
+      deps: IterableOnce[BoundDep],
       mapDependencies: Option[Dependency => Dependency] = None,
       customizer: Option[coursier.core.Resolution => coursier.core.Resolution] = None,
       ctx: Option[Ctx.Log] = None,
@@ -33,8 +33,8 @@ object Lib {
     val depSeq = deps.iterator.toSeq
     mill.modules.Jvm.resolveDependenciesMetadata(
       repositories = repositories,
-      deps = depSeq.map(depToDependency),
-      force = depSeq.filter(_.force).map(depToDependency),
+      deps = depSeq.map(_.dep),
+      force = depSeq.filter(_.force).map(_.dep),
       mapDependencies = mapDependencies,
       customizer = customizer,
       ctx = ctx,
@@ -51,8 +51,7 @@ object Lib {
    */
   def resolveDependencies(
       repositories: Seq[Repository],
-      depToDependency: Dep => coursier.Dependency,
-      deps: IterableOnce[Dep],
+      deps: IterableOnce[BoundDep],
       sources: Boolean = false,
       mapDependencies: Option[Dependency => Dependency] = None,
       customizer: Option[coursier.core.Resolution => coursier.core.Resolution] = None,
@@ -64,8 +63,8 @@ object Lib {
     val depSeq = deps.iterator.toSeq
     mill.modules.Jvm.resolveDependencies(
       repositories = repositories,
-      deps = depSeq.map(depToDependency),
-      force = depSeq.filter(_.force).map(depToDependency),
+      deps = depSeq.map(_.dep),
+      force = depSeq.filter(_.force).map(_.dep),
       sources = sources,
       mapDependencies = mapDependencies,
       customizer = customizer,

--- a/scalalib/src/Lib.scala
+++ b/scalalib/src/Lib.scala
@@ -5,7 +5,6 @@ import coursier.util.Task
 import coursier.{Dependency, Repository, Resolution}
 import mill.api.{Ctx, Loose, PathRef, Result}
 import mill.scalalib.api.ZincWorkerUtil
-import sbt.testing._
 
 object Lib {
   def depToDependencyJava(dep: Dep, platformSuffix: String = ""): Dependency = {

--- a/scalalib/src/Lib.scala
+++ b/scalalib/src/Lib.scala
@@ -20,6 +20,9 @@ object Lib {
       platformSuffix = platformSuffix
     )
 
+  def depToBoundDep(dep: Dep, scalaVersion: String, platformSuffix: String = ""): BoundDep =
+    BoundDep(depToDependency(dep, scalaVersion, platformSuffix), dep.force)
+
   def resolveDependenciesMetadata(
       repositories: Seq[Repository],
       deps: IterableOnce[BoundDep],

--- a/scalalib/src/Lib.scala
+++ b/scalalib/src/Lib.scala
@@ -5,6 +5,7 @@ import coursier.util.Task
 import coursier.{Dependency, Repository, Resolution}
 import mill.api.{Ctx, Loose, PathRef, Result}
 import mill.scalalib.api.ZincWorkerUtil
+import sbt.testing._
 
 object Lib {
   def depToDependencyJava(dep: Dep, platformSuffix: String = ""): Dependency = {

--- a/scalalib/src/ScalaModule.scala
+++ b/scalalib/src/ScalaModule.scala
@@ -81,8 +81,6 @@ trait ScalaModule extends JavaModule with SemanticDbJavaModule { outer =>
       Lib.depToDependency(_: Dep, scalaVersion(), platformSuffix())
     }
 
-  override def resolveCrossVersion: Task[Dep => Dep] = T.task { dep: Dep => dep.withScalaVersion(scalaVersion()) }
-
   override def resolvePublishDependency: Task[Dep => publish.Dependency] =
     T.task {
       publish.Artifact.fromDep(

--- a/scalalib/src/ScalaModule.scala
+++ b/scalalib/src/ScalaModule.scala
@@ -81,6 +81,8 @@ trait ScalaModule extends JavaModule with SemanticDbJavaModule { outer =>
       Lib.depToDependency(_: Dep, scalaVersion(), platformSuffix())
     }
 
+  override def resolveCrossVersion: Task[Dep => Dep] = T.task { dep: Dep => dep.withScalaVersion(scalaVersion()) }
+
   override def resolvePublishDependency: Task[Dep => publish.Dependency] =
     T.task {
       publish.Artifact.fromDep(

--- a/scalalib/src/ZincWorkerModule.scala
+++ b/scalalib/src/ZincWorkerModule.scala
@@ -105,14 +105,17 @@ trait ZincWorkerModule extends mill.Module with OfflineSupportModule { self: Cou
         val org = "org.scala-sbt"
         val name = "compiler-bridge"
         val version = Versions.zinc
-        (ivy"$org::$name:$version", s"${name}_$scalaBinaryVersion0", version)
+        (
+          ivy"$org:${name}_${scalaBinaryVersion0}:$version",
+          s"${name}_$scalaBinaryVersion0",
+          version
+        )
       }
     val useSources = !isBinaryBridgeAvailable(scalaVersion)
 
     val bridgeJar = resolveDependencies(
       repositories,
-      Lib.depToDependency(_, scalaVersion0),
-      Seq(bridgeDep),
+      Seq(bridgeDep.bindDep("", "", "")),
       useSources,
       Some(overrideScalaLibrary(scalaVersion, scalaOrganization))
     ).map(deps =>
@@ -136,8 +139,7 @@ trait ZincWorkerModule extends mill.Module with OfflineSupportModule { self: Cou
   ): Result[Agg[PathRef]] = {
     resolveDependencies(
       repositories = repositories,
-      depToDependency = Lib.depToDependency(_, scalaVersion, ""),
-      deps = Seq(ivy"org.scala-sbt:compiler-interface:${Versions.zinc}"),
+      deps = Seq(ivy"org.scala-sbt:compiler-interface:${Versions.zinc}".bindDep("", "", "")),
       // Since Zinc 1.4.0, the compiler-interface depends on the Scala library
       // We need to override it with the scalaVersion and scalaOrganization of the module
       mapDependencies = Some(overrideScalaLibrary(scalaVersion, scalaOrganization))

--- a/scalalib/src/dependency/versions/VersionsFinder.scala
+++ b/scalalib/src/dependency/versions/VersionsFinder.scala
@@ -32,7 +32,7 @@ private[dependency] object VersionsFinder {
   ): Seq[(JavaModule, Seq[Dependency])] = Evaluator.evalOrThrow(evaluator) {
     javaModules.map { javaModule =>
       T.task {
-        val depToDependency = javaModule.resolveCoursierDependency()
+        val bindDependency = javaModule.bindDependency()
         val deps = javaModule.ivyDeps()
         val compileIvyDeps = javaModule.compileIvyDeps()
         val runIvyDeps = javaModule.runIvyDeps()
@@ -44,8 +44,7 @@ private[dependency] object VersionsFinder {
         val (dependencies, _) =
           Lib.resolveDependenciesMetadata(
             repositories = repos,
-            depToDependency = depToDependency,
-            deps = deps ++ compileIvyDeps ++ runIvyDeps,
+            deps = (deps ++ compileIvyDeps ++ runIvyDeps).map(bindDependency),
             mapDependencies = Some(mapDeps),
             customizer = custom,
             coursierCacheCustomizer = cacheCustom,

--- a/scalalib/src/giter8/Giter8Module.scala
+++ b/scalalib/src/giter8/Giter8Module.scala
@@ -19,7 +19,8 @@ trait Giter8Module extends CoursierModule {
     val giter8Dependencies = resolveDeps(
       T.task {
         val scalaBinVersion = ZincWorkerUtil.scalaBinaryVersion(BuildInfo.scalaVersion)
-        Loose.Agg(ivy"org.foundweekends.giter8:giter8_${scalaBinVersion}:0.14.0")
+        Loose.Agg(ivy"org.foundweekends.giter8:giter8_${scalaBinVersion}:0.14.0"
+          .bindDep("", "", ""))
       }
     )()
 

--- a/scalalib/src/mil/scalalib/BoundDep.scala
+++ b/scalalib/src/mil/scalalib/BoundDep.scala
@@ -1,0 +1,21 @@
+package mil.scalalib
+
+import mill.scalalib.{CrossVersion, Dep}
+
+/**
+ * Same as [[Dep]] but with already bound cross and platform settings.
+ */
+case class BoundDep(
+    dep: coursier.Dependency,
+    force: Boolean
+) {
+
+  def toDep: Dep = Dep(dep = dep, cross = CrossVersion.empty(false), force = force)
+
+  def exclude(exclusions: (String, String)*) = copy(
+    dep = dep.withExclusions(
+      dep.exclusions ++
+        exclusions.map { case (k, v) => (coursier.Organization(k), coursier.ModuleName(v)) }
+    )
+  )
+}

--- a/scalalib/src/mil/scalalib/BoundDep.scala
+++ b/scalalib/src/mil/scalalib/BoundDep.scala
@@ -1,6 +1,7 @@
 package mil.scalalib
 
 import mill.scalalib.{CrossVersion, Dep}
+import mill.scalalib.JsonFormatters._
 
 /**
  * Same as [[Dep]] but with already bound cross and platform settings.
@@ -9,6 +10,9 @@ case class BoundDep(
     dep: coursier.Dependency,
     force: Boolean
 ) {
+  def organization = dep.module.organization.value
+  def name = dep.module.name.value
+  def version = dep.version
 
   def toDep: Dep = Dep(dep = dep, cross = CrossVersion.empty(false), force = force)
 
@@ -18,4 +22,8 @@ case class BoundDep(
         exclusions.map { case (k, v) => (coursier.Organization(k), coursier.ModuleName(v)) }
     )
   )
+}
+
+object BoundDep {
+  implicit val jsonify: upickle.default.ReadWriter[BoundDep] = upickle.default.macroRW
 }

--- a/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
+++ b/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
@@ -50,16 +50,25 @@ trait SemanticDbJavaModule extends JavaModule { hostModule =>
    * Scalac options to activate the compiler plugins.
    */
   private def semanticDbEnablePluginScalacOptions: Target[Seq[String]] = T {
-    val resolvedJars = resolveDeps(semanticDbPluginIvyDeps.map(_.map(_.exclude("*" -> "*"))))()
+    val resolvedJars = resolveDeps(T.task {
+      val bind = bindDependency()
+      semanticDbPluginIvyDeps().map(_.exclude("*" -> "*")).map(bind)
+    })()
     resolvedJars.iterator.map(jar => s"-Xplugin:${jar.path}").toSeq
   }
 
   private def semanticDbPluginClasspath: T[Agg[PathRef]] = hostModule match {
     case m: ScalaModule => T {
-        resolveDeps(T { m.scalacPluginIvyDeps() ++ semanticDbPluginIvyDeps() })()
+        resolveDeps(T.task {
+          val bind = bindDependency()
+          (m.scalacPluginIvyDeps() ++ semanticDbPluginIvyDeps()).map(bind)
+        })()
       }
     case _ => T {
-        resolveDeps(semanticDbPluginIvyDeps)()
+        resolveDeps(T.task {
+          val bind = bindDependency()
+          semanticDbPluginIvyDeps().map(bind)
+        })()
       }
   }
 

--- a/scalalib/test/src/CrossVersionTests.scala
+++ b/scalalib/test/src/CrossVersionTests.scala
@@ -115,10 +115,13 @@ object CrossVersionTests extends TestSuite {
     val eval = init()
     eval.apply(mod.ivyDepsTree(IvyDepsTreeArgs()))
 
-    val expectedDepsTree = mod.tree
-    val depsTree =
-      os.read(eval.evaluator.pathsResolver.resolveDest(mod.ivyDepsTree(IvyDepsTreeArgs())).log)
-    assert(depsTree == expectedDepsTree)
+    if(!scala.util.Properties.isWin) {
+      // Escape-sequence formatting isn't working under bare Windows
+      val expectedDepsTree = mod.tree
+      val depsTree =
+        os.read(eval.evaluator.pathsResolver.resolveDest(mod.ivyDepsTree(IvyDepsTreeArgs())).log)
+      assert(depsTree == expectedDepsTree)
+    }
 
     val Right((deps, _)) = eval.apply(mod.transitiveIvyDeps)
 

--- a/scalalib/test/src/CrossVersionTests.scala
+++ b/scalalib/test/src/CrossVersionTests.scala
@@ -10,75 +10,86 @@ object CrossVersionTests extends TestSuite {
 
   object TestCases extends TestUtil.BaseModule {
 
-    object StandaloneScala213 extends ScalaModule {
-      // ├─ com.lihaoyi:upickle_2.13:1.4.0
-      // │  ├─ com.lihaoyi:ujson_2.13:1.4.0
-      // │  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0
-      // │  │     └─ com.lihaoyi:geny_2.13:0.6.10
-      // │  ├─ com.lihaoyi:upack_2.13:1.4.0
-      // │  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0
-      // │  │     └─ com.lihaoyi:geny_2.13:0.6.10
-      // │  └─ com.lihaoyi:upickle-implicits_2.13:1.4.0
-      // │     └─ com.lihaoyi:upickle-core_2.13:1.4.0
-      // │        └─ com.lihaoyi:geny_2.13:0.6.10
-      // └─ org.scala-lang:scala-library:2.13.10
+    trait ExpectedDepsTree {
+      def tree: String
+    }
+    object StandaloneScala213 extends ScalaModule with ExpectedDepsTree {
+      override val tree =
+        """├─ com.lihaoyi:upickle_2.13:1.4.0
+          |│  ├─ com.lihaoyi:ujson_2.13:1.4.0
+          |│  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0
+          |│  │     └─ com.lihaoyi:geny_2.13:0.6.10
+          |│  ├─ com.lihaoyi:upack_2.13:1.4.0
+          |│  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0
+          |│  │     └─ com.lihaoyi:geny_2.13:0.6.10
+          |│  └─ com.lihaoyi:upickle-implicits_2.13:1.4.0
+          |│     └─ com.lihaoyi:upickle-core_2.13:1.4.0
+          |│        └─ com.lihaoyi:geny_2.13:0.6.10
+          |└─ org.scala-lang:scala-library:2.13.10
+          |""".stripMargin
       override def scalaVersion = "2.13.10"
       override def ivyDeps = Agg(ivy"com.lihaoyi::upickle:1.4.0")
     }
 
-    object JavaDependsOnScala213 extends JavaModule {
-      // ├─ org.slf4j:slf4j-api:1.7.35
-      // ├─ com.lihaoyi:upickle_2.13:1.4.0
-      // │  ├─ com.lihaoyi:ujson_2.13:1.4.0
-      // │  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0
-      // │  │     └─ com.lihaoyi:geny_2.13:0.6.10
-      // │  ├─ com.lihaoyi:upack_2.13:1.4.0
-      // │  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0
-      // │  │     └─ com.lihaoyi:geny_2.13:0.6.10
-      // │  └─ com.lihaoyi:upickle-implicits_2.13:1.4.0
-      // │     └─ com.lihaoyi:upickle-core_2.13:1.4.0
-      // │        └─ com.lihaoyi:geny_2.13:0.6.10
-      // └─ org.scala-lang:scala-library:2.13.10
+    object JavaDependsOnScala213 extends JavaModule with ExpectedDepsTree {
+      override val tree =
+        """├─ org.slf4j:slf4j-api:1.7.35
+          |├─ com.lihaoyi:upickle_2.13:1.4.0
+          |│  ├─ com.lihaoyi:ujson_2.13:1.4.0
+          |│  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0
+          |│  │     └─ com.lihaoyi:geny_2.13:0.6.10
+          |│  ├─ com.lihaoyi:upack_2.13:1.4.0
+          |│  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0
+          |│  │     └─ com.lihaoyi:geny_2.13:0.6.10
+          |│  └─ com.lihaoyi:upickle-implicits_2.13:1.4.0
+          |│     └─ com.lihaoyi:upickle-core_2.13:1.4.0
+          |│        └─ com.lihaoyi:geny_2.13:0.6.10
+          |└─ org.scala-lang:scala-library:2.13.10
+          |""".stripMargin
       override def moduleDeps = Seq(StandaloneScala213)
       override def ivyDeps = Agg(ivy"org.slf4j:slf4j-api:1.7.35")
     }
 
-    object Scala3DependsOnScala213 extends ScalaModule {
-      // ├─ com.lihaoyi:sourcecode_3:0.2.7
-      // ├─ org.scala-lang:scala3-library_3:3.2.1
-      // │  └─ org.scala-lang:scala-library:2.13.10
-      // ├─ com.lihaoyi:upickle_2.13:1.4.0
-      // │  ├─ com.lihaoyi:ujson_2.13:1.4.0
-      // │  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0
-      // │  │     └─ com.lihaoyi:geny_2.13:0.6.10
-      // │  ├─ com.lihaoyi:upack_2.13:1.4.0
-      // │  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0
-      // │  │     └─ com.lihaoyi:geny_2.13:0.6.10
-      // │  └─ com.lihaoyi:upickle-implicits_2.13:1.4.0
-      // │     └─ com.lihaoyi:upickle-core_2.13:1.4.0
-      // │        └─ com.lihaoyi:geny_2.13:0.6.10
-      // └─ org.scala-lang:scala-library:2.13.10
+    object Scala3DependsOnScala213 extends ScalaModule with ExpectedDepsTree {
+      override val tree =
+        """├─ com.lihaoyi:sourcecode_3:0.2.7
+          |├─ org.scala-lang:scala3-library_3:3.2.1
+          |│  └─ org.scala-lang:scala-library:2.13.10
+          |├─ com.lihaoyi:upickle_2.13:1.4.0
+          |│  ├─ com.lihaoyi:ujson_2.13:1.4.0
+          |│  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0
+          |│  │     └─ com.lihaoyi:geny_2.13:0.6.10
+          |│  ├─ com.lihaoyi:upack_2.13:1.4.0
+          |│  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0
+          |│  │     └─ com.lihaoyi:geny_2.13:0.6.10
+          |│  └─ com.lihaoyi:upickle-implicits_2.13:1.4.0
+          |│     └─ com.lihaoyi:upickle-core_2.13:1.4.0
+          |│        └─ com.lihaoyi:geny_2.13:0.6.10
+          |└─ org.scala-lang:scala-library:2.13.10
+          |""".stripMargin
       override def scalaVersion = "3.2.1"
       override def moduleDeps = Seq(StandaloneScala213)
       override def ivyDeps = Agg(ivy"com.lihaoyi::sourcecode:0.2.7")
     }
 
-    object JavaDependsOnScala3 extends JavaModule {
-      // ├─ org.slf4j:slf4j-api:1.7.35
-      // ├─ com.lihaoyi:sourcecode_3:0.2.7
-      // ├─ org.scala-lang:scala3-library_3:3.2.1
-      // │  └─ org.scala-lang:scala-library:2.13.10
-      // ├─ com.lihaoyi:upickle_2.13:1.4.0
-      // │  ├─ com.lihaoyi:ujson_2.13:1.4.0
-      // │  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0
-      // │  │     └─ com.lihaoyi:geny_2.13:0.6.10
-      // │  ├─ com.lihaoyi:upack_2.13:1.4.0
-      // │  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0
-      // │  │     └─ com.lihaoyi:geny_2.13:0.6.10
-      // │  └─ com.lihaoyi:upickle-implicits_2.13:1.4.0
-      // │     └─ com.lihaoyi:upickle-core_2.13:1.4.0
-      // │        └─ com.lihaoyi:geny_2.13:0.6.10
-      // └─ org.scala-lang:scala-library:2.13.10
+    object JavaDependsOnScala3 extends JavaModule with ExpectedDepsTree {
+      override val tree =
+        """├─ org.slf4j:slf4j-api:1.7.35
+          |├─ com.lihaoyi:sourcecode_3:0.2.7
+          |├─ org.scala-lang:scala3-library_3:3.2.1
+          |│  └─ org.scala-lang:scala-library:2.13.10
+          |├─ com.lihaoyi:upickle_2.13:1.4.0
+          |│  ├─ com.lihaoyi:ujson_2.13:1.4.0
+          |│  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0
+          |│  │     └─ com.lihaoyi:geny_2.13:0.6.10
+          |│  ├─ com.lihaoyi:upack_2.13:1.4.0
+          |│  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0
+          |│  │     └─ com.lihaoyi:geny_2.13:0.6.10
+          |│  └─ com.lihaoyi:upickle-implicits_2.13:1.4.0
+          |│     └─ com.lihaoyi:upickle-core_2.13:1.4.0
+          |│        └─ com.lihaoyi:geny_2.13:0.6.10
+          |└─ org.scala-lang:scala-library:2.13.10
+          |""".stripMargin
       override def moduleDeps = Seq(Scala3DependsOnScala213)
       override def ivyDeps = Agg(ivy"org.slf4j:slf4j-api:1.7.35")
     }
@@ -94,11 +105,21 @@ object CrossVersionTests extends TestSuite {
 
   import TestCases._
 
-  def check(mod: JavaModule, expectedDeps: Seq[String], expectedLibs: Seq[String])(implicit
+  def check(
+      mod: JavaModule with ExpectedDepsTree,
+      expectedDeps: Seq[String],
+      expectedLibs: Seq[String]
+  )(implicit
       testPath: TestPath
   ) = {
     val eval = init()
-    eval.apply(mod.ivyDepsTree())
+    eval.apply(mod.ivyDepsTree(IvyDepsTreeArgs()))
+
+    val expectedDepsTree = mod.tree
+    val depsTree =
+      os.read(eval.evaluator.pathsResolver.resolveDest(mod.ivyDepsTree(IvyDepsTreeArgs())).log)
+    assert(depsTree == expectedDepsTree)
+
     val Right((deps, _)) = eval.apply(mod.transitiveIvyDeps)
 
     val depNames = deps.toSeq.map(d => d.name).sorted

--- a/scalalib/test/src/CrossVersionTests.scala
+++ b/scalalib/test/src/CrossVersionTests.scala
@@ -13,22 +13,24 @@ object CrossVersionTests extends TestSuite {
 //      TestUtil.getSrcPathBase() / millOuterCtx.enclosing.split('.')
   }
 
-  object HelloJava extends TestBase with JavaModule {
-    override def moduleDeps = Seq(HelloScala213)
-    override def ivyDeps = T { Agg(ivy"org.slf4j:slf4j-api:1.2.6") }
-  }
-  object HelloScala213 extends TestBase with ScalaModule {
-    def scalaVersion = "2.13.6"
-    override def moduleDeps = Seq(HelloScala3)
-    override def ivyDeps = T { Agg(ivy"com.lihaoyi::sourcecode:0.2.7") }
-    override def scalacOptions = T { Seq("-Ytasty-reader") }
-  }
   object HelloScala3 extends TestBase with ScalaModule {
     def scalaVersion = "3.0.2"
     override def ivyDeps = T { Agg(ivy"com.lihaoyi::upickle:1.4.0") }
   }
 
-//  val resourcePath = os.pwd / "scalalib" / "test" / "resources" / "hello-java"
+  object HelloScala213 extends TestBase with ScalaModule {
+    def scalaVersion = "2.13.7"
+    override def moduleDeps = Seq(HelloScala3)
+    override def ivyDeps = T { Agg(ivy"com.lihaoyi::sourcecode:0.2.7") }
+    override def scalacOptions = T { Seq("-Ytasty-reader") }
+  }
+
+  object HelloJava extends TestBase with JavaModule {
+    override def moduleDeps = Seq(HelloScala213)
+    override def ivyDeps = T { Agg(ivy"org.slf4j:slf4j-api:1.2.6") }
+  }
+
+  //  val resourcePath = os.pwd / "scalalib" / "test" / "resources" / "hello-java"
 
   def init()(implicit tp: TestPath) = {
     val eval = new TestEvaluator(HelloJava)
@@ -44,39 +46,42 @@ object CrossVersionTests extends TestSuite {
       val eval = init()
 
       {
+        println("1")
         eval.apply(HelloScala3.ivyDepsTree())
         val Right((deps, _)) = eval.apply(HelloScala3.allIvyDeps)
         assert(
-          deps.size == 2
-          //        deps.forall(_.cross.isBinary)
+          deps.size == 2,
+          deps.forall(_.cross.isBinary)
         )
       }
 
       {
+        println("2")
         eval.apply(HelloScala213.ivyDepsTree())
-        val Right((deps, _)) = eval.apply(HelloScala213.transitiveIvyDeps)
-        assert(
-          deps.size == 4
-//        deps.forall(_.cross.isConstant)
-        )
+//        val Right((deps, _)) = eval.apply(HelloScala213.transitiveIvyDeps)
+//        assert(
+//          deps.size == 4,
+//          deps.forall(_.cross.isConstant)
+//        )
       }
 
       {
+        println("3")
         eval.apply(HelloJava.ivyDepsTree())
-        val Right((deps, _)) = eval.apply(HelloJava.transitiveIvyDeps)
-        assert(
-          deps.size == 5,
-//        deps.forall(_.cross.isConstant),
-          deps.collect {
-            case d @ Dep(_, CrossVersion.Constant("_3", _), _) => d
-          }.size == 2,
-          deps.collect {
-            case d @ Dep(_, CrossVersion.Constant("_2.13", _), _) => d
-          }.size == 1,
-          deps.collect {
-            case d @ Dep(_, CrossVersion.Constant("", _), _) => d
-          }.size == 2
-        )
+//        val Right((deps, _)) = eval.apply(HelloJava.transitiveIvyDeps)
+//        assert(
+//          deps.size == 5,
+////        deps.forall(_.cross.isConstant),
+//          deps.collect {
+//            case d @ Dep(_, CrossVersion.Constant("_3", _), _) => d
+//          }.size == 2,
+//          deps.collect {
+//            case d @ Dep(_, CrossVersion.Constant("_2.13", _), _) => d
+//          }.size == 1,
+//          deps.collect {
+//            case d @ Dep(_, CrossVersion.Constant("", _), _) => d
+//          }.size == 2
+//        )
       }
     }
   }

--- a/scalalib/test/src/CrossVersionTests.scala
+++ b/scalalib/test/src/CrossVersionTests.scala
@@ -1,0 +1,83 @@
+package mill.scalalib
+
+import mill.{Agg, Module, T}
+import mill.api.{Loose, Result}
+import mill.util.{TestEvaluator, TestUtil}
+import utest._
+import utest.framework.TestPath
+
+object CrossVersionTests extends TestSuite {
+
+  trait TestBase extends TestUtil.BaseModule {
+//    override def millSourcePath: os.Path =
+//      TestUtil.getSrcPathBase() / millOuterCtx.enclosing.split('.')
+  }
+
+  object HelloJava extends TestBase with JavaModule {
+    override def moduleDeps = Seq(HelloScala213)
+    override def ivyDeps = T { Agg(ivy"org.slf4j:slf4j-api:1.2.6") }
+  }
+  object HelloScala213 extends TestBase with ScalaModule {
+    def scalaVersion = "2.13.6"
+    override def moduleDeps = Seq(HelloScala3)
+    override def ivyDeps = T { Agg(ivy"com.lihaoyi::sourcecode:0.2.7") }
+    override def scalacOptions = T { Seq("-Ytasty-reader") }
+  }
+  object HelloScala3 extends TestBase with ScalaModule {
+    def scalaVersion = "3.0.2"
+    override def ivyDeps = T { Agg(ivy"com.lihaoyi::upickle:1.4.0") }
+  }
+
+//  val resourcePath = os.pwd / "scalalib" / "test" / "resources" / "hello-java"
+
+  def init()(implicit tp: TestPath) = {
+    val eval = new TestEvaluator(HelloJava)
+//    os.remove.all(HelloJava.millSourcePath)
+    os.remove.all(eval.outPath)
+    os.makeDir.all(HelloJava.millSourcePath / os.up)
+//    os.copy(resourcePath, HelloJava.millSourcePath)
+    eval
+  }
+
+  def tests: Tests = Tests {
+    "transitive ivy deps have resolved cross-versions" - {
+      val eval = init()
+
+      {
+        eval.apply(HelloScala3.ivyDepsTree())
+        val Right((deps, _)) = eval.apply(HelloScala3.allIvyDeps)
+        assert(
+          deps.size == 2
+          //        deps.forall(_.cross.isBinary)
+        )
+      }
+
+      {
+        eval.apply(HelloScala213.ivyDepsTree())
+        val Right((deps, _)) = eval.apply(HelloScala213.transitiveIvyDeps)
+        assert(
+          deps.size == 4
+//        deps.forall(_.cross.isConstant)
+        )
+      }
+
+      {
+        eval.apply(HelloJava.ivyDepsTree())
+        val Right((deps, _)) = eval.apply(HelloJava.transitiveIvyDeps)
+        assert(
+          deps.size == 5,
+//        deps.forall(_.cross.isConstant),
+          deps.collect {
+            case d @ Dep(_, CrossVersion.Constant("_3", _), _) => d
+          }.size == 2,
+          deps.collect {
+            case d @ Dep(_, CrossVersion.Constant("_2.13", _), _) => d
+          }.size == 1,
+          deps.collect {
+            case d @ Dep(_, CrossVersion.Constant("", _), _) => d
+          }.size == 2
+        )
+      }
+    }
+  }
+}

--- a/scalalib/test/src/CrossVersionTests.scala
+++ b/scalalib/test/src/CrossVersionTests.scala
@@ -8,81 +8,198 @@ import utest.framework.TestPath
 
 object CrossVersionTests extends TestSuite {
 
-  trait TestBase extends TestUtil.BaseModule {
-//    override def millSourcePath: os.Path =
-//      TestUtil.getSrcPathBase() / millOuterCtx.enclosing.split('.')
-  }
+  object TestCases extends TestUtil.BaseModule {
 
-  object HelloScala3 extends TestBase with ScalaModule {
-    def scalaVersion = "3.0.2"
-    override def ivyDeps = T { Agg(ivy"com.lihaoyi::upickle:1.4.0") }
-  }
+    object StandaloneScala213 extends ScalaModule {
+      // ├─ com.lihaoyi:upickle_2.13:1.4.0
+      // │  ├─ com.lihaoyi:ujson_2.13:1.4.0
+      // │  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0
+      // │  │     └─ com.lihaoyi:geny_2.13:0.6.10
+      // │  ├─ com.lihaoyi:upack_2.13:1.4.0
+      // │  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0
+      // │  │     └─ com.lihaoyi:geny_2.13:0.6.10
+      // │  └─ com.lihaoyi:upickle-implicits_2.13:1.4.0
+      // │     └─ com.lihaoyi:upickle-core_2.13:1.4.0
+      // │        └─ com.lihaoyi:geny_2.13:0.6.10
+      // └─ org.scala-lang:scala-library:2.13.10
+      override def scalaVersion = "2.13.10"
+      override def ivyDeps = Agg(ivy"com.lihaoyi::upickle:1.4.0")
+    }
 
-  object HelloScala213 extends TestBase with ScalaModule {
-    def scalaVersion = "2.13.7"
-    override def moduleDeps = Seq(HelloScala3)
-    override def ivyDeps = T { Agg(ivy"com.lihaoyi::sourcecode:0.2.7") }
-    override def scalacOptions = T { Seq("-Ytasty-reader") }
-  }
+    object JavaDependsOnScala213 extends JavaModule {
+      // ├─ org.slf4j:slf4j-api:1.7.35
+      // ├─ com.lihaoyi:upickle_2.13:1.4.0
+      // │  ├─ com.lihaoyi:ujson_2.13:1.4.0
+      // │  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0
+      // │  │     └─ com.lihaoyi:geny_2.13:0.6.10
+      // │  ├─ com.lihaoyi:upack_2.13:1.4.0
+      // │  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0
+      // │  │     └─ com.lihaoyi:geny_2.13:0.6.10
+      // │  └─ com.lihaoyi:upickle-implicits_2.13:1.4.0
+      // │     └─ com.lihaoyi:upickle-core_2.13:1.4.0
+      // │        └─ com.lihaoyi:geny_2.13:0.6.10
+      // └─ org.scala-lang:scala-library:2.13.10
+      override def moduleDeps = Seq(StandaloneScala213)
+      override def ivyDeps = Agg(ivy"org.slf4j:slf4j-api:1.7.35")
+    }
 
-  object HelloJava extends TestBase with JavaModule {
-    override def moduleDeps = Seq(HelloScala213)
-    override def ivyDeps = T { Agg(ivy"org.slf4j:slf4j-api:1.2.6") }
-  }
+    object Scala3DependsOnScala213 extends ScalaModule {
+      // ├─ com.lihaoyi:sourcecode_3:0.2.7
+      // ├─ org.scala-lang:scala3-library_3:3.2.1
+      // │  └─ org.scala-lang:scala-library:2.13.10
+      // ├─ com.lihaoyi:upickle_2.13:1.4.0
+      // │  ├─ com.lihaoyi:ujson_2.13:1.4.0
+      // │  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0
+      // │  │     └─ com.lihaoyi:geny_2.13:0.6.10
+      // │  ├─ com.lihaoyi:upack_2.13:1.4.0
+      // │  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0
+      // │  │     └─ com.lihaoyi:geny_2.13:0.6.10
+      // │  └─ com.lihaoyi:upickle-implicits_2.13:1.4.0
+      // │     └─ com.lihaoyi:upickle-core_2.13:1.4.0
+      // │        └─ com.lihaoyi:geny_2.13:0.6.10
+      // └─ org.scala-lang:scala-library:2.13.10
+      override def scalaVersion = "3.2.1"
+      override def moduleDeps = Seq(StandaloneScala213)
+      override def ivyDeps = Agg(ivy"com.lihaoyi::sourcecode:0.2.7")
+    }
 
-  //  val resourcePath = os.pwd / "scalalib" / "test" / "resources" / "hello-java"
+    object JavaDependsOnScala3 extends JavaModule {
+      // ├─ org.slf4j:slf4j-api:1.7.35
+      // ├─ com.lihaoyi:sourcecode_3:0.2.7
+      // ├─ org.scala-lang:scala3-library_3:3.2.1
+      // │  └─ org.scala-lang:scala-library:2.13.10
+      // ├─ com.lihaoyi:upickle_2.13:1.4.0
+      // │  ├─ com.lihaoyi:ujson_2.13:1.4.0
+      // │  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0
+      // │  │     └─ com.lihaoyi:geny_2.13:0.6.10
+      // │  ├─ com.lihaoyi:upack_2.13:1.4.0
+      // │  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0
+      // │  │     └─ com.lihaoyi:geny_2.13:0.6.10
+      // │  └─ com.lihaoyi:upickle-implicits_2.13:1.4.0
+      // │     └─ com.lihaoyi:upickle-core_2.13:1.4.0
+      // │        └─ com.lihaoyi:geny_2.13:0.6.10
+      // └─ org.scala-lang:scala-library:2.13.10
+      override def moduleDeps = Seq(Scala3DependsOnScala213)
+      override def ivyDeps = Agg(ivy"org.slf4j:slf4j-api:1.7.35")
+    }
+
+  }
 
   def init()(implicit tp: TestPath) = {
-    val eval = new TestEvaluator(HelloJava)
-//    os.remove.all(HelloJava.millSourcePath)
+    val eval = new TestEvaluator(TestCases)
     os.remove.all(eval.outPath)
-    os.makeDir.all(HelloJava.millSourcePath / os.up)
-//    os.copy(resourcePath, HelloJava.millSourcePath)
+    os.makeDir.all(TestCases.millSourcePath / os.up)
     eval
   }
 
+  import TestCases._
+
+  def check(mod: JavaModule, expectedDeps: Seq[String], expectedLibs: Seq[String])(implicit
+      testPath: TestPath
+  ) = {
+    val eval = init()
+    eval.apply(mod.ivyDepsTree())
+    val Right((deps, _)) = eval.apply(mod.transitiveIvyDeps)
+
+    val depNames = deps.toSeq.map(d => d.name).sorted
+
+    assert(depNames == expectedDeps.sorted)
+
+    val Right((libs, _)) = eval.apply(mod.compileClasspath)
+
+    val libNames = libs.map(l => l.path.last).filter(_.endsWith(".jar")).toSeq.sorted
+    assert(libNames == expectedLibs.sorted)
+  }
+
   def tests: Tests = Tests {
-    "transitive ivy deps have resolved cross-versions" - {
-      val eval = init()
 
-      {
-        println("1")
-        eval.apply(HelloScala3.ivyDepsTree())
-        val Right((deps, _)) = eval.apply(HelloScala3.allIvyDeps)
-        assert(
-          deps.size == 2,
-          deps.forall(_.cross.isBinary)
+    test("StandaloneScala213") {
+      check(
+        mod = StandaloneScala213,
+        expectedDeps = Seq(
+          "scala-library",
+          "upickle_2.13"
+        ),
+        expectedLibs = Seq(
+          "geny_2.13-0.6.10.jar",
+          "scala-library-2.13.10.jar",
+          "ujson_2.13-1.4.0.jar",
+          "upack_2.13-1.4.0.jar",
+          "upickle-core_2.13-1.4.0.jar",
+          "upickle-implicits_2.13-1.4.0.jar",
+          "upickle_2.13-1.4.0.jar"
         )
-      }
-
-      {
-        println("2")
-        eval.apply(HelloScala213.ivyDepsTree())
-//        val Right((deps, _)) = eval.apply(HelloScala213.transitiveIvyDeps)
-//        assert(
-//          deps.size == 4,
-//          deps.forall(_.cross.isConstant)
-//        )
-      }
-
-      {
-        println("3")
-        eval.apply(HelloJava.ivyDepsTree())
-//        val Right((deps, _)) = eval.apply(HelloJava.transitiveIvyDeps)
-//        assert(
-//          deps.size == 5,
-////        deps.forall(_.cross.isConstant),
-//          deps.collect {
-//            case d @ Dep(_, CrossVersion.Constant("_3", _), _) => d
-//          }.size == 2,
-//          deps.collect {
-//            case d @ Dep(_, CrossVersion.Constant("_2.13", _), _) => d
-//          }.size == 1,
-//          deps.collect {
-//            case d @ Dep(_, CrossVersion.Constant("", _), _) => d
-//          }.size == 2
-//        )
-      }
+      )
     }
+
+    test("JavaDependsOnScala213") {
+      check(
+        mod = JavaDependsOnScala213,
+        expectedDeps = Seq(
+          "scala-library",
+          "upickle_2.13",
+          "slf4j-api"
+        ),
+        expectedLibs = Seq(
+          "slf4j-api-1.7.35.jar",
+          "geny_2.13-0.6.10.jar",
+          "scala-library-2.13.10.jar",
+          "ujson_2.13-1.4.0.jar",
+          "upack_2.13-1.4.0.jar",
+          "upickle-core_2.13-1.4.0.jar",
+          "upickle-implicits_2.13-1.4.0.jar",
+          "upickle_2.13-1.4.0.jar"
+        )
+      )
+    }
+
+    test("Scala3DependsOnScala213") {
+      check(
+        mod = Scala3DependsOnScala213,
+        expectedDeps = Seq(
+          "scala-library",
+          "scala3-library_3",
+          "upickle_2.13",
+          "sourcecode_3"
+        ),
+        expectedLibs = Seq(
+          "sourcecode_3-0.2.7.jar",
+          "geny_2.13-0.6.10.jar",
+          "scala-library-2.13.10.jar",
+          "scala3-library_3-3.2.1.jar",
+          "ujson_2.13-1.4.0.jar",
+          "upack_2.13-1.4.0.jar",
+          "upickle-core_2.13-1.4.0.jar",
+          "upickle-implicits_2.13-1.4.0.jar",
+          "upickle_2.13-1.4.0.jar"
+        )
+      )
+    }
+
+    test("JavaDependsOnScala3") {
+      check(
+        mod = JavaDependsOnScala3,
+        expectedDeps = Seq(
+          "scala-library",
+          "scala3-library_3",
+          "upickle_2.13",
+          "sourcecode_3",
+          "slf4j-api"
+        ),
+        expectedLibs = Seq(
+          "slf4j-api-1.7.35.jar",
+          "sourcecode_3-0.2.7.jar",
+          "geny_2.13-0.6.10.jar",
+          "scala-library-2.13.10.jar",
+          "scala3-library_3-3.2.1.jar",
+          "ujson_2.13-1.4.0.jar",
+          "upack_2.13-1.4.0.jar",
+          "upickle-core_2.13-1.4.0.jar",
+          "upickle-implicits_2.13-1.4.0.jar",
+          "upickle_2.13-1.4.0.jar"
+        )
+      )
+    }
+
   }
 }

--- a/scalalib/test/src/ResolveDepsTests.scala
+++ b/scalalib/test/src/ResolveDepsTests.scala
@@ -13,8 +13,7 @@ object ResolveDepsTests extends TestSuite {
 
   def evalDeps(deps: Agg[Dep]): Result[Agg[PathRef]] = Lib.resolveDependencies(
     repos,
-    Lib.depToDependency(_, scala212Version, ""),
-    deps
+    deps.map(Lib.depToBoundDep(_, scala212Version, ""))
   )
 
   val tests = Tests {

--- a/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
+++ b/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
@@ -2,6 +2,7 @@ package mill
 package scalanativelib
 
 import ch.epfl.scala.bsp4j.{BuildTargetDataKind, ScalaBuildTarget, ScalaPlatform}
+import mil.scalalib.BoundDep
 import mill.api.Loose.Agg
 import mill.api.{Result, internal}
 import mill.define.{Target, Task}
@@ -272,31 +273,31 @@ trait ScalaNativeModule extends ScalaModule { outer =>
     ))
   }
 
-  override def transitiveIvyDeps: T[Agg[Dep]] = T {
-    // TODO when in bin-compat breaking window: Change list to `super.transitiveIvyDeps()`
-    (ivyDeps() ++ mandatoryIvyDeps() ++ T.traverse(moduleDeps)(_.transitiveIvyDeps)().flatten).map {
-      dep =>
-        // Exclude cross published version dependencies leading to conflicts in Scala 3 vs 2.13
-        // When using Scala 3 exclude Scala 2.13 standard native libraries,
-        // when using Scala 2.13 exclude Scala 3 standard native libraries
-        // Use full name, Maven style published artifacts cannot use artifact/cross version for exclusion rules
-        val nativeStandardLibraries =
-          Seq("nativelib", "clib", "posixlib", "windowslib", "javalib", "auxlib")
+  override def transitiveIvyDeps: T[Agg[BoundDep]] = T {
 
-        val scalaBinaryVersionToExclude = artifactScalaVersion() match {
-          case "3" => "2.13" :: Nil
-          case "2.13" => "3" :: Nil
-          case _ => Nil
-        }
+    // Exclude cross published version dependencies leading to conflicts in Scala 3 vs 2.13
+    // When using Scala 3 exclude Scala 2.13 standard native libraries,
+    // when using Scala 2.13 exclude Scala 3 standard native libraries
+    // Use full name, Maven style published artifacts cannot use artifact/cross version for exclusion rules
+    val nativeStandardLibraries =
+      Seq("nativelib", "clib", "posixlib", "windowslib", "javalib", "auxlib")
 
-        val nativeSuffix = platformSuffix()
+    val scalaBinaryVersionToExclude = artifactScalaVersion() match {
+      case "3" => "2.13" :: Nil
+      case "2.13" => "3" :: Nil
+      case _ => Nil
+    }
 
-        val exclusions = scalaBinaryVersionToExclude.flatMap { scalaBinVersion =>
-          nativeStandardLibraries.map(library =>
-            "org.scala-native" -> s"$library${nativeSuffix}_$scalaBinVersion"
-          )
-        }
-        dep.exclude(exclusions: _*)
+    val nativeSuffix = platformSuffix()
+
+    val exclusions = scalaBinaryVersionToExclude.flatMap { scalaBinVersion =>
+      nativeStandardLibraries.map(library =>
+        "org.scala-native" -> s"$library${nativeSuffix}_$scalaBinVersion"
+      )
+    }
+
+    super.transitiveIvyDeps().map { dep =>
+      dep.exclude(exclusions: _*)
     }
   }
 }

--- a/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
+++ b/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
@@ -96,8 +96,7 @@ trait ScalaNativeModule extends ScalaModule { outer =>
   def bridgeFullClassPath: T[Agg[PathRef]] = T {
     Lib.resolveDependencies(
       repositoriesTask(),
-      Lib.depToDependency(_, mill.BuildInfo.scalaVersion, ""),
-      toolsIvyDeps(),
+      toolsIvyDeps().map(Lib.depToBoundDep(_, mill.BuildInfo.scalaVersion, "")),
       ctx = Some(T.log)
     ).map(t => (scalaNativeWorkerClasspath() ++ t))
   }


### PR DESCRIPTION
`mill.scalalib.Dep` represents a generic dependency, which include potential cross-compilation properties. E.g. it knows whether it is specific to a `platform` but it does not specify the platform. And it knows whether it is specific to a Scala binary or full version, but it does not specify the exact Scala version. This mean we can define a `Dep` without knowing those context. 

In this PR I introduce a new type `mill.scalalib.BoundDep`, which is kind-of a `Dep` where all these potential open context bindings are bound to an exact context. There is no further cross-resolution necessary nor possible. By having a separate type, we always know with what kind of dependency we work. Also, we can be explicit about the "when" the binding happens. 

When mixing dependencies of multiple modules, we also mix contexts. Until this PR, we had no way to get it right, as `Dep`s could come from different contexts. Now, we can safely mix `BoundDep`s as they are already context-bound.

We could encode the bound-state in the `Dep`, but this would result in only a dynamic property. To ensure a resolved state, we always would need to run some runtime checks. Also, it could lead to situations, where we need a resolved dep, but have not the proper context to do the resolution. This is exactly what I implemented in the initial attempt, but it didn't worked out very well. With the separated types, it is always clear from the API, what kind of dependency we expect.

We could also just resolve to a `coursier.Dependency`, but that would loose the `force` flag. Also, we want to rather decouple our API from the coursier API, which seem easier when we avoid to hand over direct coursier API to the user.

I `@deprecated` the existing `CoursierModule.resolveCoursierDependency` and bases the new `CoursierModule.bindDependency` on this old task. This should ease the transition. It's up for revisit, when we decouple from coursier API altogether.

This is an attempt to fix https://github.com/com-lihaoyi/mill/issues/860.
