### PR TITLE
Optimize Mill evaluation logic

### DIFF
--- a/main/eval/src/mill/eval/EvaluatorCore.scala
+++ b/main/eval/src/mill/eval/EvaluatorCore.scala
@@ -81,6 +81,47 @@ private[mill] trait EvaluatorCore extends GroupEvaluator {
     val count = new AtomicInteger(1)
 
     val futures = mutable.Map.empty[Terminal, Future[Option[GroupEvaluator.Results]]]
+//    def resolveParents(c: Class[_]): Seq[Class[_]] = {
+//      Seq(c) ++
+//        Option(c.getSuperclass).toSeq.flatMap(resolveParents) ++
+//        c.getInterfaces.flatMap(resolveParents)
+//    }
+//
+//    val allEnclosingClasses = sortedGroups
+//      .values()
+//      .flatten
+//      .collect { case namedTask: NamedTask[_] => namedTask.ctx.enclosingCls }
+//      .distinct
+//      .toVector
+//
+//    val enclosingClassMethodNames = allEnclosingClasses
+//      .map { c =>
+//        val cMangledName = c.getName.replace('.', '$')
+//        (
+//          c,
+//          c.getDeclaredMethods
+//            .iterator
+//            .flatMap(m =>
+//              Seq(
+//                m.getName -> m,
+//                // Handle scenarios where private method names get mangled when they are
+//                // not really JVM-private due to being accessed by Scala nested objects
+//                // or classes https://github.com/scala/bug/issues/9306
+//                m.getName.stripPrefix(cMangledName + "$$") -> m,
+//                m.getName.stripPrefix(cMangledName + "$") -> m
+//              )
+//            )
+//            .toMap
+//        )
+//      }
+//      .toMap
+//
+//    val classPossibleTaskNames = allEnclosingClasses
+//      .map { c =>
+//        (c, resolveParents(c).map(c => enclosingClassMethodNames.getOrElse(c, Map())))
+//      }
+//      .toMap
+
 
     def evaluateTerminals(terminals: Seq[Terminal], contextLoggerMsg: Int => String)(implicit
         ec: ExecutionContext
@@ -116,7 +157,8 @@ private[mill] trait EvaluatorCore extends GroupEvaluator {
               counterMsg = counterMsg,
               zincProblemReporter = reporter,
               testReporter = testReporter,
-              logger = contextLogger
+              logger = contextLogger,
+//              classPossibleTaskNames = classPossibleTaskNames
             )
 
             if (failFast && res.newResults.values.exists(_.result.asSuccess.isEmpty))

--- a/main/eval/src/mill/eval/EvaluatorCore.scala
+++ b/main/eval/src/mill/eval/EvaluatorCore.scala
@@ -218,8 +218,8 @@ private[mill] trait EvaluatorCore extends GroupEvaluator {
   }
 
   private def precomputeMethodNamesPerClass(sortedGroups: MultiBiMap[Terminal, Task[_]]) = {
-    def resolveTransitiveParents(c: Class[_]): Seq[Class[_]] = {
-      Seq(c) ++
+    def resolveTransitiveParents(c: Class[_]): Array[Class[_]] = {
+      Array(c) ++
       (Option(c.getSuperclass).toSeq ++ c.getInterfaces).flatMap(resolveTransitiveParents)
     }
 
@@ -227,7 +227,7 @@ private[mill] trait EvaluatorCore extends GroupEvaluator {
       .values()
       .flatten
       .collect { case namedTask: NamedTask[_] => namedTask.ctx.enclosingCls }
-      .map(cls => cls -> resolveTransitiveParents(cls))
+      .map(cls => cls -> (resolveTransitiveParents(cls): IndexedSeq[Class[_]]))
       .toMap
 
     val allTransitiveClasses = classToTransitiveClasses

--- a/main/eval/src/mill/eval/GroupEvaluator.scala
+++ b/main/eval/src/mill/eval/GroupEvaluator.scala
@@ -75,7 +75,8 @@ private[mill] trait GroupEvaluator {
       counterMsg: String,
       zincProblemReporter: Int => Option[CompileProblemReporter],
       testReporter: TestReporter,
-      logger: ColorLogger
+      logger: ColorLogger,
+//      groupTransitiveParents: Map[Class[_], Map[String, java.lang.reflect.Method]]
   ): GroupEvaluator.Results = synchronizedEval(
     terminal,
     onCollision =
@@ -126,6 +127,7 @@ private[mill] trait GroupEvaluator {
         .collect{case namedTask: NamedTask[_] =>
           namedTask.ctx.enclosingCls ->
             resolveParents(namedTask.ctx.enclosingCls)
+              .reverse
               .flatMap { c =>
                 val cMangledName = c.getName.replace('.', '$')
                 c.getDeclaredMethods.flatMap { m =>

--- a/main/eval/src/mill/eval/JsonArrayLogger.scala
+++ b/main/eval/src/mill/eval/JsonArrayLogger.scala
@@ -6,7 +6,7 @@ import java.nio.file.{Files, StandardOpenOption}
 private class JsonArrayLogger[T: upickle.default.Writer](outPath: os.Path, indent: Int) {
   private var used = false
 
-  val indentStr = " " * indent
+  val indentStr: String = " " * indent
   private lazy val traceStream = {
     val options = Seq(
       Seq(StandardOpenOption.CREATE, StandardOpenOption.WRITE),

--- a/main/eval/src/mill/eval/JsonArrayLogger.scala
+++ b/main/eval/src/mill/eval/JsonArrayLogger.scala
@@ -6,6 +6,7 @@ import java.nio.file.{Files, StandardOpenOption}
 private class JsonArrayLogger[T: upickle.default.Writer](outPath: os.Path, indent: Int) {
   private var used = false
 
+  val indentStr = " " * indent
   private lazy val traceStream = {
     val options = Seq(
       Seq(StandardOpenOption.CREATE, StandardOpenOption.WRITE),
@@ -21,7 +22,7 @@ private class JsonArrayLogger[T: upickle.default.Writer](outPath: os.Path, inden
     used = true
     val indented = upickle.default.write(t, indent = indent)
       .linesIterator
-      .map(" " * indent + _)
+      .map(indentStr + _)
       .mkString("\n")
 
     traceStream.print(indented)

--- a/runner/src/mill/runner/Watching.scala
+++ b/runner/src/mill/runner/Watching.scala
@@ -23,7 +23,6 @@ object Watching {
       evaluate: Option[T] => Result[T]
   ): (Boolean, T) = {
     var prevState: Option[T] = None
-    var previous = System.currentTimeMillis()
     while (true) {
       val Result(watchables, errorOpt, result) = evaluate(prevState)
       prevState = Some(result)
@@ -41,13 +40,10 @@ object Watching {
         return (errorOpt.isEmpty, result)
       }
 
-      val alreadyStale = true
+      val alreadyStale = watchables.exists(!_.validate())
       if (!alreadyStale) {
         Watching.watchAndWait(logger, setIdle, streams.in, watchables)
       }
-      val next = System.currentTimeMillis()
-      println("Delta Millis " + (next - previous))
-      previous = next
     }
     ???
   }

--- a/runner/src/mill/runner/Watching.scala
+++ b/runner/src/mill/runner/Watching.scala
@@ -23,6 +23,7 @@ object Watching {
       evaluate: Option[T] => Result[T]
   ): (Boolean, T) = {
     var prevState: Option[T] = None
+    var previous = System.currentTimeMillis()
     while (true) {
       val Result(watchables, errorOpt, result) = evaluate(prevState)
       prevState = Some(result)
@@ -40,10 +41,13 @@ object Watching {
         return (errorOpt.isEmpty, result)
       }
 
-      val alreadyStale = watchables.exists(!_.validate())
+      val alreadyStale = true
       if (!alreadyStale) {
         Watching.watchAndWait(logger, setIdle, streams.in, watchables)
       }
+      val next = System.currentTimeMillis()
+      println("Delta Millis " + (next - previous))
+      previous = next
     }
     ???
   }


### PR DESCRIPTION
Pre-compute a bunch of values we use to compute the code signature of enclosing objects of task methods. 

Cuts down the time taken of a hot no-op `./mill __.compile` (i.e. pure overhead) on the Mill repo from ~4000ms to ~2000ms

Benchmarked were run ad hoc on my laptop by making the `-w` flag loop immediately rather than waiting

```diff
diff --git a/runner/src/mill/runner/Watching.scala b/runner/src/mill/runner/Watching.scala
index 08e8df5e3f..e8f41a3cc5 100644
--- a/runner/src/mill/runner/Watching.scala
+++ b/runner/src/mill/runner/Watching.scala
@@ -23,6 +23,7 @@ object Watching {
       evaluate: Option[T] => Result[T]
   ): (Boolean, T) = {
     var prevState: Option[T] = None
+    var previous = System.currentTimeMillis()
     while (true) {
       val Result(watchables, errorOpt, result) = evaluate(prevState)
       prevState = Some(result)
@@ -40,10 +41,13 @@ object Watching {
         return (errorOpt.isEmpty, result)
       }

-      val alreadyStale = watchables.exists(!_.validate())
+      val alreadyStale = true
       if (!alreadyStale) {
         Watching.watchAndWait(logger, setIdle, streams.in, watchables)
       }
+      val next = System.currentTimeMillis()
+      println("Delta Millis " + (next - previous))
+      previous = next
     }
     ???
   }
```

Covered by the existing `integration/invalidation/codesig-*` tests

