### PR TITLE
Support `build.sc` in Bloop

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -1447,6 +1447,7 @@ object dev extends MillPublishScalaModule {
   def testTransitiveDeps = super.testTransitiveDeps() ++ Seq(
     runner.linenumbers.testDep(),
     scalalib.backgroundwrapper.testDep(),
+    contrib.bloop.testDep(),
     contrib.buildinfo.testDep(),
     contrib.scoverage.testDep(),
     contrib.scoverage.worker2.testDep(),

--- a/contrib/bloop/src/mill/contrib/bloop/Bloop.scala
+++ b/contrib/bloop/src/mill/contrib/bloop/Bloop.scala
@@ -5,4 +5,4 @@ import mill.eval.Evaluator
 /**
  * Usage : `mill mill.contrib.bloop.Bloop/install`
  */
-object Bloop extends BloopImpl(() => Evaluator.currentEvaluator.value, os.pwd)
+object Bloop extends BloopImpl(() => Evaluator.allBootstrapEvaluators.value.value, os.pwd)

--- a/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
+++ b/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
@@ -5,7 +5,7 @@ import mill._
 import mill.api.Result
 import mill.define.{Discover, ExternalModule, Module => MillModule}
 import mill.eval.Evaluator
-import mill.scalalib.internal.{JavaModuleUtils, ModuleUtils}
+import mill.scalalib.internal.JavaModuleUtils
 import mill.scalajslib.ScalaJSModule
 import mill.scalajslib.api.{JsEnvConfig, ModuleKind}
 import mill.scalalib._
@@ -17,7 +17,8 @@ import mill.scalanativelib.api.ReleaseMode
  * `mill.contrib.bloop.Bloop` object, and usable in tests by passing
  * a custom evaluator.
  */
-class BloopImpl(ev: () => Evaluator, wd: os.Path) extends ExternalModule { outer =>
+class BloopImpl(evs: () => Seq[Evaluator], wd: os.Path) extends ExternalModule {
+  outer =>
   import BloopFormats._
 
   private val bloopDir = wd / ".bloop"
@@ -116,12 +117,14 @@ class BloopImpl(ev: () => Evaluator, wd: os.Path) extends ExternalModule { outer
   }
 
   protected def computeModules: Seq[JavaModule] = {
-    val eval = ev()
-    if (eval != null)
-      JavaModuleUtils.transitiveModules(eval.rootModule, accept)
-        .collect { case jm: JavaModule => jm }
-    else
-      Seq.empty
+    val evals = evs()
+    evals.flatMap { eval =>
+      if (eval != null)
+        JavaModuleUtils.transitiveModules(eval.rootModule, accept)
+          .collect { case jm: JavaModule => jm }
+      else
+        Seq.empty
+    }
   }
 
   // class-based pattern matching against path-dependant types doesn't seem to work.
@@ -144,10 +147,7 @@ class BloopImpl(ev: () => Evaluator, wd: os.Path) extends ExternalModule { outer
     Result.Success(sources.toMap)
   }
 
-  protected def name(m: JavaModule): String = ModuleUtils.moduleDisplayName(m) match {
-    case "" => "root-module"
-    case n => n
-  }
+  protected def name(m: JavaModule): String = m.bspDisplayName.replace('/', '-')
 
   protected def bloopConfigPath(module: JavaModule): os.Path =
     bloopDir / s"${name(module)}.json"
@@ -358,6 +358,7 @@ class BloopImpl(ev: () => Evaluator, wd: os.Path) extends ExternalModule { outer
           .groupBy {
             case (org, mod, version, _, _) => (org, mod, version)
           }
+          .view
           .mapValues {
             _.map {
               case (_, mod, _, classifier, file) =>
@@ -374,8 +375,9 @@ class BloopImpl(ev: () => Evaluator, wd: os.Path) extends ExternalModule { outer
                 artifacts = artifacts
               )
           }
+          .toList
 
-      gatherTask.unsafeRun().toList
+      gatherTask.unsafeRun()
     }
 
     val bloopResolution: Task[BloopConfig.Resolution] = T.task {

--- a/contrib/bloop/test/src/mill/contrib/bloop/BloopTests.scala
+++ b/contrib/bloop/test/src/mill/contrib/bloop/BloopTests.scala
@@ -17,7 +17,7 @@ object BloopTests extends TestSuite {
 
   val workdir = os.pwd / "target" / "workspace" / "bloop"
   val testEvaluator = TestEvaluator.static(build)
-  val testBloop = new BloopImpl(() => testEvaluator.evaluator, workdir)
+  val testBloop = new BloopImpl(() => Seq(testEvaluator.evaluator), workdir)
 
   object build extends TestUtil.BaseModule {
 

--- a/integration/feature/bloop/repo/build.sc
+++ b/integration/feature/bloop/repo/build.sc
@@ -1,0 +1,8 @@
+// mill plugins
+import $ivy.`com.lihaoyi::mill-contrib-bloop:`
+
+// imports
+import mill._
+import mill.scalalib._
+
+object root extends RootModule with JavaModule

--- a/integration/feature/bloop/test/src/BloopTests.scala
+++ b/integration/feature/bloop/test/src/BloopTests.scala
@@ -1,0 +1,28 @@
+package mill.integration
+
+import utest._
+
+object BloopTests extends IntegrationTestSuite {
+  initWorkspace()
+
+  val installResult = eval("mill.contrib.bloop.Bloop/install")
+
+  val tests: Tests = Tests {
+    test("test") - {
+      assert(installResult)
+
+      "root module bloop config should be created" - {
+        assert(os.exists(wd / ".bloop" / "root-module.json"))
+      }
+      val millBuildJsonFile = wd / ".bloop" / "mill-build-.json"
+      "mill-build module bloop config should be created" - {
+        assert(os.exists(millBuildJsonFile))
+      }
+
+      val config = ujson.read(os.read.stream(millBuildJsonFile))
+      "mill-build config should contain build.sc source" - {
+        assert(config("project")("sources").arr.exists(path => os.Path(path.str).last == "build.sc"))
+      }
+    }
+  }
+}

--- a/integration/feature/bloop/test/src/BloopTests.scala
+++ b/integration/feature/bloop/test/src/BloopTests.scala
@@ -21,7 +21,9 @@ object BloopTests extends IntegrationTestSuite {
 
       val config = ujson.read(os.read.stream(millBuildJsonFile))
       "mill-build config should contain build.sc source" - {
-        assert(config("project")("sources").arr.exists(path => os.Path(path.str).last == "build.sc"))
+        assert(config("project")("sources").arr.exists(path =>
+          os.Path(path.str).last == "build.sc"
+        ))
       }
     }
   }

--- a/integration/feature/bloop/test/src/BloopTests.scala
+++ b/integration/feature/bloop/test/src/BloopTests.scala
@@ -5,7 +5,7 @@ import utest._
 object BloopTests extends IntegrationTestSuite {
   initWorkspace()
 
-  val installResult = eval("mill.contrib.bloop.Bloop/install")
+  val installResult: Boolean = eval("mill.contrib.bloop.Bloop/install")
 
   val tests: Tests = Tests {
     test("test") - {


### PR DESCRIPTION
After Mill `0.11` `mill-contrib-bloop` stopped supporting the build module.
Now `BloopImpl` gets a sequence of `Evaluator`s and gets all modules for all the evaluators in `Evaluator.allBootstrapEvaluators`, so it supports the build module again.

Pull Request: https://github.com/com-lihaoyi/mill/pull/3208