### PR TITLE
Microsecond precision in chrome profile

### DIFF
--- a/main/eval/src/mill/eval/EvaluatorCore.scala
+++ b/main/eval/src/mill/eval/EvaluatorCore.scala
@@ -97,7 +97,7 @@ private[mill] trait EvaluatorCore extends GroupEvaluator {
             .flatMap(_.iterator.flatMap(_.newResults))
             .toMap
 
-          val startTime = System.currentTimeMillis()
+          val startTime = System.nanoTime() / 1000
           val threadId = threadNumberer.getThreadId(Thread.currentThread())
           val counterMsg = s"${count.getAndIncrement()}/${terminals.size}"
           val contextLogger = PrefixLogger(
@@ -119,13 +119,15 @@ private[mill] trait EvaluatorCore extends GroupEvaluator {
           if (failFast && res.newResults.values.exists(_.result.asSuccess.isEmpty))
             failed.set(true)
 
-          val endTime = System.currentTimeMillis()
+          val endTime = System.nanoTime() / 1000
+
+          val duration = endTime - startTime
 
           chromeProfileLogger.log(
             task = Terminal.printTerm(terminal),
             cat = "job",
             startTime = startTime,
-            endTime = endTime,
+            duration = duration,
             threadId = threadNumberer.getThreadId(Thread.currentThread()),
             cached = res.cached
           )
@@ -133,7 +135,7 @@ private[mill] trait EvaluatorCore extends GroupEvaluator {
           profileLogger.log(
             ProfileLogger.Timing(
               terminal.render,
-              (endTime - startTime).toInt,
+              (duration / 1000).toInt,
               res.cached,
               deps.map(_.render),
               res.inputsHash,

--- a/main/eval/src/mill/eval/JsonArrayLogger.scala
+++ b/main/eval/src/mill/eval/JsonArrayLogger.scala
@@ -59,7 +59,7 @@ private class ChromeProfileLogger(outPath: os.Path)
       task: String,
       cat: String,
       startTime: Long,
-      endTime: Long,
+      duration: Long,
       threadId: Int,
       cached: Boolean
   ): Unit = {
@@ -68,8 +68,8 @@ private class ChromeProfileLogger(outPath: os.Path)
       name = task,
       cat = cat,
       ph = "X",
-      ts = startTime * 1000,
-      dur = (endTime - startTime) * 1000 /*chrome treats the duration as microseconds*/,
+      ts = startTime,
+      dur = duration,
       pid = 1,
       tid = threadId,
       args = if (cached) Seq("cached") else Seq()


### PR DESCRIPTION
Chrome profiles support microsecond precision, so we can use `System.nanoTime` instead of `System.currentTimeMillis` to have better profiles