### PR TITLE
Declutter out/ folder by flattening out/foo/ foo folders into their constituent files

### DIFF
--- a/bsp/src/mill/bsp/MillBuildServer.scala
+++ b/bsp/src/mill/bsp/MillBuildServer.scala
@@ -611,11 +611,12 @@ class MillBuildServer(
               false
             )
             else {
-              val outDir = evaluator.pathsResolver.resolveDest(
+              val outPaths = evaluator.pathsResolver.resolveDest(
                 module.millModuleSegments ++ Seq(Label("compile"))
               )
-                .out
-              while (os.exists(outDir)) Thread.sleep(10)
+              val outPathSeq = Seq(outPaths.dest, outPaths.meta, outPaths.log)
+
+              while (outPathSeq.exists(os.exists(_))) Thread.sleep(10)
 
               (msg + s"${module.bspBuildTarget.displayName} cleaned \n", cleaned)
             }

--- a/ci/test-mill-bootstrap-0.sh
+++ b/ci/test-mill-bootstrap-0.sh
@@ -25,7 +25,7 @@ ci/patch-mill-bootstrap.sh
 
 # Second build
 ~/mill-1 -i "{__.publishLocal,assembly}"
-cp out/assembly/dest/mill ~/mill-2
+cp out/assembly.dest/mill ~/mill-2
 
 # Clean up
 git stash -u

--- a/ci/test-mill-bootstrap-1.sh
+++ b/ci/test-mill-bootstrap-1.sh
@@ -25,7 +25,7 @@ ci/patch-mill-bootstrap.sh
 
 # Second build
 ~/mill-1 -i "{__.publishLocal,assembly}"
-cp out/assembly/dest/mill ~/mill-2
+cp out/assembly.dest/mill ~/mill-2
 
 # Clean up
 git stash -u

--- a/contrib/buildinfo/test/src/BuildInfoTests.scala
+++ b/contrib/buildinfo/test/src/BuildInfoTests.scala
@@ -70,7 +70,7 @@ object BuildInfoTests extends TestSuite {
         val Right(((result, _), evalCount)) =
           eval.apply(BuildInfo.generatedBuildInfo)
         assert(
-          result.head.path == eval.outPath / "generatedBuildInfo" / "dest" / "BuildInfo.scala" &&
+          result.head.path == eval.outPath / "generatedBuildInfo.dest" / "BuildInfo.scala" &&
             os.exists(result.head.path) &&
             os.read(result.head.path) == expected
         )
@@ -82,7 +82,7 @@ object BuildInfoTests extends TestSuite {
         assert(
           result.isEmpty &&
             !os.exists(
-              eval.outPath / "generatedBuildInfo" / "dest" / "BuildInfo.scala"
+              eval.outPath / "generatedBuildInfo.dest" / "BuildInfo.scala"
             )
         )
       }
@@ -91,7 +91,7 @@ object BuildInfoTests extends TestSuite {
         val Right(((result, _), evalCount)) = eval.apply(BuildInfoSettings.generatedBuildInfo)
         val path = result.head.path
         assert(
-          path == eval.outPath / "generatedBuildInfo" / "dest" / "BuildInfo.scala" &&
+          path == eval.outPath / "generatedBuildInfo.dest" / "BuildInfo.scala" &&
             os.exists(path)
         )
 
@@ -124,7 +124,7 @@ object BuildInfoTests extends TestSuite {
       }
 
       "generatedSources must be a folder" - workspaceTest(BuildInfo) { eval =>
-        val buildInfoGeneratedSourcesFolder = eval.outPath / "generatedBuildInfo" / "dest"
+        val buildInfoGeneratedSourcesFolder = eval.outPath / "generatedBuildInfo.dest"
         val Right((result, evalCount)) = eval.apply(BuildInfo.generatedSources)
         assert(
           result.size == 1,

--- a/contrib/playlib/test/src/mill/playlib/PlayModuleTests.scala
+++ b/contrib/playlib/test/src/mill/playlib/PlayModuleTests.scala
@@ -100,10 +100,10 @@ object PlayModuleTests extends TestSuite with PlayTestSuite {
             os.RelPath("views/html/main$.class"),
             os.RelPath("views/html/main.class")
           ).map(
-            eval.outPath / "core" / scalaVersion / playVersion / "compile" / "dest" / "classes" / _
+            eval.outPath / "core" / scalaVersion / playVersion / "compile.dest" / "classes" / _
           )
           assert(
-            result.classes.path == eval.outPath / "core" / scalaVersion / playVersion / "compile" / "dest" / "classes",
+            result.classes.path == eval.outPath / "core" / scalaVersion / playVersion / "compile.dest" / "classes",
             outputFiles.nonEmpty,
             outputFiles.forall(expectedClassfiles.contains),
             outputFiles.size == 15,

--- a/contrib/playlib/test/src/mill/playlib/PlaySingleApiModuleTests.scala
+++ b/contrib/playlib/test/src/mill/playlib/PlaySingleApiModuleTests.scala
@@ -71,10 +71,10 @@ object PlaySingleApiModuleTests extends TestSuite with PlayTestSuite {
           os.RelPath("router/RoutesPrefix$.class"),
           os.RelPath("router/RoutesPrefix.class")
         ).map(
-          eval.outPath / "compile" / "dest" / "classes" / _
+          eval.outPath / "compile.dest" / "classes" / _
         )
         assert(
-          result.classes.path == eval.outPath / "compile" / "dest" / "classes",
+          result.classes.path == eval.outPath / "compile.dest" / "classes",
           outputFiles.nonEmpty,
           outputFiles.forall(expectedClassfiles.contains),
           outputFiles.size == 11,

--- a/contrib/playlib/test/src/mill/playlib/PlaySingleModuleTests.scala
+++ b/contrib/playlib/test/src/mill/playlib/PlaySingleModuleTests.scala
@@ -63,10 +63,10 @@ object PlaySingleModuleTests extends TestSuite with PlayTestSuite {
           os.RelPath("views/html/main$.class"),
           os.RelPath("views/html/main.class")
         ).map(
-          eval.outPath / "compile" / "dest" / "classes" / _
+          eval.outPath / "compile.dest" / "classes" / _
         )
         assert(
-          result.classes.path == eval.outPath / "compile" / "dest" / "classes",
+          result.classes.path == eval.outPath / "compile.dest" / "classes",
           outputFiles.nonEmpty,
           outputFiles.forall(expectedClassfiles.contains),
           outputFiles.size == 15,

--- a/contrib/playlib/test/src/mill/playlib/RouterModuleTests.scala
+++ b/contrib/playlib/test/src/mill/playlib/RouterModuleTests.scala
@@ -50,10 +50,10 @@ object RouterModuleTests extends TestSuite with PlayTestSuite {
             os.RelPath("sub/RoutesPrefix.scala"),
             os.RelPath("controllers/javascript/JavaScriptReverseRoutes.scala")
           ).map(
-            eval.outPath / "core" / scalaVersion / playVersion / "compileRouter" / "dest" / _
+            eval.outPath / "core" / scalaVersion / playVersion / "compileRouter.dest" / _
           )
           assert(
-            result.classes.path == eval.outPath / "core" / scalaVersion / playVersion / "compileRouter" / "dest",
+            result.classes.path == eval.outPath / "core" / scalaVersion / playVersion / "compileRouter.dest",
             outputFiles.nonEmpty,
             outputFiles.forall(expectedClassfiles.contains),
             outputFiles.size == 7,

--- a/contrib/scalapblib/test/src/TutorialTests.scala
+++ b/contrib/scalapblib/test/src/TutorialTests.scala
@@ -46,7 +46,7 @@ object TutorialTests extends TestSuite {
   val resourcePath: os.Path = os.pwd / "contrib" / "scalapblib" / "test" / "protobuf" / "tutorial"
 
   def protobufOutPath(eval: TestEvaluator): os.Path =
-    eval.outPath / "core" / "compileScalaPB" / "dest" / "com" / "example" / "tutorial"
+    eval.outPath / "core" / "compileScalaPB.dest" / "com" / "example" / "tutorial"
 
   def workspaceTest[T](m: TestUtil.BaseModule)(t: TestEvaluator => T)(implicit tp: TestPath): T = {
     val eval = new TestEvaluator(m)
@@ -91,7 +91,7 @@ object TutorialTests extends TestSuite {
         val expectedSourcefiles = compiledSourcefiles.map(outPath / _)
 
         assert(
-          result.path == eval.outPath / "core" / "compileScalaPB" / "dest",
+          result.path == eval.outPath / "core" / "compileScalaPB.dest",
           outputFiles.nonEmpty,
           outputFiles.forall(expectedSourcefiles.contains),
           outputFiles.size == 5,

--- a/contrib/scoverage/src/ScoverageModule.scala
+++ b/contrib/scoverage/src/ScoverageModule.scala
@@ -45,9 +45,9 @@ import mill.scalalib.{Dep, DepSyntax, JavaModule, ScalaModule}
  * - mill foo.scoverage.htmlReport   # uses the metrics collected by a previous test run to generate a coverage report in html format
  * - mill foo.scoverage.xmlReport    # uses the metrics collected by a previous test run to generate a coverage report in xml format
  *
- * The measurement data by default is available at `out/foo/scoverage/dataDir/dest/`,
- * the html report is saved in `out/foo/scoverage/htmlReport/dest/`,
- * and the xml report is saved in `out/foo/scoverage/xmlReport/dest/`.
+ * The measurement data by default is available at `out/foo/scoverage/dataDir.dest/`,
+ * the html report is saved in `out/foo/scoverage/htmlReport.dest/`,
+ * and the xml report is saved in `out/foo/scoverage/xmlReport.dest/`.
  */
 trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
 

--- a/contrib/scoverage/src/ScoverageReport.scala
+++ b/contrib/scoverage/src/ScoverageReport.scala
@@ -30,8 +30,8 @@ import os.Path
  * - mill scoverage.xmlReportAll      # generates report in xml format for all modules
  * - mill scoverage.consoleReportAll  # reports to the console for all modules
  *
- * The aggregated report will be available at either `out/scoverage/htmlReportAll/dest/`
- * for html reports or `out/scoverage/xmlReportAll/dest/` for xml reports.
+ * The aggregated report will be available at either `out/scoverage/htmlReportAll.dest/`
+ * for html reports or `out/scoverage/xmlReportAll.dest/` for xml reports.
  */
 trait ScoverageReport extends Module {
   outer =>

--- a/contrib/scoverage/test/src/HelloWorldTests.scala
+++ b/contrib/scoverage/test/src/HelloWorldTests.scala
@@ -115,7 +115,7 @@ trait HelloWorldTests extends utest.TestSuite {
 
             assert(
               result.path.toIO.getPath.replace("""\""", "/").endsWith(
-                "mill/target/workspace/mill/contrib/scoverage/HelloWorldTests/eval/HelloWorld/core/scoverage/data/core/scoverage/data/dest"
+                "mill/target/workspace/mill/contrib/scoverage/HelloWorldTests/eval/HelloWorld/core/scoverage/data/core/scoverage/data.dest"
               ),
               evalCount > 0
             )

--- a/contrib/twirllib/test/src/HelloWorldTests.scala
+++ b/contrib/twirllib/test/src/HelloWorldTests.scala
@@ -96,11 +96,11 @@ object HelloWorldTests extends TestSuite {
 
       val outputFiles = os.walk(result.classes.path).filter(_.last.endsWith(".scala"))
       val expectedClassfiles = compileClassfiles.map(
-        eval.outPath / "core" / "compileTwirl" / "dest" / _
+        eval.outPath / "core" / "compileTwirl.dest" / _
       )
 
       assert(
-        result.classes.path == eval.outPath / "core" / "compileTwirl" / "dest",
+        result.classes.path == eval.outPath / "core" / "compileTwirl.dest",
         outputFiles.nonEmpty,
         outputFiles.forall(expectedClassfiles.contains),
         outputFiles.size == 3,
@@ -132,7 +132,7 @@ object HelloWorldTests extends TestSuite {
 
       val outputFiles = os.walk(result.classes.path).filter(_.last.endsWith(".scala"))
       val expectedClassfiles = compileClassfiles.map(name =>
-        eval.outPath / "core" / "compileTwirl" / "dest" / name / os.RelPath.up / name.last.replace(
+        eval.outPath / "core" / "compileTwirl.dest" / name / os.RelPath.up / name.last.replace(
           ".template.scala",
           "$$TwirlInclusiveDot.template.scala"
         )
@@ -141,7 +141,7 @@ object HelloWorldTests extends TestSuite {
       println(s"outputFiles: $outputFiles")
 
       assert(
-        result.classes.path == eval.outPath / "core" / "compileTwirl" / "dest",
+        result.classes.path == eval.outPath / "core" / "compileTwirl.dest",
         outputFiles.nonEmpty,
         outputFiles.forall(expectedClassfiles.contains),
         outputFiles.size == 3,

--- a/docs/antora/modules/ROOT/pages/Contrib_Plugins.adoc
+++ b/docs/antora/modules/ROOT/pages/Contrib_Plugins.adoc
@@ -850,8 +850,8 @@ mill foo.scoverage.xmlReport    # uses the metrics collected by a previous test 
 ----
 
 The measurement data is by default available at `out/foo/scoverage/data/dest`,
-the html report is saved in `out/foo/scoverage/htmlReport/dest/`,
-and the xml report is saved in `out/foo/scoverage/xmlReport/dest/`.
+the html report is saved in `out/foo/scoverage/htmlReport.dest/`,
+and the xml report is saved in `out/foo/scoverage/xmlReport.dest/`.
 
 === Multi-module projects
 
@@ -879,8 +879,8 @@ mill scoverage.xmlReportAll      # generates report in xml format for all module
 mill scoverage.consoleReportAll  # reports to the console for all modules
 ----
 
-The aggregated report will be available at either `out/scoverage/htmlReportAll/dest/`
-for html reports or `out/scoverage/xmlReportAll/dest/` for xml reports.
+The aggregated report will be available at either `out/scoverage/htmlReportAll.dest/`
+for html reports or `out/scoverage/xmlReportAll.dest/` for xml reports.
 
 == TestNG
 

--- a/docs/antora/modules/ROOT/pages/Intro_to_Mill.adoc
+++ b/docs/antora/modules/ROOT/pages/Intro_to_Mill.adoc
@@ -211,7 +211,7 @@ $ mill foo.run                     # run the main method, if any
 
 $ mill foo.runBackground           # run the main method in the background
 
-$ mill foo.launcher                # prepares a foo/launcher/dest/run you can run later
+$ mill foo.launcher                # prepares a foo/launcher.dest/run you can run later
 
 $ mill foo.jar                     # bundle the classfiles into a jar
 
@@ -238,17 +238,34 @@ Mill puts all its output in the top-level `out/` folder. The above commands woul
 ----
 out/
     foo/
-        compile/
-        run/
-        runBackground/
-        launcher/
-        jar/
-        assembly/
+        compile.dest
+        compile.log
+        compile.json
+
+        run.dest
+        run.log
+        run.json
+
+        runBackground.dest
+        runBackground.log
+        runBackground.json
+
+        launcher.dest
+        launcher.log
+        launcher.json
+
+        jar.dest
+        jar.log
+        jar.json
+
+        assembly.dest
+        assembly.log
+        assembly.json
 ----
 
-Within the output folder for each task there's a `meta.json` file containing the metadata returned by that task, and
-a `dest/` folder containing any files that the task generates. For example, `out/foo/compile/dest/` contains the
-compiled classfiles, while `out/foo/assembly/dest/` contains the self-contained assembly with the project's classfiles
+For each task there's a `foo.json` file containing the metadata returned by that task, and
+two optional paths: a `foo.dest/` folder containing any files that the task generates and a `foo.log` file containing the the logs of running that task. For example, `out/foo/compile.dest/` contains the
+compiled classfiles, while `out/foo/assembly.dest/` contains the self-contained assembly with the project's classfiles
 jar-ed up with all its dependencies.
 
 Given a task `foo.bar`, all its output and results are inside its respective `out/foo/bar/` folder.
@@ -615,8 +632,8 @@ $ mill show foo.compile
 [1/1] show
 [10/25] foo.resources
 {
-    "analysisFile": "/Users/lihaoyi/Dropbox/Github/test//out/foo/compile/dest/zinc",
-    "classes": "ref:07960649:/Users/lihaoyi/Dropbox/Github/test//out/foo/compile/dest/classes"
+    "analysisFile": "/Users/lihaoyi/Dropbox/Github/test//out/foo/compile.dest/zinc",
+    "classes": "ref:07960649:/Users/lihaoyi/Dropbox/Github/test//out/foo/compile.dest/classes"
 }
 ----
 
@@ -693,11 +710,11 @@ $ mill show visualize foo._
 [1/1] show
 [3/3] visualize
 [
-    ".../out/visualize/dest/out.txt",
-    ".../out/visualize/dest/out.dot",
-    ".../out/visualize/dest/out.json",
-    ".../out/visualize/dest/out.png",
-    ".../out/visualize/dest/out.svg"
+    ".../out/visualize.dest/out.txt",
+    ".../out/visualize.dest/out.dot",
+    ".../out/visualize.dest/out.json",
+    ".../out/visualize.dest/out.png",
+    ".../out/visualize.dest/out.svg"
 ]
 ----
 
@@ -717,11 +734,11 @@ $ mill show visualizePlan foo.compile
 [1/1] show
 [3/3] visualizePlan
 [
-    ".../out/visualizePlan/dest/out.txt",
-    ".../out/visualizePlan/dest/out.dot",
-    ".../out/visualizePlan/dest/out.json",
-    ".../out/visualizePlan/dest/out.png",
-    ".../out/visualizePlan/dest/out.svg"
+    ".../out/visualizePlan.dest/out.txt",
+    ".../out/visualizePlan.dest/out.dot",
+    ".../out/visualizePlan.dest/out.json",
+    ".../out/visualizePlan.dest/out.png",
+    ".../out/visualizePlan.dest/out.svg"
 ]
 ----
 
@@ -896,8 +913,8 @@ Inputs:
 @ foo.compile()
 [25/25] foo.compile
 res2: mill.scalalib.api.CompilationResult = CompilationResult(
-  /Users/lihaoyi/Dropbox/Github/test/out/foo/compile/dest/zinc,
-  PathRef(/Users/lihaoyi/Dropbox/Github/test/out/foo/compile/dest/classes, false, -61934706)
+  /Users/lihaoyi/Dropbox/Github/test/out/foo/compile.dest/zinc,
+  PathRef(/Users/lihaoyi/Dropbox/Github/test/out/foo/compile.dest/classes, false, -61934706)
 )
 ----
 
@@ -931,15 +948,15 @@ You can make a self-contained assembly via:
 ----
 $ mill foo.assembly
 
-$ ls -lh out/foo/assembly/dest/out.jar
--rw-r--r--  1 lihaoyi  staff   5.0M Feb 17 11:14 out/foo/assembly/dest/out.jar
+$ ls -lh out/foo/assembly.dest/out.jar
+-rw-r--r--  1 lihaoyi  staff   5.0M Feb 17 11:14 out/foo/assembly.dest/out.jar
 ----
 
 You can then move the `out.jar` file anywhere you would like, and run it standalone using `java`:
 
 [source,bash]
 ----
-$ java -cp out/foo/assembly/dest/out.jar foo.Example
+$ java -cp out/foo/assembly.dest/out.jar foo.Example
 Hello World!
 ----
 
@@ -1018,22 +1035,22 @@ There are also top-level build-related files in the `out/` folder, prefixed as
 `mill-*`. The most useful is `mill-profile.json`, which logs the tasks run and time taken for the last Mill command you
 executed. This is very useful if you want to find out exactly what tasks are being run and Mill is being slow.
 
-Each folder currently contains the following files:
+Each task currently creates contains the following files:
 
-* `dest/`: a path for the `Task` to use either as a scratch space, or to place generated files that are returned
+* `foo.dest/`: optional, a path for the `Task` to use either as a scratch space, or to place generated files that are returned
  using `PathRef` references. A `Task` should only output files within its own given `dest/` folder (available as `T.dest`) to avoid
  conflicting with another `Task`, but can name files within `dest/`  arbitrarily.
 
-* `log`: the `stdout`/`stderr` of the `Task`. This is also streamed to the console during evaluation.
+* `foo.log`: optional, the `stdout`/`stderr` of the `Task`. This is also streamed to the console during evaluation.
 
-* `meta.json`: the cache-key and JSON-serialized return-value of the
+* `foo.json`: the cache-key and JSON-serialized return-value of the
  `Target`/`Command`. The return-value can also be retrieved via `mill show foo.compile`. Binary blobs are typically not
- included in `meta.json`, and instead stored as separate binary files in `dest/` which are then referenced
- by `meta.json` via `PathRef` references.
+ included in `foo.json`, and instead stored as separate binary files in `dest/` which are then referenced
+ by `foo.json` via `PathRef` references.
 
 The `out/` folder is intentionally kept simple and user-readable. If your build is not behaving as you would expect,
 feel free to poke around the various
-`dest/` folders to see what files are being created, or the `meta.json` files to see what is being returned by a
+`foo.dest/` folders to see what files are being created, or the `foo.json` files to see what is being returned by a
 particular task. You can also simply delete folders within `out/` if you want to force portions of your project to be
 rebuilt, e.g. by deleting the `out/main/` or `out/main/test/compile/` folders.
 

--- a/docs/antora/modules/ROOT/pages/Mill_Internals.adoc
+++ b/docs/antora/modules/ROOT/pages/Mill_Internals.adoc
@@ -44,8 +44,8 @@ run something via `mill core.cross[a].printIt` while from code you use
 === Caching by default
 
 Every `Target` in a build, defined by `def foo = T {...}`, is cached by default.
-Currently this is done using a `foo/meta.json` file in the `out/` folder. The
-`Target` is also provided a `foo/` path on the filesystem dedicated to it, for
+Currently this is done using a `foo.json` file in the `out/` folder. The
+`Target` is also provided a `foo.dest/` path on the filesystem dedicated to it, for
 it to store output files etc.
 
 This happens whether you want it to or not. Every `Target` is cached, not just
@@ -65,10 +65,10 @@ structures where a previous process left off, in order to continue the build.
 
 Re-construction is done via the hierarchical nature of the build: each `Target`
 `foo.bar.baz` has a fixed position in the build hierarchy, and thus a fixed
-position on disk `out/foo/bar/baz/meta.json`. When the old process dies and a
+position on disk `out/foo/bar/baz.json`. When the old process dies and a
 new process starts, there will be a new instance of `Target` with the same
 implementation code and same position in the build hierarchy: this new `Target`
-can then load the `out/foo/bar/baz/meta.json` file and pick up where the
+can then load the `out/foo/bar/baz.json` file and pick up where the
 previous process left off.
 
 Minimizing startup time means aggressive caching, as well as minimizing the
@@ -189,9 +189,9 @@ the ``Target``s you can run.
 A `Target`'s position in the module hierarchy tells you many things. For
 example, a `Target` at position `core.test.compile` would:
 
-* Cache output metadata at `out/core/test/compile/meta.json`
+* Cache output metadata at `out/core/test/compile.json`
 
-* Output files to the folder `out/core/test/compile/dest/`
+* Output files to the folder `out/core/test/compile.dest/`
 
 * Source files default to a folder in `core/test/`, `core/test/src/`
 

--- a/docs/antora/modules/ROOT/pages/Task_Context_API.adoc
+++ b/docs/antora/modules/ROOT/pages/Task_Context_API.adoc
@@ -9,7 +9,7 @@ Command:
 * `T.dest`
 * `implicitly[mill.api.Ctx.Dest]`
 
-This is a unique `os.Path` (e.g. `out/classFiles/dest/` or `out/run/dest/`)  that is
+This is a unique `os.Path` (e.g. `out/classFiles.dest/` or `out/run.dest/`)  that is
 assigned to every Target or Command. It is cleared before your task runs, and
 you can use it as a scratch space for temporary files or a place to put returned
 artifacts.

--- a/docs/antora/modules/ROOT/pages/Tasks.adoc
+++ b/docs/antora/modules/ROOT/pages/Tasks.adoc
@@ -89,8 +89,8 @@ other targets are defined using `foo()` to extract the value from them.
 Apart from the `foo()` calls, the `T {...}` block contains arbitrary code that does some work and returns a result.
 
 Each target, e.g. `classFiles`, is assigned a path on disk as scratch space & to
-store its output files at `out/classFiles/dest/`, and its returned metadata is
-automatically JSON-serialized and stored at `out/classFiles/meta.json`.
+store its output files at `out/classFiles.dest/`, and its returned metadata is
+automatically JSON-serialized and stored at `out/classFiles.json`.
 The return-value of targets has to be JSON-serializable via
 {upickle-github-url}[uPickle].
 
@@ -167,8 +167,8 @@ Like <<_targets>>, a command only evaluates after all its upstream
 dependencies have completed, and will not begin to run if any upstream
 dependency has failed.
 
-Commands are assigned the same scratch/output folder `out/run/dest/` as
-Targets are, and its returned metadata stored at the same `out/run/meta.json`
+Commands are assigned the same scratch/output folder `out/run.dest/` as
+Targets are, and its returned metadata stored at the same `out/run.json`
 path for consumption by external tools.
 
 Commands can only be defined directly within a `Module` body.

--- a/integration/test/src/AmmoniteTests.scala
+++ b/integration/test/src/AmmoniteTests.scala
@@ -26,7 +26,7 @@ class AmmoniteTests(fork: Boolean)
 
       assert(
         compileResult,
-        os.walk(workspacePath / "out" / "integration" / scalaVersion / "test" / "compile")
+        os.walk(workspacePath / "out" / "integration" / scalaVersion / "test" / "compile.dest")
           .exists(_.last == "ErrorTruncationTests.class")
       )
     }

--- a/main/core/src/mill/eval/Evaluator.scala
+++ b/main/core/src/mill/eval/Evaluator.scala
@@ -317,7 +317,6 @@ case class Evaluator(
           destSegments(labelledNamedTask)
         )
 
-        if (!os.exists(paths.out)) os.makeDir.all(paths.out)
         val cached = for {
           cached <-
             try Some(upickle.default.read[Evaluator.Cached](paths.meta.toIO))
@@ -474,15 +473,6 @@ case class Evaluator(
           val args = new Ctx(
             args = targetInputValues.toArray[Any],
             dest0 = () =>
-              //              usedDest match {
-              //              case Some((earlierTask, earlierStack)) if earlierTask != task =>
-              //                val inner = new Exception("Earlier usage of `dest`")
-              //                inner.setStackTrace(earlierStack)
-              //                throw new Exception(
-              //                  "`dest` can only be used in one place within each Target[T]",
-              //                  inner
-              //                )
-              //              case _ =>
               paths match {
                 case Some(dest) =>
                   if (usedDest.isEmpty) os.makeDir.all(dest.dest)

--- a/main/core/src/mill/eval/EvaluatorPaths.scala
+++ b/main/core/src/mill/eval/EvaluatorPaths.scala
@@ -2,7 +2,7 @@ package mill.eval
 
 import mill.define.{NamedTask, Segment, Segments}
 
-case class EvaluatorPaths(out: os.Path, dest: os.Path, meta: os.Path, log: os.Path)
+case class EvaluatorPaths(dest: os.Path, meta: os.Path, log: os.Path)
 
 object EvaluatorPaths {
   private[eval] def makeSegmentStrings(segments: Segments) = segments.value.flatMap {
@@ -17,7 +17,11 @@ object EvaluatorPaths {
     val refinedSegments = foreignSegments.map(_ ++ segments).getOrElse(segments)
     val segmentStrings = makeSegmentStrings(refinedSegments)
     val targetPath = workspacePath / segmentStrings
-    EvaluatorPaths(targetPath, targetPath / "dest", targetPath / "meta.json", targetPath / "log")
+    EvaluatorPaths(
+      targetPath / os.up / s"${targetPath.last}.dest",
+      targetPath / os.up / s"${targetPath.last}.json",
+      targetPath / os.up / s"${targetPath.last}.log"
+    )
   }
   def resolveDestPaths(
       workspacePath: os.Path,

--- a/main/core/src/mill/util/Loggers.scala
+++ b/main/core/src/mill/util/Loggers.scala
@@ -163,6 +163,7 @@ class FileLogger(
   private[this] var outputStreamUsed: Boolean = false
 
   lazy val outputStream = {
+
     val options = Seq(
       Seq(StandardOpenOption.CREATE, StandardOpenOption.WRITE),
       Seq(StandardOpenOption.APPEND).filter(_ => append),
@@ -170,8 +171,23 @@ class FileLogger(
     ).flatten
 //    if (!append && !outputStreamUsed) os.remove.all(file)
     outputStreamUsed = true
-    os.makeDir.all(file / os.up)
-    new PrintStream(Files.newOutputStream(file.toNIO, options: _*))
+    var folderCreated = false
+    lazy val inner = {
+      if (!os.exists(file / os.up)) os.makeDir.all(file / os.up)
+      folderCreated = true
+      Files.newOutputStream(file.toNIO, options: _*)
+    }
+    new PrintStream(new OutputStream {
+      override def write(b: Int): Unit = inner.write(b)
+
+      override def write(b: Array[Byte]): Unit = inner.write(b)
+
+      override def write(b: Array[Byte], off: Int, len: Int): Unit = inner.write(b, off, len)
+
+      override def close(): Unit = if (folderCreated) inner.close()
+
+      override def flush(): Unit = if (folderCreated) inner.flush()
+    })
   }
 
   lazy val errorStream = outputStream

--- a/main/core/src/mill/util/Loggers.scala
+++ b/main/core/src/mill/util/Loggers.scala
@@ -172,6 +172,8 @@ class FileLogger(
 //    if (!append && !outputStreamUsed) os.remove.all(file)
     outputStreamUsed = true
     var folderCreated = false
+    // Lazily create the folder and file that we're logging to, so as to avoid spamming the out/ 
+    // folder with empty folders/files for the vast majority of tasks that do not have any logs
     lazy val inner = {
       if (!os.exists(file / os.up)) os.makeDir.all(file / os.up)
       folderCreated = true

--- a/main/src/mill/main/MainModule.scala
+++ b/main/src/mill/main/MainModule.scala
@@ -286,8 +286,9 @@ trait MainModule extends mill.Module {
           targets,
           SelectMode.Multi
         ).map(
-          _.map { segments =>
-            EvaluatorPaths.resolveDestPaths(rootDir, segments).out
+          _.flatMap { segments =>
+            val paths = EvaluatorPaths.resolveDestPaths(rootDir, segments)
+            Seq(paths.dest, paths.meta, paths.log)
           }
         )
 

--- a/main/test/resources/examples/foreign/conflict/build.sc
+++ b/main/test/resources/examples/foreign/conflict/build.sc
@@ -19,5 +19,5 @@ def checkDests : T[Unit] = T {
 }
 
 object inner extends mill.Module {
-  def selfDest = T { T.dest / os.up / os.up }
+  def selfDest = T { T.dest / os.up }
 }

--- a/main/test/resources/examples/foreign/conflict/inner/build.sc
+++ b/main/test/resources/examples/foreign/conflict/inner/build.sc
@@ -1,3 +1,3 @@
 import mill._
 
-def selfDest = T { T.dest / os.up / os.up }
+def selfDest = T { T.dest / os.up }

--- a/main/test/resources/examples/foreign/outer/build.sc
+++ b/main/test/resources/examples/foreign/outer/build.sc
@@ -6,7 +6,7 @@ trait PathAware extends mill.Module {
 }
 
 trait DestAware extends mill.Module {
-  def selfDest = T { T.dest / os.up / os.up }
+  def selfDest = T { T.dest / os.up }
 }
 
 object sub extends PathAware with DestAware {
@@ -14,16 +14,16 @@ object sub extends PathAware with DestAware {
 }
 
 object sourcepathmod extends mill.Module {
-  def selfDest = T { T.dest / os.up / os.up }
+  def selfDest = T { T.dest / os.up }
 
   object jvm extends mill.Module {
-    def selfDest = T { T.dest / os.up / os.up }
+    def selfDest = T { T.dest / os.up }
     def millSourcePath = sourcepathmod.millSourcePath
     def sources = T.sources( millSourcePath / "src", millSourcePath / "src-jvm" )
   }
 
   object js extends mill.Module {
-    def selfDest = T { T.dest / os.up / os.up }
+    def selfDest = T { T.dest / os.up }
     def millSourcePath = sourcepathmod.millSourcePath
     def sources = T.sources( millSourcePath / "src", millSourcePath / "src-js" )
   }

--- a/main/test/resources/examples/foreign/outer/inner/build.sc
+++ b/main/test/resources/examples/foreign/outer/inner/build.sc
@@ -5,7 +5,7 @@ trait PathAware extends mill.Module {
 }
 
 trait DestAware extends mill.Module {
-  def selfDest = T { T.dest / os.up / os.up }
+  def selfDest = T { T.dest / os.up }
 }
 
 object sub extends PathAware with DestAware {

--- a/main/test/resources/examples/foreign/project/build.sc
+++ b/main/test/resources/examples/foreign/project/build.sc
@@ -82,6 +82,6 @@ trait PathAware extends mill.Module {
 }
 
 trait DestAware extends mill.Module {
-  def selfDest = T { T.dest / os.up / os.up }
+  def selfDest = T { T.dest / os.up }
 }
 

--- a/main/test/resources/examples/foreign/project/inner/build.sc
+++ b/main/test/resources/examples/foreign/project/inner/build.sc
@@ -5,7 +5,7 @@ trait PathAware extends mill.Module {
 }
 
 trait DestAware extends mill.Module {
-  def selfDest = T { T.dest / os.up / os.up }
+  def selfDest = T { T.dest / os.up }
 }
 
 object sub extends PathAware with DestAware {

--- a/main/test/src/eval/EvaluationTests.scala
+++ b/main/test/src/eval/EvaluationTests.scala
@@ -225,10 +225,10 @@ class EvaluationTests(threadCount: Option[Int]) extends TestSuite {
         val checker = new Checker(canOverrideSuper)
         checker(foo, Seq("base", "object"), Agg(foo), extraEvaled = -1)
 
-        val public = os.read(checker.evaluator.outPath / "foo" / "meta.json")
+        val public = os.read(checker.evaluator.outPath / "foo.json")
         val overriden = os.read(
           checker.evaluator.outPath / "foo" /
-            "overriden" / "mill" / "util" / "TestGraphs" / "BaseModule" / "foo" / "meta.json"
+            "overriden" / "mill" / "util" / "TestGraphs" / "BaseModule" / "foo.json"
         )
         assert(
           public.contains("base"),
@@ -253,10 +253,10 @@ class EvaluationTests(threadCount: Option[Int]) extends TestSuite {
           secondRunNoOp = false
         )
 
-        val public = os.read(checker.evaluator.outPath / "cmd" / "meta.json")
+        val public = os.read(checker.evaluator.outPath / "cmd.json")
         val overriden = os.read(
           checker.evaluator.outPath / "cmd" /
-            "overriden" / "mill" / "util" / "TestGraphs" / "BaseModule" / "cmd" / "meta.json"
+            "overriden" / "mill" / "util" / "TestGraphs" / "BaseModule" / "cmd.json"
         )
         assert(
           public.contains("base1"),

--- a/main/test/src/eval/JavaCompileJarTests.scala
+++ b/main/test/src/eval/JavaCompileJarTests.scala
@@ -122,7 +122,7 @@ object JavaCompileJarTests extends TestSuite {
       check(targets = Agg(allSources), expected = Agg(allSources))
       check(targets = Agg(jar), expected = Agg(classFiles, jar))
 
-      val jarContents = os.proc("jar", "-tf", evaluator.outPath / "jar" / "dest" / "out.jar").call(
+      val jarContents = os.proc("jar", "-tf", evaluator.outPath / "jar.dest" / "out.jar").call(
         evaluator.outPath
       ).out.string
       val expectedJarContents =
@@ -144,7 +144,7 @@ object JavaCompileJarTests extends TestSuite {
       val filteredJarContents = os.proc(
         "jar",
         "-tf",
-        evaluator.outPath / "filterJar" / "dest" / "out.jar"
+        evaluator.outPath / "filterJar.dest" / "out.jar"
       ).call(evaluator.outPath).out.string
       assert(filteredJarContents.linesIterator.toSeq == expectedJarContents.linesIterator.filter(
         noFoos(_)
@@ -153,7 +153,7 @@ object JavaCompileJarTests extends TestSuite {
       val executed = os.proc(
         "java",
         "-cp",
-        evaluator.outPath / "jar" / "dest" / "out.jar",
+        evaluator.outPath / "jar.dest" / "out.jar",
         "test.Foo"
       ).call(evaluator.outPath).out.string
       assert(executed == (31337 + 271828) + System.lineSeparator)

--- a/main/test/src/eval/ModuleTests.scala
+++ b/main/test/src/eval/ModuleTests.scala
@@ -24,12 +24,12 @@ object ModuleTests extends TestSuite {
       val zresult = check.apply(Build.z)
       assert(
         zresult == Right((30, 1)),
-        os.read(check.evaluator.outPath / "z" / "meta.json").contains("30"),
+        os.read(check.evaluator.outPath / "z.json").contains("30"),
         os.read(
-          TestEvaluator.externalOutPath / "mill" / "eval" / "ModuleTests" / "ExternalModule" / "x" / "meta.json"
+          TestEvaluator.externalOutPath / "mill" / "eval" / "ModuleTests" / "ExternalModule" / "x.json"
         ).contains("13"),
         os.read(
-          TestEvaluator.externalOutPath / "mill" / "eval" / "ModuleTests" / "ExternalModule" / "inner" / "y" / "meta.json"
+          TestEvaluator.externalOutPath / "mill" / "eval" / "ModuleTests" / "ExternalModule" / "inner" / "y.json"
         ).contains("17")
       )
     }

--- a/main/test/src/util/ScriptTestSuite.scala
+++ b/main/test/src/util/ScriptTestSuite.scala
@@ -68,7 +68,8 @@ abstract class ScriptTestSuite(fork: Boolean) extends TestSuite {
   def meta(s: String): String = {
     val (List(selector), args) = ParseArgs.apply(Seq(s), multiSelect = false).right.get
 
-    os.read(wd / "out" / selector._2.value.flatMap(_.pathSegments) / "meta.json")
+    val segments = selector._2.value.flatMap(_.pathSegments)
+    os.read(wd / "out" / segments.init / s"${segments.last}.json")
   }
 
   def initWorkspace(): Path = {

--- a/readme.adoc
+++ b/readme.adoc
@@ -121,7 +121,7 @@ Mill without the bootstrap Mill process present:
 ./mill dev.launcher
 ----
 
-This creates the `out/dev/launcher/dest/run` launcher script, which you can then
+This creates the `out/dev/launcher.dest/run` launcher script, which you can then
 use to run your current checkout of Mill where-ever you'd like. Note that this
 script relies on the compiled code already present in the Mill `out/` folder,
 and thus isn't suitable for testing on Mill's own Mill build since you would be
@@ -133,7 +133,7 @@ folder without the bootstrap Mill process being present via:
 
 [source,bash]
 ----
-./mill dev.launcher && (cd scratch && ../out/dev/launcher/dest/run -w show thingy)
+./mill dev.launcher && (cd scratch && ../out/dev/launcher.dest/run -w show thingy)
 ----
 
 === Bootstrapping: Building Mill with your current checkout of Mill

--- a/scalalib/test/resources/gen-idea-extended-hello-world/idea/mill_modules/helloworld.iml
+++ b/scalalib/test/resources/gen-idea-extended-hello-world/idea/mill_modules/helloworld.iml
@@ -1,9 +1,9 @@
 <module type="JAVA_MODULE" version="4">
     <component name="NewModuleRootManager">
-        <output url="file://$MODULE_DIR$/../../out/HelloWorld/ideaCompileOutput/dest/classes"/>
+        <output url="file://$MODULE_DIR$/../../out/HelloWorld/ideaCompileOutput.dest/classes"/>
         <exclude-output/>
-        <content url="file://$MODULE_DIR$/../../out/HelloWorld/generatedSources/dest/classes">
-            <sourceFolder url="file://$MODULE_DIR$/../../out/HelloWorld/generatedSources/dest/classes" isTestSource="false" generated="true"/>
+        <content url="file://$MODULE_DIR$/../../out/HelloWorld/generatedSources.dest/classes">
+            <sourceFolder url="file://$MODULE_DIR$/../../out/HelloWorld/generatedSources.dest/classes" isTestSource="false" generated="true"/>
         </content>
         <content url="file://$MODULE_DIR$/../../HelloWorld/src">
             <sourceFolder url="file://$MODULE_DIR$/../../HelloWorld/src" isTestSource="false"/>

--- a/scalalib/test/resources/gen-idea-extended-hello-world/idea/mill_modules/helloworld.subscala3.iml
+++ b/scalalib/test/resources/gen-idea-extended-hello-world/idea/mill_modules/helloworld.subscala3.iml
@@ -1,6 +1,6 @@
 <module type="JAVA_MODULE" version="4">
     <component name="NewModuleRootManager">
-        <output url="file://$MODULE_DIR$/../../out/HelloWorld/subScala3/ideaCompileOutput/dest/classes"/>
+        <output url="file://$MODULE_DIR$/../../out/HelloWorld/subScala3/ideaCompileOutput.dest/classes"/>
         <exclude-output/>
         <content url="file://$MODULE_DIR$/../../HelloWorld/subScala3/src">
             <sourceFolder url="file://$MODULE_DIR$/../../HelloWorld/subScala3/src" isTestSource="false"/>

--- a/scalalib/test/resources/gen-idea-extended-hello-world/idea/mill_modules/helloworld.test.iml
+++ b/scalalib/test/resources/gen-idea-extended-hello-world/idea/mill_modules/helloworld.test.iml
@@ -1,6 +1,6 @@
 <module type="JAVA_MODULE" version="4">
     <component name="NewModuleRootManager">
-        <output-test url="file://$MODULE_DIR$/../../out/HelloWorld/test/ideaCompileOutput/dest/classes"/>
+        <output-test url="file://$MODULE_DIR$/../../out/HelloWorld/test/ideaCompileOutput.dest/classes"/>
         <exclude-output/>
         <content url="file://$MODULE_DIR$/../../HelloWorld/test/src">
             <sourceFolder url="file://$MODULE_DIR$/../../HelloWorld/test/src" isTestSource="true"/>

--- a/scalalib/test/resources/gen-idea-hello-world/idea/mill_modules/helloworld.iml
+++ b/scalalib/test/resources/gen-idea-hello-world/idea/mill_modules/helloworld.iml
@@ -1,6 +1,6 @@
 <module type="JAVA_MODULE" version="4">
     <component name="NewModuleRootManager">
-        <output url="file://$MODULE_DIR$/../../out/HelloWorld/ideaCompileOutput/dest/classes"/>
+        <output url="file://$MODULE_DIR$/../../out/HelloWorld/ideaCompileOutput.dest/classes"/>
         <exclude-output/>
         <content url="file://$MODULE_DIR$/../../HelloWorld/src">
             <sourceFolder url="file://$MODULE_DIR$/../../HelloWorld/src" isTestSource="false"/>

--- a/scalalib/test/resources/gen-idea-hello-world/idea/mill_modules/helloworld.test.iml
+++ b/scalalib/test/resources/gen-idea-hello-world/idea/mill_modules/helloworld.test.iml
@@ -1,6 +1,6 @@
 <module type="JAVA_MODULE" version="4">
     <component name="NewModuleRootManager">
-        <output-test url="file://$MODULE_DIR$/../../out/HelloWorld/test/ideaCompileOutput/dest/classes"/>
+        <output-test url="file://$MODULE_DIR$/../../out/HelloWorld/test/ideaCompileOutput.dest/classes"/>
         <exclude-output/>
         <content url="file://$MODULE_DIR$/../../HelloWorld/test/src">
             <sourceFolder url="file://$MODULE_DIR$/../../HelloWorld/test/src" isTestSource="true"/>

--- a/scalalib/test/src/DottyDocTests.scala
+++ b/scalalib/test/src/DottyDocTests.scala
@@ -57,7 +57,7 @@ object DottyDocTests extends TestSuite {
   def tests: Tests = Tests {
     "static" - workspaceTest(StaticDocsModule) { eval =>
       val Right((_, _)) = eval.apply(StaticDocsModule.static.docJar)
-      val dest = eval.outPath / "static" / "docJar" / "dest"
+      val dest = eval.outPath / "static" / "docJar.dest"
       assert(
         os.exists(dest / "out.jar"), // final jar should exist
         // check if extra markdown files have been included and translated to html
@@ -69,7 +69,7 @@ object DottyDocTests extends TestSuite {
     }
     "empty" - workspaceTest(EmptyDocsModule) { eval =>
       val Right((_, _)) = eval.apply(EmptyDocsModule.empty.docJar)
-      val dest = eval.outPath / "empty" / "docJar" / "dest"
+      val dest = eval.outPath / "empty" / "docJar.dest"
       assert(
         os.exists(dest / "out.jar"),
         os.exists(dest / "javadoc" / "_site" / "api" / "pkg" / "SomeClass.html")
@@ -77,7 +77,7 @@ object DottyDocTests extends TestSuite {
     }
     "multiple" - workspaceTest(MultiDocsModule) { eval =>
       val Right((_, _)) = eval.apply(MultiDocsModule.multidocs.docJar)
-      val dest = eval.outPath / "multidocs" / "docJar" / "dest"
+      val dest = eval.outPath / "multidocs" / "docJar.dest"
       assert(
         os.exists(dest / "out.jar"), // final jar should exist
         os.exists(dest / "javadoc" / "_site" / "api" / "pkg" / "SomeClass.html"),

--- a/scalalib/test/src/HelloWorldTests.scala
+++ b/scalalib/test/src/HelloWorldTests.scala
@@ -369,7 +369,7 @@ object HelloWorldTests extends TestSuite {
         val Right((_, evalCount)) = eval.apply(HelloWorldDocTitle.core.docJar)
         assert(
           evalCount > 0,
-          os.read(eval.outPath / "core" / "docJar" / "dest" / "javadoc" / "index.html").contains(
+          os.read(eval.outPath / "core" / "docJar.dest" / "javadoc" / "index.html").contains(
             "<span id=\"doc-title\">Hello World"
           )
         )
@@ -420,10 +420,10 @@ object HelloWorldTests extends TestSuite {
         val analysisFile = result.analysisFile
         val outputFiles = os.walk(result.classes.path)
         val expectedClassfiles = compileClassfiles.map(
-          eval.outPath / "core" / "compile" / "dest" / "classes" / _
+          eval.outPath / "core" / "compile.dest" / "classes" / _
         )
         assert(
-          result.classes.path == eval.outPath / "core" / "compile" / "dest" / "classes",
+          result.classes.path == eval.outPath / "core" / "compile.dest" / "classes",
           os.exists(analysisFile),
           outputFiles.nonEmpty,
           outputFiles.forall(expectedClassfiles.contains),
@@ -481,7 +481,7 @@ object HelloWorldTests extends TestSuite {
 
     "runMain" - {
       "runMainObject" - workspaceTest(HelloWorld) { eval =>
-        val runResult = eval.outPath / "core" / "runMain" / "dest" / "hello-mill"
+        val runResult = eval.outPath / "core" / "runMain.dest" / "hello-mill"
 
         val Right((_, evalCount)) = eval.apply(HelloWorld.core.runMain("Main", runResult.toString))
         assert(evalCount > 0)
@@ -537,7 +537,7 @@ object HelloWorldTests extends TestSuite {
 
     "forkRun" - {
       "runIfMainClassProvided" - workspaceTest(HelloWorldWithMain) { eval =>
-        val runResult = eval.outPath / "core" / "run" / "dest" / "hello-mill"
+        val runResult = eval.outPath / "core" / "run.dest" / "hello-mill"
         val Right((_, evalCount)) = eval.apply(
           HelloWorldWithMain.core.run(runResult.toString)
         )
@@ -559,7 +559,7 @@ object HelloWorldTests extends TestSuite {
       "runDiscoverMainClass" - workspaceTest(HelloWorldWithoutMain) { eval =>
         // Make sure even if there isn't a main class defined explicitly, it gets
         // discovered by Zinc and used
-        val runResult = eval.outPath / "core" / "run" / "dest" / "hello-mill"
+        val runResult = eval.outPath / "core" / "run.dest" / "hello-mill"
         val Right((_, evalCount)) = eval.apply(
           HelloWorldWithoutMain.core.run(runResult.toString)
         )
@@ -575,7 +575,7 @@ object HelloWorldTests extends TestSuite {
 
     "run" - {
       "runIfMainClassProvided" - workspaceTest(HelloWorldWithMain) { eval =>
-        val runResult = eval.outPath / "core" / "run" / "dest" / "hello-mill"
+        val runResult = eval.outPath / "core" / "run.dest" / "hello-mill"
         val Right((_, evalCount)) = eval.apply(
           HelloWorldWithMain.core.runLocal(runResult.toString)
         )
@@ -588,7 +588,7 @@ object HelloWorldTests extends TestSuite {
         )
       }
       "runWithDefaultMain" - workspaceTest(HelloWorldDefaultMain) { eval =>
-        val runResult = eval.outPath / "core" / "run" / "dest" / "hello-mill"
+        val runResult = eval.outPath / "core" / "run.dest" / "hello-mill"
         val Right((_, evalCount)) = eval.apply(
           HelloWorldDefaultMain.core.runLocal(runResult.toString)
         )
@@ -641,7 +641,7 @@ object HelloWorldTests extends TestSuite {
         val outPath = eval.outPath
         eval.apply(HelloWorld.core.compile)
 
-        val logFile = outPath / "core" / "compile" / "log"
+        val logFile = outPath / "core" / "compile.log"
         assert(os.exists(logFile))
       }
     }

--- a/scalalib/test/src/ScalaDoc3Tests.scala
+++ b/scalalib/test/src/ScalaDoc3Tests.scala
@@ -57,7 +57,7 @@ object ScalaDoc3Tests extends TestSuite {
   def tests: Tests = Tests {
     "static" - workspaceTest(StaticDocsModule) { eval =>
       val Right((_, _)) = eval.apply(StaticDocsModule.static.docJar)
-      val dest = eval.outPath / "static" / "docJar" / "dest"
+      val dest = eval.outPath / "static" / "docJar.dest"
       assert(
         os.exists(dest / "out.jar"), // final jar should exist
         // check if extra markdown files have been included and translated to html
@@ -69,7 +69,7 @@ object ScalaDoc3Tests extends TestSuite {
     }
     "empty" - workspaceTest(EmptyDocsModule) { eval =>
       val Right((_, _)) = eval.apply(EmptyDocsModule.empty.docJar)
-      val dest = eval.outPath / "empty" / "docJar" / "dest"
+      val dest = eval.outPath / "empty" / "docJar.dest"
       assert(
         os.exists(dest / "out.jar"),
         os.exists(dest / "javadoc" / "api" / "pkg" / "SomeClass.html")
@@ -77,7 +77,7 @@ object ScalaDoc3Tests extends TestSuite {
     }
     "multiple" - workspaceTest(MultiDocsModule) { eval =>
       val Right((_, _)) = eval.apply(MultiDocsModule.multidocs.docJar)
-      val dest = eval.outPath / "multidocs" / "docJar" / "dest"
+      val dest = eval.outPath / "multidocs" / "docJar.dest"
       assert(
         os.exists(dest / "out.jar"), // final jar should exist
         os.exists(dest / "javadoc" / "api" / "pkg" / "SomeClass.html"),

--- a/scalanativelib/test/src/HelloNativeWorldTests.scala
+++ b/scalanativelib/test/src/HelloNativeWorldTests.scala
@@ -230,7 +230,7 @@ object HelloNativeWorldTests extends TestSuite {
       val Right((_, evalCount)) = helloWorldEvaluator(task)
 
       val paths = EvaluatorPaths.resolveDestPaths(helloWorldEvaluator.outPath, task)
-      val stdout = os.proc(paths.out / "dest" / "out").call().out.lines
+      val stdout = os.proc(paths.dest / "out").call().out.lines
       assert(
         stdout.contains("Hello Scala Native"),
         evalCount > 0

--- a/scratch/build.sc
+++ b/scratch/build.sc
@@ -3,11 +3,4 @@ import mill.scalalib._
 
 object foo extends ScalaModule{
   def scalaVersion = "2.13.2"
-  object bar extends ScalaModule{
-    def scalaVersion = "2.13.2"
-  }
-
-  object qux extends ScalaModule{
-    def scalaVersion = "2.13.2"
-  }
 }

--- a/scratch/build.sc
+++ b/scratch/build.sc
@@ -3,4 +3,11 @@ import mill.scalalib._
 
 object foo extends ScalaModule{
   def scalaVersion = "2.13.2"
+  object bar extends ScalaModule{
+    def scalaVersion = "2.13.2"
+  }
+
+  object qux extends ScalaModule{
+    def scalaVersion = "2.13.2"
+  }
 }


### PR DESCRIPTION
This PR modifies the Mill evaluator output format, so that the `foo/meta.json` file is now top level as `foo.json`, as are the `foo.dest/` folder and `foo.log` file, although the latter two are not created unless necessary. This helps makes it easier to browse the output folder and find what you want: most "boring" tasks which do a trivial computation no longer generate a `foo/` folder, making the "interesting" tasks or the sub-modules stand out.

# Why

For example. Given the simple `build.sc` below:

```scala
import mill._
import mill.scalalib._

object foo extends ScalaModule{
  def scalaVersion = "2.13.2"
  object bar extends ScalaModule{
    def scalaVersion = "2.13.2"
  }

  object qux extends ScalaModule{
    def scalaVersion = "2.13.2"
  }
}
```

With the status quo, it is quite hard to look at the out folder and distinguish important tasks like "compile" or submodules like "bar" and "qux" in a sea of folders holding trivial task output. This holds true both in the terminal or in a graphical browser like an IDE:

<img width="706" alt="Screenshot 2021-11-25 at 2 22 26 PM" src="https://user-images.githubusercontent.com/934140/143390500-88b9179b-0e33-4f5e-bbb5-a2f2623f3139.png">

<img width="262" alt="Screenshot 2021-11-25 at 2 22 50 PM" src="https://user-images.githubusercontent.com/934140/143390511-e183e460-e7d6-4bce-a217-c953cb3ba857.png">

With this PR, the "trivial" tasks and "important" tasks or submodules are clearly visible at a glance, making it much easier to navigate the output folder:




# Changes

- We already lazily create the `foo/dest/` folder, so the only change here is to lazily create the `foo/log` file when someone writes to the output logger.

- I modified `./mill clean` to take delete both `foo/` and `foo.json` paths

- Updated the docs to refer to the new output layout

<img width="682" alt="Screenshot 2021-11-26 at 9 44 28 AM" src="https://user-images.githubusercontent.com/934140/143514513-c1fb8e0a-4580-48a7-a882-bd62a6a720d1.png">


<img width="286" alt="Screenshot 2021-11-26 at 9 44 11 AM" src="https://user-images.githubusercontent.com/934140/143514505-ebdb655a-5ee7-4871-8771-5681898ea5f4.png">


# Misc

Currently, we end up with *both* a `foo.json` file and a `foo.dest/` folder or `foo.log` file in the cases where they are necessary. I had considered automatically swapping between the `foo.json` file and the old `foo/meta.json` output style, but I figured that would make it harder to predict where the `.json` output file would end up. Decided to go with the proposed arrangement of `foo.json` and `foo.dest`/`foo.log` side by side for simplicity and predictability, even if it does make the output folder a bit more cluttered.

`rm -rf out/path/to/task/` no longer works for cleaning it; you'll have to remove the `out/path/to/task.*` now, or use `./mill clean`

Note that this has a chance of making the out folder even *more* cluttered, if most tasks have `.dest` and `.log` files defined. However, empirically it seems those tasks are very much the minority, and the vast majority of tasks are "trivial" tasks that only generate the `.json` file and nothing else


This is a big-ish change, so shouldn't be in a point version bump. Maybe it can go into 0.10.x?