### PR TITLE
Fix `init` command and support running Mill without existing `build.sc`

### DIFF
--- a/bsp/worker/src/mill/bsp/worker/State.scala
+++ b/bsp/worker/src/mill/bsp/worker/State.scala
@@ -39,7 +39,8 @@ private class State(projectRoot: os.Path, baseLogger: ColorLogger, debug: String
       threadCount = None,
       targetsAndParams = Seq("resolve", "_"),
       prevRunnerState = mill.runner.RunnerState.empty,
-      logger = baseLogger
+      logger = baseLogger,
+      needBuildSc = true
     ).evaluate()
 
     val rootModules0 = evaluated.result.frames

--- a/integration/feature/init/test/src/MillInitTests.scala
+++ b/integration/feature/init/test/src/MillInitTests.scala
@@ -1,0 +1,16 @@
+package mill.integration
+package local
+import mill.bsp.Constants
+import utest._
+
+object MillInitTests extends IntegrationTestSuite {
+
+  def tests: Tests = Tests {
+    test("Mill init works") {
+      val workspacePath = initWorkspace()
+      eval("init", "com-lihaoyi/mill-scala-hello.g8", "--name=example") ==> true
+      val projFile = workspacePath / "example" / "build.sc"
+      assert(os.exists(projFile))
+    }
+  }
+}

--- a/runner/src/mill/runner/FileImportGraph.scala
+++ b/runner/src/mill/runner/FileImportGraph.scala
@@ -60,7 +60,7 @@ object FileImportGraph {
           case Right(stmts) =>
             val fileImports = mutable.Set.empty[os.Path]
             // we don't expect any new imports when using an empty dummy
-            if(useDummy) assert(fileImports.isEmpty)
+            if (useDummy) assert(fileImports.isEmpty)
             val transformedStmts = mutable.Buffer.empty[String]
             for ((stmt0, importTrees) <- Parsers.parseImportHooksWithIndices(stmts)) {
               walkStmt(s, stmt0, importTrees, fileImports, transformedStmts)

--- a/runner/src/mill/runner/FileImportGraph.scala
+++ b/runner/src/mill/runner/FileImportGraph.scala
@@ -59,6 +59,8 @@ object FileImportGraph {
 
           case Right(stmts) =>
             val fileImports = mutable.Set.empty[os.Path]
+            // we don't expect any new imports when using an empty dummy
+            if(useDummy) assert(fileImports.isEmpty)
             val transformedStmts = mutable.Buffer.empty[String]
             for ((stmt0, importTrees) <- Parsers.parseImportHooksWithIndices(stmts)) {
               walkStmt(s, stmt0, importTrees, fileImports, transformedStmts)
@@ -117,7 +119,8 @@ object FileImportGraph {
       transformedStmts.append(stmt)
     }
 
-    walkScripts(projectRoot / "build.sc", !os.exists(projectRoot / "build.sc"))
+    val useDummy = !os.exists(projectRoot / "build.sc")
+    walkScripts(projectRoot / "build.sc", useDummy)
     new FileImportGraph(
       seenScripts.toMap,
       seenRepo.toSeq,

--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -61,7 +61,7 @@ class MillBuildBootstrap(
   }
 
   def evaluateRec(depth: Int): RunnerState = {
-//    println(s"+evaluateRec($depth) " + recRoot(projectRoot, depth))
+   // println(s"+evaluateRec($depth) " + recRoot(projectRoot, depth))
     val prevFrameOpt = prevRunnerState.frames.lift(depth)
     val prevOuterFrameOpt = prevRunnerState.frames.lift(depth - 1)
 

--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -61,7 +61,7 @@ class MillBuildBootstrap(
   }
 
   def evaluateRec(depth: Int): RunnerState = {
-   // println(s"+evaluateRec($depth) " + recRoot(projectRoot, depth))
+    // println(s"+evaluateRec($depth) " + recRoot(projectRoot, depth))
     val prevFrameOpt = prevRunnerState.frames.lift(depth)
     val prevOuterFrameOpt = prevRunnerState.frames.lift(depth - 1)
 

--- a/runner/src/mill/runner/MillMain.scala
+++ b/runner/src/mill/runner/MillMain.scala
@@ -202,7 +202,8 @@ object MillMain {
                       threadCount = threadCount,
                       targetsAndParams = targetsAndParams,
                       prevRunnerState = prevState.getOrElse(stateCache),
-                      logger = logger
+                      logger = logger,
+                      needBuildSc = needBuildSc(targetsAndParams)
                     ).evaluate()
                   }
                 )
@@ -260,6 +261,19 @@ object MillMain {
       printLoggerState
     )
     logger
+  }
+
+  private def needBuildSc(targetsAndParams: Seq[String]): Boolean = {
+    // Tasks, for which running Mill without an existing buildfile is allowed.
+    val noBuildFileTaskWhitelist = Seq(
+      "init",
+      "version",
+      "mill.scalalib.giter8.Giter8Module/init"
+    )
+    val whitelistMatch =
+      targetsAndParams.nonEmpty && noBuildFileTaskWhitelist.exists(targetsAndParams.head == _)
+
+    !whitelistMatch
   }
 
   def checkMillVersionFromFile(projectDir: os.Path, stderr: PrintStream) = {

--- a/runner/src/mill/runner/MillMain.scala
+++ b/runner/src/mill/runner/MillMain.scala
@@ -203,7 +203,7 @@ object MillMain {
                       targetsAndParams = targetsAndParams,
                       prevRunnerState = prevState.getOrElse(stateCache),
                       logger = logger,
-                      needBuildSc = needBuildSc(targetsAndParams)
+                      needBuildSc = needBuildSc(config)
                     ).evaluate()
                   }
                 )
@@ -263,17 +263,23 @@ object MillMain {
     logger
   }
 
-  private def needBuildSc(targetsAndParams: Seq[String]): Boolean = {
+  /**
+   * Determine, whether we need a `build.sc` or not.
+   */
+  private def needBuildSc(config: MillCliConfig): Boolean = {
     // Tasks, for which running Mill without an existing buildfile is allowed.
     val noBuildFileTaskWhitelist = Seq(
       "init",
       "version",
       "mill.scalalib.giter8.Giter8Module/init"
     )
+    val targetsAndParams = config.leftoverArgs.value
     val whitelistMatch =
       targetsAndParams.nonEmpty && noBuildFileTaskWhitelist.exists(targetsAndParams.head == _)
-
-    !whitelistMatch
+    // Has the user additional/extra imports
+    // (which could provide additional commands that could make sense without a build.sc)
+    val extraPlugins = config.imports.nonEmpty
+    !(whitelistMatch || extraPlugins)
   }
 
   def checkMillVersionFromFile(projectDir: os.Path, stderr: PrintStream) = {

--- a/runner/src/mill/runner/RunnerState.scala
+++ b/runner/src/mill/runner/RunnerState.scala
@@ -33,7 +33,10 @@ case class RunnerState(
     frames: Seq[RunnerState.Frame],
     errorOpt: Option[String]
 ) {
-  def add(frame: RunnerState.Frame = RunnerState.Frame.empty, errorOpt: Option[String] = None) = {
+  def add(
+      frame: RunnerState.Frame = RunnerState.Frame.empty,
+      errorOpt: Option[String] = None
+  ): RunnerState = {
     this.copy(frames = Seq(frame) ++ frames, errorOpt = errorOpt)
   }
 }


### PR DESCRIPTION
I first added an integration test for the init command to reproduce the issues and make sure the feature now works.

Instead of failing in case there is no `build.sc`, we now check the targets against a whitelist of tasks (`init` and `version`) and continue with an empty setup.

We also accept a missing `build.sc` in case additional imports are given, which could mean, the imports contain Mill plugins which itself provide commands that could work without a `build.sc`.

Only when we discover an error afterwards, we add a message about the missing `build.sc` to the underlying error message. That means, we don't see the spurious "no build.sc" message when everything works as expected.

* Fix #2660