### PR TITLE
Support `exclude` attribute in `Dep` parser

### DIFF
--- a/docs/modules/ROOT/pages/Library_Dependencies.adoc
+++ b/docs/modules/ROOT/pages/Library_Dependencies.adoc
@@ -10,10 +10,16 @@ For more details about coursier, refer to the {link-coursier-doc}[coursier docum
 
 == Dependencies in General
 
-Mill dependencies have the form:
+Mill dependencies have the simple form:
 
 ----
 ivy"{organization}:{name}:{version}"
+----
+
+Additional attributes are also supported:
+
+----
+ivy"{organization}:{name}:{version}[;{attribute}={value}]*"
 ----
 
 When working in other Java and Scala projects, you will find some synonyms, which typically all mean the same.
@@ -225,6 +231,15 @@ def deps = Agg(
 
 You can also use `.excludeOrg` or `excludeName`:
 
+There is also a short notation available:
+
+.Example: Shot notation to exclude `fansi_2.12` library from transitive dependency set of `pprint`.
+[source,scala]
+----
+def deps = Agg(
+  ivy"com.lihaoyi::pprint:0.5.3;exclude=com.lihaoyi:fansi_2.12"
+)
+----
 
 .Example: Exclude all `com.lihaoyi` libraries from transitive dependency set of `pprint`.
 [source,scala]

--- a/scalalib/test/src/mill/scalalib/ResolveDepsTests.scala
+++ b/scalalib/test/src/mill/scalalib/ResolveDepsTests.scala
@@ -54,14 +54,14 @@ object ResolveDepsTests extends TestSuite {
 
     test("excludeTransitiveDeps") {
       val deps = Agg(ivy"com.lihaoyi::pprint:0.5.3".exclude("com.lihaoyi" -> "fansi_2.12"))
-      assertRoundTrip(deps, simplified = false)
+      assertRoundTrip(deps, simplified = true)
       val Success(paths) = evalDeps(deps)
       assert(!paths.exists(_.path.toString.contains("fansi_2.12")))
     }
 
     test("excludeTransitiveDepsByOrg") {
       val deps = Agg(ivy"com.lihaoyi::pprint:0.5.3".excludeOrg("com.lihaoyi"))
-      assertRoundTrip(deps, simplified = false)
+      assertRoundTrip(deps, simplified = true)
       val Success(paths) = evalDeps(deps)
       assert(!paths.exists(path =>
         path.path.toString.contains("com/lihaoyi") && !path.path.toString.contains("pprint_2.12")
@@ -70,7 +70,7 @@ object ResolveDepsTests extends TestSuite {
 
     test("excludeTransitiveDepsByName") {
       val deps = Agg(ivy"com.lihaoyi::pprint:0.5.3".excludeName("fansi_2.12"))
-      assertRoundTrip(deps, simplified = false)
+      assertRoundTrip(deps, simplified = true)
       val Success(paths) = evalDeps(deps)
       assert(!paths.exists(_.path.toString.contains("fansi_2.12")))
     }


### PR DESCRIPTION
You can give exclusions with `;exclude=org:name` or `;exclude=org:*` or `;exclude=*:name`.
