### PR TITLE
Fix discord link to be inviting 

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-Please don't open issues for questions, but ask in our Discussions forum at https://github.com/com-lihaoyi/mill/discussions or Discord channel at https://discord.com/channels/632150470000902164/940067748103487558
+Please don't open issues for questions, but ask in our Discussions forum at https://github.com/com-lihaoyi/mill/discussions or Discord channel at https://discord.gg/mMVxRMZc
 
 Mill installations via `coursier` or `cs` are unsupported.
 

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -1,6 +1,6 @@
 = Contributing to Mill
 :link-github: https://github.com/com-lihaoyi/mill
-:link-chat: https://discord.com/channels/632150470000902164/940067748103487558
+:link-chat: https://discord.gg/mMVxRMZc
 
 Thank you for considering contributing to Mill.
 

--- a/docs/supplemental-ui/partials/header-content.hbs
+++ b/docs/supplemental-ui/partials/header-content.hbs
@@ -20,7 +20,7 @@
         <a class="navbar-item" href="{{{or site.url (or siteRootUrl siteRootPath)}}}/api/latest/index.html">API</a>
         <a class="navbar-item" href="https://github.com/com-lihaoyi/mill/issues">Issues</a>
         <a class="navbar-item" href="https://github.com/com-lihaoyi/mill/discussions">Discuss</a>
-        <a class="navbar-item" href="https://discord.com/channels/632150470000902164/940067748103487558">Chat</a>
+        <a class="navbar-item" href="https://discord.gg/mMVxRMZc">Chat</a>
 
             <!--
         <a class="navbar-item" href="#">Home</a>

--- a/example/scalalib/basic/4-builtin-commands/build.mill
+++ b/example/scalalib/basic/4-builtin-commands/build.mill
@@ -357,6 +357,6 @@ foo.compileClasspath
 //
 // ---
 //
-// Come by our https://discord.com/channels/632150470000902164/940067748103487558[Discord Channel]
+// Come by our https://discord.gg/mMVxRMZc[Discord Channel]
 // if you want to ask questions or say hi!
 //


### PR DESCRIPTION
This replaces a direct link to the discord channel with an invite to that channel. The invite does not time out. It has the advantage to easily let new users to register to discord.

Fix https://github.com/com-lihaoyi/mill/issues/3541