### PR TITLE
Tighten up `mill/main/client/lock` files

### DIFF
--- a/main/client/src/mill/main/client/lock/FileLock.java
+++ b/main/client/src/mill/main/client/lock/FileLock.java
@@ -5,8 +5,8 @@ import java.nio.channels.FileChannel;
 
 class FileLock extends Lock {
 
-    private RandomAccessFile raf;
-    private FileChannel chan;
+    final private RandomAccessFile raf;
+    final private FileChannel chan;
 
     public FileLock(String path) throws Exception {
         raf = new RandomAccessFile(path, "rw");

--- a/main/client/src/mill/main/client/lock/FileLocked.java
+++ b/main/client/src/mill/main/client/lock/FileLocked.java
@@ -2,7 +2,7 @@ package mill.main.client.lock;
 
 class FileLocked implements Locked {
 
-    protected java.nio.channels.FileLock lock;
+    final protected java.nio.channels.FileLock lock;
 
     public FileLocked(java.nio.channels.FileLock lock) {
         this.lock = lock;

--- a/main/client/src/mill/main/client/lock/FileLocked.java
+++ b/main/client/src/mill/main/client/lock/FileLocked.java
@@ -2,7 +2,7 @@ package mill.main.client.lock;
 
 class FileLocked implements Locked {
 
-    final protected java.nio.channels.FileLock lock;
+    protected java.nio.channels.FileLock lock;
 
     public FileLocked(java.nio.channels.FileLock lock) {
         this.lock = lock;

--- a/main/client/src/mill/main/client/lock/FileTryLocked.java
+++ b/main/client/src/mill/main/client/lock/FileTryLocked.java
@@ -1,6 +1,6 @@
 package mill.main.client.lock;
 
-public class FileTryLocked extends FileLocked implements TryLocked{
+class FileTryLocked extends FileLocked implements TryLocked{
     public FileTryLocked(java.nio.channels.FileLock lock) {
         super(lock);
     }

--- a/main/client/src/mill/main/client/lock/Locks.java
+++ b/main/client/src/mill/main/client/lock/Locks.java
@@ -2,26 +2,32 @@ package mill.main.client.lock;
 
 import mill.main.client.ServerFiles;
 
-public class Locks implements AutoCloseable {
+final public class Locks implements AutoCloseable {
 
-    public Lock processLock;
-    public Lock serverLock;
-    public Lock clientLock;
+    final public Lock processLock;
+    final public Lock serverLock;
+    final public Lock clientLock;
+
+    public Locks(Lock processLock, Lock serverLock, Lock clientLock){
+        this.processLock = processLock;
+        this.serverLock = serverLock;
+        this.clientLock = clientLock;
+    }
 
     public static Locks files(String lockBase) throws Exception {
-        return new Locks(){{
-            processLock = new FileLock(lockBase + "/" + ServerFiles.processLock);
-            serverLock = new FileLock(lockBase + "/" + ServerFiles.serverLock);
-            clientLock = new FileLock(lockBase + "/" + ServerFiles.clientLock);
-        }};
+        return new Locks(
+            new FileLock(lockBase + "/" + ServerFiles.processLock),
+            new FileLock(lockBase + "/" + ServerFiles.serverLock),
+            new FileLock(lockBase + "/" + ServerFiles.clientLock)
+        );
     }
 
     public static Locks memory() {
-        return new Locks(){{
-            this.processLock = new MemoryLock();
-            this.serverLock = new MemoryLock();
-            this.clientLock = new MemoryLock();
-        }};
+        return new Locks(
+            new MemoryLock(),
+            new MemoryLock(),
+            new MemoryLock()
+        );
     }
 
     @Override

--- a/main/client/src/mill/main/client/lock/MemoryLock.java
+++ b/main/client/src/mill/main/client/lock/MemoryLock.java
@@ -4,7 +4,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 class MemoryLock extends Lock {
 
-    private ReentrantLock innerLock = new ReentrantLock();
+    final private ReentrantLock innerLock = new ReentrantLock();
 
     public boolean probe() {
         return !innerLock.isLocked();

--- a/main/client/src/mill/main/client/lock/MemoryLocked.java
+++ b/main/client/src/mill/main/client/lock/MemoryLocked.java
@@ -2,7 +2,7 @@ package mill.main.client.lock;
 
 class MemoryLocked implements Locked {
 
-    final protected java.util.concurrent.locks.Lock lock;
+    protected java.util.concurrent.locks.Lock lock;
 
     public MemoryLocked(java.util.concurrent.locks.Lock lock) {
         this.lock = lock;

--- a/main/client/src/mill/main/client/lock/MemoryLocked.java
+++ b/main/client/src/mill/main/client/lock/MemoryLocked.java
@@ -2,7 +2,7 @@ package mill.main.client.lock;
 
 class MemoryLocked implements Locked {
 
-    protected java.util.concurrent.locks.Lock lock;
+    final protected java.util.concurrent.locks.Lock lock;
 
     public MemoryLocked(java.util.concurrent.locks.Lock lock) {
         this.lock = lock;

--- a/main/client/src/mill/main/client/lock/MemoryTryLocked.java
+++ b/main/client/src/mill/main/client/lock/MemoryTryLocked.java
@@ -1,6 +1,6 @@
 package mill.main.client.lock;
 
-public class MemoryTryLocked extends MemoryLocked implements TryLocked {
+class MemoryTryLocked extends MemoryLocked implements TryLocked {
     public MemoryTryLocked(java.util.concurrent.locks.Lock lock) {
         super(lock);
     }

--- a/main/client/src/mill/main/client/lock/TryLocked.java
+++ b/main/client/src/mill/main/client/lock/TryLocked.java
@@ -1,5 +1,5 @@
 package mill.main.client.lock;
 
 public interface TryLocked extends Locked {
-    public boolean isLocked();
+    boolean isLocked();
 }


### PR DESCRIPTION
follow up for https://github.com/com-lihaoyi/mill/pull/3363

* Remove the `public`-ness from `FileTryLocked` and `MemoryTryLocked`. They do not need to be public, as people should only access them through the `TryLocked` interface

* Add `final` to the fields that do not need to be mutated (i.e. all of them)

* Make `Locks` `final`, and replace weird anonymous class initializers with a proper constructor