### PR TITLE
Add Junit5 TestModule

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -1192,15 +1192,18 @@ object docs extends Module {
 
   /** Generates the mill documentation with Antora. */
   object antora extends Module {
+    private val npmExe = if (scala.util.Properties.isWin) "npm.cmd" else "npm"
+    private val antoraExe = if (scala.util.Properties.isWin) "antora.cmd" else "antora"
     def npmBase: T[os.Path] = T.persistent { T.dest }
     def prepareAntora(npmDir: os.Path) = {
       Jvm.runSubprocess(
         commandArgs = Seq(
-          "npm",
+          npmExe,
           "install",
           "@antora/cli",
           "@antora/site-generator-default",
-          "gitlab:antora/xref-validator"
+          "gitlab:antora/xref-validator",
+          "@antora/lunr-extension"
         ),
         envArgs = Map(),
         workingDir = npmDir
@@ -1211,7 +1214,7 @@ object docs extends Module {
     ) = {
       prepareAntora(npmDir)
       val cmdArgs =
-        Seq(s"${npmDir}/node_modules/@antora/cli/bin/antora") ++ args
+        Seq(s"${npmDir}/node_modules/.bin/${antoraExe}") ++ args
       ctx.log.debug(s"command: ${cmdArgs.mkString("'", "' '", "'")}")
       Jvm.runSubprocess(
         commandArgs = cmdArgs,
@@ -1267,6 +1270,11 @@ object docs extends Module {
          |    mill-doc-url: ${Settings.docUrl}
          |    utest-github-url: https://github.com/com-lihaoyi/utest
          |    upickle-github-url: https://github.com/com-lihaoyi/upickle
+         |
+         |antora:
+         |  extensions:
+         |  - require: '@antora/lunr-extension'
+         |    index_latest_only: true
          |
          |""".stripMargin
     }

--- a/docs/antora/modules/ROOT/pages/Configuring_Mill.adoc
+++ b/docs/antora/modules/ROOT/pages/Configuring_Mill.adoc
@@ -180,7 +180,8 @@ object foo extends ScalaModule {
 
 For convenience, you can also use one of the predefined test frameworks:
 
-* `TestModule.Junit`
+* `TestModule.Junit4`
+* `TestModule.Junit5`
 * `TestModule.TestNg`
 * `TestModule.Munit`
 * `TestModule.ScalaTest`

--- a/docs/antora/supplemental-ui/css/search.css
+++ b/docs/antora/supplemental-ui/css/search.css
@@ -1,0 +1,75 @@
+.search-result-dropdown-menu {
+  position: absolute;
+  z-index: 100;
+  display: block;
+  right: 0;
+  left: inherit;
+  top: 100%;
+  border-radius: 4px;
+  margin: 6px 0 0;
+  padding: 0;
+  text-align: left;
+  height: auto;
+  background: transparent;
+  border: none;
+  max-width: 600px;
+  min-width: 500px;
+  box-shadow: 0 1px 0 0 rgba(0, 0, 0, 0.2), 0 2px 3px 0 rgba(0, 0, 0, 0.1);
+}
+
+@media screen and (max-width: 768px) {
+  .search-result-dropdown-menu {
+    min-width: calc(100vw - 3.75rem);
+  }
+}
+
+.search-result-dataset {
+  position: relative;
+  border: 1px solid #d9d9d9;
+  background: #fff;
+  border-radius: 4px;
+  overflow: auto;
+  padding: 0 8px;
+  max-height: calc(100vh - 5.25rem);
+  line-height: 1.5;
+}
+
+.search-result-item {
+  display: flex;
+  margin: 0.5rem 0;
+}
+
+.search-result-document-title {
+  width: 33%;
+  border-right: 1px solid #ddd;
+  color: #02060c;
+  font-weight: 500;
+  font-size: 0.8rem;
+  padding: 0.5rem 0.5rem 0.5rem 0;
+  text-align: right;
+  position: relative;
+  word-wrap: break-word;
+}
+
+.search-result-document-hit {
+  flex: 1;
+  font-size: 0.75rem;
+  color: #63676d;
+}
+
+.search-result-document-hit > a {
+  color: inherit;
+  display: block;
+  padding: 0.55rem 0.25rem 0.55rem 0.75rem;
+}
+
+.search-result-document-hit > a:hover {
+  background-color: rgba(69, 142, 225, 0.05);
+}
+
+.search-result-highlight {
+  color: #174d8c;
+  background: rgba(143, 187, 237, 0.1);
+  padding: 0.1em 0.05em;
+  font-weight: 500;
+}

--- a/docs/antora/supplemental-ui/js/search-ui.js
+++ b/docs/antora/supplemental-ui/js/search-ui.js
@@ -1,0 +1,248 @@
+/* global CustomEvent */
+;(function (globalScope) {
+  /* eslint-disable no-var */
+  var config = document.getElementById('search-ui-script').dataset
+  var snippetLength = parseInt(config.snippetLength || 100, 10)
+  var siteRootPath = config.siteRootPath || ''
+  appendStylesheet(config.stylesheet)
+  var searchInput = document.getElementById('search-input')
+  var searchResult = document.createElement('div')
+  searchResult.classList.add('search-result-dropdown-menu')
+  searchInput.parentNode.appendChild(searchResult)
+
+  function appendStylesheet (href) {
+    if (!href) return
+    document.head.appendChild(Object.assign(document.createElement('link'), { rel: 'stylesheet', href: href }))
+  }
+
+  function highlightText (doc, position) {
+    var hits = []
+    var start = position[0]
+    var length = position[1]
+
+    var text = doc.text
+    var highlightSpan = document.createElement('span')
+    highlightSpan.classList.add('search-result-highlight')
+    highlightSpan.innerText = text.substr(start, length)
+
+    var end = start + length
+    var textEnd = text.length - 1
+    var contextAfter = end + snippetLength > textEnd ? textEnd : end + snippetLength
+    var contextBefore = start - snippetLength < 0 ? 0 : start - snippetLength
+    if (start === 0 && end === textEnd) {
+      hits.push(highlightSpan)
+    } else if (start === 0) {
+      hits.push(highlightSpan)
+      hits.push(document.createTextNode(text.substr(end, contextAfter)))
+    } else if (end === textEnd) {
+      hits.push(document.createTextNode(text.substr(0, start)))
+      hits.push(highlightSpan)
+    } else {
+      hits.push(document.createTextNode('...' + text.substr(contextBefore, start - contextBefore)))
+      hits.push(highlightSpan)
+      hits.push(document.createTextNode(text.substr(end, contextAfter - end) + '...'))
+    }
+    return hits
+  }
+
+  function highlightTitle (sectionTitle, doc, position) {
+    var hits = []
+    var start = position[0]
+    var length = position[1]
+
+    var highlightSpan = document.createElement('span')
+    highlightSpan.classList.add('search-result-highlight')
+    var title
+    if (sectionTitle) {
+      title = sectionTitle.text
+    } else {
+      title = doc.title
+    }
+    highlightSpan.innerText = title.substr(start, length)
+
+    var end = start + length
+    var titleEnd = title.length - 1
+    if (start === 0 && end === titleEnd) {
+      hits.push(highlightSpan)
+    } else if (start === 0) {
+      hits.push(highlightSpan)
+      hits.push(document.createTextNode(title.substr(length, titleEnd)))
+    } else if (end === titleEnd) {
+      hits.push(document.createTextNode(title.substr(0, start)))
+      hits.push(highlightSpan)
+    } else {
+      hits.push(document.createTextNode(title.substr(0, start)))
+      hits.push(highlightSpan)
+      hits.push(document.createTextNode(title.substr(end, titleEnd)))
+    }
+    return hits
+  }
+
+  function highlightHit (metadata, sectionTitle, doc) {
+    var hits = []
+    for (var token in metadata) {
+      var fields = metadata[token]
+      for (var field in fields) {
+        var positions = fields[field]
+        if (positions.position) {
+          var position = positions.position[0] // only higlight the first match
+          if (field === 'title') {
+            hits = highlightTitle(sectionTitle, doc, position)
+          } else if (field === 'text') {
+            hits = highlightText(doc, position)
+          }
+        }
+      }
+    }
+    return hits
+  }
+
+  function createSearchResult (result, store, searchResultDataset) {
+    result.forEach(function (item) {
+      var ids = item.ref.split('-')
+      var docId = ids[0]
+      var doc = store[docId]
+      var sectionTitle
+      if (ids.length > 1) {
+        var titleId = ids[1]
+        sectionTitle = doc.titles.filter(function (item) {
+          return String(item.id) === titleId
+        })[0]
+      }
+      var metadata = item.matchData.metadata
+      var hits = highlightHit(metadata, sectionTitle, doc)
+      searchResultDataset.appendChild(createSearchResultItem(doc, sectionTitle, item, hits))
+    })
+  }
+
+  function createSearchResultItem (doc, sectionTitle, item, hits) {
+    var documentTitle = document.createElement('div')
+    documentTitle.classList.add('search-result-document-title')
+    documentTitle.innerText = doc.title
+    var documentHit = document.createElement('div')
+    documentHit.classList.add('search-result-document-hit')
+    var documentHitLink = document.createElement('a')
+    documentHitLink.href = siteRootPath + doc.url + (sectionTitle ? '#' + sectionTitle.hash : '')
+    documentHit.appendChild(documentHitLink)
+    hits.forEach(function (hit) {
+      documentHitLink.appendChild(hit)
+    })
+    var searchResultItem = document.createElement('div')
+    searchResultItem.classList.add('search-result-item')
+    searchResultItem.appendChild(documentTitle)
+    searchResultItem.appendChild(documentHit)
+    searchResultItem.addEventListener('mousedown', function (e) {
+      e.preventDefault()
+    })
+    return searchResultItem
+  }
+
+  function createNoResult (text) {
+    var searchResultItem = document.createElement('div')
+    searchResultItem.classList.add('search-result-item')
+    var documentHit = document.createElement('div')
+    documentHit.classList.add('search-result-document-hit')
+    var message = document.createElement('strong')
+    message.innerText = 'No results found for query "' + text + '"'
+    documentHit.appendChild(message)
+    searchResultItem.appendChild(documentHit)
+    return searchResultItem
+  }
+
+  function clearSearchResults (reset) {
+    if (reset === true) searchInput.value = ''
+    searchResult.innerHTML = ''
+  }
+
+  function search (index, text) {
+    // execute an exact match search
+    var result = index.search(text)
+    if (result.length > 0) {
+      return result
+    }
+    // no result, use a begins with search
+    result = index.search(text + '*')
+    if (result.length > 0) {
+      return result
+    }
+    // no result, use a contains search
+    result = index.search('*' + text + '*')
+    return result
+  }
+
+  function searchIndex (index, store, text) {
+    clearSearchResults(false)
+    if (text.trim() === '') {
+      return
+    }
+    var result = search(index, text)
+    var searchResultDataset = document.createElement('div')
+    searchResultDataset.classList.add('search-result-dataset')
+    searchResult.appendChild(searchResultDataset)
+    if (result.length > 0) {
+      createSearchResult(result, store, searchResultDataset)
+    } else {
+      searchResultDataset.appendChild(createNoResult(text))
+    }
+  }
+
+  function confineEvent (e) {
+    e.stopPropagation()
+  }
+
+  function debounce (func, wait, immediate) {
+    var timeout
+    return function () {
+      var context = this
+      var args = arguments
+      var later = function () {
+        timeout = null
+        if (!immediate) func.apply(context, args)
+      }
+      var callNow = immediate && !timeout
+      clearTimeout(timeout)
+      timeout = setTimeout(later, wait)
+      if (callNow) func.apply(context, args)
+    }
+  }
+
+  function enableSearchInput (enabled) {
+    searchInput.disabled = !enabled
+    searchInput.title = enabled ? '' : 'Loading index...'
+  }
+
+  function initSearch (lunr, data) {
+    var start = performance.now()
+    var index = Object.assign({ index: lunr.Index.load(data.index), store: data.store })
+    enableSearchInput(true)
+    searchInput.dispatchEvent(
+      new CustomEvent('loadedindex', {
+        detail: {
+          took: performance.now() - start,
+        },
+      })
+    )
+    var debug = 'URLSearchParams' in globalScope && new URLSearchParams(globalScope.location.search).has('lunr-debug')
+    searchInput.addEventListener(
+      'keydown',
+      debounce(function (e) {
+        if (e.key === 'Escape' || e.key === 'Esc') return clearSearchResults(true)
+        try {
+          var query = searchInput.value
+          if (!query) return clearSearchResults()
+          searchIndex(index.index, index.store, searchInput.value)
+        } catch (err) {
+          if (debug) console.debug('Invalid search query: ' + query + ' (' + err.message + ')')
+        }
+      }, 100)
+    )
+    searchInput.addEventListener('click', confineEvent)
+    searchResult.addEventListener('click', confineEvent)
+    document.documentElement.addEventListener('click', clearSearchResults)
+  }
+
+  // disable the search input until the index is loaded
+  enableSearchInput(false)
+
+  globalScope.initSearch = initSearch
+})(typeof globalThis !== 'undefined' ? globalThis : window)

--- a/docs/antora/supplemental-ui/partials/header-content.hbs
+++ b/docs/antora/supplemental-ui/partials/header-content.hbs
@@ -3,6 +3,11 @@
     <div class="navbar-brand">
       <!-- TODO: add mill icon -->
       <a class="navbar-item" href="{{{or site.url (or siteRootUrl siteRootPath)}}}"><img src="{{{uiRootPath}}}/logo-white.svg" height="20" />&nbsp;{{site.title}}</a>
+      <div class="navbar-item search">
+      {{#if env.SITE_SEARCH_PROVIDER}}
+        <input id="search-input" type="text" placeholder="Search the docs">
+      {{/if}}
+      </div>
       <button class="navbar-burger" data-target="topbar-nav">
         <span></span>
         <span></span>

--- a/scalalib/src/TestModule.scala
+++ b/scalalib/src/TestModule.scala
@@ -215,6 +215,17 @@ object TestModule {
   }
 
   /**
+   * TestModule that uses JUnit 5 Framework to run tests.
+   * You may want to provide the junit dependency explicitly to use another version.
+   */
+  trait Junit5 extends TestModule {
+    override def testFramework: T[String] = "net.aichler.jupiter.api.JupiterFramework"
+    override def ivyDeps: T[Agg[Dep]] = T {
+      super.ivyDeps() ++ Agg(ivy"net.aichler:jupiter-interface:0.9.0")
+    }
+  }
+
+  /**
    * TestModule that uses ScalaTest Framework to run tests.
    * You need to provide the scalatest dependencies yourself.
    */


### PR DESCRIPTION
As per https://github.com/com-lihaoyi/mill/discussions/1411 and https://junit.org/junit5/docs/current/user-guide/#launcher-api-discovery it seems like JUnit5 has its own test discovery mechanism so sbt's fingerprinting is not needed.  
It is indeed skipped in [sbt-jupiter-interface](https://github.com/sbt/sbt-jupiter-interface/blob/master/src/library/src/main/java/net/aichler/jupiter/api/JupiterTestFingerprint.java#L40-L41) so I needed to add a small hack to bypass Mill's internal filtering.