### PR TITLE
Re-add Mill version marker into universal script

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -1128,7 +1128,8 @@ def launcherScript(
     shellJvmArgs: Seq[String],
     cmdJvmArgs: Seq[String],
     shellClassPath: Agg[String],
-    cmdClassPath: Agg[String]
+    cmdClassPath: Agg[String],
+    millVersion: String,
 ) = {
 
   val millMainClass = "mill.main.client.MillClientMain"
@@ -1144,7 +1145,8 @@ def launcherScript(
           )}" $mainClass "$$@""""
       }
 
-      s"""if [ -z "$$JAVA_HOME" ] ; then
+      s"""# Marker for millw to detect mill version: -DMILL_VERSION=${millVersion} -
+         |if [ -z "$$JAVA_HOME" ] ; then
          |  JAVACMD="java"
          |else
          |  JAVACMD="$$JAVA_HOME/bin/java"
@@ -1324,7 +1326,7 @@ object dev extends MillPublishScalaModule {
     os.move(
       mill.scalalib.Assembly.createAssembly(
         devRunClasspath,
-        prependShellScript = launcherScript(shellArgs, cmdArgs, Agg("$0"), Agg("%~dpnx0")),
+        prependShellScript = launcherScript(shellArgs, cmdArgs, Agg("$0"), Agg("%~dpnx0"), millVersion()),
         assemblyRules = assemblyRules
       ).path,
       T.dest / filename
@@ -1348,7 +1350,8 @@ object dev extends MillPublishScalaModule {
       jvmArgs,
       jvmArgs,
       classpath,
-      Agg(pathingJar().path.toString) // TODO not working yet on Windows! see #791
+      Agg(pathingJar().path.toString), // TODO not working yet on Windows! see #791
+      millVersion()
     )
   }
 


### PR DESCRIPTION
Mill used to invoke the JVM with -DMILL_VERSION=… as part of its universal script. This was used by millw (the Mill wrapper) to efficiently detect the version of a system-wide mill installation [1].

However, lately this changed and the universal script did not longer include the -DMILL_VERSION "marker". This re-introduces the marker so that millw can detect the version of a system-wide mill installation again.

1: https://github.com/lefou/millw/blob/e62923f3182861d2d1cc0273828f63e5d2ab6763/millw#L108-L139