### PR TITLE
Mark `reformatAll`/`checkReformatAll`/`runMain` arguments as positional

### DIFF
--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -1,7 +1,7 @@
 package mill
 package scalajslib
 
-import mainargs.Flag
+import mainargs.{Flag, arg}
 import mill.api.{Loose, PathRef, Result, internal}
 import mill.scalalib.api.ZincWorkerUtil
 import mill.scalalib.Lib.resolveDependencies
@@ -163,13 +163,17 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
 
   }
 
-  override def runMainLocal(mainClass: String, args: String*): Command[Unit] = T.command[Unit] {
+  override def runMainLocal(
+      @arg(positional = true) mainClass: String,
+      args: String*
+  ): Command[Unit] = T.command[Unit] {
     mill.api.Result.Failure("runMain is not supported in Scala.js")
   }
 
-  override def runMain(mainClass: String, args: String*): Command[Unit] = T.command[Unit] {
-    mill.api.Result.Failure("runMain is not supported in Scala.js")
-  }
+  override def runMain(@arg(positional = true) mainClass: String, args: String*): Command[Unit] =
+    T.command[Unit] {
+      mill.api.Result.Failure("runMain is not supported in Scala.js")
+    }
 
   private[scalajslib] def linkJs(
       worker: ScalaJSWorker,

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -7,7 +7,7 @@ import coursier.core.Resolution
 import coursier.parse.JavaOrScalaModule
 import coursier.parse.ModuleParser
 import coursier.util.ModuleMatcher
-import mainargs.Flag
+import mainargs.{Flag, arg}
 import mill.Agg
 import mill.api.{Ctx, JarManifest, MillException, PathRef, Result, internal}
 import mill.define.{Command, ModuleRef, Segment, Task, TaskModule}
@@ -950,7 +950,10 @@ trait JavaModule
   /**
    * Same as `runBackground`, but lets you specify a main class to run
    */
-  override def runMainBackground(mainClass: String, args: String*): Command[Unit] = {
+  override def runMainBackground(
+      @arg(positional = true) mainClass: String,
+      args: String*
+  ): Command[Unit] = {
     // overridden here for binary compatibility (0.11.x)
     super.runMainBackground(mainClass, args: _*)
   }
@@ -958,7 +961,10 @@ trait JavaModule
   /**
    * Same as `runLocal`, but lets you specify a main class to run
    */
-  override def runMainLocal(mainClass: String, args: String*): Command[Unit] = {
+  override def runMainLocal(
+      @arg(positional = true) mainClass: String,
+      args: String*
+  ): Command[Unit] = {
     // overridden here for binary compatibility (0.11.x)
     super.runMainLocal(mainClass, args: _*)
   }
@@ -966,7 +972,7 @@ trait JavaModule
   /**
    * Same as `run`, but lets you specify a main class to run
    */
-  override def runMain(mainClass: String, args: String*): Command[Unit] = {
+  override def runMain(@arg(positional = true) mainClass: String, args: String*): Command[Unit] = {
     // overridden here for binary compatibility (0.11.x)
     super.runMain(mainClass, args: _*)
   }

--- a/scalalib/src/mill/scalalib/RunModule.scala
+++ b/scalalib/src/mill/scalalib/RunModule.scala
@@ -1,5 +1,6 @@
 package mill.scalalib
 
+import mainargs.arg
 import mill.api.JsonFormatters.pathReadWrite
 import mill.api.{Ctx, PathRef, Result}
 import mill.define.{Command, Task}
@@ -95,7 +96,7 @@ trait RunModule extends WithZincWorker {
   /**
    * Same as `run`, but lets you specify a main class to run
    */
-  def runMain(mainClass: String, args: String*): Command[Unit] = {
+  def runMain(@arg(positional = true) mainClass: String, args: String*): Command[Unit] = {
     val task = runForkedTask(T.task { mainClass }, T.task { Args(args) })
     T.command { task }
   }
@@ -103,7 +104,7 @@ trait RunModule extends WithZincWorker {
   /**
    * Same as `runBackground`, but lets you specify a main class to run
    */
-  def runMainBackground(mainClass: String, args: String*): Command[Unit] = {
+  def runMainBackground(@arg(positional = true) mainClass: String, args: String*): Command[Unit] = {
     val task = runBackgroundTask(T.task { mainClass }, T.task { Args(args) })
     T.command { task }
   }
@@ -111,7 +112,7 @@ trait RunModule extends WithZincWorker {
   /**
    * Same as `runLocal`, but lets you specify a main class to run
    */
-  def runMainLocal(mainClass: String, args: String*): Command[Unit] = {
+  def runMainLocal(@arg(positional = true) mainClass: String, args: String*): Command[Unit] = {
     val task = runLocalTask(T.task { mainClass }, T.task { Args(args) })
     T.command { task }
   }

--- a/scalalib/src/mill/scalalib/scalafmt/ScalafmtModule.scala
+++ b/scalalib/src/mill/scalalib/scalafmt/ScalafmtModule.scala
@@ -81,7 +81,8 @@ object ScalafmtModule extends ExternalModule with ScalafmtModule {
         )
     }
 
-  def checkFormatAll(@arg(positional = true) sources: mill.main.Tasks[Seq[PathRef]]): Command[Unit] =
+  def checkFormatAll(@arg(positional = true) sources: mill.main.Tasks[Seq[PathRef]])
+      : Command[Unit] =
     T.command {
       val files = T.sequence(sources.value)().flatMap(filesToFormat)
       ScalafmtWorkerModule

--- a/scalalib/src/mill/scalalib/scalafmt/ScalafmtModule.scala
+++ b/scalalib/src/mill/scalalib/scalafmt/ScalafmtModule.scala
@@ -5,6 +5,7 @@ import mill.main.client.CodeGenConstants.buildFileExtensions
 import mill.api.Result
 import mill.define.{ExternalModule, Discover}
 import mill.scalalib._
+import mainargs.arg
 
 trait ScalafmtModule extends JavaModule {
 
@@ -69,7 +70,7 @@ trait ScalafmtModule extends JavaModule {
 
 object ScalafmtModule extends ExternalModule with ScalafmtModule {
 
-  def reformatAll(sources: mill.main.Tasks[Seq[PathRef]]): Command[Unit] =
+  def reformatAll(@arg(positional = true) sources: mill.main.Tasks[Seq[PathRef]]): Command[Unit] =
     T.command {
       val files = T.sequence(sources.value)().flatMap(filesToFormat)
       ScalafmtWorkerModule
@@ -80,7 +81,7 @@ object ScalafmtModule extends ExternalModule with ScalafmtModule {
         )
     }
 
-  def checkFormatAll(sources: mill.main.Tasks[Seq[PathRef]]): Command[Unit] =
+  def checkFormatAll(@arg(positional = true) sources: mill.main.Tasks[Seq[PathRef]]): Command[Unit] =
     T.command {
       val files = T.sequence(sources.value)().flatMap(filesToFormat)
       ScalafmtWorkerModule


### PR DESCRIPTION
These are commands that probably do not expect named params that I found in a cursory audit, that would otherwise be broken by https://github.com/com-lihaoyi/mill/pull/3431. We can annotate others as we find them