### PR TITLE
Isolate scoverage modules from their parent modules

### DIFF
--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
@@ -80,13 +80,13 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
     } else {
       if (isScoverage2()) {
         Agg(
-          ivy"org.scoverage:::scalac-scoverage-plugin:$sv",
-          ivy"org.scoverage::scalac-scoverage-domain:$sv",
-          ivy"org.scoverage::scalac-scoverage-serializer:$sv",
-          ivy"org.scoverage::scalac-scoverage-reporter:$sv"
+          ivy"org.scoverage:::scalac-scoverage-plugin:${sv}",
+          ivy"org.scoverage::scalac-scoverage-domain:${sv}",
+          ivy"org.scoverage::scalac-scoverage-serializer:${sv}",
+          ivy"org.scoverage::scalac-scoverage-reporter:${sv}"
         )
       } else {
-        Agg(ivy"org.scoverage:::scalac-scoverage-plugin:$sv")
+        Agg(ivy"org.scoverage:::scalac-scoverage-plugin:${sv}")
       }
     }
   }
@@ -123,20 +123,20 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
         case "2" :: "13" :: c :: _ if Try(c.toInt).getOrElse(0) > 8 =>
           val v = "2.13.8"
           T.log.outputStream.println(
-            s"Detected an unsupported Scala version ($millScalaVersion). Using Scala version $v to resolve scoverage $sv reporting API."
+            s"Detected an unsupported Scala version (${millScalaVersion}). Using Scala version ${v} to resolve scoverage ${sv} reporting API."
           )
           v
         case _ => millScalaVersion
       }
-      Agg(ivy"org.scoverage:scalac-scoverage-plugin_$scalaVersion:$sv")
+      Agg(ivy"org.scoverage:scalac-scoverage-plugin_${scalaVersion}:${sv}")
     } else {
       // we need to resolve with same Scala version used for Mill, not the project Scala version
       val scalaBinVersion = ZincWorkerUtil.scalaBinaryVersion(millScalaVersion)
       // In Scoverage 2.x, the reporting API is no longer bundled in the plugin jar
       Agg(
-        ivy"org.scoverage:scalac-scoverage-domain_$scalaBinVersion:$sv",
-        ivy"org.scoverage:scalac-scoverage-serializer_$scalaBinVersion:$sv",
-        ivy"org.scoverage:scalac-scoverage-reporter_$scalaBinVersion:$sv"
+        ivy"org.scoverage:scalac-scoverage-domain_${scalaBinVersion}:${sv}",
+        ivy"org.scoverage:scalac-scoverage-serializer_${scalaBinVersion}:${sv}",
+        ivy"org.scoverage:scalac-scoverage-reporter_${scalaBinVersion}:${sv}"
       )
     }
   }
@@ -189,31 +189,31 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
       PathRef(T.dest)
     }
 
-    override def generatedSources: T[Seq[PathRef]] = outer.generatedSources
-    override def allSources: T[Seq[PathRef]] = outer.allSources
+    override def generatedSources: Target[Seq[PathRef]] = T { outer.generatedSources() }
+    override def allSources: Target[Seq[PathRef]] = T { outer.allSources() }
     override def moduleDeps: Seq[JavaModule] = outer.moduleDeps
     override def compileModuleDeps: Seq[JavaModule] = outer.compileModuleDeps
-    override def sources: T[Seq[PathRef]] = outer.sources
-    override def resources: T[Seq[PathRef]] = outer.resources
-    override def scalaVersion: T[String] = outer.scalaVersion
-    override def repositoriesTask: Task[Seq[Repository]] = outer.repositoriesTask
-    override def compileIvyDeps: T[Agg[Dep]] = outer.compileIvyDeps
-    override def ivyDeps: T[Agg[Dep]] =
+    override def sources: T[Seq[PathRef]] = T.sources { outer.sources() }
+    override def resources: T[Seq[PathRef]] = T.sources { outer.resources() }
+    override def scalaVersion = T { outer.scalaVersion() }
+    override def repositoriesTask: Task[Seq[Repository]] = T.task { outer.repositoriesTask() }
+    override def compileIvyDeps: Target[Agg[Dep]] = T { outer.compileIvyDeps() }
+    override def ivyDeps: Target[Agg[Dep]] =
       T { outer.ivyDeps() ++ outer.scoverageRuntimeDeps() }
-    override def unmanagedClasspath: T[Agg[PathRef]] = outer.unmanagedClasspath
+    override def unmanagedClasspath: Target[Agg[PathRef]] = T { outer.unmanagedClasspath() }
 
     /** Add the scoverage scalac plugin. */
     override def scalacPluginIvyDeps: Target[Loose.Agg[Dep]] =
       T { outer.scalacPluginIvyDeps() ++ outer.scoveragePluginDeps() }
 
     /** Add the scoverage specific plugin settings (`dataDir`). */
-    override def scalacOptions: T[Seq[String]] =
+    override def scalacOptions: Target[Seq[String]] =
       T {
         val extras =
           if (isScala3()) {
-            Seq(s"-coverage-out:${data().path.toIO.getPath}")
+            Seq(s"-coverage-out:${data().path.toIO.getPath()}")
           } else {
-            val base = s"-P:scoverage:dataDir:${data().path.toIO.getPath}"
+            val base = s"-P:scoverage:dataDir:${data().path.toIO.getPath()}"
             if (isScoverage2()) Seq(base, s"-P:scoverage:sourceRoot:${T.workspace}")
             else Seq(base)
           }

--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
@@ -232,7 +232,7 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
   trait ScoverageTests extends ScalaTests { outerTests: ScalaTests =>
 
     /** Inner worker module. This is not an `object` to allow users to override and customize it. */
-    lazy val scoverage: ScoverageTestsData = new ScoverageTestsData {}
+    lazy val scoverage: ScoverageTestsDelegate = new ScoverageTestsDelegate {}
 
     /**
      * The actual task shared by `test`-tasks that runs test in a forked JVM.
@@ -244,7 +244,8 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
 
     override def testLocal(args: String*): Command[(String, Seq[TestResult])] =
       scoverage.testLocal(args: _*)
-    trait ScoverageTestsData extends ScalaTests {
+
+    trait ScoverageTestsDelegate extends ScalaTests {
       override def testTask(
           args: Task[Seq[String]],
           globSelectors: Task[Seq[String]]

--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
@@ -80,13 +80,13 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
     } else {
       if (isScoverage2()) {
         Agg(
-          ivy"org.scoverage:::scalac-scoverage-plugin:${sv}",
-          ivy"org.scoverage::scalac-scoverage-domain:${sv}",
-          ivy"org.scoverage::scalac-scoverage-serializer:${sv}",
-          ivy"org.scoverage::scalac-scoverage-reporter:${sv}"
+          ivy"org.scoverage:::scalac-scoverage-plugin:$sv",
+          ivy"org.scoverage::scalac-scoverage-domain:$sv",
+          ivy"org.scoverage::scalac-scoverage-serializer:$sv",
+          ivy"org.scoverage::scalac-scoverage-reporter:$sv"
         )
       } else {
-        Agg(ivy"org.scoverage:::scalac-scoverage-plugin:${sv}")
+        Agg(ivy"org.scoverage:::scalac-scoverage-plugin:$sv")
       }
     }
   }
@@ -123,20 +123,20 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
         case "2" :: "13" :: c :: _ if Try(c.toInt).getOrElse(0) > 8 =>
           val v = "2.13.8"
           T.log.outputStream.println(
-            s"Detected an unsupported Scala version (${millScalaVersion}). Using Scala version ${v} to resolve scoverage ${sv} reporting API."
+            s"Detected an unsupported Scala version ($millScalaVersion). Using Scala version $v to resolve scoverage $sv reporting API."
           )
           v
         case _ => millScalaVersion
       }
-      Agg(ivy"org.scoverage:scalac-scoverage-plugin_${scalaVersion}:${sv}")
+      Agg(ivy"org.scoverage:scalac-scoverage-plugin_$scalaVersion:$sv")
     } else {
       // we need to resolve with same Scala version used for Mill, not the project Scala version
       val scalaBinVersion = ZincWorkerUtil.scalaBinaryVersion(millScalaVersion)
       // In Scoverage 2.x, the reporting API is no longer bundled in the plugin jar
       Agg(
-        ivy"org.scoverage:scalac-scoverage-domain_${scalaBinVersion}:${sv}",
-        ivy"org.scoverage:scalac-scoverage-serializer_${scalaBinVersion}:${sv}",
-        ivy"org.scoverage:scalac-scoverage-reporter_${scalaBinVersion}:${sv}"
+        ivy"org.scoverage:scalac-scoverage-domain_$scalaBinVersion:$sv",
+        ivy"org.scoverage:scalac-scoverage-serializer_$scalaBinVersion:$sv",
+        ivy"org.scoverage:scalac-scoverage-reporter_$scalaBinVersion:$sv"
       )
     }
   }

--- a/example/misc/7-contrib-scoverage/build.sc
+++ b/example/misc/7-contrib-scoverage/build.sc
@@ -1,0 +1,127 @@
+import mill._, scalalib._
+import $ivy.`com.lihaoyi::mill-contrib-scoverage:`
+
+import mill.contrib.scoverage._
+
+object foo extends RootModule with ScoverageModule {
+  def scoverageVersion = "2.1.0"
+  def scalaVersion = "2.13.11"
+  def ivyDeps = Agg(
+    ivy"com.lihaoyi::scalatags:0.12.0",
+    ivy"com.lihaoyi::mainargs:0.6.2"
+  )
+
+  object test extends ScoverageTests /*with TestModule.Utest */{
+    def ivyDeps = Agg(ivy"com.lihaoyi::utest:0.7.11")
+    def testFramework = "utest.runner.Framework"
+  }
+}
+
+// This is a basic Mill build for a single `ScalaModule`, with two
+// third-party dependencies and a test suite using the uTest framework. As a
+// single-module project, it `extends RootModule` to mark `object foo` as the
+// top-level module in the build. This lets us directly perform operations
+// `./mill compile` or `./mill run` without needing to prefix it as
+// `foo.compile` or `foo.run`.
+//
+// You can download this example project using the *download* link above
+// if you want to try out the commands below yourself. The only requirement is
+// that you have some version of the JVM installed; the `./mill` script takes
+// care of any further dependencies that need to be downloaded.
+//
+// The source code for this module lives in the `src/` folder.
+// Output for this module (compiled files, resolved dependency lists, ...)
+// lives in `out/`.
+//
+// This example project uses two third-party dependencies - MainArgs for CLI
+// argument parsing, Scalatags for HTML generation - and uses them to wrap a
+// given input string in HTML templates with proper escaping.
+//
+// You can run `assembly` to generate a standalone executable jar, which then
+// can be run from the command line or deployed to be run elsewhere.
+
+/** Usage
+
+> ./mill resolve _ # List what tasks are available to run
+assembly
+...
+clean
+...
+compile
+...
+run
+...
+show
+...
+inspect
+...
+
+> ./mill inspect compile # Show documentation and inputs of a task
+compile(ScalaModule.scala:...)
+    Compiles the current module to generate compiled classfiles/bytecode.
+Inputs:
+    scalaVersion
+    upstreamCompileOutput
+    allSourceFiles
+    compileClasspath
+
+> ./mill compile # compile sources into classfiles
+...
+compiling 1 Scala source to...
+
+> ./mill run # run the main method, if any
+error: Missing argument: --text <str>
+
+> ./mill run --text hello
+<h1>hello</h1>
+
+> ./mill test
+...
++ foo.FooTests.simple ...  <h1>hello</h1>
++ foo.FooTests.escaping ...  <h1>&lt;hello&gt;</h1>
+
+> ./mill assembly # bundle classfiles and libraries into a jar for deployment
+
+> ./mill show assembly # show the output of the assembly task
+".../out/assembly.dest/out.jar"
+
+> java -jar ./out/assembly.dest/out.jar --text hello
+<h1>hello</h1>
+
+> ./out/assembly.dest/out.jar --text hello # mac/linux
+<h1>hello</h1>
+
+*/
+
+// The output of every Mill task is stored in the `out/` folder under a name
+// corresponding to the task that created it. e.g. The `assembly` task puts its
+// metadata output in `out/assembly.json`, and its output files in
+// `out/assembly.dest`. You can also use `show` to make Mill print out the
+// metadata output for a particular task.
+//
+// Additional Mill tasks you would likely need include:
+//
+// [source,bash]
+// ----
+// $ mill runBackground # run the main method in the background
+//
+// $ mill clean <task>  # delete the cached output of a task, terminate any runBackground
+//
+// $ mill launcher      # prepares a foo/launcher.dest/run you can run later
+//
+// $ mill jar           # bundle the classfiles into a jar suitable for publishing
+//
+// $ mill -i console    # start a Scala console within your project
+//
+// $ mill -i repl       # start an Ammonite Scala REPL within your project
+// ----
+//
+// You can run `+mill resolve __+` to see a full list of the different tasks that
+// are available, `+mill resolve _+` to see the tasks within `foo`,
+// `mill inspect compile` to inspect a task's doc-comment documentation or what
+// it depends on, or `mill show foo.scalaVersion` to show the output of any task.
+//
+// The most common *tasks* that Mill can run are cached *targets*, such as
+// `compile`, and un-cached *commands* such as `foo.run`. Targets do not
+// re-evaluate unless one of their inputs changes, whereas commands re-run every
+// time.

--- a/example/misc/7-contrib-scoverage/build.sc
+++ b/example/misc/7-contrib-scoverage/build.sc
@@ -17,12 +17,18 @@ object foo extends RootModule with ScoverageModule {
   }
 }
 
-// This is a basic Mill build for a single `ScalaModule`, with two
-// third-party dependencies and a test suite using the uTest framework. As a
-// single-module project, it `extends RootModule` to mark `object foo` as the
-// top-level module in the build. This lets us directly perform operations
-// `./mill compile` or `./mill run` without needing to prefix it as
-// `foo.compile` or `foo.run`.
+// This is a basic Mill build for a single `ScalaModule`, enhanced with
+// Scoverage plugin. The root module extends the `ScoverageModule` and
+// specifies the version of scoverage version to use here: `2.1.0`. This
+// version can be change if there is newer ones. This will all use to
+// call the scoverage targets to produce coverage reports.
+// Then the sub test module extends `ScoverageTests` to transform the
+// execution of the various testXXX targets to use scoverage and produce
+// coverage data.
+// This lets us perform the coverage operations but before that you
+// must first run the test.
+// `./mill test` then `./mill scoverage.consoleReport` and get your
+// coverage into your console output.
 //
 // You can download this example project using the *download* link above
 // if you want to try out the commands below yourself. The only requirement is

--- a/example/misc/7-contrib-scoverage/build.sc
+++ b/example/misc/7-contrib-scoverage/build.sc
@@ -42,7 +42,7 @@ object foo extends RootModule with ScoverageModule {
 + foo.FooTests.simple ...  <h1>hello</h1>
 + foo.FooTests.escaping ...  <h1>&lt;hello&gt;</h1>
 
-> ./mill result scoverage._ # List what tasks are available to run from scoverage
+> ./mill resolve scoverage._ # List what tasks are available to run from scoverage
 ...
 scoverage.consoleReport
 ...

--- a/example/misc/7-contrib-scoverage/build.sc
+++ b/example/misc/7-contrib-scoverage/build.sc
@@ -20,7 +20,7 @@ object foo extends RootModule with ScoverageModule {
 // This is a basic Mill build for a single `ScalaModule`, enhanced with
 // Scoverage plugin. The root module extends the `ScoverageModule` and
 // specifies the version of scoverage version to use here: `2.1.0`. This
-// version can be change if there is newer ones. This will all use to
+// version can be changed if there is a newer one. This will all use to
 // call the scoverage targets to produce coverage reports.
 // Then the sub test module extends `ScoverageTests` to transform the
 // execution of the various testXXX targets to use scoverage and produce

--- a/example/misc/7-contrib-scoverage/build.sc
+++ b/example/misc/7-contrib-scoverage/build.sc
@@ -20,9 +20,9 @@ object foo extends RootModule with ScoverageModule {
 // This is a basic Mill build for a single `ScalaModule`, enhanced with
 // Scoverage plugin. The root module extends the `ScoverageModule` and
 // specifies the version of scoverage version to use here: `2.1.0`. This
-// version can be changed if there is a newer one. This will all use to
-// call the scoverage targets to produce coverage reports.
-// Then the sub test module extends `ScoverageTests` to transform the
+// version can be changed if there is a newer one. Now you can call the
+// scoverage targets to produce coverage reports.
+// The sub test module extends `ScoverageTests` to transform the
 // execution of the various testXXX targets to use scoverage and produce
 // coverage data.
 // This lets us perform the coverage operations but before that you
@@ -34,100 +34,27 @@ object foo extends RootModule with ScoverageModule {
 // if you want to try out the commands below yourself. The only requirement is
 // that you have some version of the JVM installed; the `./mill` script takes
 // care of any further dependencies that need to be downloaded.
-//
-// The source code for this module lives in the `src/` folder.
-// Output for this module (compiled files, resolved dependency lists, ...)
-// lives in `out/`.
-//
-// This example project uses two third-party dependencies - MainArgs for CLI
-// argument parsing, Scalatags for HTML generation - and uses them to wrap a
-// given input string in HTML templates with proper escaping.
-//
-// You can run `assembly` to generate a standalone executable jar, which then
-// can be run from the command line or deployed to be run elsewhere.
 
 /** Usage
 
-> ./mill resolve _ # List what tasks are available to run
-assembly
-...
-clean
-...
-compile
-...
-run
-...
-show
-...
-inspect
-...
-
-> ./mill inspect compile # Show documentation and inputs of a task
-compile(ScalaModule.scala:...)
-    Compiles the current module to generate compiled classfiles/bytecode.
-Inputs:
-    scalaVersion
-    upstreamCompileOutput
-    allSourceFiles
-    compileClasspath
-
-> ./mill compile # compile sources into classfiles
-...
-compiling 1 Scala source to...
-
-> ./mill run # run the main method, if any
-error: Missing argument: --text <str>
-
-> ./mill run --text hello
-<h1>hello</h1>
-
-> ./mill test
+> ./mill test # Run the tests and produce the coverage data
 ...
 + foo.FooTests.simple ...  <h1>hello</h1>
 + foo.FooTests.escaping ...  <h1>&lt;hello&gt;</h1>
 
-> ./mill assembly # bundle classfiles and libraries into a jar for deployment
+> ./mill result scoverage._ # List what tasks are available to run from scoverage
+...
+scoverage.consoleReport
+...
+scoverage.htmlReport
+...
+scoverage.xmlCoberturaReport
+...
+scoverage.xmlReport
+...
 
-> ./mill show assembly # show the output of the assembly task
-".../out/assembly.dest/out.jar"
-
-> java -jar ./out/assembly.dest/out.jar --text hello
-<h1>hello</h1>
-
-> ./out/assembly.dest/out.jar --text hello # mac/linux
-<h1>hello</h1>
-
+> ./mill scoverage.consoleReport
+...
+Statement coverage.: 16.67%
+Branch coverage....: 100.00%
 */
-
-// The output of every Mill task is stored in the `out/` folder under a name
-// corresponding to the task that created it. e.g. The `assembly` task puts its
-// metadata output in `out/assembly.json`, and its output files in
-// `out/assembly.dest`. You can also use `show` to make Mill print out the
-// metadata output for a particular task.
-//
-// Additional Mill tasks you would likely need include:
-//
-// [source,bash]
-// ----
-// $ mill runBackground # run the main method in the background
-//
-// $ mill clean <task>  # delete the cached output of a task, terminate any runBackground
-//
-// $ mill launcher      # prepares a foo/launcher.dest/run you can run later
-//
-// $ mill jar           # bundle the classfiles into a jar suitable for publishing
-//
-// $ mill -i console    # start a Scala console within your project
-//
-// $ mill -i repl       # start an Ammonite Scala REPL within your project
-// ----
-//
-// You can run `+mill resolve __+` to see a full list of the different tasks that
-// are available, `+mill resolve _+` to see the tasks within `foo`,
-// `mill inspect compile` to inspect a task's doc-comment documentation or what
-// it depends on, or `mill show foo.scalaVersion` to show the output of any task.
-//
-// The most common *tasks* that Mill can run are cached *targets*, such as
-// `compile`, and un-cached *commands* such as `foo.run`. Targets do not
-// re-evaluate unless one of their inputs changes, whereas commands re-run every
-// time.

--- a/example/misc/7-contrib-scoverage/src/Foo.scala
+++ b/example/misc/7-contrib-scoverage/src/Foo.scala
@@ -1,0 +1,16 @@
+package foo
+import scalatags.Text.all._
+import mainargs.{main, ParserForMethods}
+
+object Foo {
+  def generateHtml(text: String) = {
+    h1(text).toString
+  }
+
+  @main
+  def main(text: String) = {
+    println(generateHtml(text))
+  }
+
+  def main(args: Array[String]): Unit = ParserForMethods(this).runOrExit(args)
+}

--- a/example/misc/7-contrib-scoverage/test/src/FooTests.scala
+++ b/example/misc/7-contrib-scoverage/test/src/FooTests.scala
@@ -1,0 +1,16 @@
+package foo
+import utest._
+object FooTests extends TestSuite {
+  def tests = Tests {
+    test("simple") {
+      val result = Foo.generateHtml("hello")
+      assert(result == "<h1>hello</h1>")
+      result
+    }
+    test("escaping") {
+      val result = Foo.generateHtml("<hello>")
+      assert(result == "<h1>&lt;hello&gt;</h1>")
+      result
+    }
+  }
+}


### PR DESCRIPTION
## Context
I encountered an issue with the way scoverage plugin alters the dependency tree of the test module by changing its module dependency from the `outer` module to the `outer.scoverage` module.
This shadow modification of the dependency tree produces a side effect that impacts the IDEA configuration generation.
When the IDEA configuration generation resolves the dependencies instead of using the outer module as a dependency for the test project it depends on the `outer.scoverage` module which should not be generated as it does not exist factually but more virtually.

## Solution
Instead of modifying the dependency tree at compile-time I change it at runtime by removing the `outer.localRunClasspath()` from the `test.runClasspath()` and appending, instead, the `outer.scoverage.localRunClasspath()`

This resolves the issue of modifying the dependency tree but introduces one more compilation as when the `outer.localRunClasspath()` is resolved it will force the compilation of the outer module. In the previous version only the `outer.scoverage` was compiled and not both of them.