### PR TITLE
BSP: Support `mainClasses` in run and test environments

### DIFF
--- a/bsp/test/src/mill/bsp/BspInstallDebugTests.scala
+++ b/bsp/test/src/mill/bsp/BspInstallDebugTests.scala
@@ -6,6 +6,7 @@ import utest._
 object BspInstallDebugTests extends ScriptTestSuite(false) {
   override def workspaceSlug: String = "bsp-install"
   override def scriptSourcePath: os.Path = os.pwd / "bsp" / "test" / "resources" / workspaceSlug
+  val bsp4jVersion = sys.props.getOrElse("BSP4J_VERSION", ???)
 
   // we purposely enable debugging in this simulated test env
   override val debugLog: Boolean = true
@@ -15,8 +16,12 @@ object BspInstallDebugTests extends ScriptTestSuite(false) {
       val workspacePath = initWorkspace()
       eval("mill.bsp.BSP/install") ==> true
       val jsonFile = workspacePath / Constants.bspDir / s"${Constants.serverName}.json"
-      os.exists(jsonFile) ==> true
-      os.read(jsonFile).contains("--debug") ==> true
+      assert(os.exists(jsonFile))
+      val contents = os.read(jsonFile)
+      assert(
+        contents.contains("--debug"),
+        contents.contains(s""""bspVersion":"${bsp4jVersion}"""")
+      )
     }
   }
 }

--- a/bsp/test/src/mill/bsp/BspInstallTests.scala
+++ b/bsp/test/src/mill/bsp/BspInstallTests.scala
@@ -6,14 +6,19 @@ import utest._
 object BspInstallTests extends ScriptTestSuite(false) {
   override def workspaceSlug: String = "bsp-install"
   override def scriptSourcePath: os.Path = os.pwd / "bsp" / "test" / "resources" / workspaceSlug
+  val bsp4jVersion = sys.props.getOrElse("BSP4J_VERSION", ???)
 
   def tests: Tests = Tests {
     test("BSP install") {
       val workspacePath = initWorkspace()
-      eval("mill.bsp.BSP/install") ==> true
+      assert(eval("mill.bsp.BSP/install"))
       val jsonFile = workspacePath / Constants.bspDir / s"${Constants.serverName}.json"
-      os.exists(jsonFile) ==> true
-      os.read(jsonFile).contains("--debug") ==> false
+      assert(os.exists(jsonFile))
+      val contents = os.read(jsonFile)
+      assert(
+        !contents.contains("--debug"),
+        contents.contains(s""""bspVersion":"${bsp4jVersion}"""")
+      )
     }
   }
 }

--- a/bsp/test/src/mill/bsp/BspModulesTests.scala
+++ b/bsp/test/src/mill/bsp/BspModulesTests.scala
@@ -6,19 +6,20 @@ import utest._
 object BspModulesTests extends ScriptTestSuite(false) {
   override def workspaceSlug: String = "bsp-modules"
   override def scriptSourcePath: os.Path = os.pwd / "bsp" / "test" / "resources" / workspaceSlug
+  val bsp4jVersion = sys.props.getOrElse("BSP4J_VERSION", ???)
 
   def tests: Tests = Tests {
     test("BSP module with foreign modules") {
       test("can be installed") {
         val workspacePath = initWorkspace()
-        eval("mill.bsp.BSP/install") ==> true
+        assert(eval("mill.bsp.BSP/install"))
         os.exists(workspacePath / Constants.bspDir / s"${Constants.serverName}.json") ==> true
       }
       test("ModuleUtils resolves all referenced transitive modules") {
         val workspacePath = initWorkspace()
-        eval("validate") ==> true
+        assert(eval("validate"))
         val file = workspacePath / "out" / "validate.dest" / "transitive-modules.json"
-        os.exists(file) ==> true
+        assert(os.exists(file))
         val readModules = os.read.lines(file).sorted
         val expectedModules = Seq(
           "", // the root module has no segemnts at all
@@ -28,7 +29,7 @@ object BspModulesTests extends ScriptTestSuite(false) {
           "foreign-modules.proj2.build.proj2"
           // "foreign-modules.proj3.proj3" // still not detected
         ).sorted
-        readModules ==> expectedModules
+        assert(readModules == expectedModules)
       }
     }
   }

--- a/bsp/worker/src/mill/bsp/worker/MillJvmBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillJvmBuildServer.scala
@@ -4,6 +4,7 @@ import ch.epfl.scala.bsp4j.{
   BuildTargetIdentifier,
   JvmBuildServer,
   JvmEnvironmentItem,
+  JvmMainClass,
   JvmRunEnvironmentParams,
   JvmRunEnvironmentResult,
   JvmTestEnvironmentParams,
@@ -17,6 +18,7 @@ import mill.scalalib.bsp.BspModule
 
 import java.util.concurrent.CompletableFuture
 import scala.jdk.CollectionConverters._
+import scala.util.chaining.scalaUtilChainingOps
 
 @internal
 trait MillJvmBuildServer extends JvmBuildServer { this: MillBuildServer =>
@@ -51,7 +53,13 @@ trait MillJvmBuildServer extends JvmBuildServer { this: MillBuildServer =>
           m.forkArgs().asJava,
           m.forkWorkingDir().toString(),
           m.forkEnv().asJava
-        )
+        ).tap { item =>
+          val classes =
+            m.mainClass().toList ++ m.zincWorker.worker().discoverMainClasses(m.compile())
+          item.setMainClasses(
+            classes.map(new JvmMainClass(_, Nil.asJava)).asJava
+          )
+        }
       }
   }
 }

--- a/build.sc
+++ b/build.sc
@@ -180,7 +180,7 @@ object Deps {
   val windowsAnsi = ivy"io.github.alexarchambault.windows-ansi:windows-ansi:0.0.4"
   val zinc = ivy"org.scala-sbt::zinc:1.8.0"
   // keep in sync with doc/antora/antory.yml
-  val bsp4j = ivy"ch.epfl.scala:bsp4j:2.1.0-M3"
+  val bsp4j = ivy"ch.epfl.scala:bsp4j:2.1.0-M4"
   val fansi = ivy"com.lihaoyi::fansi:0.4.0"
   val jarjarabrams = ivy"com.eed3si9n.jarjarabrams::jarjar-abrams-core:1.8.2"
   val requests = ivy"com.lihaoyi::requests:0.8.0"

--- a/build.sc
+++ b/build.sc
@@ -972,6 +972,10 @@ object bsp extends MillModule {
       bsp.worker.publishLocal()()
       super.forkEnv()
     }
+
+    override def forkArgs: Target[Seq[String]] = super.forkArgs() ++ Seq(
+      s"-DBSP4J_VERSION=${Deps.bsp4j.dep.version}"
+    )
   }
 
   object worker extends MillInternalModule {

--- a/docs/antora/antora.yml
+++ b/docs/antora/antora.yml
@@ -7,7 +7,7 @@ asciidoc:
   attributes:
     mill-version: '0.11.0-M6'
     mill-last-tag: '0.11-0-M6'
-    bsp-version: '2.1.0-M3'
+    bsp-version: '2.1.0-M4'
     example-semanticdb-version: '4.7.5'
     example-scala-2-13-version: '2.13.10'
     example-utest-version: '0.8.1'


### PR DESCRIPTION
Updated bsp4j to 2.1.0-M4.

* Fix https://github.com/com-lihaoyi/mill/issues/2283