### PR TITLE
Fix Scala Native for versions `> 0.4.2`

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -704,7 +704,7 @@ object scalanativelib extends MillModule {
 
   override def testArgs = T {
     val mapping = Map(
-      "MILL_SCALANATIVE_WORKER_0_4" -> worker("0.4").assembly().path
+      "MILL_SCALANATIVE_WORKER_0_4" -> worker("0.4").compile().classes.path
     )
     scalalib.worker.testArgs() ++
       scalalib.backgroundwrapper.testArgs() ++

--- a/scalanativelib/worker/0.4/src/ScalaNativeWorkerImpl.scala
+++ b/scalanativelib/worker/0.4/src/ScalaNativeWorkerImpl.scala
@@ -15,6 +15,7 @@ import scala.scalanative.build.{
   Mode,
   NativeConfig => ScalaNativeNativeConfig
 }
+import scala.scalanative.nir.Versions
 import mill.scalanativelib.api.{GetFrameworkResult, LTO, NativeConfig, NativeLogLevel, ReleaseMode}
 import sbt.testing.Framework
 
@@ -52,8 +53,10 @@ class ScalaNativeWorkerImpl extends mill.scalanativelib.api.ScalaNativeWorkerApi
       nativeOptimize: Boolean,
       logLevel: NativeLogLevel
   ): NativeConfig = {
-    val entry = mainClass + "$"
-
+    val entry = Versions.current match {
+      case "0.4.0" | "0.4.1" | "0.4.2" => mainClass + "$"
+      case _ => mainClass
+    }
     val config =
       Config.empty
         .withMainClass(entry)


### PR DESCRIPTION
Workers in Mill work (pun not intended) by compiling to a base version and then substitute the classloader with the dependencies from the project they are compiling.
Before this PR, the Scala Native worker dependency was a uberjar created with `assembly` so it was depending on the Scala Native version defined in Mill's `build.sc`.
Now worker contains only the Worker classes and all the other dependencies are injected by Mill using the `scalaNativeVersion` from the `ScalaNativeModule` it is compiling.