### PR TITLE
Put back `withPromptPaused`, but make it `private[mill]`

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -116,7 +116,7 @@ object Deps {
     Seq(Play_3_0, Play_2_9, Play_2_8, Play_2_7, Play_2_6).map(p => (p.playBinVersion, p)).toMap
 
   val acyclic = ivy"com.lihaoyi:::acyclic:0.3.12"
-  val ammoniteVersion = "3.0.0"
+  val ammoniteVersion = "3.0.0-2-6342755f"
   val asmTree = ivy"org.ow2.asm:asm-tree:9.7"
   val bloopConfig = ivy"ch.epfl.scala::bloop-config:1.5.5"
 

--- a/main/api/src/mill/api/Logger.scala
+++ b/main/api/src/mill/api/Logger.scala
@@ -59,6 +59,7 @@ trait Logger {
   private[mill] def clearPromptStatuses(): Unit = ()
   private[mill] def removePromptLine(key: Seq[String]): Unit = ()
   private[mill] def removePromptLine(): Unit = ()
+  private[mill] def withPromptPaused[T](t: => T): T = t
 
   /**
    * @since Mill 0.10.5

--- a/main/eval/src/mill/eval/EvaluatorCore.scala
+++ b/main/eval/src/mill/eval/EvaluatorCore.scala
@@ -150,22 +150,20 @@ private[mill] trait EvaluatorCore extends GroupEvaluator {
               noPrefix = serial
             )
 
-            def wrap[T](t: => T): T = if (serial) contextLogger.withPromptPaused(t) else t
-            val res = wrap {
-              evaluateGroupCached(
-                terminal = terminal,
-                group = sortedGroups.lookupKey(terminal),
-                results = upstreamResults,
-                countMsg = countMsg,
-                verboseKeySuffix = verboseKeySuffix,
-                zincProblemReporter = reporter,
-                testReporter = testReporter,
-                logger = contextLogger,
-                classToTransitiveClasses,
-                allTransitiveClassMethods,
-                forkExecutionContext
-              )
-            }
+            val res = evaluateGroupCached(
+              terminal = terminal,
+              group = sortedGroups.lookupKey(terminal),
+              results = upstreamResults,
+              countMsg = countMsg,
+              verboseKeySuffix = verboseKeySuffix,
+              zincProblemReporter = reporter,
+              testReporter = testReporter,
+              logger = contextLogger,
+              classToTransitiveClasses,
+              allTransitiveClassMethods,
+              forkExecutionContext,
+              serial
+            )
 
             if (failFast && res.newResults.values.exists(_.result.asSuccess.isEmpty))
               failed.set(true)

--- a/main/eval/src/mill/eval/EvaluatorCore.scala
+++ b/main/eval/src/mill/eval/EvaluatorCore.scala
@@ -151,7 +151,7 @@ private[mill] trait EvaluatorCore extends GroupEvaluator {
             )
 
             def wrap[T](t: => T): T = if (serial) contextLogger.withPromptPaused(t) else t
-            val res = wrap{
+            val res = wrap {
               evaluateGroupCached(
                 terminal = terminal,
                 group = sortedGroups.lookupKey(terminal),

--- a/main/eval/src/mill/eval/EvaluatorCore.scala
+++ b/main/eval/src/mill/eval/EvaluatorCore.scala
@@ -150,19 +150,22 @@ private[mill] trait EvaluatorCore extends GroupEvaluator {
               noPrefix = serial
             )
 
-            val res = evaluateGroupCached(
-              terminal = terminal,
-              group = sortedGroups.lookupKey(terminal),
-              results = upstreamResults,
-              countMsg = countMsg,
-              verboseKeySuffix = verboseKeySuffix,
-              zincProblemReporter = reporter,
-              testReporter = testReporter,
-              logger = contextLogger,
-              classToTransitiveClasses,
-              allTransitiveClassMethods,
-              forkExecutionContext
-            )
+            def wrap[T](t: => T): T = if (serial) contextLogger.withPromptPaused(t) else t
+            val res = wrap{
+              evaluateGroupCached(
+                terminal = terminal,
+                group = sortedGroups.lookupKey(terminal),
+                results = upstreamResults,
+                countMsg = countMsg,
+                verboseKeySuffix = verboseKeySuffix,
+                zincProblemReporter = reporter,
+                testReporter = testReporter,
+                logger = contextLogger,
+                classToTransitiveClasses,
+                allTransitiveClassMethods,
+                forkExecutionContext
+              )
+            }
 
             if (failFast && res.newResults.values.exists(_.result.asSuccess.isEmpty))
               failed.set(true)

--- a/main/eval/src/mill/eval/EvaluatorImpl.scala
+++ b/main/eval/src/mill/eval/EvaluatorImpl.scala
@@ -1,6 +1,6 @@
 package mill.eval
 
-import mill.api.{CompileProblemReporter, Strict, TestReporter, Val}
+import mill.api.{CompileProblemReporter, Strict, SystemStreams, TestReporter, Val}
 import mill.api.Strict.Agg
 import mill.define._
 import mill.util._
@@ -30,7 +30,8 @@ private[mill] case class EvaluatorImpl(
     methodCodeHashSignatures: Map[String, Int],
     override val disableCallgraph: Boolean,
     override val allowPositionalCommandArgs: Boolean,
-    val systemExit: Int => Nothing
+    val systemExit: Int => Nothing,
+    val exclusiveSystemStreams: SystemStreams
 ) extends Evaluator with EvaluatorCore {
   import EvaluatorImpl._
 

--- a/main/eval/src/mill/eval/GroupEvaluator.scala
+++ b/main/eval/src/mill/eval/GroupEvaluator.scala
@@ -301,8 +301,7 @@ private[mill] trait GroupEvaluator {
                   if (serial) {
                     logger.reportKey(Seq(counterMsg))
                     logger.withPromptPaused { t }
-                  }
-                  else t
+                  } else t
                 }
               }
             }

--- a/main/eval/src/mill/eval/GroupEvaluator.scala
+++ b/main/eval/src/mill/eval/GroupEvaluator.scala
@@ -55,7 +55,8 @@ private[mill] trait GroupEvaluator {
       logger: ColorLogger,
       classToTransitiveClasses: Map[Class[_], IndexedSeq[Class[_]]],
       allTransitiveClassMethods: Map[Class[_], Map[String, Method]],
-      executionContext: mill.api.Ctx.Fork.Api
+      executionContext: mill.api.Ctx.Fork.Api,
+      serial: Boolean
   ): GroupEvaluator.Results = {
 
     val targetLabel = terminal match {
@@ -141,7 +142,8 @@ private[mill] trait GroupEvaluator {
             zincProblemReporter,
             testReporter,
             logger,
-            executionContext
+            executionContext,
+            serial
           )
           GroupEvaluator.Results(newResults, newEvaluated.toSeq, null, inputsHash, -1)
 
@@ -197,7 +199,8 @@ private[mill] trait GroupEvaluator {
                     zincProblemReporter,
                     testReporter,
                     logger,
-                    executionContext
+                    executionContext,
+                    serial
                   )
                 }
 
@@ -239,7 +242,8 @@ private[mill] trait GroupEvaluator {
       reporter: Int => Option[CompileProblemReporter],
       testReporter: TestReporter,
       logger: mill.api.Logger,
-      executionContext: mill.api.Ctx.Fork.Api
+      executionContext: mill.api.Ctx.Fork.Api,
+      serial: Boolean
   ): (Map[Task[_], TaskResult[(Val, Int)]], mutable.Buffer[Task[_]]) = {
 
     def computeAll() = {
@@ -286,17 +290,32 @@ private[mill] trait GroupEvaluator {
               override def jobs: Int = effectiveThreadCount
             }
 
-            os.dynamicPwdFunction.withValue(() => makeDest()) {
-              mill.api.SystemStreams.withStreams(multiLogger.systemStreams) {
-                try task.evaluate(args).map(Val(_))
-                catch {
-                  case f: Result.Failing[Val] => f
-                  case NonFatal(e) =>
-                    Result.Exception(
-                      e,
-                      new OuterStack(new Exception().getStackTrace.toIndexedSeq)
-                    )
+            def wrap[T](t: => T): T = {
+
+              val (streams, destFunc) =
+                if (serial) (SystemStreams.original, () => workspace)
+                else (multiLogger.systemStreams, () => makeDest())
+
+              os.dynamicPwdFunction.withValue(destFunc) {
+                SystemStreams.withStreams(streams) {
+                  if (serial) {
+                    logger.reportKey(Seq(counterMsg))
+                    logger.withPromptPaused { t }
+                  }
+                  else t
                 }
+              }
+            }
+
+            wrap {
+              try task.evaluate(args).map(Val(_))
+              catch {
+                case f: Result.Failing[Val] => f
+                case NonFatal(e) =>
+                  Result.Exception(
+                    e,
+                    new OuterStack(new Exception().getStackTrace.toIndexedSeq)
+                  )
               }
             }
           }

--- a/main/util/src/mill/util/MultiLogger.scala
+++ b/main/util/src/mill/util/MultiLogger.scala
@@ -79,9 +79,13 @@ class MultiLogger(
     logger2.setPromptLeftHeader(s)
   }
 
+  private[mill] override def withPromptPaused[T](t: => T): T = {
+    logger1.withPromptPaused(logger2.withPromptPaused(t))
+  }
+
   override def enableTicker: Boolean = logger1.enableTicker || logger2.enableTicker
 
-  override def subLogger(path: os.Path, key: String, message: String): Logger = {
+  private[mill] override def subLogger(path: os.Path, key: String, message: String): Logger = {
     new MultiLogger(
       colored,
       logger1.subLogger(path, key, message),

--- a/main/util/src/mill/util/PrefixLogger.scala
+++ b/main/util/src/mill/util/PrefixLogger.scala
@@ -98,7 +98,11 @@ class PrefixLogger(
   private[mill] override def setPromptLeftHeader(s: String): Unit = logger0.setPromptLeftHeader(s)
   override def enableTicker = logger0.enableTicker
 
-  private[mill] override def subLogger(path: os.Path, subKeySuffix: String, message: String): Logger = {
+  private[mill] override def subLogger(
+      path: os.Path,
+      subKeySuffix: String,
+      message: String
+  ): Logger = {
     new PrefixLogger(
       logger0,
       key :+ subKeySuffix,

--- a/main/util/src/mill/util/PrefixLogger.scala
+++ b/main/util/src/mill/util/PrefixLogger.scala
@@ -98,7 +98,7 @@ class PrefixLogger(
   private[mill] override def setPromptLeftHeader(s: String): Unit = logger0.setPromptLeftHeader(s)
   override def enableTicker = logger0.enableTicker
 
-  override def subLogger(path: os.Path, subKeySuffix: String, message: String): Logger = {
+  private[mill] override def subLogger(path: os.Path, subKeySuffix: String, message: String): Logger = {
     new PrefixLogger(
       logger0,
       key :+ subKeySuffix,
@@ -109,6 +109,7 @@ class PrefixLogger(
       message
     )
   }
+  private[mill] override def withPromptPaused[T](t: => T): T = logger0.withPromptPaused(t)
 }
 
 object PrefixLogger {

--- a/main/util/src/mill/util/PromptLogger.scala
+++ b/main/util/src/mill/util/PromptLogger.scala
@@ -138,7 +138,7 @@ private[mill] class PromptLogger(
       // After the prompt gets paused, wait until the `promptUpdaterThread` marks
       // `pauseNoticed = true`, so we can be sure it's done printing out prompt updates for
       // now and we can proceed with running `t` without any last updates slipping through
-      while(!pauseNoticed) Thread.sleep(1)
+      while (!pauseNoticed) Thread.sleep(1)
       // Clear the prompt so the code in `t` has a blank terminal to work with
       systemStreams0.err.write(AnsiNav.clearScreen(0).getBytes)
       systemStreams0.err.flush()

--- a/main/util/src/mill/util/PromptLogger.scala
+++ b/main/util/src/mill/util/PromptLogger.scala
@@ -51,6 +51,7 @@ private[mill] class PromptLogger(
 
   @volatile var stopped = false
   @volatile var paused = false
+  @volatile var pauseNoticed = false
 
   val promptUpdaterThread = new Thread(() =>
     while (!stopped) {
@@ -69,6 +70,8 @@ private[mill] class PromptLogger(
             refreshPrompt()
           }
         }
+      } else {
+        pauseNoticed = true
       }
     }
   )
@@ -129,16 +132,18 @@ private[mill] class PromptLogger(
   def systemStreams = streamManager.systemStreams
 
   private[mill] override def withPromptPaused[T](t: => T): T = {
+    pauseNoticed = false
     paused = true
-
     try {
+      // After the prompt gets paused, wait until the `promptUpdaterThread` marks
+      // `pauseNoticed = true`, so we can be sure it's done printing out prompt updates for
+      // now and we can proceed with running `t` without any last updates slipping through
+      while(!pauseNoticed) Thread.sleep(1)
       // Clear the prompt so the code in `t` has a blank terminal to work with
-      outputStream.flush()
-      errorStream.flush()
       systemStreams0.err.write(AnsiNav.clearScreen(0).getBytes)
-      SystemStreams.withStreams(systemStreams0) {
-        t
-      }
+      systemStreams0.err.flush()
+      t
+
     } finally paused = false
   }
 

--- a/main/util/src/mill/util/PromptLogger.scala
+++ b/main/util/src/mill/util/PromptLogger.scala
@@ -128,7 +128,6 @@ private[mill] class PromptLogger(
 
   def systemStreams = streamManager.systemStreams
 
-
   private[mill] override def withPromptPaused[T](t: => T): T = {
     paused = true
 

--- a/main/util/src/mill/util/PromptLogger.scala
+++ b/main/util/src/mill/util/PromptLogger.scala
@@ -127,6 +127,22 @@ private[mill] class PromptLogger(
   }
 
   def systemStreams = streamManager.systemStreams
+
+
+  private[mill] override def withPromptPaused[T](t: => T): T = {
+    paused = true
+
+    try {
+      // Clear the prompt so the code in `t` has a blank terminal to work with
+      outputStream.flush()
+      errorStream.flush()
+      systemStreams0.err.write(AnsiNav.clearScreen(0).getBytes)
+      SystemStreams.withStreams(systemStreams0) {
+        t
+      }
+    } finally paused = false
+  }
+
 }
 
 private[mill] object PromptLogger {

--- a/main/util/src/mill/util/ProxyLogger.scala
+++ b/main/util/src/mill/util/ProxyLogger.scala
@@ -36,6 +36,7 @@ class ProxyLogger(logger: Logger) extends Logger {
   private[mill] override def removePromptLine(key: Seq[String]): Unit = logger.removePromptLine(key)
   private[mill] override def removePromptLine(): Unit = logger.removePromptLine()
   private[mill] override def setPromptLeftHeader(s: String): Unit = logger.setPromptLeftHeader(s)
+  private[mill] override def withPromptPaused[T](t: => T): T = logger.withPromptPaused(t)
 
   override def enableTicker = logger.enableTicker
 }

--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -3,7 +3,7 @@ package mill.runner
 import mill.util.{ColorLogger, PrefixLogger, Watchable}
 import mill.main.BuildInfo
 import mill.main.client.CodeGenConstants._
-import mill.api.{PathRef, Val, internal}
+import mill.api.{PathRef, SystemStreams, Val, internal}
 import mill.eval.Evaluator
 import mill.main.RunScript
 import mill.resolve.SelectMode
@@ -356,7 +356,8 @@ class MillBuildBootstrap(
       methodCodeHashSignatures = methodCodeHashSignatures,
       disableCallgraph = disableCallgraph,
       allowPositionalCommandArgs = allowPositionalCommandArgs,
-      systemExit = systemExit
+      systemExit = systemExit,
+      exclusiveSystemStreams = SystemStreams.original
     )
   }
 

--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -1,7 +1,7 @@
 package mill
 package scalalib
 
-import mill.api.{DummyInputStream, JarManifest, PathRef, Result, SystemStreams, internal}
+import mill.api.{DummyInputStream, JarManifest, PathRef, Result, internal}
 import mill.main.BuildInfo
 import mill.util.{Jvm, Util}
 import mill.util.Jvm.createJar
@@ -437,22 +437,21 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
       Result.Failure("console needs to be run with the -i/--interactive flag")
     } else {
       val useJavaCp = "-usejavacp"
-      SystemStreams.withStreams(SystemStreams.original) {
-        Jvm.runSubprocess(
-          mainClass =
-            if (ZincWorkerUtil.isDottyOrScala3(scalaVersion()))
-              "dotty.tools.repl.Main"
-            else
-              "scala.tools.nsc.MainGenericRunner",
-          classPath = runClasspath().map(_.path) ++ scalaCompilerClasspath().map(
-            _.path
-          ),
-          jvmArgs = forkArgs(),
-          envArgs = forkEnv(),
-          mainArgs = Seq(useJavaCp) ++ consoleScalacOptions().filterNot(Set(useJavaCp)),
-          workingDir = forkWorkingDir()
-        )
-      }
+
+      Jvm.runSubprocess(
+        mainClass =
+          if (ZincWorkerUtil.isDottyOrScala3(scalaVersion()))
+            "dotty.tools.repl.Main"
+          else
+            "scala.tools.nsc.MainGenericRunner",
+        classPath = runClasspath().map(_.path) ++ scalaCompilerClasspath().map(
+          _.path
+        ),
+        jvmArgs = forkArgs(),
+        envArgs = forkEnv(),
+        mainArgs = Seq(useJavaCp) ++ consoleScalacOptions().filterNot(Set(useJavaCp)),
+        workingDir = forkWorkingDir()
+      )
       Result.Success(())
     }
   }
@@ -511,16 +510,14 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
     } else {
       val mainClass = ammoniteMainClass()
       T.log.debug(s"Using ammonite main class: ${mainClass}")
-      SystemStreams.withStreams(SystemStreams.original) {
-        Jvm.runSubprocess(
-          mainClass = mainClass,
-          classPath = ammoniteReplClasspath().map(_.path),
-          jvmArgs = forkArgs(),
-          envArgs = forkEnv(),
-          mainArgs = replOptions,
-          workingDir = forkWorkingDir()
-        )
-      }
+      Jvm.runSubprocess(
+        mainClass = mainClass,
+        classPath = ammoniteReplClasspath().map(_.path),
+        jvmArgs = forkArgs(),
+        envArgs = forkEnv(),
+        mainArgs = replOptions,
+        workingDir = forkWorkingDir()
+      )
       Result.Success(())
     }
 

--- a/testkit/src/mill/testkit/UnitTester.scala
+++ b/testkit/src/mill/testkit/UnitTester.scala
@@ -101,7 +101,8 @@ class UnitTester(
     methodCodeHashSignatures = Map(),
     disableCallgraph = false,
     allowPositionalCommandArgs = false,
-    systemExit = i => ???
+    systemExit = i => ???,
+    exclusiveSystemStreams = new SystemStreams(outStream, errStream, inStream)
   )
 
   def apply(args: String*): Either[Result.Failing[_], UnitTester.Result[Seq[_]]] = {


### PR DESCRIPTION
Turns out we still need it for `console` and `repl` commands in order to disable the prompt auto updater thread. But we can limit its use to only within `EvaluatorCore` for every `exclusive` command, rather than letting it be used in any random user-land task

Also refactors it such that `exclusive = true` commands use `SystemStreams.original` by default, allowing `def repl` and `def console` to work without overriding the system streams themselves

Tested manually

```
$ ./mill -i dist.launcher && (cd example/scalalib/basic/1-simple  && ../../../../out/dist/launcher.dest/run -i path compile sources + console + version)

[2579/2579] ========================================================================= dist.launcher ============================================================================= 2s
[5/57] path
sources
allSources
allSourceFiles
compile
[56/57] console
Welcome to Scala 2.13.11 (OpenJDK 64-Bit Server VM, Java 17.0.6).
Type in expressions for evaluation. Or try :help.

scala> 1 + 1
val res0: Int = 2

scala> :quit
[57/57] version
0.12.0-RC2-65-906911
[57/57] =============================================================== path compile sources + console + version ================================================================ 7s
lihaoyi mill$
```