### PR TITLE
Decouple publish/releasing from main CI

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -1,0 +1,79 @@
+name: Publish Artifacts
+
+# Tags are automatically published
+#
+# Manual publishing (workflow_dispatch) from the main branch is also supported
+#
+# Separate from main test running, because we assume that anything you push a
+# tag for or trigger manually would already have passed tests, so no need to run
+# them again and deal with slowness and flakiness twice.
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '**'
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+
+# cancel older runs of a pull request;
+# this will not cancel anything for normal git pushes
+concurrency:
+  group: cancel-old-pr-runs-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  publish-sonatype:
+    # when in master repo, publish all tags and manual runs on main
+    if: github.repository == 'com-lihaoyi/mill' && (startsWith( github.ref, 'refs/tags/') || (github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch' ) )
+    runs-on: ubuntu-latest
+
+    # only run one publish job for the same sha at the same time
+    # e.g. when a main-branch push is also tagged
+    concurrency: publish-sonatype-${{ github.sha }}
+
+    env:
+      SONATYPE_PGP_SECRET: ${{ secrets.SONATYPE_PGP_SECRET }}
+      SONATYPE_USERNAME: ${{ secrets.SONATYPE_DEPLOY_USER }}
+      SONATYPE_PASSWORD: ${{ secrets.SONATYPE_DEPLOY_PASSWORD }}
+      SONATYPE_PGP_PASSWORD: ${{ secrets.SONATYPE_PGP_PASSWORD }}
+      LANG: "en_US.UTF-8"
+      LC_MESSAGES: "en_US.UTF-8"
+      LC_ALL: "en_US.UTF-8"
+
+    steps:
+      - uses: actions/checkout@v4
+        with: {fetch-depth: 0}
+
+      - uses: coursier/cache-action@v6
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 11
+          distribution: temurin
+
+      - run: ci/release-maven.sh
+
+  release-github:
+    # when in master repo, publish all tags and manual runs on main
+    if: github.repository == 'com-lihaoyi/mill' && (startsWith( github.ref, 'refs/tags/') || (github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch' ) )
+    needs: publish-sonatype
+    runs-on: ubuntu-latest
+
+    env:
+      REPO_ACCESS_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with: {fetch-depth: 0}
+
+      - uses: coursier/cache-action@v6
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 11
+          distribution: temurin
+
+      - run: ./mill -i uploadToGithub $REPO_ACCESS_TOKEN

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,3 +1,7 @@
+# Runs every commit that lands in main, but the default landing page is the last
+# stable published tag. You have to navigate in the UI to find the latest docs for
+# what's in main but not yet released, but it's there for those who want it
+
 name: Publish Docs
 on:
   push:
@@ -12,8 +16,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+        with: {fetch-depth: 0}
 
       - uses: coursier/cache-action@v6
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,15 +1,13 @@
-name: CI
+name: Run Tests
 
 # We run full CI on push builds to main and on all pull requests
-#
-# Tags are automatically published
 #
 # Manual builds (workflow_dispatch) to the main branch are also published
 #
 # To maximize bug-catching changes while keeping CI times reasonable, we run:
 # - All tests on Linux/Java17
-# - Fewer tests on Linux/Java8 and Windows/Java17
-# - Fewest tests on Windows/Java8
+# - Fewer tests on Linux/Java11 and Windows/Java17
+# - Fewest tests on Windows/Java11
 
 on:
   push:
@@ -153,58 +151,3 @@ jobs:
       os: windows-latest
       java-version: ${{ matrix.java-version }}
       millargs: ${{ matrix.millargs }}
-
-  publish-sonatype:
-    # when in master repo, publish all tags and manual runs on main
-    if: github.repository == 'com-lihaoyi/mill' && (startsWith( github.ref, 'refs/tags/') || (github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch' ) )
-    needs: [linux, windows, compiler-bridge, lint-autofix, itest, test-docs]
-
-    runs-on: ubuntu-latest
-
-    # only run one publish job for the same sha at the same time
-    # e.g. when a main-branch push is also tagged
-    concurrency: publish-sonatype-${{ github.sha }}
-
-    env:
-      SONATYPE_PGP_SECRET: ${{ secrets.SONATYPE_PGP_SECRET }}
-      SONATYPE_USERNAME: ${{ secrets.SONATYPE_DEPLOY_USER }}
-      SONATYPE_PASSWORD: ${{ secrets.SONATYPE_DEPLOY_PASSWORD }}
-      SONATYPE_PGP_PASSWORD: ${{ secrets.SONATYPE_PGP_PASSWORD }}
-      LANG: "en_US.UTF-8"
-      LC_MESSAGES: "en_US.UTF-8"
-      LC_ALL: "en_US.UTF-8"
-
-    steps:
-      - uses: actions/checkout@v4
-        with: {fetch-depth: 0}
-
-      - uses: coursier/cache-action@v6
-
-      - uses: actions/setup-java@v4
-        with:
-          java-version: 8
-          distribution: temurin
-
-      - run: ci/release-maven.sh
-
-  release-github:
-    # when in master repo, publish all tags and manual runs on main
-    if: github.repository == 'com-lihaoyi/mill' && (startsWith( github.ref, 'refs/tags/') || (github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch' ) )
-    needs: publish-sonatype
-    runs-on: ubuntu-latest
-
-    env:
-      REPO_ACCESS_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
-
-    steps:
-      - uses: actions/checkout@v4
-        with: {fetch-depth: 0}
-
-      - uses: coursier/cache-action@v6
-
-      - uses: actions/setup-java@v4
-        with:
-          java-version: 8
-          distribution: temurin
-
-      - run: ./mill -i uploadToGithub $REPO_ACCESS_TOKEN


### PR DESCRIPTION
By the time things passed tests and land in master, they have already passed tests twice (once on PR, once in master). So no need to run tests a third time when we push a tag or manually trigger a release