### PR TITLE
Improve binary compatibility

### DIFF
--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
@@ -66,40 +66,12 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
 
   private def isScala2: Task[Boolean] = T.task { !isScala3() }
 
-  /** Binary compatibility shim. */
-  @deprecated("Use scoverageRuntimeDeps instead.", "Mill after 0.10.7")
-  def scoverageRuntimeDep: T[Dep] = T {
-    T.log.error(
-      "scoverageRuntimeDep is no longer used. To customize your module, use scoverageRuntimeDeps."
-    )
-    val result: Result[Dep] = if (isScala3()) {
-      Result.Failure("When using Scala 3 there is no external runtime dependency")
-    } else {
-      scoverageRuntimeDeps().toIndexedSeq.head
-    }
-    result
-  }
-
   def scoverageRuntimeDeps: T[Agg[Dep]] = T {
     if (isScala3()) {
       Agg.empty
     } else {
       Agg(ivy"org.scoverage::scalac-scoverage-runtime:${outer.scoverageVersion()}")
     }
-  }
-
-  /** Binary compatibility shim. */
-  @deprecated("Use scoveragePluginDeps instead.", "Mill after 0.10.7")
-  def scoveragePluginDep: T[Dep] = T {
-    T.log.error(
-      "scoveragePluginDep is no longer used. To customize your module, use scoverageRuntimeDeps."
-    )
-    val result: Result[Dep] = if (isScala3()) {
-      Result.Failure("When using Scala 3 there is no external plugin dependency")
-    } else {
-      scoveragePluginDeps().toIndexedSeq.head
-    }
-    result
   }
 
   def scoveragePluginDeps: T[Agg[Dep]] = T {

--- a/main/core/src/mill/define/Cross.scala
+++ b/main/core/src/mill/define/Cross.scala
@@ -1,4 +1,5 @@
 package mill.define
+
 import language.experimental.macros
 import scala.reflect.ClassTag
 import scala.reflect.macros.blackbox
@@ -24,8 +25,8 @@ object Cross {
 
       val instance = c.Expr[(Product, mill.define.Ctx, Seq[Product]) => T](
         q"""{ (v, ctx0, vs) => new $tpe(..$argTupleValues){
-          override def millOuterCtx = ctx0.copy(
-            crossInstances = vs.map(v => new $tpe(..$argTupleValues))
+          override def millOuterCtx = ctx0.withCrossInstances(
+            vs.map(v => new $tpe(..$argTupleValues))
           )
         } }"""
       )

--- a/main/core/src/mill/define/Cross.scala
+++ b/main/core/src/mill/define/Cross.scala
@@ -70,11 +70,10 @@ class Cross[T <: Module: ClassTag](cases: Any*)(implicit ci: Cross.Factory[T], c
     val relPath = ctx.segment.pathSegments
     val sub = ci.make(
       c,
-      ctx.copy(
-        segments = ctx.segments ++ Seq(ctx.segment),
-        millSourcePath = ctx.millSourcePath / relPath,
-        segment = Segment.Cross(crossValues)
-      ),
+      ctx
+        .withSegments(ctx.segments ++ Seq(ctx.segment))
+        .withMillSourcePath(ctx.millSourcePath / relPath)
+        .withSegment(Segment.Cross(crossValues)),
       products
     )
     (crossValues, sub)

--- a/main/core/src/mill/define/Cross.scala
+++ b/main/core/src/mill/define/Cross.scala
@@ -4,7 +4,10 @@ import scala.reflect.ClassTag
 import scala.reflect.macros.blackbox
 
 object Cross {
-  case class Factory[T](make: (Product, mill.define.Ctx, Seq[Product]) => T)
+  case class Factory[T](make: (Product, mill.define.Ctx, Seq[Product]) => T) {
+    private def copy[T](make: (Product, mill.define.Ctx, Seq[Product]) => T = make): Factory[T] =
+      new Factory[T](make)
+  }
 
   object Factory {
     implicit def make[T]: Factory[T] = macro makeImpl[T]
@@ -29,6 +32,9 @@ object Cross {
 
       reify { mill.define.Cross.Factory[T](instance.splice) }
     }
+
+    private def unapply[T](factory: Factory[T]): Option[(Product, Ctx, Seq[Product]) => T] =
+      Some(factory.make)
   }
 
   trait Resolver[-T <: Module] {

--- a/main/core/src/mill/define/Ctx.scala
+++ b/main/core/src/mill/define/Ctx.scala
@@ -41,6 +41,7 @@ case class Ctx private (
     crossInstances
   )
   def withCrossInstances(crossInstances: Seq[AnyRef]): Ctx = copy(crossInstances = crossInstances)
+  def withSegments(segments: Segments): Ctx = copy(segments = segments)
 }
 
 object Ctx {

--- a/main/core/src/mill/define/Ctx.scala
+++ b/main/core/src/mill/define/Ctx.scala
@@ -17,7 +17,7 @@ case class Ctx private (
     enclosingCls: Class[_],
     crossInstances: Seq[AnyRef]
 ) {
-  private[mill] def copy(
+  private def copy(
       enclosing: String = enclosing,
       lineNum: Int = lineNum,
       segment: Segment = segment,
@@ -40,6 +40,7 @@ case class Ctx private (
     enclosingCls,
     crossInstances
   )
+  def withCrossInstances(crossInstances: Seq[AnyRef]): Ctx = copy(crossInstances = crossInstances)
 }
 
 object Ctx {

--- a/main/core/src/mill/define/Ctx.scala
+++ b/main/core/src/mill/define/Ctx.scala
@@ -17,7 +17,7 @@ case class Ctx private (
     enclosingCls: Class[_],
     crossInstances: Seq[AnyRef]
 ) {
-  def copy(
+  private[mill] def copy(
       enclosing: String = enclosing,
       lineNum: Int = lineNum,
       segment: Segment = segment,

--- a/main/core/src/mill/define/Ctx.scala
+++ b/main/core/src/mill/define/Ctx.scala
@@ -41,6 +41,8 @@ case class Ctx private (
     crossInstances
   )
   def withCrossInstances(crossInstances: Seq[AnyRef]): Ctx = copy(crossInstances = crossInstances)
+  def withMillSourcePath(millSourcePath: os.Path): Ctx = copy(millSourcePath = millSourcePath)
+  def withSegment(segment: Segment): Ctx = copy(segment = segment)
   def withSegments(segments: Segments): Ctx = copy(segments = segments)
 }
 

--- a/main/core/src/mill/define/Ctx.scala
+++ b/main/core/src/mill/define/Ctx.scala
@@ -1,9 +1,11 @@
 package mill.define
 
+import os.Path
+
 import scala.annotation.implicitNotFound
 
 @implicitNotFound("Modules, Targets and Commands can only be defined within a mill Module")
-case class Ctx(
+case class Ctx private (
     enclosing: String,
     lineNum: Int,
     segment: Segment,
@@ -14,7 +16,31 @@ case class Ctx(
     fileName: String,
     enclosingCls: Class[_],
     crossInstances: Seq[AnyRef]
-) {}
+) {
+  def copy(
+      enclosing: String = enclosing,
+      lineNum: Int = lineNum,
+      segment: Segment = segment,
+      millSourcePath: os.Path = millSourcePath,
+      segments: Segments = segments,
+      external: Boolean = external,
+      foreign: Option[Segments] = foreign,
+      fileName: String = fileName,
+      enclosingCls: Class[_] = enclosingCls,
+      crossInstances: Seq[AnyRef] = crossInstances
+  ): Ctx = new Ctx(
+    enclosing,
+    lineNum,
+    segment,
+    millSourcePath,
+    segments,
+    external,
+    foreign,
+    fileName,
+    enclosingCls,
+    crossInstances
+  )
+}
 
 object Ctx {
 
@@ -33,6 +59,7 @@ object Ctx {
    * Marker for the foreign module segments of a module to be used implicitly by [[Ctx]].
    */
   final case class Foreign(value: Option[Segments])
+
   implicit def make(implicit
       millModuleEnclosing0: sourcecode.Enclosing,
       millModuleLine0: sourcecode.Line,
@@ -57,4 +84,51 @@ object Ctx {
       Seq()
     )
   }
+
+  def apply(
+      enclosing: String,
+      lineNum: Int,
+      segment: Segment,
+      millSourcePath: os.Path,
+      segments: Segments,
+      external: Boolean,
+      foreign: Option[Segments],
+      fileName: String,
+      enclosingCls: Class[_],
+      crossInstances: Seq[AnyRef]
+  ): Ctx = new Ctx(
+    enclosing,
+    lineNum,
+    segment,
+    millSourcePath,
+    segments,
+    external,
+    foreign,
+    fileName,
+    enclosingCls,
+    crossInstances
+  )
+  private def unapply(ctx: Ctx): Option[(
+      String,
+      Int,
+      Segment,
+      Path,
+      Segments,
+      Boolean,
+      Option[Segments],
+      String,
+      Class[_],
+      Seq[AnyRef]
+  )] = Some((
+    ctx.enclosing,
+    ctx.lineNum,
+    ctx.segment,
+    ctx.millSourcePath,
+    ctx.segments,
+    ctx.external,
+    ctx.foreign,
+    ctx.fileName,
+    ctx.enclosingCls,
+    ctx.crossInstances
+  ))
 }

--- a/main/core/src/mill/define/Discover.scala
+++ b/main/core/src/mill/define/Discover.scala
@@ -3,7 +3,7 @@ package mill.define
 import language.experimental.macros
 
 case class Discover[T] private (value: Map[Class[_], Seq[(Int, mainargs.MainData[_, _])]]) {
-  def copy(value: Map[Class[_], Seq[(Int, mainargs.MainData[_, _])]] = value): Discover[T] =
+  private[mill] def copy(value: Map[Class[_], Seq[(Int, mainargs.MainData[_, _])]] = value): Discover[T] =
     new Discover[T](value)
 }
 object Discover {

--- a/main/core/src/mill/define/Discover.scala
+++ b/main/core/src/mill/define/Discover.scala
@@ -2,7 +2,14 @@ package mill.define
 
 import language.experimental.macros
 
-case class Discover[T](value: Map[Class[_], Seq[(Int, mainargs.MainData[_, _])]])
+case class Discover[T] private (value: Map[Class[_], Seq[(Int, mainargs.MainData[_, _])]]) {
+  def copy(value: Map[Class[_], Seq[(Int, mainargs.MainData[_, _])]] = value): Discover[T] =
+    new Discover[T](value)
+}
 object Discover {
+  def apply[T](value: Map[Class[_], Seq[(Int, mainargs.MainData[_, _])]]): Discover[T] =
+    new Discover[T](value)
   def apply[T]: Discover[T] = macro mill.define.Router.applyImpl[T]
+  private def unapply[T](discover: Discover[T])
+      : Option[Map[Class[_], Seq[(Int, mainargs.MainData[_, _])]]] = Some(discover.value)
 }

--- a/main/core/src/mill/define/ScriptNode.scala
+++ b/main/core/src/mill/define/ScriptNode.scala
@@ -1,3 +1,11 @@
 package mill.define
 
-case class ScriptNode(cls: String, inputs: Seq[ScriptNode]) extends GraphNode[ScriptNode]
+case class ScriptNode(cls: String, inputs: Seq[ScriptNode]) extends GraphNode[ScriptNode] {
+  private def copy(cls: String = cls, inputs: Seq[ScriptNode] = inputs): ScriptNode =
+    new ScriptNode(cls, inputs)
+}
+
+object ScriptNode {
+  private def unapply(scriptNode: ScriptNode): Option[(String, Seq[ScriptNode])] =
+    Some(scriptNode.cls, scriptNode.inputs)
+}

--- a/main/core/src/mill/define/Task.scala
+++ b/main/core/src/mill/define/Task.scala
@@ -381,7 +381,7 @@ abstract class NamedTaskImpl[+T](
     override val isPrivate: Option[Boolean]
 ) extends NamedTask[T] {
   def evaluate(args: mill.api.Ctx) = args[T](0)
-  val ctx = ctx0.copy(segments = ctx0.segments ++ Seq(ctx0.segment))
+  val ctx = ctx0.withSegments(segments = ctx0.segments ++ Seq(ctx0.segment))
   val inputs = Seq(t)
 }
 

--- a/main/core/src/mill/eval/EvaluatorPaths.scala
+++ b/main/core/src/mill/eval/EvaluatorPaths.scala
@@ -3,9 +3,19 @@ package mill.eval
 import mill.api.internal
 import mill.define.{NamedTask, Segment, Segments}
 
-case class EvaluatorPaths(dest: os.Path, meta: os.Path, log: os.Path)
+case class EvaluatorPaths private (dest: os.Path, meta: os.Path, log: os.Path) {
+  private def copy(dest: os.Path = dest, meta: os.Path = meta, log: os.Path = log): EvaluatorPaths =
+    new EvaluatorPaths(dest, meta, log)
+}
 
 object EvaluatorPaths {
+
+  def apply(dest: os.Path, meta: os.Path, log: os.Path): EvaluatorPaths =
+    new EvaluatorPaths(dest, meta, log)
+
+  private def unapply(evaluatorPaths: EvaluatorPaths): Option[(os.Path, os.Path, os.Path)] =
+    Option(evaluatorPaths.dest, evaluatorPaths.meta, evaluatorPaths.log)
+
   @internal
   private[mill] def makeSegmentStrings(segments: Segments): Seq[String] = segments.value.flatMap {
     case Segment.Label(s) => Seq(s)

--- a/main/core/src/mill/eval/ParallelProfileLogger.scala
+++ b/main/core/src/mill/eval/ParallelProfileLogger.scala
@@ -3,7 +3,7 @@ package mill.eval
 import java.io.PrintStream
 import java.nio.file.{Files, StandardOpenOption}
 
-class ParallelProfileLogger(outPath: os.Path, startTime: Long) {
+private[eval] class ParallelProfileLogger(outPath: os.Path, startTime: Long) {
   private var used = false
   private val threadIds = collection.mutable.Map.empty[String, Int]
   lazy val traceStream = {
@@ -56,7 +56,7 @@ class ParallelProfileLogger(outPath: os.Path, startTime: Long) {
  * Trace Event Format, that can be loaded with Google Chrome via chrome://tracing
  * See https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/
  */
-case class TraceEvent(
+private[eval] case class TraceEvent(
     name: String,
     cat: String,
     ph: String,
@@ -66,6 +66,6 @@ case class TraceEvent(
     tid: Int,
     args: Seq[String]
 )
-object TraceEvent {
+private[eval] object TraceEvent {
   implicit val readWrite: upickle.default.ReadWriter[TraceEvent] = upickle.default.macroRW
 }

--- a/main/src/mill/main/MainModule.scala
+++ b/main/src/mill/main/MainModule.scala
@@ -208,8 +208,7 @@ trait MainModule extends mill.Module {
         // When using `show`, redirect all stdout of the evaluated tasks so the
         // printed JSON is the only thing printed to stdout.
         evaluator.baseLogger match {
-          case PrintLogger(c1, d, c2, c3, _, i, e, in, de, uc) =>
-            PrintLogger(c1, d, c2, c3, e, i, e, in, de, uc)
+          case p: PrintLogger => p.withOutStream(p.errStream)
           case l => l
         }
       ),
@@ -237,8 +236,7 @@ trait MainModule extends mill.Module {
         // When using `show`, redirect all stdout of the evaluated tasks so the
         // printed JSON is the only thing printed to stdout.
         evaluator.baseLogger match {
-          case PrintLogger(c1, d, c2, c3, _, i, e, in, de, uc) =>
-            PrintLogger(c1, d, c2, c3, e, i, e, in, de, uc)
+          case p: PrintLogger => p.withOutStream(outStream = p.errStream)
           case l => l
         }
       ),

--- a/main/src/mill/main/MainRunner.scala
+++ b/main/src/mill/main/MainRunner.scala
@@ -90,7 +90,7 @@ class MainRunner(
       isRepl = false,
       printing = true,
       mainCfg => {
-        val logger = PrintLogger(
+        val logger = new PrintLogger(
           colored = colored,
           disableTicker = disableTicker,
           infoColor = colors.info(),

--- a/main/src/mill/modules/CoursierSupport.scala
+++ b/main/src/mill/modules/CoursierSupport.scala
@@ -247,13 +247,13 @@ object CoursierSupport {
    * In practice, this ticker output gets prefixed with the current target for which
    * dependencies are being resolved, using a [[mill.util.ProxyLogger]] subclass.
    */
-  class TickerResolutionLogger(ctx: Ctx.Log) extends coursier.cache.CacheLogger {
-    case class DownloadState(var current: Long, var total: Long)
+  private[CoursierSupport] class TickerResolutionLogger(ctx: Ctx.Log) extends coursier.cache.CacheLogger {
+    private[CoursierSupport] case class DownloadState(var current: Long, var total: Long)
 
-    var downloads = new mutable.TreeMap[String, DownloadState]()
-    var totalDownloadCount = 0
-    var finishedCount = 0
-    var finishedState = DownloadState(0, 0)
+    private[CoursierSupport] var downloads = new mutable.TreeMap[String, DownloadState]()
+    private[CoursierSupport] var totalDownloadCount = 0
+    private[CoursierSupport] var finishedCount = 0
+    private[CoursierSupport] var finishedState = DownloadState(0, 0)
 
     def updateTicker(): Unit = {
       val sums = downloads.values

--- a/main/test/src/mill/util/TestUtil.scala
+++ b/main/test/src/mill/util/TestUtil.scala
@@ -46,7 +46,7 @@ object TestUtil extends MillTestKit {
   class TestTarget(inputs: Seq[Task[Int]], val pure: Boolean)(implicit ctx0: mill.define.Ctx)
       extends Test(inputs)
       with Target[Int] {
-    val ctx = ctx0.copy(segments = ctx0.segments ++ Seq(ctx0.segment))
+    val ctx = ctx0.withSegments(ctx0.segments ++ Seq(ctx0.segment))
     val readWrite = upickle.default.readwriter[Int]
 
   }

--- a/main/util/src/mill/util/Loggers.scala
+++ b/main/util/src/mill/util/Loggers.scala
@@ -69,7 +69,7 @@ trait ColorLogger extends Logger {
   def errorColor: fansi.Attrs
 }
 
-case class PrefixLogger(out: ColorLogger, context: String, tickerContext: String = "")
+class PrefixLogger(out: ColorLogger, context: String, tickerContext: String = "")
     extends ColorLogger {
   override def colored = out.colored
 
@@ -97,25 +97,30 @@ case class PrefixLogger(out: ColorLogger, context: String, tickerContext: String
   override def debugEnabled: Boolean = out.debugEnabled
 }
 
-case class PrintLogger(
+object PrefixLogger {
+  def apply(out: ColorLogger, context: String, tickerContext: String = ""): PrefixLogger =
+    new PrefixLogger(out, context, tickerContext)
+}
+
+class PrintLogger(
     override val colored: Boolean,
-    disableTicker: Boolean,
+    val disableTicker: Boolean,
     override val infoColor: fansi.Attrs,
     override val errorColor: fansi.Attrs,
-    outStream: PrintStream,
-    infoStream: PrintStream,
-    errStream: PrintStream,
+    val outStream: PrintStream,
+    val infoStream: PrintStream,
+    val errStream: PrintStream,
     override val inStream: InputStream,
     override val debugEnabled: Boolean,
-    context: String
+    val context: String
 ) extends ColorLogger {
 
   var printState: PrintState = PrintState.Newline
 
-  override val errorStream = new PrintStream(
+  override val errorStream: PrintStream = new PrintStream(
     new CallbackStream(errStream, printState = _)
   )
-  override val outputStream = new PrintStream(
+  override val outputStream: PrintStream = new PrintStream(
     new CallbackStream(outStream, printState = _)
   )
 
@@ -151,6 +156,32 @@ case class PrintLogger(
       printState = PrintState.Ticker
     }
   }
+
+  def withOutStream(outStream: PrintStream): PrintLogger = copy(outStream = outStream)
+
+  private def copy(
+      colored: Boolean = colored,
+      disableTicker: Boolean = disableTicker,
+      infoColor: fansi.Attrs = infoColor,
+      errorColor: fansi.Attrs = errorColor,
+      outStream: PrintStream = outStream,
+      infoStream: PrintStream = infoStream,
+      errStream: PrintStream = errStream,
+      inStream: InputStream = inStream,
+      debugEnabled: Boolean = debugEnabled,
+      context: String = context
+  ): PrintLogger = new PrintLogger(
+    colored,
+    disableTicker,
+    infoColor,
+    errorColor,
+    outStream,
+    infoStream,
+    errStream,
+    inStream,
+    debugEnabled,
+    context
+  )
 
   def debug(s: String) = synchronized {
     if (debugEnabled) {

--- a/testrunner/src/mill/testrunner/TestRunner.scala
+++ b/testrunner/src/mill/testrunner/TestRunner.scala
@@ -108,7 +108,7 @@ object TestRunner {
     }.map { f => (cls, f) }
   }
 
-  case class TestArgs(
+  case class TestArgs private (
       framework: String,
       classpath: Seq[String],
       arguments: Seq[String],
@@ -141,6 +141,28 @@ object TestRunner {
       )
       s"@${argsFile.toString()}"
     }
+    private def copy(
+        framework: String = framework,
+        classpath: Seq[String] = classpath,
+        arguments: Seq[String] = arguments,
+        sysProps: Map[String, String] = sysProps,
+        outputPath: String = outputPath,
+        colored: Boolean = colored,
+        testCp: String = testCp,
+        homeStr: String = homeStr,
+        globSelectors: Seq[String] = globSelectors
+    ): TestArgs = new TestArgs(
+      framework,
+      classpath,
+      arguments,
+      sysProps,
+      outputPath,
+      colored,
+      testCp,
+      homeStr,
+      globSelectors
+    )
+
   }
 
   object TestArgs {
@@ -196,6 +218,52 @@ object TestRunner {
         globFilters.toIndexedSeq
       )
     }
+
+    def apply(
+        framework: String,
+        classpath: Seq[String],
+        arguments: Seq[String],
+        sysProps: Map[String, String],
+        outputPath: String,
+        colored: Boolean,
+        testCp: String,
+        homeStr: String,
+        globSelectors: Seq[String]
+    ): TestArgs = new TestArgs(
+      framework,
+      classpath,
+      arguments,
+      sysProps,
+      outputPath,
+      colored,
+      testCp,
+      homeStr,
+      globSelectors
+    )
+
+    private def unapply(testArgs: TestArgs): Option[(
+        String,
+        Seq[String],
+        Seq[String],
+        Map[String, String],
+        String,
+        Boolean,
+        String,
+        String,
+        Seq[String]
+    )] =
+      Some((
+        testArgs.framework,
+        testArgs.classpath,
+        testArgs.arguments,
+        testArgs.sysProps,
+        testArgs.outputPath,
+        testArgs.colored,
+        testArgs.testCp,
+        testArgs.homeStr,
+        testArgs.globSelectors
+      ))
+
   }
 
   def main(args: Array[String]): Unit = {

--- a/testrunner/src/mill/testrunner/TestRunner.scala
+++ b/testrunner/src/mill/testrunner/TestRunner.scala
@@ -270,7 +270,7 @@ object TestRunner {
     try {
       val testArgs = TestArgs.parseArgs(args).get
       val ctx = new Ctx.Log with Ctx.Home {
-        val log = PrintLogger(
+        val log = new PrintLogger(
           testArgs.colored,
           true,
           if (testArgs.colored) fansi.Color.Blue


### PR DESCRIPTION
Reviewed various case classes and hid their `unapply` and `copy` methods. Also added some `with`-methods where needed. This improves the ability to evolve them while still preserving binary compatibility.
