### PR TITLE
Update testng to 7.5.1

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -133,7 +133,8 @@ object Deps {
   val millModuledefs = ivy"${millModuledefsString}"
   val millModuledefsPlugin =
     ivy"com.lihaoyi:::scalac-mill-moduledefs-plugin:${millModuledefsVersion}"
-  val testng = ivy"org.testng:testng:7.5"
+  // can't use newer versions, as these need higher Java versions
+  val testng = ivy"org.testng:testng:7.5.1"
   val sbtTestInterface = ivy"org.scala-sbt:test-interface:1.0"
   val scalaCheck = ivy"org.scalacheck::scalacheck:1.17.0"
   def scalaCompiler(scalaVersion: String) = ivy"org.scala-lang:scala-compiler:${scalaVersion}"


### PR DESCRIPTION
This fixes a security vulnerability discovered in https://github.com/cbeust/testng/issues/2852
