### PR TITLE
Move inline file paths to static helper methods so we can describe them and document them

### DIFF
--- a/integration/invalidation/multi-level-editing/test/src/MultiLevelBuildTests.scala
+++ b/integration/invalidation/multi-level-editing/test/src/MultiLevelBuildTests.scala
@@ -1,5 +1,6 @@
 package mill.integration
 
+import mill.main.client.OutFiles
 import mill.runner.RunnerState
 import utest._
 
@@ -47,7 +48,7 @@ object MultiLevelBuildTests extends IntegrationTestSuite {
     def loadFrames(n: Int) = {
       for (depth <- Range(0, n))
         yield {
-          val path = wsRoot / "out" / Seq.fill(depth)("mill-build") / "mill-runner-state.json"
+          val path = wsRoot / "out" / Seq.fill(depth)(OutFiles.millBuild()) / OutFiles.millRunnerState()
           if (os.exists(path)) upickle.default.read[RunnerState.Frame.Logged](os.read(path)) -> path
           else RunnerState.Frame.Logged(Map(), Seq(), Seq(), Map(), None, Seq(), 0) -> path
         }

--- a/integration/invalidation/multi-level-editing/test/src/MultiLevelBuildTests.scala
+++ b/integration/invalidation/multi-level-editing/test/src/MultiLevelBuildTests.scala
@@ -48,7 +48,8 @@ object MultiLevelBuildTests extends IntegrationTestSuite {
     def loadFrames(n: Int) = {
       for (depth <- Range(0, n))
         yield {
-          val path = wsRoot / "out" / Seq.fill(depth)(OutFiles.millBuild()) / OutFiles.millRunnerState()
+          val path =
+            wsRoot / "out" / Seq.fill(depth)(OutFiles.millBuild()) / OutFiles.millRunnerState()
           if (os.exists(path)) upickle.default.read[RunnerState.Frame.Logged](os.read(path)) -> path
           else RunnerState.Frame.Logged(Map(), Seq(), Seq(), Map(), None, Seq(), 0) -> path
         }

--- a/main/client/src/mill/main/client/MillClientMain.java
+++ b/main/client/src/mill/main/client/MillClientMain.java
@@ -1,6 +1,5 @@
 package mill.main.client;
 
-import com.sun.security.ntlm.Server;
 import mill.main.client.lock.Locked;
 import mill.main.client.lock.Locks;
 import org.newsclub.net.unix.AFUNIXSocket;

--- a/main/client/src/mill/main/client/OutFiles.java
+++ b/main/client/src/mill/main/client/OutFiles.java
@@ -1,0 +1,50 @@
+package mill.main.client;
+
+/**
+ * Central place containing all the files that live inside the `out/` folder
+ * and documentation about what they do
+ */
+public class OutFiles {
+    /**
+     * Path of the Mill "meta-build", used to compile the `build.sc` file so we can
+     * run the primary Mill build. Can be nested for multiple stages of bootstrapping
+     */
+    public static String millBuild(){
+        return "mill-build";
+    }
+
+    /**
+     * A parallel performance and timing profile generated for every Mill execution.
+     * Can be loaded into the Chrome browser chrome://tracing page to visualize where
+     * time in a build is being spent
+     */
+    public static String millChromeProfile(){
+        return "mill-chrome-profile.json";
+    }
+
+    /**
+     * A sequential profile containing rich information about the tasks that were run
+     * as part of a build: name, duration, cached, dependencies, etc.. Useful to help
+     * understand what tasks are taking time in a build run and why those tasks are
+     * being executed
+     */
+    public static String millProfile(){
+        return "mill-profile.json";
+    }
+
+    /**
+     * Long lived metadata about the Mill bootstrap process that persists between runs:
+     * workers, watched files, classpaths, etc.
+     */
+    public static String millRunnerState(){
+        return "mill-runner-state.json";
+    }
+
+    /**
+     * Subfolder of `out/` that contains the machinery necessary for a single Mill background
+     * server: metadata files, pipes, logs, etc.
+     */
+    public static String millWorker(){
+        return "mill-worker-";
+    }
+}

--- a/main/client/src/mill/main/client/ServerFiles.java
+++ b/main/client/src/mill/main/client/ServerFiles.java
@@ -1,0 +1,63 @@
+package mill.main.client;
+
+/**
+ * Central place containing all the files that live inside the `out/mill-worker-*` folder
+ * and documentation about what they do
+ */
+public class ServerFiles {
+
+    /**
+     * Lock file used to ensure a single server is running in a particular
+     * mill-worker folder.
+     */
+    public static String processLock(String base){
+        return base + "/processLock";
+    }
+
+    public static String clientLock(String base){
+        return base + "/clientLock";
+    }
+
+    public static String serverLock(String base){
+        return base + "/serverLock";
+    }
+
+
+    /**
+     * The pipe by which the client snd server exchange IO
+     *
+     * Use uniquely-named pipes based on the fully qualified path of the project folder
+     * because on Windows the un-qualified name of the pipe must be globally unique
+     * across the whole filesystem
+     */
+    public static String pipe(String base) {
+        try {
+            return base + "/mill-" + Util.md5hex(new java.io.File(base).getCanonicalPath()) + "-io";
+        }catch (Exception e){
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Log file containing server housekeeping information
+     */
+    public static String serverLog(String base){
+        return base + "/server.log";
+    }
+
+    /**
+     * File that the client writes to pass the arguments, environment variables,
+     * and other necessary metadata to the Mill server to kick off a run
+     */
+    public static String runArgs(String base){
+        return base + "/runArgs";
+    }
+
+    /**
+     * File the server writes to pass the exit code of a completed run back to the
+     * client
+     */
+    public static String exitCode(String base){
+        return base + "/exitCode";
+    }
+}

--- a/main/client/src/mill/main/client/lock/Locks.java
+++ b/main/client/src/mill/main/client/lock/Locks.java
@@ -1,5 +1,7 @@
 package mill.main.client.lock;
 
+import mill.main.client.ServerFiles;
+
 public class Locks implements AutoCloseable {
 
     public Lock processLock;
@@ -8,9 +10,9 @@ public class Locks implements AutoCloseable {
 
     public static Locks files(String lockBase) throws Exception {
         return new Locks(){{
-            processLock = new FileLock(lockBase + "/pid");
-            serverLock = new FileLock(lockBase + "/serverLock");
-            clientLock = new FileLock(lockBase + "/clientLock");
+            processLock = new FileLock(ServerFiles.processLock(lockBase));
+            serverLock = new FileLock(ServerFiles.serverLock(lockBase));
+            clientLock = new FileLock(ServerFiles.clientLock(lockBase));
         }};
     }
 

--- a/main/eval/src/mill/eval/EvaluatorCore.scala
+++ b/main/eval/src/mill/eval/EvaluatorCore.scala
@@ -5,6 +5,7 @@ import mill.api.Strict.Agg
 import mill.api._
 import mill.define._
 import mill.eval.Evaluator.TaskResult
+import mill.main.client.OutFiles
 import mill.util._
 
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
@@ -69,8 +70,8 @@ private[mill] trait EvaluatorCore extends GroupEvaluator {
       contextLoggerMsg0: Int => String
   ): Evaluator.Results = {
     os.makeDir.all(outPath)
-    val chromeProfileLogger = new ChromeProfileLogger(outPath / "mill-chrome-profile.json")
-    val profileLogger = new ProfileLogger(outPath / "mill-profile.json")
+    val chromeProfileLogger = new ChromeProfileLogger(outPath / OutFiles.millChromeProfile())
+    val profileLogger = new ProfileLogger(outPath / OutFiles.millProfile())
     val threadNumberer = new ThreadNumberer()
     val (sortedGroups, transitive) = Plan.plan(goals)
     val interGroupDeps = findInterGroupDeps(sortedGroups)

--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -7,6 +7,7 @@ import mill.eval.Evaluator
 import mill.main.RunScript
 import mill.resolve.SelectMode
 import mill.define.{BaseModule, Discover, Segments}
+import mill.main.client.OutFiles
 
 import java.net.URLClassLoader
 
@@ -50,7 +51,7 @@ class MillBuildBootstrap(
 
     for ((frame, depth) <- runnerState.frames.zipWithIndex) {
       os.write.over(
-        recOut(projectRoot, depth) / "mill-runner-state.json",
+        recOut(projectRoot, depth) / OutFiles.millRunnerState(),
         upickle.default.write(frame.loggedData, indent = 4),
         createFolders = true
       )

--- a/runner/src/mill/runner/MillServerMain.scala
+++ b/runner/src/mill/runner/MillServerMain.scala
@@ -102,7 +102,7 @@ class Server[T](
     )
   )
 
-  def serverLog(s: String) = {
+  def serverLog(s: String): Unit = {
     serverLog0.write(s + "\n")
     serverLog0.flush()
   }
@@ -140,8 +140,9 @@ class Server[T](
                 serverLog("handling run")
                 handleRun(sock, initialSystemProperties)
                 serverSocket.close()
-              } catch { case e: Throwable =>
-                serverLog(e.toString + "\n" + e.getStackTrace.mkString("\n"))
+              } catch {
+                case e: Throwable =>
+                  serverLog(e.toString + "\n" + e.getStackTrace.mkString("\n"))
               }
           }
         }
@@ -247,7 +248,7 @@ class Server[T](
 }
 
 object Server {
-  val uniqueServerId = scala.util.Random.nextLong()
+  val uniqueServerId: Long = scala.util.Random.nextLong()
 
   def lockBlock[T](lock: Lock)(t: => T): T = {
     val l = lock.lock()

--- a/runner/src/mill/runner/MillServerMain.scala
+++ b/runner/src/mill/runner/MillServerMain.scala
@@ -227,7 +227,6 @@ class Server[T](
 }
 
 object Server {
-  val uniqueServerId: Long = scala.util.Random.nextLong()
 
   def lockBlock[T](lock: Lock)(t: => T): T = {
     val l = lock.lock()


### PR DESCRIPTION
This makes the documentation somewhat discoverable: both grepping the codebase would pull it up, as would jump-to-definition from any of the use sites in the code (which is why this is better than having it in some readme file or docsite page). We could also link to it from the docs to make it more discoverable.

Pull request: https://github.com/com-lihaoyi/mill/pull/3361