### PR TITLE
Use unwrapped underlying subprocess input streams when pumping

### DIFF
--- a/main/api/src/mill/api/SystemStreams.scala
+++ b/main/api/src/mill/api/SystemStreams.scala
@@ -52,14 +52,14 @@ object SystemStreams {
   private class PumpedProcessInput extends os.ProcessInput {
     def redirectFrom = ProcessBuilder.Redirect.PIPE
     def processInput(processIn: => os.SubProcess.InputStream): Some[InputPumper] = Some(
-      new InputPumper(() => System.in, () => processIn, true, () => true)
+      new InputPumper(() => System.in, () => processIn.wrapped, true, () => true)
     )
   }
 
   private class PumpedProcessOutput(dest: OutputStream) extends os.ProcessOutput {
     def redirectTo = ProcessBuilder.Redirect.PIPE
     def processOutput(processOut: => os.SubProcess.OutputStream): Some[InputPumper] =
-      Some(new InputPumper(() => processOut, () => dest, false, () => true))
+      Some(new InputPumper(() => processOut.wrapped, () => dest, false, () => true))
   }
   def withStreams[T](systemStreams: SystemStreams)(t: => T): T = {
     val in = System.in


### PR DESCRIPTION
Sometimes when you run tests in client/server mode and interrupt the run, it leaves the server stuck at the stack trace below. Eventually, `jps` shows a bunch of `MillServerMain` processes that seem to be stuck

The problem seems to go away when using unwrapped streams. I suspect it's due to https://github.com/com-lihaoyi/os-lib/issues/28 which means that the `InputPumper` calling `.available()` never gets `-1` to indicate the stream is complete, but instead keeps getting `0` telling it to try again.

The failure mode is nondeterministic, but running `./mill main.resolve.test`, entering garbage into the terminal, and `Ctrl-C` to cancel seems to reproduce it reasonably well in a few minutes. And with this PR, I haven't been able to reproduce it: no matter how I fiddle with `./mill main.resolve.test` and garbage input and `Ctrl-C`, I always end up with only a single `MillServerMain` process when calling `jps`

I don't know exactly what the failure mechanism is, but as a shot in the dark hopefully this fixes it


```
"/Library/Java/JavaVirtualMachines/amazon-corretto-17.jdk/Contents/Home/bin/java -DMILL_SCALA_2_13_VERSION=2.13.14 -DMILL_SCALA_2_12_VERSION=2.12.19 -DTEST_SCALA_2_13_VERSION=2.13.14 -DTEST_SCALA_2_13_VERSION_FOR_SCALANATIVE_4_2=2.13.8 -DTEST_SCALA_2_12_VERSION=2.12.6 -DTEST_SCALA_2_11_VERSION=2.11.12 -DTEST_SCALA_2_10_VERSION=2.10.6 -DTEST_SCALA_3_0_VERSION=3.0.2 -DTEST_SCALA_3_1_VERSION=3.1.3 -DTEST_SCALA_3_2_VERSION=3.2.0 -DTEST_SCALA_3_3_VERSION=3.3.1 -DTEST_SCALAJS_VERSION=1.16.0 -DTEST_SCALANATIVE_0_4_VERSION=0.4.17 -DTEST_SCALANATIVE_0_5_VERSION=0.5.4 -DTEST_UTEST_VERSION=0.8.4 -DTEST_SCALATEST_VERSION=3.2.19 -DTEST_TEST_INTERFACE_VERSION=1.0 -DTEST_ZIOTEST_VERSION=2.0.22 -DTEST_ZINC_VERSION=1.10.1 -Djna.nosys=true -cp /Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/utest_2.13/0.8.4/utest_2.13-0.8.4.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.14/scala-library-2.13.14.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/mill-moduledefs_2.13/0.10.9/mill-moduledefs_2.13-0.10.9.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/net/java/dev/jna/jna/5.14.0/jna-5.14.0.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/net/java/dev/jna/jna-platform/5.14.0/jna-platform-5.14.0.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/eed3si9n/jarjarabrams/jarjar-abrams-core_2.13/1.14.0/jarjar-abrams-core_2.13-1.14.0.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/mainargs_2.13/0.7.1/mainargs_2.13-0.7.1.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/scalaparse_2.13/3.1.1/scalaparse_2.13-3.1.1.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/os-lib_2.13/0.10.3/os-lib_2.13-0.10.3.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/upickle_2.13/3.3.1/upickle_2.13-3.3.1.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/pprint_2.13/0.9.0/pprint_2.13-0.9.0.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/fansi_2.13/0.5.0/fansi_2.13-0.5.0.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-sbt/test-interface/1.0/test-interface-1.0.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/io/get-coursier/coursier_2.13/2.1.10/coursier_2.13-2.1.10.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/jline/jline/3.26.3/jline-3.26.3.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/io/github/alexarchambault/windows-ansi/windows-ansi/0.0.5/windows-ansi-0.0.5.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/io/get-coursier/interface/1.0.19/interface-1.0.19.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/requests_2.13/0.9.0/requests_2.13-0.9.0.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/portable-scala/portable-scala-reflect_2.13/1.1.3/portable-scala-reflect_2.13-1.1.3.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.13.14/scala-reflect-2.13.14.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.13.14/scala-compiler-2.13.14.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/sourcecode_2.13/0.4.0/sourcecode_2.13-0.4.0.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/eed3si9n/jarjar/jarjar/1.14.0/jarjar-1.14.0.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-collection-compat_2.13/2.12.0/scala-collection-compat_2.13-2.12.0.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/fastparse_2.13/3.1.1/fastparse_2.13-3.1.1.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/geny_2.13/1.1.1/geny_2.13-1.1.1.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/ujson_2.13/3.3.1/ujson_2.13-3.3.1.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/upack_2.13/3.3.1/upack_2.13-3.3.1.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/upickle-implicits_2.13/3.3.1/upickle-implicits_2.13-3.3.1.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/kohlschutter/junixsocket/junixsocket-native-common/2.10.0/junixsocket-native-common-2.10.0.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/kohlschutter/junixsocket/junixsocket-common/2.10.0/junixsocket-common-2.10.0.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/github/plokhotnyuk/jsoniter-scala/jsoniter-scala-core_2.13/2.13.5.2/jsoniter-scala-core_2.13-2.13.5.2.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/io/get-coursier/coursier-core_2.13/2.1.10/coursier-core_2.13-2.1.10.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/io/get-coursier/coursier-cache_2.13/2.1.10/coursier-cache_2.13-2.1.10.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/io/get-coursier/coursier-proxy-setup/2.1.10/coursier-proxy-setup-2.1.10.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/fusesource/jansi/jansi/1.18/jansi-1.18.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/io/github/java-diff-utils/java-diff-utils/4.12/java-diff-utils-4.12.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/ow2/asm/asm/9.6/asm-9.6.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/ow2/asm/asm-commons/9.6/asm-commons-9.6.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.14.0/commons-lang3-3.14.0.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/upickle-core_2.13/3.3.1/upickle-core_2.13-3.3.1.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/io/github/alexarchambault/concurrent-reference-hash-map/1.1.0/concurrent-reference-hash-map-1.1.0.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.13/2.3.0/scala-xml_2.13-2.3.0.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/io/get-coursier/coursier-util_2.13/2.1.10/coursier-util_2.13-2.1.10.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/io/get-coursier/jniutils/windows-jni-utils/0.3.3/windows-jni-utils-0.3.3.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/codehaus/plexus/plexus-archiver/4.9.0/plexus-archiver-4.9.0.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/codehaus/plexus/plexus-container-default/2.1.1/plexus-container-default-2.1.1.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/virtuslab/scala-cli/config_2.13/0.2.1/config_2.13-0.2.1.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/ow2/asm/asm-tree/9.6/asm-tree-9.6.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/javax/inject/javax.inject/1/javax.inject-1.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/codehaus/plexus/plexus-utils/4.0.0/plexus-utils-4.0.0.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/codehaus/plexus/plexus-io/3.4.1/plexus-io-3.4.1.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/commons-io/commons-io/2.16.1/commons-io-2.16.1.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/commons/commons-compress/1.26.2/commons-compress-1.26.2.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/iq80/snappy/snappy/0.4/snappy-0.4.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/tukaani/xz/1.9/xz-1.9.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/github/luben/zstd-jni/1.5.5-10/zstd-jni-1.5.5-10.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/codehaus/plexus/plexus-classworlds/2.6.0/plexus-classworlds-2.6.0.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/xbean/xbean-reflect/3.7/xbean-reflect-3.7.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/commons-codec/commons-codec/1.17.0/commons-codec-1.17.0.jar:/Users/lihaoyi/Github/mill/main/resolve/compile-resources:/Users/lihaoyi/Github/mill/main/resolve/resources:/Users/lihaoyi/Github/mill/out/main/resolve/compile.dest/classes:/Users/lihaoyi/Github/mill/main/client/compile-resources:/Users/lihaoyi/Github/mill/main/client/resources:/Users/lihaoyi/Github/mill/out/main/client/buildInfoResources.dest:/Users/lihaoyi/Github/mill/out/main/client/compile.dest/classes:/Users/lihaoyi/Github/mill/main/api/compile-resources:/Users/lihaoyi/Github/mill/main/api/resources:/Users/lihaoyi/Github/mill/out/main/api/buildInfoResources.dest:/Users/lihaoyi/Github/mill/out/main/api/compile.dest/classes:/Users/lihaoyi/Github/mill/main/util/compile-resources:/Users/lihaoyi/Github/mill/main/util/resources:/Users/lihaoyi/Github/mill/out/main/util/compile.dest/classes:/Users/lihaoyi/Github/mill/main/define/compile-resources:/Users/lihaoyi/Github/mill/main/define/resources:/Users/lihaoyi/Github/mill/out/main/define/compile.dest/classes:/Users/lihaoyi/Github/mill/main/test/compile-resources:/Users/lihaoyi/Github/mill/main/test/resources:/Users/lihaoyi/Github/mill/out/main/test/compile.dest/classes:/Users/lihaoyi/Github/mill/main/eval/compile-resources:/Users/lihaoyi/Github/mill/main/eval/resources:/Users/lihaoyi/Github/mill/out/main/eval/compile.dest/classes:/Users/lihaoyi/Github/mill/main/compile-resources:/Users/lihaoyi/Github/mill/main/resources:/Users/lihaoyi/Github/mill/out/main/buildInfoResources.dest:/Users/lihaoyi/Github/mill/out/main/compile.dest/classes:/Users/lihaoyi/Github/mill/main/testkit/compile-resources:/Users/lihaoyi/Github/mill/main/testkit/resources:/Users/lihaoyi/Github/mill/out/main/testkit/compile.dest/classes:/Users/lihaoyi/Github/mill/main/resolve/test/compile-resources:/Users/lihaoyi/Github/mill/main/resolve/test/resources:/Users/lihaoyi/Github/mill/out/main/resolve/test/compile.dest/classes:/Users/lihaoyi/Github/mill/out/main/resolve/test/runClasspath.dest:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/mill-testrunner-entrypoint/0.11.11/mill-testrunner-entrypoint-0.11.11.jar mill.testrunner.entrypoint.TestRunnerMain file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/mill-scalalib_2.13/0.11.11/mill-scalalib_2.13-0.11.11.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scalameta/scalafmt-dynamic_2.13/3.7.15/scalafmt-dynamic_2.13-3.7.15.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.13/2.3.0/scala-xml_2.13-2.3.0.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.14/scala-library-2.13.14.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/mill-moduledefs_2.13/0.10.9/mill-moduledefs_2.13-0.10.9.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/mill-main_2.13/0.11.11/mill-main_2.13-0.11.11.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/mill-scalalib-api_2.13/0.11.11/mill-scalalib-api_2.13-0.11.11.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/mill-testrunner_2.13/0.11.11/mill-testrunner_2.13-0.11.11.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scalameta/scalafmt-interfaces/3.7.15/scalafmt-interfaces-3.7.15.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/io/get-coursier/interface/1.0.19/interface-1.0.19.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/typesafe/config/1.4.2/config-1.4.2.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.13.10/scala-compiler-2.13.10.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/sourcecode_2.13/0.4.0/sourcecode_2.13-0.4.0.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/io/github/alexarchambault/windows-ansi/windows-ansi/0.0.5/windows-ansi-0.0.5.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/mainargs_2.13/0.7.1/mainargs_2.13-0.7.1.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/requests_2.13/0.8.3/requests_2.13-0.8.3.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/mill-main-eval_2.13/0.11.11/mill-main-eval_2.13-0.11.11.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/mill-main-resolve_2.13/0.11.11/mill-main-resolve_2.13-0.11.11.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/mill-main-client/0.11.11/mill-main-client-0.11.11.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/mill-main-api_2.13/0.11.11/mill-main-api_2.13-0.11.11.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/mill-main-util_2.13/0.11.11/mill-main-util_2.13-0.11.11.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/mill-testrunner-entrypoint/0.11.11/mill-testrunner-entrypoint-0.11.11.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.13.12/scala-reflect-2.13.12.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/io/github/java-diff-utils/java-diff-utils/4.12/java-diff-utils-4.12.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/jline/jline/3.26.3/jline-3.26.3.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/net/java/dev/jna/jna/5.14.0/jna-5.14.0.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/fusesource/jansi/jansi/1.18/jansi-1.18.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-collection-compat_2.13/2.12.0/scala-collection-compat_2.13-2.12.0.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/geny_2.13/1.1.1/geny_2.13-1.1.1.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/mill-main-define_2.13/0.11.11/mill-main-define_2.13-0.11.11.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/os-lib_2.13/0.10.3/os-lib_2.13-0.10.3.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/upickle_2.13/3.3.1/upickle_2.13-3.3.1.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/pprint_2.13/0.9.0/pprint_2.13-0.9.0.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/fansi_2.13/0.5.0/fansi_2.13-0.5.0.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-sbt/test-interface/1.0/test-interface-1.0.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/io/get-coursier/coursier_2.13/2.1.10/coursier_2.13-2.1.10.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/net/java/dev/jna/jna-platform/5.14.0/jna-platform-5.14.0.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/eed3si9n/jarjarabrams/jarjar-abrams-core_2.13/1.14.0/jarjar-abrams-core_2.13-1.14.0.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/scalaparse_2.13/3.1.1/scalaparse_2.13-3.1.1.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/kohlschutter/junixsocket/junixsocket-native-common/2.10.0/junixsocket-native-common-2.10.0.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/kohlschutter/junixsocket/junixsocket-common/2.10.0/junixsocket-common-2.10.0.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/ujson_2.13/3.3.1/ujson_2.13-3.3.1.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/upack_2.13/3.3.1/upack_2.13-3.3.1.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/upickle-implicits_2.13/3.3.1/upickle-implicits_2.13-3.3.1.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/github/plokhotnyuk/jsoniter-scala/jsoniter-scala-core_2.13/2.13.5.2/jsoniter-scala-core_2.13-2.13.5.2.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/io/get-coursier/coursier-core_2.13/2.1.10/coursier-core_2.13-2.1.10.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/io/get-coursier/coursier-cache_2.13/2.1.10/coursier-cache_2.13-2.1.10.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/io/get-coursier/coursier-proxy-setup/2.1.10/coursier-proxy-setup-2.1.10.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/eed3si9n/jarjar/jarjar/1.14.0/jarjar-1.14.0.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/fastparse_2.13/3.1.1/fastparse_2.13-3.1.1.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/upickle-core_2.13/3.3.1/upickle-core_2.13-3.3.1.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/io/github/alexarchambault/concurrent-reference-hash-map/1.1.0/concurrent-reference-hash-map-1.1.0.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/io/get-coursier/coursier-util_2.13/2.1.10/coursier-util_2.13-2.1.10.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/io/get-coursier/jniutils/windows-jni-utils/0.3.3/windows-jni-utils-0.3.3.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/codehaus/plexus/plexus-archiver/4.9.0/plexus-archiver-4.9.0.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/codehaus/plexus/plexus-container-default/2.1.1/plexus-container-default-2.1.1.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/virtuslab/scala-cli/config_2.13/0.2.1/config_2.13-0.2.1.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/ow2/asm/asm/9.6/asm-9.6.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/ow2/asm/asm-commons/9.6/asm-commons-9.6.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/javax/inject/javax.inject/1/javax.inject-1.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/codehaus/plexus/plexus-utils/4.0.0/plexus-utils-4.0.0.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/codehaus/plexus/plexus-io/3.4.1/plexus-io-3.4.1.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/commons-io/commons-io/2.15.0/commons-io-2.15.0.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/commons/commons-compress/1.24.0/commons-compress-1.24.0.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/iq80/snappy/snappy/0.4/snappy-0.4.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/tukaani/xz/1.9/xz-1.9.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/github/luben/zstd-jni/1.5.5-10/zstd-jni-1.5.5-10.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/codehaus/plexus/plexus-classworlds/2.6.0/plexus-classworlds-2.6.0.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/xbean/xbean-reflect/3.7/xbean-reflect-3.7.jar,file:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/ow2/asm/asm-tree/9.6/asm-tree-9.6.jar /Users/lihaoyi/Github/mill/out/main/resolve/test/test.dest/testargs stdin thread" #30 prio=5 os_prio=31 cpu=56.56ms elapsed=13.94s tid=0x0000000163032800 nid=0xa507 waiting on condition  [0x000000016f72e000]
   java.lang.Thread.State: TIMED_WAITING (sleeping)
	at java.lang.Thread.sleep(java.base@17.0.6/Native Method)
	at mill.main.client.InputPumper.run(InputPumper.java:39)
	at java.lang.Thread.run(java.base@17.0.6/Thread.java:833)
```