### PR TITLE
Properly distinct-ify commands when resolved multiple times by query

### DIFF
--- a/main/resolve/src/mill/resolve/Resolve.scala
+++ b/main/resolve/src/mill/resolve/Resolve.scala
@@ -28,7 +28,7 @@ object Resolve {
       Right(resolved.map(_.segments))
     }
 
-    private[mill] def deduplicate(items: List[Segments]) = items.distinct
+    private[mill] override def deduplicate(items: List[Segments]) = items.distinct
   }
 
   object Tasks extends Resolve[NamedTask[Any]] {
@@ -83,7 +83,7 @@ object Resolve {
       )
     }
 
-    private[mill] def deduplicate(items: List[NamedTask[Any]]) = items.distinctBy(_.ctx.segments)
+    private[mill] override def deduplicate(items: List[NamedTask[Any]]) = items.distinctBy(_.ctx.segments)
   }
 
   private def instantiateTarget(r: Resolved.Target, p: Module) = {
@@ -240,7 +240,7 @@ trait Resolve[T] {
       .flatMap(handleResolved(rootModule, _, args, sel, nullCommandDefaults))
   }
 
-  private[mill] def deduplicate(items: List[T]): List[T]
+  private[mill] def deduplicate(items: List[T]): List[T] = items
 
   private[mill] def resolveRootModule(rootModule: BaseModule, scopedSel: Option[Segments]) = {
     scopedSel match {

--- a/main/resolve/src/mill/resolve/Resolve.scala
+++ b/main/resolve/src/mill/resolve/Resolve.scala
@@ -83,7 +83,8 @@ object Resolve {
       )
     }
 
-    private[mill] override def deduplicate(items: List[NamedTask[Any]]) = items.distinctBy(_.ctx.segments)
+    private[mill] override def deduplicate(items: List[NamedTask[Any]]) =
+      items.distinctBy(_.ctx.segments)
   }
 
   private def instantiateTarget(r: Resolved.Target, p: Module) = {

--- a/main/resolve/src/mill/resolve/Resolve.scala
+++ b/main/resolve/src/mill/resolve/Resolve.scala
@@ -76,7 +76,7 @@ object Resolve {
       val sequenced = EitherOps.sequence(taskList).map(_.flatten)
 
       sequenced.flatMap(flattened =>
-        if (flattened.nonEmpty) Right(flattened)
+        if (flattened.nonEmpty) Right(flattened.distinctBy(_.ctx.segments))
         else Left(s"Cannot find default task to evaluate for module ${selector.render}")
       )
     }

--- a/main/resolve/test/src/mill/main/ResolveTests.scala
+++ b/main/resolve/test/src/mill/main/ResolveTests.scala
@@ -545,6 +545,67 @@ object ResolveTests extends TestSuite {
       }
     }
 
+    "duplicate" - {
+      val check = new Checker(duplicates)
+
+      def segments(
+          found: Either[String, List[NamedTask[_]]],
+          expected: Either[String, List[NamedTask[_]]]
+      ) = {
+        found.map(_.map(_.ctx.segments)) == expected.map(_.map(_.ctx.segments))
+      }
+
+      "wildcard" - {
+        "wrapped" - {
+          "targets" - check.checkSeq0(
+            Seq("__.test1"),
+            _ == Right(List(duplicates.wrapper.test1.test1)),
+            _ == Right(List("wrapper.test1", "wrapper.test1.test1"))
+          )
+          "commands" - check.checkSeq0(
+            Seq("__.test2"),
+            segments(_, Right(List(duplicates.wrapper.test2.test2()))),
+            _ == Right(List("wrapper.test2", "wrapper.test2.test2"))
+          )
+        }
+        "targets" - check.checkSeq0(
+          Seq("__.test3"),
+          _ == Right(List(duplicates.test3.test3)),
+          _ == Right(List("test3", "test3.test3"))
+        )
+        "commands" - check.checkSeq0(
+          Seq("__.test4"),
+          segments(_, Right(List(duplicates.test4.test4()))),
+          _ == Right(List("test4", "test4.test4"))
+        )
+      }
+
+      "braces" - {
+        "targets" - check.checkSeq0(
+          Seq("{test3.test3,test3.test3}"),
+          _ == Right(List(duplicates.test3.test3)),
+          _ == Right(List("test3.test3"))
+        )
+        "commands" - check.checkSeq0(
+          Seq("{test4,test4}"),
+          segments(_, Right(List(duplicates.test4.test4()))),
+          _ == Right(List("test4"))
+        )
+      }
+      "plus" - {
+        "targets" - check.checkSeq0(
+          Seq("test3.test3", "+", "test3.test3"),
+          _ == Right(List(duplicates.test3.test3)),
+          _ == Right(List("test3.test3"))
+        )
+        "commands" - check.checkSeq0(
+          Seq("test4", "+", "test4"),
+          segments(_, Right(List(duplicates.test4.test4()))),
+          _ == Right(List("test4"))
+        )
+      }
+    }
+
     "moduleInitError" - {
       "simple" - {
         val check = new Checker(moduleInitError)

--- a/main/src/mill/main/RunScript.scala
+++ b/main/src/mill/main/RunScript.scala
@@ -24,7 +24,7 @@ object RunScript {
       Resolve.Tasks.resolve(evaluator.rootModule, scriptArgs, selectMode)
     }
     for (targets <- resolved)
-      yield evaluateNamed(evaluator, Agg.from(targets.distinctBy(_.ctx.segments)))
+      yield evaluateNamed(evaluator, Agg.from(targets))
   }
 
   /**

--- a/main/src/mill/main/RunScript.scala
+++ b/main/src/mill/main/RunScript.scala
@@ -23,8 +23,7 @@ object RunScript {
     val resolved = mill.eval.Evaluator.currentEvaluator.withValue(evaluator) {
       Resolve.Tasks.resolve(evaluator.rootModule, scriptArgs, selectMode)
     }
-    for (targets <- resolved)
-      yield evaluateNamed(evaluator, Agg.from(targets))
+    for (targets <- resolved) yield evaluateNamed(evaluator, Agg.from(targets))
   }
 
   /**

--- a/main/src/mill/main/RunScript.scala
+++ b/main/src/mill/main/RunScript.scala
@@ -24,7 +24,7 @@ object RunScript {
       Resolve.Tasks.resolve(evaluator.rootModule, scriptArgs, selectMode)
     }
     for (targets <- resolved)
-      yield evaluateNamed(evaluator, Agg.from(targets.distinct))
+      yield evaluateNamed(evaluator, Agg.from(targets.distinctBy(_.ctx.segments)))
   }
 
   /**

--- a/main/test/src/mill/util/TestGraphs.scala
+++ b/main/test/src/mill/util/TestGraphs.scala
@@ -349,6 +349,30 @@ object TestGraphs {
     override lazy val millDiscover: Discover[this.type] = Discover[this.type]
   }
 
+  object duplicates extends TestUtil.BaseModule {
+    object wrapper extends Module {
+      object test1 extends Module {
+        def test1 = T {}
+      }
+
+      object test2 extends TaskModule {
+        override def defaultCommandName() = "test2"
+        def test2() = T.command {}
+      }
+    }
+
+    object test3 extends Module {
+      def test3 = T {}
+    }
+
+    object test4 extends TaskModule {
+      override def defaultCommandName() = "test4"
+
+      def test4() = T.command {}
+    }
+    override lazy val millDiscover: Discover[this.type] = Discover[this.type]
+  }
+
   object singleCross extends TestUtil.BaseModule {
     object cross extends mill.Cross[Cross]("210", "211", "212")
     trait Cross extends Cross.Module[String] {


### PR DESCRIPTION
Should fix https://github.com/com-lihaoyi/mill/issues/2602. The previous `.distinct` doesn't work because `T.command`s take arguments, and their `Command` instances cannot be cached the same way that `T{}` and other tasks can be. Also, the fact that it was in `RunScript` meant that code resolving tasks without running them didn't benefit, e.g. when you run `inspect __.test`, so I moved it into `Resolve` with separate implementations for `Resolve.Task` and `Resolve.Segments`

Tested manually, both `./mill -i dev.run example/basic/1-simple-scala -i inspect __.test` and `./mill -i dev.run example/basic/1-simple-scala -i __.test` no longer contain duplicates. Also covered by new unit tests to ensure that various kinds of potential duplication (via wildcards, brace-expansion, `+`) all are properly deduplicated