### PR TITLE
Support `mill.scalalib.JavaModule.zincReportCachedProblems` sys property

### DIFF
--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -313,7 +313,12 @@ trait JavaModule
    * If `true`, we always show problems (errors, warnings, infos) found in all source files, even when they have not changed since the previous incremental compilation.
    * When `false`, we report only problems for files which we re-compiled.
    */
-  def zincReportCachedProblems: T[Boolean] = T(false)
+  def zincReportCachedProblems: T[Boolean] = T.input {
+    sys.props.getOrElse(
+      "mill.scalalib.JavaModule.zincReportCachedProblems",
+      "false"
+    ).equalsIgnoreCase("true")
+  }
 
   /**
    * Compiles the current module to generate compiled classfiles/bytecode.


### PR DESCRIPTION
Reporting cached problems does not change the compilation result,
hence it should be safe to make it configurable at runtime via a system property.
