### PR TITLE
Deprecated `T.command(task)` for removal in Mill 0.13

### DIFF
--- a/contrib/playlib/src/mill/playlib/PlayModule.scala
+++ b/contrib/playlib/src/mill/playlib/PlayModule.scala
@@ -20,7 +20,7 @@ trait PlayApiModule extends Dependencies with Router with Server {
     override def sources = T.sources { millSourcePath }
   }
 
-  def start(args: Task[Args] = T.task(Args())) = T.command { run(args) }
+  def start(args: Task[Args] = T.task(Args())) = T.command { run(args)() }
 
 }
 trait PlayModule extends PlayApiModule with Static with Twirl {

--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
@@ -217,10 +217,10 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
         outer.scalacOptions() ++ extras
       }
 
-    def htmlReport(): Command[Unit] = T.command { doReport(ReportType.Html) }
-    def xmlReport(): Command[Unit] = T.command { doReport(ReportType.Xml) }
-    def xmlCoberturaReport(): Command[Unit] = T.command { doReport(ReportType.XmlCobertura) }
-    def consoleReport(): Command[Unit] = T.command { doReport(ReportType.Console) }
+    def htmlReport(): Command[Unit] = T.command { doReport(ReportType.Html)() }
+    def xmlReport(): Command[Unit] = T.command { doReport(ReportType.Xml)() }
+    def xmlCoberturaReport(): Command[Unit] = T.command { doReport(ReportType.XmlCobertura)() }
+    def consoleReport(): Command[Unit] = T.command { doReport(ReportType.Console)() }
 
     override def skipIdea = true
   }

--- a/main/define/src/mill/define/Task.scala
+++ b/main/define/src/mill/define/Task.scala
@@ -278,6 +278,7 @@ object Target extends Applicative.Applyer[Task, Task, Result, mill.api.Ctx] {
    * take arguments that are automatically converted to command-line
    * arguments, as long as an implicit [[mainargs.TokensReader]] is available.
    */
+  @deprecated("Creating command from tasks is deprecated. You most likely forget a parenthesis pair `()`", "Mill after 0.12.0-RC1")
   def command[T](t: Task[T])(implicit
       ctx: mill.define.Ctx,
       w: W[T],

--- a/main/define/src/mill/define/Task.scala
+++ b/main/define/src/mill/define/Task.scala
@@ -204,6 +204,7 @@ object Target extends Applicative.Applyer[Task, Task, Result, mill.api.Ctx] {
   implicit def apply[T](t: Result[T])(implicit rw: RW[T], ctx: mill.define.Ctx): Target[T] =
     macro Internal.targetResultImpl[T]
 
+  @deprecated("Creating a target from a task is deprecated. You most likely forgot a parenthesis pair `()`", "Mill after 0.12.0-RC1")
   def apply[T](t: Task[T])(implicit rw: RW[T], ctx: mill.define.Ctx): Target[T] =
     macro Internal.targetTaskImpl[T]
 
@@ -278,7 +279,7 @@ object Target extends Applicative.Applyer[Task, Task, Result, mill.api.Ctx] {
    * take arguments that are automatically converted to command-line
    * arguments, as long as an implicit [[mainargs.TokensReader]] is available.
    */
-  @deprecated("Creating command from tasks is deprecated. You most likely forgot a parenthesis pair `()`", "Mill after 0.12.0-RC1")
+  @deprecated("Creating a command from a task is deprecated. You most likely forgot a parenthesis pair `()`", "Mill after 0.12.0-RC1")
   def command[T](t: Task[T])(implicit
       ctx: mill.define.Ctx,
       w: W[T],
@@ -305,6 +306,7 @@ object Target extends Applicative.Applyer[Task, Task, Result, mill.api.Ctx] {
    * responsibility of ensuring the implementation is idempotent regardless of
    * what in-memory state the worker may have.
    */
+  @deprecated("Creating a worker from a task is deprecated. You most likely forgot a parenthesis pair `()`", "Mill after 0.12.0-RC1")
   def worker[T](t: Task[T])(implicit ctx: mill.define.Ctx): Worker[T] =
     macro Internal.workerImpl1[T]
 

--- a/main/define/src/mill/define/Task.scala
+++ b/main/define/src/mill/define/Task.scala
@@ -204,7 +204,10 @@ object Target extends Applicative.Applyer[Task, Task, Result, mill.api.Ctx] {
   implicit def apply[T](t: Result[T])(implicit rw: RW[T], ctx: mill.define.Ctx): Target[T] =
     macro Internal.targetResultImpl[T]
 
-  @deprecated("Creating a target from a task is deprecated. You most likely forgot a parenthesis pair `()`", "Mill after 0.12.0-RC1")
+  @deprecated(
+    "Creating a target from a task is deprecated. You most likely forgot a parenthesis pair `()`",
+    "Mill after 0.12.0-RC1"
+  )
   def apply[T](t: Task[T])(implicit rw: RW[T], ctx: mill.define.Ctx): Target[T] =
     macro Internal.targetTaskImpl[T]
 
@@ -279,7 +282,10 @@ object Target extends Applicative.Applyer[Task, Task, Result, mill.api.Ctx] {
    * take arguments that are automatically converted to command-line
    * arguments, as long as an implicit [[mainargs.TokensReader]] is available.
    */
-  @deprecated("Creating a command from a task is deprecated. You most likely forgot a parenthesis pair `()`", "Mill after 0.12.0-RC1")
+  @deprecated(
+    "Creating a command from a task is deprecated. You most likely forgot a parenthesis pair `()`",
+    "Mill after 0.12.0-RC1"
+  )
   def command[T](t: Task[T])(implicit
       ctx: mill.define.Ctx,
       w: W[T],
@@ -306,7 +312,10 @@ object Target extends Applicative.Applyer[Task, Task, Result, mill.api.Ctx] {
    * responsibility of ensuring the implementation is idempotent regardless of
    * what in-memory state the worker may have.
    */
-  @deprecated("Creating a worker from a task is deprecated. You most likely forgot a parenthesis pair `()`", "Mill after 0.12.0-RC1")
+  @deprecated(
+    "Creating a worker from a task is deprecated. You most likely forgot a parenthesis pair `()`",
+    "Mill after 0.12.0-RC1"
+  )
   def worker[T](t: Task[T])(implicit ctx: mill.define.Ctx): Worker[T] =
     macro Internal.workerImpl1[T]
 

--- a/main/define/src/mill/define/Task.scala
+++ b/main/define/src/mill/define/Task.scala
@@ -278,7 +278,7 @@ object Target extends Applicative.Applyer[Task, Task, Result, mill.api.Ctx] {
    * take arguments that are automatically converted to command-line
    * arguments, as long as an implicit [[mainargs.TokensReader]] is available.
    */
-  @deprecated("Creating command from tasks is deprecated. You most likely forget a parenthesis pair `()`", "Mill after 0.12.0-RC1")
+  @deprecated("Creating command from tasks is deprecated. You most likely forgot a parenthesis pair `()`", "Mill after 0.12.0-RC1")
   def command[T](t: Task[T])(implicit
       ctx: mill.define.Ctx,
       w: W[T],

--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -144,7 +144,8 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
     )
   }
 
-  override def runLocal(args: Task[Args] = T.task(Args())): Command[Unit] = T.command { run(args)() }
+  override def runLocal(args: Task[Args] = T.task(Args())): Command[Unit] =
+    T.command { run(args)() }
 
   override def run(args: Task[Args] = T.task(Args())): Command[Unit] = T.command {
     if (args().value.nonEmpty) {

--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -144,7 +144,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
     )
   }
 
-  override def runLocal(args: Task[Args] = T.task(Args())): Command[Unit] = T.command { run(args) }
+  override def runLocal(args: Task[Args] = T.task(Args())): Command[Unit] = T.command { run(args)() }
 
   override def run(args: Task[Args] = T.task(Args())): Command[Unit] = T.command {
     if (args().value.nonEmpty) {
@@ -374,7 +374,7 @@ trait TestScalaJSModule extends ScalaJSModule with TestModule {
   }
 
   override def testLocal(args: String*): Command[(String, Seq[TestResult])] =
-    T.command { test(args: _*) }
+    T.command { test(args: _*)() }
 
   override protected def testTask(
       args: Task[Seq[String]],

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -872,11 +872,11 @@ trait JavaModule
                 transitiveCompileIvyDeps() ++ runIvyDeps().map(bindDependency())
               },
               validModules
-            )
+            )()
           }
         case (Flag(true), Flag(false)) =>
           T.command {
-            printDepsTree(args.inverse.value, transitiveCompileIvyDeps, validModules)
+            printDepsTree(args.inverse.value, transitiveCompileIvyDeps, validModules)()
           }
         case (Flag(false), Flag(true)) =>
           T.command {
@@ -884,11 +884,11 @@ trait JavaModule
               args.inverse.value,
               T.task { runIvyDeps().map(bindDependency()) },
               validModules
-            )
+            )()
           }
         case _ =>
           T.command {
-            printDepsTree(args.inverse.value, T.task { Agg.empty[BoundDep] }, validModules)
+            printDepsTree(args.inverse.value, T.task { Agg.empty[BoundDep] }, validModules)()
           }
       }
     } else {
@@ -958,7 +958,7 @@ trait JavaModule
    */
   def runBackground(args: String*): Command[Unit] = {
     val task = runBackgroundTask(finalMainClass, T.task { Args(args) })
-    T.command { task }
+    T.command { task() }
   }
 
   /**

--- a/scalalib/src/mill/scalalib/RunModule.scala
+++ b/scalalib/src/mill/scalalib/RunModule.scala
@@ -79,7 +79,7 @@ trait RunModule extends WithZincWorker {
    * Runs this module's code in a subprocess and waits for it to finish
    */
   def run(args: Task[Args] = T.task(Args())): Command[Unit] = T.command {
-    runForkedTask(finalMainClass, args)
+    runForkedTask(finalMainClass, args)()
   }
 
   /**
@@ -89,7 +89,7 @@ trait RunModule extends WithZincWorker {
    * in a bad state.
    */
   def runLocal(args: Task[Args] = T.task(Args())): Command[Unit] = T.command {
-    runLocalTask(finalMainClass, args)
+    runLocalTask(finalMainClass, args)()
   }
 
   /**
@@ -97,7 +97,7 @@ trait RunModule extends WithZincWorker {
    */
   def runMain(@arg(positional = true) mainClass: String, args: String*): Command[Unit] = {
     val task = runForkedTask(T.task { mainClass }, T.task { Args(args) })
-    T.command { task }
+    T.command { task() }
   }
 
   /**
@@ -105,7 +105,7 @@ trait RunModule extends WithZincWorker {
    */
   def runMainBackground(@arg(positional = true) mainClass: String, args: String*): Command[Unit] = {
     val task = runBackgroundTask(T.task { mainClass }, T.task { Args(args) })
-    T.command { task }
+    T.command { task() }
   }
 
   /**
@@ -113,7 +113,7 @@ trait RunModule extends WithZincWorker {
    */
   def runMainLocal(@arg(positional = true) mainClass: String, args: String*): Command[Unit] = {
     val task = runLocalTask(T.task { mainClass }, T.task { Args(args) })
-    T.command { task }
+    T.command { task() }
   }
 
   /**

--- a/scalalib/test/src/mill/scalalib/PublishModuleTests.scala
+++ b/scalalib/test/src/mill/scalalib/PublishModuleTests.scala
@@ -47,7 +47,7 @@ object PublishModuleTests extends TestSuite {
       override def versionScheme = Some(VersionScheme.EarlySemVer)
 
       def checkSonatypeCreds(sonatypeCreds: String) = T.command {
-        PublishModule.checkSonatypeCreds(sonatypeCreds)
+        PublishModule.checkSonatypeCreds(sonatypeCreds)()
       }
     }
   }

--- a/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
+++ b/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
@@ -345,7 +345,7 @@ trait ScalaNativeModule extends ScalaModule { outer =>
 
 trait TestScalaNativeModule extends ScalaNativeModule with TestModule {
   override def resources: T[Seq[PathRef]] = super[ScalaNativeModule].resources
-  override def testLocal(args: String*) = T.command { test(args: _*) }
+  override def testLocal(args: String*) = T.command { test(args: _*)() }
   override protected def testTask(
       args: Task[Seq[String]],
       globSeletors: Task[Seq[String]]


### PR DESCRIPTION
`T.command` currently has two overloads, one accepting a `Result` (like most of the other task factories, `T`, `T.input`, `T.task` and so on) and one accepting a `Task`. Because of the second version, command definitions like the following don't do what the user thinks they do, although they seem to work.

```scala
override def publishLocal(localIvyRepo: String): Command[Unit] = T.command {
  super.publishLocal(localIvyRepo)
}
```

Instead of creating a new command that depends on another command (the `super`-version) and returns just the result, it returns the `super`-command as-is.

The correct version is:

```scala
override def publishLocal(localIvyRepo: String): Command[Unit] = T.command {
  super.publishLocal(localIvyRepo)()
}
```

```diff
 override def publishLocal(localIvyRepo: String): Command[Unit] = T.command {
-  super.publishLocal(localIvyRepo)
+  super.publishLocal(localIvyRepo)()
 }
```

This change deprecates all overloads accepting a `Task` in favor of accepting a `Result`. `Result`s can be easily acquired from a `Task` by calling `apply()` or short `()`. 

This is also the more correct way of re-using or re-defining tasks, since directly re-used tasks may result in an incorrect tasks context, esp. an incorrect source location, which is relevant when debugging misbehaving builds.

See https://github.com/com-lihaoyi/mill/issues/3517
