### PR TITLE
POC: Make BSP modular and support dynamic extensions

### DIFF
--- a/bsp/src/mill/bsp/BSP.scala
+++ b/bsp/src/mill/bsp/BSP.scala
@@ -19,7 +19,7 @@ object BSP extends ExternalModule with CoursierModule {
 
   lazy val millDiscover: Discover[this.type] = Discover[this.type]
 
-  private def bspModuleData: T[(Seq[String], Seq[Dep], Seq[String])] = T.input {
+  private def bspExtensions: T[(Seq[String], Seq[Dep])] = T.input {
     // As this is a runtime value which can change, we need to be in an input target
     val modules = JavaModuleUtils.transitiveModules(evaluator().rootModule)
       .collect { case m: BspModule => m }
@@ -28,9 +28,7 @@ object BSP extends ExternalModule with CoursierModule {
     T.log.debug(s"BSP extensions: ${BspUtil.pretty(extensions)}")
     val extensionIvyDeps = extensions.flatMap(_.ivyDeps)
 
-    val languages = modules.flatMap(m => m.bspBuildTarget.languageIds).distinct
-
-    (classes, extensionIvyDeps, languages)
+    (classes, extensionIvyDeps)
   }
 
   override def bindDependency: Task[Dep => BoundDep] = T.task { dep: Dep =>
@@ -41,7 +39,7 @@ object BSP extends ExternalModule with CoursierModule {
     millProjectModule(
       "mill-bsp-worker",
       repositoriesTask(),
-      extraDeps = bspModuleData()._2.map(bindDependency().andThen(_.dep))
+      extraDeps = bspExtensions()._2.map(bindDependency().andThen(_.dep))
     )
   }
 
@@ -63,13 +61,11 @@ object BSP extends ExternalModule with CoursierModule {
     // we create a file containing the additional jars to load
 //    val libUrls = bspWorkerLibs().map(_.path.toNIO.toUri).iterator.toSeq
 
-    val moduleData = bspModuleData()
-    val (classes, _, languages) = moduleData
+    val classes = bspExtensions()._1
 
     val bspServerConfig = BspServerConfig(
       classes,
-      bspWorkerLibs().toSeq,
-      languages
+      bspWorkerLibs().toSeq
     )
 
     val cpFile =

--- a/bsp/src/mill/bsp/BSP.scala
+++ b/bsp/src/mill/bsp/BSP.scala
@@ -6,8 +6,7 @@ import mill.define.{Command, Discover, ExternalModule, Task}
 import mill.main.BuildInfo
 import mill.eval.Evaluator
 import mill.util.Util.millProjectModule
-import mill.scalalib.{BoundDep, CoursierModule, Dep, Lib}
-import mill.scalalib.bsp.BspModule
+import mill.scalalib.{BoundDep, CoursierModule, Dep, JavaModule, Lib}
 import mill.scalalib.internal.JavaModuleUtils
 
 object BSP extends ExternalModule with CoursierModule {
@@ -22,7 +21,7 @@ object BSP extends ExternalModule with CoursierModule {
   private def bspExtensions: T[(Seq[String], Seq[Dep])] = T.input {
     // As this is a runtime value which can change, we need to be in an input target
     val modules = JavaModuleUtils.transitiveModules(evaluator().rootModule)
-      .collect { case m: BspModule => m }
+      .collect { case m: JavaModule => m }
     val extensions = modules.flatMap(m => m.bspExtensions).distinct
     val classes = extensions.map(_.className).distinct
     T.log.debug(s"BSP extensions: ${BspUtil.pretty(extensions)}")

--- a/bsp/src/mill/bsp/BspContext.scala
+++ b/bsp/src/mill/bsp/BspContext.scala
@@ -68,7 +68,8 @@ private[mill] class BspContext(
         streams,
         logStream.getOrElse(streams.err),
         home / Constants.bspDir,
-        canReload
+        canReload,
+        os.pwd
       )
     }
   }

--- a/bsp/src/mill/bsp/BspServerConfig.scala
+++ b/bsp/src/mill/bsp/BspServerConfig.scala
@@ -1,11 +1,11 @@
 package mill.bsp
 
-import mill.Agg
 import mill.api.PathRef
 
 case class BspServerConfig(
     services: Seq[String],
-    classpath: Seq[PathRef]
+    classpath: Seq[PathRef],
+    languages: Seq[String]
 )
 
 object BspServerConfig {

--- a/bsp/src/mill/bsp/BspServerConfig.scala
+++ b/bsp/src/mill/bsp/BspServerConfig.scala
@@ -1,0 +1,14 @@
+package mill.bsp
+
+import mill.Agg
+import mill.api.PathRef
+
+case class BspServerConfig(
+    services: Seq[String],
+    classpath: Seq[PathRef]
+)
+
+object BspServerConfig {
+  implicit val jsonify: upickle.default.ReadWriter[BspServerConfig] =
+    upickle.default.macroRW
+}

--- a/bsp/src/mill/bsp/BspServerConfig.scala
+++ b/bsp/src/mill/bsp/BspServerConfig.scala
@@ -4,8 +4,7 @@ import mill.api.PathRef
 
 case class BspServerConfig(
     services: Seq[String],
-    classpath: Seq[PathRef],
-    languages: Seq[String]
+    classpath: Seq[PathRef]
 )
 
 object BspServerConfig {

--- a/bsp/src/mill/bsp/BspServerConfig.scala
+++ b/bsp/src/mill/bsp/BspServerConfig.scala
@@ -3,7 +3,7 @@ package mill.bsp
 import mill.api.PathRef
 
 case class BspServerConfig(
-    services: Seq[String],
+    extensions: Seq[String],
     classpath: Seq[PathRef]
 )
 

--- a/bsp/src/mill/bsp/BspUtil.scala
+++ b/bsp/src/mill/bsp/BspUtil.scala
@@ -1,0 +1,7 @@
+package mill.bsp
+
+private[bsp] trait BspUtil {
+  def pretty = pprint.PPrinter(defaultHeight = 10000)
+}
+
+object BspUtil extends BspUtil

--- a/bsp/src/mill/bsp/BspWorker.scala
+++ b/bsp/src/mill/bsp/BspWorker.scala
@@ -4,14 +4,14 @@ import mill.api.{Ctx, Logger, SystemStreams}
 import os.Path
 
 import java.io.PrintStream
-import java.net.URL
 
 private trait BspWorker {
   def startBspServer(
       streams: SystemStreams,
       logStream: PrintStream,
       logDir: os.Path,
-      canReload: Boolean
+      canReload: Boolean,
+      projectDir: os.Path
   ): Either[String, BspServerHandle]
 }
 
@@ -19,43 +19,54 @@ private object BspWorker {
 
   private[this] var worker: Option[BspWorker] = None
 
+  def readConfig(workspace: os.Path): Either[String, BspServerConfig] = {
+    val configFile =
+      workspace / Constants.bspDir / s"${Constants.serverName}-${mill.main.BuildInfo.millVersion}.conf"
+    if (!os.exists(configFile)) return Left(
+      s"""Could not find config file: ${configFile}
+         |You need to run `mill mill.bsp.BSP/install` before you can use the BSP server""".stripMargin
+    )
+
+    val config = upickle.default.read[BspServerConfig](
+      os.read(configFile)
+    )
+
+    // TODO: if outdated, we could regenerate the resource file and re-load the worker
+    Right(config)
+  }
+
   def apply(
       workspace: os.Path,
       home0: os.Path,
-      log: Logger,
-      workerLibs: Option[Seq[URL]] = None
+      log: Logger
+//      workerLibs: Option[Seq[URL]] = None
   ): Either[String, BspWorker] = {
     worker match {
       case Some(x) => Right(x)
       case None =>
-        val urls = workerLibs.map { urls =>
-          log.debug("Using direct submitted worker libs")
-          urls
-        }.getOrElse {
-          // load extra classpath entries from file
-          val cpFile =
-            workspace / Constants.bspDir / s"${Constants.serverName}-${mill.main.BuildInfo.millVersion}.resources"
-          if (!os.exists(cpFile)) return Left(
-            "You need to run `mill mill.bsp.BSP/install` before you can use the BSP server"
+//        val urls = workerLibs.map { urls =>
+//          log.debug("Using direct submitted worker libs")
+//          urls
+//        }.getOrElse {
+        // load extra config from file
+        readConfig(workspace).map { config =>
+          log.debug(s"BSP Server config: ${BspUtil.pretty(config)}")
+
+          val urls = config.classpath.map(_.path.toNIO.toUri.toURL)
+
+          // create classloader with bsp.worker and deps
+          val cl = mill.api.ClassLoader.create(urls, getClass().getClassLoader())(
+            new Ctx.Home {
+              override def home: Path = home0
+            }
           )
 
-          // TODO: if outdated, we could regenerate the resource file and re-load the worker
-
-          // read the classpath from resource file
-          log.debug(s"Reading worker classpath from file: ${cpFile}")
-          os.read(cpFile).linesIterator.map(u => new URL(u)).toSeq
+          val workerCls = cl.loadClass(Constants.bspWorkerImplClass)
+          val ctr = workerCls.getConstructor()
+          val workerImpl = ctr.newInstance().asInstanceOf[BspWorker]
+          worker = Some(workerImpl)
+          workerImpl
         }
-
-        // create classloader with bsp.worker and deps
-        val cl = mill.api.ClassLoader.create(urls, getClass().getClassLoader())(
-          new Ctx.Home { override def home: Path = home0 }
-        )
-
-        val workerCls = cl.loadClass(Constants.bspWorkerImplClass)
-        val ctr = workerCls.getConstructor()
-        val workerImpl = ctr.newInstance().asInstanceOf[BspWorker]
-        worker = Some(workerImpl)
-        Right(workerImpl)
     }
   }
 

--- a/bsp/src/mill/bsp/spi/MillBuildServerBase.scala
+++ b/bsp/src/mill/bsp/spi/MillBuildServerBase.scala
@@ -1,9 +1,8 @@
-package mill.bsp.worker
+package mill.bsp.spi
 
-import ch.epfl.scala.bsp4j.BuildTargetIdentifier
 import mill.define.Task
 import mill.eval.Evaluator
-import mill.scalalib.bsp.BspModule
+import mill.scalalib.bsp.{BspModule, BspUri}
 
 import java.util.concurrent.CompletableFuture
 import scala.reflect.ClassTag
@@ -30,9 +29,9 @@ trait MillBuildServerBase {
 
   def completableTasks[T, V, W: ClassTag](
       hint: String,
-      targetIds: State => Seq[BuildTargetIdentifier],
+      targetIds: State => Seq[BspUri],
       tasks: BspModule => Task[W]
-  )(f: (Evaluator, State, BuildTargetIdentifier, BspModule, W) => T)(agg: java.util.List[T] => V)
+  )(f: (Evaluator, State, BspUri, BspModule, W) => T)(agg: java.util.List[T] => V)
       : CompletableFuture[V]
 
   /**

--- a/bsp/worker/src/mill/bsp/worker/BspWorkerImpl.scala
+++ b/bsp/worker/src/mill/bsp/worker/BspWorkerImpl.scala
@@ -55,7 +55,8 @@ private class BspWorkerImpl() extends BspWorker {
           serverVersion = BuildInfo.millVersion,
           serverName = Constants.serverName,
           logStream = logStream,
-          canReload = canReload
+          canReload = canReload,
+          languages = config.languages
         )
 
       val services = config.services.map(s => s -> loadService(s, Seq(millServer))).toSeq

--- a/bsp/worker/src/mill/bsp/worker/BspWorkerImpl.scala
+++ b/bsp/worker/src/mill/bsp/worker/BspWorkerImpl.scala
@@ -2,12 +2,15 @@ package mill.bsp.worker
 
 import ch.epfl.scala.bsp4j.BuildClient
 import mill.main.BuildInfo
-import mill.bsp.{BspServerHandle, BspServerResult, BspWorker, Constants}
+import mill.bsp.{BspServerHandle, BspServerResult, BspUtil, BspWorker, Constants}
 import mill.eval.Evaluator
 import mill.api.SystemStreams
+import mill.bsp.BspUtil.pretty
+import mill.util.EitherOps
 import org.eclipse.lsp4j.jsonrpc.Launcher
 
 import java.io.{PrintStream, PrintWriter}
+import java.lang.reflect.Constructor
 import java.util.concurrent.Executors
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, CancellationException, Promise}
@@ -15,98 +18,121 @@ import scala.jdk.CollectionConverters._
 
 private class BspWorkerImpl() extends BspWorker {
 
+  def loadService(className: String, services: Seq[AnyRef]): AnyRef = {
+    val cl = getClass().getClassLoader()
+    val serviceClass = cl.loadClass(className)
+    val ctrWithParams: Seq[Either[String, (Constructor[_], Seq[AnyRef])]] =
+      serviceClass.getConstructors().toSeq.map { ctr =>
+        val ctrParams: Seq[Either[String, AnyRef]] =
+          ctr.getParameterTypes().toSeq.map { paramType =>
+            services.find(s => paramType.isAssignableFrom(s.getClass())).toRight(
+              s"Could not inject constructor parameter of type `${paramType}`"
+            )
+          }
+        EitherOps.sequence(ctrParams).map(p => (ctr, p))
+      }
+    ctrWithParams.collectFirst {
+      case Right((ctr, params)) =>
+        ctr.newInstance(params: _*).asInstanceOf[AnyRef]
+    }.getOrElse(sys.error("Could not found acceptable contructor"))
+  }
+
   override def startBspServer(
       streams: SystemStreams,
       logStream: PrintStream,
       logDir: os.Path,
-      canReload: Boolean
+      canReload: Boolean,
+      projectDir: os.Path
   ): Either[String, BspServerHandle] = {
 
-    val millServer = new MillBuildServer(
-      bspVersion = Constants.bspProtocolVersion,
-      serverVersion = BuildInfo.millVersion,
-      serverName = Constants.serverName,
-      logStream = logStream,
-      canReload = canReload
-    )
+    logStream.println("Preparing BSP server start")
+    os.makeDir.all(projectDir / Constants.bspDir)
 
-    val jvmBuildServer = new MillJvmBuildServer(millServer)
-    val javaBuildServer = new MillJavaBuildServer(millServer)
-    val scalaBuildServer = new MillScalaBuildServer(millServer)
+    BspWorker.readConfig(projectDir).flatMap { config =>
+      val millServer =
+        new MillBuildServer(
+          bspVersion = Constants.bspProtocolVersion,
+          serverVersion = BuildInfo.millVersion,
+          serverName = Constants.serverName,
+          logStream = logStream,
+          canReload = canReload
+        )
 
-    val services: Seq[AnyRef] = Seq(millServer, jvmBuildServer, javaBuildServer, scalaBuildServer)
+      val services = config.services.map(s => s -> loadService(s, Seq(millServer))).toSeq
+      logStream.println(s"Loaded services: ${BspUtil.pretty(services)}")
 
-    val executor = Executors.newCachedThreadPool()
+      val executor = Executors.newCachedThreadPool()
 
-    var shutdownRequestedBeforeExit = false
+      var shutdownRequestedBeforeExit = false
 
-    try {
-      val launcher = new Launcher.Builder[BuildClient]()
-        .setOutput(streams.out)
-        .setInput(streams.in)
-        .setLocalServices(services.asJava)
-        .setRemoteInterface(classOf[BuildClient])
-        .traceMessages(new PrintWriter(
-          (logDir / s"${Constants.serverName}.trace").toIO
-        ))
-        .setExecutorService(executor)
-        .setClassLoader(getClass().getClassLoader())
-        .create()
+      try {
+        val launcher = new Launcher.Builder[BuildClient]()
+          .setOutput(streams.out)
+          .setInput(streams.in)
+          .setLocalServices(services.map(_._2).asJava)
+          .setRemoteInterface(classOf[BuildClient])
+          .traceMessages(new PrintWriter(
+            (logDir / s"${Constants.serverName}.trace").toIO
+          ))
+          .setExecutorService(executor)
+          .setClassLoader(getClass().getClassLoader())
+          .create()
 
-      millServer.onConnectWithClient(launcher.getRemoteProxy)
-      val listening = launcher.startListening()
-      millServer.cancellator = shutdownBefore => {
-        shutdownRequestedBeforeExit = shutdownBefore
-        listening.cancel(true)
-      }
-
-      val bspServerHandle = new BspServerHandle {
-        private[this] var lastResult0: Option[BspServerResult] = None
-
-        override def runSession(evaluators: Seq[Evaluator]): BspServerResult = {
-          lastResult0 = None
-          millServer.updateEvaluator(Option(evaluators))
-          val onReload = Promise[BspServerResult]()
-          millServer.onSessionEnd = Some { serverResult =>
-            if (!onReload.isCompleted) {
-              streams.err.println("Unsetting evaluator on session end")
-              millServer.updateEvaluator(None)
-              lastResult0 = Some(serverResult)
-              onReload.success(serverResult)
-            }
-          }
-          val res = Await.result(onReload.future, Duration.Inf)
-          streams.err.println(s"Reload finished, result: ${res}")
-          lastResult0 = Some(res)
-          res
-        }
-
-        override def lastResult: Option[BspServerResult] = lastResult0
-
-        override def stop(): Unit = {
-          streams.err.println("Stopping server via handle...")
+        millServer.onConnectWithClient(launcher.getRemoteProxy)
+        val listening = launcher.startListening()
+        millServer.cancellator = shutdownBefore => {
+          shutdownRequestedBeforeExit = shutdownBefore
           listening.cancel(true)
         }
+
+        val bspServerHandle = new BspServerHandle {
+          private[this] var lastResult0: Option[BspServerResult] = None
+
+          override def runSession(evaluators: Seq[Evaluator]): BspServerResult = {
+            lastResult0 = None
+            millServer.updateEvaluator(Option(evaluators))
+            val onReload = Promise[BspServerResult]()
+            millServer.onSessionEnd = Some { serverResult =>
+              if (!onReload.isCompleted) {
+                streams.err.println("Unsetting evaluator on session end")
+                millServer.updateEvaluator(None)
+                lastResult0 = Some(serverResult)
+                onReload.success(serverResult)
+              }
+            }
+            val res = Await.result(onReload.future, Duration.Inf)
+            streams.err.println(s"Reload finished, result: ${pretty(res)}")
+            lastResult0 = Some(res)
+            res
+          }
+
+          override def lastResult: Option[BspServerResult] = lastResult0
+
+          override def stop(): Unit = {
+            streams.err.println("Stopping server via handle...")
+            listening.cancel(true)
+          }
+        }
+
+        new Thread(() => {
+          listening.get()
+          streams.err.println("Shutting down executor")
+          executor.shutdown()
+        }).start()
+
+        Right(bspServerHandle)
+      } catch {
+        case _: CancellationException =>
+          Left("The mill server was shut down.")
+        case e: Exception =>
+          Left(
+            s"""An exception occurred while connecting to the client.
+               |Cause: ${e.getCause}
+               |Message: ${e.getMessage}
+               |Exception class: ${e.getClass}
+               |Stack Trace: ${e.getStackTrace.mkString("\n")}""".stripMargin
+          )
       }
-
-      new Thread(() => {
-        listening.get()
-        streams.err.println("Shutting down executor")
-        executor.shutdown()
-      }).start()
-
-      Right(bspServerHandle)
-    } catch {
-      case _: CancellationException =>
-        Left("The mill server was shut down.")
-      case e: Exception =>
-        Left(
-          s"""An exception occurred while connecting to the client.
-             |Cause: ${e.getCause}
-             |Message: ${e.getMessage}
-             |Exception class: ${e.getClass}
-             |Stack Trace: ${e.getStackTrace.mkString("\n")}""".stripMargin
-        )
     }
   }
 }

--- a/bsp/worker/src/mill/bsp/worker/BspWorkerImpl.scala
+++ b/bsp/worker/src/mill/bsp/worker/BspWorkerImpl.scala
@@ -59,7 +59,7 @@ private class BspWorkerImpl() extends BspWorker {
         )
 
       val extensions: Seq[(String, MillBspExtension)] =
-        config.services.map(s => s -> loadExtension(s, Seq(millServer)))
+        config.extensions.map(s => s -> loadExtension(s, Seq(millServer)))
 
       logStream.println(s"Loaded extensions: ${BspUtil.pretty(extensions)}")
 

--- a/bsp/worker/src/mill/bsp/worker/ExtensionCapabilities.scala
+++ b/bsp/worker/src/mill/bsp/worker/ExtensionCapabilities.scala
@@ -1,0 +1,11 @@
+package mill.bsp.worker
+
+class ExtensionCapabilities private (
+    val languages: Seq[String]
+)
+object ExtensionCapabilities {
+  def apply(languages: Seq[String]): ExtensionCapabilities =
+    new ExtensionCapabilities(
+      languages = languages
+    )
+}

--- a/bsp/worker/src/mill/bsp/worker/MillBspExtension.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBspExtension.scala
@@ -1,0 +1,5 @@
+package mill.bsp.worker
+
+trait MillBspExtension {
+  def extensionCapabilities: ExtensionCapabilities
+}

--- a/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -85,8 +85,7 @@ private class MillBuildServer(
     serverName: String,
     logStream: PrintStream,
     canReload: Boolean
-) extends ExternalModule
-    with BuildServer {
+) extends ExternalModule with BuildServer with MillBuildServerBase {
 
   lazy val millDiscover: Discover[this.type] = Discover[this.type]
 
@@ -95,7 +94,8 @@ private class MillBuildServer(
   protected var client: BuildClient = _
   private var initialized = false
   private var shutdownRequested = false
-  private[worker] var clientWantsSemanticDb = false
+  protected var clientWantsSemanticDb = false
+  def enableSemanticDb: Boolean = clientWantsSemanticDb
   protected var clientIsIntelliJ = false
 
   private[this] var statePromise: Promise[State] = Promise[State]()

--- a/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -75,6 +75,7 @@ import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}
 import Utils.sanitizeUri
 import mill.bsp.BspServerResult
+import mill.bsp.BspUtil.pretty
 import mill.eval.Evaluator.TaskResult
 
 import scala.util.chaining.scalaUtilChainingOps
@@ -116,7 +117,7 @@ private class MillBuildServer(
 
   override def buildInitialize(request: InitializeBuildParams)
       : CompletableFuture[InitializeBuildResult] =
-    completableNoState(s"buildInitialize ${request}", checkInitialized = false) {
+    completableNoState(s"buildInitialize ${pretty(request)}", checkInitialized = false) {
 
       // TODO: scan BspModules and infer their capabilities
 

--- a/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -78,6 +78,7 @@ import mill.bsp.BspServerResult
 import mill.eval.Evaluator.TaskResult
 
 import scala.util.chaining.scalaUtilChainingOps
+
 private class MillBuildServer(
     bspVersion: String,
     serverVersion: String,
@@ -94,7 +95,7 @@ private class MillBuildServer(
   protected var client: BuildClient = _
   private var initialized = false
   private var shutdownRequested = false
-  protected var clientWantsSemanticDb = false
+  private[worker] var clientWantsSemanticDb = false
   protected var clientIsIntelliJ = false
 
   private[this] var statePromise: Promise[State] = Promise[State]()

--- a/bsp/worker/src/mill/bsp/worker/MillBuildServerBase.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServerBase.scala
@@ -9,6 +9,11 @@ import java.util.concurrent.CompletableFuture
 import scala.reflect.ClassTag
 
 trait MillBuildServerBase {
+
+  /**
+   * Write a debug message to the log file.
+   * @param msg
+   */
   def debug(msg: String): Unit
 
   /**
@@ -30,5 +35,9 @@ trait MillBuildServerBase {
   )(f: (Evaluator, State, BuildTargetIdentifier, BspModule, W) => T)(agg: java.util.List[T] => V)
       : CompletableFuture[V]
 
+  /**
+   * `true` if semanticDb generation is enabled for this build.
+   * @return
+   */
   def enableSemanticDb: Boolean
 }

--- a/bsp/worker/src/mill/bsp/worker/MillBuildServerBase.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServerBase.scala
@@ -1,0 +1,34 @@
+package mill.bsp.worker
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier
+import mill.define.Task
+import mill.eval.Evaluator
+import mill.scalalib.bsp.BspModule
+
+import java.util.concurrent.CompletableFuture
+import scala.reflect.ClassTag
+
+trait MillBuildServerBase {
+  def debug(msg: String): Unit
+
+  /**
+   * Given a function that take input of type T and return output of type V,
+   * apply the function on the given inputs and return a completable future of
+   * the result. If the execution of the function raises an Exception, complete
+   * the future exceptionally. Also complete exceptionally if the server was not
+   * yet initialized.
+   */
+  protected def completable[V](
+      hint: String,
+      checkInitialized: Boolean = true
+  )(f: State => V): CompletableFuture[V]
+
+  def completableTasks[T, V, W: ClassTag](
+      hint: String,
+      targetIds: State => Seq[BuildTargetIdentifier],
+      tasks: BspModule => Task[W]
+  )(f: (Evaluator, State, BuildTargetIdentifier, BspModule, W) => T)(agg: java.util.List[T] => V)
+      : CompletableFuture[V]
+
+  def enableSemanticDb: Boolean
+}

--- a/bsp/worker/src/mill/bsp/worker/MillJavaBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillJavaBuildServer.scala
@@ -13,7 +13,7 @@ import mill.scalalib.{JavaModule, SemanticDbJavaModule}
 import java.util.concurrent.CompletableFuture
 import scala.jdk.CollectionConverters._
 
-private class MillJavaBuildServer(base: MillBuildServerBase) extends JavaBuildServer {
+class MillJavaBuildServer(base: MillBuildServerBase) extends JavaBuildServer {
 
   override def buildTargetJavacOptions(javacOptionsParams: JavacOptionsParams)
       : CompletableFuture[JavacOptionsResult] =

--- a/bsp/worker/src/mill/bsp/worker/MillJavaBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillJavaBuildServer.scala
@@ -13,16 +13,16 @@ import mill.scalalib.{JavaModule, SemanticDbJavaModule}
 import java.util.concurrent.CompletableFuture
 import scala.jdk.CollectionConverters._
 
-private trait MillJavaBuildServer extends JavaBuildServer { this: MillBuildServer =>
+private class MillJavaBuildServer(base: MillBuildServer) extends JavaBuildServer {
 
   override def buildTargetJavacOptions(javacOptionsParams: JavacOptionsParams)
       : CompletableFuture[JavacOptionsResult] =
-    completableTasks(
+    base.completableTasks(
       s"buildTargetJavacOptions ${javacOptionsParams}",
       targetIds = _ => javacOptionsParams.getTargets.asScala.toSeq,
       tasks = { case m: JavaModule =>
         val classesPathTask = m match {
-          case sem: SemanticDbJavaModule if clientWantsSemanticDb =>
+          case sem: SemanticDbJavaModule if base.clientWantsSemanticDb =>
             sem.bspCompiledClassesAndSemanticDbFiles
           case _ => m.bspCompileClassesPath
         }

--- a/bsp/worker/src/mill/bsp/worker/MillJavaBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillJavaBuildServer.scala
@@ -13,7 +13,7 @@ import mill.scalalib.{JavaModule, SemanticDbJavaModule}
 import java.util.concurrent.CompletableFuture
 import scala.jdk.CollectionConverters._
 
-private class MillJavaBuildServer(base: MillBuildServer) extends JavaBuildServer {
+private class MillJavaBuildServer(base: MillBuildServerBase) extends JavaBuildServer {
 
   override def buildTargetJavacOptions(javacOptionsParams: JavacOptionsParams)
       : CompletableFuture[JavacOptionsResult] =
@@ -22,7 +22,7 @@ private class MillJavaBuildServer(base: MillBuildServer) extends JavaBuildServer
       targetIds = _ => javacOptionsParams.getTargets.asScala.toSeq,
       tasks = { case m: JavaModule =>
         val classesPathTask = m match {
-          case sem: SemanticDbJavaModule if base.clientWantsSemanticDb =>
+          case sem: SemanticDbJavaModule if base.enableSemanticDb =>
             sem.bspCompiledClassesAndSemanticDbFiles
           case _ => m.bspCompileClassesPath
         }

--- a/bsp/worker/src/mill/bsp/worker/MillJavaBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillJavaBuildServer.scala
@@ -13,7 +13,13 @@ import mill.scalalib.{JavaModule, SemanticDbJavaModule}
 import java.util.concurrent.CompletableFuture
 import scala.jdk.CollectionConverters._
 
-class MillJavaBuildServer(base: MillBuildServerBase) extends JavaBuildServer {
+class MillJavaBuildServer(base: MillBuildServerBase)
+    extends MillBspExtension
+    with JavaBuildServer {
+
+  override def extensionCapabilities: ExtensionCapabilities = ExtensionCapabilities(
+    languages = Seq("java")
+  )
 
   override def buildTargetJavacOptions(javacOptionsParams: JavacOptionsParams)
       : CompletableFuture[JavacOptionsResult] =
@@ -44,4 +50,5 @@ class MillJavaBuildServer(base: MillBuildServerBase) extends JavaBuildServer {
     } {
       new JavacOptionsResult(_)
     }
+
 }

--- a/bsp/worker/src/mill/bsp/worker/MillJvmBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillJvmBuildServer.scala
@@ -17,7 +17,7 @@ import mill.scalalib.JavaModule
 import java.util.concurrent.CompletableFuture
 import scala.jdk.CollectionConverters._
 
-private class MillJvmBuildServer(base: MillBuildServerBase) extends JvmBuildServer {
+class MillJvmBuildServer(base: MillBuildServerBase) extends JvmBuildServer {
 
   override def buildTargetJvmRunEnvironment(params: JvmRunEnvironmentParams)
       : CompletableFuture[JvmRunEnvironmentResult] = {

--- a/bsp/worker/src/mill/bsp/worker/MillJvmBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillJvmBuildServer.scala
@@ -17,7 +17,13 @@ import mill.scalalib.JavaModule
 import java.util.concurrent.CompletableFuture
 import scala.jdk.CollectionConverters._
 
-class MillJvmBuildServer(base: MillBuildServerBase) extends JvmBuildServer {
+class MillJvmBuildServer(base: MillBuildServerBase)
+    extends MillBspExtension
+    with JvmBuildServer {
+
+  override def extensionCapabilities: ExtensionCapabilities = ExtensionCapabilities(
+    languages = Seq()
+  )
 
   override def buildTargetJvmRunEnvironment(params: JvmRunEnvironmentParams)
       : CompletableFuture[JvmRunEnvironmentResult] = {

--- a/bsp/worker/src/mill/bsp/worker/MillJvmBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillJvmBuildServer.scala
@@ -41,9 +41,9 @@ class MillJvmBuildServer(base: MillBuildServerBase) extends JvmBuildServer {
       name: String,
       targetIds: Seq[BuildTargetIdentifier],
       agg: java.util.List[JvmEnvironmentItem] => V
-  ) = {
+  ): CompletableFuture[V] = {
     base.completableTasks(
-      name,
+      hint = name,
       targetIds = _ => targetIds,
       tasks = {
         case m: JavaModule =>

--- a/bsp/worker/src/mill/bsp/worker/MillJvmBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillJvmBuildServer.scala
@@ -17,7 +17,7 @@ import mill.scalalib.JavaModule
 import java.util.concurrent.CompletableFuture
 import scala.jdk.CollectionConverters._
 
-private class MillJvmBuildServer(base: MillBuildServer) extends JvmBuildServer {
+private class MillJvmBuildServer(base: MillBuildServerBase) extends JvmBuildServer {
 
   override def buildTargetJvmRunEnvironment(params: JvmRunEnvironmentParams)
       : CompletableFuture[JvmRunEnvironmentResult] = {

--- a/bsp/worker/src/mill/bsp/worker/MillJvmBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillJvmBuildServer.scala
@@ -17,7 +17,7 @@ import mill.scalalib.JavaModule
 import java.util.concurrent.CompletableFuture
 import scala.jdk.CollectionConverters._
 
-private trait MillJvmBuildServer extends JvmBuildServer { this: MillBuildServer =>
+private class MillJvmBuildServer(base: MillBuildServer) extends JvmBuildServer {
 
   override def buildTargetJvmRunEnvironment(params: JvmRunEnvironmentParams)
       : CompletableFuture[JvmRunEnvironmentResult] = {
@@ -42,7 +42,7 @@ private trait MillJvmBuildServer extends JvmBuildServer { this: MillBuildServer 
       targetIds: Seq[BuildTargetIdentifier],
       agg: java.util.List[JvmEnvironmentItem] => V
   ) = {
-    completableTasks(
+    base.completableTasks(
       name,
       targetIds = _ => targetIds,
       tasks = {

--- a/bsp/worker/src/mill/bsp/worker/MillJvmBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillJvmBuildServer.scala
@@ -11,8 +11,9 @@ import ch.epfl.scala.bsp4j.{
   JvmTestEnvironmentResult
 }
 import mill.T
-import mill.bsp.worker.Utils.sanitizeUri
+import mill.bsp.spi.MillBuildServerBase
 import mill.scalalib.JavaModule
+import mill.scalalib.bsp.BspUri
 
 import java.util.concurrent.CompletableFuture
 import scala.jdk.CollectionConverters._
@@ -50,7 +51,7 @@ class MillJvmBuildServer(base: MillBuildServerBase)
   ): CompletableFuture[V] = {
     base.completableTasks(
       hint = name,
-      targetIds = _ => targetIds,
+      targetIds = _ => targetIds.map(_.bspUri),
       tasks = {
         case m: JavaModule =>
           T.task {
@@ -74,9 +75,9 @@ class MillJvmBuildServer(base: MillBuildServerBase)
             m: JavaModule,
             (runClasspath, forkArgs, forkWorkingDir, forkEnv, mainClass, zincWorker, compile)
           ) =>
-        val classpath = runClasspath.map(_.path).map(sanitizeUri)
+        val classpath = runClasspath.map(_.path).map(BspUri.sanitizeUri)
         val item = new JvmEnvironmentItem(
-          id,
+          id.buildTargetIdentifier,
           classpath.iterator.toSeq.asJava,
           forkArgs.asJava,
           forkWorkingDir.toString(),

--- a/bsp/worker/src/mill/bsp/worker/MillScalaBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillScalaBuildServer.scala
@@ -24,7 +24,13 @@ import java.util.concurrent.CompletableFuture
 import scala.jdk.CollectionConverters._
 import scala.util.chaining.scalaUtilChainingOps
 
-class MillScalaBuildServer(base: MillBuildServerBase) extends ScalaBuildServer {
+class MillScalaBuildServer(base: MillBuildServerBase)
+    extends MillBspExtension
+    with ScalaBuildServer {
+
+  override def extensionCapabilities: ExtensionCapabilities = ExtensionCapabilities(
+    languages = Seq("scala")
+  )
 
   override def buildTargetScalacOptions(p: ScalacOptionsParams)
       : CompletableFuture[ScalacOptionsResult] =

--- a/bsp/worker/src/mill/bsp/worker/MillScalaBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillScalaBuildServer.scala
@@ -24,17 +24,17 @@ import java.util.concurrent.CompletableFuture
 import scala.jdk.CollectionConverters._
 import scala.util.chaining.scalaUtilChainingOps
 
-private trait MillScalaBuildServer extends ScalaBuildServer { this: MillBuildServer =>
+private class MillScalaBuildServer(base: MillBuildServer) extends ScalaBuildServer {
 
   override def buildTargetScalacOptions(p: ScalacOptionsParams)
       : CompletableFuture[ScalacOptionsResult] =
-    completableTasks(
+    base.completableTasks(
       hint = s"buildTargetScalacOptions ${p}",
       targetIds = _ => p.getTargets.asScala.toSeq,
       tasks = {
         case m: ScalaModule =>
           val classesPathTask = m match {
-            case sem: SemanticDbJavaModule if clientWantsSemanticDb =>
+            case sem: SemanticDbJavaModule if base.clientWantsSemanticDb =>
               sem.bspCompiledClassesAndSemanticDbFiles
             case _ => m.bspCompileClassesPath
           }
@@ -43,7 +43,7 @@ private trait MillScalaBuildServer extends ScalaBuildServer { this: MillBuildSer
 
         case m: JavaModule =>
           val classesPathTask = m match {
-            case sem: SemanticDbJavaModule if clientWantsSemanticDb =>
+            case sem: SemanticDbJavaModule if base.clientWantsSemanticDb =>
               sem.bspCompiledClassesAndSemanticDbFiles
             case _ => m.bspCompileClassesPath
           }
@@ -73,7 +73,7 @@ private trait MillScalaBuildServer extends ScalaBuildServer { this: MillBuildSer
 
   override def buildTargetScalaMainClasses(p: ScalaMainClassesParams)
       : CompletableFuture[ScalaMainClassesResult] =
-    completableTasks(
+    base.completableTasks(
       hint = "buildTargetScalaMainClasses",
       targetIds = _ => p.getTargets.asScala.toSeq,
       tasks = { case m: JavaModule =>
@@ -99,7 +99,7 @@ private trait MillScalaBuildServer extends ScalaBuildServer { this: MillBuildSer
 
   override def buildTargetScalaTestClasses(p: ScalaTestClassesParams)
       : CompletableFuture[ScalaTestClassesResult] =
-    completableTasks(
+    base.completableTasks(
       s"buildTargetScalaTestClasses ${p}",
       targetIds = _ => p.getTargets.asScala.toSeq,
       tasks = {

--- a/bsp/worker/src/mill/bsp/worker/MillScalaBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillScalaBuildServer.scala
@@ -24,7 +24,7 @@ import java.util.concurrent.CompletableFuture
 import scala.jdk.CollectionConverters._
 import scala.util.chaining.scalaUtilChainingOps
 
-private class MillScalaBuildServer(base: MillBuildServer) extends ScalaBuildServer {
+private class MillScalaBuildServer(base: MillBuildServerBase) extends ScalaBuildServer {
 
   override def buildTargetScalacOptions(p: ScalacOptionsParams)
       : CompletableFuture[ScalacOptionsResult] =
@@ -34,7 +34,7 @@ private class MillScalaBuildServer(base: MillBuildServer) extends ScalaBuildServ
       tasks = {
         case m: ScalaModule =>
           val classesPathTask = m match {
-            case sem: SemanticDbJavaModule if base.clientWantsSemanticDb =>
+            case sem: SemanticDbJavaModule if base.enableSemanticDb =>
               sem.bspCompiledClassesAndSemanticDbFiles
             case _ => m.bspCompileClassesPath
           }
@@ -43,7 +43,7 @@ private class MillScalaBuildServer(base: MillBuildServer) extends ScalaBuildServ
 
         case m: JavaModule =>
           val classesPathTask = m match {
-            case sem: SemanticDbJavaModule if base.clientWantsSemanticDb =>
+            case sem: SemanticDbJavaModule if base.enableSemanticDb =>
               sem.bspCompiledClassesAndSemanticDbFiles
             case _ => m.bspCompileClassesPath
           }

--- a/bsp/worker/src/mill/bsp/worker/MillScalaBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillScalaBuildServer.scala
@@ -24,7 +24,7 @@ import java.util.concurrent.CompletableFuture
 import scala.jdk.CollectionConverters._
 import scala.util.chaining.scalaUtilChainingOps
 
-private class MillScalaBuildServer(base: MillBuildServerBase) extends ScalaBuildServer {
+class MillScalaBuildServer(base: MillBuildServerBase) extends ScalaBuildServer {
 
   override def buildTargetScalacOptions(p: ScalacOptionsParams)
       : CompletableFuture[ScalacOptionsResult] =

--- a/bsp/worker/src/mill/bsp/worker/package.scala
+++ b/bsp/worker/src/mill/bsp/worker/package.scala
@@ -1,0 +1,16 @@
+package mill.bsp
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier
+import mill.scalalib.bsp.BspUri
+
+package object worker {
+
+  implicit class BspUriSupport(bspUri: BspUri) {
+    def buildTargetIdentifier: BuildTargetIdentifier = new BuildTargetIdentifier(bspUri.uri)
+  }
+
+  implicit class BuildTargetIdentifierSupport(id: BuildTargetIdentifier) {
+    def bspUri: BspUri = BspUri(id.getUri())
+  }
+
+}

--- a/integration/feature/bsp-install/test/src/BspInstallDebugTests.scala
+++ b/integration/feature/bsp-install/test/src/BspInstallDebugTests.scala
@@ -18,7 +18,7 @@ object BspInstallDebugTests extends IntegrationTestSuite {
       val contents = os.read(jsonFile)
       assert(
         contents.contains("--debug"),
-        contents.contains(s""""bspVersion":"${bsp4jVersion}"""")
+        contents.contains(s""""bspVersion": "${bsp4jVersion}"""")
       )
     }
   }

--- a/integration/feature/bsp-install/test/src/BspInstallTests.scala
+++ b/integration/feature/bsp-install/test/src/BspInstallTests.scala
@@ -15,7 +15,7 @@ object BspInstallTests extends IntegrationTestSuite {
       val contents = os.read(jsonFile)
       assert(
         !contents.contains("--debug"),
-        contents.contains(s""""bspVersion":"${bsp4jVersion}"""")
+        contents.contains(s""""bspVersion": "${bsp4jVersion}"""")
       )
     }
   }

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -9,11 +9,11 @@ import coursier.parse.ModuleParser
 import coursier.util.ModuleMatcher
 import mainargs.Flag
 import mill.Agg
-import mill.api.{Ctx, JarManifest, MillException, PathRef, Result, internal}
+import mill.api.{Ctx, JarManifest, MillException, PathRef, Result, experimental, internal}
 import mill.define.{Command, ModuleRef, Segment, Task, TaskModule}
 import mill.scalalib.internal.ModuleUtils
 import mill.scalalib.api.CompilationResult
-import mill.scalalib.bsp.{BspBuildTarget, BspModule, BspUri, JvmBuildTarget}
+import mill.scalalib.bsp.{BspBuildTarget, BspExtension, BspModule, BspUri, JvmBuildTarget}
 import mill.scalalib.publish.Artifact
 import mill.util.Jvm
 import os.{Path, ProcessOutput}
@@ -1017,6 +1017,13 @@ trait JavaModule
       ()
     }
   }
+
+  @internal
+  @experimental
+  override def bspExtensions: Seq[BspExtension] = super.bspExtensions ++ Seq(
+    BspExtension("mill.bsp.worker.MillJvmBuildServer", Seq()),
+    BspExtension("mill.bsp.worker.MillJavaBuildServer", Seq())
+  )
 
   @internal
   override def bspBuildTarget: BspBuildTarget = super.bspBuildTarget.copy(

--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -1,7 +1,15 @@
 package mill
 package scalalib
 
-import mill.api.{DummyInputStream, JarManifest, PathRef, Result, SystemStreams, internal}
+import mill.api.{
+  DummyInputStream,
+  JarManifest,
+  PathRef,
+  Result,
+  SystemStreams,
+  experimental,
+  internal
+}
 import mill.main.BuildInfo
 import mill.util.{Jvm, Util}
 import mill.util.Jvm.createJar
@@ -10,6 +18,7 @@ import mill.scalalib.api.{CompilationResult, Versions, ZincWorkerUtil}
 import mainargs.Flag
 import mill.scalalib.bsp.{
   BspBuildTarget,
+  BspExtension,
   BspModule,
   BspUri,
   JvmBuildTarget,
@@ -585,6 +594,12 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
   override def manifest: T[JarManifest] = T {
     super.manifest().add("Scala-Version" -> scalaVersion())
   }
+
+  @internal
+  @experimental
+  override def bspExtensions: Seq[BspExtension] = super.bspExtensions ++ Seq(
+    BspExtension("mill.bsp.worker.MillScalaBuildServer", Seq())
+  )
 
   @internal
   override def bspBuildTarget: BspBuildTarget = super.bspBuildTarget.copy(

--- a/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
+++ b/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
@@ -125,7 +125,7 @@ trait SemanticDbJavaModule extends CoursierModule {
   }
 
   // keep in sync with bspCompiledClassesAndSemanticDbFiles
-  def compiledClassesAndSemanticDbFiles: Target[PathRef] = T {
+  def compiledClassesAndSemanticDbFiles: T[PathRef] = T {
     val dest = T.dest
     val classes = compile().classes.path
     val sems = semanticDbData().path
@@ -135,7 +135,7 @@ trait SemanticDbJavaModule extends CoursierModule {
   }
 
   // keep in sync with compiledClassesAndSemanticDbFiles
-  def bspCompiledClassesAndSemanticDbFiles: Target[UnresolvedPath] = {
+  def bspCompiledClassesAndSemanticDbFiles: T[UnresolvedPath] = {
     if (
       compiledClassesAndSemanticDbFiles.ctx.enclosing == s"${classOf[SemanticDbJavaModule].getName}#compiledClassesAndSemanticDbFiles"
     ) {

--- a/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
+++ b/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
@@ -1,7 +1,7 @@
 package mill.scalalib
 
 import mill.api.{PathRef, Result, experimental}
-import mill.define.{ModuleRef, Target}
+import mill.define.ModuleRef
 import mill.main.BuildInfo
 import mill.scalalib.api.{CompilationResult, Versions, ZincWorkerUtil}
 import mill.scalalib.bsp.BspBuildTarget

--- a/scalalib/src/mill/scalalib/bsp/BspExtension.scala
+++ b/scalalib/src/mill/scalalib/bsp/BspExtension.scala
@@ -1,0 +1,13 @@
+package mill.scalalib.bsp
+
+import mill.Agg
+import mill.scalalib.Dep
+
+/** A BSP Extension to be loaded by the Mill BSP server.
+ * @param className The extension class to be loaded.
+ * @param ivyDeps Additional dependencies to be loaded into the BSP server classpath.
+ */
+case class BspExtension(
+    className: String,
+    ivyDeps: Agg[Dep]
+)

--- a/scalalib/src/mill/scalalib/bsp/BspExtension.scala
+++ b/scalalib/src/mill/scalalib/bsp/BspExtension.scala
@@ -3,7 +3,8 @@ package mill.scalalib.bsp
 import mill.Agg
 import mill.scalalib.Dep
 
-/** A BSP Extension to be loaded by the Mill BSP server.
+/**
+ * A BSP Extension to be loaded by the Mill BSP server.
  * @param className The extension class to be loaded.
  * @param ivyDeps Additional dependencies to be loaded into the BSP server classpath.
  */

--- a/scalalib/src/mill/scalalib/bsp/BspModule.scala
+++ b/scalalib/src/mill/scalalib/bsp/BspModule.scala
@@ -1,6 +1,6 @@
 package mill.scalalib.bsp
 
-import mill.api.internal
+import mill.api.{experimental, internal}
 import mill.define.Task
 import mill.scalalib.internal.ModuleUtils
 import mill._
@@ -38,6 +38,13 @@ trait BspModule extends Module {
   @internal
   def bspBuildTargetData: Task[Option[(String, AnyRef)]] = T.task { None }
 
+  /**
+   * Extensions to load when BSP is used.
+   */
+  @internal
+  @experimental
+  def bspExtensions: Seq[BspExtension] = Seq()
+
 }
 
 object BspModule {
@@ -58,4 +65,5 @@ object BspModule {
     val NoIDE = "no-ide"
     val Manual = "manual"
   }
+
 }

--- a/scalalib/src/mill/scalalib/bsp/BspUri.scala
+++ b/scalalib/src/mill/scalalib/bsp/BspUri.scala
@@ -1,7 +1,16 @@
 package mill.scalalib.bsp
 
-case class BspUri(uri: String)
+import mill.api.PathRef
+
+case class BspUri private (uri: String)
 
 object BspUri {
-  def apply(path: os.Path): BspUri = BspUri(path.toNIO.toUri.toString)
+  def apply(uri: String): BspUri = new BspUri(sanitizeUri(uri))
+  def apply(path: os.Path): BspUri = apply(path.toNIO.toUri.toString)
+  def apply(uri: PathRef): BspUri = apply(uri.path)
+
+  def sanitizeUri(uri: String): String =
+    if (uri.endsWith("/")) sanitizeUri(uri.substring(0, uri.length - 1)) else uri
+  def sanitizeUri(path: os.Path): String = sanitizeUri(path.toNIO.toUri.toString)
+  def sanitizeUri(uri: PathRef): String = sanitizeUri(uri.path)
 }


### PR DESCRIPTION
Introduce a `BspExtension` trait, which holds a class name and it's potential ivy dependencies.

Split up the various BSP server extensions and instantiate them independently. They are now concrete classes with either a default contructor or one accepting the new `MillBuildServerBase` parameter.

The `BspModule` now has a new `bspExtensions` method, which declares what BSP extension should be used to support the module. The extension is loaded via reflection. `JavaModule` and `ScalaModule` now explicitly declare their extensions. That means, if no `ScalaModule` is part of the project, we also should not load the extension.

* Fix https://github.com/com-lihaoyi/mill/issues/2598

