### PR TITLE
More tweaks to simplify BSP logic

### DIFF
--- a/bsp/src/mill/bsp/BspContext.scala
+++ b/bsp/src/mill/bsp/BspContext.scala
@@ -22,7 +22,6 @@ class BspContext(streams: SystemStreams, bspLogStream: Option[PrintStream], home
   BspContext.bspServerHandle =
     try {
       startBspServer(
-        initialEvaluator = None,
         streams = streams,
         logStream = bspLogStream,
         canReload = true
@@ -39,7 +38,6 @@ class BspContext(streams: SystemStreams, bspLogStream: Option[PrintStream], home
   streams.err.println("BSP server started")
 
   def startBspServer(
-      initialEvaluator: Option[Evaluator],
       streams: SystemStreams,
       logStream: Option[PrintStream],
       canReload: Boolean
@@ -62,7 +60,6 @@ class BspContext(streams: SystemStreams, bspLogStream: Option[PrintStream], home
     BspWorker(os.pwd, home, log).flatMap { worker =>
       os.makeDir.all(home / Constants.bspDir)
       worker.startBspServer(
-        initialEvaluator,
         streams,
         logStream.getOrElse(streams.err),
         home / Constants.bspDir,

--- a/bsp/src/mill/bsp/BspWorker.scala
+++ b/bsp/src/mill/bsp/BspWorker.scala
@@ -10,7 +10,6 @@ import java.net.URL
 @internal
 trait BspWorker {
   def startBspServer(
-      initialEvaluator: Option[Evaluator],
       streams: SystemStreams,
       logStream: PrintStream,
       logDir: os.Path,

--- a/bsp/worker/src/mill/bsp/worker/BspWorkerImpl.scala
+++ b/bsp/worker/src/mill/bsp/worker/BspWorkerImpl.scala
@@ -15,17 +15,14 @@ import scala.concurrent.{Await, CancellationException, Promise}
 private class BspWorkerImpl() extends BspWorker {
 
   override def startBspServer(
-      initialEvaluator: Option[Evaluator],
       streams: SystemStreams,
       logStream: PrintStream,
       logDir: os.Path,
       canReload: Boolean
   ): Either[String, BspServerHandle] = {
-    val evaluator = initialEvaluator.map(_.withFailFast(false))
 
     val millServer =
       new MillBuildServer(
-        initialEvaluator = evaluator,
         bspVersion = Constants.bspProtocolVersion,
         serverVersion = MillBuildInfo.millVersion,
         serverName = Constants.serverName,

--- a/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -74,7 +74,6 @@ import scala.util.{Failure, Success, Try}
 import Utils.sanitizeUri
 import mill.bsp.BspServerResult
 private class MillBuildServer(
-    initialEvaluator: Option[Evaluator],
     bspVersion: String,
     serverVersion: String,
     serverName: String,
@@ -97,7 +96,7 @@ private class MillBuildServer(
   private[this] var statePromise: Promise[State] = Promise[State]()
   var evaluatorOpt: Option[Evaluator] = None
   def evaluator = evaluatorOpt.get
-  updateEvaluator(initialEvaluator)
+
   def updateEvaluator(evaluator: Option[Evaluator]): Unit = {
     debug(s"Updating Evaluator: $evaluator")
     if (statePromise.isCompleted) statePromise = Promise[State]() // replace the promise


### PR DESCRIPTION
The initial call to `updateEvaluator` always happens with `None`, which makes it a no-op