### PR TITLE
Fix universal-main args handling

### DIFF
--- a/main/client/src/mill/main/client/MillClientMain.java
+++ b/main/client/src/mill/main/client/MillClientMain.java
@@ -60,7 +60,7 @@ public class MillClientMain {
     }
 
     public static void main(String[] args) throws Exception {
-        if (args.length > 1) {
+        if (args.length > 0) {
             String firstArg = args[0];
             if (Arrays.asList("-i", "--interactive", "--no-server", "--repl", "--bsp").contains(firstArg)) {
                 // start in no-server mode


### PR DESCRIPTION
Fixes #1795  
In the stacktrace of that issue you can see that `MillServerMain` was (wrongly) used.