### PR TITLE
Move build dependencies into meta build

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -1,6 +1,4 @@
 // imports
-import $meta._
-
 import scala.util.chaining._
 import com.github.lolgab.mill.mima.Mima
 import coursier.maven.MavenRepository
@@ -20,14 +18,9 @@ import mill.T
 import mill.define.Cross
 
 // plugins and dependencies
+import $meta._
 import $file.ci.shared
 import $file.ci.upload
-import $ivy.`org.scalaj::scalaj-http:2.4.2`
-import $ivy.`de.tototec::de.tobiasroeser.mill.vcs.version::0.4.0`
-import $ivy.`com.github.lolgab::mill-mima::0.1.1`
-import $ivy.`net.sourceforge.htmlcleaner:htmlcleaner:2.29`
-import $ivy.`com.lihaoyi::mill-contrib-buildinfo:`
-import $ivy.`com.goyeau::mill-scalafix::0.4.0`
 
 object Settings {
   val pomOrg = "com.lihaoyi"

--- a/mill-build/build.sc
+++ b/mill-build/build.sc
@@ -1,1 +1,15 @@
-object build extends MillBuildRootModule
+import mill._
+import mill.runner.MillBuildRootModule
+import mill.scalalib._
+
+object build extends MillBuildRootModule {
+  override def ivyDeps = Agg(
+    ivy"org.scalaj::scalaj-http:2.4.2",
+    ivy"de.tototec::de.tobiasroeser.mill.vcs.version::0.4.0",
+    ivy"com.github.lolgab::mill-mima::0.1.1",
+    ivy"net.sourceforge.htmlcleaner:htmlcleaner:2.29",
+    // TODO: implement empty version for ivy deps as we do in import parser
+    ivy"com.lihaoyi::mill-contrib-buildinfo:${mill.api.BuildInfo.millVersion}",
+    ivy"com.goyeau::mill-scalafix::0.4.0"
+  )
+}


### PR DESCRIPTION
Since we now have a meta build, we should manage all plugins in one place.
