### PR TITLE
Update LICENSE to use Github template

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,4 @@
-License
-=======
-
-
-The MIT License (MIT)
+MIT License
 
 Copyright (c) 2017 Li Haoyi (haoyi.sg@gmail.com)
 
@@ -13,13 +9,13 @@ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-DEALINGS IN THE SOFTWARE.
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Mill LICENSE is not reported as MIT by the Github API Updating it to use the GIthub template so it shows as MIT.

It appears as:
![immagine](https://github.com/com-lihaoyi/mill/assets/5793054/0eaa402d-c89e-4b7d-97d5-72e7566bf7a5)

while other repositories have:
![immagine](https://github.com/com-lihaoyi/mill/assets/5793054/76b5f5d5-5f1c-4d01-9bf1-d57b2c73fadd)
