### PR TITLE
Allow Mill CLI to select the meta-build frame it operates on

### DIFF
--- a/docs/modules/ROOT/pages/Extending_Mill.adoc
+++ b/docs/modules/ROOT/pages/Extending_Mill.adoc
@@ -45,6 +45,8 @@ Hence, you can easily search for updates with the external `mill.scalalib.Depend
 .Check for Mill Plugin updates
 ----
 $ mill --meta-level 1 mill.scalalib.Dependency/showUpdates
+Found 1 dependency update for
+  de.tototec:de.tobiasroeser.mill.vcs.version_mill0.11_2.13 : 0.3.1-> 0.4.0
 ----
 
 === Example: Customizing the Meta-Build

--- a/docs/modules/ROOT/pages/Extending_Mill.adoc
+++ b/docs/modules/ROOT/pages/Extending_Mill.adoc
@@ -11,12 +11,12 @@ include::example/misc/3-import-file-ivy.adoc[]
 
 == The Mill Meta-Build
 
-The Meta-Build manages the compilation of the `build.sc`.
-If you don't configure it explicitly, the Meta-Build is built-in into Mill.
+The meta-build manages the compilation of the `build.sc`.
+If you don't configure it explicitly, a built-in synthetic meta-build is used.
 
 To customize it, you need to explicitly enable it with `import $meta._`.
-Once enabled, it lives in the `mill-build/` directory.
-A Meta-Build is required to contain a `MillBuildRootModule`.
+Once enabled, the meta-build lives in the `mill-build/` directory.
+It needs to contain a top-level module of type `MillBuildRootModule`.
 
 Meta-Builds are recursive, which means, a Meta-Build can itself have Meta-Builds, and so on.
 

--- a/docs/modules/ROOT/pages/Extending_Mill.adoc
+++ b/docs/modules/ROOT/pages/Extending_Mill.adoc
@@ -18,9 +18,9 @@ To customize it, you need to explicitly enable it with `import $meta._`.
 Once enabled, the meta-build lives in the `mill-build/` directory.
 It needs to contain a top-level module of type `MillBuildRootModule`.
 
-Meta-Builds are recursive, which means, a Meta-Build can itself have Meta-Builds, and so on.
+Meta-builds are recursive, which means, it can itself have a nested meta-builds, and so on.
 
-To run a task on a meta-build by specifying the `--meta-level` option to select the meta-build level.
+To run a task on a meta-build, you specifying the `--meta-level` option to select the meta-build level.
 
 === Example: Format the `build.sc`
 

--- a/docs/modules/ROOT/pages/Extending_Mill.adoc
+++ b/docs/modules/ROOT/pages/Extending_Mill.adoc
@@ -11,6 +11,44 @@ include::example/misc/3-import-file-ivy.adoc[]
 
 == The Mill Meta-Build
 
+The Meta-Build manages the compilation of the `build.sc`.
+If you don't configure it explicitly, the Meta-Build is built-in into Mill.
+
+To customize it, you need to explicitly enable it with `import $meta._`.
+Once enabled, it lives in the `mill-build/` directory.
+A Meta-Build is required to contain a `MillBuildRootModule`.
+
+Meta-Builds are recursive, which means, a Meta-Build can itself have Meta-Builds, and so on.
+
+To run a task on a meta-build by specifying the `--meta-level` option to select the meta-build level.
+
+=== Example: Format the `build.sc`
+
+As an example of running a task on the meta-build, you can format the `build.sc` with Scalafmt.
+Everything is already provided by Mill.
+You only need a `.scalafmt.conf` config file which at least needs configure the Scalafmt version.
+
+.Run Scalafmt on the `build.sc` (and potentially included files)
+----
+$ mill --meta-level 1 mill.scalalib.scalafmt.ScalafmtModule/reformatAll sources
+----
+
+* `--meta-level 1` selects the first meta-build. Without any customization, this is the only built-in meta-build.
+* `mill.scalalib.scalafmt.ScalafmtModule/reformatAll` is a generic task to format scala source files with Scalafmt. It requires the targets that refer to the source files as argument
+* `sources` this selects the `sources` targets of the meta-build, which at least contains the `build.sc`.
+
+=== Example: Find plugin updates
+
+Mill plugins are defined as `ivyDeps` in the meta-build.
+Hence, you can easily search for updates with the external `mill.scalalib.Dependency` module.
+
+.Check for Mill Plugin updates
+----
+$ mill --meta-level 1 mill.scalalib.Dependency/showUpdates
+----
+
+=== Example: Customizing the Meta-Build
+
 include::example/misc/4-mill-build-folder.adoc[]
 
 == Using ScalaModule.run as a task

--- a/docs/modules/ROOT/pages/Intro_to_Mill.adoc
+++ b/docs/modules/ROOT/pages/Intro_to_Mill.adoc
@@ -124,35 +124,48 @@ Run `mill --help` for a complete list of options
 ----
 Mill Build Tool, version {mill-version}
 usage: mill [options] [[target [target-options]] [+ [target ...]]]
-  -D --define <k=v>       Define (or overwrite) a system property.
-  -b --bell               Ring the bell once if the run completes successfully, twice if it fails.
-  --bsp                   Enable BSP server mode.
-  --color <bool>          Enable or disable colored output; by default colors are enabled in both
-                          REPL and scripts mode if the console is interactive, and disabled
-                          otherwise.
-  -d --debug              Show debug output on STDOUT
-  --disable-ticker        Disable ticker log (e.g. short-lived prints of stages and progress bars).
-  --enable-ticker <bool>  Enable ticker log (e.g. short-lived prints of stages and progress bars).
-  -h --home <path>        (internal) The home directory of internally used Ammonite script engine;
-                          where it looks for config and caches.
-  --help                  Print this help message and exit.
-  -i --interactive        Run Mill in interactive mode, suitable for opening REPLs and taking user
-                          input. This implies --no-server and no mill server will be used. Must be
-                          the first argument.
-  --import <str>          Additional ivy dependencies to load into mill, e.g. plugins.
-  -j --jobs <int>         Allow processing N targets in parallel. Use 1 to disable parallel and 0 to
-                          use as much threads as available processors.
-  -k --keep-going         Continue build, even after build failures.
-  --no-server             Run Mill in single-process mode. In this mode, no Mill server will be
-                          started or used. Must be the first argument.
-  --repl                  This flag is no longer supported.
-  -s --silent             Make ivy logs during script import resolution go silent instead of
-                          printing; though failures will still throw exception.
-  -v --version            Show mill version information and exit.
-  -w --watch              Watch and re-run your scripts when they change.
-  target <str>...         The name or a pattern of the target(s) you want to build, followed by any
-                          parameters you wish to pass to those targets. To specify multiple target
-                          names or patterns, use the `+` separator.
+  -D --define <k=v>                 Define (or overwrite) a system property.
+  -b --bell                         Ring the bell once if the run completes successfully, twice if
+                                    it fails.
+  --bsp                             Enable BSP server mode.
+  --color <bool>                    Enable or disable colored output; by default colors are enabled
+                                    in both REPL and scripts mode if the console is interactive, and
+                                    disabled otherwise.
+  -d --debug                        Show debug output on STDOUT
+  --disable-callgraph-invalidation  Disable the fine-grained callgraph-based target invalidation in
+                                    response to code changes, and instead fall back to the previous
+                                    coarse-grained implementation relying on the script `import
+                                    $file` graph
+  --disable-ticker                  Disable ticker log (e.g. short-lived prints of stages and
+                                    progress bars).
+  --enable-ticker <bool>            Enable ticker log (e.g. short-lived prints of stages and
+                                    progress bars).
+  -h --home <path>                  (internal) The home directory of internally used Ammonite script
+                                    engine; where it looks for config and caches.
+  --help                            Print this help message and exit.
+  -i --interactive                  Run Mill in interactive mode, suitable for opening REPLs and
+                                    taking user input. This implies --no-server and no mill server
+                                    will be used. Must be the first argument.
+  --import <str>                    Additional ivy dependencies to load into mill, e.g. plugins.
+  -j --jobs <int>                   Allow processing N targets in parallel. Use 1 to disable
+                                    parallel and 0 to use as much threads as available processors.
+  -k --keep-going                   Continue build, even after build failures.
+  --meta-level <int>                Experimental: Select a meta-build level to run the given
+                                    targets. Level 0 is the normal project, level 1 the first
+                                    meta-build, and so on. The last level is the built-in synthetic
+                                    meta-build which Mill uses to bootstrap the project.
+  --no-server                       Run Mill in single-process mode. In this mode, no Mill server
+                                    will be started or used. Must be the first argument.
+  --repl                            This flag is no longer supported.
+  -s --silent                       Make ivy logs during script import resolution go silent instead
+                                    of printing; though failures will still throw exception.
+  -v --version                      Show mill version information and exit.
+  -w --watch                        Watch and re-run your scripts when they change.
+  target <str>...                   The name or a pattern of the target(s) you want to build,
+                                    followed by any parameters you wish to pass to those targets. To
+                                    specify multiple target names or patterns, use the `+`
+                                    separator.
+
 ----
 
 All _options_ must be given before the first target.

--- a/example/misc/4-mill-build-folder/build.sc
+++ b/example/misc/4-mill-build-folder/build.sc
@@ -63,3 +63,19 @@ scalatagsVersion: 0.8.2
 
 */
 
+// You can also run tasks on the meta-build by using the `--meta-level`
+// cli option.
+
+/** Usage
+
+> ./mill --meta-level 1 show sources
+[
+.../build.sc",
+.../mill-build/src"
+]
+
+> ./mill --meta-level 2 show sources
+.../mill-build/build.sc"
+
+
+*/

--- a/example/misc/5-module-run-task/build.sc
+++ b/example/misc/5-module-run-task/build.sc
@@ -17,7 +17,7 @@ object bar extends ScalaModule{
   def ivyDeps = Agg(ivy"com.lihaoyi::os-lib:0.9.1")
 }
 
-// This example demonstrates using Mill `ScalaModule`s as build tasks: rather
+// This example demonstrates using Mill ``ScalaModule``s as build tasks: rather
 // than defining the task logic in the `build.sc`, we instead put the build
 // logic within the `bar` module as `bar/src/Bar.scala`. In this example, we use
 // `Bar.scala` as a source-code pre-processor on the `foo` module source code:
@@ -34,7 +34,7 @@ Foo.value: HELLO
 */
 
 // This example does a trivial string-replace of "hello" with "HELLO", but is
-// enough to demonstrate how you can use Mill `ScalaModule`s to implement your
+// enough to demonstrate how you can use Mill ``ScalaModule``s to implement your
 // own arbitrarily complex transformations. This is useful for build logic that
 // may not fit nicely inside a `build.sc` file, whether due to the sheer lines
 // of code or due to dependencies that may conflict with the Mill classpath

--- a/runner/src/mill/runner/MillBuild.scala
+++ b/runner/src/mill/runner/MillBuild.scala
@@ -6,7 +6,7 @@ import mill.eval.Evaluator.AllBootstrapEvaluators
 
 trait MillBuild extends Module {
 
-  def frameCount(evaluators: AllBootstrapEvaluators): Command[Int] = T.command {
+  def levelCount(evaluators: AllBootstrapEvaluators): Command[Int] = T.command {
     val count = evaluators.value.size
     T.log.outputStream.println(s"${count}")
     count

--- a/runner/src/mill/runner/MillBuild.scala
+++ b/runner/src/mill/runner/MillBuild.scala
@@ -8,11 +8,10 @@ trait MillBuild extends Module {
 
   /**
    * Count of the nested build-levels, the main project and all its nested meta-builds.
+   * If you run this on a meta-build, the non-meta-builds are not included.
    */
   def levelCount(evaluators: AllBootstrapEvaluators): Command[Int] = T.command {
-    val count = evaluators.value.size
-    T.log.outputStream.println(s"${count}")
-    count
+    evaluators.value.size
   }
 
 }

--- a/runner/src/mill/runner/MillBuild.scala
+++ b/runner/src/mill/runner/MillBuild.scala
@@ -6,6 +6,9 @@ import mill.eval.Evaluator.AllBootstrapEvaluators
 
 trait MillBuild extends Module {
 
+  /**
+   * Count of the nested build-levels, the main project and all its nested meta-builds.
+   */
   def levelCount(evaluators: AllBootstrapEvaluators): Command[Int] = T.command {
     val count = evaluators.value.size
     T.log.outputStream.println(s"${count}")

--- a/runner/src/mill/runner/MillBuild.scala
+++ b/runner/src/mill/runner/MillBuild.scala
@@ -1,0 +1,19 @@
+package mill.runner
+
+import mill.T
+import mill.define.{Command, Discover, ExternalModule, Module}
+import mill.eval.Evaluator.AllBootstrapEvaluators
+
+trait MillBuild extends Module {
+
+  def frameCount(evaluators: AllBootstrapEvaluators): Command[Int] = T.command {
+    val count = evaluators.value.size
+    T.log.outputStream.println(s"${count}")
+    count
+  }
+
+}
+
+object MillBuild extends ExternalModule with MillBuild {
+  override lazy val millDiscover = Discover[this.type]
+}

--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -119,7 +119,7 @@ class MillBuildBootstrap(
         // User has requested a frame depth, we actually don't have
         nestedState.add(errorOpt =
           Some(
-            s"Invalid selected frame ${requestedDepth}. Valid range: 0 .. ${nestedState.frames.size}"
+            s"Invalid selected meta-level ${requestedDepth}. Valid range: 0 .. ${nestedState.frames.size}"
           )
         )
       } else if (depth < requestedDepth) {

--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -38,7 +38,7 @@ class MillBuildBootstrap(
     logger: ColorLogger,
     disableCallgraphInvalidation: Boolean,
     needBuildSc: Boolean,
-    requestedFrame: Option[Int]
+    requestedMetaLevel: Option[Int]
 ) {
   import MillBuildBootstrap._
 
@@ -67,7 +67,7 @@ class MillBuildBootstrap(
     val prevFrameOpt = prevRunnerState.frames.lift(depth)
     val prevOuterFrameOpt = prevRunnerState.frames.lift(depth - 1)
 
-    val requestedDepth = requestedFrame.filter(_ >= 0).getOrElse(0)
+    val requestedDepth = requestedMetaLevel.filter(_ >= 0).getOrElse(0)
 
     val nestedState =
       if (depth == 0) {
@@ -117,7 +117,11 @@ class MillBuildBootstrap(
       if (nestedState.errorOpt.isDefined) nestedState.add(errorOpt = nestedState.errorOpt)
       else if (depth == 0 && requestedDepth > nestedState.frames.size) {
         // User has requested a frame depth, we actually don't have
-        nestedState.add(errorOpt = Some(s"Invalid selected frame ${requestedDepth}. Valid range: 0 .. ${nestedState.frames.size}"))
+        nestedState.add(errorOpt =
+          Some(
+            s"Invalid selected frame ${requestedDepth}. Valid range: 0 .. ${nestedState.frames.size}"
+          )
+        )
       } else if (depth < requestedDepth) {
         // We already evaluated, hence we just need to make sure, we return a proper structure with all already existing watch data
         val evalState = RunnerState.Frame(

--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -132,10 +132,10 @@ class MillBuildBootstrap(
           Map.empty,
           None,
           Nil,
-          // FIXME we don't want to evaluator anything in this depth, so we just skip creating an evaluator,
+          // We set this to None here.
+          // We don't want to evaluate anything in this depth, so we just skip creating an evaluator,
           // mainly because we didn't even constructed (compiled) it's classpath
-          // TODO: Instead, introduce a skipped frame type, so we can better comunicate that state
-          null
+          None
         )
         nestedState.add(frame = evalState, errorOpt = None)
       } else {
@@ -232,7 +232,7 @@ class MillBuildBootstrap(
           Map.empty,
           None,
           Nil,
-          evaluator
+          Option(evaluator)
         )
 
         nestedState.add(frame = evalState, errorOpt = Some(error))
@@ -282,7 +282,7 @@ class MillBuildBootstrap(
           methodCodeHashSignatures,
           Some(classLoader),
           runClasspath,
-          evaluator
+          Option(evaluator)
         )
 
         nestedState.add(frame = evalState)
@@ -300,10 +300,10 @@ class MillBuildBootstrap(
       evaluator: Evaluator
   ): RunnerState = {
 
-    assert(nestedState.frames.forall(_.evaluator != null))
+    assert(nestedState.frames.forall(_.evaluator.isDefined))
 
     val (evaled, evalWatched, moduleWatches) = Evaluator.allBootstrapEvaluators.withValue(
-      Evaluator.AllBootstrapEvaluators(Seq(evaluator) ++ nestedState.frames.map(_.evaluator))
+      Evaluator.AllBootstrapEvaluators(Seq(evaluator) ++ nestedState.frames.flatMap(_.evaluator))
     ) {
       evaluateWithWatches(rootModule, evaluator, targetsAndParams)
     }
@@ -316,7 +316,7 @@ class MillBuildBootstrap(
       Map.empty,
       None,
       Nil,
-      evaluator
+      Option(evaluator)
     )
 
     nestedState.add(frame = evalState, errorOpt = evaled.left.toOption)

--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -1,6 +1,5 @@
 package mill.runner
-import mill.util.{ColorLogger, PrefixLogger, Util, Watchable}
-import mill.T
+import mill.util.{ColorLogger, PrefixLogger, Watchable}
 import mill.main.BuildInfo
 import mill.api.{PathRef, Val, internal}
 import mill.eval.Evaluator
@@ -123,7 +122,8 @@ class MillBuildBootstrap(
           )
         )
       } else if (depth < requestedDepth) {
-        // We already evaluated, hence we just need to make sure, we return a proper structure with all already existing watch data
+        // We already evaluated on a deeper level, hence we just need to make sure,
+        // we return a proper structure with all already existing watch data
         val evalState = RunnerState.Frame(
           prevFrameOpt.map(_.workerCache).getOrElse(Map.empty),
           Seq.empty,
@@ -132,8 +132,7 @@ class MillBuildBootstrap(
           Map.empty,
           None,
           Nil,
-          // We set this to None here.
-          // We don't want to evaluate anything in this depth, so we just skip creating an evaluator,
+          // We don't want to evaluate anything in this depth (and above), so we just skip creating an evaluator,
           // mainly because we didn't even constructed (compiled) it's classpath
           None
         )

--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -300,6 +300,8 @@ class MillBuildBootstrap(
       evaluator: Evaluator
   ): RunnerState = {
 
+    assert(nestedState.frames.forall(_.evaluator != null))
+
     val (evaled, evalWatched, moduleWatches) = Evaluator.allBootstrapEvaluators.withValue(
       Evaluator.AllBootstrapEvaluators(Seq(evaluator) ++ nestedState.frames.map(_.evaluator))
     ) {

--- a/runner/src/mill/runner/MillCliConfig.scala
+++ b/runner/src/mill/runner/MillCliConfig.scala
@@ -117,7 +117,11 @@ class MillCliConfig private (
            code changes, and instead fall back to the previous coarse-grained implementation
            relying on the script `import $file` graph"""
     )
-    val disableCallgraphInvalidation: Flag
+    val disableCallgraphInvalidation: Flag,
+    @arg(
+      doc = """Experimental: Select a meta-build to run the given targets."""
+    )
+    val frame: Option[Int]
 ) {
   override def toString: String = Seq(
     "home" -> home,
@@ -139,7 +143,8 @@ class MillCliConfig private (
     "silent" -> silent,
     "leftoverArgs" -> leftoverArgs,
     "color" -> color,
-    "disableCallgraphInvalidation" -> disableCallgraphInvalidation
+    "disableCallgraphInvalidation" -> disableCallgraphInvalidation,
+    "frame" -> frame
   ).map(p => s"${p._1}=${p._2}").mkString(getClass().getSimpleName + "(", ",", ")")
 }
 
@@ -148,8 +153,8 @@ object MillCliConfig {
    * mainargs requires us to keep this apply method in sync with the private ctr of the class.
    * mainargs is designed to work with case classes,
    * but case classes can't be evolved in a binary compatible fashion.
-   * mainargs parses the class ctr for itss internal model,
-   * but used the companion's apply to actually create an instance of the config class,
+   * mainargs parses the class ctr for its internal model,
+   * but uses the companion's apply to actually create an instance of the config class,
    * hence we need both in sync.
    */
   def apply(
@@ -173,7 +178,8 @@ object MillCliConfig {
       silent: Flag = Flag(),
       leftoverArgs: Leftover[String] = Leftover(),
       color: Option[Boolean] = None,
-      disableCallgraphInvalidation: Flag = Flag()
+      disableCallgraphInvalidation: Flag = Flag(),
+      frame: Option[Int] = None
   ): MillCliConfig = new MillCliConfig(
     home = home,
     repl = repl,
@@ -194,7 +200,8 @@ object MillCliConfig {
     silent = silent,
     leftoverArgs = leftoverArgs,
     color = color,
-    disableCallgraphInvalidation
+    disableCallgraphInvalidation,
+    frame = frame
   )
 
   @deprecated("Bin-compat shim", "Mill after 0.11.0")

--- a/runner/src/mill/runner/MillCliConfig.scala
+++ b/runner/src/mill/runner/MillCliConfig.scala
@@ -183,7 +183,7 @@ object MillCliConfig {
       leftoverArgs: Leftover[String] = Leftover(),
       color: Option[Boolean] = None,
       disableCallgraphInvalidation: Flag = Flag(),
-      frame: Option[Int] = None
+      metaLevel: Option[Int] = None
   ): MillCliConfig = new MillCliConfig(
     home = home,
     repl = repl,
@@ -205,7 +205,7 @@ object MillCliConfig {
     leftoverArgs = leftoverArgs,
     color = color,
     disableCallgraphInvalidation,
-    metaLevel = frame
+    metaLevel = metaLevel
   )
 
   @deprecated("Bin-compat shim", "Mill after 0.11.0")

--- a/runner/src/mill/runner/MillCliConfig.scala
+++ b/runner/src/mill/runner/MillCliConfig.scala
@@ -119,9 +119,13 @@ class MillCliConfig private (
     )
     val disableCallgraphInvalidation: Flag,
     @arg(
-      doc = """Experimental: Select a meta-build to run the given targets."""
+      name = "meta-level",
+      doc =
+        """Experimental: Select a meta-build level to run the given targets.
+           Level 0 is the normal project, level 1 the first meta-build, and so on.
+           The last level is the built-in synthetic meta-build which Mill uses to bootstrap the project."""
     )
-    val frame: Option[Int]
+    val metaLevel: Option[Int]
 ) {
   override def toString: String = Seq(
     "home" -> home,
@@ -144,7 +148,7 @@ class MillCliConfig private (
     "leftoverArgs" -> leftoverArgs,
     "color" -> color,
     "disableCallgraphInvalidation" -> disableCallgraphInvalidation,
-    "frame" -> frame
+    "metaLevel" -> metaLevel
   ).map(p => s"${p._1}=${p._2}").mkString(getClass().getSimpleName + "(", ",", ")")
 }
 
@@ -201,7 +205,7 @@ object MillCliConfig {
     leftoverArgs = leftoverArgs,
     color = color,
     disableCallgraphInvalidation,
-    frame = frame
+    metaLevel = frame
   )
 
   @deprecated("Bin-compat shim", "Mill after 0.11.0")

--- a/runner/src/mill/runner/MillMain.scala
+++ b/runner/src/mill/runner/MillMain.scala
@@ -127,7 +127,7 @@ object MillMain {
           (false, RunnerState.empty)
 
         // Check non-negative --frame option
-        case Right(config) if config.frame.exists(_ < 0) =>
+        case Right(config) if config.metaLevel.exists(_ < 0) =>
           streams.err.println("--frame cannot be negative")
           (false, RunnerState.empty)
 
@@ -210,7 +210,7 @@ object MillMain {
                       logger = logger,
                       disableCallgraphInvalidation = config.disableCallgraphInvalidation.value,
                       needBuildSc = needBuildSc(config),
-                      requestedFrame = config.frame
+                      requestedMetaLevel = config.metaLevel
                     ).evaluate()
                   }
                 )

--- a/runner/src/mill/runner/MillMain.scala
+++ b/runner/src/mill/runner/MillMain.scala
@@ -126,6 +126,11 @@ object MillMain {
           )
           (false, RunnerState.empty)
 
+        // Check non-negative --frame option
+        case Right(config) if config.frame.exists(_ < 0) =>
+          streams.err.println("--frame cannot be negative")
+          (false, RunnerState.empty)
+
         case Right(config) =>
           val logger = getLogger(
             streams,
@@ -204,7 +209,8 @@ object MillMain {
                       prevRunnerState = prevState.getOrElse(stateCache),
                       logger = logger,
                       disableCallgraphInvalidation = config.disableCallgraphInvalidation.value,
-                      needBuildSc = needBuildSc(config)
+                      needBuildSc = needBuildSc(config),
+                      requestedFrame = config.frame
                     ).evaluate()
                   }
                 )
@@ -224,8 +230,9 @@ object MillMain {
                 )
                 BspContext.bspServerHandle.stop()
               }
-              loopRes
 
+              // return with evaluation result
+              loopRes
             }
           }
           if (config.ringBell.value) {

--- a/runner/src/mill/runner/MillMain.scala
+++ b/runner/src/mill/runner/MillMain.scala
@@ -126,9 +126,9 @@ object MillMain {
           )
           (false, RunnerState.empty)
 
-        // Check non-negative --frame option
+        // Check non-negative --meta-level option
         case Right(config) if config.metaLevel.exists(_ < 0) =>
-          streams.err.println("--frame cannot be negative")
+          streams.err.println("--meta-level cannot be negative")
           (false, RunnerState.empty)
 
         case Right(config) =>

--- a/runner/src/mill/runner/RunnerState.scala
+++ b/runner/src/mill/runner/RunnerState.scala
@@ -65,7 +65,7 @@ object RunnerState {
       evaluator: Evaluator
   ) {
 
-    def loggedData = {
+    def loggedData: Frame.Logged = {
       Frame.Logged(
         workerCache.map { case (k, (i, v)) =>
           (k.render, Frame.WorkerInfo(System.identityHashCode(v), i))

--- a/runner/src/mill/runner/RunnerState.scala
+++ b/runner/src/mill/runner/RunnerState.scala
@@ -62,7 +62,7 @@ object RunnerState {
       methodCodeHashSignatures: Map[String, Int],
       classLoaderOpt: Option[RunnerState.URLClassLoader],
       runClasspath: Seq[PathRef],
-      evaluator: Evaluator
+      evaluator: Option[Evaluator]
   ) {
 
     def loggedData: Frame.Logged = {


### PR DESCRIPTION
Add a new CLI option `--meta-level` accepting an `Int`. Default is `0` and means the root project, `1` is the parent meta-build, if defined, or the built-in bootstrap module, and so on.

This is a first draft, to get more familiar with the recursive but mutable nature of our meta-build support.
Don't hesitate to point out shortcomings.

* Fixes https://github.com/com-lihaoyi/mill/issues/2658

Review by @lihaoyi

**Example: Find version updates in the meta build**

Here is some example output (applied to the mill repo):

``` 
$ mill --meta-level 1 mill.scalalib.Dependency/showUpdates
[1657/1657] dev.run 
Found 3 dependency update for 
  net.sourceforge.htmlcleaner:htmlcleaner : 2.25 -> 2.26 -> 2.27 -> 2.28 -> 2.29
  com.lihaoyi:mill-contrib-buildinfo_2.13 : 0.11.2-6-261437 -> 0.11.2
  com.github.lolgab:mill-mima_mill0.11_2.13 : 0.0.23 -> 0.0.24
```

**Meta information about the build**

I also added a new external module `mill.runner.MillBuild` to get some meta-information about the project, for now, the meta-module count or frame count.

Here on a project with one meta-build:

```
$ mill show mill.runner.MillBuild/levelCount
3
```

Pull request: https://github.com/com-lihaoyi/mill/pull/2719