### PR TITLE
Downgrade upickle to 1.6.0

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -123,7 +123,7 @@ object Deps {
   def scalaReflect(scalaVersion: String) = ivy"org.scala-lang:scala-reflect:${scalaVersion}"
   def scalacScoveragePlugin = ivy"org.scoverage:::scalac-scoverage-plugin:1.4.11"
   val sourcecode = ivy"com.lihaoyi::sourcecode:0.2.8"
-  val upickle = ivy"com.lihaoyi::upickle:2.0.0"
+  val upickle = ivy"com.lihaoyi::upickle:1.6.0"
   val utest = ivy"com.lihaoyi::utest:0.7.11"
   val windowsAnsi = ivy"io.github.alexarchambault.windows-ansi:windows-ansi:0.0.3"
   val zinc = ivy"org.scala-sbt::zinc:1.6.1"


### PR DESCRIPTION
Turns out, it causes instable caches when switching mill server mode, which results in perceived full cache invalidations.

This reverts pull request: https://github.com/com-lihaoyi/mill/pull/1854

Reported by @lolgab, see https://gitter.im/lihaoyi/mill?at=62741f02949ae94006917596
