### PR TITLE
Properly wire stdin in client-server mode and enable "Enter to Re-run" for mill -w

### DIFF
--- a/main/client/src/mill/main/client/InputPumper.java
+++ b/main/client/src/mill/main/client/InputPumper.java
@@ -2,7 +2,6 @@ package mill.main.client;
 
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.Arrays;
 
 public class InputPumper implements Runnable{
     private InputStream src;

--- a/main/client/src/mill/main/client/InputPumper.java
+++ b/main/client/src/mill/main/client/InputPumper.java
@@ -2,6 +2,7 @@ package mill.main.client;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Arrays;
 
 public class InputPumper implements Runnable{
     private InputStream src;

--- a/main/src/mill/main/MainRunner.scala
+++ b/main/src/mill/main/MainRunner.scala
@@ -49,20 +49,9 @@ class MainRunner(
   var stateCache = stateCache0
 
   override def watchAndWait(watched: Seq[(ammonite.interp.Watchable, Long)]) = {
-    val (watchedPaths, watchedValues) = watched.partitionMap {
-      case (ammonite.interp.Watchable.Path(p), _) => Left(())
-      case (_, _) => Right(())
-    }
-    val watchedValueStr =
-      if (watchedValues.isEmpty) "" else s" and ${watchedValues.size} other values"
-    printInfo(
-      s"Watching for changes to ${watchedPaths.size} paths$watchedValueStr... (Ctrl-C to exit)"
-    )
-    def statAll() = watched.forall { case (file, lastMTime) =>
-      file.poll() == lastMTime
-    }
+
     setIdle(true)
-    while (statAll()) Thread.sleep(100)
+    super.watchAndWait(watched)
     setIdle(false)
   }
 

--- a/main/src/mill/main/MillServerMain.scala
+++ b/main/src/mill/main/MillServerMain.scala
@@ -68,7 +68,7 @@ object MillServerMain extends mill.main.MillServerMain[EvaluatorState] {
       args,
       stateCache,
       mainInteractive = mainInteractive,
-      DummyInputStream,
+      stdin,
       stdout,
       stderr,
       env,
@@ -78,6 +78,7 @@ object MillServerMain extends mill.main.MillServerMain[EvaluatorState] {
     )
   }
 }
+
 
 class Server[T](
     lockBase: String,
@@ -134,12 +135,26 @@ class Server[T](
     }.getOrElse(throw new Exception("PID already present"))
   }
 
+  def proxyInputStreamThroughPumper(in: InputStream) = {
+    val pipedInput = new PipedInputStream()
+    val pipedOutput = new PipedOutputStream()
+    pipedOutput.connect(pipedInput)
+    val pumper = new InputPumper(in, pipedOutput, false)
+    val pumperThread = new Thread(pumper)
+    pumperThread.start()
+    pipedInput
+  }
   def handleRun(clientSocket: Socket, initialSystemProperties: Map[String, String]) = {
 
     val currentOutErr = clientSocket.getOutputStream
     val stdout = new PrintStream(new ProxyOutputStream(currentOutErr, 1), true)
     val stderr = new PrintStream(new ProxyOutputStream(currentOutErr, -1), true)
-    val socketIn = clientSocket.getInputStream
+    // Proxy the input stream through a pair of Piped**putStream via a pumper,
+    // as the `UnixDomainSocketInputStream` we get directly from the socket does
+    // not properly implement `available(): Int` and thus messes up polling logic
+    // that relies on that method
+    val proxiedSocketInput = proxyInputStreamThroughPumper(clientSocket.getInputStream)
+
     val argStream = new FileInputStream(lockBase + "/run")
     val interactive = argStream.read() != 0
     val clientMillVersion = Util.readString(argStream)
@@ -168,7 +183,7 @@ class Server[T](
             args,
             sm.stateCache,
             interactive,
-            socketIn,
+            proxiedSocketInput,
             stdout,
             stderr,
             env.asScala.toMap,

--- a/main/src/mill/main/MillServerMain.scala
+++ b/main/src/mill/main/MillServerMain.scala
@@ -141,6 +141,7 @@ class Server[T](
     pipedOutput.connect(pipedInput)
     val pumper = new InputPumper(in, pipedOutput, false)
     val pumperThread = new Thread(pumper)
+    pumperThread.setDaemon(true)
     pumperThread.start()
     pipedInput
   }

--- a/main/src/mill/modules/Jvm.scala
+++ b/main/src/mill/modules/Jvm.scala
@@ -1,25 +1,24 @@
 package mill.modules
 
-import java.io.{ByteArrayInputStream, File, FileOutputStream, InputStream, SequenceInputStream}
+import java.io.{ByteArrayInputStream, File, FileOutputStream, InputStream, PipedInputStream, SequenceInputStream}
 import java.lang.reflect.Modifier
 import java.net.URI
 import java.nio.file.{FileSystems, Files, StandardOpenOption}
 import java.nio.file.attribute.PosixFilePermission
 import java.util.jar.{Attributes, JarEntry, JarFile, JarOutputStream, Manifest}
-
 import coursier.{Dependency, Repository, Resolution}
 import coursier.util.{Gather, Task}
-import java.util.Collections
 
+import java.util.Collections
 import mill.main.client.InputPumper
 import mill.api.{Ctx, IO, PathRef, Result}
 import mill.api.Loose.Agg
 import mill.modules.Assembly.{AppendEntry, WriteOnceEntry}
+
 import scala.collection.mutable
 import scala.util.Properties.isWin
 import scala.jdk.CollectionConverters._
 import scala.util.Using
-
 import mill.BuildInfo
 import upickle.default.{ReadWriter => RW}
 
@@ -191,7 +190,7 @@ object Jvm {
     // to System.in/System.out/System.err, so the subprocess's streams get sent
     // to the parent process's origin outputs even if we want to direct them
     // elsewhere
-    if (System.in.isInstanceOf[ByteArrayInputStream]) {
+    if (System.in.isInstanceOf[PipedInputStream]) {
       val process = os.proc(commandArgs).spawn(
         cwd = workingDir,
         env = envArgs,

--- a/scratch/foo/src/Foo.scala
+++ b/scratch/foo/src/Foo.scala
@@ -2,6 +2,8 @@ package foo
 object Foo{
 
   def main(args: Array[String]): Unit = {
-    println(1 == "")
+    println("enter any character: ")
+    val c = System.in.read().toChar
+    println("c: [" + c + "]")
   }
 }

--- a/scratch/foo/src/Foo.scala
+++ b/scratch/foo/src/Foo.scala
@@ -2,8 +2,6 @@ package foo
 object Foo{
 
   def main(args: Array[String]): Unit = {
-    println("enter any character: ")
-    val c = System.in.read().toChar
-    println("c: [" + c + "]")
+    println(1 == "")
   }
 }


### PR DESCRIPTION
This gets rid of our custom `watchAndWait` logic, standardizing it with what's upstream in Ammonite and allowing Mill to use the "Enter to re-run" functionality that was introduced in Ammonite 2.5.0.

While this worked for `./mill -i` out of the box, some work was necessary to get it working for Mill's client-server mode. This fixes the wiring for the socket's stdin to ensure it gets plumbed through, and works around the broken `available()` implementation in the `UnixDomainSocketInputStream` by proxying it via an `InputPumper`.

Tested manually:

```
lihaoyi mill$ ./mill -i dev.run scratch -w foo.run
[90/647] de.tobiasroeser.mill.vcs.version.VcsVersion.vcsState
[647/647] dev.run
[44/44] foo.run
false
Watching for changes to 4 paths... (Enter to re-run, Ctrl-C to exit)

<ENTER>
[44/44] foo.run
false
Watching for changes to 4 paths... (Enter to re-run, Ctrl-C to exit)

<ENTER>
[44/44] foo.run
false
Watching for changes to 4 paths... (Enter to re-run, Ctrl-C to exit)

<ENTER>
[44/44] foo.run
false
Watching for changes to 4 paths... (Enter to re-run, Ctrl-C to exit)
<Ctrl-C>
Host JVM shutdown. Forcefully destroying subprocess ...
```

Notably, this change also allows you to run interactive `mill foo.run` programs without using `-i`, e.g. using this modified `scratch/src/Foo.scala`:


```
package foo
object Foo{

  def main(args: Array[String]): Unit = {
    println("enter any character: ")
    val c = System.in.read().toChar
    println("c: [" + c + "]")
  }
}
```

```bash
lihaoyi mill$ ./mill -i dev.run scratch -w foo.run
...
[44/44] foo.run
enter any character:
g<ENTER>
c: [g]
Watching for changes to 4 paths... (Enter to re-run, Ctrl-C to exit)
```

