### PR TITLE
Ignore empty `module.sc` files when generating code

### DIFF
--- a/runner/src/mill/runner/FileImportGraph.scala
+++ b/runner/src/mill/runner/FileImportGraph.scala
@@ -139,7 +139,7 @@ object FileImportGraph {
             p == projectRoot / millBuild ||
             (os.isDir(p) && !os.exists(p / "module.sc"))
       )
-      .filter(_.last == "module.sc")
+      .filter(p => p.last == "module.sc" && os.read(p).nonEmpty)
 
     buildFiles.foreach(walkScripts(_))
 


### PR DESCRIPTION
We want to keep them as markers to limit how deeply in the folder hierarchy we discover things, so we don't need to traverse the project arbitrarily deeply every time. But we want to allow people to migrate individual sub-sub-folders to `module.sc` without causing naming conflict with modules defined in the project root. 

This allows us to use empty `module.sc` files as markers for discovery but avoid generating code for them, avoiding the conflicts