### PR TITLE
Fix some hardcoded scala versions

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -519,14 +519,14 @@ object main extends MillStableScalaModule with BuildInfo {
       trait CaseModule extends ScalaModule with Cross.Module[String] {
         def caseName = crossValue
         object external extends ScalaModule {
-          def scalaVersion = "2.13.10"
+          def scalaVersion = Deps.scalaVersion
         }
 
         def moduleDeps = Seq(external)
 
         val Array(prefix, suffix, rest) = caseName.split("-", 3)
         def millSourcePath = super.millSourcePath / prefix / suffix / rest
-        def scalaVersion = "2.13.10"
+        def scalaVersion = Deps.scalaVersion
         def ivyDeps = T {
           if (!caseName.contains("realistic") && !caseName.contains("sourcecode")) super.ivyDeps()
           else Agg(

--- a/integration/feature/watch-source-input/test/src/WatchSourceInputTests.scala
+++ b/integration/feature/watch-source-input/test/src/WatchSourceInputTests.scala
@@ -47,6 +47,7 @@ object WatchSourceInputTests extends IntegrationTestSuite {
       val res = f(expectedOut, expectedErr, expectedShows)
       val (shows, out) = res.out.linesIterator.toVector.partition(_.startsWith("\""))
       val err = res.err.linesIterator.toVector
+        .filter(!_.contains("Compiling compiler interface..."))
         .filter(!_.contains("Watching for changes"))
         .filter(!_.contains("[info] compiling"))
         .filter(!_.contains("[info] done compiling"))

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -41,7 +41,7 @@ class MillBuildRootModule()(implicit
   override def millSourcePath = millBuildRootModuleInfo.projectRoot / os.up / "mill-build"
   override def intellijModulePath: os.Path = millSourcePath / os.up
 
-  override def scalaVersion: T[String] = "2.13.10"
+  override def scalaVersion: T[String] = BuildInfo.scalaVersion
 
   /**
    * All script files (that will get wrapped later)

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -4,7 +4,7 @@ import coursier.Repository
 import mill._
 import mill.api.{PathRef, Result, internal}
 import mill.define.{Discover, Task}
-import mill.scalalib.{BoundDep, Dep, DepSyntax, Lib, ScalaModule}
+import mill.scalalib.{Dep, DepSyntax, Lib, ScalaModule}
 import mill.util.CoursierSupport
 import mill.util.Util.millProjectModule
 import mill.scalalib.api.Versions


### PR DESCRIPTION
The Scala version used in `MillBuildBootstrapModule` to compile the `build.sc` was hardcoded to `2.13.10`. Instead, we want to always use the same version we used to build that Mill version.

As an side effect, Mill is now compatible with new Java 21, due to the use of a newer Scala version.