### PR TITLE
Enable pathref revalidation for all coursier downloads

### DIFF
--- a/main/api/src/mill/api/PathRef.scala
+++ b/main/api/src/mill/api/PathRef.scala
@@ -189,7 +189,7 @@ object PathRef {
       // Parsing to a long and casting to an int is the only way to make
       // round-trip handling of negative numbers work =(
       val sig = java.lang.Long.parseLong(hex, 16).toInt
-      val pr = PathRef(path, quick, sig, validOrig)
+      val pr = PathRef(path, quick, sig, revalidate = validOrig)
       validatedPaths.value.revalidateIfNeededOrThrow(pr)
       pr
     }

--- a/main/util/src/mill/util/Util.scala
+++ b/main/util/src/mill/util/Util.scala
@@ -95,7 +95,7 @@ object Util {
       ),
       force = Nil,
       resolveFilter = resolveFilter
-    )
+    ).map(_.map(_.withRevalidateOnce))
   }
 
   def millProperty(key: String): Option[String] =

--- a/scalalib/src/mill/scalalib/CoursierModule.scala
+++ b/scalalib/src/mill/scalalib/CoursierModule.scala
@@ -47,7 +47,7 @@ trait CoursierModule extends mill.Module {
         customizer = resolutionCustomizer(),
         coursierCacheCustomizer = coursierCacheCustomizer(),
         ctx = Some(implicitly[mill.api.Ctx.Log])
-      ).map(_.map(_.withRevalidateOnce))
+      )
     }
 
   /**

--- a/scalalib/src/mill/scalalib/Lib.scala
+++ b/scalalib/src/mill/scalalib/Lib.scala
@@ -74,7 +74,7 @@ object Lib {
       customizer = customizer,
       ctx = ctx,
       coursierCacheCustomizer = coursierCacheCustomizer
-    )
+    ).map(_.map(_.withRevalidateOnce))
   }
 
   def scalaCompilerIvyDeps(scalaOrganization: String, scalaVersion: String): Loose.Agg[Dep] =


### PR DESCRIPTION
This change sets the `revalidate` flag on the coursier resolved pathrefs in more situations, to better detect the case, that the cache might have changed.

Fix https://github.com/com-lihaoyi/mill/issues/2845

Pull request: https://github.com/com-lihaoyi/mill/pull/2846