### PR TITLE
mill script is POSIX-compliant and has quoted paths.

### DIFF
--- a/mill
+++ b/mill
@@ -10,7 +10,7 @@ set -e
 if [ -z "$MILL_VERSION" ] ; then
   if [ -f ".mill-version" ] ; then
     MILL_VERSION="$(head -n 1 .mill-version 2> /dev/null)"
-  elif [ -f "mill" ] && [ "$BASH_SOURCE" != "mill" ] ; then
+  elif [ -f "mill" ] && [ "$0" != "mill" ] ; then
     MILL_VERSION=$(grep -F "DEFAULT_MILL_VERSION=" "mill" | head -n 1 | cut -d= -f2)
   else
     MILL_VERSION=$DEFAULT_MILL_VERSION
@@ -29,7 +29,7 @@ MILL_MAJOR_VERSION="${version_remainder%%.*}"; version_remainder="${version_rema
 MILL_MINOR_VERSION="${version_remainder%%.*}"; version_remainder="${version_remainder#*.}"
 
 if [ ! -s "$MILL_EXEC_PATH" ] ; then
-  mkdir -p $MILL_DOWNLOAD_PATH
+  mkdir -p "$MILL_DOWNLOAD_PATH"
   if [ "$MILL_MAJOR_VERSION" -gt 0 ] || [ "$MILL_MINOR_VERSION" -ge 5 ] ; then
     ASSEMBLY="-assembly"
   fi


### PR DESCRIPTION
These are both mostly trivial changes.

The first one makes it so that the script works on systems where Bash is not symlinked to /bin/sh like Alpine Linux and FreeBSD. I'm not 100% sure what that line is trying to do. I read the commit (a41c632291b017b47e2c40979ffc49b279442f3c) that added it and I couldn't make sense of it. Either way, `BASH_SOURCE == BASH_SOURCE[0]` which is equal to `$0` when the script isn't getting sourced. The script is meant to be run, not sourced, so the change should be fine.

The second change just quotes the path in case someone's `XDG_CACHE_HOME` has a space in it. And it's good for consistency.