### PR TITLE
Added per-dependency format to dependency update finder

### DIFF
--- a/scalalib/src/mill/scalalib/Dependency.scala
+++ b/scalalib/src/mill/scalalib/Dependency.scala
@@ -3,7 +3,7 @@ package mill.scalalib
 import mill.T
 import mill.define.{Command, Discover, ExternalModule}
 import mill.eval.Evaluator
-import mill.scalalib.dependency.DependencyUpdatesImpl
+import mill.scalalib.dependency.{DependencyUpdatesImpl, Format}
 import mill.scalalib.dependency.updates.ModuleDependenciesUpdates
 
 object Dependency extends ExternalModule {
@@ -24,9 +24,17 @@ object Dependency extends ExternalModule {
     }
 
   /** Show possible dependency updates. */
-  def showUpdates(ev: Evaluator, allowPreRelease: Boolean = false): Command[Unit] = T.command {
-    DependencyUpdatesImpl.showAllUpdates(updates(ev, allowPreRelease)())
+  def showUpdates(
+      ev: Evaluator,
+      allowPreRelease: Boolean = false,
+      format: Format = Format.PerModule
+  ): Command[Unit] = T.command {
+    DependencyUpdatesImpl.showAllUpdates(updates(ev, allowPreRelease)(), format)
   }
+
+  @deprecated("Use other overload instead", "Mill after 0.11.6")
+  def showUpdates(ev: Evaluator, allowPreRelease: Boolean): Command[Unit] =
+    Dependency.showUpdates(ev, allowPreRelease, Format.PerModule)
 
   lazy val millDiscover: Discover[Dependency.this.type] = Discover[this.type]
 }

--- a/scalalib/src/mill/scalalib/dependency/DependencyUpdatesImpl.scala
+++ b/scalalib/src/mill/scalalib/dependency/DependencyUpdatesImpl.scala
@@ -1,5 +1,6 @@
 package mill.scalalib.dependency
 
+import mill.api.Ctx.{Home, Log}
 import mill.define._
 import mill.eval.Evaluator
 import mill.scalalib.dependency.updates.{
@@ -8,7 +9,6 @@ import mill.scalalib.dependency.updates.{
   UpdatesFinder
 }
 import mill.scalalib.dependency.versions.{ModuleDependenciesVersions, VersionsFinder}
-import mill.api.Ctx.{Home, Log}
 
 object DependencyUpdatesImpl {
 
@@ -33,25 +33,64 @@ object DependencyUpdatesImpl {
     allUpdates
   }
 
+  @deprecated("Use other overload instead", "Mill after 0.11.6")
   def showAllUpdates(updates: Seq[ModuleDependenciesUpdates]): Unit =
-    updates.foreach { dependencyUpdates =>
-      val module = dependencyUpdates.modulePath
-      val actualUpdates =
-        dependencyUpdates.dependencies.filter(_.updates.nonEmpty)
-      if (actualUpdates.isEmpty) {
-        println(s"No dependency updates found for $module")
-      } else {
-        println(s"Found ${actualUpdates.length} dependency update for $module")
-        showUpdates(actualUpdates)
-      }
+    showAllUpdates(updates, format = Format.PerModule)
+
+  def showAllUpdates(
+      updates: Seq[ModuleDependenciesUpdates],
+      format: Format = Format.PerModule
+  ): Unit = {
+    val theUpdates =
+      updates.map(u => if (u.modulePath.isEmpty) u.copy(modulePath = "root module") else u)
+
+    format match {
+      case Format.PerModule =>
+        theUpdates.foreach { dependencyUpdates =>
+          val module = dependencyUpdates.modulePath
+          val actualUpdates =
+            dependencyUpdates.dependencies.filter(_.updates.nonEmpty)
+          if (actualUpdates.isEmpty) {
+            println(s"No dependency updates found for $module")
+          } else {
+            println(s"Found ${actualUpdates.length} dependency update for $module")
+            showUpdates(actualUpdates)
+          }
+        }
+      case Format.PerDependency =>
+        val acutalUpdates = theUpdates
+          .view
+          .flatMap(depUpdates =>
+            depUpdates.dependencies
+              .filter(_.updates.nonEmpty)
+              .map(d => (formatDependencyUpdate(d), depUpdates.modulePath))
+          )
+          .groupBy(d => d._1)
+          .map { u =>
+            val dep = u._1 // formatDependencyUpdate(u._1)
+            val modules = u._2.map(_._2).mkString("\n  ", "\n  ", "")
+            s"${dep} in ${modules}"
+          }
+          .toSeq
+
+        if (acutalUpdates.isEmpty) {
+          println("No dependency updates found")
+        } else {
+          acutalUpdates.sorted.foreach(println(_))
+        }
+
     }
+  }
+
+  private def formatDependencyUpdate(dependencyUpdate: DependencyUpdates): String = {
+    val module = s"${dependencyUpdate.dependency.module}"
+    val versions = (dependencyUpdate.currentVersion +: dependencyUpdate.updates.toList)
+      .mkString(" -> ")
+    s"${module} : ${versions}"
+  }
 
   private def showUpdates(updates: Seq[DependencyUpdates]): Unit =
     updates.foreach { dependencyUpdate =>
-      val module = s"${dependencyUpdate.dependency.module}"
-      val allVersions =
-        (dependencyUpdate.currentVersion +: dependencyUpdate.updates.toList)
-          .mkString(" -> ")
-      println(s"  $module : $allVersions")
+      println(s"  ${formatDependencyUpdate(dependencyUpdate)}")
     }
 }

--- a/scalalib/src/mill/scalalib/dependency/Format.scala
+++ b/scalalib/src/mill/scalalib/dependency/Format.scala
@@ -1,0 +1,25 @@
+package mill.scalalib.dependency
+
+import mainargs.TokensReader
+
+sealed trait Format {
+  def name: String = toString
+}
+
+object Format {
+  case object PerModule extends Format
+  case object PerDependency extends Format
+
+  implicit object FormatRead extends TokensReader.Simple[Format] {
+    override def shortName: String = "format"
+    override def read(strs: scala.Seq[String]): Either[String, Format] = {
+      val all = Seq[Format](Format.PerModule, Format.PerDependency)
+      strs.headOption
+        .flatMap(n => all.find(f => f.name == n))
+        .toRight(strs.headOption
+          .map(f => s"Unknown format: ${f}")
+          .getOrElse("Missing format") +
+          s". Possible formats: ${all.mkString(", ")}")
+    }
+  }
+}

--- a/scalalib/src/mill/scalalib/dependency/updates/DependencyUpdates.scala
+++ b/scalalib/src/mill/scalalib/dependency/updates/DependencyUpdates.scala
@@ -1,0 +1,18 @@
+package mill.scalalib.dependency.updates
+
+import mill.scalalib.dependency.versions.Version
+
+import scala.collection.SortedSet
+
+final case class DependencyUpdates(
+    dependency: coursier.Dependency,
+    currentVersion: Version,
+    updates: SortedSet[Version]
+)
+
+object DependencyUpdates {
+  import mill.scalalib.JsonFormatters.depFormat
+
+  implicit val rw: upickle.default.ReadWriter[DependencyUpdates] =
+    upickle.default.macroRW
+}

--- a/scalalib/src/mill/scalalib/dependency/updates/ModuleDependenciesUpdates.scala
+++ b/scalalib/src/mill/scalalib/dependency/updates/ModuleDependenciesUpdates.scala
@@ -9,7 +9,3 @@ object ModuleDependenciesUpdates {
   implicit val rw: upickle.default.ReadWriter[ModuleDependenciesUpdates] =
     upickle.default.macroRW
 }
-
-
-
-

--- a/scalalib/src/mill/scalalib/dependency/updates/ModuleDependenciesUpdates.scala
+++ b/scalalib/src/mill/scalalib/dependency/updates/ModuleDependenciesUpdates.scala
@@ -1,9 +1,5 @@
 package mill.scalalib.dependency.updates
 
-import mill.scalalib.dependency.versions.Version
-
-import scala.collection.SortedSet
-
 final case class ModuleDependenciesUpdates(
     modulePath: String,
     dependencies: Seq[DependencyUpdates]
@@ -14,15 +10,6 @@ object ModuleDependenciesUpdates {
     upickle.default.macroRW
 }
 
-final case class DependencyUpdates(
-    dependency: coursier.Dependency,
-    currentVersion: Version,
-    updates: SortedSet[Version]
-)
 
-object DependencyUpdates {
-  import mill.scalalib.JsonFormatters.depFormat
 
-  implicit val rw: upickle.default.ReadWriter[DependencyUpdates] =
-    upickle.default.macroRW
-}
+


### PR DESCRIPTION
Previously, we always presented all possible updates per modules.
Since, many Mill projects declare dependencies in a shared location
and use the same versions in all modules, this list can be rather long
and redundant.

This change adds a new `--format` option to select the format,
when searching for dependency updates. The old format is now named
`PerModule` and is the default (for compatibility).

Example:

```
> mill --meta-level 1 mill.scalalib.Dependency/showUpdates
Found 1 dependency update for root module
  io.github.classgraph:classgraph : 4.8.164 -> 4.8.165
```

I also added a new `PerDependency` format, which presents the dependency
with all it's possible versions and all affected modules.

Example:

```
> mill --meta-level 1 mill.scalalib.Dependency/showUpdates --format PerDependency
io.github.classgraph:classgraph : 4.8.164 -> 4.8.165 in
  root module
```
