### PR TITLE
Add error log when passing args to `run` on `ScalaJSModule`

### DIFF
--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -147,7 +147,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
 
   override def run(args: Task[Args] = T.task(Args())): Command[Unit] = T.command {
     if (args().value.nonEmpty) {
-      T.log.info("Passing command line arguments to run is not supported by Scala.js.")
+      T.log.error("Passing command line arguments to run is not supported by Scala.js.")
     }
     finalMainClassOpt() match {
       case Left(err) => Result.Failure(err)

--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -146,6 +146,9 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
   override def runLocal(args: Task[Args] = T.task(Args())): Command[Unit] = T.command { run(args) }
 
   override def run(args: Task[Args] = T.task(Args())): Command[Unit] = T.command {
+    if (args().value.nonEmpty) {
+      T.log.info("Passing command line arguments to run is not supported by Scala.js.")
+    }
     finalMainClassOpt() match {
       case Left(err) => Result.Failure(err)
       case Right(_) =>


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/3324

Pull Request: https://github.com/com-lihaoyi/mill/pull/3327