### PR TITLE
Support exoego fork of JsDom JsEnv

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -97,6 +97,7 @@ object Deps {
 
   object Scalajs_1 {
     val scalajsEnvJsdomNodejs = ivy"org.scala-js::scalajs-env-jsdom-nodejs:1.1.0"
+    val scalajsEnvExoegoJsdomNodejs = ivy"net.exoego::scalajs-env-jsdom-nodejs:2.1.0"
     val scalajsEnvNodejs = ivy"org.scala-js::scalajs-env-nodejs:1.4.0"
     val scalajsEnvPhantomjs = ivy"org.scala-js::scalajs-env-phantomjs:1.0.0"
     val scalajsSbtTestAdapter = ivy"org.scala-js::scalajs-sbt-test-adapter:1.11.0"
@@ -672,6 +673,7 @@ object scalajslib extends MillModule {
          |    val javaxServlet = "org.eclipse.jetty.orbit:javax.servlet:3.0.0.v201112011016"
          |    val scalajsEnvNodejs = "${formatDep(Deps.Scalajs_1.scalajsEnvNodejs)}"
          |    val scalajsEnvJsdomNodejs = "${formatDep(Deps.Scalajs_1.scalajsEnvJsdomNodejs)}"
+         |    val scalajsEnvExoegoJsdomNodejs = "${formatDep(Deps.Scalajs_1.scalajsEnvExoegoJsdomNodejs)}"
          |    val scalajsEnvPhantomJs = "${formatDep(Deps.Scalajs_1.scalajsEnvPhantomjs)}"
          |  }
          |}
@@ -701,6 +703,7 @@ object scalajslib extends MillModule {
           Deps.Scalajs_1.scalajsSbtTestAdapter,
           Deps.Scalajs_1.scalajsEnvNodejs,
           Deps.Scalajs_1.scalajsEnvJsdomNodejs,
+          Deps.Scalajs_1.scalajsEnvExoegoJsdomNodejs,
           Deps.Scalajs_1.scalajsEnvPhantomjs
         )
     }

--- a/scalajslib/src/mill/scalajslib/api/ScalaJSApi.scala
+++ b/scalajslib/src/mill/scalajslib/api/ScalaJSApi.scala
@@ -83,6 +83,7 @@ sealed trait JsEnvConfig
 object JsEnvConfig {
   implicit def rwNodeJs: RW[NodeJs] = macroRW
   implicit def rwJsDom: RW[JsDom] = macroRW
+  implicit def rwExoegoJsDomNodeJs: RW[ExoegoJsDomNodeJs] = macroRW
   implicit def rwPhantom: RW[Phantom] = macroRW
   implicit def rw: RW[JsEnvConfig] = macroRW
 
@@ -94,6 +95,12 @@ object JsEnvConfig {
   ) extends JsEnvConfig
 
   final case class JsDom(
+      executable: String = "node",
+      args: List[String] = Nil,
+      env: Map[String, String] = Map.empty
+  ) extends JsEnvConfig
+
+  final case class ExoegoJsDomNodeJs(
       executable: String = "node",
       args: List[String] = Nil,
       env: Map[String, String] = Map.empty

--- a/scalajslib/src/mill/scalajslib/worker/ScalaJSWorker.scala
+++ b/scalajslib/src/mill/scalajslib/worker/ScalaJSWorker.scala
@@ -77,6 +77,12 @@ private[scalajslib] class ScalaJSWorker extends AutoCloseable {
           args = config.args,
           env = config.env
         )
+      case config: api.JsEnvConfig.ExoegoJsDomNodeJs =>
+        workerApi.JsEnvConfig.ExoegoJsDomNodeJs(
+          executable = config.executable,
+          args = config.args,
+          env = config.env
+        )
       case config: api.JsEnvConfig.Phantom =>
         workerApi.JsEnvConfig.Phantom(
           executable = config.executable,

--- a/scalajslib/worker-api/src/ScalaJSWorkerApi.scala
+++ b/scalajslib/worker-api/src/ScalaJSWorkerApi.scala
@@ -68,6 +68,12 @@ private[scalajslib] object JsEnvConfig {
       env: Map[String, String]
   ) extends JsEnvConfig
 
+  final case class ExoegoJsDomNodeJs(
+      executable: String,
+      args: List[String],
+      env: Map[String, String]
+  ) extends JsEnvConfig
+
   final case class Phantom(
       executable: String,
       args: List[String],

--- a/scalajslib/worker/0.6/src/ScalaJSWorkerImpl.scala
+++ b/scalajslib/worker/0.6/src/ScalaJSWorkerImpl.scala
@@ -197,5 +197,8 @@ class ScalaJSWorkerImpl extends ScalaJSWorkerApi {
           .withEnv(config.env)
           .withAutoExit(config.autoExit)
       )
+    case _: JsEnvConfig.ExoegoJsDomNodeJs => throw new Exception(
+      "Not supported on Scala.js 0.6"
+    )
   }
 }

--- a/scalajslib/worker/1/src/ScalaJSWorkerImpl.scala
+++ b/scalajslib/worker/1/src/ScalaJSWorkerImpl.scala
@@ -301,6 +301,13 @@ class ScalaJSWorkerImpl extends ScalaJSWorkerApi {
           .withArgs(config.args)
           .withEnv(config.env)
       )
+    case config: JsEnvConfig.ExoegoJsDomNodeJs =>
+      new net.exoego.jsenv.jsdomnodejs.JSDOMNodeJSEnv(
+        net.exoego.jsenv.jsdomnodejs.JSDOMNodeJSEnv.Config()
+          .withExecutable(config.executable)
+          .withArgs(config.args)
+          .withEnv(config.env)
+      )
     case config: JsEnvConfig.Phantom =>
       new org.scalajs.jsenv.phantomjs.PhantomJSEnv(
         org.scalajs.jsenv.phantomjs.PhantomJSEnv.Config()


### PR DESCRIPTION
My first approach to solve #2144 was to create a `Custom` `JsEnvConfig` which would take a `className` and then the implementation would instantiate that class with java reflection. It worked fine but didn't support parameters or builders used by the JsEnv to create itself.
Since there aren't many custom `JsEnv`s out there (the only one I know is [exoego](https://github.com/exoego/scala-js-env-jsdom-nodejs)'s fork of jsdom-nodejs, I'm proposing of supporting it officially in Mill.
This PR also changes the worker classpath to only download and load the jsEnv dependencies that are needed. This skips downloading artifacts and loading classes for jsEnvs that aren't used, like this new one for people not using it, or the deprecated phantom jsEnv.
 
Testing this properly means installing `jsdom` which can only be done in the root because of https://github.com/com-lihaoyi/mill/issues/1036 (to my understanding). I tested in manually in scratch but I needed to have a global `package.json`
