### PR TITLE
Fix issue with lazy val on Scala Native + Scala 3.2

### DIFF
--- a/scalanativelib/src/ScalaNativeModule.scala
+++ b/scalanativelib/src/ScalaNativeModule.scala
@@ -8,7 +8,7 @@ import mill.api.{internal, Result}
 import mill.define.{Target, Task}
 import mill.modules.Jvm
 import mill.scalalib.api.Util.{isScala3, scalaBinaryVersion}
-import mill.scalalib.{Dep, DepSyntax, Lib, SbtModule, ScalaModule, TestModule}
+import mill.scalalib.{CrossVersion, Dep, DepSyntax, Lib, SbtModule, ScalaModule, TestModule}
 import mill.testrunner.TestRunner
 import mill.scalanativelib.api._
 
@@ -84,7 +84,13 @@ trait ScalaNativeModule extends ScalaModule { outer =>
   }
 
   override def scalaLibraryIvyDeps = T {
-    if (isScala3(scalaVersion())) Agg.empty[Dep] else super.scalaLibraryIvyDeps()
+    super.scalaLibraryIvyDeps().map(dep =>
+      dep.copy(cross = dep.cross match {
+        case c: CrossVersion.Constant => c.copy(platformed = false)
+        case c: CrossVersion.Binary => c.copy(platformed = false)
+        case c: CrossVersion.Full => c.copy(platformed = false)
+      })
+    )
   }
 
   /** Adds [[nativeIvyDeps]] as mandatory dependencies. */

--- a/scalanativelib/test/resources/hello-native-world/src/Main.scala
+++ b/scalanativelib/test/resources/hello-native-world/src/Main.scala
@@ -1,6 +1,9 @@
 package hello
 
 object Main extends App {
+  // tests lazy val work in Scala 3.2+
+  lazy val foo = 1
+
   println("Hello " + vmName)
   def vmName = sys.props("java.vm.name")
 }

--- a/scalanativelib/test/src/HelloNativeWorldTests.scala
+++ b/scalanativelib/test/src/HelloNativeWorldTests.scala
@@ -29,8 +29,8 @@ object HelloNativeWorldTests extends TestSuite {
 
   object HelloNativeWorld extends TestUtil.BaseModule {
     val matrix = for {
-      scala <- Seq("3.1.0", scala213, "2.12.13", "2.11.12")
-      scalaNative <- Seq(scalaNative04, "0.4.3")
+      scala <- Seq("3.2.0", "3.1.3", scala213, "2.12.13", "2.11.12")
+      scalaNative <- Seq(scalaNative04, "0.4.7")
       mode <- List(ReleaseMode.Debug, ReleaseMode.ReleaseFast)
       if !(ZincWorkerUtil.isScala3(scala) && scalaNative == scalaNative04)
     } yield (scala, scalaNative, mode)


### PR DESCRIPTION
Scala Native depends on the scala3-library `3.1.3`.
To work on Scala 3.2 you need to explicitly depend on scala3-library
for `3.2.0`.
In Scala.js it is a single artifact generated in the dotty repository,
so it's platformed. In Scala Native, however, we need to depend on the
jvm artifact, which is used by the compiler, so we patch
`scalaLibraryIvyDeps` to be `platformed = false`