### PR TITLE
Update bsp4j to 2.1.0-M6 and adapt to breaking API changes

### DIFF
--- a/bsp/worker/src/mill/bsp/worker/BspCompileProblemReporter.scala
+++ b/bsp/worker/src/mill/bsp/worker/BspCompileProblemReporter.scala
@@ -164,7 +164,7 @@ private class BspCompileProblemReporter(
       val taskStartParams = new TaskStartParams(taskId)
       taskStartParams.setEventTime(System.currentTimeMillis())
       taskStartParams.setData(compileTask)
-      taskStartParams.setDataKind(TaskDataKind.COMPILE_TASK)
+      taskStartParams.setDataKind(TaskStartDataKind.COMPILE_TASK)
       taskStartParams.setMessage(s"Compiling target ${targetDisplayName}")
       client.onBuildTaskStart(taskStartParams)
       started.set(true)
@@ -176,7 +176,7 @@ private class BspCompileProblemReporter(
       val taskFinishParams = new TaskFinishParams(taskId, getStatusCode)
       taskFinishParams.setEventTime(System.currentTimeMillis())
       taskFinishParams.setMessage(s"Compiled ${targetDisplayName}")
-      taskFinishParams.setDataKind(TaskDataKind.COMPILE_REPORT)
+      taskFinishParams.setDataKind(TaskFinishDataKind.COMPILE_REPORT)
       val compileReport = new CompileReport(targetId, errors.get, warnings.get)
       compilationOriginId match {
         case Some(id) => compileReport.setOriginId(id)

--- a/bsp/worker/src/mill/bsp/worker/BspTestReporter.scala
+++ b/bsp/worker/src/mill/bsp/worker/BspTestReporter.scala
@@ -4,9 +4,10 @@ import ch.epfl.scala.bsp4j.{
   BuildClient,
   BuildTargetIdentifier,
   StatusCode,
-  TaskDataKind,
+  TaskFinishDataKind,
   TaskFinishParams,
   TaskId,
+  TaskStartDataKind,
   TaskStartParams,
   TestFinish,
   TestReport,
@@ -56,7 +57,7 @@ private class BspTestReporter(
   override def logStart(event: Event): Unit = {
     val taskStartParams = new TaskStartParams(taskId)
     taskStartParams.setEventTime(System.currentTimeMillis())
-    taskStartParams.setDataKind(TaskDataKind.TEST_START)
+    taskStartParams.setDataKind(TaskStartDataKind.TEST_START)
     taskStartParams.setData(new TestStart(getDisplayName(event)))
     taskStartParams.setMessage("Starting running: " + getDisplayName(event))
     client.onBuildTaskStart(taskStartParams)
@@ -108,7 +109,7 @@ private class BspTestReporter(
         TestStatus.SKIPPED // TODO: what to do here
     }
 
-    taskFinishParams.setDataKind(TaskDataKind.TEST_FINISH)
+    taskFinishParams.setDataKind(TaskFinishDataKind.TEST_FINISH)
     taskFinishParams.setData({
       val testFinish = new TestFinish(getDisplayName(event), status)
       if (event.throwable.isDefined)

--- a/bsp/worker/src/mill/bsp/worker/MillBspLogger.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBspLogger.scala
@@ -47,7 +47,7 @@ private class MillBspLogger(client: BuildClient, taskId: Int, logger: Logger)
 
   override def info(s: String): Unit = {
     super.info(s)
-    client.onBuildShowMessage(new ShowMessageParams(MessageType.INFORMATION, s))
+    client.onBuildShowMessage(new ShowMessageParams(MessageType.INFO, s))
   }
 
   override def debug(s: String): Unit = {

--- a/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -43,9 +43,10 @@ import ch.epfl.scala.bsp4j.{
   SourcesParams,
   SourcesResult,
   StatusCode,
-  TaskDataKind,
+  TaskFinishDataKind,
   TaskFinishParams,
   TaskId,
+  TaskStartDataKind,
   TaskStartParams,
   TestParams,
   TestProvider,
@@ -73,6 +74,9 @@ import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}
 import Utils.sanitizeUri
 import mill.bsp.BspServerResult
+import mill.eval.Evaluator.TaskResult
+
+import scala.util.chaining.scalaUtilChainingOps
 private class MillBuildServer(
     bspVersion: String,
     serverVersion: String,
@@ -88,7 +92,6 @@ private class MillBuildServer(
   private[worker] var onSessionEnd: Option[BspServerResult => Unit] = None
   protected var client: BuildClient = _
   private var initialized = false
-  private var clientInitialized = false
   private var shutdownRequested = false
   protected var clientWantsSemanticDb = false
   protected var clientIsIntelliJ = false
@@ -107,7 +110,7 @@ private class MillBuildServer(
 
   def debug(msg: String) = logStream.println(msg)
 
-  override def onConnectWithClient(buildClient: BuildClient): Unit = client = buildClient
+  def onConnectWithClient(buildClient: BuildClient): Unit = client = buildClient
 
   override def buildInitialize(request: InitializeBuildParams)
       : CompletableFuture[InitializeBuildResult] =
@@ -167,7 +170,7 @@ private class MillBuildServer(
     }
 
   override def onBuildInitialized(): Unit = {
-    clientInitialized = true
+    debug("Build initialized")
   }
 
   override def buildShutdown(): CompletableFuture[Object] = {
@@ -218,13 +221,15 @@ private class MillBuildServer(
           Some((dataKind, target))
 
         case Some((dataKind, d: JvmBuildTarget)) =>
-          val target = new bsp4j.JvmBuildTarget(
-            d.javaHome.map(_.uri).getOrElse(null),
-            d.javaVersion.getOrElse(null)
-          )
+          val target = new bsp4j.JvmBuildTarget().tap { it =>
+            d.javaHome.foreach(jh => it.setJavaHome(jh.uri))
+            d.javaVersion.foreach(jv => it.setJavaVersion(jv))
+          }
           Some((dataKind, target))
 
-        case Some((dataKind, d)) => None // unsupported data kind
+        case Some((dataKind, d)) =>
+          debug(s"Unsupported dataKind=${dataKind} with value=${d}")
+          None // unsupported data kind
         case None => None
       }
 
@@ -233,7 +238,12 @@ private class MillBuildServer(
         s.tags.asJava,
         s.languageIds.asJava,
         deps.asJava,
-        new BuildTargetCapabilities(s.canCompile, s.canTest, s.canRun, s.canDebug)
+        new BuildTargetCapabilities().tap { it =>
+          it.setCanCompile(s.canCompile)
+          it.setCanTest(s.canTest)
+          it.setCanRun(s.canRun)
+          it.setCanDebug(s.canDebug)
+        }
       )
 
       s.displayName.foreach(buildTarget.setDisplayName)
@@ -524,7 +534,7 @@ private class MillBuildServer(
               val taskStartParams = new TaskStartParams(new TaskId(testTask.hashCode().toString))
               taskStartParams.setEventTime(System.currentTimeMillis())
               taskStartParams.setMessage("Testing target: " + targetId)
-              taskStartParams.setDataKind(TaskDataKind.TEST_TASK)
+              taskStartParams.setDataKind(TaskStartDataKind.TEST_TASK)
               taskStartParams.setData(new TestTask(targetId))
               client.onBuildTaskStart(taskStartParams)
 
@@ -555,7 +565,7 @@ private class MillBuildServer(
               taskFinishParams.setMessage(
                 s"Finished testing target${testModule.bspBuildTarget.displayName}"
               )
-              taskFinishParams.setDataKind(TaskDataKind.TEST_REPORT)
+              taskFinishParams.setDataKind(TaskFinishDataKind.TEST_REPORT)
               taskFinishParams.setData(testReporter.getTestReport)
               client.onBuildTaskFinish(taskFinishParams)
 
@@ -603,8 +613,11 @@ private class MillBuildServer(
             if (cleanResult.failing.keyCount > 0) (
               msg + s" Target ${compileTargetName} could not be cleaned. See message from mill: \n" +
                 (cleanResult.results(cleanTask) match {
-                  case fail: Result.Failure[Any] => fail.msg + "\n"
-                  case _ => "could not retrieve message"
+                  case TaskResult(Result.Failure(msg, _), _) => msg
+                  case TaskResult(ex: Result.Exception, _) => ex.toString()
+                  case TaskResult(Result.Skipped, _) => "Task was skipped"
+                  case TaskResult(Result.Aborted, _) => "Task was aborted"
+                  case _ => "could not retrieve the failure message"
                 }),
               false
             )
@@ -620,7 +633,9 @@ private class MillBuildServer(
             }
         }
 
-      new CleanCacheResult(msg, cleaned)
+      new CleanCacheResult(cleaned).tap { it =>
+        it.setMessage(msg)
+      }
     }
 
   override def debugSessionStart(debugParams: DebugSessionParams)

--- a/bsp/worker/src/mill/bsp/worker/MillJavaBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillJavaBuildServer.scala
@@ -29,6 +29,7 @@ private trait MillJavaBuildServer extends JavaBuildServer { this: MillBuildServe
         T.task { (classesPathTask(), m.javacOptions(), m.bspCompileClasspath()) }
       }
     ) {
+      // We ignore all non-JavaModule
       case (ev, state, id, m: JavaModule, (classesPath, javacOptions, bspCompileClasspath)) =>
         val pathResolver = ev.pathsResolver
         val options = javacOptions

--- a/bsp/worker/src/mill/bsp/worker/MillJvmBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillJvmBuildServer.scala
@@ -18,7 +18,8 @@ import java.util.concurrent.CompletableFuture
 import scala.jdk.CollectionConverters._
 
 private trait MillJvmBuildServer extends JvmBuildServer { this: MillBuildServer =>
-  override def jvmRunEnvironment(params: JvmRunEnvironmentParams)
+
+  override def buildTargetJvmRunEnvironment(params: JvmRunEnvironmentParams)
       : CompletableFuture[JvmRunEnvironmentResult] = {
     jvmRunTestEnvironment(
       s"jvmRunEnvironment ${params}",
@@ -27,7 +28,7 @@ private trait MillJvmBuildServer extends JvmBuildServer { this: MillBuildServer 
     )
   }
 
-  override def jvmTestEnvironment(params: JvmTestEnvironmentParams)
+  override def buildTargetJvmTestEnvironment(params: JvmTestEnvironmentParams)
       : CompletableFuture[JvmTestEnvironmentResult] = {
     jvmRunTestEnvironment(
       s"jvmTestEnvironment ${params}",
@@ -59,6 +60,7 @@ private trait MillJvmBuildServer extends JvmBuildServer { this: MillBuildServer 
           }
       }
     ) {
+      // We ignore all non-JavaModule
       case (
             ev,
             state,

--- a/bsp/worker/src/mill/bsp/worker/State.scala
+++ b/bsp/worker/src/mill/bsp/worker/State.scala
@@ -23,7 +23,7 @@ private class State(evaluators: Seq[Evaluator], debug: String => Unit) {
         }
       }
       .toMap
-    debug(s"BspModules: ${map.mapValues(_._1.bspDisplayName).toMap}")
+    debug(s"BspModules: ${map.view.mapValues(_._1.bspDisplayName).toMap}")
 
     map
   }
@@ -31,5 +31,5 @@ private class State(evaluators: Seq[Evaluator], debug: String => Unit) {
   lazy val rootModules: Seq[mill.define.BaseModule] = evaluators.map(_.rootModule)
 
   lazy val bspIdByModule: Map[BspModule, BuildTargetIdentifier] =
-    bspModulesById.mapValues(_._1).map(_.swap).toMap
+    bspModulesById.view.mapValues(_._1).map(_.swap).toMap
 }

--- a/build.sc
+++ b/build.sc
@@ -157,7 +157,7 @@ object Deps {
   val windowsAnsi = ivy"io.github.alexarchambault.windows-ansi:windows-ansi:0.0.5"
   val zinc = ivy"org.scala-sbt::zinc:1.9.5"
   // keep in sync with doc/antora/antory.yml
-  val bsp4j = ivy"ch.epfl.scala:bsp4j:2.1.0-M5"
+  val bsp4j = ivy"ch.epfl.scala:bsp4j:2.1.0-M6"
   val fansi = ivy"com.lihaoyi::fansi:0.4.0"
   val jarjarabrams = ivy"com.eed3si9n.jarjarabrams::jarjar-abrams-core:1.9.0"
   val requests = ivy"com.lihaoyi::requests:0.8.0"

--- a/main/api/src/mill/api/Result.scala
+++ b/main/api/src/mill/api/Result.scala
@@ -83,7 +83,7 @@ object Result {
     def map[V](f: Nothing => V): Exception = this
     def flatMap[V](f: Nothing => Result[V]): Exception = this
 
-    override def toString: String = {
+    override def toString(): String = {
       var current = List(throwable)
       while (current.head.getCause != null) {
         current = current.head.getCause :: current


### PR DESCRIPTION
This PR adapts the Mill BSP server to the latest bsp4j API changes (binary incompatible). This will eventually end up in BSP protocol version `2.2.0`.

Pull request: https://github.com/com-lihaoyi/mill/pull/2794