### PR TITLE
[BSP] Support buildTarget/wrappedSources for build scripts

### DIFF
--- a/bsp/src/mill/bsp/Constants.scala
+++ b/bsp/src/mill/bsp/Constants.scala
@@ -6,6 +6,6 @@ private[mill] object Constants {
   val bspProtocolVersion = BuildInfo.bsp4jVersion
   val bspWorkerImplClass = "mill.bsp.worker.BspWorkerImpl"
   val bspWorkerBuildInfoClass = "mill.bsp.worker.BuildInfo"
-  val languages: Seq[String] = Seq("scala", "java")
+  val languages: Seq[String] = Seq("scala", "java", "scala-sc")
   val serverName = "mill-bsp"
 }

--- a/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -135,7 +135,7 @@ private class MillBuildServer(
 
       // TODO: scan BspModules and infer their capabilities
 
-      val supportedLangs = Seq("java", "scala").asJava
+      val supportedLangs = Seq("java", "scala", "scala-sc").asJava
       val capabilities = new BuildServerCapabilities
 
       capabilities.setBuildTargetChangedProvider(false)

--- a/build.sc
+++ b/build.sc
@@ -188,6 +188,7 @@ object Deps {
   val zinc = ivy"org.scala-sbt::zinc:1.10.0"
   // keep in sync with doc/antora/antory.yml
   val bsp4j = ivy"ch.epfl.scala:bsp4j:2.2.0-M2"
+  val scalaCliBsp = ivy"org.virtuslab.scala-cli:scala-cli-bsp:1.3.2"
   val fansi = ivy"com.lihaoyi::fansi:0.5.0"
   val jarjarabrams = ivy"com.eed3si9n.jarjarabrams::jarjar-abrams-core:1.14.0"
   val requests = ivy"com.lihaoyi::requests:0.8.2"
@@ -1102,7 +1103,7 @@ object bsp extends MillPublishScalaModule with BuildInfo {
 
   object worker extends MillPublishScalaModule {
     def compileModuleDeps = Seq(bsp, scalalib, testrunner, runner) ++ scalalib.compileModuleDeps
-    def ivyDeps = Agg(Deps.bsp4j, Deps.sbtTestInterface)
+    def ivyDeps = Agg(Deps.bsp4j, Deps.scalaCliBsp, Deps.sbtTestInterface)
   }
 }
 

--- a/runner/src/mill/runner/FileImportGraph.scala
+++ b/runner/src/mill/runner/FileImportGraph.scala
@@ -113,7 +113,7 @@ object FileImportGraph {
               val end = rest.last._2
               (
                 start,
-                fileImportToSegments(projectRoot, nextPaths(0) / os.up, false)
+                fileImportToSegments(projectRoot, nextPaths(0) / os.up, ext = "")
                   .map(backtickWrap)
                   .mkString("."),
                 end
@@ -152,8 +152,8 @@ object FileImportGraph {
     s / os.up / restSegments / os.up / s"${rest.last}.sc"
   }
 
-  def fileImportToSegments(base: os.Path, s: os.Path, stripExt: Boolean): Seq[String] = {
-    val rel = (s / os.up / (if (stripExt) s.baseName else s.last)).relativeTo(base)
+  def fileImportToSegments(base: os.Path, s: os.Path, ext: String): Seq[String] = {
+    val rel = (s / os.up / s"${s.baseName}${ext}").relativeTo(base)
     Seq("millbuild") ++ Seq.fill(rel.ups)("^") ++ rel.segments
   }
 }

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -314,12 +314,16 @@ object MillBuildRootModule {
   ): Unit = {
     for (scriptSource <- scriptSources) {
       val relative = scriptSource.path.relativeTo(base)
-      val dest = targetDest / FileImportGraph.fileImportToSegments(base, scriptSource.path, false)
+      val dest = targetDest / FileImportGraph.fileImportToSegments(
+        base,
+        scriptSource.path,
+        ext = ".scala"
+      )
 
       val newSource = MillBuildRootModule.top(
         relative,
         scriptSource.path / os.up,
-        FileImportGraph.fileImportToSegments(base, scriptSource.path, true).dropRight(1),
+        FileImportGraph.fileImportToSegments(base, scriptSource.path, ext = "").dropRight(1),
         scriptSource.path.baseName,
         enclosingClasspath,
         millTopLevelProjectRoot,


### PR DESCRIPTION
scala-cli supports a bespoke extension to the the build server protocol.
This extension allows the support of Scala scripts. Scala scripts
are Scala code which is then wrapped at build time by some Scala
code to make them valid Scala code.
scala-cli-bsp's buildTarget/wrappedSources allows build tools to
give the following information:
- the scala script file
- the generated scala file generated from the script
- the string that is added on the top of the file
- the string that is added on the bottom of the file

This PR adds Virtuslab's scala-cli-bsp library to the bsp worker module,
and implements the handler for the buildTarget/wrappedSources call.
To make the information available, it changes the return type of
`generateScriptSources` in `MillBuildRootModule` to return, together
with the `PathRef` of the destination folder, the four elements
described above, so it can be used by BSP.