### PR TITLE
Fix/1625 Poc automatically pick up scalapb-options.proto filles

### DIFF
--- a/contrib/scalapblib/src/ScalaPBModule.scala
+++ b/contrib/scalapblib/src/ScalaPBModule.scala
@@ -37,16 +37,16 @@ trait ScalaPBModule extends ScalaModule {
   def scalaPBLenses: T[Boolean] = T { true }
 
   /**
-    * Additional arguments for scalaPBC.
-    *
-    *  If you'd like to pass additional arguments to the ScalaPB compiler directly,
-    *  you can override this task.
-    *
-    *  @see See [[http://www.lihaoyi.com/mill/page/contrib-modules.html#scalapb Configuration Options]] to
-    *       know more.
-    *  @return a sequence of Strings representing the additional arguments to append
-    *          (defaults to empty Seq[String]).
-    */
+   * Additional arguments for scalaPBC.
+   *
+   *  If you'd like to pass additional arguments to the ScalaPB compiler directly,
+   *  you can override this task.
+   *
+   *  @see See [[http://www.lihaoyi.com/mill/page/contrib-modules.html#scalapb Configuration Options]] to
+   *       know more.
+   *  @return a sequence of Strings representing the additional arguments to append
+   *          (defaults to empty Seq[String]).
+   */
   def scalaPBAdditionalArgs: T[Seq[String]] = T { Seq.empty[String] }
 
   def scalaPBProtocPath: T[Option[String]] = T { None }
@@ -134,15 +134,16 @@ trait ScalaPBModule extends ScalaModule {
 
   def scalaPbOptionFiles: T[Seq[PathRef]] = T {
     val isModifier = scalaPbModifierFileName().toSet
-    def findProtoModifiers(path: os.Path) = if (path.toIO.exists()) {
-      os.walk
-        .stream(path)
-        .filter(f => isModifier(f.toIO.getName))
-        .map(PathRef(_, quick = true))
-        .toList
-    } else {
-      List.empty
-    }
+    def findProtoModifiers(path: os.Path) =
+      if (path.toIO.exists()) {
+        os.walk
+          .stream(path)
+          .filter(f => isModifier(f.toIO.getName))
+          .map(PathRef(_, quick = true))
+          .toList
+      } else {
+        List.empty
+      }
 
     (Target.sequence(moduleDeps.collect { case m: ScalaPBModule => m.scalaPbOptionFiles })().flatten
       ++ findProtoModifiers(scalaPBUnpackProto().path)

--- a/contrib/scalapblib/src/ScalaPBWorker.scala
+++ b/contrib/scalapblib/src/ScalaPBWorker.scala
@@ -36,7 +36,7 @@ class ScalaPBWorker {
               s"--scala_out=${opts}${generatedDirectory.getCanonicalPath}",
               s"--proto_path=${root.getCanonicalPath}"
             ) ++ sources.map(_.getCanonicalPath)
-            ctx.log.debug(s"ScalaPBC args: ${args.mkString(" ")}")
+            ctx.log.debug(args.mkString(" "))
             mainMethod.invoke(null, args.toArray)
           }
         }
@@ -81,7 +81,9 @@ class ScalaPBWorker {
       scalaPBOptions: String,
       dest: os.Path,
       scalaPBCExtraArgs: Seq[String]
-  )(implicit ctx: mill.api.Ctx): mill.api.Result[PathRef] = {
+  )(
+      implicit ctx: mill.api.Ctx
+  ): mill.api.Result[PathRef] = {
     val compiler = scalaPB(scalaPBClasspath)
 
     def compileScalaPBDir(inputDir: os.Path): Unit = {

--- a/contrib/scalapblib/src/ScalaPBWorker.scala
+++ b/contrib/scalapblib/src/ScalaPBWorker.scala
@@ -92,7 +92,16 @@ class ScalaPBWorker {
           .filter(_.last.matches(".*.proto"))
           .map(_.toIO)
           .toIndexedSeq
-        compiler.compileScalaPB(inputDir.toIO, files, scalaPBOptions, dest.toIO, scalaPBCExtraArgs)
+
+        if (files.nonEmpty) {
+          compiler.compileScalaPB(
+            inputDir.toIO,
+            files,
+            scalaPBOptions,
+            dest.toIO,
+            scalaPBCExtraArgs
+          )
+        }
       }
     }
 

--- a/contrib/scalapblib/src/ScalaPBWorker.scala
+++ b/contrib/scalapblib/src/ScalaPBWorker.scala
@@ -36,7 +36,7 @@ class ScalaPBWorker {
               s"--scala_out=${opts}${generatedDirectory.getCanonicalPath}",
               s"--proto_path=${root.getCanonicalPath}"
             ) ++ sources.map(_.getCanonicalPath)
-            ctx.log.debug(args.mkString(" "))
+            ctx.log.debug(s"ScalaPBC args: ${args.mkString(" ")}")
             mainMethod.invoke(null, args.toArray)
           }
         }
@@ -81,9 +81,7 @@ class ScalaPBWorker {
       scalaPBOptions: String,
       dest: os.Path,
       scalaPBCExtraArgs: Seq[String]
-  )(
-      implicit ctx: mill.api.Ctx
-  ): mill.api.Result[PathRef] = {
+  )(implicit ctx: mill.api.Ctx): mill.api.Result[PathRef] = {
     val compiler = scalaPB(scalaPBClasspath)
 
     def compileScalaPBDir(inputDir: os.Path): Unit = {

--- a/contrib/scalapblib/test/protobuf/options/IgnoreMe.proto
+++ b/contrib/scalapblib/test/protobuf/options/IgnoreMe.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package tutorial;
+
+import "google/protobuf/wrappers.proto";
+
+option java_package = "com.example.tutorial";
+
+// this should not end up in the compiled project of another project
+message IgnoreMe{
+    google.protobuf.Int32Value my_int32 = 5;
+}

--- a/contrib/scalapblib/test/protobuf/options/scalapb-options.proto
+++ b/contrib/scalapblib/test/protobuf/options/scalapb-options.proto
@@ -1,0 +1,18 @@
+syntax = "proto2";
+
+package tutorial;
+
+import "scalapb/scalapb.proto";
+
+option (scalapb.options) = {
+  scope: PACKAGE
+  field_transformations : [
+    {
+      when : {
+        type: TYPE_MESSAGE
+        type_name: ".google.protobuf.Timestamp"
+      }
+      set : {[scalapb.field] {type : 'java.time.Instant' }}
+    }
+  ]
+};

--- a/contrib/scalapblib/test/protobuf/tutorial/Tutorial.proto
+++ b/contrib/scalapblib/test/protobuf/tutorial/Tutorial.proto
@@ -4,6 +4,7 @@ package tutorial;
 
 option java_package = "com.example.tutorial";
 option java_outer_classname = "AddressBookProtos";
+import "google/protobuf/timestamp.proto";
 
 message Person {
   required string name = 1;
@@ -26,4 +27,5 @@ message Person {
 
 message AddressBook {
   repeated Person people = 1;
+  optional google.protobuf.Timestamp at = 2;
 }

--- a/contrib/scalapblib/test/src/TutorialTests.scala
+++ b/contrib/scalapblib/test/src/TutorialTests.scala
@@ -27,6 +27,8 @@ object TutorialTests extends TestSuite {
     }
   }
 
+  // todo add tests for automatic search for scalapb-options.proto files
+
   object TutorialWithProtoc extends TutorialBase {
     object core extends TutorialModule {
       override def scalaPBProtocPath = Some("/dev/null")


### PR DESCRIPTION
This is a poc and i still need to add tests, (i need to have a look for that)
This scans all files for scalapb-options.proto and puts it on the generator path thus it picks up the package options from all dependencies and trasistivie projects.