### PR TITLE
fix: ensure the BSP clean works as expected

### DIFF
--- a/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -592,9 +592,8 @@ private class MillBuildServer(
   override def buildTargetCleanCache(cleanCacheParams: CleanCacheParams)
       : CompletableFuture[CleanCacheResult] =
     completable(s"buildTargetCleanCache ${cleanCacheParams}") { state =>
-      val targetIds = state.rootModules.map { case b: BspModule => state.bspIdByModule(b) }
       val (msg, cleaned) =
-        cleanCacheParams.getTargets.asScala.filter(targetIds.contains).foldLeft((
+        cleanCacheParams.getTargets.asScala.foldLeft((
           "",
           true
         )) {


### PR DESCRIPTION
Looking at the last change that was made to this code in https://github.com/com-lihaoyi/mill/commit/65fbd53108fb155858094d242a16a67ef7d067f4 it's not clear to me why this line was added where we map everything to `BspModule` and then filtering the build targets on that which where in the request. My assumption is that anything that the build client is requesting to clean _should_ be a valid identifier. If not, then that originally came from Mill, so I'm unsure why we have this. Before this change it was causing issues since not everything in `state.rootModules` was a `BspModule` so you'd get a match exception.

To expand a bit the build targets here in an example `mill-test` (hello world) project are:

```
BuildTargetIdentifier [
  uri = "file:///Users/<me>/Documents/scala-workspace/mill-test/milltest"
],BuildTargetIdentifier [
  uri = "file:///Users/<me>/Documents/scala-workspace/mill-test/mill-build"
]
```

But when looking into the `state.rootModules` one of them is

```
/Users/<me>/Documents/scala-workspace/mill-test
```

This was the problematic one. I'm not sure if this is just a mapping issue or not, but the change I made instead just takes the build target identifies given from the client, does a look up in the `state.bspModulesById` mapping, and goes with it. This seems to work and simplifies this unless this is introducing an issue that I don't see.

closes #2915