### PR TITLE
Disabled snapshot publishing to avoid misleading version numbers

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -161,8 +161,8 @@ jobs:
       - run: ci/release-maven.sh
 
   release-github:
-    # when in master repo: all commits to main branch and all additional tags
-    if: github.repository == 'com-lihaoyi/mill' && ( github.ref == 'refs/heads/main' || (github.ref != 'refs/heads/main' && startsWith( github.ref, 'refs/tags/') ) )
+    # when in master repo, publish all tags
+    if: github.repository == 'com-lihaoyi/mill' && startsWith( github.ref, 'refs/tags/')
     needs: publish-sonatype
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Later, we will introduce kind-of nightly builds, maybe manually triggered ones first.
