### PR TITLE
Renamings for conciseness: Scala*ModuleTests -> Scala*Tests, InnerCrossModule -> CrossValue

### DIFF
--- a/ci/mill-bootstrap.patch
+++ b/ci/mill-bootstrap.patch
@@ -1,0 +1,13 @@
+diff --git a/build.sc b/build.sc
+index 8a61eaa089..464d12d012 100644
+--- a/build.sc
++++ b/build.sc
+@@ -315,7 +315,7 @@ trait MillScalaModule extends ScalaModule with MillJavaModule { outer =>
+ 
+   /** Default tests module. */
+   lazy val test: MillScalaModuleTests = new MillScalaModuleTests {}
+-  trait MillScalaModuleTests extends ScalaModuleTests with MillBaseTestsModule {
++  trait MillScalaModuleTests extends ScalaTests with MillBaseTestsModule {
+     def runClasspath = super.runClasspath() ++ writeLocalTestOverrides()
+     def forkArgs = super.forkArgs() ++ outer.testArgs()
+     def moduleDeps = outer.testModuleDeps

--- a/contrib/bloop/test/src/mill/contrib/bloop/BloopTests.scala
+++ b/contrib/bloop/test/src/mill/contrib/bloop/BloopTests.scala
@@ -44,7 +44,7 @@ object BloopTests extends TestSuite {
         ivy"org.postgresql:postgresql:42.3.3"
       )
 
-      object test extends ScalaModuleTests with TestModule.Utest
+      object test extends ScalaTests with TestModule.Utest
     }
 
     object scalaModule2 extends scalalib.ScalaModule {

--- a/contrib/playlib/src/mill/playlib/PlayModule.scala
+++ b/contrib/playlib/src/mill/playlib/PlayModule.scala
@@ -6,7 +6,7 @@ import mill.scalalib._
 import mill.{Agg, Args, T}
 
 trait PlayApiModule extends Dependencies with Router with Server {
-  trait PlayTests extends ScalaModuleTests with TestModule.ScalaTest {
+  trait PlayTests extends ScalaTests with TestModule.ScalaTest {
     override def ivyDeps = T {
       val scalatestPlusPlayVersion = playMinorVersion() match {
         case Versions.PLAY_2_6 => "3.1.3"

--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
@@ -231,7 +231,7 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
     override def skipIdea = outer.skipIdea
   }
 
-  trait ScoverageTests extends ScalaModuleTests {
+  trait ScoverageTests extends ScalaTests {
     override def upstreamAssemblyClasspath = T {
       super.upstreamAssemblyClasspath() ++
         resolveDeps(T.task {

--- a/contrib/testng/readme.adoc
+++ b/contrib/testng/readme.adoc
@@ -12,7 +12,7 @@ To use TestNG as test framework, you need to add it to the `TestModule.testFrame
 import mill.scalalib._
 
 object project extends ScalaModule {
-  object test extends ScalaModuleTests {
+  object test extends ScalaTests {
     def testFramework = "mill.testng.TestNGFramework"
     def ivyDeps = super.ivyDeps ++ Agg(
       ivy"com.lihaoyi:mill-contrib-testng:${mill.BuildInfo.millVersion}"
@@ -29,6 +29,6 @@ You can also use the more convenient `TestModule.TestNg` trait.
 import mill.scalalib._
 
 object project extends ScalaModule {
-  object test extends ScalaModuleTests with TestModule.TestNg
+  object test extends ScalaTests with TestModule.TestNg
 }
 ----

--- a/example/basic/1-simple-scala/build.sc
+++ b/example/basic/1-simple-scala/build.sc
@@ -8,7 +8,7 @@ object foo extends RootModule with ScalaModule {
     ivy"com.lihaoyi::mainargs:0.4.0"
   )
 
-  object test extends ScalaModuleTests {
+  object test extends ScalaTests {
     def ivyDeps = Agg(ivy"com.lihaoyi::utest:0.7.11")
     def testFramework = "utest.runner.Framework"
   }

--- a/example/cross/7-inner-cross-module/build.sc
+++ b/example/cross/7-inner-cross-module/build.sc
@@ -8,17 +8,17 @@ trait MyModule extends Module{
 
 object foo extends Cross[FooModule]("a", "b")
 trait FooModule extends Cross.Module[String] {
-  object bar extends MyModule with InnerCrossModule{
+  object bar extends MyModule with CrossValue{
     def name = "Bar"
   }
-  object qux extends MyModule with InnerCrossModule{
+  object qux extends MyModule with CrossValue{
     def name = "Qux"
   }
 }
 
 def baz = T { s"hello ${foo("a").bar.param()}" }
 
-// You can use the `InnerCrossModule` trait within any `Cross.Module` to
+// You can use the `CrossValue` trait within any `Cross.Module` to
 // propagate the `crossValue` defined by an enclosing `Cross.Module` to some
 // nested module. In this case, we use it to bind `crossValue` so it can be
 // used in `def param`. This lets you reduce verbosity by defining the `Cross`
@@ -27,7 +27,7 @@ def baz = T { s"hello ${foo("a").bar.param()}" }
 // modules that take multiple inputs.
 //
 // You can reference the modules and tasks defined within such a
-// `InnerCrossModule` as is done in `def qux` above
+// `CrossValue` as is done in `def qux` above
 
 /** Usage
 

--- a/example/scalabuilds/10-scala-realistic/build.sc
+++ b/example/scalabuilds/10-scala-realistic/build.sc
@@ -15,7 +15,7 @@ trait MyModule extends PublishModule {
 
 trait MyScalaModule extends MyModule with CrossScalaModule {
   def ivyDeps = Agg(ivy"com.lihaoyi::scalatags:0.12.0")
-  object test extends ScalaModuleTests {
+  object test extends ScalaTests {
     def ivyDeps = Agg(ivy"com.lihaoyi::utest:0.7.11")
     def testFramework = "utest.runner.Framework"
   }

--- a/example/scalabuilds/5-test-suite/build.sc
+++ b/example/scalabuilds/5-test-suite/build.sc
@@ -2,7 +2,7 @@ import mill._, scalalib._
 
 object foo extends ScalaModule {
   def scalaVersion = "2.13.8"
-  object test extends ScalaModuleTests {
+  object test extends ScalaTests {
     def ivyDeps = Agg(ivy"com.lihaoyi::utest:0.7.11")
     def testFramework = "utest.runner.Framework"
   }
@@ -47,7 +47,7 @@ compiling 1 Scala source...
 object bar extends ScalaModule {
   def scalaVersion = "2.13.8"
 
-  object test extends ScalaModuleTests with TestModule.Utest {
+  object test extends ScalaTests with TestModule.Utest {
     def ivyDeps = Agg(ivy"com.lihaoyi::utest:0.7.11")
   }
 }
@@ -87,10 +87,10 @@ object bar extends ScalaModule {
 object qux extends ScalaModule {
   def scalaVersion = "2.13.8"
 
-  object test extends ScalaModuleTests with TestModule.Utest {
+  object test extends ScalaTests with TestModule.Utest {
     def ivyDeps = Agg(ivy"com.lihaoyi::utest:0.7.11")
   }
-  object integration extends ScalaModuleTests with TestModule.Utest {
+  object integration extends ScalaTests with TestModule.Utest {
     def ivyDeps = Agg(ivy"com.lihaoyi::utest:0.7.11")
   }
 }

--- a/example/scalamodule/4-test-deps/build.sc
+++ b/example/scalamodule/4-test-deps/build.sc
@@ -15,7 +15,7 @@ object qux extends ScalaModule {
   def scalaVersion = "2.13.8"
   def moduleDeps = Seq(baz)
 
-  object test extends ScalaModuleTests {
+  object test extends ScalaTests {
     def ivyDeps = Agg(ivy"com.lihaoyi::utest:0.7.11")
     def testFramework = "utest.runner.Framework"
     def moduleDeps = super.moduleDeps ++ Seq(baz.test)
@@ -26,7 +26,7 @@ object qux extends ScalaModule {
 object baz extends ScalaModule {
   def scalaVersion = "2.13.8"
 
-  object test extends ScalaModuleTests {
+  object test extends ScalaTests {
     def ivyDeps = Agg(ivy"com.lihaoyi::utest:0.7.11")
     def testFramework = "utest.runner.Framework"
   }

--- a/example/thirdparty/acyclic/build.sc
+++ b/example/thirdparty/acyclic/build.sc
@@ -30,7 +30,7 @@ trait AcyclicModule extends CrossScalaModule with PublishModule {
 
   def compileIvyDeps = Agg(Deps.scalaCompiler(crossScalaVersion))
 
-  object test extends ScalaModuleTests with TestModule.Utest {
+  object test extends ScalaTests with TestModule.Utest {
     def sources = T.sources(millSourcePath / "src", millSourcePath / "resources")
     def ivyDeps = Agg(Deps.utest, Deps.scalaCompiler(crossScalaVersion))
   }

--- a/example/thirdparty/fansi/build.sc
+++ b/example/thirdparty/fansi/build.sc
@@ -20,7 +20,7 @@ trait FansiModule extends PublishModule with CrossScalaModule with PlatformScala
 
   def ivyDeps = Agg(ivy"com.lihaoyi::sourcecode::0.3.0")
 
-  trait FansiTestModule extends ScalaTests with TestModule.Utest {
+  trait FansiTests extends ScalaTests with TestModule.Utest {
     def ivyDeps = Agg(ivy"com.lihaoyi::utest::0.8.1")
   }
 }
@@ -28,19 +28,19 @@ trait FansiModule extends PublishModule with CrossScalaModule with PlatformScala
 object fansi extends Module {
   object jvm extends Cross[JvmFansiModule](scalaVersions)
   trait JvmFansiModule extends FansiModule with ScalaModule {
-    object test extends FansiTestModule with ScalaTests
+    object test extends FansiTests with ScalaTests
   }
 
   object js extends Cross[JsFansiModule](scalaVersions)
   trait JsFansiModule extends FansiModule with ScalaJSModule {
     def scalaJSVersion = "1.10.1"
-    object test extends FansiTestModule with ScalaJSTests
+    object test extends FansiTests with ScalaJSTests
   }
 
   object native extends Cross[NativeFansiModule](scalaVersions)
   trait NativeFansiModule extends FansiModule with ScalaNativeModule {
     def scalaNativeVersion = "0.4.5"
-    object test extends FansiTestModule with ScalaNativeTests
+    object test extends FansiTests with ScalaNativeTests
   }
 }
 

--- a/example/thirdparty/fansi/build.sc
+++ b/example/thirdparty/fansi/build.sc
@@ -20,7 +20,7 @@ trait FansiModule extends PublishModule with CrossScalaModule with PlatformScala
 
   def ivyDeps = Agg(ivy"com.lihaoyi::sourcecode::0.3.0")
 
-  trait FansiTestModule extends ScalaModuleTests with TestModule.Utest {
+  trait FansiTestModule extends ScalaTests with TestModule.Utest {
     def ivyDeps = Agg(ivy"com.lihaoyi::utest::0.8.1")
   }
 }
@@ -28,19 +28,19 @@ trait FansiModule extends PublishModule with CrossScalaModule with PlatformScala
 object fansi extends Module {
   object jvm extends Cross[JvmFansiModule](scalaVersions)
   trait JvmFansiModule extends FansiModule with ScalaModule {
-    object test extends FansiTestModule with ScalaModuleTests
+    object test extends FansiTestModule with ScalaTests
   }
 
   object js extends Cross[JsFansiModule](scalaVersions)
   trait JsFansiModule extends FansiModule with ScalaJSModule {
     def scalaJSVersion = "1.10.1"
-    object test extends FansiTestModule with ScalaJSModuleTests
+    object test extends FansiTestModule with ScalaJSTests
   }
 
   object native extends Cross[NativeFansiModule](scalaVersions)
   trait NativeFansiModule extends FansiModule with ScalaNativeModule {
     def scalaNativeVersion = "0.4.5"
-    object test extends FansiTestModule with ScalaNativeModuleTests
+    object test extends FansiTestModule with ScalaNativeTests
   }
 }
 

--- a/example/web/1-todo-webapp/build.sc
+++ b/example/web/1-todo-webapp/build.sc
@@ -7,7 +7,7 @@ object app extends RootModule with ScalaModule {
     ivy"com.lihaoyi::scalatags:0.12.0"
   )
 
-  object test extends ScalaModuleTests {
+  object test extends ScalaTests {
     def testFramework = "utest.runner.Framework"
 
     def ivyDeps = Agg(

--- a/example/web/2-webapp-cache-busting/build.sc
+++ b/example/web/2-webapp-cache-busting/build.sc
@@ -26,7 +26,7 @@ object app extends RootModule with ScalaModule {
     Seq(PathRef(T.dest))
   }
 
-  object test extends ScalaModuleTests {
+  object test extends ScalaTests {
     def testFramework = "utest.runner.Framework"
     def ivyDeps = Agg(
       ivy"com.lihaoyi::utest::0.7.10",

--- a/example/web/3-scalajs-module/build.sc
+++ b/example/web/3-scalajs-module/build.sc
@@ -4,7 +4,7 @@ object foo extends ScalaJSModule {
   def scalaVersion = "2.13.8"
   def scalaJSVersion = "1.13.0"
   def ivyDeps = Agg(ivy"com.lihaoyi::scalatags::0.12.0")
-  object test extends ScalaJSModuleTests {
+  object test extends ScalaJSTests {
     def ivyDeps = Agg(ivy"com.lihaoyi::utest::0.7.11")
     def testFramework = "utest.runner.Framework"
   }

--- a/example/web/4-webapp-scalajs/build.sc
+++ b/example/web/4-webapp-scalajs/build.sc
@@ -18,7 +18,7 @@ object app extends RootModule with ScalaModule {
     super.resources() ++ Seq(PathRef(T.dest))
   }
 
-  object test extends ScalaModuleTests {
+  object test extends ScalaTests {
     def testFramework = "utest.runner.Framework"
 
     def ivyDeps = Agg(

--- a/example/web/5-webapp-scalajs-shared/build.sc
+++ b/example/web/5-webapp-scalajs-shared/build.sc
@@ -20,7 +20,7 @@ object app extends RootModule with AppScalaModule {
     super.resources() ++ Seq(PathRef(T.dest))
   }
 
-  object test extends ScalaModuleTests {
+  object test extends ScalaTests {
     def testFramework = "utest.runner.Framework"
 
     def ivyDeps = Agg(

--- a/example/web/6-cross-version-platform-publishing/build.sc
+++ b/example/web/6-cross-version-platform-publishing/build.sc
@@ -2,7 +2,7 @@ import mill._, scalalib._, scalajslib._, publish._
 
 object foo extends Cross[FooModule]("2.13.8", "3.2.2")
 trait FooModule extends Cross.Module[String] {
-  trait Shared extends CrossScalaModule with InnerCrossModule with PlatformScalaModule with PublishModule {
+  trait Shared extends CrossScalaModule with CrossValue with PlatformScalaModule with PublishModule {
     def publishVersion = "0.0.1"
 
     def pomSettings = PomSettings(

--- a/example/web/6-cross-version-platform-publishing/build.sc
+++ b/example/web/6-cross-version-platform-publishing/build.sc
@@ -28,10 +28,10 @@ trait FooModule extends Cross.Module[String] {
 
   object bar extends Module {
     object jvm extends Shared{
-      object test extends ScalaModuleTests with FooTestModule
+      object test extends ScalaTests with FooTestModule
     }
     object js extends SharedJS {
-      object test extends ScalaJSModuleTests with FooTestModule
+      object test extends ScalaJSTests with FooTestModule
     }
   }
 
@@ -40,13 +40,13 @@ trait FooModule extends Cross.Module[String] {
       def moduleDeps = Seq(bar.jvm)
       def ivyDeps = super.ivyDeps() ++ Agg(ivy"com.lihaoyi::upickle::3.0.0")
 
-      object test extends ScalaModuleTests with FooTestModule
+      object test extends ScalaTests with FooTestModule
     }
 
     object js extends SharedJS {
       def moduleDeps = Seq(bar.js)
 
-      object test extends ScalaJSModuleTests with FooTestModule
+      object test extends ScalaJSTests with FooTestModule
     }
   }
 }

--- a/example/web/7-cross-platform-version-publishing/build.sc
+++ b/example/web/7-cross-platform-version-publishing/build.sc
@@ -29,12 +29,12 @@ val scalaVersions = Seq("2.13.8", "3.2.2")
 object bar extends Module {
   object jvm extends Cross[JvmModule](scalaVersions)
   trait JvmModule extends Shared {
-    object test extends ScalaModuleTests with SharedTestModule
+    object test extends ScalaTests with SharedTestModule
   }
 
   object js extends Cross[JsModule](scalaVersions)
   trait JsModule extends SharedJS {
-    object test extends ScalaJSModuleTests with SharedTestModule
+    object test extends ScalaJSTests with SharedTestModule
   }
 }
 
@@ -44,14 +44,14 @@ object qux extends Module {
     def moduleDeps = Seq(bar.jvm())
     def ivyDeps = super.ivyDeps() ++ Agg(ivy"com.lihaoyi::upickle::3.0.0")
 
-    object test extends ScalaModuleTests with SharedTestModule
+    object test extends ScalaTests with SharedTestModule
   }
 
   object js extends Cross[JsModule](scalaVersions)
   trait JsModule extends SharedJS {
     def moduleDeps = Seq(bar.js())
 
-    object test extends ScalaJSModuleTests with SharedTestModule
+    object test extends ScalaJSTests with SharedTestModule
   }
 }
 

--- a/integration/feature/bsp-install/repo/build.sc
+++ b/integration/feature/bsp-install/repo/build.sc
@@ -4,7 +4,7 @@ import mill.scalalib._
 
 trait HelloBspModule extends ScalaModule {
   def scalaVersion = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
-  object test extends ScalaModuleTests with TestModule.Utest
+  object test extends ScalaTests with TestModule.Utest
 
   override def generatedSources = T {
     Seq(PathRef(T.ctx().dest / "classes"))

--- a/integration/feature/bsp-modules/repo/build.sc
+++ b/integration/feature/bsp-modules/repo/build.sc
@@ -7,7 +7,7 @@ import $file.proj3.{build => proj3}
 
 trait HelloBspModule extends ScalaModule {
   def scalaVersion = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
-  object test extends ScalaModuleTests with TestModule.Utest
+  object test extends ScalaTests with TestModule.Utest
 }
 
 object HelloBsp extends HelloBspModule {

--- a/integration/feature/gen-idea/repo/extended/build.sc
+++ b/integration/feature/gen-idea/repo/extended/build.sc
@@ -8,7 +8,7 @@ import mill.scalalib.TestModule
 
 trait HelloWorldModule extends scalalib.ScalaModule {
   override def scalaVersion = "2.13.6"
-  object test extends ScalaModuleTests with TestModule.Utest
+  object test extends ScalaTests with TestModule.Utest
 
   override def generatedSources = T {
     Seq(PathRef(T.dest / "classes"))

--- a/integration/feature/gen-idea/repo/hello-world/build.sc
+++ b/integration/feature/gen-idea/repo/hello-world/build.sc
@@ -5,7 +5,7 @@ import mill.scalalib.{Dep, DepSyntax, TestModule}
 
 trait HelloWorldModule extends scalalib.ScalaModule {
   def scalaVersion = "2.12.5"
-  object test extends ScalaModuleTests with TestModule.Utest {
+  object test extends ScalaTests with TestModule.Utest {
     override def compileIvyDeps: Target[Agg[Dep]] = Agg(
       ivy"org.slf4j:jcl-over-slf4j:1.7.25"
     )

--- a/main/define/src/mill/define/Cross.scala
+++ b/main/define/src/mill/define/Cross.scala
@@ -21,7 +21,7 @@ object Cross {
      * trait that can be mixed into any sub-modules within the body of a
      * [[Cross.Module]], to automatically inherit the [[crossValue]]
      */
-    trait InnerCrossModule extends Module[T1] {
+    trait CrossValue extends Module[T1] {
       def crossValue: T1 = Module.this.crossValue
       override def crossWrapperSegments: List[String] = Module.this.millModuleSegments.parts
     }
@@ -38,7 +38,7 @@ object Cross {
      * trait that can be mixed into any sub-modules within the body of a
      * [[Cross.Arg2]], to automatically inherit the [[crossValue2]]
      */
-    trait InnerCrossModule2 extends InnerCrossModule with Module2[T1, T2] {
+    trait InnerCrossModule2 extends CrossValue with Module2[T1, T2] {
       def crossValue2: T2 = Module2.this.crossValue2
     }
   }

--- a/main/test/src/mill/util/TestGraphs.scala
+++ b/main/test/src/mill/util/TestGraphs.scala
@@ -411,11 +411,11 @@ object TestGraphs {
   object innerCrossModule extends TestUtil.BaseModule {
     object myCross extends Cross[MyCrossModule]("a", "b")
     trait MyCrossModule extends Cross.Module[String] {
-      object foo extends InnerCrossModule {
+      object foo extends CrossValue {
         def bar = T { "foo " + crossValue }
       }
 
-      object baz extends InnerCrossModule {
+      object baz extends CrossValue {
         def bar = T { "baz " + crossValue }
       }
     }

--- a/readme.adoc
+++ b/readme.adoc
@@ -338,8 +338,8 @@ these packages mature over time.
   https://github.com/com-lihaoyi/mill/pull/2560[#2560]
 
 * `Tests` inner trait was removed, to avoid trait shadowing which will be
-  removed in Scala 3. Please use `ScalaModuleTests`, `ScalaJSModuleTests`, or
-  `ScalaNativeModuleTests` instead
+  removed in Scala 3. Please use `ScalaTests`, `ScalaJSTests`, or
+  `ScalaNativeTests` instead
   https://github.com/com-lihaoyi/mill/pull/2558[#2558]
 
 
@@ -583,8 +583,8 @@ _Changes since {prev-version}:_
 * Fixed the caching for private targets with same name but defined in different super traits.
 * Fixed non-functional `clean` command when used with arguments denoting modules.
 * `scalalib`: Fixed `GenIdea` issues on Windows, when the build uses plugins or additional libraries.
-* `scalajslib`: `ScalaJSModule.ScalaJSModuleTests` now extends `ScalaModule.ScalaModuleTests` which improves consistency, better default values and compatibility with other modules like `ScoverageModule`.
-* `scalanativelib`: `ScalaNativeModule.ScalaNativeModuleTests` now extends `ScalaModule.ScalaModuleTests` which improves consistency, better default values and compatibility with other modules.
+* `scalajslib`: `ScalaJSModule.ScalaJSTests` now extends `ScalaModule.ScalaTests` which improves consistency, better default values and compatibility with other modules like `ScoverageModule`.
+* `scalanativelib`: `ScalaNativeModule.ScalaNativeTests` now extends `ScalaModule.ScalaTests` which improves consistency, better default values and compatibility with other modules.
 * `contrib.gitlab`: Improved error handling for token lookup and documentation.
 * Updated dependencies: coursier 2.1.0-RC5, jna 5.13.0, semanticdb-scala 4.7.3, trees 4.7.3
 * Documentation improvements
@@ -1188,7 +1188,7 @@ and the {link-compare}/0.9.5\...0.9.6[list of commits]._
 * Support for Scala Native 0.4.0
 * Support for Scala.js ESModule (including Bloop support)
 * Inner `Tests` traits in modules like `JavaModule`, `ScalaModule` and others now have unique
- names (`JavaModuleTests`, `ScalaModuleTests`, etc), to allow for easier customization
+ names (`JavaModuleTests`, `ScalaTests`, etc), to allow for easier customization
 * Various version bumps of dependencies
 * CI now runs all tests, it did miss some before
 

--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -19,7 +19,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
 
   def scalaJSVersion: T[String]
 
-  trait ScalaJSModuleTests extends ScalaModuleTests with TestScalaJSModule {
+  trait ScalaJSTests extends ScalaTests with TestScalaJSModule {
     override def scalaJSVersion = outer.scalaJSVersion()
     override def moduleKind = outer.moduleKind()
     override def moduleSplitStyle = outer.moduleSplitStyle()

--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -19,6 +19,8 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
 
   def scalaJSVersion: T[String]
 
+  @deprecated("use ScalaJSTests", "0.11.0")
+  type ScalaJSModuleTests = ScalaJSTests
   trait ScalaJSTests extends ScalaTests with TestScalaJSModule {
     override def scalaJSVersion = outer.scalaJSVersion()
     override def moduleKind = outer.moduleKind()

--- a/scalajslib/test/src/mill/scalajslib/HelloJSWorldTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/HelloJSWorldTests.scala
@@ -53,7 +53,7 @@ object HelloJSWorldTests extends TestSuite {
 
     object buildUTest extends Cross[BuildModuleUtest](matrix)
     trait BuildModuleUtest extends RootModule {
-      object test extends ScalaJSModuleTests with TestModule.Utest {
+      object test extends ScalaJSTests with TestModule.Utest {
         override def sources = T.sources { millSourcePath / "src" / "utest" }
         val utestVersion = if (ZincWorkerUtil.isScala3(crossScalaVersion)) "0.7.7" else "0.7.5"
         override def ivyDeps = Agg(
@@ -64,7 +64,7 @@ object HelloJSWorldTests extends TestSuite {
 
     object buildScalaTest extends Cross[BuildModuleScalaTest](matrix)
     trait BuildModuleScalaTest extends RootModule {
-      object test extends ScalaJSModuleTests with TestModule.ScalaTest {
+      object test extends ScalaJSTests with TestModule.ScalaTest {
         override def sources = T.sources { millSourcePath / "src" / "scalatest" }
         override def ivyDeps = Agg(
           ivy"org.scalatest::scalatest::3.1.2"
@@ -79,7 +79,7 @@ object HelloJSWorldTests extends TestSuite {
       def scalaOrganization = "org.example"
       def scalaVersion = scala
       def scalaJSVersion = scalaJS
-      object test extends ScalaJSModuleTests with TestModule.Utest
+      object test extends ScalaJSTests with TestModule.Utest
     }
 
     override lazy val millDiscover = Discover[this.type]

--- a/scalajslib/test/src/mill/scalajslib/MultiModuleTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/MultiModuleTests.scala
@@ -21,7 +21,7 @@ object MultiModuleTests extends TestSuite {
       override def millSourcePath = workspacePath / "client"
       override def moduleDeps = Seq(shared)
       override def mainClass = Some("Main")
-      object test extends ScalaJSModuleTests with TestModule.Utest {
+      object test extends ScalaJSTests with TestModule.Utest {
         override def ivyDeps =
           Agg(ivy"com.lihaoyi::utest::${sys.props.getOrElse("TEST_UTEST_VERSION", ???)}")
       }

--- a/scalajslib/test/src/mill/scalajslib/NodeJSConfigTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/NodeJSConfigTests.scala
@@ -46,7 +46,7 @@ object NodeJSConfigTests extends TestSuite {
 
     object buildUTest extends Cross[BuildModuleUtest](matrix)
     trait BuildModuleUtest extends RootModule {
-      object test extends ScalaJSModuleTests with TestModule.Utest {
+      object test extends ScalaJSTests with TestModule.Utest {
         override def sources = T.sources { millSourcePath / "src" / "utest" }
         override def ivyDeps = Agg(
           ivy"com.lihaoyi::utest::$utestVersion"

--- a/scalalib/src/mill/scalalib/SbtModule.scala
+++ b/scalalib/src/mill/scalalib/SbtModule.scala
@@ -12,7 +12,7 @@ trait SbtModule extends ScalaModule with MavenModule {
     millSourcePath / "src" / "main" / "java"
   )
 
-  trait SbtModuleTests extends ScalaModuleTests with MavenModuleTests {
+  trait SbtModuleTests extends ScalaTests with MavenModuleTests {
     override def sources = T.sources(
       millSourcePath / "src" / "test" / "scala",
       millSourcePath / "src" / "test" / "java"

--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -18,6 +18,8 @@ import mill.scalalib.dependency.versions.{ValidVersion, Version}
  * Core configuration required to compile a single Scala compilation target
  */
 trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
+  @deprecated("use ScalaTests", "0.11.0")
+  type ScalaModuleTests = ScalaTests
 
   trait ScalaTests extends JavaModuleTests with ScalaModule {
     override def scalaOrganization: Target[String] = outer.scalaOrganization()

--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -19,7 +19,7 @@ import mill.scalalib.dependency.versions.{ValidVersion, Version}
  */
 trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
 
-  trait ScalaModuleTests extends JavaModuleTests with ScalaModule {
+  trait ScalaTests extends JavaModuleTests with ScalaModule {
     override def scalaOrganization: Target[String] = outer.scalaOrganization()
     override def scalaVersion: Target[String] = outer.scalaVersion()
     override def scalacPluginIvyDeps: Target[Agg[Dep]] = outer.scalacPluginIvyDeps()

--- a/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
+++ b/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
@@ -287,7 +287,7 @@ object HelloWorldTests extends TestSuite {
   object HelloScalacheck extends HelloBase {
     object foo extends ScalaModule {
       def scalaVersion = scala212Version
-      object test extends ScalaModuleTests {
+      object test extends ScalaTests {
         override def ivyDeps = Agg(ivy"org.scalacheck::scalacheck:1.13.5")
         override def testFramework = "org.scalacheck.ScalaCheckFramework"
       }

--- a/scalalib/test/src/mill/scalalib/ScalaVersionsRangesTests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaVersionsRangesTests.scala
@@ -14,7 +14,7 @@ object ScalaVersionsRangesTests extends TestSuite {
     object core extends Cross[CoreCrossModule]("2.11.12", "2.12.13", "2.13.5", "3.0.0-RC2")
     trait CoreCrossModule extends CrossScalaModule
         with CrossScalaVersionRanges {
-      object test extends ScalaModuleTests with TestModule.Utest {
+      object test extends ScalaTests with TestModule.Utest {
         def ivyDeps = Agg(ivy"com.lihaoyi::utest:0.7.8")
       }
     }

--- a/scalalib/test/src/mill/scalalib/TestClassLoaderTests.scala
+++ b/scalalib/test/src/mill/scalalib/TestClassLoaderTests.scala
@@ -12,7 +12,7 @@ object TestClassLoaderTests extends TestSuite {
 
     def scalaVersion = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
 
-    object test extends ScalaModuleTests with TestModule.Utest {
+    object test extends ScalaTests with TestModule.Utest {
       override def ivyDeps = T {
         super.ivyDeps() ++ Agg(
           ivy"com.lihaoyi::utest:${sys.props.getOrElse("TEST_UTEST_VERSION", ???)}"

--- a/scalalib/test/src/mill/scalalib/TestRunnerTests.scala
+++ b/scalalib/test/src/mill/scalalib/TestRunnerTests.scala
@@ -12,7 +12,7 @@ object TestRunnerTests extends TestSuite {
 
     def scalaVersion = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
 
-    object test extends ScalaModuleTests with TestModule.Utest {
+    object test extends ScalaTests with TestModule.Utest {
       override def ivyDeps = T {
         super.ivyDeps() ++ Agg(
           ivy"com.lihaoyi::utest:${sys.props.getOrElse("TEST_UTEST_VERSION", ???)}"

--- a/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
+++ b/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
@@ -31,7 +31,7 @@ trait ScalaNativeModule extends ScalaModule { outer =>
   def scalaNativeVersion: T[String]
   override def platformSuffix = s"_native${scalaNativeBinaryVersion()}"
 
-  trait ScalaNativeModuleTests extends ScalaModuleTests with TestScalaNativeModule {
+  trait ScalaNativeTests extends ScalaTests with TestScalaNativeModule {
     override def scalaNativeVersion = outer.scalaNativeVersion()
     override def releaseMode = T { outer.releaseMode() }
     override def logLevel = outer.logLevel()

--- a/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
+++ b/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
@@ -31,6 +31,8 @@ trait ScalaNativeModule extends ScalaModule { outer =>
   def scalaNativeVersion: T[String]
   override def platformSuffix = s"_native${scalaNativeBinaryVersion()}"
 
+  @deprecated("use ScalaNativeTests", "0.11.0")
+  type ScalaNativeModuleTests = ScalaNativeTests
   trait ScalaNativeTests extends ScalaTests with TestScalaNativeModule {
     override def scalaNativeVersion = outer.scalaNativeVersion()
     override def releaseMode = T { outer.releaseMode() }

--- a/scalanativelib/test/src/mill/scalanativelib/HelloNativeWorldTests.scala
+++ b/scalanativelib/test/src/mill/scalanativelib/HelloNativeWorldTests.scala
@@ -61,7 +61,7 @@ object HelloNativeWorldTests extends TestSuite {
     }
     object buildUTest extends Cross[BuildModuleUtest](matrix)
     trait BuildModuleUtest extends RootModule {
-      object test extends ScalaNativeModuleTests with TestModule.Utest {
+      object test extends ScalaNativeTests with TestModule.Utest {
         override def sources = T.sources { millSourcePath / "src" / "utest" }
         override def ivyDeps = super.ivyDeps() ++ Agg(
           ivy"com.lihaoyi::utest::0.7.6"
@@ -74,7 +74,7 @@ object HelloNativeWorldTests extends TestSuite {
       def scalaOrganization = "org.example"
       def scalaVersion = scala
       def scalaNativeVersion = scalaNative
-      object test extends ScalaNativeModuleTests with TestModule.Utest
+      object test extends ScalaNativeTests with TestModule.Utest
     }
 
     override lazy val millDiscover: Discover[HelloNativeWorld.this.type] = Discover[this.type]


### PR DESCRIPTION
Last minute idea I had before we release 0.11.0 final

The current names are pretty verbose, especially for things that people would use often, and especially compared to the old `Tests` name. This cuts down the verbosity considerably.

WDYT @lefou @lolgab? If you don't like this I can skip it and release 0.11.0 as is, but I thought it's worth bringing up before the names become locked in for a while

