### PR TITLE
Set Jvm.spawnSubprocess input pumper thread to daemon mode.

### DIFF
--- a/main/src/mill/modules/Jvm.scala
+++ b/main/src/mill/modules/Jvm.scala
@@ -206,7 +206,9 @@ object Jvm {
       )
 
       for ((std, dest) <- sources) {
-        new Thread(new InputPumper(std, dest, false)).start()
+        val t = new Thread(new InputPumper(std, dest, false))
+        t.setDaemon(true)
+        t.start()
       }
 
       process


### PR DESCRIPTION
I noticed that sometimes when I have a bunch of zombie `MillServerMain` processes laying around, their `jstack` indicates that the only non-daemon threads are as follows:

```
"Thread-5" #32 prio=5 os_prio=31 cpu=193.46ms elapsed=4037.87s tid=0x00007fb64eba7000 nid=0x8303 in Object.wait()  [0x0000700002e98000]
   java.lang.Thread.State: TIMED_WAITING (on object monitor)
	at java.lang.Object.wait(java.base@11.0.7/Native Method)
	- waiting on <no object reference available>
	at java.io.PipedInputStream.read(java.base@11.0.7/PipedInputStream.java:326)
	- waiting to re-lock in wait() <0x0000000701a001c0> (a java.io.PipedInputStream)
	at java.io.PipedInputStream.read(java.base@11.0.7/PipedInputStream.java:377)
	- waiting to re-lock in wait() <0x0000000701a001c0> (a java.io.PipedInputStream)
	at java.io.InputStream.read(java.base@11.0.7/InputStream.java:205)
	at mill.main.client.InputPumper.run(InputPumper.java:25)
	at java.lang.Thread.run(java.base@11.0.7/Thread.java:834)

"Thread-9" #39 prio=5 os_prio=31 cpu=187.99ms elapsed=3987.75s tid=0x00007fb646ff9800 nid=0x15403 in Object.wait()  [0x00007000031a1000]
   java.lang.Thread.State: TIMED_WAITING (on object monitor)
	at java.lang.Object.wait(java.base@11.0.7/Native Method)
	- waiting on <no object reference available>
	at java.io.PipedInputStream.read(java.base@11.0.7/PipedInputStream.java:326)
	- waiting to re-lock in wait() <0x0000000702b3d090> (a java.io.PipedInputStream)
	at java.io.PipedInputStream.read(java.base@11.0.7/PipedInputStream.java:377)
	- waiting to re-lock in wait() <0x0000000702b3d090> (a java.io.PipedInputStream)
	at java.io.InputStream.read(java.base@11.0.7/InputStream.java:205)
	at mill.main.client.InputPumper.run(InputPumper.java:25)
	at java.lang.Thread.run(java.base@11.0.7/Thread.java:834)
```

These clearly indicate they are being kept alive by an `InputPumper` thread reading from a `PipedInputStream`. Grepping through the source code, this was the only place I found such an occurrence, so hopefully by marking this thread as `daemon` it'll allow the zombie `MillServerMain` processes to exit cleanly