### PR TITLE
Handle Ammonite build scripts with symbols

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -19,7 +19,7 @@ jobs:
           - ./mill -i -k "{main,scalalib,scalajslib,scalanativelib,bsp}.__.test"
           - ./mill -i -k "contrib.__.prepareOffline" + "contrib._.test"
           # - ./mill -i integration.test "mill.integration.local.JawnTests"
-          - ./mill -i integration.test "mill.integration.local.{AcyclicTests,AmmoniteTests,DocAnnotationsTests}"
+          - ./mill -i integration.test "mill.integration.local.{AcyclicTests,AmmoniteTests,DocAnnotationsTests,ScriptsInvalidationTests,ScriptsInvalidationForeignTests}"
           - ./mill -i docs.antora.githubPages
           # Caffeine tests require a published testng contrib module
           - |
@@ -91,7 +91,7 @@ jobs:
         buildcmd:
           - cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i -d -k "{__.publishLocal,assembly,__.compile}"
           - cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i -d -k "{main,scalalib,scalajslib,bsp}.__.test"
-          - cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i -d integration.test "mill.integration.local.{AcyclicTests,AmmoniteTests,DocAnnotationsTests}"
+          - cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i -d integration.test "mill.integration.local.{AcyclicTests,AmmoniteTests,DocAnnotationsTests,ScriptsInvalidationTests,ScriptsInvalidationForeignTests}"
           - cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i -d -k "contrib.__.prepareOffline" + "contrib.__.test"
 
     runs-on: windows-latest

--- a/integration/test/resources/invalidation/-#+&%.sc
+++ b/integration/test/resources/invalidation/-#+&%.sc
@@ -1,0 +1,3 @@
+object module extends Module {
+  def input = T {}
+}

--- a/integration/test/resources/invalidation/build.sc
+++ b/integration/test/resources/invalidation/build.sc
@@ -4,6 +4,7 @@ import $file.inputC
 import $ivy.`org.scalaj::scalaj-http:2.4.2`
 import $file.e.inputE
 import $file.`-#!+→&%=~`.inputSymbols
+import $file.`-#+&%`
 
 def task = T {
   inputA.input()
@@ -28,4 +29,9 @@ def taskE = T {
 def taskSymbols = T {
   println("taskSymbols")
   inputSymbols.input()
+}
+
+def taskSymbolsInFile = T {
+  println("taskSymbolsInFile")
+  `-#+&%`.module.input()
 }

--- a/integration/test/src/ScriptsInvalidationTests.scala
+++ b/integration/test/src/ScriptsInvalidationTests.scala
@@ -117,5 +117,13 @@ class ScriptsInvalidationTests(fork: Boolean) extends ScriptTestSuite(fork) {
 
       assert(result == expected)
     }
+    test("should handle ammonite files with symbols") {
+      initWorkspace()
+
+      val result = runTask("taskSymbolsInFile")
+      val expected = Seq("taskSymbolsInFile")
+
+      assert(result == expected)
+    }
   }
 }

--- a/main/core/test/src/mill/internal/AmmoniteUtilsTests.scala
+++ b/main/core/test/src/mill/internal/AmmoniteUtilsTests.scala
@@ -5,8 +5,7 @@ import utest._
 object AmmoniteUtilsTests extends TestSuite {
   val tests = Tests {
     test("normalizeAmmoniteImportPath") {
-      def normalize(s: String): String =
-        AmmoniteUtils.normalizeAmmoniteImportPath(s.split('.').toIndexedSeq).mkString(".")
+      def normalize(s: String): String = AmmoniteUtils.normalizeAmmoniteImportPath(s)
       test("should normalize classes compiled from multiple scripts") {
         val input1 = "ammonite.$file.e.$up.a.inputA"
         val input2 = "ammonite.$file.a.inputA"
@@ -61,7 +60,15 @@ object AmmoniteUtilsTests extends TestSuite {
       test("should handle special symbols") {
         val input = "ammonite.$file.-#!|\\?+*<→:&>%=~.inputSymbols"
         val result = normalize(input)
-        val expected = "ammonite.$file.$minus$hash$bang$bar$bslash$qmark$plus$times$less$u2192$colon$amp$greater$percent$eq$tilde.inputSymbols"
+        val expected =
+          "ammonite.$file.$minus$hash$bang$bar$bslash$qmark$plus$times$less$u2192$colon$amp$greater$percent$eq$tilde.inputSymbols"
+
+        assert(result == expected)
+      }
+      test("should handle special symbols in last file while removing inner classes") {
+        val input = "ammonite.$file.before$minusplus$something$minusafter"
+        val result = normalize(input)
+        val expected = "ammonite.$file.before$minusplus"
 
         assert(result == expected)
       }


### PR DESCRIPTION
Fixes #1798

The idea of `normalizeAmmoniteImportPath` is to have a single entry per file.
An ammonite file can have multiple classes inside its object.
The previous version was deduplicating all the classes by removing everything starting from the first `$`.
`ammonite.$file.build$module$` would become `ammonite.$file.build`
When a file contains symbols this doesn't work since  `` import $file.`with-symbols` `` generates  `ammonite.$file.with$minussymbols` which the old algorithm would change to `ammonite.$file.with`, which is wrong.
The new algorithm skips the special symbols mappings (`$minus`, `$plus`, etc.) from this removal.