### PR TITLE
Make Mill commands require named CLI parameters by default

### DIFF
--- a/example/depth/tasks/3-anonymous-tasks/build.sc
+++ b/example/depth/tasks/3-anonymous-tasks/build.sc
@@ -32,10 +32,10 @@ def printFileData(fileName: String) = T.command {
 > ./mill show helloFileData
 "Hello"
 
-> ./mill printFileData hello.txt
+> ./mill printFileData --file-name hello.txt
 Hello
 
-> ./mill printFileData world.txt
+> ./mill printFileData --file-name world.txt
 World!
 
 */

--- a/integration/failure/module-init-error/test/src/ModuleInitErrorTests.scala
+++ b/integration/failure/module-init-error/test/src/ModuleInitErrorTests.scala
@@ -53,7 +53,7 @@ object ModuleInitErrorTests extends IntegrationTestSuite {
     test("rootCommand") {
       // If we specify a target in the root module, we are not
       // affected by the sub-modules failing to initialize
-      val res = eval(("rootCommand", "hello"))
+      val res = eval(("rootCommand", "-s", "hello"))
       assert(res.isSuccess == true)
       assert(res.out.contains("""Running rootCommand hello"""))
     }
@@ -66,7 +66,7 @@ object ModuleInitErrorTests extends IntegrationTestSuite {
       assert(fansi.Str(res.err).plainText.linesIterator.size < 20)
     }
     test("fooCommand") {
-      val res = eval(("foo.fooCommand", "hello"))
+      val res = eval(("foo.fooCommand", "-s", "hello"))
       assert(res.isSuccess == false)
       assert(fansi.Str(res.err).plainText.contains("""java.lang.Exception: Foo Boom"""))
       assert(fansi.Str(res.err).plainText.linesIterator.size < 20)
@@ -77,7 +77,7 @@ object ModuleInitErrorTests extends IntegrationTestSuite {
       assert(res.out.contains("""Running barTarget"""))
     }
     test("barCommand") {
-      val res = eval(("bar.barCommand", "hello"))
+      val res = eval(("bar.barCommand", "-s", "hello"))
       assert(res.isSuccess == true)
       assert(res.out.contains("""Running barCommand hello"""))
     }
@@ -88,7 +88,7 @@ object ModuleInitErrorTests extends IntegrationTestSuite {
       assert(fansi.Str(res.err).plainText.linesIterator.size < 20)
     }
     test("quxCommand") {
-      val res = eval(("bar.qux.quxCommand", "hello"))
+      val res = eval(("bar.qux.quxCommand", "-s", "hello"))
       assert(res.isSuccess == false)
       assert(fansi.Str(res.err).plainText.contains("""java.lang.Exception: Qux Boom"""))
       assert(fansi.Str(res.err).plainText.linesIterator.size < 20)

--- a/main/eval/src/mill/eval/Evaluator.scala
+++ b/main/eval/src/mill/eval/Evaluator.scala
@@ -33,7 +33,7 @@ trait Evaluator {
 
   def withBaseLogger(newBaseLogger: ColorLogger): Evaluator
   def withFailFast(newFailFast: Boolean): Evaluator
-  def allowPositionalCommandArgs: Boolean
+  def allowPositionalCommandArgs: Boolean = false
   def plan(goals: Agg[Task[_]]): (MultiBiMap[Terminal, Task[_]], Agg[Task[_]])
 
   /**

--- a/main/eval/src/mill/eval/Evaluator.scala
+++ b/main/eval/src/mill/eval/Evaluator.scala
@@ -33,7 +33,7 @@ trait Evaluator {
 
   def withBaseLogger(newBaseLogger: ColorLogger): Evaluator
   def withFailFast(newFailFast: Boolean): Evaluator
-
+  def allowPositionalCommandArgs: Boolean
   def plan(goals: Agg[Task[_]]): (MultiBiMap[Terminal, Task[_]], Agg[Task[_]])
 
   /**

--- a/main/eval/src/mill/eval/EvaluatorImpl.scala
+++ b/main/eval/src/mill/eval/EvaluatorImpl.scala
@@ -28,7 +28,7 @@ private[mill] case class EvaluatorImpl(
     scriptImportGraph: Map[os.Path, (Int, Seq[os.Path])] = Map.empty,
     methodCodeHashSignatures: Map[String, Int],
     override val disableCallgraphInvalidation: Boolean,
-    allowPositionalCommandArgs: Boolean
+    override val allowPositionalCommandArgs: Boolean
 ) extends Evaluator with EvaluatorCore {
   import EvaluatorImpl._
 

--- a/main/eval/src/mill/eval/EvaluatorImpl.scala
+++ b/main/eval/src/mill/eval/EvaluatorImpl.scala
@@ -27,7 +27,8 @@ private[mill] case class EvaluatorImpl(
     threadCount: Option[Int] = Some(1),
     scriptImportGraph: Map[os.Path, (Int, Seq[os.Path])] = Map.empty,
     methodCodeHashSignatures: Map[String, Int],
-    override val disableCallgraphInvalidation: Boolean
+    override val disableCallgraphInvalidation: Boolean,
+    allowPositionalCommandArgs: Boolean
 ) extends Evaluator with EvaluatorCore {
   import EvaluatorImpl._
 

--- a/main/resolve/src/mill/resolve/Resolve.scala
+++ b/main/resolve/src/mill/resolve/Resolve.scala
@@ -209,7 +209,7 @@ trait Resolve[T] {
       rootModule: BaseModule,
       scriptArgs: Seq[String],
       selectMode: SelectMode,
-      allowPositionalCommandArgs: Boolean
+      allowPositionalCommandArgs: Boolean = false
   ): Either[String, List[T]] = {
     resolve0(Seq(rootModule), scriptArgs, selectMode, allowPositionalCommandArgs)
   }
@@ -220,6 +220,13 @@ trait Resolve[T] {
       allowPositionalCommandArgs: Boolean
   ): Either[String, List[T]] = {
     resolve0(rootModules, scriptArgs, selectMode, allowPositionalCommandArgs)
+  }
+  def resolve(
+      rootModules: Seq[BaseModule],
+      scriptArgs: Seq[String],
+      selectMode: SelectMode,
+  ): Either[String, List[T]] = {
+    resolve0(rootModules, scriptArgs, selectMode, false)
   }
 
   private[mill] def resolve0(

--- a/main/resolve/src/mill/resolve/Resolve.scala
+++ b/main/resolve/src/mill/resolve/Resolve.scala
@@ -214,6 +214,13 @@ trait Resolve[T] {
     resolve0(Seq(rootModule), scriptArgs, selectMode, allowPositionalCommandArgs)
   }
   def resolve(
+      rootModule: BaseModule,
+      scriptArgs: Seq[String],
+      selectMode: SelectMode,
+  ): Either[String, List[T]] = {
+    resolve0(Seq(rootModule), scriptArgs, selectMode, false)
+  }
+  def resolve(
       rootModules: Seq[BaseModule],
       scriptArgs: Seq[String],
       selectMode: SelectMode,

--- a/main/resolve/src/mill/resolve/Resolve.scala
+++ b/main/resolve/src/mill/resolve/Resolve.scala
@@ -53,7 +53,14 @@ object Resolve {
           val instantiated = ResolveCore
             .instantiateModule0(baseModules, r.segments.init)
             .flatMap { case (mod, rootMod) =>
-              instantiateCommand(rootMod, r, mod, args, nullCommandDefaults, allowPositionalCommandArgs)
+              instantiateCommand(
+                rootMod,
+                r,
+                mod,
+                args,
+                nullCommandDefaults,
+                allowPositionalCommandArgs
+              )
             }
 
           instantiated.map(Some(_))
@@ -216,7 +223,7 @@ trait Resolve[T] {
   def resolve(
       rootModule: BaseModule,
       scriptArgs: Seq[String],
-      selectMode: SelectMode,
+      selectMode: SelectMode
   ): Either[String, List[T]] = {
     resolve0(Seq(rootModule), scriptArgs, selectMode, false)
   }
@@ -231,7 +238,7 @@ trait Resolve[T] {
   def resolve(
       rootModules: Seq[BaseModule],
       scriptArgs: Seq[String],
-      selectMode: SelectMode,
+      selectMode: SelectMode
   ): Either[String, List[T]] = {
     resolve0(rootModules, scriptArgs, selectMode, false)
   }
@@ -247,7 +254,13 @@ trait Resolve[T] {
       val resolved = groups.map { case (selectors, args) =>
         val selected = selectors.map { case (scopedSel, sel) =>
           resolveRootModule(baseModules, scopedSel).map { rootModuleSels =>
-            resolveNonEmptyAndHandle(args, rootModuleSels, sel, nullCommandDefaults, allowPositionalCommandArgs)
+            resolveNonEmptyAndHandle(
+              args,
+              rootModuleSels,
+              sel,
+              nullCommandDefaults,
+              allowPositionalCommandArgs
+            )
           }
         }
 
@@ -294,7 +307,14 @@ trait Resolve[T] {
 
     resolved
       .map(_.toSeq.sortBy(_.segments.render))
-      .flatMap(handleResolved(baseModules, _, args, sel, nullCommandDefaults, allowPositionalCommandArgs))
+      .flatMap(handleResolved(
+        baseModules,
+        _,
+        args,
+        sel,
+        nullCommandDefaults,
+        allowPositionalCommandArgs
+      ))
   }
 
   private[mill] def deduplicate(items: List[T]): List[T] = items

--- a/main/resolve/test/src/mill/main/ResolveTests.scala
+++ b/main/resolve/test/src/mill/main/ResolveTests.scala
@@ -52,7 +52,8 @@ object ResolveTests extends TestSuite {
       Resolve.Tasks.resolve0(
         Seq(module),
         selectorStrings,
-        SelectMode.Separated
+        SelectMode.Separated,
+        false
       )
     }
 
@@ -60,7 +61,8 @@ object ResolveTests extends TestSuite {
       Resolve.Segments.resolve0(
         Seq(module),
         selectorStrings,
-        SelectMode.Separated
+        SelectMode.Separated,
+        false
       ).map(_.map(_.render))
     }
   }

--- a/main/src/mill/main/MainModule.scala
+++ b/main/src/mill/main/MainModule.scala
@@ -125,7 +125,10 @@ trait MainModule extends BaseModule0 {
    * If there are multiple dependency paths between `src` and `dest`, the path
    * chosen is arbitrary.
    */
-  def path(evaluator: Evaluator, src: String, dest: String): Command[List[String]] =
+
+  def path(evaluator: Evaluator,
+           @mainargs.arg(positional = true) src: String,
+           @mainargs.arg(positional = true) dest: String): Command[List[String]] =
     Target.command {
       val resolved = Resolve.Tasks.resolve(
         evaluator.rootModules,

--- a/main/src/mill/main/MainModule.scala
+++ b/main/src/mill/main/MainModule.scala
@@ -28,7 +28,7 @@ object MainModule {
       evaluator: Evaluator,
       targets: Seq[String],
       log: Logger,
-      watch0: Watchable => Unit,
+      watch0: Watchable => Unit
   )(f: Seq[(Any, Option[(RunScript.TaskName, ujson.Value)])] => ujson.Value)
       : Result[ujson.Value] = {
 
@@ -126,9 +126,11 @@ trait MainModule extends BaseModule0 {
    * chosen is arbitrary.
    */
 
-  def path(evaluator: Evaluator,
-           @mainargs.arg(positional = true) src: String,
-           @mainargs.arg(positional = true) dest: String): Command[List[String]] =
+  def path(
+      evaluator: Evaluator,
+      @mainargs.arg(positional = true) src: String,
+      @mainargs.arg(positional = true) dest: String
+  ): Command[List[String]] =
     Target.command {
       val resolved = Resolve.Tasks.resolve(
         evaluator.rootModules,

--- a/main/src/mill/main/MainModule.scala
+++ b/main/src/mill/main/MainModule.scala
@@ -28,7 +28,7 @@ object MainModule {
       evaluator: Evaluator,
       targets: Seq[String],
       log: Logger,
-      watch0: Watchable => Unit
+      watch0: Watchable => Unit,
   )(f: Seq[(Any, Option[(RunScript.TaskName, ujson.Value)])] => ujson.Value)
       : Result[ujson.Value] = {
 

--- a/main/src/mill/main/RunScript.scala
+++ b/main/src/mill/main/RunScript.scala
@@ -15,13 +15,13 @@ object RunScript {
   def evaluateTasksNamed(
       evaluator: Evaluator,
       scriptArgs: Seq[String],
-      selectMode: SelectMode
+      selectMode: SelectMode,
   ): Either[
     String,
     (Seq[Watchable], Either[String, Seq[(Any, Option[(TaskName, ujson.Value)])]])
   ] = {
     val resolved = mill.eval.Evaluator.currentEvaluator.withValue(evaluator) {
-      Resolve.Tasks.resolve(evaluator.rootModules, scriptArgs, selectMode)
+      Resolve.Tasks.resolve(evaluator.rootModules, scriptArgs, selectMode, evaluator.allowPositionalCommandArgs)
     }
     for (targets <- resolved) yield evaluateNamed(evaluator, Agg.from(targets))
   }

--- a/main/src/mill/main/RunScript.scala
+++ b/main/src/mill/main/RunScript.scala
@@ -15,13 +15,18 @@ object RunScript {
   def evaluateTasksNamed(
       evaluator: Evaluator,
       scriptArgs: Seq[String],
-      selectMode: SelectMode,
+      selectMode: SelectMode
   ): Either[
     String,
     (Seq[Watchable], Either[String, Seq[(Any, Option[(TaskName, ujson.Value)])]])
   ] = {
     val resolved = mill.eval.Evaluator.currentEvaluator.withValue(evaluator) {
-      Resolve.Tasks.resolve(evaluator.rootModules, scriptArgs, selectMode, evaluator.allowPositionalCommandArgs)
+      Resolve.Tasks.resolve(
+        evaluator.rootModules,
+        scriptArgs,
+        selectMode,
+        evaluator.allowPositionalCommandArgs
+      )
     }
     for (targets <- resolved) yield evaluateNamed(evaluator, Agg.from(targets))
   }

--- a/main/test/src/mill/util/TestGraphs.scala
+++ b/main/test/src/mill/util/TestGraphs.scala
@@ -1,5 +1,6 @@
 package mill.util
 import TestUtil.test
+import mainargs.arg
 import mill.testkit.TestBaseModule
 import mill.define.{Command, Cross, Discover, DynamicModule, ModuleRef, TaskModule}
 import mill.{Module, T}
@@ -132,21 +133,21 @@ class TestGraphs() {
 
   object moduleInitError extends TestBaseModule {
     def rootTarget = T { println("Running rootTarget"); "rootTarget Result" }
-    def rootCommand(s: String) = T.command { println(s"Running rootCommand $s") }
+    def rootCommand(@arg(positional = true) s: String) = T.command { println(s"Running rootCommand $s") }
 
     object foo extends Module {
       def fooTarget = T { println(s"Running fooTarget"); 123 }
-      def fooCommand(s: String) = T.command { println(s"Running fooCommand $s") }
+      def fooCommand(@arg(positional = true) s: String) = T.command { println(s"Running fooCommand $s") }
       throw new Exception("Foo Boom")
     }
 
     object bar extends Module {
       def barTarget = T { println(s"Running barTarget"); "barTarget Result" }
-      def barCommand(s: String) = T.command { println(s"Running barCommand $s") }
+      def barCommand(@arg(positional = true) s: String) = T.command { println(s"Running barCommand $s") }
 
       object qux extends Module {
         def quxTarget = T { println(s"Running quxTarget"); "quxTarget Result" }
-        def quxCommand(s: String) = T.command { println(s"Running quxCommand $s") }
+        def quxCommand(@arg(positional = true) s: String) = T.command { println(s"Running quxCommand $s") }
         throw new Exception("Qux Boom")
       }
     }
@@ -158,7 +159,7 @@ class TestGraphs() {
 
     object foo extends Module {
       def fooTarget = T { println(s"Running fooTarget"); 123 }
-      def fooCommand(s: String) = T.command { println(s"Running fooCommand $s") }
+      def fooCommand(@arg(positional = true) s: String) = T.command { println(s"Running fooCommand $s") }
       throw new Exception("Foo Boom")
     }
 
@@ -167,7 +168,7 @@ class TestGraphs() {
         println(s"Running barTarget")
         s"${foo.fooTarget()} barTarget Result"
       }
-      def barCommand(s: String) = T.command {
+      def barCommand(@arg(positional = true) s: String) = T.command {
         foo.fooCommand(s)()
         println(s"Running barCommand $s")
       }
@@ -514,7 +515,7 @@ object TestGraphs {
       trait Cross2 extends mill.Cross.Module[String] with TaskModule {
         def platform = crossValue
         override def defaultCommandName(): String = "suffixCmd"
-        def suffixCmd(suffix: String = "default"): Command[String] = T.command {
+        def suffixCmd(@arg(positional = true) suffix: String = "default"): Command[String] = T.command {
           scalaVersion + "_" + platform + "_" + suffix
         }
       }

--- a/main/test/src/mill/util/TestGraphs.scala
+++ b/main/test/src/mill/util/TestGraphs.scala
@@ -133,21 +133,25 @@ class TestGraphs() {
 
   object moduleInitError extends TestBaseModule {
     def rootTarget = T { println("Running rootTarget"); "rootTarget Result" }
-    def rootCommand(@arg(positional = true) s: String) = T.command { println(s"Running rootCommand $s") }
+    def rootCommand(@arg(positional = true) s: String) =
+      T.command { println(s"Running rootCommand $s") }
 
     object foo extends Module {
       def fooTarget = T { println(s"Running fooTarget"); 123 }
-      def fooCommand(@arg(positional = true) s: String) = T.command { println(s"Running fooCommand $s") }
+      def fooCommand(@arg(positional = true) s: String) =
+        T.command { println(s"Running fooCommand $s") }
       throw new Exception("Foo Boom")
     }
 
     object bar extends Module {
       def barTarget = T { println(s"Running barTarget"); "barTarget Result" }
-      def barCommand(@arg(positional = true) s: String) = T.command { println(s"Running barCommand $s") }
+      def barCommand(@arg(positional = true) s: String) =
+        T.command { println(s"Running barCommand $s") }
 
       object qux extends Module {
         def quxTarget = T { println(s"Running quxTarget"); "quxTarget Result" }
-        def quxCommand(@arg(positional = true) s: String) = T.command { println(s"Running quxCommand $s") }
+        def quxCommand(@arg(positional = true) s: String) =
+          T.command { println(s"Running quxCommand $s") }
         throw new Exception("Qux Boom")
       }
     }
@@ -159,7 +163,8 @@ class TestGraphs() {
 
     object foo extends Module {
       def fooTarget = T { println(s"Running fooTarget"); 123 }
-      def fooCommand(@arg(positional = true) s: String) = T.command { println(s"Running fooCommand $s") }
+      def fooCommand(@arg(positional = true) s: String) =
+        T.command { println(s"Running fooCommand $s") }
       throw new Exception("Foo Boom")
     }
 
@@ -515,9 +520,10 @@ object TestGraphs {
       trait Cross2 extends mill.Cross.Module[String] with TaskModule {
         def platform = crossValue
         override def defaultCommandName(): String = "suffixCmd"
-        def suffixCmd(@arg(positional = true) suffix: String = "default"): Command[String] = T.command {
-          scalaVersion + "_" + platform + "_" + suffix
-        }
+        def suffixCmd(@arg(positional = true) suffix: String = "default"): Command[String] =
+          T.command {
+            scalaVersion + "_" + platform + "_" + suffix
+          }
       }
 
     }

--- a/readme.adoc
+++ b/readme.adoc
@@ -306,37 +306,37 @@ endif::[]
 === main
 
 * *Breaking Changes*
-  * Builds can now be modularized into per-folder definitions by defining
-  `module.sc` files in subfolders {link-pr}/3213[#3213]
+    * Builds can now be modularized into per-folder definitions by defining
+    `module.sc` files in subfolders {link-pr}/3213[#3213]
 
-  * Turn on parallelism for task evaluation by default, except for commands
-  which always run serially at the end {link-pr}/3265[#3265]
-  * This can be disabled by passing `--jobs 1`
+    * Turn on parallelism for task evaluation by default, except for commands
+    which always run serially at the end {link-pr}/3265[#3265]
+    * This can be disabled by passing `--jobs 1`
 
-  * Overhaul the Mill client-server protocol to improve robustness
-  {link-pr}/3363[#3363] {link-pr}/3366[#3366] {link-pr}/3368[#3368] {link-pr}/3370[#3370]
+    * Overhaul the Mill client-server protocol to improve robustness
+    {link-pr}/3363[#3363] {link-pr}/3366[#3366] {link-pr}/3368[#3368] {link-pr}/3370[#3370]
 
-  * Mill uses empty sandbox folders as the working directory for running its own code and
-  {link-pr}/3367[#3367] and test suites {link-pr}/3347[#3347], to avoid accidental interference
-  between tasks and tests due to parallelism
-  * This can be disabled by adding `def testSandboxWorkingDir = false` in your test module
+    * Mill uses empty sandbox folders as the working directory for running its own code and
+    {link-pr}/3367[#3367] and test suites {link-pr}/3347[#3347], to avoid accidental interference
+    between tasks and tests due to parallelism
+    * This can be disabled by adding `def testSandboxWorkingDir = false` in your test module
 
-  * Mill commands now require arguments to be passed named via `./mill mycommand --key value`, rather than
-    allowing just `./mill mycommand value`. {link-pr}/3431[#3431]. You can pass in
-    `--allow-positional-command-args` to fall back to the old behavior
+    * Mill commands now require arguments to be passed named via `./mill mycommand --key value`, rather than
+      allowing just `./mill mycommand value`. {link-pr}/3431[#3431]. You can pass in
+      `--allow-positional-command-args` to fall back to the old behavior
 
 * Other Changes
-  * Mill now publishes unit, integration, and example test fixtures for writing plugins {link-pr}/3398[#3398]
-  for downstream plugin authors to use in testing their own Mill extensions
-
-  * Bump default Sonatype Maven Central publishing timeouts to 10 minutes to avoid
-  timeouts due to slowness https://github.com/com-lihaoyi/mill/commit/b4c9386b0233fab53a312426715e226e4a7f6302
-
-  * Importing Mill projects into IntelliJ via BSP now properly marks the `out/`, `.idea/`, and `.bsp/` folders
-  as excluded {link-pr}/3329[#3329]
-
-  * Optimizations to Mill evaluation logic to reduce fixed overhead of running Mill
-  on large projects {link-pr}/3388[#3388]
+    * Mill now publishes unit, integration, and example test fixtures for writing plugins {link-pr}/3398[#3398]
+    for downstream plugin authors to use in testing their own Mill extensions
+   
+    * Bump default Sonatype Maven Central publishing timeouts to 10 minutes to avoid
+    timeouts due to slowness https://github.com/com-lihaoyi/mill/commit/b4c9386b0233fab53a312426715e226e4a7f6302
+   
+    * Importing Mill projects into IntelliJ via BSP now properly marks the `out/`, `.idea/`, and `.bsp/` folders
+    as excluded {link-pr}/3329[#3329]
+   
+    * Optimizations to Mill evaluation logic to reduce fixed overhead of running Mill
+    on large projects {link-pr}/3388[#3388]
 
 
 [#0-11-12]

--- a/readme.adoc
+++ b/readme.adoc
@@ -308,6 +308,9 @@ endif::[]
 * *Breaking Changes*
 ** Builds can now be modularized into per-folder definitions by defining
 `module.sc` files in subfolders {link-pr}/3213[#3213]
+*** This change removes the ability to define targets and modules in arbitrary scripts that
+you `import $file`. All targets and modules need to be moved to `module.sc` files in each
+subfolder
 
 ** Turn on parallelism for task evaluation by default, except for commands
 which always run serially at the end {link-pr}/3265[#3265]

--- a/readme.adoc
+++ b/readme.adoc
@@ -306,37 +306,43 @@ endif::[]
 === main
 
 * *Breaking Changes*
-    * Builds can now be modularized into per-folder definitions by defining
-    `module.sc` files in subfolders {link-pr}/3213[#3213]
+** Builds can now be modularized into per-folder definitions by defining
+`module.sc` files in subfolders {link-pr}/3213[#3213]
 
-    * Turn on parallelism for task evaluation by default, except for commands
-    which always run serially at the end {link-pr}/3265[#3265]
-    * This can be disabled by passing `--jobs 1`
+** Turn on parallelism for task evaluation by default, except for commands
+which always run serially at the end {link-pr}/3265[#3265]
 
-    * Overhaul the Mill client-server protocol to improve robustness
-    {link-pr}/3363[#3363] {link-pr}/3366[#3366] {link-pr}/3368[#3368] {link-pr}/3370[#3370]
+*** This can be disabled by passing `--jobs 1`
 
-    * Mill uses empty sandbox folders as the working directory for running its own code and
-    {link-pr}/3367[#3367] and test suites {link-pr}/3347[#3347], to avoid accidental interference
-    between tasks and tests due to parallelism
-    * This can be disabled by adding `def testSandboxWorkingDir = false` in your test module
+** Mill uses empty sandbox folders as the working directory for running its own code and
+{link-pr}/3367[#3367] and test suites {link-pr}/3347[#3347], to avoid accidental interference
+between tasks and tests due to parallelism
 
-    * Mill commands now require arguments to be passed named via `./mill mycommand --key value`, rather than
-      allowing just `./mill mycommand value`. {link-pr}/3431[#3431]. You can pass in
-      `--allow-positional-command-args` to fall back to the old behavior
+*** This can be disabled by adding `def testSandboxWorkingDir = false` in your test module
+
+** Mill commands now require arguments to be passed named via `./mill mycommand --key value`, rather than
+  allowing just `./mill mycommand value`. {link-pr}/3431[#3431].
+
+*** You can pass in
+  `--allow-positional-command-args` to fall back to the old behavior
 
 * Other Changes
-    * Mill now publishes unit, integration, and example test fixtures for writing plugins {link-pr}/3398[#3398]
-    for downstream plugin authors to use in testing their own Mill extensions
-   
-    * Bump default Sonatype Maven Central publishing timeouts to 10 minutes to avoid
-    timeouts due to slowness https://github.com/com-lihaoyi/mill/commit/b4c9386b0233fab53a312426715e226e4a7f6302
-   
-    * Importing Mill projects into IntelliJ via BSP now properly marks the `out/`, `.idea/`, and `.bsp/` folders
-    as excluded {link-pr}/3329[#3329]
-   
-    * Optimizations to Mill evaluation logic to reduce fixed overhead of running Mill
-    on large projects {link-pr}/3388[#3388]
+
+** Overhaul the Mill client-server protocol to improve robustness
+{link-pr}/3363[#3363] {link-pr}/3366[#3366] {link-pr}/3368[#3368] {link-pr}/3370[#3370]
+
+
+** Mill now publishes unit, integration, and example test fixtures for writing plugins {link-pr}/3398[#3398]
+for downstream plugin authors to use in testing their own Mill extensions
+
+** Bump default Sonatype Maven Central publishing timeouts to 10 minutes to avoid
+timeouts due to slowness https://github.com/com-lihaoyi/mill/commit/b4c9386b0233fab53a312426715e226e4a7f6302
+
+** Importing Mill projects into IntelliJ via BSP now properly marks the `out/`, `.idea/`, and `.bsp/` folders
+as excluded {link-pr}/3329[#3329]
+
+** Optimizations to Mill evaluation logic to reduce fixed overhead of running Mill
+on large projects {link-pr}/3388[#3388]
 
 
 [#0-11-12]

--- a/readme.adoc
+++ b/readme.adoc
@@ -305,32 +305,39 @@ endif::[]
 [#main] branch
 === main
 
-* Builds can now be modularized into per-folder definitions by defining
-`module.sc` files in subfolders {link-pr}/3213[#3213]
+* *Breaking Changes*
+  * Builds can now be modularized into per-folder definitions by defining
+  `module.sc` files in subfolders {link-pr}/3213[#3213]
 
-* Turn on parallelism for task evaluation by default, except for commands
-which always run serially at the end {link-pr}/3265[#3265]
-* This can be disabled by passing `--jobs 1`
+  * Turn on parallelism for task evaluation by default, except for commands
+  which always run serially at the end {link-pr}/3265[#3265]
+  * This can be disabled by passing `--jobs 1`
 
-* Overhaul the Mill client-server protocol to improve robustness
-{link-pr}/3363[#3363] {link-pr}/3366[#3366] {link-pr}/3368[#3368] {link-pr}/3370[#3370]
+  * Overhaul the Mill client-server protocol to improve robustness
+  {link-pr}/3363[#3363] {link-pr}/3366[#3366] {link-pr}/3368[#3368] {link-pr}/3370[#3370]
 
-* Mill uses empty sandbox folders as the working directory for running its own code and
-{link-pr}/3367[#3367] and test suites {link-pr}/3347[#3347], to avoid accidental interference
-between tasks and tests due to parallelism
-* This can be disabled by adding `def testSandboxWorkingDir = false` in your test module
+  * Mill uses empty sandbox folders as the working directory for running its own code and
+  {link-pr}/3367[#3367] and test suites {link-pr}/3347[#3347], to avoid accidental interference
+  between tasks and tests due to parallelism
+  * This can be disabled by adding `def testSandboxWorkingDir = false` in your test module
 
-* Mill now publishes unit, integration, and example test fixtures for writing plugins {link-pr}/3398[#3398]
-for downstream plugin authors to use in testing their own Mill extensions
+  * Mill commands now require arguments to be passed named via `./mill mycommand --key value`, rather than
+    allowing just `./mill mycommand value`. {link-pr}/3431[#3431]. You can pass in
+    `--allow-positional-command-args` to fall back to the old behavior
 
-* Bump default Sonatype Maven Central publishing timeouts to 10 minutes to avoid
-timeouts due to slowness https://github.com/com-lihaoyi/mill/commit/b4c9386b0233fab53a312426715e226e4a7f6302
+* Other Changes
+  * Mill now publishes unit, integration, and example test fixtures for writing plugins {link-pr}/3398[#3398]
+  for downstream plugin authors to use in testing their own Mill extensions
 
-* Importing Mill projects into IntelliJ via BSP now properly marks the `out/`, `.idea/`, and `.bsp/` folders
-as excluded {link-pr}/3329[#3329]
+  * Bump default Sonatype Maven Central publishing timeouts to 10 minutes to avoid
+  timeouts due to slowness https://github.com/com-lihaoyi/mill/commit/b4c9386b0233fab53a312426715e226e4a7f6302
 
-* Optimizations to Mill evaluation logic to reduce fixed overhead of running Mill
-on large projects {link-pr}/3388[#3388]
+  * Importing Mill projects into IntelliJ via BSP now properly marks the `out/`, `.idea/`, and `.bsp/` folders
+  as excluded {link-pr}/3329[#3329]
+
+  * Optimizations to Mill evaluation logic to reduce fixed overhead of running Mill
+  on large projects {link-pr}/3388[#3388]
+
 
 [#0-11-12]
 === 0.11.12 - 2024-08-20

--- a/readme.adoc
+++ b/readme.adoc
@@ -327,7 +327,8 @@ between tasks and tests due to parallelism
   allowing just `./mill mycommand value`. {link-pr}/3431[#3431].
 
 *** You can pass in
-  `--allow-positional-command-args` to fall back to the old behavior
+  `--allow-positional-command-args` to fall back to the old behavior, or use `@mainargs.arg(positional = true)`
+  on individual parameters
 
 * Other Changes
 

--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -39,7 +39,8 @@ class MillBuildBootstrap(
     logger: ColorLogger,
     disableCallgraphInvalidation: Boolean,
     needBuildSc: Boolean,
-    requestedMetaLevel: Option[Int]
+    requestedMetaLevel: Option[Int],
+    allowPositionalCommandArgs: Boolean
 ) {
   import MillBuildBootstrap._
 
@@ -362,7 +363,8 @@ class MillBuildBootstrap(
       threadCount = threadCount,
       scriptImportGraph = scriptImportGraph,
       methodCodeHashSignatures = methodCodeHashSignatures,
-      disableCallgraphInvalidation = disableCallgraphInvalidation
+      disableCallgraphInvalidation = disableCallgraphInvalidation,
+      allowPositionalCommandArgs = allowPositionalCommandArgs
     )
   }
 
@@ -403,7 +405,7 @@ object MillBuildBootstrap {
   def evaluateWithWatches(
       rootModules: Seq[BaseModule],
       evaluator: Evaluator,
-      targetsAndParams: Seq[String]
+      targetsAndParams: Seq[String],
   ): (Either[String, Seq[Any]], Seq[Watchable], Seq[Watchable]) = {
     rootModules.foreach(_.evalWatchedValues.clear())
     val evalTaskResult =

--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -405,7 +405,7 @@ object MillBuildBootstrap {
   def evaluateWithWatches(
       rootModules: Seq[BaseModule],
       evaluator: Evaluator,
-      targetsAndParams: Seq[String],
+      targetsAndParams: Seq[String]
   ): (Either[String, Seq[Any]], Seq[Watchable], Seq[Watchable]) = {
     rootModules.foreach(_.evalWatchedValues.clear())
     val evalTaskResult =

--- a/runner/src/mill/runner/MillCliConfig.scala
+++ b/runner/src/mill/runner/MillCliConfig.scala
@@ -127,7 +127,7 @@ class MillCliConfig private (
       doc =
         """"""
     )
-    val allowPositionalCommandArgs: Flag,
+    val allowPositionalCommandArgs: Flag
 ) {
   override def toString: String = Seq(
     "home" -> home,
@@ -151,7 +151,7 @@ class MillCliConfig private (
     "color" -> color,
     "disableCallgraphInvalidation" -> disableCallgraphInvalidation,
     "metaLevel" -> metaLevel,
-    "allowPositionalCommandArgs" -> allowPositionalCommandArgs,
+    "allowPositionalCommandArgs" -> allowPositionalCommandArgs
   ).map(p => s"${p._1}=${p._2}").mkString(getClass().getSimpleName + "(", ",", ")")
 }
 

--- a/runner/src/mill/runner/MillCliConfig.scala
+++ b/runner/src/mill/runner/MillCliConfig.scala
@@ -122,7 +122,12 @@ class MillCliConfig private (
            Level 0 is the normal project, level 1 the first meta-build, and so on.
            The last level is the built-in synthetic meta-build which Mill uses to bootstrap the project."""
     )
-    val metaLevel: Option[Int]
+    val metaLevel: Option[Int],
+    @arg(
+      doc =
+        """"""
+    )
+    val allowPositionalCommandArgs: Flag,
 ) {
   override def toString: String = Seq(
     "home" -> home,
@@ -145,7 +150,8 @@ class MillCliConfig private (
     "leftoverArgs" -> leftoverArgs,
     "color" -> color,
     "disableCallgraphInvalidation" -> disableCallgraphInvalidation,
-    "metaLevel" -> metaLevel
+    "metaLevel" -> metaLevel,
+    "allowPositionalCommandArgs" -> allowPositionalCommandArgs,
   ).map(p => s"${p._1}=${p._2}").mkString(getClass().getSimpleName + "(", ",", ")")
 }
 
@@ -202,7 +208,8 @@ object MillCliConfig {
     leftoverArgs = leftoverArgs,
     color = color,
     disableCallgraphInvalidation,
-    metaLevel = metaLevel
+    metaLevel = metaLevel,
+    allowPositionalCommandArgs = Flag()
   )
 
   @deprecated("Bin-compat shim", "Mill after 0.11.0")

--- a/runner/src/mill/runner/MillCliConfig.scala
+++ b/runner/src/mill/runner/MillCliConfig.scala
@@ -186,7 +186,56 @@ object MillCliConfig {
       leftoverArgs: Leftover[String] = Leftover(),
       color: Option[Boolean] = None,
       disableCallgraphInvalidation: Flag = Flag(),
-      metaLevel: Option[Int] = None
+      metaLevel: Option[Int] = None,
+      allowPositionalCommandArgs: Flag = Flag()
+  ): MillCliConfig = new MillCliConfig(
+    home = home,
+    repl = repl,
+    noServer = noServer,
+    bsp = bsp,
+    showVersion = showVersion,
+    ringBell = ringBell,
+    disableTicker = disableTicker,
+    enableTicker = enableTicker,
+    debugLog = debugLog,
+    keepGoing = keepGoing,
+    extraSystemProperties = extraSystemProperties,
+    threadCountRaw = threadCountRaw,
+    imports = imports,
+    interactive = interactive,
+    help = help,
+    watch = watch,
+    silent = silent,
+    leftoverArgs = leftoverArgs,
+    color = color,
+    disableCallgraphInvalidation,
+    metaLevel = metaLevel,
+    allowPositionalCommandArgs = allowPositionalCommandArgs
+  )
+  @deprecated("Bin-compat shim", "Mill after 0.11.12")
+  def apply(
+      home: os.Path,
+      @deprecated("No longer supported.", "Mill 0.11.0-M8")
+      repl: Flag,
+      noServer: Flag,
+      bsp: Flag,
+      showVersion: Flag,
+      ringBell: Flag,
+      disableTicker: Flag,
+      enableTicker: Option[Boolean],
+      debugLog: Flag,
+      keepGoing: Flag,
+      extraSystemProperties: Map[String, String],
+      threadCountRaw: Option[Int],
+      imports: Seq[String],
+      interactive: Flag,
+      help: Flag,
+      watch: Flag,
+      silent: Flag,
+      leftoverArgs: Leftover[String],
+      color: Option[Boolean],
+      disableCallgraphInvalidation: Flag,
+      metaLevel: Option[Int]
   ): MillCliConfig = new MillCliConfig(
     home = home,
     repl = repl,

--- a/runner/src/mill/runner/MillMain.scala
+++ b/runner/src/mill/runner/MillMain.scala
@@ -231,7 +231,8 @@ object MillMain {
                       logger = logger,
                       disableCallgraphInvalidation = config.disableCallgraphInvalidation.value,
                       needBuildSc = needBuildSc(config),
-                      requestedMetaLevel = config.metaLevel
+                      requestedMetaLevel = config.metaLevel,
+                      config.allowPositionalCommandArgs.value
                     ).evaluate()
                   }
                 )

--- a/testkit/src/mill/testkit/UnitTester.scala
+++ b/testkit/src/mill/testkit/UnitTester.scala
@@ -99,7 +99,8 @@ class UnitTester(
     threadCount = threads,
     env = env,
     methodCodeHashSignatures = Map(),
-    disableCallgraphInvalidation = false
+    disableCallgraphInvalidation = false,
+    allowPositionalCommandArgs = false
   )
 
   def apply(args: String*): Either[Result.Failing[_], UnitTester.Result[Seq[_]]] = {


### PR DESCRIPTION
This aligns the semantics with MainArgs library defaults. Previously we grandfathered in the "positional by default" behavior because Mill pre-dates mainargs, with original behavior inherited from Ammonite. But most CLIs do not allow keyword args to be naively replaced by positional args, and MainArgs thus chose to have such behavior as opt-in. Mill should follow suite

Added a flag `--allow-positional-command-args` to fall back to the old behavior, and covered this behavior with example tests, docs, and updated the changelog.

This is a binary-compatible but semantically-incompatible change, so it should go into 0.12.0. It's a pretty painful breaking change, but it's definitely the right thing to do long term, so better to get it over with. People can also add `--allow-positional-command-args` to their `./mill` file if they want to preserve the old behavior in perpetuity