### PR TITLE
Add `@nowarn` to generated ammonite script's `millDiscover` (Backport of #2242)

### DIFF
--- a/main/src/mill/main/MainRunner.scala
+++ b/main/src/mill/main/MainRunner.scala
@@ -220,6 +220,7 @@ class MainRunner(
            |  // doesn't get picked up during reflective child-module discovery
            |  def millSelf = Some(this)
            |
+           |  @_root_.scala.annotation.nowarn("cat=deprecation")
            |  implicit lazy val millDiscover: _root_.mill.define.Discover[this.type] = _root_.mill.define.Discover[this.type]
            |}
            |


### PR DESCRIPTION
This is useful when you enable deprecation warnings using:
```scala
interp.configureCompiler { c =>
  val settings = c.settings
  settings.nowarnings.value = false
  settings.maxwarns.value = 100
  settings.deprecation.value = true
}
```
Otherwise, it prints warnings for unused deprecated targets in `mill.main.MainModule`.
In `0.10.10` it prints:
```
/Users/lorenzo/scala/example-mill-4/build.sc:61: method all in trait MainModule is deprecated (since mill after 0.10.0-M3): Use the + separator, wildcards, or brace-expansion to specify multiple targets.
  implicit lazy val millDiscover: _root_.mill.define.Discover[this.type] = _root_.mill.define.Discover[this.type]
                                                                                                      ^
/Users/lorenzo/scala/example-mill-4/build.sc:61: method par in trait MainModule is deprecated (since mill after 0.10.0-M3): Use the + separator, wildcards, or brace-expansion to specify multiple targets.
  implicit lazy val millDiscover: _root_.mill.define.Discover[this.type] = _root_.mill.define.Discover[this.type]
```

Co-authored-by: Tobias Roeser <le.petit.fou@web.de>

Initial pull request: https://github.com/com-lihaoyi/mill/pull/2242