### PR TITLE
Support type selectors in Resolve

### DIFF
--- a/main/resolve/src/mill/resolve/ParseArgs.scala
+++ b/main/resolve/src/mill/resolve/ParseArgs.scala
@@ -93,9 +93,10 @@ object ParseArgs {
     }
 
   private def selector[_p: P]: P[(Option[Segments], Segments)] = {
-    def ident2 = P(CharsWhileIn("a-zA-Z0-9_\\-.")).!
-    def segment = P(mill.define.Reflect.ident).map(Segment.Label)
-    def crossSegment = P("[" ~ ident2.rep(1, sep = ",") ~ "]").map(Segment.Cross)
+    def identLabel = P(CharsWhileIn("a-zA-Z0-9_\\-:$")).!
+    def identCross = P(CharsWhileIn("a-zA-Z0-9_\\-.")).!
+    def segment = P(identLabel).map(Segment.Label)
+    def crossSegment = P("[" ~ identCross.rep(1, sep = ",") ~ "]").map(Segment.Cross)
     def defaultCrossSegment = P("[]").map(_ => Segment.Cross(Seq()))
     def simpleQuery = P(segment ~ ("." ~ segment | crossSegment | defaultCrossSegment).rep).map {
       case (h, rest) => Segments(h +: rest)

--- a/main/resolve/src/mill/resolve/ParseArgs.scala
+++ b/main/resolve/src/mill/resolve/ParseArgs.scala
@@ -93,8 +93,10 @@ object ParseArgs {
     }
 
   private def selector[_p: P]: P[(Option[Segments], Segments)] = {
-    def typeLabel = P(("!" | "") ~~ CharsWhileIn("a-zA-Z0-9_\\-$")).!
-    def typePattern = P(("__" | "_") ~~ (":" ~~ typeLabel).rep).!
+    def typeLabel = P("!".? ~~ CharsWhileIn("a-zA-Z0-9_\\-$")).!
+    def typeLabelWithDots = P("!".? ~~ CharsWhileIn("a-zA-Z0-9_\\-$.")).!
+    def parenTypeLabel = P("(" ~~ typeLabelWithDots ~~ ")")
+    def typePattern = P("_".rep(min = 1, max = 2) ~~ (":" ~~ (parenTypeLabel | typeLabel)).rep(1)).!
     def identCross = P(CharsWhileIn("a-zA-Z0-9_\\-.")).!
     def segment = P(typePattern | mill.define.Reflect.ident).map(Segment.Label)
     def crossSegment = P("[" ~ identCross.rep(1, sep = ",") ~ "]").map(Segment.Cross)

--- a/main/resolve/src/mill/resolve/ParseArgs.scala
+++ b/main/resolve/src/mill/resolve/ParseArgs.scala
@@ -98,7 +98,7 @@ object ParseArgs {
 
     def typeQualifier(simple: Boolean) = {
       val maxSegments = if (simple) 0 else Int.MaxValue
-      P(("!"|"^").? ~~ label ~~ ("." ~~ label).rep(max = maxSegments)).!
+      P(("!" | "^").? ~~ label ~~ ("." ~~ label).rep(max = maxSegments)).!
     }
 
     def typePattern(simple: Boolean) = P(wildcard ~~ (":" ~~ typeQualifier(simple)).rep(1)).!

--- a/main/resolve/src/mill/resolve/ParseArgs.scala
+++ b/main/resolve/src/mill/resolve/ParseArgs.scala
@@ -98,7 +98,7 @@ object ParseArgs {
 
     def typeQualifier(simple: Boolean) = {
       val maxSegments = if (simple) 0 else Int.MaxValue
-      P("!".? ~~ label ~~ ("." ~~ label).rep(max = maxSegments)).!
+      P(("!"|"^").? ~~ label ~~ ("." ~~ label).rep(max = maxSegments)).!
     }
 
     def typePattern(simple: Boolean) = P(wildcard ~~ (":" ~~ typeQualifier(simple)).rep(1)).!

--- a/main/resolve/src/mill/resolve/ParseArgs.scala
+++ b/main/resolve/src/mill/resolve/ParseArgs.scala
@@ -94,7 +94,7 @@ object ParseArgs {
 
   private def selector[_p: P]: P[(Option[Segments], Segments)] = {
     def typeLabel = P(("!" | "") ~~ CharsWhileIn("a-zA-Z0-9_\\-$")).!
-    def typePattern = P(("_:" | "__:") ~~ typeLabel).!
+    def typePattern = P(("__" | "_") ~~ (":" ~~ typeLabel).rep).!
     def identCross = P(CharsWhileIn("a-zA-Z0-9_\\-.")).!
     def segment = P(typePattern | mill.define.Reflect.ident).map(Segment.Label)
     def crossSegment = P("[" ~ identCross.rep(1, sep = ",") ~ "]").map(Segment.Cross)

--- a/main/resolve/src/mill/resolve/ParseArgs.scala
+++ b/main/resolve/src/mill/resolve/ParseArgs.scala
@@ -98,7 +98,7 @@ object ParseArgs {
 
     def typeQualifier(simple: Boolean) = {
       val maxSegments = if (simple) 0 else Int.MaxValue
-      P(("!" | "^").? ~~ label ~~ ("." ~~ label).rep(max = maxSegments)).!
+      P(("^" | "!").? ~~ label ~~ ("." ~~ label).rep(max = maxSegments)).!
     }
 
     def typePattern(simple: Boolean) = P(wildcard ~~ (":" ~~ typeQualifier(simple)).rep(1)).!

--- a/main/resolve/src/mill/resolve/ParseArgs.scala
+++ b/main/resolve/src/mill/resolve/ParseArgs.scala
@@ -93,9 +93,10 @@ object ParseArgs {
     }
 
   private def selector[_p: P]: P[(Option[Segments], Segments)] = {
-    def identLabel = P(CharsWhileIn("a-zA-Z0-9_\\-:$")).!
+    def typeLabel = P(("!" | "") ~~ CharsWhileIn("a-zA-Z0-9_\\-$")).!
+    def typePattern = P(("_:" | "__:") ~~ typeLabel).!
     def identCross = P(CharsWhileIn("a-zA-Z0-9_\\-.")).!
-    def segment = P(identLabel).map(Segment.Label)
+    def segment = P(typePattern | mill.define.Reflect.ident).map(Segment.Label)
     def crossSegment = P("[" ~ identCross.rep(1, sep = ",") ~ "]").map(Segment.Cross)
     def defaultCrossSegment = P("[]").map(_ => Segment.Cross(Seq()))
     def simpleQuery = P(segment ~ ("." ~ segment | crossSegment | defaultCrossSegment).rep).map {

--- a/main/resolve/src/mill/resolve/Resolve.scala
+++ b/main/resolve/src/mill/resolve/Resolve.scala
@@ -230,11 +230,23 @@ trait Resolve[T] {
   ): Either[String, Seq[T]] = {
     val rootResolved = ResolveCore.Resolved.Module(Segments(), rootModule.getClass)
     val resolved =
-      ResolveCore.resolve(rootModule, sel.value.toList, rootResolved, Segments()) match {
+      ResolveCore.resolve(
+        rootModule = rootModule,
+        remainingQuery = sel.value.toList,
+        current = rootResolved,
+        querySoFar = Segments()
+      ) match {
         case ResolveCore.Success(value) => Right(value)
         case ResolveCore.NotFound(segments, found, next, possibleNexts) =>
           val allPossibleNames = rootModule.millDiscover.value.values.flatMap(_._1).toSet
-          Left(ResolveNotFoundHandler(sel, segments, found, next, possibleNexts, allPossibleNames))
+          Left(ResolveNotFoundHandler(
+            selector = sel,
+            segments = segments,
+            found = found,
+            next = next,
+            possibleNexts = possibleNexts,
+            allPossibleNames = allPossibleNames
+          ))
         case ResolveCore.Error(value) => Left(value)
       }
 

--- a/main/resolve/src/mill/resolve/Resolve.scala
+++ b/main/resolve/src/mill/resolve/Resolve.scala
@@ -28,7 +28,7 @@ object Resolve {
       Right(resolved.map(_.segments))
     }
 
-    private[mill] override def deduplicate(items: List[Segments]) = items.distinct
+    private[mill] override def deduplicate(items: List[Segments]): List[Segments] = items.distinct
   }
 
   object Tasks extends Resolve[NamedTask[Any]] {
@@ -83,11 +83,11 @@ object Resolve {
       )
     }
 
-    private[mill] override def deduplicate(items: List[NamedTask[Any]]) =
+    private[mill] override def deduplicate(items: List[NamedTask[Any]]): List[NamedTask[Any]] =
       items.distinctBy(_.ctx.segments)
   }
 
-  private def instantiateTarget(r: Resolved.Target, p: Module) = {
+  private def instantiateTarget(r: Resolved.Target, p: Module): Either[String, Target[_]] = {
     val definition = Reflect
       .reflect(p.getClass, classOf[Target[_]], _ == r.segments.parts.last, true)
       .head
@@ -245,7 +245,10 @@ trait Resolve[T] {
 
   private[mill] def deduplicate(items: List[T]): List[T] = items
 
-  private[mill] def resolveRootModule(rootModule: BaseModule, scopedSel: Option[Segments]) = {
+  private[mill] def resolveRootModule(
+      rootModule: BaseModule,
+      scopedSel: Option[Segments]
+  ): Either[String, BaseModule] = {
     scopedSel match {
       case None => Right(rootModule)
       case Some(scoping) =>

--- a/main/resolve/src/mill/resolve/ResolveCore.scala
+++ b/main/resolve/src/mill/resolve/ResolveCore.scala
@@ -258,21 +258,22 @@ private object ResolveCore {
     typePattern match {
       case None => true
       case Some(pat) =>
+        val negate = pat.startsWith("!")
+        val clsPat = pat.drop(if (negate) 1 else 0)
+
         // We split full class names by `.` and `$`
         // a class matches a type patter, if the type pattern segments match from the right
         // to express a full match, use `_root_` as first segment
 
+        val typeNames = clsPat.split("[.$]").toSeq.reverse.inits.toSeq.filter(_.nonEmpty)
+
         val parents = resolveParents(cls)
-        val classNames =
-          parents.flatMap(c =>
-            ("_root_$" + c.getName).split("[.$]").toSeq.reverse.inits.toSeq.filter(_.nonEmpty)
-          )
+        val classNames = parents.flatMap(c =>
+          ("_root_$" + c.getName).split("[.$]").toSeq.reverse.inits.toSeq.filter(_.nonEmpty)
+        )
 
-        val typeNames = pat.split("[.$]").toSeq.reverse.inits.toSeq.filter(_.nonEmpty)
-
-        val ok = classNames.exists(cn => typeNames.exists(_ == cn))
-
-        ok
+        val isOfType = classNames.exists(cn => typeNames.exists(_ == cn))
+        if (negate) !isOfType else isOfType
     }
 
   def resolveDirectChildren(

--- a/main/resolve/src/mill/resolve/ResolveCore.scala
+++ b/main/resolve/src/mill/resolve/ResolveCore.scala
@@ -231,14 +231,6 @@ private object ResolveCore {
       typePattern: Option[String]
   ): Either[String, Set[Resolved]] = {
     val direct = resolveDirectChildren(rootModule, cls, nameOpt, segments, typePattern)
-    val indirect = for {
-      directTraverse <- resolveDirectChildren(rootModule, cls, nameOpt, segments, None)
-      indirect0 = directTraverse
-        .collect { case m: Resolved.Module =>
-          resolveTransitiveChildren(rootModule, m.cls, nameOpt, m.segments, typePattern)
-        }
-      indirect <- EitherOps.sequence(indirect0).map(_.flatten)
-    } yield indirect
     direct.flatMap { direct =>
       for {
         directTraverse <- resolveDirectChildren(rootModule, cls, nameOpt, segments, None)

--- a/main/resolve/src/mill/resolve/ResolveCore.scala
+++ b/main/resolve/src/mill/resolve/ResolveCore.scala
@@ -255,14 +255,15 @@ private object ResolveCore {
         // a class matches a type patter, if the type pattern segments match from the right
         // to express a full match, use `_root_` as first segment
 
-        val typeNames = clsPat.split("[.$]").toSeq.reverse.inits.toSeq.filter(_.nonEmpty)
+        val typeNames = clsPat.split("[.$]").toSeq.reverse
 
         val parents = resolveParents(cls)
+        println(s"parents: ${pprint.apply(parents)}")
         val classNames = parents.flatMap(c =>
           ("_root_$" + c.getName).split("[.$]").toSeq.reverse.inits.toSeq.filter(_.nonEmpty)
         )
 
-        val isOfType = classNames.exists(cn => typeNames.exists(_ == cn))
+        val isOfType = classNames.contains(typeNames)
         if (negate) !isOfType else isOfType
       }
 

--- a/main/resolve/src/mill/resolve/ResolveCore.scala
+++ b/main/resolve/src/mill/resolve/ResolveCore.scala
@@ -105,7 +105,6 @@ private object ResolveCore {
 
               case pattern if pattern.startsWith("_:") =>
                 val typePattern = pattern.drop(2)
-                debug(s"Type pattern: ${typePattern}")
                 resolveDirectChildren(
                   rootModule,
                   m.cls,

--- a/main/resolve/src/mill/resolve/ResolveCore.scala
+++ b/main/resolve/src/mill/resolve/ResolveCore.scala
@@ -258,7 +258,6 @@ private object ResolveCore {
         val typeNames = clsPat.split("[.$]").toSeq.reverse
 
         val parents = resolveParents(cls)
-        println(s"parents: ${pprint.apply(parents)}")
         val classNames = parents.flatMap(c =>
           ("_root_$" + c.getName).split("[.$]").toSeq.reverse.inits.toSeq.filter(_.nonEmpty)
         )

--- a/main/resolve/src/mill/resolve/ResolveCore.scala
+++ b/main/resolve/src/mill/resolve/ResolveCore.scala
@@ -304,14 +304,11 @@ private object ResolveCore {
     } else Right(Nil)
 
     crossesOrErr.flatMap { crosses =>
-//      val filteredCrosses = crosses.filter { c =>
-//        classMatchesTypePred(typePattern)(c.cls)
-//      }
+      val filteredCrosses = crosses.filter { c =>
+        classMatchesTypePred(typePattern)(c.cls)
+      }
 
-      val res1 =
-        resolveDirectChildren0(rootModule, segments, cls, nameOpt, typePattern)
-
-      res1
+      resolveDirectChildren0(rootModule, segments, cls, nameOpt, typePattern)
         .map(
           _.map {
             case (Resolved.Module(s, cls), _) => Resolved.Module(segments ++ s, cls)
@@ -319,7 +316,7 @@ private object ResolveCore {
             case (Resolved.Command(s), _) => Resolved.Command(segments ++ s)
           }
             .toSet
-            .++(crosses)
+            .++(filteredCrosses)
         )
     }
   }

--- a/main/resolve/src/mill/resolve/ResolveCore.scala
+++ b/main/resolve/src/mill/resolve/ResolveCore.scala
@@ -247,7 +247,7 @@ private object ResolveCore {
   private def classMatchesTypePred(typePattern: Seq[String])(cls: Class[_]): Boolean =
     typePattern
       .forall { pat =>
-        val negate = pat.startsWith("!") || pat.startsWith("^")
+        val negate = pat.startsWith("^") || pat.startsWith("!")
         val clsPat = pat.drop(if (negate) 1 else 0)
 
         // We split full class names by `.` and `$`

--- a/main/resolve/src/mill/resolve/ResolveCore.scala
+++ b/main/resolve/src/mill/resolve/ResolveCore.scala
@@ -219,6 +219,14 @@ private object ResolveCore {
       rootModule: Module,
       cls: Class[_],
       nameOpt: Option[String],
+      segments: Segments
+  ): Either[String, Set[Resolved]] =
+    resolveTransitiveChildren(rootModule, cls, nameOpt, segments, None)
+
+  def resolveTransitiveChildren(
+      rootModule: Module,
+      cls: Class[_],
+      nameOpt: Option[String],
       segments: Segments,
       typePattern: Option[String]
   ): Either[String, Set[Resolved]] = {
@@ -304,9 +312,9 @@ private object ResolveCore {
     } else Right(Nil)
 
     crossesOrErr.flatMap { crosses =>
-      val filteredCrosses = crosses.filter { c =>
-        classMatchesTypePred(typePattern)(c.cls)
-      }
+//      val filteredCrosses = crosses.filter { c =>
+//        classMatchesTypePred(typePattern)(c.cls)
+//      }
 
       val res1 =
         resolveDirectChildren0(rootModule, segments, cls, nameOpt, typePattern)
@@ -323,6 +331,14 @@ private object ResolveCore {
         )
     }
   }
+
+  def resolveDirectChildren0(
+      rootModule: Module,
+      segments: Segments,
+      cls: Class[_],
+      nameOpt: Option[String]
+  ): Either[String, Seq[(Resolved, Option[Module => Either[String, Module]])]] =
+    resolveDirectChildren0(rootModule, segments, cls, nameOpt, None)
 
   def resolveDirectChildren0(
       rootModule: Module,

--- a/main/resolve/src/mill/resolve/ResolveCore.scala
+++ b/main/resolve/src/mill/resolve/ResolveCore.scala
@@ -246,9 +246,8 @@ private object ResolveCore {
    */
   private def classMatchesTypePred(typePattern: Seq[String])(cls: Class[_]): Boolean =
     typePattern
-      .map(p => if (p.startsWith("(") && p.endsWith(")")) p.drop(1).dropRight(1) else p)
       .forall { pat =>
-        val negate = pat.startsWith("!")
+        val negate = pat.startsWith("!") || pat.startsWith("^")
         val clsPat = pat.drop(if (negate) 1 else 0)
 
         // We split full class names by `.` and `$`

--- a/main/resolve/test/src/mill/main/ResolveTests.scala
+++ b/main/resolve/test/src/mill/main/ResolveTests.scala
@@ -942,6 +942,11 @@ object ResolveTests extends TestSuite {
         Right(Set(_.typeA.foo, _.typeAB.foo, _.typeAB.bar, _.typeC.typeA.foo)),
         Set()
       )
+      test - check(
+        "__:!TypeA._",
+        Right(Set(_.typeB.bar, _.typeC.baz)),
+        Set()
+      )
 
     }
   }

--- a/main/resolve/test/src/mill/main/ResolveTests.scala
+++ b/main/resolve/test/src/mill/main/ResolveTests.scala
@@ -950,6 +950,10 @@ object ResolveTests extends TestSuite {
         Right(Set(_.typeA.foo, _.typeAB.foo, _.typeAB.bar, _.typeC.typeA.foo))
       )
       test - check(
+        "__:TypeA:!TypeB._",
+        Right(Set(_.typeA.foo, _.typeC.typeA.foo))
+      )
+      test - check(
         "__:!TypeA._",
         Right(Set(_.typeB.bar, _.typeC.baz))
       )

--- a/main/resolve/test/src/mill/main/ResolveTests.scala
+++ b/main/resolve/test/src/mill/main/ResolveTests.scala
@@ -949,7 +949,9 @@ object ResolveTests extends TestSuite {
       )
       test - check(
         "(_:!_root_.mill.define.Module)._",
-        Left("Cannot resolve _:!_root_.mill.define.Module._. Try `mill resolve _` to see what's available.")
+        Left(
+          "Cannot resolve _:!_root_.mill.define.Module._. Try `mill resolve _` to see what's available."
+        )
       )
       test - check(
         "_:TypeA._",
@@ -977,7 +979,9 @@ object ResolveTests extends TestSuite {
       // missing parens
       test - check(
         "__:TypeA:!TypedModules.TypeB._",
-        Left("Cannot resolve __:TypeA:!TypedModules.TypeB._. Try `mill resolve _` to see what's available.")
+        Left(
+          "Cannot resolve __:TypeA:!TypedModules.TypeB._. Try `mill resolve _` to see what's available."
+        )
       )
       test - check(
         "(__:TypeA:!TypeB)._",

--- a/main/resolve/test/src/mill/main/ResolveTests.scala
+++ b/main/resolve/test/src/mill/main/ResolveTests.scala
@@ -916,28 +916,23 @@ object ResolveTests extends TestSuite {
           _.typeAB.bar,
           _.typeC.baz,
           _.typeC.typeA.foo
-        )),
-        Set()
+        ))
       )
       test - check(
         "_._",
-        Right(Set(_.typeA.foo, _.typeB.bar, _.typeAB.foo, _.typeAB.bar, _.typeC.baz)),
-        Set()
+        Right(Set(_.typeA.foo, _.typeB.bar, _.typeAB.foo, _.typeAB.bar, _.typeC.baz))
       )
       test - check(
         "_:Module._",
-        Right(Set(_.typeA.foo, _.typeB.bar, _.typeAB.foo, _.typeAB.bar, _.typeC.baz)),
-        Set()
+        Right(Set(_.typeA.foo, _.typeB.bar, _.typeAB.foo, _.typeAB.bar, _.typeC.baz))
       )
       test - check(
         "_:_root_$mill$define$Module._",
-        Right(Set(_.typeA.foo, _.typeB.bar, _.typeAB.foo, _.typeAB.bar, _.typeC.baz)),
-        Set()
+        Right(Set(_.typeA.foo, _.typeB.bar, _.typeAB.foo, _.typeAB.bar, _.typeC.baz))
       )
       test - check(
         "_:TypeA._",
-        Right(Set(_.typeA.foo, _.typeAB.foo, _.typeAB.bar)),
-        Set()
+        Right(Set(_.typeA.foo, _.typeAB.foo, _.typeAB.bar))
       )
       test - check(
         "__:Module._",
@@ -948,20 +943,82 @@ object ResolveTests extends TestSuite {
           _.typeAB.bar,
           _.typeC.baz,
           _.typeC.typeA.foo
-        )),
-        Set()
+        ))
       )
       test - check(
         "__:TypeA._",
-        Right(Set(_.typeA.foo, _.typeAB.foo, _.typeAB.bar, _.typeC.typeA.foo)),
-        Set()
+        Right(Set(_.typeA.foo, _.typeAB.foo, _.typeAB.bar, _.typeC.typeA.foo))
       )
       test - check(
         "__:!TypeA._",
-        Right(Set(_.typeB.bar, _.typeC.baz)),
-        Set()
+        Right(Set(_.typeB.bar, _.typeC.baz))
       )
-
+    }
+    test("crossTypeSelector") {
+      val check = new Checker(TestGraphs.TypedCrossModules)
+      test - check(
+        "__",
+        Right(Set(
+          _.typeA("a").foo,
+          _.typeA("b").foo,
+          _.typeAB("a").foo,
+          _.typeAB("a").bar,
+          _.typeAB("b").foo,
+          _.typeAB("b").bar,
+          _.inner.typeA("a").foo,
+          _.inner.typeA("b").foo,
+          _.inner.typeAB("a").foo,
+          _.inner.typeAB("a").bar,
+          _.inner.typeAB("b").foo,
+          _.inner.typeAB("b").bar,
+          _.nestedAB("a").foo,
+          _.nestedAB("a").bar,
+          _.nestedAB("b").foo,
+          _.nestedAB("b").bar,
+          _.nestedAB("a").typeAB("a").foo,
+          _.nestedAB("a").typeAB("a").bar,
+          _.nestedAB("a").typeAB("b").foo,
+          _.nestedAB("a").typeAB("b").bar,
+          _.nestedAB("b").typeAB("a").foo,
+          _.nestedAB("b").typeAB("a").bar,
+          _.nestedAB("b").typeAB("b").foo,
+          _.nestedAB("b").typeAB("b").bar
+        ))
+      )
+      test - check(
+        "__:TypeB._",
+        Right(Set(
+          _.typeAB("a").foo,
+          _.typeAB("a").bar,
+          _.typeAB("b").foo,
+          _.typeAB("b").bar,
+          _.inner.typeAB("a").foo,
+          _.inner.typeAB("a").bar,
+          _.inner.typeAB("b").foo,
+          _.inner.typeAB("b").bar,
+          _.nestedAB("a").foo,
+          _.nestedAB("a").bar,
+          _.nestedAB("b").foo,
+          _.nestedAB("b").bar,
+          _.nestedAB("a").typeAB("a").foo,
+          _.nestedAB("a").typeAB("a").bar,
+          _.nestedAB("a").typeAB("b").foo,
+          _.nestedAB("a").typeAB("b").bar,
+          _.nestedAB("b").typeAB("a").foo,
+          _.nestedAB("b").typeAB("a").bar,
+          _.nestedAB("b").typeAB("b").foo,
+          _.nestedAB("b").typeAB("b").bar
+        ))
+      )
+      test - check(
+        "__:!TypeB._",
+        Right(Set(
+          _.typeA("a").foo,
+          _.typeA("b").foo,
+          _.inner.typeA("a").foo,
+          _.inner.typeA("b").foo
+        ))
+      )
     }
   }
 }

--- a/main/resolve/test/src/mill/main/ResolveTests.scala
+++ b/main/resolve/test/src/mill/main/ResolveTests.scala
@@ -950,7 +950,15 @@ object ResolveTests extends TestSuite {
         Right(Set(_.typeA.foo, _.typeAB.foo, _.typeAB.bar, _.typeC.typeA.foo))
       )
       test - check(
-        "__:TypeA:!TypeB._",
+        "__:TypeA:!TypedModules$TypeB._",
+        Right(Set(_.typeA.foo, _.typeC.typeA.foo))
+      )
+      test - check(
+        "__:(TypeA):(!TypeB)._",
+        Right(Set(_.typeA.foo, _.typeC.typeA.foo))
+      )
+      test - check(
+        "__:(TypedModules.TypeA):(!TypedModules$TypeB)._",
         Right(Set(_.typeA.foo, _.typeC.typeA.foo))
       )
       test - check(

--- a/main/resolve/test/src/mill/main/ResolveTests.scala
+++ b/main/resolve/test/src/mill/main/ResolveTests.scala
@@ -1031,6 +1031,29 @@ object ResolveTests extends TestSuite {
           _.inner.typeA("b").foo
         ))
       )
+      test("innerTypeSelector") {
+        val check = new Checker(TestGraphs.TypedInnerModules)
+        test - check(
+          "__:(TypeA)._",
+          Right(Set(
+            _.typeA.foo,
+            _.inner.typeA.foo
+          ))
+        )
+        test - check(
+          "__:(!TypeA)._",
+          Right(Set(
+            _.typeB.foo
+          ))
+        )
+        test - check(
+          "__:(!inner.TypeA)._",
+          Right(Set(
+            _.typeA.foo,
+            _.typeB.foo
+          ))
+        )
+      }
     }
   }
 }

--- a/main/resolve/test/src/mill/main/ResolveTests.scala
+++ b/main/resolve/test/src/mill/main/ResolveTests.scala
@@ -948,9 +948,9 @@ object ResolveTests extends TestSuite {
         Right(Set(_.typeA.foo, _.typeB.bar, _.typeAB.foo, _.typeAB.bar, _.typeC.baz))
       )
       test - check(
-        "(_:!_root_.mill.define.Module)._",
+        "(_:^_root_.mill.define.Module)._",
         Left(
-          "Cannot resolve _:!_root_.mill.define.Module._. Try `mill resolve _` to see what's available."
+          "Cannot resolve _:^_root_.mill.define.Module._. Try `mill resolve _` to see what's available."
         )
       )
       test - check(
@@ -973,14 +973,14 @@ object ResolveTests extends TestSuite {
         Right(Set(_.typeA.foo, _.typeAB.foo, _.typeAB.bar, _.typeC.typeA.foo))
       )
       test - check(
-        "(__:TypeA:!TypedModules.TypeB)._",
+        "(__:TypeA:^TypedModules.TypeB)._",
         Right(Set(_.typeA.foo, _.typeC.typeA.foo))
       )
       // missing parens
       test - check(
-        "__:TypeA:!TypedModules.TypeB._",
+        "__:TypeA:^TypedModules.TypeB._",
         Left(
-          "Cannot resolve __:TypeA:!TypedModules.TypeB._. Try `mill resolve _` to see what's available."
+          "Cannot resolve __:TypeA:^TypedModules.TypeB._. Try `mill resolve _` to see what's available."
         )
       )
       test - check(
@@ -988,11 +988,11 @@ object ResolveTests extends TestSuite {
         Right(Set(_.typeA.foo, _.typeC.typeA.foo))
       )
       test - check(
-        "(__:TypedModules.TypeA:!TypedModules.TypeB)._",
+        "(__:TypedModules.TypeA:^TypedModules.TypeB)._",
         Right(Set(_.typeA.foo, _.typeC.typeA.foo))
       )
       test - check(
-        "__:!TypeA._",
+        "__:^TypeA._",
         Right(Set(_.typeB.bar, _.typeC.baz))
       )
       test - check(
@@ -1057,7 +1057,7 @@ object ResolveTests extends TestSuite {
         ))
       )
       test - check(
-        "__:!TypeB._",
+        "__:^TypeB._",
         Right(Set(
           _.typeA("a").foo,
           _.typeA("b").foo,
@@ -1065,8 +1065,9 @@ object ResolveTests extends TestSuite {
           _.inner.typeA("b").foo
         ))
       )
+      // Keep `!` as alternative to `^`
       test - check(
-        "__:^TypeB._",
+        "__:!TypeB._",
         Right(Set(
           _.typeA("a").foo,
           _.typeA("b").foo,
@@ -1084,13 +1085,13 @@ object ResolveTests extends TestSuite {
           ))
         )
         test - check(
-          "__:!TypeA._",
+          "__:^TypeA._",
           Right(Set(
             _.typeB.foo
           ))
         )
         test - check(
-          "(__:!inner.TypeA)._",
+          "(__:^inner.TypeA)._",
           Right(Set(
             _.typeA.foo,
             _.typeB.foo

--- a/main/resolve/test/src/mill/main/ResolveTests.scala
+++ b/main/resolve/test/src/mill/main/ResolveTests.scala
@@ -919,7 +919,18 @@ object ResolveTests extends TestSuite {
         ))
       )
       test - check(
-        "_._",
+        "(__)",
+        Right(Set(
+          _.typeA.foo,
+          _.typeB.bar,
+          _.typeAB.foo,
+          _.typeAB.bar,
+          _.typeC.baz,
+          _.typeC.typeA.foo
+        ))
+      )
+      test - check(
+        "(_)._",
         Right(Set(_.typeA.foo, _.typeB.bar, _.typeAB.foo, _.typeAB.bar, _.typeC.baz))
       )
       test - check(
@@ -927,7 +938,11 @@ object ResolveTests extends TestSuite {
         Right(Set(_.typeA.foo, _.typeB.bar, _.typeAB.foo, _.typeAB.bar, _.typeC.baz))
       )
       test - check(
-        "_:_root_$mill$define$Module._",
+        "(_:Module)._",
+        Right(Set(_.typeA.foo, _.typeB.bar, _.typeAB.foo, _.typeAB.bar, _.typeC.baz))
+      )
+      test - check(
+        "(_:_root_$mill$define$Module)._",
         Right(Set(_.typeA.foo, _.typeB.bar, _.typeAB.foo, _.typeAB.bar, _.typeC.baz))
       )
       test - check(
@@ -950,15 +965,15 @@ object ResolveTests extends TestSuite {
         Right(Set(_.typeA.foo, _.typeAB.foo, _.typeAB.bar, _.typeC.typeA.foo))
       )
       test - check(
-        "__:TypeA:!TypedModules$TypeB._",
+        "(__:TypeA:!TypedModules$TypeB)._",
         Right(Set(_.typeA.foo, _.typeC.typeA.foo))
       )
       test - check(
-        "__:(TypeA):(!TypeB)._",
+        "(__:(TypeA):(!TypeB))._",
         Right(Set(_.typeA.foo, _.typeC.typeA.foo))
       )
       test - check(
-        "__:(TypedModules.TypeA):(!TypedModules$TypeB)._",
+        "(__:(TypedModules.TypeA):(!TypedModules$TypeB))._",
         Right(Set(_.typeA.foo, _.typeC.typeA.foo))
       )
       test - check(
@@ -1034,20 +1049,20 @@ object ResolveTests extends TestSuite {
       test("innerTypeSelector") {
         val check = new Checker(TestGraphs.TypedInnerModules)
         test - check(
-          "__:(TypeA)._",
+          "__:TypeA._",
           Right(Set(
             _.typeA.foo,
             _.inner.typeA.foo
           ))
         )
         test - check(
-          "__:(!TypeA)._",
+          "__:!TypeA._",
           Right(Set(
             _.typeB.foo
           ))
         )
         test - check(
-          "__:(!inner.TypeA)._",
+          "(__:(!inner.TypeA))._",
           Right(Set(
             _.typeA.foo,
             _.typeB.foo

--- a/main/resolve/test/src/mill/main/ResolveTests.scala
+++ b/main/resolve/test/src/mill/main/ResolveTests.scala
@@ -909,7 +909,7 @@ object ResolveTests extends TestSuite {
       val check = new Checker(TestGraphs.TypedModules)
       test - check(
         "__",
-        Right(Set(_.typeA.foo, _.typeB.bar, _.typeAB.foo, _.typeAB.bar, _.typeC.baz)),
+        Right(Set(_.typeA.foo, _.typeB.bar, _.typeAB.foo, _.typeAB.bar, _.typeC.baz, _.typeC.typeA.foo)),
         Set()
       )
       test - check(
@@ -930,6 +930,16 @@ object ResolveTests extends TestSuite {
       test - check(
         "_:TypeA._",
         Right(Set(_.typeA.foo, _.typeAB.foo, _.typeAB.bar)),
+        Set()
+      )
+      test - check(
+        "__:Module._",
+        Right(Set(_.typeA.foo, _.typeB.bar, _.typeAB.foo, _.typeAB.bar, _.typeC.baz, _.typeC.typeA.foo)),
+        Set()
+      )
+      test - check(
+        "__:TypeA._",
+        Right(Set(_.typeA.foo, _.typeAB.foo, _.typeAB.bar, _.typeC.typeA.foo)),
         Set()
       )
 

--- a/main/resolve/test/src/mill/main/ResolveTests.scala
+++ b/main/resolve/test/src/mill/main/ResolveTests.scala
@@ -918,6 +918,7 @@ object ResolveTests extends TestSuite {
           _.typeC.typeA.foo
         ))
       )
+      // parens should work
       test - check(
         "(__)",
         Right(Set(
@@ -937,13 +938,18 @@ object ResolveTests extends TestSuite {
         "_:Module._",
         Right(Set(_.typeA.foo, _.typeB.bar, _.typeAB.foo, _.typeAB.bar, _.typeC.baz))
       )
+      // parens should work
       test - check(
         "(_:Module)._",
         Right(Set(_.typeA.foo, _.typeB.bar, _.typeAB.foo, _.typeAB.bar, _.typeC.baz))
       )
       test - check(
-        "(_:_root_$mill$define$Module)._",
+        "(_:_root_.mill.define.Module)._",
         Right(Set(_.typeA.foo, _.typeB.bar, _.typeAB.foo, _.typeAB.bar, _.typeC.baz))
+      )
+      test - check(
+        "(_:!_root_.mill.define.Module)._",
+        Left("Cannot resolve _:!_root_.mill.define.Module._. Try `mill resolve _` to see what's available.")
       )
       test - check(
         "_:TypeA._",
@@ -965,15 +971,20 @@ object ResolveTests extends TestSuite {
         Right(Set(_.typeA.foo, _.typeAB.foo, _.typeAB.bar, _.typeC.typeA.foo))
       )
       test - check(
-        "(__:TypeA:!TypedModules$TypeB)._",
+        "(__:TypeA:!TypedModules.TypeB)._",
+        Right(Set(_.typeA.foo, _.typeC.typeA.foo))
+      )
+      // missing parens
+      test - check(
+        "__:TypeA:!TypedModules.TypeB._",
+        Left("Cannot resolve __:TypeA:!TypedModules.TypeB._. Try `mill resolve _` to see what's available.")
+      )
+      test - check(
+        "(__:TypeA:!TypeB)._",
         Right(Set(_.typeA.foo, _.typeC.typeA.foo))
       )
       test - check(
-        "(__:(TypeA):(!TypeB))._",
-        Right(Set(_.typeA.foo, _.typeC.typeA.foo))
-      )
-      test - check(
-        "(__:(TypedModules.TypeA):(!TypedModules$TypeB))._",
+        "(__:TypedModules.TypeA:!TypedModules.TypeB)._",
         Right(Set(_.typeA.foo, _.typeC.typeA.foo))
       )
       test - check(
@@ -1062,7 +1073,7 @@ object ResolveTests extends TestSuite {
           ))
         )
         test - check(
-          "(__:(!inner.TypeA))._",
+          "(__:!inner.TypeA)._",
           Right(Set(
             _.typeA.foo,
             _.typeB.foo

--- a/main/resolve/test/src/mill/main/ResolveTests.scala
+++ b/main/resolve/test/src/mill/main/ResolveTests.scala
@@ -1,6 +1,7 @@
 package mill.resolve
 
 import mill.define.NamedTask
+import mill.util.TestGraphs
 import mill.util.TestGraphs._
 import utest._
 object ResolveTests extends TestSuite {
@@ -31,6 +32,7 @@ object ResolveTests extends TestSuite {
         expectedMetadata.isEmpty ||
           resolvedMetadata.map(_.toSet) == Right(expectedMetadata)
       )
+      selectorStrings.mkString(" ")
     }
 
     def checkSeq0(
@@ -902,6 +904,35 @@ object ResolveTests extends TestSuite {
         Right(Set(_.normal.inner.target)),
         Set("normal.inner.target")
       )
+    }
+    test("typeSelector") {
+      val check = new Checker(TestGraphs.TypedModules)
+      test - check(
+        "__",
+        Right(Set(_.typeA.foo, _.typeB.bar, _.typeAB.foo, _.typeAB.bar, _.typeC.baz)),
+        Set()
+      )
+      test - check(
+        "_._",
+        Right(Set(_.typeA.foo, _.typeB.bar, _.typeAB.foo, _.typeAB.bar, _.typeC.baz)),
+        Set()
+      )
+      test - check(
+        "_:Module._",
+        Right(Set(_.typeA.foo, _.typeB.bar, _.typeAB.foo, _.typeAB.bar, _.typeC.baz)),
+        Set()
+      )
+      test - check(
+        "_:_root_$mill$define$Module._",
+        Right(Set(_.typeA.foo, _.typeB.bar, _.typeAB.foo, _.typeAB.bar, _.typeC.baz)),
+        Set()
+      )
+      test - check(
+        "_:TypeA._",
+        Right(Set(_.typeA.foo, _.typeAB.foo, _.typeAB.bar)),
+        Set()
+      )
+
     }
   }
 }

--- a/main/resolve/test/src/mill/main/ResolveTests.scala
+++ b/main/resolve/test/src/mill/main/ResolveTests.scala
@@ -909,7 +909,14 @@ object ResolveTests extends TestSuite {
       val check = new Checker(TestGraphs.TypedModules)
       test - check(
         "__",
-        Right(Set(_.typeA.foo, _.typeB.bar, _.typeAB.foo, _.typeAB.bar, _.typeC.baz, _.typeC.typeA.foo)),
+        Right(Set(
+          _.typeA.foo,
+          _.typeB.bar,
+          _.typeAB.foo,
+          _.typeAB.bar,
+          _.typeC.baz,
+          _.typeC.typeA.foo
+        )),
         Set()
       )
       test - check(
@@ -934,7 +941,14 @@ object ResolveTests extends TestSuite {
       )
       test - check(
         "__:Module._",
-        Right(Set(_.typeA.foo, _.typeB.bar, _.typeAB.foo, _.typeAB.bar, _.typeC.baz, _.typeC.typeA.foo)),
+        Right(Set(
+          _.typeA.foo,
+          _.typeB.bar,
+          _.typeAB.foo,
+          _.typeAB.bar,
+          _.typeC.baz,
+          _.typeC.typeA.foo
+        )),
         Set()
       )
       test - check(

--- a/main/resolve/test/src/mill/main/ResolveTests.scala
+++ b/main/resolve/test/src/mill/main/ResolveTests.scala
@@ -991,6 +991,10 @@ object ResolveTests extends TestSuite {
         "__:!TypeA._",
         Right(Set(_.typeB.bar, _.typeC.baz))
       )
+      test - check(
+        "__:^TypeA._",
+        Right(Set(_.typeB.bar, _.typeC.baz))
+      )
     }
     test("crossTypeSelector") {
       val check = new Checker(TestGraphs.TypedCrossModules)
@@ -1050,6 +1054,15 @@ object ResolveTests extends TestSuite {
       )
       test - check(
         "__:!TypeB._",
+        Right(Set(
+          _.typeA("a").foo,
+          _.typeA("b").foo,
+          _.inner.typeA("a").foo,
+          _.inner.typeA("b").foo
+        ))
+      )
+      test - check(
+        "__:^TypeB._",
         Right(Set(
           _.typeA("a").foo,
           _.typeA("b").foo,

--- a/main/test/src/mill/util/TestGraphs.scala
+++ b/main/test/src/mill/util/TestGraphs.scala
@@ -561,7 +561,9 @@ object TestGraphs {
 
     object typeA extends TypeA
     object typeB extends TypeB
-    object typeC extends TypeC
+    object typeC extends TypeC {
+      object typeA extends TypeA
+    }
     object typeAB extends TypeAB
   }
 

--- a/main/test/src/mill/util/TestGraphs.scala
+++ b/main/test/src/mill/util/TestGraphs.scala
@@ -592,4 +592,20 @@ object TestGraphs {
     object nestedAB extends Cross[NestedAB]("a", "b")
   }
 
+  object TypedInnerModules extends TestUtil.BaseModule {
+    trait TypeA extends Module {
+      def foo = T { "foo" }
+    }
+    object typeA extends TypeA
+    object typeB extends Module {
+      def foo = T { "foo" }
+    }
+    object inner extends Module {
+      trait TypeA extends Module {
+        def foo = T { "foo" }
+      }
+      object typeA extends TypeA
+    }
+  }
+
 }

--- a/main/test/src/mill/util/TestGraphs.scala
+++ b/main/test/src/mill/util/TestGraphs.scala
@@ -546,4 +546,40 @@ object TestGraphs {
     }
     object mod extends M1 with M2
   }
+
+  object TypedModules extends TestUtil.BaseModule {
+    trait TypeA extends Module {
+      def foo = T { "foo" }
+    }
+    trait TypeB extends Module {
+      def bar = T { "bar" }
+    }
+    trait TypeC extends Module {
+      def baz = T { "baz" }
+    }
+    trait TypeAB extends TypeA with TypeB
+
+    object typeA extends TypeA
+    object typeB extends TypeB
+    object typeC extends TypeC
+    object typeAB extends TypeAB
+  }
+
+//  object TypedCrossModules extends TestUtil.BaseModule {
+//    trait TypeA extends Module {
+//      def foo = T { "foo" }
+//    }
+//    trait TypeB extends Module {
+//      def bar = T { "bar" }
+//    }
+//    trait TypeC extends Module {
+//      def baz = T { "baz" }
+//    }
+//    trait TypeAB extends TypeA with TypeB
+//
+//    object typeA extends TypeA
+//    object typeB extends TypeB
+//    object typeC extends TypeC
+//    object typeAB extends TypeAB
+//  }
 }

--- a/main/test/src/mill/util/TestGraphs.scala
+++ b/main/test/src/mill/util/TestGraphs.scala
@@ -567,21 +567,29 @@ object TestGraphs {
     object typeAB extends TypeAB
   }
 
-//  object TypedCrossModules extends TestUtil.BaseModule {
-//    trait TypeA extends Module {
-//      def foo = T { "foo" }
-//    }
-//    trait TypeB extends Module {
-//      def bar = T { "bar" }
-//    }
-//    trait TypeC extends Module {
-//      def baz = T { "baz" }
-//    }
-//    trait TypeAB extends TypeA with TypeB
-//
-//    object typeA extends TypeA
-//    object typeB extends TypeB
-//    object typeC extends TypeC
-//    object typeAB extends TypeAB
-//  }
+  object TypedCrossModules extends TestUtil.BaseModule {
+    trait TypeA extends Cross.Module[String] {
+      def foo = T { crossValue }
+    }
+
+    trait TypeB extends Module {
+      def bar = T { "bar" }
+    }
+
+    trait TypeAB extends TypeA with TypeB
+
+    object typeA extends Cross[TypeA]("a", "b")
+    object typeAB extends Cross[TypeAB]("a", "b")
+
+    object inner extends Module {
+      object typeA extends Cross[TypeA]("a", "b")
+      object typeAB extends Cross[TypeAB]("a", "b")
+    }
+
+    trait NestedAB extends TypeAB {
+      object typeAB extends Cross[TypeAB]("a", "b")
+    }
+    object nestedAB extends Cross[NestedAB]("a", "b")
+  }
+
 }


### PR DESCRIPTION
This PR add support for new selector pattern `_:Type`.

In addition to `_` and `__`, which select arbitrary segments, the `_:MyType` and `__:MyType` patterns can select modules of the specified type.

The type is matched by it's name and optionally by it's enclosing types and packages, separated by a `.` sign. Since this is also used to separate target path segments, a type selector segment containing a `.` needs to be enclosed in parenthesis. A full qualified type can be enforced with the `_root_` package. 

Example: Find all test jars

```sh
> mill resolve __:TestModule.jar
> mill resolve "(__:scalalib.TestModule).jar"
> mill resolve "(__:mill.scalalib.TestModule).jar"
> mill resolve "(__:_root_.mill.scalalib.TestModule).jar"
```

If a `^` or `!` is preceding the type pattern, it only matches segments not an instance of that specified type. Please note that in some shells like `bash`, you need to mask the `!` character.

Example: Find all jars not in test modules

```sh
> mill resolve __:^TestModule.jar
```

You can also provide more than one type pattern, separated with `:`. 

Example: Find all `JavaModule`s which are not `ScalaModule`s or `TestModule`s:

```sh
> mill resolve "__:JavaModule:^ScalaModule:^TestModule.jar"
```

Remarks:

* Kudos to @lihaoyi who refactored the resolver in https://github.com/com-lihaoyi/mill/pull/2511 and made this PR possible. I tried to implement it multiple times before, and ever got bitten by the old gnarly resolver code.
* It's currently not possible to match task/target types. It might be possible, but due to `Task` being a parametrized type, it might not be as easy to implement and use.

Fix https://github.com/com-lihaoyi/mill/issues/1550

Pull request: https://github.com/com-lihaoyi/mill/pull/2997