### PR TITLE
Add a newer log4j2 dependency to avoid a critical vulnerability in zinc

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -87,6 +87,7 @@ object Deps {
 
   val junitInterface = ivy"com.github.sbt:junit-interface:0.13.2"
   val lambdaTest = ivy"de.tototec:de.tobiasroeser.lambdatest:0.7.0"
+  val log4j2Core = ivy"org.apache.logging.log4j:log4j-core:2.16.0"
   val osLib = ivy"com.lihaoyi::os-lib:0.7.8"
   val testng = ivy"org.testng:testng:7.4.0"
   val sbtTestInterface = ivy"org.scala-sbt:test-interface:1.0"
@@ -359,7 +360,8 @@ object scalalib extends MillModule {
     def moduleDeps = Seq(scalalib.api)
 
     def ivyDeps = Agg(
-      Deps.zinc
+      Deps.zinc,
+      Deps.log4j2Core
     )
     def testArgs = T{Seq(
       "-DMILL_SCALA_WORKER=" + runClasspath().map(_.path).mkString(",")


### PR DESCRIPTION
Backport of https://github.com/com-lihaoyi/mill/pull/1620