### PR TITLE
Make mill-build folder opt in via `import $mill.build`

### DIFF
--- a/example/misc/4-mill-build-folder/build.sc
+++ b/example/misc/4-mill-build-folder/build.sc
@@ -21,7 +21,7 @@ object foo extends RootModule with ScalaModule {
 // file and it's `import $file` and `$ivy` are a shorthand syntax for defining
 // a Mill `ScalaModule`, with sources and `ivyDeps` and so on, which is
 // compiled and executed to perform your build. This module lives in
-// `mill-build/`.
+// `mill-build/`, and can be enabled via the `import $mill.build` statement above.
 
 /** See Also: mill-build/build.sc */
 

--- a/example/misc/4-mill-build-folder/build.sc
+++ b/example/misc/4-mill-build-folder/build.sc
@@ -1,3 +1,4 @@
+import $mill.build
 import mill._, scalalib._
 import scalatags.Text.all._
 

--- a/example/misc/4-mill-build-folder/build.sc
+++ b/example/misc/4-mill-build-folder/build.sc
@@ -1,4 +1,4 @@
-import $mill.build
+import $meta._
 import mill._, scalalib._
 import scalatags.Text.all._
 
@@ -21,7 +21,7 @@ object foo extends RootModule with ScalaModule {
 // file and it's `import $file` and `$ivy` are a shorthand syntax for defining
 // a Mill `ScalaModule`, with sources and `ivyDeps` and so on, which is
 // compiled and executed to perform your build. This module lives in
-// `mill-build/`, and can be enabled via the `import $mill.build` statement above.
+// `mill-build/`, and can be enabled via the `import $meta._` statement above.
 
 /** See Also: mill-build/build.sc */
 

--- a/integration/failure/invalid-meta-module/repo/build.sc
+++ b/integration/failure/invalid-meta-module/repo/build.sc
@@ -1,1 +1,1 @@
-import $mill.build
+import $meta._

--- a/integration/failure/invalid-meta-module/repo/build.sc
+++ b/integration/failure/invalid-meta-module/repo/build.sc
@@ -1,0 +1,1 @@
+import $mill.build

--- a/integration/feature/editing/repo/build.sc
+++ b/integration/feature/editing/repo/build.sc
@@ -1,3 +1,4 @@
+import $mill.build
 import mill._, scalalib._
 import scalatags.Text.all._
 

--- a/integration/feature/editing/repo/build.sc
+++ b/integration/feature/editing/repo/build.sc
@@ -1,4 +1,4 @@
-import $mill.build
+import $meta._
 import mill._, scalalib._
 import scalatags.Text.all._
 

--- a/integration/feature/editing/repo/mill-build/build.sc
+++ b/integration/feature/editing/repo/mill-build/build.sc
@@ -1,3 +1,4 @@
+import $mill.build
 import mill._, scalalib._
 
 object millbuild extends MillBuildRootModule{

--- a/integration/feature/editing/repo/mill-build/build.sc
+++ b/integration/feature/editing/repo/mill-build/build.sc
@@ -1,4 +1,4 @@
-import $mill.build
+import $meta._
 import mill._, scalalib._
 
 object millbuild extends MillBuildRootModule{

--- a/runner/src/mill/runner/FileImportGraph.scala
+++ b/runner/src/mill/runner/FileImportGraph.scala
@@ -86,7 +86,7 @@ object FileImportGraph {
           case ImportTree(Seq(("$ivy", _), rest @ _*), mapping, start, end) =>
             seenIvy.addAll(mapping.map(_._1))
             (start, "_root_._", end)
-          case ImportTree(Seq(("$mill", _), rest @ _*), mapping, start, end) =>
+          case ImportTree(Seq(("$meta", _), rest @ _*), mapping, start, end) =>
             millImport = true
             (start, "_root_._", end)
           case ImportTree(Seq(("$file", _), rest @ _*), mapping, start, end) =>

--- a/runner/src/mill/runner/FileImportGraph.scala
+++ b/runner/src/mill/runner/FileImportGraph.scala
@@ -10,7 +10,8 @@ case class FileImportGraph(
     repos: Seq[(String, os.Path)],
     ivyDeps: Set[String],
     importGraphEdges: Map[os.Path, Seq[os.Path]],
-    errors: Seq[String]
+    errors: Seq[String],
+    millImport: Boolean
 )
 
 /**
@@ -33,6 +34,7 @@ object FileImportGraph {
     val seenRepo = mutable.ListBuffer.empty[(String, os.Path)]
     val importGraphEdges = mutable.Map.empty[os.Path, Seq[os.Path]]
     val errors = mutable.Buffer.empty[String]
+    var millImport = false
 
     def walkScripts(s: os.Path): Unit = {
       importGraphEdges(s) = Nil
@@ -84,6 +86,9 @@ object FileImportGraph {
           case ImportTree(Seq(("$ivy", _), rest @ _*), mapping, start, end) =>
             seenIvy.addAll(mapping.map(_._1))
             (start, "_root_._", end)
+          case ImportTree(Seq(("$mill", _), rest @ _*), mapping, start, end) =>
+            millImport = true
+            (start, "_root_._", end)
           case ImportTree(Seq(("$file", _), rest @ _*), mapping, start, end) =>
             val nextPaths = mapping.map { case (lhs, rhs) => nextPathFor(s, rest.map(_._1) :+ lhs) }
 
@@ -113,7 +118,8 @@ object FileImportGraph {
       seenRepo.toSeq,
       seenIvy.toSet,
       importGraphEdges.toMap,
-      errors.toSeq
+      errors.toSeq,
+      millImport
     )
   }
 


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/2461

For now it remains hard-coded as `mill-build/`, for simplicity. Given the `mill-` prefix, it's unlikely to collide with user-defined folders. Making it configurable would open another can of worms where the `import $mill.foo` can now collide with an `object foo`, which is very unintuitive.

For now, we just parse the script files one additional time in `MillBuildBootstrap.scala`. This is a bit wasteful, but is probably fast enough for now, and we're already pretty sloppy parsing everything twice in `MillBuildRootModule#scriptSources` and `MillBuildRootModule#parseBuildFiles`, so parsing things three times isn't the end of the world. We can look into optimizing it in future if necessary