### PR TITLE
Scope PromptLogger to `MillBuildBootstrap#evaluate` call to make prompt more intuitive

### DIFF
--- a/example/depth/tasks/7-forking-futures/build.mill
+++ b/example/depth/tasks/7-forking-futures/build.mill
@@ -35,7 +35,6 @@ def taskSpawningFutures = Task {
 
 */
 
-
 // `T.fork.async` takes several parameters in addition to the code block to be run:
 //
 // - `dest` is a folder for which the async future is to be run, overriding `os.pwd`

--- a/main/util/src/mill/util/PromptLogger.scala
+++ b/main/util/src/mill/util/PromptLogger.scala
@@ -42,7 +42,7 @@ private[mill] class PromptLogger(
     infoColor
   )
 
-  private val streams = new Streams(
+  private val streamManager = new StreamManager(
     enableTicker,
     systemStreams0,
     () => state.currentPromptBytes,
@@ -111,7 +111,7 @@ private[mill] class PromptLogger(
     }
   }
 
-  def streamsAwaitPumperEmpty(): Unit = streams.awaitPumperEmpty()
+  def streamsAwaitPumperEmpty(): Unit = streamManager.awaitPumperEmpty()
   private val seenIdentifiers = collection.mutable.Map.empty[Seq[String], (String, String)]
   private val reportedIdentifiers = collection.mutable.Set.empty[Seq[String]]
   override def setPromptLine(key: Seq[String], verboseKeySuffix: String, message: String): Unit =
@@ -127,16 +127,16 @@ private[mill] class PromptLogger(
 
   override def close(): Unit = synchronized {
     if (enableTicker) state.refreshPrompt(ending = true)
-    streams.close()
+    streamManager.close()
     stopped = true
   }
 
-  def systemStreams = streams.systemStreams
+  def systemStreams = streamManager.systemStreams
 }
 
 private[mill] object PromptLogger {
 
-  private class Streams(
+  private class StreamManager(
       enableTicker: Boolean,
       systemStreams0: SystemStreams,
       currentPromptBytes: () => Array[Byte],

--- a/runner/src/mill/runner/MillMain.scala
+++ b/runner/src/mill/runner/MillMain.scala
@@ -158,7 +158,6 @@ object MillMain {
             (false, RunnerState.empty)
 
           case Right(config) =>
-
             if (!config.silent.value) {
               checkMillVersionFromFile(WorkspaceRoot.workspaceRoot, streams.err)
             }
@@ -232,22 +231,22 @@ object MillMain {
                         serverDir
                       )
                       try new MillBuildBootstrap(
-                        projectRoot = WorkspaceRoot.workspaceRoot,
-                        output = os.Path(OutFiles.out, WorkspaceRoot.workspaceRoot),
-                        home = config.home,
-                        keepGoing = config.keepGoing.value,
-                        imports = config.imports,
-                        env = env,
-                        threadCount = threadCount,
-                        targetsAndParams = targetsAndParams,
-                        prevRunnerState = prevState.getOrElse(stateCache),
-                        logger = logger,
-                        disableCallgraph = config.disableCallgraph.value,
-                        needBuildSc = needBuildSc(config),
-                        requestedMetaLevel = config.metaLevel,
-                        config.allowPositional.value,
-                        systemExit = systemExit
-                      ).evaluate()
+                          projectRoot = WorkspaceRoot.workspaceRoot,
+                          output = os.Path(OutFiles.out, WorkspaceRoot.workspaceRoot),
+                          home = config.home,
+                          keepGoing = config.keepGoing.value,
+                          imports = config.imports,
+                          env = env,
+                          threadCount = threadCount,
+                          targetsAndParams = targetsAndParams,
+                          prevRunnerState = prevState.getOrElse(stateCache),
+                          logger = logger,
+                          disableCallgraph = config.disableCallgraph.value,
+                          needBuildSc = needBuildSc(config),
+                          requestedMetaLevel = config.metaLevel,
+                          config.allowPositional.value,
+                          systemExit = systemExit
+                        ).evaluate()
                       finally {
                         logger.close()
                       }

--- a/runner/src/mill/runner/Watching.scala
+++ b/runner/src/mill/runner/Watching.scala
@@ -59,7 +59,7 @@ object Watching {
 
     val watchedValueStr = if (watchedValues == 0) "" else s" and $watchedValues other values"
 
-    streams.out.println(
+    streams.err.println(
       s"Watching for changes to ${watchedPaths.size} paths$watchedValueStr... (Enter to re-run, Ctrl-C to exit)"
     )
 

--- a/runner/src/mill/runner/Watching.scala
+++ b/runner/src/mill/runner/Watching.scala
@@ -15,7 +15,6 @@ object Watching {
   case class Result[T](watched: Seq[Watchable], error: Option[String], result: T)
 
   def watchLoop[T](
-      logger: ColorLogger,
       ringBell: Boolean,
       watch: Boolean,
       streams: SystemStreams,
@@ -26,7 +25,7 @@ object Watching {
     while (true) {
       val Result(watchables, errorOpt, result) = evaluate(prevState)
       prevState = Some(result)
-      errorOpt.foreach(logger.error)
+      errorOpt.foreach(streams.err.println)
       if (ringBell) {
         if (errorOpt.isEmpty) println("\u0007")
         else {
@@ -42,14 +41,14 @@ object Watching {
 
       val alreadyStale = watchables.exists(!_.validate())
       if (!alreadyStale) {
-        Watching.watchAndWait(logger, setIdle, streams.in, watchables)
+        Watching.watchAndWait(streams, setIdle, streams.in, watchables)
       }
     }
     ???
   }
 
   def watchAndWait(
-      logger: ColorLogger,
+      streams: SystemStreams,
       setIdle: Boolean => Unit,
       stdin: InputStream,
       watched: Seq[Watchable]
@@ -60,7 +59,7 @@ object Watching {
 
     val watchedValueStr = if (watchedValues == 0) "" else s" and $watchedValues other values"
 
-    logger.info(
+    streams.out.println(
       s"Watching for changes to ${watchedPaths.size} paths$watchedValueStr... (Enter to re-run, Ctrl-C to exit)"
     )
 

--- a/runner/src/mill/runner/Watching.scala
+++ b/runner/src/mill/runner/Watching.scala
@@ -1,7 +1,7 @@
 package mill.runner
 
 import mill.api.internal
-import mill.util.{ColorLogger, Watchable}
+import mill.util.Watchable
 import mill.api.SystemStreams
 import java.io.InputStream
 import scala.annotation.tailrec


### PR DESCRIPTION
Now, if you use `-w`/`--watch` the prompt starts and ends after each evaluation (which is bounded) rather than around the entire watch (which may last forever). This is much more useful so you can see where each run started and ended and how long it took, v.s. previously where it just tells you how long you've been watching for overall which is usually not something you care about

Also fixed a race condition where the `promptUpdaterThread` was still running for one iteration even after `PromptLogger#close()`, causing extra prompts to sometimes be displayed overlapping other logs