### PR TITLE
Fix #2946: Avoid evaluating `T.input`s twice

### DIFF
--- a/main/src/mill/main/RunScript.scala
+++ b/main/src/mill/main/RunScript.scala
@@ -46,7 +46,7 @@ object RunScript {
           Seq(Watchable.Path(p))
         case (t: InputImpl[_], TaskResult(result, recalc)) =>
           val pretty = t.ctx0.fileName + ":" + t.ctx0.lineNum
-          Seq(Watchable.Value(() => recalc().hashCode(), result.hashCode, pretty))
+          Seq(Watchable.Value(() => recalc().hashCode(), result.hashCode(), pretty))
       }
       .flatten
       .toSeq

--- a/main/src/mill/main/RunScript.scala
+++ b/main/src/mill/main/RunScript.scala
@@ -44,9 +44,9 @@ object RunScript {
           ps.map(Watchable.Path(_))
         case (t: SourceImpl, TaskResult(Result.Success(Val(p: PathRef)), _)) =>
           Seq(Watchable.Path(p))
-        case (t: InputImpl[_], TaskResult(_, recalc)) =>
+        case (t: InputImpl[_], TaskResult(result, recalc)) =>
           val pretty = t.ctx0.fileName + ":" + t.ctx0.lineNum
-          Seq(Watchable.Value(() => recalc().hashCode(), recalc().hashCode(), pretty))
+          Seq(Watchable.Value(() => recalc().hashCode(), result.hashCode, pretty))
       }
       .flatten
       .toSeq


### PR DESCRIPTION
Fixes #2946

In `evaluateNamed`, after evaluating `Task`s we are matching for `ImputImpl[_]` instances to construct a `Watchable`.
A `Watchable` instance contains a `hashCode` for the current result and a callback to evaluate it again and get the next result.
Instead of using the current result which was contained in `TaskResult`, we were already calling the `recalc` callback, which executes again the `T.input`s and performs their side effects twice.
Now we are returning the hashCode for the already computed result, so we don't execute the `recalc` callback right away.

Pull Request: https://github.com/com-lihaoyi/mill/pull/2952