### PR TITLE
Use SoftReference instead of WeakReference for caches

### DIFF
--- a/scalajslib/worker/0.6/src/ScalaJSWorkerImpl.scala
+++ b/scalajslib/worker/0.6/src/ScalaJSWorkerImpl.scala
@@ -22,7 +22,7 @@ import org.scalajs.jsenv._
 import org.scalajs.testadapter.TestAdapter
 
 import scala.collection.mutable
-import scala.ref.WeakReference
+import scala.ref.SoftReference
 
 class ScalaJSWorkerImpl extends ScalaJSWorkerApi {
   private case class LinkerInput(
@@ -32,12 +32,12 @@ class ScalaJSWorkerImpl extends ScalaJSWorkerApi {
       esFeatures: ESFeatures
   )
   private object ScalaJSLinker {
-    private val cache = mutable.Map.empty[LinkerInput, WeakReference[ClearableLinker]]
+    private val cache = mutable.Map.empty[LinkerInput, SoftReference[ClearableLinker]]
     def reuseOrCreate(input: LinkerInput): ClearableLinker = cache.get(input) match {
-      case Some(WeakReference(linker)) => linker
+      case Some(SoftReference(linker)) => linker
       case _ =>
         val newLinker = createLinker(input)
-        cache.update(input, WeakReference(newLinker))
+        cache.update(input, SoftReference(newLinker))
         newLinker
     }
     private def createLinker(input: LinkerInput): ClearableLinker = {

--- a/scalajslib/worker/1/src/ScalaJSWorkerImpl.scala
+++ b/scalajslib/worker/1/src/ScalaJSWorkerImpl.scala
@@ -27,7 +27,7 @@ import org.scalajs.testing.adapter.TestAdapter
 import org.scalajs.testing.adapter.{TestAdapterInitializer => TAI}
 
 import scala.collection.mutable
-import scala.ref.WeakReference
+import scala.ref.SoftReference
 
 class ScalaJSWorkerImpl extends ScalaJSWorkerApi {
   private case class LinkerInput(
@@ -43,12 +43,12 @@ class ScalaJSWorkerImpl extends ScalaJSWorkerApi {
     case _ => true
   }
   private object ScalaJSLinker {
-    private val cache = mutable.Map.empty[LinkerInput, WeakReference[Linker]]
+    private val cache = mutable.Map.empty[LinkerInput, SoftReference[Linker]]
     def reuseOrCreate(input: LinkerInput): Linker = cache.get(input) match {
-      case Some(WeakReference(linker)) => linker
+      case Some(SoftReference(linker)) => linker
       case _ =>
         val newLinker = createLinker(input)
-        cache.update(input, WeakReference(newLinker))
+        cache.update(input, SoftReference(newLinker))
         newLinker
     }
     private def createLinker(input: LinkerInput): Linker = {


### PR DESCRIPTION
`SoftReference`s are [better suited to implement memory-sensitive caches](https://docs.oracle.com/javase/8/docs/api/java/lang/ref/SoftReference.html).

Suggested in a code review in bloop: https://github.com/scalacenter/bloop/pull/1761#discussion_r925512643
