### PR TITLE
Report when we could not detect the declaring parent of a target

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -1419,15 +1419,17 @@ object dev extends MillPublishScalaModule {
       case wd0 +: rest =>
         val wd = os.Path(wd0, T.workspace)
         os.makeDir.all(wd)
-        try Jvm.runSubprocess(
+        try {
+          Jvm.runSubprocess(
             Seq(launcher().path.toString) ++ rest,
             forkEnv(),
             workingDir = wd
           )
-        catch {
-          case e: Throwable => () /*ignore to avoid confusing stacktrace and error messages*/
+          mill.api.Result.Success(())
+        } catch {
+          case e: Throwable =>
+            mill.api.Result.Failure(s"dev.run failed with an exception. ${e.getMessage()}")
         }
-        mill.api.Result.Success(())
     }
   }
 }

--- a/build.sc
+++ b/build.sc
@@ -31,6 +31,7 @@ object Settings {
   val githubRepo = "mill"
   val projectUrl = s"https://github.com/${githubOrg}/${githubRepo}"
   val changelogUrl = s"${projectUrl}#changelog"
+  val newIssueUrl = s"${projectUrl}/issues/new/choose"
   val docUrl = "https://mill-build.com"
   // the exact branches containing a doc root
   val docBranches = Seq()
@@ -493,7 +494,8 @@ object main extends MillStableScalaModule with BuildInfo {
     def buildInfoPackageName = "mill.api"
     def buildInfoMembers = Seq(
       BuildInfo.Value("millVersion", millVersion(), "Mill version."),
-      BuildInfo.Value("millDocUrl", Settings.docUrl, "Mill documentation url.")
+      BuildInfo.Value("millDocUrl", Settings.docUrl, "Mill documentation url."),
+      BuildInfo.Value("millReportNewIssueUrl", Settings.newIssueUrl, "URL to create a new issue in Mills issue tracker.")
     )
 
     def ivyDeps = Agg(

--- a/build.sc
+++ b/build.sc
@@ -110,7 +110,8 @@ object Deps {
   object Play_3_0 extends Play {
     val playVersion = "3.0.0"
   }
-  val play = Seq(Play_3_0, Play_2_9, Play_2_8, Play_2_7, Play_2_6).map(p => (p.playBinVersion, p)).toMap
+  val play =
+    Seq(Play_3_0, Play_2_9, Play_2_8, Play_2_7, Play_2_6).map(p => (p.playBinVersion, p)).toMap
 
   val acyclic = ivy"com.lihaoyi:::acyclic:0.3.9"
   val ammoniteVersion = "3.0.0-M0-53-084f7f4e"
@@ -495,7 +496,11 @@ object main extends MillStableScalaModule with BuildInfo {
     def buildInfoMembers = Seq(
       BuildInfo.Value("millVersion", millVersion(), "Mill version."),
       BuildInfo.Value("millDocUrl", Settings.docUrl, "Mill documentation url."),
-      BuildInfo.Value("millReportNewIssueUrl", Settings.newIssueUrl, "URL to create a new issue in Mills issue tracker.")
+      BuildInfo.Value(
+        "millReportNewIssueUrl",
+        Settings.newIssueUrl,
+        "URL to create a new issue in Mills issue tracker."
+      )
     )
 
     def ivyDeps = Agg(

--- a/main/eval/src/mill/eval/GroupEvaluator.scala
+++ b/main/eval/src/mill/eval/GroupEvaluator.scala
@@ -123,7 +123,7 @@ private[mill] trait GroupEvaluator {
                 ctx.enclosingModule match {
                   case null => None
                   case m: mill.define.Module => Some((m, m.millOuterCtx))
-                  case unknown => throw new MillException(s"Unknown ctx: $unknown")
+                  case unknown => throw new MillException(s"Unknown ctx of target ${namedTask}: $unknown")
                 }
             }
 

--- a/main/eval/src/mill/eval/GroupEvaluator.scala
+++ b/main/eval/src/mill/eval/GroupEvaluator.scala
@@ -123,7 +123,8 @@ private[mill] trait GroupEvaluator {
                 ctx.enclosingModule match {
                   case null => None
                   case m: mill.define.Module => Some((m, m.millOuterCtx))
-                  case unknown => throw new MillException(s"Unknown ctx of target ${namedTask}: $unknown")
+                  case unknown =>
+                    throw new MillException(s"Unknown ctx of target ${namedTask}: $unknown")
                 }
             }
 

--- a/main/eval/src/mill/eval/GroupEvaluator.scala
+++ b/main/eval/src/mill/eval/GroupEvaluator.scala
@@ -105,7 +105,7 @@ private[mill] trait GroupEvaluator {
               .headOption
               .getOrElse(throw new MillException(
                 s"Could not detect the parent class of target ${namedTask}. " +
-                  s"Please report this at ${BuildInfo.millReportNewIssueUrl} " +
+                  s"Please report this at ${BuildInfo.millReportNewIssueUrl} . " +
                   s"As a workaround, you can run Mill with `--disable-callgraph-invalidation` option."
               ))
               .getDeclaringClass.getName

--- a/main/eval/src/mill/eval/GroupEvaluator.scala
+++ b/main/eval/src/mill/eval/GroupEvaluator.scala
@@ -101,7 +101,14 @@ private[mill] trait GroupEvaluator {
               if decode(m.getName) == namedTask.ctx.segment.pathSegments.head
             } yield m
 
-            val methodClass = methods.head.getDeclaringClass.getName
+            val methodClass = methods
+              .headOption
+              .getOrElse(throw new MillException(
+                s"Could not detect the parent class of target ${namedTask}. " +
+                  s"Please report this at ${BuildInfo.millReportNewIssueUrl}. " +
+                  s"As a workaround, you can run Mill with `--disable-callgraph-invalidation` option."
+              ))
+              .getDeclaringClass.getName
             val name = namedTask.ctx.segment.pathSegments.last
             val expectedName = methodClass + "#" + name + "()mill.define.Target"
 
@@ -116,7 +123,7 @@ private[mill] trait GroupEvaluator {
                 ctx.enclosingModule match {
                   case null => None
                   case m: mill.define.Module => Some((m, m.millOuterCtx))
-                  case unknown => sys.error(s"Unknown ctx: $unknown")
+                  case unknown => throw new MillException(s"Unknown ctx: $unknown")
                 }
             }
 
@@ -124,7 +131,7 @@ private[mill] trait GroupEvaluator {
               .map(m =>
                 constructorHashSignatures.get(m.getClass.getName) match {
                   case Some(Seq((singleMethod, hash))) => hash
-                  case Some(multiple) => sys.error(
+                  case Some(multiple) => throw new MillException(
                       s"Multiple constructors found for module $m: ${multiple.mkString(",")}"
                     )
                   case None => 0

--- a/main/eval/src/mill/eval/GroupEvaluator.scala
+++ b/main/eval/src/mill/eval/GroupEvaluator.scala
@@ -105,7 +105,7 @@ private[mill] trait GroupEvaluator {
               .headOption
               .getOrElse(throw new MillException(
                 s"Could not detect the parent class of target ${namedTask}. " +
-                  s"Please report this at ${BuildInfo.millReportNewIssueUrl}. " +
+                  s"Please report this at ${BuildInfo.millReportNewIssueUrl} " +
                   s"As a workaround, you can run Mill with `--disable-callgraph-invalidation` option."
               ))
               .getDeclaringClass.getName


### PR DESCRIPTION
This is related to #2844.

We report the target name in case we weren't able to detect it's declaring parent class.

Tested manually with a Mill version before the merge of #2883.

```scala
// /tmp/mill-2844/build.sc
import mill._

object mod extends Module {

  object foo extends Module {
    def bar = T {
      baz()
    }
  }

  private def baz = T { "baz" }
}
```

```
> mill -i dev.run /tmp/mill-2844 -i mod.foo.bar
[1691/1691] dev.run 
[info] compiling 1 Scala source to /tmp/mill-2844/out/mill-build/compile.dest/classes ...
[info] done compiling
Could not detect the parent class of target mod.baz. Please report this at https://github.com/com-lihaoyi/mill/issues/new/choose. As a workaround, you can run Mill with `--disable-callgraph-invalidation` option.
```

Pull request: https://github.com/com-lihaoyi/mill/pull/2885