### PR TITLE
Changed out path for overridden targets for consistency

### DIFF
--- a/docs/antora/modules/ROOT/pages/Configuring_Mill.adoc
+++ b/docs/antora/modules/ROOT/pages/Configuring_Mill.adoc
@@ -237,7 +237,7 @@ mill foo.test
 ----
 
 By default, tests are run in a subprocess, and `forkArg` and `forkEnv` can be
-overriden to pass JVM flags &amp; environment variables. You can also use
+overridden to pass JVM flags &amp; environment variables. You can also use
 
 [source,bash]
 ----

--- a/docs/antora/modules/ROOT/pages/Modules.adoc
+++ b/docs/antora/modules/ROOT/pages/Modules.adoc
@@ -135,7 +135,7 @@ would have its `millSourcePath` be `./foo/lols/baz`.
 
 Note that `millSourcePath` is generally only used for a module's input source files.
 Output is always in the `out/` folder and cannot be changed, e.g. even with the
-overriden `millSourcePath` the output paths are still the default `./out/foo/bar` and
+overridden `millSourcePath` the output paths are still the default `./out/foo/bar` and
 `./out/foo/baz/qux` folders.
 
 == External Modules

--- a/main/core/src/mill/define/Ctx.scala
+++ b/main/core/src/mill/define/Ctx.scala
@@ -9,10 +9,7 @@ sealed trait Segment {
   }
 }
 object Segment {
-  case class Label(value: String) extends Segment {
-    // FIXME: Document, why we have this requirement, see https://github.com/com-lihaoyi/mill/issues/820
-    require(!value.contains('.'), "A label must not contain a dot ('.').")
-  }
+  case class Label(value: String) extends Segment
   case class Cross(value: Seq[Any]) extends Segment
 }
 

--- a/main/test/src/define/BasePathTests.scala
+++ b/main/test/src/define/BasePathTests.scala
@@ -54,20 +54,20 @@ object BasePathTests extends TestSuite {
         "js"
       )
     }
-    "overriden" - {
-      object overridenBasePath extends TestUtil.BaseModule {
-        override def millSourcePath = os.pwd / "overridenBasePathRootValue"
+    "overridden" - {
+      object overriddenBasePath extends TestUtil.BaseModule {
+        override def millSourcePath = os.pwd / "overriddenBasePathRootValue"
         object nested extends Module {
-          override def millSourcePath = super.millSourcePath / "overridenBasePathNested"
+          override def millSourcePath = super.millSourcePath / "overriddenBasePathNested"
           object nested extends Module {
-            override def millSourcePath = super.millSourcePath / "overridenBasePathDoubleNested"
+            override def millSourcePath = super.millSourcePath / "overriddenBasePathDoubleNested"
           }
         }
       }
       assert(
-        overridenBasePath.millSourcePath == os.pwd / "overridenBasePathRootValue",
-        overridenBasePath.nested.millSourcePath == os.pwd / "overridenBasePathRootValue" / "nested" / "overridenBasePathNested",
-        overridenBasePath.nested.nested.millSourcePath == os.pwd / "overridenBasePathRootValue" / "nested" / "overridenBasePathNested" / "nested" / "overridenBasePathDoubleNested"
+        overriddenBasePath.millSourcePath == os.pwd / "overriddenBasePathRootValue",
+        overriddenBasePath.nested.millSourcePath == os.pwd / "overriddenBasePathRootValue" / "nested" / "overriddenBasePathNested",
+        overriddenBasePath.nested.nested.millSourcePath == os.pwd / "overriddenBasePathRootValue" / "nested" / "overriddenBasePathNested" / "nested" / "overriddenBasePathDoubleNested"
       )
     }
 

--- a/main/test/src/define/CacherTests.scala
+++ b/main/test/src/define/CacherTests.scala
@@ -16,7 +16,7 @@ object CacherTests extends TestSuite {
   object Middle extends Middle
   trait Middle extends Base {
     override def value = T { super.value() + 2 }
-    def overriden = T { super.value() }
+    def overridden = T { super.value() }
   }
   object Terminal extends Terminal
   trait Terminal extends Middle {
@@ -45,13 +45,13 @@ object CacherTests extends TestSuite {
       Predef.assert(Middle.value eq Middle.value)
     }
 
-    "overridenDefRemainsAvailable" - {
-      Predef.assert(eval(Middle, Middle.overriden) == 1)
+    "overriddenDefRemainsAvailable" - {
+      Predef.assert(eval(Middle, Middle.overridden) == 1)
     }
 
     "multipleOverridesWork" - {
       Predef.assert(eval(Terminal, Terminal.value) == 7)
-      Predef.assert(eval(Terminal, Terminal.overriden) == 1)
+      Predef.assert(eval(Terminal, Terminal.overridden) == 1)
     }
     //    Doesn't fail, presumably compileError doesn't go far enough in the
     //    compilation pipeline to hit the override checks

--- a/main/test/src/eval/EvaluationTests.scala
+++ b/main/test/src/eval/EvaluationTests.scala
@@ -5,6 +5,7 @@ import mill.define.{Discover, Graph, Target, Task}
 import mill.{Module, T}
 import mill.util.{DummyLogger, TestEvaluator, TestGraphs, TestUtil}
 import mill.api.Strict.Agg
+import os.SubPath
 import utest._
 import utest.framework.TestPath
 
@@ -227,8 +228,7 @@ class EvaluationTests(threadCount: Option[Int]) extends TestSuite {
 
         val public = os.read(checker.evaluator.outPath / "foo.json")
         val overriden = os.read(
-          checker.evaluator.outPath / "foo" /
-            "overriden" / "mill" / "util" / "TestGraphs" / "BaseModule" / "foo.json"
+          checker.evaluator.outPath / "foo.overridden" / "mill" / "util" / "TestGraphs" / "BaseModule" / "foo.json"
         )
         assert(
           public.contains("base"),
@@ -255,8 +255,7 @@ class EvaluationTests(threadCount: Option[Int]) extends TestSuite {
 
         val public = os.read(checker.evaluator.outPath / "cmd.json")
         val overriden = os.read(
-          checker.evaluator.outPath / "cmd" /
-            "overriden" / "mill" / "util" / "TestGraphs" / "BaseModule" / "cmd.json"
+          checker.evaluator.outPath / "cmd.overridden" / "mill" / "util" / "TestGraphs" / "BaseModule" / "cmd.json"
         )
         assert(
           public.contains("base1"),
@@ -370,15 +369,15 @@ class EvaluationTests(threadCount: Option[Int]) extends TestSuite {
         extraEvaled = -1
       )
 
-      val overridePrefix =
-        os.sub / "overriden" / "mill" / "util" / "TestGraphs" / "StackableOverrides"
+      def overridePath(task: String): SubPath =
+        os.sub / s"${task}.overridden" / "mill" / "util" / "TestGraphs" / "StackableOverrides"
 
       assert(
-        os.read(checker.evaluator.outPath / "m" / "f" / overridePrefix / "X" / "f.json")
+        os.read(checker.evaluator.outPath / "m" / overridePath("f") / "X" / "f.json")
           .contains(" 1,")
       )
       assert(
-        os.read(checker.evaluator.outPath / "m" / "f" / overridePrefix / "A" / "f.json")
+        os.read(checker.evaluator.outPath / "m" / overridePath("f") / "A" / "f.json")
           .contains(" 3,")
       )
       assert(os.read(checker.evaluator.outPath / "m" / "f.json").contains(" 6,"))

--- a/main/test/src/eval/EvaluationTests.scala
+++ b/main/test/src/eval/EvaluationTests.scala
@@ -219,7 +219,7 @@ class EvaluationTests(threadCount: Option[Int]) extends TestSuite {
 
       "overrideSuperTask" - {
         // Make sure you can override targets, call their supers, and have the
-        // overriden target be allocated a spot within the overriden/ folder of
+        // overridden target be allocated a spot within the overridden/ folder of
         // the main publicly-available target
         import canOverrideSuper._
 
@@ -227,19 +227,19 @@ class EvaluationTests(threadCount: Option[Int]) extends TestSuite {
         checker(foo, Seq("base", "object"), Agg(foo), extraEvaled = -1)
 
         val public = os.read(checker.evaluator.outPath / "foo.json")
-        val overriden = os.read(
+        val overridden = os.read(
           checker.evaluator.outPath / "foo.overridden" / "mill" / "util" / "TestGraphs" / "BaseModule" / "foo.json"
         )
         assert(
           public.contains("base"),
           public.contains("object"),
-          overriden.contains("base"),
-          !overriden.contains("object")
+          overridden.contains("base"),
+          !overridden.contains("object")
         )
       }
       "overrideSuperCommand" - {
         // Make sure you can override commands, call their supers, and have the
-        // overriden command be allocated a spot within the overriden/ folder of
+        // overridden command be allocated a spot within the overridden/ folder of
         // the main publicly-available command
         import canOverrideSuper._
 
@@ -254,14 +254,14 @@ class EvaluationTests(threadCount: Option[Int]) extends TestSuite {
         )
 
         val public = os.read(checker.evaluator.outPath / "cmd.json")
-        val overriden = os.read(
+        val overridden = os.read(
           checker.evaluator.outPath / "cmd.overridden" / "mill" / "util" / "TestGraphs" / "BaseModule" / "cmd.json"
         )
         assert(
           public.contains("base1"),
           public.contains("object1"),
-          overriden.contains("base1"),
-          !overriden.contains("object1")
+          overridden.contains("base1"),
+          !overridden.contains("object1")
         )
       }
       "nullTasks" - {
@@ -357,7 +357,7 @@ class EvaluationTests(threadCount: Option[Int]) extends TestSuite {
     }
     "stackableOverrides" - {
       // Make sure you can override commands, call their supers, and have the
-      // overriden command be allocated a spot within the overriden/ folder of
+      // overridden command be allocated a spot within the overridden/ folder of
       // the main publicly-available command
       import StackableOverrides._
 


### PR DESCRIPTION
To be more consistent with the changes from PR
https://github.com/com-lihaoyi/mill/pull/1588
which re-layouted the log, meta, and dest path for targets.
This change touches the path of overriden target results.
It replaces the `../target/overriden/..` part with
`../target.overriden/..`.

There is a catch though, to make this work I had to remove one
`require` assertion, which guarded the presence of dots (`.`) in
labels. TBH, I previously stubled upon this require
and also added the FIXME comment to it, as it is unclear why it
even exists. Probably, because labels with dots can't be properly
parsed when given on cli. More details and hisory can be found in
issue https://github.com/com-lihaoyi/mill/issues/820.

Fix #820.

Review by @lihaoyi.
