### PR TITLE
Accepts all args in .mill-jvm-opts now

### DIFF
--- a/docs/antora/modules/ROOT/pages/Intro_to_Mill.adoc
+++ b/docs/antora/modules/ROOT/pages/Intro_to_Mill.adoc
@@ -1111,8 +1111,7 @@ or
 == Running Mill with custom JVM options
 
 It's possible to pass JVM options to the Mill launcher. To do this you need to create a `.mill-jvm-opts` file in your
-project's root. This file should contain JVM options (strings, starting with `-X`), one per line. All other lines will
-be ignored.
+project's root. This file should contain JVM options, one per line.
 
 For example, if your build requires a lot of memory and bigger stack size, your `.mill-jvm-opts` could look like this:
 

--- a/main/client/src/mill/main/client/MillClientMain.java
+++ b/main/client/src/mill/main/client/MillClientMain.java
@@ -78,9 +78,7 @@ public class MillClientMain {
             try (Scanner sc = new Scanner(millJvmOptsFile)) {
                 while (sc.hasNextLine()) {
                     String arg = sc.nextLine();
-                    if (arg.startsWith("-X")) {
-                        vmOptions.add(arg);
-                    }
+                    vmOptions.add(arg);
                 }
             }
         }


### PR DESCRIPTION
Resolves #1682 by allowing mill to be configured to work with incubator modules and other uncommon builds.