### PR TITLE
Update jarjar-abrams-core to 1.9.0

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -160,7 +160,7 @@ object Deps {
   // keep in sync with doc/antora/antory.yml
   val bsp4j = ivy"ch.epfl.scala:bsp4j:2.1.0-M5"
   val fansi = ivy"com.lihaoyi::fansi:0.4.0"
-  val jarjarabrams = ivy"com.eed3si9n.jarjarabrams::jarjar-abrams-core:1.8.2"
+  val jarjarabrams = ivy"com.eed3si9n.jarjarabrams::jarjar-abrams-core:1.9.0"
   val requests = ivy"com.lihaoyi::requests:0.8.0"
   // tests framework (test)
   val testScalaTest = ivy"org.scalatest::scalatest:3.2.16"


### PR DESCRIPTION
This version comes will less transtive dependencies.
