### PR TITLE
Implement `runBackgroundInherit` / `runMainBackgroundInherit`

### DIFF
--- a/main/api/src/mill/api/JsonFormatters.scala
+++ b/main/api/src/mill/api/JsonFormatters.scala
@@ -17,6 +17,12 @@ trait JsonFormatters {
       os.Path(_)
     )
 
+  implicit val filePathReadWrite: RW[os.FilePath] = upickle.default.readwriter[String]
+    .bimap[os.FilePath](
+      _.toString,
+      os.FilePath(_)
+    )
+
   implicit val regexReadWrite: RW[Regex] = upickle.default.readwriter[String]
     .bimap[Regex](
       _.pattern.toString,

--- a/main/api/src/mill/api/JsonFormatters.scala
+++ b/main/api/src/mill/api/JsonFormatters.scala
@@ -17,6 +17,18 @@ trait JsonFormatters {
       os.Path(_)
     )
 
+  implicit val relPathReadWrite: RW[os.RelPath] = upickle.default.readwriter[String]
+    .bimap[os.RelPath](
+      _.toString,
+      os.RelPath(_)
+    )
+
+  implicit val subPathReadWrite: RW[os.SubPath] = upickle.default.readwriter[String]
+    .bimap[os.SubPath](
+      _.toString,
+      os.SubPath(_)
+    )
+
   implicit val filePathReadWrite: RW[os.FilePath] = upickle.default.readwriter[String]
     .bimap[os.FilePath](
       _.toString,

--- a/main/util/src/mill/util/Jvm.scala
+++ b/main/util/src/mill/util/Jvm.scala
@@ -3,7 +3,7 @@ package mill.util
 import mill.api.Loose.Agg
 import mill.api._
 import mill.main.client.InputPumper
-import os.{ProcessOutput,SubProcess}
+import os.{ProcessOutput, SubProcess}
 
 import java.io._
 import java.lang.reflect.Modifier
@@ -56,8 +56,8 @@ object Jvm extends CoursierSupport {
 
   def javaExe: String = jdkTool("java")
 
-  def defaultBackgroundOutputs( outputDir : os.Path ) : Option[(ProcessOutput,ProcessOutput)]
-    = Some( (outputDir / "stdout.log", outputDir / "stderr.log") )
+  def defaultBackgroundOutputs(outputDir: os.Path): Option[(ProcessOutput, ProcessOutput)] =
+    Some((outputDir / "stdout.log", outputDir / "stderr.log"))
 
   /**
    * Runs a JVM subprocess with the given configuration and streams
@@ -92,7 +92,7 @@ object Jvm extends CoursierSupport {
       envArgs,
       mainArgs,
       workingDir,
-      if (background) defaultBackgroundOutputs( ctx.dest ) else None,
+      if (background) defaultBackgroundOutputs(ctx.dest) else None,
       useCpPassingJar
     )
   }
@@ -120,7 +120,7 @@ object Jvm extends CoursierSupport {
       envArgs: Map[String, String] = Map.empty,
       mainArgs: Seq[String] = Seq.empty,
       workingDir: os.Path = null,
-      backgroundOutputs: Option[Tuple2[ProcessOutput,ProcessOutput]] = None,
+      backgroundOutputs: Option[Tuple2[ProcessOutput, ProcessOutput]] = None,
       useCpPassingJar: Boolean = false
   )(implicit ctx: Ctx): Unit = {
 
@@ -156,7 +156,12 @@ object Jvm extends CoursierSupport {
    * Runs a generic subprocess and waits for it to terminate.
    */
   def runSubprocess(commandArgs: Seq[String], envArgs: Map[String, String], workingDir: os.Path) = {
-    val process = spawnSubprocessWithBackgroundOutputs(commandArgs, envArgs, workingDir, backgroundOutputs = None)
+    val process = spawnSubprocessWithBackgroundOutputs(
+      commandArgs,
+      envArgs,
+      workingDir,
+      backgroundOutputs = None
+    )
     val shutdownHook = new Thread("subprocess-shutdown") {
       override def run(): Unit = {
         System.err.println("Host JVM shutdown. Forcefully destroying subprocess ...")
@@ -193,8 +198,8 @@ object Jvm extends CoursierSupport {
   ): SubProcess = {
     // XXX: workingDir is perhaps not the best choice for outputs, but absent a Ctx, we have
     //      no other place to choose.
-    val backgroundOutputs = if (background) defaultBackgroundOutputs( workingDir ) else None
-    spawnSubprocessWithBackgroundOutputs( commandArgs, envArgs, workingDir, backgroundOutputs )
+    val backgroundOutputs = if (background) defaultBackgroundOutputs(workingDir) else None
+    spawnSubprocessWithBackgroundOutputs(commandArgs, envArgs, workingDir, backgroundOutputs)
   }
 
   /**
@@ -211,7 +216,7 @@ object Jvm extends CoursierSupport {
       commandArgs: Seq[String],
       envArgs: Map[String, String],
       workingDir: os.Path,
-      backgroundOutputs: Option[Tuple2[ProcessOutput,ProcessOutput]] = None
+      backgroundOutputs: Option[Tuple2[ProcessOutput, ProcessOutput]] = None
   ): SubProcess = {
     // If System.in is fake, then we pump output manually rather than relying
     // on `os.Inherit`. That is because `os.Inherit` does not follow changes
@@ -224,8 +229,8 @@ object Jvm extends CoursierSupport {
         cwd = workingDir,
         env = envArgs,
         stdin = if (backgroundOutputs.isEmpty) os.Pipe else "",
-        stdout = backgroundOutputs.map( _._1 ).getOrElse(os.Pipe),
-        stderr = backgroundOutputs.map( _._2 ).getOrElse(os.Pipe)
+        stdout = backgroundOutputs.map(_._1).getOrElse(os.Pipe),
+        stderr = backgroundOutputs.map(_._2).getOrElse(os.Pipe)
       )
 
       val sources = Seq(
@@ -249,8 +254,8 @@ object Jvm extends CoursierSupport {
         cwd = workingDir,
         env = envArgs,
         stdin = if (backgroundOutputs.isEmpty) os.Inherit else "",
-        stdout = backgroundOutputs.map( _._1 ).getOrElse(os.Inherit),
-        stderr = backgroundOutputs.map( _._2 ).getOrElse(os.Inherit)
+        stdout = backgroundOutputs.map(_._1).getOrElse(os.Inherit),
+        stderr = backgroundOutputs.map(_._2).getOrElse(os.Inherit)
       )
     }
   }

--- a/main/util/src/mill/util/Jvm.scala
+++ b/main/util/src/mill/util/Jvm.scala
@@ -3,7 +3,7 @@ package mill.util
 import mill.api.Loose.Agg
 import mill.api._
 import mill.main.client.InputPumper
-import os.SubProcess
+import os.{ProcessOutput,SubProcess}
 
 import java.io._
 import java.lang.reflect.Modifier
@@ -56,6 +56,9 @@ object Jvm extends CoursierSupport {
 
   def javaExe: String = jdkTool("java")
 
+  private[this] def defaultBackgroundOutputs( outputDir : os.Path ) : Option[(ProcessOutput,ProcessOutput)]
+    = Some( (outputDir / "stdout.log", outputDir / "stderr.log") )
+
   /**
    * Runs a JVM subprocess with the given configuration and streams
    * it's stdout and stderr to the console.
@@ -82,6 +85,44 @@ object Jvm extends CoursierSupport {
       background: Boolean = false,
       useCpPassingJar: Boolean = false
   )(implicit ctx: Ctx): Unit = {
+    runSubprocessWithBackgroundOutputs(
+      mainClass,
+      classPath,
+      jvmArgs,
+      envArgs,
+      mainArgs,
+      workingDir,
+      if (background) defaultBackgroundOutputs( ctx.dest ) else None,
+      useCpPassingJar
+    )
+  }
+
+  /**
+   * Runs a JVM subprocess with the given configuration and streams
+   * it's stdout and stderr to the console.
+   * @param mainClass The main class to run
+   * @param classPath The classpath
+   * @param JvmArgs Arguments given to the forked JVM
+   * @param envArgs Environment variables used when starting the forked JVM
+   * @param workingDir The working directory to be used by the forked JVM
+   * @param backgroundOutputs If the subprocess should run in the background, a Tuple of ProcessOutputs containing out and err respectively. Specify None for nonbackground processes.
+   * @param useCpPassingJar When `false`, the `-cp` parameter is used to pass the classpath
+   *                        to the forked JVM.
+   *                        When `true`, a temporary empty JAR is created
+   *                        which contains a `Class-Path` manifest entry containing the actual classpath.
+   *                        This might help with long classpaths on OS'es (like Windows)
+   *                        which only supports limited command-line length
+   */
+  def runSubprocessWithBackgroundOutputs(
+      mainClass: String,
+      classPath: Agg[os.Path],
+      jvmArgs: Seq[String] = Seq.empty,
+      envArgs: Map[String, String] = Map.empty,
+      mainArgs: Seq[String] = Seq.empty,
+      workingDir: os.Path = null,
+      backgroundOutputs: Option[Tuple2[ProcessOutput,ProcessOutput]] = None,
+      useCpPassingJar: Boolean = false
+  )(implicit ctx: Ctx): Unit = {
 
     val cp =
       if (useCpPassingJar && !classPath.iterator.isEmpty) {
@@ -105,15 +146,17 @@ object Jvm extends CoursierSupport {
 
     ctx.log.debug(s"Run subprocess with args: ${args.map(a => s"'${a}'").mkString(" ")}")
 
-    if (background) spawnSubprocess(args, envArgs, workingDir, background = true)
-    else runSubprocess(args, envArgs, workingDir)
+    if (backgroundOutputs.nonEmpty)
+      spawnSubprocessWithBackgroundOutputs(args, envArgs, workingDir, backgroundOutputs)
+    else
+      runSubprocess(args, envArgs, workingDir)
   }
 
   /**
    * Runs a generic subprocess and waits for it to terminate.
    */
   def runSubprocess(commandArgs: Seq[String], envArgs: Map[String, String], workingDir: os.Path) = {
-    val process = spawnSubprocess(commandArgs, envArgs, workingDir, background = false)
+    val process = spawnSubprocessWithBackgroundOutputs(commandArgs, envArgs, workingDir, backgroundOutputs = None)
     val shutdownHook = new Thread("subprocess-shutdown") {
       override def run(): Unit = {
         System.err.println("Host JVM shutdown. Forcefully destroying subprocess ...")
@@ -148,6 +191,28 @@ object Jvm extends CoursierSupport {
       workingDir: os.Path,
       background: Boolean = false
   ): SubProcess = {
+    // XXX: workingDir is perhaps not the best choice for outputs, but absent a Ctx, we have
+    //      no other place to choose.
+    val backgroundOutputs = if (background) defaultBackgroundOutputs( workingDir ) else None
+    spawnSubprocessWithBackgroundOutputs( commandArgs, envArgs, workingDir, backgroundOutputs )
+  }
+
+  /**
+   * Spawns a generic subprocess, streaming the stdout and stderr to the
+   * console. If the System.out/System.err have been substituted, makes sure
+   * that the subprocess's stdout and stderr streams go to the subtituted
+   * streams.
+   *
+   * If the process should be spawned in the background, destination streams for out and err
+   * respectively must be defined in the backgroundOutputs tuple. Nonbackground process should set
+   * backgroundOutputs to None
+   */
+  def spawnSubprocessWithBackgroundOutputs(
+      commandArgs: Seq[String],
+      envArgs: Map[String, String],
+      workingDir: os.Path,
+      backgroundOutputs: Option[Tuple2[ProcessOutput,ProcessOutput]] = None
+  ): SubProcess = {
     // If System.in is fake, then we pump output manually rather than relying
     // on `os.Inherit`. That is because `os.Inherit` does not follow changes
     // to System.in/System.out/System.err, so the subprocess's streams get sent
@@ -158,9 +223,9 @@ object Jvm extends CoursierSupport {
       val process = os.proc(commandArgs).spawn(
         cwd = workingDir,
         env = envArgs,
-        stdin = if (!background) os.Pipe else "",
-        stdout = if (!background) os.Pipe else workingDir / "stdout.log",
-        stderr = if (!background) os.Pipe else workingDir / "stderr.log"
+        stdin = if (backgroundOutputs.isEmpty) os.Pipe else "",
+        stdout = backgroundOutputs.map( _._1 ).getOrElse(os.Pipe),
+        stderr = backgroundOutputs.map( _._2 ).getOrElse(os.Pipe)
       )
 
       val sources = Seq(
@@ -183,9 +248,9 @@ object Jvm extends CoursierSupport {
       os.proc(commandArgs).spawn(
         cwd = workingDir,
         env = envArgs,
-        stdin = if (!background) os.Inherit else "",
-        stdout = if (!background) os.Inherit else workingDir / "stdout.log",
-        stderr = if (!background) os.Inherit else workingDir / "stderr.log"
+        stdin = if (backgroundOutputs.isEmpty) os.Inherit else "",
+        stdout = backgroundOutputs.map( _._1 ).getOrElse(os.Inherit),
+        stderr = backgroundOutputs.map( _._2 ).getOrElse(os.Inherit)
       )
     }
   }

--- a/main/util/src/mill/util/Jvm.scala
+++ b/main/util/src/mill/util/Jvm.scala
@@ -56,7 +56,7 @@ object Jvm extends CoursierSupport {
 
   def javaExe: String = jdkTool("java")
 
-  private[this] def defaultBackgroundOutputs( outputDir : os.Path ) : Option[(ProcessOutput,ProcessOutput)]
+  def defaultBackgroundOutputs( outputDir : os.Path ) : Option[(ProcessOutput,ProcessOutput)]
     = Some( (outputDir / "stdout.log", outputDir / "stderr.log") )
 
   /**

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -17,7 +17,7 @@ import mill.util.Jvm
 import mill.scalalib.api.CompilationResult
 import mill.scalalib.bsp.{BspBuildTarget, BspModule}
 import mill.scalalib.publish.Artifact
-import os.{Path,ProcessOutput}
+import os.{Path, ProcessOutput}
 
 /**
  * Core configuration required to compile a single Java compilation target
@@ -774,15 +774,15 @@ trait JavaModule
   }
 
   private[this] def doRunBackground(
-    taskDest: Path,
-    runClasspath: Seq[PathRef],
-    zwBackgroundWrapperClasspath: Agg[PathRef],
-    forkArgs: Seq[String],
-    forkEnv: Map[String,String],
-    finalMainClass: String,
-    forkWorkingDir: Path,
-    runUseArgsFile: Boolean,
-    backgroundOutputs : Option[Tuple2[ProcessOutput,ProcessOutput]]
+      taskDest: Path,
+      runClasspath: Seq[PathRef],
+      zwBackgroundWrapperClasspath: Agg[PathRef],
+      forkArgs: Seq[String],
+      forkEnv: Map[String, String],
+      finalMainClass: String,
+      forkWorkingDir: Path,
+      runUseArgsFile: Boolean,
+      backgroundOutputs: Option[Tuple2[ProcessOutput, ProcessOutput]]
   )(args: String*): Ctx => Result[Unit] = ctx => {
     val (procId, procTombstone, token) = backgroundSetup(taskDest)
     try Result.Success(
@@ -795,7 +795,7 @@ trait JavaModule
           workingDir = forkWorkingDir,
           backgroundOutputs,
           useCpPassingJar = runUseArgsFile
-        )( ctx )
+        )(ctx)
       )
     catch {
       case e: Exception =>
@@ -825,8 +825,8 @@ trait JavaModule
       finalMainClass = finalMainClass(),
       forkWorkingDir = forkWorkingDir(),
       runUseArgsFile = runUseArgsFile(),
-      backgroundOutputs = Jvm.defaultBackgroundOutputs( T.dest )
-    )(args : _*)( ctx )
+      backgroundOutputs = Jvm.defaultBackgroundOutputs(T.dest)
+    )(args: _*)(ctx)
   }
 
   /**
@@ -843,8 +843,8 @@ trait JavaModule
       finalMainClass = mainClass,
       forkWorkingDir = forkWorkingDir(),
       runUseArgsFile = runUseArgsFile(),
-      backgroundOutputs = Jvm.defaultBackgroundOutputs( T.dest )
-    )(args : _*)( ctx )
+      backgroundOutputs = Jvm.defaultBackgroundOutputs(T.dest)
+    )(args: _*)(ctx)
   }
 
   def runBackgroundInherit(args: String*): Command[Unit] = T.command {
@@ -858,8 +858,8 @@ trait JavaModule
       finalMainClass = finalMainClass(),
       forkWorkingDir = forkWorkingDir(),
       runUseArgsFile = runUseArgsFile(),
-      backgroundOutputs = Some( (os.Inherit, os.Inherit) )
-    )(args : _*)( ctx )
+      backgroundOutputs = Some((os.Inherit, os.Inherit))
+    )(args: _*)(ctx)
   }
 
   /**
@@ -876,8 +876,8 @@ trait JavaModule
       finalMainClass = mainClass,
       forkWorkingDir = forkWorkingDir(),
       runUseArgsFile = runUseArgsFile(),
-      backgroundOutputs = Some( (os.Inherit, os.Inherit) )
-    )(args : _*)( ctx )
+      backgroundOutputs = Some((os.Inherit, os.Inherit))
+    )(args: _*)(ctx)
   }
 
   /**

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -815,103 +815,69 @@ trait JavaModule
    * that would otherwise run forever
    */
   def runBackground(args: String*): Command[Unit] = T.command {
-    val _taskDest                     = T.dest
-    val _runClasspath                 = runClasspath()
-    val _zwBackgroundWrapperClasspath = zincWorker().backgroundWrapperClasspath()
-    val _forkArgs                     = forkArgs()
-    val _forkEnv                      = forkEnv()
-    val _finalMainClass               = finalMainClass()
-    val _forkWorkingDir               = forkWorkingDir()
-    val _runUseArgsFile               = runUseArgsFile()
-    val _ctx                          = implicitly[Ctx]
-    val _backgroundOutputs            = Jvm.defaultBackgroundOutputs( _taskDest )
+    val ctx = implicitly[Ctx]
     doRunBackground(
-      _taskDest,
-      _runClasspath,
-      _zwBackgroundWrapperClasspath,
-      _forkArgs,
-      _forkEnv,
-      _finalMainClass,
-      _forkWorkingDir,
-      _runUseArgsFile,
-      _backgroundOutputs
-    )(args : _*)( _ctx )
+      taskDest = T.dest,
+      runClasspath = runClasspath(),
+      zwBackgroundWrapperClasspath = zincWorker().backgroundWrapperClasspath(),
+      forkArgs = forkArgs(),
+      forkEnv = forkEnv(),
+      finalMainClass = finalMainClass(),
+      forkWorkingDir = forkWorkingDir(),
+      runUseArgsFile = runUseArgsFile(),
+      backgroundOutputs = Jvm.defaultBackgroundOutputs( T.dest )
+    )(args : _*)( ctx )
   }
 
   /**
    * Same as `runBackground`, but lets you specify a main class to run
    */
   def runMainBackground(mainClass: String, args: String*): Command[Unit] = T.command {
-    val _taskDest                     = T.dest
-    val _runClasspath                 = runClasspath()
-    val _zwBackgroundWrapperClasspath = zincWorker().backgroundWrapperClasspath()
-    val _forkArgs                     = forkArgs()
-    val _forkEnv                      = forkEnv()
-    val _forkWorkingDir               = forkWorkingDir()
-    val _runUseArgsFile               = runUseArgsFile()
-    val _ctx                          = implicitly[Ctx]
-    val _backgroundOutputs            = Jvm.defaultBackgroundOutputs( _taskDest )
+    val ctx = implicitly[Ctx]
     doRunBackground(
-      _taskDest,
-      _runClasspath,
-      _zwBackgroundWrapperClasspath,
-      _forkArgs,
-      _forkEnv,
-      mainClass,
-      _forkWorkingDir,
-      _runUseArgsFile,
-      _backgroundOutputs
-    )(args : _*)( _ctx )
+      taskDest = T.dest,
+      runClasspath = runClasspath(),
+      zwBackgroundWrapperClasspath = zincWorker().backgroundWrapperClasspath(),
+      forkArgs = forkArgs(),
+      forkEnv = forkEnv(),
+      finalMainClass = mainClass,
+      forkWorkingDir = forkWorkingDir(),
+      runUseArgsFile = runUseArgsFile(),
+      backgroundOutputs = Jvm.defaultBackgroundOutputs( T.dest )
+    )(args : _*)( ctx )
   }
 
   def runBackgroundInherit(args: String*): Command[Unit] = T.command {
-    val _taskDest                     = T.dest
-    val _runClasspath                 = runClasspath()
-    val _zwBackgroundWrapperClasspath = zincWorker().backgroundWrapperClasspath()
-    val _forkArgs                     = forkArgs()
-    val _forkEnv                      = forkEnv()
-    val _finalMainClass               = finalMainClass()
-    val _forkWorkingDir               = forkWorkingDir()
-    val _runUseArgsFile               = runUseArgsFile()
-    val _ctx                          = implicitly[Ctx]
-    val _backgroundOutputs            = Some( (os.Inherit, os.Inherit) )
+    val ctx = implicitly[Ctx]
     doRunBackground(
-      _taskDest,
-      _runClasspath,
-      _zwBackgroundWrapperClasspath,
-      _forkArgs,
-      _forkEnv,
-      _finalMainClass,
-      _forkWorkingDir,
-      _runUseArgsFile,
-      _backgroundOutputs
-    )(args : _*)( _ctx )
+      taskDest = T.dest,
+      runClasspath = runClasspath(),
+      zwBackgroundWrapperClasspath = zincWorker().backgroundWrapperClasspath(),
+      forkArgs = forkArgs(),
+      forkEnv = forkEnv(),
+      finalMainClass = finalMainClass(),
+      forkWorkingDir = forkWorkingDir(),
+      runUseArgsFile = runUseArgsFile(),
+      backgroundOutputs = Some( (os.Inherit, os.Inherit) )
+    )(args : _*)( ctx )
   }
 
   /**
    * Same as `runBackground`, but lets you specify a main class to run
    */
   def runMainBackgroundInherit(mainClass: String, args: String*): Command[Unit] = T.command {
-    val _taskDest                     = T.dest
-    val _runClasspath                 = runClasspath()
-    val _zwBackgroundWrapperClasspath = zincWorker().backgroundWrapperClasspath()
-    val _forkArgs                     = forkArgs()
-    val _forkEnv                      = forkEnv()
-    val _forkWorkingDir               = forkWorkingDir()
-    val _runUseArgsFile               = runUseArgsFile()
-    val _ctx                          = implicitly[Ctx]
-    val _backgroundOutputs            = Some( (os.Inherit, os.Inherit) )
+    val ctx = implicitly[Ctx]
     doRunBackground(
-      _taskDest,
-      _runClasspath,
-      _zwBackgroundWrapperClasspath,
-      _forkArgs,
-      _forkEnv,
-      mainClass,
-      _forkWorkingDir,
-      _runUseArgsFile,
-      _backgroundOutputs
-    )(args : _*)( _ctx )
+      taskDest = T.dest,
+      runClasspath = runClasspath(),
+      zwBackgroundWrapperClasspath = zincWorker().backgroundWrapperClasspath(),
+      forkArgs = forkArgs(),
+      forkEnv = forkEnv(),
+      finalMainClass = mainClass,
+      forkWorkingDir = forkWorkingDir(),
+      runUseArgsFile = runUseArgsFile(),
+      backgroundOutputs = Some( (os.Inherit, os.Inherit) )
+    )(args : _*)( ctx )
   }
 
   /**


### PR DESCRIPTION
For what it's worth, here's a sketch of one possible way to address where `runBackground` process output should go.

I'm not at all wedded to it! Mostly, since I'm coming at you with asks, I want to do my part to help. For example, @lolgab's suggestion of overridable

```scala
def runBackgroundStdout: T[ProcessOutput] = os.Pipe
def runBackgroundStderr: T[ProcessOutput] = os.Pipe
```

strikes me as perhaps more elegant and flexible than duplicating `runBackground` commands, which I've done here.

In general, this pull request

1. factors out the common implementations of `JavaModule.runBackground` and `JavaModule.runMainBackground` into a helper method.

2. creates variants of `Jvm.spawnSubprocess` and `Jvm.runSubprocess` that permit specifying `out` and `err` via an optional `Tuple2` of `ProcessOutput` (and reimplements the existing methods, which offer a `Boolean` flag `background`, in terms of these methods)

3. modifies the common `doRunBackground` implementation to accept that optional tuple of `ProcessOutput`

4. modifies `JavaModule.runBackground` and `JavaModule.runMainBackground` to call the new methods, **using `T.dest/stdout.log` and `T.dest/stderr.log`** as outputs

5. adds two new commands `JavaModule.runBackgroundInherit` and `JavaModule.runMainBackgroundInherit` which sets both `out` and `err` to `os.Inherit`

Please note the bit in bold. In general, everything old is preserved. No method signatures are removed or changed, there are only additions and reimplementations in terms of those additions. But, following the discussion on discord, I did make one change to the current behavior, dropping the default logs in `runBackground.dest` / `runMainBackground.dest` rather than in the project root directory.

I've had to bring in https://github.com/com-lihaoyi/mill/pull/2752 so that I could give this a try.  It seems like it works!

I apologize for the amateurishness. I feel like I'm groping my way around in `mill`. It was very helpful to learn from @lihaoyi on the discord that `./mill -i installLocal` generates a binary one can play with in `target/`

Thank you all for your work. I love this tool.