### PR TITLE
Update Scala to 2.13.10

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -138,12 +138,12 @@ object Deps {
   val scalafmtDynamic = ivy"org.scalameta::scalafmt-dynamic:3.5.8"
   val scalametaTrees = ivy"org.scalameta::trees:4.6.0"
   def scalaReflect(scalaVersion: String) = ivy"org.scala-lang:scala-reflect:${scalaVersion}"
-  def scalacScoveragePlugin = ivy"org.scoverage:::scalac-scoverage-plugin:1.4.11"
-  val scoverage2Version = "2.0.5"
-  def scalacScoverage2Plugin = ivy"org.scoverage:::scalac-scoverage-plugin:${scoverage2Version}"
-  def scalacScoverage2Reporter = ivy"org.scoverage::scalac-scoverage-reporter:${scoverage2Version}"
-  def scalacScoverage2Domain = ivy"org.scoverage::scalac-scoverage-domain:${scoverage2Version}"
-  def scalacScoverage2Serializer =
+  val scalacScoveragePlugin = ivy"org.scoverage:::scalac-scoverage-plugin:1.4.11"
+  val scoverage2Version = "2.0.7"
+  val scalacScoverage2Plugin = ivy"org.scoverage:::scalac-scoverage-plugin:${scoverage2Version}"
+  val scalacScoverage2Reporter = ivy"org.scoverage::scalac-scoverage-reporter:${scoverage2Version}"
+  val scalacScoverage2Domain = ivy"org.scoverage::scalac-scoverage-domain:${scoverage2Version}"
+  val scalacScoverage2Serializer =
     ivy"org.scoverage::scalac-scoverage-serializer:${scoverage2Version}"
   val semanticDB = ivy"org.scalameta:::semanticdb-scalac:4.6.0"
   val sourcecode = ivy"com.lihaoyi::sourcecode:0.3.0"

--- a/build.sc
+++ b/build.sc
@@ -61,7 +61,9 @@ object Settings {
 object Deps {
 
   // The Scala version to use
-  val scalaVersion = "2.13.8"
+  val scalaVersion = "2.13.9"
+  // Scoverage 1.x will not get releases for newer Scala versions
+  val scalaVersionForScoverageWorker1 = "2.13.8"
   // The Scala 2.12.x version to use for some workers
   val workerScalaVersion212 = "2.12.15"
 
@@ -770,6 +772,7 @@ object contrib extends MillModule {
       contrib.buildinfo
     )
 
+    // Worker for Scoverage 1.x
     object worker extends MillInternalModule {
       override def compileModuleDeps = Seq(main.api)
       override def moduleDeps = Seq(scoverage.api)
@@ -781,13 +784,13 @@ object contrib extends MillModule {
           Deps.osLib
         )
       }
+      override def scalaVersion: Target[String] = Deps.scalaVersionForScoverageWorker1
     }
 
+    // Worker for Scoverage 2.0
     object worker2 extends MillInternalModule {
       override def compileModuleDeps = Seq(main.api)
-
       override def moduleDeps = Seq(scoverage.api)
-
       override def compileIvyDeps = T {
         Agg(
           // compile-time only, need to provide the correct scoverage version at runtime

--- a/build.sc
+++ b/build.sc
@@ -61,7 +61,7 @@ object Settings {
 object Deps {
 
   // The Scala version to use
-  val scalaVersion = "2.13.9"
+  val scalaVersion = "2.13.10"
   // Scoverage 1.x will not get releases for newer Scala versions
   val scalaVersionForScoverageWorker1 = "2.13.8"
   // The Scala 2.12.x version to use for some workers
@@ -99,7 +99,7 @@ object Deps {
   }
 
   val acyclic = ivy"com.lihaoyi::acyclic:0.2.1"
-  val ammoniteVersion = "2.5.4-33-0af04a5b"
+  val ammoniteVersion = "2.5.5"
   val ammonite = ivy"com.lihaoyi:::ammonite:${ammoniteVersion}"
   val ammoniteTerminal = ivy"com.lihaoyi::ammonite-terminal:${ammoniteVersion}"
   // Exclude trees here to force the version of we have defined. We use this

--- a/build.sc
+++ b/build.sc
@@ -759,7 +759,8 @@ object contrib extends MillModule {
         "MILL_SCOVERAGE_REPORT_WORKER" -> worker.compile().classes.path,
         "MILL_SCOVERAGE2_REPORT_WORKER" -> worker2.compile().classes.path,
         "MILL_SCOVERAGE_VERSION" -> Deps.scalacScoveragePlugin.dep.version,
-        "MILL_SCOVERAGE2_VERSION" -> Deps.scalacScoverage2Plugin.dep.version
+        "MILL_SCOVERAGE2_VERSION" -> Deps.scalacScoverage2Plugin.dep.version,
+        "TEST_SCALA_2_12_VERSION" -> Deps.workerScalaVersion212
       )
       scalalib.worker.testArgs() ++
         scalalib.backgroundwrapper.testArgs() ++

--- a/contrib/scoverage/test/src/HelloWorldTests.scala
+++ b/contrib/scoverage/test/src/HelloWorldTests.scala
@@ -304,7 +304,7 @@ trait FailedWorldTests extends HelloWorldTests {
 }
 
 object Scoverage1Tests_2_12 extends HelloWorldTests {
-  override def testScalaVersion: String = sys.props.getOrElse("MILL_SCALA_2_12_VERSION", ???)
+  override def testScalaVersion: String = sys.props.getOrElse("TEST_SCALA_2_12_VERSION", ???)
   override def testScoverageVersion = sys.props.getOrElse("MILL_SCOVERAGE_VERSION", ???)
 }
 


### PR DESCRIPTION
This one was a bit tricky, as just bumping the Scala version broke the contrib.scoverage tests.

So I needed to implement a workaround for resolving the scoverage 1.x reporter API.

The issue is, that Scoverage 1.x is no longer maintained, but still the only option for projects on older Scala versions. So, we try to keep the support for it. Scala 2.13.9 and 2.13.10 are not directly supported (as there are no full-version releases targeting the compiler). But the reporting API, which is not compiler specific, is not shipped independently but inside the plugin jar. So we work around that by resolving the plugin jar against Scala version 2.13.8 (the latest supported version).

This also bumps Ammonite to 2.5.5 and Scoverage to 2.0.7.