### PR TITLE
Implemented `AutoCloseable` Workers

### DIFF
--- a/docs/antora/modules/ROOT/pages/Tasks.adoc
+++ b/docs/antora/modules/ROOT/pages/Tasks.adoc
@@ -301,11 +301,14 @@ externally-visible behavior of the worker.
 As <<Workers>> may also hold limited resources, it may be necessary to free up these resources once a worker is no longer needed.
 This is especially the case, when your worker tasks depends on other tasks and these tasks change, as Mill will then also create a new worker instance.
 
-To implement resource cleanup, your worker can implement `java.lang.AutoClosable`.
+To implement resource cleanup, your worker can implement `java.lang.AutoCloseable`.
 Once the worker is no longer needed, Mill will call the `close()` method on it before any newer version of this worker is created.
 
 [source,scala]
 ----
+import mill._
+import java.lang.AutoCloseable
+
 def myWorker = T.worker {
   new MyWorker with AutoCloseable {
     // ...

--- a/docs/antora/modules/ROOT/pages/Tasks.adoc
+++ b/docs/antora/modules/ROOT/pages/Tasks.adoc
@@ -296,6 +296,24 @@ mutable state, and it is up to the implementation to ensure that this mutable
 state is only used for caching/performance and does not affect the
 externally-visible behavior of the worker.
 
+=== `Autoclosable` Workers
+
+As <<Workers>> may also hold limited resources, it may be necessary to free up these resources once a worker is no longer needed.
+This is especially the case, when your worker tasks depends on other tasks and these tasks change, as Mill will then also create a new worker instance.
+
+To implement resource cleanup, your worker can implement `java.lang.AutoClosable`.
+Once the worker is no longer needed, Mill will call the `close()` method on it before any newer version of this worker is created.
+
+[source,scala]
+----
+def myWorker = T.worker {
+  new MyWorker with AutoCloseable {
+    // ...
+    override def close() = { /* cleanup and free resources */ }
+  }
+}
+----
+
 == Task Cheat Sheet
 
 The following table might help you make sense of the small collection of

--- a/main/core/src/mill/eval/Evaluator.scala
+++ b/main/core/src/mill/eval/Evaluator.scala
@@ -519,11 +519,11 @@ class Evaluator private[Evaluator] (
       metaPath: os.Path,
       inputsHash: Int,
       labelledNamedTask: Labelled[_]
-  ) = {
+  ): Unit = {
     labelledNamedTask.task.asWorker match {
       case Some(w) =>
         workerCache.synchronized {
-          workerCache.put(w.ctx.segments, (inputsHash, v))
+          workerCache.update(w.ctx.segments, (inputsHash, v))
         }
       case None =>
         val terminalResult = labelledNamedTask

--- a/main/core/src/mill/eval/Evaluator.scala
+++ b/main/core/src/mill/eval/Evaluator.scala
@@ -36,7 +36,7 @@ case class Labelled[T](task: NamedTask[T], segments: Segments) {
 /**
  * Evaluate tasks.
  */
-class Evaluator private (
+class Evaluator private[Evaluator] (
     _home: os.Path,
     _outPath: os.Path,
     _externalOutPath: os.Path,
@@ -170,7 +170,6 @@ class Evaluator private (
       testReporter: TestReporter = DummyTestReporter
   ): Evaluator.Results = {
     val (sortedGroups, transitive) = Evaluator.plan(goals)
-
     val evaluated = new Agg.Mutable[Task[_]]
     val results = mutable.LinkedHashMap.empty[Task[_], mill.api.Result[(Any, Int)]]
     var someTaskFailed: Boolean = false
@@ -190,9 +189,10 @@ class Evaluator private (
         )
 
         val startTime = System.currentTimeMillis()
-        // Increment the counter message by 1 to go from 1/10 to 10/10 instead of 0/10 to 9/10
 
+        // Increment the counter message by 1 to go from 1/10 to 10/10 instead of 0/10 to 9/10
         val counterMsg = (i + 1) + "/" + sortedGroups.keyCount
+
         val Evaluated(newResults, newEvaluated, cached) = evaluateGroupCached(
           terminal = terminal,
           group = group,
@@ -386,7 +386,7 @@ class Evaluator private (
         externalClassLoaderSigHash + scriptsHash
       } else {
         // We fallback to the old mechanism when the importTree was not populated
-        classLoaderSignHash
+        classLoaderSig.hashCode()
       }
 
     val inputsHash = externalInputsHash + sideHashes + classLoaderSigHash
@@ -405,6 +405,7 @@ class Evaluator private (
           logger
         )
         Evaluated(newResults, newEvaluated.toSeq, false)
+
       case lntRight @ Right(labelledNamedTask) =>
         val out =
           if (!labelledNamedTask.task.ctx.external) outPath
@@ -426,9 +427,33 @@ class Evaluator private (
             catch { case e: Throwable => None }
         } yield (parsed, cached.valueHash)
 
-        val workerCached: Option[Any] = labelledNamedTask.task.asWorker
-          .flatMap { w => synchronized { workerCache.get(w.ctx.segments) } }
-          .collect { case (`inputsHash`, v) => v }
+        val previousWorker = labelledNamedTask.task.asWorker.flatMap { w =>
+          workerCache.synchronized { workerCache.get(w.ctx.segments) }
+        }
+        val workerCached: Option[Any] = previousWorker.collect { case (`inputsHash`, v) => v }
+
+        // Cleanup outdated worker
+        previousWorker
+          .collect {
+            case (hash, v) if v.isInstanceOf[AutoCloseable] && inputsHash != hash => v
+          }
+          .foreach { closableWorkerValue =>
+            try {
+              logger.debug(s"Closing previous worker: ${labelledNamedTask.segments.render}")
+              closableWorkerValue.asInstanceOf[AutoCloseable].close()
+            } catch {
+              case NonFatal(e) =>
+                logger.error(
+                  s"${labelledNamedTask.segments.render}: Errors while closing obsolete worker: ${e.getMessage()}"
+                )
+            }
+            // make sure, we can no longer re-use a closed worker
+            labelledNamedTask.task.asWorker.foreach { w =>
+              workerCache.synchronized {
+                workerCache.remove(w.ctx.segments)
+              }
+            }
+          }
 
         workerCached.map((_, inputsHash)) orElse cached match {
           case Some((v, hashCode)) =>
@@ -496,7 +521,10 @@ class Evaluator private (
       labelledNamedTask: Labelled[_]
   ) = {
     labelledNamedTask.task.asWorker match {
-      case Some(w) => synchronized { workerCache(w.ctx.segments) = (inputsHash, v) }
+      case Some(w) =>
+        workerCache.synchronized {
+          workerCache.put(w.ctx.segments, (inputsHash, v))
+        }
       case None =>
         val terminalResult = labelledNamedTask
           .writer
@@ -528,6 +556,9 @@ class Evaluator private (
       logger: Logger
   ): (mutable.LinkedHashMap[Task[_], mill.api.Result[(Any, Int)]], mutable.Buffer[Task[_]]) = {
 
+    val namedTasks = group.collect {
+      case t: NamedTask[_] => t
+    }
     val newEvaluated = mutable.Buffer.empty[Task[_]]
     val newResults = mutable.LinkedHashMap.empty[Task[_], mill.api.Result[(Any, Int)]]
 
@@ -864,7 +895,7 @@ object Evaluator {
     val topoSorted = Graph.topoSorted(transitive)
     val seen = collection.mutable.Set.empty[Segments]
     val overridden = collection.mutable.Set.empty[Task[_]]
-    topoSorted.values.reverse.foreach {
+    topoSorted.values.reverse.iterator.foreach {
       case x: NamedTask[_] =>
         if (!seen.contains(x.ctx.segments)) seen.add(x.ctx.segments)
         else overridden.add(x)
@@ -872,6 +903,7 @@ object Evaluator {
     }
 
     val sortedGroups = Graph.groupAroundImportantTargets(topoSorted) {
+      // important: all named tasks and those explicitly requested
       case t: NamedTask[Any] =>
         val segments = t.ctx.segments
         Right(
@@ -1036,7 +1068,7 @@ object Evaluator {
     Seq.empty
   )
 
-  @deprecated(message = "Pattern matching not supported with EvaluatorState", since = "mill 0.10.1")
+  @deprecated(message = "Pattern matching not supported with Evaluator", since = "mill 0.10.1")
   def unapply(evaluator: Evaluator): Option[(
       os.Path,
       os.Path,

--- a/main/core/src/mill/eval/Evaluator.scala
+++ b/main/core/src/mill/eval/Evaluator.scala
@@ -556,9 +556,6 @@ class Evaluator private[Evaluator] (
       logger: Logger
   ): (mutable.LinkedHashMap[Task[_], mill.api.Result[(Any, Int)]], mutable.Buffer[Task[_]]) = {
 
-    val namedTasks = group.collect {
-      case t: NamedTask[_] => t
-    }
     val newEvaluated = mutable.Buffer.empty[Task[_]]
     val newResults = mutable.LinkedHashMap.empty[Task[_], mill.api.Result[(Any, Int)]]
 

--- a/main/test/src/eval/TaskTests.scala
+++ b/main/test/src/eval/TaskTests.scala
@@ -3,209 +3,217 @@ package mill.eval
 import utest._
 import mill.T
 import mill.define.Worker
-import mill.util.TestEvaluator
-class TaskTests(threadCount: Option[Int]) extends TestSuite {
-  val tests = Tests {
-    object build extends mill.util.TestUtil.BaseModule {
-      var count = 0
-      var changeOnceCount = 0
-      var workerCloseCount = 0
-      // Explicitly instantiate `Function1` objects to make sure we get
-      // different instances each time
-      def staticWorker: Worker[Int => Int] = T.worker {
-        new Function1[Int, Int] {
-          def apply(v1: Int) = v1 + 1
-        }
-      }
-      def changeOnceWorker: Worker[Int => Int] = T.worker {
-        new Function1[Int, Int] {
-          def apply(v1: Int): Int = changeOnceInput() + v1
-        }
-      }
-      def noisyWorker: Worker[Int => Int] = T.worker {
-        new Function1[Int, Int] {
-          def apply(v1: Int) = input() + v1
-        }
-      }
-      def noisyClosableWorker: Worker[(Int => Int) with AutoCloseable] = T.worker {
-        new Function1[Int, Int] with AutoCloseable {
-          override def apply(v1: Int) = input() + v1
-          override def close(): Unit = workerCloseCount += 1
-        }
-      }
-      def changeOnceInput = T.input {
-        val ret = changeOnceCount
-        if (changeOnceCount != 1) changeOnceCount = 1
-        ret
-      }
-      def input = T.input {
-        count += 1
-        count
-      }
-      def task = T.task {
-        count += 1
-        count
-      }
-      def taskInput = T { input() }
-      def taskNoInput = T { task() }
+import mill.util.{TestEvaluator, TestUtil}
+import utest.framework.TestPath
 
-      def persistent = T.persistent {
-        input() // force re-computation
-        os.makeDir.all(T.dest)
-        os.write.append(T.dest / "count", "hello\n")
-        os.read.lines(T.dest / "count").length
-      }
-      def nonPersistent = T {
-        input() // force re-computation
-        os.makeDir.all(T.dest)
-        os.write.append(T.dest / "count", "hello\n")
-        os.read.lines(T.dest / "count").length
-      }
-
-      def staticWorkerDownstream = T {
-        val w = staticWorker()
-        w.apply(1)
-      }
-
-      def reevalTrigger = T.input {
-        new Object().hashCode()
-      }
-      def staticWorkerDownstreamReeval = T {
-        val w = staticWorker()
-        reevalTrigger()
-        w.apply(1)
-      }
-
-      def noisyWorkerDownstream = T {
-        val w = noisyWorker()
-        w.apply(1)
-      }
-      def noisyClosableWorkerDownstream = T {
-        val w = noisyClosableWorker()
-        w.apply(1)
-      }
-      def changeOnceWorkerDownstream = T {
-        val w = changeOnceWorker()
-        w.apply(1)
+trait TaskTests extends TestSuite {
+  trait Build extends TestUtil.BaseModule {
+    var count = 0
+    var changeOnceCount = 0
+    var workerCloseCount = 0
+    // Explicitly instantiate `Function1` objects to make sure we get
+    // different instances each time
+    def staticWorker: Worker[Int => Int] = T.worker {
+      new Function1[Int, Int] {
+        def apply(v1: Int) = v1 + 1
       }
     }
+    def changeOnceWorker: Worker[Int => Int] = T.worker {
+      new Function1[Int, Int] {
+        def apply(v1: Int): Int = changeOnceInput() + v1
+      }
+    }
+    def noisyWorker: Worker[Int => Int] = T.worker {
+      new Function1[Int, Int] {
+        def apply(v1: Int) = input() + v1
+      }
+    }
+    def noisyClosableWorker: Worker[(Int => Int) with AutoCloseable] = T.worker {
+      new Function1[Int, Int] with AutoCloseable {
+        override def apply(v1: Int) = input() + v1
+        override def close(): Unit = workerCloseCount += 1
+      }
+    }
+    def changeOnceInput = T.input {
+      val ret = changeOnceCount
+      if (changeOnceCount != 1) changeOnceCount = 1
+      ret
+    }
+    def input = T.input {
+      count += 1
+      count
+    }
+    def task = T.task {
+      count += 1
+      count
+    }
+    def taskInput = T { input() }
+    def taskNoInput = T { task() }
 
-    "inputs" - {
+    def persistent = T.persistent {
+      input() // force re-computation
+      os.makeDir.all(T.dest)
+      os.write.append(T.dest / "count", "hello\n")
+      os.read.lines(T.dest / "count").length
+    }
+    def nonPersistent = T {
+      input() // force re-computation
+      os.makeDir.all(T.dest)
+      os.write.append(T.dest / "count", "hello\n")
+      os.read.lines(T.dest / "count").length
+    }
+
+    def staticWorkerDownstream = T {
+      val w = staticWorker()
+      w.apply(1)
+    }
+
+    def reevalTrigger = T.input {
+      new Object().hashCode()
+    }
+    def staticWorkerDownstreamReeval = T {
+      val w = staticWorker()
+      reevalTrigger()
+      w.apply(1)
+    }
+
+    def noisyWorkerDownstream = T {
+      val w = noisyWorker()
+      w.apply(1)
+    }
+    def noisyClosableWorkerDownstream = T {
+      val w = noisyClosableWorker()
+      w.apply(1)
+    }
+    def changeOnceWorkerDownstream = T {
+      val w = changeOnceWorker()
+      w.apply(1)
+    }
+  }
+
+  def withEnv(f: (Build, TestEvaluator) => Unit)(implicit tp: TestPath)
+
+  val tests = Tests {
+
+    "inputs" - withEnv { (build, check) =>
       // Inputs always re-evaluate, including forcing downstream cached Targets
       // to re-evaluate, but normal Tasks behind a Target run once then are cached
-      val check = new TestEvaluator(build, threads = threadCount)
-
-      val Right((1, 1)) = check.apply(build.taskInput)
-      val Right((2, 1)) = check.apply(build.taskInput)
-      val Right((3, 1)) = check.apply(build.taskInput)
-
-      val Right((4, 1)) = check.apply(build.taskNoInput)
-      val Right((4, 0)) = check.apply(build.taskNoInput)
-      val Right((4, 0)) = check.apply(build.taskNoInput)
+      check.apply(build.taskInput) ==> Right((1, 1))
+      check.apply(build.taskInput) ==> Right((2, 1))
+      check.apply(build.taskInput) ==> Right((3, 1))
+    }
+    "noInputs" - withEnv { (build, check) =>
+      // Inputs always re-evaluate, including forcing downstream cached Targets
+      // to re-evaluate, but normal Tasks behind a Target run once then are cached
+      check.apply(build.taskNoInput) ==> Right((1, 1))
+      check.apply(build.taskNoInput) ==> Right((1, 0))
+      check.apply(build.taskNoInput) ==> Right((1, 0))
     }
 
-    "persistent" - {
+    "persistent" - withEnv { (build, check) =>
       // Persistent tasks keep the working dir around between runs
-      val check = new TestEvaluator(build, threads = threadCount)
-      val Right((1, 1)) = check.apply(build.persistent)
-      val Right((2, 1)) = check.apply(build.persistent)
-      val Right((3, 1)) = check.apply(build.persistent)
-
-      val Right((1, 1)) = check.apply(build.nonPersistent)
-      val Right((1, 1)) = check.apply(build.nonPersistent)
-      val Right((1, 1)) = check.apply(build.nonPersistent)
+      println(build.millSourcePath + "\n")
+      check.apply(build.persistent) ==> Right((1, 1))
+      check.apply(build.persistent) ==> Right((2, 1))
+      check.apply(build.persistent) ==> Right((3, 1))
+    }
+    "nonPersistent" - withEnv { (build, check) =>
+      // non-Persistent tasks keep the working dir around between runs
+      check.apply(build.nonPersistent) ==> Right((1, 1))
+      check.apply(build.nonPersistent) ==> Right((1, 1))
+      check.apply(build.nonPersistent) ==> Right((1, 1))
     }
 
     "worker" - {
-      "static" - {
-        val check = new TestEvaluator(build, threads = threadCount)
-        assert(
-          check.apply(build.staticWorkerDownstream) == Right((2, 1)),
-          check.evaluator.workerCache.size == 1
-        )
-        val firstCached = check.evaluator.workerCache.head
+      "static" - withEnv { (build, check) =>
+        val wc = check.evaluator.workerCache
 
-        assert(
-          check.apply(build.staticWorkerDownstream) == Right((2, 0)),
-          check.evaluator.workerCache.head == firstCached,
-          check.apply(build.staticWorkerDownstream) == Right((2, 0)),
-          check.evaluator.workerCache.head == firstCached
-        )
+        check.apply(build.staticWorkerDownstream) ==> Right((2, 1))
+        wc.size ==> 1
+        val firstCached = wc.head
+
+        check.apply(build.staticWorkerDownstream) ==> Right((2, 0))
+        wc.head ==> firstCached
+        check.apply(build.staticWorkerDownstream) ==> Right((2, 0))
+        wc.head ==> firstCached
       }
-      "staticButReevaluated" - {
-        val check = new TestEvaluator(build, threads = threadCount)
+      "staticButReevaluated" - withEnv { (build, check) =>
+        val wc = check.evaluator.workerCache
 
-        assert(
-          check.apply(build.staticWorkerDownstreamReeval) == Right((2, 1)),
-          check.evaluator.workerCache.size == 1
-        )
-        val firstCached = check.evaluator.workerCache.head
+        check.apply(build.staticWorkerDownstreamReeval) ==> Right((2, 1))
+        check.evaluator.workerCache.size ==> 1
+        val firstCached = wc.head
 
-        assert(
-          check.apply(build.staticWorkerDownstreamReeval) == Right((2, 1)),
-          check.evaluator.workerCache.head == firstCached,
-          check.apply(build.staticWorkerDownstreamReeval) == Right((2, 1)),
-          check.evaluator.workerCache.head == firstCached
-        )
+        check.apply(build.staticWorkerDownstreamReeval) ==> Right((2, 1))
+        wc.head ==> firstCached
+        check.apply(build.staticWorkerDownstreamReeval) ==> Right((2, 1))
+        wc.head ==> firstCached
       }
-      "changedOnce" - {
-        val check = new TestEvaluator(build, threads = threadCount)
-        assert(
-          check.apply(build.changeOnceWorkerDownstream) == Right((1, 1)),
-          // changed
-          check.apply(build.changeOnceWorkerDownstream) == Right((2, 1)),
-          check.apply(build.changeOnceWorkerDownstream) == Right((2, 0))
-        )
+      "changedOnce" - withEnv { (build, check) =>
+        check.apply(build.changeOnceWorkerDownstream) ==> Right((1, 1))
+        // changed
+        check.apply(build.changeOnceWorkerDownstream) ==> Right((2, 1))
+        check.apply(build.changeOnceWorkerDownstream) ==> Right((2, 0))
       }
-      "alwaysChanged" - {
-        val check = new TestEvaluator(build, threads = threadCount)
+      "alwaysChanged" - withEnv { (build, check) =>
+        val wc = check.evaluator.workerCache
 
-        assert(
-          check.apply(build.noisyWorkerDownstream) == Right((2, 1)),
-          check.evaluator.workerCache.size == 1
-        )
-        val firstCached = check.evaluator.workerCache.head
+        check.apply(build.noisyWorkerDownstream) ==> Right((2, 1))
+        wc.size ==> 1
+        val firstCached = wc.head
 
-        assert(
-          check.apply(build.noisyWorkerDownstream) == Right((3, 1)),
-          check.evaluator.workerCache.size == 1,
-          check.evaluator.workerCache.head != firstCached
-        )
-        val secondCached = check.evaluator.workerCache.head
+        check.apply(build.noisyWorkerDownstream) ==> Right((3, 1))
+        wc.size ==> 1
+        assert(wc.head != firstCached)
+        val secondCached = wc.head
 
-        assert(
-          check.apply(build.noisyWorkerDownstream) == Right((4, 1)),
-          check.evaluator.workerCache.size == 1,
-          check.evaluator.workerCache.head != secondCached
-        )
+        check.apply(build.noisyWorkerDownstream) ==> Right((4, 1))
+        wc.size ==> 1
+        assert(wc.head != secondCached)
       }
-      "closableWorker" - {
-        val check = new TestEvaluator(build, threads = threadCount)
+      "closableWorker" - withEnv { (build, check) =>
+        val wc = check.evaluator.workerCache
 
-        assert(
-          check.apply(build.noisyClosableWorkerDownstream) == Right((2, 1)),
-          check.evaluator.workerCache.size == 1,
-          build.workerCloseCount == 0
-        )
-        val firstCached = check.evaluator.workerCache.head
+        check.apply(build.noisyClosableWorkerDownstream) ==> Right((2, 1))
+        wc.size ==> 1
+        build.workerCloseCount ==> 0
 
-        assert(
-          check.apply(build.noisyClosableWorkerDownstream) == Right((3, 1)),
-          check.evaluator.workerCache.size == 1,
-          build.workerCloseCount == 1,
-          check.evaluator.workerCache.head != firstCached
-        )
-        val secondCached = check.evaluator.workerCache.head
+        val firstCached = wc.head
 
-        assert(
-          check.apply(build.noisyClosableWorkerDownstream) == Right((4, 1)),
-          check.evaluator.workerCache.size == 1,
-          check.evaluator.workerCache.head != secondCached
-        )
+        check.apply(build.noisyClosableWorkerDownstream) ==> Right((3, 1))
+        wc.size ==> 1
+        build.workerCloseCount ==> 1
+        assert(wc.head != firstCached)
+
+        val secondCached = wc.head
+
+        check.apply(build.noisyClosableWorkerDownstream) ==> Right((4, 1))
+        wc.size ==> 1
+        assert(wc.head != secondCached)
       }
     }
   }
 }
 
-object SeqTaskTests extends TaskTests(Some(1))
-object ParTaskTests extends TaskTests(Some(16))
+object SeqTaskTests extends TaskTests {
+  def withEnv(f: (Build, TestEvaluator) => Unit)(implicit tp: TestPath) = {
+    object build extends Build
+    val check = new TestEvaluator(
+      build,
+      threads = Some(1),
+      extraPathEnd = Seq(getClass().getSimpleName())
+    )
+    f(build, check)
+  }
+}
+object ParTaskTests extends TaskTests {
+  def withEnv(f: (Build, TestEvaluator) => Unit)(implicit tp: TestPath) = {
+    object build extends Build
+    val check = new TestEvaluator(
+      build,
+      threads = Some(16),
+      extraPathEnd = Seq(getClass().getSimpleName())
+    )
+    f(build, check)
+  }
+}

--- a/main/test/src/eval/TaskTests.scala
+++ b/main/test/src/eval/TaskTests.scala
@@ -1,25 +1,42 @@
 package mill.eval
 
 import utest._
-
 import mill.T
-
+import mill.define.Worker
 import mill.util.TestEvaluator
-object TaskTests extends TestSuite {
+class TaskTests(threadCount: Option[Int]) extends TestSuite {
   val tests = Tests {
     object build extends mill.util.TestUtil.BaseModule {
       var count = 0
+      var changeOnceCount = 0
+      var workerCloseCount = 0
       // Explicitly instantiate `Function1` objects to make sure we get
       // different instances each time
-      def staticWorker = T.worker {
+      def staticWorker: Worker[Int => Int] = T.worker {
         new Function1[Int, Int] {
           def apply(v1: Int) = v1 + 1
         }
       }
-      def noisyWorker = T.worker {
+      def changeOnceWorker: Worker[Int => Int] = T.worker {
         new Function1[Int, Int] {
-          def apply(v1: Int) = input() + 1
+          def apply(v1: Int): Int = changeOnceInput() + v1
         }
+      }
+      def noisyWorker: Worker[Int => Int] = T.worker {
+        new Function1[Int, Int] {
+          def apply(v1: Int) = input() + v1
+        }
+      }
+      def noisyClosableWorker: Worker[(Int => Int) with AutoCloseable] = T.worker {
+        new Function1[Int, Int] with AutoCloseable {
+          override def apply(v1: Int) = input() + v1
+          override def close(): Unit = workerCloseCount += 1
+        }
+      }
+      def changeOnceInput = T.input {
+        val ret = changeOnceCount
+        if (changeOnceCount != 1) changeOnceCount = 1
+        ret
       }
       def input = T.input {
         count += 1
@@ -46,17 +63,37 @@ object TaskTests extends TestSuite {
       }
 
       def staticWorkerDownstream = T {
-        staticWorker().apply(1)
+        val w = staticWorker()
+        w.apply(1)
       }
+
+      def reevalTrigger = T.input {
+        new Object().hashCode()
+      }
+      def staticWorkerDownstreamReeval = T {
+        val w = staticWorker()
+        reevalTrigger()
+        w.apply(1)
+      }
+
       def noisyWorkerDownstream = T {
-        noisyWorker().apply(1)
+        val w = noisyWorker()
+        w.apply(1)
+      }
+      def noisyClosableWorkerDownstream = T {
+        val w = noisyClosableWorker()
+        w.apply(1)
+      }
+      def changeOnceWorkerDownstream = T {
+        val w = changeOnceWorker()
+        w.apply(1)
       }
     }
 
     "inputs" - {
       // Inputs always re-evaluate, including forcing downstream cached Targets
       // to re-evaluate, but normal Tasks behind a Target run once then are cached
-      val check = new TestEvaluator(build)
+      val check = new TestEvaluator(build, threads = threadCount)
 
       val Right((1, 1)) = check.apply(build.taskInput)
       val Right((2, 1)) = check.apply(build.taskInput)
@@ -69,7 +106,7 @@ object TaskTests extends TestSuite {
 
     "persistent" - {
       // Persistent tasks keep the working dir around between runs
-      val check = new TestEvaluator(build)
+      val check = new TestEvaluator(build, threads = threadCount)
       val Right((1, 1)) = check.apply(build.persistent)
       val Right((2, 1)) = check.apply(build.persistent)
       val Right((3, 1)) = check.apply(build.persistent)
@@ -80,16 +117,95 @@ object TaskTests extends TestSuite {
     }
 
     "worker" - {
-      // Persistent task
-      def check = new TestEvaluator(build)
+      "static" - {
+        val check = new TestEvaluator(build, threads = threadCount)
+        assert(
+          check.apply(build.staticWorkerDownstream) == Right((2, 1)),
+          check.evaluator.workerCache.size == 1
+        )
+        val firstCached = check.evaluator.workerCache.head
 
-      val Right((2, 1)) = check.apply(build.noisyWorkerDownstream)
-      val Right((3, 1)) = check.apply(build.noisyWorkerDownstream)
-      val Right((4, 1)) = check.apply(build.noisyWorkerDownstream)
+        assert(
+          check.apply(build.staticWorkerDownstream) == Right((2, 0)),
+          check.evaluator.workerCache.head == firstCached,
+          check.apply(build.staticWorkerDownstream) == Right((2, 0)),
+          check.evaluator.workerCache.head == firstCached
+        )
+      }
+      "staticButReevaluated" - {
+        val check = new TestEvaluator(build, threads = threadCount)
 
-      val Right((2, 1)) = check.apply(build.staticWorkerDownstream)
-      val Right((2, 0)) = check.apply(build.staticWorkerDownstream)
-      val Right((2, 0)) = check.apply(build.staticWorkerDownstream)
+        assert(
+          check.apply(build.staticWorkerDownstreamReeval) == Right((2, 1)),
+          check.evaluator.workerCache.size == 1
+        )
+        val firstCached = check.evaluator.workerCache.head
+
+        assert(
+          check.apply(build.staticWorkerDownstreamReeval) == Right((2, 1)),
+          check.evaluator.workerCache.head == firstCached,
+          check.apply(build.staticWorkerDownstreamReeval) == Right((2, 1)),
+          check.evaluator.workerCache.head == firstCached
+        )
+      }
+      "changedOnce" - {
+        val check = new TestEvaluator(build, threads = threadCount)
+        assert(
+          check.apply(build.changeOnceWorkerDownstream) == Right((1, 1)),
+          // changed
+          check.apply(build.changeOnceWorkerDownstream) == Right((2, 1)),
+          check.apply(build.changeOnceWorkerDownstream) == Right((2, 0))
+        )
+      }
+      "alwaysChanged" - {
+        val check = new TestEvaluator(build, threads = threadCount)
+
+        assert(
+          check.apply(build.noisyWorkerDownstream) == Right((2, 1)),
+          check.evaluator.workerCache.size == 1
+        )
+        val firstCached = check.evaluator.workerCache.head
+
+        assert(
+          check.apply(build.noisyWorkerDownstream) == Right((3, 1)),
+          check.evaluator.workerCache.size == 1,
+          check.evaluator.workerCache.head != firstCached
+        )
+        val secondCached = check.evaluator.workerCache.head
+
+        assert(
+          check.apply(build.noisyWorkerDownstream) == Right((4, 1)),
+          check.evaluator.workerCache.size == 1,
+          check.evaluator.workerCache.head != secondCached
+        )
+      }
+      "closableWorker" - {
+        val check = new TestEvaluator(build, threads = threadCount)
+
+        assert(
+          check.apply(build.noisyClosableWorkerDownstream) == Right((2, 1)),
+          check.evaluator.workerCache.size == 1,
+          build.workerCloseCount == 0
+        )
+        val firstCached = check.evaluator.workerCache.head
+
+        assert(
+          check.apply(build.noisyClosableWorkerDownstream) == Right((3, 1)),
+          check.evaluator.workerCache.size == 1,
+          build.workerCloseCount == 1,
+          check.evaluator.workerCache.head != firstCached
+        )
+        val secondCached = check.evaluator.workerCache.head
+
+        assert(
+          check.apply(build.noisyClosableWorkerDownstream) == Right((4, 1)),
+          check.evaluator.workerCache.size == 1,
+          check.evaluator.workerCache.head != secondCached
+        )
+      }
     }
   }
 }
+
+object SeqTaskTests extends TaskTests(Some(1))
+object ParTaskTests extends TaskTests(Some(16))

--- a/main/test/src/util/TestEvaluator.scala
+++ b/main/test/src/util/TestEvaluator.scala
@@ -1,16 +1,15 @@
 package mill.util
 
 import java.io.{InputStream, PrintStream}
-
 import mill.define.{Input, Target, Task}
 import mill.api.Result.OuterStack
-import mill.eval.{Evaluator, Result}
+import mill.eval.Evaluator
 import mill.api.Strict.Agg
 import utest.assert
 import utest.framework.TestPath
-import language.experimental.macros
 
-import mill.api.DummyInputStream
+import language.experimental.macros
+import mill.api.{DummyInputStream, Result}
 object TestEvaluator {
   val externalOutPath = os.pwd / "target" / "external"
 

--- a/main/test/src/util/TestEvaluator.scala
+++ b/main/test/src/util/TestEvaluator.scala
@@ -29,9 +29,10 @@ class TestEvaluator(
     threads: Option[Int] = Some(1),
     outStream: PrintStream = System.out,
     inStream: InputStream = DummyInputStream,
-    debugEnabled: Boolean = false
+    debugEnabled: Boolean = false,
+    extraPathEnd: Seq[String] = Seq.empty
 )(implicit fullName: sourcecode.FullName, tp: TestPath) {
-  val outPath = TestUtil.getOutPath()
+  val outPath = TestUtil.getOutPath() / extraPathEnd
 
 //  val logger = DummyLogger
   val logger = new PrintLogger(


### PR DESCRIPTION
This PR implements this idea:

*  https://github.com/com-lihaoyi/mill/discussions/1780

The idea is, to automatically call the `java.lang.AutoCloseable.close()` method on workers than gets dropped, to provide a chance to clean up and free resources.

I also applied some minor improvements on the go. E.g. synchronized access to `Evaluator.workerCache` now synchronizes on the `workerCache`, not on the `Evaluator` instance.

I also added tests cases to test `AutoCloseable` workers, sequentially and parallel.

Updated documentation.