### PR TITLE
Avoid recalculating `PathRef`s for `allSourceFiles`

### DIFF
--- a/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -311,7 +311,7 @@ private class MillBuildServer(
       val tasksEvaluators = state.bspModulesById.iterator.collect {
         case (id, (m: JavaModule, ev)) =>
           T.task {
-            val src = m.allSourceFiles()
+            val src = m.allSourceFilesTask()
             val found = src.map(sanitizeUri).contains(
               p.getTextDocument.getUri
             )

--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -219,7 +219,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
       .worker()
       .compileMixed(
         upstreamCompileOutput = upstreamCompileOutput(),
-        sources = allSourceFiles().map(_.path),
+        sources = allSourceFilesTask(),
         compileClasspath = compileClasspath().map(_.path),
         javacOptions = javacOptions(),
         scalaVersion = sv,
@@ -569,7 +569,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
     zincWorker().worker()
       .compileMixed(
         upstreamCompileOutput = upstreamCompileOutput(),
-        sources = allSourceFiles().map(_.path),
+        sources = allSourceFilesTask(),
         compileClasspath =
           (compileClasspath() ++ resolvedSemanticDbJavaPluginIvyDeps()).map(_.path),
         javacOptions = javacOpts,

--- a/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
+++ b/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
@@ -15,6 +15,7 @@ trait SemanticDbJavaModule extends CoursierModule {
   def zincWorker: ModuleRef[ZincWorkerModule]
   def upstreamCompileOutput: T[Seq[CompilationResult]]
   def zincReportCachedProblems: T[Boolean]
+  private[mill] def allSourceFilesTask: T[Seq[os.Path]]
   def allSourceFiles: T[Seq[PathRef]]
   def compile: T[mill.scalalib.api.CompilationResult]
   def bspBuildTarget: BspBuildTarget
@@ -111,7 +112,7 @@ trait SemanticDbJavaModule extends CoursierModule {
     zincWorker().worker()
       .compileJava(
         upstreamCompileOutput = upstreamCompileOutput(),
-        sources = allSourceFiles().map(_.path),
+        sources = allSourceFilesTask(),
         compileClasspath =
           (compileClasspath() ++ resolvedSemanticDbJavaPluginIvyDeps()).map(_.path),
         javacOptions = javacOpts,


### PR DESCRIPTION
Calculating `PathRef`s is expensive, so reducing them to the minimum improves performances.
This PR adds an internal task called `allSourceFilesTask` that is calculated everytime and returns `Seq[os.Path]` instead of `Seq[PathRef]`. The invalidation still works since `sources`, which is the input of `allSourceFilesTask` returns the `PathRef`s of the sources directories