### PR TITLE
#1625 fix transformer not picked up

### DIFF
--- a/contrib/scalapblib/src/ScalaPBWorker.scala
+++ b/contrib/scalapblib/src/ScalaPBWorker.scala
@@ -36,7 +36,7 @@ class ScalaPBWorker {
               s"--scala_out=${opts}${generatedDirectory.getCanonicalPath}",
               s"--proto_path=${root.getCanonicalPath}"
             ) ++ sources.map(_.getCanonicalPath)
-            ctx.log.debug(args.mkString(" "))
+            ctx.log.debug(s"ScalaPBC args: ${args.mkString(" ")}")
             mainMethod.invoke(null, args.toArray)
           }
         }
@@ -81,9 +81,7 @@ class ScalaPBWorker {
       scalaPBOptions: String,
       dest: os.Path,
       scalaPBCExtraArgs: Seq[String]
-  )(
-      implicit ctx: mill.api.Ctx
-  ): mill.api.Result[PathRef] = {
+  )(implicit ctx: mill.api.Ctx): mill.api.Result[PathRef] = {
     val compiler = scalaPB(scalaPBClasspath)
 
     def compileScalaPBDir(inputDir: os.Path): Unit = {

--- a/contrib/scalapblib/src/ScalaPBWorker.scala
+++ b/contrib/scalapblib/src/ScalaPBWorker.scala
@@ -25,7 +25,8 @@ class ScalaPBWorker {
 
         val instance = new ScalaPBWorkerApi {
           override def compileScalaPB(
-              source: File,
+              root: File,
+              sources: Seq[File],
               scalaPBOptions: String,
               generatedDirectory: File,
               otherArgs: Seq[String]
@@ -33,9 +34,9 @@ class ScalaPBWorker {
             val opts = if (scalaPBOptions.isEmpty) "" else scalaPBOptions + ":"
             val args = otherArgs ++ Seq(
               s"--scala_out=${opts}${generatedDirectory.getCanonicalPath}",
-              s"--proto_path=${source.getParentFile.getCanonicalPath}",
-              source.getCanonicalPath
-            )
+              s"--proto_path=${root.getCanonicalPath}"
+            ) ++ sources.map(_.getCanonicalPath)
+            ctx.log.debug(args.mkString(" "))
             mainMethod.invoke(null, args.toArray)
           }
         }
@@ -80,16 +81,20 @@ class ScalaPBWorker {
       scalaPBOptions: String,
       dest: os.Path,
       scalaPBCExtraArgs: Seq[String]
-  )(implicit ctx: mill.api.Ctx): mill.api.Result[PathRef] = {
+  )(
+      implicit ctx: mill.api.Ctx
+  ): mill.api.Result[PathRef] = {
     val compiler = scalaPB(scalaPBClasspath)
 
     def compileScalaPBDir(inputDir: os.Path): Unit = {
       // ls throws if the path doesn't exist
       if (inputDir.toIO.exists) {
-        os.walk(inputDir).filter(_.last.matches(".*.proto"))
-          .foreach { proto =>
-            compiler.compileScalaPB(proto.toIO, scalaPBOptions, dest.toIO, scalaPBCExtraArgs)
-          }
+        val files = os
+          .walk(inputDir)
+          .filter(_.last.matches(".*.proto"))
+          .map(_.toIO)
+          .toIndexedSeq
+        compiler.compileScalaPB(inputDir.toIO, files, scalaPBOptions, dest.toIO, scalaPBCExtraArgs)
       }
     }
 
@@ -101,7 +106,8 @@ class ScalaPBWorker {
 
 trait ScalaPBWorkerApi {
   def compileScalaPB(
-      source: File,
+      root: File,
+      source: Seq[File],
       scalaPBOptions: String,
       generatedDirectory: File,
       otherArgs: Seq[String]


### PR DESCRIPTION
fixes related issue #1625 
It was easy to resolve the missing package context file by passing all files that need to be generated to protoc at once.
This is similar how sbt and gradle use protoc to compile the sources. 