### PR TITLE
Move `package mill` statement after comments in examples

### DIFF
--- a/example/depth/cross/1-simple/build.mill
+++ b/example/depth/cross/1-simple/build.mill
@@ -1,6 +1,5 @@
-package build
 // Mill handles cross-building of all sorts via the `Cross[T]` module.
-
+package build
 import mill._
 
 object foo extends Cross[FooModule]("2.10", "2.11", "2.12")

--- a/example/depth/cross/10-static-blog/build.mill
+++ b/example/depth/cross/10-static-blog/build.mill
@@ -1,9 +1,8 @@
-package build
 // The following example demonstrates a use case: using cross modules to
 // turn files on disk into blog posts. To begin with, we import two third-party
 // libraries - Commonmark and Scalatags - to deal with Markdown parsing and
 // HTML generation respectively:
-
+package build
 import $ivy.`com.lihaoyi::scalatags:0.12.0`, scalatags.Text.all._
 import $ivy.`com.atlassian.commonmark:commonmark:0.13.1`
 import org.commonmark.parser.Parser

--- a/example/depth/cross/2-cross-source-path/build.mill
+++ b/example/depth/cross/2-cross-source-path/build.mill
@@ -1,7 +1,6 @@
-package build
 // If you want to have dedicated ``millSourcePath``s, you can add the cross
 // parameters to it as follows:
-
+package build
 import mill._
 
 object foo extends Cross[FooModule]("2.10", "2.11", "2.12")

--- a/example/depth/cross/3-outside-dependency/build.mill
+++ b/example/depth/cross/3-outside-dependency/build.mill
@@ -1,6 +1,5 @@
-package build
 // You can refer to targets defined in cross-modules as follows:
-
+package build
 import mill._
 
 object foo extends Cross[FooModule]("2.10", "2.11", "2.12")

--- a/example/depth/cross/4-cross-dependencies/build.mill
+++ b/example/depth/cross/4-cross-dependencies/build.mill
@@ -1,7 +1,6 @@
-package build
 // Targets in cross-modules can use one another the same way they are used from
 // external targets:
-
+package build
 import mill._
 
 object foo extends mill.Cross[FooModule]("2.10", "2.11", "2.12")

--- a/example/depth/cross/5-multiple-cross-axes/build.mill
+++ b/example/depth/cross/5-multiple-cross-axes/build.mill
@@ -1,7 +1,6 @@
-package build
 // You can have a cross-module with multiple inputs using the `Cross.Module2`
 // trait:
-
+package build
 import mill._
 
 val crossMatrix = for {

--- a/example/depth/cross/6-axes-extension/build.mill
+++ b/example/depth/cross/6-axes-extension/build.mill
@@ -1,6 +1,6 @@
-package build
 // You can also take an existing cross module and extend it with additional cross
 // axes as shown:
+package build
 import mill._
 
 object foo extends Cross[FooModule]("a", "b")

--- a/example/depth/large/11-helper-files/util.mill
+++ b/example/depth/large/11-helper-files/util.mill
@@ -1,5 +1,4 @@
 package build
-
 import mill._, scalalib._
 
 def myScalaVersion = "2.13.14"

--- a/example/depth/large/13-helper-files-mill-sc/util.mill.sc
+++ b/example/depth/large/13-helper-files-mill-sc/util.mill.sc
@@ -1,5 +1,4 @@
 package build
-
 import mill._, scalalib._
 
 def myScalaVersion = "2.13.14"

--- a/example/depth/modules/7-modules/build.mill
+++ b/example/depth/modules/7-modules/build.mill
@@ -1,10 +1,9 @@
-package build
 // == Simple Modules
 //
 // The path to a Mill module from the root of your build file corresponds to the
 // path you would use to run tasks within that module from the command line. e.g.
 // for the following `build.mill`:
-
+package build
 import mill._
 
 object foo extends Module {

--- a/example/depth/modules/8-diy-java-modules/build.mill
+++ b/example/depth/modules/8-diy-java-modules/build.mill
@@ -1,8 +1,7 @@
-package build
 // This section puts together what we've learned about ``Task``s and ``Module``s
 // so far into a worked example: implementing our own minimal version of
 // `mill.scalalib.JavaModule` from first principles.
-
+package build
 import mill._
 
 trait DiyJavaModule extends Module{

--- a/example/depth/tasks/1-task-graph/build.mill
+++ b/example/depth/tasks/1-task-graph/build.mill
@@ -1,6 +1,5 @@
-package build
 // The following is a simple self-contained example using Mill to compile Java:
-
+package build
 import mill._
 
 def mainClass: T[Option[String]] = Some("foo.Foo")

--- a/example/depth/tasks/2-primary-tasks/build.mill
+++ b/example/depth/tasks/2-primary-tasks/build.mill
@@ -1,4 +1,3 @@
-package build
 // There are three primary kinds of _Tasks_ that you should care about:
 //
 // * <<_sources>>, defined using `T.sources {...}`
@@ -6,7 +5,7 @@ package build
 // * <<_commands>>, defined using `T.command {...}`
 
 // === Sources
-
+package build
 
 import mill.{Module, T, _}
 

--- a/example/depth/tasks/5-persistent-targets/build.mill
+++ b/example/depth/tasks/5-persistent-targets/build.mill
@@ -1,11 +1,10 @@
-package build
 // Persistent targets defined using `T.persistent` are similar to normal
 // ``Target``s, except their `T.dest` folder is not cleared before every
 // evaluation. This makes them useful for caching things on disk in a more
 // fine-grained manner than Mill's own Target-level caching.
 //
 // Below is a semi-realistic example of using a `T.persistent` target:
-
+package build
 import mill._, scalalib._
 import java.util.Arrays
 import java.io.ByteArrayOutputStream

--- a/example/depth/tasks/6-workers/build.mill
+++ b/example/depth/tasks/6-workers/build.mill
@@ -1,4 +1,3 @@
-package build
 // Mill workers defined using `T.worker` are long-lived in-memory objects that
 // can persistent across multiple evaluations. These are similar to persistent
 // targets in that they let you cache things, but the fact that they let you
@@ -6,7 +5,7 @@ package build
 // flexibility: you are no longer limited to caching only serializable data
 // and paying the cost of serializing it to disk every evaluation. This example
 // uses a Worker to provide simple in-memory caching for compressed files.
-
+package build
 import mill._, scalalib._
 import java.util.Arrays
 import java.io.ByteArrayOutputStream

--- a/example/extending/plugins/7-writing-mill-plugins/build.mill
+++ b/example/extending/plugins/7-writing-mill-plugins/build.mill
@@ -1,10 +1,9 @@
-package build
 // This example demonstrates how to write and test Mill plugin, and publish it to
 // Sonatype's Maven Central so it can be used by other developers over the internet
 // via xref:Import_File_And_Import_Ivy.adoc[import $ivy].
 
 // == Project Configuration
-
+package build
 import mill._, scalalib._, publish._
 import mill.main.BuildInfo.millVersion
 

--- a/example/javalib/basic/1-simple/build.mill
+++ b/example/javalib/basic/1-simple/build.mill
@@ -1,6 +1,5 @@
-package build
 //// SNIPPET:BUILD
-
+package build
 import mill._, javalib._
 
 object `package` extends RootModule with JavaModule {

--- a/example/javalib/basic/2-custom-build-logic/build.mill
+++ b/example/javalib/basic/2-custom-build-logic/build.mill
@@ -1,6 +1,5 @@
-package build
 //// SNIPPET:BUILD
-
+package build
 import mill._, javalib._
 
 object `package` extends RootModule with JavaModule {

--- a/example/javalib/basic/3-multi-module/build.mill
+++ b/example/javalib/basic/3-multi-module/build.mill
@@ -1,6 +1,5 @@
-package build
 //// SNIPPET:BUILD
-
+package build
 import mill._, javalib._
 
 trait MyModule extends JavaModule{

--- a/example/javalib/basic/4-builtin-commands/build.mill
+++ b/example/javalib/basic/4-builtin-commands/build.mill
@@ -1,5 +1,5 @@
-package build
 //// SNIPPET:BUILD
+package build
 import mill._, javalib._
 
 trait MyModule extends JavaModule{

--- a/example/javalib/builds/1-common-config/build.mill
+++ b/example/javalib/builds/1-common-config/build.mill
@@ -1,5 +1,5 @@
-package build
 //// SNIPPET:BUILD
+package build
 import mill._, javalib._
 
 object `package` extends RootModule with JavaModule {

--- a/example/javalib/builds/2-custom-tasks/build.mill
+++ b/example/javalib/builds/2-custom-tasks/build.mill
@@ -1,6 +1,5 @@
-package build
 //// SNIPPET:BUILD
-
+package build
 import mill._, javalib._
 
 object `package` extends RootModule with JavaModule {

--- a/example/javalib/builds/3-override-tasks/build.mill
+++ b/example/javalib/builds/3-override-tasks/build.mill
@@ -1,5 +1,5 @@
-package build
 //// SNIPPET:BUILD1
+package build
 import mill._, javalib._
 
 object foo extends JavaModule {

--- a/example/javalib/builds/4-nested-modules/build.mill
+++ b/example/javalib/builds/4-nested-modules/build.mill
@@ -1,5 +1,5 @@
-package build
 //// SNIPPET:BUILD
+package build
 import mill._, javalib._
 
 trait MyModule extends JavaModule {

--- a/example/javalib/builds/6-publish-module/build.mill
+++ b/example/javalib/builds/6-publish-module/build.mill
@@ -1,5 +1,5 @@
-package build
 //// SNIPPET:BUILD
+package build
 import mill._, javalib._, publish._
 
 object foo extends JavaModule with PublishModule {

--- a/example/javalib/builds/8-compat-modules/build.mill
+++ b/example/javalib/builds/8-compat-modules/build.mill
@@ -1,5 +1,5 @@
-package build
 //// SNIPPET:ALL
+package build
 import mill._, javalib._
 
 object foo extends MavenModule {

--- a/example/javalib/builds/9-realistic/build.mill
+++ b/example/javalib/builds/9-realistic/build.mill
@@ -1,5 +1,5 @@
-package build
 //// SNIPPET:ALL
+package build
 import mill._, javalib._, publish._
 
 trait MyModule extends JavaModule with PublishModule {

--- a/example/javalib/module/1-compilation-execution-flags/build.mill
+++ b/example/javalib/module/1-compilation-execution-flags/build.mill
@@ -1,5 +1,5 @@
-package build
 //// SNIPPET:BUILD
+package build
 import mill._, javalib._
 
 object `package` extends RootModule with JavaModule{

--- a/example/javalib/module/10-downloading-non-maven-jars/build.mill
+++ b/example/javalib/module/10-downloading-non-maven-jars/build.mill
@@ -1,5 +1,5 @@
-package build
 //// SNIPPET:BUILD
+package build
 import mill._, javalib._
 
 object `package` extends RootModule with JavaModule {

--- a/example/javalib/module/11-assembly-config/build.mill
+++ b/example/javalib/module/11-assembly-config/build.mill
@@ -1,5 +1,5 @@
-package build
 //// SNIPPET:BUILD
+package build
 import mill._, javalib._
 import mill.javalib.Assembly._
 

--- a/example/javalib/module/12-repository-config/build.mill
+++ b/example/javalib/module/12-repository-config/build.mill
@@ -1,6 +1,5 @@
-package build
 //// SNIPPET:BUILD1
-
+package build
 import mill._, javalib._
 import mill.define.ModuleRef
 import coursier.maven.MavenRepository

--- a/example/javalib/module/2-ivy-deps/build.mill
+++ b/example/javalib/module/2-ivy-deps/build.mill
@@ -1,5 +1,5 @@
-package build
 //// SNIPPET:BUILD
+package build
 import mill._, javalib._
 
 object `package` extends RootModule with JavaModule {

--- a/example/javalib/module/3-run-compile-deps/build.mill
+++ b/example/javalib/module/3-run-compile-deps/build.mill
@@ -1,6 +1,5 @@
-package build
 //// SNIPPET:BUILD1
-
+package build
 import mill._, javalib._
 
 object foo extends JavaModule {

--- a/example/javalib/module/5-resources/build.mill
+++ b/example/javalib/module/5-resources/build.mill
@@ -1,5 +1,5 @@
-package build
 //// SNIPPET:BUILD
+package build
 import mill._, javalib._
 
 object foo extends JavaModule {

--- a/example/javalib/module/7-docjar/build.mill
+++ b/example/javalib/module/7-docjar/build.mill
@@ -1,6 +1,5 @@
-package build
 //// SNIPPET:BUILD
-
+package build
 import mill._, javalib._
 
 object foo extends JavaModule {

--- a/example/javalib/module/8-unmanaged-jars/build.mill
+++ b/example/javalib/module/8-unmanaged-jars/build.mill
@@ -1,5 +1,5 @@
-package build
 //// SNIPPET:BUILD
+package build
 import mill._, javalib._
 
 object `package` extends RootModule with JavaModule {

--- a/example/javalib/module/9-main-class/build.mill
+++ b/example/javalib/module/9-main-class/build.mill
@@ -1,5 +1,5 @@
-package build
 //// SNIPPET:BUILD
+package build
 import mill._, javalib._
 
 object `package` extends RootModule with JavaModule {

--- a/example/javalib/testing/1-test-suite/build.mill
+++ b/example/javalib/testing/1-test-suite/build.mill
@@ -1,5 +1,5 @@
-package build
 //// SNIPPET:BUILD1
+package build
 import mill._, javalib._
 
 object foo extends JavaModule {

--- a/example/javalib/testing/2-test-deps/build.mill
+++ b/example/javalib/testing/2-test-deps/build.mill
@@ -1,6 +1,5 @@
-package build
 //// SNIPPET:BUILD
-
+package build
 import mill._, javalib._
 
 object qux extends JavaModule {

--- a/example/javalib/testing/3-integration-suite/build.mill
+++ b/example/javalib/testing/3-integration-suite/build.mill
@@ -1,5 +1,5 @@
-package build
 //// SNIPPET:BUILD3
+package build
 import mill._, javalib._
 object qux extends JavaModule {
   object test extends JavaTests with TestModule.Junit5

--- a/example/scalalib/basic/1-simple/build.mill
+++ b/example/scalalib/basic/1-simple/build.mill
@@ -1,6 +1,5 @@
-package build
 //// SNIPPET:BUILD
-
+package build
 import mill._, scalalib._
 
 object `package` extends RootModule with ScalaModule {

--- a/example/scalalib/basic/2-custom-build-logic/build.mill
+++ b/example/scalalib/basic/2-custom-build-logic/build.mill
@@ -1,4 +1,3 @@
-package build
 // Mill makes it very easy to customize your build graph, overriding portions
 // of it with custom logic. In this example, we override the JVM `resources` of
 // our `ScalaModule` - normally the `resources/` folder - to instead contain a
@@ -6,6 +5,7 @@ package build
 // in that module
 
 //// SNIPPET:BUILD
+package build
 import mill._, scalalib._
 
 object `package` extends RootModule with ScalaModule {

--- a/example/scalalib/basic/3-multi-module/build.mill
+++ b/example/scalalib/basic/3-multi-module/build.mill
@@ -1,5 +1,5 @@
-package build
 //// SNIPPET:BUILD
+package build
 import mill._, scalalib._
 
 trait MyModule extends ScalaModule {

--- a/example/scalalib/basic/4-builtin-commands/build.mill
+++ b/example/scalalib/basic/4-builtin-commands/build.mill
@@ -1,9 +1,9 @@
-package build
 // == Example `build.mill`
 //
 // The following examples will be assuming the `build.mill` file given below:
 
 //// SNIPPET:BUILD
+package build
 import mill._, scalalib._
 
 trait MyModule extends ScalaModule {

--- a/example/scalalib/builds/1-common-config/build.mill
+++ b/example/scalalib/builds/1-common-config/build.mill
@@ -1,10 +1,10 @@
-package build
 // This example shows some of the common tasks you may want to override on a
 // `ScalaModule`: specifying the `mainClass`, adding additional
 // sources/resources, generating resources, and setting compilation/run
 // options.
 
 //// SNIPPET:BUILD
+package build
 import mill._, scalalib._
 
 object `package` extends RootModule with ScalaModule {

--- a/example/scalalib/builds/2-custom-tasks/build.mill
+++ b/example/scalalib/builds/2-custom-tasks/build.mill
@@ -1,4 +1,3 @@
-package build
 // This example shows how to define target that depend on other tasks:
 //
 // 1. For `generatedSources`, we override an the task and make it depend
@@ -10,7 +9,7 @@ package build
 //    count at runtime using `sys.props` and print it when the program runs
 
 //// SNIPPET:BUILD
-
+package build
 import mill._, scalalib._
 
 object `package` extends RootModule with ScalaModule {

--- a/example/scalalib/builds/3-override-tasks/build.mill
+++ b/example/scalalib/builds/3-override-tasks/build.mill
@@ -1,5 +1,5 @@
-package build
 //// SNIPPET:BUILD1
+package build
 import mill._, scalalib._
 
 object foo extends ScalaModule {

--- a/example/scalalib/builds/4-nested-modules/build.mill
+++ b/example/scalalib/builds/4-nested-modules/build.mill
@@ -1,5 +1,5 @@
-package build
 //// SNIPPET:BUILD
+package build
 import mill._, scalalib._
 
 trait MyModule extends ScalaModule {

--- a/example/scalalib/builds/6-publish-module/build.mill
+++ b/example/scalalib/builds/6-publish-module/build.mill
@@ -1,5 +1,5 @@
-package build
 //// SNIPPET:BUILD
+package build
 import mill._, scalalib._, publish._
 
 object foo extends ScalaModule with PublishModule {

--- a/example/scalalib/builds/8-compat-modules/build.mill
+++ b/example/scalalib/builds/8-compat-modules/build.mill
@@ -1,5 +1,5 @@
-package build
 //// SNIPPET:ALL
+package build
 import mill._, scalalib._
 
 object foo extends SbtModule {

--- a/example/scalalib/builds/9-realistic/build.mill
+++ b/example/scalalib/builds/9-realistic/build.mill
@@ -1,5 +1,5 @@
-package build
 //// SNIPPET:ALL
+package build
 import mill._, scalalib._, publish._
 
 trait MyModule extends PublishModule {

--- a/example/scalalib/module/1-compilation-execution-flags/build.mill
+++ b/example/scalalib/module/1-compilation-execution-flags/build.mill
@@ -1,5 +1,5 @@
-package build
 //// SNIPPET:BUILD
+package build
 import mill._, scalalib._
 
 object `package` extends RootModule with ScalaModule{

--- a/example/scalalib/module/10-downloading-non-maven-jars/build.mill
+++ b/example/scalalib/module/10-downloading-non-maven-jars/build.mill
@@ -1,5 +1,5 @@
-package build
 //// SNIPPET:BUILD
+package build
 import mill._, scalalib._
 
 object `package` extends RootModule with ScalaModule {

--- a/example/scalalib/module/11-assembly-config/build.mill
+++ b/example/scalalib/module/11-assembly-config/build.mill
@@ -1,5 +1,5 @@
-package build
 //// SNIPPET:BUILD
+package build
 import mill._, scalalib._
 import mill.scalalib.Assembly._
 

--- a/example/scalalib/module/12-repository-config/build.mill
+++ b/example/scalalib/module/12-repository-config/build.mill
@@ -1,9 +1,8 @@
-package build
 // By default, dependencies are resolved from maven central, but you can add
 // your own resolvers by overriding the `repositoriesTask` task in the module:
 
 //// SNIPPET:BUILD1
-
+package build
 import mill._, scalalib._
 import mill.define.ModuleRef
 import coursier.maven.MavenRepository

--- a/example/scalalib/module/2-ivy-deps/build.mill
+++ b/example/scalalib/module/2-ivy-deps/build.mill
@@ -1,5 +1,5 @@
-package build
 //// SNIPPET:BUILD
+package build
 import mill._, scalalib._
 
 object `package` extends RootModule with ScalaModule {

--- a/example/scalalib/module/3-run-compile-deps/build.mill
+++ b/example/scalalib/module/3-run-compile-deps/build.mill
@@ -1,10 +1,9 @@
-package build
 // If you want to use additional dependencies at runtime or override
 // dependencies and their versions at runtime, you can do so with
 // `runIvyDeps`.
 
 //// SNIPPET:BUILD1
-
+package build
 import mill._, scalalib._
 
 object foo extends ScalaModule {

--- a/example/scalalib/module/5-resources/build.mill
+++ b/example/scalalib/module/5-resources/build.mill
@@ -1,5 +1,5 @@
-package build
 //// SNIPPET:BUILD
+package build
 import mill._, scalalib._
 
 object foo extends ScalaModule {

--- a/example/scalalib/module/7-docjar/build.mill
+++ b/example/scalalib/module/7-docjar/build.mill
@@ -1,10 +1,9 @@
-package build
 // To generate API documenation you can use the `docJar` task on the module you'd
 // like to create the documenation for, configured via `scalaDocOptions` or
 // `javadocOptions`:
 
 //// SNIPPET:BUILD
-
+package build
 import mill._, scalalib._
 
 object foo extends ScalaModule {

--- a/example/scalalib/module/8-unmanaged-jars/build.mill
+++ b/example/scalalib/module/8-unmanaged-jars/build.mill
@@ -1,5 +1,5 @@
-package build
 //// SNIPPET:BUILD
+package build
 import mill._, scalalib._
 
 object `package` extends RootModule with ScalaModule {

--- a/example/scalalib/module/9-main-class/build.mill
+++ b/example/scalalib/module/9-main-class/build.mill
@@ -1,5 +1,5 @@
-package build
 //// SNIPPET:BUILD
+package build
 import mill._, scalalib._
 
 object `package` extends RootModule with ScalaModule {

--- a/example/scalalib/testing/1-test-suite/build.mill
+++ b/example/scalalib/testing/1-test-suite/build.mill
@@ -1,5 +1,5 @@
-package build
 //// SNIPPET:BUILD1
+package build
 import mill._, scalalib._
 
 object foo extends ScalaModule {

--- a/example/scalalib/testing/2-test-deps/build.mill
+++ b/example/scalalib/testing/2-test-deps/build.mill
@@ -1,4 +1,3 @@
-package build
 // [IMPORTANT]
 // --
 // _Mill has no `test`-scoped dependencies!_
@@ -11,7 +10,7 @@ package build
 // can use their `moduleDeps` to also depend on each other
 
 //// SNIPPET:BUILD
-
+package build
 import mill._, scalalib._
 
 object qux extends ScalaModule {

--- a/example/scalalib/testing/3-integration-suite/build.mill
+++ b/example/scalalib/testing/3-integration-suite/build.mill
@@ -1,10 +1,9 @@
-package build
 // You can also define test suites with different names other than `test`. For example,
 // the build below defines a test suite with the name `integration`, in addition
 // to that named `test`.
 
 //// SNIPPET:BUILD3
-
+package build
 import mill._, scalalib._
 
 object qux extends ScalaModule {


### PR DESCRIPTION
Otherwise it ends up really weird in the docs with this `package mill` code block in the middle of nowhere