### PR TITLE
Use project root as `T.workspace` also in meta-build

### DIFF
--- a/main/eval/src/mill/eval/EvaluatorImpl.scala
+++ b/main/eval/src/mill/eval/EvaluatorImpl.scala
@@ -14,7 +14,7 @@ import scala.reflect.ClassTag
  */
 private[mill] case class EvaluatorImpl(
     home: os.Path,
-    projectRoot: os.Path,
+    workspace: os.Path,
     outPath: os.Path,
     externalOutPath: os.Path,
     rootModule: mill.define.BaseModule,

--- a/main/eval/src/mill/eval/EvaluatorImpl.scala
+++ b/main/eval/src/mill/eval/EvaluatorImpl.scala
@@ -14,6 +14,7 @@ import scala.reflect.ClassTag
  */
 private[mill] case class EvaluatorImpl(
     home: os.Path,
+    projectRoot: os.Path,
     outPath: os.Path,
     externalOutPath: os.Path,
     rootModule: mill.define.BaseModule,

--- a/main/eval/src/mill/eval/GroupEvaluator.scala
+++ b/main/eval/src/mill/eval/GroupEvaluator.scala
@@ -18,6 +18,7 @@ import scala.util.control.NonFatal
  */
 private[mill] trait GroupEvaluator {
   def home: os.Path
+  def projectRoot: os.Path
   def outPath: os.Path
   def externalOutPath: os.Path
   def rootModule: mill.define.BaseModule
@@ -299,7 +300,7 @@ private[mill] trait GroupEvaluator {
               env = env,
               reporter = reporter,
               testReporter = testReporter,
-              workspace = rootModule.millSourcePath
+              workspace = projectRoot
             ) with mill.api.Ctx.Jobs {
               override def jobs: Int = effectiveThreadCount
             }

--- a/main/eval/src/mill/eval/GroupEvaluator.scala
+++ b/main/eval/src/mill/eval/GroupEvaluator.scala
@@ -18,7 +18,7 @@ import scala.util.control.NonFatal
  */
 private[mill] trait GroupEvaluator {
   def home: os.Path
-  def projectRoot: os.Path
+  def workspace: os.Path
   def outPath: os.Path
   def externalOutPath: os.Path
   def rootModule: mill.define.BaseModule
@@ -300,7 +300,7 @@ private[mill] trait GroupEvaluator {
               env = env,
               reporter = reporter,
               testReporter = testReporter,
-              workspace = projectRoot
+              workspace = workspace
             ) with mill.api.Ctx.Jobs {
               override def jobs: Int = effectiveThreadCount
             }

--- a/main/testkit/src/mill/testkit/MillTestkit.scala
+++ b/main/testkit/src/mill/testkit/MillTestkit.scala
@@ -94,6 +94,7 @@ trait MillTestKit {
     }
     val evaluator = mill.eval.EvaluatorImpl(
       mill.api.Ctx.defaultHome,
+      module.millSourcePath,
       outPath,
       outPath,
       module,

--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -338,6 +338,7 @@ class MillBuildBootstrap(
 
     mill.eval.EvaluatorImpl(
       home,
+      projectRoot,
       recOut(projectRoot, depth),
       recOut(projectRoot, depth),
       rootModule,


### PR DESCRIPTION
Fixes #2802

Pull request: https://github.com/com-lihaoyi/mill/pull/2809