### PR TITLE
Reviewed tests under Java 9

### DIFF
--- a/contrib/scoverage/test/src/HelloWorldTests.scala
+++ b/contrib/scoverage/test/src/HelloWorldTests.scala
@@ -155,14 +155,14 @@ trait HelloWorldTests extends utest.TestSuite {
             )
           }
           // TODO: document why we disable for Java9+
-          "runClasspath" - TestUtil.disableInJava9OrAbove(workspaceTest(HelloWorld) { eval =>
+          "runClasspath" - workspaceTest(HelloWorld) { eval =>
             val Right((result, evalCount)) = eval.apply(HelloWorld.core.scoverage.runClasspath)
 
             assert(
               result.map(_.toString).exists(_.contains("scalac-scoverage-runtime")),
               evalCount > 0
             )
-          })
+          }
         }
       }
     }

--- a/integration/thirdparty/local/resources/ammonite/build.sc
+++ b/integration/thirdparty/local/resources/ammonite/build.sc
@@ -42,7 +42,7 @@ trait AmmModule extends AmmInternalModule with PublishModule{
 trait AmmDependenciesResourceFileModule extends JavaModule{
   def crossScalaVersion: String
   def dependencyResourceFileName: String
-  def resources = T.sources {
+  override def resources = T.sources {
 
     val deps0 = T.task{compileIvyDeps() ++ transitiveIvyDeps()}()
     val (_, res) = mill.modules.Jvm.resolveDependenciesMetadata(

--- a/integration/thirdparty/local/src/AcyclicTests.scala
+++ b/integration/thirdparty/local/src/AcyclicTests.scala
@@ -24,7 +24,7 @@ class AcyclicTests(fork: Boolean)
       assert(!brokenCompile)
     }
 
-    "scala2118" - mill.util.TestUtil.disableInJava9OrAbove(check("2.11.8"))
+    "scala2118" - mill.util.TestUtil.disableInJava9OrAbove("Scala 2.11 not supported")(check("2.11.8"))
     "scala2125" - check("2.12.5")
 
   }

--- a/integration/thirdparty/local/src/AcyclicTests.scala
+++ b/integration/thirdparty/local/src/AcyclicTests.scala
@@ -8,20 +8,27 @@ class AcyclicTests(fork: Boolean)
     initWorkspace()
 
     def check(scalaVersion: String) = {
-      val firstCompile = eval(s"acyclic[$scalaVersion].compile")
+      val tccl = Thread.currentThread().getContextClassLoader()
+      try {
+        Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader())
 
-      assert(
-        firstCompile,
-        os.walk(workspacePath).exists(_.last == "GraphAnalysis.class"),
-        os.walk(workspacePath).exists(_.last == "PluginPhase.class")
-      )
-      for (scalaFile <- os.walk(workspacePath).filter(_.ext == "scala")) {
-        os.write.append(scalaFile, "\n}")
+        val firstCompile = eval(s"acyclic[$scalaVersion].compile")
+
+        assert(
+          firstCompile,
+          os.walk(workspacePath).exists(_.last == "GraphAnalysis.class"),
+          os.walk(workspacePath).exists(_.last == "PluginPhase.class")
+        )
+        for (scalaFile <- os.walk(workspacePath).filter(_.ext == "scala")) {
+          os.write.append(scalaFile, "\n}")
+        }
+
+        val brokenCompile = eval(s"acyclic[$scalaVersion].compile")
+
+        assert(!brokenCompile)
+      } finally {
+        Thread.currentThread().setContextClassLoader(tccl)
       }
-
-      val brokenCompile = eval(s"acyclic[$scalaVersion].compile")
-
-      assert(!brokenCompile)
     }
 
     "scala2118" - mill.util.TestUtil.disableInJava9OrAbove("Scala 2.11 not supported")(check("2.11.8"))

--- a/integration/thirdparty/local/src/AmmoniteTests.scala
+++ b/integration/thirdparty/local/src/AmmoniteTests.scala
@@ -8,27 +8,33 @@ class AmmoniteTests(fork: Boolean)
     initWorkspace()
 
     def check(scalaVersion: String) = {
-      val replTests = eval(
-        s"amm.repl[$scalaVersion].test",
-        "{ammonite.unit,ammonite.session.ProjectTests.guava}"
-      )
-      val replTestMeta = meta(s"amm.repl[$scalaVersion].test.test")
-      assert(
-        replTests,
-        replTestMeta.contains("ammonite.session.ProjectTests.guava"),
-        replTestMeta.contains("ammonite.unit.SourceTests.objectInfo.thirdPartyJava")
-      )
+      val tccl = Thread.currentThread().getContextClassLoader()
+      try {
+        Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader())
+        val replTests = eval(
+          s"amm.repl[$scalaVersion].test",
+          "{ammonite.unit,ammonite.session.ProjectTests.guava}"
+        )
+        val replTestMeta = meta(s"amm.repl[$scalaVersion].test.test")
+        assert(
+          replTests,
+          replTestMeta.contains("ammonite.session.ProjectTests.guava"),
+          replTestMeta.contains("ammonite.unit.SourceTests.objectInfo.thirdPartyJava")
+        )
 
-      val compileResult = eval(
-        "all",
-        s"{shell,sshd,amm,integration}[$scalaVersion].test.compile"
-      )
+        val compileResult = eval(
+          "all",
+          s"{shell,sshd,amm,integration}[$scalaVersion].test.compile"
+        )
 
-      assert(
-        compileResult,
-        os.walk(workspacePath / "out" / "integration" / scalaVersion / "test" / "compile.dest")
-          .exists(_.last == "ErrorTruncationTests.class")
-      )
+        assert(
+          compileResult,
+          os.walk(workspacePath / "out" / "integration" / scalaVersion / "test" / "compile.dest")
+            .exists(_.last == "ErrorTruncationTests.class")
+        )
+      } finally {
+        Thread.currentThread().setContextClassLoader(tccl)
+      }
     }
 
     "scala2126" - check("2.12.6")

--- a/integration/thirdparty/local/src/JawnTests.scala
+++ b/integration/thirdparty/local/src/JawnTests.scala
@@ -1,31 +1,28 @@
 package mill.integration.thirdparty
 
+import mill.util.TestUtil
 import utest._
 
 class JawnTests(fork: Boolean) extends IntegrationTestSuite("MILL_JAWN_REPO", "jawn", fork) {
   val tests = Tests {
     initWorkspace()
 
-    def check(scalaVersion: String) = {
-      if (!sys.props("java.version").startsWith("1.")) {
-        println(s"*** Beware: Tests is not supported with this Java version! ***")
-      } else {
-        val firstCompile = eval(s"jawn[$scalaVersion].parser.test")
+    def check(scalaVersion: String) = TestUtil.disableInJava9OrAbove("Old tests don't work") {
+      val firstCompile = eval(s"jawn[$scalaVersion].parser.test")
 
-        assert(
-          firstCompile,
-          os.walk(workspacePath).exists(_.last == "AsyncParser.class"),
-          os.walk(workspacePath).exists(_.last == "CharBuilderSpec.class")
-        )
+      assert(
+        firstCompile,
+        os.walk(workspacePath).exists(_.last == "AsyncParser.class"),
+        os.walk(workspacePath).exists(_.last == "CharBuilderSpec.class")
+      )
 
-        for (scalaFile <- os.walk(workspacePath).filter(_.ext == "scala")) {
-          os.write.append(scalaFile, "\n}")
-        }
-
-        val brokenCompile = eval(s"jawn[$scalaVersion].parser.test")
-
-        assert(!brokenCompile)
+      for (scalaFile <- os.walk(workspacePath).filter(_.ext == "scala")) {
+        os.write.append(scalaFile, "\n}")
       }
+
+      val brokenCompile = eval(s"jawn[$scalaVersion].parser.test")
+
+      assert(!brokenCompile)
     }
 
     "scala21111" - check("2.11.11")

--- a/integration/thirdparty/local/src/JawnTests.scala
+++ b/integration/thirdparty/local/src/JawnTests.scala
@@ -8,21 +8,27 @@ class JawnTests(fork: Boolean) extends IntegrationTestSuite("MILL_JAWN_REPO", "j
     initWorkspace()
 
     def check(scalaVersion: String) = TestUtil.disableInJava9OrAbove("Old tests don't work") {
-      val firstCompile = eval(s"jawn[$scalaVersion].parser.test")
+      val tccl = Thread.currentThread().getContextClassLoader()
+      try {
+        Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader())
+        val firstCompile = eval(s"jawn[$scalaVersion].parser.test")
 
-      assert(
-        firstCompile,
-        os.walk(workspacePath).exists(_.last == "AsyncParser.class"),
-        os.walk(workspacePath).exists(_.last == "CharBuilderSpec.class")
-      )
+        assert(
+          firstCompile,
+          os.walk(workspacePath).exists(_.last == "AsyncParser.class"),
+          os.walk(workspacePath).exists(_.last == "CharBuilderSpec.class")
+        )
 
-      for (scalaFile <- os.walk(workspacePath).filter(_.ext == "scala")) {
-        os.write.append(scalaFile, "\n}")
+        for (scalaFile <- os.walk(workspacePath).filter(_.ext == "scala")) {
+          os.write.append(scalaFile, "\n}")
+        }
+
+        val brokenCompile = eval(s"jawn[$scalaVersion].parser.test")
+
+        assert(!brokenCompile)
+      } finally {
+        Thread.currentThread().setContextClassLoader(tccl)
       }
-
-      val brokenCompile = eval(s"jawn[$scalaVersion].parser.test")
-
-      assert(!brokenCompile)
     }
 
     "scala21111" - check("2.11.11")

--- a/integration/thirdparty/local/src/UpickleTests.scala
+++ b/integration/thirdparty/local/src/UpickleTests.scala
@@ -7,12 +7,12 @@ class UpickleTests(fork: Boolean)
   val tests = Tests {
     initWorkspace()
     "jvm21111" - {
-      mill.util.TestUtil.disableInJava9OrAbove({
+      mill.util.TestUtil.disableInJava9OrAbove {
         assert(eval("upickleJvm[2.11.11].test"))
         val jvmMeta = meta("upickleJvm[2.11.11].test.test")
         assert(jvmMeta.contains("example.ExampleTests.simple"))
         assert(jvmMeta.contains("upickle.MacroTests.commonCustomStructures.simpleAdt"))
-      })
+      }
     }
     "jvm2123" - {
       assert(eval("upickleJvm[2.12.3].test"))

--- a/integration/thirdparty/local/src/UpickleTests.scala
+++ b/integration/thirdparty/local/src/UpickleTests.scala
@@ -7,7 +7,7 @@ class UpickleTests(fork: Boolean)
   val tests = Tests {
     initWorkspace()
     "jvm21111" - {
-      mill.util.TestUtil.disableInJava9OrAbove {
+      mill.util.TestUtil.disableInJava9OrAbove("Scala 2.11 tests don't support Java 9+") {
         assert(eval("upickleJvm[2.11.11].test"))
         val jvmMeta = meta("upickleJvm[2.11.11].test.test")
         assert(jvmMeta.contains("example.ExampleTests.simple"))

--- a/main/test/src/util/TestUtil.scala
+++ b/main/test/src/util/TestUtil.scala
@@ -79,11 +79,14 @@ object TestUtil {
       }
     }
   }
-  def disableInJava9OrAbove(f: => Any): Any = {
+  @deprecated("Use other overload which support a reason parameter instead", "mill after 0.10.3")
+  def disableInJava9OrAbove(f: => Any): Any = disableInJava9OrAbove(reason = "???")(f)
+
+  def disableInJava9OrAbove(reason: String)(f: => Any): Any = {
     if (System.getProperty("java.specification.version").startsWith("1.")) {
       f
     } else {
-      "*** Disabled in Java 9+ ***"
+      s"*** Disabled in Java 9+ - Reason: ${reason} ***"
     }
   }
 }

--- a/main/test/src/util/TestUtil.scala
+++ b/main/test/src/util/TestUtil.scala
@@ -79,9 +79,11 @@ object TestUtil {
       }
     }
   }
-  def disableInJava9OrAbove(f: => Any): Unit = {
-    if (!ammonite.util.Util.java9OrAbove) {
+  def disableInJava9OrAbove(f: => Any): Any = {
+    if (System.getProperty("java.specification.version").startsWith("1.")) {
       f
+    } else {
+      "*** Disabled in Java 9+ ***"
     }
   }
 }

--- a/scalajslib/test/src/HelloJSWorldTests.scala
+++ b/scalajslib/test/src/HelloJSWorldTests.scala
@@ -131,12 +131,12 @@ object HelloJSWorldTests extends TestSuite {
 
     test("fullOpt") {
       testAllMatrix((scala, scalaJS) =>
-        TestUtil.disableInJava9OrAbove(testRun(scala, scalaJS, FullOpt))
+        testRun(scala, scalaJS, FullOpt)
       )
     }
     test("fastOpt") {
       testAllMatrix((scala, scalaJS) =>
-        TestUtil.disableInJava9OrAbove(testRun(scala, scalaJS, FastOpt))
+        testRun(scala, scalaJS, FastOpt)
       )
     }
     test("jar") {

--- a/scalajslib/test/src/HelloJSWorldTests.scala
+++ b/scalajslib/test/src/HelloJSWorldTests.scala
@@ -318,7 +318,7 @@ object HelloJSWorldTests extends TestSuite {
       if !skipScalaJS(scalaJS)
     } {
       if (scala.startsWith("2.11.")) {
-        TestUtil.disableInJava9OrAbove(f(scala, scalaJS))
+        TestUtil.disableInJava9OrAbove("Scala 2.11 tests don't run under Java 9+")(f(scala, scalaJS))
       } else {
         f(scala, scalaJS)
       }

--- a/scalajslib/test/src/MultiModuleTests.scala
+++ b/scalajslib/test/src/MultiModuleTests.scala
@@ -53,8 +53,8 @@ object MultiModuleTests extends TestSuite {
       )
     }
 
-    "fastOpt" - TestUtil.disableInJava9OrAbove(checkOpt(FastOpt))
-    "fullOpt" - TestUtil.disableInJava9OrAbove(checkOpt(FullOpt))
+    "fastOpt" - checkOpt(FastOpt)
+    "fullOpt" - checkOpt(FullOpt)
 
     "test" - {
       val Right(((_, testResults), evalCount)) = evaluator(MultiModule.client.test.test())

--- a/scalalib/test/src/HelloWorldTests.scala
+++ b/scalalib/test/src/HelloWorldTests.scala
@@ -542,12 +542,12 @@ object HelloWorldTests extends TestSuite {
             os.read(runResult) == expectedOut
           )
         }
-        "v210" - TestUtil.disableInJava9OrAbove(workspaceTest(CrossHelloWorld)(cross(
+        "v210" - TestUtil.disableInJava9OrAbove("Scala 2.10 tests don't work with Java 9+")(workspaceTest(CrossHelloWorld)(cross(
           _,
           scala2106Version,
           s"${scala2106Version} rox"
         )))
-        "v211" - TestUtil.disableInJava9OrAbove(workspaceTest(CrossHelloWorld)(cross(
+        "v211" - TestUtil.disableInJava9OrAbove("Scala 2.11 tests don't work with Java 9+")(workspaceTest(CrossHelloWorld)(cross(
           _,
           scala21111Version,
           s"${scala21111Version} pwns"

--- a/scalanativelib/test/src/HelloNativeWorldTests.scala
+++ b/scalanativelib/test/src/HelloNativeWorldTests.scala
@@ -257,7 +257,7 @@ object HelloNativeWorldTests extends TestSuite {
       if !skipReleaseMode(releaseMode)
     } {
       if (scala.startsWith("2.11.")) {
-        TestUtil.disableInJava9OrAbove(f(scala, scalaNative, releaseMode))
+        TestUtil.disableInJava9OrAbove("Scala 2.11 tests don't run in Java 9+")(f(scala, scalaNative, releaseMode))
       } else {
         f(scala, scalaNative, releaseMode)
       }


### PR DESCRIPTION
Reviewed and removed some disablements of tests under Java 9+.

Also added some thread context classloader tweak to integration test in the hope it fixes the issues in CI. As I could not reproduce, these fixes are just wild guesses, as Ammonite tries to load the `amm-dependencies.txt` file via the thread context classloader and this failed sometimes in CI.