### PR TITLE
Exclude mill provided dependencies in meta builds

### DIFF
--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -2,7 +2,7 @@ package mill.runner
 
 import coursier.Repository
 import mill._
-import mill.api.{Loose, PathRef, Result, internal}
+import mill.api.{PathRef, Result, internal}
 import mill.define.{Discover, Task}
 import mill.scalalib.{Dep, DepSyntax, Lib, ScalaModule}
 import mill.util.CoursierSupport

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -91,7 +91,7 @@ class MillBuildRootModule()(implicit
     imports
   }
 
-  val millAssemblyEmbeddedDepsExcludes: Seq[(String, String)] =
+  private val millAssemblyEmbeddedDepsExcludes: Seq[(String, String)] =
     Lib.millAssemblyEmbeddedDeps.toSeq.map(d =>
       (d.dep.module.organization.value, d.dep.module.name.value)
     )

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -230,7 +230,7 @@ class MillBuildRootModule()(implicit
    * By default, these are the dependencies, which Mill provides itself (via [[unmanagedClasspath]]).
    * We exclude them to avoid incompatible or duplicate artifacts on the classpath.
    */
-  protected def resolveDepsExclusions: T[Seq[(String, String)]] = T{
+  protected def resolveDepsExclusions: T[Seq[(String, String)]] = T {
     Lib.millAssemblyEmbeddedDeps.toSeq.map(d =>
       (d.dep.module.organization.value, d.dep.module.name.value)
     )


### PR DESCRIPTION
This should fix issues where plugins bring in potentially incompatible or duplicate version of an already provided Mill dependency.

We override `resolveDeps` and exclude all provided mill artifacts. Direct dependency are not filtered out, only transitive onces. If exclusions turn out to be a problem in some setups, the protected `resolveDepsExclusions` target can be customized, e.g. by returning an empty set of exclusions.
