### PR TITLE
Fix spurious `T.command` definitions must have 1 parameter list error

### DIFF
--- a/main/core/src/mill/define/Discover.scala
+++ b/main/core/src/mill/define/Discover.scala
@@ -65,7 +65,9 @@ object Discover {
       ): Unit = {
         for (m <- methods.toList) {
           cases
-            .find { case (tt, n, label) => m.returnType <:< tt }
+            .find { case (tt, n, label) =>
+              m.returnType <:< tt && !(m.returnType <:< weakTypeOf[Nothing])
+            }
             .foreach { case (tt, n, label) =>
               if (m.paramLists.length != n) c.abort(
                 m.pos,


### PR DESCRIPTION
This used to happen when a target had a compile error, causing it's return type to be `Nothing`. This PR explicitly ignores that case

Tested manually. For some reason, the `compileError` macro in uTest isn't able to pick up this error, so I can't catch it and assert