### PR TITLE
BSP: use build/logMessage for logging

### DIFF
--- a/bsp/src/mill/bsp/MillBspLogger.scala
+++ b/bsp/src/mill/bsp/MillBspLogger.scala
@@ -53,7 +53,7 @@ class MillBspLogger(client: BuildClient, taskId: Int, logger: Logger)
   override def debug(s: String): Unit = {
     super.debug(s)
     if (debugEnabled) {
-      client.onBuildShowMessage(new ShowMessageParams(MessageType.LOG, s))
+      client.onBuildLogMessage(new LogMessageParams(MessageType.LOG, s))
     }
   }
 


### PR DESCRIPTION
This pr makes 2 changes. First, debug messages shouldn't go through
`build/showMessage`. Taken from the BSP [docs](https://build-server-protocol.github.io/docs/specification.html#show-message):

> The show message notification is sent from a server to a client to ask
> the client to display a particular message in the user interface.

From my experience these are reserved for helpful messages that the user
should know about. So I changed this to `build/logMessage` which seems
more appropriate:

> The log message notification is sent from the server to the client to
> ask the client to log a particular message.

I also then just went ahead and removed this because even if we keep it
as log message, this will get logged all the time, and I don't think
it's that useful to log unless you think it should be. It's just every
time new semanticdb is being produced this is getting logged, which is
almost constant during development.

Closes #2005