### PR TITLE
BSP: Handle new `JvmCompileClasspath` request

### DIFF
--- a/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -138,13 +138,13 @@ private class MillBuildServer(
       capabilities.setDependencyModulesProvider(true)
       capabilities.setDependencySourcesProvider(true)
       capabilities.setInverseSourcesProvider(true)
+      capabilities.setJvmCompileClasspathProvider(enableJvmCompileClasspathProvider)
       capabilities.setJvmRunEnvironmentProvider(true)
       capabilities.setJvmTestEnvironmentProvider(true)
       capabilities.setOutputPathsProvider(true)
       capabilities.setResourcesProvider(true)
       capabilities.setRunProvider(new RunProvider(supportedLangs))
       capabilities.setTestProvider(new TestProvider(supportedLangs))
-      capabilities.setJvmCompileClasspathProvider(enableJvmCompileClasspathProvider)
 
       // IJ is currently not able to handle files as source paths, only dirs
       // TODO: Rumor has it, that newer version may handle it, so we need to better detect that

--- a/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -100,6 +100,9 @@ private class MillBuildServer(
   protected var clientWantsSemanticDb = false
   protected var clientIsIntelliJ = false
 
+  /** `true` when client and server support the `JvmCompileClasspathProvider`` request. */
+  protected var enableJvmCompileClasspathProvider = false
+
   private[this] var statePromise: Promise[State] = Promise[State]()
 
   def updateEvaluator(evaluatorsOpt: Option[Seq[Evaluator]]): Unit = {
@@ -120,6 +123,9 @@ private class MillBuildServer(
       : CompletableFuture[InitializeBuildResult] =
     completableNoState(s"buildInitialize ${request}", checkInitialized = false) {
 
+      val clientCapabilities = request.getCapabilities()
+      enableJvmCompileClasspathProvider = clientCapabilities.getJvmCompileClasspathReceiver
+
       // TODO: scan BspModules and infer their capabilities
 
       val supportedLangs = Seq("java", "scala").asJava
@@ -138,6 +144,7 @@ private class MillBuildServer(
       capabilities.setResourcesProvider(true)
       capabilities.setRunProvider(new RunProvider(supportedLangs))
       capabilities.setTestProvider(new TestProvider(supportedLangs))
+      capabilities.setJvmCompileClasspathProvider(enableJvmCompileClasspathProvider)
 
       // IJ is currently not able to handle files as source paths, only dirs
       // TODO: Rumor has it, that newer version may handle it, so we need to better detect that

--- a/bsp/worker/src/mill/bsp/worker/MillScalaBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillScalaBuildServer.scala
@@ -33,7 +33,6 @@ private trait MillScalaBuildServer extends ScalaBuildServer { this: MillBuildSer
       targetIds = _ => p.getTargets.asScala.toSeq,
       tasks = {
         case m: JavaModule =>
-
           val scalacOptionsTask = m match {
             case m: ScalaModule => m.allScalacOptions
             case _ => T.task { Seq.empty[String] }

--- a/build.sc
+++ b/build.sc
@@ -184,7 +184,7 @@ object Deps {
   val windowsAnsi = ivy"io.github.alexarchambault.windows-ansi:windows-ansi:0.0.5"
   val zinc = ivy"org.scala-sbt::zinc:1.9.6"
   // keep in sync with doc/antora/antory.yml
-  val bsp4j = ivy"ch.epfl.scala:bsp4j:2.2.0-M1"
+  val bsp4j = ivy"ch.epfl.scala:bsp4j:2.2.0-M2"
   val fansi = ivy"com.lihaoyi::fansi:0.4.0"
   val jarjarabrams = ivy"com.eed3si9n.jarjarabrams::jarjar-abrams-core:1.14.0"
   val requests = ivy"com.lihaoyi::requests:0.8.0"


### PR DESCRIPTION
Implemented the new `JmvCompileClasspath` request as part of the JVM extension.

If the client reports to support the `JvmCompileClasspathReceiver` capability,
we also return an empty classpath from the `ScalacOptions` request.

Update bsp4j from 2.2.0-M1 to 2.2.0-M2

See:
* https://github.com/build-server-protocol/build-server-protocol/pull/650
* https://github.com/build-server-protocol/build-server-protocol/pull/656
* https://github.com/build-server-protocol/build-server-protocol/pull/657
