### PR TITLE
Use root as the name for `RootModule`s in examples

### DIFF
--- a/example/web/1-todo-webapp/build.sc
+++ b/example/web/1-todo-webapp/build.sc
@@ -1,6 +1,6 @@
 import mill._, scalalib._
 
-object app extends RootModule with ScalaModule {
+object root extends RootModule with ScalaModule {
   def scalaVersion = "2.13.8"
   def ivyDeps = Agg(
     ivy"com.lihaoyi::cask:0.9.1",

--- a/example/web/2-webapp-cache-busting/build.sc
+++ b/example/web/2-webapp-cache-busting/build.sc
@@ -1,7 +1,7 @@
 import mill._, scalalib._
 import java.util.Arrays
 
-object app extends RootModule with ScalaModule {
+object root extends RootModule with ScalaModule {
   def scalaVersion = "2.13.8"
   def ivyDeps = Agg(
     ivy"com.lihaoyi::cask:0.9.1",

--- a/example/web/4-webapp-scalajs/build.sc
+++ b/example/web/4-webapp-scalajs/build.sc
@@ -1,6 +1,6 @@
 import mill._, scalalib._, scalajslib._
 
-object app extends RootModule with ScalaModule {
+object root extends RootModule with ScalaModule {
 
   def scalaVersion = "2.13.8"
   def ivyDeps = Agg(

--- a/example/web/5-webapp-scalajs-shared/build.sc
+++ b/example/web/5-webapp-scalajs-shared/build.sc
@@ -8,7 +8,7 @@ trait AppScalaJSModule extends AppScalaModule with ScalaJSModule {
   def scalaJSVersion = "1.13.0"
 }
 
-object app extends RootModule with AppScalaModule {
+object root extends RootModule with AppScalaModule {
   def moduleDeps = Seq(shared.jvm)
   def ivyDeps = Agg(ivy"com.lihaoyi::cask:0.9.1")
 


### PR DESCRIPTION
Calling a `RootModule` `app` gives the false impression that its `millSourcePath` is `./app` when, in reality, it's the project root directory. `root` makes it more obvious.

Pull Request: https://github.com/com-lihaoyi/mill/pull/2928