### PR TITLE
Removed .scala-steward.conf

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,7 +1,0 @@
-# If "on-conflicts", Scala Steward will update the PR it created to resolve conflicts as
-# long as you don't change it yourself.
-# If "always", Scala Steward will always update the PR it created as long as
-# you don't change it yourself.
-# If "never", Scala Steward will never update the PR
-# Default: "on-conflicts"
-updatePullRequests = "always"


### PR DESCRIPTION
GitHub UI now allows to manually update PRs on demand.
