### PR TITLE
Introduce `Task.Command(exclusive = true)` and convert `Task.Persistent` to `Task(persistent = true)`

### DIFF
--- a/contrib/playlib/src/mill/playlib/RouterModule.scala
+++ b/contrib/playlib/src/mill/playlib/RouterModule.scala
@@ -60,7 +60,7 @@ trait RouterModule extends ScalaModule with Version {
 
   protected val routeCompilerWorker: RouteCompilerWorkerModule = RouteCompilerWorkerModule
 
-  def compileRouter: T[CompilationResult] = Task.Persistent {
+  def compileRouter: T[CompilationResult] = Task(persistent = true) {
     T.log.debug(s"compiling play routes with ${playVersion()} worker")
     routeCompilerWorker.routeCompilerWorker().compile(
       routerClasspath = playRouterToolsClasspath(),

--- a/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBModule.scala
+++ b/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBModule.scala
@@ -126,7 +126,7 @@ trait ScalaPBModule extends ScalaModule {
     )
   }
 
-  def compileScalaPB: T[PathRef] = Task.Persistent {
+  def compileScalaPB: T[PathRef] = Task(persistent = true) {
     ScalaPBWorkerApi.scalaPBWorker()
       .compile(
         scalaPBClasspath(),

--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
@@ -146,7 +146,7 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
      * The persistent data dir used to store scoverage coverage data.
      * Use to store coverage data at compile-time and by the various report targets.
      */
-    def data: T[PathRef] = Task.Persistent {
+    def data: T[PathRef] = Task(persistent = true) {
       // via the persistent target, we ensure, the dest dir doesn't get cleared
       PathRef(T.dest)
     }

--- a/contrib/twirllib/src/mill/twirllib/TwirlModule.scala
+++ b/contrib/twirllib/src/mill/twirllib/TwirlModule.scala
@@ -88,7 +88,7 @@ trait TwirlModule extends mill.Module { twirlModule =>
 
   def twirlInclusiveDot: Boolean = false
 
-  def compileTwirl: T[mill.scalalib.api.CompilationResult] = Task.Persistent {
+  def compileTwirl: T[mill.scalalib.api.CompilationResult] = Task(persistent = true) {
     TwirlWorkerApi.twirlWorker
       .compile(
         twirlClasspath(),

--- a/example/depth/tasks/5-persistent-targets/build.mill
+++ b/example/depth/tasks/5-persistent-targets/build.mill
@@ -12,7 +12,7 @@ import java.util.zip.GZIPOutputStream
 
 def data = Task.Source(millSourcePath / "data")
 
-def compressedData = Task.Persistent{
+def compressedData = Task(persistent = true) {
   println("Evaluating compressedData")
   os.makeDir.all(Task.dest / "cache")
   os.remove.all(Task.dest / "compressed")

--- a/main/define/src/mill/define/NamedParameterOnlyDummy.scala
+++ b/main/define/src/mill/define/NamedParameterOnlyDummy.scala
@@ -3,4 +3,4 @@ package mill.define
 /**
  * Dummy class used to mark parameters that come after it as named only parameters
  */
-object NamedParameterOnlyDummy
+class NamedParameterOnlyDummy private[mill] ()

--- a/main/define/src/mill/define/NamedParameterOnlyDummy.scala
+++ b/main/define/src/mill/define/NamedParameterOnlyDummy.scala
@@ -1,0 +1,6 @@
+package mill.define
+
+/**
+ * Dummy class used to mark parameters that come after it as named only parameters
+ */
+object NamedParameterOnlyDummy

--- a/main/define/src/mill/define/Task.scala
+++ b/main/define/src/mill/define/Task.scala
@@ -579,7 +579,7 @@ object Target extends TaskBase {
           w.splice,
           cls.splice.value,
           taskIsPrivate.splice,
-          serial = c.prefix.splice.asInstanceOf[Task.CommandFactory].exclusive
+          exclusive = c.prefix.splice.asInstanceOf[Task.CommandFactory].exclusive
         )
       )
     }
@@ -762,7 +762,7 @@ class Command[+T](
     val writer: W[_],
     val cls: Class[_],
     val isPrivate: Option[Boolean],
-    val serial: Boolean
+    val exclusive: Boolean
 ) extends NamedTask[T] {
   def this(
       t: Task[T],

--- a/main/define/src/mill/define/Task.scala
+++ b/main/define/src/mill/define/Task.scala
@@ -107,10 +107,10 @@ object Task extends TaskBase {
   ): Command[T] = macro Target.Internal.commandImpl[T]
 
   def Command(
-      t: NamedParameterOnlyDummy.type = NamedParameterOnlyDummy,
-      serial: Boolean = false
-  ): CommandFactory = new CommandFactory(serial)
-  class CommandFactory private[mill] (val serial: Boolean) extends TaskBase.TraverseCtxHolder {
+               t: NamedParameterOnlyDummy.type = NamedParameterOnlyDummy,
+               exclusive: Boolean = false
+  ): CommandFactory = new CommandFactory(exclusive)
+  class CommandFactory private[mill] (val exclusive: Boolean) extends TaskBase.TraverseCtxHolder {
     def apply[T](t: Result[T])(implicit
         w: W[T],
         ctx: mill.define.Ctx,
@@ -579,7 +579,7 @@ object Target extends TaskBase {
           w.splice,
           cls.splice.value,
           taskIsPrivate.splice,
-          serial = c.prefix.splice.asInstanceOf[Task.CommandFactory].serial
+          serial = c.prefix.splice.asInstanceOf[Task.CommandFactory].exclusive
         )
       )
     }

--- a/main/define/src/mill/define/Task.scala
+++ b/main/define/src/mill/define/Task.scala
@@ -107,8 +107,8 @@ object Task extends TaskBase {
   ): Command[T] = macro Target.Internal.commandImpl[T]
 
   def Command(
-               t: NamedParameterOnlyDummy.type = NamedParameterOnlyDummy,
-               exclusive: Boolean = false
+      t: NamedParameterOnlyDummy = new NamedParameterOnlyDummy,
+      exclusive: Boolean = false
   ): CommandFactory = new CommandFactory(exclusive)
   class CommandFactory private[mill] (val exclusive: Boolean) extends TaskBase.TraverseCtxHolder {
     def apply[T](t: Result[T])(implicit
@@ -170,7 +170,7 @@ object Task extends TaskBase {
    * Violating that invariant can result in confusing mis-behaviors
    */
   def apply(
-      t: NamedParameterOnlyDummy.type = NamedParameterOnlyDummy,
+      t: NamedParameterOnlyDummy = new NamedParameterOnlyDummy,
       persistent: Boolean = false
   ): ApplyFactory = new ApplyFactory(persistent)
   class ApplyFactory private[mill] (val persistent: Boolean) extends TaskBase.TraverseCtxHolder {

--- a/main/define/test/src/mill/define/MacroErrorTests.scala
+++ b/main/define/test/src/mill/define/MacroErrorTests.scala
@@ -69,7 +69,7 @@ object MacroErrorTests extends TestSuite {
       test("persistent") {
         val e = compileError("""
           object foo extends TestBaseModule{
-            def a() = Task.Persistent{1}
+            def a() = Task(persistent = true){1}
           }
           mill.define.Discover[foo.type]
         """)

--- a/main/eval/src/mill/eval/EvaluatorCore.scala
+++ b/main/eval/src/mill/eval/EvaluatorCore.scala
@@ -184,7 +184,7 @@ private[mill] trait EvaluatorCore extends GroupEvaluator {
       case Terminal.Labelled(t, _) =>
         if (tasksTransitive.contains(t)) true
         else t match {
-          case t: Command[_] => t.parallelizable
+          case t: Command[_] => !t.serial
           case _ => false
         }
       case _ => !serialCommandExec

--- a/main/eval/src/mill/eval/EvaluatorCore.scala
+++ b/main/eval/src/mill/eval/EvaluatorCore.scala
@@ -180,8 +180,13 @@ private[mill] trait EvaluatorCore extends GroupEvaluator {
     val (_, tasksTransitive0) = Plan.plan(Agg.from(tasks0.map(_.task)))
 
     val tasksTransitive = tasksTransitive0.toSet
-    val (tasks, leafCommands) = terminals0.partition {
-      case Terminal.Labelled(t, _) if tasksTransitive.contains(t) => true
+    val (tasks, leafSerialCommands) = terminals0.partition {
+      case Terminal.Labelled(t, _) =>
+        if (tasksTransitive.contains(t)) true
+        else t match {
+          case t: Command[_] => t.parallelizable
+          case _ => false
+        }
       case _ => !serialCommandExec
     }
 
@@ -194,7 +199,7 @@ private[mill] trait EvaluatorCore extends GroupEvaluator {
       if (sys.env.contains(EnvVars.MILL_TEST_SUITE)) _ => ""
       else contextLoggerMsg0
     )(ec)
-    evaluateTerminals(leafCommands, _ => "")(ExecutionContexts.RunNow)
+    evaluateTerminals(leafSerialCommands, _ => "")(ExecutionContexts.RunNow)
 
     logger.clearAllTickers()
     val finishedOptsMap = terminals0

--- a/main/eval/src/mill/eval/EvaluatorCore.scala
+++ b/main/eval/src/mill/eval/EvaluatorCore.scala
@@ -184,7 +184,7 @@ private[mill] trait EvaluatorCore extends GroupEvaluator {
       case Terminal.Labelled(t, _) =>
         if (tasksTransitive.contains(t)) true
         else t match {
-          case t: Command[_] => !t.serial
+          case t: Command[_] => !t.exclusive
           case _ => false
         }
       case _ => !serialCommandExec

--- a/main/eval/src/mill/eval/Terminal.scala
+++ b/main/eval/src/mill/eval/Terminal.scala
@@ -5,7 +5,7 @@ import mill.define.{NamedTask, Segment, Segments}
 /**
  * A terminal or terminal target is some important work unit, that in most cases has a name (Right[Labelled])
  * or was directly called by the user (Left[Task]).
- * It's a T, Task.Worker, Task.Input, Task.Source, Task.Sources, Task.Persistent
+ * It's a Task, Task.Worker, Task.Input, Task.Source, Task.Sources, Task.Command
  */
 sealed trait Terminal {
   def render: String

--- a/main/eval/test/src/mill/eval/TaskTests.scala
+++ b/main/eval/test/src/mill/eval/TaskTests.scala
@@ -70,7 +70,7 @@ trait TaskTests extends TestSuite {
     def taskInput = Task { input() }
     def taskNoInput = Task { task() }
 
-    def persistent = Task.Persistent {
+    def persistent = Task(persistent = true) {
       input() // force re-computation
       os.makeDir.all(T.dest)
       os.write.append(T.dest / "count", "hello\n")

--- a/main/src/mill/main/MainModule.scala
+++ b/main/src/mill/main/MainModule.scala
@@ -69,7 +69,7 @@ trait MainModule extends BaseModule0 {
   /**
    * Show the mill version.
    */
-  def version(): Command[String] = Target.command {
+  def version(): Command[String] = Task.Command(serial = true) {
     val res = BuildInfo.millVersion
     Task.log.withPromptPaused {
       println(res)
@@ -80,39 +80,41 @@ trait MainModule extends BaseModule0 {
   /**
    * Resolves a mill query string and prints out the tasks it resolves to.
    */
-  def resolve(evaluator: Evaluator, targets: String*): Command[List[String]] = Target.command {
-    val resolved = Resolve.Segments.resolve(
-      evaluator.rootModule,
-      targets,
-      SelectMode.Multi
-    )
+  def resolve(evaluator: Evaluator, targets: String*): Command[List[String]] =
+    Task.Command(serial = true) {
+      val resolved = Resolve.Segments.resolve(
+        evaluator.rootModule,
+        targets,
+        SelectMode.Multi
+      )
 
-    resolved match {
-      case Left(err) => Result.Failure(err)
-      case Right(resolvedSegmentsList) =>
-        val resolvedStrings = resolvedSegmentsList.map(_.render)
-        Task.log.withPromptPaused {
-          resolvedStrings.sorted.foreach(println)
-        }
-        Result.Success(resolvedStrings)
+      resolved match {
+        case Left(err) => Result.Failure(err)
+        case Right(resolvedSegmentsList) =>
+          val resolvedStrings = resolvedSegmentsList.map(_.render)
+          Task.log.withPromptPaused {
+            resolvedStrings.sorted.foreach(println)
+          }
+          Result.Success(resolvedStrings)
+      }
     }
-  }
 
   /**
    * Given a set of tasks, prints out the execution plan of what tasks will be
    * executed in what order, without actually executing them.
    */
-  def plan(evaluator: Evaluator, targets: String*): Command[Array[String]] = Target.command {
-    plan0(evaluator, targets) match {
-      case Left(err) => Result.Failure(err)
-      case Right(success) =>
-        val renderedTasks = success.map(_.segments.render)
-        Task.log.withPromptPaused {
-          renderedTasks.foreach(println)
-        }
-        Result.Success(renderedTasks)
+  def plan(evaluator: Evaluator, targets: String*): Command[Array[String]] =
+    Task.Command(serial = true) {
+      plan0(evaluator, targets) match {
+        case Left(err) => Result.Failure(err)
+        case Right(success) =>
+          val renderedTasks = success.map(_.segments.render)
+          Task.log.withPromptPaused {
+            renderedTasks.foreach(println)
+          }
+          Result.Success(renderedTasks)
+      }
     }
-  }
 
   private def plan0(evaluator: Evaluator, targets: Seq[String]) = {
     Resolve.Tasks.resolve(
@@ -139,7 +141,7 @@ trait MainModule extends BaseModule0 {
       @mainargs.arg(positional = true) src: String,
       @mainargs.arg(positional = true) dest: String
   ): Command[List[String]] =
-    Target.command {
+    Task.Command(serial = true) {
       val resolved = Resolve.Tasks.resolve(
         evaluator.rootModule,
         List(src, dest),
@@ -183,216 +185,222 @@ trait MainModule extends BaseModule0 {
   /**
    * Displays metadata about the given task without actually running it.
    */
-  def inspect(evaluator: Evaluator, targets: String*): Command[String] = Target.command {
+  def inspect(evaluator: Evaluator, targets: String*): Command[String] =
+    Task.Command(serial = true) {
 
-    def resolveParents(c: Class[_]): Seq[Class[_]] = {
-      Seq(c) ++ Option(c.getSuperclass).toSeq.flatMap(resolveParents) ++ c.getInterfaces.flatMap(
-        resolveParents
-      )
-    }
-    def pprintTask(t: NamedTask[_], evaluator: Evaluator): Tree.Lazy = {
-      val seen = mutable.Set.empty[Task[_]]
+      def resolveParents(c: Class[_]): Seq[Class[_]] = {
+        Seq(c) ++ Option(c.getSuperclass).toSeq.flatMap(resolveParents) ++ c.getInterfaces.flatMap(
+          resolveParents
+        )
+      }
+      def pprintTask(t: NamedTask[_], evaluator: Evaluator): Tree.Lazy = {
+        val seen = mutable.Set.empty[Task[_]]
 
-      def rec(t: Task[_]): Seq[Segments] = {
-        if (seen(t)) Nil // do nothing
-        else t match {
-          case t: mill.define.Target[_]
-              if evaluator.rootModule.millInternal.targets.contains(t) =>
-            Seq(t.ctx.segments)
-          case _ =>
-            seen.add(t)
-            t.inputs.flatMap(rec)
+        def rec(t: Task[_]): Seq[Segments] = {
+          if (seen(t)) Nil // do nothing
+          else t match {
+            case t: mill.define.Target[_]
+                if evaluator.rootModule.millInternal.targets.contains(t) =>
+              Seq(t.ctx.segments)
+            case _ =>
+              seen.add(t)
+              t.inputs.flatMap(rec)
+          }
+        }
+
+        val annots = for {
+          c <- resolveParents(t.ctx.enclosingCls)
+          m <- c.getMethods
+          if m.getName == t.ctx.segment.pathSegments.head
+          a = m.getAnnotation(classOf[mill.moduledefs.Scaladoc])
+          if a != null
+        } yield a
+
+        val allDocs =
+          for (a <- annots.distinct)
+            yield mill.util.Util.cleanupScaladoc(a.value).map("\n    " + _).mkString
+
+        pprint.Tree.Lazy { ctx =>
+          val mainMethodSig =
+            if (t.asCommand.isEmpty) List()
+            else {
+              val mainDataOpt = evaluator
+                .rootModule
+                .millDiscover
+                .value
+                .get(t.ctx.enclosingCls)
+                .flatMap(_._2.find(_.name == t.ctx.segments.parts.last))
+                .headOption
+
+              mainDataOpt match {
+                case Some(mainData) if mainData.renderedArgSigs.nonEmpty =>
+                  val rendered = mainargs.Renderer.formatMainMethodSignature(
+                    mainDataOpt.get,
+                    leftIndent = 2,
+                    totalWidth = 100,
+                    leftColWidth = mainargs.Renderer.getLeftColWidth(mainData.renderedArgSigs),
+                    docsOnNewLine = false,
+                    customName = None,
+                    customDoc = None,
+                    sorted = true
+                  )
+
+                  // trim first line containing command name, since we already render
+                  // the command name below with the filename and line num
+                  val trimmedRendered = rendered
+                    .linesIterator
+                    .drop(1)
+                    .mkString("\n")
+
+                  List("\n", trimmedRendered, "\n")
+
+                case _ => List()
+              }
+            }
+
+          Iterator(
+            ctx.applyPrefixColor(t.toString).toString,
+            "(",
+            // handle both Windows or Unix separators
+            t.ctx.fileName.split('/').last.split('\\').last,
+            ":",
+            t.ctx.lineNum.toString,
+            ")",
+            allDocs.mkString("\n"),
+            "\n"
+          ) ++
+            mainMethodSig.iterator ++
+            Iterator(
+              "\n",
+              ctx.applyPrefixColor("Inputs").toString,
+              ":"
+            ) ++ t.inputs.iterator.flatMap(rec).map("\n    " + _.render).distinct
         }
       }
 
-      val annots = for {
-        c <- resolveParents(t.ctx.enclosingCls)
-        m <- c.getMethods
-        if m.getName == t.ctx.segment.pathSegments.head
-        a = m.getAnnotation(classOf[mill.moduledefs.Scaladoc])
-        if a != null
-      } yield a
-
-      val allDocs =
-        for (a <- annots.distinct)
-          yield mill.util.Util.cleanupScaladoc(a.value).map("\n    " + _).mkString
-
-      pprint.Tree.Lazy { ctx =>
-        val mainMethodSig =
-          if (t.asCommand.isEmpty) List()
-          else {
-            val mainDataOpt = evaluator
-              .rootModule
-              .millDiscover
-              .value
-              .get(t.ctx.enclosingCls)
-              .flatMap(_._2.find(_.name == t.ctx.segments.parts.last))
-              .headOption
-
-            mainDataOpt match {
-              case Some(mainData) if mainData.renderedArgSigs.nonEmpty =>
-                val rendered = mainargs.Renderer.formatMainMethodSignature(
-                  mainDataOpt.get,
-                  leftIndent = 2,
-                  totalWidth = 100,
-                  leftColWidth = mainargs.Renderer.getLeftColWidth(mainData.renderedArgSigs),
-                  docsOnNewLine = false,
-                  customName = None,
-                  customDoc = None,
-                  sorted = true
-                )
-
-                // trim first line containing command name, since we already render
-                // the command name below with the filename and line num
-                val trimmedRendered = rendered
-                  .linesIterator
-                  .drop(1)
-                  .mkString("\n")
-
-                List("\n", trimmedRendered, "\n")
-
-              case _ => List()
-            }
-          }
-
-        Iterator(
-          ctx.applyPrefixColor(t.toString).toString,
-          "(",
-          // handle both Windows or Unix separators
-          t.ctx.fileName.split('/').last.split('\\').last,
-          ":",
-          t.ctx.lineNum.toString,
-          ")",
-          allDocs.mkString("\n"),
-          "\n"
-        ) ++
-          mainMethodSig.iterator ++
-          Iterator(
-            "\n",
-            ctx.applyPrefixColor("Inputs").toString,
-            ":"
-          ) ++ t.inputs.iterator.flatMap(rec).map("\n    " + _.render).distinct
+      MainModule.resolveTasks(evaluator, targets, SelectMode.Multi) { tasks =>
+        val output = (for {
+          task <- tasks
+          tree = pprintTask(task, evaluator)
+          defaults = pprint.PPrinter()
+          renderer = new Renderer(
+            defaults.defaultWidth,
+            defaults.colorApplyPrefix,
+            defaults.colorLiteral,
+            defaults.defaultIndent
+          )
+          rendered = renderer.rec(tree, 0, 0).iter
+          truncated = new Truncated(rendered, defaults.defaultWidth, defaults.defaultHeight)
+        } yield {
+          val sb = new StringBuilder()
+          for { str <- truncated ++ Iterator("\n") } sb.append(str)
+          sb.toString()
+        }).mkString("\n")
+        Task.log.withPromptPaused {
+          println(output)
+        }
+        fansi.Str(output).plainText
       }
     }
-
-    MainModule.resolveTasks(evaluator, targets, SelectMode.Multi) { tasks =>
-      val output = (for {
-        task <- tasks
-        tree = pprintTask(task, evaluator)
-        defaults = pprint.PPrinter()
-        renderer = new Renderer(
-          defaults.defaultWidth,
-          defaults.colorApplyPrefix,
-          defaults.colorLiteral,
-          defaults.defaultIndent
-        )
-        rendered = renderer.rec(tree, 0, 0).iter
-        truncated = new Truncated(rendered, defaults.defaultWidth, defaults.defaultHeight)
-      } yield {
-        val sb = new StringBuilder()
-        for { str <- truncated ++ Iterator("\n") } sb.append(str)
-        sb.toString()
-      }).mkString("\n")
-      Task.log.withPromptPaused {
-        println(output)
-      }
-      fansi.Str(output).plainText
-    }
-  }
 
   /**
    * Runs a given task and prints the JSON result to stdout. This is useful
    * to integrate Mill into external scripts and tooling.
    */
-  def show(evaluator: Evaluator, targets: String*): Command[ujson.Value] = Target.command {
-    MainModule.show0(evaluator, targets, Target.log, interp.evalWatch0) { res =>
-      res.flatMap(_._2) match {
-        case Seq((k, singleValue)) => singleValue
-        case multiple => ujson.Obj.from(multiple)
+  def show(evaluator: Evaluator, targets: String*): Command[ujson.Value] =
+    Task.Command(serial = true) {
+      MainModule.show0(evaluator, targets, Target.log, interp.evalWatch0) { res =>
+        res.flatMap(_._2) match {
+          case Seq((k, singleValue)) => singleValue
+          case multiple => ujson.Obj.from(multiple)
+        }
       }
     }
-  }
 
   /**
    * Runs a given task and prints the results as JSON dictionary to stdout. This is useful
    * to integrate Mill into external scripts and tooling.
    */
-  def showNamed(evaluator: Evaluator, targets: String*): Command[ujson.Value] = Target.command {
-    MainModule.show0(evaluator, targets, Target.log, interp.evalWatch0) { res =>
-      ujson.Obj.from(res.flatMap(_._2))
+  def showNamed(evaluator: Evaluator, targets: String*): Command[ujson.Value] =
+    Task.Command(serial = true) {
+      MainModule.show0(evaluator, targets, Target.log, interp.evalWatch0) { res =>
+        ujson.Obj.from(res.flatMap(_._2))
+      }
     }
-  }
 
   /**
    * Deletes the given targets from the out directory. Providing no targets
    * will clean everything.
    */
-  def clean(evaluator: Evaluator, targets: String*): Command[Seq[PathRef]] = Target.command {
-    val rootDir = evaluator.outPath
+  def clean(evaluator: Evaluator, targets: String*): Command[Seq[PathRef]] =
+    Task.Command(serial = true) {
+      val rootDir = evaluator.outPath
 
-    val KeepPattern = "(mill-.+)".r.anchored
+      val KeepPattern = "(mill-.+)".r.anchored
 
-    def keepPath(path: os.Path) = path.last match {
-      case KeepPattern(_) => true
-      case _ => false
-    }
+      def keepPath(path: os.Path) = path.last match {
+        case KeepPattern(_) => true
+        case _ => false
+      }
 
-    val pathsToRemove =
-      if (targets.isEmpty)
-        Right((os.list(rootDir).filterNot(keepPath), List(mill.define.Segments())))
-      else
-        mill.resolve.Resolve.Segments.resolve(
-          evaluator.rootModule,
-          targets,
-          SelectMode.Multi
-        ).map { ts =>
-          val allPaths = ts.flatMap { segments =>
-            val evPaths = EvaluatorPaths.resolveDestPaths(rootDir, segments)
-            val paths = Seq(evPaths.dest, evPaths.meta, evPaths.log)
-            val potentialModulePath = rootDir / EvaluatorPaths.makeSegmentStrings(segments)
-            if (os.exists(potentialModulePath)) {
-              // this is either because of some pre-Mill-0.10 files lying around
-              // or most likely because the segments denote a module but not a task
-              // in which case we want to remove the module and all its sub-modules
-              // (If this logic is later found to be to harsh, we could further guard it,
-              // to when non of the other paths exists.)
-              paths :+ potentialModulePath
-            } else paths
+      val pathsToRemove =
+        if (targets.isEmpty)
+          Right((os.list(rootDir).filterNot(keepPath), List(mill.define.Segments())))
+        else
+          mill.resolve.Resolve.Segments.resolve(
+            evaluator.rootModule,
+            targets,
+            SelectMode.Multi
+          ).map { ts =>
+            val allPaths = ts.flatMap { segments =>
+              val evPaths = EvaluatorPaths.resolveDestPaths(rootDir, segments)
+              val paths = Seq(evPaths.dest, evPaths.meta, evPaths.log)
+              val potentialModulePath = rootDir / EvaluatorPaths.makeSegmentStrings(segments)
+              if (os.exists(potentialModulePath)) {
+                // this is either because of some pre-Mill-0.10 files lying around
+                // or most likely because the segments denote a module but not a task
+                // in which case we want to remove the module and all its sub-modules
+                // (If this logic is later found to be to harsh, we could further guard it,
+                // to when non of the other paths exists.)
+                paths :+ potentialModulePath
+              } else paths
+            }
+            (allPaths, ts)
           }
-          (allPaths, ts)
-        }
 
-    pathsToRemove match {
-      case Left(err) =>
-        Result.Failure(err)
-      case Right((paths, allSegments)) =>
-        for {
-          workerSegments <- evaluator.workerCache.keys.toList
-          if allSegments.exists(workerSegments.startsWith)
-          (_, Val(closeable: AutoCloseable)) <- evaluator.mutableWorkerCache.remove(workerSegments)
-        } {
-          closeable.close()
-        }
+      pathsToRemove match {
+        case Left(err) =>
+          Result.Failure(err)
+        case Right((paths, allSegments)) =>
+          for {
+            workerSegments <- evaluator.workerCache.keys.toList
+            if allSegments.exists(workerSegments.startsWith)
+            (_, Val(closeable: AutoCloseable)) <-
+              evaluator.mutableWorkerCache.remove(workerSegments)
+          } {
+            closeable.close()
+          }
 
-        val existing = paths.filter(p => os.exists(p))
-        Target.log.debug(s"Cleaning ${existing.size} paths ...")
-        existing.foreach(os.remove.all)
-        Result.Success(existing.map(PathRef(_)))
+          val existing = paths.filter(p => os.exists(p))
+          Target.log.debug(s"Cleaning ${existing.size} paths ...")
+          existing.foreach(os.remove.all)
+          Result.Success(existing.map(PathRef(_)))
+      }
     }
-  }
 
   /**
    * Renders the dependencies between the given tasks as a SVG for you to look at
    */
-  def visualize(evaluator: Evaluator, targets: String*): Command[Seq[PathRef]] = Target.command {
-    visualize0(evaluator, targets, Target.ctx(), mill.main.VisualizeModule.worker())
-  }
+  def visualize(evaluator: Evaluator, targets: String*): Command[Seq[PathRef]] =
+    Task.Command(serial = true) {
+      visualize0(evaluator, targets, Target.ctx(), mill.main.VisualizeModule.worker())
+    }
 
   /**
    * Renders the dependencies between the given tasks, and all their dependencies, as a SVG
    */
   def visualizePlan(evaluator: Evaluator, targets: String*): Command[Seq[PathRef]] =
-    Target.command {
+    Task.Command(serial = true) {
       plan0(evaluator, targets) match {
         case Left(err) => Result.Failure(err)
         case Right(planResults) => visualize0(
@@ -408,7 +416,7 @@ trait MainModule extends BaseModule0 {
   /**
    * Shuts down mill's background server
    */
-  def shutdown(): Command[Unit] = Target.command {
+  def shutdown(): Command[Unit] = Task.Command(serial = true) {
     Target.log.info("Shutting down Mill server...")
     Target.ctx.systemExit(0)
     ()
@@ -420,7 +428,7 @@ trait MainModule extends BaseModule0 {
    * You can use it to quickly generate a starter project. There are lots of
    * templates out there for many frameworks and tools!
    */
-  def init(evaluator: Evaluator, args: String*): Command[Unit] = Target.command {
+  def init(evaluator: Evaluator, args: String*): Command[Unit] = Task.Command(serial = true) {
     RunScript.evaluateTasksNamed(
       evaluator,
       Seq("mill.scalalib.giter8.Giter8Module/init") ++ args,

--- a/main/src/mill/main/MainModule.scala
+++ b/main/src/mill/main/MainModule.scala
@@ -99,39 +99,41 @@ trait MainModule extends BaseModule0 {
   /**
    * Resolves a mill query string and prints out the tasks it resolves to.
    */
-  def resolve(evaluator: Evaluator, targets: String*): Command[List[String]] = Task.Command(exclusive = true) {
-    val resolved = Resolve.Segments.resolve(
-      evaluator.rootModule,
-      targets,
-      SelectMode.Multi
-    )
+  def resolve(evaluator: Evaluator, targets: String*): Command[List[String]] =
+    Task.Command(exclusive = true) {
+      val resolved = Resolve.Segments.resolve(
+        evaluator.rootModule,
+        targets,
+        SelectMode.Multi
+      )
 
-    resolved match {
-      case Left(err) => Result.Failure(err)
-      case Right(resolvedSegmentsList) =>
-        val resolvedStrings = resolvedSegmentsList.map(_.render)
-        Task.log.withPromptPaused {
-          resolvedStrings.sorted.foreach(println)
-        }
-        Result.Success(resolvedStrings)
+      resolved match {
+        case Left(err) => Result.Failure(err)
+        case Right(resolvedSegmentsList) =>
+          val resolvedStrings = resolvedSegmentsList.map(_.render)
+          Task.log.withPromptPaused {
+            resolvedStrings.sorted.foreach(println)
+          }
+          Result.Success(resolvedStrings)
+      }
     }
-  }
 
   /**
    * Given a set of tasks, prints out the execution plan of what tasks will be
    * executed in what order, without actually executing them.
    */
-  def plan(evaluator: Evaluator, targets: String*): Command[Array[String]] = Task.Command(exclusive = true) {
-    plan0(evaluator, targets) match {
-      case Left(err) => Result.Failure(err)
-      case Right(success) =>
-        val renderedTasks = success.map(_.segments.render)
-        Task.log.withPromptPaused {
-          renderedTasks.foreach(println)
-        }
-        Result.Success(renderedTasks)
+  def plan(evaluator: Evaluator, targets: String*): Command[Array[String]] =
+    Task.Command(exclusive = true) {
+      plan0(evaluator, targets) match {
+        case Left(err) => Result.Failure(err)
+        case Right(success) =>
+          val renderedTasks = success.map(_.segments.render)
+          Task.log.withPromptPaused {
+            renderedTasks.foreach(println)
+          }
+          Result.Success(renderedTasks)
+      }
     }
-  }
 
   private def plan0(evaluator: Evaluator, targets: Seq[String]) = {
     Resolve.Tasks.resolve(
@@ -202,264 +204,270 @@ trait MainModule extends BaseModule0 {
   /**
    * Displays metadata about the given task without actually running it.
    */
-  def inspect(evaluator: Evaluator, targets: String*): Command[String] = Task.Command(exclusive = true) {
-    def resolveParents(c: Class[_]): Seq[Class[_]] = {
-      Seq(c) ++ Option(c.getSuperclass).toSeq.flatMap(resolveParents) ++ c.getInterfaces.flatMap(
-        resolveParents
-      )
-    }
-
-    def pprintTask(t: NamedTask[_], evaluator: Evaluator): Tree.Lazy = {
-      val seen = mutable.Set.empty[Task[_]]
-
-      def rec(t: Task[_]): Seq[Segments] = {
-        if (seen(t)) Nil // do nothing
-        else t match {
-          case t: mill.define.Target[_]
-              if evaluator.rootModule.millInternal.targets.contains(t) =>
-            Seq(t.ctx.segments)
-          case _ =>
-            seen.add(t)
-            t.inputs.flatMap(rec)
-        }
-      }
-
-      val annots = for {
-        c <- resolveParents(t.ctx.enclosingCls)
-        m <- c.getMethods
-        if m.getName == t.ctx.segment.pathSegments.head
-        a = m.getAnnotation(classOf[mill.moduledefs.Scaladoc])
-        if a != null
-      } yield a
-
-      val allDocs =
-        for (a <- annots.distinct)
-          yield mill.util.Util.cleanupScaladoc(a.value).map("\n    " + _).mkString
-
-      pprint.Tree.Lazy { ctx =>
-        val mainMethodSig =
-          if (t.asCommand.isEmpty) List()
-          else {
-            val mainDataOpt = evaluator
-              .rootModule
-              .millDiscover
-              .value
-              .get(t.ctx.enclosingCls)
-              .flatMap(_._2.find(_.name == t.ctx.segments.parts.last))
-              .headOption
-
-            mainDataOpt match {
-              case Some(mainData) if mainData.renderedArgSigs.nonEmpty =>
-                val rendered = mainargs.Renderer.formatMainMethodSignature(
-                  mainDataOpt.get,
-                  leftIndent = 2,
-                  totalWidth = 100,
-                  leftColWidth = mainargs.Renderer.getLeftColWidth(mainData.renderedArgSigs),
-                  docsOnNewLine = false,
-                  customName = None,
-                  customDoc = None,
-                  sorted = true
-                )
-
-                // trim first line containing command name, since we already render
-                // the command name below with the filename and line num
-                val trimmedRendered = rendered
-                  .linesIterator
-                  .drop(1)
-                  .mkString("\n")
-
-                List("\n", trimmedRendered, "\n")
-
-              case _ => List()
-            }
-          }
-
-        Iterator(
-          ctx.applyPrefixColor(t.toString).toString,
-          "(",
-          // handle both Windows or Unix separators
-          t.ctx.fileName.split('/').last.split('\\').last,
-          ":",
-          t.ctx.lineNum.toString,
-          ")",
-          allDocs.mkString("\n"),
-          "\n"
-        ) ++
-          mainMethodSig.iterator ++
-          Iterator(
-            "\n",
-            ctx.applyPrefixColor("Inputs").toString,
-            ":"
-          ) ++ t.inputs.iterator.flatMap(rec).map("\n    " + _.render).distinct
-      }
-    }
-
-    def pprintModule(t: ModuleTask[_], evaluator: Evaluator): Tree.Lazy = {
-      val cls = t.module.getClass
-      val annotation = cls.getAnnotation(classOf[Scaladoc])
-      val scaladocOpt = Option.when(annotation != null)(
-        Util.cleanupScaladoc(annotation.value).map("\n    " + _).mkString
-      )
-      val fileName = t.ctx.fileName.split('/').last.split('\\').last
-      val parents = cls.getInterfaces ++ Option(cls.getSuperclass).toSeq
-      val inheritedModules =
-        parents.distinct.filter(classOf[Module].isAssignableFrom(_)).map(_.getSimpleName)
-      val moduleDepsOpt = cls.getMethods.find(m => decode(m.getName) == "moduleDeps").map(
-        _.invoke(t.module).asInstanceOf[Seq[Module]]
-      ).filter(_.nonEmpty)
-      val defaultTaskOpt = t.module match {
-        case taskMod: TaskModule => Some(s"${t.module}.${taskMod.defaultCommandName()}")
-        case _ => None
-      }
-      val methodMap = evaluator.rootModule.millDiscover.value
-      val tasksOpt = methodMap.get(cls).map {
-        case (_, _, tasks) => tasks.map(task => s"${t.module}.$task")
-      }
-      pprint.Tree.Lazy { ctx =>
-        Iterator(
-          ctx.applyPrefixColor(t.module.toString).toString,
-          s"($fileName:${t.ctx.lineNum})"
-        ) ++ Iterator(scaladocOpt).flatten ++ Iterator(
-          "\n\n",
-          ctx.applyPrefixColor("Inherited Modules").toString,
-          ": ",
-          inheritedModules.mkString(", ")
-        ) ++ moduleDepsOpt.fold(Iterator.empty[String])(deps =>
-          Iterator(
-            "\n\n",
-            ctx.applyPrefixColor("Module Dependencies").toString,
-            ": ",
-            deps.mkString(", ")
-          )
-        ) ++ defaultTaskOpt.fold(Iterator.empty[String])(task =>
-          Iterator("\n\n", ctx.applyPrefixColor("Default Task").toString, ": ", task)
-        ) ++ tasksOpt.fold(Iterator.empty[String])(tasks =>
-          Iterator(
-            "\n\n",
-            ctx.applyPrefixColor("Tasks").toString,
-            ": ",
-            tasks.mkString(", ")
-          )
+  def inspect(evaluator: Evaluator, targets: String*): Command[String] =
+    Task.Command(exclusive = true) {
+      def resolveParents(c: Class[_]): Seq[Class[_]] = {
+        Seq(c) ++ Option(c.getSuperclass).toSeq.flatMap(resolveParents) ++ c.getInterfaces.flatMap(
+          resolveParents
         )
       }
-    }
 
-    MainModule.resolveTasks(evaluator, targets, SelectMode.Multi, resolveToModuleTasks = true) {
-      tasks =>
-        val output = (for {
-          task <- tasks
-          tree = task match {
-            case t: ModuleTask[_] => pprintModule(t, evaluator)
-            case t => pprintTask(t, evaluator)
+      def pprintTask(t: NamedTask[_], evaluator: Evaluator): Tree.Lazy = {
+        val seen = mutable.Set.empty[Task[_]]
+
+        def rec(t: Task[_]): Seq[Segments] = {
+          if (seen(t)) Nil // do nothing
+          else t match {
+            case t: mill.define.Target[_]
+                if evaluator.rootModule.millInternal.targets.contains(t) =>
+              Seq(t.ctx.segments)
+            case _ =>
+              seen.add(t)
+              t.inputs.flatMap(rec)
           }
-          defaults = pprint.PPrinter()
-          renderer = new Renderer(
-            defaults.defaultWidth,
-            defaults.colorApplyPrefix,
-            defaults.colorLiteral,
-            defaults.defaultIndent
-          )
-          rendered = renderer.rec(tree, 0, 0).iter
-          truncated = new Truncated(rendered, defaults.defaultWidth, defaults.defaultHeight)
-        } yield {
-          val sb = new StringBuilder()
-          for { str <- truncated ++ Iterator("\n") } sb.append(str)
-          sb.toString()
-        }).mkString("\n")
-        Task.log.withPromptPaused {
-          println(output)
         }
-        fansi.Str(output).plainText
+
+        val annots = for {
+          c <- resolveParents(t.ctx.enclosingCls)
+          m <- c.getMethods
+          if m.getName == t.ctx.segment.pathSegments.head
+          a = m.getAnnotation(classOf[mill.moduledefs.Scaladoc])
+          if a != null
+        } yield a
+
+        val allDocs =
+          for (a <- annots.distinct)
+            yield mill.util.Util.cleanupScaladoc(a.value).map("\n    " + _).mkString
+
+        pprint.Tree.Lazy { ctx =>
+          val mainMethodSig =
+            if (t.asCommand.isEmpty) List()
+            else {
+              val mainDataOpt = evaluator
+                .rootModule
+                .millDiscover
+                .value
+                .get(t.ctx.enclosingCls)
+                .flatMap(_._2.find(_.name == t.ctx.segments.parts.last))
+                .headOption
+
+              mainDataOpt match {
+                case Some(mainData) if mainData.renderedArgSigs.nonEmpty =>
+                  val rendered = mainargs.Renderer.formatMainMethodSignature(
+                    mainDataOpt.get,
+                    leftIndent = 2,
+                    totalWidth = 100,
+                    leftColWidth = mainargs.Renderer.getLeftColWidth(mainData.renderedArgSigs),
+                    docsOnNewLine = false,
+                    customName = None,
+                    customDoc = None,
+                    sorted = true
+                  )
+
+                  // trim first line containing command name, since we already render
+                  // the command name below with the filename and line num
+                  val trimmedRendered = rendered
+                    .linesIterator
+                    .drop(1)
+                    .mkString("\n")
+
+                  List("\n", trimmedRendered, "\n")
+
+                case _ => List()
+              }
+            }
+
+          Iterator(
+            ctx.applyPrefixColor(t.toString).toString,
+            "(",
+            // handle both Windows or Unix separators
+            t.ctx.fileName.split('/').last.split('\\').last,
+            ":",
+            t.ctx.lineNum.toString,
+            ")",
+            allDocs.mkString("\n"),
+            "\n"
+          ) ++
+            mainMethodSig.iterator ++
+            Iterator(
+              "\n",
+              ctx.applyPrefixColor("Inputs").toString,
+              ":"
+            ) ++ t.inputs.iterator.flatMap(rec).map("\n    " + _.render).distinct
+        }
+      }
+
+      def pprintModule(t: ModuleTask[_], evaluator: Evaluator): Tree.Lazy = {
+        val cls = t.module.getClass
+        val annotation = cls.getAnnotation(classOf[Scaladoc])
+        val scaladocOpt = Option.when(annotation != null)(
+          Util.cleanupScaladoc(annotation.value).map("\n    " + _).mkString
+        )
+        val fileName = t.ctx.fileName.split('/').last.split('\\').last
+        val parents = cls.getInterfaces ++ Option(cls.getSuperclass).toSeq
+        val inheritedModules =
+          parents.distinct.filter(classOf[Module].isAssignableFrom(_)).map(_.getSimpleName)
+        val moduleDepsOpt = cls.getMethods.find(m => decode(m.getName) == "moduleDeps").map(
+          _.invoke(t.module).asInstanceOf[Seq[Module]]
+        ).filter(_.nonEmpty)
+        val defaultTaskOpt = t.module match {
+          case taskMod: TaskModule => Some(s"${t.module}.${taskMod.defaultCommandName()}")
+          case _ => None
+        }
+        val methodMap = evaluator.rootModule.millDiscover.value
+        val tasksOpt = methodMap.get(cls).map {
+          case (_, _, tasks) => tasks.map(task => s"${t.module}.$task")
+        }
+        pprint.Tree.Lazy { ctx =>
+          Iterator(
+            ctx.applyPrefixColor(t.module.toString).toString,
+            s"($fileName:${t.ctx.lineNum})"
+          ) ++ Iterator(scaladocOpt).flatten ++ Iterator(
+            "\n\n",
+            ctx.applyPrefixColor("Inherited Modules").toString,
+            ": ",
+            inheritedModules.mkString(", ")
+          ) ++ moduleDepsOpt.fold(Iterator.empty[String])(deps =>
+            Iterator(
+              "\n\n",
+              ctx.applyPrefixColor("Module Dependencies").toString,
+              ": ",
+              deps.mkString(", ")
+            )
+          ) ++ defaultTaskOpt.fold(Iterator.empty[String])(task =>
+            Iterator("\n\n", ctx.applyPrefixColor("Default Task").toString, ": ", task)
+          ) ++ tasksOpt.fold(Iterator.empty[String])(tasks =>
+            Iterator(
+              "\n\n",
+              ctx.applyPrefixColor("Tasks").toString,
+              ": ",
+              tasks.mkString(", ")
+            )
+          )
+        }
+      }
+
+      MainModule.resolveTasks(evaluator, targets, SelectMode.Multi, resolveToModuleTasks = true) {
+        tasks =>
+          val output = (for {
+            task <- tasks
+            tree = task match {
+              case t: ModuleTask[_] => pprintModule(t, evaluator)
+              case t => pprintTask(t, evaluator)
+            }
+            defaults = pprint.PPrinter()
+            renderer = new Renderer(
+              defaults.defaultWidth,
+              defaults.colorApplyPrefix,
+              defaults.colorLiteral,
+              defaults.defaultIndent
+            )
+            rendered = renderer.rec(tree, 0, 0).iter
+            truncated = new Truncated(rendered, defaults.defaultWidth, defaults.defaultHeight)
+          } yield {
+            val sb = new StringBuilder()
+            for { str <- truncated ++ Iterator("\n") } sb.append(str)
+            sb.toString()
+          }).mkString("\n")
+          Task.log.withPromptPaused {
+            println(output)
+          }
+          fansi.Str(output).plainText
+      }
     }
-  }
 
   /**
    * Runs a given task and prints the JSON result to stdout. This is useful
    * to integrate Mill into external scripts and tooling.
    */
-  def show(evaluator: Evaluator, targets: String*): Command[ujson.Value] = Task.Command(exclusive = true) {
-    MainModule.show0(evaluator, targets, Target.log, interp.evalWatch0) { res =>
-      res.flatMap(_._2) match {
-        case Seq((k, singleValue)) => singleValue
-        case multiple => ujson.Obj.from(multiple)
+  def show(evaluator: Evaluator, targets: String*): Command[ujson.Value] =
+    Task.Command(exclusive = true) {
+      MainModule.show0(evaluator, targets, Target.log, interp.evalWatch0) { res =>
+        res.flatMap(_._2) match {
+          case Seq((k, singleValue)) => singleValue
+          case multiple => ujson.Obj.from(multiple)
+        }
       }
     }
-  }
 
   /**
    * Runs a given task and prints the results as JSON dictionary to stdout. This is useful
    * to integrate Mill into external scripts and tooling.
    */
-  def showNamed(evaluator: Evaluator, targets: String*): Command[ujson.Value] = Task.Command(exclusive = true) {
-    MainModule.show0(evaluator, targets, Target.log, interp.evalWatch0) { res =>
-      ujson.Obj.from(res.flatMap(_._2))
+  def showNamed(evaluator: Evaluator, targets: String*): Command[ujson.Value] =
+    Task.Command(exclusive = true) {
+      MainModule.show0(evaluator, targets, Target.log, interp.evalWatch0) { res =>
+        ujson.Obj.from(res.flatMap(_._2))
+      }
     }
-  }
 
   /**
    * Deletes the given targets from the out directory. Providing no targets
    * will clean everything.
    */
-  def clean(evaluator: Evaluator, targets: String*): Command[Seq[PathRef]] = Task.Command(exclusive = true) {
-    val rootDir = evaluator.outPath
+  def clean(evaluator: Evaluator, targets: String*): Command[Seq[PathRef]] =
+    Task.Command(exclusive = true) {
+      val rootDir = evaluator.outPath
 
-    val KeepPattern = "(mill-.+)".r.anchored
+      val KeepPattern = "(mill-.+)".r.anchored
 
-    def keepPath(path: os.Path) = path.last match {
-      case KeepPattern(_) => true
-      case _ => false
-    }
+      def keepPath(path: os.Path) = path.last match {
+        case KeepPattern(_) => true
+        case _ => false
+      }
 
-    val pathsToRemove =
-      if (targets.isEmpty)
-        Right((os.list(rootDir).filterNot(keepPath), List(mill.define.Segments())))
-      else
-        mill.resolve.Resolve.Segments.resolve(
-          evaluator.rootModule,
-          targets,
-          SelectMode.Multi
-        ).map { ts =>
-          val allPaths = ts.flatMap { segments =>
-            val evPaths = EvaluatorPaths.resolveDestPaths(rootDir, segments)
-            val paths = Seq(evPaths.dest, evPaths.meta, evPaths.log)
-            val potentialModulePath = rootDir / EvaluatorPaths.makeSegmentStrings(segments)
-            if (os.exists(potentialModulePath)) {
-              // this is either because of some pre-Mill-0.10 files lying around
-              // or most likely because the segments denote a module but not a task
-              // in which case we want to remove the module and all its sub-modules
-              // (If this logic is later found to be to harsh, we could further guard it,
-              // to when non of the other paths exists.)
-              paths :+ potentialModulePath
-            } else paths
+      val pathsToRemove =
+        if (targets.isEmpty)
+          Right((os.list(rootDir).filterNot(keepPath), List(mill.define.Segments())))
+        else
+          mill.resolve.Resolve.Segments.resolve(
+            evaluator.rootModule,
+            targets,
+            SelectMode.Multi
+          ).map { ts =>
+            val allPaths = ts.flatMap { segments =>
+              val evPaths = EvaluatorPaths.resolveDestPaths(rootDir, segments)
+              val paths = Seq(evPaths.dest, evPaths.meta, evPaths.log)
+              val potentialModulePath = rootDir / EvaluatorPaths.makeSegmentStrings(segments)
+              if (os.exists(potentialModulePath)) {
+                // this is either because of some pre-Mill-0.10 files lying around
+                // or most likely because the segments denote a module but not a task
+                // in which case we want to remove the module and all its sub-modules
+                // (If this logic is later found to be to harsh, we could further guard it,
+                // to when non of the other paths exists.)
+                paths :+ potentialModulePath
+              } else paths
+            }
+            (allPaths, ts)
           }
-          (allPaths, ts)
-        }
 
-    pathsToRemove match {
-      case Left(err) =>
-        Result.Failure(err)
-      case Right((paths, allSegments)) =>
-        for {
-          workerSegments <- evaluator.workerCache.keys.toList
-          if allSegments.exists(workerSegments.startsWith)
-          (_, Val(closeable: AutoCloseable)) <- evaluator.mutableWorkerCache.remove(workerSegments)
-        } {
-          closeable.close()
-        }
+      pathsToRemove match {
+        case Left(err) =>
+          Result.Failure(err)
+        case Right((paths, allSegments)) =>
+          for {
+            workerSegments <- evaluator.workerCache.keys.toList
+            if allSegments.exists(workerSegments.startsWith)
+            (_, Val(closeable: AutoCloseable)) <-
+              evaluator.mutableWorkerCache.remove(workerSegments)
+          } {
+            closeable.close()
+          }
 
-        val existing = paths.filter(p => os.exists(p))
-        Target.log.debug(s"Cleaning ${existing.size} paths ...")
-        existing.foreach(os.remove.all)
-        Result.Success(existing.map(PathRef(_)))
+          val existing = paths.filter(p => os.exists(p))
+          Target.log.debug(s"Cleaning ${existing.size} paths ...")
+          existing.foreach(os.remove.all)
+          Result.Success(existing.map(PathRef(_)))
+      }
     }
-  }
 
   /**
    * Renders the dependencies between the given tasks as a SVG for you to look at
    */
-  def visualize(evaluator: Evaluator, targets: String*): Command[Seq[PathRef]] = Task.Command(exclusive = true) {
-    visualize0(evaluator, targets, Target.ctx(), mill.main.VisualizeModule.worker())
-  }
+  def visualize(evaluator: Evaluator, targets: String*): Command[Seq[PathRef]] =
+    Task.Command(exclusive = true) {
+      visualize0(evaluator, targets, Target.ctx(), mill.main.VisualizeModule.worker())
+    }
 
   /**
    * Renders the dependencies between the given tasks, and all their dependencies, as a SVG

--- a/main/src/mill/main/MainModule.scala
+++ b/main/src/mill/main/MainModule.scala
@@ -69,7 +69,7 @@ trait MainModule extends BaseModule0 {
   /**
    * Show the mill version.
    */
-  def version(): Command[String] = Task.Command(serial = true) {
+  def version(): Command[String] = Task.Command(exclusive = true) {
     val res = BuildInfo.millVersion
     Task.log.withPromptPaused {
       println(res)
@@ -81,7 +81,7 @@ trait MainModule extends BaseModule0 {
    * Resolves a mill query string and prints out the tasks it resolves to.
    */
   def resolve(evaluator: Evaluator, targets: String*): Command[List[String]] =
-    Task.Command(serial = true) {
+    Task.Command(exclusive = true) {
       val resolved = Resolve.Segments.resolve(
         evaluator.rootModule,
         targets,
@@ -104,7 +104,7 @@ trait MainModule extends BaseModule0 {
    * executed in what order, without actually executing them.
    */
   def plan(evaluator: Evaluator, targets: String*): Command[Array[String]] =
-    Task.Command(serial = true) {
+    Task.Command(exclusive = true) {
       plan0(evaluator, targets) match {
         case Left(err) => Result.Failure(err)
         case Right(success) =>
@@ -141,7 +141,7 @@ trait MainModule extends BaseModule0 {
       @mainargs.arg(positional = true) src: String,
       @mainargs.arg(positional = true) dest: String
   ): Command[List[String]] =
-    Task.Command(serial = true) {
+    Task.Command(exclusive = true) {
       val resolved = Resolve.Tasks.resolve(
         evaluator.rootModule,
         List(src, dest),
@@ -186,7 +186,7 @@ trait MainModule extends BaseModule0 {
    * Displays metadata about the given task without actually running it.
    */
   def inspect(evaluator: Evaluator, targets: String*): Command[String] =
-    Task.Command(serial = true) {
+    Task.Command(exclusive = true) {
 
       def resolveParents(c: Class[_]): Seq[Class[_]] = {
         Seq(c) ++ Option(c.getSuperclass).toSeq.flatMap(resolveParents) ++ c.getInterfaces.flatMap(
@@ -308,7 +308,7 @@ trait MainModule extends BaseModule0 {
    * to integrate Mill into external scripts and tooling.
    */
   def show(evaluator: Evaluator, targets: String*): Command[ujson.Value] =
-    Task.Command(serial = true) {
+    Task.Command(exclusive = true) {
       MainModule.show0(evaluator, targets, Target.log, interp.evalWatch0) { res =>
         res.flatMap(_._2) match {
           case Seq((k, singleValue)) => singleValue
@@ -322,7 +322,7 @@ trait MainModule extends BaseModule0 {
    * to integrate Mill into external scripts and tooling.
    */
   def showNamed(evaluator: Evaluator, targets: String*): Command[ujson.Value] =
-    Task.Command(serial = true) {
+    Task.Command(exclusive = true) {
       MainModule.show0(evaluator, targets, Target.log, interp.evalWatch0) { res =>
         ujson.Obj.from(res.flatMap(_._2))
       }
@@ -333,7 +333,7 @@ trait MainModule extends BaseModule0 {
    * will clean everything.
    */
   def clean(evaluator: Evaluator, targets: String*): Command[Seq[PathRef]] =
-    Task.Command(serial = true) {
+    Task.Command(exclusive = true) {
       val rootDir = evaluator.outPath
 
       val KeepPattern = "(mill-.+)".r.anchored
@@ -392,7 +392,7 @@ trait MainModule extends BaseModule0 {
    * Renders the dependencies between the given tasks as a SVG for you to look at
    */
   def visualize(evaluator: Evaluator, targets: String*): Command[Seq[PathRef]] =
-    Task.Command(serial = true) {
+    Task.Command(exclusive = true) {
       visualize0(evaluator, targets, Target.ctx(), mill.main.VisualizeModule.worker())
     }
 
@@ -400,7 +400,7 @@ trait MainModule extends BaseModule0 {
    * Renders the dependencies between the given tasks, and all their dependencies, as a SVG
    */
   def visualizePlan(evaluator: Evaluator, targets: String*): Command[Seq[PathRef]] =
-    Task.Command(serial = true) {
+    Task.Command(exclusive = true) {
       plan0(evaluator, targets) match {
         case Left(err) => Result.Failure(err)
         case Right(planResults) => visualize0(
@@ -416,7 +416,7 @@ trait MainModule extends BaseModule0 {
   /**
    * Shuts down mill's background server
    */
-  def shutdown(): Command[Unit] = Task.Command(serial = true) {
+  def shutdown(): Command[Unit] = Task.Command(exclusive = true) {
     Target.log.info("Shutting down Mill server...")
     Target.ctx.systemExit(0)
     ()
@@ -428,7 +428,7 @@ trait MainModule extends BaseModule0 {
    * You can use it to quickly generate a starter project. There are lots of
    * templates out there for many frameworks and tools!
    */
-  def init(evaluator: Evaluator, args: String*): Command[Unit] = Task.Command(serial = true) {
+  def init(evaluator: Evaluator, args: String*): Command[Unit] = Task.Command(exclusive = true) {
     RunScript.evaluateTasksNamed(
       evaluator,
       Seq("mill.scalalib.giter8.Giter8Module/init") ++ args,

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -127,7 +127,7 @@ abstract class MillBuildRootModule()(implicit
     }
   }
 
-  def methodCodeHashSignatures: T[Map[String, Int]] = Task.Persistent {
+  def methodCodeHashSignatures: T[Map[String, Int]] = Task(persistent = true) {
     os.remove.all(T.dest / "previous")
     if (os.exists(T.dest / "current")) os.move.over(T.dest / "current", T.dest / "previous")
     val debugEnabled = T.log.debugEnabled

--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -106,11 +106,11 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
 
   def scalaJSToolsClasspath = Task { scalaJSWorkerClasspath() ++ scalaJSLinkerClasspath() }
 
-  def fastLinkJS: T[Report] = Task.Persistent {
+  def fastLinkJS: T[Report] = Task(persistent = true) {
     linkTask(isFullLinkJS = false, forceOutJs = false)()
   }
 
-  def fullLinkJS: T[Report] = Task.Persistent {
+  def fullLinkJS: T[Report] = Task(persistent = true) {
     linkTask(isFullLinkJS = true, forceOutJs = false)()
   }
 
@@ -354,7 +354,7 @@ trait TestScalaJSModule extends ScalaJSModule with TestModule {
     )
   }
 
-  def fastLinkJSTest: T[Report] = Task.Persistent {
+  def fastLinkJSTest: T[Report] = Task(persistent = true) {
     linkJs(
       worker = ScalaJSWorkerExternalModule.scalaJSWorker(),
       toolsClasspath = scalaJSToolsClasspath(),

--- a/scalalib/src/mill/scalalib/GenIdeaModule.scala
+++ b/scalalib/src/mill/scalalib/GenIdeaModule.scala
@@ -31,7 +31,7 @@ trait GenIdeaModule extends Module {
   def ideaConfigFiles(ideaConfigVersion: Int): Task[Seq[IdeaConfigFile]] =
     Task.Anon { Seq[IdeaConfigFile]() }
 
-  def ideaCompileOutput: T[PathRef] = Task.Persistent {
+  def ideaCompileOutput: T[PathRef] = Task(persistent = true) {
     PathRef(T.dest / "classes")
   }
 

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -420,7 +420,7 @@ trait JavaModule
    *
    * Keep in sync with [[bspCompileClassesPath]]
    */
-  def compile: T[mill.scalalib.api.CompilationResult] = Task.Persistent {
+  def compile: T[mill.scalalib.api.CompilationResult] = Task(persistent = true) {
     zincWorker()
       .worker()
       .compileJava(

--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -267,7 +267,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
   }
 
   // Keep in sync with [[bspCompileClassesPath]]
-  override def compile: T[CompilationResult] = Task.Persistent {
+  override def compile: T[CompilationResult] = Task(persistent = true) {
     val sv = scalaVersion()
     if (sv == "2.12.4") T.log.error(
       """Attention: Zinc is known to not work properly for Scala version 2.12.4.
@@ -432,7 +432,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
    * Opens up a Scala console with your module and all dependencies present,
    * for you to test and operate your code interactively.
    */
-  def console(): Command[Unit] = Task.Command {
+  def console(): Command[Unit] = Task.Command(serial = true) {
     if (!Util.isInteractive()) {
       Result.Failure("console needs to be run with the -i/--interactive flag")
     } else {
@@ -507,7 +507,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
    * for you to test and operate your code interactively.
    * Use [[ammoniteVersion]] to customize the Ammonite version to use.
    */
-  def repl(replOptions: String*): Command[Unit] = Task.Command {
+  def repl(replOptions: String*): Command[Unit] = Task.Command(serial = true) {
     if (T.log.inStream == DummyInputStream) {
       Result.Failure("repl needs to be run with the -i/--interactive flag")
     } else {
@@ -624,7 +624,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
     )
   }
 
-  override def semanticDbData: T[PathRef] = Task.Persistent {
+  override def semanticDbData: T[PathRef] = Task(persistent = true) {
     val sv = scalaVersion()
 
     val scalacOptions = (

--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -432,7 +432,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
    * Opens up a Scala console with your module and all dependencies present,
    * for you to test and operate your code interactively.
    */
-  def console(): Command[Unit] = Task.Command(serial = true) {
+  def console(): Command[Unit] = Task.Command(exclusive = true) {
     if (!Util.isInteractive()) {
       Result.Failure("console needs to be run with the -i/--interactive flag")
     } else {
@@ -507,7 +507,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
    * for you to test and operate your code interactively.
    * Use [[ammoniteVersion]] to customize the Ammonite version to use.
    */
-  def repl(replOptions: String*): Command[Unit] = Task.Command(serial = true) {
+  def repl(replOptions: String*): Command[Unit] = Task.Command(exclusive = true) {
     if (T.log.inStream == DummyInputStream) {
       Result.Failure("repl needs to be run with the -i/--interactive flag")
     } else {

--- a/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
+++ b/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
@@ -98,7 +98,7 @@ trait SemanticDbJavaModule extends CoursierModule {
     defaultResolver().resolveDeps(semanticDbJavaPluginIvyDeps())
   }
 
-  def semanticDbData: T[PathRef] = Task.Persistent {
+  def semanticDbData: T[PathRef] = Task(persistent = true) {
     val javacOpts = SemanticDbJavaModule.javacOptionsTask(
       javacOptions() ++ mandatoryJavacOptions(),
       semanticDbJavaVersion()

--- a/scalalib/src/mill/scalalib/TestModule.scala
+++ b/scalalib/src/mill/scalalib/TestModule.scala
@@ -72,12 +72,12 @@ trait TestModule
    * @see [[testCached]]
    */
   def test(args: String*): Command[(String, Seq[TestResult])] =
-    Task.Command {
+    Task.ParallelCommand {
       testTask(Task.Anon { args }, Task.Anon { Seq.empty[String] })()
     }
 
   def getTestEnvironmentVars(args: String*): Command[(String, String, String, Seq[String])] = {
-    Task.Command {
+    Task.ParallelCommand {
       getTestEnvironmentVarsTask(Task.Anon { args })()
     }
   }
@@ -113,7 +113,7 @@ trait TestModule
         val (s, t) = args.splitAt(pos)
         (s, t.tail)
     }
-    Task.Command {
+    Task.ParallelCommand {
       testTask(Task.Anon { testArgs }, Task.Anon { selector })()
     }
   }
@@ -265,7 +265,7 @@ trait TestModule
    * Discovers and runs the module's tests in-process in an isolated classloader,
    * reporting the results to the console
    */
-  def testLocal(args: String*): Command[(String, Seq[TestResult])] = Task.Command {
+  def testLocal(args: String*): Command[(String, Seq[TestResult])] = Task.ParallelCommand {
     val (doneMsg, results) = TestRunner.runTestFramework(
       Framework.framework(testFramework()),
       runClasspath().map(_.path),

--- a/scalalib/src/mill/scalalib/TestModule.scala
+++ b/scalalib/src/mill/scalalib/TestModule.scala
@@ -72,12 +72,12 @@ trait TestModule
    * @see [[testCached]]
    */
   def test(args: String*): Command[(String, Seq[TestResult])] =
-    Task.ParallelCommand {
+    Task.Command {
       testTask(Task.Anon { args }, Task.Anon { Seq.empty[String] })()
     }
 
   def getTestEnvironmentVars(args: String*): Command[(String, String, String, Seq[String])] = {
-    Task.ParallelCommand {
+    Task.Command {
       getTestEnvironmentVarsTask(Task.Anon { args })()
     }
   }
@@ -113,7 +113,7 @@ trait TestModule
         val (s, t) = args.splitAt(pos)
         (s, t.tail)
     }
-    Task.ParallelCommand {
+    Task.Command {
       testTask(Task.Anon { testArgs }, Task.Anon { selector })()
     }
   }
@@ -265,7 +265,7 @@ trait TestModule
    * Discovers and runs the module's tests in-process in an isolated classloader,
    * reporting the results to the console
    */
-  def testLocal(args: String*): Command[(String, Seq[TestResult])] = Task.ParallelCommand {
+  def testLocal(args: String*): Command[(String, Seq[TestResult])] = Task.Command {
     val (doneMsg, results) = TestRunner.runTestFramework(
       Framework.framework(testFramework()),
       runClasspath().map(_.path),


### PR DESCRIPTION
fixes https://github.com/com-lihaoyi/mill/issues/3566. Mostly a straightforward implementation of what was discussed.

We use `Task.Command(exclusive = true)` to make `console`/`repl`/`clean`/etc. run serially, all other commands should run in parallel. That includes most `test` commands. The name `exclusive` is taken from the Bazel action/target tag with the same meaning: that the tagged action runs alone with no other actions in parallel

`Task.Persistent` was changed to `Task(persistent = true)` for consistency, and also for other reasons: the new syntax is more composable, e.g. a user can more easily choose whether they want `persistent = true` or `persistent = false` based on a computed `Boolean` value, and Mill can in future extend it such that we can have `Task(exclusive = true, persistent = true)`, `Task.Command(exclusive = true, persistent = true)`, or other such combinations perhaps with even more flags (e.g. Bazel has a pretty long list https://bazel.build/reference/be/common-definitions#common.tags). 

To make overload resolution work correctly, I make the first parameter of the `(exclusive = true)` or `(persistent = true)` parameter list `dummy: NamedParameterOnlyDummy.type = NamedParameterOnlyDummy`. This ensures that there is no normal value the user could pass in positionally that would select that overload of `def Command` or `def apply`, and the only way to select it is by passing in `exclusive = true` or `persistent = true` as a named parameter

Tested manually by adding `println`s and making sure that `leafSerialCommands` no longer contains test tasks when I run tests in `example/scalalib/basic/1-simple`.