### PR TITLE
Use build info for versions in kotlinlib

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -187,16 +187,35 @@ object Deps {
   val logback = ivy"ch.qos.logback:logback-classic:1.5.7"
   val sonatypeCentralClient = ivy"com.lumidion::sonatype-central-client-requests:0.3.0"
   val kotlinCompiler = ivy"org.jetbrains.kotlin:kotlin-compiler:1.9.24"
-  val koverVersion = "0.8.3"
-  val ktfmtVersion = "0.52"
-  val detektVersion = "1.23.7"
-  val dokkaVersion = "1.9.20"
 
   object RuntimeDeps {
     val errorProneCore = ivy"com.google.errorprone:error_prone_core:2.31.0"
     val jupiterInterface = ivy"com.github.sbt.junit:jupiter-interface:0.11.4"
     val sbtTestInterface = ivy"com.github.sbt:junit-interface:0.13.2"
-    def all = Seq(errorProneCore, jupiterInterface, sbtTestInterface)
+    val koverVersion = "0.8.3"
+    val koverCli = ivy"org.jetbrains.kotlinx:kover-cli:$koverVersion"
+    val koverJvmAgent = ivy"org.jetbrains.kotlinx:kover-jvm-agent:$koverVersion"
+    val ktfmtVersion = "0.52"
+    val ktfmt = ivy"com.facebook:ktfmt:$ktfmtVersion"
+    val detektVersion = "1.23.7"
+    val detektCli = ivy"io.gitlab.arturbosch.detekt:detekt-cli:$detektVersion"
+    val dokkaVersion = "1.9.20"
+    val dokkaCli = ivy"org.jetbrains.dokka:dokka-cli:$dokkaVersion"
+    val dokkaBase = ivy"org.jetbrains.dokka:dokka-base:$dokkaVersion"
+    val dokkaAnalysisDescriptors = ivy"org.jetbrains.dokka:analysis-kotlin-descriptors:$dokkaVersion"
+
+    def all = Seq(
+      errorProneCore,
+      jupiterInterface,
+      sbtTestInterface,
+      koverCli,
+      koverJvmAgent,
+      ktfmt,
+      detektCli,
+      dokkaCli,
+      dokkaBase,
+      dokkaAnalysisDescriptors
+    )
   }
 
   /** Used to manage transitive versions. */

--- a/build.mill
+++ b/build.mill
@@ -188,6 +188,7 @@ object Deps {
   val sonatypeCentralClient = ivy"com.lumidion::sonatype-central-client-requests:0.3.0"
   val kotlinCompiler = ivy"org.jetbrains.kotlin:kotlin-compiler:1.9.24"
   val koverVersion = "0.8.3"
+  val ktfmtVersion = "0.52"
 
   object RuntimeDeps {
     val errorProneCore = ivy"com.google.errorprone:error_prone_core:2.31.0"

--- a/build.mill
+++ b/build.mill
@@ -190,6 +190,7 @@ object Deps {
   val koverVersion = "0.8.3"
   val ktfmtVersion = "0.52"
   val detektVersion = "1.23.7"
+  val dokkaVersion = "1.9.20"
 
   object RuntimeDeps {
     val errorProneCore = ivy"com.google.errorprone:error_prone_core:2.31.0"

--- a/build.mill
+++ b/build.mill
@@ -189,6 +189,7 @@ object Deps {
   val kotlinCompiler = ivy"org.jetbrains.kotlin:kotlin-compiler:1.9.24"
   val koverVersion = "0.8.3"
   val ktfmtVersion = "0.52"
+  val detektVersion = "1.23.7"
 
   object RuntimeDeps {
     val errorProneCore = ivy"com.google.errorprone:error_prone_core:2.31.0"

--- a/kotlinlib/package.mill
+++ b/kotlinlib/package.mill
@@ -17,7 +17,8 @@ object `package` extends RootModule with build.MillPublishScalaModule with Build
   def buildInfoMembers = Seq(
     BuildInfo.Value("koverVersion", build.Deps.koverVersion, "Version of Kover."),
     BuildInfo.Value("ktfmtVersion", build.Deps.ktfmtVersion, "Version of Ktfmt."),
-    BuildInfo.Value("detektVersion", build.Deps.detektVersion, "Version of Detekt.")
+    BuildInfo.Value("detektVersion", build.Deps.detektVersion, "Version of Detekt."),
+    BuildInfo.Value("dokkaVersion", build.Deps.dokkaVersion, "Version of Dokka.")
   )
 
   trait MillKotlinModule extends build.MillPublishScalaModule {

--- a/kotlinlib/package.mill
+++ b/kotlinlib/package.mill
@@ -15,10 +15,10 @@ object `package` extends RootModule with build.MillPublishScalaModule with Build
   def buildInfoPackageName = "mill.kotlinlib"
   def buildInfoObjectName = "Versions"
   def buildInfoMembers = Seq(
-    BuildInfo.Value("koverVersion", build.Deps.koverVersion, "Version of Kover."),
-    BuildInfo.Value("ktfmtVersion", build.Deps.ktfmtVersion, "Version of Ktfmt."),
-    BuildInfo.Value("detektVersion", build.Deps.detektVersion, "Version of Detekt."),
-    BuildInfo.Value("dokkaVersion", build.Deps.dokkaVersion, "Version of Dokka.")
+    BuildInfo.Value("koverVersion", build.Deps.RuntimeDeps.koverVersion, "Version of Kover."),
+    BuildInfo.Value("ktfmtVersion", build.Deps.RuntimeDeps.ktfmtVersion, "Version of Ktfmt."),
+    BuildInfo.Value("detektVersion", build.Deps.RuntimeDeps.detektVersion, "Version of Detekt."),
+    BuildInfo.Value("dokkaVersion", build.Deps.RuntimeDeps.dokkaVersion, "Version of Dokka.")
   )
 
   trait MillKotlinModule extends build.MillPublishScalaModule {

--- a/kotlinlib/package.mill
+++ b/kotlinlib/package.mill
@@ -16,7 +16,8 @@ object `package` extends RootModule with build.MillPublishScalaModule with Build
   def buildInfoObjectName = "Versions"
   def buildInfoMembers = Seq(
     BuildInfo.Value("koverVersion", build.Deps.koverVersion, "Version of Kover."),
-    BuildInfo.Value("ktfmtVersion", build.Deps.ktfmtVersion, "Version of Ktfmt.")
+    BuildInfo.Value("ktfmtVersion", build.Deps.ktfmtVersion, "Version of Ktfmt."),
+    BuildInfo.Value("detektVersion", build.Deps.detektVersion, "Version of Detekt.")
   )
 
   trait MillKotlinModule extends build.MillPublishScalaModule {

--- a/kotlinlib/package.mill
+++ b/kotlinlib/package.mill
@@ -15,7 +15,8 @@ object `package` extends RootModule with build.MillPublishScalaModule with Build
   def buildInfoPackageName = "mill.kotlinlib"
   def buildInfoObjectName = "Versions"
   def buildInfoMembers = Seq(
-    BuildInfo.Value("koverVersion", build.Deps.koverVersion, "Version of Kover.")
+    BuildInfo.Value("koverVersion", build.Deps.koverVersion, "Version of Kover."),
+    BuildInfo.Value("ktfmtVersion", build.Deps.ktfmtVersion, "Version of Ktfmt.")
   )
 
   trait MillKotlinModule extends build.MillPublishScalaModule {

--- a/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -183,7 +183,7 @@ trait KotlinModule extends JavaModule { outer =>
    * Dokka version.
    */
   def dokkaVersion: T[String] = T {
-    "1.9.20"
+    Versions.dokkaVersion
   }
 
   /**

--- a/kotlinlib/src/mill/kotlinlib/detekt/DetektModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/detekt/DetektModule.scala
@@ -2,7 +2,7 @@ package mill.kotlinlib.detekt
 
 import mill._
 import mill.api.{Loose, PathRef}
-import mill.kotlinlib.{DepSyntax, KotlinModule}
+import mill.kotlinlib.{DepSyntax, KotlinModule, Versions}
 import mill.util.Jvm
 
 /**
@@ -75,7 +75,7 @@ trait DetektModule extends KotlinModule {
    * Detekt version.
    */
   def detektVersion: T[String] = T {
-    "1.23.7"
+    Versions.detektVersion
   }
 
   /**

--- a/kotlinlib/src/mill/kotlinlib/ktfmt/KtfmtModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/ktfmt/KtfmtModule.scala
@@ -4,7 +4,7 @@ import mill._
 import mainargs.Leftover
 import mill.api.{Loose, PathRef}
 import mill.define.{Discover, ExternalModule}
-import mill.kotlinlib.{DepSyntax, KotlinModule}
+import mill.kotlinlib.{DepSyntax, KotlinModule, Versions}
 import mill.main.Tasks
 import mill.util.Jvm
 
@@ -23,7 +23,7 @@ trait KtfmtBaseModule extends KotlinModule {
    * Ktfmt version.
    */
   def ktfmtVersion: T[String] = T {
-    "0.52"
+    Versions.ktfmtVersion
   }
 
   /**

--- a/kotlinlib/src/mill/kotlinlib/ktfmt/KtfmtModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/ktfmt/KtfmtModule.scala
@@ -4,11 +4,12 @@ import mill._
 import mainargs.Leftover
 import mill.api.{Loose, PathRef}
 import mill.define.{Discover, ExternalModule}
-import mill.kotlinlib.{DepSyntax, KotlinModule, Versions}
+import mill.kotlinlib.{DepSyntax, Versions}
 import mill.main.Tasks
+import mill.scalalib.JavaModule
 import mill.util.Jvm
 
-trait KtfmtBaseModule extends KotlinModule {
+trait KtfmtBaseModule extends JavaModule {
 
   /**
    * Classpath for running Ktfmt.
@@ -67,8 +68,6 @@ trait KtfmtModule extends KtfmtBaseModule {
 }
 
 object KtfmtModule extends ExternalModule with KtfmtBaseModule with TaskModule {
-
-  def kotlinVersion = "1.9.24"
 
   lazy val millDiscover: Discover = Discover[this.type]
 

--- a/kotlinlib/test/src/mill/kotlinlib/contrib/kover/KoverModuleTests.scala
+++ b/kotlinlib/test/src/mill/kotlinlib/contrib/kover/KoverModuleTests.scala
@@ -11,6 +11,8 @@ import scala.xml.{Node, XML}
 
 object KoverModuleTests extends TestSuite {
 
+  val kotlinVersion = "1.9.24"
+
   val resourcePath = os.Path(sys.env("MILL_TEST_RESOURCE_FOLDER")) / "contrib" / "kover"
 
   object module extends TestBaseModule {
@@ -26,18 +28,18 @@ object KoverModuleTests extends TestSuite {
     }
 
     object foo extends KotlinModule with KoverModule {
-      def kotlinVersion = "1.9.24"
+      def kotlinVersion = KoverModuleTests.kotlinVersion
       object test extends KotlinModuleTests with module.KotestTestModule with KoverTests
     }
 
     object bar extends KotlinModule with KoverModule {
-      def kotlinVersion = "1.9.24"
+      def kotlinVersion = KoverModuleTests.kotlinVersion
       object test extends KotlinModuleTests with module.KotestTestModule with KoverTests
     }
 
     // module not instrumented with Kover
     object qux extends KotlinModule {
-      def kotlinVersion = "1.9.24"
+      def kotlinVersion = KoverModuleTests.kotlinVersion
       object test extends KotlinModuleTests with module.KotestTestModule
     }
   }

--- a/kotlinlib/test/src/mill/kotlinlib/contrib/ktfmt/KtfmtModuleTests.scala
+++ b/kotlinlib/test/src/mill/kotlinlib/contrib/ktfmt/KtfmtModuleTests.scala
@@ -9,6 +9,9 @@ import mill.testkit.{TestBaseModule, UnitTester}
 import utest.{TestSuite, Tests, assert, test}
 
 object KtfmtModuleTests extends TestSuite {
+
+  val kotlinVersion = "1.9.24"
+
   def tests: Tests = Tests {
 
     val (before, after) = {
@@ -95,7 +98,7 @@ object KtfmtModuleTests extends TestSuite {
   ): Seq[os.Path] = {
 
     object module extends TestBaseModule with KotlinModule with KtfmtModule {
-      override def kotlinVersion: T[String] = "1.9.24"
+      override def kotlinVersion: T[String] = KtfmtModuleTests.kotlinVersion
     }
 
     val eval = UnitTester(module, moduleRoot)
@@ -123,7 +126,7 @@ object KtfmtModuleTests extends TestSuite {
   def afterFormatAll(modulesRoot: os.Path, format: Boolean = true): Seq[os.Path] = {
 
     object module extends TestBaseModule with KotlinModule {
-      override def kotlinVersion: T[String] = "1.9.24"
+      override def kotlinVersion: T[String] = KtfmtModuleTests.kotlinVersion
     }
 
     val eval = UnitTester(module, modulesRoot)


### PR DESCRIPTION
Some minor cleanup for the previous work on the Kotlin-related modules:

* Read tooling versions from build info (https://github.com/com-lihaoyi/mill/pull/3620#discussion_r1779445633 and https://github.com/com-lihaoyi/mill/pull/3620#discussion_r1779445811)
* Declare versions only once in the unit tests
* Change parent module to `JavaModule` for Ktfmt support, because we don't need the code to be compiled in this module, so declaring Kotlin version there was looking a bit strange. In fact only `sources()` method is needed, which is available in the `JavaModule`. In the future `KotlinModule` may be split into different traits: the one which collects Kotlin+Java files, but doesn't do any compilation (so Kotlin version is not needed) and the one which actually does compilation.