### PR TITLE
Don't add semanticdb plugin for Scala 3.

### DIFF
--- a/scalalib/src/mill/scalalib/bsp/ScalaMetalsSupport.scala
+++ b/scalalib/src/mill/scalalib/bsp/ScalaMetalsSupport.scala
@@ -3,23 +3,46 @@ package mill.scalalib.bsp
 import mill.api.experimental
 import mill.{Agg, T}
 import mill.define.Target
+import mill.scalalib.api.ZincWorkerUtil.isScala3
 import mill.scalalib.{Dep, DepSyntax, ScalaModule}
+import mill.api.Result
 
 /*+ Enable some common settings required to properly support Metals Language Server (via BSP). */
 @experimental
 trait ScalaMetalsSupport extends ScalaModule {
 
-  /** The semanticDB version to use. It needs to support your configured Scala versions. */
-  def semanticDbVersion: T[String]
+  /** The semanticDB version to use. It needs to support your configured Scala 2 version. */
+  def semanticDbVersion: T[String] = T { "" }
+
   override def scalacPluginIvyDeps: Target[Agg[Dep]] = T {
-    super.scalacPluginIvyDeps() ++ Agg(
-      ivy"org.scalameta:::semanticdb-scalac:${semanticDbVersion()}"
-    )
+    if (!isScala3(scalaVersion()) && semanticDbVersion().isEmpty) {
+      val msg =
+        """|
+           |When using ScalaMetalsSupport with Scala 2 you must provide a semanticDbVersion
+           |
+           |def semanticDbVersion = ???
+           |""".stripMargin
+      Result.Failure(msg)
+    } else if (isScala3(scalaVersion())) {
+      Result.Success(super.scalacPluginIvyDeps())
+    } else {
+      Result.Success(
+        super.scalacPluginIvyDeps() ++ Agg(
+          ivy"org.scalameta:::semanticdb-scalac:${semanticDbVersion()}"
+        )
+      )
+    }
   }
 
   /** Adds some options and configures the semanticDB plugin. */
   override def mandatoryScalacOptions: Target[Seq[String]] = T {
-    super.mandatoryScalacOptions() ++ Seq("-Yrangepos", s"-P:semanticdb:sourceroot:${T.workspace}")
+    super.mandatoryScalacOptions() ++ {
+      if (isScala3(scalaVersion())) {
+        Seq("-Xsemanticdb")
+      } else {
+        Seq("-Yrangepos", s"-P:semanticdb:sourceroot:${T.workspace}")
+      }
+    }
   }
 
   /** Filters options unsupported by Metals. */


### PR DESCRIPTION
For Scala 3 semanticdb is produced natively by the compiler behind the
`-Xsemanticdb` flag, so the plugin isn't necessary. This change ensures
the correct scalacOptions are set when using Scala 3 with
ScalaMetalsSupport.