### PR TITLE
Fix issue #2958 - deduplicate (anonymous) tasks in result

### DIFF
--- a/main/eval/src/mill/eval/EvaluatorCore.scala
+++ b/main/eval/src/mill/eval/EvaluatorCore.scala
@@ -170,7 +170,7 @@ private[mill] trait EvaluatorCore extends GroupEvaluator {
     EvaluatorCore.Results(
       goals.indexed.map(results(_).map(_._1).result),
       // result of flatMap may contain non-distinct entries,
-      // se we manually clean it up before converting to a `Strict.Agg`
+      // so we manually clean it up before converting to a `Strict.Agg`
       // see https://github.com/com-lihaoyi/mill/issues/2958
       Strict.Agg.from(
         finishedOptsMap.values.flatMap(_.toSeq.flatMap(_.newEvaluated)).iterator.distinct

--- a/main/eval/src/mill/eval/EvaluatorCore.scala
+++ b/main/eval/src/mill/eval/EvaluatorCore.scala
@@ -169,7 +169,11 @@ private[mill] trait EvaluatorCore extends GroupEvaluator {
 
     EvaluatorCore.Results(
       goals.indexed.map(results(_).map(_._1).result),
-      finishedOptsMap.map(_._2).flatMap(_.toSeq.flatMap(_.newEvaluated)),
+      Strict.Agg.from(
+        Loose.Agg.from(
+          finishedOptsMap.values.flatMap(_.toSeq.flatMap(_.newEvaluated))
+        )
+      ),
       transitive,
       getFailing(sortedGroups, results),
       results.map { case (k, v) => (k, v.map(_._1)) }

--- a/main/eval/src/mill/eval/EvaluatorCore.scala
+++ b/main/eval/src/mill/eval/EvaluatorCore.scala
@@ -169,10 +169,11 @@ private[mill] trait EvaluatorCore extends GroupEvaluator {
 
     EvaluatorCore.Results(
       goals.indexed.map(results(_).map(_._1).result),
+      // result of flatMap may contain non-distinct entries,
+      // se we manually clean it up before converting to a `Strict.Agg`
+      // see https://github.com/com-lihaoyi/mill/issues/2958
       Strict.Agg.from(
-        Loose.Agg.from(
-          finishedOptsMap.values.flatMap(_.toSeq.flatMap(_.newEvaluated))
-        )
+        finishedOptsMap.values.flatMap(_.toSeq.flatMap(_.newEvaluated)).iterator.distinct
       ),
       transitive,
       getFailing(sortedGroups, results),

--- a/main/eval/test/src/mill/eval/TaskTests.scala
+++ b/main/eval/test/src/mill/eval/TaskTests.scala
@@ -124,7 +124,7 @@ trait TaskTests extends TestSuite {
       val task1 = T.task { "task1" }
       def task2 = T { task1() }
       def task3 = T { task1() }
-      def com1() = T.command {
+      def command() = T.command {
         val t2 = task2()
         val t3 = task3()
         s"${t2},${t3}"
@@ -254,7 +254,7 @@ trait TaskTests extends TestSuite {
       }
     }
     "duplicateTaskInResult-issue2958" - withEnv { (build, check) =>
-      check.apply(build.repro2958.com1()) ==> Right(("task1,task1", 3))
+      check.apply(build.repro2958.command()) ==> Right(("task1,task1", 3))
     }
   }
 

--- a/main/eval/test/src/mill/eval/TaskTests.scala
+++ b/main/eval/test/src/mill/eval/TaskTests.scala
@@ -251,7 +251,7 @@ trait TaskTests extends TestSuite {
         check.apply(build.superBuildTargetOverrideWithInput) ==> Right((3, 0))
       }
     }
-    "duplicateTaskInResult-issue2958" - withEnv { (build,check) =>
+    "duplicateTaskInResult-issue2958" - withEnv { (build, check) =>
       check.apply(build.com1()) ==> Right("task1,task1", 1)
     }
   }

--- a/main/eval/test/src/mill/eval/TaskTests.scala
+++ b/main/eval/test/src/mill/eval/TaskTests.scala
@@ -2,7 +2,7 @@ package mill.eval
 
 import utest._
 import mill.T
-import mill.define.Worker
+import mill.define.{Module, Worker}
 import mill.util.{TestEvaluator, TestUtil}
 import utest.framework.TestPath
 
@@ -120,13 +120,15 @@ trait TaskTests extends TestSuite {
     }
 
     // Reproduction of issue https://github.com/com-lihaoyi/mill/issues/2958
-    val task1 = T.task { "task1" }
-    def task2 = T { task1() }
-    def task3 = T { task1() }
-    def com1() = T.command {
-      val t2 = task2()
-      val t3 = task3()
-      s"${t2},${t3}"
+    object repro2958 extends Module {
+      val task1 = T.task { "task1" }
+      def task2 = T { task1() }
+      def task3 = T { task1() }
+      def com1() = T.command {
+        val t2 = task2()
+        val t3 = task3()
+        s"${t2},${t3}"
+      }
     }
   }
 
@@ -252,7 +254,7 @@ trait TaskTests extends TestSuite {
       }
     }
     "duplicateTaskInResult-issue2958" - withEnv { (build, check) =>
-      check.apply(build.com1()) ==> Right("task1,task1", 1)
+      check.apply(build.repro2958.com1()) ==> Right(("task1,task1", 3))
     }
   }
 


### PR DESCRIPTION
Anonymous tasks can be defined as `val` or `def`. This is in contrast to named targets, which always need to be defined as `def`.

Also, anonymous tasks end up in the terminal group of the target that's using them.

If the same anonymous task is used in multiple targets, it also ends up multiple time in the task results. When a `Evaluator.Results` is created, this clashes, due to the use of a `Strict.Agg` for `Evalutor.Results.evaluated`.

This change deduplicated the results before constructing the `Evaluator.Results`.

Fix: https://github.com/com-lihaoyi/mill/issues/2958
