### PR TITLE
Update scalafmt from 3.7.15 to 3.8.3

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,5 @@
 # Newer versions won't work with Java 8!
-version = "3.7.15"
+version = "3.8.3"
 
 align.openParenCallSite = false
 align.preset = none

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,5 @@
 # Newer versions won't work with Java 8!
-version = "3.8.3"
+version = "3.7.15"
 
 align.openParenCallSite = false
 align.preset = none

--- a/build.mill
+++ b/build.mill
@@ -160,8 +160,7 @@ object Deps {
   val testng = ivy"org.testng:testng:7.5.1"
   val sbtTestInterface = ivy"org.scala-sbt:test-interface:1.0"
   def scalaCompiler(scalaVersion: String) = ivy"org.scala-lang:scala-compiler:${scalaVersion}"
-  // last scalafmt release supporting Java 8 is 3.7.15
-  val scalafmtDynamic = ivy"org.scalameta::scalafmt-dynamic:3.7.15" // scala-steward:off
+  val scalafmtDynamic = ivy"org.scalameta::scalafmt-dynamic:3.8.3"
   def scalap(scalaVersion: String) = ivy"org.scala-lang:scalap:${scalaVersion}"
   def scalaReflect(scalaVersion: String) = ivy"org.scala-lang:scala-reflect:${scalaVersion}"
   val scalacScoveragePlugin = ivy"org.scoverage:::scalac-scoverage-plugin:1.4.11"


### PR DESCRIPTION
We no longer need to support Java 8, hence we can bump this one.