### PR TITLE
Allow publishing bridge for a single version

### DIFF
--- a/.github/workflows/publish-bridges.yml
+++ b/.github/workflows/publish-bridges.yml
@@ -5,6 +5,12 @@ name: Publish Bridges
 # publishing workflow that runs every Mill version
 on:
   workflow_dispatch:
+    inputs:
+      bridge_versions:
+        description: 'comma-separated list of Scala versions to publish or `all` for all supported versions'
+        required: true
+        type: string
+
 jobs:
   publish-bridges:
     runs-on: ubuntu-latest
@@ -19,7 +25,7 @@ jobs:
       LANG: "en_US.UTF-8"
       LC_MESSAGES: "en_US.UTF-8"
       LC_ALL: "en_US.UTF-8"
-      MILL_BUILD_COMPILER_BRIDGES: "true"
+      MILL_COMPILER_BRIDGE_VERSIONS: ${{ inputs.bridge_versions }}
 
     steps:
       - uses: actions/checkout@v4

--- a/build.sc
+++ b/build.sc
@@ -224,7 +224,7 @@ val bridgeScalaVersions = Seq(
 val compilerBridgeScalaVersions = interp.watchValue(sys.env.get("MILL_COMPILER_BRIDGE_VERSIONS")) match {
   case None => Seq.empty[String]
   case Some("all") => bridgeScalaVersions
-  case Some(versions) => versions.split(',').toSeq
+  case Some(versions) => versions.split(',').map(_.trim).toSeq
 }
 val bridgeVersion = "0.0.1"
 


### PR DESCRIPTION
Releasing a new version of the bridge just for adding a Scala version is wasteful.
We can publish the bridge just for the new version (in our case `2.13.12`) without tagging a `0.0.2`.
This PR adds a `bridge_versions` input to the `workflow_dispatch` which can be `all` for the current behavior or a comma separated list of Scala versions. This way we can release the current bridge for Scala `2.13.12` and then add `2.13.12` to the list of supported bridges in a later PR.