### PR TITLE
Don't include resources into compileClasspath.

### DIFF
--- a/scalalib/src/JavaModule.scala
+++ b/scalalib/src/JavaModule.scala
@@ -238,12 +238,15 @@ trait JavaModule
   def sources = T.sources { millSourcePath / "src" }
 
   /**
-   * The folders where the resource files for this module live
+   * The folders where the resource files for this module live.
+   * If you need resources to be seen by the compiler, use [[compileResources]].
    */
   def resources: Sources = T.sources { millSourcePath / "resources" }
 
   /**
-   * The folders where the compile time resource files for this module live
+   * The folders where the compile time resource files for this module live.
+   * If your resources files do not necessarily need to be seen by the compiler,
+   * you should use [[resources]] instead.
    */
   def compileResources: Sources = T.sources { millSourcePath / "compile-resources" }
 

--- a/scalalib/src/JavaModule.scala
+++ b/scalalib/src/JavaModule.scala
@@ -243,6 +243,11 @@ trait JavaModule
   def resources: Sources = T.sources { millSourcePath / "resources" }
 
   /**
+   * The folders where the compile time resource files for this module live
+   */
+  def compileResources: Sources = T.sources { millSourcePath / "compile-resources" }
+
+  /**
    * Folders containing source files that are generated rather than
    * hand-written; these files can be generated in this target itself,
    * or can refer to files generated from other targets
@@ -325,7 +330,7 @@ trait JavaModule
   // Keep in sync with [[bspCompileClasspath]]
   def compileClasspath: T[Agg[PathRef]] = T {
     transitiveLocalClasspath() ++
-      resources() ++
+      compileResources() ++
       unmanagedClasspath() ++
       resolvedIvyDeps()
   }
@@ -335,7 +340,7 @@ trait JavaModule
   @internal
   def bspCompileClasspath: Target[Agg[UnresolvedPath]] = T {
     bspTransitiveLocalClasspath() ++
-      (resources() ++ unmanagedClasspath() ++ resolvedIvyDeps())
+      (compileResources() ++ unmanagedClasspath() ++ resolvedIvyDeps())
         .map(p => UnresolvedPath.ResolvedPath(p.path))
   }
 
@@ -515,7 +520,7 @@ trait JavaModule
    */
   def sourceJar: Target[PathRef] = T {
     Jvm.createJar(
-      (allSources() ++ resources()).map(_.path).filter(os.exists),
+      (allSources() ++ resources() ++ compileResources()).map(_.path).filter(os.exists),
       manifest()
     )
   }

--- a/scalalib/src/JavaModule.scala
+++ b/scalalib/src/JavaModule.scala
@@ -309,7 +309,7 @@ trait JavaModule
    * modules and third-party dependencies
    */
   def localClasspath: T[Seq[PathRef]] = T {
-    resources() ++ Agg(compile().classes)
+    compileResources() ++ resources() ++ Agg(compile().classes)
   }
 
   /**
@@ -318,7 +318,7 @@ trait JavaModule
    */
   @internal
   def bspLocalClasspath: Target[Agg[UnresolvedPath]] = T {
-    resources().map(p => UnresolvedPath.ResolvedPath(p.path)) ++ Agg(
+    (compileResources() ++ resources()).map(p => UnresolvedPath.ResolvedPath(p.path)) ++ Agg(
       bspCompileClassesPath()
     )
   }

--- a/scalalib/test/src/mill/scalalib/bsp/BspModuleTests.scala
+++ b/scalalib/test/src/mill/scalalib/bsp/BspModuleTests.scala
@@ -60,13 +60,15 @@ object BspModuleTests extends TestSuite {
             MultiBase.HelloBsp.bspCompileClasspath
           )
 
+          val relResult = result.iterator.map(_.resolve(eval.evaluator.pathsResolver).last).toSeq.sorted
+          val expected = Seq(
+            "compile-resources",
+            "slf4j-api-1.7.34.jar",
+            s"scala-library-${testScalaVersion}.jar"
+          ).sorted
+
           assert(
-            result.size == 3,
-            result.map(_.resolve(eval.evaluator.pathsResolver).last).toSet == Set(
-              "resources",
-              "slf4j-api-1.7.34.jar",
-              s"scala-library-${testScalaVersion}.jar"
-            ),
+            relResult == expected,
             evalCount > 0
           )
         }
@@ -85,7 +87,8 @@ object BspModuleTests extends TestSuite {
 
             val expected: Seq[FilePath] = Seq(
               MultiBase.HelloBsp.millSourcePath / "resources",
-              MultiBase.HelloBsp2.millSourcePath / "resources",
+              MultiBase.HelloBsp.millSourcePath / "compile-resources",
+              MultiBase.HelloBsp2.millSourcePath / "compile-resources",
               EvaluatorPaths.resolveDestPaths(eval.outPath, MultiBase.HelloBsp.compile)
                 .dest / "classes",
               os.rel / "slf4j-api-1.7.34.jar",
@@ -95,7 +98,6 @@ object BspModuleTests extends TestSuite {
             ).sortBy(_.toString)
 
             assert(
-              result.size == 7,
               relResults == expected,
               evalCount > 0
             )


### PR DESCRIPTION
Instead we now have a compileResources that is part of compileClasspath.

Fixes #1807 

* #1826 