### PR TITLE
Make scalafmt version dynamic in ScalafmtModule

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -165,7 +165,7 @@ object Deps {
   val scalaCheck = ivy"org.scalacheck::scalacheck:1.17.0"
   def scalaCompiler(scalaVersion: String) = ivy"org.scala-lang:scala-compiler:${scalaVersion}"
   // last scalafmt release supporting Java 8 is 3.7.15
-  val scalafmtDynamic = ivy"org.scalameta::scalafmt-dynamic:3.7.15" // scala-steward:off
+  val scalafmtInterfaces = ivy"org.scalameta:scalafmt-interfaces:3.7.15" // scala-steward:off
   def scalap(scalaVersion: String) = ivy"org.scala-lang:scalap:${scalaVersion}"
   def scalaReflect(scalaVersion: String) = ivy"org.scala-lang:scala-reflect:${scalaVersion}"
   val scalacScoveragePlugin = ivy"org.scoverage:::scalac-scoverage-plugin:1.4.11"
@@ -732,7 +732,7 @@ def formatDep(dep: Dep) = {
 
 object scalalib extends MillStableScalaModule {
   def moduleDeps = Seq(main, scalalib.api, testrunner)
-  def ivyDeps = Agg(Deps.scalafmtDynamic, Deps.scalaXml)
+  def ivyDeps = Agg(Deps.scalafmtInterfaces, Deps.scalaXml)
   def testIvyDeps = super.testIvyDeps() ++ Agg(Deps.scalaCheck)
   def testTransitiveDeps = super.testTransitiveDeps() ++ Seq(worker.testDep())
 
@@ -748,7 +748,7 @@ object scalalib extends MillStableScalaModule {
     def buildInfoMembers = Seq(
       BuildInfo.Value("ammonite", Deps.ammoniteVersion, "Version of Ammonite."),
       BuildInfo.Value("zinc", Deps.zinc.dep.version, "Version of Zinc"),
-      BuildInfo.Value("scalafmtVersion", Deps.scalafmtDynamic.dep.version, "Version of Scalafmt"),
+      BuildInfo.Value("scalafmtVersion", Deps.scalafmtInterfaces.dep.version, "Version of Scalafmt"),
       BuildInfo.Value("semanticDBVersion", Deps.semanticDBscala.dep.version, "SemanticDB version."),
       BuildInfo.Value(
         "semanticDbJavaVersion",


### PR DESCRIPTION
I see that the `scalafmt` version has been stuck at `3.7.15` for a bit, since java 8 support was dropped past that version. I'd like to use some bugfixes from later versions, so how about we make the version dynamic in `ScalafmtModule`? Scalafmt offers a nice binary-compatible interface through `scalafmt-interfaces`, so mill itself can stick with that. Some considerations:

* The BuildInfo entry does not make much sense now, since in general the interfaces version is unrelated to any used scalafmt version.
* I'm not a fan of setting an arbitrary old default version for `scalafmtVersion`, but I guess this is required for compatibility (?)

Thanks!