### PR TITLE
Fix Zip Slip Vulnerabilities

### DIFF
--- a/ci/shared.sc
+++ b/ci/shared.sc
@@ -20,7 +20,7 @@ def unpackZip(zipDest: os.Path, url: String) = {
       case null => false
       case entry =>
         if (!entry.isDirectory) {
-          val dest = zipDest / os.RelPath(entry.getName)
+          val dest = zipDest / os.SubPath(entry.getName)
           os.makeDir.all(dest / os.up)
           val fileOut = new java.io.FileOutputStream(dest.toString)
           val buffer = new Array[Byte](4096)

--- a/main/api/src/mill/api/IO.scala
+++ b/main/api/src/mill/api/IO.scala
@@ -13,7 +13,10 @@ object IO extends StreamSupport {
    * @param ctx The target context
    * @return The [[PathRef]] to the unpacked folder.
    */
-  def unpackZip(src: os.Path, dest: os.RelPath = os.rel / "unpacked")(implicit
+  def unpackZip(
+      src: os.Path,
+      dest: os.RelPath = os.rel / "unpacked"
+  )(implicit
       ctx: Ctx.Dest
   ): PathRef = {
 
@@ -24,7 +27,7 @@ object IO extends StreamSupport {
         case null => false
         case entry =>
           if (!entry.isDirectory) {
-            val entryDest = ctx.dest / dest / os.RelPath(entry.getName)
+            val entryDest = ctx.dest / dest / os.SubPath(entry.getName)
             os.makeDir.all(entryDest / os.up)
             val fileOut = new java.io.FileOutputStream(entryDest.toString)
             IO.stream(zipStream, fileOut)


### PR DESCRIPTION
Specially prepared zip archives with crafted entries containing relative paths may result in overwritten files outside the destination directory. By using `os.SubPath`, we detect and fail in such cases.