### PR TITLE
feat: add in a pluginArtifact helper

### DIFF
--- a/scalalib/test/src/api/ZincWorkerUtilTests.scala
+++ b/scalalib/test/src/api/ZincWorkerUtilTests.scala
@@ -1,0 +1,15 @@
+package mill.scalalib.api
+
+import utest._
+
+object ZincWorkerUtilTests extends TestSuite {
+  val tests = Tests {
+    test("pluginArtfact") {
+      val res = ZincWorkerUtil.pluginArtifact("example", "0.10.5")
+
+      val exp = "example_mill0.10"
+
+      assert(res == exp)
+    }
+  }
+}


### PR DESCRIPTION
I've noticed myself (and copied from others) doing the same thing over
and over using the `scalaNativeBinaryVersion` help and then putting
together the artifact string ourselves, but this is easy to screw up if
you're not familiar with expected format. This just creates a helper
method that you can pass in the artifact name and Mill version and it
will put together the correct artifact name for you.

Note, I wasn't 100% sure where to put this. I sort of wanted to put it in
`module.Util` instead, but there are other similar things where I put it. Do
you think I should move this somewhere else?
