### PR TITLE
Update bsp4j from 2.1.0-M7 to 2.1.0

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -175,7 +175,7 @@ object Deps {
   val windowsAnsi = ivy"io.github.alexarchambault.windows-ansi:windows-ansi:0.0.5"
   val zinc = ivy"org.scala-sbt::zinc:1.9.6"
   // keep in sync with doc/antora/antory.yml
-  val bsp4j = ivy"ch.epfl.scala:bsp4j:2.1.0-M7"
+  val bsp4j = ivy"ch.epfl.scala:bsp4j:2.1.0"
   val fansi = ivy"com.lihaoyi::fansi:0.4.0"
   val jarjarabrams = ivy"com.eed3si9n.jarjarabrams::jarjar-abrams-core:1.9.0"
   val requests = ivy"com.lihaoyi::requests:0.8.0"


### PR DESCRIPTION
Should contain no new changes, but finally a stable version.