### PR TITLE
Override Failure.toString implementation

### DIFF
--- a/main/api/src/mill/api/Result.scala
+++ b/main/api/src/mill/api/Result.scala
@@ -75,6 +75,7 @@ object Result {
     def map[V](f: T => V): Failure[V] = Result.Failure(msg, value.map(f(_)))
     def flatMap[V](f: T => Result[V]): Failure[V] =
       Failure(msg, value.flatMap(f(_).asSuccess.map(_.value)))
+    override def toString(): String = msg
   }
 
   /**


### PR DESCRIPTION
Avoid the very confusing failure message like
```
1 targets failed
ws.resolvedIvyDeps mill.api.Result$Failure
    mill.api.Result$Failure.map(Result.scala:75)
    mill.api.Result$Failure.map(Result.scala:74)
    mill.scalalib.Lib$.resolveDependencies(Lib.scala:77)
    mill.scalalib.CoursierModule$Resolver.resolveDeps(CoursierModule.scala:146)
    mill.scalalib.JavaModule.$anonfun$resolvedIvyDeps$3(JavaModule.scala:535)
```