### PR TITLE
Fix source links in API documentation

### DIFF
--- a/scalalib/src/mill/scalalib/UnidocModule.scala
+++ b/scalalib/src/mill/scalalib/UnidocModule.scala
@@ -36,7 +36,8 @@ trait UnidocModule extends ScalaModule {
         if (local) Seq(
           "-doc-source-url",
           "file://€{FILE_PATH}.scala"
-        ) else Seq(
+        )
+        else Seq(
           "-doc-source-url",
           url + "€{FILE_PATH}.scala",
           "-sourcepath",

--- a/scalalib/src/mill/scalalib/UnidocModule.scala
+++ b/scalalib/src/mill/scalalib/UnidocModule.scala
@@ -33,10 +33,12 @@ trait UnidocModule extends ScalaModule {
     ) ++
       unidocVersion().toSeq.flatMap(Seq("-doc-version", _)) ++
       unidocSourceUrl().toSeq.flatMap { url =>
-        val prefix = if (local) "file://" else url
-        Seq(
+        if (local) Seq(
           "-doc-source-url",
-          prefix + "€{FILE_PATH}.scala",
+          "file://€{FILE_PATH}.scala"
+        ) else Seq(
+          "-doc-source-url",
+          url + "€{FILE_PATH}.scala",
           "-sourcepath",
           T.workspace.toString
         )


### PR DESCRIPTION
The API documentation has links to local files (e.g. [mill.define.Args](https://mill-build.com/api/latest/mill/define/Args.html) points to `file:///home/runner/work/mill/mill/main/define/src/mill/define/Args.scala`). This PR is for fixing that.

There's already code to replace every occurrence of `file://path/to/project/root` with the right URL, but it's for `.scala` files so I didn't touch it. I figured `-sourcepath` was a safer way to do the same thing.