### PR TITLE
Support default crossSegment selection with `cross[]` notation

### DIFF
--- a/docs/modules/ROOT/pages/Cross_Builds.adoc
+++ b/docs/modules/ROOT/pages/Cross_Builds.adoc
@@ -10,6 +10,10 @@ config and building it across a variety of source folders.
 
 include::example/cross/1-simple.adoc[]
 
+== Default Cross Modules
+
+include::example/cross/11-default-cross-module.adoc[]
+
 == Cross Modules Source Paths
 
 include::example/cross/2-cross-source-path.adoc[]

--- a/example/cross/1-simple/build.sc
+++ b/example/cross/1-simple/build.sc
@@ -19,7 +19,7 @@ trait FooModule extends Cross.Module[String] {
 // `"2.12"`, each of which has their own `suffix` target. You can then run
 // them as shown below. Note that by default, `sources` returns `foo` for every
 // cross module, assuming you want to build the same sources for each. This can
-// be overriden
+// be overridden.
 
 /** Usage
 

--- a/example/cross/11-default-cross-module/build.sc
+++ b/example/cross/11-default-cross-module/build.sc
@@ -1,0 +1,30 @@
+import mill._
+
+object foo extends Cross[FooModule]("2.10", "2.11", "2.12")
+
+trait FooModule extends Cross.Module[String] {
+  def suffix = T { "_" + crossValue }
+}
+
+object bar extends Cross[FooModule]("2.10", "2.11", "2.12") {
+  def defaultCrossSegments = Seq("2.12")
+}
+
+
+// For convenience, you can omit the selector for the default cross segment.
+// By default, this is the first cross value specified.
+
+/** Usage
+
+> ./mill show foo[2.10].suffix
+"_2.10"
+
+> ./mill show foo[].suffix
+"_2.10"
+
+> ./mill show bar[].suffix
+"_2.12"
+
+*/
+
+

--- a/main/define/src/mill/define/Cross.scala
+++ b/main/define/src/mill/define/Cross.scala
@@ -340,6 +340,12 @@ class Cross[M <: Cross.Module[_]](factories: Cross.Factory[M]*)(implicit
     .mapValues(_.value)
 
   /**
+   * The default cross segments to use, when no cross value is specified.
+   * Defaults to the first cross value per cross level.
+   */
+  def defaultCrossSegments: Seq[String] = items.head.crossSegments
+
+  /**
    * Fetch the cross module corresponding to the given cross values
    */
   def get(args: Seq[Any]): M = valuesToModules(args.toList)

--- a/main/define/src/mill/define/Cross.scala
+++ b/main/define/src/mill/define/Cross.scala
@@ -128,6 +128,7 @@ object Cross {
   )
 
   object Factory {
+    import scala.language.implicitConversions
 
     /**
      * Implicitly constructs a Factory[M] for a target-typed `M`. Takes in an

--- a/main/resolve/src/mill/resolve/ParseArgs.scala
+++ b/main/resolve/src/mill/resolve/ParseArgs.scala
@@ -41,7 +41,7 @@ object ParseArgs {
           r2.drop(1)
         )
     }
-    val parts: Seq[Seq[String]] = separated(Seq(), scriptArgs)
+    val parts: Seq[Seq[String]] = separated(Seq() /* start value */, scriptArgs)
     val parsed: Seq[Either[String, TargetsWithParams]] =
       parts.map(extractAndValidate(_, selectMode == SelectMode.Multi))
 
@@ -96,7 +96,8 @@ object ParseArgs {
     def ident2 = P(CharsWhileIn("a-zA-Z0-9_\\-.")).!
     def segment = P(mill.define.Reflect.ident).map(Segment.Label)
     def crossSegment = P("[" ~ ident2.rep(1, sep = ",") ~ "]").map(Segment.Cross)
-    def simpleQuery = P(segment ~ ("." ~ segment | crossSegment).rep).map {
+    def defaultCrossSegment = P("[]").map(_ => Segment.Cross(Seq()))
+    def simpleQuery = P(segment ~ ("." ~ segment | crossSegment | defaultCrossSegment).rep).map {
       case (h, rest) => Segments(h +: rest)
     }
 

--- a/main/resolve/src/mill/resolve/ResolveCore.scala
+++ b/main/resolve/src/mill/resolve/ResolveCore.scala
@@ -123,7 +123,13 @@ private object ResolveCore {
                       if segments.length == cross.length
                       if segments.zip(cross).forall { case (l, r) => l == r || r == "_" }
                     } yield v
-                  } else c.segmentsToModules.get(cross.toList).toSeq
+                  } else {
+                    val crossOrDefault = if (cross.isEmpty) {
+                      // We want to select the default (first) crossValue
+                      c.defaultCrossSegments
+                    } else cross
+                    c.segmentsToModules.get(crossOrDefault.toList).toSeq
+                  }
                 )
               } match {
                 case Left(err) => Error(err)

--- a/main/resolve/src/mill/resolve/ResolveCore.scala
+++ b/main/resolve/src/mill/resolve/ResolveCore.scala
@@ -293,7 +293,7 @@ private object ResolveCore {
   def notFoundResult(rootModule: Module, querySoFar: Segments, current: Resolved, next: Segment) = {
     val possibleNexts = current match {
       case m: Resolved.Module =>
-        resolveDirectChildren(rootModule, m.cls, None, current.segments).right.get.map(
+        resolveDirectChildren(rootModule, m.cls, None, current.segments).toOption.get.map(
           _.segments.value.last
         )
 

--- a/main/resolve/test/src/mill/main/ResolveTests.scala
+++ b/main/resolve/test/src/mill/main/ResolveTests.scala
@@ -543,13 +543,13 @@ object ResolveTests extends TestSuite {
           )
           // "212" is the defaultCrossSegments
           "head" - check(
-              "cross[].cross2[jvm].suffix",
-              Right(Set(
-                _.cross("212").cross2("jvm").suffix
-              )),
-              Set(
-                "cross[212].cross2[jvm].suffix"
-              )
+            "cross[].cross2[jvm].suffix",
+            Right(Set(
+              _.cross("212").cross2("jvm").suffix
+            )),
+            Set(
+              "cross[212].cross2[jvm].suffix"
+            )
           )
         }
       }

--- a/main/resolve/test/src/mill/main/ResolveTests.scala
+++ b/main/resolve/test/src/mill/main/ResolveTests.scala
@@ -315,6 +315,19 @@ object ResolveTests extends TestSuite {
           )),
           Set("cross[210].suffix", "cross[211].suffix", "cross[212].suffix")
         )
+        "head" - check(
+          "cross[].suffix",
+          Right(Set(
+            _.cross("210").suffix
+          )),
+          Set("cross[210].suffix")
+        )
+        "headNeg" - check(
+          "cross[].doesntExist",
+          Left(
+            "Cannot resolve cross[].doesntExist. Try `mill resolve cross[]._` to see what's available."
+          )
+        )
       }
       "double" - {
         val check = new Checker(doubleCross)
@@ -441,6 +454,21 @@ object ResolveTests extends TestSuite {
               "cross[212,js].suffix",
               "cross[212,js].suffix",
               "cross[212,native].suffix"
+            )
+          )
+          "head" - check(
+            "cross[].suffix",
+            Right(Set(
+              _.cross("210", "jvm").suffix
+            )),
+            Set(
+              "cross[210,jvm].suffix"
+            )
+          )
+          "headNeg" - check(
+            "cross[].doesntExist",
+            Left(
+              "Cannot resolve cross[].doesntExist. Try `mill resolve cross[]._` to see what's available."
             )
           )
         }

--- a/main/resolve/test/src/mill/main/ResolveTests.scala
+++ b/main/resolve/test/src/mill/main/ResolveTests.scala
@@ -541,6 +541,16 @@ object ResolveTests extends TestSuite {
               "cross[212].cross2[native].suffix"
             )
           )
+          // "212" is the defaultCrossSegments
+          "head" - check(
+              "cross[].cross2[jvm].suffix",
+              Right(Set(
+                _.cross("212").cross2("jvm").suffix
+              )),
+              Set(
+                "cross[212].cross2[jvm].suffix"
+              )
+          )
         }
       }
 

--- a/main/test/src/mill/util/TestGraphs.scala
+++ b/main/test/src/mill/util/TestGraphs.scala
@@ -488,7 +488,9 @@ object TestGraphs {
   }
 
   object nestedCrosses extends TestUtil.BaseModule {
-    object cross extends mill.Cross[Cross]("210", "211", "212")
+    object cross extends mill.Cross[Cross]("210", "211", "212") {
+      override def defaultCrossSegments: Seq[String] = Seq("212")
+    }
     trait Cross extends Cross.Module[String] {
       val scalaVersion = crossValue
       object cross2 extends mill.Cross[Cross]("jvm", "js", "native")


### PR DESCRIPTION
* Implements idea https://github.com/com-lihaoyi/mill/discussions/2588

With this change, one can select the default cross segment by leaving the cross selection empty.

```
$ mill cross[].compile
```

The default selection is the first provided cross value for each cross level.

To override the default cross segment, one can override the `defaultCrossSegments` method.
