### PR TITLE
Remove the ability for T.inputs and T.sources to take input tasks

### DIFF
--- a/ci/mill-bootstrap.patch
+++ b/ci/mill-bootstrap.patch
@@ -1,5 +1,5 @@
 diff --git a/build.sc b/build.sc
-index d7275ab3de..96c5bc0d9c 100644
+index efdd619224..30e988d0eb 100644
 --- a/build.sc
 +++ b/build.sc
 @@ -25,8 +25,10 @@ import mill.main.MainModule
@@ -41,6 +41,15 @@ index d7275ab3de..96c5bc0d9c 100644
    def scalaVersion = crossScalaVersion
    def publishVersion = bridgeVersion
    def artifactName = T { "mill-scala-compiler-bridge" }
+@@ -229,7 +227,7 @@ class BridgeModule(val crossScalaVersion: String) extends PublishModule with Cro
+     ivy"org.scala-lang:scala-compiler:${crossScalaVersion}"
+   )
+ 
+-  def resources = T.sources {
++  def resources = T{
+     os.copy(generatedSources().head.path / "META-INF", T.dest / "META-INF")
+     Seq(PathRef(T.dest))
+   }
 @@ -237,239 +235,25 @@ class BridgeModule(val crossScalaVersion: String) extends PublishModule with Cro
    def generatedSources = T {
      import mill.scalalib.api.ZincWorkerUtil.{grepJar, scalaBinaryVersion}
@@ -315,7 +324,7 @@ index d7275ab3de..96c5bc0d9c 100644
  }
  
  /** A Module compiled with applied Mill-specific compiler plugins: mill-moduledefs. */
-@@ -846,7 +611,10 @@ object scalajslib extends MillModule with BuildInfo {
+@@ -850,7 +615,10 @@ object scalajslib extends MillModule with BuildInfo {
      override def ivyDeps = Agg(Deps.sbtTestInterface)
    }
    object worker extends Cross[WorkerModule]("1")
@@ -327,20 +336,22 @@ index d7275ab3de..96c5bc0d9c 100644
      def testDepPaths = T{ Seq(compile().classes) }
      override def moduleDeps = Seq(scalajslib.`worker-api`, main.client, main.api)
      override def ivyDeps = Agg(
-@@ -911,8 +679,10 @@ object contrib extends MillModule {
+@@ -915,9 +683,11 @@ object contrib extends MillModule {
  
      object api extends MillPublishModule
  
 -    object worker extends Cross[WorkerModule](Deps.play.keys.toSeq: _*)
 -    class WorkerModule(playBinary: String) extends MillInternalModule {
+-      override def sources = T.sources {
 +    object worker extends Cross[WorkerModule](Deps.play.keys.toSeq)
 +    trait WorkerModule extends MillInternalModule with Cross.Module[String] {
 +      def playBinary = crossValue
 +      override def millSourcePath: os.Path = super.millSourcePath / playBinary
-       override def sources = T.sources {
++      override def sources = T {
          // We want to avoid duplicating code as long as the Play APIs allow.
          // But if newer Play versions introduce incompatibilities,
-@@ -1074,8 +844,9 @@ object scalanativelib extends MillModule {
+         // just remove the shared source dir for that worker and implement directly.
+@@ -1078,8 +848,9 @@ object scalanativelib extends MillModule {
      override def ivyDeps = Agg(Deps.sbtTestInterface)
    }
    object worker extends Cross[WorkerModule]("0.4")
@@ -352,7 +363,7 @@ index d7275ab3de..96c5bc0d9c 100644
      def testDepPaths = T{ Seq(compile().classes) }
      override def moduleDeps = Seq(scalanativelib.`worker-api`)
      override def ivyDeps = scalaNativeWorkerVersion match {
-@@ -1228,7 +999,9 @@ trait IntegrationTestModule extends MillScalaModule {
+@@ -1229,7 +1000,9 @@ trait IntegrationTestModule extends MillScalaModule {
    }
  }
  
@@ -363,7 +374,7 @@ index d7275ab3de..96c5bc0d9c 100644
    object local extends ModeModule{
      def testTransitiveDeps = super.testTransitiveDeps() ++ Seq(
        runner.linenumbers.testDep(),
-@@ -1254,15 +1027,15 @@ object example extends MillScalaModule {
+@@ -1250,15 +1023,15 @@ object example extends MillScalaModule {
  
    def moduleDeps = Seq(integration)
  
@@ -387,7 +398,7 @@ index d7275ab3de..96c5bc0d9c 100644
      def sources = T.sources()
      def testRepoRoot: T[PathRef] = T.source(millSourcePath)
      def compile = example.compile()
-@@ -1312,7 +1085,7 @@ object example extends MillScalaModule {
+@@ -1308,7 +1081,7 @@ object example extends MillScalaModule {
                val title =
                  if (seenCode) ""
                  else {
@@ -396,7 +407,7 @@ index d7275ab3de..96c5bc0d9c 100644
                    val exampleDashed = examplePath.segments.mkString("-")
                    val download = s"{mill-download-url}/$label-$exampleDashed.zip[download]"
                    val browse = s"{mill-example-url}/$examplePath[browse]"
-@@ -1343,9 +1116,9 @@ object example extends MillScalaModule {
+@@ -1339,9 +1112,9 @@ object example extends MillScalaModule {
  }
  
  object integration extends MillScalaModule {
@@ -409,7 +420,7 @@ index d7275ab3de..96c5bc0d9c 100644
  
    def moduleDeps = Seq(scalalib, scalajslib, scalanativelib, runner.test)
  
-@@ -1677,67 +1450,11 @@ object docs extends Module {
+@@ -1666,67 +1439,11 @@ object docs extends Module {
      def moduleDeps = build.millInternal.modules.collect { case m: MillApiModule => m }
  
      def unidocSourceUrl = T {
@@ -478,7 +489,7 @@ index d7275ab3de..96c5bc0d9c 100644
    private val npmExe = if (scala.util.Properties.isWin) "npm.cmd" else "npm"
    private val antoraExe = if (scala.util.Properties.isWin) "antora.cmd" else "antora"
    def npmBase: T[os.Path] = T.persistent { T.dest }
-@@ -1790,7 +1507,7 @@ object docs extends Module {
+@@ -1779,7 +1496,7 @@ object docs extends Module {
  
      val contribReadmes = T.traverse(contrib.contribModules)(m =>
        T.task {
@@ -487,7 +498,7 @@ index d7275ab3de..96c5bc0d9c 100644
        }
      )()
  
-@@ -2019,7 +1736,7 @@ def exampleZips: Target[Seq[PathRef]] = T {
+@@ -2009,7 +1726,7 @@ def exampleZips: Target[Seq[PathRef]] = T {
      examplePath = exampleMod.millSourcePath
    } yield {
      val example = examplePath.subRelativeTo(T.workspace)
@@ -496,7 +507,7 @@ index d7275ab3de..96c5bc0d9c 100644
      os.copy(examplePath, T.dest / exampleStr, createFolders = true)
      os.copy(launcher().path, T.dest / exampleStr / "mill")
      val zip = T.dest / s"$exampleStr.zip"
-@@ -2028,49 +1745,7 @@ def exampleZips: Target[Seq[PathRef]] = T {
+@@ -2018,49 +1735,7 @@ def exampleZips: Target[Seq[PathRef]] = T {
    }
  }
  

--- a/main/define/test/src/mill/define/MacroErrorTests.scala
+++ b/main/define/test/src/mill/define/MacroErrorTests.scala
@@ -170,5 +170,42 @@ object MacroErrorTests extends TestSuite {
         "could not find implicit value for evidence parameter of type mill.define.Cross.ToSegments[sun.misc.Unsafe]"
       ))
     }
+
+    "inputsNoDeps" - {
+      val error = utest.compileError(
+        """
+        object foo extends mill.util.TestUtil.BaseModule{
+          def task = T.task("hello")
+          def input = T.input(task())
+        }
+      """
+      )
+      assert(error.pos.contains("def input = T.input(task())"))
+      assert(error.msg.contains("Target#apply() can only be used with a T{...} block"))
+    }
+    "sourceNoDeps" - {
+      val error = utest.compileError(
+        """
+        object foo extends mill.util.TestUtil.BaseModule{
+          def task = T.task(mill.api.PathRef(os.pwd))
+          def source = T.input(task())
+        }
+      """
+      )
+      assert(error.pos.contains("def source = T.input(task())"))
+      assert(error.msg.contains("Target#apply() can only be used with a T{...} block"))
+    }
+    "sourcesNoDeps" - {
+      val error = utest.compileError(
+        """
+        object foo extends mill.util.TestUtil.BaseModule{
+          def task = T.task(Seq(mill.api.PathRef(os.pwd)))
+          def sources = T.input(task())
+        }
+      """
+      )
+      assert(error.pos.contains("def sources = T.input(task())"))
+      assert(error.msg.contains("Target#apply() can only be used with a T{...} block"))
+    }
   }
 }


### PR DESCRIPTION
`T.sources` or `T.input` taking task inputs used to be necessary to allow them to be overriden and extended, e.g.

```scala
override def sources = T.sources{super.sources() ++ Seq(PathRef(...))}
```

However that workflow is no longer necessary since https://github.com/com-lihaoyi/mill/pull/2402 landed, since now you can do:

```scala
override def sources = T{super.sources() ++ Seq(PathRef(...))}
```

Which is generally more correct, since the current task is no longer a "source" input to the Mill build graph, but rather an intermediate target like any other.

The fact that `T.input`s and `T.source`s can themselves take input tasks isn't very intuitive, since most people do not imagine that build graph tasks can both be inputs as intermediate targets at the same time. Since it is now no longer necessary, better to prohibit it unless there's a strong reason not to, to simplify the data/execution model and reduce the unnecessarily different ways of implementing the same build

Tested via `compileError` assertions in `MacroErrorTests.scala`