### PR TITLE
Fix some doc typos + slight doc proposal on java integration test section

### DIFF
--- a/docs/modules/ROOT/pages/Case_Study_Mill_vs_Gradle.adoc
+++ b/docs/modules/ROOT/pages/Case_Study_Mill_vs_Gradle.adoc
@@ -38,7 +38,7 @@ For comparison purposes, I disabled the Gradle subprojects that we did not fully
 
 For the benchmarks below, each provided number is the median wall time of three consecutive runs
 on my M1 Macbook Pro. While ad-hoc, these benchmarks are enough to give you a flavor of how
-Mill's performance compares to Maven:
+Mill's performance compares to Gradle:
 
 [cols="1,1,1,1"]
 |===
@@ -52,7 +52,7 @@ Mill's performance compares to Maven:
 |===
 
 The column on the right shows the speedups of how much faster Mill is compared to the
-equivalent Maven workflow. In most cases,  Mill is 5-10x faster than Gradle. Below, we
+equivalent Gradle workflow. In most cases,  Mill is 5-10x faster than Gradle. Below, we
 will go into more detail of each benchmark: how they were run, what they mean, and how
 we can explain the difference in performing the same task with the two different build tools.
 

--- a/example/javalib/testing/3-integration-suite/build.mill
+++ b/example/javalib/testing/3-integration-suite/build.mill
@@ -6,5 +6,4 @@ object qux extends JavaModule {
   object integration extends JavaTests with TestModule.Junit5
 }
 
-// This example also demonstrates using Junit 5 instead of Junit 4,
-// with
+// This example also demonstrates using Junit 5 instead of Junit 4

--- a/example/javalib/testing/3-integration-suite/build.mill
+++ b/example/javalib/testing/3-integration-suite/build.mill
@@ -6,4 +6,5 @@ object qux extends JavaModule {
   object integration extends JavaTests with TestModule.Junit5
 }
 
-// This example also demonstrates using Junit 5 instead of Junit 4
+// The integration suite is just another regular test module within the parent JavaModule
+// (This example also demonstrates using Junit 5 instead of Junit 4)

--- a/example/javalib/web/4-hello-micronaut/build.mill
+++ b/example/javalib/web/4-hello-micronaut/build.mill
@@ -57,7 +57,8 @@ trait MicronautModule extends MavenModule{
 // Although Mill does not have a built in `MicronautModule`, this example shows how easy
 // it is to define it yourself as `trait MicronautModule`: setting up the annotation processor
 // classpath as a `JavaModule` and setting up the annotation via `javacOptions`. Once defined,
-// you can then use `MicronautModule` in your build just like you.
+// you can then use `MicronautModule` in your build just like you can use any builtin
+// `trait` like `JavaModule`.
 //
 // The `MicronautModule` shown here does not implement the full functionality of the micronaut
 // CLI; in particular, support for Micronaut AOT compilation is missing. But it easily can be

--- a/example/javalib/web/4-hello-micronaut/build.mill
+++ b/example/javalib/web/4-hello-micronaut/build.mill
@@ -57,7 +57,7 @@ trait MicronautModule extends MavenModule{
 // Although Mill does not have a built in `MicronautModule`, this example shows how easy
 // it is to define it yourself as `trait MicronautModule`: setting up the annotation processor
 // classpath as a `JavaModule` and setting up the annotation via `javacOptions`. Once defined,
-// you can then use `MicronautModule in your build just like you.
+// you can then use `MicronautModule` in your build just like you.
 //
 // The `MicronautModule` shown here does not implement the full functionality of the micronaut
 // CLI; in particular, support for Micronaut AOT compilation is missing. But it easily can be


### PR DESCRIPTION
Fixed some doc typos in the Java section,
- Maven/Gradle confusion
- Missing closing markdiwn quote
- Dangling sentence

I also rephrased a section on java integration test, emphasizing more on the mill way to do it rather than the usage of Junit5/4, i can drop the commit if it is not suited
