### PR TITLE
Update semanticdb-scalac from 4.9.3 to 4.9.4

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -179,7 +179,7 @@ object Deps {
   val scalatags = ivy"com.lihaoyi::scalatags:0.12.0"
   def scalaXml = ivy"org.scala-lang.modules::scala-xml:2.2.0"
   // keep in sync with doc/antora/antory.yml
-  val semanticDBscala = ivy"org.scalameta:::semanticdb-scalac:4.9.3"
+  val semanticDBscala = ivy"org.scalameta:::semanticdb-scalac:4.9.4"
   val semanticDbJava = ivy"com.sourcegraph:semanticdb-java:0.9.10"
   val sourcecode = ivy"com.lihaoyi::sourcecode:0.3.1"
   val upickle = ivy"com.lihaoyi::upickle:3.2.0"

--- a/build.sc
+++ b/build.sc
@@ -58,7 +58,7 @@ object Deps {
   // The Scala 2.12.x version to use for some workers
   val workerScalaVersion212 = "2.12.19"
 
-  val testScala213Version = "2.13.10"
+  val testScala213Version = "2.13.14"
   // Scala Native 4.2 will not get releases for new Scala version
   val testScala213VersionForScalaNative42 = "2.13.8"
   val testScala212Version = "2.12.6"

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -8,6 +8,6 @@ asciidoc:
     mill-version: '0.11.7'
     mill-last-tag: '0.11.7'
     bsp-version: '2.2.0-M1'
-    example-semanticdb-version: '4.9.3'
+    example-semanticdb-version: '4.9.4'
     example-scala-2-13-version: '2.13.12'
     example-utest-version: '0.8.2'

--- a/scalajslib/test/src/mill/scalajslib/OutputPatternsTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/OutputPatternsTests.scala
@@ -13,7 +13,8 @@ object OutputPatternsTests extends TestSuite {
     object outputPatternsModule extends ScalaJSModule {
       override def millSourcePath = workspacePath
       override def scalaVersion = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
-      override def scalaJSVersion = sys.props.getOrElse("TEST_SCALAJS_VERSION", ???) // at least "1.12.0"
+      override def scalaJSVersion =
+        sys.props.getOrElse("TEST_SCALAJS_VERSION", ???) // at least "1.12.0"
       override def moduleKind = ModuleKind.CommonJSModule
       override def scalaJSOutputPatterns = OutputPatterns.fromJSFile("%s.mjs")
     }

--- a/scalajslib/test/src/mill/scalajslib/OutputPatternsTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/OutputPatternsTests.scala
@@ -13,7 +13,7 @@ object OutputPatternsTests extends TestSuite {
     object outputPatternsModule extends ScalaJSModule {
       override def millSourcePath = workspacePath
       override def scalaVersion = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
-      override def scalaJSVersion = "1.12.0"
+      override def scalaJSVersion = sys.props.getOrElse("TEST_SCALAJS_VERSION", ???) // at least "1.12.0"
       override def moduleKind = ModuleKind.CommonJSModule
       override def scalaJSOutputPatterns = OutputPatterns.fromJSFile("%s.mjs")
     }

--- a/scalajslib/test/src/mill/scalajslib/SmallModulesForTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/SmallModulesForTests.scala
@@ -13,7 +13,7 @@ object SmallModulesForTests extends TestSuite {
     object smallModulesForModule extends ScalaJSModule {
       override def millSourcePath = workspacePath
       override def scalaVersion = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
-      override def scalaJSVersion = "1.10.0"
+      override def scalaJSVersion = sys.props.getOrElse("TEST_SCALAJS_VERSION", ???) // at least "1.10.0"
       override def moduleKind = ModuleKind.ESModule
       override def moduleSplitStyle = ModuleSplitStyle.SmallModulesFor(List("app"))
     }
@@ -30,17 +30,20 @@ object SmallModulesForTests extends TestSuite {
 
     test("ModuleSplitStyle.SmallModulesFor") {
       println(evaluator(SmallModulesForModule.smallModulesForModule.sources))
-      val Right((report, _)) =
-        evaluator(SmallModulesForModule.smallModulesForModule.fastLinkJS)
+
+      val Right((report, _)) = evaluator(SmallModulesForModule.smallModulesForModule.fastLinkJS)
       val publicModules = report.publicModules
       test("it should have a single publicModule") {
         assert(publicModules.size == 1)
       }
-      val modulesLength = os.list(report.dest.path).length
       test("my.Foo should not have its own file since it is in a separate package") {
         assert(!os.exists(report.dest.path / "otherpackage.Foo.js"))
       }
-      assert(modulesLength == 10)
+      println(os.list(report.dest.path))
+      val modulesLength = os.list(report.dest.path).length
+
+      // this changed from 10 to 8 after Scala JS version 1.13
+      assert(modulesLength == 8)
     }
   }
 

--- a/scalajslib/test/src/mill/scalajslib/SmallModulesForTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/SmallModulesForTests.scala
@@ -13,7 +13,8 @@ object SmallModulesForTests extends TestSuite {
     object smallModulesForModule extends ScalaJSModule {
       override def millSourcePath = workspacePath
       override def scalaVersion = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
-      override def scalaJSVersion = sys.props.getOrElse("TEST_SCALAJS_VERSION", ???) // at least "1.10.0"
+      override def scalaJSVersion =
+        sys.props.getOrElse("TEST_SCALAJS_VERSION", ???) // at least "1.10.0"
       override def moduleKind = ModuleKind.ESModule
       override def moduleSplitStyle = ModuleSplitStyle.SmallModulesFor(List("app"))
     }

--- a/scalajslib/test/src/mill/scalajslib/SourceMapTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/SourceMapTests.scala
@@ -12,7 +12,8 @@ object SourceMapTests extends TestSuite {
     object sourceMapModule extends ScalaJSModule {
       override def millSourcePath = workspacePath
       override def scalaVersion = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
-      override def scalaJSVersion = sys.props.getOrElse("TEST_SCALAJS_VERSION", ???) // at least 1.8.0
+      override def scalaJSVersion =
+        sys.props.getOrElse("TEST_SCALAJS_VERSION", ???) // at least 1.8.0
       override def scalaJSSourceMap = false
     }
 

--- a/scalajslib/test/src/mill/scalajslib/SourceMapTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/SourceMapTests.scala
@@ -12,7 +12,7 @@ object SourceMapTests extends TestSuite {
     object sourceMapModule extends ScalaJSModule {
       override def millSourcePath = workspacePath
       override def scalaVersion = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
-      override def scalaJSVersion = "1.8.0"
+      override def scalaJSVersion = sys.props.getOrElse("TEST_SCALAJS_VERSION", ???) // at least 1.8.0
       override def scalaJSSourceMap = false
     }
 

--- a/scalajslib/test/src/mill/scalajslib/TopLevelExportsTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/TopLevelExportsTests.scala
@@ -13,7 +13,8 @@ object TopLevelExportsTests extends TestSuite {
     object topLevelExportsModule extends ScalaJSModule {
       override def millSourcePath = workspacePath
       override def scalaVersion = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
-      override def scalaJSVersion = sys.props.getOrElse("TEST_SCALAJS_VERSION", ???) // at least "1.8.0"
+      override def scalaJSVersion =
+        sys.props.getOrElse("TEST_SCALAJS_VERSION", ???) // at least "1.8.0"
       override def moduleKind = ModuleKind.ESModule
     }
 

--- a/scalajslib/test/src/mill/scalajslib/TopLevelExportsTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/TopLevelExportsTests.scala
@@ -13,7 +13,7 @@ object TopLevelExportsTests extends TestSuite {
     object topLevelExportsModule extends ScalaJSModule {
       override def millSourcePath = workspacePath
       override def scalaVersion = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
-      override def scalaJSVersion = "1.8.0"
+      override def scalaJSVersion = sys.props.getOrElse("TEST_SCALAJS_VERSION", ???) // at least "1.8.0"
       override def moduleKind = ModuleKind.ESModule
     }
 


### PR DESCRIPTION
semanticdb-scalac dropped support for Scala 2.13.10, so I bumped the Scala version for some tests.