### PR TITLE
SemanticDB for Java improvements

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -169,7 +169,7 @@ object Deps {
   val semanticDB = ivy"org.scalameta:::semanticdb-scalac:4.7.3"
   // when bumping this, also update SemanticDbJavaModule.scala to use -build-tool:mill
   // see https://github.com/sourcegraph/scip-java/pull/527
-  val semanticDbJava = ivy"com.sourcegraph:semanticdb-java:0.8.9"
+  val semanticDbJava = ivy"com.sourcegraph:semanticdb-java:0.8.10"
   val sourcecode = ivy"com.lihaoyi::sourcecode:0.3.0"
   val upickle = ivy"com.lihaoyi::upickle:3.0.0-M1"
   val utest = ivy"com.lihaoyi::utest:0.8.1"

--- a/build.sc
+++ b/build.sc
@@ -358,9 +358,9 @@ object main extends MillModule {
       Deps.sbtTestInterface
     )
   }
-  object util extends MillApiModule {
+  object util extends MillApiModule with MillAutoTestSetup {
     override def moduleDeps = Seq(api)
-    def ivyDeps = Agg(
+    override def ivyDeps = Agg(
       Deps.ammoniteTerminal,
       Deps.fansi
     )

--- a/main/core/src/mill/define/ParseArgs.scala
+++ b/main/core/src/mill/define/ParseArgs.scala
@@ -3,8 +3,7 @@ package mill.define
 import scala.annotation.tailrec
 
 import fastparse._
-import NoWhitespace._
-import mill.define.{Segment, Segments}
+import fastparse.NoWhitespace.noWhitespaceImplicit
 import mill.util.EitherOps
 
 sealed trait SelectMode

--- a/main/util/src/mill/util/Version.scala
+++ b/main/util/src/mill/util/Version.scala
@@ -2,6 +2,7 @@ package mill.util
 
 import mill.api.experimental
 
+@experimental
 class Version private (
     val major: Int,
     val minor: Option[Int],
@@ -46,6 +47,7 @@ final class IgnoreQualifierVersion(val underlying: Version) extends AnyVal {
     underlying.isNewerThan(other.underlying)(Version.IgnoreQualifierOrdering)
 }
 
+@experimental
 object Version {
 
   /**

--- a/main/util/src/mill/util/Version.scala
+++ b/main/util/src/mill/util/Version.scala
@@ -1,0 +1,161 @@
+package mill.util
+
+import mill.api.experimental
+
+class Version private (
+    val major: Int,
+    val minor: Option[Int],
+    val micro: Option[Int],
+    val qualifierWithSep: Option[(String, String)]
+) { outer =>
+
+  override def toString(): String = Seq(
+    Some(major),
+    minor.map("." + _),
+    micro.map("." + _),
+    qualifierWithSep.map(q => q._2 + q._1)
+  ).flatten.mkString
+
+  def isNewerThan(other: Version)(implicit ordering: Ordering[Version]): Boolean =
+    ordering.compare(this, other) > 0
+
+  def chooseNewest(versions: Version*)(implicit ordering: Ordering[Version]): Version =
+    versions.foldLeft(this)((best, next) =>
+      if (next.isNewerThan(best)) next else best
+    )
+
+  def isAtLeast(other: Version)(implicit ordering: Ordering[Version]): Boolean =
+    ordering.compare(this, other) >= 0
+
+  def asMaven: MavenVersion = new MavenVersion(this)
+  def asOsgiVersion: OsgiVersion = new OsgiVersion(this)
+  def asIgnoreQualifierVersion: IgnoreQualifierVersion = new IgnoreQualifierVersion(this)
+}
+
+final class MavenVersion(val underlying: Version) extends AnyVal {
+  def isNewerThan(other: MavenVersion): Boolean = {
+    underlying.isNewerThan(other.underlying)(Version.MavenOrdering)
+  }
+}
+final class OsgiVersion(val underlying: Version) extends AnyVal {
+  def isNewerThan(other: OsgiVersion): Boolean =
+    underlying.isNewerThan(other.underlying)(Version.OsgiOrdering)
+}
+final class IgnoreQualifierVersion(val underlying: Version) extends AnyVal {
+  def isNewerThan(other: IgnoreQualifierVersion): Boolean =
+    underlying.isNewerThan(other.underlying)(Version.IgnoreQualifierOrdering)
+}
+
+object Version {
+
+  /**
+   * Missing minor or micro versions are equal to zero,
+   * a qualifier is ignored,
+   * stable ordering.
+   */
+  object IgnoreQualifierOrdering extends Ordering[Version] {
+    override def compare(l: Version, r: Version): Int =
+      l.major - r.major match {
+        case 0 =>
+          l.minor.getOrElse(0) - r.minor.getOrElse(0) match {
+            case 0 => l.micro.getOrElse(0) - r.micro.getOrElse(0)
+            case x => x
+          }
+        case x => x
+      }
+  }
+
+  /**
+   * Missing minor or micro versions are equal to zero,
+   * a qualifier is higher that no qualifier,
+   * qualifiers are sorted alphabetically,
+   * stable ordering.
+   */
+  object OsgiOrdering extends Ordering[Version] {
+    override def compare(l: Version, r: Version): Int =
+      l.major - r.major match {
+        case 0 =>
+          l.minor.getOrElse(0) - r.minor.getOrElse(0) match {
+            case 0 =>
+              l.micro.getOrElse(0) - r.micro.getOrElse(0) match {
+                case 0 =>
+                  l.qualifierWithSep.map(_._1).getOrElse("")
+                    .compareTo(r.qualifierWithSep.map(_._1).getOrElse(""))
+                case x => x
+              }
+            case x => x
+          }
+        case x => x
+      }
+  }
+
+  /**
+   * Missing minor or micro versions are equal to zero,
+   * a qualifier is lower that no qualifier,
+   * qualifiers are sorted alphabetically,
+   * stable ordering.
+   *
+   * TODO: Review ordering wrt Maven 3
+   * TODO: also consider a coursier ordering
+   */
+  @experimental
+  object MavenOrdering extends Ordering[Version] {
+    override def compare(l: Version, r: Version): Int =
+      l.major - r.major match {
+        case 0 =>
+          l.minor.getOrElse(0) - r.minor.getOrElse(0) match {
+            case 0 =>
+              l.micro.getOrElse(0) - r.micro.getOrElse(0) match {
+                case 0 =>
+                  (l.qualifierWithSep.isDefined, r.qualifierWithSep.isDefined) match {
+                    case (false, false) => 0
+                    case (true, false) => -1
+                    case (false, true) => 1
+                    case (true, true) =>
+                      l.qualifierWithSep.map(_._1).getOrElse("")
+                        .compareTo(r.qualifierWithSep.map(_._1).getOrElse(""))
+                  }
+                case x => x
+              }
+            case x => x
+          }
+        case x => x
+      }
+  }
+
+  private val Pattern = raw"""(\d+)(\.(\d+)(\.(\d+))?)?(([._\-+])(.+))?""".r
+
+  def parse(version: String): Version = {
+    version match {
+      case Pattern(major, _, minor, _, micro, _, qualifierSep, qualifier) =>
+        new Version(
+          major.toInt,
+          Option(minor).map(_.toInt),
+          Option(micro).map(_.toInt),
+          Option(qualifier).map(q => (q, qualifierSep))
+        )
+    }
+  }
+
+  def chooseNewest(
+      version: String,
+      versions: String*
+  )(implicit
+      ordering: Ordering[Version]
+  ): String =
+    chooseNewest(parse(version), versions.map(parse): _*).toString()
+
+  def chooseNewest(
+      version: Version,
+      versions: Version*
+  )(implicit
+      ordering: Ordering[Version]
+  ): Version =
+    versions.foldLeft(version)((best, next) =>
+      if (next.isNewerThan(best)) next else best
+    )
+
+  def isAtLeast(version: String, atLeast: String)(implicit ordering: Ordering[Version]): Boolean =
+    Version.parse(version).isAtLeast(Version.parse(atLeast))
+
+}

--- a/main/util/test/src/mill/util/VersionTests.scala
+++ b/main/util/test/src/mill/util/VersionTests.scala
@@ -1,0 +1,92 @@
+package mill.util
+
+import utest.{assert, TestSuite, Tests, test}
+
+import scala.math.random
+
+object VersionTests extends TestSuite {
+
+  val tests = Tests {
+    test("ordering") {
+      val versions = Seq(
+        "1.0",
+        "1.2.3.alpha1",
+        "1",
+        "0.10.0",
+        "1.0.0",
+        "1_1",
+        "0.10.0-M2",
+        "1.0.0-alpha+001",
+        "1.0.0+20130313144700",
+        "1.0.0-beta+exp.sha.5114f85",
+        "1.0.0+21AF26D3----117B344092BD"
+      )
+      test("ignoreQualifier") {
+        val ordering = Version.IgnoreQualifierOrdering
+        val input =
+          versions.map(Version.parse).sorted(ordering).map(_.toString())
+        val expected = Seq(
+          "0.10.0",
+          "0.10.0-M2",
+          "1.0",
+          "1",
+          "1.0.0",
+          "1_1",
+          "1.0.0-alpha+001",
+          "1.0.0+20130313144700",
+          "1.0.0-beta+exp.sha.5114f85",
+          "1.0.0+21AF26D3----117B344092BD",
+          "1.2.3.alpha1"
+        )
+        assert(input == expected)
+      }
+      test("maven") {
+        val ordering = Version.MavenOrdering
+        val input = versions.map(Version.parse).sorted(ordering).map(_.toString())
+        val expected = Seq(
+          "0.10.0-M2",
+          "0.10.0",
+          "1_1",
+          "1.0.0+20130313144700",
+          "1.0.0+21AF26D3----117B344092BD",
+          "1.0.0-alpha+001",
+          "1.0.0-beta+exp.sha.5114f85",
+          "1.0",
+          "1",
+          "1.0.0",
+          "1.2.3.alpha1"
+        )
+        assert(input == expected)
+      }
+      test("osgi") {
+        val ordering = Version.OsgiOrdering
+        val input = versions.map(Version.parse).sorted(ordering).map(_.toString())
+        val expected = Seq(
+          "0.10.0",
+          "0.10.0-M2",
+          "1.0",
+          "1",
+          "1.0.0",
+          "1_1",
+          "1.0.0+20130313144700",
+          "1.0.0+21AF26D3----117B344092BD",
+          "1.0.0-alpha+001",
+          "1.0.0-beta+exp.sha.5114f85",
+          "1.2.3.alpha1"
+        )
+        assert(input == expected)
+      }
+    }
+    test("Version.isAtLeast(String, String)") {
+      test("ignoreQualifier") {
+        implicit val ordering = Version.IgnoreQualifierOrdering
+        assert(
+          Version.isAtLeast("0.8.9", "0.7.10") == true,
+          Version.isAtLeast("0.8.9", "0.8.10") == false,
+          Version.isAtLeast("0.8.10", "0.8.10") == true,
+          Version.isAtLeast("0.8.10", "0.9.10") == false
+        )
+      }
+    }
+  }
+}

--- a/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
+++ b/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
@@ -120,10 +120,12 @@ trait SemanticDbJavaModule extends CoursierModule { hostModule: JavaModule =>
         )
         else List.empty
 
-      val more = if (T.log.debugEnabled) " -verbose" else ""
+      val isNewEnough =
+        Version.isAtLeast(semanticDbJavaVersion(), "0.8.10")(Version.IgnoreQualifierOrdering)
+      val buildTool = s" -build-tool:${if (isNewEnough) "mill" else "sbt"}"
+      val verbose = if (T.log.debugEnabled) " -verbose" else ""
       m.javacOptions() ++ Seq(
-        // FIXME: change to -build-tool:mill once semanticdb-java after 0.8.9 comes out
-        s"-Xplugin:semanticdb -sourceroot:${T.workspace} -targetroot:${T.dest / "classes"} -build-tool:sbt" + more
+        s"-Xplugin:semanticdb -sourceroot:${T.workspace} -targetroot:${T.dest / "classes"}${buildTool}${verbose}"
       ) ++ extracJavacExports
 
     }

--- a/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
+++ b/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
@@ -3,6 +3,7 @@ package mill.scalalib
 import mill.api.{PathRef, Result, experimental}
 import mill.define.{Input, Target, Task}
 import mill.scalalib.api.ZincWorkerUtil
+import mill.util.Version
 import mill.{Agg, BuildInfo, T}
 
 import scala.util.Properties
@@ -11,23 +12,21 @@ import scala.util.Properties
 trait SemanticDbJavaModule extends CoursierModule { hostModule: JavaModule =>
 
   def semanticDbVersion: Input[String] = T.input {
-    T.env.getOrElse[String](
+    val builtin = SemanticDbJavaModule.buildTimeSemanticDbVersion
+    val requested = T.env.getOrElse[String](
       "SEMANTICDB_VERSION",
-      SemanticDbJavaModule.contextSemanticDbVersion.get()
-        .getOrElse(
-          SemanticDbJavaModule.buildTimeSemanticDbVersion
-        )
+      SemanticDbJavaModule.contextSemanticDbVersion.get().getOrElse(builtin)
     )
+    Version.chooseNewest(requested, builtin)(Version.IgnoreQualifierOrdering)
   }
 
   def semanticDbJavaVersion: Input[String] = T.input {
-    T.env.getOrElse[String](
+    val builtin = SemanticDbJavaModule.buildTimeJavaSemanticDbVersion
+    val requested = T.env.getOrElse[String](
       "JAVASEMANTICDB_VERSION",
-      SemanticDbJavaModule.contextJavaSemanticDbVersion.get()
-        .getOrElse(
-          SemanticDbJavaModule.buildTimeJavaSemanticDbVersion
-        )
+      SemanticDbJavaModule.contextJavaSemanticDbVersion.get().getOrElse(builtin)
     )
+    Version.chooseNewest(requested, builtin)(Version.IgnoreQualifierOrdering)
   }
 
   def semanticDbScalaVersion = hostModule match {


### PR DESCRIPTION
This change updates semanticdb-java to 0.8.10.

As this version properly added support for the `-build-tool:mill` option, we enable it, but only, if we really use this version (or newer) at runtime.

The thing is: Metals is sending us its preferred versions for semanticdb-scalac and semanticdb-java. There is a high change, that Mill was build with another version. (When I introduced the semanticdb-java support, Metals came with a much outdated version, resulting in  build failures due to these unexpected low version during development.) Before, Mill used the version from the context (requested by Metals), even if the built-time version was newer. Now, we compare the built-time version with the context version and use whatever is newer. This should be the safest option, but there is still a chance of producing too new semanticdb data, which is not understood by the consumer (Metals). I don't know, how to better check for compatibility though.

I added a new `mill.util.Version` class, which is meant to help with comparing versions.
