### PR TITLE
Enable `inspect`, `path`, etc. on `T.command`s without needing to pass in args in common cases

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -104,7 +104,7 @@ jobs:
           - java-version: 17
             # just run a subset of examples/ on Windows, because for some reason running
             # the whole suite can take hours on windows v.s. half an hour on linux
-            buildcmd: cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i -d -k "example.scalabuilds.local.test"
+            buildcmd: cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i -d -k "example[scalabuilds].local.test"
           - java-version: 17
             buildcmd: cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i -d -k "integration.feature.__.fork.test"
           - java-version: 17

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -104,7 +104,7 @@ jobs:
           - java-version: 17
             # just run a subset of examples/ on Windows, because for some reason running
             # the whole suite can take hours on windows v.s. half an hour on linux
-            buildcmd: cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i -d -k "example.scalabuilds.__.local.test"
+            buildcmd: cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i -d -k "example.{scalabuilds,scalamodule,cross,tasks}.__.local.test"
           - java-version: 17
             buildcmd: cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i -d -k "integration.feature.__.fork.test"
           - java-version: 17

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -102,7 +102,9 @@ jobs:
         include:
           # Limit some tests to Java 17 to limit CI times
           - java-version: 17
-            buildcmd: cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i -d -k "example.__.local.test"
+            # just run a subset of examples/ on Windows, because for some reason running
+            # the whole suite can take hours on windows v.s. half an hour on linux
+            buildcmd: cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i -d -k "example.scalabuilds.local.test"
           - java-version: 17
             buildcmd: cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i -d -k "integration.feature.__.fork.test"
           - java-version: 17

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -104,7 +104,7 @@ jobs:
           - java-version: 17
             # just run a subset of examples/ on Windows, because for some reason running
             # the whole suite can take hours on windows v.s. half an hour on linux
-            buildcmd: cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i -d -k "example.{scalabuilds,scalamodule,cross,tasks}.__.local.test"
+            buildcmd: cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i -d -k "example.{scalabuilds,cross,tasks}.__.local.test"
           - java-version: 17
             buildcmd: cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i -d -k "integration.feature.__.fork.test"
           - java-version: 17

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -104,7 +104,7 @@ jobs:
           - java-version: 17
             # just run a subset of examples/ on Windows, because for some reason running
             # the whole suite can take hours on windows v.s. half an hour on linux
-            buildcmd: cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i -d -k "example[scalabuilds].local.test"
+            buildcmd: cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i -d -k "example.scalabuilds.__.local.test"
           - java-version: 17
             buildcmd: cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i -d -k "integration.feature.__.fork.test"
           - java-version: 17

--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageReport.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageReport.scala
@@ -83,7 +83,7 @@ trait ScoverageReport extends Module {
     val sourcesTasks: Seq[Task[Seq[PathRef]]] = ResolveTasks.resolve(
       evaluator,
       Seq(sources),
-      SelectMode.Single
+      SelectMode.Separated
     ) match {
       case Left(err) => throw new Exception(err)
       case Right(tasks) => tasks.asInstanceOf[Seq[Task[Seq[PathRef]]]]
@@ -91,7 +91,7 @@ trait ScoverageReport extends Module {
     val dataTasks: Seq[Task[PathRef]] = ResolveTasks.resolve(
       evaluator,
       Seq(dataTargets),
-      SelectMode.Single
+      SelectMode.Separated
     ) match {
       case Left(err) => throw new Exception(err)
       case Right(tasks) => tasks.asInstanceOf[Seq[Task[PathRef]]]

--- a/integration/src/mill/integration/IntegrationTestSuite.scala
+++ b/integration/src/mill/integration/IntegrationTestSuite.scala
@@ -84,7 +84,7 @@ abstract class IntegrationTestSuite extends TestSuite {
 
   def meta(s: String): String = {
     val Seq((List(selector), _)) =
-      mill.main.ParseArgs.apply(Seq(s), SelectMode.Single).getOrElse(???)
+      mill.main.ParseArgs.apply(Seq(s), SelectMode.Separated).getOrElse(???)
 
     val segments = selector._2.value.flatMap(_.pathSegments)
     os.read(wd / "out" / segments.init / s"${segments.last}.json")

--- a/main/src/mill/main/MainModule.scala
+++ b/main/src/mill/main/MainModule.scala
@@ -393,7 +393,7 @@ trait MainModule extends mill.Module {
     RunScript.evaluateTasksNamed(
       evaluator,
       Seq("mill.scalalib.giter8.Giter8Module/init") ++ args,
-      SelectMode.Single
+      SelectMode.Separated
     )
 
     ()

--- a/main/src/mill/main/ParseArgs.scala
+++ b/main/src/mill/main/ParseArgs.scala
@@ -13,9 +13,6 @@ object SelectMode {
   /** All args are treated as targets or commands. If a `--` is detected, subsequent args are parameters to all commands. */
   object Multi extends SelectMode
 
-  /** Only the first arg is treated as target or command, subsequent args are parameters of the command. */
-  object Single extends SelectMode
-
   /** Like a combination of [[Single]] and [[Multi]], behaving like [[Single]] but using a special separator (`++`) to start parsing another target/command. */
   object Separated extends SelectMode
 }

--- a/main/src/mill/main/Resolve.scala
+++ b/main/src/mill/main/Resolve.scala
@@ -10,7 +10,8 @@ object ResolveSegments extends Resolve[Segments] {
       resolved: Seq[Resolved],
       discover: Discover[_],
       args: Seq[String],
-      selector: Segments
+      selector: Segments,
+      nullCommandDefaults: Boolean
   ) = {
     Right(resolved.map(_.segments))
   }
@@ -21,7 +22,8 @@ object ResolveMetadata extends Resolve[String] {
       resolved: Seq[Resolved],
       discover: Discover[_],
       args: Seq[String],
-      selector: Segments
+      selector: Segments,
+      nullCommandDefaults: Boolean
   ) = {
     Right(resolved.map(_.segments.render))
   }
@@ -32,7 +34,8 @@ object ResolveTasks extends Resolve[NamedTask[Any]] {
       resolved: Seq[Resolved],
       discover: Discover[_],
       args: Seq[String],
-      selector: Segments
+      selector: Segments,
+      nullCommandDefaults: Boolean
   ) = {
 
     val taskList: Seq[Either[String, NamedTask[_]]] = resolved
@@ -46,7 +49,8 @@ object ResolveTasks extends Resolve[NamedTask[Any]] {
               Some(value.defaultCommandName()),
               discover,
               args,
-              value.millModuleSegments
+              value.millModuleSegments,
+              nullCommandDefaults
             ).head match {
               case r: Resolved.Target => r.valueOrErr
               case r: Resolved.Command => r.valueOrErr
@@ -64,7 +68,8 @@ trait Resolve[T] {
       resolved: Seq[Resolved],
       discover: Discover[_],
       args: Seq[String],
-      segments: Segments
+      segments: Segments,
+      nullCommandDefaults: Boolean
   ): Either[String, Seq[T]]
 
   def resolve(
@@ -80,12 +85,13 @@ trait Resolve[T] {
       scriptArgs: Seq[String],
       selectMode: SelectMode
   ): Either[String, List[T]] = {
+    val nullCommandDefaults = selectMode == SelectMode.Multi
     val resolvedGroups = ParseArgs(scriptArgs, selectMode).flatMap { groups =>
       val resolved = groups.map { case (selectors, args) =>
         val selected = selectors.map { case (scopedSel, sel) =>
           resolveRootModule(baseModule, scopedSel).map { rootModule =>
             evaluatorOpt match {
-              case None => resolveNonEmptyAndHandle(args, sel, rootModule)
+              case None => resolveNonEmptyAndHandle(args, sel, rootModule, nullCommandDefaults)
               case Some(eval) =>
                 // We inject the `evaluator.rootModule` into the TargetScopt, rather
                 // than the `rootModule`, because even if you are running an external
@@ -93,7 +99,7 @@ trait Resolve[T] {
                 // main build. Resolving targets from external builds as CLI arguments
                 // is not currently supported
                 mill.eval.Evaluator.currentEvaluator.withValue(eval) {
-                  resolveNonEmptyAndHandle(args, sel, rootModule)
+                  resolveNonEmptyAndHandle(args, sel, rootModule, nullCommandDefaults)
                 }
             }
           }
@@ -114,11 +120,13 @@ trait Resolve[T] {
   def resolveNonEmptyAndHandle(
       args: Seq[String],
       sel: Segments,
-      rootModule: BaseModule
+      rootModule: BaseModule,
+      nullCommandDefaults: Boolean
   ): Either[String, Seq[T]] = {
-    ResolveNonEmpty.resolveNonEmpty(sel.value.toList, rootModule, rootModule.millDiscover, args)
+    ResolveNonEmpty
+      .resolveNonEmpty(sel.value.toList, rootModule, rootModule.millDiscover, args, nullCommandDefaults)
       .map(_.toSeq.sortBy(_.segments.render))
-      .flatMap(handleResolved(_, rootModule.millDiscover, args, sel))
+      .flatMap(handleResolved(_, rootModule.millDiscover, args, sel, nullCommandDefaults))
   }
 
   def resolveRootModule(rootModule: BaseModule, scopedSel: Option[Segments]) = {

--- a/main/src/mill/main/Resolve.scala
+++ b/main/src/mill/main/Resolve.scala
@@ -124,7 +124,13 @@ trait Resolve[T] {
       nullCommandDefaults: Boolean
   ): Either[String, Seq[T]] = {
     ResolveNonEmpty
-      .resolveNonEmpty(sel.value.toList, rootModule, rootModule.millDiscover, args, nullCommandDefaults)
+      .resolveNonEmpty(
+        sel.value.toList,
+        rootModule,
+        rootModule.millDiscover,
+        args,
+        nullCommandDefaults
+      )
       .map(_.toSeq.sortBy(_.segments.render))
       .flatMap(handleResolved(_, rootModule.millDiscover, args, sel, nullCommandDefaults))
   }

--- a/main/src/mill/main/ResolveCore.scala
+++ b/main/src/mill/main/ResolveCore.scala
@@ -86,13 +86,27 @@ object ResolveCore {
                 ).map(
                   _.flatMap(m =>
                     Seq(Resolved.Module(m.millModuleSegments, Right(m))) ++
-                      resolveDirectChildren(m, None, discover, args, m.millModuleSegments, nullCommandDefaults)
+                      resolveDirectChildren(
+                        m,
+                        None,
+                        discover,
+                        args,
+                        m.millModuleSegments,
+                        nullCommandDefaults
+                      )
                   )
                 )
 
                 res
               case "_" =>
-                Right(resolveDirectChildren(obj, None, discover, args, current.segments, nullCommandDefaults))
+                Right(resolveDirectChildren(
+                  obj,
+                  None,
+                  discover,
+                  args,
+                  current.segments,
+                  nullCommandDefaults
+                ))
               case _ =>
                 Right(resolveDirectChildren(
                   obj,
@@ -252,7 +266,7 @@ object ResolveCore {
     val flattenedArgSigsWithDefaults = ep
       ._2
       .flattenedArgSigs
-      .map{case (arg, term) => (withNullDefault(arg), term)}
+      .map { case (arg, term) => (withNullDefault(arg), term) }
 
     mainargs.TokenGrouping.groupArgs(
       rest,
@@ -261,7 +275,6 @@ object ResolveCore {
       allowRepeats = false,
       allowLeftover = ep._2.argSigs0.exists(_.reader.isLeftover)
     ).flatMap { (grouped: TokenGrouping[_]) =>
-
       val mainData = ep._2.asInstanceOf[MainData[_, Any]]
       val mainDataWithDefaults = mainData
         .copy(argSigs0 = mainData.argSigs0.map(withNullDefault))

--- a/main/src/mill/main/ResolveCore.scala
+++ b/main/src/mill/main/ResolveCore.scala
@@ -267,8 +267,7 @@ object ResolveCore {
           if (a.reader.isInstanceOf[SimpleTaskTokenReader[_]]) Some(_ => Target.task(null))
           else Some(_ => null)
         )
-      }
-      else a
+      } else a
     }
 
     val flattenedArgSigsWithDefaults = ep

--- a/main/src/mill/main/ResolveCore.scala
+++ b/main/src/mill/main/ResolveCore.scala
@@ -51,13 +51,14 @@ object ResolveCore {
       current: Resolved,
       discover: Discover[_],
       args: Seq[String],
-      querySoFar: Segments
+      querySoFar: Segments,
+      nullCommandDefaults: Boolean
   ): Result = remainingQuery match {
     case Nil => Success(Set(current))
     case head :: tail =>
       def recurse(searchModules: Set[Resolved]): Result = {
         val (failures, successesLists) = searchModules
-          .map(r => resolve(tail, r, discover, args, querySoFar ++ Seq(head)))
+          .map(r => resolve(tail, r, discover, args, querySoFar ++ Seq(head), nullCommandDefaults))
           .partitionMap { case s: Success => Right(s.value); case f: Failed => Left(f) }
 
         val (errors, notFounds) = failures.partitionMap {
@@ -69,7 +70,7 @@ object ResolveCore {
         else if (successesLists.flatten.nonEmpty) Success(successesLists.flatten)
         else notFounds.size match {
           case 1 => notFounds.head
-          case _ => notFoundResult(querySoFar, current, head, discover, args)
+          case _ => notFoundResult(querySoFar, current, head, discover, args, nullCommandDefaults)
         }
       }
 
@@ -85,20 +86,21 @@ object ResolveCore {
                 ).map(
                   _.flatMap(m =>
                     Seq(Resolved.Module(m.millModuleSegments, Right(m))) ++
-                      resolveDirectChildren(m, None, discover, args, m.millModuleSegments)
+                      resolveDirectChildren(m, None, discover, args, m.millModuleSegments, nullCommandDefaults)
                   )
                 )
 
                 res
               case "_" =>
-                Right(resolveDirectChildren(obj, None, discover, args, current.segments))
+                Right(resolveDirectChildren(obj, None, discover, args, current.segments, nullCommandDefaults))
               case _ =>
                 Right(resolveDirectChildren(
                   obj,
                   Some(singleLabel),
                   discover,
                   args,
-                  current.segments
+                  current.segments,
+                  nullCommandDefaults
                 ))
             }
           }
@@ -126,7 +128,7 @@ object ResolveCore {
               recurse(searchModules.map(m => Resolved.Module(m.millModuleSegments, Right(m))).toSet)
           }
 
-        case _ => notFoundResult(querySoFar, current, head, discover, args)
+        case _ => notFoundResult(querySoFar, current, head, discover, args, nullCommandDefaults)
       }
   }
 
@@ -150,7 +152,8 @@ object ResolveCore {
       nameOpt: Option[String] = None,
       discover: Discover[_],
       args: Seq[String],
-      segments: Segments
+      segments: Segments,
+      nullCommandDefaults: Boolean
   ): Set[Resolved] = {
     def namePred(n: String) = nameOpt.isEmpty || nameOpt.contains(n)
 
@@ -197,7 +200,8 @@ object ResolveCore {
               obj,
               name,
               discover.asInstanceOf[Discover[Module]],
-              args
+              args,
+              nullCommandDefaults
             ).head
           ).flatten
         )
@@ -211,12 +215,13 @@ object ResolveCore {
       current: Resolved,
       next: Segment,
       discover: Discover[_],
-      args: Seq[String]
+      args: Seq[String],
+      nullCommandDefaults: Boolean
   ) = {
     val possibleNextsOrErr = current match {
       case m: Resolved.Module =>
         m.valueOrErr.map(obj =>
-          resolveDirectChildren(obj, None, discover, args, querySoFar)
+          resolveDirectChildren(obj, None, discover, args, querySoFar, nullCommandDefaults)
             .map(_.segments.value.last)
         )
 
@@ -233,23 +238,37 @@ object ResolveCore {
       target: Module,
       name: String,
       discover: Discover[Module],
-      rest: Seq[String]
+      rest: Seq[String],
+      nullCommandDefaults: Boolean
   ): immutable.Iterable[Either[String, Command[_]]] = for {
     (cls, entryPoints) <- discover.value
     if cls.isAssignableFrom(target.getClass)
     ep <- entryPoints
     if ep._2.name == name
   } yield {
+    def withNullDefault(a: mainargs.ArgSig): mainargs.ArgSig =
+      if (nullCommandDefaults) a.copy(default = Some(_ => null)) else a
+
+    val flattenedArgSigsWithDefaults = ep
+      ._2
+      .flattenedArgSigs
+      .map{case (arg, term) => (withNullDefault(arg), term)}
+
     mainargs.TokenGrouping.groupArgs(
       rest,
-      ep._2.flattenedArgSigs,
+      flattenedArgSigsWithDefaults,
       allowPositional = true,
       allowRepeats = false,
       allowLeftover = ep._2.argSigs0.exists(_.reader.isLeftover)
     ).flatMap { (grouped: TokenGrouping[_]) =>
+
+      val mainData = ep._2.asInstanceOf[MainData[_, Any]]
+      val mainDataWithDefaults = mainData
+        .copy(argSigs0 = mainData.argSigs0.map(withNullDefault))
+
       mainargs.Invoker.invoke(
         target,
-        ep._2.asInstanceOf[MainData[_, Any]],
+        mainDataWithDefaults,
         grouped.asInstanceOf[TokenGrouping[Any]]
       )
     } match {

--- a/main/src/mill/main/ResolveCore.scala
+++ b/main/src/mill/main/ResolveCore.scala
@@ -260,8 +260,16 @@ object ResolveCore {
     ep <- entryPoints
     if ep._2.name == name
   } yield {
-    def withNullDefault(a: mainargs.ArgSig): mainargs.ArgSig =
-      if (nullCommandDefaults) a.copy(default = Some(_ => null)) else a
+    def withNullDefault(a: mainargs.ArgSig): mainargs.ArgSig = {
+      if (a.default.nonEmpty) a
+      else if (nullCommandDefaults) {
+        a.copy(default =
+          if (a.reader.isInstanceOf[SimpleTaskTokenReader[_]]) Some(_ => Target.task(null))
+          else Some(_ => null)
+        )
+      }
+      else a
+    }
 
     val flattenedArgSigsWithDefaults = ep
       ._2

--- a/main/src/mill/main/ResolveCore.scala
+++ b/main/src/mill/main/ResolveCore.scala
@@ -3,8 +3,9 @@ package mill.main
 import mainargs.{MainData, TokenGrouping}
 import mill.define._
 import mill.util.EitherOps
-import scala.reflect.NameTransformer.decode
 
+import java.lang.reflect.InvocationTargetException
+import scala.reflect.NameTransformer.decode
 import scala.collection.immutable
 
 /**
@@ -148,7 +149,9 @@ object ResolveCore {
 
   def catchReflectException[T](t: => T): Either[String, T] = {
     try Right(t)
-    catch { case e: Exception => makeResultException(e.getCause, new Exception()) }
+    catch { case e: InvocationTargetException =>
+      makeResultException(e.getCause, new Exception())
+    }
   }
 
   def catchNormalException[T](t: => T): Either[String, T] = {

--- a/main/src/mill/main/ResolveNonEmpty.scala
+++ b/main/src/mill/main/ResolveNonEmpty.scala
@@ -11,11 +11,12 @@ object ResolveNonEmpty {
       selector: List[Segment],
       current: BaseModule,
       discover: Discover[_],
-      args: Seq[String]
+      args: Seq[String],
+      nullCommandDefaults: Boolean
   ): Either[String, Set[Resolved]] = {
     val rootResolved = ResolveCore.Resolved.Module(current.millModuleSegments, Right(current))
 
-    ResolveCore.resolve(selector, rootResolved, discover, args, Segments()) match {
+    ResolveCore.resolve(selector, rootResolved, discover, args, Segments(), nullCommandDefaults) match {
       case ResolveCore.Success(value) => Right(value)
       case ResolveCore.NotFound(segments, found, next, possibleNexts) =>
         val errorMsg = if (found.head.isInstanceOf[Resolved.Module]) {

--- a/main/src/mill/main/ResolveNonEmpty.scala
+++ b/main/src/mill/main/ResolveNonEmpty.scala
@@ -16,7 +16,14 @@ object ResolveNonEmpty {
   ): Either[String, Set[Resolved]] = {
     val rootResolved = ResolveCore.Resolved.Module(current.millModuleSegments, Right(current))
 
-    ResolveCore.resolve(selector, rootResolved, discover, args, Segments(), nullCommandDefaults) match {
+    ResolveCore.resolve(
+      selector,
+      rootResolved,
+      discover,
+      args,
+      Segments(),
+      nullCommandDefaults
+    ) match {
       case ResolveCore.Success(value) => Right(value)
       case ResolveCore.NotFound(segments, found, next, possibleNexts) =>
         val errorMsg = if (found.head.isInstanceOf[Resolved.Module]) {

--- a/main/src/mill/main/TokenReaders.scala
+++ b/main/src/mill/main/TokenReaders.scala
@@ -13,7 +13,7 @@ object Tasks {
       ResolveTasks.resolve(
         Evaluator.currentEvaluator.value,
         s,
-        SelectMode.Single
+        SelectMode.Separated
       ).map(x => Tasks(x.asInstanceOf[Seq[mill.define.NamedTask[T]]]))
     }
     override def alwaysRepeatable = false

--- a/main/test/src/mill/main/ParseArgsTests.scala
+++ b/main/test/src/mill/main/ParseArgsTests.scala
@@ -95,7 +95,7 @@ object ParseArgsTests extends TestSuite {
           multiSelect: Boolean
       ) = {
         val Right((selectors0, args) :: _) =
-          ParseArgs(input, if (multiSelect) SelectMode.Multi else SelectMode.Single)
+          ParseArgs(input, if (multiSelect) SelectMode.Multi else SelectMode.Separated)
 
         val selectors = selectors0.map {
           case (Some(v1), v2) => (Some(v1.value), v2.value)
@@ -108,7 +108,7 @@ object ParseArgsTests extends TestSuite {
       }
 
       "rejectEmpty" - {
-        val parsed = ParseArgs(Seq.empty, selectMode = SelectMode.Single)
+        val parsed = ParseArgs(Seq.empty, selectMode = SelectMode.Separated)
         assert(
           parsed == Left("Selector cannot be empty")
         )
@@ -194,7 +194,7 @@ object ParseArgsTests extends TestSuite {
         multiSelect = true
       )
       "multiSelectorsBraceExpansionWithoutAll" - {
-        val res = ParseArgs(Seq("{core,application}.compile"), SelectMode.Single)
+        val res = ParseArgs(Seq("{core,application}.compile"), SelectMode.Separated)
         val expected = Right(
           List(
             (


### PR DESCRIPTION
In general, *most* commands do not depend on their arguments to instantiate the `mill.Command` object, and only depend on their arguments to actually execute. For that common case, we should be able to pass in `null`s for the arguments, which would allow us to do `inspect`, `path`, `plan`, etc. without needing to tediously pass in dummy arguments at the command line.

We add a `nullCommandDefaults` flag to calls to `Resolve*.resolve` in `MainModule.scala`, and make it override the MainArgs `ArgSig`s to set all default values to `null` when passed (`T.task(null)` for `Task[_]` params, primitive params it gets casted to `0` for numbers, `false` for booleans, etc.). This allows us to instantiate the `Command` object and analyze the task graph, even if we aren't able to actually execute it

This PR also removes support for `SelectMode.Single`, since it is largely superseded by `SelectMode.Separated`. Looking at the various use sites of `SelectMode.Single`, I don't think avoiding the need to escape `\\+` in edge cases is worth the additional `SelectMode` when `Separated` is close enough

Would fix https://github.com/com-lihaoyi/mill/issues/503. Fixes https://github.com/com-lihaoyi/mill/issues/937 in the common case where the commands in question instantiate their `mill.Command` task graph and metadata without depending on the input arguments; the scenario where we `if`/`else` on the input arguments and return different `T.command`s in each case is not resolved by this PR, but should be a pretty rare scenario so better to fix the common case first