### PR TITLE
Use `millModuleDirectChildren` consistently everywhere

### DIFF
--- a/main/core/src/mill/define/Cross.scala
+++ b/main/core/src/mill/define/Cross.scala
@@ -46,12 +46,11 @@ object Cross {
  *   ...
  * }
  */
-class Cross[T <: Module : ClassTag](cases: Any*)(implicit ci: Cross.Factory[T], ctx: mill.define.Ctx)
+class Cross[T <: Module: ClassTag](cases: Any*)(implicit ci: Cross.Factory[T], ctx: mill.define.Ctx)
     extends mill.define.Module()(ctx) {
 
-  // TODO: change to Seq[Module] in 0.11
-  override lazy val millModuleDirectChildren: IndexedSeq[Module] =
-    this.millInternal.reflectNestedObjects[Module].toIndexedSeq ++
+  override lazy val millModuleDirectChildren: Seq[Module] =
+    super.millModuleDirectChildren ++
       items.collect { case (_, v: mill.define.Module) => v }
 
   private val products: List[Product] = cases.toList.map {

--- a/main/core/src/mill/define/Module.scala
+++ b/main/core/src/mill/define/Module.scala
@@ -22,7 +22,11 @@ class Module(implicit outerCtx0: mill.define.Ctx) extends mill.moduledefs.Cacher
    */
   object millInternal extends Module.Internal(this)
 
-  lazy val millModuleDirectChildren: Seq[Module] = millInternal.reflectNestedObjects[Module].toSeq
+  def millModuleDirectChildren: Seq[Module] = millModuleDirectChildrenImpl
+  // We keep a private `lazy val` and a public `def` so
+  // subclasses can call `super.millModuleDirectChildren`
+  private lazy val millModuleDirectChildrenImpl: Seq[Module] =
+    millInternal.reflectNestedObjects[Module].toSeq
   def millOuterCtx = outerCtx0
   def millSourcePath: os.Path = millOuterCtx.millSourcePath / millOuterCtx.segment.pathSegments
   implicit def millModuleExternal: Ctx.External = Ctx.External(millOuterCtx.external)

--- a/main/src/mill/main/Resolve.scala
+++ b/main/src/mill/main/Resolve.scala
@@ -211,7 +211,8 @@ abstract class Resolve[R: ClassTag] {
                 case "__" => obj.millInternal.modules
                 case "_" => obj.millModuleDirectChildren
                 case _ =>
-                  obj.millInternal.reflectNestedObjects[mill.Module]
+                  obj
+                    .millModuleDirectChildren
                     .find(_.millOuterCtx.segment == Segment.Label(singleLabel))
                     .toSeq
               },


### PR DESCRIPTION
Make `super.millModuleDirectChildren` available using a private lazy val + a public def.
After this PR it's possible to override `millModuleDirectChildren` and expect consistent behavior across all Mill's functionality.
What I'm especially interested in, is a way to dynamically disable modules based on build variables (like the `crossScalaVersion`). It seems to do the trick but not all the codebase is using `millModuleDirectChidren` as the source of truth. `Cross`, for example, has a copy of its implementation since `lazy val`s don't support calling `super.` on them.