### PR TITLE
Fixed wrong resolver error message for cross modules

### DIFF
--- a/main/src/mill/main/Resolve.scala
+++ b/main/src/mill/main/Resolve.scala
@@ -170,7 +170,7 @@ object ResolveTasks extends Resolve[NamedTask[Any]] {
           case None =>
             Left(
               "Cannot find default task to evaluate for module " +
-                Segments((Segment.Cross(last) +: obj.millModuleSegments.value).reverse: _*).render
+                Segments((obj.millModuleSegments.value :+ Segment.Cross(last)): _*).render
             )
           case Some(v) => v.map(Seq(_))
         }

--- a/main/test/src/main/MainTests.scala
+++ b/main/test/src/main/MainTests.scala
@@ -283,6 +283,10 @@ object MainTests extends TestSuite {
           "cross[211].cross2[jvm].suffix",
           Right(Seq(_.cross("211").cross2("jvm").suffix))
         )
+        "pos2NoDefaultTask" - check(
+          "cross[211].cross2[jvm]",
+          Left("Cannot find default task to evaluate for module cross[211].cross2[jvm]")
+        )
         "wildcard" - {
           "first" - check(
             "cross[_].cross2[jvm].suffix",


### PR DESCRIPTION
Added a test case for nested cross module resolve error.

* Reported via #2027
