### PR TITLE
use Scalafmt latest version (won't build with Java 8)

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,4 @@
-# Newer versions won't work with Java 8!
-version = "3.7.15"
+version = "3.8.3"
 
 align.openParenCallSite = false
 align.preset = none

--- a/bsp/src/mill/bsp/BspWorker.scala
+++ b/bsp/src/mill/bsp/BspWorker.scala
@@ -34,8 +34,8 @@ private object BspWorker {
           urls
         }.getOrElse {
           // load extra classpath entries from file
-          val cpFile =
-            workspace / Constants.bspDir / s"${Constants.serverName}-${mill.main.BuildInfo.millVersion}.resources"
+          val resources = s"${Constants.serverName}-${mill.main.BuildInfo.millVersion}.resources"
+          val cpFile = workspace / Constants.bspDir / resources
           if (!os.exists(cpFile)) return Left(
             "You need to run `mill mill.bsp.BSP/install` before you can use the BSP server"
           )

--- a/contrib/buildinfo/src/mill/contrib/buildinfo/BuildInfo.scala
+++ b/contrib/buildinfo/src/mill/contrib/buildinfo/BuildInfo.scala
@@ -161,9 +161,10 @@ object BuildInfo {
         case v =>
           if (isScala)
             s"""${commentStr(v)}val ${v.key} = buildInfoProperties.getProperty("${v.key}")"""
-          else s"""${commentStr(
-              v
-            )}public static final java.lang.String ${v.key} = buildInfoProperties.getProperty("${v.key}");"""
+          else {
+            val propValue = s"""buildInfoProperties.getProperty("${v.key}")"""
+            s"""${commentStr(v)}public static final java.lang.String ${v.key} = $propValue;"""
+          }
       }
       .mkString("\n\n  ")
 

--- a/main/util/src/mill/util/PromptLoggerUtil.scala
+++ b/main/util/src/mill/util/PromptLoggerUtil.scala
@@ -171,7 +171,10 @@ private object PromptLoggerUtil {
     // as the `headerPrefixStr` changes, even at the expense of it not being perfectly centered.
     val leftDivider = "=" * ((maxWidth / 2) - (titleText.length / 2) - headerPrefixStr.length + 2)
     val rightDivider =
-      "=" * (maxWidth - headerPrefixStr.length - leftDivider.length - shortenedTitle.length - headerSuffixStr.length)
+      "=" * (
+        maxWidth - headerPrefixStr.length - leftDivider.length -
+          shortenedTitle.length - headerSuffixStr.length
+      )
     val headerString =
       headerPrefixStr + leftDivider + shortenedTitle + rightDivider + headerSuffixStr
     assert(

--- a/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
+++ b/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
@@ -440,7 +440,8 @@ class ZincWorkerImpl(
     val combinedCompilerClasspath = compilerClasspath ++ scalacPluginClasspath
     val javacRuntimeOptions = javacOptions.filter(filterJavacRuntimeOptions)
     val compilersSig =
-      combinedCompilerClasspath.hashCode() + scalaVersion.hashCode() + scalaOrganization.hashCode() + javacRuntimeOptions.hashCode()
+      combinedCompilerClasspath.hashCode() + scalaVersion.hashCode() +
+        scalaOrganization.hashCode() + javacRuntimeOptions.hashCode()
     val combinedCompilerJars = combinedCompilerClasspath.iterator.map(_.path.toIO).toArray
 
     val compiledCompilerBridge = compileBridgeIfNeeded(


### PR DESCRIPTION
Scalafmt needs to be updated to support the latest scala 3 syntax.

according to the now-deleted comment, this version was frozen because of supporting building with JDK 8, but if 0.12.0 will drop JDK 8 support then why not update