### PR TITLE
Support Java 20 (Backport of #2501)

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -36,8 +36,6 @@ jobs:
             buildcmd: | 
               ./mill -i -k __.ivyDepsTree
               ./mill -i -k __.ivyDepsTree --withRuntime true
-          - java-version: 20
-            buildcmd: ci/test-mill-bootstrap-0.sh
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -36,6 +36,8 @@ jobs:
             buildcmd: | 
               ./mill -i -k __.ivyDepsTree
               ./mill -i -k __.ivyDepsTree --withRuntime true
+          - java-version: 20
+            buildcmd: ci/test-mill-bootstrap-0.sh
 
     runs-on: ubuntu-latest
 
@@ -108,7 +110,6 @@ jobs:
           - cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i -d -k "integration.{local,forked,forked-server}"
           - cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i -d -k "integration.thirdparty.{local,forked}"
           - cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i -d -k "contrib.__.test"
-
 
     runs-on: windows-latest
 

--- a/main/src/mill/main/MillServerMain.scala
+++ b/main/src/mill/main/MillServerMain.scala
@@ -208,6 +208,8 @@ class Server[T](
     Thread.sleep(5)
     try t.stop()
     catch {
+      case e: UnsupportedOperationException =>
+      // nothing we can do about, removed in Java 20
       case e: java.lang.Error if e.getMessage.contains("Cleaner terminated abnormally") =>
       // ignore this error and do nothing; seems benign
     }


### PR DESCRIPTION
Ignore the `UnsupportedOperationException` of `Thread.stop`. This is a
quick fix to de-block users from using Java 20.

* Original Pull request: https://github.com/com-lihaoyi/mill/pull/2501

* Fix: https://github.com/com-lihaoyi/mill/issues/2545