### PR TITLE
Show gpg output in server/client in publish (fix #387)

### DIFF
--- a/scalalib/src/PublishModule.scala
+++ b/scalalib/src/PublishModule.scala
@@ -177,6 +177,8 @@ trait PublishModule extends JavaModule { outer =>
       readTimeout,
       connectTimeout,
       T.log,
+      T.workspace,
+      T.env,
       awaitTimeout,
       stagingRelease
     ).publish(artifacts.map { case (a, b) => (a.path, b) }, artifactInfo, release)
@@ -236,6 +238,8 @@ object PublishModule extends ExternalModule {
       readTimeout,
       connectTimeout,
       T.log,
+      T.workspace,
+      T.env,
       awaitTimeout,
       stagingRelease
     ).publishAll(

--- a/scalalib/src/publish/SonatypePublisher.scala
+++ b/scalalib/src/publish/SonatypePublisher.scala
@@ -16,9 +16,37 @@ class SonatypePublisher(
     readTimeout: Int,
     connectTimeout: Int,
     log: Logger,
+    workspace: os.Path,
+    env: Map[String, String],
     awaitTimeout: Int,
-    stagingRelease: Boolean = true
+    stagingRelease: Boolean
 ) {
+  @deprecated("Use other constructor instead", since = "mill 0.10.8")
+  def this(
+      uri: String,
+      snapshotUri: String,
+      credentials: String,
+      signed: Boolean,
+      gpgArgs: Seq[String],
+      readTimeout: Int,
+      connectTimeout: Int,
+      log: Logger,
+      awaitTimeout: Int,
+      stagingRelease: Boolean = true
+  ) = this(
+    uri = uri,
+    snapshotUri = snapshotUri,
+    credentials = credentials,
+    signed = signed,
+    gpgArgs = gpgArgs,
+    readTimeout = readTimeout,
+    connectTimeout = connectTimeout,
+    log = log,
+    workspace = os.pwd,
+    env = sys.env,
+    awaitTimeout = awaitTimeout,
+    stagingRelease = stagingRelease
+  )
 
   private val api = new SonatypeHttpApi(
     uri,
@@ -175,7 +203,7 @@ class SonatypePublisher(
     val fileName = file.toString
     val command = "gpg" +: args :+ fileName
 
-    Jvm.runSubprocess(command, sys.env, workingDir = null)
+    Jvm.runSubprocess(command, env, workspace)
     os.Path(fileName + ".asc")
   }
 

--- a/scalalib/src/publish/SonatypePublisher.scala
+++ b/scalalib/src/publish/SonatypePublisher.scala
@@ -175,7 +175,7 @@ class SonatypePublisher(
     val fileName = file.toString
     val command = "gpg" +: args :+ fileName
 
-    Jvm.runSubprocess(command, Map.empty[String, String], workingDir = null)
+    Jvm.runSubprocess(command, sys.env, workingDir = null)
     os.Path(fileName + ".asc")
   }
 

--- a/scalalib/src/publish/SonatypePublisher.scala
+++ b/scalalib/src/publish/SonatypePublisher.scala
@@ -4,6 +4,7 @@ import java.math.BigInteger
 import java.security.MessageDigest
 
 import mill.api.Logger
+import mill.modules.Jvm
 import os.Shellable
 
 class SonatypePublisher(
@@ -174,8 +175,7 @@ class SonatypePublisher(
     val fileName = file.toString
     val command = "gpg" +: args :+ fileName
 
-    os.proc(command.map(v => v: Shellable))
-      .call(stdin = os.Inherit, stdout = os.Inherit, stderr = os.Inherit)
+    Jvm.runSubprocess(command, Map.empty[String, String], workingDir = null)
     os.Path(fileName + ".asc")
   }
 


### PR DESCRIPTION
Avoid using `os.Inherit` which is known to break the output in server/client mode.

Fixes #387
Checked manually and the errors now appear with and without `-i`.