### PR TITLE
Add 2.13.12 to compiler bridge versions

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -213,7 +213,8 @@ val bridgeScalaVersions = Seq(
   "2.13.8",
   "2.13.9",
   "2.13.10",
-  "2.13.11"
+  "2.13.11",
+  "2.13.12"
 )
 
 // We limit the number of compiler bridges to compile and publish for local


### PR DESCRIPTION
`mill-scala-compiler-bridge_2.13.12` `0.0.1` is already on Maven Central so we can add `2.13.12` to the list of the supported versions. This way Mill will use published artifact instead of compiling from sources

Pull Request: https://github.com/com-lihaoyi/mill/pull/2830