### PR TITLE
Fix crash aggregating failures

### DIFF
--- a/main/core/src/mill/eval/Evaluator.scala
+++ b/main/core/src/mill/eval/Evaluator.scala
@@ -182,7 +182,11 @@ class Evaluator private (
     for ((k, vs) <- sortedGroups.items()) {
       failing.addAll(
         k,
-        vs.items.flatMap(results.get).collect { case f: mill.api.Result.Failing[_] => f.map(_._1) }
+        Loose.Agg.from(
+          vs.items.flatMap(results.get).collect { case f: mill.api.Result.Failing[_] =>
+            f.map(_._1)
+          }
+        )
       )
     }
     failing


### PR DESCRIPTION
The current code is crashing since it's trying to insert twice the same failure when it's linked to multiple tasks.
My solution was to wrap the Iterator into a `Loose.Agg` so we remove the duplicates before adding to the `MultiBiMap`, which uses `Strict.Agg`.

Before:
![immagine](https://user-images.githubusercontent.com/5793054/235160680-99e5f802-4319-4957-8f88-71a7dd65256d.png)

After:
![immagine](https://user-images.githubusercontent.com/5793054/235160452-3226913a-6897-49df-ab95-7c87b9aa7951.png)
