### PR TITLE
Optimize `SoftReference` caches using `ConcurrentHashMap`'s `compute`

### DIFF
--- a/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
+++ b/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
@@ -694,7 +694,7 @@ object ZincWorkerImpl {
     protected val cache =
       new java.util.concurrent.ConcurrentHashMap[A, SoftReference[B]]
 
-    def getOrElseCreate(a: A)(create: => B) =
+    def getOrElseCreate(a: A)(create: => B): B =
       cache.compute(
         a,
         {


### PR DESCRIPTION
@bjaglin raised a great point about concurrent initialization in mill-scalafix: https://github.com/joan38/mill-scalafix/pull/206#discussion_r1781402921
In `ZincWorkerImpl` were using `synchronized` to avoid that, but the built-in `compute` method in `java.util.concurrent.ConcurrentHashMap` is probably better.

Pull Request: https://github.com/com-lihaoyi/mill/pull/3641