### PR TITLE
Fix withDottyCompat in Scala Native

### DIFF
--- a/scalalib/src/JavaModule.scala
+++ b/scalalib/src/JavaModule.scala
@@ -174,6 +174,7 @@ trait JavaModule
    * This is calculated from [[ivyDeps]], [[mandatoryIvyDeps]] and recursively from [[moduleDeps]].
    */
   def transitiveIvyDeps: T[Agg[Dep]] = T {
+    // NOTE: If you update this, reflect the changes in ScalaNativeModule
     ivyDeps() ++ mandatoryIvyDeps() ++ T.traverse(moduleDeps)(_.transitiveIvyDeps)().flatten
   }
 

--- a/scalanativelib/src/ScalaNativeModule.scala
+++ b/scalanativelib/src/ScalaNativeModule.scala
@@ -228,7 +228,8 @@ trait ScalaNativeModule extends ScalaModule { outer =>
   }
 
   override def transitiveIvyDeps: T[Agg[Dep]] = T {
-    super.transitiveIvyDeps().map { dep =>
+    // TODO when in bin-compat breaking window: Change list to `super.transitiveIvyDeps()`
+    (ivyDeps() ++ mandatoryIvyDeps() ++ T.traverse(moduleDeps)(_.transitiveIvyDeps)().flatten).map { dep =>
       // Exclude cross published version dependencies leading to conflicts in Scala 3 vs 2.13
       // When using Scala 3 exclude Scala 2.13 standard native libraries,
       // when using Scala 2.13 exclude Scala 3 standard native libraries

--- a/scalanativelib/src/ScalaNativeModule.scala
+++ b/scalanativelib/src/ScalaNativeModule.scala
@@ -51,10 +51,8 @@ trait ScalaNativeModule extends ScalaModule { outer =>
   def scalaNativeWorkerClasspath = T {
     val workerScalaBinaryVersion = scalaBinaryVersion(scalaNativeWorkerScalaVersion())
     val workerKey =
-      s"MILL_SCALANATIVE_WORKER_${scalaNativeWorkerVersion()}_$workerScalaBinaryVersion".replace(
-        '.',
-        '_'
-      )
+      s"MILL_SCALANATIVE_WORKER_${scalaNativeWorkerVersion()}_$workerScalaBinaryVersion"
+        .replace('.', '_')
     mill.modules.Util.millProjectModule(
       workerKey,
       s"mill-scalanativelib-worker-${scalaNativeWorkerVersion()}",
@@ -227,6 +225,32 @@ trait ScalaNativeModule extends ScalaModule { outer =>
         scalaCompilerClasspath().map(_.path.toNIO.toUri.toString).iterator.toSeq.asJava
       )
     ))
+  }
+
+  override def transitiveIvyDeps: T[Agg[Dep]] = T {
+    super.transitiveIvyDeps().map { dep =>
+      // Exclude cross published version dependencies leading to conflicts in Scala 3 vs 2.13
+      // When using Scala 3 exclude Scala 2.13 standard native libraries,
+      // when using Scala 2.13 exclude Scala 3 standard native libraries
+      // Use full name, Maven style published artifacts cannot use artifact/cross version for exclusion rules
+      val nativeStandardLibraries =
+        Seq("nativelib", "clib", "posixlib", "windowslib", "javalib", "auxlib")
+
+      val scalaBinaryVersionToExclude = artifactScalaVersion() match {
+        case "3" => "2.13" :: Nil
+        case "2.13" => "3" :: Nil
+        case _ => Nil
+      }
+
+      val nativeSuffix = platformSuffix()
+
+      val exclusions = scalaBinaryVersionToExclude.flatMap { scalaBinVersion =>
+        nativeStandardLibraries.map(library =>
+          "org.scala-native" -> s"$library${nativeSuffix}_$scalaBinVersion"
+        )
+      }
+      dep.exclude(exclusions: _*)
+    }
   }
 }
 

--- a/scalanativelib/test/src/ExclusionsTests.scala
+++ b/scalanativelib/test/src/ExclusionsTests.scala
@@ -1,0 +1,49 @@
+package mill.scalanativelib
+
+import mill.Agg
+import mill.scalalib._
+import mill.define.Discover
+import mill.scalanativelib.api._
+import mill.util.{TestEvaluator, TestUtil}
+import utest._
+
+object ExclusionsTests extends TestSuite {
+  object Exclusions extends TestUtil.BaseModule {
+    object scala213 extends ScalaNativeModule {
+      def scalaNativeVersion = "0.4.3"
+      def scalaVersion = "2.13.8"
+      override def ivyDeps = super.ivyDeps() ++ Agg(
+        ivy"com.github.scopt:scopt_native0.4_3:4.0.1"
+      )
+    }
+    object scala3 extends ScalaNativeModule {
+      def scalaNativeVersion = "0.4.3"
+      def scalaVersion = "3.1.1"
+      override def ivyDeps = super.ivyDeps() ++ Agg(
+        ivy"com.github.scopt:scopt_native0.4_2.13:4.0.1"
+      )
+    }
+    override lazy val millDiscover: Discover[Exclusions.this.type] = Discover[this.type]
+  }
+
+  val exclusionsEvaluator = TestEvaluator.static(Exclusions)
+
+  val tests: Tests = Tests {
+    test("scala3 scala native libraries are excluded in Scala 2.13") {
+      val Right((result, evalCount)) = exclusionsEvaluator(Exclusions.scala213.resolvedIvyDeps)
+      val jars = result.map(_.path.last).toSet
+      assert(jars.contains("nativelib_native0.4_2.13-0.4.3.jar"))
+      assert(!jars.contains("nativelib_native0.4_3-0.4.3.jar"))
+      assert(jars.contains("clib_native0.4_2.13-0.4.3.jar"))
+      assert(!jars.contains("clib_native0.4_3-0.4.3.jar"))
+    }
+    test("scala2.13 scala native libraries are excluded in Scala 3") {
+      val Right((result, evalCount)) = exclusionsEvaluator(Exclusions.scala3.resolvedIvyDeps)
+      val jars = result.map(_.path.last).toSet
+      assert(jars.contains("nativelib_native0.4_3-0.4.3.jar"))
+      assert(!jars.contains("nativelib_native0.4_2.13-0.4.3.jar"))
+      assert(jars.contains("clib_native0.4_3-0.4.3.jar"))
+      assert(!jars.contains("clib_native0.4_2.13-0.4.3.jar"))
+    }
+  }
+}


### PR DESCRIPTION
Port of the workaround Scala Native is doing for Sbt in this PR: https://github.com/scala-native/scala-native/pull/2553