### PR TITLE
feat: add framework name to the test classes BSP request

### DIFF
--- a/bsp/src/mill/bsp/MillBuildServer.scala
+++ b/bsp/src/mill/bsp/MillBuildServer.scala
@@ -13,6 +13,8 @@ import ch.epfl.scala.bsp4j.{
   CompileProvider,
   CompileResult,
   DebugProvider,
+  DebugSessionAddress,
+  DebugSessionParams,
   DependencyModule,
   DependencyModulesItem,
   DependencyModulesParams,
@@ -623,6 +625,12 @@ class MillBuildServer(
         }
 
       new CleanCacheResult(msg, cleaned)
+    }
+
+  override def debugSessionStart(debugParams: DebugSessionParams)
+      : CompletableFuture[DebugSessionAddress] =
+    completable(s"debugSessionStart ${debugParams}") { state =>
+      throw new NotImplementedError("debugSessionStart endpoint is not implemented")
     }
 
   def completableTasks[T: ClassTag, V](

--- a/bsp/src/mill/bsp/MillScalaBuildServer.scala
+++ b/bsp/src/mill/bsp/MillScalaBuildServer.scala
@@ -93,22 +93,23 @@ trait MillScalaBuildServer extends ScalaBuildServer { this: MillBuildServer =>
           val testFramework = m.testFramework()
           val compResult = m.compile()
 
-          val classFingerprint: Agg[(Class[_], Fingerprint)] = Jvm.inprocess(
+          val (frameworkName, classFingerprint): (String, Agg[(Class[_], Fingerprint)]) = Jvm.inprocess(
             classpath.map(_.path),
             classLoaderOverrideSbtTesting = true,
             isolated = true,
             closeContextClassLoaderWhenDone = false,
             cl => {
               val framework = TestRunner.framework(testFramework)(cl)
-              TestRunner.discoverTests(
+              val discoveredTests = TestRunner.discoverTests(
                 cl,
                 framework,
                 Agg(compResult.classes.path)
               )
+              (framework.name(), discoveredTests)
             }
           )
           val classes = Seq.from(classFingerprint.map(classF => classF._1.getName.stripSuffix("$")))
-          new ScalaTestClassesItem(id, classes.asJava)
+          new ScalaTestClassesItem(id, classes.asJava, frameworkName)
         }
       case (id, _) => T.task {
           // Not a test module, so no test classes

--- a/build.sc
+++ b/build.sc
@@ -133,7 +133,7 @@ object Deps {
   val utest = ivy"com.lihaoyi::utest:0.7.11"
   val windowsAnsi = ivy"io.github.alexarchambault.windows-ansi:windows-ansi:0.0.3"
   val zinc = ivy"org.scala-sbt::zinc:1.6.1"
-  val bsp = ivy"ch.epfl.scala:bsp4j:2.0.0+60-b6a5df8b-SNAPSHOT"
+  val bsp = ivy"ch.epfl.scala:bsp4j:2.1.0-M1"
   val fansi = ivy"com.lihaoyi::fansi:0.3.1"
   val jarjarabrams = ivy"com.eed3si9n.jarjarabrams::jarjar-abrams-core:1.8.1"
 }

--- a/build.sc
+++ b/build.sc
@@ -133,7 +133,7 @@ object Deps {
   val utest = ivy"com.lihaoyi::utest:0.7.11"
   val windowsAnsi = ivy"io.github.alexarchambault.windows-ansi:windows-ansi:0.0.3"
   val zinc = ivy"org.scala-sbt::zinc:1.6.1"
-  val bsp = ivy"ch.epfl.scala:bsp4j:2.0.0"
+  val bsp = ivy"ch.epfl.scala:bsp4j:2.0.0+60-b6a5df8b-SNAPSHOT"
   val fansi = ivy"com.lihaoyi::fansi:0.3.1"
   val jarjarabrams = ivy"com.eed3si9n.jarjarabrams::jarjar-abrams-core:1.8.1"
 }


### PR DESCRIPTION
I've added `[skip ci]` because for now I only want to see what do you folks think about this PR.
This PR will stay as a draft until changes in `bsp4j` are merged, for now I've used locally published `bsp4j` version.

It is an implementation of the BSP proposal which is described [here](https://github.com/build-server-protocol/build-server-protocol/issues/296#issuecomment-1041525725). This proposal adds an optional framework field to the returned class.

There's already implementation for [bloop](https://github.com/scalacenter/bloop/pull/1695).
