### PR TITLE
CI: ignore failing bincompat reports

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -84,13 +84,12 @@ jobs:
       buildcmd: ./mill -i -k mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll __.sources
 
   bincompat-check:
-    # when doing milestone builds, this may be true
-    continue-on-error: true
     uses: ./.github/workflows/run-mill-action.yml
     with:
       os: ubuntu-latest
       java-version: '8'
       buildcmd: ./mill -i -k __.mimaReportBinaryIssues
+      continue-on-error: true
 
   test-windows:
     strategy:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -84,6 +84,8 @@ jobs:
       buildcmd: ./mill -i -k mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll __.sources
 
   bincompat-check:
+    # when doing milestone builds, this may be true
+    continue-on-error: true
     uses: ./.github/workflows/run-mill-action.yml
     with:
       os: ubuntu-latest

--- a/.github/workflows/run-mill-action.yml
+++ b/.github/workflows/run-mill-action.yml
@@ -12,10 +12,16 @@ on:
       os:
         required: true
         type: string
+      continue-on-error:
+        default: false
+        type: boolean
 
 jobs:
   build:
+
     runs-on: ${{ inputs.os }}
+    continue-on-error: ${{ inputs.continue-on-error }}
+
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
This means, although the bincompat-check fails, the overall report is marked as successful run.