### PR TITLE
Support ESFeatures in Scala.js

### DIFF
--- a/scalajslib/api/src/ScalaJSWorkerApi.scala
+++ b/scalajslib/api/src/ScalaJSWorkerApi.scala
@@ -58,9 +58,11 @@ case class ESFeatures private (
     avoidLetsAndConsts: Boolean,
     esVersion: ESVersion
 ) {
-  def withAllowBigIntsForLongs(allowBigIntsForLongs: Boolean): ESFeatures = copy(allowBigIntsForLongs = allowBigIntsForLongs)
+  def withAllowBigIntsForLongs(allowBigIntsForLongs: Boolean): ESFeatures =
+    copy(allowBigIntsForLongs = allowBigIntsForLongs)
   def withAvoidClasses(avoidClasses: Boolean): ESFeatures = copy(avoidClasses = avoidClasses)
-  def withAvoidLetsAndConsts(avoidLetsAndConsts: Boolean): ESFeatures = copy(avoidLetsAndConsts = avoidLetsAndConsts)
+  def withAvoidLetsAndConsts(avoidLetsAndConsts: Boolean): ESFeatures =
+    copy(avoidLetsAndConsts = avoidLetsAndConsts)
   def withESVersion(esVersion: ESVersion): ESFeatures = copy(esVersion = esVersion)
 }
 object ESFeatures {

--- a/scalajslib/api/src/ScalaJSWorkerApi.scala
+++ b/scalajslib/api/src/ScalaJSWorkerApi.scala
@@ -1,6 +1,9 @@
 package mill.scalajslib.api
+
 import java.io.File
 import mill.api.Result
+import upickle.default.{ReadWriter => RW, macroRW}
+
 trait ScalaJSWorkerApi {
   def link(
       sources: Array[File],
@@ -10,7 +13,7 @@ trait ScalaJSWorkerApi {
       testBridgeInit: Boolean,
       fullOpt: Boolean,
       moduleKind: ModuleKind,
-      useECMAScript2015: Boolean
+      esFeatures: ESFeatures
   ): Result[File]
 
   def run(config: JsEnvConfig, linkedFile: File): Unit
@@ -36,10 +39,42 @@ object ModuleKind {
   object ESModule extends ModuleKind
 }
 
+sealed trait ESVersion
+object ESVersion {
+  implicit val rw: RW[ESVersion] = macroRW[ESVersion]
+  object ES2015 extends ESVersion
+  object ES2016 extends ESVersion
+  object ES2017 extends ESVersion
+  object ES2018 extends ESVersion
+  object ES2019 extends ESVersion
+  object ES2020 extends ESVersion
+  object ES2021 extends ESVersion
+  object ES5_1 extends ESVersion
+}
+
+case class ESFeatures private (
+    allowBigIntsForLongs: Boolean,
+    avoidClasses: Boolean,
+    avoidLetsAndConsts: Boolean,
+    esVersion: ESVersion
+) {
+  def withAllowBigIntsForLongs(allowBigIntsForLongs: Boolean): ESFeatures = copy(allowBigIntsForLongs = allowBigIntsForLongs)
+  def withAvoidClasses(avoidClasses: Boolean): ESFeatures = copy(avoidClasses = avoidClasses)
+  def withAvoidLetsAndConsts(avoidLetsAndConsts: Boolean): ESFeatures = copy(avoidLetsAndConsts = avoidLetsAndConsts)
+  def withESVersion(esVersion: ESVersion): ESFeatures = copy(esVersion = esVersion)
+}
+object ESFeatures {
+  val Defaults: ESFeatures = ESFeatures(
+    allowBigIntsForLongs = false,
+    avoidClasses = true,
+    avoidLetsAndConsts = true,
+    esVersion = ESVersion.ES2015
+  )
+  implicit val rw: RW[ESFeatures] = macroRW[ESFeatures]
+}
+
 sealed trait JsEnvConfig
 object JsEnvConfig {
-
-  import upickle.default.{ReadWriter => RW, macroRW}
   implicit def rwNodeJs: RW[NodeJs] = macroRW
   implicit def rwJsDom: RW[JsDom] = macroRW
   implicit def rwPhantom: RW[Phantom] = macroRW

--- a/scalajslib/src/ScalaJSModule.scala
+++ b/scalajslib/src/ScalaJSModule.scala
@@ -74,8 +74,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
 
   def scalaJSToolsClasspath = T { scalaJSWorkerClasspath() ++ scalaJSLinkerClasspath() }
 
-  private def checkDeprecations(): Task[Unit] = T.task {
-    pprint.pprintln("Calling checkDeprecations.")
+  private def checkDeprecations: Task[Unit] = T.task {
     useECMAScript2015()
     if(overriddenUseECMAScript2015) {
       Result.Failure("Overriding `useECMAScript2015` is not supported anymore. Override `esFeatures` instead")
@@ -85,7 +84,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
   }
 
   def fastOpt = T {
-    // checkDeprecations()
+    checkDeprecations()
     link(
       worker = ScalaJSWorkerApi.scalaJSWorker(),
       toolsClasspath = scalaJSToolsClasspath(),

--- a/scalajslib/src/ScalaJSModule.scala
+++ b/scalajslib/src/ScalaJSModule.scala
@@ -204,7 +204,9 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
 
   def esFeatures: T[ESFeatures] = T {
     if (useECMAScript2015.ctx.enclosing != s"${classOf[ScalaJSModule].getName}#useECMAScript2015") {
-      Result.Failure("Overriding `useECMAScript2015` is not supported anymore. Override `esFeatures` instead")
+      Result.Failure(
+        "Overriding `useECMAScript2015` is not supported anymore. Override `esFeatures` instead"
+      )
     } else {
       Result.Success {
         if (scalaJSVersion().startsWith("0.")) ESFeatures.Defaults.withESVersion(ESVersion.ES5_1)

--- a/scalajslib/src/ScalaJSModule.scala
+++ b/scalajslib/src/ScalaJSModule.scala
@@ -83,7 +83,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
       testBridgeInit = false,
       mode = FastOpt,
       moduleKind = moduleKind(),
-      useECMAScript2015 = useECMAScript2015()
+      esFeatures = esFeatures()
     )
   }
 
@@ -96,7 +96,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
       testBridgeInit = false,
       mode = FullOpt,
       moduleKind = moduleKind(),
-      useECMAScript2015 = useECMAScript2015()
+      esFeatures = esFeatures()
     )
   }
 
@@ -132,7 +132,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
       testBridgeInit: Boolean,
       mode: OptimizeMode,
       moduleKind: ModuleKind,
-      useECMAScript2015: Boolean
+      esFeatures: ESFeatures
   )(implicit ctx: Ctx): Result[PathRef] = {
     val outputPath = ctx.dest / "out.js"
 
@@ -154,7 +154,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
       testBridgeInit,
       mode == FullOpt,
       moduleKind,
-      useECMAScript2015
+      esFeatures
     ).map(PathRef(_))
   }
 
@@ -197,8 +197,12 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
 
   def moduleKind: T[ModuleKind] = T { ModuleKind.NoModule }
 
-  def useECMAScript2015: T[Boolean] = T { 
-    !scalaJSVersion().startsWith("0.")
+  @deprecated("Use esFeatures().esVersion instead", since = "mill after 0.10.0-M5")
+  def useECMAScript2015: T[Boolean] = T { esFeatures().esVersion != ESVersion.ES5_1 }
+
+  def esFeatures: T[ESFeatures] = T {
+    if (scalaJSVersion().startsWith("0.")) ESFeatures.Defaults.withESVersion(ESVersion.ES5_1)
+    else ESFeatures.Defaults
   }
 
   @internal
@@ -239,7 +243,7 @@ trait TestScalaJSModule extends ScalaJSModule with TestModule {
       testBridgeInit = true,
       FastOpt,
       moduleKind(),
-      useECMAScript2015()
+      esFeatures()
     )
   }
 

--- a/scalajslib/src/ScalaJSModule.scala
+++ b/scalajslib/src/ScalaJSModule.scala
@@ -199,20 +199,15 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
 
   @deprecated("Use esFeatures().esVersion instead", since = "mill after 0.10.0-M5")
   def useECMAScript2015: T[Boolean] = T {
-    esFeatures().esVersion != ESVersion.ES5_1
+    !scalaJSVersion().startsWith("0.")
   }
 
   def esFeatures: T[ESFeatures] = T {
     if (useECMAScript2015.ctx.enclosing != s"${classOf[ScalaJSModule].getName}#useECMAScript2015") {
-      Result.Failure(
-        "Overriding `useECMAScript2015` is not supported anymore. Override `esFeatures` instead"
-      )
-    } else {
-      Result.Success {
-        if (scalaJSVersion().startsWith("0.")) ESFeatures.Defaults.withESVersion(ESVersion.ES5_1)
-        else ESFeatures.Defaults
-      }
+      T.log.error("Overriding `useECMAScript2015` is deprecated. Override `esFeatures` instead")
     }
+    if (useECMAScript2015()) ESFeatures.Defaults
+    else ESFeatures.Defaults.withESVersion(ESVersion.ES5_1)
   }
 
   @internal

--- a/scalajslib/src/ScalaJSWorkerApi.scala
+++ b/scalajslib/src/ScalaJSWorkerApi.scala
@@ -38,7 +38,7 @@ class ScalaJSWorker {
       testBridgeInit: Boolean,
       fullOpt: Boolean,
       moduleKind: ModuleKind,
-      useECMAScript2015: Boolean
+      esFeatures: ESFeatures
   )(implicit ctx: Ctx.Home): Result[os.Path] = {
     bridge(toolsClasspath).link(
       sources.items.map(_.toIO).toArray,
@@ -48,7 +48,7 @@ class ScalaJSWorker {
       testBridgeInit,
       fullOpt,
       moduleKind,
-      useECMAScript2015
+      esFeatures
     ).map(os.Path(_))
   }
 

--- a/scalajslib/test/src/HelloJSWorldTests.scala
+++ b/scalajslib/test/src/HelloJSWorldTests.scala
@@ -37,7 +37,6 @@ object HelloJSWorldTests extends TestSuite {
         extends HelloJSWorldModule {
       override def artifactName = "hello-js-world"
       def scalaJSVersion = sjsVersion0
-      override def useECMAScript2015 = false
       def pomSettings = PomSettings(
         organization = "com.lihaoyi",
         description = "hello js world ready for real world publishing",
@@ -136,10 +135,10 @@ object HelloJSWorldTests extends TestSuite {
       )
     }
     test("fastOpt") {
-      testAllMatrix(
-        (scala, scalaJS) =>
-          TestUtil.disableInJava9OrAbove(testRun(scala, scalaJS, FastOpt))
-      )
+      // testAllMatrix(
+        // (scala, scalaJS) =>
+          TestUtil.disableInJava9OrAbove(testRun("2.13.3", "1.8.0", FastOpt))
+      // )
     }
     test("jar") {
       test("containsSJSIRs") {

--- a/scalajslib/test/src/HelloJSWorldTests.scala
+++ b/scalajslib/test/src/HelloJSWorldTests.scala
@@ -135,10 +135,9 @@ object HelloJSWorldTests extends TestSuite {
       )
     }
     test("fastOpt") {
-      // testAllMatrix(
-        // (scala, scalaJS) =>
-          TestUtil.disableInJava9OrAbove(testRun("2.13.3", "1.8.0", FastOpt))
-      // )
+      testAllMatrix((scala, scalaJS) =>
+        TestUtil.disableInJava9OrAbove(testRun(scala, scalaJS, FastOpt))
+      )
     }
     test("jar") {
       test("containsSJSIRs") {
@@ -270,9 +269,7 @@ object HelloJSWorldTests extends TestSuite {
     }
 
     test("run") {
-      testAllMatrix(
-        (scala, scalaJS) => checkRun(scala, scalaJS)
-      )
+      testAllMatrix((scala, scalaJS) => checkRun(scala, scalaJS))
     }
   }
 

--- a/scalajslib/test/src/HelloJSWorldTests.scala
+++ b/scalajslib/test/src/HelloJSWorldTests.scala
@@ -154,8 +154,7 @@ object HelloJSWorldTests extends TestSuite {
       def testArtifactId(scalaVersion: String, scalaJSVersion: String, artifactId: String): Unit = {
         val Right((result, evalCount)) = helloWorldEvaluator(HelloJSWorld.helloJsWorld(
           scalaVersion,
-          scalaJSVersion,
-          false
+          scalaJSVersion
         ).artifactMetadata)
         assert(result.id == artifactId)
       }
@@ -195,8 +194,8 @@ object HelloJSWorldTests extends TestSuite {
 
     def checkUtest(scalaVersion: String, scalaJSVersion: String, cached: Boolean) = {
       val resultMap = runTests(
-        if (!cached) HelloJSWorld.buildUTest(scalaVersion, scalaJSVersion, false).test.test()
-        else HelloJSWorld.buildUTest(scalaVersion, scalaJSVersion, false).test.testCached
+        if (!cached) HelloJSWorld.buildUTest(scalaVersion, scalaJSVersion).test.test()
+        else HelloJSWorld.buildUTest(scalaVersion, scalaJSVersion).test.testCached
       )
 
       val mainTests = resultMap("MainTests")
@@ -214,8 +213,8 @@ object HelloJSWorldTests extends TestSuite {
 
     def checkScalaTest(scalaVersion: String, scalaJSVersion: String, cached: Boolean) = {
       val resultMap = runTests(
-        if (!cached) HelloJSWorld.buildScalaTest(scalaVersion, scalaJSVersion, false).test.test()
-        else HelloJSWorld.buildScalaTest(scalaVersion, scalaJSVersion, false).test.testCached
+        if (!cached) HelloJSWorld.buildScalaTest(scalaVersion, scalaJSVersion).test.test()
+        else HelloJSWorld.buildScalaTest(scalaVersion, scalaJSVersion).test.testCached
       )
 
       val mainSpec = resultMap("MainSpec")

--- a/scalajslib/test/src/HelloJSWorldTests.scala
+++ b/scalajslib/test/src/HelloJSWorldTests.scala
@@ -37,6 +37,7 @@ object HelloJSWorldTests extends TestSuite {
         extends HelloJSWorldModule {
       override def artifactName = "hello-js-world"
       def scalaJSVersion = sjsVersion0
+      override def useECMAScript2015 = false
       def pomSettings = PomSettings(
         organization = "com.lihaoyi",
         description = "hello js world ready for real world publishing",
@@ -63,8 +64,7 @@ object HelloJSWorldTests extends TestSuite {
     object buildScalaTest extends Cross[BuildModuleScalaTest](matrix: _*)
     class BuildModuleScalaTest(
         crossScalaVersion: String,
-        sjsVersion0: String,
-        sjsUseECMA2015: Boolean
+        sjsVersion0: String
     ) extends BuildModule(crossScalaVersion, sjsVersion0) {
       object test extends super.Tests {
         override def sources = T.sources { millSourcePath / "src" / "scalatest" }

--- a/scalajslib/test/src/HelloJSWorldTests.scala
+++ b/scalajslib/test/src/HelloJSWorldTests.scala
@@ -175,7 +175,7 @@ object HelloJSWorldTests extends TestSuite {
       test("artifactId_1") {
         testArtifactId(
           HelloJSWorld.scalaVersions.head,
-          "1.4.0",
+          HelloJSWorld.scalaJSVersions.head,
           "hello-js-world_sjs1_2.13"
         )
       }

--- a/scalajslib/worker/0.6/src/ScalaJSWorkerImpl.scala
+++ b/scalajslib/worker/0.6/src/ScalaJSWorkerImpl.scala
@@ -5,7 +5,7 @@ package worker
 import java.io.File
 
 import mill.api.Result
-import mill.scalajslib.api.{ESFeatures, JsEnvConfig, ModuleKind}
+import mill.scalajslib.api.{ESFeatures, ESVersion, JsEnvConfig, ModuleKind}
 import org.scalajs.core.tools.io.IRFileCache.IRContainer
 import org.scalajs.core.tools.io._
 import org.scalajs.core.tools.jsdep.ResolvedJSDependency
@@ -49,7 +49,15 @@ class ScalaJSWorkerImpl extends mill.scalajslib.api.ScalaJSWorkerApi {
         case ModuleKind.CommonJSModule => ScalaJSModuleKind.CommonJSModule
         case ModuleKind.ESModule => ScalaJSModuleKind.ESModule
       }
-      val scalaJSESFeatures = ScalaJSESFeatures.Default
+      val scalaJSESFeatures =
+        ScalaJSESFeatures.Default.withUseECMAScript2015(input.esFeatures.esVersion match {
+          case ESVersion.ES5_1 => false
+          case ESVersion.ES2015 => true
+          case v => throw new Exception(
+              s"ESVersion $v is not supported with Scala.js < 1.6. Either update Scala.js or use one of ESVersion.ES5_1 or ESVersion.ES2015"
+            )
+        })
+
       val useClosure = input.fullOpt && input.moduleKind != ModuleKind.ESModule
       val config = StandardLinker.Config()
         .withOptimizer(input.fullOpt)

--- a/scalajslib/worker/0.6/src/ScalaJSWorkerImpl.scala
+++ b/scalajslib/worker/0.6/src/ScalaJSWorkerImpl.scala
@@ -5,11 +5,12 @@ package worker
 import java.io.File
 
 import mill.api.Result
-import mill.scalajslib.api.{JsEnvConfig, ModuleKind}
+import mill.scalajslib.api.{ESFeatures, JsEnvConfig, ModuleKind}
 import org.scalajs.core.tools.io.IRFileCache.IRContainer
 import org.scalajs.core.tools.io._
 import org.scalajs.core.tools.jsdep.ResolvedJSDependency
 import org.scalajs.core.tools.linker.{
+  ESFeatures => ScalaJSESFeatures,
   Linker,
   ModuleInitializer,
   Semantics,
@@ -27,7 +28,7 @@ class ScalaJSWorkerImpl extends mill.scalajslib.api.ScalaJSWorkerApi {
   private case class LinkerInput(
       fullOpt: Boolean,
       moduleKind: ModuleKind,
-      useECMAScript2015: Boolean
+      esFeatures: ESFeatures
   )
   private object ScalaJSLinker {
     private val cache = mutable.Map.empty[LinkerInput, WeakReference[Linker]]
@@ -48,13 +49,14 @@ class ScalaJSWorkerImpl extends mill.scalajslib.api.ScalaJSWorkerApi {
         case ModuleKind.CommonJSModule => ScalaJSModuleKind.CommonJSModule
         case ModuleKind.ESModule => ScalaJSModuleKind.ESModule
       }
+      val scalaJSESFeatures = ScalaJSESFeatures.Default
       val useClosure = input.fullOpt && input.moduleKind != ModuleKind.ESModule
       val config = StandardLinker.Config()
         .withOptimizer(input.fullOpt)
         .withClosureCompilerIfAvailable(useClosure)
         .withSemantics(semantics)
         .withModuleKind(scalaJSModuleKind)
-        .withESFeatures(_.withUseECMAScript2015(input.useECMAScript2015))
+        .withESFeatures(scalaJSESFeatures)
       StandardLinker(config)
     }
   }
@@ -67,9 +69,9 @@ class ScalaJSWorkerImpl extends mill.scalajslib.api.ScalaJSWorkerApi {
       testBridgeInit: Boolean, // ignored in 0.6
       fullOpt: Boolean,
       moduleKind: ModuleKind,
-      useECMAScript2015: Boolean
+      esFeatures: ESFeatures
   ) = {
-    val linker = ScalaJSLinker.reuseOrCreate(LinkerInput(fullOpt, moduleKind, useECMAScript2015))
+    val linker = ScalaJSLinker.reuseOrCreate(LinkerInput(fullOpt, moduleKind, esFeatures))
     val sourceSJSIRs = sources.map(new FileVirtualScalaJSIRFile(_))
     val jars =
       libraries.map(jar => IRContainer.Jar(new FileVirtualBinaryFile(jar) with VirtualJarFile))

--- a/scalajslib/worker/1/src/ScalaJSWorkerImpl.scala
+++ b/scalajslib/worker/1/src/ScalaJSWorkerImpl.scala
@@ -59,7 +59,9 @@ class ScalaJSWorkerImpl extends mill.scalajslib.api.ScalaJSWorkerApi {
         val useECMAScript2015: Boolean = input.esFeatures.esVersion match {
           case ESVersion.ES5_1 => false
           case ESVersion.ES2015 => true
-          case v => throw new Exception(s"ESVersion $v is not supported with Scala.js < 1.6. Either update Scala.js or use one of ESVersion.ES5_1 or ESVersion.ES2015")
+          case v => throw new Exception(
+              s"ESVersion $v is not supported with Scala.js < 1.6. Either update Scala.js or use one of ESVersion.ES5_1 or ESVersion.ES2015"
+            )
         }
         esFeatures.withUseECMAScript2015(useECMAScript2015)
       }
@@ -78,14 +80,14 @@ class ScalaJSWorkerImpl extends mill.scalajslib.api.ScalaJSWorkerApi {
       }
       var scalaJSESFeatures: ScalaJSESFeatures = ScalaJSESFeatures.Defaults
         .withAllowBigIntsForLongs(input.esFeatures.allowBigIntsForLongs)
-        
-      if(minorIsGreaterThan(3)) {
+
+      if (minorIsGreaterThan(3)) {
         scalaJSESFeatures = scalaJSESFeatures
           .withAvoidClasses(input.esFeatures.avoidClasses)
           .withAvoidLetsAndConsts(input.esFeatures.avoidLetsAndConsts)
       }
       scalaJSESFeatures =
-        if(minorIsGreaterThan(6)) withESVersion_1_6_plus(scalaJSESFeatures)
+        if (minorIsGreaterThan(6)) withESVersion_1_6_plus(scalaJSESFeatures)
         else withESVersion_1_5_minus(scalaJSESFeatures)
 
       val useClosure = input.fullOpt && input.moduleKind != ModuleKind.ESModule


### PR DESCRIPTION
`ScalaJSModule` currently supports the `useECMAScript2015` settings.
Nowadays Scala.js offers support for multiple `ESVersion`.
In the official Sbt plugin they are set inside an object called `ESFeatures` that contains other settings.
This PR tries to mimic the Scala.js API.
It is a breaking change, since overriding the old `useECMAScript2015` doesn't have any effect anymore.

### How deprecate overriding `useECMAScript2015`
Since we can't derive `ESFeatures` from `useECMAScript2015`, I can't use the same deprecation mechanism as `testFrameworks`. What I did instead is to define a private boolean `var` in ScalaJSModule called `overriddenUseECMAScript2015` that is first set to `true`. It is then set to `false` by the default implementation of `useECMAScript2015` which calls back the new `esFeatures`. Before `fastOpt` and `fullOpt` I call a private `checkDeprecations` task, which calls `useECMAScript2015()` and then checks the `overriddenUseECMAScript2015`. If it was overridden then the value remains `true` and it fails the task with an error message; otherwise it finds `false` and continues with the build.