### PR TITLE
Don't include the compilation output in the compile classpath

### DIFF
--- a/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
+++ b/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
@@ -489,7 +489,7 @@ class ZincWorkerImpl(
 
     // Fix jdk classes marked as binary dependencies, see https://github.com/com-lihaoyi/mill/pull/1904
     val converter = MappedFileConverter.empty
-    val classpath = (compileClasspath.iterator ++ Some(classesDir))
+    val classpath = (compileClasspath.iterator) // ++ Some(classesDir))
       .map(path => converter.toVirtualFile(path.toNIO))
       .toArray
     val virtualSources = sources.iterator


### PR DESCRIPTION
Fix https://github.com/com-lihaoyi/mill/issues/3068

But we need to make sure this is the right thing to do. We include the classes dir in the classpath since very early.
