### PR TITLE
More cleanups for github actions

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   submit-dependency-graph:
+    # doesn't work on Mill 0.12.x yet
     #if: github.repository == 'com-lihaoyi/mill' && github.ref == 'refs/heads/main'
     if: false
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -10,12 +10,8 @@ name: Publish Artifacts
 
 on:
   push:
-    branches:
-      - main
     tags:
       - '**'
-  pull_request:
-  merge_group:
   workflow_dispatch:
 
 # cancel older runs of a pull request;
@@ -27,7 +23,7 @@ concurrency:
 jobs:
   publish-sonatype:
     # when in master repo, publish all tags and manual runs on main
-    if: github.repository == 'com-lihaoyi/mill' && (startsWith( github.ref, 'refs/tags/') || (github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch' ) )
+    if: github.repository == 'com-lihaoyi/mill'
     runs-on: ubuntu-latest
 
     # only run one publish job for the same sha at the same time
@@ -58,7 +54,7 @@ jobs:
 
   release-github:
     # when in master repo, publish all tags and manual runs on main
-    if: github.repository == 'com-lihaoyi/mill' && (startsWith( github.ref, 'refs/tags/') || (github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch' ) )
+    if: github.repository == 'com-lihaoyi/mill'
     needs: publish-sonatype
     runs-on: ubuntu-latest
 

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -72,4 +72,4 @@ jobs:
           java-version: '11'
           distribution: temurin
 
-      - run: ./mill -i uploadToGithub $REPO_ACCESS_TOKEN
+      - run: ./mill -i uploadToGithub --authKey $REPO_ACCESS_TOKEN

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -9,7 +9,7 @@ on:
       - main
 jobs:
   publishDocs:
-    if: github.repository == 'com-lihaoyi/mill' && github.ref == 'refs/heads/main'
+    if: github.repository == 'com-lihaoyi/mill'
     runs-on: ubuntu-latest
     env:
       REPO_DEPLOY_KEY: ${{ secrets.REPO_DEPLOY_KEY }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,10 +13,7 @@ on:
   push:
     branches:
       - main
-    tags:
-      - '**'
   pull_request:
-  merge_group:
   workflow_dispatch:
 
 # cancel older runs of a pull request;

--- a/ci/release-bridge-maven.sh
+++ b/ci/release-bridge-maven.sh
@@ -11,8 +11,6 @@ rm gpg_key
 # Build all artifacts
 ./mill -i __.publishArtifacts
 
-export MILL_BUILD_COMPILER_BRIDGES=true
-
 # Publish all artifacts
 ./mill -i \
     mill.scalalib.PublishModule/publishAll \


### PR DESCRIPTION
- Only trigger `Publish Artifacts` on tags and explicit `workflow_dispatch`
- Remove redundant job conditionals
- Don't both running tests on tags since they already run on the commits land in the branch containing the tag