### PR TITLE
Don't print unwanted debug messages - Multilogger prefers first logger

### DIFF
--- a/main/util/src/mill/util/Loggers.scala
+++ b/main/util/src/mill/util/Loggers.scala
@@ -265,7 +265,7 @@ case class MultiLogger(colored: Boolean, logger1: Logger, logger2: Logger, inStr
     logger2.close()
   }
 
-  override def debugEnabled: Boolean = logger1.debugEnabled || logger2.debugEnabled
+  override def debugEnabled: Boolean = logger1.debugEnabled
 }
 
 /**


### PR DESCRIPTION
A better solution would be to add the `debugEnabled` flag to the contructor parameters of MultiLogger, but that would affect binary compatibilty.
