### PR TITLE
Fixes the default args for publish

### DIFF
--- a/scalalib/src/PublishModule.scala
+++ b/scalalib/src/PublishModule.scala
@@ -155,6 +155,11 @@ trait PublishModule extends JavaModule { outer =>
   def publish(
       sonatypeCreds: String,
       signed: Boolean = true,
+      // mainargs wasn't handling a default value properly, 
+      // so we instead use the empty Seq as default.
+      // see https://github.com/com-lihaoyi/mill/pull/1678
+      // TODO: In mill 0.11, we may want to change to a String argument 
+      // which we can split at `,` symbols, as we do in `PublishModule.publishAll`.
       gpgArgs: Seq[String] = Seq.empty,
       release: Boolean = false,
       readTimeout: Int = 60000,

--- a/scalalib/src/PublishModule.scala
+++ b/scalalib/src/PublishModule.scala
@@ -155,7 +155,7 @@ trait PublishModule extends JavaModule { outer =>
   def publish(
       sonatypeCreds: String,
       signed: Boolean = true,
-      gpgArgs: Seq[String] = PublishModule.defaultGpgArgs,
+      gpgArgs: Seq[String] = Seq.empty,
       release: Boolean = false,
       readTimeout: Int = 60000,
       connectTimeout: Int = 5000,
@@ -168,7 +168,7 @@ trait PublishModule extends JavaModule { outer =>
       sonatypeSnapshotUri,
       sonatypeCreds,
       signed,
-      gpgArgs.flatMap(_.split("[,]")),
+      if (gpgArgs.isEmpty) PublishModule.defaultGpgArgs else gpgArgs,
       readTimeout,
       connectTimeout,
       T.log,


### PR DESCRIPTION
It seems the default argument for gpgArgs in publish cannot ever resolve to anything but empty. So, if the argument is an empty Seq, replace it with the default gpgArgs. 

This allows projects like mine to publish easily.