### PR TITLE
Fix compiler bridge build setup and build essential versions in CI

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -152,7 +152,7 @@ jobs:
   publish-sonatype:
     # when in master repo, publish all tags and manual runs on main
     if: github.repository == 'com-lihaoyi/mill' && (startsWith( github.ref, 'refs/tags/') || (github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch' ) )
-    needs: [linux, windows, format-check, bincompat-check, scalafix-check, itest]
+    needs: [linux, windows, compiler-bridge, format-check, bincompat-check, scalafix-check, itest]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -53,7 +53,6 @@ jobs:
               ./mill -i -k __.ivyDepsTree
               ./mill -i -k __.ivyDepsTree --withRuntime
 
-
     uses: ./.github/workflows/run-mill-action.yml
     with:
       java-version: ${{ matrix.java-version }}
@@ -86,10 +85,18 @@ jobs:
           - java-version: 17
             millargs: docs.githubPages
 
+
     uses: ./.github/workflows/run-mill-action.yml
     with:
       java-version: ${{ matrix.java-version }}
       millargs: ${{ matrix.millargs }}
+
+  compiler-bridge:
+    uses: ./.github/workflows/run-mill-action.yml
+    with:
+      java-version: '8'
+      millargs: bridge.__.publishLocal
+      env-bridge-versions: 'essential'
 
   format-check:
     uses: ./.github/workflows/run-mill-action.yml

--- a/.github/workflows/run-mill-action.yml
+++ b/.github/workflows/run-mill-action.yml
@@ -22,7 +22,7 @@ on:
         default: 90
         type: number
       env-bridge-versions:
-        default: ''
+        default: 'none'
         type: string
 
 jobs:

--- a/.github/workflows/run-mill-action.yml
+++ b/.github/workflows/run-mill-action.yml
@@ -21,6 +21,9 @@ on:
       timeout-minutes:
         default: 90
         type: number
+      env-bridge-versions:
+        default: ''
+        type: string
 
 jobs:
   build:
@@ -28,6 +31,8 @@ jobs:
     runs-on: ${{ inputs.os }}
     continue-on-error: ${{ inputs.continue-on-error }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
+    env:
+      MILL_COMPILER_BRIDGE_VERSIONS: ${{ inputs.env-bridge-versions }}
 
     steps:
       - uses: actions/checkout@v4

--- a/build.sc
+++ b/build.sc
@@ -280,10 +280,10 @@ val bridgeScalaVersions = (essentialBridgeScalaVersions ++ Seq(
 // if given.
 val compilerBridgeScalaVersions =
   interp.watchValue(sys.env.get("MILL_COMPILER_BRIDGE_VERSIONS")) match {
-    case None | Some("") => Seq.empty[String]
+    case None | Some("") | Some("none") => Seq.empty[String]
     case Some("all") => bridgeScalaVersions
     case Some("essential") => essentialBridgeScalaVersions
-    case Some(versions) => versions.split(',').map(_.trim()).toSeq
+    case Some(versions) => versions.split(',').map(_.trim()).filterNot(_.isEmpty).toSeq
   }
 val bridgeVersion = "0.0.1"
 

--- a/build.sc
+++ b/build.sc
@@ -235,11 +235,9 @@ def millBinPlatform: T[String] = T {
 
 def baseDir = build.millSourcePath
 
-val bridgeScalaVersions = (Seq(
-  Deps.scalaVersion,
-  Deps.scalaVersionForScoverageWorker1,
-  Deps.workerScalaVersion212
-) ++ Seq(
+val essentialBridgeScalaVersions =
+  Seq(Deps.scalaVersion, Deps.scalaVersionForScoverageWorker1, Deps.workerScalaVersion212)
+val bridgeScalaVersions = (essentialBridgeScalaVersions ++ Seq(
   // Our version of Zinc doesn't work with Scala 2.12.0 and 2.12.4 compiler
   // bridges. We skip 2.12.1 because it's so old not to matter, and we need a
   // non-supported scala version for testing purposes. We skip 2.13.0-2 because
@@ -282,9 +280,10 @@ val bridgeScalaVersions = (Seq(
 // if given.
 val compilerBridgeScalaVersions =
   interp.watchValue(sys.env.get("MILL_COMPILER_BRIDGE_VERSIONS")) match {
-    case None => Seq.empty[String]
+    case None | Some("") => Seq.empty[String]
     case Some("all") => bridgeScalaVersions
-    case Some(versions) => versions.split(',').map(_.trim).toSeq
+    case Some("essential") => essentialBridgeScalaVersions
+    case Some(versions) => versions.split(',').map(_.trim()).toSeq
   }
 val bridgeVersion = "0.0.1"
 

--- a/build.sc
+++ b/build.sc
@@ -192,7 +192,6 @@ object Deps {
   val jarjarabrams = ivy"com.eed3si9n.jarjarabrams::jarjar-abrams-core:1.14.0"
   val requests = ivy"com.lihaoyi::requests:0.8.2"
 
-
   /** Used to manage transitive versions. */
   val transitiveDeps = Seq(
     ivy"org.apache.ant:ant:1.10.14",
@@ -236,10 +235,14 @@ def millBinPlatform: T[String] = T {
 
 def baseDir = build.millSourcePath
 
-val bridgeScalaVersions = Seq(
+val bridgeScalaVersions = (Seq(
+  Deps.scalaVersion,
+  Deps.scalaVersionForScoverageWorker1,
+  Deps.workerScalaVersion212
+) ++ Seq(
   // Our version of Zinc doesn't work with Scala 2.12.0 and 2.12.4 compiler
   // bridges. We skip 2.12.1 because it's so old not to matter, and we need a
-  // non-supported scala versionm for testing purposes. We skip 2.13.0-2 because
+  // non-supported scala version for testing purposes. We skip 2.13.0-2 because
   // scaladoc fails on windows
   /*"2.12.0",*/ /*2.12.1",*/ "2.12.2",
   "2.12.3", /*"2.12.4",*/ "2.12.5",
@@ -257,7 +260,8 @@ val bridgeScalaVersions = Seq(
   "2.12.17",
   "2.12.18",
   "2.12.19",
-  /*"2.13.0", "2.13.1", "2.13.2",*/ "2.13.3",
+  /*"2.13.0", "2.13.1", "2.13.2",*/
+  "2.13.3",
   "2.13.4",
   "2.13.5",
   "2.13.6",
@@ -267,8 +271,9 @@ val bridgeScalaVersions = Seq(
   "2.13.10",
   "2.13.11",
   "2.13.12",
-  "2.13.13"
-)
+  "2.13.13",
+  "2.13.14"
+)).distinct
 
 // We limit the number of compiler bridges to compile and publish for local
 // development and testing, because otherwise it takes forever to compile all

--- a/build.sc
+++ b/build.sc
@@ -237,7 +237,8 @@ def baseDir = build.millSourcePath
 
 val essentialBridgeScalaVersions =
   Seq(Deps.scalaVersion, Deps.scalaVersionForScoverageWorker1, Deps.workerScalaVersion212)
-val bridgeScalaVersions = (essentialBridgeScalaVersions ++ Seq(
+// published compiler bridges
+val bridgeScalaVersions = Seq(
   // Our version of Zinc doesn't work with Scala 2.12.0 and 2.12.4 compiler
   // bridges. We skip 2.12.1 because it's so old not to matter, and we need a
   // non-supported scala version for testing purposes. We skip 2.13.0-2 because
@@ -269,9 +270,8 @@ val bridgeScalaVersions = (essentialBridgeScalaVersions ++ Seq(
   "2.13.10",
   "2.13.11",
   "2.13.12",
-  "2.13.13",
-  "2.13.14"
-)).distinct
+  "2.13.13"
+)
 
 // We limit the number of compiler bridges to compile and publish for local
 // development and testing, because otherwise it takes forever to compile all
@@ -281,7 +281,7 @@ val bridgeScalaVersions = (essentialBridgeScalaVersions ++ Seq(
 val compilerBridgeScalaVersions =
   interp.watchValue(sys.env.get("MILL_COMPILER_BRIDGE_VERSIONS")) match {
     case None | Some("") | Some("none") => Seq.empty[String]
-    case Some("all") => bridgeScalaVersions
+    case Some("all") => (essentialBridgeScalaVersions ++ bridgeScalaVersions).distinct
     case Some("essential") => essentialBridgeScalaVersions
     case Some(versions) => versions.split(',').map(_.trim()).filterNot(_.isEmpty).toSeq
   }


### PR DESCRIPTION
Fixed the build setup to build compiler brigdes. There were missing dependencies. I added all transitive dependencies of the source package to the compile classpath.

Also extended the CI setup to build essential compiler bridges with each CI run to detect any issues as early as possible.

Fix https://github.com/com-lihaoyi/mill/issues/2576