### PR TITLE
Fix timestamp attribute in junit xml report

### DIFF
--- a/scalalib/src/mill/scalalib/TestModule.scala
+++ b/scalalib/src/mill/scalalib/TestModule.scala
@@ -387,8 +387,8 @@ object TestModule {
                  failures={testResults.count(_.status == Status.Failure.toString).toString}
                  errors={testResults.count(_.status == Status.Error.toString).toString}
                  skipped={testResults.count(_.status == Status.Skipped.toString).toString}
-                 time={(testResults.map(_.duration).sum / 1000.0).toString}>
-                 timestamp={timestamp}
+                 time={(testResults.map(_.duration).sum / 1000.0).toString}
+                 timestamp={timestamp}>
         {properties}
         {cases}
       </testsuite>


### PR DESCRIPTION
There is a bug in the way the `testsuite` element is generated.
### Actual
```
    <testsuite name="MyTest" tests="4" failures="0" errors="0" skipped="0"
               time="0.724">
        timestamp=2024-05-21T18:57:25
        ...
    </testsuite>
```
### Expected
```
    <testsuite name="MyTest" tests="4" failures="0" errors="0" skipped="0"
               time="0.724" timestamp="2024-05-21T18:57:25">
        ...
    </testsuite>
```

The `timestamp` attribute in not an attribute...