### PR TITLE
Fetch more tooling deps in `prepareOffine`

### DIFF
--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -1,6 +1,7 @@
 package mill
 package scalajslib
 
+import mainargs.Flag
 import mill.api.{Loose, PathRef, Result, internal}
 import mill.scalalib.api.ZincWorkerUtil
 import mill.scalalib.Lib.resolveDependencies
@@ -234,6 +235,17 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
 
   /** Name patterns for output. */
   def scalaJSOutputPatterns: Target[OutputPatterns] = T { OutputPatterns.Defaults }
+
+  override def prepareOffline(all: Flag): Command[Unit] = {
+    val tasks =
+      if (all.value) Seq(scalaJSToolsClasspath)
+      else Seq()
+    T.command {
+      super.prepareOffline(all)()
+      T.sequence(tasks)()
+      ()
+    }
+  }
 
   @internal
   override def bspBuildTargetData: Task[Option[(String, AnyRef)]] = T.task {

--- a/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
+++ b/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
@@ -1,9 +1,10 @@
 package mill
 package scalanativelib
 
+import mainargs.Flag
 import mill.api.Loose.Agg
 import mill.api.{Result, internal}
-import mill.define.{Target, Task}
+import mill.define.{Command, Target, Task}
 import mill.modules.Jvm
 import mill.scalalib.api.ZincWorkerUtil
 import mill.scalalib.bsp.{ScalaBuildTarget, ScalaPlatform}
@@ -306,6 +307,21 @@ trait ScalaNativeModule extends ScalaModule { outer =>
       dep.exclude(exclusions: _*)
     }
   }
+
+  override def prepareOffline(all: Flag): Command[Unit] = {
+    val tasks =
+      if (all.value) Seq(
+        scalaNativeWorkerClasspath,
+        bridgeFullClassPath
+      )
+      else Seq()
+    T.command {
+      super.prepareOffline(all)()
+      T.sequence(tasks)()
+      ()
+    }
+  }
+
 }
 
 trait TestScalaNativeModule extends ScalaNativeModule with TestModule {


### PR DESCRIPTION
`ScalaJSModule` and `ScalaNativeModule` did not fetched their worker and tooling classpaths previously.
