### PR TITLE
Show workers in resolve / show / inspect too

### DIFF
--- a/integration/feature/docannotations/resources/build.mill
+++ b/integration/feature/docannotations/resources/build.mill
@@ -11,13 +11,27 @@ trait JUnitTests extends TestModule.Junit4 {
   def task = Task {
     "???"
   }
+
+  /**
+   * *The worker*
+   */
+  def theWorker = Task.Worker {
+    ()
+  }
 }
 
 /**
  * The Core Module Docz!
  */
 object core extends JavaModule {
-  object test extends JavaTests with JUnitTests
+  object test extends JavaTests with JUnitTests {
+    /**
+     * -> The worker <-
+     */
+    def theWorker = Task.Worker {
+      ()
+    }
+  }
 
   /**
    * Core Target Docz!

--- a/integration/feature/docannotations/src/DocAnnotationsTests.scala
+++ b/integration/feature/docannotations/src/DocAnnotationsTests.scala
@@ -113,6 +113,22 @@ object DocAnnotationsTests extends UtestIntegrationTestSuite {
         )
       )
 
+      assert(eval(("inspect", "core.test.theWorker")).isSuccess)
+      val theWorkerInspect = out("inspect").json.str
+
+      assert(
+        globMatches(
+          """core.test.theWorker(build.mill:...)
+            |    -> The worker <-
+            |
+            |    *The worker*
+            |
+            |Inputs:
+            |""".stripMargin,
+          theWorkerInspect
+        )
+      )
+
       // Make sure both kebab-case and camelCase flags work, even though the
       // docs from `inspect` only show the kebab-case version
       assert(eval(("core.ivyDepsTree", "--withCompile", "--withRuntime")).isSuccess)

--- a/main/eval/src/mill/eval/GroupEvaluator.scala
+++ b/main/eval/src/mill/eval/GroupEvaluator.scala
@@ -364,28 +364,27 @@ private[mill] trait GroupEvaluator {
       inputsHash: Int,
       labelled: Terminal.Labelled[_]
   ): Unit = {
-    labelled.task.asWorker match {
-      case Some(w) =>
-        workerCache.synchronized {
-          workerCache.update(w.ctx.segments, (workerCacheHash(inputsHash), v))
-        }
-      case None =>
-        val terminalResult = labelled
-          .task
-          .writerOpt
-          .asInstanceOf[Option[upickle.default.Writer[Any]]]
-          .map { w => upickle.default.writeJs(v.value)(w) }
+    for (w <- labelled.task.asWorker)
+      workerCache.synchronized {
+        workerCache.update(w.ctx.segments, (workerCacheHash(inputsHash), v))
+      }
 
-        for (json <- terminalResult) {
-          os.write.over(
-            metaPath,
-            upickle.default.stream(
-              Evaluator.Cached(json, hashCode, inputsHash),
-              indent = 4
-            ),
-            createFolders = true
-          )
-        }
+    val terminalResult = labelled
+      .task
+      .writerOpt
+      .map { w =>
+        upickle.default.writeJs(v.value)(w.asInstanceOf[upickle.default.Writer[Any]])
+      }
+
+    for (json <- terminalResult) {
+      os.write.over(
+        metaPath,
+        upickle.default.stream(
+          Evaluator.Cached(json, hashCode, inputsHash),
+          indent = 4
+        ),
+        createFolders = true
+      )
     }
   }
 

--- a/main/eval/src/mill/eval/GroupEvaluator.scala
+++ b/main/eval/src/mill/eval/GroupEvaluator.scala
@@ -375,6 +375,15 @@ private[mill] trait GroupEvaluator {
       .map { w =>
         upickle.default.writeJs(v.value)(w.asInstanceOf[upickle.default.Writer[Any]])
       }
+      .orElse {
+        labelled.task.asWorker.map { w =>
+          ujson.Obj(
+            "worker" -> ujson.Str(labelled.segments.render),
+            "toString" -> ujson.Str(v.value.toString),
+            "inputsHash" -> ujson.Num(inputsHash)
+          )
+        }
+      }
 
     for (json <- terminalResult) {
       os.write.over(

--- a/main/resolve/src/mill/resolve/Resolve.scala
+++ b/main/resolve/src/mill/resolve/Resolve.scala
@@ -41,10 +41,10 @@ object Resolve {
         allowPositionalCommandArgs: Boolean
     ) = {
       val taskList = resolved.map {
-        case r: Resolved.Target =>
+        case r: Resolved.NamedTask =>
           val instantiated = ResolveCore
             .instantiateModule(rootModule, r.segments.init)
-            .flatMap(instantiateTarget(r, _))
+            .flatMap(instantiateNamedTask(r, _))
 
           instantiated.map(Some(_))
 
@@ -76,7 +76,7 @@ object Resolve {
 
               directChildrenOrErr.flatMap(directChildren =>
                 directChildren.head match {
-                  case r: Resolved.Target => instantiateTarget(r, value).map(Some(_))
+                  case r: Resolved.NamedTask => instantiateNamedTask(r, value).map(Some(_))
                   case r: Resolved.Command =>
                     instantiateCommand(
                       rootModule,
@@ -104,13 +104,16 @@ object Resolve {
       items.distinctBy(_.ctx.segments)
   }
 
-  private def instantiateTarget(r: Resolved.Target, p: Module): Either[String, Target[_]] = {
+  private def instantiateNamedTask(
+      r: Resolved.NamedTask,
+      p: Module
+  ): Either[String, NamedTask[_]] = {
     val definition = Reflect
-      .reflect(p.getClass, classOf[Target[_]], _ == r.segments.parts.last, true)
+      .reflect(p.getClass, classOf[NamedTask[_]], _ == r.segments.parts.last, true)
       .head
 
     ResolveCore.catchWrapException(
-      definition.invoke(p).asInstanceOf[Target[_]]
+      definition.invoke(p).asInstanceOf[NamedTask[_]]
     )
   }
 

--- a/main/resolve/src/mill/resolve/ResolveCore.scala
+++ b/main/resolve/src/mill/resolve/ResolveCore.scala
@@ -29,7 +29,7 @@ private object ResolveCore {
 
   object Resolved {
     case class Module(segments: Segments, cls: Class[_]) extends Resolved
-    case class Target(segments: Segments) extends Resolved
+    case class NamedTask(segments: Segments) extends Resolved
     case class Command(segments: Segments) extends Resolved
   }
 
@@ -327,7 +327,7 @@ private object ResolveCore {
         .map(
           _.map {
             case (Resolved.Module(s, cls), _) => Resolved.Module(segments ++ s, cls)
-            case (Resolved.Target(s), _) => Resolved.Target(segments ++ s)
+            case (Resolved.NamedTask(s), _) => Resolved.NamedTask(segments ++ s)
             case (Resolved.Command(s), _) => Resolved.Command(segments ++ s)
           }
             .toSet
@@ -376,10 +376,10 @@ private object ResolveCore {
       }
     }
 
-    val targets = Reflect
-      .reflect(cls, classOf[Target[_]], namePred, noParams = true)
+    val namedTasks = Reflect
+      .reflect(cls, classOf[NamedTask[_]], namePred, noParams = true)
       .map { m =>
-        Resolved.Target(Segments.labels(decode(m.getName))) ->
+        Resolved.NamedTask(Segments.labels(decode(m.getName))) ->
           None
       }
 
@@ -388,7 +388,7 @@ private object ResolveCore {
       .map(m => decode(m.getName))
       .map { name => Resolved.Command(Segments.labels(name)) -> None }
 
-    modulesOrErr.map(_ ++ targets ++ commands)
+    modulesOrErr.map(_ ++ namedTasks ++ commands)
   }
 
   def notFoundResult(

--- a/main/src/mill/main/RunScript.scala
+++ b/main/src/mill/main/RunScript.scala
@@ -62,7 +62,7 @@ object RunScript {
       case 0 =>
         val nameAndJson = for (t <- targets.toSeq) yield {
           t match {
-            case t: mill.define.NamedTask[_] =>
+            case t: mill.define.NamedTask[_] if t.writerOpt.isDefined || t.asWorker.isDefined =>
               val jsonFile = EvaluatorPaths.resolveDestPaths(evaluator.outPath, t).meta
               val metadata = upickle.default.read[Evaluator.Cached](ujson.read(jsonFile.toIO))
               Some((t.toString, metadata.value))

--- a/main/src/mill/main/RunScript.scala
+++ b/main/src/mill/main/RunScript.scala
@@ -62,7 +62,7 @@ object RunScript {
       case 0 =>
         val nameAndJson = for (t <- targets.toSeq) yield {
           t match {
-            case t: mill.define.NamedTask[_] if t.writerOpt.isDefined || t.asWorker.isDefined =>
+            case t: mill.define.NamedTask[_] =>
               val jsonFile = EvaluatorPaths.resolveDestPaths(evaluator.outPath, t).meta
               val metadata = upickle.default.read[Evaluator.Cached](ujson.read(jsonFile.toIO))
               Some((t.toString, metadata.value))


### PR DESCRIPTION
This PR generalizes some `Target`-related stuff in `Resolve` to all `NamedTask`s with no arguments (targets and workers), and makes sure `resolve` / `show` / `inspect` work fine with workers. In particular, running `show` on a worker now prints something like
```json
{
  "worker": "foo.theWorker",
  "toString": "build_.package_$foo$$anon$1@4acbdb44",
  "inputsHash": -2075822978
}
```