### PR TITLE
Optimize ScalaJSModule and cache `IRFileCache`

### DIFF
--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -89,7 +89,8 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
     // we need to use the scala-library of the currently running mill
     resolveDependencies(
       repositoriesTask(),
-      (commonDeps.iterator ++ envDeps).map(Lib.depToBoundDep(_, mill.main.BuildInfo.scalaVersion, "")),
+      (commonDeps.iterator ++ envDeps)
+        .map(Lib.depToBoundDep(_, mill.main.BuildInfo.scalaVersion, "")),
       ctx = Some(T.log)
     )
   }

--- a/scalajslib/src/mill/scalajslib/worker/ScalaJSWorker.scala
+++ b/scalajslib/src/mill/scalajslib/worker/ScalaJSWorker.scala
@@ -149,10 +149,9 @@ private[scalajslib] class ScalaJSWorker extends AutoCloseable {
 
   def link(
       toolsClasspath: Agg[mill.PathRef],
-      sources: Agg[os.Path],
-      libraries: Agg[os.Path],
+      runClasspath: Agg[mill.PathRef],
       dest: File,
-      main: Option[String],
+      main: Either[String, String],
       forceOutJs: Boolean,
       testBridgeInit: Boolean,
       isFullLinkJS: Boolean,
@@ -164,10 +163,9 @@ private[scalajslib] class ScalaJSWorker extends AutoCloseable {
       outputPatterns: api.OutputPatterns
   )(implicit ctx: Ctx.Home): Result[api.Report] = {
     bridge(toolsClasspath).link(
-      sources = sources.items.map(_.toIO).toArray,
-      libraries = libraries.items.map(_.toIO).toArray,
+      runClasspath = runClasspath.iterator.map(_.path.toNIO).toSeq,
       dest = dest,
-      main = main.orNull,
+      main = main,
       forceOutJs = forceOutJs,
       testBridgeInit = testBridgeInit,
       isFullLinkJS = isFullLinkJS,
@@ -186,8 +184,7 @@ private[scalajslib] class ScalaJSWorker extends AutoCloseable {
   def run(toolsClasspath: Agg[mill.PathRef], config: api.JsEnvConfig, report: api.Report)(
       implicit ctx: Ctx.Home
   ): Unit = {
-    val dest =
-      bridge(toolsClasspath).run(toWorkerApi(config), toWorkerApi(report))
+    bridge(toolsClasspath).run(toWorkerApi(config), toWorkerApi(report))
   }
 
   def getFramework(

--- a/scalajslib/worker-api/src/mill/scalajslib/worker/api/ScalaJSWorkerApi.scala
+++ b/scalajslib/worker-api/src/mill/scalajslib/worker/api/ScalaJSWorkerApi.scala
@@ -1,13 +1,13 @@
 package mill.scalajslib.worker.api
 
 import java.io.File
+import java.nio.file.Path
 
 private[scalajslib] trait ScalaJSWorkerApi {
   def link(
-      sources: Array[File],
-      libraries: Array[File],
+      runClasspath: Seq[Path],
       dest: File,
-      main: String,
+      main: Either[String, String],
       forceOutJs: Boolean,
       testBridgeInit: Boolean,
       isFullLinkJS: Boolean,


### PR DESCRIPTION
This PR contains various optimizations in `ScalaJSModule` and `ScalaJSWorkerImpl`.
Changes:
- Limit the conversions between types and try to propagate the values to the worker to avoid allocations
- Avoid manually splitting `sjsir` files and `jar` files manually and let the Scala.js toolchain do it with `PathIRContainer.fromClasspath(runClasspath)` passing the full runClasspath
- Avoid allocating extra lists
- Cache the `IRFileCache.Cache` together with the linker so it can be reused in multiple invocations of `fastLinkJS`

Pull request: https://github.com/com-lihaoyi/mill/pull/2783