### PR TITLE
Fix #2881 Propagate environment from `ctx` to subprocesses

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -374,6 +374,12 @@ trait MillBaseTestsModule extends MillJavaModule with TestModule {
     )
   }
 
+  def forkEnv = T {
+    super.forkEnv() ++ Seq(
+      "TEST_ENV_VARIABLE" -> "value"
+    )
+  }
+
   def testFramework = "mill.UTestFramework"
 }
 

--- a/main/util/src/mill/util/Jvm.scala
+++ b/main/util/src/mill/util/Jvm.scala
@@ -230,7 +230,8 @@ object Jvm extends CoursierSupport {
         env = envArgs,
         stdin = if (backgroundOutputs.isEmpty) os.Pipe else "",
         stdout = backgroundOutputs.map(_._1).getOrElse(os.Pipe),
-        stderr = backgroundOutputs.map(_._2).getOrElse(os.Pipe)
+        stderr = backgroundOutputs.map(_._2).getOrElse(os.Pipe),
+        propagateEnv = false
       )
 
       val sources = Seq(
@@ -255,7 +256,8 @@ object Jvm extends CoursierSupport {
         env = envArgs,
         stdin = if (backgroundOutputs.isEmpty) os.Inherit else "",
         stdout = backgroundOutputs.map(_._1).getOrElse(os.Inherit),
-        stderr = backgroundOutputs.map(_._2).getOrElse(os.Inherit)
+        stderr = backgroundOutputs.map(_._2).getOrElse(os.Inherit),
+        propagateEnv = false
       )
     }
   }

--- a/scalalib/test/resources/hello-world/env/src/Main.scala
+++ b/scalalib/test/resources/hello-world/env/src/Main.scala
@@ -1,0 +1,12 @@
+import java.nio.file.{Files, Paths}
+
+object Main {
+  def main(args: Array[String]): Unit = {
+    val resultPath = Paths.get(args(0))
+    Files.createDirectories(resultPath.getParent)
+    Files.write(
+      resultPath,
+      s"TEST_ENV_VARIABLE=${sys.env.getOrElse("TEST_ENV_VARIABLE", "")}".getBytes
+    )
+  }
+}

--- a/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
+++ b/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
@@ -382,12 +382,6 @@ object HelloWorldTests extends TestSuite {
     }
   }
 
-  object HelloWorldWithEnv extends HelloBase {
-    object env extends HelloWorldModule {
-      def forkEnv = T { T.env }
-    }
-  }
-
   object HelloWorldWithoutEnv extends HelloBase {
     object env extends HelloWorldModule {
       def forkEnv = T { Map.empty[String, String] }
@@ -822,25 +816,17 @@ object HelloWorldTests extends TestSuite {
         val Left(Result.Failure(_, None)) = eval.apply(HelloWorldWithoutMain.core.runLocal())
 
       }
-      "withEnv" - workspaceTest(HelloWorldWithEnv) { eval =>
+      "envIsPropagated" - workspaceTest(HelloWorldWithoutEnv) { eval =>
         val runResult = eval.outPath / "env" / "run.dest" / "hello-mill"
-        val Right((_, evalCount)) = eval.apply(HelloWorldWithEnv.env.run(T.task(Args(runResult.toString))))
+        val Right((_, evalCount)) =
+          eval.apply(HelloWorldWithoutEnv.env.run(T.task(Args(runResult.toString))))
 
+        assert(sys.env.get("TEST_ENV_VARIABLE") == Some("value"))
         assert(evalCount > 0)
         assert(os.exists(runResult))
 
         val output = os.read(runResult)
         assert(output == "TEST_ENV_VARIABLE=value")
-      }
-      "withoutEnv" - workspaceTest(HelloWorldWithoutEnv) { eval =>
-        val runResult = eval.outPath / "env" / "run.dest" / "hello-mill"
-        val Right((_, evalCount)) = eval.apply(HelloWorldWithoutEnv.env.run(T.task(Args(runResult.toString))))
-
-        assert(evalCount > 0)
-        assert(os.exists(runResult))
-
-        val output = os.read(runResult)
-        assert(output == "TEST_ENV_VARIABLE=")
       }
     }
 


### PR DESCRIPTION
Fixes #2881

## Dependencies

- [x] os-lib fix for `propagateEnv` https://github.com/com-lihaoyi/os-lib/pull/238
