### PR TITLE
Make ScalaNativeModule use Scala 2.13 toolchain when available

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -68,10 +68,10 @@ object Deps {
   }
 
   object Scalanative_0_4 {
-    val scalanativeTools = ivy"org.scala-native::tools:0.4.0"
-    val scalanativeUtil = ivy"org.scala-native::util:0.4.0"
-    val scalanativeNir = ivy"org.scala-native::nir:0.4.0"
-    val scalanativeTestRunner = ivy"org.scala-native::test-runner:0.4.0"
+    val scalanativeTools = ivy"org.scala-native::tools:0.4.2"
+    val scalanativeUtil = ivy"org.scala-native::util:0.4.2"
+    val scalanativeNir = ivy"org.scala-native::nir:0.4.2"
+    val scalanativeTestRunner = ivy"org.scala-native::test-runner:0.4.2"
   }
 
   val acyclic = ivy"com.lihaoyi::acyclic:0.2.1"
@@ -720,7 +720,7 @@ object scalanativelib extends MillModule {
   }
   object worker extends Cross[WorkerModule]("0.4")
   class WorkerModule(scalaNativeWorkerVersion: String) extends MillInternalModule {
-    override def scalaVersion = Deps.workerScalaVersion212
+    override def scalaVersion = Deps.scalaVersion
     override def moduleDeps = Seq(scalanativelib.api)
     override def ivyDeps = scalaNativeWorkerVersion match {
       case "0.4" =>

--- a/build.sc
+++ b/build.sc
@@ -291,6 +291,8 @@ object main extends MillModule {
            |object BuildInfo {
            |  /** Scala version used to compile mill core. */
            |  val scalaVersion = "$scalaVersion"
+           |  /** Scala 2.12 version used by some workers. */
+           |  val workerScalaVersion212 = "${Deps.workerScalaVersion212}"
            |  /** Mill version. */
            |  val millVersion = "$millVersion"
            |  /** Mill binary platform version. */
@@ -708,7 +710,8 @@ object scalanativelib extends MillModule {
 
   override def testArgs = T {
     val mapping = Map(
-      "MILL_SCALANATIVE_WORKER_0_4" -> worker("0.4").compile().classes.path
+      "MILL_SCALANATIVE_WORKER_0_4_2_12" -> worker("0.4", Deps.workerScalaVersion212).compile().classes.path,
+      "MILL_SCALANATIVE_WORKER_0_4_2_13" -> worker("0.4", Deps.scalaVersion).compile().classes.path
     )
     scalalib.worker.testArgs() ++
       scalalib.backgroundwrapper.testArgs() ++
@@ -718,9 +721,9 @@ object scalanativelib extends MillModule {
   object api extends MillPublishModule {
     override def ivyDeps = Agg(Deps.sbtTestInterface)
   }
-  object worker extends Cross[WorkerModule]("0.4")
-  class WorkerModule(scalaNativeWorkerVersion: String) extends MillInternalModule {
-    override def scalaVersion = Deps.scalaVersion
+  object worker extends Cross[WorkerModule](("0.4", Deps.scalaVersion), ("0.4", Deps.workerScalaVersion212))
+  class WorkerModule(scalaNativeWorkerVersion: String, val crossScalaVersion: String) extends CrossModuleBase with MillInternalModule {
+    override def scalaVersion = T { crossScalaVersion }
     override def moduleDeps = Seq(scalanativelib.api)
     override def ivyDeps = scalaNativeWorkerVersion match {
       case "0.4" =>

--- a/contrib/bloop/test/src/mill/contrib/bloop/BloopTests.scala
+++ b/contrib/bloop/test/src/mill/contrib/bloop/BloopTests.scala
@@ -52,7 +52,7 @@ object BloopTests extends TestSuite {
     object scalanativeModule extends scalanativelib.ScalaNativeModule with testBloop.Module {
       override def skipBloop: Boolean = scala.util.Properties.isWin
       override def scalaVersion = "2.13.4"
-      override def scalaNativeVersion = "0.4.0"
+      override def scalaNativeVersion = "0.4.2"
       override def releaseMode = T(ReleaseMode.Debug)
     }
 

--- a/scalanativelib/src/ScalaNativeModule.scala
+++ b/scalanativelib/src/ScalaNativeModule.scala
@@ -47,15 +47,14 @@ trait ScalaNativeModule extends ScalaModule { outer =>
       workerKey,
       s"mill-scalanativelib-worker-${scalaNativeWorkerVersion()}",
       repositoriesTask(),
-      resolveFilter = _.toString.contains("mill-scalanativelib-worker"),
-      artifactSuffix = "_2.12"
+      resolveFilter = _.toString.contains("mill-scalanativelib-worker")
     )
   }
 
   def toolsIvyDeps = T {
     Agg(
-      ivy"org.scala-native:tools_2.12:${scalaNativeVersion()}",
-      ivy"org.scala-native:test-runner_2.12:${scalaNativeVersion()}"
+      ivy"org.scala-native::tools:${scalaNativeVersion()}",
+      ivy"org.scala-native::test-runner:${scalaNativeVersion()}"
     )
   }
 
@@ -82,12 +81,10 @@ trait ScalaNativeModule extends ScalaModule { outer =>
     super.mandatoryIvyDeps() ++ nativeIvyDeps()
   }
 
-  // Using `resolveDeps` from `CoursierModule` incorrectly resolves
-  // scala-library 2.13 instead of the required 2.12
   def bridgeFullClassPath: T[Agg[os.Path]] = T {
     Lib.resolveDependencies(
       repositoriesTask(),
-      resolveCoursierDependency().apply(_),
+      Lib.depToDependency(_, mill.BuildInfo.scalaVersion, ""),
       toolsIvyDeps(),
       ctx = Some(T.log)
     ).map(t => (scalaNativeWorkerClasspath() ++ t).map(_.path))

--- a/scalanativelib/src/ScalaNativeWorkerApi.scala
+++ b/scalanativelib/src/ScalaNativeWorkerApi.scala
@@ -17,8 +17,7 @@ class ScalaNativeWorker {
       case _ =>
         val cl = mill.api.ClassLoader.create(
           toolsClasspath.map(_.toIO.toURI.toURL).toSeq,
-          null,
-          sharedPrefixes = Seq("mill.scalanativelib.api.", "sbt.testing.")
+          getClass.getClassLoader
         )
         try {
           val bridge = cl

--- a/scalanativelib/test/src/HelloNativeWorldTests.scala
+++ b/scalanativelib/test/src/HelloNativeWorldTests.scala
@@ -24,7 +24,7 @@ object HelloNativeWorldTests extends TestSuite {
   }
 
   val scala213 = "2.13.6"
-  val scalaNative04 = "0.4.2"
+  val scalaNative04 = "0.4.0"
 
   object HelloNativeWorld extends TestUtil.BaseModule {
     val matrix = for {
@@ -231,7 +231,7 @@ object HelloNativeWorldTests extends TestSuite {
       )
 
     val scalaNativeVersionSpecific =
-      if (scalaNativeVersion == "0.4.2") Set.empty
+      if (scalaNativeVersion == scalaNative04) Set.empty
       else Set("Main.nir", "ArgsParser.nir")
 
     common ++ scalaVersionSpecific ++ scalaNativeVersionSpecific

--- a/scalanativelib/test/src/HelloNativeWorldTests.scala
+++ b/scalanativelib/test/src/HelloNativeWorldTests.scala
@@ -24,12 +24,12 @@ object HelloNativeWorldTests extends TestSuite {
   }
 
   val scala213 = "2.13.6"
-  val scalaNative04 = "0.4.0"
+  val scalaNative04 = "0.4.2"
 
   object HelloNativeWorld extends TestUtil.BaseModule {
     val matrix = for {
       scala <- Seq("3.1.0", scala213, "2.12.13", "2.11.12")
-      scalaNative <- Seq(scalaNative04, "0.4.3-RC2")
+      scalaNative <- Seq(scalaNative04, "0.4.3")
       mode <- List(ReleaseMode.Debug, ReleaseMode.ReleaseFast)
       if !(isScala3(scala) && scalaNative == scalaNative04)
     } yield (scala, scalaNative, mode)
@@ -231,7 +231,7 @@ object HelloNativeWorldTests extends TestSuite {
       )
 
     val scalaNativeVersionSpecific =
-      if (scalaNativeVersion == "0.4.0") Set.empty
+      if (scalaNativeVersion == "0.4.2") Set.empty
       else Set("Main.nir", "ArgsParser.nir")
 
     common ++ scalaVersionSpecific ++ scalaNativeVersionSpecific

--- a/scalanativelib/worker/0.4/src/ScalaNativeWorkerImpl.scala
+++ b/scalanativelib/worker/0.4/src/ScalaNativeWorkerImpl.scala
@@ -54,7 +54,7 @@ class ScalaNativeWorkerImpl extends mill.scalanativelib.api.ScalaNativeWorkerApi
       logLevel: NativeLogLevel
   ): NativeConfig = {
     val entry = Versions.current match {
-      case "0.4.2" => mainClass + "$"
+      case "0.4.0" | "0.4.1" | "0.4.2" => mainClass + "$"
       case _ => mainClass
     }
     val config =

--- a/scalanativelib/worker/0.4/src/ScalaNativeWorkerImpl.scala
+++ b/scalanativelib/worker/0.4/src/ScalaNativeWorkerImpl.scala
@@ -54,7 +54,7 @@ class ScalaNativeWorkerImpl extends mill.scalanativelib.api.ScalaNativeWorkerApi
       logLevel: NativeLogLevel
   ): NativeConfig = {
     val entry = Versions.current match {
-      case "0.4.0" | "0.4.1" | "0.4.2" => mainClass + "$"
+      case "0.4.2" => mainClass + "$"
       case _ => mainClass
     }
     val config =


### PR DESCRIPTION
# Motivation

- Consistency with `ScalaJSModule`
- Not resolving Scala 2.12 if not needed (imagining a Scala 2.13 only project) could make the build faster
- Not loading a new classloader from scratch and populating it with a brand new scala-library for Scala 2.12 could be faster (I have no data to prove this theory)