### PR TITLE
Remove scalameta trees dependency

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -132,8 +132,6 @@ object Deps {
   val scalaCheck = ivy"org.scalacheck::scalacheck:1.17.0"
   def scalaCompiler(scalaVersion: String) = ivy"org.scala-lang:scala-compiler:${scalaVersion}"
   val scalafmtDynamic = ivy"org.scalameta::scalafmt-dynamic:3.7.4"
-  val scalametaVersion = "4.7.8"
-  val scalametaTrees = ivy"org.scalameta::trees:${scalametaVersion}"
   def scalaReflect(scalaVersion: String) = ivy"org.scala-lang:scala-reflect:${scalaVersion}"
   val scalacScoveragePlugin = ivy"org.scoverage:::scalac-scoverage-plugin:1.4.11"
   val scoverage2Version = "2.0.10"
@@ -143,7 +141,7 @@ object Deps {
   val scalacScoverage2Serializer =
     ivy"org.scoverage::scalac-scoverage-serializer:${scoverage2Version}"
   // keep in sync with doc/antora/antory.yml
-  val semanticDB = ivy"org.scalameta:::semanticdb-scalac:${scalametaVersion}"
+  val semanticDB = ivy"org.scalameta:::semanticdb-scalac:4.7.8"
   val semanticDbJava = ivy"com.sourcegraph:semanticdb-java:0.8.18"
   val sourcecode = ivy"com.lihaoyi::sourcecode:0.3.0"
   val upickle = ivy"com.lihaoyi::upickle:3.1.0"
@@ -473,7 +471,6 @@ object main extends MillStableScalaModule with BuildInfo {
     def compileIvyDeps = Agg(Deps.scalaReflect(scalaVersion()))
     def ivyDeps = Agg(
       Deps.millModuledefs,
-      Deps.scalametaTrees,
       // Necessary so we can share the JNA classes throughout the build process
       Deps.jna,
       Deps.jnaPlatform,


### PR DESCRIPTION
This dependency is unused and created a conflict since it transitively depends on geny `0.6.5` while we depend on geny `1.0.0` (problem reported on Discord by @kubukoz)