### PR TITLE
Rename `External Reference` to `Bundled Libraries`

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -72,6 +72,6 @@
 // *somewhere*.
 .Reference
 * xref:Mill_Design_Principles.adoc[]
-* xref:External_References.adoc[]
+* xref:Bundled_Libraries.adoc[]
 * {mill-doc-url}/api/latest/mill/index.html[Mill Scaladoc]
 * xref:Changelog.adoc[]

--- a/docs/modules/ROOT/pages/Bundled_Libraries.adoc
+++ b/docs/modules/ROOT/pages/Bundled_Libraries.adoc
@@ -41,7 +41,7 @@ ScalaDoc:: https://javadoc.io/doc/com.lihaoyi/requests_2.13/latest/index.html
 MainArgs is a small, dependency-free library for command line argument parsing
 in Scala.
 
-Mill uses MainArgs to handle argument parsing for `T.command`s that are run
+Mill uses MainArgs to handle argument parsing for ``T.command``s that are run
 from the command line.
 
 Project page:: https://github.com/com-lihaoyi/mainargs

--- a/docs/modules/ROOT/pages/Bundled_Libraries.adoc
+++ b/docs/modules/ROOT/pages/Bundled_Libraries.adoc
@@ -1,4 +1,6 @@
-= External References
+= Bundled Libraries
+
+:page-aliases: External_References.adoc
 
 Mill comes bundled with a set of external Open Source libraries and projects.
 


### PR DESCRIPTION
Since that's all there is on that page