### PR TITLE
Parallelize windows CI

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -133,15 +133,15 @@ jobs:
           # just run a subset of examples/ on Windows, because for some reason running
           # the whole suite can take hours on windows v.s. half an hour on linux
           - java-version: 11
-            millargs: '"{main,scalalib,bsp}.__.test"'
+            millargs: '"{main,scalalib,bsp}.__.testCached"'
           - java-version: 11
-            millargs: '"example.scalalib.{basic,web}.__.fork.test"'
+            millargs: '"example.scalalib.{basic,web}.__.fork.testCached"'
           - java-version: 17
-            millargs: "'integration.{feature,failure}[_].fork.test'"
+            millargs: "'integration.{feature,failure}[_].fork.testCached'"
           - java-version: 11
-            millargs: "'integration.invalidation[_].server.test'"
+            millargs: "'integration.invalidation[_].server.testCached'"
           - java-version: 11
-            millargs: "contrib.__.test"
+            millargs: "contrib.__.testCached"
 
     uses: ./.github/workflows/run-mill-action.yml
     with:

--- a/.github/workflows/run-mill-action.yml
+++ b/.github/workflows/run-mill-action.yml
@@ -73,7 +73,7 @@ jobs:
         if: inputs.millargs != '' && !startsWith(inputs.os, 'windows')
 
       - name: Run Mill (on Windows) '${{ inputs.millargs }}'
-        run: cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -ij1 __.resolvedIvyDeps; cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i -j1 -k ${{ inputs.millargs }}
+        run: cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i -k ${{ inputs.millargs }}
         if: inputs.millargs != '' && startsWith(inputs.os, 'windows')
 
       - name: Run Mill (on Windows) Worker Cleanup

--- a/.github/workflows/run-mill-action.yml
+++ b/.github/workflows/run-mill-action.yml
@@ -69,11 +69,13 @@ jobs:
         if: inputs.buildcmd != ''
 
       - name: Run Mill '${{ inputs.millargs }}'
-        run:  ./mill -i -k ${{ inputs.millargs }}
+        # mill unit and integration tests are very heavyweight, so only run
+        # 3 threads on the 4 core Github Actions workers to leave some slack
+        run:  ./mill -i -j3 -k ${{ inputs.millargs }}
         if: inputs.millargs != '' && !startsWith(inputs.os, 'windows')
 
       - name: Run Mill (on Windows) '${{ inputs.millargs }}'
-        run: cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i -k ${{ inputs.millargs }}
+        run: cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i -j3 -k ${{ inputs.millargs }}
         if: inputs.millargs != '' && startsWith(inputs.os, 'windows')
 
       - name: Run Mill (on Windows) Worker Cleanup

--- a/.github/workflows/run-mill-action.yml
+++ b/.github/workflows/run-mill-action.yml
@@ -69,13 +69,11 @@ jobs:
         if: inputs.buildcmd != ''
 
       - name: Run Mill '${{ inputs.millargs }}'
-        # mill unit and integration tests are very heavyweight, so only run
-        # 3 threads on the 4 core Github Actions workers to leave some slack
-        run:  ./mill -i -j3 -k ${{ inputs.millargs }}
+        run:  ./mill -i -k ${{ inputs.millargs }}
         if: inputs.millargs != '' && !startsWith(inputs.os, 'windows')
 
       - name: Run Mill (on Windows) '${{ inputs.millargs }}'
-        run: cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i -j3 -k ${{ inputs.millargs }}
+        run: cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i -k ${{ inputs.millargs }}
         if: inputs.millargs != '' && startsWith(inputs.os, 'windows')
 
       - name: Run Mill (on Windows) Worker Cleanup

--- a/example/javalib/web/5-todo-micronaut/build.mill
+++ b/example/javalib/web/5-todo-micronaut/build.mill
@@ -92,7 +92,7 @@ trait MicronautModule extends MavenModule{
 
 > mill runBackground; sleep 5 # give time for server to start
 
-> curl http://localhost:8088
+> curl http://localhost:8089
  ...<h1>todos</h1>...
 
 > mill clean runBackground

--- a/example/javalib/web/5-todo-micronaut/src/main/resources/application.properties
+++ b/example/javalib/web/5-todo-micronaut/src/main/resources/application.properties
@@ -14,4 +14,4 @@ micronaut.router.static-resources.learnjson.paths=classpath\:public
 micronaut.router.static-resources.learnjson.mapping=/*.json
 # Views
 micronaut.views.dir=templates
-micronaut.server.port=8088
+micronaut.server.port=8089

--- a/main/client/src/mill/main/client/ProxyStream.java
+++ b/main/client/src/mill/main/client/ProxyStream.java
@@ -141,6 +141,10 @@ public class ProxyStream{
                             flush();
                         }
                     }
+                }
+                catch (org.newsclub.net.unix.ConnectionResetSocketException e) {
+                    // This happens when you run mill shutdown and the server exits gracefully
+                    break;
                 } catch (IOException e) {
                     e.printStackTrace();
                     System.exit(1);

--- a/main/client/src/mill/main/client/ProxyStream.java
+++ b/main/client/src/mill/main/client/ProxyStream.java
@@ -141,8 +141,7 @@ public class ProxyStream{
                             flush();
                         }
                     }
-                }
-                catch (org.newsclub.net.unix.ConnectionResetSocketException e) {
+                } catch (org.newsclub.net.unix.ConnectionResetSocketException e) {
                     // This happens when you run mill shutdown and the server exits gracefully
                     break;
                 } catch (IOException e) {

--- a/main/util/src/mill/util/CoursierSupport.scala
+++ b/main/util/src/mill/util/CoursierSupport.scala
@@ -7,7 +7,6 @@ import coursier.{Dependency, Repository, Resolution}
 import mill.api.{Ctx, PathRef, Result}
 import mill.api.Loose.Agg
 import java.io.File
-import java.nio.file.NoSuchFileException
 import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.util.{Failure, Success, Try}

--- a/testkit/src/mill/testkit/ExampleTester.scala
+++ b/testkit/src/mill/testkit/ExampleTester.scala
@@ -216,11 +216,7 @@ class ExampleTester(
       try {
         try os.remove.all(workspacePath / "out")
         catch {case e: Throwable =>
-          Thread.sleep(100) // try twice to remove the out folder
-          try os.remove.all(workspacePath / "out")
-          catch{case e: Throwable =>
-            /*do nothing*/
-          }
+          /*do nothing*/
         }
 
         for (commandBlock <- commandBlocks) processCommandBlock(commandBlock)

--- a/testkit/src/mill/testkit/ExampleTester.scala
+++ b/testkit/src/mill/testkit/ExampleTester.scala
@@ -216,8 +216,7 @@ class ExampleTester(
       try {
         try os.remove.all(workspacePath / "out")
         catch {
-          case e: Throwable =>
-          /*do nothing*/
+          case e: Throwable => /*do nothing*/
         }
 
         for (commandBlock <- commandBlocks) processCommandBlock(commandBlock)

--- a/testkit/src/mill/testkit/ExampleTester.scala
+++ b/testkit/src/mill/testkit/ExampleTester.scala
@@ -215,8 +215,12 @@ class ExampleTester(
     retryOnTimeout(3) {
       try {
         try os.remove.all(workspacePath / "out")
-        catch {
-          case e: Throwable => /*do nothing*/
+        catch {case e: Throwable =>
+          Thread.sleep(100) // try twice to remove the out folder
+          try os.remove.all(workspacePath / "out")
+          catch{case e: Throwable =>
+            /*do nothing*/
+          }
         }
 
         for (commandBlock <- commandBlocks) processCommandBlock(commandBlock)

--- a/testkit/src/mill/testkit/ExampleTester.scala
+++ b/testkit/src/mill/testkit/ExampleTester.scala
@@ -215,7 +215,8 @@ class ExampleTester(
     retryOnTimeout(3) {
       try {
         try os.remove.all(workspacePath / "out")
-        catch {case e: Throwable =>
+        catch {
+          case e: Throwable =>
           /*do nothing*/
         }
 


### PR DESCRIPTION
* Remove `-j1` parallelism limit on windows, enable parallelism for windows tests by changing `.test` to `.testCached`

* Clean up coursier retry logic and add more cases

* Two of our example tests were conflicting on port `8088`, moved one of them to `8089`