### PR TITLE
Added a deprecated type alias for removed `EvaluatorScopts`

### DIFF
--- a/main/src/mill/main/TokenReaders.scala
+++ b/main/src/mill/main/TokenReaders.scala
@@ -24,7 +24,7 @@ object Tasks {
 }
 
 class EvaluatorTokenReader[T]() extends mainargs.TokensReader.Constant[mill.eval.Evaluator] {
-  def read() = Right(Evaluator.currentEvaluator.value)
+  def read(): Either[String, Evaluator] = Right(Evaluator.currentEvaluator.value)
 }
 
 class LeftoverTaskTokenReader[T](tokensReaderOfT: TokensReader.Leftover[T, _])

--- a/main/src/mill/main/package.scala
+++ b/main/src/mill/main/package.scala
@@ -1,0 +1,6 @@
+package mill
+
+package object main {
+  @deprecated("Renamed to EvaluatorTokenReader.", "Mill 0.11.0-M8")
+  type EvaluatorScopts[T] = EvaluatorTokenReader[T]
+}


### PR DESCRIPTION
Fix https://github.com/com-lihaoyi/mill/issues/2459
