### PR TITLE
Refine compile options management

### DIFF
--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -32,9 +32,9 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
     override def scalaOrganization: Target[String] = outer.scalaOrganization()
     override def scalaVersion: Target[String] = outer.scalaVersion()
     override def scalacPluginIvyDeps: Target[Agg[Dep]] = outer.scalacPluginIvyDeps()
-    override def scalacPluginClasspath: Target[Agg[PathRef]] = outer.scalacPluginClasspath()
+//    override def scalacPluginClasspath: Target[Agg[PathRef]] = outer.scalacPluginClasspath()
     override def scalacOptions: Target[Seq[String]] = outer.scalacOptions()
-    override def mandatoryScalacOptions: Target[Seq[String]] = outer.mandatoryScalacOptions()
+//    override def mandatoryScalacOptions: Target[Seq[String]] = outer.mandatoryScalacOptions()
   }
 
   /**


### PR DESCRIPTION
Don't propagate `mandatoryScalacOptions` and `scalacPluginclasspath` from the `ScalaModule` to `ScalaTests`.
