### PR TITLE
Upgrade shapeless

### DIFF
--- a/integration/test/resources/ammonite/build.sc
+++ b/integration/test/resources/ammonite/build.sc
@@ -2,30 +2,44 @@ import mill._, scalalib._, publish._
 
 val binCrossScalaVersions = Seq("2.11.12", "2.12.7")
 val fullCrossScalaVersions = Seq(
-  "2.11.3", "2.11.4", "2.11.5", "2.11.6", "2.11.7", "2.11.8", "2.11.9", "2.11.11", "2.11.12",
-  "2.12.0", "2.12.1", "2.12.2", "2.12.3", "2.12.4", "2.12.6", "2.12.7"
+  "2.11.3",
+  "2.11.4",
+  "2.11.5",
+  "2.11.6",
+  "2.11.7",
+  "2.11.8",
+  "2.11.9",
+  "2.11.11",
+  "2.11.12",
+  "2.12.0",
+  "2.12.1",
+  "2.12.2",
+  "2.12.3",
+  "2.12.4",
+  "2.12.6",
+  "2.12.7"
 )
 
 val latestAssemblies = binCrossScalaVersions.map(amm(_).assembly)
 
 val buildVersion = "dev"
 
-trait AmmInternalModule extends mill.scalalib.CrossSbtModule{
+trait AmmInternalModule extends mill.scalalib.CrossSbtModule {
   def artifactName = "ammonite-" + millOuterCtx.segments.parts.last
   def testFramework = "utest.runner.Framework"
   def scalacOptions = Seq("-P:acyclic:force", "-target:jvm-1.7")
   def compileIvyDeps = Agg(ivy"com.lihaoyi::acyclic:0.1.7")
   def scalacPluginIvyDeps = Agg(ivy"com.lihaoyi::acyclic:0.1.7")
-  trait Tests extends super.Tests{
+  trait Tests extends super.Tests {
     def ivyDeps = Agg(ivy"com.lihaoyi::utest:0.6.0")
     def testFrameworks = Seq("utest.runner.Framework")
     def forkArgs = Seq("-XX:MaxPermSize=2g", "-Xmx4g", "-Dfile.encoding=UTF8")
   }
-  def externalSources = T{
+  def externalSources = T {
     resolveDeps(transitiveIvyDeps, sources = true)()
   }
 }
-trait AmmModule extends AmmInternalModule with PublishModule{
+trait AmmModule extends AmmInternalModule with PublishModule {
   def publishVersion = buildVersion
   def pomSettings = PomSettings(
     description = artifactName(),
@@ -34,18 +48,17 @@ trait AmmModule extends AmmInternalModule with PublishModule{
     licenses = Seq(License.MIT),
     versionControl = VersionControl.github("lihaoyi", "ammonite"),
     developers = Seq(
-      Developer("lihaoyi", "Li Haoyi","https://github.com/lihaoyi")
+      Developer("lihaoyi", "Li Haoyi", "https://github.com/lihaoyi")
     )
   )
 
-
 }
-trait AmmDependenciesResourceFileModule extends JavaModule{
+trait AmmDependenciesResourceFileModule extends JavaModule {
   def crossScalaVersion: String
   def dependencyResourceFileName: String
   def resources = T.sources {
 
-    val deps0 = T.task{compileIvyDeps() ++ transitiveIvyDeps()}()
+    val deps0 = T.task { compileIvyDeps() ++ transitiveIvyDeps() }()
     val (_, res) = mill.modules.Jvm.resolveDependenciesMetadata(
       repositoriesTask(),
       deps0.map(resolveCoursierDependency().apply(_)),
@@ -62,15 +75,15 @@ trait AmmDependenciesResourceFileModule extends JavaModule{
   }
 }
 
-object ops extends Cross[OpsModule](binCrossScalaVersions:_*)
-class OpsModule(val crossScalaVersion: String) extends AmmModule{
+object ops extends Cross[OpsModule](binCrossScalaVersions: _*)
+class OpsModule(val crossScalaVersion: String) extends AmmModule {
   def ivyDeps = Agg(ivy"com.lihaoyi::os-lib:0.2.0")
   def scalacOptions = super.scalacOptions().filter(!_.contains("acyclic"))
   object test extends Tests
 }
 
-object terminal extends Cross[TerminalModule](binCrossScalaVersions:_*)
-class TerminalModule(val crossScalaVersion: String) extends AmmModule{
+object terminal extends Cross[TerminalModule](binCrossScalaVersions: _*)
+class TerminalModule(val crossScalaVersion: String) extends AmmModule {
   def ivyDeps = Agg(
     ivy"com.lihaoyi::sourcecode:0.1.3",
     ivy"com.lihaoyi::fansi:0.2.4"
@@ -82,9 +95,9 @@ class TerminalModule(val crossScalaVersion: String) extends AmmModule{
   object test extends Tests
 }
 
-object amm extends Cross[MainModule](fullCrossScalaVersions:_*){
-  object util extends Cross[UtilModule](binCrossScalaVersions:_*)
-  class UtilModule(val crossScalaVersion: String) extends AmmModule{
+object amm extends Cross[MainModule](fullCrossScalaVersions: _*) {
+  object util extends Cross[UtilModule](binCrossScalaVersions: _*)
+  class UtilModule(val crossScalaVersion: String) extends AmmModule {
     def moduleDeps = Seq(ops())
     def ivyDeps = Agg(
       ivy"com.lihaoyi::upickle:0.6.7",
@@ -97,9 +110,8 @@ object amm extends Cross[MainModule](fullCrossScalaVersions:_*){
 
   }
 
-
-  object runtime extends Cross[RuntimeModule](binCrossScalaVersions:_*)
-  class RuntimeModule(val crossScalaVersion: String) extends AmmModule{
+  object runtime extends Cross[RuntimeModule](binCrossScalaVersions: _*)
+  class RuntimeModule(val crossScalaVersion: String) extends AmmModule {
     def moduleDeps = Seq(ops(), amm.util())
     def ivyDeps = Agg(
       ivy"io.get-coursier::coursier:1.1.0-M7",
@@ -107,13 +119,13 @@ object amm extends Cross[MainModule](fullCrossScalaVersions:_*){
       ivy"org.scalaj::scalaj-http:2.4.2"
     )
 
-    def generatedSources = T{
+    def generatedSources = T {
       Seq(PathRef(generateConstantsFile(buildVersion)))
     }
   }
 
-  object interp extends Cross[InterpModule](fullCrossScalaVersions:_*)
-  class InterpModule(val crossScalaVersion: String) extends AmmModule{
+  object interp extends Cross[InterpModule](fullCrossScalaVersions: _*)
+  class InterpModule(val crossScalaVersion: String) extends AmmModule {
     def moduleDeps = Seq(ops(), amm.util(), amm.runtime())
     def crossFullScalaVersion = true
     def ivyDeps = Agg(
@@ -124,12 +136,14 @@ object amm extends Cross[MainModule](fullCrossScalaVersions:_*){
     )
   }
 
-  object repl extends Cross[ReplModule](fullCrossScalaVersions:_*)
-  class ReplModule(val crossScalaVersion: String) extends AmmModule{
+  object repl extends Cross[ReplModule](fullCrossScalaVersions: _*)
+  class ReplModule(val crossScalaVersion: String) extends AmmModule {
     def crossFullScalaVersion = true
     def moduleDeps = Seq(
-      ops(), amm.util(),
-      amm.runtime(), amm.interp(),
+      ops(),
+      amm.util(),
+      amm.runtime(),
+      amm.interp(),
       terminal()
     )
     def ivyDeps = Agg(
@@ -140,7 +154,7 @@ object amm extends Cross[MainModule](fullCrossScalaVersions:_*){
       ivy"com.github.scopt::scopt:3.5.0"
     )
 
-    object test extends Tests with AmmDependenciesResourceFileModule{
+    object test extends Tests with AmmDependenciesResourceFileModule {
       def crossScalaVersion = ReplModule.this.crossScalaVersion
       def dependencyResourceFileName = "amm-test-dependencies.txt"
       def resources = T.sources {
@@ -155,7 +169,8 @@ object amm extends Cross[MainModule](fullCrossScalaVersions:_*){
     }
   }
 }
-class MainModule(val crossScalaVersion: String) extends AmmModule with AmmDependenciesResourceFileModule{
+class MainModule(val crossScalaVersion: String) extends AmmModule
+    with AmmDependenciesResourceFileModule {
 
   def artifactName = "ammonite"
 
@@ -164,12 +179,15 @@ class MainModule(val crossScalaVersion: String) extends AmmModule with AmmDepend
   def mainClass = Some("ammonite.Main")
 
   def moduleDeps = Seq(
-    terminal(), ops(),
-    amm.util(), amm.runtime(),
-    amm.interp(), amm.repl()
+    terminal(),
+    ops(),
+    amm.util(),
+    amm.runtime(),
+    amm.interp(),
+    amm.repl()
   )
   def ivyDeps = Agg(
-    ivy"com.github.scopt::scopt:3.5.0",
+    ivy"com.github.scopt::scopt:3.5.0"
   )
 
   def runClasspath =
@@ -183,9 +201,7 @@ class MainModule(val crossScalaVersion: String) extends AmmModule with AmmDepend
       sources() ++
       externalSources()
 
-
-
-  def prependShellScript = T{
+  def prependShellScript = T {
     mill.modules.Jvm.launcherUniversalScript(
       mainClass().get,
       Agg("$0"),
@@ -197,10 +213,10 @@ class MainModule(val crossScalaVersion: String) extends AmmModule with AmmDepend
 
   def dependencyResourceFileName = "amm-dependencies.txt"
 
-  object test extends Tests{
+  object test extends Tests {
     def moduleDeps = super.moduleDeps ++ Seq(amm.repl().test)
     def ivyDeps = super.ivyDeps() ++ Agg(
-      ivy"com.chuusai::shapeless:2.3.2"
+      ivy"com.chuusai::shapeless:2.3.7"
     )
     // Need to duplicate this from MainModule due to Mill not properly propagating it through
     def runClasspath =
@@ -217,11 +233,11 @@ class MainModule(val crossScalaVersion: String) extends AmmModule with AmmDepend
   }
 }
 
-object shell extends Cross[ShellModule](fullCrossScalaVersions:_*)
-class ShellModule(val crossScalaVersion: String) extends AmmModule{
+object shell extends Cross[ShellModule](fullCrossScalaVersions: _*)
+class ShellModule(val crossScalaVersion: String) extends AmmModule {
   def moduleDeps = Seq(ops(), amm())
   def crossFullScalaVersion = true
-  object test extends Tests{
+  object test extends Tests {
     def moduleDeps = super.moduleDeps ++ Seq(amm.repl().test)
     def forkEnv = super.forkEnv() ++ Seq(
       "AMMONITE_SHELL" -> shell().jar().path.toString,
@@ -229,8 +245,8 @@ class ShellModule(val crossScalaVersion: String) extends AmmModule{
     )
   }
 }
-object integration extends Cross[IntegrationModule](fullCrossScalaVersions:_*)
-class IntegrationModule(val crossScalaVersion: String) extends AmmInternalModule{
+object integration extends Cross[IntegrationModule](fullCrossScalaVersions: _*)
+class IntegrationModule(val crossScalaVersion: String) extends AmmInternalModule {
   def moduleDeps = Seq(ops(), amm())
   object test extends Tests {
     def forkEnv = super.forkEnv() ++ Seq(
@@ -240,14 +256,14 @@ class IntegrationModule(val crossScalaVersion: String) extends AmmInternalModule
   }
 }
 
-object sshd extends Cross[SshdModule](fullCrossScalaVersions:_*)
-class SshdModule(val crossScalaVersion: String) extends AmmModule{
+object sshd extends Cross[SshdModule](fullCrossScalaVersions: _*)
+class SshdModule(val crossScalaVersion: String) extends AmmModule {
   def moduleDeps = Seq(ops(), amm())
   def crossFullScalaVersion = true
   def ivyDeps = Agg(
     // sshd-core 1.3.0 requires java8
     ivy"org.apache.sshd:sshd-core:1.2.0",
-    ivy"org.bouncycastle:bcprov-jdk15on:1.56",
+    ivy"org.bouncycastle:bcprov-jdk15on:1.56"
   )
   object test extends Tests {
     def ivyDeps = super.ivyDeps() ++ Agg(
@@ -259,7 +275,7 @@ class SshdModule(val crossScalaVersion: String) extends AmmModule{
   }
 }
 
-def unitTest(scalaVersion: String = sys.env("TRAVIS_SCALA_VERSION")) = T.command{
+def unitTest(scalaVersion: String = sys.env("TRAVIS_SCALA_VERSION")) = T.command {
   ops(scalaVersion).test.test()()
   terminal(scalaVersion).test.test()()
   amm.repl(scalaVersion).test.test()()
@@ -268,17 +284,18 @@ def unitTest(scalaVersion: String = sys.env("TRAVIS_SCALA_VERSION")) = T.command
   sshd(scalaVersion).test.test()()
 }
 
-def integrationTest(scalaVersion: String = sys.env("TRAVIS_SCALA_VERSION")) = T.command{
+def integrationTest(scalaVersion: String = sys.env("TRAVIS_SCALA_VERSION")) = T.command {
   integration(scalaVersion).test.test()()
 }
 
-def generateConstantsFile(version: String = buildVersion,
-                          unstableVersion: String = "<fill-me-in-in-Constants.scala>",
-                          curlUrl: String = "<fill-me-in-in-Constants.scala>",
-                          unstableCurlUrl: String = "<fill-me-in-in-Constants.scala>",
-                          oldCurlUrls: Seq[(String, String)] = Nil,
-                          oldUnstableCurlUrls: Seq[(String, String)] = Nil)
-                         (implicit ctx: mill.api.Ctx.Dest)= {
+def generateConstantsFile(
+    version: String = buildVersion,
+    unstableVersion: String = "<fill-me-in-in-Constants.scala>",
+    curlUrl: String = "<fill-me-in-in-Constants.scala>",
+    unstableCurlUrl: String = "<fill-me-in-in-Constants.scala>",
+    oldCurlUrls: Seq[(String, String)] = Nil,
+    oldUnstableCurlUrls: Seq[(String, String)] = Nil
+)(implicit ctx: mill.api.Ctx.Dest) = {
   val versionTxt = s"""
     package ammonite
     object Constants{
@@ -287,23 +304,26 @@ def generateConstantsFile(version: String = buildVersion,
       val curlUrl = "$curlUrl"
       val unstableCurlUrl = "$unstableCurlUrl"
       val oldCurlUrls = Seq[(String, String)](
-        ${oldCurlUrls.map{case (name, value) => s""" "$name" -> "$value" """}.mkString(",\n")}
+        ${oldCurlUrls.map { case (name, value) => s""" "$name" -> "$value" """ }.mkString(",\n")}
       )
       val oldUnstableCurlUrls = Seq[(String, String)](
-        ${oldUnstableCurlUrls.map{case (name, value) => s""" "$name" -> "$value" """}.mkString(",\n")}
+        ${oldUnstableCurlUrls.map { case (name, value) => s""" "$name" -> "$value" """ }.mkString(
+    ",\n"
+  )}
       )
     }
   """
   println("Writing Constants.scala")
 
-  os.write(ctx.dest/"Constants.scala", versionTxt)
-  ctx.dest/"Constants.scala"
+  os.write(ctx.dest / "Constants.scala", versionTxt)
+  ctx.dest / "Constants.scala"
 }
 
-def generateDependenciesFile(scalaVersion: String,
-                             fileName: String,
-                             deps: Seq[coursier.Dependency])
-                            (implicit ctx: mill.api.Ctx.Dest) = {
+def generateDependenciesFile(
+    scalaVersion: String,
+    fileName: String,
+    deps: Seq[coursier.Dependency]
+)(implicit ctx: mill.api.Ctx.Dest) = {
 
   val dir = ctx.dest / "extra-resources"
   val dest = dir / fileName
@@ -324,4 +344,3 @@ def generateDependenciesFile(scalaVersion: String,
 
   dir
 }
-

--- a/integration/test/resources/better-files/build.sc
+++ b/integration/test/resources/better-files/build.sc
@@ -1,56 +1,57 @@
 import mill.scalalib.{SbtModule, Dep, DepSyntax}
 
-trait BetterFilesModule extends SbtModule{
+trait BetterFilesModule extends SbtModule {
   def scalaVersion = "2.12.4"
   def scalacOptions = Seq(
-    "-deprecation",                      // Emit warning and location for usages of deprecated APIs.
-    "-encoding", "utf-8",                // Specify character encoding used by source files.
-    "-explaintypes",                     // Explain type errors in more detail.
-    "-feature",                          // Emit warning and location for usages of features that should be imported explicitly.
-    "-language:existentials",            // Existential types (besides wildcard types) can be written and inferred
-    "-language:experimental.macros",     // Allow macro definition (besides implementation and application)
-    "-language:higherKinds",             // Allow higher-kinded types
-    "-language:implicitConversions",     // Allow definition of implicit functions called views
-    "-unchecked",                        // Enable additional warnings where generated code depends on assumptions.
-    "-Xcheckinit",                       // Wrap field accessors to throw an exception on uninitialized access.
-    "-Xfatal-warnings",                  // Fail the compilation if there are any warnings.
-    "-Xfuture",                          // Turn on future language features.
-    "-Xlint:adapted-args",               // Warn if an argument list is modified to match the receiver.
-    "-Xlint:by-name-right-associative",  // By-name parameter of right associative operator.
-    "-Xlint:constant",                   // Evaluation of a constant arithmetic expression results in an error.
-    "-Xlint:delayedinit-select",         // Selecting member of DelayedInit.
-    "-Xlint:doc-detached",               // A Scaladoc comment appears to be detached from its element.
-    "-Xlint:inaccessible",               // Warn about inaccessible types in method signatures.
-    "-Xlint:infer-any",                  // Warn when a type argument is inferred to be `Any`.
-    "-Xlint:missing-interpolator",       // A string literal appears to be missing an interpolator id.
-    "-Xlint:nullary-override",           // Warn when non-nullary `def f()' overrides nullary `def f'.
-    "-Xlint:nullary-unit",               // Warn when nullary methods return Unit.
-    "-Xlint:option-implicit",            // Option.apply used implicit view.
-    "-Xlint:package-object-classes",     // Class or object defined in package object.
-    "-Xlint:poly-implicit-overload",     // Parameterized overloaded implicit methods are not visible as view bounds.
-    "-Xlint:private-shadow",             // A private field (or class parameter) shadows a superclass field.
-    "-Xlint:stars-align",                // Pattern sequence wildcard must align with sequence component.
-    "-Xlint:type-parameter-shadow",      // A local type parameter shadows a type already in scope.
-    "-Xlint:unsound-match",              // Pattern match may not be typesafe.
-    "-Yno-adapted-args",                 // Do not adapt an argument list (either by inserting () or creating a tuple) to match the receiver.
-    "-Ypartial-unification",             // Enable partial unification in type constructor inference
-    "-Ywarn-dead-code",                  // Warn when dead code is identified.
-    "-Ywarn-extra-implicit",             // Warn when more than one implicit parameter section is defined.
-    "-Ywarn-inaccessible",               // Warn about inaccessible types in method signatures.
-    "-Ywarn-infer-any",                  // Warn when a type argument is inferred to be `Any`.
-    "-Ywarn-nullary-override",           // Warn when non-nullary `def f()' overrides nullary `def f'.
-    "-Ywarn-nullary-unit",               // Warn when nullary methods return Unit.
-    "-Ywarn-numeric-widen",              // Warn when numerics are widened.
-    "-Ywarn-unused:implicits",           // Warn if an implicit parameter is unused.
-    "-Ywarn-unused:imports",             // Warn if an import selector is not referenced.
-    "-Ywarn-unused:locals",              // Warn if a local definition is unused.
-    "-Ywarn-unused:params",              // Warn if a value parameter is unused.
-    "-Ywarn-unused:patvars",             // Warn if a variable bound in a pattern is unused.
-    "-Ywarn-unused:privates",            // Warn if a private member is unused.
-    "-Ywarn-value-discard"               // Warn when non-Unit expression results are unused.
+    "-deprecation", // Emit warning and location for usages of deprecated APIs.
+    "-encoding",
+    "utf-8", // Specify character encoding used by source files.
+    "-explaintypes", // Explain type errors in more detail.
+    "-feature", // Emit warning and location for usages of features that should be imported explicitly.
+    "-language:existentials", // Existential types (besides wildcard types) can be written and inferred
+    "-language:experimental.macros", // Allow macro definition (besides implementation and application)
+    "-language:higherKinds", // Allow higher-kinded types
+    "-language:implicitConversions", // Allow definition of implicit functions called views
+    "-unchecked", // Enable additional warnings where generated code depends on assumptions.
+    "-Xcheckinit", // Wrap field accessors to throw an exception on uninitialized access.
+    "-Xfatal-warnings", // Fail the compilation if there are any warnings.
+    "-Xfuture", // Turn on future language features.
+    "-Xlint:adapted-args", // Warn if an argument list is modified to match the receiver.
+    "-Xlint:by-name-right-associative", // By-name parameter of right associative operator.
+    "-Xlint:constant", // Evaluation of a constant arithmetic expression results in an error.
+    "-Xlint:delayedinit-select", // Selecting member of DelayedInit.
+    "-Xlint:doc-detached", // A Scaladoc comment appears to be detached from its element.
+    "-Xlint:inaccessible", // Warn about inaccessible types in method signatures.
+    "-Xlint:infer-any", // Warn when a type argument is inferred to be `Any`.
+    "-Xlint:missing-interpolator", // A string literal appears to be missing an interpolator id.
+    "-Xlint:nullary-override", // Warn when non-nullary `def f()' overrides nullary `def f'.
+    "-Xlint:nullary-unit", // Warn when nullary methods return Unit.
+    "-Xlint:option-implicit", // Option.apply used implicit view.
+    "-Xlint:package-object-classes", // Class or object defined in package object.
+    "-Xlint:poly-implicit-overload", // Parameterized overloaded implicit methods are not visible as view bounds.
+    "-Xlint:private-shadow", // A private field (or class parameter) shadows a superclass field.
+    "-Xlint:stars-align", // Pattern sequence wildcard must align with sequence component.
+    "-Xlint:type-parameter-shadow", // A local type parameter shadows a type already in scope.
+    "-Xlint:unsound-match", // Pattern match may not be typesafe.
+    "-Yno-adapted-args", // Do not adapt an argument list (either by inserting () or creating a tuple) to match the receiver.
+    "-Ypartial-unification", // Enable partial unification in type constructor inference
+    "-Ywarn-dead-code", // Warn when dead code is identified.
+    "-Ywarn-extra-implicit", // Warn when more than one implicit parameter section is defined.
+    "-Ywarn-inaccessible", // Warn about inaccessible types in method signatures.
+    "-Ywarn-infer-any", // Warn when a type argument is inferred to be `Any`.
+    "-Ywarn-nullary-override", // Warn when non-nullary `def f()' overrides nullary `def f'.
+    "-Ywarn-nullary-unit", // Warn when nullary methods return Unit.
+    "-Ywarn-numeric-widen", // Warn when numerics are widened.
+    "-Ywarn-unused:implicits", // Warn if an implicit parameter is unused.
+    "-Ywarn-unused:imports", // Warn if an import selector is not referenced.
+    "-Ywarn-unused:locals", // Warn if a local definition is unused.
+    "-Ywarn-unused:params", // Warn if a value parameter is unused.
+    "-Ywarn-unused:patvars", // Warn if a variable bound in a pattern is unused.
+    "-Ywarn-unused:privates", // Warn if a private member is unused.
+    "-Ywarn-value-discard" // Warn when non-Unit expression results are unused.
   )
   override def javacOptions = Seq("-source", "1.8", "-target", "1.8", "-Xlint")
-  object test extends Tests{
+  object test extends Tests {
     def moduleDeps =
       if (this == core.test) super.moduleDeps
       else super.moduleDeps ++ Seq(core.test)
@@ -61,17 +62,17 @@ trait BetterFilesModule extends SbtModule{
 
 object core extends BetterFilesModule
 
-object akka extends BetterFilesModule{
+object akka extends BetterFilesModule {
   def moduleDeps = Seq(core)
   def ivyDeps = Agg(ivy"com.typesafe.akka::akka-actor:2.5.6")
 }
 
-object shapeless extends BetterFilesModule{
+object shapeless extends BetterFilesModule {
   def moduleDeps = Seq(core)
-  def ivyDeps = Agg(ivy"com.chuusai::shapeless:2.3.2")
+  def ivyDeps = Agg(ivy"com.chuusai::shapeless:2.3.7")
 }
 
-object benchmarks extends BetterFilesModule{
+object benchmarks extends BetterFilesModule {
   def moduleDeps = Seq(core)
   def ivyDeps = Agg(
     ivy"commons-io:commons-io:2.5"
@@ -83,4 +84,3 @@ object benchmarks extends BetterFilesModule{
     )
   )
 }
-

--- a/integration/test/resources/play-json/build.sc
+++ b/integration/test/resources/play-json/build.sc
@@ -10,14 +10,13 @@ import jmh.Jmh
 //import headers.Headers
 //import com.typesafe.tools.mima.core._
 
-
 import mill.define.Task
 
 val ScalaVersions = Seq("2.10.7", "2.11.12", "2.12.4", "2.13.0-M3")
 
 trait BaseModule extends CrossSbtModule with Scalariform /*with Headers*/
 
-trait PlayJsonModule extends BaseModule with PublishModule /*with MiMa */{
+trait PlayJsonModule extends BaseModule with PublishModule /*with MiMa */ {
 
   def pomSettings = PomSettings(
     description = artifactName(),
@@ -34,7 +33,7 @@ trait PlayJsonModule extends BaseModule with PublishModule /*with MiMa */{
     )
   )
 
-  trait Tests extends super.Tests with Scalariform /*with Headers */{
+  trait Tests extends super.Tests with Scalariform /*with Headers */ {
     val specs2Core = T {
       val v = mill.scalalib.api.Util.scalaBinaryVersion(scalaVersion()) match {
         case "2.10" => "3.9.1"
@@ -44,7 +43,7 @@ trait PlayJsonModule extends BaseModule with PublishModule /*with MiMa */{
     }
   }
 
-  override def scalacOptions  = Seq("-deprecation", "-feature", "-unchecked", "-encoding", "utf8")
+  override def scalacOptions = Seq("-deprecation", "-feature", "-unchecked", "-encoding", "utf8")
   override def javacOptions = Seq("-encoding", "UTF-8", "-Xlint:-options")
 
   def publishVersion = playJsonVersion.current
@@ -52,7 +51,7 @@ trait PlayJsonModule extends BaseModule with PublishModule /*with MiMa */{
 
 abstract class PlayJson(val platformSegment: String) extends PlayJsonModule {
   def crossScalaVersion: String
-  override def millSourcePath = os.pwd /  "play-json"
+  override def millSourcePath = os.pwd / "play-json"
   override def artifactName = "play-json"
 
   override def sources = T.sources(
@@ -105,7 +104,8 @@ abstract class PlayJson(val platformSegment: String) extends PlayJsonModule {
       val typeTuple = commaSeparated(j => s"T$j")
       val written = commaSeparated(j => s"implicitly[Writes[T$j]].writes(x._$j)")
       val readValues = commaSeparated(j => s"t$j")
-      val readGenerators = newlineSeparated(j => s"t$j <- implicitly[Reads[T$j]].reads(arr(${j - 1}))")
+      val readGenerators =
+        newlineSeparated(j => s"t$j <- implicitly[Reads[T$j]].reads(arr(${j - 1}))")
       (
         s"""
           implicit def Tuple${i}W[$writerTypes]: Writes[Tuple${i}[$typeTuple]] = Writes[Tuple${i}[$typeTuple]](
@@ -122,10 +122,13 @@ abstract class PlayJson(val platformSegment: String) extends PlayJsonModule {
             case _ =>
               JsError(Seq(JsPath() -> Seq(JsonValidationError("Expected array of $i elements"))))
           }
-        """)
+        """
+      )
     }.unzip
 
-    os.write(file, s"""
+    os.write(
+      file,
+      s"""
         package play.api.libs.json
 
         trait GeneratedReads {
@@ -135,13 +138,14 @@ abstract class PlayJson(val platformSegment: String) extends PlayJsonModule {
         trait GeneratedWrites{
           ${writes.mkString("\n")}
         }
-        """)
+        """
+    )
 
     Seq(PathRef(dir))
   }
 }
 
-object playJsonJvm extends Cross[PlayJsonJvm](ScalaVersions:_*)
+object playJsonJvm extends Cross[PlayJsonJvm](ScalaVersions: _*)
 class PlayJsonJvm(val crossScalaVersion: String) extends PlayJson("jvm") {
   override def moduleDeps = Seq(playFunctionalJvm(crossScalaVersion))
 
@@ -161,7 +165,7 @@ class PlayJsonJvm(val crossScalaVersion: String) extends PlayJson("jvm") {
       Agg(
         ivy"org.scalatest::scalatest:3.0.5-M1",
         ivy"org.scalacheck::scalacheck:1.13.5",
-        ivy"com.chuusai::shapeless:2.3.3",
+        ivy"com.chuusai::shapeless:2.3.7",
         ivy"ch.qos.logback:logback-classic:1.2.3",
         specs2Core()
       )
@@ -169,15 +173,15 @@ class PlayJsonJvm(val crossScalaVersion: String) extends PlayJson("jvm") {
     override def sources = {
       val docSpecs = os.walk(millSourcePath / os.up / "docs" / "manual" / "working" / "scalaGuide")
         .filter(os.isDir)
-        .filter(_.last=="code")
+        .filter(_.last == "code")
         .map(PathRef(_))
 
       T.sources(
         docSpecs ++
-        Seq(
-          PathRef(millSourcePath / platformSegment / "src" / "test"),
-          PathRef(millSourcePath / "shared" / "src" / "test")
-        )
+          Seq(
+            PathRef(millSourcePath / platformSegment / "src" / "test"),
+            PathRef(millSourcePath / "shared" / "src" / "test")
+          )
       )
     }
   }
@@ -187,19 +191,20 @@ class PlayJsonJvm(val crossScalaVersion: String) extends PlayJson("jvm") {
 
 }
 
-object playJsonJs extends Cross[PlayJsonJs](ScalaVersions:_*)
+object playJsonJs extends Cross[PlayJsonJs](ScalaVersions: _*)
 class PlayJsonJs(val crossScalaVersion: String) extends PlayJson("js") with ScalaJSModule {
   override def moduleDeps = Seq(playFunctionalJs(crossScalaVersion))
 
   def scalaJSVersion = "0.6.32"
 
   // TODO: remove super[PlayJson].Tests with super[ScalaJSModule].Tests hack
-  object test extends super[PlayJson].Tests with super[ScalaJSModule].Tests with Scalariform with TestModule.ScalaTest /* with Headers*/ {
+  object test extends super[PlayJson].Tests with super[ScalaJSModule].Tests with Scalariform
+      with TestModule.ScalaTest /* with Headers*/ {
     override def ivyDeps =
       Agg(
         ivy"org.scalatest::scalatest::3.0.5-M1",
         ivy"org.scalacheck::scalacheck::1.13.5",
-        ivy"com.chuusai::shapeless::2.3.3"
+        ivy"com.chuusai::shapeless::2.3.7"
       )
 
     override def sources = T.sources(
@@ -214,15 +219,15 @@ trait PlayFunctional extends PlayJsonModule {
   override def artifactName = "play-functional"
 }
 
-object playFunctionalJvm extends Cross[PlayFunctionalJvm](ScalaVersions:_*)
+object playFunctionalJvm extends Cross[PlayFunctionalJvm](ScalaVersions: _*)
 class PlayFunctionalJvm(val crossScalaVersion: String) extends PlayFunctional
 
-object playFunctionalJs extends Cross[PlayFunctionalJs](ScalaVersions:_*)
+object playFunctionalJs extends Cross[PlayFunctionalJs](ScalaVersions: _*)
 class PlayFunctionalJs(val crossScalaVersion: String) extends PlayFunctional with ScalaJSModule {
   def scalaJSVersion = "0.6.32"
 }
 
-object playJoda extends Cross[PlayJoda](ScalaVersions:_*)
+object playJoda extends Cross[PlayJoda](ScalaVersions: _*)
 class PlayJoda(val crossScalaVersion: String) extends PlayJsonModule {
   override def moduleDeps = Seq(playJsonJvm(crossScalaVersion))
 
@@ -239,7 +244,7 @@ class PlayJoda(val crossScalaVersion: String) extends PlayJsonModule {
 
 }
 
-object benchmarks extends Cross[Benchmarks](ScalaVersions:_*)
+object benchmarks extends Cross[Benchmarks](ScalaVersions: _*)
 class Benchmarks(val crossScalaVersion: String) extends BaseModule with Jmh {
   override def moduleDeps = Seq(playJsonJvm(crossScalaVersion))
 
@@ -257,7 +262,7 @@ val testModules = Seq(
 val sourceModules = Seq(
   playJsonJvm("2.12.4"),
   playJsonJs("2.12.4"),
-  playJoda("2.12.4"),
+  playJoda("2.12.4")
 )
 
 val allModules = testModules ++ sourceModules
@@ -303,17 +308,17 @@ val allModules = testModules ++ sourceModules
 //}
 
 /**
-  * Release steps are:
-  * 1) clean
-  * 2) run tests
-  * 3) set release version
-  * 4) commit release version
-  * 5) make release tag
-  * 6) publish all modules to sonatype
-  * 7) set next version
-  * 8) commit next version
-  * 9) push everything to git
-  */
+ * Release steps are:
+ * 1) clean
+ * 2) run tests
+ * 3) set release version
+ * 4) commit release version
+ * 5) make release tag
+ * 6) publish all modules to sonatype
+ * 7) set next version
+ * 8) commit next version
+ * 9) push everything to git
+ */
 object release extends Module {
 
   implicit val wd = os.pwd
@@ -331,7 +336,7 @@ object release extends Module {
   }
 
   private val nextVersion = playJsonVersion.current match {
-    case v@MinorSnapshotVersion(major, minor, patch) => v
+    case v @ MinorSnapshotVersion(major, minor, patch) => v
     case ReleaseVersion(major, minor, patch) =>
       s"${major}.${minor}.${patch.toInt + 1}-SNAPSHOT"
   }


### PR DESCRIPTION
To avoid clash with plugins:
```
java.lang.NoSuchMethodError: 'shapeless.DefaultSymbolicLabelling shapeless.DefaultSymbolicLabelling$.instance(shapeless.HList)'
        at com.netflix.mill.spaas.JobRegisterer$anon$importedEncoder$macro$33$1.inst$macro$1$lzycompute(JobRegisterer.scala:23)
        at com.netflix.mill.spaas.JobRegisterer$anon$importedEncoder$macro$33$1.inst$macro$1(JobRegisterer.scala:23)
        at com.netflix.mill.spaas.JobRegisterer$.$anonfun$apply$1(JobRegisterer.scala:23)
        at cats.data.Chain$.$anonfun$traverseViaChain$3(Chain.scala:795)
        at cats.Eval$.loop$1(Eval.scala:317)
        at cats.Eval$.cats$Eval$$evaluate(Eval.scala:363)
        at cats.Eval$FlatMap.value(Eval.scala:284)
        at cats.data.Chain$.traverseViaChain(Chain.scala:817)
        at cats.instances.ListInstances$$anon$1.traverse(list.scala:100)
        at cats.instances.ListInstances$$anon$1.traverse(list.scala:17)
        at cats.Traverse$Ops.traverse(Traverse.scala:181)
        at cats.Traverse$Ops.traverse$(Traverse.scala:180)
        at cats.Traverse$ToTraverseOps$$anon$3.traverse(Traverse.scala:206)
        at com.netflix.mill.spaas.JobRegisterer$.apply(JobRegisterer.scala:21)
        at com.netflix.mill.spaas.SpaasModule$SpaasDocker.$anonfun$register$8(SpaasModule.scala:161)
        at cats.effect.kernel.Resource.loop$1(Resource.scala:185)
        at cats.effect.kernel.Resource.continue$1(Resource.scala:164)
        at cats.effect.kernel.Resource.$anonfun$fold$3(Resource.scala:190)
        at cats.effect.IOFiber.next$2(IOFiber.scala:382)
        at cats.effect.IOFiber.runLoop(IOFiber.scala:428)
        at cats.effect.IOFiber.execR(IOFiber.scala:1275)
        at cats.effect.IOFiber.run(IOFiber.scala:124)
        at cats.effect.unsafe.WorkerThread.run(WorkerThread.scala:443)
1 targets failed
app.docker.register java.lang.NoSuchMethodError: 'shapeless.DefaultSymbolicLabelling shapeless.DefaultSymbolicLabelling$.instance(shapeless.HList)'
```