### PR TITLE
fix zinc binary dependencies

### DIFF
--- a/scalalib/worker/src/mill/scalalib/worker/MockedLookup.scala
+++ b/scalalib/worker/src/mill/scalalib/worker/MockedLookup.scala
@@ -13,6 +13,9 @@ case class MockedLookup(am: VirtualFile => Optional[CompileAnalysis])
   override def analysis(classpathEntry: VirtualFile): Optional[CompileAnalysis] =
     am(classpathEntry)
 
-  override def definesClass(classpathEntry: VirtualFile): DefinesClass =
-    Locate.definesClass(classpathEntry)
+  override def definesClass(classpathEntry: VirtualFile): DefinesClass = {
+    if (classpathEntry.name.toString != "rt.jar")
+      Locate.definesClass(classpathEntry)
+    else (_: String) => false
+  }
 }

--- a/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
+++ b/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
@@ -474,6 +474,7 @@ class ZincWorkerImpl(
 
     val store = FileAnalysisStore.binary(zincFile.toIO)
 
+    // Fix jdk classes marked as binary dependencies, see https://github.com/com-lihaoyi/mill/pull/1904
     val converter = MappedFileConverter.empty
     val classpath = (compileClasspath.iterator ++ Some(classesDir))
       .map(path => converter.toVirtualFile(path.toNIO))

--- a/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
+++ b/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
@@ -474,7 +474,7 @@ class ZincWorkerImpl(
 
     val store = FileAnalysisStore.binary(zincFile.toIO)
 
-    val converter = PlainVirtualFileConverter.converter
+    val converter = MappedFileConverter.empty
     val classpath = (compileClasspath.iterator ++ Some(classesDir))
       .map(path => converter.toVirtualFile(path.toNIO))
       .toArray


### PR DESCRIPTION
Fix #1901 
Sbt use a `MappedFileConverter`, it will converter `jdk` internal classes like `/module/java.base/java.lang.String` associated with a dummpy `rt.jar`.
https://github.com/sbt/zinc/blob/57d03412abe3810be5762a8c8e8c55cbf622ed03/internal/zinc-core/src/main/scala/sbt/internal/inc/MappedVirtualFile.scala#L56
```scala
def toVirtualFile(path: Path): VirtualFile = {
    rootPaths2.find { case (_, rootPath) => path.startsWith(rootPath) } match {
      case Some((key, rootPath)) =>
        MappedVirtualFile(s"$${$key}/${rootPath.relativize(path)}".replace('\\', '/'), rootPaths)
      case _ =>
        def isCtSym =
          path.getFileSystem
            .provider()
            .getScheme == "jar" && path.getFileSystem.toString.endsWith("ct.sym")
        def isJrt = path.getFileSystem.provider().getScheme == "jrt"
        if (isJrt || path.getFileName.toString == "rt.jar" || isCtSym)
          DummyVirtualFile("rt.jar", path)
        else if (allowMachinePath) MappedVirtualFile(s"$path".replace('\\', '/'), rootPaths)
        else sys.error(s"$path cannot be mapped using the root paths $rootPaths")
    }
  }
```

And later the `Incremental`  will exclude such binary dependencies.
https://github.com/sbt/zinc/blob/57d03412abe3810be5762a8c8e8c55cbf622ed03/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala#L783
```scala

        // dependency is some other binary on the classpath.
        // exclude dependency tracking with rt.jar, for example java.lang.String -> rt.jar.
        if (!vf.id.endsWith("rt.jar")) {
          externalLibraryDependency(
            vf,
            onBinaryName,
            sourceFile,
            context
          )
        }
```
