### PR TITLE
Add support for JUnit legacy XML reports

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -871,6 +871,11 @@ object contrib extends Module {
     def testModuleDeps = super.testModuleDeps ++ Seq(scalalib)
   }
 
+  object junit extends ContribModule {
+    override def compileModuleDeps = super.compileModuleDeps ++ Seq(scalalib)
+    override def testModuleDeps = super.testModuleDeps ++ Seq(scalalib)
+  }
+
   object scoverage extends ContribModule {
     object api extends MillPublishScalaModule {
       def compileModuleDeps = Seq(main.api)

--- a/contrib/junit/readme.adoc
+++ b/contrib/junit/readme.adoc
@@ -1,0 +1,45 @@
+= JUnit Report
+:page-aliases: Plugin_JUnit_report.adoc
+
+
+This module allows you to generate JUnit legacy XML report for Scala projects:
+https://github.com/testmoapp/junitxml[JUnit XML]. This plugin does not require
+you to run JUnit test. It relies on the intermediate data structure for test
+results provided by Mill.
+
+This plugin aims to allow integration in CI environment that support out of the
+box JUnit legacy XML like GitLab does.
+
+== Multi-module projects
+
+If you're using JUnit report on a project with multiple modules (or even one) then
+an additional module, `JUnitReport`, is available to help aggregate the reports from
+all test execution results.
+
+Simply define a `junit` module at the root of your project as shown:
+
+[source,scala]
+----
+  object junit extends JUnitReport
+----
+
+By default `JUnitReport` collects the test results in the output folder of the
+`testCached` task. If you want to change this behavior you can define a different
+`testDataSources` for example if you want to use the `test` command output.
+
+[source,scala]
+----
+  object junit extends JUnitReport {
+    override def testDataSources = "test"
+  }
+----
+
+This provides you with the following reporting function:
+
+[source,bash]
+----
+mill __.testCached       # run tests for all modules (to produce test execution data)
+mill junit.xmlReportAll  # generates testsuite reports in junit xml legacy format for all modules
+----
+
+The generated reports will be available `out/junit/xmlReportAll.dest/`, one per testsuite.

--- a/contrib/junit/src/mill/contrib/junit/JUnitReport.scala
+++ b/contrib/junit/src/mill/contrib/junit/JUnitReport.scala
@@ -1,0 +1,111 @@
+package mill.contrib.junit
+import mill.api.Logger
+import mill.define.Segment.Label
+import mill.define.{Command, Module, NamedTask, Segment, Segments, Target}
+import mill.eval.{Evaluator, EvaluatorPaths}
+import mill.resolve.{Resolve, SelectMode}
+import mill.scalalib.api.CompilationResult
+import mill.testrunner.TestResult
+import mill.{PathRef, T}
+
+import java.nio.file.Files
+import java.nio.file.attribute.FileTime
+import java.time.Instant
+import scala.xml.XML
+
+/**
+ * Allows the generation of JUnit XML legacy reports across multi-module projects.
+ *
+ * Once tests have been run across all modules, this collects reports from
+ * all modules that contains test data. Simply
+ * define a module that extends [[mill.contrib.junit.JUnitReport]] and
+ * call the "report all" function.
+ *
+ * For example, define the following `junit` module to generate the reports:
+ * {{{
+ * object junit extends JUnitReport
+ * }}}
+ *
+ * By default `JUnitReport` collects the test results in the output folder of the
+ * `testCached` task. If you want to change this behavior you can define a different
+ * `testDataSources` for example if you want to use the `test` command output.
+ * {{{
+ * object junit extends JUnitReport {
+ *   override def testDataSources = "test"
+ * }
+ * }}}
+ *
+ * This provides you with the following reporting function:
+ *
+ * - mill __.testCached       # run tests for all modules
+ * - mill junit.xmlReportAll  # generates testsuite reports in junit xml legacy format for all modules
+ *
+ * The aggregated report will be available at either `out/scoverage/htmlReportAll.dest/`
+ * for html reports or `out/scoverage/xmlReportAll.dest/` for xml reports.
+ */
+trait JUnitReport extends Module {
+
+  def testDataSources: String = "testCached"
+
+  def xmlReportAll(
+      evaluator: Evaluator
+  ): Command[PathRef] = Target.command {
+    val dataTasks = Resolve.Tasks.resolve(
+      evaluator.rootModule,
+      Seq("__.test.compile"),
+      SelectMode.Separated
+    ) match {
+      case Left(err) => throw new Exception(err)
+      case Right(tasks) =>
+        tasks
+          .asInstanceOf[Seq[NamedTask[CompilationResult]]]
+          .map(task =>
+            task.map { _ =>
+              val testTaskSegments: Seq[Segment] =
+                task.ctx.segments.value.dropRight(1).appended(Label(testDataSources))
+              val testPaths =
+                EvaluatorPaths.resolveDestPaths(evaluator.outPath, Segments(testTaskSegments))
+              val testOutputPath = testPaths.dest / "out.json"
+              val testResults = if (os.exists(testOutputPath)) {
+                import upickle.default._
+                val (_, results) = read[(String, Seq[TestResult])](testOutputPath.toNIO)
+                results
+              } else {
+                Seq.empty
+              }
+              TestData(testOutputPath, testResults, Segments(testTaskSegments))
+            }
+          )
+    }
+    T.task {
+      val testsData = T
+        .sequence(dataTasks)()
+        .filter { td =>
+          if (td.result.isEmpty) {
+            T.log.info(s"No test result in ${td.path.toNIO}")
+          }
+          td.result.nonEmpty
+        }
+      testsData.flatMap(asTestSuite).foreach(saveAsXML(T.log, T.dest))
+      PathRef(T.dest)
+    }
+  }
+
+  private def asTestSuite(testData: TestData): Iterable[TestSuite] = {
+    val modified: FileTime = Files.getLastModifiedTime(testData.path.toNIO)
+    val modifiedInstant: Instant = modified.toInstant
+    TestData.asTestSuites(testData, modifiedInstant)
+  }
+
+  private def saveAsXML(log: Logger, outPath: os.Path)(ts: TestSuite): Unit = {
+    val xmlPath = (outPath / s"TEST-${normalizeName(ts.name)}.xml").toNIO
+    log.info(s"Save junit tests XML report: $xmlPath, with ${ts.tests} test(s)")
+    XML.save(
+      xmlPath.toAbsolutePath.toString,
+      ts.asXML,
+      "UTF-8",
+      xmlDecl = true
+    )
+  }
+  private def normalizeName(s: String) = s.replaceAll("""\s+""", "-")
+}

--- a/contrib/junit/src/mill/contrib/junit/Model.scala
+++ b/contrib/junit/src/mill/contrib/junit/Model.scala
@@ -1,0 +1,47 @@
+package mill.contrib.junit
+
+import scala.xml.Elem
+
+sealed trait XMLAdaptable {
+  def asXML: Elem
+}
+case class TestCase(className: String, name: String, time: String, detail: Option[XMLAdaptable])
+    extends XMLAdaptable {
+  override def asXML: Elem = <testcase classname={className} name={name} time={time}>
+    {detail.map(_.asXML).getOrElse {}}
+  </testcase>
+}
+
+case object ErrorDetail extends XMLAdaptable {
+  override def asXML: Elem = <error message="No Exception or message provided"/>
+}
+
+case object FailureDetail extends XMLAdaptable {
+  override def asXML: Elem = <failure message="No Exception or message provided"/>
+}
+
+case object SkippedDetail extends XMLAdaptable {
+  override def asXML: Elem = <skipped/>
+}
+
+case class TestSuite(
+    hostname: String,
+    name: String,
+    tests: Int,
+    errors: Int,
+    failures: Int,
+    skipped: Int,
+    time: String,
+    timestamp: String,
+    testCases: Seq[TestCase]
+) extends XMLAdaptable {
+  override def asXML: Elem =
+    <testsuite hostname={hostname} name={name} tests={tests.toString} errors={
+      errors.toString
+    } failures={failures.toString} skipped={skipped.toString} time={time} timestamp={timestamp}>
+    <properties></properties>
+    {testCases.map(_.asXML)}
+    <system-out><![CDATA[]]></system-out>
+    <system-err><![CDATA[]]></system-err>
+  </testsuite>
+}

--- a/contrib/junit/src/mill/contrib/junit/TestData.scala
+++ b/contrib/junit/src/mill/contrib/junit/TestData.scala
@@ -1,0 +1,63 @@
+package mill.contrib.junit
+
+import mill.define.{Segment, Segments}
+import mill.testrunner.TestResult
+import os.Path
+
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+import java.time.{Instant, LocalDateTime, ZoneId}
+
+case class TestData(path: Path, result: Seq[TestResult], segments: Segments)
+
+object TestData {
+  private val skippedStatus = Set("Skipped", "Ignored", "Pending")
+  private val errorStatus = Set("Error", "Canceled")
+
+  def asTestSuites(testData: TestData, executionTimestamp: Instant): Iterable[TestSuite] = {
+    val timestamp = DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(
+      LocalDateTime.ofInstant(
+        executionTimestamp.truncatedTo(ChronoUnit.SECONDS),
+        ZoneId.systemDefault()
+      )
+    )
+    val maybeCrossVersions = testData.segments.value.filter(_.isInstanceOf[Segment.Cross])
+    val maybeCrossVersion: Option[String] =
+      if (maybeCrossVersions.isEmpty) None else Some(maybeCrossVersions.head.pathSegments.head)
+    testData.result.groupBy(_.fullyQualifiedName).map { case (fqn, testResults) =>
+      def durationAsString(value: Long) = (value / 1000d).toString
+      val testCases = testResults.map { testResult =>
+        val detail = testResult.status match {
+          case "Failure" => Some(FailureDetail)
+          case value if skippedStatus.contains(value) => Some(SkippedDetail)
+          case value if errorStatus.contains(value) =>
+            Some(ErrorDetail)
+          case _ => None
+        }
+        TestCase(
+          testResult.fullyQualifiedName,
+          testResult.selector,
+          durationAsString(testResult.duration),
+          detail
+        )
+      }
+      val nbErrors = testResults.count(r => errorStatus.contains(r.status))
+      val nbFailures = testResults.count(r => r.status == "Failure")
+
+      val nbSkipped = testResults.count(r => skippedStatus.contains(r.status))
+      // approximation as some test are potentially run in parallel
+      val totalDuration = testResults.map(_.duration).sum
+      TestSuite(
+        "localhost",
+        maybeCrossVersion.map(v => s"$fqn-$v").getOrElse(fqn),
+        testResults.size,
+        nbErrors,
+        nbFailures,
+        nbSkipped,
+        durationAsString(totalDuration),
+        timestamp,
+        testCases
+      )
+    }
+  }
+}

--- a/contrib/junit/test/src/mill/contrib/junit/JUnitReportTests.scala
+++ b/contrib/junit/test/src/mill/contrib/junit/JUnitReportTests.scala
@@ -1,0 +1,9 @@
+package mill.contrib.junit
+
+import utest._
+
+object JUnitReportTests extends TestSuite {
+  override def tests: Tests = Tests {
+    test("")
+  }
+}

--- a/contrib/junit/test/src/mill/contrib/junit/ModelTests.scala
+++ b/contrib/junit/test/src/mill/contrib/junit/ModelTests.scala
@@ -1,0 +1,109 @@
+package mill.contrib.junit
+
+import mill.contrib.junit.{TestSuite => TS}
+import utest._
+
+import scala.xml.Elem
+
+object ModelTests extends TestSuite {
+  private def checkElementName(expected: String, adaptable: XMLAdaptable) =
+    expected == adaptable.asXML.nameToString(new StringBuilder()).toString()
+  private def checkAtt(expected: String, adaptable: XMLAdaptable, att: String): Boolean =
+    adaptable.asXML.attributes.get(att).exists(v => expected == v.toString())
+  override def tests: Tests = Tests {
+    test("ErrorDetail") {
+      test("asXML") {
+        assert(checkElementName("error", ErrorDetail))
+      }
+    }
+    test("FailureDetail") {
+      test("asXML") {
+        assert(checkElementName("failure", FailureDetail))
+      }
+    }
+    test("SkippedDetail") {
+      test("asXML") {
+        assert(checkElementName("skipped", SkippedDetail))
+      }
+    }
+    test("TestCase") {
+      test("asXML without details") {
+        val sut = TestCase("mill.test", "test-case", "123", None)
+        assert(
+          checkElementName("testcase", sut),
+          checkAtt("mill.test", sut, "classname"),
+          checkAtt("test-case", sut, "name"),
+          checkAtt("123", sut, "time"),
+          !sut.asXML.child.exists(_.isInstanceOf[Elem])
+        )
+      }
+      test("asXML with details") {
+        val sut = TestCase("mill.test.Skip", "test-case-skip", "42", Some(SkippedDetail))
+        assert(
+          checkElementName("testcase", sut),
+          checkAtt("mill.test.Skip", sut, "classname"),
+          checkAtt("test-case-skip", sut, "name"),
+          checkAtt("42", sut, "time"),
+          sut.asXML.child.count(_.isInstanceOf[Elem]) == 1
+        )
+      }
+    }
+    test("TestSuite") {
+      test("asXML without testcases") {
+        val sut = TS(
+          "localhost",
+          "test-suite",
+          42,
+          2,
+          4,
+          24,
+          "0.42s",
+          "15:00",
+          Seq.empty
+        )
+
+        assert(
+          checkElementName("testsuite", sut),
+          checkAtt("localhost", sut, "hostname"),
+          checkAtt("test-suite", sut, "name"),
+          checkAtt("42", sut, "tests"),
+          checkAtt("2", sut, "errors"),
+          checkAtt("4", sut, "failures"),
+          checkAtt("24", sut, "skipped"),
+          checkAtt("0.42s", sut, "time"),
+          checkAtt("15:00", sut, "timestamp"),
+          sut.asXML.child.count(_.isInstanceOf[Elem]) == 3
+        )
+      }
+      test("asXML with testcases") {
+        val sut = TS(
+          "localhost2",
+          "test-suite-2",
+          42,
+          2,
+          4,
+          24,
+          "0.42s",
+          "15:00",
+          Seq(
+            TestCase("mill.test.Skip", "test-case-skip", "42", Some(SkippedDetail)),
+            TestCase("mill.test.Error", "test-case-error", "24", Some(ErrorDetail))
+          )
+        )
+
+        assert(
+          checkElementName("testsuite", sut),
+          checkAtt("localhost2", sut, "hostname"),
+          checkAtt("test-suite-2", sut, "name"),
+          checkAtt("42", sut, "tests"),
+          checkAtt("2", sut, "errors"),
+          checkAtt("4", sut, "failures"),
+          checkAtt("24", sut, "skipped"),
+          checkAtt("0.42s", sut, "time"),
+          checkAtt("15:00", sut, "timestamp"),
+          sut.asXML.child.count(_.isInstanceOf[Elem]) == 5
+        )
+      }
+    }
+  }
+}

--- a/contrib/junit/test/src/mill/contrib/junit/TestDataTests.scala
+++ b/contrib/junit/test/src/mill/contrib/junit/TestDataTests.scala
@@ -1,0 +1,120 @@
+package mill.contrib.junit
+import mill.contrib.junit.{TestSuite => TS}
+import mill.define.Segment.{Cross, Label}
+import mill.define.Segments
+import mill.testrunner.TestResult
+import utest._
+
+import java.time.Instant
+
+object TestDataTests extends TestSuite {
+  override def tests: Tests = Tests {
+    test("TestData") {
+      test("asTestSuites empty") {
+        val sut = TestData(os.Path("/test/data"), Seq.empty, Segments(Seq.empty))
+        assert(TestData.asTestSuites(sut, Instant.now).isEmpty)
+      }
+      test("asTestSuites") {
+        val sut = TestData(
+          os.Path("/test/data"),
+          Seq(
+            TestResult("mill.contrib.junit.TestDataTests", "asTestSuites success", 1L, "Success"),
+            TestResult(
+              "mill.contrib.junit.TestDataTests",
+              "asTestSuites failure",
+              10L,
+              "Failure",
+              exceptionName = Some("utest.AssertionError"),
+              exceptionMsg = Some("assert(Seq(expected) == ...)"),
+              exceptionTrace = None
+            ),
+            TestResult("mill.contrib.junit.ModelTests", "TestCase asXML success", 101L, "Success"),
+            TestResult("mill.contrib.junit.TestDataTests", "asTestSuites error", 100L, "Error"),
+            TestResult("mill.contrib.junit.TestDataTests", "asTestSuites skipped", 1000L, "Ignored")
+          ),
+          Segments(Seq.empty)
+        )
+        val expected = Seq(
+          TS(
+            "localhost",
+            "mill.contrib.junit.ModelTests",
+            1,
+            0,
+            0,
+            0,
+            "0.101",
+            "1970-01-01T01:00:00",
+            Seq(
+              TestCase("mill.contrib.junit.ModelTests", "TestCase asXML success", "0.101", None)
+            )
+          ),
+          TS(
+            "localhost",
+            "mill.contrib.junit.TestDataTests",
+            4,
+            1,
+            1,
+            1,
+            "1.111",
+            "1970-01-01T01:00:00",
+            Seq(
+              TestCase("mill.contrib.junit.TestDataTests", "asTestSuites success", "0.001", None),
+              TestCase(
+                "mill.contrib.junit.TestDataTests",
+                "asTestSuites failure",
+                "0.01",
+                Some(FailureDetail)
+              ),
+              TestCase(
+                "mill.contrib.junit.TestDataTests",
+                "asTestSuites error",
+                "0.1",
+                Some(ErrorDetail)
+              ),
+              TestCase(
+                "mill.contrib.junit.TestDataTests",
+                "asTestSuites skipped",
+                "1.0",
+                Some(SkippedDetail)
+              )
+            )
+          )
+        )
+        val actual = TestData.asTestSuites(sut, Instant.ofEpochMilli(0)).toSeq.sortBy(_.name)
+        assert(expected == actual)
+      }
+      test("asTestSuites cross build") {
+        val sut = TestData(
+          os.Path("/test/data"),
+          Seq(TestResult(
+            "mill.contrib.junit.TestDataTests",
+            "asTestSuites success",
+            1L,
+            "Success"
+          )),
+          Segments(Seq(
+            Label("mill"),
+            Label("contrib"),
+            Label("junit"),
+            Cross(Seq("2.13.13")),
+            Label("test"),
+            Label("testCached")
+          ))
+        )
+        val expected = Seq(TS(
+          "localhost",
+          "mill.contrib.junit.TestDataTests-2.13.13",
+          1,
+          0,
+          0,
+          0,
+          "0.001",
+          "1970-01-01T01:00:00",
+          Seq(TestCase("mill.contrib.junit.TestDataTests", "asTestSuites success", "0.001", None))
+        ))
+        val actual = TestData.asTestSuites(sut, Instant.ofEpochMilli(0)).toSeq.sortBy(_.name)
+        assert(expected == actual)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Some CI environments provide Unit test reports but for that, they need a specific output format.

This PR adds a general usage module to export TestResult into JUnit legacy XML test suite reports.