### PR TITLE
Cleanups for Mill client

### DIFF
--- a/integration/failure/missing-build-file/test/src/MissingBuildFileTests.scala
+++ b/integration/failure/missing-build-file/test/src/MissingBuildFileTests.scala
@@ -9,7 +9,7 @@ object MissingBuildFileTests extends IntegrationTestSuite {
     test {
       val res = evalStdout("resolve", "_")
       assert(!res.isSuccess)
-      assert(res.err.contains("build.sc file not found. Are you in a Mill project folder"))
+      val s"build.sc file not found in $msg. Are you in a Mill project folder?" = res.err
     }
   }
 }

--- a/integration/invalidation/multi-level-editing/test/src/MultiLevelBuildTests.scala
+++ b/integration/invalidation/multi-level-editing/test/src/MultiLevelBuildTests.scala
@@ -49,7 +49,7 @@ object MultiLevelBuildTests extends IntegrationTestSuite {
       for (depth <- Range(0, n))
         yield {
           val path =
-            wsRoot / "out" / Seq.fill(depth)(millBuild) / millRunnerState
+            wsRoot / out / Seq.fill(depth)(millBuild) / millRunnerState
           if (os.exists(path)) upickle.default.read[RunnerState.Frame.Logged](os.read(path)) -> path
           else RunnerState.Frame.Logged(Map(), Seq(), Seq(), Map(), None, Seq(), 0) -> path
         }

--- a/integration/invalidation/multi-level-editing/test/src/MultiLevelBuildTests.scala
+++ b/integration/invalidation/multi-level-editing/test/src/MultiLevelBuildTests.scala
@@ -1,6 +1,6 @@
 package mill.integration
 
-import mill.main.client.OutFiles
+import mill.main.client.OutFiles._
 import mill.runner.RunnerState
 import utest._
 
@@ -49,7 +49,7 @@ object MultiLevelBuildTests extends IntegrationTestSuite {
       for (depth <- Range(0, n))
         yield {
           val path =
-            wsRoot / "out" / Seq.fill(depth)(OutFiles.millBuild()) / OutFiles.millRunnerState()
+            wsRoot / "out" / Seq.fill(depth)(millBuild) / millRunnerState
           if (os.exists(path)) upickle.default.read[RunnerState.Frame.Logged](os.read(path)) -> path
           else RunnerState.Frame.Logged(Map(), Seq(), Seq(), Map(), None, Seq(), 0) -> path
         }

--- a/main/api/src/mill/api/WorkspaceRoot.scala
+++ b/main/api/src/mill/api/WorkspaceRoot.scala
@@ -1,5 +1,6 @@
 package mill.api
 
+import os.Path
 object WorkspaceRoot {
-  val workspaceRoot = sys.env.get("MILL_WORKSPACE_ROOT").fold(os.pwd)(os.Path(_, os.pwd))
+  val workspaceRoot: Path = sys.env.get("MILL_WORKSPACE_ROOT").fold(os.pwd)(os.Path(_, os.pwd))
 }

--- a/main/api/src/mill/api/WorkspaceRoot.scala
+++ b/main/api/src/mill/api/WorkspaceRoot.scala
@@ -1,0 +1,6 @@
+package mill.api
+
+
+object WorkspaceRoot {
+  val workspaceRoot = sys.env.get("MILL_WORKSPACE_ROOT").fold(os.pwd)(os.Path(_, os.pwd))
+}

--- a/main/api/src/mill/api/WorkspaceRoot.scala
+++ b/main/api/src/mill/api/WorkspaceRoot.scala
@@ -1,6 +1,5 @@
 package mill.api
 
-
 object WorkspaceRoot {
   val workspaceRoot = sys.env.get("MILL_WORKSPACE_ROOT").fold(os.pwd)(os.Path(_, os.pwd))
 }

--- a/main/client/src/mill/main/client/IsolatedMillMainLoader.java
+++ b/main/client/src/mill/main/client/IsolatedMillMainLoader.java
@@ -72,6 +72,7 @@ class IsolatedMillMainLoader {
 
         Process running = new ProcessBuilder()
             .command(l)
+            .directory(new java.io.File(ServerFiles.sandbox("out/mill-client")))
             .inheritIO()
             .start();
         return running.waitFor();

--- a/main/client/src/mill/main/client/MillClientMain.java
+++ b/main/client/src/mill/main/client/MillClientMain.java
@@ -51,6 +51,7 @@ public class MillClientMain {
 
         new ProcessBuilder()
             .command(l)
+            .directory(new java.io.File(ServerFiles.sandbox(lockBase)))
             .redirectOutput(stdout)
             .redirectError(stderr)
             .start();

--- a/main/client/src/mill/main/client/MillClientMain.java
+++ b/main/client/src/mill/main/client/MillClientMain.java
@@ -1,25 +1,7 @@
 package mill.main.client;
 
-import mill.main.client.lock.Locked;
-import mill.main.client.lock.Locks;
-import org.newsclub.net.unix.AFUNIXSocket;
-import org.newsclub.net.unix.AFUNIXSocketAddress;
-
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.net.Socket;
-import java.net.URISyntaxException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.security.NoSuchAlgorithmException;
-import java.lang.Math;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
 
 /**
  * This is a Java implementation to speed up repetitive starts.
@@ -27,71 +9,43 @@ import java.util.Map;
  */
 public class MillClientMain {
 
-    // use methods instead of constants to avoid inlining by compiler
-    public static final int ExitClientCodeCannotReadFromExitCodeFile() {
-        return 1;
-    }
 
-    public static final int ExitServerCodeWhenIdle() {
-        return 0;
-    }
-
-    public static final int ExitServerCodeWhenVersionMismatch() {
-        return 101;
-    }
-
-    static void initServer(String lockBase, boolean setJnaNoSys) throws IOException, URISyntaxException {
-        List<String> l = new ArrayList<>();
-        l.addAll(MillEnv.millLaunchJvmCommand(setJnaNoSys));
-        l.add("mill.runner.MillServerMain");
-        l.add(lockBase);
-
-        File stdout = new java.io.File(lockBase + "/stdout");
-        File stderr = new java.io.File(lockBase + "/stderr");
-
-        new ProcessBuilder()
-            .command(l)
-            .directory(new java.io.File(ServerFiles.sandbox(lockBase)))
-            .redirectOutput(stdout)
-            .redirectError(stderr)
-            .start();
-    }
 
     public static void main(String[] args) throws Exception {
-        boolean runIsolated = false;
+        boolean runNoServer = false;
         if (args.length > 0) {
             String firstArg = args[0];
-            runIsolated =
+            runNoServer =
                 Arrays.asList("--interactive", "--no-server", "--repl", "--bsp", "--help")
                     .contains(firstArg) || firstArg.startsWith("-i");
         }
-        if (!runIsolated) {
+        if (!runNoServer) {
             // WSL2 has the directory /run/WSL/ and WSL1 not.
-            String osVersion =System.getProperty("os.version");
+            String osVersion = System.getProperty("os.version");
             if(osVersion != null && (osVersion.contains("icrosoft") || osVersion.contains("WSL"))) {
                 // Server-Mode not supported under WSL1
-                runIsolated = true;
+                runNoServer = true;
             }
         }
 
-        if (runIsolated) {
+        if (runNoServer) {
             // start in no-server mode
-            IsolatedMillMainLoader.runMain(args);
+            MillNoServerLauncher.runMain(args);
         } else try {
             // start in client-server mode
-            int exitCode = main0(args);
-            if (exitCode == ExitServerCodeWhenVersionMismatch()) {
-                exitCode = main0(args);
+            int exitCode = MillServerLauncher.runMain(args);
+            if (exitCode == Util.ExitServerCodeWhenVersionMismatch()) {
+                exitCode = MillServerLauncher.runMain(args);
             }
             System.exit(exitCode);
         } catch (MillServerCouldNotBeStarted e) {
             // TODO: try to run in-process
             System.err.println("Could not start a Mill server process.\n" +
                 "This could be caused by too many already running Mill instances " +
-                "or by an unsupported platform.\n");
-            if (IsolatedMillMainLoader.load().canLoad) {
+                "or by an unsupported platform.\n" + e.getMessage() + "\n");
+            if (MillNoServerLauncher.load().canLoad) {
                 System.err.println("Trying to run Mill in-process ...");
-                IsolatedMillMainLoader.runMain(args);
+                MillNoServerLauncher.runMain(args);
             } else {
                 System.err.println("Loading Mill in-process isn't possible.\n" +
                     "Please check your Mill installation!");
@@ -99,179 +53,4 @@ public class MillClientMain {
             }
         }
     }
-
-    public static int main0(String[] args) throws Exception {
-
-        final boolean setJnaNoSys = System.getProperty("jna.nosys") == null;
-        if (setJnaNoSys) {
-            System.setProperty("jna.nosys", "true");
-        }
-
-        final String versionAndJvmHomeEncoding = Util.sha1Hash(BuildInfo.millVersion + System.getProperty("java.home"));
-        final int serverProcessesLimit = getServerProcessesLimit(versionAndJvmHomeEncoding);
-
-        int index = 0;
-        while (index < serverProcessesLimit) {
-            index++;
-            final String lockBase = "out/" + OutFiles.millWorker() + versionAndJvmHomeEncoding + "-" + index;
-            java.io.File lockBaseFile = new java.io.File(lockBase);
-            final File stdout = new java.io.File(lockBaseFile, "stdout");
-            final File stderr = new java.io.File(lockBaseFile, "stderr");
-
-            int attempts = 0;
-            while (attempts < 3) {
-                try {
-                    lockBaseFile.mkdirs();
-
-                    final int refeshIntervalMillis = 2;
-
-                    try (
-                        Locks locks = Locks.files(lockBase);
-                        final FileToStreamTailer stdoutTailer = new FileToStreamTailer(stdout, System.out, refeshIntervalMillis);
-                        final FileToStreamTailer stderrTailer = new FileToStreamTailer(stderr, System.err, refeshIntervalMillis);
-                    ) {
-                        Locked clientLock = locks.clientLock.tryLock();
-                        if (clientLock != null) {
-                            stdoutTailer.start();
-                            stderrTailer.start();
-                            final int exitCode = run(
-                                lockBase,
-                                () -> {
-                                    try {
-                                        initServer(lockBase, setJnaNoSys);
-                                    } catch (Exception e) {
-                                        throw new RuntimeException(e);
-                                    }
-                                },
-                                locks,
-                                System.in,
-                                System.out,
-                                System.err,
-                                args,
-                                System.getenv());
-
-                            // Here, we ensure we process the tails of the output files before interrupting
-                            // the threads
-                            stdoutTailer.flush();
-                            stderrTailer.flush();
-                            clientLock.release();
-                            return exitCode;
-                        }
-                    }
-                } catch (Exception e) {
-                    for (File file : lockBaseFile.listFiles()) {
-                        file.delete();
-                    }
-                } finally {
-                    attempts++;
-                }
-            }
-        }
-        throw new MillServerCouldNotBeStarted("Reached max server processes limit: " + serverProcessesLimit);
-    }
-
-    public static class MillServerCouldNotBeStarted extends Exception {
-        public MillServerCouldNotBeStarted(String msg) {
-            super(msg);
-        }
-    }
-
-    public static int run(
-        String lockBase,
-        Runnable initServer,
-        Locks locks,
-        InputStream stdin,
-        OutputStream stdout,
-        OutputStream stderr,
-        String[] args,
-        Map<String, String> env) throws Exception {
-
-        try (FileOutputStream f = new FileOutputStream(ServerFiles.runArgs(lockBase))) {
-            f.write(System.console() != null ? 1 : 0);
-            Util.writeString(f, BuildInfo.millVersion);
-            Util.writeArgs(args, f);
-            Util.writeMap(env, f);
-        }
-
-        boolean serverInit = false;
-        if (locks.processLock.probe()) {
-            serverInit = true;
-            initServer.run();
-        }
-        while (locks.processLock.probe()) Thread.sleep(3);
-
-        String socketName = ServerFiles.pipe(lockBase);
-        AFUNIXSocketAddress addr = AFUNIXSocketAddress.of(new File(socketName));
-
-        long retryStart = System.currentTimeMillis();
-        Socket ioSocket = null;
-        Throwable socketThrowable = null;
-        while (ioSocket == null && System.currentTimeMillis() - retryStart < 1000) {
-            try {
-                ioSocket = AFUNIXSocket.connectTo(addr);
-            } catch (Throwable e) {
-                socketThrowable = e;
-                Thread.sleep(1);
-            }
-        }
-
-        if (ioSocket == null) {
-            throw new Exception("Failed to connect to server", socketThrowable);
-        }
-
-        InputStream outErr = ioSocket.getInputStream();
-        OutputStream in = ioSocket.getOutputStream();
-        ProxyStreamPumper outPump = new ProxyStreamPumper(outErr, stdout, stderr);
-        InputPumper inPump = new InputPumper(() -> stdin, () -> in, true);
-        Thread outThread = new Thread(outPump, "outPump");
-        outThread.setDaemon(true);
-        Thread inThread = new Thread(inPump, "inPump");
-        inThread.setDaemon(true);
-        outThread.start();
-        inThread.start();
-
-        locks.serverLock.await();
-
-        // Although the process that the server was running has terminated and the server has sent all the stdout/stderr
-        // over the unix pipe and released its lock we don't know that all the data has arrived at the client
-        // The outThread of the ProxyStreamPumper will not close until the socket is closed (so we can't join on it)
-        // but we also can't close the socket until all the data has arrived. Catch 22. We could signal termination
-        // in the stream (ProxyOutputStream / ProxyStreamPumper) but that would require a new protocol.
-        // So we just wait until there has been X ms with no data
-
-        outPump.getLastData().waitForSilence(50);
-
-        try {
-            return Integer.parseInt(Files.readAllLines(Paths.get(ServerFiles.exitCode(lockBase))).get(0));
-        } catch (Throwable e) {
-            return ExitClientCodeCannotReadFromExitCodeFile();
-        } finally {
-            ioSocket.close();
-        }
-    }
-
-    // 5 processes max
-    private static int getServerProcessesLimit(String jvmHomeEncoding) {
-        File outFolder = new File("out");
-        String[] totalProcesses = outFolder.list((dir, name) -> name.startsWith(OutFiles.millWorker()));
-        String[] thisJdkProcesses = outFolder.list((dir, name) -> name.startsWith(OutFiles.millWorker() + jvmHomeEncoding));
-
-        int processLimit = 5;
-        if (totalProcesses != null) {
-            if (thisJdkProcesses != null) {
-                processLimit -= Math.min(totalProcesses.length - thisJdkProcesses.length, 5);
-            } else {
-                processLimit -= Math.min(totalProcesses.length, 5);
-            }
-        }
-        return processLimit;
-    }
-
-    /**
-     * @deprecated Use {@link Util#md5hex(String)} instead. (Deprecated since after Mill 0.10.0)
-     */
-    public static String md5hex(String str) throws NoSuchAlgorithmException {
-        return Util.md5hex(str);
-    }
-
 }

--- a/main/client/src/mill/main/client/MillLauncher.java
+++ b/main/client/src/mill/main/client/MillLauncher.java
@@ -45,7 +45,7 @@ public class MillLauncher {
         builder.environment().put("MILL_WORKSPACE_ROOT", new File("").getCanonicalPath());
         File sandbox = new java.io.File(lockBase + "/" + ServerFiles.sandbox);
         sandbox.mkdirs();
-        builder.directory(sandbox);
+        // builder.directory(sandbox);
         return builder.start();
     }
 

--- a/main/client/src/mill/main/client/MillLauncher.java
+++ b/main/client/src/mill/main/client/MillLauncher.java
@@ -28,8 +28,8 @@ public class MillLauncher {
         l.add("mill.runner.MillServerMain");
         l.add(new File(lockBase).getCanonicalPath());
 
-        File stdout = new java.io.File(lockBase + "/stdout");
-        File stderr = new java.io.File(lockBase + "/stderr");
+        File stdout = new java.io.File(ServerFiles.stdout(lockBase));
+        File stderr = new java.io.File(ServerFiles.stderr(lockBase));
 
         ProcessBuilder builder = new ProcessBuilder()
                 .command(l)

--- a/main/client/src/mill/main/client/MillLauncher.java
+++ b/main/client/src/mill/main/client/MillLauncher.java
@@ -19,7 +19,7 @@ public class MillLauncher {
                 .command(l)
                 .inheritIO();
 
-        return configureRunMillProcess(builder, "out/mill-client").waitFor();
+        return configureRunMillProcess(builder, OutFiles.out() + "/" + OutFiles.millNoServer()).waitFor();
     }
 
     static void launchMillServer(String lockBase, boolean setJnaNoSys) throws Exception {

--- a/main/client/src/mill/main/client/MillLauncher.java
+++ b/main/client/src/mill/main/client/MillLauncher.java
@@ -1,5 +1,6 @@
 package mill.main.client;
 
+import static mill.main.client.OutFiles.*;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -19,7 +20,7 @@ public class MillLauncher {
                 .command(l)
                 .inheritIO();
 
-        return configureRunMillProcess(builder, OutFiles.out() + "/" + OutFiles.millNoServer()).waitFor();
+        return configureRunMillProcess(builder, out + "/" + millNoServer).waitFor();
     }
 
     static void launchMillServer(String lockBase, boolean setJnaNoSys) throws Exception {
@@ -28,21 +29,21 @@ public class MillLauncher {
         l.add("mill.runner.MillServerMain");
         l.add(new File(lockBase).getCanonicalPath());
 
-        File stdout = new java.io.File(ServerFiles.stdout(lockBase));
-        File stderr = new java.io.File(ServerFiles.stderr(lockBase));
+        File stdout = new java.io.File(lockBase + "/" + ServerFiles.stdout);
+        File stderr = new java.io.File(lockBase + "/" + ServerFiles.stderr);
 
         ProcessBuilder builder = new ProcessBuilder()
                 .command(l)
                 .redirectOutput(stdout)
                 .redirectError(stderr);
 
-        configureRunMillProcess(builder, ServerFiles.sandbox(lockBase));
+        configureRunMillProcess(builder, lockBase + "/" + ServerFiles.sandbox);
     }
 
     static Process configureRunMillProcess(ProcessBuilder builder,
                                            String lockBase) throws Exception {
         builder.environment().put("MILL_WORKSPACE_ROOT", new File("").getCanonicalPath());
-        File sandbox = new java.io.File(ServerFiles.sandbox(lockBase));
+        File sandbox = new java.io.File(lockBase + "/" + ServerFiles.sandbox);
         sandbox.mkdirs();
         builder.directory(sandbox);
         return builder.start();

--- a/main/client/src/mill/main/client/MillNoServerLauncher.java
+++ b/main/client/src/mill/main/client/MillNoServerLauncher.java
@@ -44,7 +44,6 @@ class MillNoServerLauncher {
     public static void runMain(String[] args) throws Exception {
         LoadResult loadResult = load();
         if (loadResult.millMainMethod.isPresent()) {
-            System.err.println("Launching Mill as sub-process ...");
             int exitVal = MillLauncher.launchMillNoServer(args);
             System.exit(exitVal);
         } else {

--- a/main/client/src/mill/main/client/MillNoServerLauncher.java
+++ b/main/client/src/mill/main/client/MillNoServerLauncher.java
@@ -1,12 +1,9 @@
 package mill.main.client;
 
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
 
-class IsolatedMillMainLoader {
+class MillNoServerLauncher {
 
     public static class LoadResult {
 
@@ -30,7 +27,7 @@ class IsolatedMillMainLoader {
             long startTime = System.currentTimeMillis();
             Optional<Method> millMainMethod = Optional.empty();
             try {
-                Class<?> millMainClass = IsolatedMillMainLoader.class.getClassLoader().loadClass("mill.runner.MillMain");
+                Class<?> millMainClass = MillNoServerLauncher.class.getClassLoader().loadClass("mill.runner.MillMain");
                 Method mainMethod = millMainClass.getMethod("main", String[].class);
                 millMainMethod = Optional.of(mainMethod);
             } catch (ClassNotFoundException | NoSuchMethodException e) {
@@ -47,34 +44,13 @@ class IsolatedMillMainLoader {
     public static void runMain(String[] args) throws Exception {
         LoadResult loadResult = load();
         if (loadResult.millMainMethod.isPresent()) {
-            if (!MillEnv.millJvmOptsAlreadyApplied() && MillEnv.millJvmOptsFile().exists()) {
-                System.err.println("Launching Mill as sub-process ...");
-                int exitVal = launchMillAsSubProcess(args);
-                System.exit(exitVal);
-            } else {
-                // launch mill in-process
-                // it will call System.exit for us
-                Method mainMethod = loadResult.millMainMethod.get();
-                mainMethod.invoke(null, new Object[]{args});
-            }
+            System.err.println("Launching Mill as sub-process ...");
+            int exitVal = MillLauncher.launchMillNoServer(args);
+            System.exit(exitVal);
         } else {
             throw new RuntimeException("Cannot load mill.runner.MillMain class");
         }
     }
 
-    private static int launchMillAsSubProcess(String[] args) throws Exception {
-        boolean setJnaNoSys = System.getProperty("jna.nosys") == null;
 
-        List<String> l = new ArrayList<>();
-        l.addAll(MillEnv.millLaunchJvmCommand(setJnaNoSys));
-        l.add("mill.runner.MillMain");
-        l.addAll(Arrays.asList(args));
-
-        Process running = new ProcessBuilder()
-            .command(l)
-            .directory(new java.io.File(ServerFiles.sandbox("out/mill-client")))
-            .inheritIO()
-            .start();
-        return running.waitFor();
-    }
 }

--- a/main/client/src/mill/main/client/MillServerCouldNotBeStarted.java
+++ b/main/client/src/mill/main/client/MillServerCouldNotBeStarted.java
@@ -1,0 +1,7 @@
+package mill.main.client;
+
+public class MillServerCouldNotBeStarted extends Exception {
+    public MillServerCouldNotBeStarted(String msg) {
+        super(msg);
+    }
+}

--- a/main/client/src/mill/main/client/MillServerLauncher.java
+++ b/main/client/src/mill/main/client/MillServerLauncher.java
@@ -31,7 +31,7 @@ public class MillServerLauncher {
         int serverIndex = 0;
         while (serverIndex < serverProcessesLimit) { // Try each possible server process (-1 to -5)
             serverIndex++;
-            final String lockBase = "out/" + OutFiles.millWorker() + versionAndJvmHomeEncoding + "-" + serverIndex;
+            final String lockBase = OutFiles.out() + "/" + OutFiles.millWorker() + versionAndJvmHomeEncoding + "-" + serverIndex;
             java.io.File lockBaseFile = new java.io.File(lockBase);
             lockBaseFile.mkdirs();
 
@@ -94,7 +94,7 @@ public class MillServerLauncher {
 
     // 5 processes max
     private static int getServerProcessesLimit(String jvmHomeEncoding) {
-        File outFolder = new File("out");
+        File outFolder = new File(OutFiles.out());
         String[] totalProcesses = outFolder.list((dir, name) -> name.startsWith(OutFiles.millWorker()));
         String[] thisJdkProcesses = outFolder.list((dir, name) -> name.startsWith(OutFiles.millWorker() + jvmHomeEncoding));
 

--- a/main/client/src/mill/main/client/MillServerLauncher.java
+++ b/main/client/src/mill/main/client/MillServerLauncher.java
@@ -1,0 +1,181 @@
+package mill.main.client;
+
+import mill.main.client.lock.Locked;
+import mill.main.client.lock.Locks;
+import org.newsclub.net.unix.AFUNIXSocket;
+import org.newsclub.net.unix.AFUNIXSocketAddress;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Map;
+
+public class MillServerLauncher {
+    public static int runMain(String[] args) throws Exception {
+
+        final boolean setJnaNoSys = System.getProperty("jna.nosys") == null;
+        if (setJnaNoSys) {
+            System.setProperty("jna.nosys", "true");
+        }
+
+        final String versionAndJvmHomeEncoding = Util.sha1Hash(BuildInfo.millVersion + System.getProperty("java.home"));
+        final int serverProcessesLimit = getServerProcessesLimit(versionAndJvmHomeEncoding);
+
+        int index = 0;
+        while (index < serverProcessesLimit) {
+            index++;
+            final String lockBase = "out/" + OutFiles.millWorker() + versionAndJvmHomeEncoding + "-" + index;
+            java.io.File lockBaseFile = new java.io.File(lockBase);
+            final File stdout = new java.io.File(lockBaseFile, "stdout");
+            final File stderr = new java.io.File(lockBaseFile, "stderr");
+
+            int attempts = 0;
+            while (attempts < 3) {
+                try {
+                    lockBaseFile.mkdirs();
+
+                    final int refeshIntervalMillis = 2;
+
+                    try (
+                            Locks locks = Locks.files(lockBase);
+                            final FileToStreamTailer stdoutTailer = new FileToStreamTailer(stdout, System.out, refeshIntervalMillis);
+                            final FileToStreamTailer stderrTailer = new FileToStreamTailer(stderr, System.err, refeshIntervalMillis);
+                    ) {
+                        Locked clientLock = locks.clientLock.tryLock();
+                        if (clientLock != null) {
+                            stdoutTailer.start();
+                            stderrTailer.start();
+                            final int exitCode = run(
+                                    lockBase,
+                                    () -> {
+                                        try {
+                                            MillLauncher.launchMillServer(lockBase, setJnaNoSys);
+                                        } catch (Exception e) {
+                                            throw new RuntimeException(e);
+                                        }
+                                    },
+                                    locks,
+                                    System.in,
+                                    System.out,
+                                    System.err,
+                                    args,
+                                    System.getenv());
+
+                            // Here, we ensure we process the tails of the output files before interrupting
+                            // the threads
+                            stdoutTailer.flush();
+                            stderrTailer.flush();
+                            clientLock.release();
+                            return exitCode;
+                        }
+                        System.err.println("clientLock is null");
+                    }
+                } catch (Exception e) {
+                    System.err.println("Exception " + e);
+                    for (File file : lockBaseFile.listFiles()) {
+                        file.delete();
+                    }
+                } finally {
+                    attempts++;
+                }
+            }
+        }
+        throw new MillServerCouldNotBeStarted("Reached max server processes limit: " + serverProcessesLimit);
+    }
+
+    // 5 processes max
+    private static int getServerProcessesLimit(String jvmHomeEncoding) {
+        File outFolder = new File("out");
+        String[] totalProcesses = outFolder.list((dir, name) -> name.startsWith(OutFiles.millWorker()));
+        String[] thisJdkProcesses = outFolder.list((dir, name) -> name.startsWith(OutFiles.millWorker() + jvmHomeEncoding));
+
+        int processLimit = 5;
+
+        if (thisJdkProcesses != null) {
+            processLimit -= Math.min(totalProcesses.length - thisJdkProcesses.length, 5);
+        } else if (totalProcesses != null) {
+            processLimit -= Math.min(totalProcesses.length, 5);
+        }
+
+        return processLimit;
+    }
+    public static int run(
+            String lockBase,
+            Runnable initServer,
+            Locks locks,
+            InputStream stdin,
+            OutputStream stdout,
+            OutputStream stderr,
+            String[] args,
+            Map<String, String> env) throws Exception {
+
+        try (FileOutputStream f = new FileOutputStream(ServerFiles.runArgs(lockBase))) {
+            f.write(System.console() != null ? 1 : 0);
+            Util.writeString(f, BuildInfo.millVersion);
+            Util.writeArgs(args, f);
+            Util.writeMap(env, f);
+        }
+
+        boolean serverInit = false;
+        if (locks.processLock.probe()) {
+            serverInit = true;
+            initServer.run();
+        }
+
+        while (locks.processLock.probe()) Thread.sleep(3);
+
+        String socketName = ServerFiles.pipe(lockBase);
+        AFUNIXSocketAddress addr = AFUNIXSocketAddress.of(new File(socketName));
+
+        long retryStart = System.currentTimeMillis();
+        Socket ioSocket = null;
+        Throwable socketThrowable = null;
+        while (ioSocket == null && System.currentTimeMillis() - retryStart < 1000) {
+            try {
+                ioSocket = AFUNIXSocket.connectTo(addr);
+            } catch (Throwable e) {
+                socketThrowable = e;
+                Thread.sleep(1);
+            }
+        }
+
+        if (ioSocket == null) {
+            throw new Exception("Failed to connect to server", socketThrowable);
+        }
+
+        InputStream outErr = ioSocket.getInputStream();
+        OutputStream in = ioSocket.getOutputStream();
+        ProxyStreamPumper outPump = new ProxyStreamPumper(outErr, stdout, stderr);
+        InputPumper inPump = new InputPumper(() -> stdin, () -> in, true);
+        Thread outThread = new Thread(outPump, "outPump");
+        outThread.setDaemon(true);
+        Thread inThread = new Thread(inPump, "inPump");
+        inThread.setDaemon(true);
+        outThread.start();
+        inThread.start();
+
+        locks.serverLock.await();
+
+        // Although the process that the server was running has terminated and the server has sent all the stdout/stderr
+        // over the unix pipe and released its lock we don't know that all the data has arrived at the client
+        // The outThread of the ProxyStreamPumper will not close until the socket is closed (so we can't join on it)
+        // but we also can't close the socket until all the data has arrived. Catch 22. We could signal termination
+        // in the stream (ProxyOutputStream / ProxyStreamPumper) but that would require a new protocol.
+        // So we just wait until there has been X ms with no data
+
+        outPump.getLastData().waitForSilence(50);
+
+        try {
+            return Integer.parseInt(Files.readAllLines(Paths.get(ServerFiles.exitCode(lockBase))).get(0));
+        } catch (Throwable e) {
+            return Util.ExitClientCodeCannotReadFromExitCodeFile();
+        } finally {
+            ioSocket.close();
+        }
+    }
+
+}

--- a/main/client/src/mill/main/client/OutFiles.java
+++ b/main/client/src/mill/main/client/OutFiles.java
@@ -6,6 +6,13 @@ package mill.main.client;
  */
 public class OutFiles {
     /**
+     * Path of the Mill `out/` folder
+     */
+    public static String out(){
+        return "out";
+    }
+
+    /**
      * Path of the Mill "meta-build", used to compile the `build.sc` file so we can
      * run the primary Mill build. Can be nested for multiple stages of bootstrapping
      */
@@ -46,5 +53,12 @@ public class OutFiles {
      */
     public static String millWorker(){
         return "mill-worker-";
+    }
+
+    /**
+     * Subfolder of `out/` used to contain the Mill subprocess when run in no-server mode
+     */
+    public static String millNoServer(){
+        return "mill-no-server";
     }
 }

--- a/main/client/src/mill/main/client/OutFiles.java
+++ b/main/client/src/mill/main/client/OutFiles.java
@@ -8,26 +8,20 @@ public class OutFiles {
     /**
      * Path of the Mill `out/` folder
      */
-    public static String out(){
-        return "out";
-    }
+    final public static String out = "out";
 
     /**
      * Path of the Mill "meta-build", used to compile the `build.sc` file so we can
      * run the primary Mill build. Can be nested for multiple stages of bootstrapping
      */
-    public static String millBuild(){
-        return "mill-build";
-    }
+    final public static String millBuild = "mill-build";
 
     /**
      * A parallel performance and timing profile generated for every Mill execution.
      * Can be loaded into the Chrome browser chrome://tracing page to visualize where
      * time in a build is being spent
      */
-    public static String millChromeProfile(){
-        return "mill-chrome-profile.json";
-    }
+    final public static String millChromeProfile = "mill-chrome-profile.json";
 
     /**
      * A sequential profile containing rich information about the tasks that were run
@@ -35,30 +29,23 @@ public class OutFiles {
      * understand what tasks are taking time in a build run and why those tasks are
      * being executed
      */
-    public static String millProfile(){
-        return "mill-profile.json";
-    }
+    final public static String millProfile = "mill-profile.json";
 
     /**
      * Long lived metadata about the Mill bootstrap process that persists between runs:
      * workers, watched files, classpaths, etc.
      */
-    public static String millRunnerState(){
-        return "mill-runner-state.json";
-    }
+    final public static String millRunnerState = "mill-runner-state.json";
 
     /**
      * Subfolder of `out/` that contains the machinery necessary for a single Mill background
      * server: metadata files, pipes, logs, etc.
      */
-    public static String millWorker(){
-        return "mill-worker-";
-    }
+    final public static String millWorker = "mill-worker-";
 
     /**
      * Subfolder of `out/` used to contain the Mill subprocess when run in no-server mode
      */
-    public static String millNoServer(){
-        return "mill-no-server";
-    }
+    final public static String millNoServer = "mill-no-server";
+
 }

--- a/main/client/src/mill/main/client/ServerFiles.java
+++ b/main/client/src/mill/main/client/ServerFiles.java
@@ -5,6 +5,9 @@ package mill.main.client;
  * and documentation about what they do
  */
 public class ServerFiles {
+    public static String sandbox(String base){
+        return base + "/sandbox";
+    }
 
     /**
      * Lock file used to ensure a single server is running in a particular

--- a/main/client/src/mill/main/client/ServerFiles.java
+++ b/main/client/src/mill/main/client/ServerFiles.java
@@ -5,25 +5,20 @@ package mill.main.client;
  * and documentation about what they do
  */
 public class ServerFiles {
-    public static String sandbox(String base){
-        return base + "/sandbox";
-    }
+    final public static String sandbox = "sandbox";
 
     /**
      * Lock file used to ensure a single server is running in a particular
      * mill-worker folder.
      */
-    public static String processLock(String base){
-        return base + "/processLock";
-    }
+    final public static String processLock = "processLock";
 
-    public static String clientLock(String base){
-        return base + "/clientLock";
-    }
 
-    public static String serverLock(String base){
-        return base + "/serverLock";
-    }
+    final public static String clientLock = "clientLock";
+
+
+    final public static String serverLock = "serverLock";
+
 
 
     /**
@@ -44,37 +39,31 @@ public class ServerFiles {
     /**
      * Log file containing server housekeeping information
      */
-    public static String serverLog(String base){
-        return base + "/server.log";
-    }
+    final public static String serverLog = "server.log";
+
 
     /**
      * File that the client writes to pass the arguments, environment variables,
      * and other necessary metadata to the Mill server to kick off a run
      */
-    public static String runArgs(String base){
-        return base + "/runArgs";
-    }
+    final public static String runArgs = "runArgs";
+
 
     /**
      * File the server writes to pass the exit code of a completed run back to the
      * client
      */
-    public static String exitCode(String base){
-        return base + "/exitCode";
-    }
+    final public static String exitCode = "exitCode";
+
 
     /**
      * Where the server's stdout is piped to
      */
-    public static String stdout(String base){
-        return base + "/stdout";
-    }
+    final public static String stdout = "stdout";
+
 
     /**
      * Where the server's stderr is piped to
      */
-    public static String stderr(String base){
-        return base + "/stderr";
-    }
+    final public static String stderr = "stderr";
 }

--- a/main/client/src/mill/main/client/ServerFiles.java
+++ b/main/client/src/mill/main/client/ServerFiles.java
@@ -63,4 +63,18 @@ public class ServerFiles {
     public static String exitCode(String base){
         return base + "/exitCode";
     }
+
+    /**
+     * Where the server's stdout is piped to
+     */
+    public static String stdout(String base){
+        return base + "/stdout";
+    }
+
+    /**
+     * Where the server's stderr is piped to
+     */
+    public static String stderr(String base){
+        return base + "/stderr";
+    }
 }

--- a/main/client/src/mill/main/client/Util.java
+++ b/main/client/src/mill/main/client/Util.java
@@ -14,6 +14,20 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class Util {
+    // use methods instead of constants to avoid inlining by compiler
+    public static final int ExitClientCodeCannotReadFromExitCodeFile() {
+        return 1;
+    }
+
+    public static final int ExitServerCodeWhenIdle() {
+        return 0;
+    }
+
+    public static final int ExitServerCodeWhenVersionMismatch() {
+        return 101;
+    }
+
+
     public static boolean isWindows = System.getProperty("os.name").toLowerCase().startsWith("windows");
     public static boolean isJava9OrAbove = !System.getProperty("java.specification.version").startsWith("1.");
     private static Charset utf8 = Charset.forName("UTF-8");

--- a/main/client/src/mill/main/client/lock/FileLock.java
+++ b/main/client/src/mill/main/client/lock/FileLock.java
@@ -17,10 +17,8 @@ class FileLock extends Lock {
         return new FileLocked(chan.lock());
     }
 
-    public Locked tryLock() throws Exception {
-        java.nio.channels.FileLock l = chan.tryLock();
-        if (l == null) return null;
-        else return new FileLocked(l);
+    public TryLocked tryLock() throws Exception {
+        return new FileTryLocked(chan.tryLock());
     }
 
     public boolean probe() throws Exception {

--- a/main/client/src/mill/main/client/lock/FileLocked.java
+++ b/main/client/src/mill/main/client/lock/FileLocked.java
@@ -2,7 +2,7 @@ package mill.main.client.lock;
 
 class FileLocked implements Locked {
 
-    private java.nio.channels.FileLock lock;
+    protected java.nio.channels.FileLock lock;
 
     public FileLocked(java.nio.channels.FileLock lock) {
         this.lock = lock;

--- a/main/client/src/mill/main/client/lock/FileTryLocked.java
+++ b/main/client/src/mill/main/client/lock/FileTryLocked.java
@@ -1,0 +1,13 @@
+package mill.main.client.lock;
+
+public class FileTryLocked extends FileLocked implements TryLocked{
+    public FileTryLocked(java.nio.channels.FileLock lock) {
+        super(lock);
+    }
+
+    public boolean isLocked(){ return lock != null; }
+
+    public void release() throws Exception {
+        if (isLocked()) super.release();
+    }
+}

--- a/main/client/src/mill/main/client/lock/Lock.java
+++ b/main/client/src/mill/main/client/lock/Lock.java
@@ -4,7 +4,7 @@ public abstract class Lock implements AutoCloseable {
 
     public abstract Locked lock() throws Exception;
 
-    public abstract Locked tryLock() throws Exception;
+    public abstract TryLocked tryLock() throws Exception;
 
     public void await() throws Exception {
         lock().release();

--- a/main/client/src/mill/main/client/lock/Locked.java
+++ b/main/client/src/mill/main/client/lock/Locked.java
@@ -1,6 +1,9 @@
 package mill.main.client.lock;
 
-public interface Locked {
+public interface Locked extends AutoCloseable {
 
     void release() throws Exception;
+    default void close() throws Exception {
+        release();
+    }
 }

--- a/main/client/src/mill/main/client/lock/Locks.java
+++ b/main/client/src/mill/main/client/lock/Locks.java
@@ -10,9 +10,9 @@ public class Locks implements AutoCloseable {
 
     public static Locks files(String lockBase) throws Exception {
         return new Locks(){{
-            processLock = new FileLock(ServerFiles.processLock(lockBase));
-            serverLock = new FileLock(ServerFiles.serverLock(lockBase));
-            clientLock = new FileLock(ServerFiles.clientLock(lockBase));
+            processLock = new FileLock(lockBase + "/" + ServerFiles.processLock);
+            serverLock = new FileLock(lockBase + "/" + ServerFiles.serverLock);
+            clientLock = new FileLock(lockBase + "/" + ServerFiles.clientLock);
         }};
     }
 

--- a/main/client/src/mill/main/client/lock/MemoryLock.java
+++ b/main/client/src/mill/main/client/lock/MemoryLock.java
@@ -15,9 +15,9 @@ class MemoryLock extends Lock {
         return new MemoryLocked(innerLock);
     }
 
-    public Locked tryLock() {
-        if (innerLock.tryLock()) return new MemoryLocked(innerLock);
-        else return null;
+    public MemoryTryLocked tryLock() {
+        if (innerLock.tryLock()) return new MemoryTryLocked(innerLock);
+        else return new MemoryTryLocked(null);
     }
 
     @Override

--- a/main/client/src/mill/main/client/lock/MemoryLocked.java
+++ b/main/client/src/mill/main/client/lock/MemoryLocked.java
@@ -2,13 +2,13 @@ package mill.main.client.lock;
 
 class MemoryLocked implements Locked {
 
-    private java.util.concurrent.locks.Lock l;
+    protected java.util.concurrent.locks.Lock lock;
 
-    public MemoryLocked(java.util.concurrent.locks.Lock l) {
-        this.l = l;
+    public MemoryLocked(java.util.concurrent.locks.Lock lock) {
+        this.lock = lock;
     }
 
     public void release() throws Exception {
-        l.unlock();
+        lock.unlock();
     }
 }

--- a/main/client/src/mill/main/client/lock/MemoryTryLocked.java
+++ b/main/client/src/mill/main/client/lock/MemoryTryLocked.java
@@ -1,0 +1,13 @@
+package mill.main.client.lock;
+
+public class MemoryTryLocked extends MemoryLocked implements TryLocked {
+    public MemoryTryLocked(java.util.concurrent.locks.Lock lock) {
+        super(lock);
+    }
+
+    public boolean isLocked(){ return lock != null; }
+
+    public void release() throws Exception {
+        if (isLocked()) super.release();
+    }
+}

--- a/main/client/src/mill/main/client/lock/TryLocked.java
+++ b/main/client/src/mill/main/client/lock/TryLocked.java
@@ -1,0 +1,5 @@
+package mill.main.client.lock;
+
+public interface TryLocked extends Locked {
+    public boolean isLocked();
+}

--- a/main/client/test/src/mill/main/client/MillEnvTests.java
+++ b/main/client/test/src/mill/main/client/MillEnvTests.java
@@ -17,7 +17,7 @@ public class MillEnvTests extends FreeSpec {
                 File file = new File(
                     getClass().getClassLoader().getResource("file-wo-final-newline.txt").toURI()
                 );
-                List<String> lines = MillEnv.readOptsFileLines(file);
+                List<String> lines = MillLauncher.readOptsFileLines(file);
                 expectEquals(
                     lines,
                     Arrays.asList(

--- a/main/define/src/mill/define/BaseModule.scala
+++ b/main/define/src/mill/define/BaseModule.scala
@@ -1,6 +1,6 @@
 package mill.define
 
-import mill.api.PathRef
+import mill.api.{PathRef, WorkspaceRoot}
 import mill.util.Watchable
 
 import scala.collection.mutable
@@ -79,7 +79,7 @@ trait BaseModule0 extends Module {
 abstract class ExternalModule(implicit
     millModuleEnclosing0: sourcecode.Enclosing,
     millModuleLine0: sourcecode.Line
-) extends BaseModule(os.pwd, external0 = true, foreign0 = None)(
+) extends BaseModule(WorkspaceRoot.workspaceRoot, external0 = true, foreign0 = None)(
       implicitly,
       implicitly,
       implicitly,

--- a/main/eval/src/mill/eval/EvaluatorCore.scala
+++ b/main/eval/src/mill/eval/EvaluatorCore.scala
@@ -5,7 +5,7 @@ import mill.api.Strict.Agg
 import mill.api._
 import mill.define._
 import mill.eval.Evaluator.TaskResult
-import mill.main.client.OutFiles
+import mill.main.client.OutFiles._
 import mill.util._
 
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
@@ -70,8 +70,8 @@ private[mill] trait EvaluatorCore extends GroupEvaluator {
       contextLoggerMsg0: Int => String
   ): Evaluator.Results = {
     os.makeDir.all(outPath)
-    val chromeProfileLogger = new ChromeProfileLogger(outPath / OutFiles.millChromeProfile())
-    val profileLogger = new ProfileLogger(outPath / OutFiles.millProfile())
+    val chromeProfileLogger = new ChromeProfileLogger(outPath / millChromeProfile)
+    val profileLogger = new ProfileLogger(outPath / millProfile)
     val threadNumberer = new ThreadNumberer()
     val (sortedGroups, transitive) = Plan.plan(goals)
     val interGroupDeps = findInterGroupDeps(sortedGroups)

--- a/main/util/src/mill/util/Classpath.scala
+++ b/main/util/src/mill/util/Classpath.scala
@@ -1,8 +1,9 @@
 package mill.util
 
+import mill.api.WorkspaceRoot
+
 import java.io.File
 import java.net.URL
-
 import scala.collection.mutable
 import scala.util.matching.Regex
 
@@ -53,7 +54,7 @@ object Classpath {
     } else {
       if (seenClassLoaders.contains(ClassLoader.getSystemClassLoader)) {
         for (p <- System.getProperty("java.class.path").split(File.pathSeparatorChar)) {
-          val f = os.Path(p, os.pwd)
+          val f = os.Path(p, WorkspaceRoot.workspaceRoot)
           if (os.exists(f)) files.append(f)
         }
       }

--- a/runner/src/mill/runner/FileImportGraph.scala
+++ b/runner/src/mill/runner/FileImportGraph.scala
@@ -1,7 +1,7 @@
 package mill.runner
 
 import mill.api.internal
-import mill.main.client.OutFiles
+import mill.main.client.OutFiles._
 
 import scala.reflect.NameTransformer.encode
 import scala.collection.mutable
@@ -135,8 +135,8 @@ object FileImportGraph {
         projectRoot,
         followLinks = true,
         skip = p =>
-          p == projectRoot / OutFiles.out() ||
-            p == projectRoot / OutFiles.millBuild() ||
+          p == projectRoot / out ||
+            p == projectRoot / millBuild ||
             (os.isDir(p) && !os.exists(p / "module.sc"))
       )
       .filter(_.last == "module.sc")

--- a/runner/src/mill/runner/FileImportGraph.scala
+++ b/runner/src/mill/runner/FileImportGraph.scala
@@ -1,6 +1,8 @@
 package mill.runner
 
 import mill.api.internal
+import mill.main.client.OutFiles
+
 import scala.reflect.NameTransformer.encode
 import scala.collection.mutable
 
@@ -133,8 +135,8 @@ object FileImportGraph {
         projectRoot,
         followLinks = true,
         skip = p =>
-          p == projectRoot / "out" ||
-            p == projectRoot / "mill-build" ||
+          p == projectRoot / OutFiles.out() ||
+            p == projectRoot / OutFiles.millBuild() ||
             (os.isDir(p) && !os.exists(p / "module.sc"))
       )
       .filter(_.last == "module.sc")

--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -41,6 +41,7 @@ class MillBuildBootstrap(
     needBuildSc: Boolean,
     requestedMetaLevel: Option[Int]
 ) {
+  pprint.log(projectRoot)
   import MillBuildBootstrap._
 
   val millBootClasspath: Seq[os.Path] = prepareMillBootClasspath(projectRoot / "out")
@@ -79,7 +80,7 @@ class MillBuildBootstrap(
         lazy val state = evaluateRec(depth + 1)
         if (os.exists(recRoot(projectRoot, depth) / "build.sc")) state
         else {
-          val msg = "build.sc file not found. Are you in a Mill project folder?"
+          val msg = s"build.sc file not found in $projectRoot. Are you in a Mill project folder?"
           if (needBuildSc) {
             RunnerState(None, Nil, Some(msg))
           } else {

--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -44,7 +44,7 @@ class MillBuildBootstrap(
   pprint.log(projectRoot)
   import MillBuildBootstrap._
 
-  val millBootClasspath: Seq[os.Path] = prepareMillBootClasspath(projectRoot / "out")
+  val millBootClasspath: Seq[os.Path] = prepareMillBootClasspath(projectRoot / OutFiles.out())
   val millBootClasspathPathRefs: Seq[PathRef] = millBootClasspath.map(PathRef(_, quick = true))
 
   def evaluate(): Watching.Result[RunnerState] = CliImports.withValue(imports) {
@@ -346,7 +346,7 @@ class MillBuildBootstrap(
 
     val bootLogPrefix =
       if (depth == 0) ""
-      else "[" + (Seq.fill(depth - 1)("mill-build") ++ Seq("build.sc")).mkString("/") + "] "
+      else "[" + (Seq.fill(depth - 1)(OutFiles.millBuild()) ++ Seq("build.sc")).mkString("/") + "] "
 
     mill.eval.EvaluatorImpl(
       home,
@@ -486,11 +486,11 @@ object MillBuildBootstrap {
   }
 
   def recRoot(projectRoot: os.Path, depth: Int): os.Path = {
-    projectRoot / Seq.fill(depth)("mill-build")
+    projectRoot / Seq.fill(depth)(OutFiles.millBuild())
   }
 
   def recOut(projectRoot: os.Path, depth: Int): os.Path = {
-    projectRoot / "out" / Seq.fill(depth)("mill-build")
+    projectRoot / OutFiles.out() / Seq.fill(depth)(OutFiles.millBuild())
   }
 
 }

--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -41,7 +41,6 @@ class MillBuildBootstrap(
     needBuildSc: Boolean,
     requestedMetaLevel: Option[Int]
 ) {
-  pprint.log(projectRoot)
   import MillBuildBootstrap._
 
   val millBootClasspath: Seq[os.Path] = prepareMillBootClasspath(projectRoot / out)

--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -7,7 +7,7 @@ import mill.eval.Evaluator
 import mill.main.RunScript
 import mill.resolve.SelectMode
 import mill.define.{BaseModule, Discover, Segments}
-import mill.main.client.OutFiles
+import mill.main.client.OutFiles._
 
 import java.net.URLClassLoader
 
@@ -44,7 +44,7 @@ class MillBuildBootstrap(
   pprint.log(projectRoot)
   import MillBuildBootstrap._
 
-  val millBootClasspath: Seq[os.Path] = prepareMillBootClasspath(projectRoot / OutFiles.out())
+  val millBootClasspath: Seq[os.Path] = prepareMillBootClasspath(projectRoot / out)
   val millBootClasspathPathRefs: Seq[PathRef] = millBootClasspath.map(PathRef(_, quick = true))
 
   def evaluate(): Watching.Result[RunnerState] = CliImports.withValue(imports) {
@@ -52,7 +52,7 @@ class MillBuildBootstrap(
 
     for ((frame, depth) <- runnerState.frames.zipWithIndex) {
       os.write.over(
-        recOut(projectRoot, depth) / OutFiles.millRunnerState(),
+        recOut(projectRoot, depth) / millRunnerState,
         upickle.default.write(frame.loggedData, indent = 4),
         createFolders = true
       )
@@ -346,7 +346,7 @@ class MillBuildBootstrap(
 
     val bootLogPrefix =
       if (depth == 0) ""
-      else "[" + (Seq.fill(depth - 1)(OutFiles.millBuild()) ++ Seq("build.sc")).mkString("/") + "] "
+      else "[" + (Seq.fill(depth - 1)(millBuild) ++ Seq("build.sc")).mkString("/") + "] "
 
     mill.eval.EvaluatorImpl(
       home,
@@ -486,11 +486,11 @@ object MillBuildBootstrap {
   }
 
   def recRoot(projectRoot: os.Path, depth: Int): os.Path = {
-    projectRoot / Seq.fill(depth)(OutFiles.millBuild())
+    projectRoot / Seq.fill(depth)(millBuild)
   }
 
   def recOut(projectRoot: os.Path, depth: Int): os.Path = {
-    projectRoot / OutFiles.out() / Seq.fill(depth)(OutFiles.millBuild())
+    projectRoot / out / Seq.fill(depth)(millBuild)
   }
 
 }

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -10,7 +10,7 @@ import mill.util.Util.millProjectModule
 import mill.scalalib.api.Versions
 import pprint.Util.literalize
 import FileImportGraph.backtickWrap
-import mill.main.client.OutFiles
+import mill.main.client.OutFiles._
 import mill.main.{BuildInfo, RootModule}
 
 import scala.collection.immutable.SortedMap
@@ -39,7 +39,7 @@ class MillBuildRootModule()(implicit
     .++(super.bspDisplayName0.split("/"))
     .mkString("/")
 
-  override def millSourcePath: os.Path = millBuildRootModuleInfo.projectRoot / os.up / OutFiles.millBuild()
+  override def millSourcePath: os.Path = millBuildRootModuleInfo.projectRoot / os.up / millBuild
   override def intellijModulePath: os.Path = millSourcePath / os.up
 
   override def scalaVersion: T[String] = BuildInfo.scalaVersion

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -10,6 +10,7 @@ import mill.util.Util.millProjectModule
 import mill.scalalib.api.Versions
 import pprint.Util.literalize
 import FileImportGraph.backtickWrap
+import mill.main.client.OutFiles
 import mill.main.{BuildInfo, RootModule}
 
 import scala.collection.immutable.SortedMap
@@ -38,7 +39,7 @@ class MillBuildRootModule()(implicit
     .++(super.bspDisplayName0.split("/"))
     .mkString("/")
 
-  override def millSourcePath: os.Path = millBuildRootModuleInfo.projectRoot / os.up / "mill-build"
+  override def millSourcePath: os.Path = millBuildRootModuleInfo.projectRoot / os.up / OutFiles.millBuild()
   override def intellijModulePath: os.Path = millSourcePath / os.up
 
   override def scalaVersion: T[String] = BuildInfo.scalaVersion

--- a/runner/src/mill/runner/MillCliConfig.scala
+++ b/runner/src/mill/runner/MillCliConfig.scala
@@ -1,6 +1,7 @@
 package mill.runner
 
 import mainargs.{Flag, Leftover, arg}
+import mill.api.WorkspaceRoot
 import os.Path
 
 class MillCliConfig private (
@@ -257,7 +258,6 @@ import mainargs.ParserForClass
 // to undercompilation, we have it in this file
 // see https://github.com/com-lihaoyi/mill/issues/2315
 object MillCliConfigParser {
-
   val customName: String = s"Mill Build Tool, version ${mill.main.BuildInfo.millVersion}"
   val customDoc = "usage: mill [options] [[target [target-options]] [+ [target ...]]]"
 
@@ -266,7 +266,7 @@ object MillCliConfigParser {
    */
   implicit object PathRead extends mainargs.TokensReader.Simple[os.Path] {
     def shortName = "path"
-    def read(strs: Seq[String]): Either[String, Path] = Right(os.Path(strs.last, os.pwd))
+    def read(strs: Seq[String]): Either[String, Path] = Right(os.Path(strs.last, WorkspaceRoot.workspaceRoot))
   }
 
   private[this] lazy val parser: ParserForClass[MillCliConfig] =

--- a/runner/src/mill/runner/MillCliConfig.scala
+++ b/runner/src/mill/runner/MillCliConfig.scala
@@ -266,7 +266,8 @@ object MillCliConfigParser {
    */
   implicit object PathRead extends mainargs.TokensReader.Simple[os.Path] {
     def shortName = "path"
-    def read(strs: Seq[String]): Either[String, Path] = Right(os.Path(strs.last, WorkspaceRoot.workspaceRoot))
+    def read(strs: Seq[String]): Either[String, Path] =
+      Right(os.Path(strs.last, WorkspaceRoot.workspaceRoot))
   }
 
   private[this] lazy val parser: ParserForClass[MillCliConfig] =

--- a/runner/src/mill/runner/MillMain.scala
+++ b/runner/src/mill/runner/MillMain.scala
@@ -1,11 +1,11 @@
 package mill.runner
 
-import java.io.{FileOutputStream, PrintStream, PipedInputStream}
+import java.io.{FileOutputStream, PipedInputStream, PrintStream}
 import java.util.Locale
 import scala.jdk.CollectionConverters._
 import scala.util.Properties
 import mill.java9rtexport.Export
-import mill.api.{MillException, internal, SystemStreams}
+import mill.api.{MillException, SystemStreams, WorkspaceRoot, internal}
 import mill.bsp.{BspContext, BspServerResult}
 import mill.main.BuildInfo
 import mill.util.PrintLogger
@@ -40,7 +40,7 @@ object MillMain {
       if (args.headOption == Option("--bsp")) {
         // In BSP mode, we use System.in/out for protocol communication
         // and all Mill output (stdout and stderr) goes to a dedicated file
-        val stderrFile = os.pwd / ".bsp" / "mill-bsp.stderr"
+        val stderrFile = WorkspaceRoot.workspaceRoot / ".bsp" / "mill-bsp.stderr"
         os.makeDir.all(stderrFile / os.up)
         val errFile = new PrintStream(new FileOutputStream(stderrFile.toIO, true))
         val errTee = new TeePrintStream(initialSystemStreams.err, errFile)
@@ -161,7 +161,7 @@ object MillMain {
             printLoggerState
           )
           if (!config.silent.value) {
-            checkMillVersionFromFile(os.pwd, streams.err)
+            checkMillVersionFromFile(WorkspaceRoot.workspaceRoot, streams.err)
           }
 
           // special BSP mode, in which we spawn a server and register the current evaluator when-ever we start to eval a dedicated command
@@ -220,7 +220,7 @@ object MillMain {
                     adjustJvmProperties(userSpecifiedProperties, initialSystemProperties)
 
                     new MillBuildBootstrap(
-                      projectRoot = os.pwd,
+                      projectRoot = WorkspaceRoot.workspaceRoot,
                       home = config.home,
                       keepGoing = config.keepGoing.value,
                       imports = config.imports,

--- a/runner/src/mill/runner/MillServerMain.scala
+++ b/runner/src/mill/runner/MillServerMain.scala
@@ -105,7 +105,8 @@ class Server[T](
 
           new File(socketName).delete()
 
-          val addr = AFUNIXSocketAddress.of(os.Path(new File(socketName)).relativeTo(os.pwd).toNIO.toFile)
+          val addr =
+            AFUNIXSocketAddress.of(os.Path(new File(socketName)).relativeTo(os.pwd).toNIO.toFile)
           val serverSocket = AFUNIXServerSocket.bindOn(addr)
           val socketClose = () => serverSocket.close()
 

--- a/runner/src/mill/runner/MillServerMain.scala
+++ b/runner/src/mill/runner/MillServerMain.scala
@@ -9,7 +9,7 @@ import org.newsclub.net.unix.AFUNIXServerSocket
 import org.newsclub.net.unix.AFUNIXSocketAddress
 import mill.main.BuildInfo
 import mill.main.client._
-import mill.api.{SystemStreams, WorkspaceRoot, internal}
+import mill.api.{SystemStreams, internal}
 import mill.main.client.lock.{Lock, Locks}
 
 import scala.util.Try

--- a/runner/src/mill/runner/MillServerMain.scala
+++ b/runner/src/mill/runner/MillServerMain.scala
@@ -153,7 +153,7 @@ class Server[T](
     // that relies on that method
     val proxiedSocketInput = proxyInputStreamThroughPumper(clientSocket.getInputStream)
 
-    val argStream = new FileInputStream(ServerFiles.runArgs(lockBase))
+    val argStream = new FileInputStream(lockBase + "/" + ServerFiles.runArgs)
     val interactive = argStream.read() != 0
     val clientMillVersion = Util.readString(argStream)
     val serverMillVersion = BuildInfo.millVersion
@@ -162,7 +162,7 @@ class Server[T](
         s"Mill version changed ($serverMillVersion -> $clientMillVersion), re-starting server"
       )
       java.nio.file.Files.write(
-        java.nio.file.Paths.get(ServerFiles.exitCode(lockBase)),
+        java.nio.file.Paths.get(lockBase + "/" + ServerFiles.exitCode),
         s"${Util.ExitServerCodeWhenVersionMismatch()}".getBytes()
       )
       System.exit(Util.ExitServerCodeWhenVersionMismatch())

--- a/runner/test/src/mill/runner/ClientServerTests.scala
+++ b/runner/test/src/mill/runner/ClientServerTests.scala
@@ -76,7 +76,7 @@ object ClientServerTests extends TestSuite {
   )(env: Map[String, String], args: Array[String]) = {
     val (in, out, err) = initStreams()
     Server.lockBlock(locks.clientLock) {
-      mill.main.client.MillClientMain.run(
+      mill.main.client.MillServerLauncher.run(
         tmpDir.toString,
         () => spawnEchoServer(tmpDir, locks),
         locks,


### PR DESCRIPTION
* `ServerFiles.*` and `OutFiles.*` have been turned into constant fields where possible

* `client/` code layout has been overhauled: `MillClientMain`/`MillEnv` have been re-organized into `MillClientMain`, `MillLauncher`, `MillServerLauncher`, `MillNoServerLauncher`

* `MillClientMain.main0`, now living in `MillServerLauncher.runMain`, has been broken down: `runMillServer` has been extracted out of it, and the `Locks`/`Lock`/`Locked` logic has been tweaked with the addition of `TryLocked implements AutoClosable` to let us fold some logic into the try-with-resources block

* Removed the code path for running the Mill server in-process: this cuts down the number of execution modes from 3 to 2, server and no-server. There'll be a bit of performance hit spawning another JVM for the no-server mode, but IMO it's worth it for the simplicity and maintainability of this gnarly code, and is necessary for moving the Mill `os.pwd` out of the root directory into a sandbox

* Some preparations for moving the Mill `os.pwd` out of the root directory into a sandbox, e.g. introducing a `MILL_WORKSPACE_ROOT` environment variable and plumbing it throughout the codebase

This should help improve the code and implementation quality of the Mill client-server codebase and set the stage for further development