### PR TITLE
Update bloop-config to 1.5.4 and update used API

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -139,7 +139,7 @@ object Deps {
     "org.scalameta" -> "trees_2.13"
   )
   val asciidoctorj = ivy"org.asciidoctor:asciidoctorj:2.4.3"
-  val bloopConfig = ivy"ch.epfl.scala::bloop-config:1.5.3"
+  val bloopConfig = ivy"ch.epfl.scala::bloop-config:1.5.4"
   val coursier = ivy"io.get-coursier::coursier:2.1.0-RC2"
 
   val flywayCore = ivy"org.flywaydb:flyway-core:8.5.13"

--- a/contrib/bloop/src/mill/contrib/bloop/BloopFormats.scala
+++ b/contrib/bloop/src/mill/contrib/bloop/BloopFormats.scala
@@ -36,14 +36,15 @@ object BloopFormats {
   implicit val platformJvmRW: ReadWriter[BloopConfig.Platform.Jvm] = macroRW
   implicit val platformNativeRW: ReadWriter[BloopConfig.Platform.Native] = macroRW
   implicit val platformRW: ReadWriter[BloopConfig.Platform] = macroRW
-  implicit val projectRW: ReadWriter[BloopConfig.Project] = macroRW
   implicit val resolutionRW: ReadWriter[BloopConfig.Resolution] = macroRW
   implicit val sbtRW: ReadWriter[BloopConfig.Sbt] = macroRW
   implicit val scalaRw: ReadWriter[BloopConfig.Scala] = macroRW
   implicit val sourcesGlobsRW: ReadWriter[BloopConfig.SourcesGlobs] = macroRW
+  implicit val sourceGeneratorRW: ReadWriter[BloopConfig.SourceGenerator] = macroRW
   implicit val testArgumentRW: ReadWriter[BloopConfig.TestArgument] = macroRW
   implicit val testFrameworkRW: ReadWriter[BloopConfig.TestFramework] = macroRW
   implicit val testOptionsRW: ReadWriter[BloopConfig.TestOptions] = macroRW
   implicit val testRW: ReadWriter[BloopConfig.Test] = macroRW
+  implicit val projectRW: ReadWriter[BloopConfig.Project] = macroRW
 
 }

--- a/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
+++ b/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
@@ -411,7 +411,8 @@ class BloopImpl(ev: () => Evaluator, wd: os.Path) extends ExternalModule { outer
         test = testConfig(),
         platform = Some(platform()),
         resolution = Some(bloopResolution()),
-        tags = Some(tags)
+        tags = Some(tags),
+        sourceGenerators = None // TODO: are we supposed to hook generated sources here?
       )
     }
 


### PR DESCRIPTION
Bloop Config introduced some binary incompatible API change between 1.5.3 and 1.5.4.
I update the upickle JSON reader/writer setup and adapted to the new API.

I just forward a `None` to the source generators, although, technically,
we probably should add a more sophisticated setup, as Mill is able to generate source code
and is also very aware of the fact it's generating it and if it needs updates.
I simply left a TODO note in the code.
