### PR TITLE
Harden GAV handling in `Dep` and `Artifact`

### DIFF
--- a/scalalib/src/Dep.scala
+++ b/scalalib/src/Dep.scala
@@ -1,11 +1,23 @@
 package mill.scalalib
+
 import JsonFormatters._
 import upickle.default.{macroRW, ReadWriter => RW}
 import CrossVersion._
-import mill.scalalib.api.Util.Scala3EarlyVersion
 
 case class Dep(dep: coursier.Dependency, cross: CrossVersion, force: Boolean) {
-  import mill.scalalib.api.Util.{isDottyOrScala3, DottyVersion, Scala3Version}
+  require(
+    !dep.module.name.value.contains("/") &&
+      !dep.module.organization.value.contains("/") &&
+      !dep.version.contains("/"),
+    "Dependency coordinate must not contain `/`s"
+  )
+
+  import mill.scalalib.api.ZincWorkerUtil.{
+    isDottyOrScala3,
+    DottyVersion,
+    Scala3Version,
+    Scala3EarlyVersion
+  }
 
   def artifactName(binaryVersion: String, fullVersion: String, platformSuffix: String) = {
     val suffix = cross.suffixString(binaryVersion, fullVersion, platformSuffix)
@@ -134,7 +146,7 @@ sealed trait CrossVersion {
   /** The string that should be appended to the module name to get the artifact name */
   def suffixString(binaryVersion: String, fullVersion: String, platformSuffix: String): String = {
     val firstSuffix = if (platformed) platformSuffix else ""
-    this match {
+    val suffix = this match {
       case cross: Constant =>
         s"${firstSuffix}${cross.value}"
       case cross: Binary =>
@@ -142,6 +154,8 @@ sealed trait CrossVersion {
       case cross: Full =>
         s"${firstSuffix}_${fullVersion}"
     }
+    require(!suffix.contains("/"), "Artifact suffix must not contain `/`s")
+    suffix
   }
 }
 object CrossVersion {

--- a/scalalib/src/Dep.scala
+++ b/scalalib/src/Dep.scala
@@ -9,7 +9,7 @@ case class Dep(dep: coursier.Dependency, cross: CrossVersion, force: Boolean) {
     !dep.module.name.value.contains("/") &&
       !dep.module.organization.value.contains("/") &&
       !dep.version.contains("/"),
-    "Dependency coordinate must not contain `/`s"
+    "Dependency coordinates must not contain `/`s"
   )
 
   import mill.scalalib.api.ZincWorkerUtil.{

--- a/scalalib/src/publish/settings.scala
+++ b/scalalib/src/publish/settings.scala
@@ -7,7 +7,7 @@ case class Artifact(group: String, id: String, version: String) {
     !group.contains("/") &&
       !id.contains("/") &&
       !version.contains("/"),
-    "Dependency coordinate must not contain `/`s"
+    "Artifact coordinates must not contain `/`s"
   )
   def isSnapshot: Boolean = version.endsWith("-SNAPSHOT")
 }

--- a/scalalib/src/publish/settings.scala
+++ b/scalalib/src/publish/settings.scala
@@ -3,6 +3,12 @@ package mill.scalalib.publish
 import mill.scalalib.Dep
 
 case class Artifact(group: String, id: String, version: String) {
+  require(
+    !group.contains("/") &&
+      !id.contains("/") &&
+      !version.contains("/"),
+    "Dependency coordinate must not contain `/`s"
+  )
   def isSnapshot: Boolean = version.endsWith("-SNAPSHOT")
 }
 


### PR DESCRIPTION
Hardening in context of [CVE-2022-37866](https://github.com/advisories/GHSA-wv7w-rj2x-556x)

* Ensure mill.scalalib.Dep does not accept `/`s in the coordinates
* Ensure mill.scalalib.publish.Artifact does not accept `/` in coords
