### PR TITLE
Convert entrypoint.runIvyDeps to ivyDeps

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -514,7 +514,7 @@ object testrunner extends MillPublishScalaModule {
   def moduleDeps = Seq(scalalib.api, main.util, entrypoint)
 
   object entrypoint extends MillPublishJavaModule {
-    override def runIvyDeps = Agg(Deps.sbtTestInterface)
+    override def ivyDeps = Agg(Deps.sbtTestInterface)
   }
 }
 


### PR DESCRIPTION
As runtime dependencies are not transitive in Mill, we need to declare the sbt test-interface as normal dependency.

* Fix: #2595