### PR TITLE
Add ErrorProne plugin

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -731,6 +731,7 @@ object dist0 extends MillPublishJavaModule {
     build.contrib.jmh.testDep(),
     build.contrib.playlib.testDep(),
     build.contrib.playlib.worker("2.8").testDep(),
+    build.contrib.errorprone.testDep(),
     build.bsp.worker.testDep(),
     build.testkit.testDep()
   )

--- a/build.mill
+++ b/build.mill
@@ -191,9 +191,10 @@ object Deps {
   val sonatypeCentralClient = ivy"com.lumidion::sonatype-central-client-requests:0.3.0"
 
   object RuntimeDeps {
-    val sbtTestInterface = ivy"com.github.sbt:junit-interface:0.13.2"
+    val errorProneCore = ivy"com.google.errorprone:error_prone_core:2.31.0"
     val jupiterInterface = ivy"com.github.sbt.junit:jupiter-interface:0.11.4"
-    def all = Seq(sbtTestInterface, jupiterInterface)
+    val sbtTestInterface = ivy"com.github.sbt:junit-interface:0.13.2"
+    def all = Seq(errorProneCore, jupiterInterface, sbtTestInterface)
   }
 
   /** Used to manage transitive versions. */

--- a/contrib/errorprone/readme.adoc
+++ b/contrib/errorprone/readme.adoc
@@ -1,20 +1,2 @@
 = Mill ErrorProne Plugin
 
-== Caveats / JVM Options
-
-If you're on Java 17 or newer, you need to add the following options to your `.mill-jvm-opts` file in your project directory.
-
-.Required options in `.mill-jvm-opts`
-----
---add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
---add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
---add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
---add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
---add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
---add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
---add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
---add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
---add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
---add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
-----
-

--- a/contrib/errorprone/readme.adoc
+++ b/contrib/errorprone/readme.adoc
@@ -1,2 +1,30 @@
 = Mill ErrorProne Plugin
 
+https://errorprone.info/index[Error Prone] augments the Java compiler's type checker and detect common mistakes at compile time.
+
+You just need to mix the `ErrorProneModule` into your `JavaModule` and it will automatically run with every compilation.
+
+.`build.mill.sc`: Enable `ErrorProne` in a module
+[source,scala]
+----
+package build
+import mill._, scalalib._
+
+import $ivy.`com.lihaoyi::mill-contrib-errorprone:`
+import mill.contrib.errorprone.ErrorProneModule
+
+object foo extends JavaModule with ErrorProneModule {
+}
+----
+
+== Configuration
+
+The following configuration options exist:
+
+`def errorProneVersion: T[String]`::
+The `error-prone` version to use. Defaults to [[BuildInfo.errorProneVersion]], the version used to build and test the module.
+Find the latest at https://mvnrepository.com/artifact/com.google.errorprone/error_prone_core[mvnrepository.com]
+
+`def errorProneOptions: T[Seq[String]]`::
+ Options directly given to the `error-prone` processor.
+Those are documented as "flags" at https://errorprone.info/docs/flags

--- a/contrib/errorprone/readme.adoc
+++ b/contrib/errorprone/readme.adoc
@@ -1,0 +1,20 @@
+= Mill ErrorProne Plugin
+
+== Caveats / JVM Options
+
+If you're on Java 17 or newer, you need to add the following options to your `.mill-jvm-opts` file in your project directory.
+
+.Required options in `.mill-jvm-opts`
+----
+--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
+----
+

--- a/contrib/errorprone/readme.adoc
+++ b/contrib/errorprone/readme.adoc
@@ -1,4 +1,5 @@
 = Mill ErrorProne Plugin
+:page-aliases: Plugin_ErrorProne.adoc
 
 https://errorprone.info/index[Error Prone] augments the Java compiler's type checker and detect common mistakes at compile time.
 

--- a/contrib/errorprone/src/mill/contrib/errorprone/ErrorProneModule.scala
+++ b/contrib/errorprone/src/mill/contrib/errorprone/ErrorProneModule.scala
@@ -1,0 +1,43 @@
+package mill.contrib.errorprone
+
+import mill.api.PathRef
+import mill.{Agg, T}
+import mill.scalalib.{Dep, DepSyntax, JavaModule}
+
+import java.io.File
+
+trait ErrorProneModule extends JavaModule {
+  def errorProneVersion: T[String] = T.input {
+    BuildInfo.errorProneVersion
+  }
+  def errorProneDeps: T[Agg[Dep]] = T {
+    Agg(
+      ivy"com.google.errorprone:error_prone_core:${errorProneVersion()}"
+    )
+  }
+  def errorProneClasspath: T[Agg[PathRef]] = T {
+    resolveDeps(T.task { errorProneDeps().map(bindDependency()) })()
+  }
+  def errorProneJavacOptions: T[Seq[String]] = T {
+    val processorPath = errorProneClasspath().map(_.path).mkString(File.pathSeparator)
+    Seq(
+      "-XDcompilePolicy=simple",
+      "-processorpath",
+      processorPath,
+      "-Xplugin:ErrorProne"
+    )
+//    val java17Options = Seq(
+//      "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+//      "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+//      "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+//      "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+//      "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+//      "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+//      "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+//      "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+//      "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+//      "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED"
+//    )
+  }
+  override def javacOptions: T[Seq[String]] = super.javacOptions() ++ errorProneJavacOptions()
+}

--- a/contrib/errorprone/test/resources/simple/src/ShortSet.java
+++ b/contrib/errorprone/test/resources/simple/src/ShortSet.java
@@ -1,0 +1,16 @@
+package simple.src;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class ShortSet {
+  public static void main (String[] args) {
+    Set<Short> s = new HashSet<>();
+    for (short i = 0; i < 100; i++) {
+      s.add(i);
+      s.remove(i - 1);
+    }
+    System.out.println(s.size());
+  }
+}
+

--- a/contrib/errorprone/test/src/mill/contrib/errorprone/ErrorProneTests.scala
+++ b/contrib/errorprone/test/src/mill/contrib/errorprone/ErrorProneTests.scala
@@ -22,13 +22,9 @@ object ErrorProneTests extends TestSuite {
     }
     test("errorprone") {
       test("compileFail") {
-        // we require additional JVM options, which we can't set at runtime, see contrib/errorprone/readme.adoc
-        if (scala.util.Properties.isJavaAtLeast(16)) "skipping test on Java 16+"
-        else {
-          val eval = UnitTester(errorProne, testModuleSourcesPath)
-          val res = eval(errorProne.compile)
-          assert(res.isLeft)
-        }
+        val eval = UnitTester(errorProne, testModuleSourcesPath)
+        val res = eval(errorProne.compile)
+        assert(res.isLeft)
       }
     }
   }

--- a/contrib/errorprone/test/src/mill/contrib/errorprone/ErrorProneTests.scala
+++ b/contrib/errorprone/test/src/mill/contrib/errorprone/ErrorProneTests.scala
@@ -1,0 +1,35 @@
+package mill.contrib.errorprone
+
+import mill.scalalib.JavaModule
+import mill.testkit.{TestBaseModule, UnitTester}
+import os.Path
+import utest._
+
+object ErrorProneTests extends TestSuite {
+
+  object noErrorProne extends TestBaseModule with JavaModule {}
+  object errorProne extends TestBaseModule with JavaModule with ErrorProneModule {}
+
+  val testModuleSourcesPath: Path = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "simple"
+
+  def tests = Tests {
+    test("reference") {
+      test("compile") {
+        val eval = UnitTester(noErrorProne, testModuleSourcesPath)
+        val res = eval(noErrorProne.compile)
+        assert(res.isRight)
+      }
+    }
+    test("errorprone") {
+      test("compileFail") {
+        // we require additional JVM options, which we can't set at runtime, see contrib/errorprone/readme.adoc
+        if (scala.util.Properties.isJavaAtLeast(16)) "skipping test on Java 16+"
+        else {
+          val eval = UnitTester(errorProne, testModuleSourcesPath)
+          val res = eval(errorProne.compile)
+          assert(res.isLeft)
+        }
+      }
+    }
+  }
+}

--- a/contrib/package.mill
+++ b/contrib/package.mill
@@ -17,6 +17,7 @@ import mill.resolve.SelectMode
 import mill.contrib.buildinfo.BuildInfo
 import mill.T
 import mill.define.Cross
+import build.Deps
 
 // plugins and dependencies
 import $meta._
@@ -225,5 +226,13 @@ object `package` extends RootModule {
   object jmh extends ContribModule {
     def compileModuleDeps = Seq(build.scalalib)
     def testModuleDeps = super.testModuleDeps ++ Seq(build.scalalib)
+  }
+
+  object errorprone extends ContribModule with BuildInfo {
+    def compileModuleDeps = Seq(build.scalalib)
+    def testModuleDeps = super.testModuleDeps ++ Seq(build.scalalib)
+    def buildInfoPackageName = "mill.contrib.errorprone"
+    def buildInfoObjectName = "BuildInfo"
+    def buildInfoMembers = Seq(BuildInfo.Value("errorProneVersion", Deps.RuntimeDeps.errorProneCore.version))
   }
 }

--- a/docs/modules/ROOT/pages/Java_Module_Config.adoc
+++ b/docs/modules/ROOT/pages/Java_Module_Config.adoc
@@ -88,3 +88,6 @@ If you are using millw, a more permanent solution could be to set the environmen
 
 include::example/javalib/module/13-jni.adoc[]
 
+=== Using the ErrorProne plugin to detect code problems
+
+include::example/javalib/module/14-error-prone.adoc[]

--- a/docs/modules/ROOT/pages/Java_Module_Config.adoc
+++ b/docs/modules/ROOT/pages/Java_Module_Config.adoc
@@ -88,6 +88,6 @@ If you are using millw, a more permanent solution could be to set the environmen
 
 include::example/javalib/module/13-jni.adoc[]
 
-=== Using the ErrorProne plugin to detect code problems
+== Using the ErrorProne plugin to detect code problems
 
 include::example/javalib/module/14-error-prone.adoc[]

--- a/example/javalib/module/14-error-prone/build.mill
+++ b/example/javalib/module/14-error-prone/build.mill
@@ -1,0 +1,36 @@
+// When adding the `ErrorPromeModule` to your `JavaModule`,
+// the `error-prone` compile plugin automatically detects various kind of programming errors.
+
+package build
+import mill._, javalib._
+import mill.contrib.errorprone._
+
+import $ivy.`com.lihaoyi::mill-contrib-errorprone:`
+
+object `package` extends RootModule with JavaModule with ErrorProneModule {
+  def errorProneOptions = Seq("-XepAllErrorsAsWarnings")
+}
+
+/** See Also: src/example/ShortSet.java */
+
+/** Usage
+
+> ./mill show errorProneOptions
+[
+  "-XepAllErrorsAsWarnings"
+]
+
+*/
+/* Can't get to work
+
+> ./mill compile
+.../src/ShortSet.java:11:15:  [CollectionIncompatibleType] Argument 'i - 1' should not be passed to this method; its type int is not compatible with its collection's type argument Short
+     s.remove(i - 1);
+              ^    (see https://errorprone.info/bugpattern/CollectionIncompatibleType)
+1 warning
+              ^
+done compiling
+
+ */
+
+

--- a/example/javalib/module/14-error-prone/build.mill
+++ b/example/javalib/module/14-error-prone/build.mill
@@ -21,15 +21,14 @@ object `package` extends RootModule with JavaModule with ErrorProneModule {
 ]
 
 */
-/* Can't get to work
+/*
 
 > ./mill compile
-.../src/ShortSet.java:11:15:  [CollectionIncompatibleType] Argument 'i - 1' should not be passed to this method; its type int is not compatible with its collection's type argument Short
-     s.remove(i - 1);
-              ^    (see https://errorprone.info/bugpattern/CollectionIncompatibleType)
-1 warning
-              ^
-done compiling
+error: [warn] .../src/ShortSet.java:11:15:  [CollectionIncompatibleType] Argument 'i - 1' should not be passed to this method; its type int is not compatible with its collection's type argument Short
+error: [warn]      s.remove(i - 1);
+error: [warn]               ^    (see https://errorprone.info/bugpattern/CollectionIncompatibleType)
+error: [warn] 1 warning
+error: [warn]               ^
 
  */
 

--- a/example/javalib/module/14-error-prone/build.mill
+++ b/example/javalib/module/14-error-prone/build.mill
@@ -1,5 +1,5 @@
 // When adding the `ErrorPromeModule` to your `JavaModule`,
-// the `error-prone` compile plugin automatically detects various kind of programming errors.
+// the `error-prone` compiler plugin automatically detects various kind of programming errors.
 
 package build
 import mill._, javalib._

--- a/example/javalib/module/14-error-prone/build.mill
+++ b/example/javalib/module/14-error-prone/build.mill
@@ -25,7 +25,7 @@ object `package` extends RootModule with JavaModule with ErrorProneModule {
 
 > ./mill compile
 error: [warn] .../src/ShortSet.java:11:15:  [CollectionIncompatibleType] Argument 'i - 1' should not be passed to this method; its type int is not compatible with its collection's type argument Short
-error: [warn]      s.remove(i - 1);
+error: [warn]       s.remove(i - 1);
 error: [warn]               ^    (see https://errorprone.info/bugpattern/CollectionIncompatibleType)
 error: [warn] 1 warning
 error: [warn]               ^

--- a/example/javalib/module/14-error-prone/build.mill
+++ b/example/javalib/module/14-error-prone/build.mill
@@ -20,16 +20,12 @@ object `package` extends RootModule with JavaModule with ErrorProneModule {
   "-XepAllErrorsAsWarnings"
 ]
 
-*/
-/*
-
 > ./mill compile
-error: [warn] .../src/ShortSet.java:11:15:  [CollectionIncompatibleType] Argument 'i - 1' should not be passed to this method; its type int is not compatible with its collection's type argument Short
-error: [warn]       s.remove(i - 1);
-error: [warn]               ^    (see https://errorprone.info/bugpattern/CollectionIncompatibleType)
-error: [warn] 1 warning
-error: [warn]               ^
-
- */
+[warn] .../src/example/ShortSet.java:11:15:  [CollectionIncompatibleType] Argument 'i - 1' should not be passed to this method; its type int is not compatible with its collection's type argument Short
+[warn]       s.remove(i - 1);
+[warn]               ^    (see https://errorprone.info/bugpattern/CollectionIncompatibleType)
+[warn] 1 warning
+[warn]               ^
+*/
 
 

--- a/example/javalib/module/14-error-prone/src/example/ShortSet.java
+++ b/example/javalib/module/14-error-prone/src/example/ShortSet.java
@@ -1,0 +1,16 @@
+package example;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class ShortSet {
+  public static void main (String[] args) {
+    Set<Short> s = new HashSet<>();
+    for (short i = 0; i < 100; i++) {
+      s.add(i);
+      s.remove(i - 1);
+    }
+    System.out.println(s.size());
+  }
+}
+

--- a/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
+++ b/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
@@ -496,6 +496,23 @@ class ZincWorkerImpl(
   )(implicit ctx: ZincWorkerApi.Ctx): Result[CompilationResult] = {
     os.makeDir.all(ctx.dest)
 
+    val classesDir =
+      if (compileToJar) ctx.dest / "classes.jar"
+      else ctx.dest / "classes"
+
+
+    if (ctx.log.debugEnabled) {
+      ctx.log.debug(
+        s"""Compiling:
+           |  javacOptions: ${javacOptions.map("'" + _ + "'").mkString(" ")}
+           |  scalacOptions: ${scalacOptions.map("'" + _ + "'").mkString(" ")}
+           |  sources: ${sources.map("'" + _ + "'").mkString(" ")}
+           |  classpath: ${compileClasspath.map("'" + _ + "'").mkString(" ")}
+           |  output: ${classesDir}"""
+          .stripMargin
+      )
+    }
+
     reporter.foreach(_.start())
 
     val consoleAppender = ConsoleAppender(
@@ -548,10 +565,6 @@ class ZincWorkerImpl(
     }
 
     val lookup = MockedLookup(analysisMap)
-
-    val classesDir =
-      if (compileToJar) ctx.dest / "classes.jar"
-      else ctx.dest / "classes"
 
     val store = fileAnalysisStore(ctx.dest / zincCache)
 

--- a/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
+++ b/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
@@ -500,7 +500,6 @@ class ZincWorkerImpl(
       if (compileToJar) ctx.dest / "classes.jar"
       else ctx.dest / "classes"
 
-
     if (ctx.log.debugEnabled) {
       ctx.log.debug(
         s"""Compiling:

--- a/testkit/src/mill/testkit/ExampleTester.scala
+++ b/testkit/src/mill/testkit/ExampleTester.scala
@@ -30,7 +30,7 @@ import scala.concurrent.duration.FiniteDuration
  * 2. Output lines can be prefixed by `error: ` to indicate we expect that
  *    command to fail.
  *
- * 3. `..` can be used to indicate wildcards, which match anything. These can
+ * 3. `...` can be used to indicate wildcards, which match anything. These can
  *    be used alone as the entire line, or in the middle of another line
  *
  * 4. Every line of stdout/stderr output by the command must match at least


### PR DESCRIPTION
This adds a new `ErrorProne` plugin to the `contrib` section of Mill.

It provides the `ErrorProneModule` `trait`, which can be mixed into `JavaModule`s. Derived modules like `ScalaModule` are also supported, as long as they support the `javacOptions` task to configure the Java compiler.

We use the [Error Prone](https://errorprone.info/index) project as a compiler plugin. Although this is a simple javac compiler plugin, it's usage isn't trivial. Fetching the correct classpath and supplying options can be tricky, since they need to be provided in a special form. Also using with JVMs starting from version 16 requires special options handling due to the new more restrictive module classpath. This plugin is handling all of the known issues and make its use easy for the user.

Additional configuration options are supported via the `errorProneOptions` target. 

Here is a usage example:

```scala
package build
import mill._, javalib._
import mill.contrib.errorprone._

import $ivy.`com.lihaoyi::mill-contrib-errorprone:`

object `package` extends RootModule with JavaModule with ErrorProneModule {
  def errorProneOptions = Seq("-XepAllErrorsAsWarnings")
}
```


Tasks:
* [x] Implement `ErrorProneModule` and tests
* [x] Support extra options
* [x] Manually test `ErrorProneModule` in private projects
* [x] Finish plugin readme
* [x] Add example and include in documentation
* [x] Document current quirks (Java 17 module classpath, test sub-module behavior)
* [x] (Open follow-up issues)

Fix https://github.com/com-lihaoyi/mill/issues/3447
