### PR TITLE
Scoverage improve classpath override to the minimal

### DIFF
--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
@@ -232,19 +232,18 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
   trait ScoverageTests extends ScalaTests {
 
     /**
-     * Alter classfiles and resources from upstream modules and dependencies
-     * by removing the ones from outer.localRunClasspath() and replacing them
-     * with outer.scoverage.localRunClasspath()
+     * Alter classpath from upstream modules by replacing in-place outer module
+     * classes folder by the outer.scoverage classes folder and adding the
+     * scoverage runtime dependency.
      */
     override def runClasspath: T[Seq[PathRef]] = T {
-      val outerLocalRunClasspath = outer.localRunClasspath().toSet
-      super.runClasspath().filterNot(
-        outerLocalRunClasspath
-      ) ++
-        outer.scoverage.localRunClasspath() ++
-        resolveDeps(T.task {
-          outer.scoverageRuntimeDeps().map(bindDependency())
-        })()
+      val outerClassesPath = outer.compile().classes
+      val outerScoverageClassesPath = outer.scoverage.compile().classes
+      (super.runClasspath().flatMap { path =>
+        if (outerClassesPath == path) Seq(outerScoverageClassesPath) else Seq(path)
+      } ++ resolveDeps(T.task {
+        outer.scoverageRuntimeDeps().map(bindDependency())
+      })()).distinct
     }
   }
 }

--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
@@ -239,8 +239,8 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
     override def runClasspath: T[Seq[PathRef]] = T {
       val outerClassesPath = outer.compile().classes
       val outerScoverageClassesPath = outer.scoverage.compile().classes
-      (super.runClasspath().flatMap { path =>
-        if (outerClassesPath == path) Seq(outerScoverageClassesPath) else Seq(path)
+      (super.runClasspath().map { path =>
+        if (outerClassesPath == path) outerScoverageClassesPath else path
       } ++ resolveDeps(T.task {
         outer.scoverageRuntimeDeps().map(bindDependency())
       })()).distinct


### PR DESCRIPTION
The previous version the `ScoverageTests.runClasspath` was more modified and reorganized.
In this version, only the outer complied classes folder is replaced (in place) by the outer.scoverage complied classes folder.
An additional runtime dependency is also added: `org.scoverage::scalac-scoverage-runtime`.
All duplicated entries in the classpath are also removed.