### PR TITLE
Update coursier to 2.1.0-M7-39-gb8f3d7532

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -110,7 +110,7 @@ object Deps {
   )
   val asciidoctorj = ivy"org.asciidoctor:asciidoctorj:2.4.3"
   val bloopConfig = ivy"ch.epfl.scala::bloop-config:1.5.3"
-  val coursier = ivy"io.get-coursier::coursier:2.1.0-M6"
+  val coursier = ivy"io.get-coursier::coursier:2.1.0-M7"
 
   val flywayCore = ivy"org.flywaydb:flyway-core:8.5.13"
   val graphvizJava = ivy"guru.nidi:graphviz-java-all-j2v8:0.18.1"

--- a/build.sc
+++ b/build.sc
@@ -110,7 +110,7 @@ object Deps {
   )
   val asciidoctorj = ivy"org.asciidoctor:asciidoctorj:2.4.3"
   val bloopConfig = ivy"ch.epfl.scala::bloop-config:1.5.3"
-  val coursier = ivy"io.get-coursier::coursier:2.1.0-M7"
+  val coursier = ivy"io.get-coursier::coursier:2.1.0-M7-39-gb8f3d7532"
 
   val flywayCore = ivy"org.flywaydb:flyway-core:8.5.13"
   val graphvizJava = ivy"guru.nidi:graphviz-java-all-j2v8:0.18.1"

--- a/scalalib/src/JsonFormatters.scala
+++ b/scalalib/src/JsonFormatters.scala
@@ -9,7 +9,14 @@ trait JsonFormatters {
   implicit lazy val extensionFormat: RW[coursier.core.Extension] = upickle.default.macroRW
 
   implicit lazy val modFormat: RW[coursier.Module] = upickle.default.macroRW
-  implicit lazy val depFormat: RW[coursier.Dependency] = upickle.default.macroRW
+  implicit lazy val depFormat: RW[coursier.core.Dependency] = upickle.default.macroRW
+  implicit lazy val minimizedExclusionsFormat: RW[coursier.core.MinimizedExclusions] = upickle.default.macroRW
+  implicit lazy val exclusionDataFormat: RW[coursier.core.MinimizedExclusions.ExclusionData] =
+    RW.merge(
+      upickle.default.macroRW[coursier.core.MinimizedExclusions.ExcludeNone.type],
+      upickle.default.macroRW[coursier.core.MinimizedExclusions.ExcludeAll.type],
+      upickle.default.macroRW[coursier.core.MinimizedExclusions.ExcludeSpecific]
+    )
   implicit lazy val attrFormat: RW[coursier.Attributes] = upickle.default.macroRW
   implicit lazy val orgFormat: RW[coursier.Organization] = upickle.default.macroRW
   implicit lazy val modNameFormat: RW[coursier.ModuleName] = upickle.default.macroRW


### PR DESCRIPTION
Added additional JSON converters for new classes exposed by `core.Dependency`. 