### PR TITLE
CI: lower job timeout to 90 minutes

### DIFF
--- a/.github/workflows/run-mill-action.yml
+++ b/.github/workflows/run-mill-action.yml
@@ -18,12 +18,16 @@ on:
       continue-on-error:
         default: false
         type: boolean
+      timeout-minutes:
+        default: 90
+        type: number
 
 jobs:
   build:
 
     runs-on: ${{ inputs.os }}
     continue-on-error: ${{ inputs.continue-on-error }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Some integration tests fail due to hanging client-server comunication.
This PR lowers the timeout form 360 to 90 minutes, to detect failing CI runs earlier.
