### PR TITLE
Make `mill.backgroundwrapper` a `JavaModule` again

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -288,7 +288,7 @@ trait MillJavaModule extends JavaModule {
 
   // Test setup
 //  def artifactName: T[String]
-  def testDep = T { (s"com.lihaoyi-${artifactName()}", testDepPaths().map(_.path).mkString("\n")) }
+  def testDep = T { (s"com.lihaoyi-${artifactId()}", testDepPaths().map(_.path).mkString("\n")) }
   def testArgs: T[Seq[String]] = T { Seq("-Djna.nosys=true") }
   def testDepPaths = T { upstreamAssemblyClasspath() ++ Seq(compile().classes) ++ resources() }
 

--- a/build.sc
+++ b/build.sc
@@ -287,7 +287,6 @@ trait MillPublishModule extends PublishModule {
 trait MillJavaModule extends JavaModule {
 
   // Test setup
-//  def artifactName: T[String]
   def testDep = T { (s"com.lihaoyi-${artifactId()}", testDepPaths().map(_.path).mkString("\n")) }
   def testArgs: T[Seq[String]] = T { Seq("-Djna.nosys=true") }
   def testDepPaths = T { upstreamAssemblyClasspath() ++ Seq(compile().classes) ++ resources() }

--- a/contrib/testng/test/src/mill/testng/TestNGTests.scala
+++ b/contrib/testng/test/src/mill/testng/TestNGTests.scala
@@ -17,7 +17,11 @@ object TestNGTests extends TestSuite {
 
     object test extends super.Tests {
       def testngClasspath = T {
-        millProjectModule("mill-contrib-testng", repositoriesTask())
+        millProjectModule(
+          "mill-contrib-testng",
+          repositoriesTask(),
+          artifactSuffix = ""
+        )
       }
 
       override def runClasspath: Target[Seq[PathRef]] =

--- a/main/util/src/mill/util/CoursierSupport.scala
+++ b/main/util/src/mill/util/CoursierSupport.scala
@@ -95,7 +95,7 @@ trait CoursierSupport {
     def isLocalTestDep(dep: coursier.Dependency): Option[Seq[PathRef]] = {
       val org = dep.module.organization.value
       val name = dep.module.name.value
-      val classpathKey = s"$org-${name.stripSuffix("_2.13").stripSuffix("_2.12")}"
+      val classpathKey = s"$org-$name"
 
       val classpathResourceText =
         try Some(os.read(


### PR DESCRIPTION
Should fix https://github.com/com-lihaoyi/mill/issues/2533, which was broken by https://github.com/com-lihaoyi/mill/pull/2476

Just requires shuffling `def testDeps` and related definitions around to make them available outside `MillScalaModule`. They moved to `MillCoursierModule`, which in order to satisfy their dependencies had to be converted to `MillJavaModule`. The overall logic of the build is unchanged

Tighted up the test artifact resolution logic for `.local` example/integration tests. Previously, they would ignore the `artifactSuffix`, which is why tests exercising `runBackground` like `example.web[1-todo-webapp].local` passed despite the bug. With the more strict test artifact resolution, this bug gets surfaced properly on `main`, and is fixed by this PR