### PR TITLE
Add missing backticks

### DIFF
--- a/docs/antora/modules/ROOT/pages/Mill_Internals.adoc
+++ b/docs/antora/modules/ROOT/pages/Mill_Internals.adoc
@@ -186,7 +186,7 @@ The module hierarchy is the graph of objects, starting from the root of the
 `build.sc` file, that extend `mill.Module`. At the leaves of the hierarchy are
 the ``Target``s you can run.
 
-A `Target`'s position in the module hierarchy tells you many things. For
+A ``Target``'s position in the module hierarchy tells you many things. For
 example, a `Target` at position `core.test.compile` would:
 
 * Cache output metadata at `out/core/test/compile.json`


### PR DESCRIPTION
Currently, the sentence is rendered wrong - I think the extra pair of ticks will make it work like the "Targets" in the previous sentence.

<img width="898" alt="image" src="https://user-images.githubusercontent.com/894884/204065525-53ee751d-2cd3-4ef4-a7af-08dfbfa1a911.png">
