### PR TITLE
Fix BSP target capabilities

### DIFF
--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -586,7 +586,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
   override def bspBuildTarget: BspBuildTarget = super.bspBuildTarget.copy(
     languageIds = Seq(BspModule.LanguageId.Java, BspModule.LanguageId.Scala),
     canCompile = true,
-    canRun = true
+    canRun = !super.bspBuildTarget.canTest
   )
 
   @internal

--- a/scalalib/src/mill/scalalib/TestModule.scala
+++ b/scalalib/src/mill/scalalib/TestModule.scala
@@ -280,6 +280,7 @@ trait TestModule
     val parent = super.bspBuildTarget
     parent.copy(
       canTest = true,
+      canRun = false,
       tags = Seq(BspModule.Tag.Test)
     )
   }


### PR DESCRIPTION
Context: I'm working on integrating Mill over the new BSP plugin (I created a pull request with more detail a few weeks ago here: https://github.com/com-lihaoyi/mill/pull/3432)

I encountered an issue where there were to many options of actions that could be performed on a certain testing module. Namely, there was a redundant run capability. On the first screenshot there is the option menu before my changes and on the second after them.

The visual aspect of this fix is nice but not the most important one. Without this fix, the testing via BSP does not work at all - the BSP plugin, even after triggering the `Test` button, launches `Run` action instead of the `Test` action if the module's `canRun` capability is set to true.

<img width="1303" alt="image" src="https://github.com/user-attachments/assets/3afb314a-ce18-4a15-9878-89cc8f17bb7e">

<img width="1168" alt="image" src="https://github.com/user-attachments/assets/b0fd3303-a2e8-4b64-9853-3d2cb11e1ee9">

