### PR TITLE
[RFC] Fix `--silent` flag

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -331,13 +331,14 @@ _Changes since {prev-version}:_
   analysis to see which targets depend on the code that was changed. See
   https://github.com/com-lihaoyi/mill/pull/2417[#2417] for more details
 
-
 * Fix redirection of stdout stream to stderr when using `show`
   https://github.com/com-lihaoyi/mill/pull/2689[#2689]
 
 * Fix line numbers in errors for scripts starting with leading comments or
   whitespace https://github.com/com-lihaoyi/mill/pull/2686[#2686]
 
+* Fix issue with BSP protocol crashing due to use of wrong evaluator
+  https://github.com/com-lihaoyi/mill/pull/2692[#2692]
 
 _For details refer to
 {link-milestone}/{milestone}?closed=1[milestone {milestone-name}]

--- a/runner/src/mill/runner/MillMain.scala
+++ b/runner/src/mill/runner/MillMain.scala
@@ -256,7 +256,13 @@ object MillMain {
       enableTicker = enableTicker.getOrElse(mainInteractive),
       infoColor = colors.info,
       errorColor = colors.error,
-      systemStreams = streams,
+      systemStreams =
+        if (config.silent.value) new SystemStreams(
+          new java.io.PrintStream(mill.api.DummyOutputStream),
+          new java.io.PrintStream(mill.api.DummyOutputStream),
+          streams.in
+        )
+        else streams,
       debugEnabled = config.debugLog.value,
       context = "",
       printLoggerState


### PR DESCRIPTION
Support for `-s`/`--silent` was accidentally dropped in 5998b561. I'm not actually sure what the most useful thing to do here is. The previous `--silent` CLI docs say

```
  -s --silent             Make ivy logs during script import resolution go silent instead of
                          printing; though failures will still throw exception.
```

However, from things like https://github.com/com-lihaoyi/mill/issues/1946 it seems clear that it's not just a matter of silencing ivy resolution, but would likely involve silencing other stuff as well.

This PR just silences everything, since it just stubs out the stdout/stderr streams, which would silence user-inserted `println`s and other things. That also doesn't seem that useful given https://github.com/com-lihaoyi/mill/issues/1946. However, the use case of https://github.com/com-lihaoyi/mill/issues/1946 seems like it could be satisfied by `show`, which redirects all stdout to stderr so that only the final value being shown goes to stdout.

One option is to move `--silent` to a flag on `show` that squelches stderr, so that we can have `show` silence all non-JSON output while still allowing the JSON output to be used

I'm not sure what we should do here. Is there some spec for `--silent` that would be useful, and if so for what?