### PR TITLE
Extend documentation for contrib.BuildInfo

### DIFF
--- a/contrib/buildinfo/readme.adoc
+++ b/contrib/buildinfo/readme.adoc
@@ -16,10 +16,23 @@ import mill.contrib.buildinfo.BuildInfo
 
 object project extends BuildInfo {
   val name = "project-name"
+  val buildInfoPackageName = "com.organization"
   def buildInfoMembers = Seq(
     BuildInfo.Value("name", name),
     BuildInfo.Value("scalaVersion", scalaVersion()),
   )
+}
+----
+
+.`Main.scala`
+[source,scala]
+----
+import com.organization.BuildInfo
+
+@main
+def main = {
+  println(BuildInfo.name)
+  println(BuildInfo.scalaVersion)
 }
 ----
 


### PR DESCRIPTION
Hi there,

I stumbled upon a few missing pieces when setting up `BuildInfo` for my project, so I added them here:

- `buildInfoPackageName` is required and not optional
- added a little usage example