### PR TITLE
Favor -SNAPSHOT version when publishing Mill locally

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -219,7 +219,32 @@ object Deps {
   }
 }
 
-def millVersion: T[String] = T { VcsVersion.vcsState().format() }
+def millVersion: T[String] = T {
+  val vcsVersion = VcsVersion.vcsState().format()
+  val isCI = System.getenv("CI") != null
+  if (!isCI && (vcsVersion.contains("DIRTY") || vcsVersion.count(_ == '-') >= 2)) {
+    // vcsVersion looks like "0.11.11-6-49d084-DIRTYa0693949", we only keep
+    // the "0.11.11" part here
+    val baseVersion = vcsVersion.takeWhile(_ != '-')
+    val lastDotIndex = baseVersion.lastIndexOf('.')
+    if (lastDotIndex < 0)
+      // unexpected shape, keeping vcsVersion
+      vcsVersion
+    else {
+      val patchVersionOpt = baseVersion.substring(lastDotIndex + 1).toIntOption
+      patchVersionOpt match {
+        case None =>
+          // unexpected shape, keeping vcsVersion
+          vcsVersion
+        case Some(patchVersion) =>
+          val base = baseVersion.substring(0, lastDotIndex)
+          s"$base.${patchVersion + 1}-SNAPSHOT"
+      }
+    }
+  }
+  else
+    vcsVersion
+}
 
 def millLastTag: T[String] = T {
   VcsVersion.vcsState().lastTag.getOrElse(


### PR DESCRIPTION
This makes the millVersion task return a more stable value during local development (the version on CI doesn't change on the other hand). That value ends up in BuildInfo files, so having it not change prevents it trigerring re-compilations.

Without this change, adding files to the staging area, committing things, or sometimes just creating new files, was changing the millVersion, and as a consequence trigerring a re-compilation of many things.