### PR TITLE
Make use of MainArgs in example/basic/

### DIFF
--- a/example/basic/1-hello-world/build.sc
+++ b/example/basic/1-hello-world/build.sc
@@ -2,7 +2,10 @@ import mill._, scalalib._
 
 object foo extends RootModule with ScalaModule {
   def scalaVersion = "2.13.2"
-  def ivyDeps = Agg(ivy"com.lihaoyi::scalatags:0.8.2")
+  def ivyDeps = Agg(
+    ivy"com.lihaoyi::scalatags:0.8.2",
+    ivy"com.lihaoyi::mainargs:0.4.0"
+  )
 }
 
 // This is a basic Mill build for a single `ScalaModule`, with a single
@@ -10,6 +13,10 @@ object foo extends RootModule with ScalaModule {
 // to mark `object foo` as the top-level module in the build. This lets us
 // directly perform operations `./mill compile` or `./mill run` without needing
 // to prefix it as `foo.compile` or `foo.run`.
+//
+// This example project uses two third-party dependencies - MainArgs for CLI
+// argument parsing, Scalatags for HTML generation - and uses them to wrap a
+// given input string in HTML templates with proper escaping.
 //
 // You can run `assembly` to generate a standalone executable jar, which then
 // can be run from the command line or deployed to be run elsewhere.
@@ -19,16 +26,22 @@ object foo extends RootModule with ScalaModule {
 > ./mill compile
 compiling 1 Scala source
 
-> ./mill run
-Foo.value: <h1>hello</h1>
+> ./mill run --text hello
+Missing argument: --text <str>
+
+> ./mill run --text hello
+<h1>hello</h1>
+
+> ./mill run --text "<script>alert('hello')</script>"
+<h1>&lt;script&gt;alert('hello')&lt;/script&gt;</h1>
 
 > ./mill show assembly
 out/assembly.dest/out.jar
 
-> java -jar ./out/assembly.dest/out.jar
-Foo.value: <h1>hello</h1>
+> java -jar ./out/assembly.dest/out.jar --text hello
+<h1>hello</h1>
 
-> ./out/assembly.dest/out.jar # mac/linux
-Foo.value: <h1>hello</h1>
+> ./out/assembly.dest/out.jar --text hello # mac/linux
+<h1>hello</h1>
 
 */

--- a/example/basic/1-hello-world/build.sc
+++ b/example/basic/1-hello-world/build.sc
@@ -26,14 +26,11 @@ object foo extends RootModule with ScalaModule {
 > ./mill compile
 compiling 1 Scala source
 
-> ./mill run --text hello
-Missing argument: --text <str>
+> ./mill run
+error: Missing argument: --text <str>
 
 > ./mill run --text hello
 <h1>hello</h1>
-
-> ./mill run --text "<script>alert('hello')</script>"
-<h1>&lt;script&gt;alert('hello')&lt;/script&gt;</h1>
 
 > ./mill show assembly
 out/assembly.dest/out.jar

--- a/example/basic/1-hello-world/src/Foo.scala
+++ b/example/basic/1-hello-world/src/Foo.scala
@@ -1,8 +1,12 @@
 package foo
 import scalatags.Text.all._
+import mainargs.{main, ParserForMethods}
 object Foo {
-  val value = h1("hello")
-  def main(args: Array[String]): Unit = {
-    println("Foo.value: " + Foo.value)
+  @main
+  def main(text: String) = {
+    val value = h1(text)
+    println(value)
   }
+
+  def main(args: Array[String]): Unit = ParserForMethods(this).runOrExit(args)
 }

--- a/example/basic/3-custom-tasks/build.sc
+++ b/example/basic/3-custom-tasks/build.sc
@@ -5,6 +5,7 @@ object foo extends RootModule with ScalaModule {
 
   def ivyDeps = Agg(
     ivy"com.lihaoyi::scalatags:0.8.2",
+    ivy"com.lihaoyi::mainargs:0.4.0",
     ivy"com.lihaoyi::os-lib:0.9.1",
   )
 
@@ -62,8 +63,8 @@ object foo extends RootModule with ScalaModule {
 
 /* Example Usage
 
-> ./mill run
-Foo.value: <h1>hello</h1>
+> ./mill run --text hello
+value: <h1>hello</h1>
 MyDeps.value: List((com.lihaoyi,scalatags,0.8.2), (com.lihaoyi,os-lib,0.9.1))
 my.line.count: 10
 */

--- a/example/basic/3-custom-tasks/build.sc
+++ b/example/basic/3-custom-tasks/build.sc
@@ -65,6 +65,6 @@ object foo extends RootModule with ScalaModule {
 
 > ./mill run --text hello
 value: <h1>hello</h1>
-MyDeps.value: List((com.lihaoyi,scalatags,0.8.2), (com.lihaoyi,os-lib,0.9.1))
-my.line.count: 10
+MyDeps.value: List((com.lihaoyi,scalatags,0.8.2), (com.lihaoyi,mainargs,0.4.0), (com.lihaoyi,os-lib,0.9.1))
+my.line.count: 14
 */

--- a/example/basic/3-custom-tasks/src/Foo.scala
+++ b/example/basic/3-custom-tasks/src/Foo.scala
@@ -1,10 +1,14 @@
 package foo
 import scalatags.Text.all._
+import mainargs.{main, ParserForMethods}
 object Foo {
-  val value = h1("hello")
-  def main(args: Array[String]): Unit = {
-    println("Foo.value: " + Foo.value)
+  @main
+  def main(text: String): Unit = {
+    val value = h1(text)
+    println("value: " + value)
     println("MyDeps.value: " + MyDeps.value)
     println("my.line.count: " + sys.props("my.line.count"))
   }
+
+  def main(args: Array[String]): Unit = ParserForMethods(this).runOrExit(args)
 }

--- a/example/basic/4-multi-module/bar/src/Bar.scala
+++ b/example/basic/4-multi-module/bar/src/Bar.scala
@@ -1,9 +1,12 @@
 package bar
 import scalatags.Text.all._
+import mainargs.{main, ParserForMethods}
 object Bar {
-  val value = p("world")
-
-  def main(args: Array[String]): Unit = {
-    println("Bar.value: " + bar.Bar.value)
+  @main
+  def main(text: String): Unit = {
+    val value = p("world")
+    println("Bar.value: " + value)
   }
+
+  def main(args: Array[String]): Unit = ParserForMethods(this).runOrExit(args)
 }

--- a/example/basic/4-multi-module/build.sc
+++ b/example/basic/4-multi-module/build.sc
@@ -2,7 +2,10 @@ import mill._, scalalib._
 
 trait MyModule extends ScalaModule{
   def scalaVersion = "2.13.2"
-  def ivyDeps = Agg(ivy"com.lihaoyi::scalatags:0.8.2")
+  def ivyDeps = Agg(
+    ivy"com.lihaoyi::scalatags:0.8.2",
+    ivy"com.lihaoyi::mainargs:0.4.0"
+  )
 }
 
 object foo extends MyModule {
@@ -27,11 +30,11 @@ object bar extends MyModule
 foo.run
 bar.run
 
-> ./mill foo.run
+> ./mill foo.run --foo-text hello --bar-text world
 Foo.value: <h1>hello</h1>
 Bar.value: <p>world</p>
 
-> ./mill bar.run
+> ./mill bar.run --text world
 Bar.value: <p>world</p>
 
 */

--- a/example/basic/4-multi-module/foo/src/Foo.scala
+++ b/example/basic/4-multi-module/foo/src/Foo.scala
@@ -1,10 +1,15 @@
 package foo
 import scalatags.Text.all._
+import mainargs.{main, ParserForMethods, arg}
 object Foo {
   val value = h1("hello")
 
-  def main(args: Array[String]): Unit = {
+  @main
+  def main(@arg(name = "foo-text") fooText: String,
+           @arg(name = "bar-text") barText: String): Unit = {
     println("Foo.value: " + Foo.value)
-    println("Bar.value: " + bar.Bar.value)
+    bar.Bar.main(barText)
   }
+
+  def main(args: Array[String]): Unit = ParserForMethods(this).runOrExit(args)
 }

--- a/example/basic/5-nested-modules/build.sc
+++ b/example/basic/5-nested-modules/build.sc
@@ -2,7 +2,10 @@ import mill._, scalalib._
 
 trait MyModule extends ScalaModule{
   def scalaVersion = "2.13.2"
-  def ivyDeps = Agg(ivy"com.lihaoyi::scalatags:0.8.2")
+  def ivyDeps = Agg(
+    ivy"com.lihaoyi::scalatags:0.8.2",
+    ivy"com.lihaoyi::mainargs:0.4.0"
+  )
 }
 
 object wrapper extends Module{
@@ -32,13 +35,12 @@ wrapper.foo.run
 wrapper.bar.run
 qux.run
 
-> ./mill qux.run
+> ./mill qux.run --foo-value hello --bar-value world --qux-value today
 Foo.value: <h1>hello</h1>
 Bar.value: <p>world</p>
 Qux.value: <p>today</p>
 
-> ./mill wrapper.foo.run
+> ./mill wrapper.foo.run --foo-value hello
 Foo.value: <h1>hello</h1>
-Bar.value: <p>world</p>
 
 */

--- a/example/basic/5-nested-modules/build.sc
+++ b/example/basic/5-nested-modules/build.sc
@@ -35,12 +35,12 @@ wrapper.foo.run
 wrapper.bar.run
 qux.run
 
-> ./mill qux.run --foo-value hello --bar-value world --qux-value today
+> ./mill qux.run --foo-text hello --bar-text world --qux-text today
 Foo.value: <h1>hello</h1>
 Bar.value: <p>world</p>
 Qux.value: <p>today</p>
 
-> ./mill wrapper.foo.run --foo-value hello
+> ./mill wrapper.foo.run --foo-text hello
 Foo.value: <h1>hello</h1>
 
 */

--- a/example/basic/5-nested-modules/build.sc
+++ b/example/basic/5-nested-modules/build.sc
@@ -40,7 +40,7 @@ Foo.value: <h1>hello</h1>
 Bar.value: <p>world</p>
 Qux.value: <p>today</p>
 
-> ./mill wrapper.foo.run --foo-text hello
+> ./mill wrapper.foo.run --text hello
 Foo.value: <h1>hello</h1>
 
 */

--- a/example/basic/5-nested-modules/qux/src/Qux.scala
+++ b/example/basic/5-nested-modules/qux/src/Qux.scala
@@ -6,12 +6,12 @@ object Qux {
 
   @main
   def main(@arg(name="foo-text") fooText: String,
-           @arg(name="foo-text") barText: String,
-           @arg(name="foo-text") quxText: String): Unit = {
-    foo.Foo.main(text)
-    bar.Bar.main(text)
+           @arg(name="bar-text") barText: String,
+           @arg(name="qux-text") quxText: String): Unit = {
+    foo.Foo.main(fooText)
+    bar.Bar.main(barText)
 
-    val value = p(text)
+    val value = p(quxText)
     println("Qux.value: " + value)
   }
 

--- a/example/basic/5-nested-modules/qux/src/Qux.scala
+++ b/example/basic/5-nested-modules/qux/src/Qux.scala
@@ -1,11 +1,19 @@
 package qux
 import scalatags.Text.all._
+import mainargs.{main, ParserForMethods, arg}
 object Qux {
-  val value = p("today")
 
-  def main(args: Array[String]): Unit = {
-    println("Foo.value: " + foo.Foo.value)
-    println("Bar.value: " + bar.Bar.value)
-    println("Qux.value: " + qux.Qux.value)
+
+  @main
+  def main(@arg(name="foo-text") fooText: String,
+           @arg(name="foo-text") barText: String,
+           @arg(name="foo-text") quxText: String): Unit = {
+    foo.Foo.main(text)
+    bar.Bar.main(text)
+
+    val value = p(text)
+    println("Qux.value: " + value)
   }
+
+  def main(args: Array[String]): Unit = ParserForMethods(this).runOrExit(args)
 }

--- a/example/basic/5-nested-modules/wrapper/bar/src/Bar.scala
+++ b/example/basic/5-nested-modules/wrapper/bar/src/Bar.scala
@@ -1,5 +1,13 @@
 package bar
 import scalatags.Text.all._
+import mainargs.{main, ParserForMethods}
 object Bar {
-  val value = p("world")
+
+  @main
+  def main(text: String): Unit = {
+    val value = p(text)
+    println("Bar.value: " + value)
+  }
+
+  def main(args: Array[String]): Unit = ParserForMethods(this).runOrExit(args)
 }

--- a/example/basic/5-nested-modules/wrapper/foo/src/Foo.scala
+++ b/example/basic/5-nested-modules/wrapper/foo/src/Foo.scala
@@ -1,10 +1,12 @@
 package foo
 import scalatags.Text.all._
+import mainargs.{main, ParserForMethods}
 object Foo {
-  val value = h1("hello")
-
-  def main(args: Array[String]): Unit = {
-    println("Foo.value: " + Foo.value)
-    println("Bar.value: " + bar.Bar.value)
+  @main
+  def main(text: String): Unit = {
+    val value = h1(text)
+    println("Foo.value: " + value)
   }
+
+  def main(args: Array[String]): Unit = ParserForMethods(this).runOrExit(args)
 }


### PR DESCRIPTION
We don't need to use it in all the examples, but I added it to a few. That means that someone following the examples will at least get some hints about how to do command line argument parsing, which is a common requirement when writing small CLI tools and utilities.

Not strictly Mill/build-config related, but definitely handy for what we expect people to want to do with Mill