### PR TITLE
Use classpath PathRefs hashCode as cache key for Zinc worker

### DIFF
--- a/scalalib/api/src/mill/scalalib/api/ZincWorkerApi.scala
+++ b/scalalib/api/src/mill/scalalib/api/ZincWorkerApi.scala
@@ -1,6 +1,6 @@
 package mill.scalalib.api
 
-import mill.api.CompileProblemReporter
+import mill.api.{CompileProblemReporter, PathRef}
 import mill.api.Loose.Agg
 
 object ZincWorkerApi {
@@ -26,8 +26,8 @@ trait ZincWorkerApi {
       scalaVersion: String,
       scalaOrganization: String,
       scalacOptions: Seq[String],
-      compilerClasspath: Agg[os.Path],
-      scalacPluginClasspath: Agg[os.Path],
+      compilerClasspath: Agg[PathRef],
+      scalacPluginClasspath: Agg[PathRef],
       reporter: Option[CompileProblemReporter]
   )(implicit ctx: ZincWorkerApi.Ctx): mill.api.Result[CompilationResult]
 
@@ -38,8 +38,8 @@ trait ZincWorkerApi {
   def docJar(
       scalaVersion: String,
       scalaOrganization: String,
-      compilerClasspath: Agg[os.Path],
-      scalacPluginClasspath: Agg[os.Path],
+      compilerClasspath: Agg[PathRef],
+      scalacPluginClasspath: Agg[PathRef],
       args: Seq[String]
   )(implicit ctx: ZincWorkerApi.Ctx): Boolean
 }

--- a/scalalib/api/src/mill/scalalib/api/ZincWorkerUtil.scala
+++ b/scalalib/api/src/mill/scalalib/api/ZincWorkerUtil.scala
@@ -1,6 +1,7 @@
 package mill.scalalib.api
 
 import mill.api.Loose.Agg
+import mill.api.PathRef
 
 trait ZincWorkerUtil {
 
@@ -14,11 +15,11 @@ trait ZincWorkerUtil {
   // **/scala-library-2.13.*.jar or
   // **/2.13.*/jars/scala-library.jar
   def grepJar(
-      classPath: Agg[os.Path],
+      classPath: Agg[PathRef],
       name: String,
       versionPrefix: String,
       sources: Boolean = false
-  ) = {
+  ): PathRef = {
     val suffix = if (sources) "-sources.jar" else ".jar"
     lazy val dir = if (sources) "srcs" else "jars"
 
@@ -34,7 +35,7 @@ trait ZincWorkerUtil {
     }
 
     classPath.iterator
-      .find(p => mavenStyleMatch(p.last) || ivyStyleMatch(p))
+      .find(pathRef => mavenStyleMatch(pathRef.path.last) || ivyStyleMatch(pathRef.path))
       .getOrElse(throw new Exception(
         s"Cannot find **/$name-$versionPrefix*$suffix or **/$versionPrefix*/$dir/$name$suffix in ${classPath.iterator.mkString("[", ", ", "]")}"
       ))

--- a/scalalib/src/ScalaModule.scala
+++ b/scalalib/src/ScalaModule.scala
@@ -212,8 +212,8 @@ trait ScalaModule extends JavaModule with SemanticDbJavaModule { outer =>
         scalaVersion = sv,
         scalaOrganization = scalaOrganization(),
         scalacOptions = allScalacOptions(),
-        compilerClasspath = scalaCompilerClasspath().map(_.path),
-        scalacPluginClasspath = scalacPluginClasspath().map(_.path),
+        compilerClasspath = scalaCompilerClasspath(),
+        scalacPluginClasspath = scalacPluginClasspath(),
         reporter = T.reporter.apply(hashCode)
       )
   }
@@ -262,8 +262,8 @@ trait ScalaModule extends JavaModule with SemanticDbJavaModule { outer =>
           .docJar(
             scalaVersion(),
             scalaOrganization(),
-            scalaDocClasspath().map(_.path),
-            scalacPluginClasspath().map(_.path),
+            scalaDocClasspath(),
+            scalacPluginClasspath(),
             options ++ compileCp ++ scalaDocOptions() ++
               files.map(_.toString())
           ) match {

--- a/scalalib/src/ZincWorkerModule.scala
+++ b/scalalib/src/ZincWorkerModule.scala
@@ -59,12 +59,12 @@ trait ZincWorkerModule extends mill.Module with OfflineSupportModule { self: Cou
     val instance = cls.getConstructor(
       classOf[
         Either[
-          (ZincWorkerApi.Ctx, (String, String) => (Option[Array[os.Path]], os.Path)),
-          String => os.Path
+          (ZincWorkerApi.Ctx, (String, String) => (Option[Agg[PathRef]], PathRef)),
+          String => PathRef
         ]
       ], // compilerBridge
-      classOf[(Agg[os.Path], String) => os.Path], // libraryJarNameGrep
-      classOf[(Agg[os.Path], String) => os.Path], // compilerJarNameGrep
+      classOf[(Agg[PathRef], String) => PathRef], // libraryJarNameGrep
+      classOf[(Agg[PathRef], String) => PathRef], // compilerJarNameGrep
       classOf[KeyedLockedCache[_]], // compilerCache
       classOf[Boolean], // compileToJar
       classOf[Boolean] // zincLogDebug
@@ -88,7 +88,7 @@ trait ZincWorkerModule extends mill.Module with OfflineSupportModule { self: Cou
       scalaVersion: String,
       scalaOrganization: String,
       repositories: Seq[Repository]
-  ): Result[(Option[Array[Path]], Path)] = {
+  ): Result[(Option[Agg[PathRef]], PathRef)] = {
     val (scalaVersion0, scalaBinaryVersion0) = scalaVersion match {
       case _ => (scalaVersion, ZincWorkerUtil.scalaBinaryVersion(scalaVersion))
     }
@@ -116,14 +116,14 @@ trait ZincWorkerModule extends mill.Module with OfflineSupportModule { self: Cou
       useSources,
       Some(overrideScalaLibrary(scalaVersion, scalaOrganization))
     ).map(deps =>
-      ZincWorkerUtil.grepJar(deps.map(_.path), bridgeName, bridgeVersion, useSources)
+      ZincWorkerUtil.grepJar(deps, bridgeName, bridgeVersion, useSources)
     )
 
     if (useSources) {
       for {
         jar <- bridgeJar
         classpath <- compilerInterfaceClasspath(scalaVersion, scalaOrganization, repositories)
-      } yield (Some(classpath.map(_.path).iterator.toArray), jar)
+      } yield (Some(classpath), jar)
     } else {
       bridgeJar.map((None, _))
     }

--- a/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
+++ b/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
@@ -96,8 +96,8 @@ trait SemanticDbJavaModule extends JavaModule { hostModule =>
             scalaVersion = sv,
             scalaOrganization = m.scalaOrganization(),
             scalacOptions = scalacOptions,
-            compilerClasspath = m.scalaCompilerClasspath().map(_.path),
-            scalacPluginClasspath = semanticDbPluginClasspath().map(_.path),
+            compilerClasspath = m.scalaCompilerClasspath(),
+            scalacPluginClasspath = semanticDbPluginClasspath(),
             reporter = T.reporter.apply(hashCode)
           )
           .map(_.classes)

--- a/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
+++ b/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
@@ -389,11 +389,7 @@ class ZincWorkerImpl(
       compilerClasspath
     )
 
-    val compilerBridgeSig = os.mtime(compiledCompilerBridge)
-
-    val compilersSig =
-      compilerBridgeSig +
-        combinedCompilerClasspath.map(p => p.toString().hashCode + os.mtime(p)).sum
+    val compilersSig = combinedCompilerClasspath.map(p => p.hashCode).sum
 
     compilerCache.withCachedValue(compilersSig) {
       val loader = getCachedClassLoader(compilersSig, combinedCompilerJars)

--- a/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
+++ b/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
@@ -380,7 +380,7 @@ class ZincWorkerImpl(
       scalacPluginClasspath: Agg[PathRef]
   )(f: Compilers => T)(implicit ctx: ZincWorkerApi.Ctx) = {
     val combinedCompilerClasspath = compilerClasspath ++ scalacPluginClasspath
-    val compilersSig = combinedCompilerClasspath.hashCode
+    val compilersSig = combinedCompilerClasspath.hashCode + scalaVersion.hashCode + scalaOrganization.hashCode
     val combinedCompilerJars = combinedCompilerClasspath.iterator.map(_.path.toIO).toArray
 
     val compiledCompilerBridge = compileBridgeIfNeeded(

--- a/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
+++ b/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
@@ -21,11 +21,11 @@ import scala.util.Properties.isWin
 @internal
 class ZincWorkerImpl(
     compilerBridge: Either[
-      (ZincWorkerApi.Ctx, (String, String) => (Option[Array[os.Path]], os.Path)),
-      String => os.Path
+      (ZincWorkerApi.Ctx, (String, String) => (Option[Agg[PathRef]], PathRef)),
+      String => PathRef
     ],
-    libraryJarNameGrep: (Agg[os.Path], String) => os.Path,
-    compilerJarNameGrep: (Agg[os.Path], String) => os.Path,
+    libraryJarNameGrep: (Agg[PathRef], String) => PathRef,
+    compilerJarNameGrep: (Agg[PathRef], String) => PathRef,
     compilerCache: KeyedLockedCache[Compilers],
     compileToJar: Boolean,
     zincLogDebug: Boolean
@@ -92,8 +92,8 @@ class ZincWorkerImpl(
   def docJar(
       scalaVersion: String,
       scalaOrganization: String,
-      compilerClasspath: Agg[os.Path],
-      scalacPluginClasspath: Agg[os.Path],
+      compilerClasspath: Agg[PathRef],
+      scalacPluginClasspath: Agg[PathRef],
       args: Seq[String]
   )(implicit ctx: ZincWorkerApi.Ctx): Boolean = {
     withCompilers(
@@ -132,8 +132,8 @@ class ZincWorkerImpl(
       workingDir: os.Path,
       compileDest: os.Path,
       scalaVersion: String,
-      compilerJars: Array[File],
-      compilerBridgeClasspath: Array[os.Path],
+      compilerClasspath: Agg[PathRef],
+      compilerBridgeClasspath: Agg[PathRef],
       compilerBridgeSourcesJar: os.Path
   ): Unit = {
     if (scalaVersion == "2.12.0") {
@@ -150,7 +150,7 @@ class ZincWorkerImpl(
     os.makeDir.all(compileDest)
 
     val sourceFolder = mill.api.IO.unpackZip(compilerBridgeSourcesJar)(workingDir)
-    val classloader = mill.api.ClassLoader.create(compilerJars.toIndexedSeq.map(_.toURI.toURL), null)(ctx0)
+    val classloader = mill.api.ClassLoader.create(compilerClasspath.iterator.map(_.path.toIO.toURI.toURL).toSeq, null)(ctx0)
 
     val (sources, resources) =
       os.walk(sourceFolder.path).filter(os.isFile)
@@ -165,7 +165,7 @@ class ZincWorkerImpl(
       "-d",
       compileDest.toString,
       "-classpath",
-      (compilerJars ++ compilerBridgeClasspath).mkString(File.pathSeparator)
+      (compilerClasspath.iterator ++ compilerBridgeClasspath).map(_.path).mkString(File.pathSeparator)
     ) ++ sources.map(_.toString)
 
     val allScala = sources.forall(_.ext == "scala")
@@ -202,10 +202,10 @@ class ZincWorkerImpl(
   def compileBridgeIfNeeded(
       scalaVersion: String,
       scalaOrganization: String,
-      compilerClasspath: Agg[os.Path]
+      compilerClasspath: Agg[PathRef]
   ): os.Path = {
     compilerBridge match {
-      case Right(compiled) => compiled(scalaVersion)
+      case Right(compiled) => compiled(scalaVersion).path
       case Left((ctx0, bridgeProvider)) =>
         val workingDir = ctx0.dest / s"zinc-${Versions.zinc}" / scalaVersion
         val lock = synchronized(compilerBridgeLocks.getOrElseUpdate(scalaVersion, new Object()))
@@ -215,17 +215,16 @@ class ZincWorkerImpl(
           else {
             val (cp, bridgeJar) = bridgeProvider(scalaVersion, scalaOrganization)
             cp match {
-              case None => bridgeJar
+              case None => bridgeJar.path
               case Some(bridgeClasspath) =>
-                val compilerJars = compilerClasspath.toArray.map(_.toIO)
                 compileZincBridge(
                   ctx0,
                   workingDir,
                   compiledDest,
                   scalaVersion,
-                  compilerJars,
+                  compilerClasspath,
                   bridgeClasspath,
-                  bridgeJar
+                  bridgeJar.path
                 )
                 os.write(compiledDest / "DONE", "")
                 compiledDest
@@ -297,8 +296,8 @@ class ZincWorkerImpl(
       scalaVersion: String,
       scalaOrganization: String,
       scalacOptions: Seq[String],
-      compilerClasspath: Agg[os.Path],
-      scalacPluginClasspath: Agg[os.Path],
+      compilerClasspath: Agg[PathRef],
+      scalacPluginClasspath: Agg[PathRef],
       reporter: Option[CompileProblemReporter]
   )(implicit ctx: ZincWorkerApi.Ctx): mill.api.Result[CompilationResult] = {
 
@@ -326,8 +325,8 @@ class ZincWorkerImpl(
       scalaVersion: String,
       scalaOrganization: String,
       scalacOptions: Seq[String],
-      compilerClasspath: Agg[os.Path],
-      scalacPluginClasspath: Agg[os.Path],
+      compilerClasspath: Agg[PathRef],
+      scalacPluginClasspath: Agg[PathRef],
       reporter: Option[CompileProblemReporter]
   )(implicit ctx: ZincWorkerApi.Ctx): mill.api.Result[(os.Path, os.Path)] = {
     withCompilers(
@@ -363,7 +362,7 @@ class ZincWorkerImpl(
           // the Scala compiler must load the `xsbti.*` classes from the same loader than `ZincWorkerImpl`
           val sharedPrefixes = Seq("xsbti")
           val cl = mill.api.ClassLoader.create(
-            combinedCompilerJars.map(_.toURI.toURL),
+            combinedCompilerJars.map(_.toURI.toURL).toSeq,
             parent = null,
             sharedLoader = getClass.getClassLoader,
             sharedPrefixes
@@ -377,19 +376,18 @@ class ZincWorkerImpl(
   private def withCompilers[T](
       scalaVersion: String,
       scalaOrganization: String,
-      compilerClasspath: Agg[os.Path],
-      scalacPluginClasspath: Agg[os.Path]
+      compilerClasspath: Agg[PathRef],
+      scalacPluginClasspath: Agg[PathRef]
   )(f: Compilers => T)(implicit ctx: ZincWorkerApi.Ctx) = {
     val combinedCompilerClasspath = compilerClasspath ++ scalacPluginClasspath
-    val combinedCompilerJars = combinedCompilerClasspath.iterator.toArray.map(_.toIO)
+    val compilersSig = combinedCompilerClasspath.hashCode
+    val combinedCompilerJars = combinedCompilerClasspath.iterator.map(_.path.toIO).toArray
 
     val compiledCompilerBridge = compileBridgeIfNeeded(
       scalaVersion,
       scalaOrganization,
       compilerClasspath
     )
-
-    val compilersSig = combinedCompilerClasspath.map(p => p.hashCode).sum
 
     compilerCache.withCachedValue(compilersSig) {
       val loader = getCachedClassLoader(compilersSig, combinedCompilerJars)
@@ -403,7 +401,7 @@ class ZincWorkerImpl(
           // we don't support too outdated dotty versions
           // and because there will be no scala 2.14, so hardcode "2.13." here is acceptable
           if (Util.isDottyOrScala3(scalaVersion)) "2.13." else scalaVersion
-        ).toIO),
+        ).path.toIO),
         compilerJars = combinedCompilerJars,
         allJars = combinedCompilerJars,
         explicitActual = None


### PR DESCRIPTION
The previous implmentation was receiving `os.Path`s so it needed to access the filesystem to know if the files did change.
Now we propagate `PathRef`s so we simply use their `hashCode` which changes if the files did change.
Here some numbers collected by compiling a Scala file 176 times and writing down the time calculating `compilersSig` took.
|               | Before  |After  |
|:--------------|:--------|:------|
|    Average    | 1364 ms | 12 ms |
| Std deviation | 6533.41 | 91.35 |
