### PR TITLE
Add support for Cobertura XML report task to help integration

### DIFF
--- a/contrib/scoverage/api/src/mill/contrib/scoverage/api/ScoverageReportWorkerApi.scala
+++ b/contrib/scoverage/api/src/mill/contrib/scoverage/api/ScoverageReportWorkerApi.scala
@@ -38,6 +38,7 @@ object ScoverageReportWorkerApi {
   object ReportType {
     final case object Html extends FileReportType { val folderName: String = "htmlReport" }
     final case object Xml extends FileReportType { val folderName: String = "xmlReport" }
+    final case object XmlCobertura extends FileReportType { val folderName: String = "xmlCoberturaReport" }
     final case object Console extends ReportType
   }
 }

--- a/contrib/scoverage/api/src/mill/contrib/scoverage/api/ScoverageReportWorkerApi.scala
+++ b/contrib/scoverage/api/src/mill/contrib/scoverage/api/ScoverageReportWorkerApi.scala
@@ -38,7 +38,9 @@ object ScoverageReportWorkerApi {
   object ReportType {
     final case object Html extends FileReportType { val folderName: String = "htmlReport" }
     final case object Xml extends FileReportType { val folderName: String = "xmlReport" }
-    final case object XmlCobertura extends FileReportType { val folderName: String = "xmlCoberturaReport" }
+    final case object XmlCobertura extends FileReportType {
+      val folderName: String = "xmlCoberturaReport"
+    }
     final case object Console extends ReportType
   }
 }

--- a/contrib/scoverage/readme.adoc
+++ b/contrib/scoverage/readme.adoc
@@ -38,7 +38,7 @@ mill foo.scoverage.compile                 # compiles your module with test inst
 mill foo.test                              # tests your project and collects metrics on code coverage
 mill foo.scoverage.htmlReport              # uses the metrics collected by a previous test run to generate a coverage report in html format
 mill foo.scoverage.xmlReport               # uses the metrics collected by a previous test run to generate a coverage report in xml format
-mill foo.scoverage..xmlCoberturaReportAll  # uses the metrics collected by a previous test run to generate a coverage report in Cobertura's xml format
+mill foo.scoverage.xmlCoberturaReportAll   # uses the metrics collected by a previous test run to generate a coverage report in Cobertura's xml format
 ----
 
 The measurement data is by default available at `out/foo/scoverage/data/dest`,

--- a/contrib/scoverage/readme.adoc
+++ b/contrib/scoverage/readme.adoc
@@ -64,10 +64,11 @@ This provides you with various reporting functions:
 
 [source,bash]
 ----
-mill __.test                     # run tests for all modules
-mill scoverage.htmlReportAll     # generates report in html format for all modules
-mill scoverage.xmlReportAll      # generates report in xml format for all modules
-mill scoverage.consoleReportAll  # reports to the console for all modules
+mill __.test                          # run tests for all modules
+mill scoverage.htmlReportAll          # generates report in html format for all modules
+mill scoverage.xmlReportAll           # generates report in xml format for all modules
+mill scoverage.xmlCoberturaReportAll  # generates report in Cobertura's xml format for all modules
+mill scoverage.consoleReportAll       # reports to the console for all modules
 ----
 
 The aggregated report will be available at either `out/scoverage/htmlReportAll.dest/`

--- a/contrib/scoverage/readme.adoc
+++ b/contrib/scoverage/readme.adoc
@@ -32,12 +32,13 @@ modules introduce a few new tasks and changes the behavior of an existing one.
 
 [source,bash]
 ----
-mill foo.scoverage.compile      # compiles your module with test instrumentation
-                                # (you don't have to run this manually, running the test task will force its invocation)
+mill foo.scoverage.compile                 # compiles your module with test instrumentation
+                                           # (you don't have to run this manually, running the test task will force its invocation)
 
-mill foo.test                   # tests your project and collects metrics on code coverage
-mill foo.scoverage.htmlReport   # uses the metrics collected by a previous test run to generate a coverage report in html format
-mill foo.scoverage.xmlReport    # uses the metrics collected by a previous test run to generate a coverage report in xml format
+mill foo.test                              # tests your project and collects metrics on code coverage
+mill foo.scoverage.htmlReport              # uses the metrics collected by a previous test run to generate a coverage report in html format
+mill foo.scoverage.xmlReport               # uses the metrics collected by a previous test run to generate a coverage report in xml format
+mill foo.scoverage..xmlCoberturaReportAll  # uses the metrics collected by a previous test run to generate a coverage report in in Cobertura's xml format
 ----
 
 The measurement data is by default available at `out/foo/scoverage/data/dest`,

--- a/contrib/scoverage/readme.adoc
+++ b/contrib/scoverage/readme.adoc
@@ -69,7 +69,7 @@ mill __.test                                 # run tests for all modules
 mill scoverage.htmlReportAll                 # generates report in html format for all modules
 mill scoverage.xmlReportAll                  # generates report in xml format for all modules
 mill scoverage.xmlCoberturaReportAll         # generates report in Cobertura's xml format for all modules
-mill scoverage.ll scoverage.consoleReportAll # reports to the console for all modules
+mill scoverage.consoleReportAll              # reports to the console for all modules
 ----
 
 The aggregated report will be available at either `out/scoverage/htmlReportAll.dest/`

--- a/contrib/scoverage/readme.adoc
+++ b/contrib/scoverage/readme.adoc
@@ -38,7 +38,7 @@ mill foo.scoverage.compile                 # compiles your module with test inst
 mill foo.test                              # tests your project and collects metrics on code coverage
 mill foo.scoverage.htmlReport              # uses the metrics collected by a previous test run to generate a coverage report in html format
 mill foo.scoverage.xmlReport               # uses the metrics collected by a previous test run to generate a coverage report in xml format
-mill foo.scoverage..xmlCoberturaReportAll  # uses the metrics collected by a previous test run to generate a coverage report in in Cobertura's xml format
+mill foo.scoverage..xmlCoberturaReportAll  # uses the metrics collected by a previous test run to generate a coverage report in Cobertura's xml format
 ----
 
 The measurement data is by default available at `out/foo/scoverage/data/dest`,
@@ -65,11 +65,11 @@ This provides you with various reporting functions:
 
 [source,bash]
 ----
-mill __.test                          # run tests for all modules
-mill scoverage.htmlReportAll          # generates report in html format for all modules
-mill scoverage.xmlReportAll           # generates report in xml format for all modules
-mill scoverage.xmlCoberturaReportAll  # generates report in Cobertura's xml format for all modules
-mill scoverage.consoleReportAll       # reports to the console for all modules
+mill __.test                                 # run tests for all modules
+mill scoverage.htmlReportAll                 # generates report in html format for all modules
+mill scoverage.xmlReportAll                  # generates report in xml format for all modules
+mill scoverage.xmlCoberturaReportAll         # generates report in Cobertura's xml format for all modules
+mill scoverage.ll scoverage.consoleReportAll # reports to the console for all modules
 ----
 
 The aggregated report will be available at either `out/scoverage/htmlReportAll.dest/`

--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
@@ -222,6 +222,7 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
 
     def htmlReport(): Command[Unit] = T.command { doReport(ReportType.Html) }
     def xmlReport(): Command[Unit] = T.command { doReport(ReportType.Xml) }
+    def xmlCoberturaReport(): Command[Unit] = T.command { doReport(ReportType.XmlCobertura) }
     def consoleReport(): Command[Unit] = T.command { doReport(ReportType.Console) }
 
     override def skipIdea: Boolean = true // being a synthetic module, no need to appear in the IDE

--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageReport.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageReport.scala
@@ -65,6 +65,15 @@ trait ScoverageReport extends Module {
     reportTask(evaluator, ReportType.Xml, sources, dataTargets)()
   }
 
+  /** Generates report in Cobertura's xml format for all modules */
+  def xmlCoberturaReportAll(
+                    evaluator: Evaluator,
+                    sources: String = "__.allSources",
+                    dataTargets: String = "__.scoverage.data"
+                  ): Command[PathRef] = T.command {
+    reportTask(evaluator, ReportType.XmlCobertura, sources, dataTargets)()
+  }
+
   /** Reports to the console for all modules */
   def consoleReportAll(
       evaluator: Evaluator,

--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageReport.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageReport.scala
@@ -27,6 +27,7 @@ import os.Path
  * - mill __.test                     # run tests for all modules
  * - mill scoverage.htmlReportAll     # generates report in html format for all modules
  * - mill scoverage.xmlReportAll      # generates report in xml format for all modules
+ * - mill scoverage.xmlCoberturaReportAll  # generates report in Cobertura's xml format for all modules
  * - mill scoverage.consoleReportAll  # reports to the console for all modules
  *
  * The aggregated report will be available at either `out/scoverage/htmlReportAll.dest/`
@@ -67,10 +68,10 @@ trait ScoverageReport extends Module {
 
   /** Generates report in Cobertura's xml format for all modules */
   def xmlCoberturaReportAll(
-                    evaluator: Evaluator,
-                    sources: String = "__.allSources",
-                    dataTargets: String = "__.scoverage.data"
-                  ): Command[PathRef] = T.command {
+      evaluator: Evaluator,
+      sources: String = "__.allSources",
+      dataTargets: String = "__.scoverage.data"
+  ): Command[PathRef] = T.command {
     reportTask(evaluator, ReportType.XmlCobertura, sources, dataTargets)()
   }
 

--- a/contrib/scoverage/test/src/mill/contrib/scoverage/HelloWorldTests.scala
+++ b/contrib/scoverage/test/src/mill/contrib/scoverage/HelloWorldTests.scala
@@ -180,6 +180,22 @@ trait HelloWorldTests extends utest.TestSuite {
               ""
             }
           }
+          "xmlCoberturaReport" - workspaceTest(HelloWorld) { eval =>
+            val Right((_, _)) = eval.apply(HelloWorld.core.test.compile)
+            val res = eval.apply(HelloWorld.core.scoverage.xmlCoberturaReport())
+            if (
+              res.isLeft && testScalaVersion.startsWith("3.2") && testScoverageVersion.startsWith(
+                "2."
+              )
+            ) {
+              s"""Disabled for Scoverage ${testScoverageVersion} on Scala ${testScalaVersion}, as it fails with "No source root found" message"""
+            } else {
+              assert(res.isRight)
+              val Right((_, evalCount)) = res
+              assert(evalCount > 0)
+              ""
+            }
+          }
           "console" - workspaceTest(HelloWorld) { eval =>
             val Right((_, _)) = eval.apply(HelloWorld.core.test.compile)
             val Right((_, evalCount)) = eval.apply(HelloWorld.core.scoverage.consoleReport())

--- a/contrib/scoverage/worker/src/mill/contrib/scoverage/worker/ScoverageReportWorkerImpl.scala
+++ b/contrib/scoverage/worker/src/mill/contrib/scoverage/worker/ScoverageReportWorkerImpl.scala
@@ -1,7 +1,12 @@
 package mill.contrib.scoverage.worker
 
 import mill.contrib.scoverage.api.ScoverageReportWorkerApi
-import _root_.scoverage.report.{CoberturaXmlWriter, CoverageAggregator, ScoverageHtmlWriter, ScoverageXmlWriter}
+import _root_.scoverage.report.{
+  CoberturaXmlWriter,
+  CoverageAggregator,
+  ScoverageHtmlWriter,
+  ScoverageXmlWriter
+}
 import mill.api.Ctx
 import mill.contrib.scoverage.api.ScoverageReportWorkerApi.ReportType
 

--- a/contrib/scoverage/worker/src/mill/contrib/scoverage/worker/ScoverageReportWorkerImpl.scala
+++ b/contrib/scoverage/worker/src/mill/contrib/scoverage/worker/ScoverageReportWorkerImpl.scala
@@ -1,7 +1,7 @@
 package mill.contrib.scoverage.worker
 
 import mill.contrib.scoverage.api.ScoverageReportWorkerApi
-import _root_.scoverage.report.{CoverageAggregator, ScoverageHtmlWriter, ScoverageXmlWriter}
+import _root_.scoverage.report.{CoberturaXmlWriter, CoverageAggregator, ScoverageHtmlWriter, ScoverageXmlWriter}
 import mill.api.Ctx
 import mill.contrib.scoverage.api.ScoverageReportWorkerApi.ReportType
 
@@ -30,6 +30,9 @@ class ScoverageReportWorkerImpl extends ScoverageReportWorkerApi {
                 .write(coverage)
             case ReportType.Xml =>
               new ScoverageXmlWriter(sourceFolders, folder.toIO, false)
+                .write(coverage)
+            case ReportType.XmlCobertura =>
+              new CoberturaXmlWriter(sourceFolders, folder.toIO)
                 .write(coverage)
             case ReportType.Console =>
               ctx.log.info(s"Statement coverage.: ${coverage.statementCoverageFormatted}%")

--- a/contrib/scoverage/worker2/src/mill/contrib/scoverage/worker/ScoverageReportWorkerImpl.scala
+++ b/contrib/scoverage/worker2/src/mill/contrib/scoverage/worker/ScoverageReportWorkerImpl.scala
@@ -1,7 +1,12 @@
 package mill.contrib.scoverage.worker
 
 import mill.contrib.scoverage.api.ScoverageReportWorkerApi
-import _root_.scoverage.reporter.{CoberturaXmlWriter, CoverageAggregator, ScoverageHtmlWriter, ScoverageXmlWriter}
+import _root_.scoverage.reporter.{
+  CoberturaXmlWriter,
+  CoverageAggregator,
+  ScoverageHtmlWriter,
+  ScoverageXmlWriter
+}
 import mill.api.Ctx
 import mill.contrib.scoverage.api.ScoverageReportWorkerApi.ReportType
 

--- a/contrib/scoverage/worker2/src/mill/contrib/scoverage/worker/ScoverageReportWorkerImpl.scala
+++ b/contrib/scoverage/worker2/src/mill/contrib/scoverage/worker/ScoverageReportWorkerImpl.scala
@@ -1,7 +1,7 @@
 package mill.contrib.scoverage.worker
 
 import mill.contrib.scoverage.api.ScoverageReportWorkerApi
-import _root_.scoverage.reporter.{CoverageAggregator, ScoverageHtmlWriter, ScoverageXmlWriter}
+import _root_.scoverage.reporter.{CoberturaXmlWriter, CoverageAggregator, ScoverageHtmlWriter, ScoverageXmlWriter}
 import mill.api.Ctx
 import mill.contrib.scoverage.api.ScoverageReportWorkerApi.ReportType
 
@@ -29,6 +29,9 @@ class ScoverageReportWorkerImpl extends ScoverageReportWorkerApi {
                 .write(coverage)
             case ReportType.Xml =>
               new ScoverageXmlWriter(sourceFolders, folder.toIO, false, None)
+                .write(coverage)
+            case ReportType.XmlCobertura =>
+              new CoberturaXmlWriter(sourceFolders, folder.toIO, None)
                 .write(coverage)
             case ReportType.Console =>
               ctx.log.info(s"Statement coverage.: ${coverage.statementCoverageFormatted}%")


### PR DESCRIPTION
To help the integration of Mill based projects in some CI/CD platforms like GitLab you have to support Cobertura XML-based coverage report.
This PR adds a new `ReportType` and its corresponding action to produce Cobertura XML-based coverage report.