### PR TITLE
Dependency maintenance and bumps

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -21,5 +21,9 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-    
+
+      # We want to see the transmitted graph in the logs
+      - run:  mill --import ivy:io.chris-kipp::mill-github-dependency-graph::0.2.0 showNamed io.kipp.mill.github.dependency.graph.Graph/generate
+
+      # Actually upload the graph
       - uses: ckipp01/mill-dependency-submission@v1

--- a/build.sc
+++ b/build.sc
@@ -240,7 +240,7 @@ trait MillCoursierModule extends CoursierModule {
   val forcedVersions: Seq[(String, String, String)] = Seq(
     ("org.apache.ant", "ant", "1.10.12"),
     ("commons-io", "commons-io", "2.11.0"),
-    ("com.google.code.gson", "gson", "2.9.1"),
+    ("com.google.code.gson", "gson", "2.10.1"),
     ("com.google.protobuf", "protobuf-java", "3.21.8"),
     ("com.google.guava", "guava", "31.1-jre")
   )


### PR DESCRIPTION
- CI: show transmitted dependency graph
- Update transitive gson to 2.10.1
