### PR TITLE
Fixed ordering-sensitive test

### DIFF
--- a/scalalib/test/src/HelloJavaTests.scala
+++ b/scalalib/test/src/HelloJavaTests.scala
@@ -89,23 +89,16 @@ object HelloJavaTests extends TestSuite {
 
       val Right((v3, _)) = eval.apply(HelloJava.app.testJunit5.test())
 
-      assert(
-        v3._2(0).fullyQualifiedName == "hello.Junit5TestsA",
-        v3._2(0).selector == "coreTest()",
-        v3._2(0).status == "Success",
-        v3._2(1).fullyQualifiedName == "hello.Junit5TestsA",
-        v3._2(1).selector == "skippedTest()",
-        v3._2(1).status == "Skipped",
-        v3._2(2).fullyQualifiedName == "hello.Junit5TestsA",
-        v3._2(2).selector == "palindromes(String):1",
-        v3._2(2).status == "Success",
-        v3._2(3).fullyQualifiedName == "hello.Junit5TestsA",
-        v3._2(3).selector == "palindromes(String):2",
-        v3._2(3).status == "Success", 
-        v3._2(4).fullyQualifiedName == "hello.Junit5TestsB",
-        v3._2(4).selector == "packagePrivateTest()",
-        v3._2(4).status == "Success"
+      val testResults = v3._2.map(t => (t.fullyQualifiedName, t.selector, t.status)).sorted
+      val expected = Seq(
+        ("hello.Junit5TestsA", "coreTest()", "Success"),
+        ("hello.Junit5TestsA", "palindromes(String):1", "Success"),
+        ("hello.Junit5TestsA", "palindromes(String):2", "Success"),
+        ("hello.Junit5TestsA", "skippedTest()", "Skipped"),
+        ("hello.Junit5TestsB", "packagePrivateTest()", "Success")
       )
+
+      assert(testResults == expected)
     }
     "failures" - {
       val eval = init()


### PR DESCRIPTION
We saw CI failures lately in this specific test.

As test cases are picked up from class files which order may depend on the used filesystem and other factors like creation time, inode number, ..., we better always try to avoid any ordering assumptions in tests.