### PR TITLE
GenIdea: Put module dependencies after library dependencies

### DIFF
--- a/idea/src/mill/idea/GenIdeaImpl.scala
+++ b/idea/src/mill/idea/GenIdeaImpl.scala
@@ -886,7 +886,7 @@ case class GenIdeaImpl(
     }
         {
         // we place the module dependencies after the library dependencies, as IJ is leaking the (transitive)
-        // library dependencies of the module dependencies, even if they are not exported
+        // library dependencies of the module dependencies, even if they are not exported.
         // This can result in wrong classpath when lib dependencies are refined.
         for (dep <- depNames.sorted)
           yield dep.scope match {

--- a/idea/src/mill/idea/GenIdeaImpl.scala
+++ b/idea/src/mill/idea/GenIdeaImpl.scala
@@ -885,16 +885,16 @@ case class GenIdeaImpl(
         }
     }
         {
-        // we place the module dependencies after the library dependencies, as IJ is leaking the (transitive)
-        // library dependencies of the module dependencies, even if they are not exported.
-        // This can result in wrong classpath when lib dependencies are refined.
-        for (dep <- depNames.sorted)
-          yield dep.scope match {
-            case None => <orderEntry type="module" module-name={dep.value} exported="" />
-            case Some(scope) =>
-                <orderEntry type="module" module-name={dep.value} exported="" scope={scope} />
-          }
+      // we place the module dependencies after the library dependencies, as IJ is leaking the (transitive)
+      // library dependencies of the module dependencies, even if they are not exported.
+      // This can result in wrong classpath when lib dependencies are refined.
+      for (dep <- depNames.sorted)
+        yield dep.scope match {
+          case None => <orderEntry type="module" module-name={dep.value} exported="" />
+          case Some(scope) =>
+            <orderEntry type="module" module-name={dep.value} exported="" scope={scope} />
         }
+    }
       </component>
       {
       if (facets.isEmpty) NodeSeq.Empty

--- a/integration/feature/gen-idea/repo/extended/idea/mill_modules/helloworld.test.iml
+++ b/integration/feature/gen-idea/repo/extended/idea/mill_modules/helloworld.test.iml
@@ -8,7 +8,7 @@
         </content>
         <orderEntry type="inheritedJdk"/>
         <orderEntry type="sourceFolder" forTests="false"/>
-        <orderEntry type="module" module-name="helloworld" exported=""/>
         <orderEntry type="library" name="scala-library-2.13.6.jar" level="project"/>
+        <orderEntry type="module" module-name="helloworld" exported=""/>
     </component>
 </module>

--- a/integration/feature/gen-idea/repo/hello-world/idea/mill_modules/helloworld.test.iml
+++ b/integration/feature/gen-idea/repo/hello-world/idea/mill_modules/helloworld.test.iml
@@ -8,11 +8,11 @@
         </content>
         <orderEntry type="inheritedJdk"/>
         <orderEntry type="sourceFolder" forTests="false"/>
-        <orderEntry type="module" module-name="helloworld" exported=""/>
         <orderEntry type="library" scope="PROVIDED" name="jcl-over-slf4j-1.7.25.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="logback-classic-1.2.3.jar" level="project"/>
         <orderEntry type="library" name="logback-core-1.2.3.jar" level="project"/>
         <orderEntry type="library" name="scala-library-2.12.5.jar" level="project"/>
         <orderEntry type="library" name="slf4j-api-1.7.25.jar" level="project"/>
+        <orderEntry type="module" module-name="helloworld" exported=""/>
     </component>
 </module>


### PR DESCRIPTION
This is to have explicitly configured lib dependencies before (unwanted) transitive ones from module dependencies.

* Fix https://github.com/com-lihaoyi/mill/issues/2924