### PR TITLE
Customize the native binary output file name

### DIFF
--- a/docs/antora/modules/ROOT/pages/Common_Project_Layouts.adoc
+++ b/docs/antora/modules/ROOT/pages/Common_Project_Layouts.adoc
@@ -155,7 +155,8 @@ object Hello{
 
 The normal commands `mill hello.compile`, `mill hello.run`, all work. If you
 want to build a standalone executable, you can use `mill show hello.nativeLink`
-to create it.
+to create it. By default the output filename will be `out` but it can be
+customized by setting `def nativeBinaryName = "binaryname"` in the module.
 
 `ScalaNativeModule` builds scala sources to executable binaries using
 http://www.scala-native.org[Scala Native]. You will need to have the

--- a/scalanativelib/src/ScalaNativeModule.scala
+++ b/scalanativelib/src/ScalaNativeModule.scala
@@ -215,7 +215,7 @@ trait ScalaNativeModule extends ScalaModule { outer =>
   }
 
   // Defines the native binary name
-  def nativeBinaryName: String = { "out" }
+  def nativeBinaryName: String = { this.toString }
 
   // Generates native binary
   def nativeLink = T {

--- a/scalanativelib/src/ScalaNativeModule.scala
+++ b/scalanativelib/src/ScalaNativeModule.scala
@@ -214,9 +214,12 @@ trait ScalaNativeModule extends ScalaModule { outer =>
     )
   }
 
+  // Defines the native binary name
+  def nativeBinaryName: String = { "out" }
+
   // Generates native binary
   def nativeLink = T {
-    os.Path(scalaNativeWorker().nativeLink(nativeConfig(), (T.dest / "out").toIO))
+    os.Path(scalaNativeWorker().nativeLink(nativeConfig(), (T.dest / nativeBinaryName).toIO))
   }
 
   // Runs the native binary


### PR DESCRIPTION
This allows customizing the output file name from `out` to anything.

Previously it would require:

```scala
  def nativeLink = T {
    os.Path(scalaNativeWorker().nativeLink(nativeConfig(), (T.dest / "binaryname").toIO))
  }
```

With this PR, it would be: `def nativeBinaryName   = "binaryname"`