### PR TITLE
Use `Task` instead of `T` when constructing targets and other tasks

### DIFF
--- a/bsp/src/mill/bsp/BSP.scala
+++ b/bsp/src/mill/bsp/BSP.scala
@@ -30,7 +30,7 @@ object BSP extends ExternalModule with CoursierModule {
    * reason, the message and stacktrace of the exception will be
    * printed to stdout.
    */
-  def install(jobs: Int = 1): Command[(PathRef, ujson.Value)] = T.command {
+  def install(jobs: Int = 1): Command[(PathRef, ujson.Value)] = Task.Command {
     // we create a file containing the additional jars to load
     val libUrls = bspWorkerLibs().map(_.path.toNIO.toUri.toURL).iterator.toSeq
     val cpFile =
@@ -50,7 +50,7 @@ object BSP extends ExternalModule with CoursierModule {
    * @return The server result, indicating if mill should re-run this command or just exit.
    */
   def startSession(allBootstrapEvaluators: Evaluator.AllBootstrapEvaluators)
-      : Command[BspServerResult] = T.command {
+      : Command[BspServerResult] = Task.Command {
     T.log.errorStream.println("BSP/startSession: Starting BSP session")
     val res = BspContext.bspServerHandle.runSession(allBootstrapEvaluators.value)
     T.log.errorStream.println(s"BSP/startSession: Finished BSP session, result: ${res}")

--- a/bsp/src/mill/bsp/BSP.scala
+++ b/bsp/src/mill/bsp/BSP.scala
@@ -1,7 +1,7 @@
 package mill.bsp
 
 import mill.api.{Ctx, PathRef}
-import mill.{Agg, T}
+import mill.{Agg, T, Task}
 import mill.define.{Command, Discover, ExternalModule}
 import mill.main.BuildInfo
 import mill.eval.Evaluator
@@ -12,7 +12,7 @@ object BSP extends ExternalModule with CoursierModule {
 
   lazy val millDiscover: Discover = Discover[this.type]
 
-  private def bspWorkerLibs: T[Agg[PathRef]] = T {
+  private def bspWorkerLibs: T[Agg[PathRef]] = Task {
     millProjectModule("mill-bsp-worker", repositoriesTask())
   }
 

--- a/bsp/worker/src/mill/bsp/worker/MillJavaBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillJavaBuildServer.scala
@@ -6,7 +6,7 @@ import ch.epfl.scala.bsp4j.{
   JavacOptionsParams,
   JavacOptionsResult
 }
-import mill.T
+import mill.Task
 import mill.bsp.worker.Utils.sanitizeUri
 import mill.scalalib.{JavaModule, SemanticDbJavaModule}
 
@@ -26,7 +26,7 @@ private trait MillJavaBuildServer extends JavaBuildServer { this: MillBuildServe
             sem.bspCompiledClassesAndSemanticDbFiles
           case _ => m.bspCompileClassesPath
         }
-        T.task {
+        Task.Anon {
           (
             classesPathTask(),
             m.javacOptions() ++ m.mandatoryJavacOptions(),

--- a/bsp/worker/src/mill/bsp/worker/MillJavaBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillJavaBuildServer.scala
@@ -6,7 +6,7 @@ import ch.epfl.scala.bsp4j.{
   JavacOptionsParams,
   JavacOptionsResult
 }
-import mill.{T, Task}
+import mill.T
 import mill.bsp.worker.Utils.sanitizeUri
 import mill.scalalib.{JavaModule, SemanticDbJavaModule}
 

--- a/bsp/worker/src/mill/bsp/worker/MillJavaBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillJavaBuildServer.scala
@@ -6,7 +6,7 @@ import ch.epfl.scala.bsp4j.{
   JavacOptionsParams,
   JavacOptionsResult
 }
-import mill.T
+import mill.{T, Task}
 import mill.bsp.worker.Utils.sanitizeUri
 import mill.scalalib.{JavaModule, SemanticDbJavaModule}
 

--- a/bsp/worker/src/mill/bsp/worker/MillJvmBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillJvmBuildServer.scala
@@ -13,7 +13,7 @@ import ch.epfl.scala.bsp4j.{
   JvmTestEnvironmentParams,
   JvmTestEnvironmentResult
 }
-import mill.T
+import mill.Task
 import mill.bsp.worker.Utils.sanitizeUri
 import mill.scalalib.api.CompilationResult
 import mill.scalalib.{JavaModule, TestModule}
@@ -55,7 +55,7 @@ private trait MillJvmBuildServer extends JvmBuildServer { this: MillBuildServer 
             case m: TestModule => m.getTestEnvironmentVars()
             case _ => m.compile
           }
-          T.task {
+          Task.Anon {
             (
               m.runClasspath(),
               m.forkArgs(),

--- a/bsp/worker/src/mill/bsp/worker/MillJvmBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillJvmBuildServer.scala
@@ -13,7 +13,7 @@ import ch.epfl.scala.bsp4j.{
   JvmTestEnvironmentParams,
   JvmTestEnvironmentResult
 }
-import mill.T
+import mill.{T, Task}
 import mill.bsp.worker.Utils.sanitizeUri
 import mill.scalalib.api.CompilationResult
 import mill.scalalib.{JavaModule, TestModule}

--- a/bsp/worker/src/mill/bsp/worker/MillJvmBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillJvmBuildServer.scala
@@ -13,7 +13,7 @@ import ch.epfl.scala.bsp4j.{
   JvmTestEnvironmentParams,
   JvmTestEnvironmentResult
 }
-import mill.{T, Task}
+import mill.T
 import mill.bsp.worker.Utils.sanitizeUri
 import mill.scalalib.api.CompilationResult
 import mill.scalalib.{JavaModule, TestModule}

--- a/bsp/worker/src/mill/bsp/worker/MillScalaBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillScalaBuildServer.scala
@@ -13,7 +13,7 @@ import ch.epfl.scala.bsp4j.{
   ScalacOptionsParams,
   ScalacOptionsResult
 }
-import mill.{Agg, T}
+import mill.{Agg, Task}
 import mill.bsp.worker.Utils.sanitizeUri
 import mill.util.Jvm
 import mill.scalalib.{JavaModule, ScalaModule, TestModule, UnresolvedPath}
@@ -35,13 +35,13 @@ private trait MillScalaBuildServer extends ScalaBuildServer { this: MillBuildSer
         case m: JavaModule =>
           val scalacOptionsTask = m match {
             case m: ScalaModule => m.allScalacOptions
-            case _ => T.task { Seq.empty[String] }
+            case _ => Task.Anon { Seq.empty[String] }
           }
 
           val compileClasspathTask =
             if (enableJvmCompileClasspathProvider) {
               // We have a dedicated request for it
-              T.task { Agg.empty[UnresolvedPath] }
+              Task.Anon { Agg.empty[UnresolvedPath] }
             } else {
               m.bspCompileClasspath
             }
@@ -53,7 +53,7 @@ private trait MillScalaBuildServer extends ScalaBuildServer { this: MillBuildSer
               m.bspCompileClassesPath
             }
 
-          T.task {
+          Task.Anon {
             (scalacOptionsTask(), compileClasspathTask(), classesPathTask())
           }
       }
@@ -85,7 +85,7 @@ private trait MillScalaBuildServer extends ScalaBuildServer { this: MillBuildSer
       hint = "buildTarget/scalaMainClasses",
       targetIds = _ => p.getTargets.asScala.toSeq,
       tasks = { case m: JavaModule =>
-        T.task((m.zincWorker().worker(), m.compile(), m.forkArgs(), m.forkEnv()))
+        Task.Anon((m.zincWorker().worker(), m.compile(), m.forkArgs(), m.forkEnv()))
       }
     ) {
       case (ev, state, id, m: JavaModule, (worker, compile, forkArgs, forkEnv)) =>
@@ -112,9 +112,9 @@ private trait MillScalaBuildServer extends ScalaBuildServer { this: MillBuildSer
       targetIds = _ => p.getTargets.asScala.toSeq,
       tasks = {
         case m: TestModule =>
-          T.task(Some((m.runClasspath(), m.testFramework(), m.testClasspath())))
+          Task.Anon(Some((m.runClasspath(), m.testFramework(), m.testClasspath())))
         case _ =>
-          T.task(None)
+          Task.Anon(None)
       }
     ) {
       case (ev, state, id, m: TestModule, Some((classpath, testFramework, testClasspath))) =>

--- a/bsp/worker/src/mill/bsp/worker/MillScalaBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillScalaBuildServer.scala
@@ -13,7 +13,7 @@ import ch.epfl.scala.bsp4j.{
   ScalacOptionsParams,
   ScalacOptionsResult
 }
-import mill.{Agg, T}
+import mill.{Agg, T, Task}
 import mill.bsp.worker.Utils.sanitizeUri
 import mill.util.Jvm
 import mill.scalalib.{JavaModule, ScalaModule, TestModule, UnresolvedPath}

--- a/bsp/worker/src/mill/bsp/worker/MillScalaBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillScalaBuildServer.scala
@@ -13,7 +13,7 @@ import ch.epfl.scala.bsp4j.{
   ScalacOptionsParams,
   ScalacOptionsResult
 }
-import mill.{Agg, T, Task}
+import mill.{Agg, T}
 import mill.bsp.worker.Utils.sanitizeUri
 import mill.util.Jvm
 import mill.scalalib.{JavaModule, ScalaModule, TestModule, UnresolvedPath}

--- a/contrib/artifactory/src/mill/contrib/artifactory/ArtifactoryPublishModule.scala
+++ b/contrib/artifactory/src/mill/contrib/artifactory/ArtifactoryPublishModule.scala
@@ -27,7 +27,7 @@ trait ArtifactoryPublishModule extends PublishModule {
       artifactorySnapshotUri: String = artifactorySnapshotUri,
       readTimeout: Int = 60000,
       connectTimeout: Int = 5000
-  ): define.Command[Unit] = T.command {
+  ): define.Command[Unit] = Task.Command {
     val PublishModule.PublishData(artifactInfo, artifacts) = publishArtifacts()
     new ArtifactoryPublisher(
       artifactoryUri,
@@ -59,7 +59,7 @@ object ArtifactoryPublishModule extends ExternalModule {
       publishArtifacts: mill.main.Tasks[PublishModule.PublishData],
       readTimeout: Int = 60000,
       connectTimeout: Int = 5000
-  ) = T.command {
+  ) = Task.Command {
 
     val artifacts = T.sequence(publishArtifacts.value)().map {
       case data @ PublishModule.PublishData(_, _) => data.withConcretePath
@@ -76,7 +76,7 @@ object ArtifactoryPublishModule extends ExternalModule {
     )
   }
 
-  private def checkArtifactoryCreds(credentials: String): Task[String] = T.task {
+  private def checkArtifactoryCreds(credentials: String): Task[String] = Task.Anon {
     if (credentials.isEmpty) {
       (for {
         username <- T.env.get("ARTIFACTORY_USERNAME")

--- a/contrib/bintray/src/mill/contrib/bintray/BintrayPublishModule.scala
+++ b/contrib/bintray/src/mill/contrib/bintray/BintrayPublishModule.scala
@@ -5,6 +5,7 @@ import mill.api.Result
 import scalalib._
 import mill.contrib.bintray.BintrayPublishModule.checkBintrayCreds
 import mill.define.{ExternalModule, Task}
+import mill.define.Target
 
 trait BintrayPublishModule extends PublishModule {
 
@@ -12,7 +13,7 @@ trait BintrayPublishModule extends PublishModule {
 
   def bintrayRepo: String
 
-  def bintrayPackage = Task { artifactId() }
+  def bintrayPackage: Target[String] = Task { artifactId() }
 
   def bintrayPublishArtifacts: T[BintrayPublishData] = Task {
     val PublishModule.PublishData(artifactInfo, artifacts) = publishArtifacts()

--- a/contrib/bintray/src/mill/contrib/bintray/BintrayPublishModule.scala
+++ b/contrib/bintray/src/mill/contrib/bintray/BintrayPublishModule.scala
@@ -5,7 +5,6 @@ import mill.api.Result
 import scalalib._
 import mill.contrib.bintray.BintrayPublishModule.checkBintrayCreds
 import mill.define.{ExternalModule, Task}
-import mill.define.Target
 
 trait BintrayPublishModule extends PublishModule {
 
@@ -13,7 +12,7 @@ trait BintrayPublishModule extends PublishModule {
 
   def bintrayRepo: String
 
-  def bintrayPackage: Target[String] = Task { artifactId() }
+  def bintrayPackage: T[String] = Task { artifactId() }
 
   def bintrayPublishArtifacts: T[BintrayPublishData] = Task {
     val PublishModule.PublishData(artifactInfo, artifacts) = publishArtifacts()

--- a/contrib/bintray/src/mill/contrib/bintray/BintrayPublishModule.scala
+++ b/contrib/bintray/src/mill/contrib/bintray/BintrayPublishModule.scala
@@ -12,9 +12,9 @@ trait BintrayPublishModule extends PublishModule {
 
   def bintrayRepo: String
 
-  def bintrayPackage = T { artifactId() }
+  def bintrayPackage = Task { artifactId() }
 
-  def bintrayPublishArtifacts: T[BintrayPublishData] = T {
+  def bintrayPublishArtifacts: T[BintrayPublishData] = Task {
     val PublishModule.PublishData(artifactInfo, artifacts) = publishArtifacts()
     BintrayPublishData(artifactInfo, artifacts, bintrayPackage())
   }

--- a/contrib/bintray/src/mill/contrib/bintray/BintrayPublishModule.scala
+++ b/contrib/bintray/src/mill/contrib/bintray/BintrayPublishModule.scala
@@ -36,7 +36,7 @@ trait BintrayPublishModule extends PublishModule {
       release: Boolean = true,
       readTimeout: Int = 60000,
       connectTimeout: Int = 5000
-  ): define.Command[Unit] = T.command {
+  ): define.Command[Unit] = Task.Command {
     new BintrayPublisher(
       bintrayOwner,
       bintrayRepo,
@@ -69,7 +69,7 @@ object BintrayPublishModule extends ExternalModule {
       publishArtifacts: mill.main.Tasks[BintrayPublishData],
       readTimeout: Int = 60000,
       connectTimeout: Int = 5000
-  ) = T.command {
+  ) = Task.Command {
     new BintrayPublisher(
       bintrayOwner,
       bintrayRepo,
@@ -83,7 +83,7 @@ object BintrayPublishModule extends ExternalModule {
     )
   }
 
-  private def checkBintrayCreds(credentials: String): Task[String] = T.task {
+  private def checkBintrayCreds(credentials: String): Task[String] = Task.Anon {
     if (credentials.isEmpty) {
       (for {
         username <- T.env.get("BINTRAY_USERNAME")

--- a/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
+++ b/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
@@ -27,7 +27,7 @@ class BloopImpl(evs: () => Seq[Evaluator], wd: os.Path) extends ExternalModule {
    * Generates bloop configuration files reflecting the build,
    * under pwd/.bloop.
    */
-  def install() = T.command {
+  def install() = Task.Command {
     val res = T.traverse(computeModules)(_.bloop.writeConfigFile())()
     val written = res.map(_._2).map(_.path)
     // Make bloopDir if it doesn't exists
@@ -87,7 +87,7 @@ class BloopImpl(evs: () => Seq[Evaluator], wd: os.Path) extends ExternalModule {
     object bloop extends MillModule {
       def config = Task { outer.bloopConfig(jm) }
 
-      def writeConfigFile(): Command[(String, PathRef)] = T.command {
+      def writeConfigFile(): Command[(String, PathRef)] = Task.Command {
         os.makeDir.all(bloopDir)
         val path = bloopConfigPath(jm)
         _root_.bloop.config.write(config(), path.toNIO)
@@ -138,7 +138,7 @@ class BloopImpl(evs: () => Seq[Evaluator], wd: os.Path) extends ExternalModule {
    * that does not get invalidated upon sourcefile change. Mainly called
    * from module#sources in bloopInstall
    */
-  def moduleSourceMap = T.input {
+  def moduleSourceMap = Task.Input {
     val sources = T.traverse(computeModules) { m =>
       m.allSources.map { paths =>
         name(m) -> paths.map(_.path)
@@ -161,7 +161,7 @@ class BloopImpl(evs: () => Seq[Evaluator], wd: os.Path) extends ExternalModule {
     def out(m: JavaModule) = bloopDir / "out" / name(m)
     def classes(m: JavaModule) = out(m) / "classes"
 
-    val javaConfig = T.task {
+    val javaConfig = Task.Anon {
       val opts = module.javacOptions() ++ module.mandatoryJavacOptions()
       Some(Config.Java(options = opts.toList))
     }
@@ -172,7 +172,7 @@ class BloopImpl(evs: () => Seq[Evaluator], wd: os.Path) extends ExternalModule {
 
     val scalaConfig = module match {
       case s: ScalaModule =>
-        T.task {
+        Task.Anon {
           Some(
             BloopConfig.Scala(
               organization = s.scalaOrganization(),
@@ -185,7 +185,7 @@ class BloopImpl(evs: () => Seq[Evaluator], wd: os.Path) extends ExternalModule {
             )
           )
         }
-      case _ => T.task(None)
+      case _ => Task.Anon(None)
     }
 
     // //////////////////////////////////////////////////////////////////////////
@@ -194,17 +194,17 @@ class BloopImpl(evs: () => Seq[Evaluator], wd: os.Path) extends ExternalModule {
 
     def jsLinkerMode(m: JavaModule): Task[Config.LinkerMode] =
       (m.asBloop match {
-        case Some(bm) => T.task(bm.linkerMode())
-        case None => T.task(None)
+        case Some(bm) => Task.Anon(bm.linkerMode())
+        case None => Task.Anon(None)
       }).map(_.getOrElse(Config.LinkerMode.Debug))
 
     // //////////////////////////////////////////////////////////////////////////
     //  Classpath
     // //////////////////////////////////////////////////////////////////////////
 
-    val classpath = T.task {
+    val classpath = Task.Anon {
       val transitiveCompileClasspath = T.traverse(module.transitiveModuleCompileModuleDeps)(m =>
-        T.task { m.localCompileClasspath().map(_.path) ++ Agg(classes(m)) }
+        Task.Anon { m.localCompileClasspath().map(_.path) ++ Agg(classes(m)) }
       )().flatten
 
       module.resolvedIvyDeps().map(_.path) ++
@@ -212,20 +212,20 @@ class BloopImpl(evs: () => Seq[Evaluator], wd: os.Path) extends ExternalModule {
         module.localCompileClasspath().map(_.path)
     }
 
-    val runtimeClasspath = T.task {
+    val runtimeClasspath = Task.Anon {
       module.transitiveModuleDeps.map(classes) ++
         module.resolvedRunIvyDeps().map(_.path) ++
         module.unmanagedClasspath().map(_.path)
     }
 
     val compileResources =
-      T.task(module.compileResources().map(_.path.toNIO).toList)
+      Task.Anon(module.compileResources().map(_.path.toNIO).toList)
     val runtimeResources =
-      T.task(compileResources() ++ module.resources().map(_.path.toNIO).toList)
+      Task.Anon(compileResources() ++ module.resources().map(_.path.toNIO).toList)
 
     val platform: Task[BloopConfig.Platform] = module match {
       case m: ScalaJSModule =>
-        T.task {
+        Task.Anon {
           BloopConfig.Platform.Js(
             BloopConfig.JsConfig.empty.copy(
               version = m.scalaJSVersion(),
@@ -246,7 +246,7 @@ class BloopImpl(evs: () => Seq[Evaluator], wd: os.Path) extends ExternalModule {
           )
         }
       case m: ScalaNativeModule =>
-        T.task {
+        Task.Anon {
           BloopConfig.Platform.Native(
             BloopConfig.NativeConfig.empty.copy(
               version = m.scalaNativeVersion(),
@@ -270,7 +270,7 @@ class BloopImpl(evs: () => Seq[Evaluator], wd: os.Path) extends ExternalModule {
           )
         }
       case _ =>
-        T.task {
+        Task.Anon {
           BloopConfig.Platform.Jvm(
             BloopConfig.JvmConfig(
               home = T.env.get("JAVA_HOME").map(s => os.Path(s).toNIO),
@@ -298,7 +298,7 @@ class BloopImpl(evs: () => Seq[Evaluator], wd: os.Path) extends ExternalModule {
 
     val testConfig = module match {
       case m: TestModule =>
-        T.task {
+        Task.Anon {
           Some(
             BloopConfig.Test(
               frameworks = Seq(m.testFramework())
@@ -311,7 +311,7 @@ class BloopImpl(evs: () => Seq[Evaluator], wd: os.Path) extends ExternalModule {
             )
           )
         }
-      case _ => T.task(None)
+      case _ => Task.Anon(None)
     }
 
     // //////////////////////////////////////////////////////////////////////////
@@ -389,7 +389,7 @@ class BloopImpl(evs: () => Seq[Evaluator], wd: os.Path) extends ExternalModule {
       gatherTask.unsafeRun()
     }
 
-    val bloopResolution: Task[BloopConfig.Resolution] = T.task {
+    val bloopResolution: Task[BloopConfig.Resolution] = Task.Anon {
       val repos = module.repositoriesTask()
       // same as input of resolvedIvyDeps
       val allIvyDeps = module.transitiveIvyDeps() ++ module.transitiveCompileIvyDeps()
@@ -401,7 +401,7 @@ class BloopImpl(evs: () => Seq[Evaluator], wd: os.Path) extends ExternalModule {
     //  Tying up
     // //////////////////////////////////////////////////////////////////////////
 
-    val project = T.task {
+    val project = Task.Anon {
       val mSources = moduleSourceMap()
         .get(name(module))
         .toSeq
@@ -436,7 +436,7 @@ class BloopImpl(evs: () => Seq[Evaluator], wd: os.Path) extends ExternalModule {
       )
     }
 
-    T.task {
+    Task.Anon {
       BloopConfig.File(
         version = BloopConfig.File.LatestVersion,
         project = project()

--- a/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
+++ b/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
@@ -96,7 +96,7 @@ class BloopImpl(evs: () => Seq[Evaluator], wd: os.Path) extends ExternalModule {
       }
 
       @deprecated("Use writeConfigFile instead.", "Mill after 0.10.9")
-      def writeConfig: Target[(String, PathRef)] = Task {
+      def writeConfig: T[(String, PathRef)] = Task {
         writeConfigFile()()
       }
     }

--- a/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
+++ b/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
@@ -61,7 +61,7 @@ class BloopImpl(evs: () => Seq[Evaluator], wd: os.Path) extends ExternalModule {
     def linkerMode: T[Option[BloopConfig.LinkerMode]] = None
 
     object bloop extends MillModule {
-      def config = T {
+      def config = Task {
         new BloopOps(self).bloop.config()
       }
     }
@@ -85,7 +85,7 @@ class BloopImpl(evs: () => Seq[Evaluator], wd: os.Path) extends ExternalModule {
     override def millOuterCtx = jm.millOuterCtx
 
     object bloop extends MillModule {
-      def config = T { outer.bloopConfig(jm) }
+      def config = Task { outer.bloopConfig(jm) }
 
       def writeConfigFile(): Command[(String, PathRef)] = T.command {
         os.makeDir.all(bloopDir)
@@ -96,7 +96,7 @@ class BloopImpl(evs: () => Seq[Evaluator], wd: os.Path) extends ExternalModule {
       }
 
       @deprecated("Use writeConfigFile instead.", "Mill after 0.10.9")
-      def writeConfig: Target[(String, PathRef)] = T {
+      def writeConfig: Target[(String, PathRef)] = Task {
         writeConfigFile()()
       }
     }

--- a/contrib/buildinfo/src/mill/contrib/buildinfo/BuildInfo.scala
+++ b/contrib/buildinfo/src/mill/contrib/buildinfo/BuildInfo.scala
@@ -37,7 +37,7 @@ trait BuildInfo extends JavaModule {
 
   def resources: T[Seq[PathRef]] =
     if (buildInfoStaticCompiled) super.resources
-    else T.sources { super.resources() ++ Seq(buildInfoResources()) }
+    else Task.Sources { super.resources() ++ Seq(buildInfoResources()) }
 
   def buildInfoResources = Task {
     val p = new java.util.Properties

--- a/contrib/buildinfo/src/mill/contrib/buildinfo/BuildInfo.scala
+++ b/contrib/buildinfo/src/mill/contrib/buildinfo/BuildInfo.scala
@@ -1,6 +1,6 @@
 package mill.contrib.buildinfo
 
-import mill.T
+import mill.{T, Task}
 import mill.api.PathRef
 import mill.scalalib.{JavaModule, ScalaModule}
 import mill.scalanativelib.ScalaNativeModule
@@ -39,7 +39,7 @@ trait BuildInfo extends JavaModule {
     if (buildInfoStaticCompiled) super.resources
     else T.sources { super.resources() ++ Seq(buildInfoResources()) }
 
-  def buildInfoResources = T {
+  def buildInfoResources = Task {
     val p = new java.util.Properties
     for (v <- buildInfoMembers()) p.setProperty(v.key, v.value)
 
@@ -59,11 +59,11 @@ trait BuildInfo extends JavaModule {
 
   private def isScala = this.isInstanceOf[ScalaModule]
 
-  override def generatedSources = T {
+  override def generatedSources = Task {
     super.generatedSources() ++ buildInfoSources()
   }
 
-  def buildInfoSources = T {
+  def buildInfoSources = Task {
     if (buildInfoMembers().isEmpty) Nil
     else {
       val code = if (buildInfoStaticCompiled) BuildInfo.staticCompiledCodegen(

--- a/contrib/buildinfo/test/src/mill/contrib/buildinfo/BuildInfoTests.scala
+++ b/contrib/buildinfo/test/src/mill/contrib/buildinfo/BuildInfoTests.scala
@@ -158,7 +158,7 @@ object BuildInfoTests extends TestSuite {
     test("run") - UnitTester(BuildInfoPlain, testModuleSourcesPath / "scala").scoped { eval =>
       val runResult = eval.outPath / "hello-mill"
       val Right(_) =
-        eval.apply(BuildInfoPlain.run(T.task(Args(runResult.toString))))
+        eval.apply(BuildInfoPlain.run(Task.Anon(Args(runResult.toString))))
 
       assert(
         os.exists(runResult),
@@ -178,7 +178,7 @@ object BuildInfoTests extends TestSuite {
       val runResult = eval.outPath / "hello-mill"
 
       val Right(_) =
-        eval.apply(BuildInfoStatic.run(T.task(Args(runResult.toString))))
+        eval.apply(BuildInfoStatic.run(Task.Anon(Args(runResult.toString))))
 
       assert(os.exists(buildInfoSourcePath(eval)))
       assert(!os.exists(buildInfoResourcePath(eval)))
@@ -189,7 +189,7 @@ object BuildInfoTests extends TestSuite {
     test("java") - UnitTester(BuildInfoJava, testModuleSourcesPath / "java").scoped { eval =>
       val runResult = eval.outPath / "hello-mill"
       val Right(_) =
-        eval.apply(BuildInfoJava.run(T.task(Args(runResult.toString))))
+        eval.apply(BuildInfoJava.run(Task.Anon(Args(runResult.toString))))
 
       assert(
         os.exists(runResult),
@@ -202,7 +202,7 @@ object BuildInfoTests extends TestSuite {
         val runResult = eval.outPath / "hello-mill"
         val generatedSrc = eval.outPath / "buildInfoSources.dest/foo/BuildInfo.java"
         val Right(_) =
-          eval.apply(BuildInfoJavaStatic.run(T.task(Args(runResult.toString))))
+          eval.apply(BuildInfoJavaStatic.run(Task.Anon(Args(runResult.toString))))
 
         assert(
           os.exists(runResult),

--- a/contrib/checkstyle/src/mill/contrib/checkstyle/CheckstyleModule.scala
+++ b/contrib/checkstyle/src/mill/contrib/checkstyle/CheckstyleModule.scala
@@ -77,7 +77,7 @@ trait CheckstyleModule extends JavaModule {
   /**
    * Classpath for running Checkstyle.
    */
-  def checkstyleClasspath: T[Loose.Agg[PathRef]] = T {
+  def checkstyleClasspath: T[Loose.Agg[PathRef]] = Task {
     defaultResolver().resolveDeps(
       Agg(ivy"com.puppycrawl.tools:checkstyle:${checkstyleVersion()}")
     )
@@ -86,35 +86,35 @@ trait CheckstyleModule extends JavaModule {
   /**
    * Checkstyle configuration file. Defaults to `checkstyle-config.xml`.
    */
-  def checkstyleConfig: T[PathRef] = T {
+  def checkstyleConfig: T[PathRef] = Task {
     PathRef(T.workspace / "checkstyle-config.xml")
   }
 
   /**
    * Checkstyle output format (` plain | sarif | xml `). Defaults to `plain`.
    */
-  def checkstyleFormat: T[String] = T {
+  def checkstyleFormat: T[String] = Task {
     "plain"
   }
 
   /**
    * Additional arguments for Checkstyle.
    */
-  def checkstyleOptions: T[Seq[String]] = T {
+  def checkstyleOptions: T[Seq[String]] = Task {
     Seq.empty[String]
   }
 
   /**
    * Checkstyle output report.
    */
-  def checkstyleOutput: T[PathRef] = T {
+  def checkstyleOutput: T[PathRef] = Task {
     PathRef(T.dest / s"checkstyle-output.${checkstyleFormat()}")
   }
 
   /**
    * Checkstyle version.
    */
-  def checkstyleVersion: T[String] = T {
+  def checkstyleVersion: T[String] = Task {
     "10.18.1"
   }
 }

--- a/contrib/checkstyle/src/mill/contrib/checkstyle/CheckstyleModule.scala
+++ b/contrib/checkstyle/src/mill/contrib/checkstyle/CheckstyleModule.scala
@@ -17,13 +17,13 @@ trait CheckstyleModule extends JavaModule {
    *
    * @note [[sources]] are processed when no [[CheckstyleArgs.sources]] are specified.
    */
-  def checkstyle(@mainargs.arg checkstyleArgs: CheckstyleArgs): Command[Int] = T.command {
+  def checkstyle(@mainargs.arg checkstyleArgs: CheckstyleArgs): Command[Int] = Task.Command {
     val (output, exitCode) = checkstyle0(checkstyleArgs.stdout, checkstyleArgs.sources)()
 
     checkstyleHandleErrors(checkstyleArgs.stdout, checkstyleArgs.check, exitCode, output)
   }
 
-  protected def checkstyle0(stdout: Boolean, leftover: mainargs.Leftover[String]) = T.task {
+  protected def checkstyle0(stdout: Boolean, leftover: mainargs.Leftover[String]) = Task.Anon {
 
     val output = checkstyleOutput().path
     val args = checkstyleOptions() ++

--- a/contrib/checkstyle/src/mill/contrib/checkstyle/CheckstyleXsltModule.scala
+++ b/contrib/checkstyle/src/mill/contrib/checkstyle/CheckstyleXsltModule.scala
@@ -74,7 +74,7 @@ trait CheckstyleXsltModule extends CheckstyleModule {
    *
    * }}}
    */
-  def checkstyleXsltReports: T[Set[CheckstyleXsltReport]] = T {
+  def checkstyleXsltReports: T[Set[CheckstyleXsltReport]] = Task {
     val dir = checkstyleXsltfFolder().path
 
     if (os.exists(dir)) {

--- a/contrib/codeartifact/src/mill/contrib/codeartifact/CodeartifactPublishModule.scala
+++ b/contrib/codeartifact/src/mill/contrib/codeartifact/CodeartifactPublishModule.scala
@@ -17,7 +17,7 @@ trait CodeartifactPublishModule extends PublishModule {
       readTimeout: Int = 60000,
       connectTimeout: Int = 5000
   ): define.Command[Unit] =
-    T.command {
+    Task.Command {
       val PublishModule.PublishData(artifactInfo, artifacts) =
         publishArtifacts()
 
@@ -41,7 +41,7 @@ object CodeartifactPublishModule extends ExternalModule {
       readTimeout: Int = 60000,
       connectTimeout: Int = 5000
   ) =
-    T.command {
+    Task.Command {
       val artifacts = T.sequence(publishArtifacts.value)().map {
         case data @ PublishModule.PublishData(_, _) => data.withConcretePath
       }

--- a/contrib/docker/src/mill/contrib/docker/DockerModule.scala
+++ b/contrib/docker/src/mill/contrib/docker/DockerModule.scala
@@ -137,7 +137,7 @@ trait DockerModule { outer: JavaModule =>
          |ENTRYPOINT [$quotedEntryPointArgs]""".stripMargin
     }
 
-    private def pullAndHash = T.input {
+    private def pullAndHash = Task.Input {
       def imageHash() =
         os.proc(executable(), "images", "--no-trunc", "--quiet", baseImage())
           .call(stderr = os.Inherit).out.text().trim
@@ -187,7 +187,7 @@ trait DockerModule { outer: JavaModule =>
       tags()
     }
 
-    final def push() = T.command {
+    final def push() = Task.Command {
       val tags = build()
       tags.foreach(t =>
         os.proc(executable(), "push", t).call(stdout = os.Inherit, stderr = os.Inherit)

--- a/contrib/docker/src/mill/contrib/docker/DockerModule.scala
+++ b/contrib/docker/src/mill/contrib/docker/DockerModule.scala
@@ -98,7 +98,7 @@ trait DockerModule { outer: JavaModule =>
      */
     def executable: T[String] = "docker"
 
-    def dockerfile: T[String] = T {
+    def dockerfile: T[String] = Task {
       val jarName = assembly().path.last
       val labelRhs = labels()
         .map { case (k, v) =>
@@ -149,7 +149,7 @@ trait DockerModule { outer: JavaModule =>
       (pullBaseImage(), imageHash())
     }
 
-    final def build = T {
+    final def build = Task {
       val dest = T.dest
 
       val asmPath = outer.assembly().path

--- a/contrib/errorprone/src/mill/contrib/errorprone/ErrorProneModule.scala
+++ b/contrib/errorprone/src/mill/contrib/errorprone/ErrorProneModule.scala
@@ -1,7 +1,7 @@
 package mill.contrib.errorprone
 
 import mill.api.PathRef
-import mill.{Agg, T}
+import mill.{Agg, T, Task}
 import mill.scalalib.{Dep, DepSyntax, JavaModule}
 
 import java.io.File
@@ -21,7 +21,7 @@ trait ErrorProneModule extends JavaModule {
   /**
    * The dependencies of the `error-prone` compiler plugin.
    */
-  def errorProneDeps: T[Agg[Dep]] = T {
+  def errorProneDeps: T[Agg[Dep]] = Task {
     Agg(
       ivy"com.google.errorprone:error_prone_core:${errorProneVersion()}"
     )
@@ -30,14 +30,14 @@ trait ErrorProneModule extends JavaModule {
   /**
    * The classpath of the `error-prone` compiler plugin.
    */
-  def errorProneClasspath: T[Agg[PathRef]] = T {
+  def errorProneClasspath: T[Agg[PathRef]] = Task {
     defaultResolver().resolveDeps(errorProneDeps())
   }
 
   /**
    * Options used to enable and configure the `eror-prone` plugin in the Java compiler.
    */
-  def errorProneJavacEnableOptions: T[Seq[String]] = T {
+  def errorProneJavacEnableOptions: T[Seq[String]] = Task {
     val processorPath = errorProneClasspath().map(_.path).mkString(File.pathSeparator)
     val enableOpts = Seq(
       "-XDcompilePolicy=simple",
@@ -65,12 +65,12 @@ trait ErrorProneModule extends JavaModule {
    *
    * Those are documented as "flags" at https://errorprone.info/docs/flags
    */
-  def errorProneOptions: T[Seq[String]] = T { Seq.empty[String] }
+  def errorProneOptions: T[Seq[String]] = Task { Seq.empty[String] }
 
   /**
    * Appends the [[errorProneJavacEnableOptions]] to the Java compiler options.
    */
-  override def mandatoryJavacOptions: T[Seq[String]] = T {
+  override def mandatoryJavacOptions: T[Seq[String]] = Task {
     super.mandatoryJavacOptions() ++ errorProneJavacEnableOptions()
   }
 }

--- a/contrib/errorprone/src/mill/contrib/errorprone/ErrorProneModule.scala
+++ b/contrib/errorprone/src/mill/contrib/errorprone/ErrorProneModule.scala
@@ -14,7 +14,7 @@ import java.io.File
 trait ErrorProneModule extends JavaModule {
 
   /** The `error-prone` version to use. Defaults to [[BuildInfo.errorProneVersion]]. */
-  def errorProneVersion: T[String] = T.input {
+  def errorProneVersion: T[String] = Task.Input {
     BuildInfo.errorProneVersion
   }
 

--- a/contrib/errorprone/test/src/mill/contrib/errorprone/ErrorProneTests.scala
+++ b/contrib/errorprone/test/src/mill/contrib/errorprone/ErrorProneTests.scala
@@ -1,6 +1,6 @@
 package mill.contrib.errorprone
 
-import mill.T
+import mill.{T, Task}
 import mill.scalalib.JavaModule
 import mill.testkit.{TestBaseModule, UnitTester}
 import os.Path

--- a/contrib/flyway/readme.adoc
+++ b/contrib/flyway/readme.adoc
@@ -41,4 +41,4 @@ mill foo.flywayMigrate
 
 CAUTION: You should never hard-code credentials or check them into a version control system.
 You should write some code to populate the settings for flyway instead.
-For example `def flywayPassword = T.input(T.ctx.env("FLYWAY_PASSWORD"))`
+For example `def flywayPassword = Task.Input(T.ctx.env("FLYWAY_PASSWORD"))`

--- a/contrib/flyway/src/mill/contrib/flyway/FlywayModule.scala
+++ b/contrib/flyway/src/mill/contrib/flyway/FlywayModule.scala
@@ -10,7 +10,7 @@ import org.flywaydb.core.internal.configuration.{ConfigUtils => flyway}
 import org.flywaydb.core.internal.info.MigrationInfoDumper
 import scala.jdk.CollectionConverters._
 
-import mill.{Agg, T}
+import mill.{Agg, T, Task}
 import mill.api.PathRef
 import mill.define.Command
 import mill.scalalib.{Dep, JavaModule}
@@ -22,13 +22,13 @@ trait FlywayModule extends JavaModule {
   def flywayUrl: T[String]
   def flywayUser: T[String] = T("")
   def flywayPassword: T[String] = T("")
-  def flywayFileLocations: T[Seq[PathRef]] = T {
+  def flywayFileLocations: T[Seq[PathRef]] = Task {
     resources().map(pr => PathRef(pr.path / "db/migration", pr.quick))
   }
 
   def flywayDriverDeps: T[Agg[Dep]]
 
-  def jdbcClasspath = T {
+  def jdbcClasspath = Task {
     defaultResolver().resolveDeps(flywayDriverDeps())
   }
 

--- a/contrib/flyway/src/mill/contrib/flyway/FlywayModule.scala
+++ b/contrib/flyway/src/mill/contrib/flyway/FlywayModule.scala
@@ -37,7 +37,7 @@ trait FlywayModule extends JavaModule {
       .filter(_.nonEmpty)
       .map(key -> _)
 
-  def flywayInstance = T.worker {
+  def flywayInstance = Task.worker {
     val jdbcClassloader = new URLClassLoader(jdbcClasspath().map(_.path.toIO.toURI.toURL).toArray)
 
     val configProps = Map(flyway.URL -> flywayUrl()) ++
@@ -53,19 +53,19 @@ trait FlywayModule extends JavaModule {
       .load
   }
 
-  def flywayMigrate(): Command[MigrateResult] = T.command {
+  def flywayMigrate(): Command[MigrateResult] = Task.Command {
     flywayInstance().migrate()
   }
 
-  def flywayClean(): Command[CleanResult] = T.command {
+  def flywayClean(): Command[CleanResult] = Task.Command {
     flywayInstance().clean()
   }
 
-  def flywayBaseline(): Command[BaselineResult] = T.command {
+  def flywayBaseline(): Command[BaselineResult] = Task.Command {
     flywayInstance().baseline()
   }
 
-  def flywayInfo(): Command[String] = T.command {
+  def flywayInfo(): Command[String] = Task.Command {
     val info = flywayInstance().info
     val current = info.current
     val currentSchemaVersion =

--- a/contrib/flyway/src/mill/contrib/flyway/FlywayModule.scala
+++ b/contrib/flyway/src/mill/contrib/flyway/FlywayModule.scala
@@ -37,7 +37,7 @@ trait FlywayModule extends JavaModule {
       .filter(_.nonEmpty)
       .map(key -> _)
 
-  def flywayInstance = Task.worker {
+  def flywayInstance = Task.Worker {
     val jdbcClassloader = new URLClassLoader(jdbcClasspath().map(_.path.toIO.toURI.toURL).toArray)
 
     val configProps = Map(flyway.URL -> flywayUrl()) ++

--- a/contrib/flyway/test/src/mill/contrib/flyway/BuildTest.scala
+++ b/contrib/flyway/test/src/mill/contrib/flyway/BuildTest.scala
@@ -11,7 +11,7 @@ object BuildTest extends TestSuite {
     object build extends FlywayModule {
 
       val resourceFolder = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER"))
-      override def resources = T.sources(resourceFolder)
+      override def resources = Task.Sources(resourceFolder)
 
       def h2 = ivy"com.h2database:h2:2.1.214"
 

--- a/contrib/gitlab/readme.adoc
+++ b/contrib/gitlab/readme.adoc
@@ -129,7 +129,7 @@ import mill.api.Result.Success
 
 override def gitlabHeaders(
     props: Map[String, String] // System properties
-  ): Task[GitlabAuthHeaders] = T.task {
+  ): Task[GitlabAuthHeaders] = Task.Anon {
   // This uses default lookup and ads custom headers
   val access = tokenLookup.resolveGitlabToken(T.env, props, T.workspace)
   val accessHeader = access.fold(_ => Seq.empty[(String, String)], _.headers)
@@ -164,7 +164,7 @@ import $ivy.`com.lihaoyi::mill-contrib-gitlab:`
 import mill.contrib.gitlab._
 
 // DON'T DO THIS
-def repositoriesTask = T.task {
+def repositoriesTask = Task.Anon {
   super.repositoriesTask() ++ Seq(
     MavenRepository("https://gitlab.local/api/v4/projects/42/packages/maven",
       Some(Authentication(Seq(("Private-Token", "<<private-token>>"))))))
@@ -186,7 +186,7 @@ object myPackageRepository extends GitlabMavenRepository {
 }
 
 object myModule extends ScalaModule {
-  def repositoriesTask = T.task {
+  def repositoriesTask = Task.Anon {
     super.repositoriesTask() ++
       Seq(
         MavenRepository("https://oss.sonatype.org/content/repositories/releases"),

--- a/contrib/gitlab/src/mill/contrib/gitlab/GitlabMavenRepository.scala
+++ b/contrib/gitlab/src/mill/contrib/gitlab/GitlabMavenRepository.scala
@@ -12,7 +12,7 @@ trait GitlabMavenRepository {
   def tokenLookup: GitlabTokenLookup = new GitlabTokenLookup {} // For token discovery
   def gitlabRepository: GitlabPackageRepository // For package discovery
 
-  def mavenRepository: Task[MavenRepository] = T.task {
+  def mavenRepository: Task[MavenRepository] = Task.Anon {
 
     val gitlabAuth = tokenLookup.resolveGitlabToken(T.env, sys.props.toMap, T.workspace)
       .map(auth => Authentication(auth.headers))

--- a/contrib/gitlab/src/mill/contrib/gitlab/GitlabPublishModule.scala
+++ b/contrib/gitlab/src/mill/contrib/gitlab/GitlabPublishModule.scala
@@ -16,7 +16,7 @@ trait GitlabPublishModule extends PublishModule { outer =>
 
   def gitlabHeaders(
       systemProps: Map[String, String] = sys.props.toMap
-  ): Task[GitlabAuthHeaders] = T.task {
+  ): Task[GitlabAuthHeaders] = Task.Anon {
     val auth = tokenLookup.resolveGitlabToken(T.env, systemProps, T.workspace)
     auth match {
       case Left(msg) =>
@@ -30,7 +30,7 @@ trait GitlabPublishModule extends PublishModule { outer =>
   def publishGitlab(
       readTimeout: Int = 60000,
       connectTimeout: Int = 5000
-  ): define.Command[Unit] = T.command {
+  ): define.Command[Unit] = Task.Command {
 
     val gitlabRepo = publishRepository
 
@@ -58,7 +58,7 @@ object GitlabPublishModule extends ExternalModule {
       publishArtifacts: mill.main.Tasks[PublishModule.PublishData],
       readTimeout: Int = 60000,
       connectTimeout: Int = 5000
-  ): Command[Unit] = T.command {
+  ): Command[Unit] = Task.Command {
     val repo = ProjectRepository(gitlabRoot, projectId)
     val auth = GitlabAuthHeaders.privateToken(personalToken)
 

--- a/contrib/gitlab/test/src/mill/contrib/gitlab/GitlabModuleTests.scala
+++ b/contrib/gitlab/test/src/mill/contrib/gitlab/GitlabModuleTests.scala
@@ -1,6 +1,6 @@
 package mill.contrib.gitlab
 
-import mill.T
+import mill.{T, Task}
 import mill.api.Result.Failure
 import mill.scalalib.publish.PomSettings
 import mill.testkit.UnitTester

--- a/contrib/jmh/src/mill/contrib/jmh/JmhModule.scala
+++ b/contrib/jmh/src/mill/contrib/jmh/JmhModule.scala
@@ -50,7 +50,7 @@ trait JmhModule extends JavaModule {
   def listJmhBenchmarks(args: String*) = runJmh(("-l" +: args): _*)
 
   def compileGeneratedSources =
-    T {
+    Task {
       val dest = T.ctx().dest
       val (sourcesDir, _) = generateBenchmarkSources()
       val sources = os.walk(sourcesDir).filter(os.isFile)
@@ -70,7 +70,7 @@ trait JmhModule extends JavaModule {
 
   // returns sources and resources directories
   def generateBenchmarkSources =
-    T {
+    Task {
       val dest = T.ctx().dest
 
       val sourcesDir = dest / "jmh_sources"
@@ -95,7 +95,7 @@ trait JmhModule extends JavaModule {
       (sourcesDir, resourcesDir)
     }
 
-  def generatorDeps = T {
+  def generatorDeps = Task {
     defaultResolver().resolveDeps(
       Agg(ivy"org.openjdk.jmh:jmh-generator-bytecode:${jmhGeneratorByteCodeVersion()}")
     )

--- a/contrib/jmh/src/mill/contrib/jmh/JmhModule.scala
+++ b/contrib/jmh/src/mill/contrib/jmh/JmhModule.scala
@@ -36,7 +36,7 @@ trait JmhModule extends JavaModule {
   def ivyDeps = super.ivyDeps() ++ Agg(ivy"org.openjdk.jmh:jmh-core:${jmhCoreVersion()}")
 
   def runJmh(args: String*) =
-    T.command {
+    Task.Command {
       val (_, resources) = generateBenchmarkSources()
       Jvm.runSubprocess(
         "org.openjdk.jmh.Main",

--- a/contrib/playlib/src/mill/playlib/Dependencies.scala
+++ b/contrib/playlib/src/mill/playlib/Dependencies.scala
@@ -1,20 +1,20 @@
 package mill.playlib
 
-import mill.{Agg, T}
+import mill.{Agg, T, Task}
 import mill.scalalib._
 
 private[playlib] trait Dependencies extends ScalaModule with Version {
-  def core = T { component("play") }
-  def guice = T { component("play-guice") }
-  def server = T { component("play-server") }
-  def logback = T { component("play-logback") }
-  def evolutions = T { component("play-jdbc-evolutions") }
-  def jdbc = T { component("play-jdbc") }
-  def filters = T { component("filters-helpers") }
-  def ws = T { component("play-ahc-ws") }
-  def caffeine = T { component("play-caffeine-cache") }
+  def core = Task { component("play") }
+  def guice = Task { component("play-guice") }
+  def server = Task { component("play-server") }
+  def logback = Task { component("play-logback") }
+  def evolutions = Task { component("play-jdbc-evolutions") }
+  def jdbc = Task { component("play-jdbc") }
+  def filters = Task { component("filters-helpers") }
+  def ws = Task { component("play-ahc-ws") }
+  def caffeine = Task { component("play-caffeine-cache") }
 
-  override def ivyDeps = T {
+  override def ivyDeps = Task {
     super.ivyDeps() ++ Agg(
       core(),
       guice(),

--- a/contrib/playlib/src/mill/playlib/Dependencies.scala
+++ b/contrib/playlib/src/mill/playlib/Dependencies.scala
@@ -1,6 +1,6 @@
 package mill.playlib
 
-import mill.{Agg, T, Task}
+import mill.{Agg, Task}
 import mill.scalalib._
 
 private[playlib] trait Dependencies extends ScalaModule with Version {

--- a/contrib/playlib/src/mill/playlib/Layout.scala
+++ b/contrib/playlib/src/mill/playlib/Layout.scala
@@ -1,13 +1,13 @@
 package mill.playlib
 
-import mill.T
+import mill.Task
 import mill.scalalib._
 
 private[playlib] trait Layout extends JavaModule {
 
-  def conf = T.sources { millSourcePath / "conf" }
-  def app = T.sources { millSourcePath / "app" }
+  def conf = Task.Sources { millSourcePath / "conf" }
+  def app = Task.Sources { millSourcePath / "app" }
 
-  override def sources = T.sources { app() }
-  override def resources = T.sources { conf() }
+  override def sources = Task.Sources { app() }
+  override def resources = Task.Sources { conf() }
 }

--- a/contrib/playlib/src/mill/playlib/Layout.scala
+++ b/contrib/playlib/src/mill/playlib/Layout.scala
@@ -1,6 +1,6 @@
 package mill.playlib
 
-import mill.{T, Task}
+import mill.T
 import mill.scalalib._
 
 private[playlib] trait Layout extends JavaModule {

--- a/contrib/playlib/src/mill/playlib/Layout.scala
+++ b/contrib/playlib/src/mill/playlib/Layout.scala
@@ -1,6 +1,6 @@
 package mill.playlib
 
-import mill.T
+import mill.{T, Task}
 import mill.scalalib._
 
 private[playlib] trait Layout extends JavaModule {

--- a/contrib/playlib/src/mill/playlib/PlayModule.scala
+++ b/contrib/playlib/src/mill/playlib/PlayModule.scala
@@ -4,6 +4,7 @@ import mill.define.Task
 import mill.playlib.api.Versions
 import mill.scalalib._
 import mill.{Agg, Args, T}
+import mill.define.Target
 
 trait PlayApiModule extends Dependencies with Router with Server {
   trait PlayTests extends ScalaTests with TestModule.ScalaTest {
@@ -24,7 +25,7 @@ trait PlayApiModule extends Dependencies with Router with Server {
 
 }
 trait PlayModule extends PlayApiModule with Static with Twirl {
-  override def twirlVersion = Task {
+  override def twirlVersion: Target[String] = Task {
     playMinorVersion() match {
       case "2.6" => "1.3.16"
       case "2.7" => "1.4.2"

--- a/contrib/playlib/src/mill/playlib/PlayModule.scala
+++ b/contrib/playlib/src/mill/playlib/PlayModule.scala
@@ -4,6 +4,8 @@ import mill.define.Task
 import mill.playlib.api.Versions
 import mill.scalalib._
 import mill.{Agg, Args, T}
+import mill.api.PathRef
+import mill.define.Target
 
 trait PlayApiModule extends Dependencies with Router with Server {
   trait PlayTests extends ScalaTests with TestModule.ScalaTest {
@@ -17,10 +19,10 @@ trait PlayApiModule extends Dependencies with Router with Server {
       }
       Agg(ivy"org.scalatestplus.play::scalatestplus-play::${scalatestPlusPlayVersion}")
     }
-    override def sources = T.sources { millSourcePath }
+    override def sources: Target[Seq[PathRef]] = Task.Sources { millSourcePath }
   }
 
-  def start(args: Task[Args] = T.task(Args())) = T.command { run(args)() }
+  def start(args: Task[Args] = Task.Anon(Args())) = Task.Command { run(args)() }
 
 }
 trait PlayModule extends PlayApiModule with Static with Twirl {

--- a/contrib/playlib/src/mill/playlib/PlayModule.scala
+++ b/contrib/playlib/src/mill/playlib/PlayModule.scala
@@ -4,7 +4,6 @@ import mill.define.Task
 import mill.playlib.api.Versions
 import mill.scalalib._
 import mill.{Agg, Args, T}
-import mill.define.Target
 
 trait PlayApiModule extends Dependencies with Router with Server {
   trait PlayTests extends ScalaTests with TestModule.ScalaTest {
@@ -25,7 +24,7 @@ trait PlayApiModule extends Dependencies with Router with Server {
 
 }
 trait PlayModule extends PlayApiModule with Static with Twirl {
-  override def twirlVersion: Target[String] = Task {
+  override def twirlVersion: T[String] = Task {
     playMinorVersion() match {
       case "2.6" => "1.3.16"
       case "2.7" => "1.4.2"

--- a/contrib/playlib/src/mill/playlib/PlayModule.scala
+++ b/contrib/playlib/src/mill/playlib/PlayModule.scala
@@ -7,7 +7,7 @@ import mill.{Agg, Args, T}
 
 trait PlayApiModule extends Dependencies with Router with Server {
   trait PlayTests extends ScalaTests with TestModule.ScalaTest {
-    override def ivyDeps = T {
+    override def ivyDeps = Task {
       val scalatestPlusPlayVersion = playMinorVersion() match {
         case Versions.PLAY_2_6 => "3.1.3"
         case Versions.PLAY_2_7 => "4.0.3"
@@ -24,7 +24,7 @@ trait PlayApiModule extends Dependencies with Router with Server {
 
 }
 trait PlayModule extends PlayApiModule with Static with Twirl {
-  override def twirlVersion = T {
+  override def twirlVersion = Task {
     playMinorVersion() match {
       case "2.6" => "1.3.16"
       case "2.7" => "1.4.2"

--- a/contrib/playlib/src/mill/playlib/RouteCompilerWorker.scala
+++ b/contrib/playlib/src/mill/playlib/RouteCompilerWorker.scala
@@ -3,7 +3,7 @@ package mill.playlib
 import mill.api.{Ctx, PathRef, Result}
 import mill.playlib.api.{RouteCompilerType, RouteCompilerWorkerApi}
 import mill.scalalib.api.CompilationResult
-import mill.{Agg, T, Task}
+import mill.{Agg, T}
 
 private[playlib] class RouteCompilerWorker extends AutoCloseable {
 

--- a/contrib/playlib/src/mill/playlib/RouteCompilerWorker.scala
+++ b/contrib/playlib/src/mill/playlib/RouteCompilerWorker.scala
@@ -3,7 +3,7 @@ package mill.playlib
 import mill.api.{Ctx, PathRef, Result}
 import mill.playlib.api.{RouteCompilerType, RouteCompilerWorkerApi}
 import mill.scalalib.api.CompilationResult
-import mill.{Agg, T}
+import mill.{Agg, T, Task}
 
 private[playlib] class RouteCompilerWorker extends AutoCloseable {
 

--- a/contrib/playlib/src/mill/playlib/RouteCompilerWorkerModule.scala
+++ b/contrib/playlib/src/mill/playlib/RouteCompilerWorkerModule.scala
@@ -4,7 +4,7 @@ import mill.{Module, Task}
 import mill.define.{Discover, ExternalModule, Worker}
 
 trait RouteCompilerWorkerModule extends Module {
-  def routeCompilerWorker: Worker[RouteCompilerWorker] = Task.worker {
+  def routeCompilerWorker: Worker[RouteCompilerWorker] = Task.Worker {
     new RouteCompilerWorker()
   }
 }

--- a/contrib/playlib/src/mill/playlib/RouteCompilerWorkerModule.scala
+++ b/contrib/playlib/src/mill/playlib/RouteCompilerWorkerModule.scala
@@ -1,10 +1,10 @@
 package mill.playlib
 
-import mill.{Module, T}
+import mill.{Module, Task}
 import mill.define.{Discover, ExternalModule, Worker}
 
 trait RouteCompilerWorkerModule extends Module {
-  def routeCompilerWorker: Worker[RouteCompilerWorker] = T.worker {
+  def routeCompilerWorker: Worker[RouteCompilerWorker] = Task.worker {
     new RouteCompilerWorker()
   }
 }

--- a/contrib/playlib/src/mill/playlib/Router.scala
+++ b/contrib/playlib/src/mill/playlib/Router.scala
@@ -1,6 +1,6 @@
 package mill.playlib
 
-import mill.{T, Task}
+import mill.Task
 
 private[playlib] trait Router extends RouterModule with Layout {
   override def routes = Task { conf() }

--- a/contrib/playlib/src/mill/playlib/Router.scala
+++ b/contrib/playlib/src/mill/playlib/Router.scala
@@ -1,7 +1,7 @@
 package mill.playlib
 
-import mill.T
+import mill.{T, Task}
 
 private[playlib] trait Router extends RouterModule with Layout {
-  override def routes = T { conf() }
+  override def routes = Task { conf() }
 }

--- a/contrib/playlib/src/mill/playlib/RouterModule.scala
+++ b/contrib/playlib/src/mill/playlib/RouterModule.scala
@@ -9,7 +9,7 @@ import mill.{Agg, T, Task}
 
 trait RouterModule extends ScalaModule with Version {
 
-  def routes: T[Seq[PathRef]] = T.sources { millSourcePath / "routes" }
+  def routes: T[Seq[PathRef]] = Task.Sources { millSourcePath / "routes" }
 
   def routeFiles = Task {
     val paths = routes().flatMap(file => os.walk(file.path))
@@ -60,7 +60,7 @@ trait RouterModule extends ScalaModule with Version {
 
   protected val routeCompilerWorker: RouteCompilerWorkerModule = RouteCompilerWorkerModule
 
-  def compileRouter: T[CompilationResult] = T.persistent {
+  def compileRouter: T[CompilationResult] = Task.Persistent {
     T.log.debug(s"compiling play routes with ${playVersion()} worker")
     routeCompilerWorker.routeCompilerWorker().compile(
       routerClasspath = playRouterToolsClasspath(),

--- a/contrib/playlib/src/mill/playlib/RouterModule.scala
+++ b/contrib/playlib/src/mill/playlib/RouterModule.scala
@@ -5,13 +5,13 @@ import mill.util.Util.millProjectModule
 import mill.playlib.api.RouteCompilerType
 import mill.scalalib._
 import mill.scalalib.api._
-import mill.{Agg, T}
+import mill.{Agg, T, Task}
 
 trait RouterModule extends ScalaModule with Version {
 
   def routes: T[Seq[PathRef]] = T.sources { millSourcePath / "routes" }
 
-  def routeFiles = T {
+  def routeFiles = Task {
     val paths = routes().flatMap(file => os.walk(file.path))
     val routeFiles = paths.filter(_.ext == "routes") ++ paths.filter(_.last == "routes")
     routeFiles.map(f => PathRef(f))
@@ -45,7 +45,7 @@ trait RouterModule extends ScalaModule with Version {
    */
   def generatorType: RouteCompilerType = RouteCompilerType.InjectedGenerator
 
-  def routerClasspath: T[Agg[PathRef]] = T {
+  def routerClasspath: T[Agg[PathRef]] = Task {
     defaultResolver().resolveDeps(
       playMinorVersion() match {
         case "2.6" | "2.7" | "2.8" =>
@@ -74,7 +74,7 @@ trait RouterModule extends ScalaModule with Version {
     )
   }
 
-  def playRouteCompilerWorkerClasspath = T {
+  def playRouteCompilerWorkerClasspath = Task {
     millProjectModule(
       s"mill-contrib-playlib-worker-${playMinorVersion()}",
       repositoriesTask(),
@@ -85,15 +85,15 @@ trait RouterModule extends ScalaModule with Version {
     )
   }
 
-  def playRouterToolsClasspath = T {
+  def playRouterToolsClasspath = Task {
     playRouteCompilerWorkerClasspath() ++ routerClasspath()
   }
 
-  def routerClasses = T {
+  def routerClasses = Task {
     Seq(compileRouter().classes)
   }
 
-  override def generatedSources = T {
+  override def generatedSources = Task {
     super.generatedSources() ++ routerClasses()
   }
 }

--- a/contrib/playlib/src/mill/playlib/Server.scala
+++ b/contrib/playlib/src/mill/playlib/Server.scala
@@ -1,26 +1,26 @@
 package mill.playlib
 
 import mill.scalalib._
-import mill.{Agg, T}
+import mill.{Agg, T, Task}
 
 private[playlib] trait Server extends ScalaModule with Version {
 
-  def nettyServer = T { component("play-netty-server") }
+  def nettyServer = Task { component("play-netty-server") }
 
-  def akkaHttpServer = T { component("play-akka-http-server") }
+  def akkaHttpServer = Task { component("play-akka-http-server") }
 
-  def pekkoHttpServer = T { component("play-pekko-http-server") }
+  def pekkoHttpServer = Task { component("play-pekko-http-server") }
 
-  def playServerProvider = T {
+  def playServerProvider = Task {
     if (playVersion().startsWith("2."))
       akkaHttpServer()
     else
       pekkoHttpServer()
   }
 
-  override def runIvyDeps = T {
+  override def runIvyDeps = Task {
     super.runIvyDeps() ++ Agg(playServerProvider())
   }
 
-  override def mainClass = T { Some("play.core.server.ProdServerStart") }
+  override def mainClass = Task { Some("play.core.server.ProdServerStart") }
 }

--- a/contrib/playlib/src/mill/playlib/Server.scala
+++ b/contrib/playlib/src/mill/playlib/Server.scala
@@ -1,7 +1,7 @@
 package mill.playlib
 
 import mill.scalalib._
-import mill.{Agg, T, Task}
+import mill.{Agg, Task}
 
 private[playlib] trait Server extends ScalaModule with Version {
 

--- a/contrib/playlib/src/mill/playlib/Static.scala
+++ b/contrib/playlib/src/mill/playlib/Static.scala
@@ -6,7 +6,7 @@ import java.nio.file.attribute.BasicFileAttributes
 import java.util
 
 import mill.scalalib.{Lib, ScalaModule}
-import mill.{PathRef, T}
+import mill.{PathRef, T, Task}
 
 trait Static extends ScalaModule {
 
@@ -20,7 +20,7 @@ trait Static extends ScalaModule {
   /**
    * Resource base path of packaged assets (path they will appear in in the jar)
    */
-  def assetsPath = T { "public" }
+  def assetsPath = Task { "public" }
 
   /**
    *  Directories to include assets from
@@ -30,7 +30,7 @@ trait Static extends ScalaModule {
   /*
   Collected static assets for the project
    */
-  def staticAssets = T {
+  def staticAssets = Task {
     val toPath = os.Path(assetsPath(), T.dest)
     assetSources().foreach { pathRef =>
       val fromPath = pathRef.path
@@ -46,14 +46,14 @@ trait Static extends ScalaModule {
   /**
    * webjar dependencies - created from transitive ivy deps
    */
-  def webJarDeps = T {
+  def webJarDeps = Task {
     transitiveIvyDeps().filter(_.dep.module.organization.value == "org.webjars")
   }
 
   /**
    * jar files of web jars
    */
-  def webJars = T {
+  def webJars = Task {
     Lib.resolveDependencies(
       repositoriesTask(),
       webJarDeps()
@@ -63,7 +63,7 @@ trait Static extends ScalaModule {
   /**
    * webjar resources extracted from their source jars with version from path removed
    */
-  def webJarResources = T {
+  def webJarResources = Task {
     extractWebJars(webJars().toSeq, os.Path(assetsPath(), T.dest) / "lib")
     PathRef(T.dest)
   }

--- a/contrib/playlib/src/mill/playlib/Static.scala
+++ b/contrib/playlib/src/mill/playlib/Static.scala
@@ -13,7 +13,7 @@ trait Static extends ScalaModule {
   /**
    * project resources including configuration, webjars and static assets
    */
-  override def resources = T.sources {
+  override def resources = Task.Sources {
     super.resources() :+ webJarResources() :+ staticAssets()
   }
 
@@ -25,7 +25,7 @@ trait Static extends ScalaModule {
   /**
    *  Directories to include assets from
    */
-  def assetSources = T.sources { millSourcePath / assetsPath() }
+  def assetSources = Task.Sources { millSourcePath / assetsPath() }
 
   /*
   Collected static assets for the project

--- a/contrib/playlib/src/mill/playlib/Twirl.scala
+++ b/contrib/playlib/src/mill/playlib/Twirl.scala
@@ -1,11 +1,11 @@
 package mill.playlib
 
-import mill.{T, Task}
+import mill.Task
 import mill.twirllib._
 
 trait Twirl extends TwirlModule with Layout {
 
-  override def twirlSources = T.sources { app() }
+  override def twirlSources = Task.Sources { app() }
 
   override def twirlImports = Task {
     super.twirlImports() ++ Seq(

--- a/contrib/playlib/src/mill/playlib/Twirl.scala
+++ b/contrib/playlib/src/mill/playlib/Twirl.scala
@@ -1,13 +1,13 @@
 package mill.playlib
 
-import mill.T
+import mill.{T, Task}
 import mill.twirllib._
 
 trait Twirl extends TwirlModule with Layout {
 
   override def twirlSources = T.sources { app() }
 
-  override def twirlImports = T {
+  override def twirlImports = Task {
     super.twirlImports() ++ Seq(
       "models._",
       "controllers._",
@@ -19,9 +19,9 @@ trait Twirl extends TwirlModule with Layout {
     )
   }
 
-  def twirlOutput = T { Seq(compileTwirl().classes) }
+  def twirlOutput = Task { Seq(compileTwirl().classes) }
 
-  override def generatedSources = T {
+  override def generatedSources = Task {
     super.generatedSources() ++ twirlOutput()
   }
 }

--- a/contrib/playlib/src/mill/playlib/Version.scala
+++ b/contrib/playlib/src/mill/playlib/Version.scala
@@ -1,6 +1,6 @@
 package mill.playlib
 
-import mill.T
+import mill.{T, Task}
 import mill.define.Module
 import mill.scalalib._
 
@@ -8,7 +8,7 @@ private[playlib] trait Version extends Module {
 
   def playVersion: T[String]
 
-  private[playlib] def playMinorVersion: T[String] = T {
+  private[playlib] def playMinorVersion: T[String] = Task {
     playVersion().split('.').take(2).mkString(".")
   }
 

--- a/contrib/playlib/src/mill/playlib/Version.scala
+++ b/contrib/playlib/src/mill/playlib/Version.scala
@@ -12,11 +12,11 @@ private[playlib] trait Version extends Module {
     playVersion().split('.').take(2).mkString(".")
   }
 
-  private[playlib] def playOrganization: T[String] = T.task {
+  private[playlib] def playOrganization: T[String] = Task.Anon {
     if (playVersion().startsWith("2.")) "com.typesafe.play" else "org.playframework"
   }
 
-  private[playlib] def component(id: String) = T.task {
+  private[playlib] def component(id: String) = Task.Anon {
     ivy"${playOrganization()}::$id::${playVersion()}"
   }
 }

--- a/contrib/playlib/test/src/mill/playlib/PlayModuleTests.scala
+++ b/contrib/playlib/test/src/mill/playlib/PlayModuleTests.scala
@@ -13,7 +13,7 @@ object PlayModuleTests extends TestSuite with PlayTestSuite {
       override def playVersion = crossPlayVersion
       override def scalaVersion = crossScalaVersion
       object test extends PlayTests
-      override def ivyDeps = T { super.ivyDeps() ++ Agg(ws()) }
+      override def ivyDeps = Task { super.ivyDeps() ++ Agg(ws()) }
     }
   }
   val resourcePath: os.Path = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "playmulti"

--- a/contrib/playlib/test/src/mill/playlib/PlaySingleApiModuleTests.scala
+++ b/contrib/playlib/test/src/mill/playlib/PlaySingleApiModuleTests.scala
@@ -1,6 +1,6 @@
 package mill.playlib
 
-import mill.T
+import mill.{T, Task}
 import mill.testkit.{TestBaseModule, UnitTester}
 import utest.{TestSuite, Tests, assert, _}
 
@@ -8,8 +8,8 @@ object PlaySingleApiModuleTests extends TestSuite with PlayTestSuite {
 
   object playsingleapi extends TestBaseModule with PlayApiModule with SingleModule {
     override val millSourcePath = os.temp() // workaround problem in `SingleModule`
-    override def playVersion = T { testPlay28 }
-    override def scalaVersion = T { "2.13.12" }
+    override def playVersion = Task { testPlay28 }
+    override def scalaVersion = Task { "2.13.12" }
     object test extends PlayTests
   }
 

--- a/contrib/playlib/test/src/mill/playlib/PlaySingleModuleTests.scala
+++ b/contrib/playlib/test/src/mill/playlib/PlaySingleModuleTests.scala
@@ -1,6 +1,6 @@
 package mill.playlib
 
-import mill.T
+import mill.{T, Task}
 import mill.testkit.{TestBaseModule, UnitTester}
 import utest.{TestSuite, Tests, assert, _}
 
@@ -8,8 +8,8 @@ object PlaySingleModuleTests extends TestSuite with PlayTestSuite {
 
   object playsingle extends TestBaseModule with PlayModule with SingleModule {
     override val millSourcePath = os.temp() // workaround problem in `SingleModule`
-    override def playVersion = T { testPlay28 }
-    override def scalaVersion = T { sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???) }
+    override def playVersion = Task { testPlay28 }
+    override def scalaVersion = Task { sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???) }
     object test extends PlayTests
   }
 

--- a/contrib/proguard/src/mill/contrib/proguard/Proguard.scala
+++ b/contrib/proguard/src/mill/contrib/proguard/Proguard.scala
@@ -1,7 +1,7 @@
 package mill.contrib.proguard
 
 import mill.java9rtexport.Export
-import mill.T
+import mill.{T, Task}
 import mill.Agg
 import mill.api.{Loose, PathRef}
 import mill.util.Jvm
@@ -22,7 +22,7 @@ trait Proguard extends ScalaModule {
    * The version of proguard to download from Maven.
    * https://mvnrepository.com/artifact/com.guardsquare/proguard-base
    */
-  def proguardVersion: T[String] = T {
+  def proguardVersion: T[String] = Task {
     T.log.error(
       "Using default proguard version is deprecated. Please override target proguardVersion to specify the version."
     )
@@ -30,20 +30,20 @@ trait Proguard extends ScalaModule {
   }
 
   /** Run the "shrink" step in the proguard pipeline. Defaults to true. */
-  def shrink: T[Boolean] = T { true }
+  def shrink: T[Boolean] = Task { true }
 
   /** Run the "optimize" step in the proguard pipeline. Defaults to true. */
-  def optimize: T[Boolean] = T { true }
+  def optimize: T[Boolean] = Task { true }
 
   /** Run the "obfuscate" step in the proguard pipeline. Defaults to true. */
-  def obfuscate: T[Boolean] = T { true }
+  def obfuscate: T[Boolean] = Task { true }
 
   /**
    * Run the "optimize" step in the proguard pipeline. Defaults to true.
    *
    * Note that this is required for Java 7 and above.
    */
-  def preverify: T[Boolean] = T { true }
+  def preverify: T[Boolean] = Task { true }
 
   /**
    * The path to JAVA_HOME.
@@ -58,13 +58,13 @@ trait Proguard extends ScalaModule {
   }
 
   /** Specifies the input jar to proguard. Defaults to the output of the `assembly` task. */
-  def inJar: T[PathRef] = T { assembly() }
+  def inJar: T[PathRef] = Task { assembly() }
 
   /**
    * This needs to return the Java RT JAR if on Java 9 or above.
    * Keep in sync with [[javaHome]].
    */
-  def java9RtJar: T[Seq[PathRef]] = T {
+  def java9RtJar: T[Seq[PathRef]] = Task {
     if (mill.main.client.Util.isJava9OrAbove) {
       val rt = T.dest / Export.rtJarName
       if (!os.exists(rt)) {
@@ -83,7 +83,7 @@ trait Proguard extends ScalaModule {
    * The library jars proguard requires
    * Defaults the jars under `javaHome`.
    */
-  def libraryJars: T[Seq[PathRef]] = T {
+  def libraryJars: T[Seq[PathRef]] = Task {
     val javaJars =
       os.list(javaHome().path / "lib", sort = false).filter(_.ext == "jar").toSeq.map(PathRef(_))
     javaJars ++ java9RtJar()
@@ -96,7 +96,7 @@ trait Proguard extends ScalaModule {
    *  The stdout and stderr of the command are written to the `dest/` folder.
    *  The output jar is written to `dest/our.jar`.
    */
-  def proguard: T[PathRef] = T {
+  def proguard: T[PathRef] = Task {
     val outJar = T.dest / "out.jar"
 
     val args = Seq[Shellable](
@@ -134,13 +134,13 @@ trait Proguard extends ScalaModule {
    * The location of the proguard jar files.
    * These are downloaded from JCenter and fed to `java -cp`
    */
-  def proguardClasspath: T[Loose.Agg[PathRef]] = T {
+  def proguardClasspath: T[Loose.Agg[PathRef]] = Task {
     defaultResolver().resolveDeps(
       Agg(ivy"com.guardsquare:proguard-base:${proguardVersion()}")
     )
   }
 
-  private def steps: T[Seq[String]] = T {
+  private def steps: T[Seq[String]] = Task {
     (if (optimize()) Seq() else Seq("-dontoptimize")) ++
       (if (obfuscate()) Seq() else Seq("-dontobfuscate")) ++
       (if (shrink()) Seq() else Seq("-dontshrink")) ++
@@ -154,7 +154,7 @@ trait Proguard extends ScalaModule {
    * Can be overridden to specify a different entrypoint,
    * or additional entrypoints can be specified with `additionalOptions`.
    */
-  def entryPoint: T[String] = T {
+  def entryPoint: T[String] = Task {
     s"""|-keep public class ${finalMainClass()} {
         |    public static void main(java.lang.String[]);
         |}
@@ -166,7 +166,7 @@ trait Proguard extends ScalaModule {
    *
    * These are fed as-is to the proguard command.
    */
-  def additionalOptions: T[Seq[String]] = T {
+  def additionalOptions: T[Seq[String]] = Task {
     T.log.error(
       "Proguard is set to not warn about message: can't find referenced method 'void invoke()' in library class java.lang.invoke.MethodHandle"
     )

--- a/contrib/proguard/src/mill/contrib/proguard/Proguard.scala
+++ b/contrib/proguard/src/mill/contrib/proguard/Proguard.scala
@@ -53,7 +53,7 @@ trait Proguard extends ScalaModule {
    * Defaults to the `java.home` system property.
    * Keep in sync with [[java9RtJar]]-
    */
-  def javaHome: T[PathRef] = T.input {
+  def javaHome: T[PathRef] = Task.Input {
     PathRef(Path(sys.props("java.home")))
   }
 

--- a/contrib/proguard/test/src/mill/contrib/proguard/ProguardTests.scala
+++ b/contrib/proguard/test/src/mill/contrib/proguard/ProguardTests.scala
@@ -19,7 +19,7 @@ object ProguardTests extends TestSuite {
       millProjectModule("mill-contrib-proguard", repositoriesTask())
     }
 
-    override def runClasspath: Target[Seq[PathRef]] =
+    override def runClasspath: T[Seq[PathRef]] =
       Task { super.runClasspath() ++ proguardContribClasspath() }
 
   }

--- a/contrib/proguard/test/src/mill/contrib/proguard/ProguardTests.scala
+++ b/contrib/proguard/test/src/mill/contrib/proguard/ProguardTests.scala
@@ -15,12 +15,12 @@ object ProguardTests extends TestSuite {
   object proguard extends TestBaseModule with ScalaModule with Proguard {
     override def scalaVersion: T[String] = T(sys.props.getOrElse("MILL_SCALA_2_13_VERSION", ???))
 
-    def proguardContribClasspath = T {
+    def proguardContribClasspath = Task {
       millProjectModule("mill-contrib-proguard", repositoriesTask())
     }
 
     override def runClasspath: Target[Seq[PathRef]] =
-      T { super.runClasspath() ++ proguardContribClasspath() }
+      Task { super.runClasspath() ++ proguardContribClasspath() }
 
   }
 

--- a/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBModule.scala
+++ b/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBModule.scala
@@ -51,7 +51,7 @@ trait ScalaPBModule extends ScalaModule {
 
   def scalaPBProtocPath: T[Option[String]] = Task { None }
 
-  def scalaPBSources: T[Seq[PathRef]] = T.sources {
+  def scalaPBSources: T[Seq[PathRef]] = Task.Sources {
     millSourcePath / "protobuf"
   }
 
@@ -80,7 +80,7 @@ trait ScalaPBModule extends ScalaModule {
     )
   }
 
-  def scalaPBIncludePath: T[Seq[PathRef]] = T.sources { Seq.empty[PathRef] }
+  def scalaPBIncludePath: T[Seq[PathRef]] = Task.Sources { Seq.empty[PathRef] }
 
   private def scalaDepsPBIncludePath = if (scalaPBSearchDeps) Task { Seq(scalaPBUnpackProto()) }
   else Task { Seq.empty[PathRef] }
@@ -126,7 +126,7 @@ trait ScalaPBModule extends ScalaModule {
     )
   }
 
-  def compileScalaPB: T[PathRef] = T.persistent {
+  def compileScalaPB: T[PathRef] = Task.Persistent {
     ScalaPBWorkerApi.scalaPBWorker()
       .compile(
         scalaPBClasspath(),

--- a/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBModule.scala
+++ b/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBModule.scala
@@ -12,9 +12,9 @@ import scala.util.Using
 /** @see [[http://www.lihaoyi.com/mill/page/contrib-modules.html#scalapb ScalaPB Module]] */
 trait ScalaPBModule extends ScalaModule {
 
-  override def generatedSources = T { super.generatedSources() :+ compileScalaPB() }
+  override def generatedSources = Task { super.generatedSources() :+ compileScalaPB() }
 
-  override def ivyDeps = T {
+  override def ivyDeps = Task {
     super.ivyDeps() ++
       Agg(ivy"com.thesamet.scalapb::scalapb-runtime::${scalaPBVersion()}") ++
       (if (!scalaPBGrpc()) Agg()
@@ -23,16 +23,16 @@ trait ScalaPBModule extends ScalaModule {
 
   def scalaPBVersion: T[String]
 
-  def scalaPBFlatPackage: T[Boolean] = T { false }
+  def scalaPBFlatPackage: T[Boolean] = Task { false }
 
-  def scalaPBJavaConversions: T[Boolean] = T { false }
+  def scalaPBJavaConversions: T[Boolean] = Task { false }
 
-  def scalaPBGrpc: T[Boolean] = T { true }
+  def scalaPBGrpc: T[Boolean] = Task { true }
 
-  def scalaPBSingleLineToProtoString: T[Boolean] = T { false }
+  def scalaPBSingleLineToProtoString: T[Boolean] = Task { false }
 
   /** ScalaPB enables lenses by default, this option allows you to disable it. */
-  def scalaPBLenses: T[Boolean] = T { true }
+  def scalaPBLenses: T[Boolean] = Task { true }
 
   def scalaPBSearchDeps: Boolean = false
 
@@ -47,15 +47,15 @@ trait ScalaPBModule extends ScalaModule {
    *  @return a sequence of Strings representing the additional arguments to append
    *          (defaults to empty Seq[String]).
    */
-  def scalaPBAdditionalArgs: T[Seq[String]] = T { Seq.empty[String] }
+  def scalaPBAdditionalArgs: T[Seq[String]] = Task { Seq.empty[String] }
 
-  def scalaPBProtocPath: T[Option[String]] = T { None }
+  def scalaPBProtocPath: T[Option[String]] = Task { None }
 
   def scalaPBSources: T[Seq[PathRef]] = T.sources {
     millSourcePath / "protobuf"
   }
 
-  def scalaPBOptions: T[String] = T {
+  def scalaPBOptions: T[String] = Task {
     (
       (if (scalaPBFlatPackage()) Seq("flat_package") else Seq.empty) ++
         (if (scalaPBJavaConversions()) Seq("java_conversions") else Seq.empty) ++
@@ -72,7 +72,7 @@ trait ScalaPBModule extends ScalaModule {
     ).mkString(",")
   }
 
-  def scalaPBClasspath: T[Loose.Agg[PathRef]] = T {
+  def scalaPBClasspath: T[Loose.Agg[PathRef]] = Task {
     resolveDependencies(
       repositoriesTask(),
       Seq(ivy"com.thesamet.scalapb::scalapbc:${scalaPBVersion()}")
@@ -82,14 +82,14 @@ trait ScalaPBModule extends ScalaModule {
 
   def scalaPBIncludePath: T[Seq[PathRef]] = T.sources { Seq.empty[PathRef] }
 
-  private def scalaDepsPBIncludePath = if (scalaPBSearchDeps) T { Seq(scalaPBUnpackProto()) }
-  else T { Seq.empty[PathRef] }
+  private def scalaDepsPBIncludePath = if (scalaPBSearchDeps) Task { Seq(scalaPBUnpackProto()) }
+  else Task { Seq.empty[PathRef] }
 
-  def scalaPBProtoClasspath: T[Agg[PathRef]] = T {
+  def scalaPBProtoClasspath: T[Agg[PathRef]] = Task {
     defaultResolver().resolveDeps(transitiveCompileIvyDeps() ++ transitiveIvyDeps())
   }
 
-  def scalaPBUnpackProto: T[PathRef] = T {
+  def scalaPBUnpackProto: T[PathRef] = Task {
     val cp = scalaPBProtoClasspath()
     val dest = T.dest
     cp.iterator.foreach { ref =>
@@ -118,7 +118,7 @@ trait ScalaPBModule extends ScalaModule {
   /*
    * options passing to ScalaPBC **except** `--scala_out=...`, `--proto_path=source_parent` and `source`
    */
-  def scalaPBCompileOptions: T[Seq[String]] = T {
+  def scalaPBCompileOptions: T[Seq[String]] = Task {
     ScalaPBWorkerApi.scalaPBWorker().compileOptions(
       scalaPBProtocPath(),
       (scalaPBIncludePath() ++ scalaDepsPBIncludePath()).map(_.path),

--- a/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBWorker.scala
+++ b/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBWorker.scala
@@ -125,6 +125,6 @@ trait ScalaPBWorkerApi {
 }
 
 object ScalaPBWorkerApi extends ExternalModule {
-  def scalaPBWorker: Worker[ScalaPBWorker] = Task.worker { new ScalaPBWorker() }
+  def scalaPBWorker: Worker[ScalaPBWorker] = Task.Worker { new ScalaPBWorker() }
   lazy val millDiscover: Discover = Discover[this.type]
 }

--- a/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBWorker.scala
+++ b/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBWorker.scala
@@ -4,7 +4,6 @@ package contrib.scalapblib
 import java.io.File
 
 import mill.api.PathRef
-import mill.T
 import mill.define.{Discover, ExternalModule, Worker}
 
 class ScalaPBWorker extends AutoCloseable {
@@ -126,6 +125,6 @@ trait ScalaPBWorkerApi {
 }
 
 object ScalaPBWorkerApi extends ExternalModule {
-  def scalaPBWorker: Worker[ScalaPBWorker] = T.worker { new ScalaPBWorker() }
+  def scalaPBWorker: Worker[ScalaPBWorker] = Task.worker { new ScalaPBWorker() }
   lazy val millDiscover: Discover = Discover[this.type]
 }

--- a/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBWorker.scala
+++ b/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBWorker.scala
@@ -4,7 +4,7 @@ package contrib.scalapblib
 import java.io.File
 
 import mill.api.PathRef
-import mill.{T, Task}
+import mill.T
 import mill.define.{Discover, ExternalModule, Worker}
 
 class ScalaPBWorker extends AutoCloseable {

--- a/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBWorker.scala
+++ b/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBWorker.scala
@@ -4,7 +4,7 @@ package contrib.scalapblib
 import java.io.File
 
 import mill.api.PathRef
-import mill.T
+import mill.{T, Task}
 import mill.define.{Discover, ExternalModule, Worker}
 
 class ScalaPBWorker extends AutoCloseable {

--- a/contrib/scalapblib/test/src/mill/contrib/scalapblib/TutorialTests.scala
+++ b/contrib/scalapblib/test/src/mill/contrib/scalapblib/TutorialTests.scala
@@ -34,7 +34,7 @@ object TutorialTests extends TestSuite {
 
   object TutorialWithAdditionalArgs extends TutorialBase {
     object core extends TutorialModule {
-      override def scalaPBAdditionalArgs = T {
+      override def scalaPBAdditionalArgs = Task {
         Seq(
           "--additional-test=..."
         )

--- a/contrib/scalapblib/test/src/mill/contrib/scalapblib/TutorialTests.scala
+++ b/contrib/scalapblib/test/src/mill/contrib/scalapblib/TutorialTests.scala
@@ -44,7 +44,7 @@ object TutorialTests extends TestSuite {
 
   object TutorialWithSpecificSources extends TutorialBase {
     object core extends TutorialModule {
-      override def scalaPBSources: T[Seq[PathRef]] = T.sources {
+      override def scalaPBSources: T[Seq[PathRef]] = Task.Sources {
         millSourcePath / "protobuf/tutorial/Tutorial.proto"
       }
 

--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
@@ -64,7 +64,7 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
 
   private def isScala3: Task[Boolean] = T.task { ZincWorkerUtil.isScala3(outer.scalaVersion()) }
 
-  def scoverageRuntimeDeps: T[Agg[Dep]] = T {
+  def scoverageRuntimeDeps: T[Agg[Dep]] = Task {
     if (isScala3()) {
       Agg.empty
     } else {
@@ -72,7 +72,7 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
     }
   }
 
-  def scoveragePluginDeps: T[Agg[Dep]] = T {
+  def scoveragePluginDeps: T[Agg[Dep]] = Task {
     val sv = scoverageVersion()
     if (isScala3()) {
       Agg.empty
@@ -107,7 +107,7 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
     }
   }
 
-  private def scoverageReporterIvyDeps: T[Agg[Dep]] = T {
+  private def scoverageReporterIvyDeps: T[Agg[Dep]] = Task {
     checkVersions()
 
     val sv = scoverageVersion()
@@ -140,16 +140,16 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
     }
   }
 
-  def scoverageToolsClasspath: T[Agg[PathRef]] = T {
+  def scoverageToolsClasspath: T[Agg[PathRef]] = Task {
     scoverageReportWorkerClasspath() ++
       defaultResolver().resolveDeps(scoverageReporterIvyDeps())
   }
 
-  def scoverageClasspath: T[Agg[PathRef]] = T {
+  def scoverageClasspath: T[Agg[PathRef]] = Task {
     defaultResolver().resolveDeps(scoveragePluginDeps())
   }
 
-  def scoverageReportWorkerClasspath: T[Agg[PathRef]] = T {
+  def scoverageReportWorkerClasspath: T[Agg[PathRef]] = Task {
     val isScov2 = isScoverage2()
 
     val workerArtifact =
@@ -185,26 +185,26 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
     }
 
     override def compileResources: T[Seq[PathRef]] = outer.compileResources
-    override def generatedSources: Target[Seq[PathRef]] = T { outer.generatedSources() }
-    override def allSources: Target[Seq[PathRef]] = T { outer.allSources() }
+    override def generatedSources: Target[Seq[PathRef]] = Task { outer.generatedSources() }
+    override def allSources: Target[Seq[PathRef]] = Task { outer.allSources() }
     override def moduleDeps: Seq[JavaModule] = outer.moduleDeps
     override def compileModuleDeps: Seq[JavaModule] = outer.compileModuleDeps
     override def sources: T[Seq[PathRef]] = T.sources { outer.sources() }
     override def resources: T[Seq[PathRef]] = T.sources { outer.resources() }
-    override def scalaVersion = T { outer.scalaVersion() }
+    override def scalaVersion = Task { outer.scalaVersion() }
     override def repositoriesTask: Task[Seq[Repository]] = T.task { outer.repositoriesTask() }
-    override def compileIvyDeps: Target[Agg[Dep]] = T { outer.compileIvyDeps() }
+    override def compileIvyDeps: Target[Agg[Dep]] = Task { outer.compileIvyDeps() }
     override def ivyDeps: Target[Agg[Dep]] =
-      T { outer.ivyDeps() ++ outer.scoverageRuntimeDeps() }
-    override def unmanagedClasspath: Target[Agg[PathRef]] = T { outer.unmanagedClasspath() }
+      Task { outer.ivyDeps() ++ outer.scoverageRuntimeDeps() }
+    override def unmanagedClasspath: Target[Agg[PathRef]] = Task { outer.unmanagedClasspath() }
 
     /** Add the scoverage scalac plugin. */
     override def scalacPluginIvyDeps: Target[Loose.Agg[Dep]] =
-      T { outer.scalacPluginIvyDeps() ++ outer.scoveragePluginDeps() }
+      Task { outer.scalacPluginIvyDeps() ++ outer.scoveragePluginDeps() }
 
     /** Add the scoverage specific plugin settings (`dataDir`). */
     override def scalacOptions: Target[Seq[String]] =
-      T {
+      Task {
         val extras =
           if (isScala3()) {
             Seq(s"-coverage-out:${data().path.toIO.getPath()}")
@@ -232,7 +232,7 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
      * classes folder by the outer.scoverage classes folder and adding the
      * scoverage runtime dependency.
      */
-    override def runClasspath: T[Seq[PathRef]] = T {
+    override def runClasspath: T[Seq[PathRef]] = Task {
       val outerClassesPath = outer.compile().classes
       val outerScoverageClassesPath = outer.scoverage.compile().classes
       (super.runClasspath().map { path =>

--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
@@ -185,25 +185,25 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
     }
 
     override def compileResources: T[Seq[PathRef]] = outer.compileResources
-    override def generatedSources: Target[Seq[PathRef]] = Task { outer.generatedSources() }
-    override def allSources: Target[Seq[PathRef]] = Task { outer.allSources() }
+    override def generatedSources: T[Seq[PathRef]] = Task { outer.generatedSources() }
+    override def allSources: T[Seq[PathRef]] = Task { outer.allSources() }
     override def moduleDeps: Seq[JavaModule] = outer.moduleDeps
     override def compileModuleDeps: Seq[JavaModule] = outer.compileModuleDeps
     override def sources: T[Seq[PathRef]] = T.sources { outer.sources() }
     override def resources: T[Seq[PathRef]] = T.sources { outer.resources() }
     override def scalaVersion = Task { outer.scalaVersion() }
     override def repositoriesTask: Task[Seq[Repository]] = T.task { outer.repositoriesTask() }
-    override def compileIvyDeps: Target[Agg[Dep]] = Task { outer.compileIvyDeps() }
-    override def ivyDeps: Target[Agg[Dep]] =
+    override def compileIvyDeps: T[Agg[Dep]] = Task { outer.compileIvyDeps() }
+    override def ivyDeps: T[Agg[Dep]] =
       Task { outer.ivyDeps() ++ outer.scoverageRuntimeDeps() }
-    override def unmanagedClasspath: Target[Agg[PathRef]] = Task { outer.unmanagedClasspath() }
+    override def unmanagedClasspath: T[Agg[PathRef]] = Task { outer.unmanagedClasspath() }
 
     /** Add the scoverage scalac plugin. */
-    override def scalacPluginIvyDeps: Target[Loose.Agg[Dep]] =
+    override def scalacPluginIvyDeps: T[Loose.Agg[Dep]] =
       Task { outer.scalacPluginIvyDeps() ++ outer.scoveragePluginDeps() }
 
     /** Add the scoverage specific plugin settings (`dataDir`). */
-    override def scalacOptions: Target[Seq[String]] =
+    override def scalacOptions: T[Seq[String]] =
       Task {
         val extras =
           if (isScala3()) {

--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
@@ -60,9 +60,9 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
    */
   def scoverageVersion: T[String]
 
-  private def isScoverage2: Task[Boolean] = T.task { scoverageVersion().startsWith("2.") }
+  private def isScoverage2: Task[Boolean] = Task.Anon { scoverageVersion().startsWith("2.") }
 
-  private def isScala3: Task[Boolean] = T.task { ZincWorkerUtil.isScala3(outer.scalaVersion()) }
+  private def isScala3: Task[Boolean] = Task.Anon { ZincWorkerUtil.isScala3(outer.scalaVersion()) }
 
   def scoverageRuntimeDeps: T[Agg[Dep]] = Task {
     if (isScala3()) {
@@ -90,7 +90,7 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
     }
   }
 
-  private def checkVersions = T.task {
+  private def checkVersions = Task.Anon {
     val sv = scalaVersion()
     val isSov2 = scoverageVersion().startsWith("2.")
     (sv.split('.'), isSov2) match {
@@ -168,7 +168,7 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
 
   trait ScoverageData extends ScalaModule {
 
-    def doReport(reportType: ReportType): Task[Unit] = T.task {
+    def doReport(reportType: ReportType): Task[Unit] = Task.Anon {
       ScoverageReportWorker
         .scoverageReportWorker()
         .bridge(scoverageToolsClasspath())
@@ -179,7 +179,7 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
      * The persistent data dir used to store scoverage coverage data.
      * Use to store coverage data at compile-time and by the various report targets.
      */
-    def data: T[PathRef] = T.persistent {
+    def data: T[PathRef] = Task.Persistent {
       // via the persistent target, we ensure, the dest dir doesn't get cleared
       PathRef(T.dest)
     }
@@ -189,10 +189,10 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
     override def allSources: T[Seq[PathRef]] = Task { outer.allSources() }
     override def moduleDeps: Seq[JavaModule] = outer.moduleDeps
     override def compileModuleDeps: Seq[JavaModule] = outer.compileModuleDeps
-    override def sources: T[Seq[PathRef]] = T.sources { outer.sources() }
-    override def resources: T[Seq[PathRef]] = T.sources { outer.resources() }
+    override def sources: T[Seq[PathRef]] = Task.Sources { outer.sources() }
+    override def resources: T[Seq[PathRef]] = Task.Sources { outer.resources() }
     override def scalaVersion = Task { outer.scalaVersion() }
-    override def repositoriesTask: Task[Seq[Repository]] = T.task { outer.repositoriesTask() }
+    override def repositoriesTask: Task[Seq[Repository]] = Task.Anon { outer.repositoriesTask() }
     override def compileIvyDeps: T[Agg[Dep]] = Task { outer.compileIvyDeps() }
     override def ivyDeps: T[Agg[Dep]] =
       Task { outer.ivyDeps() ++ outer.scoverageRuntimeDeps() }
@@ -217,10 +217,10 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
         outer.scalacOptions() ++ extras
       }
 
-    def htmlReport(): Command[Unit] = T.command { doReport(ReportType.Html)() }
-    def xmlReport(): Command[Unit] = T.command { doReport(ReportType.Xml)() }
-    def xmlCoberturaReport(): Command[Unit] = T.command { doReport(ReportType.XmlCobertura)() }
-    def consoleReport(): Command[Unit] = T.command { doReport(ReportType.Console)() }
+    def htmlReport(): Command[Unit] = Task.Command { doReport(ReportType.Html)() }
+    def xmlReport(): Command[Unit] = Task.Command { doReport(ReportType.Xml)() }
+    def xmlCoberturaReport(): Command[Unit] = Task.Command { doReport(ReportType.XmlCobertura)() }
+    def consoleReport(): Command[Unit] = Task.Command { doReport(ReportType.Console)() }
 
     override def skipIdea = true
   }

--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageReport.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageReport.scala
@@ -53,7 +53,7 @@ trait ScoverageReport extends Module {
       evaluator: Evaluator,
       sources: String = "__.allSources",
       dataTargets: String = "__.scoverage.data"
-  ): Command[PathRef] = T.command {
+  ): Command[PathRef] = Task.Command {
     reportTask(evaluator, ReportType.Html, sources, dataTargets)()
   }
 
@@ -62,7 +62,7 @@ trait ScoverageReport extends Module {
       evaluator: Evaluator,
       sources: String = "__.allSources",
       dataTargets: String = "__.scoverage.data"
-  ): Command[PathRef] = T.command {
+  ): Command[PathRef] = Task.Command {
     reportTask(evaluator, ReportType.Xml, sources, dataTargets)()
   }
 
@@ -71,7 +71,7 @@ trait ScoverageReport extends Module {
       evaluator: Evaluator,
       sources: String = "__.allSources",
       dataTargets: String = "__.scoverage.data"
-  ): Command[PathRef] = T.command {
+  ): Command[PathRef] = Task.Command {
     reportTask(evaluator, ReportType.XmlCobertura, sources, dataTargets)()
   }
 
@@ -80,7 +80,7 @@ trait ScoverageReport extends Module {
       evaluator: Evaluator,
       sources: String = "__.allSources",
       dataTargets: String = "__.scoverage.data"
-  ): Command[PathRef] = T.command {
+  ): Command[PathRef] = Task.Command {
     reportTask(evaluator, ReportType.Console, sources, dataTargets)()
   }
 
@@ -107,7 +107,7 @@ trait ScoverageReport extends Module {
       case Right(tasks) => tasks.asInstanceOf[Seq[Task[PathRef]]]
     }
 
-    T.task {
+    Task.Anon {
       val sourcePaths: Seq[Path] = T.sequence(sourcesTasks)().flatten.map(_.path)
       val dataPaths: Seq[Path] = T.sequence(dataTasks)().map(_.path)
       scoverageReportWorkerModule

--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageReportWorker.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageReportWorker.scala
@@ -39,6 +39,6 @@ class ScoverageReportWorker extends AutoCloseable {
 object ScoverageReportWorker extends ExternalModule {
 
   def scoverageReportWorker: Worker[ScoverageReportWorker] =
-    Task.worker { new ScoverageReportWorker() }
+    Task.Worker { new ScoverageReportWorker() }
   lazy val millDiscover: Discover = Discover[this.type]
 }

--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageReportWorker.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageReportWorker.scala
@@ -1,6 +1,6 @@
 package mill.contrib.scoverage
 
-import mill.{Agg, T}
+import mill.{Agg, T, Task}
 import mill.api.{ClassLoader, Ctx, PathRef}
 import mill.contrib.scoverage.api.ScoverageReportWorkerApi
 import mill.define.{Discover, ExternalModule, Worker}

--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageReportWorker.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageReportWorker.scala
@@ -1,6 +1,6 @@
 package mill.contrib.scoverage
 
-import mill.{Agg, T, Task}
+import mill.{Agg, T}
 import mill.api.{ClassLoader, Ctx, PathRef}
 import mill.contrib.scoverage.api.ScoverageReportWorkerApi
 import mill.define.{Discover, ExternalModule, Worker}

--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageReportWorker.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageReportWorker.scala
@@ -1,6 +1,6 @@
 package mill.contrib.scoverage
 
-import mill.{Agg, T}
+import mill.{Agg, Task}
 import mill.api.{ClassLoader, Ctx, PathRef}
 import mill.contrib.scoverage.api.ScoverageReportWorkerApi
 import mill.define.{Discover, ExternalModule, Worker}
@@ -39,6 +39,6 @@ class ScoverageReportWorker extends AutoCloseable {
 object ScoverageReportWorker extends ExternalModule {
 
   def scoverageReportWorker: Worker[ScoverageReportWorker] =
-    T.worker { new ScoverageReportWorker() }
+    Task.worker { new ScoverageReportWorker() }
   lazy val millDiscover: Discover = Discover[this.type]
 }

--- a/contrib/sonatypecentral/src/mill/contrib/sonatypecentral/SonatypeCentralPublishModule.scala
+++ b/contrib/sonatypecentral/src/mill/contrib/sonatypecentral/SonatypeCentralPublishModule.scala
@@ -21,15 +21,15 @@ import mill.scalalib.publish.SonatypeHelpers.{
 }
 
 trait SonatypeCentralPublishModule extends PublishModule {
-  def sonatypeCentralGpgArgs: T[String] = T { defaultGpgArgs.mkString(",") }
+  def sonatypeCentralGpgArgs: T[String] = Task { defaultGpgArgs.mkString(",") }
 
-  def sonatypeCentralConnectTimeout: T[Int] = T { defaultConnectTimeout }
+  def sonatypeCentralConnectTimeout: T[Int] = Task { defaultConnectTimeout }
 
-  def sonatypeCentralReadTimeout: T[Int] = T { defaultReadTimeout }
+  def sonatypeCentralReadTimeout: T[Int] = Task { defaultReadTimeout }
 
-  def sonatypeCentralAwaitTimeout: T[Int] = T { defaultAwaitTimeout }
+  def sonatypeCentralAwaitTimeout: T[Int] = Task { defaultAwaitTimeout }
 
-  def sonatypeCentralShouldRelease: T[Boolean] = T { true }
+  def sonatypeCentralShouldRelease: T[Boolean] = Task { true }
 
   def publishSonatypeCentral(
       username: String = defaultCredentials,

--- a/contrib/sonatypecentral/src/mill/contrib/sonatypecentral/SonatypeCentralPublishModule.scala
+++ b/contrib/sonatypecentral/src/mill/contrib/sonatypecentral/SonatypeCentralPublishModule.scala
@@ -35,7 +35,7 @@ trait SonatypeCentralPublishModule extends PublishModule {
       username: String = defaultCredentials,
       password: String = defaultCredentials
   ): define.Command[Unit] =
-    T.command {
+    Task.Command {
       val publishData = publishArtifacts()
       val fileMapping = publishData.withConcretePath._1
       val artifact = publishData.meta
@@ -80,7 +80,7 @@ object SonatypeCentralPublishModule extends ExternalModule {
       connectTimeout: Int = defaultConnectTimeout,
       awaitTimeout: Int = defaultAwaitTimeout,
       bundleName: String = ""
-  ): Command[Unit] = T.command {
+  ): Command[Unit] = Task.Command {
 
     val artifacts: Seq[(Seq[(os.Path, String)], Artifact)] =
       T.sequence(publishArtifacts.value)().map {
@@ -122,7 +122,7 @@ object SonatypeCentralPublishModule extends ExternalModule {
       credentialParameterValue: String,
       credentialName: String,
       envVariableName: String
-  ): Task[String] = T.task {
+  ): Task[String] = Task.Anon {
     if (credentialParameterValue.nonEmpty) {
       Result.Success(credentialParameterValue)
     } else {
@@ -141,7 +141,7 @@ object SonatypeCentralPublishModule extends ExternalModule {
   private def getSonatypeCredentials(
       usernameParameterValue: String,
       passwordParameterValue: String
-  ): Task[SonatypeCredentials] = T.task {
+  ): Task[SonatypeCredentials] = Task.Anon {
     val username =
       getSonatypeCredential(usernameParameterValue, "username", USERNAME_ENV_VARIABLE_NAME)()
     val password =

--- a/contrib/testng/test/src/mill/testng/TestNGTests.scala
+++ b/contrib/testng/test/src/mill/testng/TestNGTests.scala
@@ -13,7 +13,7 @@ object TestNGTests extends TestSuite {
   object demo extends TestBaseModule with JavaModule {
 
     object test extends JavaTests {
-      def testngClasspath = T {
+      def testngClasspath = Task {
         millProjectModule(
           "mill-contrib-testng",
           repositoriesTask(),
@@ -22,15 +22,15 @@ object TestNGTests extends TestSuite {
       }
 
       override def runClasspath: Target[Seq[PathRef]] =
-        T { super.runClasspath() ++ testngClasspath() }
-      override def ivyDeps = T {
+        Task { super.runClasspath() ++ testngClasspath() }
+      override def ivyDeps = Task {
         super.ivyDeps() ++
           Agg(
             ivy"org.testng:testng:6.11",
             ivy"de.tototec:de.tobiasroeser.lambdatest:0.8.0"
           )
       }
-      override def testFramework = T {
+      override def testFramework = Task {
         "mill.testng.TestNGFramework"
       }
     }

--- a/contrib/testng/test/src/mill/testng/TestNGTests.scala
+++ b/contrib/testng/test/src/mill/testng/TestNGTests.scala
@@ -21,7 +21,7 @@ object TestNGTests extends TestSuite {
         )
       }
 
-      override def runClasspath: Target[Seq[PathRef]] =
+      override def runClasspath: T[Seq[PathRef]] =
         Task { super.runClasspath() ++ testngClasspath() }
       override def ivyDeps = Task {
         super.ivyDeps() ++

--- a/contrib/twirllib/src/mill/twirllib/TwirlModule.scala
+++ b/contrib/twirllib/src/mill/twirllib/TwirlModule.scala
@@ -18,7 +18,7 @@ trait TwirlModule extends mill.Module { twirlModule =>
    * The Scala version matching the twirl version.
    * @since Mill after 0.10.5
    */
-  def twirlScalaVersion: T[String] = T {
+  def twirlScalaVersion: T[String] = Task {
     twirlVersion() match {
       case s"1.$minor.$_" if minor.toIntOption.exists(_ < 4) => BuildInfo.workerScalaVersion212
       case _ => BuildInfo.scalaVersion
@@ -41,7 +41,7 @@ trait TwirlModule extends mill.Module { twirlModule =>
   /**
    * @since Mill after 0.10.5
    */
-  def twirlIvyDeps: T[Agg[Dep]] = T {
+  def twirlIvyDeps: T[Agg[Dep]] = Task {
     Agg(
       if (twirlVersion().startsWith("1."))
         ivy"com.typesafe.play::twirl-compiler:${twirlVersion()}"
@@ -72,11 +72,11 @@ trait TwirlModule extends mill.Module { twirlModule =>
    */
   lazy val twirlCoursierResolver: TwirlResolver = new TwirlResolver {}
 
-  def twirlClasspath: T[Loose.Agg[PathRef]] = T {
+  def twirlClasspath: T[Loose.Agg[PathRef]] = Task {
     twirlCoursierResolver.defaultResolver().resolveDeps(twirlIvyDeps())
   }
 
-  def twirlImports: T[Seq[String]] = T {
+  def twirlImports: T[Seq[String]] = Task {
     TwirlWorkerApi.twirlWorker.defaultImports(twirlClasspath())
   }
 

--- a/contrib/twirllib/src/mill/twirllib/TwirlModule.scala
+++ b/contrib/twirllib/src/mill/twirllib/TwirlModule.scala
@@ -25,7 +25,7 @@ trait TwirlModule extends mill.Module { twirlModule =>
     }
   }
 
-  def twirlSources: T[Seq[PathRef]] = T.sources {
+  def twirlSources: T[Seq[PathRef]] = Task.Sources {
     millSourcePath / "views"
   }
 
@@ -57,7 +57,7 @@ trait TwirlModule extends mill.Module { twirlModule =>
    * @since Mill after 0.10.5
    */
   trait TwirlResolver extends CoursierModule {
-    override def resolveCoursierDependency: Task[Dep => Dependency] = T.task { d: Dep =>
+    override def resolveCoursierDependency: Task[Dep => Dependency] = Task.Anon { d: Dep =>
       Lib.depToDependency(d, twirlScalaVersion())
     }
 
@@ -88,7 +88,7 @@ trait TwirlModule extends mill.Module { twirlModule =>
 
   def twirlInclusiveDot: Boolean = false
 
-  def compileTwirl: T[mill.scalalib.api.CompilationResult] = T.persistent {
+  def compileTwirl: T[mill.scalalib.api.CompilationResult] = Task.Persistent {
     TwirlWorkerApi.twirlWorker
       .compile(
         twirlClasspath(),

--- a/contrib/versionfile/src/mill/contrib/versionfile/VersionFileModule.scala
+++ b/contrib/versionfile/src/mill/contrib/versionfile/VersionFileModule.scala
@@ -8,10 +8,10 @@ trait VersionFileModule extends Module {
   def versionFile: T[PathRef] = T.source(millSourcePath / "version")
 
   /** The current version. */
-  def currentVersion: T[Version] = T { Version.of(os.read(versionFile().path).trim) }
+  def currentVersion: T[Version] = Task { Version.of(os.read(versionFile().path).trim) }
 
   /** The release version. */
-  def releaseVersion: T[Version] = T { currentVersion().asRelease }
+  def releaseVersion: T[Version] = Task { currentVersion().asRelease }
 
   /** The next snapshot version. */
   def nextVersion(bump: String): Task[Version] = T.task { currentVersion().asSnapshot.bump(bump) }
@@ -43,7 +43,7 @@ trait VersionFileModule extends Module {
     )
 
   /** Procs for tagging current version and committing changes. */
-  def tag = T {
+  def tag = Task {
     Seq(
       os.proc("git", "commit", "-am", generateCommitMessage(currentVersion())),
       os.proc("git", "tag", currentVersion().toString)
@@ -51,7 +51,7 @@ trait VersionFileModule extends Module {
   }
 
   /** Procs for committing changes and pushing. */
-  def push = T {
+  def push = Task {
     Seq(
       os.proc("git", "commit", "-am", generateCommitMessage(currentVersion())),
       os.proc("git", "push", "origin", "master", "--tags")

--- a/contrib/versionfile/test/src/mill/contrib/versionfile/VersionFileModuleTests.scala
+++ b/contrib/versionfile/test/src/mill/contrib/versionfile/VersionFileModuleTests.scala
@@ -1,6 +1,6 @@
 package mill.contrib.versionfile
 
-import mill.T
+import mill.{T, Task}
 import mill.testkit.{UnitTester, TestBaseModule}
 import utest.{TestSuite, Tests, assert, assertMatch, test}
 import utest.framework.TestPath

--- a/contrib/versionfile/test/src/mill/contrib/versionfile/VersionFileModuleTests.scala
+++ b/contrib/versionfile/test/src/mill/contrib/versionfile/VersionFileModuleTests.scala
@@ -108,7 +108,7 @@ object VersionFileModuleTests extends TestSuite {
 
       test("setVersion") - workspaceTest(versions: _*) { eval =>
         val expected = Version.Release(1, 2, 4)
-        eval(TestModule.versionFile.setVersion(T.task(expected)))
+        eval(TestModule.versionFile.setVersion(Task.Anon(expected)))
         val Right(actual) = eval(TestModule.versionFile.currentVersion)
         assert(actual.value == expected)
       }

--- a/docs/modules/ROOT/pages/Case_Study_Mill_vs_Maven.adoc
+++ b/docs/modules/ROOT/pages/Case_Study_Mill_vs_Maven.adoc
@@ -407,7 +407,7 @@ import $ivy.`ant:ant-optional:1.5.3-1`
 
 object common extends NettyModule{
   ...
-  def script = T.source(millSourcePath / "src" / "main" / "script")
+  def script = Task.Source(millSourcePath / "src" / "main" / "script")
   def generatedSources0 = T{
     val shell = new groovy.lang.GroovyShell()
     val context = new java.util.HashMap[String, Object]
@@ -523,8 +523,8 @@ with the `make` command essentially being a bash script wrapped in layers of XML
 In contrast, the Mill configuration for this logic is as follows:
 
 ```scala
-def makefile = T.source(millSourcePath / "Makefile")
-def cSources = T.source(millSourcePath / "src" / "main" / "c")
+def makefile = Task.Source(millSourcePath / "Makefile")
+def cSources = Task.Source(millSourcePath / "src" / "main" / "c")
 def cHeaders = T{
   for(p <- os.walk(cSources().path) if p.ext == "h"){
     os.copy(p, T.dest / p.relativeTo(cSources().path), createFolders = true)
@@ -537,7 +537,7 @@ def make = T{
   os.copy(cSources().path, T.dest / "src" / "main" / "c", createFolders = true)
 
   val Seq(sourceJar) = resolveDeps(
-    deps = T.task(Agg(ivy"io.netty:netty-jni-util:0.0.9.Final").map(bindDependency())),
+    deps = Task.Anon(Agg(ivy"io.netty:netty-jni-util:0.0.9.Final").map(bindDependency())),
     sources = true
   )().toSeq
 

--- a/docs/modules/ROOT/pages/Mill_Design_Principles.adoc
+++ b/docs/modules/ROOT/pages/Mill_Design_Principles.adoc
@@ -15,7 +15,7 @@ Mill:
 === Dependency graph first
 
 Mill's most important abstraction is the dependency graph of ``Task``s.
-Constructed using the `T {...}` `T.task {...}` `T.command {...}` syntax, these
+Constructed using the `T {...}` `Task.Anon {...}` `Task.Command {...}` syntax, these
 track the dependencies between steps of a build, so those steps can be executed
 in the correct order, queried, or parallelized.
 
@@ -116,13 +116,13 @@ sorts of useful operations on the graph before running it:
  with an exception
 
 In order to avoid making people using `.map` and `.zip` all over the place when
-defining their ``Task``s, we use the `T {...}`/`T.task {...}`/`T.command {...}`
+defining their ``Task``s, we use the `T {...}`/`Task.Anon {...}`/`Task.Command {...}`
 macros which allow you to use `Task#apply()` within the block to "extract" a
 value.
 
 [source,scala]
 ----
-def test() = T.command {
+def test() = Task.Command {
   TestRunner.apply(
    "mill.UTestFramework",
    runDepClasspath().map(_.path) :+ compile().path,
@@ -136,7 +136,7 @@ This is roughly equivalent to the following:
 
 [source,scala]
 ----
-def test() = T.command { T.zipMap(runDepClasspath, compile, compile) { 
+def test() = Task.Command { T.zipMap(runDepClasspath, compile, compile) {
   (runDepClasspath1, compile2, compile3) =>
   TestRunner.apply(
     "mill.UTestFramework",

--- a/docs/modules/ROOT/pages/Modules.adoc
+++ b/docs/modules/ROOT/pages/Modules.adoc
@@ -35,7 +35,7 @@ import mill._
 
 object Bar extends mill.define.ExternalModule {
   def baz = T { 1 }
-  def qux() = T.command { println(baz() + 1) }
+  def qux() = Task.Command { println(baz() + 1) }
 
   lazy val millDiscover = mill.define.Discover[this.type]
 }
@@ -56,4 +56,4 @@ that is shared by the entire build: for example,
 `mill.scalalib.ZincWorkerApi/zincWorker` provides a shared Scala compilation
 service & cache that is shared between all ``ScalaModule``s, and
 `mill.scalalib.GenIdea/idea` lets you generate IntelliJ projects without
-needing to define your own `T.command` in your `build.mill` file
+needing to define your own `Task.Command` in your `build.mill` file

--- a/docs/modules/ROOT/pages/The_Mill_Evaluation_Model.adoc
+++ b/docs/modules/ROOT/pages/The_Mill_Evaluation_Model.adoc
@@ -76,7 +76,7 @@ the overall workflow remains fast even for large projects:
       allowing for finer-grained caching than Mill's default target-by-target
       caching and invalidation
 
-    * xref:Tasks.adoc#_workers[Task.worker]s are kept in-memory between runs where possible, and only
+    * xref:Tasks.adoc#_workers[Task.Worker]s are kept in-memory between runs where possible, and only
       invalidated if their input ``Task``s change as well.
 
     * ``Task``s in general are invalidated if the code they depend on changes,

--- a/docs/modules/ROOT/pages/The_Mill_Evaluation_Model.adoc
+++ b/docs/modules/ROOT/pages/The_Mill_Evaluation_Model.adoc
@@ -72,11 +72,11 @@ the overall workflow remains fast even for large projects:
     * xref:Tasks.adoc#_targets[Target]s only re-evaluate if their input ``Task``s
      change.
 
-    * xref:Tasks.adoc#_persistent_targets[T.persistent]s preserve the `T.dest` folder on disk between runs,
+    * xref:Tasks.adoc#_persistent_targets[Task.Persistent]s preserve the `T.dest` folder on disk between runs,
       allowing for finer-grained caching than Mill's default target-by-target
       caching and invalidation
 
-    * xref:Tasks.adoc#_workers[T.worker]s are kept in-memory between runs where possible, and only
+    * xref:Tasks.adoc#_workers[Task.worker]s are kept in-memory between runs where possible, and only
       invalidated if their input ``Task``s change as well.
 
     * ``Task``s in general are invalidated if the code they depend on changes,

--- a/docs/modules/ROOT/pages/Thirdparty_Plugins.adoc
+++ b/docs/modules/ROOT/pages/Thirdparty_Plugins.adoc
@@ -63,7 +63,7 @@ import $ivy.`net.mlbox::mill-antlr:0.1.0`
 import net.mlbox.millantlr.AntlrModule
 
 object foo extends ScalaModule with AntlrModule {
-  override def antlrGrammarSources = T.sources {
+  override def antlrGrammarSources = Task.Sources {
     Seq(os.pwd/"someGrammar.g4").map(PathRef(_))
   }
 }

--- a/example/depth/cross/1-simple/build.mill
+++ b/example/depth/cross/1-simple/build.mill
@@ -6,7 +6,7 @@ object foo extends Cross[FooModule]("2.10", "2.11", "2.12")
 trait FooModule extends Cross.Module[String] {
   def suffix = Task { "_" + crossValue }
   def bigSuffix = Task { "[[[" + suffix() + "]]]" }
-  def sources = T.sources(millSourcePath)
+  def sources = Task.sources(millSourcePath)
 }
 
 // [graphviz]

--- a/example/depth/cross/1-simple/build.mill
+++ b/example/depth/cross/1-simple/build.mill
@@ -6,7 +6,7 @@ object foo extends Cross[FooModule]("2.10", "2.11", "2.12")
 trait FooModule extends Cross.Module[String] {
   def suffix = Task { "_" + crossValue }
   def bigSuffix = Task { "[[[" + suffix() + "]]]" }
-  def sources = Task.sources(millSourcePath)
+  def sources = Task.Sources(millSourcePath)
 }
 
 // [graphviz]

--- a/example/depth/cross/1-simple/build.mill
+++ b/example/depth/cross/1-simple/build.mill
@@ -4,8 +4,8 @@ import mill._
 
 object foo extends Cross[FooModule]("2.10", "2.11", "2.12")
 trait FooModule extends Cross.Module[String] {
-  def suffix = T { "_" + crossValue }
-  def bigSuffix = T { "[[[" + suffix() + "]]]" }
+  def suffix = Task { "_" + crossValue }
+  def bigSuffix = Task { "[[[" + suffix() + "]]]" }
   def sources = T.sources(millSourcePath)
 }
 

--- a/example/depth/cross/10-static-blog/build.mill
+++ b/example/depth/cross/10-static-blog/build.mill
@@ -67,7 +67,7 @@ def index = T{
 // Lastly we copy the individual post HTML files and the `index.html` file
 // into a single target's `.dest` folder, and return it:
 
-def dist = T {
+def dist = Task {
   for (post <- T.traverse(post.crossModules)(_.render)()) {
     os.copy(post.path, T.dest / "post" / post.path.last, createFolders = true)
   }

--- a/example/depth/cross/10-static-blog/build.mill
+++ b/example/depth/cross/10-static-blog/build.mill
@@ -26,7 +26,7 @@ val posts = interp.watchValue {
 
 object post extends Cross[PostModule](posts)
 trait PostModule extends Cross.Module[String]{
-  def source = Task.source(millSourcePath / crossValue)
+  def source = Task.Source(millSourcePath / crossValue)
   def render = T{
     val doc = Parser.builder().build().parse(os.read(source().path))
     val title = mdNameToTitle(crossValue)
@@ -46,11 +46,11 @@ trait PostModule extends Cross.Module[String]{
 
 // The last page we need to generate is the index page, listing out the various
 // blog posts and providing links so we can navigate into them. To do this, we
-// need to wrap the `posts` value in a `Task.input`, as it can change depending on
+// need to wrap the `posts` value in a `Task.Input`, as it can change depending on
 // what `os.list` finds on disk. After that, it's straightforward to render the
 // `index.html` file we want:
 
-def postsInput = Task.input{ posts }
+def postsInput = Task.Input{ posts }
 
 def renderIndexEntry(mdName: String) = {
   h2(a(mdNameToTitle(mdName), href := ("post/" + mdNameToHtml(mdName))))

--- a/example/depth/cross/10-static-blog/build.mill
+++ b/example/depth/cross/10-static-blog/build.mill
@@ -26,7 +26,7 @@ val posts = interp.watchValue {
 
 object post extends Cross[PostModule](posts)
 trait PostModule extends Cross.Module[String]{
-  def source = T.source(millSourcePath / crossValue)
+  def source = Task.source(millSourcePath / crossValue)
   def render = T{
     val doc = Parser.builder().build().parse(os.read(source().path))
     val title = mdNameToTitle(crossValue)
@@ -39,18 +39,18 @@ trait PostModule extends Cross.Module[String]{
       )
     )
 
-    os.write(T.dest /  mdNameToHtml(crossValue), rendered)
-    PathRef(T.dest / mdNameToHtml(crossValue))
+    os.write(Task.dest /  mdNameToHtml(crossValue), rendered)
+    PathRef(Task.dest / mdNameToHtml(crossValue))
   }
 }
 
 // The last page we need to generate is the index page, listing out the various
 // blog posts and providing links so we can navigate into them. To do this, we
-// need to wrap the `posts` value in a `T.input`, as it can change depending on
+// need to wrap the `posts` value in a `Task.input`, as it can change depending on
 // what `os.list` finds on disk. After that, it's straightforward to render the
 // `index.html` file we want:
 
-def postsInput = T.input{ posts }
+def postsInput = Task.input{ posts }
 
 def renderIndexEntry(mdName: String) = {
   h2(a(mdNameToTitle(mdName), href := ("post/" + mdNameToHtml(mdName))))
@@ -60,19 +60,19 @@ def index = T{
   val rendered = doctype("html")(
     html(body(h1("Blog"), postsInput().map(renderIndexEntry)))
   )
-  os.write(T.dest / "index.html", rendered)
-  PathRef(T.dest / "index.html")
+  os.write(Task.dest / "index.html", rendered)
+  PathRef(Task.dest / "index.html")
 }
 
 // Lastly we copy the individual post HTML files and the `index.html` file
 // into a single target's `.dest` folder, and return it:
 
 def dist = Task {
-  for (post <- T.traverse(post.crossModules)(_.render)()) {
-    os.copy(post.path, T.dest / "post" / post.path.last, createFolders = true)
+  for (post <- Task.traverse(post.crossModules)(_.render)()) {
+    os.copy(post.path, Task.dest / "post" / post.path.last, createFolders = true)
   }
-  os.copy(index().path, T.dest / "index.html")
-  PathRef(T.dest)
+  os.copy(index().path, Task.dest / "index.html")
+  PathRef(Task.dest)
 }
 
 // Now, you can run `mill dist` to generate the blog:

--- a/example/depth/cross/11-default-cross-module/build.mill
+++ b/example/depth/cross/11-default-cross-module/build.mill
@@ -4,7 +4,7 @@ import mill._
 object foo extends Cross[FooModule]("2.10", "2.11", "2.12")
 
 trait FooModule extends Cross.Module[String] {
-  def suffix = T { "_" + crossValue }
+  def suffix = Task { "_" + crossValue }
 }
 
 object bar extends Cross[FooModule]("2.10", "2.11", "2.12") {

--- a/example/depth/cross/2-cross-source-path/build.mill
+++ b/example/depth/cross/2-cross-source-path/build.mill
@@ -6,7 +6,7 @@ import mill._
 object foo extends Cross[FooModule]("2.10", "2.11", "2.12")
 trait FooModule extends Cross.Module[String] {
   def millSourcePath = super.millSourcePath / crossValue
-  def sources = Task.sources(millSourcePath)
+  def sources = Task.Sources(millSourcePath)
 }
 
 // By default, cross modules do not include the cross key as part of the

--- a/example/depth/cross/2-cross-source-path/build.mill
+++ b/example/depth/cross/2-cross-source-path/build.mill
@@ -6,7 +6,7 @@ import mill._
 object foo extends Cross[FooModule]("2.10", "2.11", "2.12")
 trait FooModule extends Cross.Module[String] {
   def millSourcePath = super.millSourcePath / crossValue
-  def sources = T.sources(millSourcePath)
+  def sources = Task.sources(millSourcePath)
 }
 
 // By default, cross modules do not include the cross key as part of the

--- a/example/depth/cross/3-outside-dependency/build.mill
+++ b/example/depth/cross/3-outside-dependency/build.mill
@@ -4,12 +4,12 @@ import mill._
 
 object foo extends Cross[FooModule]("2.10", "2.11", "2.12")
 trait FooModule extends Cross.Module[String] {
-  def suffix = T { "_" + crossValue }
+  def suffix = Task { "_" + crossValue }
 }
 
-def bar = T { s"hello ${foo("2.10").suffix()}" }
+def bar = Task { s"hello ${foo("2.10").suffix()}" }
 
-def qux = T { s"hello ${foo("2.10").suffix()} world ${foo("2.12").suffix()}" }
+def qux = Task { s"hello ${foo("2.10").suffix()} world ${foo("2.12").suffix()}" }
 
 // [graphviz]
 // ....

--- a/example/depth/cross/4-cross-dependencies/build.mill
+++ b/example/depth/cross/4-cross-dependencies/build.mill
@@ -5,12 +5,12 @@ import mill._
 
 object foo extends mill.Cross[FooModule]("2.10", "2.11", "2.12")
 trait FooModule extends Cross.Module[String] {
-  def suffix = T { "_" + crossValue }
+  def suffix = Task { "_" + crossValue }
 }
 
 object bar extends mill.Cross[BarModule]("2.10", "2.11", "2.12")
 trait BarModule extends Cross.Module[String] {
-  def bigSuffix = T { "[[[" + foo(crossValue).suffix() + "]]]" }
+  def bigSuffix = Task { "[[[" + foo(crossValue).suffix() + "]]]" }
 }
 
 // [graphviz]

--- a/example/depth/cross/5-multiple-cross-axes/build.mill
+++ b/example/depth/cross/5-multiple-cross-axes/build.mill
@@ -12,10 +12,10 @@ val crossMatrix = for {
 object foo extends mill.Cross[FooModule](crossMatrix)
 trait FooModule extends Cross.Module2[String, String] {
   val (crossVersion, platform) = (crossValue, crossValue2)
-  def suffix = T { "_" + crossVersion + "_" + platform }
+  def suffix = Task { "_" + crossVersion + "_" + platform }
 }
 
-def bar = T { s"hello ${foo("2.10", "jvm").suffix()}" }
+def bar = Task { s"hello ${foo("2.10", "jvm").suffix()}" }
 
 // [graphviz]
 // ....

--- a/example/depth/cross/6-axes-extension/build.mill
+++ b/example/depth/cross/6-axes-extension/build.mill
@@ -5,13 +5,13 @@ import mill._
 
 object foo extends Cross[FooModule]("a", "b")
 trait FooModule extends Cross.Module[String] {
-  def param1 = T { "Param Value: " + crossValue }
+  def param1 = Task { "Param Value: " + crossValue }
 }
 
 object foo2 extends Cross[FooModule2](("a", 1), ("b", 2))
 trait FooModule2 extends Cross.Module2[String, Int] {
-  def param1 = T { "Param Value: " + crossValue }
-  def param2 = T { "Param Value: " + crossValue2 }
+  def param1 = Task { "Param Value: " + crossValue }
+  def param2 = Task { "Param Value: " + crossValue2 }
 }
 
 object foo3 extends Cross[FooModule3](("a", 1, true), ("b", 2, false))

--- a/example/depth/cross/7-inner-cross-module/build.mill
+++ b/example/depth/cross/7-inner-cross-module/build.mill
@@ -4,7 +4,7 @@ import mill._
 trait MyModule extends Module{
   def crossValue: String
   def name: T[String]
-  def param = T { name() + " Param Value: " + crossValue }
+  def param = Task { name() + " Param Value: " + crossValue }
 }
 
 object foo extends Cross[FooModule]("a", "b")
@@ -17,7 +17,7 @@ trait FooModule extends Cross.Module[String] {
   }
 }
 
-def baz = T { s"hello ${foo("a").bar.param()}" }
+def baz = Task { s"hello ${foo("a").bar.param()}" }
 
 // [graphviz]
 // ....

--- a/example/depth/cross/8-resolvers/build.mill
+++ b/example/depth/cross/8-resolvers/build.mill
@@ -9,12 +9,12 @@ trait MyModule extends Cross.Module[String] {
 
 object foo extends mill.Cross[FooModule]("2.10", "2.11", "2.12")
 trait FooModule extends MyModule {
-  def suffix = T { "_" + crossValue }
+  def suffix = Task { "_" + crossValue }
 }
 
 object bar extends mill.Cross[BarModule]("2.10", "2.11", "2.12")
 trait BarModule extends MyModule {
-  def bigSuffix = T { "[[[" + foo().suffix() + "]]]" }
+  def bigSuffix = Task { "[[[" + foo().suffix() + "]]]" }
 }
 
 // You can define an implicit `mill.define.Cross.Resolver` within your

--- a/example/depth/modules/7-modules/build.mill
+++ b/example/depth/modules/7-modules/build.mill
@@ -7,9 +7,9 @@ package build
 import mill._
 
 object foo extends Module {
-  def bar = T { "hello" }
+  def bar = Task { "hello" }
   object qux extends Module {
-    def baz = T { "world" }
+    def baz = Task { "world" }
   }
 }
 
@@ -60,7 +60,7 @@ object foo extends Module {
 
 trait FooModule extends Module {
   def bar: T[String] // required override
-  def qux = T { bar() + " world" }
+  def qux = Task { bar() + " world" }
 }
 
 object foo1 extends FooModule{
@@ -69,7 +69,7 @@ object foo1 extends FooModule{
 }
 object foo2 extends FooModule {
   def bar = "hi"
-  def baz = T { qux() + " I am Cow" } // add a new `def`
+  def baz = Task { qux() + " I am Cow" } // add a new `def`
 }
 
 // This generates the following module tree and task graph, with the dotted boxes and
@@ -132,7 +132,7 @@ object foo2 extends FooModule {
 
 trait MyModule extends Module{
   def sources = T.source(millSourcePath / "sources")
-  def target = T { "hello " + os.list(sources().path).map(os.read(_)).mkString(" ") }
+  def target = Task { "hello " + os.list(sources().path).map(os.read(_)).mkString(" ") }
 }
 
 object outer extends MyModule {

--- a/example/depth/modules/7-modules/build.mill
+++ b/example/depth/modules/7-modules/build.mill
@@ -131,7 +131,7 @@ object foo2 extends FooModule {
 // module expects its input files to be on disk.
 
 trait MyModule extends Module{
-  def sources = T.source(millSourcePath / "sources")
+  def sources = Task.source(millSourcePath / "sources")
   def target = Task { "hello " + os.list(sources().path).map(os.read(_)).mkString(" ") }
 }
 

--- a/example/depth/modules/7-modules/build.mill
+++ b/example/depth/modules/7-modules/build.mill
@@ -131,7 +131,7 @@ object foo2 extends FooModule {
 // module expects its input files to be on disk.
 
 trait MyModule extends Module{
-  def sources = Task.source(millSourcePath / "sources")
+  def sources = Task.Source(millSourcePath / "sources")
   def target = Task { "hello " + os.list(sources().path).map(os.read(_)).mkString(" ") }
 }
 

--- a/example/depth/modules/8-diy-java-modules/build.mill
+++ b/example/depth/modules/8-diy-java-modules/build.mill
@@ -11,7 +11,7 @@ trait DiyJavaModule extends Module{
   def upstream: T[Seq[PathRef]] = T{ T.traverse(moduleDeps)(_.classPath)().flatten }
   def sources = T.source(millSourcePath / "src")
 
-  def compile = T {
+  def compile = Task {
     val allSources = os.walk(sources().path)
     val cpFlag = Seq("-cp", upstream().map(_.path).mkString(":"))
     os.proc("javac", cpFlag, allSources, "-d", T.dest).call()
@@ -20,7 +20,7 @@ trait DiyJavaModule extends Module{
 
   def classPath = T{ Seq(compile()) ++ upstream() }
 
-  def assembly = T {
+  def assembly = Task {
     for(cp <- classPath()) os.copy(cp.path, T.dest, mergeFolders = true)
 
     val mainFlags = mainClass().toSeq.flatMap(Seq("-e", _))

--- a/example/depth/modules/8-diy-java-modules/build.mill
+++ b/example/depth/modules/8-diy-java-modules/build.mill
@@ -9,7 +9,7 @@ trait DiyJavaModule extends Module{
   def mainClass: T[Option[String]] = None
 
   def upstream: T[Seq[PathRef]] = T{ Task.traverse(moduleDeps)(_.classPath)().flatten }
-  def sources = Task.source(millSourcePath / "src")
+  def sources = Task.Source(millSourcePath / "src")
 
   def compile = Task {
     val allSources = os.walk(sources().path)

--- a/example/depth/modules/8-diy-java-modules/build.mill
+++ b/example/depth/modules/8-diy-java-modules/build.mill
@@ -8,26 +8,26 @@ trait DiyJavaModule extends Module{
   def moduleDeps: Seq[DiyJavaModule] = Nil
   def mainClass: T[Option[String]] = None
 
-  def upstream: T[Seq[PathRef]] = T{ T.traverse(moduleDeps)(_.classPath)().flatten }
-  def sources = T.source(millSourcePath / "src")
+  def upstream: T[Seq[PathRef]] = T{ Task.traverse(moduleDeps)(_.classPath)().flatten }
+  def sources = Task.source(millSourcePath / "src")
 
   def compile = Task {
     val allSources = os.walk(sources().path)
     val cpFlag = Seq("-cp", upstream().map(_.path).mkString(":"))
-    os.proc("javac", cpFlag, allSources, "-d", T.dest).call()
-    PathRef(T.dest)
+    os.proc("javac", cpFlag, allSources, "-d", Task.dest).call()
+    PathRef(Task.dest)
   }
 
   def classPath = T{ Seq(compile()) ++ upstream() }
 
   def assembly = Task {
-    for(cp <- classPath()) os.copy(cp.path, T.dest, mergeFolders = true)
+    for(cp <- classPath()) os.copy(cp.path, Task.dest, mergeFolders = true)
 
     val mainFlags = mainClass().toSeq.flatMap(Seq("-e", _))
-    os.proc("jar", "-c", mainFlags, "-f", T.dest / s"assembly.jar", ".")
-      .call(cwd = T.dest)
+    os.proc("jar", "-c", mainFlags, "-f", Task.dest / s"assembly.jar", ".")
+      .call(cwd = Task.dest)
 
-    PathRef(T.dest / s"assembly.jar")
+    PathRef(Task.dest / s"assembly.jar")
   }
 }
 // This defines the following build graph for `DiyJavaModule`. Note that some of the
@@ -59,11 +59,11 @@ trait DiyJavaModule extends Module{
 //   change the shape of the task graph during evaluation, whereas `moduleDeps`
 //   defines  module dependencies that determine the shape of the graph.
 //
-// * Using `T.traverse` to recursively gather the upstream classpath. This is
+// * Using `Task.traverse` to recursively gather the upstream classpath. This is
 //   necessary to convert the `Seq[T[V]]` into a `T[Seq[V]]` that we can work
 //   with inside our targets
 //
-// * We use the `millSourcePath` together with `T.workspace` to infer a default
+// * We use the `millSourcePath` together with `Task.workspace` to infer a default
 //   name for the jar of each module. Users can override it if they want, but
 //   having a default is very convenient
 //

--- a/example/depth/sandbox/1-task/build.mill
+++ b/example/depth/sandbox/1-task/build.mill
@@ -15,7 +15,7 @@ package build
 import mill._
 
 object foo extends Module{
-  def tDestTask = T { println(T.dest.toString) }
+  def tDestTask = Task { println(T.dest.toString) }
 }
 
 /** Usage
@@ -28,7 +28,7 @@ object foo extends Module{
 // Mill also redirects the `os.pwd` property from https://github.com/com-lihaoyi/os-lib[OS-Lib],
 // such that that also points towards a running task's own `.dest/` folder
 
-def osPwdTask = T { println(os.pwd.toString) }
+def osPwdTask = Task { println(os.pwd.toString) }
 
 /** Usage
 > ./mill osPwdTask
@@ -39,7 +39,7 @@ def osPwdTask = T { println(os.pwd.toString) }
 // as well. In the example below, we can see the `python3` subprocess we spawn prints
 // its `os.getcwd()`, which is our `osProcTask.dest/` sandbox folder:
 
-def osProcTask = T {
+def osProcTask = Task {
   println(os.call(("python3", "-c", "import os; print(os.getcwd())"), cwd = T.dest).out.trim())
 }
 
@@ -55,7 +55,7 @@ def osProcTask = T {
 // towards an empty `sandbox/` folder in `out/mill-worker.../`:
 
 val externalPwd = os.pwd
-def externalPwdTask = T { println(externalPwd.toString) }
+def externalPwdTask = Task { println(externalPwd.toString) }
 
 /** Usage
 > ./mill externalPwdTask

--- a/example/depth/sandbox/1-task/build.mill
+++ b/example/depth/sandbox/1-task/build.mill
@@ -5,17 +5,17 @@
 // the filesystem operations of other tasks that may be occurring in parallel.
 //
 //
-// === `T.dest`
-// The standard way of working with a task's `.dest/` folder is through the `T.dest`
+// === `Task.dest`
+// The standard way of working with a task's `.dest/` folder is through the `Task.dest`
 // property. This is available within any task, and gives you access to the
 // `out/<module-names>/<task-name>.dest/` folder to use. The `.dest/` folder for
-// each task is lazily initialized when `T.dest` is referenced and used:
+// each task is lazily initialized when `Task.dest` is referenced and used:
 
 package build
 import mill._
 
 object foo extends Module{
-  def tDestTask = Task { println(T.dest.toString) }
+  def tDestTask = Task { println(Task.dest.toString) }
 }
 
 /** Usage
@@ -40,7 +40,7 @@ def osPwdTask = Task { println(os.pwd.toString) }
 // its `os.getcwd()`, which is our `osProcTask.dest/` sandbox folder:
 
 def osProcTask = Task {
-  println(os.call(("python3", "-c", "import os; print(os.getcwd())"), cwd = T.dest).out.trim())
+  println(os.call(("python3", "-c", "import os; print(os.getcwd())"), cwd = Task.dest).out.trim())
 }
 
 /** Usage

--- a/example/depth/sandbox/3-breaking/build.mill
+++ b/example/depth/sandbox/3-breaking/build.mill
@@ -1,6 +1,6 @@
 // Mill's sandboxing approach is best effort: while it tries to guide you into using
 // isolated sandbox folders, Mill cannot guarantee it, and in fact provides the
-// `T.workspace` property and `MILL_WORKSPACE_ROOT` environment variable to reference the
+// `Task.workspace` property and `MILL_WORKSPACE_ROOT` environment variable to reference the
 // project root folder for scenarios where you may need it. This can be useful for a variety
 // of reasons:
 //
@@ -8,11 +8,11 @@
 // * Scenarios where writing the the original source repository is necessary:
 //   code auto-formatters, auto-fixers, auto-updaters. etc.
 //
-// `T.workspace` can be used in tasks:
+// `Task.workspace` can be used in tasks:
 package build
 import mill._, javalib._
 
-def tWorkspaceTask = Task { println(T.workspace) }
+def tWorkspaceTask = Task { println(Task.workspace) }
 
 /** Usage
 > ./mill tWorkspaceTask

--- a/example/depth/sandbox/3-breaking/build.mill
+++ b/example/depth/sandbox/3-breaking/build.mill
@@ -12,7 +12,7 @@
 package build
 import mill._, javalib._
 
-def tWorkspaceTask = T { println(T.workspace) }
+def tWorkspaceTask = Task { println(T.workspace) }
 
 /** Usage
 > ./mill tWorkspaceTask

--- a/example/depth/tasks/1-task-graph/build.mill
+++ b/example/depth/tasks/1-task-graph/build.mill
@@ -7,13 +7,13 @@ def mainClass: T[Option[String]] = Some("foo.Foo")
 def sources = T.source(millSourcePath / "src")
 def resources = T.source(millSourcePath / "resources")
 
-def compile = T {
+def compile = Task {
   val allSources = os.walk(sources().path)
   os.proc("javac", allSources, "-d", T.dest).call()
   PathRef(T.dest)
 }
 
-def assembly = T {
+def assembly = Task {
   for(p <- Seq(compile(), resources())) os.copy(p.path, T.dest, mergeFolders = true)
 
   val mainFlags = mainClass().toSeq.flatMap(Seq("-e", _))

--- a/example/depth/tasks/1-task-graph/build.mill
+++ b/example/depth/tasks/1-task-graph/build.mill
@@ -40,7 +40,7 @@ def assembly = Task {
 // This example does not use any of Mill's builtin support for building Java or
 // Scala projects, and instead builds a pipeline "from scratch" using Mill
 // tasks and `javac`/`jar`/`java` subprocesses. We define `Task.Source` folders,
-// plain `T{...}` targets that depend on them, and a `Task.command`.
+// plain `T{...}` targets that depend on them, and a `Task.Command`.
 
 /** Usage
 

--- a/example/depth/tasks/1-task-graph/build.mill
+++ b/example/depth/tasks/1-task-graph/build.mill
@@ -4,23 +4,23 @@ import mill._
 
 def mainClass: T[Option[String]] = Some("foo.Foo")
 
-def sources = T.source(millSourcePath / "src")
-def resources = T.source(millSourcePath / "resources")
+def sources = Task.source(millSourcePath / "src")
+def resources = Task.source(millSourcePath / "resources")
 
 def compile = Task {
   val allSources = os.walk(sources().path)
-  os.proc("javac", allSources, "-d", T.dest).call()
-  PathRef(T.dest)
+  os.proc("javac", allSources, "-d", Task.dest).call()
+  PathRef(Task.dest)
 }
 
 def assembly = Task {
-  for(p <- Seq(compile(), resources())) os.copy(p.path, T.dest, mergeFolders = true)
+  for(p <- Seq(compile(), resources())) os.copy(p.path, Task.dest, mergeFolders = true)
 
   val mainFlags = mainClass().toSeq.flatMap(Seq("-e", _))
-  os.proc("jar", "-c", mainFlags, "-f", T.dest / s"assembly.jar", ".")
-    .call(cwd = T.dest)
+  os.proc("jar", "-c", mainFlags, "-f", Task.dest / s"assembly.jar", ".")
+    .call(cwd = Task.dest)
 
-  PathRef(T.dest / s"assembly.jar")
+  PathRef(Task.dest / s"assembly.jar")
 }
 
 // This code defines the following task graph, with the boxes being the tasks
@@ -39,8 +39,8 @@ def assembly = Task {
 //
 // This example does not use any of Mill's builtin support for building Java or
 // Scala projects, and instead builds a pipeline "from scratch" using Mill
-// tasks and `javac`/`jar`/`java` subprocesses. We define `T.source` folders,
-// plain `T{...}` targets that depend on them, and a `T.command`.
+// tasks and `javac`/`jar`/`java` subprocesses. We define `Task.source` folders,
+// plain `T{...}` targets that depend on them, and a `Task.command`.
 
 /** Usage
 

--- a/example/depth/tasks/1-task-graph/build.mill
+++ b/example/depth/tasks/1-task-graph/build.mill
@@ -4,8 +4,8 @@ import mill._
 
 def mainClass: T[Option[String]] = Some("foo.Foo")
 
-def sources = Task.source(millSourcePath / "src")
-def resources = Task.source(millSourcePath / "resources")
+def sources = Task.Source(millSourcePath / "src")
+def resources = Task.Source(millSourcePath / "resources")
 
 def compile = Task {
   val allSources = os.walk(sources().path)
@@ -39,7 +39,7 @@ def assembly = Task {
 //
 // This example does not use any of Mill's builtin support for building Java or
 // Scala projects, and instead builds a pipeline "from scratch" using Mill
-// tasks and `javac`/`jar`/`java` subprocesses. We define `Task.source` folders,
+// tasks and `javac`/`jar`/`java` subprocesses. We define `Task.Source` folders,
 // plain `T{...}` targets that depend on them, and a `Task.command`.
 
 /** Usage

--- a/example/depth/tasks/11-module-run-task/build.mill
+++ b/example/depth/tasks/11-module-run-task/build.mill
@@ -9,7 +9,7 @@ object foo extends ScalaModule {
 
   def sources = T{
     bar.runner().run(args = super.sources())
-    Seq(PathRef(T.dest))
+    Seq(PathRef(Task.dest))
   }
 }
 
@@ -23,7 +23,7 @@ object bar extends ScalaModule{
 // logic within the `bar` module as `bar/src/Bar.scala`. In this example, we use
 // `Bar.scala` as a source-code pre-processor on the `foo` module source code:
 // we override `foo.sources`, passing the `super.sources()` and `bar.runClasspath`
-// to `bar.runner().run` along with a `T.dest`, and returning a `PathRef(T.dest)`
+// to `bar.runner().run` along with a `Task.dest`, and returning a `PathRef(Task.dest)`
 // as the new `foo.sources`.
 
 /** Usage
@@ -43,7 +43,7 @@ Foo.value: HELLO
 //
 // `bar.runner().run` by default inherits the `mainClass`, `forkEnv`, `forkArgs`,
 // from the owning module `bar`, and the working directory from the calling task's
-// `T.dest`. You can also pass in these parameters explicitly to `run()` as named
+// `Task.dest`. You can also pass in these parameters explicitly to `run()` as named
 // arguments if you wish to override the defaults
 //
 // [source,scala]

--- a/example/depth/tasks/2-primary-tasks/build.mill
+++ b/example/depth/tasks/2-primary-tasks/build.mill
@@ -1,7 +1,7 @@
 // There are three primary kinds of _Tasks_ that you should care about:
 //
 // * <<_sources>>, defined using `T.sources {...}`
-// * <<_targets>>, defined using `T {...}`
+// * <<_targets>>, defined using `Task {...}`
 // * <<_commands>>, defined using `T.command {...}`
 
 // === Sources
@@ -25,13 +25,13 @@ def resources = T.source { millSourcePath / "resources" }
 
 // === Targets
 
-def allSources = T {
+def allSources = Task {
   os.walk(sources().path)
     .filter(_.ext == "java")
     .map(PathRef(_))
 }
 
-def lineCount: T[Int] = T {
+def lineCount: T[Int] = Task {
   println("Computing line count")
   allSources()
     .map(p => os.read.lines(p.path).size)
@@ -48,9 +48,9 @@ def lineCount: T[Int] = T {
 // }
 // ....
 //
-// ``Target``s are defined using the `def foo = T {...}` syntax, and dependencies
+// ``Target``s are defined using the `def foo = Task {...}` syntax, and dependencies
 // on other targets are defined using `foo()` to extract the value from them.
-// Apart from the `foo()` calls, the `T {...}` block contains arbitrary code that
+// Apart from the `foo()` calls, the `Task {...}` block contains arbitrary code that
 // does some work and returns a result.
 //
 // The `os.walk` and `os.read.lines` statements above are from the
@@ -81,7 +81,7 @@ Computing line count
 // not cause it to recompute:
 
 // ```diff
-//  def lineCount: T[Int] = T {
+//  def lineCount: T[Int] = Task {
 //   println("Computing line count")
 //+  // Hello World
 //   allSources()
@@ -94,7 +94,7 @@ Computing line count
 // next time it is invoked:
 //
 // ```diff
-//   def lineCount: T[Int] = T {
+//   def lineCount: T[Int] = Task {
 //-  println("Computing line count")
 //+  println("Computing line count!!!")
 //   allSources()
@@ -123,7 +123,7 @@ Computing line count
 // folder and return a `PathRef()` that referencing the files or folders
 // you want to return:
 
-def classFiles = T {
+def classFiles = Task {
   println("Generating classfiles")
 
   os.proc("javac", allSources().map(_.path), "-d", T.dest)
@@ -132,7 +132,7 @@ def classFiles = T {
   PathRef(T.dest)
 }
 
-def jar = T {
+def jar = Task {
   println("Generating jar")
   os.copy(classFiles().path, T.dest, mergeFolders = true)
   os.copy(resources().path, T.dest, mergeFolders = true)
@@ -186,7 +186,7 @@ Generating jar
 // in `def largeFile` running even though the `largeFile()` branch of the
 // `if` conditional does not get used:
 
-def largeFile = T {
+def largeFile = Task {
   println("Finding Largest File")
   allSources()
     .map(_.path)
@@ -368,7 +368,7 @@ trait Foo extends Module {
 
 trait Bar extends Foo {
   def additionalSources = T.sources(millSourcePath / "src2")
-  def sourceRoots = T { super.sourceRoots() ++ additionalSources() }
+  def sourceRoots = Task { super.sourceRoots() ++ additionalSources() }
 }
 
 object bar extends Bar

--- a/example/depth/tasks/2-primary-tasks/build.mill
+++ b/example/depth/tasks/2-primary-tasks/build.mill
@@ -1,25 +1,25 @@
 // There are three primary kinds of _Tasks_ that you should care about:
 //
-// * <<_sources>>, defined using `T.sources {...}`
+// * <<_sources>>, defined using `Task.sources {...}`
 // * <<_targets>>, defined using `Task {...}`
-// * <<_commands>>, defined using `T.command {...}`
+// * <<_commands>>, defined using `Task.command {...}`
 
 // === Sources
 package build
 
 import mill.{Module, T, _}
 
-def sources = T.source { millSourcePath / "src" }
-def resources = T.source { millSourcePath / "resources" }
+def sources = Task.source { millSourcePath / "src" }
+def resources = Task.source { millSourcePath / "resources" }
 
 
-// ``Source``s are defined using `T.source{...}` taking one `os.Path`, or `T.sources{...}`,
+// ``Source``s are defined using `Task.source{...}` taking one `os.Path`, or `Task.sources{...}`,
 // taking multiple ``os.Path``s as arguments. A ``Source``'s':
 // its build signature/`hashCode` depends not just on the path
 // it refers to (e.g. `foo/bar/baz`) but also the MD5 hash of the filesystem
 // tree under that path.
 //
-// `T.source` and `T.sources` are most common inputs in any Mill build:
+// `Task.source` and `Task.sources` are most common inputs in any Mill build:
 // they watch source files and folders and cause downstream targets to
 // re-compute if a change is detected.
 
@@ -113,33 +113,33 @@ Computing line count
 //
 // * {upickle-github-url}[uPickle Library Documentation]
 
-// ==== T.dest
+// ==== Task.dest
 //
-// Each target, e.g. `classFiles`, is assigned a {mill-doc-url}/api/latest/mill/api/Ctx.html#dest:os.Path[T.dest]
+// Each target, e.g. `classFiles`, is assigned a {mill-doc-url}/api/latest/mill/api/Ctx.html#dest:os.Path[Task.dest]
 // folder e.g. `out/classFiles.dest/` on disk as scratch space & to store its
 // output files , and its returned metadata is automatically JSON-serialized
 // and stored at `out/classFiles.json`. If you want to return a file or a set
-// of files as the result of a `Target`, write them to disk within your `T.dest`
+// of files as the result of a `Target`, write them to disk within your `Task.dest`
 // folder and return a `PathRef()` that referencing the files or folders
 // you want to return:
 
 def classFiles = Task {
   println("Generating classfiles")
 
-  os.proc("javac", allSources().map(_.path), "-d", T.dest)
-    .call(cwd = T.dest)
+  os.proc("javac", allSources().map(_.path), "-d", Task.dest)
+    .call(cwd = Task.dest)
 
-  PathRef(T.dest)
+  PathRef(Task.dest)
 }
 
 def jar = Task {
   println("Generating jar")
-  os.copy(classFiles().path, T.dest, mergeFolders = true)
-  os.copy(resources().path, T.dest, mergeFolders = true)
+  os.copy(classFiles().path, Task.dest, mergeFolders = true)
+  os.copy(resources().path, Task.dest, mergeFolders = true)
 
-  os.proc("jar", "-cfe", T.dest / "foo.jar", "foo.Foo", ".").call(cwd = T.dest)
+  os.proc("jar", "-cfe", Task.dest / "foo.jar", "foo.Foo", ".").call(cwd = Task.dest)
 
-  PathRef(T.dest / "foo.jar")
+  PathRef(Task.dest / "foo.jar")
 }
 
 // [graphviz]
@@ -170,8 +170,8 @@ Generating jar
 // which would cause problems with Mill's caches not invalidating properly or files from different
 // tasks colliding and causing issues.
 // You should never use `os.pwd` or rely on the process working directory, and always explicitly
-// use `T.dest` or the `.path` of upstream ``PathRef``s when accessing files. In the rare case where
-// you truly need the Mill project root folder, you can access it via `T.workspace`
+// use `Task.dest` or the `.path` of upstream ``PathRef``s when accessing files. In the rare case where
+// you truly need the Mill project root folder, you can access it via `Task.workspace`
 //
 // ==== Dependent Targets
 //
@@ -266,7 +266,7 @@ def summarizeClassFileStats = T{
 
 // === Commands
 
-def run(mainClass: String, args: String*) = T.command {
+def run(mainClass: String, args: String*) = Task.command {
   os.proc(
       "java",
       "-cp", s"${classFiles().path}:${resources().path}",
@@ -288,11 +288,11 @@ def run(mainClass: String, args: String*) = T.command {
 // }
 // ....
 
-// Defined using `T.command {...}` syntax, ``Command``s can run arbitrary code, with
+// Defined using `Task.command {...}` syntax, ``Command``s can run arbitrary code, with
 // dependencies declared using the same `foo()` syntax (e.g. `classFiles()` above).
 // Commands can be parametrized, but their output is not cached, so they will
 // re-evaluate every time even if none of their inputs have changed.
-// A command with no parameter is defined as `def myCommand() = T.command {...}`.
+// A command with no parameter is defined as `def myCommand() = Task.command {...}`.
 // It is a compile error if `()` is missing.
 //
 // Targets can take command line params, parsed by the https://github.com/com-lihaoyi/mainargs[MainArgs]
@@ -352,11 +352,11 @@ foo.txt resource: My Example Text
 
 // Tasks can be overriden, with the overriden task callable via `super`.
 // You can also override a task with a different type of task, e.g. below
-// we override `sourceRoots` which is a `T.sources` with a `T{}` target:
+// we override `sourceRoots` which is a `Task.sources` with a `T{}` target:
 //
 
 trait Foo extends Module {
-  def sourceRoots = T.sources(millSourcePath / "src")
+  def sourceRoots = Task.sources(millSourcePath / "src")
   def sourceContents = T{
     sourceRoots()
       .flatMap(pref => os.walk(pref.path))
@@ -367,7 +367,7 @@ trait Foo extends Module {
 }
 
 trait Bar extends Foo {
-  def additionalSources = T.sources(millSourcePath / "src2")
+  def additionalSources = Task.sources(millSourcePath / "src2")
   def sourceRoots = Task { super.sourceRoots() ++ additionalSources() }
 }
 

--- a/example/depth/tasks/2-primary-tasks/build.mill
+++ b/example/depth/tasks/2-primary-tasks/build.mill
@@ -1,6 +1,6 @@
 // There are three primary kinds of _Tasks_ that you should care about:
 //
-// * <<_sources>>, defined using `Task.sources {...}`
+// * <<_sources>>, defined using `Task.Sources {...}`
 // * <<_targets>>, defined using `Task {...}`
 // * <<_commands>>, defined using `Task.command {...}`
 
@@ -9,17 +9,17 @@ package build
 
 import mill.{Module, T, _}
 
-def sources = Task.source { millSourcePath / "src" }
-def resources = Task.source { millSourcePath / "resources" }
+def sources = Task.Source { millSourcePath / "src" }
+def resources = Task.Source { millSourcePath / "resources" }
 
 
-// ``Source``s are defined using `Task.source{...}` taking one `os.Path`, or `Task.sources{...}`,
+// ``Source``s are defined using `Task.Source{...}` taking one `os.Path`, or `Task.Sources{...}`,
 // taking multiple ``os.Path``s as arguments. A ``Source``'s':
 // its build signature/`hashCode` depends not just on the path
 // it refers to (e.g. `foo/bar/baz`) but also the MD5 hash of the filesystem
 // tree under that path.
 //
-// `Task.source` and `Task.sources` are most common inputs in any Mill build:
+// `Task.Source` and `Task.Sources` are most common inputs in any Mill build:
 // they watch source files and folders and cause downstream targets to
 // re-compute if a change is detected.
 
@@ -352,11 +352,11 @@ foo.txt resource: My Example Text
 
 // Tasks can be overriden, with the overriden task callable via `super`.
 // You can also override a task with a different type of task, e.g. below
-// we override `sourceRoots` which is a `Task.sources` with a `T{}` target:
+// we override `sourceRoots` which is a `Task.Sources` with a `T{}` target:
 //
 
 trait Foo extends Module {
-  def sourceRoots = Task.sources(millSourcePath / "src")
+  def sourceRoots = Task.Sources(millSourcePath / "src")
   def sourceContents = T{
     sourceRoots()
       .flatMap(pref => os.walk(pref.path))
@@ -367,7 +367,7 @@ trait Foo extends Module {
 }
 
 trait Bar extends Foo {
-  def additionalSources = Task.sources(millSourcePath / "src2")
+  def additionalSources = Task.Sources(millSourcePath / "src2")
   def sourceRoots = Task { super.sourceRoots() ++ additionalSources() }
 }
 

--- a/example/depth/tasks/2-primary-tasks/build.mill
+++ b/example/depth/tasks/2-primary-tasks/build.mill
@@ -2,7 +2,7 @@
 //
 // * <<_sources>>, defined using `Task.Sources {...}`
 // * <<_targets>>, defined using `Task {...}`
-// * <<_commands>>, defined using `Task.command {...}`
+// * <<_commands>>, defined using `Task.Command {...}`
 
 // === Sources
 package build
@@ -266,7 +266,7 @@ def summarizeClassFileStats = T{
 
 // === Commands
 
-def run(mainClass: String, args: String*) = Task.command {
+def run(mainClass: String, args: String*) = Task.Command {
   os.proc(
       "java",
       "-cp", s"${classFiles().path}:${resources().path}",
@@ -288,11 +288,11 @@ def run(mainClass: String, args: String*) = Task.command {
 // }
 // ....
 
-// Defined using `Task.command {...}` syntax, ``Command``s can run arbitrary code, with
+// Defined using `Task.Command {...}` syntax, ``Command``s can run arbitrary code, with
 // dependencies declared using the same `foo()` syntax (e.g. `classFiles()` above).
 // Commands can be parametrized, but their output is not cached, so they will
 // re-evaluate every time even if none of their inputs have changed.
-// A command with no parameter is defined as `def myCommand() = Task.command {...}`.
+// A command with no parameter is defined as `def myCommand() = Task.Command {...}`.
 // It is a compile error if `()` is missing.
 //
 // Targets can take command line params, parsed by the https://github.com/com-lihaoyi/mainargs[MainArgs]

--- a/example/depth/tasks/3-anonymous-tasks/build.mill
+++ b/example/depth/tasks/3-anonymous-tasks/build.mill
@@ -3,7 +3,7 @@ import mill._, define.Task
 
 def data = Task.source(millSourcePath / "data")
 
-def anonTask(fileName: String): Task[String] = Task.task {
+def anonTask(fileName: String): Task[String] = Task.anon {
   os.read(data().path / fileName)
 }
 
@@ -12,7 +12,7 @@ def printFileData(fileName: String) = Task.command {
   println(anonTask(fileName)())
 }
 
-// You can define anonymous tasks using the `Task.task {...}` syntax. These are
+// You can define anonymous tasks using the `Task.anon {...}` syntax. These are
 // not runnable from the command-line, but can be used to share common code you
 // find yourself repeating in ``Target``s and ``Command``s.
 //

--- a/example/depth/tasks/3-anonymous-tasks/build.mill
+++ b/example/depth/tasks/3-anonymous-tasks/build.mill
@@ -1,7 +1,7 @@
 package build
 import mill._, define.Task
 
-def data = Task.source(millSourcePath / "data")
+def data = Task.Source(millSourcePath / "data")
 
 def anonTask(fileName: String): Task[String] = Task.anon {
   os.read(data().path / fileName)

--- a/example/depth/tasks/3-anonymous-tasks/build.mill
+++ b/example/depth/tasks/3-anonymous-tasks/build.mill
@@ -3,16 +3,16 @@ import mill._, define.Task
 
 def data = Task.Source(millSourcePath / "data")
 
-def anonTask(fileName: String): Task[String] = Task.anon {
+def anonTask(fileName: String): Task[String] = Task.Anon {
   os.read(data().path / fileName)
 }
 
 def helloFileData = Task { anonTask("hello.txt")() }
-def printFileData(fileName: String) = Task.command {
+def printFileData(fileName: String) = Task.Command {
   println(anonTask(fileName)())
 }
 
-// You can define anonymous tasks using the `Task.anon {...}` syntax. These are
+// You can define anonymous tasks using the `Task.Anon {...}` syntax. These are
 // not runnable from the command-line, but can be used to share common code you
 // find yourself repeating in ``Target``s and ``Command``s.
 //

--- a/example/depth/tasks/3-anonymous-tasks/build.mill
+++ b/example/depth/tasks/3-anonymous-tasks/build.mill
@@ -1,18 +1,18 @@
 package build
 import mill._, define.Task
 
-def data = T.source(millSourcePath / "data")
+def data = Task.source(millSourcePath / "data")
 
-def anonTask(fileName: String): Task[String] = T.task {
+def anonTask(fileName: String): Task[String] = Task.task {
   os.read(data().path / fileName)
 }
 
 def helloFileData = Task { anonTask("hello.txt")() }
-def printFileData(fileName: String) = T.command {
+def printFileData(fileName: String) = Task.command {
   println(anonTask(fileName)())
 }
 
-// You can define anonymous tasks using the `T.task {...}` syntax. These are
+// You can define anonymous tasks using the `Task.task {...}` syntax. These are
 // not runnable from the command-line, but can be used to share common code you
 // find yourself repeating in ``Target``s and ``Command``s.
 //

--- a/example/depth/tasks/3-anonymous-tasks/build.mill
+++ b/example/depth/tasks/3-anonymous-tasks/build.mill
@@ -7,7 +7,7 @@ def anonTask(fileName: String): Task[String] = T.task {
   os.read(data().path / fileName)
 }
 
-def helloFileData = T { anonTask("hello.txt")() }
+def helloFileData = Task { anonTask("hello.txt")() }
 def printFileData(fileName: String) = T.command {
   println(anonTask(fileName)())
 }

--- a/example/depth/tasks/4-inputs/build.mill
+++ b/example/depth/tasks/4-inputs/build.mill
@@ -1,14 +1,14 @@
 package build
 import mill._
 
-def myInput = Task.input {
+def myInput = Task.Input {
   os.proc("git", "rev-parse", "HEAD").call(cwd = Task.workspace)
     .out
     .text()
     .trim()
 }
 
-// A generalization of <<_sources>>, ``Task.input``s are tasks that re-evaluate
+// A generalization of <<_sources>>, ``Task.Input``s are tasks that re-evaluate
 // _every time_ (unlike <<_anonymous_tasks>>), containing an
 // arbitrary block of code.
 //
@@ -47,9 +47,9 @@ def gitStatusTarget = Task {
 // `gitStatusTarget` will continue to use any previously cached value, and
 // ``gitStatusTarget``'s output will  be out of date!
 
-// To fix this, you can wrap your `git log` in a `Task.input`:
+// To fix this, you can wrap your `git log` in a `Task.Input`:
 
-def gitStatusInput = Task.input {
+def gitStatusInput = Task.Input {
   os.proc("git", "log", "-1", "--pretty=format:%h-%B ")
     .call(cwd = Task.workspace)
     .out
@@ -75,7 +75,7 @@ def gitStatusTarget2 = Task { "v-" + gitStatusInput() }
 
 */
 
-// Note that because ``Task.input``s re-evaluate every time, you should ensure that the
-// code you put in `Task.input` runs quickly. Ideally it should just be a simple check
+// Note that because ``Task.Input``s re-evaluate every time, you should ensure that the
+// code you put in `Task.Input` runs quickly. Ideally it should just be a simple check
 // "did anything change?" and any heavy-lifting should be delegated to downstream
 // targets where it can be cached if possible.

--- a/example/depth/tasks/4-inputs/build.mill
+++ b/example/depth/tasks/4-inputs/build.mill
@@ -1,14 +1,14 @@
 package build
 import mill._
 
-def myInput = T.input {
-  os.proc("git", "rev-parse", "HEAD").call(cwd = T.workspace)
+def myInput = Task.input {
+  os.proc("git", "rev-parse", "HEAD").call(cwd = Task.workspace)
     .out
     .text()
     .trim()
 }
 
-// A generalization of <<_sources>>, ``T.input``s are tasks that re-evaluate
+// A generalization of <<_sources>>, ``Task.input``s are tasks that re-evaluate
 // _every time_ (unlike <<_anonymous_tasks>>), containing an
 // arbitrary block of code.
 //
@@ -21,7 +21,7 @@ def myInput = T.input {
 def gitStatusTarget = Task {
   "v-" +
   os.proc("git", "log", "-1", "--pretty=format:%h-%B ")
-    .call(cwd = T.workspace)
+    .call(cwd = Task.workspace)
     .out
     .text()
     .trim()
@@ -47,11 +47,11 @@ def gitStatusTarget = Task {
 // `gitStatusTarget` will continue to use any previously cached value, and
 // ``gitStatusTarget``'s output will  be out of date!
 
-// To fix this, you can wrap your `git log` in a `T.input`:
+// To fix this, you can wrap your `git log` in a `Task.input`:
 
-def gitStatusInput = T.input {
+def gitStatusInput = Task.input {
   os.proc("git", "log", "-1", "--pretty=format:%h-%B ")
-    .call(cwd = T.workspace)
+    .call(cwd = Task.workspace)
     .out
     .text()
     .trim()
@@ -75,7 +75,7 @@ def gitStatusTarget2 = Task { "v-" + gitStatusInput() }
 
 */
 
-// Note that because ``T.input``s re-evaluate every time, you should ensure that the
-// code you put in `T.input` runs quickly. Ideally it should just be a simple check
+// Note that because ``Task.input``s re-evaluate every time, you should ensure that the
+// code you put in `Task.input` runs quickly. Ideally it should just be a simple check
 // "did anything change?" and any heavy-lifting should be delegated to downstream
 // targets where it can be cached if possible.

--- a/example/depth/tasks/4-inputs/build.mill
+++ b/example/depth/tasks/4-inputs/build.mill
@@ -18,7 +18,7 @@ def myInput = T.input {
 // that target does not have any `Task` inputs and so will never re-compute
 // even if the external `git` status changes:
 
-def gitStatusTarget = T {
+def gitStatusTarget = Task {
   "v-" +
   os.proc("git", "log", "-1", "--pretty=format:%h-%B ")
     .call(cwd = T.workspace)
@@ -56,7 +56,7 @@ def gitStatusInput = T.input {
     .text()
     .trim()
 }
-def gitStatusTarget2 = T { "v-" + gitStatusInput() }
+def gitStatusTarget2 = Task { "v-" + gitStatusInput() }
 
 // This makes `gitStatusInput` to always re-evaluate every build, and only if
 // the output of `gitStatusInput` changes will `gitStatusTarget2` re-compute

--- a/example/depth/tasks/5-persistent-targets/build.mill
+++ b/example/depth/tasks/5-persistent-targets/build.mill
@@ -1,27 +1,27 @@
-// Persistent targets defined using `T.persistent` are similar to normal
-// ``Target``s, except their `T.dest` folder is not cleared before every
+// Persistent targets defined using `Task.persistent` are similar to normal
+// ``Target``s, except their `Task.dest` folder is not cleared before every
 // evaluation. This makes them useful for caching things on disk in a more
 // fine-grained manner than Mill's own Target-level caching.
 //
-// Below is a semi-realistic example of using a `T.persistent` target:
+// Below is a semi-realistic example of using a `Task.persistent` target:
 package build
 import mill._, scalalib._
 import java.util.Arrays
 import java.io.ByteArrayOutputStream
 import java.util.zip.GZIPOutputStream
 
-def data = T.source(millSourcePath / "data")
+def data = Task.source(millSourcePath / "data")
 
-def compressedData = T.persistent{
+def compressedData = Task.persistent{
   println("Evaluating compressedData")
-  os.makeDir.all(T.dest / "cache")
-  os.remove.all(T.dest / "compressed")
+  os.makeDir.all(Task.dest / "cache")
+  os.remove.all(Task.dest / "compressed")
 
   for(p <- os.list(data().path)){
-    val compressedPath = T.dest / "compressed" / s"${p.last}.gz"
+    val compressedPath = Task.dest / "compressed" / s"${p.last}.gz"
     val bytes = os.read.bytes(p)
     val hash = Arrays.hashCode(bytes)
-    val cachedPath = T.dest / "cache" / hash.toHexString
+    val cachedPath = Task.dest / "cache" / hash.toHexString
     if (!os.exists(cachedPath)) {
       println("Compressing: " + p.last)
       os.write(cachedPath, compressBytes(bytes))
@@ -31,7 +31,7 @@ def compressedData = T.persistent{
     os.copy(cachedPath, compressedPath, createFolders = true)
   }
 
-  os.list(T.dest / "compressed").map(PathRef(_))
+  os.list(Task.dest / "compressed").map(PathRef(_))
 }
 
 def compressBytes(input: Array[Byte]) = {
@@ -51,7 +51,7 @@ def compressBytes(input: Array[Byte]) = {
 // Since persistent targets have long-lived state on disk that lives beyond a
 // single evaluation, this raises the possibility of the disk contents getting
 // into a bad state and causing all future evaluations to fail. It is left up
-// to the person implementing the `T.persistent` to ensure their implementation
+// to the person implementing the `Task.persistent` to ensure their implementation
 // is eventually consistent. You can also use `mill clean` to manually purge
 // the disk contents to start fresh.
 

--- a/example/depth/tasks/5-persistent-targets/build.mill
+++ b/example/depth/tasks/5-persistent-targets/build.mill
@@ -1,18 +1,18 @@
-// Persistent targets defined using `Task.persistent` are similar to normal
+// Persistent targets defined using `Task.Persistent` are similar to normal
 // ``Target``s, except their `Task.dest` folder is not cleared before every
 // evaluation. This makes them useful for caching things on disk in a more
 // fine-grained manner than Mill's own Target-level caching.
 //
-// Below is a semi-realistic example of using a `Task.persistent` target:
+// Below is a semi-realistic example of using a `Task.Persistent` target:
 package build
 import mill._, scalalib._
 import java.util.Arrays
 import java.io.ByteArrayOutputStream
 import java.util.zip.GZIPOutputStream
 
-def data = Task.source(millSourcePath / "data")
+def data = Task.Source(millSourcePath / "data")
 
-def compressedData = Task.persistent{
+def compressedData = Task.Persistent{
   println("Evaluating compressedData")
   os.makeDir.all(Task.dest / "cache")
   os.remove.all(Task.dest / "compressed")
@@ -51,7 +51,7 @@ def compressBytes(input: Array[Byte]) = {
 // Since persistent targets have long-lived state on disk that lives beyond a
 // single evaluation, this raises the possibility of the disk contents getting
 // into a bad state and causing all future evaluations to fail. It is left up
-// to the person implementing the `Task.persistent` to ensure their implementation
+// to the person implementing the `Task.Persistent` to ensure their implementation
 // is eventually consistent. You can also use `mill clean` to manually purge
 // the disk contents to start fresh.
 

--- a/example/depth/tasks/6-workers/build.mill
+++ b/example/depth/tasks/6-workers/build.mill
@@ -11,7 +11,7 @@ import java.util.Arrays
 import java.io.ByteArrayOutputStream
 import java.util.zip.GZIPOutputStream
 
-def data = Task.source(millSourcePath / "data")
+def data = Task.Source(millSourcePath / "data")
 
 def compressWorker = Task.worker{ new CompressWorker(Task.dest) }
 

--- a/example/depth/tasks/6-workers/build.mill
+++ b/example/depth/tasks/6-workers/build.mill
@@ -1,4 +1,4 @@
-// Mill workers defined using `T.worker` are long-lived in-memory objects that
+// Mill workers defined using `Task.worker` are long-lived in-memory objects that
 // can persistent across multiple evaluations. These are similar to persistent
 // targets in that they let you cache things, but the fact that they let you
 // cache the worker object in-memory allows for greater performance and
@@ -11,19 +11,19 @@ import java.util.Arrays
 import java.io.ByteArrayOutputStream
 import java.util.zip.GZIPOutputStream
 
-def data = T.source(millSourcePath / "data")
+def data = Task.source(millSourcePath / "data")
 
-def compressWorker = T.worker{ new CompressWorker(T.dest) }
+def compressWorker = Task.worker{ new CompressWorker(Task.dest) }
 
 def compressedData = T{
   println("Evaluating compressedData")
   for(p <- os.list(data().path)){
     os.write(
-      T.dest / s"${p.last}.gz",
+      Task.dest / s"${p.last}.gz",
       compressWorker().compress(p.last, os.read.bytes(p))
     )
   }
-  os.list(T.dest).map(PathRef(_))
+  os.list(Task.dest).map(PathRef(_))
 }
 
 class CompressWorker(dest: os.Path){
@@ -69,7 +69,7 @@ def compressBytes(input: Array[Byte]) = {
 // workers after every command. Commands run repeatedly using `--watch` will
 // also preserve the workers between them.
 //
-// Workers can also make use of their `T.dest` folder as a cache that persist
+// Workers can also make use of their `Task.dest` folder as a cache that persist
 // when the worker shuts down, as a second layer of caching. The example usage
 // below demonstrates how using the `--no-server` flag will make the worker
 // read from its disk cache, where it would have normally read from its
@@ -121,4 +121,4 @@ class MyWorker() extends AutoCloseable {
   override def close() = { /* cleanup and free resources */ }
 }
 
-def myWorker = T.worker { new MyWorker() }
+def myWorker = Task.worker { new MyWorker() }

--- a/example/depth/tasks/6-workers/build.mill
+++ b/example/depth/tasks/6-workers/build.mill
@@ -1,4 +1,4 @@
-// Mill workers defined using `Task.worker` are long-lived in-memory objects that
+// Mill workers defined using `Task.Worker` are long-lived in-memory objects that
 // can persistent across multiple evaluations. These are similar to persistent
 // targets in that they let you cache things, but the fact that they let you
 // cache the worker object in-memory allows for greater performance and
@@ -13,7 +13,7 @@ import java.util.zip.GZIPOutputStream
 
 def data = Task.Source(millSourcePath / "data")
 
-def compressWorker = Task.worker{ new CompressWorker(Task.dest) }
+def compressWorker = Task.Worker{ new CompressWorker(Task.dest) }
 
 def compressedData = T{
   println("Evaluating compressedData")
@@ -121,4 +121,4 @@ class MyWorker() extends AutoCloseable {
   override def close() = { /* cleanup and free resources */ }
 }
 
-def myWorker = Task.worker { new MyWorker() }
+def myWorker = Task.Worker { new MyWorker() }

--- a/example/extending/imports/3-import-ivy/build.mill
+++ b/example/extending/imports/3-import-ivy/build.mill
@@ -7,9 +7,9 @@ object `package` extends RootModule with ScalaModule {
 
   def ivyDeps = Agg(ivy"com.lihaoyi::os-lib:0.10.7")
   def htmlSnippet = T{ div(h1("hello"), p("world")).toString }
-  def resources = T.sources{
-    os.write(T.dest / "snippet.txt", htmlSnippet())
-    super.resources() ++ Seq(PathRef(T.dest))
+  def resources = Task.sources{
+    os.write(Task.dest / "snippet.txt", htmlSnippet())
+    super.resources() ++ Seq(PathRef(Task.dest))
   }
 }
 

--- a/example/extending/imports/3-import-ivy/build.mill
+++ b/example/extending/imports/3-import-ivy/build.mill
@@ -7,7 +7,7 @@ object `package` extends RootModule with ScalaModule {
 
   def ivyDeps = Agg(ivy"com.lihaoyi::os-lib:0.10.7")
   def htmlSnippet = T{ div(h1("hello"), p("world")).toString }
-  def resources = Task.sources{
+  def resources = Task.Sources{
     os.write(Task.dest / "snippet.txt", htmlSnippet())
     super.resources() ++ Seq(PathRef(Task.dest))
   }

--- a/example/extending/metabuild/4-meta-build/build.mill
+++ b/example/extending/metabuild/4-meta-build/build.mill
@@ -11,7 +11,7 @@ object `package` extends RootModule with ScalaModule {
   )
 
   def htmlSnippet = T{ h1("hello").toString }
-  def resources = Task.sources{
+  def resources = Task.Sources{
     os.write(Task.dest / "snippet.txt", htmlSnippet())
     super.resources() ++ Seq(PathRef(Task.dest))
   }

--- a/example/extending/metabuild/4-meta-build/build.mill
+++ b/example/extending/metabuild/4-meta-build/build.mill
@@ -11,9 +11,9 @@ object `package` extends RootModule with ScalaModule {
   )
 
   def htmlSnippet = T{ h1("hello").toString }
-  def resources = T.sources{
-    os.write(T.dest / "snippet.txt", htmlSnippet())
-    super.resources() ++ Seq(PathRef(T.dest))
+  def resources = Task.sources{
+    os.write(Task.dest / "snippet.txt", htmlSnippet())
+    super.resources() ++ Seq(PathRef(Task.dest))
   }
 }
 

--- a/example/extending/metabuild/4-meta-build/mill-build/build.mill
+++ b/example/extending/metabuild/4-meta-build/mill-build/build.mill
@@ -5,7 +5,7 @@ object `package` extends MillBuildRootModule{
   val scalatagsVersion = "0.12.0"
   def ivyDeps = Agg(ivy"com.lihaoyi::scalatags:$scalatagsVersion")
 
-  def generatedSources = T {
+  def generatedSources = Task {
     os.write(
       T.dest / "DepVersions.scala",
       s"""

--- a/example/extending/metabuild/4-meta-build/mill-build/build.mill
+++ b/example/extending/metabuild/4-meta-build/mill-build/build.mill
@@ -7,7 +7,7 @@ object `package` extends MillBuildRootModule{
 
   def generatedSources = Task {
     os.write(
-      T.dest / "DepVersions.scala",
+      Task.dest / "DepVersions.scala",
       s"""
          |package millbuild
          |object DepVersions{
@@ -15,6 +15,6 @@ object `package` extends MillBuildRootModule{
          |}
       """.stripMargin
     )
-    super.generatedSources() ++ Seq(PathRef(T.dest))
+    super.generatedSources() ++ Seq(PathRef(Task.dest))
   }
 }

--- a/example/extending/metabuild/5-meta-shared-sources/build.mill
+++ b/example/extending/metabuild/5-meta-shared-sources/build.mill
@@ -4,7 +4,7 @@ import mill._, scalalib._
 
 object `package` extends RootModule with ScalaModule {
   def scalaVersion = millbuild.ScalaVersion.myScalaVersion
-  def sources = T.sources{
+  def sources = Task.sources{
     super.sources() ++ Seq(PathRef(millSourcePath / "mill-build/src"))
   }
 }

--- a/example/extending/metabuild/5-meta-shared-sources/build.mill
+++ b/example/extending/metabuild/5-meta-shared-sources/build.mill
@@ -4,7 +4,7 @@ import mill._, scalalib._
 
 object `package` extends RootModule with ScalaModule {
   def scalaVersion = millbuild.ScalaVersion.myScalaVersion
-  def sources = Task.sources{
+  def sources = Task.Sources{
     super.sources() ++ Seq(PathRef(millSourcePath / "mill-build/src"))
   }
 }

--- a/example/extending/plugins/7-writing-mill-plugins/build.mill
+++ b/example/extending/plugins/7-writing-mill-plugins/build.mill
@@ -21,9 +21,9 @@ object myplugin extends ScalaModule with PublishModule {
       def ivyDeps = Agg(ivy"com.lihaoyi:mill-dist:$millVersion")
       def mainClass = Some("mill.runner.client.MillClientMain")
       def resources = T{
-        val p = T.dest / "mill/local-test-overrides" / s"com.lihaoyi-${myplugin.artifactId()}"
+        val p = Task.dest / "mill/local-test-overrides" / s"com.lihaoyi-${myplugin.artifactId()}"
         os.write(p, myplugin.localClasspath().map(_.path).mkString("\n"), createFolders = true)
-        Seq(PathRef(T.dest))
+        Seq(PathRef(Task.dest))
       }
     }
   }

--- a/example/extending/plugins/7-writing-mill-plugins/myplugin/src/LineCountJavaModule.scala
+++ b/example/extending/plugins/7-writing-mill-plugins/myplugin/src/LineCountJavaModule.scala
@@ -15,7 +15,7 @@ trait LineCountJavaModule extends mill.javalib.JavaModule{
 
   /** Generate resources using lineCount of sources */
   override def resources = T{
-    os.write(T.dest / lineCountResourceFileName(), "" + lineCount())
-    super.resources() ++ Seq(PathRef(T.dest))
+    os.write(Task.dest / lineCountResourceFileName(), "" + lineCount())
+    super.resources() ++ Seq(PathRef(Task.dest))
   }
 }

--- a/example/external/libraries/3-requests/build.mill
+++ b/example/external/libraries/3-requests/build.mill
@@ -18,10 +18,10 @@ import mill._
 def remoteApisZip = T{
   println("downloading bazel-remote-apis sources...")
   os.write(
-    T.dest / "source.zip",
+    Task.dest / "source.zip",
     requests.get("https://github.com/bazelbuild/remote-apis/archive/refs/tags/v2.2.0.zip")
   )
-  PathRef(T.dest / "source.zip")
+  PathRef(Task.dest / "source.zip")
 }
 
 def bazel = T{
@@ -31,27 +31,27 @@ def bazel = T{
     else "bazel-5.4.1-linux-x86_64"
 
   os.write(
-    T.dest / "bazel",
+    Task.dest / "bazel",
     requests.get(s"https://github.com/bazelbuild/bazel/releases/download/5.4.1/$fileName")
   )
-  os.perms.set(T.dest / "bazel", "rwxrwxrwx")
-  PathRef(T.dest / "bazel")
+  os.perms.set(Task.dest / "bazel", "rwxrwxrwx")
+  PathRef(Task.dest / "bazel")
 }
 
 def compiledRemoteApis = T{
   val javaBuildTarget = "build/bazel/remote/execution/v2:remote_execution_java_proto"
-  os.call(("unzip", remoteApisZip().path, "-d", T.dest))
-  os.call((bazel().path, "build", javaBuildTarget), cwd = T.dest / "remote-apis-2.2.0")
+  os.call(("unzip", remoteApisZip().path, "-d", Task.dest))
+  os.call((bazel().path, "build", javaBuildTarget), cwd = Task.dest / "remote-apis-2.2.0")
 
   val queried = os.call(
     (bazel().path, "cquery", javaBuildTarget, "--output=files"),
-    cwd = T.dest / "remote-apis-2.2.0"
+    cwd = Task.dest / "remote-apis-2.2.0"
   )
 
   queried
     .out
     .lines()
-    .map(line => PathRef(T.dest / "remote-apis-2.2.0" / os.SubPath(line)))
+    .map(line => PathRef(Task.dest / "remote-apis-2.2.0" / os.SubPath(line)))
 }
 
 // In the execution example below, we can see the first time we ask for `compiledRemoteApis`,

--- a/example/external/libraries/4-mainargs/build.mill
+++ b/example/external/libraries/4-mainargs/build.mill
@@ -1,8 +1,8 @@
-// Mill uses MainArgs to handle argument parsing for ``Task.command``s that
+// Mill uses MainArgs to handle argument parsing for ``Task.Command``s that
 // are run from the command line.
 import mill._
 
-def commandSimple(str: String, i: Int, bool: Boolean = true) = Task.command{
+def commandSimple(str: String, i: Int, bool: Boolean = true) = Task.Command{
   println(s"$str $i $bool")
 }
 
@@ -26,7 +26,7 @@ hello 123 true
 // supports parsing OS-Lib ``os.Path``s from the command line:
 
 
-def commandTakingPath(path: os.Path) = Task.command{
+def commandTakingPath(path: os.Path) = Task.Command{
   println(path)
 }
 
@@ -54,7 +54,7 @@ implicit object LettersOrDigitsTokensReader
   }
 }
 
-def commandCustomArg(custom: LettersOrDigits) = Task.command{
+def commandCustomArg(custom: LettersOrDigits) = Task.Command{
   println("hello " + custom.value)
 }
 
@@ -82,7 +82,7 @@ error: Invalid argument --custom <letters-or-digits> failed to parse "123?abc"..
 // command as part of another target, while passing it the value of an upstream
 // target:
 
-def commandTakingTask(str: Task[String]) = Task.command{
+def commandTakingTask(str: Task[String]) = Task.Command{
   val result = "arg: " + str()
   println(result)
   result
@@ -125,7 +125,7 @@ def targetCallingCommand = T{
 import mill.eval.{Evaluator, Terminal}
 import mill.resolve.{Resolve, SelectMode}
 
-def customPlanCommand(evaluator: Evaluator, targets: String*) = Task.command {
+def customPlanCommand(evaluator: Evaluator, targets: String*) = Task.Command {
   Resolve.Tasks.resolve(
     evaluator.rootModule,
     targets,

--- a/example/external/libraries/4-mainargs/build.mill
+++ b/example/external/libraries/4-mainargs/build.mill
@@ -1,8 +1,8 @@
-// Mill uses MainArgs to handle argument parsing for ``T.command``s that
+// Mill uses MainArgs to handle argument parsing for ``Task.command``s that
 // are run from the command line.
 import mill._
 
-def commandSimple(str: String, i: Int, bool: Boolean = true) = T.command{
+def commandSimple(str: String, i: Int, bool: Boolean = true) = Task.command{
   println(s"$str $i $bool")
 }
 
@@ -26,7 +26,7 @@ hello 123 true
 // supports parsing OS-Lib ``os.Path``s from the command line:
 
 
-def commandTakingPath(path: os.Path) = T.command{
+def commandTakingPath(path: os.Path) = Task.command{
   println(path)
 }
 
@@ -54,7 +54,7 @@ implicit object LettersOrDigitsTokensReader
   }
 }
 
-def commandCustomArg(custom: LettersOrDigits) = T.command{
+def commandCustomArg(custom: LettersOrDigits) = Task.command{
   println("hello " + custom.value)
 }
 
@@ -82,7 +82,7 @@ error: Invalid argument --custom <letters-or-digits> failed to parse "123?abc"..
 // command as part of another target, while passing it the value of an upstream
 // target:
 
-def commandTakingTask(str: Task[String]) = T.command{
+def commandTakingTask(str: Task[String]) = Task.command{
   val result = "arg: " + str()
   println(result)
   result
@@ -125,7 +125,7 @@ def targetCallingCommand = T{
 import mill.eval.{Evaluator, Terminal}
 import mill.resolve.{Resolve, SelectMode}
 
-def customPlanCommand(evaluator: Evaluator, targets: String*) = T.command {
+def customPlanCommand(evaluator: Evaluator, targets: String*) = Task.command {
   Resolve.Tasks.resolve(
     evaluator.rootModule,
     targets,

--- a/example/javalib/basic/2-custom-build-logic/build.mill
+++ b/example/javalib/basic/2-custom-build-logic/build.mill
@@ -10,7 +10,7 @@ object `package` extends RootModule with JavaModule {
 
   /** Generate resources using lineCount of sources */
   override def resources = T{
-    os.write(T.dest / "line-count.txt", "" + lineCount())
-    Seq(PathRef(T.dest))
+    os.write(Task.dest / "line-count.txt", "" + lineCount())
+    Seq(PathRef(Task.dest))
   }
 }

--- a/example/javalib/builds/1-common-config/build.mill
+++ b/example/javalib/builds/1-common-config/build.mill
@@ -12,19 +12,19 @@ object `package` extends RootModule with JavaModule {
   def mainClass: T[Option[String]] = Some("foo.Foo2")
 
   // Add (or replace) source folders for the module to use
-  def sources = T.sources{
+  def sources = Task.sources{
     super.sources() ++ Seq(PathRef(millSourcePath / "custom-src"))
   }
 
   // Add (or replace) resource folders for the module to use
-  def resources = T.sources{
+  def resources = Task.sources{
     super.resources() ++ Seq(PathRef(millSourcePath / "custom-resources"))
   }
 
   // Generate sources at build time
   def generatedSources: T[Seq[PathRef]] = Task {
     for(name <- Seq("A", "B", "C")) os.write(
-      T.dest / s"Foo$name.java",
+      Task.dest / s"Foo$name.java",
       s"""
          |package foo;
          |public class Foo$name {
@@ -33,7 +33,7 @@ object `package` extends RootModule with JavaModule {
       """.stripMargin
     )
 
-    Seq(PathRef(T.dest))
+    Seq(PathRef(Task.dest))
   }
 
   // Pass additional JVM flags when `.run` is called or in the executable

--- a/example/javalib/builds/1-common-config/build.mill
+++ b/example/javalib/builds/1-common-config/build.mill
@@ -12,12 +12,12 @@ object `package` extends RootModule with JavaModule {
   def mainClass: T[Option[String]] = Some("foo.Foo2")
 
   // Add (or replace) source folders for the module to use
-  def sources = Task.sources{
+  def sources = Task.Sources{
     super.sources() ++ Seq(PathRef(millSourcePath / "custom-src"))
   }
 
   // Add (or replace) resource folders for the module to use
-  def resources = Task.sources{
+  def resources = Task.Sources{
     super.resources() ++ Seq(PathRef(millSourcePath / "custom-resources"))
   }
 

--- a/example/javalib/builds/1-common-config/build.mill
+++ b/example/javalib/builds/1-common-config/build.mill
@@ -22,7 +22,7 @@ object `package` extends RootModule with JavaModule {
   }
 
   // Generate sources at build time
-  def generatedSources: T[Seq[PathRef]] = T {
+  def generatedSources: T[Seq[PathRef]] = Task {
     for(name <- Seq("A", "B", "C")) os.write(
       T.dest / s"Foo$name.java",
       s"""

--- a/example/javalib/builds/2-custom-tasks/build.mill
+++ b/example/javalib/builds/2-custom-tasks/build.mill
@@ -14,7 +14,7 @@ object `package` extends RootModule with JavaModule {
     }
     val ivyDepsString = prettyIvyDeps.mkString(" + \"\\n\" + \n")
     os.write(
-      T.dest / s"MyDeps.java",
+      Task.dest / s"MyDeps.java",
       s"""
          |package foo;
          |public class MyDeps {
@@ -24,7 +24,7 @@ object `package` extends RootModule with JavaModule {
       """.stripMargin
     )
 
-    Seq(PathRef(T.dest))
+    Seq(PathRef(Task.dest))
   }
 
   def lineCount: T[Int] = Task {
@@ -37,7 +37,7 @@ object `package` extends RootModule with JavaModule {
 
   def forkArgs: T[Seq[String]] = Seq(s"-Dmy.line.count=${lineCount()}")
 
-  def printLineCount() = T.command { println(lineCount()) }
+  def printLineCount() = Task.command { println(lineCount()) }
 }
 
 //// SNIPPET:COMMANDS

--- a/example/javalib/builds/2-custom-tasks/build.mill
+++ b/example/javalib/builds/2-custom-tasks/build.mill
@@ -37,7 +37,7 @@ object `package` extends RootModule with JavaModule {
 
   def forkArgs: T[Seq[String]] = Seq(s"-Dmy.line.count=${lineCount()}")
 
-  def printLineCount() = Task.command { println(lineCount()) }
+  def printLineCount() = Task.Command { println(lineCount()) }
 }
 
 //// SNIPPET:COMMANDS

--- a/example/javalib/builds/2-custom-tasks/build.mill
+++ b/example/javalib/builds/2-custom-tasks/build.mill
@@ -5,7 +5,7 @@ import mill._, javalib._
 object `package` extends RootModule with JavaModule {
   def ivyDeps = Agg(ivy"net.sourceforge.argparse4j:argparse4j:0.9.0")
 
-  def generatedSources: T[Seq[PathRef]] = T {
+  def generatedSources: T[Seq[PathRef]] = Task {
     val prettyIvyDeps = for(ivyDep <- ivyDeps()) yield {
       val org = ivyDep.dep.module.organization.value
       val name = ivyDep.dep.module.name.value
@@ -27,7 +27,7 @@ object `package` extends RootModule with JavaModule {
     Seq(PathRef(T.dest))
   }
 
-  def lineCount: T[Int] = T {
+  def lineCount: T[Int] = Task {
     sources()
       .flatMap(pathRef => os.walk(pathRef.path))
       .filter(_.ext == "java")

--- a/example/javalib/builds/3-override-tasks/build.mill
+++ b/example/javalib/builds/3-override-tasks/build.mill
@@ -24,7 +24,7 @@ object foo extends JavaModule {
     super.compile()
   }
 
-  def run(args: Task[Args] = Task.anon(Args())) = Task.command {
+  def run(args: Task[Args] = Task.Anon(Args())) = Task.Command {
     println("Running..." + args().value.mkString(" "))
     super.run(args)()
   }

--- a/example/javalib/builds/3-override-tasks/build.mill
+++ b/example/javalib/builds/3-override-tasks/build.mill
@@ -6,7 +6,7 @@ object foo extends JavaModule {
 
   def sources = T{
     os.write(
-      T.dest / "Foo.java",
+      Task.dest / "Foo.java",
       """package foo;
         |
         |public class Foo {
@@ -16,7 +16,7 @@ object foo extends JavaModule {
         |}
       """.stripMargin
     )
-    Seq(PathRef(T.dest))
+    Seq(PathRef(Task.dest))
   }
 
   def compile = Task {
@@ -24,7 +24,7 @@ object foo extends JavaModule {
     super.compile()
   }
 
-  def run(args: Task[Args] = T.task(Args())) = T.command {
+  def run(args: Task[Args] = Task.task(Args())) = Task.command {
     println("Running..." + args().value.mkString(" "))
     super.run(args)()
   }
@@ -33,14 +33,14 @@ object foo extends JavaModule {
 
 object foo2 extends JavaModule {
   def generatedSources = T{
-    os.write(T.dest / "Foo.java", """...""")
-    Seq(PathRef(T.dest))
+    os.write(Task.dest / "Foo.java", """...""")
+    Seq(PathRef(Task.dest))
   }
 }
 
 object foo3 extends JavaModule {
   def sources = T{
-    os.write(T.dest / "Foo.java", """...""")
-    super.sources() ++ Seq(PathRef(T.dest))
+    os.write(Task.dest / "Foo.java", """...""")
+    super.sources() ++ Seq(PathRef(Task.dest))
   }
 }

--- a/example/javalib/builds/3-override-tasks/build.mill
+++ b/example/javalib/builds/3-override-tasks/build.mill
@@ -24,7 +24,7 @@ object foo extends JavaModule {
     super.compile()
   }
 
-  def run(args: Task[Args] = Task.task(Args())) = Task.command {
+  def run(args: Task[Args] = Task.anon(Args())) = Task.command {
     println("Running..." + args().value.mkString(" "))
     super.run(args)()
   }

--- a/example/javalib/builds/3-override-tasks/build.mill
+++ b/example/javalib/builds/3-override-tasks/build.mill
@@ -19,7 +19,7 @@ object foo extends JavaModule {
     Seq(PathRef(T.dest))
   }
 
-  def compile = T {
+  def compile = Task {
     println("Compiling...")
     super.compile()
   }

--- a/example/javalib/builds/9-realistic/build.mill
+++ b/example/javalib/builds/9-realistic/build.mill
@@ -24,7 +24,7 @@ object foo extends MyModule {
 
   def generatedSources = Task {
     os.write(
-      T.dest / "Version.java",
+      Task.dest / "Version.java",
       s"""
          |package foo;
          |public class Version {
@@ -34,7 +34,7 @@ object foo extends MyModule {
          |}
       """.stripMargin
     )
-    Seq(PathRef(T.dest))
+    Seq(PathRef(Task.dest))
   }
 }
 

--- a/example/javalib/builds/9-realistic/build.mill
+++ b/example/javalib/builds/9-realistic/build.mill
@@ -22,7 +22,7 @@ trait MyModule extends JavaModule with PublishModule {
 object foo extends MyModule {
   def moduleDeps = Seq(bar, qux)
 
-  def generatedSources = T {
+  def generatedSources = Task {
     os.write(
       T.dest / "Version.java",
       s"""

--- a/example/javalib/module/10-downloading-non-maven-jars/build.mill
+++ b/example/javalib/module/10-downloading-non-maven-jars/build.mill
@@ -3,7 +3,7 @@ package build
 import mill._, javalib._
 
 object `package` extends RootModule with JavaModule {
-  def unmanagedClasspath = T {
+  def unmanagedClasspath = Task {
     os.write(
       T.dest / "fastjavaio.jar",
       requests.get.stream(

--- a/example/javalib/module/10-downloading-non-maven-jars/build.mill
+++ b/example/javalib/module/10-downloading-non-maven-jars/build.mill
@@ -5,12 +5,12 @@ import mill._, javalib._
 object `package` extends RootModule with JavaModule {
   def unmanagedClasspath = Task {
     os.write(
-      T.dest / "fastjavaio.jar",
+      Task.dest / "fastjavaio.jar",
       requests.get.stream(
         "https://github.com/williamfiset/FastJavaIO/releases/download/1.1/fastjavaio.jar"
       )
     )
-    Agg(PathRef(T.dest / "fastjavaio.jar"))
+    Agg(PathRef(Task.dest / "fastjavaio.jar"))
   }
 }
 

--- a/example/javalib/module/12-repository-config/build.mill
+++ b/example/javalib/module/12-repository-config/build.mill
@@ -15,18 +15,18 @@ object foo extends JavaModule {
     ivy"org.apache.commons:commons-text:1.12.0"
   )
 
-  def repositoriesTask = T.task { super.repositoriesTask() ++ sonatypeReleases }
+  def repositoriesTask = Task.task { super.repositoriesTask() ++ sonatypeReleases }
 }
 
 //// SNIPPET:BUILD2
 
 object CustomZincWorkerModule extends ZincWorkerModule with CoursierModule {
-  def repositoriesTask = T.task { super.repositoriesTask() ++ sonatypeReleases }
+  def repositoriesTask = Task.task { super.repositoriesTask() ++ sonatypeReleases }
 }
 
 object bar extends JavaModule {
   def zincWorker = ModuleRef(CustomZincWorkerModule)
   // ... rest of your build definitions
 
-  def repositoriesTask = T.task { super.repositoriesTask() ++ sonatypeReleases }
+  def repositoriesTask = Task.task { super.repositoriesTask() ++ sonatypeReleases }
 }

--- a/example/javalib/module/12-repository-config/build.mill
+++ b/example/javalib/module/12-repository-config/build.mill
@@ -15,18 +15,18 @@ object foo extends JavaModule {
     ivy"org.apache.commons:commons-text:1.12.0"
   )
 
-  def repositoriesTask = Task.task { super.repositoriesTask() ++ sonatypeReleases }
+  def repositoriesTask = Task.anon { super.repositoriesTask() ++ sonatypeReleases }
 }
 
 //// SNIPPET:BUILD2
 
 object CustomZincWorkerModule extends ZincWorkerModule with CoursierModule {
-  def repositoriesTask = Task.task { super.repositoriesTask() ++ sonatypeReleases }
+  def repositoriesTask = Task.anon { super.repositoriesTask() ++ sonatypeReleases }
 }
 
 object bar extends JavaModule {
   def zincWorker = ModuleRef(CustomZincWorkerModule)
   // ... rest of your build definitions
 
-  def repositoriesTask = Task.task { super.repositoriesTask() ++ sonatypeReleases }
+  def repositoriesTask = Task.anon { super.repositoriesTask() ++ sonatypeReleases }
 }

--- a/example/javalib/module/12-repository-config/build.mill
+++ b/example/javalib/module/12-repository-config/build.mill
@@ -15,18 +15,18 @@ object foo extends JavaModule {
     ivy"org.apache.commons:commons-text:1.12.0"
   )
 
-  def repositoriesTask = Task.anon { super.repositoriesTask() ++ sonatypeReleases }
+  def repositoriesTask = Task.Anon { super.repositoriesTask() ++ sonatypeReleases }
 }
 
 //// SNIPPET:BUILD2
 
 object CustomZincWorkerModule extends ZincWorkerModule with CoursierModule {
-  def repositoriesTask = Task.anon { super.repositoriesTask() ++ sonatypeReleases }
+  def repositoriesTask = Task.Anon { super.repositoriesTask() ++ sonatypeReleases }
 }
 
 object bar extends JavaModule {
   def zincWorker = ModuleRef(CustomZincWorkerModule)
   // ... rest of your build definitions
 
-  def repositoriesTask = Task.anon { super.repositoriesTask() ++ sonatypeReleases }
+  def repositoriesTask = Task.Anon { super.repositoriesTask() ++ sonatypeReleases }
 }

--- a/example/javalib/module/13-jni/build.mill
+++ b/example/javalib/module/13-jni/build.mill
@@ -3,12 +3,12 @@ import mill._, javalib._, util.Jvm
 
 object `package` extends RootModule with JavaModule {
   // Additional source folder to put C sources
-  def nativeSources = T.sources(millSourcePath / "native-src")
+  def nativeSources = Task.sources(millSourcePath / "native-src")
 
   // Auto-generate JNI `.h` files from Java classes using Javac
   def nativeHeaders = Task {
-    os.proc(Jvm.jdkTool("javac"), "-h", T.dest, "-d", T.dest.toString, allSourceFiles().map(_.path)).call()
-    PathRef(T.dest)
+    os.proc(Jvm.jdkTool("javac"), "-h", Task.dest, "-d", Task.dest.toString, allSourceFiles().map(_.path)).call()
+    PathRef(Task.dest)
   }
 
   // Compile C
@@ -21,12 +21,12 @@ object `package` extends RootModule with JavaModule {
         "-I" + sys.props("java.home") + "/include/", // global JVM header files
         "-I" + sys.props("java.home") + "/include/darwin",
         "-I" + sys.props("java.home") + "/include/linux",
-        "-o", T.dest / output,
+        "-o", Task.dest / output,
         cSourceFiles
       )
       .call(stdout = os.Inherit)
 
-    PathRef(T.dest / output)
+    PathRef(Task.dest / output)
   }
 
   def forkEnv = Map("HELLO_WORLD_BINARY" -> nativeCompiled().path.toString)

--- a/example/javalib/module/13-jni/build.mill
+++ b/example/javalib/module/13-jni/build.mill
@@ -6,7 +6,7 @@ object `package` extends RootModule with JavaModule {
   def nativeSources = T.sources(millSourcePath / "native-src")
 
   // Auto-generate JNI `.h` files from Java classes using Javac
-  def nativeHeaders = T {
+  def nativeHeaders = Task {
     os.proc(Jvm.jdkTool("javac"), "-h", T.dest, "-d", T.dest.toString, allSourceFiles().map(_.path)).call()
     PathRef(T.dest)
   }

--- a/example/javalib/module/13-jni/build.mill
+++ b/example/javalib/module/13-jni/build.mill
@@ -3,7 +3,7 @@ import mill._, javalib._, util.Jvm
 
 object `package` extends RootModule with JavaModule {
   // Additional source folder to put C sources
-  def nativeSources = Task.sources(millSourcePath / "native-src")
+  def nativeSources = Task.Sources(millSourcePath / "native-src")
 
   // Auto-generate JNI `.h` files from Java classes using Javac
   def nativeHeaders = Task {

--- a/example/javalib/module/5-resources/build.mill
+++ b/example/javalib/module/5-resources/build.mill
@@ -4,7 +4,7 @@ import mill._, javalib._
 
 object foo extends JavaModule {
   object test extends JavaTests with TestModule.Junit4 {
-    def otherFiles = T.source(millSourcePath / "other-files")
+    def otherFiles = Task.source(millSourcePath / "other-files")
 
     def forkEnv = super.forkEnv() ++ Map(
       "OTHER_FILES_FOLDER" -> otherFiles().path.toString

--- a/example/javalib/module/5-resources/build.mill
+++ b/example/javalib/module/5-resources/build.mill
@@ -4,7 +4,7 @@ import mill._, javalib._
 
 object foo extends JavaModule {
   object test extends JavaTests with TestModule.Junit4 {
-    def otherFiles = Task.source(millSourcePath / "other-files")
+    def otherFiles = Task.Source(millSourcePath / "other-files")
 
     def forkEnv = super.forkEnv() ++ Map(
       "OTHER_FILES_FOLDER" -> otherFiles().path.toString

--- a/example/javalib/module/8-unmanaged-jars/build.mill
+++ b/example/javalib/module/8-unmanaged-jars/build.mill
@@ -3,7 +3,7 @@ package build
 import mill._, javalib._
 
 object `package` extends RootModule with JavaModule {
-  def unmanagedClasspath = T {
+  def unmanagedClasspath = Task {
     if (!os.exists(millSourcePath / "lib")) Agg()
     else Agg.from(os.list(millSourcePath / "lib").map(PathRef(_)))
   }

--- a/example/javalib/web/5-todo-micronaut/build.mill
+++ b/example/javalib/web/5-todo-micronaut/build.mill
@@ -40,7 +40,7 @@ object `package` extends RootModule with MicronautModule {
 trait MicronautModule extends MavenModule{
   def micronautVersion: String
 
-  def processors = T {
+  def processors = Task {
     defaultResolver().resolveDeps(
       Agg(
         ivy"io.micronaut.data:micronaut-data-processor:4.7.0",

--- a/example/javalib/web/5-todo-micronaut/src/main/java/example/micronaut/LoggingHeadersFilter.java
+++ b/example/javalib/web/5-todo-micronaut/src/main/java/example/micronaut/LoggingHeadersFilter.java
@@ -23,6 +23,6 @@ class LoggingHeadersFilter implements Ordered {
 
     @Override
     public int getOrder() {
-        return ServerFilterPhase.FIRST.order();
+        return ServerFilterPhase.FIRSTask.order();
     }
 }

--- a/example/javalib/web/5-todo-micronaut/src/main/java/example/micronaut/LoggingHeadersFilter.java
+++ b/example/javalib/web/5-todo-micronaut/src/main/java/example/micronaut/LoggingHeadersFilter.java
@@ -23,6 +23,6 @@ class LoggingHeadersFilter implements Ordered {
 
     @Override
     public int getOrder() {
-        return ServerFilterPhase.FIRSTask.order();
+        return ServerFilterPhase.FIRST.order();
     }
 }

--- a/example/kotlinlib/basic/2-custom-build-logic/build.mill
+++ b/example/kotlinlib/basic/2-custom-build-logic/build.mill
@@ -15,8 +15,8 @@ object `package` extends RootModule with KotlinModule {
 
   /** Generate resources using lineCount of sources */
   override def resources = T{
-    os.write(T.dest / "line-count.txt", "" + lineCount())
-    Seq(PathRef(T.dest))
+    os.write(Task.dest / "line-count.txt", "" + lineCount())
+    Seq(PathRef(Task.dest))
   }
 
   object test extends KotlinModuleTests with TestModule.Junit5 {

--- a/example/scalalib/basic/2-custom-build-logic/build.mill
+++ b/example/scalalib/basic/2-custom-build-logic/build.mill
@@ -18,8 +18,8 @@ object `package` extends RootModule with ScalaModule {
 
   /** Generate resources using lineCount of sources */
   override def resources = T{
-    os.write(T.dest / "line-count.txt", "" + lineCount())
-    Seq(PathRef(T.dest))
+    os.write(Task.dest / "line-count.txt", "" + lineCount())
+    Seq(PathRef(Task.dest))
   }
 }
 

--- a/example/scalalib/builds/1-common-config/build.mill
+++ b/example/scalalib/builds/1-common-config/build.mill
@@ -20,12 +20,12 @@ object `package` extends RootModule with ScalaModule {
   def mainClass: T[Option[String]] = Some("foo.Foo2")
 
   // Add (or replace) source folders for the module to use
-  def sources = Task.sources{
+  def sources = Task.Sources{
     super.sources() ++ Seq(PathRef(millSourcePath / "custom-src"))
   }
 
   // Add (or replace) resource folders for the module to use
-  def resources = Task.sources{
+  def resources = Task.Sources{
     super.resources() ++ Seq(PathRef(millSourcePath / "custom-resources"))
   }
 

--- a/example/scalalib/builds/1-common-config/build.mill
+++ b/example/scalalib/builds/1-common-config/build.mill
@@ -20,19 +20,19 @@ object `package` extends RootModule with ScalaModule {
   def mainClass: T[Option[String]] = Some("foo.Foo2")
 
   // Add (or replace) source folders for the module to use
-  def sources = T.sources{
+  def sources = Task.sources{
     super.sources() ++ Seq(PathRef(millSourcePath / "custom-src"))
   }
 
   // Add (or replace) resource folders for the module to use
-  def resources = T.sources{
+  def resources = Task.sources{
     super.resources() ++ Seq(PathRef(millSourcePath / "custom-resources"))
   }
 
   // Generate sources at build time
   def generatedSources: T[Seq[PathRef]] = Task {
     for(name <- Seq("A", "B", "C")) os.write(
-      T.dest / s"Foo$name.scala",
+      Task.dest / s"Foo$name.scala",
       s"""
          |package foo
          |object Foo$name {
@@ -41,7 +41,7 @@ object `package` extends RootModule with ScalaModule {
       """.stripMargin
     )
 
-    Seq(PathRef(T.dest))
+    Seq(PathRef(Task.dest))
   }
 
   // Pass additional JVM flags when `.run` is called or in the executable
@@ -68,7 +68,7 @@ object `package` extends RootModule with ScalaModule {
 //// SNIPPET:END
 //
 //
-// Note the use of `millSourcePath`, `T.dest`, and `PathRef` when preforming
+// Note the use of `millSourcePath`, `Task.dest`, and `PathRef` when preforming
 // various filesystem operations:
 //
 // 1. `millSourcePath` refers to the base path of the module. For the root
@@ -76,7 +76,7 @@ object `package` extends RootModule with ScalaModule {
 //    the module path e.g. for module `foo.bar.qux` the `millSourcePath` would
 //    be `foo/bar/qux`. This can also be overriden if necessary
 //
-// 2. `T.dest` refers to the destination folder for a task in the `out/`
+// 2. `Task.dest` refers to the destination folder for a task in the `out/`
 //    folder. This is unique to each task, and can act as both a scratch space
 //    for temporary computations as well as a place to put "output" files,
 //    without worrying about filesystem conflicts with other tasks

--- a/example/scalalib/builds/1-common-config/build.mill
+++ b/example/scalalib/builds/1-common-config/build.mill
@@ -30,7 +30,7 @@ object `package` extends RootModule with ScalaModule {
   }
 
   // Generate sources at build time
-  def generatedSources: T[Seq[PathRef]] = T {
+  def generatedSources: T[Seq[PathRef]] = Task {
     for(name <- Seq("A", "B", "C")) os.write(
       T.dest / s"Foo$name.scala",
       s"""

--- a/example/scalalib/builds/2-custom-tasks/build.mill
+++ b/example/scalalib/builds/2-custom-tasks/build.mill
@@ -48,7 +48,7 @@ object `package` extends RootModule with ScalaModule {
 
   def forkArgs: T[Seq[String]] = Seq(s"-Dmy.line.count=${lineCount()}")
 
-  def printLineCount() = Task.command { println(lineCount()) }
+  def printLineCount() = Task.Command { println(lineCount()) }
 }
 
 //// SNIPPET:END

--- a/example/scalalib/builds/2-custom-tasks/build.mill
+++ b/example/scalalib/builds/2-custom-tasks/build.mill
@@ -16,7 +16,7 @@ object `package` extends RootModule with ScalaModule {
   def scalaVersion = "2.13.8"
   def ivyDeps = Agg(ivy"com.lihaoyi::mainargs:0.4.0")
 
-  def generatedSources: T[Seq[PathRef]] = T {
+  def generatedSources: T[Seq[PathRef]] = Task {
     val prettyIvyDeps = for(ivyDep <- ivyDeps()) yield {
       val org = ivyDep.dep.module.organization.value
       val name = ivyDep.dep.module.name.value
@@ -38,7 +38,7 @@ object `package` extends RootModule with ScalaModule {
     Seq(PathRef(T.dest))
   }
 
-  def lineCount: T[Int] = T {
+  def lineCount: T[Int] = Task {
     sources()
       .flatMap(pathRef => os.walk(pathRef.path))
       .filter(_.ext == "scala")
@@ -53,7 +53,7 @@ object `package` extends RootModule with ScalaModule {
 
 //// SNIPPET:END
 
-// Mill lets you define new cached Targets using the `T {...}` syntax,
+// Mill lets you define new cached Targets using the `Task {...}` syntax,
 // depending on existing Targets e.g. `foo.sources` via the `foo.sources()`
 // syntax to extract their current value, as shown in `lineCount` above. The
 // return-type of a Target has to be JSON-serializable (using
@@ -91,7 +91,7 @@ my.line.count: 14
 // download files using `requests.get`, shell-out to Webpack
 // to compile some Javascript, generate sources to feed into a compiler, or
 // create some custom jar/zip assembly with the files you want , all of these
-// can simply be custom targets with your code running in the `T {...}` block.
+// can simply be custom targets with your code running in the `Task {...}` block.
 //
 // You can create arbitrarily long chains of dependent targets, and Mill will
 // handle the re-evaluation and caching of the targets' output for you.

--- a/example/scalalib/builds/2-custom-tasks/build.mill
+++ b/example/scalalib/builds/2-custom-tasks/build.mill
@@ -24,7 +24,7 @@ object `package` extends RootModule with ScalaModule {
       s"""("$org", "$name", "$version")"""
     }
     os.write(
-      T.dest / s"MyDeps.scala",
+      Task.dest / s"MyDeps.scala",
       s"""
          |package foo
          |object MyDeps {
@@ -35,7 +35,7 @@ object `package` extends RootModule with ScalaModule {
       """.stripMargin
     )
 
-    Seq(PathRef(T.dest))
+    Seq(PathRef(Task.dest))
   }
 
   def lineCount: T[Int] = Task {
@@ -48,7 +48,7 @@ object `package` extends RootModule with ScalaModule {
 
   def forkArgs: T[Seq[String]] = Seq(s"-Dmy.line.count=${lineCount()}")
 
-  def printLineCount() = T.command { println(lineCount()) }
+  def printLineCount() = Task.command { println(lineCount()) }
 }
 
 //// SNIPPET:END
@@ -95,10 +95,10 @@ my.line.count: 14
 //
 // You can create arbitrarily long chains of dependent targets, and Mill will
 // handle the re-evaluation and caching of the targets' output for you.
-// Mill also provides you a `T.dest` folder for you to use as scratch space or
+// Mill also provides you a `Task.dest` folder for you to use as scratch space or
 // to store files you want to return: all files a task creates should live
-// within `T.dest`, and any files you want to modify should be copied into
-// `T.dest` before being modified. That ensures that the files belonging to a
+// within `Task.dest`, and any files you want to modify should be copied into
+// `Task.dest` before being modified. That ensures that the files belonging to a
 // particular target all live in one place, avoiding file-name conflicts and
 // letting Mill automatically invalidate the files when the target's inputs
 // change.

--- a/example/scalalib/builds/3-override-tasks/build.mill
+++ b/example/scalalib/builds/3-override-tasks/build.mill
@@ -35,7 +35,7 @@ object foo extends ScalaModule {
 // You can re-define targets and commands to override them, and use `super` if you
 // want to refer to the originally defined task. The above example shows how to
 // override `compile` and `run` to add additional logging messages, and we
-// override `sources` which was `Task.sources` for the `src/` folder with a plain
+// override `sources` which was `Task.Sources` for the `src/` folder with a plain
 // `T{...}` target that generates the  necessary source files on-the-fly.
 //
 // Note that this example *replaces* your `src/` folder with the generated

--- a/example/scalalib/builds/3-override-tasks/build.mill
+++ b/example/scalalib/builds/3-override-tasks/build.mill
@@ -7,7 +7,7 @@ object foo extends ScalaModule {
 
   def sources = T{
     os.write(
-      T.dest / "Foo.scala",
+      Task.dest / "Foo.scala",
       """package foo
         |object Foo {
         |  def main(args: Array[String]): Unit = {
@@ -16,7 +16,7 @@ object foo extends ScalaModule {
         |}
       """.stripMargin
     )
-    Seq(PathRef(T.dest))
+    Seq(PathRef(Task.dest))
   }
 
   def compile = Task {
@@ -24,7 +24,7 @@ object foo extends ScalaModule {
     super.compile()
   }
 
-  def run(args: Task[Args] = T.task(Args())) = T.command {
+  def run(args: Task[Args] = Task.task(Args())) = Task.command {
     println("Running..." + args().value.mkString(" "))
     super.run(args)()
   }
@@ -35,7 +35,7 @@ object foo extends ScalaModule {
 // You can re-define targets and commands to override them, and use `super` if you
 // want to refer to the originally defined task. The above example shows how to
 // override `compile` and `run` to add additional logging messages, and we
-// override `sources` which was `T.sources` for the `src/` folder with a plain
+// override `sources` which was `Task.sources` for the `src/` folder with a plain
 // `T{...}` target that generates the  necessary source files on-the-fly.
 //
 // Note that this example *replaces* your `src/` folder with the generated
@@ -49,8 +49,8 @@ object foo2 extends ScalaModule {
   def scalaVersion = "2.13.8"
 
   def generatedSources = T{
-    os.write(T.dest / "Foo.scala", """...""")
-    Seq(PathRef(T.dest))
+    os.write(Task.dest / "Foo.scala", """...""")
+    Seq(PathRef(Task.dest))
   }
 }
 
@@ -58,8 +58,8 @@ object foo3 extends ScalaModule {
   def scalaVersion = "2.13.8"
 
   def sources = T{
-    os.write(T.dest / "Foo.scala", """...""")
-    super.sources() ++ Seq(PathRef(T.dest))
+    os.write(Task.dest / "Foo.scala", """...""")
+    super.sources() ++ Seq(PathRef(Task.dest))
   }
 }
 

--- a/example/scalalib/builds/3-override-tasks/build.mill
+++ b/example/scalalib/builds/3-override-tasks/build.mill
@@ -24,7 +24,7 @@ object foo extends ScalaModule {
     super.compile()
   }
 
-  def run(args: Task[Args] = Task.anon(Args())) = Task.command {
+  def run(args: Task[Args] = Task.Anon(Args())) = Task.Command {
     println("Running..." + args().value.mkString(" "))
     super.run(args)()
   }

--- a/example/scalalib/builds/3-override-tasks/build.mill
+++ b/example/scalalib/builds/3-override-tasks/build.mill
@@ -19,7 +19,7 @@ object foo extends ScalaModule {
     Seq(PathRef(T.dest))
   }
 
-  def compile = T {
+  def compile = Task {
     println("Compiling...")
     super.compile()
   }

--- a/example/scalalib/builds/3-override-tasks/build.mill
+++ b/example/scalalib/builds/3-override-tasks/build.mill
@@ -24,7 +24,7 @@ object foo extends ScalaModule {
     super.compile()
   }
 
-  def run(args: Task[Args] = Task.task(Args())) = Task.command {
+  def run(args: Task[Args] = Task.anon(Args())) = Task.command {
     println("Running..." + args().value.mkString(" "))
     super.run(args)()
   }

--- a/example/scalalib/builds/9-realistic/build.mill
+++ b/example/scalalib/builds/9-realistic/build.mill
@@ -29,7 +29,7 @@ object foo extends Cross[FooModule](scalaVersions)
 trait FooModule extends MyScalaModule {
   def moduleDeps = Seq(bar(), qux)
 
-  def generatedSources = T {
+  def generatedSources = Task {
     os.write(
       T.dest / "Version.scala",
       s"""

--- a/example/scalalib/builds/9-realistic/build.mill
+++ b/example/scalalib/builds/9-realistic/build.mill
@@ -31,7 +31,7 @@ trait FooModule extends MyScalaModule {
 
   def generatedSources = Task {
     os.write(
-      T.dest / "Version.scala",
+      Task.dest / "Version.scala",
       s"""
          |package foo
          |object Version{
@@ -39,7 +39,7 @@ trait FooModule extends MyScalaModule {
          |}
       """.stripMargin
     )
-    Seq(PathRef(T.dest))
+    Seq(PathRef(Task.dest))
   }
 }
 

--- a/example/scalalib/module/10-downloading-non-maven-jars/build.mill
+++ b/example/scalalib/module/10-downloading-non-maven-jars/build.mill
@@ -4,7 +4,7 @@ import mill._, scalalib._
 
 object `package` extends RootModule with ScalaModule {
   def scalaVersion = "2.13.8"
-  def unmanagedClasspath = T {
+  def unmanagedClasspath = Task {
     os.write(
       T.dest / "fastjavaio.jar",
       requests.get.stream(

--- a/example/scalalib/module/10-downloading-non-maven-jars/build.mill
+++ b/example/scalalib/module/10-downloading-non-maven-jars/build.mill
@@ -6,12 +6,12 @@ object `package` extends RootModule with ScalaModule {
   def scalaVersion = "2.13.8"
   def unmanagedClasspath = Task {
     os.write(
-      T.dest / "fastjavaio.jar",
+      Task.dest / "fastjavaio.jar",
       requests.get.stream(
         "https://github.com/williamfiset/FastJavaIO/releases/download/1.1/fastjavaio.jar"
       )
     )
-    Agg(PathRef(T.dest / "fastjavaio.jar"))
+    Agg(PathRef(Task.dest / "fastjavaio.jar"))
   }
 }
 

--- a/example/scalalib/module/11-assembly-config/build.mill
+++ b/example/scalalib/module/11-assembly-config/build.mill
@@ -30,7 +30,7 @@ object bar extends ScalaModule {
 // instance `reference.conf` files from library dependencies).
 //
 // By default mill excludes all `+*.sf+`, `+*.dsa+`, `+*.rsa+`, and
-// `META-INF/MANIFEST.MF` files from assembly, and concatenates all
+// `META-INF/MANIFESTask.MF` files from assembly, and concatenates all
 // `reference.conf` files. You can also define your own merge/exclude rules.
 
 /** Usage

--- a/example/scalalib/module/12-repository-config/build.mill
+++ b/example/scalalib/module/12-repository-config/build.mill
@@ -19,7 +19,7 @@ object foo extends ScalaModule {
     ivy"com.lihaoyi::mainargs:0.6.2"
   )
 
-  def repositoriesTask = Task.anon {
+  def repositoriesTask = Task.Anon {
     super.repositoriesTask() ++ sonatypeReleases
   }
 }
@@ -51,7 +51,7 @@ object foo extends ScalaModule {
 //// SNIPPET:BUILD2
 
 object CustomZincWorkerModule extends ZincWorkerModule with CoursierModule {
-  def repositoriesTask = Task.anon { super.repositoriesTask() ++ sonatypeReleases }
+  def repositoriesTask = Task.Anon { super.repositoriesTask() ++ sonatypeReleases }
 }
 
 object bar extends ScalaModule {
@@ -59,7 +59,7 @@ object bar extends ScalaModule {
   def zincWorker = ModuleRef(CustomZincWorkerModule)
   // ... rest of your build definitions
 
-  def repositoriesTask = Task.anon {super.repositoriesTask() ++ sonatypeReleases}
+  def repositoriesTask = Task.Anon {super.repositoriesTask() ++ sonatypeReleases}
 }
 
 //// SNIPPET:END

--- a/example/scalalib/module/12-repository-config/build.mill
+++ b/example/scalalib/module/12-repository-config/build.mill
@@ -19,7 +19,7 @@ object foo extends ScalaModule {
     ivy"com.lihaoyi::mainargs:0.6.2"
   )
 
-  def repositoriesTask = T.task {
+  def repositoriesTask = Task.task {
     super.repositoriesTask() ++ sonatypeReleases
   }
 }
@@ -51,7 +51,7 @@ object foo extends ScalaModule {
 //// SNIPPET:BUILD2
 
 object CustomZincWorkerModule extends ZincWorkerModule with CoursierModule {
-  def repositoriesTask = T.task { super.repositoriesTask() ++ sonatypeReleases }
+  def repositoriesTask = Task.task { super.repositoriesTask() ++ sonatypeReleases }
 }
 
 object bar extends ScalaModule {
@@ -59,7 +59,7 @@ object bar extends ScalaModule {
   def zincWorker = ModuleRef(CustomZincWorkerModule)
   // ... rest of your build definitions
 
-  def repositoriesTask = T.task {super.repositoriesTask() ++ sonatypeReleases}
+  def repositoriesTask = Task.task {super.repositoriesTask() ++ sonatypeReleases}
 }
 
 //// SNIPPET:END

--- a/example/scalalib/module/12-repository-config/build.mill
+++ b/example/scalalib/module/12-repository-config/build.mill
@@ -19,7 +19,7 @@ object foo extends ScalaModule {
     ivy"com.lihaoyi::mainargs:0.6.2"
   )
 
-  def repositoriesTask = Task.task {
+  def repositoriesTask = Task.anon {
     super.repositoriesTask() ++ sonatypeReleases
   }
 }
@@ -51,7 +51,7 @@ object foo extends ScalaModule {
 //// SNIPPET:BUILD2
 
 object CustomZincWorkerModule extends ZincWorkerModule with CoursierModule {
-  def repositoriesTask = Task.task { super.repositoriesTask() ++ sonatypeReleases }
+  def repositoriesTask = Task.anon { super.repositoriesTask() ++ sonatypeReleases }
 }
 
 object bar extends ScalaModule {
@@ -59,7 +59,7 @@ object bar extends ScalaModule {
   def zincWorker = ModuleRef(CustomZincWorkerModule)
   // ... rest of your build definitions
 
-  def repositoriesTask = Task.task {super.repositoriesTask() ++ sonatypeReleases}
+  def repositoriesTask = Task.anon {super.repositoriesTask() ++ sonatypeReleases}
 }
 
 //// SNIPPET:END

--- a/example/scalalib/module/5-resources/build.mill
+++ b/example/scalalib/module/5-resources/build.mill
@@ -12,7 +12,7 @@ object foo extends ScalaModule {
     def ivyDeps = Agg(ivy"com.lihaoyi::utest:0.8.4")
     def testFramework = "utest.runner.Framework"
 
-    def otherFiles = T.source(millSourcePath / "other-files")
+    def otherFiles = Task.source(millSourcePath / "other-files")
 
     def forkEnv = super.forkEnv() ++ Map(
       "OTHER_FILES_FOLDER" -> otherFiles().path.toString
@@ -48,7 +48,7 @@ object foo extends ScalaModule {
 //   packaged for deployment via `.assembly`
 //
 // * Apart from `resources/`, you can provide additional folders to your test suite
-//   by defining a `T.source` (`otherFiles` above) and passing it to `forkEnv`. This
+//   by defining a `Task.source` (`otherFiles` above) and passing it to `forkEnv`. This
 //   provide the folder path as an environment variable that the test can make use of
 //
 // Example application code demonstrating the techniques above can be seen below:

--- a/example/scalalib/module/5-resources/build.mill
+++ b/example/scalalib/module/5-resources/build.mill
@@ -12,7 +12,7 @@ object foo extends ScalaModule {
     def ivyDeps = Agg(ivy"com.lihaoyi::utest:0.8.4")
     def testFramework = "utest.runner.Framework"
 
-    def otherFiles = Task.source(millSourcePath / "other-files")
+    def otherFiles = Task.Source(millSourcePath / "other-files")
 
     def forkEnv = super.forkEnv() ++ Map(
       "OTHER_FILES_FOLDER" -> otherFiles().path.toString
@@ -48,7 +48,7 @@ object foo extends ScalaModule {
 //   packaged for deployment via `.assembly`
 //
 // * Apart from `resources/`, you can provide additional folders to your test suite
-//   by defining a `Task.source` (`otherFiles` above) and passing it to `forkEnv`. This
+//   by defining a `Task.Source` (`otherFiles` above) and passing it to `forkEnv`. This
 //   provide the folder path as an environment variable that the test can make use of
 //
 // Example application code demonstrating the techniques above can be seen below:

--- a/example/scalalib/module/8-unmanaged-jars/build.mill
+++ b/example/scalalib/module/8-unmanaged-jars/build.mill
@@ -4,7 +4,7 @@ import mill._, scalalib._
 
 object `package` extends RootModule with ScalaModule {
   def scalaVersion = "2.13.8"
-  def unmanagedClasspath = T {
+  def unmanagedClasspath = Task {
     if (!os.exists(millSourcePath / "lib")) Agg()
     else Agg.from(os.list(millSourcePath / "lib").map(PathRef(_)))
   }

--- a/example/scalalib/web/2-webapp-cache-busting/build.mill
+++ b/example/scalalib/web/2-webapp-cache-busting/build.mill
@@ -15,14 +15,14 @@ object `package` extends RootModule with ScalaModule {
       resourceRoot <- super.resources()
       path <- os.walk(resourceRoot.path)
       if os.isFile(path)
-    } yield hashFile(path, resourceRoot.path, T.dest)
+    } yield hashFile(path, resourceRoot.path, Task.dest)
 
     os.write(
-      T.dest / "hashed-resource-mapping.json",
+      Task.dest / "hashed-resource-mapping.json",
       upickle.default.write(hashMapping.toMap, indent = 4)
     )
 
-    Seq(PathRef(T.dest))
+    Seq(PathRef(Task.dest))
   }
 
   object test extends ScalaTests {

--- a/example/scalalib/web/2-webapp-cache-busting/build.mill
+++ b/example/scalalib/web/2-webapp-cache-busting/build.mill
@@ -10,7 +10,7 @@ object `package` extends RootModule with ScalaModule {
     ivy"com.lihaoyi::os-lib:0.10.7"
   )
 
-  def resources = T {
+  def resources = Task {
     val hashMapping = for {
       resourceRoot <- super.resources()
       path <- os.walk(resourceRoot.path)

--- a/example/scalalib/web/4-webapp-scalajs/build.mill
+++ b/example/scalalib/web/4-webapp-scalajs/build.mill
@@ -9,7 +9,7 @@ object `package` extends RootModule with ScalaModule {
     ivy"com.lihaoyi::scalatags:0.12.0"
   )
 
-  def resources = T {
+  def resources = Task {
     os.makeDir(T.dest / "webapp")
     val jsPath = client.fastLinkJS().dest.path
     // Move main.js[.map]into the proper filesystem position

--- a/example/scalalib/web/4-webapp-scalajs/build.mill
+++ b/example/scalalib/web/4-webapp-scalajs/build.mill
@@ -10,13 +10,13 @@ object `package` extends RootModule with ScalaModule {
   )
 
   def resources = Task {
-    os.makeDir(T.dest / "webapp")
+    os.makeDir(Task.dest / "webapp")
     val jsPath = client.fastLinkJS().dest.path
     // Move main.js[.map]into the proper filesystem position
     // in the resource folder for the web server code to pick up
-    os.copy(jsPath / "main.js", T.dest / "webapp/main.js")
-    os.copy(jsPath / "main.js.map", T.dest / "webapp/main.js.map")
-    super.resources() ++ Seq(PathRef(T.dest))
+    os.copy(jsPath / "main.js", Task.dest / "webapp/main.js")
+    os.copy(jsPath / "main.js.map", Task.dest / "webapp/main.js.map")
+    super.resources() ++ Seq(PathRef(Task.dest))
   }
 
   object test extends ScalaTests {

--- a/example/scalalib/web/5-webapp-scalajs-shared/build.mill
+++ b/example/scalalib/web/5-webapp-scalajs-shared/build.mill
@@ -14,11 +14,11 @@ object `package` extends RootModule with AppScalaModule {
   def ivyDeps = Agg(ivy"com.lihaoyi::cask:0.9.1")
 
   def resources = T{
-    os.makeDir(T.dest / "webapp")
+    os.makeDir(Task.dest / "webapp")
     val jsPath = client.fastLinkJS().dest.path
-    os.copy(jsPath / "main.js", T.dest / "webapp/main.js")
-    os.copy(jsPath / "main.js.map", T.dest / "webapp/main.js.map")
-    super.resources() ++ Seq(PathRef(T.dest))
+    os.copy(jsPath / "main.js", Task.dest / "webapp/main.js")
+    os.copy(jsPath / "main.js.map", Task.dest / "webapp/main.js.map")
+    super.resources() ++ Seq(PathRef(Task.dest))
   }
 
   object test extends ScalaTests with TestModule.Utest {

--- a/example/thirdparty/acyclic/build.mill
+++ b/example/thirdparty/acyclic/build.mill
@@ -39,7 +39,7 @@ trait AcyclicModule extends CrossScalaModule with PublishModule {
   def compileIvyDeps = Agg(Deps.scalaCompiler(crossScalaVersion))
 
   object test extends ScalaTests with TestModule.Utest {
-    def sources = T.sources(millSourcePath / "src", millSourcePath / "resources")
+    def sources = Task.sources(millSourcePath / "src", millSourcePath / "resources")
     def ivyDeps = Agg(Deps.utest, Deps.scalaCompiler(crossScalaVersion))
   }
 }

--- a/example/thirdparty/acyclic/build.mill
+++ b/example/thirdparty/acyclic/build.mill
@@ -39,7 +39,7 @@ trait AcyclicModule extends CrossScalaModule with PublishModule {
   def compileIvyDeps = Agg(Deps.scalaCompiler(crossScalaVersion))
 
   object test extends ScalaTests with TestModule.Utest {
-    def sources = Task.sources(millSourcePath / "src", millSourcePath / "resources")
+    def sources = Task.Sources(millSourcePath / "src", millSourcePath / "resources")
     def ivyDeps = Agg(Deps.utest, Deps.scalaCompiler(crossScalaVersion))
   }
 }

--- a/example/thirdparty/mockito/build.mill
+++ b/example/thirdparty/mockito/build.mill
@@ -200,7 +200,7 @@ object `package` extends RootModule with MockitoModule{
 //      trait BundleModule extends MockitoModule{
 //        def bundleName: String = millModuleSegments.parts.last
 //        override def millSourcePath = `osgi-test`.millSourcePath
-//        def sources = Task.sources(millSourcePath / "src" / bundleName / "java")
+//        def sources = Task.Sources(millSourcePath / "src" / bundleName / "java")
 //
 //        def manifest = super.manifest().add(
 //          "Bundle-Name" -> bundleName,

--- a/example/thirdparty/mockito/build.mill
+++ b/example/thirdparty/mockito/build.mill
@@ -79,10 +79,10 @@ object `package` extends RootModule with MockitoModule{
     val subpath = os.SubPath("org/mockito/internal/creation/bytebuddy/inject/")
     os.copy(
       compile().classes.path / subpath / "MockMethodDispatcher.class",
-      T.dest / subpath / "MockMethodDispatcher.raw",
+      Task.dest / subpath / "MockMethodDispatcher.raw",
       createFolders = true
     )
-    super.resources() ++ Seq(PathRef(T.dest))
+    super.resources() ++ Seq(PathRef(Task.dest))
   }
 
   object subprojects extends Module {
@@ -200,7 +200,7 @@ object `package` extends RootModule with MockitoModule{
 //      trait BundleModule extends MockitoModule{
 //        def bundleName: String = millModuleSegments.parts.last
 //        override def millSourcePath = `osgi-test`.millSourcePath
-//        def sources = T.sources(millSourcePath / "src" / bundleName / "java")
+//        def sources = Task.sources(millSourcePath / "src" / bundleName / "java")
 //
 //        def manifest = super.manifest().add(
 //          "Bundle-Name" -> bundleName,

--- a/example/thirdparty/netty/build.mill
+++ b/example/thirdparty/netty/build.mill
@@ -405,7 +405,7 @@ object `testsuite-http2` extends NettyTestSuiteModule{
     os.proc("tar", "xzf", Task.dest / "h2spec.tar.gz").call(cwd = Task.dest)
     PathRef(Task.dest / "h2spec")
   }
-  override def test(args: String*) = Task.command{
+  override def test(args: String*) = Task.Command{
     val server = os.proc(assembly().path).spawn(stdout = os.Inherit)
     try {
       Thread.sleep(1000) // let the server start up
@@ -543,7 +543,7 @@ object `transport-native-unix-common` extends NettyModule{
 
   def make = T{
     val Seq(sourceJar) = resolveDeps(
-      deps = Task.anon(Agg(ivy"io.netty:netty-jni-util:0.0.9.Final").map(bindDependency())),
+      deps = Task.Anon(Agg(ivy"io.netty:netty-jni-util:0.0.9.Final").map(bindDependency())),
       sources = true
     )().toSeq
 

--- a/example/thirdparty/netty/build.mill
+++ b/example/thirdparty/netty/build.mill
@@ -61,7 +61,7 @@ trait NettyBaseTestSuiteModule extends NettyBaseModule with TestModule.Junit5{
   def compile = T{
     // Hack to satisfy fragile tests that look for /test-classes/ in the file paths
     val sup = super.compile()
-    val testClasses = T.dest / "test-classes"
+    val testClasses = Task.dest / "test-classes"
     if (os.exists(sup.classes.path)) os.copy(sup.classes.path, testClasses, createFolders = true)
     sup.copy(classes = PathRef(testClasses))
   }
@@ -86,10 +86,10 @@ trait NettyModule extends NettyBaseModule{
 
 trait NettyJniModule extends NettyModule {
   def jniLibraryName: T[String]
-  def cSources = T.source(millSourcePath / "src/main/c")
+  def cSources = Task.source(millSourcePath / "src/main/c")
   def resources = T{
-    os.copy(clang().path, T.dest / "META-INF/native" / jniLibraryName(), createFolders = true)
-    Seq(PathRef(T.dest))
+    os.copy(clang().path, Task.dest / "META-INF/native" / jniLibraryName(), createFolders = true)
+    Seq(PathRef(Task.dest))
   }
   def clang = T{
     val Seq(sourceJar) = defaultResolver()
@@ -99,15 +99,15 @@ trait NettyJniModule extends NettyModule {
       )
       .toSeq
 
-    os.makeDir.all(T.dest  / "src/main/c")
-    os.proc("jar", "xf", sourceJar.path).call(cwd = T.dest  / "src/main/c")
+    os.makeDir.all(Task.dest  / "src/main/c")
+    os.proc("jar", "xf", sourceJar.path).call(cwd = Task.dest  / "src/main/c")
 
     os.proc(
       "clang",
       // CFLAGS
       "-O3", "-Werror", "-fno-omit-frame-pointer",
       "-Wunused-variable", "-fvisibility=hidden",
-      "-I" + (T.dest / "src/main/c"),
+      "-I" + (Task.dest / "src/main/c"),
       "-I" + `transport-native-unix-common`.cHeaders().path,
       "-I" + sys.props("java.home") + "/include/",
       "-I" + sys.props("java.home") + "/include/darwin",
@@ -122,9 +122,9 @@ trait NettyJniModule extends NettyModule {
       "-DPIC",
       // sources
       os.list(cSources().path)
-    ).call(cwd = T.dest, env = Map("MACOSX_DEPLOYMENT_TARGET" -> "10.9"))
+    ).call(cwd = Task.dest, env = Map("MACOSX_DEPLOYMENT_TARGET" -> "10.9"))
 
-    PathRef(T.dest / "a.out")
+    PathRef(Task.dest / "a.out")
   }
 }
 
@@ -248,19 +248,19 @@ object common extends NettyModule{
     ivy"org.jctools:jctools-core:4.0.5",
   )
 
-  def script = T.source(millSourcePath / "src/main/script")
+  def script = Task.source(millSourcePath / "src/main/script")
   def generatedSources0 = T{
     val shell = new groovy.lang.GroovyShell()
 
     val context = new java.util.HashMap[String, Object]
-    context.put("collection.template.dir", T.workspace + "/common/src/main/templates")
-    context.put("collection.template.test.dir", T.workspace + "/common/src/test/templates")
-    context.put("collection.src.dir", (T.dest / "src").toString)
-    context.put("collection.testsrc.dir", (T.dest / "testsrc").toString)
+    context.put("collection.template.dir", Task.workspace + "/common/src/main/templates")
+    context.put("collection.template.test.dir", Task.workspace + "/common/src/test/templates")
+    context.put("collection.src.dir", (Task.dest / "src").toString)
+    context.put("collection.testsrc.dir", (Task.dest / "testsrc").toString)
     shell.setProperty("properties", context)
     shell.setProperty("ant", new groovy.ant.AntBuilder())
     shell.evaluate((script().path / "codegen.groovy").toIO)
-    (PathRef(T.dest / "src"), PathRef(T.dest / "testsrc"))
+    (PathRef(Task.dest / "src"), PathRef(Task.dest / "testsrc"))
   }
 
   def generatedSources = T{ Seq(generatedSources0()._1)}
@@ -400,21 +400,21 @@ object `testsuite-http2` extends NettyTestSuiteModule{
     val isOSX = sys.props("os.name").toLowerCase.contains("mac")
     val binaryName = if (isOSX) "h2spec_darwin_amd64.tar.gz" else "h2spec_linux_amd64.tar.gz"
     val url = s"https://github.com/summerwind/h2spec/releases/download/v2.6.0/$binaryName"
-    os.write(T.dest / "h2spec.tar.gz", requests.get(url))
+    os.write(Task.dest / "h2spec.tar.gz", requests.get(url))
 
-    os.proc("tar", "xzf", T.dest / "h2spec.tar.gz").call(cwd = T.dest)
-    PathRef(T.dest / "h2spec")
+    os.proc("tar", "xzf", Task.dest / "h2spec.tar.gz").call(cwd = Task.dest)
+    PathRef(Task.dest / "h2spec")
   }
-  override def test(args: String*) = T.command{
+  override def test(args: String*) = Task.command{
     val server = os.proc(assembly().path).spawn(stdout = os.Inherit)
     try {
       Thread.sleep(1000) // let the server start up
 
-      os.proc(h2Spec().path, "-p9000", "--junit-report", T.dest / "report.xml")
+      os.proc(h2Spec().path, "-p9000", "--junit-report", Task.dest / "report.xml")
         .call(stdout = os.Inherit, check = false)
 
       // Use the Scala XML library to parse and fish out the data we want from the report
-      val xmlFile = scala.xml.XML.loadFile((T.dest / "report.xml").toIO)
+      val xmlFile = scala.xml.XML.loadFile((Task.dest / "report.xml").toIO)
       val testCasesWithErrors = (xmlFile \\ "testcase").filter { testcase =>
         (testcase \\ "error").nonEmpty
       }
@@ -445,7 +445,7 @@ object `testsuite-http2` extends NettyTestSuiteModule{
 object `testsuite-native` extends NettyTestSuiteModule{
   def moduleDeps = Seq(`transport-native-kqueue`, `resolver-dns-native-macos`, `resolver-dns-classes-macos`, `transport-native-epoll`)
   def testModuleDeps = Seq(`resolver-dns-classes-macos`)
-  override def sources = T.sources( millSourcePath / "src/test/java" )
+  override def sources = Task.sources( millSourcePath / "src/test/java" )
 }
 
 object `testsuite-native-image` extends NettyTestSuiteModule{
@@ -471,7 +471,7 @@ object `testsuite-osgi` extends NettyTestSuiteModule{
     transport, `transport-sctp`, `transport-udt`
   )
 
-  override def sources = T.sources( millSourcePath / "src/test/java" )
+  override def sources = Task.sources( millSourcePath / "src/test/java" )
 
   def ivyDeps = super.ivyDeps() ++ Agg(
     ivy"org.apache.felix:org.apache.felix.configadmin:1.9.14",
@@ -484,7 +484,7 @@ object `testsuite-osgi` extends NettyTestSuiteModule{
 
 object `testsuite-shading` extends NettyTestSuiteModule{
   def moduleDeps = Seq(common)
-  override def sources = T.sources( millSourcePath / "src/test/java" )
+  override def sources = Task.sources( millSourcePath / "src/test/java" )
 }
 
 object transport extends NettyModule{
@@ -532,27 +532,27 @@ object `transport-native-unix-common` extends NettyModule{
   def moduleDeps = Seq(common, buffer, transport)
   def ivyDeps = Agg(ivy"org.junit.jupiter:junit-jupiter-api:5.9.0")
 
-  def makefile = T.source(millSourcePath / "Makefile")
-  def cSources = T.source(millSourcePath / "src/main/c")
+  def makefile = Task.source(millSourcePath / "Makefile")
+  def cSources = Task.source(millSourcePath / "src/main/c")
   def cHeaders = T{
     for(p <- os.walk(cSources().path) if p.ext == "h"){
-      os.copy(p, T.dest / p.relativeTo(cSources().path), createFolders = true)
+      os.copy(p, Task.dest / p.relativeTo(cSources().path), createFolders = true)
     }
-    PathRef(T.dest)
+    PathRef(Task.dest)
   }
 
   def make = T{
     val Seq(sourceJar) = resolveDeps(
-      deps = T.task(Agg(ivy"io.netty:netty-jni-util:0.0.9.Final").map(bindDependency())),
+      deps = Task.task(Agg(ivy"io.netty:netty-jni-util:0.0.9.Final").map(bindDependency())),
       sources = true
     )().toSeq
 
-    os.copy(makefile().path, T.dest / "Makefile")
-    os.copy(cSources().path, T.dest / "src/main/c", createFolders = true)
-    os.proc("jar", "xf", sourceJar.path).call(cwd = T.dest  / "src/main/c")
+    os.copy(makefile().path, Task.dest / "Makefile")
+    os.copy(cSources().path, Task.dest / "src/main/c", createFolders = true)
+    os.proc("jar", "xf", sourceJar.path).call(cwd = Task.dest  / "src/main/c")
 
     os.proc("make").call(
-      cwd = T.dest,
+      cwd = Task.dest,
       env = Map(
         "CC" -> "clang",
         "AR" -> "ar",
@@ -578,7 +578,7 @@ object `transport-native-unix-common` extends NettyModule{
     )
 
 
-    (PathRef(T.dest / "lib-out"), PathRef(T.dest / "obj-out"))
+    (PathRef(Task.dest / "lib-out"), PathRef(Task.dest / "obj-out"))
   }
 }
 object `transport-native-unix-common-tests` extends NettyTestSuiteModule{

--- a/example/thirdparty/netty/build.mill
+++ b/example/thirdparty/netty/build.mill
@@ -86,7 +86,7 @@ trait NettyModule extends NettyBaseModule{
 
 trait NettyJniModule extends NettyModule {
   def jniLibraryName: T[String]
-  def cSources = Task.source(millSourcePath / "src/main/c")
+  def cSources = Task.Source(millSourcePath / "src/main/c")
   def resources = T{
     os.copy(clang().path, Task.dest / "META-INF/native" / jniLibraryName(), createFolders = true)
     Seq(PathRef(Task.dest))
@@ -248,7 +248,7 @@ object common extends NettyModule{
     ivy"org.jctools:jctools-core:4.0.5",
   )
 
-  def script = Task.source(millSourcePath / "src/main/script")
+  def script = Task.Source(millSourcePath / "src/main/script")
   def generatedSources0 = T{
     val shell = new groovy.lang.GroovyShell()
 
@@ -445,7 +445,7 @@ object `testsuite-http2` extends NettyTestSuiteModule{
 object `testsuite-native` extends NettyTestSuiteModule{
   def moduleDeps = Seq(`transport-native-kqueue`, `resolver-dns-native-macos`, `resolver-dns-classes-macos`, `transport-native-epoll`)
   def testModuleDeps = Seq(`resolver-dns-classes-macos`)
-  override def sources = Task.sources( millSourcePath / "src/test/java" )
+  override def sources = Task.Sources( millSourcePath / "src/test/java" )
 }
 
 object `testsuite-native-image` extends NettyTestSuiteModule{
@@ -471,7 +471,7 @@ object `testsuite-osgi` extends NettyTestSuiteModule{
     transport, `transport-sctp`, `transport-udt`
   )
 
-  override def sources = Task.sources( millSourcePath / "src/test/java" )
+  override def sources = Task.Sources( millSourcePath / "src/test/java" )
 
   def ivyDeps = super.ivyDeps() ++ Agg(
     ivy"org.apache.felix:org.apache.felix.configadmin:1.9.14",
@@ -484,7 +484,7 @@ object `testsuite-osgi` extends NettyTestSuiteModule{
 
 object `testsuite-shading` extends NettyTestSuiteModule{
   def moduleDeps = Seq(common)
-  override def sources = Task.sources( millSourcePath / "src/test/java" )
+  override def sources = Task.Sources( millSourcePath / "src/test/java" )
 }
 
 object transport extends NettyModule{
@@ -532,8 +532,8 @@ object `transport-native-unix-common` extends NettyModule{
   def moduleDeps = Seq(common, buffer, transport)
   def ivyDeps = Agg(ivy"org.junit.jupiter:junit-jupiter-api:5.9.0")
 
-  def makefile = Task.source(millSourcePath / "Makefile")
-  def cSources = Task.source(millSourcePath / "src/main/c")
+  def makefile = Task.Source(millSourcePath / "Makefile")
+  def cSources = Task.Source(millSourcePath / "src/main/c")
   def cHeaders = T{
     for(p <- os.walk(cSources().path) if p.ext == "h"){
       os.copy(p, Task.dest / p.relativeTo(cSources().path), createFolders = true)

--- a/example/thirdparty/netty/build.mill
+++ b/example/thirdparty/netty/build.mill
@@ -543,7 +543,7 @@ object `transport-native-unix-common` extends NettyModule{
 
   def make = T{
     val Seq(sourceJar) = resolveDeps(
-      deps = Task.task(Agg(ivy"io.netty:netty-jni-util:0.0.9.Final").map(bindDependency())),
+      deps = Task.anon(Agg(ivy"io.netty:netty-jni-util:0.0.9.Final").map(bindDependency())),
       sources = true
     )().toSeq
 

--- a/idea/src/mill/idea/GenIdea.scala
+++ b/idea/src/mill/idea/GenIdea.scala
@@ -1,6 +1,6 @@
 package mill.idea
 
-import mill.T
+import mill.{T, Task}
 import mill.api.Result
 import mill.define.{Command, Discover, ExternalModule}
 import mill.eval.Evaluator

--- a/idea/src/mill/idea/GenIdea.scala
+++ b/idea/src/mill/idea/GenIdea.scala
@@ -1,6 +1,6 @@
 package mill.idea
 
-import mill.{T, Task}
+import mill.T
 import mill.api.Result
 import mill.define.{Command, Discover, ExternalModule}
 import mill.eval.Evaluator

--- a/idea/src/mill/idea/GenIdea.scala
+++ b/idea/src/mill/idea/GenIdea.scala
@@ -1,6 +1,6 @@
 package mill.idea
 
-import mill.T
+import mill.Task
 import mill.api.Result
 import mill.define.{Command, Discover, ExternalModule}
 import mill.eval.Evaluator
@@ -9,7 +9,7 @@ import scala.util.control.NonFatal
 
 object GenIdea extends ExternalModule {
 
-  def idea(allBootstrapEvaluators: Evaluator.AllBootstrapEvaluators): Command[Unit] = T.command {
+  def idea(allBootstrapEvaluators: Evaluator.AllBootstrapEvaluators): Command[Unit] = Task.Command {
     try {
       Result.Success(GenIdeaImpl(
         evaluators = allBootstrapEvaluators.value

--- a/idea/src/mill/idea/GenIdeaImpl.scala
+++ b/idea/src/mill/idea/GenIdeaImpl.scala
@@ -131,65 +131,65 @@ case class GenIdeaImpl(
           case (path, mod) => {
 
             // same as input of resolvedIvyDeps
-            val allIvyDeps = T.task {
+            val allIvyDeps = Task.Anon {
               mod.transitiveIvyDeps() ++ mod.transitiveCompileIvyDeps()
             }
 
             val scalaCompilerClasspath = mod match {
               case x: ScalaModule => x.scalaCompilerClasspath
               case _ =>
-                T.task {
+                Task.Anon {
                   Agg.empty[PathRef]
                 }
             }
 
-            val externalLibraryDependencies = T.task {
+            val externalLibraryDependencies = Task.Anon {
               mod.defaultResolver().resolveDeps(mod.mandatoryIvyDeps())
             }
 
-            val externalDependencies = T.task {
+            val externalDependencies = Task.Anon {
               mod.resolvedIvyDeps() ++
                 T.traverse(mod.transitiveModuleDeps)(_.unmanagedClasspath)().flatten
             }
-            val extCompileIvyDeps = T.task {
+            val extCompileIvyDeps = Task.Anon {
               mod.defaultResolver().resolveDeps(mod.compileIvyDeps())
             }
             val extRunIvyDeps = mod.resolvedRunIvyDeps
 
-            val externalSources = T.task {
+            val externalSources = Task.Anon {
               mod.resolveDeps(allIvyDeps, sources = true)()
             }
 
             val (scalacPluginsIvyDeps, allScalacOptions, scalaVersion) = mod match {
               case mod: ScalaModule => (
-                  T.task(mod.scalacPluginIvyDeps()),
-                  T.task(mod.allScalacOptions()),
-                  T.task { Some(mod.scalaVersion()) }
+                  Task.Anon(mod.scalacPluginIvyDeps()),
+                  Task.Anon(mod.allScalacOptions()),
+                  Task.Anon { Some(mod.scalaVersion()) }
                 )
               case _ => (
-                  T.task(Agg[Dep]()),
-                  T.task(Seq[String]()),
-                  T.task(None)
+                  Task.Anon(Agg[Dep]()),
+                  Task.Anon(Seq[String]()),
+                  Task.Anon(None)
                 )
             }
 
-            val scalacPluginDependencies = T.task {
+            val scalacPluginDependencies = Task.Anon {
               mod.defaultResolver().resolveDeps(scalacPluginsIvyDeps())
             }
 
-            val facets = T.task {
+            val facets = Task.Anon {
               mod.ideaJavaModuleFacets(ideaConfigVersion)()
             }
 
-            val configFileContributions = T.task {
+            val configFileContributions = Task.Anon {
               mod.ideaConfigFiles(ideaConfigVersion)()
             }
 
-            val compilerOutput = T.task {
+            val compilerOutput = Task.Anon {
               mod.ideaCompileOutput()
             }
 
-            T.task {
+            Task.Anon {
               val resolvedCp: Agg[Scoped[os.Path]] =
                 externalDependencies().map(_.path).map(Scoped(_, None)) ++
                   extCompileIvyDeps()

--- a/integration/failure/module-init-error/resources/build.mill
+++ b/integration/failure/module-init-error/resources/build.mill
@@ -2,21 +2,21 @@ package build
 import mill._, scalalib._
 
 def rootTarget = Task { println("Running rootTarget"); "rootTarget" }
-def rootCommand(s: String) = Task.command { println(s"Running rootCommand $s") }
+def rootCommand(s: String) = Task.Command { println(s"Running rootCommand $s") }
 
 object foo extends Module {
   def fooTarget = Task { println(s"Running fooTarget"); 123 }
-  def fooCommand(s: String) = Task.command { println(s"Running fooCommand $s") }
+  def fooCommand(s: String) = Task.Command { println(s"Running fooCommand $s") }
   throw new Exception("Foo Boom")
 }
 
 object bar extends Module {
   def barTarget = Task { println(s"Running barTarget"); "abc" }
-  def barCommand(s: String) = Task.command { println(s"Running barCommand $s") }
+  def barCommand(s: String) = Task.Command { println(s"Running barCommand $s") }
 
   object qux extends Module {
     def quxTarget = Task { println(s"Running quxTarget"); "xyz" }
-    def quxCommand(s: String) = Task.command { println(s"Running quxCommand $s") }
+    def quxCommand(s: String) = Task.Command { println(s"Running quxCommand $s") }
     throw new Exception("Qux Boom")
   }
 }

--- a/integration/failure/module-init-error/resources/build.mill
+++ b/integration/failure/module-init-error/resources/build.mill
@@ -2,21 +2,21 @@ package build
 import mill._, scalalib._
 
 def rootTarget = Task { println("Running rootTarget"); "rootTarget" }
-def rootCommand(s: String) = T.command { println(s"Running rootCommand $s") }
+def rootCommand(s: String) = Task.command { println(s"Running rootCommand $s") }
 
 object foo extends Module {
   def fooTarget = Task { println(s"Running fooTarget"); 123 }
-  def fooCommand(s: String) = T.command { println(s"Running fooCommand $s") }
+  def fooCommand(s: String) = Task.command { println(s"Running fooCommand $s") }
   throw new Exception("Foo Boom")
 }
 
 object bar extends Module {
   def barTarget = Task { println(s"Running barTarget"); "abc" }
-  def barCommand(s: String) = T.command { println(s"Running barCommand $s") }
+  def barCommand(s: String) = Task.command { println(s"Running barCommand $s") }
 
   object qux extends Module {
     def quxTarget = Task { println(s"Running quxTarget"); "xyz" }
-    def quxCommand(s: String) = T.command { println(s"Running quxCommand $s") }
+    def quxCommand(s: String) = Task.command { println(s"Running quxCommand $s") }
     throw new Exception("Qux Boom")
   }
 }

--- a/integration/failure/module-init-error/resources/build.mill
+++ b/integration/failure/module-init-error/resources/build.mill
@@ -1,21 +1,21 @@
 package build
 import mill._, scalalib._
 
-def rootTarget = T { println("Running rootTarget"); "rootTarget" }
+def rootTarget = Task { println("Running rootTarget"); "rootTarget" }
 def rootCommand(s: String) = T.command { println(s"Running rootCommand $s") }
 
 object foo extends Module {
-  def fooTarget = T { println(s"Running fooTarget"); 123 }
+  def fooTarget = Task { println(s"Running fooTarget"); 123 }
   def fooCommand(s: String) = T.command { println(s"Running fooCommand $s") }
   throw new Exception("Foo Boom")
 }
 
 object bar extends Module {
-  def barTarget = T { println(s"Running barTarget"); "abc" }
+  def barTarget = Task { println(s"Running barTarget"); "abc" }
   def barCommand(s: String) = T.command { println(s"Running barCommand $s") }
 
   object qux extends Module {
-    def quxTarget = T { println(s"Running quxTarget"); "xyz" }
+    def quxTarget = Task { println(s"Running quxTarget"); "xyz" }
     def quxCommand(s: String) = T.command { println(s"Running quxCommand $s") }
     throw new Exception("Qux Boom")
   }

--- a/integration/feature/docannotations/resources/build.mill
+++ b/integration/feature/docannotations/resources/build.mill
@@ -8,7 +8,7 @@ trait JUnitTests extends TestModule.Junit4 {
    * Overridden ivyDeps Docs!!!
    */
   def ivyDeps = Agg(ivy"com.novocode:junit-interface:0.11")
-  def task = T {
+  def task = Task {
     "???"
   }
 }
@@ -22,7 +22,7 @@ object core extends JavaModule {
   /**
    * Core Target Docz!
    */
-  def target = T {
+  def target = Task {
     import collection.JavaConverters._
     println(this.getClass.getClassLoader.getResources("scalac-plugin.xml").asScala.toList)
     "Hello!"

--- a/integration/feature/hygiene/resources/build.mill
+++ b/integration/feature/hygiene/resources/build.mill
@@ -2,7 +2,7 @@ package build
 import _root_.mill._, scalalib._, publish._
 
 object scala extends Module {
-  def foo = T {
+  def foo = Task {
     "fooValue"
   }
 }

--- a/integration/feature/mill-jvm-opts/resources/build.mill
+++ b/integration/feature/mill-jvm-opts/resources/build.mill
@@ -3,7 +3,7 @@ import mill._
 import java.lang.management.ManagementFactory
 import scala.jdk.CollectionConverters._
 
-def checkJvmOpts() = Task.command {
+def checkJvmOpts() = Task.Command {
   val prop = System.getProperty("PROPERTY_PROPERLY_SET_VIA_JVM_OPTS")
   if (prop != "value-from-file") sys.error("jvm-opts not correctly applied, value was: " + prop)
   val runtime = ManagementFactory.getRuntimeMXBean()

--- a/integration/feature/mill-jvm-opts/resources/build.mill
+++ b/integration/feature/mill-jvm-opts/resources/build.mill
@@ -3,7 +3,7 @@ import mill._
 import java.lang.management.ManagementFactory
 import scala.jdk.CollectionConverters._
 
-def checkJvmOpts() = T.command {
+def checkJvmOpts() = Task.command {
   val prop = System.getProperty("PROPERTY_PROPERLY_SET_VIA_JVM_OPTS")
   if (prop != "value-from-file") sys.error("jvm-opts not correctly applied, value was: " + prop)
   val runtime = ManagementFactory.getRuntimeMXBean()

--- a/integration/feature/private-methods/resources/build.mill
+++ b/integration/feature/private-methods/resources/build.mill
@@ -1,31 +1,31 @@
 package build
 import mill._
 
-def pub = T {
+def pub = Task {
   priv()
 }
 
-private def priv = T {
+private def priv = Task {
   "priv"
 }
 
 object foo extends Module {
-  def bar = T {
+  def bar = Task {
     baz()
   }
 }
 
-private def baz = T {
+private def baz = Task {
   "bazOuter"
 }
 
 object qux extends Module {
   object foo extends Module {
-    def bar = T {
+    def bar = Task {
       baz()
     }
   }
-  private def baz = T {
+  private def baz = Task {
     "bazInner"
   }
 }
@@ -33,12 +33,12 @@ object qux extends Module {
 object cls extends cls
 class cls extends Module {
   object foo extends Module {
-    def bar = T {
+    def bar = Task {
       baz()
     }
   }
 
-  private def baz = T {
+  private def baz = Task {
     "bazCls"
   }
 }

--- a/integration/feature/subprocess-stdout/resources/build.mill
+++ b/integration/feature/subprocess-stdout/resources/build.mill
@@ -2,7 +2,7 @@ package build
 import scala.util.Properties
 import mill._
 
-def inheritInterleaved = T {
+def inheritInterleaved = Task {
   for (i <- Range.inclusive(1, 9)) {
     println("print stdout" + i)
     val echoCommandStdout =
@@ -17,7 +17,7 @@ def inheritInterleaved = T {
   }
 }
 
-def inheritRaw = T {
+def inheritRaw = Task {
   println("print stdoutRaw")
   val echoCommandStdoutRaw =
     if (Properties.isWin) Seq("cmd.exe", "/C", "echo proc stdoutRaw")

--- a/integration/ide/bsp-install/resources/build.mill
+++ b/integration/ide/bsp-install/resources/build.mill
@@ -8,7 +8,7 @@ trait HelloBspModule extends ScalaModule {
   object test extends ScalaTests with TestModule.Utest
 
   override def generatedSources = Task {
-    Seq(PathRef(T.ctx().dest / "classes"))
+    Seq(PathRef(Task.ctx().dest / "classes"))
   }
 }
 

--- a/integration/ide/bsp-install/resources/build.mill
+++ b/integration/ide/bsp-install/resources/build.mill
@@ -7,7 +7,7 @@ trait HelloBspModule extends ScalaModule {
   def scalaVersion = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
   object test extends ScalaTests with TestModule.Utest
 
-  override def generatedSources = T {
+  override def generatedSources = Task {
     Seq(PathRef(T.ctx().dest / "classes"))
   }
 }

--- a/integration/ide/bsp-modules/resources/build.mill
+++ b/integration/ide/bsp-modules/resources/build.mill
@@ -17,7 +17,7 @@ object HelloBsp extends HelloBspModule {
   override def unmanagedClasspath: T[Agg[PathRef]] = Agg(build.proj3.jar())
 }
 
-def validate() = Task.command {
+def validate() = Task.Command {
   val transitiveModules = mill.scalalib.internal.JavaModuleUtils.transitiveModules(build)
   val file = Task.dest / "transitive-modules.json"
   val moduleNames = transitiveModules.map(m =>

--- a/integration/ide/bsp-modules/resources/build.mill
+++ b/integration/ide/bsp-modules/resources/build.mill
@@ -17,9 +17,9 @@ object HelloBsp extends HelloBspModule {
   override def unmanagedClasspath: T[Agg[PathRef]] = Agg(build.proj3.jar())
 }
 
-def validate() = T.command {
+def validate() = Task.command {
   val transitiveModules = mill.scalalib.internal.JavaModuleUtils.transitiveModules(build)
-  val file = T.dest / "transitive-modules.json"
+  val file = Task.dest / "transitive-modules.json"
   val moduleNames = transitiveModules.map(m =>
     mill.scalalib.internal.ModuleUtils.moduleDisplayName(m)
   ).mkString("\n")

--- a/integration/ide/gen-idea/resources/extended/build.mill
+++ b/integration/ide/gen-idea/resources/extended/build.mill
@@ -18,7 +18,7 @@ trait HelloWorldModule extends scalalib.ScalaModule {
   }
 
   def ideaJavaModuleFacets(ideaConfigVersion: Int): Task[Seq[JavaFacet]] =
-    Task.anon {
+    Task.Anon {
       ideaConfigVersion match {
         case 4 =>
           Seq(
@@ -46,7 +46,7 @@ trait HelloWorldModule extends scalalib.ScalaModule {
 
   override def ideaConfigFiles(
       ideaConfigVersion: Int
-  ): Task[Seq[IdeaConfigFile]] = Task.anon {
+  ): Task[Seq[IdeaConfigFile]] = Task.Anon {
     ideaConfigVersion match {
       case 4 =>
         Seq(

--- a/integration/ide/gen-idea/resources/extended/build.mill
+++ b/integration/ide/gen-idea/resources/extended/build.mill
@@ -9,7 +9,7 @@ trait HelloWorldModule extends scalalib.ScalaModule {
   override def scalaVersion = "2.13.6"
   object test extends ScalaTests with TestModule.Utest
 
-  override def generatedSources = T {
+  override def generatedSources = Task {
     Seq(PathRef(T.dest / "classes"))
   }
 

--- a/integration/ide/gen-idea/resources/extended/build.mill
+++ b/integration/ide/gen-idea/resources/extended/build.mill
@@ -10,7 +10,7 @@ trait HelloWorldModule extends scalalib.ScalaModule {
   object test extends ScalaTests with TestModule.Utest
 
   override def generatedSources = Task {
-    Seq(PathRef(T.dest / "classes"))
+    Seq(PathRef(Task.dest / "classes"))
   }
 
   object subScala3 extends scalalib.ScalaModule {
@@ -18,7 +18,7 @@ trait HelloWorldModule extends scalalib.ScalaModule {
   }
 
   def ideaJavaModuleFacets(ideaConfigVersion: Int): Task[Seq[JavaFacet]] =
-    T.task {
+    Task.task {
       ideaConfigVersion match {
         case 4 =>
           Seq(
@@ -46,7 +46,7 @@ trait HelloWorldModule extends scalalib.ScalaModule {
 
   override def ideaConfigFiles(
       ideaConfigVersion: Int
-  ): Task[Seq[IdeaConfigFile]] = T.task {
+  ): Task[Seq[IdeaConfigFile]] = Task.task {
     ideaConfigVersion match {
       case 4 =>
         Seq(

--- a/integration/ide/gen-idea/resources/extended/build.mill
+++ b/integration/ide/gen-idea/resources/extended/build.mill
@@ -18,7 +18,7 @@ trait HelloWorldModule extends scalalib.ScalaModule {
   }
 
   def ideaJavaModuleFacets(ideaConfigVersion: Int): Task[Seq[JavaFacet]] =
-    Task.task {
+    Task.anon {
       ideaConfigVersion match {
         case 4 =>
           Seq(
@@ -46,7 +46,7 @@ trait HelloWorldModule extends scalalib.ScalaModule {
 
   override def ideaConfigFiles(
       ideaConfigVersion: Int
-  ): Task[Seq[IdeaConfigFile]] = Task.task {
+  ): Task[Seq[IdeaConfigFile]] = Task.anon {
     ideaConfigVersion match {
       case 4 =>
         Seq(

--- a/integration/ide/gen-idea/resources/hello-idea/build.mill
+++ b/integration/ide/gen-idea/resources/hello-idea/build.mill
@@ -8,14 +8,14 @@ import mill.scalalib.{Dep, DepSyntax, JavaModule, TestModule}
 trait HelloIdeaModule extends scalalib.ScalaModule {
   def scalaVersion = "2.12.5"
   object test extends ScalaTests with TestModule.Utest {
-    override def compileIvyDeps: Target[Agg[Dep]] = Agg(
+    override def compileIvyDeps: T[Agg[Dep]] = Agg(
       ivy"org.slf4j:jcl-over-slf4j:1.7.25"
     )
-    override def ivyDeps: Target[Agg[Dep]] = Agg(
+    override def ivyDeps: T[Agg[Dep]] = Agg(
       ivy"org.slf4j:slf4j-api:1.7.25",
       ivy"ch.qos.logback:logback-core:1.2.3"
     )
-    override def runIvyDeps: Target[Agg[Dep]] = Agg(
+    override def runIvyDeps: T[Agg[Dep]] = Agg(
       ivy"ch.qos.logback:logback-core:1.2.3",
       ivy"ch.qos.logback:logback-classic:1.2.3"
     )
@@ -36,7 +36,7 @@ object HelloIdeaJs extends ScalaJSModule {
   override def scalaVersion = "3.3.1"
   override def scalaJSVersion = "1.16.0"
   object test extends ScalaJSTests with TestModule.Utest {
-    override def ivyDeps: Target[Agg[Dep]] = Agg(
+    override def ivyDeps: T[Agg[Dep]] = Agg(
       ivy"com.lihaoyi::utest::0.8.4"
     )
   }

--- a/integration/invalidation/codesig-hello/resources/build.mill
+++ b/integration/invalidation/codesig-hello/resources/build.mill
@@ -4,4 +4,4 @@ import mill._
 val valueFoo = 0
 val valueFooUsedInBar = 0
 def helperFoo = { println("running helperFoo"); 1 + valueFoo }
-def foo = T { println("running foo"); helperFoo }
+def foo = Task { println("running foo"); helperFoo }

--- a/integration/invalidation/codesig-nested/resources/build.mill
+++ b/integration/invalidation/codesig-nested/resources/build.mill
@@ -4,18 +4,18 @@ import mill._
 val valueFoo = 0
 val valueFooUsedInBar = 0
 def helperFoo = { println("running helperFoo"); 1 + valueFoo }
-def foo = T { println("running foo"); helperFoo }
+def foo = Task { println("running foo"); helperFoo }
 
 object outer extends Module {
   val valueBar = 0
   val valueBarUsedInQux = 0
   def helperBar = { println("running helperBar"); 20 }
-  def bar = T { println("running bar"); helperBar + valueBar + valueFooUsedInBar }
+  def bar = Task { println("running bar"); helperBar + valueBar + valueFooUsedInBar }
 
   trait InnerModule extends Module {
     val valueQux = 0
     def helperQux = { println("running helperQux"); 300 + valueQux + valueBarUsedInQux }
-    def qux = T { println("running qux"); foo() + bar() + helperQux }
+    def qux = Task { println("running qux"); foo() + bar() + helperQux }
   }
   object inner extends InnerModule
 }
@@ -23,14 +23,14 @@ object outer extends Module {
 trait TraitOuter extends Module {
   val valueTraitOuter = 0
   def helperTraitOuter = { println("running helperTraitOuter"); 300 + valueTraitOuter }
-  def outer = T { println("running outer"); foo() + helperTraitOuter }
+  def outer = Task { println("running outer"); foo() + helperTraitOuter }
 
   object traitInner extends Module {
     val valueTraitInner = 0
     def helperTraitInner = {
       println("running helperTraitInner"); 300 + valueTraitOuter + valueTraitInner
     }
-    def inner = T { println("running inner"); foo() + outer() + helperTraitInner }
+    def inner = Task { println("running inner"); foo() + outer() + helperTraitInner }
   }
 }
 

--- a/integration/invalidation/codesig-scalamodule/resources/build.mill
+++ b/integration/invalidation/codesig-scalamodule/resources/build.mill
@@ -25,7 +25,7 @@ object foo extends ScalaModule {
     super.compile()
   }
 
-  def run(args: Task[Args] = Task.task(Args())) = Task.command {
+  def run(args: Task[Args] = Task.anon(Args())) = Task.command {
     println("Foo running..." + args().value.mkString(" "))
     super.run(args)()
   }

--- a/integration/invalidation/codesig-scalamodule/resources/build.mill
+++ b/integration/invalidation/codesig-scalamodule/resources/build.mill
@@ -25,7 +25,7 @@ object foo extends ScalaModule {
     super.compile()
   }
 
-  def run(args: Task[Args] = Task.anon(Args())) = Task.command {
+  def run(args: Task[Args] = Task.Anon(Args())) = Task.Command {
     println("Foo running..." + args().value.mkString(" "))
     super.run(args)()
   }

--- a/integration/invalidation/codesig-scalamodule/resources/build.mill
+++ b/integration/invalidation/codesig-scalamodule/resources/build.mill
@@ -7,7 +7,7 @@ object foo extends ScalaModule {
   def sources = Task {
     println("Foo generating sources...")
     os.write(
-      T.dest / "Foo.scala",
+      Task.dest / "Foo.scala",
       """package foo
         |object Foo {
         |  final val fooMsg = "Hello World"
@@ -17,7 +17,7 @@ object foo extends ScalaModule {
         |  }
         |}""".stripMargin
     )
-    Seq(PathRef(T.dest))
+    Seq(PathRef(Task.dest))
   }
 
   def compile = Task {
@@ -25,7 +25,7 @@ object foo extends ScalaModule {
     super.compile()
   }
 
-  def run(args: Task[Args] = T.task(Args())) = T.command {
+  def run(args: Task[Args] = Task.task(Args())) = Task.command {
     println("Foo running..." + args().value.mkString(" "))
     super.run(args)()
   }
@@ -43,7 +43,7 @@ object bar extends ScalaModule {
   def sources = Task {
     println("Bar generating sources...")
     os.write(
-      T.dest / "Bar.scala",
+      Task.dest / "Bar.scala",
       """package bar
         |object Bar {
         |  def main(args: Array[String]): Unit = {
@@ -51,7 +51,7 @@ object bar extends ScalaModule {
         |  }
         |}""".stripMargin
     )
-    Seq(PathRef(T.dest))
+    Seq(PathRef(Task.dest))
   }
 
   def compile = Task {
@@ -71,7 +71,7 @@ object qux extends ScalaModule {
   def sources = Task {
     println("Qux generating sources...")
     os.write(
-      T.dest / "Qux.scala",
+      Task.dest / "Qux.scala",
       """package qux
         |object Qux {
         |  def main(args: Array[String]): Unit = {
@@ -79,7 +79,7 @@ object qux extends ScalaModule {
         |  }
         |}""".stripMargin
     )
-    Seq(PathRef(T.dest))
+    Seq(PathRef(Task.dest))
   }
 
   def compile = Task {

--- a/integration/invalidation/codesig-scalamodule/resources/build.mill
+++ b/integration/invalidation/codesig-scalamodule/resources/build.mill
@@ -4,7 +4,7 @@ import mill._, scalalib._
 object foo extends ScalaModule {
   def scalaVersion = "2.13.8"
 
-  def sources = T {
+  def sources = Task {
     println("Foo generating sources...")
     os.write(
       T.dest / "Foo.scala",
@@ -20,7 +20,7 @@ object foo extends ScalaModule {
     Seq(PathRef(T.dest))
   }
 
-  def compile = T {
+  def compile = Task {
     println("Foo compiling...")
     super.compile()
   }
@@ -30,7 +30,7 @@ object foo extends ScalaModule {
     super.run(args)()
   }
 
-  def assembly = T {
+  def assembly = Task {
     println("Foo assembly...")
     super.assembly()
   }
@@ -40,7 +40,7 @@ object bar extends ScalaModule {
   def moduleDeps = Seq(foo)
   def scalaVersion = "2.13.8"
 
-  def sources = T {
+  def sources = Task {
     println("Bar generating sources...")
     os.write(
       T.dest / "Bar.scala",
@@ -54,12 +54,12 @@ object bar extends ScalaModule {
     Seq(PathRef(T.dest))
   }
 
-  def compile = T {
+  def compile = Task {
     println("Bar compiling...")
     super.compile()
   }
 
-  def assembly = T {
+  def assembly = Task {
     println("Bar assembly...")
     super.assembly()
   }
@@ -68,7 +68,7 @@ object bar extends ScalaModule {
 object qux extends ScalaModule {
   def scalaVersion = "2.13.8"
 
-  def sources = T {
+  def sources = Task {
     println("Qux generating sources...")
     os.write(
       T.dest / "Qux.scala",
@@ -82,12 +82,12 @@ object qux extends ScalaModule {
     Seq(PathRef(T.dest))
   }
 
-  def compile = T {
+  def compile = Task {
     println("Qux compiling...")
     super.compile()
   }
 
-  def assembly = T {
+  def assembly = Task {
     println("Qux assembly...")
     super.assembly()
   }

--- a/integration/invalidation/invalidation/resources/-#+&%/package.mill
+++ b/integration/invalidation/invalidation/resources/-#+&%/package.mill
@@ -2,5 +2,5 @@ package build.`-#+&%`
 import mill._
 
 object `package` extends RootModule {
-  def input = T {}
+  def input = Task {}
 }

--- a/integration/invalidation/invalidation/resources/a/package.mill
+++ b/integration/invalidation/invalidation/resources/a/package.mill
@@ -1,6 +1,6 @@
 package build.a
 import mill._
 
-def input = T {
+def input = Task {
   println("a")
 }

--- a/integration/invalidation/invalidation/resources/b/package.mill
+++ b/integration/invalidation/invalidation/resources/b/package.mill
@@ -2,7 +2,7 @@ package build.b
 import mill._
 import $file.b.inputD
 
-def input = T {
+def input = Task {
   inputD.method()
   println("b")
 }

--- a/integration/invalidation/invalidation/resources/build.mill
+++ b/integration/invalidation/invalidation/resources/build.mill
@@ -3,14 +3,14 @@ import mill._
 
 import $ivy.`org.scalaj::scalaj-http:2.4.2`
 
-def task = T {
+def task = Task {
   build.a.input()
   build.b.input()
   build.c.input()
 }
 
 object module extends Module {
-  def task = T {
+  def task = Task {
     println("task")
     build.a.input()
     build.b.input()
@@ -18,17 +18,17 @@ object module extends Module {
   }
 }
 
-def taskE = T {
+def taskE = Task {
   println("taskE")
   build.e.input()
 }
 
-def taskSymbols = T {
+def taskSymbols = Task {
   println("taskSymbols")
   build.`-#!+→&%=~`.input()
 }
 
-def taskSymbolsInFile = T {
+def taskSymbolsInFile = Task {
   println("taskSymbolsInFile")
   build.`-#+&%`.input()
 }

--- a/integration/invalidation/invalidation/resources/c/package.mill
+++ b/integration/invalidation/invalidation/resources/c/package.mill
@@ -1,6 +1,6 @@
 package build.c
 import mill._
 
-def input = T {
+def input = Task {
   println("c")
 }

--- a/integration/invalidation/invalidation/resources/e/package.mill
+++ b/integration/invalidation/invalidation/resources/e/package.mill
@@ -1,7 +1,7 @@
 package build.e
 import mill._
 
-def input = T {
+def input = Task {
   println("e")
   build.a.input()
 }

--- a/integration/invalidation/multi-level-editing/resources/mill-build/build.mill
+++ b/integration/invalidation/multi-level-editing/resources/mill-build/build.mill
@@ -5,7 +5,7 @@ import mill._, scalalib._
 object `package` extends MillBuildRootModule {
   def ivyDeps = Agg(ivy"com.lihaoyi::scalatags:${constant.MetaConstant.scalatagsVersion}")
 
-  def generatedSources = T {
+  def generatedSources = Task {
     os.write(
       T.dest / "Constant.scala",
       s"""package constant

--- a/integration/invalidation/multi-level-editing/resources/mill-build/build.mill
+++ b/integration/invalidation/multi-level-editing/resources/mill-build/build.mill
@@ -7,13 +7,13 @@ object `package` extends MillBuildRootModule {
 
   def generatedSources = Task {
     os.write(
-      T.dest / "Constant.scala",
+      Task.dest / "Constant.scala",
       s"""package constant
          |object Constant{
          |  def scalatagsVersion = "${constant.MetaConstant.scalatagsVersion}"
          |}
          |""".stripMargin
     )
-    super.generatedSources() ++ Seq(PathRef(T.dest / "Constant.scala"))
+    super.generatedSources() ++ Seq(PathRef(Task.dest / "Constant.scala"))
   }
 }

--- a/integration/invalidation/multi-level-editing/resources/mill-build/mill-build/build.mill
+++ b/integration/invalidation/multi-level-editing/resources/mill-build/mill-build/build.mill
@@ -5,13 +5,13 @@ import mill._, scalalib._
 object `package` extends MillBuildRootModule {
   def generatedSources = Task {
     os.write(
-      T.dest / "MetaConstant.scala",
+      Task.dest / "MetaConstant.scala",
       """package constant
         |object MetaConstant{
         |  def scalatagsVersion = "0.8.2"
         |}
         |""".stripMargin
     )
-    super.generatedSources() ++ Seq(PathRef(T.dest / "MetaConstant.scala"))
+    super.generatedSources() ++ Seq(PathRef(Task.dest / "MetaConstant.scala"))
   }
 }

--- a/integration/invalidation/multi-level-editing/resources/mill-build/mill-build/build.mill
+++ b/integration/invalidation/multi-level-editing/resources/mill-build/mill-build/build.mill
@@ -3,7 +3,7 @@ package build
 import mill._, scalalib._
 
 object `package` extends MillBuildRootModule {
-  def generatedSources = T {
+  def generatedSources = Task {
     os.write(
       T.dest / "MetaConstant.scala",
       """package constant

--- a/integration/invalidation/watch-source-input/resources/build.mill
+++ b/integration/invalidation/watch-source-input/resources/build.mill
@@ -6,7 +6,7 @@ println("Setting up build.mill")
 def foo = T.sources(millSourcePath / "foo1.txt", millSourcePath / "foo2.txt")
 def bar = T.source(millSourcePath / "bar.txt")
 
-def qux = T {
+def qux = Task {
   val fooMsg = "Running qux foo contents " + foo().map(p => os.read(p.path)).mkString(" ")
   println(fooMsg)
 
@@ -22,7 +22,7 @@ interp.watchValue(PathRef(millSourcePath / "watchValue.txt"))
 
 def baz = T.input(PathRef(millSourcePath / "baz.txt"))
 
-def lol = T {
+def lol = Task {
   val barMsg = "Running lol baz contents " + os.read(baz().path)
   println(barMsg)
 

--- a/integration/invalidation/watch-source-input/resources/build.mill
+++ b/integration/invalidation/watch-source-input/resources/build.mill
@@ -3,8 +3,8 @@ import mill._
 
 println("Setting up build.mill")
 
-def foo = T.sources(millSourcePath / "foo1.txt", millSourcePath / "foo2.txt")
-def bar = T.source(millSourcePath / "bar.txt")
+def foo = Task.sources(millSourcePath / "foo1.txt", millSourcePath / "foo2.txt")
+def bar = Task.source(millSourcePath / "bar.txt")
 
 def qux = Task {
   val fooMsg = "Running qux foo contents " + foo().map(p => os.read(p.path)).mkString(" ")
@@ -20,7 +20,7 @@ def qux = Task {
 
 interp.watchValue(PathRef(millSourcePath / "watchValue.txt"))
 
-def baz = T.input(PathRef(millSourcePath / "baz.txt"))
+def baz = Task.input(PathRef(millSourcePath / "baz.txt"))
 
 def lol = Task {
   val barMsg = "Running lol baz contents " + os.read(baz().path)

--- a/integration/invalidation/watch-source-input/resources/build.mill
+++ b/integration/invalidation/watch-source-input/resources/build.mill
@@ -3,8 +3,8 @@ import mill._
 
 println("Setting up build.mill")
 
-def foo = Task.sources(millSourcePath / "foo1.txt", millSourcePath / "foo2.txt")
-def bar = Task.source(millSourcePath / "bar.txt")
+def foo = Task.Sources(millSourcePath / "foo1.txt", millSourcePath / "foo2.txt")
+def bar = Task.Source(millSourcePath / "bar.txt")
 
 def qux = Task {
   val fooMsg = "Running qux foo contents " + foo().map(p => os.read(p.path)).mkString(" ")
@@ -20,7 +20,7 @@ def qux = Task {
 
 interp.watchValue(PathRef(millSourcePath / "watchValue.txt"))
 
-def baz = Task.input(PathRef(millSourcePath / "baz.txt"))
+def baz = Task.Input(PathRef(millSourcePath / "baz.txt"))
 
 def lol = Task {
   val barMsg = "Running lol baz contents " + os.read(baz().path)

--- a/integration/invalidation/watch-source-input/src/WatchSourceInputTests.scala
+++ b/integration/invalidation/watch-source-input/src/WatchSourceInputTests.scala
@@ -14,9 +14,9 @@ import scala.concurrent.ExecutionContext.Implicits.global
 /**
  * Test to make sure that `--watch` works in the following cases:
  *
- * 1. `T.source`
- * 2. `T.sources`
- * 3. `T.input`
+ * 1. `Task.source`
+ * 2. `Task.sources`
+ * 3. `Task.input`
  * 4. `interp.watchValue`
  * 5. Implicitly watched files, like `build.mill`
  */

--- a/integration/invalidation/watch-source-input/src/WatchSourceInputTests.scala
+++ b/integration/invalidation/watch-source-input/src/WatchSourceInputTests.scala
@@ -14,9 +14,9 @@ import scala.concurrent.ExecutionContext.Implicits.global
 /**
  * Test to make sure that `--watch` works in the following cases:
  *
- * 1. `Task.source`
- * 2. `Task.sources`
- * 3. `Task.input`
+ * 1. `Task.Source`
+ * 2. `Task.Sources`
+ * 3. `Task.Input`
  * 4. `interp.watchValue`
  * 5. Implicitly watched files, like `build.mill`
  */

--- a/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -14,14 +14,13 @@ import mill.util.Util.millProjectModule
 import mill.{Agg, T}
 
 import java.io.File
-import mill.define.Target
 
 trait KotlinModule extends JavaModule { outer =>
 
   /**
    * All individual source files fed into the compiler.
    */
-  override def allSourceFiles: Target[Seq[PathRef]] = Task {
+  override def allSourceFiles: T[Seq[PathRef]] = Task {
     Lib.findSourceFiles(allSources(), Seq("kt", "kts", "java")).map(PathRef(_))
   }
 
@@ -29,7 +28,7 @@ trait KotlinModule extends JavaModule { outer =>
    * All individual Java source files fed into the compiler.
    * Subset of [[allSourceFiles]].
    */
-  def allJavaSourceFiles: Target[Seq[PathRef]] = Task {
+  def allJavaSourceFiles: T[Seq[PathRef]] = Task {
     allSourceFiles().filter(_.path.ext.toLowerCase() == "java")
   }
 
@@ -37,7 +36,7 @@ trait KotlinModule extends JavaModule { outer =>
    * All individual Kotlin source files fed into the compiler.
    * Subset of [[allSourceFiles]].
    */
-  def allKotlinSourceFiles: Target[Seq[PathRef]] = Task {
+  def allKotlinSourceFiles: T[Seq[PathRef]] = Task {
     allSourceFiles().filter(path => Seq("kt", "kts").exists(path.path.ext.toLowerCase() == _))
   }
 

--- a/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -81,7 +81,7 @@ trait KotlinModule extends JavaModule { outer =>
    */
   def kotlinCompilerClasspath: T[Seq[PathRef]] = Task {
     resolveDeps(
-      T.task { kotlinCompilerIvyDeps().map(bindDependency()) }
+      Task.Anon { kotlinCompilerIvyDeps().map(bindDependency()) }
     )().toSeq ++ kotlinWorkerClasspath()
   }
 
@@ -110,11 +110,11 @@ trait KotlinModule extends JavaModule { outer =>
   }
 
 //  @Deprecated("Use kotlinWorkerTask instead, as this does not need to be cached as Worker")
-//  def kotlinWorker: Worker[KotlinWorker] = T.worker {
+//  def kotlinWorker: Worker[KotlinWorker] = Task.worker {
 //    kotlinWorkerTask()
 //  }
 
-  def kotlinWorkerTask: Task[KotlinWorker] = T.task {
+  def kotlinWorkerTask: Task[KotlinWorker] = Task.Anon {
     kotlinWorkerRef().kotlinWorkerManager().get(kotlinCompilerClasspath())
   }
 
@@ -129,7 +129,7 @@ trait KotlinModule extends JavaModule { outer =>
    * Runs the Kotlin compiler with the `-help` argument to show you the built-in cmdline help.
    * You might want to add additional arguments like `-X` to see extra help.
    */
-  def kotlincHelp(args: String*): Command[Unit] = T.command {
+  def kotlincHelp(args: String*): Command[Unit] = Task.Command {
     kotlinCompileTask(Seq("-help") ++ args)()
     ()
   }
@@ -140,7 +140,7 @@ trait KotlinModule extends JavaModule { outer =>
    * The actual Kotlin compile task (used by [[compile]] and [[kotlincHelp]]).
    */
   protected def kotlinCompileTask(extraKotlinArgs: Seq[String] = Seq()): Task[CompilationResult] =
-    T.task {
+    Task.Anon {
       val ctx = T.ctx()
       val dest = ctx.dest
       val classes = dest / "classes"

--- a/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -20,7 +20,7 @@ trait KotlinModule extends JavaModule { outer =>
   /**
    * All individual source files fed into the compiler.
    */
-  override def allSourceFiles = T {
+  override def allSourceFiles = Task {
     Lib.findSourceFiles(allSources(), Seq("kt", "kts", "java")).map(PathRef(_))
   }
 
@@ -28,7 +28,7 @@ trait KotlinModule extends JavaModule { outer =>
    * All individual Java source files fed into the compiler.
    * Subset of [[allSourceFiles]].
    */
-  def allJavaSourceFiles = T {
+  def allJavaSourceFiles = Task {
     allSourceFiles().filter(_.path.ext.toLowerCase() == "java")
   }
 
@@ -36,7 +36,7 @@ trait KotlinModule extends JavaModule { outer =>
    * All individual Kotlin source files fed into the compiler.
    * Subset of [[allSourceFiles]].
    */
-  def allKotlinSourceFiles = T {
+  def allKotlinSourceFiles = Task {
     allSourceFiles().filter(path => Seq("kt", "kts").exists(path.path.ext.toLowerCase() == _))
   }
 
@@ -49,7 +49,7 @@ trait KotlinModule extends JavaModule { outer =>
    * The dependencies of this module.
    * Defaults to add the kotlin-stdlib dependency matching the [[kotlinVersion]].
    */
-  override def mandatoryIvyDeps: T[Agg[Dep]] = T {
+  override def mandatoryIvyDeps: T[Agg[Dep]] = Task {
     super.mandatoryIvyDeps() ++ Agg(
       ivy"org.jetbrains.kotlin:kotlin-stdlib:${kotlinVersion()}"
     )
@@ -59,7 +59,7 @@ trait KotlinModule extends JavaModule { outer =>
    * The version of the Kotlin compiler to be used.
    * Default is derived from [[kotlinVersion]].
    */
-  def kotlinCompilerVersion: T[String] = T { kotlinVersion() }
+  def kotlinCompilerVersion: T[String] = Task { kotlinVersion() }
 
   type CompileProblemReporter = mill.api.CompileProblemReporter
 
@@ -67,7 +67,7 @@ trait KotlinModule extends JavaModule { outer =>
 
   protected def kotlinWorkerRef: ModuleRef[KotlinWorkerModule] = ModuleRef(KotlinWorkerModule)
 
-  private[kotlinlib] def kotlinWorkerClasspath = T {
+  private[kotlinlib] def kotlinWorkerClasspath = Task {
     millProjectModule(
       "mill-kotlinlib-worker-impl",
       repositoriesTask(),
@@ -79,7 +79,7 @@ trait KotlinModule extends JavaModule { outer =>
    * The Java classpath resembling the Kotlin compiler.
    * Default is derived from [[kotlinCompilerIvyDeps]].
    */
-  def kotlinCompilerClasspath: T[Seq[PathRef]] = T {
+  def kotlinCompilerClasspath: T[Seq[PathRef]] = Task {
     resolveDeps(
       T.task { kotlinCompilerIvyDeps().map(bindDependency()) }
     )().toSeq ++ kotlinWorkerClasspath()
@@ -89,7 +89,7 @@ trait KotlinModule extends JavaModule { outer =>
    * The Ivy/Coursier dependencies resembling the Kotlin compiler.
    * Default is derived from [[kotlinCompilerVersion]].
    */
-  def kotlinCompilerIvyDeps: T[Agg[Dep]] = T {
+  def kotlinCompilerIvyDeps: T[Agg[Dep]] = Task {
     Agg(ivy"org.jetbrains.kotlin:kotlin-compiler:${kotlinCompilerVersion()}") ++
 //      (
 //        if (Seq("1.0.", "1.1.", "1.2").exists(prefix => kotlinVersion().startsWith(prefix)))
@@ -121,7 +121,7 @@ trait KotlinModule extends JavaModule { outer =>
   /**
    * Compiles all the sources to JVM class files.
    */
-  override def compile: T[CompilationResult] = T {
+  override def compile: T[CompilationResult] = Task {
     kotlinCompileTask()()
   }
 
@@ -221,7 +221,7 @@ trait KotlinModule extends JavaModule { outer =>
   /**
    * Additional Kotlin compiler options to be used by [[compile]].
    */
-  def kotlincOptions: T[Seq[String]] = T {
+  def kotlincOptions: T[Seq[String]] = Task {
     Seq("-no-stdlib") ++
       when(!kotlinVersion().startsWith("1.0"))(
         "-language-version",
@@ -256,9 +256,9 @@ trait KotlinModule extends JavaModule { outer =>
    * A test sub-module linked to its parent module best suited for unit-tests.
    */
   trait KotlinModuleTests extends JavaModuleTests with KotlinModule {
-    override def kotlinVersion: T[String] = T { outer.kotlinVersion() }
-    override def kotlinCompilerVersion: T[String] = T { outer.kotlinCompilerVersion() }
-    override def kotlincOptions: T[Seq[String]] = T { outer.kotlincOptions() }
+    override def kotlinVersion: T[String] = Task { outer.kotlinVersion() }
+    override def kotlinCompilerVersion: T[String] = Task { outer.kotlinCompilerVersion() }
+    override def kotlincOptions: T[Seq[String]] = Task { outer.kotlincOptions() }
     override def defaultCommandName(): String = super.defaultCommandName()
   }
 

--- a/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -110,7 +110,7 @@ trait KotlinModule extends JavaModule { outer =>
   }
 
 //  @Deprecated("Use kotlinWorkerTask instead, as this does not need to be cached as Worker")
-//  def kotlinWorker: Worker[KotlinWorker] = Task.worker {
+//  def kotlinWorker: Worker[KotlinWorker] = Task.Worker {
 //    kotlinWorkerTask()
 //  }
 

--- a/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -14,13 +14,14 @@ import mill.util.Util.millProjectModule
 import mill.{Agg, T}
 
 import java.io.File
+import mill.define.Target
 
 trait KotlinModule extends JavaModule { outer =>
 
   /**
    * All individual source files fed into the compiler.
    */
-  override def allSourceFiles = Task {
+  override def allSourceFiles: Target[Seq[PathRef]] = Task {
     Lib.findSourceFiles(allSources(), Seq("kt", "kts", "java")).map(PathRef(_))
   }
 
@@ -28,7 +29,7 @@ trait KotlinModule extends JavaModule { outer =>
    * All individual Java source files fed into the compiler.
    * Subset of [[allSourceFiles]].
    */
-  def allJavaSourceFiles = Task {
+  def allJavaSourceFiles: Target[Seq[PathRef]] = Task {
     allSourceFiles().filter(_.path.ext.toLowerCase() == "java")
   }
 
@@ -36,7 +37,7 @@ trait KotlinModule extends JavaModule { outer =>
    * All individual Kotlin source files fed into the compiler.
    * Subset of [[allSourceFiles]].
    */
-  def allKotlinSourceFiles = Task {
+  def allKotlinSourceFiles: Target[Seq[PathRef]] = Task {
     allSourceFiles().filter(path => Seq("kt", "kts").exists(path.path.ext.toLowerCase() == _))
   }
 

--- a/kotlinlib/src/mill/kotlinlib/KotlinWorkerModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/KotlinWorkerModule.scala
@@ -4,7 +4,7 @@
 
 package mill.kotlinlib
 
-import mill.T
+import mill.{T, Task}
 import mill.define.{Discover, ExternalModule, Module, Worker}
 
 trait KotlinWorkerModule extends Module {

--- a/kotlinlib/src/mill/kotlinlib/KotlinWorkerModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/KotlinWorkerModule.scala
@@ -8,7 +8,7 @@ import mill.{T, Task}
 import mill.define.{Discover, ExternalModule, Module, Worker}
 
 trait KotlinWorkerModule extends Module {
-  def kotlinWorkerManager: Worker[KotlinWorkerManager] = Task.worker {
+  def kotlinWorkerManager: Worker[KotlinWorkerManager] = Task.Worker {
     new KotlinWorkerManagerImpl(T.ctx())
   }
 }

--- a/kotlinlib/src/mill/kotlinlib/KotlinWorkerModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/KotlinWorkerModule.scala
@@ -4,11 +4,11 @@
 
 package mill.kotlinlib
 
-import mill.T
+import mill.{T, Task}
 import mill.define.{Discover, ExternalModule, Module, Worker}
 
 trait KotlinWorkerModule extends Module {
-  def kotlinWorkerManager: Worker[KotlinWorkerManager] = T.worker {
+  def kotlinWorkerManager: Worker[KotlinWorkerManager] = Task.worker {
     new KotlinWorkerManagerImpl(T.ctx())
   }
 }

--- a/kotlinlib/src/mill/kotlinlib/KotlinWorkerModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/KotlinWorkerModule.scala
@@ -4,7 +4,7 @@
 
 package mill.kotlinlib
 
-import mill.{T, Task}
+import mill.T
 import mill.define.{Discover, ExternalModule, Module, Worker}
 
 trait KotlinWorkerModule extends Module {

--- a/main/api/src/mill/api/Ctx.scala
+++ b/main/api/src/mill/api/Ctx.scala
@@ -63,7 +63,7 @@ object Ctx {
 
     /**
      * `T.env` is the environment variable map passed to the Mill command when
-     * it is run; typically used inside a `T.input` to ensure any changes in
+     * it is run; typically used inside a `Task.Input` to ensure any changes in
      * the env vars are properly detected.
      *
      * Note that you should not use `sys.env`, as Mill's long-lived server

--- a/main/define/src/mill/define/Discover.scala
+++ b/main/define/src/mill/define/Discover.scala
@@ -6,14 +6,14 @@ import scala.reflect.macros.blackbox
 
 /**
  * Macro to walk the module tree and generate `mainargs` entrypoints for any
- * `T.command` methods that it finds.
+ * `Task.Command` methods that it finds.
  *
  * Note that unlike the rest of Mill's module-handling logic which uses Java
  * reflection, generation of entrypoints requires typeclass resolution, and so
  * needs to be done at compile time. Thus we walk the entire module tree,
  * collecting all the module `Class[_]`s we can find, and for each one generate
  * the `mainargs.MainData` containing metadata and resolved typeclasses for all
- * the `T.command` methods we find. This mapping from `Class[_]` to `MainData`
+ * the `Task.Command` methods we find. This mapping from `Class[_]` to `MainData`
  * can then be used later to look up the `MainData` for any module.
  */
 case class Discover private (
@@ -109,7 +109,7 @@ object Discover {
         overridesRoutes = {
           assertParamListCounts(
             methods,
-            (weakTypeOf[mill.define.Command[_]], 1, "`T.command`"),
+            (weakTypeOf[mill.define.Command[_]], 1, "`Task.Command`"),
             (weakTypeOf[mill.define.Target[_]], 0, "Target")
           )
 

--- a/main/define/src/mill/define/Task.scala
+++ b/main/define/src/mill/define/Task.scala
@@ -59,8 +59,7 @@ object Task extends TaskBase {
    * Violating that invariant can result in confusing mis-behaviors
    */
   def Persistent[T](t: Result[T])(implicit rw: RW[T], ctx: mill.define.Ctx): Target[T] =
-  macro Target.Internal.persistentImpl[T]
-
+    macro Target.Internal.persistentImpl[T]
 
   /**
    * A specialization of [[InputImpl]] defined via `Task.Sources`, [[SourcesImpl]]
@@ -73,20 +72,20 @@ object Task extends TaskBase {
    * [[TargetImpl]]s need to be invalidated and re-computed.
    */
   def Sources(values: Result[os.Path]*)(implicit ctx: mill.define.Ctx): Target[Seq[PathRef]] =
-  macro Target.Internal.sourcesImpl1
+    macro Target.Internal.sourcesImpl1
 
   def Sources(values: Result[Seq[PathRef]])(implicit ctx: mill.define.Ctx): Target[Seq[PathRef]] =
-  macro Target.Internal.sourcesImpl2
+    macro Target.Internal.sourcesImpl2
 
   /**
    * Similar to [[Source]], but only for a single source file or folder. Defined
    * using `Task.Source`.
    */
   def Source(value: Result[os.Path])(implicit ctx: mill.define.Ctx): Target[PathRef] =
-  macro Target.Internal.sourceImpl1
+    macro Target.Internal.sourceImpl1
 
   def Source(value: Result[PathRef])(implicit ctx: mill.define.Ctx): Target[PathRef] =
-  macro Target.Internal.sourceImpl2
+    macro Target.Internal.sourceImpl2
 
   /**
    * [[InputImpl]]s, normally defined using `Task.Input`, are [[NamedTask]]s that
@@ -105,10 +104,10 @@ object Task extends TaskBase {
    * used for detecting changes to source files.
    */
   def Input[T](value: Result[T])(implicit
-                                 w: upickle.default.Writer[T],
-                                 ctx: mill.define.Ctx
+      w: upickle.default.Writer[T],
+      ctx: mill.define.Ctx
   ): Target[T] =
-  macro Target.Internal.inputImpl[T]
+    macro Target.Internal.inputImpl[T]
 
   /**
    * [[Command]]s are only [[NamedTask]]s defined using
@@ -118,11 +117,10 @@ object Task extends TaskBase {
    * arguments, as long as an implicit [[mainargs.TokensReader]] is available.
    */
   def Command[T](t: Result[T])(implicit
-                               w: W[T],
-                               ctx: mill.define.Ctx,
-                               cls: EnclosingClass
+      w: W[T],
+      ctx: mill.define.Ctx,
+      cls: EnclosingClass
   ): Command[T] = macro Target.Internal.commandImpl[T]
-
 
   /**
    * [[Worker]] is a [[NamedTask]] that lives entirely in-memory, defined using
@@ -139,7 +137,7 @@ object Task extends TaskBase {
    * what in-memory state the worker may have.
    */
   def Worker[T](t: Result[T])(implicit ctx: mill.define.Ctx): Worker[T] =
-  macro Target.Internal.workerImpl2[T]
+    macro Target.Internal.workerImpl2[T]
 
   /**
    * Creates an anonymous `Task`. These depend on other tasks and
@@ -242,46 +240,45 @@ trait Target[+T] extends NamedTask[T]
 object Target extends TaskBase {
   @deprecated("Use Task.Persistent instead", "Mill after 0.12.0-RC1")
   def persistent[T](t: Result[T])(implicit rw: RW[T], ctx: mill.define.Ctx): Target[T] =
-  macro Target.Internal.persistentImpl[T]
+    macro Target.Internal.persistentImpl[T]
 
   @deprecated("Use Task.Sources instead", "Mill after 0.12.0-RC1")
   def sources(values: Result[os.Path]*)(implicit ctx: mill.define.Ctx): Target[Seq[PathRef]] =
-  macro Target.Internal.sourcesImpl1
+    macro Target.Internal.sourcesImpl1
   @deprecated("Use Task.Sources instead", "Mill after 0.12.0-RC1")
   def sources(values: Result[Seq[PathRef]])(implicit ctx: mill.define.Ctx): Target[Seq[PathRef]] =
-  macro Target.Internal.sourcesImpl2
-
+    macro Target.Internal.sourcesImpl2
 
   @deprecated("Use Task.Source instead", "Mill after 0.12.0-RC1")
   def source(value: Result[os.Path])(implicit ctx: mill.define.Ctx): Target[PathRef] =
-  macro Target.Internal.sourceImpl1
+    macro Target.Internal.sourceImpl1
 
   @deprecated("Use Task.Source instead", "Mill after 0.12.0-RC1")
   def source(value: Result[PathRef])(implicit ctx: mill.define.Ctx): Target[PathRef] =
-  macro Target.Internal.sourceImpl2
+    macro Target.Internal.sourceImpl2
 
   @deprecated("Use Task.Input instead", "Mill after 0.12.0-RC1")
   def input[T](value: Result[T])(implicit
-                                 w: upickle.default.Writer[T],
-                                 ctx: mill.define.Ctx
+      w: upickle.default.Writer[T],
+      ctx: mill.define.Ctx
   ): Target[T] =
-  macro Target.Internal.inputImpl[T]
+    macro Target.Internal.inputImpl[T]
 
   @deprecated(
     "Creating a command from a task is deprecated. You most likely forgot a parenthesis pair `()`",
     "Mill after 0.12.0-RC1"
   )
   def command[T](t: Task[T])(implicit
-                             ctx: mill.define.Ctx,
-                             w: W[T],
-                             cls: EnclosingClass
+      ctx: mill.define.Ctx,
+      w: W[T],
+      cls: EnclosingClass
   ): Command[T] = macro Target.Internal.commandFromTask[T]
 
   @deprecated("Use Task.Command instead", "Mill after 0.12.0-RC1")
   def command[T](t: Result[T])(implicit
-                               w: W[T],
-                               ctx: mill.define.Ctx,
-                               cls: EnclosingClass
+      w: W[T],
+      ctx: mill.define.Ctx,
+      cls: EnclosingClass
   ): Command[T] = macro Target.Internal.commandImpl[T]
 
   @deprecated(
@@ -289,15 +286,14 @@ object Target extends TaskBase {
     "Mill after 0.12.0-RC1"
   )
   def worker[T](t: Task[T])(implicit ctx: mill.define.Ctx): Worker[T] =
-  macro Target.Internal.workerImpl1[T]
+    macro Target.Internal.workerImpl1[T]
 
   @deprecated("Use Task.Worker instead", "Mill after 0.12.0-RC1")
   def worker[T](t: Result[T])(implicit ctx: mill.define.Ctx): Worker[T] =
-  macro Target.Internal.workerImpl2[T]
+    macro Target.Internal.workerImpl2[T]
 
   @deprecated("Use Task.Anon instead", "Mill after 0.12.0-RC2")
   def task[T](t: Result[T]): Task[T] = macro Applicative.impl[Task, T, mill.api.Ctx]
-
 
   @deprecated(
     "Creating a target from a task is deprecated. You most likely forgot a parenthesis pair `()`",

--- a/main/define/src/mill/define/Task.scala
+++ b/main/define/src/mill/define/Task.scala
@@ -44,6 +44,111 @@ abstract class Task[+T] extends Task.Ops[T] with Applyable[Task, T] {
 }
 
 object Task extends TaskBase {
+
+  /**
+   * [[PersistentImpl]] are a flavor of [[TargetImpl]], normally defined using
+   * the `Task.Persistent{...}` syntax. The main difference is that while
+   * [[TargetImpl]] deletes the `T.dest` folder in between runs,
+   * [[PersistentImpl]] preserves it. This lets the user make use of files on
+   * disk that persistent between runs of the task, e.g. to implement their own
+   * fine-grained caching beyond what Mill provides by default.
+   *
+   * Note that the user defining a `Task.Persistent` task is taking on the
+   * responsibility of ensuring that their implementation is idempotent, i.e.
+   * that it computes the same result whether or not there is data in `T.dest`.
+   * Violating that invariant can result in confusing mis-behaviors
+   */
+  def Persistent[T](t: Result[T])(implicit rw: RW[T], ctx: mill.define.Ctx): Target[T] =
+  macro Target.Internal.persistentImpl[T]
+
+
+  /**
+   * A specialization of [[InputImpl]] defined via `Task.Sources`, [[SourcesImpl]]
+   * uses [[PathRef]]s to compute a signature for a set of source files and
+   * folders.
+   *
+   * This is most used when detecting changes in source code: when you edit a
+   * file and run `mill compile`, it is the `Task.Sources` that re-computes the
+   * signature for you source files/folders and decides whether or not downstream
+   * [[TargetImpl]]s need to be invalidated and re-computed.
+   */
+  def Sources(values: Result[os.Path]*)(implicit ctx: mill.define.Ctx): Target[Seq[PathRef]] =
+  macro Target.Internal.sourcesImpl1
+
+  def Sources(values: Result[Seq[PathRef]])(implicit ctx: mill.define.Ctx): Target[Seq[PathRef]] =
+  macro Target.Internal.sourcesImpl2
+
+  /**
+   * Similar to [[Source]], but only for a single source file or folder. Defined
+   * using `Task.Source`.
+   */
+  def Source(value: Result[os.Path])(implicit ctx: mill.define.Ctx): Target[PathRef] =
+  macro Target.Internal.sourceImpl1
+
+  def Source(value: Result[PathRef])(implicit ctx: mill.define.Ctx): Target[PathRef] =
+  macro Target.Internal.sourceImpl2
+
+  /**
+   * [[InputImpl]]s, normally defined using `Task.Input`, are [[NamedTask]]s that
+   * re-evaluate every time Mill is run. This is in contrast to [[TargetImpl]]s
+   * which only re-evaluate when upstream tasks change.
+   *
+   * [[InputImpl]]s are useful when you want to capture some input to the Mill
+   * build graph that comes from outside: maybe from an environment variable, a
+   * JVM system property, the hash returned by `git rev-parse HEAD`. Reading
+   * these external mutable variables inside a `T{...}` [[TargetImpl]] will
+   * incorrectly cache them forever. Reading them inside a `Task.Input{...}`
+   * will re-compute them every time, and only if the value changes would it
+   * continue to invalidate downstream [[TargetImpl]]s
+   *
+   * The most common case of [[InputImpl]] is [[SourceImpl]] and [[SourcesImpl]],
+   * used for detecting changes to source files.
+   */
+  def Input[T](value: Result[T])(implicit
+                                 w: upickle.default.Writer[T],
+                                 ctx: mill.define.Ctx
+  ): Target[T] =
+  macro Target.Internal.inputImpl[T]
+
+  /**
+   * [[Command]]s are only [[NamedTask]]s defined using
+   * `def foo() = Task.Command{...}` and are typically called from the
+   * command-line. Unlike other [[NamedTask]]s, [[Command]]s can be defined to
+   * take arguments that are automatically converted to command-line
+   * arguments, as long as an implicit [[mainargs.TokensReader]] is available.
+   */
+  def Command[T](t: Result[T])(implicit
+                               w: W[T],
+                               ctx: mill.define.Ctx,
+                               cls: EnclosingClass
+  ): Command[T] = macro Target.Internal.commandImpl[T]
+
+
+  /**
+   * [[Worker]] is a [[NamedTask]] that lives entirely in-memory, defined using
+   * `Task.Worker{...}`. The value returned by `Task.Worker{...}` is long-lived,
+   * persisting as long as the Mill process is kept alive (e.g. via `--watch`,
+   * or via its default `MillServerMain` server process). This allows the user to
+   * perform in-memory caching that is even more aggressive than the disk-based
+   * caching enabled by [[PersistentImpl]]: your [[Worker]] can cache running
+   * sub-processes, JVM Classloaders with JITed code, and all sorts of things
+   * that do not easily serialize to JSON on disk.
+   *
+   * Like [[PersistentImpl]], The user defining a [[Worker]] assumes the
+   * responsibility of ensuring the implementation is idempotent regardless of
+   * what in-memory state the worker may have.
+   */
+  def Worker[T](t: Result[T])(implicit ctx: mill.define.Ctx): Worker[T] =
+  macro Target.Internal.workerImpl2[T]
+
+  /**
+   * Creates an anonymous `Task`. These depend on other tasks and
+   * be-depended-upon by other tasks, but cannot be run directly from the
+   * command line and do not perform any caching. Typically used as helpers to
+   * implement `T{...}` targets.
+   */
+  def Anon[T](t: Result[T]): Task[T] = macro Applicative.impl[Task, T, mill.api.Ctx]
+
   @deprecated(
     "Creating a target from a task is deprecated. You most likely forgot a parenthesis pair `()`",
     "Mill after 0.12.0-RC1"
@@ -99,7 +204,7 @@ object Task extends TaskBase {
 
 /**
  * Represents a task that can be referenced by its path segments. `T{...}`
- * targets, `Task.Input`, `Task.worker`, etc. but not including anonymous
+ * targets, `Task.Input`, `Task.Worker`, etc. but not including anonymous
  * `Task.Anon` or `T.traverse` etc. instances
  */
 trait NamedTask[+T] extends Task[T] {
@@ -135,6 +240,65 @@ trait NamedTask[+T] extends Task[T] {
 trait Target[+T] extends NamedTask[T]
 
 object Target extends TaskBase {
+  @deprecated("Use Task.Persistent instead", "Mill after 0.12.0-RC1")
+  def persistent[T](t: Result[T])(implicit rw: RW[T], ctx: mill.define.Ctx): Target[T] =
+  macro Target.Internal.persistentImpl[T]
+
+  @deprecated("Use Task.Sources instead", "Mill after 0.12.0-RC1")
+  def sources(values: Result[os.Path]*)(implicit ctx: mill.define.Ctx): Target[Seq[PathRef]] =
+  macro Target.Internal.sourcesImpl1
+  @deprecated("Use Task.Sources instead", "Mill after 0.12.0-RC1")
+  def sources(values: Result[Seq[PathRef]])(implicit ctx: mill.define.Ctx): Target[Seq[PathRef]] =
+  macro Target.Internal.sourcesImpl2
+
+
+  @deprecated("Use Task.Source instead", "Mill after 0.12.0-RC1")
+  def source(value: Result[os.Path])(implicit ctx: mill.define.Ctx): Target[PathRef] =
+  macro Target.Internal.sourceImpl1
+
+  @deprecated("Use Task.Source instead", "Mill after 0.12.0-RC1")
+  def source(value: Result[PathRef])(implicit ctx: mill.define.Ctx): Target[PathRef] =
+  macro Target.Internal.sourceImpl2
+
+  @deprecated("Use Task.Input instead", "Mill after 0.12.0-RC1")
+  def input[T](value: Result[T])(implicit
+                                 w: upickle.default.Writer[T],
+                                 ctx: mill.define.Ctx
+  ): Target[T] =
+  macro Target.Internal.inputImpl[T]
+
+  @deprecated(
+    "Creating a command from a task is deprecated. You most likely forgot a parenthesis pair `()`",
+    "Mill after 0.12.0-RC1"
+  )
+  def command[T](t: Task[T])(implicit
+                             ctx: mill.define.Ctx,
+                             w: W[T],
+                             cls: EnclosingClass
+  ): Command[T] = macro Target.Internal.commandFromTask[T]
+
+  @deprecated("Use Task.Command instead", "Mill after 0.12.0-RC1")
+  def command[T](t: Result[T])(implicit
+                               w: W[T],
+                               ctx: mill.define.Ctx,
+                               cls: EnclosingClass
+  ): Command[T] = macro Target.Internal.commandImpl[T]
+
+  @deprecated(
+    "Creating a worker from a task is deprecated. You most likely forgot a parenthesis pair `()`",
+    "Mill after 0.12.0-RC1"
+  )
+  def worker[T](t: Task[T])(implicit ctx: mill.define.Ctx): Worker[T] =
+  macro Target.Internal.workerImpl1[T]
+
+  @deprecated("Use Task.Worker instead", "Mill after 0.12.0-RC1")
+  def worker[T](t: Result[T])(implicit ctx: mill.define.Ctx): Worker[T] =
+  macro Target.Internal.workerImpl2[T]
+
+  @deprecated("Use Task.anon instead", "Mill after 0.12.0-RC2")
+  def task[T](t: Result[T]): Task[T] = macro Applicative.impl[Task, T, mill.api.Ctx]
+
+
   @deprecated(
     "Creating a target from a task is deprecated. You most likely forgot a parenthesis pair `()`",
     "Mill after 0.12.0-RC1"
@@ -484,169 +648,6 @@ class TaskBase extends Applicative.Applyer[Task, Task, Result, mill.api.Ctx] {
    * use cases like BSP or LSP server usage).
    */
   def workspace(implicit ctx: mill.api.Ctx): os.Path = ctx.workspace
-
-  @deprecated("Use Task.Persistent instead", "Mill after 0.12.0-RC1")
-  def persistent[T](t: Result[T])(implicit rw: RW[T], ctx: mill.define.Ctx): Target[T] =
-    macro Target.Internal.persistentImpl[T]
-
-  /**
-   * [[PersistentImpl]] are a flavor of [[TargetImpl]], normally defined using
-   * the `Task.Persistent{...}` syntax. The main difference is that while
-   * [[TargetImpl]] deletes the `T.dest` folder in between runs,
-   * [[PersistentImpl]] preserves it. This lets the user make use of files on
-   * disk that persistent between runs of the task, e.g. to implement their own
-   * fine-grained caching beyond what Mill provides by default.
-   *
-   * Note that the user defining a `Task.Persistent` task is taking on the
-   * responsibility of ensuring that their implementation is idempotent, i.e.
-   * that it computes the same result whether or not there is data in `T.dest`.
-   * Violating that invariant can result in confusing mis-behaviors
-   */
-  def Persistent[T](t: Result[T])(implicit rw: RW[T], ctx: mill.define.Ctx): Target[T] =
-    macro Target.Internal.persistentImpl[T]
-
-  @deprecated("Use Task.Sources instead", "Mill after 0.12.0-RC1")
-  def sources(values: Result[os.Path]*)(implicit ctx: mill.define.Ctx): Target[Seq[PathRef]] =
-    macro Target.Internal.sourcesImpl1
-  @deprecated("Use Task.Sources instead", "Mill after 0.12.0-RC1")
-  def sources(values: Result[Seq[PathRef]])(implicit ctx: mill.define.Ctx): Target[Seq[PathRef]] =
-    macro Target.Internal.sourcesImpl2
-
-  /**
-   * A specialization of [[InputImpl]] defined via `Task.Sources`, [[SourcesImpl]]
-   * uses [[PathRef]]s to compute a signature for a set of source files and
-   * folders.
-   *
-   * This is most used when detecting changes in source code: when you edit a
-   * file and run `mill compile`, it is the `Task.Sources` that re-computes the
-   * signature for you source files/folders and decides whether or not downstream
-   * [[TargetImpl]]s need to be invalidated and re-computed.
-   */
-  def Sources(values: Result[os.Path]*)(implicit ctx: mill.define.Ctx): Target[Seq[PathRef]] =
-    macro Target.Internal.sourcesImpl1
-
-  def Sources(values: Result[Seq[PathRef]])(implicit ctx: mill.define.Ctx): Target[Seq[PathRef]] =
-    macro Target.Internal.sourcesImpl2
-
-  /**
-   * Similar to [[Source]], but only for a single source file or folder. Defined
-   * using `Task.Source`.
-   */
-  @deprecated("Use Task.Source instead", "Mill after 0.12.0-RC1")
-  def source(value: Result[os.Path])(implicit ctx: mill.define.Ctx): Target[PathRef] =
-    macro Target.Internal.sourceImpl1
-
-  @deprecated("Use Task.Source instead", "Mill after 0.12.0-RC1")
-  def source(value: Result[PathRef])(implicit ctx: mill.define.Ctx): Target[PathRef] =
-    macro Target.Internal.sourceImpl2
-
-  /**
-   * Similar to [[Source]], but only for a single source file or folder. Defined
-   * using `Task.Source`.
-   */
-  def Source(value: Result[os.Path])(implicit ctx: mill.define.Ctx): Target[PathRef] =
-    macro Target.Internal.sourceImpl1
-
-  def Source(value: Result[PathRef])(implicit ctx: mill.define.Ctx): Target[PathRef] =
-    macro Target.Internal.sourceImpl2
-
-  @deprecated("Use Task.Input instead", "Mill after 0.12.0-RC1")
-  def input[T](value: Result[T])(implicit
-      w: upickle.default.Writer[T],
-      ctx: mill.define.Ctx
-  ): Target[T] =
-    macro Target.Internal.inputImpl[T]
-
-  /**
-   * [[InputImpl]]s, normally defined using `Task.Input`, are [[NamedTask]]s that
-   * re-evaluate every time Mill is run. This is in contrast to [[TargetImpl]]s
-   * which only re-evaluate when upstream tasks change.
-   *
-   * [[InputImpl]]s are useful when you want to capture some input to the Mill
-   * build graph that comes from outside: maybe from an environment variable, a
-   * JVM system property, the hash returned by `git rev-parse HEAD`. Reading
-   * these external mutable variables inside a `T{...}` [[TargetImpl]] will
-   * incorrectly cache them forever. Reading them inside a `Task.Input{...}`
-   * will re-compute them every time, and only if the value changes would it
-   * continue to invalidate downstream [[TargetImpl]]s
-   *
-   * The most common case of [[InputImpl]] is [[SourceImpl]] and [[SourcesImpl]],
-   * used for detecting changes to source files.
-   */
-  def Input[T](value: Result[T])(implicit
-      w: upickle.default.Writer[T],
-      ctx: mill.define.Ctx
-  ): Target[T] =
-    macro Target.Internal.inputImpl[T]
-
-  @deprecated(
-    "Creating a command from a task is deprecated. You most likely forgot a parenthesis pair `()`",
-    "Mill after 0.12.0-RC1"
-  )
-  def command[T](t: Task[T])(implicit
-      ctx: mill.define.Ctx,
-      w: W[T],
-      cls: EnclosingClass
-  ): Command[T] = macro Target.Internal.commandFromTask[T]
-
-  @deprecated("Use Task.Command instead", "Mill after 0.12.0-RC1")
-  def command[T](t: Result[T])(implicit
-      w: W[T],
-      ctx: mill.define.Ctx,
-      cls: EnclosingClass
-  ): Command[T] = macro Target.Internal.commandImpl[T]
-
-  /**
-   * [[Command]]s are only [[NamedTask]]s defined using
-   * `def foo() = Task.Command{...}` and are typically called from the
-   * command-line. Unlike other [[NamedTask]]s, [[Command]]s can be defined to
-   * take arguments that are automatically converted to command-line
-   * arguments, as long as an implicit [[mainargs.TokensReader]] is available.
-   */
-  def Command[T](t: Result[T])(implicit
-      w: W[T],
-      ctx: mill.define.Ctx,
-      cls: EnclosingClass
-  ): Command[T] = macro Target.Internal.commandImpl[T]
-
-  @deprecated(
-    "Creating a worker from a task is deprecated. You most likely forgot a parenthesis pair `()`",
-    "Mill after 0.12.0-RC1"
-  )
-  def worker[T](t: Task[T])(implicit ctx: mill.define.Ctx): Worker[T] =
-    macro Target.Internal.workerImpl1[T]
-
-  @deprecated("Use Task.Worker instead", "Mill after 0.12.0-RC1")
-  def worker[T](t: Result[T])(implicit ctx: mill.define.Ctx): Worker[T] =
-    macro Target.Internal.workerImpl2[T]
-
-  /**
-   * [[Worker]] is a [[NamedTask]] that lives entirely in-memory, defined using
-   * `Task.worker{...}`. The value returned by `Task.worker{...}` is long-lived,
-   * persisting as long as the Mill process is kept alive (e.g. via `--watch`,
-   * or via its default `MillServerMain` server process). This allows the user to
-   * perform in-memory caching that is even more aggressive than the disk-based
-   * caching enabled by [[PersistentImpl]]: your [[Worker]] can cache running
-   * sub-processes, JVM Classloaders with JITed code, and all sorts of things
-   * that do not easily serialize to JSON on disk.
-   *
-   * Like [[PersistentImpl]], The user defining a [[Worker]] assumes the
-   * responsibility of ensuring the implementation is idempotent regardless of
-   * what in-memory state the worker may have.
-   */
-  def Worker[T](t: Result[T])(implicit ctx: mill.define.Ctx): Worker[T] =
-    macro Target.Internal.workerImpl2[T]
-
-  @deprecated("Use Task.anon instead", "Mill after 0.12.0-RC2")
-  def task[T](t: Result[T]): Task[T] = macro Applicative.impl[Task, T, mill.api.Ctx]
-
-  /**
-   * Creates an anonymous `Task`. These depend on other tasks and
-   * be-depended-upon by other tasks, but cannot be run directly from the
-   * command line and do not perform any caching. Typically used as helpers to
-   * implement `T{...}` targets.
-   */
-  def Anon[T](t: Result[T]): Task[T] = macro Applicative.impl[Task, T, mill.api.Ctx]
 
   /**
    * Converts a `Seq[Task[T]]` into a `Task[Seq[T]]`

--- a/main/define/src/mill/define/Task.scala
+++ b/main/define/src/mill/define/Task.scala
@@ -43,7 +43,7 @@ abstract class Task[+T] extends Task.Ops[T] with Applyable[Task, T] {
   def self: Task[T] = this
 }
 
-object Task extends TargetBase {
+object Task extends TaskBase {
   @deprecated(
     "Creating a target from a task is deprecated. You most likely forgot a parenthesis pair `()`",
     "Mill after 0.12.0-RC1"
@@ -134,7 +134,7 @@ trait NamedTask[+T] extends Task[T] {
  */
 trait Target[+T] extends NamedTask[T]
 
-object Target extends TargetBase {
+object Target extends TaskBase {
   @deprecated(
     "Creating a target from a task is deprecated. You most likely forgot a parenthesis pair `()`",
     "Mill after 0.12.0-RC1"
@@ -421,7 +421,7 @@ object Target extends TargetBase {
  * define the tasks, while methods like `T.`[[dest]], `T.`[[log]] or
  * `T.`[[env]] provide the core APIs that are provided to a task implementation
  */
-class TargetBase extends Applicative.Applyer[Task, Task, Result, mill.api.Ctx] {
+class TaskBase extends Applicative.Applyer[Task, Task, Result, mill.api.Ctx] {
 
   /**
    * `T.dest` is a unique `os.Path` (e.g. `out/classFiles.dest/` or `out/run.dest/`)
@@ -596,13 +596,16 @@ class TargetBase extends Applicative.Applyer[Task, Task, Result, mill.api.Ctx] {
   def worker[T](t: Result[T])(implicit ctx: mill.define.Ctx): Worker[T] =
     macro Target.Internal.workerImpl2[T]
 
+
+  @deprecated("Use Task.anon instead", "Mill after 0.12.0-RC2")
+  def task[T](t: Result[T]): Task[T] = macro Applicative.impl[Task, T, mill.api.Ctx]
   /**
    * Creates an anonymous `Task`. These depend on other tasks and
    * be-depended-upon by other tasks, but cannot be run directly from the
    * command line and do not perform any caching. Typically used as helpers to
    * implement `T{...}` targets.
    */
-  def task[T](t: Result[T]): Task[T] = macro Applicative.impl[Task, T, mill.api.Ctx]
+  def anon[T](t: Result[T]): Task[T] = macro Applicative.impl[Task, T, mill.api.Ctx]
 
   /**
    * Converts a `Seq[Task[T]]` into a `Task[Seq[T]]`

--- a/main/define/src/mill/define/Task.scala
+++ b/main/define/src/mill/define/Task.scala
@@ -43,19 +43,19 @@ abstract class Task[+T] extends Task.Ops[T] with Applyable[Task, T] {
   def self: Task[T] = this
 }
 
-object Task extends TargetBase{
+object Task extends TargetBase {
   @deprecated(
     "Creating a target from a task is deprecated. You most likely forgot a parenthesis pair `()`",
     "Mill after 0.12.0-RC1"
   )
   def apply[T](t: Task[T])(implicit rw: RW[T], ctx: mill.define.Ctx): Target[T] =
-  macro Target.Internal.targetTaskImpl[T]
+    macro Target.Internal.targetTaskImpl[T]
 
-  implicit def apply[T](t: T)(implicit rw: RW[T], ctx: mill.define.Ctx): Target[T] =
-  macro Target.Internal.targetImpl[T]
+  def apply[T](t: T)(implicit rw: RW[T], ctx: mill.define.Ctx): Target[T] =
+    macro Target.Internal.targetImpl[T]
 
-  implicit def apply[T](t: Result[T])(implicit rw: RW[T], ctx: mill.define.Ctx): Target[T] =
-  macro Target.Internal.targetResultImpl[T]
+  def apply[T](t: Result[T])(implicit rw: RW[T], ctx: mill.define.Ctx): Target[T] =
+    macro Target.Internal.targetResultImpl[T]
 
   abstract class Ops[+T] { this: Task[T] =>
     def map[V](f: T => V): Task[V] = new Task.Mapped(this, f)
@@ -134,13 +134,14 @@ trait NamedTask[+T] extends Task[T] {
  */
 trait Target[+T] extends NamedTask[T]
 
-object Target extends TargetBase{
+object Target extends TargetBase {
   @deprecated(
     "Creating a target from a task is deprecated. You most likely forgot a parenthesis pair `()`",
     "Mill after 0.12.0-RC1"
   )
   def apply[T](t: Task[T])(implicit rw: RW[T], ctx: mill.define.Ctx): Target[T] =
-  macro Target.Internal.targetTaskImpl[T]
+    macro Target.Internal.targetTaskImpl[T]
+
   /**
    * A target is the most common [[Task]] a user would encounter, commonly
    * defined using the `def foo = T{...}` syntax. [[TargetImpl]]s require that their
@@ -148,10 +149,10 @@ object Target extends TargetBase{
    * return value to disk, only re-computing if upstream [[Task]]s change
    */
   implicit def apply[T](t: T)(implicit rw: RW[T], ctx: mill.define.Ctx): Target[T] =
-  macro Internal.targetImpl[T]
+    macro Internal.targetImpl[T]
 
   implicit def apply[T](t: Result[T])(implicit rw: RW[T], ctx: mill.define.Ctx): Target[T] =
-  macro Internal.targetResultImpl[T]
+    macro Internal.targetResultImpl[T]
 
   object Internal {
     private def isPrivateTargetOption(c: Context): c.Expr[Option[Boolean]] = {
@@ -161,8 +162,8 @@ object Target extends TargetBase{
     }
 
     def targetImpl[T: c.WeakTypeTag](c: Context)(t: c.Expr[T])(
-      rw: c.Expr[RW[T]],
-      ctx: c.Expr[mill.define.Ctx]
+        rw: c.Expr[RW[T]],
+        ctx: c.Expr[mill.define.Ctx]
     ): c.Expr[Target[T]] = {
       import c.universe._
 
@@ -183,8 +184,8 @@ object Target extends TargetBase{
     }
 
     def targetResultImpl[T: c.WeakTypeTag](c: Context)(t: c.Expr[Result[T]])(
-      rw: c.Expr[RW[T]],
-      ctx: c.Expr[mill.define.Ctx]
+        rw: c.Expr[RW[T]],
+        ctx: c.Expr[mill.define.Ctx]
     ): c.Expr[Target[T]] = {
       import c.universe._
 
@@ -203,8 +204,8 @@ object Target extends TargetBase{
     }
 
     def targetTaskImpl[T: c.WeakTypeTag](c: Context)(t: c.Expr[Task[T]])(
-      rw: c.Expr[RW[T]],
-      ctx: c.Expr[mill.define.Ctx]
+        rw: c.Expr[RW[T]],
+        ctx: c.Expr[mill.define.Ctx]
     ): c.Expr[Target[T]] = {
       import c.universe._
 
@@ -223,7 +224,7 @@ object Target extends TargetBase{
     }
 
     def sourcesImpl1(c: Context)(values: c.Expr[Result[os.Path]]*)(ctx: c.Expr[mill.define.Ctx])
-    : c.Expr[Target[Seq[PathRef]]] = {
+        : c.Expr[Target[Seq[PathRef]]] = {
       import c.universe._
       val wrapped =
         for (value <- values.toList)
@@ -245,7 +246,7 @@ object Target extends TargetBase{
     }
 
     def sourcesImpl2(c: Context)(values: c.Expr[Result[Seq[PathRef]]])(ctx: c.Expr[mill.define.Ctx])
-    : c.Expr[Target[Seq[PathRef]]] = {
+        : c.Expr[Target[Seq[PathRef]]] = {
       import c.universe._
 
       val taskIsPrivate = isPrivateTargetOption(c)
@@ -262,7 +263,7 @@ object Target extends TargetBase{
     }
 
     def sourceImpl1(c: Context)(value: c.Expr[Result[os.Path]])(ctx: c.Expr[mill.define.Ctx])
-    : c.Expr[Target[PathRef]] = {
+        : c.Expr[Target[PathRef]] = {
       import c.universe._
 
       val wrapped =
@@ -284,7 +285,7 @@ object Target extends TargetBase{
     }
 
     def sourceImpl2(c: Context)(value: c.Expr[Result[PathRef]])(ctx: c.Expr[mill.define.Ctx])
-    : c.Expr[Target[PathRef]] = {
+        : c.Expr[Target[PathRef]] = {
       import c.universe._
 
       val taskIsPrivate = isPrivateTargetOption(c)
@@ -301,8 +302,8 @@ object Target extends TargetBase{
     }
 
     def inputImpl[T: c.WeakTypeTag](c: Context)(value: c.Expr[T])(
-      w: c.Expr[upickle.default.Writer[T]],
-      ctx: c.Expr[mill.define.Ctx]
+        w: c.Expr[upickle.default.Writer[T]],
+        ctx: c.Expr[mill.define.Ctx]
     ): c.Expr[Target[T]] = {
       import c.universe._
 
@@ -321,9 +322,9 @@ object Target extends TargetBase{
     }
 
     def commandFromTask[T: c.WeakTypeTag](c: Context)(t: c.Expr[Task[T]])(
-      ctx: c.Expr[mill.define.Ctx],
-      w: c.Expr[W[T]],
-      cls: c.Expr[EnclosingClass]
+        ctx: c.Expr[mill.define.Ctx],
+        w: c.Expr[W[T]],
+        cls: c.Expr[EnclosingClass]
     ): c.Expr[Command[T]] = {
       import c.universe._
 
@@ -341,9 +342,9 @@ object Target extends TargetBase{
     }
 
     def commandImpl[T: c.WeakTypeTag](c: Context)(t: c.Expr[T])(
-      w: c.Expr[W[T]],
-      ctx: c.Expr[mill.define.Ctx],
-      cls: c.Expr[EnclosingClass]
+        w: c.Expr[W[T]],
+        ctx: c.Expr[mill.define.Ctx],
+        cls: c.Expr[EnclosingClass]
     ): c.Expr[Command[T]] = {
       import c.universe._
 
@@ -361,7 +362,7 @@ object Target extends TargetBase{
     }
 
     def workerImpl1[T: c.WeakTypeTag](c: Context)(t: c.Expr[Task[T]])(ctx: c.Expr[mill.define.Ctx])
-    : c.Expr[Worker[T]] = {
+        : c.Expr[Worker[T]] = {
       import c.universe._
 
       val taskIsPrivate = isPrivateTargetOption(c)
@@ -374,7 +375,7 @@ object Target extends TargetBase{
     }
 
     def workerImpl2[T: c.WeakTypeTag](c: Context)(t: c.Expr[T])(ctx: c.Expr[mill.define.Ctx])
-    : c.Expr[Worker[T]] = {
+        : c.Expr[Worker[T]] = {
       import c.universe._
 
       val taskIsPrivate = isPrivateTargetOption(c)
@@ -391,8 +392,8 @@ object Target extends TargetBase{
     }
 
     def persistentImpl[T: c.WeakTypeTag](c: Context)(t: c.Expr[T])(
-      rw: c.Expr[RW[T]],
-      ctx: c.Expr[mill.define.Ctx]
+        rw: c.Expr[RW[T]],
+        ctx: c.Expr[mill.define.Ctx]
     ): c.Expr[PersistentImpl[T]] = {
       import c.universe._
 
@@ -412,6 +413,7 @@ object Target extends TargetBase{
   }
 
 }
+
 /**
  * The [[mill.define.Target]] companion object, usually aliased as [[T]],
  * provides most of the helper methods and macros used to build task graphs.

--- a/main/define/src/mill/define/Task.scala
+++ b/main/define/src/mill/define/Task.scala
@@ -295,7 +295,7 @@ object Target extends TaskBase {
   def worker[T](t: Result[T])(implicit ctx: mill.define.Ctx): Worker[T] =
   macro Target.Internal.workerImpl2[T]
 
-  @deprecated("Use Task.anon instead", "Mill after 0.12.0-RC2")
+  @deprecated("Use Task.Anon instead", "Mill after 0.12.0-RC2")
   def task[T](t: Result[T]): Task[T] = macro Applicative.impl[Task, T, mill.api.Ctx]
 
 

--- a/main/define/test/src/mill/define/CacherTests.scala
+++ b/main/define/test/src/mill/define/CacherTests.scala
@@ -2,7 +2,7 @@ package mill.define
 
 import mill.testkit.UnitTester
 import mill.testkit.TestBaseModule
-import mill.T
+import mill.{T, Task}
 import mill.api.Result.Success
 import utest._
 import utest.framework.TestPath
@@ -10,17 +10,17 @@ import utest.framework.TestPath
 object CacherTests extends TestSuite {
   object Base extends Base
   trait Base extends TestBaseModule {
-    def value = T { 1 }
-    def result = T { Success(1) }
+    def value = Task { 1 }
+    def result = Task { Success(1) }
   }
   object Middle extends Middle
   trait Middle extends Base {
-    override def value = T { super.value() + 2 }
-    def overridden = T { super.value() }
+    override def value = Task { super.value() + 2 }
+    def overridden = Task { super.value() }
   }
   object Terminal extends Terminal
   trait Terminal extends Middle {
-    override def value = T { super.value() + 4 }
+    override def value = Task { super.value() + 4 }
   }
 
   val tests = Tests {

--- a/main/define/test/src/mill/define/MacroErrorTests.scala
+++ b/main/define/test/src/mill/define/MacroErrorTests.scala
@@ -20,12 +20,12 @@ object MacroErrorTests extends TestSuite {
       test("command") {
         val e = compileError("""
           object foo extends TestBaseModule{
-            def w = T.command{1}
+            def w = Task.Command{1}
           }
           mill.define.Discover[foo.type]
         """)
         assert(
-          e.msg.contains("`T.command` definitions must have 1 parameter list"),
+          e.msg.contains("`Task.Command` definitions must have 1 parameter list"),
           e.pos.contains("def w = ")
         )
       }
@@ -45,7 +45,7 @@ object MacroErrorTests extends TestSuite {
       test("input") {
         val e = compileError("""
           object foo extends TestBaseModule{
-            def y() = T.input{1}
+            def y() = Task.Input{1}
           }
           mill.define.Discover[foo.type]
         """)
@@ -57,7 +57,7 @@ object MacroErrorTests extends TestSuite {
       test("sources") {
         val e = compileError("""
           object foo extends TestBaseModule{
-            def z() = T.sources{os.pwd}
+            def z() = Task.Sources{os.pwd}
           }
           mill.define.Discover[foo.type]
         """)
@@ -69,7 +69,7 @@ object MacroErrorTests extends TestSuite {
       test("persistent") {
         val e = compileError("""
           object foo extends TestBaseModule{
-            def a() = T.persistent{1}
+            def a() = Task.Persistent{1}
           }
           mill.define.Discover[foo.type]
         """)

--- a/main/eval/src/mill/eval/Terminal.scala
+++ b/main/eval/src/mill/eval/Terminal.scala
@@ -5,7 +5,7 @@ import mill.define.{NamedTask, Segment, Segments}
 /**
  * A terminal or terminal target is some important work unit, that in most cases has a name (Right[Labelled])
  * or was directly called by the user (Left[Task]).
- * It's a T, Task.worker, Task.Input, Task.Source, Task.Sources, Task.Persistent
+ * It's a T, Task.Worker, Task.Input, Task.Source, Task.Sources, Task.Persistent
  */
 sealed trait Terminal {
   def render: String

--- a/main/eval/src/mill/eval/Terminal.scala
+++ b/main/eval/src/mill/eval/Terminal.scala
@@ -5,7 +5,7 @@ import mill.define.{NamedTask, Segment, Segments}
 /**
  * A terminal or terminal target is some important work unit, that in most cases has a name (Right[Labelled])
  * or was directly called by the user (Left[Task]).
- * It's a T, T.worker, T.input, T.source, T.sources, T.persistent
+ * It's a T, Task.worker, Task.Input, Task.Source, Task.Sources, Task.Persistent
  */
 sealed trait Terminal {
   def render: String

--- a/main/eval/test/src/mill/eval/EvaluationTests.scala
+++ b/main/eval/test/src/mill/eval/EvaluationTests.scala
@@ -301,11 +301,11 @@ class EvaluationTests(threadCount: Option[Int]) extends TestSuite {
           var leftCount = 0
           var rightCount = 0
           var middleCount = 0
-          def up = T { test.anon() }
+          def up = Task { test.anon() }
           def left = T.task { leftCount += 1; up() + 1 }
           def middle = T.task { middleCount += 1; 100 }
-          def right = T { rightCount += 1; 10000 }
-          def down = T { left() + middle() + right() }
+          def right = Task { rightCount += 1; 10000 }
+          def down = Task { left() + middle() + right() }
         }
 
         import build._

--- a/main/eval/test/src/mill/eval/EvaluationTests.scala
+++ b/main/eval/test/src/mill/eval/EvaluationTests.scala
@@ -302,8 +302,8 @@ class EvaluationTests(threadCount: Option[Int]) extends TestSuite {
           var rightCount = 0
           var middleCount = 0
           def up = Task { test.anon() }
-          def left = T.task { leftCount += 1; up() + 1 }
-          def middle = T.task { middleCount += 1; 100 }
+          def left = Task.Anon { leftCount += 1; up() + 1 }
+          def middle = Task.Anon { middleCount += 1; 100 }
           def right = Task { rightCount += 1; 10000 }
           def down = Task { left() + middle() + right() }
         }

--- a/main/eval/test/src/mill/eval/FailureTests.scala
+++ b/main/eval/test/src/mill/eval/FailureTests.scala
@@ -1,6 +1,6 @@
 package mill.eval
 
-import mill.T
+import mill.{T, Task}
 import mill.testkit.UnitTester
 import mill.testkit.TestBaseModule
 import mill.api.Result.OuterStack
@@ -183,11 +183,11 @@ object FailureTests extends TestSuite {
     test("multipleUsesOfDest") {
       object build extends TestBaseModule {
         // Using `T.ctx(  ).dest` twice in a single task is ok
-        def left = T { +T.dest.toString.length + T.dest.toString.length }
+        def left = Task { +T.dest.toString.length + T.dest.toString.length }
 
         // Using `T.ctx(  ).dest` once in two different tasks is ok
         val task = T.task { T.dest.toString.length }
-        def right = T { task() + left() + T.dest.toString().length }
+        def right = Task { task() + left() + T.dest.toString().length }
       }
 
       val check = UnitTester(build, null)

--- a/main/eval/test/src/mill/eval/FailureTests.scala
+++ b/main/eval/test/src/mill/eval/FailureTests.scala
@@ -186,7 +186,7 @@ object FailureTests extends TestSuite {
         def left = Task { +T.dest.toString.length + T.dest.toString.length }
 
         // Using `T.ctx(  ).dest` once in two different tasks is ok
-        val task = T.task { T.dest.toString.length }
+        val task = Task.Anon { T.dest.toString.length }
         def right = Task { task() + left() + T.dest.toString().length }
       }
 

--- a/main/eval/test/src/mill/eval/JavaCompileJarTests.scala
+++ b/main/eval/test/src/mill/eval/JavaCompileJarTests.scala
@@ -35,9 +35,9 @@ object JavaCompileJarTests extends TestSuite {
         //           resourceRoot ---->  jar
         //                                ^
         //           readmePath---------- |
-        def readme = T.source { readmePath }
-        def sourceRoot = T.sources { sourceRootPath }
-        def resourceRoot = T.sources { resourceRootPath }
+        def readme = Task.Source { readmePath }
+        def sourceRoot = Task.Sources { sourceRootPath }
+        def resourceRoot = Task.Sources { resourceRootPath }
         def allSources =
           Task { sourceRoot().flatMap(p => os.walk(p.path)).map(mill.api.PathRef(_)) }
         def classFiles = Task { compileAll(allSources()) }
@@ -53,7 +53,7 @@ object JavaCompileJarTests extends TestSuite {
           )
         }
 
-        def run(mainClsName: String) = T.command {
+        def run(mainClsName: String) = Task.Command {
           os.proc("java", "-Duser.language=en", "-cp", classFiles().path, mainClsName)
             .call(stderr = os.Pipe)
         }
@@ -98,7 +98,7 @@ object JavaCompileJarTests extends TestSuite {
       append(resourceRootPath / "hello.txt", " ")
       check(targets = Agg(jar), expected = Agg(jar))
 
-      // Touching the readme.md, defined as `T.source`, forces a jar rebuid
+      // Touching the readme.md, defined as `Task.Source`, forces a jar rebuid
       append(readmePath, " ")
       check(targets = Agg(jar), expected = Agg(jar))
 

--- a/main/eval/test/src/mill/eval/JavaCompileJarTests.scala
+++ b/main/eval/test/src/mill/eval/JavaCompileJarTests.scala
@@ -2,7 +2,7 @@ package mill.eval
 
 import mill.util.{Jvm, TestUtil}
 import mill.api.Ctx.Dest
-import mill.T
+import mill.{T, Task}
 import mill.testkit.UnitTester
 import mill.testkit.TestBaseModule
 import mill.api.Strict.Agg
@@ -38,13 +38,13 @@ object JavaCompileJarTests extends TestSuite {
         def readme = T.source { readmePath }
         def sourceRoot = T.sources { sourceRootPath }
         def resourceRoot = T.sources { resourceRootPath }
-        def allSources = T { sourceRoot().flatMap(p => os.walk(p.path)).map(mill.api.PathRef(_)) }
-        def classFiles = T { compileAll(allSources()) }
-        def jar = T {
+        def allSources = Task { sourceRoot().flatMap(p => os.walk(p.path)).map(mill.api.PathRef(_)) }
+        def classFiles = Task { compileAll(allSources()) }
+        def jar = Task {
           Jvm.createJar(Loose.Agg(classFiles().path, readme().path) ++ resourceRoot().map(_.path))
         }
         // Test createJar() with optional file filter.
-        def filterJar(fileFilter: (os.Path, os.RelPath) => Boolean) = T {
+        def filterJar(fileFilter: (os.Path, os.RelPath) => Boolean) = Task {
           Jvm.createJar(
             Loose.Agg(classFiles().path, readme().path) ++ resourceRoot().map(_.path),
             JarManifest.MillDefault,

--- a/main/eval/test/src/mill/eval/JavaCompileJarTests.scala
+++ b/main/eval/test/src/mill/eval/JavaCompileJarTests.scala
@@ -38,7 +38,8 @@ object JavaCompileJarTests extends TestSuite {
         def readme = T.source { readmePath }
         def sourceRoot = T.sources { sourceRootPath }
         def resourceRoot = T.sources { resourceRootPath }
-        def allSources = Task { sourceRoot().flatMap(p => os.walk(p.path)).map(mill.api.PathRef(_)) }
+        def allSources =
+          Task { sourceRoot().flatMap(p => os.walk(p.path)).map(mill.api.PathRef(_)) }
         def classFiles = Task { compileAll(allSources()) }
         def jar = Task {
           Jvm.createJar(Loose.Agg(classFiles().path, readme().path) ++ resourceRoot().map(_.path))

--- a/main/eval/test/src/mill/eval/ModuleTests.scala
+++ b/main/eval/test/src/mill/eval/ModuleTests.scala
@@ -3,22 +3,22 @@ package mill.eval
 import mill.testkit.UnitTester
 import mill.testkit.UnitTester.Result
 import mill.testkit.TestBaseModule
-import mill.T
+import mill.{T, Task}
 import mill.define.Discover
 
 import utest._
 
 object TestExternalModule extends mill.define.ExternalModule with mill.define.TaskModule {
   def defaultCommandName = "x"
-  def x = T { 13 }
+  def x = Task { 13 }
   object inner extends mill.Module {
-    def y = T { 17 }
+    def y = Task { 17 }
   }
   lazy val millDiscover = Discover[this.type]
 }
 object ModuleTests extends TestSuite {
   object Build extends TestBaseModule {
-    def z = T { TestExternalModule.x() + TestExternalModule.inner.y() }
+    def z = Task { TestExternalModule.x() + TestExternalModule.inner.y() }
   }
   val tests = Tests {
     test("externalModuleCalls") {
@@ -47,7 +47,7 @@ object ModuleTests extends TestSuite {
 
       object Build extends mill.define.ExternalModule {
 
-        def z = T { TestExternalModule.x() + TestExternalModule.inner.y() }
+        def z = Task { TestExternalModule.x() + TestExternalModule.inner.y() }
         lazy val millDiscover = Discover[this.type]
       }
 

--- a/main/eval/test/src/mill/eval/TaskTests.scala
+++ b/main/eval/test/src/mill/eval/TaskTests.scala
@@ -1,7 +1,7 @@
 package mill.eval
 
 import utest._
-import mill.T
+import mill.{T, Task}
 import mill.define.{Module, Worker}
 import mill.testkit.UnitTester
 import mill.testkit.UnitTester.Result
@@ -23,7 +23,7 @@ trait TaskTests extends TestSuite {
       superBuildInputCount
     }
 
-    def superBuildTargetOverrideWithInput = T {
+    def superBuildTargetOverrideWithInput = Task {
       1234
     }
   }
@@ -67,8 +67,8 @@ trait TaskTests extends TestSuite {
       count += 1
       count
     }
-    def taskInput = T { input() }
-    def taskNoInput = T { task() }
+    def taskInput = Task { input() }
+    def taskNoInput = Task { task() }
 
     def persistent = T.persistent {
       input() // force re-computation
@@ -76,14 +76,14 @@ trait TaskTests extends TestSuite {
       os.write.append(T.dest / "count", "hello\n")
       os.read.lines(T.dest / "count").length
     }
-    def nonPersistent = T {
+    def nonPersistent = Task {
       input() // force re-computation
       os.makeDir.all(T.dest)
       os.write.append(T.dest / "count", "hello\n")
       os.read.lines(T.dest / "count").length
     }
 
-    def staticWorkerDownstream = T {
+    def staticWorkerDownstream = Task {
       val w = staticWorker()
       w.apply(1)
     }
@@ -91,27 +91,27 @@ trait TaskTests extends TestSuite {
     def reevalTrigger = T.input {
       new Object().hashCode()
     }
-    def staticWorkerDownstreamReeval = T {
+    def staticWorkerDownstreamReeval = Task {
       val w = staticWorker()
       reevalTrigger()
       w.apply(1)
     }
 
-    def noisyWorkerDownstream = T {
+    def noisyWorkerDownstream = Task {
       val w = noisyWorker()
       w.apply(1)
     }
-    def noisyClosableWorkerDownstream = T {
+    def noisyClosableWorkerDownstream = Task {
       val w = noisyClosableWorker()
       w.apply(1)
     }
-    def changeOnceWorkerDownstream = T {
+    def changeOnceWorkerDownstream = Task {
       val w = changeOnceWorker()
       w.apply(1)
     }
 
-    override def superBuildInputOverrideWithConstant = T { 123 }
-    override def superBuildInputOverrideUsingSuper = T {
+    override def superBuildInputOverrideWithConstant = Task { 123 }
+    override def superBuildInputOverrideUsingSuper = Task {
       123 + super.superBuildInputOverrideUsingSuper()
     }
 
@@ -124,8 +124,8 @@ trait TaskTests extends TestSuite {
     // Reproduction of issue https://github.com/com-lihaoyi/mill/issues/2958
     object repro2958 extends Module {
       val task1 = T.task { "task1" }
-      def task2 = T { task1() }
-      def task3 = T { task1() }
+      def task2 = Task { task1() }
+      def task3 = Task { task1() }
       def command() = T.command {
         val t2 = task2()
         val t3 = task3()

--- a/main/eval/test/src/mill/eval/TaskTests.scala
+++ b/main/eval/test/src/mill/eval/TaskTests.scala
@@ -33,22 +33,22 @@ trait TaskTests extends TestSuite {
     var workerCloseCount = 0
     // Explicitly instantiate `Function1` objects to make sure we get
     // different instances each time
-    def staticWorker: Worker[Int => Int] = Task.worker {
+    def staticWorker: Worker[Int => Int] = Task.Worker {
       new Function1[Int, Int] {
         def apply(v1: Int) = v1 + 1
       }
     }
-    def changeOnceWorker: Worker[Int => Int] = Task.worker {
+    def changeOnceWorker: Worker[Int => Int] = Task.Worker {
       new Function1[Int, Int] {
         def apply(v1: Int): Int = changeOnceInput() + v1
       }
     }
-    def noisyWorker: Worker[Int => Int] = Task.worker {
+    def noisyWorker: Worker[Int => Int] = Task.Worker {
       new Function1[Int, Int] {
         def apply(v1: Int) = input() + v1
       }
     }
-    def noisyClosableWorker: Worker[(Int => Int) with AutoCloseable] = Task.worker {
+    def noisyClosableWorker: Worker[(Int => Int) with AutoCloseable] = Task.Worker {
       new Function1[Int, Int] with AutoCloseable {
         override def apply(v1: Int) = input() + v1
         override def close(): Unit = workerCloseCount += 1

--- a/main/resolve/src/mill/resolve/SimpleTaskTokenReader.scala
+++ b/main/resolve/src/mill/resolve/SimpleTaskTokenReader.scala
@@ -4,7 +4,7 @@ import mainargs.TokensReader
 import mill.define.{Target, Task}
 
 /**
- * Transparently handle `Task[T]` like simple `T` but lift the result into a T.task.
+ * Transparently handle `Task[T]` like simple `T` but lift the result into a Task.Anon.
  */
 class SimpleTaskTokenReader[T](tokensReaderOfT: TokensReader.Simple[T])
     extends mainargs.TokensReader.Simple[Task[T]] {

--- a/main/resolve/test/src/mill/main/ResolveTests.scala
+++ b/main/resolve/test/src/mill/main/ResolveTests.scala
@@ -71,7 +71,7 @@ object ResolveTests extends TestSuite {
     x.left.exists(_.contains(s)) &&
       // Make sure the stack traces are truncated and short-ish, and do not
       // contain the entire Mill internal call stack at point of failure
-      x.left.exists(_.linesIterator.size < 20)
+      x.left.exists(_.linesIterator.size < 25)
 
   val tests = Tests {
     val graphs = new mill.util.TestGraphs()

--- a/main/src/mill/main/VisualizeModule.scala
+++ b/main/src/mill/main/VisualizeModule.scala
@@ -4,7 +4,6 @@ import java.util.concurrent.LinkedBlockingQueue
 import coursier.LocalRepositories
 import coursier.core.Repository
 import coursier.maven.MavenRepository
-import mill.T
 import mill.define.{Discover, ExternalModule, Target}
 import mill.api.{PathRef, Result}
 import mill.util.Util.millProjectModule
@@ -24,7 +23,7 @@ object VisualizeModule extends ExternalModule with VisualizeModule {
 trait VisualizeModule extends mill.define.TaskModule {
   def repositories: Seq[Repository]
   def defaultCommandName() = "run"
-  def classpath: T[Loose.Agg[PathRef]] = Target {
+  def classpath: Target[Loose.Agg[PathRef]] = Target {
     millProjectModule("mill-main-graphviz", repositories)
   }
 

--- a/main/src/mill/main/VisualizeModule.scala
+++ b/main/src/mill/main/VisualizeModule.scala
@@ -4,6 +4,7 @@ import java.util.concurrent.LinkedBlockingQueue
 import coursier.LocalRepositories
 import coursier.core.Repository
 import coursier.maven.MavenRepository
+import mill.T
 import mill.define.{Discover, ExternalModule, Target}
 import mill.api.{PathRef, Result}
 import mill.util.Util.millProjectModule
@@ -23,7 +24,7 @@ object VisualizeModule extends ExternalModule with VisualizeModule {
 trait VisualizeModule extends mill.define.TaskModule {
   def repositories: Seq[Repository]
   def defaultCommandName() = "run"
-  def classpath: Target[Loose.Agg[PathRef]] = Target {
+  def classpath: T[Loose.Agg[PathRef]] = Target {
     millProjectModule("mill-main-graphviz", repositories)
   }
 

--- a/main/test/src/mill/main/MainModuleTests.scala
+++ b/main/test/src/mill/main/MainModuleTests.scala
@@ -1,8 +1,8 @@
 package mill.main
 
 import mill.api.{PathRef, Result, Val}
-import mill.{Agg, T}
-import mill.define.{Cross, Discover, Module, Task}
+import mill.{Agg, T, Task}
+import mill.define.{Cross, Discover, Module}
 import mill.testkit.UnitTester
 import mill.testkit.TestBaseModule
 import utest.{TestSuite, Tests, assert, test}
@@ -12,14 +12,14 @@ import java.io.{ByteArrayOutputStream, PrintStream}
 object MainModuleTests extends TestSuite {
 
   object mainModule extends TestBaseModule with MainModule {
-    def hello = T {
+    def hello = Task {
       System.out.println("Hello System Stdout")
       System.err.println("Hello System Stderr")
       Console.out.println("Hello Console Stdout")
       Console.err.println("Hello Console Stderr")
       Seq("hello", "world")
     }
-    def hello2 = T {
+    def hello2 = Task {
       System.out.println("Hello2 System Stdout")
       System.err.println("Hello2 System Stderr")
       Console.out.println("Hello2 Console Stdout")
@@ -33,7 +33,7 @@ object MainModuleTests extends TestSuite {
   object cleanModule extends TestBaseModule with MainModule {
 
     trait Cleanable extends Module {
-      def target = T {
+      def target = Task {
         os.write(T.dest / "dummy.txt", "dummy text")
         Seq(PathRef(T.dest))
       }
@@ -43,7 +43,7 @@ object MainModuleTests extends TestSuite {
       object sub extends Cleanable
     }
     object bar extends Cleanable {
-      override def target = T {
+      override def target = Task {
         os.write(T.dest / "dummy.txt", "dummy text")
         super.target() ++ Seq(PathRef(T.dest))
       }
@@ -51,7 +51,7 @@ object MainModuleTests extends TestSuite {
     object bazz extends Cross[Bazz]("1", "2", "3")
     trait Bazz extends Cleanable with Cross.Module[String]
 
-    def all = T {
+    def all = Task {
       foo.target()
       bar.target()
       bazz("1").target()

--- a/main/test/src/mill/main/MainModuleTests.scala
+++ b/main/test/src/mill/main/MainModuleTests.scala
@@ -26,7 +26,7 @@ object MainModuleTests extends TestSuite {
       Console.err.println("Hello2 Console Stderr")
       Map("1" -> "hello", "2" -> "world")
     }
-    def helloCommand(x: Int, y: Task[String]) = T.command { (x, y(), hello()) }
+    def helloCommand(x: Int, y: Task[String]) = Task.Command { (x, y(), hello()) }
     override lazy val millDiscover: Discover = Discover[this.type]
   }
 

--- a/main/test/src/mill/util/TestGraphs.scala
+++ b/main/test/src/mill/util/TestGraphs.scala
@@ -123,10 +123,10 @@ class TestGraphs() {
   //               _/
   // change - task2
   object separateGroups extends TestBaseModule {
-    val task1 = T.task { 1 }
+    val task1 = Task.Anon { 1 }
     def left = Task { task1() }
     val change = test()
-    val task2 = T.task { change() }
+    val task2 = Task.Anon { change() }
     def right = Task { task1() + task2() + left() + 1 }
 
   }
@@ -134,24 +134,24 @@ class TestGraphs() {
   object moduleInitError extends TestBaseModule {
     def rootTarget = Task { println("Running rootTarget"); "rootTarget Result" }
     def rootCommand(@arg(positional = true) s: String) =
-      T.command { println(s"Running rootCommand $s") }
+      Task.Command { println(s"Running rootCommand $s") }
 
     object foo extends Module {
       def fooTarget = Task { println(s"Running fooTarget"); 123 }
       def fooCommand(@arg(positional = true) s: String) =
-        T.command { println(s"Running fooCommand $s") }
+        Task.Command { println(s"Running fooCommand $s") }
       throw new Exception("Foo Boom")
     }
 
     object bar extends Module {
       def barTarget = Task { println(s"Running barTarget"); "barTarget Result" }
       def barCommand(@arg(positional = true) s: String) =
-        T.command { println(s"Running barCommand $s") }
+        Task.Command { println(s"Running barCommand $s") }
 
       object qux extends Module {
         def quxTarget = Task { println(s"Running quxTarget"); "quxTarget Result" }
         def quxCommand(@arg(positional = true) s: String) =
-          T.command { println(s"Running quxCommand $s") }
+          Task.Command { println(s"Running quxCommand $s") }
         throw new Exception("Qux Boom")
       }
     }
@@ -164,7 +164,7 @@ class TestGraphs() {
     object foo extends Module {
       def fooTarget = Task { println(s"Running fooTarget"); 123 }
       def fooCommand(@arg(positional = true) s: String) =
-        T.command { println(s"Running fooCommand $s") }
+        Task.Command { println(s"Running fooCommand $s") }
       throw new Exception("Foo Boom")
     }
 
@@ -173,7 +173,7 @@ class TestGraphs() {
         println(s"Running barTarget")
         s"${foo.fooTarget()} barTarget Result"
       }
-      def barCommand(@arg(positional = true) s: String) = T.command {
+      def barCommand(@arg(positional = true) s: String) = Task.Command {
         foo.fooCommand(s)()
         println(s"Running barCommand $s")
       }
@@ -263,7 +263,7 @@ object TestGraphs {
   //     /        \
   // task -------- right
   object triangleTask extends TestBaseModule {
-    val task = T.task { 1 }
+    val task = Task.Anon { 1 }
     def left = Task { task() }
     def right = Task { task() + left() + 1 }
   }
@@ -272,7 +272,7 @@ object TestGraphs {
   //     /
   // task -------- right
   object multiTerminalGroup extends TestBaseModule {
-    val task = T.task { 1 }
+    val task = Task.Anon { 1 }
     def left = Task { task() }
     def right = Task { task() }
   }
@@ -281,10 +281,10 @@ object TestGraphs {
   //      /        \           \
   // task1 -------- right ----- task2
   object multiTerminalBoundary extends TestBaseModule {
-    val task1 = T.task { 1 }
+    val task1 = Task.Anon { 1 }
     def left = Task { task1() }
     def right = Task { task1() + left() + 1 }
-    val task2 = T.task { left() + right() }
+    val task2 = Task.Anon { left() + right() }
   }
 
   trait CanNest extends Module {
@@ -317,19 +317,19 @@ object TestGraphs {
 
   trait BaseModule extends Module {
     def foo = Task { Seq("base") }
-    def cmd(i: Int) = T.command { Seq("base" + i) }
+    def cmd(i: Int) = Task.Command { Seq("base" + i) }
   }
 
   object canOverrideSuper extends TestBaseModule with BaseModule {
     override def foo = Task { super.foo() ++ Seq("object") }
-    override def cmd(i: Int) = T.command { super.cmd(i)() ++ Seq("object" + i) }
+    override def cmd(i: Int) = Task.Command { super.cmd(i)() ++ Seq("object" + i) }
     override lazy val millDiscover: Discover = Discover[this.type]
   }
 
   trait TraitWithModule extends Module { outer =>
     object TraitModule extends Module {
       def testFrameworks = Task { Seq("mill.UTestFramework") }
-      def test() = T.command { () /*donothing*/ }
+      def test() = Task.Command { () /*donothing*/ }
     }
   }
 
@@ -340,18 +340,18 @@ object TestGraphs {
 
   object nullTasks extends TestBaseModule {
     val nullString: String = null
-    def nullTask1 = T.task { nullString }
-    def nullTask2 = T.task { nullTask1() }
+    def nullTask1 = Task.Anon { nullString }
+    def nullTask2 = Task.Anon { nullTask1() }
 
     def nullTarget1 = Task { nullString }
     def nullTarget2 = Task { nullTarget1() }
     def nullTarget3 = Task { nullTask1() }
     def nullTarget4 = Task { nullTask2() }
 
-    def nullCommand1() = T.command { nullString }
-    def nullCommand2() = T.command { nullTarget1() }
-    def nullCommand3() = T.command { nullTask1() }
-    def nullCommand4() = T.command { nullTask2() }
+    def nullCommand1() = Task.Command { nullString }
+    def nullCommand2() = Task.Command { nullTarget1() }
+    def nullCommand3() = Task.Command { nullTask1() }
+    def nullCommand4() = Task.Command { nullTask2() }
 
     override lazy val millDiscover: Discover = Discover[this.type]
   }
@@ -364,7 +364,7 @@ object TestGraphs {
 
       object test2 extends TaskModule {
         override def defaultCommandName() = "test2"
-        def test2() = T.command {}
+        def test2() = Task.Command {}
       }
     }
 
@@ -375,7 +375,7 @@ object TestGraphs {
     object test4 extends TaskModule {
       override def defaultCommandName() = "test4"
 
-      def test4() = T.command {}
+      def test4() = Task.Command {}
     }
     override lazy val millDiscover: Discover = Discover[this.type]
   }
@@ -521,7 +521,7 @@ object TestGraphs {
         def platform = crossValue
         override def defaultCommandName(): String = "suffixCmd"
         def suffixCmd(@arg(positional = true) suffix: String = "default"): Command[String] =
-          T.command {
+          Task.Command {
             scalaVersion + "_" + platform + "_" + suffix
           }
       }

--- a/main/test/src/mill/util/TestGraphs.scala
+++ b/main/test/src/mill/util/TestGraphs.scala
@@ -3,7 +3,7 @@ import TestUtil.test
 import mainargs.arg
 import mill.testkit.TestBaseModule
 import mill.define.{Command, Cross, Discover, DynamicModule, ModuleRef, TaskModule}
-import mill.{Module, T}
+import mill.{Module, T, Task}
 
 /**
  * Example dependency graphs for us to use in our test suite.
@@ -66,10 +66,10 @@ class TestGraphs() {
   }
 
   object defCachedDiamond extends TestBaseModule {
-    def up = T { test() }
-    def left = T { test(up) }
-    def right = T { test(up) }
-    def down = T { test(left, right) }
+    def up = Task { test() }
+    def left = Task { test(up) }
+    def right = Task { test(up) }
+    def down = Task { test(left, right) }
   }
 
   object borkedCachedDiamond2 extends TestBaseModule {
@@ -124,32 +124,32 @@ class TestGraphs() {
   // change - task2
   object separateGroups extends TestBaseModule {
     val task1 = T.task { 1 }
-    def left = T { task1() }
+    def left = Task { task1() }
     val change = test()
     val task2 = T.task { change() }
-    def right = T { task1() + task2() + left() + 1 }
+    def right = Task { task1() + task2() + left() + 1 }
 
   }
 
   object moduleInitError extends TestBaseModule {
-    def rootTarget = T { println("Running rootTarget"); "rootTarget Result" }
+    def rootTarget = Task { println("Running rootTarget"); "rootTarget Result" }
     def rootCommand(@arg(positional = true) s: String) =
       T.command { println(s"Running rootCommand $s") }
 
     object foo extends Module {
-      def fooTarget = T { println(s"Running fooTarget"); 123 }
+      def fooTarget = Task { println(s"Running fooTarget"); 123 }
       def fooCommand(@arg(positional = true) s: String) =
         T.command { println(s"Running fooCommand $s") }
       throw new Exception("Foo Boom")
     }
 
     object bar extends Module {
-      def barTarget = T { println(s"Running barTarget"); "barTarget Result" }
+      def barTarget = Task { println(s"Running barTarget"); "barTarget Result" }
       def barCommand(@arg(positional = true) s: String) =
         T.command { println(s"Running barCommand $s") }
 
       object qux extends Module {
-        def quxTarget = T { println(s"Running quxTarget"); "quxTarget Result" }
+        def quxTarget = Task { println(s"Running quxTarget"); "quxTarget Result" }
         def quxCommand(@arg(positional = true) s: String) =
           T.command { println(s"Running quxCommand $s") }
         throw new Exception("Qux Boom")
@@ -162,14 +162,14 @@ class TestGraphs() {
   object moduleDependencyInitError extends TestBaseModule {
 
     object foo extends Module {
-      def fooTarget = T { println(s"Running fooTarget"); 123 }
+      def fooTarget = Task { println(s"Running fooTarget"); 123 }
       def fooCommand(@arg(positional = true) s: String) =
         T.command { println(s"Running fooCommand $s") }
       throw new Exception("Foo Boom")
     }
 
     object bar extends Module {
-      def barTarget = T {
+      def barTarget = Task {
         println(s"Running barTarget")
         s"${foo.fooTarget()} barTarget Result"
       }
@@ -187,7 +187,7 @@ class TestGraphs() {
       throw new Exception(s"MyCross Boom")
     }
     trait MyCross extends Cross.Module[Int] {
-      def foo = T { crossValue }
+      def foo = Task { crossValue }
     }
 
     override lazy val millDiscover = Discover[this.type]
@@ -196,7 +196,7 @@ class TestGraphs() {
     object myCross extends Cross[MyCross](1, 2, 3, 4)
     trait MyCross extends Cross.Module[Int] {
       if (crossValue > 2) throw new Exception(s"MyCross Boom $crossValue")
-      def foo = T { crossValue }
+      def foo = Task { crossValue }
     }
 
     override lazy val millDiscover = Discover[this.type]
@@ -204,7 +204,7 @@ class TestGraphs() {
   object crossModuleSelfInitError extends TestBaseModule {
     object myCross extends Cross[MyCross](1, 2, 3, throw new Exception(s"MyCross Boom"))
     trait MyCross extends Cross.Module[Int] {
-      def foo = T { crossValue }
+      def foo = Task { crossValue }
     }
 
     override lazy val millDiscover = Discover[this.type]
@@ -215,7 +215,7 @@ class TestGraphs() {
       throw new Exception(s"Parent Boom")
       object myCross extends Cross[MyCross](1, 2, 3, 4)
       trait MyCross extends Cross.Module[Int] {
-        def foo = T { crossValue }
+        def foo = Task { crossValue }
       }
     }
 
@@ -227,14 +227,14 @@ class TestGraphs() {
       lazy val inner: BaseInnerModule = new BaseInnerModule {}
       lazy val ignored: ModuleRef[BaseInnerModule] = ModuleRef(new BaseInnerModule {})
       trait BaseInnerModule extends mill.define.Module {
-        def baseTarget = T { 1 }
+        def baseTarget = Task { 1 }
       }
     }
     object sub extends Base {
       override lazy val inner: SubInnerModule = new SubInnerModule {}
       override lazy val ignored: ModuleRef[SubInnerModule] = ModuleRef(new SubInnerModule {})
       trait SubInnerModule extends BaseInnerModule {
-        def subTarget = T { 2 }
+        def subTarget = Task { 2 }
       }
     }
 
@@ -244,13 +244,13 @@ class TestGraphs() {
   object dynamicModule extends TestBaseModule {
     object normal extends DynamicModule {
       object inner extends Module {
-        def target = T { 1 }
+        def target = Task { 1 }
       }
     }
     object niled extends DynamicModule {
       override def millModuleDirectChildren: Seq[Module] = Nil
       object inner extends Module {
-        def target = T { 1 }
+        def target = Task { 1 }
       }
     }
 
@@ -264,8 +264,8 @@ object TestGraphs {
   // task -------- right
   object triangleTask extends TestBaseModule {
     val task = T.task { 1 }
-    def left = T { task() }
-    def right = T { task() + left() + 1 }
+    def left = Task { task() }
+    def right = Task { task() + left() + 1 }
   }
 
   //      _ left
@@ -273,8 +273,8 @@ object TestGraphs {
   // task -------- right
   object multiTerminalGroup extends TestBaseModule {
     val task = T.task { 1 }
-    def left = T { task() }
-    def right = T { task() }
+    def left = Task { task() }
+    def right = Task { task() }
   }
 
   //       _ left _____________
@@ -282,53 +282,53 @@ object TestGraphs {
   // task1 -------- right ----- task2
   object multiTerminalBoundary extends TestBaseModule {
     val task1 = T.task { 1 }
-    def left = T { task1() }
-    def right = T { task1() + left() + 1 }
+    def left = Task { task1() }
+    def right = Task { task1() + left() + 1 }
     val task2 = T.task { left() + right() }
   }
 
   trait CanNest extends Module {
-    def single = T { 1 }
-    def invisible: Any = T { 2 }
-    def invisible2: mill.define.Task[Int] = T { 3 }
-    def invisible3: mill.define.Task[_] = T { 4 }
+    def single = Task { 1 }
+    def invisible: Any = Task { 2 }
+    def invisible2: mill.define.Task[Int] = Task { 3 }
+    def invisible3: mill.define.Task[_] = Task { 4 }
   }
   object nestedModule extends TestBaseModule {
-    def single = T { 5 }
-    def invisible: Any = T { 6 }
+    def single = Task { 5 }
+    def invisible: Any = Task { 6 }
     object nested extends Module {
-      def single = T { 7 }
-      def invisible: Any = T { 8 }
+      def single = Task { 7 }
+      def invisible: Any = Task { 8 }
 
     }
     object classInstance extends CanNest
 
   }
   object doubleNestedModule extends TestBaseModule {
-    def single = T { 5 }
+    def single = Task { 5 }
     object nested extends Module {
-      def single = T { 7 }
+      def single = Task { 7 }
 
       object inner extends Module {
-        def single = T { 9 }
+        def single = Task { 9 }
       }
     }
   }
 
   trait BaseModule extends Module {
-    def foo = T { Seq("base") }
+    def foo = Task { Seq("base") }
     def cmd(i: Int) = T.command { Seq("base" + i) }
   }
 
   object canOverrideSuper extends TestBaseModule with BaseModule {
-    override def foo = T { super.foo() ++ Seq("object") }
+    override def foo = Task { super.foo() ++ Seq("object") }
     override def cmd(i: Int) = T.command { super.cmd(i)() ++ Seq("object" + i) }
     override lazy val millDiscover: Discover = Discover[this.type]
   }
 
   trait TraitWithModule extends Module { outer =>
     object TraitModule extends Module {
-      def testFrameworks = T { Seq("mill.UTestFramework") }
+      def testFrameworks = Task { Seq("mill.UTestFramework") }
       def test() = T.command { () /*donothing*/ }
     }
   }
@@ -343,10 +343,10 @@ object TestGraphs {
     def nullTask1 = T.task { nullString }
     def nullTask2 = T.task { nullTask1() }
 
-    def nullTarget1 = T { nullString }
-    def nullTarget2 = T { nullTarget1() }
-    def nullTarget3 = T { nullTask1() }
-    def nullTarget4 = T { nullTask2() }
+    def nullTarget1 = Task { nullString }
+    def nullTarget2 = Task { nullTarget1() }
+    def nullTarget3 = Task { nullTask1() }
+    def nullTarget4 = Task { nullTask2() }
 
     def nullCommand1() = T.command { nullString }
     def nullCommand2() = T.command { nullTarget1() }
@@ -359,7 +359,7 @@ object TestGraphs {
   object duplicates extends TestBaseModule {
     object wrapper extends Module {
       object test1 extends Module {
-        def test1 = T {}
+        def test1 = Task {}
       }
 
       object test2 extends TaskModule {
@@ -369,7 +369,7 @@ object TestGraphs {
     }
 
     object test3 extends Module {
-      def test3 = T {}
+      def test3 = Task {}
     }
 
     object test4 extends TaskModule {
@@ -383,26 +383,26 @@ object TestGraphs {
   object singleCross extends TestBaseModule {
     object cross extends mill.Cross[Cross]("210", "211", "212")
     trait Cross extends Cross.Module[String] {
-      def suffix = T { crossValue }
+      def suffix = Task { crossValue }
     }
 
     object cross2 extends mill.Cross[Cross2]("210", "211", "212")
     trait Cross2 extends Cross.Module[String] {
       override def millSourcePath = super.millSourcePath / crossValue
-      def suffix = T { crossValue }
+      def suffix = Task { crossValue }
     }
   }
 
   object nonStringCross extends TestBaseModule {
     object cross extends mill.Cross[Cross](210, 211, 212)
     trait Cross extends Cross.Module[Int] {
-      def suffix = T { crossValue }
+      def suffix = Task { crossValue }
     }
 
     object cross2 extends mill.Cross[Cross2](210L, 211L, 212L)
     trait Cross2 extends Cross.Module[Long] {
       override def millSourcePath = super.millSourcePath / crossValue.toString
-      def suffix = T { crossValue }
+      def suffix = Task { crossValue }
     }
   }
 
@@ -415,12 +415,12 @@ object TestGraphs {
 
     object foo extends mill.Cross[FooModule]("2.10", "2.11", "2.12")
     trait FooModule extends MyModule {
-      def suffix = T { crossValue }
+      def suffix = Task { crossValue }
     }
 
     object bar extends mill.Cross[BarModule]("2.10", "2.11", "2.12")
     trait BarModule extends MyModule {
-      def longSuffix = T { "_" + foo().suffix() }
+      def longSuffix = Task { "_" + foo().suffix() }
     }
   }
   object doubleCross extends TestBaseModule {
@@ -432,26 +432,26 @@ object TestGraphs {
     object cross extends mill.Cross[Cross](crossMatrix)
     trait Cross extends Cross.Module2[String, String] {
       val (scalaVersion, platform) = (crossValue, crossValue2)
-      def suffix = T { scalaVersion + "_" + platform }
+      def suffix = Task { scalaVersion + "_" + platform }
     }
   }
 
   object crossExtension extends TestBaseModule {
     object myCross extends Cross[MyCrossModule]("a", "b")
     trait MyCrossModule extends Cross.Module[String] {
-      def param1 = T { "Param Value: " + crossValue }
+      def param1 = Task { "Param Value: " + crossValue }
     }
 
     object myCrossExtended extends Cross[MyCrossModuleExtended](("a", 1), ("b", 2))
     trait MyCrossModuleExtended extends MyCrossModule with Cross.Module2[String, Int] {
-      def param2 = T { "Param Value: " + crossValue2 }
+      def param2 = Task { "Param Value: " + crossValue2 }
     }
 
     object myCrossExtendedAgain
         extends Cross[MyCrossModuleExtendedAgain](("a", 1, true), ("b", 2, false))
     trait MyCrossModuleExtendedAgain extends MyCrossModuleExtended
         with Cross.Module3[String, Int, Boolean] {
-      def param3 = T { "Param Value: " + crossValue3 }
+      def param3 = Task { "Param Value: " + crossValue3 }
     }
   }
 
@@ -459,37 +459,37 @@ object TestGraphs {
     object myCross extends Cross[MyCrossModule]("a", "b")
     trait MyCrossModule extends Cross.Module[String] {
       object foo extends CrossValue {
-        def bar = T { "foo " + crossValue }
+        def bar = Task { "foo " + crossValue }
       }
 
       object baz extends CrossValue {
-        def bar = T { "baz " + crossValue }
+        def bar = Task { "baz " + crossValue }
       }
     }
 
     object myCross2 extends Cross[MyCrossModule2](("a", 1), ("b", 2))
     trait MyCrossModule2 extends Cross.Module2[String, Int] {
       object foo extends InnerCrossModule2 {
-        def bar = T { "foo " + crossValue }
-        def qux = T { "foo " + crossValue2 }
+        def bar = Task { "foo " + crossValue }
+        def qux = Task { "foo " + crossValue2 }
       }
       object baz extends InnerCrossModule2 {
-        def bar = T { "baz " + crossValue }
-        def qux = T { "baz " + crossValue2 }
+        def bar = Task { "baz " + crossValue }
+        def qux = Task { "baz " + crossValue2 }
       }
     }
 
     object myCross3 extends Cross[MyCrossModule3](("a", 1, true), ("b", 2, false))
     trait MyCrossModule3 extends Cross.Module3[String, Int, Boolean] {
       object foo extends InnerCrossModule3 {
-        def bar = T { "foo " + crossValue }
-        def qux = T { "foo " + crossValue2 }
-        def lol = T { "foo " + crossValue3 }
+        def bar = Task { "foo " + crossValue }
+        def qux = Task { "foo " + crossValue2 }
+        def lol = Task { "foo " + crossValue3 }
       }
       object baz extends InnerCrossModule3 {
-        def bar = T { "baz " + crossValue }
-        def qux = T { "baz " + crossValue2 }
-        def lol = T { "baz " + crossValue3 }
+        def bar = Task { "baz " + crossValue }
+        def qux = Task { "baz " + crossValue2 }
+        def lol = Task { "baz " + crossValue3 }
       }
     }
   }
@@ -503,7 +503,7 @@ object TestGraphs {
       object cross2 extends mill.Cross[Cross]("jvm", "js", "native")
       trait Cross extends Cross.Module[String] {
         val platform = crossValue
-        def suffix = T { scalaVersion + "_" + platform }
+        def suffix = Task { scalaVersion + "_" + platform }
       }
     }
   }
@@ -531,14 +531,14 @@ object TestGraphs {
 
   object StackableOverrides extends TestBaseModule {
     trait X extends Module {
-      def f = T { 1 }
+      def f = Task { 1 }
     }
     trait A extends X {
-      override def f = T { super.f() + 2 }
+      override def f = Task { super.f() + 2 }
     }
 
     trait B extends X {
-      override def f = T { super.f() + 3 }
+      override def f = Task { super.f() + 3 }
     }
     object m extends A with B {}
   }
@@ -546,56 +546,56 @@ object TestGraphs {
   object StackableOverrides2 extends TestBaseModule {
     object A extends Module {
       trait X extends Module {
-        def f = T { 1 }
+        def f = Task { 1 }
       }
     }
     object B extends Module {
       trait X extends A.X {
-        override def f = T { super.f() + 2 }
+        override def f = Task { super.f() + 2 }
       }
     }
 
     object m extends B.X {
-      override def f = T { super.f() + 3 }
+      override def f = Task { super.f() + 3 }
     }
   }
 
   object StackableOverrides3 extends TestBaseModule {
     object A extends Module {
       trait X extends Module {
-        def f = T { 1 }
+        def f = Task { 1 }
       }
     }
     trait X extends A.X {
-      override def f = T { super.f() + 2 }
+      override def f = Task { super.f() + 2 }
     }
 
     object m extends X {
-      override def f = T { super.f() + 3 }
+      override def f = Task { super.f() + 3 }
     }
   }
 
   object PrivateTasksInMixedTraits extends TestBaseModule {
     trait M1 extends Module {
-      private def foo = T { "foo-m1" }
-      def bar = T { foo() }
+      private def foo = Task { "foo-m1" }
+      def bar = Task { foo() }
     }
     trait M2 extends Module {
-      private def foo = T { "foo-m2" }
-      def baz = T { foo() }
+      private def foo = Task { "foo-m2" }
+      def baz = Task { foo() }
     }
     object mod extends M1 with M2
   }
 
   object TypedModules extends TestBaseModule {
     trait TypeA extends Module {
-      def foo = T { "foo" }
+      def foo = Task { "foo" }
     }
     trait TypeB extends Module {
-      def bar = T { "bar" }
+      def bar = Task { "bar" }
     }
     trait TypeC extends Module {
-      def baz = T { "baz" }
+      def baz = Task { "baz" }
     }
     trait TypeAB extends TypeA with TypeB
 
@@ -609,11 +609,11 @@ object TestGraphs {
 
   object TypedCrossModules extends TestBaseModule {
     trait TypeA extends Cross.Module[String] {
-      def foo = T { crossValue }
+      def foo = Task { crossValue }
     }
 
     trait TypeB extends Module {
-      def bar = T { "bar" }
+      def bar = Task { "bar" }
     }
 
     trait TypeAB extends TypeA with TypeB
@@ -634,15 +634,15 @@ object TestGraphs {
 
   object TypedInnerModules extends TestBaseModule {
     trait TypeA extends Module {
-      def foo = T { "foo" }
+      def foo = Task { "foo" }
     }
     object typeA extends TypeA
     object typeB extends Module {
-      def foo = T { "foo" }
+      def foo = Task { "foo" }
     }
     object inner extends Module {
       trait TypeA extends Module {
-        def foo = T { "foo" }
+        def foo = Task { "foo" }
       }
       object typeA extends TypeA
     }
@@ -658,9 +658,9 @@ object TestGraphs {
       override lazy val tests: ConcreteTests = new ConcreteTests {}
       trait ConcreteTests extends Tests {
         object inner extends Module {
-          def foo = T { "foo" }
+          def foo = Task { "foo" }
           object innerer extends Module {
-            def bar = T { "bar" }
+            def bar = Task { "bar" }
           }
         }
       }

--- a/readme.adoc
+++ b/readme.adoc
@@ -680,7 +680,7 @@ __New features__
 __Fixes and Improvements__
 
 * Better detect Windows Subsystem for Linux environments {link-pr}/2901[#2901]
-* Avoid evaluating `T.input`s twice {link-pr}/2952[#2952]
+* Avoid evaluating `Task.Input`s twice {link-pr}/2952[#2952]
 * Deduplicate (anonymous) tasks in results {link-pr}/2959[#2959]
 * Synchronize `evaluateGroupCached` to avoid concurrent access to cache  {link-pr}/2980[#2980]
 * Properly sanitize Windows reserved names and symbols in evaluator paths {link-pr}/2964[#2964], {link-pr}/2965[#2965]
@@ -979,7 +979,7 @@ It is now significantly lazier, resulting in less of the module tree being un-ne
 `run` to be easily used in the implementation of other tasks
 {link-pr}/2452[#2452]
 
-* ``T.input``s are now watched properly with `--watch`, and trigger re-evaluations when the watched value changes {link-pr}/2489[#2489]
+* ``Task.Input``s are now watched properly with `--watch`, and trigger re-evaluations when the watched value changes {link-pr}/2489[#2489]
 
 * Support for Java 20 {link-pr}/2501[#2501]
 
@@ -994,7 +994,7 @@ It is now significantly lazier, resulting in less of the module tree being un-ne
 * Enabled compilation warnings in `build.sc`
 {link-pr}/2519[#2519]
 
-* Print out the CLI flags when inspecting ``T.command``s
+* Print out the CLI flags when inspecting ``Task.Command``s
 {link-pr}/2522[#2522]
 
 _For details refer to
@@ -1020,7 +1020,7 @@ folder in the Mill repo, containing common build setups demonstrating Mill featu
 
 * Add some helpers to simplify cross-version/cross-platform modules {#2406}[{link-pr}/2406]
 
-* You can now override `T{...}` ``Target``s with `T.source` or `T.sources`, and vice versa {link-pr}/2402[#2402]
+* You can now override `T{...}` ``Target``s with `Task.Source` or `Task.Sources`, and vice versa {link-pr}/2402[#2402]
 
 * Removed the Ammonite script runner dependency used to evaluate `build.sc`
 files and instead compile them using Mill {link-pr}/2377[#2377]
@@ -1916,7 +1916,7 @@ and the {link-compare}/0.7.0\...0.7.1[list of commits]._
 * `build.sc` files now uses Scala 2.13.2
 * Avoid duplicate target resolution with `mill resolve __`
 * Add ability to pass GPG arguments to publish via `--gpgArgs`
-* `-w`/`--watch` now works for `T.source` targets
+* `-w`/`--watch` now works for `Task.Source` targets
 
 _For details refer to {link-milestone}/37?closed=1[milestone 0.7.0]
 and the {link-compare}/0.6.3\...0.7.0[list of commits]._

--- a/readme.adoc
+++ b/readme.adoc
@@ -583,7 +583,7 @@ __New features__
 * Pass auxiliary class files to zinc, so they are deleted together  {link-pr}/3072[#3072]
 * BSP: Handle new `JvmCompileClasspath` request  {link-pr}/3086[#3086]
 * Add support for Cobertura XML report task to help integration  {link-pr}/3093[#3093]
-* Support Scala.js minify via `scalaJSMinify: Target[String]`  {link-pr}/3094[#3094]
+* Support Scala.js minify via `scalaJSMinify: T[String]`  {link-pr}/3094[#3094]
 * Restructure `TestModule`, add `RunModule`   {link-pr}/3064[#3064]
 * Move `run`-targets into `RunModule`  {link-pr}/3090[#3090]
 * `TestModule`: Support generation of JUnit-compatible xml report  {link-pr}/3099[#3099] {link-pr}/3172[#3172] {link-pr}/3135[#3135] {link-pr}/3184[#3184]

--- a/runner/src/mill/runner/MillBuild.scala
+++ b/runner/src/mill/runner/MillBuild.scala
@@ -1,6 +1,6 @@
 package mill.runner
 
-import mill.T
+import mill.Task
 import mill.define.{Command, Discover, ExternalModule, Module}
 import mill.eval.Evaluator.AllBootstrapEvaluators
 
@@ -10,7 +10,7 @@ trait MillBuild extends Module {
    * Count of the nested build-levels, the main project and all its nested meta-builds.
    * If you run this on a meta-build, the non-meta-builds are not included.
    */
-  def levelCount(evaluators: AllBootstrapEvaluators): Command[Int] = T.command {
+  def levelCount(evaluators: AllBootstrapEvaluators): Command[Int] = Task.Command {
     evaluators.value.size
   }
 

--- a/runner/src/mill/runner/MillBuild.scala
+++ b/runner/src/mill/runner/MillBuild.scala
@@ -1,6 +1,6 @@
 package mill.runner
 
-import mill.T
+import mill.{T, Task}
 import mill.define.{Command, Discover, ExternalModule, Module}
 import mill.eval.Evaluator.AllBootstrapEvaluators
 

--- a/runner/src/mill/runner/MillBuild.scala
+++ b/runner/src/mill/runner/MillBuild.scala
@@ -1,6 +1,6 @@
 package mill.runner
 
-import mill.{T, Task}
+import mill.T
 import mill.define.{Command, Discover, ExternalModule, Module}
 import mill.eval.Evaluator.AllBootstrapEvaluators
 

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -79,7 +79,7 @@ abstract class MillBuildRootModule()(implicit
     }
   }
 
-  def cliImports: Target[Seq[String]] = T.input {
+  def cliImports: T[Seq[String]] = T.input {
     val imports = CliImports.value
     if (imports.nonEmpty) {
       T.log.debug(s"Using cli-provided runtime imports: ${imports.mkString(", ")}")

--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -7,7 +7,7 @@ import mill.scalalib.api.ZincWorkerUtil
 import mill.scalalib.Lib.resolveDependencies
 import mill.scalalib.{CrossVersion, Dep, DepSyntax, Lib, TestModule}
 import mill.testrunner.{TestResult, TestRunner, TestRunnerUtils}
-import mill.define.{Command, Target, Task}
+import mill.define.{Command, Task}
 import mill.scalajslib.api._
 import mill.scalajslib.internal.ScalaJSUtils.getReportMainFilePathRef
 import mill.scalajslib.worker.{ScalaJSWorker, ScalaJSWorkerExternalModule}
@@ -20,11 +20,11 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
 
   trait ScalaJSTests extends ScalaTests with TestScalaJSModule {
     override def scalaJSVersion = outer.scalaJSVersion()
-    override def moduleKind: Target[ModuleKind] = outer.moduleKind()
-    override def moduleSplitStyle: Target[ModuleSplitStyle] = outer.moduleSplitStyle()
+    override def moduleKind: T[ModuleKind] = outer.moduleKind()
+    override def moduleSplitStyle: T[ModuleSplitStyle] = outer.moduleSplitStyle()
     override def esFeatures = outer.esFeatures()
-    override def jsEnvConfig: Target[JsEnvConfig] = outer.jsEnvConfig()
-    override def scalaJSOptimizer: Target[Boolean] = outer.scalaJSOptimizer()
+    override def jsEnvConfig: T[JsEnvConfig] = outer.jsEnvConfig()
+    override def scalaJSOptimizer: T[Boolean] = outer.scalaJSOptimizer()
   }
   @deprecated("use ScalaJSTests", "0.11.0")
   type ScalaJSModuleTests = ScalaJSTests
@@ -35,7 +35,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
 
   def scalaJSWorkerVersion = Task { ZincWorkerUtil.scalaJSWorkerVersion(scalaJSVersion()) }
 
-  override def scalaLibraryIvyDeps: Target[Loose.Agg[Dep]] = Task {
+  override def scalaLibraryIvyDeps: T[Loose.Agg[Dep]] = Task {
     val deps = super.scalaLibraryIvyDeps()
     if (ZincWorkerUtil.isScala3(scalaVersion())) {
       // Since Dotty/Scala3, Scala.JS is published with a platform suffix
@@ -57,7 +57,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
     )
   }
 
-  def scalaJSJsEnvIvyDeps: Target[Agg[Dep]] = Task {
+  def scalaJSJsEnvIvyDeps: T[Agg[Dep]] = Task {
     val dep = jsEnvConfig() match {
       case _: JsEnvConfig.NodeJs =>
         ivy"${ScalaJSBuildInfo.scalajsEnvNodejs}"
@@ -106,21 +106,21 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
 
   def scalaJSToolsClasspath = Task { scalaJSWorkerClasspath() ++ scalaJSLinkerClasspath() }
 
-  def fastLinkJS: Target[Report] = T.persistent {
+  def fastLinkJS: T[Report] = T.persistent {
     linkTask(isFullLinkJS = false, forceOutJs = false)()
   }
 
-  def fullLinkJS: Target[Report] = T.persistent {
+  def fullLinkJS: T[Report] = T.persistent {
     linkTask(isFullLinkJS = true, forceOutJs = false)()
   }
 
   @deprecated("Use fastLinkJS instead", "Mill 0.10.12")
-  def fastOpt: Target[PathRef] = Task {
+  def fastOpt: T[PathRef] = Task {
     getReportMainFilePathRef(linkTask(isFullLinkJS = false, forceOutJs = true)())
   }
 
   @deprecated("Use fullLinkJS instead", "Mill 0.10.12")
-  def fullOpt: Target[PathRef] = Task {
+  def fullOpt: T[PathRef] = Task {
     getReportMainFilePathRef(linkTask(isFullLinkJS = true, forceOutJs = true)())
   }
 
@@ -216,7 +216,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
     )
   }
 
-  override def mandatoryScalacOptions: Target[Seq[String]] = Task {
+  override def mandatoryScalacOptions: T[Seq[String]] = Task {
     // Don't add flag twice, e.g. if a test suite inherits it both directly
     // ScalaJSModule as well as from the enclosing non-test ScalaJSModule
     val scalajsFlag =
@@ -269,11 +269,11 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
     else scalaJSBinaryVersion()
   }
 
-  override def platformSuffix: Target[String] = s"_sjs${artifactScalaJSVersion()}"
+  override def platformSuffix: T[String] = s"_sjs${artifactScalaJSVersion()}"
 
-  def jsEnvConfig: Target[JsEnvConfig] = Task { JsEnvConfig.NodeJs() }
+  def jsEnvConfig: T[JsEnvConfig] = Task { JsEnvConfig.NodeJs() }
 
-  def moduleKind: Target[ModuleKind] = Task { ModuleKind.NoModule }
+  def moduleKind: T[ModuleKind] = Task { ModuleKind.NoModule }
 
   def esFeatures: T[ESFeatures] = Task {
     if (scalaJSVersion().startsWith("0."))
@@ -282,19 +282,19 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
       ESFeatures.Defaults
   }
 
-  def moduleSplitStyle: Target[ModuleSplitStyle] = Task { ModuleSplitStyle.FewestModules }
+  def moduleSplitStyle: T[ModuleSplitStyle] = Task { ModuleSplitStyle.FewestModules }
 
-  def scalaJSOptimizer: Target[Boolean] = Task { true }
+  def scalaJSOptimizer: T[Boolean] = Task { true }
 
-  def scalaJSImportMap: Target[Seq[ESModuleImportMapping]] = Task {
+  def scalaJSImportMap: T[Seq[ESModuleImportMapping]] = Task {
     Seq.empty[ESModuleImportMapping]
   }
 
   /** Whether to emit a source map. */
-  def scalaJSSourceMap: Target[Boolean] = Task { true }
+  def scalaJSSourceMap: T[Boolean] = Task { true }
 
   /** Name patterns for output. */
-  def scalaJSOutputPatterns: Target[OutputPatterns] = Task { OutputPatterns.Defaults }
+  def scalaJSOutputPatterns: T[OutputPatterns] = Task { OutputPatterns.Defaults }
 
   /**
    * Apply Scala.js-specific minification of the produced .js files.
@@ -309,7 +309,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
    *  minifier to be used in conjunction with a general-purpose JavaScript
    *  minifier.
    */
-  def scalaJSMinify: Target[Boolean] = Task { true }
+  def scalaJSMinify: T[Boolean] = Task { true }
 
   override def prepareOffline(all: Flag): Command[Unit] = {
     val tasks =
@@ -354,7 +354,7 @@ trait TestScalaJSModule extends ScalaJSModule with TestModule {
     )
   }
 
-  def fastLinkJSTest: Target[Report] = T.persistent {
+  def fastLinkJSTest: T[Report] = T.persistent {
     linkJs(
       worker = ScalaJSWorkerExternalModule.scalaJSWorker(),
       toolsClasspath = scalaJSToolsClasspath(),

--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -35,7 +35,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
 
   def scalaJSWorkerVersion = Task { ZincWorkerUtil.scalaJSWorkerVersion(scalaJSVersion()) }
 
-  override def scalaLibraryIvyDeps = Task {
+  override def scalaLibraryIvyDeps: Target[Loose.Agg[Dep]] = Task {
     val deps = super.scalaLibraryIvyDeps()
     if (ZincWorkerUtil.isScala3(scalaVersion())) {
       // Since Dotty/Scala3, Scala.JS is published with a platform suffix
@@ -216,7 +216,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
     )
   }
 
-  override def mandatoryScalacOptions = Task {
+  override def mandatoryScalacOptions: Target[Seq[String]] = Task {
     // Don't add flag twice, e.g. if a test suite inherits it both directly
     // ScalaJSModule as well as from the enclosing non-test ScalaJSModule
     val scalajsFlag =

--- a/scalajslib/src/mill/scalajslib/worker/ScalaJSWorker.scala
+++ b/scalajslib/src/mill/scalajslib/worker/ScalaJSWorker.scala
@@ -5,7 +5,7 @@ import mill.scalajslib.api
 import mill.scalajslib.worker.{api => workerApi}
 import mill.api.{Ctx, Result, internal}
 import mill.define.{Discover, Worker}
-import mill.{Agg, T}
+import mill.{Agg, T, Task}
 
 @internal
 private[scalajslib] class ScalaJSWorker extends AutoCloseable {

--- a/scalajslib/src/mill/scalajslib/worker/ScalaJSWorker.scala
+++ b/scalajslib/src/mill/scalajslib/worker/ScalaJSWorker.scala
@@ -5,7 +5,7 @@ import mill.scalajslib.api
 import mill.scalajslib.worker.{api => workerApi}
 import mill.api.{Ctx, Result, internal}
 import mill.define.{Discover, Worker}
-import mill.{Agg, T, Task}
+import mill.{Agg, T}
 
 @internal
 private[scalajslib] class ScalaJSWorker extends AutoCloseable {

--- a/scalajslib/src/mill/scalajslib/worker/ScalaJSWorker.scala
+++ b/scalajslib/src/mill/scalajslib/worker/ScalaJSWorker.scala
@@ -219,6 +219,6 @@ private[scalajslib] class ScalaJSWorker extends AutoCloseable {
 @internal
 private[scalajslib] object ScalaJSWorkerExternalModule extends mill.define.ExternalModule {
 
-  def scalaJSWorker: Worker[ScalaJSWorker] = Task.worker { new ScalaJSWorker() }
+  def scalaJSWorker: Worker[ScalaJSWorker] = Task.Worker { new ScalaJSWorker() }
   lazy val millDiscover: Discover = Discover[this.type]
 }

--- a/scalajslib/src/mill/scalajslib/worker/ScalaJSWorker.scala
+++ b/scalajslib/src/mill/scalajslib/worker/ScalaJSWorker.scala
@@ -5,7 +5,7 @@ import mill.scalajslib.api
 import mill.scalajslib.worker.{api => workerApi}
 import mill.api.{Ctx, Result, internal}
 import mill.define.{Discover, Worker}
-import mill.{Agg, T}
+import mill.{Agg, Task}
 
 @internal
 private[scalajslib] class ScalaJSWorker extends AutoCloseable {
@@ -219,6 +219,6 @@ private[scalajslib] class ScalaJSWorker extends AutoCloseable {
 @internal
 private[scalajslib] object ScalaJSWorkerExternalModule extends mill.define.ExternalModule {
 
-  def scalaJSWorker: Worker[ScalaJSWorker] = T.worker { new ScalaJSWorker() }
+  def scalaJSWorker: Worker[ScalaJSWorker] = Task.worker { new ScalaJSWorker() }
   lazy val millDiscover: Discover = Discover[this.type]
 }

--- a/scalajslib/test/src/mill/scalajslib/EsModuleRemapTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/EsModuleRemapTests.scala
@@ -6,6 +6,7 @@ import mill.testkit.UnitTester
 import mill.testkit.TestBaseModule
 import utest._
 import mill.define.Target
+import mill.T
 import mill.scalajslib.api._
 
 object EsModuleRemapTests extends TestSuite {
@@ -20,7 +21,7 @@ object EsModuleRemapTests extends TestSuite {
 
     override def moduleKind = ModuleKind.ESModule
 
-    override def scalaJSImportMap: Target[Seq[ESModuleImportMapping]] = Seq(
+    override def scalaJSImportMap: T[Seq[ESModuleImportMapping]] = Seq(
       ESModuleImportMapping.Prefix("@stdlib/linspace", remapTo)
     )
 
@@ -33,7 +34,7 @@ object EsModuleRemapTests extends TestSuite {
     override def scalaJSSourceMap = false
     override def moduleKind = ModuleKind.ESModule
 
-    override def scalaJSImportMap: Target[Seq[ESModuleImportMapping]] = Seq(
+    override def scalaJSImportMap: T[Seq[ESModuleImportMapping]] = Seq(
       ESModuleImportMapping.Prefix("@stdlib/linspace", remapTo)
     )
 

--- a/scalajslib/test/src/mill/scalajslib/HelloJSWorldTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/HelloJSWorldTests.scala
@@ -50,7 +50,7 @@ object HelloJSWorldTests extends TestSuite {
       )
 
       object `test-utest` extends ScalaJSTests with TestModule.Utest {
-        override def sources = T.sources { millSourcePath / "src/utest" }
+        override def sources = Task.Sources { millSourcePath / "src/utest" }
         val utestVersion = if (ZincWorkerUtil.isScala3(crossScalaVersion)) "0.7.7" else "0.7.5"
         override def ivyDeps = Agg(
           ivy"com.lihaoyi::utest::$utestVersion"
@@ -58,7 +58,7 @@ object HelloJSWorldTests extends TestSuite {
       }
 
       object `test-scalatest` extends ScalaJSTests with TestModule.ScalaTest {
-        override def sources = T.sources { millSourcePath / "src/scalatest" }
+        override def sources = Task.Sources { millSourcePath / "src/scalatest" }
         override def ivyDeps = Agg(
           ivy"org.scalatest::scalatest::3.1.2"
         )

--- a/scalajslib/test/src/mill/scalajslib/NodeJSConfigTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/NodeJSConfigTests.scala
@@ -40,14 +40,14 @@ object NodeJSConfigTests extends TestSuite {
 
       override def artifactName = "hello-js-world"
       def scalaJSVersion = NodeJSConfigTests.scalaJSVersion
-      override def jsEnvConfig = T { JsEnvConfig.NodeJs(args = nodeArgs) }
+      override def jsEnvConfig = Task { JsEnvConfig.NodeJs(args = nodeArgs) }
 
       object `test-utest` extends ScalaJSTests with TestModule.Utest {
         override def sources = T.sources { millSourcePath / "src/utest" }
         override def ivyDeps = Agg(
           ivy"com.lihaoyi::utest::$utestVersion"
         )
-        override def jsEnvConfig = T { JsEnvConfig.NodeJs(args = nodeArgs) }
+        override def jsEnvConfig = Task { JsEnvConfig.NodeJs(args = nodeArgs) }
       }
     }
 

--- a/scalajslib/test/src/mill/scalajslib/NodeJSConfigTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/NodeJSConfigTests.scala
@@ -43,7 +43,7 @@ object NodeJSConfigTests extends TestSuite {
       override def jsEnvConfig = Task { JsEnvConfig.NodeJs(args = nodeArgs) }
 
       object `test-utest` extends ScalaJSTests with TestModule.Utest {
-        override def sources = T.sources { millSourcePath / "src/utest" }
+        override def sources = Task.Sources { millSourcePath / "src/utest" }
         override def ivyDeps = Agg(
           ivy"com.lihaoyi::utest::$utestVersion"
         )

--- a/scalalib/src/mill/scalalib/CoursierModule.scala
+++ b/scalalib/src/mill/scalalib/CoursierModule.scala
@@ -3,7 +3,6 @@ package mill.scalalib
 import coursier.cache.FileCache
 import coursier.{Dependency, Repository, Resolve}
 import coursier.core.Resolution
-import mill.T
 import mill.define.Task
 import mill.api.PathRef
 
@@ -24,16 +23,16 @@ trait CoursierModule extends mill.Module {
    * Bind a dependency ([[Dep]]) to the actual module contetxt (e.g. the scala version and the platform suffix)
    * @return The [[BoundDep]]
    */
-  def bindDependency: Task[Dep => BoundDep] = T.task { dep: Dep =>
+  def bindDependency: Task[Dep => BoundDep] = Task.Anon { dep: Dep =>
     BoundDep((resolveCoursierDependency(): @nowarn).apply(dep), dep.force)
   }
 
   @deprecated("To be replaced by bindDependency", "Mill after 0.11.0-M0")
-  def resolveCoursierDependency: Task[Dep => coursier.Dependency] = T.task {
+  def resolveCoursierDependency: Task[Dep => coursier.Dependency] = Task.Anon {
     Lib.depToDependencyJava(_: Dep)
   }
 
-  def defaultResolver: Task[CoursierModule.Resolver] = T.task {
+  def defaultResolver: Task[CoursierModule.Resolver] = Task.Anon {
     new CoursierModule.Resolver(
       repositories = repositoriesTask(),
       bind = bindDependency(),
@@ -52,7 +51,7 @@ trait CoursierModule extends mill.Module {
    * @return The [[PathRef]]s to the resolved files.
    */
   def resolveDeps(deps: Task[Agg[BoundDep]], sources: Boolean = false): Task[Agg[PathRef]] =
-    T.task {
+    Task.Anon {
       Lib.resolveDependencies(
         repositories = repositoriesTask(),
         deps = deps(),
@@ -68,12 +67,12 @@ trait CoursierModule extends mill.Module {
    * Map dependencies before resolving them.
    * Override this to customize the set of dependencies.
    */
-  def mapDependencies: Task[Dependency => Dependency] = T.task { d: Dependency => d }
+  def mapDependencies: Task[Dependency => Dependency] = Task.Anon { d: Dependency => d }
 
   /**
    * The repositories used to resolved dependencies with [[resolveDeps()]].
    */
-  def repositoriesTask: Task[Seq[Repository]] = T.task {
+  def repositoriesTask: Task[Seq[Repository]] = Task.Anon {
     import scala.concurrent.ExecutionContext.Implicits.global
     val repos = Await.result(
       Resolve().finalRepositories.future(),
@@ -91,7 +90,7 @@ trait CoursierModule extends mill.Module {
    * For example, the JavaFX artifacts are known to use OS specific properties.
    * To fix resolution for JavaFX, you could override this task like the following:
    * {{{
-   *     override def resolutionCustomizer = T.task {
+   *     override def resolutionCustomizer = Task.Anon {
    *       Some( (r: coursier.core.Resolution) =>
    *         r.withOsInfo(coursier.core.Activation.Os.fromProperties(sys.props.toMap))
    *       )
@@ -99,7 +98,7 @@ trait CoursierModule extends mill.Module {
    * }}}
    * @return
    */
-  def resolutionCustomizer: Task[Option[Resolution => Resolution]] = T.task { None }
+  def resolutionCustomizer: Task[Option[Resolution => Resolution]] = Task.Anon { None }
 
   /**
    * Customize the coursier file cache.
@@ -107,7 +106,7 @@ trait CoursierModule extends mill.Module {
    * This is rarely needed to be changed, but sometimes e.g you want to load a coursier plugin.
    * Doing so requires adding to coursier's classpath. To do this you could use the following:
    * {{{
-   *   override def coursierCacheCustomizer = T.task {
+   *   override def coursierCacheCustomizer = Task.Anon {
    *      Some( (fc: coursier.cache.FileCache[Task]) =>
    *        fc.withClassLoaders(Seq(classOf[coursier.cache.protocol.S3Handler].getClassLoader))
    *      )
@@ -117,7 +116,7 @@ trait CoursierModule extends mill.Module {
    */
   def coursierCacheCustomizer
       : Task[Option[FileCache[coursier.util.Task] => FileCache[coursier.util.Task]]] =
-    T.task { None }
+    Task.Anon { None }
 
 }
 object CoursierModule {

--- a/scalalib/src/mill/scalalib/CrossModuleBase.scala
+++ b/scalalib/src/mill/scalalib/CrossModuleBase.scala
@@ -1,6 +1,6 @@
 package mill.scalalib
 
-import mill.T
+import mill.{T, Task}
 import mill.define.Cross
 import mill.define.Cross.Resolver
 import mill.scalalib.api.ZincWorkerUtil
@@ -8,7 +8,7 @@ import mill.scalalib.api.ZincWorkerUtil
 trait CrossModuleBase extends ScalaModule with Cross.Module[String] {
   def crossScalaVersion: String = crossValue
 
-  def scalaVersion = T { crossScalaVersion }
+  def scalaVersion = Task { crossScalaVersion }
 
   protected def scalaVersionDirectoryNames: Seq[String] =
     ZincWorkerUtil.matchingVersions(crossScalaVersion)

--- a/scalalib/src/mill/scalalib/CrossSbtModule.scala
+++ b/scalalib/src/mill/scalalib/CrossSbtModule.scala
@@ -1,14 +1,14 @@
 package mill.scalalib
 
 import mill.api.PathRef
-import mill.T
+import mill.{T, Task}
 import mill.scalalib.{CrossModuleBase, SbtModule}
 
 import scala.annotation.nowarn
 
 trait CrossSbtModule extends SbtModule with CrossModuleBase { outer =>
 
-  override def sources: T[Seq[PathRef]] = T.sources {
+  override def sources: T[Seq[PathRef]] = Task.Sources {
     super.sources() ++ scalaVersionDirectoryNames.map(s =>
       PathRef(millSourcePath / "src/main" / s"scala-$s")
     )
@@ -19,7 +19,7 @@ trait CrossSbtModule extends SbtModule with CrossModuleBase { outer =>
   @deprecated("Use CrossSbtTests instead", since = "Mill 0.11.10")
   trait CrossSbtModuleTests extends SbtTests {
     override def millSourcePath = outer.millSourcePath
-    override def sources = T.sources {
+    override def sources = Task.Sources {
       super.sources() ++ scalaVersionDirectoryNames.map(s =>
         PathRef(millSourcePath / "src/test" / s"scala-$s")
       )

--- a/scalalib/src/mill/scalalib/CrossSbtModule.scala
+++ b/scalalib/src/mill/scalalib/CrossSbtModule.scala
@@ -1,7 +1,7 @@
 package mill.scalalib
 
 import mill.api.PathRef
-import mill.{T, Task}
+import mill.T
 import mill.scalalib.{CrossModuleBase, SbtModule}
 
 import scala.annotation.nowarn

--- a/scalalib/src/mill/scalalib/CrossSbtModule.scala
+++ b/scalalib/src/mill/scalalib/CrossSbtModule.scala
@@ -1,7 +1,7 @@
 package mill.scalalib
 
 import mill.api.PathRef
-import mill.T
+import mill.{T, Task}
 import mill.scalalib.{CrossModuleBase, SbtModule}
 
 import scala.annotation.nowarn

--- a/scalalib/src/mill/scalalib/CrossScalaModule.scala
+++ b/scalalib/src/mill/scalalib/CrossScalaModule.scala
@@ -1,7 +1,7 @@
 package mill.scalalib
 
 import mill.api.PathRef
-import mill.T
+import mill.{T, Task}
 
 /**
  * A [[ScalaModule]] which is suited to be used with [[mill.define.Cross]].
@@ -13,7 +13,7 @@ import mill.T
  * - src-2.12.3
  */
 trait CrossScalaModule extends ScalaModule with CrossModuleBase {
-  override def sources: T[Seq[PathRef]] = T.sources {
+  override def sources: T[Seq[PathRef]] = Task.Sources {
     super.sources() ++
       scalaVersionDirectoryNames.map(s => PathRef(millSourcePath / s"src-$s"))
   }

--- a/scalalib/src/mill/scalalib/CrossScalaModule.scala
+++ b/scalalib/src/mill/scalalib/CrossScalaModule.scala
@@ -1,7 +1,7 @@
 package mill.scalalib
 
 import mill.api.PathRef
-import mill.T
+import mill.{T, Task}
 
 /**
  * A [[ScalaModule]] which is suited to be used with [[mill.define.Cross]].

--- a/scalalib/src/mill/scalalib/CrossScalaModule.scala
+++ b/scalalib/src/mill/scalalib/CrossScalaModule.scala
@@ -1,7 +1,7 @@
 package mill.scalalib
 
 import mill.api.PathRef
-import mill.{T, Task}
+import mill.T
 
 /**
  * A [[ScalaModule]] which is suited to be used with [[mill.define.Cross]].

--- a/scalalib/src/mill/scalalib/Dependency.scala
+++ b/scalalib/src/mill/scalalib/Dependency.scala
@@ -1,6 +1,6 @@
 package mill.scalalib
 
-import mill.T
+import mill.Task
 import mill.define.{Command, Discover, ExternalModule}
 import mill.eval.Evaluator
 import mill.scalalib.dependency.{DependencyUpdatesImpl, Format}
@@ -13,7 +13,7 @@ object Dependency extends ExternalModule {
       ev: Evaluator,
       allowPreRelease: Boolean = false
   ): Command[Seq[ModuleDependenciesUpdates]] =
-    T.command {
+    Task.Command {
       DependencyUpdatesImpl(
         ev,
         implicitly,
@@ -28,7 +28,7 @@ object Dependency extends ExternalModule {
       ev: Evaluator,
       allowPreRelease: Boolean = false,
       format: Format = Format.PerModule
-  ): Command[Unit] = T.command {
+  ): Command[Unit] = Task.Command {
     DependencyUpdatesImpl.showAllUpdates(updates(ev, allowPreRelease)(), format)
   }
 

--- a/scalalib/src/mill/scalalib/Dependency.scala
+++ b/scalalib/src/mill/scalalib/Dependency.scala
@@ -1,6 +1,6 @@
 package mill.scalalib
 
-import mill.{T, Task}
+import mill.T
 import mill.define.{Command, Discover, ExternalModule}
 import mill.eval.Evaluator
 import mill.scalalib.dependency.{DependencyUpdatesImpl, Format}

--- a/scalalib/src/mill/scalalib/Dependency.scala
+++ b/scalalib/src/mill/scalalib/Dependency.scala
@@ -1,6 +1,6 @@
 package mill.scalalib
 
-import mill.T
+import mill.{T, Task}
 import mill.define.{Command, Discover, ExternalModule}
 import mill.eval.Evaluator
 import mill.scalalib.dependency.{DependencyUpdatesImpl, Format}

--- a/scalalib/src/mill/scalalib/GenIdea.scala
+++ b/scalalib/src/mill/scalalib/GenIdea.scala
@@ -1,6 +1,6 @@
 package mill.scalalib
 
-import mill.T
+import mill.{T, Task}
 import mill.define.{Command, Discover, ExternalModule}
 import mill.eval.Evaluator
 import mill.resolve.SelectMode
@@ -9,7 +9,7 @@ import mill.resolve.SelectMode
 object GenIdea extends ExternalModule {
 
   @deprecated("Use mill.idea.GenIdea/idea instead", "Mill 0.11.2")
-  def idea(ev: Evaluator): Command[Unit] = T.command {
+  def idea(ev: Evaluator): Command[Unit] = Task.Command {
     T.log.error(
       "mill.scalalib.GenIdea/idea is deprecated. Please use mill.idea.GenIdea/idea instead."
     )

--- a/scalalib/src/mill/scalalib/GenIdea.scala
+++ b/scalalib/src/mill/scalalib/GenIdea.scala
@@ -1,6 +1,6 @@
 package mill.scalalib
 
-import mill.T
+import mill.{T, Task}
 import mill.define.{Command, Discover, ExternalModule}
 import mill.eval.Evaluator
 import mill.resolve.SelectMode

--- a/scalalib/src/mill/scalalib/GenIdea.scala
+++ b/scalalib/src/mill/scalalib/GenIdea.scala
@@ -1,6 +1,6 @@
 package mill.scalalib
 
-import mill.{T, Task}
+import mill.T
 import mill.define.{Command, Discover, ExternalModule}
 import mill.eval.Evaluator
 import mill.resolve.SelectMode

--- a/scalalib/src/mill/scalalib/GenIdeaModule.scala
+++ b/scalalib/src/mill/scalalib/GenIdeaModule.scala
@@ -23,15 +23,15 @@ trait GenIdeaModule extends Module {
    * @return
    */
   def ideaJavaModuleFacets(ideaConfigVersion: Int): Task[Seq[JavaFacet]] =
-    T.task { Seq[JavaFacet]() }
+    Task.Anon { Seq[JavaFacet]() }
 
   /**
    * Contribute components to idea config files.
    */
   def ideaConfigFiles(ideaConfigVersion: Int): Task[Seq[IdeaConfigFile]] =
-    T.task { Seq[IdeaConfigFile]() }
+    Task.Anon { Seq[IdeaConfigFile]() }
 
-  def ideaCompileOutput: T[PathRef] = T.persistent {
+  def ideaCompileOutput: T[PathRef] = Task.Persistent {
     PathRef(T.dest / "classes")
   }
 

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -47,10 +47,10 @@ trait JavaModule
     override def repositoriesTask: Task[Seq[Repository]] = outer.repositoriesTask
     override def resolutionCustomizer: Task[Option[coursier.Resolution => coursier.Resolution]] =
       outer.resolutionCustomizer
-    override def javacOptions: T[Seq[String]] = T { outer.javacOptions() }
+    override def javacOptions: T[Seq[String]] = Task { outer.javacOptions() }
     override def zincWorker: ModuleRef[ZincWorkerModule] = outer.zincWorker
     override def skipIdea: Boolean = outer.skipIdea
-    override def runUseArgsFile: T[Boolean] = T { outer.runUseArgsFile() }
+    override def runUseArgsFile: T[Boolean] = Task { outer.runUseArgsFile() }
     override def sources = T.sources {
       for (src <- outer.sources()) yield {
         PathRef(this.millSourcePath / src.path.relativeTo(outer.millSourcePath))
@@ -98,7 +98,7 @@ trait JavaModule
    */
   def mainClass: T[Option[String]] = None
 
-  def finalMainClassOpt: T[Either[String, String]] = T {
+  def finalMainClassOpt: T[Either[String, String]] = Task {
     mainClass() match {
       case Some(m) => Right(m)
       case None =>
@@ -115,7 +115,7 @@ trait JavaModule
     }
   }
 
-  def finalMainClass: T[String] = T {
+  def finalMainClass: T[String] = Task {
     finalMainClassOpt() match {
       case Right(main) => Result.Success(main)
       case Left(msg) => Result.Failure(msg)
@@ -126,44 +126,44 @@ trait JavaModule
    * Mandatory ivy dependencies that are typically always required and shouldn't be removed by
    * overriding [[ivyDeps]], e.g. the scala-library in the [[ScalaModule]].
    */
-  def mandatoryIvyDeps: T[Agg[Dep]] = T { Agg.empty[Dep] }
+  def mandatoryIvyDeps: T[Agg[Dep]] = Task { Agg.empty[Dep] }
 
   /**
    * Any ivy dependencies you want to add to this Module, in the format
    * ivy"org::name:version" for Scala dependencies or ivy"org:name:version"
    * for Java dependencies
    */
-  def ivyDeps: T[Agg[Dep]] = T { Agg.empty[Dep] }
+  def ivyDeps: T[Agg[Dep]] = Task { Agg.empty[Dep] }
 
   /**
    * Aggregation of mandatoryIvyDeps and ivyDeps.
    * In most cases, instead of overriding this Target you want to override `ivyDeps` instead.
    */
-  def allIvyDeps: T[Agg[Dep]] = T { mandatoryIvyDeps() ++ ivyDeps() }
+  def allIvyDeps: T[Agg[Dep]] = Task { mandatoryIvyDeps() ++ ivyDeps() }
 
   /**
    * Same as `ivyDeps`, but only present at compile time. Useful for e.g.
    * macro-related dependencies like `scala-reflect` that doesn't need to be
    * present at runtime
    */
-  def compileIvyDeps: T[Agg[Dep]] = T { Agg.empty[Dep] }
+  def compileIvyDeps: T[Agg[Dep]] = Task { Agg.empty[Dep] }
 
   /**
    * Additional dependencies, only present at runtime. Useful for e.g.
    * selecting different versions of a dependency to use at runtime after your
    * code has already been compiled.
    */
-  def runIvyDeps: T[Agg[Dep]] = T { Agg.empty[Dep] }
+  def runIvyDeps: T[Agg[Dep]] = Task { Agg.empty[Dep] }
 
   /**
    * Options to pass to the java compiler
    */
-  def javacOptions: T[Seq[String]] = T { Seq.empty[String] }
+  def javacOptions: T[Seq[String]] = Task { Seq.empty[String] }
 
   /**
    * Additional options for the java compiler derived from other module settings.
    */
-  def mandatoryJavacOptions: T[Seq[String]] = T { Seq.empty[String] }
+  def mandatoryJavacOptions: T[Seq[String]] = Task { Seq.empty[String] }
 
   /**
    *  The direct dependencies of this module.
@@ -235,7 +235,7 @@ trait JavaModule
   }
 
   /** The compile-only transitive ivy dependencies of this module and all it's upstream compile-only modules. */
-  def transitiveCompileIvyDeps: T[Agg[BoundDep]] = T {
+  def transitiveCompileIvyDeps: T[Agg[BoundDep]] = Task {
     // We never include compile-only dependencies transitively, but we must include normal transitive dependencies!
     compileIvyDeps().map(bindDependency()) ++
       T.traverse(compileModuleDepsChecked)(_.transitiveIvyDeps)().flatten
@@ -268,13 +268,13 @@ trait JavaModule
    * from disk rather than being downloaded from Maven Central or other package
    * repositories
    */
-  def unmanagedClasspath: T[Agg[PathRef]] = T { Agg.empty[PathRef] }
+  def unmanagedClasspath: T[Agg[PathRef]] = Task { Agg.empty[PathRef] }
 
   /**
    * The transitive ivy dependencies of this module and all it's upstream modules.
    * This is calculated from [[ivyDeps]], [[mandatoryIvyDeps]] and recursively from [[moduleDeps]].
    */
-  def transitiveIvyDeps: T[Agg[BoundDep]] = T {
+  def transitiveIvyDeps: T[Agg[BoundDep]] = Task {
     (ivyDeps() ++ mandatoryIvyDeps()).map(bindDependency()) ++
       T.traverse(moduleDepsChecked)(_.transitiveIvyDeps)().flatten
   }
@@ -282,14 +282,14 @@ trait JavaModule
   /**
    * The upstream compilation output of all this module's upstream modules
    */
-  def upstreamCompileOutput: T[Seq[CompilationResult]] = T {
+  def upstreamCompileOutput: T[Seq[CompilationResult]] = Task {
     T.traverse(transitiveModuleCompileModuleDeps)(_.compile)
   }
 
   /**
    * The transitive version of `localClasspath`
    */
-  def transitiveLocalClasspath: T[Agg[PathRef]] = T {
+  def transitiveLocalClasspath: T[Agg[PathRef]] = Task {
     T.traverse(transitiveModuleCompileModuleDeps)(_.localClasspath)().flatten
   }
 
@@ -300,14 +300,14 @@ trait JavaModule
    * Keep in sync with [[transitiveLocalClasspath]]
    */
   @internal
-  def bspTransitiveLocalClasspath: T[Agg[UnresolvedPath]] = T {
+  def bspTransitiveLocalClasspath: T[Agg[UnresolvedPath]] = Task {
     T.traverse(transitiveModuleCompileModuleDeps)(_.bspLocalClasspath)().flatten
   }
 
   /**
    * The transitive version of `compileClasspath`
    */
-  def transitiveCompileClasspath: T[Agg[PathRef]] = T {
+  def transitiveCompileClasspath: T[Agg[PathRef]] = Task {
     T.traverse(transitiveModuleCompileModuleDeps)(m =>
       T.task { m.localCompileClasspath() ++ Agg(m.compile().classes) }
     )().flatten
@@ -320,7 +320,7 @@ trait JavaModule
    * Keep in sync with [[transitiveCompileClasspath]]
    */
   @internal
-  def bspTransitiveCompileClasspath: T[Agg[UnresolvedPath]] = T {
+  def bspTransitiveCompileClasspath: T[Agg[UnresolvedPath]] = Task {
     T.traverse(transitiveModuleCompileModuleDeps)(m =>
       T.task {
         m.localCompileClasspath().map(p => UnresolvedPath.ResolvedPath(p.path)) ++
@@ -334,14 +334,14 @@ trait JavaModule
    * What platform suffix to use for publishing, e.g. `_sjs` for Scala.js
    * projects
    */
-  def platformSuffix: T[String] = T { "" }
+  def platformSuffix: T[String] = Task { "" }
 
   /**
    * What shell script to use to launch the executable generated by `assembly`.
    * Defaults to a generic "universal" launcher that should work for Windows,
    * OS-X and Linux
    */
-  def prependShellScript: T[String] = T {
+  def prependShellScript: T[String] = Task {
     finalMainClassOpt().toOption match {
       case None => ""
       case Some(cls) =>
@@ -383,17 +383,17 @@ trait JavaModule
    * hand-written; these files can be generated in this target itself,
    * or can refer to files generated from other targets
    */
-  def generatedSources: T[Seq[PathRef]] = T { Seq.empty[PathRef] }
+  def generatedSources: T[Seq[PathRef]] = Task { Seq.empty[PathRef] }
 
   /**
    * The folders containing all source files fed into the compiler
    */
-  def allSources: T[Seq[PathRef]] = T { sources() ++ generatedSources() }
+  def allSources: T[Seq[PathRef]] = Task { sources() ++ generatedSources() }
 
   /**
    * All individual source files fed into the Java compiler
    */
-  def allSourceFiles: T[Seq[PathRef]] = T {
+  def allSourceFiles: T[Seq[PathRef]] = Task {
     Lib.findSourceFiles(allSources(), Seq("java")).map(PathRef(_))
   }
 
@@ -408,7 +408,7 @@ trait JavaModule
     ).equalsIgnoreCase("true")
   }
 
-  def zincIncrementalCompilation: T[Boolean] = T {
+  def zincIncrementalCompilation: T[Boolean] = Task {
     true
   }
 
@@ -444,14 +444,14 @@ trait JavaModule
   @internal
   def bspCompileClassesPath: T[UnresolvedPath] =
     if (compile.ctx.enclosing == s"${classOf[JavaModule].getName}#compile") {
-      T {
+      Task {
         T.log.debug(
           s"compile target was not overridden, assuming hard-coded classes directory for target ${compile}"
         )
         UnresolvedPath.DestPath(os.sub / "classes", compile.ctx.segments, compile.ctx.foreign)
       }
     } else {
-      T {
+      Task {
         T.log.debug(
           s"compile target was overridden, need to actually execute compilation to get the compiled classes directory for target ${compile}"
         )
@@ -464,7 +464,7 @@ trait JavaModule
    *
    * Keep in sync with [[bspLocalRunClasspath]]
    */
-  override def localRunClasspath: T[Seq[PathRef]] = T {
+  override def localRunClasspath: T[Seq[PathRef]] = Task {
     super.localRunClasspath() ++ resources() ++
       Agg(compile().classes)
   }
@@ -474,7 +474,7 @@ trait JavaModule
    *
    * Keep in sync with [[localRunClasspath]]
    */
-  def bspLocalRunClasspath: T[Agg[UnresolvedPath]] = T {
+  def bspLocalRunClasspath: T[Agg[UnresolvedPath]] = Task {
     Agg.from(super.localRunClasspath() ++ resources())
       .map(p => UnresolvedPath.ResolvedPath(p.path)) ++
       Agg(bspCompileClassesPath())
@@ -489,7 +489,7 @@ trait JavaModule
    *
    * Keep in sync with [[bspLocalClasspath]]
    */
-  def localClasspath: T[Seq[PathRef]] = T {
+  def localClasspath: T[Seq[PathRef]] = Task {
     localCompileClasspath().toSeq ++ localRunClasspath()
   }
 
@@ -500,7 +500,7 @@ trait JavaModule
    * Keep in sync with [[localClasspath]]
    */
   @internal
-  def bspLocalClasspath: T[Agg[UnresolvedPath]] = T {
+  def bspLocalClasspath: T[Agg[UnresolvedPath]] = Task {
     (localCompileClasspath()).map(p => UnresolvedPath.ResolvedPath(p.path)) ++
       bspLocalRunClasspath()
   }
@@ -511,7 +511,7 @@ trait JavaModule
    *
    * Keep in sync with [[bspCompileClasspath]]
    */
-  def compileClasspath: T[Agg[PathRef]] = T {
+  def compileClasspath: T[Agg[PathRef]] = Task {
     resolvedIvyDeps() ++ transitiveCompileClasspath() ++ localCompileClasspath()
   }
 
@@ -521,7 +521,7 @@ trait JavaModule
    * Keep in sync with [[compileClasspath]]
    */
   @internal
-  def bspCompileClasspath: T[Agg[UnresolvedPath]] = T {
+  def bspCompileClasspath: T[Agg[UnresolvedPath]] = Task {
     resolvedIvyDeps().map(p => UnresolvedPath.ResolvedPath(p.path)) ++
       bspTransitiveCompileClasspath() ++
       localCompileClasspath().map(p => UnresolvedPath.ResolvedPath(p.path))
@@ -531,14 +531,14 @@ trait JavaModule
    * The *input* classfiles/resources from this module, used during compilation,
    * excluding upstream modules and third-party dependencies
    */
-  def localCompileClasspath: T[Agg[PathRef]] = T {
+  def localCompileClasspath: T[Agg[PathRef]] = Task {
     compileResources() ++ unmanagedClasspath()
   }
 
   /**
    * Resolved dependencies based on [[transitiveIvyDeps]] and [[transitiveCompileIvyDeps]].
    */
-  def resolvedIvyDeps: T[Agg[PathRef]] = T {
+  def resolvedIvyDeps: T[Agg[PathRef]] = Task {
     defaultResolver().resolveDeps(transitiveCompileIvyDeps() ++ transitiveIvyDeps())
   }
 
@@ -546,11 +546,11 @@ trait JavaModule
    * All upstream classfiles and resources necessary to build and executable
    * assembly, but without this module's contribution
    */
-  def upstreamAssemblyClasspath: T[Agg[PathRef]] = T {
+  def upstreamAssemblyClasspath: T[Agg[PathRef]] = Task {
     resolvedRunIvyDeps() ++ transitiveLocalClasspath()
   }
 
-  def resolvedRunIvyDeps: T[Agg[PathRef]] = T {
+  def resolvedRunIvyDeps: T[Agg[PathRef]] = Task {
     defaultResolver().resolveDeps(runIvyDeps().map(bindDependency()) ++ transitiveIvyDeps())
   }
 
@@ -558,7 +558,7 @@ trait JavaModule
    * All classfiles and resources from upstream modules and dependencies
    * necessary to run this module's code after compilation
    */
-  override def runClasspath: T[Seq[PathRef]] = T {
+  override def runClasspath: T[Seq[PathRef]] = Task {
     super.runClasspath() ++
       resolvedRunIvyDeps().toSeq ++
       transitiveLocalClasspath() ++
@@ -569,7 +569,7 @@ trait JavaModule
    * Creates a manifest representation which can be modified or replaced
    * The default implementation just adds the `Manifest-Version`, `Main-Class` and `Created-By` attributes
    */
-  def manifest: T[JarManifest] = T {
+  def manifest: T[JarManifest] = Task {
     Jvm.createManifest(finalMainClassOpt().toOption)
   }
 
@@ -584,7 +584,7 @@ trait JavaModule
    * Please use [[upstreamAssembly2]] instead.
    */
   @deprecated("Use upstreamAssembly2 instead, which has a richer return value", "Mill 0.11.8")
-  def upstreamAssembly: T[PathRef] = T {
+  def upstreamAssembly: T[PathRef] = Task {
     T.log.error(
       s"upstreamAssembly target is deprecated and should no longer used." +
         s" Please make sure to use upstreamAssembly2 instead."
@@ -599,7 +599,7 @@ trait JavaModule
    * This should allow much faster assembly creation in the common case where
    * upstream dependencies do not change
    */
-  def upstreamAssembly2: T[Assembly] = T {
+  def upstreamAssembly2: T[Assembly] = Task {
     Assembly.create(
       destJar = T.dest / "out.jar",
       inputPaths = upstreamAssemblyClasspath().map(_.path),
@@ -612,7 +612,7 @@ trait JavaModule
    * An executable uber-jar/assembly containing all the resources and compiled
    * classfiles from this module and all it's upstream modules and dependencies
    */
-  def assembly: T[PathRef] = T {
+  def assembly: T[PathRef] = Task {
     // detect potential inconsistencies due to `upstreamAssembly` deprecation after 0.11.7
     if (
       (upstreamAssembly.ctx.enclosing: @nowarn) != s"${classOf[JavaModule].getName}#upstreamAssembly"
@@ -658,7 +658,7 @@ trait JavaModule
    * A jar containing only this module's resources and compiled classfiles,
    * without those from upstream modules and dependencies
    */
-  def jar: T[PathRef] = T {
+  def jar: T[PathRef] = Task {
     Jvm.createJar(localClasspath().map(_.path).filter(os.exists), manifest())
   }
 
@@ -667,7 +667,7 @@ trait JavaModule
    * You should not set the `-d` setting for specifying the target directory,
    * as that is done in the [[docJar]] target.
    */
-  def javadocOptions: T[Seq[String]] = T { Seq[String]() }
+  def javadocOptions: T[Seq[String]] = Task { Seq[String]() }
 
   /**
    * Directories to be processed by the API documentation tool.
@@ -691,7 +691,7 @@ trait JavaModule
    * Defaults to `true` on Windows.
    * Beware: Using an args-file is probably not supported for very old javadoc versions.
    */
-  def docJarUseArgsFile: T[Boolean] = T { scala.util.Properties.isWin }
+  def docJarUseArgsFile: T[Boolean] = Task { scala.util.Properties.isWin }
 
   /**
    * The documentation jar, containing all the Javadoc/Scaladoc HTML files, for
@@ -754,7 +754,7 @@ trait JavaModule
   /**
    * The source jar, containing only source code for publishing to Maven Central
    */
-  def sourceJar: T[PathRef] = T {
+  def sourceJar: T[PathRef] = Task {
     Jvm.createJar(
       (allSources() ++ resources() ++ compileResources()).map(_.path).filter(os.exists),
       manifest()
@@ -765,7 +765,7 @@ trait JavaModule
    * Any command-line parameters you want to pass to the forked JVM under `run`,
    * `test` or `repl`
    */
-  override def forkArgs: T[Seq[String]] = T {
+  override def forkArgs: T[Seq[String]] = Task {
     // overridden here for binary compatibility (0.11.x)
     super.forkArgs()
   }
@@ -774,7 +774,7 @@ trait JavaModule
    * Any environment variables you want to pass to the forked JVM under `run`,
    * `test` or `repl`
    */
-  override def forkEnv: T[Map[String, String]] = T {
+  override def forkEnv: T[Map[String, String]] = Task {
     // overridden here for binary compatibility (0.11.x)
     super.forkEnv()
   }
@@ -784,7 +784,7 @@ trait JavaModule
    * code, without the Mill process. Useful for deployment & other places where
    * you do not want a build tool running
    */
-  def launcher = T {
+  def launcher = Task {
     Result.Success(
       Jvm.createLauncher(
         finalMainClass(),
@@ -893,7 +893,7 @@ trait JavaModule
     }
   }
 
-  override def runUseArgsFile: T[Boolean] = T {
+  override def runUseArgsFile: T[Boolean] = Task {
     // overridden here for binary compatibility (0.11.x)
     super.runUseArgsFile()
   }
@@ -1006,7 +1006,7 @@ trait JavaModule
    */
   def artifactSuffix: T[String] = platformSuffix()
 
-  override def forkWorkingDir: T[Path] = T {
+  override def forkWorkingDir: T[Path] = Task {
     // overridden here for binary compatibility (0.11.x)
     super.forkWorkingDir()
   }
@@ -1016,7 +1016,7 @@ trait JavaModule
    * This means, if zinc needs to remove a class file, it will also remove files
    * which match the class file basename and a listed file extension.
    */
-  def zincAuxiliaryClassFileExtensions: T[Seq[String]] = T { Seq.empty[String] }
+  def zincAuxiliaryClassFileExtensions: T[Seq[String]] = Task { Seq.empty[String] }
 
   /**
    * @param all If `true` fetches also source dependencies

--- a/scalalib/src/mill/scalalib/MavenModule.scala
+++ b/scalalib/src/mill/scalalib/MavenModule.scala
@@ -1,6 +1,6 @@
 package mill.scalalib
 
-import mill.{T, Task}
+import mill.T
 
 import scala.annotation.nowarn
 

--- a/scalalib/src/mill/scalalib/MavenModule.scala
+++ b/scalalib/src/mill/scalalib/MavenModule.scala
@@ -1,6 +1,6 @@
 package mill.scalalib
 
-import mill.T
+import mill.Task
 
 import scala.annotation.nowarn
 
@@ -11,10 +11,10 @@ import scala.annotation.nowarn
  */
 trait MavenModule extends JavaModule { outer =>
 
-  override def sources = T.sources(
+  override def sources = Task.Sources(
     millSourcePath / "src/main/java"
   )
-  override def resources = T.sources {
+  override def resources = Task.Sources {
     millSourcePath / "src/main/resources"
   }
 
@@ -25,10 +25,10 @@ trait MavenModule extends JavaModule { outer =>
     override def millSourcePath = outer.millSourcePath
     override def intellijModulePath: os.Path = outer.millSourcePath / "src/test"
 
-    override def sources = T.sources(
+    override def sources = Task.Sources(
       millSourcePath / "src/test/java"
     )
-    override def resources = T.sources {
+    override def resources = Task.Sources {
       millSourcePath / "src/test/resources"
     }
   }

--- a/scalalib/src/mill/scalalib/MavenModule.scala
+++ b/scalalib/src/mill/scalalib/MavenModule.scala
@@ -1,6 +1,6 @@
 package mill.scalalib
 
-import mill.T
+import mill.{T, Task}
 
 import scala.annotation.nowarn
 

--- a/scalalib/src/mill/scalalib/OfflineSupportModule.scala
+++ b/scalalib/src/mill/scalalib/OfflineSupportModule.scala
@@ -1,7 +1,7 @@
 package mill.scalalib
 
 import mainargs.Flag
-import mill.T
+import mill.Task
 import mill.define.Command
 
 trait OfflineSupportModule extends mill.Module {
@@ -10,7 +10,7 @@ trait OfflineSupportModule extends mill.Module {
    * Prepare the module for working offline. This should typically fetch (missing) resources like ivy dependencies.
    * @param all If `true`, it also fetches resources not always needed.
    */
-  def prepareOffline(all: Flag): Command[Unit] = T.command {
+  def prepareOffline(all: Flag): Command[Unit] = Task.Command {
     // nothing to do
   }
 

--- a/scalalib/src/mill/scalalib/OfflineSupportModule.scala
+++ b/scalalib/src/mill/scalalib/OfflineSupportModule.scala
@@ -1,7 +1,7 @@
 package mill.scalalib
 
 import mainargs.Flag
-import mill.T
+import mill.{T, Task}
 import mill.define.Command
 
 trait OfflineSupportModule extends mill.Module {

--- a/scalalib/src/mill/scalalib/OfflineSupportModule.scala
+++ b/scalalib/src/mill/scalalib/OfflineSupportModule.scala
@@ -1,7 +1,7 @@
 package mill.scalalib
 
 import mainargs.Flag
-import mill.{T, Task}
+import mill.T
 import mill.define.Command
 
 trait OfflineSupportModule extends mill.Module {

--- a/scalalib/src/mill/scalalib/PlatformScalaModule.scala
+++ b/scalalib/src/mill/scalalib/PlatformScalaModule.scala
@@ -26,7 +26,7 @@ trait PlatformScalaModule extends ScalaModule {
     .collect { case l: mill.define.Segment.Label => l.value }
     .last
 
-  override def sources: T[Seq[PathRef]] = T.sources {
+  override def sources: T[Seq[PathRef]] = Task.Sources {
     super.sources().flatMap { source =>
       val platformPath =
         PathRef(source.path / _root_.os.up / s"${source.path.last}-${platformScalaSuffix}")

--- a/scalalib/src/mill/scalalib/PublishModule.scala
+++ b/scalalib/src/mill/scalalib/PublishModule.scala
@@ -1,7 +1,7 @@
 package mill
 package scalalib
 
-import mill.define.{Command, ExternalModule, Target, Task}
+import mill.define.{Command, ExternalModule, Task}
 import mill.api.{JarManifest, PathRef, Result}
 import mill.main.Tasks
 import mill.scalalib.PublishModule.checkSonatypeCreds
@@ -55,9 +55,9 @@ trait PublishModule extends JavaModule { outer =>
    *
    * @since Mill after 0.10.0-M5
    */
-  def versionScheme: Target[Option[VersionScheme]] = Task { None }
+  def versionScheme: T[Option[VersionScheme]] = Task { None }
 
-  def publishSelfDependency: Target[Artifact] = Task {
+  def publishSelfDependency: T[Artifact] = Task {
     Artifact(pomSettings().organization, artifactId(), publishVersion())
   }
 
@@ -81,7 +81,7 @@ trait PublishModule extends JavaModule { outer =>
       compileModulePomDeps.map(Dependency(_, Scope.Provided))
   }
 
-  def pom: Target[PathRef] = Task {
+  def pom: T[PathRef] = Task {
     val pom = Pom(
       artifactMetadata(),
       publishXmlDeps(),
@@ -95,28 +95,28 @@ trait PublishModule extends JavaModule { outer =>
     PathRef(pomPath)
   }
 
-  def ivy: Target[PathRef] = Task {
+  def ivy: T[PathRef] = Task {
     val ivy = Ivy(artifactMetadata(), publishXmlDeps(), extraPublish())
     val ivyPath = T.dest / "ivy.xml"
     os.write.over(ivyPath, ivy)
     PathRef(ivyPath)
   }
 
-  def artifactMetadata: Target[Artifact] = Task {
+  def artifactMetadata: T[Artifact] = Task {
     Artifact(pomSettings().organization, artifactId(), publishVersion())
   }
 
   /**
    * Extra artifacts to publish.
    */
-  def extraPublish: Target[Seq[PublishInfo]] = Task { Seq.empty[PublishInfo] }
+  def extraPublish: T[Seq[PublishInfo]] = Task { Seq.empty[PublishInfo] }
 
   /**
    * Properties to be published with the published pom/ivy XML.
    * Use `super.publishProperties() ++` when overriding to avoid losing default properties.
    * @since Mill after 0.10.0-M5
    */
-  def publishProperties: Target[Map[String, String]] = Task {
+  def publishProperties: T[Map[String, String]] = Task {
     versionScheme().map(_.toProperty).toMap
   }
 

--- a/scalalib/src/mill/scalalib/PublishModule.scala
+++ b/scalalib/src/mill/scalalib/PublishModule.scala
@@ -55,9 +55,9 @@ trait PublishModule extends JavaModule { outer =>
    *
    * @since Mill after 0.10.0-M5
    */
-  def versionScheme: Target[Option[VersionScheme]] = T { None }
+  def versionScheme: Target[Option[VersionScheme]] = Task { None }
 
-  def publishSelfDependency: Target[Artifact] = T {
+  def publishSelfDependency: Target[Artifact] = Task {
     Artifact(pomSettings().organization, artifactId(), publishVersion())
   }
 
@@ -81,7 +81,7 @@ trait PublishModule extends JavaModule { outer =>
       compileModulePomDeps.map(Dependency(_, Scope.Provided))
   }
 
-  def pom: Target[PathRef] = T {
+  def pom: Target[PathRef] = Task {
     val pom = Pom(
       artifactMetadata(),
       publishXmlDeps(),
@@ -95,28 +95,28 @@ trait PublishModule extends JavaModule { outer =>
     PathRef(pomPath)
   }
 
-  def ivy: Target[PathRef] = T {
+  def ivy: Target[PathRef] = Task {
     val ivy = Ivy(artifactMetadata(), publishXmlDeps(), extraPublish())
     val ivyPath = T.dest / "ivy.xml"
     os.write.over(ivyPath, ivy)
     PathRef(ivyPath)
   }
 
-  def artifactMetadata: Target[Artifact] = T {
+  def artifactMetadata: Target[Artifact] = Task {
     Artifact(pomSettings().organization, artifactId(), publishVersion())
   }
 
   /**
    * Extra artifacts to publish.
    */
-  def extraPublish: Target[Seq[PublishInfo]] = T { Seq.empty[PublishInfo] }
+  def extraPublish: Target[Seq[PublishInfo]] = Task { Seq.empty[PublishInfo] }
 
   /**
    * Properties to be published with the published pom/ivy XML.
    * Use `super.publishProperties() ++` when overriding to avoid losing default properties.
    * @since Mill after 0.10.0-M5
    */
-  def publishProperties: Target[Map[String, String]] = T {
+  def publishProperties: Target[Map[String, String]] = Task {
     versionScheme().map(_.toProperty).toMap
   }
 
@@ -135,7 +135,7 @@ trait PublishModule extends JavaModule { outer =>
   /**
    * Publish artifacts the local ivy repository.
    */
-  def publishLocalCached: T[Seq[PathRef]] = T {
+  def publishLocalCached: T[Seq[PathRef]] = Task {
     publishLocalTask(T.task(None))().map(p => PathRef(p).withRevalidateOnce)
   }
 
@@ -171,7 +171,7 @@ trait PublishModule extends JavaModule { outer =>
    * Publish artifacts to the local Maven repository.
    * @return [[PathRef]]s to published files.
    */
-  def publishM2LocalCached: T[Seq[PathRef]] = T {
+  def publishM2LocalCached: T[Seq[PathRef]] = Task {
     publishM2LocalTask(T.task {
       os.Path(os.home / ".m2/repository", T.workspace)
     })()
@@ -208,7 +208,7 @@ trait PublishModule extends JavaModule { outer =>
           )
         }
     }
-    T {
+    Task {
       val baseName = baseNameTask()
       PublishModule.PublishData(
         meta = artifactMetadata(),
@@ -266,7 +266,7 @@ trait PublishModule extends JavaModule { outer =>
     ).publish(artifacts.map { case (a, b) => (a.path, b) }, artifactInfo, release)
   }
 
-  override def manifest: T[JarManifest] = T {
+  override def manifest: T[JarManifest] = Task {
     import java.util.jar.Attributes.Name
     val pom = pomSettings()
     super.manifest().add(

--- a/scalalib/src/mill/scalalib/RunModule.scala
+++ b/scalalib/src/mill/scalalib/RunModule.scala
@@ -78,7 +78,7 @@ trait RunModule extends WithZincWorker {
   /**
    * Runs this module's code in a subprocess and waits for it to finish
    */
-  def run(args: Task[Args] = T.task(Args())): Command[Unit] = T.command {
+  def run(args: Task[Args] = Task.Anon(Args())): Command[Unit] = Task.Command {
     runForkedTask(finalMainClass, args)()
   }
 
@@ -88,7 +88,7 @@ trait RunModule extends WithZincWorker {
    * since the code can dirty the parent Mill process and potentially leave it
    * in a bad state.
    */
-  def runLocal(args: Task[Args] = T.task(Args())): Command[Unit] = T.command {
+  def runLocal(args: Task[Args] = Task.Anon(Args())): Command[Unit] = Task.Command {
     runLocalTask(finalMainClass, args)()
   }
 
@@ -96,31 +96,31 @@ trait RunModule extends WithZincWorker {
    * Same as `run`, but lets you specify a main class to run
    */
   def runMain(@arg(positional = true) mainClass: String, args: String*): Command[Unit] = {
-    val task = runForkedTask(T.task { mainClass }, T.task { Args(args) })
-    T.command { task() }
+    val task = runForkedTask(Task.Anon { mainClass }, Task.Anon { Args(args) })
+    Task.Command { task() }
   }
 
   /**
    * Same as `runBackground`, but lets you specify a main class to run
    */
   def runMainBackground(@arg(positional = true) mainClass: String, args: String*): Command[Unit] = {
-    val task = runBackgroundTask(T.task { mainClass }, T.task { Args(args) })
-    T.command { task() }
+    val task = runBackgroundTask(Task.Anon { mainClass }, Task.Anon { Args(args) })
+    Task.Command { task() }
   }
 
   /**
    * Same as `runLocal`, but lets you specify a main class to run
    */
   def runMainLocal(@arg(positional = true) mainClass: String, args: String*): Command[Unit] = {
-    val task = runLocalTask(T.task { mainClass }, T.task { Args(args) })
-    T.command { task() }
+    val task = runLocalTask(Task.Anon { mainClass }, Task.Anon { Args(args) })
+    Task.Command { task() }
   }
 
   /**
    * Runs this module's code in a subprocess and waits for it to finish
    */
-  def runForkedTask(mainClass: Task[String], args: Task[Args] = T.task(Args())): Task[Unit] =
-    T.task {
+  def runForkedTask(mainClass: Task[String], args: Task[Args] = Task.Anon(Args())): Task[Unit] =
+    Task.Anon {
       try Result.Success(
           runner().run(args = args().value, mainClass = mainClass(), workingDir = forkWorkingDir())
         )
@@ -129,7 +129,7 @@ trait RunModule extends WithZincWorker {
       }
     }
 
-  def runner: Task[RunModule.Runner] = T.task {
+  def runner: Task[RunModule.Runner] = Task.Anon {
     new RunModule.RunnerImpl(
       finalMainClassOpt(),
       runClasspath().map(_.path),
@@ -139,8 +139,8 @@ trait RunModule extends WithZincWorker {
     )
   }
 
-  def runLocalTask(mainClass: Task[String], args: Task[Args] = T.task(Args())): Task[Unit] =
-    T.task {
+  def runLocalTask(mainClass: Task[String], args: Task[Args] = Task.Anon(Args())): Task[Unit] =
+    Task.Anon {
       Jvm.runLocal(
         mainClass(),
         runClasspath().map(_.path),
@@ -148,8 +148,8 @@ trait RunModule extends WithZincWorker {
       )
     }
 
-  def runBackgroundTask(mainClass: Task[String], args: Task[Args] = T.task(Args())): Task[Unit] =
-    T.task {
+  def runBackgroundTask(mainClass: Task[String], args: Task[Args] = Task.Anon(Args())): Task[Unit] =
+    Task.Anon {
       val (procId, procTombstone, token) = backgroundSetup(T.dest)
       runner().run(
         args = Seq(procId.toString, procTombstone.toString, token, mainClass()) ++ args().value,

--- a/scalalib/src/mill/scalalib/RunModule.scala
+++ b/scalalib/src/mill/scalalib/RunModule.scala
@@ -15,26 +15,26 @@ trait RunModule extends WithZincWorker {
   /**
    * Any command-line parameters you want to pass to the forked JVM.
    */
-  def forkArgs: T[Seq[String]] = T { Seq.empty[String] }
+  def forkArgs: T[Seq[String]] = Task { Seq.empty[String] }
 
   /**
    * Any environment variables you want to pass to the forked JVM.
    */
-  def forkEnv: T[Map[String, String]] = T { Map.empty[String, String] }
+  def forkEnv: T[Map[String, String]] = Task { Map.empty[String, String] }
 
-  def forkWorkingDir: T[os.Path] = T { T.workspace }
+  def forkWorkingDir: T[os.Path] = Task { T.workspace }
 
   /**
    * All classfiles and resources including upstream modules and dependencies
    * necessary to run this module's code.
    */
-  def runClasspath: T[Seq[PathRef]] = T { Seq.empty[PathRef] }
+  def runClasspath: T[Seq[PathRef]] = Task { Seq.empty[PathRef] }
 
   /**
    * The elements of the run classpath which are local to this module.
    * This is typically the output of a compilation step and bundles runtime resources.
    */
-  def localRunClasspath: T[Seq[PathRef]] = T { Seq.empty[PathRef] }
+  def localRunClasspath: T[Seq[PathRef]] = Task { Seq.empty[PathRef] }
 
   /**
    * Allows you to specify an explicit main class to use for the `run` command.
@@ -43,11 +43,11 @@ trait RunModule extends WithZincWorker {
    */
   def mainClass: T[Option[String]] = None
 
-  def allLocalMainClasses: T[Seq[String]] = T {
+  def allLocalMainClasses: T[Seq[String]] = Task {
     zincWorker().worker().discoverMainClasses(localRunClasspath().map(_.path))
   }
 
-  def finalMainClassOpt: T[Either[String, String]] = T {
+  def finalMainClassOpt: T[Either[String, String]] = Task {
     mainClass() match {
       case Some(m) => Right(m)
       case None =>
@@ -63,7 +63,7 @@ trait RunModule extends WithZincWorker {
     }
   }
 
-  def finalMainClass: T[String] = T {
+  def finalMainClass: T[String] = Task {
     finalMainClassOpt() match {
       case Right(main) => Result.Success(main)
       case Left(msg) => Result.Failure(msg)
@@ -73,7 +73,7 @@ trait RunModule extends WithZincWorker {
   /**
    * Control whether `run*`-targets should use an args file to pass command line args, if possible.
    */
-  def runUseArgsFile: T[Boolean] = T { scala.util.Properties.isWin }
+  def runUseArgsFile: T[Boolean] = Task { scala.util.Properties.isWin }
 
   /**
    * Runs this module's code in a subprocess and waits for it to finish

--- a/scalalib/src/mill/scalalib/SbtModule.scala
+++ b/scalalib/src/mill/scalalib/SbtModule.scala
@@ -1,6 +1,6 @@
 package mill.scalalib
 
-import mill.T
+import mill.Task
 
 import scala.annotation.nowarn
 
@@ -9,7 +9,7 @@ import scala.annotation.nowarn
  */
 trait SbtModule extends ScalaModule with MavenModule {
 
-  override def sources = T.sources(
+  override def sources = Task.Sources(
     millSourcePath / "src/main/scala",
     millSourcePath / "src/main/java"
   )
@@ -18,7 +18,7 @@ trait SbtModule extends ScalaModule with MavenModule {
   type SbtTests = SbtModuleTests
   @deprecated("Use SbtTests instead", since = "Mill 0.11.10")
   trait SbtModuleTests extends ScalaTests with MavenTests {
-    override def sources = T.sources(
+    override def sources = Task.Sources(
       millSourcePath / "src/test/scala",
       millSourcePath / "src/test/java"
     )

--- a/scalalib/src/mill/scalalib/SbtModule.scala
+++ b/scalalib/src/mill/scalalib/SbtModule.scala
@@ -1,6 +1,6 @@
 package mill.scalalib
 
-import mill.{T, Task}
+import mill.T
 
 import scala.annotation.nowarn
 

--- a/scalalib/src/mill/scalalib/SbtModule.scala
+++ b/scalalib/src/mill/scalalib/SbtModule.scala
@@ -1,6 +1,6 @@
 package mill.scalalib
 
-import mill.T
+import mill.{T, Task}
 
 import scala.annotation.nowarn
 

--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -29,12 +29,12 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
   type ScalaModuleTests = ScalaTests
 
   trait ScalaTests extends JavaTests with ScalaModule {
-    override def scalaOrganization: Target[String] = outer.scalaOrganization()
-    override def scalaVersion: Target[String] = outer.scalaVersion()
-    override def scalacPluginIvyDeps: Target[Agg[Dep]] = outer.scalacPluginIvyDeps()
-    override def scalacPluginClasspath: Target[Agg[PathRef]] = outer.scalacPluginClasspath()
-    override def scalacOptions: Target[Seq[String]] = outer.scalacOptions()
-    override def mandatoryScalacOptions: Target[Seq[String]] =
+    override def scalaOrganization: T[String] = outer.scalaOrganization()
+    override def scalaVersion: T[String] = outer.scalaVersion()
+    override def scalacPluginIvyDeps: T[Agg[Dep]] = outer.scalacPluginIvyDeps()
+    override def scalacPluginClasspath: T[Agg[PathRef]] = outer.scalacPluginClasspath()
+    override def scalacOptions: T[Seq[String]] = outer.scalacOptions()
+    override def mandatoryScalacOptions: T[Seq[String]] =
       Task { super.mandatoryScalacOptions() }
   }
 
@@ -161,20 +161,20 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
   /**
    * Allows you to make use of Scala compiler plugins.
    */
-  def scalacPluginIvyDeps: Target[Agg[Dep]] = Task { Agg.empty[Dep] }
+  def scalacPluginIvyDeps: T[Agg[Dep]] = Task { Agg.empty[Dep] }
 
-  def scalaDocPluginIvyDeps: Target[Agg[Dep]] = Task { scalacPluginIvyDeps() }
+  def scalaDocPluginIvyDeps: T[Agg[Dep]] = Task { scalacPluginIvyDeps() }
 
   /**
    * Mandatory command-line options to pass to the Scala compiler
    * that shouldn't be removed by overriding `scalacOptions`
    */
-  protected def mandatoryScalacOptions: Target[Seq[String]] = Task { Seq.empty[String] }
+  protected def mandatoryScalacOptions: T[Seq[String]] = Task { Seq.empty[String] }
 
   /**
    * Scalac options to activate the compiler plugins.
    */
-  private def enablePluginScalacOptions: Target[Seq[String]] = Task {
+  private def enablePluginScalacOptions: T[Seq[String]] = Task {
 
     val resolvedJars = defaultResolver().resolveDeps(
       scalacPluginIvyDeps().map(_.exclude("*" -> "*"))
@@ -185,7 +185,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
   /**
    * Scalac options to activate the compiler plugins for ScalaDoc generation.
    */
-  private def enableScalaDocPluginScalacOptions: Target[Seq[String]] = Task {
+  private def enableScalaDocPluginScalacOptions: T[Seq[String]] = Task {
     val resolvedJars = defaultResolver().resolveDeps(
       scalaDocPluginIvyDeps().map(_.exclude("*" -> "*"))
     )
@@ -196,13 +196,13 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
    * Command-line options to pass to the Scala compiler defined by the user.
    * Consumers should use `allScalacOptions` to read them.
    */
-  override def scalacOptions: Target[Seq[String]] = Task { Seq.empty[String] }
+  override def scalacOptions: T[Seq[String]] = Task { Seq.empty[String] }
 
   /**
    * Aggregation of all the options passed to the Scala compiler.
    * In most cases, instead of overriding this Target you want to override `scalacOptions` instead.
    */
-  def allScalacOptions: Target[Seq[String]] = Task {
+  def allScalacOptions: T[Seq[String]] = Task {
     mandatoryScalacOptions() ++ enablePluginScalacOptions() ++ scalacOptions()
   }
 
@@ -295,7 +295,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
 
   /** the path to the compiled classes without forcing the compilation. */
   @internal
-  override def bspCompileClassesPath: Target[UnresolvedPath] =
+  override def bspCompileClassesPath: T[UnresolvedPath] =
     if (compile.ctx.enclosing == s"${classOf[ScalaModule].getName}#compile") {
       Task {
         T.log.debug(

--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -34,7 +34,8 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
     override def scalacPluginIvyDeps: Target[Agg[Dep]] = outer.scalacPluginIvyDeps()
     override def scalacPluginClasspath: Target[Agg[PathRef]] = outer.scalacPluginClasspath()
     override def scalacOptions: Target[Seq[String]] = outer.scalacOptions()
-    override def mandatoryScalacOptions: Target[Seq[String]] = Task { super.mandatoryScalacOptions() }
+    override def mandatoryScalacOptions: Target[Seq[String]] =
+      Task { super.mandatoryScalacOptions() }
   }
 
   /**

--- a/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
+++ b/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
@@ -1,7 +1,7 @@
 package mill.scalalib
 
 import mill.api.{PathRef, Result, experimental}
-import mill.define.{ModuleRef, Target}
+import mill.define.ModuleRef
 import mill.main.BuildInfo
 import mill.scalalib.api.{CompilationResult, Versions, ZincWorkerUtil}
 import mill.scalalib.bsp.BspBuildTarget
@@ -125,7 +125,7 @@ trait SemanticDbJavaModule extends CoursierModule {
   }
 
   // keep in sync with bspCompiledClassesAndSemanticDbFiles
-  def compiledClassesAndSemanticDbFiles: Target[PathRef] = Task {
+  def compiledClassesAndSemanticDbFiles: T[PathRef] = Task {
     val dest = T.dest
     val classes = compile().classes.path
     val sems = semanticDbData().path
@@ -135,7 +135,7 @@ trait SemanticDbJavaModule extends CoursierModule {
   }
 
   // keep in sync with compiledClassesAndSemanticDbFiles
-  def bspCompiledClassesAndSemanticDbFiles: Target[UnresolvedPath] = {
+  def bspCompiledClassesAndSemanticDbFiles: T[UnresolvedPath] = {
     if (
       compiledClassesAndSemanticDbFiles.ctx.enclosing == s"${classOf[SemanticDbJavaModule].getName}#compiledClassesAndSemanticDbFiles"
     ) {

--- a/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
+++ b/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
@@ -23,7 +23,7 @@ trait SemanticDbJavaModule extends CoursierModule {
   def mandatoryJavacOptions: T[Seq[String]]
   def compileClasspath: T[Agg[PathRef]]
 
-  def semanticDbVersion: T[String] = T.input {
+  def semanticDbVersion: T[String] = Task.Input {
     val builtin = SemanticDbJavaModule.buildTimeSemanticDbVersion
     val requested = T.env.getOrElse[String](
       "SEMANTICDB_VERSION",
@@ -32,7 +32,7 @@ trait SemanticDbJavaModule extends CoursierModule {
     Version.chooseNewest(requested, builtin)(Version.IgnoreQualifierOrdering)
   }
 
-  def semanticDbJavaVersion: T[String] = T.input {
+  def semanticDbJavaVersion: T[String] = Task.Input {
     val builtin = SemanticDbJavaModule.buildTimeJavaSemanticDbVersion
     val requested = T.env.getOrElse[String](
       "JAVASEMANTICDB_VERSION",
@@ -98,7 +98,7 @@ trait SemanticDbJavaModule extends CoursierModule {
     defaultResolver().resolveDeps(semanticDbJavaPluginIvyDeps())
   }
 
-  def semanticDbData: T[PathRef] = T.persistent {
+  def semanticDbData: T[PathRef] = Task.Persistent {
     val javacOpts = SemanticDbJavaModule.javacOptionsTask(
       javacOptions() ++ mandatoryJavacOptions(),
       semanticDbJavaVersion()

--- a/scalalib/src/mill/scalalib/TestModule.scala
+++ b/scalalib/src/mill/scalalib/TestModule.scala
@@ -72,13 +72,13 @@ trait TestModule
    * @see [[testCached]]
    */
   def test(args: String*): Command[(String, Seq[TestResult])] =
-    T.command {
-      testTask(T.task { args }, T.task { Seq.empty[String] })()
+    Task.Command {
+      testTask(Task.Anon { args }, Task.Anon { Seq.empty[String] })()
     }
 
   def getTestEnvironmentVars(args: String*): Command[(String, String, String, Seq[String])] = {
-    T.command {
-      getTestEnvironmentVarsTask(T.task { args })()
+    Task.Command {
+      getTestEnvironmentVarsTask(Task.Anon { args })()
     }
   }
 
@@ -94,7 +94,7 @@ trait TestModule
    * @see [[test()]]
    */
   def testCached: T[(String, Seq[TestResult])] = Task {
-    testTask(testCachedArgs, T.task { Seq.empty[String] })()
+    testTask(testCachedArgs, Task.Anon { Seq.empty[String] })()
   }
 
   /**
@@ -113,8 +113,8 @@ trait TestModule
         val (s, t) = args.splitAt(pos)
         (s, t.tail)
     }
-    T.command {
-      testTask(T.task { testArgs }, T.task { selector })()
+    Task.Command {
+      testTask(Task.Anon { testArgs }, Task.Anon { selector })()
     }
   }
 
@@ -135,7 +135,7 @@ trait TestModule
    */
   private def getTestEnvironmentVarsTask(args: Task[Seq[String]])
       : Task[(String, String, String, Seq[String])] =
-    T.task {
+    Task.Anon {
       val mainClass = "mill.testrunner.entrypoint.TestRunnerMain"
       val outputPath = T.dest / "out.json"
       val selectors = Seq.empty
@@ -181,7 +181,7 @@ trait TestModule
       args: Task[Seq[String]],
       globSelectors: Task[Seq[String]]
   ): Task[(String, Seq[TestResult])] =
-    T.task {
+    Task.Anon {
       val outputPath = T.dest / "out.json"
       val useArgsFile = testUseArgsFile()
 
@@ -265,7 +265,7 @@ trait TestModule
    * Discovers and runs the module's tests in-process in an isolated classloader,
    * reporting the results to the console
    */
-  def testLocal(args: String*): Command[(String, Seq[TestResult])] = T.command {
+  def testLocal(args: String*): Command[(String, Seq[TestResult])] = Task.Command {
     val (doneMsg, results) = TestRunner.runTestFramework(
       Framework.framework(testFramework()),
       runClasspath().map(_.path),

--- a/scalalib/src/mill/scalalib/TestModule.scala
+++ b/scalalib/src/mill/scalalib/TestModule.scala
@@ -29,7 +29,7 @@ trait TestModule
    * The classpath containing the tests. This is most likely the output of the compilation target.
    * By default this uses the result of [[localRunClasspath]], which is most likely the result of a local compilation.
    */
-  def testClasspath: T[Seq[PathRef]] = T { localRunClasspath() }
+  def testClasspath: T[Seq[PathRef]] = Task { localRunClasspath() }
 
   /**
    * The test framework to use.
@@ -47,7 +47,7 @@ trait TestModule
    */
   def testFramework: T[String]
 
-  def discoveredTestClasses: T[Seq[String]] = T {
+  def discoveredTestClasses: T[Seq[String]] = Task {
     val classes = Jvm.inprocess(
       runClasspath().map(_.path),
       classLoaderOverrideSbtTesting = true,
@@ -85,7 +85,7 @@ trait TestModule
   /**
    * Args to be used by [[testCached]].
    */
-  def testCachedArgs: T[Seq[String]] = T { Seq[String]() }
+  def testCachedArgs: T[Seq[String]] = Task { Seq[String]() }
 
   /**
    * Discovers and runs the module's tests in a subprocess, reporting the
@@ -93,7 +93,7 @@ trait TestModule
    * If no input has changed since the last run, no test were executed.
    * @see [[test()]]
    */
-  def testCached: T[(String, Seq[TestResult])] = T {
+  def testCached: T[(String, Seq[TestResult])] = Task {
     testTask(testCachedArgs, T.task { Seq.empty[String] })()
   }
 
@@ -122,7 +122,7 @@ trait TestModule
    * Controls whether the TestRunner should receive it's arguments via an args-file instead of a as long parameter list.
    * Defaults to what `runUseArgsFile` return.
    */
-  def testUseArgsFile: T[Boolean] = T { runUseArgsFile() || scala.util.Properties.isWin }
+  def testUseArgsFile: T[Boolean] = Task { runUseArgsFile() || scala.util.Properties.isWin }
 
   /**
    * Sets the file name for the generated JUnit-compatible test report.
@@ -298,7 +298,7 @@ object TestModule {
    */
   trait TestNg extends TestModule {
     override def testFramework: T[String] = "mill.testng.TestNGFramework"
-    override def ivyDeps: T[Agg[Dep]] = T {
+    override def ivyDeps: T[Agg[Dep]] = Task {
       super.ivyDeps() ++ Agg(
         ivy"com.lihaoyi:mill-contrib-testng:${mill.api.BuildInfo.millVersion}"
       )
@@ -311,7 +311,7 @@ object TestModule {
    */
   trait Junit4 extends TestModule {
     override def testFramework: T[String] = "com.novocode.junit.JUnitFramework"
-    override def ivyDeps: T[Agg[Dep]] = T {
+    override def ivyDeps: T[Agg[Dep]] = Task {
       super.ivyDeps() ++ Agg(ivy"${mill.scalalib.api.Versions.sbtTestInterface}")
     }
   }
@@ -322,7 +322,7 @@ object TestModule {
    */
   trait Junit5 extends TestModule {
     override def testFramework: T[String] = "com.github.sbt.junit.jupiter.api.JupiterFramework"
-    override def ivyDeps: T[Agg[Dep]] = T {
+    override def ivyDeps: T[Agg[Dep]] = Task {
       super.ivyDeps() ++ Agg(ivy"${mill.scalalib.api.Versions.jupiterInterface}")
     }
   }
@@ -341,7 +341,7 @@ object TestModule {
    */
   trait Specs2 extends ScalaModuleBase with TestModule {
     override def testFramework: T[String] = "org.specs2.runner.Specs2Framework"
-    override def scalacOptions = T {
+    override def scalacOptions = Task {
       super.scalacOptions() ++ Seq("-Yrangepos")
     }
   }
@@ -430,7 +430,7 @@ object TestModule {
 
   trait JavaModuleBase extends BspModule {
     def ivyDeps: T[Agg[Dep]] = Agg.empty[Dep]
-    def resources: T[Seq[PathRef]] = T { Seq.empty[PathRef] }
+    def resources: T[Seq[PathRef]] = Task { Seq.empty[PathRef] }
   }
 
   trait ScalaModuleBase extends mill.Module {

--- a/scalalib/src/mill/scalalib/UnidocModule.scala
+++ b/scalalib/src/mill/scalalib/UnidocModule.scala
@@ -11,7 +11,7 @@ trait UnidocModule extends ScalaModule {
 
   def unidocVersion: T[Option[String]] = None
 
-  def unidocCommon(local: Boolean) = T.task {
+  def unidocCommon(local: Boolean) = Task.Anon {
     def unidocCompileClasspath =
       Seq(compile().classes) ++ T.traverse(moduleDeps)(_.compileClasspath)().flatten
 

--- a/scalalib/src/mill/scalalib/UnidocModule.scala
+++ b/scalalib/src/mill/scalalib/UnidocModule.scala
@@ -57,12 +57,12 @@ trait UnidocModule extends ScalaModule {
     }
   }
 
-  def unidocLocal = T {
+  def unidocLocal = Task {
     unidocCommon(true)()
     PathRef(T.dest)
   }
 
-  def unidocSite = T {
+  def unidocSite = Task {
     unidocCommon(false)()
     for {
       sourceUrl <- unidocSourceUrl()

--- a/scalalib/src/mill/scalalib/ZincWorkerModule.scala
+++ b/scalalib/src/mill/scalalib/ZincWorkerModule.scala
@@ -45,7 +45,7 @@ trait ZincWorkerModule extends mill.Module with OfflineSupportModule { self: Cou
 
   def zincLogDebug: T[Boolean] = Task.Input(T.ctx().log.debugEnabled)
 
-  def worker: Worker[ZincWorkerApi] = Task.worker {
+  def worker: Worker[ZincWorkerApi] = Task.Worker {
     val jobs = T.ctx() match {
       case j: Ctx.Jobs => j.jobs
       case _ => 1

--- a/scalalib/src/mill/scalalib/ZincWorkerModule.scala
+++ b/scalalib/src/mill/scalalib/ZincWorkerModule.scala
@@ -43,9 +43,9 @@ trait ZincWorkerModule extends mill.Module with OfflineSupportModule { self: Cou
     )
   }
 
-  def zincLogDebug: T[Boolean] = T.input(T.ctx().log.debugEnabled)
+  def zincLogDebug: T[Boolean] = Task.Input(T.ctx().log.debugEnabled)
 
-  def worker: Worker[ZincWorkerApi] = T.worker {
+  def worker: Worker[ZincWorkerApi] = Task.worker {
     val jobs = T.ctx() match {
       case j: Ctx.Jobs => j.jobs
       case _ => 1
@@ -167,14 +167,14 @@ trait ZincWorkerModule extends mill.Module with OfflineSupportModule { self: Cou
     } else dep
   }
 
-  override def prepareOffline(all: Flag): Command[Unit] = T.command {
+  override def prepareOffline(all: Flag): Command[Unit] = Task.Command {
     super.prepareOffline(all)()
     classpath()
     ()
   }
 
   def prepareOfflineCompiler(scalaVersion: String, scalaOrganization: String): Command[Unit] =
-    T.command {
+    Task.Command {
       classpath()
       scalaCompilerBridgeJar(scalaVersion, scalaOrganization, repositoriesTask())
       ()

--- a/scalalib/src/mill/scalalib/ZincWorkerModule.scala
+++ b/scalalib/src/mill/scalalib/ZincWorkerModule.scala
@@ -23,19 +23,19 @@ object ZincWorkerModule extends ExternalModule with ZincWorkerModule with Coursi
  */
 trait ZincWorkerModule extends mill.Module with OfflineSupportModule { self: CoursierModule =>
 
-  def classpath: T[Agg[PathRef]] = T {
+  def classpath: T[Agg[PathRef]] = Task {
     millProjectModule("mill-scalalib-worker", repositoriesTask())
   }
 
-  def scalalibClasspath: T[Agg[PathRef]] = T {
+  def scalalibClasspath: T[Agg[PathRef]] = Task {
     millProjectModule("mill-scalalib", repositoriesTask())
   }
 
-  def testrunnerEntrypointClasspath: T[Agg[PathRef]] = T {
+  def testrunnerEntrypointClasspath: T[Agg[PathRef]] = Task {
     millProjectModule("mill-testrunner-entrypoint", repositoriesTask(), artifactSuffix = "")
   }
 
-  def backgroundWrapperClasspath: T[Agg[PathRef]] = T {
+  def backgroundWrapperClasspath: T[Agg[PathRef]] = Task {
     millProjectModule(
       "mill-scalalib-backgroundwrapper",
       repositoriesTask(),

--- a/scalalib/src/mill/scalalib/bsp/BspModule.scala
+++ b/scalalib/src/mill/scalalib/bsp/BspModule.scala
@@ -36,7 +36,7 @@ trait BspModule extends Module {
    * - [[ScalaBuildTarget]]
    */
   @internal
-  def bspBuildTargetData: Task[Option[(String, AnyRef)]] = T.task { None }
+  def bspBuildTargetData: Task[Option[(String, AnyRef)]] = Task.Anon { None }
 
 }
 

--- a/scalalib/src/mill/scalalib/bsp/ScalaMetalsSupport.scala
+++ b/scalalib/src/mill/scalalib/bsp/ScalaMetalsSupport.scala
@@ -2,7 +2,6 @@ package mill.scalalib.bsp
 
 import mill.api.experimental
 import mill.{Agg, T, Task}
-import mill.define.Target
 import mill.scalalib.{Dep, DepSyntax, ScalaModule}
 import mill.api.Result
 import mill.scalalib.api.ZincWorkerUtil
@@ -16,7 +15,7 @@ import mill.scalalib.api.ZincWorkerUtil
 )
 trait ScalaMetalsSupport extends ScalaModule {
 
-  override def scalacPluginIvyDeps: Target[Agg[Dep]] = Task {
+  override def scalacPluginIvyDeps: T[Agg[Dep]] = Task {
     val sv = scalaVersion()
     val semDbVersion = semanticDbVersion()
     val superRes = super.scalacPluginIvyDeps()
@@ -40,7 +39,7 @@ trait ScalaMetalsSupport extends ScalaModule {
   }
 
   /** Adds some options and configures the semanticDB plugin. */
-  override def mandatoryScalacOptions: Target[Seq[String]] = Task {
+  override def mandatoryScalacOptions: T[Seq[String]] = Task {
     super.mandatoryScalacOptions() ++ {
       if (ZincWorkerUtil.isScala3(scalaVersion())) {
         Seq("-Xsemanticdb")
@@ -51,7 +50,7 @@ trait ScalaMetalsSupport extends ScalaModule {
   }
 
   /** Filters options unsupported by Metals. */
-  override def allScalacOptions: Target[Seq[String]] = Task {
+  override def allScalacOptions: T[Seq[String]] = Task {
     super.allScalacOptions().filterNot(_ == "-Xfatal-warnings")
   }
 }

--- a/scalalib/src/mill/scalalib/bsp/ScalaMetalsSupport.scala
+++ b/scalalib/src/mill/scalalib/bsp/ScalaMetalsSupport.scala
@@ -1,7 +1,7 @@
 package mill.scalalib.bsp
 
 import mill.api.experimental
-import mill.{Agg, T}
+import mill.{Agg, T, Task}
 import mill.define.Target
 import mill.scalalib.{Dep, DepSyntax, ScalaModule}
 import mill.api.Result
@@ -16,7 +16,7 @@ import mill.scalalib.api.ZincWorkerUtil
 )
 trait ScalaMetalsSupport extends ScalaModule {
 
-  override def scalacPluginIvyDeps: Target[Agg[Dep]] = T {
+  override def scalacPluginIvyDeps: Target[Agg[Dep]] = Task {
     val sv = scalaVersion()
     val semDbVersion = semanticDbVersion()
     val superRes = super.scalacPluginIvyDeps()
@@ -40,7 +40,7 @@ trait ScalaMetalsSupport extends ScalaModule {
   }
 
   /** Adds some options and configures the semanticDB plugin. */
-  override def mandatoryScalacOptions: Target[Seq[String]] = T {
+  override def mandatoryScalacOptions: Target[Seq[String]] = Task {
     super.mandatoryScalacOptions() ++ {
       if (ZincWorkerUtil.isScala3(scalaVersion())) {
         Seq("-Xsemanticdb")
@@ -51,7 +51,7 @@ trait ScalaMetalsSupport extends ScalaModule {
   }
 
   /** Filters options unsupported by Metals. */
-  override def allScalacOptions: Target[Seq[String]] = T {
+  override def allScalacOptions: Target[Seq[String]] = Task {
     super.allScalacOptions().filterNot(_ == "-Xfatal-warnings")
   }
 }

--- a/scalalib/src/mill/scalalib/dependency/versions/VersionsFinder.scala
+++ b/scalalib/src/mill/scalalib/dependency/versions/VersionsFinder.scala
@@ -40,7 +40,7 @@ private[dependency] object VersionsFinder {
   private def resolveDeps(progress: Progress)(
       javaModule: JavaModule
   ): Task[ResolvedDependencies] =
-    T.task {
+    Task.Anon {
       T.log.ticker(s"Resolving dependencies [${progress.next()}/${progress.count}]: ${javaModule}")
 
       val bindDependency = javaModule.bindDependency()
@@ -72,7 +72,7 @@ private[dependency] object VersionsFinder {
 
   private def resolveVersions(progres: Progress)(
       resolvedDependencies: ResolvedDependencies
-  ): Task[ModuleDependenciesVersions] = T.task {
+  ): Task[ModuleDependenciesVersions] = Task.Anon {
     val (javaModule, metadataLoaders, dependencies) = resolvedDependencies
 
     val versions = dependencies.map { dependency =>

--- a/scalalib/src/mill/scalalib/giter8/Giter8Module.scala
+++ b/scalalib/src/mill/scalalib/giter8/Giter8Module.scala
@@ -1,6 +1,6 @@
 package mill.scalalib.giter8
 
-import mill.{T, Task}
+import mill.T
 import mill.define.{Command, Discover, ExternalModule}
 import mill.util.Jvm
 import mill.scalalib.api.ZincWorkerUtil

--- a/scalalib/src/mill/scalalib/giter8/Giter8Module.scala
+++ b/scalalib/src/mill/scalalib/giter8/Giter8Module.scala
@@ -1,6 +1,6 @@
 package mill.scalalib.giter8
 
-import mill.T
+import mill.{T, Task}
 import mill.define.{Command, Discover, ExternalModule}
 import mill.util.Jvm
 import mill.scalalib.api.ZincWorkerUtil
@@ -14,7 +14,7 @@ object Giter8Module extends ExternalModule with Giter8Module {
 
 trait Giter8Module extends CoursierModule {
 
-  def init(args: String*): Command[Unit] = T.command {
+  def init(args: String*): Command[Unit] = Task.Command {
     T.log.info("Creating a new project...")
     val giter8Dependencies = defaultResolver().resolveDeps {
       val scalaBinVersion = ZincWorkerUtil.scalaBinaryVersion(BuildInfo.scalaVersion)

--- a/scalalib/src/mill/scalalib/giter8/Giter8Module.scala
+++ b/scalalib/src/mill/scalalib/giter8/Giter8Module.scala
@@ -1,6 +1,6 @@
 package mill.scalalib.giter8
 
-import mill.T
+import mill.{T, Task}
 import mill.define.{Command, Discover, ExternalModule}
 import mill.util.Jvm
 import mill.scalalib.api.ZincWorkerUtil

--- a/scalalib/src/mill/scalalib/scalafmt/ScalafmtModule.scala
+++ b/scalalib/src/mill/scalalib/scalafmt/ScalafmtModule.scala
@@ -10,7 +10,7 @@ import mill.main.Tasks
 
 trait ScalafmtModule extends JavaModule {
 
-  def reformat(): Command[Unit] = T.command {
+  def reformat(): Command[Unit] = Task.Command {
     ScalafmtWorkerModule
       .worker()
       .reformat(
@@ -19,7 +19,7 @@ trait ScalafmtModule extends JavaModule {
       )
   }
 
-  def checkFormat(): Command[Unit] = T.command {
+  def checkFormat(): Command[Unit] = Task.Command {
     ScalafmtWorkerModule
       .worker()
       .checkFormat(
@@ -28,13 +28,13 @@ trait ScalafmtModule extends JavaModule {
       )
   }
 
-  def scalafmtConfig: T[Seq[PathRef]] = T.sources(
+  def scalafmtConfig: T[Seq[PathRef]] = Task.Sources(
     T.workspace / ".scalafmt.conf",
     os.pwd / ".scalafmt.conf"
   )
 
   // TODO: Do we want provide some defaults or write a default file?
-  private[ScalafmtModule] def resolvedScalafmtConfig: Task[PathRef] = T.task {
+  private[ScalafmtModule] def resolvedScalafmtConfig: Task[PathRef] = Task.Anon {
     val locs = scalafmtConfig()
     locs.find(p => os.exists(p.path)) match {
       case None => Result.Failure(
@@ -76,7 +76,7 @@ object ScalafmtModule extends ExternalModule with ScalafmtModule with TaskModule
 
   def reformatAll(@arg(positional = true) sources: Tasks[Seq[PathRef]] =
     Tasks.resolveMainDefault("__.sources")) =
-    T.command {
+    Task.Command {
       val files = T.sequence(sources.value)().flatMap(filesToFormat)
       ScalafmtWorkerModule
         .worker()
@@ -88,7 +88,7 @@ object ScalafmtModule extends ExternalModule with ScalafmtModule with TaskModule
 
   def checkFormatAll(@arg(positional = true) sources: Tasks[Seq[PathRef]] =
     Tasks.resolveMainDefault("__.sources")): Command[Unit] =
-    T.command {
+    Task.Command {
       val files = T.sequence(sources.value)().flatMap(filesToFormat)
       ScalafmtWorkerModule
         .worker()

--- a/scalalib/src/mill/scalalib/scalafmt/ScalafmtWorker.scala
+++ b/scalalib/src/mill/scalalib/scalafmt/ScalafmtWorker.scala
@@ -9,7 +9,7 @@ import scala.collection.mutable
 import mill.api.Result
 
 object ScalafmtWorkerModule extends ExternalModule {
-  def worker: Worker[ScalafmtWorker] = Task.worker { new ScalafmtWorker() }
+  def worker: Worker[ScalafmtWorker] = Task.Worker { new ScalafmtWorker() }
 
   lazy val millDiscover: Discover = Discover[this.type]
 }

--- a/scalalib/src/mill/scalalib/scalafmt/ScalafmtWorker.scala
+++ b/scalalib/src/mill/scalalib/scalafmt/ScalafmtWorker.scala
@@ -9,7 +9,7 @@ import scala.collection.mutable
 import mill.api.Result
 
 object ScalafmtWorkerModule extends ExternalModule {
-  def worker: Worker[ScalafmtWorker] = T.worker { new ScalafmtWorker() }
+  def worker: Worker[ScalafmtWorker] = Task.worker { new ScalafmtWorker() }
 
   lazy val millDiscover: Discover = Discover[this.type]
 }

--- a/scalalib/test/src/mill/scalalib/AssemblyTests.scala
+++ b/scalalib/test/src/mill/scalalib/AssemblyTests.scala
@@ -21,7 +21,7 @@ object AssemblyTests extends TestSuite {
   object TestCase extends TestBaseModule {
     trait Setup extends ScalaModule {
       def scalaVersion = "2.13.11"
-      def sources = T.sources(T.workspace / "src")
+      def sources = Task.Sources(T.workspace / "src")
       def ivyDeps = super.ivyDeps() ++ Agg(
         ivy"com.lihaoyi::scalatags:0.8.2",
         ivy"com.lihaoyi::mainargs:0.4.0",

--- a/scalalib/test/src/mill/scalalib/DottyDocTests.scala
+++ b/scalalib/test/src/mill/scalalib/DottyDocTests.scala
@@ -25,7 +25,7 @@ object DottyDocTests extends TestSuite {
   object MultiDocsModule extends TestBaseModule {
     object multidocs extends ScalaModule {
       def scalaVersion = "0.24.0-RC1"
-      def docResources = T.sources(
+      def docResources = Task.Sources(
         millSourcePath / "docs1",
         millSourcePath / "docs2"
       )

--- a/scalalib/test/src/mill/scalalib/HelloJavaTests.scala
+++ b/scalalib/test/src/mill/scalalib/HelloJavaTests.scala
@@ -19,7 +19,7 @@ object HelloJavaTests extends TestSuite {
       override def moduleDeps = Seq(core)
       object test extends JavaTests with TestModule.Junit4
       object testJunit5 extends JavaTests with TestModule.Junit5 {
-        override def ivyDeps: T[Agg[Dep]] = T {
+        override def ivyDeps: T[Agg[Dep]] = Task {
           super.ivyDeps() ++ Agg(ivy"org.junit.jupiter:junit-jupiter-params:5.7.0")
         }
       }

--- a/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
+++ b/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
@@ -206,7 +206,7 @@ object HelloWorldTests extends TestSuite {
 
   object HelloWorldScalaOverride extends TestBaseModule {
     object core extends HelloWorldModule {
-      override def scalaVersion: Target[String] = scala213Version
+      override def scalaVersion: T[String] = scala213Version
     }
   }
 
@@ -930,7 +930,7 @@ object HelloWorldTests extends TestSuite {
       }
 
       test("assemblyRules") {
-        def checkAppend[M <: mill.testkit.TestBaseModule](module: M, target: Target[PathRef]) =
+        def checkAppend[M <: mill.testkit.TestBaseModule](module: M, target: T[PathRef]) =
           UnitTester(module, resourcePath).scoped { eval =>
             val Right(result) = eval.apply(target)
 
@@ -959,7 +959,7 @@ object HelloWorldTests extends TestSuite {
 
         def checkAppendMulti[M <: mill.testkit.TestBaseModule](
             module: M,
-            target: Target[PathRef]
+            target: T[PathRef]
         ): Unit = UnitTester(
           module,
           sourceRoot = helloWorldMultiResourcePath
@@ -985,7 +985,7 @@ object HelloWorldTests extends TestSuite {
 
         def checkAppendWithSeparator[M <: mill.testkit.TestBaseModule](
             module: M,
-            target: Target[PathRef]
+            target: T[PathRef]
         ): Unit = UnitTester(
           module,
           sourceRoot = helloWorldMultiResourcePath
@@ -1024,7 +1024,7 @@ object HelloWorldTests extends TestSuite {
 
         def checkExclude[M <: mill.testkit.TestBaseModule](
             module: M,
-            target: Target[PathRef],
+            target: T[PathRef],
             resourcePath: os.Path = resourcePath
         ) = UnitTester(module, resourcePath).scoped { eval =>
           val Right(result) = eval.apply(target)
@@ -1055,7 +1055,7 @@ object HelloWorldTests extends TestSuite {
 
         def checkRelocate[M <: mill.testkit.TestBaseModule](
             module: M,
-            target: Target[PathRef],
+            target: T[PathRef],
             resourcePath: os.Path = resourcePath
         ) = UnitTester(module, resourcePath).scoped { eval =>
           val Right(result) = eval.apply(target)
@@ -1300,7 +1300,7 @@ object HelloWorldTests extends TestSuite {
 
     test("validated") {
       test("PathRef") {
-        def check(t: Target[PathRef], flip: Boolean) = UnitTester(ValidatedTarget, null).scoped {
+        def check(t: T[PathRef], flip: Boolean) = UnitTester(ValidatedTarget, null).scoped {
           eval =>
             // we reconstruct faulty behavior
             val Right(result) = eval.apply(t)
@@ -1320,7 +1320,7 @@ object HelloWorldTests extends TestSuite {
         test("checked") - check(ValidatedTarget.checkedPathRef, true)
       }
       test("SeqPathRef") {
-        def check(t: Target[Seq[PathRef]], flip: Boolean) =
+        def check(t: T[Seq[PathRef]], flip: Boolean) =
           UnitTester(ValidatedTarget, null).scoped { eval =>
             // we reconstruct faulty behavior
             val Right(result) = eval.apply(t)
@@ -1340,7 +1340,7 @@ object HelloWorldTests extends TestSuite {
         test("checked") - check(ValidatedTarget.checkedSeqPathRef, true)
       }
       test("AggPathRef") {
-        def check(t: Target[Agg[PathRef]], flip: Boolean) =
+        def check(t: T[Agg[PathRef]], flip: Boolean) =
           UnitTester(ValidatedTarget, null).scoped { eval =>
             // we reconstruct faulty behavior
             val Right(result) = eval.apply(t)
@@ -1360,7 +1360,7 @@ object HelloWorldTests extends TestSuite {
         test("checked") - check(ValidatedTarget.checkedAggPathRef, true)
       }
       test("other") {
-        def check(t: Target[Tuple1[PathRef]], flip: Boolean) =
+        def check(t: T[Tuple1[PathRef]], flip: Boolean) =
           UnitTester(ValidatedTarget, null).scoped { eval =>
             // we reconstruct faulty behavior
             val Right(result) = eval.apply(t)

--- a/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
+++ b/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
@@ -308,7 +308,7 @@ object HelloWorldTests extends TestSuite {
   }
 
   object ValidatedTarget extends TestBaseModule {
-    private def mkDirWithFile = T.task {
+    private def mkDirWithFile = Task.Anon {
       os.write(T.dest / "dummy", "dummy", createFolders = true)
       PathRef(T.dest)
     }
@@ -803,7 +803,7 @@ object HelloWorldTests extends TestSuite {
       test("runIfMainClassProvided") - UnitTester(HelloWorldWithMain, resourcePath).scoped { eval =>
         val runResult = eval.outPath / "core/run.dest/hello-mill"
         val Right(result) = eval.apply(
-          HelloWorldWithMain.core.run(T.task(Args(runResult.toString)))
+          HelloWorldWithMain.core.run(Task.Anon(Args(runResult.toString)))
         )
 
         assert(result.evalCount > 0)
@@ -826,7 +826,7 @@ object HelloWorldTests extends TestSuite {
           // discovered by Zinc and used
           val runResult = eval.outPath / "core/run.dest/hello-mill"
           val Right(result) = eval.apply(
-            HelloWorldWithoutMain.core.run(T.task(Args(runResult.toString)))
+            HelloWorldWithoutMain.core.run(Task.Anon(Args(runResult.toString)))
           )
 
           assert(result.evalCount > 0)
@@ -842,7 +842,7 @@ object HelloWorldTests extends TestSuite {
       test("runIfMainClassProvided") - UnitTester(HelloWorldWithMain, resourcePath).scoped { eval =>
         val runResult = eval.outPath / "core/run.dest/hello-mill"
         val Right(result) = eval.apply(
-          HelloWorldWithMain.core.runLocal(T.task(Args(runResult.toString)))
+          HelloWorldWithMain.core.runLocal(Task.Anon(Args(runResult.toString)))
         )
 
         assert(result.evalCount > 0)
@@ -855,7 +855,7 @@ object HelloWorldTests extends TestSuite {
       test("runWithDefaultMain") - UnitTester(HelloWorldDefaultMain, resourcePath).scoped { eval =>
         val runResult = eval.outPath / "core/run.dest/hello-mill"
         val Right(result) = eval.apply(
-          HelloWorldDefaultMain.core.runLocal(T.task(Args(runResult.toString)))
+          HelloWorldDefaultMain.core.runLocal(Task.Anon(Args(runResult.toString)))
         )
 
         assert(result.evalCount > 0)

--- a/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
+++ b/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
@@ -25,7 +25,7 @@ object HelloWorldTests extends TestSuite {
 
   trait HelloWorldModule extends scalalib.ScalaModule {
     def scalaVersion = scala212Version
-    override def semanticDbVersion: T[String] = T {
+    override def semanticDbVersion: T[String] = Task {
       // The latest semanticDB release for Scala 2.12.6
       "4.1.9"
     }
@@ -312,15 +312,15 @@ object HelloWorldTests extends TestSuite {
       os.write(T.dest / "dummy", "dummy", createFolders = true)
       PathRef(T.dest)
     }
-    def uncheckedPathRef: T[PathRef] = T { mkDirWithFile() }
-    def uncheckedSeqPathRef: T[Seq[PathRef]] = T { Seq(mkDirWithFile()) }
-    def uncheckedAggPathRef: T[Agg[PathRef]] = T { Agg(mkDirWithFile()) }
-    def uncheckedTuplePathRef: T[Tuple1[PathRef]] = T { Tuple1(mkDirWithFile()) }
+    def uncheckedPathRef: T[PathRef] = Task { mkDirWithFile() }
+    def uncheckedSeqPathRef: T[Seq[PathRef]] = Task { Seq(mkDirWithFile()) }
+    def uncheckedAggPathRef: T[Agg[PathRef]] = Task { Agg(mkDirWithFile()) }
+    def uncheckedTuplePathRef: T[Tuple1[PathRef]] = Task { Tuple1(mkDirWithFile()) }
 
-    def checkedPathRef: T[PathRef] = T { mkDirWithFile().withRevalidateOnce }
-    def checkedSeqPathRef: T[Seq[PathRef]] = T { Seq(mkDirWithFile()).map(_.withRevalidateOnce) }
-    def checkedAggPathRef: T[Agg[PathRef]] = T { Agg(mkDirWithFile()).map(_.withRevalidateOnce) }
-    def checkedTuplePathRef: T[Tuple1[PathRef]] = T { Tuple1(mkDirWithFile().withRevalidateOnce) }
+    def checkedPathRef: T[PathRef] = Task { mkDirWithFile().withRevalidateOnce }
+    def checkedSeqPathRef: T[Seq[PathRef]] = Task { Seq(mkDirWithFile()).map(_.withRevalidateOnce) }
+    def checkedAggPathRef: T[Agg[PathRef]] = Task { Agg(mkDirWithFile()).map(_.withRevalidateOnce) }
+    def checkedTuplePathRef: T[Tuple1[PathRef]] = Task { Tuple1(mkDirWithFile().withRevalidateOnce) }
   }
 
   object MultiModuleClasspaths extends TestBaseModule {
@@ -330,7 +330,7 @@ object HelloWorldTests extends TestSuite {
       def ivyDeps = Agg(ivy"com.lihaoyi::sourcecode:0.2.2")
       def compileIvyDeps = Agg(ivy"com.lihaoyi::geny:0.4.2")
       def runIvyDeps = Agg(ivy"com.lihaoyi::utest:0.8.4")
-      def unmanagedClasspath = T { Agg(PathRef(millSourcePath / "unmanaged")) }
+      def unmanagedClasspath = Task { Agg(PathRef(millSourcePath / "unmanaged")) }
     }
     trait BarModule extends ScalaModule {
       def scalaVersion = "2.13.12"
@@ -338,7 +338,7 @@ object HelloWorldTests extends TestSuite {
       def ivyDeps = Agg(ivy"com.lihaoyi::sourcecode:0.2.1")
       def compileIvyDeps = Agg(ivy"com.lihaoyi::geny:0.4.1")
       def runIvyDeps = Agg(ivy"com.lihaoyi::utest:0.8.4")
-      def unmanagedClasspath = T { Agg(PathRef(millSourcePath / "unmanaged")) }
+      def unmanagedClasspath = Task { Agg(PathRef(millSourcePath / "unmanaged")) }
     }
     trait QuxModule extends ScalaModule {
       def scalaVersion = "2.13.12"
@@ -346,7 +346,7 @@ object HelloWorldTests extends TestSuite {
       def ivyDeps = Agg(ivy"com.lihaoyi::sourcecode:0.2.0")
       def compileIvyDeps = Agg(ivy"com.lihaoyi::geny:0.4.0")
       def runIvyDeps = Agg(ivy"com.lihaoyi::utest:0.8.4")
-      def unmanagedClasspath = T { Agg(PathRef(millSourcePath / "unmanaged")) }
+      def unmanagedClasspath = Task { Agg(PathRef(millSourcePath / "unmanaged")) }
     }
     object ModMod extends Module {
       object foo extends FooModule

--- a/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
+++ b/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
@@ -320,7 +320,8 @@ object HelloWorldTests extends TestSuite {
     def checkedPathRef: T[PathRef] = Task { mkDirWithFile().withRevalidateOnce }
     def checkedSeqPathRef: T[Seq[PathRef]] = Task { Seq(mkDirWithFile()).map(_.withRevalidateOnce) }
     def checkedAggPathRef: T[Agg[PathRef]] = Task { Agg(mkDirWithFile()).map(_.withRevalidateOnce) }
-    def checkedTuplePathRef: T[Tuple1[PathRef]] = Task { Tuple1(mkDirWithFile().withRevalidateOnce) }
+    def checkedTuplePathRef: T[Tuple1[PathRef]] =
+      Task { Tuple1(mkDirWithFile().withRevalidateOnce) }
   }
 
   object MultiModuleClasspaths extends TestBaseModule {

--- a/scalalib/test/src/mill/scalalib/PublishModuleTests.scala
+++ b/scalalib/test/src/mill/scalalib/PublishModuleTests.scala
@@ -1,6 +1,6 @@
 package mill.scalalib
 
-import mill.{Agg, T}
+import mill.{Agg, T, Task}
 import mill.api.{PathRef, Result}
 import mill.eval.Evaluator
 import mill.scalalib.publish.{
@@ -25,7 +25,7 @@ object PublishModuleTests extends TestSuite {
 
   trait HelloScalaModule extends ScalaModule {
     def scalaVersion = scala212Version
-    override def semanticDbVersion: T[String] = T {
+    override def semanticDbVersion: T[String] = Task {
       // The latest semanticDB release for Scala 2.12.6
       "4.1.9"
     }
@@ -71,9 +71,9 @@ object PublishModuleTests extends TestSuite {
         ivy"org.slf4j:slf4j-api:2.0.7"
       )
       // ensure, these target wont be called
-      override def jar: T[PathRef] = T { ???.asInstanceOf[PathRef] }
-      override def docJar: T[PathRef] = T { ???.asInstanceOf[PathRef] }
-      override def sourceJar: T[PathRef] = T { ???.asInstanceOf[PathRef] }
+      override def jar: T[PathRef] = Task { ???.asInstanceOf[PathRef] }
+      override def docJar: T[PathRef] = Task { ???.asInstanceOf[PathRef] }
+      override def sourceJar: T[PathRef] = Task { ???.asInstanceOf[PathRef] }
     }
   }
 

--- a/scalalib/test/src/mill/scalalib/PublishModuleTests.scala
+++ b/scalalib/test/src/mill/scalalib/PublishModuleTests.scala
@@ -46,7 +46,7 @@ object PublishModuleTests extends TestSuite {
       )
       override def versionScheme = Some(VersionScheme.EarlySemVer)
 
-      def checkSonatypeCreds(sonatypeCreds: String) = T.command {
+      def checkSonatypeCreds(sonatypeCreds: String) = Task.Command {
         PublishModule.checkSonatypeCreds(sonatypeCreds)()
       }
     }

--- a/scalalib/test/src/mill/scalalib/ScalaDoc3Tests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaDoc3Tests.scala
@@ -25,7 +25,7 @@ object ScalaDoc3Tests extends TestSuite {
   object MultiDocsModule extends TestBaseModule {
     object multidocs extends ScalaModule {
       def scalaVersion = "3.0.0-RC1"
-      def docResources = T.sources(
+      def docResources = Task.Sources(
         millSourcePath / "docs1",
         millSourcePath / "docs2"
       )

--- a/scalalib/test/src/mill/scalalib/TestClassLoaderTests.scala
+++ b/scalalib/test/src/mill/scalalib/TestClassLoaderTests.scala
@@ -1,6 +1,6 @@
 package mill.scalalib
 
-import mill.{Agg, T}
+import mill.{Agg, T, Task}
 
 import mill.testkit.UnitTester
 import mill.testkit.TestBaseModule
@@ -12,7 +12,7 @@ object TestClassLoaderTests extends TestSuite {
     def scalaVersion = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
 
     object test extends ScalaTests with TestModule.Utest {
-      override def ivyDeps = T {
+      override def ivyDeps = Task {
         super.ivyDeps() ++ Agg(
           ivy"com.lihaoyi::utest:${sys.props.getOrElse("TEST_UTEST_VERSION", ???)}"
         )

--- a/scalalib/test/src/mill/scalalib/TestRunnerTests.scala
+++ b/scalalib/test/src/mill/scalalib/TestRunnerTests.scala
@@ -3,7 +3,7 @@ package mill.scalalib
 import mill.api.Result
 import mill.testkit.UnitTester
 import mill.testkit.TestBaseModule
-import mill.{Agg, T}
+import mill.{Agg, T, Task}
 import os.Path
 import sbt.testing.Status
 import utest._
@@ -16,7 +16,7 @@ object TestRunnerTests extends TestSuite {
     def scalaVersion = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
 
     object utest extends ScalaTests with TestModule.Utest {
-      override def ivyDeps = T {
+      override def ivyDeps = Task {
         super.ivyDeps() ++ Agg(
           ivy"com.lihaoyi::utest:${sys.props.getOrElse("TEST_UTEST_VERSION", ???)}"
         )
@@ -24,7 +24,7 @@ object TestRunnerTests extends TestSuite {
     }
 
     object scalatest extends ScalaTests with TestModule.ScalaTest {
-      override def ivyDeps = T {
+      override def ivyDeps = Task {
         super.ivyDeps() ++ Agg(
           ivy"org.scalatest::scalatest:${sys.props.getOrElse("TEST_SCALATEST_VERSION", ???)}"
         )
@@ -32,7 +32,7 @@ object TestRunnerTests extends TestSuite {
     }
 
     trait DoneMessage extends ScalaTests {
-      override def ivyDeps = T {
+      override def ivyDeps = Task {
         super.ivyDeps() ++ Agg(
           ivy"org.scala-sbt:test-interface:${sys.props.getOrElse("TEST_TEST_INTERFACE_VERSION", ???)}"
         )
@@ -49,7 +49,7 @@ object TestRunnerTests extends TestSuite {
     }
 
     object ziotest extends ScalaTests with TestModule.ZioTest {
-      override def ivyDeps = T {
+      override def ivyDeps = Task {
         super.ivyDeps() ++ Agg(
           ivy"dev.zio::zio-test:${sys.props.getOrElse("TEST_ZIOTEST_VERSION", ???)}",
           ivy"dev.zio::zio-test-sbt:${sys.props.getOrElse("TEST_ZIOTEST_VERSION", ???)}"

--- a/scalalib/test/src/mill/scalalib/bsp/BspModuleTests.scala
+++ b/scalalib/test/src/mill/scalalib/bsp/BspModuleTests.scala
@@ -2,7 +2,7 @@ package mill.scalalib.bsp
 
 import mill.define.Cross
 import mill.eval.EvaluatorPaths
-import mill.{Agg, T}
+import mill.{Agg, T, Task}
 import mill.scalalib.{DepSyntax, JavaModule, ScalaModule}
 import mill.testkit.UnitTester
 import mill.testkit.TestBaseModule

--- a/scalalib/test/src/mill/scalalib/scalafmt/ScalafmtTests.scala
+++ b/scalalib/test/src/mill/scalalib/scalafmt/ScalafmtTests.scala
@@ -20,7 +20,7 @@ object ScalafmtTests extends TestSuite {
     object core extends ScalaModule with ScalafmtModule with BuildSrcModule {
       def scalaVersion: T[String] = sys.props.getOrElse("TEST_SCALA_2_12_VERSION", ???)
 
-      def buildSources: T[Seq[PathRef]] = T.sources {
+      def buildSources: T[Seq[PathRef]] = Task.Sources {
         millSourcePath / "util.sc"
       }
 

--- a/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
+++ b/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
@@ -4,7 +4,7 @@ package scalanativelib
 import mainargs.Flag
 import mill.api.Loose.Agg
 import mill.api.{Result, internal}
-import mill.define.{Command, Target, Task}
+import mill.define.{Command, Task}
 import mill.util.Jvm
 import mill.util.Util.millProjectModule
 import mill.scalalib.api.ZincWorkerUtil
@@ -34,8 +34,8 @@ trait ScalaNativeModule extends ScalaModule { outer =>
   type ScalaNativeModuleTests = ScalaNativeTests
   trait ScalaNativeTests extends ScalaTests with TestScalaNativeModule {
     override def scalaNativeVersion = outer.scalaNativeVersion()
-    override def releaseMode: Target[ReleaseMode] = Task { outer.releaseMode() }
-    override def logLevel: Target[NativeLogLevel] = outer.logLevel()
+    override def releaseMode: T[ReleaseMode] = Task { outer.releaseMode() }
+    override def logLevel: T[NativeLogLevel] = outer.logLevel()
   }
 
   def scalaNativeBinaryVersion =
@@ -85,7 +85,7 @@ trait ScalaNativeModule extends ScalaModule { outer =>
     ) ++ scalaVersionSpecific
   }
 
-  override def scalaLibraryIvyDeps: Target[Agg[Dep]] = Task {
+  override def scalaLibraryIvyDeps: T[Agg[Dep]] = Task {
     super.scalaLibraryIvyDeps().map(dep =>
       dep.copy(cross = dep.cross match {
         case c: CrossVersion.Constant => c.copy(platformed = false)
@@ -118,7 +118,7 @@ trait ScalaNativeModule extends ScalaModule { outer =>
     )
   }
 
-  def logLevel: Target[NativeLogLevel] = Task { NativeLogLevel.Info }
+  def logLevel: T[NativeLogLevel] = Task { NativeLogLevel.Info }
 
   private def readEnvVariable[T](
       env: Map[String, String],
@@ -139,11 +139,11 @@ trait ScalaNativeModule extends ScalaModule { outer =>
     }
   }
 
-  protected def releaseModeInput: Target[Option[ReleaseMode]] = T.input {
+  protected def releaseModeInput: T[Option[ReleaseMode]] = T.input {
     readEnvVariable[ReleaseMode](T.env, "SCALANATIVE_MODE", ReleaseMode.values, _.value)
   }
 
-  def releaseMode: Target[ReleaseMode] = Task {
+  def releaseMode: T[ReleaseMode] = Task {
     releaseModeInput().getOrElse(ReleaseMode.Debug)
   }
 
@@ -164,7 +164,7 @@ trait ScalaNativeModule extends ScalaModule { outer =>
   }
 
   // GC choice, either "none", "boehm", "immix" or "commix"
-  protected def nativeGCInput: Target[Option[String]] = T.input {
+  protected def nativeGCInput: T[Option[String]] = T.input {
     T.env.get("SCALANATIVE_GC")
   }
 
@@ -174,7 +174,7 @@ trait ScalaNativeModule extends ScalaModule { outer =>
     )
   }
 
-  def nativeTarget: Target[Option[String]] = Task { None }
+  def nativeTarget: T[Option[String]] = Task { None }
 
   // Options that are passed to clang during compilation
   def nativeCompileOptions = Task {
@@ -187,7 +187,7 @@ trait ScalaNativeModule extends ScalaModule { outer =>
   }
 
   // Whether to link `@stub` methods, or ignore them
-  def nativeLinkStubs: Target[Boolean] = Task { false }
+  def nativeLinkStubs: T[Boolean] = Task { false }
 
   /**
    * Shall the resource files be embedded in the resulting binary file? Allows
@@ -195,30 +195,30 @@ trait ScalaNativeModule extends ScalaModule { outer =>
    *  not embed files with certain extensions, including ".c", ".h", ".scala"
    *  and ".class".
    */
-  def nativeEmbedResources: Target[Boolean] = Task { false }
+  def nativeEmbedResources: T[Boolean] = Task { false }
 
   /** Shall we use the incremental compilation? */
-  def nativeIncrementalCompilation: Target[Boolean] = Task { false }
+  def nativeIncrementalCompilation: T[Boolean] = Task { false }
 
   /** Shall linker dump intermediate NIR after every phase? */
-  def nativeDump: Target[Boolean] = Task { false }
+  def nativeDump: T[Boolean] = Task { false }
 
   // The LTO mode to use used during a release build
-  protected def nativeLTOInput: Target[Option[LTO]] = T.input {
+  protected def nativeLTOInput: T[Option[LTO]] = T.input {
     readEnvVariable[LTO](T.env, "SCALANATIVE_LTO", LTO.values, _.value)
   }
 
-  def nativeLTO: Target[LTO] = Task { nativeLTOInput().getOrElse(LTO.None) }
+  def nativeLTO: T[LTO] = Task { nativeLTOInput().getOrElse(LTO.None) }
 
   // Shall we optimize the resulting NIR code?
-  protected def nativeOptimizeInput: Target[Option[Boolean]] = T.input {
+  protected def nativeOptimizeInput: T[Option[Boolean]] = T.input {
     readEnvVariable[Boolean](T.env, "SCALANATIVE_OPTIMIZE", Seq(true, false), _.toString)
   }
 
-  def nativeOptimize: Target[Boolean] = Task { nativeOptimizeInput().getOrElse(true) }
+  def nativeOptimize: T[Boolean] = Task { nativeOptimizeInput().getOrElse(true) }
 
   /** Build target for current compilation */
-  def nativeBuildTarget: Target[BuildTarget] = Task { BuildTarget.Application }
+  def nativeBuildTarget: T[BuildTarget] = Task { BuildTarget.Application }
 
   private def nativeConfig: Task[NativeConfig] = T.task {
     val classpath = runClasspath().map(_.path).filter(_.toIO.exists).toList

--- a/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
+++ b/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
@@ -34,17 +34,17 @@ trait ScalaNativeModule extends ScalaModule { outer =>
   type ScalaNativeModuleTests = ScalaNativeTests
   trait ScalaNativeTests extends ScalaTests with TestScalaNativeModule {
     override def scalaNativeVersion = outer.scalaNativeVersion()
-    override def releaseMode = T { outer.releaseMode() }
+    override def releaseMode = Task { outer.releaseMode() }
     override def logLevel: Target[NativeLogLevel] = outer.logLevel()
   }
 
   def scalaNativeBinaryVersion =
-    T { ZincWorkerUtil.scalaNativeBinaryVersion(scalaNativeVersion()) }
+    Task { ZincWorkerUtil.scalaNativeBinaryVersion(scalaNativeVersion()) }
 
   def scalaNativeWorkerVersion =
-    T { ZincWorkerUtil.scalaNativeWorkerVersion(scalaNativeVersion()) }
+    Task { ZincWorkerUtil.scalaNativeWorkerVersion(scalaNativeVersion()) }
 
-  def scalaNativeWorkerClasspath = T {
+  def scalaNativeWorkerClasspath = Task {
     millProjectModule(
       s"mill-scalanativelib-worker-${scalaNativeWorkerVersion()}",
       repositoriesTask(),
@@ -52,7 +52,7 @@ trait ScalaNativeModule extends ScalaModule { outer =>
     )
   }
 
-  def toolsIvyDeps = T {
+  def toolsIvyDeps = Task {
     scalaNativeVersion() match {
       case v @ ("0.4.0" | "0.4.1") =>
         Result.Failure(s"Scala Native $v is not supported. Please update to 0.4.2+")
@@ -67,7 +67,7 @@ trait ScalaNativeModule extends ScalaModule { outer =>
     }
   }
 
-  def nativeIvyDeps: T[Agg[Dep]] = T {
+  def nativeIvyDeps: T[Agg[Dep]] = Task {
     val scalaVersionSpecific = {
       val version =
         if (scalaNativeVersion().startsWith("0.4")) scalaNativeVersion()
@@ -85,7 +85,7 @@ trait ScalaNativeModule extends ScalaModule { outer =>
     ) ++ scalaVersionSpecific
   }
 
-  override def scalaLibraryIvyDeps = T {
+  override def scalaLibraryIvyDeps = Task {
     super.scalaLibraryIvyDeps().map(dep =>
       dep.copy(cross = dep.cross match {
         case c: CrossVersion.Constant => c.copy(platformed = false)
@@ -96,11 +96,11 @@ trait ScalaNativeModule extends ScalaModule { outer =>
   }
 
   /** Adds [[nativeIvyDeps]] as mandatory dependencies. */
-  override def mandatoryIvyDeps = T {
+  override def mandatoryIvyDeps = Task {
     super.mandatoryIvyDeps() ++ nativeIvyDeps()
   }
 
-  def bridgeFullClassPath: T[Agg[PathRef]] = T {
+  def bridgeFullClassPath: T[Agg[PathRef]] = Task {
     Lib.resolveDependencies(
       repositoriesTask(),
       toolsIvyDeps().map(Lib.depToBoundDep(_, mill.main.BuildInfo.scalaVersion, "")),
@@ -112,13 +112,13 @@ trait ScalaNativeModule extends ScalaModule { outer =>
     ScalaNativeWorkerExternalModule.scalaNativeWorker().bridge(bridgeFullClassPath())
   }
 
-  override def scalacPluginIvyDeps: T[Agg[Dep]] = T {
+  override def scalacPluginIvyDeps: T[Agg[Dep]] = Task {
     super.scalacPluginIvyDeps() ++ Agg(
       ivy"org.scala-native:::nscplugin:${scalaNativeVersion()}"
     )
   }
 
-  def logLevel: Target[NativeLogLevel] = T { NativeLogLevel.Info }
+  def logLevel: Target[NativeLogLevel] = Task { NativeLogLevel.Info }
 
   private def readEnvVariable[T](
       env: Map[String, String],
@@ -143,21 +143,21 @@ trait ScalaNativeModule extends ScalaModule { outer =>
     readEnvVariable[ReleaseMode](T.env, "SCALANATIVE_MODE", ReleaseMode.values, _.value)
   }
 
-  def releaseMode: Target[ReleaseMode] = T {
+  def releaseMode: Target[ReleaseMode] = Task {
     releaseModeInput().getOrElse(ReleaseMode.Debug)
   }
 
-  def nativeWorkdir = T { T.dest }
+  def nativeWorkdir = Task { T.dest }
 
   // Location of the clang compiler
-  def nativeClang = T {
+  def nativeClang = Task {
     os.Path(
       scalaNativeBridge().discoverClang()
     )
   }
 
   // Location of the clang++ compiler
-  def nativeClangPP = T {
+  def nativeClangPP = Task {
     os.Path(
       scalaNativeBridge().discoverClangPP()
     )
@@ -168,26 +168,26 @@ trait ScalaNativeModule extends ScalaModule { outer =>
     T.env.get("SCALANATIVE_GC")
   }
 
-  def nativeGC = T {
+  def nativeGC = Task {
     nativeGCInput().getOrElse(
       scalaNativeBridge().defaultGarbageCollector()
     )
   }
 
-  def nativeTarget: Target[Option[String]] = T { None }
+  def nativeTarget: Target[Option[String]] = Task { None }
 
   // Options that are passed to clang during compilation
-  def nativeCompileOptions = T {
+  def nativeCompileOptions = Task {
     scalaNativeBridge().discoverCompileOptions()
   }
 
   // Options that are passed to clang during linking
-  def nativeLinkingOptions = T {
+  def nativeLinkingOptions = Task {
     scalaNativeBridge().discoverLinkingOptions()
   }
 
   // Whether to link `@stub` methods, or ignore them
-  def nativeLinkStubs = T { false }
+  def nativeLinkStubs = Task { false }
 
   /**
    * Shall the resource files be embedded in the resulting binary file? Allows
@@ -195,30 +195,30 @@ trait ScalaNativeModule extends ScalaModule { outer =>
    *  not embed files with certain extensions, including ".c", ".h", ".scala"
    *  and ".class".
    */
-  def nativeEmbedResources = T { false }
+  def nativeEmbedResources = Task { false }
 
   /** Shall we use the incremental compilation? */
-  def nativeIncrementalCompilation = T { false }
+  def nativeIncrementalCompilation = Task { false }
 
   /** Shall linker dump intermediate NIR after every phase? */
-  def nativeDump = T { false }
+  def nativeDump = Task { false }
 
   // The LTO mode to use used during a release build
   protected def nativeLTOInput: Target[Option[LTO]] = T.input {
     readEnvVariable[LTO](T.env, "SCALANATIVE_LTO", LTO.values, _.value)
   }
 
-  def nativeLTO: Target[LTO] = T { nativeLTOInput().getOrElse(LTO.None) }
+  def nativeLTO: Target[LTO] = Task { nativeLTOInput().getOrElse(LTO.None) }
 
   // Shall we optimize the resulting NIR code?
   protected def nativeOptimizeInput: Target[Option[Boolean]] = T.input {
     readEnvVariable[Boolean](T.env, "SCALANATIVE_OPTIMIZE", Seq(true, false), _.toString)
   }
 
-  def nativeOptimize: Target[Boolean] = T { nativeOptimizeInput().getOrElse(true) }
+  def nativeOptimize: Target[Boolean] = Task { nativeOptimizeInput().getOrElse(true) }
 
   /** Build target for current compilation */
-  def nativeBuildTarget: Target[BuildTarget] = T { BuildTarget.Application }
+  def nativeBuildTarget: Target[BuildTarget] = Task { BuildTarget.Application }
 
   private def nativeConfig: Task[NativeConfig] = T.task {
     val classpath = runClasspath().map(_.path).filter(_.toIO.exists).toList
@@ -265,7 +265,7 @@ trait ScalaNativeModule extends ScalaModule { outer =>
     }
 
   // Generates native binary
-  def nativeLink = T {
+  def nativeLink = Task {
     os.Path(scalaNativeBridge().nativeLink(
       nativeConfig().config,
       T.dest.toIO
@@ -296,7 +296,7 @@ trait ScalaNativeModule extends ScalaModule { outer =>
     ))
   }
 
-  override def transitiveIvyDeps: T[Agg[BoundDep]] = T {
+  override def transitiveIvyDeps: T[Agg[BoundDep]] = Task {
 
     // Exclude cross published version dependencies leading to conflicts in Scala 3 vs 2.13
     // When using Scala 3 exclude Scala 2.13 standard native libraries,

--- a/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
+++ b/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
@@ -34,7 +34,7 @@ trait ScalaNativeModule extends ScalaModule { outer =>
   type ScalaNativeModuleTests = ScalaNativeTests
   trait ScalaNativeTests extends ScalaTests with TestScalaNativeModule {
     override def scalaNativeVersion = outer.scalaNativeVersion()
-    override def releaseMode = Task { outer.releaseMode() }
+    override def releaseMode: Target[ReleaseMode] = Task { outer.releaseMode() }
     override def logLevel: Target[NativeLogLevel] = outer.logLevel()
   }
 
@@ -85,7 +85,7 @@ trait ScalaNativeModule extends ScalaModule { outer =>
     ) ++ scalaVersionSpecific
   }
 
-  override def scalaLibraryIvyDeps = Task {
+  override def scalaLibraryIvyDeps: Target[Agg[Dep]] = Task {
     super.scalaLibraryIvyDeps().map(dep =>
       dep.copy(cross = dep.cross match {
         case c: CrossVersion.Constant => c.copy(platformed = false)
@@ -187,7 +187,7 @@ trait ScalaNativeModule extends ScalaModule { outer =>
   }
 
   // Whether to link `@stub` methods, or ignore them
-  def nativeLinkStubs = Task { false }
+  def nativeLinkStubs: Target[Boolean] = Task { false }
 
   /**
    * Shall the resource files be embedded in the resulting binary file? Allows
@@ -195,13 +195,13 @@ trait ScalaNativeModule extends ScalaModule { outer =>
    *  not embed files with certain extensions, including ".c", ".h", ".scala"
    *  and ".class".
    */
-  def nativeEmbedResources = Task { false }
+  def nativeEmbedResources: Target[Boolean] = Task { false }
 
   /** Shall we use the incremental compilation? */
-  def nativeIncrementalCompilation = Task { false }
+  def nativeIncrementalCompilation: Target[Boolean] = Task { false }
 
   /** Shall linker dump intermediate NIR after every phase? */
-  def nativeDump = Task { false }
+  def nativeDump: Target[Boolean] = Task { false }
 
   // The LTO mode to use used during a release build
   protected def nativeLTOInput: Target[Option[LTO]] = T.input {

--- a/scalanativelib/src/mill/scalanativelib/worker/ScalaNativeWorker.scala
+++ b/scalanativelib/src/mill/scalanativelib/worker/ScalaNativeWorker.scala
@@ -1,7 +1,7 @@
 package mill.scalanativelib.worker
 
 import mill.define.{Discover, Worker}
-import mill.{Agg, PathRef, T}
+import mill.{Agg, PathRef, Task}
 import mill.scalanativelib.worker.{api => workerApi}
 
 private[scalanativelib] class ScalaNativeWorker extends AutoCloseable {
@@ -41,6 +41,6 @@ private[scalanativelib] class ScalaNativeWorker extends AutoCloseable {
 }
 
 private[scalanativelib] object ScalaNativeWorkerExternalModule extends mill.define.ExternalModule {
-  def scalaNativeWorker: Worker[ScalaNativeWorker] = T.worker { new ScalaNativeWorker() }
+  def scalaNativeWorker: Worker[ScalaNativeWorker] = Task.worker { new ScalaNativeWorker() }
   lazy val millDiscover: Discover = Discover[this.type]
 }

--- a/scalanativelib/src/mill/scalanativelib/worker/ScalaNativeWorker.scala
+++ b/scalanativelib/src/mill/scalanativelib/worker/ScalaNativeWorker.scala
@@ -41,6 +41,6 @@ private[scalanativelib] class ScalaNativeWorker extends AutoCloseable {
 }
 
 private[scalanativelib] object ScalaNativeWorkerExternalModule extends mill.define.ExternalModule {
-  def scalaNativeWorker: Worker[ScalaNativeWorker] = Task.worker { new ScalaNativeWorker() }
+  def scalaNativeWorker: Worker[ScalaNativeWorker] = Task.Worker { new ScalaNativeWorker() }
   lazy val millDiscover: Discover = Discover[this.type]
 }

--- a/scalanativelib/test/src/mill/scalanativelib/HelloNativeWorldTests.scala
+++ b/scalanativelib/test/src/mill/scalanativelib/HelloNativeWorldTests.scala
@@ -48,7 +48,7 @@ object HelloNativeWorldTests extends TestSuite {
     trait RootModule extends HelloNativeWorldModule {
       override def artifactName = "hello-native-world"
       def scalaNativeVersion = sNativeVersion
-      def releaseMode = T { mode }
+      def releaseMode = Task { mode }
       def pomSettings = PomSettings(
         organization = "com.lihaoyi",
         description = "hello native world ready for real world publishing",

--- a/scalanativelib/test/src/mill/scalanativelib/HelloNativeWorldTests.scala
+++ b/scalanativelib/test/src/mill/scalanativelib/HelloNativeWorldTests.scala
@@ -60,7 +60,7 @@ object HelloNativeWorldTests extends TestSuite {
       )
 
       object test extends ScalaNativeTests with TestModule.Utest {
-        override def sources = T.sources { millSourcePath / "src/utest" }
+        override def sources = Task.Sources { millSourcePath / "src/utest" }
         override def ivyDeps = super.ivyDeps() ++ Agg(
           ivy"com.lihaoyi::utest::$utestVersion"
         )

--- a/testkit/test/resources/example-test-example-project/build.mill
+++ b/testkit/test/resources/example-test-example-project/build.mill
@@ -1,7 +1,7 @@
 package build
 import mill._
 
-def testSource = T.source(millSourcePath / "source-file.txt")
+def testSource = Task.Source(millSourcePath / "source-file.txt")
 def testTask = T { os.read(testSource().path).toUpperCase() }
 
 /** Usage

--- a/testkit/test/resources/integration-test-example-project/build.mill
+++ b/testkit/test/resources/integration-test-example-project/build.mill
@@ -1,5 +1,5 @@
 package build
 import mill._
 
-def testSource = T.source(millSourcePath / "source-file.txt")
+def testSource = Task.Source(millSourcePath / "source-file.txt")
 def testTask = T { os.read(testSource().path).toUpperCase() }

--- a/testkit/test/src/mill/testkit/UnitTesterTests.scala
+++ b/testkit/test/src/mill/testkit/UnitTesterTests.scala
@@ -9,7 +9,7 @@ object UnitTesterTests extends TestSuite {
   def tests: Tests = Tests {
     test("simple") {
       object build extends TestBaseModule {
-        def testTask = T { "test" }
+        def testTask = Task { "test" }
       }
 
       UnitTester(build, resourcePath).scoped { eval =>
@@ -21,7 +21,7 @@ object UnitTesterTests extends TestSuite {
     test("sources") {
       object build extends TestBaseModule {
         def testSource = T.source(millSourcePath / "source-file.txt")
-        def testTask = T { os.read(testSource().path).toUpperCase() }
+        def testTask = Task { os.read(testSource().path).toUpperCase() }
       }
 
       UnitTester(build, resourcePath).scoped { eval =>

--- a/testkit/test/src/mill/testkit/UnitTesterTests.scala
+++ b/testkit/test/src/mill/testkit/UnitTesterTests.scala
@@ -20,7 +20,7 @@ object UnitTesterTests extends TestSuite {
 
     test("sources") {
       object build extends TestBaseModule {
-        def testSource = T.source(millSourcePath / "source-file.txt")
+        def testSource = Task.Source(millSourcePath / "source-file.txt")
         def testTask = Task { os.read(testSource().path).toUpperCase() }
       }
 


### PR DESCRIPTION
Essentially a minimized binary-compatible version of https://github.com/com-lihaoyi/mill/pull/3356, renaming all the factory methods for various tasks to follow more standard naming conventions:

* `T {...}` ->  `Task {...}`
* `T.command {...}` ->  `Task.Command {...}`
* `T.input {...}` ->  `Task.Input {...}`
* `T.source {...}` ->  `Task.Source {...}`
* `T.sources {...}` ->  `Task.Sources {...}`
* `T.persistent {...}` ->  `Task.Persistent {...}`
* `T.task {...}` ->  `Task.Anon {...}`

The type `T[_]` remains an alias for `Target[_]`, and `Task{ ... }` returns a `T[_]`, to maintain binary compatibility. Not quite ideal but can probably be hand-waved away until Mill 0.13.0 when we are allowed to break binary compatibility. 

All the `T.*` operations have been duplicated to `Task.*` by sharing them via a `trait TargetBase`, except the factory methods which were copied over and upper-cased while the old version deprecated. I have updated all the code and examples to use `Task` instead of `T` where relevant. The only exceptions are the `implicit def apply`s which needed to be manually copied without the `implicit` (otherwise the multiple implicits cause ambiguity).

This gets us most of the user-facing benefits of https://github.com/com-lihaoyi/mill/pull/3356 without the bin-compat breakage: users no longer see an odd `T { ... }` syntax in the docs and in their build files, and now see `Task { ... }` which should be much more familiar. Although it does not allow us to do the type-hierarchy cleanups that the other PR provides, it's still worth doing so we can get it in in 0.12.0

The old `T { ... }` and `T.*` syntaxes should continue to work, and are exercised via the bootstrap tests as they continue to be used in Mill's own build. This PR should be source compatible to avoid migration pains, and given the prevalence of `T` everywhere we probably should just support it forever