### PR TITLE
Add `publishLocalCached` and `publishM2LocalCached` targets

### DIFF
--- a/scalalib/src/mill/scalalib/publish/LocalIvyPublisher.scala
+++ b/scalalib/src/mill/scalalib/publish/LocalIvyPublisher.scala
@@ -4,6 +4,7 @@ import mill.api.Ctx
 
 class LocalIvyPublisher(localIvyRepo: os.Path) {
 
+  @deprecated("Use publishLocal instead", "Mill 0.11.7")
   def publish(
       jar: os.Path,
       sourcesJar: os.Path,
@@ -12,29 +13,38 @@ class LocalIvyPublisher(localIvyRepo: os.Path) {
       ivy: os.Path,
       artifact: Artifact,
       extras: Seq[PublishInfo]
-  )(implicit ctx: Ctx.Log): Unit = {
+  )(implicit ctx: Ctx.Log): Unit = publishLocal(jar, sourcesJar, docJar, pom, ivy, artifact, extras)
+
+  def publishLocal(
+      jar: os.Path,
+      sourcesJar: os.Path,
+      docJar: os.Path,
+      pom: os.Path,
+      ivy: os.Path,
+      artifact: Artifact,
+      extras: Seq[PublishInfo]
+  )(implicit ctx: Ctx.Log): Seq[os.Path] = {
 
     ctx.log.info(s"Publishing ${artifact} to ivy repo ${localIvyRepo}")
     val releaseDir = localIvyRepo / artifact.group / artifact.id / artifact.version
-    writeFiles(
+
+    val toCopy: Seq[(os.Path, os.Path)] = Seq(
       jar -> releaseDir / "jars" / s"${artifact.id}.jar",
       sourcesJar -> releaseDir / "srcs" / s"${artifact.id}-sources.jar",
       docJar -> releaseDir / "docs" / s"${artifact.id}-javadoc.jar",
       pom -> releaseDir / "poms" / s"${artifact.id}.pom",
       ivy -> releaseDir / "ivys" / "ivy.xml"
-    )
-    writeFiles(extras.map { entry =>
+    ) ++ extras.map { entry =>
       (
         entry.file.path,
         releaseDir / s"${entry.ivyType}s" / s"${artifact.id}${entry.classifierPart}.${entry.ext}"
       )
-    }: _*)
-  }
+    }
 
-  private def writeFiles(fromTo: (os.Path, os.Path)*): Unit = {
-    fromTo.foreach {
+    toCopy.map {
       case (from, to) =>
         os.copy.over(from, to, createFolders = true)
+        to
     }
   }
 

--- a/scalalib/src/mill/scalalib/publish/LocalM2Publisher.scala
+++ b/scalalib/src/mill/scalalib/publish/LocalM2Publisher.scala
@@ -15,7 +15,7 @@ class LocalM2Publisher(m2Repo: os.Path) {
 
     val releaseDir = m2Repo / artifact.group.split("[.]") / artifact.id / artifact.version
     ctx.log.info(s"Publish ${artifact.id}-${artifact.version} to ${releaseDir}")
-    os.makeDir.all(releaseDir)
+
     val toCopy: Seq[(os.Path, os.Path)] = Seq(
       jar -> releaseDir / s"${artifact.id}-${artifact.version}.jar",
       sourcesJar -> releaseDir / s"${artifact.id}-${artifact.version}-sources.jar",
@@ -26,7 +26,7 @@ class LocalM2Publisher(m2Repo: os.Path) {
     }
     toCopy.map {
       case (from, to) =>
-        os.copy.over(from, to)
+        os.copy.over(from, to, createFolders = true)
         to
     }
   }


### PR DESCRIPTION
The new targets are cached and invalidate properly when the target files (which are outside of Mills cache folder) are changed or removed from the repository cache, as the `PathRef.revalidate` flag is used and enforced by Mill.

Fix https://github.com/com-lihaoyi/mill/issues/2975

Pull request: https://github.com/com-lihaoyi/mill/pull/2976