### PR TITLE
Avoid spurious deprecation warnings in generated code (Backport #3379)

### DIFF
--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -364,6 +364,7 @@ object MillBuildRootModule {
        |
        |import _root_.mill.runner.MillBuildRootModule
        |
+       |@scala.annotation.nowarn
        |object ${backtickWrap(miscInfoName)} {
        |  implicit lazy val millBuildRootModuleInfo: _root_.mill.runner.MillBuildRootModule.Info = _root_.mill.runner.MillBuildRootModule.Info(
        |    ${enclosingClasspath.map(p => literalize(p.toString))}.map(_root_.os.Path(_)),


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/3371

The direct problem is that we are generating code with resolved type aliases, resulting in the `JavaTests` aliases being resolved to deprecated `JavaModuleTests` traits. However, in general generated code should probably not display warnings at all, so better to just slap `@nowarn` on the whole chunk rather than trying to fix the immediate alias resolution problem

Pull Request: https://github.com/com-lihaoyi/mill/pull/3400