### PR TITLE
Disable flaky mockito unit test

### DIFF
--- a/example/thirdparty/mockito/build.mill
+++ b/example/thirdparty/mockito/build.mill
@@ -264,6 +264,8 @@ object `package` extends RootModule with MockitoModule{
 // but only running the subset of tests that run quickly
 /** Usage
 
+> sed -i.bak 's/assertEquals(50, settings.getStubbingLookupListeners().size())//g' src/test/java/org/mockitousage/debugging/StubbingLookupListenerCallbackTest.java # disable flaky test
+
 > ./mill -j5 __.compile
 
 > ./mill __.test


### PR DESCRIPTION
It's known to be flaky upstream, no sense suffering the flakes ourselves when there's nothing we can do https://github.com/mockito/mockito/blob/1e337ed703ce2b78ce9ea40ff8b8c645f8219cf2/src/test/java/org/mockitousage/debugging/StubbingLookupListenerCallbackTest.java#L200-L201