### PR TITLE
Fix sneaky binary incompatibility in Discover.scala

### DIFF
--- a/main/define/src/mill/define/Discover.scala
+++ b/main/define/src/mill/define/Discover.scala
@@ -25,7 +25,7 @@ case class Discover[T] private (
 ) {
   @deprecated
   def this(value: Map[Class[_], Seq[mainargs.MainData[_, _]]]) =
-    this(value.mapValues((Nil, _)).toMap)
+    this(value.view.mapValues((Nil, _)).toMap)
 }
 
 object Discover {

--- a/main/define/src/mill/define/Discover.scala
+++ b/main/define/src/mill/define/Discover.scala
@@ -22,7 +22,10 @@ case class Discover[T] private (
       (Seq[String], Seq[mainargs.MainData[_, _]])
     ],
     dummy: Int = 0 /* avoid conflict with Discover.apply(value: Map) below*/
-)
+) {
+  def this(value: Map[Class[_], Seq[mainargs.MainData[_, _]]]) =
+    this(value.mapValues((Nil, _)).toMap)
+}
 
 object Discover {
   def apply2[T](value: Map[Class[_], (Seq[String], Seq[mainargs.MainData[_, _]])]): Discover[T] =

--- a/main/define/src/mill/define/Discover.scala
+++ b/main/define/src/mill/define/Discover.scala
@@ -16,10 +16,13 @@ import scala.reflect.macros.blackbox
  * the `T.command` methods we find. This mapping from `Class[_]` to `MainData`
  * can then be used later to look up the `MainData` for any module.
  */
-case class Discover[T] private (val value: Map[
-  Class[_],
-  (Seq[String], Seq[mainargs.MainData[_, _]])
-], dummy: Int = 0 /* avoid conflict with Discover.apply(value: Map) below*/)
+case class Discover[T] private (
+    val value: Map[
+      Class[_],
+      (Seq[String], Seq[mainargs.MainData[_, _]])
+    ],
+    dummy: Int = 0 /* avoid conflict with Discover.apply(value: Map) below*/
+)
 
 object Discover {
   def apply2[T](value: Map[Class[_], (Seq[String], Seq[mainargs.MainData[_, _]])]): Discover[T] =

--- a/main/define/src/mill/define/Discover.scala
+++ b/main/define/src/mill/define/Discover.scala
@@ -19,11 +19,14 @@ import scala.reflect.macros.blackbox
 case class Discover[T] private (val value: Map[
   Class[_],
   (Seq[String], Seq[mainargs.MainData[_, _]])
-])
+], dummy: Int = 0)
 
 object Discover {
   def apply2[T](value: Map[Class[_], (Seq[String], Seq[mainargs.MainData[_, _]])]): Discover[T] =
     new Discover[T](value)
+
+  def apply[T](value: Map[Class[_], Seq[mainargs.MainData[_, _]]]): Discover[T] =
+    new Discover[T](value.mapValues((Nil, _)).toMap)
 
   def apply[T]: Discover[T] = macro Router.applyImpl[T]
 

--- a/main/define/src/mill/define/Discover.scala
+++ b/main/define/src/mill/define/Discover.scala
@@ -23,6 +23,7 @@ case class Discover[T] private (
     ],
     dummy: Int = 0 /* avoid conflict with Discover.apply(value: Map) below*/
 ) {
+  @deprecated
   def this(value: Map[Class[_], Seq[mainargs.MainData[_, _]]]) =
     this(value.mapValues((Nil, _)).toMap)
 }
@@ -31,6 +32,7 @@ object Discover {
   def apply2[T](value: Map[Class[_], (Seq[String], Seq[mainargs.MainData[_, _]])]): Discover[T] =
     new Discover[T](value)
 
+  @deprecated
   def apply[T](value: Map[Class[_], Seq[mainargs.MainData[_, _]]]): Discover[T] =
     new Discover[T](value.mapValues((Nil, _)).toMap)
 

--- a/main/define/src/mill/define/Discover.scala
+++ b/main/define/src/mill/define/Discover.scala
@@ -34,7 +34,7 @@ object Discover {
 
   @deprecated
   def apply[T](value: Map[Class[_], Seq[mainargs.MainData[_, _]]]): Discover[T] =
-    new Discover[T](value.mapValues((Nil, _)).toMap)
+    new Discover[T](value.view.mapValues((Nil, _)).toMap)
 
   def apply[T]: Discover[T] = macro Router.applyImpl[T]
 

--- a/main/define/src/mill/define/Discover.scala
+++ b/main/define/src/mill/define/Discover.scala
@@ -23,7 +23,7 @@ case class Discover[T] private (
     ],
     dummy: Int = 0 /* avoid conflict with Discover.apply(value: Map) below*/
 ) {
-  @deprecated
+  @deprecated("Binary compatibility shim", "Mill 0.11.4")
   def this(value: Map[Class[_], Seq[mainargs.MainData[_, _]]]) =
     this(value.view.mapValues((Nil, _)).toMap)
 }

--- a/main/define/src/mill/define/Discover.scala
+++ b/main/define/src/mill/define/Discover.scala
@@ -19,7 +19,7 @@ import scala.reflect.macros.blackbox
 case class Discover[T] private (val value: Map[
   Class[_],
   (Seq[String], Seq[mainargs.MainData[_, _]])
-], dummy: Int = 0)
+], dummy: Int = 0 /* avoid conflict with Discover.apply(value: Map) below*/)
 
 object Discover {
   def apply2[T](value: Map[Class[_], (Seq[String], Seq[mainargs.MainData[_, _]])]): Discover[T] =

--- a/main/define/src/mill/define/Discover.scala
+++ b/main/define/src/mill/define/Discover.scala
@@ -17,15 +17,27 @@ import scala.reflect.macros.blackbox
  * can then be used later to look up the `MainData` for any module.
  */
 case class Discover[T] private (
-    val value: Map[
+    value: Map[
       Class[_],
       (Seq[String], Seq[mainargs.MainData[_, _]])
     ],
     dummy: Int = 0 /* avoid conflict with Discover.apply(value: Map) below*/
 ) {
   @deprecated("Binary compatibility shim", "Mill 0.11.4")
-  def this(value: Map[Class[_], Seq[mainargs.MainData[_, _]]]) =
+  private[define] def this(value: Map[Class[_], Seq[mainargs.MainData[_, _]]]) =
     this(value.view.mapValues((Nil, _)).toMap)
+  // Explicit copy, as we also need to provide an override for bin-compat reasons
+  def copy[T](
+      value: Map[
+        Class[_],
+        (Seq[String], Seq[mainargs.MainData[_, _]])
+      ] = value,
+      dummy: Int = dummy /* avoid conflict with Discover.apply(value: Map) below*/
+  ): Discover[T] = new Discover[T](value, dummy)
+  @deprecated("Binary compatibility shim", "Mill 0.11.4")
+  private[define] def copy[T](value: Map[Class[_], Seq[mainargs.MainData[_, _]]]): Discover[T] = {
+    new Discover[T](value.view.mapValues((Nil, _)).toMap, dummy)
+  }
 }
 
 object Discover {

--- a/main/define/src/mill/define/Discover.scala
+++ b/main/define/src/mill/define/Discover.scala
@@ -32,7 +32,7 @@ object Discover {
   def apply2[T](value: Map[Class[_], (Seq[String], Seq[mainargs.MainData[_, _]])]): Discover[T] =
     new Discover[T](value)
 
-  @deprecated
+  @deprecated("Binary compatibility shim", "Mill 0.11.4")
   def apply[T](value: Map[Class[_], Seq[mainargs.MainData[_, _]]]): Discover[T] =
     new Discover[T](value.view.mapValues((Nil, _)).toMap)
 

--- a/main/resolve/src/mill/resolve/Resolve.scala
+++ b/main/resolve/src/mill/resolve/Resolve.scala
@@ -227,11 +227,11 @@ trait Resolve[T] {
       nullCommandDefaults: Boolean
   ): Either[String, Seq[T]] = {
     val rootResolved = ResolveCore.Resolved.Module(Segments(), rootModule.getClass)
-    val allPossibleNames = rootModule.millDiscover.value.values.flatMap(_._1).toSet
     val resolved =
       ResolveCore.resolve(rootModule, sel.value.toList, rootResolved, Segments()) match {
         case ResolveCore.Success(value) => Right(value)
         case ResolveCore.NotFound(segments, found, next, possibleNexts) =>
+          val allPossibleNames = rootModule.millDiscover.value.values.flatMap(_._1).toSet
           Left(ResolveNotFoundHandler(sel, segments, found, next, possibleNexts, allPossibleNames))
         case ResolveCore.Error(value) => Left(value)
       }


### PR DESCRIPTION
fixes #2749

The basic problem is that the signature of `Discover.apply()` changed, but it only changed in the argument's generic type parameters, so it was nominally the same type after erasure, and accepted the `Map[Class[_], Seq]` even though it was expecting a `Map[Class[_], (Seq, Seq)]`, but later on in the code it would blow up with a `ClassCastException`

This causes problems with Mill plugins containing external modules, which have their own `Discover[T]` macro pre-expanded and would not get re-compiled with the new 0.11.3 version of Mill.

This PR works around the problem by adding a forwarder `Discover.apply(value: Map[Class, Seq])` that does the right thing and expands the `Seq` into a `(Seq, Seq)`, while adding a dummy paramter to `case class Discover` to avoid conflicts. A similar forwarder `Discover.<init>(value: Map[Class, Seq])` is needed to preserve binary compatibility (I think?)

Tested manually via `./mill -i dev.run example/basic/1-simple-scala --import ivy:io.chris-kipp::mill-github-dependency-graph::0.2.6 io.kipp.mill.github.dependency.graph.Graph/generate`, which fails before this PR and passes after