### PR TITLE
Experimental scalajs module splitting support

### DIFF
--- a/scalajslib/api/src/ScalaJSWorkerApi.scala
+++ b/scalajslib/api/src/ScalaJSWorkerApi.scala
@@ -1,6 +1,7 @@
 package mill.scalajslib.api
 import java.io.File
 import mill.api.Result
+
 trait ScalaJSWorkerApi {
   def link(
       sources: Array[File],
@@ -10,6 +11,20 @@ trait ScalaJSWorkerApi {
       testBridgeInit: Boolean,
       fullOpt: Boolean,
       moduleKind: ModuleKind,
+      useECMAScript2015: Boolean
+  ): Result[File]
+
+  def linkJs(
+      sources: Array[File],
+      libraries: Array[File],
+      destDirectory: File,
+      main: Option[String],
+      testBridgeInit: Boolean,
+      fullOpt: Boolean,
+      moduleKind: ModuleKind,
+      moduleSplitStyle: ModuleSplitStyle,
+      moduleInitializers: Seq[ModuleInitializer],
+      outputPatterns: OutputPatterns,
       useECMAScript2015: Boolean
   ): Result[File]
 
@@ -34,6 +49,34 @@ object ModuleKind {
   object NoModule extends ModuleKind
   object CommonJSModule extends ModuleKind
   object ESModule extends ModuleKind
+}
+
+sealed trait ModuleSplitStyle
+object ModuleSplitStyle {
+  object FewestModules extends ModuleSplitStyle
+  object SmallestModules extends ModuleSplitStyle
+}
+
+object ModuleInitializer {
+  import upickle.default.{ReadWriter => RW, macroRW}
+  implicit def rw: RW[ModuleInitializer] = macroRW
+}
+
+case class ModuleInitializer(className: String, mainMethod: String, moduleId: String)
+
+sealed trait OutputPatterns
+
+object OutputPatterns {
+  import upickle.default.{ReadWriter => RW, macroRW}
+  implicit def rwFromJsFile: RW[OutputPatternsFromJsFile] = macroRW
+  implicit def rw: RW[OutputPatterns] = macroRW
+
+  def fromJSFile(jsFile: String): OutputPatterns = OutputPatternsFromJsFile(jsFile)
+
+  case object OutputPatternsDefaults extends OutputPatterns
+
+  case class OutputPatternsFromJsFile(jsFile: String) extends OutputPatterns
+
 }
 
 sealed trait JsEnvConfig

--- a/scalajslib/src/ScalaJSWorkerApi.scala
+++ b/scalajslib/src/ScalaJSWorkerApi.scala
@@ -52,6 +52,35 @@ class ScalaJSWorker {
     ).map(os.Path(_))
   }
 
+  def linkJs(
+      toolsClasspath: Agg[os.Path],
+      sources: Agg[os.Path],
+      libraries: Agg[os.Path],
+      dest: File,
+      main: Option[String],
+      testBridgeInit: Boolean,
+      fullOpt: Boolean,
+      moduleKind: ModuleKind,
+      moduleSplitStyle: ModuleSplitStyle,
+      moduleInitializers: Seq[ModuleInitializer],
+      outputPatterns: OutputPatterns,
+      useECMAScript2015: Boolean
+  )(implicit ctx: Ctx.Home): Result[os.Path] = {
+    bridge(toolsClasspath).linkJs(
+      sources.items.map(_.toIO).toArray,
+      libraries.items.map(_.toIO).toArray,
+      dest,
+      main,
+      testBridgeInit,
+      fullOpt,
+      moduleKind,
+      moduleSplitStyle,
+      moduleInitializers,
+      outputPatterns,
+      useECMAScript2015
+    ).map(os.Path(_))
+  }
+
   def run(toolsClasspath: Agg[os.Path], config: JsEnvConfig, linkedFile: File)(implicit
       ctx: Ctx.Home
   ): Unit = {

--- a/scalajslib/test/resources/hello-split-js-world/src/MainA.scala
+++ b/scalajslib/test/resources/hello-split-js-world/src/MainA.scala
@@ -1,0 +1,18 @@
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSExportTopLevel}
+
+object MainA extends App {
+
+  @JSExportTopLevel(name = "startA", moduleID = "main")
+  def entrypointA() = {
+    println("Hello entrypoint A" + vmName)
+  }
+
+  println("Hello A " + vmName)
+
+  def vmName = sys.props("java.vm.name")
+
+  def main(): Unit = {
+    println("Module init A")
+  }
+}

--- a/scalajslib/test/resources/hello-split-js-world/src/MainB.scala
+++ b/scalajslib/test/resources/hello-split-js-world/src/MainB.scala
@@ -1,0 +1,17 @@
+import scala.scalajs.js.annotation.{JSExportTopLevel}
+
+object MainB {
+
+  @JSExportTopLevel(name = "startB", moduleID = "b")
+  def entrypointB() = {
+    println("Hello entrypoint B" + vmName)
+  }
+
+  println("Hello B " + vmName)
+
+  def vmName = sys.props("java.vm.name")
+
+  def main(): Unit = {
+    println("Module init B")
+  }
+}

--- a/scalajslib/test/src/HelloJSWorldTestsBase.scala
+++ b/scalajslib/test/src/HelloJSWorldTestsBase.scala
@@ -1,0 +1,100 @@
+package mill.scalajslib
+
+import java.util.jar.JarFile
+import mill._
+import mill.define.Discover
+import mill.eval.{EvaluatorPaths, Result}
+import mill.scalalib.{CrossScalaModule, DepSyntax, Lib, PublishModule, TestModule}
+import mill.testrunner.TestRunner
+import mill.scalalib.api.Util.isScala3
+import mill.scalalib.publish.{Developer, License, PomSettings, VersionControl}
+import mill.util.{TestEvaluator, TestUtil}
+import utest._
+
+import scala.collection.JavaConverters._
+import mill.scalajslib.api._
+import os.Path
+
+trait HelloJSWorldTestsBase extends TestSuite {
+  def workspacePath: Path
+  def scalaVersions: Seq[String] // = Seq("2.13.3", /* "3.0.0-RC1", */ "2.12.12", "2.11.12")
+  def scalaJSVersionsAndUseECMA2015
+      : Seq[(String, Boolean)] // = Seq(("1.7.1", false), ("1.4.0", false), ("1.3.1", true))
+  def matrix = for {
+    scala <- scalaVersions
+    (scalaJS, useECMAScript2015) <- scalaJSVersionsAndUseECMA2015
+    if !(isScala3(scala) && scalaJS != scalaJSVersionsAndUseECMA2015.head._1)
+  } yield (scala, scalaJS, useECMAScript2015)
+
+  trait HelloJSWorldBase extends TestUtil.BaseModule {
+
+    abstract class BuildModuleBase(
+        val crossScalaVersion: String,
+        sjsVersion0: String,
+        sjsUseECMA2015: Boolean
+    ) extends CrossScalaModule with ScalaJSModule {
+      override def millSourcePath = workspacePath
+      override def artifactName = "hello-split-world"
+      def scalaJSVersion = sjsVersion0
+      def useECMAScript2015 = sjsUseECMA2015
+    }
+
+    abstract class BuildModuleUtestBase(
+        crossScalaVersion: String,
+        sjsVersion0: String,
+        sjsUseECMA2015: Boolean
+    ) extends BuildModuleBase(crossScalaVersion, sjsVersion0, sjsUseECMA2015) {
+      object test extends super.Tests with TestModule.Utest {
+        override def sources = T.sources { millSourcePath / "src" / "utest" }
+        val utestVersion = if (isScala3(crossScalaVersion)) "0.7.7" else "0.7.5"
+        override def ivyDeps = Agg(
+          ivy"com.lihaoyi::utest::$utestVersion"
+        )
+      }
+    }
+
+    abstract class BuildModuleScalaTestBase(
+        crossScalaVersion: String,
+        sjsVersion0: String,
+        sjsUseECMA2015: Boolean
+    ) extends BuildModuleBase(crossScalaVersion, sjsVersion0, sjsUseECMA2015) {
+      object test extends super.Tests with TestModule.ScalaTest {
+        override def sources = T.sources { millSourcePath / "src" / "scalatest" }
+        override def ivyDeps = Agg(
+          ivy"org.scalatest::scalatest::3.1.2"
+        )
+      }
+    }
+  }
+
+  val millSourcePath: Path
+
+  val helloWorldEvaluator: TestEvaluator
+
+  def prepareWorkspace(): Unit = {
+    os.remove.all(workspacePath)
+    os.makeDir.all(workspacePath / os.up)
+    os.copy(millSourcePath, workspacePath)
+  }
+
+  def testAllMatrix(
+      f: (String, String, Boolean) => Unit,
+      skipScala: String => Boolean = _ => false,
+      skipScalaJS: String => Boolean = _ => false,
+      skipECMAScript2015: Boolean = true
+  ): Unit = {
+    for {
+      (scala, scalaJS, useECMAScript2015) <- matrix
+      if !skipScala(scala)
+      if !skipScalaJS(scalaJS)
+      if !(skipECMAScript2015 && useECMAScript2015)
+    } {
+      if (scala.startsWith("2.11.")) {
+        TestUtil.disableInJava9OrAbove(f(scala, scalaJS, useECMAScript2015))
+      } else {
+        f(scala, scalaJS, useECMAScript2015)
+      }
+    }
+  }
+
+}

--- a/scalajslib/test/src/HelloSplitJSWorldTests.scala
+++ b/scalajslib/test/src/HelloSplitJSWorldTests.scala
@@ -1,0 +1,170 @@
+package mill.scalajslib
+
+import java.util.jar.JarFile
+import mill._
+import mill.define.Discover
+import mill.eval.{EvaluatorPaths, Result}
+import mill.scalalib.{CrossScalaModule, DepSyntax, Lib, PublishModule, TestModule}
+import mill.testrunner.TestRunner
+import mill.scalalib.api.Util.isScala3
+import mill.scalalib.publish.{Developer, License, PomSettings, VersionControl}
+import mill.util.{TestEvaluator, TestUtil}
+import utest._
+
+import scala.collection.JavaConverters._
+import mill.scalajslib.api._
+
+object HelloSplitJSWorldTests extends TestSuite with HelloJSWorldTestsBase {
+  val workspacePath = TestUtil.getOutPathStatic() / "hello-split-js-world"
+
+  val scalaVersions = Seq("2.13.3", "3.1.0", "2.12.12", "2.11.12")
+
+  val scalaJSVersionsAndUseECMA2015 =
+    Seq(("1.7.1", false), ("1.4.0", false), ("1.3.1", true))
+
+  trait HelloJSWorldModule extends CrossScalaModule with ScalaJSModule {
+    override def millSourcePath = workspacePath
+    def publishVersion = "0.0.1-SNAPSHOT"
+    override def mainClass = None
+    override def moduleKind: T[ModuleKind] = T { ModuleKind.ESModule }
+    override def moduleSplitStyle: T[ModuleSplitStyle] = T { ModuleSplitStyle.FewestModules }
+    override def moduleInitializers: T[Seq[ModuleInitializer]] =
+      T { Seq(ModuleInitializer("MainA", "main", "main"), ModuleInitializer("MainB", "main", "b")) }
+    override def outputPatterns: T[OutputPatterns] = T { OutputPatterns.fromJSFile("%s.mjs") }
+  }
+
+  object HelloJSWorld extends HelloJSWorldBase {
+
+    object helloJsWorld extends Cross[BuildModule](matrix: _*)
+    class BuildModule(crossScalaVersion: String, sjsVersion0: String, sjsUseECMA2015: Boolean)
+        extends BuildModuleBase(crossScalaVersion, sjsVersion0, sjsUseECMA2015)
+        with HelloJSWorldModule
+  }
+
+  val millSourcePath = os.pwd / "scalajslib" / "test" / "resources" / "hello-split-js-world"
+
+  val helloWorldEvaluator = TestEvaluator.static(HelloJSWorld)
+
+  def tests: Tests = Tests {
+    prepareWorkspace()
+    "compile" - {
+      def testCompileFromScratch(
+          scalaVersion: String,
+          scalaJSVersion: String,
+          useECMAScript2015: Boolean
+      ): Unit = {
+        val Right((result, evalCount)) =
+          helloWorldEvaluator(HelloJSWorld.helloJsWorld(
+            scalaVersion,
+            scalaJSVersion,
+            useECMAScript2015
+          ).compile)
+
+        val outPath = result.classes.path
+        val outputFiles = os.walk(outPath)
+        val expectedClassfiles = compileClassfiles(outPath, scalaVersion, scalaJSVersion)
+        assert(
+          outputFiles.toSet == expectedClassfiles,
+          evalCount > 0
+        )
+
+        // don't recompile if nothing changed
+        val Right((_, unchangedEvalCount)) =
+          helloWorldEvaluator(HelloJSWorld.helloJsWorld(
+            scalaVersion,
+            scalaJSVersion,
+            useECMAScript2015
+          ).compile)
+        assert(unchangedEvalCount == 0)
+      }
+
+      testAllMatrix(
+        (scala, scalaJS, useECMAScript2015) =>
+          testCompileFromScratch(scala, scalaJS, useECMAScript2015),
+        skipECMAScript2015 = false
+      )
+    }
+
+    def testRun(
+        scalaVersion: String,
+        scalaJSVersion: String,
+        useECMAScript2015: Boolean,
+        mode: OptimizeMode
+    ): Unit = {
+      val task = mode match {
+        case FullOpt =>
+          HelloJSWorld.helloJsWorld(scalaVersion, scalaJSVersion, useECMAScript2015).fullLinkJS
+        case FastOpt =>
+          HelloJSWorld.helloJsWorld(scalaVersion, scalaJSVersion, useECMAScript2015).fastLinkJS
+      }
+      val Right((result, evalCount)) = helloWorldEvaluator(task)
+      val jsFile = result.path / "bootstrap.mjs"
+      val jsFileContent =
+        """
+          |import { startA } from './main.mjs'
+          |import { startB } from './b.mjs'
+          |
+          |startA()
+          |startB()
+          |""".stripMargin
+      os.write(jsFile, jsFileContent)
+      val output = ScalaJsUtils.runJS(jsFile)
+      println("output", output)
+      val expectedOutput =
+        """|Hello A Scala.js
+           |Module init A
+           |Hello B Scala.js
+           |Module init B
+           |Hello entrypoint AScala.js
+           |Hello entrypoint BScala.js
+           |""".stripMargin
+      assert(output.replaceAll("\r", "") == expectedOutput)
+      val sourceMapA = result.path / "main.mjs.map"
+      val sourceMapB = result.path / "b.mjs.map"
+      assert(sourceMapA.toIO.exists()) // sourceMap file was generated
+      assert(sourceMapB.toIO.exists()) // sourceMap file was generated
+      assert(ujson.read(sourceMapA.toIO).obj.get("file").exists(
+        _.str == "main.mjs"
+      )) // sourceMap references jsFile
+      assert(ujson.read(sourceMapB.toIO).obj.get("file").exists(
+        _.str == "b.mjs"
+      )) // sourceMap references jsFile
+    }
+
+    "fullLinkJS" - {
+      testAllMatrix((scala, scalaJS, _) =>
+        TestUtil.disableInJava9OrAbove(testRun(scala, scalaJS, false, FullOpt))
+      )
+    }
+    "fastLinkJS" - {
+      testAllMatrix(
+        (scala, scalaJS, useECMAScript2015) =>
+          TestUtil.disableInJava9OrAbove(testRun(scala, scalaJS, useECMAScript2015, FastOpt)),
+        skipECMAScript2015 = false
+      )
+    }
+  }
+
+  def compileClassfiles(parentDir: os.Path, scalaVersion: String, scalaJSVersion: String) = {
+    val inAllVersions = Set(
+      parentDir / "MainA$.class",
+      parentDir / "MainA$.sjsir",
+      parentDir / "MainA.class",
+      parentDir / "MainA.sjsir",
+      parentDir / "MainB$.class",
+      parentDir / "MainB$.sjsir",
+      parentDir / "MainB.class",
+      parentDir / "MainB.sjsir"
+    )
+    val scalaVersionSpecific =
+      if (isScala3(scalaVersion)) Set(
+        parentDir / "MainA.tasty",
+        parentDir / "MainB.tasty"
+      )
+      else Set(
+        parentDir / "MainA$delayedInit$body.class",
+        parentDir / "MainA$delayedInit$body.sjsir"
+      )
+    inAllVersions ++ scalaVersionSpecific
+  }
+}

--- a/scalajslib/worker/0.6/src/ScalaJSWorkerImpl.scala
+++ b/scalajslib/worker/0.6/src/ScalaJSWorkerImpl.scala
@@ -3,17 +3,22 @@ package scalajslib
 package worker
 
 import java.io.File
-
 import mill.api.Result
-import mill.scalajslib.api.{JsEnvConfig, ModuleKind}
+import mill.scalajslib.api.{
+  JsEnvConfig,
+  ModuleInitializer,
+  ModuleKind,
+  ModuleSplitStyle,
+  OutputPatterns
+}
 import org.scalajs.core.tools.io.IRFileCache.IRContainer
 import org.scalajs.core.tools.io._
 import org.scalajs.core.tools.jsdep.ResolvedJSDependency
 import org.scalajs.core.tools.linker.{
   Linker,
-  ModuleInitializer,
   Semantics,
   StandardLinker,
+  ModuleInitializer => ScalaJSModuleInitializer,
   ModuleKind => ScalaJSModuleKind
 }
 import org.scalajs.core.tools.logging.ScalaConsoleLogger
@@ -76,7 +81,9 @@ class ScalaJSWorkerImpl extends mill.scalajslib.api.ScalaJSWorkerApi {
     val jarSJSIRs = jars.flatMap(_.jar.sjsirFiles)
     val destFile = AtomicWritableFileVirtualJSFile(dest)
     val logger = new ScalaConsoleLogger
-    val initializer = Option(main).map { cls => ModuleInitializer.mainMethodWithArgs(cls, "main") }
+    val initializer = Option(main).map { cls =>
+      ScalaJSModuleInitializer.mainMethodWithArgs(cls, "main")
+    }
     try {
       linker.link(sourceSJSIRs ++ jarSJSIRs, initializer.toSeq, destFile, logger)
       Result.Success(dest)
@@ -85,6 +92,21 @@ class ScalaJSWorkerImpl extends mill.scalajslib.api.ScalaJSWorkerApi {
         Result.Failure(e.getMessage)
     }
   }
+
+  def linkJs(
+      sources: Array[File],
+      libraries: Array[File],
+      destDirectory: File,
+      main: Option[String],
+      testBridgeInit: Boolean,
+      fullOpt: Boolean,
+      moduleKind: ModuleKind,
+      moduleSplitStyle: ModuleSplitStyle,
+      moduleInitializers: Seq[ModuleInitializer],
+      outputPatterns: OutputPatterns,
+      useECMAScript2015: Boolean
+  ): Result[File] =
+    mill.api.Result.Failure("fastLinkJS/fullLinkJS is not supported in Scala.js below 1.3")
 
   def run(config: JsEnvConfig, linkedFile: File): Unit = {
     jsEnv(config)

--- a/scalajslib/worker/1/src/ScalaJsLinker_1_3Support.scala
+++ b/scalajslib/worker/1/src/ScalaJsLinker_1_3Support.scala
@@ -1,0 +1,142 @@
+package mill
+package scalajslib
+package worker
+
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration.Duration
+import java.io.File
+import mill.api.{internal, Result}
+import mill.scalajslib.api.{ModuleInitializer, ModuleKind, ModuleSplitStyle, OutputPatterns}
+
+import org.scalajs.linker.{PathIRContainer, PathIRFile, PathOutputDirectory, StandardImpl}
+import org.scalajs.linker.interface.{ModuleKind => ScalaJSModuleKind, _}
+import org.scalajs.linker.interface.{ModuleSplitStyle => ScalaJSModuleSplitStyle}
+import org.scalajs.linker.interface.{OutputPatterns => ScalaJSOutputPatterns}
+import org.scalajs.logging.ScalaConsoleLogger
+import org.scalajs.testing.adapter.{TestAdapterInitializer => TAI}
+
+import scala.collection.mutable
+import scala.ref.WeakReference
+
+@internal
+class ScalaJsLinker_1_3Support {
+  private case class LinkerInput_1_3(
+      fullOpt: Boolean,
+      moduleKind: ModuleKind,
+      moduleSplitStyle: ModuleSplitStyle,
+      outputPatterns: OutputPatterns,
+      useECMAScript2015: Boolean,
+      dest: File
+  )
+
+  private object ScalaJSLinker_1_3 {
+    private val cache = mutable.Map.empty[LinkerInput_1_3, WeakReference[Linker]]
+
+    def reuseOrCreate(input: LinkerInput_1_3): Linker = cache.get(input) match {
+      case Some(WeakReference(linker)) => linker
+      case _ =>
+        val newLinker = createLinker(input)
+        cache.update(input, WeakReference(newLinker))
+        newLinker
+    }
+
+    private def createLinker(input: LinkerInput_1_3): Linker = {
+      val semantics = input.fullOpt match {
+        case true => Semantics.Defaults.optimized
+        case false => Semantics.Defaults
+      }
+      val scalaJSModuleKind = input.moduleKind match {
+        case ModuleKind.NoModule => ScalaJSModuleKind.NoModule
+        case ModuleKind.CommonJSModule => ScalaJSModuleKind.CommonJSModule
+        case ModuleKind.ESModule => ScalaJSModuleKind.ESModule
+      }
+      val scalaJSModuleSplitStyle = input.moduleSplitStyle match {
+        case ModuleSplitStyle.FewestModules => ScalaJSModuleSplitStyle.FewestModules
+        case ModuleSplitStyle.SmallestModules => ScalaJSModuleSplitStyle.SmallestModules
+      }
+      val scalaJSOutputPatterns = input.outputPatterns match {
+        case OutputPatterns.OutputPatternsDefaults => ScalaJSOutputPatterns.Defaults
+        case OutputPatterns.OutputPatternsFromJsFile(jsFile) =>
+          ScalaJSOutputPatterns.fromJSFile(jsFile)
+      }
+
+      val useClosure = input.fullOpt && input.moduleKind != ModuleKind.ESModule
+      val config = StandardConfig()
+        .withOptimizer(input.fullOpt)
+        .withClosureCompilerIfAvailable(useClosure)
+        .withSemantics(semantics)
+        .withModuleKind(scalaJSModuleKind)
+        .withModuleSplitStyle(scalaJSModuleSplitStyle)
+        .withOutputPatterns(scalaJSOutputPatterns)
+        .withESFeatures(_.withUseECMAScript2015(input.useECMAScript2015))
+      StandardImpl.linker(config)
+    }
+  }
+
+  def linkJs(
+      sources: Array[File],
+      libraries: Array[File],
+      dest: File,
+      main: Option[String],
+      testBridgeInit: Boolean,
+      fullOpt: Boolean,
+      moduleKind: ModuleKind,
+      moduleSplitStyle: ModuleSplitStyle,
+      moduleInitializers: Seq[ModuleInitializer],
+      outputPatterns: OutputPatterns,
+      useECMAScript2015: Boolean
+  ) = {
+    import scala.concurrent.ExecutionContext.Implicits.global
+    val linker =
+      ScalaJSLinker_1_3.reuseOrCreate(LinkerInput_1_3(
+        fullOpt,
+        moduleKind,
+        moduleSplitStyle,
+        outputPatterns,
+        useECMAScript2015,
+        dest
+      ))
+    val cache = StandardImpl.irFileCache().newCache
+    val sourceIRsFuture = Future.sequence(sources.toSeq.map(f => PathIRFile(f.toPath())))
+    val irContainersPairs = PathIRContainer.fromClasspath(libraries.map(_.toPath()))
+    val libraryIRsFuture = irContainersPairs.flatMap(pair => cache.cached(pair._1))
+    val logger = new ScalaConsoleLogger
+
+    val mainInitializer = main.map(cls =>
+      org.scalajs.linker.interface.ModuleInitializer.mainMethodWithArgs(
+        className = cls,
+        mainMethodName = "main"
+      )
+    )
+
+    val otherInitializers = moduleInitializers.map(mi =>
+      org.scalajs.linker.interface.ModuleInitializer.mainMethod(
+        className = mi.className,
+        mainMethodName = mi.mainMethod
+      ).withModuleID(mi.moduleId)
+    )
+
+    val testInitializer =
+      if (testBridgeInit)
+        Some(org.scalajs.linker.interface.ModuleInitializer.mainMethod(
+          TAI.ModuleClassName,
+          TAI.MainMethodName
+        ))
+      else None
+    val allModuleInitializers =
+      mainInitializer.toList ::: otherInitializers.toList ::: testInitializer.toList
+    val linkerOutputDirectory = PathOutputDirectory(dest.toPath)
+    val resultFuture = (for {
+      sourceIRs <- sourceIRsFuture
+      libraryIRs <- libraryIRsFuture
+      _ <-
+        linker.link(sourceIRs ++ libraryIRs, allModuleInitializers, linkerOutputDirectory, logger)
+    } yield {
+      Result.Success(dest)
+    }).recover {
+      case e: org.scalajs.linker.interface.LinkingException =>
+        Result.Failure(e.getMessage)
+    }
+    Await.result(resultFuture, Duration.Inf)
+  }
+}


### PR DESCRIPTION
New PR which replaces previous PR https://github.com/com-lihaoyi/mill/pull/1573 where I messed up with branch rebase and not sure how to recover it - sorry for the chaos.

It takes into account comments from the previous PR. 
- common part of the tests has been refactored
- scala 3.0 tests now pass
- code style issues fixed

Open issues:
 - test, run use old fastOpt and I am not actually sure what it shoud do for multi module output
 - mima check failures but they are all over the palce not just part which I changed 
