### PR TITLE
Add actual Mill cli as sysprop and use it in BSP config

### DIFF
--- a/bsp/src/mill/bsp/BSP.scala
+++ b/bsp/src/mill/bsp/BSP.scala
@@ -42,18 +42,17 @@ object BSP extends ExternalModule {
    * reason, the message and stacktrace of the exception will be
    * printed to stdout.
    */
-  def install(evaluator: Evaluator, jobs: Int = 1): Command[Unit] =
-    T.command {
-      val bspDirectory = evaluator.rootModule.millSourcePath / ".bsp"
-      val bspFile = bspDirectory / s"${serverName}.json"
-      if (os.exists(bspFile)) T.log.info(s"Overwriting BSP connection file: ${bspFile}")
-      else T.log.info(s"Creating BSP connection file: ${bspFile}")
-      val withDebug = T.log.debugEnabled
-      if (withDebug) T.log.debug(
-        "Enabled debug logging for the BSP server. If you want to disable it, you need to re-run this install command without the --debug option."
-      )
-      os.write.over(bspFile, createBspConnectionJson(jobs, withDebug), createFolders = true)
-    }
+  def install(evaluator: Evaluator, jobs: Int = 1): Command[Unit] = T.command {
+    val bspDirectory = evaluator.rootModule.millSourcePath / ".bsp"
+    val bspFile = bspDirectory / s"${serverName}.json"
+    if (os.exists(bspFile)) T.log.info(s"Overwriting BSP connection file: ${bspFile}")
+    else T.log.info(s"Creating BSP connection file: ${bspFile}")
+    val withDebug = T.log.debugEnabled
+    if (withDebug) T.log.debug(
+      "Enabled debug logging for the BSP server. If you want to disable it, you need to re-run this install command without the --debug option."
+    )
+    os.write.over(bspFile, createBspConnectionJson(jobs, withDebug), createFolders = true)
+  }
 
   @deprecated("Use other overload instead.", "Mill after 0.10.7")
   def createBspConnectionJson(jobs: Int): String =
@@ -61,10 +60,10 @@ object BSP extends ExternalModule {
 
   // creates a Json with the BSP connection details
   def createBspConnectionJson(jobs: Int, debug: Boolean): String = {
-    // we assume, the classpath is an executable jar here, FIXME
     val props = sys.props
     val millPath = props
       .get("mill.main.cli")
+      // we assume, the classpath is an executable jar here
       .orElse(props.get("java.class.path"))
       .getOrElse(throw new IllegalStateException("System property 'java.class.path' not set"))
 

--- a/bsp/src/mill/bsp/BSP.scala
+++ b/bsp/src/mill/bsp/BSP.scala
@@ -62,8 +62,10 @@ object BSP extends ExternalModule {
   // creates a Json with the BSP connection details
   def createBspConnectionJson(jobs: Int, debug: Boolean): String = {
     // we assume, the classpath is an executable jar here, FIXME
-    val millPath = sys.props
-      .get("java.class.path")
+    val props = sys.props
+    val millPath = props
+      .get("mill.main.cli")
+      .orElse(props.get("java.class.path"))
       .getOrElse(throw new IllegalStateException("System property 'java.class.path' not set"))
 
     write(

--- a/mill
+++ b/mill
@@ -48,4 +48,4 @@ fi
 unset MILL_DOWNLOAD_PATH
 unset MILL_VERSION
 
-exec $MILL_EXEC_PATH "$@"
+exec $MILL_EXEC_PATH -D "mill.main.cli=${0}" "$@"

--- a/mill
+++ b/mill
@@ -45,7 +45,11 @@ if [ ! -s "$MILL_EXEC_PATH" ] ; then
   unset MILL_DOWNLOAD_URL
 fi
 
+if [ -z "$MILL_MAIN_CLI" ] ; then
+  MILL_MAIN_CLI="${0}"
+fi
+
 unset MILL_DOWNLOAD_PATH
 unset MILL_VERSION
 
-exec $MILL_EXEC_PATH -D "mill.main.cli=${0}" "$@"
+exec $MILL_EXEC_PATH -D "mill.main.cli=${MILL_MAIN_CLI}" "$@"


### PR DESCRIPTION
Uses the Java system property `mill.main.cli` internally.
Also accepts a `MILL_MAIN_CLI` environment variable to override the cli name (if needed).

When BSP connection files (JSON) are generated, the value of the sysprop is used as application, resulting in a BSP server setup, that will respect config changes e.g. to `.mill-version`.

Read more about the motivation in discussion:

* https://github.com/com-lihaoyi/mill/discussions/2079

