### PR TITLE
Refactored root modules finder

### DIFF
--- a/bsp/worker/src/mill/bsp/worker/State.scala
+++ b/bsp/worker/src/mill/bsp/worker/State.scala
@@ -24,7 +24,7 @@ private class State(projectRoot: os.Path, baseLogger: ColorLogger, debug: String
         }
       }
       .toMap
-    debug(s"BspModules: ${map.mapValues(_.bspDisplayName)}")
+    debug(s"BspModules: ${map.view.mapValues(_.bspDisplayName)}")
 
     map
   }

--- a/bsp/worker/src/mill/bsp/worker/State.scala
+++ b/bsp/worker/src/mill/bsp/worker/State.scala
@@ -29,7 +29,8 @@ private class State(projectRoot: os.Path, baseLogger: ColorLogger, debug: String
     map
   }
 
-  lazy val rootModules: Seq[mill.main.RootModule] = RootModuleFinder.findRootModules(projectRoot, baseLogger)
+  lazy val rootModules: Seq[mill.main.RootModule] =
+    RootModuleFinder.findRootModules(projectRoot, baseLogger)
 
   lazy val bspIdByModule: Map[BspModule, BuildTargetIdentifier] = bspModulesById.map(_.swap)
 }

--- a/bsp/worker/src/mill/bsp/worker/State.scala
+++ b/bsp/worker/src/mill/bsp/worker/State.scala
@@ -1,7 +1,7 @@
 package mill.bsp.worker
 
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier
-import mill.runner.MillBuildBootstrap
+import mill.runner.{MillBuildBootstrap, RootModuleFinder}
 import mill.scalalib.bsp.BspModule
 import mill.scalalib.internal.{JavaModuleUtils, ModuleUtils}
 import mill.define.Module
@@ -29,39 +29,7 @@ private class State(projectRoot: os.Path, baseLogger: ColorLogger, debug: String
     map
   }
 
-  lazy val rootModules: Seq[mill.main.RootModule] = {
-    val evaluated = new mill.runner.MillBuildBootstrap(
-      projectRoot = projectRoot,
-      home = os.home,
-      keepGoing = false,
-      imports = Nil,
-      env = Map.empty,
-      threadCount = None,
-      targetsAndParams = Seq("resolve", "_"),
-      prevRunnerState = mill.runner.RunnerState.empty,
-      logger = baseLogger
-    ).evaluate()
+  lazy val rootModules: Seq[mill.main.RootModule] = RootModuleFinder.findRootModules(projectRoot, baseLogger)
 
-    val rootModules0 = evaluated.result.frames
-      .flatMap(_.classLoaderOpt)
-      .zipWithIndex
-      .map { case (c, i) =>
-        MillBuildBootstrap
-          .getRootModule(c, i, projectRoot)
-          .fold(sys.error(_), identity(_))
-      }
-
-    val bootstrapModule = evaluated.result.bootstrapModuleOpt.map(m =>
-      MillBuildBootstrap
-        .getChildRootModule(
-          m,
-          evaluated.result.frames.length,
-          projectRoot
-        )
-        .fold(sys.error(_), identity(_))
-    )
-
-    rootModules0 ++ bootstrapModule
-  }
   lazy val bspIdByModule: Map[BspModule, BuildTargetIdentifier] = bspModulesById.map(_.swap)
 }

--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -2,7 +2,7 @@ package mill.runner
 import mill.util.{ColorLogger, PrefixLogger, Util, Watchable}
 import mill.T
 import mill.main.BuildInfo
-import mill.api.{PathRef, Val, internal}
+import mill.api.{Logger, PathRef, Val, internal}
 import mill.eval.Evaluator
 import mill.main.{RootModule, RunScript}
 import mill.resolve.SelectMode
@@ -35,7 +35,7 @@ class MillBuildBootstrap(
     threadCount: Option[Int],
     targetsAndParams: Seq[String],
     prevRunnerState: RunnerState,
-    logger: ColorLogger
+    logger: Logger
 ) {
   import MillBuildBootstrap._
 

--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -348,7 +348,11 @@ object MillBuildBootstrap {
     getChildRootModule(rootModule0, depth, projectRoot)
   }
 
-  def getChildRootModule(rootModule0: RootModule, depth: Int, projectRoot: os.Path) = {
+  def getChildRootModule(
+      rootModule0: RootModule,
+      depth: Int,
+      projectRoot: os.Path
+  ): Either[String, RootModule] = {
 
     val childRootModules: Seq[RootModule] = rootModule0
       .millInternal
@@ -382,11 +386,11 @@ object MillBuildBootstrap {
     )
   }
 
-  def recRoot(projectRoot: os.Path, depth: Int) = {
+  def recRoot(projectRoot: os.Path, depth: Int): os.Path = {
     projectRoot / Seq.fill(depth)("mill-build")
   }
 
-  def recOut(projectRoot: os.Path, depth: Int) = {
+  def recOut(projectRoot: os.Path, depth: Int): os.Path = {
     projectRoot / "out" / Seq.fill(depth)("mill-build")
   }
 }

--- a/runner/src/mill/runner/RootModuleFinder.scala
+++ b/runner/src/mill/runner/RootModuleFinder.scala
@@ -1,0 +1,41 @@
+package mill.runner
+
+import mill.api.Logger
+
+object RootModuleFinder {
+  def findRootModules(projectRoot: os.Path, logger: Logger): Seq[mill.main.RootModule] = {
+    val evaluated = new mill.runner.MillBuildBootstrap(
+      projectRoot = projectRoot,
+      home = os.home,
+      keepGoing = false,
+      imports = Nil,
+      env = Map.empty,
+      threadCount = None,
+      targetsAndParams = Seq("resolve", "--quiet", "_"),
+      prevRunnerState = mill.runner.RunnerState.empty,
+      logger = logger
+    ).evaluate()
+
+    val rootModules0 = evaluated.result.frames
+      .flatMap(_.classLoaderOpt)
+      .zipWithIndex
+      .map { case (c, i) =>
+        MillBuildBootstrap
+          .getRootModule(c, i, projectRoot)
+          .fold(sys.error(_), identity(_))
+      }
+
+    val bootstrapModule = evaluated.result.bootstrapModuleOpt.map(m =>
+      MillBuildBootstrap
+        .getChildRootModule(
+          m,
+          evaluated.result.frames.length,
+          projectRoot
+        )
+        .fold(sys.error(_), identity(_))
+    )
+
+    rootModules0 ++ bootstrapModule
+  }
+
+}

--- a/runner/src/mill/runner/RunnerState.scala
+++ b/runner/src/mill/runner/RunnerState.scala
@@ -32,7 +32,10 @@ case class RunnerState(
     frames: Seq[RunnerState.Frame],
     errorOpt: Option[String]
 ) {
-  def add(frame: RunnerState.Frame = RunnerState.Frame.empty, errorOpt: Option[String] = None): RunnerState = {
+  def add(
+      frame: RunnerState.Frame = RunnerState.Frame.empty,
+      errorOpt: Option[String] = None
+  ): RunnerState = {
     this.copy(frames = Seq(frame) ++ frames, errorOpt = errorOpt)
   }
 }

--- a/runner/src/mill/runner/RunnerState.scala
+++ b/runner/src/mill/runner/RunnerState.scala
@@ -5,7 +5,6 @@ import mill.define.{BaseModule, Segments}
 import mill.util.Watchable
 import upickle.default.{ReadWriter, macroRW}
 import mill.api.JsonFormatters._
-import mill.eval.Evaluator
 import mill.main.RootModule
 
 /**
@@ -33,7 +32,7 @@ case class RunnerState(
     frames: Seq[RunnerState.Frame],
     errorOpt: Option[String]
 ) {
-  def add(frame: RunnerState.Frame = RunnerState.Frame.empty, errorOpt: Option[String] = None) = {
+  def add(frame: RunnerState.Frame = RunnerState.Frame.empty, errorOpt: Option[String] = None): RunnerState = {
     this.copy(frames = Seq(frame) ++ frames, errorOpt = errorOpt)
   }
 }


### PR DESCRIPTION
Moved root module finder logic into dedicated `RootModuleFinder` object.

Changed `PrefixLogger` to accept a `Logger` instead of a `ColorLogger`.

Also added a `quiet` flag to `MainModule.resolve`. This is useful, if we need the return value, but do not want the command to print the resolved outcome.
