### PR TITLE
Improve the support of JUnit XML report

### DIFF
--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -373,8 +373,7 @@ trait TestScalaJSModule extends ScalaJSModule with TestModule {
       T.testReporter,
       TestRunnerUtils.globFilter(globSelectors())
     )
-    val res =
-      TestModule.handleResults(doneMsg, results, T.ctx(), testReportXml(), jsEnvConfig().env)
+    val res = TestModule.handleResults(doneMsg, results, T.ctx(), testReportXml())
     // Hack to try and let the Node.js subprocess finish streaming it's stdout
     // to the JVM. Without this, the stdout can still be streaming when `close()`
     // is called, and some of the output is dropped onto the floor.

--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -373,7 +373,7 @@ trait TestScalaJSModule extends ScalaJSModule with TestModule {
       T.testReporter,
       TestRunnerUtils.globFilter(globSelectors())
     )
-    val res = TestModule.handleResults(doneMsg, results, Some(T.ctx()))
+    val res = TestModule.handleResults(doneMsg, results, T.ctx(), testReportXml())
     // Hack to try and let the Node.js subprocess finish streaming it's stdout
     // to the JVM. Without this, the stdout can still be streaming when `close()`
     // is called, and some of the output is dropped onto the floor.

--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -373,7 +373,8 @@ trait TestScalaJSModule extends ScalaJSModule with TestModule {
       T.testReporter,
       TestRunnerUtils.globFilter(globSelectors())
     )
-    val res = TestModule.handleResults(doneMsg, results, T.ctx(), testReportXml())
+    val res =
+      TestModule.handleResults(doneMsg, results, T.ctx(), testReportXml(), jsEnvConfig().env)
     // Hack to try and let the Node.js subprocess finish streaming it's stdout
     // to the JVM. Without this, the stdout can still be streaming when `close()`
     // is called, and some of the output is dropped onto the floor.

--- a/scalajslib/src/mill/scalajslib/api/ScalaJSApi.scala
+++ b/scalajslib/src/mill/scalajslib/api/ScalaJSApi.scala
@@ -71,9 +71,7 @@ object ModuleSplitStyle {
   implicit val rw: RW[ModuleSplitStyle] = macroRW
 }
 
-sealed trait JsEnvConfig {
-  val env: Map[String, String]
-}
+sealed trait JsEnvConfig
 object JsEnvConfig {
   implicit def rwNodeJs: RW[NodeJs] = macroRW
   implicit def rwJsDom: RW[JsDom] = macroRW
@@ -132,10 +130,7 @@ object JsEnvConfig {
    */
   final class Selenium private (
       val capabilities: Selenium.Capabilities
-  ) extends JsEnvConfig {
-    override val env: Map[String, String] = Map.empty
-  }
-
+  ) extends JsEnvConfig
   object Selenium {
     implicit def rwCapabilities: RW[Capabilities] = macroRW
 

--- a/scalajslib/src/mill/scalajslib/api/ScalaJSApi.scala
+++ b/scalajslib/src/mill/scalajslib/api/ScalaJSApi.scala
@@ -71,7 +71,9 @@ object ModuleSplitStyle {
   implicit val rw: RW[ModuleSplitStyle] = macroRW
 }
 
-sealed trait JsEnvConfig
+sealed trait JsEnvConfig {
+  val env: Map[String, String]
+}
 object JsEnvConfig {
   implicit def rwNodeJs: RW[NodeJs] = macroRW
   implicit def rwJsDom: RW[JsDom] = macroRW
@@ -130,7 +132,10 @@ object JsEnvConfig {
    */
   final class Selenium private (
       val capabilities: Selenium.Capabilities
-  ) extends JsEnvConfig
+  ) extends JsEnvConfig {
+    override val env: Map[String, String] = Map.empty
+  }
+
   object Selenium {
     implicit def rwCapabilities: RW[Capabilities] = macroRW
 

--- a/scalalib/src/mill/scalalib/TestModule.scala
+++ b/scalalib/src/mill/scalalib/TestModule.scala
@@ -173,13 +173,7 @@ trait TestModule
           val (doneMsg, results) = {
             upickle.default.read[(String, Seq[TestResult])](jsonOutput)
           }
-          TestModule.handleResults(
-            doneMsg,
-            results,
-            T.ctx(),
-            testReportXml(),
-            sys.props.toMap ++ forkEnv()
-          )
+          TestModule.handleResults(doneMsg, results, T.ctx(), testReportXml())
         } catch {
           case e: Throwable =>
             Result.Failure("Test reporting failed: " + e)
@@ -338,9 +332,11 @@ object TestModule {
       results: Seq[TestResult],
       ctx: Ctx.Env with Ctx.Dest,
       testReportXml: Option[String],
-      props: Map[String, String] = Map.empty
+      props: Option[Map[String, String]] = None
   ): Result[(String, Seq[TestResult])] = {
-    testReportXml.foreach(fileName => genTestXmlReport(results, ctx.dest / fileName, props))
+    testReportXml.foreach(fileName =>
+      genTestXmlReport(results, ctx.dest / fileName, props.getOrElse(Map.empty))
+    )
     handleResults(doneMsg, results, Some(ctx))
   }
 

--- a/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
+++ b/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
@@ -362,7 +362,7 @@ trait TestScalaNativeModule extends ScalaNativeModule with TestModule {
       T.testReporter,
       TestRunnerUtils.globFilter(globSeletors())
     )
-    val res = TestModule.handleResults(doneMsg, results, Some(T.ctx()))
+    val res = TestModule.handleResults(doneMsg, results, T.ctx(), testReportXml())
     // Hack to try and let the Scala Native subprocess finish streaming it's stdout
     // to the JVM. Without this, the stdout can still be streaming when `close()`
     // is called, and some of the output is dropped onto the floor.


### PR DESCRIPTION
# JUnit XML
Rework the JUnit XML reporting feature. After a couple of tests, the XML report output is not compliant with the "standard"
I try to make it more compliant without breaking the great first solution!
I took inspiration from the pseudo specification and SBT implementation.
One important point is that Maven and SBT are producing one output file per `<testsuite>` a.k.a. per test (spec...) class 
while this solution (original) is producing one `<testsuites>` output file for the entire module. The specification supports it. We should keep this approach.

In this PR:
 * Follow the "specification" provided in https://github.com/testmoapp/junitxml
 * Fix the failure/error reporting as there is not necessarily an exception and error message provided (optional)
 * Call the junit report from `testLocal`
 * Make sure all the test module types call the same code for junit report: `TestModule`, `ScalaJSModule`, `ScalaNativeModule`

## Resources
 * Specification (more or less): https://github.com/testmoapp/junitxml
 * Sbt Inspiration: https://github.com/sbt/sbt/blob/72bfb3f45ab346ddf3558bc23853dfbb9392cc55/testing/src/main/scala/sbt/JUnitXmlTestsListener.scala

## Maven output

One output per test class: `target/surefire-reports/TEST-io.ultra.AppTest.xml`

```
<?xml version="1.0" encoding="UTF-8"?>
<testsuite xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report.xsd" name="io.ultra.AppTest" time="0.009" tests="4" errors="1" skipped="0" failures="2">
  <properties>
    <property name="awt.toolkit" value="sun.awt.X11.XToolkit"/>
    ...
    <property name="java.class.version" value="55.0"/>
  </properties>
  <testcase name="testApp" classname="io.ultra.AppTest" time="0"/>
  <testcase name="testFailAssertionApp" classname="io.ultra.AppTest" time="0.003">
    <failure type="junit.framework.AssertionFailedError">junit.framework.AssertionFailedError
	at junit.framework.Assert.fail(Assert.java:47)
	at junit.framework.Assert.assertTrue(Assert.java:20)
	at junit.framework.Assert.assertTrue(Assert.java:27)
	at io.ultra.AppTest.testFailAssertionApp(AppTest.java:41)
</failure>
  </testcase>
  <testcase name="testFailApp" classname="io.ultra.AppTest" time="0">
    <failure type="junit.framework.AssertionFailedError">junit.framework.AssertionFailedError
	at junit.framework.Assert.fail(Assert.java:47)
	at junit.framework.Assert.fail(Assert.java:53)
	at io.ultra.AppTest.testFailApp(AppTest.java:46)
</failure>
  </testcase>
  <testcase name="testErrorApp" classname="io.ultra.AppTest" time="0.001">
    <error message="big error" type="java.lang.RuntimeException">java.lang.RuntimeException: big error
	at io.ultra.AppTest.testErrorApp(AppTest.java:51)
</error>
  </testcase>
</testsuite>
```

## mill test output Examples vs SBT

### UTest

```
    {
      "fullyQualifiedName": "foo.FooTests",
      "selector": "foo.FooTests.simple",
      "duration": 26,
      "status": "Success"
    },
    {
      "fullyQualifiedName": "foo.FooTests",
      "selector": "foo.FooTests.escaping",
      "duration": 0,
      "status": "Success"
    }
```

### ZIO test

```
    {
      "fullyQualifiedName": "io.ultra.uniq.indexer.ATestSuite",
      "selector": "root - test-case-1",
      "duration": 16,
      "status": "Success"
    },
    {
      "fullyQualifiedName": "io.ultra.uniq.indexer.ATestSuite",
      "selector": "root - sub-suite - test-case-2.1",
      "duration": 17,
      "status": "Success"
    },
    {
      "fullyQualifiedName": "io.ultra.uniq.indexer.ATestSuite",
      "selector": "root - test-case-2",
      "duration": 18,
      "status": "Success"
    },
    {
      "fullyQualifiedName": "io.ultra.uniq.indexer.ATestSuite",
      "selector": "root - sub-suite - test-case-2.2",
      "duration": 17,
      "status": "Success"
    },
```

sbt output:
```
<?xml version='1.0' encoding='UTF-8'?>
<testsuite hostname="ultra-lapttop-roro" name="io.ultra.uniq.indexer.ATestSuite" tests="4" errors="0" failures="0"
           skipped="0" time="1.045" timestamp="2024-04-24T17:27:38">
    <properties>
        <property name="awt.toolkit" value="sun.awt.X11.XToolkit"/>
        ...
        <property name="jna.nosys" value="true"/>
        <property name="java.runtime.name" value="OpenJDK Runtime Environment"/>
        <property name="java.vm.name" value="OpenJDK 64-Bit Server VM"/>
        <property name="jna.platform.library.path"
                  value="/usr/lib64:/lib64:/usr/lib:/lib:/usr/lib32:/usr/lib/opencollada:/opt/intel/oneapi/tbb/latest/lib/intel64/gcc4.8:/opt/intel/oneapi/compiler/latest/linux/lib:/opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64_lin"/>
        <property name="java.vendor.url.bug" value="https://github.com/adoptium/adoptium-support/issues"/>
        <property name="user.dir" value="/home/rogilles/sandbox/ultra/platform"/>
        <property name="os.arch" value="amd64"/>
        <property name="grouping.with.qualified.names.enabled" value="true"/>
        <property name="idea.managed" value="true"/>
        <property name="java.vm.info" value="mixed mode"/>
        <property name="java.vm.version" value="11.0.23+9"/>
        <property name="java.class.version" value="55.0"/>
    </properties>
    <testcase classname="io.ultra.uniq.indexer.ATestSuite" name="root - test-case-1" time="0.256">

    </testcase>
    <testcase classname="io.ultra.uniq.indexer.ATestSuite" name="root - test-case-2" time="0.272">

    </testcase>
    <testcase classname="io.ultra.uniq.indexer.ATestSuite" name="root - sub-suite - test-case-2.1" time="0.259">

    </testcase>
    <testcase classname="io.ultra.uniq.indexer.ATestSuite" name="root - sub-suite - test-case-2.2" time="0.258">

    </testcase>
    <system-out><![CDATA[]]></system-out>
    <system-err><![CDATA[]]></system-err>
</testsuite>
```

### scalatest

#### FreeSpec

```
    {
      "fullyQualifiedName": "io.ultra.cloudevent.ATestSuiteFreeSpec",
      "selector": "A Set when empty should have size 0",
      "duration": 2,
      "status": "Success"
    },
    {
      "fullyQualifiedName": "io.ultra.cloudevent.ATestSuiteFreeSpec",
      "selector": "A Set when empty should produce NoSuchElementException when head is invoked",
      "duration": 1,
      "status": "Success"
    },
    {
      "fullyQualifiedName": "io.ultra.cloudevent.ATestSuiteFreeSpec",
      "selector": "A Set when non-empty should have size > 0",
      "duration": 0,
      "status": "Success"
    }
 ```

sbt output:
```
<?xml version='1.0' encoding='UTF-8'?>
<testsuite hostname="ultra-lapttop-roro" name="io.ultra.cloudevent.ATestSuiteFreeSpec" tests="3" errors="0" failures="0"
           skipped="0" time="0.016" timestamp="2024-04-24T18:08:19">
    <properties>
        <property name="awt.toolkit" value="sun.awt.X11.XToolkit"/>
        <property name="java.specification.version" value="11"/>
        ...
        <property name="java.class.version" value="55.0"/>
    </properties>
    <testcase classname="io.ultra.cloudevent.ATestSuiteFreeSpec" name="A Set when empty should have size 0"
              time="0.014">

    </testcase>
    <testcase classname="io.ultra.cloudevent.ATestSuiteFreeSpec"
              name="A Set when empty should produce NoSuchElementException when head is invoked" time="0.0">

    </testcase>
    <testcase classname="io.ultra.cloudevent.ATestSuiteFreeSpec" name="A Set when non-empty should have size &gt; 0"
              time="0.002">

    </testcase>
    <system-out><![CDATA[]]></system-out>
    <system-err><![CDATA[]]></system-err>
</testsuite>
```

 #### FlatSpec

 ```
     {
      "fullyQualifiedName": "io.ultra.cloudevent.ATestSuiteFlatSpec",
      "selector": "root should work 1",
      "duration": 16,
      "status": "Success"
    },
    {
      "fullyQualifiedName": "io.ultra.cloudevent.ATestSuiteFlatSpec",
      "selector": "root should work 2",
      "duration": 0,
      "status": "Success"
    },
```

sbt output:
```
<?xml version='1.0' encoding='UTF-8'?>
<testsuite hostname="ultra-lapttop-roro" name="io.ultra.cloudevent.ATestSuiteFlatSpec" tests="2" errors="0" failures="0"
           skipped="0" time="0.017" timestamp="2024-04-24T18:08:19">
    <properties>
        <property name="awt.toolkit" value="sun.awt.X11.XToolkit"/>
        ...
        <property name="java.class.version" value="55.0"/>
    </properties>
    <testcase classname="io.ultra.cloudevent.ATestSuiteFlatSpec" name="root should work 1" time="0.017">

    </testcase>
    <testcase classname="io.ultra.cloudevent.ATestSuiteFlatSpec" name="root should work 2" time="0.0">

    </testcase>
    <system-out><![CDATA[]]></system-out>
    <system-err><![CDATA[]]></system-err>
</testsuite>
```
