### PR TITLE
GenIdea: Use common content root and allow optional package prefixes

### DIFF
--- a/scalalib/src/GenIdeaModule.scala
+++ b/scalalib/src/GenIdeaModule.scala
@@ -18,6 +18,11 @@ trait GenIdeaModule extends Module {
   def skipIdea: Boolean = false
 
   /**
+   * Map containing a map of source folder names to package prefixes for Idea project file generation.
+   */
+  def packagePrefix: Map[String, String] = Map.empty[String, String]
+
+  /**
    * Contribute facets to the Java module configuration.
    * @param ideaConfigVersion The IDEA configuration version in use. Probably `4`.
    * @return

--- a/scalalib/test/resources/gen-idea-hello-world/idea/mill_modules/helloworld.iml
+++ b/scalalib/test/resources/gen-idea-hello-world/idea/mill_modules/helloworld.iml
@@ -2,10 +2,8 @@
     <component name="NewModuleRootManager">
         <output url="file://$MODULE_DIR$/../../out/HelloWorld/ideaCompileOutput.dest/classes"/>
         <exclude-output/>
-        <content url="file://$MODULE_DIR$/../../HelloWorld/src">
+        <content url="file://$MODULE_DIR$/../../HelloWorld">
             <sourceFolder url="file://$MODULE_DIR$/../../HelloWorld/src" isTestSource="false"/>
-        </content>
-        <content url="file://$MODULE_DIR$/../../HelloWorld/resources">
             <sourceFolder url="file://$MODULE_DIR$/../../HelloWorld/resources" type="java-resource"/>
         </content>
         <orderEntry type="inheritedJdk"/>

--- a/scalalib/test/resources/gen-idea-hello-world/idea/mill_modules/helloworld.test.iml
+++ b/scalalib/test/resources/gen-idea-hello-world/idea/mill_modules/helloworld.test.iml
@@ -2,10 +2,8 @@
     <component name="NewModuleRootManager">
         <output-test url="file://$MODULE_DIR$/../../out/HelloWorld/test/ideaCompileOutput.dest/classes"/>
         <exclude-output/>
-        <content url="file://$MODULE_DIR$/../../HelloWorld/test/src">
+        <content url="file://$MODULE_DIR$/../../HelloWorld/test">
             <sourceFolder url="file://$MODULE_DIR$/../../HelloWorld/test/src" isTestSource="true"/>
-        </content>
-        <content url="file://$MODULE_DIR$/../../HelloWorld/test/resources">
             <sourceFolder url="file://$MODULE_DIR$/../../HelloWorld/test/resources" type="java-test-resource"/>
         </content>
         <orderEntry type="inheritedJdk"/>

--- a/scratch/build.sc
+++ b/scratch/build.sc
@@ -3,4 +3,7 @@ import mill.scalalib._
 
 object foo extends ScalaModule{
   def scalaVersion = "2.13.2"
+  def packagePrefix: Map[String, String] = Map(
+    "src" -> "foo",
+  )
 }


### PR DESCRIPTION
Allows a build.sc like 
```scala
import mill._
import mill.scalalib._

object foo extends ScalaModule{
  def scalaVersion = "3.1.0"
  override def sources = T.sources(
    millSourcePath / "src",
    millSourcePath / "src2",
  )
  override def packagePrefix: Map[String, String] = Map(
    "src" -> "foo",
  )
}
```
to produce a module.xml like this
```xml
<module type="JAVA_MODULE" version="4">
    <component name="NewModuleRootManager">
        <output url="file://$MODULE_DIR$/../../out/foo/ideaCompileOutput.dest/classes"/>
        <exclude-output/>
        <content url="file://$MODULE_DIR$/../../foo">
            <sourceFolder url="file://$MODULE_DIR$/../../foo/src" isTestSource="false" packagePrefix="foo"/>
            <sourceFolder url="file://$MODULE_DIR$/../../foo/src2" isTestSource="false"/>
            <sourceFolder url="file://$MODULE_DIR$/../../foo/resources" type="java-resource"/>
        </content>
        <orderEntry type="inheritedJdk"/>
        <orderEntry type="sourceFolder" forTests="false"/>
        <orderEntry type="library" name="scala-library-2.13.6.jar" level="project"/>
        <orderEntry type="library" name="scala3-library_3-3.1.0.jar" level="project"/>
    </component>
</module>
```
![module settings](https://i.ibb.co/6PRMRsr/Screenshot-at-2022-01-22-11-57-26.png)

Compare this to the current implementation
```scala
import mill._
import mill.scalalib._

object foo extends ScalaModule{
  def scalaVersion = "3.1.0"
  override def sources = T.sources(
    millSourcePath / "src",
    millSourcePath / "src2",
  )
}
```
```xml
<module type="JAVA_MODULE" version="4">
    <component name="NewModuleRootManager">
        <output url="file://$MODULE_DIR$/../../out/foo/ideaCompileOutput.dest/classes"/>
        <exclude-output/>
        <content url="file://$MODULE_DIR$/../../foo/src">
            <sourceFolder url="file://$MODULE_DIR$/../../foo/src" isTestSource="false"/>
        </content>
        <content url="file://$MODULE_DIR$/../../foo/src2">
            <sourceFolder url="file://$MODULE_DIR$/../../foo/src2" isTestSource="false"/>
        </content>
        <content url="file://$MODULE_DIR$/../../foo/resources">
            <sourceFolder url="file://$MODULE_DIR$/../../foo/resources" type="java-resource"/>
        </content>
        <orderEntry type="inheritedJdk"/>
        <orderEntry type="sourceFolder" forTests="false"/>
        <orderEntry type="library" name="scala-library-2.13.6.jar" level="project"/>
        <orderEntry type="library" name="scala3-library_3-3.1.0.jar" level="project"/>
    </component>
</module>
```
![module settings](https://i.ibb.co/XSn4R76/Screenshot-at-2022-01-22-12-09-18.png)
