### PR TITLE
Define reasonable `platformSuffix` in `MillBuildPlatformModule`

### DIFF
--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -11,6 +11,8 @@ import mill.scalalib.api.Versions
 import os.{Path, rel}
 import pprint.Util.literalize
 import FileImportGraph.backtickWrap
+import mill.main.BuildInfo
+
 import scala.util.Try
 
 /**
@@ -111,6 +113,8 @@ class MillBuildRootModule()(implicit
         .map(mill.scalalib.Dep.parse)
     )
   }
+
+  override def platformSuffix: T[String] = s"_mill${BuildInfo.millBinPlatform}"
 
   override def generatedSources: T[Seq[PathRef]] = T {
     generateScriptSources()

--- a/runner/src/mill/runner/MillIvy.scala
+++ b/runner/src/mill/runner/MillIvy.scala
@@ -2,24 +2,18 @@ package mill.runner
 
 object MillIvy {
   def processMillIvyDepSignature(signatures: Set[String]): Set[String] = {
-    // replace platform notation and empty version
-    val millSigs: Set[String] = for (signature <- signatures) yield {
-
-      if (signature.endsWith(":") && signature.count(_ == ":") == 4) signature + "$MILL_VERSION"
-      //      else
-      signature.split("[:]") match {
-        case Array(org, "", pname, "", version)
-            if org.length > 0 && pname.length > 0 && version.length > 0 =>
-          s"${org}::${pname}_mill$$MILL_BIN_PLATFORM:${version}"
-        case Array(org, "", "", pname, "", version)
-            if org.length > 0 && pname.length > 0 && version.length > 0 =>
-          s"${org}:::${pname}_mill$$MILL_BIN_PLATFORM:${version}"
-        case Array(org, "", name) if org.length > 0 && name.length > 0 && signature.endsWith(":") =>
-          s"${org}::${name}:$$MILL_VERSION"
-        case _ => signature
+    val millSigs: Set[String] =
+      for (signature <- signatures) yield {
+        signature.split("[:]") match {
+          case Array(org, "", name)
+              if org.length > 0 && name.length > 0 && signature.endsWith(":") =>
+            // replace empty version with Mill Version Placeholder
+            signature + "$MILL_VERSION"
+          case _ => signature
+        }
       }
-    }
 
+    // replace special MILL_ placeholders
     val replaced = millSigs.map(_
       .replace("$MILL_VERSION", mill.main.BuildInfo.millVersion)
       .replace("${MILL_VERSION}", mill.main.BuildInfo.millVersion)


### PR DESCRIPTION
It's a typical use case to add plugin dependencies to a meta-build. To make this more convenient, we set the `platformSuffix` to `_mill<binary-platform>`.

* Fix https://github.com/com-lihaoyi/mill/issues/2634