### PR TITLE
Fix repl due to orphan hard-coded import

### DIFF
--- a/main/src/mill/MillMain.scala
+++ b/main/src/mill/MillMain.scala
@@ -180,7 +180,6 @@ object MillMain {
                    |  threadCount = ${threadCount}
                    |)
                    |repl.pprinter() = replApplyHandler.pprinter
-                   |import replApplyHandler.generatedEval._
                    |""".stripMargin
 
             val importsPredefCode: String = config.imports.map {


### PR DESCRIPTION
Repl is [broken](https://gist.github.com/nitay/202497eae0d620ecca0d95554678ea00), I think by [this PR](https://github.com/com-lihaoyi/mill/pull/1623/files#diff-cf8cae18d6322a4629c16905aab926c3ac355868f5d7f2aa3ff2bd515d5bec23)
This fixes it
