### PR TITLE
Allow fractional inputs to thread count flag

### DIFF
--- a/runner/src/mill/runner/MillCliConfig.scala
+++ b/runner/src/mill/runner/MillCliConfig.scala
@@ -65,7 +65,7 @@ class MillCliConfig private (
         """Allow processing N targets in parallel.
            Use 1 to disable parallel and 0 to use as much threads as available processors."""
     )
-    val threadCountRaw: Option[Int],
+    val threadCountRaw: Option[String],
     @arg(
       name = "import",
       doc = """Additional ivy dependencies to load into mill, e.g. plugins."""
@@ -175,7 +175,7 @@ object MillCliConfig {
       debugLog: Flag = Flag(),
       keepGoing: Flag = Flag(),
       extraSystemProperties: Map[String, String] = Map(),
-      threadCountRaw: Option[Int] = None,
+      threadCountRaw: Option[String] = None,
       imports: Seq[String] = Seq(),
       interactive: Flag = Flag(),
       help: Flag = Flag(),
@@ -224,7 +224,7 @@ object MillCliConfig {
       debugLog: Flag,
       keepGoing: Flag,
       extraSystemProperties: Map[String, String],
-      threadCountRaw: Option[Int],
+      threadCountRaw: Option[String],
       imports: Seq[String],
       interactive: Flag,
       help: Flag,
@@ -273,7 +273,7 @@ object MillCliConfig {
       debugLog: Flag,
       keepGoing: Flag,
       extraSystemProperties: Map[String, String],
-      threadCountRaw: Option[Int],
+      threadCountRaw: Option[String],
       imports: Seq[String],
       interactive: Flag,
       help: Flag,

--- a/runner/src/mill/runner/MillCliConfig.scala
+++ b/runner/src/mill/runner/MillCliConfig.scala
@@ -63,7 +63,8 @@ class MillCliConfig private (
       short = 'j',
       doc =
         """Allow processing N targets in parallel.
-           Use 1 to disable parallel and 0 to use as much threads as available processors."""
+           Use 1 to disable parallel and 0 to use as much threads as available processors.
+           For fractional inputs (e.g. 50% of available processors), use a decimal number followed by C (e.g. 0.5C)."""
     )
     val threadCountRaw: Option[String],
     @arg(

--- a/runner/src/mill/runner/MillMain.scala
+++ b/runner/src/mill/runner/MillMain.scala
@@ -187,27 +187,27 @@ object MillMain {
 
                 val threadCount: Option[Int] = config.threadCountRaw match {
                   case None => None
-                  case Some(threadCountStr) => {
-                    Try(threadCountStr.toInt).toOption match {
-                      case Some(0) => None
-                      case Some(n) => Some(n)
-                      case _ =>
-                        logger.errorStream.println(s"Thread count may be a fraction of cores: $threadCountStr")
-                        Try(threadCountStr.toFloat).toOption match {
-                          case Some(n) => {
-                            val cores = Runtime.getRuntime.availableProcessors()
-                            val threads = Math.round(n * cores)
-                            logger.errorStream.println(s"Fractional thread count is $threads ($n * $cores)")
-                            if (threads > 0) Some(threads.toInt)
-                            else {
-                              None
-                            }
-                          }
-                          case _ =>
-                            logger.errorStream.println(s"Thread count must be either an integer number of cores OR a fraction of cores: $threadCountStr")
-                            None
-                        }
+                  case Some(s"${threadFraction}C") => Try(threadFraction.toFloat).toOption match {
+                    case Some(n) => {
+                      val cores = Runtime.getRuntime.availableProcessors()
+                      val threads = Math.round(n * cores)
+                      logger.errorStream.println(s"Fractional thread count is $threads ($n * $cores)")
+                      if (threads > 0) Some(threads.toInt)
+                      else {
+                        None
+                      }
                     }
+                    case _ =>
+                      logger.errorStream.println(s"Thread count must be either an integer number of cores OR a fraction of cores")
+                      None
+                  }
+
+                  case Some(threadCount) => Try(threadCount.toInt).toOption match {
+                    case Some(0) => None
+                    case Some(n) => Some(n)
+                    case _ =>
+                      logger.errorStream.println(s"Thread count must be either an integer number of cores OR a fraction of cores")
+                      None
                   }
                 }
 


### PR DESCRIPTION
Adds support for fractional thread counts when using thread count flag `-j`

E.g.:
```
-j 1 => 1 thread
-j 3 => 3 threads
-j 0.75C => 3 threads on a 4-core machine
-j 1C => 4 threads on a 4-core machine
```

Closes #3482 