### PR TITLE
docs: add some documentation about generating a doc jar

### DIFF
--- a/docs/antora/modules/ROOT/pages/Configuring_Mill.adoc
+++ b/docs/antora/modules/ROOT/pages/Configuring_Mill.adoc
@@ -343,6 +343,90 @@ NOTE: Remember that compiler plugins are published against the full Scala
 version (eg. 2.13.8 instead of just 2.13), so when including them make sure to
 use the  `:::` syntax shown above in the example.
 
+== Generating API Documentation
+
+To generate API documenation you can use the `docJar` task on the module you'd
+like to create the documenation for. For example, given a module called
+`example` you could do:
+
+[source, bash]
+----
+mill example.docJar
+----
+
+This will result in your `javaDoc` being created in
+`out/app/docJar.dest/javadoc`.
+
+For both Scala and Java modules there may be extra options that you'd like to
+pass specifically to either `javadoc` or `scaladoc`. You can pass these with
+`javadocOptions` and `scalaDocOptions` respectively.
+
+.`build.sc`
+[source,scala]
+----
+import mill._, scalalib._
+
+object example extends ScalaModule {
+  def scalaVersion = "3.1.3"
+
+  def scalaDocOptions = Seq(
+    "-siteroot",
+    "mydocs",
+    "-no-link-warnings"
+  )
+}
+----
+
+=== Scaladoc 3 Site Generation
+
+When using Scala 3 you're also able to use Scaladoc to generate a full static
+site next to your API documenation. This can include general documenation for
+your project and even a blog. While you can find the full documenation for this
+in the https://docs.scala-lang.org/scala3/guides/scaladoc/index.html[Scala 3
+docs], below you'll find some useful information to help you generate this with
+Mill.
+
+By default Mill will consider the _site root_ as it's called in
+https://docs.scala-lang.org/scala3/guides/scaladoc/static-site.html[Scala 3
+docs], to be the value of `docResources()`. It will look there for your
+`_docs/` and your `_blog/` directory if any exist. Let's pretend we have a
+project called `example` defined like this:
+
+.`build.sc`
+[source,scala]
+----
+import mill._, scalalib._
+
+object example extends ScalaModule {
+  def scalaVersion = "3.1.3"
+}
+----
+
+Your project structure for this would look something like this:
+
+----
+.
+├── build.sc
+├── example
+│  ├── docs
+│  │  ├── _blog
+│  │  │  ├── _posts
+│  │  │  │  └── 2022-08-14-hello-world.md
+│  │  │  └── index.md
+│  │  └── _docs
+│  │     ├── getting-started.md
+│  │     ├── index.html
+│  │     └── index.md
+│  └── src
+│     └── example
+│        └── Hello.scala
+----
+
+After generating your docs with `mill example.docJar` you'll find by opening
+your `out/app/docJar.dest/javadoc/index.hmtl` locally in your browser you'll
+have a full static site including your API docs, your blog, and your
+documenation!
+
 == Reformatting your code
 
 Mill supports code formatting via https://scalameta.org/scalafmt/[scalafmt] out of the box.

--- a/scalalib/src/ScalaModule.scala
+++ b/scalalib/src/ScalaModule.scala
@@ -134,6 +134,9 @@ trait ScalaModule extends JavaModule { outer =>
     mandatoryScalacOptions() ++ enablePluginScalacOptions() ++ scalacOptions()
   }
 
+  /**
+   * Options to pass directly into Scaladoc.
+   */
   def scalaDocOptions: T[Seq[String]] = T {
     val defaults =
       if (ZincWorkerUtil.isDottyOrScala3(scalaVersion()))
@@ -235,7 +238,6 @@ trait ScalaModule extends JavaModule { outer =>
     }
 
   override def docSources: Sources = T.sources {
-    // Scaladoc 3.0.0 is consuming tasty files
     if (
       ZincWorkerUtil.isScala3(scalaVersion()) && !ZincWorkerUtil.isScala3Milestone(scalaVersion())
     ) Seq(compile().classes)


### PR DESCRIPTION
I recently wanted to play around with the static site generator that
comes with Scaladoc for Scala 3, but the upstream documentation is very
sbt-focused and a bit confusing. I was also pretty unfamiliar with the
various doc-related tasks in Mill and since there wasn't any
documentation on it, I've included some basic documentation and also an
example of how to generate a full site with Scala 3.