### PR TITLE
Check for collisions in Cross instances, ban forward slash in Cross segments, support os.SubPath in Cross modules

### DIFF
--- a/integration/failure/dest-directory-collision/repo/build.sc
+++ b/integration/failure/dest-directory-collision/repo/build.sc
@@ -1,0 +1,4 @@
+import mill._
+
+object foo extends Cross[Foo](Seq((Seq("a", "b"), Seq("c")), (Seq("a"), Seq("b", "c"))))
+trait Foo extends Cross.Module2[Seq[String], Seq[String]]

--- a/integration/failure/dest-directory-collision/test/src/DestDirectoryCollision.scala
+++ b/integration/failure/dest-directory-collision/test/src/DestDirectoryCollision.scala
@@ -1,0 +1,19 @@
+package mill.integration
+
+import utest._
+
+object DestDirectoryCollisionTests extends IntegrationTestSuite {
+  val tests = Tests {
+    val workspaceRoot = initWorkspace()
+
+    test("success") {
+      val res = evalStdout("resolve", "foo._")
+      assert(!res.isSuccess)
+      assert(
+        res.err.contains(
+          "have colliding destination path segments"
+        )
+      )
+    }
+  }
+}

--- a/integration/failure/forward-slash-in-path-segment/repo/build.sc
+++ b/integration/failure/forward-slash-in-path-segment/repo/build.sc
@@ -1,0 +1,4 @@
+import mill._
+
+object foo extends Cross[Foo]("a/b")
+trait Foo extends Cross.Module[String]

--- a/integration/failure/forward-slash-in-path-segment/test/src/ForwardSlashInPathSegment.scala
+++ b/integration/failure/forward-slash-in-path-segment/test/src/ForwardSlashInPathSegment.scala
@@ -1,0 +1,19 @@
+package mill.integration
+
+import utest._
+
+object ForwardSlashInPathSegmentTests extends IntegrationTestSuite {
+  val tests = Tests {
+    val workspaceRoot = initWorkspace()
+
+    test("success") {
+      val res = evalStdout("resolve", "foo._")
+      assert(!res.isSuccess)
+      assert(
+        res.err.contains(
+          "contains '/' which is not allowed. Try using os.SubPath"
+        )
+      )
+    }
+  }
+}

--- a/main/define/src/mill/define/Cross.scala
+++ b/main/define/src/mill/define/Cross.scala
@@ -111,6 +111,7 @@ object Cross {
     implicit object ShortToPathSegment extends ToSegments[Short](v => List(v.toString))
     implicit object ByteToPathSegment extends ToSegments[Byte](v => List(v.toString))
     implicit object BooleanToPathSegment extends ToSegments[Boolean](v => List(v.toString))
+    implicit object SubPathToPathSegment extends ToSegments[os.SubPath](v => v.segments.toList)
     implicit def SeqToPathSegment[T: ToSegments]: ToSegments[Seq[T]] = new ToSegments[Seq[T]](
       _.flatMap(implicitly[ToSegments[T]].convert).toList
     )

--- a/main/define/src/mill/define/Cross.scala
+++ b/main/define/src/mill/define/Cross.scala
@@ -304,6 +304,11 @@ class Cross[M <: Cross.Module[_]](factories: Cross.Factory[M]*)(implicit
             .withEnclosingModule(this)
         )
       )
+      if (crossSegments0.exists(_.contains('/'))) {
+        val msg = s"In ${ctx.fileName} on line ${ctx.lineNum},\n" +
+          s"Segments $crossSegments0 for cross value $crossValues0 contains '/' which is not allowed. Try using os.SubPath."
+        throw new RuntimeException(msg) with scala.util.control.NoStackTrace
+      }
       seenPaths.get(crossSegments0) match {
         case Some(prev) =>
           val msg = s"In ${ctx.fileName} on line ${ctx.lineNum},\n" +


### PR DESCRIPTION
Fixes #2835

This PR does 3 things (and I'm happy to split it into smaller PRs since each commit is separable):
1. Checks for collisions in cross instances
2. Bans '/' in cross segments (my original approach is now disallowed, and the user is encouraged to use os.SubPath)
3. Adds support for os.SubPath in Cross instances

My implementations for (1) and (2) could be better, I don't love throwing exceptions, but I wanted to get something functional out for review to get pointers on how better to report errors to the user here. It would be nice to print the actual line rather than just printing the filename and line.

For (3), I have not yet added a test because I figure it would make sense to include in the examples, probably in a section immediately after https://mill-build.com/mill/Cross_Builds.html#_dynamic_cross_modules (ie. before `Use Case: Static Blog`), but I wanted @lefou's blessing before starting that work.