### PR TITLE
Bump zinc and account for diagnostic code

### DIFF
--- a/bsp/src/mill/bsp/BspCompileProblemReporter.scala
+++ b/bsp/src/mill/bsp/BspCompileProblemReporter.scala
@@ -130,7 +130,6 @@ class BspCompileProblemReporter(
       pos.endColumn.orElse(pos.pointer).getOrElse[Int](start.getCharacter.intValue())
     )
     val diagnostic = new bsp.Diagnostic(new bsp.Range(start, end), problem.message)
-    diagnostic.setCode(pos.lineContent)
     diagnostic.setSource("mill")
     diagnostic.setSeverity(
       problem.severity match {
@@ -139,6 +138,7 @@ class BspCompileProblemReporter(
         case mill.api.Warn => bsp.DiagnosticSeverity.WARNING
       }
     )
+    problem.diagnosticCode.foreach { existingCode => diagnostic.setCode(existingCode.code) }
     diagnostic
   }
 

--- a/build.sc
+++ b/build.sc
@@ -145,7 +145,7 @@ object Deps {
   val upickle = ivy"com.lihaoyi::upickle:2.0.0"
   val utest = ivy"com.lihaoyi::utest:0.7.11"
   val windowsAnsi = ivy"io.github.alexarchambault.windows-ansi:windows-ansi:0.0.4"
-  val zinc = ivy"org.scala-sbt::zinc:1.7.1"
+  val zinc = ivy"org.scala-sbt::zinc:1.7.2"
   val bsp = ivy"ch.epfl.scala:bsp4j:2.1.0-M1"
   val fansi = ivy"com.lihaoyi::fansi:0.4.0"
   val jarjarabrams = ivy"com.eed3si9n.jarjarabrams::jarjar-abrams-core:1.8.1"

--- a/main/api/src/mill/api/CompileProblemReporter.scala
+++ b/main/api/src/mill/api/CompileProblemReporter.scala
@@ -30,6 +30,18 @@ trait Problem {
   def message: String
 
   def position: ProblemPosition
+
+  // TODO Remove default implementation in 0.11.x series
+  def diagnosticCode: Option[DiagnosticCode] = None
+}
+
+/**
+ * Unique diagnostic code given from the compiler with an optional further explanation.
+ */
+trait DiagnosticCode {
+  def code: String
+
+  def explanation: Option[String]
 }
 
 /**

--- a/scalalib/worker/src/mill/scalalib/worker/ZincDiagnosticCode.scala
+++ b/scalalib/worker/src/mill/scalalib/worker/ZincDiagnosticCode.scala
@@ -1,0 +1,12 @@
+package mill.scalalib.worker
+
+import mill.api.internal
+import mill.api.DiagnosticCode
+
+import scala.jdk.OptionConverters._
+
+@internal
+final case class ZincDiagnosticCode(base: xsbti.DiagnosticCode) extends DiagnosticCode {
+  override def code: String = base.code()
+  override def explanation: Option[String] = base.explanation().toScala
+}

--- a/scalalib/worker/src/mill/scalalib/worker/ZincProblem.scala
+++ b/scalalib/worker/src/mill/scalalib/worker/ZincProblem.scala
@@ -1,6 +1,8 @@
 package mill.scalalib.worker
 
 import mill.api.{Problem, ProblemPosition, Severity, internal}
+import mill.api.DiagnosticCode
+import scala.jdk.OptionConverters._
 
 @internal
 class ZincProblem(base: xsbti.Problem) extends Problem {
@@ -15,4 +17,7 @@ class ZincProblem(base: xsbti.Problem) extends Problem {
   override def message: String = base.message()
 
   override def position: ProblemPosition = new ZincProblemPosition(base.position())
+
+  override def diagnosticCode: Option[DiagnosticCode] =
+    base.diagnosticCode().toScala.map(ZincDiagnosticCode)
 }

--- a/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
+++ b/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
@@ -455,6 +455,7 @@ class ZincWorkerImpl(
     val newReporter = reporter match {
       case None => new ManagedLoggedReporter(10, logger)
       case Some(r) => new ManagedLoggedReporter(10, logger) {
+
           override def logError(problem: xsbti.Problem): Unit = {
             r.logError(new ZincProblem(problem))
             super.logError(problem)


### PR DESCRIPTION
At the moment this is just testing a bit. I see you already have a test
PR to bump zinc in https://github.com/com-lihaoyi/mill/pull/1845 but one
of the things that this brings in is the changes to `Problem` I made in
https://github.com/sbt/sbt/pull/6874 that expose the diagnostic code of
the diagnostic coming from dotc. I have been doing some work on that on
the compiler side in https://github.com/lampepfl/dotty/pull/15565 and
wanted to try it out with Mill.

I tried to mimic the way you currently have it set up, so let me know if
it's not the direction you'd want to go. However, the idea here would be
that the diagnostic code is forwarded when diagnostics are published via
BSP so that Metals could then capture that code and know what code
actions to offer. You can see more of the big picture in https://github.com/lampepfl/dotty/issues/14904.