### PR TITLE
Support Java 20

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -68,6 +68,10 @@ jobs:
           - java-version: 17
             buildcmd: ./mill -i docs.githubPages
 
+          # Have one job on latest JVM
+          - java-version: 20
+            buildcmd: ci/test-mill-bootstrap.sh
+
     uses: ./.github/workflows/run-mill-action.yml
     with:
       os: ubuntu-latest

--- a/runner/src/mill/runner/MillServerMain.scala
+++ b/runner/src/mill/runner/MillServerMain.scala
@@ -204,6 +204,8 @@ class Server[T](
     Thread.sleep(5)
     try t.stop()
     catch {
+      case e: UnsupportedOperationException =>
+        // nothing we can do about, removed in Java 20
       case e: java.lang.Error if e.getMessage.contains("Cleaner terminated abnormally") =>
       // ignore this error and do nothing; seems benign
     }

--- a/runner/src/mill/runner/MillServerMain.scala
+++ b/runner/src/mill/runner/MillServerMain.scala
@@ -205,7 +205,7 @@ class Server[T](
     try t.stop()
     catch {
       case e: UnsupportedOperationException =>
-        // nothing we can do about, removed in Java 20
+      // nothing we can do about, removed in Java 20
       case e: java.lang.Error if e.getMessage.contains("Cleaner terminated abnormally") =>
       // ignore this error and do nothing; seems benign
     }


### PR DESCRIPTION
Ignore the `UnsupportedOperationException` of `Thread.stop`. This is a quick fix to de-block users from using Java 20.

Added a bootstrap CI run using Java 20.

* Fix #2429 