### PR TITLE
Support newer scalafmt versions which require a config file

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -124,7 +124,7 @@ object Deps {
   val sbtTestInterface = ivy"org.scala-sbt:test-interface:1.0"
   val scalaCheck = ivy"org.scalacheck::scalacheck:1.15.4"
   def scalaCompiler(scalaVersion: String) = ivy"org.scala-lang:scala-compiler:${scalaVersion}"
-  val scalafmtDynamic = ivy"org.scalameta::scalafmt-dynamic:3.0.8"
+  val scalafmtDynamic = ivy"org.scalameta::scalafmt-dynamic:3.4.3"
   val scalametaTrees = ivy"org.scalameta::trees:4.5.0"
   def scalaReflect(scalaVersion: String) = ivy"org.scala-lang:scala-reflect:${scalaVersion}"
   def scalacScoveragePlugin = ivy"org.scoverage:::scalac-scoverage-plugin:1.4.11"
@@ -428,7 +428,8 @@ object scalalib extends MillModule {
       Seq(
         "-Djna.nosys=true",
         "-DMILL_BUILD_LIBRARIES=" + genIdeaArgs.map(_.path).mkString(","),
-        "-DMILL_SCALA_LIB=" + runClasspath().map(_.path).mkString(",")
+        "-DMILL_SCALA_LIB=" + runClasspath().map(_.path).mkString(","),
+        s"-DTEST_SCALAFMT_VERSION=${Deps.scalafmtDynamic.dep.version}"
       )
   }
   object backgroundwrapper extends MillPublishModule {

--- a/scalalib/src/scalafmt/ScalafmtModule.scala
+++ b/scalalib/src/scalafmt/ScalafmtModule.scala
@@ -34,8 +34,8 @@ trait ScalafmtModule extends JavaModule {
       case None => Result.Failure(s"None of the specified `scalafmtConfig` locations exist. Searched in: ${locs.map(_.path).mkString(", ")}")
       case Some(c) if (os.read.lines.stream(c.path).find(_.trim.startsWith("version")).isEmpty) =>
         Result.Failure(
-          s"""Found scalafmtConfig file does not specify to scalafmt version to use.
-            |Please specify the scalafmt version in ${c}
+          s"""Found scalafmtConfig file does not specify the scalafmt version to use.
+            |Please specify the scalafmt version in ${c.path}
             |Example:
             |version = "2.4.3"
             |""".stripMargin)

--- a/scalalib/src/scalafmt/ScalafmtModule.scala
+++ b/scalalib/src/scalafmt/ScalafmtModule.scala
@@ -1,6 +1,7 @@
 package mill.scalalib.scalafmt
 
 import mill._
+import mill.api.Result
 import mill.define._
 import mill.scalalib._
 
@@ -11,7 +12,7 @@ trait ScalafmtModule extends JavaModule {
       .worker()
       .reformat(
         filesToFormat(sources()),
-        scalafmtConfig().head
+        resolvedScalafmtConfig()
       )
   }
 
@@ -20,11 +21,27 @@ trait ScalafmtModule extends JavaModule {
       .worker()
       .checkFormat(
         filesToFormat(sources()),
-        scalafmtConfig().head
+        resolvedScalafmtConfig()
       )
   }
 
   def scalafmtConfig: Sources = T.sources(T.workspace / ".scalafmt.conf")
+
+  // TODO: Do we want provide some defaults or write a default file?
+  private[ScalafmtModule] def resolvedScalafmtConfig: Task[PathRef] = T.task {
+    val locs = scalafmtConfig()
+    locs.find(p => os.exists(p.path)) match {
+      case None => Result.Failure(s"None of the specified `scalafmtConfig` locations exist. Searched in: ${locs.map(_.path).mkString(", ")}")
+      case Some(c) if (os.read.lines.stream(c.path).find(_.trim.startsWith("version")).isEmpty) =>
+        Result.Failure(
+          s"""Found scalafmtConfig file does not specify to scalafmt version to use.
+            |Please specify the scalafmt version in ${c}
+            |Example:
+            |version = "2.4.3"
+            |""".stripMargin)
+      case Some(c) => Result.Success(c)
+    }
+  }
 
   protected def filesToFormat(sources: Seq[PathRef]) = {
     for {
@@ -52,7 +69,7 @@ object ScalafmtModule extends ExternalModule with ScalafmtModule {
         .worker()
         .reformat(
           files,
-          scalafmtConfig().head
+          resolvedScalafmtConfig()
         )
     }
 
@@ -63,7 +80,7 @@ object ScalafmtModule extends ExternalModule with ScalafmtModule {
         .worker()
         .checkFormat(
           files,
-          scalafmtConfig().head
+          resolvedScalafmtConfig()
         )
     }
 

--- a/scalalib/src/scalafmt/ScalafmtWorker.scala
+++ b/scalalib/src/scalafmt/ScalafmtWorker.scala
@@ -66,7 +66,6 @@ private[scalafmt] class ScalafmtWorker {
 
       val scalafmt = Scalafmt
         .create(this.getClass.getClassLoader)
-        .withRespectVersion(false)
 
       def readDefaultScalafmtConfig(): Try[Path] = {
         Try(JPaths.get(getClass.getResource("default.scalafmt.conf").toURI))

--- a/scalalib/test/src/scalafmt/ScalafmtTests.scala
+++ b/scalalib/test/src/scalafmt/ScalafmtTests.scala
@@ -10,6 +10,8 @@ import utest.framework.TestPath
 
 object ScalafmtTests extends TestSuite {
 
+  val scalafmtTestVersion = sys.props.getOrElse("TEST_SCALAFMT_VERSION", ???)
+
   trait TestBase extends TestUtil.BaseModule {
     def millSourcePath =
       TestUtil.getSrcPathBase() / millOuterCtx.enclosing.split('.')
@@ -43,6 +45,12 @@ object ScalafmtTests extends TestSuite {
     os.remove.all(eval.outPath)
     os.makeDir.all(m.millSourcePath / os.up)
     os.copy(resourcePath, m.millSourcePath)
+    os.write(
+      m.millSourcePath / ".scalafmt.conf",
+      s"""version = $scalafmtTestVersion
+         |runner.dialect = scala213
+         |""".stripMargin
+    )
     t(eval)
   }
 


### PR DESCRIPTION
Removed deprecated API calls.
Version bump scalafmt-dynamic to 3.4.3.
Removed support to read a `default.scalafmt.conf` from classpath.
