### PR TITLE
Print `done` message from test framework to stdout

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -397,6 +397,7 @@ trait MillBaseTestsModule extends MillJavaModule with TestModule {
       s"-DTEST_SCALANATIVE_VERSION=${Deps.Scalanative_0_4.scalanativeVersion}",
       s"-DTEST_UTEST_VERSION=${Deps.utest.dep.version}",
       s"-DTEST_SCALATEST_VERSION=${Deps.TestDeps.scalaTest.dep.version}",
+      s"-DTEST_TEST_INTERFACE_VERSION=${Deps.sbtTestInterface.dep.version}",
       s"-DTEST_ZIOTEST_VERSION=${Deps.TestDeps.zioTest.dep.version}",
       s"-DTEST_ZINC_VERSION=${Deps.zinc.dep.version}"
     )

--- a/scalalib/test/resources/testrunner/doneMessageFailure/src/DoneMessageFailureFramework.scala
+++ b/scalalib/test/resources/testrunner/doneMessageFailure/src/DoneMessageFailureFramework.scala
@@ -1,0 +1,42 @@
+package mill.scalalib
+
+import sbt.testing._
+
+class DoneMessageFailureFramework extends Framework {
+  def fingerprints() = Array.empty
+  def name() = "DoneMessageFailureFramework"
+  def runner(
+      args: Array[String],
+      remoteArgs: Array[String],
+      testClassLoader: ClassLoader
+  ): Runner = new Runner {
+    def args() = Array.empty
+    def done() = "test failure done message"
+    def remoteArgs() = Array.empty
+    def tasks(taskDefs: Array[TaskDef]) = Array(new Task {
+      def taskDef(): TaskDef = null
+      def execute(
+          eventHandler: EventHandler,
+          loggers: Array[Logger]
+      ): Array[Task] = {
+        eventHandler.handle(new Event {
+
+          override def fullyQualifiedName(): String = "foo.bar"
+
+          override def fingerprint(): Fingerprint = new Fingerprint {}
+
+          override def selector(): Selector = new TestSelector("foo.bar")
+
+          override def status(): Status = Status.Failure
+
+          override def throwable(): OptionalThrowable = new OptionalThrowable()
+
+          override def duration(): Long = 0L
+
+        })
+        Array.empty
+      }
+      def tags = Array.empty
+    })
+  }
+}

--- a/scalalib/test/resources/testrunner/doneMessageNull/src/DoneMessageNullFramework.scala
+++ b/scalalib/test/resources/testrunner/doneMessageNull/src/DoneMessageNullFramework.scala
@@ -1,0 +1,18 @@
+package mill.scalalib
+
+import sbt.testing._
+
+class DoneMessageNullFramework extends Framework {
+  def fingerprints() = Array.empty
+  def name() = "DoneMessageNullFramework"
+  def runner(
+      args: Array[String],
+      remoteArgs: Array[String],
+      testClassLoader: ClassLoader
+  ): Runner = new Runner {
+    def args() = Array.empty
+    def done() = null
+    def remoteArgs() = Array.empty
+    def tasks(taskDefs: Array[TaskDef]) = Array.empty
+  }
+}

--- a/scalalib/test/resources/testrunner/doneMessageSuccess/src/DoneMessageSuccessFramework.scala
+++ b/scalalib/test/resources/testrunner/doneMessageSuccess/src/DoneMessageSuccessFramework.scala
@@ -1,0 +1,18 @@
+package mill.scalalib
+
+import sbt.testing._
+
+class DoneMessageSuccessFramework extends Framework {
+  def fingerprints() = Array.empty
+  def name() = "DoneMessageSuccessFramework"
+  def runner(
+      args: Array[String],
+      remoteArgs: Array[String],
+      testClassLoader: ClassLoader
+  ): Runner = new Runner {
+    def args() = Array.empty
+    def done() = "test success done message"
+    def remoteArgs() = Array.empty
+    def tasks(taskDefs: Array[TaskDef]) = Array.empty
+  }
+}

--- a/scalalib/test/src/mill/scalalib/TestRunnerTests.scala
+++ b/scalalib/test/src/mill/scalalib/TestRunnerTests.scala
@@ -44,6 +44,9 @@ object TestRunnerTests extends TestSuite {
     object doneMessageFailure extends DoneMessage {
       def testFramework = "mill.scalalib.DoneMessageFailureFramework"
     }
+    object doneMessageNull extends DoneMessage {
+      def testFramework = "mill.scalalib.DoneMessageNullFramework"
+    }
 
     object ziotest extends ScalaTests with TestModule.ZioTest {
       override def ivyDeps = T {
@@ -121,6 +124,11 @@ object TestRunnerTests extends TestSuite {
             val Right(_) = eval(testrunner.doneMessageSuccess.test())
             val stdout = new String(outStream.toByteArray)
             assert(stdout.contains("test success done message"))
+          }
+        }
+        test("null") {
+          workspaceTest(testrunner) { eval =>
+            val Right(_) = eval(testrunner.doneMessageNull.test())
           }
         }
       }

--- a/testrunner/src/mill/testrunner/TestRunnerUtils.scala
+++ b/testrunner/src/mill/testrunner/TestRunnerUtils.scala
@@ -156,7 +156,7 @@ import scala.jdk.CollectionConverters.IteratorHasAsScala
       runner.done()
     }
 
-    if (doneMessage.nonEmpty) {
+    if (doneMessage != null && doneMessage.nonEmpty) {
       if (doneMessage.endsWith("\n"))
         ctx.log.outputStream.print(doneMessage)
       else

--- a/testrunner/src/mill/testrunner/TestRunnerUtils.scala
+++ b/testrunner/src/mill/testrunner/TestRunnerUtils.scala
@@ -156,6 +156,8 @@ import scala.jdk.CollectionConverters.IteratorHasAsScala
       runner.done()
     }
 
+    ctx.log.outputStream.println(doneMessage)
+
     val results = for (e <- events.iterator().asScala) yield {
       val ex =
         if (e.throwable().isDefined) Some(e.throwable().get) else None

--- a/testrunner/src/mill/testrunner/TestRunnerUtils.scala
+++ b/testrunner/src/mill/testrunner/TestRunnerUtils.scala
@@ -156,7 +156,12 @@ import scala.jdk.CollectionConverters.IteratorHasAsScala
       runner.done()
     }
 
-    ctx.log.outputStream.println(doneMessage)
+    if (doneMessage.nonEmpty) {
+      if (doneMessage.endsWith("\n"))
+        ctx.log.outputStream.print(doneMessage)
+      else
+        ctx.log.outputStream.println(doneMessage)
+    }
 
     val results = for (e <- events.iterator().asScala) yield {
       val ex =


### PR DESCRIPTION
Fixes #2992 

We are returning the doneMessage from the test framework as value of the test task, but we are not printing it. Moreover, the output is shortcircuited when a task fails, so it's not passed to the `test` command.
This PR uses `ctx.log.outputStream.println(doneMessage)` to print the message before returning it so users can clearly see it in case of both success and failure.
This was discovered because of the way weaver works on Scala.js Since the `TestRunnerTests` are on `scalalib` and can't use Scala.js code, I implemented some dummy `sbt.testing.Framework`s which just return a fixed `done` message.

Pull Request: https://github.com/com-lihaoyi/mill/pull/2993