### PR TITLE
Distribute Mill Assembly via Maven Central 

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -1622,18 +1622,18 @@ def millBootstrap = T.sources(T.workspace / "mill")
 
 def bootstrapLauncher = T {
   val outputPath = T.ctx.dest / "mill"
-  val millBootstrapGrepPrefix = "DEFAULT_MILL_VERSION="
-  val millDownloadUrlPrefix = "MILL_DOWNLOAD_URL="
+  val millBootstrapGrepPrefix = "(\n *DEFAULT_MILL_VERSION=)"
+  val millDownloadUrlPrefix = "(\n *MILL_DOWNLOAD_URL=)"
   os.write(
     outputPath,
     os.read(millBootstrap().head.path)
       .replaceAll(
         millBootstrapGrepPrefix + "[^\\n]+",
-        millBootstrapGrepPrefix + millVersion()
+        "$1" + millVersion()
       )
       .replaceAll(
         millDownloadUrlPrefix + "[^\\n]+",
-        millDownloadUrlPrefix + "\"https://repo1.maven.org/maven2/com/lihaoyi/mill-dist/\\$MILL_VERSION/mill-dist-\\$MILL_VERSION.jar\""
+        "$1" + "\"https://repo1.maven.org/maven2/com/lihaoyi/mill-dist/\\$MILL_VERSION/mill-dist-\\$MILL_VERSION.jar\""
       )
   )
   os.perms.set(outputPath, "rwxrwxrwx")

--- a/build.sc
+++ b/build.sc
@@ -1258,6 +1258,8 @@ object dev extends MillPublishScalaModule {
     mill.scalalib.Assembly.Rule.ExcludePattern("mill/local-test-overrides/.*")
   )
 
+  // All modules that we want to aggregate as part of this `dev` assembly.
+  // Excluding itself, and the `dist` module that uses it
   lazy val allPublishModules = build.millInternal.modules.collect {
     case m: PublishModule if (m ne this) && (m ne dist) => m
   }


### PR DESCRIPTION
Creates a stub `dist` module whose only purpose is to take the `dev.assembly` and put it on maven central, which the updated bootstrap script will download.

This should help reduce the number of external failure points in Mill bootstrap script; rather than having hard dependency on both Github and Maven Central, this PR reduces it to only a hard dependency on Maven Central.  Maven Central is also by default a write-only package store. That means that short of sending them a lawyer letter, the packages published there are immutable (https://central.sonatype.org/faq/can-i-change-a-component). This is in contrast to Github release assets which are read/write. 

With Github, a bug in our CI auto-upload system could easily override/delete/corrupt already-published assemblies, causing a widespread outage to anyone depending on the bootstrap script (e.g. in CI) until someone fixes it. It is also vulnerable to Github outages, which are not unheard of. Distribution via Maven Central removes both Github outages and over-writing-existing-artifacts as possible failure modes. While Sonatype can and does have outages, that would already cause a failure in Mill's bootstrapping, so it would be no worse than it already is today

The validity of the various URLs and bootstrap scripts etc. have been tested manually, but end-to-end testing will need to be done post-merge