### PR TITLE
Fix GitHub asset upload

### DIFF
--- a/ci/upload.sc
+++ b/ci/upload.sc
@@ -1,20 +1,6 @@
 #!/usr/bin/env amm
-import scala.util.Try
-import scala.util.control.NonFatal
 
 import scalaj.http._
-
-@main
-def shorten(longUrl: String) = {
-  println("shorten longUrl " + longUrl)
-  val shortUrl = Http("https://git.io")
-    .postForm(Seq("url" -> longUrl))
-    .asString
-    .headers("Location")
-    .head
-  println("shorten shortUrl " + shortUrl)
-  shortUrl
-}
 
 @main
 def apply(
@@ -56,13 +42,5 @@ def apply(
   val longUrl = ujson.read(res.body)("browser_download_url").str
 
   println("Long Url " + longUrl)
-
-  Try {
-    val shortUrl = shorten(longUrl)
-    println("Short Url " + shortUrl)
-    shortUrl
-  }.toOption.getOrElse {
-    // could not shorten the url
-    longUrl
-  }
+  longUrl
 }

--- a/ci/upload.sc
+++ b/ci/upload.sc
@@ -1,4 +1,7 @@
 #!/usr/bin/env amm
+import scala.util.Try
+import scala.util.control.NonFatal
+
 import scalaj.http._
 
 @main
@@ -24,7 +27,8 @@ def apply(
 ): String = {
 
   val response = Http(
-    s"https://api.github.com/repos/${githubOrg}/${githubRepo}/releases/tags/${tagName}")
+    s"https://api.github.com/repos/${githubOrg}/${githubRepo}/releases/tags/${tagName}"
+  )
     .header("Authorization", "token " + authKey)
     .header("Accept", "application/vnd.github.v3+json")
     .asString
@@ -53,8 +57,12 @@ def apply(
 
   println("Long Url " + longUrl)
 
-  val shortUrl = shorten(longUrl)
-
-  println("Short Url " + shortUrl)
-  shortUrl
+  Try {
+    val shortUrl = shorten(longUrl)
+    println("Short Url " + shortUrl)
+    shortUrl
+  }.toOption.getOrElse {
+    // could not shorten the url
+    longUrl
+  }
 }


### PR DESCRIPTION
Removed support for shortening URLs. `git.io` no longer accepts new URLs.
