### PR TITLE
Tooling maintenance

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -127,8 +127,8 @@ jobs:
         run: ${{ matrix.buildcmd }}
 
   publish-sonatype:
-    # when in master repo: all commits to main branch and all additional tags
-    if: github.repository == 'com-lihaoyi/mill' && ( github.ref == 'refs/heads/main' || (github.ref != 'refs/heads/main' && startsWith( github.ref, 'refs/tags/') ) )
+    # when in master repo, publish all tags
+    if: github.repository == 'com-lihaoyi/mill' && startsWith( github.ref, 'refs/tags/')
     needs: [test, test-windows, test-bin-compat]
 
     runs-on: ubuntu-latest
@@ -161,8 +161,8 @@ jobs:
       - run: ci/release-maven.sh
 
   release-github:
-    # when in master repo: all commits to main branch and all additional tags
-    if: github.repository == 'com-lihaoyi/mill' && ( github.ref == 'refs/heads/main' || (github.ref != 'refs/heads/main' && startsWith( github.ref, 'refs/tags/') ) )
+    # when in master repo, publish all tags
+    if: github.repository == 'com-lihaoyi/mill' && startsWith( github.ref, 'refs/tags/')
     needs: publish-sonatype
     runs-on: ubuntu-latest
 

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -129,7 +129,7 @@ jobs:
 
   publish-sonatype:
     # when in master repo, publish all tags and manual runs
-    if: github.repository == 'com-lihaoyi/mill' && (startsWith( github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' )
+    if: github.repository == 'com-lihaoyi/mill' && (startsWith( github.ref, 'refs/tags/') || (github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch' ) )
     needs: [test, test-windows, test-bin-compat]
 
     runs-on: ubuntu-latest
@@ -163,7 +163,7 @@ jobs:
 
   release-github:
     # when in master repo, publish all tags and manual runs
-    if: github.repository == 'com-lihaoyi/mill' && (startsWith( github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' )
+    if: github.repository == 'com-lihaoyi/mill' && (startsWith( github.ref, 'refs/tags/') || (github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch' ) )
     needs: publish-sonatype
     runs-on: ubuntu-latest
 

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -71,7 +71,7 @@ jobs:
 
     runs-on: ubuntu-latest
     # when doing milestone builds, this may be true
-    continue-on-error: false
+    continue-on-error: true
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -3,6 +3,7 @@ name: Build and Release
 on:
   push:
   pull_request:
+  workflow_dispatch:
 
 jobs:
 
@@ -127,8 +128,8 @@ jobs:
         run: ${{ matrix.buildcmd }}
 
   publish-sonatype:
-    # when in master repo, publish all tags
-    if: github.repository == 'com-lihaoyi/mill' && startsWith( github.ref, 'refs/tags/')
+    # when in master repo, publish all tags and manual runs
+    if: github.repository == 'com-lihaoyi/mill' && (startsWith( github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' )
     needs: [test, test-windows, test-bin-compat]
 
     runs-on: ubuntu-latest
@@ -161,8 +162,8 @@ jobs:
       - run: ci/release-maven.sh
 
   release-github:
-    # when in master repo, publish all tags
-    if: github.repository == 'com-lihaoyi/mill' && startsWith( github.ref, 'refs/tags/')
+    # when in master repo, publish all tags and manual runs
+    if: github.repository == 'com-lihaoyi/mill' && (startsWith( github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' )
     needs: publish-sonatype
     runs-on: ubuntu-latest
 

--- a/build.sc
+++ b/build.sc
@@ -57,7 +57,7 @@ object Settings {
     "0.10.10",
     "0.11.0-M1"
   )
-  val mimaBaseVersions: Seq[String] = Seq()
+  val mimaBaseVersions: Seq[String] = Seq("0.11.0-M1")
 }
 
 object Deps {


### PR DESCRIPTION
* Re-enabled MiMa checks against previous milestone release
* Don't fail the Milestone build for MiMa checks
* Disables snapshot release for each commit, but enable manual workflow dispatch, to trigger a snapshot release (The idea is to have less frequent snapshot releases for maintenance commits)

Eventually, I'd like to have some kind of nightly-builds, so we only auto-create one snapshot per day. But I need to figure out, how to detect whether anything has changed in a github actions compatible way. Manually triggered snapshot releases should always work.