### PR TITLE
Don't fetch sources when not explicitly requested for

### DIFF
--- a/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -329,16 +329,16 @@ private class MillBuildServer(
       targetIds = _ => p.getTargets.asScala.toSeq,
       tasks = {
         case m: JavaModule =>
-        T.task {
-          (
-            m.resolveDeps(
-              T.task(m.transitiveCompileIvyDeps() ++ m.transitiveIvyDeps()),
-              sources = true
-            )(),
-            m.unmanagedClasspath(),
-            m.repositoriesTask()
-          )
-        }
+          T.task {
+            (
+              m.resolveDeps(
+                T.task(m.transitiveCompileIvyDeps() ++ m.transitiveIvyDeps()),
+                sources = true
+              )(),
+              m.unmanagedClasspath(),
+              m.repositoriesTask()
+            )
+          }
       }
     ) {
       case (ev, state, id, m: JavaModule, (resolveDepsSources, unmanagedClasspath, repos)) =>

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -41,23 +41,6 @@ class MillBuildRootModule()(implicit
   override def millSourcePath = millBuildRootModuleInfo.projectRoot / os.up / "mill-build"
   override def intellijModulePath: os.Path = millSourcePath / os.up
 
-//  override def resolveDeps(
-//      deps: Task[Agg[BoundDep]],
-//      sources: Boolean = false
-//  ): Task[Agg[PathRef]] =
-//    T.task {
-//      if (sources == true) super.resolveDeps(deps, true)()
-//      else {
-//        // We need to resolve the sources to make GenIdeaExtendedTests pass,
-//        // because those do not call `resolveDeps` explicitly for build file
-//        // `import $ivy`s but instead rely on the deps that are resolved as
-//        // part of the bootstrapping process. We thus need to make sure
-//        // bootstrapping the rootModule ends up putting the sources on disk
-//        val unused = super.resolveDeps(deps, true)()
-//        super.resolveDeps(deps, false)()
-//      }
-//    }
-
   override def scalaVersion: T[String] = "2.13.10"
 
   /**

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -41,22 +41,22 @@ class MillBuildRootModule()(implicit
   override def millSourcePath = millBuildRootModuleInfo.projectRoot / os.up / "mill-build"
   override def intellijModulePath: os.Path = millSourcePath / os.up
 
-  override def resolveDeps(
-      deps: Task[Agg[BoundDep]],
-      sources: Boolean = false
-  ): Task[Agg[PathRef]] =
-    T.task {
-      if (sources == true) super.resolveDeps(deps, true)()
-      else {
-        // We need to resolve the sources to make GenIdeaExtendedTests pass,
-        // because those do not call `resolveDeps` explicitly for build file
-        // `import $ivy`s but instead rely on the deps that are resolved as
-        // part of the bootstrapping process. We thus need to make sure
-        // bootstrapping the rootModule ends up putting the sources on disk
-        val unused = super.resolveDeps(deps, true)()
-        super.resolveDeps(deps, false)()
-      }
-    }
+//  override def resolveDeps(
+//      deps: Task[Agg[BoundDep]],
+//      sources: Boolean = false
+//  ): Task[Agg[PathRef]] =
+//    T.task {
+//      if (sources == true) super.resolveDeps(deps, true)()
+//      else {
+//        // We need to resolve the sources to make GenIdeaExtendedTests pass,
+//        // because those do not call `resolveDeps` explicitly for build file
+//        // `import $ivy`s but instead rely on the deps that are resolved as
+//        // part of the bootstrapping process. We thus need to make sure
+//        // bootstrapping the rootModule ends up putting the sources on disk
+//        val unused = super.resolveDeps(deps, true)()
+//        super.resolveDeps(deps, false)()
+//      }
+//    }
 
   override def scalaVersion: T[String] = "2.13.10"
 

--- a/scalalib/src/mill/scalalib/Lib.scala
+++ b/scalalib/src/mill/scalalib/Lib.scala
@@ -138,20 +138,18 @@ object Lib {
   }
 
   def resolveMillBuildDeps(
-      repos0: Seq[Repository],
+      repos: Seq[Repository],
       ctx: Option[mill.api.Ctx.Log],
       useSources: Boolean
   ): Seq[os.Path] = {
     Util.millProperty("MILL_BUILD_LIBRARIES") match {
       case Some(found) => found.split(',').map(os.Path(_)).distinct.toList
       case None =>
-        val repos = (repos0 ++ Seq(
-          LocalRepositories.ivy2Local,
-          Repositories.central
-        )).distinct
-        val millDeps = BuildInfo.millEmbeddedDeps.split(",").map(d => ivy"$d").map(dep =>
-          BoundDep(Lib.depToDependency(dep, BuildInfo.scalaVersion, ""), dep.force)
-        )
+        val millDeps = BuildInfo.millEmbeddedDeps
+          .split(",")
+          .map(d => ivy"$d")
+          .map(dep => Lib.depToBoundDep(dep, BuildInfo.scalaVersion))
+
         val Result.Success(res) = scalalib.Lib.resolveDependencies(
           repositories = repos.toList,
           deps = millDeps,
@@ -161,20 +159,6 @@ object Lib {
           coursierCacheCustomizer = None,
           ctx = ctx
         )
-
-        // Also trigger resolve sources, but don't use them (will happen implicitly by Idea)
-        if (!useSources) {
-          scalalib.Lib.resolveDependencies(
-            repositories = repos.toList,
-            deps = millDeps,
-            sources = true,
-            mapDependencies = None,
-            customizer = None,
-            coursierCacheCustomizer = None,
-            ctx = ctx
-          )
-        }
-
         res.items.toList.map(_.path)
     }
   }


### PR DESCRIPTION
Also fixed use of hardcoded repositories set. This code was previously located in the GenIdea and moved here. But we now have proper access to the build module repositories, so using hardcoded repos is no longer justified.
