### PR TITLE
Use `quick = true` when calculating PathRef for Mill executable

### DIFF
--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -42,6 +42,7 @@ class MillBuildBootstrap(
   import MillBuildBootstrap._
 
   val millBootClasspath = prepareMillBootClasspath(projectRoot / "out")
+  val millBootClasspathPathRefs = millBootClasspath.map(PathRef(_, quick = true))
 
   def evaluate(): Watching.Result[RunnerState] = {
     val runnerState = evaluateRec(0)
@@ -162,7 +163,7 @@ class MillBuildBootstrap(
                 .dropRight(1)
                 .headOption
                 .map(_.runClasspath)
-                .getOrElse(millBootClasspath.map(PathRef(_, quick = true)))
+                .getOrElse(millBootClasspathPathRefs)
                 .map(p => (p.path, p.sig))
                 .hashCode(),
               nestedState

--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -162,7 +162,7 @@ class MillBuildBootstrap(
                 .dropRight(1)
                 .headOption
                 .map(_.runClasspath)
-                .getOrElse(millBootClasspath.map(PathRef(_)))
+                .getOrElse(millBootClasspath.map(PathRef(_, quick = true)))
                 .map(p => (p.path, p.sig))
                 .hashCode(),
               nestedState


### PR DESCRIPTION
The Mill executable is a static file that is downloaded and doesn't change. Changing the `PathRef` calculation to `quick = true` makes it invalidate the cache everytime the mill executable changes.
Before it took ~160ms, after it takes ~100μs ~100 times faster. This code runs twice on every Mill command line task execution.
This also stores the `PathRef`s in memory so they don't need to be computed on every command invocation

Pull request: https://github.com/com-lihaoyi/mill/pull/2785