### PR TITLE
Update Play 3.0 version from 3.0.1 to 3.0.3

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -121,7 +121,7 @@ object Deps {
     val playVersion = "2.9.1"
   }
   object Play_3_0 extends Play {
-    val playVersion = "3.0.1"
+    val playVersion = "3.0.3"
   }
   val play =
     Seq(Play_3_0, Play_2_9, Play_2_8, Play_2_7, Play_2_6).map(p => (p.playBinVersion, p)).toMap

--- a/contrib/playlib/worker/src-shared/mill/playlib/worker/RouteCompilerWorkerBase.scala
+++ b/contrib/playlib/worker/src-shared/mill/playlib/worker/RouteCompilerWorkerBase.scala
@@ -83,7 +83,7 @@ protected[playlib] class RouteCompilerWorkerBase extends RouteCompilerWorkerApi 
   ): Either[Seq[RoutesCompilationError], Seq[File]] = {
     val result =
       RoutesCompiler.compile(
-        RoutesCompilerTask(
+        new RoutesCompilerTask(
           file.toIO,
           additionalImports,
           forwardsRouter,


### PR DESCRIPTION
Router compiler API changed slightly. To use the convenience constructor, I have to use the `new` keyword.