### PR TITLE
Make serial command execution at the evaluation end optional

### DIFF
--- a/main/eval/src/mill/eval/EvaluatorImpl.scala
+++ b/main/eval/src/mill/eval/EvaluatorImpl.scala
@@ -1,9 +1,10 @@
 package mill.eval
 
-import mill.api.Val
+import mill.api.{CompileProblemReporter, Strict, TestReporter, Val}
 import mill.api.Strict.Agg
 import mill.define._
 import mill.util._
+
 import scala.collection.mutable
 import scala.reflect.ClassTag
 
@@ -41,6 +42,18 @@ private[mill] case class EvaluatorImpl(
 
   override def plan(goals: Agg[Task[_]]): (MultiBiMap[Terminal, Task[_]], Agg[Task[_]]) = {
     Plan.plan(goals)
+  }
+
+  override def evaluate(
+      goals: Strict.Agg[Task[_]],
+      reporter: Int => Option[CompileProblemReporter],
+      testReporter: TestReporter,
+      logger: ColorLogger,
+      serialCommandExec: Boolean
+  ): Evaluator.Results = {
+    // TODO: cleanup once we break bin-compat in Mill 0.13
+    // disambiguate override hierarchy
+    super.evaluate(goals, reporter, testReporter, logger, serialCommandExec)
   }
 
   override def evalOrThrow(exceptionFactory: Evaluator.Results => Throwable)

--- a/main/src/mill/main/RunScript.scala
+++ b/main/src/mill/main/RunScript.scala
@@ -35,7 +35,7 @@ object RunScript {
       evaluator: Evaluator,
       targets: Agg[Task[Any]]
   ): (Seq[Watchable], Either[String, Seq[(Any, Option[(TaskName, ujson.Value)])]]) = {
-    val evaluated: Results = evaluator.evaluate(targets)
+    val evaluated: Results = evaluator.evaluate(targets, serialCommandExec = true)
 
     val watched = evaluated.results
       .iterator


### PR DESCRIPTION
Introduced a new `serialCommandExec` parameter in `Evaluator.evaluate` and added required binary compatibility shims.

Fix https://github.com/com-lihaoyi/mill/issues/3359
