### PR TITLE
Update os-lib from 0.9.3 to 0.10.0

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -150,7 +150,7 @@ object Deps {
   val junitInterface = ivy"com.github.sbt:junit-interface:0.13.3"
   val lambdaTest = ivy"de.tototec:de.tobiasroeser.lambdatest:0.8.0"
   val log4j2Core = ivy"org.apache.logging.log4j:log4j-core:2.23.0"
-  val osLib = ivy"com.lihaoyi::os-lib:0.9.3"
+  val osLib = ivy"com.lihaoyi::os-lib:0.10.0"
   val pprint = ivy"com.lihaoyi::pprint:0.8.1"
   val mainargs = ivy"com.lihaoyi::mainargs:0.6.3"
   val millModuledefsVersion = "0.10.9"


### PR DESCRIPTION
Beside the version bump, this release is binary compatible to 0.9.x for Scala 2.13.