### PR TITLE
Always give included files a unique foreign module path

### DIFF
--- a/bsp/test/src/BspModulesTests.scala
+++ b/bsp/test/src/BspModulesTests.scala
@@ -23,8 +23,8 @@ object BspModulesTests extends ScriptTestSuite(false) {
           "", // the root module has no segemnts at all
           "HelloBsp",
           "HelloBsp.test",
-          "foreign-modules.proj1.proj1",
-          "foreign-modules.proj2.proj2"
+          "foreign-modules.proj1.build.proj1",
+          "foreign-modules.proj2.build.proj2"
           // "foreign-modules.proj3.proj3" // still not detected
         ).sorted
         readModules ==> expectedModules

--- a/main/src/mill/main/MainRunner.scala
+++ b/main/src/mill/main/MainRunner.scala
@@ -188,7 +188,6 @@ class MainRunner(
         .map(_ / os.up)
         .getOrElse(wd)
       val literalPath = pprint.Util.literalize(path.toString)
-      println("path: " + path)
       val foreignPath = path / wrapName
       val foreign =
         if (foreignPath != wd / "build") {
@@ -198,7 +197,6 @@ class MainRunner(
           // Encoding the number of `/..`
           val ups = if (relative.ups > 0) Seq(s"up-${relative.ups}") else Seq()
           val segs = Seq("foreign-modules") ++ ups ++ relative.segments
-          println("foreign segments: " + segs)
           val segsList = segs.map(pprint.Util.literalize(_)).mkString(", ")
           s"Some(_root_.mill.define.Segments.labels($segsList))"
         } else "None"

--- a/main/src/mill/main/MainRunner.scala
+++ b/main/src/mill/main/MainRunner.scala
@@ -188,14 +188,17 @@ class MainRunner(
         .map(_ / os.up)
         .getOrElse(wd)
       val literalPath = pprint.Util.literalize(path.toString)
+      println("path: " + path)
+      val foreignPath = path / wrapName
       val foreign =
-        if (path != wd) {
+        if (foreignPath != wd / "build") {
           // Computing a path in "out" that uniquely reflects the location
           // of the foreign module relatively to the current build.
-          val relative = path.relativeTo(wd)
+          val relative = foreignPath.relativeTo(wd)
           // Encoding the number of `/..`
           val ups = if (relative.ups > 0) Seq(s"up-${relative.ups}") else Seq()
           val segs = Seq("foreign-modules") ++ ups ++ relative.segments
+          println("foreign segments: " + segs)
           val segsList = segs.map(pprint.Util.literalize(_)).mkString(", ")
           s"Some(_root_.mill.define.Segments.labels($segsList))"
         } else "None"

--- a/main/test/resources/examples/foreign/project/build.sc
+++ b/main/test/resources/examples/foreign/project/build.sc
@@ -65,25 +65,28 @@ def checkProjectDests = T {
 
 def checkInnerDests = T {
   val foreignOut: os.Path = millSourcePath / "out" / "foreign-modules"
-  assertPathsEqual(inner.build.sub.selfDest(), foreignOut / "inner" / "sub")
-  assertPathsEqual(inner.build.sub.sub.selfDest(), foreignOut / "inner" / "sub" / "sub")
+  assertPathsEqual(inner.build.sub.selfDest(), foreignOut / "inner" / "build" / "sub")
+  assertPathsEqual(inner.build.sub.sub.selfDest(), foreignOut / "inner" / "build" / "sub" / "sub")
 }
 
 def checkOuterDests = T {
   val foreignOut: os.Path = millSourcePath / "out" / "foreign-modules"
-  assertPathsEqual(^.outer.build.sub.selfDest(), foreignOut / "up-1" / "outer" / "sub")
-  assertPathsEqual(^.outer.build.sub.sub.selfDest(), foreignOut / "up-1" / "outer" / "sub" / "sub")
+  assertPathsEqual(^.outer.build.sub.selfDest(), foreignOut / "up-1" / "outer" / "build" / "sub")
+  assertPathsEqual(
+    ^.outer.build.sub.sub.selfDest(),
+    foreignOut / "up-1" / "outer" / "build" / "sub" / "sub"
+  )
 }
 
 def checkOuterInnerDests = T {
   val foreignOut: os.Path = millSourcePath / "out" / "foreign-modules"
   assertPathsEqual(
     ^.outer.inner.build.sub.selfDest(),
-    foreignOut / "up-1" / "outer" / "inner" / "sub"
+    foreignOut / "up-1" / "outer" / "inner" / "build" / "sub"
   )
   assertPathsEqual(
     ^.outer.inner.build.sub.sub.selfDest(),
-    foreignOut / "up-1" / "outer" / "inner" / "sub" / "sub"
+    foreignOut / "up-1" / "outer" / "inner" / "build" / "sub" / "sub"
   )
 }
 

--- a/main/test/resources/examples/foreign/project/build.sc
+++ b/main/test/resources/examples/foreign/project/build.sc
@@ -1,5 +1,6 @@
 import $file.^.outer.build
 import $file.inner.build
+import $file.other
 
 import mill._
 
@@ -56,6 +57,13 @@ def checkOuterInnerPaths = T {
   )
 }
 
+def checkOtherPaths = T {
+  val thisPath: os.Path = millSourcePath
+  assertPathsEqual(other.millSourcePath, thisPath )
+  assertPathsEqual(other.sub.selfPath(), thisPath / "sub")
+  assertPathsEqual(other.sub.sub.selfPath(), thisPath / "sub" / "sub")
+}
+
 def checkProjectDests = T {
   val outPath: os.Path = millSourcePath / "out"
   assertPathsEqual(sub.selfDest(), outPath / "sub")
@@ -88,6 +96,12 @@ def checkOuterInnerDests = T {
     ^.outer.inner.build.sub.sub.selfDest(),
     foreignOut / "up-1" / "outer" / "inner" / "build" / "sub" / "sub"
   )
+}
+
+def checkOtherDests = T {
+  val foreignOut: os.Path = millSourcePath / "out" / "foreign-modules"
+  assertPathsEqual(other.sub.selfDest(), foreignOut / "other" / "sub")
+  assertPathsEqual(other.sub.sub.selfDest(), foreignOut / "other" / "sub" / "sub")
 }
 
 trait PathAware extends mill.Module {

--- a/main/test/resources/examples/foreign/project/other.sc
+++ b/main/test/resources/examples/foreign/project/other.sc
@@ -1,0 +1,13 @@
+import mill._
+
+trait PathAware extends mill.Module {
+  def selfPath = T { millSourcePath }
+}
+
+trait DestAware extends mill.Module {
+  def selfDest = T { T.dest / os.up }
+}
+
+object sub extends PathAware with DestAware {
+  object sub extends PathAware with DestAware
+}

--- a/main/test/src/main/ForeignBuildsTest.scala
+++ b/main/test/src/main/ForeignBuildsTest.scala
@@ -18,10 +18,12 @@ object ForeignBuildsTest extends ScriptTestSuite(fork = false) {
       "checkInnerPaths" - checkTarget()
       "checkOuterPaths" - checkTarget()
       "checkOuterInnerPaths" - checkTarget()
+      "checkOtherPaths" - checkTarget()
       "checkProjectDests" - checkTarget()
       "checkInnerDests" - checkTarget()
       "checkOuterDests" - checkTarget()
       "checkOuterInnerDests" - checkTarget()
+      "checkOtherDests" - checkTarget()
     }
   }
 }

--- a/main/test/src/main/ForeignBuildsTest.scala
+++ b/main/test/src/main/ForeignBuildsTest.scala
@@ -2,6 +2,7 @@ package mill.main
 
 import mill.util.ScriptTestSuite
 import utest._
+import utest.framework.TestPath
 
 object ForeignBuildsTest extends ScriptTestSuite(fork = false) {
   def workspaceSlug = "foreign-builds"
@@ -11,20 +12,16 @@ object ForeignBuildsTest extends ScriptTestSuite(fork = false) {
 
   val tests = Tests {
     initWorkspace()
+    def checkTarget()(implicit testPath: TestPath): Unit = assert(eval(testPath.value.last))
     "test" - {
-      // See https://github.com/lihaoyi/mill/issues/302
-      if (!ammonite.util.Util.java9OrAbove) {
-        assert(
-          eval("checkProjectPaths"),
-          eval("checkInnerPaths"),
-          eval("checkOuterPaths"),
-          eval("checkOuterInnerPaths"),
-          eval("checkProjectDests"),
-          eval("checkInnerDests"),
-          eval("checkOuterDests"),
-          eval("checkOuterInnerDests")
-        )
-      }
+      "checkProjectPaths" - checkTarget()
+      "checkInnerPaths" - checkTarget()
+      "checkOuterPaths" - checkTarget()
+      "checkOuterInnerPaths" - checkTarget()
+      "checkProjectDests" - checkTarget()
+      "checkInnerDests" - checkTarget()
+      "checkOuterDests" - checkTarget()
+      "checkOuterInnerDests" - checkTarget()
     }
   }
 }


### PR DESCRIPTION
## What is changed

With this change, we always give included files a unique foreign module path. This makes the dest path more consistent and robust.

Unfortunately, this slightly changes the encoding of foreign modules names. This is no issue when writing `.sc` files, but it will be visible in the progress output and in BSP client and IntelliJ Idea. E.g. the name of an included file in directory `proj1` containing a module `proj1`, will now have the module name "foreign-modules.proj1.build.proj1", whereas previously it was "foreign-modules.proj1.proj1".

* Fix https://github.com/com-lihaoyi/mill/issues/2130

## Reproduction of the new fixed issue (reported in #2130)

If you import `.sc` files from the same directory, the cache location is shared with `build.sc` , resulting in colliding dest paths when modules have the same name.

Example:
```scala
// build.sc
import mill._
import $file.other

def foo = T {
  println(s"build.foo: ${T.dest}")
  "build.foo"
}

def bar = T{
  other.foo()
}
```

```scala
// other.sc
import mill._

def foo = T {
  println(s"other.foo: ${T.dest}")
  "other.foo"
}
```

Now the cache location is re-used and overridden by different targets.

```
$ mill show bar
[1/1] show 
[1/1] show > [1/2] foo 
other.foo: /tmp/mill-1/out/foo.dest
"other.foo"

$mill show foo
[1/1] show 
[1/1] show > [1/1] foo 
build.foo: /tmp/mill-1/out/foo.dest
"build.foo"
```
