### PR TITLE
Fixed inconsistency in args parser

### DIFF
--- a/main/core/src/mill/define/ParseArgs.scala
+++ b/main/core/src/mill/define/ParseArgs.scala
@@ -49,7 +49,7 @@ object ParseArgs {
      */
     @tailrec
     def separated(result: Seq[Seq[String]], rest: Seq[String]): Seq[Seq[String]] = rest match {
-      case Seq() => result
+      case Seq() => if (result.nonEmpty) result else Seq(Seq())
       case r =>
         val (next, r2) = r.span(_ != TargetSeparator)
         separated(

--- a/main/test/src/util/ParseArgsTest.scala
+++ b/main/test/src/util/ParseArgsTest.scala
@@ -276,6 +276,7 @@ object ParseArgsTest extends TestSuite {
       def parsed(args: String*) = ParseArgs(args, selectMode)
       test("rejectEmpty") {
         assert(parsed("") == Left("Selector cannot be empty"))
+        assert(parsed() == Left("Selector cannot be empty"))
       }
       def check(
           input: Seq[String],


### PR DESCRIPTION
Since we support separated arguments, we first separate all arguemnts and
later valdate and extract each separated group individualy.
When we get no args at all, we create no separated groups, hence we dont
have anything to validate and we miss to create a parse error for it.

This fix instead creates an empty first separated group, so we properly
validate it and detect the case of missing args.
