### PR TITLE
Improved `show` output to be valid JSON and added `showNamed`

### DIFF
--- a/docs/antora/modules/ROOT/pages/Intro_to_Mill.adoc
+++ b/docs/antora/modules/ROOT/pages/Intro_to_Mill.adoc
@@ -660,6 +660,46 @@ $ mill show foo.compileClasspath
 `show` is also useful for interacting with Mill from external tools, since the JSON it outputs is structured and easily
 parsed and manipulated.
 
+When `show` is used with multiple targets, it's output will slightly change to a JSON array, containing all the results of the given targets.
+
+[source,bash]
+----
+$ mill show "foo.{sources,compileClasspath}"
+[1/1] show
+[2/11] foo.resources
+[
+  [
+    "ref:8befb7a8:/Users/lihaoyi/Dropbox/Github/test/foo/src"
+  ],
+  [
+    "ref:c984eca8:/Users/lihaoyi/Dropbox/Github/test/foo/resources",
+    ".../org/scala-lang/scala-library/2.13.1/scala-library-2.13.1.jar"
+  ]
+]
+----
+
+=== showNamed
+
+Same as `show`, but the output will always be structured in a JSON dictionary, with the task names as key and the task results as JSON values.
+
+[source,bash]
+----
+$ mill showNamed "foo.{sources,compileClasspath}"
+[1/1] show
+[2/11] foo.resources
+{
+  "foo.sources":
+  [
+    "ref:8befb7a8:/Users/lihaoyi/Dropbox/Github/test/foo/src"
+  ],
+  "foo.compileClasspath":
+  [
+    "ref:c984eca8:/Users/lihaoyi/Dropbox/Github/test/foo/resources",
+    ".../org/scala-lang/scala-library/2.13.1/scala-library-2.13.1.jar"
+  ]
+}
+----
+
 === path
 
 [source,bash]

--- a/docs/antora/modules/ROOT/pages/Intro_to_Mill.adoc
+++ b/docs/antora/modules/ROOT/pages/Intro_to_Mill.adoc
@@ -660,7 +660,7 @@ $ mill show foo.compileClasspath
 `show` is also useful for interacting with Mill from external tools, since the JSON it outputs is structured and easily
 parsed and manipulated.
 
-When `show` is used with multiple targets, it's output will slightly change to a JSON array, containing all the results of the given targets.
+When `show` is used with multiple targets, its output will slightly change to a JSON array, containing all the results of the given targets.
 
 [source,bash]
 ----

--- a/main/src/mill/main/MainModule.scala
+++ b/main/src/mill/main/MainModule.scala
@@ -267,8 +267,6 @@ trait MainModule extends mill.Module {
     ) { res: Seq[(Any, Option[(String, Value)])] =>
       val nameAndJson = res.flatMap(_._2)
       val output = ujson.Obj.from(nameAndJson)
-      // it would be nice to also have the task name in the result
-      // as described in https://github.com/com-lihaoyi/mill/issues/1763#issuecomment-1059329035
       T.log.outputStream.println(output.render(indent = 2))
     }
   }

--- a/main/src/mill/main/MainModule.scala
+++ b/main/src/mill/main/MainModule.scala
@@ -63,7 +63,7 @@ object MainModule {
       evaluator: Evaluator,
       targets: Seq[String],
       selectMode: SelectMode
-  )(f: Seq[(Any, Option[(String, ujson.Value)])] => T): Result[Watched[Option[T]]] = {
+  )(f: Seq[(Any, Option[(RunScript.TaskName, ujson.Value)])] => T): Result[Watched[Option[T]]] = {
     RunScript.evaluateTasks1(evaluator, targets, selectMode) match {
       case Left(err) => Result.Failure(err)
       case Right((watched, Left(err))) => Result.Failure(err, Some(Watched(None, watched)))

--- a/main/src/mill/main/MainModule.scala
+++ b/main/src/mill/main/MainModule.scala
@@ -59,12 +59,12 @@ object MainModule {
   }
 
   @internal
-  def evaluateTasks1[T](
+  def evaluateTasksNamed[T](
       evaluator: Evaluator,
       targets: Seq[String],
       selectMode: SelectMode
   )(f: Seq[(Any, Option[(RunScript.TaskName, ujson.Value)])] => T): Result[Watched[Option[T]]] = {
-    RunScript.evaluateTasks1(evaluator, targets, selectMode) match {
+    RunScript.evaluateTasksNamed(evaluator, targets, selectMode) match {
       case Left(err) => Result.Failure(err)
       case Right((watched, Left(err))) => Result.Failure(err, Some(Watched(None, watched)))
       case Right((watched, Right(res))) =>
@@ -252,7 +252,7 @@ trait MainModule extends mill.Module {
    * to integrate Mill into external scripts and tooling.
    */
   def show(evaluator: Evaluator, targets: String*): Command[Value] = T.command {
-    MainModule.evaluateTasks1(
+    MainModule.evaluateTasksNamed(
       evaluator.withBaseLogger(
         // When using `show`, redirect all stdout of the evaluated tasks so the
         // printed JSON is the only thing printed to stdout.
@@ -282,7 +282,7 @@ trait MainModule extends mill.Module {
    * to integrate Mill into external scripts and tooling.
    */
   def showNamed(evaluator: Evaluator, targets: String*): Command[Value] = T.command {
-    MainModule.evaluateTasks1(
+    MainModule.evaluateTasksNamed(
       evaluator.withBaseLogger(
         // When using `show`, redirect all stdout of the evaluated tasks so the
         // printed JSON is the only thing printed to stdout.

--- a/main/src/mill/main/MainRunner.scala
+++ b/main/src/mill/main/MainRunner.scala
@@ -49,7 +49,6 @@ class MainRunner(
   var stateCache = stateCache0
 
   override def watchAndWait(watched: Seq[(ammonite.interp.Watchable, Long)]) = {
-
     setIdle(true)
     super.watchAndWait(watched)
     setIdle(false)
@@ -86,7 +85,7 @@ class MainRunner(
   val colored = config.core.color.getOrElse(mainInteractive)
 
   override val colors = if (colored) Colors.Default else Colors.BlackWhite
-  override def runScript(scriptPath: os.Path, scriptArgs: List[String]) =
+  override def runScript(scriptPath: os.Path, scriptArgs: List[String]): Boolean =
     watchLoop2(
       isRepl = false,
       printing = true,

--- a/main/src/mill/main/RunScript.scala
+++ b/main/src/mill/main/RunScript.scala
@@ -25,6 +25,9 @@ import ujson.Value
  * subsystem
  */
 object RunScript {
+
+  type TaskName = String
+
   def runScript(
       home: os.Path,
       wd: os.Path,
@@ -324,7 +327,7 @@ object RunScript {
       evaluator: Evaluator,
       scriptArgs: Seq[String],
       selectMode: SelectMode
-  ): Either[String, (Seq[PathRef], Either[String, Seq[(Any, Option[(String, ujson.Value)])]])] = {
+  ): Either[String, (Seq[PathRef], Either[String, Seq[(Any, Option[(TaskName, ujson.Value)])]])] = {
     for (targets <- resolveTasks(mill.main.ResolveTasks, evaluator, scriptArgs, selectMode))
       yield {
         val (watched, res) = evaluate1(evaluator, Agg.from(targets.distinct))
@@ -357,7 +360,7 @@ object RunScript {
   def evaluate1(
       evaluator: Evaluator,
       targets: Agg[Task[Any]]
-  ): (Seq[PathRef], Either[String, Seq[(Any, Option[(String, ujson.Value)])]]) = {
+  ): (Seq[PathRef], Either[String, Seq[(Any, Option[(TaskName, ujson.Value)])]]) = {
     val evaluated: Evaluator.Results = evaluator.evaluate(targets)
     val watched = evaluated.results
       .iterator

--- a/main/src/mill/main/RunScript.scala
+++ b/main/src/mill/main/RunScript.scala
@@ -17,6 +17,7 @@ import mill.internal.AmmoniteUtils
 import scala.collection.mutable
 import scala.reflect.ClassTag
 import mill.define.ParseArgs.TargetsWithParams
+import ujson.Value
 
 /**
  * Custom version of ammonite.main.Scripts, letting us run the build.sc script
@@ -319,11 +320,38 @@ object RunScript {
       }
   }
 
+  def evaluateTasks1[T](
+      evaluator: Evaluator,
+      scriptArgs: Seq[String],
+      selectMode: SelectMode
+  ): Either[String, (Seq[PathRef], Either[String, Seq[(Any, Option[(String, ujson.Value)])]])] = {
+    for (targets <- resolveTasks(mill.main.ResolveTasks, evaluator, scriptArgs, selectMode))
+      yield {
+        val (watched, res) = evaluate1(evaluator, Agg.from(targets.distinct))
+
+        val watched2 = for {
+          x <- res.toSeq
+          (Watched(_, extraWatched), _) <- x
+          w <- extraWatched
+        } yield w
+
+        (watched ++ watched2, res)
+      }
+  }
+
   def evaluate(
       evaluator: Evaluator,
       targets: Agg[Task[Any]]
   ): (Seq[PathRef], Either[String, Seq[(Any, Option[ujson.Value])]]) = {
-    val evaluated = evaluator.evaluate(targets)
+    val res = evaluate1(evaluator, targets)
+    (res._1, res._2.map(_.map(p => (p._1, p._2.map(_._2)))))
+  }
+
+  def evaluate1(
+      evaluator: Evaluator,
+      targets: Agg[Task[Any]]
+  ): (Seq[PathRef], Either[String, Seq[(Any, Option[(String, ujson.Value)])]]) = {
+    val evaluated: Evaluator.Results = evaluator.evaluate(targets)
     val watched = evaluated.results
       .iterator
       .collect {
@@ -337,18 +365,18 @@ object RunScript {
 
     evaluated.failing.keyCount match {
       case 0 =>
-        val json = for (t <- targets.toSeq) yield {
+        val nameAndJson = for (t <- targets.toSeq) yield {
           t match {
             case t: mill.define.NamedTask[_] =>
               val jsonFile = EvaluatorPaths.resolveDestPaths(evaluator.outPath, t).meta
               val metadata = upickle.default.read[Evaluator.Cached](ujson.read(jsonFile.toIO))
-              Some(metadata.value)
+              Some(t.toString, metadata.value)
 
             case _ => None
           }
         }
 
-        watched -> Right(evaluated.values.zip(json))
+        watched -> Right(evaluated.values.zip(nameAndJson))
       case n => watched -> Left(s"$n targets failed\n$errorStr")
     }
   }

--- a/main/src/mill/main/RunScript.scala
+++ b/main/src/mill/main/RunScript.scala
@@ -323,14 +323,14 @@ object RunScript {
       }
   }
 
-  def evaluateTasks1[T](
+  def evaluateTasksNamed[T](
       evaluator: Evaluator,
       scriptArgs: Seq[String],
       selectMode: SelectMode
   ): Either[String, (Seq[PathRef], Either[String, Seq[(Any, Option[(TaskName, ujson.Value)])]])] = {
     for (targets <- resolveTasks(mill.main.ResolveTasks, evaluator, scriptArgs, selectMode))
       yield {
-        val (watched, res) = evaluate1(evaluator, Agg.from(targets.distinct))
+        val (watched, res) = evaluateNamed(evaluator, Agg.from(targets.distinct))
 
         val watched2 = for {
           x <- res.toSeq
@@ -346,7 +346,7 @@ object RunScript {
       evaluator: Evaluator,
       targets: Agg[Task[Any]]
   ): (Seq[PathRef], Either[String, Seq[(Any, Option[ujson.Value])]]) = {
-    val (watched, results) = evaluate1(evaluator, targets)
+    val (watched, results) = evaluateNamed(evaluator, targets)
     // we drop the task name in the inner tuple
     (watched, results.map(_.map(p => (p._1, p._2.map(_._2)))))
   }
@@ -357,7 +357,7 @@ object RunScript {
    * @param targets
    * @return (watched-paths, Either[err-msg, Seq[(task-result, Option[(task-name, task-return-as-json)])]])
    */
-  def evaluate1(
+  def evaluateNamed(
       evaluator: Evaluator,
       targets: Agg[Task[Any]]
   ): (Seq[PathRef], Either[String, Seq[(Any, Option[(TaskName, ujson.Value)])]]) = {

--- a/main/src/mill/main/RunScript.scala
+++ b/main/src/mill/main/RunScript.scala
@@ -343,10 +343,17 @@ object RunScript {
       evaluator: Evaluator,
       targets: Agg[Task[Any]]
   ): (Seq[PathRef], Either[String, Seq[(Any, Option[ujson.Value])]]) = {
-    val res = evaluate1(evaluator, targets)
-    (res._1, res._2.map(_.map(p => (p._1, p._2.map(_._2)))))
+    val (watched, results) = evaluate1(evaluator, targets)
+    // we drop the task name in the inner tuple
+    (watched, results.map(_.map(p => (p._1, p._2.map(_._2)))))
   }
 
+  /**
+   *
+   * @param evaluator
+   * @param targets
+   * @return (watched-paths, Either[err-msg, Seq[(task-result, Option[(task-name, task-return-as-json)])]])
+   */
   def evaluate1(
       evaluator: Evaluator,
       targets: Agg[Task[Any]]

--- a/main/test/src/main/MainModuleTests.scala
+++ b/main/test/src/main/MainModuleTests.scala
@@ -1,0 +1,50 @@
+package mill.main
+
+import mill.api.Result
+import mill.{Agg, T}
+import mill.util.{TestEvaluator, TestUtil}
+import utest.{TestSuite, Tests, test}
+
+object MainModuleTests extends TestSuite {
+
+  object mainModule extends TestUtil.BaseModule with MainModule {
+    def hello = T { Seq("hello") }
+    def hello2 = T { Seq("hello2") }
+  }
+
+  override def tests: Tests = Tests {
+    test("show") {
+      val evaluator = new TestEvaluator(mainModule)
+      test("single") {
+        val results =
+          evaluator.evaluator.evaluate(Agg(mainModule.show(evaluator.evaluator, "hello")))
+
+        assert(results.failing.keyCount == 0)
+
+        val Result.Success(value) = results.rawValues.head
+
+        assert(value == ujson.Obj.from(Map(
+          "hello" -> ujson.Arr.from(Seq("hello"))
+        )))
+      }
+      test("multi") {
+        val results =
+          evaluator.evaluator.evaluate(Agg(mainModule.show(
+            evaluator.evaluator,
+            "hello",
+            "+",
+            "hello2"
+          )))
+
+        assert(results.failing.keyCount == 0)
+
+        val Result.Success(value) = results.rawValues.head
+
+        assert(value == ujson.Obj.from(Map(
+          "hello" -> ujson.Arr.from(Seq("hello")),
+          "hello2" -> ujson.Arr.from(Seq("hello2"))
+        )))
+      }
+    }
+  }
+}


### PR DESCRIPTION
Currently, show invoked with more than one target returns invalid JSON, as it is only concatenating multiple JSON values.

Example:

```
$ mill show __.artifactMetdata
[1/1] show
{
    "group": "com.acme",
    "id": "pkg1",
    "version": "1.0.0"
}
{
    "group": "com.acme",
    "id": "pkg2",
    "version": "1.0.0"
}
```

This PR makes its output valid JSON by outputting a proper JSON array when there is more than one task result. 

Example: 

```
$ mill show __.artifactMetdata
[1/1] show
[
  {
    "group": "com.acme",
    "id": "pkg1",
    "version": "1.0.0"
  },
  {
    "group": "com.acme",
    "id": "pkg2",
    "version": "1.0.0"
  }
]
```

Also it introduces a new `showNamed` command, which puts each task result in a JSON dictionary. The keys are reflecting the task names. 

Example:

```
 mill showNamed __.artifactMetadata
[1/1] show
{
  "pkg1.artifactMetadata":
  {
      "group": "com.acme",
      "id": "pkg1",
      "version": "1.0.0"
  },
  "pkg2.artifctMetadata":
  {
      "group": "com.acme",
      "id": "pkg2",
      "version": "1.0.0"
  }
}
```

This makes the output of `show` and `showNamed` much more usable. For humans it's easier to recognize, which task outputted what, and for external tools, as they now can process the `mill show` output as-is.

Fix https://github.com/com-lihaoyi/mill/issues/1763

To implement this, I needed to enlarge the result values of some
evaluate methods to also contain the task name, so I added new methods.
These now also transport the actual result value in addition to the watched paths.
I was uncreative and just added a "1" to the existing methods names.
Any suggestions for better names are much appreciated.

I also took the opportunity to let `show` and `showNamed` return their result.
