### PR TITLE
Support reporting of all compilation problems

### DIFF
--- a/scalalib/api/src/mill/scalalib/api/ZincWorkerApi.scala
+++ b/scalalib/api/src/mill/scalalib/api/ZincWorkerApi.scala
@@ -14,7 +14,8 @@ trait ZincWorkerApi {
       sources: Agg[os.Path],
       compileClasspath: Agg[os.Path],
       javacOptions: Seq[String],
-      reporter: Option[CompileProblemReporter]
+      reporter: Option[CompileProblemReporter],
+      reportOldProblems: Boolean
   )(implicit ctx: ZincWorkerApi.Ctx): mill.api.Result[CompilationResult]
 
   /** Compile a mixed Scala/Java or Scala-only project */
@@ -28,7 +29,8 @@ trait ZincWorkerApi {
       scalacOptions: Seq[String],
       compilerClasspath: Agg[PathRef],
       scalacPluginClasspath: Agg[PathRef],
-      reporter: Option[CompileProblemReporter]
+      reporter: Option[CompileProblemReporter],
+      reportOldProblems: Boolean
   )(implicit ctx: ZincWorkerApi.Ctx): mill.api.Result[CompilationResult]
 
   def discoverMainClasses(compilationResult: CompilationResult)(implicit

--- a/scalalib/api/src/mill/scalalib/api/ZincWorkerApi.scala
+++ b/scalalib/api/src/mill/scalalib/api/ZincWorkerApi.scala
@@ -15,7 +15,7 @@ trait ZincWorkerApi {
       compileClasspath: Agg[os.Path],
       javacOptions: Seq[String],
       reporter: Option[CompileProblemReporter],
-      reportOldProblems: Boolean
+      reportCachedProblems: Boolean
   )(implicit ctx: ZincWorkerApi.Ctx): mill.api.Result[CompilationResult]
 
   /** Compile a mixed Scala/Java or Scala-only project */
@@ -30,7 +30,7 @@ trait ZincWorkerApi {
       compilerClasspath: Agg[PathRef],
       scalacPluginClasspath: Agg[PathRef],
       reporter: Option[CompileProblemReporter],
-      reportOldProblems: Boolean
+      reportCachedProblems: Boolean
   )(implicit ctx: ZincWorkerApi.Ctx): mill.api.Result[CompilationResult]
 
   def discoverMainClasses(compilationResult: CompilationResult)(implicit

--- a/scalalib/src/JavaModule.scala
+++ b/scalalib/src/JavaModule.scala
@@ -275,6 +275,8 @@ trait JavaModule
     Lib.findSourceFiles(allSources(), Seq("java")).map(PathRef(_))
   }
 
+  def zincReportOldProblems: T[Boolean] = T(false)
+
   /**
    * Compiles the current module to generate compiled classfiles/bytecode.
    *
@@ -285,11 +287,12 @@ trait JavaModule
     zincWorker
       .worker()
       .compileJava(
-        upstreamCompileOutput(),
-        allSourceFiles().map(_.path),
-        compileClasspath().map(_.path),
-        javacOptions(),
-        T.reporter.apply(hashCode)
+        upstreamCompileOutput = upstreamCompileOutput(),
+        sources = allSourceFiles().map(_.path),
+        compileClasspath = compileClasspath().map(_.path),
+        javacOptions = javacOptions(),
+        reporter = T.reporter.apply(hashCode),
+        reportOldProblems = zincReportOldProblems()
       )
   }
 

--- a/scalalib/src/JavaModule.scala
+++ b/scalalib/src/JavaModule.scala
@@ -279,7 +279,7 @@ trait JavaModule
    * If `true`, we always show problems (errors, warnings, infos) found in all source files, even when they have not changed since the previous incremental compilation.
    * When `false`, we report only problems for files which we re-compiled.
    */
-  def zincReportOldProblems: T[Boolean] = T(false)
+  def zincReportCachedProblems: T[Boolean] = T(false)
 
   /**
    * Compiles the current module to generate compiled classfiles/bytecode.
@@ -296,7 +296,7 @@ trait JavaModule
         compileClasspath = compileClasspath().map(_.path),
         javacOptions = javacOptions(),
         reporter = T.reporter.apply(hashCode),
-        reportOldProblems = zincReportOldProblems()
+        reportCachedProblems = zincReportCachedProblems()
       )
   }
 

--- a/scalalib/src/JavaModule.scala
+++ b/scalalib/src/JavaModule.scala
@@ -275,6 +275,10 @@ trait JavaModule
     Lib.findSourceFiles(allSources(), Seq("java")).map(PathRef(_))
   }
 
+  /**
+   * If `true`, we always show problems (errors, warnings, infos) found in all source files, even when they have not changed since the previous incremental compilation.
+   * When `false`, we report only problems for files which we re-compiled.
+   */
   def zincReportOldProblems: T[Boolean] = T(false)
 
   /**

--- a/scalalib/src/ScalaModule.scala
+++ b/scalalib/src/ScalaModule.scala
@@ -227,7 +227,8 @@ trait ScalaModule extends JavaModule { outer =>
         scalacOptions = allScalacOptions(),
         compilerClasspath = scalaCompilerClasspath(),
         scalacPluginClasspath = scalacPluginClasspath(),
-        reporter = T.reporter.apply(hashCode)
+        reporter = T.reporter.apply(hashCode),
+        reportOldProblems = zincReportOldProblems()
       )
   }
 

--- a/scalalib/src/ScalaModule.scala
+++ b/scalalib/src/ScalaModule.scala
@@ -228,7 +228,7 @@ trait ScalaModule extends JavaModule { outer =>
         compilerClasspath = scalaCompilerClasspath(),
         scalacPluginClasspath = scalacPluginClasspath(),
         reporter = T.reporter.apply(hashCode),
-        reportOldProblems = zincReportOldProblems()
+        reportCachedProblems = zincReportCachedProblems()
       )
   }
 

--- a/scalalib/src/ScalaModule.scala
+++ b/scalalib/src/ScalaModule.scala
@@ -3,7 +3,16 @@ package scalalib
 
 import scala.annotation.nowarn
 import mill.define.{Command, Sources, Target, Task}
-import mill.api.{DummyInputStream, PathRef, Result, internal}
+import mill.api.{
+  CompileProblemReporter,
+  DummyInputStream,
+  PathRef,
+  Problem,
+  ProblemPosition,
+  Result,
+  Severity,
+  internal
+}
 import mill.modules.Jvm
 import mill.modules.Jvm.createJar
 import mill.api.Loose.Agg
@@ -13,6 +22,12 @@ import scala.jdk.CollectionConverters._
 import mainargs.Flag
 import mill.scalalib.bsp.{BspBuildTarget, BspModule, ScalaBuildTarget, ScalaPlatform}
 import mill.scalalib.dependency.versions.{ValidVersion, Version}
+import os.Path
+import upickle.default.{ReadWriter, macroRW}
+
+import java.io.File
+import scala.collection.immutable.Queue
+import scala.util.Try
 
 /**
  * Core configuration required to compile a single Scala compilation target
@@ -215,7 +230,55 @@ trait ScalaModule extends JavaModule { outer =>
         |You may want to select another version. Upgrading to a more recent Scala version is recommended.
         |For details, see: https://github.com/sbt/zinc/issues/1010""".stripMargin
     )
-    zincWorker
+
+    import ScalaModule.{LastCompilation, ProblemImpl}
+
+    val previousProblemFile = T.dest / "zinc-reports.json"
+    val lastCompilation = if (os.exists(previousProblemFile)) {
+      Try {
+        upickle.default.read[LastCompilation](os.read.stream(previousProblemFile))
+      }.recover {
+        e =>
+          T.log.debug(s"Could not read last compilation problems, starting fresh. Cause: ${e}")
+          LastCompilation(0, Seq(), Seq())
+      }.get
+    } else LastCompilation(0, Seq(), Seq())
+
+    val compileIncrement = lastCompilation.increment + 1
+
+    //    case class FileProblems(file: Path, problems: Seq[(String, ProblemImpl)])
+
+    //    val problems = Map[String, FileProblems]
+    T.log.debug(s"Previous problems: ${lastCompilation}")
+
+    class RecordingReporter(underlying: Option[CompileProblemReporter])
+        extends CompileProblemReporter {
+      var visitedFiles: Queue[os.Path] = Queue()
+      var problems: Queue[ProblemImpl] = Queue()
+      override def start(): Unit = underlying.foreach(_.start())
+      override def logError(problem: Problem): Unit = {
+        problems = problems.appended(ProblemImpl(compileIncrement, problem))
+        underlying.foreach(_.logError(problem))
+      }
+      override def logWarning(problem: Problem): Unit = {
+        problems = problems.appended(ProblemImpl(compileIncrement, problem))
+        underlying.foreach(_.logWarning(problem))
+      }
+      override def logInfo(problem: Problem): Unit = {
+        problems = problems.appended(ProblemImpl(compileIncrement, problem))
+        underlying.foreach(_.logInfo(problem))
+      }
+      override def fileVisited(file: os.Path): Unit = {
+        visitedFiles = visitedFiles.appended(file)
+        underlying.foreach(_.fileVisited(file))
+      }
+      override def printSummary(): Unit = underlying.foreach(_.printSummary())
+      override def finish(): Unit = underlying.foreach(_.finish())
+    }
+
+    val reporter = new RecordingReporter(T.reporter.apply(hashCode))
+
+    val result = zincWorker
       .worker()
       .compileMixed(
         upstreamCompileOutput = upstreamCompileOutput(),
@@ -227,8 +290,46 @@ trait ScalaModule extends JavaModule { outer =>
         scalacOptions = allScalacOptions(),
         compilerClasspath = scalaCompilerClasspath(),
         scalacPluginClasspath = scalacPluginClasspath(),
-        reporter = T.reporter.apply(hashCode)
+        reporter = Some(reporter)
       )
+
+    val newVisitedFiles = reporter.visitedFiles.toSeq.distinct
+
+    val lastProblemCount = lastCompilation.lastProblems.size
+    // filter all problems, which are released to files we re-visited
+    val cleanedCachedProblems = lastCompilation.lastProblems.toSeq
+      .filter(p =>
+        p.position.sourceFile.isEmpty || !newVisitedFiles.contains(
+          os.Path(p.position.sourceFile.get)
+        )
+      )
+
+    T.log.debug(
+      s"${cleanedCachedProblems.size} of ${lastProblemCount} cached problems from previous compilation: ${cleanedCachedProblems}"
+    )
+
+    T.log.debug(s"${newVisitedFiles.size} recorded visited files: ${newVisitedFiles}")
+    T.log.debug(s"${reporter.problems.size} recorded new file problems: ${reporter.problems.toSeq}")
+    // TODO: show those recorded problems
+
+    if (cleanedCachedProblems.nonEmpty) {
+      val reportStream = T.log.errorStream
+      reportStream.println("Previous compile problems:")
+      cleanedCachedProblems.foreach { p =>
+        reportStream.println(p.formatted)
+      }
+
+    }
+
+    val curCompilation = LastCompilation(
+      compileIncrement,
+      lastVisitedFiles = lastCompilation.lastVisitedFiles ++ reporter.visitedFiles,
+      lastProblems = cleanedCachedProblems ++ reporter.problems
+    )
+
+    os.write.over(previousProblemFile, upickle.default.write(curCompilation, 2))
+
+    result
   }
 
   /** the path to the compiled classes without forcing the compilation. */
@@ -524,6 +625,107 @@ trait ScalaModule extends JavaModule { outer =>
         jvmBuildTarget = None
       )
     ))
+  }
+
+}
+
+object ScalaModule {
+
+  case class LastCompilation(
+      increment: Int,
+      lastVisitedFiles: Seq[os.Path],
+      lastProblems: Seq[ProblemImpl]
+  )
+
+  object LastCompilation {
+    //    implicit val pathJsonRW: ReadWriter[os.Path] = mill.api.JsonFormatters.pathReadWrite
+//    implicit val pathJsonRW: ReadWriter[os.Path] = upickle.default.readwriter[String].bimap[os.Path](
+//      _.toString(),
+//      os.Path(_)
+//    )
+    implicit def jsonRW: ReadWriter[LastCompilation] = macroRW
+  }
+
+  case class ProblemImpl(
+      increment: Int,
+      override val category: String,
+      override val severity: Severity,
+      override val message: String,
+      override val position: ProblemPositionImpl
+  ) extends Problem {
+    def formatted: String = {
+      // TODO: colors
+      s"[${severity match {
+          case mill.api.Info => "info"
+          case mill.api.Warn => "warn"
+          case mill.api.Error => "error"
+        }}] ${position.sourceFile.getOrElse("")}:${position.line.getOrElse("")}:${position.offset.getOrElse("")}: ${message}"
+    }
+  }
+
+  object ProblemImpl {
+    def apply(increment: Int, other: Problem): ProblemImpl =
+      ProblemImpl(
+        increment = increment,
+        category = other.category,
+        severity = other.severity,
+        message = other.message,
+        position = ProblemPositionImpl(other.position)
+      )
+
+    implicit val jsonRW: ReadWriter[ProblemImpl] = macroRW
+    implicit val severityJsonRW: ReadWriter[Severity] = upickle.default.readwriter[String].bimap(
+      {
+        case mill.api.Info => "Info"
+        case mill.api.Warn => "Warn"
+        case mill.api.Error => "Error"
+      },
+      {
+        case "Info" => mill.api.Info
+        case "Warn" => mill.api.Warn
+        case "Error" => mill.api.Error
+      }
+    )
+
+  }
+
+  case class ProblemPositionImpl(
+      override val line: Option[Int],
+      override val lineContent: String,
+      override val offset: Option[Int],
+      override val pointer: Option[Int],
+      override val pointerSpace: Option[String],
+      override val sourcePath: Option[String],
+      override val sourceFile: Option[File],
+      override val startOffset: Option[Int],
+      override val endOffset: Option[Int],
+      override val startLine: Option[Int],
+      override val startColumn: Option[Int],
+      override val endLine: Option[Int],
+      override val endColumn: Option[Int]
+  ) extends ProblemPosition
+
+  object ProblemPositionImpl {
+    def apply(other: ProblemPosition): ProblemPositionImpl = ProblemPositionImpl(
+      line = other.line,
+      lineContent = other.lineContent,
+      offset = other.offset,
+      pointer = other.pointer,
+      pointerSpace = other.pointerSpace,
+      sourcePath = other.sourcePath,
+      sourceFile = other.sourceFile,
+      startOffset = other.startOffset,
+      endOffset = other.endOffset,
+      startLine = other.startLine,
+      startColumn = other.startColumn,
+      endLine = other.endLine,
+      endColumn = other.endColumn
+    )
+    implicit val jsonRW: ReadWriter[ProblemPositionImpl] = macroRW
+    implicit val fileJsonRW: ReadWriter[File] = upickle.default.readwriter[String].bimap(
+      _.toString(),
+      new File(_)
+    )
   }
 
 }

--- a/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
+++ b/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
@@ -199,7 +199,7 @@ trait SemanticDbJavaModule extends CoursierModule { hostModule: JavaModule =>
               compilerClasspath = m.scalaCompilerClasspath(),
               scalacPluginClasspath = semanticDbPluginClasspath(),
               reporter = T.reporter.apply(hashCode),
-              reportOldProblems = zincReportOldProblems()
+              reportCachedProblems = zincReportCachedProblems()
             )
             .map(r => copySemanticdbFiles(r.classes.path, T.workspace, T.dest / "data"))
         }
@@ -219,7 +219,7 @@ trait SemanticDbJavaModule extends CoursierModule { hostModule: JavaModule =>
               compileClasspath = compileClasspathTask(m)().map(_.path),
               javacOptions = javacOpts,
               reporter = T.reporter.apply(m.hashCode()),
-              reportOldProblems = zincReportOldProblems()
+              reportCachedProblems = zincReportCachedProblems()
             ).map(r => copySemanticdbFiles(r.classes.path, T.workspace, T.dest / "data"))
         }
     }

--- a/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
+++ b/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
@@ -198,7 +198,8 @@ trait SemanticDbJavaModule extends CoursierModule { hostModule: JavaModule =>
               scalacOptions = scalacOptions,
               compilerClasspath = m.scalaCompilerClasspath(),
               scalacPluginClasspath = semanticDbPluginClasspath(),
-              reporter = T.reporter.apply(hashCode)
+              reporter = T.reporter.apply(hashCode),
+              reportOldProblems = false
             )
             .map(r => copySemanticdbFiles(r.classes.path, T.workspace, T.dest / "data"))
         }
@@ -213,11 +214,12 @@ trait SemanticDbJavaModule extends CoursierModule { hostModule: JavaModule =>
 
           zincWorker.worker()
             .compileJava(
-              upstreamCompileOutput(),
-              allSourceFiles().map(_.path),
-              compileClasspathTask(m)().map(_.path),
-              javacOpts,
-              T.reporter.apply(m.hashCode())
+              upstreamCompileOutput = upstreamCompileOutput(),
+              sources = allSourceFiles().map(_.path),
+              compileClasspath = compileClasspathTask(m)().map(_.path),
+              javacOptions = javacOpts,
+              reporter = T.reporter.apply(m.hashCode()),
+              reportOldProblems = false
             ).map(r => copySemanticdbFiles(r.classes.path, T.workspace, T.dest / "data"))
         }
     }

--- a/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
+++ b/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
@@ -199,7 +199,7 @@ trait SemanticDbJavaModule extends CoursierModule { hostModule: JavaModule =>
               compilerClasspath = m.scalaCompilerClasspath(),
               scalacPluginClasspath = semanticDbPluginClasspath(),
               reporter = T.reporter.apply(hashCode),
-              reportOldProblems = false
+              reportOldProblems = zincReportOldProblems()
             )
             .map(r => copySemanticdbFiles(r.classes.path, T.workspace, T.dest / "data"))
         }
@@ -219,7 +219,7 @@ trait SemanticDbJavaModule extends CoursierModule { hostModule: JavaModule =>
               compileClasspath = compileClasspathTask(m)().map(_.path),
               javacOptions = javacOpts,
               reporter = T.reporter.apply(m.hashCode()),
-              reportOldProblems = false
+              reportOldProblems = zincReportOldProblems()
             ).map(r => copySemanticdbFiles(r.classes.path, T.workspace, T.dest / "data"))
         }
     }

--- a/scalalib/worker/src/mill/scalalib/worker/RecordingReporter.scala
+++ b/scalalib/worker/src/mill/scalalib/worker/RecordingReporter.scala
@@ -1,0 +1,52 @@
+package mill.scalalib.worker
+
+import mill.api.internal
+import sbt.internal.inc.Analysis
+import xsbti.compile.CompileAnalysis
+
+import scala.collection.mutable
+
+/**
+ * A zinc reporter which records reported problems
+ * and is able to log all not already reported problems later
+ * via [[logOldProblems(CompileAnalysis)]].
+ */
+@internal
+trait RecordingReporter extends xsbti.Reporter {
+  // `lazy` to allow initialization before first access
+  private lazy val seenProblems: mutable.Set[xsbti.Problem] = mutable.Set()
+
+  abstract override def log(problem: xsbti.Problem): Unit = {
+    super.log(problem)
+    seenProblems.add(problem)
+  }
+
+  abstract override def reset(): Unit = {
+    super.reset()
+    seenProblems.clear()
+  }
+
+  // we need to override this, to allow the call from [[printOldProblems]]
+  abstract override def printSummary(): Unit = super.printSummary()
+
+  /**
+   * Log problem contained in the given [[CompileAnalysis]]
+   * but not already reported.
+   */
+  def logOldProblems(compileAnalysis: CompileAnalysis): Unit = {
+    val problems = compileAnalysis match {
+      // Looks like the info we need is only contained in Analysis
+      case a: Analysis =>
+        a.infos.allInfos.values.flatMap(i =>
+          i.getReportedProblems ++ i.getUnreportedProblems
+        )
+      case _ => Nil
+    }
+    val oldProblems = problems.filterNot(seenProblems)
+    if (oldProblems.nonEmpty) {
+      oldProblems.foreach(log)
+      // show a summary again
+      super.printSummary()
+    }
+  }
+}


### PR DESCRIPTION
In it's incremental nature, Zinc does only report problems for re-compiled files,
which leads to situations, where you only see a glimpse of the overall compiler warnings.

Now, we use the Zinc internal analysis to recover all found problems. We also record all already shown problems and simply log the not shown but still valid problems after the compilation finished.

This behavior can be configured by the new target `JavaModule.zincReportCachedProblems: T[Boolean]`. It defaults to `false` to keep backward-compatible output. 
