### PR TITLE
Link Scala.js using Directory path when available

### DIFF
--- a/scalajslib/src/ScalaJSModule.scala
+++ b/scalajslib/src/ScalaJSModule.scala
@@ -134,10 +134,9 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
       moduleKind: ModuleKind,
       esFeatures: ESFeatures
   )(implicit ctx: Ctx): Result[PathRef] = {
-    val outputPath = ctx.dest / "out.js"
+    val outputPath = ctx.dest
 
     os.makeDir.all(ctx.dest)
-    os.remove.all(outputPath)
 
     val classpath = runClasspath.map(_.path)
     val sjsirFiles = classpath

--- a/scalajslib/test/resources/top-level-exports/src/App.scala
+++ b/scalajslib/test/resources/top-level-exports/src/App.scala
@@ -1,0 +1,26 @@
+package my.app
+
+import scala.collection.mutable
+import scala.scalajs.js.annotation._
+
+object AppA {
+  @JSExportTopLevel(name = "start", moduleID = "a")
+  def a(): Unit = println("hello from a")
+}
+
+object AppB {
+  private val x = mutable.Set.empty[String]
+
+  @JSExportTopLevel(name = "start", moduleID = "b")
+  def b(): Unit = {
+    println("hello from b")
+    println(x)
+  }
+
+  def main(): Unit = x.add("something")
+}
+object App {
+  def main(args: Array[String]): Unit = {
+    println("Hello")
+  }
+}

--- a/scalajslib/test/src/TopLevelExportsTests.scala
+++ b/scalajslib/test/src/TopLevelExportsTests.scala
@@ -1,0 +1,49 @@
+package mill.scalajslib
+
+import mill._
+import mill.define.Discover
+import mill.scalajslib.api._
+import mill.util.{TestEvaluator, TestUtil}
+import utest._
+
+object TopLevelExportsTests extends TestSuite {
+  val workspacePath = TestUtil.getOutPathStatic() / "top-level-exports"
+
+  object TopLevelExportsModule extends TestUtil.BaseModule {
+
+    object topLevelExportsModule extends ScalaJSModule {
+      override def millSourcePath = workspacePath
+      override def scalaVersion = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
+      override def scalaJSVersion = "1.8.0"
+      override def moduleKind = ModuleKind.ESModule
+    }
+
+    override lazy val millDiscover = Discover[this.type]
+  }
+
+  val millSourcePath = os.pwd / "scalajslib" / "test" / "resources" / "top-level-exports"
+
+  val evaluator = TestEvaluator.static(TopLevelExportsModule)
+
+  val tests: Tests = Tests {
+    prepareWorkspace()
+
+    test("top level exports") {
+      println(evaluator(TopLevelExportsModule.topLevelExportsModule.sources))
+      val Right((PathRef(outFile, _, _), _)) =
+        evaluator(TopLevelExportsModule.topLevelExportsModule.fastOpt)
+      assert(os.exists(outFile))
+      assert(os.exists(outFile / os.up / "a.js"))
+      assert(os.exists(outFile / os.up / "a.js.map"))
+      assert(os.exists(outFile / os.up / "b.js"))
+      assert(os.exists(outFile / os.up / "b.js.map"))
+    }
+  }
+
+  def prepareWorkspace(): Unit = {
+    os.remove.all(workspacePath)
+    os.makeDir.all(workspacePath / os.up)
+    os.copy(millSourcePath, workspacePath)
+  }
+
+}

--- a/scalajslib/worker/0.6/src/ScalaJSWorkerImpl.scala
+++ b/scalajslib/worker/0.6/src/ScalaJSWorkerImpl.scala
@@ -72,7 +72,7 @@ class ScalaJSWorkerImpl extends mill.scalajslib.api.ScalaJSWorkerApi {
   def link(
       sources: Array[File],
       libraries: Array[File],
-      dest: File,
+      destDir: File,
       main: String,
       testBridgeInit: Boolean, // ignored in 0.6
       fullOpt: Boolean,
@@ -84,6 +84,7 @@ class ScalaJSWorkerImpl extends mill.scalajslib.api.ScalaJSWorkerApi {
     val jars =
       libraries.map(jar => IRContainer.Jar(new FileVirtualBinaryFile(jar) with VirtualJarFile))
     val jarSJSIRs = jars.flatMap(_.jar.sjsirFiles)
+    val dest = new File(destDir, "out.js")
     val destFile = AtomicWritableFileVirtualJSFile(dest)
     val logger = new ScalaConsoleLogger
     val initializer = Option(main).map { cls => ModuleInitializer.mainMethodWithArgs(cls, "main") }


### PR DESCRIPTION
This doesn't change any API but makes the Scala.js emit top level
exports.

## Motivation

Thinking about APIs is hard, so I tried to make the process of support the new `faskLinkJS` a two step approach. For now I migrated only the implementation to the new api using `DirectoryOutputPath` (in Scala. js 1.3+ only) but maintaed the `out.js` output path. It doesn't fail anymore if you try to export a module from the Scala.js code. At the same time it is not optimal since the ausiliary files are not returned by the `fastOpt` task, so are not considered for the tasks cache purposes.