### PR TITLE
Cleanup leftover --repl flag handling, fail when --repl is given

### DIFF
--- a/docs/modules/ROOT/pages/Installation_IDE_Support.adoc
+++ b/docs/modules/ROOT/pages/Installation_IDE_Support.adoc
@@ -123,7 +123,7 @@ https://gitforwindows.org[Git-Bash],
 https://docs.microsoft.com/en-us/windows/wsl[WSL]); to get started, follow the instructions in the <<_manual>>
 section. Note that:
 
-* In some environments (such as WSL), Mill might have to be run without a server (using `-i`, `--interactive`, `--no-server`, or `--repl`.)
+* In some environments (such as WSL), Mill might have to be run without a server (using `-i`, `--interactive`, or `--no-server`.)
 
 * On Cygwin, run the following after downloading mill:
 

--- a/docs/modules/ROOT/pages/Intro_to_Mill.adoc
+++ b/docs/modules/ROOT/pages/Intro_to_Mill.adoc
@@ -122,36 +122,40 @@ Run `mill --help` for a complete list of options
 .Output of `mill --help`
 ----
 Mill Build Tool, version {mill-version}
+
 usage: mill [options] [[target [target-options]] [+ [target ...]]]
-  -D --define <k=v>    Define (or overwrite) a system property.
-  -b --bell            Ring the bell once if the run completes successfully, twice if it fails.
-  --bsp                Enable BSP server mode.
-  --color <bool>       Enable or disable colored output; by default colors are enabled in both REPL
-                       and scripts mode if the console is interactive, and disabled otherwise.
-  -d --debug           Show debug output on STDOUT
-  --disable-ticker     Disable ticker log (e.g. short-lived prints of stages and progress bars).
-  -h --home <path>     (internal) The home directory of internally used Ammonite script engine;
-                       where it looks for config and caches.
-  --help               Print this help message and exit.
-  -i --interactive     Run Mill in interactive mode, suitable for opening REPLs and taking user
-                       input. This implies --no-server and no mill server will be used. Must be the
-                       first argument.
-  --import <str>       Additional ivy dependencies to load into mill, e.g. plugins.
-  -j --jobs <int>      Allow processing N targets in parallel. Use 1 to disable parallel and 0 to
-                       use as much threads as available processors.
-  -k --keep-going      Continue build, even after build failures.
-  --no-default-predef  Disable the default predef and run Mill with the minimal predef possible.
-  --no-server          Run Mill in single-process mode. In this mode, no mill server will be started
-                       or used. Must be the first argument.
-  -p --predef <path>   Lets you load your predef from a custom location, rather than the "default
-                       location in your Ammonite home
-  -s --silent          Make ivy logs during script import resolution go silent instead of printing;
-                       though failures will still throw exception.
-  -v --version         Show mill version information and exit.
-  -w --watch           Watch and re-run your scripts when they change.
-  target <str>...      The name or a pattern of the target(s) you want to build, followed by any
-                       parameters you wish to pass to those targets. To specify multiple target
-                       names or patterns, use the `+` separator.
+  -D --define <k=v>       Define (or overwrite) a system property.
+  -b --bell               Ring the bell once if the run completes successfully, twice if it fails.
+  --bsp                   Enable BSP server mode.
+  --color <bool>          Enable or disable colored output; by default colors are enabled in both
+                          REPL and scripts mode if the console is interactive, and disabled
+                          otherwise.
+  -d --debug              Show debug output on STDOUT
+  --disable-ticker        Disable ticker log (e.g. short-lived prints of stages and progress bars).
+  --enable-ticker <bool>  Enable ticker log (e.g. short-lived prints of stages and progress bars).
+  -h --home <path>        (internal) The home directory of internally used Ammonite script engine;
+                          where it looks for config and caches.
+  --help                  Print this help message and exit.
+  -i --interactive        Run Mill in interactive mode, suitable for opening REPLs and taking user
+                          input. This implies --no-server and no mill server will be used. Must be
+                          the first argument.
+  --import <str>          Additional ivy dependencies to load into mill, e.g. plugins.
+  -j --jobs <int>         Allow processing N targets in parallel. Use 1 to disable parallel and 0 to
+                          use as much threads as available processors.
+  -k --keep-going         Continue build, even after build failures.
+  --no-default-predef     Disable the default predef and run Mill with the minimal predef possible.
+  --no-server             Run Mill in single-process mode. In this mode, no Mill server will be
+                          started or used. Must be the first argument.
+  -p --predef <path>      Lets you load your predef from a custom location, rather than the "default
+                          location in your Ammonite home
+  --repl                  This flag is no longer supported.
+  -s --silent             Make ivy logs during script import resolution go silent instead of
+                          printing; though failures will still throw exception.
+  -v --version            Show mill version information and exit.
+  -w --watch              Watch and re-run your scripts when they change.
+  target <str>...         The name or a pattern of the target(s) you want to build, followed by any
+                          parameters you wish to pass to those targets. To specify multiple target
+                          names or patterns, use the `+` separator.
 ----
 
 All _options_ must be given before the first target.

--- a/docs/modules/ROOT/pages/Intro_to_Mill.adoc
+++ b/docs/modules/ROOT/pages/Intro_to_Mill.adoc
@@ -122,7 +122,6 @@ Run `mill --help` for a complete list of options
 .Output of `mill --help`
 ----
 Mill Build Tool, version {mill-version}
-
 usage: mill [options] [[target [target-options]] [+ [target ...]]]
   -D --define <k=v>       Define (or overwrite) a system property.
   -b --bell               Ring the bell once if the run completes successfully, twice if it fails.
@@ -143,11 +142,8 @@ usage: mill [options] [[target [target-options]] [+ [target ...]]]
   -j --jobs <int>         Allow processing N targets in parallel. Use 1 to disable parallel and 0 to
                           use as much threads as available processors.
   -k --keep-going         Continue build, even after build failures.
-  --no-default-predef     Disable the default predef and run Mill with the minimal predef possible.
   --no-server             Run Mill in single-process mode. In this mode, no Mill server will be
                           started or used. Must be the first argument.
-  -p --predef <path>      Lets you load your predef from a custom location, rather than the "default
-                          location in your Ammonite home
   --repl                  This flag is no longer supported.
   -s --silent             Make ivy logs during script import resolution go silent instead of
                           printing; though failures will still throw exception.

--- a/runner/src/mill/runner/MillCliConfig.scala
+++ b/runner/src/mill/runner/MillCliConfig.scala
@@ -16,14 +16,9 @@ class MillCliConfig private (
            This implies --no-server and no mill server will be used.
            Must be the first argument."""
     )
+    @deprecated("No longer supported.", "Mill 0.11.0-M8")
     val repl: Flag,
-    @arg(
-      name = "no-server",
-      doc =
-        """Run Mill in single-process mode.
-           In this mode, no mill server will be started or used.
-           Must be the first argument."""
-    )
+    @arg(name = "no-server", doc = """This flag is no longer supported.""")
     val noServer: Flag,
     @arg(doc = """Enable BSP server mode.""")
     val bsp: Flag,
@@ -160,6 +155,7 @@ object MillCliConfig {
    */
   def apply(
       home: os.Path = mill.api.Ctx.defaultHome,
+      @deprecated("No longer supported.", "Mill 0.11.0-M8")
       repl: Flag = Flag(),
       noServer: Flag = Flag(),
       bsp: Flag = Flag(),

--- a/runner/src/mill/runner/MillCliConfig.scala
+++ b/runner/src/mill/runner/MillCliConfig.scala
@@ -45,6 +45,7 @@ class MillCliConfig private (
       doc =
         """Enable ticker log (e.g. short-lived prints of stages and progress bars)."""
     )
+
     val enableTicker: Option[Boolean],
     @arg(name = "debug", short = 'd', doc = "Show debug output on STDOUT")
     val debugLog: Flag,
@@ -95,11 +96,6 @@ class MillCliConfig private (
     )
     val silent: Flag,
     @arg(
-      name = "no-default-predef",
-      doc = """Disable the default predef and run Mill with the minimal predef possible."""
-    )
-    val noDefaultPredef: Flag,
-    @arg(
       name = "target",
       doc =
         """The name or a pattern of the target(s) you want to build,
@@ -113,15 +109,7 @@ class MillCliConfig private (
           in both REPL and scripts mode if the console is interactive, and disabled
           otherwise."""
     )
-    val color: Option[Boolean],
-    @arg(
-      name = "predef",
-      short = 'p',
-      doc =
-        """Lets you load your predef from a custom location, rather than the
-        "default location in your Ammonite home."""
-    )
-    val predefFile: Option[os.Path]
+    val color: Option[Boolean]
 ) {
   override def toString: String = Seq(
     "home" -> home,
@@ -141,10 +129,8 @@ class MillCliConfig private (
     "help" -> help,
     "watch" -> watch,
     "silent" -> silent,
-    "noDefaultPredef" -> noDefaultPredef,
     "leftoverArgs" -> leftoverArgs,
-    "color" -> color,
-    "predefFile" -> predefFile
+    "color" -> color
   ).map(p => s"${p._1}=${p._2}").mkString(getClass().getSimpleName + "(", ",", ")")
 }
 
@@ -176,10 +162,8 @@ object MillCliConfig {
       help: Flag = Flag(),
       watch: Flag = Flag(),
       silent: Flag = Flag(),
-      noDefaultPredef: Flag = Flag(),
       leftoverArgs: Leftover[String] = Leftover(),
-      color: Option[Boolean] = None,
-      predefFile: Option[os.Path] = None
+      color: Option[Boolean] = None
   ): MillCliConfig = new MillCliConfig(
     home = home,
     repl = repl,
@@ -198,10 +182,54 @@ object MillCliConfig {
     help = help,
     watch = watch,
     silent = silent,
-    noDefaultPredef = noDefaultPredef,
     leftoverArgs = leftoverArgs,
-    color = color,
-    predefFile = predefFile
+    color = color
+  )
+
+  @deprecated("Bin-compat shim", "Mill after 0.11.0")
+  private[runner] def apply(
+      home: os.Path,
+      @deprecated("No longer supported.", "Mill 0.11.0-M8")
+      repl: Flag,
+      noServer: Flag,
+      bsp: Flag,
+      showVersion: Flag,
+      ringBell: Flag,
+      disableTicker: Flag,
+      enableTicker: Option[Boolean],
+      debugLog: Flag,
+      keepGoing: Flag,
+      extraSystemProperties: Map[String, String],
+      threadCountRaw: Option[Int],
+      imports: Seq[String],
+      interactive: Flag,
+      help: Flag,
+      watch: Flag,
+      silent: Flag,
+      noDefaultPredef: Flag,
+      leftoverArgs: Leftover[String],
+      color: Option[Boolean],
+      predefFile: Option[os.Path]
+  ): MillCliConfig = apply(
+    home,
+    repl,
+    noServer,
+    bsp,
+    showVersion,
+    ringBell,
+    disableTicker,
+    enableTicker,
+    debugLog,
+    keepGoing,
+    extraSystemProperties,
+    threadCountRaw,
+    imports,
+    interactive,
+    help,
+    watch,
+    silent,
+    leftoverArgs,
+    color
   )
 }
 

--- a/runner/src/mill/runner/MillCliConfig.scala
+++ b/runner/src/mill/runner/MillCliConfig.scala
@@ -10,17 +10,19 @@ class MillCliConfig private (
            where it looks for config and caches."""
     )
     val home: os.Path,
-    @arg(
-      doc =
-        """Run Mill in interactive mode and start a build REPL.
-           This implies --no-server and no mill server will be used.
-           Must be the first argument."""
-    )
     // We need to keep it, otherwise, a given --repl would be silently parsed as target and result in misleading error messages.
     // Instead we fail when this flag is set.
     @deprecated("No longer supported.", "Mill 0.11.0-M8")
+    @arg(
+      doc = """This flag is no longer supported."""
+    )
     val repl: Flag,
-    @arg(name = "no-server", doc = """This flag is no longer supported.""")
+    @arg(
+      name = "no-server",
+      doc = """Run Mill in single-process mode.
+               In this mode, no Mill server will be started or used.
+               Must be the first argument."""
+    )
     val noServer: Flag,
     @arg(doc = """Enable BSP server mode.""")
     val bsp: Flag,
@@ -117,7 +119,7 @@ class MillCliConfig private (
       short = 'p',
       doc =
         """Lets you load your predef from a custom location, rather than the
-        "default location in your Ammonite home"""
+        "default location in your Ammonite home."""
     )
     val predefFile: Option[os.Path]
 ) {

--- a/runner/src/mill/runner/MillCliConfig.scala
+++ b/runner/src/mill/runner/MillCliConfig.scala
@@ -16,6 +16,8 @@ class MillCliConfig private (
            This implies --no-server and no mill server will be used.
            Must be the first argument."""
     )
+    // We need to keep it, otherwise, a given --repl would be silently parsed as target and result in misleading error messages.
+    // Instead we fail when this flag is set.
     @deprecated("No longer supported.", "Mill 0.11.0-M8")
     val repl: Flag,
     @arg(name = "no-server", doc = """This flag is no longer supported.""")

--- a/runner/src/mill/runner/MillMain.scala
+++ b/runner/src/mill/runner/MillMain.scala
@@ -107,23 +107,22 @@ object MillMain {
 
         case Right(config)
             if (
-              config.interactive.value || config.repl.value || config.noServer.value || config.bsp.value
+              config.interactive.value || config.noServer.value || config.bsp.value
             ) && streams.in == DummyInputStream =>
           // because we have stdin as dummy, we assume we were already started in server process
           streams.err.println(
-            "-i/--interactive/--repl/--no-server/--bsp must be passed in as the first argument"
+            "-i/--interactive/--no-server/--bsp must be passed in as the first argument"
           )
           (false, RunnerState.empty)
 
         case Right(config)
             if Seq(
               config.interactive.value,
-              config.repl.value,
               config.noServer.value,
               config.bsp.value
             ).count(identity) > 1 =>
           streams.err.println(
-            "Only one of -i/--interactive, --repl, --no-server or --bsp may be given"
+            "Only one of -i/--interactive, --no-server or --bsp may be given"
           )
           (false, RunnerState.empty)
 
@@ -139,35 +138,19 @@ object MillMain {
             checkMillVersionFromFile(os.pwd, streams.err)
           }
 
-          val useRepl =
-            config.repl.value || (config.interactive.value && config.leftoverArgs.value.isEmpty)
-
           // special BSP mode, in which we spawn a server and register the current evaluator when-ever we start to eval a dedicated command
           val bspMode = config.bsp.value && config.leftoverArgs.value.isEmpty
 
-          val (success, nextStateCache) =
-            if (config.repl.value && config.leftoverArgs.value.nonEmpty) {
-              logger.error("No target may be provided with the --repl flag")
+          val (success, nextStateCache) = {
+            if (config.repl.value) {
+              logger.error("The --repl mode is no longer supported.")
               (false, stateCache)
-              //          } else if(config.bsp.value && config.leftoverArgs.value.nonEmpty) {
-              //            stderr.println("No target may be provided with the --bsp flag")
-              //            (false, stateCache)
-            } else if (config.leftoverArgs.value.isEmpty && config.noServer.value) {
-              logger.error(
-                "A target must be provided when not starting a build REPL"
-              )
+
+            } else if (config.leftoverArgs.value.isEmpty) {
+              logger.error("A target must be provided.")
               (false, stateCache)
-            } else if (useRepl && streams.in == DummyInputStream) {
-              logger.error(
-                "Build REPL needs to be run with the -i/--interactive/--repl flag"
-              )
-              (false, stateCache)
+
             } else {
-              if (useRepl && config.interactive.value) {
-                logger.error(
-                  "WARNING: Starting a build REPL without --repl is deprecated"
-                )
-              }
               val userSpecifiedProperties =
                 userSpecifiedProperties0 ++ config.extraSystemProperties
 
@@ -242,6 +225,7 @@ object MillMain {
               loopRes
 
             }
+          }
           if (config.ringBell.value) {
             if (success) println("\u0007")
             else {


### PR DESCRIPTION
In Mill `0.11.0-M8` we change Mill internals to no longer use Ammonite. Since then, we no longer support the `--repl` mode, but forgot to cleanup the CLI configuration.