### PR TITLE
Make BSP task processing more resilient

### DIFF
--- a/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -670,11 +670,15 @@ private class MillBuildServer(
             case (_, TaskResult(res: Result.Failing[_], _)) => res
           }
 
-          if (failures.nonEmpty) {
-            // somehow report failures to the build client
-            val msg = s"Request '$prefix' failed for ${id.getUri}: ${failures.mkString(", ")}"
+          def logError(errorMsg: String) = {
+            val msg = s"Request '$prefix' failed for ${id.getUri}: ${errorMsg}"
             debug(msg)
             client.onBuildLogMessage(new LogMessageParams(MessageType.ERROR, msg))
+          }
+
+          if (failures.nonEmpty) {
+            // somehow report failures to the build client
+            logError(failures.mkString(", "))
           }
 
           // only the successful results
@@ -685,9 +689,7 @@ private class MillBuildServer(
                 Seq(f(ev, state, id, state.bspModulesById(id)._1, v))
               } catch {
                 case NonFatal(e) =>
-                  val msg = s"Request '$prefix' failed for ${id.getUri}: ${failures.mkString(", ")}"
-                  debug(msg)
-                  client.onBuildLogMessage(new LogMessageParams(MessageType.ERROR, msg))
+                  logError(e.toString)
                   Seq()
               }
             }

--- a/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -77,7 +77,7 @@ import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}
 import Utils.sanitizeUri
 import mill.bsp.BspServerResult
-import mill.eval.Evaluator.{Results, TaskResult}
+import mill.eval.Evaluator.TaskResult
 
 import scala.util.chaining.scalaUtilChainingOps
 import scala.util.control.NonFatal

--- a/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -677,7 +677,6 @@ private class MillBuildServer(
           }
 
           if (failures.nonEmpty) {
-            // somehow report failures to the build client
             logError(failures.mkString(", "))
           }
 

--- a/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -26,6 +26,8 @@ import ch.epfl.scala.bsp4j.{
   InitializeBuildResult,
   InverseSourcesParams,
   InverseSourcesResult,
+  LogMessageParams,
+  MessageType,
   OutputPathItem,
   OutputPathItemKind,
   OutputPathsItem,
@@ -75,9 +77,10 @@ import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}
 import Utils.sanitizeUri
 import mill.bsp.BspServerResult
-import mill.eval.Evaluator.TaskResult
+import mill.eval.Evaluator.{Results, TaskResult}
 
 import scala.util.chaining.scalaUtilChainingOps
+import scala.util.control.NonFatal
 private class MillBuildServer(
     bspVersion: String,
     serverVersion: String,
@@ -649,7 +652,8 @@ private class MillBuildServer(
       targetIds: State => Seq[BuildTargetIdentifier],
       tasks: BspModule => Task[W]
   )(f: (Evaluator, State, BuildTargetIdentifier, BspModule, W) => T)(agg: java.util.List[T] => V)
-      : CompletableFuture[V] =
+      : CompletableFuture[V] = {
+    val prefix = hint.split(" ").head
     completable(hint) { state: State =>
       val ids = targetIds(state)
       val tasksSeq = ids.map { id =>
@@ -658,14 +662,40 @@ private class MillBuildServer(
       }
 
       val evaluated = tasksSeq
+        // group by evaluator (different root module)
         .groupMap(_._2)(_._1)
         .map { case ((ev, id), ts) =>
-          ev.evalOrThrow()(ts)
-            .map { v => f(ev, state, id, state.bspModulesById(id)._1, v) }
+          val results = ev.evaluate(ts)
+          val failures = results.results.collect {
+            case (_, TaskResult(res: Result.Failing[_], _)) => res
+          }
+
+          if (failures.nonEmpty) {
+            // somehow report failures to the build client
+            val msg = s"Request '$prefix' failed for ${id.getUri}: ${failures.mkString(", ")}"
+            debug(msg)
+            client.onBuildLogMessage(new LogMessageParams(MessageType.ERROR, msg))
+          }
+
+          // only the successful results
+          val successes = results.values.map(_.value).asInstanceOf[Seq[W]]
+          successes
+            .flatMap { v =>
+              try {
+                Seq(f(ev, state, id, state.bspModulesById(id)._1, v))
+              } catch {
+                case NonFatal(e) =>
+                  val msg = s"Request '$prefix' failed for ${id.getUri}: ${failures.mkString(", ")}"
+                  debug(msg)
+                  client.onBuildLogMessage(new LogMessageParams(MessageType.ERROR, msg))
+                  Seq()
+              }
+            }
         }
 
       agg(evaluated.flatten.toSeq.asJava)
     }
+  }
 
   /**
    * Given a function that take input of type T and return output of type V,


### PR DESCRIPTION
Since BSP clients can handle incomplete result lists (e.g. they request a task on 5 build targets, but only receive the results for 3 of them), we just don't include the failed targets in the final request result. This is also what sbt and Bloop does to handle failures.

In addition, we send a log message to the server, so the failure doesn't go unnoticed.

Fix: https://github.com/com-lihaoyi/mill/issues/3011

Pull request: https://github.com/com-lihaoyi/mill/pull/3022