### PR TITLE
Move `mill.BuildInfo` to`mill.main.BuildInfo`

### DIFF
--- a/bsp/src/mill/bsp/BSP.scala
+++ b/bsp/src/mill/bsp/BSP.scala
@@ -1,8 +1,9 @@
 package mill.bsp
 
 import mill.api.{Ctx, PathRef}
-import mill.{Agg, T, BuildInfo => MillBuildInfo}
+import mill.{Agg, T}
 import mill.define.{Command, Discover, ExternalModule}
+import mill.main.BuildInfo
 import mill.eval.Evaluator
 import mill.util.Util.millProjectModule
 import mill.scalalib.CoursierModule
@@ -33,7 +34,7 @@ object BSP extends ExternalModule with CoursierModule {
     // we create a file containing the additional jars to load
     val libUrls = bspWorkerLibs().map(_.path.toNIO.toUri.toURL).iterator.toSeq
     val cpFile =
-      T.workspace / Constants.bspDir / s"${Constants.serverName}-${mill.BuildInfo.millVersion}.resources"
+      T.workspace / Constants.bspDir / s"${Constants.serverName}-${BuildInfo.millVersion}.resources"
     os.write.over(
       cpFile,
       libUrls.mkString("\n"),
@@ -92,7 +93,7 @@ object BSP extends ExternalModule with CoursierModule {
           "--jobs",
           s"${jobs}"
         ) ++ (if (debug) Seq("--debug") else Seq()),
-        millVersion = MillBuildInfo.millVersion,
+        millVersion = BuildInfo.millVersion,
         bspVersion = Constants.bspProtocolVersion,
         languages = Constants.languages
       )

--- a/bsp/src/mill/bsp/BspWorker.scala
+++ b/bsp/src/mill/bsp/BspWorker.scala
@@ -37,7 +37,7 @@ object BspWorker {
         }.getOrElse {
           // load extra classpath entries from file
           val cpFile =
-            workspace / Constants.bspDir / s"${Constants.serverName}-${mill.BuildInfo.millVersion}.resources"
+            workspace / Constants.bspDir / s"${Constants.serverName}-${mill.main.BuildInfo.millVersion}.resources"
           if (!os.exists(cpFile)) return Left(
             "You need to run `mill mill.bsp.BSP/install` before you can use the BSP server"
           )

--- a/bsp/worker/src/mill/bsp/worker/BspWorkerImpl.scala
+++ b/bsp/worker/src/mill/bsp/worker/BspWorkerImpl.scala
@@ -1,7 +1,7 @@
 package mill.bsp.worker
 
 import ch.epfl.scala.bsp4j.BuildClient
-import mill.{BuildInfo => MillBuildInfo}
+import mill.main.BuildInfo
 import mill.bsp.{BspServerHandle, BspServerResult, BspWorker, Constants}
 import mill.eval.Evaluator
 import mill.api.SystemStreams
@@ -24,7 +24,7 @@ private class BspWorkerImpl() extends BspWorker {
     val millServer =
       new MillBuildServer(
         bspVersion = Constants.bspProtocolVersion,
-        serverVersion = MillBuildInfo.millVersion,
+        serverVersion = BuildInfo.millVersion,
         serverName = Constants.serverName,
         logStream = logStream,
         canReload = canReload

--- a/contrib/buildinfo/test/src/mill/contrib/buildinfo/BuildInfoTests.scala
+++ b/contrib/buildinfo/test/src/mill/contrib/buildinfo/BuildInfoTests.scala
@@ -1,6 +1,6 @@
 package mill.contrib.buildinfo
 
-import mill.{BuildInfo => _, _}
+import mill._
 import mill.util.TestEvaluator
 import mill.util.TestUtil
 import os.Path

--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
@@ -3,6 +3,7 @@ package mill.contrib.scoverage
 import coursier.Repository
 import mill._
 import mill.api.{Loose, PathRef}
+import mill.main.BuildInfo
 import mill.contrib.scoverage.api.ScoverageReportWorkerApi.ReportType
 import mill.scalalib.api.ZincWorkerUtil
 import mill.scalalib.{Dep, DepSyntax, JavaModule, ScalaModule}

--- a/main/src/mill/main/MainModule.scala
+++ b/main/src/mill/main/MainModule.scala
@@ -1,7 +1,8 @@
 package mill.main
 
 import java.util.concurrent.LinkedBlockingQueue
-import mill.{BuildInfo, T}
+import mill.T
+import mill.main.BuildInfo
 import mill.api.{Ctx, Logger, PathRef, Result}
 import mill.define.{Command, NamedTask, Segments, Task}
 import mill.eval.{Evaluator, EvaluatorPaths}

--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -1,6 +1,7 @@
 package mill.runner
 import mill.util.{ColorLogger, PrefixLogger, Util, Watchable}
-import mill.{BuildInfo, T}
+import mill.T
+import mill.main.BuildInfo
 import mill.api.{PathRef, Val, internal}
 import mill.eval.Evaluator
 import mill.main.{RootModule, RunScript}

--- a/runner/src/mill/runner/MillCliConfig.scala
+++ b/runner/src/mill/runner/MillCliConfig.scala
@@ -212,7 +212,7 @@ import mainargs.ParserForClass
 // see https://github.com/com-lihaoyi/mill/issues/2315
 object MillCliConfigParser {
 
-  val customName = s"Mill Build Tool, version ${mill.BuildInfo.millVersion}"
+  val customName = s"Mill Build Tool, version ${mill.main.BuildInfo.millVersion}"
   val customDoc = "usage: mill [options] [[target [target-options]] [+ [target ...]]]"
 
   /**

--- a/runner/src/mill/runner/MillIvy.scala
+++ b/runner/src/mill/runner/MillIvy.scala
@@ -21,10 +21,10 @@ object MillIvy {
     }
 
     val replaced = millSigs.map(_
-      .replace("$MILL_VERSION", mill.BuildInfo.millVersion)
-      .replace("${MILL_VERSION}", mill.BuildInfo.millVersion)
-      .replace("$MILL_BIN_PLATFORM", mill.BuildInfo.millBinPlatform)
-      .replace("${MILL_BIN_PLATFORM}", mill.BuildInfo.millBinPlatform))
+      .replace("$MILL_VERSION", mill.main.BuildInfo.millVersion)
+      .replace("${MILL_VERSION}", mill.main.BuildInfo.millVersion)
+      .replace("$MILL_BIN_PLATFORM", mill.main.BuildInfo.millBinPlatform)
+      .replace("${MILL_BIN_PLATFORM}", mill.main.BuildInfo.millBinPlatform))
 
     replaced
   }

--- a/runner/src/mill/runner/MillMain.scala
+++ b/runner/src/mill/runner/MillMain.scala
@@ -1,5 +1,5 @@
 package mill.runner
-import mill.BuildInfo
+import mill.main.BuildInfo
 
 import java.io.{FileOutputStream, PrintStream}
 import java.util.Locale

--- a/runner/src/mill/runner/MillServerMain.scala
+++ b/runner/src/mill/runner/MillServerMain.scala
@@ -7,7 +7,7 @@ import java.net.Socket
 import scala.jdk.CollectionConverters._
 import org.newsclub.net.unix.AFUNIXServerSocket
 import org.newsclub.net.unix.AFUNIXSocketAddress
-import mill.BuildInfo
+import mill.main.BuildInfo
 import mill.main.client._
 import mill.api.internal
 import mill.main.client.lock.{Lock, Locks}

--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -77,7 +77,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
     // we need to use the scala-library of the currently running mill
     resolveDependencies(
       repositoriesTask(),
-      (commonDeps ++ envDeps).map(Lib.depToBoundDep(_, mill.BuildInfo.scalaVersion, "")),
+      (commonDeps ++ envDeps).map(Lib.depToBoundDep(_, mill.main.BuildInfo.scalaVersion, "")),
       ctx = Some(T.log)
     )
   }

--- a/scalalib/src/mill/scalalib/GenIdeaImpl.scala
+++ b/scalalib/src/mill/scalalib/GenIdeaImpl.scala
@@ -5,18 +5,16 @@ import scala.util.Try
 import scala.xml.{Elem, MetaData, Node, NodeSeq, Null, UnprefixedAttribute}
 import coursier.core.compatibility.xmlParseDom
 import coursier.maven.Pom
-import coursier.{LocalRepositories, Repositories, Repository}
 
-import java.nio.file.Paths
 import mill.Agg
 import mill.api.Ctx.{Home, Log}
 import mill.api.{PathRef, Result, Strict}
 import mill.define._
 import mill.eval.Evaluator
-import mill.util.Util
+import mill.main.BuildInfo
 import mill.scalalib.GenIdeaModule.{IdeaConfigFile, JavaFacet}
 import mill.util.Classpath
-import mill.{BuildInfo, T, scalalib}
+import mill.{T, scalalib}
 import os.{Path, SubPath}
 
 case class GenIdeaImpl(

--- a/scalalib/src/mill/scalalib/Lib.scala
+++ b/scalalib/src/mill/scalalib/Lib.scala
@@ -4,6 +4,7 @@ package scalalib
 import coursier.util.Task
 import coursier.{Dependency, LocalRepositories, Repositories, Repository, Resolution}
 import mill.api.{Ctx, Loose, PathRef, Result}
+import mill.main.BuildInfo
 import mill.modules.Util
 import mill.scalalib.api.ZincWorkerUtil
 

--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -3,6 +3,7 @@ package scalalib
 
 import scala.annotation.nowarn
 import mill.api.{DummyInputStream, JarManifest, PathRef, Result, internal}
+import mill.main.BuildInfo
 import mill.util.Jvm
 import mill.util.Jvm.createJar
 import mill.api.Loose.Agg

--- a/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
+++ b/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
@@ -2,9 +2,10 @@ package mill.scalalib
 
 import mill.api.{PathRef, Result, experimental}
 import mill.define.{Target, Task}
+import mill.main.BuildInfo
 import mill.scalalib.api.{Versions, ZincWorkerUtil}
 import mill.util.Version
-import mill.{Agg, BuildInfo, T}
+import mill.{Agg, T}
 
 import scala.util.Properties
 

--- a/scalalib/src/mill/scalalib/TestModule.scala
+++ b/scalalib/src/mill/scalalib/TestModule.scala
@@ -171,7 +171,7 @@ object TestModule {
     override def testFramework: T[String] = "mill.testng.TestNGFramework"
     override def ivyDeps: T[Agg[Dep]] = T {
       super.ivyDeps() ++ Agg(
-        ivy"com.lihaoyi:mill-contrib-testng:${mill.BuildInfo.millVersion}"
+        ivy"com.lihaoyi:mill-contrib-testng:${mill.api.BuildInfo.millVersion}"
       )
     }
   }

--- a/scalalib/src/mill/scalalib/giter8/Giter8Module.scala
+++ b/scalalib/src/mill/scalalib/giter8/Giter8Module.scala
@@ -5,7 +5,7 @@ import mill.define.{Command, Discover, ExternalModule}
 import mill.util.Jvm
 import mill.scalalib.api.ZincWorkerUtil
 import mill.scalalib._
-import mill.BuildInfo
+import mill.main.BuildInfo
 import mill.api.Loose
 
 object Giter8Module extends ExternalModule with Giter8Module {

--- a/scalalib/src/mill/scalalib/publish/SonatypeHttpApi.scala
+++ b/scalalib/src/mill/scalalib/publish/SonatypeHttpApi.scala
@@ -6,7 +6,7 @@ import scala.annotation.tailrec
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
 
-import mill.BuildInfo
+import mill.main.BuildInfo
 import requests.BaseSession
 import ujson.ParseException
 

--- a/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
+++ b/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
@@ -100,7 +100,7 @@ trait ScalaNativeModule extends ScalaModule { outer =>
   def bridgeFullClassPath: T[Agg[PathRef]] = T {
     Lib.resolveDependencies(
       repositoriesTask(),
-      toolsIvyDeps().map(Lib.depToBoundDep(_, mill.BuildInfo.scalaVersion, "")),
+      toolsIvyDeps().map(Lib.depToBoundDep(_, mill.main.BuildInfo.scalaVersion, "")),
       ctx = Some(T.log)
     ).map(t => (scalaNativeWorkerClasspath() ++ t))
   }


### PR DESCRIPTION
We currently encourage `import mill._`, which causes problems when people want to also `import mill.contrib.buildinfo.BuildInfo`. There's a workaround to `import mill.{BuildInfo => MillBuildInfo, _}`, which we do in several places in our own codebase, but it's a pain in the neck and an unnecessary hurdle for users to cross. The majority of users would not need to access `mill.BuildInfo` at all, so putting it in the default namespace just adds clutter.

The `mill.BuildInfo` is used throughout `mill.scalalib` and `mill.scalajslib` and so on, but is not used in `main/`, so I put it in as downstream a module as possible which turns out to be `mill.main.BuildInfo`