### PR TITLE
Fix bsp compile classpath inconsistencies

### DIFF
--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -301,7 +301,8 @@ trait JavaModule
   def bspTransitiveCompileClasspath: T[Agg[UnresolvedPath]] = T {
     T.traverse(transitiveModuleCompileModuleDeps)(m =>
       T.task {
-        m.bspCompileClasspath() ++ Agg(m.bspCompileClassesPath())
+        m.localCompileClasspath().map(p => UnresolvedPath.ResolvedPath(p.path)) ++
+          Agg(m.bspCompileClassesPath())
       }
     )()
       .flatten
@@ -468,9 +469,9 @@ trait JavaModule
   // Keep in sync with [[compileClasspath]]
   @internal
   def bspCompileClasspath: T[Agg[UnresolvedPath]] = T {
-    bspTransitiveCompileClasspath() ++
-      (localCompileClasspath() ++ resolvedIvyDeps())
-        .map(p => UnresolvedPath.ResolvedPath(p.path))
+    resolvedIvyDeps().map(p => UnresolvedPath.ResolvedPath(p.path)) ++
+      bspTransitiveCompileClasspath() ++
+      localCompileClasspath().map(p => UnresolvedPath.ResolvedPath(p.path))
   }
 
   /**


### PR DESCRIPTION
Resolve some inconsistencies between the BSP and non-BSP versions of `compileClasspath` and `transitiveCompileClasspath`.

The `bspTransitiveCompileClasspath` contained resolved ivy dependencies, which resulted in too many and potentially conflicting jars ending up in the same classpath.

Fix https://github.com/com-lihaoyi/mill/issues/3013
