### PR TITLE
update: flyway-core 8.0.2 -> 8.5.13, requires NOTICE log level

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -97,7 +97,7 @@ object Deps {
   val bloopConfig = ivy"ch.epfl.scala::bloop-config:1.5.2"
   val coursier = ivy"io.get-coursier::coursier:2.1.0-M6"
 
-  val flywayCore = ivy"org.flywaydb:flyway-core:8.0.2"
+  val flywayCore = ivy"org.flywaydb:flyway-core:8.5.13"
   val graphvizJava = ivy"guru.nidi:graphviz-java-all-j2v8:0.18.1"
   val junixsocket = ivy"com.kohlschutter.junixsocket:junixsocket-core:2.5.1"
 

--- a/contrib/flyway/src/ConsoleLog.scala
+++ b/contrib/flyway/src/ConsoleLog.scala
@@ -38,6 +38,10 @@ class ConsoleLog(val level: ConsoleLog.Level.Level) extends Log {
     System.out.println("WARNING: " + message)
   }
 
+  override def notice(message: String): Unit = {
+    System.err.println("NOTICE: " + message)
+  }
+
   override def error(message: String): Unit = {
     System.err.println("ERROR: " + message)
   }


### PR DESCRIPTION
This was one of the version updates scala steward has missed for a while.

I guess this is because scala steward couldn't add the required NOTICE log code change.