### PR TITLE
Fix ScalaTest testOnly include option

### DIFF
--- a/scalalib/test/resources/testrunner/scalatest/src/ScalaTestSpec.scala
+++ b/scalalib/test/resources/testrunner/scalatest/src/ScalaTestSpec.scala
@@ -1,6 +1,9 @@
 package mill.scalalib
 
+import org.scalatest.Tag
 import org.scalatest.freespec.AnyFreeSpec
+
+object TaggedTest extends Tag("tagged")
 
 class ScalaTestSpec extends AnyFreeSpec {
 
@@ -14,6 +17,10 @@ class ScalaTestSpec extends AnyFreeSpec {
         assertThrows[NoSuchElementException] {
           Set.empty.head
         }
+      }
+
+      "should be tagged" taggedAs(TaggedTest) in {
+        assert(true)
       }
     }
   }

--- a/testrunner/src/mill/testrunner/TestRunnerUtils.scala
+++ b/testrunner/src/mill/testrunner/TestRunnerUtils.scala
@@ -126,7 +126,7 @@ import scala.jdk.CollectionConverters.IteratorHasAsScala
           yield new TaskDef(
             cls.getName.stripSuffix("$"),
             fingerprint,
-            true,
+            false,
             Array(new SuiteSelector)
           )
       )


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/3440

The problem is mill defines all the test tasks with `explicitlySpecified` to be `true`. This makes all the tests always be included. [Related code](https://github.com/scalatest/scalatest/blob/main/jvm/core/src/main/scala/org/scalatest/tools/Framework.scala#L267) in Scalatest.