### PR TITLE
Fix not-interactive warning for mill console

### DIFF
--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -4,7 +4,7 @@ package scalalib
 import scala.annotation.nowarn
 import mill.api.{DummyInputStream, JarManifest, PathRef, Result, SystemStreams, internal}
 import mill.main.BuildInfo
-import mill.util.{Jvm,Util}
+import mill.util.{Jvm, Util}
 import mill.util.Jvm.createJar
 import mill.api.Loose.Agg
 import mill.scalalib.api.{CompilationResult, Versions, ZincWorkerUtil}

--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -4,7 +4,7 @@ package scalalib
 import scala.annotation.nowarn
 import mill.api.{DummyInputStream, JarManifest, PathRef, Result, SystemStreams, internal}
 import mill.main.BuildInfo
-import mill.util.Jvm
+import mill.util.{Jvm,Util}
 import mill.util.Jvm.createJar
 import mill.api.Loose.Agg
 import mill.scalalib.api.{CompilationResult, Versions, ZincWorkerUtil}
@@ -367,7 +367,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
    * for you to test and operate your code interactively.
    */
   def console(): Command[Unit] = T.command {
-    if (T.log.inStream == DummyInputStream) {
+    if (!Util.isInteractive()) {
       Result.Failure("console needs to be run with the -i/--interactive flag")
     } else {
       SystemStreams.withStreams(SystemStreams.original) {


### PR DESCRIPTION
Currently, if I run `mill foo.console` without the `--interactive` flag, I get a warning and then a nonfunctional REPL:

```plaintext
WARNING: Unable to create a system terminal, creating a dumb terminal (enable debug logging for more information)

scala> // does not respond to input
```

This PR just changes the test for interactivity in the `console` command to one that seems to work (at least in my environment). When `console` is invoked without the `--interactive` flag, the intended warning is emitted and the command fails:

```plaintext
main.console console needs to be run with the -i/--interactive flag
```
(`mill -i foo.console` works with or without this PR. This just restores the warning.)