### PR TITLE
Fix line numbers in errors for scripts starting with leading comments or whitespace

### DIFF
--- a/example/basic/2-custom-build-logic/build.sc
+++ b/example/basic/2-custom-build-logic/build.sc
@@ -30,7 +30,7 @@ Line Count: 11
 11
 
 > ./mill inspect lineCount
-lineCount(build.sc:7)
+lineCount(build.sc:12)
     Total number of lines in module's source files
 Inputs:
     allSourceFiles

--- a/integration/failure/compile-error/repo/bar.sc
+++ b/integration/failure/compile-error/repo/bar.sc
@@ -1,3 +1,16 @@
+// Make sure this
+/* gives the correct */
+// line numbers
+import scala._
+
 def myScalaVersion = "2.13.8"
+// when there
+// are a bunch
+
+/**
+ * Of comments and imports
+ */
 
 println(doesntExist)
+
+// Scattered throughout

--- a/integration/failure/compile-error/test/src/CompileErrorTests.scala
+++ b/integration/failure/compile-error/test/src/CompileErrorTests.scala
@@ -12,7 +12,7 @@ object CompileErrorTests extends IntegrationTestSuite {
       val res = evalStdout("foo.scalaVersion")
 
       assert(res.isSuccess == false)
-      assert(res.err.contains("""bar.sc:3:9: not found: value doesntExist"""))
+      assert(res.err.contains("""bar.sc:14:9: not found: value doesntExist"""))
       assert(res.err.contains("""println(doesntExist)"""))
       assert(res.err.contains("""qux.sc:3:34: type mismatch;"""))
       assert(res.err.contains(

--- a/integration/failure/parse-error/repo/bar.sc
+++ b/integration/failure/parse-error/repo/bar.sc
@@ -1,4 +1,16 @@
-def myScalaVersion = "2.13.8"
+// Make sure this
+/* gives the correct */
+// line numbers
+import scala._
 
+def myScalaVersion = "2.13.8"
+// when there
+// are a bunch
+
+/**
+ * Of comments and imports
+ */
 
 println(doesntExist})
+
+// Scattered throughout

--- a/integration/failure/parse-error/test/src/ParseErrorTests.scala
+++ b/integration/failure/parse-error/test/src/ParseErrorTests.scala
@@ -12,7 +12,7 @@ object ParseErrorTests extends IntegrationTestSuite {
 
       assert(res.isSuccess == false)
 
-      assert(res.err.contains("""bar.sc:4:20 expected ")""""))
+      assert(res.err.contains("""bar.sc:14:20 expected ")""""))
       assert(res.err.contains("""println(doesntExist})"""))
       assert(res.err.contains("""qux.sc:3:31 expected ")""""))
       assert(res.err.contains("""System.out.println(doesntExist"""))

--- a/readme.adoc
+++ b/readme.adoc
@@ -331,6 +331,9 @@ _Changes since {prev-version}:_
   analysis to see which targets depend on the code that was changed. See
   https://github.com/com-lihaoyi/mill/pull/2417[#2417] for more details
 
+* Fix line numbers in errors for scripts starting with leading comments or
+  whitespace https://github.com/com-lihaoyi/mill/pull/2686[#2686]
+
 _For details refer to
 {link-milestone}/{milestone}?closed=1[milestone {milestone-name}]
 and the {link-compare}/{prev-version}\...{version}[list of commits]._

--- a/runner/src/mill/runner/Parsers.scala
+++ b/runner/src/mill/runner/Parsers.scala
@@ -59,17 +59,8 @@ object Parsers {
   def StatementBlock[$: P] =
     P(Semis.? ~ (TmplStat ~~ WS ~~ (Semis | &("}") | End)).!.repX)
 
-  def CompilationUnit[$: P] = P(HashBang.!.? ~ WL.! ~ StatementBlock ~ WL ~ End)
+  def CompilationUnit[$: P] = P(HashBang.!.? ~~ WL.! ~~ StatementBlock ~ WL ~ End)
 
-  def stringWrap(s: String): String = "\"" + pprint.Util.literalize(s) + "\""
-  def stringSymWrap(s: String): String = {
-    def idToEnd[$: P] = P(scalaparse.syntax.Identifiers.Id ~ End)
-    if (s == "") "'"
-    else parse(s, idToEnd(_)) match {
-      case Parsed.Success(v, _) => "'" + s
-      case f: Parsed.Failure => stringWrap(s)
-    }
-  }
   def parseImportHooksWithIndices(stmts: Seq[String]): Seq[(String, Seq[ImportTree])] = {
     val hookedStmts = mutable.Buffer.empty[(String, Seq[ImportTree])]
     for (stmt <- stmts) {


### PR DESCRIPTION
This is basically a port of the following fix in the Ammonite repo https://github.com/com-lihaoyi/Ammonite/pull/1361. There were some changes when the logic was first ported from Ammonite to Mill, resulting in a much smaller code change than was necessary in the Ammonite repo

There are two related follow up PRs that AFAICT do not apply to Mill: https://github.com/com-lihaoyi/Ammonite/pull/1363 
and https://github.com/com-lihaoyi/Ammonite/pull/1369. Both have to do with the special handling of multi-statement top-level-blocks `{...}`, that is a thing in the Ammonite REPL (to allow multiple top-level declarations to be entered into the REPL before submitting it) but doesn't apply to Mill scripts.

I have updated the integration tests to include a bunch of random comments and imports to reproduce the problem causing the tests to fail, and verified the fix causes the tests to pass. Also this caused a previously passing test to fail (`2-custom-build-logic`), which on inspection appears like it was asserting the wrong thing, so I fixed the assert

Fixes https://github.com/com-lihaoyi/mill/issues/2681