### PR TITLE
Use unique `out` path for private named tasks - fixes #2107

### DIFF
--- a/ci/mill-bootstrap.patch
+++ b/ci/mill-bootstrap.patch
@@ -1,0 +1,119 @@
+diff --git a/build.sc b/build.sc
+index be462bb7c..50eb14412 100644
+--- a/build.sc
++++ b/build.sc
+@@ -2,22 +2,10 @@
+ import $file.ci.shared
+ import $file.ci.upload
+ import $ivy.`org.scalaj::scalaj-http:2.4.2`
+-import $ivy.`de.tototec::de.tobiasroeser.mill.vcs.version_mill0.10:0.3.0`
+-import $ivy.`com.github.lolgab::mill-mima_mill0.10:0.0.13`
+ import $ivy.`net.sourceforge.htmlcleaner:htmlcleaner:2.25`
+ 
+ // imports
+-import com.github.lolgab.mill.mima
+-import com.github.lolgab.mill.mima.{
+-  CheckDirection,
+-  DirectMissingMethodProblem,
+-  IncompatibleMethTypeProblem,
+-  IncompatibleSignatureProblem,
+-  ProblemFilter,
+-  ReversedMissingMethodProblem
+-}
+ import coursier.maven.MavenRepository
+-import de.tobiasroeser.mill.vcs.version.VcsVersion
+ import mill._
+ import mill.define.{Command, Source, Sources, Target, Task}
+ import mill.eval.Evaluator
+@@ -180,12 +168,8 @@ object Deps {
+   val requests = ivy"com.lihaoyi::requests:0.8.0"
+ }
+ 
+-def millVersion: T[String] = T { VcsVersion.vcsState().format() }
+-def millLastTag: T[String] = T {
+-  VcsVersion.vcsState().lastTag.getOrElse(
+-    sys.error("No (last) git tag found. Your git history seems incomplete!")
+-  )
+-}
++def millVersion: T[String] = T { "0.0.0.test" }
++def millLastTag: T[String] = T { "0.0.0.test" }
+ def millBinPlatform: T[String] = T {
+   val tag = millLastTag()
+   if (tag.contains("-M")) tag
+@@ -244,20 +228,7 @@ trait MillCoursierModule extends CoursierModule {
+   )
+ }
+ 
+-trait MillMimaConfig extends mima.Mima {
+-  override def mimaPreviousVersions: T[Seq[String]] = Settings.mimaBaseVersions
+-  override def mimaPreviousArtifacts =
+-    if (Settings.mimaBaseVersions.isEmpty) T { Agg[Dep]() }
+-    else super.mimaPreviousArtifacts
+-  override def mimaExcludeAnnotations: T[Seq[String]] = Seq(
+-    "mill.api.internal",
+-    "mill.api.experimental"
+-  )
+-  override def mimaCheckDirection: Target[CheckDirection] = T { CheckDirection.Backward }
+-  override def mimaBinaryIssueFilters: Target[Seq[ProblemFilter]] = T {
+-    issueFilterByModule.getOrElse(this, Seq())
+-  }
+-  lazy val issueFilterByModule: Map[MillMimaConfig, Seq[ProblemFilter]] = Map()
++trait MillMimaConfig extends Module {
+ }
+ 
+ /** A Module compiled with applied Mill-specific compiler plugins: mill-moduledefs. */
+@@ -1549,53 +1520,7 @@ def launcher = T {
+ }
+ 
+ def uploadToGithub(authKey: String) = T.command {
+-  val vcsState = VcsVersion.vcsState()
+-  val label = vcsState.format()
+-  if (label != millVersion()) sys.error("Modified mill version detected, aborting upload")
+-  val releaseTag = vcsState.lastTag.getOrElse(sys.error(
+-    "Incomplete git history. No tag found.\nIf on CI, make sure your git checkout job includes enough history."
+-  ))
+-
+-  if (releaseTag == label) {
+-    // TODO: check if the tag already exists (e.g. because we created it manually) and do not fail
+-    scalaj.http.Http(
+-      s"https://api.github.com/repos/${Settings.githubOrg}/${Settings.githubRepo}/releases"
+-    )
+-      .postData(
+-        ujson.write(
+-          ujson.Obj(
+-            "tag_name" -> releaseTag,
+-            "name" -> releaseTag
+-          )
+-        )
+-      )
+-      .header("Authorization", "token " + authKey)
+-      .asString
+-  }
+-
+-  val exampleZips = Seq("example-1", "example-2", "example-3")
+-    .map { example =>
+-      os.copy(T.workspace / "example" / example, T.dest / example)
+-      os.copy(launcher().path, T.dest / example / "mill")
+-      os.proc("zip", "-r", T.dest / s"$example.zip", example).call(cwd = T.dest)
+-      (T.dest / s"$example.zip", label + "-" + example + ".zip")
+-    }
+-
+-  val zips = exampleZips ++ Seq(
+-    (assembly().path, label + "-assembly"),
+-    (launcher().path, label)
+-  )
+-
+-  for ((zip, name) <- zips) {
+-    upload.apply(
+-      zip,
+-      releaseTag,
+-      name,
+-      authKey,
+-      Settings.githubOrg,
+-      Settings.githubRepo
+-    )
+-  }
++  // never upload a bootstrapped version
+ }
+ 
+ def validate(ev: Evaluator): Command[Unit] = T.command {

--- a/main/core/src/mill/eval/Evaluator.scala
+++ b/main/core/src/mill/eval/Evaluator.scala
@@ -812,6 +812,9 @@ object Evaluator {
     val seen = collection.mutable.Set.empty[Segments]
     val overridden = collection.mutable.Set.empty[Task[_]]
     topoSorted.values.reverse.iterator.foreach {
+      case x: NamedTask[_] if x.isPrivate == Some(true) =>
+        // we always need to store them in the super-path
+        overridden.add(x)
       case x: NamedTask[_] =>
         if (!seen.contains(x.ctx.segments)) seen.add(x.ctx.segments)
         else overridden.add(x)

--- a/main/test/src/eval/EvaluationTests.scala
+++ b/main/test/src/eval/EvaluationTests.scala
@@ -361,7 +361,7 @@ class EvaluationTests(threadCount: Option[Int]) extends TestSuite {
       // the main publicly-available command
       import StackableOverrides._
 
-      val checker = new Checker(canOverrideSuper)
+      val checker = new Checker(StackableOverrides)
       checker(
         m.f,
         6,
@@ -381,6 +381,26 @@ class EvaluationTests(threadCount: Option[Int]) extends TestSuite {
           .contains(" 3,")
       )
       assert(os.read(checker.evaluator.outPath / "m" / "f.json").contains(" 6,"))
+    }
+    "privateTasksInMixedTraits" - {
+      // Make sure we can have private cached targets in different trait with the same name,
+      // and caching still works when these traits are mixed together
+      import PrivateTasksInMixedTraits._
+      val checker = new Checker(PrivateTasksInMixedTraits)
+      checker(
+        mod.bar,
+        "foo-m1",
+        Agg(mod.bar),
+        extraEvaled = -1
+      )
+      // If we evaluate to "foo-m1" instead of "foo-m2",
+      // we don't properly distinguish between the two private `foo` targets
+      checker(
+        mod.baz,
+        "foo-m2",
+        Agg(mod.baz),
+        extraEvaled = -1
+      )
     }
   }
 }

--- a/main/test/src/util/TestGraphs.scala
+++ b/main/test/src/util/TestGraphs.scala
@@ -297,4 +297,16 @@ object TestGraphs {
     }
     object m extends A with B {}
   }
+
+  object PrivateTasksInMixedTraits extends TestUtil.BaseModule {
+    trait M1 extends Module {
+      private def foo = T { "foo-m1" }
+      def bar = T { foo() }
+    }
+    trait M2 extends Module {
+      private def foo = T { "foo-m2" }
+      def baz = T { foo() }
+    }
+    object mod extends M1 with M2
+  }
 }


### PR DESCRIPTION
This change ensures, we always use the `super`-`out` path when we try to store metadata and scratch files for private named tasks. As private tasks can't be seen from other traits/classes in the same module hierarchy, our previous logic to detect potential collisions of the metadata location fails. Hence we now keep the `isPrivate` property in the named target.

I also added a test case that reproduce the initial issue but now succeeds.

* Fixes: https://github.com/com-lihaoyi/mill/issues/2107

This is a binary compatibility breaking change.

By applying the same approach and tracking also `public`-ness of a target, there is potential to fix also other issues like

* https://github.com/com-lihaoyi/mill/issues/803

This PR should be merged after 

* #2262