### PR TITLE
[Docs] Targets fastOpt and fullOpt have been deprecated in Mill 0.10.4

### DIFF
--- a/docs/antora/modules/ROOT/pages/Common_Project_Layouts.adoc
+++ b/docs/antora/modules/ROOT/pages/Common_Project_Layouts.adoc
@@ -107,7 +107,7 @@ object foo extends ScalaJSModule {
 `ScalaJSModule` is a variant of `ScalaModule` that builds your code using
 Scala.js. In addition to the standard `foo.compile` and `foo.run` commands (the
 latter of which runs your code on Node.js, which must be pre-installed)
-`ScalaJSModule` also exposes the `foo.fastOpt` and `foo.fullOpt` tasks for
+`ScalaJSModule` also exposes the `foo.fastLinkJS` and `foo.fullLinkJS` tasks for
 generating the optimized Javascript file.
 
 ScalaJSModule requires declaring it's dependencies as third party


### PR DESCRIPTION
As stated on https://github.com/com-lihaoyi/mill/blob/fbedc99d436f608cbfbc3609c1834ac7b3ea2a50/readme.adoc#0104---2022-05-06, `fastOpt` and `fullOpt` have been deprecated in favor of `fastLinkJS` and `fullLinkJS`.