### PR TITLE
Be stricter about requiring `build.` prefix for cross-`package.mill`-file references

### DIFF
--- a/integration/failure/root-subfolder-module-collision/test/src/RootSubfolderModuleCollisionTests.scala
+++ b/integration/failure/root-subfolder-module-collision/test/src/RootSubfolderModuleCollisionTests.scala
@@ -11,7 +11,7 @@ object RootSubfolderModuleCollisionTests extends IntegrationTestSuite {
     test("success") {
       val res = eval(("resolve", "_"))
       assert(res.isSuccess == false)
-      assert(res.err.contains("sub is already defined as object sub"))
+      assert(res.err.contains("cannot override final member"))
       assert(res.err.contains(
         " final lazy val sub: _root_.build_.sub.package_.type = _root_.build_.sub.package_ // subfolder module referenc"
       ))

--- a/integration/failure/subfolder-missing-build-prefix/repo/build.mill
+++ b/integration/failure/subfolder-missing-build-prefix/repo/build.mill
@@ -1,0 +1,4 @@
+package build
+import mill._
+
+val x = sub.y

--- a/integration/failure/subfolder-missing-build-prefix/repo/sub/package.mill
+++ b/integration/failure/subfolder-missing-build-prefix/repo/sub/package.mill
@@ -1,0 +1,6 @@
+package build.sub
+
+import mill._
+object `package` extends RootModule{
+  def y = 1
+}

--- a/integration/failure/subfolder-missing-build-prefix/test/src/SubfolderMissingBuildPrefix.scala
+++ b/integration/failure/subfolder-missing-build-prefix/test/src/SubfolderMissingBuildPrefix.scala
@@ -1,0 +1,17 @@
+package mill.integration
+
+import mill.testkit.IntegrationTestSuite
+
+import utest._
+
+object SubfolderMissingBuildPrefix extends IntegrationTestSuite {
+  val tests: Tests = Tests {
+    initWorkspace()
+
+    test("success") {
+      val res = eval(("resolve", "_"))
+      assert(res.isSuccess == false)
+      assert(res.err.contains("object y is not a member of package build_.sub"))
+    }
+  }
+}

--- a/integration/ide/bsp-modules/repo/build.mill
+++ b/integration/ide/bsp-modules/repo/build.mill
@@ -14,7 +14,7 @@ object HelloBsp extends HelloBspModule {
   // Explicitly depends on proj2
   def compileModuleDeps: Seq[JavaModule] = Seq(build.proj2)
   // Implicitly depends on proj3 via a target
-  override def unmanagedClasspath: T[Agg[PathRef]] = T Agg(build.proj3.jar())
+  override def unmanagedClasspath: T[Agg[PathRef]] = Agg(build.proj3.jar())
 }
 
 def validate() = T.command {

--- a/integration/ide/bsp-modules/repo/build.mill
+++ b/integration/ide/bsp-modules/repo/build.mill
@@ -10,13 +10,11 @@ trait HelloBspModule extends ScalaModule {
 
 object HelloBsp extends HelloBspModule {
   // Explicitly depends on proj1
-  def moduleDeps: Seq[JavaModule] = Seq(proj1)
+  def moduleDeps: Seq[JavaModule] = Seq(build.proj1)
   // Explicitly depends on proj2
-  def compileModuleDeps: Seq[JavaModule] = Seq(proj2)
+  def compileModuleDeps: Seq[JavaModule] = Seq(build.proj2)
   // Implicitly depends on proj3 via a target
-  override def unmanagedClasspath: T[Agg[PathRef]] = T {
-    Agg(proj3.jar())
-  }
+  override def unmanagedClasspath: T[Agg[PathRef]] = T Agg(build.proj3.jar())
 }
 
 def validate() = T.command {

--- a/integration/invalidation/invalidation/repo/build.mill
+++ b/integration/invalidation/invalidation/repo/build.mill
@@ -4,31 +4,31 @@ import mill._
 import $ivy.`org.scalaj::scalaj-http:2.4.2`
 
 def task = T {
-  a.input()
-  b.input()
-  c.input()
+  build.a.input()
+  build.b.input()
+  build.c.input()
 }
 
 object module extends Module {
   def task = T {
     println("task")
-    a.input()
-    b.input()
-    c.input()
+    build.a.input()
+    build.b.input()
+    build.c.input()
   }
 }
 
 def taskE = T {
   println("taskE")
-  e.input()
+  build.e.input()
 }
 
 def taskSymbols = T {
   println("taskSymbols")
-  `-#!+→&%=~`.input()
+  build.`-#!+→&%=~`.input()
 }
 
 def taskSymbolsInFile = T {
   println("taskSymbolsInFile")
-  `-#+&%`.input()
+  build.`-#+&%`.input()
 }

--- a/runner/src/mill/runner/CodeGen.scala
+++ b/runner/src/mill/runner/CodeGen.scala
@@ -183,7 +183,7 @@ object CodeGen {
   def topBuildPrelude(
       scriptFolderPath: os.Path,
       enclosingClasspath: Seq[os.Path],
-      millTopLevelProjectRoot: os.Path,
+      millTopLevelProjectRoot: os.Path
   ): String = {
     s"""import _root_.mill.runner.MillBuildRootModule
        |@_root_.scala.annotation.nowarn
@@ -217,8 +217,8 @@ object CodeGen {
     // User code needs to be put in a separate class for proper submodule
     // object initialization due to https://github.com/scala/scala3/issues/21444
     s"""object $wrapperObjectName extends $wrapperObjectName{
-        |  $childAliases
-        |}
+       |  $childAliases
+       |}
        |class $wrapperObjectName $extendsClause {""".stripMargin
 
   }

--- a/runner/src/mill/runner/CodeGen.scala
+++ b/runner/src/mill/runner/CodeGen.scala
@@ -124,8 +124,7 @@ object CodeGen {
     val prelude = topBuildPrelude(
       scriptFolderPath,
       enclosingClasspath,
-      millTopLevelProjectRoot,
-      childAliases
+      millTopLevelProjectRoot
     )
     val segments = scriptFolderPath.relativeTo(projectRoot).segments
     val instrument = new ObjectDataInstrument(scriptCode)
@@ -173,12 +172,9 @@ object CodeGen {
         s"""$pkgLine
            |$aliasImports
            |$prelude
-           |${topBuildHeader(segments, scriptFolderPath, millTopLevelProjectRoot)}
+           |${topBuildHeader(segments, scriptFolderPath, millTopLevelProjectRoot, childAliases)}
            |$markerComment
            |$scriptCode
-           |// define this after user code so in case of conflict these lines are what turn
-           |// up in the error message, so we can add a comment and control what the user sees
-           |$childAliases
            |}""".stripMargin
 
     }
@@ -188,7 +184,6 @@ object CodeGen {
       scriptFolderPath: os.Path,
       enclosingClasspath: Seq[os.Path],
       millTopLevelProjectRoot: os.Path,
-      childAliases: String
   ): String = {
     s"""import _root_.mill.runner.MillBuildRootModule
        |@_root_.scala.annotation.nowarn
@@ -197,12 +192,7 @@ object CodeGen {
        |  ${literalize(scriptFolderPath.toString)},
        |  ${literalize(millTopLevelProjectRoot.toString)},
        |  _root_.mill.define.Discover[$wrapperObjectName.type]
-       |){
-       |  // aliases so child modules can be referred to directly as `foo` rather
-       |  // than `foo.module`. Need to be outside `MillPackageClass` in case they are
-       |  // referenced in the combined `extends` clause
-       |  $childAliases
-       |}
+       |)
        |import MillMiscInfo._
        |""".stripMargin
   }
@@ -210,7 +200,8 @@ object CodeGen {
   def topBuildHeader(
       segs: Seq[String],
       scriptFolderPath: os.Path,
-      millTopLevelProjectRoot: os.Path
+      millTopLevelProjectRoot: os.Path,
+      childAliases: String
   ): String = {
     val extendsClause = if (segs.isEmpty) {
       if (millTopLevelProjectRoot == scriptFolderPath) {
@@ -225,7 +216,9 @@ object CodeGen {
 
     // User code needs to be put in a separate class for proper submodule
     // object initialization due to https://github.com/scala/scala3/issues/21444
-    s"""object $wrapperObjectName extends $wrapperObjectName
+    s"""object $wrapperObjectName extends $wrapperObjectName{
+        |  $childAliases
+        |}
        |class $wrapperObjectName $extendsClause {""".stripMargin
 
   }


### PR DESCRIPTION
This ensures that IDEs can trace the execution since we pretend that everything lives in `package build`. Previously, if the `build.` prefix is elided, we get code that works but the IDE does the wrong thing. Now that code is a compile error and you need to use `build.` which the IDE can understand