### PR TITLE
Fix sonatype release

### DIFF
--- a/ci/release-maven.sh
+++ b/ci/release-maven.sh
@@ -11,10 +11,8 @@ rm gpg_key
 # Build all artifacts
 ./mill -i __.publishArtifacts
 
-./mill -i installLocal
-
 # Publish all artifacts
-./target/mill-release -i \
+./mill -i \
     mill.scalalib.PublishModule/publishAll \
     --sonatypeCreds $SONATYPE_USERNAME:$SONATYPE_PASSWORD \
     --gpgArgs --passphrase=$SONATYPE_PGP_PASSWORD,--no-tty,--pinentry-mode,loopback,--batch,--yes,-a,-b \


### PR DESCRIPTION
https://github.com/com-lihaoyi/mill/commit/a293b46e made use a locally built mill to release to sonatype, since the previous versions did not work with the latest sonatype API. But it neglected to run `ci/patch-mill-bootstrap.sh`, resulting in failures like https://github.com/com-lihaoyi/mill/actions/runs/10472316798/job/29046150876 ever since https://github.com/com-lihaoyi/mill/commit/33fa9530f165a5e5e1d367a5b51b291c2bb15d1f landed. This reverts back to the original usage of committed `./mill` script for publishing, since we've now re-bootstrapped on a new enough version that publishing works without needing to build a local version