### PR TITLE
Migrate to new Scala.js Linker API

### DIFF
--- a/scalajslib/api/src/ScalaJSWorkerApi.scala
+++ b/scalajslib/api/src/ScalaJSWorkerApi.scala
@@ -14,7 +14,7 @@ trait ScalaJSWorkerApi {
       fullOpt: Boolean,
       moduleKind: ModuleKind,
       esFeatures: ESFeatures
-  ): Result[File]
+  ): Result[Seq[File]]
 
   def run(config: JsEnvConfig, linkedFile: File): Unit
 

--- a/scalajslib/api/src/ScalaJSWorkerApi.scala
+++ b/scalajslib/api/src/ScalaJSWorkerApi.scala
@@ -14,18 +14,20 @@ trait ScalaJSWorkerApi {
       fullOpt: Boolean,
       moduleKind: ModuleKind,
       esFeatures: ESFeatures
-  ): Result[Seq[File]]
+  ): Result[LinkedModules]
 
-  def run(config: JsEnvConfig, linkedFile: File): Unit
+  def run(config: JsEnvConfig, linkedModules: LinkedModules): Unit
 
   def getFramework(
       config: JsEnvConfig,
       frameworkName: String,
-      linkedFile: File,
+      linkedModules: LinkedModules,
       moduleKind: ModuleKind
   ): (() => Unit, sbt.testing.Framework)
 
 }
+
+case class LinkedModules(modules: Map[String, File], moduleKind: ModuleKind)
 
 sealed trait OptimizeMode
 

--- a/scalajslib/src/ScalaJSWorkerApi.scala
+++ b/scalajslib/src/ScalaJSWorkerApi.scala
@@ -39,7 +39,7 @@ class ScalaJSWorker {
       fullOpt: Boolean,
       moduleKind: ModuleKind,
       esFeatures: ESFeatures
-  )(implicit ctx: Ctx.Home): Result[Seq[os.Path]] = {
+  )(implicit ctx: Ctx.Home): Result[LinkedModules] = {
     bridge(toolsClasspath).link(
       sources.items.map(_.toIO).toArray,
       libraries.items.map(_.toIO).toArray,
@@ -49,23 +49,23 @@ class ScalaJSWorker {
       fullOpt,
       moduleKind,
       esFeatures
-    ).map(_.map(os.Path(_)))
+    )
   }
 
-  def run(toolsClasspath: Agg[os.Path], config: JsEnvConfig, linkedFile: File)(implicit
+  def run(toolsClasspath: Agg[os.Path], config: JsEnvConfig, linkedModules: LinkedModules)(implicit
       ctx: Ctx.Home
   ): Unit = {
-    bridge(toolsClasspath).run(config, linkedFile)
+    bridge(toolsClasspath).run(config, linkedModules)
   }
 
   def getFramework(
       toolsClasspath: Agg[os.Path],
       config: JsEnvConfig,
       frameworkName: String,
-      linkedFile: File,
+      linkedModules: LinkedModules,
       moduleKind: ModuleKind
   )(implicit ctx: Ctx.Home): (() => Unit, sbt.testing.Framework) = {
-    bridge(toolsClasspath).getFramework(config, frameworkName, linkedFile, moduleKind)
+    bridge(toolsClasspath).getFramework(config, frameworkName, linkedModules, moduleKind)
   }
 
 }

--- a/scalajslib/src/ScalaJSWorkerApi.scala
+++ b/scalajslib/src/ScalaJSWorkerApi.scala
@@ -39,7 +39,7 @@ class ScalaJSWorker {
       fullOpt: Boolean,
       moduleKind: ModuleKind,
       esFeatures: ESFeatures
-  )(implicit ctx: Ctx.Home): Result[os.Path] = {
+  )(implicit ctx: Ctx.Home): Result[Seq[os.Path]] = {
     bridge(toolsClasspath).link(
       sources.items.map(_.toIO).toArray,
       libraries.items.map(_.toIO).toArray,
@@ -49,7 +49,7 @@ class ScalaJSWorker {
       fullOpt,
       moduleKind,
       esFeatures
-    ).map(os.Path(_))
+    ).map(_.map(os.Path(_)))
   }
 
   def run(toolsClasspath: Agg[os.Path], config: JsEnvConfig, linkedFile: File)(implicit

--- a/scalajslib/worker/0.6/src/ScalaJSWorkerImpl.scala
+++ b/scalajslib/worker/0.6/src/ScalaJSWorkerImpl.scala
@@ -89,7 +89,7 @@ class ScalaJSWorkerImpl extends mill.scalajslib.api.ScalaJSWorkerApi {
     val initializer = Option(main).map { cls => ModuleInitializer.mainMethodWithArgs(cls, "main") }
     try {
       linker.link(sourceSJSIRs ++ jarSJSIRs, initializer.toSeq, destFile, logger)
-      Result.Success(dest)
+      Result.Success(Seq(dest))
     } catch {
       case e: org.scalajs.core.tools.linker.LinkingException =>
         Result.Failure(e.getMessage)


### PR DESCRIPTION
Scala.js linker now supports multiple top-level modules: https://www.scala-js.org/doc/project/module.html.

Currently, Mill fails to link those setup as it is using deprecated Linker API. See https://github.com/com-lihaoyi/mill/issues/1684.

This PR is my attempt to migrate to the new API that solves the issue.

As I'm new to the project, please let me know what else might be impacted by the change. I've managed to get my original issue with `fastOpt` resolved. Still need to test the `test` command as well.