### PR TITLE
[BSP] Use consistent file URI format

### DIFF
--- a/bsp/worker/src/mill/bsp/worker/BspCompileProblemReporter.scala
+++ b/bsp/worker/src/mill/bsp/worker/BspCompileProblemReporter.scala
@@ -69,9 +69,9 @@ private class BspCompileProblemReporter(
     val diagnostic = getSingleDiagnostic(problem)
     val sourceFile = problem.position.sourceFile
     val textDocument = new TextDocumentIdentifier(
-      sourceFile.getOrElse(None) match {
+      sourceFile match {
         case None => targetId.getUri
-        case f: File => f.toURI.toString
+        case Some(f) => f.toPath.toUri.toString
       }
     )
     val params = new bsp.PublishDiagnosticsParams(

--- a/bsp/worker/src/mill/bsp/worker/BspCompileProblemReporter.scala
+++ b/bsp/worker/src/mill/bsp/worker/BspCompileProblemReporter.scala
@@ -71,7 +71,7 @@ private class BspCompileProblemReporter(
     val textDocument = new TextDocumentIdentifier(
       sourceFile match {
         case None => targetId.getUri
-        case Some(f) => 
+        case Some(f) =>
           // The extra step invoking `toPath` results in a nicer URI starting with `file:///`
           f.toPath.toUri.toString
       }

--- a/bsp/worker/src/mill/bsp/worker/BspCompileProblemReporter.scala
+++ b/bsp/worker/src/mill/bsp/worker/BspCompileProblemReporter.scala
@@ -71,7 +71,9 @@ private class BspCompileProblemReporter(
     val textDocument = new TextDocumentIdentifier(
       sourceFile match {
         case None => targetId.getUri
-        case Some(f) => f.toPath.toUri.toString
+        case Some(f) => 
+          // The extra step invoking `toPath` results in a nicer URI starting with `file:///`
+          f.toPath.toUri.toString
       }
     )
     val params = new bsp.PublishDiagnosticsParams(


### PR DESCRIPTION
Previously we were emitting different URI formats if the sourceFile info was missing or not.
Not sure if this is a problem, but `targetId.getUri` is returning files as `file:///foo/bar/file.scala` while our `java.io.File` `toURI` returns `file:/foo/bar/file.scala`
Changing it to `.toPath.toUri` for consistency