### PR TITLE
Fix Mill BSP workspace directory

### DIFF
--- a/bsp/src/mill/bsp/BspContext.scala
+++ b/bsp/src/mill/bsp/BspContext.scala
@@ -62,7 +62,7 @@ private[mill] class BspContext(
       override def rawOutputStream: PrintStream = systemStreams.out
     }
 
-    BspWorker(os.pwd, home, log).flatMap { worker =>
+    BspWorker(mill.api.WorkspaceRoot.workspaceRoot, home, log).flatMap { worker =>
       os.makeDir.all(home / Constants.bspDir)
       worker.startBspServer(
         streams,


### PR DESCRIPTION
`os.pwd` is no longer the repo root as of https://github.com/com-lihaoyi/mill/pull/3367, so we need to explicitly ask for `mill.api.WorkspaceRoot.workspaceRoot`

This allows a `installLocalCache`d version of Mill to successfully be used to load a project into IntelliJ via BSP, whereas in `main` that fails due to the incorrect workspace directory 