### PR TITLE
Use classpath `PathRef`s hashCode as cache key for Scala.js worker (Backport of #2183)

### DIFF
--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -138,7 +138,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
       case Left(err) => Result.Failure(err)
       case Right(_) =>
         ScalaJSWorkerExternalModule.scalaJSWorker().run(
-          scalaJSToolsClasspath().map(_.path),
+          scalaJSToolsClasspath(),
           jsEnvConfig(),
           fastLinkJS()
         )
@@ -203,7 +203,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
       .filter(_.ext == "sjsir")
     val libraries = classpath.filter(_.ext == "jar")
     worker.link(
-      toolsClasspath.map(_.path),
+      toolsClasspath,
       sjsirFiles,
       libraries,
       outputPath.toIO,
@@ -346,7 +346,7 @@ trait TestScalaJSModule extends ScalaJSModule with TestModule {
   ): Task[(String, Seq[TestRunner.Result])] = T.task {
 
     val (close, framework) = ScalaJSWorkerExternalModule.scalaJSWorker().getFramework(
-      scalaJSToolsClasspath().map(_.path),
+      scalaJSToolsClasspath(),
       jsEnvConfig(),
       testFramework(),
       fastLinkJSTest()

--- a/scalajslib/src/mill/scalajslib/ScalaJSWorkerApi.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSWorkerApi.scala
@@ -26,7 +26,7 @@ class ScalaJSWorker private (val bridgeWorker: worker.ScalaJSWorker, createdInte
       moduleKind: ModuleKind,
       esFeatures: ESFeatures
   )(implicit ctx: Ctx.Home): Result[os.Path] = bridgeWorker.link(
-    toolsClasspath = toolsClasspath,
+    toolsClasspath = toolsClasspath.map(mill.PathRef(_)),
     sources = sources,
     libraries = libraries,
     dest = dest,
@@ -62,7 +62,7 @@ class ScalaJSWorker private (val bridgeWorker: worker.ScalaJSWorker, createdInte
       dest = mill.PathRef(linkedFilePath / os.up)
     )
     bridgeWorker.getFramework(
-      toolsClasspath = toolsClasspath,
+      toolsClasspath = toolsClasspath.map(mill.PathRef(_)),
       config = config,
       frameworkName = frameworkName,
       report = report


### PR DESCRIPTION
* Backport of:  https://github.com/com-lihaoyi/mill/pull/2183