### PR TITLE
Changed encoding of inner `Tests` modules

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -294,7 +294,8 @@ trait MillScalaModule extends ScalaModule with MillCoursierModule { outer =>
     if (this == main) Seq(main)
     else Seq(this, main.test)
 
-  trait MillScalaModuleTests extends ScalaModuleTests with MillCoursierModule
+  type MillScalaModuleTests = Tests
+  trait Tests extends ScalaModuleTests with MillCoursierModule
       with WithMillCompiler {
     override def forkArgs = T {
       Seq(
@@ -316,7 +317,6 @@ trait MillScalaModule extends ScalaModule with MillCoursierModule { outer =>
     override def ivyDeps: T[Agg[Dep]] = T { super.ivyDeps() ++ outer.testIvyDeps() }
     override def testFramework = "mill.UTestFramework"
   }
-  trait Tests extends MillScalaModuleTests
 }
 
 /** A MillScalaModule with default set up test module. */
@@ -324,7 +324,7 @@ trait MillAutoTestSetup extends MillScalaModule {
   // instead of `object test` which can't be overridden, we hand-made a val+class singleton
   /** Default tests module. */
   val test = new Tests(implicitly)
-  class Tests(ctx0: mill.define.Ctx) extends mill.Module()(ctx0) with super.MillScalaModuleTests
+  class Tests(ctx0: mill.define.Ctx) extends mill.Module()(ctx0) with MillScalaModuleTests
 }
 
 /** Published module which does not contain strictly handled API. */
@@ -1015,7 +1015,8 @@ object integration extends MillScalaModule {
     T { PathRef(installLocalTask(binFile = T.task((T.dest / name).toString()))()) }
   }
 
-  trait ITests extends super.Tests {
+  type ITests = Tests
+  trait Tests extends MillScalaModuleTests {
     def workspaceDir = T.persistent { PathRef(T.dest) }
     override def forkArgs: Target[Seq[String]] = T {
       super.forkArgs() ++

--- a/contrib/playlib/src/mill/playlib/PlayModule.scala
+++ b/contrib/playlib/src/mill/playlib/PlayModule.scala
@@ -5,7 +5,9 @@ import mill.scalalib._
 import mill.{Agg, T}
 
 trait PlayApiModule extends Dependencies with Router with Server {
-  trait PlayTests extends super.Tests with TestModule.ScalaTest {
+
+  type PlayTests = Tests
+  trait Tests extends ScalaModuleTests with TestModule.ScalaTest {
     override def ivyDeps = T {
       val scalatestPlusPlayVersion = playMinorVersion() match {
         case Versions.PLAY_2_6 => "3.1.3"

--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -19,6 +19,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
 
   def scalaJSVersion: T[String]
 
+  type ScalaJSModuleTests = Tests
   trait Tests extends ScalaModuleTests with TestScalaJSModule {
     override def scalaJSVersion = outer.scalaJSVersion()
     override def moduleKind = outer.moduleKind()
@@ -27,7 +28,6 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
     override def jsEnvConfig = outer.jsEnvConfig()
     override def scalaJSOptimizer = outer.scalaJSOptimizer()
   }
-  type ScalaJSModuleTests = Tests
 
   def scalaJSBinaryVersion = T { ZincWorkerUtil.scalaJSBinaryVersion(scalaJSVersion()) }
 

--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -19,9 +19,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
 
   def scalaJSVersion: T[String]
 
-  trait Tests extends ScalaJSModuleTests
-
-  trait ScalaJSModuleTests extends ScalaModuleTests with TestScalaJSModule {
+  trait Tests extends ScalaModuleTests with TestScalaJSModule {
     override def scalaJSVersion = outer.scalaJSVersion()
     override def moduleKind = outer.moduleKind()
     override def moduleSplitStyle = outer.moduleSplitStyle()
@@ -29,6 +27,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
     override def jsEnvConfig = outer.jsEnvConfig()
     override def scalaJSOptimizer = outer.scalaJSOptimizer()
   }
+  type ScalaJSModuleTests = Tests
 
   def scalaJSBinaryVersion = T { ZincWorkerUtil.scalaJSBinaryVersion(scalaJSVersion()) }
 

--- a/scalalib/src/CrossSbtModule.scala
+++ b/scalalib/src/CrossSbtModule.scala
@@ -11,6 +11,8 @@ trait CrossSbtModule extends SbtModule with CrossModuleBase { outer =>
       PathRef(millSourcePath / "src" / "main" / s"scala-$s")
     )
   }
+
+  type CrossSbtModuleTests = Tests
   trait Tests extends SbtModuleTests {
     override def millSourcePath = outer.millSourcePath
     override def sources = T.sources {
@@ -19,5 +21,4 @@ trait CrossSbtModule extends SbtModule with CrossModuleBase { outer =>
       )
     }
   }
-  type CrossSbtModuleTests = Tests
 }

--- a/scalalib/src/CrossSbtModule.scala
+++ b/scalalib/src/CrossSbtModule.scala
@@ -11,7 +11,7 @@ trait CrossSbtModule extends SbtModule with CrossModuleBase { outer =>
       PathRef(millSourcePath / "src" / "main" / s"scala-$s")
     )
   }
-  trait CrossSbtModuleTests extends SbtModuleTests {
+  trait Tests extends SbtModuleTests {
     override def millSourcePath = outer.millSourcePath
     override def sources = T.sources {
       super.sources() ++ scalaVersionDirectoryNames.map(s =>
@@ -19,5 +19,5 @@ trait CrossSbtModule extends SbtModule with CrossModuleBase { outer =>
       )
     }
   }
-  trait Tests extends CrossSbtModuleTests
+  type CrossSbtModuleTests = Tests
 }

--- a/scalalib/src/CrossScalaModule.scala
+++ b/scalalib/src/CrossScalaModule.scala
@@ -17,11 +17,11 @@ trait CrossScalaModule extends ScalaModule with CrossModuleBase { outer =>
       scalaVersionDirectoryNames.map(s => PathRef(millSourcePath / s"src-$s"))
   }
 
+  type CrossScalaModuleTests = Tests
   trait Tests extends ScalaModuleTests {
     override def sources = T.sources {
       super.sources() ++
         scalaVersionDirectoryNames.map(s => PathRef(millSourcePath / s"src-$s"))
     }
   }
-  type CrossScalaModuleTests = Tests
 }

--- a/scalalib/src/CrossScalaModule.scala
+++ b/scalalib/src/CrossScalaModule.scala
@@ -17,11 +17,11 @@ trait CrossScalaModule extends ScalaModule with CrossModuleBase { outer =>
       scalaVersionDirectoryNames.map(s => PathRef(millSourcePath / s"src-$s"))
   }
 
-  trait CrossScalaModuleTests extends ScalaModuleTests {
+  trait Tests extends ScalaModuleTests {
     override def sources = T.sources {
       super.sources() ++
         scalaVersionDirectoryNames.map(s => PathRef(millSourcePath / s"src-$s"))
     }
   }
-  trait Tests extends CrossScalaModuleTests
+  type CrossScalaModuleTests = Tests
 }

--- a/scalalib/src/JavaModule.scala
+++ b/scalalib/src/JavaModule.scala
@@ -33,6 +33,7 @@ trait JavaModule
 
   def zincWorker: ZincWorkerModule = mill.scalalib.ZincWorkerModule
 
+  type JavaModuleTests = Tests
   trait Tests extends TestModule {
     override def moduleDeps: Seq[JavaModule] = Seq(outer)
     override def repositoriesTask: Task[Seq[Repository]] = outer.repositoriesTask
@@ -43,7 +44,6 @@ trait JavaModule
     override def skipIdea: Boolean = outer.skipIdea
     override def runUseArgsFile: T[Boolean] = super.runUseArgsFile
   }
-  type JavaModuleTests = Tests
 
   def defaultCommandName() = "run"
   def resolvePublishDependency: Task[Dep => publish.Dependency] = T.task {

--- a/scalalib/src/JavaModule.scala
+++ b/scalalib/src/JavaModule.scala
@@ -33,7 +33,7 @@ trait JavaModule
 
   def zincWorker: ZincWorkerModule = mill.scalalib.ZincWorkerModule
 
-  trait JavaModuleTests extends TestModule {
+  trait Tests extends TestModule {
     override def moduleDeps: Seq[JavaModule] = Seq(outer)
     override def repositoriesTask: Task[Seq[Repository]] = outer.repositoriesTask
     override def resolutionCustomizer: Task[Option[coursier.Resolution => coursier.Resolution]] =
@@ -43,7 +43,7 @@ trait JavaModule
     override def skipIdea: Boolean = outer.skipIdea
     override def runUseArgsFile: T[Boolean] = super.runUseArgsFile
   }
-  trait Tests extends JavaModuleTests
+  type JavaModuleTests = Tests
 
   def defaultCommandName() = "run"
   def resolvePublishDependency: Task[Dep => publish.Dependency] = T.task {

--- a/scalalib/src/MavenModule.scala
+++ b/scalalib/src/MavenModule.scala
@@ -16,6 +16,7 @@ trait MavenModule extends JavaModule { outer =>
     millSourcePath / "src" / "main" / "resources"
   }
 
+  type MavenModuleTests = Tests
   trait Tests extends JavaModuleTests {
     override def millSourcePath = outer.millSourcePath
     override def intellijModulePath = outer.millSourcePath / "src" / "test"
@@ -27,5 +28,4 @@ trait MavenModule extends JavaModule { outer =>
       millSourcePath / "src" / "test" / "resources"
     }
   }
-  type MavenModuleTests = Tests
 }

--- a/scalalib/src/MavenModule.scala
+++ b/scalalib/src/MavenModule.scala
@@ -16,7 +16,7 @@ trait MavenModule extends JavaModule { outer =>
     millSourcePath / "src" / "main" / "resources"
   }
 
-  trait MavenModuleTests extends JavaModuleTests {
+  trait Tests extends JavaModuleTests {
     override def millSourcePath = outer.millSourcePath
     override def intellijModulePath = outer.millSourcePath / "src" / "test"
 
@@ -27,5 +27,5 @@ trait MavenModule extends JavaModule { outer =>
       millSourcePath / "src" / "test" / "resources"
     }
   }
-  trait Tests extends MavenModuleTests
+  type MavenModuleTests = Tests
 }

--- a/scalalib/src/SbtModule.scala
+++ b/scalalib/src/SbtModule.scala
@@ -12,11 +12,11 @@ trait SbtModule extends ScalaModule with MavenModule {
     millSourcePath / "src" / "main" / "java"
   )
 
+  type SbtModuleTests = Tests
   trait Tests extends ScalaModuleTests with MavenModuleTests {
     override def sources = T.sources(
       millSourcePath / "src" / "test" / "scala",
       millSourcePath / "src" / "test" / "java"
     )
   }
-  type SbtModuleTests = Tests
 }

--- a/scalalib/src/SbtModule.scala
+++ b/scalalib/src/SbtModule.scala
@@ -12,11 +12,11 @@ trait SbtModule extends ScalaModule with MavenModule {
     millSourcePath / "src" / "main" / "java"
   )
 
-  trait SbtModuleTests extends ScalaModuleTests with MavenModuleTests {
+  trait Tests extends ScalaModuleTests with MavenModuleTests {
     override def sources = T.sources(
       millSourcePath / "src" / "test" / "scala",
       millSourcePath / "src" / "test" / "java"
     )
   }
-  trait Tests extends SbtModuleTests
+  type SbtModuleTests = Tests
 }

--- a/scalalib/src/ScalaModule.scala
+++ b/scalalib/src/ScalaModule.scala
@@ -19,7 +19,7 @@ import mill.scalalib.dependency.versions.{ValidVersion, Version}
  */
 trait ScalaModule extends JavaModule { outer =>
 
-  trait ScalaModuleTests extends JavaModuleTests with ScalaModule {
+  trait Tests extends JavaModuleTests with ScalaModule {
     override def scalaOrganization: T[String] = outer.scalaOrganization()
     override def scalaVersion: T[String] = outer.scalaVersion()
     override def scalacPluginIvyDeps = outer.scalacPluginIvyDeps
@@ -27,8 +27,7 @@ trait ScalaModule extends JavaModule { outer =>
     override def scalacOptions = outer.scalacOptions
     override def mandatoryScalacOptions = outer.mandatoryScalacOptions
   }
-
-  trait Tests extends ScalaModuleTests
+  type ScalaModuleTests = Tests
 
   /**
    * What Scala organization to use

--- a/scalalib/src/ScalaModule.scala
+++ b/scalalib/src/ScalaModule.scala
@@ -19,6 +19,7 @@ import mill.scalalib.dependency.versions.{ValidVersion, Version}
  */
 trait ScalaModule extends JavaModule { outer =>
 
+  type ScalaModuleTests = Tests
   trait Tests extends JavaModuleTests with ScalaModule {
     override def scalaOrganization: T[String] = outer.scalaOrganization()
     override def scalaVersion: T[String] = outer.scalaVersion()
@@ -27,7 +28,6 @@ trait ScalaModule extends JavaModule { outer =>
     override def scalacOptions = outer.scalacOptions
     override def mandatoryScalacOptions = outer.mandatoryScalacOptions
   }
-  type ScalaModuleTests = Tests
 
   /**
    * What Scala organization to use

--- a/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
+++ b/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
@@ -30,12 +30,12 @@ trait ScalaNativeModule extends ScalaModule { outer =>
   def scalaNativeVersion: T[String]
   override def platformSuffix = s"_native${scalaNativeBinaryVersion()}"
 
+  type ScalaNativeModuleTests = Tests
   trait Tests extends ScalaModuleTests with TestScalaNativeModule {
     override def scalaNativeVersion = outer.scalaNativeVersion()
     override def releaseMode = T { outer.releaseMode() }
     override def logLevel = outer.logLevel()
   }
-  type ScalaNativeModuleTests = Tests
 
   def scalaNativeBinaryVersion =
     T { ZincWorkerUtil.scalaNativeBinaryVersion(scalaNativeVersion()) }

--- a/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
+++ b/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
@@ -30,13 +30,12 @@ trait ScalaNativeModule extends ScalaModule { outer =>
   def scalaNativeVersion: T[String]
   override def platformSuffix = s"_native${scalaNativeBinaryVersion()}"
 
-  trait Tests extends ScalaNativeModuleTests
-
-  trait ScalaNativeModuleTests extends ScalaModuleTests with TestScalaNativeModule {
+  trait Tests extends ScalaModuleTests with TestScalaNativeModule {
     override def scalaNativeVersion = outer.scalaNativeVersion()
     override def releaseMode = T { outer.releaseMode() }
     override def logLevel = outer.logLevel()
   }
+  type ScalaNativeModuleTests = Tests
 
   def scalaNativeBinaryVersion =
     T { ZincWorkerUtil.scalaNativeBinaryVersion(scalaNativeVersion()) }


### PR DESCRIPTION
## TL;DR

I now switched back to name all derivations `Tests` again, but also keep a local type alias with an unique name.
As these types are unique names, it's easy to reference each derivation in the hierearchy exactly, by still keeping the convenience of a simple `object test extends Tests`.


```scala
object foo extends ScalaModule {

  // using the convenient `Tests` trait
  object test extends Tests
  // or the more explicit unique name
  object test2 extends ScalaModuleTests

  // this allows explicit reference to super trait
  object test3 extends JavaModuleTests {
    // ...
  }

}
```

## Details

In very older Mill versions, all inner test modules had the same `Tests` class name.
This made recognizing as user and referencing concrete super test modules rather hard.
Therefore, we started to give each derived instance an unique name (e.g. `ScalaModuleTests`) and created a new local `Tests` trait also deriving this unique trait.
Although convenient, it led to compiler warning, that a derived `Tests` trait shadows its super `Tests` trait.
In Scala 3, this will even be a error, hence I tried to find another encoding.

Making just the `Tests` trait an type alias to the uniquely named trait is not possible, as the compiler will error out with an `incompatible type in overriding` message.

