### PR TITLE
Provided dummy `def millDiscover` and implicit `RootModule.Info` to make IDEs not display errors

### DIFF
--- a/main/src/mill/main/RootModule.scala
+++ b/main/src/mill/main/RootModule.scala
@@ -2,7 +2,7 @@ package mill.main
 
 import mill.api.internal
 import mill.define.{BaseModule, Ctx, Caller, Discover, Module, Segments}
-
+import scala.annotation.compileTimeOnly
 /**
  * Used to mark a module in your `build.mill` as a top-level module, so it's
  * targets and commands can be run directly e.g. via `mill run` rather than
@@ -27,6 +27,11 @@ abstract class RootModule()(implicit
 @internal
 object RootModule {
   case class Info(millSourcePath0: os.Path, discover: Discover)
+  object Info{
+    @compileTimeOnly("RootModule can only be instantiated in a build.mill or package.mill file")
+    implicit def dummyInfo: Info = ???
+  }
+
   case class SubFolderInfo(value: Seq[String])
 
   abstract class Subfolder()(implicit

--- a/main/src/mill/main/RootModule.scala
+++ b/main/src/mill/main/RootModule.scala
@@ -23,6 +23,10 @@ abstract class RootModule()(implicit
       millFile0,
       Caller(null)
     ) with mill.main.MainModule{
+
+  // Dummy `millDiscover` defined but never actually used and overriden by codegen.
+  // Provided for IDEs to think that one is available and not show errors in
+  // build.mill/package.mill even though they can't see the codegen
   def millDiscover: Discover = sys.error("RootModule#millDiscover must be overriden")
 }
 
@@ -30,8 +34,11 @@ abstract class RootModule()(implicit
 object RootModule {
   case class Info(millSourcePath0: os.Path, discover: Discover)
   object Info{
+    // Dummy `RootModule.Info` available in implicit scope but never actually used.
+    // as it is provided by the codegen. Defined for IDEs to think that one is available
+    // and not show errors in build.mill/package.mill even though they can't see the codegen
     @compileTimeOnly("RootModule can only be instantiated in a build.mill or package.mill file")
-    implicit def dummyInfo: Info = ???
+    implicit def dummyInfo: Info = sys.error("implicit RootModule.Info must be provided")
   }
 
   case class SubFolderInfo(value: Seq[String])

--- a/main/src/mill/main/RootModule.scala
+++ b/main/src/mill/main/RootModule.scala
@@ -22,7 +22,9 @@ abstract class RootModule()(implicit
       millModuleLine0,
       millFile0,
       Caller(null)
-    ) with mill.main.MainModule
+    ) with mill.main.MainModule{
+  def millDiscover: Discover = sys.error("RootModule#millDiscover must be overriden")
+}
 
 @internal
 object RootModule {

--- a/main/src/mill/main/RootModule.scala
+++ b/main/src/mill/main/RootModule.scala
@@ -3,6 +3,7 @@ package mill.main
 import mill.api.internal
 import mill.define.{BaseModule, Ctx, Caller, Discover, Module, Segments}
 import scala.annotation.compileTimeOnly
+
 /**
  * Used to mark a module in your `build.mill` as a top-level module, so it's
  * targets and commands can be run directly e.g. via `mill run` rather than
@@ -22,7 +23,7 @@ abstract class RootModule()(implicit
       millModuleLine0,
       millFile0,
       Caller(null)
-    ) with mill.main.MainModule{
+    ) with mill.main.MainModule {
 
   // Dummy `millDiscover` defined but never actually used and overriden by codegen.
   // Provided for IDEs to think that one is available and not show errors in
@@ -33,7 +34,7 @@ abstract class RootModule()(implicit
 @internal
 object RootModule {
   case class Info(millSourcePath0: os.Path, discover: Discover)
-  object Info{
+  object Info {
     // Dummy `RootModule.Info` available in implicit scope but never actually used.
     // as it is provided by the codegen. Defined for IDEs to think that one is available
     // and not show errors in build.mill/package.mill even though they can't see the codegen


### PR DESCRIPTION
IntelliJ/VSCode can't see the generated code so they think that these things are missing, but they're not. Rather than changing IntelliJ/VSCode, for now we just provide dummy definitions that get overriden by the codegen but are enough to make the IDEs happy

Before, we see errors in `extends RootModule` because of the missing implicit `RootModule.Info`, and errors on the `object` as a whole because of the missing `def millDiscover`:

<img width="976" alt="Screenshot 2024-09-16 at 1 20 54 PM" src="https://github.com/user-attachments/assets/85b1d86a-de34-4622-bd1b-36428bfbc9bc">

After, those two errors are gone, although the "need override keyword" errors remain:

<img width="976" alt="Screenshot 2024-09-16 at 1 19 35 PM" src="https://github.com/user-attachments/assets/5b91acdd-02bd-4ede-bf3d-85b2b236ec9d">

Eventually we may have dedicated IDE support, but for now this hacks around one of the more visible IDE issues