### PR TITLE
Fix type annotation for inner scoverage module

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -1181,6 +1181,7 @@ object dev extends MillPublishScalaModule {
     runner.linenumbers.testDep(),
     scalalib.backgroundwrapper.testDep(),
     contrib.buildinfo.testDep(),
+    contrib.scoverage.testDep(),
     contrib.playlib.testDep(),
     contrib.playlib.worker("2.8").testDep(),
     bsp.worker.testDep()

--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
@@ -172,7 +172,7 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
     )
   }
 
-  lazy val scoverage = new ScoverageData {}
+  val scoverage: ScoverageData = new ScoverageData {}
 
   trait ScoverageData extends ScalaModule {
 

--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
@@ -8,6 +8,7 @@ import mill.contrib.scoverage.api.ScoverageReportWorkerApi.ReportType
 import mill.scalalib.api.ZincWorkerUtil
 import mill.scalalib.{Dep, DepSyntax, JavaModule, ScalaModule}
 import mill.api.Result
+import mill.define.ModuleRef
 import mill.util.Util.millProjectModule
 
 import scala.util.Try
@@ -172,13 +173,13 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
     )
   }
 
-  private lazy val scoverageData = new ScoverageData {}
+  private[scoverage] lazy val scoverageData: ScoverageData = new ScoverageData {}
 
   /**
    * Inner worker. It's a `def` instead of an `object` or `val` to give users a chance to properly override and customize it.
-   * When overridden, the value should not change, once initialized. You may want to use a `private lazy val` to hold the actual value.
+   * When overridden, the value should not change, once initialized. You may want to use a `private[package] lazy val` to hold the actual value.
    */
-  def scoverage: ScoverageData = scoverageData
+  def scoverage: ModuleRef[ScoverageData] = ModuleRef(scoverageData)
 
   trait ScoverageData extends ScalaModule {
 
@@ -258,6 +259,6 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
     }
 
     // Need the sources compiled with scoverage instrumentation to run.
-    override def moduleDeps: Seq[JavaModule] = Seq(outer.scoverage)
+    override def moduleDeps: Seq[JavaModule] = Seq(outer.scoverage())
   }
 }

--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
@@ -172,7 +172,13 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
     )
   }
 
-  val scoverage: ScoverageData = new ScoverageData {}
+  private lazy val scoverageData = new ScoverageData {}
+
+  /**
+   * Inner worker. It's a `def` instead of an `object` or `val` to give users a chance to properly override and customize it.
+   * When overridden, the value should not change, once initialized. You may want to use a `private lazy val` to hold the actual value.
+   */
+  def scoverage: ScoverageData = scoverageData
 
   trait ScoverageData extends ScalaModule {
 

--- a/contrib/scoverage/test/src/mill/contrib/scoverage/HelloWorldTests.scala
+++ b/contrib/scoverage/test/src/mill/contrib/scoverage/HelloWorldTests.scala
@@ -207,7 +207,8 @@ trait HelloWorldTests extends utest.TestSuite {
             }
           }
           "compileClasspath" - workspaceTest(HelloWorld) { eval =>
-            val Right((result, evalCount)) = eval.apply(HelloWorld.core.scoverage().compileClasspath)
+            val Right((result, evalCount)) =
+              eval.apply(HelloWorld.core.scoverage().compileClasspath)
 
             val runtimeExistsOnClasspath =
               result.map(_.toString).iterator.exists(_.contains("scalac-scoverage-runtime"))
@@ -258,7 +259,8 @@ trait HelloWorldTests extends utest.TestSuite {
         }
         "console" - workspaceTest(HelloWorldSbt, sbtResourcePath) { eval =>
           val Right((_, _)) = eval.apply(HelloWorldSbt.core.test.compile)
-          val Right((result, evalCount)) = eval.apply(HelloWorldSbt.core.scoverage().consoleReport())
+          val Right((result, evalCount)) =
+            eval.apply(HelloWorldSbt.core.scoverage().consoleReport())
           assert(evalCount > 0)
         }
       }

--- a/contrib/scoverage/test/src/mill/contrib/scoverage/HelloWorldTests.scala
+++ b/contrib/scoverage/test/src/mill/contrib/scoverage/HelloWorldTests.scala
@@ -93,7 +93,7 @@ trait HelloWorldTests extends utest.TestSuite {
         "scoverage" - {
           "unmanagedClasspath" - workspaceTest(HelloWorld) { eval =>
             val Right((result, evalCount)) =
-              eval.apply(HelloWorld.core.scoverage.unmanagedClasspath)
+              eval.apply(HelloWorld.core.scoverage().unmanagedClasspath)
 
             assert(
               result.map(_.toString).iterator.exists(_.contains("unmanaged.xml")),
@@ -102,7 +102,7 @@ trait HelloWorldTests extends utest.TestSuite {
           }
           "ivyDeps" - workspaceTest(HelloWorld) { eval =>
             val Right((result, evalCount)) =
-              eval.apply(HelloWorld.core.scoverage.ivyDeps)
+              eval.apply(HelloWorld.core.scoverage().ivyDeps)
 
             val expected = if (isScala3) Agg.empty
             else Agg(
@@ -116,7 +116,7 @@ trait HelloWorldTests extends utest.TestSuite {
           }
           "scalacPluginIvyDeps" - workspaceTest(HelloWorld) { eval =>
             val Right((result, evalCount)) =
-              eval.apply(HelloWorld.core.scoverage.scalacPluginIvyDeps)
+              eval.apply(HelloWorld.core.scoverage().scalacPluginIvyDeps)
 
             val expected = (isScov3, isScala3) match {
               case (true, true) => Agg.empty
@@ -138,11 +138,11 @@ trait HelloWorldTests extends utest.TestSuite {
             )
           }
           "data" - workspaceTest(HelloWorld) { eval =>
-            val Right((result, evalCount)) = eval.apply(HelloWorld.core.scoverage.data)
+            val Right((result, evalCount)) = eval.apply(HelloWorld.core.scoverage().data)
 
             val resultPath = result.path.toIO.getPath.replace("""\""", "/")
             val expectedEnd =
-              "/target/workspace/mill/contrib/scoverage/HelloWorldTests/eval/HelloWorld/core/scoverage/data/core/scoverage/data.dest"
+              "/target/workspace/mill/contrib/scoverage/HelloWorldTests/eval/HelloWorld/core/scoverage/data/core/scoverageData/data.dest"
 
             assert(
               resultPath.endsWith(expectedEnd),
@@ -151,7 +151,7 @@ trait HelloWorldTests extends utest.TestSuite {
           }
           "htmlReport" - workspaceTest(HelloWorld) { eval =>
             val Right((_, _)) = eval.apply(HelloWorld.core.test.compile)
-            val res = eval.apply(HelloWorld.core.scoverage.htmlReport())
+            val res = eval.apply(HelloWorld.core.scoverage().htmlReport())
             if (
               res.isLeft && testScalaVersion.startsWith("3.2") && testScoverageVersion.startsWith(
                 "2."
@@ -167,7 +167,7 @@ trait HelloWorldTests extends utest.TestSuite {
           }
           "xmlReport" - workspaceTest(HelloWorld) { eval =>
             val Right((_, _)) = eval.apply(HelloWorld.core.test.compile)
-            val res = eval.apply(HelloWorld.core.scoverage.xmlReport())
+            val res = eval.apply(HelloWorld.core.scoverage().xmlReport())
             if (
               res.isLeft && testScalaVersion.startsWith("3.2") && testScoverageVersion.startsWith(
                 "2."
@@ -183,14 +183,14 @@ trait HelloWorldTests extends utest.TestSuite {
           }
           "console" - workspaceTest(HelloWorld) { eval =>
             val Right((_, _)) = eval.apply(HelloWorld.core.test.compile)
-            val Right((_, evalCount)) = eval.apply(HelloWorld.core.scoverage.consoleReport())
+            val Right((_, evalCount)) = eval.apply(HelloWorld.core.scoverage().consoleReport())
             assert(evalCount > 0)
           }
         }
         test("test") - {
           "upstreamAssemblyClasspath" - workspaceTest(HelloWorld) { eval =>
             val Right((result, evalCount)) =
-              eval.apply(HelloWorld.core.scoverage.upstreamAssemblyClasspath)
+              eval.apply(HelloWorld.core.scoverage().upstreamAssemblyClasspath)
 
             val runtimeExistsOnClasspath =
               result.map(_.toString).iterator.exists(_.contains("scalac-scoverage-runtime"))
@@ -207,7 +207,7 @@ trait HelloWorldTests extends utest.TestSuite {
             }
           }
           "compileClasspath" - workspaceTest(HelloWorld) { eval =>
-            val Right((result, evalCount)) = eval.apply(HelloWorld.core.scoverage.compileClasspath)
+            val Right((result, evalCount)) = eval.apply(HelloWorld.core.scoverage().compileClasspath)
 
             val runtimeExistsOnClasspath =
               result.map(_.toString).iterator.exists(_.contains("scalac-scoverage-runtime"))
@@ -223,9 +223,8 @@ trait HelloWorldTests extends utest.TestSuite {
               )
             }
           }
-          // TODO: document why we disable for Java9+
           "runClasspath" - workspaceTest(HelloWorld) { eval =>
-            val Right((result, evalCount)) = eval.apply(HelloWorld.core.scoverage.runClasspath)
+            val Right((result, evalCount)) = eval.apply(HelloWorld.core.scoverage().runClasspath)
 
             val runtimeExistsOnClasspath =
               result.map(_.toString).iterator.exists(_.contains("scalac-scoverage-runtime"))
@@ -249,17 +248,17 @@ trait HelloWorldTests extends utest.TestSuite {
       "scoverage" - {
         "htmlReport" - workspaceTest(HelloWorldSbt, sbtResourcePath) { eval =>
           val Right((_, _)) = eval.apply(HelloWorldSbt.core.test.compile)
-          val Right((result, evalCount)) = eval.apply(HelloWorldSbt.core.scoverage.htmlReport())
+          val Right((result, evalCount)) = eval.apply(HelloWorldSbt.core.scoverage().htmlReport())
           assert(evalCount > 0)
         }
         "xmlReport" - workspaceTest(HelloWorldSbt, sbtResourcePath) { eval =>
           val Right((_, _)) = eval.apply(HelloWorldSbt.core.test.compile)
-          val Right((result, evalCount)) = eval.apply(HelloWorldSbt.core.scoverage.xmlReport())
+          val Right((result, evalCount)) = eval.apply(HelloWorldSbt.core.scoverage().xmlReport())
           assert(evalCount > 0)
         }
         "console" - workspaceTest(HelloWorldSbt, sbtResourcePath) { eval =>
           val Right((_, _)) = eval.apply(HelloWorldSbt.core.test.compile)
-          val Right((result, evalCount)) = eval.apply(HelloWorldSbt.core.scoverage.consoleReport())
+          val Right((result, evalCount)) = eval.apply(HelloWorldSbt.core.scoverage().consoleReport())
           assert(evalCount > 0)
         }
       }
@@ -280,7 +279,7 @@ trait FailedWorldTests extends HelloWorldTests {
           assert(msg == errorMsg)
         }
         "other" - workspaceTest(mod) { eval =>
-          val Left(Result.Failure(msg, _)) = eval.apply(mod.core.scoverage.xmlReport())
+          val Left(Result.Failure(msg, _)) = eval.apply(mod.core.scoverage().xmlReport())
           assert(msg == errorMsg)
         }
       }
@@ -296,7 +295,7 @@ trait FailedWorldTests extends HelloWorldTests {
           assert(msg == errorMsg)
         }
         "other" - workspaceTest(mod) { eval =>
-          val Left(Result.Failure(msg, _)) = eval.apply(mod.core.scoverage.xmlReport())
+          val Left(Result.Failure(msg, _)) = eval.apply(mod.core.scoverage().xmlReport())
           assert(msg == errorMsg)
         }
       }

--- a/integration/feature/scoverage/repo/build.sc
+++ b/integration/feature/scoverage/repo/build.sc
@@ -1,0 +1,226 @@
+// mill plugins
+import $ivy.`de.tototec::de.tobiasroeser.mill.vcs.version::0.4.0`
+import $ivy.`de.tototec::de.tobiasroeser.mill.integrationtest::0.7.1`
+import $ivy.`com.lihaoyi::mill-contrib-scoverage:`
+import $ivy.`com.github.lolgab::mill-mima::0.0.23`
+
+// imports
+import mill._
+import mill.contrib.scoverage.ScoverageModule
+import mill.define.{Command, Sources, Target, Task, TaskModule}
+import mill.scalalib._
+import mill.scalalib.api.ZincWorkerUtil
+import mill.scalalib.publish._
+import de.tobiasroeser.mill.integrationtest._
+import de.tobiasroeser.mill.vcs.version._
+import com.github.lolgab.mill.mima.Mima
+import scala.util.{Properties, Try}
+
+val baseDir = build.millSourcePath
+
+trait Deps {
+  def millPlatform: String
+  def millVersion: String
+  def scalaVersion: String = "2.13.11"
+  def testWithMill: Seq[String]
+
+  def mimaPreviousVersions: Seq[String] = Seq()
+
+  val millMain = ivy"com.lihaoyi::mill-main:${millVersion}"
+  val scalaTest = ivy"org.scalatest::scalatest:3.2.16"
+  val scoverageVersion = "2.0.10"
+  val scoverageRuntime = ivy"org.scoverage::scalac-scoverage-runtime:${scoverageVersion}"
+}
+
+class Deps_latest(override val millVersion: String) extends Deps {
+  override def millPlatform = millVersion
+  override def testWithMill = Seq(millVersion)
+  override def mimaPreviousVersions = Seq()
+}
+object Deps_0_11 extends Deps {
+  override def millPlatform = "0.11"
+  override def millVersion = "0.11.0" // scala-steward:off
+  override def testWithMill = Seq(millVersion)
+  override def mimaPreviousVersions = Seq()
+}
+object Deps_0_10 extends Deps {
+  override def millPlatform = "0.10"
+  override def millVersion = "0.10.0" // scala-steward:off
+  // 0.10.4 and 0.10.3 don't run in CI on Windows
+  override def testWithMill = Seq("0.10.12", "0.10.5", millVersion)
+}
+object Deps_0_9 extends Deps {
+  override def millPlatform = "0.9"
+  override def millVersion = "0.9.3" // scala-steward:off
+  override def testWithMill =
+    Seq("0.9.12", "0.9.11", "0.9.10", "0.9.9", "0.9.8", "0.9.7", "0.9.6", "0.9.5", "0.9.4", millVersion)
+}
+object Deps_0_7 extends Deps {
+  override def millPlatform = "0.7"
+  override def millVersion = "0.7.0" // scala-steward:off
+  override def testWithMill = Seq("0.8.0", "0.7.4", "0.7.3", "0.7.2", "0.7.1", millVersion)
+}
+object Deps_0_6 extends Deps {
+  override def millPlatform = "0.6"
+  override def millVersion = "0.6.0" // scala-steward:off
+  override def scalaVersion = "2.12.18"
+  override def testWithMill = Seq("0.6.3", "0.6.2", "0.6.1", millVersion)
+}
+
+val latestDeps: Seq[Deps] = {
+  val path = baseDir / "MILL_DEV_VERSION"
+  interp.watch(path)
+  println(s"Checking for file ${path}")
+  if (os.exists(path)) {
+    Try { Seq(new Deps_latest(os.read(path).trim())) }
+      .recover { _ => Seq() }
+  }.get
+  else Seq()
+}
+
+val crossDeps: Seq[Deps] = (Seq(Deps_0_11, Deps_0_10, Deps_0_9, Deps_0_7, Deps_0_6) ++ latestDeps).distinct
+val millApiVersions = crossDeps.map(x => x.millPlatform -> x)
+val millItestVersions = crossDeps.flatMap(x => x.testWithMill.map(_ -> x))
+
+/** Shared configuration. */
+trait BaseModule extends CrossScalaModule with PublishModule with ScoverageModule with Mima {
+  def millApiVersion: String
+  def deps: Deps = millApiVersions.toMap.apply(millApiVersion)
+  def crossScalaVersion = deps.scalaVersion
+  override def artifactSuffix: T[String] = s"_mill${deps.millPlatform}_${artifactScalaVersion()}"
+
+  override def ivyDeps = T {
+    Agg(ivy"${scalaOrganization()}:scala-library:${scalaVersion()}")
+  }
+
+  def publishVersion = VcsVersion.vcsState().format()
+  override def versionScheme: T[Option[VersionScheme]] = T(Option(VersionScheme.EarlySemVer))
+
+  override def mimaPreviousVersions = deps.mimaPreviousVersions
+  override def mimaPreviousArtifacts: Target[Agg[Dep]] = T {
+    val md = artifactMetadata()
+    Agg.from(
+      mimaPreviousVersions().map(v => ivy"${md.group}:${md.id}:${v}")
+    )
+  }
+
+  override def sources: Sources = T.sources {
+    Seq(PathRef(millSourcePath / "src")) ++
+      (ZincWorkerUtil.matchingVersions(millApiVersion) ++
+        ZincWorkerUtil.versionRanges(millApiVersion, crossDeps.map(_.millPlatform)))
+        .map(p => PathRef(millSourcePath / s"src-${p}"))
+  }
+
+  override def javacOptions = {
+    (if (Properties.isJavaAtLeast(9)) Seq("--release", "8") else Seq("-source", "1.8", "-target", "1.8")) ++
+      Seq("-encoding", "UTF-8", "-deprecation")
+  }
+
+  override def scalacOptions = Seq("-target:jvm-1.8", "-encoding", "UTF-8", "-deprecation")
+
+  def pomSettings = T {
+    PomSettings(
+      description = "Mill plugin to derive a version from (last) git tag and edit state",
+      organization = "de.tototec",
+      url = "https://github.com/lefou/mill-vcs-version",
+      licenses = Seq(License.`Apache-2.0`),
+      versionControl = VersionControl.github("lefou", "mill-vcs-version"),
+      developers = Seq(Developer("lefou", "Tobias Roeser", "https.//github.com/lefou"))
+    )
+  }
+
+  override def scoverageVersion = deps.scoverageVersion
+
+  trait Tests extends ScoverageTests
+}
+
+/* The actual mill plugin compilied against different mill APIs. */
+object core extends Cross[CoreCross](millApiVersions.map(_._1))
+trait CoreCross extends BaseModule with Cross.Module[String] {
+  override def millApiVersion: String = crossValue
+
+  override def artifactName = "de.tobiasroeser.mill.vcs.version"
+
+  override def skipIdea: Boolean = deps != crossDeps.head
+
+  override def compileIvyDeps = Agg(deps.millMain)
+
+  object test extends Tests with TestModule.ScalaTest {
+    override def ivyDeps = Agg(deps.scalaTest, deps.millMain)
+  }
+}
+
+/** Integration tests. */
+object itest extends Cross[ItestCross](millItestVersions.map(_._1)) with TaskModule {
+  override def defaultCommandName(): String = "test"
+  def testCached: T[Seq[TestCase]] = itest(millItestVersions.map(_._1).head).testCached
+  def test(args: String*): Command[Seq[TestCase]] = itest(millItestVersions.map(_._1).head).test(args: _*)
+}
+trait ItestCross extends MillIntegrationTestModule with Cross.Module[String] {
+
+  def millItestVersion = crossValue
+
+  val millApiVersion = millItestVersions.toMap.apply(millItestVersion).millPlatform
+  def deps: Deps = millApiVersions.toMap.apply(millApiVersion)
+
+  override def millSourcePath: os.Path = super.millSourcePath / os.up
+  override def millTestVersion = millItestVersion
+  override def pluginsUnderTest = Seq(core(millApiVersion))
+
+  /** Replaces the plugin jar with a scoverage-enhanced version of it. */
+  override def pluginUnderTestDetails: Task[Seq[(PathRef, (PathRef, (PathRef, (PathRef, (PathRef, Artifact)))))]] =
+    Target.traverse(pluginsUnderTest) { p =>
+      val jar = p match {
+        case p: ScoverageModule => p.scoverage.jar
+        case p                  => p.jar
+      }
+      jar zip (p.sourceJar zip (p.docJar zip (p.pom zip (p.ivy zip p.artifactMetadata))))
+    }
+
+  override def testInvocations: Target[Seq[(PathRef, Seq[TestInvocation.Targets])]] = T {
+    testCases().map { pathref =>
+      pathref.path.last match {
+        case "01-simple" =>
+          pathref -> Seq(
+            TestInvocation.Targets(Seq("-d", "verify1")),
+            TestInvocation.Targets(Seq("de.tobiasroeser.mill.vcs.version.VcsVersion/vcsState")),
+            TestInvocation.Targets(Seq("changeSomething")),
+            TestInvocation.Targets(Seq("verify2"))
+          )
+        case "no-git" =>
+          pathref -> Seq(
+            // setting GIT_DIR explicitly disables repository discovery
+            TestInvocation.Targets(targets = Seq("-d", "verify"), env = Map("GIT_DIR" -> "."))
+          )
+        case _ =>
+          pathref -> Seq(TestInvocation.Targets(Seq("-d", "verify")))
+      }
+    }
+  }
+
+  override def perTestResources = T.sources { Seq(generatedSharedSrc()) }
+  def generatedSharedSrc = T {
+    os.write(
+      T.dest / "shared.sc",
+      s"""import $$ivy.`${deps.scoverageRuntime.dep.module.organization.value}::${deps.scoverageRuntime.dep.module.name.value}:${deps.scoverageRuntime.dep.version}`
+         |""".stripMargin
+    )
+    PathRef(T.dest)
+  }
+
+}
+
+def findLatestMill(toFile: String = "") = T.command {
+  import coursier._
+  val versions =
+    Versions(cache.FileCache().withTtl(concurrent.duration.Duration(1, java.util.concurrent.TimeUnit.MINUTES)))
+      .withModule(mod"com.lihaoyi:mill-main_2.13")
+      .run()
+  println(s"Latest Mill versions: ${versions.latest}")
+  if (toFile.nonEmpty) {
+    val path = os.Path.expandUser(toFile, os.pwd)
+    println(s"Writing file: ${path}")
+    os.write.over(path, versions.latest, createFolders = true)
+  }
+  versions.latest
+}

--- a/integration/feature/scoverage/repo/build.sc
+++ b/integration/feature/scoverage/repo/build.sc
@@ -10,8 +10,6 @@ import mill._
 import mill.contrib.scoverage.ScoverageModule
 import mill.scalalib._
 
-val baseDir = build.millSourcePath
-
 object Deps {
   val millVersion = "0.11.0"
   val millMain = ivy"com.lihaoyi::mill-main:${millVersion}"

--- a/integration/feature/scoverage/repo/build.sc
+++ b/integration/feature/scoverage/repo/build.sc
@@ -1,3 +1,6 @@
+// Reproduction of issue https://github.com/com-lihaoyi/mill/issues/2579
+// and issue https://github.com/com-lihaoyi/mill/issues/2582
+
 // mill plugins
 import $ivy.`de.tototec::de.tobiasroeser.mill.vcs.version::0.4.0`
 import $ivy.`de.tototec::de.tobiasroeser.mill.integrationtest::0.7.1`

--- a/integration/feature/scoverage/repo/build.sc
+++ b/integration/feature/scoverage/repo/build.sc
@@ -2,173 +2,27 @@
 // and issue https://github.com/com-lihaoyi/mill/issues/2582
 
 // mill plugins
-import $ivy.`de.tototec::de.tobiasroeser.mill.vcs.version::0.4.0`
-import $ivy.`de.tototec::de.tobiasroeser.mill.integrationtest::0.7.1`
 import $ivy.`com.lihaoyi::mill-contrib-scoverage:`
 import $ivy.`com.github.lolgab::mill-mima::0.0.23`
 
 // imports
 import mill._
 import mill.contrib.scoverage.ScoverageModule
-import mill.define.{Command, Sources, Target, Task, TaskModule}
 import mill.scalalib._
-import mill.scalalib.api.ZincWorkerUtil
-import mill.scalalib.publish._
-import de.tobiasroeser.mill.integrationtest._
-import de.tobiasroeser.mill.vcs.version._
-import com.github.lolgab.mill.mima.Mima
-import scala.util.{Properties, Try}
 
 val baseDir = build.millSourcePath
 
-trait Deps {
-  def millPlatform: String
-  def millVersion: String
-  def scalaVersion: String = "2.13.11"
-  def testWithMill: Seq[String]
-
-  def mimaPreviousVersions: Seq[String] = Seq()
-
+object Deps {
+  val millVersion = "0.11.0"
   val millMain = ivy"com.lihaoyi::mill-main:${millVersion}"
   val scalaTest = ivy"org.scalatest::scalatest:3.2.16"
-  val scoverageVersion = "2.0.10"
-  val scoverageRuntime = ivy"org.scoverage::scalac-scoverage-runtime:${scoverageVersion}"
 }
 
-object Deps_0_11 extends Deps {
-  override def millPlatform = "0.11"
-  override def millVersion = "0.11.0" // scala-steward:off
-  override def testWithMill = Seq(millVersion)
-  override def mimaPreviousVersions = Seq()
-}
-
-val crossDeps: Seq[Deps] = Seq(Deps_0_11)
-val millApiVersions = crossDeps.map(x => x.millPlatform -> x)
-val millItestVersions = crossDeps.flatMap(x => x.testWithMill.map(_ -> x))
-
-/** Shared configuration. */
-trait BaseModule extends CrossScalaModule with PublishModule with ScoverageModule with Mima {
-  def millApiVersion: String
-  def deps: Deps = millApiVersions.toMap.apply(millApiVersion)
-  def crossScalaVersion = deps.scalaVersion
-  override def artifactSuffix: T[String] = s"_mill${deps.millPlatform}_${artifactScalaVersion()}"
-
-  override def ivyDeps = T {
-    Agg(ivy"${scalaOrganization()}:scala-library:${scalaVersion()}")
-  }
-
-  def publishVersion = VcsVersion.vcsState().format()
-  override def versionScheme: T[Option[VersionScheme]] = T(Option(VersionScheme.EarlySemVer))
-
-  override def mimaPreviousVersions = deps.mimaPreviousVersions
-  override def mimaPreviousArtifacts: Target[Agg[Dep]] = T {
-    val md = artifactMetadata()
-    Agg.from(
-      mimaPreviousVersions().map(v => ivy"${md.group}:${md.id}:${v}")
-    )
-  }
-
-  override def sources: Sources = T.sources {
-    Seq(PathRef(millSourcePath / "src")) ++
-      (ZincWorkerUtil.matchingVersions(millApiVersion) ++
-        ZincWorkerUtil.versionRanges(millApiVersion, crossDeps.map(_.millPlatform)))
-        .map(p => PathRef(millSourcePath / s"src-${p}"))
-  }
-
-  override def javacOptions = {
-    (if (Properties.isJavaAtLeast(9)) Seq("--release", "8") else Seq("-source", "1.8", "-target", "1.8")) ++
-      Seq("-encoding", "UTF-8", "-deprecation")
-  }
-
-  override def scalacOptions = Seq("-target:jvm-1.8", "-encoding", "UTF-8", "-deprecation")
-
-  def pomSettings = T {
-    PomSettings(
-      description = "Mill plugin to derive a version from (last) git tag and edit state",
-      organization = "de.tototec",
-      url = "https://github.com/lefou/mill-vcs-version",
-      licenses = Seq(License.`Apache-2.0`),
-      versionControl = VersionControl.github("lefou", "mill-vcs-version"),
-      developers = Seq(Developer("lefou", "Tobias Roeser", "https.//github.com/lefou"))
-    )
-  }
-
-  override def scoverageVersion = deps.scoverageVersion
-
-}
-
-/* The actual mill plugin compilied against different mill APIs. */
-object core extends Cross[CoreCross](millApiVersions.map(_._1))
-trait CoreCross extends BaseModule with Cross.Module[String] {
-  override def millApiVersion: String = crossValue
-
-  override def artifactName = "de.tobiasroeser.mill.vcs.version"
-
-  override def skipIdea: Boolean = deps != crossDeps.head
-
-  override def compileIvyDeps = Agg(deps.millMain)
-
+object core extends Cross[CoreCross]("2.13.11")
+trait CoreCross extends CrossScalaModule with ScoverageModule {
+  override def scoverageVersion = "2.0.10"
   object test extends ScoverageTests with TestModule.ScalaTest {
-    override def ivyDeps = Agg(deps.scalaTest, deps.millMain)
+    override def ivyDeps = Agg(Deps.scalaTest, Deps.millMain)
   }
 }
 
-/** Integration tests. */
-object itest extends Cross[ItestCross](millItestVersions.map(_._1)) with TaskModule {
-  override def defaultCommandName(): String = "test"
-  def testCached: T[Seq[TestCase]] = itest(millItestVersions.map(_._1).head).testCached
-  def test(args: String*): Command[Seq[TestCase]] = itest(millItestVersions.map(_._1).head).test(args: _*)
-}
-trait ItestCross extends MillIntegrationTestModule with Cross.Module[String] {
-
-  def millItestVersion = crossValue
-
-  val millApiVersion = millItestVersions.toMap.apply(millItestVersion).millPlatform
-  def deps: Deps = millApiVersions.toMap.apply(millApiVersion)
-
-  override def millSourcePath: os.Path = super.millSourcePath / os.up
-  override def millTestVersion = millItestVersion
-  override def pluginsUnderTest = Seq(core(millApiVersion))
-
-  /** Replaces the plugin jar with a scoverage-enhanced version of it. */
-  override def pluginUnderTestDetails: Task[Seq[(PathRef, (PathRef, (PathRef, (PathRef, (PathRef, Artifact)))))]] =
-    Target.traverse(pluginsUnderTest) { p =>
-      val jar = p match {
-        case p: ScoverageModule => p.scoverage.jar
-        case p                  => p.jar
-      }
-      jar zip (p.sourceJar zip (p.docJar zip (p.pom zip (p.ivy zip p.artifactMetadata))))
-    }
-
-  override def testInvocations: Target[Seq[(PathRef, Seq[TestInvocation.Targets])]] = T {
-    testCases().map { pathref =>
-      pathref.path.last match {
-        case "01-simple" =>
-          pathref -> Seq(
-            TestInvocation.Targets(Seq("-d", "verify1")),
-            TestInvocation.Targets(Seq("de.tobiasroeser.mill.vcs.version.VcsVersion/vcsState")),
-            TestInvocation.Targets(Seq("changeSomething")),
-            TestInvocation.Targets(Seq("verify2"))
-          )
-        case "no-git" =>
-          pathref -> Seq(
-            // setting GIT_DIR explicitly disables repository discovery
-            TestInvocation.Targets(targets = Seq("-d", "verify"), env = Map("GIT_DIR" -> "."))
-          )
-        case _ =>
-          pathref -> Seq(TestInvocation.Targets(Seq("-d", "verify")))
-      }
-    }
-  }
-
-  override def perTestResources = T.sources { Seq(generatedSharedSrc()) }
-  def generatedSharedSrc = T {
-    os.write(
-      T.dest / "shared.sc",
-      s"""import $$ivy.`${deps.scoverageRuntime.dep.module.organization.value}::${deps.scoverageRuntime.dep.module.name.value}:${deps.scoverageRuntime.dep.version}`
-         |""".stripMargin
-    )
-    PathRef(T.dest)
-  }
-
-}

--- a/integration/feature/scoverage/test/src/ScoverageTests.scala
+++ b/integration/feature/scoverage/test/src/ScoverageTests.scala
@@ -1,0 +1,12 @@
+package mill.integration
+
+import utest._
+
+object ScoverageTests extends IntegrationTestSuite {
+  val tests = Tests {
+    initWorkspace()
+    test("test") - {
+      assert(eval("__.compile"))
+    }
+  }
+}


### PR DESCRIPTION
* [x] Fix https://github.com/com-lihaoyi/mill/issues/2579

I also changed from `lazy val` to `def` to make overridding and `super.scoverageData`-calls easier.
