### PR TITLE
WIP: track public-ness of named tasks

### DIFF
--- a/contrib/scoverage/src/ScoverageReport.scala
+++ b/contrib/scoverage/src/ScoverageReport.scala
@@ -85,7 +85,8 @@ trait ScoverageReport extends Module {
       mill.main.ResolveTasks,
       evaluator,
       Seq(sources),
-      SelectMode.Single
+      SelectMode.Single,
+      filterPublic = true
     ) match {
       case Left(err) => throw new Exception(err)
       case Right(tasks) => tasks.asInstanceOf[Seq[Task[Seq[PathRef]]]]
@@ -94,7 +95,8 @@ trait ScoverageReport extends Module {
       mill.main.ResolveTasks,
       evaluator,
       Seq(dataTargets),
-      SelectMode.Single
+      SelectMode.Single,
+      filterPublic = true
     ) match {
       case Left(err) => throw new Exception(err)
       case Right(tasks) => tasks.asInstanceOf[Seq[Task[PathRef]]]

--- a/main/src/mill/main/MainScopts.scala
+++ b/main/src/mill/main/MainScopts.scala
@@ -15,7 +15,8 @@ object Tasks {
             mill.main.ResolveTasks,
             Evaluator.currentEvaluator.get,
             s,
-            SelectMode.Single
+            SelectMode.Single,
+            filterPublic = true
           ).map(x => Tasks(x.asInstanceOf[Seq[mill.define.NamedTask[T]]])),
         alwaysRepeatable = false,
         allowEmpty = false

--- a/main/src/mill/main/Resolve.scala
+++ b/main/src/mill/main/Resolve.scala
@@ -167,13 +167,15 @@ abstract class Resolve[R: ClassTag] {
       obj: Module,
       last: List[String],
       discover: Discover[_],
-      rest: Seq[String]
+      rest: Seq[String],
+      filterPublic: Boolean
   ): Either[String, Seq[R]]
   def endResolveLabel(
       obj: Module,
       last: String,
       discover: Discover[_],
-      rest: Seq[String]
+      rest: Seq[String],
+      filterPublic: Boolean
   ): Either[String, Seq[R]]
 
   def resolve(
@@ -181,14 +183,15 @@ abstract class Resolve[R: ClassTag] {
       obj: mill.Module,
       discover: Discover[_],
       rest: Seq[String],
-      remainingCrossSelectors: List[List[String]]
+      remainingCrossSelectors: List[List[String]],
+      filterPublic: Boolean
   ): Either[String, Seq[R]] = {
 
     remainingSelector match {
       case Segment.Cross(last) :: Nil =>
-        endResolveCross(obj, last.map(_.toString).toList, discover, rest)
+        endResolveCross(obj, last.map(_.toString).toList, discover, rest, filterPublic)
       case Segment.Label(last) :: Nil =>
-        endResolveLabel(obj, last, discover, rest)
+        endResolveLabel(obj, last, discover, rest, filterPublic)
 
       case head :: tail =>
         def recurse(
@@ -196,7 +199,7 @@ abstract class Resolve[R: ClassTag] {
             resolveFailureMsg: => Left[String, Nothing]
         ): Either[String, Seq[R]] = {
           val matching = searchModules
-            .map(m => resolve(tail, m, discover, rest, remainingCrossSelectors))
+            .map(m => resolve(tail, m, discover, rest, remainingCrossSelectors, filterPublic))
 
           matching match {
             case Seq(Left(err)) => Left(err)
@@ -231,13 +234,13 @@ abstract class Resolve[R: ClassTag] {
                   )
                 case "__" =>
                   Resolve.errorMsgLabel(
-                    singleModuleMeta(obj, discover, obj.millModuleSegments.value.isEmpty),
+                    singleModuleMeta(obj, discover, obj.millModuleSegments.value.isEmpty, filterPublic),
                     remainingSelector,
                     obj.millModuleSegments.value
                   )
                 case _ =>
                   Resolve.errorMsgLabel(
-                    singleModuleMeta(obj, discover, obj.millModuleSegments.value.isEmpty),
+                    singleModuleMeta(obj, discover, obj.millModuleSegments.value.isEmpty, filterPublic),
                     Seq(Segment.Label(singleLabel)),
                     obj.millModuleSegments.value
                   )

--- a/main/src/mill/main/ResolveSegments.scala
+++ b/main/src/mill/main/ResolveSegments.scala
@@ -9,7 +9,8 @@ object ResolveSegments extends Resolve[Segments] {
       obj: Module,
       last: List[String],
       discover: Discover[_],
-      rest: Seq[String]
+      rest: Seq[String],
+      filterPublic: Boolean
   ): Either[String, Seq[Segments]] = {
     obj match {
       case c: Cross[_] =>
@@ -37,11 +38,12 @@ object ResolveSegments extends Resolve[Segments] {
     }
   }
 
-  def endResolveLabel(
+  override def endResolveLabel(
       obj: Module,
       last: String,
       discover: Discover[_],
-      rest: Seq[String]
+      rest: Seq[String],
+      filterPublic: Boolean
   ): Either[String, Seq[Segments]] = {
     val target =
       obj
@@ -64,7 +66,7 @@ object ResolveSegments extends Resolve[Segments] {
     command orElse target orElse module match {
       case None =>
         Resolve.errorMsgLabel(
-          singleModuleMeta(obj, discover, obj.millModuleSegments.value.isEmpty),
+          singleModuleMeta(obj, discover, obj.millModuleSegments.value.isEmpty, filterPublic),
           Seq(Segment.Label(last)),
           obj.millModuleSegments.value
         )

--- a/main/src/mill/main/ResolveTasks.scala
+++ b/main/src/mill/main/ResolveTasks.scala
@@ -5,11 +5,12 @@ import mill.main.ResolveMetadata.singleModuleMeta
 
 object ResolveTasks extends Resolve[NamedTask[Any]] {
 
-  def endResolveCross(
+  override def endResolveCross(
       obj: Module,
       last: List[String],
       discover: Discover[_],
-      rest: Seq[String]
+      rest: Seq[String],
+      filterPublic: Boolean
   ): Either[String, Seq[NamedTask[Any]]] = {
     obj match {
       case _: Cross[Module] =>
@@ -29,11 +30,12 @@ object ResolveTasks extends Resolve[NamedTask[Any]] {
     }
   }
 
-  def endResolveLabel(
+  override def endResolveLabel(
       obj: Module,
       last: String,
       discover: Discover[_],
-      rest: Seq[String]
+      rest: Seq[String],
+      filterPublic: Boolean
   ): Either[String, Seq[NamedTask[Any]]] = last match {
     case "__" =>
       Right(
@@ -69,7 +71,7 @@ object ResolveTasks extends Resolve[NamedTask[Any]] {
         } match {
         case None =>
           Resolve.errorMsgLabel(
-            singleModuleMeta(obj, discover, obj.millModuleSegments.value.isEmpty),
+            singleModuleMeta(obj, discover, obj.millModuleSegments.value.isEmpty, filterPublic),
             Seq(Segment.Label(last)),
             obj.millModuleSegments.value
           )

--- a/main/test/src/main/MainTests.scala
+++ b/main/test/src/main/MainTests.scala
@@ -27,7 +27,8 @@ object MainTests extends TestSuite {
         module,
         module.millDiscover,
         Nil,
-        crossSelectors.toList
+        crossSelectors.toList,
+        filterPublic = false
       )
     } yield task
     // doesn't work for commands, don't know why


### PR DESCRIPTION
WIP. Track the public-ness of named tasks and restrict cli resolver to public tasks.

* Fixes https://github.com/com-lihaoyi/mill/issues/803

This breaks binary compatibility with older releases.


