### PR TITLE
Support Scala Native `nativeEmbedResources`

### DIFF
--- a/scalanativelib/api/src/mill/scalanativelib/api/ScalaNativeWorkerApi.java
+++ b/scalanativelib/api/src/mill/scalanativelib/api/ScalaNativeWorkerApi.java
@@ -1,4 +1,5 @@
 package mill.scalanativelib.api;
+
 import sbt.testing.Framework;
 
 public interface ScalaNativeWorkerApi {
@@ -20,6 +21,7 @@ public interface ScalaNativeWorkerApi {
                         LTO nativeLTO,
                         ReleaseMode releaseMode,
                         boolean optimize,
+                        boolean embedResources,
                         NativeLogLevel logLevel);
 
     String defaultGarbageCollector();

--- a/scalanativelib/src/ScalaNativeModule.scala
+++ b/scalanativelib/src/ScalaNativeModule.scala
@@ -164,6 +164,14 @@ trait ScalaNativeModule extends ScalaModule { outer =>
   // Whether to link `@stub` methods, or ignore them
   def nativeLinkStubs = T { false }
 
+  /**
+   * Shall the resource files be embedded in the resulting binary file? Allows
+   *  the use of getClass().getResourceAsStream() on the included files. Will
+   *  not embed files with certain extensions, including ".c", ".h", ".scala"
+   *  and ".class".
+   */
+  def nativeEmbedResources = T { false }
+
   // The LTO mode to use used during a release build
   protected def nativeLTOInput: Target[Option[LTO]] = T.input {
     readEnvVariable[LTO](T.env, "SCALANATIVE_LTO", LTO.values, _.value)
@@ -195,7 +203,8 @@ trait ScalaNativeModule extends ScalaModule { outer =>
       nativeLTO(),
       releaseMode(),
       nativeOptimize(),
-      logLevel()
+      nativeEmbedResources(),
+      logLevel(),
     )
   }
 

--- a/scalanativelib/worker/0.4/src/ScalaNativeWorkerImpl.scala
+++ b/scalanativelib/worker/0.4/src/ScalaNativeWorkerImpl.scala
@@ -51,6 +51,7 @@ class ScalaNativeWorkerImpl extends mill.scalanativelib.api.ScalaNativeWorkerApi
       nativeLTO: LTO,
       releaseMode: ReleaseMode,
       nativeOptimize: Boolean,
+      nativeEmbedResources: Boolean,
       logLevel: NativeLogLevel
   ): NativeConfig = {
     val entry = Versions.current match {
@@ -74,6 +75,7 @@ class ScalaNativeWorkerImpl extends mill.scalanativelib.api.ScalaNativeWorkerApi
             .withMode(Mode(releaseMode.value))
             .withOptimize(nativeOptimize)
             .withLTO(ScalaNativeLTO(nativeLTO.value))
+            .withEmbedResources(nativeEmbedResources)
         )
         .withLogger(logger(logLevel))
     new NativeConfig(config)

--- a/scalanativelib/worker/0.4/src/ScalaNativeWorkerImpl.scala
+++ b/scalanativelib/worker/0.4/src/ScalaNativeWorkerImpl.scala
@@ -24,7 +24,7 @@ import scala.util.{Success, Try}
 
 class ScalaNativeWorkerImpl extends mill.scalanativelib.api.ScalaNativeWorkerApi {
   private def patchIsGreaterThanOrEqual(number: Int) = {
-    val patch = Versions.current.stripSuffix("0.4.")
+    val patch = Versions.current.stripPrefix("0.4.")
     Try(patch.toInt) match {
       case Success(n) if n < number => false
       case _ => true

--- a/scalanativelib/worker/0.4/src/ScalaNativeWorkerImpl.scala
+++ b/scalanativelib/worker/0.4/src/ScalaNativeWorkerImpl.scala
@@ -3,6 +3,8 @@ package mill.scalanativelib.worker
 import java.io.File
 import java.lang.System.{err, out}
 
+import mill.scalanativelib.api.{GetFrameworkResult, LTO, NativeConfig, NativeLogLevel, ReleaseMode}
+import sbt.testing.Framework
 import scala.scalanative.util.Scope
 import scala.scalanative.build.{
   Build,
@@ -16,15 +18,17 @@ import scala.scalanative.build.{
   NativeConfig => ScalaNativeNativeConfig
 }
 import scala.scalanative.nir.Versions
-import mill.scalanativelib.api.{GetFrameworkResult, LTO, NativeConfig, NativeLogLevel, ReleaseMode}
-import sbt.testing.Framework
-
 import scala.scalanative.testinterface.adapter.TestAdapter
 
+import scala.util.{Success, Try}
+
 class ScalaNativeWorkerImpl extends mill.scalanativelib.api.ScalaNativeWorkerApi {
-  private def patchIsGreaterThanOrEqual(number: Int) = Versions.current match {
-    case s"0.4.$n" if n.toIntOption.exists(_ < number) => false
-    case _ => true
+  private def patchIsGreaterThanOrEqual(number: Int) = {
+    val patch = Versions.current.stripSuffix("0.4.")
+    Try(patch.toInt) match {
+      case Success(n) if n < number => false
+      case _ => true
+    }
   }
 
   def logger(level: NativeLogLevel) =


### PR DESCRIPTION
This adds support for `nativeEmbedResources` (available in Scala Native 0.4.4+)
Since we support Scala Native 0.4.0+ this uses the same mechanism `scalajslib` uses to execute methods only on versions a certain feature is available.