### PR TITLE
docs: Fix favicon

### DIFF
--- a/docs/antora/supplemental-ui/partials/head-icons.hbs
+++ b/docs/antora/supplemental-ui/partials/head-icons.hbs
@@ -1,0 +1,1 @@
+<link rel="icon" href="{{{uiRootPath}}}/favicon.png" type="image/x-icon">


### PR DESCRIPTION
Currently [the docs](https://com-lihaoyi.github.io/mill/mill/Intro_to_Mill.html) have no favicon. This fixes that to use ![favicon.png](https://raw.githubusercontent.com/com-lihaoyi/mill/main/docs/antora/supplemental-ui/favicon.png "docs/antora/supplemental-ui/favicon.png"), which was probably the original intention