### PR TITLE
Improve Mill plugin classpath exclusions

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -590,7 +590,7 @@ object main extends MillStableScalaModule with BuildInfo {
       "millEmbeddedDeps",
       (
         T.traverse(
-          dev.transitiveModuleDeps.collect { case m: PublishModule => m }
+          dev.recursiveModuleDeps.collect { case m: PublishModule => m }
         )(
           _.publishSelfDependency
         )()

--- a/build.sc
+++ b/build.sc
@@ -201,7 +201,7 @@ object Deps {
     ivy"com.google.protobuf:protobuf-java:3.25.3",
     ivy"com.google.guava:guava:33.2.1-jre",
     ivy"org.yaml:snakeyaml:2.2",
-    ivy"org.apache.commons:commons-compress:[1.26.0,)"
+    ivy"org.apache.commons:commons-compress:1.26.0"
   )
 
   /** Used in tests. */
@@ -588,8 +588,25 @@ object main extends MillStableScalaModule with BuildInfo {
     BuildInfo.Value("millBinPlatform", millBinPlatform(), "Mill binary platform version."),
     BuildInfo.Value(
       "millEmbeddedDeps",
-      T.traverse(dev.moduleDeps)(_.publishSelfDependency)()
-        .map(artifact => s"${artifact.group}:${artifact.id}:${artifact.version}")
+      (
+        T.traverse(
+          dev.transitiveModuleDeps.collect { case m: PublishModule => m }
+        )(
+          _.publishSelfDependency
+        )()
+          .map(artifact => s"${artifact.group}:${artifact.id}:${artifact.version}") ++
+          Lib.resolveDependenciesMetadata(
+            repositories = dev.repositoriesTask(),
+            dev.transitiveIvyDeps(),
+            Some(dev.mapDependencies()),
+            dev.resolutionCustomizer(),
+            Some(T.ctx()),
+            dev.coursierCacheCustomizer()
+          )._2.minDependencies.toSeq
+            .map(d => s"${d.module.organization.value}:${d.module.name.value}:${d.version}")
+      )
+//      T.traverse(dev.moduleDeps)(_.publishSelfDependency)()
+//        .map(artifact => s"${artifact.group}:${artifact.id}:${artifact.version}")
         .mkString(","),
       "Dependency artifacts embedded in mill assembly by default."
     ),
@@ -1008,7 +1025,6 @@ object contrib extends Module {
     def compileModuleDeps = Seq(scalalib)
     def ivyDeps = Agg(Deps.requests)
   }
-
 
   object sonatypecentral extends ContribModule {
     def compileModuleDeps = Seq(scalalib)

--- a/integration/feature/gen-idea/repo/hello-idea/idea/libraries/scala_SDK_2_13_14.xml
+++ b/integration/feature/gen-idea/repo/hello-idea/idea/libraries/scala_SDK_2_13_14.xml
@@ -3,9 +3,6 @@
         <properties>
             <language-level>Scala_2_13</language-level>
             <compiler-classpath>
-                <root url="file://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/io/github/java-diff-utils/java-diff-utils/4.12/java-diff-utils-4.12.jar"/>
-                <root url="file://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/net/java/dev/jna/jna/5.14.0/jna-5.14.0.jar"/>
-                <root url="file://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/jline/jline/3.25.1/jline-3.25.1.jar"/>
                 <root url="file://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.13.14/scala-compiler-2.13.14.jar"/>
                 <root url="file://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.14/scala-library-2.13.14.jar"/>
                 <root url="file://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.13.14/scala-reflect-2.13.14.jar"/>

--- a/integration/feature/gen-idea/test/src/GenIdeaUtils.scala
+++ b/integration/feature/gen-idea/test/src/GenIdeaUtils.scala
@@ -23,7 +23,8 @@ object GenIdeaUtils {
 
       assertPartialContentMatches(
         found = actualResourceString,
-        expected = expectedResourceString
+        expected = expectedResourceString,
+        resource.toString()
       )
     }
     println(
@@ -33,9 +34,9 @@ object GenIdeaUtils {
     check.get
   }
 
-  def assertPartialContentMatches(found: String, expected: String): Unit = {
+  def assertPartialContentMatches(found: String, expected: String, context: String = ""): Unit = {
     if (!expected.contains(ignoreString)) {
-      assert(found == expected)
+      assert(context != null && found == expected)
     }
 
     val pattern =

--- a/integration/feature/plugin-classpath/repo/build.sc
+++ b/integration/feature/plugin-classpath/repo/build.sc
@@ -1,0 +1,9 @@
+// This plugin brings a incompatible transitive version of Mill
+import $ivy.`com.disneystreaming.smithy4s::smithy4s-mill-codegen-plugin::0.18.22`
+
+import mill._
+import mill.scalalib._
+
+object root extends RootModule with ScalaModule {
+  def scalaVersion = "3.4.2"
+}

--- a/integration/feature/plugin-classpath/repo/build.sc
+++ b/integration/feature/plugin-classpath/repo/build.sc
@@ -1,4 +1,5 @@
 // This plugin brings a incompatible transitive version of Mill
+// See https://github.com/com-lihaoyi/mill/issues/3207
 import $ivy.`com.disneystreaming.smithy4s::smithy4s-mill-codegen-plugin::0.18.22`
 
 import mill._

--- a/integration/feature/plugin-classpath/test/src/MillPluginClasspathTest.scala
+++ b/integration/feature/plugin-classpath/test/src/MillPluginClasspathTest.scala
@@ -5,7 +5,7 @@ import utest._
 object MillPluginClasspathTest extends IntegrationTestSuite {
   initWorkspace()
 
-  val embeddedModules = Seq(
+  val embeddedModules: Seq[(String, String)] = Seq(
     ("com.lihaoyi", "mill-dev_2.13"),
     ("com.lihaoyi", "mill-main-client"),
     ("com.lihaoyi", "mill-main-api_2.13"),

--- a/integration/feature/plugin-classpath/test/src/MillPluginClasspathTest.scala
+++ b/integration/feature/plugin-classpath/test/src/MillPluginClasspathTest.scala
@@ -1,0 +1,131 @@
+package mill.integration
+
+import utest._
+
+object MillPluginClasspathTest extends IntegrationTestSuite {
+  initWorkspace()
+
+  val embeddedModules = Seq(
+    ("com.lihaoyi", "mill-dev_2.13"),
+    ("com.lihaoyi", "mill-main-client"),
+    ("com.lihaoyi", "mill-main-api_2.13"),
+    ("com.lihaoyi", "mill-main-util_2.13"),
+    ("com.lihaoyi", "mill-main-codesig_2.13"),
+    ("com.lihaoyi", "mill-runner-linenumbers_2.13"),
+    ("com.lihaoyi", "mill-bsp_2.13"),
+    ("com.lihaoyi", "mill-scalanativelib-worker-api_2.13"),
+    ("com.lihaoyi", "mill-testrunner-entrypoint"),
+    ("com.lihaoyi", "mill-scalalib-api_2.13"),
+    ("com.lihaoyi", "mill-testrunner_2.13"),
+    ("com.lihaoyi", "mill-main-define_2.13"),
+    ("com.lihaoyi", "mill-main-resolve_2.13"),
+    ("com.lihaoyi", "mill-main-eval_2.13"),
+    ("com.lihaoyi", "mill-main_2.13"),
+    ("com.lihaoyi", "mill-scalalib_2.13"),
+    ("com.lihaoyi", "mill-scalanativelib_2.13"),
+    ("com.lihaoyi", "mill-scalajslib-worker-api_2.13"),
+    ("com.lihaoyi", "mill-scalajslib_2.13"),
+    ("com.lihaoyi", "mill-runner_2.13"),
+    ("com.lihaoyi", "mill-idea_2.13")
+//    ("com.lihaoyi", "mainargs_2.13"),
+//    ("org.codehaus.plexus", "plexus-utils"),
+//    ("com.lihaoyi", "upack_2.13"),
+//    ("org.codehaus.plexus", "plexus-container-default"),
+//    ("com.lihaoyi", "sourcecode_2.13"),
+//    ("org.virtuslab.scala-cli", "config_2.13"),
+//    ("com.lihaoyi", "fastparse_2.13"),
+//    ("com.eed3si9n.jarjarabrams", "jarjar-abrams-core_2.13"),
+//    ("com.kohlschutter.junixsocket", "junixsocket-common"),
+//    ("com.lihaoyi", "requests_2.13"),
+//    ("org.scala-lang.modules", "scala-xml_2.13"),
+//    ("org.codehaus.plexus", "plexus-archiver"),
+//    ("io.get-coursier", "coursier-cache_2.13"),
+//    ("com.eed3si9n.jarjar", "jarjar"),
+//    ("com.lihaoyi", "ujson_2.13"),
+//    ("org.apache.xbean", "xbean-reflect"),
+//    ("com.lihaoyi", "upickle-implicits_2.13"),
+//    ("org.scalameta", "scalafmt-dynamic_2.13"),
+//    ("org.apache.commons", "commons-lang3"),
+//    ("org.scalameta", "scalafmt-interfaces"),
+//    ("com.lihaoyi", "upickle_2.13"),
+//    ("io.get-coursier", "coursier-proxy-setup"),
+//    ("net.java.dev.jna", "jna-platform"),
+//    ("com.lihaoyi", "scalaparse_2.13"),
+//    ("com.github.luben", "zstd-jni"),
+//    ("org.apache.commons", "commons-compress"),
+//    ("com.lihaoyi", "fansi_2.13"),
+//    ("org.codehaus.plexus", "plexus-io"),
+//    ("com.lihaoyi", "os-lib_2.13"),
+//    ("org.scala-lang.modules", "scala-collection-compat_2.13"),
+//    ("io.get-coursier", "coursier_2.13"),
+//    ("org.tukaani", "xz"),
+//    ("net.java.dev.jna", "jna"),
+//    ("com.kohlschutter.junixsocket", "junixsocket-native-common"),
+//    ("com.lihaoyi", "pprint_2.13"),
+//    ("com.lihaoyi", "upickle-core_2.13"),
+//    ("io.get-coursier.jniutils", "windows-jni-utils"),
+//    ("javax.inject", "javax.inject"),
+//    ("io.github.java-diff-utils", "java-diff-utils"),
+//    ("io.get-coursier", "interface"),
+//    ("org.scala-lang", "scala-compiler"),
+//    ("org.scala-lang", "scala-library"),
+//    ("io.get-coursier", "coursier-core_2.13"),
+//    ("org.iq80.snappy", "snappy"),
+//    ("org.fusesource.jansi", "jansi"),
+//    ("org.jline", "jline"),
+//    ("io.github.alexarchambault", "concurrent-reference-hash-map"),
+//    ("commons-io", "commons-io"),
+//    ("io.get-coursier", "coursier-util_2.13"),
+//    ("org.scala-sbt", "test-interface"),
+//    ("org.ow2.asm", "asm-tree"),
+//    ("org.ow2.asm", "asm-commons"),
+//    ("com.github.plokhotnyuk.jsoniter-scala", "jsoniter-scala-core_2.13"),
+//    ("org.scala-lang", "scala-reflect"),
+//    ("com.kohlschutter.junixsocket", "junixsocket-core"),
+//    ("com.lihaoyi", "geny_2.13"),
+//    ("com.typesafe", "config"),
+//    ("org.codehaus.plexus", "plexus-classworlds"),
+//    ("org.slf4j", "slf4j-api"),
+//    ("io.github.alexarchambault.windows-ansi", "windows-ansi"),
+//    ("org.ow2.asm", "asm"),
+//    ("com.lihaoyi", "mill-moduledefs_2.13")
+  )
+
+  val tests: Tests = Tests {
+    test("exclusions") - {
+      val res1 = eval("--meta-level", "1", "resolveDepsExclusions")
+      assert(res1)
+
+      val exclusions = metaValue[Seq[(String, String)]]("mill-build.resolveDepsExclusions")
+
+      // pprint.pprintln(exclusions)
+      val expectedExclusions = embeddedModules
+
+      val diff = expectedExclusions.toSet.diff(exclusions.toSet)
+      assert(diff.isEmpty)
+
+    }
+    test("runClasspath") - {
+      // We expect Mill core transitive dependencies to be filtered out
+      val res1 = eval("--meta-level", "1", "runClasspath")
+      assert(res1)
+
+      val runClasspath = metaValue[Seq[String]]("mill-build.runClasspath")
+//      pprint.pprintln(runClasspath)
+
+      val unexpectedArtifacts = embeddedModules.map {
+        case (o, n) => s"${o.replaceAll("[.]", "/")}/${n}"
+      }
+//      pprint.pprintln(unexpectedArtifacts)
+
+      val unexpected = unexpectedArtifacts.flatMap { a =>
+        runClasspath.find(p => p.toString.contains(a)).map((a, _))
+      }.toMap
+      assert(unexpected.isEmpty)
+
+      val expected = Seq("com/disneystreaming/smithy4s/smithy4s-mill-codegen-plugin_mill0.11_2.13")
+      assert(expected.forall(a => runClasspath.exists(p => p.toString().contains(a))))
+    }
+
+  }
+}

--- a/integration/feature/plugin-classpath/test/src/MillPluginClasspathTest.scala
+++ b/integration/feature/plugin-classpath/test/src/MillPluginClasspathTest.scala
@@ -6,7 +6,6 @@ object MillPluginClasspathTest extends IntegrationTestSuite {
   initWorkspace()
 
   val embeddedModules: Seq[(String, String)] = Seq(
-    ("com.lihaoyi", "mill-dev_2.13"),
     ("com.lihaoyi", "mill-main-client"),
     ("com.lihaoyi", "mill-main-api_2.13"),
     ("com.lihaoyi", "mill-main-util_2.13"),

--- a/integration/feature/plugin-classpath/test/src/MillPluginClasspathTest.scala
+++ b/integration/feature/plugin-classpath/test/src/MillPluginClasspathTest.scala
@@ -26,68 +26,6 @@ object MillPluginClasspathTest extends IntegrationTestSuite {
     ("com.lihaoyi", "mill-scalajslib_2.13"),
     ("com.lihaoyi", "mill-runner_2.13"),
     ("com.lihaoyi", "mill-idea_2.13")
-//    ("com.lihaoyi", "mainargs_2.13"),
-//    ("org.codehaus.plexus", "plexus-utils"),
-//    ("com.lihaoyi", "upack_2.13"),
-//    ("org.codehaus.plexus", "plexus-container-default"),
-//    ("com.lihaoyi", "sourcecode_2.13"),
-//    ("org.virtuslab.scala-cli", "config_2.13"),
-//    ("com.lihaoyi", "fastparse_2.13"),
-//    ("com.eed3si9n.jarjarabrams", "jarjar-abrams-core_2.13"),
-//    ("com.kohlschutter.junixsocket", "junixsocket-common"),
-//    ("com.lihaoyi", "requests_2.13"),
-//    ("org.scala-lang.modules", "scala-xml_2.13"),
-//    ("org.codehaus.plexus", "plexus-archiver"),
-//    ("io.get-coursier", "coursier-cache_2.13"),
-//    ("com.eed3si9n.jarjar", "jarjar"),
-//    ("com.lihaoyi", "ujson_2.13"),
-//    ("org.apache.xbean", "xbean-reflect"),
-//    ("com.lihaoyi", "upickle-implicits_2.13"),
-//    ("org.scalameta", "scalafmt-dynamic_2.13"),
-//    ("org.apache.commons", "commons-lang3"),
-//    ("org.scalameta", "scalafmt-interfaces"),
-//    ("com.lihaoyi", "upickle_2.13"),
-//    ("io.get-coursier", "coursier-proxy-setup"),
-//    ("net.java.dev.jna", "jna-platform"),
-//    ("com.lihaoyi", "scalaparse_2.13"),
-//    ("com.github.luben", "zstd-jni"),
-//    ("org.apache.commons", "commons-compress"),
-//    ("com.lihaoyi", "fansi_2.13"),
-//    ("org.codehaus.plexus", "plexus-io"),
-//    ("com.lihaoyi", "os-lib_2.13"),
-//    ("org.scala-lang.modules", "scala-collection-compat_2.13"),
-//    ("io.get-coursier", "coursier_2.13"),
-//    ("org.tukaani", "xz"),
-//    ("net.java.dev.jna", "jna"),
-//    ("com.kohlschutter.junixsocket", "junixsocket-native-common"),
-//    ("com.lihaoyi", "pprint_2.13"),
-//    ("com.lihaoyi", "upickle-core_2.13"),
-//    ("io.get-coursier.jniutils", "windows-jni-utils"),
-//    ("javax.inject", "javax.inject"),
-//    ("io.github.java-diff-utils", "java-diff-utils"),
-//    ("io.get-coursier", "interface"),
-//    ("org.scala-lang", "scala-compiler"),
-//    ("org.scala-lang", "scala-library"),
-//    ("io.get-coursier", "coursier-core_2.13"),
-//    ("org.iq80.snappy", "snappy"),
-//    ("org.fusesource.jansi", "jansi"),
-//    ("org.jline", "jline"),
-//    ("io.github.alexarchambault", "concurrent-reference-hash-map"),
-//    ("commons-io", "commons-io"),
-//    ("io.get-coursier", "coursier-util_2.13"),
-//    ("org.scala-sbt", "test-interface"),
-//    ("org.ow2.asm", "asm-tree"),
-//    ("org.ow2.asm", "asm-commons"),
-//    ("com.github.plokhotnyuk.jsoniter-scala", "jsoniter-scala-core_2.13"),
-//    ("org.scala-lang", "scala-reflect"),
-//    ("com.kohlschutter.junixsocket", "junixsocket-core"),
-//    ("com.lihaoyi", "geny_2.13"),
-//    ("com.typesafe", "config"),
-//    ("org.codehaus.plexus", "plexus-classworlds"),
-//    ("org.slf4j", "slf4j-api"),
-//    ("io.github.alexarchambault.windows-ansi", "windows-ansi"),
-//    ("org.ow2.asm", "asm"),
-//    ("com.lihaoyi", "mill-moduledefs_2.13")
   )
 
   val tests: Tests = Tests {
@@ -96,8 +34,6 @@ object MillPluginClasspathTest extends IntegrationTestSuite {
       assert(res1)
 
       val exclusions = metaValue[Seq[(String, String)]]("mill-build.resolveDepsExclusions")
-
-      // pprint.pprintln(exclusions)
       val expectedExclusions = embeddedModules
 
       val diff = expectedExclusions.toSet.diff(exclusions.toSet)
@@ -110,12 +46,10 @@ object MillPluginClasspathTest extends IntegrationTestSuite {
       assert(res1)
 
       val runClasspath = metaValue[Seq[String]]("mill-build.runClasspath")
-//      pprint.pprintln(runClasspath)
 
       val unexpectedArtifacts = embeddedModules.map {
         case (o, n) => s"${o.replaceAll("[.]", "/")}/${n}"
       }
-//      pprint.pprintln(unexpectedArtifacts)
 
       val unexpected = unexpectedArtifacts.flatMap { a =>
         runClasspath.find(p => p.toString.contains(a)).map((a, _))

--- a/integration/src/mill/integration/IntegrationTestSuite.scala
+++ b/integration/src/mill/integration/IntegrationTestSuite.scala
@@ -1,5 +1,6 @@
 package mill.integration
 
+import mill.eval.Evaluator
 import mill.resolve.SelectMode
 import mill.runner.RunnerState
 import os.{Path, Shellable}
@@ -89,6 +90,16 @@ abstract class IntegrationTestSuite extends TestSuite {
 
     val segments = selector._2.value.flatMap(_.pathSegments)
     os.read(wd / "out" / segments.init / s"${segments.last}.json")
+  }
+
+  def metaCached(selector: String): Evaluator.Cached = {
+    val data = meta(selector)
+    upickle.default.read[Evaluator.Cached](data)
+  }
+
+  def metaValue[T: upickle.default.Reader](selector: String): T = {
+    val cached = metaCached(selector)
+    upickle.default.read[T](cached.value)
   }
 
   def initWorkspace(): Path = {


### PR DESCRIPTION
Also refer to transitive modules coordinates in the `BuildInfo.millEmbededDeps` data field.

Added an integration test to make sure it's effectively excluding transitive Mill dependencies.

Fix https://github.com/com-lihaoyi/mill/issues/3207