### PR TITLE
fix: set `project.git = true` in scalafmt settings

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,7 @@
 version = "3.7.10"
 
+project.git = true
+
 align.preset = none
 align.openParenCallSite = false
 align.stripMargin = true

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,9 +1,7 @@
 version = "3.7.10"
 
-project.git = true
-
-align.preset = none
 align.openParenCallSite = false
+align.preset = none
 align.stripMargin = true
 
 assumeStandardLibraryStripMargin = true
@@ -11,13 +9,15 @@ assumeStandardLibraryStripMargin = true
 continuationIndent.callSite = 2
 continuationIndent.defnSite = 4
 
-docstrings.style = Asterisk
 docstrings.oneline = keep
+docstrings.style = Asterisk
 docstrings.wrap = no
 
 maxColumn = 100
 
 newlines.source = keep
+
+project.git = true
 
 runner.dialect = scala213
 


### PR DESCRIPTION
This ensures that if someone is using `scalafmt` via the CLI that it
correctly knows to ignore Scala files that are also ignored via git.
Without this locally when I used `scalafmt` from the command line I got
a ton of undesired changes.
