### PR TITLE
Add boolean flag to search for proto files in dependencies. Update docs.

### DIFF
--- a/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBModule.scala
+++ b/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBModule.scala
@@ -36,7 +36,7 @@ trait ScalaPBModule extends ScalaModule {
   /** ScalaPB enables lenses by default, this option allows you to disable it. */
   def scalaPBLenses: T[Boolean] = T { true }
 
-  def scalaPBSearchDeps: T[Boolean] = T { false }
+  def scalaPBSearchDeps: Boolean = false
 
   /**
    * Additional arguments for scalaPBC.
@@ -87,6 +87,9 @@ trait ScalaPBModule extends ScalaModule {
 
   def scalaPBIncludePath: T[Seq[PathRef]] = T.sources { Seq.empty[PathRef] }
 
+  private def scalaDepsPBIncludePath = if (scalaPBSearchDeps) T { Seq(scalaPBUnpackProto()) }
+  else T { Seq.empty[PathRef] }
+
   def scalaPBProtoClasspath: T[Agg[PathRef]] = T {
     resolveDeps(T.task { transitiveCompileIvyDeps() ++ transitiveIvyDeps() })()
   }
@@ -119,8 +122,7 @@ trait ScalaPBModule extends ScalaModule {
   def scalaPBCompileOptions: T[Seq[String]] = T {
     ScalaPBWorkerApi.scalaPBWorker().compileOptions(
       scalaPBProtocPath(),
-      (scalaPBIncludePath() ++ (if (scalaPBSearchDeps()) Seq(scalaPBUnpackProto())
-                                else Seq.empty[PathRef])).map(_.path),
+      (scalaPBIncludePath() ++ scalaDepsPBIncludePath()).map(_.path),
       scalaPBAdditionalArgs()
     )
   }

--- a/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBModule.scala
+++ b/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBModule.scala
@@ -36,6 +36,8 @@ trait ScalaPBModule extends ScalaModule {
   /** ScalaPB enables lenses by default, this option allows you to disable it. */
   def scalaPBLenses: T[Boolean] = T { true }
 
+  def scalaPBSearchDeps: T[Boolean] = T { false }
+
   /**
    * Additional arguments for scalaPBC.
    *
@@ -117,7 +119,8 @@ trait ScalaPBModule extends ScalaModule {
   def scalaPBCompileOptions: T[Seq[String]] = T {
     ScalaPBWorkerApi.scalaPBWorker().compileOptions(
       scalaPBProtocPath(),
-      scalaPBIncludePath().map(_.path),
+      (scalaPBIncludePath() ++ (if (scalaPBSearchDeps()) Seq(scalaPBUnpackProto())
+                                else Seq.empty[PathRef])).map(_.path),
       scalaPBAdditionalArgs()
     )
   }

--- a/contrib/scalapblib/test/src/mill/contrib/scalapblib/TutorialTests.scala
+++ b/contrib/scalapblib/test/src/mill/contrib/scalapblib/TutorialTests.scala
@@ -51,11 +51,10 @@ object TutorialTests extends TestSuite {
         millSourcePath / "protobuf" / "tutorial" / "Tutorial.proto"
       }
 
+      override def scalaPBSearchDeps = true
       override def scalaPBIncludePath = Seq(
-        scalaPBUnpackProto(),
         PathRef(millSourcePath / "protobuf" / "tutorial")
       )
-
     }
   }
 

--- a/docs/antora/modules/ROOT/pages/Plugin_ScalaPB.adoc
+++ b/docs/antora/modules/ROOT/pages/Plugin_ScalaPB.adoc
@@ -43,6 +43,10 @@ example/
 
 * scalaPBProtocPath - A `Option[Path]` option which determines the protoc compiler to use. If `None`, a java embedded protoc will be used, if set to `Some` path, the given binary is used.
 
+* scalaPBSearchDeps - A `Boolean` option which determines whether to search for `.proto` files in dependencies and add them to `scalaPBIncludePath`. Defaults to `false`.
+
+* scalaPBIncludePath - Additional paths to include `.proto` files when compiling.
+
 If you'd like to configure the https://scalapb.github.io/docs/scalapbc#passing-generator-parameters[options] that are passed to the ScalaPB compiler directly, you can override the `scalaPBOptions` task, for example:
 
 .`build.sc`


### PR DESCRIPTION
Add boolean flag `scalaPBSearchDeps` that uses the `scalaPBUnpackProto()` task to add to existing `scalaPBIncludePath`, .proto files from included dependencies.