### PR TITLE
Add `mill.define.DynamicModule` to allow custom overriding of `millModuleDirectChildren`

### DIFF
--- a/main/define/src/mill/define/DynamicModule.scala
+++ b/main/define/src/mill/define/DynamicModule.scala
@@ -1,7 +1,7 @@
 package mill.define
 
 /**
- * A module which you can dynamically disable at runtime
+ * A module which you can override [[millModuleDirectChildren]] to dynamically
+ * enable or disable child modules at runtime
  */
-trait DynamicModule extends Module{
-}
+trait DynamicModule extends Module

--- a/main/define/src/mill/define/DynamicModule.scala
+++ b/main/define/src/mill/define/DynamicModule.scala
@@ -1,0 +1,7 @@
+package mill.define
+
+/**
+ * A module which you can dynamically disable at runtime
+ */
+trait DynamicModule extends Module{
+}

--- a/main/resolve/src/mill/resolve/ResolveCore.scala
+++ b/main/resolve/src/mill/resolve/ResolveCore.scala
@@ -146,7 +146,7 @@ private object ResolveCore {
     segments.value.foldLeft[Either[String, Module]](Right(rootModule)) {
       case (Right(current), Segment.Label(s)) =>
         assert(s != "_", s)
-        resolveDirectChildren0(current.getClass, Some(s)) match {
+        resolveDirectChildren0(rootModule, current.millModuleSegments, current.getClass, Some(s)).flatMap{
           case Seq((_, Some(f))) => f(current)
           case unknown =>
             sys.error(
@@ -204,43 +204,64 @@ private object ResolveCore {
       }
     } else Right(Nil)
 
-    crossesOrErr.map { crosses =>
-      resolveDirectChildren0(cls, nameOpt)
-        .map {
-          case (Resolved.Module(s, cls), _) => Resolved.Module(segments ++ s, cls)
-          case (Resolved.Target(s), _) => Resolved.Target(segments ++ s)
-          case (Resolved.Command(s), _) => Resolved.Command(segments ++ s)
-        }
-        .toSet
-        .++(crosses)
+    crossesOrErr.flatMap { crosses =>
+      resolveDirectChildren0(rootModule, segments, cls, nameOpt)
+        .map(
+          _.map {
+            case (Resolved.Module(s, cls), _) => Resolved.Module(segments ++ s, cls)
+            case (Resolved.Target(s), _) => Resolved.Target(segments ++ s)
+            case (Resolved.Command(s), _) => Resolved.Command(segments ++ s)
+          }
+          .toSet
+          .++(crosses)
+        )
     }
   }
 
   def resolveDirectChildren0(
+      rootModule: Module,
+      segments: Segments,
       cls: Class[_],
       nameOpt: Option[String]
-  ): Seq[(Resolved, Option[Module => Either[String, Module]])] = {
+  ): Either[String, Seq[(Resolved, Option[Module => Either[String, Module]])]] = {
     def namePred(n: String) = nameOpt.isEmpty || nameOpt.contains(n)
 
-    val modules = Reflect
-      .reflectNestedObjects0[Module](cls, namePred)
-      .map { case (name, member) =>
-        Resolved.Module(
-          Segments.labels(decode(name)),
-          member match {
-            case f: java.lang.reflect.Field => f.getType
-            case f: java.lang.reflect.Method => f.getReturnType
-          }
-        ) -> (
-          member match {
-            case f: java.lang.reflect.Field =>
-              Some((x: Module) => catchWrapException(f.get(x).asInstanceOf[Module]))
-
-            case f: java.lang.reflect.Method =>
-              Some((x: Module) => catchWrapException(f.invoke(x).asInstanceOf[Module]))
-          }
-        )
+    val modulesOrErr: Either[String, Seq[(Resolved, Option[Module => Either[String, Module]])]] = if (classOf[DynamicModule].isAssignableFrom(cls) ) {
+      instantiateModule(rootModule, segments).map{
+        case m: DynamicModule =>
+          m.millModuleDirectChildren
+            .filter(c => namePred(c.millModuleSegments.parts.last))
+            .map(c =>
+              (
+                Resolved.Module(
+                  Segments.labels(c.millModuleSegments.parts.last),
+                  c.getClass
+                ),
+                Some((x: Module) => Right(c))
+              )
+            )
       }
+    }else Right {
+      Reflect
+        .reflectNestedObjects0[Module](cls, namePred)
+        .map { case (name, member) =>
+          Resolved.Module(
+            Segments.labels(decode(name)),
+            member match {
+              case f: java.lang.reflect.Field => f.getType
+              case f: java.lang.reflect.Method => f.getReturnType
+            }
+          ) -> (
+            member match {
+              case f: java.lang.reflect.Field =>
+                Some((x: Module) => catchWrapException(f.get(x).asInstanceOf[Module]))
+
+              case f: java.lang.reflect.Method =>
+                Some((x: Module) => catchWrapException(f.invoke(x).asInstanceOf[Module]))
+            }
+            )
+        }
+    }
 
     val targets = Reflect
       .reflect(cls, classOf[Target[_]], namePred, noParams = true)
@@ -254,7 +275,7 @@ private object ResolveCore {
       .map(m => decode(m.getName))
       .map { name => Resolved.Command(Segments.labels(name)) -> None }
 
-    modules ++ targets ++ commands
+    modulesOrErr.map(_ ++ targets ++ commands)
   }
 
   def notFoundResult(rootModule: Module, querySoFar: Segments, current: Resolved, next: Segment) = {

--- a/main/resolve/src/mill/resolve/ResolveCore.scala
+++ b/main/resolve/src/mill/resolve/ResolveCore.scala
@@ -146,7 +146,12 @@ private object ResolveCore {
     segments.value.foldLeft[Either[String, Module]](Right(rootModule)) {
       case (Right(current), Segment.Label(s)) =>
         assert(s != "_", s)
-        resolveDirectChildren0(rootModule, current.millModuleSegments, current.getClass, Some(s)).flatMap{
+        resolveDirectChildren0(
+          rootModule,
+          current.millModuleSegments,
+          current.getClass,
+          Some(s)
+        ).flatMap {
           case Seq((_, Some(f))) => f(current)
           case unknown =>
             sys.error(
@@ -212,8 +217,8 @@ private object ResolveCore {
             case (Resolved.Target(s), _) => Resolved.Target(segments ++ s)
             case (Resolved.Command(s), _) => Resolved.Command(segments ++ s)
           }
-          .toSet
-          .++(crosses)
+            .toSet
+            .++(crosses)
         )
     }
   }
@@ -226,42 +231,43 @@ private object ResolveCore {
   ): Either[String, Seq[(Resolved, Option[Module => Either[String, Module]])]] = {
     def namePred(n: String) = nameOpt.isEmpty || nameOpt.contains(n)
 
-    val modulesOrErr: Either[String, Seq[(Resolved, Option[Module => Either[String, Module]])]] = if (classOf[DynamicModule].isAssignableFrom(cls) ) {
-      instantiateModule(rootModule, segments).map{
-        case m: DynamicModule =>
-          m.millModuleDirectChildren
-            .filter(c => namePred(c.millModuleSegments.parts.last))
-            .map(c =>
-              (
-                Resolved.Module(
-                  Segments.labels(c.millModuleSegments.parts.last),
-                  c.getClass
-                ),
-                Some((x: Module) => Right(c))
+    val modulesOrErr: Either[String, Seq[(Resolved, Option[Module => Either[String, Module]])]] =
+      if (classOf[DynamicModule].isAssignableFrom(cls)) {
+        instantiateModule(rootModule, segments).map {
+          case m: DynamicModule =>
+            m.millModuleDirectChildren
+              .filter(c => namePred(c.millModuleSegments.parts.last))
+              .map(c =>
+                (
+                  Resolved.Module(
+                    Segments.labels(c.millModuleSegments.parts.last),
+                    c.getClass
+                  ),
+                  Some((x: Module) => Right(c))
+                )
               )
-            )
-      }
-    }else Right {
-      Reflect
-        .reflectNestedObjects0[Module](cls, namePred)
-        .map { case (name, member) =>
-          Resolved.Module(
-            Segments.labels(decode(name)),
-            member match {
-              case f: java.lang.reflect.Field => f.getType
-              case f: java.lang.reflect.Method => f.getReturnType
-            }
-          ) -> (
-            member match {
-              case f: java.lang.reflect.Field =>
-                Some((x: Module) => catchWrapException(f.get(x).asInstanceOf[Module]))
-
-              case f: java.lang.reflect.Method =>
-                Some((x: Module) => catchWrapException(f.invoke(x).asInstanceOf[Module]))
-            }
-            )
         }
-    }
+      } else Right {
+        Reflect
+          .reflectNestedObjects0[Module](cls, namePred)
+          .map { case (name, member) =>
+            Resolved.Module(
+              Segments.labels(decode(name)),
+              member match {
+                case f: java.lang.reflect.Field => f.getType
+                case f: java.lang.reflect.Method => f.getReturnType
+              }
+            ) -> (
+              member match {
+                case f: java.lang.reflect.Field =>
+                  Some((x: Module) => catchWrapException(f.get(x).asInstanceOf[Module]))
+
+                case f: java.lang.reflect.Method =>
+                  Some((x: Module) => catchWrapException(f.invoke(x).asInstanceOf[Module]))
+              }
+            )
+          }
+      }
 
     val targets = Reflect
       .reflect(cls, classOf[Target[_]], namePred, noParams = true)

--- a/main/resolve/test/src/mill/main/ResolveTests.scala
+++ b/main/resolve/test/src/mill/main/ResolveTests.scala
@@ -773,7 +773,9 @@ object ResolveTests extends TestSuite {
       )
       test - check(
         "niled.inner.target",
-        Left("Cannot resolve niled.inner.target. Try `mill resolve niled._` to see what's available."),
+        Left(
+          "Cannot resolve niled.inner.target. Try `mill resolve niled._` to see what's available."
+        ),
         Set()
       )
       test - check(

--- a/main/resolve/test/src/mill/main/ResolveTests.scala
+++ b/main/resolve/test/src/mill/main/ResolveTests.scala
@@ -759,5 +759,33 @@ object ResolveTests extends TestSuite {
         Set("sub.inner.baseTarget")
       )
     }
+    test("dynamicModule") {
+      val check = new Checker(dynamicModule)
+      test - check(
+        "normal.inner.target",
+        Right(Set(_.normal.inner.target)),
+        Set("normal.inner.target")
+      )
+      test - check(
+        "normal._.target",
+        Right(Set(_.normal.inner.target)),
+        Set("normal.inner.target")
+      )
+      test - check(
+        "niled.inner.target",
+        Left("Cannot resolve niled.inner.target. Try `mill resolve niled._` to see what's available."),
+        Set()
+      )
+      test - check(
+        "niled._.target",
+        Left("Cannot resolve niled._.target. Try `mill resolve niled._` to see what's available."),
+        Set()
+      )
+      test - check(
+        "__.target",
+        Right(Set(_.normal.inner.target)),
+        Set("normal.inner.target")
+      )
+    }
   }
 }

--- a/main/test/src/mill/util/TestGraphs.scala
+++ b/main/test/src/mill/util/TestGraphs.scala
@@ -1,6 +1,6 @@
 package mill.util
 import TestUtil.test
-import mill.define.{ModuleRef, Command, Cross, Discover, TaskModule}
+import mill.define.{Command, Cross, Discover, DynamicModule, ModuleRef, TaskModule}
 import mill.{Module, T}
 
 /**
@@ -228,6 +228,22 @@ class TestGraphs() {
       override lazy val ignored: ModuleRef[SubInnerModule] = ModuleRef(new SubInnerModule {})
       trait SubInnerModule extends BaseInnerModule {
         def subTarget = T { 2 }
+      }
+    }
+
+    override lazy val millDiscover = Discover[this.type]
+  }
+
+  object dynamicModule extends TestUtil.BaseModule {
+    object normal extends DynamicModule {
+      object inner extends Module{
+        def target = T{ 1 }
+      }
+    }
+    object niled extends DynamicModule {
+      override def millModuleDirectChildren: Seq[Module] = Nil
+      object inner extends Module {
+        def target = T{ 1 }
       }
     }
 

--- a/main/test/src/mill/util/TestGraphs.scala
+++ b/main/test/src/mill/util/TestGraphs.scala
@@ -236,14 +236,14 @@ class TestGraphs() {
 
   object dynamicModule extends TestUtil.BaseModule {
     object normal extends DynamicModule {
-      object inner extends Module{
-        def target = T{ 1 }
+      object inner extends Module {
+        def target = T { 1 }
       }
     }
     object niled extends DynamicModule {
       override def millModuleDirectChildren: Seq[Module] = Nil
       object inner extends Module {
-        def target = T{ 1 }
+        def target = T { 1 }
       }
     }
 


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/2573

For now, I just preserved the `def millModuleDirectChildren` overriding. I couldn't figure out how to get `def enabled: Boolean` working without causing circular dependencies between `instantiateModule` depend on `resolveDirectChildren0`, resulting in an infinite recursion. Avoiding the infinite recursion would require some re-working on `ResolveCore.scala`. That can come in a follow-up, for now I just want to fix the regression and preserve the status quo (except for the new requirement of needing to extend a marker trait)