### PR TITLE
Bloop: Fixed re-generation of bloop config dir

### DIFF
--- a/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
+++ b/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
@@ -86,12 +86,17 @@ class BloopImpl(ev: () => Evaluator, wd: os.Path) extends ExternalModule { outer
     object bloop extends MillModule {
       def config = T { outer.bloopConfig(jm) }
 
-      def writeConfig: Target[(String, PathRef)] = T {
+      def writeConfigFile(): Command[(String, PathRef)] = T.command {
         os.makeDir.all(bloopDir)
         val path = bloopConfigPath(jm)
         _root_.bloop.config.write(config(), path.toNIO)
         T.log.info(s"Wrote $path")
         name(jm) -> PathRef(path)
+      }
+
+      @deprecated("Use writeConfigFile instead.", "Mill after 0.10.9")
+      def writeConfig: Target[(String, PathRef)] = T {
+        writeConfigFile()()
       }
     }
 

--- a/contrib/bloop/test/src/mill/contrib/bloop/BloopTests.scala
+++ b/contrib/bloop/test/src/mill/contrib/bloop/BloopTests.scala
@@ -215,6 +215,17 @@ object BloopTests extends TestSuite {
         assert(exists == false)
       }
     }
+    "regenerateAfterBloopDirRemoval" - {
+      testEvaluator(testBloop.install())
+      val bloopDir = workdir / ".bloop"
+      val files = os.list(bloopDir)
+      assert(files.size == 5)
+      os.remove.all(bloopDir)
+      testEvaluator(testBloop.install())
+      val files2 = os.list(bloopDir)
+      assert(files2.size == 5)
+      assert(files2 == files)
+    }
   }
 
 }

--- a/contrib/bloop/test/src/mill/contrib/bloop/BloopTests.scala
+++ b/contrib/bloop/test/src/mill/contrib/bloop/BloopTests.scala
@@ -11,6 +11,7 @@ import os.Path
 import upickle.default._
 import utest._
 import bloop.config.Config.Platform.Jvm
+import scala.util.Properties.isWin
 
 object BloopTests extends TestSuite {
   import BloopFormats._
@@ -58,7 +59,7 @@ object BloopTests extends TestSuite {
     }
 
     object scalanativeModule extends scalanativelib.ScalaNativeModule with testBloop.Module {
-      override def skipBloop: Boolean = scala.util.Properties.isWin
+      override def skipBloop: Boolean = isWin
       override def scalaVersion = "2.13.4"
       override def scalaNativeVersion = "0.4.2"
       override def releaseMode = T(ReleaseMode.Debug)
@@ -219,11 +220,12 @@ object BloopTests extends TestSuite {
       testEvaluator(testBloop.install())
       val bloopDir = workdir / ".bloop"
       val files = os.list(bloopDir)
-      assert(files.size == 5)
+      val size = (if(isWin) 4 else 5)
+      assert(files.size == size)
       os.remove.all(bloopDir)
       testEvaluator(testBloop.install())
       val files2 = os.list(bloopDir)
-      assert(files2.size == 5)
+      assert(files2.size == size)
       assert(files2 == files)
     }
   }


### PR DESCRIPTION
The `bloop.writeConfig` was a cached target, but it generated files outside of `T.dest`. Instead, it should be a command.

To preserve source and binary compatibilty, I created a new command `writeConfigFile`, and let the `writeConfig` target forward the result of `writeConfigFile`.
