### PR TITLE
Restore correct default for `esFeatures`

### DIFF
--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -231,7 +231,10 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
   def moduleKind: Target[ModuleKind] = T { ModuleKind.NoModule }
 
   def esFeatures: T[ESFeatures] = T {
-    ESFeatures.Defaults.withESVersion(ESVersion.ES5_1)
+    if (scalaJSVersion().startsWith("0."))
+      ESFeatures.Defaults.withESVersion(ESVersion.ES5_1)
+    else
+      ESFeatures.Defaults
   }
 
   def moduleSplitStyle: Target[ModuleSplitStyle] = T { ModuleSplitStyle.FewestModules }


### PR DESCRIPTION
The default was changed by mistake in
https://github.com/com-lihaoyi/mill/commit/7f990b3ca7b71e3bd07eb18b562f64f964b1a8e1