### PR TITLE
Add multi platform support to contrib.docker through docker buildx

### DIFF
--- a/contrib/docker/readme.adoc
+++ b/contrib/docker/readme.adoc
@@ -64,7 +64,11 @@ object docker extends DockerConfig {
   def user = "new-user"
   // Optionally override the docker executable to use something else
   def executable = "podman"
+  // If the executable is docker (which is also the default), you can optionally also pass a platform parameter
+  // docker buildx is then used to build multi-platform images
+  def platform = "linux/arm64"
 }
 ----
+
 
 Run mill in interactive mode to see the docker client output, like `mill -i foo.docker.build`.

--- a/contrib/docker/src/mill/contrib/docker/DockerModule.scala
+++ b/contrib/docker/src/mill/contrib/docker/DockerModule.scala
@@ -85,12 +85,12 @@ trait DockerModule { outer: JavaModule =>
     def user: T[String] = ""
 
     /**
-      * Optional platform parameter, if set uses buildkit to build for specified platform.
-      * 
-      * See also the Docker docs on
-      * [[https://docs.docker.com/reference/cli/docker/buildx/build/#platform]]
-      * for more information.
-      */
+     * Optional platform parameter, if set uses buildkit to build for specified platform.
+     *
+     * See also the Docker docs on
+     * [[https://docs.docker.com/reference/cli/docker/buildx/build/#platform]]
+     * for more information.
+     */
     def platform: T[String] = ""
 
     /**
@@ -164,14 +164,23 @@ trait DockerModule { outer: JavaModule =>
       val (pull, _) = pullAndHash()
       val pullLatestBase = IterableShellable(if (pull) Some("--pull") else None)
 
-      
       val result = if (platform().isEmpty || executable() != "docker") {
-        if (platform().nonEmpty) log.info("Platform parameter is ignored when using non-docker executable")
+        if (platform().nonEmpty)
+          log.info("Platform parameter is ignored when using non-docker executable")
         os.proc(executable(), "build", tagArgs, pullLatestBase, dest)
-        .call(stdout = os.Inherit, stderr = os.Inherit)
+          .call(stdout = os.Inherit, stderr = os.Inherit)
       } else {
-        os.proc(executable(),"buildx", "build", tagArgs, pullLatestBase, "--platform", platform(), dest)
-        .call(stdout = os.Inherit, stderr = os.Inherit)
+        os.proc(
+          executable(),
+          "buildx",
+          "build",
+          tagArgs,
+          pullLatestBase,
+          "--platform",
+          platform(),
+          dest
+        )
+          .call(stdout = os.Inherit, stderr = os.Inherit)
       }
       log.info(s"Docker build completed ${if (result.exitCode == 0) "successfully"
         else "unsuccessfully"} with ${result.exitCode}")

--- a/contrib/docker/src/mill/contrib/docker/DockerModule.scala
+++ b/contrib/docker/src/mill/contrib/docker/DockerModule.scala
@@ -165,7 +165,8 @@ trait DockerModule { outer: JavaModule =>
       val pullLatestBase = IterableShellable(if (pull) Some("--pull") else None)
 
       
-      val result = if (platform().isEmpty) {
+      val result = if (platform().isEmpty || executable() != "docker") {
+        if (platform().nonEmpty) log.info("Platform parameter is ignored when using non-docker executable")
         os.proc(executable(), "build", tagArgs, pullLatestBase, dest)
         .call(stdout = os.Inherit, stderr = os.Inherit)
       } else {
@@ -174,7 +175,6 @@ trait DockerModule { outer: JavaModule =>
       }
       log.info(s"Docker build completed ${if (result.exitCode == 0) "successfully"
         else "unsuccessfully"} with ${result.exitCode}")
-      log.info(platform())
       tags()
     }
 

--- a/contrib/docker/src/mill/contrib/docker/DockerModule.scala
+++ b/contrib/docker/src/mill/contrib/docker/DockerModule.scala
@@ -85,6 +85,15 @@ trait DockerModule { outer: JavaModule =>
     def user: T[String] = ""
 
     /**
+      * Optional platform parameter, if set uses buildkit to build for specified platform.
+      * 
+      * See also the Docker docs on
+      * [[https://docs.docker.com/reference/cli/docker/buildx/build/#platform]]
+      * for more information.
+      */
+    def platform: T[String] = ""
+
+    /**
      * The name of the executable to use, the default is "docker".
      */
     def executable: T[String] = "docker"
@@ -155,12 +164,17 @@ trait DockerModule { outer: JavaModule =>
       val (pull, _) = pullAndHash()
       val pullLatestBase = IterableShellable(if (pull) Some("--pull") else None)
 
-      val result = os
-        .proc(executable(), "build", tagArgs, pullLatestBase, dest)
+      
+      val result = if (platform().isEmpty) {
+        os.proc(executable(), "build", tagArgs, pullLatestBase, dest)
         .call(stdout = os.Inherit, stderr = os.Inherit)
-
+      } else {
+        os.proc(executable(),"buildx", "build", tagArgs, pullLatestBase, "--platform", platform(), dest)
+        .call(stdout = os.Inherit, stderr = os.Inherit)
+      }
       log.info(s"Docker build completed ${if (result.exitCode == 0) "successfully"
         else "unsuccessfully"} with ${result.exitCode}")
+      log.info(platform())
       tags()
     }
 

--- a/contrib/docker/src/mill/contrib/docker/DockerModule.scala
+++ b/contrib/docker/src/mill/contrib/docker/DockerModule.scala
@@ -85,12 +85,12 @@ trait DockerModule { outer: JavaModule =>
     def user: T[String] = ""
 
     /**
-      * Optional platform parameter, if set uses buildkit to build for specified platform.
-      * 
-      * See also the Docker docs on
-      * [[https://docs.docker.com/reference/cli/docker/buildx/build/#platform]]
-      * for more information.
-      */
+     * Optional platform parameter, if set uses buildkit to build for specified platform.
+     *
+     * See also the Docker docs on
+     * [[https://docs.docker.com/reference/cli/docker/buildx/build/#platform]]
+     * for more information.
+     */
     def platform: T[String] = ""
 
     /**
@@ -164,14 +164,25 @@ trait DockerModule { outer: JavaModule =>
       val (pull, _) = pullAndHash()
       val pullLatestBase = IterableShellable(if (pull) Some("--pull") else None)
 
-      
       val result = if (platform().isEmpty || executable() != "docker") {
-        if (platform().nonEmpty) log.info("Platform parameter is ignored when using non-docker executable")
+        if (!platform().isEmpty)
+          log.warn(
+            "Building for other platforms is currently only supported through buildx on docker"
+          )
         os.proc(executable(), "build", tagArgs, pullLatestBase, dest)
-        .call(stdout = os.Inherit, stderr = os.Inherit)
+          .call(stdout = os.Inherit, stderr = os.Inherit)
       } else {
-        os.proc(executable(),"buildx", "build", tagArgs, pullLatestBase, "--platform", platform(), dest)
-        .call(stdout = os.Inherit, stderr = os.Inherit)
+        os.proc(
+          executable(),
+          "buildx",
+          "build",
+          tagArgs,
+          pullLatestBase,
+          "--platform",
+          platform(),
+          dest
+        )
+          .call(stdout = os.Inherit, stderr = os.Inherit)
       }
       log.info(s"Docker build completed ${if (result.exitCode == 0) "successfully"
         else "unsuccessfully"} with ${result.exitCode}")

--- a/contrib/docker/src/mill/contrib/docker/DockerModule.scala
+++ b/contrib/docker/src/mill/contrib/docker/DockerModule.scala
@@ -85,12 +85,12 @@ trait DockerModule { outer: JavaModule =>
     def user: T[String] = ""
 
     /**
-     * Optional platform parameter, if set uses buildkit to build for specified platform.
-     *
-     * See also the Docker docs on
-     * [[https://docs.docker.com/reference/cli/docker/buildx/build/#platform]]
-     * for more information.
-     */
+      * Optional platform parameter, if set uses buildkit to build for specified platform.
+      * 
+      * See also the Docker docs on
+      * [[https://docs.docker.com/reference/cli/docker/buildx/build/#platform]]
+      * for more information.
+      */
     def platform: T[String] = ""
 
     /**
@@ -164,25 +164,14 @@ trait DockerModule { outer: JavaModule =>
       val (pull, _) = pullAndHash()
       val pullLatestBase = IterableShellable(if (pull) Some("--pull") else None)
 
+      
       val result = if (platform().isEmpty || executable() != "docker") {
-        if (!platform().isEmpty)
-          log.warn(
-            "Building for other platforms is currently only supported through buildx on docker"
-          )
+        if (platform().nonEmpty) log.info("Platform parameter is ignored when using non-docker executable")
         os.proc(executable(), "build", tagArgs, pullLatestBase, dest)
-          .call(stdout = os.Inherit, stderr = os.Inherit)
+        .call(stdout = os.Inherit, stderr = os.Inherit)
       } else {
-        os.proc(
-          executable(),
-          "buildx",
-          "build",
-          tagArgs,
-          pullLatestBase,
-          "--platform",
-          platform(),
-          dest
-        )
-          .call(stdout = os.Inherit, stderr = os.Inherit)
+        os.proc(executable(),"buildx", "build", tagArgs, pullLatestBase, "--platform", platform(), dest)
+        .call(stdout = os.Inherit, stderr = os.Inherit)
       }
       log.info(s"Docker build completed ${if (result.exitCode == 0) "successfully"
         else "unsuccessfully"} with ${result.exitCode}")


### PR DESCRIPTION
A very minor change to the contrib.docker plugin (and its docs).

Allows to build for other architectures - a use case that becomes more and more useful with ARM architectures becoming more relevant.

**Relevant docs:**
[docker buildx (Buildkit)](https://docs.docker.com/reference/cli/docker/buildx/build/#platform)