### PR TITLE
use bspCompileClassesPath in bspTransitiveCompileClasspath

### DIFF
--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -236,7 +236,7 @@ trait JavaModule
       (moduleDeps ++ compileModuleDeps).flatMap(_.transitiveModuleDeps).distinct
     )(m =>
       T.task {
-        m.bspCompileClasspath() ++ Agg(UnresolvedPath.ResolvedPath(m.compile().classes.path))
+        m.bspCompileClasspath() ++ Agg(m.bspCompileClassesPath())
       }
     )()
       .flatten


### PR DESCRIPTION
Hi! This is my first contribution, so please let me know if there is anything for me to do.

As far as I understand this is OK, since `bspCompileClasspath` mentions it tries not to trigger compilation, so the transitive version may also try not to trigger compilation of the module dependencies.

This would be helpful to us, since we currently cannot load projects in intellij via bsp if there is a compilation error in any module other than the topmost module. On the surface this seems similar to the issue in #2484 (failing on `buildTarget/scalacOptions` due to an error within `_.compile`).