### PR TITLE
Retry example integration tests that didn't finish after 5 minutes

### DIFF
--- a/example/src/mill/integration/ExampleTestSuite.scala
+++ b/example/src/mill/integration/ExampleTestSuite.scala
@@ -72,20 +72,18 @@ object ExampleTestSuite extends IntegrationTestSuite {
     }
 
     test("exampleUsage") {
-      try {
-        def body = {
-          val parsed = upickle.default.read[Seq[(String, String)]](sys.env("MILL_EXAMPLE_PARSED"))
-          val usageComment = parsed.collect { case ("example", txt) => txt }.mkString("\n\n")
-          val commandBlocks = ("\n" + usageComment.trim).split("\n> ").filter(_.nonEmpty)
+      val parsed = upickle.default.read[Seq[(String, String)]](sys.env("MILL_EXAMPLE_PARSED"))
+      val usageComment = parsed.collect { case ("example", txt) => txt }.mkString("\n\n")
+      val commandBlocks = ("\n" + usageComment.trim).split("\n> ").filter(_.nonEmpty)
 
+      retryOnTimeout(3) {
+        try {
           for (commandBlock <- commandBlocks) processCommandBlock(workspaceRoot, commandBlock)
-
           if (integrationTestMode != "fork") evalStdout("shutdown")
+        } finally {
+          try os.remove.all(workspaceRoot / "out")
+          catch { case e: Throwable => /*do nothing*/ }
         }
-        retryOnTimeout(3)(body)
-      } finally {
-        try os.remove.all(workspaceRoot / "out")
-        catch { case e: Throwable => /*do nothing*/ }
       }
     }
   }


### PR DESCRIPTION
The idea is, that our example integration tests should finish after a short period of time. But sometimes then hang in CI, so we simply abort and retry them automatically, instaed of manually.

The hardcoded timeout of 5 minutes is just a guess. I want to see the CI results. Maybe, we can make it configurable per test suite.
