### PR TITLE
enforce stdout/stderr contents in `.local` example/integration tests

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -822,7 +822,7 @@ object scalajslib extends MillModule with BuildInfo{
   }
   object worker extends Cross[WorkerModule]("1")
   class WorkerModule(scalajsWorkerVersion: String) extends MillInternalModule {
-    override def moduleDeps = Seq(scalajslib.`worker-api`)
+    override def moduleDeps = Seq(scalajslib.`worker-api`, main.client, main.api)
     override def ivyDeps = Agg(
       Deps.Scalajs_1.scalajsLinker,
       Deps.Scalajs_1.scalajsSbtTestAdapter,

--- a/ci/mill-bootstrap.patch
+++ b/ci/mill-bootstrap.patch
@@ -1,5 +1,5 @@
 diff --git a/build.sc b/build.sc
-index 8fcdeb538..c8155558d 100644
+index 4f70fbc1a4..6506f15622 100644
 --- a/build.sc
 +++ b/build.sc
 @@ -2,27 +2,18 @@
@@ -48,7 +48,7 @@ index 8fcdeb538..c8155558d 100644
  def millBinPlatform: T[String] = T {
    val tag = millLastTag()
    if (tag.contains("-M")) tag
-@@ -239,219 +226,23 @@ class BridgeModule(val crossScalaVersion: String) extends PublishModule with Cro
+@@ -240,219 +227,23 @@ class BridgeModule(val crossScalaVersion: String) extends PublishModule with Cro
    def generatedSources = T {
      import mill.scalalib.api.ZincWorkerUtil.{grepJar, scalaBinaryVersion}
      val resolvedJars = resolveDeps(
@@ -271,7 +271,7 @@ index 8fcdeb538..c8155558d 100644
  def commonPomSettings(artifactName: String) = {
    PomSettings(
      description = artifactName,
-@@ -505,27 +296,8 @@ trait MillCoursierModule extends CoursierModule {
+@@ -506,27 +297,8 @@ trait MillCoursierModule extends CoursierModule {
    )
  }
  
@@ -300,15 +300,15 @@ index 8fcdeb538..c8155558d 100644
  }
  
  /** A Module compiled with applied Mill-specific compiler plugins: mill-moduledefs. */
-@@ -821,6 +593,7 @@ object scalajslib extends MillModule with BuildInfo{
-   }
+@@ -823,6 +595,7 @@ object scalajslib extends MillModule with BuildInfo{
    object worker extends Cross[WorkerModule]("1")
    class WorkerModule(scalajsWorkerVersion: String) extends MillInternalModule {
+     override def moduleDeps = Seq(scalajslib.`worker-api`, main.client, main.api)
 +    override def millSourcePath: os.Path = super.millSourcePath / scalajsWorkerVersion
-     override def moduleDeps = Seq(scalajslib.`worker-api`)
      override def ivyDeps = Agg(
        Deps.Scalajs_1.scalajsLinker,
-@@ -883,6 +656,7 @@ object contrib extends MillModule {
+       Deps.Scalajs_1.scalajsSbtTestAdapter,
+@@ -884,6 +657,7 @@ object contrib extends MillModule {
  
      object worker extends Cross[WorkerModule](Deps.play.keys.toSeq: _*)
      class WorkerModule(playBinary: String) extends MillInternalModule {
@@ -316,7 +316,7 @@ index 8fcdeb538..c8155558d 100644
        override def sources = T.sources {
          // We want to avoid duplicating code as long as the Play APIs allow.
          // But if newer Play versions introduce incompatibilities,
-@@ -1074,6 +848,7 @@ object scalanativelib extends MillModule {
+@@ -1075,6 +849,7 @@ object scalanativelib extends MillModule {
    object worker extends Cross[WorkerModule]("0.4")
    class WorkerModule(scalaNativeWorkerVersion: String)
        extends MillInternalModule {

--- a/example/src/mill/integration/ExampleTestSuite.scala
+++ b/example/src/mill/integration/ExampleTestSuite.scala
@@ -144,18 +144,16 @@ object ExampleTestSuite extends IntegrationTestSuite {
     }
 
     for (expected <- unwrappedExpected) {
-      if (integrationTestMode != "local") {
-        println("ExampleTestSuite expected: " + expected)
+      println("ExampleTestSuite expected: " + expected)
 
-        def plainText(s: String) =
-          fansi.Str(s, errorMode = fansi.ErrorMode.Strip).plainText
-            .replace("\\\\", "/") // Convert windows paths in JSON strings to Unix
+      def plainText(s: String) =
+        fansi.Str(s, errorMode = fansi.ErrorMode.Strip).plainText
+          .replace("\\\\", "/") // Convert windows paths in JSON strings to Unix
 
-        val filteredErr = plainText(evalResult.err)
-        val filteredOut = plainText(evalResult.out)
+      val filteredErr = plainText(evalResult.err)
+      val filteredOut = plainText(evalResult.out)
 
-        assert(filteredErr.contains(expected) || filteredOut.contains(expected))
-      }
+      assert(filteredErr.contains(expected) || filteredOut.contains(expected))
     }
   }
 }

--- a/integration/feature/dynamic-cross-module/test/src/DynamicCrossModuleTests.scala
+++ b/integration/feature/dynamic-cross-module/test/src/DynamicCrossModuleTests.scala
@@ -22,9 +22,7 @@ object DynamicCrossModuleTests extends IntegrationTestSuite {
 
       val res2 = evalStdout("modules[bar].run")
       assert(res2.isSuccess == true)
-      if (integrationTestMode != "local") {
-        assert(res2.out.contains("Hello World Bar"))
-      }
+      assert(res2.out.contains("Hello World Bar"))
 
       val res3 = evalStdout("modules[new].run")
       assert(res3.isSuccess == false)
@@ -47,15 +45,11 @@ object DynamicCrossModuleTests extends IntegrationTestSuite {
 
       val res5 = evalStdout("modules[new].run")
       assert(res5.isSuccess == true)
-      if (integrationTestMode != "local") {
-        assert(res5.out.contains("Hello World New"))
-      }
+      assert(res5.out.contains("Hello World New"))
 
       val res6 = evalStdout("modules[newer].run")
       assert(res6.isSuccess == true)
-      if (integrationTestMode != "local") {
-        assert(res6.out.contains("Hello World Newer"))
-      }
+      assert(res6.out.contains("Hello World Newer"))
 
       val res7 = evalStdout("resolve", "modules._")
       assert(res7.isSuccess == true)

--- a/integration/feature/editing/test/src/MultiLevelBuildTests.scala
+++ b/integration/feature/editing/test/src/MultiLevelBuildTests.scala
@@ -17,9 +17,7 @@ object MultiLevelBuildTests extends IntegrationTestSuite {
     def runAssertSuccess(expected: String) = {
       val res = evalStdout("foo.run")
       assert(res.isSuccess == true)
-      // Don't check foo.run stdout in local mode, because it the subprocess
-      // println is not properly captured by the test harness
-      if (integrationTestMode != "local") assert(res.out.contains(expected))
+      assert(res.out.contains(expected))
     }
 
     val fooPaths = Seq(

--- a/integration/src/mill/integration/IntegrationTestSuite.scala
+++ b/integration/src/mill/integration/IntegrationTestSuite.scala
@@ -44,7 +44,7 @@ abstract class IntegrationTestSuite extends TestSuite {
 
   private def runnerStdout(stdout: PrintStream, stderr: PrintStream, s: Seq[String]) = {
     val streams = new SystemStreams(stdout, stderr, stdIn)
-    mill.util.Util.withStreams(streams) {
+    SystemStreams.withStreams(streams) {
       val config = MillCliConfig(
         debugLog = Flag(debugLog),
         keepGoing = Flag(keepGoing),

--- a/main/api/src/mill/api/SystemStreams.scala
+++ b/main/api/src/mill/api/SystemStreams.scala
@@ -34,7 +34,7 @@ object SystemStreams{
    * want to print stuff while the system streams override are messed up
    */
 
-  def originalErr = original.err
+  def originalErr: PrintStream = original.err
 
   def withStreams[T](systemStreams: SystemStreams)(t: => T): T = {
     val out = System.out

--- a/main/api/src/mill/api/SystemStreams.scala
+++ b/main/api/src/mill/api/SystemStreams.scala
@@ -9,10 +9,34 @@ class SystemStreams(
 )
 
 object SystemStreams{
-  val original = new SystemStreams(System.out, System.err, System.in)
+
+  private val original = new SystemStreams(System.out, System.err, System.in)
+
+  /**
+   * Used to check whether the system streams are all "original", i,e. they
+   * have not been overriden. Used for code paths that need to work differently
+   * if they have been overriden (e.g. handling subprocess stdout/stderr)
+   *
+   * Assumes that the application only uses [[withStreams]] to override
+   * stdout/stderr/stdin.
+   */
+  def isOriginal() = {
+    (System.out eq original.out) &&
+    (System.err eq original.err) &&
+    (System.in eq original.in) &&
+    (Console.out eq original.out) &&
+    (Console.err eq original.err) &&
+    (Console.in eq original.in)
+  }
+
+  /**
+   * The original non-override stderr, used for debugging purposes e.g. if you
+   * want to print stuff while the system streams override are messed up
+   */
+
+  def originalErr = original.err
 
   def withStreams[T](systemStreams: SystemStreams)(t: => T): T = {
-
     val out = System.out
     val in = System.in
     val err = System.err

--- a/main/api/src/mill/api/SystemStreams.scala
+++ b/main/api/src/mill/api/SystemStreams.scala
@@ -7,3 +7,30 @@ class SystemStreams(
     val err: PrintStream,
     val in: InputStream
 )
+
+object SystemStreams{
+  val original = new SystemStreams(System.out, System.err, System.in)
+
+  def withStreams[T](systemStreams: SystemStreams)(t: => T): T = {
+
+    val out = System.out
+    val in = System.in
+    val err = System.err
+    try {
+      System.setIn(systemStreams.in)
+      System.setErr(systemStreams.err)
+      System.setOut(systemStreams.out)
+      Console.withIn(systemStreams.in) {
+        Console.withOut(systemStreams.out) {
+          Console.withErr(systemStreams.err) {
+            t
+          }
+        }
+      }
+    } finally {
+      System.setErr(err)
+      System.setOut(out)
+      System.setIn(in)
+    }
+  }
+}

--- a/main/api/src/mill/api/SystemStreams.scala
+++ b/main/api/src/mill/api/SystemStreams.scala
@@ -20,7 +20,7 @@ object SystemStreams{
    * Assumes that the application only uses [[withStreams]] to override
    * stdout/stderr/stdin.
    */
-  def isOriginal() = {
+  def isOriginal(): Boolean = {
     (System.out eq original.out) &&
     (System.err eq original.err) &&
     (System.in eq original.in) &&

--- a/main/core/src/mill/eval/Evaluator.scala
+++ b/main/core/src/mill/eval/Evaluator.scala
@@ -578,7 +578,7 @@ class Evaluator private (
           val out = System.out
           val in = System.in
           val err = System.err
-          mill.util.Util.withStreams(multiLogger.systemStreams) {
+          mill.api.SystemStreams.withStreams(multiLogger.systemStreams) {
             try task.evaluate(args)
             catch {
               case NonFatal(e) =>

--- a/main/src/mill/modules/Jvm.scala
+++ b/main/src/mill/modules/Jvm.scala
@@ -163,7 +163,7 @@ object Jvm extends CoursierSupport {
     // to the parent process's origin outputs even if we want to direct them
     // elsewhere
 
-    if (System.in != SystemStreams.original.in) {
+    if (!SystemStreams.isOriginal()) {
       val process = os.proc(commandArgs).spawn(
         cwd = workingDir,
         env = envArgs,

--- a/main/src/mill/modules/Jvm.scala
+++ b/main/src/mill/modules/Jvm.scala
@@ -144,6 +144,7 @@ object Jvm extends CoursierSupport {
     else throw new Exception("Interactive Subprocess Failed (exit code " + process.exitCode() + ")")
   }
 
+
   /**
    * Spawns a generic subprocess, streaming the stdout and stderr to the
    * console. If the System.out/System.err have been substituted, makes sure
@@ -162,7 +163,7 @@ object Jvm extends CoursierSupport {
     // to the parent process's origin outputs even if we want to direct them
     // elsewhere
 
-    if (System.in.isInstanceOf[PipedInputStream]) {
+    if (System.in != SystemStreams.original.in) {
       val process = os.proc(commandArgs).spawn(
         cwd = workingDir,
         env = envArgs,

--- a/main/util/src/mill/util/Util.scala
+++ b/main/util/src/mill/util/Util.scala
@@ -11,27 +11,4 @@ object Util {
   val windowsPlatform = System.getProperty("os.name").startsWith("Windows")
 
   val java9OrAbove = !System.getProperty("java.specification.version").startsWith("1.")
-
-  def withStreams[T](systemStreams: SystemStreams)(t: => T): T = {
-
-    val out = System.out
-    val in = System.in
-    val err = System.err
-    try {
-      System.setIn(systemStreams.in)
-      System.setErr(systemStreams.err)
-      System.setOut(systemStreams.out)
-      Console.withIn(systemStreams.in) {
-        Console.withOut(systemStreams.out) {
-          Console.withErr(systemStreams.err) {
-            t
-          }
-        }
-      }
-    } finally {
-      System.setErr(err)
-      System.setOut(out)
-      System.setIn(in)
-    }
-  }
 }

--- a/runner/src/mill/runner/MillMain.scala
+++ b/runner/src/mill/runner/MillMain.scala
@@ -76,7 +76,7 @@ object MillMain {
   ): (Boolean, RunnerState) = {
     val printLoggerState = new PrintLogger.State()
     val streams = PrintLogger.wrapSystemStreams(streams0, printLoggerState)
-    Util.withStreams(streams) {
+    SystemStreams.withStreams(streams) {
       MillCliConfigParser.parse(args) match {
         // Cannot parse args
         case Left(msg) =>

--- a/scalajslib/worker/1/src/mill/scalajslib/worker/ScalaJSWorkerImpl.scala
+++ b/scalajslib/worker/1/src/mill/scalajslib/worker/ScalaJSWorkerImpl.scala
@@ -262,7 +262,7 @@ class ScalaJSWorkerImpl extends ScalaJSWorkerApi {
     val input = jsEnvInput(report)
     val runConfig0 = RunConfig().withLogger(new ScalaConsoleLogger)
     val runConfig =
-      if (System.in == mill.api.SystemStreams.original.in) runConfig0
+      if (mill.api.SystemStreams.isOriginal()) runConfig0
       else runConfig0
         .withInheritErr(false)
         .withInheritOut(false)

--- a/scalajslib/worker/1/src/mill/scalajslib/worker/ScalaJSWorkerImpl.scala
+++ b/scalajslib/worker/1/src/mill/scalajslib/worker/ScalaJSWorkerImpl.scala
@@ -260,7 +260,27 @@ class ScalaJSWorkerImpl extends ScalaJSWorkerApi {
   def run(config: JsEnvConfig, report: Report): Unit = {
     val env = jsEnv(config)
     val input = jsEnvInput(report)
-    val runConfig = RunConfig().withLogger(new ScalaConsoleLogger)
+    val runConfig0 = RunConfig().withLogger(new ScalaConsoleLogger)
+    val runConfig =
+      if (System.in == mill.api.SystemStreams.original.in) runConfig0
+      else runConfig0
+        .withInheritErr(false)
+        .withInheritOut(false)
+        .withOnOutputStream{case (Some(processOut), Some(processErr)) =>
+          val sources = Seq(
+            (processOut, System.out, "spawnSubprocess.stdout", false, () => true),
+            (processErr, System.err, "spawnSubprocess.stderr", false, () => true)
+          )
+
+          for ((std, dest, name, checkAvailable, runningCheck) <- sources) {
+            val t = new Thread(
+              new mill.main.client.InputPumper(std, dest, checkAvailable, () => runningCheck()),
+              name
+            )
+            t.setDaemon(true)
+            t.start()
+          }
+        }
     Run.runInterruptible(env, input, runConfig)
   }
 


### PR DESCRIPTION
This should allow us to do debugging or iteration on example/integration in `.local` mode, which is a lot faster than `.fork` or `.server`

Even after https://github.com/com-lihaoyi/mill/pull/2425 landed, the `.local` integration tests are still much faster to run than `.fork` and `.server`, with publishing taking ~20s down from ~60s before which is still a very annoying wait. Better if we can avoid that, using `.local` in the common development workflow and leaving `.fork` and `.server` for CI to catch rare edge-case bugs

We basically needed to be a bit more robust in spawning subprocesses, allowing the `InputPumper` machinery to work for any redirected streams rather than being hardcoded to work with the `PipedInputStream` that `MillServerMain` uses.

I had to fix an issue in `ScalaJSModule#run` to make `example.web[3-scalajs-module].local.test` pass with this additional enforcement. It appears we were not properly pumping the JSEnv subprocess stdout/stderr. This would cause the outputs to disappear when run repeatedly in client-server mode, since the output would be inherited by first MillClient process that spawned the server, and not subsequent clients that simply connect to it