### PR TITLE
Introduce `mill.api.MillException` to transport the error condition

### DIFF
--- a/main/api/src/mill/api/MillException.scala
+++ b/main/api/src/mill/api/MillException.scala
@@ -1,0 +1,7 @@
+package mill.api
+
+/**
+ * This exception is specifically handled in [[mill.runner.MillMain]] and [[mill.runner.MillServerMain]]. You can use it, if you need to exit Mill with a nice error message.
+ * @param msg The error message, to be displayed to the user.
+ */
+class MillException(msg: String) extends Exception(msg)

--- a/runner/src/mill/runner/MillServerMain.scala
+++ b/runner/src/mill/runner/MillServerMain.scala
@@ -71,17 +71,18 @@ object MillServerMain extends MillServerMain[RunnerState] {
       userSpecifiedProperties: Map[String, String],
       initialSystemProperties: Map[String, String]
   ): (Boolean, RunnerState) = {
-    MillMain.main0(
-      args = args,
-      stateCache = stateCache,
-      mainInteractive = mainInteractive,
-      streams0 = streams,
-      bspLog = None,
-      env = env,
-      setIdle = setIdle,
-      userSpecifiedProperties0 = userSpecifiedProperties,
-      initialSystemProperties = initialSystemProperties
-    )
+    try MillMain.main0(
+        args = args,
+        stateCache = stateCache,
+        mainInteractive = mainInteractive,
+        streams0 = streams,
+        bspLog = None,
+        env = env,
+        setIdle = setIdle,
+        userSpecifiedProperties0 = userSpecifiedProperties,
+        initialSystemProperties = initialSystemProperties
+      )
+    catch MillMain.handleMillException(streams.err, stateCache)
   }
 }
 


### PR DESCRIPTION
_I needed this in various situations, so I created this PR as a base for other PRs. It's ok to keep this unmerged until we need it._

Not all build inconsistencies can't be detected before we start evaluation and not all can be reported as evaluation errors, hence this PR add an additional way to exit Mill with a proper error message. You can throw a `mill.api.MillException`. It will be handled in `MillMain` as well as `MillClientMain`, our central entry points to Mill. The error message will be reported to the user and Mill exits with code 1. No stack trace will be shown.

Pull request: https://github.com/com-lihaoyi/mill/pull/2789