### PR TITLE
Detect colliding cross module values

### DIFF
--- a/integration/failure/cross-collisions/repo/build.sc
+++ b/integration/failure/cross-collisions/repo/build.sc
@@ -1,0 +1,7 @@
+import mill._
+
+object foo extends Cross[Foo](
+      (Seq("a", "b"), Seq("c")),
+      (Seq("a"), Seq("b", "c"))
+    )
+trait Foo extends Cross.Module2[Seq[String], Seq[String]]

--- a/integration/failure/cross-collisions/test/src/CrossCollisionsTests.scala
+++ b/integration/failure/cross-collisions/test/src/CrossCollisionsTests.scala
@@ -1,0 +1,19 @@
+package mill.integration
+
+import utest._
+
+object CrossCollisionsTests extends IntegrationTestSuite {
+  val tests = Tests {
+    val workspaceRoot = initWorkspace()
+
+    test("detect-collision") {
+      val res = evalStdout("resolve", "foo._")
+      assert(!res.isSuccess)
+      assert(
+        res.err.contains(
+          "Cross module millbuild.build#foo contains colliding cross values: List(List(a, b), List(c)) and List(List(a), List(b, c))"
+        )
+      )
+    }
+  }
+}

--- a/integration/failure/cross-collisions/test/src/CrossCollisionsTests.scala
+++ b/integration/failure/cross-collisions/test/src/CrossCollisionsTests.scala
@@ -3,8 +3,8 @@ package mill.integration
 import utest._
 
 object CrossCollisionsTests extends IntegrationTestSuite {
-  val tests = Tests {
-    val workspaceRoot = initWorkspace()
+  val tests: Tests = Tests {
+    initWorkspace()
 
     test("detect-collision") {
       val res = evalStdout("resolve", "foo._")

--- a/main/api/src/mill/api/MillException.scala
+++ b/main/api/src/mill/api/MillException.scala
@@ -6,5 +6,9 @@ package mill.api
  */
 class MillException(msg: String) extends Exception(msg)
 
-class BuildScriptException(msg: String)
-    extends MillException("Build script contains errors:\n" + msg)
+class BuildScriptException(msg: String, script: Option[String])
+    extends MillException(
+      script.map(_ + ": ").getOrElse("") + "Build script contains errors:\n" + msg
+    ) {
+  def this(msg: String) = this(msg, None)
+}

--- a/main/define/src/mill/define/Cross.scala
+++ b/main/define/src/mill/define/Cross.scala
@@ -1,6 +1,6 @@
 package mill.define
 
-import mill.api.{BuildScriptException, Lazy, MillException}
+import mill.api.{BuildScriptException, Lazy}
 
 import language.experimental.macros
 import scala.collection.mutable

--- a/main/define/src/mill/define/Cross.scala
+++ b/main/define/src/mill/define/Cross.scala
@@ -112,6 +112,7 @@ object Cross {
     implicit object ShortToPathSegment extends ToSegments[Short](v => List(v.toString))
     implicit object ByteToPathSegment extends ToSegments[Byte](v => List(v.toString))
     implicit object BooleanToPathSegment extends ToSegments[Boolean](v => List(v.toString))
+    implicit object SubPathToPathSegment extends ToSegments[os.SubPath](v => v.segments.toList)
     implicit def SeqToPathSegment[T: ToSegments]: ToSegments[Seq[T]] = new ToSegments[Seq[T]](
       _.flatMap(implicitly[ToSegments[T]].convert).toList
     )


### PR DESCRIPTION
Also add an implicit `ToSegements[os.SubPath]` to accept `os.SubPath` as values in cross modules.

Fix https://github.com/com-lihaoyi/mill/issues/2835