### PR TITLE
CI: only auto-build main and pull requests

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,11 +1,18 @@
 name: Build and Release
 
+# We run full CI on push builds to main and on all pull requests
+# Tags are automatically published
+# Manual builds (workflow_dispatch) to the main branch are also published
+
 on:
   push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
 
-# cancel older pull request runs
+# cancel older runs of a pull request;
+# this will not cancel anything for normal git pushes
 concurrency:
   group: cancel-old-pr-runs-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -13,9 +20,6 @@ concurrency:
 jobs:
 
   test:
-    # don't build dependabot branches on push, we already build them on pull request
-    if: github.event != 'push' || !startsWith(github.ref, 'refs/heads/dependabot')
-
     strategy:
       fail-fast: false
       matrix:
@@ -65,9 +69,6 @@ jobs:
         run: ${{ matrix.buildcmd }}
 
   test-bin-compat:
-    # don't build dependabot branches on push, we already build them on pull request
-    if: github.event != 'push' || !startsWith(github.ref, 'refs/heads/dependabot')
-
     strategy:
       fail-fast: false
       matrix:
@@ -100,9 +101,6 @@ jobs:
         run: ${{ matrix.buildcmd }}
 
   test-windows:
-    # don't build dependabot branches on push, we already build them on pull request
-    if: github.event != 'push' || !startsWith(github.ref, 'refs/heads/dependabot')
-
     strategy:
       fail-fast: false
       matrix:
@@ -133,7 +131,7 @@ jobs:
         run: ${{ matrix.buildcmd }}
 
   publish-sonatype:
-    # when in master repo, publish all tags and manual runs
+    # when in master repo, publish all tags and manual runs on main
     if: github.repository == 'com-lihaoyi/mill' && (startsWith( github.ref, 'refs/tags/') || (github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch' ) )
     needs: [test, test-windows, test-bin-compat]
 
@@ -167,7 +165,7 @@ jobs:
       - run: ci/release-maven.sh
 
   release-github:
-    # when in master repo, publish all tags and manual runs
+    # when in master repo, publish all tags and manual runs on main
     if: github.repository == 'com-lihaoyi/mill' && (startsWith( github.ref, 'refs/tags/') || (github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch' ) )
     needs: publish-sonatype
     runs-on: ubuntu-latest


### PR DESCRIPTION
If you need to test a branch which is not a pull request,
you can run the workflow manually.

Tags and manually triggered commits to main are published automatically.