### PR TITLE
Move CI jobs for draft PRs to contributor's personal forks of Mill

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,3 +2,6 @@ Please don't open issues for questions, but ask in our Discussions forum at http
 
 Mill installations via `coursier` or `cs` are unsupported.
 
+Please open all PRs as drafts to avoid being bottlenecked by Mill CI, and only
+convert to ready for review once CI on your own fork is green. There will be a 
+PR status check linking your fork's commit/CI history for convenient viewing 

--- a/.github/workflows/draft-ci.yml
+++ b/.github/workflows/draft-ci.yml
@@ -1,0 +1,34 @@
+name: Draft CI
+
+permissions: write-all
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - name: Debug Echos
+        run: |
+          echo ${{ github.event.action }}
+          echo ${{ github.event.action == 'ready_for_review' }}
+          echo "${{ github.event.pull_request.head.repo.html_url }}/commits/${{github.event.pull_request.head.ref}}"
+      - name: Create status
+        run: |
+          curl --request POST \
+          --url ${{ github.event.pull_request.statuses_url }} \
+          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+          --header 'content-type: application/json' \
+          --data '{
+            "state": "${{(github.event.action != 'ready_for_review' && github.event.pull_request.draft) && 'pending' || 'success'}}",
+            "context": "Draft CI / link",
+            "target_url": ${{(github.event.action != 'ready_for_review' && github.event.pull_request.draft) && format('"{0}/commits/{1}"', github.event.pull_request.head.repo.html_url, github.event.pull_request.head.ref) || 'null'}},
+            "description": "${{(github.event.action != 'ready_for_review' && github.event.pull_request.draft) && 'use CI on your repo fork (link on right) until this PR is ready for review' || 'PR is ready for review, running CI in Mill repo'}}"
+            }' \
+          --fail-with-body

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -14,12 +14,6 @@ on:
       - '**'
   workflow_dispatch:
 
-# cancel older runs of a pull request;
-# this will not cancel anything for normal git pushes
-concurrency:
-  group: cancel-old-pr-runs-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   build-artifacts:
     # when in master repo, publish all tags and manual runs on main

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,28 +32,36 @@ name: Run Tests
 on:
   push:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
   workflow_dispatch:
 
 # cancel older runs of a pull request;
 # this will not cancel anything for normal git pushes
 concurrency:
-  group: cancel-old-pr-runs-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: cancel-old-pr-runs-${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:
   # Jobs are listed in rough order of priority: if multiple jobs fail, the first job
   # in the list should be the one that's most worth looking into
   build-linux:
+    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
     uses: ./.github/workflows/pre-build.yml
     with:
       os: ubuntu-latest
 
   build-windows:
+    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
     uses: ./.github/workflows/pre-build.yml
     with:
       os: windows-latest
 
   test-docs:
+    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -70,6 +70,7 @@ jobs:
       - run: ./mill -i docs.githubPages + docs.checkBrokenLinks
 
   mac:
+    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This PR aims to reduce the bottleneck of contributors waiting for CI jobs on the shared Mill repo by moving CI for draft/WIP pull requests to each contributor's own fork, each of which has a separate concurrency budget (~20 concurrent workers) from the `com-lihaoyi` organization. 

Once a PR is marked ready-for-review, `com-lihaoyi` CI begins, so the author effectively has a choice of where they want to run their CI workloads. Mill's main PR validation CI jobs are portable, do not need any special secrets or environment, and can run just fine in contributor's GH Actions environments

To do this:

* Made the upstream `build-linux`/`build-windows`/`test-docs` CI jobs filter on `github.event.pull_request.draft == false`, and 

* Removed the `branches: - main` filter on the `run-tests` jobs so they begin running in contributor GH Actions when commits are pushed to a branch

* Add a new `Draft CI` workflow that pushes a github status linking to the PR's branch in the contributor's fork, as an easy way to see the CI history for the PR there. This needs to run on `pull_request_target` rather than just `pull_request` to have the suitable permissions to update statuses

* Some subtleties around handling `ready_for_review` events such that when a contributor marks a PR as ready for review, CI is re-triggered and handled appropriately without needing to subsequently push a new commit.

* Substituted `github.head_ref` with `github.ref_name` in the `concurrency.group` key since the former only works on PR events while the latter also works on push events

This is a bit of an unusual setup AFAIK for Github Actions, but I've tested it manually a bunch and it seems to work, and should mitigate the bottleneck of multiple people updating their WIP PRs and having everyone blocked waiting on everyone else. Worst come to worst, if you mark a PR as `ready_for_review` it falls back to the old behavior, but this setup gives you an option to run draft PR validation on your own fork's GH Actions where it won't get blocked by other people's PRs. This is something you can actually already do today, but it requires some tedious fiddling that PR makes seamless

Tested on https://github.com/com-lihaoyi/mill/pull/3540 via `git commit -am . --allow-empty && git commit -am . --allow-empty && git push origin head && git push upstream head~1:test-non-draft && git commit -am . --allow-empty && git push origin head`, and targeting this PR against the `test-non-draft` branch in the Mill repo