### PR TITLE
Test opts file reader to cover issue #2140

### DIFF
--- a/main/client/src/mill/main/client/MillEnv.java
+++ b/main/client/src/mill/main/client/MillEnv.java
@@ -108,13 +108,23 @@ public class MillEnv {
     }
 
     static List<String> readMillJvmOpts() {
+        return readOptsFileLines(millJvmOptsFile());
+    }
+
+    /**
+     * Reads a file, ignoring empty or comment lines
+     *
+     * @return The non-empty lines of the files or an empty list, if the file does not exists
+     */
+    static List<String> readOptsFileLines(final File file) {
         final List<String> vmOptions = new LinkedList<>();
         try (
-            final Scanner sc = new Scanner(millJvmOptsFile())
+            final Scanner sc = new Scanner(file)
         ) {
             while (sc.hasNextLine()) {
                 String arg = sc.nextLine();
-                if (!arg.trim().isEmpty() && !arg.startsWith("#")) {
+                String trimmed = arg.trim();
+                if (!trimmed.isEmpty() && !trimmed.startsWith("#")) {
                     vmOptions.add(arg);
                 }
             }

--- a/main/client/src/mill/main/client/MillEnv.java
+++ b/main/client/src/mill/main/client/MillEnv.java
@@ -98,7 +98,7 @@ public class MillEnv {
         // extra opts
         File millJvmOptsFile = millJvmOptsFile();
         if (millJvmOptsFile.exists()) {
-            vmOptions.addAll(readMillJvmOpts());
+            vmOptions.addAll(readOptsFileLines(millJvmOptsFile));
         }
 
         vmOptions.add("-cp");

--- a/main/client/test/resources/file-wo-final-newline.txt
+++ b/main/client/test/resources/file-wo-final-newline.txt
@@ -1,0 +1,4 @@
+
+# comment after an empty line
+-DPROPERTY_PROPERLY_SET_VIA_JVM_OPTS=value-from-file
+-Xss120m

--- a/main/client/test/src/mill/main/client/MillEnvTests.java
+++ b/main/client/test/src/mill/main/client/MillEnvTests.java
@@ -1,0 +1,31 @@
+package mill.main.client;
+
+import de.tobiasroeser.lambdatest.junit.FreeSpec;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+import static de.tobiasroeser.lambdatest.Expect.expectEquals;
+
+public class MillEnvTests extends FreeSpec {
+
+    @Override
+    protected void initTests() {
+        section("readOptsFileLines", () -> {
+            test("without final newline", () -> {
+                File file = new File(
+                    getClass().getClassLoader().getResource("file-wo-final-newline.txt").toURI()
+                );
+                List<String> lines = MillEnv.readOptsFileLines(file);
+                expectEquals(
+                    lines,
+                    Arrays.asList(
+                        "-DPROPERTY_PROPERLY_SET_VIA_JVM_OPTS=value-from-file",
+                        "-Xss120m"
+                    ));
+            });
+        });
+    }
+
+}


### PR DESCRIPTION
Tried to reprodude #2140, which claims, we miss the last option when the opts file does not end with a newline.

Can't reproduce locally.

Here is a hex dump of the file added:

```
$ hexdump -C main/client/test/resources/file-wo-final-newline.txt
00000000  0a 23 20 63 6f 6d 6d 65  6e 74 20 61 66 74 65 72  |.# comment after|
00000010  20 61 6e 20 65 6d 70 74  79 20 6c 69 6e 65 0a 2d  | an empty line.-|
00000020  44 50 52 4f 50 45 52 54  59 5f 50 52 4f 50 45 52  |DPROPERTY_PROPER|
00000030  4c 59 5f 53 45 54 5f 56  49 41 5f 4a 56 4d 5f 4f  |LY_SET_VIA_JVM_O|
00000040  50 54 53 3d 76 61 6c 75  65 2d 66 72 6f 6d 2d 66  |PTS=value-from-f|
00000050  69 6c 65 0a 2d 58 73 73  31 32 30 6d              |ile.-Xss120m|
0000005c
```
