### PR TITLE
protobuf module: fix truncation issue when unpacking

### DIFF
--- a/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBModule.scala
+++ b/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBModule.scala
@@ -104,7 +104,7 @@ trait ScalaPBModule extends ScalaModule {
             case Some(entry) =>
               if (entry.getName.endsWith(".proto")) {
                 val protoDest = dest / os.SubPath(entry.getName)
-                Using(os.write.outputStream(protoDest, createFolders = true))(IO.stream(zip, _))
+                Using(os.write.over.outputStream(protoDest, createFolders = true))(IO.stream(zip, _))
               }
               zip.closeEntry()
               true

--- a/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBModule.scala
+++ b/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBModule.scala
@@ -104,10 +104,9 @@ trait ScalaPBModule extends ScalaModule {
             case Some(entry) =>
               if (entry.getName.endsWith(".proto")) {
                 val protoDest = dest / os.SubPath(entry.getName)
-                Using(os.write.over.outputStream(protoDest, createFolders = true))(IO.stream(
-                  zip,
-                  _
-                ))
+                Using.resource(os.write.over.outputStream(protoDest, createFolders = true)) { os =>
+                  IO.stream(zip, os)
+                }```
               }
               zip.closeEntry()
               true

--- a/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBModule.scala
+++ b/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBModule.scala
@@ -104,7 +104,10 @@ trait ScalaPBModule extends ScalaModule {
             case Some(entry) =>
               if (entry.getName.endsWith(".proto")) {
                 val protoDest = dest / os.SubPath(entry.getName)
-                Using(os.write.over.outputStream(protoDest, createFolders = true))(IO.stream(zip, _))
+                Using(os.write.over.outputStream(protoDest, createFolders = true))(IO.stream(
+                  zip,
+                  _
+                ))
               }
               zip.closeEntry()
               true

--- a/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBModule.scala
+++ b/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBModule.scala
@@ -106,7 +106,7 @@ trait ScalaPBModule extends ScalaModule {
                 val protoDest = dest / os.SubPath(entry.getName)
                 Using.resource(os.write.over.outputStream(protoDest, createFolders = true)) { os =>
                   IO.stream(zip, os)
-                }```
+                }
               }
               zip.closeEntry()
               true

--- a/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBModule.scala
+++ b/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBModule.scala
@@ -104,6 +104,8 @@ trait ScalaPBModule extends ScalaModule {
             case Some(entry) =>
               if (entry.getName.endsWith(".proto")) {
                 val protoDest = dest / os.SubPath(entry.getName)
+                if (os.exists(protoDest))
+                  T.log.error(s"Warning: Overwriting ${dest} / ${os.SubPath(entry.getName)} ...")
                 Using.resource(os.write.over.outputStream(protoDest, createFolders = true)) { os =>
                   IO.stream(zip, os)
                 }


### PR DESCRIPTION
It is possible that unpacked files from the classpath share the same name but not the same content. In case an existing unpacked file is replaced by a shorter file, it needs to be properly truncated lest the result be garbage.

A warning messages is logged when a proto file gets overwritten.

Pull request: https://github.com/com-lihaoyi/mill/pull/2800