### PR TITLE
Differentiate by  Mill version when selecting a server worker

### DIFF
--- a/main/client/src/mill/main/client/MillClientMain.java
+++ b/main/client/src/mill/main/client/MillClientMain.java
@@ -96,13 +96,13 @@ public class MillClientMain {
             System.setProperty("jna.nosys", "true");
         }
 
-        String jvmHomeEncoding = Util.sha1Hash(System.getProperty("java.home"));
-        int serverProcessesLimit = getServerProcessesLimit(jvmHomeEncoding);
+        String versionAndJvmHomeEncoding = Util.sha1Hash(BuildInfo.millVersion + System.getProperty("java.home"));
+        int serverProcessesLimit = getServerProcessesLimit(versionAndJvmHomeEncoding);
 
         int index = 0;
         while (index < serverProcessesLimit) {
             index += 1;
-            String lockBase = "out/mill-worker-" + jvmHomeEncoding + "-" + index;
+            String lockBase = "out/mill-worker-" + versionAndJvmHomeEncoding + "-" + index;
             new java.io.File(lockBase).mkdirs();
 
             File stdout = new java.io.File(lockBase + "/stdout");

--- a/main/client/src/mill/main/client/MillClientMain.java
+++ b/main/client/src/mill/main/client/MillClientMain.java
@@ -91,34 +91,34 @@ public class MillClientMain {
 
     public static int main0(String[] args) throws Exception {
 
-        boolean setJnaNoSys = System.getProperty("jna.nosys") == null;
+        final boolean setJnaNoSys = System.getProperty("jna.nosys") == null;
         if (setJnaNoSys) {
             System.setProperty("jna.nosys", "true");
         }
 
-        String versionAndJvmHomeEncoding = Util.sha1Hash(BuildInfo.millVersion + System.getProperty("java.home"));
-        int serverProcessesLimit = getServerProcessesLimit(versionAndJvmHomeEncoding);
+        final String versionAndJvmHomeEncoding = Util.sha1Hash(BuildInfo.millVersion + System.getProperty("java.home"));
+        final int serverProcessesLimit = getServerProcessesLimit(versionAndJvmHomeEncoding);
 
         int index = 0;
         while (index < serverProcessesLimit) {
             index += 1;
-            String lockBase = "out/mill-worker-" + versionAndJvmHomeEncoding + "-" + index;
+            final String lockBase = "out/mill-worker-" + versionAndJvmHomeEncoding + "-" + index;
             new java.io.File(lockBase).mkdirs();
 
-            File stdout = new java.io.File(lockBase + "/stdout");
-            File stderr = new java.io.File(lockBase + "/stderr");
-            int refeshIntervalMillis = 2;
+            final File stdout = new java.io.File(lockBase + "/stdout");
+            final File stderr = new java.io.File(lockBase + "/stderr");
+            final int refeshIntervalMillis = 2;
 
             try (
                 Locks locks = Locks.files(lockBase);
-                FileToStreamTailer stdoutTailer = new FileToStreamTailer(stdout, System.out, refeshIntervalMillis);
-                FileToStreamTailer stderrTailer = new FileToStreamTailer(stderr, System.err, refeshIntervalMillis);
+                final FileToStreamTailer stdoutTailer = new FileToStreamTailer(stdout, System.out, refeshIntervalMillis);
+                final FileToStreamTailer stderrTailer = new FileToStreamTailer(stderr, System.err, refeshIntervalMillis);
             ) {
                 Locked clientLock = locks.clientLock.tryLock();
                 if (clientLock != null) {
                     stdoutTailer.start();
                     stderrTailer.start();
-                    int exitCode = run(
+                    final int exitCode = run(
                         lockBase,
                         () -> {
                             try {


### PR DESCRIPTION
In older Mill versions, we tried to detect when the Mill version changed. In that case, we stopped the server process and started a new one. This server stopping worked unrelieble and is currently not working at all.

This pragmatic change simply does not try to re-use a mill server process when the Mill version does not match. Instead, we only choose between instances with the exact version or start a new instance. This is identical to the beavior, when we run with a differnet JVM.

Resource wise, we potentially increase the amount of running processes, but we do this anyways in other situations. Also, idle Mill servers stop themselves after a some time span.
