### PR TITLE
Fix resolution of children of `override lazy val` modules

### DIFF
--- a/main/define/src/mill/define/Reflect.scala
+++ b/main/define/src/mill/define/Reflect.scala
@@ -29,7 +29,6 @@ private[mill] object Reflect {
         isLegalIdentifier(n) &&
         (!noParams || m.getParameterCount == 0) &&
         (m.getModifiers & Modifier.STATIC) == 0 &&
-        (m.getModifiers & Modifier.ABSTRACT) == 0 &&
         inner.isAssignableFrom(m.getReturnType)
     } yield m
 

--- a/main/resolve/test/src/mill/main/ResolveTests.scala
+++ b/main/resolve/test/src/mill/main/ResolveTests.scala
@@ -1099,5 +1099,12 @@ object ResolveTests extends TestSuite {
         )
       }
     }
+    test("abstractModule") {
+      val check = new Checker(TestGraphs.AbstractModule)
+      test - check(
+        "concrete.tests.inner.foo",
+        Right(Set(_.concrete.tests.inner.foo))
+      )
+    }
   }
 }

--- a/main/test/src/mill/util/TestGraphs.scala
+++ b/main/test/src/mill/util/TestGraphs.scala
@@ -608,4 +608,20 @@ object TestGraphs {
     }
   }
 
+  object AbstractModule extends TestUtil.BaseModule {
+    trait Abstract extends Module {
+      lazy val tests: Tests = new Tests{}
+      trait Tests extends Module{}
+    }
+
+    object concrete extends Abstract{
+      override lazy val tests: ConcreteTests = new ConcreteTests{}
+      trait ConcreteTests extends Tests {
+        object inner extends Module{
+          def foo = T { "foo" }
+        }
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
Filtering out `abstract` methods in `Reflect` seems unnecessary, since compilation checks that every method is implemented already