### PR TITLE
Bump uPickle to 2.0.0 together with Ammonite 2.5.4

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -83,7 +83,7 @@ object Deps {
   }
 
   val acyclic = ivy"com.lihaoyi::acyclic:0.2.1"
-  val ammoniteVersion = "2.5.3-1-b7b4900a"
+  val ammoniteVersion = "2.5.4"
   val ammonite = ivy"com.lihaoyi:::ammonite:${ammoniteVersion}"
   val ammoniteTerminal = ivy"com.lihaoyi::ammonite-terminal:${ammoniteVersion}"
   // Exclude trees here to force the version of we have defined. We use this

--- a/build.sc
+++ b/build.sc
@@ -83,7 +83,7 @@ object Deps {
   }
 
   val acyclic = ivy"com.lihaoyi::acyclic:0.2.1"
-  val ammoniteVersion = "2.5.3"
+  val ammoniteVersion = "2.5.3-1-b7b4900a"
   val ammonite = ivy"com.lihaoyi:::ammonite:${ammoniteVersion}"
   val ammoniteTerminal = ivy"com.lihaoyi::ammonite-terminal:${ammoniteVersion}"
   // Exclude trees here to force the version of we have defined. We use this
@@ -124,7 +124,7 @@ object Deps {
   def scalaReflect(scalaVersion: String) = ivy"org.scala-lang:scala-reflect:${scalaVersion}"
   def scalacScoveragePlugin = ivy"org.scoverage:::scalac-scoverage-plugin:1.4.11"
   val sourcecode = ivy"com.lihaoyi::sourcecode:0.2.8"
-  val upickle = ivy"com.lihaoyi::upickle:1.6.0"
+  val upickle = ivy"com.lihaoyi::upickle:2.0.0"
   val utest = ivy"com.lihaoyi::utest:0.7.11"
   val windowsAnsi = ivy"io.github.alexarchambault.windows-ansi:windows-ansi:0.0.3"
   val zinc = ivy"org.scala-sbt::zinc:1.6.1"


### PR DESCRIPTION
Second attempt at landing https://github.com/com-lihaoyi/mill/pull/1854. Let's see if keeping the uPickle version consistent between Ammonite and Mill helps

I tried to repro the original problem using the locally-built `target/mill-release` binary, and am able to reproduce the problem (unwanted re-compilation of build.sc) without the Ammonite update, and am unable to reproduce the problem with the Ammonite update. I don't know what the problem is, but I can only conclude that the Ammonite update fixed it.

@lolgab could you help try this out see if it works properly for you too?