### PR TITLE
Added BSP JVM Extension support

### DIFF
--- a/bsp/src/mill/bsp/BSP.scala
+++ b/bsp/src/mill/bsp/BSP.scala
@@ -132,7 +132,7 @@ object BSP extends ExternalModule {
         serverName = serverName,
         logStream = errStream,
         canReload = canReload
-      ) with MillJavaBuildServer with MillScalaBuildServer
+      ) with MillJvmBuildServer with MillJavaBuildServer with MillScalaBuildServer
 
     val executor = Executors.newCachedThreadPool()
 

--- a/bsp/src/mill/bsp/MillBuildServer.scala
+++ b/bsp/src/mill/bsp/MillBuildServer.scala
@@ -216,6 +216,8 @@ class MillBuildServer(
         false
       )
       capabilities.setCanReload(canReload)
+      capabilities.setJvmRunEnvironmentProvider(true)
+      capabilities.setJvmTestEnvironmentProvider(true)
 
       request.getData match {
         case d: JsonObject =>

--- a/bsp/src/mill/bsp/MillJvmBuildServer.scala
+++ b/bsp/src/mill/bsp/MillJvmBuildServer.scala
@@ -1,0 +1,55 @@
+package mill.bsp
+
+import ch.epfl.scala.bsp4j.{
+  BuildTargetIdentifier,
+  JvmBuildServer,
+  JvmEnvironmentItem,
+  JvmRunEnvironmentParams,
+  JvmRunEnvironmentResult,
+  JvmTestEnvironmentParams,
+  JvmTestEnvironmentResult
+}
+import mill.T
+import mill.define.Task
+import mill.scalalib.JavaModule
+import mill.scalalib.bsp.BspModule
+
+import java.util.concurrent.CompletableFuture
+import scala.jdk.CollectionConverters._
+
+trait MillJvmBuildServer extends JvmBuildServer { this: MillBuildServer =>
+  override def jvmRunEnvironment(params: JvmRunEnvironmentParams)
+      : CompletableFuture[JvmRunEnvironmentResult] =
+    completable(s"jvmRunEnvironment ${params}") { state =>
+      targetTasks(
+        state,
+        targetIds = params.getTargets.asScala.toSeq,
+        agg = (items: Seq[JvmEnvironmentItem]) => new JvmRunEnvironmentResult(items.asJava)
+      )(taskToJvmEnvironmentItem)
+    }
+
+  override def jvmTestEnvironment(params: JvmTestEnvironmentParams)
+      : CompletableFuture[JvmTestEnvironmentResult] =
+    completable(s"jvmTestEnvironment ${params}") { state =>
+      targetTasks(
+        state,
+        targetIds = params.getTargets.asScala.toSeq,
+        agg = (items: Seq[JvmEnvironmentItem]) => new JvmTestEnvironmentResult(items.asJava)
+      )(taskToJvmEnvironmentItem)
+    }
+
+  private val taskToJvmEnvironmentItem
+      : (BuildTargetIdentifier, BspModule) => Task[JvmEnvironmentItem] = {
+    case (id, m: JavaModule) =>
+      T.task {
+        val classpath = m.runClasspath().map(_.path).map(sanitizeUri.apply)
+        new JvmEnvironmentItem(
+          id,
+          classpath.iterator.toSeq.asJava,
+          m.forkArgs().asJava,
+          m.forkWorkingDir().toString(),
+          m.forkEnv().asJava
+        )
+      }
+  }
+}


### PR DESCRIPTION
Add support for [BSP JVM Extension](https://build-server-protocol.github.io/docs/extensions/jvm.html) methods `buildTarget/jvmTestEnvironment` and `buildTarget/jvmRunEnvironment`. This will correctly set the classpath for execution and testing from IntelliJ IDEA.

Without this addition, IntelliJ IDEA determines the classpath when executing and testing in a BSP Imported project, but the order of precedence when multiple version Jars exist seems to be different than in Mill. Therefore, binary incompatibility error may occur at runtime.

With this addition, IntelliJ IDEA will add the classpath resolved by Mill to the beginning of the classpath, which is the same behavior as Mill.

* https://github.com/JetBrains/intellij-scala/blob/a3f19b5967c87d0e9f3ca49b2278ddf709dd798b/bsp/src/org/jetbrains/bsp/project/test/environment/BspJvmEnvironment.scala#L185-L198
* https://github.com/JetBrains/intellij-scala/blob/a3f19b5967c87d0e9f3ca49b2278ddf709dd798b/bsp/src/org/jetbrains/bsp/project/test/environment/BspJvmEnvironmentProgramPatcher.scala

It will also reflect `forkArgs`, `forkEnv`, and `forkWorkingDir` as defined in the Mill.