### PR TITLE
Let prepareOffline accept a `all` flag

### DIFF
--- a/scalalib/src/ZincWorkerModule.scala
+++ b/scalalib/src/ZincWorkerModule.scala
@@ -151,13 +151,13 @@ trait ZincWorkerModule extends mill.Module with OfflineSupportModule { self: Cou
   }
 
   @nowarn("msg=pure expression does nothing")
-  override def prepareOffline(): Command[Unit] =
+  override def prepareOffline(hint: String*): Command[Unit] = {
     T.command {
-      super.prepareOffline()()
+      super.prepareOffline(hint: _*)()
       classpath()
-      // worker()
       ()
     }
+  }
 
   @nowarn("msg=pure expression does nothing")
   def prepareOfflineCompiler(scalaVersion: String, scalaOrganization: String): Command[Unit] =

--- a/scalalib/src/ZincWorkerModule.scala
+++ b/scalalib/src/ZincWorkerModule.scala
@@ -3,6 +3,7 @@ package mill.scalalib
 import scala.annotation.nowarn
 
 import coursier.Repository
+import mainargs.Flag
 import mill.Agg
 import mill.T
 import mill.api.{Ctx, FixSizedCache, KeyedLockedCache, Loose, PathRef, Result}
@@ -151,12 +152,10 @@ trait ZincWorkerModule extends mill.Module with OfflineSupportModule { self: Cou
   }
 
   @nowarn("msg=pure expression does nothing")
-  override def prepareOffline(hint: String*): Command[Unit] = {
-    T.command {
-      super.prepareOffline(hint: _*)()
-      classpath()
-      ()
-    }
+  override def prepareOffline(all: Flag): Command[Unit] = T.command {
+    super.prepareOffline(all)()
+    classpath()
+    ()
   }
 
   @nowarn("msg=pure expression does nothing")

--- a/scalalib/src/mill/scalalib/OfflineSupportModule.scala
+++ b/scalalib/src/mill/scalalib/OfflineSupportModule.scala
@@ -1,14 +1,16 @@
 package mill.scalalib
 
+import mainargs.Flag
 import mill.T
 import mill.define.Command
 
 trait OfflineSupportModule extends mill.Module {
 
   /**
-   * Prepare the module for working offline. This should typically fetch (missing) resources like ivy dependencies.
-   */
-  def prepareOffline(hint: String*): Command[Unit] = T.command {
+    * Prepare the module for working offline. This should typically fetch (missing) resources like ivy dependencies.
+    * @param all If `true`, it also fetches resources not always needed.
+    */
+  def prepareOffline(all: Flag): Command[Unit] = T.command {
     // nothing to do
   }
 

--- a/scalalib/src/mill/scalalib/OfflineSupportModule.scala
+++ b/scalalib/src/mill/scalalib/OfflineSupportModule.scala
@@ -8,7 +8,7 @@ trait OfflineSupportModule extends mill.Module {
   /**
    * Prepare the module for working offline. This should typically fetch (missing) resources like ivy dependencies.
    */
-  def prepareOffline(): Command[Unit] = T.command {
+  def prepareOffline(hint: String*): Command[Unit] = T.command {
     // nothing to do
   }
 


### PR DESCRIPTION
This should support more control in inheriting modules.

Also, fetch only essential dependencies in Java and Scala modules,
and keep the full fetch behind a `all` flag, which can be set as parameter.

This is a binary-incompatible change and I have no idea how to preserve compatibility.
Although I could keep the old signature and just forward to the newer,
Loading plugins that also inherit older `OfflineSupportModule`s seem to fail nevertheless.
Also I think Mill isn't checking for multiple commands with the same name, 
so I fear just because it works on my machine, it may still lead to some failures for others.
Only fix would be to invent a new name for the command (and deprecate the old).
As Mill 0.10.x is binary-incompatible anyways, I think this one should be ok.

Fix https://github.com/com-lihaoyi/mill/issues/1576