### PR TITLE
[WIP] [BSP] `scala-test-suites` `debugAdapter` support

### DIFF
--- a/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -760,7 +760,8 @@ private class MillBuildServer(
                           )
 
                       result match {
-                        case Result.Success(Val((doneMsg: String, results: Seq[mill.testrunner.TestResult]))) =>
+                        case s @ Result.Success(Val((doneMsg: String, results: Seq[mill.testrunner.TestResult]))) =>
+                          debug(s"Result.Success: $s")
                           val resultsMap = bySuite(results)
 
                           resultsMap.foreach {
@@ -791,9 +792,16 @@ private class MillBuildServer(
                                 totalDuration,
                                 tests.asJava
                               ))
-                            case _ =>
+                              debug(s"listener.testResult(${TestSuiteSummary(
+                                suite,
+                                totalDuration,
+                                tests.asJava
+                              )})")
+                            case other =>
+                              debug(s"other: $other")    
                           }
-                        case Result.Failure(message, Some(Val((doneMsg: String, results: Seq[mill.testrunner.TestResult])))) =>
+                        case f @ Result.Failure(message, Some(Val((doneMsg: String, results: Seq[mill.testrunner.TestResult])))) =>
+                          debug(s"Result.Failure: $f")
                           val resultsMap = bySuite(results)
 
                           resultsMap.foreach {
@@ -826,6 +834,9 @@ private class MillBuildServer(
                           )
                           debug("Result.Skipped")
                           throw new Exception("Aborted")
+
+                        case other =>
+                            debug(s"completely other: $other")    
                       }
                     }
                     debug("FINISHED WORK WITH FUTURE")

--- a/bsp/worker/src/mill/bsp/worker/debug/DebuggeeLogger.scala
+++ b/bsp/worker/src/mill/bsp/worker/debug/DebuggeeLogger.scala
@@ -1,0 +1,41 @@
+package mill.bsp.worker.debug
+
+import ch.epfl.scala.debugadapter._
+
+import java.net.InetSocketAddress
+import java.util.concurrent.atomic.AtomicBoolean
+import java.io.PrintStream
+
+class DebuggeeLogger(listener: DebuggeeListener, systemOut: PrintStream, systemErr: PrintStream, debugFunc: String => Unit)
+    extends Logger {
+
+  private val initialized = new AtomicBoolean(false)
+
+  def debug(msg: => String): Unit =
+    listener.err(s"[error] $msg")
+
+  def info(msg: => String): Unit = {
+    val message = msg
+
+    // Expect the first log to be JDI notification since debuggee runs with `quiet=n` JDI option
+    if (message.startsWith(DebuggeeLogger.JDINotificationPrefix)) {
+      if (initialized.compareAndSet(false, true)) {
+        val port = Integer.parseInt(msg.drop(DebuggeeLogger.JDINotificationPrefix.length))
+        val address = new InetSocketAddress("127.0.0.1", port)
+        listener.onListening(address)
+      }
+    } else {
+      listener.out(message)
+    }
+  }
+  def warn(msg: => String): Unit = {
+    listener.out(msg)
+  }
+  def error(msg: => String): Unit = {
+    listener.err(msg)
+  }
+  def trace(t: => Throwable): Unit = t.printStackTrace()
+}
+object DebuggeeLogger {
+  final val JDINotificationPrefix = "Listening for transport dt_socket at address: "
+}

--- a/bsp/worker/src/mill/bsp/worker/debug/MillDebugee.scala
+++ b/bsp/worker/src/mill/bsp/worker/debug/MillDebugee.scala
@@ -1,0 +1,33 @@
+package mill.bsp.worker.debug
+
+import ch.epfl.scala.debugadapter._
+
+abstract class AbstractDebuggee extends Debuggee {}
+
+abstract class ScalaTestSuitesDebuggee(scalaVersion: String, debug: String => Unit) extends AbstractDebuggee {
+  def javaRuntime: Option[JavaRuntime] = {
+    debug("javaRuntime called")
+    ???
+  }
+  def libraries: Seq[Library] = {
+    debug("libraries called")
+    ???
+  }
+  def modules: Seq[Module] = {
+    debug("modules called") 
+    ???
+  }
+  def name: String = s"test adapter ${scala.util.Random.nextInt()}"
+  def observeClassUpdates(onClassUpdate: Seq[String] => Unit): java.io.Closeable = {
+    debug("observeClassUpdates called")
+    new java.io.Closeable {
+      def close(): Unit = ()
+    }
+  }
+
+  def scalaVersion: ScalaVersion = ScalaVersion(scalaVersion)
+  def unmanagedEntries: Seq[UnmanagedEntry] = {
+    debug("unmanagedEntries called")
+    ???
+  }
+}

--- a/bsp/worker/src/mill/bsp/worker/debug/MillDebugee.scala
+++ b/bsp/worker/src/mill/bsp/worker/debug/MillDebugee.scala
@@ -17,7 +17,7 @@ abstract class ScalaTestSuitesDebuggee(scalaVersion: String, debug: String => Un
     debug("modules called") 
     ???
   }
-  def name: String = s"test adapter ${scala.util.Random.nextInt()}"
+  val name: String = s"test adapter ${scala.util.Random.nextInt()}"
   def observeClassUpdates(onClassUpdate: Seq[String] => Unit): java.io.Closeable = {
     debug("observeClassUpdates called")
     new java.io.Closeable {

--- a/build.sc
+++ b/build.sc
@@ -188,6 +188,7 @@ object Deps {
   val zinc = ivy"org.scala-sbt::zinc:1.10.0"
   // keep in sync with doc/antora/antory.yml
   val bsp4j = ivy"ch.epfl.scala:bsp4j:2.2.0-M2"
+  val scalaDebugAdapter = ivy"ch.epfl.scala::scala-debug-adapter:4.1.1"
   val fansi = ivy"com.lihaoyi::fansi:0.5.0"
   val jarjarabrams = ivy"com.eed3si9n.jarjarabrams::jarjar-abrams-core:1.14.0"
   val requests = ivy"com.lihaoyi::requests:0.8.2"
@@ -1102,7 +1103,7 @@ object bsp extends MillPublishScalaModule with BuildInfo {
 
   object worker extends MillPublishScalaModule {
     def compileModuleDeps = Seq(bsp, scalalib, testrunner, runner) ++ scalalib.compileModuleDeps
-    def ivyDeps = Agg(Deps.bsp4j, Deps.sbtTestInterface)
+    def ivyDeps = Agg(Deps.bsp4j, Deps.scalaDebugAdapter, Deps.sbtTestInterface)
   }
 }
 

--- a/main/util/src/mill/util/ColorLogger.scala
+++ b/main/util/src/mill/util/ColorLogger.scala
@@ -8,4 +8,5 @@ trait ColorLogger extends Logger {
   def infoColor: fansi.Attrs
   def errorColor: fansi.Attrs
   def withOutStream(outStream: PrintStream): ColorLogger = this
+  def withErrStream(errStream: PrintStream): ColorLogger = this
 }

--- a/main/util/src/mill/util/PrefixLogger.scala
+++ b/main/util/src/mill/util/PrefixLogger.scala
@@ -51,6 +51,14 @@ class PrefixLogger(
     outStream0 = Some(outStream),
     errStream0 = Some(systemStreams.err)
   )
+
+  override def withErrStream(errStream: PrintStream): PrefixLogger = new PrefixLogger(
+    logger0.withErrStream(errStream),
+    context,
+    tickerContext,
+    outStream0 = Some(systemStreams.out),
+    errStream0 = Some(errStream)
+  )
 }
 
 object PrefixLogger {

--- a/main/util/src/mill/util/PrintLogger.scala
+++ b/main/util/src/mill/util/PrintLogger.scala
@@ -50,6 +50,9 @@ class PrintLogger(
   override def withOutStream(outStream: PrintStream): PrintLogger =
     copy(systemStreams = new SystemStreams(outStream, systemStreams.err, systemStreams.in))
 
+  override def withErrStream(errStream: PrintStream): PrintLogger =
+    copy(systemStreams = new SystemStreams(systemStreams.out, errStream, systemStreams.in))
+
   private def copy(
       colored: Boolean = colored,
       enableTicker: Boolean = enableTicker,

--- a/scalalib/src/mill/scalalib/TestModule.scala
+++ b/scalalib/src/mill/scalalib/TestModule.scala
@@ -178,7 +178,7 @@ trait TestModule
           (runClasspath() ++ zincWorker().testrunnerEntrypointClasspath()).map(
             _.path
           ),
-        jvmArgs = jvmArgs,
+        jvmArgs = jvmArgs ++ Seq(s"-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,quiet=n"),
         envArgs = forkEnv(),
         mainArgs = mainArgs,
         workingDir = forkWorkingDir(),


### PR DESCRIPTION
Attempt to fix part of #2225 

## Preview

https://github.com/com-lihaoyi/mill/assets/5793054/b5db552f-f7c0-4cec-aeec-24e0716c7559

## TODO

- Add task to run tests in debug mode or a way to `jvmOpts` dynamically