### PR TITLE
Use semanticdb files directly in ScalaModule

### DIFF
--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -667,8 +667,6 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
         reportCachedProblems = zincReportCachedProblems(),
         incrementalCompilation = zincIncrementalCompilation()
       )
-      .map(r =>
-        SemanticDbJavaModule.copySemanticdbFiles(r.classes.path, T.workspace, T.dest / "data")
-      )
+      .map(_.classes)
   }
 }


### PR DESCRIPTION
A copy mechanism was introduced in https://github.com/com-lihaoyi/mill/pull/2227 because of a bug in semanticdb-java
But we don't need to use it in ScalaModule as well if the Scala semanticdb works correctly.