### PR TITLE
Fix visualize command

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -97,7 +97,7 @@ object Deps {
   val coursier = ivy"io.get-coursier::coursier:2.1.0-M5"
 
   val flywayCore = ivy"org.flywaydb:flyway-core:8.0.2"
-  val graphvizJava = ivy"guru.nidi:graphviz-java:0.18.1"
+  val graphvizJava = ivy"guru.nidi:graphviz-java-all-j2v8:0.18.1"
   val junixsocket = ivy"com.kohlschutter.junixsocket:junixsocket-core:2.4.0"
 
   object jetty {
@@ -106,7 +106,7 @@ object Deps {
     val websocket = ivy"org.eclipse.jetty:jetty-websocket:${version}"
   }
   val javaxServlet = ivy"org.eclipse.jetty.orbit:javax.servlet:3.0.0.v201112011016"
-  val jgraphtCore = ivy"org.jgrapht:jgrapht-core:1.5.1"
+  val jgraphtCore = ivy"org.jgrapht:jgrapht-core:1.4.0" //1.5.0+ dont support JDK8
 
   val jna = ivy"net.java.dev.jna:jna:5.11.0"
   val jnaPlatform = ivy"net.java.dev.jna:jna-platform:5.11.0"


### PR DESCRIPTION
Fixes #1652

1. use graphviz-java-all-j2v8 instead of graphviz-java (now as transitive dependency)
Following instructions from graphviz-java [docs](https://github.com/nidi3/graphviz-java#maven
) they say:
> gradle does not support this way of defining a dependency
> Instead of graphviz-java there are two alternative dependencies that can be used:
> - graphviz-java-all-j2v8 additionally contains dependencies to all J2V8 platforms. So the same application can run on Linux, Mac OS X and Windows.
> - graphviz-java-min-deps contains only dependencies that are absolutely necessary. All other dependencies are marked as optional and must added manually. See the [pom.xml](https://github.com/nidi3/graphviz-java/blob/master/graphviz-java-min-deps/pom.xml#L64-L90) for details.

2. downgrade jgrapht since 1.5.0+ dont support JDK8
https://github.com/jgrapht/jgrapht#dependencies

This adds around 3MB of extra dependencies.  
The upside is that it works on all JDK: 8, 11 and 17! (tested locally on win10)