### PR TITLE
Try to make `PathRef` robust against concurrent filesystem modifications

### DIFF
--- a/main/api/src/mill/api/PathRef.scala
+++ b/main/api/src/mill/api/PathRef.scala
@@ -124,7 +124,7 @@ object PathRef {
         ) {
           val sub = path.subRelativeTo(basePath)
           digest.update(sub.toString().getBytes())
-          if (!attrs.isDir) {
+          if (!attrs.isDir) try {
             if (isPosix) {
               updateWithInt(os.perms(path, followLinks = false).value)
             }
@@ -148,6 +148,13 @@ object PathRef {
                 }
               }
             }
+          } catch {
+            case e: java.nio.file.NoSuchFileException =>
+            // If file was deleted after we listed the folder but before we operate on it,
+            // `os.perms` or `os.read.inputStream` will crash. In that case, just do nothing,
+            // so next time we calculate the `PathRef` we'll get a different value (either
+            // with the file missing, or with the file present) and invalidate any caches
+
           }
         }
       }

--- a/main/api/src/mill/api/PathRef.scala
+++ b/main/api/src/mill/api/PathRef.scala
@@ -124,7 +124,7 @@ object PathRef {
         ) {
           val sub = path.subRelativeTo(basePath)
           digest.update(sub.toString().getBytes())
-          if (!attrs.isDir)
+          if (!attrs.isDir) {
             try {
               if (isPosix) {
                 updateWithInt(os.perms(path, followLinks = false).value)
@@ -158,6 +158,7 @@ object PathRef {
               // caches
 
             }
+          }
         }
       }
 

--- a/main/api/src/mill/api/PathRef.scala
+++ b/main/api/src/mill/api/PathRef.scala
@@ -152,8 +152,9 @@ object PathRef {
             case e: java.nio.file.NoSuchFileException =>
             // If file was deleted after we listed the folder but before we operate on it,
             // `os.perms` or `os.read.inputStream` will crash. In that case, just do nothing,
-            // so next time we calculate the `PathRef` we'll get a different value (either
-            // with the file missing, or with the file present) and invalidate any caches
+            // so next time we calculate the `PathRef` we'll get a different hash signature
+            // (either with the file missing, or with the file present) and invalidate any
+            // caches
 
           }
         }

--- a/main/api/src/mill/api/PathRef.scala
+++ b/main/api/src/mill/api/PathRef.scala
@@ -124,39 +124,40 @@ object PathRef {
         ) {
           val sub = path.subRelativeTo(basePath)
           digest.update(sub.toString().getBytes())
-          if (!attrs.isDir) try {
-            if (isPosix) {
-              updateWithInt(os.perms(path, followLinks = false).value)
-            }
-            if (quick) {
-              val value = (attrs.mtime, attrs.size).hashCode()
-              updateWithInt(value)
-            } else if (jnio.Files.isReadable(path.toNIO)) {
-              val is =
-                try Some(os.read.inputStream(path))
-                catch {
-                  case _: jnio.FileSystemException =>
-                    // This is known to happen, when we try to digest a socket file.
-                    // We ignore the content of this file for now, as we would do,
-                    // when the file isn't readable.
-                    // See https://github.com/com-lihaoyi/mill/issues/1875
-                    None
-                }
-              is.foreach {
-                Using.resource(_) { is =>
-                  StreamSupport.stream(is, digestOut)
+          if (!attrs.isDir)
+            try {
+              if (isPosix) {
+                updateWithInt(os.perms(path, followLinks = false).value)
+              }
+              if (quick) {
+                val value = (attrs.mtime, attrs.size).hashCode()
+                updateWithInt(value)
+              } else if (jnio.Files.isReadable(path.toNIO)) {
+                val is =
+                  try Some(os.read.inputStream(path))
+                  catch {
+                    case _: jnio.FileSystemException =>
+                      // This is known to happen, when we try to digest a socket file.
+                      // We ignore the content of this file for now, as we would do,
+                      // when the file isn't readable.
+                      // See https://github.com/com-lihaoyi/mill/issues/1875
+                      None
+                  }
+                is.foreach {
+                  Using.resource(_) { is =>
+                    StreamSupport.stream(is, digestOut)
+                  }
                 }
               }
-            }
-          } catch {
-            case e: java.nio.file.NoSuchFileException =>
-            // If file was deleted after we listed the folder but before we operate on it,
-            // `os.perms` or `os.read.inputStream` will crash. In that case, just do nothing,
-            // so next time we calculate the `PathRef` we'll get a different hash signature
-            // (either with the file missing, or with the file present) and invalidate any
-            // caches
+            } catch {
+              case e: java.nio.file.NoSuchFileException =>
+              // If file was deleted after we listed the folder but before we operate on it,
+              // `os.perms` or `os.read.inputStream` will crash. In that case, just do nothing,
+              // so next time we calculate the `PathRef` we'll get a different hash signature
+              // (either with the file missing, or with the file present) and invalidate any
+              // caches
 
-          }
+            }
         }
       }
 


### PR DESCRIPTION
Attempts to fix https://github.com/com-lihaoyi/mill/issues/2808

No real tests; the failure is timing-dependent and hard to reproduce. But hopefully just wrapping everything up in a big try-catch will fix it

Pull request: https://github.com/com-lihaoyi/mill/pull/2832