### PR TITLE
Make ScalaJS and Native Tests modules extend ScalaModule

### DIFF
--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -18,12 +18,10 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
 
   def scalaJSVersion: T[String]
 
-  trait Tests extends TestScalaJSModule {
-    override def zincWorker = outer.zincWorker
-    override def scalaOrganization = outer.scalaOrganization()
-    override def scalaVersion = outer.scalaVersion()
+  trait Tests extends ScalaJSModuleTests
+
+  trait ScalaJSModuleTests extends ScalaModuleTests with TestScalaJSModule {
     override def scalaJSVersion = outer.scalaJSVersion()
-    override def moduleDeps = Seq(outer)
     override def moduleKind = outer.moduleKind()
     override def moduleSplitStyle = outer.moduleSplitStyle()
     override def esFeatures = outer.esFeatures()
@@ -254,7 +252,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
 
 }
 
-trait TestScalaJSModule extends ScalaJSModule with TestModule {
+trait TestScalaJSModule extends TestModule with ScalaJSModule {
 
   def scalaJSTestDeps = T {
     resolveDeps(T.task {

--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -252,7 +252,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
 
 }
 
-trait TestScalaJSModule extends TestModule with ScalaJSModule {
+trait TestScalaJSModule extends ScalaJSModule with TestModule {
 
   def scalaJSTestDeps = T {
     resolveDeps(T.task {

--- a/scalajslib/test/src/HelloJSWorldTests.scala
+++ b/scalajslib/test/src/HelloJSWorldTests.scala
@@ -72,6 +72,17 @@ object HelloJSWorldTests extends TestSuite {
         )
       }
     }
+
+    object inherited extends ScalaJSModule {
+      val (scala, scalaJS) = matrix.head
+      def scalacOptions = Seq("-deprecation")
+      def mandatoryScalacOptions = Seq("-mandatory")
+      def scalaOrganization = "org.example"
+      def scalaVersion = scala
+      def scalaJSVersion = scalaJS
+      object test extends Tests with TestModule.Utest
+    }
+
     override lazy val millDiscover = Discover[this.type]
   }
 
@@ -279,6 +290,22 @@ object HelloJSWorldTests extends TestSuite {
 
     test("run") {
       testAllMatrix((scala, scalaJS) => checkRun(scala, scalaJS))
+    }
+
+    def checkInheritedTargets[A](target: ScalaJSModule => T[A], expected: A) = {
+      val Right((mainResult, _)) = helloWorldEvaluator(target(HelloJSWorld.inherited))
+      val Right((testResult, _)) = helloWorldEvaluator(target(HelloJSWorld.inherited.test))
+      assert(mainResult == expected)
+      assert(testResult == expected)
+    }
+    test("test-scalacOptions") {
+      checkInheritedTargets(_.scalacOptions, Seq("-deprecation"))
+    }
+    test("test-mandatoryScalacOptions") {
+      checkInheritedTargets(_.mandatoryScalacOptions, Seq("-mandatory"))
+    }
+    test("test-scalaOrganization") {
+      checkInheritedTargets(_.scalaOrganization, "org.example")
     }
   }
 

--- a/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
+++ b/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
@@ -29,14 +29,12 @@ trait ScalaNativeModule extends ScalaModule { outer =>
   def scalaNativeVersion: T[String]
   override def platformSuffix = s"_native${scalaNativeBinaryVersion()}"
 
-  trait Tests extends TestScalaNativeModule {
-    override def zincWorker = outer.zincWorker
-    override def scalaOrganization = outer.scalaOrganization()
-    override def scalaVersion = outer.scalaVersion()
+  trait Tests extends ScalaNativeModuleTests
+
+  trait ScalaNativeModuleTests extends ScalaModuleTests with TestScalaNativeModule {
     override def scalaNativeVersion = outer.scalaNativeVersion()
     override def releaseMode = T { outer.releaseMode() }
     override def logLevel = outer.logLevel()
-    override def moduleDeps = Seq(outer)
   }
 
   def scalaNativeBinaryVersion =

--- a/scalanativelib/test/src/HelloNativeWorldTests.scala
+++ b/scalanativelib/test/src/HelloNativeWorldTests.scala
@@ -61,6 +61,15 @@ object HelloNativeWorldTests extends TestSuite {
         )
       }
     }
+    object inherited extends ScalaNativeModule {
+      val (scala, scalaNative, _) = matrix.head
+      def scalacOptions = Seq("-deprecation")
+      def scalaOrganization = "org.example"
+      def scalaVersion = scala
+      def scalaNativeVersion = scalaNative
+      object test extends Tests with TestModule.Utest
+    }
+
     override lazy val millDiscover: Discover[HelloNativeWorld.this.type] = Discover[this.type]
   }
 
@@ -212,6 +221,19 @@ object HelloNativeWorldTests extends TestSuite {
 
     "run" - {
       testAllMatrix((scala, scalaNative, releaseMode) => checkRun(scala, scalaNative, releaseMode))
+    }
+
+    def checkInheritedTargets[A](target: ScalaNativeModule => T[A], expected: A) = {
+      val Right((mainResult, _)) = helloWorldEvaluator(target(HelloNativeWorld.inherited))
+      val Right((testResult, _)) = helloWorldEvaluator(target(HelloNativeWorld.inherited.test))
+      assert(mainResult == expected)
+      assert(testResult == expected)
+    }
+    test("test-scalacOptions") {
+      checkInheritedTargets(_.scalacOptions, Seq("-deprecation"))
+    }
+    test("test-scalaOrganization") {
+      checkInheritedTargets(_.scalaOrganization, "org.example")
     }
   }
 


### PR DESCRIPTION
Some targets like `scalacOptions` were not inherited by `ScalaJSModule`'s `Tests` trait and by `ScalaNativeModule`'s `Tests` trait This fixes that by making it follow the same convention `ScalaModule` follows