### PR TITLE
Add an option to disable incremental compilation with zinc

### DIFF
--- a/docs/modules/ROOT/pages/Scala_Module_Config.adoc
+++ b/docs/modules/ROOT/pages/Scala_Module_Config.adoc
@@ -144,3 +144,22 @@ As a consequence, Ammonite needs full Scala version specific releases.
 
 The older your used Mill version or the newer the Scala version you want to use, the higher is the risk that the default Ammonite version will not match.
 --
+
+== Disabling incremental compilation with Zinc
+
+By default all `ScalaModule`s use incremental compilation via https://github.com/sbt/zinc[Zinc] to
+only recompile sources that have changed since the last compile, or ones that have been invalidated
+by changes to upstream sources.
+
+If for any reason you want to disable incremental compilation for a module, you can override and set
+`zincIncrementalCompilation` to `false`
+
+.`build.sc`
+[source,scala,subs="attributes,verbatim"]
+----
+import mill._, scalalib._
+
+object foo extends ScalaModule {
+  def zincIncrementalCompilation = false
+}
+----

--- a/scalalib/api/src/mill/scalalib/api/ZincWorkerApi.scala
+++ b/scalalib/api/src/mill/scalalib/api/ZincWorkerApi.scala
@@ -3,6 +3,8 @@ package mill.scalalib.api
 import mill.api.{CompileProblemReporter, PathRef}
 import mill.api.Loose.Agg
 
+import scala.annotation.nowarn
+
 object ZincWorkerApi {
   type Ctx = mill.api.Ctx.Dest with mill.api.Ctx.Log with mill.api.Ctx.Home
 }
@@ -17,7 +19,15 @@ trait ZincWorkerApi {
       reporter: Option[CompileProblemReporter],
       reportCachedProblems: Boolean,
       incrementalCompilation: Boolean
-  )(implicit ctx: ZincWorkerApi.Ctx): mill.api.Result[CompilationResult]
+  )(implicit ctx: ZincWorkerApi.Ctx): mill.api.Result[CompilationResult] =
+    compileJava(
+      upstreamCompileOutput = upstreamCompileOutput,
+      sources = sources,
+      compileClasspath = compileClasspath,
+      javacOptions = javacOptions,
+      reporter = reporter,
+      reportCachedProblems = reportCachedProblems
+    ): @nowarn("cat=deprecation")
 
   /** Compile a Java-only project */
   @deprecated("Use override with `incrementalCompilation` parameter", "Mill 0.11.6")
@@ -30,13 +40,13 @@ trait ZincWorkerApi {
       reportCachedProblems: Boolean
   )(implicit ctx: ZincWorkerApi.Ctx): mill.api.Result[CompilationResult] =
     compileJava(
-      upstreamCompileOutput,
-      sources,
-      compileClasspath,
-      javacOptions,
-      reporter,
-      reportCachedProblems,
-      true
+      upstreamCompileOutput = upstreamCompileOutput,
+      sources = sources,
+      compileClasspath = compileClasspath,
+      javacOptions = javacOptions,
+      reporter = reporter,
+      reportCachedProblems = reportCachedProblems,
+      incrementalCompilation = true
     )
 
   /** Compile a mixed Scala/Java or Scala-only project */
@@ -53,7 +63,20 @@ trait ZincWorkerApi {
       reporter: Option[CompileProblemReporter],
       reportCachedProblems: Boolean,
       incrementalCompilation: Boolean
-  )(implicit ctx: ZincWorkerApi.Ctx): mill.api.Result[CompilationResult]
+  )(implicit ctx: ZincWorkerApi.Ctx): mill.api.Result[CompilationResult] =
+    compileMixed(
+      upstreamCompileOutput = upstreamCompileOutput,
+      sources = sources,
+      compileClasspath = compileClasspath,
+      javacOptions = javacOptions,
+      scalaVersion = scalaVersion,
+      scalaOrganization = scalaOrganization,
+      scalacOptions = scalacOptions,
+      compilerClasspath = compilerClasspath,
+      scalacPluginClasspath = scalacPluginClasspath,
+      reporter = reporter,
+      reportCachedProblems = reportCachedProblems
+    ): @nowarn("cat=deprecation")
 
   /** Compile a mixed Scala/Java or Scala-only project */
   @deprecated("Use override with `incrementalCompilation` parameter", "Mill 0.11.6")
@@ -71,18 +94,18 @@ trait ZincWorkerApi {
       reportCachedProblems: Boolean
   )(implicit ctx: ZincWorkerApi.Ctx): mill.api.Result[CompilationResult] =
     compileMixed(
-      upstreamCompileOutput,
-      sources,
-      compileClasspath,
-      javacOptions,
-      scalaVersion,
-      scalaOrganization,
-      scalacOptions,
-      compilerClasspath,
-      scalacPluginClasspath,
-      reporter,
-      reportCachedProblems,
-      true
+      upstreamCompileOutput = upstreamCompileOutput,
+      sources = sources,
+      compileClasspath = compileClasspath,
+      javacOptions = javacOptions,
+      scalaVersion = scalaVersion,
+      scalaOrganization = scalaOrganization,
+      scalacOptions = scalacOptions,
+      compilerClasspath = compilerClasspath,
+      scalacPluginClasspath = scalacPluginClasspath,
+      reporter = reporter,
+      reportCachedProblems = reportCachedProblems,
+      incrementalCompilation = true
     )
 
   def discoverMainClasses(compilationResult: CompilationResult): Seq[String]

--- a/scalalib/api/src/mill/scalalib/api/ZincWorkerApi.scala
+++ b/scalalib/api/src/mill/scalalib/api/ZincWorkerApi.scala
@@ -19,6 +19,26 @@ trait ZincWorkerApi {
       incrementalCompilation: Boolean
   )(implicit ctx: ZincWorkerApi.Ctx): mill.api.Result[CompilationResult]
 
+  /** Compile a Java-only project */
+  @deprecated("Use override with `incrementalCompilation` parameter", "Mill 0.11.6")
+  def compileJava(
+      upstreamCompileOutput: Seq[CompilationResult],
+      sources: Agg[os.Path],
+      compileClasspath: Agg[os.Path],
+      javacOptions: Seq[String],
+      reporter: Option[CompileProblemReporter],
+      reportCachedProblems: Boolean
+  )(implicit ctx: ZincWorkerApi.Ctx): mill.api.Result[CompilationResult] =
+    compileJava(
+      upstreamCompileOutput,
+      sources,
+      compileClasspath,
+      javacOptions,
+      reporter,
+      reportCachedProblems,
+      true
+    )
+
   /** Compile a mixed Scala/Java or Scala-only project */
   def compileMixed(
       upstreamCompileOutput: Seq[CompilationResult],
@@ -34,6 +54,36 @@ trait ZincWorkerApi {
       reportCachedProblems: Boolean,
       incrementalCompilation: Boolean
   )(implicit ctx: ZincWorkerApi.Ctx): mill.api.Result[CompilationResult]
+
+  /** Compile a mixed Scala/Java or Scala-only project */
+  @deprecated("Use override with `incrementalCompilation` parameter", "Mill 0.11.6")
+  def compileMixed(
+      upstreamCompileOutput: Seq[CompilationResult],
+      sources: Agg[os.Path],
+      compileClasspath: Agg[os.Path],
+      javacOptions: Seq[String],
+      scalaVersion: String,
+      scalaOrganization: String,
+      scalacOptions: Seq[String],
+      compilerClasspath: Agg[PathRef],
+      scalacPluginClasspath: Agg[PathRef],
+      reporter: Option[CompileProblemReporter],
+      reportCachedProblems: Boolean
+  )(implicit ctx: ZincWorkerApi.Ctx): mill.api.Result[CompilationResult] =
+    compileMixed(
+      upstreamCompileOutput,
+      sources,
+      compileClasspath,
+      javacOptions,
+      scalaVersion,
+      scalaOrganization,
+      scalacOptions,
+      compilerClasspath,
+      scalacPluginClasspath,
+      reporter,
+      reportCachedProblems,
+      true
+    )
 
   def discoverMainClasses(compilationResult: CompilationResult): Seq[String]
 

--- a/scalalib/api/src/mill/scalalib/api/ZincWorkerApi.scala
+++ b/scalalib/api/src/mill/scalalib/api/ZincWorkerApi.scala
@@ -15,7 +15,8 @@ trait ZincWorkerApi {
       compileClasspath: Agg[os.Path],
       javacOptions: Seq[String],
       reporter: Option[CompileProblemReporter],
-      reportCachedProblems: Boolean
+      reportCachedProblems: Boolean,
+      incrementalCompilation: Boolean
   )(implicit ctx: ZincWorkerApi.Ctx): mill.api.Result[CompilationResult]
 
   /** Compile a mixed Scala/Java or Scala-only project */
@@ -30,7 +31,8 @@ trait ZincWorkerApi {
       compilerClasspath: Agg[PathRef],
       scalacPluginClasspath: Agg[PathRef],
       reporter: Option[CompileProblemReporter],
-      reportCachedProblems: Boolean
+      reportCachedProblems: Boolean,
+      incrementalCompilation: Boolean
   )(implicit ctx: ZincWorkerApi.Ctx): mill.api.Result[CompilationResult]
 
   def discoverMainClasses(compilationResult: CompilationResult): Seq[String]

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -361,7 +361,8 @@ trait JavaModule
 
   protected def zincIncrementalCompilationCacheBuster: T[(Boolean, Double)] = T.input {
     val incrementalCompilation = zincIncrementalCompilation()
-    if (incrementalCompilation) (incrementalCompilation, 0d) else (incrementalCompilation, Math.random())
+    if (incrementalCompilation) (incrementalCompilation, 0d)
+    else (incrementalCompilation, Math.random())
   }
 
   /**

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -355,6 +355,10 @@ trait JavaModule
     ).equalsIgnoreCase("true")
   }
 
+  def zincIncrementalCompilation: T[Boolean] = T {
+    true
+  }
+
   /**
    * Compiles the current module to generate compiled classfiles/bytecode.
    *
@@ -370,7 +374,8 @@ trait JavaModule
         compileClasspath = compileClasspath().map(_.path),
         javacOptions = javacOptions(),
         reporter = T.reporter.apply(hashCode),
-        reportCachedProblems = zincReportCachedProblems()
+        reportCachedProblems = zincReportCachedProblems(),
+        incrementalCompilation = zincIncrementalCompilation()
       )
   }
 

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -359,6 +359,11 @@ trait JavaModule
     true
   }
 
+  protected def zincIncrementalCompilationCacheBuster: T[(Boolean, Double)] = T.input {
+    val incrementalCompilation = zincIncrementalCompilation()
+    if (incrementalCompilation) (incrementalCompilation, 0d) else (incrementalCompilation, Math.random())
+  }
+
   /**
    * Compiles the current module to generate compiled classfiles/bytecode.
    *
@@ -366,6 +371,7 @@ trait JavaModule
    */
   // Keep in sync with [[bspCompileClassesPath]]
   def compile: T[mill.scalalib.api.CompilationResult] = T.persistent {
+    val (incrementalCompilation, _) = zincIncrementalCompilationCacheBuster()
     zincWorker()
       .worker()
       .compileJava(
@@ -375,7 +381,7 @@ trait JavaModule
         javacOptions = javacOptions(),
         reporter = T.reporter.apply(hashCode),
         reportCachedProblems = zincReportCachedProblems(),
-        incrementalCompilation = zincIncrementalCompilation()
+        incrementalCompilation = incrementalCompilation
       )
   }
 

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -359,12 +359,6 @@ trait JavaModule
     true
   }
 
-  protected def zincIncrementalCompilationCacheBuster: T[(Boolean, Double)] = T.input {
-    val incrementalCompilation = zincIncrementalCompilation()
-    if (incrementalCompilation) (incrementalCompilation, 0d)
-    else (incrementalCompilation, Math.random())
-  }
-
   /**
    * Compiles the current module to generate compiled classfiles/bytecode.
    *
@@ -372,7 +366,6 @@ trait JavaModule
    */
   // Keep in sync with [[bspCompileClassesPath]]
   def compile: T[mill.scalalib.api.CompilationResult] = T.persistent {
-    val (incrementalCompilation, _) = zincIncrementalCompilationCacheBuster()
     zincWorker()
       .worker()
       .compileJava(
@@ -382,7 +375,7 @@ trait JavaModule
         javacOptions = javacOptions(),
         reporter = T.reporter.apply(hashCode),
         reportCachedProblems = zincReportCachedProblems(),
-        incrementalCompilation = incrementalCompilation
+        incrementalCompilation = zincIncrementalCompilation()
       )
   }
 

--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -215,6 +215,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
         |You may want to select another version. Upgrading to a more recent Scala version is recommended.
         |For details, see: https://github.com/sbt/zinc/issues/1010""".stripMargin
     )
+    val (incrementalCompilation, _) = zincIncrementalCompilationCacheBuster()
     zincWorker()
       .worker()
       .compileMixed(
@@ -229,7 +230,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
         scalacPluginClasspath = scalacPluginClasspath(),
         reporter = T.reporter.apply(hashCode),
         reportCachedProblems = zincReportCachedProblems(),
-        incrementalCompilation = zincIncrementalCompilation()
+        incrementalCompilation = incrementalCompilation
       )
   }
 
@@ -567,6 +568,8 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
     T.log.debug(s"effective scalac options: ${scalacOptions}")
     T.log.debug(s"effective javac options: ${javacOpts}")
 
+    val (incrementalCompilation, _) = zincIncrementalCompilationCacheBuster()
+
     zincWorker().worker()
       .compileMixed(
         upstreamCompileOutput = upstreamCompileOutput(),
@@ -581,7 +584,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
         scalacPluginClasspath = semanticDbPluginClasspath(),
         reporter = None,
         reportCachedProblems = zincReportCachedProblems(),
-        incrementalCompilation = zincIncrementalCompilation()
+        incrementalCompilation = incrementalCompilation
       )
       .map(r =>
         SemanticDbJavaModule.copySemanticdbFiles(r.classes.path, T.workspace, T.dest / "data")

--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -215,7 +215,6 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
         |You may want to select another version. Upgrading to a more recent Scala version is recommended.
         |For details, see: https://github.com/sbt/zinc/issues/1010""".stripMargin
     )
-    val (incrementalCompilation, _) = zincIncrementalCompilationCacheBuster()
     zincWorker()
       .worker()
       .compileMixed(
@@ -230,7 +229,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
         scalacPluginClasspath = scalacPluginClasspath(),
         reporter = T.reporter.apply(hashCode),
         reportCachedProblems = zincReportCachedProblems(),
-        incrementalCompilation = incrementalCompilation
+        incrementalCompilation = zincIncrementalCompilation()
       )
   }
 
@@ -568,8 +567,6 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
     T.log.debug(s"effective scalac options: ${scalacOptions}")
     T.log.debug(s"effective javac options: ${javacOpts}")
 
-    val (incrementalCompilation, _) = zincIncrementalCompilationCacheBuster()
-
     zincWorker().worker()
       .compileMixed(
         upstreamCompileOutput = upstreamCompileOutput(),
@@ -584,7 +581,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
         scalacPluginClasspath = semanticDbPluginClasspath(),
         reporter = None,
         reportCachedProblems = zincReportCachedProblems(),
-        incrementalCompilation = incrementalCompilation
+        incrementalCompilation = zincIncrementalCompilation()
       )
       .map(r =>
         SemanticDbJavaModule.copySemanticdbFiles(r.classes.path, T.workspace, T.dest / "data")

--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -228,7 +228,8 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
         compilerClasspath = scalaCompilerClasspath(),
         scalacPluginClasspath = scalacPluginClasspath(),
         reporter = T.reporter.apply(hashCode),
-        reportCachedProblems = zincReportCachedProblems()
+        reportCachedProblems = zincReportCachedProblems(),
+        incrementalCompilation = zincIncrementalCompilation()
       )
   }
 
@@ -579,7 +580,8 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
         compilerClasspath = scalaCompilerClasspath(),
         scalacPluginClasspath = semanticDbPluginClasspath(),
         reporter = None,
-        reportCachedProblems = zincReportCachedProblems()
+        reportCachedProblems = zincReportCachedProblems(),
+        incrementalCompilation = zincIncrementalCompilation()
       )
       .map(r =>
         SemanticDbJavaModule.copySemanticdbFiles(r.classes.path, T.workspace, T.dest / "data")

--- a/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
+++ b/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
@@ -15,6 +15,7 @@ trait SemanticDbJavaModule extends CoursierModule {
   def zincWorker: ModuleRef[ZincWorkerModule]
   def upstreamCompileOutput: T[Seq[CompilationResult]]
   def zincReportCachedProblems: T[Boolean]
+  def zincIncrementalCompilation: T[Boolean]
   def allSourceFiles: T[Seq[PathRef]]
   def compile: T[mill.scalalib.api.CompilationResult]
   def bspBuildTarget: BspBuildTarget
@@ -116,7 +117,8 @@ trait SemanticDbJavaModule extends CoursierModule {
           (compileClasspath() ++ resolvedSemanticDbJavaPluginIvyDeps()).map(_.path),
         javacOptions = javacOpts,
         reporter = None,
-        reportCachedProblems = zincReportCachedProblems()
+        reportCachedProblems = zincReportCachedProblems(),
+        incrementalCompilation = zincIncrementalCompilation()
       ).map(r =>
         SemanticDbJavaModule.copySemanticdbFiles(r.classes.path, T.workspace, T.dest / "data")
       )

--- a/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
+++ b/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
@@ -15,7 +15,7 @@ trait SemanticDbJavaModule extends CoursierModule {
   def zincWorker: ModuleRef[ZincWorkerModule]
   def upstreamCompileOutput: T[Seq[CompilationResult]]
   def zincReportCachedProblems: T[Boolean]
-  protected def zincIncrementalCompilationCacheBuster: T[(Boolean, Double)]
+  def zincIncrementalCompilation: T[Boolean]
   def allSourceFiles: T[Seq[PathRef]]
   def compile: T[mill.scalalib.api.CompilationResult]
   def bspBuildTarget: BspBuildTarget
@@ -109,8 +109,6 @@ trait SemanticDbJavaModule extends CoursierModule {
 
     T.log.debug(s"effective javac options: ${javacOpts}")
 
-    val (incrementalCompilation, _) = zincIncrementalCompilationCacheBuster()
-
     zincWorker().worker()
       .compileJava(
         upstreamCompileOutput = upstreamCompileOutput(),
@@ -120,7 +118,7 @@ trait SemanticDbJavaModule extends CoursierModule {
         javacOptions = javacOpts,
         reporter = None,
         reportCachedProblems = zincReportCachedProblems(),
-        incrementalCompilation = incrementalCompilation
+        incrementalCompilation = zincIncrementalCompilation()
       ).map(r =>
         SemanticDbJavaModule.copySemanticdbFiles(r.classes.path, T.workspace, T.dest / "data")
       )

--- a/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
+++ b/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
@@ -23,7 +23,6 @@ import xsbti.compile.{
   ClasspathOptions,
   CompileAnalysis,
   CompileOrder,
-  CompileProgress,
   Compilers,
   IncOptions,
   JavaTools,
@@ -34,7 +33,6 @@ import xsbti.{PathBasedFile, VirtualFile}
 
 import java.io.File
 import java.util.Optional
-import java.util.concurrent.ConcurrentHashMap
 import scala.collection.mutable
 import scala.ref.SoftReference
 import scala.util.Properties.isWin
@@ -289,7 +287,7 @@ class ZincWorkerImpl(
       .getOrElse(Seq.empty[String])
   }
 
-  def compileJava(
+  override def compileJava(
       upstreamCompileOutput: Seq[CompilationResult],
       sources: Agg[os.Path],
       compileClasspath: Agg[os.Path],


### PR DESCRIPTION
This was sparked by [a conversation in gitter](https://matrix.to/#/!zXvttAKLPnvdnmiYsY:matrix.am/$C1K_tZdqQwKYjFfDXcmd3kbLWRBhYcMo2cggtG6S_wM?via=matrix.am&via=gitter.im&via=matrix.org) about forcing a full recompile for a given module.

The change to `ZincWorkerApi` is not binary compatible, but it could be if I added overloads for both `compileJava` and `compileMixed` -- let me know if you think I should.