### PR TITLE
Update coursier to 2.1.0-RC1

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -128,7 +128,7 @@ object Deps {
   )
   val asciidoctorj = ivy"org.asciidoctor:asciidoctorj:2.4.3"
   val bloopConfig = ivy"ch.epfl.scala::bloop-config:1.5.3"
-  val coursier = ivy"io.get-coursier::coursier:2.1.0-M7-39-gb8f3d7532"
+  val coursier = ivy"io.get-coursier::coursier:2.1.0-RC1"
 
   val flywayCore = ivy"org.flywaydb:flyway-core:8.5.13"
   val graphvizJava = ivy"guru.nidi:graphviz-java-all-j2v8:0.18.1"


### PR DESCRIPTION
This release includes a security fix for [CVE-2022-37866](https://github.com/advisories/GHSA-wv7w-rj2x-556x) to prevent path-traversal with bogus module coordinates