### PR TITLE
Make `--import` flag work again

### DIFF
--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -72,7 +72,12 @@ class MillBuildBootstrap(
         } else {
 
           val bootstrapModule =
-            new MillBuildRootModule.BootstrapModule(projectRoot, recRoot(depth), millBootClasspath)(
+            new MillBuildRootModule.BootstrapModule(
+              projectRoot,
+              recRoot(depth),
+              millBootClasspath,
+              config.imports.collect{ case s"ivy:$rest" => rest }
+            )(
               mill.main.RootModule.Info(
                 recRoot(depth),
                 Discover[MillBuildRootModule.BootstrapModule]

--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -76,7 +76,7 @@ class MillBuildBootstrap(
               projectRoot,
               recRoot(depth),
               millBootClasspath,
-              config.imports.collect{ case s"ivy:$rest" => rest }
+              config.imports.collect { case s"ivy:$rest" => rest }
             )(
               mill.main.RootModule.Info(
                 recRoot(depth),

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -84,22 +84,21 @@ class MillBuildRootModule()(implicit
     }
   }
 
+  def cliImports = T.input { millBuildRootModuleInfo.cliImports }
+
   override def ivyDeps = T {
     Agg.from(
-      MillIvy.processMillIvyDepSignature(
-        parseBuildFiles().ivyDeps ++ millBuildRootModuleInfo.cliImports
-      )
-        .map(str =>
-          mill.scalalib.Dep.parse(
-            str
-              .replace("$MILL_VERSION", mill.BuildInfo.millVersion)
-              .replace("${MILL_VERSION}", mill.BuildInfo.millVersion)
-              .replace("$MILL_BIN_PLATFORM", mill.BuildInfo.millBinPlatform)
-              .replace("${MILL_BIN_PLATFORM}", mill.BuildInfo.millBinPlatform)
-          )
-        )
+      MillIvy.processMillIvyDepSignature(parseBuildFiles().ivyDeps)
+        .map(mill.scalalib.Dep.parse)
     ) ++
       Seq(ivy"com.lihaoyi::mill-moduledefs:${Versions.millModuledefsVersion}")
+  }
+
+  override def runIvyDeps = T {
+    Agg.from(
+      MillIvy.processMillIvyDepSignature(cliImports().toSet)
+        .map(mill.scalalib.Dep.parse)
+    )
   }
 
   override def generatedSources: T[Seq[PathRef]] = T {

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -86,7 +86,9 @@ class MillBuildRootModule()(implicit
 
   override def ivyDeps = T {
     Agg.from(
-      MillIvy.processMillIvyDepSignature(parseBuildFiles().ivyDeps ++ millBuildRootModuleInfo.cliImports)
+      MillIvy.processMillIvyDepSignature(
+        parseBuildFiles().ivyDeps ++ millBuildRootModuleInfo.cliImports
+      )
         .map(str =>
           mill.scalalib.Dep.parse(
             str


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/2485

We take the `config.imports` field and pass it to `MillIvy.processMillIvyDepSignature` inside `ivyDeps`. This was overlooked in https://github.com/com-lihaoyi/mill/pull/2377, but seems easy enough to put back

Honestly not super sure how to test this. But when I run

```
./mill -i dev.run example/tasks/3-anonymous-tasks -i --import ivy:com.lihaoyi::mill-contrib-bloop:0.11.0-M8  mill.contrib.bloop.Bloop/install
```

On main branch, I get 

```
Cannot resolve external module mill.contrib.bloop.Bloop
```

On this PR I get

```
java.lang.NoSuchMethodError: 'java.lang.ThreadLocal mill.eval.Evaluator$.currentEvaluator()'
    mill.contrib.bloop.Bloop$$anonfun$$lessinit$greater$1.apply(Bloop.scala:8)
    mill.contrib.bloop.Bloop$$anonfun$$lessinit$greater$1.apply(Bloop.scala:8)
```

Seems like there's a binary incompatibility, but at least the `--import` flag took effect?