### PR TITLE
Enforce ScalaFix unused imports and other things during PR validation

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -101,7 +101,7 @@ jobs:
     uses: ./.github/workflows/run-mill-action.yml
     with:
       java-version: '8'
-      millargs: -i __.fix && git diff --exit-code
+      millargs: -i -k __.fix --check
 
   bincompat-check:
     uses: ./.github/workflows/run-mill-action.yml

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -95,6 +95,12 @@ jobs:
     uses: ./.github/workflows/run-mill-action.yml
     with:
       java-version: '8'
+      millargs: mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll __.sources
+
+  scalafix-check:
+    uses: ./.github/workflows/run-mill-action.yml
+    with:
+      java-version: '8'
       millargs: -i __.fix && git diff --exit-code
 
   bincompat-check:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -95,7 +95,7 @@ jobs:
     uses: ./.github/workflows/run-mill-action.yml
     with:
       java-version: '8'
-      millargs: mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll __.sources
+      millargs: -i __.fix && git diff --exit-code
 
   bincompat-check:
     uses: ./.github/workflows/run-mill-action.yml

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,3 @@
+rules = [
+    RemoveUnused
+]

--- a/build.sc
+++ b/build.sc
@@ -7,11 +7,13 @@ import $ivy.`de.tototec::de.tobiasroeser.mill.vcs.version::0.4.0`
 import $ivy.`com.github.lolgab::mill-mima::0.1.0`
 import $ivy.`net.sourceforge.htmlcleaner:htmlcleaner:2.29`
 import $ivy.`com.lihaoyi::mill-contrib-buildinfo:`
+import $ivy.`com.goyeau::mill-scalafix::0.3.1`
 
 // imports
 import com.github.lolgab.mill.mima.{CheckDirection, ProblemFilter, Mima}
 import coursier.maven.MavenRepository
 import de.tobiasroeser.mill.vcs.version.VcsVersion
+import com.goyeau.mill.scalafix.ScalafixModule
 import mill._
 import mill.api.JarManifest
 import mill.define.NamedTask
@@ -317,10 +319,10 @@ trait MillPublishJavaModule extends MillJavaModule with PublishModule {
 /**
  * Some custom scala settings and test convenience
  */
-trait MillScalaModule extends ScalaModule with MillJavaModule { outer =>
+trait MillScalaModule extends ScalaModule with MillJavaModule with ScalafixModule{ outer =>
   def scalaVersion = Deps.scalaVersion
   def scalacOptions =
-    super.scalacOptions() ++ Seq("-deprecation", "-P:acyclic:force", "-feature", "-Xlint:unused")
+    super.scalacOptions() ++ Seq("-deprecation", "-P:acyclic:force", "-feature", "-Ywarn-unused:imports")
 
   def testIvyDeps: T[Agg[Dep]] = Agg(Deps.utest)
   def testModuleDeps: Seq[JavaModule] =
@@ -820,6 +822,8 @@ object contrib extends Module {
 
     // Worker for Scoverage 1.x
     object worker extends MillPublishScalaModule {
+      // scoverage is on an old Scala version which doesnt support scalafix
+      def fix(args: String*): Command[Unit] = T.command{}
       def compileModuleDeps = Seq(main.api)
       def moduleDeps = Seq(scoverage.api)
       def testDepPaths = T { Seq(compile().classes) }
@@ -1044,6 +1048,8 @@ object example extends MillScalaModule {
   object web extends Cross[ExampleCrossModule](listIn(millSourcePath / "web"))
 
   trait ExampleCrossModule extends IntegrationTestCrossModule {
+    // disable scalafix because these example modules don't have sources causing it to misbehave
+    def fix(args: String*): Command[Unit] = T.command{}
     def testRepoRoot: T[PathRef] = T.source(millSourcePath)
     def compile = example.compile()
     def forkEnv = super.forkEnv() ++ Map("MILL_EXAMPLE_PARSED" -> upickle.default.write(parsed()))
@@ -1301,6 +1307,8 @@ object dist extends MillPublishJavaModule {
 }
 
 object dev extends MillPublishScalaModule {
+  // disable scalafix here because it crashes when a module has no sources
+  def fix(args: String*): Command[Unit] = T.command{}
   def moduleDeps = Seq(runner, idea)
 
   def testTransitiveDeps = super.testTransitiveDeps() ++ Seq(

--- a/build.sc
+++ b/build.sc
@@ -322,7 +322,7 @@ trait MillPublishJavaModule extends MillJavaModule with PublishModule {
 trait MillScalaModule extends ScalaModule with MillJavaModule with ScalafixModule{ outer =>
   def scalaVersion = Deps.scalaVersion
   def scalacOptions =
-    super.scalacOptions() ++ Seq("-deprecation", "-P:acyclic:force", "-feature", "-Ywarn-unused:imports")
+    super.scalacOptions() ++ Seq("-deprecation", "-P:acyclic:force", "-feature", "-Xlint:unused")
 
   def testIvyDeps: T[Agg[Dep]] = Agg(Deps.utest)
   def testModuleDeps: Seq[JavaModule] =

--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageReportWorker.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageReportWorker.scala
@@ -9,7 +9,7 @@ class ScoverageReportWorker extends AutoCloseable {
   private[this] var scoverageClCache = Option.empty[(Long, ClassLoader)]
 
   def bridge(classpath: Agg[PathRef])(implicit ctx: Ctx): ScoverageReportWorkerApi = {
-    val klassName = "mill.contrib.scoverage.worker.ScoverageReportWorkerImpl"
+    
     val classloaderSig = classpath.hashCode
     val cl = scoverageClCache match {
       case Some((sig, cl)) if sig == classloaderSig => cl

--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageReportWorker.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageReportWorker.scala
@@ -9,7 +9,7 @@ class ScoverageReportWorker extends AutoCloseable {
   private[this] var scoverageClCache = Option.empty[(Long, ClassLoader)]
 
   def bridge(classpath: Agg[PathRef])(implicit ctx: Ctx): ScoverageReportWorkerApi = {
-    
+
     val classloaderSig = classpath.hashCode
     val cl = scoverageClCache match {
       case Some((sig, cl)) if sig == classloaderSig => cl

--- a/contrib/twirllib/src/mill/twirllib/TwirlWorker.scala
+++ b/contrib/twirllib/src/mill/twirllib/TwirlWorker.scala
@@ -103,7 +103,7 @@ class TwirlWorker {
             //   Codec codec,
             //   boolean inclusiveDot
             // )
-            val o = compileMethod.invoke(
+            compileMethod.invoke(
               null,
               source,
               sourceDirectory,

--- a/idea/src/mill/idea/GenIdeaImpl.scala
+++ b/idea/src/mill/idea/GenIdeaImpl.scala
@@ -205,7 +205,7 @@ case class GenIdeaImpl(
                   extRunIvyDeps().map(_.path).map(Scoped(_, Some("RUNTIME")))
               // unused, but we want to trigger sources, to have them available (automatically)
               // TODO: make this a separate eval to handle resolve errors
-              val resolvedSrcs: Agg[PathRef] = externalSources()
+              externalSources()
               val resolvedSp: Agg[PathRef] = scalacPluginDependencies()
               val resolvedCompilerCp: Agg[PathRef] =
                 scalaCompilerClasspath()
@@ -443,9 +443,6 @@ case class GenIdeaImpl(
           val key = (q.pluginClasspath, q.scalaOptions)
           r + (key -> (r.getOrElse(key, Vector()) :+ q.module))
       }
-
-    val allBuildLibraries: Set[ResolvedLibrary] =
-      resolvedLibraries(buildLibraryPaths ++ buildDepsPaths).toSet
 
     val fixedFiles: Seq[(SubPath, Elem)] = Seq(
       Tuple2(os.sub / "misc.xml", miscXmlTemplate(jdkInfo)),

--- a/integration/feature/private-methods/test/src/PrivateMethodsTests.scala
+++ b/integration/feature/private-methods/test/src/PrivateMethodsTests.scala
@@ -4,7 +4,7 @@ import utest._
 
 object PrivateMethodsTests extends IntegrationTestSuite {
   val tests = Tests {
-    val wsRoot = initWorkspace()
+    initWorkspace()
     "simple" - {
       // Simple public target depending on private target works
       val pub = evalStdout("show", "pub")

--- a/main/define/src/mill/define/EnclosingClass.scala
+++ b/main/define/src/mill/define/EnclosingClass.scala
@@ -8,7 +8,6 @@ object EnclosingClass {
   implicit def generate: EnclosingClass = macro impl
   def impl(c: Context): c.Tree = {
     import c.universe._
-    val cls = c.internal.enclosingOwner.owner.asType.asClass
     //    q"new _root_.mill.define.EnclosingClass(classOf[$cls])"
     q"new _root_.mill.define.EnclosingClass(this.getClass)"
   }

--- a/main/eval/src/mill/eval/EvaluatorCore.scala
+++ b/main/eval/src/mill/eval/EvaluatorCore.scala
@@ -2,7 +2,7 @@ package mill.eval
 
 import mill.api.Result.{Aborted, Failing}
 import mill.api.Strict.Agg
-import mill.api.{Ctx, _}
+import mill.api._
 import mill.define._
 import mill.eval.Evaluator.TaskResult
 import mill.util._

--- a/main/eval/src/mill/eval/GroupEvaluator.scala
+++ b/main/eval/src/mill/eval/GroupEvaluator.scala
@@ -9,7 +9,7 @@ import mill.util._
 
 import java.io.PrintStream
 import scala.collection.mutable
-import scala.reflect.NameTransformer.{encode, decode}
+import scala.reflect.NameTransformer.encode
 import scala.util.DynamicVariable
 import scala.util.control.NonFatal
 

--- a/scalalib/src/mill/scalalib/Dep.scala
+++ b/scalalib/src/mill/scalalib/Dep.scala
@@ -136,7 +136,7 @@ object Dep {
       force
     )
   }
-  private implicit val depFormat: RW[Dependency] = mill.scalalib.JsonFormatters.depFormat
+
   implicit def rw: RW[Dep] = macroRW
 }
 
@@ -208,6 +208,6 @@ case class BoundDep(
 }
 
 object BoundDep {
-  private implicit val depFormat: RW[Dependency] = mill.scalalib.JsonFormatters.depFormat
+  mill.scalalib.JsonFormatters.depFormat
   implicit val jsonify: upickle.default.ReadWriter[BoundDep] = upickle.default.macroRW
 }

--- a/scalalib/src/mill/scalalib/Dep.scala
+++ b/scalalib/src/mill/scalalib/Dep.scala
@@ -208,6 +208,5 @@ case class BoundDep(
 }
 
 object BoundDep {
-  mill.scalalib.JsonFormatters.depFormat
   implicit val jsonify: upickle.default.ReadWriter[BoundDep] = upickle.default.macroRW
 }

--- a/scalalib/src/mill/scalalib/Dep.scala
+++ b/scalalib/src/mill/scalalib/Dep.scala
@@ -5,6 +5,8 @@ import mill.scalalib.CrossVersion._
 import coursier.core.Dependency
 import mill.scalalib.api.ZincWorkerUtil
 
+import scala.annotation.unused
+
 case class Dep(dep: coursier.Dependency, cross: CrossVersion, force: Boolean) {
   require(
     !dep.module.name.value.contains("/") &&
@@ -136,7 +138,7 @@ object Dep {
       force
     )
   }
-
+  @unused private implicit val depFormat: RW[Dependency] = mill.scalalib.JsonFormatters.depFormat
   implicit def rw: RW[Dep] = macroRW
 }
 
@@ -208,5 +210,6 @@ case class BoundDep(
 }
 
 object BoundDep {
+  @unused private implicit val depFormat: RW[Dependency] = mill.scalalib.JsonFormatters.depFormat
   implicit val jsonify: upickle.default.ReadWriter[BoundDep] = upickle.default.macroRW
 }

--- a/scalalib/src/mill/scalalib/GenIdeaImpl.scala
+++ b/scalalib/src/mill/scalalib/GenIdeaImpl.scala
@@ -178,7 +178,7 @@ case class GenIdeaImpl(
               extRunIvyDeps().map(_.path).map(Scoped(_, Some("RUNTIME")))
           // unused, but we want to trigger sources, to have them available (automatically)
           // TODO: make this a separate eval to handle resolve errors
-          val resolvedSrcs: Agg[PathRef] = externalSources()
+          externalSources()
           val resolvedSp: Agg[PathRef] = scalacPluginDependencies()
           val resolvedCompilerCp: Agg[PathRef] =
             scalaCompilerClasspath()


### PR DESCRIPTION
Spiritual successor to #2776. This PR makes it such that no more unused imports will slip in in future, and allows them to be auto-fixed via `./mill __.fix`

Pull request: https://github.com/com-lihaoyi/mill/pull/2918