### PR TITLE
Force transitive dependency commons-compress to 1.26.0 or newer

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -186,7 +186,8 @@ object Deps {
     ivy"com.google.code.gson:gson:2.10.1",
     ivy"com.google.protobuf:protobuf-java:3.25.3",
     ivy"com.google.guava:guava:33.0.0-jre",
-    ivy"org.yaml:snakeyaml:2.2"
+    ivy"org.yaml:snakeyaml:2.2",
+    ivy"org.apache.commons:commons-compress:1.26.0"
   )
 
   /** Used in tests. */

--- a/build.sc
+++ b/build.sc
@@ -187,7 +187,7 @@ object Deps {
     ivy"com.google.protobuf:protobuf-java:3.25.3",
     ivy"com.google.guava:guava:33.0.0-jre",
     ivy"org.yaml:snakeyaml:2.2",
-    ivy"org.apache.commons:commons-compress:1.26.0"
+    ivy"org.apache.commons:commons-compress:[1.26.0,)"
   )
 
   /** Used in tests. */


### PR DESCRIPTION
This is to fix security issue CVE-2024-25710.

Supersedes https://github.com/com-lihaoyi/mill/pull/3048
