### PR TITLE
Trim down CI matrix further

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -61,6 +61,9 @@ jobs:
           # Run unit and module tests on both oldest and newest Java versions
           - '"{main,scalalib,testrunner,bsp}.__.test"'
         include:
+          # For most tests, run them arbitrarily on Java 8 or Java 17 on Linux, and
+          # on the opposite version on Windows below, so we get decent coverage of
+          # each test on each Java version and each operating system
           - java-version: 8
             millargs: '"scalajslib.__.test"'
           - java-version: 8

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -65,7 +65,7 @@ jobs:
             millargs: '"scalajslib.__.test"'
           - java-version: 8
             millargs: '"scalanativelib.__.test"'
-          - java-version: 8
+          - java-version: 17
             millargs: "contrib._.test"
 
           # Group these tests together to try and balance out the runtimes of each job

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -60,13 +60,13 @@ jobs:
         millargs:
           # Run unit and module tests on both oldest and newest Java versions
           - '"{main,scalalib,testrunner,bsp}.__.test"'
-          - '"scalajslib.__.test"'
-          - '"scalanativelib.__.test"'
-          # contrib tests
-          - "contrib._.test"
-
         include:
-          # Integration and example tests are slow, so don't run the on multiple Java versions
+          - java-version: 8
+            millargs: '"scalajslib.__.test"'
+          - java-version: 8
+            millargs: '"scalanativelib.__.test"'
+          - java-version: 8
+            millargs: "contrib._.test"
 
           # Group these tests together to try and balance out the runtimes of each job
           # Just running in `local` mode since they shouldn't depend on the mode
@@ -131,26 +131,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java-version: [8, 17]
-        millargs:
-          # Run a stripped down build matrix on Windows, to avoid taking too long
-          - '"{__.publishLocal,dev.assembly,__.compile}"'
-          - '"{main,scalalib,bsp}.__.test"'
-          - '"scalajslib.__.test"'
-
         include:
-          # Limit some tests to Java 17 to limit CI times
           # just run a subset of examples/ on Windows, because for some reason running
           # the whole suite can take hours on windows v.s. half an hour on linux
+          - java-version: 8
+            millargs: '"{main,scalalib,bsp}.__.test"'
           - java-version: 17
+            millargs: '"scalajslib.__.test"'
+          - java-version: 8
             millargs: '"example.basic[_].local.test"'
           - java-version: 17
             millargs: "'integration.feature[_].fork.test'"
-          - java-version: 17
+          - java-version: 8
             millargs: "'integration.invalidation[_].server.test'"
           - java-version: 17
             millargs: "'integration.failure[_].fork.test'"
-          - java-version: 17
+          - java-version: 8
             millargs: "contrib.__.test"
 
     uses: ./.github/workflows/run-mill-action.yml

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -79,7 +79,7 @@ jobs:
 
             # Most of these integration tests should not depend on which mode they
             # are run in, so just run them in `local`
-          - java-version: 17
+          - java-version: 8
             millargs: "'integration.{failure,feature,ide}[_].local.test'"
 
             # These invalidation tests need to be exercised in all three execution modes

--- a/.github/workflows/run-mill-action.yml
+++ b/.github/workflows/run-mill-action.yml
@@ -19,7 +19,7 @@ on:
         default: false
         type: boolean
       timeout-minutes:
-        default: 90
+        default: 60
         type: number
       env-bridge-versions:
         default: 'none'


### PR DESCRIPTION
- Stop running Scala.js, Native, and contrib tests across both JVM versions
- Cut down windows tests to avoid running the same tests against both JVM versions; rather run each set of tests once but pick the version arbitrarily so both JVM versions get some coverage
- We don't need `{__.publishLocal,dev.assembly,__.compile}` on windows because the `integration._.{local,fork,server}` tests should exercise those code paths
- Cut down job timeout from 90min to 60min. Most jobs finish in <25min right now, so 60min should be plenty of time and give faster feedback if jobs get stuck

For the various test suites, every test is still run on both Java8 and Java 17, and on Windows or Linux: e.g. "Java8/Windows + Java17/Linux" or "Java17/Windows + Java8/Linux". Not as good as full coverage of all spots in the matrix, but should hopefully be enough to catch most bugs