### PR TITLE
Put modules before libraries in Intellij iml files

### DIFF
--- a/scalalib/src/GenIdeaImpl.scala
+++ b/scalalib/src/GenIdeaImpl.scala
@@ -818,6 +818,14 @@ case class GenIdeaImpl(
         <orderEntry type="sourceFolder" forTests="false" />
 
         {
+      for (dep <- depNames.sorted)
+        yield dep.scope match {
+          case None => <orderEntry type="module" module-name={dep.value} exported="" />
+          case Some(scope) =>
+            <orderEntry type="module" module-name={dep.value} exported="" scope={scope} />
+        }
+    }
+        {
       for (name <- libNames.sorted)
         yield name.scope match {
           case None => <orderEntry type="library" name={name.value} level="project" />
@@ -825,14 +833,6 @@ case class GenIdeaImpl(
             <orderEntry type="library" scope={scope} name={name.value} level="project" />
         }
 
-    }
-        {
-      for (dep <- depNames.sorted)
-        yield dep.scope match {
-          case None => <orderEntry type="module" module-name={dep.value} exported="" />
-          case Some(scope) =>
-            <orderEntry type="module" module-name={dep.value} exported="" scope={scope} />
-        }
     }
       </component>
       {

--- a/scalalib/test/resources/gen-idea-extended-hello-world/idea/mill_modules/helloworld.test.iml
+++ b/scalalib/test/resources/gen-idea-extended-hello-world/idea/mill_modules/helloworld.test.iml
@@ -10,7 +10,7 @@
         </content>
         <orderEntry type="inheritedJdk"/>
         <orderEntry type="sourceFolder" forTests="false"/>
-        <orderEntry type="library" name="scala-library-2.13.6.jar" level="project"/>
         <orderEntry type="module" module-name="helloworld" exported=""/>
+        <orderEntry type="library" name="scala-library-2.13.6.jar" level="project"/>
     </component>
 </module>

--- a/scalalib/test/resources/gen-idea-hello-world/idea/mill_modules/helloworld.test.iml
+++ b/scalalib/test/resources/gen-idea-hello-world/idea/mill_modules/helloworld.test.iml
@@ -10,11 +10,11 @@
         </content>
         <orderEntry type="inheritedJdk"/>
         <orderEntry type="sourceFolder" forTests="false"/>
+        <orderEntry type="module" module-name="helloworld" exported=""/>
         <orderEntry type="library" scope="PROVIDED" name="jcl-over-slf4j-1.7.25.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="logback-classic-1.2.3.jar" level="project"/>
         <orderEntry type="library" name="logback-core-1.2.3.jar" level="project"/>
         <orderEntry type="library" name="scala-library-2.12.5.jar" level="project"/>
         <orderEntry type="library" name="slf4j-api-1.7.25.jar" level="project"/>
-        <orderEntry type="module" module-name="helloworld" exported=""/>
     </component>
 </module>


### PR DESCRIPTION
PR fixes dependency priority for GenIdea command.

**Problem description:**
When multiple dependencies have a class with the same name, Mill takes first one from the classpath, as well as Intellij takes first one from the iml file. If some dependencies are modules, Mill put them higher in the classpath, so module classes always take precedence over libraries. But GenIdea put modules after the libraries and therefore Intellij resolves different than Mill class versions. Example of generated iml file:
```
...
<orderEntry type="inheritedJdk"/>
<orderEntry type="sourceFolder" forTests="false"/>
<orderEntry type="library" name="..." level="project"/>
...
<orderEntry type="module" module-name="..." exported=""/>
...
```

**Fix description:**
I swapped libraries and modules in the iml file, so result file looks like:
```
...
<orderEntry type="inheritedJdk"/>
<orderEntry type="sourceFolder" forTests="false"/>
<orderEntry type="module" module-name="..." exported=""/>
...
<orderEntry type="library" name="..." level="project"/>
...
```
To prove that this order is correct, I generated iml files for the same project with SBT and Mill BSP, both of them put modules before libraries.