### PR TITLE
Tweak windows CI

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -65,7 +65,9 @@ jobs:
         java-version: [8, 17]
         millargs:
           # unit and module tests
-          - '"{main,scalalib,scalajslib,scalanativelib,testrunner,bsp}.__.test"'
+          - '"{main,scalalib,testrunner,bsp}.__.test"'
+          - '"scalajslib.__.test"'
+          - '"scalanativelib.__.test"'
           # integration tests
           - "integration.feature.__.server.test"
           - "integration.feature.__.fork.test"
@@ -111,14 +113,15 @@ jobs:
         millargs:
           # Run a stripped down build matrix on Windows, to avoid taking too long
           - '"{__.publishLocal,dev.assembly,__.compile}"'
-          - '"{main,scalalib,scalajslib,bsp}.__.test"'
+          - '"{main,scalalib,bsp}.__.test"'
+          - '"scalajslib.__.test"'
 
         include:
           # Limit some tests to Java 17 to limit CI times
           - java-version: 17
             # just run a subset of examples/ on Windows, because for some reason running
             # the whole suite can take hours on windows v.s. half an hour on linux
-            millargs: '"example.{scalabuilds,tasks}.__.local.test"'
+            millargs: '"example.basic.__.local.test"'
           - java-version: 17
             millargs: "integration.feature.__.fork.test"
           - java-version: 17


### PR DESCRIPTION
- Further reduce the example tests on Windows, to try and avoid random hangs in Windows CI
- Break up `scalajslib` and `scalanativelib` tests into their own jobs, since they are very slow