### PR TITLE
[WIP] Support Scala Native for Scala 3

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -66,10 +66,10 @@ object Deps {
   }
 
   object Scalanative_0_4 {
-    val scalanativeTools = ivy"org.scala-native::tools:0.4.3-SNAPSHOT"
-    val scalanativeUtil = ivy"org.scala-native::util:0.4.3-SNAPSHOT"
-    val scalanativeNir = ivy"org.scala-native::nir:0.4.3-SNAPSHOT"
-    val scalanativeTestRunner = ivy"org.scala-native::test-runner:0.4.3-SNAPSHOT"
+    val scalanativeTools = ivy"org.scala-native::tools:0.4.3-RC1"
+    val scalanativeUtil = ivy"org.scala-native::util:0.4.3-RC1"
+    val scalanativeNir = ivy"org.scala-native::nir:0.4.3-RC1"
+    val scalanativeTestRunner = ivy"org.scala-native::test-runner:0.4.3-RC1"
   }
 
   val acyclic = ivy"com.lihaoyi::acyclic:0.2.0"

--- a/build.sc
+++ b/build.sc
@@ -66,10 +66,10 @@ object Deps {
   }
 
   object Scalanative_0_4 {
-    val scalanativeTools = ivy"org.scala-native::tools:0.4.0"
-    val scalanativeUtil = ivy"org.scala-native::util:0.4.0"
-    val scalanativeNir = ivy"org.scala-native::nir:0.4.0"
-    val scalanativeTestRunner = ivy"org.scala-native::test-runner:0.4.0"
+    val scalanativeTools = ivy"org.scala-native::tools:0.4.3-SNAPSHOT"
+    val scalanativeUtil = ivy"org.scala-native::util:0.4.3-SNAPSHOT"
+    val scalanativeNir = ivy"org.scala-native::nir:0.4.3-SNAPSHOT"
+    val scalanativeTestRunner = ivy"org.scala-native::test-runner:0.4.3-SNAPSHOT"
   }
 
   val acyclic = ivy"com.lihaoyi::acyclic:0.2.0"
@@ -168,7 +168,8 @@ trait MillCoursierModule extends CoursierModule {
     super.repositoriesTask() ++ Seq(
       MavenRepository(
         "https://oss.sonatype.org/content/repositories/releases"
-      )
+      ),
+      MavenRepository("http://oss.sonatype.org/content/repositories/snapshots")
     )
   }
 }

--- a/scalalib/src/ScalaModule.scala
+++ b/scalalib/src/ScalaModule.scala
@@ -168,7 +168,7 @@ trait ScalaModule extends JavaModule { outer =>
     resolveDeps(
       T.task {
         scalaCompilerIvyDeps(scalaOrganization(), scalaVersion()) ++
-          scalaRuntimeIvyDeps(scalaOrganization(), scalaVersion())
+          scalaLibraryIvyDeps()
       }
     )()
   }

--- a/scalanativelib/test/src/HelloNativeWorldTests.scala
+++ b/scalanativelib/test/src/HelloNativeWorldTests.scala
@@ -22,12 +22,12 @@ object HelloNativeWorldTests extends TestSuite {
     override def mainClass = Some("hello.Main")
   }
 
-  val scala213 = "2.13.6"
-  val scalaNative04 = "0.4.0"
+  val scala213 = "2.13.7"
+  val scalaNative04 = "0.4.3-SNAPSHOT"
 
   object HelloNativeWorld extends TestUtil.BaseModule {
     val matrix = for {
-      scala <- Seq(scala213, "2.12.13", "2.11.12")
+      scala <- Seq("3.1.0", scala213, "2.12.13", "2.11.12")
       scalaNative <- Seq(scalaNative04)
       mode <- List(ReleaseMode.Debug, ReleaseMode.ReleaseFast)
     } yield (scala, scalaNative, mode)
@@ -38,6 +38,11 @@ object HelloNativeWorldTests extends TestSuite {
       override def artifactName = "hello-native-world"
       def scalaNativeVersion = sNativeVersion
       def releaseMode = T { mode }
+      override def repositoriesTask = T.task {
+        super.repositoriesTask() :+ coursier.MavenRepository(
+          "http://oss.sonatype.org/content/repositories/snapshots"
+        )
+      }
       def pomSettings = PomSettings(
         organization = "com.lihaoyi",
         description = "hello native world ready for real world publishing",

--- a/scalanativelib/test/src/HelloNativeWorldTests.scala
+++ b/scalanativelib/test/src/HelloNativeWorldTests.scala
@@ -24,7 +24,7 @@ object HelloNativeWorldTests extends TestSuite {
   }
 
   val scala213 = "2.13.7"
-  val scalaNative04 = "0.4.3-SNAPSHOT"
+  val scalaNative04 = "0.4.3-RC1"
 
   object HelloNativeWorld extends TestUtil.BaseModule {
     val matrix = for {

--- a/scalanativelib/worker/0.4/src/ScalaNativeWorkerImpl.scala
+++ b/scalanativelib/worker/0.4/src/ScalaNativeWorkerImpl.scala
@@ -52,11 +52,9 @@ class ScalaNativeWorkerImpl extends mill.scalanativelib.api.ScalaNativeWorkerApi
       nativeOptimize: Boolean,
       logLevel: NativeLogLevel
   ): NativeConfig = {
-    val entry = mainClass + "$"
-
     val config =
       Config.empty
-        .withMainClass(entry)
+        .withMainClass(mainClass)
         .withClassPath(classpath.map(_.toPath))
         .withWorkdir(nativeWorkdir.toPath)
         .withCompilerConfig(


### PR DESCRIPTION
- Bump Scala Native to 0.4.3-SNAPSHOT
- Return `Result.Failure` on wrong env variables
- Use right dependencies in Scala 3
- Use `repositoriesTask` to resolve Scala Native `bridgeFullClassPath`
  instead of hardcoded list of resolvers.
  This allows builds to use SNAPSHOT versions of Scala Native.
- Drop support for Scala Native 0.4.2-