### PR TITLE
Scoverage inner module defaults to `skipIdea = outer.skipIdea`

### DIFF
--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
@@ -225,7 +225,7 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
     def xmlCoberturaReport(): Command[Unit] = T.command { doReport(ReportType.XmlCobertura) }
     def consoleReport(): Command[Unit] = T.command { doReport(ReportType.Console) }
 
-    override def skipIdea: Boolean = true // being a synthetic module, no need to appear in the IDE
+    override def skipIdea = outer.skipIdea
   }
 
   trait ScoverageTests extends ScalaTests {


### PR DESCRIPTION
This reverts PR https://github.com/com-lihaoyi/mill/pull/2989

Fix https://github.com/com-lihaoyi/mill/issues/3097