### PR TITLE
deps: update semanticdb to 4.8.1

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -142,7 +142,7 @@ object Deps {
   val scalacScoverage2Serializer =
     ivy"org.scoverage::scalac-scoverage-serializer:${scoverage2Version}"
   // keep in sync with doc/antora/antory.yml
-  val semanticDB = ivy"org.scalameta:::semanticdb-scalac:4.7.8"
+  val semanticDB = ivy"org.scalameta:::semanticdb-scalac:4.8.1"
   val semanticDbJava = ivy"com.sourcegraph:semanticdb-java:0.8.18"
   val sourcecode = ivy"com.lihaoyi::sourcecode:0.3.0"
   val upickle = ivy"com.lihaoyi::upickle:3.1.0"

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -8,6 +8,6 @@ asciidoc:
     mill-version: '0.11.1'
     mill-last-tag: '0.11-1'
     bsp-version: '2.1.0-M5'
-    example-semanticdb-version: '4.7.8'
+    example-semanticdb-version: '4.8.1'
     example-scala-2-13-version: '2.13.11'
     example-utest-version: '0.8.1'


### PR DESCRIPTION
This just bumps the default version of semanticdb from 4.7.8 to 4.8.1. I
realized when using mill-scalafix that I needed to manually do this
since the new Mill version is still using an older semanticdb version
that doesn't support for example 2.13.11.
