### PR TITLE
add -sourceroot flag when generating semanticdb with scala 3

### DIFF
--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -629,7 +629,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
       allScalacOptions() ++
         semanticDbEnablePluginScalacOptions() ++ {
           if (ZincWorkerUtil.isScala3(sv)) {
-            Seq("-Xsemanticdb")
+            Seq("-Xsemanticdb", s"-sourceroot:${T.workspace}")
           } else {
             Seq(
               "-Yrangepos",


### PR DESCRIPTION
while developing Scala 3 port, when using metals as the BSP server then semanticdb files are generated in the same folder as the source file.

With this change, and setting the bootstrapped mill version for BSP server, metals no longer puts semanticdb in the same directory, but instead in `out/../semanticdbData.dest/classes/META-INF/semanticdb/...`