### PR TITLE
Add 2.13.13 and 2.12.19 to supported bridges list

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -252,6 +252,7 @@ val bridgeScalaVersions = Seq(
   "2.12.16",
   "2.12.17",
   "2.12.18",
+  "2.12.19",
   /*"2.13.0", "2.13.1", "2.13.2",*/ "2.13.3",
   "2.13.4",
   "2.13.5",
@@ -261,7 +262,8 @@ val bridgeScalaVersions = Seq(
   "2.13.9",
   "2.13.10",
   "2.13.11",
-  "2.13.12"
+  "2.13.12",
+  "2.13.13"
 )
 
 // We limit the number of compiler bridges to compile and publish for local


### PR DESCRIPTION
The bridges are already on Maven Central.

Pull Request: https://github.com/com-lihaoyi/mill/pull/3066