### PR TITLE
Fix conflicting dependencies between upstream `JavaModule`s

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -907,7 +907,7 @@ object scalanativelib extends MillStableScalaModule {
 }
 
 object bsp extends MillPublishScalaModule with BuildInfo {
-  def compileModuleDeps = Seq(scalalib) ++ scalalib.compileModuleDeps
+  def compileModuleDeps = Seq(scalalib)
   def testModuleDeps = super.testModuleDeps ++ compileModuleDeps
   def buildInfoPackageName = "mill.bsp"
 

--- a/build.sc
+++ b/build.sc
@@ -907,7 +907,7 @@ object scalanativelib extends MillStableScalaModule {
 }
 
 object bsp extends MillPublishScalaModule with BuildInfo {
-  def compileModuleDeps = Seq(scalalib)
+  def compileModuleDeps = Seq(scalalib) ++ scalalib.compileModuleDeps
   def testModuleDeps = super.testModuleDeps ++ compileModuleDeps
   def buildInfoPackageName = "mill.bsp"
 
@@ -934,7 +934,7 @@ object bsp extends MillPublishScalaModule with BuildInfo {
   }
 
   object worker extends MillPublishScalaModule {
-    def compileModuleDeps = Seq(bsp, scalalib, testrunner, runner)
+    def compileModuleDeps = Seq(bsp, scalalib, testrunner, runner) ++ scalalib.compileModuleDeps
     def ivyDeps = Agg(Deps.bsp4j, Deps.sbtTestInterface)
   }
 }

--- a/example/basic/4-builtin-commands/build.sc
+++ b/example/basic/4-builtin-commands/build.sc
@@ -129,9 +129,9 @@ Inputs:
 
 > ./mill show foo.compileClasspath
 [
-  ".../foo/compile-resources",
   ".../org/scala-lang/scala-library/2.13.11/scala-library-2.13.11.jar",
   ...
+  ".../foo/compile-resources"
 ]
 
 */
@@ -150,9 +150,9 @@ Inputs:
     ".../foo/src"
   ],
   "foo.compileClasspath": [
-    ".../foo/compile-resources",
     ".../org/scala-lang/scala-library/2.13.11/scala-library-2.13.11.jar",
     ...
+    ".../foo/compile-resources"
   ]
 }
 
@@ -171,9 +171,9 @@ Inputs:
     ".../foo/src"
   ],
   "foo.compileClasspath": [
-    ".../foo/compile-resources",
     ".../org/scala-lang/scala-library/2.13.11/scala-library-2.13.11.jar",
     ...
+    ".../foo/compile-resources"
   ]
 }
 

--- a/example/cross/10-static-blog/build.sc
+++ b/example/cross/10-static-blog/build.sc
@@ -3,7 +3,7 @@
 // libraries - Commonmark and Scalatags - to deal with Markdown parsing and
 // HTML generation respectively:
 
-import $ivy.`com.lihaoyi::scalatags:0.9.1`, scalatags.Text.all._
+import $ivy.`com.lihaoyi::scalatags:0.12.0`, scalatags.Text.all._
 import $ivy.`com.atlassian.commonmark:commonmark:0.13.1`
 import org.commonmark.parser.Parser
 import org.commonmark.renderer.html.HtmlRenderer

--- a/example/misc/3-import-file-ivy/build.sc
+++ b/example/misc/3-import-file-ivy/build.sc
@@ -1,5 +1,5 @@
 import mill._, scalalib._
-import $ivy.`com.lihaoyi::scalatags:0.8.2`, scalatags.Text.all._
+import $ivy.`com.lihaoyi::scalatags:0.12.0`, scalatags.Text.all._
 import $file.scalaversion, scalaversion.myScalaVersion
 
 object foo extends RootModule with ScalaModule {

--- a/example/misc/4-mill-build-folder/build.sc
+++ b/example/misc/4-mill-build-folder/build.sc
@@ -52,14 +52,14 @@ compiling 1 Scala source...
 
 > ./mill run
 Foo.value: <h1>hello</h1>
-scalatagsVersion: 0.8.2
+scalatagsVersion: 0.12.0
 
 > ./mill show assembly
 ".../out/assembly.dest/out.jar"
 
 > ./out/assembly.dest/out.jar # mac/linux
 Foo.value: <h1>hello</h1>
-scalatagsVersion: 0.8.2
+scalatagsVersion: 0.12.0
 
 */
 

--- a/example/misc/4-mill-build-folder/mill-build/build.sc
+++ b/example/misc/4-mill-build-folder/mill-build/build.sc
@@ -1,7 +1,7 @@
 import mill._, scalalib._
 
 object millbuild extends MillBuildRootModule{
-  val scalatagsVersion = "0.8.2"
+  val scalatagsVersion = "0.12.0"
   def ivyDeps = Agg(ivy"com.lihaoyi::scalatags:$scalatagsVersion")
 
   def generatedSources = T {

--- a/example/thirdparty/jimfs/build.sc
+++ b/example/thirdparty/jimfs/build.sc
@@ -1,7 +1,7 @@
 import mill._, scalalib._, publish._
 
-trait JimFsModule extends JavaModule{
-  def compileIvyDeps = Agg(
+def sharedCompileIvyDeps = T{
+  Agg(
     ivy"com.google.auto.service:auto-service:1.0.1",
     ivy"com.google.code.findbugs:jsr305:3.0.2",
     ivy"org.checkerframework:checker-compat-qual:2.5.5",
@@ -9,7 +9,8 @@ trait JimFsModule extends JavaModule{
   )
 }
 
-object jimfs extends PublishModule with MavenModule with JimFsModule{
+
+object jimfs extends PublishModule with MavenModule {
   def publishVersion = "1.3.3.7"
 
   def pomSettings = PomSettings(
@@ -21,14 +22,14 @@ object jimfs extends PublishModule with MavenModule with JimFsModule{
     developers = Nil
   )
 
-  def ivyDeps = super.ivyDeps() ++ Agg(
+  def ivyDeps = sharedCompileIvyDeps() ++ Agg(
     ivy"com.google.guava:guava:31.1-android",
   )
 
   def javacOptions = Seq("-processor", "com.google.auto.service.processor.AutoServiceProcessor")
 
-  object test extends MavenModuleTests with JimFsModule{
-    def ivyDeps = super.ivyDeps() ++ Agg(
+  object test extends MavenModuleTests {
+    def ivyDeps = sharedCompileIvyDeps() ++ Agg(
       ivy"junit:junit:4.13.2",
       ivy"com.google.guava:guava-testlib:31.1-android",
       ivy"com.google.truth:truth:1.1.3",

--- a/example/thirdparty/jimfs/build.sc
+++ b/example/thirdparty/jimfs/build.sc
@@ -1,6 +1,15 @@
 import mill._, scalalib._, publish._
 
-object jimfs extends PublishModule with MavenModule{
+trait JimFsModule extends JavaModule{
+  def compileIvyDeps = Agg(
+    ivy"com.google.auto.service:auto-service:1.0.1",
+    ivy"com.google.code.findbugs:jsr305:3.0.2",
+    ivy"org.checkerframework:checker-compat-qual:2.5.5",
+    ivy"com.ibm.icu:icu4j:73.1",
+  )
+}
+
+object jimfs extends PublishModule with MavenModule with JimFsModule{
   def publishVersion = "1.3.3.7"
 
   def pomSettings = PomSettings(
@@ -12,21 +21,14 @@ object jimfs extends PublishModule with MavenModule{
     developers = Nil
   )
 
-  def ivyDeps = Agg(
+  def ivyDeps = super.ivyDeps() ++ Agg(
     ivy"com.google.guava:guava:31.1-android",
-  )
-
-  def compileIvyDeps = Agg(
-    ivy"com.google.auto.service:auto-service:1.0.1",
-    ivy"com.google.code.findbugs:jsr305:3.0.2",
-    ivy"org.checkerframework:checker-compat-qual:2.5.5",
-    ivy"com.ibm.icu:icu4j:73.1",
   )
 
   def javacOptions = Seq("-processor", "com.google.auto.service.processor.AutoServiceProcessor")
 
-  object test extends MavenModuleTests{
-    def ivyDeps = Agg(
+  object test extends MavenModuleTests with JimFsModule{
+    def ivyDeps = super.ivyDeps() ++ Agg(
       ivy"junit:junit:4.13.2",
       ivy"com.google.guava:guava-testlib:31.1-android",
       ivy"com.google.truth:truth:1.1.3",

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -413,7 +413,7 @@ trait JavaModule
    * assembly, but without this module's contribution
    */
   def upstreamAssemblyClasspath: T[Agg[PathRef]] = T {
-    resolvedRunIvyDeps() ++ transitiveLocalClasspath() ++ unmanagedClasspath()
+    resolvedRunIvyDeps() ++ transitiveLocalClasspath()
   }
 
   def resolvedRunIvyDeps: T[Agg[PathRef]] = T {

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -427,7 +427,7 @@ trait JavaModule
    * necessary to run this module's code after compilation
    */
   def runClasspath: T[Seq[PathRef]] = T {
-    resolvedRunIvyDeps() ++ transitiveLocalClasspath() ++ localClasspath()
+    resolvedRunIvyDeps().toSeq ++ transitiveLocalClasspath() ++ localClasspath()
   }
 
   /**

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -369,7 +369,7 @@ trait JavaModule
   @internal
   def bspLocalClasspath: T[Agg[UnresolvedPath]] = T {
     (compileResources() ++ resources()).map(p => UnresolvedPath.ResolvedPath(p.path)) ++
-    Agg(bspCompileClassesPath())
+      Agg(bspCompileClassesPath())
   }
 
   /**
@@ -402,7 +402,7 @@ trait JavaModule
    * Resolved dependencies based on [[transitiveIvyDeps]] and [[transitiveCompileIvyDeps]].
    */
   def resolvedIvyDeps: T[Agg[PathRef]] = T {
-    resolveDeps(T.task {transitiveCompileIvyDeps() ++ transitiveIvyDeps()})()
+    resolveDeps(T.task { transitiveCompileIvyDeps() ++ transitiveIvyDeps() })()
   }
 
   /**
@@ -414,7 +414,7 @@ trait JavaModule
   }
 
   def resolvedRunIvyDeps: T[Agg[PathRef]] = T {
-    resolveDeps(T.task {runIvyDeps().map(bindDependency()) ++ transitiveIvyDeps()})()
+    resolveDeps(T.task { runIvyDeps().map(bindDependency()) ++ transitiveIvyDeps() })()
   }
 
   /**

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -154,9 +154,8 @@ trait JavaModule
   /** The compile-only transitive ivy dependencies of this module and all it's upstream compile-only modules. */
   def transitiveCompileIvyDeps: T[Agg[BoundDep]] = T {
     // We never include compile-only dependencies transitively, but we must include normal transitive dependencies!
-    compileIvyDeps().map(bindDependency()) ++ T
-      .traverse(compileModuleDeps)(_.transitiveIvyDeps)()
-      .flatten
+    compileIvyDeps().map(bindDependency()) ++
+      T.traverse(compileModuleDeps)(_.transitiveIvyDeps)().flatten
   }
 
   /**
@@ -380,7 +379,7 @@ trait JavaModule
    */
   // Keep in sync with [[bspCompileClasspath]]
   def compileClasspath: T[Agg[PathRef]] = T {
-    transitiveCompileClasspath() ++ localCompileClasspath() ++ resolvedIvyDeps()
+    resolvedIvyDeps() ++ transitiveCompileClasspath() ++ localCompileClasspath()
   }
 
   /**
@@ -414,9 +413,7 @@ trait JavaModule
    * assembly, but without this module's contribution
    */
   def upstreamAssemblyClasspath: T[Agg[PathRef]] = T {
-    transitiveLocalClasspath() ++
-      unmanagedClasspath() ++
-      resolvedRunIvyDeps()
+    resolvedRunIvyDeps() ++ transitiveLocalClasspath() ++ unmanagedClasspath()
   }
 
   def resolvedRunIvyDeps: T[Agg[PathRef]] = T {
@@ -430,9 +427,7 @@ trait JavaModule
    * necessary to run this module's code after compilation
    */
   def runClasspath: T[Seq[PathRef]] = T {
-    transitiveLocalClasspath() ++
-      localClasspath() ++
-      resolvedRunIvyDeps()
+    resolvedRunIvyDeps() ++ transitiveLocalClasspath() ++ localClasspath()
   }
 
   /**

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -368,9 +368,8 @@ trait JavaModule
    */
   @internal
   def bspLocalClasspath: T[Agg[UnresolvedPath]] = T {
-    (compileResources() ++ resources()).map(p => UnresolvedPath.ResolvedPath(p.path)) ++ Agg(
-      bspCompileClassesPath()
-    )
+    (compileResources() ++ resources()).map(p => UnresolvedPath.ResolvedPath(p.path)) ++
+    Agg(bspCompileClassesPath())
   }
 
   /**
@@ -403,9 +402,7 @@ trait JavaModule
    * Resolved dependencies based on [[transitiveIvyDeps]] and [[transitiveCompileIvyDeps]].
    */
   def resolvedIvyDeps: T[Agg[PathRef]] = T {
-    resolveDeps(T.task {
-      compileIvyDeps().map(bindDependency()) ++ transitiveIvyDeps()
-    })()
+    resolveDeps(T.task {transitiveCompileIvyDeps() ++ transitiveIvyDeps()})()
   }
 
   /**
@@ -417,9 +414,7 @@ trait JavaModule
   }
 
   def resolvedRunIvyDeps: T[Agg[PathRef]] = T {
-    resolveDeps(T.task {
-      runIvyDeps().map(bindDependency()) ++ transitiveIvyDeps()
-    })()
+    resolveDeps(T.task {runIvyDeps().map(bindDependency()) ++ transitiveIvyDeps()})()
   }
 
   /**
@@ -472,10 +467,7 @@ trait JavaModule
    * without those from upstream modules and dependencies
    */
   def jar: T[PathRef] = T {
-    Jvm.createJar(
-      localClasspath().map(_.path).filter(os.exists),
-      manifest()
-    )
+    Jvm.createJar(localClasspath().map(_.path).filter(os.exists), manifest())
   }
 
   /**

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -404,7 +404,7 @@ trait JavaModule
    */
   def resolvedIvyDeps: T[Agg[PathRef]] = T {
     resolveDeps(T.task {
-      transitiveCompileIvyDeps() ++ transitiveIvyDeps()
+      compileIvyDeps().map(bindDependency()) ++ transitiveIvyDeps()
     })()
   }
 

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -430,8 +430,9 @@ trait JavaModule
    * necessary to run this module's code after compilation
    */
   def runClasspath: T[Seq[PathRef]] = T {
-    localClasspath() ++
-      upstreamAssemblyClasspath()
+    transitiveLocalClasspath() ++
+      localClasspath() ++
+      resolvedRunIvyDeps()
   }
 
   /**

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -191,7 +191,7 @@ trait JavaModule
    */
   def transitiveIvyDeps: T[Agg[BoundDep]] = T {
     (ivyDeps() ++ mandatoryIvyDeps()).map(bindDependency()) ++
-    T.traverse(moduleDeps)(_.transitiveIvyDeps)().flatten
+      T.traverse(moduleDeps)(_.transitiveIvyDeps)().flatten
   }
 
   /**
@@ -221,8 +221,8 @@ trait JavaModule
    * The transitive version of `compileClasspath`
    */
   def transitiveCompileClasspath: T[Agg[PathRef]] = T {
-    T.traverse(transitiveModuleCompileModuleDeps)(
-      m => T.task { m.localCompileClasspath() ++ Agg(m.compile().classes) }
+    T.traverse(transitiveModuleCompileModuleDeps)(m =>
+      T.task { m.localCompileClasspath() ++ Agg(m.compile().classes) }
     )().flatten
   }
 
@@ -377,7 +377,7 @@ trait JavaModule
    */
   // Keep in sync with [[bspCompileClasspath]]
   def compileClasspath: T[Agg[PathRef]] = T {
-    transitiveCompileClasspath() ++ localCompileClasspath()  ++ resolvedIvyDeps()
+    transitiveCompileClasspath() ++ localCompileClasspath() ++ resolvedIvyDeps()
   }
 
   /**

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -143,6 +143,9 @@ trait JavaModule
    * All direct and indirect module dependencies of this module, including
    * compile-only dependencies: basically the modules whose classpath are needed
    * at compile-time.
+   *
+   * Note that `compileModuleDeps` are defined to be non-transitive, so we only
+   * look at the direct `compileModuleDeps` when assembling this list
    */
   def transitiveModuleCompileModuleDeps: Seq[JavaModule] = {
     (moduleDeps ++ compileModuleDeps).flatMap(_.transitiveModuleDeps).distinct

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -205,7 +205,7 @@ trait JavaModule
    * The transitive version of `localClasspath`
    */
   def transitiveLocalClasspath: T[Agg[PathRef]] = T {
-    T.traverse(transitiveModuleCompileModuleDeps)(m => m.localClasspath)().flatten
+    T.traverse(transitiveModuleCompileModuleDeps)(_.localClasspath)().flatten
   }
 
   /**
@@ -214,7 +214,7 @@ trait JavaModule
   // Keep in sync with [[transitiveLocalClasspath]]
   @internal
   def bspTransitiveLocalClasspath: T[Agg[UnresolvedPath]] = T {
-    T.traverse(transitiveModuleCompileModuleDeps)(m => m.bspLocalClasspath)().flatten
+    T.traverse(transitiveModuleCompileModuleDeps)(_.bspLocalClasspath)().flatten
   }
 
   /**

--- a/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
+++ b/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
@@ -1447,10 +1447,12 @@ object HelloWorldTests extends TestSuite {
             "MultiModuleClasspaths/ModMod/bar/unmanaged",
             "MultiModuleClasspaths/ModMod/bar/resources",
             "multiModuleClasspaths/modMod/ModMod/bar/compile.dest/classes",
+            //
             "MultiModuleClasspaths/ModMod/foo/compile-resources",
             "MultiModuleClasspaths/ModMod/foo/unmanaged",
             "MultiModuleClasspaths/ModMod/foo/resources",
             "multiModuleClasspaths/modMod/ModMod/foo/compile.dest/classes",
+            //
             "MultiModuleClasspaths/ModMod/qux/compile-resources",
             "MultiModuleClasspaths/ModMod/qux/unmanaged",
             "MultiModuleClasspaths/ModMod/qux/resources",
@@ -1475,6 +1477,8 @@ object HelloWorldTests extends TestSuite {
             //
             "MultiModuleClasspaths/ModMod/qux/compile-resources",
             "MultiModuleClasspaths/ModMod/qux/unmanaged"
+            // We do not include `qux/compile.dest/classes` here, because this is the input
+            // that is required to compile `qux` in the first place
           )
         )
 

--- a/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
+++ b/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
@@ -1417,7 +1417,7 @@ object HelloWorldTests extends TestSuite {
         }
 
         val simplerRunClasspath = simplify(runClasspath)
-        val simplerCompileClasspath = simplify(compileClasspath)
+        val simplerCompileClasspath = simplify(compileClasspath.toSeq)
         val simplerLocalClasspath = simplify(localClasspath)
 
         assert(expectedRunClasspath == simplerRunClasspath)

--- a/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
+++ b/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
@@ -1519,7 +1519,6 @@ object HelloWorldTests extends TestSuite {
           ),
           expectedCompileClasspath = List(
             "com/lihaoyi/geny_2.13/0.4.0/geny_2.13-0.4.0.jar",
-            // We aggregate upstream module `compileIvyDeps` during compilation
             "com/lihaoyi/sourcecode_2.13/0.2.0/sourcecode_2.13-0.2.0.jar",
             //
             "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",

--- a/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
+++ b/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
@@ -1519,8 +1519,10 @@ object HelloWorldTests extends TestSuite {
           ),
           expectedCompileClasspath = List(
             "com/lihaoyi/geny_2.13/0.4.0/geny_2.13-0.4.0.jar",
-            // `sourcecode` is a `compileIvyDeps`, which still get picked up
-            // transitively.
+            // `sourcecode` is a `ivyDeps` from a `compileModuleDeps, which still
+            // gets picked up transitively, but only for compilation. This is necessary
+            // in order to make sure that we can correctly compile against the upstream
+            // module's classes.
             "com/lihaoyi/sourcecode_2.13/0.2.2/sourcecode_2.13-0.2.2.jar",
             //
             "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",

--- a/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
+++ b/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
@@ -329,31 +329,30 @@ object HelloWorldTests extends TestSuite {
     def checkedTuplePathRef: T[Tuple1[PathRef]] = T { Tuple1(mkDirWithFile().withRevalidateOnce) }
   }
 
-
   object MultiModuleClasspaths extends HelloBase {
-    trait FooModule extends ScalaModule{
+    trait FooModule extends ScalaModule {
       def scalaVersion = "2.13.12"
 
       def ivyDeps = Agg(ivy"com.lihaoyi::sourcecode:0.2.4")
       def compileIvyDeps = Agg(ivy"com.lihaoyi::geny:0.6.8")
       def runIvyDeps = Agg(ivy"com.lihaoyi::utest:0.7.4")
-      def unmanagedClasspath = T{ Agg(PathRef(millSourcePath / "unmanaged")) }
+      def unmanagedClasspath = T { Agg(PathRef(millSourcePath / "unmanaged")) }
     }
-    trait BarModule extends ScalaModule{
+    trait BarModule extends ScalaModule {
       def scalaVersion = "2.13.12"
 
       def ivyDeps = Agg(ivy"com.lihaoyi::sourcecode:0.2.2")
       def compileIvyDeps = Agg(ivy"com.lihaoyi::geny:0.6.5")
       def runIvyDeps = Agg(ivy"com.lihaoyi::utest:0.7.1")
-      def unmanagedClasspath = T{ Agg(PathRef(millSourcePath / "unmanaged")) }
+      def unmanagedClasspath = T { Agg(PathRef(millSourcePath / "unmanaged")) }
     }
-    trait QuxModule extends ScalaModule{
+    trait QuxModule extends ScalaModule {
       def scalaVersion = "2.13.12"
 
       def ivyDeps = Agg(ivy"com.lihaoyi::sourcecode:0.2.0")
       def compileIvyDeps = Agg(ivy"com.lihaoyi::geny:0.6.4")
       def runIvyDeps = Agg(ivy"com.lihaoyi::utest:0.7.0")
-      def unmanagedClasspath = T{ Agg(PathRef(millSourcePath / "unmanaged")) }
+      def unmanagedClasspath = T { Agg(PathRef(millSourcePath / "unmanaged")) }
     }
     object ModMod extends Module {
       object foo extends FooModule
@@ -1400,10 +1399,12 @@ object HelloWorldTests extends TestSuite {
     "multiModuleClasspaths" - {
       // Make sure that a bunch of modules dependent on each other has their various
       // {classpaths,moduleDeps,ivyDeps}x{run,compile,normal} properly aggregated
-      def check(eval: TestEvaluator,
-                mod: ScalaModule,
-                expectedRunClasspath: Seq[String],
-                expectedCompileClasspath: Seq[String]) = {
+      def check(
+          eval: TestEvaluator,
+          mod: ScalaModule,
+          expectedRunClasspath: Seq[String],
+          expectedCompileClasspath: Seq[String]
+      ) = {
         val Right((runClasspath, _)) = eval.apply(mod.runClasspath)
         val Right((compileClasspath, _)) = eval.apply(mod.compileClasspath)
         val Right((upstreamAssemblyClasspath, _)) = eval.apply(mod.upstreamAssemblyClasspath)
@@ -1436,10 +1437,12 @@ object HelloWorldTests extends TestSuite {
             // We pick up the newest version of sourcecode 0.2.4 from the upstream module, because
             // sourcecode is a `ivyDeps` and `runIvyDeps` and those are picked up transitively
             "com/lihaoyi/sourcecode_2.13/0.2.4/sourcecode_2.13-0.2.4.jar",
+            //
             "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
             "org/scala-sbt/test-interface/1.0/test-interface-1.0.jar",
             "org/portable-scala/portable-scala-reflect_2.13/0.1.1/portable-scala-reflect_2.13-0.1.1.jar",
             "org/scala-lang/scala-reflect/2.13.12/scala-reflect-2.13.12.jar",
+            //
             "MultiModuleClasspaths/ModMod/bar/compile-resources",
             "MultiModuleClasspaths/ModMod/bar/unmanaged",
             "MultiModuleClasspaths/ModMod/bar/resources",
@@ -1459,7 +1462,9 @@ object HelloWorldTests extends TestSuite {
             // is not picked up transitively
             "com/lihaoyi/geny_2.13/0.6.4/geny_2.13-0.6.4.jar",
             "com/lihaoyi/sourcecode_2.13/0.2.4/sourcecode_2.13-0.2.4.jar",
+            //
             "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
+            //
             "MultiModuleClasspaths/ModMod/bar/compile-resources",
             "MultiModuleClasspaths/ModMod/bar/unmanaged",
             "multiModuleClasspaths/modMod/ModMod/bar/compile.dest/classes",
@@ -1481,18 +1486,22 @@ object HelloWorldTests extends TestSuite {
           expectedRunClasspath = List(
             "com/lihaoyi/utest_2.13/0.7.0/utest_2.13-0.7.0.jar",
             "com/lihaoyi/sourcecode_2.13/0.2.0/sourcecode_2.13-0.2.0.jar",
+            //
             "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
             "org/scala-sbt/test-interface/1.0/test-interface-1.0.jar",
             "org/portable-scala/portable-scala-reflect_2.13/0.1.0/portable-scala-reflect_2.13-0.1.0.jar",
             "org/scala-lang/scala-reflect/2.13.12/scala-reflect-2.13.12.jar",
+            //
             "MultiModuleClasspaths/ModCompile/bar/compile-resources",
             "MultiModuleClasspaths/ModCompile/bar/unmanaged",
             "MultiModuleClasspaths/ModCompile/bar/resources",
             "multiModuleClasspaths/modCompile/ModCompile/bar/compile.dest/classes",
+            //
             "MultiModuleClasspaths/ModCompile/foo/compile-resources",
             "MultiModuleClasspaths/ModCompile/foo/unmanaged",
             "MultiModuleClasspaths/ModCompile/foo/resources",
             "multiModuleClasspaths/modCompile/ModCompile/foo/compile.dest/classes",
+            //
             "MultiModuleClasspaths/ModCompile/qux/compile-resources",
             "MultiModuleClasspaths/ModCompile/qux/unmanaged",
             "MultiModuleClasspaths/ModCompile/qux/resources",
@@ -1501,13 +1510,17 @@ object HelloWorldTests extends TestSuite {
           expectedCompileClasspath = List(
             "com/lihaoyi/geny_2.13/0.6.4/geny_2.13-0.6.4.jar",
             "com/lihaoyi/sourcecode_2.13/0.2.4/sourcecode_2.13-0.2.4.jar",
+            //
             "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
+            //
             "MultiModuleClasspaths/ModCompile/bar/compile-resources",
             "MultiModuleClasspaths/ModCompile/bar/unmanaged",
             "multiModuleClasspaths/modCompile/ModCompile/bar/compile.dest/classes",
+            //
             "MultiModuleClasspaths/ModCompile/foo/compile-resources",
             "MultiModuleClasspaths/ModCompile/foo/unmanaged",
             "multiModuleClasspaths/modCompile/ModCompile/foo/compile.dest/classes",
+            //
             "MultiModuleClasspaths/ModCompile/qux/compile-resources",
             "MultiModuleClasspaths/ModCompile/qux/unmanaged"
           )
@@ -1525,14 +1538,17 @@ object HelloWorldTests extends TestSuite {
           expectedRunClasspath = List(
             "com/lihaoyi/utest_2.13/0.7.0/utest_2.13-0.7.0.jar",
             "com/lihaoyi/sourcecode_2.13/0.2.2/sourcecode_2.13-0.2.2.jar",
+            //
             "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
             "org/scala-sbt/test-interface/1.0/test-interface-1.0.jar",
             "org/portable-scala/portable-scala-reflect_2.13/0.1.0/portable-scala-reflect_2.13-0.1.0.jar",
             "org/scala-lang/scala-reflect/2.13.12/scala-reflect-2.13.12.jar",
+            //
             "MultiModuleClasspaths/CompileMod/bar/compile-resources",
             "MultiModuleClasspaths/CompileMod/bar/unmanaged",
             "MultiModuleClasspaths/CompileMod/bar/resources",
             "multiModuleClasspaths/compileMod/CompileMod/bar/compile.dest/classes",
+            //
             "MultiModuleClasspaths/CompileMod/qux/compile-resources",
             "MultiModuleClasspaths/CompileMod/qux/unmanaged",
             "MultiModuleClasspaths/CompileMod/qux/resources",
@@ -1541,10 +1557,13 @@ object HelloWorldTests extends TestSuite {
           expectedCompileClasspath = List(
             "com/lihaoyi/geny_2.13/0.6.4/geny_2.13-0.6.4.jar",
             "com/lihaoyi/sourcecode_2.13/0.2.2/sourcecode_2.13-0.2.2.jar",
+            //
             "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
+            //
             "MultiModuleClasspaths/CompileMod/bar/compile-resources",
             "MultiModuleClasspaths/CompileMod/bar/unmanaged",
             "multiModuleClasspaths/compileMod/CompileMod/bar/compile.dest/classes",
+            //
             "MultiModuleClasspaths/CompileMod/qux/compile-resources",
             "MultiModuleClasspaths/CompileMod/qux/unmanaged"
           )

--- a/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
+++ b/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
@@ -1519,7 +1519,9 @@ object HelloWorldTests extends TestSuite {
           ),
           expectedCompileClasspath = List(
             "com/lihaoyi/geny_2.13/0.4.0/geny_2.13-0.4.0.jar",
-            "com/lihaoyi/sourcecode_2.13/0.2.0/sourcecode_2.13-0.2.0.jar",
+            // `sourcecode` is a `compileIvyDeps`, which still get picked up
+            // transitively.
+            "com/lihaoyi/sourcecode_2.13/0.2.2/sourcecode_2.13-0.2.2.jar",
             //
             "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
             //

--- a/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
+++ b/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
@@ -1594,6 +1594,8 @@ object HelloWorldTests extends TestSuite {
             "com/lihaoyi/sourcecode_2.13/0.2.1/sourcecode_2.13-0.2.1.jar",
             //
             "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
+            // We do not include `foo`s compile output here, because `foo` is a
+            // `compileModuleDep` of `bar`, and `compileModuleDep`s are non-transitive
             //
             "MultiModuleClasspaths/CompileMod/bar/compile-resources",
             "MultiModuleClasspaths/CompileMod/bar/unmanaged",

--- a/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
+++ b/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
@@ -335,8 +335,8 @@ object HelloWorldTests extends TestSuite {
       def scalaVersion = "2.13.12"
 
       def ivyDeps = Agg(ivy"com.lihaoyi::sourcecode:0.2.4")
-      def compileIvyDeps = Agg(ivy"com.lihaoyi::geny:0.6.4")
-      def runIvyDeps = Agg(ivy"com.lihaoyi::utest:0.7.0")
+      def compileIvyDeps = Agg(ivy"com.lihaoyi::geny:0.6.8")
+      def runIvyDeps = Agg(ivy"com.lihaoyi::utest:0.7.4")
       def unmanagedClasspath = T{ Agg(PathRef(millSourcePath / "unmanaged")) }
     }
     trait BarModule extends ScalaModule{
@@ -351,8 +351,8 @@ object HelloWorldTests extends TestSuite {
       def scalaVersion = "2.13.12"
 
       def ivyDeps = Agg(ivy"com.lihaoyi::sourcecode:0.2.0")
-      def compileIvyDeps = Agg(ivy"com.lihaoyi::geny:0.6.8")
-      def runIvyDeps = Agg(ivy"com.lihaoyi::utest:0.7.4")
+      def compileIvyDeps = Agg(ivy"com.lihaoyi::geny:0.6.4")
+      def runIvyDeps = Agg(ivy"com.lihaoyi::utest:0.7.0")
       def unmanagedClasspath = T{ Agg(PathRef(millSourcePath / "unmanaged")) }
     }
     object ModMod extends Module {
@@ -1430,7 +1430,11 @@ object HelloWorldTests extends TestSuite {
           eval,
           MultiModuleClasspaths.ModMod.qux,
           expectedRunClasspath = List(
-            "com/lihaoyi/utest_2.13/0.7.4/utest_2.13-0.7.4.jar",
+            // We pick up the oldest version of utest 0.7.0 from the current module, because
+            // utest is a `runIvyDeps` and not picked up transitively
+            "com/lihaoyi/utest_2.13/0.7.4/utest_2.13-0.7.0.jar",
+            // We pick up the newest version of sourcecode 0.2.4 from the upstream module, because
+            // sourcecode is a `ivyDeps` and `runIvyDeps` and those are picked up transitively
             "com/lihaoyi/sourcecode_2.13/0.2.4/sourcecode_2.13-0.2.4.jar",
             "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
             "org/scala-sbt/test-interface/1.0/test-interface-1.0.jar",
@@ -1450,7 +1454,10 @@ object HelloWorldTests extends TestSuite {
             "multiModuleClasspaths/modMod/ModMod/qux/compile.dest/classes"
           ),
           expectedCompileClasspath = List(
-            "com/lihaoyi/geny_2.13/0.6.8/geny_2.13-0.6.8.jar",
+            // Make sure we only have geny 0.6.4 from the current module, and not newer
+            // versions pulled in by the upstream modules, because as `compileIvyDeps` it
+            // is not picked up transitively
+            "com/lihaoyi/geny_2.13/0.6.4/geny_2.13-0.6.4.jar",
             "com/lihaoyi/sourcecode_2.13/0.2.4/sourcecode_2.13-0.2.4.jar",
             "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
             "MultiModuleClasspaths/ModMod/bar/compile-resources",
@@ -1472,11 +1479,11 @@ object HelloWorldTests extends TestSuite {
           eval,
           MultiModuleClasspaths.ModCompile.qux,
           expectedRunClasspath = List(
-            "com/lihaoyi/utest_2.13/0.7.4/utest_2.13-0.7.4.jar",
+            "com/lihaoyi/utest_2.13/0.7.0/utest_2.13-0.7.0.jar",
             "com/lihaoyi/sourcecode_2.13/0.2.0/sourcecode_2.13-0.2.0.jar",
             "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
             "org/scala-sbt/test-interface/1.0/test-interface-1.0.jar",
-            "org/portable-scala/portable-scala-reflect_2.13/0.1.1/portable-scala-reflect_2.13-0.1.1.jar",
+            "org/portable-scala/portable-scala-reflect_2.13/0.1.0/portable-scala-reflect_2.13-0.1.0.jar",
             "org/scala-lang/scala-reflect/2.13.12/scala-reflect-2.13.12.jar",
             "MultiModuleClasspaths/ModCompile/bar/compile-resources",
             "MultiModuleClasspaths/ModCompile/bar/unmanaged",
@@ -1492,7 +1499,7 @@ object HelloWorldTests extends TestSuite {
             "multiModuleClasspaths/modCompile/ModCompile/qux/compile.dest/classes"
           ),
           expectedCompileClasspath = List(
-            "com/lihaoyi/geny_2.13/0.6.8/geny_2.13-0.6.8.jar",
+            "com/lihaoyi/geny_2.13/0.6.4/geny_2.13-0.6.4.jar",
             "com/lihaoyi/sourcecode_2.13/0.2.4/sourcecode_2.13-0.2.4.jar",
             "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
             "MultiModuleClasspaths/ModCompile/bar/compile-resources",
@@ -1516,11 +1523,11 @@ object HelloWorldTests extends TestSuite {
           eval,
           MultiModuleClasspaths.CompileMod.qux,
           expectedRunClasspath = List(
-            "com/lihaoyi/utest_2.13/0.7.4/utest_2.13-0.7.4.jar",
+            "com/lihaoyi/utest_2.13/0.7.0/utest_2.13-0.7.0.jar",
             "com/lihaoyi/sourcecode_2.13/0.2.2/sourcecode_2.13-0.2.2.jar",
             "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
             "org/scala-sbt/test-interface/1.0/test-interface-1.0.jar",
-            "org/portable-scala/portable-scala-reflect_2.13/0.1.1/portable-scala-reflect_2.13-0.1.1.jar",
+            "org/portable-scala/portable-scala-reflect_2.13/0.1.0/portable-scala-reflect_2.13-0.1.0.jar",
             "org/scala-lang/scala-reflect/2.13.12/scala-reflect-2.13.12.jar",
             "MultiModuleClasspaths/CompileMod/bar/compile-resources",
             "MultiModuleClasspaths/CompileMod/bar/unmanaged",
@@ -1532,7 +1539,7 @@ object HelloWorldTests extends TestSuite {
             "multiModuleClasspaths/compileMod/CompileMod/qux/compile.dest/classes"
           ),
           expectedCompileClasspath = List(
-            "com/lihaoyi/geny_2.13/0.6.8/geny_2.13-0.6.8.jar",
+            "com/lihaoyi/geny_2.13/0.6.4/geny_2.13-0.6.4.jar",
             "com/lihaoyi/sourcecode_2.13/0.2.2/sourcecode_2.13-0.2.2.jar",
             "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
             "MultiModuleClasspaths/CompileMod/bar/compile-resources",

--- a/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
+++ b/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
@@ -1520,7 +1520,7 @@ object HelloWorldTests extends TestSuite {
           expectedCompileClasspath = List(
             "com/lihaoyi/geny_2.13/0.4.0/geny_2.13-0.4.0.jar",
             // We aggregate upstream module `compileIvyDeps` during compilation
-            "com/lihaoyi/sourcecode_2.13/0.2.2/sourcecode_2.13-0.2.2.jar",
+            "com/lihaoyi/sourcecode_2.13/0.2.0/sourcecode_2.13-0.2.0.jar",
             //
             "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
             //

--- a/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
+++ b/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
@@ -333,16 +333,16 @@ object HelloWorldTests extends TestSuite {
     trait FooModule extends ScalaModule {
       def scalaVersion = "2.13.12"
 
-      def ivyDeps = Agg(ivy"com.lihaoyi::sourcecode:0.2.4")
-      def compileIvyDeps = Agg(ivy"com.lihaoyi::geny:0.6.8")
-      def runIvyDeps = Agg(ivy"com.lihaoyi::utest:0.7.4")
+      def ivyDeps = Agg(ivy"com.lihaoyi::sourcecode:0.2.2")
+      def compileIvyDeps = Agg(ivy"com.lihaoyi::geny:0.4.2")
+      def runIvyDeps = Agg(ivy"com.lihaoyi::utest:0.7.2")
       def unmanagedClasspath = T { Agg(PathRef(millSourcePath / "unmanaged")) }
     }
     trait BarModule extends ScalaModule {
       def scalaVersion = "2.13.12"
 
-      def ivyDeps = Agg(ivy"com.lihaoyi::sourcecode:0.2.2")
-      def compileIvyDeps = Agg(ivy"com.lihaoyi::geny:0.6.5")
+      def ivyDeps = Agg(ivy"com.lihaoyi::sourcecode:0.2.1")
+      def compileIvyDeps = Agg(ivy"com.lihaoyi::geny:0.4.1")
       def runIvyDeps = Agg(ivy"com.lihaoyi::utest:0.7.1")
       def unmanagedClasspath = T { Agg(PathRef(millSourcePath / "unmanaged")) }
     }
@@ -350,7 +350,7 @@ object HelloWorldTests extends TestSuite {
       def scalaVersion = "2.13.12"
 
       def ivyDeps = Agg(ivy"com.lihaoyi::sourcecode:0.2.0")
-      def compileIvyDeps = Agg(ivy"com.lihaoyi::geny:0.6.4")
+      def compileIvyDeps = Agg(ivy"com.lihaoyi::geny:0.4.0")
       def runIvyDeps = Agg(ivy"com.lihaoyi::utest:0.7.0")
       def unmanagedClasspath = T { Agg(PathRef(millSourcePath / "unmanaged")) }
     }
@@ -1433,14 +1433,14 @@ object HelloWorldTests extends TestSuite {
           expectedRunClasspath = List(
             // We pick up the oldest version of utest 0.7.0 from the current module, because
             // utest is a `runIvyDeps` and not picked up transitively
-            "com/lihaoyi/utest_2.13/0.7.4/utest_2.13-0.7.0.jar",
+            "com/lihaoyi/utest_2.13/0.7.0/utest_2.13-0.7.0.jar",
             // We pick up the newest version of sourcecode 0.2.4 from the upstream module, because
             // sourcecode is a `ivyDeps` and `runIvyDeps` and those are picked up transitively
-            "com/lihaoyi/sourcecode_2.13/0.2.4/sourcecode_2.13-0.2.4.jar",
+            "com/lihaoyi/sourcecode_2.13/0.2.2/sourcecode_2.13-0.2.2.jar",
             //
             "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
             "org/scala-sbt/test-interface/1.0/test-interface-1.0.jar",
-            "org/portable-scala/portable-scala-reflect_2.13/0.1.1/portable-scala-reflect_2.13-0.1.1.jar",
+            "org/portable-scala/portable-scala-reflect_2.13/0.1.0/portable-scala-reflect_2.13-0.1.0.jar",
             "org/scala-lang/scala-reflect/2.13.12/scala-reflect-2.13.12.jar",
             //
             "MultiModuleClasspaths/ModMod/bar/compile-resources",
@@ -1460,17 +1460,19 @@ object HelloWorldTests extends TestSuite {
             // Make sure we only have geny 0.6.4 from the current module, and not newer
             // versions pulled in by the upstream modules, because as `compileIvyDeps` it
             // is not picked up transitively
-            "com/lihaoyi/geny_2.13/0.6.4/geny_2.13-0.6.4.jar",
-            "com/lihaoyi/sourcecode_2.13/0.2.4/sourcecode_2.13-0.2.4.jar",
+            "com/lihaoyi/geny_2.13/0.4.0/geny_2.13-0.4.0.jar",
+            "com/lihaoyi/sourcecode_2.13/0.2.2/sourcecode_2.13-0.2.2.jar",
             //
             "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
             //
             "MultiModuleClasspaths/ModMod/bar/compile-resources",
             "MultiModuleClasspaths/ModMod/bar/unmanaged",
             "multiModuleClasspaths/modMod/ModMod/bar/compile.dest/classes",
+            //
             "MultiModuleClasspaths/ModMod/foo/compile-resources",
             "MultiModuleClasspaths/ModMod/foo/unmanaged",
             "multiModuleClasspaths/modMod/ModMod/foo/compile.dest/classes",
+            //
             "MultiModuleClasspaths/ModMod/qux/compile-resources",
             "MultiModuleClasspaths/ModMod/qux/unmanaged"
           )
@@ -1478,13 +1480,17 @@ object HelloWorldTests extends TestSuite {
 
       }
       "modCompile" - workspaceTest(MultiModuleClasspaths) { eval =>
-        // Mostly the same as `modMod` above, but with a different version
-        // of `sourcecode` (0.2.0) because ???
+        // Mostly the same as `modMod` above, but with the dependency
+        // from `qux` to `bar` being a `compileModuleDeps`
         check(
           eval,
           MultiModuleClasspaths.ModCompile.qux,
           expectedRunClasspath = List(
+            // `utest` is a `runIvyDeps` and not picked up transitively
             "com/lihaoyi/utest_2.13/0.7.0/utest_2.13-0.7.0.jar",
+            // Because `sourcecode` comes from `ivyDeps`, and the dependency from
+            // `qux` to `bar` is a `compileModuleDeps`, we do not include its
+            // dependencies for `qux`'s `runClasspath`
             "com/lihaoyi/sourcecode_2.13/0.2.0/sourcecode_2.13-0.2.0.jar",
             //
             "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
@@ -1508,8 +1514,9 @@ object HelloWorldTests extends TestSuite {
             "multiModuleClasspaths/modCompile/ModCompile/qux/compile.dest/classes"
           ),
           expectedCompileClasspath = List(
-            "com/lihaoyi/geny_2.13/0.6.4/geny_2.13-0.6.4.jar",
-            "com/lihaoyi/sourcecode_2.13/0.2.4/sourcecode_2.13-0.2.4.jar",
+            "com/lihaoyi/geny_2.13/0.4.0/geny_2.13-0.4.0.jar",
+            // We aggregate upstream module `compileIvyDeps` during compilation
+            "com/lihaoyi/sourcecode_2.13/0.2.2/sourcecode_2.13-0.2.2.jar",
             //
             "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
             //
@@ -1537,7 +1544,11 @@ object HelloWorldTests extends TestSuite {
           MultiModuleClasspaths.CompileMod.qux,
           expectedRunClasspath = List(
             "com/lihaoyi/utest_2.13/0.7.0/utest_2.13-0.7.0.jar",
-            "com/lihaoyi/sourcecode_2.13/0.2.2/sourcecode_2.13-0.2.2.jar",
+            // We pick up the version of `sourcecode` from `ivyDeps` from `bar` because
+            // we have a normal `moduleDeps` from `qux` to `bar`, but do not pick it up
+            // from `foo` because it's a `compileIvyDeps` from `bar` to `foo` and
+            // `compileIvyDeps` are not transitive
+            "com/lihaoyi/sourcecode_2.13/0.2.1/sourcecode_2.13-0.2.1.jar",
             //
             "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
             "org/scala-sbt/test-interface/1.0/test-interface-1.0.jar",
@@ -1555,8 +1566,8 @@ object HelloWorldTests extends TestSuite {
             "multiModuleClasspaths/compileMod/CompileMod/qux/compile.dest/classes"
           ),
           expectedCompileClasspath = List(
-            "com/lihaoyi/geny_2.13/0.6.4/geny_2.13-0.6.4.jar",
-            "com/lihaoyi/sourcecode_2.13/0.2.2/sourcecode_2.13-0.2.2.jar",
+            "com/lihaoyi/geny_2.13/0.4.0/geny_2.13-0.4.0.jar",
+            "com/lihaoyi/sourcecode_2.13/0.2.1/sourcecode_2.13-0.2.1.jar",
             //
             "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
             //


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/2732

We introduce a new `localCompileClasspath`, which differs from `compileClasspath` in that it leaves out the `transitiveCompileClasspath` from upstream modules and `resolvedIvyDeps` from third party dependencies.

Also tried to do some cleanup of `JavaModule`, refactoring out a `transitiveModuleCompileModuleDeps` helper to DRY things up, re-arranging things so all the `fooModuleDeps` helpers are all together.

Tested via a new unit test `mill.scalalib.HelloWorldTests.multiModuleClasspaths`, which fails on master and passes on this PR. This test case asserts the overall "shape" of the classpaths, which should help rule out an entire class of mis-configuration w.r.t. how the classpaths are wired up