### PR TITLE
Make buildinfo not depend on scalajslib and scalanativelib

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -701,8 +701,7 @@ object contrib extends Module {
 
     // So we can test with buildinfo in the classpath
     def testModuleDeps =
-      super.testModuleDeps ++
-      Seq(scalalib, scalajslib, scalanativelib, contrib.buildinfo)
+      super.testModuleDeps ++ Seq(scalalib, contrib.buildinfo)
 
     // Worker for Scoverage 1.x
     object worker extends MillPublishScalaModule {
@@ -726,15 +725,19 @@ object contrib extends Module {
           Deps.scalacScoverage2Plugin,
           Deps.scalacScoverage2Reporter,
           Deps.scalacScoverage2Domain,
-          Deps.scalacScoverage2Serializer,
+          Deps.scalacScoverage2Serializer
         )
       }
     }
   }
 
   object buildinfo extends ContribModule {
-    def compileModuleDeps = Seq(scalalib, scalajslib, scalanativelib)
+    def compileModuleDeps = Seq(scalalib)
     def testModuleDeps = super.testModuleDeps ++ Seq(scalalib, scalajslib, scalanativelib)
+    def testTransitiveDeps = super.testTransitiveDeps() ++ Seq(
+      scalajslib.worker("1").testDep(),
+      scalanativelib.worker("0.4").testDep()
+    )
   }
 
   object proguard extends ContribModule {

--- a/contrib/buildinfo/src/mill/contrib/buildinfo/BuildInfo.scala
+++ b/contrib/buildinfo/src/mill/contrib/buildinfo/BuildInfo.scala
@@ -2,8 +2,6 @@ package mill.contrib.buildinfo
 
 import mill.{PathRef, T}
 import mill.scalalib.{JavaModule, ScalaModule}
-import mill.scalanativelib.ScalaNativeModule
-import mill.scalajslib.ScalaJSModule
 
 trait BuildInfo extends JavaModule {
 
@@ -22,10 +20,27 @@ trait BuildInfo extends JavaModule {
    * rather than the default behavior of storing them as a JVM resource. Needed
    * to use BuildInfo on Scala.js which does not support JVM resources
    */
-  def buildInfoStaticCompiled: Boolean = this match {
-    case _: ScalaJSModule => true
-    case _: ScalaNativeModule => true
-    case _ => false
+  def buildInfoStaticCompiled: Boolean = {
+    def isScalaJSModule = {
+      type ScalaJSModule = {
+        def scalaJSVersion: T[String]
+      }
+      try {
+        this.asInstanceOf[ScalaJSModule].scalaJSVersion
+        true
+      } catch { case _: NoSuchMethodException => false }
+    }
+    def isScalaNativeModule = {
+      type ScalaNativeModule = {
+        def scalaNativeVersion: T[String]
+      }
+      try {
+        this.asInstanceOf[ScalaNativeModule].scalaNativeVersion
+        true
+      } catch { case _: NoSuchMethodException => false }
+    }
+    if (isScalaJSModule || isScalaNativeModule) true
+    else false
   }
 
   /**

--- a/contrib/buildinfo/test/resources/buildinfo/scala-simple/src/Main.scala
+++ b/contrib/buildinfo/test/resources/buildinfo/scala-simple/src/Main.scala
@@ -1,0 +1,5 @@
+package foo
+
+object Main extends App {
+  println(BuildInfo.scalaVersion)
+}

--- a/contrib/buildinfo/test/src/mill/contrib/buildinfo/BuildInfoTests.scala
+++ b/contrib/buildinfo/test/src/mill/contrib/buildinfo/BuildInfoTests.scala
@@ -10,6 +10,7 @@ import utest.framework.TestPath
 object BuildInfoTests extends TestSuite {
 
   val scalaVersionString = sys.props.getOrElse("TEST_SCALA_2_12_VERSION", ???)
+  val scalaJSVersionString = sys.props.getOrElse("TEST_SCALAJS_VERSION", ???)
   trait BuildInfoModule extends TestUtil.BaseModule with BuildInfo {
     // override build root to test custom builds/modules
     override def millSourcePath: Path = TestUtil.getSrcPathStatic() / "scala"
@@ -23,6 +24,15 @@ object BuildInfoTests extends TestSuite {
 
   object BuildInfoPlain extends BuildInfoModule with scalalib.ScalaModule {
     def scalaVersion = scalaVersionString
+    def buildInfoPackageName = "foo"
+    def buildInfoMembers = Seq(
+      BuildInfo.Value("scalaVersion", scalaVersion())
+    )
+  }
+
+  object BuildInfoScalaJS extends BuildInfoModule with scalajslib.ScalaJSModule {
+    def scalaVersion = scalaVersionString
+    def scalaJSVersion = scalaJSVersionString
     def buildInfoPackageName = "foo"
     def buildInfoMembers = Seq(
       BuildInfo.Value("scalaVersion", scalaVersion())
@@ -165,6 +175,11 @@ object BuildInfoTests extends TestSuite {
         os.exists(runResult),
         os.read(runResult) == scalaVersionString
       )
+    }
+
+    "scalajs" - workspaceTest(BuildInfoScalaJS, "scala-simple") { eval =>
+      val runResult = eval.outPath / "hello-mill"
+      assert(eval.apply(BuildInfoScalaJS.fastLinkJS).isRight)
     }
 
     "static" - workspaceTest(BuildInfoStatic, "scala") { eval =>


### PR DESCRIPTION
This uses structural types and catching `NoSuchMethodException` to check if a module is a `ScalaJSModule` or a `ScalaNativeModule`.
This way, users of `buildinfo` don't have to depend no `scalajslib` and `scalanativelib` mitigating the transitive dependencies problem.