### PR TITLE
Enable `buildInfoStaticCompiled` on ScalaJSModule and ScalaNativeModule

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -730,7 +730,6 @@ object contrib extends Module {
 
   object buildinfo extends ContribModule {
     def moduleDeps = Seq(scalalib, scalajslib, scalanativelib)
-    def testModuleDeps = super.testModuleDeps 
   }
 
   object proguard extends ContribModule {

--- a/build.sc
+++ b/build.sc
@@ -729,7 +729,7 @@ object contrib extends Module {
   }
 
   object buildinfo extends ContribModule {
-    def compileModuleDeps = Seq(scalalib)
+    def compileModuleDeps = Seq(scalalib, scalajslib, scalanativelib)
     def testModuleDeps = super.testModuleDeps ++ Seq(scalalib)
   }
 

--- a/build.sc
+++ b/build.sc
@@ -729,8 +729,8 @@ object contrib extends Module {
   }
 
   object buildinfo extends ContribModule {
-    def compileModuleDeps = Seq(scalalib, scalajslib, scalanativelib)
-    def testModuleDeps = super.testModuleDeps ++ Seq(scalalib, scalajslib, scalanativelib)
+    def moduleDeps = Seq(scalalib, scalajslib, scalanativelib)
+    def testModuleDeps = super.testModuleDeps 
   }
 
   object proguard extends ContribModule {

--- a/build.sc
+++ b/build.sc
@@ -730,7 +730,7 @@ object contrib extends Module {
 
   object buildinfo extends ContribModule {
     def compileModuleDeps = Seq(scalalib, scalajslib, scalanativelib)
-    def testModuleDeps = super.testModuleDeps ++ Seq(scalalib)
+    def testModuleDeps = super.testModuleDeps ++ Seq(scalalib, scalajslib, scalanativelib)
   }
 
   object proguard extends ContribModule {

--- a/contrib/buildinfo/src/mill/contrib/buildinfo/BuildInfo.scala
+++ b/contrib/buildinfo/src/mill/contrib/buildinfo/BuildInfo.scala
@@ -2,6 +2,8 @@ package mill.contrib.buildinfo
 
 import mill.{PathRef, T}
 import mill.scalalib.{JavaModule, ScalaModule}
+import mill.scalanativelib.ScalaNativeModule
+import mill.scalajslib.ScalaJSModule
 
 trait BuildInfo extends JavaModule {
 
@@ -20,7 +22,11 @@ trait BuildInfo extends JavaModule {
    * rather than the default behavior of storing them as a JVM resource. Needed
    * to use BuildInfo on Scala.js which does not support JVM resources
    */
-  def buildInfoStaticCompiled: Boolean = false
+  def buildInfoStaticCompiled: Boolean = this match {
+    case _: ScalaJSModule => true
+    case _: ScalaNativeModule => true
+    case _ => false
+  }
 
   /**
    * A mapping of key-value pairs to pass from the Build script to the


### PR DESCRIPTION
Status quo fails linking with a cryptic error message where previous version was working out of the box.
This sets the default to the static behavior on Scala.js and Scala Native so users don't need to care.