### PR TITLE
Update default Mill version in wrapper script to 0.10.10 (Backport of #2279)

### DIFF
--- a/mill
+++ b/mill
@@ -7,7 +7,7 @@
 set -e
 
 if [ -z "${DEFAULT_MILL_VERSION}" ] ; then
-  DEFAULT_MILL_VERSION=0.10.9
+  DEFAULT_MILL_VERSION=0.10.10
 fi
 
 if [ -z "$MILL_VERSION" ] ; then


### PR DESCRIPTION
Original pull request: https://github.com/com-lihaoyi/mill/pull/2279
