### PR TITLE
Try to fix console and .repl

### DIFF
--- a/main/api/src/mill/api/SystemStreams.scala
+++ b/main/api/src/mill/api/SystemStreams.scala
@@ -16,7 +16,7 @@ class SystemStreams(
 
 object SystemStreams {
 
-  private val original = new SystemStreams(System.out, System.err, System.in)
+  val original = new SystemStreams(System.out, System.err, System.in)
 
   /**
    * Used to check whether the system streams are all "original", i,e. they
@@ -31,8 +31,14 @@ object SystemStreams {
     (System.err eq original.err) &&
     (System.in eq original.in) &&
     (Console.out eq original.out) &&
-    (Console.err eq original.err) &&
-    (Console.in eq original.in)
+    (Console.err eq original.err)
+
+    // We do not check `Console.in` for equality, because `Console.withIn` always wraps
+    // `Console.in` in a `new BufferedReader` each time, and so it is impossible to check
+    // whether it is original or not. We just have to assume that it is kept in sync with
+    // `System.in`, which `withStreams` does ensure.
+    //
+    //(Console.in eq original.consoleIn)
   }
 
   /**

--- a/main/api/src/mill/api/SystemStreams.scala
+++ b/main/api/src/mill/api/SystemStreams.scala
@@ -38,7 +38,7 @@ object SystemStreams {
     // whether it is original or not. We just have to assume that it is kept in sync with
     // `System.in`, which `withStreams` does ensure.
     //
-    //(Console.in eq original.consoleIn)
+    // (Console.in eq original.consoleIn)
   }
 
   /**

--- a/main/util/src/mill/util/Jvm.scala
+++ b/main/util/src/mill/util/Jvm.scala
@@ -162,6 +162,8 @@ object Jvm extends CoursierSupport {
     // elsewhere
 
     if (!SystemStreams.isOriginal()) {
+      println("then")
+
       val process = os.proc(commandArgs).spawn(
         cwd = workingDir,
         env = envArgs,
@@ -187,6 +189,10 @@ object Jvm extends CoursierSupport {
 
       process
     } else {
+      println("else")
+      pprint.log(if (!background) os.Inherit else "")
+      pprint.log(if (!background) os.Inherit else workingDir / "stdout.log")
+      pprint.log(if (!background) os.Inherit else workingDir / "stderr.log")
       os.proc(commandArgs).spawn(
         cwd = workingDir,
         env = envArgs,

--- a/main/util/src/mill/util/Jvm.scala
+++ b/main/util/src/mill/util/Jvm.scala
@@ -190,6 +190,9 @@ object Jvm extends CoursierSupport {
       process
     } else {
       println("else")
+      pprint.log(commandArgs)
+      pprint.log(workingDir)
+      pprint.log(envArgs)
       pprint.log(if (!background) os.Inherit else "")
       pprint.log(if (!background) os.Inherit else workingDir / "stdout.log")
       pprint.log(if (!background) os.Inherit else workingDir / "stderr.log")

--- a/main/util/src/mill/util/Jvm.scala
+++ b/main/util/src/mill/util/Jvm.scala
@@ -162,8 +162,6 @@ object Jvm extends CoursierSupport {
     // elsewhere
 
     if (!SystemStreams.isOriginal()) {
-      println("then")
-
       val process = os.proc(commandArgs).spawn(
         cwd = workingDir,
         env = envArgs,
@@ -189,13 +187,6 @@ object Jvm extends CoursierSupport {
 
       process
     } else {
-      println("else")
-      pprint.log(commandArgs)
-      pprint.log(workingDir)
-      pprint.log(envArgs)
-      pprint.log(if (!background) os.Inherit else "")
-      pprint.log(if (!background) os.Inherit else workingDir / "stdout.log")
-      pprint.log(if (!background) os.Inherit else workingDir / "stderr.log")
       os.proc(commandArgs).spawn(
         cwd = workingDir,
         env = envArgs,


### PR DESCRIPTION
Tries to fix https://github.com/com-lihaoyi/mill/issues/2704 by ensuring the system streams are properly inherited when running `.console` or `.repl` with `-i`.


Tested via

```bash
> ./mill show dev.launcher

> cd example/basic/1-simple-scala

> /Users/lihaoyi/Github/mill/out/dev/launcher.dest/run  -i console
```

Notably this cannot be tested via `dev.run`, because we would need to apply the same `SystemStreams.withStreams(SystemStreams.original)` wrapper to `dev.run`, which would first require re-bootstrapping Mill on top of this PR