### PR TITLE
Add a documentation link to the coursier resolution failure output

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -413,6 +413,8 @@ object main extends MillModule {
            |  val millEmbeddedDeps = ${artifacts.map(artifact =>
             s""""${artifact.group}:${artifact.id}:${artifact.version}""""
           )}
+           |  /** Mill documentation url. */
+           |  val millDocUrl = "${Settings.docUrl}"
            |}
       """.stripMargin.trim
 

--- a/main/src/mill/modules/Jvm.scala
+++ b/main/src/mill/modules/Jvm.scala
@@ -548,7 +548,7 @@ object Jvm {
             |--------------------------------------------
             |
             |For additional information on library dependencies, see the docs at
-            |https://com-lihaoyi.github.io/mill/mill/Library_Dependencies.html""".stripMargin
+            |${mill.BuildInfo.millDocUrl}/mill/Library_Dependencies.html""".stripMargin
 
       val errLines = errs.map {
         case ((module, vsn), errMsgs) => s"  ${module.trim}:$vsn \n\t" + errMsgs.mkString("\n\t")

--- a/main/src/mill/modules/Jvm.scala
+++ b/main/src/mill/modules/Jvm.scala
@@ -543,10 +543,17 @@ object Jvm {
             |--------------------------------------------
             |""".stripMargin
 
+      val helpMessage =
+        s"""|
+            |--------------------------------------------
+            |
+            |For additional information on library dependencies, see the docs at
+            |https://com-lihaoyi.github.io/mill/mill/Library_Dependencies.html""".stripMargin
+
       val errLines = errs.map {
         case ((module, vsn), errMsgs) => s"  ${module.trim}:$vsn \n\t" + errMsgs.mkString("\n\t")
       }.mkString("\n")
-      val msg = header + errLines + "\n"
+      val msg = header + errLines + "\n" + helpMessage + "\n"
       Result.Failure(msg)
     } else {
 


### PR DESCRIPTION
I've created a small PR which adds a link to the CLI output whenever dependency resolution fails. I am happy to change the text if needed. Any feedback is welcome.

An example of the output:
<img width="716" alt="example" src="https://user-images.githubusercontent.com/1618616/210608506-0bdec16b-1136-480d-96f2-b1678620dcf6.png">

Small note:
I am not really an active contributor in the open source community (yet). I am trying it out, to see if I'll enjoy it. I've decided to just get started with this easy task. Again, any feedback is welcome!

Fixes #1401 