### PR TITLE
Make semanticDbEnablePluginScalacOptions protected

### DIFF
--- a/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
+++ b/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
@@ -49,7 +49,7 @@ trait SemanticDbJavaModule extends JavaModule { hostModule =>
   /**
    * Scalac options to activate the compiler plugins.
    */
-  private def semanticDbEnablePluginScalacOptions: Target[Seq[String]] = T {
+  protected def semanticDbEnablePluginScalacOptions: T[Seq[String]] = T {
     val resolvedJars = resolveDeps(semanticDbPluginIvyDeps.map(_.map(_.exclude("*" -> "*"))))()
     resolvedJars.iterator.map(jar => s"-Xplugin:${jar.path}").toSeq
   }


### PR DESCRIPTION
This makes it accessible for downstream tooling.

* Use case: https://github.com/joan38/mill-scalafix/pull/172

Essentially, this is a backport of what we have in Mill 0.11, so this PR is in the spirit of the previous pull requests we merged.