### PR TITLE
Use newer resolve API from coursier

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -949,6 +949,8 @@ object contrib extends Module {
       // compile-time only, need to provide the correct scoverage version at runtime
       def compileIvyDeps = Agg(Deps.scalacScoveragePlugin)
       def scalaVersion = Deps.scalaVersionForScoverageWorker1
+      // Work around error: Can't force version 2.13.12 for modules org.scala-lang:scala-library
+      def enforceSameDependencyVersions = T.task { Seq.empty[Set[(String, String)]] }
     }
 
     // Worker for Scoverage 2.0

--- a/build.sc
+++ b/build.sc
@@ -900,6 +900,16 @@ object contrib extends Module {
       def scalaVersion = Deps.play(playBinary).scalaVersion
       def moduleDeps = Seq(playlib.api)
       def ivyDeps = Agg(Deps.osLib, Deps.play(playBinary).routesCompiler)
+
+      // We don't have tests, but we need to override the auto-added `test` module
+      // since it's only supposed to be used with Scala 2.13
+      // otherwise, we get resolution conflicts
+      override lazy val test: MillScalaTests = new PlaylibWorkerTests {}
+      trait PlaylibWorkerTests extends MillScalaTests {
+        def scalaVersion = Deps.scalaVersion
+        def moduleDeps = Seq()
+        def ivyDeps = Agg.empty[Dep]
+      }
     }
   }
 

--- a/build.sc
+++ b/build.sc
@@ -728,7 +728,7 @@ object main extends MillStableScalaModule with BuildInfo {
   def testModuleDeps = super.testModuleDeps ++ Seq(testkit)
 }
 
-object testrunner extends MillPublishScalaModule {
+object testrunner extends MillPublishScalaModule with MillScalaModuleWithTest {
   def moduleDeps = Seq(scalalib.api, main.util, entrypoint)
 
   object entrypoint extends MillPublishJavaModule {

--- a/build.sc
+++ b/build.sc
@@ -955,6 +955,16 @@ object contrib extends Module {
       // compile-time only, need to provide the correct scoverage version at runtime
       def compileIvyDeps = Agg(Deps.scalacScoveragePlugin)
       def scalaVersion = Deps.scalaVersionForScoverageWorker1
+
+      // We don't have tests, but we need to override the auto-added `test` module
+      // since it's only supposed to be used with Scala 2.13
+      // otherwise, we get resolution conflicts
+      override lazy val test: MillScalaTests = new ScoverageWorkerTests {}
+      trait ScoverageWorkerTests extends MillScalaTests {
+        def scalaVersion = Deps.scalaVersion
+        def moduleDeps = Seq()
+        def ivyDeps = Agg.empty[Dep]
+      }
     }
 
     // Worker for Scoverage 2.0

--- a/main/test/src/mill/util/TestEvaluator.scala
+++ b/main/test/src/mill/util/TestEvaluator.scala
@@ -28,16 +28,18 @@ class TestEvaluator(
     inStream: InputStream = DummyInputStream,
     debugEnabled: Boolean = false,
     extraPathEnd: Seq[String] = Seq.empty,
-    env: Map[String, String] = Evaluator.defaultEnv
+    env: Map[String, String] = Evaluator.defaultEnv,
+    enableTicker: Boolean = false
 )(implicit fullName: sourcecode.FullName, tp: TestPath) extends TestUtil.TestEvaluator(
-      module,
-      tp.value,
-      failFast,
-      threads,
-      outStream,
-      errStream,
-      inStream,
-      debugEnabled,
-      extraPathEnd,
-      env
+      module = module,
+      testPath = tp.value,
+      failFast = failFast,
+      threads = threads,
+      outStream = outStream,
+      errStream = errStream,
+      inStream = inStream,
+      debugEnabled = debugEnabled,
+      extraPathEnd = extraPathEnd,
+      env = env,
+      enableTicker = enableTicker
     )

--- a/main/testkit/src/mill/testkit/MillTestkit.scala
+++ b/main/testkit/src/mill/testkit/MillTestkit.scala
@@ -69,7 +69,8 @@ trait MillTestKit {
       inStream: InputStream = DummyInputStream,
       debugEnabled: Boolean = false,
       extraPathEnd: Seq[String] = Seq.empty,
-      env: Map[String, String] = Evaluator.defaultEnv
+      env: Map[String, String] = Evaluator.defaultEnv,
+      enableTicker: Boolean = false
   )(implicit fullName: sourcecode.FullName) {
     val outPath: Path = getOutPath(testPath) / extraPathEnd
 
@@ -77,7 +78,7 @@ trait MillTestKit {
     val logger: logger = new logger
     class logger extends mill.util.PrintLogger(
           colored = true,
-          enableTicker = true,
+          enableTicker = enableTicker,
           mill.util.Colors.Default.info,
           mill.util.Colors.Default.error,
           new SystemStreams(out = outStream, err = errStream, in = inStream),

--- a/main/util/src/mill/util/CoursierSupport.scala
+++ b/main/util/src/mill/util/CoursierSupport.scala
@@ -1,14 +1,15 @@
 package mill.util
 
-import coursier.cache.{ArtifactError, Cache, FileCache}
-import coursier.core.{Dependency, Module, Repository, Resolution}
+import coursier.cache.{ArtifactError, FileCache}
+import coursier.core._
+import coursier.error.ResolutionError
 import coursier.params.ResolutionParams
+import coursier.params.rule.{RuleResolution, SameVersion}
 import coursier.parse.RepositoryParser
-import coursier.util.{Gather, Task}
-import coursier.{Artifacts, Fetch, Resolve}
-import mill.api.{Ctx, PathRef, Result}
+import coursier.util.{Gather, ModuleMatcher, Task}
+import coursier.{Organization, Resolve}
 import mill.api.Loose.Agg
-import mill.api.PathRef.Revalidate
+import mill.api.{Ctx, PathRef, Result}
 
 import java.io.File
 import java.nio.file.NoSuchFileException
@@ -19,8 +20,6 @@ import scala.util.{Failure, Success, Try}
 
 trait CoursierSupport {
   import CoursierSupport._
-
-  private val useNewCoursierApi = true
 
   private val CoursierRetryCount = 5
   private val CoursierRetryWait = 100
@@ -97,7 +96,8 @@ trait CoursierSupport {
       coursierCacheCustomizer: Option[
         coursier.cache.FileCache[Task] => coursier.cache.FileCache[Task]
       ] = None,
-      resolveFilter: os.Path => Boolean = _ => true
+      resolveFilter: os.Path => Boolean = _ => true,
+      sameDependencyVersions: Seq[Set[(String, String)]] = Seq()
   ): Result[Agg[PathRef]] = {
     def isLocalTestDep(dep: coursier.Dependency): Option[Seq[PathRef]] = {
       val org = dep.module.organization.value
@@ -120,21 +120,29 @@ trait CoursierSupport {
       }
     )
 
-    val (_, resolution) = resolveDependenciesMetadata(
-      repositories,
-      remoteDeps,
-      force,
-      mapDependencies,
-      customizer,
-      ctx,
-      coursierCacheCustomizer
-    )
-    val errs = resolution.errors
+    val (resolution, resErrs, otherErrors) =
+      try {
+        val (_, resolution) = resolveDependenciesMetadata(
+          repositories = repositories,
+          deps = remoteDeps,
+          force = force,
+          mapDependencies = mapDependencies,
+          customizer = customizer,
+          ctx = ctx,
+          coursierCacheCustomizer = coursierCacheCustomizer,
+          sameDependencyVersions = sameDependencyVersions
+        )
+        val errs = resolution.errors
+        (resolution, errs, None)
+      } catch {
+        case e: ResolutionError =>
+          (e.resolution, e.resolution.errors, Some(e.getMessage))
+      }
 
-    if (errs.nonEmpty) {
+    if (resErrs.nonEmpty) {
       val header =
         s"""|
-            |Resolution failed for ${errs.length} modules:
+            |Resolution failed for ${resErrs.length} modules:
             |--------------------------------------------
             |""".stripMargin
 
@@ -145,11 +153,15 @@ trait CoursierSupport {
             |For additional information on library dependencies, see the docs at
             |${mill.api.BuildInfo.millDocUrl}/mill/Library_Dependencies.html""".stripMargin
 
-      val errLines = errs.map {
+      val errLines = resErrs.map {
         case ((module, vsn), errMsgs) => s"  ${module.trim}:$vsn \n\t" + errMsgs.mkString("\n\t")
       }.mkString("\n")
       val msg = header + errLines + "\n" + helpMessage + "\n"
       Result.Failure(msg)
+
+    } else if (otherErrors.nonEmpty) {
+      Result.Failure(otherErrors.get)
+
     } else {
 
       val coursierCache0 = coursier.cache.FileCache[Task]().noCredentials
@@ -224,15 +236,16 @@ trait CoursierSupport {
       ctx: Option[mill.api.Ctx.Log] = None,
       coursierCacheCustomizer: Option[
         coursier.cache.FileCache[Task] => coursier.cache.FileCache[Task]
-      ] = None
+      ] = None,
+      sameDependencyVersions: Seq[Set[(String, String)]] = Seq()
   ): (Seq[Dependency], Resolution) = {
 
     val rootDeps = deps.iterator
-      .map(mapDependencies.getOrElse(identity[Dependency](_)))
+      .map(d => mapDependencies.fold(d)(_.apply(d)))
       .toSeq
 
     val forceVersions: Map[Module, String] = force.iterator
-      .map(mapDependencies.getOrElse(identity[Dependency](_)))
+      .map(d => mapDependencies.fold(d)(_.apply(d)))
       .map { d => d.module -> d.version }
       .toMap
 
@@ -244,15 +257,17 @@ trait CoursierSupport {
         ctx.fold(cache)(c => cache.withLogger(new TickerResolutionLogger(c)))
       }
 
-    ctx.foreach {
-      _.log.debug(s"Resolving root dependencies: ${rootDeps}, forced versions: ${forceVersions}")
+    val rules = sameDependencyVersions.map { same =>
+      val modMatchers = same.map { case (org, name) =>
+        ModuleMatcher(Organization(org), ModuleName(name))
+      }
+      (SameVersion(modMatchers), RuleResolution.TryResolve)
     }
 
-    if (useNewCoursierApi) {
-//      ctx.foreach { _.log.debug("Using new coursier API") }
-
+    {
       val resolutionParams = ResolutionParams()
         .withForceVersion(forceVersions)
+        .withRules(rules)
 
       val resolve = Resolve()
         .withCache(coursierCache)
@@ -260,48 +275,27 @@ trait CoursierSupport {
         .withRepositories(repositories)
         .withResolutionParams(resolutionParams)
 
-      val resolution = resolve.run()
+      val resolution0 =
+//        try {
+        retry(
+          ctx = ctx,
+          errorMsgExtractor = (r: Resolution) => r.errors.flatMap(_._2)
+        ) {
+          () => resolve.run()
+        }
+//        } catch {
+//          case e: ResolutionError =>
+//
+//        }
+
+      val resolution = resolution0
         .withMapDependencies(mapDependencies)
-
-      (deps.iterator.to(Seq), resolution)
-
-    } else {
-
-//      val cachePolicies = coursier.cache.CacheDefaults.cachePolicies
-
-      val start0 = Resolution()
-        .withRootDependencies(rootDeps)
-        .withForceVersions(forceVersions)
-        .withMapDependencies(mapDependencies)
-
-      val start = customizer.getOrElse(identity[Resolution](_)).apply(start0)
-
-//      val resolutionLogger = ctx.map(c => new TickerResolutionLogger(c))
-//      val coursierCache0 = resolutionLogger match {
-//        case None => coursier.cache.FileCache[Task]().withCachePolicies(cachePolicies)
-//        case Some(l) =>
-//          coursier.cache.FileCache[Task]()
-//            .withCachePolicies(cachePolicies)
-//            .withLogger(l)
-//      }
-//      val coursierCache = coursierCacheCustomizer.getOrElse(
-//        identity[coursier.cache.FileCache[Task]](_)
-//      ).apply(coursierCache0)
-
-      val fetches = coursierCache.fetchs
-
-      val fetch = coursier.core.ResolutionProcess.fetch(repositories, fetches.head, fetches.tail)
-
-      import scala.concurrent.ExecutionContext.Implicits.global
-
-      val resolution =
-        retry(ctx = ctx, errorMsgExtractor = (r: Resolution) => r.errors.flatMap(_._2)) {
-          () => start.process.run(fetch).unsafeRun()
+        .pipe { res =>
+          customizer.fold(res)(_.apply(res))
         }
 
-      Resolve.validate(resolution)
-
       (deps.iterator.to(Seq), resolution)
+
     }
   }
 

--- a/main/util/src/mill/util/CoursierSupport.scala
+++ b/main/util/src/mill/util/CoursierSupport.scala
@@ -249,7 +249,7 @@ trait CoursierSupport {
     }
 
     if (useNewCoursierApi) {
-      ctx.foreach { _.log.info("Using new coursier API") }
+//      ctx.foreach { _.log.debug("Using new coursier API") }
 
       val resolutionParams = ResolutionParams()
         .withForceVersion(forceVersions)

--- a/main/util/src/mill/util/CoursierSupport.scala
+++ b/main/util/src/mill/util/CoursierSupport.scala
@@ -305,18 +305,10 @@ trait CoursierSupport {
         .withRepositories(repositories)
         .withResolutionParams(resolutionParams)
 
-      val resolution0 =
-//        try {
-        retry(
-          ctx = ctx,
-          errorMsgExtractor = (r: Resolution) => r.errors.flatMap(_._2)
-        ) {
-          () => resolve.run()
-        }
-//        } catch {
-//          case e: ResolutionError =>
-//
-//        }
+      val resolution0 = retry(
+        ctx = ctx,
+        errorMsgExtractor = (r: Resolution) => r.errors.flatMap(_._2)
+      )(resolve.run)
 
       val resolution = resolution0
         .withMapDependencies(mapDependencies)

--- a/main/util/src/mill/util/CoursierSupport.scala
+++ b/main/util/src/mill/util/CoursierSupport.scala
@@ -227,6 +227,36 @@ trait CoursierSupport {
     }
   }
 
+  @deprecated(
+    "Compatibility shim. Use the overload with parameter sameDependencyVersions instead",
+    "Mill after 0.11.7"
+  )
+  def resolveDependencies(
+      repositories: Seq[Repository],
+      deps: IterableOnce[coursier.Dependency],
+      force: IterableOnce[coursier.Dependency],
+      sources: Boolean,
+      mapDependencies: Option[Dependency => Dependency],
+      customizer: Option[coursier.core.Resolution => coursier.core.Resolution],
+      ctx: Option[mill.api.Ctx.Log],
+      coursierCacheCustomizer: Option[
+        coursier.cache.FileCache[Task] => coursier.cache.FileCache[Task]
+      ],
+      resolveFilter: os.Path => Boolean
+  ): Result[Agg[PathRef]] =
+    resolveDependencies(
+      repositories = repositories,
+      deps = deps,
+      force = force,
+      sources = sources,
+      mapDependencies = mapDependencies,
+      customizer = customizer,
+      ctx = ctx,
+      coursierCacheCustomizer = coursierCacheCustomizer,
+      resolveFilter = resolveFilter,
+      sameDependencyVersions = Seq()
+    )
+
   def resolveDependenciesMetadata(
       repositories: Seq[Repository],
       deps: IterableOnce[Dependency],
@@ -298,6 +328,32 @@ trait CoursierSupport {
 
     }
   }
+
+  @deprecated(
+    "Compatibility shim. Use the overload with parameter sameDependencyVersions instead",
+    "Mill after 0.11.7"
+  )
+  def resolveDependenciesMetadata(
+      repositories: Seq[Repository],
+      deps: IterableOnce[Dependency],
+      force: IterableOnce[Dependency],
+      mapDependencies: Option[Dependency => Dependency],
+      customizer: Option[Resolution => Resolution],
+      ctx: Option[mill.api.Ctx.Log],
+      coursierCacheCustomizer: Option[
+        coursier.cache.FileCache[Task] => coursier.cache.FileCache[Task]
+      ]
+  ): (Seq[Dependency], Resolution) =
+    resolveDependenciesMetadata(
+      repositories = repositories,
+      deps = deps,
+      force = force,
+      mapDependencies = mapDependencies,
+      customizer = customizer,
+      ctx = ctx,
+      coursierCacheCustomizer = coursierCacheCustomizer,
+      sameDependencyVersions = Seq()
+    )
 
 }
 

--- a/scalalib/src/mill/scalalib/CoursierModule.scala
+++ b/scalalib/src/mill/scalalib/CoursierModule.scala
@@ -48,7 +48,7 @@ trait CoursierModule extends mill.Module {
         mapDependencies = Some(mapDependencies()),
         customizer = resolutionCustomizer(),
         coursierCacheCustomizer = coursierCacheCustomizer(),
-        ctx = Some(implicitly[mill.api.Ctx.Log])
+        ctx = Some(T.ctx())
       )
     }
 

--- a/scalalib/src/mill/scalalib/CoursierModule.scala
+++ b/scalalib/src/mill/scalalib/CoursierModule.scala
@@ -48,7 +48,8 @@ trait CoursierModule extends mill.Module {
         mapDependencies = Some(mapDependencies()),
         customizer = resolutionCustomizer(),
         coursierCacheCustomizer = coursierCacheCustomizer(),
-        ctx = Some(T.ctx())
+        ctx = Some(T.ctx()),
+        sameDependencyVersions = enforceSameDependencyVersions()
       )
     }
 
@@ -107,4 +108,10 @@ trait CoursierModule extends mill.Module {
       : Task[Option[FileCache[coursier.util.Task] => FileCache[coursier.util.Task]]] =
     T.task { None }
 
+  /**
+   * Enforce the same version for all modules (organization-artifactId-pairs) in the same set.
+   * This is for example needed to make sure verison of `scala-library` and `scala-reflect` is used.
+   */
+  def enforceSameDependencyVersions: Task[Seq[Set[(String, String)]]] =
+    T.task { Seq.empty[Set[(String, String)]] }
 }

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -807,7 +807,8 @@ trait JavaModule
         additionalDeps() ++ transitiveIvyDeps(),
         Some(mapDependencies()),
         customizer = resolutionCustomizer(),
-        coursierCacheCustomizer = coursierCacheCustomizer()
+        coursierCacheCustomizer = coursierCacheCustomizer(),
+        ctx = Option(T.ctx())
       )
 
       val roots = whatDependsOn match {

--- a/scalalib/src/mill/scalalib/Lib.scala
+++ b/scalalib/src/mill/scalalib/Lib.scala
@@ -79,6 +79,31 @@ object Lib {
     ).map(_.map(_.withRevalidateOnce))
   }
 
+  @deprecated(
+    "Compatibility shim. Use the overload with parameter sameDependencyVersions instead",
+    "Mill after 0.11.7"
+  )
+  def resolveDependencies(
+      repositories: Seq[Repository],
+      deps: IterableOnce[BoundDep],
+      sources: Boolean,
+      mapDependencies: Option[Dependency => Dependency],
+      customizer: Option[coursier.core.Resolution => coursier.core.Resolution],
+      ctx: Option[Ctx.Log],
+      coursierCacheCustomizer: Option[
+        coursier.cache.FileCache[Task] => coursier.cache.FileCache[Task]
+      ]
+  ): Result[Agg[PathRef]] = resolveDependencies(
+    repositories = repositories,
+    deps = deps,
+    sources = sources,
+    mapDependencies = mapDependencies,
+    customizer = customizer,
+    ctx = ctx,
+    coursierCacheCustomizer = coursierCacheCustomizer,
+    sameDependencyVersions = Seq()
+  )
+
   def scalaCompilerIvyDeps(scalaOrganization: String, scalaVersion: String): Loose.Agg[Dep] =
     if (ZincWorkerUtil.isDotty(scalaVersion))
       Agg(

--- a/scalalib/src/mill/scalalib/Lib.scala
+++ b/scalalib/src/mill/scalalib/Lib.scala
@@ -62,7 +62,8 @@ object Lib {
       ctx: Option[Ctx.Log] = None,
       coursierCacheCustomizer: Option[
         coursier.cache.FileCache[Task] => coursier.cache.FileCache[Task]
-      ] = None
+      ] = None,
+      sameDependencyVersions: Seq[Set[(String, String)]] = Seq()
   ): Result[Agg[PathRef]] = {
     val depSeq = deps.iterator.toSeq
     mill.util.Jvm.resolveDependencies(
@@ -73,7 +74,8 @@ object Lib {
       mapDependencies = mapDependencies,
       customizer = customizer,
       ctx = ctx,
-      coursierCacheCustomizer = coursierCacheCustomizer
+      coursierCacheCustomizer = coursierCacheCustomizer,
+      sameDependencyVersions = sameDependencyVersions
     ).map(_.map(_.withRevalidateOnce))
   }
 

--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -81,6 +81,15 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
     }
   }
 
+  override def enforceSameDependencyVersions: Task[Seq[Set[(String, String)]]] = T.task {
+    Seq(
+      // scala 2.x
+      Set("scala-library", "scala-compiler", "scala-reflect", "scalap").map(("org.scala-lang", _)),
+      // Dotty (early Scala 3)
+      Set("dotty-library", "dotty-compiler").map(("ch.epfl.lamp", _))
+    )
+  }
+
   override def resolveCoursierDependency: Task[Dep => coursier.Dependency] =
     T.task {
       Lib.depToDependency(_: Dep, scalaVersion(), platformSuffix())

--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -90,20 +90,18 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
     )
   }
 
-  override def resolveCoursierDependency: Task[Dep => coursier.Dependency] =
-    T.task {
-      Lib.depToDependency(_: Dep, scalaVersion(), platformSuffix())
-    }
+  override def resolveCoursierDependency: Task[Dep => coursier.Dependency] = T.task {
+    Lib.depToDependency(_: Dep, scalaVersion(), platformSuffix())
+  }
 
-  override def resolvePublishDependency: Task[Dep => publish.Dependency] =
-    T.task {
-      publish.Artifact.fromDep(
-        _: Dep,
-        scalaVersion(),
-        ZincWorkerUtil.scalaBinaryVersion(scalaVersion()),
-        platformSuffix()
-      )
-    }
+  override def resolvePublishDependency: Task[Dep => publish.Dependency] = T.task {
+    publish.Artifact.fromDep(
+      _: Dep,
+      scalaVersion(),
+      ZincWorkerUtil.scalaBinaryVersion(scalaVersion()),
+      platformSuffix()
+    )
+  }
 
   /**
    * Print the scala compile built-in help output.

--- a/scalalib/src/mill/scalalib/dependency/versions/VersionsFinder.scala
+++ b/scalalib/src/mill/scalalib/dependency/versions/VersionsFinder.scala
@@ -61,7 +61,7 @@ private[dependency] object VersionsFinder {
           mapDependencies = Some(mapDeps),
           customizer = custom,
           coursierCacheCustomizer = cacheCustom,
-          ctx = Some(T.log)
+          ctx = Some(T.ctx())
         )
 
       (javaModule, metadataLoaders, dependencies)

--- a/scalalib/test/src/mill/scalalib/CrossVersionTests.scala
+++ b/scalalib/test/src/mill/scalalib/CrossVersionTests.scala
@@ -141,10 +141,15 @@ object CrossVersionTests extends TestSuite {
     expectedIvyDepsTree.foreach { tree =>
       if (!scala.util.Properties.isWin) {
         // Escape-sequence formatting isn't working under bare Windows
-        val expectedDepsTree = tree
-        val logFile =
+        val expectedDepsTree = tree.trim()
+        val logFile = {
           eval.evaluator.pathsResolver.resolveDest(mod.ivyDepsTree(IvyDepsTreeArgs())).log
-        val depsTree = os.read(logFile)
+        }
+        val depsTree = os.read.lines(logFile)
+          // need to erage any Mill ticker output
+          .filter(!_.contains("Downloading ["))
+          .mkString("\n")
+          .trim()
         assert(depsTree == expectedDepsTree)
       }
     }

--- a/scalalib/test/src/mill/scalalib/CrossVersionTests.scala
+++ b/scalalib/test/src/mill/scalalib/CrossVersionTests.scala
@@ -119,7 +119,7 @@ object CrossVersionTests extends TestSuite {
   }
 
   def init()(implicit tp: TestPath) = {
-    val eval = new TestEvaluator(TestCases)
+    val eval = new TestEvaluator(TestCases, enableTicker = false)
     os.remove.all(eval.outPath)
     os.makeDir.all(TestCases.millSourcePath / os.up)
     eval
@@ -142,8 +142,9 @@ object CrossVersionTests extends TestSuite {
       if (!scala.util.Properties.isWin) {
         // Escape-sequence formatting isn't working under bare Windows
         val expectedDepsTree = tree
-        val depsTree =
-          os.read(eval.evaluator.pathsResolver.resolveDest(mod.ivyDepsTree(IvyDepsTreeArgs())).log)
+        val logFile =
+          eval.evaluator.pathsResolver.resolveDest(mod.ivyDepsTree(IvyDepsTreeArgs())).log
+        val depsTree = os.read(logFile)
         assert(depsTree == expectedDepsTree)
       }
     }


### PR DESCRIPTION
As part of experimenting the solution space for feature request https://github.com/com-lihaoyi/mill/issues/3075, I found that some resolution validation errors are only correctly detected, when the newer coursier API is used. Therefore I extracted some commits of PR https://github.com/com-lihaoyi/mill/pull/3084 into this standalone PR and fixed any issues on the way.

Changes:
* Use newer coursier `Resolve` API to really detect conflicting dependencies
* Introduce a new `CoursierModule.enforceSameDependencyVersions`, which allows to sync versions for artifacts belonging to the same release, e.g. `scala-library` and `scala-reflect`.
