### PR TITLE
Pass clientServer parameter to the IntegrationTestSuite constructor

### DIFF
--- a/integration/local/resources/mill-jvm-opts/.mill-jvm-opts
+++ b/integration/local/resources/mill-jvm-opts/.mill-jvm-opts
@@ -1,3 +1,4 @@
 
 # comment after an empty line
 -DPROPERTY_PROPERLY_SET_VIA_JVM_OPTS=value-from-file
+-Xss120m

--- a/integration/local/resources/mill-jvm-opts/build.sc
+++ b/integration/local/resources/mill-jvm-opts/build.sc
@@ -1,7 +1,17 @@
 import mill._
+import java.lang.management.ManagementFactory
+import scala.jdk.CollectionConverters._
 
 def checkJvmOpts() = T.command {
   val prop = System.getProperty("PROPERTY_PROPERLY_SET_VIA_JVM_OPTS")
   if (prop != "value-from-file") sys.error("jvm-opts not correctly applied, value was: " + prop)
+  val runtime = ManagementFactory.getRuntimeMXBean()
+  val args = runtime.getInputArguments().asScala.toSet
+  if (!args.contains("-DPROPERTY_PROPERLY_SET_VIA_JVM_OPTS=value-from-file")) {
+    sys.error("jvm-opts not correctly applied, args were: " + args.mkString)
+  }
+  if (!args.contains("-Xss120m")) {
+    sys.error("jvm-opts not correctly applied, args were: " + args.mkString)
+  }
   ()
 }

--- a/integration/local/src/IntegrationTestSuite.scala
+++ b/integration/local/src/IntegrationTestSuite.scala
@@ -7,7 +7,7 @@ abstract class IntegrationTestSuite(
     override val workspaceSlug: String,
     fork: Boolean,
     clientServer: Boolean = false
-) extends ScriptTestSuite(fork) {
+) extends ScriptTestSuite(fork, clientServer) {
 
   override def workspacePath: os.Path =
     os.Path(sys.props.getOrElse("MILL_WORKSPACE_PATH", ???)) / workspaceSlug


### PR DESCRIPTION
I've been having problems with my .mill-jvm-opts file not being applied while in client-server mode.  I was doing some testing and realized the integration tests were always using `--no-server`.

I found that the clientServer parameter was not being passed down.  This is a small one line PR to fix that.

Regarding my original issue, it doesn't seem to happen as of c81ac64ee91b8d85074ff373df1c01f8bd91b06e