### PR TITLE
Fix the scala-library dependency for (generic) platform modules

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -364,14 +364,16 @@ trait MillPublishScalaModule extends MillScalaModule with MillPublishJavaModule
 /** Publishable module which contains strictly handled API. */
 trait MillStableScalaModule extends MillPublishScalaModule with Mima {
   import com.github.lolgab.mill.mima._
-  // MIMA doesn't properly ignore things which are nested inside other private things
-  // so we have to put explicit ignores here (https://github.com/lightbend/mima/issues/771)
   override def mimaBinaryIssueFilters: T[Seq[ProblemFilter]] = Seq(
+    // MIMA doesn't properly ignore things which are nested inside other private things
+    // so we have to put explicit ignores here (https://github.com/lightbend/mima/issues/771)
     ProblemFilter.exclude[Problem]("mill.eval.ProfileLogger*"),
     ProblemFilter.exclude[Problem]("mill.eval.GroupEvaluator*"),
     ProblemFilter.exclude[Problem]("mill.eval.Tarjans*"),
     ProblemFilter.exclude[Problem]("mill.define.Ctx#Impl*"),
-    ProblemFilter.exclude[Problem]("mill.resolve.ResolveNotFoundHandler*")
+    ProblemFilter.exclude[Problem]("mill.resolve.ResolveNotFoundHandler*"),
+    // See https://github.com/com-lihaoyi/mill/pull/2739
+    ProblemFilter.exclude[ReversedMissingMethodProblem]("mill.scalajslib.ScalaJSModule.mill$scalajslib$ScalaJSModule$$super$scalaLibraryIvyDeps")
   )
   def mimaPreviousVersions: T[Seq[String]] = Settings.mimaBaseVersions
 

--- a/scalalib/src/mill/scalalib/Dep.scala
+++ b/scalalib/src/mill/scalalib/Dep.scala
@@ -181,7 +181,7 @@ object CrossVersion {
     implicit def rw: RW[Full] = macroRW
   }
 
-  def empty(platformed: Boolean) = Constant(value = "", platformed)
+  def empty(platformed: Boolean): Constant = Constant(value = "", platformed)
 
   implicit def rw: RW[CrossVersion] = RW.merge(Constant.rw, Binary.rw, Full.rw)
 }

--- a/scalalib/src/mill/scalalib/Lib.scala
+++ b/scalalib/src/mill/scalalib/Lib.scala
@@ -114,13 +114,11 @@ object Lib {
   def scalaRuntimeIvyDeps(scalaOrganization: String, scalaVersion: String): Loose.Agg[Dep] =
     if (ZincWorkerUtil.isDotty(scalaVersion)) {
       Agg(
-        // note that dotty-library has a binary version suffix, hence the :: is necessary here
         ivy"$scalaOrganization::dotty-library:$scalaVersion".forceVersion()
       )
     } else if (ZincWorkerUtil.isScala3(scalaVersion))
       Agg(
-        // note that dotty-library has a binary version suffix, hence the :: is necessary here
-        ivy"$scalaOrganization::scala3-library::$scalaVersion".forceVersion()
+        ivy"$scalaOrganization::scala3-library:$scalaVersion".forceVersion()
       )
     else
       Agg(


### PR DESCRIPTION
In Scala 3 modules, that also define a platform, the scala library is not correctly resolved.
The current implementation exists merely as a convenience for JS and Native modules. `ScalaNativeModule` already handles a correct scala library by overriding `scalaLibraryIvyDeps`. This pull request overrides the same in `ScalaJSModule` and removed the faulty platfrom dependency from `ScalaModule`.

E.g. imagine, someone tries to build a Mill plugin with Scala 3 (which is currently not supported) and sets the platform to `_mill0.11`, then you would run into the following issue:

```scala
object root extends ScalaModule {
  override def scalaVersion = "3.3.0"
  override def platformSuffix = "_mill0.11"
  // ..
}
```

```
>> mill ivyDepsTree
1 targets failed
resolvedIvyDeps
Resolution failed for 1 modules:
--------------------------------------------
  org.scala-lang:scala3-library_mill0.11_3:3.3.0
	not found: /Users/me/ivy2/local/org.scala-lang/scala3-library_mill0.11_3/3.3.0/ivys/ivy.xml
	not found: https://repo1.maven.org/maven2/org/scala-lang/scala3-library_mill0.11_3/3.3.0/scala3-library_mill0.11_3-3.3.0.pom
```

* See also https://github.com/com-lihaoyi/mill/pull/1187#discussion_r1326540338