### PR TITLE
Update Discord Invite link

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-Please don't open issues for questions, but ask in our Discussions forum at https://github.com/com-lihaoyi/mill/discussions or Discord channel at https://discord.gg/mMVxRMZc
+Please don't open issues for questions, but ask in our Discussions forum at https://github.com/com-lihaoyi/mill/discussions or Discord channel at https://discord.gg/MNAXQMAr
 
 Mill installations via `coursier` or `cs` are unsupported.
 

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -1,6 +1,6 @@
 = Contributing to Mill
 :link-github: https://github.com/com-lihaoyi/mill
-:link-chat: https://discord.gg/mMVxRMZc
+:link-chat: https://discord.gg/MNAXQMAr
 
 Thank you for considering contributing to Mill.
 

--- a/docs/supplemental-ui/partials/header-content.hbs
+++ b/docs/supplemental-ui/partials/header-content.hbs
@@ -20,7 +20,7 @@
         <a class="navbar-item" href="{{{or site.url (or siteRootUrl siteRootPath)}}}/api/latest/index.html">API</a>
         <a class="navbar-item" href="https://github.com/com-lihaoyi/mill/issues">Issues</a>
         <a class="navbar-item" href="https://github.com/com-lihaoyi/mill/discussions">Discuss</a>
-        <a class="navbar-item" href="https://discord.gg/mMVxRMZc">Chat</a>
+        <a class="navbar-item" href="https://discord.gg/MNAXQMAr">Chat</a>
 
             <!--
         <a class="navbar-item" href="#">Home</a>

--- a/example/scalalib/basic/4-builtin-commands/build.mill
+++ b/example/scalalib/basic/4-builtin-commands/build.mill
@@ -366,6 +366,6 @@ foo.compileClasspath
 //
 // ---
 //
-// Come by our https://discord.gg/mMVxRMZc[Discord Channel]
+// Come by our https://discord.gg/MNAXQMAr[Discord Channel]
 // if you want to ask questions or say hi!
 //


### PR DESCRIPTION
Replaced with a never expiring link, again.

![grafik](https://github.com/user-attachments/assets/1d70b6f3-f779-45b1-8bf0-4895defc8bf7)

Fix https://github.com/com-lihaoyi/mill/issues/3590