### PR TITLE
Add separator to AppendPattern assembly rule

### DIFF
--- a/main/src/mill/modules/Assembly.scala
+++ b/main/src/mill/modules/Assembly.scala
@@ -35,7 +35,8 @@ object Assembly {
       @deprecated(message = "Binary compatibility shim. Don't use it. To be removed", since = "mill 0.10.1")
       def unapply(value: AppendPattern): Option[Pattern] = Some(value.pattern)
     }
-    class AppendPattern(val pattern: Pattern, val separator: String) extends Rule {
+    class AppendPattern private(val pattern: Pattern, val separator: String) extends Rule {
+      @deprecated(message = "Binary compatibility shim. Don't use it. To be removed", since = "mill 0.10.1")
       def this(pattern: Pattern) = this(pattern, defaultSeparator)
 
       override def productPrefix: String = "AppendPattern"
@@ -77,8 +78,8 @@ object Assembly {
     }.toMap
 
     val matchPatterns = assemblyRules.collect {
-      case r : Rule.AppendPattern => r.pattern.asPredicate() -> r
-      case r @ Rule.ExcludePattern(pattern) => pattern.asPredicate() -> r
+      case r: Rule.AppendPattern => r.pattern.asPredicate() -> r
+      case r@Rule.ExcludePattern(pattern) => pattern.asPredicate() -> r
     }
 
     mappings.foldLeft(Map.empty[String, GroupedEntry]) {

--- a/main/src/mill/modules/Jvm.scala
+++ b/main/src/mill/modules/Jvm.scala
@@ -408,9 +408,9 @@ object Jvm {
                   .flatMap(inputStream =>
                     Seq(new ByteArrayInputStream(entry.separator.getBytes), inputStream())
                   )
-                  .drop(1)
+                val cleaned = if (Files.exists(path)) separated else separated.drop(1)
                 val concatenated =
-                  new SequenceInputStream(Collections.enumeration(separated.asJava))
+                  new SequenceInputStream(Collections.enumeration(cleaned.asJava))
                 writeEntry(path, concatenated, append = true)
               case entry: WriteOnceEntry => writeEntry(path, entry.inputStream(), append = false)
             }

--- a/scalalib/test/resources/hello-world-multi/core/resources/without-new-line.conf
+++ b/scalalib/test/resources/hello-world-multi/core/resources/without-new-line.conf
@@ -1,0 +1,1 @@
+without-new-line.first=first

--- a/scalalib/test/resources/hello-world-multi/model/resources/without-new-line.conf
+++ b/scalalib/test/resources/hello-world-multi/model/resources/without-new-line.conf
@@ -1,0 +1,1 @@
+without-new-line.second=second

--- a/scalalib/test/src/HelloWorldTests.scala
+++ b/scalalib/test/src/HelloWorldTests.scala
@@ -131,18 +131,10 @@ object HelloWorldTests extends TestSuite {
     object model extends HelloWorldModule
   }
 
-  object HelloWorldMultiAppendByPattern extends HelloBase {
-    object core extends HelloWorldModuleWithMain {
-      override def moduleDeps = Seq(model)
-      override def assemblyRules = Seq(Assembly.Rule.AppendByPattern(".*.conf"))
-    }
-    object model extends HelloWorldModule
-  }
-
   object HelloWorldMultiAppendByPatternWithSeparator extends HelloBase {
     object core extends HelloWorldModuleWithMain {
       override def moduleDeps = Seq(model)
-      override def assemblyRules = Seq(Assembly.Rule.AppendByPattern(".*.conf", "\n"))
+      override def assemblyRules = Seq(Assembly.Rule.AppendPattern(".*.conf", "\n"))
     }
     object model extends HelloWorldModule
   }
@@ -811,11 +803,7 @@ object HelloWorldTests extends TestSuite {
           HelloWorldMultiAppendPattern,
           HelloWorldMultiAppendPattern.core.assembly
         )
-        "appendByPatternMultiModule" - checkAppendMulti(
-          HelloWorldMultiAppendByPattern,
-          HelloWorldMultiAppendByPattern.core.assembly
-        )
-        "appendByPatternWithSeparator" - checkAppendWithSeparator(
+        "appendPatternMultiModuleWithSeparator" - checkAppendWithSeparator(
           HelloWorldMultiAppendByPatternWithSeparator,
           HelloWorldMultiAppendByPatternWithSeparator.core.assembly
         )

--- a/scalalib/test/src/HelloWorldTests.scala
+++ b/scalalib/test/src/HelloWorldTests.scala
@@ -778,12 +778,9 @@ object HelloWorldTests extends TestSuite {
             Using.resource(new JarFile(result.path.toIO)) { jarFile =>
               assert(jarEntries(jarFile).contains("without-new-line.conf"))
 
-              val fileContent = readFileFromJar(jarFile, "without-new-line.conf")
-
-              assert(
-                "without-new-line\\.first=first(?:\n|$)".r.findFirstIn(fileContent).isDefined,
-                "without-new-line\\.second=second(?:\n|$)".r.findFirstIn(fileContent).isDefined,
-              )
+              val result  = readFileFromJar(jarFile, "without-new-line.conf").split('\n').toSet
+              val expected = Set("without-new-line.first=first", "without-new-line.second=second")
+              assert(result == expected)
             }
           }
 


### PR DESCRIPTION
PR adds separator to AppendPattern assembly rule.

Implementation and motivation are identical to `mill.modules.Assembly.Rule.Append#separator`