### PR TITLE
Fix invalidation of workers pulled in from `import $ivy` when build.sc is modified

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -1297,6 +1297,8 @@ object dev extends MillModule {
     runner.linenumbers.testDep(),
     scalalib.backgroundwrapper.testDep(),
     contrib.buildinfo.testDep(),
+    contrib.playlib.testDep(),
+    contrib.playlib.worker("2.8").testDep(),
     bsp.worker.testDep()
   )
 

--- a/example/basic/1-simple-scala/.mill-version
+++ b/example/basic/1-simple-scala/.mill-version
@@ -1,1 +1,0 @@
-0.11.0-M9-16-bdace6-DIRTYe4dd961f

--- a/integration/feature/import-ivy-worker-invalidation/repo/build.sc
+++ b/integration/feature/import-ivy-worker-invalidation/repo/build.sc
@@ -1,0 +1,14 @@
+// Test to make sure that the worker instances whose classes come from an
+// `import $ivy` dependency are properly invalidated when the `build.sc` is
+// modified and re-compiled, causing a new classloader to be created which
+// would have an incompatible worker class than before.
+//
+// In this test case, `mill.playlib.RouteCompilerWorker` is the relevant worker
+// class, instantiated in `RouterModule.routeCompilerWorker`
+
+import $ivy.`com.lihaoyi::mill-contrib-playlib:`, mill.playlib._
+
+object app extends PlayApiModule {
+  def scalaVersion = "2.13.10"
+  def playVersion = "2.8.19"
+}

--- a/integration/feature/import-ivy-worker-invalidation/test/src/ImportIvyWorkerInvalidation.scala
+++ b/integration/feature/import-ivy-worker-invalidation/test/src/ImportIvyWorkerInvalidation.scala
@@ -1,0 +1,17 @@
+package mill.integration
+
+import utest._
+
+import scala.collection.mutable
+
+object ImportIvyWorkerInvalidation extends IntegrationTestSuite {
+
+  val tests = Tests {
+    test {
+      val wsRoot = initWorkspace()
+      assert(evalStdout("app.compile").isSuccess)
+      mangleFile(wsRoot / "build.sc", _.replace("object app", "println(\"hello\"); object app"))
+      assert(evalStdout("app.compile").isSuccess)
+    }
+  }
+}

--- a/integration/feature/import-ivy-worker-invalidation/test/src/ImportIvyWorkerInvalidation.scala
+++ b/integration/feature/import-ivy-worker-invalidation/test/src/ImportIvyWorkerInvalidation.scala
@@ -9,9 +9,9 @@ object ImportIvyWorkerInvalidation extends IntegrationTestSuite {
   val tests = Tests {
     test {
       val wsRoot = initWorkspace()
-      assert(evalStdout("app.compile").isSuccess)
+      assert(eval("app.compile"))
       mangleFile(wsRoot / "build.sc", _.replace("object app", "println(\"hello\"); object app"))
-      assert(evalStdout("app.compile").isSuccess)
+      assert(eval("app.compile"))
     }
   }
 }

--- a/main/eval/src/mill/eval/EvaluatorImpl.scala
+++ b/main/eval/src/mill/eval/EvaluatorImpl.scala
@@ -21,6 +21,7 @@ private[mill] case class EvaluatorImpl(
     rootModule: mill.define.BaseModule,
     baseLogger: ColorLogger,
     classLoaderSigHash: Int,
+    classLoaderIdentityHash: Int,
     workerCache: mutable.Map[Segments, (Int, Val)] = mutable.Map.empty,
     env: Map[String, String] = Evaluator.defaultEnv,
     failFast: Boolean = true,

--- a/main/eval/src/mill/eval/GroupEvaluator.scala
+++ b/main/eval/src/mill/eval/GroupEvaluator.scala
@@ -292,7 +292,7 @@ private[mill] trait GroupEvaluator {
   // read from disk and re-instantiated every time, so whether the
   // classloader/class is the same or different doesn't matter.
   def workerCacheHash(inputHash: Int) = {
-    inputHash + classLoaderIdentityHash
+    inputHash // + classLoaderIdentityHash
   }
 
   private def handleTaskResult(

--- a/main/eval/src/mill/eval/GroupEvaluator.scala
+++ b/main/eval/src/mill/eval/GroupEvaluator.scala
@@ -291,9 +291,7 @@ private[mill] trait GroupEvaluator {
   // We do not want to do this for normal targets, because those are always
   // read from disk and re-instantiated every time, so whether the
   // classloader/class is the same or different doesn't matter.
-  def workerCacheHash(inputHash: Int) = {
-    inputHash + classLoaderIdentityHash
-  }
+  def workerCacheHash(inputHash: Int) = inputHash + classLoaderIdentityHash
 
   private def handleTaskResult(
       v: Val,

--- a/main/eval/src/mill/eval/GroupEvaluator.scala
+++ b/main/eval/src/mill/eval/GroupEvaluator.scala
@@ -21,6 +21,7 @@ private[mill] trait GroupEvaluator {
   def externalOutPath: os.Path
   def rootModule: mill.define.BaseModule
   def classLoaderSigHash: Int
+  def classLoaderIdentityHash: Int
   def workerCache: mutable.Map[Segments, (Int, Val)]
   def env: Map[String, String]
   def failFast: Boolean
@@ -277,6 +278,23 @@ private[mill] trait GroupEvaluator {
     )
   }
 
+  // Include the classloader identity hash as part of the worker hash. This is
+  // because unlike other targets, workers are long-lived in memory objects,
+  // and are not re-instantiated every run. Thus we need to make sure we
+  // invalidate workers in the scenario where a the worker classloader is
+  // re-created - so the worker *class* changes - but the *value* inputs to the
+  // worker does not change. This typically happens when the worker class is
+  // brought in via `import $ivy`, since the class then comes from the
+  // non-bootstrap classloader which can be re-created when the `build.sc` file
+  // changes.
+  //
+  // We do not want to do this for normal targets, because those are always
+  // read from disk and re-instantiated every time, so whether the
+  // classloader/class is the same or different doesn't matter.
+  def workerCacheHash(inputHash: Int) = {
+    inputHash + classLoaderIdentityHash
+  }
+
   private def handleTaskResult(
       v: Val,
       hashCode: Int,
@@ -287,21 +305,7 @@ private[mill] trait GroupEvaluator {
     labelled.task.asWorker match {
       case Some(w) =>
         workerCache.synchronized {
-          // Include the worker class hash as part of the worker hash. This is
-          // because unlike other targets, workers are long-lived in memory
-          // objects, and are not re-instantiated every run. Thus we need to
-          // make sure we invalidate workers in the scenario where a the worker
-          // classloader is re-created - so the worker *class* changes - but
-          // the *value* inputs to the worker does not change. This typically
-          // happens when the worker class is brought in via `import $ivy`,
-          // since the class then comes from the non-bootstrap classloader
-          // which can be re-created when the `build.sc` file changes.
-          //
-          // We do not want to do this for normal targets, because those are
-          // always read from disk and re-instantiated every time, so whether
-          // the classloader/class is the same or different doesn't matter.
-          val workerHash = inputsHash + v.value.getClass.hashCode()
-          workerCache.update(w.ctx.segments, (workerHash, v))
+          workerCache.update(w.ctx.segments, (workerCacheHash(inputsHash), v))
         }
       case None =>
         val terminalResult = labelled
@@ -375,7 +379,10 @@ private[mill] trait GroupEvaluator {
         }
       }
       .flatMap {
-        case (`inputsHash`, upToDate) => Some(upToDate) // worker cached and up-to-date
+        case (cachedHash, upToDate)
+          if cachedHash == workerCacheHash(inputsHash) =>
+          Some(upToDate) // worker cached and up-to-date
+
         case (_, Val(obsolete: AutoCloseable)) =>
           // worker cached but obsolete, needs to be closed
           try {

--- a/main/eval/src/mill/eval/GroupEvaluator.scala
+++ b/main/eval/src/mill/eval/GroupEvaluator.scala
@@ -380,7 +380,7 @@ private[mill] trait GroupEvaluator {
       }
       .flatMap {
         case (cachedHash, upToDate)
-          if cachedHash == workerCacheHash(inputsHash) =>
+            if cachedHash == workerCacheHash(inputsHash) =>
           Some(upToDate) // worker cached and up-to-date
 
         case (_, Val(obsolete: AutoCloseable)) =>

--- a/main/eval/src/mill/eval/GroupEvaluator.scala
+++ b/main/eval/src/mill/eval/GroupEvaluator.scala
@@ -292,7 +292,7 @@ private[mill] trait GroupEvaluator {
   // read from disk and re-instantiated every time, so whether the
   // classloader/class is the same or different doesn't matter.
   def workerCacheHash(inputHash: Int) = {
-    inputHash // + classLoaderIdentityHash
+    inputHash + classLoaderIdentityHash
   }
 
   private def handleTaskResult(

--- a/main/testkit/src/mill/testkit/MillTestkit.scala
+++ b/main/testkit/src/mill/testkit/MillTestkit.scala
@@ -100,6 +100,7 @@ trait MillTestKit {
       module,
       logger,
       0,
+      0,
       failFast = failFast,
       threadCount = threads,
       env = env

--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -100,18 +100,10 @@ class MillBuildBootstrap(
       else {
         val validatedRootModuleOrErr = nestedState.frames.headOption match {
           case None =>
-            getChildRootModule(
-              nestedState.bootstrapModuleOpt.get,
-              depth,
-              projectRoot
-            )
+            getChildRootModule(nestedState.bootstrapModuleOpt.get, depth, projectRoot)
 
           case Some(nestedFrame) =>
-            getRootModule(
-              nestedFrame.classLoaderOpt.get,
-              depth,
-              projectRoot
-            )
+            getRootModule(nestedFrame.classLoaderOpt.get, depth, projectRoot)
         }
 
         validatedRootModuleOrErr match {


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/2548. Explanation in comments.

Added an integration test to cover this, since the behavior has to do with how the bootstrap process interacts with the worker invalidation when the `build.sc` is modified, and so cannot be tested via `TestEvaluator`