### PR TITLE
Add transitive moduleDeps to BSP evaluated modules

### DIFF
--- a/bsp/src/mill/bsp/MillBuildServer.scala
+++ b/bsp/src/mill/bsp/MillBuildServer.scala
@@ -54,7 +54,7 @@ import mill.api.{DummyTestReporter, Result, Strict}
 import mill.define.Segment.Label
 import mill.define.{BaseModule, Discover, ExternalModule, Segments, Task}
 import mill.eval.Evaluator
-import mill.internal.ModuleUtils
+import mill.scalalib.internal.ModuleUtils
 import mill.main.{BspServerResult, EvaluatorScopt, MainModule}
 import mill.scalalib.{JavaModule, TestModule}
 import mill.scalalib.bsp.{BspModule, MillBuildTarget}

--- a/bsp/src/mill/bsp/MillBuildServer.scala
+++ b/bsp/src/mill/bsp/MillBuildServer.scala
@@ -54,6 +54,7 @@ import mill.api.{DummyTestReporter, Result, Strict}
 import mill.define.Segment.Label
 import mill.define.{BaseModule, Discover, ExternalModule, Segments, Task}
 import mill.eval.Evaluator
+import mill.internal.ModuleUtils
 import mill.main.{BspServerResult, EvaluatorScopt, MainModule}
 import mill.scalalib.{JavaModule, TestModule}
 import mill.scalalib.bsp.{BspModule, MillBuildTarget}
@@ -93,7 +94,7 @@ class MillBuildServer(
         idToModule match {
           case None =>
             val modules: Seq[Module] =
-              evaluator.rootModule.millInternal.modules ++ Seq(`mill-build`)
+              ModuleUtils.transitiveModules(evaluator.rootModule) ++ Seq(`mill-build`)
             val map = modules.collect {
               case m: MillBuildTarget =>
                 val uri = sanitizeUri(m.millSourcePath) +

--- a/bsp/test/resources/bsp-modules/build.sc
+++ b/bsp/test/resources/bsp-modules/build.sc
@@ -1,0 +1,35 @@
+import mill._
+import mill.api.{PathRef}
+import mill.scalalib._
+import $file.proj1.{build => proj1}
+import $file.proj2.{build => proj2}
+import $file.proj3.{build => proj3}
+
+trait HelloBspModule extends ScalaModule {
+  def scalaVersion = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
+  object test extends super.Tests with TestModule.Utest
+}
+
+object HelloBsp extends HelloBspModule {
+  // Explicitly depends on proj1
+  def moduleDeps: Seq[JavaModule] = Seq(proj1.proj1)
+  // Explicitly depends on proj2
+  def compileModuleDeps: Seq[JavaModule] = Seq(proj2.proj2)
+  // Implicitly depends on proj3 via a target
+  override def unmanagedClasspath: T[Agg[PathRef]] = T {
+    Agg(proj3.proj3.jar())
+  }
+}
+
+def validate() = T.command {
+  val transitiveModules = mill.scalalib.internal.ModuleUtils.transitiveModules(build)
+  val file = T.dest / "transitive-modules.json"
+  val moduleNames = transitiveModules.map(m =>
+    s"${m.millOuterCtx.foreign.map(f => s"${f.render}.").mkString}${m.millModuleSegments.render}"
+  ).mkString("\n")
+  val content =
+    s"""${moduleNames}
+       |""".stripMargin
+  os.write(file, content)
+  PathRef(file)
+}

--- a/bsp/test/resources/bsp-modules/proj1/build.sc
+++ b/bsp/test/resources/bsp-modules/proj1/build.sc
@@ -1,0 +1,6 @@
+import mill._
+import mill.scalalib._
+
+object proj1 extends ScalaModule {
+  def scalaVersion = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
+}

--- a/bsp/test/resources/bsp-modules/proj2/build.sc
+++ b/bsp/test/resources/bsp-modules/proj2/build.sc
@@ -1,0 +1,6 @@
+import mill._
+import mill.scalalib._
+
+object proj2 extends ScalaModule {
+  def scalaVersion = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
+}

--- a/bsp/test/resources/bsp-modules/proj3/build.sc
+++ b/bsp/test/resources/bsp-modules/proj3/build.sc
@@ -1,0 +1,6 @@
+import mill._
+import mill.scalalib._
+
+object proj3 extends ScalaModule {
+  def scalaVersion = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
+}

--- a/bsp/test/src/BspModulesTests.scala
+++ b/bsp/test/src/BspModulesTests.scala
@@ -25,7 +25,7 @@ object BspModulesTests extends ScriptTestSuite(false) {
           "HelloBsp.test",
           "foreign-modules.proj1.proj1",
           "foreign-modules.proj2.proj2",
-          // "proj3" // still not detected
+          // "foreign-modules.proj3.proj3" // still not detected
         ).sorted
         readModules ==> expectedModules
       }

--- a/bsp/test/src/BspModulesTests.scala
+++ b/bsp/test/src/BspModulesTests.scala
@@ -1,0 +1,34 @@
+import mill.bsp.BSP
+import mill.util.ScriptTestSuite
+import utest._
+
+object BspModulesTests extends ScriptTestSuite(false) {
+  override def workspaceSlug: String = "bsp-modules"
+  override def scriptSourcePath: os.Path = os.pwd / "bsp" / "test" / "resources" / workspaceSlug
+
+  def tests: Tests = Tests {
+    test("BSP module with foreign modules") {
+      test("can be installed") {
+        val workspacePath = initWorkspace()
+        eval("mill.bsp.BSP/install") ==> true
+        os.exists(workspacePath / ".bsp" / s"${BSP.serverName}.json") ==> true
+      }
+      test("ModuleUtils resolves all referenced transitive modules") {
+        val workspacePath = initWorkspace()
+        eval("validate") ==> true
+        val file = workspacePath / "out" / "validate.dest" / "transitive-modules.json"
+        os.exists(file) ==> true
+        val readModules = os.read.lines(file).sorted
+        val expectedModules = Seq(
+          "", // the root module has no segemnts at all
+          "HelloBsp",
+          "HelloBsp.test",
+          "foreign-modules.proj1.proj1",
+          "foreign-modules.proj2.proj2",
+          // "proj3" // still not detected
+        ).sorted
+        readModules ==> expectedModules
+      }
+    }
+  }
+}

--- a/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
+++ b/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
@@ -4,7 +4,7 @@ import bloop.config.{Config => BloopConfig, Tag => BloopTag}
 import mill._
 import mill.define.{Module => MillModule, _}
 import mill.eval.Evaluator
-import mill.internal.ModuleUtils
+import mill.scalalib.internal.ModuleUtils
 import mill.scalajslib.ScalaJSModule
 import mill.scalajslib.api.{JsEnvConfig, ModuleKind}
 import mill.scalalib._

--- a/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
+++ b/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
@@ -4,6 +4,7 @@ import bloop.config.{Config => BloopConfig, Tag => BloopTag}
 import mill._
 import mill.define.{Module => MillModule, _}
 import mill.eval.Evaluator
+import mill.internal.ModuleUtils
 import mill.scalajslib.ScalaJSModule
 import mill.scalajslib.api.{JsEnvConfig, ModuleKind}
 import mill.scalalib._
@@ -100,23 +101,12 @@ class BloopImpl(ev: () => Evaluator, wd: os.Path) extends ExternalModule { outer
   }
 
   // Compute all transitive modules from build children and via moduleDeps
+  @deprecated("Internal use only. To be removed", since = "mill 0.10.3")
   def transitiveModules(
       mod: define.Module,
       found: Seq[define.Module] = Seq.empty
   ): Seq[define.Module] = {
-    val skip = mod match {
-      case jm: JavaModule => skippable(jm)
-      case _ => false
-    }
-    if (found.contains(mod) || skip)
-      found
-    else {
-      val subMods = mod.millModuleDirectChildren ++ (mod match {
-        case jm: JavaModule => jm.moduleDeps
-        case other => Seq.empty
-      })
-      subMods.foldLeft(found ++ Seq(mod)) { (all, mod) => transitiveModules(mod, all) }
-    }
+    ModuleUtils.transitiveModules(mod, toSkip)
   }
 
   protected def computeModules: Seq[JavaModule] = {
@@ -128,8 +118,9 @@ class BloopImpl(ev: () => Evaluator, wd: os.Path) extends ExternalModule { outer
   }
 
   // class-based pattern matching against path-dependant types doesn't seem to work.
-  private def skippable(module: scalalib.JavaModule): Boolean =
-    if (module.isInstanceOf[outer.Module]) module.asInstanceOf[outer.Module].skipBloop
+  private def toSkip(module: MillModule): Boolean =
+    if (module.isInstanceOf[JavaModule] && module.isInstanceOf[outer.Module])
+      module.asInstanceOf[outer.Module].skipBloop
     else false
 
   /**

--- a/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
+++ b/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
@@ -101,12 +101,12 @@ class BloopImpl(ev: () => Evaluator, wd: os.Path) extends ExternalModule { outer
   }
 
   // Compute all transitive modules from build children and via moduleDeps
-  @deprecated("Internal use only. To be removed", since = "mill 0.10.3")
+  @deprecated("Use mill.internal.ModuleUtils.transitiveModules instead", since = "mill 0.10.3")
   def transitiveModules(
       mod: define.Module,
       found: Seq[define.Module] = Seq.empty
   ): Seq[define.Module] = {
-    ModuleUtils.transitiveModules(mod, toSkip)
+    ModuleUtils.transitiveModules(mod, accept)
   }
 
   protected def computeModules: Seq[JavaModule] = {
@@ -118,10 +118,10 @@ class BloopImpl(ev: () => Evaluator, wd: os.Path) extends ExternalModule { outer
   }
 
   // class-based pattern matching against path-dependant types doesn't seem to work.
-  private def toSkip(module: MillModule): Boolean =
+  private def accept(module: MillModule): Boolean =
     if (module.isInstanceOf[JavaModule] && module.isInstanceOf[outer.Module])
-      module.asInstanceOf[outer.Module].skipBloop
-    else false
+      !module.asInstanceOf[outer.Module].skipBloop
+    else true
 
   /**
    * Computes sources files paths for the whole project. Cached in a way

--- a/scalalib/src/internal/ModuleUtils.scala
+++ b/scalalib/src/internal/ModuleUtils.scala
@@ -3,16 +3,18 @@ package mill.internal
 import mill.define.Module
 import mill.scalalib.JavaModule
 
+/**
+ * Compute all transitive modules from module children and via moduleDeps
+ */
 @mill.api.internal
 private[mill] object ModuleUtils {
-  // Compute all transitive modules from build children and via moduleDeps
-  def transitiveModules(module: Module, toSkip: Module => Boolean = _ => false): Seq[Module] = {
+  def transitiveModules(module: Module, accept: Module => Boolean = _ => true): Seq[Module] = {
     def loop(mod: Module, found: Seq[Module]): Seq[Module] = {
-      if (toSkip(mod) || found.contains(mod))
+      if (!accept(mod) || found.contains(mod))
         found
       else {
         val subMods = mod.millModuleDirectChildren ++ (mod match {
-          case jm: JavaModule => jm.moduleDeps
+          case jm: JavaModule => jm.moduleDeps ++ jm.compileModuleDeps
           case other => Seq.empty
         })
         subMods.foldLeft(found ++ Seq(mod)) { (all, mod) => loop(mod, all) }

--- a/scalalib/src/internal/ModuleUtils.scala
+++ b/scalalib/src/internal/ModuleUtils.scala
@@ -1,0 +1,24 @@
+package mill.internal
+
+import mill.define.Module
+import mill.scalalib.JavaModule
+
+@mill.api.internal
+private[mill] object ModuleUtils {
+  // Compute all transitive modules from build children and via moduleDeps
+  def transitiveModules(module: Module, toSkip: Module => Boolean = _ => false): Seq[Module] = {
+    def loop(mod: Module, found: Seq[Module]): Seq[Module] = {
+      if (toSkip(mod) || found.contains(mod))
+        found
+      else {
+        val subMods = mod.millModuleDirectChildren ++ (mod match {
+          case jm: JavaModule => jm.moduleDeps
+          case other => Seq.empty
+        })
+        subMods.foldLeft(found ++ Seq(mod)) { (all, mod) => loop(mod, all) }
+      }
+    }
+
+    loop(module, Seq.empty)
+  }
+}

--- a/scalalib/src/mill/scalalib/internal/ModuleUtils.scala
+++ b/scalalib/src/mill/scalalib/internal/ModuleUtils.scala
@@ -1,4 +1,4 @@
-package mill.internal
+package mill.scalalib.internal
 
 import mill.define.Module
 import mill.scalalib.JavaModule
@@ -7,7 +7,7 @@ import mill.scalalib.JavaModule
  * Compute all transitive modules from module children and via moduleDeps
  */
 @mill.api.internal
-private[mill] object ModuleUtils {
+object ModuleUtils {
   def transitiveModules(module: Module, accept: Module => Boolean = _ => true): Seq[Module] = {
     def loop(mod: Module, found: Seq[Module]): Seq[Module] = {
       if (!accept(mod) || found.contains(mod))


### PR DESCRIPTION
Fixes #1800 

Extracted the method used by `BloopImpl` to get the transitive modules from `rootModule` in a `internal` module and make BSP use it as well.