### PR TITLE
Properly close Scala compiler classloaders in server and unit tests

### DIFF
--- a/contrib/buildinfo/test/src/mill/contrib/buildinfo/BuildInfoTests.scala
+++ b/contrib/buildinfo/test/src/mill/contrib/buildinfo/BuildInfoTests.scala
@@ -95,14 +95,12 @@ object BuildInfoTests extends TestSuite {
     eval.outPath / "buildInfoResources.dest" / "foo" / "BuildInfo.buildinfo.properties"
   def tests: Tests = Tests {
 
-    test("notCreateEmptySourcefile") {
-      val eval = UnitTester(EmptyBuildInfo, testModuleSourcesPath / "scala")
+    test("notCreateEmptySourcefile") - UnitTester(EmptyBuildInfo, testModuleSourcesPath / "scala").scoped{eval =>
       val Right(_) = eval.apply(EmptyBuildInfo.buildInfoSources)
       assert(!os.exists(buildInfoSourcePath(eval)))
     }
 
-    test("fileGeneration") {
-      val eval = UnitTester(BuildInfoComment, testModuleSourcesPath / "scala")
+    test("fileGeneration") - UnitTester(BuildInfoComment, testModuleSourcesPath / "scala").scoped{eval =>
       val Right(_) = eval.apply(BuildInfoComment.compile)
 
       // Make sure that the buildinfo Scala file buildinfo is created and buildinfo
@@ -135,8 +133,7 @@ object BuildInfoTests extends TestSuite {
       assert(buildInfoResource.contains(expectedResource))
     }
 
-    test("supportCustomSettings") {
-      val eval = UnitTester(BuildInfoSettings, testModuleSourcesPath / "scala")
+    test("supportCustomSettings") - UnitTester(BuildInfoSettings, testModuleSourcesPath / "scala").scoped{eval =>
       val Right(result) = eval.apply(BuildInfoSettings.buildInfoSources)
       val path = result.value.head.path
 
@@ -146,14 +143,12 @@ object BuildInfoTests extends TestSuite {
       assert(found.contains("object bar"))
     }
 
-    test("compile") {
-      val eval = UnitTester(BuildInfoPlain, testModuleSourcesPath / "scala")
+    test("compile") - UnitTester(BuildInfoPlain, testModuleSourcesPath / "scala").scoped{eval =>
       val Right(_) = eval.apply(BuildInfoPlain.compile)
       assert(true)
     }
 
-    test("run") {
-      val eval = UnitTester(BuildInfoPlain, testModuleSourcesPath / "scala")
+    test("run") - UnitTester(BuildInfoPlain, testModuleSourcesPath / "scala").scoped{eval =>
       val runResult = eval.outPath / "hello-mill"
       val Right(_) =
         eval.apply(BuildInfoPlain.run(T.task(Args(runResult.toString))))
@@ -164,14 +159,12 @@ object BuildInfoTests extends TestSuite {
       )
     }
 
-    test("scalajs") {
-      val eval = UnitTester(BuildInfoScalaJS, testModuleSourcesPath / "scala-simple")
+    test("scalajs") - UnitTester(BuildInfoScalaJS, testModuleSourcesPath / "scala-simple").scoped{eval =>
       val runResult = eval.outPath / "hello-mill"
       assert(eval.apply(BuildInfoScalaJS.fastLinkJS).isRight)
     }
 
-    test("static") {
-      val eval = UnitTester(BuildInfoStatic, testModuleSourcesPath / "scala")
+    test("static") - UnitTester(BuildInfoStatic, testModuleSourcesPath / "scala").scoped{eval =>
       // When `buildInfoStaticCompiled = true`, make sure we always create the
       // buildinfo Scala file and never create the resource file
       val runResult = eval.outPath / "hello-mill"
@@ -185,8 +178,7 @@ object BuildInfoTests extends TestSuite {
       assert(os.read(runResult) == scalaVersionString)
     }
 
-    test("java") {
-      val eval = UnitTester(BuildInfoJava, testModuleSourcesPath / "java")
+    test("java") - UnitTester(BuildInfoJava, testModuleSourcesPath / "java").scoped{eval =>
       val runResult = eval.outPath / "hello-mill"
       val Right(_) =
         eval.apply(BuildInfoJava.run(T.task(Args(runResult.toString))))
@@ -197,8 +189,7 @@ object BuildInfoTests extends TestSuite {
       )
     }
 
-    test("java-static") {
-      val eval = UnitTester(BuildInfoJavaStatic, testModuleSourcesPath / "java")
+    test("java-static") - UnitTester(BuildInfoJavaStatic, testModuleSourcesPath / "java").scoped{eval =>
       val runResult = eval.outPath / "hello-mill"
       val generatedSrc = eval.outPath / "buildInfoSources.dest" / "foo" / "BuildInfo.java"
       val Right(_) =
@@ -211,8 +202,7 @@ object BuildInfoTests extends TestSuite {
       )
     }
 
-    test("generatedSources must be a folder") {
-      val eval = UnitTester(BuildInfoPlain, testModuleSourcesPath / "scala")
+    test("generatedSources must be a folder") - UnitTester(BuildInfoPlain, testModuleSourcesPath / "scala").scoped{eval =>
       val buildInfoGeneratedSourcesFolder = eval.outPath / "buildInfoSources.dest"
       val Right(result) = eval.apply(BuildInfoPlain.generatedSources)
       assert(

--- a/contrib/buildinfo/test/src/mill/contrib/buildinfo/BuildInfoTests.scala
+++ b/contrib/buildinfo/test/src/mill/contrib/buildinfo/BuildInfoTests.scala
@@ -95,45 +95,52 @@ object BuildInfoTests extends TestSuite {
     eval.outPath / "buildInfoResources.dest" / "foo" / "BuildInfo.buildinfo.properties"
   def tests: Tests = Tests {
 
-    test("notCreateEmptySourcefile") - UnitTester(EmptyBuildInfo, testModuleSourcesPath / "scala").scoped{eval =>
+    test("notCreateEmptySourcefile") - UnitTester(
+      EmptyBuildInfo,
+      testModuleSourcesPath / "scala"
+    ).scoped { eval =>
       val Right(_) = eval.apply(EmptyBuildInfo.buildInfoSources)
       assert(!os.exists(buildInfoSourcePath(eval)))
     }
 
-    test("fileGeneration") - UnitTester(BuildInfoComment, testModuleSourcesPath / "scala").scoped{eval =>
-      val Right(_) = eval.apply(BuildInfoComment.compile)
+    test("fileGeneration") - UnitTester(BuildInfoComment, testModuleSourcesPath / "scala").scoped {
+      eval =>
+        val Right(_) = eval.apply(BuildInfoComment.compile)
 
-      // Make sure that the buildinfo Scala file buildinfo is created and buildinfo
-      // resource file is *not* created when we compile the Scala code
-      assert(os.exists(buildInfoSourcePath(eval)))
-      assert(!os.exists(buildInfoResourcePath(eval)))
+        // Make sure that the buildinfo Scala file buildinfo is created and buildinfo
+        // resource file is *not* created when we compile the Scala code
+        assert(os.exists(buildInfoSourcePath(eval)))
+        assert(!os.exists(buildInfoResourcePath(eval)))
 
-      val expectedSource = Seq(
-        """  /** a helpful comment explaining what scalaVersion is all about */
-          |  val scalaVersion = buildInfoProperties.getProperty("scalaVersion")""".stripMargin,
-        """  /**
-          |    * a helpful comment explaining what scalaVersion
-          |    * is all about
-          |    */
-          |  val scalaVersion2 = buildInfoProperties.getProperty("scalaVersion2")""".stripMargin
-      )
+        val expectedSource = Seq(
+          """  /** a helpful comment explaining what scalaVersion is all about */
+            |  val scalaVersion = buildInfoProperties.getProperty("scalaVersion")""".stripMargin,
+          """  /**
+            |    * a helpful comment explaining what scalaVersion
+            |    * is all about
+            |    */
+            |  val scalaVersion2 = buildInfoProperties.getProperty("scalaVersion2")""".stripMargin
+        )
 
-      val buildInfoCode = os.read(buildInfoSourcePath(eval)).linesIterator.mkString("\n")
-      for (e <- expectedSource) {
-        assert(buildInfoCode.contains(e.linesIterator.mkString("\n")))
-      }
+        val buildInfoCode = os.read(buildInfoSourcePath(eval)).linesIterator.mkString("\n")
+        for (e <- expectedSource) {
+          assert(buildInfoCode.contains(e.linesIterator.mkString("\n")))
+        }
 
-      // But becomes created once we package the jar for running
-      val Right(_) = eval.apply(BuildInfoComment.jar)
+        // But becomes created once we package the jar for running
+        val Right(_) = eval.apply(BuildInfoComment.jar)
 
-      val expectedResource = "mill.contrib.buildinfo.BuildInfo for foo."
+        val expectedResource = "mill.contrib.buildinfo.BuildInfo for foo."
 
-      assert(os.exists(buildInfoResourcePath(eval)))
-      val buildInfoResource = os.read(buildInfoResourcePath(eval))
-      assert(buildInfoResource.contains(expectedResource))
+        assert(os.exists(buildInfoResourcePath(eval)))
+        val buildInfoResource = os.read(buildInfoResourcePath(eval))
+        assert(buildInfoResource.contains(expectedResource))
     }
 
-    test("supportCustomSettings") - UnitTester(BuildInfoSettings, testModuleSourcesPath / "scala").scoped{eval =>
+    test("supportCustomSettings") - UnitTester(
+      BuildInfoSettings,
+      testModuleSourcesPath / "scala"
+    ).scoped { eval =>
       val Right(result) = eval.apply(BuildInfoSettings.buildInfoSources)
       val path = result.value.head.path
 
@@ -143,12 +150,12 @@ object BuildInfoTests extends TestSuite {
       assert(found.contains("object bar"))
     }
 
-    test("compile") - UnitTester(BuildInfoPlain, testModuleSourcesPath / "scala").scoped{eval =>
+    test("compile") - UnitTester(BuildInfoPlain, testModuleSourcesPath / "scala").scoped { eval =>
       val Right(_) = eval.apply(BuildInfoPlain.compile)
       assert(true)
     }
 
-    test("run") - UnitTester(BuildInfoPlain, testModuleSourcesPath / "scala").scoped{eval =>
+    test("run") - UnitTester(BuildInfoPlain, testModuleSourcesPath / "scala").scoped { eval =>
       val runResult = eval.outPath / "hello-mill"
       val Right(_) =
         eval.apply(BuildInfoPlain.run(T.task(Args(runResult.toString))))
@@ -159,12 +166,13 @@ object BuildInfoTests extends TestSuite {
       )
     }
 
-    test("scalajs") - UnitTester(BuildInfoScalaJS, testModuleSourcesPath / "scala-simple").scoped{eval =>
-      val runResult = eval.outPath / "hello-mill"
-      assert(eval.apply(BuildInfoScalaJS.fastLinkJS).isRight)
+    test("scalajs") - UnitTester(BuildInfoScalaJS, testModuleSourcesPath / "scala-simple").scoped {
+      eval =>
+        val runResult = eval.outPath / "hello-mill"
+        assert(eval.apply(BuildInfoScalaJS.fastLinkJS).isRight)
     }
 
-    test("static") - UnitTester(BuildInfoStatic, testModuleSourcesPath / "scala").scoped{eval =>
+    test("static") - UnitTester(BuildInfoStatic, testModuleSourcesPath / "scala").scoped { eval =>
       // When `buildInfoStaticCompiled = true`, make sure we always create the
       // buildinfo Scala file and never create the resource file
       val runResult = eval.outPath / "hello-mill"
@@ -178,7 +186,7 @@ object BuildInfoTests extends TestSuite {
       assert(os.read(runResult) == scalaVersionString)
     }
 
-    test("java") - UnitTester(BuildInfoJava, testModuleSourcesPath / "java").scoped{eval =>
+    test("java") - UnitTester(BuildInfoJava, testModuleSourcesPath / "java").scoped { eval =>
       val runResult = eval.outPath / "hello-mill"
       val Right(_) =
         eval.apply(BuildInfoJava.run(T.task(Args(runResult.toString))))
@@ -189,20 +197,24 @@ object BuildInfoTests extends TestSuite {
       )
     }
 
-    test("java-static") - UnitTester(BuildInfoJavaStatic, testModuleSourcesPath / "java").scoped{eval =>
-      val runResult = eval.outPath / "hello-mill"
-      val generatedSrc = eval.outPath / "buildInfoSources.dest" / "foo" / "BuildInfo.java"
-      val Right(_) =
-        eval.apply(BuildInfoJavaStatic.run(T.task(Args(runResult.toString))))
+    test("java-static") - UnitTester(BuildInfoJavaStatic, testModuleSourcesPath / "java").scoped {
+      eval =>
+        val runResult = eval.outPath / "hello-mill"
+        val generatedSrc = eval.outPath / "buildInfoSources.dest" / "foo" / "BuildInfo.java"
+        val Right(_) =
+          eval.apply(BuildInfoJavaStatic.run(T.task(Args(runResult.toString))))
 
-      assert(
-        os.exists(runResult),
-        os.exists(generatedSrc),
-        os.read(runResult) == "not-provided-for-java-modules"
-      )
+        assert(
+          os.exists(runResult),
+          os.exists(generatedSrc),
+          os.read(runResult) == "not-provided-for-java-modules"
+        )
     }
 
-    test("generatedSources must be a folder") - UnitTester(BuildInfoPlain, testModuleSourcesPath / "scala").scoped{eval =>
+    test("generatedSources must be a folder") - UnitTester(
+      BuildInfoPlain,
+      testModuleSourcesPath / "scala"
+    ).scoped { eval =>
       val buildInfoGeneratedSourcesFolder = eval.outPath / "buildInfoSources.dest"
       val Right(result) = eval.apply(BuildInfoPlain.generatedSources)
       assert(

--- a/contrib/docker/test/src/mill/contrib/docker/DockerModuleTest.scala
+++ b/contrib/docker/test/src/mill/contrib/docker/DockerModuleTest.scala
@@ -89,8 +89,7 @@ object DockerModuleTest extends TestSuite {
     }
 
     test("dockerfile contents") {
-      test("default options") {
-        val eval = UnitTester(Docker, null)
+      test("default options") - UnitTester(Docker, null).scoped{eval =>
         val Right(result) = eval(Docker.dockerDefault.dockerfile)
         val expected = multineRegex.replaceAllIn(
           """
@@ -106,8 +105,7 @@ object DockerModuleTest extends TestSuite {
         assert(dockerfileStringRefined == expected)
       }
 
-      test("all options") {
-        val eval = UnitTester(Docker, null)
+      test("all options") - UnitTester(Docker, null).scoped{eval =>
         val Right(result) = eval(Docker.dockerAll.dockerfile)
         val expected = multineRegex.replaceAllIn(
           """
@@ -132,8 +130,7 @@ object DockerModuleTest extends TestSuite {
         assert(dockerfileStringRefined == expected)
       }
 
-      test("extra jvm options") {
-        val eval = UnitTester(Docker, null)
+      test("extra jvm options") - UnitTester(Docker, null).scoped{eval =>
         val Right(result) = eval(Docker.dockerJvmOptions.dockerfile)
         val expected = multineRegex.replaceAllIn(
           """

--- a/contrib/docker/test/src/mill/contrib/docker/DockerModuleTest.scala
+++ b/contrib/docker/test/src/mill/contrib/docker/DockerModuleTest.scala
@@ -89,7 +89,7 @@ object DockerModuleTest extends TestSuite {
     }
 
     test("dockerfile contents") {
-      test("default options") - UnitTester(Docker, null).scoped{eval =>
+      test("default options") - UnitTester(Docker, null).scoped { eval =>
         val Right(result) = eval(Docker.dockerDefault.dockerfile)
         val expected = multineRegex.replaceAllIn(
           """
@@ -105,7 +105,7 @@ object DockerModuleTest extends TestSuite {
         assert(dockerfileStringRefined == expected)
       }
 
-      test("all options") - UnitTester(Docker, null).scoped{eval =>
+      test("all options") - UnitTester(Docker, null).scoped { eval =>
         val Right(result) = eval(Docker.dockerAll.dockerfile)
         val expected = multineRegex.replaceAllIn(
           """
@@ -130,7 +130,7 @@ object DockerModuleTest extends TestSuite {
         assert(dockerfileStringRefined == expected)
       }
 
-      test("extra jvm options") - UnitTester(Docker, null).scoped{eval =>
+      test("extra jvm options") - UnitTester(Docker, null).scoped { eval =>
         val Right(result) = eval(Docker.dockerJvmOptions.dockerfile)
         val expected = multineRegex.replaceAllIn(
           """

--- a/contrib/flyway/test/src/mill/contrib/flyway/BuildTest.scala
+++ b/contrib/flyway/test/src/mill/contrib/flyway/BuildTest.scala
@@ -21,12 +21,12 @@ object BuildTest extends TestSuite {
   }
 
   def tests = Tests {
-    test("clean") - UnitTester(Build, null).scoped{eval =>
+    test("clean") - UnitTester(Build, null).scoped { eval =>
       val Right(result) = eval(Build.build.flywayClean())
       assert(result.evalCount > 0)
     }
 
-    test("migrate") - UnitTester(Build, null).scoped{eval =>
+    test("migrate") - UnitTester(Build, null).scoped { eval =>
       val Right(result) = eval(Build.build.flywayMigrate())
       assert(
         result.evalCount > 0,
@@ -39,7 +39,7 @@ object BuildTest extends TestSuite {
       )
     }
 
-    test("info") - UnitTester(Build, null).scoped{eval =>
+    test("info") - UnitTester(Build, null).scoped { eval =>
       val Right(result) = eval(Build.build.flywayInfo())
       assert(result.evalCount > 0)
     }

--- a/contrib/flyway/test/src/mill/contrib/flyway/BuildTest.scala
+++ b/contrib/flyway/test/src/mill/contrib/flyway/BuildTest.scala
@@ -21,14 +21,12 @@ object BuildTest extends TestSuite {
   }
 
   def tests = Tests {
-    test("clean") {
-      val eval = UnitTester(Build, null)
+    test("clean") - UnitTester(Build, null).scoped{eval =>
       val Right(result) = eval(Build.build.flywayClean())
       assert(result.evalCount > 0)
     }
 
-    test("migrate") {
-      val eval = UnitTester(Build, null)
+    test("migrate") - UnitTester(Build, null).scoped{eval =>
       val Right(result) = eval(Build.build.flywayMigrate())
       assert(
         result.evalCount > 0,
@@ -41,8 +39,7 @@ object BuildTest extends TestSuite {
       )
     }
 
-    test("info") {
-      val eval = UnitTester(Build, null)
+    test("info") - UnitTester(Build, null).scoped{eval =>
       val Right(result) = eval(Build.build.flywayInfo())
       assert(result.evalCount > 0)
     }

--- a/contrib/gitlab/test/src/mill/contrib/gitlab/GitlabModuleTests.scala
+++ b/contrib/gitlab/test/src/mill/contrib/gitlab/GitlabModuleTests.scala
@@ -37,8 +37,7 @@ object GitlabModuleTests extends TestSuite {
 
   override def tests: Tests = Tests {
 
-    test("GitlabPublishModule produces sane error message") {
-      val eval = UnitTester(GitlabModule, null)
+    test("GitlabPublishModule produces sane error message") - UnitTester(GitlabModule, null).scoped{eval =>
       val e = eval(GitlabModule.gitlabHeaders(Map.empty))
 
       assertMatch(e) {
@@ -47,8 +46,7 @@ object GitlabModuleTests extends TestSuite {
       }
     }
 
-    test("GitlabMavenRepository produces sane error message") {
-      val eval = UnitTester(GLMvnRepo, null)
+    test("GitlabMavenRepository produces sane error message") - UnitTester(GLMvnRepo, null).scoped{eval =>
       val e = eval(GLMvnRepo.mavenRepository)
 
       assertMatch(e) {

--- a/contrib/gitlab/test/src/mill/contrib/gitlab/GitlabModuleTests.scala
+++ b/contrib/gitlab/test/src/mill/contrib/gitlab/GitlabModuleTests.scala
@@ -37,7 +37,10 @@ object GitlabModuleTests extends TestSuite {
 
   override def tests: Tests = Tests {
 
-    test("GitlabPublishModule produces sane error message") - UnitTester(GitlabModule, null).scoped{eval =>
+    test("GitlabPublishModule produces sane error message") - UnitTester(
+      GitlabModule,
+      null
+    ).scoped { eval =>
       val e = eval(GitlabModule.gitlabHeaders(Map.empty))
 
       assertMatch(e) {
@@ -46,13 +49,14 @@ object GitlabModuleTests extends TestSuite {
       }
     }
 
-    test("GitlabMavenRepository produces sane error message") - UnitTester(GLMvnRepo, null).scoped{eval =>
-      val e = eval(GLMvnRepo.mavenRepository)
+    test("GitlabMavenRepository produces sane error message") - UnitTester(GLMvnRepo, null).scoped {
+      eval =>
+        val e = eval(GLMvnRepo.mavenRepository)
 
-      assertMatch(e) {
-        case Left(Failure(s, _))
-            if s.startsWith("Token lookup for PACKAGE repository") =>
-      }
+        assertMatch(e) {
+          case Left(Failure(s, _))
+              if s.startsWith("Token lookup for PACKAGE repository") =>
+        }
     }
   }
 

--- a/contrib/jmh/test/src/mill/contrib/jmh/JmhModuleTest.scala
+++ b/contrib/jmh/test/src/mill/contrib/jmh/JmhModuleTest.scala
@@ -20,7 +20,7 @@ object JmhModuleTest extends TestSuite {
 
   def tests = Tests {
     test("jmh") {
-      test("listJmhBenchmarks") - UnitTester(jmh, testModuleSourcesPath).scoped{eval =>
+      test("listJmhBenchmarks") - UnitTester(jmh, testModuleSourcesPath).scoped { eval =>
         val paths = EvaluatorPaths.resolveDestPaths(eval.outPath, jmh.listJmhBenchmarks())
         val outFile = paths.dest / "benchmarks.out"
         val Right(result) = eval(jmh.listJmhBenchmarks("-o", outFile.toString))

--- a/contrib/jmh/test/src/mill/contrib/jmh/JmhModuleTest.scala
+++ b/contrib/jmh/test/src/mill/contrib/jmh/JmhModuleTest.scala
@@ -20,8 +20,7 @@ object JmhModuleTest extends TestSuite {
 
   def tests = Tests {
     test("jmh") {
-      test("listJmhBenchmarks") {
-        val eval = UnitTester(jmh, testModuleSourcesPath)
+      test("listJmhBenchmarks") - UnitTester(jmh, testModuleSourcesPath).scoped{eval =>
         val paths = EvaluatorPaths.resolveDestPaths(eval.outPath, jmh.listJmhBenchmarks())
         val outFile = paths.dest / "benchmarks.out"
         val Right(result) = eval(jmh.listJmhBenchmarks("-o", outFile.toString))

--- a/contrib/playlib/test/src/mill/playlib/PlayModuleTests.scala
+++ b/contrib/playlib/test/src/mill/playlib/PlayModuleTests.scala
@@ -22,107 +22,111 @@ object PlayModuleTests extends TestSuite with PlayTestSuite {
     test("layout") {
       test("fromBuild") {
         matrix.foreach { case (scalaVersion, playVersion) =>
-          val eval = UnitTester(playmulti, resourcePath)
-          val Right(conf) = eval.apply(playmulti.core(scalaVersion, playVersion).conf)
-          val Right(app) = eval.apply(playmulti.core(scalaVersion, playVersion).app)
-          val Right(sources) = eval.apply(playmulti.core(scalaVersion, playVersion).sources)
-          val Right(resources) =
-            eval.apply(playmulti.core(scalaVersion, playVersion).resources)
-          val Right(testSources) =
-            eval.apply(playmulti.core(scalaVersion, playVersion).test.sources)
-          val Right(testResources) =
-            eval.apply(playmulti.core(scalaVersion, playVersion).test.resources)
-          assert(
-            conf.value.map(_.path.relativeTo(playmulti.millSourcePath).toString()) == Seq(
-              "core/conf"
-            ),
-            app.value.map(_.path.relativeTo(playmulti.millSourcePath).toString()) == Seq(
-              "core/app"
-            ),
-            sources == app,
-            resources.value.map(_.path.relativeTo(playmulti.millSourcePath).toString()).contains(
-              "core/conf"
-            ),
-            testSources.value.map(_.path.relativeTo(playmulti.millSourcePath).toString()) == Seq(
-              "core/test"
-            ),
-            testResources.value.map(
-              _.path.relativeTo(playmulti.millSourcePath).toString()
-            ) == Seq(
-              "core/test/resources"
+          UnitTester(playmulti, resourcePath).scoped { eval =>
+            val Right(conf) = eval.apply(playmulti.core(scalaVersion, playVersion).conf)
+            val Right(app) = eval.apply(playmulti.core(scalaVersion, playVersion).app)
+            val Right(sources) = eval.apply(playmulti.core(scalaVersion, playVersion).sources)
+            val Right(resources) =
+              eval.apply(playmulti.core(scalaVersion, playVersion).resources)
+            val Right(testSources) =
+              eval.apply(playmulti.core(scalaVersion, playVersion).test.sources)
+            val Right(testResources) =
+              eval.apply(playmulti.core(scalaVersion, playVersion).test.resources)
+            assert(
+              conf.value.map(_.path.relativeTo(playmulti.millSourcePath).toString()) == Seq(
+                "core/conf"
+              ),
+              app.value.map(_.path.relativeTo(playmulti.millSourcePath).toString()) == Seq(
+                "core/app"
+              ),
+              sources == app,
+              resources.value.map(_.path.relativeTo(playmulti.millSourcePath).toString()).contains(
+                "core/conf"
+              ),
+              testSources.value.map(_.path.relativeTo(playmulti.millSourcePath).toString()) == Seq(
+                "core/test"
+              ),
+              testResources.value.map(
+                _.path.relativeTo(playmulti.millSourcePath).toString()
+              ) == Seq(
+                "core/test/resources"
+              )
             )
-          )
+          }
         }
       }
     }
     test("dependencies") {
       test("fromBuild") {
         matrix.foreach { case (scalaVersion, playVersion) =>
-          val eval = UnitTester(playmulti, resourcePath)
-          val Right(result) =
-            eval.apply(playmulti.core(scalaVersion, playVersion).ivyDeps)
-          val expectedModules = Seq[String](
-            "play",
-            "play-guice",
-            "play-server",
-            "play-logback",
-            "play-ahc-ws"
-          )
-          val outputModules = result.value.map(_.dep.module.name.value)
-          assert(
-            outputModules.forall(expectedModules.contains),
-            result.evalCount > 0
-          )
+          UnitTester(playmulti, resourcePath).scoped { eval =>
+            val Right(result) =
+              eval.apply(playmulti.core(scalaVersion, playVersion).ivyDeps)
+            val expectedModules = Seq[String](
+              "play",
+              "play-guice",
+              "play-server",
+              "play-logback",
+              "play-ahc-ws"
+            )
+            val outputModules = result.value.map(_.dep.module.name.value)
+            assert(
+              outputModules.forall(expectedModules.contains),
+              result.evalCount > 0
+            )
+          }
         }
       }
       test("resolvedRunIvyDeps") {
         matrix.foreach { case (scalaVersion, playVersion) =>
-          val eval = UnitTester(playmulti, resourcePath)
-          val Right(_) = eval.apply(playmulti.core(scalaVersion, playVersion).resolvedRunIvyDeps)
+          UnitTester(playmulti, resourcePath).scoped { eval =>
+            val Right(_) = eval.apply(playmulti.core(scalaVersion, playVersion).resolvedRunIvyDeps)
+          }
         }
       }
     }
     test("compile") {
       matrix.foreach { case (scalaVersion, playVersion) =>
         skipUnsupportedVersions(playVersion) {
-          val eval = UnitTester(playmulti, resourcePath)
-          val eitherResult = eval.apply(playmulti.core(scalaVersion, playVersion).compile)
-          val Right(result) = eitherResult
-          val outputClassFiles =
-            os.walk(result.value.classes.path).filter(f => os.isFile(f) && f.ext == "class")
+          UnitTester(playmulti, resourcePath).scoped { eval =>
+            val eitherResult = eval.apply(playmulti.core(scalaVersion, playVersion).compile)
+            val Right(result) = eitherResult
+            val outputClassFiles =
+              os.walk(result.value.classes.path).filter(f => os.isFile(f) && f.ext == "class")
 
-          val expectedClassfiles = Seq[os.RelPath](
-            os.RelPath("controllers/HomeController.class"),
-            os.RelPath("controllers/ReverseAssets.class"),
-            os.RelPath("controllers/ReverseHomeController.class"),
-            os.RelPath("controllers/routes.class"),
-            os.RelPath("controllers/routes$javascript.class"),
-            os.RelPath("controllers/javascript/ReverseHomeController.class"),
-            os.RelPath("controllers/javascript/ReverseAssets.class"),
-            if (scalaVersion.startsWith("3.")) os.RelPath("router/Routes$$anon$1.class")
-            else os.RelPath("router/Routes$$anonfun$routes$1.class"),
-            os.RelPath("router/Routes.class"),
-            os.RelPath("router/RoutesPrefix$.class"),
-            os.RelPath("router/RoutesPrefix.class"),
-            os.RelPath("views/html/index$.class"),
-            os.RelPath("views/html/index.class"),
-            os.RelPath("views/html/main$.class"),
-            os.RelPath("views/html/main.class")
-          ).map(
-            eval.outPath / "core" / scalaVersion / playVersion / "compile.dest" / "classes" / _
-          )
-          assert(
-            result.value.classes.path == eval.outPath / "core" / scalaVersion / playVersion / "compile.dest" / "classes",
-            outputClassFiles.nonEmpty,
-            outputClassFiles.forall(expectedClassfiles.contains),
-            outputClassFiles.size == 15,
-            result.evalCount > 0
-          )
+            val expectedClassfiles = Seq[os.RelPath](
+              os.RelPath("controllers/HomeController.class"),
+              os.RelPath("controllers/ReverseAssets.class"),
+              os.RelPath("controllers/ReverseHomeController.class"),
+              os.RelPath("controllers/routes.class"),
+              os.RelPath("controllers/routes$javascript.class"),
+              os.RelPath("controllers/javascript/ReverseHomeController.class"),
+              os.RelPath("controllers/javascript/ReverseAssets.class"),
+              if (scalaVersion.startsWith("3.")) os.RelPath("router/Routes$$anon$1.class")
+              else os.RelPath("router/Routes$$anonfun$routes$1.class"),
+              os.RelPath("router/Routes.class"),
+              os.RelPath("router/RoutesPrefix$.class"),
+              os.RelPath("router/RoutesPrefix.class"),
+              os.RelPath("views/html/index$.class"),
+              os.RelPath("views/html/index.class"),
+              os.RelPath("views/html/main$.class"),
+              os.RelPath("views/html/main.class")
+            ).map(
+              eval.outPath / "core" / scalaVersion / playVersion / "compile.dest" / "classes" / _
+            )
+            assert(
+              result.value.classes.path == eval.outPath / "core" / scalaVersion / playVersion / "compile.dest" / "classes",
+              outputClassFiles.nonEmpty,
+              outputClassFiles.forall(expectedClassfiles.contains),
+              outputClassFiles.size == 15,
+              result.evalCount > 0
+            )
 
-          // don't recompile if nothing changed
-          val Right(result2) =
-            eval.apply(playmulti.core(scalaVersion, playVersion).compile)
-          assert(result2.evalCount == 0)
+            // don't recompile if nothing changed
+            val Right(result2) =
+              eval.apply(playmulti.core(scalaVersion, playVersion).compile)
+            assert(result2.evalCount == 0)
+          }
         }
       }
     }

--- a/contrib/playlib/test/src/mill/playlib/PlaySingleApiModuleTests.scala
+++ b/contrib/playlib/test/src/mill/playlib/PlaySingleApiModuleTests.scala
@@ -17,7 +17,7 @@ object PlaySingleApiModuleTests extends TestSuite with PlayTestSuite {
 
   def tests: Tests = Tests {
     test("playVersion") {
-      test("fromBuild") - UnitTester(playsingleapi, resourcePath).scoped{eval =>
+      test("fromBuild") - UnitTester(playsingleapi, resourcePath).scoped { eval =>
         val Right(result) = eval.apply(playsingleapi.playVersion)
         assert(
           result.value == testPlay28,
@@ -26,7 +26,7 @@ object PlaySingleApiModuleTests extends TestSuite with PlayTestSuite {
       }
     }
     test("layout") {
-      test("fromBuild") - UnitTester(playsingleapi, resourcePath).scoped{eval =>
+      test("fromBuild") - UnitTester(playsingleapi, resourcePath).scoped { eval =>
         val Right(conf) = eval.apply(playsingleapi.conf)
         val Right(app) = eval.apply(playsingleapi.app)
         val Right(sources) = eval.apply(playsingleapi.sources)
@@ -53,7 +53,7 @@ object PlaySingleApiModuleTests extends TestSuite with PlayTestSuite {
         )
       }
     }
-    test("compile") - UnitTester(playsingleapi, resourcePath).scoped{eval =>
+    test("compile") - UnitTester(playsingleapi, resourcePath).scoped { eval =>
       val eitherResult = eval.apply(playsingleapi.compile)
       val Right(result) = eitherResult
       val outputFiles = os.walk(result.value.classes.path).filter(os.isFile)

--- a/contrib/playlib/test/src/mill/playlib/PlaySingleApiModuleTests.scala
+++ b/contrib/playlib/test/src/mill/playlib/PlaySingleApiModuleTests.scala
@@ -17,8 +17,7 @@ object PlaySingleApiModuleTests extends TestSuite with PlayTestSuite {
 
   def tests: Tests = Tests {
     test("playVersion") {
-      test("fromBuild") {
-        val eval = UnitTester(playsingleapi, resourcePath)
+      test("fromBuild") - UnitTester(playsingleapi, resourcePath).scoped{eval =>
         val Right(result) = eval.apply(playsingleapi.playVersion)
         assert(
           result.value == testPlay28,
@@ -27,8 +26,7 @@ object PlaySingleApiModuleTests extends TestSuite with PlayTestSuite {
       }
     }
     test("layout") {
-      test("fromBuild") {
-        val eval = UnitTester(playsingleapi, resourcePath)
+      test("fromBuild") - UnitTester(playsingleapi, resourcePath).scoped{eval =>
         val Right(conf) = eval.apply(playsingleapi.conf)
         val Right(app) = eval.apply(playsingleapi.app)
         val Right(sources) = eval.apply(playsingleapi.sources)
@@ -55,8 +53,7 @@ object PlaySingleApiModuleTests extends TestSuite with PlayTestSuite {
         )
       }
     }
-    test("compile") {
-      val eval = UnitTester(playsingleapi, resourcePath)
+    test("compile") - UnitTester(playsingleapi, resourcePath).scoped{eval =>
       val eitherResult = eval.apply(playsingleapi.compile)
       val Right(result) = eitherResult
       val outputFiles = os.walk(result.value.classes.path).filter(os.isFile)

--- a/contrib/playlib/test/src/mill/playlib/PlaySingleModuleTests.scala
+++ b/contrib/playlib/test/src/mill/playlib/PlaySingleModuleTests.scala
@@ -17,8 +17,7 @@ object PlaySingleModuleTests extends TestSuite with PlayTestSuite {
 
   def tests: Tests = Tests {
     test("layout") {
-      test("fromBuild") {
-        val eval = UnitTester(playsingle, resourcePath)
+      test("fromBuild") - UnitTester(playsingle, resourcePath).scoped{eval =>
         val Right(conf) = eval.apply(playsingle.conf)
         val Right(app) = eval.apply(playsingle.app)
         val Right(sources) = eval.apply(playsingle.sources)
@@ -41,8 +40,7 @@ object PlaySingleModuleTests extends TestSuite with PlayTestSuite {
         )
       }
     }
-    test("compile") {
-      val eval = UnitTester(playsingle, resourcePath)
+    test("compile") - UnitTester(playsingle, resourcePath).scoped{eval =>
       val eitherResult = eval.apply(playsingle.compile)
       val Right(result) = eitherResult
       val outputFiles = os.walk(result.value.classes.path).filter(os.isFile)

--- a/contrib/playlib/test/src/mill/playlib/PlaySingleModuleTests.scala
+++ b/contrib/playlib/test/src/mill/playlib/PlaySingleModuleTests.scala
@@ -17,7 +17,7 @@ object PlaySingleModuleTests extends TestSuite with PlayTestSuite {
 
   def tests: Tests = Tests {
     test("layout") {
-      test("fromBuild") - UnitTester(playsingle, resourcePath).scoped{eval =>
+      test("fromBuild") - UnitTester(playsingle, resourcePath).scoped { eval =>
         val Right(conf) = eval.apply(playsingle.conf)
         val Right(app) = eval.apply(playsingle.app)
         val Right(sources) = eval.apply(playsingle.sources)
@@ -40,7 +40,7 @@ object PlaySingleModuleTests extends TestSuite with PlayTestSuite {
         )
       }
     }
-    test("compile") - UnitTester(playsingle, resourcePath).scoped{eval =>
+    test("compile") - UnitTester(playsingle, resourcePath).scoped { eval =>
       val eitherResult = eval.apply(playsingle.compile)
       val Right(result) = eitherResult
       val outputFiles = os.walk(result.value.classes.path).filter(os.isFile)

--- a/contrib/playlib/test/src/mill/playlib/RouterModuleTests.scala
+++ b/contrib/playlib/test/src/mill/playlib/RouterModuleTests.scala
@@ -31,87 +31,90 @@ object RouterModuleTests extends TestSuite with PlayTestSuite {
     test("compileRouter") {
       matrix.foreach { case (scalaVersion, playVersion) =>
         skipUnsupportedVersions(playVersion) {
-          val eval = UnitTester(HelloWorld, resourcePath)
-          val eitherResult = eval.apply(HelloWorld.core(scalaVersion, playVersion).compileRouter)
-          val Right(result) = eitherResult
-          val outputFiles = os.walk(result.value.classes.path).filter(os.isFile)
-          val expectedClassfiles = Seq[os.RelPath](
-            os.RelPath("controllers/ReverseRoutes.scala"),
-            os.RelPath("controllers/routes.java"),
-            os.RelPath("router/Routes.scala"),
-            os.RelPath("router/RoutesPrefix.scala"),
-            os.RelPath("sub/Routes.scala"),
-            os.RelPath("sub/RoutesPrefix.scala"),
-            os.RelPath("controllers/javascript/JavaScriptReverseRoutes.scala")
-          ).map(
-            eval.outPath / "core" / scalaVersion / playVersion / "compileRouter.dest" / _
-          )
-          assert(
-            result.value.classes.path == eval.outPath / "core" / scalaVersion / playVersion / "compileRouter.dest",
-            outputFiles.nonEmpty,
-            outputFiles.forall(expectedClassfiles.contains),
-            outputFiles.size == 7,
-            result.evalCount > 0
-          )
+          UnitTester(HelloWorld, resourcePath).scoped{eval =>
+            val eitherResult = eval.apply(HelloWorld.core(scalaVersion, playVersion).compileRouter)
+            val Right(result) = eitherResult
+            val outputFiles = os.walk(result.value.classes.path).filter(os.isFile)
+            val expectedClassfiles = Seq[os.RelPath](
+              os.RelPath("controllers/ReverseRoutes.scala"),
+              os.RelPath("controllers/routes.java"),
+              os.RelPath("router/Routes.scala"),
+              os.RelPath("router/RoutesPrefix.scala"),
+              os.RelPath("sub/Routes.scala"),
+              os.RelPath("sub/RoutesPrefix.scala"),
+              os.RelPath("controllers/javascript/JavaScriptReverseRoutes.scala")
+            ).map(
+              eval.outPath / "core" / scalaVersion / playVersion / "compileRouter.dest" / _
+            )
+            assert(
+              result.value.classes.path == eval.outPath / "core" / scalaVersion / playVersion / "compileRouter.dest",
+              outputFiles.nonEmpty,
+              outputFiles.forall(expectedClassfiles.contains),
+              outputFiles.size == 7,
+              result.evalCount > 0
+            )
 
-          // don't recompile if nothing changed
-          val Right(result2) =
-            eval.apply(HelloWorld.core(scalaVersion, playVersion).compileRouter)
+            // don't recompile if nothing changed
+            val Right(result2) =
+              eval.apply(HelloWorld.core(scalaVersion, playVersion).compileRouter)
 
-          assert(result2.evalCount == 0)
+            assert(result2.evalCount == 0)
+          }
         }
       }
     }
     test("compileRouterInvalidRoutes") {
       matrix.foreach { case (scalaVersion, playVersion) =>
         skipUnsupportedVersions(playVersion) {
-          val eval = UnitTester(HelloWorld, invalidResourcePath)
-          val project = HelloWorld.core(scalaVersion, playVersion)
-          val eitherResult = eval.apply(project.compileRouter)
-          val Left(Failure(message, x)) = eitherResult
-          val playExpectedMessage =
-            if (playVersion.startsWith("2.6.")) {
-              "HTTP Verb (GET, POST, ...), include (->), comment (#), or modifier line (+) expected"
-            } else {
-              "end of input expected"
-            }
-          val expectedMessage = "Unable to compile play routes, compilation error in " +
-            project.millSourcePath.toIO.getAbsolutePath.replace(
-              """\""",
-              "/"
-            ) + "/routes/routes at line 4, " +
-            "column" + " 1: " + playExpectedMessage
-          // fix windows paths
-          val normalizeMessage = message.replace("""\""", "/")
-          assert(
-            normalizeMessage == expectedMessage
-          )
+          UnitTester(HelloWorld, invalidResourcePath).scoped{eval =>
+            val project = HelloWorld.core(scalaVersion, playVersion)
+            val eitherResult = eval.apply(project.compileRouter)
+            val Left(Failure(message, x)) = eitherResult
+            val playExpectedMessage =
+              if (playVersion.startsWith("2.6.")) {
+                "HTTP Verb (GET, POST, ...), include (->), comment (#), or modifier line (+) expected"
+              } else {
+                "end of input expected"
+              }
+            val expectedMessage = "Unable to compile play routes, compilation error in " +
+              project.millSourcePath.toIO.getAbsolutePath.replace(
+                """\""",
+                "/"
+              ) + "/routes/routes at line 4, " +
+              "column" + " 1: " + playExpectedMessage
+            // fix windows paths
+            val normalizeMessage = message.replace("""\""", "/")
+            assert(
+              normalizeMessage == expectedMessage
+            )
+          }
         }
       }
     }
     test("compileRouterInvalidSubRoutes") {
       matrix.foreach { case (scalaVersion, playVersion) =>
         skipUnsupportedVersions(playVersion) {
-          val eval = UnitTester(HelloWorld, invalidSubResourcePath)
-          val eitherResult = eval.apply(HelloWorld.core(scalaVersion, playVersion).compileRouter)
-          val Left(Failure(message, x)) = eitherResult
-          val playExpectedMessage =
-            if (playVersion.startsWith("2.6.")) {
-              "HTTP Verb (GET, POST, ...), include (->), comment (#), or modifier line (+) expected"
-            } else {
-              "end of input expected"
-            }
-          val expectedMessage = "Unable to compile play routes, compilation error in " +
-            HelloWorld.core.millSourcePath.toIO.getAbsolutePath.replace(
-              """\""",
-              "/"
-            ) + "/routes/sub.routes at line 3, column" +
-            " 1: " + playExpectedMessage
-          // fix windows paths
-          val normalizeMessage = message.replace("""\""", "/")
-          assert(
-            normalizeMessage == expectedMessage
-          )
+          UnitTester(HelloWorld, invalidSubResourcePath).scoped{eval =>
+            val eitherResult = eval.apply(HelloWorld.core(scalaVersion, playVersion).compileRouter)
+            val Left(Failure(message, x)) = eitherResult
+            val playExpectedMessage =
+              if (playVersion.startsWith("2.6.")) {
+                "HTTP Verb (GET, POST, ...), include (->), comment (#), or modifier line (+) expected"
+              } else {
+                "end of input expected"
+              }
+            val expectedMessage = "Unable to compile play routes, compilation error in " +
+              HelloWorld.core.millSourcePath.toIO.getAbsolutePath.replace(
+                """\""",
+                "/"
+              ) + "/routes/sub.routes at line 3, column" +
+              " 1: " + playExpectedMessage
+            // fix windows paths
+            val normalizeMessage = message.replace("""\""", "/")
+            assert(
+              normalizeMessage == expectedMessage
+            )
+          }
         }
       }
     }

--- a/contrib/playlib/test/src/mill/playlib/RouterModuleTests.scala
+++ b/contrib/playlib/test/src/mill/playlib/RouterModuleTests.scala
@@ -31,7 +31,7 @@ object RouterModuleTests extends TestSuite with PlayTestSuite {
     test("compileRouter") {
       matrix.foreach { case (scalaVersion, playVersion) =>
         skipUnsupportedVersions(playVersion) {
-          UnitTester(HelloWorld, resourcePath).scoped{eval =>
+          UnitTester(HelloWorld, resourcePath).scoped { eval =>
             val eitherResult = eval.apply(HelloWorld.core(scalaVersion, playVersion).compileRouter)
             val Right(result) = eitherResult
             val outputFiles = os.walk(result.value.classes.path).filter(os.isFile)
@@ -66,7 +66,7 @@ object RouterModuleTests extends TestSuite with PlayTestSuite {
     test("compileRouterInvalidRoutes") {
       matrix.foreach { case (scalaVersion, playVersion) =>
         skipUnsupportedVersions(playVersion) {
-          UnitTester(HelloWorld, invalidResourcePath).scoped{eval =>
+          UnitTester(HelloWorld, invalidResourcePath).scoped { eval =>
             val project = HelloWorld.core(scalaVersion, playVersion)
             val eitherResult = eval.apply(project.compileRouter)
             val Left(Failure(message, x)) = eitherResult
@@ -94,7 +94,7 @@ object RouterModuleTests extends TestSuite with PlayTestSuite {
     test("compileRouterInvalidSubRoutes") {
       matrix.foreach { case (scalaVersion, playVersion) =>
         skipUnsupportedVersions(playVersion) {
-          UnitTester(HelloWorld, invalidSubResourcePath).scoped{eval =>
+          UnitTester(HelloWorld, invalidSubResourcePath).scoped { eval =>
             val eitherResult = eval.apply(HelloWorld.core(scalaVersion, playVersion).compileRouter)
             val Left(Failure(message, x)) = eitherResult
             val playExpectedMessage =

--- a/contrib/proguard/test/src/mill/contrib/proguard/ProguardTests.scala
+++ b/contrib/proguard/test/src/mill/contrib/proguard/ProguardTests.scala
@@ -28,8 +28,7 @@ object ProguardTests extends TestSuite {
 
   def tests: Tests = Tests {
     test("Proguard module") {
-      test("should download proguard jars") {
-        val eval = UnitTester(proguard, testModuleSourcesPath)
+      test("should download proguard jars") - UnitTester(proguard, testModuleSourcesPath).scoped{eval =>
         val Right(result) = eval.apply(proguard.proguardClasspath)
         assert(
           result.value.iterator.toSeq.nonEmpty,
@@ -37,8 +36,7 @@ object ProguardTests extends TestSuite {
         )
       }
 
-      test("should create a proguarded jar") {
-        val eval = UnitTester(proguard, testModuleSourcesPath)
+      test("should create a proguarded jar") - UnitTester(proguard, testModuleSourcesPath).scoped{eval =>
         val Right(result) = eval.apply(proguard.proguard)
         assert(os.exists(result.value.path))
       }

--- a/contrib/proguard/test/src/mill/contrib/proguard/ProguardTests.scala
+++ b/contrib/proguard/test/src/mill/contrib/proguard/ProguardTests.scala
@@ -28,17 +28,19 @@ object ProguardTests extends TestSuite {
 
   def tests: Tests = Tests {
     test("Proguard module") {
-      test("should download proguard jars") - UnitTester(proguard, testModuleSourcesPath).scoped{eval =>
-        val Right(result) = eval.apply(proguard.proguardClasspath)
-        assert(
-          result.value.iterator.toSeq.nonEmpty,
-          result.value.iterator.toSeq.head.path.toString().contains("proguard-base")
-        )
+      test("should download proguard jars") - UnitTester(proguard, testModuleSourcesPath).scoped {
+        eval =>
+          val Right(result) = eval.apply(proguard.proguardClasspath)
+          assert(
+            result.value.iterator.toSeq.nonEmpty,
+            result.value.iterator.toSeq.head.path.toString().contains("proguard-base")
+          )
       }
 
-      test("should create a proguarded jar") - UnitTester(proguard, testModuleSourcesPath).scoped{eval =>
-        val Right(result) = eval.apply(proguard.proguard)
-        assert(os.exists(result.value.path))
+      test("should create a proguarded jar") - UnitTester(proguard, testModuleSourcesPath).scoped {
+        eval =>
+          val Right(result) = eval.apply(proguard.proguard)
+          assert(os.exists(result.value.path))
       }
     }
   }

--- a/contrib/scalapblib/test/src/mill/contrib/scalapblib/TutorialTests.scala
+++ b/contrib/scalapblib/test/src/mill/contrib/scalapblib/TutorialTests.scala
@@ -71,7 +71,7 @@ object TutorialTests extends TestSuite {
   def tests: Tests = Tests {
     test("scalapbVersion") {
 
-      test("fromBuild") - UnitTester(Tutorial, resourcePath).scoped{eval =>
+      test("fromBuild") - UnitTester(Tutorial, resourcePath).scoped { eval =>
         val Right(result) = eval.apply(Tutorial.core.scalaPBVersion)
 
         assert(
@@ -82,7 +82,7 @@ object TutorialTests extends TestSuite {
     }
 
     test("compileScalaPB") {
-      test("calledDirectly") - UnitTester(Tutorial, resourcePath).scoped{eval =>
+      test("calledDirectly") - UnitTester(Tutorial, resourcePath).scoped { eval =>
         val Right(result) = eval.apply(Tutorial.core.compileScalaPB)
 
         val outPath = protobufOutPath(eval)
@@ -105,7 +105,10 @@ object TutorialTests extends TestSuite {
         assert(result2.evalCount == 0)
       }
 
-      test("calledWithSpecificFile") - UnitTester(TutorialWithSpecificSources, resourcePath).scoped{eval =>
+      test("calledWithSpecificFile") - UnitTester(
+        TutorialWithSpecificSources,
+        resourcePath
+      ).scoped { eval =>
         val Right(result) = eval.apply(TutorialWithSpecificSources.core.compileScalaPB)
 
         val outPath = protobufOutPath(eval)
@@ -163,14 +166,18 @@ object TutorialTests extends TestSuite {
       /* This ensure that the `scalaPBProtocPath` is properly used.
        * As the given path is incorrect, the compilation should fail.
        */
-      test("calledWithWrongProtocFile") - UnitTester(TutorialWithProtoc, resourcePath).scoped{eval =>
-        val result = eval.apply(TutorialWithProtoc.core.compileScalaPB)
-        assert(result.isLeft)
+      test("calledWithWrongProtocFile") - UnitTester(TutorialWithProtoc, resourcePath).scoped {
+        eval =>
+          val result = eval.apply(TutorialWithProtoc.core.compileScalaPB)
+          assert(result.isLeft)
       }
     }
 
     test("compilationArgs") {
-      test("calledWithAdditionalArgs") - UnitTester(TutorialWithAdditionalArgs, resourcePath).scoped{eval =>
+      test("calledWithAdditionalArgs") - UnitTester(
+        TutorialWithAdditionalArgs,
+        resourcePath
+      ).scoped { eval =>
         val result =
           eval.apply(TutorialWithAdditionalArgs.core.scalaPBCompileOptions)
         result match {

--- a/contrib/scalapblib/test/src/mill/contrib/scalapblib/TutorialTests.scala
+++ b/contrib/scalapblib/test/src/mill/contrib/scalapblib/TutorialTests.scala
@@ -71,8 +71,7 @@ object TutorialTests extends TestSuite {
   def tests: Tests = Tests {
     test("scalapbVersion") {
 
-      test("fromBuild") {
-        val eval = UnitTester(Tutorial, resourcePath)
+      test("fromBuild") - UnitTester(Tutorial, resourcePath).scoped{eval =>
         val Right(result) = eval.apply(Tutorial.core.scalaPBVersion)
 
         assert(
@@ -83,8 +82,7 @@ object TutorialTests extends TestSuite {
     }
 
     test("compileScalaPB") {
-      test("calledDirectly") {
-        val eval = UnitTester(Tutorial, resourcePath)
+      test("calledDirectly") - UnitTester(Tutorial, resourcePath).scoped{eval =>
         val Right(result) = eval.apply(Tutorial.core.compileScalaPB)
 
         val outPath = protobufOutPath(eval)
@@ -107,8 +105,7 @@ object TutorialTests extends TestSuite {
         assert(result2.evalCount == 0)
       }
 
-      test("calledWithSpecificFile") {
-        val eval = UnitTester(TutorialWithSpecificSources, resourcePath)
+      test("calledWithSpecificFile") - UnitTester(TutorialWithSpecificSources, resourcePath).scoped{eval =>
         val Right(result) = eval.apply(TutorialWithSpecificSources.core.compileScalaPB)
 
         val outPath = protobufOutPath(eval)
@@ -166,16 +163,14 @@ object TutorialTests extends TestSuite {
       /* This ensure that the `scalaPBProtocPath` is properly used.
        * As the given path is incorrect, the compilation should fail.
        */
-      test("calledWithWrongProtocFile") {
-        val eval = UnitTester(TutorialWithProtoc, resourcePath)
+      test("calledWithWrongProtocFile") - UnitTester(TutorialWithProtoc, resourcePath).scoped{eval =>
         val result = eval.apply(TutorialWithProtoc.core.compileScalaPB)
         assert(result.isLeft)
       }
     }
 
     test("compilationArgs") {
-      test("calledWithAdditionalArgs") {
-        val eval = UnitTester(TutorialWithAdditionalArgs, resourcePath)
+      test("calledWithAdditionalArgs") - UnitTester(TutorialWithAdditionalArgs, resourcePath).scoped{eval =>
         val result =
           eval.apply(TutorialWithAdditionalArgs.core.scalaPBCompileOptions)
         result match {

--- a/contrib/scoverage/test/src/mill/contrib/scoverage/HelloWorldTests.scala
+++ b/contrib/scoverage/test/src/mill/contrib/scoverage/HelloWorldTests.scala
@@ -64,8 +64,7 @@ trait HelloWorldTests extends utest.TestSuite {
   def tests: utest.Tests = utest.Tests {
     test("HelloWorld") {
       test("core") {
-        test("scoverageVersion") {
-          val eval = UnitTester(HelloWorld, resourcePath)
+        test("scoverageVersion") - UnitTester(HelloWorld, resourcePath).scoped{eval =>
           val Right(result) = eval.apply(HelloWorld.core.scoverageVersion)
 
           assert(
@@ -74,8 +73,7 @@ trait HelloWorldTests extends utest.TestSuite {
           )
         }
         test("scoverage") {
-          test("unmanagedClasspath") {
-            val eval = UnitTester(HelloWorld, resourcePath)
+          test("unmanagedClasspath") - UnitTester(HelloWorld, resourcePath).scoped{eval =>
             val Right(result) =
               eval.apply(HelloWorld.core.scoverage.unmanagedClasspath)
 
@@ -84,8 +82,7 @@ trait HelloWorldTests extends utest.TestSuite {
               result.evalCount > 0
             )
           }
-          test("ivyDeps") {
-            val eval = UnitTester(HelloWorld, resourcePath)
+          test("ivyDeps") - UnitTester(HelloWorld, resourcePath).scoped{eval =>
             val Right(result) =
               eval.apply(HelloWorld.core.scoverage.ivyDeps)
 
@@ -99,8 +96,7 @@ trait HelloWorldTests extends utest.TestSuite {
               result.evalCount > 0
             )
           }
-          test("scalacPluginIvyDeps") {
-            val eval = UnitTester(HelloWorld, resourcePath)
+          test("scalacPluginIvyDeps") - UnitTester(HelloWorld, resourcePath).scoped{eval =>
             val Right(result) =
               eval.apply(HelloWorld.core.scoverage.scalacPluginIvyDeps)
 
@@ -123,8 +119,7 @@ trait HelloWorldTests extends utest.TestSuite {
               result.evalCount > 0
             )
           }
-          test("data") {
-            val eval = UnitTester(HelloWorld, resourcePath)
+          test("data") - UnitTester(HelloWorld, resourcePath).scoped{eval =>
             val Right(result) = eval.apply(HelloWorld.core.scoverage.data)
 
             val resultPath = result.value.path.toIO.getPath.replace("""\""", "/")
@@ -135,8 +130,7 @@ trait HelloWorldTests extends utest.TestSuite {
               result.evalCount > 0
             )
           }
-          test("htmlReport") {
-            val eval = UnitTester(HelloWorld, resourcePath)
+          test("htmlReport") - UnitTester(HelloWorld, resourcePath).scoped{eval =>
             val Right(_) = eval.apply(HelloWorld.core.test.compile)
             val res = eval.apply(HelloWorld.core.scoverage.htmlReport())
             if (
@@ -152,8 +146,7 @@ trait HelloWorldTests extends utest.TestSuite {
               ""
             }
           }
-          test("xmlReport") {
-            val eval = UnitTester(HelloWorld, resourcePath)
+          test("xmlReport") - UnitTester(HelloWorld, resourcePath).scoped{eval =>
             val Right(_) = eval.apply(HelloWorld.core.test.compile)
             val res = eval.apply(HelloWorld.core.scoverage.xmlReport())
             if (
@@ -169,8 +162,7 @@ trait HelloWorldTests extends utest.TestSuite {
               ""
             }
           }
-          test("xmlCoberturaReport") {
-            val eval = UnitTester(HelloWorld, resourcePath)
+          test("xmlCoberturaReport") - UnitTester(HelloWorld, resourcePath).scoped{eval =>
             val Right(_) = eval.apply(HelloWorld.core.test.compile)
             val res = eval.apply(HelloWorld.core.scoverage.xmlCoberturaReport())
             if (
@@ -186,16 +178,14 @@ trait HelloWorldTests extends utest.TestSuite {
               ""
             }
           }
-          test("console") {
-            val eval = UnitTester(HelloWorld, resourcePath)
+          test("console") - UnitTester(HelloWorld, resourcePath).scoped{eval =>
             val Right(_) = eval.apply(HelloWorld.core.test.compile)
             val Right(result) = eval.apply(HelloWorld.core.scoverage.consoleReport())
             assert(result.evalCount > 0)
           }
         }
         test("test") - {
-          test("upstreamAssemblyClasspath") {
-            val eval = UnitTester(HelloWorld, resourcePath)
+          test("upstreamAssemblyClasspath") - UnitTester(HelloWorld, resourcePath).scoped{eval =>
             val Right(result) =
               eval.apply(HelloWorld.core.scoverage.upstreamAssemblyClasspath)
 
@@ -213,8 +203,7 @@ trait HelloWorldTests extends utest.TestSuite {
               )
             }
           }
-          test("compileClasspath") {
-            val eval = UnitTester(HelloWorld, resourcePath)
+          test("compileClasspath") - UnitTester(HelloWorld, resourcePath).scoped{eval =>
             val Right(result) =
               eval.apply(HelloWorld.core.scoverage.compileClasspath)
 
@@ -232,8 +221,7 @@ trait HelloWorldTests extends utest.TestSuite {
               )
             }
           }
-          test("runClasspath") {
-            val eval = UnitTester(HelloWorld, resourcePath)
+          test("runClasspath") - UnitTester(HelloWorld, resourcePath).scoped{eval =>
             val Right(result) = eval.apply(HelloWorld.core.scoverage.runClasspath)
 
             val runtimeExistsOnClasspath =
@@ -256,20 +244,17 @@ trait HelloWorldTests extends utest.TestSuite {
     }
     test("HelloWorldSbt") {
       test("scoverage") {
-        test("htmlReport") {
-          val eval = UnitTester(HelloWorld, sbtResourcePath)
+        test("htmlReport") - UnitTester(HelloWorld, sbtResourcePath).scoped{eval =>
           val Right(_) = eval.apply(HelloWorldSbt.core.test.compile)
           val Right(result) = eval.apply(HelloWorldSbt.core.scoverage.htmlReport())
           assert(result.evalCount > 0)
         }
-        test("xmlReport") {
-          val eval = UnitTester(HelloWorld, sbtResourcePath)
+        test("xmlReport") - UnitTester(HelloWorld, sbtResourcePath).scoped{eval =>
           val Right(_) = eval.apply(HelloWorldSbt.core.test.compile)
           val Right(result) = eval.apply(HelloWorldSbt.core.scoverage.xmlReport())
           assert(result.evalCount > 0)
         }
-        test("console") {
-          val eval = UnitTester(HelloWorld, sbtResourcePath)
+        test("console") - UnitTester(HelloWorld, sbtResourcePath).scoped{eval =>
           val Right(_) = eval.apply(HelloWorldSbt.core.test.compile)
           val Right(result) =
             eval.apply(HelloWorldSbt.core.scoverage.consoleReport())
@@ -288,13 +273,11 @@ trait FailedWorldTests extends HelloWorldTests {
     test("HelloWorld") {
       val mod = HelloWorld
       test("shouldFail") {
-        test("scoverageToolsCp") {
-          val eval = UnitTester(mod, resourcePath)
+        test("scoverageToolsCp") - UnitTester(mod, resourcePath).scoped{eval =>
           val Left(Result.Failure(msg, _)) = eval.apply(mod.core.scoverageToolsClasspath)
           assert(msg == errorMsg)
         }
-        test("other") {
-          val eval = UnitTester(mod, resourcePath)
+        test("other") - UnitTester(mod, resourcePath).scoped{eval =>
           val Left(Result.Failure(msg, _)) = eval.apply(mod.core.scoverage.xmlReport())
           assert(msg == errorMsg)
         }
@@ -303,16 +286,14 @@ trait FailedWorldTests extends HelloWorldTests {
     test("HelloWorldSbt") {
       val mod = HelloWorldSbt
       test("shouldFail") {
-        test("scoverageToolsCp") {
-          val eval = UnitTester(mod, resourcePath)
+        test("scoverageToolsCp") - UnitTester(mod, resourcePath).scoped{eval =>
           val res = eval.apply(mod.core.scoverageToolsClasspath)
           assert(res.isLeft)
           println(s"res: ${res}")
           val Left(Result.Failure(msg, _)) = res
           assert(msg == errorMsg)
         }
-        test("other") {
-          val eval = UnitTester(mod, resourcePath)
+        test("other") - UnitTester(mod, resourcePath).scoped{eval =>
           val Left(Result.Failure(msg, _)) = eval.apply(mod.core.scoverage.xmlReport())
           assert(msg == errorMsg)
         }

--- a/contrib/scoverage/test/src/mill/contrib/scoverage/HelloWorldTests.scala
+++ b/contrib/scoverage/test/src/mill/contrib/scoverage/HelloWorldTests.scala
@@ -64,7 +64,7 @@ trait HelloWorldTests extends utest.TestSuite {
   def tests: utest.Tests = utest.Tests {
     test("HelloWorld") {
       test("core") {
-        test("scoverageVersion") - UnitTester(HelloWorld, resourcePath).scoped{eval =>
+        test("scoverageVersion") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
           val Right(result) = eval.apply(HelloWorld.core.scoverageVersion)
 
           assert(
@@ -73,7 +73,7 @@ trait HelloWorldTests extends utest.TestSuite {
           )
         }
         test("scoverage") {
-          test("unmanagedClasspath") - UnitTester(HelloWorld, resourcePath).scoped{eval =>
+          test("unmanagedClasspath") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
             val Right(result) =
               eval.apply(HelloWorld.core.scoverage.unmanagedClasspath)
 
@@ -82,7 +82,7 @@ trait HelloWorldTests extends utest.TestSuite {
               result.evalCount > 0
             )
           }
-          test("ivyDeps") - UnitTester(HelloWorld, resourcePath).scoped{eval =>
+          test("ivyDeps") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
             val Right(result) =
               eval.apply(HelloWorld.core.scoverage.ivyDeps)
 
@@ -96,7 +96,7 @@ trait HelloWorldTests extends utest.TestSuite {
               result.evalCount > 0
             )
           }
-          test("scalacPluginIvyDeps") - UnitTester(HelloWorld, resourcePath).scoped{eval =>
+          test("scalacPluginIvyDeps") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
             val Right(result) =
               eval.apply(HelloWorld.core.scoverage.scalacPluginIvyDeps)
 
@@ -119,7 +119,7 @@ trait HelloWorldTests extends utest.TestSuite {
               result.evalCount > 0
             )
           }
-          test("data") - UnitTester(HelloWorld, resourcePath).scoped{eval =>
+          test("data") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
             val Right(result) = eval.apply(HelloWorld.core.scoverage.data)
 
             val resultPath = result.value.path.toIO.getPath.replace("""\""", "/")
@@ -130,7 +130,7 @@ trait HelloWorldTests extends utest.TestSuite {
               result.evalCount > 0
             )
           }
-          test("htmlReport") - UnitTester(HelloWorld, resourcePath).scoped{eval =>
+          test("htmlReport") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
             val Right(_) = eval.apply(HelloWorld.core.test.compile)
             val res = eval.apply(HelloWorld.core.scoverage.htmlReport())
             if (
@@ -146,7 +146,7 @@ trait HelloWorldTests extends utest.TestSuite {
               ""
             }
           }
-          test("xmlReport") - UnitTester(HelloWorld, resourcePath).scoped{eval =>
+          test("xmlReport") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
             val Right(_) = eval.apply(HelloWorld.core.test.compile)
             val res = eval.apply(HelloWorld.core.scoverage.xmlReport())
             if (
@@ -162,7 +162,7 @@ trait HelloWorldTests extends utest.TestSuite {
               ""
             }
           }
-          test("xmlCoberturaReport") - UnitTester(HelloWorld, resourcePath).scoped{eval =>
+          test("xmlCoberturaReport") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
             val Right(_) = eval.apply(HelloWorld.core.test.compile)
             val res = eval.apply(HelloWorld.core.scoverage.xmlCoberturaReport())
             if (
@@ -178,14 +178,14 @@ trait HelloWorldTests extends utest.TestSuite {
               ""
             }
           }
-          test("console") - UnitTester(HelloWorld, resourcePath).scoped{eval =>
+          test("console") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
             val Right(_) = eval.apply(HelloWorld.core.test.compile)
             val Right(result) = eval.apply(HelloWorld.core.scoverage.consoleReport())
             assert(result.evalCount > 0)
           }
         }
         test("test") - {
-          test("upstreamAssemblyClasspath") - UnitTester(HelloWorld, resourcePath).scoped{eval =>
+          test("upstreamAssemblyClasspath") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
             val Right(result) =
               eval.apply(HelloWorld.core.scoverage.upstreamAssemblyClasspath)
 
@@ -203,7 +203,7 @@ trait HelloWorldTests extends utest.TestSuite {
               )
             }
           }
-          test("compileClasspath") - UnitTester(HelloWorld, resourcePath).scoped{eval =>
+          test("compileClasspath") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
             val Right(result) =
               eval.apply(HelloWorld.core.scoverage.compileClasspath)
 
@@ -221,7 +221,7 @@ trait HelloWorldTests extends utest.TestSuite {
               )
             }
           }
-          test("runClasspath") - UnitTester(HelloWorld, resourcePath).scoped{eval =>
+          test("runClasspath") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
             val Right(result) = eval.apply(HelloWorld.core.scoverage.runClasspath)
 
             val runtimeExistsOnClasspath =
@@ -244,17 +244,17 @@ trait HelloWorldTests extends utest.TestSuite {
     }
     test("HelloWorldSbt") {
       test("scoverage") {
-        test("htmlReport") - UnitTester(HelloWorld, sbtResourcePath).scoped{eval =>
+        test("htmlReport") - UnitTester(HelloWorld, sbtResourcePath).scoped { eval =>
           val Right(_) = eval.apply(HelloWorldSbt.core.test.compile)
           val Right(result) = eval.apply(HelloWorldSbt.core.scoverage.htmlReport())
           assert(result.evalCount > 0)
         }
-        test("xmlReport") - UnitTester(HelloWorld, sbtResourcePath).scoped{eval =>
+        test("xmlReport") - UnitTester(HelloWorld, sbtResourcePath).scoped { eval =>
           val Right(_) = eval.apply(HelloWorldSbt.core.test.compile)
           val Right(result) = eval.apply(HelloWorldSbt.core.scoverage.xmlReport())
           assert(result.evalCount > 0)
         }
-        test("console") - UnitTester(HelloWorld, sbtResourcePath).scoped{eval =>
+        test("console") - UnitTester(HelloWorld, sbtResourcePath).scoped { eval =>
           val Right(_) = eval.apply(HelloWorldSbt.core.test.compile)
           val Right(result) =
             eval.apply(HelloWorldSbt.core.scoverage.consoleReport())
@@ -273,11 +273,11 @@ trait FailedWorldTests extends HelloWorldTests {
     test("HelloWorld") {
       val mod = HelloWorld
       test("shouldFail") {
-        test("scoverageToolsCp") - UnitTester(mod, resourcePath).scoped{eval =>
+        test("scoverageToolsCp") - UnitTester(mod, resourcePath).scoped { eval =>
           val Left(Result.Failure(msg, _)) = eval.apply(mod.core.scoverageToolsClasspath)
           assert(msg == errorMsg)
         }
-        test("other") - UnitTester(mod, resourcePath).scoped{eval =>
+        test("other") - UnitTester(mod, resourcePath).scoped { eval =>
           val Left(Result.Failure(msg, _)) = eval.apply(mod.core.scoverage.xmlReport())
           assert(msg == errorMsg)
         }
@@ -286,14 +286,14 @@ trait FailedWorldTests extends HelloWorldTests {
     test("HelloWorldSbt") {
       val mod = HelloWorldSbt
       test("shouldFail") {
-        test("scoverageToolsCp") - UnitTester(mod, resourcePath).scoped{eval =>
+        test("scoverageToolsCp") - UnitTester(mod, resourcePath).scoped { eval =>
           val res = eval.apply(mod.core.scoverageToolsClasspath)
           assert(res.isLeft)
           println(s"res: ${res}")
           val Left(Result.Failure(msg, _)) = res
           assert(msg == errorMsg)
         }
-        test("other") - UnitTester(mod, resourcePath).scoped{eval =>
+        test("other") - UnitTester(mod, resourcePath).scoped { eval =>
           val Left(Result.Failure(msg, _)) = eval.apply(mod.core.scoverage.xmlReport())
           assert(msg == errorMsg)
         }

--- a/contrib/testng/test/src/mill/testng/TestNGTests.scala
+++ b/contrib/testng/test/src/mill/testng/TestNGTests.scala
@@ -42,16 +42,14 @@ object TestNGTests extends TestSuite {
 
   def tests: Tests = Tests {
     test("TestNG") {
-      test("demo") {
-        val eval = UnitTester(demo, resourcePath)
+      test("demo") - UnitTester(demo, resourcePath).scoped{eval =>
         val Right(result) = eval.apply(demo.test.testFramework)
         assert(
           result.value == "mill.testng.TestNGFramework",
           result.evalCount > 0
         )
       }
-      test("Test case lookup from inherited annotations") {
-        val eval = UnitTester(demo, resourcePath)
+      test("Test case lookup from inherited annotations") - UnitTester(demo, resourcePath).scoped{eval =>
         val Right(result) = eval.apply(demo.test.test())
         val tres = result.value.asInstanceOf[(String, Seq[mill.testrunner.TestResult])]
         assert(

--- a/contrib/testng/test/src/mill/testng/TestNGTests.scala
+++ b/contrib/testng/test/src/mill/testng/TestNGTests.scala
@@ -42,19 +42,20 @@ object TestNGTests extends TestSuite {
 
   def tests: Tests = Tests {
     test("TestNG") {
-      test("demo") - UnitTester(demo, resourcePath).scoped{eval =>
+      test("demo") - UnitTester(demo, resourcePath).scoped { eval =>
         val Right(result) = eval.apply(demo.test.testFramework)
         assert(
           result.value == "mill.testng.TestNGFramework",
           result.evalCount > 0
         )
       }
-      test("Test case lookup from inherited annotations") - UnitTester(demo, resourcePath).scoped{eval =>
-        val Right(result) = eval.apply(demo.test.test())
-        val tres = result.value.asInstanceOf[(String, Seq[mill.testrunner.TestResult])]
-        assert(
-          tres._2.size == 8
-        )
+      test("Test case lookup from inherited annotations") - UnitTester(demo, resourcePath).scoped {
+        eval =>
+          val Right(result) = eval.apply(demo.test.test())
+          val tres = result.value.asInstanceOf[(String, Seq[mill.testrunner.TestResult])]
+          assert(
+            tres._2.size == 8
+          )
       }
     }
   }

--- a/contrib/twirllib/test/src/mill/twirllib/HelloWorldTests.scala
+++ b/contrib/twirllib/test/src/mill/twirllib/HelloWorldTests.scala
@@ -66,8 +66,7 @@ trait HelloWorldTests extends TestSuite {
   def tests: Tests = Tests {
     test("twirlVersion") {
 
-      test("fromBuild") {
-        val eval = UnitTester(HelloWorld, resourcePath / "hello-world")
+      test("fromBuild") - UnitTester(HelloWorld, resourcePath / "hello-world").scoped{eval =>
         val Right(result) =
           eval.apply(HelloWorld.core.twirlVersion)
 
@@ -79,79 +78,81 @@ trait HelloWorldTests extends TestSuite {
     }
     test("compileTwirl") {
       skipUnsupportedVersions {
-        val eval = UnitTester(HelloWorld, resourcePath / "hello-world", debugEnabled = true)
-        val res = eval.apply(HelloWorld.core.compileTwirl)
-        assert(res.isRight)
-        val Right(result) = res
+        UnitTester(HelloWorld, resourcePath / "hello-world", debugEnabled = true).scoped{eval =>
+          val res = eval.apply(HelloWorld.core.compileTwirl)
+          assert(res.isRight)
+          val Right(result) = res
 
-        val outputFiles = os.walk(result.value.classes.path).filter(_.last.endsWith(".scala"))
-        val expectedClassfiles = compileClassfiles.map(
-          eval.outPath / "core" / "compileTwirl.dest" / _
-        )
+          val outputFiles = os.walk(result.value.classes.path).filter(_.last.endsWith(".scala"))
+          val expectedClassfiles = compileClassfiles.map(
+            eval.outPath / "core" / "compileTwirl.dest" / _
+          )
 
-        assert(
-          result.value.classes.path == eval.outPath / "core" / "compileTwirl.dest",
-          outputFiles.nonEmpty,
-          outputFiles.forall(expectedClassfiles.contains),
-          outputFiles.size == 3,
-          result.evalCount > 0,
-          outputFiles.forall { p =>
-            val lines = os.read.lines(p).map(_.trim)
-            (expectedDefaultImports ++ testAdditionalImports.map(s => s"import $s")).forall(
-              lines.contains
-            )
-          },
-          outputFiles.filter(_.toString().contains("hello.template.scala")).forall { p =>
-            val lines = os.read.lines(p).map(_.trim)
-            val expectedClassDeclaration = s"class hello ${testConstructorAnnotations.mkString}"
-            lines.exists(_.startsWith(expectedClassDeclaration))
-          }
-        )
+          assert(
+            result.value.classes.path == eval.outPath / "core" / "compileTwirl.dest",
+            outputFiles.nonEmpty,
+            outputFiles.forall(expectedClassfiles.contains),
+            outputFiles.size == 3,
+            result.evalCount > 0,
+            outputFiles.forall { p =>
+              val lines = os.read.lines(p).map(_.trim)
+              (expectedDefaultImports ++ testAdditionalImports.map(s => s"import $s")).forall(
+                lines.contains
+              )
+            },
+            outputFiles.filter(_.toString().contains("hello.template.scala")).forall { p =>
+              val lines = os.read.lines(p).map(_.trim)
+              val expectedClassDeclaration = s"class hello ${testConstructorAnnotations.mkString}"
+              lines.exists(_.startsWith(expectedClassDeclaration))
+            }
+          )
 
-        // don't recompile if nothing changed
-        val Right(result2) =
-          eval.apply(HelloWorld.core.compileTwirl)
+          // don't recompile if nothing changed
+          val Right(result2) =
+            eval.apply(HelloWorld.core.compileTwirl)
 
-        assert(result2.evalCount == 0)
+          assert(result2.evalCount == 0)
+        }
       }
     }
 
     test("compileTwirlInclusiveDot") {
       skipUnsupportedVersions {
-        val eval = UnitTester(
+        UnitTester(
           HelloWorldWithInclusiveDot,
           sourceRoot = resourcePath / "hello-world-inclusive-dot"
-        )
+        ).scoped{eval =>
 
-        val Right(result) = eval.apply(HelloWorldWithInclusiveDot.core.compileTwirl)
+          val Right(result) = eval.apply(HelloWorldWithInclusiveDot.core.compileTwirl)
 
-        val outputFiles = os.walk(result.value.classes.path).filter(_.last.endsWith(".scala"))
-        val expectedClassfiles = compileClassfiles.map(name =>
-          eval.outPath / "core" / "compileTwirl.dest" / name / os.RelPath.up / name.last.replace(
-            ".template.scala",
-            "$$TwirlInclusiveDot.template.scala"
+          val outputFiles = os.walk(result.value.classes.path).filter(_.last.endsWith(".scala"))
+          val expectedClassfiles = compileClassfiles.map(name =>
+            eval.outPath / "core" / "compileTwirl.dest" / name / os.RelPath.up / name.last.replace(
+              ".template.scala",
+              "$$TwirlInclusiveDot.template.scala"
+            )
           )
-        )
 
-        println(s"outputFiles: $outputFiles")
+          println(s"outputFiles: $outputFiles")
 
-        assert(
-          result.value.classes.path == eval.outPath / "core" / "compileTwirl.dest",
-          outputFiles.nonEmpty,
-          outputFiles.forall(expectedClassfiles.contains),
-          outputFiles.size == 3,
-          result.evalCount > 0,
-          outputFiles.filter(_.toString().contains("hello.template.scala")).forall { p =>
-            val lines = os.read.lines(p).map(_.trim)
-            lines.exists(_.contains("$$TwirlInclusiveDot"))
-          }
-        )
+          assert(
+            result.value.classes.path == eval.outPath / "core" / "compileTwirl.dest",
+            outputFiles.nonEmpty,
+            outputFiles.forall(expectedClassfiles.contains),
+            outputFiles.size == 3,
+            result.evalCount > 0,
+            outputFiles.filter(_.toString().contains("hello.template.scala")).forall { p =>
+              val lines = os.read.lines(p).map(_.trim)
+              lines.exists(_.contains("$$TwirlInclusiveDot"))
+            }
+          )
 
-        // don't recompile if nothing changed
-        val Right(result2) =
-          eval.apply(HelloWorld.core.compileTwirl)
+          // don't recompile if nothing changed
+          val Right(result2) =
+            eval.apply(HelloWorld.core.compileTwirl)
 
-        assert(result2.evalCount == 0)
+          assert(result2.evalCount == 0)
+        }
       }
     }
   }

--- a/contrib/twirllib/test/src/mill/twirllib/HelloWorldTests.scala
+++ b/contrib/twirllib/test/src/mill/twirllib/HelloWorldTests.scala
@@ -66,7 +66,7 @@ trait HelloWorldTests extends TestSuite {
   def tests: Tests = Tests {
     test("twirlVersion") {
 
-      test("fromBuild") - UnitTester(HelloWorld, resourcePath / "hello-world").scoped{eval =>
+      test("fromBuild") - UnitTester(HelloWorld, resourcePath / "hello-world").scoped { eval =>
         val Right(result) =
           eval.apply(HelloWorld.core.twirlVersion)
 
@@ -78,7 +78,7 @@ trait HelloWorldTests extends TestSuite {
     }
     test("compileTwirl") {
       skipUnsupportedVersions {
-        UnitTester(HelloWorld, resourcePath / "hello-world", debugEnabled = true).scoped{eval =>
+        UnitTester(HelloWorld, resourcePath / "hello-world", debugEnabled = true).scoped { eval =>
           val res = eval.apply(HelloWorld.core.compileTwirl)
           assert(res.isRight)
           val Right(result) = res
@@ -121,8 +121,7 @@ trait HelloWorldTests extends TestSuite {
         UnitTester(
           HelloWorldWithInclusiveDot,
           sourceRoot = resourcePath / "hello-world-inclusive-dot"
-        ).scoped{eval =>
-
+        ).scoped { eval =>
           val Right(result) = eval.apply(HelloWorldWithInclusiveDot.core.compileTwirl)
 
           val outputFiles = os.walk(result.value.classes.path).filter(_.last.endsWith(".scala"))

--- a/contrib/versionfile/test/src/mill/contrib/versionfile/VersionFileModuleTests.scala
+++ b/contrib/versionfile/test/src/mill/contrib/versionfile/VersionFileModuleTests.scala
@@ -15,8 +15,7 @@ object VersionFileModuleTests extends TestSuite {
       m: M,
       vf: M => VersionFileModule,
       versionText: String
-  ): UnitTester = {
-    val eval = UnitTester(m, null)
+  ): UnitTester = UnitTester(m, null).scoped{eval =>
     os.write.over(
       vf(m).millSourcePath / "version",
       versionText,

--- a/contrib/versionfile/test/src/mill/contrib/versionfile/VersionFileModuleTests.scala
+++ b/contrib/versionfile/test/src/mill/contrib/versionfile/VersionFileModuleTests.scala
@@ -15,7 +15,7 @@ object VersionFileModuleTests extends TestSuite {
       m: M,
       vf: M => VersionFileModule,
       versionText: String
-  ): UnitTester = UnitTester(m, null).scoped{eval =>
+  ): UnitTester = UnitTester(m, null).scoped { eval =>
     os.write.over(
       vf(m).millSourcePath / "version",
       versionText,

--- a/example/extending/plugins/7-writing-mill-plugins/myplugin/test/src/mill/testkit/UnitTests.scala
+++ b/example/extending/plugins/7-writing-mill-plugins/myplugin/test/src/mill/testkit/UnitTests.scala
@@ -6,31 +6,32 @@ import utest._
 object UnitTests extends TestSuite {
   def tests: Tests = Tests {
     test("unit") {
-      object build extends TestBaseModule with LineCountJavaModule{
+      object build extends TestBaseModule with LineCountJavaModule {
         def lineCountResourceFileName = "line-count.txt"
       }
 
       val resourceFolder = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER"))
-      val eval = UnitTester(build, resourceFolder/ "unit-test-project")
+      UnitTester(build, resourceFolder / "unit-test-project").scoped { eval =>
 
-      // Evaluating tasks by direct reference
-      val Right(result) = eval(build.resources)
-      assert(
-        result.value.exists(pathref =>
-          os.exists(pathref.path / "line-count.txt") &&
-          os.read(pathref.path / "line-count.txt") == "17"
+        // Evaluating tasks by direct reference
+        val Right(result) = eval(build.resources)
+        assert(
+          result.value.exists(pathref =>
+            os.exists(pathref.path / "line-count.txt") &&
+              os.read(pathref.path / "line-count.txt") == "17"
+          )
         )
-      )
 
-      // Evaluating tasks by passing in their Mill selector
-      val Right(result2) = eval("resources")
-      val Seq(pathrefs: Seq[mill.api.PathRef]) = result2.value
-      assert(
-        pathrefs.exists(pathref =>
-          os.exists(pathref.path / "line-count.txt") &&
-            os.read(pathref.path / "line-count.txt") == "17"
+        // Evaluating tasks by passing in their Mill selector
+        val Right(result2) = eval("resources")
+        val Seq(pathrefs: Seq[mill.api.PathRef]) = result2.value
+        assert(
+          pathrefs.exists(pathref =>
+            os.exists(pathref.path / "line-count.txt") &&
+              os.read(pathref.path / "line-count.txt") == "17"
+          )
         )
-      )
+      }
     }
   }
 }

--- a/main/test/src/mill/main/MainModuleTests.scala
+++ b/main/test/src/mill/main/MainModuleTests.scala
@@ -63,7 +63,7 @@ object MainModuleTests extends TestSuite {
   override def tests: Tests = Tests {
 
     test("inspect") {
-      test("single") - UnitTester(mainModule, null).scoped{eval =>
+      test("single") - UnitTester(mainModule, null).scoped { eval =>
         val res = eval.evaluator.evaluate(Agg(mainModule.inspect(eval.evaluator, "hello")))
         val Result.Success(Val(value: String)) = res.rawValues.head
         assert(
@@ -72,7 +72,7 @@ object MainModuleTests extends TestSuite {
           value.contains("MainModuleTests.scala:")
         )
       }
-      test("multi") - UnitTester(mainModule, null).scoped{eval =>
+      test("multi") - UnitTester(mainModule, null).scoped { eval =>
         val res =
           eval.evaluator.evaluate(Agg(mainModule.inspect(eval.evaluator, "hello", "hello2")))
         val Result.Success(Val(value: String)) = res.rawValues.head
@@ -83,7 +83,7 @@ object MainModuleTests extends TestSuite {
           value.contains("\n\nhello2(")
         )
       }
-      test("command") - UnitTester(mainModule, null).scoped{eval =>
+      test("command") - UnitTester(mainModule, null).scoped { eval =>
         val Right(result) = eval.apply("inspect", "helloCommand")
 
         val Seq(res: String) = result.value

--- a/main/test/src/mill/main/MainModuleTests.scala
+++ b/main/test/src/mill/main/MainModuleTests.scala
@@ -63,8 +63,7 @@ object MainModuleTests extends TestSuite {
   override def tests: Tests = Tests {
 
     test("inspect") {
-      val eval = UnitTester(mainModule, null)
-      test("single") {
+      test("single") - UnitTester(mainModule, null).scoped{eval =>
         val res = eval.evaluator.evaluate(Agg(mainModule.inspect(eval.evaluator, "hello")))
         val Result.Success(Val(value: String)) = res.rawValues.head
         assert(
@@ -73,7 +72,7 @@ object MainModuleTests extends TestSuite {
           value.contains("MainModuleTests.scala:")
         )
       }
-      test("multi") {
+      test("multi") - UnitTester(mainModule, null).scoped{eval =>
         val res =
           eval.evaluator.evaluate(Agg(mainModule.inspect(eval.evaluator, "hello", "hello2")))
         val Result.Success(Val(value: String)) = res.rawValues.head
@@ -84,7 +83,7 @@ object MainModuleTests extends TestSuite {
           value.contains("\n\nhello2(")
         )
       }
-      test("command") {
+      test("command") - UnitTester(mainModule, null).scoped{eval =>
         val Right(result) = eval.apply("inspect", "helloCommand")
 
         val Seq(res: String) = result.value

--- a/main/util/src/mill/util/CoursierSupport.scala
+++ b/main/util/src/mill/util/CoursierSupport.scala
@@ -41,9 +41,9 @@ trait CoursierSupport {
       case Failure(e)
           if retryCount > 0
             && e.getMessage.contains("__sha1.computed")
-            && (e.isInstanceOf[NoSuchFileException] || e.isInstanceOf[
-              java.nio.file.AccessDeniedException
-            ]) =>
+            && (e.isInstanceOf[NoSuchFileException] ||
+              e.isInstanceOf[java.nio.file.AccessDeniedException] ||
+              e.isInstanceOf[java.io.FileNotFoundException]) =>
         // this one is not detected by coursier itself, so we try-catch handle it
         // I assume, this happens when another coursier thread already moved or rename dthe temporary file
         ctx.foreach(_.log.debug(

--- a/scalajslib/test/src/mill/scalajslib/FullOptESModuleTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/FullOptESModuleTests.scala
@@ -22,8 +22,7 @@ object FullOptESModuleTests extends TestSuite {
   val millSourcePath = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "hello-js-world"
 
   val tests: Tests = Tests {
-    test("fullOpt with ESModule moduleKind") {
-      val eval = UnitTester(FullOptESModuleModule, millSourcePath)
+    test("fullOpt with ESModule moduleKind") - UnitTester(FullOptESModuleModule, millSourcePath).scoped{eval =>
       val result = eval(FullOptESModuleModule.fullOptESModuleModule.fullOpt)
       assert(result.isRight)
     }

--- a/scalajslib/test/src/mill/scalajslib/FullOptESModuleTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/FullOptESModuleTests.scala
@@ -22,7 +22,10 @@ object FullOptESModuleTests extends TestSuite {
   val millSourcePath = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "hello-js-world"
 
   val tests: Tests = Tests {
-    test("fullOpt with ESModule moduleKind") - UnitTester(FullOptESModuleModule, millSourcePath).scoped{eval =>
+    test("fullOpt with ESModule moduleKind") - UnitTester(
+      FullOptESModuleModule,
+      millSourcePath
+    ).scoped { eval =>
       val result = eval(FullOptESModuleModule.fullOptESModuleModule.fullOpt)
       assert(result.isRight)
     }

--- a/scalajslib/test/src/mill/scalajslib/HelloJSWorldTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/HelloJSWorldTests.scala
@@ -81,7 +81,7 @@ object HelloJSWorldTests extends TestSuite {
   val millSourcePath = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "hello-js-world"
 
   def tests: Tests = Tests {
-    test("compile") - UnitTester(HelloJSWorld, millSourcePath).scoped{eval =>
+    test("compile") - UnitTester(HelloJSWorld, millSourcePath).scoped { eval =>
       def testCompileFromScratch(scalaVersion: String, scalaJSVersion: String): Unit = {
         val Right(result) =
           eval(HelloJSWorld.build(scalaVersion, scalaJSVersion).compile)
@@ -108,7 +108,7 @@ object HelloJSWorldTests extends TestSuite {
         scalaJSVersion: String,
         optimize: Boolean,
         legacy: Boolean
-    ): Unit = UnitTester(HelloJSWorld, millSourcePath).scoped{eval =>
+    ): Unit = UnitTester(HelloJSWorld, millSourcePath).scoped { eval =>
       val module = HelloJSWorld.build(scalaVersion, scalaJSVersion)
       val jsFile =
         if (legacy) {
@@ -153,7 +153,7 @@ object HelloJSWorldTests extends TestSuite {
       )
     }
     test("jar") {
-      test("containsSJSIRs") - UnitTester(HelloJSWorld, millSourcePath).scoped{eval =>
+      test("containsSJSIRs") - UnitTester(HelloJSWorld, millSourcePath).scoped { eval =>
         val (scala, scalaJS) = HelloJSWorld.matrix.head
         val Right(result) =
           eval(HelloJSWorld.build(scala, scalaJS).jar)
@@ -166,13 +166,14 @@ object HelloJSWorldTests extends TestSuite {
       }
     }
     test("publish") {
-      def testArtifactId(scalaVersion: String, scalaJSVersion: String, artifactId: String): Unit = UnitTester(HelloJSWorld, millSourcePath).scoped{eval =>
-        val Right(result) = eval(HelloJSWorld.build(
-          scalaVersion,
-          scalaJSVersion
-        ).artifactMetadata)
-        assert(result.value.id == artifactId)
-      }
+      def testArtifactId(scalaVersion: String, scalaJSVersion: String, artifactId: String): Unit =
+        UnitTester(HelloJSWorld, millSourcePath).scoped { eval =>
+          val Right(result) = eval(HelloJSWorld.build(
+            scalaVersion,
+            scalaJSVersion
+          ).artifactMetadata)
+          assert(result.value.id == artifactId)
+        }
       test("artifactId_10") {
         testArtifactId(
           HelloJSWorld.scalaVersions.head,
@@ -190,16 +191,17 @@ object HelloJSWorldTests extends TestSuite {
     }
 
     def runTests(testTask: define.NamedTask[(String, Seq[TestResult])])
-        : Map[String, Map[String, TestResult]] = UnitTester(HelloJSWorld, millSourcePath).scoped{eval =>
-      val Left(Result.Failure(_, Some(res))) = eval(testTask)
+        : Map[String, Map[String, TestResult]] =
+      UnitTester(HelloJSWorld, millSourcePath).scoped { eval =>
+        val Left(Result.Failure(_, Some(res))) = eval(testTask)
 
-      val (doneMsg, testResults) = res
-      testResults
-        .groupBy(_.fullyQualifiedName)
-        .view
-        .mapValues(_.map(e => e.selector -> e).toMap)
-        .toMap
-    }
+        val (doneMsg, testResults) = res
+        testResults
+          .groupBy(_.fullyQualifiedName)
+          .view
+          .mapValues(_.map(e => e.selector -> e).toMap)
+          .toMap
+      }
 
     def checkUtest(scalaVersion: String, scalaJSVersion: String, cached: Boolean) = {
       val resultMap = runTests(
@@ -259,32 +261,34 @@ object HelloJSWorldTests extends TestSuite {
       )
     }
 
-    def checkRun(scalaVersion: String, scalaJSVersion: String): Unit = UnitTester(HelloJSWorld, millSourcePath).scoped{eval =>
-      val task = HelloJSWorld.build(scalaVersion, scalaJSVersion).run()
+    def checkRun(scalaVersion: String, scalaJSVersion: String): Unit =
+      UnitTester(HelloJSWorld, millSourcePath).scoped { eval =>
+        val task = HelloJSWorld.build(scalaVersion, scalaJSVersion).run()
 
-      val Right(result) = eval(task)
+        val Right(result) = eval(task)
 
-      val paths = EvaluatorPaths.resolveDestPaths(eval.outPath, task)
-      val log = os.read(paths.log)
-      assert(
-        result.evalCount > 0,
-        log.contains("node")
-        // TODO: reenable somehow
-        // In Scala.js 1.x, println's are sent to the stdout, not to the logger
-        // log.contains("Scala.js")
-      )
-    }
+        val paths = EvaluatorPaths.resolveDestPaths(eval.outPath, task)
+        val log = os.read(paths.log)
+        assert(
+          result.evalCount > 0,
+          log.contains("node")
+          // TODO: reenable somehow
+          // In Scala.js 1.x, println's are sent to the stdout, not to the logger
+          // log.contains("Scala.js")
+        )
+      }
 
     test("run") {
       testAllMatrix((scala, scalaJS) => checkRun(scala, scalaJS))
     }
 
-    def checkInheritedTargets[A](target: ScalaJSModule => T[A], expected: A) = UnitTester(HelloJSWorld, millSourcePath).scoped{eval =>
-      val Right(mainResult) = eval(target(HelloJSWorld.inherited))
-      val Right(testResult) = eval(target(HelloJSWorld.inherited.test))
-      assert(mainResult.value == expected)
-      assert(testResult.value == expected)
-    }
+    def checkInheritedTargets[A](target: ScalaJSModule => T[A], expected: A) =
+      UnitTester(HelloJSWorld, millSourcePath).scoped { eval =>
+        val Right(mainResult) = eval(target(HelloJSWorld.inherited))
+        val Right(testResult) = eval(target(HelloJSWorld.inherited.test))
+        assert(mainResult.value == expected)
+        assert(testResult.value == expected)
+      }
     test("test-scalacOptions") {
       checkInheritedTargets(_.scalacOptions, Seq("-deprecation"))
     }

--- a/scalajslib/test/src/mill/scalajslib/HelloJSWorldTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/HelloJSWorldTests.scala
@@ -28,7 +28,7 @@ object HelloJSWorldTests extends TestSuite {
 
   object HelloJSWorld extends TestBaseModule {
     val scalaVersions = Seq("2.13.3", "3.0.0-RC1", "2.12.12")
-    val scalaJSVersions = Seq("1.8.0", "1.3.1", "1.0.1")
+    val scalaJSVersions = Seq("1.8.0", "1.0.1")
     val matrix = for {
       scala <- scalaVersions
       scalaJS <- scalaJSVersions
@@ -81,8 +81,7 @@ object HelloJSWorldTests extends TestSuite {
   val millSourcePath = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "hello-js-world"
 
   def tests: Tests = Tests {
-    test("compile") {
-      val eval = UnitTester(HelloJSWorld, millSourcePath)
+    test("compile") - UnitTester(HelloJSWorld, millSourcePath).scoped{eval =>
       def testCompileFromScratch(scalaVersion: String, scalaJSVersion: String): Unit = {
         val Right(result) =
           eval(HelloJSWorld.build(scalaVersion, scalaJSVersion).compile)
@@ -109,8 +108,7 @@ object HelloJSWorldTests extends TestSuite {
         scalaJSVersion: String,
         optimize: Boolean,
         legacy: Boolean
-    ): Unit = {
-      val eval = UnitTester(HelloJSWorld, millSourcePath)
+    ): Unit = UnitTester(HelloJSWorld, millSourcePath).scoped{eval =>
       val module = HelloJSWorld.build(scalaVersion, scalaJSVersion)
       val jsFile =
         if (legacy) {
@@ -155,8 +153,7 @@ object HelloJSWorldTests extends TestSuite {
       )
     }
     test("jar") {
-      test("containsSJSIRs") {
-        val eval = UnitTester(HelloJSWorld, millSourcePath)
+      test("containsSJSIRs") - UnitTester(HelloJSWorld, millSourcePath).scoped{eval =>
         val (scala, scalaJS) = HelloJSWorld.matrix.head
         val Right(result) =
           eval(HelloJSWorld.build(scala, scalaJS).jar)
@@ -169,8 +166,7 @@ object HelloJSWorldTests extends TestSuite {
       }
     }
     test("publish") {
-      val eval = UnitTester(HelloJSWorld, millSourcePath)
-      def testArtifactId(scalaVersion: String, scalaJSVersion: String, artifactId: String): Unit = {
+      def testArtifactId(scalaVersion: String, scalaJSVersion: String, artifactId: String): Unit = UnitTester(HelloJSWorld, millSourcePath).scoped{eval =>
         val Right(result) = eval(HelloJSWorld.build(
           scalaVersion,
           scalaJSVersion
@@ -194,8 +190,7 @@ object HelloJSWorldTests extends TestSuite {
     }
 
     def runTests(testTask: define.NamedTask[(String, Seq[TestResult])])
-        : Map[String, Map[String, TestResult]] = {
-      val eval = UnitTester(HelloJSWorld, millSourcePath)
+        : Map[String, Map[String, TestResult]] = UnitTester(HelloJSWorld, millSourcePath).scoped{eval =>
       val Left(Result.Failure(_, Some(res))) = eval(testTask)
 
       val (doneMsg, testResults) = res
@@ -264,8 +259,7 @@ object HelloJSWorldTests extends TestSuite {
       )
     }
 
-    def checkRun(scalaVersion: String, scalaJSVersion: String): Unit = {
-      val eval = UnitTester(HelloJSWorld, millSourcePath)
+    def checkRun(scalaVersion: String, scalaJSVersion: String): Unit = UnitTester(HelloJSWorld, millSourcePath).scoped{eval =>
       val task = HelloJSWorld.build(scalaVersion, scalaJSVersion).run()
 
       val Right(result) = eval(task)
@@ -285,8 +279,7 @@ object HelloJSWorldTests extends TestSuite {
       testAllMatrix((scala, scalaJS) => checkRun(scala, scalaJS))
     }
 
-    def checkInheritedTargets[A](target: ScalaJSModule => T[A], expected: A) = {
-      val eval = UnitTester(HelloJSWorld, millSourcePath)
+    def checkInheritedTargets[A](target: ScalaJSModule => T[A], expected: A) = UnitTester(HelloJSWorld, millSourcePath).scoped{eval =>
       val Right(mainResult) = eval(target(HelloJSWorld.inherited))
       val Right(testResult) = eval(target(HelloJSWorld.inherited.test))
       assert(mainResult.value == expected)

--- a/scalalib/test/src/mill/scalalib/AssemblyTests.scala
+++ b/scalalib/test/src/mill/scalalib/AssemblyTests.scala
@@ -75,22 +75,19 @@ object AssemblyTests extends TestSuite {
   def tests: Tests = Tests {
     test("Assembly") {
       test("noExe") {
-        test("small") {
-          val eval = UnitTester(TestCase, sourceRoot = sources)
+        test("small") - UnitTester(TestCase, sourceRoot = sources).scoped{eval =>
           val Right(result) = eval(TestCase.noExe.small.assembly)
           runAssembly(result.value.path, TestCase.millSourcePath)
 
         }
-        test("large") {
-          val eval = UnitTester(TestCase, sourceRoot = sources)
+        test("large") - UnitTester(TestCase, sourceRoot = sources).scoped{eval =>
           val Right(result) = eval(TestCase.noExe.large.assembly)
           runAssembly(result.value.path, TestCase.millSourcePath)
 
         }
       }
       test("exe") {
-        test("small") {
-          val eval = UnitTester(TestCase, sourceRoot = sources)
+        test("small") - UnitTester(TestCase, sourceRoot = sources).scoped{eval =>
           val Right(result) = eval(TestCase.exe.small.assembly)
           val originalPath = result.value.path
           val resolvedPath =
@@ -102,8 +99,7 @@ object AssemblyTests extends TestSuite {
           runAssembly(resolvedPath, TestCase.millSourcePath, checkExe = true)
         }
 
-        test("large-should-fail") {
-          val eval = UnitTester(TestCase, sourceRoot = sources)
+        test("large-should-fail") - UnitTester(TestCase, sourceRoot = sources).scoped{eval =>
           val Left(Result.Failure(msg, Some(res))) = eval(TestCase.exe.large.assembly)
           val expectedMsg =
             """The created assembly jar contains more than 65535 ZIP entries.

--- a/scalalib/test/src/mill/scalalib/AssemblyTests.scala
+++ b/scalalib/test/src/mill/scalalib/AssemblyTests.scala
@@ -75,19 +75,19 @@ object AssemblyTests extends TestSuite {
   def tests: Tests = Tests {
     test("Assembly") {
       test("noExe") {
-        test("small") - UnitTester(TestCase, sourceRoot = sources).scoped{eval =>
+        test("small") - UnitTester(TestCase, sourceRoot = sources).scoped { eval =>
           val Right(result) = eval(TestCase.noExe.small.assembly)
           runAssembly(result.value.path, TestCase.millSourcePath)
 
         }
-        test("large") - UnitTester(TestCase, sourceRoot = sources).scoped{eval =>
+        test("large") - UnitTester(TestCase, sourceRoot = sources).scoped { eval =>
           val Right(result) = eval(TestCase.noExe.large.assembly)
           runAssembly(result.value.path, TestCase.millSourcePath)
 
         }
       }
       test("exe") {
-        test("small") - UnitTester(TestCase, sourceRoot = sources).scoped{eval =>
+        test("small") - UnitTester(TestCase, sourceRoot = sources).scoped { eval =>
           val Right(result) = eval(TestCase.exe.small.assembly)
           val originalPath = result.value.path
           val resolvedPath =
@@ -99,7 +99,7 @@ object AssemblyTests extends TestSuite {
           runAssembly(resolvedPath, TestCase.millSourcePath, checkExe = true)
         }
 
-        test("large-should-fail") - UnitTester(TestCase, sourceRoot = sources).scoped{eval =>
+        test("large-should-fail") - UnitTester(TestCase, sourceRoot = sources).scoped { eval =>
           val Left(Result.Failure(msg, Some(res))) = eval(TestCase.exe.large.assembly)
           val expectedMsg =
             """The created assembly jar contains more than 65535 ZIP entries.

--- a/scalalib/test/src/mill/scalalib/CoursierMirrorTests.scala
+++ b/scalalib/test/src/mill/scalalib/CoursierMirrorTests.scala
@@ -18,7 +18,7 @@ object CoursierMirrorTests extends TestSuite {
 
   def tests: Tests = Tests {
     sys.props("coursier.mirrors") = (resourcePath / "mirror.properties").toString
-    test("readMirror") - UnitTester(CoursierTest, resourcePath).scoped{eval =>
+    test("readMirror") - UnitTester(CoursierTest, resourcePath).scoped { eval =>
       val Right(result) = eval.apply(CoursierTest.core.repositoriesTask)
       val centralReplaced = result.value.exists { repo =>
         repo.repr.contains("https://repo.maven.apache.org/maven2")

--- a/scalalib/test/src/mill/scalalib/CoursierMirrorTests.scala
+++ b/scalalib/test/src/mill/scalalib/CoursierMirrorTests.scala
@@ -18,8 +18,7 @@ object CoursierMirrorTests extends TestSuite {
 
   def tests: Tests = Tests {
     sys.props("coursier.mirrors") = (resourcePath / "mirror.properties").toString
-    test("readMirror") {
-      val eval = UnitTester(CoursierTest, resourcePath)
+    test("readMirror") - UnitTester(CoursierTest, resourcePath).scoped{eval =>
       val Right(result) = eval.apply(CoursierTest.core.repositoriesTask)
       val centralReplaced = result.value.exists { repo =>
         repo.repr.contains("https://repo.maven.apache.org/maven2")

--- a/scalalib/test/src/mill/scalalib/CycleTests.scala
+++ b/scalalib/test/src/mill/scalalib/CycleTests.scala
@@ -33,15 +33,13 @@ object CycleTests extends TestSuite {
 
   override def tests: Tests = Tests {
     test("moduleDeps") {
-      test("self-reference") {
-        val eval = UnitTester(CycleBase, null)
+      test("self-reference") - UnitTester(CycleBase, null).scoped{eval =>
         val ex = intercept[BuildScriptException] {
           eval.apply(CycleBase.a.compile)
         }
         assert(ex.getMessage.contains("a.moduleDeps: cycle detected: a -> a"))
       }
-      test("cycle-in-deps") {
-        val eval = UnitTester(CycleBase, null)
+      test("cycle-in-deps") - UnitTester(CycleBase, null).scoped{eval =>
         val ex = intercept[BuildScriptException] {
           eval.apply(CycleBase.e.compile)
         }
@@ -49,8 +47,7 @@ object CycleTests extends TestSuite {
       }
     }
     test("compileModuleDeps") {
-      test("self-reference") {
-        val eval = UnitTester(CycleBase, null)
+      test("self-reference") - UnitTester(CycleBase, null).scoped{eval =>
         val ex = intercept[BuildScriptException] {
           eval.apply(CycleBase.f.compile)
         }

--- a/scalalib/test/src/mill/scalalib/CycleTests.scala
+++ b/scalalib/test/src/mill/scalalib/CycleTests.scala
@@ -33,13 +33,13 @@ object CycleTests extends TestSuite {
 
   override def tests: Tests = Tests {
     test("moduleDeps") {
-      test("self-reference") - UnitTester(CycleBase, null).scoped{eval =>
+      test("self-reference") - UnitTester(CycleBase, null).scoped { eval =>
         val ex = intercept[BuildScriptException] {
           eval.apply(CycleBase.a.compile)
         }
         assert(ex.getMessage.contains("a.moduleDeps: cycle detected: a -> a"))
       }
-      test("cycle-in-deps") - UnitTester(CycleBase, null).scoped{eval =>
+      test("cycle-in-deps") - UnitTester(CycleBase, null).scoped { eval =>
         val ex = intercept[BuildScriptException] {
           eval.apply(CycleBase.e.compile)
         }
@@ -47,7 +47,7 @@ object CycleTests extends TestSuite {
       }
     }
     test("compileModuleDeps") {
-      test("self-reference") - UnitTester(CycleBase, null).scoped{eval =>
+      test("self-reference") - UnitTester(CycleBase, null).scoped { eval =>
         val ex = intercept[BuildScriptException] {
           eval.apply(CycleBase.f.compile)
         }

--- a/scalalib/test/src/mill/scalalib/DottyDocTests.scala
+++ b/scalalib/test/src/mill/scalalib/DottyDocTests.scala
@@ -35,8 +35,7 @@ object DottyDocTests extends TestSuite {
   val resourcePath = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "dottydoc"
 
   def tests: Tests = Tests {
-    test("static") {
-      val eval = UnitTester(StaticDocsModule, resourcePath)
+    test("static") - UnitTester(StaticDocsModule, resourcePath).scoped{eval =>
       val Right(_) = eval.apply(StaticDocsModule.static.docJar)
       val dest = eval.outPath / "static" / "docJar.dest"
       assert(
@@ -48,8 +47,7 @@ object DottyDocTests extends TestSuite {
         os.exists(dest / "javadoc" / "_site" / "api" / "pkg" / "SomeClass.html")
       )
     }
-    test("empty") {
-      val eval = UnitTester(EmptyDocsModule, resourcePath)
+    test("empty") - UnitTester(EmptyDocsModule, resourcePath).scoped{eval =>
       val Right(_) = eval.apply(EmptyDocsModule.empty.docJar)
       val dest = eval.outPath / "empty" / "docJar.dest"
       assert(
@@ -57,8 +55,7 @@ object DottyDocTests extends TestSuite {
         os.exists(dest / "javadoc" / "_site" / "api" / "pkg" / "SomeClass.html")
       )
     }
-    test("multiple") {
-      val eval = UnitTester(MultiDocsModule, resourcePath)
+    test("multiple") - UnitTester(MultiDocsModule, resourcePath).scoped{eval =>
       val Right(_) = eval.apply(MultiDocsModule.multidocs.docJar)
       val dest = eval.outPath / "multidocs" / "docJar.dest"
       assert(

--- a/scalalib/test/src/mill/scalalib/DottyDocTests.scala
+++ b/scalalib/test/src/mill/scalalib/DottyDocTests.scala
@@ -35,7 +35,7 @@ object DottyDocTests extends TestSuite {
   val resourcePath = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "dottydoc"
 
   def tests: Tests = Tests {
-    test("static") - UnitTester(StaticDocsModule, resourcePath).scoped{eval =>
+    test("static") - UnitTester(StaticDocsModule, resourcePath).scoped { eval =>
       val Right(_) = eval.apply(StaticDocsModule.static.docJar)
       val dest = eval.outPath / "static" / "docJar.dest"
       assert(
@@ -47,7 +47,7 @@ object DottyDocTests extends TestSuite {
         os.exists(dest / "javadoc" / "_site" / "api" / "pkg" / "SomeClass.html")
       )
     }
-    test("empty") - UnitTester(EmptyDocsModule, resourcePath).scoped{eval =>
+    test("empty") - UnitTester(EmptyDocsModule, resourcePath).scoped { eval =>
       val Right(_) = eval.apply(EmptyDocsModule.empty.docJar)
       val dest = eval.outPath / "empty" / "docJar.dest"
       assert(
@@ -55,7 +55,7 @@ object DottyDocTests extends TestSuite {
         os.exists(dest / "javadoc" / "_site" / "api" / "pkg" / "SomeClass.html")
       )
     }
-    test("multiple") - UnitTester(MultiDocsModule, resourcePath).scoped{eval =>
+    test("multiple") - UnitTester(MultiDocsModule, resourcePath).scoped { eval =>
       val Right(_) = eval.apply(MultiDocsModule.multidocs.docJar)
       val dest = eval.outPath / "multidocs" / "docJar.dest"
       assert(

--- a/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
+++ b/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
@@ -410,7 +410,7 @@ object HelloWorldTests extends TestSuite {
   def tests: Tests = Tests {
     test("scalaVersion") {
 
-      test("fromBuild") - UnitTester(HelloWorld, resourcePath).scoped{eval =>
+      test("fromBuild") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
         val Right(result) = eval.apply(HelloWorld.core.scalaVersion)
 
         assert(
@@ -418,7 +418,7 @@ object HelloWorldTests extends TestSuite {
           result.evalCount > 0
         )
       }
-      test("override") - UnitTester(HelloWorldScalaOverride, resourcePath).scoped{eval =>
+      test("override") - UnitTester(HelloWorldScalaOverride, resourcePath).scoped { eval =>
         val Right(result) = eval.apply(HelloWorldScalaOverride.core.scalaVersion)
 
         assert(
@@ -429,7 +429,7 @@ object HelloWorldTests extends TestSuite {
     }
 
     test("scalacOptions") {
-      test("emptyByDefault") - UnitTester(HelloWorld, resourcePath).scoped{eval =>
+      test("emptyByDefault") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
         val Right(result) = eval.apply(HelloWorld.core.scalacOptions)
 
         assert(
@@ -437,7 +437,7 @@ object HelloWorldTests extends TestSuite {
           result.evalCount > 0
         )
       }
-      test("override") - UnitTester(HelloWorldFatalWarnings, resourcePath).scoped{eval =>
+      test("override") - UnitTester(HelloWorldFatalWarnings, resourcePath).scoped { eval =>
         val Right(result) = eval.apply(HelloWorldFatalWarnings.core.scalacOptions)
 
         assert(
@@ -448,21 +448,21 @@ object HelloWorldTests extends TestSuite {
     }
 
     test("scalaDocOptions") {
-      test("emptyByDefault") - UnitTester(HelloWorld, resourcePath).scoped{eval =>
+      test("emptyByDefault") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
         val Right(result) = eval.apply(HelloWorld.core.scalaDocOptions)
         assert(
           result.value.isEmpty,
           result.evalCount > 0
         )
       }
-      test("override") - UnitTester(HelloWorldDocTitle, resourcePath).scoped{eval =>
+      test("override") - UnitTester(HelloWorldDocTitle, resourcePath).scoped { eval =>
         val Right(result) = eval.apply(HelloWorldDocTitle.core.scalaDocOptions)
         assert(
           result.value == Seq("-doc-title", "Hello World"),
           result.evalCount > 0
         )
       }
-      test("extend") - UnitTester(HelloWorldWithDocVersion, resourcePath).scoped{eval =>
+      test("extend") - UnitTester(HelloWorldWithDocVersion, resourcePath).scoped { eval =>
         val Right(result) = eval.apply(HelloWorldWithDocVersion.core.scalaDocOptions)
         assert(
           result.value == Seq("-Ywarn-unused", "-Xfatal-warnings", "-doc-version", "1.2.3"),
@@ -473,7 +473,7 @@ object HelloWorldTests extends TestSuite {
       test("docJarWithTitle") - UnitTester(
         HelloWorldDocTitle,
         sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "hello-world"
-      ).scoped{eval =>
+      ).scoped { eval =>
         val Right(result) = eval.apply(HelloWorldDocTitle.core.docJar)
         assert(
           result.evalCount > 0,
@@ -485,21 +485,21 @@ object HelloWorldTests extends TestSuite {
       test("docJarWithVersion") - UnitTester(
         HelloWorldWithDocVersion,
         sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "hello-world"
-      ).scoped{eval =>
+      ).scoped { eval =>
         // scaladoc generation fails because of "-Xfatal-warnings" flag
         val Left(Result.Failure(_, None)) = eval.apply(HelloWorldWithDocVersion.core.docJar)
       }
       test("docJarOnlyVersion") - UnitTester(
-          HelloWorldOnlyDocVersion,
-          sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "hello-world"
-        ).scoped{eval =>
+        HelloWorldOnlyDocVersion,
+        sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "hello-world"
+      ).scoped { eval =>
         // `docJar` requires the `compile` task to succeed (since the addition of Scaladoc 3)
         val Left(Result.Failure(_, None)) = eval.apply(HelloWorldOnlyDocVersion.core.docJar)
       }
     }
 
     test("scalacPluginClasspath") {
-      test("withMacroParadise") - UnitTester(HelloWorldTypeLevel, resourcePath).scoped{eval =>
+      test("withMacroParadise") - UnitTester(HelloWorldTypeLevel, resourcePath).scoped { eval =>
         val Right(result) = eval.apply(HelloWorldTypeLevel.foo.scalacPluginClasspath)
         assert(
           result.value.nonEmpty,
@@ -510,7 +510,7 @@ object HelloWorldTests extends TestSuite {
     }
 
     test("scalaDocPluginClasspath") {
-      test("extend") - UnitTester(HelloWorldTypeLevel, sourceRoot = resourcePath).scoped{eval =>
+      test("extend") - UnitTester(HelloWorldTypeLevel, sourceRoot = resourcePath).scoped { eval =>
         val Right(result) = eval.apply(HelloWorldTypeLevel.foo.scalaDocPluginClasspath)
         assert(
           result.value.iterator.nonEmpty,
@@ -522,7 +522,7 @@ object HelloWorldTests extends TestSuite {
     }
 
     test("compile") {
-      test("fromScratch") - UnitTester(HelloWorld, sourceRoot = resourcePath).scoped{eval =>
+      test("fromScratch") - UnitTester(HelloWorld, sourceRoot = resourcePath).scoped { eval =>
         val Right(result) = eval.apply(HelloWorld.core.compile)
 
         val classesPath = eval.outPath / "core" / "compile.dest" / "classes"
@@ -549,7 +549,10 @@ object HelloWorldTests extends TestSuite {
         ))
       }
 
-      test("nonPreCompiledBridge") - UnitTester(HelloWorldNonPrecompiledBridge, sourceRoot = resourcePath).scoped{eval =>
+      test("nonPreCompiledBridge") - UnitTester(
+        HelloWorldNonPrecompiledBridge,
+        sourceRoot = resourcePath
+      ).scoped { eval =>
         val Right(result) = eval.apply(HelloWorldNonPrecompiledBridge.core.compile)
 
         val classesPath = eval.outPath / "core" / "compile.dest" / "classes"
@@ -577,7 +580,7 @@ object HelloWorldTests extends TestSuite {
         ))
       }
 
-      test("recompileOnChange") - UnitTester(HelloWorld, sourceRoot = resourcePath).scoped{eval =>
+      test("recompileOnChange") - UnitTester(HelloWorld, sourceRoot = resourcePath).scoped { eval =>
         val Right(result) = eval.apply(HelloWorld.core.compile)
         assert(result.evalCount > 0)
 
@@ -586,7 +589,7 @@ object HelloWorldTests extends TestSuite {
         val Right(result2) = eval.apply(HelloWorld.core.compile)
         assert(result2.evalCount > 0, result2.evalCount < result.evalCount)
       }
-      test("failOnError") - UnitTester(HelloWorld, sourceRoot = resourcePath).scoped{eval =>
+      test("failOnError") - UnitTester(HelloWorld, sourceRoot = resourcePath).scoped { eval =>
         os.write.append(HelloWorld.millSourcePath / "core" / "src" / "Main.scala", "val x: ")
 
         val Left(Result.Failure("Compilation failed", _)) = eval.apply(HelloWorld.core.compile)
@@ -607,7 +610,10 @@ object HelloWorldTests extends TestSuite {
 
         val Right(_) = eval.apply(HelloWorld.core.compile)
       }
-      test("passScalacOptions") - UnitTester(HelloWorldFatalWarnings, sourceRoot = resourcePath).scoped{eval =>
+      test("passScalacOptions") - UnitTester(
+        HelloWorldFatalWarnings,
+        sourceRoot = resourcePath
+      ).scoped { eval =>
         // compilation fails because of "-Xfatal-warnings" flag
         val Left(Result.Failure("Compilation failed", _)) =
           eval.apply(HelloWorldFatalWarnings.core.compile)
@@ -620,7 +626,7 @@ object HelloWorldTests extends TestSuite {
         os.sub / "META-INF" / "semanticdb" / "core" / "src" / "Result.scala.semanticdb"
       )
 
-      test("fromScratch") - UnitTester(SemanticWorld, sourceRoot = resourcePath).scoped{eval =>
+      test("fromScratch") - UnitTester(SemanticWorld, sourceRoot = resourcePath).scoped { eval =>
         {
           println("first - expected full compile")
           val Right(result) = eval.apply(SemanticWorld.core.semanticDbData)
@@ -645,7 +651,11 @@ object HelloWorldTests extends TestSuite {
           assert(result2.evalCount == 0)
         }
       }
-      test("incremental") - UnitTester(SemanticWorld, sourceRoot = resourcePath, debugEnabled = true).scoped{eval =>
+      test("incremental") - UnitTester(
+        SemanticWorld,
+        sourceRoot = resourcePath,
+        debugEnabled = true
+      ).scoped { eval =>
         // create some more source file to have a reasonable low incremental change later
         val extraFiles = Seq("Second", "Third", "Fourth").map { f =>
           val file = eval.evaluator.workspace / "core" / "src" / "hello" / s"${f}.scala"
@@ -715,10 +725,11 @@ object HelloWorldTests extends TestSuite {
       }
     }
 
-    test("artifactNameCross") - UnitTester(CrossHelloWorld, sourceRoot = resourcePath).scoped{eval =>
-      val Right(result) =
-        eval.apply(CrossHelloWorld.core(scala213Version).artifactName)
-      assert(result.value == "core")
+    test("artifactNameCross") - UnitTester(CrossHelloWorld, sourceRoot = resourcePath).scoped {
+      eval =>
+        val Right(result) =
+          eval.apply(CrossHelloWorld.core(scala213Version).artifactName)
+        assert(result.value == "core")
     }
 
     test("scala-33-depend-on-scala-32-works") {
@@ -734,7 +745,7 @@ object HelloWorldTests extends TestSuite {
     }
 
     test("runMain") {
-      test("runMainObject") - UnitTester(HelloWorld, resourcePath).scoped{eval =>
+      test("runMainObject") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
         val runResult = eval.outPath / "core" / "runMain.dest" / "hello-mill"
 
         val Right(result) = eval.apply(HelloWorld.core.runMain("Main", runResult.toString))
@@ -766,19 +777,19 @@ object HelloWorldTests extends TestSuite {
           cross(eval, scala2123Version, s"${scala2123Version} leet")
 
         }
-        test("v2124") - UnitTester(CrossHelloWorld, resourcePath).scoped{eval =>
+        test("v2124") - UnitTester(CrossHelloWorld, resourcePath).scoped { eval =>
           cross(eval, scala212Version, s"${scala212Version} leet")
         }
-        test("v2131") - UnitTester(CrossHelloWorld, resourcePath).scoped{eval =>
+        test("v2131") - UnitTester(CrossHelloWorld, resourcePath).scoped { eval =>
           cross(eval, scala213Version, s"${scala213Version} idk")
         }
       }
 
-      test("notRunInvalidMainObject") - UnitTester(HelloWorld, resourcePath).scoped{eval =>
+      test("notRunInvalidMainObject") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
         val Left(Result.Failure("Subprocess failed", _)) =
           eval.apply(HelloWorld.core.runMain("Invalid"))
       }
-      test("notRunWhenCompileFailed") - UnitTester(HelloWorld, resourcePath).scoped{eval =>
+      test("notRunWhenCompileFailed") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
         os.write.append(HelloWorld.millSourcePath / "core" / "src" / "Main.scala", "val x: ")
 
         val Left(Result.Failure("Compilation failed", _)) =
@@ -788,7 +799,7 @@ object HelloWorldTests extends TestSuite {
     }
 
     test("forkRun") {
-      test("runIfMainClassProvided") - UnitTester(HelloWorldWithMain, resourcePath).scoped{eval =>
+      test("runIfMainClassProvided") - UnitTester(HelloWorldWithMain, resourcePath).scoped { eval =>
         val runResult = eval.outPath / "core" / "run.dest" / "hello-mill"
         val Right(result) = eval.apply(
           HelloWorldWithMain.core.run(T.task(Args(runResult.toString)))
@@ -804,29 +815,30 @@ object HelloWorldTests extends TestSuite {
       test("notRunWithoutMainClass") - UnitTester(
         HelloWorldWithoutMain,
         sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "hello-world-no-main"
-      ).scoped{eval =>
+      ).scoped { eval =>
         val Left(Result.Failure(_, None)) = eval.apply(HelloWorldWithoutMain.core.run())
       }
 
-      test("runDiscoverMainClass") - UnitTester(HelloWorldWithoutMain, resourcePath).scoped{eval =>
-        // Make sure even if there isn't a main class defined explicitly, it gets
-        // discovered by Zinc and used
-        val runResult = eval.outPath / "core" / "run.dest" / "hello-mill"
-        val Right(result) = eval.apply(
-          HelloWorldWithoutMain.core.run(T.task(Args(runResult.toString)))
-        )
+      test("runDiscoverMainClass") - UnitTester(HelloWorldWithoutMain, resourcePath).scoped {
+        eval =>
+          // Make sure even if there isn't a main class defined explicitly, it gets
+          // discovered by Zinc and used
+          val runResult = eval.outPath / "core" / "run.dest" / "hello-mill"
+          val Right(result) = eval.apply(
+            HelloWorldWithoutMain.core.run(T.task(Args(runResult.toString)))
+          )
 
-        assert(result.evalCount > 0)
+          assert(result.evalCount > 0)
 
-        assert(
-          os.exists(runResult),
-          os.read(runResult) == "hello rockjam, your age is: 25"
-        )
+          assert(
+            os.exists(runResult),
+            os.read(runResult) == "hello rockjam, your age is: 25"
+          )
       }
     }
 
     test("run") {
-      test("runIfMainClassProvided") - UnitTester(HelloWorldWithMain, resourcePath).scoped{eval =>
+      test("runIfMainClassProvided") - UnitTester(HelloWorldWithMain, resourcePath).scoped { eval =>
         val runResult = eval.outPath / "core" / "run.dest" / "hello-mill"
         val Right(result) = eval.apply(
           HelloWorldWithMain.core.runLocal(T.task(Args(runResult.toString)))
@@ -839,7 +851,7 @@ object HelloWorldTests extends TestSuite {
           os.read(runResult) == "hello rockjam, your age is: 25"
         )
       }
-      test("runWithDefaultMain") - UnitTester(HelloWorldDefaultMain, resourcePath).scoped{eval =>
+      test("runWithDefaultMain") - UnitTester(HelloWorldDefaultMain, resourcePath).scoped { eval =>
         val runResult = eval.outPath / "core" / "run.dest" / "hello-mill"
         val Right(result) = eval.apply(
           HelloWorldDefaultMain.core.runLocal(T.task(Args(runResult.toString)))
@@ -855,13 +867,13 @@ object HelloWorldTests extends TestSuite {
       test("notRunWithoutMainClass") - UnitTester(
         HelloWorldWithoutMain,
         sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "hello-world-no-main"
-      ).scoped{eval =>
+      ).scoped { eval =>
         val Left(Result.Failure(_, None)) = eval.apply(HelloWorldWithoutMain.core.runLocal())
       }
     }
 
     test("jar") {
-      test("nonEmpty") - UnitTester(HelloWorldWithMain, resourcePath).scoped{eval =>
+      test("nonEmpty") - UnitTester(HelloWorldWithMain, resourcePath).scoped { eval =>
         val Right(result) = eval.apply(HelloWorldWithMain.core.jar)
 
         assert(
@@ -889,7 +901,7 @@ object HelloWorldTests extends TestSuite {
         }
       }
 
-      test("logOutputToFile") - UnitTester(HelloWorld, resourcePath).scoped{eval =>
+      test("logOutputToFile") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
         val outPath = eval.outPath
         eval.apply(HelloWorld.core.compile)
 
@@ -899,7 +911,7 @@ object HelloWorldTests extends TestSuite {
     }
 
     test("assembly") {
-      test("assembly") - UnitTester(HelloWorldWithMain, resourcePath).scoped{eval =>
+      test("assembly") - UnitTester(HelloWorldWithMain, resourcePath).scoped { eval =>
         val Right(result) = eval.apply(HelloWorldWithMain.core.assembly)
         assert(
           os.exists(result.value.path),
@@ -917,28 +929,29 @@ object HelloWorldTests extends TestSuite {
       }
 
       test("assemblyRules") {
-        def checkAppend[M <: mill.testkit.TestBaseModule](module: M, target: Target[PathRef]) = UnitTester(module, resourcePath).scoped{eval =>
-          val Right(result) = eval.apply(target)
+        def checkAppend[M <: mill.testkit.TestBaseModule](module: M, target: Target[PathRef]) =
+          UnitTester(module, resourcePath).scoped { eval =>
+            val Right(result) = eval.apply(target)
 
-          Using.resource(new JarFile(result.value.path.toIO)) { jarFile =>
-            assert(jarEntries(jarFile).contains("reference.conf"))
+            Using.resource(new JarFile(result.value.path.toIO)) { jarFile =>
+              assert(jarEntries(jarFile).contains("reference.conf"))
 
-            val referenceContent = readFileFromJar(jarFile, "reference.conf")
+              val referenceContent = readFileFromJar(jarFile, "reference.conf")
 
-            assert(
-              // akka modules configs are present
-              referenceContent.contains("akka-http Reference Config File"),
-              referenceContent.contains("akka-http-core Reference Config File"),
-              referenceContent.contains("Akka Actor Reference Config File"),
-              referenceContent.contains("Akka Stream Reference Config File"),
-              // our application config is present too
-              referenceContent.contains("My application Reference Config File"),
-              referenceContent.contains(
-                """akka.http.client.user-agent-header="hello-world-client""""
+              assert(
+                // akka modules configs are present
+                referenceContent.contains("akka-http Reference Config File"),
+                referenceContent.contains("akka-http-core Reference Config File"),
+                referenceContent.contains("Akka Actor Reference Config File"),
+                referenceContent.contains("Akka Stream Reference Config File"),
+                // our application config is present too
+                referenceContent.contains("My application Reference Config File"),
+                referenceContent.contains(
+                  """akka.http.client.user-agent-header="hello-world-client""""
+                )
               )
-            )
+            }
           }
-        }
 
         val helloWorldMultiResourcePath =
           os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "hello-world-multi"
@@ -947,9 +960,9 @@ object HelloWorldTests extends TestSuite {
             module: M,
             target: Target[PathRef]
         ): Unit = UnitTester(
-            module,
-            sourceRoot = helloWorldMultiResourcePath
-          ).scoped{eval =>
+          module,
+          sourceRoot = helloWorldMultiResourcePath
+        ).scoped { eval =>
           val Right(result) = eval.apply(target)
 
           Using.resource(new JarFile(result.value.path.toIO)) { jarFile =>
@@ -973,9 +986,9 @@ object HelloWorldTests extends TestSuite {
             module: M,
             target: Target[PathRef]
         ): Unit = UnitTester(
-            module,
-            sourceRoot = helloWorldMultiResourcePath
-          ).scoped{eval =>
+          module,
+          sourceRoot = helloWorldMultiResourcePath
+        ).scoped { eval =>
           val Right(result) = eval.apply(target)
 
           Using.resource(new JarFile(result.value.path.toIO)) { jarFile =>
@@ -1012,7 +1025,7 @@ object HelloWorldTests extends TestSuite {
             module: M,
             target: Target[PathRef],
             resourcePath: os.Path = resourcePath
-        ) = UnitTester(module, resourcePath).scoped{eval =>
+        ) = UnitTester(module, resourcePath).scoped { eval =>
           val Right(result) = eval.apply(target)
 
           Using.resource(new JarFile(result.value.path.toIO)) { jarFile =>
@@ -1043,7 +1056,7 @@ object HelloWorldTests extends TestSuite {
             module: M,
             target: Target[PathRef],
             resourcePath: os.Path = resourcePath
-        ) = UnitTester(module, resourcePath).scoped{eval =>
+        ) = UnitTester(module, resourcePath).scoped { eval =>
           val Right(result) = eval.apply(target)
           Using.resource(new JarFile(result.value.path.toIO)) { jarFile =>
             assert(!jarEntries(jarFile).contains("akka/http/scaladsl/model/HttpEntity.class"))
@@ -1060,16 +1073,16 @@ object HelloWorldTests extends TestSuite {
           )
 
           test("run") - UnitTester(
-              HelloWorldAkkaHttpRelocate,
-              sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "hello-world-deps"
-            ).scoped{eval =>
-          val Right(result) = eval.apply(HelloWorldAkkaHttpRelocate.core.runMain("Main"))
+            HelloWorldAkkaHttpRelocate,
+            sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "hello-world-deps"
+          ).scoped { eval =>
+            val Right(result) = eval.apply(HelloWorldAkkaHttpRelocate.core.runMain("Main"))
             assert(result.evalCount > 0)
           }
         }
 
         test("writeDownstreamWhenNoRule") {
-          test("withDeps") - UnitTester(HelloWorldAkkaHttpNoRules, null).scoped{eval =>
+          test("withDeps") - UnitTester(HelloWorldAkkaHttpNoRules, null).scoped { eval =>
             val Right(result) = eval.apply(HelloWorldAkkaHttpNoRules.core.assembly)
 
             Using.resource(new JarFile(result.value.path.toIO)) { jarFile =>
@@ -1092,9 +1105,9 @@ object HelloWorldTests extends TestSuite {
           }
 
           test("multiModule") - UnitTester(
-              HelloWorldMultiNoRules,
-              sourceRoot = helloWorldMultiResourcePath
-            ).scoped{eval =>
+            HelloWorldMultiNoRules,
+            sourceRoot = helloWorldMultiResourcePath
+          ).scoped { eval =>
             val Right(result) = eval.apply(HelloWorldMultiNoRules.core.assembly)
 
             Using.resource(new JarFile(result.value.path.toIO)) { jarFile =>
@@ -1113,7 +1126,7 @@ object HelloWorldTests extends TestSuite {
         }
       }
 
-      test("run") - UnitTester(HelloWorldWithMain, resourcePath).scoped{eval =>
+      test("run") - UnitTester(HelloWorldWithMain, resourcePath).scoped { eval =>
         val Right(result) = eval.apply(HelloWorldWithMain.core.assembly)
 
         assert(
@@ -1131,7 +1144,7 @@ object HelloWorldTests extends TestSuite {
       }
     }
 
-    test("ivyDeps") - UnitTester(HelloWorldIvyDeps, resourcePath).scoped{eval =>
+    test("ivyDeps") - UnitTester(HelloWorldIvyDeps, resourcePath).scoped { eval =>
       val Right(result) = eval.apply(HelloWorldIvyDeps.moduleA.runClasspath)
       assert(
         result.value.exists(_.path.last == "sourcecode_2.12-0.1.3.jar"),
@@ -1145,7 +1158,7 @@ object HelloWorldTests extends TestSuite {
       )
     }
 
-    test("typeLevel") - UnitTester(HelloWorldTypeLevel, null).scoped{eval =>
+    test("typeLevel") - UnitTester(HelloWorldTypeLevel, null).scoped { eval =>
       val classPathsToCheck = Seq(
         HelloWorldTypeLevel.foo.runClasspath,
         HelloWorldTypeLevel.foo.ammoniteReplClasspath,
@@ -1174,10 +1187,10 @@ object HelloWorldTests extends TestSuite {
         // make sure macros are applied when compiling/running
         val mod = HelloWorldMacros212
         test("runMain") - UnitTester(
-            mod,
-            sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "hello-world-macros"
-          ).scoped{eval =>
-        if (Properties.isJavaAtLeast(17)) "skipped on Java 17+"
+          mod,
+          sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "hello-world-macros"
+        ).scoped { eval =>
+          if (Properties.isJavaAtLeast(17)) "skipped on Java 17+"
           else {
             val Right(result) = eval.apply(mod.core.runMain("Main"))
             assert(result.evalCount > 0)
@@ -1185,10 +1198,10 @@ object HelloWorldTests extends TestSuite {
         }
         // make sure macros are applied when compiling during scaladoc generation
         test("docJar") - UnitTester(
-            mod,
-            sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "hello-world-macros"
-          ).scoped{eval =>
-        if (Properties.isJavaAtLeast(17)) "skipped on Java 17+"
+          mod,
+          sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "hello-world-macros"
+        ).scoped { eval =>
+          if (Properties.isJavaAtLeast(17)) "skipped on Java 17+"
           else {
             val Right(result) = eval.apply(mod.core.docJar)
             assert(result.evalCount > 0)
@@ -1199,18 +1212,18 @@ object HelloWorldTests extends TestSuite {
         // make sure macros are applied when compiling/running
         val mod = HelloWorldMacros213
         test("runMain") - UnitTester(
-            mod,
-            sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "hello-world-macros"
-          ).scoped{eval =>
-        val Right(result) = eval.apply(mod.core.runMain("Main"))
+          mod,
+          sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "hello-world-macros"
+        ).scoped { eval =>
+          val Right(result) = eval.apply(mod.core.runMain("Main"))
           assert(result.evalCount > 0)
         }
         // make sure macros are applied when compiling during scaladoc generation
         test("docJar") - UnitTester(
-            mod,
-            sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "hello-world-macros"
-          ).scoped{eval =>
-        val Right(result) = eval.apply(mod.core.docJar)
+          mod,
+          sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "hello-world-macros"
+        ).scoped { eval =>
+          val Right(result) = eval.apply(mod.core.docJar)
           assert(result.evalCount > 0)
         }
       }
@@ -1218,19 +1231,19 @@ object HelloWorldTests extends TestSuite {
 
     test("flags") {
       // make sure flags are passed when compiling/running
-      test("runMain") -UnitTester(
-          HelloWorldFlags,
-          sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "hello-world-flags"
-        ).scoped{eval =>
-      val Right(result) = eval.apply(HelloWorldFlags.core.runMain("Main"))
+      test("runMain") - UnitTester(
+        HelloWorldFlags,
+        sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "hello-world-flags"
+      ).scoped { eval =>
+        val Right(result) = eval.apply(HelloWorldFlags.core.runMain("Main"))
         assert(result.evalCount > 0)
       }
       // make sure flags are passed during ScalaDoc generation
-      test("docJar") -UnitTester(
-          HelloWorldFlags,
-          sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "hello-world-flags"
-        ).scoped{eval =>
-      val Right(result) = eval.apply(HelloWorldFlags.core.docJar)
+      test("docJar") - UnitTester(
+        HelloWorldFlags,
+        sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "hello-world-flags"
+      ).scoped { eval =>
+        val Right(result) = eval.apply(HelloWorldFlags.core.docJar)
         assert(result.evalCount > 0)
       }
     }
@@ -1254,10 +1267,10 @@ object HelloWorldTests extends TestSuite {
     }
 
     test("scalacheck") - UnitTester(
-        HelloScalacheck,
-        sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "hello-scalacheck"
-      ).scoped{eval =>
-    val Right(result) = eval.apply(HelloScalacheck.foo.test.test())
+      HelloScalacheck,
+      sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "hello-scalacheck"
+    ).scoped { eval =>
+      val Right(result) = eval.apply(HelloScalacheck.foo.test.test())
       assert(
         result.evalCount > 0,
         result.value._2.map(_.selector) == Seq(
@@ -1269,7 +1282,7 @@ object HelloWorldTests extends TestSuite {
       )
     }
 
-    test("dotty213") -UnitTester(
+    test("dotty213") - UnitTester(
       Dotty213,
       sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "dotty213"
     ).scoped { eval =>
@@ -1277,8 +1290,7 @@ object HelloWorldTests extends TestSuite {
       assert(result.evalCount > 0)
     }
 
-
-    test("replAmmoniteMainClass") - UnitTester(AmmoniteReplMainClass, null).scoped{eval =>
+    test("replAmmoniteMainClass") - UnitTester(AmmoniteReplMainClass, null).scoped { eval =>
       val Right(result) = eval.apply(AmmoniteReplMainClass.oldAmmonite.ammoniteMainClass)
       assert(result.value == "ammonite.Main")
       val Right(result2) = eval.apply(AmmoniteReplMainClass.newAmmonite.ammoniteMainClass)
@@ -1287,78 +1299,82 @@ object HelloWorldTests extends TestSuite {
 
     test("validated") {
       test("PathRef") {
-        def check(t: Target[PathRef], flip: Boolean) = UnitTester(ValidatedTarget, null).scoped{eval =>
-          // we reconstruct faulty behavior
-          val Right(result) = eval.apply(t)
-          assert(
-            result.value.path.last == (t.asInstanceOf[NamedTask[_]].label + ".dest"),
-            os.exists(result.value.path)
-          )
-          os.remove.all(result.value.path)
-          val Right(result2) = eval.apply(t)
-          assert(
-            result2.value.path.last == (t.asInstanceOf[NamedTask[_]].label + ".dest"),
-            // as the result was cached but not checked, this path is missing
-            os.exists(result2.value.path) == flip
-          )
+        def check(t: Target[PathRef], flip: Boolean) = UnitTester(ValidatedTarget, null).scoped {
+          eval =>
+            // we reconstruct faulty behavior
+            val Right(result) = eval.apply(t)
+            assert(
+              result.value.path.last == (t.asInstanceOf[NamedTask[_]].label + ".dest"),
+              os.exists(result.value.path)
+            )
+            os.remove.all(result.value.path)
+            val Right(result2) = eval.apply(t)
+            assert(
+              result2.value.path.last == (t.asInstanceOf[NamedTask[_]].label + ".dest"),
+              // as the result was cached but not checked, this path is missing
+              os.exists(result2.value.path) == flip
+            )
         }
         test("unchecked") - check(ValidatedTarget.uncheckedPathRef, false)
         test("checked") - check(ValidatedTarget.checkedPathRef, true)
       }
       test("SeqPathRef") {
-        def check(t: Target[Seq[PathRef]], flip: Boolean) = UnitTester(ValidatedTarget, null).scoped{eval =>
-          // we reconstruct faulty behavior
-          val Right(result) = eval.apply(t)
-          assert(
-            result.value.map(_.path.last) == Seq(t.asInstanceOf[NamedTask[_]].label + ".dest"),
-            result.value.forall(p => os.exists(p.path))
-          )
-          result.value.foreach(p => os.remove.all(p.path))
-          val Right(result2) = eval.apply(t)
-          assert(
-            result2.value.map(_.path.last) == Seq(t.asInstanceOf[NamedTask[_]].label + ".dest"),
-            // as the result was cached but not checked, this path is missing
-            result2.value.forall(p => os.exists(p.path) == flip)
-          )
-        }
+        def check(t: Target[Seq[PathRef]], flip: Boolean) =
+          UnitTester(ValidatedTarget, null).scoped { eval =>
+            // we reconstruct faulty behavior
+            val Right(result) = eval.apply(t)
+            assert(
+              result.value.map(_.path.last) == Seq(t.asInstanceOf[NamedTask[_]].label + ".dest"),
+              result.value.forall(p => os.exists(p.path))
+            )
+            result.value.foreach(p => os.remove.all(p.path))
+            val Right(result2) = eval.apply(t)
+            assert(
+              result2.value.map(_.path.last) == Seq(t.asInstanceOf[NamedTask[_]].label + ".dest"),
+              // as the result was cached but not checked, this path is missing
+              result2.value.forall(p => os.exists(p.path) == flip)
+            )
+          }
         test("unchecked") - check(ValidatedTarget.uncheckedSeqPathRef, false)
         test("checked") - check(ValidatedTarget.checkedSeqPathRef, true)
       }
       test("AggPathRef") {
-        def check(t: Target[Agg[PathRef]], flip: Boolean) = UnitTester(ValidatedTarget, null).scoped{eval =>
-          // we reconstruct faulty behavior
-          val Right(result) = eval.apply(t)
-          assert(
-            result.value.map(_.path.last) == Agg(t.asInstanceOf[NamedTask[_]].label + ".dest"),
-            result.value.forall(p => os.exists(p.path))
-          )
-          result.value.foreach(p => os.remove.all(p.path))
-          val Right(result2) = eval.apply(t)
-          assert(
-            result2.value.map(_.path.last) == Agg(t.asInstanceOf[NamedTask[_]].label + ".dest"),
-            // as the result was cached but not checked, this path is missing
-            result2.value.forall(p => os.exists(p.path) == flip)
-          )
-        }
+        def check(t: Target[Agg[PathRef]], flip: Boolean) =
+          UnitTester(ValidatedTarget, null).scoped { eval =>
+            // we reconstruct faulty behavior
+            val Right(result) = eval.apply(t)
+            assert(
+              result.value.map(_.path.last) == Agg(t.asInstanceOf[NamedTask[_]].label + ".dest"),
+              result.value.forall(p => os.exists(p.path))
+            )
+            result.value.foreach(p => os.remove.all(p.path))
+            val Right(result2) = eval.apply(t)
+            assert(
+              result2.value.map(_.path.last) == Agg(t.asInstanceOf[NamedTask[_]].label + ".dest"),
+              // as the result was cached but not checked, this path is missing
+              result2.value.forall(p => os.exists(p.path) == flip)
+            )
+          }
         test("unchecked") - check(ValidatedTarget.uncheckedAggPathRef, false)
         test("checked") - check(ValidatedTarget.checkedAggPathRef, true)
       }
       test("other") {
-        def check(t: Target[Tuple1[PathRef]], flip: Boolean) = UnitTester(ValidatedTarget, null).scoped{eval =>
-          // we reconstruct faulty behavior
-          val Right(result) = eval.apply(t)
-          assert(
-            result.value._1.path.last == (t.asInstanceOf[NamedTask[_]].label + ".dest"),
-            os.exists(result.value._1.path)
-          )
-          os.remove.all(result.value._1.path)
-          val Right(result2) = eval.apply(t)
-          assert(
-            result2.value._1.path.last == (t.asInstanceOf[NamedTask[_]].label + ".dest"),
-            // as the result was cached but not checked, this path is missing
-            os.exists(result2.value._1.path) == flip
-          )
-        }
+        def check(t: Target[Tuple1[PathRef]], flip: Boolean) =
+          UnitTester(ValidatedTarget, null).scoped { eval =>
+            // we reconstruct faulty behavior
+            val Right(result) = eval.apply(t)
+            assert(
+              result.value._1.path.last == (t.asInstanceOf[NamedTask[_]].label + ".dest"),
+              os.exists(result.value._1.path)
+            )
+            os.remove.all(result.value._1.path)
+            val Right(result2) = eval.apply(t)
+            assert(
+              result2.value._1.path.last == (t.asInstanceOf[NamedTask[_]].label + ".dest"),
+              // as the result was cached but not checked, this path is missing
+              os.exists(result2.value._1.path) == flip
+            )
+          }
         test("unchecked") - check(ValidatedTarget.uncheckedTuplePathRef, false)
         test("checked") - check(ValidatedTarget.checkedTuplePathRef, true)
       }
@@ -1404,7 +1420,7 @@ object HelloWorldTests extends TestSuite {
         )
       }
 
-      test("modMod") - UnitTester(MultiModuleClasspaths, resourcePath).scoped{eval =>
+      test("modMod") - UnitTester(MultiModuleClasspaths, resourcePath).scoped { eval =>
         // Make sure that `compileClasspath` has all the same things as `runClasspath`,
         // but without the `/resources`
         check(
@@ -1469,7 +1485,7 @@ object HelloWorldTests extends TestSuite {
         )
       }
 
-      test("modCompile") - UnitTester(MultiModuleClasspaths, resourcePath).scoped{eval =>
+      test("modCompile") - UnitTester(MultiModuleClasspaths, resourcePath).scoped { eval =>
         // Mostly the same as `modMod` above, but with the dependency
         // from `qux` to `bar` being a `compileModuleDeps`
         check(
@@ -1533,7 +1549,7 @@ object HelloWorldTests extends TestSuite {
         )
       }
 
-      test("compileMod") - UnitTester(MultiModuleClasspaths, resourcePath).scoped{eval =>
+      test("compileMod") - UnitTester(MultiModuleClasspaths, resourcePath).scoped { eval =>
         // Both the `runClasspath` and `compileClasspath` should not have `foo` on the
         // classpath, nor should it have the versions of libraries pulled in by `foo`
         // (e.g. `sourcecode-0.2.4`), because it is a `compileModuleDep` of an upstream

--- a/scalalib/test/src/mill/scalalib/PublishModuleTests.scala
+++ b/scalalib/test/src/mill/scalalib/PublishModuleTests.scala
@@ -81,7 +81,10 @@ object PublishModuleTests extends TestSuite {
 
   def tests: Tests = Tests {
     test("pom") {
-      test("should include scala-library dependency") - UnitTester(HelloWorldWithPublish, resourcePath).scoped{eval =>
+      test("should include scala-library dependency") - UnitTester(
+        HelloWorldWithPublish,
+        resourcePath
+      ).scoped { eval =>
         val Right(result) = eval.apply(HelloWorldWithPublish.core.pom)
 
         assert(
@@ -97,7 +100,7 @@ object PublishModuleTests extends TestSuite {
           (scalaLibrary \ "groupId").text == "org.scala-lang"
         )
       }
-      test("versionScheme") - UnitTester(HelloWorldWithPublish, resourcePath).scoped{eval =>
+      test("versionScheme") - UnitTester(HelloWorldWithPublish, resourcePath).scoped { eval =>
         val Right(result) = eval.apply(HelloWorldWithPublish.core.pom)
 
         assert(
@@ -143,7 +146,6 @@ object PublishModuleTests extends TestSuite {
             "SONATYPE_PASSWORD" -> "password"
           )
         ).scoped { eval =>
-
           val directValue = "direct:value"
           val Right(result) =
             eval.apply(HelloWorldWithPublish.core.checkSonatypeCreds(directValue))
@@ -156,7 +158,7 @@ object PublishModuleTests extends TestSuite {
       }
       test(
         "should throw exception if neither environment variables or direct argument were not passed"
-      ) - UnitTester(HelloWorldWithPublish, resourcePath).scoped{eval =>
+      ) - UnitTester(HelloWorldWithPublish, resourcePath).scoped { eval =>
         val Left(Result.Failure(msg, None)) =
           eval.apply(HelloWorldWithPublish.core.checkSonatypeCreds(""))
 
@@ -167,7 +169,10 @@ object PublishModuleTests extends TestSuite {
     }
 
     test("ivy") {
-      test("should include scala-library dependency") - UnitTester(HelloWorldWithPublish, resourcePath).scoped{eval =>
+      test("should include scala-library dependency") - UnitTester(
+        HelloWorldWithPublish,
+        resourcePath
+      ).scoped { eval =>
         val Right(result) = eval.apply(HelloWorldWithPublish.core.ivy)
 
         assert(
@@ -185,7 +190,7 @@ object PublishModuleTests extends TestSuite {
     }
 
     test("pom-packaging-type") - {
-      test("pom") - UnitTester(PomOnly, resourcePath).scoped{eval =>
+      test("pom") - UnitTester(PomOnly, resourcePath).scoped { eval =>
         val Right(result) = eval.apply(PomOnly.core.pom)
 //
 //        assert(

--- a/scalalib/test/src/mill/scalalib/PublishModuleTests.scala
+++ b/scalalib/test/src/mill/scalalib/PublishModuleTests.scala
@@ -81,8 +81,7 @@ object PublishModuleTests extends TestSuite {
 
   def tests: Tests = Tests {
     test("pom") {
-      test("should include scala-library dependency") {
-        val eval = UnitTester(HelloWorldWithPublish, resourcePath)
+      test("should include scala-library dependency") - UnitTester(HelloWorldWithPublish, resourcePath).scoped{eval =>
         val Right(result) = eval.apply(HelloWorldWithPublish.core.pom)
 
         assert(
@@ -98,8 +97,7 @@ object PublishModuleTests extends TestSuite {
           (scalaLibrary \ "groupId").text == "org.scala-lang"
         )
       }
-      test("versionScheme") {
-        val eval = UnitTester(HelloWorldWithPublish, resourcePath)
+      test("versionScheme") - UnitTester(HelloWorldWithPublish, resourcePath).scoped{eval =>
         val Right(result) = eval.apply(HelloWorldWithPublish.core.pom)
 
         assert(
@@ -117,47 +115,48 @@ object PublishModuleTests extends TestSuite {
       test(
         "should retrieve credentials from environment variables if direct argument is empty"
       ) {
-        val eval = UnitTester(
+        UnitTester(
           HelloWorldWithPublish,
           sourceRoot = resourcePath,
           env = Evaluator.defaultEnv ++ Seq(
             "SONATYPE_USERNAME" -> "user",
             "SONATYPE_PASSWORD" -> "password"
           )
-        )
-        val Right(result) =
-          eval.apply(HelloWorldWithPublish.core.checkSonatypeCreds(""))
+        ).scoped { eval =>
+          val Right(result) =
+            eval.apply(HelloWorldWithPublish.core.checkSonatypeCreds(""))
 
-        assert(
-          result.value == "user:password",
-          result.evalCount > 0
-        )
+          assert(
+            result.value == "user:password",
+            result.evalCount > 0
+          )
+        }
       }
       test(
         "should prefer direct argument as credentials over environment variables"
       ) {
-        val eval = UnitTester(
+        UnitTester(
           HelloWorldWithPublish,
           sourceRoot = resourcePath,
           env = Evaluator.defaultEnv ++ Seq(
             "SONATYPE_USERNAME" -> "user",
             "SONATYPE_PASSWORD" -> "password"
           )
-        )
+        ).scoped { eval =>
 
-        val directValue = "direct:value"
-        val Right(result) =
-          eval.apply(HelloWorldWithPublish.core.checkSonatypeCreds(directValue))
+          val directValue = "direct:value"
+          val Right(result) =
+            eval.apply(HelloWorldWithPublish.core.checkSonatypeCreds(directValue))
 
-        assert(
-          result.value == directValue,
-          result.evalCount > 0
-        )
+          assert(
+            result.value == directValue,
+            result.evalCount > 0
+          )
+        }
       }
       test(
         "should throw exception if neither environment variables or direct argument were not passed"
-      ) {
-        val eval = UnitTester(HelloWorldWithPublish, resourcePath)
+      ) - UnitTester(HelloWorldWithPublish, resourcePath).scoped{eval =>
         val Left(Result.Failure(msg, None)) =
           eval.apply(HelloWorldWithPublish.core.checkSonatypeCreds(""))
 
@@ -168,8 +167,7 @@ object PublishModuleTests extends TestSuite {
     }
 
     test("ivy") {
-      test("should include scala-library dependency") {
-        val eval = UnitTester(HelloWorldWithPublish, resourcePath)
+      test("should include scala-library dependency") - UnitTester(HelloWorldWithPublish, resourcePath).scoped{eval =>
         val Right(result) = eval.apply(HelloWorldWithPublish.core.ivy)
 
         assert(
@@ -187,8 +185,7 @@ object PublishModuleTests extends TestSuite {
     }
 
     test("pom-packaging-type") - {
-      test("pom") {
-        val eval = UnitTester(PomOnly, resourcePath)
+      test("pom") - UnitTester(PomOnly, resourcePath).scoped{eval =>
         val Right(result) = eval.apply(PomOnly.core.pom)
 //
 //        assert(

--- a/scalalib/test/src/mill/scalalib/ScalaDoc3Tests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaDoc3Tests.scala
@@ -35,8 +35,7 @@ object ScalaDoc3Tests extends TestSuite {
   val resourcePath = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "scaladoc3"
 
   def tests: Tests = Tests {
-    test("static") {
-      val eval = UnitTester(StaticDocsModule, resourcePath)
+    test("static") - UnitTester(StaticDocsModule, resourcePath).scoped{eval =>
       val Right(_) = eval.apply(StaticDocsModule.static.docJar)
       val dest = eval.outPath / "static" / "docJar.dest"
       assert(
@@ -48,8 +47,7 @@ object ScalaDoc3Tests extends TestSuite {
         os.exists(dest / "javadoc" / "api" / "pkg" / "SomeClass.html")
       )
     }
-    test("empty") {
-      val eval = UnitTester(EmptyDocsModule, resourcePath)
+    test("empty") - UnitTester(EmptyDocsModule, resourcePath).scoped{eval =>
       val Right(_) = eval.apply(EmptyDocsModule.empty.docJar)
       val dest = eval.outPath / "empty" / "docJar.dest"
       assert(
@@ -57,8 +55,7 @@ object ScalaDoc3Tests extends TestSuite {
         os.exists(dest / "javadoc" / "api" / "pkg" / "SomeClass.html")
       )
     }
-    test("multiple") {
-      val eval = UnitTester(MultiDocsModule, resourcePath)
+    test("multiple") - UnitTester(MultiDocsModule, resourcePath).scoped{eval =>
       val Right(_) = eval.apply(MultiDocsModule.multidocs.docJar)
       val dest = eval.outPath / "multidocs" / "docJar.dest"
       assert(

--- a/scalalib/test/src/mill/scalalib/ScalaDoc3Tests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaDoc3Tests.scala
@@ -35,7 +35,7 @@ object ScalaDoc3Tests extends TestSuite {
   val resourcePath = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "scaladoc3"
 
   def tests: Tests = Tests {
-    test("static") - UnitTester(StaticDocsModule, resourcePath).scoped{eval =>
+    test("static") - UnitTester(StaticDocsModule, resourcePath).scoped { eval =>
       val Right(_) = eval.apply(StaticDocsModule.static.docJar)
       val dest = eval.outPath / "static" / "docJar.dest"
       assert(
@@ -47,7 +47,7 @@ object ScalaDoc3Tests extends TestSuite {
         os.exists(dest / "javadoc" / "api" / "pkg" / "SomeClass.html")
       )
     }
-    test("empty") - UnitTester(EmptyDocsModule, resourcePath).scoped{eval =>
+    test("empty") - UnitTester(EmptyDocsModule, resourcePath).scoped { eval =>
       val Right(_) = eval.apply(EmptyDocsModule.empty.docJar)
       val dest = eval.outPath / "empty" / "docJar.dest"
       assert(
@@ -55,7 +55,7 @@ object ScalaDoc3Tests extends TestSuite {
         os.exists(dest / "javadoc" / "api" / "pkg" / "SomeClass.html")
       )
     }
-    test("multiple") - UnitTester(MultiDocsModule, resourcePath).scoped{eval =>
+    test("multiple") - UnitTester(MultiDocsModule, resourcePath).scoped { eval =>
       val Right(_) = eval.apply(MultiDocsModule.multidocs.docJar)
       val dest = eval.outPath / "multidocs" / "docJar.dest"
       assert(

--- a/scalalib/test/src/mill/scalalib/ScalaVersionsRangesTests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaVersionsRangesTests.scala
@@ -21,12 +21,18 @@ object ScalaVersionsRangesTests extends TestSuite {
     os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "scala-versions-ranges"
 
   val tests = Tests {
-    test("main with Scala 2.12- and 2.13+ specific code") - UnitTester(ScalaVersionsRanges, resourcePath).scoped{eval =>
+    test("main with Scala 2.12- and 2.13+ specific code") - UnitTester(
+      ScalaVersionsRanges,
+      resourcePath
+    ).scoped { eval =>
       ScalaVersionsRanges.core.crossModules.map { c =>
         val Right(_) = eval(c.run())
       }
     }
-    test("test with Scala 2.12- and 2.13+ specific code") - UnitTester(ScalaVersionsRanges, resourcePath).scoped{eval =>
+    test("test with Scala 2.12- and 2.13+ specific code") - UnitTester(
+      ScalaVersionsRanges,
+      resourcePath
+    ).scoped { eval =>
       ScalaVersionsRanges.core.crossModules.map { c =>
         val Right(_) = eval(c.test.test())
       }

--- a/scalalib/test/src/mill/scalalib/ScalaVersionsRangesTests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaVersionsRangesTests.scala
@@ -21,14 +21,12 @@ object ScalaVersionsRangesTests extends TestSuite {
     os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "scala-versions-ranges"
 
   val tests = Tests {
-    test("main with Scala 2.12- and 2.13+ specific code") {
-      val eval = UnitTester(ScalaVersionsRanges, resourcePath)
+    test("main with Scala 2.12- and 2.13+ specific code") - UnitTester(ScalaVersionsRanges, resourcePath).scoped{eval =>
       ScalaVersionsRanges.core.crossModules.map { c =>
         val Right(_) = eval(c.run())
       }
     }
-    test("test with Scala 2.12- and 2.13+ specific code") {
-      val eval = UnitTester(ScalaVersionsRanges, resourcePath)
+    test("test with Scala 2.12- and 2.13+ specific code") - UnitTester(ScalaVersionsRanges, resourcePath).scoped{eval =>
       ScalaVersionsRanges.core.crossModules.map { c =>
         val Right(_) = eval(c.test.test())
       }

--- a/scalalib/test/src/mill/scalalib/TestClassLoaderTests.scala
+++ b/scalalib/test/src/mill/scalalib/TestClassLoaderTests.scala
@@ -23,7 +23,10 @@ object TestClassLoaderTests extends TestSuite {
   val resourcePath = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "classloader-test"
 
   override def tests: Tests = Tests {
-    test("com.sun classes exist in tests classpath (Java 8 only)") - UnitTester(testclassloader, resourcePath).scoped{eval =>
+    test("com.sun classes exist in tests classpath (Java 8 only)") - UnitTester(
+      testclassloader,
+      resourcePath
+    ).scoped { eval =>
       assert(eval.apply(testclassloader.test.test()).isRight)
     }
   }

--- a/scalalib/test/src/mill/scalalib/TestClassLoaderTests.scala
+++ b/scalalib/test/src/mill/scalalib/TestClassLoaderTests.scala
@@ -23,8 +23,7 @@ object TestClassLoaderTests extends TestSuite {
   val resourcePath = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "classloader-test"
 
   override def tests: Tests = Tests {
-    test("com.sun classes exist in tests classpath (Java 8 only)") {
-      val eval = UnitTester(testclassloader, resourcePath)
+    test("com.sun classes exist in tests classpath (Java 8 only)") - UnitTester(testclassloader, resourcePath).scoped{eval =>
       assert(eval.apply(testclassloader.test.test()).isRight)
     }
   }

--- a/scalalib/test/src/mill/scalalib/TestRunnerTests.scala
+++ b/scalalib/test/src/mill/scalalib/TestRunnerTests.scala
@@ -64,7 +64,7 @@ object TestRunnerTests extends TestSuite {
   override def tests: Tests = Tests {
     test("TestRunner") - {
       test("utest") - {
-        test("test case lookup") - UnitTester(testrunner, resourcePath).scoped{eval =>
+        test("test case lookup") - UnitTester(testrunner, resourcePath).scoped { eval =>
           val Right(result) = eval.apply(testrunner.utest.test())
           val test = result.value.asInstanceOf[(String, Seq[mill.testrunner.TestResult])]
           assert(
@@ -72,7 +72,7 @@ object TestRunnerTests extends TestSuite {
           )
           junitReportIn(eval.outPath, "utest").shouldHave(3 -> Status.Success)
         }
-        test("discoveredTestClasses") - UnitTester(testrunner, resourcePath).scoped{eval =>
+        test("discoveredTestClasses") - UnitTester(testrunner, resourcePath).scoped { eval =>
           val Right(result) = eval.apply(testrunner.utest.discoveredTestClasses)
           val expected = Seq(
             "mill.scalalib.BarTests",
@@ -91,19 +91,19 @@ object TestRunnerTests extends TestSuite {
             )
           }
 
-          test("suffix") - UnitTester(testrunner, resourcePath).scoped{eval =>
+          test("suffix") - UnitTester(testrunner, resourcePath).scoped { eval =>
             testOnly(eval, Seq("*arTests"), 2)
           }
-          test("prefix") - UnitTester(testrunner, resourcePath).scoped{eval =>
+          test("prefix") - UnitTester(testrunner, resourcePath).scoped { eval =>
             testOnly(eval, Seq("mill.scalalib.FooT*"), 1)
           }
-          test("exactly") - UnitTester(testrunner, resourcePath).scoped{eval =>
+          test("exactly") - UnitTester(testrunner, resourcePath).scoped { eval =>
             testOnly(eval, Seq("mill.scalalib.FooTests"), 1)
           }
-          test("multi") - UnitTester(testrunner, resourcePath).scoped{eval =>
+          test("multi") - UnitTester(testrunner, resourcePath).scoped { eval =>
             testOnly(eval, Seq("*Bar*", "*bar*"), 2)
           }
-          test("noMatch") - UnitTester(testrunner, resourcePath).scoped{eval =>
+          test("noMatch") - UnitTester(testrunner, resourcePath).scoped { eval =>
             val Left(Result.Failure(msg, _)) =
               eval.apply(testrunner.utest.testOnly("noMatch", "noMatch*2"))
             assert(
@@ -121,7 +121,6 @@ object TestRunnerTests extends TestSuite {
             outStream = new PrintStream(outStream, true),
             sourceRoot = resourcePath
           ).scoped { eval =>
-
             val Left(Result.Failure(msg, _)) = eval(testrunner.doneMessageFailure.test())
             val stdout = new String(outStream.toByteArray)
             assert(stdout.contains("test failure done message"))
@@ -135,24 +134,23 @@ object TestRunnerTests extends TestSuite {
             outStream = new PrintStream(outStream, true),
             sourceRoot = resourcePath
           ).scoped { eval =>
-
             val Right(_) = eval(testrunner.doneMessageSuccess.test())
             val stdout = new String(outStream.toByteArray)
             assert(stdout.contains("test success done message"))
           }
         }
 
-        test("null") - UnitTester(testrunner, resourcePath).scoped{eval =>
+        test("null") - UnitTester(testrunner, resourcePath).scoped { eval =>
           val Right(_) = eval(testrunner.doneMessageNull.test())
         }
       }
       test("ScalaTest") {
-        test("test") - UnitTester(testrunner, resourcePath).scoped{eval =>
+        test("test") - UnitTester(testrunner, resourcePath).scoped { eval =>
           val Right(result) = eval(testrunner.scalatest.test())
           assert(result.value._2.size == 2)
           junitReportIn(eval.outPath, "scalatest").shouldHave(2 -> Status.Success)
         }
-        test("discoveredTestClasses") - UnitTester(testrunner, resourcePath).scoped{eval =>
+        test("discoveredTestClasses") - UnitTester(testrunner, resourcePath).scoped { eval =>
           val Right(result) = eval.apply(testrunner.scalatest.discoveredTestClasses)
           val expected = Seq("mill.scalalib.ScalaTestSpec")
           assert(result.value == expected)
@@ -161,12 +159,12 @@ object TestRunnerTests extends TestSuite {
       }
 
       test("ZioTest") {
-        test("test") - UnitTester(testrunner, resourcePath).scoped{eval =>
+        test("test") - UnitTester(testrunner, resourcePath).scoped { eval =>
           val Right(result) = eval(testrunner.ziotest.test())
           assert(result.value._2.size == 1)
           junitReportIn(eval.outPath, "ziotest").shouldHave(1 -> Status.Success)
         }
-        test("discoveredTestClasses") - UnitTester(testrunner, resourcePath).scoped{eval =>
+        test("discoveredTestClasses") - UnitTester(testrunner, resourcePath).scoped { eval =>
           val Right(result) = eval.apply(testrunner.ziotest.discoveredTestClasses)
           val expected = Seq("mill.scalalib.ZioTestSpec")
           assert(result.value == expected)

--- a/scalalib/test/src/mill/scalalib/TestRunnerTests.scala
+++ b/scalalib/test/src/mill/scalalib/TestRunnerTests.scala
@@ -64,8 +64,7 @@ object TestRunnerTests extends TestSuite {
   override def tests: Tests = Tests {
     test("TestRunner") - {
       test("utest") - {
-        test("test case lookup") {
-          val eval = UnitTester(testrunner, resourcePath)
+        test("test case lookup") - UnitTester(testrunner, resourcePath).scoped{eval =>
           val Right(result) = eval.apply(testrunner.utest.test())
           val test = result.value.asInstanceOf[(String, Seq[mill.testrunner.TestResult])]
           assert(
@@ -73,8 +72,7 @@ object TestRunnerTests extends TestSuite {
           )
           junitReportIn(eval.outPath, "utest").shouldHave(3 -> Status.Success)
         }
-        test("discoveredTestClasses") {
-          val eval = UnitTester(testrunner, resourcePath)
+        test("discoveredTestClasses") - UnitTester(testrunner, resourcePath).scoped{eval =>
           val Right(result) = eval.apply(testrunner.utest.discoveredTestClasses)
           val expected = Seq(
             "mill.scalalib.BarTests",
@@ -93,24 +91,19 @@ object TestRunnerTests extends TestSuite {
             )
           }
 
-          test("suffix") {
-            val eval = UnitTester(testrunner, resourcePath)
+          test("suffix") - UnitTester(testrunner, resourcePath).scoped{eval =>
             testOnly(eval, Seq("*arTests"), 2)
           }
-          test("prefix") {
-            val eval = UnitTester(testrunner, resourcePath)
+          test("prefix") - UnitTester(testrunner, resourcePath).scoped{eval =>
             testOnly(eval, Seq("mill.scalalib.FooT*"), 1)
           }
-          test("exactly") {
-            val eval = UnitTester(testrunner, resourcePath)
+          test("exactly") - UnitTester(testrunner, resourcePath).scoped{eval =>
             testOnly(eval, Seq("mill.scalalib.FooTests"), 1)
           }
-          test("multi") {
-            val eval = UnitTester(testrunner, resourcePath)
+          test("multi") - UnitTester(testrunner, resourcePath).scoped{eval =>
             testOnly(eval, Seq("*Bar*", "*bar*"), 2)
           }
-          test("noMatch") {
-            val eval = UnitTester(testrunner, resourcePath)
+          test("noMatch") - UnitTester(testrunner, resourcePath).scoped{eval =>
             val Left(Result.Failure(msg, _)) =
               eval.apply(testrunner.utest.testOnly("noMatch", "noMatch*2"))
             assert(
@@ -123,44 +116,43 @@ object TestRunnerTests extends TestSuite {
       test("doneMessage") {
         test("failure") {
           val outStream = new ByteArrayOutputStream()
-          val eval = UnitTester(
+          UnitTester(
             testrunner,
             outStream = new PrintStream(outStream, true),
             sourceRoot = resourcePath
-          )
+          ).scoped { eval =>
 
-          val Left(Result.Failure(msg, _)) = eval(testrunner.doneMessageFailure.test())
-          val stdout = new String(outStream.toByteArray)
-          assert(stdout.contains("test failure done message"))
-          junitReportIn(eval.outPath, "doneMessageFailure").shouldHave(1 -> Status.Failure)
+            val Left(Result.Failure(msg, _)) = eval(testrunner.doneMessageFailure.test())
+            val stdout = new String(outStream.toByteArray)
+            assert(stdout.contains("test failure done message"))
+            junitReportIn(eval.outPath, "doneMessageFailure").shouldHave(1 -> Status.Failure)
+          }
         }
         test("success") {
           val outStream = new ByteArrayOutputStream()
-          val eval = UnitTester(
+          UnitTester(
             testrunner,
             outStream = new PrintStream(outStream, true),
             sourceRoot = resourcePath
-          )
+          ).scoped { eval =>
 
-          val Right(_) = eval(testrunner.doneMessageSuccess.test())
-          val stdout = new String(outStream.toByteArray)
-          assert(stdout.contains("test success done message"))
+            val Right(_) = eval(testrunner.doneMessageSuccess.test())
+            val stdout = new String(outStream.toByteArray)
+            assert(stdout.contains("test success done message"))
+          }
         }
 
-        test("null") {
-          val eval = UnitTester(testrunner, resourcePath)
+        test("null") - UnitTester(testrunner, resourcePath).scoped{eval =>
           val Right(_) = eval(testrunner.doneMessageNull.test())
         }
       }
       test("ScalaTest") {
-        test("test") {
-          val eval = UnitTester(testrunner, resourcePath)
+        test("test") - UnitTester(testrunner, resourcePath).scoped{eval =>
           val Right(result) = eval(testrunner.scalatest.test())
           assert(result.value._2.size == 2)
           junitReportIn(eval.outPath, "scalatest").shouldHave(2 -> Status.Success)
         }
-        test("discoveredTestClasses") {
-          val eval = UnitTester(testrunner, resourcePath)
+        test("discoveredTestClasses") - UnitTester(testrunner, resourcePath).scoped{eval =>
           val Right(result) = eval.apply(testrunner.scalatest.discoveredTestClasses)
           val expected = Seq("mill.scalalib.ScalaTestSpec")
           assert(result.value == expected)
@@ -169,14 +161,12 @@ object TestRunnerTests extends TestSuite {
       }
 
       test("ZioTest") {
-        test("test") {
-          val eval = UnitTester(testrunner, resourcePath)
+        test("test") - UnitTester(testrunner, resourcePath).scoped{eval =>
           val Right(result) = eval(testrunner.ziotest.test())
           assert(result.value._2.size == 1)
           junitReportIn(eval.outPath, "ziotest").shouldHave(1 -> Status.Success)
         }
-        test("discoveredTestClasses") {
-          val eval = UnitTester(testrunner, resourcePath)
+        test("discoveredTestClasses") - UnitTester(testrunner, resourcePath).scoped{eval =>
           val Right(result) = eval.apply(testrunner.ziotest.discoveredTestClasses)
           val expected = Seq("mill.scalalib.ZioTestSpec")
           assert(result.value == expected)

--- a/scalalib/test/src/mill/scalalib/bsp/BspModuleTests.scala
+++ b/scalalib/test/src/mill/scalalib/bsp/BspModuleTests.scala
@@ -42,7 +42,7 @@ object BspModuleTests extends TestSuite {
 
   override def tests: Tests = Tests {
     test("bspCompileClasspath") {
-      test("single module") - UnitTester(MultiBase, null).scoped{eval =>
+      test("single module") - UnitTester(MultiBase, null).scoped { eval =>
         val Right(result) = eval.apply(
           MultiBase.HelloBsp.bspCompileClasspath
         )
@@ -60,7 +60,7 @@ object BspModuleTests extends TestSuite {
           result.evalCount > 0
         )
       }
-      test("dependent module") - UnitTester(MultiBase, null).scoped{eval =>
+      test("dependent module") - UnitTester(MultiBase, null).scoped { eval =>
         val Right(result) = eval.apply(
           MultiBase.HelloBsp2.bspCompileClasspath
         )
@@ -90,7 +90,7 @@ object BspModuleTests extends TestSuite {
       }
       test("interdependencies are fast") {
         test("reference (no BSP)") {
-          def runNoBsp(entry: Int, maxTime: Int) = UnitTester(InterDeps, null).scoped{eval =>
+          def runNoBsp(entry: Int, maxTime: Int) = UnitTester(InterDeps, null).scoped { eval =>
             val start = System.currentTimeMillis()
             val Right(_) = eval.apply(
               InterDeps.Mod(entry).compileClasspath
@@ -104,7 +104,7 @@ object BspModuleTests extends TestSuite {
           test("index 15") { runNoBsp(15, 30000) }
         }
         def run(entry: Int, maxTime: Int) = retry(3) {
-          UnitTester(InterDeps, null).scoped{eval =>
+          UnitTester(InterDeps, null).scoped { eval =>
             val start = System.currentTimeMillis()
             val Right(_) = eval.apply(
               InterDeps.Mod(entry).bspCompileClasspath

--- a/scalalib/test/src/mill/scalalib/bsp/BspModuleTests.scala
+++ b/scalalib/test/src/mill/scalalib/bsp/BspModuleTests.scala
@@ -42,8 +42,7 @@ object BspModuleTests extends TestSuite {
 
   override def tests: Tests = Tests {
     test("bspCompileClasspath") {
-      test("single module") {
-        val eval = UnitTester(MultiBase, null)
+      test("single module") - UnitTester(MultiBase, null).scoped{eval =>
         val Right(result) = eval.apply(
           MultiBase.HelloBsp.bspCompileClasspath
         )
@@ -61,8 +60,7 @@ object BspModuleTests extends TestSuite {
           result.evalCount > 0
         )
       }
-      test("dependent module") {
-        val eval = UnitTester(MultiBase, null)
+      test("dependent module") - UnitTester(MultiBase, null).scoped{eval =>
         val Right(result) = eval.apply(
           MultiBase.HelloBsp2.bspCompileClasspath
         )
@@ -92,8 +90,7 @@ object BspModuleTests extends TestSuite {
       }
       test("interdependencies are fast") {
         test("reference (no BSP)") {
-          def runNoBsp(entry: Int, maxTime: Int) = {
-            val eval = UnitTester(InterDeps, null)
+          def runNoBsp(entry: Int, maxTime: Int) = UnitTester(InterDeps, null).scoped{eval =>
             val start = System.currentTimeMillis()
             val Right(_) = eval.apply(
               InterDeps.Mod(entry).compileClasspath
@@ -107,14 +104,15 @@ object BspModuleTests extends TestSuite {
           test("index 15") { runNoBsp(15, 30000) }
         }
         def run(entry: Int, maxTime: Int) = retry(3) {
-          val eval = UnitTester(InterDeps, null)
-          val start = System.currentTimeMillis()
-          val Right(_) = eval.apply(
-            InterDeps.Mod(entry).bspCompileClasspath
-          )
-          val timeSpent = System.currentTimeMillis() - start
-          assert(timeSpent < maxTime)
-          s"${timeSpent} msec"
+          UnitTester(InterDeps, null).scoped{eval =>
+            val start = System.currentTimeMillis()
+            val Right(_) = eval.apply(
+              InterDeps.Mod(entry).bspCompileClasspath
+            )
+            val timeSpent = System.currentTimeMillis() - start
+            assert(timeSpent < maxTime)
+            s"${timeSpent} msec"
+          }
         }
         test("index 1 (no deps)") { run(1, 500) }
         test("index 10") { run(10, 5000) }

--- a/scalalib/test/src/mill/scalalib/scalafmt/ScalafmtTests.scala
+++ b/scalalib/test/src/mill/scalalib/scalafmt/ScalafmtTests.scala
@@ -31,8 +31,7 @@ object ScalafmtTests extends TestSuite {
 
   def tests: Tests = Tests {
     test("scalafmt") {
-      def checkReformat(reformatCommand: mill.define.Command[Unit], buildSrcIncluded: Boolean) = {
-        val eval = UnitTester(ScalafmtTestModule, resourcePath)
+      def checkReformat(reformatCommand: mill.define.Command[Unit], buildSrcIncluded: Boolean) = UnitTester(ScalafmtTestModule, resourcePath).scoped{eval =>
         os.write(
           ScalafmtTestModule.millSourcePath / ".scalafmt.conf",
           s"""version = $scalafmtTestVersion

--- a/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
+++ b/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
@@ -643,9 +643,10 @@ class ZincWorkerImpl(
   override def close(): Unit = {
     val closeableClassloaders = classloaderCache
       .flatMap(_._2.get)
-      .collect{case v: AutoCloseable => v}
+      .collect { case v: AutoCloseable => v }
 
-    val urlClassLoaders = classloaderCache.flatMap(_._2.get).collect{case t: java.net.URLClassLoader => t}
+    val urlClassLoaders =
+      classloaderCache.flatMap(_._2.get).collect { case t: java.net.URLClassLoader => t }
 
     // Make sure we at least pick up all the URLClassLoaders, since we know those are
     // AutoCloseable, although there may be other AutoCloseable classloaders as well

--- a/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
+++ b/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
@@ -641,6 +641,9 @@ class ZincWorkerImpl(
   }
 
   override def close(): Unit = {
+    for(classLoader: java.net.URLClassLoader <- classloaderCache.flatMap(_._2.get)){
+      classLoader.close()
+    }
     classloaderCache.clear()
     javaOnlyCompilersCache.clear()
   }

--- a/scalanativelib/test/src/mill/scalanativelib/FeaturesTests.scala
+++ b/scalanativelib/test/src/mill/scalanativelib/FeaturesTests.scala
@@ -16,8 +16,7 @@ object FeaturesTests extends TestSuite {
   val millSourcePath = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "features"
 
   val tests: Tests = Tests {
-    test("incremental compilation works") {
-      val eval = UnitTester(Features, millSourcePath)
+    test("incremental compilation works") - UnitTester(Features, millSourcePath).scoped{eval =>
       val Right(_) = eval(Features.nativeLink)
       val Right(result) = eval(Features.nativeWorkdir)
       assert(os.walk(result.value).exists(_.ext == "ll"))

--- a/scalanativelib/test/src/mill/scalanativelib/FeaturesTests.scala
+++ b/scalanativelib/test/src/mill/scalanativelib/FeaturesTests.scala
@@ -16,7 +16,7 @@ object FeaturesTests extends TestSuite {
   val millSourcePath = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "features"
 
   val tests: Tests = Tests {
-    test("incremental compilation works") - UnitTester(Features, millSourcePath).scoped{eval =>
+    test("incremental compilation works") - UnitTester(Features, millSourcePath).scoped { eval =>
       val Right(_) = eval(Features.nativeLink)
       val Right(result) = eval(Features.nativeWorkdir)
       assert(os.walk(result.value).exists(_.ext == "ll"))

--- a/scalanativelib/test/src/mill/scalanativelib/HelloNativeWorldTests.scala
+++ b/scalanativelib/test/src/mill/scalanativelib/HelloNativeWorldTests.scala
@@ -87,8 +87,7 @@ object HelloNativeWorldTests extends TestSuite {
           scalaVersion: String,
           scalaNativeVersion: String,
           mode: ReleaseMode
-      ): Unit = {
-        val eval = UnitTester(HelloNativeWorld, millSourcePath)
+      ): Unit = UnitTester(HelloNativeWorld, millSourcePath).scoped{eval =>
         val Right(result) =
           eval(HelloNativeWorld.build(
             scalaVersion,
@@ -120,8 +119,7 @@ object HelloNativeWorldTests extends TestSuite {
     }
 
     test("jar") {
-      test("containsNirs") {
-        val eval = UnitTester(HelloNativeWorld, millSourcePath)
+      test("containsNirs") - UnitTester(HelloNativeWorld, millSourcePath).scoped{eval =>
         val Right(result) =
           eval(HelloNativeWorld.build(
             scala213,
@@ -139,8 +137,7 @@ object HelloNativeWorldTests extends TestSuite {
           scalaNativeVersion: String,
           mode: ReleaseMode,
           artifactId: String
-      ): Unit = {
-        val eval = UnitTester(HelloNativeWorld, millSourcePath)
+      ): Unit = UnitTester(HelloNativeWorld, millSourcePath).scoped{eval =>
         val Right(result) = eval(
           HelloNativeWorld.build(
             scalaVersion,
@@ -153,8 +150,7 @@ object HelloNativeWorldTests extends TestSuite {
     }
 
     def runTests(testTask: define.NamedTask[(String, Seq[TestResult])])
-        : Map[String, Map[String, TestResult]] = {
-      val eval = UnitTester(HelloNativeWorld, millSourcePath)
+        : Map[String, Map[String, TestResult]] = UnitTester(HelloNativeWorld, millSourcePath).scoped{eval =>
       val Left(Result.Failure(_, Some(res))) = eval(testTask)
 
       val (doneMsg, testResults) = res
@@ -203,8 +199,7 @@ object HelloNativeWorldTests extends TestSuite {
       )
     }
 
-    def checkRun(scalaVersion: String, scalaNativeVersion: String, mode: ReleaseMode): Unit = {
-      val eval = UnitTester(HelloNativeWorld, millSourcePath)
+    def checkRun(scalaVersion: String, scalaNativeVersion: String, mode: ReleaseMode): Unit = UnitTester(HelloNativeWorld, millSourcePath).scoped{eval =>
       val task =
         HelloNativeWorld.build(scalaVersion, scalaNativeVersion, mode).nativeLink
       val Right(result) = eval(task)
@@ -221,8 +216,7 @@ object HelloNativeWorldTests extends TestSuite {
       testAllMatrix((scala, scalaNative, releaseMode) => checkRun(scala, scalaNative, releaseMode))
     }
 
-    def checkInheritedTargets[A](target: ScalaNativeModule => T[A], expected: A) = {
-      val eval = UnitTester(HelloNativeWorld, millSourcePath)
+    def checkInheritedTargets[A](target: ScalaNativeModule => T[A], expected: A) = UnitTester(HelloNativeWorld, millSourcePath).scoped{eval =>
       val Right(mainResult) = eval(target(HelloNativeWorld.inherited))
       val Right(testResult) = eval(target(HelloNativeWorld.inherited.test))
       assert(mainResult.value == expected)

--- a/scalanativelib/test/src/mill/scalanativelib/HelloNativeWorldTests.scala
+++ b/scalanativelib/test/src/mill/scalanativelib/HelloNativeWorldTests.scala
@@ -87,7 +87,7 @@ object HelloNativeWorldTests extends TestSuite {
           scalaVersion: String,
           scalaNativeVersion: String,
           mode: ReleaseMode
-      ): Unit = UnitTester(HelloNativeWorld, millSourcePath).scoped{eval =>
+      ): Unit = UnitTester(HelloNativeWorld, millSourcePath).scoped { eval =>
         val Right(result) =
           eval(HelloNativeWorld.build(
             scalaVersion,
@@ -119,7 +119,7 @@ object HelloNativeWorldTests extends TestSuite {
     }
 
     test("jar") {
-      test("containsNirs") - UnitTester(HelloNativeWorld, millSourcePath).scoped{eval =>
+      test("containsNirs") - UnitTester(HelloNativeWorld, millSourcePath).scoped { eval =>
         val Right(result) =
           eval(HelloNativeWorld.build(
             scala213,
@@ -137,7 +137,7 @@ object HelloNativeWorldTests extends TestSuite {
           scalaNativeVersion: String,
           mode: ReleaseMode,
           artifactId: String
-      ): Unit = UnitTester(HelloNativeWorld, millSourcePath).scoped{eval =>
+      ): Unit = UnitTester(HelloNativeWorld, millSourcePath).scoped { eval =>
         val Right(result) = eval(
           HelloNativeWorld.build(
             scalaVersion,
@@ -150,16 +150,17 @@ object HelloNativeWorldTests extends TestSuite {
     }
 
     def runTests(testTask: define.NamedTask[(String, Seq[TestResult])])
-        : Map[String, Map[String, TestResult]] = UnitTester(HelloNativeWorld, millSourcePath).scoped{eval =>
-      val Left(Result.Failure(_, Some(res))) = eval(testTask)
+        : Map[String, Map[String, TestResult]] =
+      UnitTester(HelloNativeWorld, millSourcePath).scoped { eval =>
+        val Left(Result.Failure(_, Some(res))) = eval(testTask)
 
-      val (doneMsg, testResults) = res
-      testResults
-        .groupBy(_.fullyQualifiedName)
-        .view
-        .mapValues(_.map(e => e.selector -> e).toMap)
-        .toMap
-    }
+        val (doneMsg, testResults) = res
+        testResults
+          .groupBy(_.fullyQualifiedName)
+          .view
+          .mapValues(_.map(e => e.selector -> e).toMap)
+          .toMap
+      }
 
     def checkUtest(
         scalaVersion: String,
@@ -199,29 +200,31 @@ object HelloNativeWorldTests extends TestSuite {
       )
     }
 
-    def checkRun(scalaVersion: String, scalaNativeVersion: String, mode: ReleaseMode): Unit = UnitTester(HelloNativeWorld, millSourcePath).scoped{eval =>
-      val task =
-        HelloNativeWorld.build(scalaVersion, scalaNativeVersion, mode).nativeLink
-      val Right(result) = eval(task)
+    def checkRun(scalaVersion: String, scalaNativeVersion: String, mode: ReleaseMode): Unit =
+      UnitTester(HelloNativeWorld, millSourcePath).scoped { eval =>
+        val task =
+          HelloNativeWorld.build(scalaVersion, scalaNativeVersion, mode).nativeLink
+        val Right(result) = eval(task)
 
-      val paths = EvaluatorPaths.resolveDestPaths(eval.outPath, task)
-      val stdout = os.proc(paths.dest / "out").call().out.lines()
-      assert(
-        stdout.contains("Hello Scala Native"),
-        result.evalCount > 0
-      )
-    }
+        val paths = EvaluatorPaths.resolveDestPaths(eval.outPath, task)
+        val stdout = os.proc(paths.dest / "out").call().out.lines()
+        assert(
+          stdout.contains("Hello Scala Native"),
+          result.evalCount > 0
+        )
+      }
 
     test("run") {
       testAllMatrix((scala, scalaNative, releaseMode) => checkRun(scala, scalaNative, releaseMode))
     }
 
-    def checkInheritedTargets[A](target: ScalaNativeModule => T[A], expected: A) = UnitTester(HelloNativeWorld, millSourcePath).scoped{eval =>
-      val Right(mainResult) = eval(target(HelloNativeWorld.inherited))
-      val Right(testResult) = eval(target(HelloNativeWorld.inherited.test))
-      assert(mainResult.value == expected)
-      assert(testResult.value == expected)
-    }
+    def checkInheritedTargets[A](target: ScalaNativeModule => T[A], expected: A) =
+      UnitTester(HelloNativeWorld, millSourcePath).scoped { eval =>
+        val Right(mainResult) = eval(target(HelloNativeWorld.inherited))
+        val Right(testResult) = eval(target(HelloNativeWorld.inherited.test))
+        assert(mainResult.value == expected)
+        assert(testResult.value == expected)
+      }
     test("test-scalacOptions") {
       checkInheritedTargets(_.scalacOptions, Seq("-deprecation"))
     }

--- a/testkit/src/mill/testkit/ExampleTester.scala
+++ b/testkit/src/mill/testkit/ExampleTester.scala
@@ -128,7 +128,7 @@ class ExampleTester(
   ): Unit = {
     val commandStr = commandStr0 match {
       case s"mill $rest" => s"./mill $rest"
-      case s"curl $rest" => s"curl --retry 5 $rest"
+      case s"curl $rest" => s"curl --retry 5 --retry-all-errors $rest"
       case s => s
     }
     Console.err.println(s"$workspacePath> $commandStr")

--- a/testkit/src/mill/testkit/ExampleTester.scala
+++ b/testkit/src/mill/testkit/ExampleTester.scala
@@ -128,6 +128,7 @@ class ExampleTester(
   ): Unit = {
     val commandStr = commandStr0 match {
       case s"mill $rest" => s"./mill $rest"
+      case s"curl $rest" => s"curl --retry 5 $rest"
       case s => s
     }
     Console.err.println(s"$workspacePath> $commandStr")

--- a/testkit/src/mill/testkit/UnitTester.scala
+++ b/testkit/src/mill/testkit/UnitTester.scala
@@ -181,12 +181,12 @@ class UnitTester(
     )
   }
 
-  def scoped[T](tester: UnitTester => T) = {
+  def scoped[T](tester: UnitTester => T): T = {
     try tester(this)
     finally close()
   }
 
-  def close() = {
+  def close(): Unit = {
     for ((_, Val(obsolete: AutoCloseable)) <- evaluator.workerCache.values) {
       obsolete.close()
     }

--- a/testkit/src/mill/testkit/UnitTester.scala
+++ b/testkit/src/mill/testkit/UnitTester.scala
@@ -54,7 +54,7 @@ class UnitTester(
     debugEnabled: Boolean,
     env: Map[String, String],
     resetSourcePath: Boolean
-)(implicit fullName: sourcecode.FullName) {
+)(implicit fullName: sourcecode.FullName) extends AutoCloseable{
   val outPath: os.Path = module.millSourcePath / "out"
 
   if (resetSourcePath) {

--- a/testkit/src/mill/testkit/UnitTester.scala
+++ b/testkit/src/mill/testkit/UnitTester.scala
@@ -187,7 +187,7 @@ class UnitTester(
   }
 
   def close() = {
-    for ((_, Val(obsolete: AutoCloseable)) <- evaluator.workerCache.values){
+    for ((_, Val(obsolete: AutoCloseable)) <- evaluator.workerCache.values) {
       obsolete.close()
     }
   }

--- a/testkit/src/mill/testkit/UnitTester.scala
+++ b/testkit/src/mill/testkit/UnitTester.scala
@@ -181,4 +181,14 @@ class UnitTester(
     )
   }
 
+  def scoped[T](tester: UnitTester => T) = {
+    try tester(this)
+    finally close()
+  }
+
+  def close() = {
+    for ((_, Val(obsolete: AutoCloseable)) <- evaluator.workerCache.values){
+      obsolete.close()
+    }
+  }
 }

--- a/testkit/src/mill/testkit/UnitTester.scala
+++ b/testkit/src/mill/testkit/UnitTester.scala
@@ -54,7 +54,7 @@ class UnitTester(
     debugEnabled: Boolean,
     env: Map[String, String],
     resetSourcePath: Boolean
-)(implicit fullName: sourcecode.FullName) extends AutoCloseable{
+)(implicit fullName: sourcecode.FullName) extends AutoCloseable {
   val outPath: os.Path = module.millSourcePath / "out"
 
   if (resetSourcePath) {

--- a/testkit/test/src/mill/testkit/UnitTesterTests.scala
+++ b/testkit/test/src/mill/testkit/UnitTesterTests.scala
@@ -12,9 +12,10 @@ object UnitTesterTests extends TestSuite {
         def testTask = T { "test" }
       }
 
-      val eval = UnitTester(build, resourcePath)
-      val Right(result) = eval(build.testTask)
-      assert(result.value == "test")
+      UnitTester(build, resourcePath).scoped { eval =>
+        val Right(result) = eval(build.testTask)
+        assert(result.value == "test")
+      }
     }
 
     test("sources") {
@@ -23,10 +24,11 @@ object UnitTesterTests extends TestSuite {
         def testTask = T { os.read(testSource().path).toUpperCase() }
       }
 
-      val eval = UnitTester(build, resourcePath)
+      UnitTester(build, resourcePath).scoped { eval =>
 
-      val Right(result) = eval(build.testTask)
-      assert(result.value == "HELLO WORLD SOURCE FILE")
+        val Right(result) = eval(build.testTask)
+        assert(result.value == "HELLO WORLD SOURCE FILE")
+      }
     }
   }
 }

--- a/testkit/test/src/mill/testkit/UnitTesterTests.scala
+++ b/testkit/test/src/mill/testkit/UnitTesterTests.scala
@@ -25,7 +25,6 @@ object UnitTesterTests extends TestSuite {
       }
 
       UnitTester(build, resourcePath).scoped { eval =>
-
         val Right(result) = eval(build.testTask)
         assert(result.value == "HELLO WORLD SOURCE FILE")
       }


### PR DESCRIPTION
Previously we were just leaking the `URLClassLoaders`, which would give `CodeHeap 'non-profiled nmethods' is full. Compiler has been disabled.` in `scalajslib.test` and sometimes in actual usage for a long lived server. This PR ensures we `ZincWorkerImpl.close` actually calls `URLClassLoader.close`, and also replaced `val eval = UnitTester` in our test suite with `UnitTester.scoped{ eval =>` so we can ensure closing of the `UnitTester` and `URLClassLoader` after each test completes

With this change, `scalajslib.test` no longer prints the above error. Hopefully it makes it stop happening in production as well. `scalajslib.test` also drops from 7.5min to 6.5min (and drops further to 5min when I removed Scala.js 1.3.1 from the test matrix)