### PR TITLE
Print pretty error message when Result.Failure is thrown

### DIFF
--- a/main/eval/src/mill/eval/Evaluator.scala
+++ b/main/eval/src/mill/eval/Evaluator.scala
@@ -81,8 +81,9 @@ object Evaluator {
     (for ((k, fs) <- evaluated.failing.items())
       yield {
         val fss = fs.map {
-          case ex: Result.Exception => ex.toString
           case Result.Failure(t, _) => t
+          case Result.Exception(Result.Failure(t, _), _) => t
+          case ex: Result.Exception => ex.toString
         }
         s"${k.render} ${fss.iterator.mkString(", ")}"
       }).mkString("\n")


### PR DESCRIPTION
The new `.getOrThrow` API allows to short-circuit the result of a `Result`. This prints a correct error message when `Result.Failure` is thrown in a method returning `T`, instead of returned via a method returning `Result[T]`.

Pull Request: https://github.com/com-lihaoyi/mill/pull/3391