### PR TITLE
Fix Scala.js toolchain logs in server-client mode

### DIFF
--- a/scalajslib/worker/1/src/mill/scalajslib/worker/ScalaJSWorkerImpl.scala
+++ b/scalajslib/worker/1/src/mill/scalajslib/worker/ScalaJSWorkerImpl.scala
@@ -17,7 +17,7 @@ import org.scalajs.linker.interface.{
   ModuleSplitStyle => _,
   _
 }
-import org.scalajs.logging.ScalaConsoleLogger
+import org.scalajs.logging.{Level, Logger}
 import org.scalajs.jsenv.{Input, JSEnv, RunConfig}
 import org.scalajs.testing.adapter.TestAdapter
 import org.scalajs.testing.adapter.{TestAdapterInitializer => TAI}
@@ -158,6 +158,15 @@ class ScalaJSWorkerImpl extends ScalaJSWorkerApi {
       (linker, irFileCacheCache)
     }
   }
+  private val logger = new Logger {
+    def log(level: Level, message: => String): Unit = level match {
+      case Level.Warn | Level.Error => System.err.println(message)
+      case Level.Info | Level.Debug => System.out.println(message)
+    }
+    def trace(t: => Throwable): Unit = {
+      t.printStackTrace()
+    }
+  }
   def link(
       runClasspath: Seq[Path],
       dest: File,
@@ -190,7 +199,6 @@ class ScalaJSWorkerImpl extends ScalaJSWorkerApi {
       dest = dest
     ))
     val irContainersAndPathsFuture = PathIRContainer.fromClasspath(runClasspath)
-    val logger = new ScalaConsoleLogger
     val testInitializer =
       if (testBridgeInit)
         ModuleInitializer.mainMethod(TAI.ModuleClassName, TAI.MainMethodName) :: Nil
@@ -284,7 +292,7 @@ class ScalaJSWorkerImpl extends ScalaJSWorkerApi {
   def run(config: JsEnvConfig, report: Report): Unit = {
     val env = jsEnv(config)
     val input = jsEnvInput(report)
-    val runConfig0 = RunConfig().withLogger(new ScalaConsoleLogger)
+    val runConfig0 = RunConfig().withLogger(logger)
     val runConfig =
       if (mill.api.SystemStreams.isOriginal()) runConfig0
       else runConfig0
@@ -315,7 +323,7 @@ class ScalaJSWorkerImpl extends ScalaJSWorkerApi {
   ): (() => Unit, sbt.testing.Framework) = {
     val env = jsEnv(config)
     val input = jsEnvInput(report)
-    val tconfig = TestAdapter.Config().withLogger(new ScalaConsoleLogger)
+    val tconfig = TestAdapter.Config().withLogger(logger)
 
     val adapter = new TestAdapter(env, input, tconfig)
 

--- a/scalajslib/worker/1/src/mill/scalajslib/worker/ScalaJSWorkerImpl.scala
+++ b/scalajslib/worker/1/src/mill/scalajslib/worker/ScalaJSWorkerImpl.scala
@@ -159,9 +159,8 @@ class ScalaJSWorkerImpl extends ScalaJSWorkerApi {
     }
   }
   private val logger = new Logger {
-    def log(level: Level, message: => String): Unit = level match {
-      case Level.Warn | Level.Error => System.err.println(message)
-      case Level.Info | Level.Debug => System.out.println(message)
+    def log(level: Level, message: => String): Unit = {
+      System.err.println(message)
     }
     def trace(t: => Throwable): Unit = {
       t.printStackTrace()


### PR DESCRIPTION
For some reason logging with `scala.Console` doesn't work with the Scala.js linker in server-client mode, maybe it's related to some classloader issue. This works around the problem by using `System.out` instead, which works correctly.

Pull Request: https://github.com/com-lihaoyi/mill/pull/3196