### PR TITLE
Explicit handling of scalac plugins and related enablement options

### DIFF
--- a/bsp/src/mill/bsp/MillScalaBuildServer.scala
+++ b/bsp/src/mill/bsp/MillScalaBuildServer.scala
@@ -37,9 +37,7 @@ trait MillScalaBuildServer extends ScalaBuildServer { this: MillBuildServer =>
       ) {
         case (id, m: JavaModule) =>
           val optionsTask = m match {
-            case sm: ScalaModule => T.task {
-                sm.allScalacOptions() ++ sm.scalacPluginClasspath().map(jar => s"-Xplugin:$jar")
-              }
+            case sm: ScalaModule => sm.allScalacOptions
             case _ => T.task { Seq.empty[String] }
           }
 

--- a/build.sc
+++ b/build.sc
@@ -199,11 +199,16 @@ trait MillInternalModule
   def scalaVersion = Deps.scalaVersion
   override def ammoniteVersion = Deps.ammonite.dep.version
 }
+
 trait MillApiModule extends MillInternalModule with MillMimaConfig
 
 trait MillModule extends MillApiModule { outer =>
-  override def scalacPluginClasspath =
+  override def scalacPluginClasspath = T {
     super.scalacPluginClasspath() ++ Seq(main.moduledefs.jar())
+  }
+  override def scalacOptions = T {
+    super.scalacOptions() ++ Seq(s"-Xplugin:${main.moduledefs.jar()}")
+  }
 
   def testArgs = T { Seq.empty[String] }
   def testIvyDeps: T[Agg[Dep]] = Agg(Deps.utest)
@@ -216,8 +221,12 @@ trait MillModule extends MillApiModule { outer =>
       else Seq(outer, main.test)
     override def ivyDeps: T[Agg[Dep]] = outer.testIvyDeps()
     override def testFramework = "mill.UTestFramework"
-    override def scalacPluginClasspath =
+    override def scalacPluginClasspath = T {
       super.scalacPluginClasspath() ++ Seq(main.moduledefs.jar())
+    }
+    override def scalacOptions = T {
+      super.scalacOptions() ++ Seq(s"-Xplugin:${main.moduledefs.jar()}")
+    }
   }
 }
 

--- a/build.sc
+++ b/build.sc
@@ -207,7 +207,7 @@ trait MillModule extends MillApiModule { outer =>
     super.scalacPluginClasspath() ++ Seq(main.moduledefs.jar())
   }
   override def scalacOptions = T {
-    super.scalacOptions() ++ Seq(s"-Xplugin:${main.moduledefs.jar()}")
+    super.scalacOptions() ++ Seq(s"-Xplugin:${main.moduledefs.jar().path}")
   }
 
   def testArgs = T { Seq.empty[String] }
@@ -221,12 +221,6 @@ trait MillModule extends MillApiModule { outer =>
       else Seq(outer, main.test)
     override def ivyDeps: T[Agg[Dep]] = outer.testIvyDeps()
     override def testFramework = "mill.UTestFramework"
-    override def scalacPluginClasspath = T {
-      super.scalacPluginClasspath() ++ Seq(main.moduledefs.jar())
-    }
-    override def scalacOptions = T {
-      super.scalacOptions() ++ Seq(s"-Xplugin:${main.moduledefs.jar()}")
-    }
   }
 }
 

--- a/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
+++ b/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
@@ -173,19 +173,12 @@ class BloopImpl(ev: () => Evaluator, wd: os.Path) extends ExternalModule { outer
     val scalaConfig = module match {
       case s: ScalaModule =>
         T.task {
-          val pluginCp = s.scalacPluginClasspath()
-          val pluginOptions = pluginCp.map { pathRef =>
-            s"-Xplugin:${pathRef.path}"
-          }
-
-          val allScalacOptions =
-            (s.allScalacOptions() ++ pluginOptions).toList
           Some(
             BloopConfig.Scala(
               organization = s.scalaOrganization(),
               name = "scala-compiler",
               version = s.scalaVersion(),
-              options = allScalacOptions,
+              options = s.allScalacOptions().toList,
               jars = s.scalaCompilerClasspath().map(_.path.toNIO).toList,
               analysis = None,
               setup = None

--- a/scalalib/src/ScalaModule.scala
+++ b/scalalib/src/ScalaModule.scala
@@ -3,13 +3,13 @@ package scalalib
 
 import scala.annotation.nowarn
 import mill.define.{Command, Sources, Target, Task}
-import mill.api.{DummyInputStream, Loose, PathRef, Result, internal}
+import mill.api.{DummyInputStream, PathRef, Result, internal}
 import mill.modules.Jvm
 import mill.modules.Jvm.createJar
 import Lib._
 import ch.epfl.scala.bsp4j.{BuildTargetDataKind, ScalaBuildTarget, ScalaPlatform}
 import mill.api.Loose.Agg
-import mill.eval.{Evaluator, EvaluatorPathsResolver}
+import mill.eval.EvaluatorPathsResolver
 import mill.scalalib.api.{CompilationResult, ZincWorkerUtil}
 import mill.scalalib.bsp.{BspBuildTarget, BspModule}
 
@@ -191,7 +191,7 @@ trait ScalaModule extends JavaModule { outer =>
   }
 
   // Keep in sync with [[bspCompileClassesInfo]]
-  override def compile: T[mill.scalalib.api.CompilationResult] = T.persistent {
+  override def compile: T[CompilationResult] = T.persistent {
     val sv = scalaVersion()
     if (sv == "2.12.4") T.log.error(
       """Attention: Zinc is known to not work properly for Scala version 2.12.4.

--- a/scalalib/src/ScalaModule.scala
+++ b/scalalib/src/ScalaModule.scala
@@ -114,7 +114,7 @@ trait ScalaModule extends JavaModule { outer =>
   /**
    * Scalac options to active the compiler plugins for ScalaDoc generation.
    */
-  private def enableScalaDocPluginScalacOption: Target[Seq[String]] = T {
+  private def enableScalaDocPluginScalacOptions: Target[Seq[String]] = T {
     val resolvedJars = resolveDeps(scalaDocPluginIvyDeps.map(_.map(_.exclude("*" -> "*"))))()
     resolvedJars.iterator.map(jar => s"-Xplugin:${jar.path}").toSeq
   }
@@ -141,7 +141,7 @@ trait ScalaModule extends JavaModule { outer =>
           artifactName()
         )
       else Seq()
-    mandatoryScalacOptions() ++ enableScalaDocPluginScalacOption() ++ scalacOptions() ++ defaults
+    mandatoryScalacOptions() ++ enableScalaDocPluginScalacOptions() ++ scalacOptions() ++ defaults
   }
 
   /**

--- a/scalalib/src/ScalaModule.scala
+++ b/scalalib/src/ScalaModule.scala
@@ -105,6 +105,14 @@ trait ScalaModule extends JavaModule { outer =>
   protected def mandatoryScalacOptions = T { Seq.empty[String] }
 
   /**
+   * Scalac options to active the compiler plugins.
+   */
+  protected def enablePluginScalacOption: Target[Seq[String]] = T {
+    val resolvedJars = resolveDeps(scalacPluginIvyDeps.map(_.map(_.exclude("*" -> "*"))))()
+    resolvedJars.iterator.toSeq.map(jar => s"-Xplugin:${jar}")
+  }
+
+  /**
    * Command-line options to pass to the Scala compiler defined by the user.
    * Consumers should use `allScalacOptions` to read them.
    */
@@ -114,7 +122,8 @@ trait ScalaModule extends JavaModule { outer =>
    * Aggregation of all the options passed to the Scala compiler.
    * In most cases, instead of overriding this Target you want to override `scalacOptions` instead.
    */
-  def allScalacOptions = T { mandatoryScalacOptions() ++ scalacOptions() }
+  def allScalacOptions =
+    T { mandatoryScalacOptions() ++ enablePluginScalacOption() ++ scalacOptions() }
 
   def scalaDocOptions: T[Seq[String]] = T {
     val defaults =

--- a/scalalib/src/ScalaModule.scala
+++ b/scalalib/src/ScalaModule.scala
@@ -104,7 +104,7 @@ trait ScalaModule extends JavaModule { outer =>
   protected def mandatoryScalacOptions: Target[Seq[String]] = T { Seq.empty[String] }
 
   /**
-   * Scalac options to active the compiler plugins.
+   * Scalac options to activate the compiler plugins.
    */
   private def enablePluginScalacOptions: Target[Seq[String]] = T {
     val resolvedJars = resolveDeps(scalacPluginIvyDeps.map(_.map(_.exclude("*" -> "*"))))()
@@ -112,7 +112,7 @@ trait ScalaModule extends JavaModule { outer =>
   }
 
   /**
-   * Scalac options to active the compiler plugins for ScalaDoc generation.
+   * Scalac options to activate the compiler plugins for ScalaDoc generation.
    */
   private def enableScalaDocPluginScalacOptions: Target[Seq[String]] = T {
     val resolvedJars = resolveDeps(scalaDocPluginIvyDeps.map(_.map(_.exclude("*" -> "*"))))()

--- a/scalalib/src/ScalaModule.scala
+++ b/scalalib/src/ScalaModule.scala
@@ -91,7 +91,7 @@ trait ScalaModule extends JavaModule { outer =>
     }
 
   /**
-   * Allows you to make use of Scala compiler plugins from maven central
+   * Allows you to make use of Scala compiler plugins.
    */
   def scalacPluginIvyDeps: Target[Agg[Dep]] = T { Agg.empty[Dep] }
 
@@ -112,7 +112,7 @@ trait ScalaModule extends JavaModule { outer =>
   }
 
   /**
-   * Scalac options to active the compiler plugins.
+   * Scalac options to active the compiler plugins for ScalaDoc generation.
    */
   private def enableScalaDocPluginScalacOption: Target[Seq[String]] = T {
     val resolvedJars = resolveDeps(scalaDocPluginIvyDeps.map(_.map(_.exclude("*" -> "*"))))()

--- a/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
+++ b/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
@@ -309,19 +309,19 @@ class ZincWorkerImpl(
       reporter: Option[CompileProblemReporter]
   )(implicit ctx: ZincWorkerApi.Ctx): mill.api.Result[(os.Path, os.Path)] = {
     withCompilers(
-      scalaVersion,
-      scalaOrganization,
-      compilerClasspath,
-      scalacPluginClasspath
+      scalaVersion = scalaVersion,
+      scalaOrganization = scalaOrganization,
+      compilerClasspath = compilerClasspath,
+      scalacPluginClasspath = scalacPluginClasspath
     ) { compilers: Compilers =>
       compileInternal(
-        upstreamCompileOutput,
-        sources,
-        compileClasspath,
-        javacOptions,
-        scalacOptions = scalacPluginClasspath.map(jar => s"-Xplugin:$jar").toSeq ++ scalacOptions,
-        compilers,
-        reporter
+        upstreamCompileOutput = upstreamCompileOutput,
+        sources = sources,
+        compileClasspath = compileClasspath,
+        javacOptions = javacOptions,
+        scalacOptions = scalacOptions,
+        compilers = compilers,
+        reporter = reporter
       )
     }
   }


### PR DESCRIPTION
We no longer generate an enablement option for each transitively resolved plugin jar, but instead, only generated one `-Xplugin:` option for each explicitly given plugin. This will fix previously seen warnings for the scalac compiler.

I took the opportunity to clean things up on the go.
I removed the handling of `-Xplugin:` from the ZincWorker into the ScalaModule.
This fixes the issue that both the BSP server implementation and the Bloop Config exporter needed to handle this on their own.
Now, this is handled in the IMHO right place, is properly shared and still overrideable by the user if the situation calls for it.

I recognized, that we don't support scalac plugin dependencies from in-project modules at the moment, but this can be added later if needed. Previously, it was enough to add the `module.jar()` to the `scalacPluginClassapth`, now it is also required to add the ```s"-Xplugin:{module.jar().path}"``` manually. Not to hard, but a future `scalacPluginModuleDeps` target could make this easier. As this also hits Mills build when we bootstrap our own project, that's why I did that change to `build.sc`.

Fix https://github.com/com-lihaoyi/mill/issues/1690
Fix https://github.com/com-lihaoyi/mill/issues/1691