### PR TITLE
Doc: Remove extra parenthesis and fixed typo

### DIFF
--- a/docs/antora/modules/ROOT/pages/Plugin_BuildInfo.adoc
+++ b/docs/antora/modules/ROOT/pages/Plugin_BuildInfo.adoc
@@ -17,7 +17,7 @@ object project extends BuildInfo {
   val name = "poject-name"
   def  buildInfoMembers: T[Map[String, String]] = T {
     Map(
-      "name" -> name),
+      "name" -> name,
       "scalaVersion" -> scalaVersion()
     )
   }

--- a/docs/antora/modules/ROOT/pages/Plugin_BuildInfo.adoc
+++ b/docs/antora/modules/ROOT/pages/Plugin_BuildInfo.adoc
@@ -14,7 +14,7 @@ import $ivy.`com.lihaoyi::mill-contrib-buildinfo:`
 import mill.contrib.buildinfo.BuildInfo
 
 object project extends BuildInfo {
-  val name = "poject-name"
+  val name = "project-name"
   def  buildInfoMembers: T[Map[String, String]] = T {
     Map(
       "name" -> name,


### PR DESCRIPTION
Small typo on the docs in the BuildInfo page