### PR TITLE
Fix URL to file path conversion for GenIdea command

### DIFF
--- a/scalalib/src/GenIdeaImpl.scala
+++ b/scalalib/src/GenIdeaImpl.scala
@@ -8,6 +8,7 @@ import ammonite.runtime.SpecialClassLoader
 import coursier.core.compatibility.xmlParseDom
 import coursier.maven.Pom
 import coursier.{LocalRepositories, Repositories, Repository}
+import java.nio.file.Paths
 import mill.Agg
 import mill.api.Ctx.{Home, Log}
 import mill.api.{PathRef, Result, Strict}
@@ -132,7 +133,7 @@ case class GenIdeaImpl(
       Try(evaluator.rootModule.getClass.getClassLoader.asInstanceOf[SpecialClassLoader])
         .map {
           _.allJars
-            .map(url => os.Path(url.getFile))
+            .map(url => os.Path(Paths.get(url.toURI)))
             .filter(_.toIO.exists)
         }
         .getOrElse(Seq())


### PR DESCRIPTION
PR fixes artifacts resolving from private repos for GenIdea command.

**Problem description**:
Coursier caches private repos under the `.../user@organization/...` path, for unix systems it translates to `.../user%40organization/...` path, and in turn `java.net.URL` translates it to `.../user%2540organization/...`, so when GenIdea constructs `buildDepsPaths` with OS independent `java.net.URL#getFile` call, double escaping breaks pathes for private repos.

**Fix description**:
OS idependent URL to file path conversion `java.net.URL#getFile` was replaced with OS dependent `java.nio.file.Paths#get(java.net.URI)`