### PR TITLE
Allow users to use a custom output dir via an env var

### DIFF
--- a/docs/modules/ROOT/pages/Out_Dir.adoc
+++ b/docs/modules/ROOT/pages/Out_Dir.adoc
@@ -111,3 +111,7 @@ This is very useful if Mill is being unexpectedly slow, and you want to find out
 
 `mill-server/*`::
  Each Mill server instance needs to keep some temporary files in one of these directories. Deleting it will also terminate the associated server instance, if it is still running.
+
+== Using another location than the `out/` directory
+
+include::example/depth/out-dir/1-custom-out.adoc[]

--- a/example/depth/out-dir/1-custom-out/build.mill
+++ b/example/depth/out-dir/1-custom-out/build.mill
@@ -1,0 +1,28 @@
+// The default location for Mill's output directory is `out/` under the project workspace.
+// A task `printDest` of a module `foo` will have a default scratch space folder
+// `out/foo/printDest.dest/`:
+package build
+
+import mill._
+
+object foo extends Module {
+  def printDest = Task {
+    println(T.dest)
+  }
+}
+
+/** Usage
+> ./mill foo.printDest
+...
+.../out/foo/printDest.dest
+*/
+
+// If you'd rather use another location than `out/`, that lives
+// in a faster or a writable filesystem for example, you can change the output directory
+// via the `MILL_OUTPUT_DIR` environment variable.
+
+/** Usage
+> MILL_OUTPUT_DIR=build-stuff/working-dir ./mill foo.printDest
+...
+.../build-stuff/working-dir/foo/printDest.dest
+*/

--- a/example/package.mill
+++ b/example/package.mill
@@ -59,6 +59,7 @@ object `package` extends RootModule with Module {
     object modules extends Cross[ExampleCrossModule](build.listIn(millSourcePath / "modules"))
     object cross extends Cross[ExampleCrossModule](build.listIn(millSourcePath / "cross"))
     object large extends Cross[ExampleCrossModule](build.listIn(millSourcePath / "large"))
+    object `out-dir` extends Cross[ExampleCrossModule](build.listIn(millSourcePath / "out-dir"))
     object sandbox extends Cross[ExampleCrossModule](build.listIn(millSourcePath / "sandbox"))
     object libraries extends Cross[ExampleCrossModule](build.listIn(millSourcePath / "libraries"))
   }

--- a/integration/feature/output-directory/resources/build.mill
+++ b/integration/feature/output-directory/resources/build.mill
@@ -1,0 +1,8 @@
+package build
+
+import mill._
+import mill.scalalib._
+
+object `package` extends RootModule with ScalaModule {
+  def scalaVersion = scala.util.Properties.versionNumberString
+}

--- a/integration/feature/output-directory/src/OutputDirectoryTests.scala
+++ b/integration/feature/output-directory/src/OutputDirectoryTests.scala
@@ -1,0 +1,41 @@
+package mill.integration
+
+import mill.main.client.{EnvVars, OutFiles}
+import mill.testkit.UtestIntegrationTestSuite
+import utest._
+
+object OutputDirectoryTests extends UtestIntegrationTestSuite {
+
+  def tests: Tests = Tests {
+    test("Output directory sanity check") - integrationTest { tester =>
+      import tester._
+      eval("__.compile").isSuccess ==> true
+      val defaultOutDir = workspacePath / OutFiles.defaultOut
+      assert(os.isDir(defaultOutDir))
+    }
+
+    test("Output directory elsewhere in workspace") - integrationTest { tester =>
+      import tester._
+      eval(
+        "__.compile",
+        env = millTestSuiteEnv + (EnvVars.MILL_OUTPUT_DIR -> "testing/test-out")
+      ).isSuccess ==> true
+      val expectedOutDir = workspacePath / "testing/test-out"
+      val defaultOutDir = workspacePath / OutFiles.defaultOut
+      assert(os.isDir(expectedOutDir))
+      assert(!os.exists(defaultOutDir))
+    }
+
+    test("Output directory outside workspace") - integrationTest { tester =>
+      import tester._
+      val outDir = os.temp.dir() / "tmp-out"
+      eval(
+        "__.compile",
+        env = millTestSuiteEnv + (EnvVars.MILL_OUTPUT_DIR -> outDir.toString)
+      ).isSuccess ==> true
+      val defaultOutDir = workspacePath / OutFiles.defaultOut
+      assert(os.isDir(outDir))
+      assert(!os.exists(defaultOutDir))
+    }
+  }
+}

--- a/main/client/src/mill/main/client/EnvVars.java
+++ b/main/client/src/mill/main/client/EnvVars.java
@@ -22,6 +22,13 @@ public class EnvVars {
 
     public static final String MILL_JVM_OPTS_PATH = "MILL_JVM_OPTS_PATH";
 
+
+    /**
+     * Output directory where Mill workers' state and Mill tasks output should be
+     * written to
+     */
+    public static final String MILL_OUTPUT_DIR = "MILL_OUTPUT_DIR";
+
     // INTERNAL ENVIRONMENT VARIABLES
     /**
      * Used to pass the Mill workspace root from the client to the server, so

--- a/main/client/src/mill/main/client/OutFiles.java
+++ b/main/client/src/mill/main/client/OutFiles.java
@@ -5,10 +5,19 @@ package mill.main.client;
  * and documentation about what they do
  */
 public class OutFiles {
+
+    final private static String envOutOrNull = System.getenv(EnvVars.MILL_OUTPUT_DIR);
+
+    /**
+     * Default hard-coded value for the Mill `out/` folder path. Unless you know
+     * what you are doing, you should favor using [[out]] instead.
+     */
+    final public static String defaultOut = "out";
+
     /**
      * Path of the Mill `out/` folder
      */
-    final public static String out = "out";
+    final public static String out = envOutOrNull == null ? defaultOut : envOutOrNull;
 
     /**
      * Path of the Mill "meta-build", used to compile the `build.sc` file so we can

--- a/runner/src/mill/runner/CodeGen.scala
+++ b/runner/src/mill/runner/CodeGen.scala
@@ -15,7 +15,8 @@ object CodeGen {
       allScriptCode: Map[os.Path, String],
       targetDest: os.Path,
       enclosingClasspath: Seq[os.Path],
-      millTopLevelProjectRoot: os.Path
+      millTopLevelProjectRoot: os.Path,
+      output: os.Path
   ): Unit = {
     for (scriptSource <- scriptSources) {
       val scriptPath = scriptSource.path
@@ -94,6 +95,7 @@ object CodeGen {
             projectRoot,
             enclosingClasspath,
             millTopLevelProjectRoot,
+            output,
             scriptPath,
             scriptFolderPath,
             childAliases,
@@ -112,6 +114,7 @@ object CodeGen {
       projectRoot: os.Path,
       enclosingClasspath: Seq[os.Path],
       millTopLevelProjectRoot: os.Path,
+      output: os.Path,
       scriptPath: os.Path,
       scriptFolderPath: os.Path,
       childAliases: String,
@@ -126,7 +129,8 @@ object CodeGen {
       segments,
       scriptFolderPath,
       enclosingClasspath,
-      millTopLevelProjectRoot
+      millTopLevelProjectRoot,
+      output
     )
 
     val instrument = new ObjectDataInstrument(scriptCode)
@@ -183,13 +187,15 @@ object CodeGen {
       segments: Seq[String],
       scriptFolderPath: os.Path,
       enclosingClasspath: Seq[os.Path],
-      millTopLevelProjectRoot: os.Path
+      millTopLevelProjectRoot: os.Path,
+      output: os.Path
   ): String = {
     s"""import _root_.mill.runner.MillBuildRootModule
        |@_root_.scala.annotation.nowarn
        |object MillMiscInfo extends MillBuildRootModule.MillMiscInfo(
        |  ${enclosingClasspath.map(p => literalize(p.toString))},
        |  ${literalize(scriptFolderPath.toString)},
+       |  ${literalize(output.toString)},
        |  ${literalize(millTopLevelProjectRoot.toString)},
        |  _root_.scala.Seq(${segments.map(pprint.Util.literalize(_)).mkString(", ")})
        |)

--- a/runner/src/mill/runner/FileImportGraph.scala
+++ b/runner/src/mill/runner/FileImportGraph.scala
@@ -43,7 +43,11 @@ object FileImportGraph {
    * starting from `build.mill`, collecting the information necessary to
    * instantiate the [[MillRootModule]]
    */
-  def parseBuildFiles(topLevelProjectRoot: os.Path, projectRoot: os.Path): FileImportGraph = {
+  def parseBuildFiles(
+      topLevelProjectRoot: os.Path,
+      projectRoot: os.Path,
+      output: os.Path
+  ): FileImportGraph = {
     val seenScripts = mutable.Map.empty[os.Path, String]
     val seenIvy = mutable.Set.empty[String]
     val seenRepo = mutable.ListBuffer.empty[(String, os.Path)]
@@ -193,7 +197,7 @@ object FileImportGraph {
             projectRoot,
             followLinks = true,
             skip = p =>
-              p == projectRoot / out ||
+              p == output ||
                 p == projectRoot / millBuild ||
                 (os.isDir(p) && !os.exists(p / nestedBuildFileName))
           )

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -121,7 +121,8 @@ abstract class MillBuildRootModule()(implicit
         parsed.seenScripts,
         T.dest,
         millBuildRootModuleInfo.enclosingClasspath,
-        millBuildRootModuleInfo.topLevelProjectRoot
+        millBuildRootModuleInfo.topLevelProjectRoot,
+        millBuildRootModuleInfo.output
       )
       Result.Success(Seq(PathRef(T.dest)))
     }
@@ -265,12 +266,14 @@ object MillBuildRootModule {
   class BootstrapModule(
       topLevelProjectRoot0: os.Path,
       projectRoot: os.Path,
+      output: os.Path,
       enclosingClasspath: Seq[os.Path]
   )(implicit baseModuleInfo: RootModule.Info) extends MillBuildRootModule()(
         implicitly,
         MillBuildRootModule.Info(
           enclosingClasspath,
           projectRoot,
+          output,
           topLevelProjectRoot0
         )
       ) {
@@ -281,25 +284,29 @@ object MillBuildRootModule {
   case class Info(
       enclosingClasspath: Seq[os.Path],
       projectRoot: os.Path,
+      output: os.Path,
       topLevelProjectRoot: os.Path
   )
 
   def parseBuildFiles(millBuildRootModuleInfo: MillBuildRootModule.Info): FileImportGraph = {
     FileImportGraph.parseBuildFiles(
       millBuildRootModuleInfo.topLevelProjectRoot,
-      millBuildRootModuleInfo.projectRoot / os.up
+      millBuildRootModuleInfo.projectRoot / os.up,
+      millBuildRootModuleInfo.output
     )
   }
 
   class MillMiscInfo(
       enclosingClasspath: Seq[String],
       projectRoot: String,
+      output: String,
       topLevelProjectRoot: String,
       segments: Seq[String]
   ) {
     implicit lazy val millBuildRootModuleInfo: MillBuildRootModule.Info = MillBuildRootModule.Info(
       enclosingClasspath.map(os.Path(_)),
       os.Path(projectRoot),
+      os.Path(output),
       os.Path(topLevelProjectRoot)
     )
     implicit lazy val millBaseModuleInfo: RootModule.Info = RootModule.Info(

--- a/runner/src/mill/runner/MillMain.scala
+++ b/runner/src/mill/runner/MillMain.scala
@@ -8,7 +8,7 @@ import mill.java9rtexport.Export
 import mill.api.{MillException, SystemStreams, WorkspaceRoot, internal}
 import mill.bsp.{BspContext, BspServerResult}
 import mill.main.BuildInfo
-import mill.main.client.ServerFiles
+import mill.main.client.{OutFiles, ServerFiles}
 import mill.util.{PromptLogger, PrintLogger}
 
 import java.lang.reflect.InvocationTargetException
@@ -234,6 +234,7 @@ object MillMain {
 
                         new MillBuildBootstrap(
                           projectRoot = WorkspaceRoot.workspaceRoot,
+                          output = os.Path(OutFiles.out, WorkspaceRoot.workspaceRoot),
                           home = config.home,
                           keepGoing = config.keepGoing.value,
                           imports = config.imports,

--- a/testkit/src/mill/testkit/IntegrationTester.scala
+++ b/testkit/src/mill/testkit/IntegrationTester.scala
@@ -91,7 +91,7 @@ object IntegrationTester {
       )
     }
 
-    private val millTestSuiteEnv = Map("MILL_TEST_SUITE" -> this.getClass().toString())
+    def millTestSuiteEnv: Map[String, String] = Map("MILL_TEST_SUITE" -> this.getClass().toString())
 
     /**
      * Helpers to read the `.json` metadata files belonging to a particular task


### PR DESCRIPTION
This allows users to change the Mill output directory (by default, `out` under the project root) to a directory of their choice, via the `MILL_OUTPUT_DIR` environment variable.

Fixes https://github.com/com-lihaoyi/mill/issues/3144