### PR TITLE
update: scalafmt-dynamic 3.4.3 -> 3.5.8

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -120,7 +120,7 @@ object Deps {
   val sbtTestInterface = ivy"org.scala-sbt:test-interface:1.0"
   val scalaCheck = ivy"org.scalacheck::scalacheck:1.16.0"
   def scalaCompiler(scalaVersion: String) = ivy"org.scala-lang:scala-compiler:${scalaVersion}"
-  val scalafmtDynamic = ivy"org.scalameta::scalafmt-dynamic:3.4.3"
+  val scalafmtDynamic = ivy"org.scalameta::scalafmt-dynamic:3.5.8"
   val scalametaTrees = ivy"org.scalameta::trees:4.5.9"
   def scalaReflect(scalaVersion: String) = ivy"org.scala-lang:scala-reflect:${scalaVersion}"
   def scalacScoveragePlugin = ivy"org.scoverage:::scalac-scoverage-plugin:1.4.11"


### PR DESCRIPTION
I can't guess why scala steward missed this update.
In my [mega-dep-update-PR](https://github.com/com-lihaoyi/mill/pull/1933), this dependency only needed a change in build.sc
