### PR TITLE
Update example `build.sc` with current library versions

### DIFF
--- a/example/basic/1-simple-scala/build.sc
+++ b/example/basic/1-simple-scala/build.sc
@@ -3,8 +3,8 @@ import mill._, scalalib._
 object foo extends RootModule with ScalaModule {
   def scalaVersion = "2.13.11"
   def ivyDeps = Agg(
-    ivy"com.lihaoyi::scalatags:0.8.2",
-    ivy"com.lihaoyi::mainargs:0.4.0"
+    ivy"com.lihaoyi::scalatags:0.12.0",
+    ivy"com.lihaoyi::mainargs:0.6.2"
   )
 
   object test extends ScalaTests {


### PR DESCRIPTION
This avoids the build error:

```
1 targets failed
resolvedIvyDeps 
Resolution failed for 1 modules:
--------------------------------------------
  com.lihaoyi:scalatags_3:0.8.2 
	not found: /home/cosmin/.ivy2/local/com.lihaoyi/scalatags_3/0.8.2/ivys/ivy.xml
	not found: https://repo1.maven.org/maven2/com/lihaoyi/scalatags_3/0.8.2/scalatags_3-0.8.2.pom

--------------------------------------------

For additional information on library dependencies, see the docs at
https://mill-build.com/mill/Library_Dependencies.html
```