### PR TITLE
BSP: Forward --debug option to BSP server

### DIFF
--- a/bsp/src/mill/bsp/BSP.scala
+++ b/bsp/src/mill/bsp/BSP.scala
@@ -48,11 +48,13 @@ object BSP extends ExternalModule {
       val bspFile = bspDirectory / s"${serverName}.json"
       if (os.exists(bspFile)) T.log.info(s"Overwriting BSP connection file: ${bspFile}")
       else T.log.info(s"Creating BSP connection file: ${bspFile}")
-      os.write.over(bspFile, createBspConnectionJson(jobs), createFolders = true)
+      val withDebug = T.log.debugEnabled
+      if(withDebug) T.log.debug("Enabled debug logging for the BSP server. If you want to disable it, you need to re-run this install command without the --debug option.")
+      os.write.over(bspFile, createBspConnectionJson(jobs, withDebug), createFolders = true)
     }
 
   // creates a Json with the BSP connection details
-  def createBspConnectionJson(jobs: Int): String = {
+  def createBspConnectionJson(jobs: Int, debug: Boolean): String = {
     // we assume, the classpath is an executable jar here, FIXME
     val millPath = sys.props
       .get("java.class.path")
@@ -69,8 +71,7 @@ object BSP extends ExternalModule {
           "false",
           "--jobs",
           s"${jobs}"
-//          s"${BSP.getClass.getCanonicalName.split("[$]").head}/start"
-        ),
+        ) ++ (if(debug) Seq("--debug") else Seq()),
         millVersion = BuildInfo.millVersion,
         bspVersion = bspProtocolVersion,
         languages = languages

--- a/bsp/src/mill/bsp/BSP.scala
+++ b/bsp/src/mill/bsp/BSP.scala
@@ -53,6 +53,9 @@ object BSP extends ExternalModule {
       os.write.over(bspFile, createBspConnectionJson(jobs, withDebug), createFolders = true)
     }
 
+  @deprecated("Use other overload instead.", "Mill after 0.10.7")
+  def createBspConnectionJson(jobs: Int): String = BSP.createBspConnectionJson(jobs: Int, debug = false)
+
   // creates a Json with the BSP connection details
   def createBspConnectionJson(jobs: Int, debug: Boolean): String = {
     // we assume, the classpath is an executable jar here, FIXME

--- a/bsp/src/mill/bsp/MillBspLogger.scala
+++ b/bsp/src/mill/bsp/MillBspLogger.scala
@@ -36,7 +36,7 @@ class MillBspLogger(client: BuildClient, taskId: Int, logger: Logger)
       client.onBuildTaskProgress(params)
       super.ticker(s)
     } catch {
-      case e: Exception =>
+      case e: Exception => // noop
     }
   }
 
@@ -52,7 +52,9 @@ class MillBspLogger(client: BuildClient, taskId: Int, logger: Logger)
 
   override def debug(s: String): Unit = {
     super.debug(s)
-    client.onBuildShowMessage(new ShowMessageParams(MessageType.LOG, s))
+    if (debugEnabled) {
+      client.onBuildShowMessage(new ShowMessageParams(MessageType.LOG, s))
+    }
   }
 
 }

--- a/bsp/test/src/BspInstallDebugTests.scala
+++ b/bsp/test/src/BspInstallDebugTests.scala
@@ -3,17 +3,20 @@ package mill.bsp
 import mill.util.ScriptTestSuite
 import utest._
 
-object BspInstallTests extends ScriptTestSuite(false) {
+object BspInstallDebugTests extends ScriptTestSuite(false) {
   override def workspaceSlug: String = "bsp-install"
   override def scriptSourcePath: os.Path = os.pwd / "bsp" / "test" / "resources" / workspaceSlug
 
+  // we purposely enable debugging in this simulated test env
+  override val debugLog: Boolean = true
+
   def tests: Tests = Tests {
-    test("BSP install") {
+    test("BSP install forwards --debug option to server") {
       val workspacePath = initWorkspace()
       eval("mill.bsp.BSP/install") ==> true
       val jsonFile = workspacePath / ".bsp" / s"${BSP.serverName}.json"
       os.exists(jsonFile) ==> true
-      os.read(jsonFile).contains("--debug") ==> false
+      os.read(jsonFile).contains("--debug") ==> true
     }
   }
 }

--- a/main/api/src/mill/api/Logger.scala
+++ b/main/api/src/mill/api/Logger.scala
@@ -1,6 +1,6 @@
 package mill.api
 
-import java.io._
+import java.io.{InputStream, PrintStream}
 
 /**
  * The standard logging interface of the Mill build tool.

--- a/main/core/src/mill/eval/Evaluator.scala
+++ b/main/core/src/mill/eval/Evaluator.scala
@@ -669,6 +669,7 @@ class Evaluator private[Evaluator] (
       case Some(path) => MultiLogger(
           logger.colored,
           logger,
+          // we always enable debug here, to get some more context in log files
           new FileLogger(logger.colored, path, debugEnabled = true),
           logger.inStream
         )


### PR DESCRIPTION
This means, we can use the effective value of `Log.debugEnabled` in BSP.

This also means, we only need to send debug messages to the BSP client, when debug is enabled.

* See also PR #2006