### PR TITLE
Upgrade Ammonite to 2.5.0, fansi to 0.3.0, acyclic to 0.3.0

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -70,7 +70,7 @@ object Deps {
     val scalanativeTestRunner = ivy"org.scala-native::test-runner:0.4.0"
   }
 
-  val acyclic = ivy"com.lihaoyi:::acyclic:0.3.0"
+  val acyclic = ivy"com.lihaoyi::acyclic:0.2.0"
   val ammonite = ivy"com.lihaoyi:::ammonite:2.5.0"
   val ammoniteTerminal = ivy"com.lihaoyi::ammonite-terminal:2.5.0"
   // Exclude trees here to force the version of we have defined. We use this

--- a/build.sc
+++ b/build.sc
@@ -70,9 +70,9 @@ object Deps {
     val scalanativeTestRunner = ivy"org.scala-native::test-runner:0.4.0"
   }
 
-  val acyclic = ivy"com.lihaoyi::acyclic:0.2.0"
-  val ammonite = ivy"com.lihaoyi:::ammonite:2.4.1"
-  val ammoniteTerminal = ivy"com.lihaoyi::ammonite-terminal:2.4.1"
+  val acyclic = ivy"com.lihaoyi:::acyclic:0.3.0"
+  val ammonite = ivy"com.lihaoyi:::ammonite:2.5.0"
+  val ammoniteTerminal = ivy"com.lihaoyi::ammonite-terminal:2.5.0"
   // Exclude trees here to force the version of we have defined. We use this
   // here instead of a `forceVersion()` on scalametaTrees since it's not
   // respected in the POM causing issues for Coursier Mill users.
@@ -123,7 +123,7 @@ object Deps {
   val windowsAnsi = ivy"io.github.alexarchambault.windows-ansi:windows-ansi:0.0.3"
   val zinc = ivy"org.scala-sbt::zinc:1.5.7"
   val bsp = ivy"ch.epfl.scala:bsp4j:2.0.0"
-  val fansi = ivy"com.lihaoyi::fansi:0.2.14"
+  val fansi = ivy"com.lihaoyi::fansi:0.3.0"
   val jarjarabrams = ivy"com.eed3si9n.jarjarabrams::jarjar-abrams-core:1.8.0"
 }
 

--- a/main/core/src/mill/define/Router.scala
+++ b/main/core/src/mill/define/Router.scala
@@ -72,7 +72,7 @@ class Router(val ctx: Context) extends mainargs.Macros(ctx) {
         } yield (
           m.overrides.length,
           extractMethod(
-            m.name.toString,
+            m.name,
             m.paramss.flatten,
             m.pos,
             m.annotations.find(_.tpe =:= typeOf[mainargs.main]),

--- a/main/src/mill/MillMain.scala
+++ b/main/src/mill/MillMain.scala
@@ -42,7 +42,7 @@ object MillMain {
         main0(
           args,
           None,
-          ammonite.Main.isInteractive(),
+          ammonite.util.Util.isInteractive(),
           System.in,
           System.out,
           System.err,


### PR DESCRIPTION
Also re-enabled the acyclic plugin, manually created a dependency cycle, and verified the error was reasonable:


```
[info] compiling 7 Scala sources to /Users/lihaoyi/Github/mill/out/main/util/compile/dest/classes ...
[error] Unwanted cyclic dependency
[info] /Users/lihaoyi/Github/mill/main/util/src/mill/util/Jvm.scala:6:11:
[info]   val y = EitherOps
[info]           ^
[info] symbol: object EitherOps
[info] /Users/lihaoyi/Github/mill/main/util/src/mill/util/EitherOps.scala:19:11:
[info]   val x = Jvm
[info]           ^
[info] symbol: object Jvm
[error] one error found
```

Probably not gonna fix all the dependency cycles and re-enable the acyclic enforcement in this PR, maybe in a follow up