### PR TITLE
Synchronize evaluateGroupCached to avoid concurrent access to cache

### DIFF
--- a/main/eval/src/mill/eval/GroupEvaluator.scala
+++ b/main/eval/src/mill/eval/GroupEvaluator.scala
@@ -41,6 +41,13 @@ private[mill] trait GroupEvaluator {
   val effectiveThreadCount: Int =
     this.threadCount.getOrElse(Runtime.getRuntime().availableProcessors())
 
+  /**
+   * Synchronize evaluations of the same terminal task. This won't necessary for normal Mill execution,
+   * but in an BSP context, where multiple requests where handled concurrently in the same Mill instance,
+   * it can happen.
+   * Note, that we don't synchronize multiple Mill-instances (e.g. run in two shells)
+   * or multiple evaluator-instances (which should have different out-dirs anyhow.
+   */
   private object synchronizedEval {
     private val keyLock = new KeyLock[Segments]()
     def apply[T](terminal: Terminal, onCollision: Option[() => Unit] = None)(f: => T): T =

--- a/main/eval/src/mill/eval/GroupEvaluator.scala
+++ b/main/eval/src/mill/eval/GroupEvaluator.scala
@@ -42,11 +42,13 @@ private[mill] trait GroupEvaluator {
     this.threadCount.getOrElse(Runtime.getRuntime().availableProcessors())
 
   /**
-   * Synchronize evaluations of the same terminal task. This won't necessary for normal Mill execution,
+   * Synchronize evaluations of the same terminal task.
+   * This isn't necessarily needed for normal Mill executions,
    * but in an BSP context, where multiple requests where handled concurrently in the same Mill instance,
-   * it can happen.
-   * Note, that we don't synchronize multiple Mill-instances (e.g. run in two shells)
-   * or multiple evaluator-instances (which should have different out-dirs anyhow.
+   * evaluating the same task concurrently  can happen.
+   *
+   * We don't synchronize multiple Mill-instances (e.g. run in two shells)
+   * or multiple evaluator-instances (which should have different `out`-dirs anyway.
    */
   private object synchronizedEval {
     private val keyLock = new KeyLock[Segments]()

--- a/main/eval/src/mill/eval/KeyLock.scala
+++ b/main/eval/src/mill/eval/KeyLock.scala
@@ -1,0 +1,21 @@
+package mill.eval
+
+private class KeyLock[K]() {
+  private[this] val lockKeys = new java.util.HashSet[K]()
+
+  def lock(key: K): AutoCloseable = {
+    lockKeys.synchronized {
+      while (!lockKeys.add(key)) {
+        lockKeys.wait();
+      }
+    }
+    () => unlock(key)
+  }
+
+  private def unlock(key: K): Unit = {
+    lockKeys.synchronized {
+      lockKeys.remove(key)
+      lockKeys.notifyAll()
+    }
+  }
+}

--- a/main/eval/src/mill/eval/KeyLock.scala
+++ b/main/eval/src/mill/eval/KeyLock.scala
@@ -3,7 +3,7 @@ package mill.eval
 private class KeyLock[K]() {
   private[this] val lockKeys = new java.util.HashSet[K]()
 
-  def lock(key: K,  onCollision: Option[() => Unit] = None): AutoCloseable = {
+  def lock(key: K, onCollision: Option[() => Unit] = None): AutoCloseable = {
     lockKeys.synchronized {
       var shown = false
       while (!lockKeys.add(key)) {

--- a/main/eval/src/mill/eval/KeyLock.scala
+++ b/main/eval/src/mill/eval/KeyLock.scala
@@ -3,9 +3,14 @@ package mill.eval
 private class KeyLock[K]() {
   private[this] val lockKeys = new java.util.HashSet[K]()
 
-  def lock(key: K): AutoCloseable = {
+  def lock(key: K,  onCollision: Option[() => Unit] = None): AutoCloseable = {
     lockKeys.synchronized {
+      var shown = false
       while (!lockKeys.add(key)) {
+        if (!shown) {
+          onCollision.foreach(_())
+          shown = true
+        }
         lockKeys.wait();
       }
     }


### PR DESCRIPTION
With this change, we synchronize evaluations of the same terminal task. This isn't necessarily needed for normal Mill executions, but in a BSP context, where multiple requests where handled concurrently in the same Mill instance, evaluating the same task concurrently  can happen.

We don't synchronize multiple Mill-instances (e.g. run in two shells) or multiple evaluator-instances (which should have different `out`-dirs anyway).

Fix: https://github.com/com-lihaoyi/mill/issues/2818

Pull request: https://github.com/com-lihaoyi/mill/pull/2980