### PR TITLE
Bump MainArgs to 0.6.1

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -1176,7 +1176,6 @@ def launcherScript(
 ) = {
 
   val millMainClass = "mill.main.client.MillClientMain"
-  val millClientMainClass = "mill.main.client.MillClientMain"
 
   Jvm.universalScript(
     shellCommands = {
@@ -1230,20 +1229,18 @@ def launcherScript(
          |    fi
          |    ${java(millMainClass, true)}
          |else
-         |    if [ "$${1:0:1}" = "-i" ] ; then
+         |    if [ "$${1%"-i"*}" != "$$1" ] ; then
          |        init_mill_jvm_opts
-         |        ${java(millMainClass, true)}
          |    else
          |        case "$$1" in
          |          -i | --interactive | --repl | --no-server | --bsp )
          |            init_mill_jvm_opts
-         |            ${java(millMainClass, true)}
          |            ;;
          |          *)
-         |            ${java(millClientMainClass, false)}
          |            ;;
          |        esac
          |    fi
+         |    ${java(millMainClass, true)}
          |fi
          |""".stripMargin
     },
@@ -1276,10 +1273,9 @@ def launcherScript(
          |      if "!line:~0,2!"=="-X" set "mill_jvm_opts=!mill_jvm_opts! !line!"
          |    )
          |  )
-         |  ${java(millMainClass, true)}
-         |) else (
-         |  ${java(millClientMainClass, false)}
          |)
+         |
+         |${java(millMainClass, true)}
          |endlocal
          |""".stripMargin
     }

--- a/build.sc
+++ b/build.sc
@@ -1229,18 +1229,20 @@ def launcherScript(
          |    fi
          |    ${java(millMainClass, true)}
          |else
-         |    if [ "$${1%"-i"*}" != "$$1" ] ; then
+         |    if [ "$${1%"-i"*}" != "$$1" ] ; then # first arg starts with "-i"
          |        init_mill_jvm_opts
+         |        ${java(millMainClass, true)}
          |    else
          |        case "$$1" in
          |          -i | --interactive | --repl | --no-server | --bsp )
          |            init_mill_jvm_opts
+         |            ${java(millMainClass, true)}
          |            ;;
          |          *)
+         |            ${java(millMainClass, false)}
          |            ;;
          |        esac
          |    fi
-         |    ${java(millMainClass, true)}
          |fi
          |""".stripMargin
     },
@@ -1273,9 +1275,10 @@ def launcherScript(
          |      if "!line:~0,2!"=="-X" set "mill_jvm_opts=!mill_jvm_opts! !line!"
          |    )
          |  )
+         |  ${java(millMainClass, true)}
+         |) else (
+         |  ${java(millMainClass, false)}
          |)
-         |
-         |${java(millMainClass, true)}
          |endlocal
          |""".stripMargin
     }

--- a/build.sc
+++ b/build.sc
@@ -1230,15 +1230,20 @@ def launcherScript(
          |    fi
          |    ${java(millMainClass, true)}
          |else
-         |    case "$$1" in
-         |      -i | --interactive | --repl | --no-server | --bsp )
+         |    if [ "$${1:0:1}" = "-i" ] ; then
          |        init_mill_jvm_opts
          |        ${java(millMainClass, true)}
-         |        ;;
-         |      *)
-         |        ${java(millClientMainClass, false)}
-         |        ;;
-         |esac
+         |    else
+         |        case "$$1" in
+         |          -i | --interactive | --repl | --no-server | --bsp )
+         |            init_mill_jvm_opts
+         |            ${java(millMainClass, true)}
+         |            ;;
+         |          *)
+         |            ${java(millClientMainClass, false)}
+         |            ;;
+         |        esac
+         |    fi
          |fi
          |""".stripMargin
     },

--- a/build.sc
+++ b/build.sc
@@ -139,7 +139,7 @@ object Deps {
   val log4j2Core = ivy"org.apache.logging.log4j:log4j-core:2.22.0"
   val osLib = ivy"com.lihaoyi::os-lib:0.9.2"
   val pprint = ivy"com.lihaoyi::pprint:0.8.1"
-  val mainargs = ivy"com.lihaoyi::mainargs:0.6.0"
+  val mainargs = ivy"com.lihaoyi::mainargs:0.6.1"
   val millModuledefsVersion = "0.10.9"
   val millModuledefsString = s"com.lihaoyi::mill-moduledefs:${millModuledefsVersion}"
   val millModuledefs = ivy"${millModuledefsString}"

--- a/build.sc
+++ b/build.sc
@@ -139,7 +139,7 @@ object Deps {
   val log4j2Core = ivy"org.apache.logging.log4j:log4j-core:2.22.0"
   val osLib = ivy"com.lihaoyi::os-lib:0.9.2"
   val pprint = ivy"com.lihaoyi::pprint:0.8.1"
-  val mainargs = ivy"com.lihaoyi::mainargs:0.5.4"
+  val mainargs = ivy"com.lihaoyi::mainargs:0.6.0"
   val millModuledefsVersion = "0.10.9"
   val millModuledefsString = s"com.lihaoyi::mill-moduledefs:${millModuledefsVersion}"
   val millModuledefs = ivy"${millModuledefsString}"

--- a/integration/feature/docannotations/test/src/DocAnnotationsTests.scala
+++ b/integration/feature/docannotations/test/src/DocAnnotationsTests.scala
@@ -90,7 +90,7 @@ object DocAnnotationsTests extends IntegrationTestSuite {
 
       assert(
         globMatches(
-          """core.ivyDepsTree(JavaModule.scala:760)
+          """core.ivyDepsTree(JavaModule.scala:...)
             |    Command to print the transitive dependency tree to STDOUT.
             |
             |    --inverse                Invert the tree representation, so that the root is on the bottom val

--- a/integration/feature/docannotations/test/src/DocAnnotationsTests.scala
+++ b/integration/feature/docannotations/test/src/DocAnnotationsTests.scala
@@ -87,19 +87,20 @@ object DocAnnotationsTests extends IntegrationTestSuite {
       assert(eval("inspect", "core.ivyDepsTree"))
 
       val ivyDepsTree = ujson.read(meta("inspect"))("value").str
+
       assert(
         globMatches(
-          """core.ivyDepsTree(JavaModule.scala:...)
+          """core.ivyDepsTree(JavaModule.scala:760)
             |    Command to print the transitive dependency tree to STDOUT.
             |
-            |    --inverse              Invert the tree representation, so that the root is on the bottom val
-            |                           inverse (will be forced when used with whatDependsOn)
-            |    --whatDependsOn <str>  Possible list of modules (org:artifact) to target in the tree in order to
-            |                           see where a dependency stems from.
-            |    --withCompile          Include the compile-time only dependencies (`compileIvyDeps`, provided
-            |                           scope) into the tree.
-            |    --withRuntime          Include the runtime dependencies (`runIvyDeps`, runtime scope) into the
-            |                           tree.
+            |    --inverse                Invert the tree representation, so that the root is on the bottom val
+            |                             inverse (will be forced when used with whatDependsOn)
+            |    --what-depends-on <str>  Possible list of modules (org:artifact) to target in the tree in order
+            |                             to see where a dependency stems from.
+            |    --with-compile           Include the compile-time only dependencies (`compileIvyDeps`, provided
+            |                             scope) into the tree.
+            |    --with-runtime           Include the runtime dependencies (`runIvyDeps`, runtime scope) into the
+            |                             tree.
             |
             |Inputs:
             |    core.transitiveIvyDeps
@@ -107,6 +108,11 @@ object DocAnnotationsTests extends IntegrationTestSuite {
           ivyDepsTree
         )
       )
+
+      // Make sure both kebab-case and camelCase flags work, even though the
+      // docs from `inspect` only show the kebab-case version
+      assert(eval("core.ivyDepsTree", "--withCompile", "--withRuntime"))
+      assert(eval("core.ivyDepsTree", "--with-compile", "--with-runtime"))
     }
   }
 }

--- a/main/client/src/mill/main/client/MillClientMain.java
+++ b/main/client/src/mill/main/client/MillClientMain.java
@@ -61,8 +61,8 @@ public class MillClientMain {
         if (args.length > 0) {
             String firstArg = args[0];
             runIsolated =
-                Arrays.asList("-i", "--interactive", "--no-server", "--repl", "--bsp", "--help")
-                    .contains(firstArg);
+                Arrays.asList("--interactive", "--no-server", "--repl", "--bsp", "--help")
+                    .contains(firstArg) || firstArg.startsWith("-i");
         }
         if (!runIsolated) {
             // WSL2 has the directory /run/WSL/ and WSL1 not.

--- a/main/resolve/src/mill/resolve/Resolve.scala
+++ b/main/resolve/src/mill/resolve/Resolve.scala
@@ -146,7 +146,8 @@ object Resolve {
       flattenedArgSigsWithDefaults,
       allowPositional = true,
       allowRepeats = false,
-      allowLeftover = ep.argSigs0.exists(_.reader.isLeftover)
+      allowLeftover = ep.argSigs0.exists(_.reader.isLeftover),
+      nameMapper = mainargs.Util.kebabCaseNameMapper
     ).flatMap { (grouped: TokenGrouping[_]) =>
       val mainData = ep.asInstanceOf[MainData[Any, Any]]
       val mainDataWithDefaults = mainData

--- a/main/resolve/src/mill/resolve/Resolve.scala
+++ b/main/resolve/src/mill/resolve/Resolve.scala
@@ -148,7 +148,7 @@ object Resolve {
       allowRepeats = false,
       allowLeftover = ep.argSigs0.exists(_.reader.isLeftover)
     ).flatMap { (grouped: TokenGrouping[_]) =>
-      val mainData = ep.asInstanceOf[MainData[_, Any]]
+      val mainData = ep.asInstanceOf[MainData[Any, Any]]
       val mainDataWithDefaults = mainData
         .copy(argSigs0 = mainData.argSigs0.map(withNullDefault))
 

--- a/main/resolve/src/mill/resolve/Resolve.scala
+++ b/main/resolve/src/mill/resolve/Resolve.scala
@@ -170,7 +170,8 @@ object Resolve {
             docsOnNewLine = false,
             customName = None,
             customDoc = None,
-            sorted = true
+            sorted = true,
+            nameMapper = mainargs.Util.nullNameMapper
           )
         )
     }

--- a/main/test/src/mill/main/MainModuleTests.scala
+++ b/main/test/src/mill/main/MainModuleTests.scala
@@ -169,6 +169,11 @@ object MainModuleTests extends TestSuite {
           evaluator.evalTokens("show", "helloCommand", "-x", "1337", "-y", "lol")
 
         assert(res == ujson.Arr(1337, "lol", ujson.Arr("hello", "world")))
+
+        val Right((Seq(res2), _)) =
+          evaluator.evalTokens("show", "hello-command", "-x", "1337", "-y", "lol")
+
+        assert(res2 == ujson.Arr(1337, "lol", ujson.Arr("hello", "world")))
       }
     }
 

--- a/main/test/src/mill/main/MainModuleTests.scala
+++ b/main/test/src/mill/main/MainModuleTests.scala
@@ -161,7 +161,7 @@ object MainModuleTests extends TestSuite {
       test("command") {
         val Left(Result.Failure(failureMsg, _)) = evaluator.evalTokens("show", "helloCommand")
         assert(
-          failureMsg.contains("Expected Signature: hello-command"),
+          failureMsg.contains("Expected Signature: helloCommand"),
           failureMsg.contains("-x <int>"),
           failureMsg.contains("-y <str>")
         )
@@ -169,11 +169,6 @@ object MainModuleTests extends TestSuite {
           evaluator.evalTokens("show", "helloCommand", "-x", "1337", "-y", "lol")
 
         assert(res == ujson.Arr(1337, "lol", ujson.Arr("hello", "world")))
-
-        val Right((Seq(res2), _)) =
-          evaluator.evalTokens("show", "hello-command", "-x", "1337", "-y", "lol")
-
-        assert(res2 == ujson.Arr(1337, "lol", ujson.Arr("hello", "world")))
       }
     }
 

--- a/main/test/src/mill/main/MainModuleTests.scala
+++ b/main/test/src/mill/main/MainModuleTests.scala
@@ -161,7 +161,7 @@ object MainModuleTests extends TestSuite {
       test("command") {
         val Left(Result.Failure(failureMsg, _)) = evaluator.evalTokens("show", "helloCommand")
         assert(
-          failureMsg.contains("Expected Signature: helloCommand"),
+          failureMsg.contains("Expected Signature: hello-command"),
           failureMsg.contains("-x <int>"),
           failureMsg.contains("-y <str>")
         )

--- a/mill
+++ b/mill
@@ -53,7 +53,7 @@ if [ -z "$MILL_MAIN_CLI" ] ; then
 fi
 
 MILL_FIRST_ARG=""
-if [ "$1" = "--bsp" ] || [ "$1" = "-i" ] || [ "$1" = "--interactive" ] || [ "$1" = "--no-server" ] || [ "$1" = "--repl" ] || [ "$1" = "--help" ] ; then
+if [ "$1" = "--bsp" ] || [ "${1:0:1}" = "-i" ] || [ "$1" = "--interactive" ] || [ "$1" = "--no-server" ] || [ "$1" = "--repl" ] || [ "$1" = "--help" ] ; then
   # Need to preserve the first position of those listed options
   MILL_FIRST_ARG=$1
   shift

--- a/mill
+++ b/mill
@@ -53,7 +53,7 @@ if [ -z "$MILL_MAIN_CLI" ] ; then
 fi
 
 MILL_FIRST_ARG=""
-if [ "$1" = "--bsp" ] || [ "${1:0:1}" = "-i" ] || [ "$1" = "--interactive" ] || [ "$1" = "--no-server" ] || [ "$1" = "--repl" ] || [ "$1" = "--help" ] ; then
+if [ "$1" = "--bsp" ] || [ "${1%"$-i"*}" != "$1" ] || [ "$1" = "--interactive" ] || [ "$1" = "--no-server" ] || [ "$1" = "--repl" ] || [ "$1" = "--help" ] ; then
   # Need to preserve the first position of those listed options
   MILL_FIRST_ARG=$1
   shift

--- a/mill
+++ b/mill
@@ -53,7 +53,9 @@ if [ -z "$MILL_MAIN_CLI" ] ; then
 fi
 
 MILL_FIRST_ARG=""
-if [ "$1" = "--bsp" ] || [ "${1%"$-i"*}" != "$1" ] || [ "$1" = "--interactive" ] || [ "$1" = "--no-server" ] || [ "$1" = "--repl" ] || [ "$1" = "--help" ] ; then
+
+ # first arg is a long flag for "--interactive" or starts with "-i"
+if [ "$1" = "--bsp" ] || [ "${1%"-i"*}" != "$1" ] || [ "$1" = "--interactive" ] || [ "$1" = "--no-server" ] || [ "$1" = "--repl" ] || [ "$1" = "--help" ] ; then
   # Need to preserve the first position of those listed options
   MILL_FIRST_ARG=$1
   shift

--- a/runner/src/mill/runner/MillCliConfig.scala
+++ b/runner/src/mill/runner/MillCliConfig.scala
@@ -19,7 +19,6 @@ class MillCliConfig private (
     )
     val repl: Flag,
     @arg(
-      name = "no-server",
       doc = """Run Mill in single-process mode.
                In this mode, no Mill server will be started or used.
                Must be the first argument."""
@@ -36,13 +35,11 @@ class MillCliConfig private (
     )
     val ringBell: Flag,
     @arg(
-      name = "disable-ticker",
       doc =
         """Disable ticker log (e.g. short-lived prints of stages and progress bars)."""
     )
     val disableTicker: Flag,
     @arg(
-      name = "enable-ticker",
       doc =
         """Enable ticker log (e.g. short-lived prints of stages and progress bars)."""
     )
@@ -51,7 +48,6 @@ class MillCliConfig private (
     @arg(name = "debug", short = 'd', doc = "Show debug output on STDOUT")
     val debugLog: Flag,
     @arg(
-      name = "keep-going",
       short = 'k',
       doc = """Continue build, even after build failures."""
     )
@@ -112,7 +108,6 @@ class MillCliConfig private (
     )
     val color: Option[Boolean],
     @arg(
-      name = "disable-callgraph-invalidation",
       doc =
         """Disable the fine-grained callgraph-based target invalidation in response to
            code changes, and instead fall back to the previous coarse-grained implementation
@@ -120,7 +115,6 @@ class MillCliConfig private (
     )
     val disableCallgraphInvalidation: Flag,
     @arg(
-      name = "meta-level",
       doc =
         """Experimental: Select a meta-build level to run the given targets.
            Level 0 is the normal project, level 1 the first meta-build, and so on.


### PR DESCRIPTION
Also updated the bash launchers' special casing of `-i` to allow for it to be part of a combined token, as long as the combined token starts with `-i`


With the `installLocalCache`ed version of Mill, I can now run:


```bash
$ ./mill -ikw contrib.__.compile
```

and the flags `-i`, `-k`, and `-w` will all take effect independently

The auto-kebab-case name mapping applies to Mill's own CLI args, the args of user-defined `T.command`s, but _not_ the names of the target/command themselves. e.g. you can call;

- `./mill --noServer core.ivyDepsTree --withCompile --withRuntime` or
- `./mill --no-server core.ivyDepsTree --with-compile --with-runtime`

but you cannot call 
- `./mill --no-server core.ivy-deps-tree --with-compile --with-runtime`

It should be easy to add name-mapping for the target selector as well, or I could also disable the name-mapping for user-define command arguments if we decide that's not the right thing to do. I'm not sure TBH what the right thing to do here is; bash naming conventions is fundamentally incompatible with Scala naming conventions, so regardless what Mill decides there will be some inconsistencies between:

- Bash naming conventions
- Mill's own CLI flag naming conventions
- Mill CLI task naming conventions
- Mill CLI command argument naming conventions
- Mill Scala object/method naming conventions
- Mill Scala method argument naming conventions
- Scala object/method naming conventions
- Scala method argument naming conventions

I guess it just depend where we want to draw the line and tolerate the inconsistency. I feel like maybe something like `./mill --no-server core.ivy-deps-tree --with-compile --with-runtime` would be the ideal outcome, where everything in Bash-land is consistent and everything in Scala-land is consistent.

Pull request: https://github.com/com-lihaoyi/mill/pull/2990