### PR TITLE
Update mill-vcs-version to 0.3.1-6-e80da7

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -2,8 +2,7 @@
 import $file.ci.shared
 import $file.ci.upload
 import $ivy.`org.scalaj::scalaj-http:2.4.2`
-// built against Mill 0.11.0-M8-24-7d871a
-import $ivy.`de.tototec::de.tobiasroeser.mill.vcs.version::0.3.1-5-910047`
+import $ivy.`de.tototec::de.tobiasroeser.mill.vcs.version::0.3.1-6-e80da7`
 import $ivy.`com.github.lolgab::mill-mima_mill0.10:0.0.19`
 import $ivy.`net.sourceforge.htmlcleaner:htmlcleaner:2.25`
 

--- a/ci/mill-bootstrap.patch
+++ b/ci/mill-bootstrap.patch
@@ -2,17 +2,6 @@ diff --git a/build.sc b/build.sc
 index 3d9bad0f5f..5646a43549 100644
 --- a/build.sc
 +++ b/build.sc
-@@ -2,8 +2,8 @@
- import $file.ci.shared
- import $file.ci.upload
- import $ivy.`org.scalaj::scalaj-http:2.4.2`
--// built against Mill 0.11.0-M8-24-7d871a
--import $ivy.`de.tototec::de.tobiasroeser.mill.vcs.version::0.3.1-5-910047`
-+// built against Mill 0.11.0-M8-37-65dd1f
-+import $ivy.`de.tototec::de.tobiasroeser.mill.vcs.version_mill0.11.0-M8-37-65dd1f:0.3.1-5-910047`
- import $ivy.`com.github.lolgab::mill-mima_mill0.10:0.0.19`
- import $ivy.`net.sourceforge.htmlcleaner:htmlcleaner:2.25`
- 
 @@ -20,17 +20,18 @@ import com.github.lolgab.mill.mima.{
  import coursier.maven.MavenRepository
  import de.tobiasroeser.mill.vcs.version.VcsVersion


### PR DESCRIPTION
This version is also released for Mill 0.11.0-M9 and should be suitable for bootstrapping
