### PR TITLE
bloop: use the same naming scheme for adding to and accessing moduleSourceMap

### DIFF
--- a/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
+++ b/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
@@ -133,7 +133,7 @@ class BloopImpl(ev: () => Evaluator, wd: os.Path) extends ExternalModule { outer
   def moduleSourceMap = T.input {
     val sources = T.traverse(computeModules) { m =>
       m.allSources.map { paths =>
-        m.millModuleSegments.render -> paths.map(_.path)
+        name(m) -> paths.map(_.path)
       }
     }()
     Result.Success(sources.toMap)


### PR DESCRIPTION
When the bloop module is computing the sources references for the project it uses the `moduleSourceMap` target. This puts paths into the map using `m.millModuleSegments.render` however when accessing the map to build the bloop configuration it uses `name(module)`. These differ for foreign modules resulting in the sources for foreign modules being omitted.
