### PR TITLE
Enable ScalaJS optimizer by default

### DIFF
--- a/scalajslib/src/mill/scalajslib/ScalaJSWorkerApi.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSWorkerApi.scala
@@ -33,7 +33,8 @@ class ScalaJSWorker private (val bridgeWorker: worker.ScalaJSWorker, createdInte
     main = main,
     forceOutJs = true,
     testBridgeInit = testBridgeInit,
-    fullOpt = fullOpt,
+    isFullLinkJS = fullOpt,
+    optimizer = fullOpt,
     moduleKind = moduleKind,
     esFeatures = esFeatures,
     moduleSplitStyle = ModuleSplitStyle.FewestModules

--- a/scalajslib/src/mill/scalajslib/worker/ScalaJSWorker.scala
+++ b/scalajslib/src/mill/scalajslib/worker/ScalaJSWorker.scala
@@ -130,7 +130,8 @@ private[scalajslib] class ScalaJSWorker extends AutoCloseable {
       main: Option[String],
       forceOutJs: Boolean,
       testBridgeInit: Boolean,
-      fullOpt: Boolean,
+      isFullLinkJS: Boolean,
+      optimizer: Boolean,
       moduleKind: api.ModuleKind,
       esFeatures: api.ESFeatures,
       moduleSplitStyle: api.ModuleSplitStyle
@@ -142,7 +143,8 @@ private[scalajslib] class ScalaJSWorker extends AutoCloseable {
       main = main.orNull,
       forceOutJs = forceOutJs,
       testBridgeInit = testBridgeInit,
-      fullOpt = fullOpt,
+      isFullLinkJS = isFullLinkJS,
+      optimizer = optimizer,
       moduleKind = toWorkerApi(moduleKind),
       esFeatures = toWorkerApi(esFeatures),
       moduleSplitStyle = toWorkerApi(moduleSplitStyle)

--- a/scalajslib/worker-api/src/ScalaJSWorkerApi.scala
+++ b/scalajslib/worker-api/src/ScalaJSWorkerApi.scala
@@ -10,7 +10,8 @@ private[scalajslib] trait ScalaJSWorkerApi {
       main: String,
       forceOutJs: Boolean,
       testBridgeInit: Boolean,
-      fullOpt: Boolean,
+      isFullLinkJS: Boolean,
+      optimizer: Boolean,
       moduleKind: ModuleKind,
       esFeatures: ESFeatures,
       moduleSplitStyle: ModuleSplitStyle


### PR DESCRIPTION
Introduce `scalaJSOptimizer: T[Boolean] = true` target
to make it configurable.
Set the default to `true` since it is what ScalaJS suggests and
uses in the official Sbt plugin