### PR TITLE
Fix generation of library paths containing `:` for Windows (Backport of #2273)

### DIFF
--- a/scalalib/src/GenIdeaImpl.scala
+++ b/scalalib/src/GenIdeaImpl.scala
@@ -384,8 +384,17 @@ case class GenIdeaImpl(
       }
     }
 
-    // Hack so that Intellij does not complain about unresolved magic
-    // imports in build.sc when in fact they are resolved
+    /**
+     * We need to use a very specific library name format.
+     * This is required in order IntelliJ IDEA can recognize `$ivy` imports in `build.sc` files and doesn't show red code.
+     * This is how currently Ammonite integration is done in Scala Plugin for IntelliJ IDEA.
+     *
+     * @see [[https://github.com/JetBrains/intellij-scala/blob/idea223.x/scala/worksheet/src/org/jetbrains/plugins/scala/worksheet/ammonite/AmmoniteUtil.scala#L240]]
+     * @example {{{
+     *   //SBT: com.lihaoyi:ammonite-ops_2.13:2.2.0:jar
+     *   import $ivy.`com.lihaoyi::ammonite-ops:2.2.0
+     * }}}
+     */
     def sbtLibraryNameFromPom(pomPath: os.Path): String = {
       val pom = xmlParseDom(os.read(pomPath)).flatMap(Pom.project)
         .getOrElse(throw new RuntimeException(s"Could not parse pom file: ${pomPath}"))
@@ -400,7 +409,6 @@ case class GenIdeaImpl(
           // Default to the scala binary version used by mill itself
           s"${artifactId}_${BuildInfo.scalaVersion.split("[.]").take(2).mkString(".")}"
       }
-      // This needs to be "SBT: " to trigger some compatibility mode in Idea
       s"SBT: ${pom.module.organization.value}:$artifactWithScalaVersion:${pom.version}:jar"
     }
 
@@ -450,8 +458,12 @@ case class GenIdeaImpl(
       )
     )
 
-    def ideaifyLibraryName(name: String): String = {
-      name.replaceAll("""[-.]""", "_")
+    /**
+     * @note `:` in path isn't supported on Windows ~ https://github.com/com-lihaoyi/mill/issues/2243<br>
+     *       It comes from [[sbtLibraryNameFromPom]]
+     */
+    def libraryNameToFileSystemPathPart(name: String): String = {
+      name.replaceAll("""[-.:]""", "_")
     }
 
     val libraries: Seq[(SubPath, Elem)] =
@@ -480,7 +492,7 @@ case class GenIdeaImpl(
               case _ => None
             }
             Tuple2(
-              os.sub / "libraries" / s"${ideaifyLibraryName(name)}.xml",
+              os.sub / "libraries" / s"${libraryNameToFileSystemPathPart(name)}.xml",
               libraryXmlTemplate(
                 name = name,
                 path = resolved.path,

--- a/scalalib/test/resources/gen-idea-extended-hello-world/build.sc
+++ b/scalalib/test/resources/gen-idea-extended-hello-world/build.sc
@@ -1,3 +1,5 @@
+import $ivy.`org.scalameta::munit:0.7.29`
+
 import mill.api.PathRef
 import mill.scalalib
 import mill.define.Command

--- a/scalalib/test/resources/gen-idea-extended-hello-world/idea/libraries/SBT_ junit_junit_2_13_4_13_2_jar.xml
+++ b/scalalib/test/resources/gen-idea-extended-hello-world/idea/libraries/SBT_ junit_junit_2_13_4_13_2_jar.xml
@@ -1,0 +1,10 @@
+<component name="libraryTable">
+    <library name="SBT: junit:junit_2.13:4.13.2:jar">
+        <CLASSES>
+            <root url="jar://COURSIER_HOME/https/repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar!/"/>
+        </CLASSES>
+        <SOURCES>
+            <root url="jar://COURSIER_HOME/https/repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2-sources.jar!/"/>
+        </SOURCES>
+    </library>
+</component>

--- a/scalalib/test/resources/gen-idea-extended-hello-world/idea/libraries/SBT_ org_scalameta_munit_2_13_0_7_29_jar.xml
+++ b/scalalib/test/resources/gen-idea-extended-hello-world/idea/libraries/SBT_ org_scalameta_munit_2_13_0_7_29_jar.xml
@@ -1,0 +1,10 @@
+<component name="libraryTable">
+    <library name="SBT: org.scalameta:munit_2.13:0.7.29:jar">
+        <CLASSES>
+            <root url="jar://COURSIER_HOME/https/repo1.maven.org/maven2/org/scalameta/munit_2.13/0.7.29/munit_2.13-0.7.29.jar!/"/>
+        </CLASSES>
+        <SOURCES>
+            <root url="jar://COURSIER_HOME/https/repo1.maven.org/maven2/org/scalameta/munit_2.13/0.7.29/munit_2.13-0.7.29-sources.jar!/"/>
+        </SOURCES>
+    </library>
+</component>

--- a/scalalib/test/src/GenIdeaExtendedTests.scala
+++ b/scalalib/test/src/GenIdeaExtendedTests.scala
@@ -13,6 +13,8 @@ object GenIdeaExtendedTests extends ScriptTestSuite(false) {
   override def scriptSourcePath: Path =
     os.pwd / "scalalib" / "test" / "resources" / workspaceSlug
 
+  private val scalaVersionLibPart = "2_13_6"
+
   def tests: Tests = Tests {
     "genIdeaTests" - {
       val workspacePath = initWorkspace()
@@ -23,7 +25,11 @@ object GenIdeaExtendedTests extends ScriptTestSuite(false) {
         os.sub / "mill_modules" / "helloworld.test.iml",
         os.sub / "mill_modules" / "helloworld.subscala3.iml",
         os.sub / "mill_modules" / "mill-build.iml",
-        os.sub / "libraries" / "scala_library_2_13_6_jar.xml",
+        os.sub / "libraries" / s"scala_library_${scalaVersionLibPart}_jar.xml",
+        //NOTE: on IntelliJ Scala Plugin side there is a cosmetic issue: scala suffix is added even for Java libraries (notice `_2_13` suffix)
+        //In future it might be fixed and `GenIdea` will need to be updated
+        os.sub / "libraries" / "SBT_ junit_junit_2_13_4_13_2_jar.xml",
+        os.sub / "libraries" / "SBT_ org_scalameta_munit_2_13_0_7_29_jar.xml",
         os.sub / "modules.xml",
         os.sub / "misc.xml",
         os.sub / "compiler.xml"

--- a/scalalib/test/src/GenIdeaTests.scala
+++ b/scalalib/test/src/GenIdeaTests.scala
@@ -11,7 +11,12 @@ import utest.{Tests, _}
 
 object GenIdeaTests extends ScriptTestSuite(false) {
 
-  val scalaVersionLibPart = "2_12_5"
+  override def workspaceSlug: String = "gen-idea-hello-world"
+
+  override def scriptSourcePath: Path =
+    os.pwd / "scalalib" / "test" / "resources" / workspaceSlug
+
+  private val scalaVersionLibPart = "2_12_5"
 
   private val ignoreString = "<!-- IGNORE -->"
 
@@ -24,14 +29,16 @@ object GenIdeaTests extends ScriptTestSuite(false) {
       fileBaseDir: os.Path,
       resource: os.RelPath
   ): Unit = {
-    val resourcePath = s"${workspaceSlug}/idea/${resource}"
-    val generated = fileBaseDir / ".idea" / resource
-    val resourceString = scala.io.Source.fromResource(resourcePath).getLines().mkString("\n")
-    val generatedString = normaliseLibraryPaths(os.read(generated), fileBaseDir)
-    assert(!resourcePath.isEmpty)
+    val expectedResourcePath = s"$workspaceSlug/idea/$resource"
+    val actualResourcePath = fileBaseDir / ".idea" / resource
+
+    val expectedResourceString = scala.io.Source.fromResource(expectedResourcePath).getLines.mkString("\n")
+    val actualResourceString = normaliseLibraryPaths(os.read(actualResourcePath), fileBaseDir)
+
+    assert(expectedResourcePath.nonEmpty)
     assertPartialContentMatches(
-      found = generatedString,
-      expected = resourceString
+      found = actualResourceString,
+      expected = expectedResourceString
     )
   }
 
@@ -123,9 +130,4 @@ object GenIdeaTests extends ScriptTestSuite(false) {
       )
     in.replace(path, "COURSIER_HOME")
   }
-
-  override def workspaceSlug: String = "gen-idea-hello-world"
-
-  override def scriptSourcePath: Path =
-    os.pwd / "scalalib" / "test" / "resources" / workspaceSlug
 }


### PR DESCRIPTION
Original Pull Request: https://github.com/com-lihaoyi/mill/pull/2273
