### PR TITLE
GenIdea: Use synthetic scala-SDK entry for compiler setup

### DIFF
--- a/idea/src/mill/idea/GenIdeaImpl.scala
+++ b/idea/src/mill/idea/GenIdeaImpl.scala
@@ -759,7 +759,6 @@ case class GenIdeaImpl(
       compilerBridgeJar: Option[os.Path],
       scaladocExtraClasspath: Agg[os.Path]
   ): Elem = {
-    val isScalaLibrary = scalaCompilerClassPath.iterator.nonEmpty
     <component name="libraryTable">
       <library name={name} type="Scala">
         <properties>

--- a/idea/src/mill/idea/GenIdeaImpl.scala
+++ b/idea/src/mill/idea/GenIdeaImpl.scala
@@ -161,18 +161,16 @@ case class GenIdeaImpl(
               mod.resolveDeps(allIvyDeps, sources = true)()
             }
 
-            val (scalacPluginsIvyDeps, allScalacOptions) = mod match {
+            val (scalacPluginsIvyDeps, allScalacOptions, scalaVersion) = mod match {
               case mod: ScalaModule => (
                   T.task(mod.scalacPluginIvyDeps()),
-                  T.task(mod.allScalacOptions())
+                  T.task(mod.allScalacOptions()),
+                  T.task { Some(mod.scalaVersion()) }
                 )
               case _ => (
-                  T.task {
-                    Agg[Dep]()
-                  },
-                  T.task {
-                    Seq()
-                  }
+                  T.task(Agg[Dep]()),
+                  T.task(Seq[String]()),
+                  T.task(None)
                 )
             }
 
@@ -215,6 +213,7 @@ case class GenIdeaImpl(
               val resolvedConfigFileContributions: Seq[IdeaConfigFile] =
                 configFileContributions()
               val resolvedCompilerOutput = compilerOutput()
+              val resolvedScalaVersion = scalaVersion()
 
               ResolvedModule(
                 path = path,
@@ -224,12 +223,13 @@ case class GenIdeaImpl(
                 module = mod,
                 pluginClasspath = resolvedSp.map(_.path).filter(_.ext == "jar"),
                 scalaOptions = scalacOpts,
-                compilerClasspath = resolvedCompilerCp.map(_.path),
+                scalaCompilerClasspath = resolvedCompilerCp.map(_.path),
                 libraryClasspath = resolvedLibraryCp.map(_.path),
                 facets = resolvedFacets,
                 configFileContributions = resolvedConfigFileContributions,
                 compilerOutput = resolvedCompilerOutput.path,
-                evaluator = evaluator
+                evaluator = evaluator,
+                scalaVersion = resolvedScalaVersion
               )
             }
           }
@@ -254,11 +254,6 @@ case class GenIdeaImpl(
       (resolvedModules.flatMap(_.classpath).map(_.value) ++ buildLibraryPaths ++ buildDepsPaths)
         .distinct
         .sorted
-
-    val librariesProperties: Map[os.Path, Agg[os.Path]] =
-      resolvedModules
-        .flatMap(rm => rm.libraryClasspath.map(_ -> rm.compilerClasspath))
-        .toMap
 
     val (wholeFileConfigs, configFileContributions) =
       resolvedModules
@@ -466,8 +461,8 @@ case class GenIdeaImpl(
      * @note `:` in path isn't supported on Windows ~ https://github.com/com-lihaoyi/mill/issues/2243<br>
      *       It comes from [[sbtLibraryNameFromPom]]
      */
-    def libraryNameToFileSystemPathPart(name: String): String = {
-      name.replaceAll("""[-.:]""", "_")
+    def libraryNameToFileSystemPathPart(name: String, ext: String): os.SubPath = {
+      os.sub / s"${name.replaceAll("""[-.:]""", "_")}.${ext}"
     }
 
     val libraries: Seq[(os.SubPath, Elem)] =
@@ -480,47 +475,31 @@ case class GenIdeaImpl(
         }
         for (name <- names)
           yield {
-            val compilerCp: Agg[os.Path] = librariesProperties.getOrElse(resolved.path, Agg.empty)
-            val languageLevel = name match {
-              case _ if compilerCp.iterator.isEmpty => None
-              case _ if name.startsWith("scala3-library_3-3.3.") => Some("Scala_3_3")
-              case _ if name.startsWith("scala3-library_3-3.2.") => Some("Scala_3_2")
-              case _ if name.startsWith("scala3-library_3-3.1.") => Some("Scala_3_1")
-              case _ if name.startsWith("scala3-library_3-3.0.") => Some("Scala_3_0")
-              case _ if name.startsWith("scala-library-2.13.") => Some("Scala_2_13")
-              case _ if name.startsWith("scala-library-2.12.") => Some("Scala_2_12")
-              case _ if name.startsWith("scala-library-2.11.") => Some("Scala_2_11")
-              case _ if name.startsWith("scala-library-2.10.") => Some("Scala_2_10")
-              case _ if name.startsWith("scala-library-2.9.") => Some("Scala_2_9")
-              case _ if name.startsWith("dotty-library-0.27") => Some("Scala_0_27")
-              case _ => None
-            }
             Tuple2(
-              os.sub / "libraries" / s"${libraryNameToFileSystemPathPart(name)}.xml",
+              os.sub / "libraries" / libraryNameToFileSystemPathPart(name, "xml"),
               libraryXmlTemplate(
                 name = name,
                 path = resolved.path,
-                sources = sources,
-                scalaCompilerClassPath = compilerCp,
-                languageLevel = languageLevel
+                sources = sources
               )
             )
           }
       }
 
-    val moduleFiles: Seq[(os.SubPath, Elem)] = resolvedModules.map {
+    val moduleFiles: Seq[(os.SubPath, Elem)] = resolvedModules.flatMap {
       case ResolvedModule(
             path,
             resolvedDeps,
             mod,
             _,
             _,
-            _,
+            compilerClasspath,
             _,
             facets,
             _,
             compilerOutput,
-            evaluator
+            evaluator,
+            scalaVersion
           ) =>
         val Seq(
           resourcesPathRefs: Seq[PathRef],
@@ -540,19 +519,6 @@ case class GenIdeaImpl(
         val normalSourcePaths = (allSourcesPathRefs
           .map(_.path)
           .toSet -- generatedSourcePaths.toSet).toSeq
-
-        val scalaVersionOpt = mod match {
-          case x: ScalaModule =>
-            Some(
-              evaluator.evalOrThrow(
-                exceptionFactory = r =>
-                  GenIdeaException(
-                    s"Failure during evaluation of the scalaVersion: ${Evaluator.formatFailing(r)}"
-                  )
-              )(x.scalaVersion)
-            )
-          case _ => None
-        }
 
         val sanizedDeps: Seq[ScopedOrd[String]] = {
           resolvedDeps
@@ -592,9 +558,9 @@ case class GenIdeaImpl(
 
         val isTest = mod.isInstanceOf[TestModule]
 
-        val elem = moduleXmlTemplate(
+        val moduleXml = moduleXmlTemplate(
           basePath = mod.intellijModulePath,
-          scalaVersionOpt = scalaVersionOpt,
+          scalaVersionOpt = scalaVersion,
           resourcePaths = Strict.Agg.from(resourcesPathRefs.map(_.path)),
           normalSourcePaths = Strict.Agg.from(normalSourcePaths),
           generatedSourcePaths = Strict.Agg.from(generatedSourcePaths),
@@ -605,10 +571,32 @@ case class GenIdeaImpl(
           facets = facets
         )
 
-        Tuple2(
+        val moduleFile = Tuple2(
           os.sub / "mill_modules" / s"${moduleName(path)}.iml",
-          elem
+          moduleXml
         )
+
+        val scalaSdkFile = {
+          Option.when(scalaVersion.isDefined && compilerClasspath.nonEmpty) {
+            val name = s"scala-SDK-${scalaVersion.get}"
+            val languageLevel =
+              scalaVersion.map(_.split("[.]", 3).take(2).mkString("Scala_", "_", ""))
+
+            Tuple2(
+              os.sub / "libraries" / libraryNameToFileSystemPathPart(name, "xml"),
+              scalaSdkTemplate(
+                name = name,
+                languageLevel = languageLevel,
+                scalaCompilerClassPath = compilerClasspath,
+                // FIXME: fill in these fields
+                compilerBridgeJar = None,
+                scaladocExtraClasspath = None
+              )
+            )
+          }
+        }
+
+        Seq(moduleFile) ++ scalaSdkFile
     }
 
     {
@@ -764,32 +752,44 @@ case class GenIdeaImpl(
     }
   }
 
-  def libraryXmlTemplate(
+  def scalaSdkTemplate(
       name: String,
-      path: os.Path,
-      sources: Option[os.Path],
+      languageLevel: Option[String],
       scalaCompilerClassPath: Agg[os.Path],
-      languageLevel: Option[String]
+      compilerBridgeJar: Option[os.Path],
+      scaladocExtraClasspath: Agg[os.Path]
   ): Elem = {
     val isScalaLibrary = scalaCompilerClassPath.iterator.nonEmpty
     <component name="libraryTable">
-      <library name={name} type={if (isScalaLibrary) "Scala" else null}>
-        {
-      if (isScalaLibrary) {
+      <library name={name} type="Scala">
         <properties>
-        {
-          if (languageLevel.isDefined) <language-level>{languageLevel.get}</language-level>
-        }
-        <compiler-classpath>
             {
-          scalaCompilerClassPath.iterator.toSeq.sortBy(_.wrapped).map(p =>
-            <root url={relativeFileUrl(p)}/>
-          )
-        }
-          </compiler-classpath>
-        </properties>
-      }
+      if (languageLevel.isDefined) <language-level>{languageLevel.get}</language-level>
     }
+            <compiler-classpath>
+              {
+      scalaCompilerClassPath.iterator.toSeq.sortBy(_.wrapped).map(p =>
+        <root url={relativeFileUrl(p)}/>
+      )
+    }
+            </compiler-classpath>
+          {
+      if (compilerBridgeJar.isDefined) <compiler-bridge-binary-jar>{
+        relativeFileUrl(compilerBridgeJar.get)
+      }</compiler-bridge-binary-jar>
+    }
+        </properties>
+      </library>
+    </component>
+  }
+
+  def libraryXmlTemplate(
+      name: String,
+      path: os.Path,
+      sources: Option[os.Path]
+  ): Elem = {
+    <component name="libraryTable">
+      <library name={name}>
         <CLASSES>
           <root url={relativeJarUrl(path)}/>
         </CLASSES>
@@ -892,6 +892,11 @@ case class GenIdeaImpl(
     }
         <orderEntry type="inheritedJdk" />
         <orderEntry type="sourceFolder" forTests="false" />
+        {
+      for {
+        scalaVersion <- scalaVersionOpt.toSeq
+      } yield <orderEntry type="library" name={s"scala-SDK-${scalaVersion}"} level="project" />
+    }
 
         {
       for (name <- libNames.sorted)
@@ -1011,12 +1016,13 @@ object GenIdeaImpl {
       module: JavaModule,
       pluginClasspath: Agg[os.Path],
       scalaOptions: Seq[String],
-      compilerClasspath: Agg[os.Path],
+      scalaCompilerClasspath: Agg[os.Path],
       libraryClasspath: Agg[os.Path],
       facets: Seq[JavaFacet],
       configFileContributions: Seq[IdeaConfigFile],
       compilerOutput: os.Path,
-      evaluator: Evaluator
+      evaluator: Evaluator,
+      scalaVersion: Option[String]
   )
 
   case class GenIdeaException(msg: String) extends RuntimeException

--- a/integration/feature/gen-idea/repo/extended/idea/libraries/scala3_library_3_3_0_2_jar.xml
+++ b/integration/feature/gen-idea/repo/extended/idea/libraries/scala3_library_3_3_0_2_jar.xml
@@ -1,0 +1,10 @@
+<component name="libraryTable">
+    <library name="scala3-library_3-3.0.2.jar">
+        <CLASSES>
+            <root url="jar://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala3-library_3/3.0.2/scala3-library_3-3.0.2.jar!/"/>
+        </CLASSES>
+        <SOURCES>
+            <root url="jar://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala3-library_3/3.0.2/scala3-library_3-3.0.2-sources.jar!/"/>
+        </SOURCES>
+    </library>
+</component>

--- a/integration/feature/gen-idea/repo/extended/idea/libraries/scala_SDK_2_13_6.xml
+++ b/integration/feature/gen-idea/repo/extended/idea/libraries/scala_SDK_2_13_6.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+    <library name="scala-SDK-2.13.6" type="Scala">
+        <properties>
+            <language-level>Scala_2_13</language-level>
+            <compiler-classpath>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/net/java/dev/jna/jna/5.3.1/jna-5.3.1.jar"/>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/jline/jline/3.19.0/jline-3.19.0.jar"/>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.13.6/scala-compiler-2.13.6.jar"/>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.6/scala-library-2.13.6.jar"/>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.13.6/scala-reflect-2.13.6.jar"/>
+            </compiler-classpath>
+        </properties>
+    </library>
+</component>

--- a/integration/feature/gen-idea/repo/extended/idea/libraries/scala_SDK_3_0_2.xml
+++ b/integration/feature/gen-idea/repo/extended/idea/libraries/scala_SDK_3_0_2.xml
@@ -1,0 +1,22 @@
+<component name="libraryTable">
+    <library name="scala-SDK-3.0.2" type="Scala">
+        <properties>
+            <language-level>Scala_3_0</language-level>
+            <compiler-classpath>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.7.0/protobuf-java-3.7.0.jar"/>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/net/java/dev/jna/jna/5.3.1/jna-5.3.1.jar"/>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/jline/jline-reader/3.19.0/jline-reader-3.19.0.jar"/>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/jline/jline-terminal-jna/3.19.0/jline-terminal-jna-3.19.0.jar"/>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/jline/jline-terminal/3.19.0/jline-terminal-3.19.0.jar"/>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-asm/9.1.0-scala-1/scala-asm-9.1.0-scala-1.jar"/>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.6/scala-library-2.13.6.jar"/>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala3-compiler_3/3.0.2/scala3-compiler_3-3.0.2.jar"/>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala3-interfaces/3.0.2/scala3-interfaces-3.0.2.jar"/>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala3-library_3/3.0.2/scala3-library_3-3.0.2.jar"/>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/tasty-core_3/3.0.2/tasty-core_3-3.0.2.jar"/>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-sbt/compiler-interface/1.3.5/compiler-interface-1.3.5.jar"/>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-sbt/util-interface/1.3.0/util-interface-1.3.0.jar"/>
+            </compiler-classpath>
+        </properties>
+    </library>
+</component>

--- a/integration/feature/gen-idea/repo/extended/idea/libraries/scala_library_2_13_6_jar.xml
+++ b/integration/feature/gen-idea/repo/extended/idea/libraries/scala_library_2_13_6_jar.xml
@@ -1,15 +1,5 @@
 <component name="libraryTable">
-    <library name="scala-library-2.13.6.jar" type="Scala">
-        <properties>
-            <language-level>Scala_2_13</language-level>
-            <compiler-classpath>
-                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/net/java/dev/jna/jna/5.3.1/jna-5.3.1.jar"/>
-                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/jline/jline/3.19.0/jline-3.19.0.jar"/>
-                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.13.6/scala-compiler-2.13.6.jar"/>
-                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.6/scala-library-2.13.6.jar"/>
-                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.13.6/scala-reflect-2.13.6.jar"/>
-            </compiler-classpath>
-        </properties>
+    <library name="scala-library-2.13.6.jar">
         <CLASSES>
             <root url="jar://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.6/scala-library-2.13.6.jar!/"/>
         </CLASSES>

--- a/integration/feature/gen-idea/repo/extended/idea/mill_modules/helloworld.iml
+++ b/integration/feature/gen-idea/repo/extended/idea/mill_modules/helloworld.iml
@@ -11,6 +11,7 @@
         </content>
         <orderEntry type="inheritedJdk"/>
         <orderEntry type="sourceFolder" forTests="false"/>
+        <orderEntry type="library" name="scala-SDK-2.13.6" level="project"/>
         <orderEntry type="library" name="scala-library-2.13.6.jar" level="project"/>
     </component>
     <component name="FacetManager">

--- a/integration/feature/gen-idea/repo/extended/idea/mill_modules/helloworld.subscala3.iml
+++ b/integration/feature/gen-idea/repo/extended/idea/mill_modules/helloworld.subscala3.iml
@@ -8,6 +8,7 @@
         </content>
         <orderEntry type="inheritedJdk"/>
         <orderEntry type="sourceFolder" forTests="false"/>
+        <orderEntry type="library" name="scala-SDK-3.0.2" level="project"/>
         <orderEntry type="library" name="scala-library-2.13.6.jar" level="project"/>
         <orderEntry type="library" name="scala3-library_3-3.0.2.jar" level="project"/>
     </component>

--- a/integration/feature/gen-idea/repo/extended/idea/mill_modules/helloworld.test.iml
+++ b/integration/feature/gen-idea/repo/extended/idea/mill_modules/helloworld.test.iml
@@ -8,6 +8,7 @@
         </content>
         <orderEntry type="inheritedJdk"/>
         <orderEntry type="sourceFolder" forTests="false"/>
+        <orderEntry type="library" name="scala-SDK-2.13.6" level="project"/>
         <orderEntry type="library" name="scala-library-2.13.6.jar" level="project"/>
         <orderEntry type="module" module-name="helloworld" exported=""/>
     </component>

--- a/integration/feature/gen-idea/repo/extended/idea/mill_modules/mill-build.iml
+++ b/integration/feature/gen-idea/repo/extended/idea/mill_modules/mill-build.iml
@@ -10,6 +10,7 @@
         </content>
         <orderEntry type="inheritedJdk"/>
         <orderEntry type="sourceFolder" forTests="false"/>
+        <orderEntry type="library" name="scala-SDK-<!-- IGNORE -->" level="project"/>
 <!-- IGNORE -->
     </component>
 </module>

--- a/integration/feature/gen-idea/repo/hello-idea/build.sc
+++ b/integration/feature/gen-idea/repo/hello-idea/build.sc
@@ -20,7 +20,11 @@ trait HelloIdeaModule extends scalalib.ScalaModule {
   }
 }
 
-object HelloIdea extends HelloIdeaModule
+object HelloIdea extends HelloIdeaModule {
+  object scala3 extends HelloIdeaModule {
+    def scalaVersion = "3.3.1"
+  }
+}
 
 object HiddenIdea extends HelloIdeaModule {
   override def skipIdea = true

--- a/integration/feature/gen-idea/repo/hello-idea/idea/libraries/scala3_library_3_3_3_1_jar.xml
+++ b/integration/feature/gen-idea/repo/hello-idea/idea/libraries/scala3_library_3_3_3_1_jar.xml
@@ -1,0 +1,10 @@
+<component name="libraryTable">
+    <library name="scala3-library_3-3.3.1.jar">
+        <CLASSES>
+            <root url="jar://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala3-library_3/3.3.1/scala3-library_3-3.3.1.jar!/"/>
+        </CLASSES>
+        <SOURCES>
+            <root url="jar://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala3-library_3/3.3.1/scala3-library_3-3.3.1-sources.jar!/"/>
+        </SOURCES>
+    </library>
+</component>

--- a/integration/feature/gen-idea/repo/hello-idea/idea/libraries/scala_SDK_2_12_5.xml
+++ b/integration/feature/gen-idea/repo/hello-idea/idea/libraries/scala_SDK_2_12_5.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+    <library name="scala-SDK-2.12.5" type="Scala">
+        <properties>
+            <language-level>Scala_2_12</language-level>
+            <compiler-classpath>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.0.6/scala-xml_2.12-1.0.6.jar"/>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.12.5/scala-compiler-2.12.5.jar"/>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.5/scala-library-2.12.5.jar"/>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.5/scala-reflect-2.12.5.jar"/>
+            </compiler-classpath>
+        </properties>
+    </library>
+</component>

--- a/integration/feature/gen-idea/repo/hello-idea/idea/libraries/scala_SDK_2_13_14.xml
+++ b/integration/feature/gen-idea/repo/hello-idea/idea/libraries/scala_SDK_2_13_14.xml
@@ -1,0 +1,15 @@
+<component name="libraryTable">
+    <library name="scala-SDK-2.13.14" type="Scala">
+        <properties>
+            <language-level>Scala_2_13</language-level>
+            <compiler-classpath>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/io/github/java-diff-utils/java-diff-utils/4.12/java-diff-utils-4.12.jar"/>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/net/java/dev/jna/jna/5.14.0/jna-5.14.0.jar"/>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/jline/jline/3.25.1/jline-3.25.1.jar"/>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.13.14/scala-compiler-2.13.14.jar"/>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.14/scala-library-2.13.14.jar"/>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.13.14/scala-reflect-2.13.14.jar"/>
+            </compiler-classpath>
+        </properties>
+    </library>
+</component>

--- a/integration/feature/gen-idea/repo/hello-idea/idea/libraries/scala_SDK_3_3_1.xml
+++ b/integration/feature/gen-idea/repo/hello-idea/idea/libraries/scala_SDK_3_3_1.xml
@@ -1,0 +1,22 @@
+<component name="libraryTable">
+    <library name="scala-SDK-3.3.1" type="Scala">
+        <properties>
+            <language-level>Scala_3_3</language-level>
+            <compiler-classpath>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.7.0/protobuf-java-3.7.0.jar"/>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/net/java/dev/jna/jna/5.3.1/jna-5.3.1.jar"/>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/jline/jline-reader/3.19.0/jline-reader-3.19.0.jar"/>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/jline/jline-terminal-jna/3.19.0/jline-terminal-jna-3.19.0.jar"/>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/jline/jline-terminal/3.19.0/jline-terminal-3.19.0.jar"/>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-asm/9.5.0-scala-1/scala-asm-9.5.0-scala-1.jar"/>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.10/scala-library-2.13.10.jar"/>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala3-compiler_3/3.3.1/scala3-compiler_3-3.3.1.jar"/>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala3-interfaces/3.3.1/scala3-interfaces-3.3.1.jar"/>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala3-library_3/3.3.1/scala3-library_3-3.3.1.jar"/>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/tasty-core_3/3.3.1/tasty-core_3-3.3.1.jar"/>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-sbt/compiler-interface/1.3.5/compiler-interface-1.3.5.jar"/>
+                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-sbt/util-interface/1.3.0/util-interface-1.3.0.jar"/>
+            </compiler-classpath>
+        </properties>
+    </library>
+</component>

--- a/integration/feature/gen-idea/repo/hello-idea/idea/libraries/scala_library_2_12_5_jar.xml
+++ b/integration/feature/gen-idea/repo/hello-idea/idea/libraries/scala_library_2_12_5_jar.xml
@@ -1,14 +1,5 @@
 <component name="libraryTable">
-    <library name="scala-library-2.12.5.jar" type="Scala">
-        <properties>
-            <language-level>Scala_2_12</language-level>
-            <compiler-classpath>
-                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.0.6/scala-xml_2.12-1.0.6.jar"/>
-                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.12.5/scala-compiler-2.12.5.jar"/>
-                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.5/scala-library-2.12.5.jar"/>
-                <root url="file://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.5/scala-reflect-2.12.5.jar"/>
-            </compiler-classpath>
-        </properties>
+    <library name="scala-library-2.12.5.jar">
         <CLASSES>
             <root url="jar://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.5/scala-library-2.12.5.jar!/"/>
         </CLASSES>

--- a/integration/feature/gen-idea/repo/hello-idea/idea/libraries/scala_library_2_13_14_jar.xml
+++ b/integration/feature/gen-idea/repo/hello-idea/idea/libraries/scala_library_2_13_14_jar.xml
@@ -1,0 +1,10 @@
+<component name="libraryTable">
+    <library name="scala-library-2.13.14.jar">
+        <CLASSES>
+            <root url="jar://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.14/scala-library-2.13.14.jar!/"/>
+        </CLASSES>
+        <SOURCES>
+            <root url="jar://$USER_HOME$/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.14/scala-library-2.13.14-sources.jar!/"/>
+        </SOURCES>
+    </library>
+</component>

--- a/integration/feature/gen-idea/repo/hello-idea/idea/mill_modules/helloidea.iml
+++ b/integration/feature/gen-idea/repo/hello-idea/idea/mill_modules/helloidea.iml
@@ -8,6 +8,7 @@
         </content>
         <orderEntry type="inheritedJdk"/>
         <orderEntry type="sourceFolder" forTests="false"/>
+        <orderEntry type="library" name="scala-SDK-2.12.5" level="project"/>
         <orderEntry type="library" name="scala-library-2.12.5.jar" level="project"/>
     </component>
 </module>

--- a/integration/feature/gen-idea/repo/hello-idea/idea/mill_modules/helloidea.scala3.iml
+++ b/integration/feature/gen-idea/repo/hello-idea/idea/mill_modules/helloidea.scala3.iml
@@ -1,0 +1,15 @@
+<module type="JAVA_MODULE" version="4">
+    <component name="NewModuleRootManager">
+        <output url="file://$MODULE_DIR$/../../out/HelloIdea/scala3/ideaCompileOutput.dest/classes"/>
+        <exclude-output/>
+        <content url="file://$MODULE_DIR$/../../HelloIdea/scala3">
+            <sourceFolder url="file://$MODULE_DIR$/../../HelloIdea/scala3/src" isTestSource="false"/>
+            <sourceFolder url="file://$MODULE_DIR$/../../HelloIdea/scala3/resources" type="java-resource"/>
+        </content>
+        <orderEntry type="inheritedJdk"/>
+        <orderEntry type="sourceFolder" forTests="false"/>
+        <orderEntry type="library" name="scala-SDK-3.3.1" level="project"/>
+        <orderEntry type="library" name="scala-library-2.13.10.jar" level="project"/>
+        <orderEntry type="library" name="scala3-library_3-3.3.1.jar" level="project"/>
+    </component>
+</module>

--- a/integration/feature/gen-idea/repo/hello-idea/idea/mill_modules/helloidea.scala3.test.iml
+++ b/integration/feature/gen-idea/repo/hello-idea/idea/mill_modules/helloidea.scala3.test.iml
@@ -1,0 +1,20 @@
+<module type="JAVA_MODULE" version="4">
+    <component name="NewModuleRootManager">
+        <output-test url="file://$MODULE_DIR$/../../out/HelloIdea/scala3/test/ideaCompileOutput.dest/classes"/>
+        <exclude-output/>
+        <content url="file://$MODULE_DIR$/../../HelloIdea/scala3/test">
+            <sourceFolder url="file://$MODULE_DIR$/../../HelloIdea/scala3/test/src" isTestSource="true"/>
+            <sourceFolder url="file://$MODULE_DIR$/../../HelloIdea/scala3/test/resources" type="java-test-resource"/>
+        </content>
+        <orderEntry type="inheritedJdk"/>
+        <orderEntry type="sourceFolder" forTests="false"/>
+        <orderEntry type="library" name="scala-SDK-3.3.1" level="project"/>
+        <orderEntry type="library" scope="PROVIDED" name="jcl-over-slf4j-1.7.25.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="logback-classic-1.2.3.jar" level="project"/>
+        <orderEntry type="library" name="logback-core-1.2.3.jar" level="project"/>
+        <orderEntry type="library" name="scala-library-2.13.10.jar" level="project"/>
+        <orderEntry type="library" name="scala3-library_3-3.3.1.jar" level="project"/>
+        <orderEntry type="library" name="slf4j-api-1.7.25.jar" level="project"/>
+        <orderEntry type="module" module-name="helloidea.scala3" exported=""/>
+    </component>
+</module>

--- a/integration/feature/gen-idea/repo/hello-idea/idea/mill_modules/helloidea.test.iml
+++ b/integration/feature/gen-idea/repo/hello-idea/idea/mill_modules/helloidea.test.iml
@@ -8,6 +8,7 @@
         </content>
         <orderEntry type="inheritedJdk"/>
         <orderEntry type="sourceFolder" forTests="false"/>
+        <orderEntry type="library" name="scala-SDK-2.12.5" level="project"/>
         <orderEntry type="library" scope="PROVIDED" name="jcl-over-slf4j-1.7.25.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="logback-classic-1.2.3.jar" level="project"/>
         <orderEntry type="library" name="logback-core-1.2.3.jar" level="project"/>

--- a/integration/feature/gen-idea/repo/hello-idea/idea/mill_modules/mill-build.iml
+++ b/integration/feature/gen-idea/repo/hello-idea/idea/mill_modules/mill-build.iml
@@ -8,6 +8,7 @@
         </content>
         <orderEntry type="inheritedJdk"/>
         <orderEntry type="sourceFolder" forTests="false"/>
+        <orderEntry type="library" name="scala-SDK-2.13.<!-- IGNORE -->" level="project"/>
 <!-- IGNORE -->
     </component>
 </module>

--- a/integration/feature/gen-idea/repo/hello-idea/idea/modules.xml
+++ b/integration/feature/gen-idea/repo/hello-idea/idea/modules.xml
@@ -2,6 +2,8 @@
     <component name="ProjectModuleManager">
         <modules>
             <module fileurl="file://$PROJECT_DIR$/.idea/mill_modules/helloidea.iml" filepath="$PROJECT_DIR$/.idea/mill_modules/helloidea.iml"/>
+            <module fileurl="file://$PROJECT_DIR$/.idea/mill_modules/helloidea.scala3.iml" filepath="$PROJECT_DIR$/.idea/mill_modules/helloidea.scala3.iml"/>
+            <module fileurl="file://$PROJECT_DIR$/.idea/mill_modules/helloidea.scala3.test.iml" filepath="$PROJECT_DIR$/.idea/mill_modules/helloidea.scala3.test.iml"/>
             <module fileurl="file://$PROJECT_DIR$/.idea/mill_modules/helloidea.test.iml" filepath="$PROJECT_DIR$/.idea/mill_modules/helloidea.test.iml"/>
             <module fileurl="file://$PROJECT_DIR$/.idea/mill_modules/mill-build.iml" filepath="$PROJECT_DIR$/.idea/mill_modules/mill-build.iml"/>
         </modules>


### PR DESCRIPTION
Previously, we attached the compiler setup to the scala-library entry. This doen't work well for Scala 3 projects, since there multiple scala-library entries are present, one for Scala 2 and one for Scala 3. If the Scala 2 version comes first, IJ uses the wrong compiler setup.

This change splits the scala-library from the compiler setup. The compiler setup now becomes a dedicated synthetic `scala-SDK` library entry for each Scala module. The scala-library no longer has any special semantic and is just an ordinary jar. Only one scala-SDK entry is added to each Scala module resulting in a proper setup.

Fix https://github.com/com-lihaoyi/mill/issues/2867
