### PR TITLE
Add Agg.when operator

### DIFF
--- a/main/api/src/mill/api/AggWrapper.scala
+++ b/main/api/src/mill/api/AggWrapper.scala
@@ -156,6 +156,10 @@ private[mill] sealed class AggWrapper(strictUniqueness: Boolean) {
 
     override def newBuilder[A]: mutable.Builder[A, Agg[A]] = Mutable.newBuilder[A]
 
+    /**
+     * Similar to [[Agg.apply]], but with a conditional boolean that makes it
+     * return `Agg.empty` if `false`.
+     */
     def when[A](cond: Boolean)(items: A*): Agg[A] = {
       if (cond) Agg.from(items) else Agg.empty
     }

--- a/main/api/src/mill/api/AggWrapper.scala
+++ b/main/api/src/mill/api/AggWrapper.scala
@@ -155,5 +155,9 @@ private[mill] sealed class AggWrapper(strictUniqueness: Boolean) {
     }
 
     override def newBuilder[A]: mutable.Builder[A, Agg[A]] = Mutable.newBuilder[A]
+
+    def when[A](cond: Boolean)(items: A*): Agg[A] = {
+      if (cond) Agg.from(items) else Agg.empty
+    }
   }
 }


### PR DESCRIPTION
This is a super common operation to want in the builds i've come across: conditional scalac flags, conditional deps, conditional sources, etc. Better to have it built in as `Agg.when(foo)("bar", "baz")` rather than jumping through hoops with `++ (if (foo) Agg("bar", "baz") else Agg.empty)`