### PR TITLE
Use coursier thread pool to run coursier-related task

### DIFF
--- a/scalalib/src/mill/scalalib/CoursierModule.scala
+++ b/scalalib/src/mill/scalalib/CoursierModule.scala
@@ -73,9 +73,9 @@ trait CoursierModule extends mill.Module {
    * The repositories used to resolved dependencies with [[resolveDeps()]].
    */
   def repositoriesTask: Task[Seq[Repository]] = Task.Anon {
-    import scala.concurrent.ExecutionContext.Implicits.global
+    val resolve = Resolve()
     val repos = Await.result(
-      Resolve().finalRepositories.future(),
+      resolve.finalRepositories.future()(resolve.cache.ec),
       Duration.Inf
     )
     repos


### PR DESCRIPTION
Using the default global `ExecutionContext`, also used by the BSP server, can lead to deadlocks, as coursier doesn't mark blocking things with `blocking`. (It deadlocks locally for me, during Mill import via BSP in IntelliJ, with 4 threads being spawned and awaiting in the default `ExecutionContext`.)