### PR TITLE
Use `showNamed` output format for `show` with more than one item

### DIFF
--- a/example/basic/3-builtin-commands/build.sc
+++ b/example/basic/3-builtin-commands/build.sc
@@ -145,25 +145,23 @@ Inputs:
 /** Usage
 
 > ./mill show "foo.{sources,compileClasspath}"
-[
-  [
+{
+  "foo.sources": [
     ".../foo/src"
   ],
-  [
+  "foo.compileClasspath": [
     ".../foo/compile-resources",
     ".../org/scala-lang/scala-library/2.13.8/scala-library-2.13.8.jar",
     ...
   ]
-]
+}
 
 */
 
 // == showNamed
 
 // Same as `show`, but the output will always be structured in a JSON
-// dictionary, with the task names as key and the task results as JSON values.
-// When you are running `show` on multiple tasks, `showNamed` is probably what
-// you want.
+// dictionary, whether there is one or more targets in the selection
 
 /** Usage
 

--- a/main/src/mill/main/MainModule.scala
+++ b/main/src/mill/main/MainModule.scala
@@ -318,7 +318,7 @@ trait MainModule extends mill.Module {
   def show(evaluator: Evaluator, targets: String*): Command[ujson.Value] = T.command {
     MainModule.show0(evaluator, targets, T.log, interp.evalWatch0) { res =>
       res.flatMap(_._2) match {
-        case Seq((k, singlev)) => k
+        case Seq((k, singleValue)) => singleValue
         case multiple => ujson.Obj.from(multiple)
       }
     }

--- a/main/src/mill/main/MainModule.scala
+++ b/main/src/mill/main/MainModule.scala
@@ -317,9 +317,9 @@ trait MainModule extends mill.Module {
    */
   def show(evaluator: Evaluator, targets: String*): Command[ujson.Value] = T.command {
     MainModule.show0(evaluator, targets, T.log, interp.evalWatch0) { res =>
-      res.flatMap(_._2).map(_._2) match {
-        case Seq(single) => single
-        case multiple => multiple
+      res.flatMap(_._2) match {
+        case Seq((k, singlev)) => k
+        case multiple => ujson.Obj.from(multiple)
       }
     }
   }

--- a/main/test/src/mill/main/MainModuleTests.scala
+++ b/main/test/src/mill/main/MainModuleTests.scala
@@ -105,10 +105,10 @@ object MainModuleTests extends TestSuite {
 
         val Result.Success(Val(value)) = results.rawValues.head
 
-        assert(value == ujson.Arr.from(Seq(
-          ujson.Arr.from(Seq("hello", "world")),
-          ujson.Obj.from(Map("1" -> "hello", "2" -> "world"))
-        )))
+        assert(value == ujson.Obj(
+          "hello" -> ujson.Arr("hello", "world"),
+          "hello2" -> ujson.Obj("1" -> "hello", "2" -> "world")
+        ))
       }
 
       test("command") {


### PR DESCRIPTION
The old array-based output is pretty useless since it doesn't tell you what targets each output actually corresponds to. For humans, `show` is now probably what they want 99% of the time, and it simplifies having to remember to use `show` or `showNamed` depending on how many targets their query returns.

We leave `showNamed` for the "always print out dictionary" behavior, which might be useful for external tools who would not appreciate the output format flip-flopping between a string and a dictionary depending on the target count. 