### PR TITLE
Fix the warning not being printed when -i/--interactive/--no-server/--bsp are not the first argument

### DIFF
--- a/runner/src/mill/runner/MillMain.scala
+++ b/runner/src/mill/runner/MillMain.scala
@@ -1,11 +1,11 @@
 package mill.runner
 
-import java.io.{FileOutputStream, PrintStream}
+import java.io.{FileOutputStream, PrintStream, PipedInputStream}
 import java.util.Locale
 import scala.jdk.CollectionConverters._
 import scala.util.Properties
 import mill.java9rtexport.Export
-import mill.api.{DummyInputStream, MillException, internal, SystemStreams}
+import mill.api.{MillException, internal, SystemStreams}
 import mill.bsp.{BspContext, BspServerResult}
 import mill.main.BuildInfo
 import mill.util.PrintLogger
@@ -129,7 +129,7 @@ object MillMain {
         case Right(config)
             if (
               config.interactive.value || config.noServer.value || config.bsp.value
-            ) && streams.in == DummyInputStream =>
+            ) && streams.in.getClass == classOf[PipedInputStream] =>
           // because we have stdin as dummy, we assume we were already started in server process
           streams.err.println(
             "-i/--interactive/--no-server/--bsp must be passed in as the first argument"


### PR DESCRIPTION
The bug stems from the fact that a `PipedInputStream` is passed to `MillMain.main0` where `DummyInputStream` used to be. This PR fixes the bug by using a `PipedInputStream` instead of a `DummyInputStream` on the check that leads to the warning being printed.
Fixes #2869.