### PR TITLE
Support Coursier plugins via customizing FileCache used (with classloaders)

### DIFF
--- a/main/src/mill/modules/Jvm.scala
+++ b/main/src/mill/modules/Jvm.scala
@@ -534,8 +534,8 @@ object Jvm {
       sources: Boolean = false,
       mapDependencies: Option[Dependency => Dependency] = None,
       customizer: Option[coursier.core.Resolution => coursier.core.Resolution] = None,
-      coursierCacheCustomizer: Option[coursier.cache.FileCache[Task] => coursier.cache.FileCache[Task]] = None,
-      ctx: Option[mill.api.Ctx.Log] = None
+      ctx: Option[mill.api.Ctx.Log] = None,
+      coursierCacheCustomizer: Option[coursier.cache.FileCache[Task] => coursier.cache.FileCache[Task]] = None
   ): Result[Agg[PathRef]] = {
 
     val (_, resolution) = resolveDependenciesMetadata(
@@ -544,8 +544,8 @@ object Jvm {
       force,
       mapDependencies,
       customizer,
-      coursierCacheCustomizer,
-      ctx
+      ctx,
+      coursierCacheCustomizer
     )
     val errs = resolution.errors
 
@@ -616,8 +616,8 @@ object Jvm {
       force: IterableOnce[coursier.Dependency],
       mapDependencies: Option[Dependency => Dependency] = None,
       customizer: Option[coursier.core.Resolution => coursier.core.Resolution] = None,
-      coursierCacheCustomizer: Option[coursier.cache.FileCache[Task] => coursier.cache.FileCache[Task]] = None,
-      ctx: Option[mill.api.Ctx.Log] = None
+      ctx: Option[mill.api.Ctx.Log] = None,
+      coursierCacheCustomizer: Option[coursier.cache.FileCache[Task] => coursier.cache.FileCache[Task]] = None
   ): (Seq[Dependency], Resolution) = {
 
     val cachePolicies = coursier.cache.CacheDefaults.cachePolicies
@@ -789,8 +789,8 @@ object Jvm {
       sources = sources,
       mapDependencies = mapDependencies,
       customizer = customizer,
-      coursierCacheCustomizer = None,
-      ctx = ctx
+      ctx = ctx,
+      coursierCacheCustomizer = None
     )
 
   @deprecated(
@@ -811,8 +811,8 @@ object Jvm {
       force = force,
       mapDependencies = mapDependencies,
       customizer = customizer,
-      coursierCacheCustomizer = None,
-      ctx = ctx
+      ctx = ctx,
+      coursierCacheCustomizer = None
     )
 
   @deprecated(
@@ -834,8 +834,8 @@ object Jvm {
       sources = sources,
       mapDependencies = mapDependencies,
       customizer = None,
-      coursierCacheCustomizer = None,
-      ctx = ctx
+      ctx = ctx,
+      coursierCacheCustomizer = None
     )
 
   @deprecated(
@@ -855,8 +855,8 @@ object Jvm {
       force = force,
       mapDependencies = mapDependencies,
       customizer = None,
-      coursierCacheCustomizer = None,
-      ctx = ctx
+      ctx = ctx,
+      coursierCacheCustomizer = None
     )
 
 }

--- a/main/src/mill/modules/Jvm.scala
+++ b/main/src/mill/modules/Jvm.scala
@@ -563,12 +563,15 @@ object Jvm {
       Result.Failure(msg)
     } else {
 
+      val cache0 = coursier.cache.FileCache[Task].noCredentials
+      val cache = cacheCustomizer.getOrElse(identity[coursier.cache.FileCache[Task]](_)).apply(cache0)
+
       def load(artifacts: Seq[coursier.util.Artifact]) = {
 
         import scala.concurrent.ExecutionContext.Implicits.global
         val loadedArtifacts = Gather[Task].gather(
           for (a <- artifacts)
-            yield coursier.cache.Cache.default.file(a).run.map(a.optional -> _)
+            yield cache.file(a).run.map(a.optional -> _)
         ).unsafeRun
 
         val errors = loadedArtifacts.collect {

--- a/scalalib/src/CoursierModule.scala
+++ b/scalalib/src/CoursierModule.scala
@@ -1,7 +1,8 @@
 package mill.scalalib
 
-import scala.annotation.nowarn
+import coursier.cache.FileCache
 
+import scala.annotation.nowarn
 import coursier.{Dependency, Repository, Resolve}
 import coursier.core.Resolution
 import mill.{Agg, T}
@@ -35,6 +36,7 @@ trait CoursierModule extends mill.Module {
       sources = sources,
       mapDependencies = Some(mapDependencies()),
       customizer = resolutionCustomizer(),
+      cacheCustomizer = cacheCustomizer(),
       ctx = Some(implicitly[mill.api.Ctx.Log])
     )
   }
@@ -70,6 +72,22 @@ trait CoursierModule extends mill.Module {
    * @return
    */
   def resolutionCustomizer: Task[Option[Resolution => Resolution]] = T.task { None }
+
+  /**
+   * Customize the coursier file cache.
+   *
+   * This is rarely needed to be changed, but sometimes e.g you want to load a coursier plugin.
+   * Doing so requires adding to coursier's classpath. To do this you could use the following:
+   * {{{
+   *   override def cacheCustomizer = T.task {
+   *      Some( (fc: coursier.cache.FileCache[Task]) =>
+   *        fc.withClassLoaders(Seq(classOf[coursier.cache.protocol.S3Handler].getClassLoader))
+   *      )
+   *   }
+   * }}}
+   * @return
+   */
+  def cacheCustomizer: Task[Option[FileCache[coursier.util.Task] => FileCache[coursier.util.Task]]] = T.task { None }
 
   /**
    * The repositories used to resolved dependencies with [[resolveDeps()]].

--- a/scalalib/src/CoursierModule.scala
+++ b/scalalib/src/CoursierModule.scala
@@ -36,7 +36,7 @@ trait CoursierModule extends mill.Module {
       sources = sources,
       mapDependencies = Some(mapDependencies()),
       customizer = resolutionCustomizer(),
-      cacheCustomizer = cacheCustomizer(),
+      coursierCacheCustomizer = coursierCacheCustomizer(),
       ctx = Some(implicitly[mill.api.Ctx.Log])
     )
   }
@@ -79,7 +79,7 @@ trait CoursierModule extends mill.Module {
    * This is rarely needed to be changed, but sometimes e.g you want to load a coursier plugin.
    * Doing so requires adding to coursier's classpath. To do this you could use the following:
    * {{{
-   *   override def cacheCustomizer = T.task {
+   *   override def coursierCacheCustomizer = T.task {
    *      Some( (fc: coursier.cache.FileCache[Task]) =>
    *        fc.withClassLoaders(Seq(classOf[coursier.cache.protocol.S3Handler].getClassLoader))
    *      )
@@ -87,7 +87,7 @@ trait CoursierModule extends mill.Module {
    * }}}
    * @return
    */
-  def cacheCustomizer: Task[Option[FileCache[coursier.util.Task] => FileCache[coursier.util.Task]]] = T.task { None }
+  def coursierCacheCustomizer: Task[Option[FileCache[coursier.util.Task] => FileCache[coursier.util.Task]]] = T.task { None }
 
   /**
    * The repositories used to resolved dependencies with [[resolveDeps()]].

--- a/scalalib/src/GenIdeaImpl.scala
+++ b/scalalib/src/GenIdeaImpl.scala
@@ -110,6 +110,7 @@ case class GenIdeaImpl(
               sources = false,
               mapDependencies = None,
               customizer = None,
+              coursierCacheCustomizer = None,
               ctx = ctx
             )
 
@@ -122,6 +123,7 @@ case class GenIdeaImpl(
                 sources = true,
                 mapDependencies = None,
                 customizer = None,
+                coursierCacheCustomizer = None,
                 ctx = ctx
               )
             }

--- a/scalalib/src/JavaModule.scala
+++ b/scalalib/src/JavaModule.scala
@@ -536,7 +536,8 @@ trait JavaModule
         resolveCoursierDependency().apply(_),
         additionalDeps() ++ transitiveIvyDeps(),
         Some(mapDependencies()),
-        customizer = resolutionCustomizer()
+        customizer = resolutionCustomizer(),
+        cacheCustomizer = cacheCustomizer(),
       )
 
       println(

--- a/scalalib/src/JavaModule.scala
+++ b/scalalib/src/JavaModule.scala
@@ -537,7 +537,7 @@ trait JavaModule
         additionalDeps() ++ transitiveIvyDeps(),
         Some(mapDependencies()),
         customizer = resolutionCustomizer(),
-        cacheCustomizer = cacheCustomizer(),
+        coursierCacheCustomizer = coursierCacheCustomizer(),
       )
 
       println(

--- a/scalalib/src/Lib.scala
+++ b/scalalib/src/Lib.scala
@@ -6,6 +6,7 @@ import java.lang.annotation.Annotation
 import java.lang.reflect.Modifier
 import java.util.zip.ZipInputStream
 
+import coursier.util.Task
 import coursier.{Dependency, Fetch, Repository, Resolution}
 import mill.api.{Ctx, Loose, PathRef, Result}
 import sbt.testing._
@@ -29,6 +30,7 @@ object Lib {
       deps: IterableOnce[Dep],
       mapDependencies: Option[Dependency => Dependency] = None,
       customizer: Option[coursier.core.Resolution => coursier.core.Resolution] = None,
+      cacheCustomizer: Option[coursier.cache.FileCache[Task] => coursier.cache.FileCache[Task]] = None,
       ctx: Option[Ctx.Log] = None
   ): (Seq[Dependency], Resolution) = {
     val depSeq = deps.iterator.toSeq
@@ -38,6 +40,7 @@ object Lib {
       force = depSeq.filter(_.force).map(depToDependency),
       mapDependencies = mapDependencies,
       customizer = customizer,
+      cacheCustomizer = cacheCustomizer,
       ctx = ctx
     )
   }
@@ -56,6 +59,7 @@ object Lib {
       sources: Boolean = false,
       mapDependencies: Option[Dependency => Dependency] = None,
       customizer: Option[coursier.core.Resolution => coursier.core.Resolution] = None,
+      cacheCustomizer: Option[coursier.cache.FileCache[Task] => coursier.cache.FileCache[Task]] = None,
       ctx: Option[Ctx.Log] = None
   ): Result[Agg[PathRef]] = {
     val depSeq = deps.iterator.toSeq
@@ -66,6 +70,7 @@ object Lib {
       sources = sources,
       mapDependencies = mapDependencies,
       customizer = customizer,
+      cacheCustomizer = cacheCustomizer,
       ctx = ctx
     )
   }
@@ -137,6 +142,7 @@ object Lib {
       deps = deps,
       mapDependencies = mapDependencies,
       customizer = None,
+      cacheCustomizer = None,
       ctx = ctx
     )
 
@@ -159,6 +165,7 @@ object Lib {
       sources = sources,
       mapDependencies = mapDependencies,
       customizer = None,
+      cacheCustomizer = None,
       ctx = ctx
     )
 

--- a/scalalib/src/Lib.scala
+++ b/scalalib/src/Lib.scala
@@ -30,7 +30,7 @@ object Lib {
       deps: IterableOnce[Dep],
       mapDependencies: Option[Dependency => Dependency] = None,
       customizer: Option[coursier.core.Resolution => coursier.core.Resolution] = None,
-      cacheCustomizer: Option[coursier.cache.FileCache[Task] => coursier.cache.FileCache[Task]] = None,
+      coursierCacheCustomizer: Option[coursier.cache.FileCache[Task] => coursier.cache.FileCache[Task]] = None,
       ctx: Option[Ctx.Log] = None
   ): (Seq[Dependency], Resolution) = {
     val depSeq = deps.iterator.toSeq
@@ -40,7 +40,7 @@ object Lib {
       force = depSeq.filter(_.force).map(depToDependency),
       mapDependencies = mapDependencies,
       customizer = customizer,
-      cacheCustomizer = cacheCustomizer,
+      coursierCacheCustomizer = coursierCacheCustomizer,
       ctx = ctx
     )
   }
@@ -59,7 +59,7 @@ object Lib {
       sources: Boolean = false,
       mapDependencies: Option[Dependency => Dependency] = None,
       customizer: Option[coursier.core.Resolution => coursier.core.Resolution] = None,
-      cacheCustomizer: Option[coursier.cache.FileCache[Task] => coursier.cache.FileCache[Task]] = None,
+      coursierCacheCustomizer: Option[coursier.cache.FileCache[Task] => coursier.cache.FileCache[Task]] = None,
       ctx: Option[Ctx.Log] = None
   ): Result[Agg[PathRef]] = {
     val depSeq = deps.iterator.toSeq
@@ -70,7 +70,7 @@ object Lib {
       sources = sources,
       mapDependencies = mapDependencies,
       customizer = customizer,
-      cacheCustomizer = cacheCustomizer,
+      coursierCacheCustomizer = coursierCacheCustomizer,
       ctx = ctx
     )
   }
@@ -127,6 +127,52 @@ object Lib {
 
   @deprecated(
     "User other overload instead. Only for binary backward compatibility.",
+    "mill after 0.10.0"
+  )
+  def resolveDependenciesMetadata(
+       repositories: Seq[Repository],
+       depToDependency: Dep => coursier.Dependency,
+       deps: IterableOnce[Dep],
+       mapDependencies: Option[Dependency => Dependency],
+       customizer: Option[coursier.core.Resolution => coursier.core.Resolution],
+       ctx: Option[Ctx.Log]
+   ): (Seq[Dependency], Resolution) =
+    resolveDependenciesMetadata(
+      repositories = repositories,
+      depToDependency = depToDependency,
+      deps = deps,
+      mapDependencies = mapDependencies,
+      customizer = customizer,
+      coursierCacheCustomizer = None,
+      ctx = ctx
+    )
+
+  @deprecated(
+    "User other overload instead. Only for binary backward compatibility.",
+    "mill after 0.10.0"
+  )
+  def resolveDependencies(
+       repositories: Seq[Repository],
+       depToDependency: Dep => coursier.Dependency,
+       deps: IterableOnce[Dep],
+       sources: Boolean,
+       mapDependencies: Option[Dependency => Dependency],
+       customizer: Option[coursier.core.Resolution => coursier.core.Resolution],
+       ctx: Option[Ctx.Log]
+   ): Result[Agg[PathRef]] =
+    resolveDependencies(
+      repositories = repositories,
+      depToDependency = depToDependency,
+      deps = deps,
+      sources = sources,
+      mapDependencies = mapDependencies,
+      customizer = customizer,
+      coursierCacheCustomizer = None,
+      ctx = ctx
+    )
+
+  @deprecated(
+    "User other overload instead. Only for binary backward compatibility.",
     "mill after 0.9.6"
   )
   def resolveDependenciesMetadata(
@@ -142,7 +188,7 @@ object Lib {
       deps = deps,
       mapDependencies = mapDependencies,
       customizer = None,
-      cacheCustomizer = None,
+      coursierCacheCustomizer = None,
       ctx = ctx
     )
 
@@ -165,7 +211,7 @@ object Lib {
       sources = sources,
       mapDependencies = mapDependencies,
       customizer = None,
-      cacheCustomizer = None,
+      coursierCacheCustomizer = None,
       ctx = ctx
     )
 

--- a/scalalib/src/Lib.scala
+++ b/scalalib/src/Lib.scala
@@ -30,8 +30,8 @@ object Lib {
       deps: IterableOnce[Dep],
       mapDependencies: Option[Dependency => Dependency] = None,
       customizer: Option[coursier.core.Resolution => coursier.core.Resolution] = None,
+      ctx: Option[Ctx.Log] = None,
       coursierCacheCustomizer: Option[coursier.cache.FileCache[Task] => coursier.cache.FileCache[Task]] = None,
-      ctx: Option[Ctx.Log] = None
   ): (Seq[Dependency], Resolution) = {
     val depSeq = deps.iterator.toSeq
     mill.modules.Jvm.resolveDependenciesMetadata(
@@ -40,8 +40,8 @@ object Lib {
       force = depSeq.filter(_.force).map(depToDependency),
       mapDependencies = mapDependencies,
       customizer = customizer,
-      coursierCacheCustomizer = coursierCacheCustomizer,
-      ctx = ctx
+      ctx = ctx,
+      coursierCacheCustomizer = coursierCacheCustomizer
     )
   }
 
@@ -59,8 +59,8 @@ object Lib {
       sources: Boolean = false,
       mapDependencies: Option[Dependency => Dependency] = None,
       customizer: Option[coursier.core.Resolution => coursier.core.Resolution] = None,
-      coursierCacheCustomizer: Option[coursier.cache.FileCache[Task] => coursier.cache.FileCache[Task]] = None,
-      ctx: Option[Ctx.Log] = None
+      ctx: Option[Ctx.Log] = None,
+      coursierCacheCustomizer: Option[coursier.cache.FileCache[Task] => coursier.cache.FileCache[Task]] = None
   ): Result[Agg[PathRef]] = {
     val depSeq = deps.iterator.toSeq
     mill.modules.Jvm.resolveDependencies(
@@ -70,8 +70,8 @@ object Lib {
       sources = sources,
       mapDependencies = mapDependencies,
       customizer = customizer,
-      coursierCacheCustomizer = coursierCacheCustomizer,
-      ctx = ctx
+      ctx = ctx,
+      coursierCacheCustomizer = coursierCacheCustomizer
     )
   }
 
@@ -143,8 +143,8 @@ object Lib {
       deps = deps,
       mapDependencies = mapDependencies,
       customizer = customizer,
-      coursierCacheCustomizer = None,
-      ctx = ctx
+      ctx = ctx,
+      coursierCacheCustomizer = None
     )
 
   @deprecated(
@@ -167,8 +167,8 @@ object Lib {
       sources = sources,
       mapDependencies = mapDependencies,
       customizer = customizer,
-      coursierCacheCustomizer = None,
-      ctx = ctx
+      ctx = ctx,
+      coursierCacheCustomizer = None
     )
 
   @deprecated(
@@ -188,8 +188,8 @@ object Lib {
       deps = deps,
       mapDependencies = mapDependencies,
       customizer = None,
-      coursierCacheCustomizer = None,
-      ctx = ctx
+      ctx = ctx,
+      coursierCacheCustomizer = None
     )
 
   @deprecated(
@@ -211,8 +211,8 @@ object Lib {
       sources = sources,
       mapDependencies = mapDependencies,
       customizer = None,
-      coursierCacheCustomizer = None,
-      ctx = ctx
+      ctx = ctx,
+      coursierCacheCustomizer = None
     )
 
   def findSourceFiles(sources: Seq[PathRef], extensions: Seq[String]): Seq[os.Path] = {

--- a/scalalib/src/dependency/versions/VersionsFinder.scala
+++ b/scalalib/src/dependency/versions/VersionsFinder.scala
@@ -39,7 +39,7 @@ private[dependency] object VersionsFinder {
         val repos = javaModule.repositoriesTask()
         val mapDeps = javaModule.mapDependencies()
         val custom = javaModule.resolutionCustomizer()
-        val cacheCustom = javaModule.cacheCustomizer()
+        val cacheCustom = javaModule.coursierCacheCustomizer()
 
         val (dependencies, _) =
           Lib.resolveDependenciesMetadata(
@@ -48,7 +48,7 @@ private[dependency] object VersionsFinder {
             deps = deps ++ compileIvyDeps ++ runIvyDeps,
             mapDependencies = Some(mapDeps),
             customizer = custom,
-            cacheCustomizer = cacheCustom,
+            coursierCacheCustomizer = cacheCustom,
             ctx = Some(T.log)
           )
 

--- a/scalalib/src/dependency/versions/VersionsFinder.scala
+++ b/scalalib/src/dependency/versions/VersionsFinder.scala
@@ -39,6 +39,7 @@ private[dependency] object VersionsFinder {
         val repos = javaModule.repositoriesTask()
         val mapDeps = javaModule.mapDependencies()
         val custom = javaModule.resolutionCustomizer()
+        val cacheCustom = javaModule.cacheCustomizer()
 
         val (dependencies, _) =
           Lib.resolveDependenciesMetadata(
@@ -47,6 +48,7 @@ private[dependency] object VersionsFinder {
             deps = deps ++ compileIvyDeps ++ runIvyDeps,
             mapDependencies = Some(mapDeps),
             customizer = custom,
+            cacheCustomizer = cacheCustom,
             ctx = Some(T.log)
           )
 


### PR DESCRIPTION
Currently loading a Coursier plugin is not possible, because the `ClassLoaders` that are used by Mill's Coursier cannot be changed. I ran into this when trying to use [my plugin](https://github.com/ActionIQ/coursier-s3) which adds support for a [new protocol](https://get-coursier.io/docs/extra#extra-protocols). Loading via `$ivy.` or anything else doesn't work because Mill uses the `default` Coursier [cache](https://github.com/com-lihaoyi/mill/blob/246e92411c874ae8a33655dec7937af8c4041509/main/src/mill/modules/Jvm.scala#L571-L570)

This PR adds a hook to allow altering the `FileCache` used. With this, I can put the following in my build module:

```
  override def cacheCustomizer: Task[Option[FileCache[coursier.util.Task] => FileCache[coursier.util.Task]]] = T.task {
    Some( (fc: FileCache[coursier.util.Task]) => {
      fc.withClassLoaders(Seq(classOf[coursier.cache.protocol.S3Handler].getClassLoader)) }
    )
  }
```
Which then fixes the resolution so that when it looks for plugins it can find my class.

This PR borrows ideas from #775

If there's better way to achieve this lmk