### PR TITLE
Clean up MillBuildRootModule codegen

### DIFF
--- a/main/define/src/mill/define/Discover.scala
+++ b/main/define/src/mill/define/Discover.scala
@@ -21,8 +21,7 @@ case class Discover[T] private (
       Class[_],
       (Seq[String], Seq[mainargs.MainData[_, _]])
     ],
-    dummy: Int = 0, /* avoid conflict with Discover.apply(value: Map) below*/
-    packageObjectDirectChildModules: Seq[String] = Nil
+    dummy: Int = 0 /* avoid conflict with Discover.apply(value: Map) below*/
 ) {
   @deprecated("Binary compatibility shim", "Mill 0.11.4")
   private[define] def this(value: Map[Class[_], Seq[mainargs.MainData[_, _]]]) =
@@ -42,12 +41,6 @@ case class Discover[T] private (
 }
 
 object Discover {
-  def apply3[T](
-      value: Map[Class[_], (Seq[String], Seq[mainargs.MainData[_, _]])],
-      packageObjectDirectChildModules: Seq[String]
-  ): Discover[T] =
-    new Discover[T](value, packageObjectDirectChildModules = packageObjectDirectChildModules)
-
   def apply2[T](value: Map[Class[_], (Seq[String], Seq[mainargs.MainData[_, _]])]): Discover[T] =
     new Discover[T](value)
 
@@ -148,18 +141,8 @@ object Discover {
         q"$lhs -> $overridesLambda"
       }
 
-      val packageObjectDirectChildModules = weakTypeOf[T]
-        .members
-        .collect { case m if m.isModule && m.info <:< weakTypeOf[mill.define.Module] => m.name }
-
       c.Expr[Discover[T]](
-        q"""
-        import _root_.mill.main.TokenReaders._
-        _root_.mill.define.Discover.apply3(
-          _root_.scala.collection.immutable.Map(..$mapping),
-          _root_.scala.collection.immutable.Seq(..$packageObjectDirectChildModules)
-        )
-        """
+        q"import _root_.mill.main.TokenReaders._; _root_.mill.define.Discover.apply2(_root_.scala.collection.immutable.Map(..$mapping))"
       )
     }
   }

--- a/main/define/src/mill/define/Discover.scala
+++ b/main/define/src/mill/define/Discover.scala
@@ -21,7 +21,8 @@ case class Discover[T] private (
       Class[_],
       (Seq[String], Seq[mainargs.MainData[_, _]])
     ],
-    dummy: Int = 0 /* avoid conflict with Discover.apply(value: Map) below*/
+    dummy: Int = 0, /* avoid conflict with Discover.apply(value: Map) below*/
+    packageObjectDirectChildModules: Seq[String] = Nil
 ) {
   @deprecated("Binary compatibility shim", "Mill 0.11.4")
   private[define] def this(value: Map[Class[_], Seq[mainargs.MainData[_, _]]]) =
@@ -41,6 +42,12 @@ case class Discover[T] private (
 }
 
 object Discover {
+  def apply3[T](
+      value: Map[Class[_], (Seq[String], Seq[mainargs.MainData[_, _]])],
+      packageObjectDirectChildModules: Seq[String]
+  ): Discover[T] =
+    new Discover[T](value, packageObjectDirectChildModules = packageObjectDirectChildModules)
+
   def apply2[T](value: Map[Class[_], (Seq[String], Seq[mainargs.MainData[_, _]])]): Discover[T] =
     new Discover[T](value)
 
@@ -141,8 +148,18 @@ object Discover {
         q"$lhs -> $overridesLambda"
       }
 
+      val packageObjectDirectChildModules = weakTypeOf[T]
+        .members
+        .collect { case m if m.isModule && m.info <:< weakTypeOf[mill.define.Module] => m.name }
+
       c.Expr[Discover[T]](
-        q"import _root_.mill.main.TokenReaders._; _root_.mill.define.Discover.apply2(_root_.scala.collection.immutable.Map(..$mapping))"
+        q"""
+        import _root_.mill.main.TokenReaders._
+        _root_.mill.define.Discover.apply3(
+          _root_.scala.collection.immutable.Map(..$mapping),
+          _root_.scala.collection.immutable.Seq(..$packageObjectDirectChildModules)
+        )
+        """
       )
     }
   }

--- a/main/src/mill/main/RootModule.scala
+++ b/main/src/mill/main/RootModule.scala
@@ -41,6 +41,12 @@ object RootModule {
         millFile0,
         Caller(null)
       ) with mill.main.MainModule {
+    def this(segments: String*)(implicit
+        baseModuleInfo: RootModule.Info,
+        millModuleEnclosing0: sourcecode.Enclosing,
+        millModuleLine0: sourcecode.Line,
+        millFile0: sourcecode.File
+    ) = this(Some(Segments.labels(segments: _*)))
 
     // Make BaseModule take the `millDiscover` as an implicit param, rather than
     // defining it itself. That is so we can define it externally in the wrapper
@@ -64,7 +70,12 @@ object RootModule {
         millFile0,
         Caller(null)
       ) {
-
+    def this(segments: String*)(implicit
+        baseModuleInfo: RootModule.Info,
+        millModuleEnclosing0: sourcecode.Enclosing,
+        millModuleLine0: sourcecode.Line,
+        millFile0: sourcecode.File
+    ) = this(Some(Segments.labels(segments: _*)))
     object interp extends Interp
 
     override lazy val millDiscover: Discover[this.type] =

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -336,11 +336,8 @@ object MillBuildRootModule {
 
       val pkgLine = pkg.map(p => "package " + backtickWrap(p)).mkString("\n")
       val markerComment =
-        s"""
-           |//MILL_ORIGINAL_FILE_PATH=${scriptSource.path}
-           |//MILL_USER_CODE_START_MARKER
-           |
-           |""".stripMargin
+        s"""//MILL_ORIGINAL_FILE_PATH=${scriptSource.path}
+           |//MILL_USER_CODE_START_MARKER""".stripMargin
 
       os.write(
         dest,

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -318,33 +318,37 @@ object MillBuildRootModule {
 
       val pkg = FileImportGraph.fileImportToSegments(base, scriptSource.path, true).dropRight(1)
       val specialNames = Set("build", "module")
-      val newSource = MillBuildRootModule.top(
-        specialNames(scriptSource.path.baseName),
-        if (specialNames(scriptSource.path.baseName)) relative.segments.init
-        else relative.segments.init :+ relative.baseName,
-        scriptSource.path / os.up,
-        if (specialNames(scriptSource.path.baseName)) pkg.dropRight(1) else pkg,
-        if (specialNames(scriptSource.path.baseName)) pkg.last else scriptSource.path.baseName,
-        enclosingClasspath,
-        millTopLevelProjectRoot,
-        scriptSource.path
-      ) +
-        scriptCode(scriptSource.path) +
-        MillBuildRootModule.bottom
+      val pkgLine = (if (specialNames(scriptSource.path.baseName)) pkg.dropRight(1) else pkg)
+        .map(p => "package " + backtickWrap(p)).mkString("\n")
+      val userScriptCode = scriptCode(scriptSource.path)
+      val markerComment = s"""//MILL_ORIGINAL_FILE_PATH=${scriptSource.path}
+                             |//MILL_USER_CODE_START_MARKER""".stripMargin
+      val newSource = if (specialNames(scriptSource.path.baseName)) {
+        top(
+          relative.segments.init,
+          scriptSource.path / os.up,
+          pkg.last,
+          enclosingClasspath,
+          millTopLevelProjectRoot
+        )
+      } else {
+        s"object ${backtickWrap(scriptSource.path.baseName)} {"
+      }
 
-      os.write(dest, newSource, createFolders = true)
+      os.write(
+        dest,
+        Seq(pkgLine, newSource, markerComment, userScriptCode, bottom).mkString("\n"),
+        createFolders = true
+      )
     }
   }
 
   def top(
-      isBuildOrModuleSc: Boolean,
       segs: Seq[String],
       base: os.Path,
-      pkg: Seq[String],
       name: String,
       enclosingClasspath: Seq[os.Path],
-      millTopLevelProjectRoot: os.Path,
-      originalFilePath: os.Path
+      millTopLevelProjectRoot: os.Path
   ): String = {
     val segsList = segs.map(pprint.Util.literalize(_)).mkString(", ")
     val superClass =
@@ -354,49 +358,31 @@ object MillBuildRootModule {
         s"_root_.mill.main.RootModule.Foreign(Some(_root_.mill.define.Segments.labels($segsList)))"
       }
 
-    val imports = ""
-//      if (name == "build") "import mill.main.RootModule"
-//      else "import mill.main.{RootModuleForeign => RootModule}"
-
     val miscInfoName = s"MiscInfo_$name"
 
-    val pkgLine = pkg.map(p => "package " + backtickWrap(p)).mkString("\n")
-
-    if (isBuildOrModuleSc) {
-      s"""$pkgLine
-         |
-         |import _root_.mill.runner.MillBuildRootModule
-         |$imports
-         |
-         |@scala.annotation.nowarn
-         |object ${backtickWrap(miscInfoName)} {
-         |  implicit lazy val millBuildRootModuleInfo: _root_.mill.runner.MillBuildRootModule.Info = _root_.mill.runner.MillBuildRootModule.Info(
-         |    ${enclosingClasspath.map(p => literalize(p.toString))}.map(_root_.os.Path(_)),
-         |    _root_.os.Path(${literalize(base.toString)}),
-         |    _root_.os.Path(${literalize(millTopLevelProjectRoot.toString)}),
-         |  )
-         |  implicit lazy val millBaseModuleInfo: _root_.mill.main.RootModule.Info = _root_.mill.main.RootModule.Info(
-         |    millBuildRootModuleInfo.projectRoot,
-         |    _root_.mill.define.Discover[${backtickWrap(name + "_")}]
-         |  )
-         |}
-         |import ${backtickWrap(miscInfoName)}.{millBuildRootModuleInfo, millBaseModuleInfo}
-         |package object ${backtickWrap(name)} extends ${backtickWrap(name + "_")}
-         |import ${backtickWrap(name)}._
-         |class ${backtickWrap(name + "_")} extends $superClass {
-         |
-         |//MILL_ORIGINAL_FILE_PATH=${originalFilePath}
-         |//MILL_USER_CODE_START_MARKER
-         |""".stripMargin
-    } else {
-      s"""$pkgLine
-         |object ${backtickWrap(name)} {
-         |
-         |//MILL_ORIGINAL_FILE_PATH=${originalFilePath}
-         |//MILL_USER_CODE_START_MARKER
-         |""".stripMargin
-    }
+    s"""
+       |import _root_.mill.runner.MillBuildRootModule
+       |
+       |@scala.annotation.nowarn
+       |object ${backtickWrap(miscInfoName)} {
+       |  implicit lazy val millBuildRootModuleInfo: _root_.mill.runner.MillBuildRootModule.Info = _root_.mill.runner.MillBuildRootModule.Info(
+       |    ${enclosingClasspath.map(p => literalize(p.toString))}.map(_root_.os.Path(_)),
+       |    _root_.os.Path(${literalize(base.toString)}),
+       |    _root_.os.Path(${literalize(millTopLevelProjectRoot.toString)}),
+       |  )
+       |  implicit lazy val millBaseModuleInfo: _root_.mill.main.RootModule.Info = _root_.mill.main.RootModule.Info(
+       |    millBuildRootModuleInfo.projectRoot,
+       |    _root_.mill.define.Discover[${backtickWrap(name + "_")}]
+       |  )
+       |}
+       |import ${backtickWrap(miscInfoName)}.{millBuildRootModuleInfo, millBaseModuleInfo}
+       |package object ${backtickWrap(name)} extends ${backtickWrap(name + "_")}
+       |import ${backtickWrap(name)}._
+       |class ${backtickWrap(name + "_")} extends $superClass {
+       |
+       |
+       |""".stripMargin
   }
 
-  val bottom = "\n}"
+  val bottom = "}"
 }

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -352,7 +352,7 @@ object MillBuildRootModule {
   ): String = {
     val segsList = segs.map(pprint.Util.literalize(_)).mkString(", ")
     val superClass = if (name == "build") "Base" else "Foreign"
-    
+
     s"""
        |import _root_.mill.runner.MillBuildRootModule
        |
@@ -366,17 +366,17 @@ object MillBuildRootModule {
        |import MillMiscInfo.{millBuildRootModuleInfo, millBaseModuleInfo}
        |object `package` extends PackageModule
        |class PackageModule extends _root_.mill.main.RootModule.$superClass(Some(_root_.mill.define.Segments.labels($segsList))) {
-       |
-       |
        |""".stripMargin
   }
 
   val bottom = "}"
 
-  class MillMiscInfo(enclosingClasspath: Seq[String],
-                     projectRoot: String,
-                     topLevelProjectRoot: String,
-                     discover: Discover[_]){
+  class MillMiscInfo(
+      enclosingClasspath: Seq[String],
+      projectRoot: String,
+      topLevelProjectRoot: String,
+      discover: Discover[_]
+  ) {
     implicit val millBuildRootModuleInfo: MillBuildRootModule.Info = MillBuildRootModule.Info(
       enclosingClasspath.map(os.Path(_)),
       os.Path(projectRoot),

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -381,9 +381,8 @@ object MillBuildRootModule {
        |import ${backtickWrap(name)}.MillMiscInfo.{millBuildRootModuleInfo, millBaseModuleInfo}
        |package object ${backtickWrap(name)} extends ${backtickWrap(name + "_")}
        |import ${backtickWrap(name)}._
-       |class ${backtickWrap(
-        name + "_"
-      )} extends _root_.mill.main.RootModule.$superClass($segsList) {
+       |class ${backtickWrap(name + "_")}
+       |extends _root_.mill.main.RootModule.$superClass($segsList) {
        |""".stripMargin
   }
 

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -365,18 +365,19 @@ object MillBuildRootModule {
 
     s"""import _root_.mill.runner.MillBuildRootModule
        |package ${backtickWrap(name)}{
-       |  @scala.annotation.nowarn
+       |  @_root_.scala.annotation.nowarn
        |  object MillMiscInfo extends MillBuildRootModule.MillMiscInfo(
        |    ${enclosingClasspath.map(p => literalize(p.toString))},
        |    ${literalize(base.toString)},
        |    ${literalize(millTopLevelProjectRoot.toString)},
        |    _root_.mill.define.Discover[${backtickWrap(name + "_")}]
        |  )
-       |
        |}
        |
        |import ${backtickWrap(name)}.MillMiscInfo._
+       |
        |package object ${backtickWrap(name)} extends ${backtickWrap(name + "_")}
+       |
        |class ${backtickWrap(name + "_")}
        |extends _root_.mill.main.RootModule.$superClass($segsList) {
        |""".stripMargin

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -319,7 +319,7 @@ object MillBuildRootModule {
       val pkg0 = FileImportGraph.fileImportToSegments(base, scriptSource.path, true).dropRight(1)
       val specialNames = Set("build", "module")
       val (pkg, newSource) =
-        if (specialNames(scriptSource.path.baseName)){
+        if (specialNames(scriptSource.path.baseName)) {
           val pkg :+ pkgLast = pkg0
 
           pkg -> topBuild(
@@ -327,10 +327,9 @@ object MillBuildRootModule {
             scriptSource.path / os.up,
             pkgLast,
             enclosingClasspath,
-            millTopLevelProjectRoot,
+            millTopLevelProjectRoot
           )
-        }
-        else {
+        } else {
           val pkg = pkg0
           pkg -> s"""object ${backtickWrap(scriptSource.path.baseName)} {"""
         }
@@ -342,7 +341,6 @@ object MillBuildRootModule {
            |//MILL_USER_CODE_START_MARKER
            |
            |""".stripMargin
-
 
       os.write(
         dest,
@@ -363,16 +361,10 @@ object MillBuildRootModule {
       base: os.Path,
       name: String,
       enclosingClasspath: Seq[os.Path],
-      millTopLevelProjectRoot: os.Path,
+      millTopLevelProjectRoot: os.Path
   ): String = {
     val segsList = segs.map(pprint.Util.literalize(_)).mkString(", ")
-    val superClass =
-      if (name == "build") {
-        s"_root_.mill.main.RootModule.Base(Some(_root_.mill.define.Segments.labels($segsList)))"
-      } else {
-        s"_root_.mill.main.RootModule.Foreign(Some(_root_.mill.define.Segments.labels($segsList)))"
-      }
-
+    val superClass = if (name == "build") "Base" else "Foreign"
 
     s"""import _root_.mill.runner.MillBuildRootModule
        |package ${backtickWrap(name)}{
@@ -383,23 +375,26 @@ object MillBuildRootModule {
        |    ${literalize(millTopLevelProjectRoot.toString)},
        |    _root_.mill.define.Discover[${backtickWrap(name + "_")}]
        |  )
+       |
        |}
        |
        |import ${backtickWrap(name)}.MillMiscInfo.{millBuildRootModuleInfo, millBaseModuleInfo}
        |package object ${backtickWrap(name)} extends ${backtickWrap(name + "_")}
        |import ${backtickWrap(name)}._
-       |class ${backtickWrap(name + "_")} extends $superClass {
+       |class ${backtickWrap(
+        name + "_"
+      )} extends _root_.mill.main.RootModule.$superClass($segsList) {
        |""".stripMargin
   }
 
   val bottom = "\n}"
 
   class MillMiscInfo(
-                      enclosingClasspath: Seq[String],
-                      projectRoot: String,
-                      topLevelProjectRoot: String,
-                      discover: Discover[_]
-                    ) {
+      enclosingClasspath: Seq[String],
+      projectRoot: String,
+      topLevelProjectRoot: String,
+      discover: Discover[_]
+  ) {
     implicit val millBuildRootModuleInfo: MillBuildRootModule.Info = MillBuildRootModule.Info(
       enclosingClasspath.map(os.Path(_)),
       os.Path(projectRoot),

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -378,9 +378,8 @@ object MillBuildRootModule {
        |
        |}
        |
-       |import ${backtickWrap(name)}.MillMiscInfo.{millBuildRootModuleInfo, millBaseModuleInfo}
+       |import ${backtickWrap(name)}.MillMiscInfo._
        |package object ${backtickWrap(name)} extends ${backtickWrap(name + "_")}
-       |import ${backtickWrap(name)}._
        |class ${backtickWrap(name + "_")}
        |extends _root_.mill.main.RootModule.$superClass($segsList) {
        |""".stripMargin


### PR DESCRIPTION
Move a bunch of logic into helper methods in order to minimize the complexity of the codegen

This PR shouldn't have any runtime impact, just a bit of internal tidying up