### PR TITLE
Properly sanitize Windows reserved names in evaluator paths

### DIFF
--- a/main/eval/src/mill/eval/EvaluatorPaths.scala
+++ b/main/eval/src/mill/eval/EvaluatorPaths.scala
@@ -45,7 +45,7 @@ object EvaluatorPaths {
     raw"^([cC][oO][nN]|[pP][rR][nN]|[aA][uU][xX]|[nN][uU][lL]|[cC][oO][mM][0-9¹²³]|[lL][pP][tT][0-9¹²³])($$|[.].*$$)".r
   def sanitizePathSegment(segment: String): os.PathChunk = {
     segment match {
-      case ReservedWinNames(keyword, rest) => s"${keyword}_${rest}"
+      case ReservedWinNames(keyword, rest) => s"${keyword}~${rest}"
       case s => s
     }
   }

--- a/main/eval/src/mill/eval/EvaluatorPaths.scala
+++ b/main/eval/src/mill/eval/EvaluatorPaths.scala
@@ -28,7 +28,7 @@ object EvaluatorPaths {
   ): EvaluatorPaths = {
     val refinedSegments = foreignSegments.map(_ ++ segments).getOrElse(segments)
     val segmentStrings = makeSegmentStrings(refinedSegments)
-    val targetPath = workspacePath / segmentStrings
+    val targetPath = workspacePath / segmentStrings.map(sanitizePathSegment)
     EvaluatorPaths(
       targetPath / os.up / s"${targetPath.last}.dest",
       targetPath / os.up / s"${targetPath.last}.json",
@@ -39,4 +39,14 @@ object EvaluatorPaths {
       workspacePath: os.Path,
       task: NamedTask[_]
   ): EvaluatorPaths = resolveDestPaths(workspacePath, task.ctx.segments, task.ctx.foreign)
+
+  // case-insensitive match on reserved names
+  private val ReservedWinNames =
+    raw"^([cC][oO][nN]|[pP][rR][nN]|[aA][uU][xX]|[nN][uU][lL]|[cC][oO][mM][0-9¹²³]|[lL][pP][tT][0-9¹²³])($$|[.].*$$)".r
+  def sanitizePathSegment(segment: String): os.PathChunk = {
+    segment match {
+      case ReservedWinNames(keyword, rest) => s"${keyword}_${rest}"
+      case s => s
+    }
+  }
 }

--- a/main/eval/test/src/mill/eval/EvaluatorPathsTests.scala
+++ b/main/eval/test/src/mill/eval/EvaluatorPathsTests.scala
@@ -8,8 +8,8 @@ object EvaluatorPathsTests extends TestSuite {
     "sanitizedPathSegment" - {
       "WindowsReservedNames" - {
         val replace = Seq(
-          "com1.json" -> "com1_.json",
-          "LPT¹" -> "LPT¹_"
+          "com1.json" -> "com1~.json",
+          "LPT¹" -> "LPT¹~"
         )
         val noReplace = Seq(
           "con10.json"

--- a/main/eval/test/src/mill/eval/EvaluatorPathsTests.scala
+++ b/main/eval/test/src/mill/eval/EvaluatorPathsTests.scala
@@ -1,0 +1,26 @@
+package mill.eval
+
+import utest._
+
+object EvaluatorPathsTests extends TestSuite {
+
+  override def tests: Tests = Tests {
+    "sanitizedPathSegment" - {
+      "WindowsReservedNames" - {
+        val replace = Seq(
+          "com1.json" -> "com1_.json",
+          "LPT¹" -> "LPT¹_"
+        )
+        val noReplace = Seq(
+          "con10.json"
+        )
+        for {
+          (segment, result) <- replace ++ noReplace.map(s => (s, s))
+        } yield {
+          EvaluatorPaths.sanitizePathSegment(segment).toString ==> result
+          (segment, result)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
In case a segment path matches one of the reserved name of the Windows filesystem namespace, we insert a `~` directly after the offending segment part.

Here is a excerpt from an official [Win32 documentation](https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file?redirectedfrom=MSDN#naming-conventions):

> * Do not use the following reserved names for the name of a file:
>
> CON, PRN, AUX, NUL, COM0, COM1, COM2, COM3, COM4, COM5, COM6, COM7, COM8, COM9, COM¹, COM², COM³, LPT0, LPT1, LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, LPT9, LPT¹, LPT², and LPT³. Also avoid these names followed immediately by an extension; for example, NUL.txt and NUL.tar.gz are both equivalent to NUL. For more information, see [Namespaces](https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file?redirectedfrom=MSDN#win32-file-namespaces).

We do the insertions on all platforms, not only Windows, for consistency of the `out/` folder.

Fix https://github.com/com-lihaoyi/mill/issues/2961