### PR TITLE
Fix lunr-extension version

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -1201,10 +1201,10 @@ object docs extends Module {
         commandArgs = Seq(
           npmExe,
           "install",
-          "@antora/cli",
-          "@antora/site-generator-default",
+          "@antora/cli@3.0.1",
+          "@antora/site-generator-default@3.0.1",
           "gitlab:antora/xref-validator",
-          "@antora/lunr-extension"
+          "@antora/lunr-extension@v1.0.0-alpha.6"
         ),
         envArgs = Map(),
         workingDir = npmDir


### PR DESCRIPTION
Seems like newer version of `lunr-extension` broke the search.  
The version is now fixed to `v1.0.0-alpha.6` (at least for now), which we know works properly.