### PR TITLE
Call overridden task from `ScalaModule.mapDependencies` (Backport of #2338)

### DIFF
--- a/scalalib/src/JavaModule.scala
+++ b/scalalib/src/JavaModule.scala
@@ -33,10 +33,10 @@ trait JavaModule
     override def repositoriesTask: Task[Seq[Repository]] = outer.repositoriesTask
     override def resolutionCustomizer: Task[Option[coursier.Resolution => coursier.Resolution]] =
       outer.resolutionCustomizer
-    override def javacOptions: T[Seq[String]] = outer.javacOptions
+    override def javacOptions: Target[Seq[String]] = T { outer.javacOptions() }
     override def zincWorker: ZincWorkerModule = outer.zincWorker
     override def skipIdea: Boolean = outer.skipIdea
-    override def runUseArgsFile: T[Boolean] = super.runUseArgsFile
+    override def runUseArgsFile: Target[Boolean] = T { outer.runUseArgsFile() }
   }
   trait Tests extends JavaModuleTests
 

--- a/scalalib/src/MavenModule.scala
+++ b/scalalib/src/MavenModule.scala
@@ -18,7 +18,7 @@ trait MavenModule extends JavaModule { outer =>
 
   trait MavenModuleTests extends JavaModuleTests {
     override def millSourcePath = outer.millSourcePath
-    override def intellijModulePath = outer.millSourcePath / "src" / "test"
+    override def intellijModulePath: os.Path = outer.millSourcePath / "src" / "test"
 
     override def sources = T.sources(
       millSourcePath / "src" / "test" / "java"

--- a/scalalib/src/ScalaModule.scala
+++ b/scalalib/src/ScalaModule.scala
@@ -23,12 +23,12 @@ import mill.scalalib.dependency.versions.{ValidVersion, Version}
 trait ScalaModule extends JavaModule with SemanticDbJavaModule { outer =>
 
   trait ScalaModuleTests extends JavaModuleTests with ScalaModule {
-    override def scalaOrganization: T[String] = outer.scalaOrganization()
-    override def scalaVersion: T[String] = outer.scalaVersion()
-    override def scalacPluginIvyDeps = outer.scalacPluginIvyDeps
-    override def scalacPluginClasspath = outer.scalacPluginClasspath
-    override def scalacOptions = outer.scalacOptions
-    override def mandatoryScalacOptions = outer.mandatoryScalacOptions
+    override def scalaOrganization: Target[String] = outer.scalaOrganization()
+    override def scalaVersion: Target[String] = outer.scalaVersion()
+    override def scalacPluginIvyDeps: Target[Agg[Dep]] = outer.scalacPluginIvyDeps()
+    override def scalacPluginClasspath: Target[Agg[PathRef]] = outer.scalacPluginClasspath()
+    override def scalacOptions: Target[Seq[String]] = outer.scalacOptions()
+    override def mandatoryScalacOptions: Target[Seq[String]] = outer.mandatoryScalacOptions()
   }
 
   trait Tests extends ScalaModuleTests
@@ -58,7 +58,7 @@ trait ScalaModule extends JavaModule with SemanticDbJavaModule { outer =>
   def scalaVersion: T[String]
 
   override def mapDependencies: Task[coursier.Dependency => coursier.Dependency] = T.task {
-    d: coursier.Dependency =>
+    super.mapDependencies().andThen { d: coursier.Dependency =>
       val artifacts =
         if (ZincWorkerUtil.isDotty(scalaVersion()))
           Set("dotty-library", "dotty-compiler")
@@ -74,6 +74,7 @@ trait ScalaModule extends JavaModule with SemanticDbJavaModule { outer =>
           )
         )
           .withVersion(scalaVersion())
+    }
   }
 
   override def resolveCoursierDependency: Task[Dep => coursier.Dependency] =

--- a/scalalib/src/publish/settings.scala
+++ b/scalalib/src/publish/settings.scala
@@ -13,7 +13,7 @@ case class Artifact(group: String, id: String, version: String) {
 }
 
 object Artifact {
-  def fromDepJava(dep: Dep) = {
+  def fromDepJava(dep: Dep): Dependency = {
     assert(dep.cross.isConstant, s"Not a Java dependency: $dep")
     fromDep(dep, "", "", "")
   }


### PR DESCRIPTION
Otherwise, we loose settings mixed in before `ScalaModule`.

Original Pull Request: https://github.com/com-lihaoyi/mill/pull/2338
