### PR TITLE
Make build.sc dependency resolution independent of Mill assembly

### DIFF
--- a/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -379,13 +379,7 @@ private class MillBuildServer(
       }
     ) {
       case (ev, state, id, m: JavaModule, (resolveDepsSources, unmanagedClasspath, repos)) =>
-        val buildSources =
-          if (!m.isInstanceOf[MillBuildRootModule]) Nil
-          else mill.scalalib.Lib
-            .resolveMillBuildDeps(repos, None, useSources = true)
-            .map(sanitizeUri(_))
-
-        val cp = (resolveDepsSources ++ unmanagedClasspath).map(sanitizeUri).toSeq ++ buildSources
+        val cp = (resolveDepsSources ++ unmanagedClasspath).map(sanitizeUri).toSeq
         new DependencySourcesItem(id, cp.asJava)
     } {
       new DependencySourcesResult(_)

--- a/example/misc/4-mill-build-folder/mill-build/build.sc
+++ b/example/misc/4-mill-build-folder/mill-build/build.sc
@@ -1,6 +1,6 @@
 import mill._, scalalib._
 
-object millbuild extends MillBuildRootModule{
+object millbuild extends runner.MillBuildRootModule{
   val scalatagsVersion = "0.12.0"
   def ivyDeps = Agg(ivy"com.lihaoyi::scalatags:$scalatagsVersion")
 

--- a/idea/src/mill/idea/GenIdeaImpl.scala
+++ b/idea/src/mill/idea/GenIdeaImpl.scala
@@ -1,6 +1,5 @@
 package mill.idea
 
-import scala.collection.immutable
 import scala.util.{Success, Try}
 import scala.xml.{Elem, MetaData, Node, NodeSeq, Null, UnprefixedAttribute}
 import coursier.core.compatibility.xmlParseDom
@@ -100,22 +99,6 @@ case class GenIdeaImpl(
 //        .map(x => (x.millModuleSegments, x))
 //        .toSeq
 //        .distinct
-
-    val buildLibraryPaths: immutable.Seq[os.Path] = {
-      if (!fetchMillModules) Nil
-      else {
-        val moduleRepos = modulesByEvaluator.toSeq.flatMap { case (ev, modules) =>
-          ev.evalOrThrow(
-            exceptionFactory = r =>
-              GenIdeaException(
-                s"Failure during resolving repositories: ${Evaluator.formatFailing(r)}"
-              )
-          )(modules.map(_._2.repositoriesTask))
-        }
-        Lib.resolveMillBuildDeps(moduleRepos.flatten, Option(ctx), useSources = true)
-        Lib.resolveMillBuildDeps(moduleRepos.flatten, Option(ctx), useSources = false)
-      }
-    }
 
     // is head the right one?
     val buildDepsPaths = Classpath.allJars(evaluators.head.rootModule.getClass.getClassLoader)
@@ -251,7 +234,7 @@ case class GenIdeaImpl(
     val moduleLabels = modules.map { case (s, m, e) => (m, s) }.toMap
 
     val allResolved: Seq[os.Path] =
-      (resolvedModules.flatMap(_.classpath).map(_.value) ++ buildLibraryPaths ++ buildDepsPaths)
+      (resolvedModules.flatMap(_.classpath).map(_.value) ++ buildDepsPaths)
         .distinct
         .sorted
 

--- a/integration/feature/gen-idea/repo/hello-idea/idea/libraries/scala_SDK_2_13_14.xml
+++ b/integration/feature/gen-idea/repo/hello-idea/idea/libraries/scala_SDK_2_13_14.xml
@@ -3,6 +3,9 @@
         <properties>
             <language-level>Scala_2_13</language-level>
             <compiler-classpath>
+                <root url="file://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/io/github/java-diff-utils/java-diff-utils/4.12/java-diff-utils-4.12.jar"/>
+                <root url="file://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/net/java/dev/jna/jna/5.14.0/jna-5.14.0.jar"/>
+                <root url="file://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/jline/jline/3.25.1/jline-3.25.1.jar"/>
                 <root url="file://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.13.14/scala-compiler-2.13.14.jar"/>
                 <root url="file://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.14/scala-library-2.13.14.jar"/>
                 <root url="file://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.13.14/scala-reflect-2.13.14.jar"/>

--- a/integration/feature/import-ivy-versions/repo/build.sc
+++ b/integration/feature/import-ivy-versions/repo/build.sc
@@ -1,0 +1,5 @@
+import mill._
+
+def getUpickleVersion = T{
+  classOf[upickle.Api].getProtectionDomain.getCodeSource.getLocation.toString
+}

--- a/integration/feature/import-ivy-versions/test/src/ImportIvyIversions.scala
+++ b/integration/feature/import-ivy-versions/test/src/ImportIvyIversions.scala
@@ -1,0 +1,19 @@
+package mill.integration
+
+import utest._
+
+object ImportIvyIversions extends IntegrationTestSuite {
+
+  val tests: Tests = Tests {
+    test {
+      val wsRoot = initWorkspace()
+      val evaled = evalStdout("show", "getUpickleVersion")
+      assert(evalStdout("show", "getUpickleVersion").out.contains ("upickle_2.13-3.3.1.jar"))
+      mangleFile(wsRoot / "build.sc", "import $ivy.`com.lihaoyi::upickle:3.3.0`\n" + _)
+      assert(evalStdout("show", "getUpickleVersion").out.contains ("upickle_2.13-3.3.1.jar"))
+      mangleFile(wsRoot / "build.sc", _.replace("3.3.0", "4.0.0-RC1"))
+      assert(evalStdout("show", "getUpickleVersion").out.contains ("upickle_2.13-3.3.1.jar"))
+
+    }
+  }
+}

--- a/integration/feature/plugin-classpath/test/src/MillPluginClasspathTest.scala
+++ b/integration/feature/plugin-classpath/test/src/MillPluginClasspathTest.scala
@@ -29,17 +29,6 @@ object MillPluginClasspathTest extends IntegrationTestSuite {
   )
 
   val tests: Tests = Tests {
-    test("exclusions") - {
-      val res1 = eval("--meta-level", "1", "resolveDepsExclusions")
-      assert(res1)
-
-      val exclusions = metaValue[Seq[(String, String)]]("mill-build.resolveDepsExclusions")
-      val expectedExclusions = embeddedModules
-
-      val diff = expectedExclusions.toSet.diff(exclusions.toSet)
-      assert(diff.isEmpty)
-
-    }
     test("runClasspath") - {
       // We expect Mill core transitive dependencies to be filtered out
       val res1 = eval("--meta-level", "1", "runClasspath")

--- a/integration/feature/plugin-classpath/test/src/MillPluginClasspathTest.scala
+++ b/integration/feature/plugin-classpath/test/src/MillPluginClasspathTest.scala
@@ -35,7 +35,7 @@ object MillPluginClasspathTest extends IntegrationTestSuite {
       assert(res1)
 
       val runClasspath = metaValue[Seq[String]]("mill-build.runClasspath")
-      
+
       val expected = Seq("com/disneystreaming/smithy4s/smithy4s-mill-codegen-plugin_mill0.11_2.13")
       assert(expected.forall(a => runClasspath.exists(p => p.toString().contains(a))))
     }

--- a/integration/feature/plugin-classpath/test/src/MillPluginClasspathTest.scala
+++ b/integration/feature/plugin-classpath/test/src/MillPluginClasspathTest.scala
@@ -35,16 +35,7 @@ object MillPluginClasspathTest extends IntegrationTestSuite {
       assert(res1)
 
       val runClasspath = metaValue[Seq[String]]("mill-build.runClasspath")
-
-      val unexpectedArtifacts = embeddedModules.map {
-        case (o, n) => s"${o.replaceAll("[.]", "/")}/${n}"
-      }
-
-      val unexpected = unexpectedArtifacts.flatMap { a =>
-        runClasspath.find(p => p.toString.contains(a)).map((a, _))
-      }.toMap
-      assert(unexpected.isEmpty)
-
+      
       val expected = Seq("com/disneystreaming/smithy4s/smithy4s-mill-codegen-plugin_mill0.11_2.13")
       assert(expected.forall(a => runClasspath.exists(p => p.toString().contains(a))))
     }

--- a/integration/feature/plugin-classpath/test/src/MillPluginClasspathTest.scala
+++ b/integration/feature/plugin-classpath/test/src/MillPluginClasspathTest.scala
@@ -5,29 +5,6 @@ import utest._
 object MillPluginClasspathTest extends IntegrationTestSuite {
   initWorkspace()
 
-  val embeddedModules: Seq[(String, String)] = Seq(
-    ("com.lihaoyi", "mill-main-client"),
-    ("com.lihaoyi", "mill-main-api_2.13"),
-    ("com.lihaoyi", "mill-main-util_2.13"),
-    ("com.lihaoyi", "mill-main-codesig_2.13"),
-    ("com.lihaoyi", "mill-runner-linenumbers_2.13"),
-    ("com.lihaoyi", "mill-bsp_2.13"),
-    ("com.lihaoyi", "mill-scalanativelib-worker-api_2.13"),
-    ("com.lihaoyi", "mill-testrunner-entrypoint"),
-    ("com.lihaoyi", "mill-scalalib-api_2.13"),
-    ("com.lihaoyi", "mill-testrunner_2.13"),
-    ("com.lihaoyi", "mill-main-define_2.13"),
-    ("com.lihaoyi", "mill-main-resolve_2.13"),
-    ("com.lihaoyi", "mill-main-eval_2.13"),
-    ("com.lihaoyi", "mill-main_2.13"),
-    ("com.lihaoyi", "mill-scalalib_2.13"),
-    ("com.lihaoyi", "mill-scalanativelib_2.13"),
-    ("com.lihaoyi", "mill-scalajslib-worker-api_2.13"),
-    ("com.lihaoyi", "mill-scalajslib_2.13"),
-    ("com.lihaoyi", "mill-runner_2.13"),
-    ("com.lihaoyi", "mill-idea_2.13")
-  )
-
   val tests: Tests = Tests {
     test("runClasspath") - {
       // We expect Mill core transitive dependencies to be filtered out

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -4,7 +4,7 @@ import coursier.Repository
 import mill._
 import mill.api.{PathRef, Result, internal}
 import mill.define.{Discover, Task}
-import mill.scalalib.{BoundDep, Dep, DepSyntax, Lib, ScalaModule}
+import mill.scalalib.{Dep, DepSyntax, Lib, ScalaModule}
 import mill.util.CoursierSupport
 import mill.util.Util.millProjectModule
 import mill.scalalib.api.Versions

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -101,7 +101,7 @@ class MillBuildRootModule()(implicit
         .map(mill.scalalib.Dep.parse)
     ) ++
       Agg(ivy"com.lihaoyi::mill-moduledefs:${Versions.millModuledefsVersion}") ++
-    Agg.from(embeddedIncluded)
+      Agg.from(embeddedIncluded)
   }
 
   override def runIvyDeps = T {

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -92,11 +92,16 @@ class MillBuildRootModule()(implicit
   }
 
   override def ivyDeps = T {
+    val embeddedIncluded = BuildInfo.millEmbeddedDeps
+      .split(",")
+      .map(d => ivy"$d")
+
     Agg.from(
       MillIvy.processMillIvyDepSignature(parseBuildFiles().ivyDeps)
         .map(mill.scalalib.Dep.parse)
     ) ++
-      Agg(ivy"com.lihaoyi::mill-moduledefs:${Versions.millModuledefsVersion}")
+      Agg(ivy"com.lihaoyi::mill-moduledefs:${Versions.millModuledefsVersion}") ++
+    Agg.from(embeddedIncluded)
   }
 
   override def runIvyDeps = T {
@@ -242,7 +247,7 @@ class MillBuildRootModule()(implicit
   }
 
   override def unmanagedClasspath: T[Agg[PathRef]] = T {
-    enclosingClasspath() ++ lineNumberPluginClasspath()
+    lineNumberPluginClasspath()
   }
 
   override def scalacPluginIvyDeps: T[Agg[Dep]] = Agg(

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -230,22 +230,6 @@ class MillBuildRootModule()(implicit
     millBuildRootModuleInfo.enclosingClasspath.map(p => mill.api.PathRef(p, quick = true))
   }
 
-  /**
-   * Dependencies, which should be transitively excluded.
-   * By default, these are the dependencies, which Mill provides itself (via [[unmanagedClasspath]]).
-   * We exclude them to avoid incompatible or duplicate artifacts on the classpath.
-   */
-  protected def resolveDepsExclusions: T[Seq[(String, String)]] = T {
-    Lib.millAssemblyEmbeddedDeps.toSeq.map(d =>
-      (d.dep.module.organization.value, d.dep.module.name.value)
-    )
-  }
-
-  override def resolveDeps(deps: Task[Agg[BoundDep]], sources: Boolean): Task[Agg[PathRef]] = {
-    val excludeProvided = T.task { deps().map(_.exclude(resolveDepsExclusions(): _*)) }
-    super.resolveDeps(excludeProvided, sources)
-  }
-
   override def unmanagedClasspath: T[Agg[PathRef]] = T {
     lineNumberPluginClasspath()
   }

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -91,7 +91,7 @@ class MillBuildRootModule()(implicit
     imports
   }
 
-  override def ivyDeps = T {
+  override def mandatoryIvyDeps = T {
     val embeddedIncluded = BuildInfo.millEmbeddedDeps
       .split(",")
       .map(d => ivy"$d")

--- a/scalalib/src/mill/scalalib/Lib.scala
+++ b/scalalib/src/mill/scalalib/Lib.scala
@@ -150,7 +150,6 @@ object Lib {
     Util.millProperty("MILL_BUILD_LIBRARIES") match {
       case Some(found) => found.split(',').map(os.Path(_)).distinct.toList
       case None =>
-        millAssemblyEmbeddedDeps
         val Result.Success(res) = scalalib.Lib.resolveDependencies(
           repositories = repos.toList,
           deps = millAssemblyEmbeddedDeps,

--- a/scalalib/src/mill/scalalib/Lib.scala
+++ b/scalalib/src/mill/scalalib/Lib.scala
@@ -4,8 +4,6 @@ package scalalib
 import coursier.util.Task
 import coursier.{Dependency, Repository, Resolution}
 import mill.api.{Ctx, Loose, PathRef, Result}
-import mill.main.BuildInfo
-import mill.util.Util
 import mill.scalalib.api.ZincWorkerUtil
 
 object Lib {
@@ -134,33 +132,4 @@ object Lib {
       if os.isFile(path) && (extensions.exists(path.ext == _) && !isHiddenFile(path))
     } yield path
   }
-
-  private[mill] def millAssemblyEmbeddedDeps: Agg[BoundDep] = Agg.from(
-    BuildInfo.millEmbeddedDeps
-      .split(",")
-      .map(d => ivy"$d")
-      .map(dep => Lib.depToBoundDep(dep, BuildInfo.scalaVersion))
-  )
-
-  def resolveMillBuildDeps(
-      repos: Seq[Repository],
-      ctx: Option[mill.api.Ctx.Log],
-      useSources: Boolean
-  ): Seq[os.Path] = {
-    Util.millProperty("MILL_BUILD_LIBRARIES") match {
-      case Some(found) => found.split(',').map(os.Path(_)).distinct.toList
-      case None =>
-        val Result.Success(res) = scalalib.Lib.resolveDependencies(
-          repositories = repos.toList,
-          deps = millAssemblyEmbeddedDeps,
-          sources = useSources,
-          mapDependencies = None,
-          customizer = None,
-          coursierCacheCustomizer = None,
-          ctx = ctx
-        )
-        res.items.toList.map(_.path)
-    }
-  }
-
 }


### PR DESCRIPTION
Should fix https://github.com/com-lihaoyi/mill/issues/2985 and https://github.com/com-lihaoyi/mill/issues/2703, at least as a first pass. 

- I did not change the actual classpath contents to try and minimize it; that can come in a follow up PR
- I did not try to cache or bundle the dependencies locally; that can also come in a follow up

At least with this change, all the Mill `build.sc` dependencies go through the same code path (Coursier resolution) and behave similarly (e.g. you should be able to update upickle via `import $ivy`. Further improvements to hygiene or performance can come in follow ups (e.g. resolving dependencies bundled in the assembly)

Notes:

- Changed `MillBuildRootModule#ivyDeps` to `mandatoryIvyDeps` to prevent accidental overriding (not sure why this didn't cause problems before??? Maybe people just didn't override `ivyDeps` much in the meta-build)

- Removed `resolveDepsExclusions`, since now we are no longer hard-coding a dependency on the Mill assembly, we also no longer need to treat these dependencies specially and they can be upgraded or evicted as the user sees fit

- Removed `Lib.resolveMillBuildDeps` and its use sites, since now the build dependencies go through the same code path as any other `ivyDeps`

Tested the `mill.idea.GenIdea/idea` workflow manually in `example/basic/1-simple-scala` and `example/misc/4-mill-build-folder` manually, the intellij jump-to-definition in `build.sc` and `mill-build/build.sc` seem to work