### PR TITLE
BSP: Add JavaModule.bspBuildTargetData to make JavaModule reports workable BuildTarget

### DIFF
--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -13,7 +13,7 @@ import mill.api.{Ctx, JarManifest, MillException, PathRef, Result, internal}
 import mill.define.{Command, ModuleRef, Segment, Task, TaskModule}
 import mill.scalalib.internal.ModuleUtils
 import mill.scalalib.api.CompilationResult
-import mill.scalalib.bsp.{BspBuildTarget, BspModule}
+import mill.scalalib.bsp.{BspBuildTarget, BspModule, BspUri, JvmBuildTarget}
 import mill.scalalib.publish.Artifact
 import mill.util.Jvm
 import os.{Path, ProcessOutput}
@@ -1025,4 +1025,14 @@ trait JavaModule
     canRun = true
   )
 
+  @internal
+  override def bspBuildTargetData: Task[Option[(String, AnyRef)]] = T.task {
+    Some((
+      JvmBuildTarget.dataKind,
+      JvmBuildTarget(
+        javaHome = Option(System.getProperty("java.home")).map(p => BspUri(os.Path(p))),
+        javaVersion = Option(System.getProperty("java.version"))
+      )
+    ))
+  }
 }

--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -11,6 +11,7 @@ import mainargs.Flag
 import mill.scalalib.bsp.{
   BspBuildTarget,
   BspModule,
+  BspUri,
   JvmBuildTarget,
   ScalaBuildTarget,
   ScalaPlatform
@@ -596,10 +597,17 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
         scalaBinaryVersion = ZincWorkerUtil.scalaBinaryVersion(scalaVersion()),
         platform = ScalaPlatform.JVM,
         jars = scalaCompilerClasspath().map(_.path.toNIO.toUri.toString).iterator.toSeq,
-        jvmBuildTarget = super.bspBuildTargetData().flatMap {
-          case (JvmBuildTarget.dataKind, bt: JvmBuildTarget) => Some(bt)
-          case _ => None
-        }
+        // this is what we want to use, but can't due to a resulting binary incompatibility
+        //        jvmBuildTarget = super.bspBuildTargetData().flatMap {
+        //          case (JvmBuildTarget.dataKind, bt: JvmBuildTarget) => Some(bt)
+        //          case _ => None
+        //        }
+        jvmBuildTarget = Some(
+          JvmBuildTarget(
+            javaHome = Option(System.getProperty("java.home")).map(p => BspUri(os.Path(p))),
+            javaVersion = Option(System.getProperty("java.version"))
+          )
+        )
       )
     ))
   }

--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -8,7 +8,13 @@ import mill.util.Jvm.createJar
 import mill.api.Loose.Agg
 import mill.scalalib.api.{CompilationResult, Versions, ZincWorkerUtil}
 import mainargs.Flag
-import mill.scalalib.bsp.{BspBuildTarget, BspModule, ScalaBuildTarget, ScalaPlatform}
+import mill.scalalib.bsp.{
+  BspBuildTarget,
+  BspModule,
+  JvmBuildTarget,
+  ScalaBuildTarget,
+  ScalaPlatform
+}
 import mill.scalalib.dependency.versions.{ValidVersion, Version}
 
 import scala.reflect.internal.util.ScalaClassLoader
@@ -590,12 +596,15 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
         scalaBinaryVersion = ZincWorkerUtil.scalaBinaryVersion(scalaVersion()),
         platform = ScalaPlatform.JVM,
         jars = scalaCompilerClasspath().map(_.path.toNIO.toUri.toString).iterator.toSeq,
-        jvmBuildTarget = None
+        jvmBuildTarget = super.bspBuildTargetData().flatMap {
+          case (JvmBuildTarget.dataKind, bt: JvmBuildTarget) => Some(bt)
+          case _ => None
+        }
       )
     ))
   }
 
-  override def semanticDbScalaVersion = scalaVersion()
+  override def semanticDbScalaVersion: T[String] = scalaVersion()
 
   override protected def semanticDbPluginClasspath = T {
     resolveDeps(T.task {
@@ -604,7 +613,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
     })()
   }
 
-  def semanticDbData: T[PathRef] = T.persistent {
+  override def semanticDbData: T[PathRef] = T.persistent {
     val sv = scalaVersion()
 
     val scalacOptions = (


### PR DESCRIPTION

it was not reporting `BuildTarget.dataKind` and `data` such that IJ will not ask `BuildTargetJavacOptions` for JavaModule and resolved as no dependency at all.