### PR TITLE
Disabled local Caffeine integration tests as they are flaky

### DIFF
--- a/integration/thirdparty/local/src/local/Tests.scala
+++ b/integration/thirdparty/local/src/local/Tests.scala
@@ -5,4 +5,5 @@ object AcyclicTests extends AcyclicTests(fork = false)
 object AmmoniteTests extends AmmoniteTests(fork = false)
 object JawnTests extends JawnTests(fork = false)
 object UpickleTests extends UpickleTests(fork = false)
-object CaffeineTests extends CaffeineTests(fork = false)
+// CaffeineTests are flaky in local (fork=false) mode
+// object CaffeineTests extends CaffeineTests(fork = false)


### PR DESCRIPTION
We still run these tests in a forked setup, so we don't loose coverage yet.