### PR TITLE
Tweak examples and visualize rendering

### DIFF
--- a/example/tasks/1-task-graph/src/Foo.java
+++ b/example/tasks/1-task-graph/src/Foo.java
@@ -13,6 +13,4 @@ public class Foo{
             System.out.println("foo.txt resource: " + br.readLine());
         }
     }
-
-
 }


### PR DESCRIPTION
Makes both a bit prettier in preparation for usage in slides for Scaladays 2023 Madrid

For the SVG visualization, I replaced the oval node shape with rectangular nodes, and make it go from left-to-right with the arrows pointing in the direction of the dataflow. This makes it much easier to read because nodes tend to be more wide than tall, and the graph tends to be more wide than deep, so having sibling nodes stack up vertically ends up being much more compact than having them side-by-side horizontally