### PR TITLE
Do not clutter user home directory with `mill-release` binary

### DIFF
--- a/ci/publish-local.sh
+++ b/ci/publish-local.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 set -eux
 
@@ -6,4 +6,6 @@ set -eux
 
 ./mill -i show main.publishVersion
 
-cp out/assembly.dest/mill ~/mill-release
+mkdir -p target
+
+cp out/assembly.dest/mill target/mill-release

--- a/ci/test-mill-bootstrap-0.sh
+++ b/ci/test-mill-bootstrap-0.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 set -eux
 
@@ -7,8 +7,8 @@ git stash -u
 git stash -a
 
 # First build
-./mill -i "{__.publishLocal,assembly}"
-cp out/assembly.dest/mill ~/mill-1
+./mill -i "__.publishLocal" + assembly
+cp out/assembly.dest/mill target/mill-1
 
 # Clean up
 git stash -u
@@ -24,8 +24,8 @@ echo "Build 2" > info.txt && git add info.txt && git commit -m "Add info.txt"
 ci/patch-mill-bootstrap.sh
 
 # Second build
-~/mill-1 -i "{__.publishLocal,assembly}"
-cp out/assembly.dest/mill ~/mill-2
+target/mill-1 -i "__.publishLocal" + assembly
+cp out/assembly.dest/mill target/mill-2
 
 # Clean up
 git stash -u
@@ -37,4 +37,4 @@ rm -rf ~/.mill/ammonite
 ci/patch-mill-bootstrap.sh
 
 # Use second build to run tests using Mill
-~/mill-2 -i "{main,scalalib,scalajslib,scalanativelib,bsp}.__.test"
+target/mill-2 -i "{main,scalalib,scalajslib,scalanativelib,bsp}.__.test"

--- a/ci/test-mill-bootstrap-0.sh
+++ b/ci/test-mill-bootstrap-0.sh
@@ -8,11 +8,14 @@ git stash -a
 
 # First build
 ./mill -i "__.publishLocal" + assembly
+mkdir -p target
 cp out/assembly.dest/mill target/mill-1
 
 # Clean up
+git stash -a -m "preserve mill-1" -- target/mill-1
 git stash -u
 git stash -a
+git stash pop "$(git stash list | grep "preserve mill-1" | head -n1 | sed -E 's/([^:]+):.*/\1/')"
 
 rm -rf ~/.mill/ammonite
 
@@ -28,8 +31,10 @@ target/mill-1 -i "__.publishLocal" + assembly
 cp out/assembly.dest/mill target/mill-2
 
 # Clean up
+git stash -a -m "preserve mill-2" -- target/mill-2
 git stash -u
 git stash -a
+git stash pop "$(git stash list | grep "preserve mill-2" | head -n1 | sed -E 's/([^:]+):.*/\1/')"
 
 rm -rf ~/.mill/ammonite
 

--- a/ci/test-mill-bootstrap-1.sh
+++ b/ci/test-mill-bootstrap-1.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 set -eux
 
@@ -7,8 +7,8 @@ git stash -u
 git stash -a
 
 # First build
-./mill -i "{__.publishLocal,assembly}"
-cp out/assembly.dest/mill ~/mill-1
+./mill -i "__.publishLocal" + assembly
+cp out/assembly.dest/mill target/mill-1
 
 # Clean up
 git stash -u
@@ -24,8 +24,8 @@ echo "Build 2" > info.txt && git add info.txt && git commit -m "Add info.txt"
 ci/patch-mill-bootstrap.sh
 
 # Second build
-~/mill-1 -i "{__.publishLocal,assembly}"
-cp out/assembly.dest/mill ~/mill-2
+target/mill-1 -i "__.publishLocal" + assembly
+cp out/assembly.dest/mill target/mill-2
 
 # Clean up
 git stash -u
@@ -37,4 +37,4 @@ rm -rf ~/.mill/ammonite
 ci/patch-mill-bootstrap.sh
 
 # Use second build to run tests using Mill
-~/mill-2 -i "contrib.__.test"
+target/mill-2 -i "contrib.__.test"

--- a/ci/test-mill-bootstrap-1.sh
+++ b/ci/test-mill-bootstrap-1.sh
@@ -8,11 +8,14 @@ git stash -a
 
 # First build
 ./mill -i "__.publishLocal" + assembly
+mkdir -p target
 cp out/assembly.dest/mill target/mill-1
 
 # Clean up
+git stash -a -m "preserve mill-1" -- target/mill-1
 git stash -u
 git stash -a
+git stash pop "$(git stash list | grep "preserve mill-1" | head -n1 | sed -E 's/([^:]+):.*/\1/')"
 
 rm -rf ~/.mill/ammonite
 
@@ -28,8 +31,10 @@ target/mill-1 -i "__.publishLocal" + assembly
 cp out/assembly.dest/mill target/mill-2
 
 # Clean up
+git stash -a -m "preserve mill-2" -- target/mill-2
 git stash -u
 git stash -a
+git stash pop "$(git stash list | grep "preserve mill-2" | head -n1 | sed -E 's/([^:]+):.*/\1/')"
 
 rm -rf ~/.mill/ammonite
 

--- a/ci/test-mill-dev.sh
+++ b/ci/test-mill-dev.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 set -eux
 

--- a/ci/test-mill-release.sh
+++ b/ci/test-mill-release.sh
@@ -10,8 +10,10 @@ git stash -a
 ci/publish-local.sh
 
 # Clean up
+git stash -a -m "preserve mill-release" -- target/mill-release
 git stash -u
 git stash -a
+git stash pop "$(git stash list | grep "preserve mill-release" | head -n1 | sed -E 's/([^:]+):.*/\1/')"
 
 rm -rf ~/.mill/ammonite
 

--- a/ci/test-mill-release.sh
+++ b/ci/test-mill-release.sh
@@ -20,9 +20,9 @@ rm -rf ~/.mill/ammonite
 # Patch local build
 ci/patch-mill-bootstrap.sh
 
-MILL_RELEASE="$(pwd)/target/mill-release"
+export MILL_TEST_RELEASE="$(pwd)/target/mill-release"
 
 # Run tests
-MILL_TEST_RELEASE="$MILL_RELEASE" "$MILL_RELEASE" -i integration.test "mill.integration.forked.{AcyclicTests,UpickleTests,PlayJsonTests}"
+"$MILL_TEST_RELEASE" -i integration.test "mill.integration.forked.{AcyclicTests,UpickleTests,PlayJsonTests}"
 
-MILL_TEST_RELEASE="$MILL_RELEASE" "$MILL_RELEASE" -i integration.test "mill.integration.forked.CaffeineTests"
+"$MILL_TEST_RELEASE" -i integration.test "mill.integration.forked.CaffeineTests"

--- a/ci/test-mill-release.sh
+++ b/ci/test-mill-release.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 set -eux
 
@@ -18,7 +18,9 @@ rm -rf ~/.mill/ammonite
 # Patch local build
 ci/patch-mill-bootstrap.sh
 
-# Run tests
-~/mill-release -i integration.test "mill.integration.forked.{AcyclicTests,UpickleTests,PlayJsonTests}"
+MILL_RELEASE="$(pwd)/target/mill-release"
 
-~/mill-release -i integration.test "mill.integration.forked.CaffeineTests"
+# Run tests
+MILL_TEST_RELEASE="$MILL_RELEASE" "$MILL_RELEASE" -i integration.test "mill.integration.forked.{AcyclicTests,UpickleTests,PlayJsonTests}"
+
+MILL_TEST_RELEASE="$MILL_RELEASE" "$MILL_RELEASE" -i integration.test "mill.integration.forked.CaffeineTests"

--- a/readme.adoc
+++ b/readme.adoc
@@ -146,12 +146,12 @@ from your checkout, you can run
 ci/publish-local.sh
 ----
 
-This creates a standalone assembly at `~/mill-release` you can use, which
+This creates a standalone assembly at `target/mill-release` you can use, which
 references jars published locally in your `~/.ivy2/local` cache. You can then
 use this standalone assembly to build & re-build your current Mill checkout
 without worrying about stomping over compiled code that the assembly is using.
 
-This assemby is design to work on bash, bash-like shells and Windows Cmd.
+This assembly is design to work on bash, bash-like shells and Windows Cmd.
 If you have another default shell like zsh or fish, you probably need to invoke it
 with `sh ~/mill-release` or prepend the file with a proper shebang. 
 


### PR DESCRIPTION
Instead, we now create that file locally under `target/mill-release`.
Also, it is no longer hard coded into the (forked) test suite, but instead
read from the `MILL_TEST_RELEASE` system environment variable.
