### PR TITLE
Use PathRef hashCode for workers caches

### DIFF
--- a/contrib/playlib/src/mill/playlib/RouterModule.scala
+++ b/contrib/playlib/src/mill/playlib/RouterModule.scala
@@ -53,7 +53,7 @@ trait RouterModule extends ScalaModule with Version {
   def compileRouter: T[CompilationResult] = T.persistent {
     T.log.debug(s"compiling play routes with ${playVersion()} worker")
     routeCompilerWorker.routeCompilerWorker().compile(
-      routerClasspath = playRouterToolsClasspath().map(_.path),
+      routerClasspath = playRouterToolsClasspath(),
       files = routeFiles().map(_.path),
       additionalImports = routesAdditionalImport,
       forwardsRouter = generateForwardsRouter,

--- a/contrib/scalapblib/src/ScalaPBModule.scala
+++ b/contrib/scalapblib/src/ScalaPBModule.scala
@@ -125,7 +125,7 @@ trait ScalaPBModule extends ScalaModule {
   def compileScalaPB: T[PathRef] = T.persistent {
     ScalaPBWorkerApi.scalaPBWorker()
       .compile(
-        scalaPBClasspath().map(_.path),
+        scalaPBClasspath(),
         scalaPBSources().map(_.path),
         scalaPBOptions(),
         T.dest,

--- a/contrib/scalapblib/src/ScalaPBWorker.scala
+++ b/contrib/scalapblib/src/ScalaPBWorker.scala
@@ -13,12 +13,12 @@ class ScalaPBWorker extends AutoCloseable {
 
   private var scalaPBInstanceCache = Option.empty[(Long, ScalaPBWorkerApi)]
 
-  private def scalaPB(scalaPBClasspath: Agg[os.Path])(implicit ctx: mill.api.Ctx) = {
-    val classloaderSig = scalaPBClasspath.map(p => p.toString().hashCode + os.mtime(p)).sum
+  private def scalaPB(scalaPBClasspath: Agg[PathRef])(implicit ctx: mill.api.Ctx) = {
+    val classloaderSig = scalaPBClasspath.hashCode
     scalaPBInstanceCache match {
       case Some((sig, instance)) if sig == classloaderSig => instance
       case _ =>
-        val pbcClasspath = scalaPBClasspath.map(_.toIO.toURI.toURL).toVector
+        val pbcClasspath = scalaPBClasspath.map(_.path.toIO.toURI.toURL).toVector
         val cl = mill.api.ClassLoader.create(pbcClasspath, null)
         val scalaPBCompilerClass = cl.loadClass("scalapb.ScalaPBC")
         val mainMethod = scalaPBCompilerClass.getMethod("main", classOf[Array[java.lang.String]])
@@ -77,7 +77,7 @@ class ScalaPBWorker extends AutoCloseable {
    * @return execute result with path ref to `dest`
    */
   def compile(
-      scalaPBClasspath: Agg[os.Path],
+      scalaPBClasspath: Agg[PathRef],
       scalaPBSources: Seq[os.Path],
       scalaPBOptions: String,
       dest: os.Path,

--- a/contrib/scoverage/src/ScoverageModule.scala
+++ b/contrib/scoverage/src/ScoverageModule.scala
@@ -208,7 +208,7 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
     def doReport(reportType: ReportType): Task[Unit] = T.task {
       ScoverageReportWorker
         .scoverageReportWorker()
-        .bridge(scoverageToolsClasspath().map(_.path))
+        .bridge(scoverageToolsClasspath())
         .report(reportType, allSources().map(_.path), Seq(data().path), T.workspace)
     }
 

--- a/contrib/scoverage/src/ScoverageReport.scala
+++ b/contrib/scoverage/src/ScoverageReport.scala
@@ -105,7 +105,7 @@ trait ScoverageReport extends Module {
       val dataPaths: Seq[Path] = T.sequence(dataTasks)().map(_.path)
       scoverageReportWorkerModule
         .scoverageReportWorker()
-        .bridge(workerModule.scoverageToolsClasspath().map(_.path))
+        .bridge(workerModule.scoverageToolsClasspath())
         .report(reportType, sourcePaths, dataPaths, T.workspace)
       PathRef(T.dest)
     }

--- a/contrib/scoverage/src/ScoverageReportWorker.scala
+++ b/contrib/scoverage/src/ScoverageReportWorker.scala
@@ -1,21 +1,20 @@
 package mill.contrib.scoverage
 
 import mill.{Agg, T}
-import mill.api.{ClassLoader, Ctx}
+import mill.api.{ClassLoader, Ctx, PathRef}
 import mill.contrib.scoverage.api.ScoverageReportWorkerApi
 import mill.define.{Discover, ExternalModule, Worker}
 
 class ScoverageReportWorker extends AutoCloseable {
   private[this] var scoverageClCache = Option.empty[(Long, ClassLoader)]
 
-  def bridge(classpath: Agg[os.Path])(implicit ctx: Ctx): ScoverageReportWorkerApi = {
+  def bridge(classpath: Agg[PathRef])(implicit ctx: Ctx): ScoverageReportWorkerApi = {
     val klassName = "mill.contrib.scoverage.worker.ScoverageReportWorkerImpl"
-    val classloaderSig =
-      classpath.map(p => p.toString().hashCode + os.mtime(p)).sum
+    val classloaderSig = classpath.hashCode
     val cl = scoverageClCache match {
       case Some((sig, cl)) if sig == classloaderSig => cl
       case _ =>
-        val toolsClassPath = classpath.map(_.toIO.toURI.toURL).toVector
+        val toolsClassPath = classpath.map(_.path.toIO.toURI.toURL).toVector
         ctx.log.debug("Loading worker classes from\n" + toolsClassPath.mkString("\n"))
         val cl = ClassLoader.create(
           toolsClassPath,

--- a/contrib/twirllib/src/TwirlModule.scala
+++ b/contrib/twirllib/src/TwirlModule.scala
@@ -60,7 +60,7 @@ trait TwirlModule extends mill.Module { twirlModule =>
   }
 
   def twirlImports: T[Seq[String]] = T {
-    TwirlWorkerApi.twirlWorker.defaultImports(twirlClasspath().map(_.path))
+    TwirlWorkerApi.twirlWorker.defaultImports(twirlClasspath())
   }
 
   def twirlFormats: T[Map[String, String]] = TwirlWorkerApi.twirlWorker.defaultFormats
@@ -74,7 +74,7 @@ trait TwirlModule extends mill.Module { twirlModule =>
   def compileTwirl: T[mill.scalalib.api.CompilationResult] = T.persistent {
     TwirlWorkerApi.twirlWorker
       .compile(
-        twirlClasspath().map(_.path),
+        twirlClasspath(),
         twirlSources().map(_.path),
         T.dest,
         twirlImports(),

--- a/scalanativelib/src/ScalaNativeModule.scala
+++ b/scalanativelib/src/ScalaNativeModule.scala
@@ -96,13 +96,13 @@ trait ScalaNativeModule extends ScalaModule { outer =>
     super.mandatoryIvyDeps() ++ nativeIvyDeps()
   }
 
-  def bridgeFullClassPath: T[Agg[os.Path]] = T {
+  def bridgeFullClassPath: T[Agg[PathRef]] = T {
     Lib.resolveDependencies(
       repositoriesTask(),
       Lib.depToDependency(_, scalaNativeWorkerScalaVersion(), ""),
       toolsIvyDeps(),
       ctx = Some(T.log)
-    ).map(t => (scalaNativeWorkerClasspath() ++ t).map(_.path))
+    ).map(t => (scalaNativeWorkerClasspath() ++ t))
   }
 
   override def scalacPluginIvyDeps: T[Agg[Dep]] = T {


### PR DESCRIPTION
Porting the approach used for the Zinc and Scala.js workers to all the workers used in the mill codebase.