### PR TITLE
Bump Cask to 0.9.1 in example/web/

### DIFF
--- a/example/web/1-hello-webapp/build.sc
+++ b/example/web/1-hello-webapp/build.sc
@@ -4,7 +4,7 @@ object app extends RootModule with ScalaModule{
 
   def scalaVersion = "2.13.10"
   def ivyDeps = Agg(
-    ivy"com.lihaoyi::cask:0.9.0",
+    ivy"com.lihaoyi::cask:0.9.1",
     ivy"com.lihaoyi::scalatags:0.12.0"
   )
 

--- a/example/web/2-todo-webapp/build.sc
+++ b/example/web/2-todo-webapp/build.sc
@@ -4,7 +4,7 @@ object app extends RootModule with ScalaModule{
 
   def scalaVersion = "2.13.10"
   def ivyDeps = Agg(
-    ivy"com.lihaoyi::cask:0.9.0",
+    ivy"com.lihaoyi::cask:0.9.1",
     ivy"com.lihaoyi::scalatags:0.12.0"
   )
 

--- a/example/web/4-webapp-scalajs/build.sc
+++ b/example/web/4-webapp-scalajs/build.sc
@@ -4,7 +4,7 @@ object app extends RootModule with ScalaModule{
 
   def scalaVersion = "2.13.10"
   def ivyDeps = Agg(
-    ivy"com.lihaoyi::cask:0.9.0",
+    ivy"com.lihaoyi::cask:0.9.1",
     ivy"com.lihaoyi::scalatags:0.12.0"
   )
 

--- a/example/web/5-webapp-scalajs-shared/build.sc
+++ b/example/web/5-webapp-scalajs-shared/build.sc
@@ -12,7 +12,7 @@ object app extends RootModule with AppScalaModule{
 
   def moduleDeps = Seq(shared.jvm)
 
-  def ivyDeps = Agg(ivy"com.lihaoyi::cask:0.9.0")
+  def ivyDeps = Agg(ivy"com.lihaoyi::cask:0.9.1")
 
   def resources = T{
     os.makeDir(T.dest / "webapp")


### PR DESCRIPTION
This fixes the content type of the static resources, letting CSS load properly in the browser