### PR TITLE
Remote Caching

### DIFF
--- a/core/constants/src/mill/constants/ConfigConstants.java
+++ b/core/constants/src/mill/constants/ConfigConstants.java
@@ -10,6 +10,9 @@ public class ConfigConstants {
   public static final String millAllowNestedBuildMill = "mill-allow-nested-build-mill";
   public static final String millSeparateBspOutputDir = "mill-separate-bsp-output-dir";
   public static final String millRepositories = "mill-repositories";
+  public static final String millRemoteCacheLocation = "mill-remote-cache-location";
+  public static final String millRemoteCacheSalt = "mill-remote-cache-salt";
+  public static final String millRemoteCacheFilter = "mill-remote-cache-filter";
 
   public static String[] all() {
     return new String[] {
@@ -21,7 +24,10 @@ public class ConfigConstants {
       millOpts,
       millAllowNestedBuildMill,
       millSeparateBspOutputDir,
-      millRepositories
+      millRepositories,
+      millRemoteCacheLocation,
+      millRemoteCacheSalt,
+      millRemoteCacheFilter
     };
   }
 }

--- a/core/exec/src/mill/exec/BazelRemoteCache.scala
+++ b/core/exec/src/mill/exec/BazelRemoteCache.scala
@@ -1,0 +1,393 @@
+package mill.exec
+
+import mill.api.{ExecutionPaths, PathRef}
+
+import java.io.{ByteArrayOutputStream, DataInputStream, DataOutputStream, InputStream, OutputStream}
+import java.net.URI
+import java.net.http.{HttpClient, HttpRequest, HttpResponse}
+import java.nio.ByteBuffer
+import java.nio.file.attribute.PosixFilePermission
+import java.security.{DigestOutputStream, MessageDigest}
+import java.time.Duration
+import java.util.zip.{GZIPInputStream, GZIPOutputStream}
+import scala.util.control.NonFatal
+
+/**
+ * A minimal client for a remote cache speaking the
+ * [[https://github.com/bazelbuild/remote-apis Bazel Remote Execution]] HTTP protocol (as served
+ * by [[https://github.com/buchgr/bazel-remote bazel-remote]], Buildbarn, EngFlow, etc.), letting
+ * builds in different folders or on different machines share `out/` task outputs.
+ *
+ * [[store]] bundles a task's `dest/`/`log`/`meta.json` into one gzipped blob, `PUT`s it to the
+ * CAS (`/cas/<sha256>`), then `PUT`s an `ActionResult` referencing it to the Action Cache
+ * (`/ac/<key>`); [[load]] reverses that. The protocol
+ * [[https://github.com/bazelbuild/remote-apis/blob/6c32c3b917cc5d3cfee680c03179d7552832bb3f/build/bazel/remote/execution/v2/remote_execution.proto#L1216-L1222 disallows]]
+ * inlining the blob into the `ActionResult`, hence the two steps. The few `ActionResult` fields
+ * are encoded by hand (see [[Protobuf]]) to avoid a `protobuf-java` dependency.
+ *
+ * A `--remote-cache-location` of `http(s)://` uses the protocol above; a `file:` URL or path
+ * uses a local/shared directory directly (see [[Backend]]), with no server. Setting
+ * `MILL_REMOTE_CACHE_AUTHORIZATION` sends its value as the `Authorization` header.
+ */
+private[mill] object BazelRemoteCache {
+
+  private val connectTimeout = Duration.ofSeconds(30)
+  private val requestTimeout = Duration.ofSeconds(120)
+
+  private lazy val client: HttpClient =
+    HttpClient.newBuilder().connectTimeout(connectTimeout).build()
+
+  private lazy val authHeader: Option[String] = sys.env.get("MILL_REMOTE_CACHE_AUTHORIZATION")
+
+  def actionCacheKey(inputsHash: Int, segmentsRender: String, salt: Option[String]): String = {
+    val md = MessageDigest.getInstance("SHA-256")
+    md.update(ByteBuffer.allocate(4).putInt(inputsHash).array())
+    md.update(0.toByte)
+    md.update(segmentsRender.getBytes("UTF-8"))
+    md.update(0.toByte)
+    salt.foreach(s => md.update(s.getBytes("UTF-8")))
+    mill.constants.Util.hexArray(md.digest())
+  }
+
+  /** Failures are swallowed: an upload must never fail the build. */
+  def store(
+      paths: ExecutionPaths,
+      inputsHash: Int,
+      segmentsRender: String,
+      location: String,
+      salt: Option[String],
+      pathRefs: Seq[PathRef],
+      workspace: os.Path
+  ): Unit = mill.api.BuildCtx.withFilesystemCheckerDisabled {
+    // Cache I/O is trusted framework I/O that legitimately writes outside the task's `dest/`.
+    val backend = Backend.forLocation(location, workspace)
+    val blobFile = os.temp(prefix = "mill-remote-cache-", deleteOnExit = true)
+    try {
+      val digest = MessageDigest.getInstance("SHA-256")
+      val out = new DigestOutputStream(os.write.outputStream(blobFile), digest)
+      try writeBlob(paths, pathRefs, out)
+      finally out.close()
+      val sha = mill.constants.Util.hexArray(digest.digest())
+
+      // Upload the blob before the AC entry that references it, so a reader never sees an AC
+      // entry pointing at a missing blob.
+      if (backend.putFile(s"cas/$sha", blobFile))
+        backend.putBytes(
+          s"ac/${actionCacheKey(inputsHash, segmentsRender, salt)}",
+          Protobuf.encodeActionResult(sha, os.size(blobFile))
+        )
+    } catch {
+      case NonFatal(_) =>
+    } finally os.remove(blobFile)
+  }
+
+  /** Reverse of [[store]]: `true` if a full entry was found and unpacked, `false` otherwise. */
+  def load(
+      paths: ExecutionPaths,
+      inputsHash: Int,
+      segmentsRender: String,
+      location: String,
+      salt: Option[String],
+      workspace: os.Path
+  ): Boolean = mill.api.BuildCtx.withFilesystemCheckerDisabled {
+    val backend = Backend.forLocation(location, workspace)
+    try {
+      backend.getBytes(s"ac/${actionCacheKey(inputsHash, segmentsRender, salt)}") match {
+        case None => false
+        case Some(acBytes) =>
+          Protobuf.decodeBlobDigestHash(acBytes) match {
+            case None => false
+            case Some(sha) =>
+              backend.getStream(s"cas/$sha") match {
+                // Blob evicted or not yet propagated: treat as a miss and recompute.
+                case None => false
+                case Some(is) =>
+                  // Wipe stale `dest/` only on a hit; a miss keeps it so a persistent task reuses
+                  // its state.
+                  if (os.exists(paths.dest)) os.remove.all(paths.dest)
+                  try readBlob(paths, is)
+                  finally is.close()
+                  true
+              }
+          }
+      }
+    } catch {
+      case NonFatal(_) => false
+    }
+  }
+
+  // Gzipped archive of a task's outputs, one entry per file/dir/symlink. Files carry mtime so
+  // `quick` PathRefs (which hash it) re-validate. See writeFile/writeDir/writeLink for the layout.
+  private def writeBlob(
+      paths: ExecutionPaths,
+      pathRefs: Seq[PathRef],
+      out: OutputStream
+  ): Unit = {
+    val dos = new DataOutputStream(new GZIPOutputStream(out))
+    try {
+      val referencedSubPaths: Set[Seq[String]] = pathRefs.iterator
+        .map(_.path)
+        .filter(_.startsWith(paths.dest))
+        .map(_.subRelativeTo(paths.dest).segments.toSeq)
+        .toSet
+
+      // Also keep ancestors of referenced PathRefs, so intermediate dirs retain their perms.
+      def referenced(sub: os.SubPath): Boolean = {
+        val segs = sub.segments.toSeq
+        referencedSubPaths.exists(ref => segs.startsWith(ref) || ref.startsWith(segs))
+      }
+
+      // os.walk yields parents before children — the order readBlob needs to recreate dirs first.
+      if (os.exists(paths.dest)) {
+        for {
+          p <- os.walk(paths.dest)
+          sub = p.subRelativeTo(paths.dest)
+          if referenced(sub)
+        } {
+          os.stat(p, followLinks = false).fileType match {
+            case os.FileType.SymLink => writeLink(dos, s"dest/$sub", os.readLink(p))
+            case os.FileType.Dir => writeDir(dos, s"dest/$sub", os.perms(p).toInt())
+            case _ => writeFile(dos, s"dest/$sub", p)
+          }
+        }
+      }
+      if (os.exists(paths.log)) writeFile(dos, "log", paths.log)
+      writeFile(dos, "json", paths.meta)
+    } finally dos.close()
+  }
+
+  private def writeDir(out: DataOutputStream, name: String, mode: Int): Unit = {
+    out.writeByte('D'); out.writeUTF(name)
+    out.writeInt(mode)
+  }
+  private def writeFile(out: DataOutputStream, name: String, path: os.Path): Unit = {
+    out.writeByte('F'); out.writeUTF(name)
+    out.writeInt(os.perms(path).toInt())
+    out.writeLong(os.mtime(path))
+    out.writeLong(os.size(path))
+    os.Internals.transfer(os.read.inputStream(path), out)
+  }
+  private def writeLink(out: DataOutputStream, name: String, target: os.FilePath): Unit = {
+    out.writeByte('L'); out.writeUTF(name)
+    out.writeUTF(target.toString)
+  }
+
+  private def readBlob(paths: ExecutionPaths, in: InputStream): Unit = {
+    val dis = new DataInputStream(new GZIPInputStream(in))
+    try {
+      while ({
+        dis.read() match {
+          case -1 => false
+          case tpe =>
+            val name = dis.readUTF()
+            // os.SubPath rejects `..`/absolute paths, so a hostile name can't escape dest/log/meta.
+            val dest = os.SubPath(name).segments.toList match {
+              case "dest" :: rest => rest.foldLeft(paths.dest)(_ / _)
+              case "log" :: Nil => paths.log
+              case "json" :: Nil => paths.meta
+              case _ => sys.error(s"Unexpected remote cache blob entry: $name")
+            }
+            tpe.toChar match {
+              case 'D' =>
+                os.makeDir.all(dest, perms = traversable(os.PermSet(dis.readInt())))
+              case 'L' =>
+                val target = dis.readUTF()
+                // Create the parent with default perms; os.symlink would give it this entry's
+                // own (non-traversable) perms.
+                os.makeDir.all(dest / os.up)
+                if (os.exists(dest, followLinks = false)) os.remove(dest)
+                os.symlink(dest, os.FilePath(target))
+              case _ => // 'F'
+                val mode = dis.readInt()
+                val mtime = dis.readLong()
+                val size = dis.readLong()
+                os.makeDir.all(dest / os.up) // see 'L': default perms for parents, not this file's
+                val fos = os.write.outputStream(dest, perms = os.PermSet(mode))
+                try transferN(dis, fos, size)
+                finally fos.close()
+                os.mtime.set(dest, mtime)
+            }
+            true
+        }
+      }) ()
+    } finally dis.close()
+  }
+
+  private def traversable(p: os.PermSet): os.PermSet =
+    p + PosixFilePermission.OWNER_EXECUTE +
+      PosixFilePermission.GROUP_EXECUTE +
+      PosixFilePermission.OTHERS_EXECUTE
+
+  private trait Backend {
+    def getBytes(key: String): Option[Array[Byte]]
+    def getStream(key: String): Option[InputStream]
+    def putFile(key: String, file: os.Path): Boolean
+    def putBytes(key: String, bytes: Array[Byte]): Boolean
+  }
+
+  private object Backend {
+    def forLocation(location: String, workspace: os.Path): Backend =
+      if (location.startsWith("http://") || location.startsWith("https://"))
+        new HttpBackend(location.stripSuffix("/"))
+      else if (location.startsWith("file:"))
+        new FileBackend(os.Path(java.nio.file.Path.of(URI.create(location))))
+      else if (location.startsWith("~/"))
+        new FileBackend(os.home / os.SubPath(location.stripPrefix("~/")))
+      else new FileBackend(os.Path(location, workspace))
+  }
+
+  private class HttpBackend(baseUrl: String) extends Backend {
+    private def requestBuilder(key: String): HttpRequest.Builder = {
+      val b = HttpRequest.newBuilder(URI.create(s"$baseUrl/$key")).timeout(requestTimeout)
+      authHeader.fold(b)(h => b.header("Authorization", h))
+    }
+    def getBytes(key: String): Option[Array[Byte]] = {
+      val resp =
+        client.send(requestBuilder(key).GET().build(), HttpResponse.BodyHandlers.ofByteArray())
+      Option.when(resp.statusCode() == 200)(resp.body())
+    }
+    def getStream(key: String): Option[InputStream] = {
+      val resp =
+        client.send(requestBuilder(key).GET().build(), HttpResponse.BodyHandlers.ofInputStream())
+      if (resp.statusCode() == 200) Some(resp.body())
+      else { resp.body().close(); None }
+    }
+    private def put(key: String, body: HttpRequest.BodyPublisher): Boolean =
+      client.send(requestBuilder(key).PUT(body).build(), HttpResponse.BodyHandlers.discarding())
+        .statusCode() / 100 == 2
+    def putFile(key: String, file: os.Path): Boolean =
+      put(key, HttpRequest.BodyPublishers.ofFile(file.wrapped))
+    def putBytes(key: String, bytes: Array[Byte]): Boolean =
+      put(key, HttpRequest.BodyPublishers.ofByteArray(bytes))
+  }
+
+  private class FileBackend(dir: os.Path) extends Backend {
+    private def path(key: String): os.Path = dir / os.SubPath(key)
+    def getBytes(key: String): Option[Array[Byte]] = {
+      val p = path(key)
+      Option.when(os.exists(p))(os.read.bytes(p))
+    }
+    def getStream(key: String): Option[InputStream] = {
+      val p = path(key)
+      Option.when(os.exists(p))(os.read.inputStream(p))
+    }
+    def putFile(key: String, file: os.Path): Boolean = {
+      os.copy.over(file, path(key), createFolders = true)
+      true
+    }
+    def putBytes(key: String, bytes: Array[Byte]): Boolean = {
+      os.write.over(path(key), bytes, createFolders = true)
+      true
+    }
+  }
+
+  private def transferN(src: InputStream, dest: OutputStream, n: Long): Unit = {
+    val buf = new Array[Byte](8192)
+    var remaining = n
+    while (remaining > 0) {
+      val r = src.read(buf, 0, math.min(buf.length.toLong, remaining).toInt)
+      if (r == -1) throw new java.io.EOFException()
+      dest.write(buf, 0, r)
+      remaining -= r
+    }
+  }
+
+  /**
+   * Hand-rolled encoder/decoder for the [[https://github.com/bazelbuild/remote-apis ActionResult]]
+   * fields Mill uses, avoiding a `protobuf-java` dependency: a single output file `"blob"` whose
+   * Digest points at the CAS blob.
+   */
+  private object Protobuf {
+    // Field numbers from build/bazel/remote/execution/v2/remote_execution.proto
+    private val ActionResultOutputFiles = 2
+    private val OutputFilePath = 1
+    private val OutputFileDigest = 2
+    private val DigestHash = 1
+    private val DigestSizeBytes = 2
+
+    private val WireVarint = 0
+    private val WireLengthDelim = 2
+
+    def encodeActionResult(blobSha: String, blobSize: Long): Array[Byte] = {
+      val digest = concat(
+        lengthDelimited(DigestHash, blobSha.getBytes("UTF-8")),
+        varintField(DigestSizeBytes, blobSize)
+      )
+      val outputFile = concat(
+        lengthDelimited(OutputFilePath, "blob".getBytes("UTF-8")),
+        lengthDelimited(OutputFileDigest, digest)
+      )
+      lengthDelimited(ActionResultOutputFiles, outputFile)
+    }
+
+    def decodeBlobDigestHash(bytes: Array[Byte]): Option[String] =
+      firstMessage(bytes, ActionResultOutputFiles)
+        .flatMap(firstMessage(_, OutputFileDigest))
+        .flatMap(firstString(_, DigestHash))
+
+    private def firstMessage(bytes: Array[Byte], field: Int): Option[Array[Byte]] =
+      fields(bytes).collectFirst { case (`field`, WireLengthDelim, v) => v }
+
+    private def firstString(bytes: Array[Byte], field: Int): Option[String] =
+      firstMessage(bytes, field).map(new String(_, "UTF-8"))
+
+    private def fields(bytes: Array[Byte]): List[(Int, Int, Array[Byte])] = {
+      val out = List.newBuilder[(Int, Int, Array[Byte])]
+      var pos = 0
+      var continue = true
+      while (continue && pos < bytes.length) {
+        val (tag, p1) = readVarint(bytes, pos)
+        val field = (tag >>> 3).toInt
+        val wire = (tag & 0x7).toInt
+        wire match {
+          case WireVarint =>
+            val (_, p2) = readVarint(bytes, p1); pos = p2
+          case WireLengthDelim =>
+            val (len, p2) = readVarint(bytes, p1)
+            val end = math.min(p2 + len.toInt, bytes.length)
+            out += ((field, wire, bytes.slice(p2, end))); pos = end
+          case 5 => pos = math.min(p1 + 4, bytes.length) // fixed32
+          case 1 => pos = math.min(p1 + 8, bytes.length) // fixed64
+          case _ => continue = false // groups (deprecated) or invalid
+        }
+      }
+      out.result()
+    }
+
+    private def concat(parts: Array[Byte]*): Array[Byte] = {
+      val out = new ByteArrayOutputStream()
+      parts.foreach(out.write)
+      out.toByteArray
+    }
+    private def tag(field: Int, wire: Int): Array[Byte] = encodeVarint(((field << 3) | wire).toLong)
+    private def varintField(field: Int, value: Long): Array[Byte] =
+      concat(tag(field, WireVarint), encodeVarint(value))
+    private def lengthDelimited(field: Int, value: Array[Byte]): Array[Byte] =
+      concat(tag(field, WireLengthDelim), encodeVarint(value.length.toLong), value)
+
+    private def encodeVarint(value0: Long): Array[Byte] = {
+      var value = value0
+      val out = new ByteArrayOutputStream()
+      while ((value & ~0x7fL) != 0) {
+        out.write(((value & 0x7f) | 0x80).toInt)
+        value >>>= 7
+      }
+      out.write((value & 0x7f).toInt)
+      out.toByteArray
+    }
+    private def readVarint(bytes: Array[Byte], pos0: Int): (Long, Int) = {
+      var result = 0L
+      var shift = 0
+      var pos = pos0
+      var done = false
+      while (!done) {
+        if (pos >= bytes.length) throw new IllegalArgumentException("truncated varint")
+        if (shift > 63) throw new IllegalArgumentException("varint too long")
+        val b = bytes(pos); pos += 1
+        result |= (b.toLong & 0x7f) << shift
+        if ((b & 0x80) == 0) done = true else shift += 7
+      }
+      (result, pos)
+    }
+  }
+}

--- a/core/exec/src/mill/exec/Execution.scala
+++ b/core/exec/src/mill/exec/Execution.scala
@@ -41,6 +41,11 @@ case class Execution(
     isFinalDepth: Boolean,
     // JSON string to avoid classloader issues when crossing classloader boundaries
     spanningInvalidationTree: Option[String],
+    // The filter is a raw string parsed into `Segments` lazily in `GroupExecution`, to avoid
+    // threading `Segments` across the reflective construction boundary.
+    remoteCacheLocation: Option[String] = None,
+    remoteCacheSalt: Option[String] = None,
+    remoteCacheFilter: Option[String] = None,
     // Tracks tasks invalidated due to version/classloader mismatch
     versionMismatchReasons: ConcurrentHashMap[Task[?], String] = ConcurrentHashMap()
 ) extends GroupExecution with AutoCloseable {
@@ -74,7 +79,10 @@ case class Execution(
       depth: Int,
       isFinalDepth: Boolean,
       // JSON string to avoid classloader issues when crossing classloader boundaries
-      spanningInvalidationTree: Option[String]
+      spanningInvalidationTree: Option[String],
+      remoteCacheLocation: Option[String],
+      remoteCacheSalt: Option[String],
+      remoteCacheFilter: Option[String]
   ) = this(
     baseLogger = baseLogger,
     // Only depth=0 (the user build) publishes through `runArtifacts`, so meta-build
@@ -106,7 +114,10 @@ case class Execution(
     enableTicker = enableTicker,
     depth = depth,
     isFinalDepth = isFinalDepth,
-    spanningInvalidationTree = spanningInvalidationTree
+    spanningInvalidationTree = spanningInvalidationTree,
+    remoteCacheLocation = remoteCacheLocation,
+    remoteCacheSalt = remoteCacheSalt,
+    remoteCacheFilter = remoteCacheFilter
   )
 
   def withBaseLogger(newBaseLogger: Logger) = {

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -2,9 +2,10 @@ package mill.exec
 
 import mill.api.ExecResult.{OuterStack, Success}
 import mill.api.*
+import mill.api.daemon.Segment
 import mill.api.daemon.internal.LauncherLocking
 import mill.api.daemon.internal.NonFatal
-import mill.api.internal.{Appendable, Cached, Located, PathAliasing}
+import mill.api.internal.{Appendable, Cached, Located, ParseArgs, PathAliasing}
 import mill.internal.{CodeSigUtils, FileLogger, LockUpgrade, MultiLogger, PromptWaitReporter}
 
 import java.lang.reflect.Method
@@ -56,6 +57,39 @@ trait GroupExecution {
   def exclusiveSystemStreams: SystemStreams
   def getEvaluator: () => EvaluatorApi
   def staticBuildOverrideFiles: Map[java.nio.file.Path, String]
+
+  def remoteCacheLocation: Option[String]
+  def remoteCacheSalt: Option[String]
+  def remoteCacheFilter: Option[String]
+
+  // `None` means "cache every eligible task". Validated eagerly in `MillMain0`, so it parses here.
+  private lazy val remoteCacheFilterSegments: Option[Segments] =
+    remoteCacheFilter.flatMap(ParseArgs.extractSegments(_).toOption.map(_._2))
+
+  /** The cache location for `labelled`, or `None` if not a filter-matching [[Task.Computed]]. */
+  private def remoteCacheTarget(labelled: Task.Named[?]): Option[String] =
+    remoteCacheLocation.filter(_ =>
+      labelled.isInstanceOf[Task.Computed[?]] &&
+        remoteCacheFilterSegments.forall(checkPatternMatch(_, labelled.ctx.segments))
+    )
+
+  /** Matches `input` against a `--remote-cache-filter` `pattern` with task-selector wildcards. */
+  private def checkPatternMatch(pattern: Segments, input: Segments): Boolean = {
+    import Segment.{Cross, Label}
+    def rec(pattern: List[Segment], input: List[Segment]): Boolean =
+      (pattern, input) match {
+        case (Nil, Nil) => true
+        case (Label("__") :: pRest, iRest) => iRest.tails.exists(rec(pRest, _))
+        case (Label("_") :: pRest, _ :: iRest) => rec(pRest, iRest)
+        case (Label(a) :: pRest, Label(b) :: iRest) if a == b => rec(pRest, iRest)
+        case (Cross(as) :: pRest, Cross(bs) :: iRest) =>
+          as.length == bs.length &&
+          as.zip(bs).forall { case ("_", _) => true; case (a, b) => a == b } &&
+          rec(pRest, iRest)
+        case _ => false
+      }
+    rec(pattern.value.toList, input.value.toList)
+  }
 
   /** Evaluate a build override YAML value and deserialize it */
   private def evaluateBuildOverride(
@@ -213,10 +247,11 @@ trait GroupExecution {
     rec(upickle.core.BufferedValue.transform(json, ujson.Value))
   }
 
-  // the JVM running this code currently
-  val javaHomeHash = sys.props("java.home").hashCode
+  // Key off the JVM *version*, not its install *path*, so the remote-cache key (via `inputsHash`)
+  // stays machine-independent while still partitioning distinct JVM versions.
+  val javaVersionHash = sys.props("java.version").hashCode
 
-  val invalidateAllHashes = classLoaderSigHash + javaHomeHash
+  val invalidateAllHashes = classLoaderSigHash + javaVersionHash
 
   /**
    * Returns the inputs Mill should walk for `task`. A `Task.Named` whose value
@@ -481,7 +516,7 @@ trait GroupExecution {
                 LockUpgrade.Decision.Escalate
             }
           } { scope =>
-            val cached = loadCached()
+            val localCached = loadCached()
             // Closing a stale worker here runs its user `close()` under
             // `GroupExecution.wrap`, which permits reads of upstream `dest/`
             // via `upstreamPathRefs`. Guard those reads with active-consumer
@@ -490,19 +525,50 @@ trait GroupExecution {
             // upstream Read this cleanup may still touch. Non-blocking
             // reacquire: this runs while holding this task's Write lock, so it
             // must not block on another task lock and recreate circular wait.
-            val reusableResultOpt =
+            val localReusable =
               leaseTracker.withActiveConsumers(labelled, () => tryReacquireDroppedReads()) {
-                loadCachedOrWorker(cached, closeStaleWorker = true)
+                loadCachedOrWorker(localCached, closeStaleWorker = true)
               }
+
+            // Remote-cache fallback on a local miss. We hold the Write lock, so materializing
+            // `dest/`/`log`/`meta` is safe; a poisoned entry re-reads as a miss and is recomputed
+            // by the `None` branch below.
+            val remoteMaterialized =
+              localReusable.isEmpty && remoteCacheTarget(labelled).exists { location =>
+                BazelRemoteCache.load(
+                  paths,
+                  inputsHash,
+                  labelled.ctx.segments.render,
+                  location,
+                  remoteCacheSalt,
+                  workspace
+                )
+              }
+
+            // After a remote materialization, re-read the now-present `meta.json` and reuse
+            // the same `loadCachedOrWorker` path as a local hit instead of duplicating it.
+            val cached = if (remoteMaterialized) loadCached() else localCached
+            val reusableResultOpt =
+              if (remoteMaterialized) loadCachedOrWorker(cached, closeStaleWorker = false)
+              else localReusable
 
             reusableResultOpt match {
               case Some(res) =>
+                // A remote-cache materialization wrote `dest/`/`meta`/`log` under this Write
+                // lock, so — like a recompute — it must bump the task version, or a peer that
+                // dropped a retained Read would validate against the unchanged version and
+                // silently consume the freshly written output. A purely-local hit wrote
+                // nothing and keeps the current version. Compute this before
+                // `downgradeAndRetain` so the bump happens while we still hold the Write lock.
+                val version =
+                  if (remoteMaterialized) workspaceLocking.markTaskWritten(taskLockPath)
+                  else workspaceLocking.taskVersion(taskLockPath)
                 leaseTracker.retain(
                   labelled,
                   taskLockPath,
                   labelled.ctx.segments.render,
                   scope.downgradeAndRetain(),
-                  workspaceLocking.taskVersion(taskLockPath)
+                  version
                 )
                 res
               case None =>
@@ -550,6 +616,18 @@ trait GroupExecution {
                     case ExecResult.Success((v, _)) =>
                       val (valueHash, serializedPaths) =
                         handleTaskResult(v, paths.meta, inputsHash, labelled)
+                      // Push freshly-computed outputs to the remote cache for other machines.
+                      remoteCacheTarget(labelled).foreach { location =>
+                        BazelRemoteCache.store(
+                          paths,
+                          inputsHash,
+                          labelled.ctx.segments.render,
+                          location,
+                          remoteCacheSalt,
+                          serializedPaths,
+                          workspace
+                        )
+                      }
                       // Reuse `handleTaskResult`'s hash (derived from the JSON it writes) as the
                       // terminal's downstream value hash too — the `0` placeholder stored by
                       // `executeGroup` is patched here — so cache and downstream consumers agree

--- a/core/internal/cli/src/mill/internal/MillCliConfig.scala
+++ b/core/internal/cli/src/mill/internal/MillCliConfig.scala
@@ -160,6 +160,26 @@ case class MillCliConfig(
     disablePrompt: Flag = Flag(),
     @arg(hidden = true, doc = "Unsupported, but kept for compatibility")
     enableTicker: Option[Boolean] = None,
+    @arg(
+      hidden = true,
+      name = "remote-cache-location",
+      doc =
+        "Remote cache location: a Bazel-remote-protocol HTTP cache URL, or a `file:` URL / path to a local or shared folder."
+    )
+    remoteCacheLocation: Option[String] = None,
+    @arg(
+      hidden = true,
+      name = "remote-cache-salt",
+      doc =
+        "Extra string mixed into the remote cache key, e.g. to keep Mac and Linux builds from sharing entries."
+    )
+    remoteCacheSalt: Option[String] = None,
+    @arg(
+      hidden = true,
+      name = "remote-cache-filter",
+      doc = "Task-selector pattern (e.g. `__.compile`) limiting which tasks use the remote cache."
+    )
+    remoteCacheFilter: Option[String] = None,
     @arg(hidden = true, doc = "Deprecated, use `--ticker false` instead")
     disableTicker: Flag
 ) {

--- a/example/large/remotecache/1-shared-folder/build.mill
+++ b/example/large/remotecache/1-shared-folder/build.mill
@@ -1,0 +1,43 @@
+//| mill-remote-cache-location: ~/mill-remote-cache-folder
+
+// Mill can share task outputs between builds in different folders, or even on different
+// machines, via a _remote cache_. Outputs computed by one build are stored in the cache and
+// transparently re-used by any other build whose inputs are unchanged, so you never need to
+// compute the same thing twice across a fleet of developer machines or CI workers.
+//
+// The simplest cache backend is a plain local or shared (e.g. NFS) _directory_: point the
+// cache at a filesystem path and Mill reads and writes cache entries there directly, with no
+// server to run. We enable it from the xref:cli/build-header.adoc[build header] above, so it
+// applies to every command without passing `--remote-cache-location` on the command line.
+
+package build
+import mill.*, javalib.*
+
+object foo extends JavaModule
+
+/** Usage
+
+> ./mill foo.run
+Hello World!
+
+> ./mill clean foo.compile
+
+> ./mill foo.run
+Hello World!
+
+*/
+
+// `./mill clean foo.compile` removed the local `out/` entry for the compile, so the second
+// `./mill foo.run` could only skip recompiling by fetching the result from the shared cache
+// folder. `out/mill-profile.json` confirms it with `"cached": true` for `foo.compile`, rather
+// than a local recompute:
+
+/** Usage
+
+> cat out/mill-profile.json | jq '.[] | select(.label == "foo.compile").cached'
+true
+
+*/
+
+// Point any other checkout of the project at the same folder, local or on a shared mount, to
+// share results between them.

--- a/example/large/remotecache/1-shared-folder/foo/src/Foo.java
+++ b/example/large/remotecache/1-shared-folder/foo/src/Foo.java
@@ -1,0 +1,5 @@
+public class Foo {
+  public static void main(String[] args) {
+    System.out.println("Hello World!");
+  }
+}

--- a/example/large/remotecache/2-bazel-remote/build.mill
+++ b/example/large/remotecache/2-bazel-remote/build.mill
@@ -1,0 +1,53 @@
+//| mill-remote-cache-location: http://localhost:8378
+
+// To share a cache across a fleet of machines or CI workers you want a real cache _server_.
+// Mill speaks the widely-supported https://github.com/bazelbuild/remote-apis[Bazel Remote
+// Execution] HTTP cache protocol, so it works against off-the-shelf servers like
+// https://github.com/buchgr/bazel-remote[bazel-remote] (as well as Buildbarn, EngFlow, and
+// others). Point `mill-remote-cache-location` at the server's base URL, here in the
+// xref:cli/build-header.adoc[build header] so every command uses it.
+//
+// Below we download the `bazel-remote` binary — the two `curl`s fetch the macOS/arm64 and
+// Linux/x86-64 builds; see the https://github.com/buchgr/bazel-remote/releases[releases] page
+// for other platforms — then run it serving an HTTP cache on a local port and build against it.
+
+package build
+import mill.*, javalib.*
+
+object foo extends JavaModule
+
+/** Usage
+
+> curl -sL -o bazel-remote https://github.com/buchgr/bazel-remote/releases/download/v2.6.1/bazel-remote-2.6.1-darwin-arm64 && chmod +x bazel-remote # mac
+
+> curl -sL -o bazel-remote https://github.com/buchgr/bazel-remote/releases/download/v2.6.1/bazel-remote-2.6.1-linux-amd64 && chmod +x bazel-remote # linux
+
+> ./bazel-remote --dir bazel-remote-data --max_size 1 --http_address localhost:8378 > bazel-remote.log 2>&1 & echo $! > bazel-remote.pid; sleep 3
+
+> ./mill foo.run
+Hello World!
+
+> ./mill clean foo.compile
+
+> ./mill foo.run
+Hello World!
+
+> kill $(cat bazel-remote.pid)
+
+*/
+
+// After `./mill clean foo.compile`, the second `./mill foo.run` skipped recompiling and instead
+// downloaded the compile output from `bazel-remote`, as `"cached": true` for `foo.compile` in
+// `out/mill-profile.json` confirms:
+
+/** Usage
+
+> cat out/mill-profile.json | jq '.[] | select(.label == "foo.compile").cached'
+true
+
+*/
+
+// Because `bazel-remote` validates each uploaded `ActionResult` against the blobs it references,
+// a successful hit also confirms Mill's protocol implementation is correct on the wire. For
+// authenticated servers, set the `MILL_REMOTE_CACHE_AUTHORIZATION` environment variable and Mill
+// sends it as the `Authorization` header on every request.

--- a/example/large/remotecache/2-bazel-remote/foo/src/Foo.java
+++ b/example/large/remotecache/2-bazel-remote/foo/src/Foo.java
@@ -1,0 +1,5 @@
+public class Foo {
+  public static void main(String[] args) {
+    System.out.println("Hello World!");
+  }
+}

--- a/example/large/remotecache/3-apache-httpd/build.mill
+++ b/example/large/remotecache/3-apache-httpd/build.mill
@@ -1,0 +1,50 @@
+//| mill-remote-cache-location: http://localhost:8379
+
+// Mill's remote cache speaks the Bazel HTTP cache protocol, which per the
+// https://bazel.build/remote/caching[Bazel docs] works against "any HTTP/1.1 server that
+// supports PUT and GET" — not just purpose-built caches. So you can also back the cache with a
+// general-purpose web server you may already run, such as https://httpd.apache.org[Apache
+// httpd] with its `mod_dav` WebDAV module.
+//
+// The `httpd.conf` next to this build serves an `apache-data/` folder over WebDAV; we create
+// that folder, start a stock Apache with the config, and point `mill-remote-cache-location` at
+// it in the build header.
+
+package build
+import mill.*, javalib.*
+
+object foo extends JavaModule
+
+/** Usage
+
+> mkdir -p apache-data/ac apache-data/cas
+
+> /usr/sbin/httpd -d "$(pwd)" -f httpd.conf -k start # mac
+
+> apache2 -d "$(pwd)" -f httpd.conf -k start # linux
+
+> ./mill foo.run
+Hello World!
+
+> ./mill clean foo.compile
+
+> ./mill foo.run
+Hello World!
+
+> kill $(cat httpd.pid)
+
+*/
+
+// After `./mill clean foo.compile`, the second `./mill foo.run` fetched the compile output from
+// Apache rather than recompiling, as `"cached": true` for `foo.compile` in
+// `out/mill-profile.json` shows:
+
+/** Usage
+
+> cat out/mill-profile.json | jq '.[] | select(.label == "foo.compile").cached'
+true
+
+*/
+
+// The cache files Apache stored end up under `apache-data/ac/` and `apache-data/cas/`, the same
+// on-the-wire layout as a dedicated Bazel remote cache.

--- a/example/large/remotecache/3-apache-httpd/foo/src/Foo.java
+++ b/example/large/remotecache/3-apache-httpd/foo/src/Foo.java
@@ -1,0 +1,5 @@
+public class Foo {
+  public static void main(String[] args) {
+    System.out.println("Hello World!");
+  }
+}

--- a/example/large/remotecache/3-apache-httpd/httpd.conf
+++ b/example/large/remotecache/3-apache-httpd/httpd.conf
@@ -1,0 +1,43 @@
+# A minimal Apache config that serves the `apache-data` folder over WebDAV, so Apache acts as a
+# Bazel-remote-protocol HTTP cache (handling the PUT/GET/HEAD that Mill's remote cache makes).
+# Start it with `-d "$(pwd)"` so the relative paths below resolve against this directory. Apache
+# ships its modules in different places on macOS and Debian/Ubuntu, so we point `MODS` at
+# whichever exists and load only the modules that aren't already built in.
+ServerName localhost
+Listen 8379
+PidFile httpd.pid
+ErrorLog httpd-error.log
+
+<IfFile "/usr/libexec/apache2/mod_dav.so">
+Define MODS "/usr/libexec/apache2"
+</IfFile>
+<IfFile "/usr/lib/apache2/modules/mod_dav.so">
+Define MODS "/usr/lib/apache2/modules"
+</IfFile>
+
+<IfModule !mpm_event_module>
+<IfModule !mpm_worker_module>
+<IfModule !mpm_prefork_module>
+LoadModule mpm_prefork_module "${MODS}/mod_mpm_prefork.so"
+</IfModule>
+</IfModule>
+</IfModule>
+<IfModule !unixd_module>
+LoadModule unixd_module "${MODS}/mod_unixd.so"
+</IfModule>
+<IfModule !authz_core_module>
+LoadModule authz_core_module "${MODS}/mod_authz_core.so"
+</IfModule>
+<IfModule !dav_module>
+LoadModule dav_module "${MODS}/mod_dav.so"
+</IfModule>
+<IfModule !dav_fs_module>
+LoadModule dav_fs_module "${MODS}/mod_dav_fs.so"
+</IfModule>
+
+DavLockDB DavLock
+DocumentRoot apache-data
+<Location />
+  Dav On
+  Require all granted
+</Location>

--- a/example/package.mill
+++ b/example/package.mill
@@ -120,6 +120,7 @@ object `package` extends Module {
     object multifile extends Cross[ExampleCrossModule](build.listCross)
     object multilang extends Cross[ExampleCrossModule](build.listCross)
     object precompiled extends Cross[ExampleCrossModule](build.listCross)
+    object remotecache extends Cross[ExampleCrossModule](build.listCross)
   }
 
   object extending extends Module {

--- a/integration/dedicated/remote-cache/resources/build.mill
+++ b/integration/dedicated/remote-cache/resources/build.mill
@@ -1,0 +1,24 @@
+package build
+import mill.*
+
+// Test fixtures. Tests read `out/mill-profile.json` to see whether each task was recomputed
+// (`"cached": false`) or served from a cache (`"cached": true`).
+
+def cachedTask = Task {
+  "cachedTask-value"
+}
+
+// Excluded by the `--remote-cache-filter` test, so always recomputed.
+def uncachedTask = Task {
+  "uncachedTask-value"
+}
+
+// Returns a PathRef under `Task.dest`, exercising the cache's bundling/restoring of `dest/` files.
+def cachedFile = Task {
+  os.write(Task.dest / "data.txt", "file-contents-12345")
+  PathRef(Task.dest / "data.txt")
+}
+
+def persistentTask = Task(persistent = true) {
+  "persistentTask-value"
+}

--- a/integration/dedicated/remote-cache/src/RemoteCacheTests.scala
+++ b/integration/dedicated/remote-cache/src/RemoteCacheTests.scala
@@ -1,0 +1,220 @@
+package mill.integration
+
+import com.sun.net.httpserver.{HttpExchange, HttpHandler, HttpServer}
+import mill.testkit.UtestIntegrationTestSuite
+import utest.*
+
+import java.net.InetSocketAddress
+import java.util.concurrent.Executors
+
+/**
+ * Integration tests for remote caching, adapted from the manual steps in
+ * https://github.com/com-lihaoyi/mill/pull/2777. Instead of a real `bazel-remote` server they
+ * use a tiny in-process HTTP cache (`PUT`/`GET` on `/ac` and `/cas`) backed by a temp dir, and
+ * each `integrationTest{}` block is a fresh checkout sharing outputs through it.
+ */
+object RemoteCacheTests extends UtestIntegrationTestSuite {
+
+  // Each block models a fresh checkout (empty `out/`), so opt out of the `fast` flavor's shared
+  // output dir — otherwise one block's local cache would satisfy a later one.
+  override def allowSharedOutputDir: Boolean = false
+
+  def withServer[T](f: String => T): T = {
+    val dir = os.temp.dir(prefix = "mill-remote-cache-server")
+    val server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0)
+    server.createContext(
+      "/",
+      new HttpHandler {
+        def handle(exchange: HttpExchange): Unit = {
+          try {
+            val rel = exchange.getRequestURI.getPath.stripPrefix("/")
+            val file = dir / os.SubPath(rel)
+            exchange.getRequestMethod match {
+              case "PUT" =>
+                val bytes = exchange.getRequestBody.readAllBytes()
+                os.write.over(file, bytes, createFolders = true)
+                exchange.sendResponseHeaders(200, -1)
+              case "GET" if os.exists(file) =>
+                val bytes = os.read.bytes(file)
+                exchange.sendResponseHeaders(200, bytes.length.toLong)
+                exchange.getResponseBody.write(bytes)
+              case "HEAD" if os.exists(file) =>
+                exchange.sendResponseHeaders(200, -1)
+              case "GET" | "HEAD" =>
+                exchange.sendResponseHeaders(404, -1)
+              case _ =>
+                exchange.sendResponseHeaders(405, -1)
+            }
+          } catch {
+            case _: Throwable => exchange.sendResponseHeaders(500, -1)
+          } finally exchange.close()
+        }
+      }
+    )
+    server.setExecutor(Executors.newFixedThreadPool(4))
+    server.start()
+    try f(s"http://127.0.0.1:${server.getAddress.getPort}")
+    finally server.stop(0)
+  }
+
+  // Whether `task` was recomputed (`"cached": false` in `mill-profile.json`) rather than served
+  // from a cache, in the most recent invocation in `tester`'s workspace.
+  def evaluated(tester: mill.testkit.IntegrationTester, task: String): Boolean = {
+    val profile = os.read(tester.workspacePath / "out" / mill.constants.OutFiles.millProfile)
+    ujson.read(profile).arr.exists { e =>
+      e("label").str == task && e.obj.get("cached").flatMap(_.boolOpt).contains(false)
+    }
+  }
+
+  val tests: Tests = Tests {
+
+    test("crossDirectorySharing") - withServer { url =>
+      integrationTest { tester =>
+        val res = tester.eval(("--remote-cache-location", url, "show", "cachedTask"))
+        assert(res.isSuccess)
+        assert(evaluated(tester, "cachedTask"))
+        assert(res.out.contains("cachedTask-value"))
+      }
+      // Second checkout: served from the cache, so `cachedTask` is not re-evaluated.
+      integrationTest { tester =>
+        val res = tester.eval(("--remote-cache-location", url, "show", "cachedTask"))
+        assert(res.isSuccess)
+        assert(res.out.contains("cachedTask-value"))
+        assert(!evaluated(tester, "cachedTask"))
+      }
+    }
+
+    // A hit must restore the referenced `dest/` files, or `PathRef` re-validation forces a recompute.
+    test("pathRefRestore") - withServer { url =>
+      integrationTest { tester =>
+        val res = tester.eval(("--remote-cache-location", url, "show", "cachedFile"))
+        assert(res.isSuccess)
+        assert(evaluated(tester, "cachedFile"))
+      }
+      integrationTest { tester =>
+        val res = tester.eval(("--remote-cache-location", url, "show", "cachedFile"))
+        assert(res.isSuccess)
+        assert(!evaluated(tester, "cachedFile"))
+        val restored = tester.workspacePath / "out/cachedFile.dest/data.txt"
+        assert(os.exists(restored))
+        assert(os.read(restored) == "file-contents-12345")
+      }
+    }
+
+    // `--remote-cache-filter` limits caching to matching tasks; `uncachedTask` is always recomputed.
+    test("filter") - withServer { url =>
+      def filterArgs =
+        Seq("--remote-cache-location", url, "--remote-cache-filter", "cachedTask")
+      integrationTest { tester =>
+        val res = tester.eval(filterArgs ++ Seq("cachedTask", "+", "uncachedTask"))
+        assert(res.isSuccess)
+        assert(evaluated(tester, "cachedTask"))
+        assert(evaluated(tester, "uncachedTask"))
+      }
+      integrationTest { tester =>
+        val res = tester.eval(filterArgs ++ Seq("cachedTask", "+", "uncachedTask"))
+        assert(res.isSuccess)
+        assert(!evaluated(tester, "cachedTask"))
+        assert(evaluated(tester, "uncachedTask"))
+      }
+    }
+
+    // Persistent tasks (e.g. `compile`) participate too — the primary use case.
+    test("persistentTaskIsCached") - withServer { url =>
+      integrationTest { tester =>
+        val res = tester.eval(("--remote-cache-location", url, "persistentTask"))
+        assert(res.isSuccess)
+        assert(evaluated(tester, "persistentTask"))
+      }
+      integrationTest { tester =>
+        val res = tester.eval(("--remote-cache-location", url, "persistentTask"))
+        assert(res.isSuccess)
+        assert(!evaluated(tester, "persistentTask")) // served from the remote cache
+      }
+    }
+
+    // A `file:` URL uses a plain directory as the cache, with no server.
+    test("localFolderBackend") - {
+      val cacheDir = os.temp.dir(prefix = "mill-remote-cache-folder")
+      val url = cacheDir.toNIO.toUri.toString
+      integrationTest { tester =>
+        val res = tester.eval(("--remote-cache-location", url, "show", "cachedTask"))
+        assert(res.isSuccess)
+        assert(evaluated(tester, "cachedTask"))
+        assert(res.out.contains("cachedTask-value"))
+      }
+      assert(os.exists(cacheDir / "ac") && os.exists(cacheDir / "cas"))
+      integrationTest { tester =>
+        val res = tester.eval(("--remote-cache-location", url, "show", "cachedTask"))
+        assert(res.isSuccess)
+        assert(res.out.contains("cachedTask-value"))
+        assert(!evaluated(tester, "cachedTask"))
+      }
+    }
+
+    // An unreachable cache degrades gracefully: the build still succeeds, computing locally.
+    test("gracefulDegradationWhenCacheUnreachable") - integrationTest { tester =>
+      val res =
+        tester.eval(("--remote-cache-location", "http://127.0.0.1:1", "show", "cachedTask"))
+      assert(res.isSuccess)
+      assert(evaluated(tester, "cachedTask"))
+      assert(res.out.contains("cachedTask-value"))
+    }
+
+    // A hit must wipe stale `dest/` from a prior different-`inputsHash` build before unpacking.
+    test("staleDestWipedOnRemoteHit") - withServer { url =>
+      integrationTest { tester =>
+        assert(tester.eval(("--remote-cache-location", url, "cachedFile")).isSuccess)
+      }
+      integrationTest { tester =>
+        import tester.*
+        os.write(workspacePath / "out/cachedFile.dest/STALE.txt", "stale", createFolders = true)
+        val res = eval(("--remote-cache-location", url, "cachedFile"))
+        assert(res.isSuccess)
+        assert(!evaluated(tester, "cachedFile"))
+        assert(os.exists(workspacePath / "out/cachedFile.dest/data.txt"))
+        assert(!os.exists(workspacePath / "out/cachedFile.dest/STALE.txt"))
+      }
+    }
+
+    // Different `--remote-cache-salt` values partition the cache into non-shared entries.
+    test("salt") - withServer { url =>
+      integrationTest { tester =>
+        val res =
+          tester.eval((
+            "--remote-cache-location",
+            url,
+            "--remote-cache-salt",
+            "saltA",
+            "cachedTask"
+          ))
+        assert(res.isSuccess)
+        assert(evaluated(tester, "cachedTask"))
+      }
+      integrationTest { tester =>
+        val res =
+          tester.eval((
+            "--remote-cache-location",
+            url,
+            "--remote-cache-salt",
+            "saltB",
+            "cachedTask"
+          ))
+        assert(res.isSuccess)
+        assert(evaluated(tester, "cachedTask")) // different salt → miss → recompute
+      }
+      integrationTest { tester =>
+        val res =
+          tester.eval((
+            "--remote-cache-location",
+            url,
+            "--remote-cache-salt",
+            "saltA",
+            "cachedTask"
+          ))
+        assert(res.isSuccess)
+        assert(!evaluated(tester, "cachedTask"))
+      }
+    }
+  }
+}

--- a/libs/tabcomplete/test/src/mill/tabcomplete/TabCompleteTests.scala
+++ b/libs/tabcomplete/test/src/mill/tabcomplete/TabCompleteTests.scala
@@ -382,7 +382,10 @@ object TabCompleteTests extends TestSuite {
             "--no-daemon               Run without a long-lived background daemon.",
             "--no-wait-for-build-lock  Do not wait for an exclusive lock on the Mill output directory to evaluate tasks / commands.",
             "--version                 Show mill version information and exit.",
-            "--task                    <str> The name or a query of the tasks(s) you want to build."
+            "--task                    <str> The name or a query of the tasks(s) you want to build.",
+            "--remote-cache-location   <str> Remote cache location: a Bazel-remote-protocol HTTP cache URL, or a `file:` URL / path to a local or shared folder.",
+            "--remote-cache-salt       <str> Extra string mixed into the remote cache key, e.g. to keep Mac and Linux builds from sharing entries.",
+            "--remote-cache-filter     <str> Task-selector pattern (e.g. `__.compile`) limiting which tasks use the remote cache."
           )
         )
       }

--- a/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
+++ b/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
@@ -61,6 +61,9 @@ class MillBuildBootstrap(
     selectiveExecution: Boolean,
     offline: Boolean,
     useFileLocks: Boolean,
+    remoteCacheLocation: Option[String],
+    remoteCacheSalt: Option[String],
+    remoteCacheFilter: Option[String],
     runArtifacts: LauncherOutFiles,
     metaBuild: MetaBuildAccess,
     reporter: EvaluatorApi => Int => Option[CompileProblemReporter],
@@ -262,6 +265,9 @@ class MillBuildBootstrap(
       selectiveExecution = selectiveExecution,
       offline = offline,
       useFileLocks = useFileLocks,
+      remoteCacheLocation = remoteCacheLocation,
+      remoteCacheSalt = remoteCacheSalt,
+      remoteCacheFilter = remoteCacheFilter,
       workspaceLocking = workspaceLocking,
       runArtifacts = runArtifacts,
       workerCache = workerCache,
@@ -808,6 +814,9 @@ object MillBuildBootstrap {
       selectiveExecution: Boolean,
       offline: Boolean,
       useFileLocks: Boolean,
+      remoteCacheLocation: Option[String],
+      remoteCacheSalt: Option[String],
+      remoteCacheFilter: Option[String],
       workspaceLocking: LauncherLocking,
       runArtifacts: LauncherOutFiles,
       workerCache: collection.mutable.Map[String, (Int, Val, TaskApi[?])],
@@ -866,7 +875,10 @@ object MillBuildBootstrap {
           enableTicker,
           depth,
           false, // isFinalDepth: set later via withIsFinalDepth when needed
-          spanningInvalidationTree
+          spanningInvalidationTree,
+          remoteCacheLocation,
+          remoteCacheSalt,
+          remoteCacheFilter
         )
       ).asInstanceOf[EvaluatorApi]
 

--- a/runner/daemon/src/mill/daemon/MillMain0.scala
+++ b/runner/daemon/src/mill/daemon/MillMain0.scala
@@ -187,6 +187,17 @@ object MillMain0 {
                 val maybeThreadCount =
                   parseThreadCount(config.threadCountRaw, Runtime.getRuntime.availableProcessors())
 
+                // Validate `--remote-cache-filter` eagerly here so a bad selector is a clean
+                // startup error, not an exception thrown mid-build from the execution pool.
+                val remoteCacheFilterError: Option[String] =
+                  config.remoteCacheFilter.flatMap { sel =>
+                    mill.api.internal.ParseArgs.extractSegments(sel) match {
+                      case _: mill.api.Result.Success[?] => None
+                      case f: mill.api.Result.Failure =>
+                        Some(s"Invalid --remote-cache-filter \"$sel\": ${f.error}")
+                    }
+                  }
+
                 // special BSP mode, in which we spawn a server and register the current evaluator when-ever we start to eval a dedicated command
                 val bspMode = config.bsp.value && config.leftoverArgs.value.isEmpty
                 val outMode = if (bspMode) OutFolderMode.BSP else OutFolderMode.REGULAR
@@ -237,6 +248,9 @@ object MillMain0 {
                     true
                   } else if (maybeThreadCount.errorOpt.isDefined) {
                     streams.err.println(maybeThreadCount.errorOpt.get)
+                    false
+                  } else if (remoteCacheFilterError.isDefined) {
+                    streams.err.println(remoteCacheFilterError.get)
                     false
                   } else {
                     val userSpecifiedProperties =
@@ -409,6 +423,9 @@ object MillMain0 {
                                     selectiveExecution = config.watch.value,
                                     offline = config.offline.value,
                                     useFileLocks = config.useFileLocks.value,
+                                    remoteCacheLocation = config.remoteCacheLocation,
+                                    remoteCacheSalt = config.remoteCacheSalt,
+                                    remoteCacheFilter = config.remoteCacheFilter,
                                     runArtifacts = runArtifacts,
                                     metaBuild = new MetaBuildAccess(
                                       ref = sharedState,

--- a/runner/launcher/src/mill/launcher/MillLauncherMain.scala
+++ b/runner/launcher/src/mill/launcher/MillLauncherMain.scala
@@ -80,7 +80,18 @@ object MillLauncherMain {
         val millRepositories =
           MillProcessLauncher.loadMillConfig(ConfigConstants.millRepositories, workDir)
         val runnerClasspath = CoursierClient.resolveMillDaemon(regularOutDir, millRepositories)
-        val optsArgs = MillProcessLauncher.loadMillConfig(ConfigConstants.millOpts, workDir) ++ args
+        // Surface build-header `mill-remote-cache-*` keys as CLI flags, before the user's args
+        // so an explicit CLI flag still wins.
+        val remoteCacheArgs = Seq(
+          ConfigConstants.millRemoteCacheLocation -> "--remote-cache-location",
+          ConfigConstants.millRemoteCacheSalt -> "--remote-cache-salt",
+          ConfigConstants.millRemoteCacheFilter -> "--remote-cache-filter"
+        ).flatMap { case (key, flag) =>
+          MillProcessLauncher.loadMillConfig(key, workDir).flatMap(value => Seq(flag, value))
+        }
+        val optsArgs =
+          MillProcessLauncher.loadMillConfig(ConfigConstants.millOpts, workDir) ++
+            remoteCacheArgs ++ args
 
         if (runNoDaemon)
           MillProcessLauncher.launchMillNoDaemon(

--- a/testkit/src/mill/testkit/ExampleTester.scala
+++ b/testkit/src/mill/testkit/ExampleTester.scala
@@ -53,6 +53,8 @@ import utest.*
  * The following comments are recognized (see [[incorrectPlatform]]):
  * - 'mac/linux'        - Only run on Linux/Mac but not on Windows
  * - 'windows'          - Only run on Windows but not on Linux/Mac
+ * - 'mac'              - Only run on Mac
+ * - 'linux'            - Only run on Linux
  * - '--no-daemon'      - Only run in no-daemon test mode
  * - 'not --no-daemon'  - Only run in daemon test mode
  */
@@ -98,6 +100,8 @@ class ExampleTester(
   def commandFilter(commandComment: String): Boolean = commandComment match {
     case s"windows$_" => isWindows
     case s"mac/linux$_" => !isWindows
+    case s"mac$_" => scala.util.Properties.isMac
+    case s"linux$_" => !scala.util.Properties.isMac && !isWindows
     case s"--no-daemon$_" => !daemonMode
     case s"not --no-daemon$_" => daemonMode
     case _ => true

--- a/website/docs/modules/ROOT/nav.adoc
+++ b/website/docs/modules/ROOT/nav.adoc
@@ -66,6 +66,7 @@
 ** xref:large/multi-file-builds.adoc[]
 ** xref:large/multi-language-builds.adoc[]
 ** xref:large/pre-compiled-modules.adoc[]
+** xref:large/remote-caching.adoc[]
 // This section talks about Mill plugins. While it could theoretically fit in
 // either section above, it is probably an important enough topic it is worth
 // breaking out on its own

--- a/website/docs/modules/ROOT/pages/cli/build-header.adoc
+++ b/website/docs/modules/ROOT/pages/cli/build-header.adoc
@@ -167,6 +167,53 @@ The configured repositories are prepended to (take precedence over) the default
 Maven Central repository. For configuring repositories on individual modules, see
 xref:javalib/dependencies.adoc#_repository_configuration[Repository Configuration].
 
+== mill-remote-cache-location
+
+You can enable xref:large/remote-caching.adoc[remote caching] for a project from its build
+header, so it applies to every invocation without passing flags each time. Only
+`mill-remote-cache-location` is required to turn remote caching on:
+
+_build.mill_
+[source,scala]
+----
+//| mill-remote-cache-location: https://my-cache.example.com
+----
+
+`mill-remote-cache-location` is the cache location: either the base URL of a server speaking the
+Bazel-remote-protocol HTTP cache (such as
+https://github.com/buchgr/bazel-remote[bazel-remote]), or a `file:` URL / path to a local or
+shared (e.g. NFS) folder used as the cache with no server.
+
+Two further keys are optional:
+
+* `mill-remote-cache-filter` restricts caching to the tasks matching a task query, e.g.
+  `__.compile`. When omitted, every cacheable task is eligible.
+* `mill-remote-cache-salt` adds an extra string to the cache key to partition the cache, e.g.
+  to keep entries computed on different operating systems apart. When omitted, no salt is
+  applied.
+
+_build.mill_
+[source,scala]
+----
+//| mill-remote-cache-location: https://my-cache.example.com
+//| mill-remote-cache-filter: __.compile
+//| mill-remote-cache-salt: linux
+----
+
+Or in `build.mill.yaml`:
+[source,yaml]
+----
+mill-remote-cache-location: https://my-cache.example.com
+mill-remote-cache-filter: __.compile
+mill-remote-cache-salt: linux
+----
+
+These keys correspond to the `--remote-cache-location`, `--remote-cache-filter`, and
+`--remote-cache-salt` xref:cli/flags.adoc[command-line flags]; an explicit flag on the command
+line overrides the build-header value (e.g. to disable the cache for a single run). See
+xref:large/remote-caching.adoc[Remote Caching] for the available backends and operational
+trade-offs.
+
 == mill-separate-bsp-output-dir
 
 By default, BSP sessions share the regular `out/` directory and Mill daemon with

--- a/website/docs/modules/ROOT/pages/large/large.adoc
+++ b/website/docs/modules/ROOT/pages/large/large.adoc
@@ -21,3 +21,5 @@ that can be utilized to help you manage the build system of a large project or c
 * xref:large/multi-language-builds.adoc[]
 
 * xref:large/pre-compiled-modules.adoc[]
+
+* xref:large/remote-caching.adoc[]

--- a/website/docs/modules/ROOT/pages/large/remote-caching.adoc
+++ b/website/docs/modules/ROOT/pages/large/remote-caching.adoc
@@ -1,0 +1,60 @@
+= Remote Caching
+
+include::partial$example/large/remotecache/1-shared-folder.adoc[]
+
+== A Bazel-Remote Cache Server
+
+include::partial$example/large/remotecache/2-bazel-remote.adoc[]
+
+== An Apache httpd Cache Server
+
+include::partial$example/large/remotecache/3-apache-httpd.adoc[]
+
+== Configuration
+
+Remote caching is controlled by three settings, set in your
+xref:cli/build-header.adoc#_mill_remote_cache_location[build header] so they apply to every
+build, or as command-line flags for a one-off run:
+
+* *`--remote-cache-location`* is the cache location: the base URL of a Bazel-remote-protocol
+  HTTP cache, or a `file:` URL / path (a leading `~/` is resolved against your home directory)
+  to a shared folder used as the cache with no server. This is the only setting needed to turn
+  remote caching on.
+
+* *`--remote-cache-filter`* restricts caching to the tasks matching a task query, e.g.
+  `__.compile`. When omitted, every cacheable task is eligible.
+
+* *`--remote-cache-salt`* adds an extra string to the cache key to partition the cache, e.g.
+  to keep entries computed on different operating systems from being shared.
+
+For caches that require authentication, set the `MILL_REMOTE_CACHE_AUTHORIZATION` environment
+variable; Mill sends its value as the `Authorization` header on every request, supporting
+bearer tokens, HTTP basic auth, and similar schemes.
+
+== Limitations
+
+As with every build tool's remote cache (Bazel, Buck, Pants, ...), remote caching comes with
+trade-offs. None of these are unique to Mill:
+
+* *Remote caching assumes all of a task's inputs are tracked.* It cannot detect a task that
+  produces different output for the same `inputsHash` because of an un-tracked input, e.g. a
+  task that shells out to a system tool whose version differs between machines. Use
+  `--remote-cache-salt` to give such environments different cache keys, for example a
+  different salt on macOS developer machines and on Linux CI.
+
+* *Anyone with write access to the cache can run code on every reader.* A task output uploaded
+  by one machine, including compiled binaries and scripts, is downloaded and used on every
+  other machine that reads from the cache, so all machines sharing a cache must be within the
+  same trust boundary. A common safe topology is to grant write access only to trusted CI
+  (e.g. main-branch builds) while letting developer laptops and PR builds read from it.
+
+* *Not every task benefits from remote caching.* Some tasks are faster to recompute locally
+  than to fetch over the network, and Mill caches at a whole-task granularity, where each
+  task's output directory is a single cache entry. Use `--remote-cache-filter` to target the
+  expensive, high-reuse tasks such as `__.compile` where caching pays off.
+
+* *Persistent tasks are cached, but many task types are not.* Persistent tasks like `compile`,
+  whose `dest/` holds incremental-compiler state, do participate, since sharing compiled
+  output is the primary use case; a remote miss leaves their local `dest/` intact so an
+  incremental recompute can still re-use it. `Task.Input`, `Task.Command`, `Task.Worker`, and
+  other non-cached task types are never sent to the remote cache.


### PR DESCRIPTION
Follow on for https://github.com/com-lihaoyi/mill/pull/4642

This PR allows Mill builds in different folders or different computers to share their `out/` folder data, by means of a third-party remote-cache service referenced via `--remote-cache-url`

1. This means that you "never" need to build something twice across an entire fleet of machines. A target compiled on one machine can have its output downloaded and re-used on another, assuming the inputs are unchanged (detected via our normal `inputsHash` invalidation logic)

2. This also means you never have to re-run tests unnecessarily (using `testCached`, which is a `Target` and thus cached), which means if you re-run a job due to a flaky test most of the other tests should be automatically skipped (since their result is in the cache) and only the specific flaky tests would need to re-run

## Limitations

1. Remote Caching assumes that all inputs are tracked. The remote cache cannot detect scenarios where un-tracked inputs cause a target with the same `inputsHash` result in different outcomes, e.g. by calling different versions of a CLI tool. I included a `--remote-cache-salt` flag for a user to explicitly pass in whatever they want as an additional cache key, e.g. they could give developers on Mac-OSX and CI machines on Linux different salts to ensure they do not share cache entries

2. Remote caching has [known security considerations](https://groups.google.com/g/bazel-discuss/c/0005BAB_mlI); anyone with push access to the remote cache can send arbitrary binaries to be executed on the other machines pulling from it. All machines sharing a remote cache have to be within the same trust boundary. Other topologies include only pushing to the cache from trusted machines (e.g. CI running on master) but allowing pulling from untrusted machines (e.g. developer laptops)

3. Not everything benefits from remote caching; some targets are faster to compute locally that fetch over the network, and it's impossible to statically determine which ones. `--remote-cache-filter` allows the user to select what targets they want to cache. There are probably other ways we could try and tune things e.g. setting minimum-durations or max-output-sizes for cache uploads.

None of these limitations are unique to Mill's implementation: every build tool with remote caching suffers from them, including Bazel. But is worth calling out for anyone who wishes to deploy such a system

## Implementation

1. We use the [bazel-remote-execution protocol](https://github.com/bazelbuild/remote-apis) for compatibility with bazel remote caches. This has become a de-facto standard, with multiple build tools supporting it as clients (Bazel, Buck, Pants, ...) and multiple backend implementations supporting it as servers ([bazel-remote](https://github.com/buchgr/bazel-remote), [Buildbarn](https://github.com/buildbarn), [EngFlow](https://www.engflow.com/), ...).

    * This also saves us from architecting/implementing/maintaining our own scalable high-performance cache backend servers, which is a huge win.
    * I didn't manage to find any other commonly-implemented file-based cache server protocols we could leverage. The closest was WebDAV, which is much simpler than bazel-remote-execution and supported by common tools like Nginx or ApacheHTTPD, but it does not come with cache-eviction and thus would be problematic to use without further configuration of cron jobs and other things

2. The Bazel remote execution protocol is extremely detailed, and does not completely match up with Mill's data model. For this PR we integrate with it relatively shallowly: on write, we PUT a single `ActionResult` to the Action Cache endpoint `/ac/...`, which references a single output file which is a `.tar.gz` of the `foo.{dest,json,log}` folders we PUT to the Content Addressable Store endpoint `/cas/...`. On read, we do the reverse: grab the `/ac/` data, use it to grab the `/cas/` blob, and unpack it.

    * This two-step process is necessary because the bazel remote cache API [disallows "inline" requests that upload file contents to the `/ac/` metadata store](https://github.com/bazelbuild/remote-apis/blob/6c32c3b917cc5d3cfee680c03179d7552832bb3f/build/bazel/remote/execution/v2/remote_execution.proto#L1216-L1222). The Bazel-Remote implementation I tested against does not seem to complain, but better follow the spec anyway in case other servers are not so forgiving

    * The fact that we bundle all target data into one big `.tar.gz` blob does mean the cache is at a target-level granularity. The protocol allows finer grained stuff (e.g. sharing individual files), but we can leave support for that for future work

    * We limit the uploads in the `.dest` folder to only things references by `PathRef`s. I use a `DynamicVariable` to instrument the JSON serialization of `PathRef`s so I can gather up all the `PathRef`s in a task's return value for this purpose. This is a similar approach as we discussed w.r.t. `PathRef.validatedPaths`

5. It took some fiddling to make input hashes consistent across different folders. 
    * I made `JsonFormatters.pathReadWrite` to serialize relative paths whenever the path is within `os.pwd`
    * I tweaked the `MillBuildRootModule` script-wrapper-code-generator to generated paths relative to `os.pwd`
    * The use of `os.pwd` is somewhat arbitrary here. It may make things a bit annoying for testing: we can only change the `os.pwd` via subprocesses in integration tests and not unit tests. But the alternative of passing an implicit `RepoRoot` everywhere in our codebase would make things more annoying for everyone else, so this may be the best option

6. The remote cache will likely need a lot more configuration in future: certificates, authentication, HTTP proxy config, etc.. This stuff cannot live in any `build.sc`, even a meta-build, since it is necessary to evaluate the `build.sc`'s tasks, unless we accept that the meta-build is never going to be remote-cached. The alternative is to put it in some JSON/YAML file somewhere

7. We need some way to annotate things like `resolvedIvyDeps` to ensure they are not remote cached, so they can be downloaded anew on each machine.

8. I pre-built and published the Java protobuf stubs from https://github.com/bazelbuild/remote-apis via a `bazelRemoteApis` target in Mill's own build file, versioned separately from the rest of Mill, similar to what we do for the Zinc compiler bridges. This shouldn't change very often, and when it does should generally be backwards compatible, so we shouldn't need to include it as a formal part of the Mill build graph

9. I broke the caching-related logic (both remote and logic) out of `GroupEvaluator.scala` so it's easier to navigate around that part of the codebase

## Testing

Tested manually with https://github.com/buchgr/bazel-remote

```
$ ./bazel-remote-2.4.3-darwin-arm64 --dir dir --max_size 1 

$ cp -R example/basic/1-simple-scala example/basic/1-simple-scala-copy

$ ./mill -i dev.run example/basic/1-simple-scala -i --remote-cache-filter __.compile --remote-cache-url http://localhost:8080 run --text hello

$ ./mill -i dev.run example/basic/1-simple-scala-copy -i --remote-cache-filter __.compile --remote-cache-url http://localhost:8080 run --text hello
```

This is a proof of concept that demonstrates the ability for multiple different checkouts of the same repo to share the remote cache. After running the commands above, we can look at `1-simple-scala-copy/out/mill-profile.json` to see that `compile` was cached, despite being run on a "clean" repository.  Removing the `--remote-cache-filter` and re-doing the above steps after removing the `out/` folders demonstrates that everything is cached except `mill.scalalib.ZincWorkerModule.worker` and `run`, which is to be expected. Not merge-ready, but it demonstrates the approach and can probably be cleaned up and fleshed out we decide to move forward with it.

## TODO

1. We need some way to handle "quick" `PathRef`s. These replacing the content-hashing with comparing `mtime` timestamps, and are used for large binary files downloaded externally where the file changes almost-never (so a timestamp is good enough to ~never invalidate them) and are often large binary blobs (so hashing them everytime is wasteful and expensive). `mtime`s won't work on remote caching because each machine will download them anew and get different download times.

