### PR TITLE
Apply coursier default config files (repositories and mirrors config)

### DIFF
--- a/scalalib/src/mill/scalalib/CoursierModule.scala
+++ b/scalalib/src/mill/scalalib/CoursierModule.scala
@@ -8,6 +8,8 @@ import mill.define.Task
 import mill.api.PathRef
 
 import scala.annotation.nowarn
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
 
 /**
  * This module provides the capability to resolve (transitive) dependencies from (remote) repositories.
@@ -60,7 +62,12 @@ trait CoursierModule extends mill.Module {
    * The repositories used to resolved dependencies with [[resolveDeps()]].
    */
   def repositoriesTask: Task[Seq[Repository]] = T.task {
-    Resolve.defaultRepositories
+    import scala.concurrent.ExecutionContext.Implicits.global
+    val repos = Await.result(
+      Resolve().finalRepositories.future(),
+      Duration.Inf
+    )
+    repos
   }
 
   /**

--- a/scalalib/test/resources/coursier/mirror.properties
+++ b/scalalib/test/resources/coursier/mirror.properties
@@ -1,0 +1,2 @@
+central.from=https://repo1.maven.org/maven2
+central.to=https://repo.maven.apache.org/maven2/

--- a/scalalib/test/src/mill/scalalib/CoursierMirrorTests.scala
+++ b/scalalib/test/src/mill/scalalib/CoursierMirrorTests.scala
@@ -1,0 +1,42 @@
+package mill.scalalib
+
+import mill.util.{TestEvaluator, TestUtil}
+import mill.eval.{Evaluator}
+import utest._
+import utest.framework.TestPath
+
+object CoursierMirrorTests extends TestSuite {
+
+  val resourcePath = os.pwd / "scalalib" / "test" / "resources" / "coursier"
+
+  object CoursierTest extends TestUtil.BaseModule {
+    object core extends ScalaModule {
+      def scalaVersion = "2.13.12"
+    }
+  }
+
+  def workspaceTest[T](
+      m: TestUtil.BaseModule,
+      resourcePath: os.Path = resourcePath,
+      env: Map[String, String] = Evaluator.defaultEnv,
+      debug: Boolean = false
+  )(t: TestEvaluator => T)(implicit tp: TestPath): T = {
+    val eval = new TestEvaluator(m, env = env, debugEnabled = debug)
+    os.remove.all(m.millSourcePath)
+    os.remove.all(eval.outPath)
+    os.makeDir.all(m.millSourcePath / os.up)
+    os.copy(resourcePath, m.millSourcePath)
+    t(eval)
+  }
+
+  def tests: Tests = Tests {
+    sys.props("coursier.mirrors") = (resourcePath / "mirror.properties").toString
+    "readMirror" - workspaceTest(CoursierTest) { eval =>
+      val Right((result, evalCount)) = eval.apply(CoursierTest.core.repositoriesTask)
+      val centralReplaced = result.exists { repo =>
+        repo.repr.contains("https://repo.maven.apache.org/maven2")
+      }
+      assert(centralReplaced)
+    }
+  }
+}


### PR DESCRIPTION
Fix #2312 

Copied from 
https://github.com/coursier/coursier/blob/main/modules/coursier/shared/src/main/scala/coursier/Resolve.scala#L61

It is possible to use `Resolve().finalRepositories.future()`  to avoid the implementation detail.

But that requires `Await` and `ExecutionContext`,  I'm not sure whether worth doing it.