### PR TITLE
Add dest to report and change jsFile to jsFileName

### DIFF
--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -19,6 +19,7 @@ import mill.scalajslib.api.{
   OptimizeMode,
   Report
 }
+import mill.scalajslib.internal.ScalaJSUtils.getReportMainFilePathRef
 import mill.scalajslib.worker.{ScalaJSWorker, ScalaJSWorkerExternalModule}
 
 import scala.jdk.CollectionConverters._
@@ -93,11 +94,11 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
   }
 
   def fastOpt: Target[PathRef] = T {
-    linkTask(optimize = false, forceOutJs = true)().publicModules.head.jsFile
+    getReportMainFilePathRef(linkTask(optimize = false, forceOutJs = true)())
   }
 
   def fullOpt: Target[PathRef] = T {
-    linkTask(optimize = true, forceOutJs = true)().publicModules.head.jsFile
+    getReportMainFilePathRef(linkTask(optimize = true, forceOutJs = true)())
   }
 
   private def linkTask(optimize: Boolean, forceOutJs: Boolean): Task[Report] = T.task {
@@ -160,7 +161,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
     moduleKind = moduleKind,
     esFeatures = esFeatures,
     moduleSplitStyle = ModuleSplitStyle.FewestModules
-  ).map(report => report.publicModules.head.jsFile)
+  ).map(getReportMainFilePathRef)
 
   private[scalajslib] def linkJs(
       worker: ScalaJSWorker,
@@ -296,7 +297,7 @@ trait TestScalaJSModule extends ScalaJSModule with TestModule {
       moduleKind = moduleKind(),
       esFeatures = esFeatures(),
       moduleSplitStyle = moduleSplitStyle()
-    ).map { report => report.publicModules.head.jsFile }
+    ).map(getReportMainFilePathRef)
   }
 
   def fastLinkJSTest: Target[Report] = T.persistent {

--- a/scalajslib/src/mill/scalajslib/api/Report.scala
+++ b/scalajslib/src/mill/scalajslib/api/Report.scala
@@ -2,23 +2,24 @@ package mill.scalajslib.api
 
 import upickle.default.{ReadWriter => RW, macroRW}
 
-final class Report private (val publicModules: Iterable[Report.Module]) {
+final class Report private (val publicModules: Iterable[Report.Module], val dest: mill.PathRef) {
   override def toString(): String =
     s"""Report(
-       |  publicModules = $publicModules
+       |  publicModules = $publicModules,
+       |  dest = $dest
        |)""".stripMargin
 }
 object Report {
   final class Module private (
       val moduleID: String,
-      val jsFile: mill.PathRef,
+      val jsFileName: String,
       val sourceMapName: Option[String],
       val moduleKind: ModuleKind
   ) {
     override def toString(): String =
       s"""Module(
          |  moduleID = $moduleID,
-         |  jsFile = $jsFile,
+         |  jsFileName = $jsFileName,
          |  sourceMapName = $sourceMapName,
          |  moduleKind = $moduleKind
          |)""".stripMargin
@@ -26,19 +27,19 @@ object Report {
   object Module {
     def apply(
         moduleID: String,
-        jsFile: mill.PathRef,
+        jsFileName: String,
         sourceMapName: Option[String],
         moduleKind: ModuleKind
     ): Module =
       new Module(
         moduleID = moduleID,
-        jsFile = jsFile,
+        jsFileName = jsFileName,
         sourceMapName = sourceMapName,
         moduleKind = moduleKind
       )
     implicit val rw: RW[Module] = macroRW[Module]
   }
-  def apply(publicModules: Iterable[Report.Module]): Report =
-    new Report(publicModules = publicModules)
+  def apply(publicModules: Iterable[Report.Module], dest: mill.PathRef): Report =
+    new Report(publicModules = publicModules, dest = dest)
   implicit val rw: RW[Report] = macroRW[Report]
 }

--- a/scalajslib/src/mill/scalajslib/internal/ScalaJSUtils.scala
+++ b/scalajslib/src/mill/scalajslib/internal/ScalaJSUtils.scala
@@ -1,0 +1,13 @@
+package mill.scalajslib.internal
+
+import mill.api.internal
+import mill.PathRef
+import mill.scalajslib.api.Report
+
+@internal
+private[scalajslib] object ScalaJSUtils {
+  def getReportMainFilePath(report: Report): os.Path =
+    report.dest.path / report.publicModules.head.jsFileName
+  def getReportMainFilePathRef(report: Report): PathRef =
+    PathRef(getReportMainFilePath(report))
+}

--- a/scalajslib/test/src/HelloJSWorldTests.scala
+++ b/scalajslib/test/src/HelloJSWorldTests.scala
@@ -120,8 +120,8 @@ object HelloJSWorldTests extends TestSuite {
           result.path
         } else {
           val task = if (optimize) module.fullLinkJS else module.fastLinkJS
-          val Right((result, evalCount)) = helloWorldEvaluator(task)
-          result.dest.path / "out.js"
+          val Right((report, evalCount)) = helloWorldEvaluator(task)
+          report.dest.path / report.publicModules.head.jsFileName
         }
       val output = ScalaJsUtils.runJS(jsFile)
       assert(output == "Hello Scala.js\n")

--- a/scalajslib/test/src/HelloJSWorldTests.scala
+++ b/scalajslib/test/src/HelloJSWorldTests.scala
@@ -113,15 +113,16 @@ object HelloJSWorldTests extends TestSuite {
         legacy: Boolean
     ): Unit = {
       val module = HelloJSWorld.helloJsWorld(scalaVersion, scalaJSVersion)
-      val jsFile = if(legacy) {
-        val task = if(optimize) module.fullOpt else module.fastOpt
-        val Right((result, evalCount)) = helloWorldEvaluator(task)
-        result.path
-      } else {
-        val task = if(optimize) module.fullLinkJS else module.fastLinkJS
-        val Right((result, evalCount)) = helloWorldEvaluator(task)
-        result.publicModules.head.jsFile.path
-      }
+      val jsFile =
+        if (legacy) {
+          val task = if (optimize) module.fullOpt else module.fastOpt
+          val Right((result, evalCount)) = helloWorldEvaluator(task)
+          result.path
+        } else {
+          val task = if (optimize) module.fullLinkJS else module.fastLinkJS
+          val Right((result, evalCount)) = helloWorldEvaluator(task)
+          result.dest.path / "out.js"
+        }
       val output = ScalaJsUtils.runJS(jsFile)
       assert(output == "Hello Scala.js\n")
       val sourceMap = jsFile / os.up / (jsFile.last + ".map")
@@ -333,7 +334,10 @@ object HelloJSWorldTests extends TestSuite {
       if !skipScalaJS(scalaJS)
     } {
       if (scala.startsWith("2.11.")) {
-        TestUtil.disableInJava9OrAbove("Scala 2.11 tests don't run under Java 9+")(f(scala, scalaJS))
+        TestUtil.disableInJava9OrAbove("Scala 2.11 tests don't run under Java 9+")(f(
+          scala,
+          scalaJS
+        ))
       } else {
         f(scala, scalaJS)
       }

--- a/scalajslib/test/src/SmallModulesForTests.scala
+++ b/scalajslib/test/src/SmallModulesForTests.scala
@@ -33,15 +33,14 @@ object SmallModulesForTests extends TestSuite {
       println(evaluator(SmallModulesForModule.smallModulesForModule.sources))
       val Right((report, _)) =
         evaluator(SmallModulesForModule.smallModulesForModule.fastLinkJS)
-      val publicModules = report.publicModules.toSeq
+      val publicModules = report.publicModules
       test("it should have a single publicModule") {
-        assert(publicModules.length == 1)
+        assert(publicModules.size == 1)
       }
       val mainModule = publicModules.head
-      val directory = mainModule.jsFile.path / os.up
-      val modulesLength = os.list(directory).length
+      val modulesLength = os.list(report.dest.path).length
       test("my.Foo should not have its own file since it is in a separate package") {
-        assert(!os.exists(directory / "otherpackage.Foo.js"))
+        assert(!os.exists(report.dest.path / "otherpackage.Foo.js"))
       }
       assert(modulesLength == 10)
     }

--- a/scalajslib/test/src/TopLevelExportsTests.scala
+++ b/scalajslib/test/src/TopLevelExportsTests.scala
@@ -35,13 +35,13 @@ object TopLevelExportsTests extends TestSuite {
       val publicModules = report.publicModules.toSeq
       assert(publicModules.length == 2)
       val b = publicModules(0)
-      assert(os.exists(b.jsFile.path))
-      assert(b.jsFile.path.last == "b.js")
-      assert(os.exists(b.jsFile.path / os.up / "b.js.map"))
+      assert(b.jsFileName == "b.js")
+      assert(os.exists(report.dest.path / "b.js"))
+      assert(os.exists(report.dest.path / "b.js.map"))
       val a = publicModules(1)
-      assert(os.exists(a.jsFile.path))
-      assert(a.jsFile.path.last == "a.js")
-      assert(os.exists(a.jsFile.path / os.up / "a.js.map"))
+      assert(a.jsFileName == "a.js")
+      assert(os.exists(report.dest.path / "a.js"))
+      assert(os.exists(report.dest.path / "a.js.map"))
     }
   }
 

--- a/scalajslib/worker-api/src/ScalaJSWorkerApi.scala
+++ b/scalajslib/worker-api/src/ScalaJSWorkerApi.scala
@@ -16,12 +16,11 @@ private[scalajslib] trait ScalaJSWorkerApi {
       moduleSplitStyle: ModuleSplitStyle
   ): Either[String, Report]
 
-  def run(config: JsEnvConfig, dest: File, report: Report): Unit
+  def run(config: JsEnvConfig, report: Report): Unit
 
   def getFramework(
       config: JsEnvConfig,
       frameworkName: String,
-      dest: File,
       report: Report
   ): (() => Unit, sbt.testing.Framework)
 
@@ -76,7 +75,10 @@ private[scalajslib] object JsEnvConfig {
   ) extends JsEnvConfig
 }
 
-private[scalajslib] final case class Report(val publicModules: Iterable[Report.Module])
+private[scalajslib] final case class Report(
+    val publicModules: Iterable[Report.Module],
+    val dest: File
+)
 private[scalajslib] object Report {
   final case class Module(
       val moduleID: String,


### PR DESCRIPTION
Report doesn't contain all linked js files but only the public
ones. Using that as Target return type breaks the cache invalidation.
This adds the dest folder PathRef as a safer cache invalidation input.
It changes jsFile to jsFileName as in official Scala.js API