### PR TITLE
Reproduce problem with trait wrapper and codesig tests

### DIFF
--- a/runner/src/mill/runner/CodeGen.scala
+++ b/runner/src/mill/runner/CodeGen.scala
@@ -155,7 +155,7 @@ object CodeGen {
         var newScriptCode = scriptCode
         newScriptCode = objectData.parent.applyTo(newScriptCode, newParent)
         newScriptCode = objectData.name.applyTo(newScriptCode, wrapperObjectName)
-        newScriptCode = objectData.obj.applyTo(newScriptCode, "abstract class")
+        newScriptCode = objectData.obj.applyTo(newScriptCode, "trait")
 
         s"""$pkgLine
            |$aliasImports
@@ -219,7 +219,7 @@ object CodeGen {
        |  $childAliases
        |  override lazy val millDiscover: _root_.mill.define.Discover = _root_.mill.define.Discover[this.type]
        |}
-       |abstract class $wrapperObjectName $extendsClause {""".stripMargin
+       |trait $wrapperObjectName $extendsClause {""".stripMargin
 
   }
 


### PR DESCRIPTION
https://github.com/com-lihaoyi/mill/pull/3504 uses `abstract class` rather than `trait` because `trait` causes codesig tests to fail. That PR worked around it, but I need to investigate why using a `trait` changes the codesig invalidation behavior, and see if it indicates a real bug in the codesig computation