### PR TITLE
Add a testkit module to hold the TestEvaluator

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -421,8 +421,7 @@ object main extends MillModule {
     )
   }
 
-  object testkit extends MillModule {
-    def scalaVersion = Deps.scalaVersion
+  object testkit extends MillInternalModule with MillAutoTestSetup {
     def moduleDeps = Seq(core, util)
   }
 

--- a/build.sc
+++ b/build.sc
@@ -289,6 +289,7 @@ trait MillModule extends MillApiModule with MillAutoTestSetup { outer =>
 }
 
 object main extends MillModule {
+
   override def moduleDeps = Seq(core, client)
   override def ivyDeps = Agg(
     Deps.windowsAnsi
@@ -420,10 +421,12 @@ object main extends MillModule {
     )
   }
 
-  object testutil extends MillPublishModule with ScalaModule {
+  object testkit extends MillPublishModule with ScalaModule {
     def scalaVersion = Deps.scalaVersion
     def moduleDeps = Seq(core, util)
   }
+
+  def testModuleDeps = super.testModuleDeps ++ Seq(testkit)
 
 }
 

--- a/build.sc
+++ b/build.sc
@@ -419,6 +419,12 @@ object main extends MillModule {
       "-DMILL_GRAPHVIZ=" + runClasspath().map(_.path).mkString(",")
     )
   }
+
+  object testutil extends MillPublishModule with ScalaModule {
+    def scalaVersion = Deps.scalaVersion
+    def moduleDeps = Seq(core, util)
+  }
+
 }
 
 object testrunner extends MillModule {

--- a/build.sc
+++ b/build.sc
@@ -421,7 +421,7 @@ object main extends MillModule {
     )
   }
 
-  object testkit extends MillPublishModule with ScalaModule {
+  object testkit extends MillModule {
     def scalaVersion = Deps.scalaVersion
     def moduleDeps = Seq(core, util)
   }

--- a/main/test/src/eval/ModuleTests.scala
+++ b/main/test/src/eval/ModuleTests.scala
@@ -18,7 +18,7 @@ object ModuleTests extends TestSuite {
     def z = T { ExternalModule.x() + ExternalModule.inner.y() }
   }
   val tests = Tests {
-    os.remove.all(TestEvaluator.externalOutPath)
+    os.remove.all(TestUtil.externalOutPath)
     "externalModuleTargetsAreNamespacedByModulePackagePath" - {
       val check = new TestEvaluator(Build)
       val zresult = check.apply(Build.z)
@@ -26,10 +26,10 @@ object ModuleTests extends TestSuite {
         zresult == Right((30, 1)),
         os.read(check.evaluator.outPath / "z.json").contains("30"),
         os.read(
-          TestEvaluator.externalOutPath / "mill" / "eval" / "ModuleTests" / "ExternalModule" / "x.json"
+          TestUtil.externalOutPath / "mill" / "eval" / "ModuleTests" / "ExternalModule" / "x.json"
         ).contains("13"),
         os.read(
-          TestEvaluator.externalOutPath / "mill" / "eval" / "ModuleTests" / "ExternalModule" / "inner" / "y.json"
+          TestUtil.externalOutPath / "mill" / "eval" / "ModuleTests" / "ExternalModule" / "inner" / "y.json"
         ).contains("17")
       )
     }

--- a/main/test/src/util/TestEvaluator.scala
+++ b/main/test/src/util/TestEvaluator.scala
@@ -1,5 +1,6 @@
 package mill.util
 
+import mill.testkit.MillTestkit
 import java.io.{InputStream, PrintStream}
 import mill.define.{Input, Target, Task}
 import mill.api.Result.OuterStack
@@ -11,8 +12,6 @@ import utest.framework.TestPath
 import language.experimental.macros
 import mill.api.{DummyInputStream, Result}
 object TestEvaluator {
-  val externalOutPath = os.pwd / "target" / "external"
-
   def static(module: => TestUtil.BaseModule)(implicit fullName: sourcecode.FullName) = {
     new TestEvaluator(module)(fullName, TestPath(Nil))
   }
@@ -31,87 +30,13 @@ class TestEvaluator(
     inStream: InputStream = DummyInputStream,
     debugEnabled: Boolean = false,
     extraPathEnd: Seq[String] = Seq.empty
-)(implicit fullName: sourcecode.FullName, tp: TestPath) {
-  val outPath = TestUtil.getOutPath() / extraPathEnd
-
-//  val logger = DummyLogger
-  val logger = new PrintLogger(
-    colored = true,
-    disableTicker = false,
-    ammonite.util.Colors.Default.info(),
-    ammonite.util.Colors.Default.error(),
-    outStream,
-    outStream,
-    outStream,
-    inStream,
-    debugEnabled = debugEnabled,
-    context = ""
-  ) {
-    val prefix = {
-      val idx = fullName.value.lastIndexOf(".")
-      if (idx > 0) fullName.value.substring(0, idx)
-      else fullName.value
-    }
-    override def error(s: String): Unit = super.error(s"${prefix}: ${s}")
-    override def info(s: String): Unit = super.info(s"${prefix}: ${s}")
-    override def debug(s: String): Unit = super.debug(s"${prefix}: ${s}")
-    override def ticker(s: String): Unit = super.ticker(s"${prefix}: ${s}")
-  }
-  val evaluator = Evaluator(
-    mill.api.Ctx.defaultHome,
-    outPath,
-    TestEvaluator.externalOutPath,
-    module,
-    logger
-  ).withFailFast(failFast).withThreadCount(threads)
-
-  def apply[T](t: Task[T]): Either[mill.api.Result.Failing[T], (T, Int)] = {
-    val evaluated = evaluator.evaluate(Agg(t))
-
-    if (evaluated.failing.keyCount == 0) {
-      Right(
-        Tuple2(
-          evaluated.rawValues.head.asInstanceOf[Result.Success[T]].value,
-          evaluated.evaluated.collect {
-            case t: Target[_]
-                if module.millInternal.targets.contains(t)
-                  && !t.isInstanceOf[Input[_]]
-                  && !t.ctx.external => t
-            case t: mill.define.Command[_] => t
-          }.size
-        )
-      )
-    } else {
-      Left(
-        evaluated.failing.lookupKey(evaluated.failing.keys().next).items.next()
-          .asInstanceOf[Result.Failing[T]]
-      )
-    }
-  }
-
-  def fail(target: Target[_], expectedFailCount: Int, expectedRawValues: Seq[Result[_]]): Unit = {
-
-    val res = evaluator.evaluate(Agg(target))
-
-    val cleaned = res.rawValues.map {
-      case Result.Exception(ex, _) => Result.Exception(ex, new OuterStack(Nil))
-      case x => x
-    }
-
-    assert(
-      cleaned == expectedRawValues,
-      res.failing.keyCount == expectedFailCount
+)(implicit fullName: sourcecode.FullName, tp: TestPath) extends TestUtil.TestEvaluator(
+      module,
+      tp.value,
+      failFast,
+      threads,
+      outStream,
+      inStream,
+      debugEnabled,
+      extraPathEnd
     )
-
-  }
-
-  def check(targets: Agg[Task[_]], expected: Agg[Task[_]]): Unit = {
-    val evaluated = evaluator.evaluate(targets)
-      .evaluated
-      .flatMap(_.asTarget)
-      .filter(module.millInternal.targets.contains)
-      .filter(!_.isInstanceOf[Input[_]])
-    assert(evaluated == expected)
-  }
-
-}

--- a/main/test/src/util/TestEvaluator.scala
+++ b/main/test/src/util/TestEvaluator.scala
@@ -1,6 +1,6 @@
 package mill.util
 
-import mill.testkit.MillTestkit
+import mill.testkit.MillTestKit
 import java.io.{InputStream, PrintStream}
 import mill.define.{Input, Target, Task}
 import mill.api.Result.OuterStack

--- a/main/test/src/util/TestUtil.scala
+++ b/main/test/src/util/TestUtil.scala
@@ -12,7 +12,7 @@ import scala.collection.mutable
 
 object TestUtil extends MillTestKit {
 
-  override val targetDir = os.pwd / "out" / "target"
+  override val targetDir = os.pwd / "target"
 
   def getOutPath()(implicit fullName: sourcecode.FullName, tp: TestPath): os.Path = {
     getOutPath(tp.value)

--- a/main/test/src/util/TestUtil.scala
+++ b/main/test/src/util/TestUtil.scala
@@ -1,6 +1,7 @@
 package mill.util
 
 import mill.define._
+import mill.testkit.MillTestkit
 import mill.api.Result
 import mill.api.Result.OuterStack
 import utest.assert
@@ -9,33 +10,9 @@ import utest.framework.TestPath
 
 import scala.collection.mutable
 
-object TestUtil {
+object TestUtil extends MillTestkit(os.pwd / "target") {
   def getOutPath()(implicit fullName: sourcecode.FullName, tp: TestPath): os.Path = {
-    getOutPathStatic() / tp.value
-  }
-  def getOutPathStatic()(implicit fullName: sourcecode.FullName): os.Path = {
-    os.pwd / "target" / "workspace" / fullName.value.split('.')
-  }
-
-  def getSrcPathStatic()(implicit fullName: sourcecode.FullName): os.Path = {
-    getSrcPathBase() / fullName.value.split('.')
-  }
-  def getSrcPathBase(): os.Path = {
-    os.pwd / "target" / "worksources"
-  }
-
-  class BaseModule(implicit
-      millModuleEnclosing0: sourcecode.Enclosing,
-      millModuleLine0: sourcecode.Line,
-      millName0: sourcecode.Name
-  ) extends mill.define.BaseModule(getSrcPathBase() / millModuleEnclosing0.value.split("\\.| |#"))(
-        implicitly,
-        implicitly,
-        implicitly,
-        implicitly,
-        implicitly
-      ) {
-    lazy val millDiscover: Discover[this.type] = Discover[this.type]
+    getOutPath(tp.value)
   }
 
   object test {

--- a/main/test/src/util/TestUtil.scala
+++ b/main/test/src/util/TestUtil.scala
@@ -10,7 +10,10 @@ import utest.framework.TestPath
 
 import scala.collection.mutable
 
-object TestUtil extends MillTestKit(os.pwd / "target") {
+object TestUtil extends MillTestKit {
+
+  override val targetDir = os.pwd / "out" / "target"
+
   def getOutPath()(implicit fullName: sourcecode.FullName, tp: TestPath): os.Path = {
     getOutPath(tp.value)
   }

--- a/main/test/src/util/TestUtil.scala
+++ b/main/test/src/util/TestUtil.scala
@@ -1,7 +1,7 @@
 package mill.util
 
 import mill.define._
-import mill.testkit.MillTestkit
+import mill.testkit.MillTestKit
 import mill.api.Result
 import mill.api.Result.OuterStack
 import utest.assert
@@ -10,7 +10,7 @@ import utest.framework.TestPath
 
 import scala.collection.mutable
 
-object TestUtil extends MillTestkit(os.pwd / "target") {
+object TestUtil extends MillTestKit(os.pwd / "target") {
   def getOutPath()(implicit fullName: sourcecode.FullName, tp: TestPath): os.Path = {
     getOutPath(tp.value)
   }

--- a/main/testkit/src/testkit/MillTestkit.scala
+++ b/main/testkit/src/testkit/MillTestkit.scala
@@ -12,13 +12,20 @@ import mill.api.{DummyInputStream, Result}
 
 import scala.collection.mutable
 
-class MillTestKit(targetDir: os.Path) {
+trait MillTestKit {
 
-  def staticTestEvaluator(module: => mill.define.BaseModule)(implicit fullName: sourcecode.FullName) = {
-    new TestEvaluator(module, Seq.empty)(fullName)
-  }
+  lazy val defaultTargetDir: os.Path =
+    sys.env.get("MILL_TESTKIT_BASEDIR").map(os.pwd / os.RelPath(_)).getOrElse(os.temp.dir())
+
+  def targetDir: os.Path = defaultTargetDir
 
   val externalOutPath: os.Path = targetDir / "external"
+
+  def staticTestEvaluator(module: => mill.define.BaseModule)(implicit
+      fullName: sourcecode.FullName
+  ) = {
+    new TestEvaluator(module, Seq.empty)(fullName)
+  }
 
   def getOutPath(testPath: Seq[String])(implicit fullName: sourcecode.FullName): os.Path = {
     getOutPathStatic() / testPath

--- a/main/testkit/src/testkit/MillTestkit.scala
+++ b/main/testkit/src/testkit/MillTestkit.scala
@@ -12,7 +12,11 @@ import mill.api.{DummyInputStream, Result}
 
 import scala.collection.mutable
 
-class MillTestkit(targetDir: os.Path) {
+class MillTestKit(targetDir: os.Path) {
+
+  def staticTestEvaluator(module: => mill.define.BaseModule)(implicit fullName: sourcecode.FullName) = {
+    new TestEvaluator(module, Seq.empty)(fullName)
+  }
 
   val externalOutPath: os.Path = targetDir / "external"
 

--- a/main/testkit/src/testkit/MillTestkit.scala
+++ b/main/testkit/src/testkit/MillTestkit.scala
@@ -14,12 +14,12 @@ import scala.collection.mutable
 
 trait MillTestKit {
 
-  lazy val defaultTargetDir: os.Path =
+  def defaultTargetDir: os.Path =
     sys.env.get("MILL_TESTKIT_BASEDIR").map(os.pwd / os.RelPath(_)).getOrElse(os.temp.dir())
 
   def targetDir: os.Path = defaultTargetDir
 
-  val externalOutPath: os.Path = targetDir / "external"
+  def externalOutPath: os.Path = targetDir / "external"
 
   def staticTestEvaluator(module: => mill.define.BaseModule)(implicit
       fullName: sourcecode.FullName

--- a/main/testkit/src/testkit/MillTestkit.scala
+++ b/main/testkit/src/testkit/MillTestkit.scala
@@ -1,4 +1,4 @@
-package mill.testutil
+package mill.testkit
 
 import mill.define._
 import mill.api.Result
@@ -12,13 +12,11 @@ import mill.api.{DummyInputStream, Result}
 
 import scala.collection.mutable
 
-object MillTests extends MillTests(os.pwd / "target")
-
-class MillTests(targetDir: os.Path) {
+class MillTestkit(targetDir: os.Path) {
 
   val externalOutPath: os.Path = targetDir / "external"
 
-  def getOutPath(testPath: os.RelPath)(implicit fullName: sourcecode.FullName): os.Path = {
+  def getOutPath(testPath: Seq[String])(implicit fullName: sourcecode.FullName): os.Path = {
     getOutPathStatic() / testPath
   }
 
@@ -33,7 +31,7 @@ class MillTests(targetDir: os.Path) {
     targetDir / "worksources"
   }
 
-  class TestBaseModule(implicit
+  class BaseModule(implicit
       millModuleEnclosing0: sourcecode.Enclosing,
       millModuleLine0: sourcecode.Line,
       millName0: sourcecode.Name
@@ -55,7 +53,7 @@ class MillTests(targetDir: os.Path) {
    */
   class TestEvaluator(
       module: mill.define.BaseModule,
-      testPath: os.RelPath,
+      testPath: Seq[String],
       failFast: Boolean = false,
       threads: Option[Int] = Some(1),
       outStream: PrintStream = System.out,

--- a/main/testkit/test/src/testkit/MillTestKitSuite.scala
+++ b/main/testkit/test/src/testkit/MillTestKitSuite.scala
@@ -1,4 +1,4 @@
-package mill.contrib.bloop
+package mill.testkit
 
 import mill.testkit.MillTestKit
 import mill._
@@ -6,8 +6,8 @@ import utest._
 
 object MillTestKitSuite extends TestSuite {
 
-  val targetDir = os.pwd / "target"
-  val testKit = new MillTestKit(targetDir)
+  object testKit extends MillTestKit
+
   val testEvaluator = testKit.staticTestEvaluator(build)
 
   object build extends testKit.BaseModule {

--- a/main/testkit/test/src/testkit/MillTestKitSuite.scala
+++ b/main/testkit/test/src/testkit/MillTestKitSuite.scala
@@ -1,0 +1,24 @@
+package mill.contrib.bloop
+
+import mill.testkit.MillTestKit
+import mill._
+import utest._
+
+object MillTestKitSuite extends TestSuite {
+
+  val targetDir = os.pwd / "target"
+  val testKit = new MillTestKit(targetDir)
+  val testEvaluator = testKit.staticTestEvaluator(build)
+
+  object build extends testKit.BaseModule {
+    def testTask = T("test")
+  }
+
+  def tests: Tests = Tests {
+    "Test evaluator allows to run tasks" - {
+      val result = testEvaluator(build.testTask).map(_._1)
+      assert(result == Right("test"))
+    }
+  }
+
+}

--- a/main/testutil/src/testutil/MillTests.scala
+++ b/main/testutil/src/testutil/MillTests.scala
@@ -1,0 +1,150 @@
+package mill.testutil
+
+import mill.define._
+import mill.api.Result
+import mill.api.Result.OuterStack
+import mill.api.Strict.Agg
+import java.io.{InputStream, PrintStream}
+import mill.define.{Input, Target, Task}
+import mill.eval.Evaluator
+import language.experimental.macros
+import mill.api.{DummyInputStream, Result}
+
+import scala.collection.mutable
+
+object MillTests extends MillTests(os.pwd / "target")
+
+class MillTests(targetDir: os.Path) {
+
+  val externalOutPath: os.Path = targetDir / "external"
+
+  def getOutPath(testPath: os.RelPath)(implicit fullName: sourcecode.FullName): os.Path = {
+    getOutPathStatic() / testPath
+  }
+
+  def getOutPathStatic()(implicit fullName: sourcecode.FullName): os.Path = {
+    targetDir / "workspace" / fullName.value.split('.')
+  }
+
+  def getSrcPathStatic()(implicit fullName: sourcecode.FullName): os.Path = {
+    getSrcPathBase() / fullName.value.split('.')
+  }
+  def getSrcPathBase(): os.Path = {
+    targetDir / "worksources"
+  }
+
+  class TestBaseModule(implicit
+      millModuleEnclosing0: sourcecode.Enclosing,
+      millModuleLine0: sourcecode.Line,
+      millName0: sourcecode.Name
+  ) extends mill.define.BaseModule(getSrcPathBase() / millModuleEnclosing0.value.split("\\.| |#"))(
+        implicitly,
+        implicitly,
+        implicitly,
+        implicitly,
+        implicitly
+      ) {
+    lazy val millDiscover: Discover[this.type] = Discover[this.type]
+  }
+
+  /**
+   * @param module The module under test
+   * @param externalOutPath The directory under which the evaluator stores its output
+   * @param failFast failFast mode enabled
+   * @param threads explicitly used nr. of parallel threads
+   */
+  class TestEvaluator(
+      module: mill.define.BaseModule,
+      testPath: os.RelPath,
+      failFast: Boolean = false,
+      threads: Option[Int] = Some(1),
+      outStream: PrintStream = System.out,
+      inStream: InputStream = DummyInputStream,
+      debugEnabled: Boolean = false,
+      extraPathEnd: Seq[String] = Seq.empty
+  )(implicit fullName: sourcecode.FullName) {
+    val outPath = getOutPath(testPath) / extraPathEnd
+
+//  val logger = DummyLogger
+    val logger = new mill.util.PrintLogger(
+      colored = true,
+      disableTicker = false,
+      ammonite.util.Colors.Default.info(),
+      ammonite.util.Colors.Default.error(),
+      outStream,
+      outStream,
+      outStream,
+      inStream,
+      debugEnabled = debugEnabled,
+      context = ""
+    ) {
+      val prefix = {
+        val idx = fullName.value.lastIndexOf(".")
+        if (idx > 0) fullName.value.substring(0, idx)
+        else fullName.value
+      }
+      override def error(s: String): Unit = super.error(s"${prefix}: ${s}")
+      override def info(s: String): Unit = super.info(s"${prefix}: ${s}")
+      override def debug(s: String): Unit = super.debug(s"${prefix}: ${s}")
+      override def ticker(s: String): Unit = super.ticker(s"${prefix}: ${s}")
+    }
+    val evaluator = Evaluator(
+      mill.api.Ctx.defaultHome,
+      outPath,
+      externalOutPath,
+      module,
+      logger
+    ).withFailFast(failFast).withThreadCount(threads)
+
+    def apply[T](t: Task[T]): Either[mill.api.Result.Failing[T], (T, Int)] = {
+      val evaluated = evaluator.evaluate(Agg(t))
+
+      if (evaluated.failing.keyCount == 0) {
+        Right(
+          Tuple2(
+            evaluated.rawValues.head.asInstanceOf[Result.Success[T]].value,
+            evaluated.evaluated.collect {
+              case t: Target[_]
+                  if module.millInternal.targets.contains(t)
+                    && !t.isInstanceOf[Input[_]]
+                    && !t.ctx.external => t
+              case t: mill.define.Command[_] => t
+            }.size
+          )
+        )
+      } else {
+        Left(
+          evaluated.failing.lookupKey(evaluated.failing.keys().next).items.next()
+            .asInstanceOf[Result.Failing[T]]
+        )
+      }
+    }
+
+    def fail(target: Target[_], expectedFailCount: Int, expectedRawValues: Seq[Result[_]]): Unit = {
+
+      val res = evaluator.evaluate(Agg(target))
+
+      val cleaned = res.rawValues.map {
+        case Result.Exception(ex, _) => Result.Exception(ex, new OuterStack(Nil))
+        case x => x
+      }
+
+      assert(
+        cleaned == expectedRawValues,
+        res.failing.keyCount == expectedFailCount
+      )
+
+    }
+
+    def check(targets: Agg[Task[_]], expected: Agg[Task[_]]): Unit = {
+      val evaluated = evaluator.evaluate(targets)
+        .evaluated
+        .flatMap(_.asTarget)
+        .filter(module.millInternal.targets.contains)
+        .filter(!_.isInstanceOf[Input[_]])
+      assert(evaluated == expected)
+    }
+
+  }
+
+}


### PR DESCRIPTION
@lefou opening this as a draft to get an early opinion (if you're against it, it's absolutely fine and I'll just publish it as a third party library from a repo I control) 

the TestEvaluator that the mill codebase uses to test itself is extremely useful for testing some mill modules with reasonably lightweight setup. I have copied it over in some projects a few times now, including [today](https://github.com/indoorvivants/sbt-vcpkg/pull/9#discussion_r890130257). I'd love to have it as a library, as testing modules this way, though not as thorough as a bonafide integration test, is absolutely neat. 

Making it available to downstream libraries and plugins could help expand the ecosystem, in particular when such plugins are built with SBT (which is the harsh reality of the status quo, and makes it hard to use mill-integrationtest). 

If that sounds appealing at all, then I'll wire that in this codebase in a way that would keep the diff to a minimum. 