### PR TITLE
Fix AssemblyTests on Windows

### DIFF
--- a/scalalib/test/src/mill/scalalib/AssemblyTests.scala
+++ b/scalalib/test/src/mill/scalalib/AssemblyTests.scala
@@ -1,5 +1,6 @@
 package mill.scalalib
 
+import scala.util.Properties
 import mill._
 import mill.api.Result
 import mill.eval.Evaluator
@@ -125,7 +126,15 @@ object AssemblyTests extends TestSuite {
         test("small") {
           workspaceTest(TestCase) { eval =>
             val Right((res, _)) = eval(TestCase.exe.small.assembly)
-            runAssembly(res.path, TestCase.millSourcePath, checkExe = true)
+            val originalPath = res.path
+            val resolvedPath = 
+              if (Properties.isWin) {
+                val winPath = originalPath / os.up / s"${originalPath.last}.bat"
+                os.copy(originalPath, winPath)
+                winPath
+              }
+              else originalPath
+            runAssembly(resolvedPath, TestCase.millSourcePath, checkExe = true)
           }
         }
         test("large-should-fail") {


### PR DESCRIPTION
Depends on #3285  

Windows has an env var called `PATHEXT` whish is usually something like this: `.COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC`  
Basically a list of extensions considered as executable.  
So the file in Mill's case needs to be a `.bat` file.