### PR TITLE
Fix outdated ArchLinux package URL

### DIFF
--- a/docs/modules/ROOT/pages/Installation_IDE_Support.adoc
+++ b/docs/modules/ROOT/pages/Installation_IDE_Support.adoc
@@ -94,7 +94,7 @@ brew install mill
 
 === Arch Linux
 
-Arch Linux has a https://www.archlinux.org/packages/community/any/mill/[Community package for mill]:
+Arch Linux has an https://archlinux.org/packages/extra/any/mill/[Extra package for mill]:
 
 [source,bash]
 ----


### PR DESCRIPTION
ArchLinux community repository has been merged into extra repository, according to https://archlinux.org/news/git-migration-announcement/. Current mill package URL doesn't work.