### PR TITLE
Remove unnecessary subfolder wrappers for integration tests

### DIFF
--- a/testkit/src/mill/testkit/IntegrationTesterBase.scala
+++ b/testkit/src/mill/testkit/IntegrationTesterBase.scala
@@ -2,18 +2,15 @@ package mill.testkit
 
 trait IntegrationTesterBase {
   def workspaceSourcePath: os.Path
-  private val workspacePathBase = os.pwd / "out" / "integration-tester-workdir"
-  os.makeDir.all(workspacePathBase)
 
   /**
    * The working directory of the integration test suite, which is the root of the
    * Mill build being tested. Contains the `build.mill` file, any application code, and
    * the `out/` folder containing the build output
    *
-   * Make sure it lives inside `os.pwd` because somehow the tests fail on windows
-   * if it lives in the global temp folder.
+   * Typically just `pwd`, which is a sandbox directory for test suites run using Mill.
    */
-  val workspacePath: os.Path = os.temp.dir(workspacePathBase, deleteOnExit = false)
+  val workspacePath: os.Path = os.pwd
 
   /**
    * Initializes the workspace in preparation for integration testing

--- a/testkit/src/mill/testkit/IntegrationTesterBase.scala
+++ b/testkit/src/mill/testkit/IntegrationTesterBase.scala
@@ -1,4 +1,5 @@
 package mill.testkit
+import mill.main.client.OutFiles.out
 
 trait IntegrationTesterBase {
   def workspaceSourcePath: os.Path
@@ -17,11 +18,8 @@ trait IntegrationTesterBase {
    */
   def initWorkspace(): Unit = {
     println(s"Copying integration test sources from $workspaceSourcePath to $workspacePath")
-    os.remove.all(workspacePath)
-    os.makeDir.all(workspacePath / os.up)
-    // somehow os.copy does not properly preserve symlinks
-    // os.copy(scriptSourcePath, workspacePath)
-    os.call(("cp", "-R", workspaceSourcePath, workspacePath))
+    os.list(workspacePath).foreach(os.remove.all(_))
+    os.list(workspaceSourcePath).filter(_.last != out).foreach(os.copy.into(_, workspacePath))
     os.remove.all(workspacePath / "out")
   }
 }


### PR DESCRIPTION
Since https://github.com/com-lihaoyi/mill/pull/3347 made all test suites run with `pwd` in the test's `.dest` folder by default, we are already guaranteed that different concurrent test suites will not collide, so we do not need the `out/blah/blah` segments to avoid conflicts