### PR TITLE
Update zinc to 1.8.1

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -628,7 +628,8 @@ trait BaseMillTestsModule extends TestModule {
       s"-DTEST_SCALA_3_2_VERSION=${Deps.testScala32Version}",
       s"-DTEST_SCALAJS_VERSION=${Deps.Scalajs_1.scalaJsVersion}",
       s"-DTEST_SCALANATIVE_VERSION=${Deps.Scalanative_0_4.scalanativeVersion}",
-      s"-DTEST_UTEST_VERSION=${Deps.utest.dep.version}"
+      s"-DTEST_UTEST_VERSION=${Deps.utest.dep.version}",
+      s"-DTEST_ZINC_VERSION=${Deps.zinc.dep.version}"
     )
   }
   override def testFramework = "mill.UTestFramework"

--- a/build.sc
+++ b/build.sc
@@ -158,7 +158,7 @@ object Deps {
   val upickle = ivy"com.lihaoyi::upickle:3.1.0"
   val utest = ivy"com.lihaoyi::utest:0.8.1"
   val windowsAnsi = ivy"io.github.alexarchambault.windows-ansi:windows-ansi:0.0.5"
-  val zinc = ivy"org.scala-sbt::zinc:1.8.0"
+  val zinc = ivy"org.scala-sbt::zinc:1.8.1"
   // keep in sync with doc/antora/antory.yml
   val bsp4j = ivy"ch.epfl.scala:bsp4j:2.1.0-M4"
   val fansi = ivy"com.lihaoyi::fansi:0.4.0"

--- a/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
+++ b/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
@@ -543,7 +543,7 @@ object HelloWorldTests extends TestSuite {
         // Make sure we *do* end up compiling the compiler bridge, since it's
         // *not* using a pre-compiled bridge value
         assert(os.exists(
-          eval.outPath / "mill" / "scalalib" / "ZincWorkerModule" / "worker.dest" / "zinc-${zincVersion}"
+          eval.outPath / "mill" / "scalalib" / "ZincWorkerModule" / "worker.dest" / s"zinc-${zincVersion}"
         ))
       }
 

--- a/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
+++ b/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
@@ -23,6 +23,7 @@ object HelloWorldTests extends TestSuite {
   val scala2123Version = "2.12.3"
   val scala212Version = sys.props.getOrElse("TEST_SCALA_2_12_VERSION", ???)
   val scala213Version = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
+  val zincVersion = sys.props.getOrElse("TEST_ZINC_VERSION", ???)
 
   trait HelloBase extends TestUtil.BaseModule {
     override def millSourcePath: os.Path =
@@ -514,7 +515,7 @@ object HelloWorldTests extends TestSuite {
         // Make sure we *do not* end up compiling the compiler bridge, since
         // it's using a pre-compiled bridge value
         assert(!os.exists(
-          eval.outPath / "mill" / "scalalib" / "ZincWorkerModule" / "worker.dest" / "zinc-1.8.0"
+          eval.outPath / "mill" / "scalalib" / "ZincWorkerModule" / "worker.dest" / s"zinc-${zincVersion}"
         ))
       }
 
@@ -542,7 +543,7 @@ object HelloWorldTests extends TestSuite {
         // Make sure we *do* end up compiling the compiler bridge, since it's
         // *not* using a pre-compiled bridge value
         assert(os.exists(
-          eval.outPath / "mill" / "scalalib" / "ZincWorkerModule" / "worker.dest" / "zinc-1.8.0"
+          eval.outPath / "mill" / "scalalib" / "ZincWorkerModule" / "worker.dest" / "zinc-${zincVersion}"
         ))
       }
 


### PR DESCRIPTION
Includes a fix for infinite compilation issues and a security fix. We should also consider a backport to Mill 0.10.
