### PR TITLE
scalapblib- support specifying individual source files

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -299,6 +299,12 @@ trait MillMimaConfig extends mima.Mima {
         "mill.contrib.scoverage.ScoverageReport#workerModule.bspCompileClasspath"
       )
     ),
+    contrib.scalapblib -> Seq(
+      // we changed signature of worker API
+      ProblemFilter.exclude[ReversedMissingMethodProblem](
+        "mill.contrib.scalapblib.ScalaPBWorkerApi.compileScalaPB"
+      )
+    ),
     // we added a new target and a submodule after 0.10.5
     contrib.twirllib -> Seq(
       ProblemFilter.exclude[ReversedMissingMethodProblem](

--- a/contrib/scalapblib/src/ScalaPBWorker.scala
+++ b/contrib/scalapblib/src/ScalaPBWorker.scala
@@ -33,14 +33,13 @@ class ScalaPBWorker extends AutoCloseable {
           ): Unit = {
             val opts = if (scalaPBOptions.isEmpty) "" else scalaPBOptions + ":"
             val args = otherArgs ++ Seq(
-              s"--scala_out=${opts}${generatedDirectory.getCanonicalPath}",
-            ) ++ roots.map(root => s"--proto_path=${root.getCanonicalPath}") ++ sources.map(_.getCanonicalPath)
+              s"--scala_out=${opts}${generatedDirectory.getCanonicalPath}"
+            ) ++ roots.map(root => s"--proto_path=${root.getCanonicalPath}") ++ sources.map(
+              _.getCanonicalPath
+            )
             ctx.log.debug(s"ScalaPBC args: ${args.mkString(" ")}")
             mainMethod.invoke(null, args.toArray)
           }
-
-          override def compileScalaPB(root: File, source: Seq[File], scalaPBOptions: String, generatedDirectory: File, otherArgs: Seq[String]): Unit =
-            compileScalaPB(Seq(root), source, scalaPBOptions, generatedDirectory, otherArgs)
         }
         scalaPBInstanceCache = Some((classloaderSig, instance))
         instance
@@ -109,19 +108,23 @@ class ScalaPBWorker extends AutoCloseable {
 
 trait ScalaPBWorkerApi {
 
-  @deprecated("Use other overload instead")
-  def compileScalaPB(root: File,
-                     source: Seq[File],
-                     scalaPBOptions: String,
-                     generatedDirectory: File,
-                     otherArgs: Seq[String]): Unit
+  @deprecated("Use other overload instead", "Mill after 0.10.9")
+  def compileScalaPB(
+      root: File,
+      source: Seq[File],
+      scalaPBOptions: String,
+      generatedDirectory: File,
+      otherArgs: Seq[String]
+  ): Unit =
+    compileScalaPB(Seq(root), source, scalaPBOptions, generatedDirectory, otherArgs)
 
-
-  def compileScalaPB(roots: Seq[File],
-                     source: Seq[File],
-                     scalaPBOptions: String,
-                     generatedDirectory: File,
-                     otherArgs: Seq[String]): Unit
+  def compileScalaPB(
+      roots: Seq[File],
+      source: Seq[File],
+      scalaPBOptions: String,
+      generatedDirectory: File,
+      otherArgs: Seq[String]
+  ): Unit
 }
 
 object ScalaPBWorkerApi extends ExternalModule {

--- a/contrib/scalapblib/src/ScalaPBWorker.scala
+++ b/contrib/scalapblib/src/ScalaPBWorker.scala
@@ -38,6 +38,9 @@ class ScalaPBWorker extends AutoCloseable {
             ctx.log.debug(s"ScalaPBC args: ${args.mkString(" ")}")
             mainMethod.invoke(null, args.toArray)
           }
+
+          override def compileScalaPB(root: File, source: Seq[File], scalaPBOptions: String, generatedDirectory: File, otherArgs: Seq[String]): Unit =
+            compileScalaPB(Seq(root), source, scalaPBOptions, generatedDirectory, otherArgs)
         }
         scalaPBInstanceCache = Some((classloaderSig, instance))
         instance
@@ -105,13 +108,20 @@ class ScalaPBWorker extends AutoCloseable {
 }
 
 trait ScalaPBWorkerApi {
-  def compileScalaPB(
-      roots: Seq[File],
-      source: Seq[File],
-      scalaPBOptions: String,
-      generatedDirectory: File,
-      otherArgs: Seq[String]
-  ): Unit
+
+  @deprecated("Use other overload instead")
+  def compileScalaPB(root: File,
+                     source: Seq[File],
+                     scalaPBOptions: String,
+                     generatedDirectory: File,
+                     otherArgs: Seq[String]): Unit
+
+
+  def compileScalaPB(roots: Seq[File],
+                     source: Seq[File],
+                     scalaPBOptions: String,
+                     generatedDirectory: File,
+                     otherArgs: Seq[String]): Unit
 }
 
 object ScalaPBWorkerApi extends ExternalModule {

--- a/contrib/scalapblib/test/src/TutorialTests.scala
+++ b/contrib/scalapblib/test/src/TutorialTests.scala
@@ -8,6 +8,7 @@ import utest.framework.TestPath
 import utest.{TestSuite, Tests, assert, _}
 
 object TutorialTests extends TestSuite {
+  val testScalaPbVersion = "0.11.7"
 
   trait TutorialBase extends TestUtil.BaseModule {
     override def millSourcePath: os.Path =
@@ -16,7 +17,7 @@ object TutorialTests extends TestSuite {
 
   trait TutorialModule extends ScalaPBModule {
     def scalaVersion = sys.props.getOrElse("TEST_SCALA_2_12_VERSION", ???)
-    def scalaPBVersion = "0.11.7"
+    def scalaPBVersion = testScalaPbVersion
     def scalaPBFlatPackage = true
     def scalaPBIncludePath = Seq(scalaPBUnpackProto())
   }
@@ -24,7 +25,7 @@ object TutorialTests extends TestSuite {
   object Tutorial extends TutorialBase {
 
     object core extends TutorialModule {
-      override def scalaPBVersion = "0.11.7"
+      override def scalaPBVersion = testScalaPbVersion
     }
   }
 
@@ -89,7 +90,7 @@ object TutorialTests extends TestSuite {
         val Right((result, evalCount)) = eval.apply(Tutorial.core.scalaPBVersion)
 
         assert(
-          result == "0.11.7",
+          result == testScalaPbVersion,
           evalCount > 0
         )
       }
@@ -120,7 +121,7 @@ object TutorialTests extends TestSuite {
       }
 
       "calledWithSpecificFile" - workspaceTest(TutorialWithSpecificSources) { eval =>
-        val Right((result, evalCount)) =  eval.apply(TutorialWithSpecificSources.core.compileScalaPB)
+        val Right((result, evalCount)) = eval.apply(TutorialWithSpecificSources.core.compileScalaPB)
 
         val outPath = protobufOutPath(eval)
 


### PR DESCRIPTION
Currently the ScalalPB plugins only allows specifying whole directories as source. This change allows specifying individual files as inputs.
In addition, ScalaPBC is now invoked once for all input paths instead of separate invocation for each input path. This is important because it allows setting package scoped options to take affect across all input paths.