### PR TITLE
Put back ??? in sys.props calls

### DIFF
--- a/contrib/bloop/test/src/mill/contrib/bloop/BloopTests.scala
+++ b/contrib/bloop/test/src/mill/contrib/bloop/BloopTests.scala
@@ -58,8 +58,8 @@ object BloopTests extends TestSuite {
     }
 
     object scalajsModule extends scalajslib.ScalaJSModule with testBloop.Module {
-      val sv = sys.props("TEST_SCALA_2_13_VERSION")
-      val sjsv = sys.props("TEST_SCALAJS_VERSION")
+      val sv = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
+      val sjsv = sys.props.getOrElse("TEST_SCALAJS_VERSION", ???)
       override def scalaVersion = sv
       override def scalaJSVersion = sjsv
       override def linkerMode = T(Some(_root_.bloop.config.Config.LinkerMode.Release))
@@ -67,10 +67,10 @@ object BloopTests extends TestSuite {
     }
 
     object scalanativeModule extends scalanativelib.ScalaNativeModule with testBloop.Module {
-      val sv = sys.props("TEST_SCALA_2_13_VERSION")
+      val sv = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
       override def skipBloop: Boolean = isWin
       override def scalaVersion = sv
-      override def scalaNativeVersion = sys.props("TEST_SCALANATIVE_0_5_VERSION")
+      override def scalaNativeVersion = sys.props.getOrElse("TEST_SCALANATIVE_0_5_VERSION", ???)
       override def releaseMode = T(ReleaseMode.Debug)
     }
 

--- a/contrib/docker/src/mill/contrib/docker/DockerModule.scala
+++ b/contrib/docker/src/mill/contrib/docker/DockerModule.scala
@@ -125,7 +125,7 @@ trait DockerModule { outer: JavaModule =>
         else volumes().map(v => s"\"$v\"").mkString("VOLUME [", ", ", "]"),
         run().map(c => s"RUN $c").mkString("\n"),
         if (user().isEmpty) "" else s"USER ${user()}"
-      ).filter(_.nonEmpty).mkString(sys.props("line.separator"))
+      ).filter(_.nonEmpty).mkString(sys.props.getOrElse("line.separator", ???))
 
       val quotedEntryPointArgs = (Seq("java") ++ jvmOptions() ++ Seq("-jar", s"/$jarName"))
         .map(arg => s"\"$arg\"").mkString(", ")

--- a/contrib/docker/test/src/mill/contrib/docker/DockerModuleTest.scala
+++ b/contrib/docker/test/src/mill/contrib/docker/DockerModuleTest.scala
@@ -98,11 +98,11 @@ object DockerModuleTest extends TestSuite {
             |FROM gcr.io/distroless/java:latest
             |COPY out.jar /out.jar
             |ENTRYPOINT ["java", "-jar", "/out.jar"]""".stripMargin,
-          sys.props("line.separator")
+          sys.props.getOrElse("line.separator", ???)
         )
         val dockerfileStringRefined = multineRegex.replaceAllIn(
           result.value,
-          sys.props("line.separator")
+          sys.props.getOrElse("line.separator", ???)
         )
         assert(dockerfileStringRefined == expected)
       }
@@ -124,11 +124,11 @@ object DockerModuleTest extends TestSuite {
             |USER user1
             |COPY out.jar /out.jar
             |ENTRYPOINT ["java", "-jar", "/out.jar"]""".stripMargin,
-          sys.props("line.separator")
+          sys.props.getOrElse("line.separator", ???)
         )
         val dockerfileStringRefined = multineRegex.replaceAllIn(
           result.value,
-          sys.props("line.separator")
+          sys.props.getOrElse("line.separator", ???)
         )
         assert(dockerfileStringRefined == expected)
       }
@@ -141,11 +141,11 @@ object DockerModuleTest extends TestSuite {
             |FROM gcr.io/distroless/java:latest
             |COPY out.jar /out.jar
             |ENTRYPOINT ["java", "-Xmx1024M", "-jar", "/out.jar"]""".stripMargin,
-          sys.props("line.separator")
+          sys.props.getOrElse("line.separator", ???)
         )
         val dockerfileStringRefined = multineRegex.replaceAllIn(
           result.value,
-          sys.props("line.separator")
+          sys.props.getOrElse("line.separator", ???)
         )
         assert(dockerfileStringRefined == expected)
       }

--- a/scalalib/test/src/mill/scalalib/TestRunnerTests.scala
+++ b/scalalib/test/src/mill/scalalib/TestRunnerTests.scala
@@ -14,12 +14,12 @@ import scala.xml.{Elem, NodeSeq, XML}
 
 object TestRunnerTests extends TestSuite {
   object testrunner extends TestBaseModule with ScalaModule {
-    def scalaVersion = sys.props("TEST_SCALA_2_13_VERSION")
+    def scalaVersion = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
 
     object utest extends ScalaTests with TestModule.Utest {
       override def ivyDeps = T {
         super.ivyDeps() ++ Agg(
-          ivy"com.lihaoyi::utest:${sys.props("TEST_UTEST_VERSION")}"
+          ivy"com.lihaoyi::utest:${sys.props.getOrElse("TEST_UTEST_VERSION", ???)}"
         )
       }
     }
@@ -27,7 +27,7 @@ object TestRunnerTests extends TestSuite {
     object scalatest extends ScalaTests with TestModule.ScalaTest {
       override def ivyDeps = T {
         super.ivyDeps() ++ Agg(
-          ivy"org.scalatest::scalatest:${sys.props("TEST_SCALATEST_VERSION")}"
+          ivy"org.scalatest::scalatest:${sys.props.getOrElse("TEST_SCALATEST_VERSION", ???)}"
         )
       }
     }
@@ -35,7 +35,7 @@ object TestRunnerTests extends TestSuite {
     trait DoneMessage extends ScalaTests {
       override def ivyDeps = T {
         super.ivyDeps() ++ Agg(
-          ivy"org.scala-sbt:test-interface:${sys.props("TEST_TEST_INTERFACE_VERSION")}"
+          ivy"org.scala-sbt:test-interface:${sys.props.getOrElse("TEST_TEST_INTERFACE_VERSION", ???)}"
         )
       }
     }


### PR DESCRIPTION
`sys.props("doesntexist")` returns `null` instead of throwing like I expected, so this change ensures any misconfiguration resulting in missing environment variables throws