### PR TITLE
Add note about "Switch Build Server" in Metals.

### DIFF
--- a/docs/antora/modules/ROOT/pages/Intro_to_Mill.adoc
+++ b/docs/antora/modules/ROOT/pages/Intro_to_Mill.adoc
@@ -847,6 +847,12 @@ You can fine control some BSP server options by specifying command options:
 
 [NOTE]
 --
+When using Metals by default Bloop will be used as your build server unless you
+explicitly choose Mill. When in a Mill workspace use the "Switch Build Server"
+command from Metals which will allow you to switch to using Mill as your build
+server. If no `.bsp/mill-bsp.json` file exists Metals will automatically create
+it for you and then connect to Mill.
+
 If you want to use Metals, you may also want to enable SemanticDB support. Without it, some functionality like find references may not work.
 
 We still work on a better and automatic SemanticDB support.


### PR DESCRIPTION
Now that https://github.com/scalameta/metals/pull/3308 is merged Metals can actually detect (based on mill version) if the current workspace can use Mill as a BSP server even if there is no `.bsp/mill-bsp.json` created yet. If the users selects this, it will automatically create the `.bsp/mill-bsp.json` file and then connect to mill. This pr just clarifies this in the docs and mentions the "Switch Build Server" command they'll need to use.

Just to show an example, you can see here there is no bsp entry, but it's still shown as an option:

![2021-11-29 19 06 17](https://user-images.githubusercontent.com/13974112/143945796-7798ceb6-dbfd-4450-9857-c05d0dedba5e.gif)