### PR TITLE
Allow resolving moduleDeps with older Scala 3 versions

### DIFF
--- a/scalalib/src/mill/scalalib/CrossModuleBase.scala
+++ b/scalalib/src/mill/scalalib/CrossModuleBase.scala
@@ -22,7 +22,7 @@ trait CrossModuleBase extends ScalaModule with Cross.Module[String] {
         crossScalaVersion
           .split('.')
           .inits
-          .takeWhile(_.length > 1)
+          .takeWhile(_.length > (if (ZincWorkerUtil.isScala3(crossScalaVersion)) 0 else 1))
           .flatMap(prefix =>
             c.crossModules
               .find(_.crossScalaVersion.split('.').startsWith(prefix))

--- a/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
+++ b/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
@@ -692,7 +692,9 @@ object HelloWorldTests extends TestSuite {
       CrossModuleDeps.cuttingEdge(scala33Version).moduleDeps
     }
     "scala-213-depend-on-scala-212-fails" - {
-      val message = intercept(CrossModuleDeps.cuttingEdge(scala213Version).moduleDeps).getMessage
+      val message = intercept[Exception](
+        CrossModuleDeps.cuttingEdge(scala213Version).moduleDeps
+      ).getMessage
       assert(message == "Unable to find compatible cross version between 2.13.8 and 2.12.6,3.2.0")
     }
 


### PR DESCRIPTION
# Motivation
Sometimes you want different modules in a build to have different Scala 3 versions, one the older and one the newer.
The current resolve implementation in `CrossModuleBase` is tailored to Scala 2 since it assumes that the binary version is `x.y` while in Scala 3 it's just the first part.

This change adapts the algorithm to consider 1 or 2 parts depending if it is Scala 3 or not.

Pull Request: https://github.com/com-lihaoyi/mill/pull/2877