### PR TITLE
Make use of OS-Lib's new literal multi-segment subpaths

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -148,7 +148,7 @@ object Deps {
   val junitInterface = ivy"com.github.sbt:junit-interface:0.13.3"
   val commonsIO = ivy"commons-io:commons-io:2.16.1"
   val log4j2Core = ivy"org.apache.logging.log4j:log4j-core:2.23.1"
-  val osLib = ivy"com.lihaoyi::os-lib:0.10.7-M1"
+  val osLib = ivy"com.lihaoyi::os-lib:0.10.7-M2"
   val pprint = ivy"com.lihaoyi::pprint:0.9.0"
   val mainargs = ivy"com.lihaoyi::mainargs:0.7.4"
   val millModuledefsVersion = "0.11.0-M2"

--- a/contrib/bloop/test/src/mill/contrib/bloop/BloopTests.scala
+++ b/contrib/bloop/test/src/mill/contrib/bloop/BloopTests.scala
@@ -104,9 +104,9 @@ object BloopTests extends TestSuite {
 
         // Ensuring that bloop config generation didn't trigger compilation
         assert(os.exists(workspaceOut / "scalaModule"))
-        assert(!os.exists(workspaceOut / "scalaModule" / "compile"))
+        assert(!os.exists(workspaceOut / "scalaModule/compile"))
         assert(os.exists(workspaceOut / "scalaModule2"))
-        assert(!os.exists(workspaceOut / "scalaModule2" / "compile"))
+        assert(!os.exists(workspaceOut / "scalaModule2/compile"))
       }
 
       test("scalaModule") {
@@ -126,7 +126,7 @@ object BloopTests extends TestSuite {
 
         assert(name == "scalaModule")
         assert(workspaceDir == Some(workdir.wrapped))
-        assert(sources == List(workdir / "scalaModule" / "src"))
+        assert(sources == List(workdir / "scalaModule/src"))
         assert(options.contains("-language:higherKinds"))
         assert(version == "2.12.8")
         assert(
@@ -171,7 +171,7 @@ object BloopTests extends TestSuite {
         val mainModuleClasspath = scalaModuleConfig.project.classpath
         assert(name == "scalaModule.test")
         assert(workspaceDir == Some(workdir.wrapped))
-        assert(sources == List(workdir / "scalaModule" / "test" / "src"))
+        assert(sources == List(workdir / "scalaModule/test/src"))
         assert(framework == "utest.runner.Framework")
         assert(dep == "scalaModule")
         assert(
@@ -228,7 +228,7 @@ object BloopTests extends TestSuite {
 
         assert(name == "scalajsModule")
         assert(workspaceDir == Some(workdir.wrapped))
-        assert(sources == List(workdir / "scalajsModule" / "src"))
+        assert(sources == List(workdir / "scalajsModule/src"))
         assert(version == build.scalajsModule.sv)
         assert(platform.config.emitSourceMaps)
         assert(platform.config.kind == BloopConfig.ModuleKindJS.CommonJSModule)
@@ -237,7 +237,7 @@ object BloopTests extends TestSuite {
       test("scalanativeModule") {
         scalanativeModuleConfig match {
           case None =>
-            val exists = os.exists(workdir / ".bloop" / "scalanativeModule.json")
+            val exists = os.exists(workdir / ".bloop/scalanativeModule.json")
             assert(exists == false)
           case Some(scalanativeModuleConfig) =>
             val p = scalanativeModuleConfig.project
@@ -252,14 +252,14 @@ object BloopTests extends TestSuite {
 
             assert(name == "scalanativeModule")
             assert(workspaceDir == Some(workdir.wrapped))
-            assert(sources == List(workdir / "scalanativeModule" / "src"))
+            assert(sources == List(workdir / "scalanativeModule/src"))
             assert(version == build.scalanativeModule.sv)
             assert(platform.config.mode == BloopConfig.LinkerMode.Debug)
             assert(platform.config.clang == clang.value.toNIO)
         }
       }
       test("skipped") {
-        val exists = os.exists(workdir / ".bloop" / "skippedModule.json")
+        val exists = os.exists(workdir / ".bloop/skippedModule.json")
         assert(exists == false)
       }
     }

--- a/contrib/buildinfo/test/src/mill/contrib/buildinfo/BuildInfoTests.scala
+++ b/contrib/buildinfo/test/src/mill/contrib/buildinfo/BuildInfoTests.scala
@@ -89,10 +89,10 @@ object BuildInfoTests extends TestSuite {
   val testModuleSourcesPath: Path = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "buildinfo"
 
   def buildInfoSourcePath(eval: UnitTester) =
-    eval.outPath / "buildInfoSources.dest" / "foo" / "BuildInfo.scala"
+    eval.outPath / "buildInfoSources.dest/foo/BuildInfo.scala"
 
   def buildInfoResourcePath(eval: UnitTester) =
-    eval.outPath / "buildInfoResources.dest" / "foo" / "BuildInfo.buildinfo.properties"
+    eval.outPath / "buildInfoResources.dest/foo/BuildInfo.buildinfo.properties"
   def tests: Tests = Tests {
 
     test("notCreateEmptySourcefile") - UnitTester(
@@ -144,9 +144,9 @@ object BuildInfoTests extends TestSuite {
       val Right(result) = eval.apply(BuildInfoSettings.buildInfoSources)
       val path = result.value.head.path
 
-      assert(os.exists(path / "foo" / "bar.scala"))
+      assert(os.exists(path / "foo/bar.scala"))
 
-      val found = os.read(path / "foo" / "bar.scala").replaceAll("(\r\n)|\r", "\n")
+      val found = os.read(path / "foo/bar.scala").replaceAll("(\r\n)|\r", "\n")
       assert(found.contains("object bar"))
     }
 
@@ -200,7 +200,7 @@ object BuildInfoTests extends TestSuite {
     test("java-static") - UnitTester(BuildInfoJavaStatic, testModuleSourcesPath / "java").scoped {
       eval =>
         val runResult = eval.outPath / "hello-mill"
-        val generatedSrc = eval.outPath / "buildInfoSources.dest" / "foo" / "BuildInfo.java"
+        val generatedSrc = eval.outPath / "buildInfoSources.dest/foo/BuildInfo.java"
         val Right(_) =
           eval.apply(BuildInfoJavaStatic.run(T.task(Args(runResult.toString))))
 

--- a/contrib/flyway/src/mill/contrib/flyway/FlywayModule.scala
+++ b/contrib/flyway/src/mill/contrib/flyway/FlywayModule.scala
@@ -23,7 +23,7 @@ trait FlywayModule extends JavaModule {
   def flywayUser: T[String] = T("")
   def flywayPassword: T[String] = T("")
   def flywayFileLocations: T[Seq[PathRef]] = T {
-    resources().map(pr => PathRef(pr.path / "db" / "migration", pr.quick))
+    resources().map(pr => PathRef(pr.path / "db/migration", pr.quick))
   }
 
   def flywayDriverDeps: T[Agg[Dep]]

--- a/contrib/playlib/test/src/mill/playlib/PlayModuleTests.scala
+++ b/contrib/playlib/test/src/mill/playlib/PlayModuleTests.scala
@@ -112,10 +112,10 @@ object PlayModuleTests extends TestSuite with PlayTestSuite {
               os.RelPath("views/html/main$.class"),
               os.RelPath("views/html/main.class")
             ).map(
-              eval.outPath / "core" / scalaVersion / playVersion / "compile.dest" / "classes" / _
+              eval.outPath / "core" / scalaVersion / playVersion / "compile.dest/classes" / _
             )
             assert(
-              result.value.classes.path == eval.outPath / "core" / scalaVersion / playVersion / "compile.dest" / "classes",
+              result.value.classes.path == eval.outPath / "core" / scalaVersion / playVersion / "compile.dest/classes",
               outputClassFiles.nonEmpty,
               outputClassFiles.forall(expectedClassfiles.contains),
               outputClassFiles.size == 15,

--- a/contrib/playlib/test/src/mill/playlib/PlaySingleApiModuleTests.scala
+++ b/contrib/playlib/test/src/mill/playlib/PlaySingleApiModuleTests.scala
@@ -70,10 +70,10 @@ object PlaySingleApiModuleTests extends TestSuite with PlayTestSuite {
         os.RelPath("router/RoutesPrefix$.class"),
         os.RelPath("router/RoutesPrefix.class")
       ).map(
-        eval.outPath / "compile.dest" / "classes" / _
+        eval.outPath / "compile.dest/classes" / _
       )
       assert(
-        result.value.classes.path == eval.outPath / "compile.dest" / "classes",
+        result.value.classes.path == eval.outPath / "compile.dest/classes",
         outputFiles.nonEmpty,
         outputFiles.forall(expectedClassfiles.contains),
         outputFiles.size == 11,

--- a/contrib/playlib/test/src/mill/playlib/PlaySingleModuleTests.scala
+++ b/contrib/playlib/test/src/mill/playlib/PlaySingleModuleTests.scala
@@ -61,10 +61,10 @@ object PlaySingleModuleTests extends TestSuite with PlayTestSuite {
         os.RelPath("views/html/main$.class"),
         os.RelPath("views/html/main.class")
       ).map(
-        eval.outPath / "compile.dest" / "classes" / _
+        eval.outPath / "compile.dest/classes" / _
       )
       assert(
-        result.value.classes.path == eval.outPath / "compile.dest" / "classes",
+        result.value.classes.path == eval.outPath / "compile.dest/classes",
         outputFiles.nonEmpty,
         outputFiles.forall(expectedClassfiles.contains),
         outputFiles.size == 15,

--- a/contrib/scalapblib/test/src/mill/contrib/scalapblib/TutorialTests.scala
+++ b/contrib/scalapblib/test/src/mill/contrib/scalapblib/TutorialTests.scala
@@ -45,12 +45,12 @@ object TutorialTests extends TestSuite {
   object TutorialWithSpecificSources extends TutorialBase {
     object core extends TutorialModule {
       override def scalaPBSources: T[Seq[PathRef]] = T.sources {
-        millSourcePath / "protobuf" / "tutorial" / "Tutorial.proto"
+        millSourcePath / "protobuf/tutorial/Tutorial.proto"
       }
 
       override def scalaPBSearchDeps = true
       override def scalaPBIncludePath = Seq(
-        PathRef(millSourcePath / "protobuf" / "tutorial")
+        PathRef(millSourcePath / "protobuf/tutorial")
       )
     }
   }
@@ -58,7 +58,7 @@ object TutorialTests extends TestSuite {
   val resourcePath: os.Path = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER"))
 
   def protobufOutPath(eval: UnitTester): os.Path =
-    eval.outPath / "core" / "compileScalaPB.dest" / "com" / "example" / "tutorial"
+    eval.outPath / "core/compileScalaPB.dest/com/example/tutorial"
 
   def compiledSourcefiles: Seq[os.RelPath] = Seq[os.RelPath](
     os.rel / "AddressBook.scala",
@@ -92,7 +92,7 @@ object TutorialTests extends TestSuite {
         val expectedSourcefiles = compiledSourcefiles.map(outPath / _)
 
         assert(
-          result.value.path == eval.outPath / "core" / "compileScalaPB.dest",
+          result.value.path == eval.outPath / "core/compileScalaPB.dest",
           outputFiles.nonEmpty,
           outputFiles.forall(expectedSourcefiles.contains),
           outputFiles.size == 5,
@@ -123,7 +123,7 @@ object TutorialTests extends TestSuite {
         ).map(outPath / _)
 
         assert(
-          result.value.path == eval.outPath / "core" / "compileScalaPB.dest",
+          result.value.path == eval.outPath / "core/compileScalaPB.dest",
           outputFiles.nonEmpty,
           outputFiles.forall(expectedSourcefiles.contains),
           outputFiles.size == 3,

--- a/contrib/sonatypecentral/src/mill/contrib/sonatypecentral/SonatypeCentralPublisher.scala
+++ b/contrib/sonatypecentral/src/mill/contrib/sonatypecentral/SonatypeCentralPublisher.scala
@@ -45,7 +45,7 @@ class SonatypeCentralPublisher(
     val (_, releases) = mappings.partition(_._1.isSnapshot)
 
     val releaseGroups = releases.groupBy(_._1.group)
-    val wd = os.pwd / "out" / "publish-central"
+    val wd = os.pwd / "out/publish-central"
     os.makeDir.all(wd)
 
     singleBundleName.fold {

--- a/contrib/twirllib/test/src/mill/twirllib/HelloWorldTests.scala
+++ b/contrib/twirllib/test/src/mill/twirllib/HelloWorldTests.scala
@@ -33,9 +33,9 @@ trait HelloWorldTests extends TestSuite {
 
   def resourcePath = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER"))
   def compileClassfiles: Seq[os.RelPath] = Seq[os.RelPath](
-    os.rel / "html" / "hello.template.scala",
-    os.rel / "html" / "wrapper.template.scala",
-    os.rel / "svg" / "test.template.scala"
+    os.rel / "html/hello.template.scala",
+    os.rel / "html/wrapper.template.scala",
+    os.rel / "svg/test.template.scala"
   )
 
   def expectedDefaultImports: Seq[String] = Seq(
@@ -85,11 +85,11 @@ trait HelloWorldTests extends TestSuite {
 
           val outputFiles = os.walk(result.value.classes.path).filter(_.last.endsWith(".scala"))
           val expectedClassfiles = compileClassfiles.map(
-            eval.outPath / "core" / "compileTwirl.dest" / _
+            eval.outPath / "core/compileTwirl.dest" / _
           )
 
           assert(
-            result.value.classes.path == eval.outPath / "core" / "compileTwirl.dest",
+            result.value.classes.path == eval.outPath / "core/compileTwirl.dest",
             outputFiles.nonEmpty,
             outputFiles.forall(expectedClassfiles.contains),
             outputFiles.size == 3,
@@ -126,7 +126,7 @@ trait HelloWorldTests extends TestSuite {
 
           val outputFiles = os.walk(result.value.classes.path).filter(_.last.endsWith(".scala"))
           val expectedClassfiles = compileClassfiles.map(name =>
-            eval.outPath / "core" / "compileTwirl.dest" / name / os.RelPath.up / name.last.replace(
+            eval.outPath / "core/compileTwirl.dest" / name / os.RelPath.up / name.last.replace(
               ".template.scala",
               "$$TwirlInclusiveDot.template.scala"
             )
@@ -135,7 +135,7 @@ trait HelloWorldTests extends TestSuite {
           println(s"outputFiles: $outputFiles")
 
           assert(
-            result.value.classes.path == eval.outPath / "core" / "compileTwirl.dest",
+            result.value.classes.path == eval.outPath / "core/compileTwirl.dest",
             outputFiles.nonEmpty,
             outputFiles.forall(expectedClassfiles.contains),
             outputFiles.size == 3,

--- a/example/depth/cross/10-static-blog/build.mill
+++ b/example/depth/cross/10-static-blog/build.mill
@@ -33,7 +33,7 @@ trait PostModule extends Cross.Module[String]{
     val rendered = doctype("html")(
       html(
         body(
-          h1(a("Blog", href := "../index.html"), /, title),
+          h1(a("Blog", href := "../index.html"), " / ", title),
           raw(HtmlRenderer.builder().build().render(doc))
         )
       )

--- a/example/depth/cross/10-static-blog/build.mill
+++ b/example/depth/cross/10-static-blog/build.mill
@@ -33,7 +33,7 @@ trait PostModule extends Cross.Module[String]{
     val rendered = doctype("html")(
       html(
         body(
-          h1(a("Blog", href := "../index.html"), " / ", title),
+          h1(a("Blog", href := "../index.html"), /, title),
           raw(HtmlRenderer.builder().build().render(doc))
         )
       )

--- a/example/depth/tasks/11-module-run-task/build.mill
+++ b/example/depth/tasks/11-module-run-task/build.mill
@@ -15,7 +15,7 @@ object foo extends ScalaModule {
 
 object bar extends ScalaModule{
   def scalaVersion = "2.13.8"
-  def ivyDeps = Agg(ivy"com.lihaoyi::os-lib:0.9.1")
+  def ivyDeps = Agg(ivy"com.lihaoyi::os-lib:0.10.7-M2")
 }
 
 // This example demonstrates using Mill ``ScalaModule``s as build tasks: rather

--- a/example/extending/imports/3-import-ivy/build.mill
+++ b/example/extending/imports/3-import-ivy/build.mill
@@ -5,7 +5,7 @@ import $ivy.`com.lihaoyi::scalatags:0.12.0`, scalatags.Text.all._
 object `package` extends RootModule with ScalaModule {
   def scalaVersion = "2.13.8"
 
-  def ivyDeps = Agg(ivy"com.lihaoyi::os-lib:0.9.1")
+  def ivyDeps = Agg(ivy"com.lihaoyi::os-lib:0.10.7-M2")
   def htmlSnippet = T{ div(h1("hello"), p("world")).toString }
   def resources = T.sources{
     os.write(T.dest / "snippet.txt", htmlSnippet())

--- a/example/extending/metabuild/4-meta-build/build.mill
+++ b/example/extending/metabuild/4-meta-build/build.mill
@@ -7,7 +7,7 @@ object `package` extends RootModule with ScalaModule {
   def scalaVersion = "2.13.4"
   def ivyDeps = Agg(
     ivy"com.lihaoyi::scalatags:${millbuild.DepVersions.scalatagsVersion}",
-    ivy"com.lihaoyi::os-lib:0.9.1"
+    ivy"com.lihaoyi::os-lib:0.10.7-M2"
   )
 
   def htmlSnippet = T{ h1("hello").toString }

--- a/example/extending/metabuild/5-meta-shared-sources/build.mill
+++ b/example/extending/metabuild/5-meta-shared-sources/build.mill
@@ -5,7 +5,7 @@ import mill._, scalalib._
 object `package` extends RootModule with ScalaModule {
   def scalaVersion = millbuild.ScalaVersion.myScalaVersion
   def sources = T.sources{
-    super.sources() ++ Seq(PathRef(millSourcePath / "mill-build" / "src"))
+    super.sources() ++ Seq(PathRef(millSourcePath / "mill-build/src"))
   }
 }
 

--- a/example/extending/plugins/7-writing-mill-plugins/build.mill
+++ b/example/extending/plugins/7-writing-mill-plugins/build.mill
@@ -21,7 +21,7 @@ object myplugin extends ScalaModule with PublishModule {
       def ivyDeps = Agg(ivy"com.lihaoyi:mill-dist:$millVersion")
       def mainClass = Some("mill.runner.client.MillClientMain")
       def resources = T{
-        val p = T.dest / "mill" / "local-test-overrides" / s"com.lihaoyi-${myplugin.artifactId()}"
+        val p = T.dest / "mill/local-test-overrides" / s"com.lihaoyi-${myplugin.artifactId()}"
         os.write(p, myplugin.localClasspath().map(_.path).mkString("\n"), createFolders = true)
         Seq(PathRef(T.dest))
       }

--- a/example/extending/plugins/7-writing-mill-plugins/myplugin/test/src/mill/testkit/IntegrationTests.scala
+++ b/example/extending/plugins/7-writing-mill-plugins/myplugin/test/src/mill/testkit/IntegrationTests.scala
@@ -28,7 +28,7 @@ object IntegrationTests extends TestSuite {
       assert(res2.out.contains("Line Count: 17"))
       assert(tester.out("lineCount").value[Int] == 17)
 
-      tester.modifyFile(tester.workspacePath / "src" / "foo" / "Foo.java", _ + "\n")
+      tester.modifyFile(tester.workspacePath / "src/foo/Foo.java", _ + "\n")
 
       val res3 = tester.eval("run") // Additional newline forces recompile and increases line count
       assert(res3.err.contains("compiling 1 Java source"))

--- a/example/package.mill
+++ b/example/package.mill
@@ -215,9 +215,9 @@ object `package` extends RootModule with Module {
         mergeFolders = true,
         replaceExisting = true
       )
-      os.remove.all(T.dest / "merged" / ".mill-version")
+      os.remove.all(T.dest / "merged/.mill-version")
 
-      os.remove.all(T.dest / "merged" / "build.sc")
+      os.remove.all(T.dest / "merged/build.sc")
       PathRef(T.dest / "merged")
     }
   }

--- a/example/package.mill
+++ b/example/package.mill
@@ -215,9 +215,9 @@ object `package` extends RootModule with Module {
         mergeFolders = true,
         replaceExisting = true
       )
-      os.remove.all(T.dest / "merged/.mill-version")
+      os.remove.all(T.dest / "merged" / ".mill-version")
 
-      os.remove.all(T.dest / "merged/build.sc")
+      os.remove.all(T.dest / "merged" / "build.sc")
       PathRef(T.dest / "merged")
     }
   }

--- a/example/scalalib/builds/1-common-config/build.mill
+++ b/example/scalalib/builds/1-common-config/build.mill
@@ -13,7 +13,7 @@ object `package` extends RootModule with ScalaModule {
   // You can have arbitrary numbers of third-party dependencies
   def ivyDeps = Agg(
     ivy"com.lihaoyi::scalatags:0.8.2",
-    ivy"com.lihaoyi::os-lib:0.9.1",
+    ivy"com.lihaoyi::os-lib:0.10.7-M2",
   )
 
   // Choose a main class to use for `.run` if there are multiple present

--- a/example/scalalib/module/11-assembly-config/build.mill
+++ b/example/scalalib/module/11-assembly-config/build.mill
@@ -6,7 +6,7 @@ import mill.scalalib.Assembly._
 object foo extends ScalaModule {
   def moduleDeps = Seq(bar)
   def scalaVersion = "2.13.8"
-  def ivyDeps = Agg(ivy"com.lihaoyi::os-lib:0.9.1")
+  def ivyDeps = Agg(ivy"com.lihaoyi::os-lib:0.10.7-M2")
   def assemblyRules = Seq(
     // all application.conf files will be concatenated into single file
     Rule.Append("application.conf"),

--- a/example/scalalib/module/5-resources/build.mill
+++ b/example/scalalib/module/5-resources/build.mill
@@ -5,7 +5,7 @@ import mill._, scalalib._
 object foo extends ScalaModule {
   def scalaVersion = "2.13.8"
   def ivyDeps = Agg(
-    ivy"com.lihaoyi::os-lib:0.9.1"
+    ivy"com.lihaoyi::os-lib:0.10.7-M2"
   )
 
   object test extends ScalaTests {

--- a/example/scalalib/web/2-webapp-cache-busting/build.mill
+++ b/example/scalalib/web/2-webapp-cache-busting/build.mill
@@ -7,7 +7,7 @@ object `package` extends RootModule with ScalaModule {
   def ivyDeps = Agg(
     ivy"com.lihaoyi::cask:0.9.1",
     ivy"com.lihaoyi::scalatags:0.12.0",
-    ivy"com.lihaoyi::os-lib:0.9.1"
+    ivy"com.lihaoyi::os-lib:0.10.7-M2"
   )
 
   def resources = T {

--- a/example/scalalib/web/4-webapp-scalajs/build.mill
+++ b/example/scalalib/web/4-webapp-scalajs/build.mill
@@ -14,8 +14,8 @@ object `package` extends RootModule with ScalaModule {
     val jsPath = client.fastLinkJS().dest.path
     // Move main.js[.map]into the proper filesystem position
     // in the resource folder for the web server code to pick up
-    os.copy(jsPath / "main.js", T.dest / "webapp" / "main.js")
-    os.copy(jsPath / "main.js.map", T.dest / "webapp" / "main.js.map")
+    os.copy(jsPath / "main.js", T.dest / "webapp/main.js")
+    os.copy(jsPath / "main.js.map", T.dest / "webapp/main.js.map")
     super.resources() ++ Seq(PathRef(T.dest))
   }
 

--- a/example/scalalib/web/5-webapp-scalajs-shared/build.mill
+++ b/example/scalalib/web/5-webapp-scalajs-shared/build.mill
@@ -16,8 +16,8 @@ object `package` extends RootModule with AppScalaModule {
   def resources = T{
     os.makeDir(T.dest / "webapp")
     val jsPath = client.fastLinkJS().dest.path
-    os.copy(jsPath / "main.js", T.dest / "webapp" / "main.js")
-    os.copy(jsPath / "main.js.map", T.dest / "webapp" / "main.js.map")
+    os.copy(jsPath / "main.js", T.dest / "webapp/main.js")
+    os.copy(jsPath / "main.js.map", T.dest / "webapp/main.js.map")
     super.resources() ++ Seq(PathRef(T.dest))
   }
 

--- a/example/thirdparty/netty/build.mill
+++ b/example/thirdparty/netty/build.mill
@@ -86,9 +86,9 @@ trait NettyModule extends NettyBaseModule{
 
 trait NettyJniModule extends NettyModule {
   def jniLibraryName: T[String]
-  def cSources = T.source(millSourcePath / "src" / "main" / "c")
+  def cSources = T.source(millSourcePath / "src/main/c")
   def resources = T{
-    os.copy(clang().path, T.dest / "META-INF" / "native" / jniLibraryName(), createFolders = true)
+    os.copy(clang().path, T.dest / "META-INF/native" / jniLibraryName(), createFolders = true)
     Seq(PathRef(T.dest))
   }
   def clang = T{
@@ -99,15 +99,15 @@ trait NettyJniModule extends NettyModule {
       )
       .toSeq
 
-    os.makeDir.all(T.dest  / "src" / "main" / "c")
-    os.proc("jar", "xf", sourceJar.path).call(cwd = T.dest  / "src" / "main" / "c")
+    os.makeDir.all(T.dest  / "src/main/c")
+    os.proc("jar", "xf", sourceJar.path).call(cwd = T.dest  / "src/main/c")
 
     os.proc(
       "clang",
       // CFLAGS
       "-O3", "-Werror", "-fno-omit-frame-pointer",
       "-Wunused-variable", "-fvisibility=hidden",
-      "-I" + (T.dest / "src" / "main" / "c"),
+      "-I" + (T.dest / "src/main/c"),
       "-I" + `transport-native-unix-common`.cHeaders().path,
       "-I" + sys.props("java.home") + "/include/",
       "-I" + sys.props("java.home") + "/include/darwin",
@@ -248,7 +248,7 @@ object common extends NettyModule{
     ivy"org.jctools:jctools-core:4.0.5",
   )
 
-  def script = T.source(millSourcePath / "src" / "main" / "script")
+  def script = T.source(millSourcePath / "src/main/script")
   def generatedSources0 = T{
     val shell = new groovy.lang.GroovyShell()
 
@@ -445,7 +445,7 @@ object `testsuite-http2` extends NettyTestSuiteModule{
 object `testsuite-native` extends NettyTestSuiteModule{
   def moduleDeps = Seq(`transport-native-kqueue`, `resolver-dns-native-macos`, `resolver-dns-classes-macos`, `transport-native-epoll`)
   def testModuleDeps = Seq(`resolver-dns-classes-macos`)
-  override def sources = T.sources( millSourcePath / "src" / "test" / "java" )
+  override def sources = T.sources( millSourcePath / "src/test/java" )
 }
 
 object `testsuite-native-image` extends NettyTestSuiteModule{
@@ -471,7 +471,7 @@ object `testsuite-osgi` extends NettyTestSuiteModule{
     transport, `transport-sctp`, `transport-udt`
   )
 
-  override def sources = T.sources( millSourcePath / "src" / "test" / "java" )
+  override def sources = T.sources( millSourcePath / "src/test/java" )
 
   def ivyDeps = super.ivyDeps() ++ Agg(
     ivy"org.apache.felix:org.apache.felix.configadmin:1.9.14",
@@ -484,7 +484,7 @@ object `testsuite-osgi` extends NettyTestSuiteModule{
 
 object `testsuite-shading` extends NettyTestSuiteModule{
   def moduleDeps = Seq(common)
-  override def sources = T.sources( millSourcePath / "src" / "test" / "java" )
+  override def sources = T.sources( millSourcePath / "src/test/java" )
 }
 
 object transport extends NettyModule{
@@ -533,7 +533,7 @@ object `transport-native-unix-common` extends NettyModule{
   def ivyDeps = Agg(ivy"org.junit.jupiter:junit-jupiter-api:5.9.0")
 
   def makefile = T.source(millSourcePath / "Makefile")
-  def cSources = T.source(millSourcePath / "src" / "main" / "c")
+  def cSources = T.source(millSourcePath / "src/main/c")
   def cHeaders = T{
     for(p <- os.walk(cSources().path) if p.ext == "h"){
       os.copy(p, T.dest / p.relativeTo(cSources().path), createFolders = true)
@@ -548,8 +548,8 @@ object `transport-native-unix-common` extends NettyModule{
     )().toSeq
 
     os.copy(makefile().path, T.dest / "Makefile")
-    os.copy(cSources().path, T.dest / "src" / "main" / "c", createFolders = true)
-    os.proc("jar", "xf", sourceJar.path).call(cwd = T.dest  / "src" / "main" / "c")
+    os.copy(cSources().path, T.dest / "src/main/c", createFolders = true)
+    os.proc("jar", "xf", sourceJar.path).call(cwd = T.dest  / "src/main/c")
 
     os.proc("make").call(
       cwd = T.dest,

--- a/idea/src/mill/idea/GenIdeaImpl.scala
+++ b/idea/src/mill/idea/GenIdeaImpl.scala
@@ -444,7 +444,7 @@ case class GenIdeaImpl(
         )
       ),
 //      Tuple2(
-//        os.sub / "mill_modules" / "mill-build.iml",
+//        os.sub / "mill_modules/mill-build.iml",
 //        rootXmlTemplate(allBuildLibraries.flatMap(lib => libraryNames(lib)))
 //      ),
       Tuple2(

--- a/integration/feature/auxiliary-class-files/src/AuxiliaryClassFilesTests.scala
+++ b/integration/feature/auxiliary-class-files/src/AuxiliaryClassFilesTests.scala
@@ -12,10 +12,10 @@ object AuxiliaryClassFilesTests extends UtestIntegrationTestSuite {
         import tester._
         assert(eval("app.jvm.compile").isSuccess)
 
-        val classes = workspacePath / "out" / "app" / "jvm" / "compile.dest" / "classes"
+        val classes = workspacePath / "out/app/jvm/compile.dest/classes"
         val firstRun = os.list(classes).map(_.last)
 
-        os.remove(workspacePath / "app" / "src" / "foo.scala")
+        os.remove(workspacePath / "app/src/foo.scala")
 
         assert(eval("app.jvm.compile").isSuccess)
 
@@ -28,14 +28,14 @@ object AuxiliaryClassFilesTests extends UtestIntegrationTestSuite {
     test("compilation fails when deleting a class used by other files") - integrationTest {
       tester =>
         import tester._
-        os.write(workspacePath / "app" / "src" / "bar.scala", "object bar { println(foo) }")
+        os.write(workspacePath / "app/src/bar.scala", "object bar { println(foo) }")
         val firstRunSuccessful = eval("app.jvm.compile")
         assert(firstRunSuccessful.isSuccess)
 
-        val classes = workspacePath / "out" / "app" / "jvm" / "compile.dest" / "classes"
+        val classes = workspacePath / "out/app/jvm/compile.dest/classes"
         val firstRun = os.list(classes).map(_.last)
 
-        os.remove(workspacePath / "app" / "src" / "foo.scala")
+        os.remove(workspacePath / "app/src/foo.scala")
 
         val secondRunSuccessful = eval("app.jvm.compile")
         assert(!secondRunSuccessful.isSuccess)
@@ -57,10 +57,10 @@ object AuxiliaryClassFilesTests extends UtestIntegrationTestSuite {
       import tester._
       assert(eval("app.native.compile").isSuccess)
 
-      val classes = workspacePath / "out" / "app" / "native" / "compile.dest" / "classes"
+      val classes = workspacePath / "out/app/native/compile.dest/classes"
       val firstRun = os.list(classes).map(_.last)
 
-      os.remove(workspacePath / "app" / "src" / "foo.scala")
+      os.remove(workspacePath / "app/src/foo.scala")
 
       assert(eval("app.native.compile").isSuccess)
 
@@ -75,10 +75,10 @@ object AuxiliaryClassFilesTests extends UtestIntegrationTestSuite {
         import tester._
         assert(eval("app.js.compile").isSuccess)
 
-        val classes = workspacePath / "out" / "app" / "js" / "compile.dest" / "classes"
+        val classes = workspacePath / "out/app/js/compile.dest/classes"
         val firstRun = os.list(classes).map(_.last)
 
-        os.remove(workspacePath / "app" / "src" / "foo.scala")
+        os.remove(workspacePath / "app/src/foo.scala")
 
         assert(eval("app.js.compile").isSuccess)
 

--- a/integration/feature/init/src/MillInitTests.scala
+++ b/integration/feature/init/src/MillInitTests.scala
@@ -9,7 +9,7 @@ object MillInitTests extends UtestIntegrationTestSuite {
     test("Mill init works") - integrationTest { tester =>
       import tester._
       eval(("init", "com-lihaoyi/mill-scala-hello.g8", "--name=example")).isSuccess ==> true
-      val projFile = workspacePath / "example" / "build.sc"
+      val projFile = workspacePath / "example/build.sc"
       assert(os.exists(projFile))
     }
   }

--- a/integration/feature/repo-config-via-import/src/ImportRepoTests.scala
+++ b/integration/feature/repo-config-via-import/src/ImportRepoTests.scala
@@ -14,7 +14,7 @@ object ImportRepoTests extends UtestIntegrationTestSuite {
       // ```
       // and use it as additional repository
       assert(eval("foo.resolvedIvyDeps").isSuccess)
-      val model = os.read(workspacePath / "out" / "mill-build" / "parseBuildFiles.json")
+      val model = os.read(workspacePath / "out/mill-build/parseBuildFiles.json")
       assert(model.contains("""file:///tmp/testrepo""""))
     }
   }

--- a/integration/ide/bloop/src/BloopTests.scala
+++ b/integration/ide/bloop/src/BloopTests.scala
@@ -13,19 +13,19 @@ object BloopTests extends UtestIntegrationTestSuite {
         import tester._
         val installResult: Boolean = eval("mill.contrib.bloop.Bloop/install").isSuccess
         assert(installResult)
-        assert(os.exists(workspacePath / ".bloop" / "root-module.json"))
+        assert(os.exists(workspacePath / ".bloop/root-module.json"))
       }
       test("mill-build module bloop config should be created") - integrationTest { tester =>
         import tester._
         val installResult: Boolean = eval("mill.contrib.bloop.Bloop/install").isSuccess
-        val millBuildJsonFile = workspacePath / ".bloop" / "mill-build-.json"
+        val millBuildJsonFile = workspacePath / ".bloop/mill-build-.json"
         assert(installResult)
         assert(os.exists(millBuildJsonFile))
       }
 
       test("mill-build config should contain build.mill source") - integrationTest { tester =>
         import tester._
-        val millBuildJsonFile = workspacePath / ".bloop" / "mill-build-.json"
+        val millBuildJsonFile = workspacePath / ".bloop/mill-build-.json"
         val installResult: Boolean = eval("mill.contrib.bloop.Bloop/install").isSuccess
         val config = ujson.read(os.read.stream(millBuildJsonFile))
         assert(installResult)

--- a/integration/ide/bsp-modules/src/BspModulesTests.scala
+++ b/integration/ide/bsp-modules/src/BspModulesTests.scala
@@ -18,7 +18,7 @@ object BspModulesTests extends UtestIntegrationTestSuite {
         import tester._
         val res = eval("validate")
         assert(res.isSuccess)
-        val file = workspacePath / "out" / "validate.dest" / "transitive-modules.json"
+        val file = workspacePath / "out/validate.dest/transitive-modules.json"
         assert(os.exists(file))
         val readModules = os.read.lines(file).sorted
         val expectedModules = Seq(

--- a/integration/invalidation/invalidation/src/ScriptsInvalidationTests.scala
+++ b/integration/invalidation/invalidation/src/ScriptsInvalidationTests.scala
@@ -45,7 +45,7 @@ object ScriptsInvalidationTests extends UtestIntegrationTestSuite {
 
       //  second run modifying script
       modifyFile(
-        workspacePath / "b" / "inputD.mill",
+        workspacePath / "b/inputD.mill",
         _.replace("""println("d")""", """System.out.println("d2")""")
       )
 

--- a/integration/invalidation/multi-level-editing/src/MultiLevelBuildTests.scala
+++ b/integration/invalidation/multi-level-editing/src/MultiLevelBuildTests.scala
@@ -23,27 +23,27 @@ object MultiLevelBuildTests extends UtestIntegrationTestSuite {
     }
 
     def fooPaths(tester: IntegrationTester) = Seq(
-      tester.workspacePath / "foo" / "compile-resources",
-      tester.workspacePath / "foo" / "resources",
-      tester.workspacePath / "foo" / "src"
+      tester.workspacePath / "foo/compile-resources",
+      tester.workspacePath / "foo/resources",
+      tester.workspacePath / "foo/src"
     )
     def buildPaths(tester: IntegrationTester) = Seq(
       tester.workspacePath / "build.mill",
-      tester.workspacePath / "mill-build" / "compile-resources",
-      tester.workspacePath / "mill-build" / "resources",
-      tester.workspacePath / "mill-build" / "src"
+      tester.workspacePath / "mill-build/compile-resources",
+      tester.workspacePath / "mill-build/resources",
+      tester.workspacePath / "mill-build/src"
     )
     def buildPaths2(tester: IntegrationTester) = Seq(
-      tester.workspacePath / "mill-build" / "build.mill",
-      tester.workspacePath / "mill-build" / "mill-build" / "compile-resources",
-      tester.workspacePath / "mill-build" / "mill-build" / "resources",
-      tester.workspacePath / "mill-build" / "mill-build" / "src"
+      tester.workspacePath / "mill-build/build.mill",
+      tester.workspacePath / "mill-build/mill-build/compile-resources",
+      tester.workspacePath / "mill-build/mill-build/resources",
+      tester.workspacePath / "mill-build/mill-build/src"
     )
     def buildPaths3(tester: IntegrationTester) = Seq(
-      tester.workspacePath / "mill-build" / "mill-build" / "build.mill",
-      tester.workspacePath / "mill-build" / "mill-build" / "mill-build" / "compile-resources",
-      tester.workspacePath / "mill-build" / "mill-build" / "mill-build" / "resources",
-      tester.workspacePath / "mill-build" / "mill-build" / "mill-build" / "src"
+      tester.workspacePath / "mill-build/mill-build/build.mill",
+      tester.workspacePath / "mill-build/mill-build/mill-build/compile-resources",
+      tester.workspacePath / "mill-build/mill-build/mill-build/resources",
+      tester.workspacePath / "mill-build/mill-build/mill-build/src"
     )
 
     def loadFrames(tester: IntegrationTester, n: Int) = {
@@ -142,7 +142,7 @@ object MultiLevelBuildTests extends UtestIntegrationTestSuite {
       // which doesn't need generate a classloader which never changes
       checkChangedClassloaders(tester, null, true, true, true)
 
-      modifyFile(workspacePath / "foo" / "src" / "Example.scala", _.replace("!", "?"))
+      modifyFile(workspacePath / "foo/src/Example.scala", _.replace("!", "?"))
       runAssertSuccess(tester, "<h1>hello</h1><p>world</p><p>0.8.2</p>?")
       checkWatchedFiles(
         tester,
@@ -166,7 +166,7 @@ object MultiLevelBuildTests extends UtestIntegrationTestSuite {
       checkChangedClassloaders(tester, null, true, false, false)
 
       modifyFile(
-        workspacePath / "mill-build" / "build.mill",
+        workspacePath / "mill-build/build.mill",
         _.replace("def scalatagsVersion = ", "def scalatagsVersion = \"changed-\" + ")
       )
       runAssertSuccess(tester, "<h1>HELLO</h1><p>world</p><p>changed-0.8.2</p>?")
@@ -180,7 +180,7 @@ object MultiLevelBuildTests extends UtestIntegrationTestSuite {
       checkChangedClassloaders(tester, null, true, true, false)
 
       modifyFile(
-        workspacePath / "mill-build" / "mill-build" / "build.mill",
+        workspacePath / "mill-build/mill-build/build.mill",
         _.replace("0.8.2", "0.12.0")
       )
       runAssertSuccess(tester, "<h1>HELLO</h1><p>world</p><p>changed-0.12.0</p>?")
@@ -194,7 +194,7 @@ object MultiLevelBuildTests extends UtestIntegrationTestSuite {
       checkChangedClassloaders(tester, null, true, true, true)
 
       modifyFile(
-        workspacePath / "mill-build" / "mill-build" / "build.mill",
+        workspacePath / "mill-build/mill-build/build.mill",
         _.replace("0.12.0", "0.8.2")
       )
       runAssertSuccess(tester, "<h1>HELLO</h1><p>world</p><p>changed-0.8.2</p>?")
@@ -208,7 +208,7 @@ object MultiLevelBuildTests extends UtestIntegrationTestSuite {
       checkChangedClassloaders(tester, null, true, true, true)
 
       modifyFile(
-        workspacePath / "mill-build" / "build.mill",
+        workspacePath / "mill-build/build.mill",
         _.replace("def scalatagsVersion = \"changed-\" + ", "def scalatagsVersion = ")
       )
       runAssertSuccess(tester, "<h1>HELLO</h1><p>world</p><p>0.8.2</p>?")
@@ -232,7 +232,7 @@ object MultiLevelBuildTests extends UtestIntegrationTestSuite {
       )
       checkChangedClassloaders(tester, null, true, false, false)
 
-      modifyFile(workspacePath / "foo" / "src" / "Example.scala", _.replace("?", "!"))
+      modifyFile(workspacePath / "foo/src/Example.scala", _.replace("?", "!"))
       runAssertSuccess(tester, "<h1>hello</h1><p>world</p><p>0.8.2</p>!")
       checkWatchedFiles(
         tester,
@@ -272,13 +272,13 @@ object MultiLevelBuildTests extends UtestIntegrationTestSuite {
       checkChangedClassloaders(tester, null, null, null, null)
 
       fixParseError(workspacePath / "build.mill")
-      causeParseError(workspacePath / "mill-build" / "build.mill")
+      causeParseError(workspacePath / "mill-build/build.mill")
       evalCheckErr(tester, "\n1 targets failed", "\ngenerateScriptSources mill-build/build.mill")
       checkWatchedFiles(tester, Nil, Nil, buildPaths2(tester), Nil)
       checkChangedClassloaders(tester, null, null, null, null)
 
-      fixParseError(workspacePath / "mill-build" / "build.mill")
-      causeParseError(workspacePath / "mill-build" / "mill-build" / "build.mill")
+      fixParseError(workspacePath / "mill-build/build.mill")
+      causeParseError(workspacePath / "mill-build/mill-build/build.mill")
       evalCheckErr(
         tester,
         "\n1 targets failed",
@@ -287,13 +287,13 @@ object MultiLevelBuildTests extends UtestIntegrationTestSuite {
       checkWatchedFiles(tester, Nil, Nil, Nil, buildPaths3(tester))
       checkChangedClassloaders(tester, null, null, null, null)
 
-      fixParseError(workspacePath / "mill-build" / "mill-build" / "build.mill")
-      causeParseError(workspacePath / "mill-build" / "build.mill")
+      fixParseError(workspacePath / "mill-build/mill-build/build.mill")
+      causeParseError(workspacePath / "mill-build/build.mill")
       evalCheckErr(tester, "\n1 targets failed", "\ngenerateScriptSources mill-build/build.mill")
       checkWatchedFiles(tester, Nil, Nil, buildPaths2(tester), Nil)
       checkChangedClassloaders(tester, null, null, null, null)
 
-      fixParseError(workspacePath / "mill-build" / "build.mill")
+      fixParseError(workspacePath / "mill-build/build.mill")
       causeParseError(workspacePath / "build.mill")
       evalCheckErr(tester, "\n1 targets failed", "\ngenerateScriptSources build.mill")
       checkWatchedFiles(tester, Nil, buildPaths(tester), Nil, Nil)
@@ -341,37 +341,37 @@ object MultiLevelBuildTests extends UtestIntegrationTestSuite {
       checkWatchedFiles(tester, Nil, buildPaths(tester), buildPaths2(tester), buildPaths3(tester))
       checkChangedClassloaders(tester, null, null, false, false)
 
-      causeCompileError(workspacePath / "mill-build" / "build.mill")
+      causeCompileError(workspacePath / "mill-build/build.mill")
       evalCheckErr(
         tester,
         "\n1 targets failed",
-        (workspacePath / "mill-build" / "build.mill").toString,
+        (workspacePath / "mill-build/build.mill").toString,
         "not found: object doesnt"
       )
       checkWatchedFiles(tester, Nil, Nil, buildPaths2(tester), buildPaths3(tester))
       checkChangedClassloaders(tester, null, null, null, false)
 
-      causeCompileError(workspacePath / "mill-build" / "mill-build" / "build.mill")
+      causeCompileError(workspacePath / "mill-build/mill-build/build.mill")
       evalCheckErr(
         tester,
         "\n1 targets failed",
-        (workspacePath / "mill-build" / "mill-build" / "build.mill").toString,
+        (workspacePath / "mill-build/mill-build/build.mill").toString,
         "not found: object doesnt"
       )
       checkWatchedFiles(tester, Nil, Nil, Nil, buildPaths3(tester))
       checkChangedClassloaders(tester, null, null, null, null)
 
-      fixCompileError(workspacePath / "mill-build" / "mill-build" / "build.mill")
+      fixCompileError(workspacePath / "mill-build/mill-build/build.mill")
       evalCheckErr(
         tester,
         "\n1 targets failed",
-        (workspacePath / "mill-build" / "build.mill").toString,
+        (workspacePath / "mill-build/build.mill").toString,
         "not found: object doesnt"
       )
       checkWatchedFiles(tester, Nil, Nil, buildPaths2(tester), buildPaths3(tester))
       checkChangedClassloaders(tester, null, null, null, true)
 
-      fixCompileError(workspacePath / "mill-build" / "build.mill")
+      fixCompileError(workspacePath / "mill-build/build.mill")
       evalCheckErr(
         tester,
         "\n1 targets failed",
@@ -428,7 +428,7 @@ object MultiLevelBuildTests extends UtestIntegrationTestSuite {
       )
       checkChangedClassloaders(tester, null, true, false, false)
 
-      causeRuntimeError(workspacePath / "mill-build" / "build.mill")
+      causeRuntimeError(workspacePath / "mill-build/build.mill")
       evalCheckErr(
         tester,
         "\n1 targets failed",
@@ -438,7 +438,7 @@ object MultiLevelBuildTests extends UtestIntegrationTestSuite {
       checkWatchedFiles(tester, Nil, buildPaths(tester), buildPaths2(tester), buildPaths3(tester))
       checkChangedClassloaders(tester, null, null, true, false)
 
-      causeRuntimeError(workspacePath / "mill-build" / "mill-build" / "build.mill")
+      causeRuntimeError(workspacePath / "mill-build/mill-build/build.mill")
       evalCheckErr(
         tester,
         "\n1 targets failed",
@@ -448,7 +448,7 @@ object MultiLevelBuildTests extends UtestIntegrationTestSuite {
       checkWatchedFiles(tester, Nil, Nil, buildPaths2(tester), buildPaths3(tester))
       checkChangedClassloaders(tester, null, null, null, true)
 
-      fixRuntimeError(workspacePath / "mill-build" / "mill-build" / "build.mill")
+      fixRuntimeError(workspacePath / "mill-build/mill-build/build.mill")
       evalCheckErr(
         tester,
         "\n1 targets failed",
@@ -458,7 +458,7 @@ object MultiLevelBuildTests extends UtestIntegrationTestSuite {
       checkWatchedFiles(tester, Nil, buildPaths(tester), buildPaths2(tester), buildPaths3(tester))
       checkChangedClassloaders(tester, null, null, true, true)
 
-      fixRuntimeError(workspacePath / "mill-build" / "build.mill")
+      fixRuntimeError(workspacePath / "mill-build/build.mill")
       evalCheckErr(
         tester,
         "\n1 targets failed",

--- a/integration/invalidation/zinc-incremental-compilation/src/ZincIncrementalCompilationTests.scala
+++ b/integration/invalidation/zinc-incremental-compilation/src/ZincIncrementalCompilationTests.scala
@@ -12,10 +12,10 @@ object ZincIncrementalCompilationTests extends UtestIntegrationTestSuite {
       val successful = tester.eval("app.compile")
       assert(successful.isSuccess)
 
-      val appSrc = workspacePath / "app" / "src" / "main" / "scala" / "App.scala"
-      val classes = workspacePath / "out" / "app" / "compile.dest" / "classes"
-      val app = classes / "app" / "App.class"
-      val model = classes / "models" / "Foo.class"
+      val appSrc = workspacePath / "app/src/main/scala/App.scala"
+      val classes = workspacePath / "out/app/compile.dest/classes"
+      val app = classes / "app/App.class"
+      val model = classes / "models/Foo.class"
       assert(Seq(classes, app, model, appSrc).forall(os.exists))
 
       val appSrcInfo1 = os.stat(appSrc)

--- a/main/api/src/mill/api/Ctx.scala
+++ b/main/api/src/mill/api/Ctx.scala
@@ -97,7 +97,7 @@ object Ctx {
     def workspace: os.Path
   }
 
-  def defaultHome: os.Path = os.home / ".mill" / "ammonite"
+  def defaultHome: os.Path = os.home / ".mill/ammonite"
 
   /**
    * Marker annotation.

--- a/main/api/src/mill/api/JarOps.scala
+++ b/main/api/src/mill/api/JarOps.scala
@@ -73,7 +73,7 @@ trait JarOps {
     os.remove.all(jar)
 
     val seen = mutable.Set.empty[os.RelPath]
-    seen.add(os.sub / "META-INF" / "MANIFEST.MF")
+    seen.add(os.sub / "META-INF/MANIFEST.MF")
 
     val jarStream = new JarOutputStream(
       new BufferedOutputStream(new FileOutputStream(jar.toIO)),

--- a/main/define/test/src/mill/define/BasePathTests.scala
+++ b/main/define/test/src/mill/define/BasePathTests.scala
@@ -65,8 +65,8 @@ object BasePathTests extends TestSuite {
       }
       assert(
         overriddenBasePath.millSourcePath == os.pwd / "overriddenBasePathRootValue",
-        overriddenBasePath.nested.millSourcePath == os.pwd / "overriddenBasePathRootValue" / "nested" / "overriddenBasePathNested",
-        overriddenBasePath.nested.nested.millSourcePath == os.pwd / "overriddenBasePathRootValue" / "nested" / "overriddenBasePathNested" / "nested" / "overriddenBasePathDoubleNested"
+        overriddenBasePath.nested.millSourcePath == os.pwd / "overriddenBasePathRootValue/nested/overriddenBasePathNested",
+        overriddenBasePath.nested.nested.millSourcePath == os.pwd / "overriddenBasePathRootValue/nested/overriddenBasePathNested/nested/overriddenBasePathDoubleNested"
       )
     }
 

--- a/main/eval/test/src/mill/eval/EvaluationTests.scala
+++ b/main/eval/test/src/mill/eval/EvaluationTests.scala
@@ -225,7 +225,7 @@ class EvaluationTests(threadCount: Option[Int]) extends TestSuite {
 
         val public = os.read(checker.evaluator.outPath / "foo.json")
         val overridden = os.read(
-          checker.evaluator.outPath / "foo.super" / "BaseModule.json"
+          checker.evaluator.outPath / "foo.super/BaseModule.json"
         )
         assert(
           public.contains("base"),
@@ -252,7 +252,7 @@ class EvaluationTests(threadCount: Option[Int]) extends TestSuite {
 
         val public = os.read(checker.evaluator.outPath / "cmd.json")
         val overridden = os.read(
-          checker.evaluator.outPath / "cmd.super" / "BaseModule.json"
+          checker.evaluator.outPath / "cmd.super/BaseModule.json"
         )
         assert(
           public.contains("base1"),
@@ -367,14 +367,14 @@ class EvaluationTests(threadCount: Option[Int]) extends TestSuite {
       )
 
       assert(
-        os.read(checker.evaluator.outPath / "m" / "f.super" / "X.json")
+        os.read(checker.evaluator.outPath / "m/f.super/X.json")
           .contains(" 1,")
       )
       assert(
-        os.read(checker.evaluator.outPath / "m" / "f.super" / "A.json")
+        os.read(checker.evaluator.outPath / "m/f.super/A.json")
           .contains(" 3,")
       )
-      assert(os.read(checker.evaluator.outPath / "m" / "f.json").contains(" 6,"))
+      assert(os.read(checker.evaluator.outPath / "m/f.json").contains(" 6,"))
     }
     utest.test("stackableOverrides2") {
       // When the supers have the same name, qualify them until they are distinct
@@ -389,14 +389,14 @@ class EvaluationTests(threadCount: Option[Int]) extends TestSuite {
       )
 
       assert(
-        os.read(checker.evaluator.outPath / "m" / "f.super" / "A" / "X.json")
+        os.read(checker.evaluator.outPath / "m/f.super/A/X.json")
           .contains(" 1,")
       )
       assert(
-        os.read(checker.evaluator.outPath / "m" / "f.super" / "B" / "X.json")
+        os.read(checker.evaluator.outPath / "m/f.super/B/X.json")
           .contains(" 3,")
       )
-      assert(os.read(checker.evaluator.outPath / "m" / "f.json").contains(" 6,"))
+      assert(os.read(checker.evaluator.outPath / "m/f.json").contains(" 6,"))
     }
     utest.test("stackableOverrides3") {
       // When the supers have the same name, qualify them until they are distinct
@@ -411,14 +411,14 @@ class EvaluationTests(threadCount: Option[Int]) extends TestSuite {
       )
 
       assert(
-        os.read(checker.evaluator.outPath / "m" / "f.super" / "A" / "X.json")
+        os.read(checker.evaluator.outPath / "m/f.super/A/X.json")
           .contains(" 1,")
       )
       assert(
-        os.read(checker.evaluator.outPath / "m" / "f.super" / "X.json")
+        os.read(checker.evaluator.outPath / "m/f.super/X.json")
           .contains(" 3,")
       )
-      assert(os.read(checker.evaluator.outPath / "m" / "f.json").contains(" 6,"))
+      assert(os.read(checker.evaluator.outPath / "m/f.json").contains(" 6,"))
     }
     utest.test("privateTasksInMixedTraits") {
       // Make sure we can have private cached targets in different trait with the same name,

--- a/main/eval/test/src/mill/eval/JavaCompileJarTests.scala
+++ b/main/eval/test/src/mill/eval/JavaCompileJarTests.scala
@@ -19,7 +19,7 @@ object JavaCompileJarTests extends TestSuite {
   }
 
   val resourceFolder = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER"))
-  val javacSrcPath = resourceFolder / "examples" / "javac"
+  val javacSrcPath = resourceFolder / "examples/javac"
 
   val tests = Tests {
 
@@ -122,7 +122,7 @@ object JavaCompileJarTests extends TestSuite {
       check(targets = Agg(allSources), expected = Agg(allSources))
       check(targets = Agg(jar), expected = Agg(classFiles, jar))
 
-      val jarContents = os.proc("jar", "-tf", evaluator.outPath / "jar.dest" / "out.jar").call(
+      val jarContents = os.proc("jar", "-tf", evaluator.outPath / "jar.dest/out.jar").call(
         evaluator.outPath
       ).out.text()
       val expectedJarContents =
@@ -147,7 +147,7 @@ object JavaCompileJarTests extends TestSuite {
       val filteredJarContents = os.proc(
         "jar",
         "-tf",
-        evaluator.outPath / "filterJar.dest" / "out.jar"
+        evaluator.outPath / "filterJar.dest/out.jar"
       ).call(evaluator.outPath).out.text()
       assert(filteredJarContents.linesIterator.toSeq == expectedJarContents.linesIterator.filter(
         noFoos(_)
@@ -156,7 +156,7 @@ object JavaCompileJarTests extends TestSuite {
       val executed = os.proc(
         "java",
         "-cp",
-        evaluator.outPath / "jar.dest" / "out.jar",
+        evaluator.outPath / "jar.dest/out.jar",
         "test.Foo"
       ).call(evaluator.outPath).out.text()
       assert(executed == s"${31337 + 271828}${System.lineSeparator}")

--- a/main/eval/test/src/mill/eval/ModuleTests.scala
+++ b/main/eval/test/src/mill/eval/ModuleTests.scala
@@ -28,10 +28,10 @@ object ModuleTests extends TestSuite {
         zresult == Right(Result(30, 1)),
         os.read(check.evaluator.outPath / "z.json").contains("30"),
         os.read(
-          check.outPath / "mill" / "eval" / "ModuleTests" / "ExternalModule" / "x.json"
+          check.outPath / "mill/eval/ModuleTests/ExternalModule/x.json"
         ).contains("13"),
         os.read(
-          check.outPath / "mill" / "eval" / "ModuleTests" / "ExternalModule" / "inner" / "y.json"
+          check.outPath / "mill/eval/ModuleTests/ExternalModule/inner/y.json"
         ).contains("17")
       )
     }

--- a/main/test/src/mill/UTestFramework.scala
+++ b/main/test/src/mill/UTestFramework.scala
@@ -6,6 +6,6 @@ class UTestFramework extends utest.runner.Framework {
   }
   override def setup(): Unit = {
 
-    os.remove.all(os.pwd / "target" / "workspace")
+    os.remove.all(os.pwd / "target/workspace")
   }
 }

--- a/main/test/src/mill/main/MainModuleTests.scala
+++ b/main/test/src/mill/main/MainModuleTests.scala
@@ -233,22 +233,22 @@ object MainModuleTests extends TestSuite {
         val r1 = ev.evaluator.evaluate(Agg(cleanModule.all))
         assert(r1.failing.keyCount == 0)
         checkExists(true)(
-          os.sub / "foo" / "target.json",
-          os.sub / "foo" / "target.dest" / "dummy.txt",
-          os.sub / "bar" / "target.json",
-          os.sub / "bar" / "target.dest" / "dummy.txt"
+          os.sub / "foo/target.json",
+          os.sub / "foo/target.dest/dummy.txt",
+          os.sub / "bar/target.json",
+          os.sub / "bar/target.dest/dummy.txt"
         )
 
         val r2 = ev.evaluator.evaluate(Agg(cleanModule.clean(ev.evaluator, "foo.target")))
         assert(r2.failing.keyCount == 0)
         checkExists(false)(
-          os.sub / "foo" / "target.log",
-          os.sub / "foo" / "target.json",
-          os.sub / "foo" / "target.dest" / "dummy.txt"
+          os.sub / "foo/target.log",
+          os.sub / "foo/target.json",
+          os.sub / "foo/target.dest/dummy.txt"
         )
         checkExists(true)(
-          os.sub / "bar" / "target.json",
-          os.sub / "bar" / "target.dest" / "dummy.txt"
+          os.sub / "bar/target.json",
+          os.sub / "bar/target.dest/dummy.txt"
         )
       }
 
@@ -256,21 +256,21 @@ object MainModuleTests extends TestSuite {
         val r1 = ev.evaluator.evaluate(Agg(cleanModule.all))
         assert(r1.failing.keyCount == 0)
         checkExists(true)(
-          os.sub / "foo" / "target.json",
-          os.sub / "foo" / "target.dest" / "dummy.txt",
-          os.sub / "bar" / "target.json",
-          os.sub / "bar" / "target.dest" / "dummy.txt"
+          os.sub / "foo/target.json",
+          os.sub / "foo/target.dest/dummy.txt",
+          os.sub / "bar/target.json",
+          os.sub / "bar/target.dest/dummy.txt"
         )
 
         val r2 = ev.evaluator.evaluate(Agg(cleanModule.clean(ev.evaluator, "bar")))
         assert(r2.failing.keyCount == 0)
         checkExists(true)(
-          os.sub / "foo" / "target.json",
-          os.sub / "foo" / "target.dest" / "dummy.txt"
+          os.sub / "foo/target.json",
+          os.sub / "foo/target.dest/dummy.txt"
         )
         checkExists(false)(
-          os.sub / "bar" / "target.json",
-          os.sub / "bar" / "target.dest" / "dummy.txt"
+          os.sub / "bar/target.json",
+          os.sub / "bar/target.dest/dummy.txt"
         )
       }
     }

--- a/main/util/src/mill/util/CoursierSupport.scala
+++ b/main/util/src/mill/util/CoursierSupport.scala
@@ -87,7 +87,7 @@ trait CoursierSupport {
 
       val classpathResourceText =
         try Some(os.read(
-            os.resource(getClass.getClassLoader) / "mill" / "local-test-overrides" / classpathKey
+            os.resource(getClass.getClassLoader) / "mill/local-test-overrides" / classpathKey
           ))
         catch { case e: os.ResourceNotFoundException => None }
 

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -170,9 +170,9 @@ class MillBuildRootModule()(implicit
         },
         logger = new mill.codesig.Logger(Option.when(debugEnabled)(T.dest / "current")),
         prevTransitiveCallGraphHashesOpt = () =>
-          Option.when(os.exists(T.dest / "previous" / "result.json"))(
+          Option.when(os.exists(T.dest / "previous/result.json"))(
             upickle.default.read[Map[String, Int]](
-              os.read.stream(T.dest / "previous" / "result.json")
+              os.read.stream(T.dest / "previous/result.json")
             )
           )
       )
@@ -180,7 +180,7 @@ class MillBuildRootModule()(implicit
     val result = codesig.transitiveCallGraphHashes
     if (debugEnabled) {
       os.write(
-        T.dest / "current" / "result.json",
+        T.dest / "current/result.json",
         upickle.default.stream(
           SortedMap.from(codesig.transitiveCallGraphHashes0.map { case (k, v) => (k.toString, v) }),
           indent = 4

--- a/runner/src/mill/runner/MillMain.scala
+++ b/runner/src/mill/runner/MillMain.scala
@@ -40,7 +40,7 @@ object MillMain {
       if (args.headOption == Option("--bsp")) {
         // In BSP mode, we use System.in/out for protocol communication
         // and all Mill output (stdout and stderr) goes to a dedicated file
-        val stderrFile = WorkspaceRoot.workspaceRoot / ".bsp" / "mill-bsp.stderr"
+        val stderrFile = WorkspaceRoot.workspaceRoot / ".bsp/mill-bsp.stderr"
         os.makeDir.all(stderrFile / os.up)
         val errFile = new PrintStream(new FileOutputStream(stderrFile.toIO, true))
         val errTee = new TeePrintStream(initialSystemStreams.err, errFile)
@@ -319,7 +319,7 @@ object MillMain {
 
   def checkMillVersionFromFile(projectDir: os.Path, stderr: PrintStream): Unit = {
     Seq(
-      projectDir / ".config" / "mill-version",
+      projectDir / ".config/mill-version",
       projectDir / ".mill-version"
     ).collectFirst {
       case f if os.exists(f) =>

--- a/scalajslib/test/src/mill/scalajslib/HelloJSWorldTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/HelloJSWorldTests.scala
@@ -50,7 +50,7 @@ object HelloJSWorldTests extends TestSuite {
       )
 
       object `test-utest` extends ScalaJSTests with TestModule.Utest {
-        override def sources = T.sources { millSourcePath / "src" / "utest" }
+        override def sources = T.sources { millSourcePath / "src/utest" }
         val utestVersion = if (ZincWorkerUtil.isScala3(crossScalaVersion)) "0.7.7" else "0.7.5"
         override def ivyDeps = Agg(
           ivy"com.lihaoyi::utest::$utestVersion"
@@ -58,7 +58,7 @@ object HelloJSWorldTests extends TestSuite {
       }
 
       object `test-scalatest` extends ScalaJSTests with TestModule.ScalaTest {
-        override def sources = T.sources { millSourcePath / "src" / "scalatest" }
+        override def sources = T.sources { millSourcePath / "src/scalatest" }
         override def ivyDeps = Agg(
           ivy"org.scalatest::scalatest::3.1.2"
         )

--- a/scalajslib/test/src/mill/scalajslib/NodeJSConfigTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/NodeJSConfigTests.scala
@@ -43,7 +43,7 @@ object NodeJSConfigTests extends TestSuite {
       override def jsEnvConfig = T { JsEnvConfig.NodeJs(args = nodeArgs) }
 
       object `test-utest` extends ScalaJSTests with TestModule.Utest {
-        override def sources = T.sources { millSourcePath / "src" / "utest" }
+        override def sources = T.sources { millSourcePath / "src/utest" }
         override def ivyDeps = Agg(
           ivy"com.lihaoyi::utest::$utestVersion"
         )
@@ -58,7 +58,7 @@ object NodeJSConfigTests extends TestSuite {
 
   val helloWorldEvaluator = UnitTester(HelloJSWorld, millSourcePath)
 
-  val mainObject = helloWorldEvaluator.outPath / "src" / "Main.scala"
+  val mainObject = helloWorldEvaluator.outPath / "src/Main.scala"
 
   def tests: Tests = Tests {
     def checkLog(command: define.Command[_], nodeArgs: List[String], notNodeArgs: List[String]) = {

--- a/scalalib/src/mill/scalalib/CrossSbtModule.scala
+++ b/scalalib/src/mill/scalalib/CrossSbtModule.scala
@@ -8,7 +8,7 @@ trait CrossSbtModule extends SbtModule with CrossModuleBase { outer =>
 
   override def sources: T[Seq[PathRef]] = T.sources {
     super.sources() ++ scalaVersionDirectoryNames.map(s =>
-      PathRef(millSourcePath / "src" / "main" / s"scala-$s")
+      PathRef(millSourcePath / "src/main" / s"scala-$s")
     )
   }
 
@@ -18,7 +18,7 @@ trait CrossSbtModule extends SbtModule with CrossModuleBase { outer =>
     override def millSourcePath = outer.millSourcePath
     override def sources = T.sources {
       super.sources() ++ scalaVersionDirectoryNames.map(s =>
-        PathRef(millSourcePath / "src" / "test" / s"scala-$s")
+        PathRef(millSourcePath / "src/test" / s"scala-$s")
       )
     }
   }

--- a/scalalib/src/mill/scalalib/MavenModule.scala
+++ b/scalalib/src/mill/scalalib/MavenModule.scala
@@ -10,23 +10,23 @@ import mill.T
 trait MavenModule extends JavaModule { outer =>
 
   override def sources = T.sources(
-    millSourcePath / "src" / "main" / "java"
+    millSourcePath / "src/main/java"
   )
   override def resources = T.sources {
-    millSourcePath / "src" / "main" / "resources"
+    millSourcePath / "src/main/resources"
   }
 
   type MavenTests = MavenModuleTests
   @deprecated("Use JavaTests instead", since = "Mill 0.11.10")
   trait MavenModuleTests extends JavaModuleTests {
     override def millSourcePath = outer.millSourcePath
-    override def intellijModulePath: os.Path = outer.millSourcePath / "src" / "test"
+    override def intellijModulePath: os.Path = outer.millSourcePath / "src/test"
 
     override def sources = T.sources(
-      millSourcePath / "src" / "test" / "java"
+      millSourcePath / "src/test/java"
     )
     override def resources = T.sources {
-      millSourcePath / "src" / "test" / "resources"
+      millSourcePath / "src/test/resources"
     }
   }
 }

--- a/scalalib/src/mill/scalalib/PublishModule.scala
+++ b/scalalib/src/mill/scalalib/PublishModule.scala
@@ -159,7 +159,7 @@ trait PublishModule extends JavaModule { outer =>
    * @param m2RepoPath The path to the local repository  as string (default: `$HOME/.m2repository`).
    * @return [[PathRef]]s to published files.
    */
-  def publishM2Local(m2RepoPath: String = (os.home / ".m2" / "repository").toString())
+  def publishM2Local(m2RepoPath: String = (os.home / ".m2/repository").toString())
       : Command[Seq[PathRef]] = T.command {
     publishM2LocalTask(T.task {
       os.Path(m2RepoPath, T.workspace)
@@ -172,7 +172,7 @@ trait PublishModule extends JavaModule { outer =>
    */
   def publishM2LocalCached: T[Seq[PathRef]] = T {
     publishM2LocalTask(T.task {
-      os.Path(os.home / ".m2" / "repository", T.workspace)
+      os.Path(os.home / ".m2/repository", T.workspace)
     })()
   }
 

--- a/scalalib/src/mill/scalalib/SbtModule.scala
+++ b/scalalib/src/mill/scalalib/SbtModule.scala
@@ -8,16 +8,16 @@ import mill.T
 trait SbtModule extends ScalaModule with MavenModule {
 
   override def sources = T.sources(
-    millSourcePath / "src" / "main" / "scala",
-    millSourcePath / "src" / "main" / "java"
+    millSourcePath / "src/main/scala",
+    millSourcePath / "src/main/java"
   )
 
   type SbtTests = SbtModuleTests
   @deprecated("Use SbtTests instead", since = "Mill 0.11.10")
   trait SbtModuleTests extends ScalaTests with MavenTests {
     override def sources = T.sources(
-      millSourcePath / "src" / "test" / "scala",
-      millSourcePath / "src" / "test" / "java"
+      millSourcePath / "src/test/scala",
+      millSourcePath / "src/test/java"
     )
   }
 }

--- a/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
+++ b/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
@@ -215,7 +215,7 @@ object SemanticDbJavaModule {
     os.makeDir.all(targetDir)
 
     val ups = sourceroot.segments.size
-    val semanticPath = os.rel / "META-INF" / "semanticdb"
+    val semanticPath = os.rel / "META-INF/semanticdb"
     val toClean = classesDir / semanticPath / sourceroot.segments.toSeq
 
     // copy over all found semanticdb-files into the target directory

--- a/scalalib/src/mill/scalalib/publish/LocalIvyPublisher.scala
+++ b/scalalib/src/mill/scalalib/publish/LocalIvyPublisher.scala
@@ -33,7 +33,7 @@ class LocalIvyPublisher(localIvyRepo: os.Path) {
       sourcesJar -> releaseDir / "srcs" / s"${artifact.id}-sources.jar",
       docJar -> releaseDir / "docs" / s"${artifact.id}-javadoc.jar",
       pom -> releaseDir / "poms" / s"${artifact.id}.pom",
-      ivy -> releaseDir / "ivys" / "ivy.xml"
+      ivy -> releaseDir / "ivys/ivy.xml"
     ) ++ extras.map { entry =>
       (
         entry.file.path,

--- a/scalalib/test/src/mill/scalalib/DottyDocTests.scala
+++ b/scalalib/test/src/mill/scalalib/DottyDocTests.scala
@@ -37,35 +37,35 @@ object DottyDocTests extends TestSuite {
   def tests: Tests = Tests {
     test("static") - UnitTester(StaticDocsModule, resourcePath).scoped { eval =>
       val Right(_) = eval.apply(StaticDocsModule.static.docJar)
-      val dest = eval.outPath / "static" / "docJar.dest"
+      val dest = eval.outPath / "static/docJar.dest"
       assert(
         os.exists(dest / "out.jar"), // final jar should exist
         // check if extra markdown files have been included and translated to html
-        os.exists(dest / "javadoc" / "_site" / "index.html"),
-        os.exists(dest / "javadoc" / "_site" / "nested" / "extra.html"),
+        os.exists(dest / "javadoc/_site/index.html"),
+        os.exists(dest / "javadoc/_site/nested/extra.html"),
         // also check that API docs have been generated
-        os.exists(dest / "javadoc" / "_site" / "api" / "pkg" / "SomeClass.html")
+        os.exists(dest / "javadoc/_site/api/pkg/SomeClass.html")
       )
     }
     test("empty") - UnitTester(EmptyDocsModule, resourcePath).scoped { eval =>
       val Right(_) = eval.apply(EmptyDocsModule.empty.docJar)
-      val dest = eval.outPath / "empty" / "docJar.dest"
+      val dest = eval.outPath / "empty/docJar.dest"
       assert(
         os.exists(dest / "out.jar"),
-        os.exists(dest / "javadoc" / "_site" / "api" / "pkg" / "SomeClass.html")
+        os.exists(dest / "javadoc/_site/api/pkg/SomeClass.html")
       )
     }
     test("multiple") - UnitTester(MultiDocsModule, resourcePath).scoped { eval =>
       val Right(_) = eval.apply(MultiDocsModule.multidocs.docJar)
-      val dest = eval.outPath / "multidocs" / "docJar.dest"
+      val dest = eval.outPath / "multidocs/docJar.dest"
       assert(
         os.exists(dest / "out.jar"), // final jar should exist
-        os.exists(dest / "javadoc" / "_site" / "api" / "pkg" / "SomeClass.html"),
-        os.exists(dest / "javadoc" / "_site" / "index.html"),
-        os.exists(dest / "javadoc" / "_site" / "nested" / "original.html"),
-        os.exists(dest / "javadoc" / "_site" / "nested" / "extra.html"),
+        os.exists(dest / "javadoc/_site/api/pkg/SomeClass.html"),
+        os.exists(dest / "javadoc/_site/index.html"),
+        os.exists(dest / "javadoc/_site/nested/original.html"),
+        os.exists(dest / "javadoc/_site/nested/extra.html"),
         // check that later doc sources overwrite earlier ones
-        os.read(dest / "javadoc" / "_site" / "index.html").contains("overwritten")
+        os.read(dest / "javadoc/_site/index.html").contains("overwritten")
       )
     }
   }

--- a/scalalib/test/src/mill/scalalib/HelloJavaTests.scala
+++ b/scalalib/test/src/mill/scalalib/HelloJavaTests.scala
@@ -49,7 +49,7 @@ object HelloJavaTests extends TestSuite {
     }
     test("semanticDbData") {
       val expectedFile1 =
-        os.rel / "META-INF" / "semanticdb" / "core" / "src" / "Core.java.semanticdb"
+        os.rel / "META-INF/semanticdb/core/src/Core.java.semanticdb"
 
       test("fromScratch") {
         val eval = testEval()
@@ -57,7 +57,7 @@ object HelloJavaTests extends TestSuite {
 
         val outputFiles =
           os.walk(result.value.path).filter(os.isFile).map(_.relativeTo(result.value.path))
-        val dataPath = eval.outPath / "core" / "semanticDbData.dest" / "data"
+        val dataPath = eval.outPath / "core/semanticDbData.dest/data"
 
         assert(
           result.value.path == dataPath,
@@ -74,7 +74,7 @@ object HelloJavaTests extends TestSuite {
         val eval = testEval()
 
         // create a second source file
-        val secondFile = eval.evaluator.workspace / "core" / "src" / "hello" / "Second.java"
+        val secondFile = eval.evaluator.workspace / "core/src/hello/Second.java"
         os.write(
           secondFile,
           """package hello;
@@ -87,7 +87,7 @@ object HelloJavaTests extends TestSuite {
             |""".stripMargin,
           createFolders = true
         )
-        val thirdFile = eval.evaluator.workspace / "core" / "src" / "hello" / "Third.java"
+        val thirdFile = eval.evaluator.workspace / "core/src/hello/Third.java"
         os.write(
           thirdFile,
           """package hello;
@@ -102,14 +102,14 @@ object HelloJavaTests extends TestSuite {
         )
         val Right(result) = eval.apply(HelloJava.core.semanticDbData)
 
-        val dataPath = eval.outPath / "core" / "semanticDbData.dest" / "data"
+        val dataPath = eval.outPath / "core/semanticDbData.dest/data"
         val outputFiles =
           os.walk(result.value.path).filter(os.isFile).map(_.relativeTo(result.value.path))
 
         val expectedFile2 =
-          os.rel / "META-INF" / "semanticdb" / "core" / "src" / "hello" / "Second.java.semanticdb"
+          os.rel / "META-INF/semanticdb/core/src/hello/Second.java.semanticdb"
         val expectedFile3 =
-          os.rel / "META-INF" / "semanticdb" / "core" / "src" / "hello" / "Third.java.semanticdb"
+          os.rel / "META-INF/semanticdb/core/src/hello/Third.java.semanticdb"
         assert(
           result.value.path == dataPath,
           outputFiles.nonEmpty,
@@ -184,8 +184,8 @@ object HelloJavaTests extends TestSuite {
     test("failures") {
       val eval = testEval()
 
-      val mainJava = HelloJava.millSourcePath / "app" / "src" / "Main.java"
-      val coreJava = HelloJava.millSourcePath / "core" / "src" / "Core.java"
+      val mainJava = HelloJava.millSourcePath / "app/src/Main.java"
+      val coreJava = HelloJava.millSourcePath / "core/src/Core.java"
 
       val Right(_) = eval.apply(HelloJava.core.compile)
       val Right(_) = eval.apply(HelloJava.app.compile)

--- a/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
+++ b/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
@@ -477,7 +477,7 @@ object HelloWorldTests extends TestSuite {
         val Right(result) = eval.apply(HelloWorldDocTitle.core.docJar)
         assert(
           result.evalCount > 0,
-          os.read(eval.outPath / "core" / "docJar.dest" / "javadoc" / "index.html").contains(
+          os.read(eval.outPath / "core/docJar.dest/javadoc/index.html").contains(
             "<span id=\"doc-title\">Hello World"
           )
         )
@@ -525,7 +525,7 @@ object HelloWorldTests extends TestSuite {
       test("fromScratch") - UnitTester(HelloWorld, sourceRoot = resourcePath).scoped { eval =>
         val Right(result) = eval.apply(HelloWorld.core.compile)
 
-        val classesPath = eval.outPath / "core" / "compile.dest" / "classes"
+        val classesPath = eval.outPath / "core/compile.dest/classes"
         val analysisFile = result.value.analysisFile
         val outputFiles = os.walk(result.value.classes.path)
         val expectedClassfiles = compileClassfiles.map(classesPath / _)
@@ -545,7 +545,7 @@ object HelloWorldTests extends TestSuite {
         // Make sure we *do not* end up compiling the compiler bridge, since
         // it's using a pre-compiled bridge value
         assert(!os.exists(
-          eval.outPath / "mill" / "scalalib" / "ZincWorkerModule" / "worker.dest" / s"zinc-${zincVersion}"
+          eval.outPath / "mill/scalalib/ZincWorkerModule/worker.dest" / s"zinc-${zincVersion}"
         ))
       }
 
@@ -555,7 +555,7 @@ object HelloWorldTests extends TestSuite {
       ).scoped { eval =>
         val Right(result) = eval.apply(HelloWorldNonPrecompiledBridge.core.compile)
 
-        val classesPath = eval.outPath / "core" / "compile.dest" / "classes"
+        val classesPath = eval.outPath / "core/compile.dest/classes"
 
         val analysisFile = result.value.analysisFile
         val outputFiles = os.walk(result.value.classes.path)
@@ -576,7 +576,7 @@ object HelloWorldTests extends TestSuite {
         // Make sure we *do* end up compiling the compiler bridge, since it's
         // *not* using a pre-compiled bridge value
         assert(os.exists(
-          eval.outPath / "mill" / "scalalib" / "ZincWorkerModule" / "worker.dest" / s"zinc-${zincVersion}"
+          eval.outPath / "mill/scalalib/ZincWorkerModule/worker.dest" / s"zinc-${zincVersion}"
         ))
       }
 
@@ -584,13 +584,13 @@ object HelloWorldTests extends TestSuite {
         val Right(result) = eval.apply(HelloWorld.core.compile)
         assert(result.evalCount > 0)
 
-        os.write.append(HelloWorld.millSourcePath / "core" / "src" / "Main.scala", "\n")
+        os.write.append(HelloWorld.millSourcePath / "core/src/Main.scala", "\n")
 
         val Right(result2) = eval.apply(HelloWorld.core.compile)
         assert(result2.evalCount > 0, result2.evalCount < result.evalCount)
       }
       test("failOnError") - UnitTester(HelloWorld, sourceRoot = resourcePath).scoped { eval =>
-        os.write.append(HelloWorld.millSourcePath / "core" / "src" / "Main.scala", "val x: ")
+        os.write.append(HelloWorld.millSourcePath / "core/src/Main.scala", "val x: ")
 
         val Left(Result.Failure("Compilation failed", _)) = eval.apply(HelloWorld.core.compile)
 
@@ -602,8 +602,8 @@ object HelloWorldTests extends TestSuite {
         )
         // Works when fixed
         os.write.over(
-          HelloWorld.millSourcePath / "core" / "src" / "Main.scala",
-          os.read(HelloWorld.millSourcePath / "core" / "src" / "Main.scala").dropRight(
+          HelloWorld.millSourcePath / "core/src/Main.scala",
+          os.read(HelloWorld.millSourcePath / "core/src/Main.scala").dropRight(
             "val x: ".length
           )
         )
@@ -622,8 +622,8 @@ object HelloWorldTests extends TestSuite {
 
     test("semanticDbData") {
       def semanticDbFiles: Set[os.SubPath] = Set(
-        os.sub / "META-INF" / "semanticdb" / "core" / "src" / "Main.scala.semanticdb",
-        os.sub / "META-INF" / "semanticdb" / "core" / "src" / "Result.scala.semanticdb"
+        os.sub / "META-INF/semanticdb/core/src/Main.scala.semanticdb",
+        os.sub / "META-INF/semanticdb/core/src/Result.scala.semanticdb"
       )
 
       test("fromScratch") - UnitTester(SemanticWorld, sourceRoot = resourcePath).scoped { eval =>
@@ -631,7 +631,7 @@ object HelloWorldTests extends TestSuite {
           println("first - expected full compile")
           val Right(result) = eval.apply(SemanticWorld.core.semanticDbData)
 
-          val dataPath = eval.outPath / "core" / "semanticDbData.dest" / "data"
+          val dataPath = eval.outPath / "core/semanticDbData.dest/data"
           val outputFiles =
             os.walk(result.value.path).filter(os.isFile).map(_.relativeTo(result.value.path))
 
@@ -658,7 +658,7 @@ object HelloWorldTests extends TestSuite {
       ).scoped { eval =>
         // create some more source file to have a reasonable low incremental change later
         val extraFiles = Seq("Second", "Third", "Fourth").map { f =>
-          val file = eval.evaluator.workspace / "core" / "src" / "hello" / s"${f}.scala"
+          val file = eval.evaluator.workspace / "core/src/hello" / s"${f}.scala"
           os.write(
             file,
             s"""package hello
@@ -667,16 +667,16 @@ object HelloWorldTests extends TestSuite {
             createFolders = true
           )
           val sem =
-            os.sub / "META-INF" / "semanticdb" / "core" / "src" / "hello" / s"${f}.scala.semanticdb"
+            os.sub / "META-INF/semanticdb/core/src/hello" / s"${f}.scala.semanticdb"
           (file, sem)
         }
-//        val resultFile = eval.evaluator.workspace / "core" / "src" / "Result.scala"
+//        val resultFile = eval.evaluator.workspace / "core/src/Result.scala"
 
         {
           println("first - expected full compile")
           val Right(result) = eval.apply(SemanticWorld.core.semanticDbData)
 
-          val dataPath = eval.outPath / "core" / "semanticDbData.dest" / "data"
+          val dataPath = eval.outPath / "core/semanticDbData.dest/data"
           val outputFiles =
             os.walk(result.value.path).filter(os.isFile).map(_.relativeTo(result.value.path))
 
@@ -746,7 +746,7 @@ object HelloWorldTests extends TestSuite {
 
     test("runMain") {
       test("runMainObject") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
-        val runResult = eval.outPath / "core" / "runMain.dest" / "hello-mill"
+        val runResult = eval.outPath / "core/runMain.dest/hello-mill"
 
         val Right(result) = eval.apply(HelloWorld.core.runMain("Main", runResult.toString))
         assert(result.evalCount > 0)
@@ -790,7 +790,7 @@ object HelloWorldTests extends TestSuite {
           eval.apply(HelloWorld.core.runMain("Invalid"))
       }
       test("notRunWhenCompileFailed") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
-        os.write.append(HelloWorld.millSourcePath / "core" / "src" / "Main.scala", "val x: ")
+        os.write.append(HelloWorld.millSourcePath / "core/src/Main.scala", "val x: ")
 
         val Left(Result.Failure("Compilation failed", _)) =
           eval.apply(HelloWorld.core.runMain("Main"))
@@ -800,7 +800,7 @@ object HelloWorldTests extends TestSuite {
 
     test("forkRun") {
       test("runIfMainClassProvided") - UnitTester(HelloWorldWithMain, resourcePath).scoped { eval =>
-        val runResult = eval.outPath / "core" / "run.dest" / "hello-mill"
+        val runResult = eval.outPath / "core/run.dest/hello-mill"
         val Right(result) = eval.apply(
           HelloWorldWithMain.core.run(T.task(Args(runResult.toString)))
         )
@@ -823,7 +823,7 @@ object HelloWorldTests extends TestSuite {
         eval =>
           // Make sure even if there isn't a main class defined explicitly, it gets
           // discovered by Zinc and used
-          val runResult = eval.outPath / "core" / "run.dest" / "hello-mill"
+          val runResult = eval.outPath / "core/run.dest/hello-mill"
           val Right(result) = eval.apply(
             HelloWorldWithoutMain.core.run(T.task(Args(runResult.toString)))
           )
@@ -839,7 +839,7 @@ object HelloWorldTests extends TestSuite {
 
     test("run") {
       test("runIfMainClassProvided") - UnitTester(HelloWorldWithMain, resourcePath).scoped { eval =>
-        val runResult = eval.outPath / "core" / "run.dest" / "hello-mill"
+        val runResult = eval.outPath / "core/run.dest/hello-mill"
         val Right(result) = eval.apply(
           HelloWorldWithMain.core.runLocal(T.task(Args(runResult.toString)))
         )
@@ -852,7 +852,7 @@ object HelloWorldTests extends TestSuite {
         )
       }
       test("runWithDefaultMain") - UnitTester(HelloWorldDefaultMain, resourcePath).scoped { eval =>
-        val runResult = eval.outPath / "core" / "run.dest" / "hello-mill"
+        val runResult = eval.outPath / "core/run.dest/hello-mill"
         val Right(result) = eval.apply(
           HelloWorldDefaultMain.core.runLocal(T.task(Args(runResult.toString)))
         )
@@ -905,7 +905,7 @@ object HelloWorldTests extends TestSuite {
         val outPath = eval.outPath
         eval.apply(HelloWorld.core.compile)
 
-        val logFile = outPath / "core" / "compile.log"
+        val logFile = outPath / "core/compile.log"
         assert(os.exists(logFile))
       }
     }

--- a/scalalib/test/src/mill/scalalib/ScalaDoc3Tests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaDoc3Tests.scala
@@ -37,35 +37,35 @@ object ScalaDoc3Tests extends TestSuite {
   def tests: Tests = Tests {
     test("static") - UnitTester(StaticDocsModule, resourcePath).scoped { eval =>
       val Right(_) = eval.apply(StaticDocsModule.static.docJar)
-      val dest = eval.outPath / "static" / "docJar.dest"
+      val dest = eval.outPath / "static/docJar.dest"
       assert(
         os.exists(dest / "out.jar"), // final jar should exist
         // check if extra markdown files have been included and translated to html
-        os.exists(dest / "javadoc" / "index.html"),
-        os.exists(dest / "javadoc" / "nested" / "extra.html"),
+        os.exists(dest / "javadoc/index.html"),
+        os.exists(dest / "javadoc/nested/extra.html"),
         // also check that API docs have been generated
-        os.exists(dest / "javadoc" / "api" / "pkg" / "SomeClass.html")
+        os.exists(dest / "javadoc/api/pkg/SomeClass.html")
       )
     }
     test("empty") - UnitTester(EmptyDocsModule, resourcePath).scoped { eval =>
       val Right(_) = eval.apply(EmptyDocsModule.empty.docJar)
-      val dest = eval.outPath / "empty" / "docJar.dest"
+      val dest = eval.outPath / "empty/docJar.dest"
       assert(
         os.exists(dest / "out.jar"),
-        os.exists(dest / "javadoc" / "api" / "pkg" / "SomeClass.html")
+        os.exists(dest / "javadoc/api/pkg/SomeClass.html")
       )
     }
     test("multiple") - UnitTester(MultiDocsModule, resourcePath).scoped { eval =>
       val Right(_) = eval.apply(MultiDocsModule.multidocs.docJar)
-      val dest = eval.outPath / "multidocs" / "docJar.dest"
+      val dest = eval.outPath / "multidocs/docJar.dest"
       assert(
         os.exists(dest / "out.jar"), // final jar should exist
-        os.exists(dest / "javadoc" / "api" / "pkg" / "SomeClass.html"),
-        os.exists(dest / "javadoc" / "index.html"),
-        os.exists(dest / "javadoc" / "docs" / "nested" / "original.html"),
-        os.exists(dest / "javadoc" / "docs" / "nested" / "extra.html"),
+        os.exists(dest / "javadoc/api/pkg/SomeClass.html"),
+        os.exists(dest / "javadoc/index.html"),
+        os.exists(dest / "javadoc/docs/nested/original.html"),
+        os.exists(dest / "javadoc/docs/nested/extra.html"),
         // check that later doc sources overwrite earlier ones
-        os.read(dest / "javadoc" / "index.html").contains("overwritten")
+        os.read(dest / "javadoc/index.html").contains("overwritten")
       )
     }
   }

--- a/scalalib/test/src/mill/scalalib/TestRunnerTests.scala
+++ b/scalalib/test/src/mill/scalalib/TestRunnerTests.scala
@@ -182,7 +182,7 @@ object TestRunnerTests extends TestSuite {
       moduleName: String,
       action: String = "test"
   ): JUnitReportMatch = {
-    val reportPath: Path = outPath / moduleName / s"$action.dest/test-report.xml"
+    val reportPath: Path = outPath / moduleName / s"$action.dest" / "test-report.xml"
     val reportXML = XML.loadFile(reportPath.toIO)
     new JUnitReportMatch {
       override def shouldHave(statuses: (Int, Status)*): Unit = {

--- a/scalalib/test/src/mill/scalalib/TestRunnerTests.scala
+++ b/scalalib/test/src/mill/scalalib/TestRunnerTests.scala
@@ -182,7 +182,7 @@ object TestRunnerTests extends TestSuite {
       moduleName: String,
       action: String = "test"
   ): JUnitReportMatch = {
-    val reportPath: Path = outPath / moduleName / s"$action.dest" / "test-report.xml"
+    val reportPath: Path = outPath / moduleName / s"$action.dest/test-report.xml"
     val reportXML = XML.loadFile(reportPath.toIO)
     new JUnitReportMatch {
       override def shouldHave(statuses: (Int, Status)*): Unit = {

--- a/scalalib/test/src/mill/scalalib/giter8/Giter8Tests.scala
+++ b/scalalib/test/src/mill/scalalib/giter8/Giter8Tests.scala
@@ -31,8 +31,8 @@ object Giter8Tests extends TestSuite {
         val files = Seq(
           os.sub / "build.mill",
           os.sub / "README.md",
-          os.sub / "hello" / "src" / "Hello.scala",
-          os.sub / "hello" / "test" / "src" / "MyTest.scala"
+          os.sub / "hello/src/Hello.scala",
+          os.sub / "hello/test/src/MyTest.scala"
         )
 
         assert(

--- a/scalalib/test/src/mill/scalalib/publish/LocalM2PublisherTests.scala
+++ b/scalalib/test/src/mill/scalalib/publish/LocalM2PublisherTests.scala
@@ -12,7 +12,7 @@ object LocalM2PublisherTests extends TestSuite {
     }
 
     def publishAndCheck(repo: os.Path): Unit = {
-      val subrepo = repo / "group" / "org" / "id" / "version"
+      val subrepo = repo / "group/org/id/version"
 
       os.write(repo / "jar", "JAR")
       os.write(repo / "doc", "DOC")
@@ -58,7 +58,7 @@ object LocalM2PublisherTests extends TestSuite {
       val repo = os.temp.dir()
 
       // existing
-      val subrepo = repo / "group" / "org" / "id" / "version"
+      val subrepo = repo / "group/org/id/version"
       os.write(subrepo / "id-version.jar", "OLDJAR", createFolders = true)
       assert(os.read(subrepo / "id-version.jar") == "OLDJAR")
 

--- a/scalanativelib/test/src/mill/scalanativelib/HelloNativeWorldTests.scala
+++ b/scalanativelib/test/src/mill/scalanativelib/HelloNativeWorldTests.scala
@@ -60,7 +60,7 @@ object HelloNativeWorldTests extends TestSuite {
       )
 
       object test extends ScalaNativeTests with TestModule.Utest {
-        override def sources = T.sources { millSourcePath / "src" / "utest" }
+        override def sources = T.sources { millSourcePath / "src/utest" }
         override def ivyDeps = super.ivyDeps() ++ Agg(
           ivy"com.lihaoyi::utest::$utestVersion"
         )

--- a/testkit/src/mill/testkit/TestBaseModule.scala
+++ b/testkit/src/mill/testkit/TestBaseModule.scala
@@ -11,8 +11,8 @@ class TestBaseModule(implicit
     millModuleFile0: sourcecode.File
 ) extends mill.define.BaseModule(
       {
-        os.makeDir.all(os.pwd / "out" / "mill-test-base-module")
-        os.temp.dir(os.pwd / "out" / "mill-test-base-module", deleteOnExit = false)
+        os.makeDir.all(os.pwd / "out/mill-test-base-module")
+        os.temp.dir(os.pwd / "out/mill-test-base-module", deleteOnExit = false)
       }
     )(
       millModuleEnclosing0,


### PR DESCRIPTION
Introduced in https://github.com/com-lihaoyi/os-lib/pull/297, these allow conciseness when working with literal paths/path-segments while limiting it to compile-time literals to avoid potential path traversal issues that may arise from parsing dynamic paths