### PR TITLE
Update documentation for Sonatype Central

### DIFF
--- a/contrib/sonatypecentral/readme.adoc
+++ b/contrib/sonatypecentral/readme.adoc
@@ -44,15 +44,15 @@ Below are the default publishing settings on the module level, which can be expl
 [source,scala]
 ----
 object mymodule extends SonatypeCentralPublishModule {
-  override def gpgArgs: T[String] = "--batch, --yes, -a, -b"
+  override def sonatypeCentralGpgArgs: T[String] = "--batch, --yes, -a, -b"
 
-  override def connectTimeout: T[Int] = 5000
+  override def sonatypeCentralConnectTimeout: T[Int] = 5000
 
-  override def readTimeout: T[Int] = 60000
+  override def sonatypeCentralReadTimeout: T[Int] = 60000
 
-  override def awaitTimeout: T[Int] = 120 * 1000
+  override def sonatypeCentralAwaitTimeout: T[Int] = 120 * 1000
 
-  override def shouldRelease: T[Boolean] = true
+  override def sonatypeCentralShouldRelease: T[Boolean] = true
   ...
 }
 ----


### PR DESCRIPTION
Class method name changes that were made in the process of approving https://github.com/com-lihaoyi/mill/pull/3130 left out corresponding documentation changes. This PR adjusts the documentation so that it reflects the final implementation. 