### PR TITLE
BSP: Send `logMessage` instead of diagnostics when `textDocument` is unknown

### DIFF
--- a/bsp/worker/src/mill/bsp/worker/BspCompileProblemReporter.scala
+++ b/bsp/worker/src/mill/bsp/worker/BspCompileProblemReporter.scala
@@ -98,6 +98,8 @@ private class BspCompileProblemReporter(
       pos.endColumn.orElse(pos.pointer).getOrElse[Int](start.getCharacter.intValue())
     )
     new bsp.Diagnostic(new bsp.Range(start, end), problem.message).tap { d =>
+      // TODO: review whether this is a proper source or if it should better
+      // something like "scala compiler" or "foo.bar.compile"
       d.setSource("mill")
       d.setSeverity(
         problem.severity match {


### PR DESCRIPTION
Since some compiler messages do not belong to a single source file, they are not actionable (in the sense of a BSP `build/publishDiagnostics`). In such situation (no text document), we send `build/logMessage` instead.

Fix https://github.com/com-lihaoyi/mill/issues/2926