### PR TITLE
Negate test-optional return code in CI

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -60,7 +60,8 @@ jobs:
       matrix:
         java-version: [8, 11]
         buildcmd:
-          - ./mill -i -k __.mimaReportBinaryIssues
+          # Negate return code with `!` since these tests are supposed to fail
+          - "! ./mill -i -k __.mimaReportBinaryIssues"
 
     runs-on: ubuntu-latest
     continue-on-error: true


### PR DESCRIPTION
Having a always red CI doens't help identify real issues.
This negates the output of the `test-optional` step, so it will be a problem when it will start to pass, and so it will not become optional anymore.