### PR TITLE
Handle potential null-stream in buildinfo plugin

### DIFF
--- a/contrib/buildinfo/src/mill/contrib/buildinfo/BuildInfo.scala
+++ b/contrib/buildinfo/src/mill/contrib/buildinfo/BuildInfo.scala
@@ -138,7 +138,7 @@ object BuildInfo {
          |public class $buildInfoObjectName {
          |  $bindingsCode
          |
-         |  public static java.util.Map<String, String> toMap(){
+         |  public static java.util.Map<String, String> toMap() {
          |    Map<String, String> map = new HashMap<String, String>();
          |    $mapEntries
          |    return map;
@@ -173,13 +173,17 @@ object BuildInfo {
          |object $buildInfoObjectName {
          |  private[this] val buildInfoProperties: java.util.Properties = new java.util.Properties()
          |
-         |  private[this] val buildInfoInputStream = getClass
+         |  {
+         |    val buildInfoInputStream = getClass
          |      .getResourceAsStream("${buildInfoObjectName}.buildinfo.properties")
          |
-         |  try {
-         |    buildInfoProperties.load(buildInfoInputStream)
-         |  } finally {
-         |    buildInfoInputStream.close()
+         |    if(buildInfoInputStream == null)
+         |      throw new RuntimeException("Could not load resource ${buildInfoObjectName}.buildinfo.properties")
+         |    else try {
+         |      buildInfoProperties.load(buildInfoInputStream)
+         |    } finally {
+         |      buildInfoInputStream.close()
+         |    }
          |  }
          |
          |  $bindingsCode


### PR DESCRIPTION
The current Scala implementation just does not load the expected values from the resource file, when the resource file can not be found on the classpath. The Java implementation already throws a `RuntimeException` (of an `IOException`) in this case. The Scala implementation does not.

I think missing a generated resource file at runtime is most likely an runtime issue and we should also throw such exception in the Scala implementation to exit early, before a missing value can cause greater harm later. Hence, we now also throw a `RuntimeException` when the resource file/stream could not be found in the Scala implementation.

Fix https://github.com/com-lihaoyi/mill/issues/2831
