### PR TITLE
Reworked `PathRef.revalidate` handling based on `DynamicVariable`

### DIFF
--- a/main/api/src/mill/api/PathRef.scala
+++ b/main/api/src/mill/api/PathRef.scala
@@ -33,8 +33,16 @@ case class PathRef private (
   def withRevalidate(revalidate: PathRef.Revalidate): PathRef = copy(revalidate = revalidate)
   def withRevalidateOnce: PathRef = copy(revalidate = PathRef.Revalidate.Once)
 
-  override def toString: String =
-    getClass().getSimpleName() + "(path=" + path + ",quick=" + quick + ",sig=" + sig + ",revalidated=" + revalidate + ")"
+  override def toString: String = {
+    val quick = if (quick) "qref:" else "ref:"
+    val valid = revalidate match {
+      case PathRef.Revalidate.Never => "v0:"
+      case PathRef.Revalidate.Once => "v1:"
+      case PathRef.Revalidate.Always => "vn:"
+    }
+    val sig = String.format("%08x", sig: Integer)
+    quick + valid + sig + ":" + path.toString()
+  }
 }
 
 object PathRef {
@@ -155,16 +163,7 @@ object PathRef {
    * Default JSON formatter for [[PathRef]].
    */
   implicit def jsonFormatter: RW[PathRef] = upickle.default.readwriter[String].bimap[PathRef](
-    p => {
-      val quick = if (p.quick) "qref:" else "ref:"
-      val valid = p.revalidate match {
-        case Revalidate.Never => "v0:"
-        case Revalidate.Once => "v1:"
-        case Revalidate.Always => "vn:"
-      }
-      val sig = String.format("%08x", p.sig: Integer)
-      quick + valid + sig + ":" + p.path.toString()
-    },
+    p => p.toString(),
     s => {
       val Array(prefix, valid0, hex, pathString) = s.split(":", 4)
 

--- a/main/api/src/mill/api/PathRef.scala
+++ b/main/api/src/mill/api/PathRef.scala
@@ -52,7 +52,7 @@ object PathRef {
      * @throws PathRefValidationException If a the [[PathRef]] needs revalidation which fails
      */
     def revalidateIfNeededOrThrow(pathRef: PathRef): Unit = {
-      def mapKey(pr: PathRef): Int = ScalaRunTime._hashCode((pr.path, pr.quick, pr.sig))
+      def mapKey(pr: PathRef): Int = (pr.path, pr.quick, pr.sig).hashCode()
       pathRef.revalidate match {
         case Revalidate.Never => // ok
         case Revalidate.Once if map.contains(mapKey(pathRef)) => // ok

--- a/main/api/src/mill/api/PathRef.scala
+++ b/main/api/src/mill/api/PathRef.scala
@@ -34,13 +34,13 @@ case class PathRef private (
   def withRevalidateOnce: PathRef = copy(revalidate = PathRef.Revalidate.Once)
 
   override def toString: String = {
-    val quick = if (quick) "qref:" else "ref:"
+    val quick = if (this.quick) "qref:" else "ref:"
     val valid = revalidate match {
       case PathRef.Revalidate.Never => "v0:"
       case PathRef.Revalidate.Once => "v1:"
       case PathRef.Revalidate.Always => "vn:"
     }
-    val sig = String.format("%08x", sig: Integer)
+    val sig = String.format("%08x", this.sig: Integer)
     quick + valid + sig + ":" + path.toString()
   }
 }

--- a/main/api/src/mill/api/PathRef.scala
+++ b/main/api/src/mill/api/PathRef.scala
@@ -56,7 +56,7 @@ object PathRef {
       pathRef.revalidate match {
         case Revalidate.Never => // ok
         case Revalidate.Once if map.contains(mapKey(pathRef)) => // ok
-        case _ =>
+        case Revalidate.Once | Revalidate.Always =>
           val changedSig = PathRef.apply(pathRef.path, pathRef.quick).sig
           if (pathRef.sig != changedSig) {
             throw new PathRefValidationException(pathRef)

--- a/main/core/src/mill/eval/Evaluator.scala
+++ b/main/core/src/mill/eval/Evaluator.scala
@@ -146,8 +146,7 @@ class Evaluator private (
       logger: ColorLogger,
       reporter: Int => Option[CompileProblemReporter] = _ => Option.empty[CompileProblemReporter],
       testReporter: TestReporter = DummyTestReporter
-  ): Evaluator.Results = {
-    PathRef.validatedPaths.set(new PathRef.ValidatedPaths())
+  ): Evaluator.Results = PathRef.validatedPaths.withValue(new PathRef.ValidatedPaths()) {
 
     val (sortedGroups, transitive) = Evaluator.plan(goals)
     val evaluated = new Agg.Mutable[Task[_]]
@@ -193,9 +192,6 @@ class Evaluator private (
       }
     }
 
-    // no need to keep this state any longer
-    PathRef.validatedPaths.get().clear()
-
     Evaluator.writeTimings(timings.toSeq, outPath)
     Evaluator.Results(
       rawValues = goals.indexed.map(results(_).map(_._1)),
@@ -226,11 +222,9 @@ class Evaluator private (
       logger: ColorLogger,
       reporter: Int => Option[CompileProblemReporter] = _ => Option.empty[CompileProblemReporter],
       testReporter: TestReporter = DummyTestReporter
-  ): Evaluator.Results = {
+  ): Evaluator.Results = PathRef.validatedPaths.withValue(new PathRef.ValidatedPaths()) {
     os.makeDir.all(outPath)
     val timeLog = new ParallelProfileLogger(outPath, System.currentTimeMillis())
-
-    PathRef.validatedPaths.set(new PathRef.ValidatedPaths())
 
     val (sortedGroups, transitive) = Evaluator.plan(goals)
 
@@ -327,8 +321,6 @@ class Evaluator private (
       )
     } finally {
       threadPool.shutdown()
-      // no need to keep this state any longer
-      PathRef.validatedPaths.get().clear()
     }
   }
 


### PR DESCRIPTION
This uses `scala.util.DynamicVariable` instead of `InheritableThreadLocal` to avoid loosing some state in case we have some nested evaluation going on, e.g. in evaluator command.

I added mostly duplicate code to `Evaluator` `sequentialEvaluate` and `parallelEvaluate` instead of only one in method `evaluate`, as both are public entry points to start evaluation.

