### PR TITLE
Fixed Version handling of short versions and made API public

### DIFF
--- a/scalalib/src/dependency/versions/Version.scala
+++ b/scalalib/src/dependency/versions/Version.scala
@@ -47,9 +47,9 @@ case class ValidVersion(
 ) extends Version {
   def major: Long = releasePart.headOption getOrElse 0
 
-  def minor: Long = releasePart.drop(1).headOption getOrElse 1
+  def minor: Long = releasePart.drop(1).headOption getOrElse 0
 
-  def patch: Long = releasePart.drop(2).headOption getOrElse 1
+  def patch: Long = releasePart.drop(2).headOption getOrElse 0
 
   override def toString: String = text
 }
@@ -117,7 +117,7 @@ private[dependency] object BuildVersion {
   }
 }
 
-private[dependency] object Version {
+object Version {
   def apply(text: String): Version = synchronized {
     VersionParser
       .parse(text)

--- a/scalalib/test/src/dependency/versions/VersionTests.scala
+++ b/scalalib/test/src/dependency/versions/VersionTests.scala
@@ -31,11 +31,13 @@ package mill.scalalib.dependency.versions
 import utest._
 import fastparse.Parsed
 
+import scala.util.chaining.scalaUtilChainingOps
+
 object VersionTests extends TestSuite {
 
   val tests = Tests {
-    'versionsClassification - {
-      'ReleaseVersion - {
+    "versionsClassification" - {
+      "ReleaseVersion" - {
         List("1.0.0", "1.0.0.Final", "1.0.0-FINAL", "1.0.0.RELEASE") foreach {
           rel =>
             assertMatch(Version(rel)) {
@@ -43,24 +45,36 @@ object VersionTests extends TestSuite {
             }
         }
       }
-      'PreReleaseVersion - {
+      "PreReleaseVersion" - {
         assertMatch(Version("1.0.0-alpha.1")) {
           case PreReleaseVersion(List(1, 0, 0), List("alpha", "1")) =>
         }
       }
-      'PreReleaseBuildVersion - {
+      "PreReleaseBuildVersion" - {
         assertMatch(Version("1.0.0-alpha.1+build.10")) {
           case PreReleaseBuildVersion(List(1, 0, 0), List("alpha", "1"), List("build", "10")) =>
         }
       }
-      'BuildVersion - {
+      "BuildVersion" - {
         assertMatch(Version("1.0.0+build.10")) {
           case BuildVersion(List(1, 0, 0), List("build", "10")) =>
         }
       }
     }
 
-    'semverVersionsOrdering - {
+    "short version defaults" - {
+      "1" - Version("1").tap { v =>
+        assert(v.major == 1, v.minor == 0, v.patch == 0)
+      }
+      "1.0" - Version("1.0").tap { v =>
+        assert(v.major == 1, v.minor == 0, v.patch == 0)
+      }
+      "1.1" - Version("1.1").tap { v =>
+        assert(v.major == 1, v.minor == 1, v.patch == 0)
+      }
+    }
+
+    "semverVersionsOrdering" - {
       import scala.Ordered._
 
       val v = List(
@@ -93,40 +107,40 @@ object VersionTests extends TestSuite {
       }
     }
 
-    'parser - {
+    "parser" - {
 
-      Symbol("parse 1.0.5") - {
+      "parse 1.0.5" - {
         assertMatch(VersionParser.parse("1.0.5")) {
           case Parsed.Success((Seq(1, 0, 5), Seq(), Seq()), _) =>
         }
       }
 
-      Symbol("parse 1.0.M3") - {
+      "parse 1.0.M3" - {
         assertMatch(VersionParser.parse("1.0.M3")) {
           case Parsed.Success((Seq(1, 0), Seq("M3"), Seq()), _) =>
         }
       }
-      Symbol("parse 1.0.3m") - {
+      "parse 1.0.3m" - {
         assertMatch(VersionParser.parse("1.0.3m")) {
           case Parsed.Success((Seq(1, 0), Seq("3m"), Seq()), _) =>
         }
       }
-      Symbol("parse 1.0.3m.4") - {
+      "parse 1.0.3m.4" - {
         assertMatch(VersionParser.parse("1.0.3m.4")) {
           case Parsed.Success((Seq(1, 0), Seq("3m", "4"), Seq()), _) =>
         }
       }
-      Symbol("parse  9.1-901-1.jdbc4") - {
+      "parse  9.1-901-1.jdbc4" - {
         assertMatch(VersionParser.parse("9.1-901-1.jdbc4")) {
           case Parsed.Success((Seq(9, 1), Seq("901", "1", "jdbc4"), Seq()), _) =>
         }
       }
-      Symbol("parse 1.33.7+build/11.e0f985a") - {
+      "parse 1.33.7+build/11.e0f985a" - {
         assertMatch(VersionParser.parse("1.33.7+build/11.e0f985a")) {
           case Parsed.Success((Seq(1, 33, 7), Seq(), Seq("build/11", "e0f985a")), _) =>
         }
       }
-      Symbol("parse 9.1-901-1.jdbc4+build/11.e0f985a") - {
+      "parse 9.1-901-1.jdbc4+build/11.e0f985a" - {
         assertMatch(VersionParser.parse("9.1-901-1.jdbc4+build/11.e0f985a")) {
           case Parsed.Success(
                 (Seq(9, 1), Seq("901", "1", "jdbc4"), Seq("build/11", "e0f985a")),


### PR DESCRIPTION
This is in preparation to use Version in various module to make version checks without reinventing regexes over and over.
