### PR TITLE
Update external plugin reference that supports 0.11

### DIFF
--- a/docs/modules/ROOT/pages/Thirdparty_Plugins.adoc
+++ b/docs/modules/ROOT/pages/Thirdparty_Plugins.adoc
@@ -831,7 +831,7 @@ You can also manually trigger this with Mill by doing the following:
 [source, shell script]
 ----
 
-mill --import ivy:io.chris-kipp::mill-scip::0.2.2 io.kipp.mill.scip.Scip/generate
+mill --import ivy:io.chris-kipp::mill-scip::0.3.4 io.kipp.mill.scip.Scip/generate
 ----
 
 This will then generate your `index.scip` inside of


### PR DESCRIPTION
The older version does not resolve using the mill 0.11 `--import` flag so the example given is just failing.