### PR TITLE
Make Evaluator and EvaluatorState normal classes

### DIFF
--- a/bsp/src/mill/bsp/BSP.scala
+++ b/bsp/src/mill/bsp/BSP.scala
@@ -122,19 +122,7 @@ object BSP extends ExternalModule {
       canReload: Boolean,
       serverHandle: Option[Promise[BspServerHandle]] = None
   ) = {
-    val evaluator = initialEvaluator.map { ev =>
-      new Evaluator(
-        ev.home,
-        ev.outPath,
-        ev.externalOutPath,
-        ev.rootModule,
-        ev.baseLogger,
-        ev.classLoaderSig,
-        ev.workerCache,
-        ev.env,
-        false
-      )
-    }
+    val evaluator = initialEvaluator.map(_.withFailFast(false))
 
     val millServer =
       new MillBuildServer(

--- a/main/core/src/mill/eval/Evaluator.scala
+++ b/main/core/src/mill/eval/Evaluator.scala
@@ -33,31 +33,50 @@ case class Labelled[T](task: NamedTask[T], segments: Segments) {
 
 /**
  * Evaluate tasks.
- * @param home
- * @param outPath The output base path.
- * @param externalOutPath The output base path to use for external modules.
- * @param rootModule The projects root module.
- * @param baseLogger
- * @param classLoaderSig
- * @param workerCache Mutable worker cache.
- * @param env
- * @param failFast If `true` the first failing task will fail the evaluation.
- *                 If `false`, it tries to evaluate all tasks, running longer and reporting possibly more than one failure.
- * @param threadCount If a [[Some]] the explicit number of threads to use for parallel task evaluation,
- *                    or [[None]] to use n threads where n is the number of available logical processors.
  */
-case class Evaluator(
-    home: os.Path,
-    outPath: os.Path,
-    externalOutPath: os.Path,
-    rootModule: mill.define.BaseModule,
-    baseLogger: ColorLogger,
-    classLoaderSig: Seq[(Either[String, java.net.URL], Long)] = Evaluator.classLoaderSig,
-    workerCache: mutable.Map[Segments, (Int, Any)] = mutable.Map.empty,
-    env: Map[String, String] = Evaluator.defaultEnv,
-    failFast: Boolean = true,
-    threadCount: Option[Int] = Some(1)
-) {
+class Evaluator @deprecated(message = "Use apply instead", since = "0.10.1") (
+    _home: os.Path,
+    _outPath: os.Path,
+    _externalOutPath: os.Path,
+    _rootModule: mill.define.BaseModule,
+    _baseLogger: ColorLogger,
+    _classLoaderSig: Seq[(Either[String, java.net.URL], Long)] = Evaluator.classLoaderSig,
+    _workerCache: mutable.Map[Segments, (Int, Any)] = mutable.Map.empty,
+    _env: Map[String, String] = Evaluator.defaultEnv,
+    _failFast: Boolean = true,
+    _threadCount: Option[Int] = Some(1)
+) extends Product with Serializable { // TODO: Remove extends Product with Serializable before 0.11.0
+
+  def home: os.Path = _home
+  /**
+   * The output base path.
+   */
+  def outPath: os.Path = _outPath
+  /**
+   * The output base path to use for external modules.
+   */
+  def externalOutPath: os.Path = _externalOutPath
+  /**
+   * The projects root module.
+   */
+  def rootModule: mill.define.BaseModule = _rootModule
+  def baseLogger: ColorLogger = _baseLogger
+  def classLoaderSig: Seq[(Either[String, java.net.URL], Long)] = _classLoaderSig
+  /**
+   * Mutable worker cache.
+   */
+  def workerCache: mutable.Map[Segments, (Int, Any)] = _workerCache
+  def env: Map[String, String] = _env
+  /**
+   * If `true` the first failing task will fail the evaluation.
+   * If `false`, it tries to evaluate all tasks, running longer and reporting possibly more than one failure.
+   */
+  def failFast: Boolean = _failFast
+  /**
+   * If a [[Some]] the explicit number of threads to use for parallel task evaluation,
+   * or [[None]] to use n threads where n is the number of available logical processors.
+   */
+  def threadCount: Option[Int] = _threadCount
 
   val effectiveThreadCount: Int =
     this.threadCount.getOrElse(Runtime.getRuntime().availableProcessors())
@@ -590,6 +609,105 @@ case class Evaluator(
       msgParts.mkString
   }
 
+  @deprecated("Use withX methods instead", since = "0.10.0")
+  def copy(
+      home: os.Path = this.home,
+      outPath: os.Path = this.outPath,
+      externalOutPath: os.Path = this.externalOutPath,
+      rootModule: mill.define.BaseModule = this.rootModule,
+      baseLogger: ColorLogger = this.baseLogger,
+      classLoaderSig: Seq[(Either[String, java.net.URL], Long)] = this.classLoaderSig,
+      workerCache: mutable.Map[Segments, (Int, Any)] = this.workerCache,
+      env: Map[String, String] = this.env,
+      failFast: Boolean = this.failFast,
+      threadCount: Option[Int] = this.threadCount
+  ): Evaluator = new Evaluator(
+    home,
+    outPath,
+    externalOutPath,
+    rootModule,
+    baseLogger,
+    classLoaderSig,
+    workerCache,
+    env,
+    failFast,
+    threadCount
+  )
+
+  override def toString(): String = {
+    s"""Evaluator(
+       |  home = $home,
+       |  outPath = $outPath,
+       |  externalOutPath = $externalOutPath,
+       |  rootModule = $rootModule,
+       |  baseLogger = $baseLogger,
+       |  classLoaderSig = $classLoaderSig,
+       |  workerCache = $workerCache,
+       |  env = $env,
+       |  failFast = $failFast,
+       |  threadCount = $threadCount
+       |)""".stripMargin
+  }
+
+  // Rename to copy once the other copy is gone (before 0.11.0)
+  private def myCopy(
+      home: os.Path = this.home,
+      outPath: os.Path = this.outPath,
+      externalOutPath: os.Path = this.externalOutPath,
+      rootModule: mill.define.BaseModule = this.rootModule,
+      baseLogger: ColorLogger = this.baseLogger,
+      classLoaderSig: Seq[(Either[String, java.net.URL], Long)] = this.classLoaderSig,
+      workerCache: mutable.Map[Segments, (Int, Any)] = this.workerCache,
+      env: Map[String, String] = this.env,
+      failFast: Boolean = this.failFast,
+      threadCount: Option[Int] = this.threadCount
+  ): Evaluator = new Evaluator(
+    home,
+    outPath,
+    externalOutPath,
+    rootModule,
+    baseLogger,
+    classLoaderSig,
+    workerCache,
+    env,
+    failFast,
+    threadCount
+  )
+
+  def withHome(home: os.Path): Evaluator = myCopy(home = home)
+  def withOutPath(outPath: os.Path): Evaluator = myCopy(outPath = outPath)
+  def withExternalOutPath(externalOutPath: os.Path): Evaluator =
+    myCopy(externalOutPath = externalOutPath)
+  def withRootModule(rootModule: mill.define.BaseModule): Evaluator =
+    myCopy(rootModule = rootModule)
+  def withBaseLogger(baseLogger: ColorLogger): Evaluator = myCopy(baseLogger = baseLogger)
+  def withClassLoaderSig(classLoaderSig: Seq[(Either[String, java.net.URL], Long)]): Evaluator =
+    myCopy(classLoaderSig = classLoaderSig)
+  def withWorkerCache(workerCache: mutable.Map[Segments, (Int, Any)]): Evaluator =
+    myCopy(workerCache = workerCache)
+  def withEnv(env: Map[String, String]): Evaluator = myCopy(env = env)
+  def withFailFast(failFast: Boolean): Evaluator = myCopy(failFast = failFast)
+  def withThreadCount(threadCount: Option[Int]): Evaluator = myCopy(threadCount = threadCount)
+
+  @deprecated(message = "Binary compatibility shim. To be removed", since = "0.10.1")
+  def canEqual(that: Any): Boolean = that.isInstanceOf[Evaluator]
+  @deprecated(message = "Binary compatibility shim. To be removed", since = "0.10.1")
+  def productArity: Int = 10
+  @deprecated(message = "Binary compatibility shim. To be removed", since = "0.10.1")
+  def productElement(n: Int): Any = n match {
+    case 0 => home
+    case 1 => outPath
+    case 2 => externalOutPath
+    case 3 => rootModule
+    case 4 => baseLogger
+    case 5 => classLoaderSig
+    case 6 => workerCache
+    case 7 => env
+    case 8 => failFast
+    case 9 => threadCount
+    case _ => throw new IndexOutOfBoundsException(n.toString)
+  }
+
 }
 
 object Evaluator {
@@ -792,4 +910,68 @@ object Evaluator {
   }
 
   private val dynamicTickerPrefix = new DynamicVariable("")
+
+  def apply(
+      home: os.Path,
+      outPath: os.Path,
+      externalOutPath: os.Path,
+      rootModule: mill.define.BaseModule,
+      baseLogger: ColorLogger
+  ): Evaluator = new Evaluator(
+    home,
+    outPath,
+    externalOutPath,
+    rootModule,
+    baseLogger
+  )
+
+  @deprecated(message = "Use other apply and withX methods instead", since = "0.10.1")
+  def apply(
+      home: os.Path,
+      outPath: os.Path,
+      externalOutPath: os.Path,
+      rootModule: mill.define.BaseModule,
+      baseLogger: ColorLogger,
+      classLoaderSig: Seq[(Either[String, java.net.URL], Long)] = Evaluator.classLoaderSig,
+      workerCache: mutable.Map[Segments, (Int, Any)] = mutable.Map.empty,
+      env: Map[String, String] = Evaluator.defaultEnv,
+      failFast: Boolean = true,
+      threadCount: Option[Int] = Some(1)
+  ): Evaluator = new Evaluator(
+    home,
+    outPath,
+    externalOutPath,
+    rootModule,
+    baseLogger,
+    classLoaderSig,
+    workerCache,
+    env,
+    failFast,
+    threadCount
+  )
+
+  @deprecated(message = "Pattern matching not supported with EvaluatorState", since = "0.10.0")
+  def unapply(evaluator: Evaluator): Option[(
+      os.Path,
+      os.Path,
+      os.Path,
+      mill.define.BaseModule,
+      ColorLogger,
+      Seq[(Either[String, java.net.URL], Long)],
+      mutable.Map[Segments, (Int, Any)],
+      Map[String, String],
+      Boolean,
+      Option[Int]
+  )] = Some((
+    evaluator.home,
+    evaluator.outPath,
+    evaluator.externalOutPath,
+    evaluator.rootModule,
+    evaluator.baseLogger,
+    evaluator.classLoaderSig,
+    evaluator.workerCache,
+    evaluator.env,
+    evaluator.failFast,
+    evaluator.threadCount
+  ))
 }

--- a/main/core/src/mill/eval/Evaluator.scala
+++ b/main/core/src/mill/eval/Evaluator.scala
@@ -34,7 +34,7 @@ case class Labelled[T](task: NamedTask[T], segments: Segments) {
 /**
  * Evaluate tasks.
  */
-class Evaluator @deprecated(message = "Use apply instead", since = "0.10.1") (
+class Evaluator @deprecated(message = "Use apply instead", since = "mill 0.10.1") (
     _home: os.Path,
     _outPath: os.Path,
     _externalOutPath: os.Path,
@@ -48,30 +48,36 @@ class Evaluator @deprecated(message = "Use apply instead", since = "0.10.1") (
 ) extends Product with Serializable { // TODO: Remove extends Product with Serializable before 0.11.0
 
   def home: os.Path = _home
+
   /**
    * The output base path.
    */
   def outPath: os.Path = _outPath
+
   /**
    * The output base path to use for external modules.
    */
   def externalOutPath: os.Path = _externalOutPath
+
   /**
    * The projects root module.
    */
   def rootModule: mill.define.BaseModule = _rootModule
   def baseLogger: ColorLogger = _baseLogger
   def classLoaderSig: Seq[(Either[String, java.net.URL], Long)] = _classLoaderSig
+
   /**
    * Mutable worker cache.
    */
   def workerCache: mutable.Map[Segments, (Int, Any)] = _workerCache
   def env: Map[String, String] = _env
+
   /**
    * If `true` the first failing task will fail the evaluation.
    * If `false`, it tries to evaluate all tasks, running longer and reporting possibly more than one failure.
    */
   def failFast: Boolean = _failFast
+
   /**
    * If a [[Some]] the explicit number of threads to use for parallel task evaluation,
    * or [[None]] to use n threads where n is the number of available logical processors.
@@ -689,11 +695,11 @@ class Evaluator @deprecated(message = "Use apply instead", since = "0.10.1") (
   def withFailFast(failFast: Boolean): Evaluator = myCopy(failFast = failFast)
   def withThreadCount(threadCount: Option[Int]): Evaluator = myCopy(threadCount = threadCount)
 
-  @deprecated(message = "Binary compatibility shim. To be removed", since = "0.10.1")
+  @deprecated(message = "Binary compatibility shim. To be removed", since = "mill 0.10.1")
   def canEqual(that: Any): Boolean = that.isInstanceOf[Evaluator]
-  @deprecated(message = "Binary compatibility shim. To be removed", since = "0.10.1")
+  @deprecated(message = "Binary compatibility shim. To be removed", since = "mill 0.10.1")
   def productArity: Int = 10
-  @deprecated(message = "Binary compatibility shim. To be removed", since = "0.10.1")
+  @deprecated(message = "Binary compatibility shim. To be removed", since = "mill 0.10.1")
   def productElement(n: Int): Any = n match {
     case 0 => home
     case 1 => outPath
@@ -925,7 +931,7 @@ object Evaluator {
     baseLogger
   )
 
-  @deprecated(message = "Use other apply and withX methods instead", since = "0.10.1")
+  @deprecated(message = "Use other apply and withX methods instead", since = "mill 0.10.1")
   def apply(
       home: os.Path,
       outPath: os.Path,

--- a/main/src/mill/main/EvaluatorState.scala
+++ b/main/src/mill/main/EvaluatorState.scala
@@ -5,7 +5,7 @@ import scala.collection.mutable
 import mill.define.Segments
 
 // TODO: Remove extends Product with Serializable before 0.11.0
-class EvaluatorState @deprecated(since = "0.10.1") private[main] (
+class EvaluatorState @deprecated(message = "Use apply instead", since = "0.10.1") private[main] (
     _rootModule: mill.define.BaseModule,
     _classLoaderSig: Seq[(Either[String, java.net.URL], Long)],
     _workerCache: mutable.Map[Segments, (Int, Any)],

--- a/main/src/mill/main/EvaluatorState.scala
+++ b/main/src/mill/main/EvaluatorState.scala
@@ -4,10 +4,100 @@ import scala.collection.mutable
 
 import mill.define.Segments
 
-case class EvaluatorState private[main] (
-    rootModule: mill.define.BaseModule,
-    classLoaderSig: Seq[(Either[String, java.net.URL], Long)],
-    workerCache: mutable.Map[Segments, (Int, Any)],
-    watched: Seq[(ammonite.interp.Watchable, Long)],
-    setSystemProperties: Set[String]
-)
+// TODO: Remove extends Product with Serializable before 0.11.0
+class EvaluatorState @deprecated(since = "0.10.1") private[main] (
+    _rootModule: mill.define.BaseModule,
+    _classLoaderSig: Seq[(Either[String, java.net.URL], Long)],
+    _workerCache: mutable.Map[Segments, (Int, Any)],
+    _watched: Seq[(ammonite.interp.Watchable, Long)],
+    _setSystemProperties: Set[String]
+) extends Product with Serializable {
+
+  def rootModule: mill.define.BaseModule = _rootModule
+  def classLoaderSig: Seq[(Either[String, java.net.URL], Long)] = _classLoaderSig
+  def workerCache: mutable.Map[Segments, (Int, Any)] = _workerCache
+  def watched: Seq[(ammonite.interp.Watchable, Long)] = _watched
+  def setSystemProperties: Set[String] = _setSystemProperties
+
+  override def toString(): String = {
+    s"""EvaluatorState(
+       |  rootModule = $rootModule,
+       |  classLoaderSig = $classLoaderSig,
+       |  workerCache = $workerCache,
+       |  watched = $watched,
+       |  setSystemProperties = $setSystemProperties
+       |)""".stripMargin
+  }
+  @deprecated(message = "Binary compatibility shim. To be removed", since = "0.10.1")
+  def canEqual(that: Any): Boolean = that.isInstanceOf[EvaluatorState]
+  @deprecated(message = "Binary compatibility shim. To be removed", since = "0.10.1")
+  def productArity: Int = 6
+  @deprecated(message = "Binary compatibility shim. To be removed", since = "0.10.1")
+  def productElement(n: Int): Any = n match {
+    case 0 => rootModule
+    case 1 => classLoaderSig
+    case 2 => workerCache
+    case 3 => watched
+    case 4 => setSystemProperties
+    case _ => throw new IndexOutOfBoundsException(n.toString)
+  }
+  @deprecated("Construct a new instance with apply instead", since = "0.10.1")
+  def copy(
+      rootModule: mill.define.BaseModule = this.rootModule,
+      classLoaderSig: Seq[(Either[String, java.net.URL], Long)] = this.classLoaderSig,
+      workerCache: mutable.Map[Segments, (Int, Any)] = this.workerCache,
+      watched: Seq[(ammonite.interp.Watchable, Long)] = this.watched,
+      setSystemProperties: Set[String] = this.setSystemProperties
+  ): EvaluatorState = new EvaluatorState(
+    rootModule,
+    classLoaderSig,
+    workerCache,
+    watched,
+    setSystemProperties
+  )
+}
+// TODO: Remove the extends runtime.AbstractFunction5[...] before 0.11.0
+object EvaluatorState extends runtime.AbstractFunction5[mill.define.BaseModule, Seq[(
+        Either[String, java.net.URL],
+        Long
+    )], mutable.Map[Segments, (Int, Any)], Seq[(
+        ammonite.interp.Watchable,
+        Long
+    )], Set[String], EvaluatorState] {
+
+  def apply(
+      rootModule: mill.define.BaseModule,
+      classLoaderSig: Seq[(Either[String, java.net.URL], Long)],
+      workerCache: mutable.Map[Segments, (Int, Any)],
+      watched: Seq[(ammonite.interp.Watchable, Long)],
+      setSystemProperties: Set[String]
+  ): EvaluatorState = new EvaluatorState(
+    rootModule,
+    classLoaderSig,
+    workerCache,
+    watched,
+    setSystemProperties
+  )
+
+  @deprecated(message = "Pattern matching not supported with EvaluatorState", since = "0.10.1")
+  def unapply(evaluatorState: EvaluatorState): Option[(
+      mill.define.BaseModule,
+      Seq[(
+          Either[String, java.net.URL],
+          Long
+      )],
+      mutable.Map[Segments, (Int, Any)],
+      Seq[(
+          ammonite.interp.Watchable,
+          Long
+      )],
+      Set[String]
+  )] =
+    Some((
+      evaluatorState.rootModule,
+      evaluatorState.classLoaderSig,
+      evaluatorState.workerCache,
+      evaluatorState.watched,
+      evaluatorState.setSystemProperties
+    ))
+}

--- a/main/src/mill/main/EvaluatorState.scala
+++ b/main/src/mill/main/EvaluatorState.scala
@@ -5,7 +5,10 @@ import scala.collection.mutable
 import mill.define.Segments
 
 // TODO: Remove extends Product with Serializable before 0.11.0
-class EvaluatorState @deprecated(message = "Use apply instead", since = "0.10.1") private[main] (
+class EvaluatorState @deprecated(
+  message = "Use apply instead",
+  since = "mill 0.10.1"
+) private[main] (
     _rootModule: mill.define.BaseModule,
     _classLoaderSig: Seq[(Either[String, java.net.URL], Long)],
     _workerCache: mutable.Map[Segments, (Int, Any)],
@@ -28,11 +31,11 @@ class EvaluatorState @deprecated(message = "Use apply instead", since = "0.10.1"
        |  setSystemProperties = $setSystemProperties
        |)""".stripMargin
   }
-  @deprecated(message = "Binary compatibility shim. To be removed", since = "0.10.1")
+  @deprecated(message = "Binary compatibility shim. To be removed", since = "mill 0.10.1")
   def canEqual(that: Any): Boolean = that.isInstanceOf[EvaluatorState]
-  @deprecated(message = "Binary compatibility shim. To be removed", since = "0.10.1")
+  @deprecated(message = "Binary compatibility shim. To be removed", since = "mill 0.10.1")
   def productArity: Int = 6
-  @deprecated(message = "Binary compatibility shim. To be removed", since = "0.10.1")
+  @deprecated(message = "Binary compatibility shim. To be removed", since = "mill 0.10.1")
   def productElement(n: Int): Any = n match {
     case 0 => rootModule
     case 1 => classLoaderSig
@@ -41,7 +44,7 @@ class EvaluatorState @deprecated(message = "Use apply instead", since = "0.10.1"
     case 4 => setSystemProperties
     case _ => throw new IndexOutOfBoundsException(n.toString)
   }
-  @deprecated("Construct a new instance with apply instead", since = "0.10.1")
+  @deprecated("Construct a new instance with apply instead", since = "mill 0.10.1")
   def copy(
       rootModule: mill.define.BaseModule = this.rootModule,
       classLoaderSig: Seq[(Either[String, java.net.URL], Long)] = this.classLoaderSig,
@@ -79,7 +82,7 @@ object EvaluatorState extends runtime.AbstractFunction5[mill.define.BaseModule, 
     setSystemProperties
   )
 
-  @deprecated(message = "Pattern matching not supported with EvaluatorState", since = "0.10.1")
+  @deprecated(message = "Pattern matching not supported with EvaluatorState", since = "mill 0.10.1")
   def unapply(evaluatorState: EvaluatorState): Option[(
       mill.define.BaseModule,
       Seq[(

--- a/main/src/mill/main/MainModule.scala
+++ b/main/src/mill/main/MainModule.scala
@@ -205,7 +205,7 @@ trait MainModule extends mill.Module {
   def all(evaluator: Evaluator, targets: String*) = mill.T.command {
     MainModule.evaluateTasks(
       evaluator =
-        if (evaluator.effectiveThreadCount > 1) evaluator.copy(threadCount = Some(1))
+        if (evaluator.effectiveThreadCount > 1) evaluator.withThreadCount(Some(1))
         else evaluator,
       targets = targets,
       SelectMode.Multi
@@ -237,10 +237,10 @@ trait MainModule extends mill.Module {
    */
   def show(evaluator: Evaluator, targets: String*) = T.command {
     MainModule.evaluateTasks(
-      evaluator.copy(
+      evaluator.withBaseLogger(
         // When using `show`, redirect all stdout of the evaluated tasks so the
         // printed JSON is the only thing printed to stdout.
-        baseLogger = evaluator.baseLogger match {
+        evaluator.baseLogger match {
           case PrintLogger(c1, d, c2, c3, _, i, e, in, de, uc) =>
             PrintLogger(c1, d, c2, c3, e, i, e, in, de, uc)
           case l => l

--- a/main/src/mill/main/ReplApplyHandler.scala
+++ b/main/src/mill/main/ReplApplyHandler.scala
@@ -39,15 +39,13 @@ object ReplApplyHandler {
 
     new ReplApplyHandler(
       pprinter0,
-      new Evaluator(
+      Evaluator(
         home,
         os.pwd / "out",
         os.pwd / "out",
         rootModule,
-        logger,
-        failFast = !keepGoing,
-        threadCount = threadCount
-      ),
+        logger
+      ).withFailFast(!keepGoing).withThreadCount(threadCount),
       systemProperties = systemProperties
     )
   }

--- a/main/src/mill/main/RunScript.scala
+++ b/main/src/mill/main/RunScript.scala
@@ -79,18 +79,17 @@ object RunScript {
 
     val evalRes =
       for (s <- evalState)
-        yield new Evaluator(
+        yield Evaluator(
           home,
           wd / "out",
           wd / "out",
           s.rootModule,
-          log,
-          s.classLoaderSig,
-          s.workerCache,
-          env,
-          failFast = !keepGoing,
-          threadCount = threadCount
-        )
+          log
+        ).withClassLoaderSig(s.classLoaderSig)
+          .withWorkerCache(s.workerCache)
+          .withEnv(env)
+          .withFailFast(!keepGoing)
+          .withThreadCount(threadCount)
 
     val evaluated = for {
       evaluator <- evalRes

--- a/main/test/src/util/TestEvaluator.scala
+++ b/main/test/src/util/TestEvaluator.scala
@@ -57,15 +57,13 @@ class TestEvaluator(
     override def debug(s: String): Unit = super.debug(s"${prefix}: ${s}")
     override def ticker(s: String): Unit = super.ticker(s"${prefix}: ${s}")
   }
-  val evaluator = new Evaluator(
+  val evaluator = Evaluator(
     mill.api.Ctx.defaultHome,
     outPath,
     TestEvaluator.externalOutPath,
     module,
-    logger,
-    failFast = failFast,
-    threadCount = threads
-  )
+    logger
+  ).withFailFast(failFast).withThreadCount(threads)
 
   def apply[T](t: Task[T]): Either[mill.api.Result.Failing[T], (T, Int)] = {
     val evaluated = evaluator.evaluate(Agg(t))


### PR DESCRIPTION
Extracted from https://github.com/com-lihaoyi/mill/pull/1663 to allow introducing new fields in the Evaluator and EvaluatorState classes without breaking the binary compatibility.