### PR TITLE
Added support for `type` attribute when parsing dependencies

### DIFF
--- a/scalalib/src/mill/scalalib/Dep.scala
+++ b/scalalib/src/mill/scalalib/Dep.scala
@@ -108,6 +108,7 @@ object Dep {
     val attributes = parts.tail.foldLeft(coursier.Attributes()) { (as, s) =>
       s.split('=') match {
         case Array("classifier", v) => as.withClassifier(coursier.Classifier(v))
+        case Array("type", v) => as.withType(coursier.Type(v))
         case Array(k, v) => throw new Exception(s"Unrecognized attribute: [$s]")
         case _ => throw new Exception(s"Unable to parse attribute specifier: [$s]")
       }


### PR DESCRIPTION
This ensures, that we can populate the `type` attribute to be used by coursier.
I have not checked whether this is self-complete to work with other dependency type.
Maybe, we need some follow up PRs to refine it.
