### PR TITLE
BSP: fix mill-build module interpretation in IntelliJ IDEA

### DIFF
--- a/bsp/src/mill/bsp/MillBuildServer.scala
+++ b/bsp/src/mill/bsp/MillBuildServer.scala
@@ -341,11 +341,11 @@ class MillBuildServer(
         targetIds = sourcesParams.getTargets.asScala.toSeq,
         agg = (items: Seq[SourcesItem]) => new SourcesResult(items.asJava)
       ) {
-        case (id, _: MillBuildTarget) if clientIsIntelliJ =>
+        case (id, module: MillBuildTarget) if clientIsIntelliJ =>
           T.task {
             val sources = new SourcesItem(
               id,
-              Seq(sourceItem(evaluator.rootModule.millSourcePath / ".bsp", false)).asJava
+              module.dummySources().map(p => sourceItem(p.path, true)).asJava
             )
             sources.setRoots(Seq(sanitizeUri(evaluator.rootModule.millSourcePath)).asJava)
             sources

--- a/scalalib/src/mill/scalalib/bsp/BspModule.scala
+++ b/scalalib/src/mill/scalalib/bsp/BspModule.scala
@@ -142,4 +142,7 @@ trait MillBuildTarget // (rootModule: BaseModule, ctx0: mill.define.Ctx)
     os.makeDir(T.dest / "classes")
     CompilationResult(T.dest / "dummy", PathRef(T.dest / "classes"))
   }
+
+  /** Used in BSP IntelliJ, which can only work with directories */
+  def dummySources: Sources = T.sources(T.dest)
 }


### PR DESCRIPTION
## Current behaviour
<img width="494" alt="Snag_d9bcecc" src="https://user-images.githubusercontent.com/316079/168531129-c8187ead-376a-4637-935f-59688f069656.png">
<img width="1050" alt="Snag_d9cc8cc" src="https://user-images.githubusercontent.com/316079/168531247-26236c6f-918c-41ad-915e-ffdb8ac6aa03.png">

* `sub` is interpreted as a package.
* `Source Folders` is `.`.

This creates a problem where IntelliJ may interpret `root.Foo` class as  `sub.foo.src.root.Foo` class.

## Changed behaviour
<img width="464" alt="Snag_d9f2fd9" src="https://user-images.githubusercontent.com/316079/168531593-ab7c23ee-90d0-4b25-8e00-04f0460ce929.png">
<img width="1063" alt="Snag_da04792" src="https://user-images.githubusercontent.com/316079/168531746-43cccdf1-31a7-42ff-99e6-57bd3318c8d8.png">

* `sub` is interpreted as a directory.
* `Source Folders` is `.bsp`.

Everything works well. `build.sc` can also be edited correctly.

If IntelliJ supports [per-file source configuration](https://youtrack.jetbrains.com/issue/SCL-19717), this change would not be necessary.
