### PR TITLE
Refined fix for `ScoverageModule` inner module

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -1182,6 +1182,7 @@ object dev extends MillPublishScalaModule {
     scalalib.backgroundwrapper.testDep(),
     contrib.buildinfo.testDep(),
     contrib.scoverage.testDep(),
+    contrib.scoverage.worker2.testDep(),
     contrib.playlib.testDep(),
     contrib.playlib.worker("2.8").testDep(),
     bsp.worker.testDep()

--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
@@ -173,13 +173,8 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
     )
   }
 
-  private[scoverage] lazy val scoverageData: ScoverageData = new ScoverageData {}
-
-  /**
-   * Inner worker. It's a `def` instead of an `object` or `val` to give users a chance to properly override and customize it.
-   * When overridden, the value should not change, once initialized. You may want to use a `private[package] lazy val` to hold the actual value.
-   */
-  def scoverage: ModuleRef[ScoverageData] = ModuleRef(scoverageData)
+  /** Inner worker module. This is a `val` to allow users to override and customize it. */
+  val scoverage: ScoverageData = new ScoverageData {}
 
   trait ScoverageData extends ScalaModule {
 
@@ -259,6 +254,6 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
     }
 
     // Need the sources compiled with scoverage instrumentation to run.
-    override def moduleDeps: Seq[JavaModule] = Seq(outer.scoverage())
+    override def moduleDeps: Seq[JavaModule] = Seq(outer.scoverage)
   }
 }

--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
@@ -173,8 +173,8 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
     )
   }
 
-  /** Inner worker module. This is a `val` to allow users to override and customize it. */
-  val scoverage: ScoverageData = new ScoverageData {}
+  /** Inner worker module. This is not an `object` to allow users to override and customize it. */
+  lazy val scoverage: ScoverageData = new ScoverageData {}
 
   trait ScoverageData extends ScalaModule {
 

--- a/contrib/scoverage/test/src/mill/contrib/scoverage/HelloWorldTests.scala
+++ b/contrib/scoverage/test/src/mill/contrib/scoverage/HelloWorldTests.scala
@@ -93,7 +93,7 @@ trait HelloWorldTests extends utest.TestSuite {
         "scoverage" - {
           "unmanagedClasspath" - workspaceTest(HelloWorld) { eval =>
             val Right((result, evalCount)) =
-              eval.apply(HelloWorld.core.scoverage().unmanagedClasspath)
+              eval.apply(HelloWorld.core.scoverage.unmanagedClasspath)
 
             assert(
               result.map(_.toString).iterator.exists(_.contains("unmanaged.xml")),
@@ -102,7 +102,7 @@ trait HelloWorldTests extends utest.TestSuite {
           }
           "ivyDeps" - workspaceTest(HelloWorld) { eval =>
             val Right((result, evalCount)) =
-              eval.apply(HelloWorld.core.scoverage().ivyDeps)
+              eval.apply(HelloWorld.core.scoverage.ivyDeps)
 
             val expected = if (isScala3) Agg.empty
             else Agg(
@@ -116,7 +116,7 @@ trait HelloWorldTests extends utest.TestSuite {
           }
           "scalacPluginIvyDeps" - workspaceTest(HelloWorld) { eval =>
             val Right((result, evalCount)) =
-              eval.apply(HelloWorld.core.scoverage().scalacPluginIvyDeps)
+              eval.apply(HelloWorld.core.scoverage.scalacPluginIvyDeps)
 
             val expected = (isScov3, isScala3) match {
               case (true, true) => Agg.empty
@@ -138,7 +138,7 @@ trait HelloWorldTests extends utest.TestSuite {
             )
           }
           "data" - workspaceTest(HelloWorld) { eval =>
-            val Right((result, evalCount)) = eval.apply(HelloWorld.core.scoverage().data)
+            val Right((result, evalCount)) = eval.apply(HelloWorld.core.scoverage.data)
 
             val resultPath = result.path.toIO.getPath.replace("""\""", "/")
             val expectedEnd =
@@ -151,7 +151,7 @@ trait HelloWorldTests extends utest.TestSuite {
           }
           "htmlReport" - workspaceTest(HelloWorld) { eval =>
             val Right((_, _)) = eval.apply(HelloWorld.core.test.compile)
-            val res = eval.apply(HelloWorld.core.scoverage().htmlReport())
+            val res = eval.apply(HelloWorld.core.scoverage.htmlReport())
             if (
               res.isLeft && testScalaVersion.startsWith("3.2") && testScoverageVersion.startsWith(
                 "2."
@@ -167,7 +167,7 @@ trait HelloWorldTests extends utest.TestSuite {
           }
           "xmlReport" - workspaceTest(HelloWorld) { eval =>
             val Right((_, _)) = eval.apply(HelloWorld.core.test.compile)
-            val res = eval.apply(HelloWorld.core.scoverage().xmlReport())
+            val res = eval.apply(HelloWorld.core.scoverage.xmlReport())
             if (
               res.isLeft && testScalaVersion.startsWith("3.2") && testScoverageVersion.startsWith(
                 "2."
@@ -183,14 +183,14 @@ trait HelloWorldTests extends utest.TestSuite {
           }
           "console" - workspaceTest(HelloWorld) { eval =>
             val Right((_, _)) = eval.apply(HelloWorld.core.test.compile)
-            val Right((_, evalCount)) = eval.apply(HelloWorld.core.scoverage().consoleReport())
+            val Right((_, evalCount)) = eval.apply(HelloWorld.core.scoverage.consoleReport())
             assert(evalCount > 0)
           }
         }
         test("test") - {
           "upstreamAssemblyClasspath" - workspaceTest(HelloWorld) { eval =>
             val Right((result, evalCount)) =
-              eval.apply(HelloWorld.core.scoverage().upstreamAssemblyClasspath)
+              eval.apply(HelloWorld.core.scoverage.upstreamAssemblyClasspath)
 
             val runtimeExistsOnClasspath =
               result.map(_.toString).iterator.exists(_.contains("scalac-scoverage-runtime"))
@@ -208,7 +208,7 @@ trait HelloWorldTests extends utest.TestSuite {
           }
           "compileClasspath" - workspaceTest(HelloWorld) { eval =>
             val Right((result, evalCount)) =
-              eval.apply(HelloWorld.core.scoverage().compileClasspath)
+              eval.apply(HelloWorld.core.scoverage.compileClasspath)
 
             val runtimeExistsOnClasspath =
               result.map(_.toString).iterator.exists(_.contains("scalac-scoverage-runtime"))
@@ -225,7 +225,7 @@ trait HelloWorldTests extends utest.TestSuite {
             }
           }
           "runClasspath" - workspaceTest(HelloWorld) { eval =>
-            val Right((result, evalCount)) = eval.apply(HelloWorld.core.scoverage().runClasspath)
+            val Right((result, evalCount)) = eval.apply(HelloWorld.core.scoverage.runClasspath)
 
             val runtimeExistsOnClasspath =
               result.map(_.toString).iterator.exists(_.contains("scalac-scoverage-runtime"))
@@ -249,18 +249,18 @@ trait HelloWorldTests extends utest.TestSuite {
       "scoverage" - {
         "htmlReport" - workspaceTest(HelloWorldSbt, sbtResourcePath) { eval =>
           val Right((_, _)) = eval.apply(HelloWorldSbt.core.test.compile)
-          val Right((result, evalCount)) = eval.apply(HelloWorldSbt.core.scoverage().htmlReport())
+          val Right((result, evalCount)) = eval.apply(HelloWorldSbt.core.scoverage.htmlReport())
           assert(evalCount > 0)
         }
         "xmlReport" - workspaceTest(HelloWorldSbt, sbtResourcePath) { eval =>
           val Right((_, _)) = eval.apply(HelloWorldSbt.core.test.compile)
-          val Right((result, evalCount)) = eval.apply(HelloWorldSbt.core.scoverage().xmlReport())
+          val Right((result, evalCount)) = eval.apply(HelloWorldSbt.core.scoverage.xmlReport())
           assert(evalCount > 0)
         }
         "console" - workspaceTest(HelloWorldSbt, sbtResourcePath) { eval =>
           val Right((_, _)) = eval.apply(HelloWorldSbt.core.test.compile)
           val Right((result, evalCount)) =
-            eval.apply(HelloWorldSbt.core.scoverage().consoleReport())
+            eval.apply(HelloWorldSbt.core.scoverage.consoleReport())
           assert(evalCount > 0)
         }
       }
@@ -281,7 +281,7 @@ trait FailedWorldTests extends HelloWorldTests {
           assert(msg == errorMsg)
         }
         "other" - workspaceTest(mod) { eval =>
-          val Left(Result.Failure(msg, _)) = eval.apply(mod.core.scoverage().xmlReport())
+          val Left(Result.Failure(msg, _)) = eval.apply(mod.core.scoverage.xmlReport())
           assert(msg == errorMsg)
         }
       }
@@ -297,7 +297,7 @@ trait FailedWorldTests extends HelloWorldTests {
           assert(msg == errorMsg)
         }
         "other" - workspaceTest(mod) { eval =>
-          val Left(Result.Failure(msg, _)) = eval.apply(mod.core.scoverage().xmlReport())
+          val Left(Result.Failure(msg, _)) = eval.apply(mod.core.scoverage.xmlReport())
           assert(msg == errorMsg)
         }
       }

--- a/contrib/scoverage/test/src/mill/contrib/scoverage/HelloWorldTests.scala
+++ b/contrib/scoverage/test/src/mill/contrib/scoverage/HelloWorldTests.scala
@@ -142,7 +142,7 @@ trait HelloWorldTests extends utest.TestSuite {
 
             val resultPath = result.path.toIO.getPath.replace("""\""", "/")
             val expectedEnd =
-              "/target/workspace/mill/contrib/scoverage/HelloWorldTests/eval/HelloWorld/core/scoverage/data/core/scoverageData/data.dest"
+              "/target/workspace/mill/contrib/scoverage/HelloWorldTests/eval/HelloWorld/core/scoverage/data/core/scoverage/data.dest"
 
             assert(
               resultPath.endsWith(expectedEnd),

--- a/integration/feature/scoverage/repo/build.sc
+++ b/integration/feature/scoverage/repo/build.sc
@@ -26,7 +26,7 @@ object extra extends ScalaModule with ScoverageModule {
   override def scoverageVersion = "2.0.10"
   override def scalaVersion = "2.13.11"
   // customized scoverage data
-  override val scoverage: ScoverageData = new ScoverageData {
+  override lazy val scoverage: ScoverageData = new ScoverageData {
     // some customizations
   }
 }

--- a/integration/feature/scoverage/repo/build.sc
+++ b/integration/feature/scoverage/repo/build.sc
@@ -1,9 +1,7 @@
 // Reproduction of issue https://github.com/com-lihaoyi/mill/issues/2579
-// and issue https://github.com/com-lihaoyi/mill/issues/2582
 
 // mill plugins
 import $ivy.`com.lihaoyi::mill-contrib-scoverage:`
-import $ivy.`com.github.lolgab::mill-mima::0.0.23`
 
 // imports
 import mill._
@@ -24,3 +22,11 @@ trait CoreCross extends CrossScalaModule with ScoverageModule {
   }
 }
 
+object extra extends ScalaModule with ScoverageModule {
+  override def scoverageVersion = "2.0.10"
+  override def scalaVersion = "2.13.11"
+  // customized scoverage data
+  override val scoverage: ScoverageData = new ScoverageData {
+    // some customizations
+  }
+}

--- a/integration/feature/scoverage/test/src/ScoverageTests.scala
+++ b/integration/feature/scoverage/test/src/ScoverageTests.scala
@@ -7,6 +7,7 @@ object ScoverageTests extends IntegrationTestSuite {
     initWorkspace()
     test("test") - {
       assert(eval("__.compile"))
+      assert(eval("core[2.13.11].scoverage.xmlReport"))
     }
   }
 }


### PR DESCRIPTION
This is a follow-up on #2583.

Using a ModuleRef make accesss to the inner module for the CLI impossible.
I added that case to the integration test and changed to use a `val`.
