### PR TITLE
Wire up post-0.11.x old docsites into Antora

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -1750,14 +1750,16 @@ object docs extends Module {
   def devAntoraSources: T[PathRef] = T {
     val dest = T.dest
     os.copy(source().path, dest, mergeFolders = true)
-    sanitizeAntoraYml(dest, millVersion(), millLastTag())
+    sanitizeAntoraYml(dest, "master", millVersion(), millLastTag())
     PathRef(dest)
   }
 
-  def sanitizeAntoraYml(dest: os.Path, millVersion: String, millLastTag: String) = {
-    println(s"sanitizeAntoraYml($dest, $millVersion, $millLastTag)")
+  def sanitizeAntoraYml(dest: os.Path,
+                        version: String,
+                        millVersion: String,
+                        millLastTag: String) = {
     val lines = os.read(dest / "antora.yml").linesIterator.map {
-      case s"version:$_" => s"version: 'master'" + "\n" + s"display-version: '$millVersion'"
+      case s"version:$_" => s"version: '$version'\ndisplay-version: '$millVersion'"
       case s"    mill-version:$_" => s"    mill-version: '$millVersion'"
       case s"    mill-last-tag:$_" => s"    mill-last-tag: '$millLastTag'"
       case l => l
@@ -1828,6 +1830,7 @@ object docs extends Module {
       os.proc("git", "checkout", oldVersion).call(cwd = checkout, stdout = os.Inherit)
       val outputFolder = checkout / "out" / "docs" / "source.dest"
       os.proc("./mill", "-i", "docs.source").call(cwd = checkout, stdout = os.Inherit)
+      sanitizeAntoraYml(outputFolder, oldVersion, oldVersion, oldVersion)
       PathRef(outputFolder)
     }
   }

--- a/build.sc
+++ b/build.sc
@@ -1837,7 +1837,7 @@ object docs extends Module {
   }
 
   def localPages = T {
-    val pages = generatePages(authorMode = true)().apply(Nil)
+    val pages = generatePages(authorMode = true)().apply(oldDocSources().map(_.path))
     T.log.outputStream.println(
       s"You can browse the local pages at: ${(pages.path / "index.html").toNIO.toUri()}"
     )

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,12 +1,12 @@
 name: mill
 title: Mill Documentation
-version: '0.11.10'
+version: ???
 nav:
   - modules/ROOT/nav.adoc
 asciidoc:
   attributes:
-    mill-version: '0.11.10'
-    mill-last-tag: '0.11.10'
+    mill-version: ???
+    mill-last-tag: ???
     bsp-version: '2.2.0'
     example-semanticdb-version: '4.9.7'
     example-scala-2-13-version: '2.13.14'


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/2455

They can now be added to `val docTags`, and will appear as previous versions on the docsite

To support this mostly transparently, I checkout the relevant versions of com-lihaoyi/mill as part of `githubPages` and run `./mill` to build their docs. This saves us the hassle of storing the materialized `.adoc` files somewhere and worrying about them getting stale/corrupted/accessible/etc.

The versions listed in `docs/antora.yml` are incorrect for some of the old tags like 0.11.10. We probably should generate them in `build.sc` to avoid duplication.

If we intend to support ongoing development of old branches, we probably should use moving `0.11.x` branches rather than fixed `0.11.x` tags for the doc-site, so that improvements to the documentation would get picked up without additional releases. We might also want to make the latest stable version the default page, so we can merge incremental documentation into `main` without confusing users. But these improvements can come in follow ups