### PR TITLE
Remove unused env var in examples forkEnv

### DIFF
--- a/example/package.mill
+++ b/example/package.mill
@@ -164,7 +164,6 @@ object `package` extends RootModule with Module {
     def localRunClasspath = build.testkit.localRunClasspath()
 
     def forkEnv = Map(
-      "MILL_EXAMPLE_PARSED" -> upickle.default.write(parsed()),
       "LANG" -> "C"
     )
 


### PR DESCRIPTION
Stumbled upon it when diving in the examples internals. It seems to me that this env var is unused (can't find it anywhere else by grepping the whole codebase).