### PR TITLE
Update zinc from 1.9.6 to 1.10.0, use improved analysis store

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -184,7 +184,7 @@ object Deps {
   val upickle = ivy"com.lihaoyi::upickle:3.2.0"
   val utest = ivy"com.lihaoyi::utest:0.8.2"
   val windowsAnsi = ivy"io.github.alexarchambault.windows-ansi:windows-ansi:0.0.5"
-  val zinc = ivy"org.scala-sbt::zinc:1.9.6"
+  val zinc = ivy"org.scala-sbt::zinc:1.10.0-M1"
   // keep in sync with doc/antora/antory.yml
   val bsp4j = ivy"ch.epfl.scala:bsp4j:2.2.0-M2"
   val fansi = ivy"com.lihaoyi::fansi:0.4.0"

--- a/build.sc
+++ b/build.sc
@@ -184,7 +184,7 @@ object Deps {
   val upickle = ivy"com.lihaoyi::upickle:3.2.0"
   val utest = ivy"com.lihaoyi::utest:0.8.2"
   val windowsAnsi = ivy"io.github.alexarchambault.windows-ansi:windows-ansi:0.0.5"
-  val zinc = ivy"org.scala-sbt::zinc:1.10.0-M3"
+  val zinc = ivy"org.scala-sbt::zinc:1.10.0-RC1"
   // keep in sync with doc/antora/antory.yml
   val bsp4j = ivy"ch.epfl.scala:bsp4j:2.2.0-M2"
   val fansi = ivy"com.lihaoyi::fansi:0.4.0"

--- a/build.sc
+++ b/build.sc
@@ -184,7 +184,7 @@ object Deps {
   val upickle = ivy"com.lihaoyi::upickle:3.2.0"
   val utest = ivy"com.lihaoyi::utest:0.8.2"
   val windowsAnsi = ivy"io.github.alexarchambault.windows-ansi:windows-ansi:0.0.5"
-  val zinc = ivy"org.scala-sbt::zinc:1.10.0-M1"
+  val zinc = ivy"org.scala-sbt::zinc:1.10.0-M2"
   // keep in sync with doc/antora/antory.yml
   val bsp4j = ivy"ch.epfl.scala:bsp4j:2.2.0-M2"
   val fansi = ivy"com.lihaoyi::fansi:0.4.0"

--- a/build.sc
+++ b/build.sc
@@ -184,7 +184,7 @@ object Deps {
   val upickle = ivy"com.lihaoyi::upickle:3.2.0"
   val utest = ivy"com.lihaoyi::utest:0.8.2"
   val windowsAnsi = ivy"io.github.alexarchambault.windows-ansi:windows-ansi:0.0.5"
-  val zinc = ivy"org.scala-sbt::zinc:1.10.0-RC2"
+  val zinc = ivy"org.scala-sbt::zinc:1.10.0"
   // keep in sync with doc/antora/antory.yml
   val bsp4j = ivy"ch.epfl.scala:bsp4j:2.2.0-M2"
   val fansi = ivy"com.lihaoyi::fansi:0.4.0"

--- a/build.sc
+++ b/build.sc
@@ -184,7 +184,7 @@ object Deps {
   val upickle = ivy"com.lihaoyi::upickle:3.2.0"
   val utest = ivy"com.lihaoyi::utest:0.8.2"
   val windowsAnsi = ivy"io.github.alexarchambault.windows-ansi:windows-ansi:0.0.5"
-  val zinc = ivy"org.scala-sbt::zinc:1.10.0-RC1"
+  val zinc = ivy"org.scala-sbt::zinc:1.10.0-RC2"
   // keep in sync with doc/antora/antory.yml
   val bsp4j = ivy"ch.epfl.scala:bsp4j:2.2.0-M2"
   val fansi = ivy"com.lihaoyi::fansi:0.4.0"

--- a/build.sc
+++ b/build.sc
@@ -184,7 +184,7 @@ object Deps {
   val upickle = ivy"com.lihaoyi::upickle:3.2.0"
   val utest = ivy"com.lihaoyi::utest:0.8.2"
   val windowsAnsi = ivy"io.github.alexarchambault.windows-ansi:windows-ansi:0.0.5"
-  val zinc = ivy"org.scala-sbt::zinc:1.10.0-M2"
+  val zinc = ivy"org.scala-sbt::zinc:1.10.0-M3"
   // keep in sync with doc/antora/antory.yml
   val bsp4j = ivy"ch.epfl.scala:bsp4j:2.2.0-M2"
   val fansi = ivy"com.lihaoyi::fansi:0.4.0"

--- a/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
+++ b/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
@@ -487,7 +487,7 @@ class ZincWorkerImpl(
       reportCachedProblems: Boolean,
       incrementalCompilation: Boolean,
       auxiliaryClassFileExtensions: Seq[String],
-      zincFile: os.SubPath = os.sub / "zinc"
+      zincCache: os.SubPath = os.sub / "zinc"
   )(implicit ctx: ZincWorkerApi.Ctx): Result[CompilationResult] = {
     os.makeDir.all(ctx.dest)
 
@@ -548,7 +548,7 @@ class ZincWorkerImpl(
       if (compileToJar) ctx.dest / "classes.jar"
       else ctx.dest / "classes"
 
-    val store = fileAnalysisStore(ctx.dest / zincFile)
+    val store = fileAnalysisStore(ctx.dest / zincCache)
 
     // Fix jdk classes marked as binary dependencies, see https://github.com/com-lihaoyi/mill/pull/1904
     val converter = MappedFileConverter.empty
@@ -577,7 +577,7 @@ class ZincWorkerImpl(
       setup = ic.setup(
         lookup = lookup,
         skip = false,
-        cacheFile = zincFile.toNIO,
+        cacheFile = zincCache.toNIO,
         cache = new FreshCompilerCache,
         incOptions = incOptions,
         reporter = newReporter,
@@ -621,7 +621,7 @@ class ZincWorkerImpl(
           newResult.setup()
         )
       )
-      Result.Success(CompilationResult((ctx.dest / zincFile), PathRef(classesDir)))
+      Result.Success(CompilationResult((ctx.dest / zincCache), PathRef(classesDir)))
     } catch {
       case e: CompileFailed =>
         Result.Failure(e.toString)

--- a/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
+++ b/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
@@ -13,7 +13,6 @@ import mill.scalalib.api.{CompilationResult, Versions, ZincWorkerApi, ZincWorker
 import sbt.internal.inc.{
   Analysis,
   CompileFailed,
-  FileAnalysisStore,
   FreshCompilerCache,
   ManagedLoggedReporter,
   MappedFileConverter,
@@ -23,6 +22,7 @@ import sbt.internal.inc.{
   javac
 }
 import sbt.internal.inc.classpath.ClasspathUtil
+import sbt.internal.inc.consistent.ConsistentFileAnalysisStore
 import sbt.internal.util.{ConsoleAppender, ConsoleOut}
 import sbt.mill.SbtLoggerUtils
 import xsbti.compile.analysis.ReadWriteMappers
@@ -474,7 +474,7 @@ class ZincWorkerImpl(
   }
 
   private def fileAnalysisStore(path: os.Path): AnalysisStore =
-    FileAnalysisStore.binary(path.toIO, ReadWriteMappers.getEmptyMappers())
+    ConsistentFileAnalysisStore.binary(path.toIO, ReadWriteMappers.getEmptyMappers())
 
   private def compileInternal(
       upstreamCompileOutput: Seq[CompilationResult],

--- a/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
+++ b/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
@@ -474,7 +474,12 @@ class ZincWorkerImpl(
   }
 
   private def fileAnalysisStore(path: os.Path): AnalysisStore =
-    ConsistentFileAnalysisStore.binary(path.toIO, ReadWriteMappers.getEmptyMappers())
+    ConsistentFileAnalysisStore.binary(
+      file = path.toIO,
+      mappers = ReadWriteMappers.getEmptyMappers(),
+      // No need to utilize more that 8 cores to serialize a small file
+      parallelism = math.min(Runtime.getRuntime.availableProcessors(), 8)
+    )
 
   private def compileInternal(
       upstreamCompileOutput: Seq[CompilationResult],


### PR DESCRIPTION
This PR updates Zinc to 1.10.0. We make use of a new `ConsistentFileAnalysisStore` which is used by zinc to store internal analysis data used for incremental compilation. The new store is faster and more reproducible.