### PR TITLE
Concurrency fixes

### DIFF
--- a/main/eval/src/mill/eval/ExecutionContexts.scala
+++ b/main/eval/src/mill/eval/ExecutionContexts.scala
@@ -42,8 +42,15 @@ private object ExecutionContexts {
     val threadPool: ExecutorService = executor
 
     def updateThreadCount(delta: Int): Unit = synchronized {
-      executor.setMaximumPoolSize(executor.getMaximumPoolSize + delta)
+      if (delta > 0) {
+        executor.setMaximumPoolSize(executor.getMaximumPoolSize + delta)
+        executor.setCorePoolSize(executor.getCorePoolSize + delta)
+      } else {
+        executor.setCorePoolSize(executor.getCorePoolSize + delta)
+        executor.setMaximumPoolSize(executor.getMaximumPoolSize + delta)
+      }
     }
+
     def blocking[T](t: => T): T = {
       updateThreadCount(1)
       try t

--- a/main/eval/src/mill/eval/ExecutionContexts.scala
+++ b/main/eval/src/mill/eval/ExecutionContexts.scala
@@ -1,10 +1,10 @@
 package mill.eval
 
 import os.Path
+
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration.Duration
-import java.util.concurrent.ForkJoinPool.ManagedBlocker
-import java.util.concurrent.{ExecutorService, ForkJoinPool}
+import java.util.concurrent.{ExecutorService, LinkedBlockingQueue, ThreadPoolExecutor, TimeUnit}
 
 private object ExecutionContexts {
 
@@ -29,21 +29,28 @@ private object ExecutionContexts {
    * A simple thread-pool-based ExecutionContext with configurable thread count
    * and AutoCloseable support
    */
-  class ThreadPool(threadCount: Int) extends mill.api.Ctx.Fork.Impl {
+  class ThreadPool(threadCount0: Int) extends mill.api.Ctx.Fork.Impl {
     def await[T](t: Future[T]): T = blocking { Await.result(t, Duration.Inf) }
-    val forkJoinPool: ForkJoinPool = new ForkJoinPool(threadCount)
-    val threadPool: ExecutorService = forkJoinPool
+    val executor: ThreadPoolExecutor = new ThreadPoolExecutor(
+      threadCount0,
+      threadCount0,
+      0,
+      TimeUnit.SECONDS,
+      new LinkedBlockingQueue[Runnable]()
+    )
 
+    val threadPool: ExecutorService = executor
+
+    private var threadCount = threadCount0
+    def updateThreadCount(delta: Int): Unit = synchronized {
+      threadCount += delta
+      executor.setMaximumPoolSize(threadCount)
+      executor.setCorePoolSize(threadCount)
+    }
     def blocking[T](t: => T): T = {
-      @volatile var res: Option[T] = None
-      ForkJoinPool.managedBlock(new ManagedBlocker {
-        def block(): Boolean = {
-          if (res.isEmpty) res = Some(t)
-          true
-        }
-        def isReleasable: Boolean = res.nonEmpty
-      })
-      res.get
+      updateThreadCount(1)
+      try t
+      finally updateThreadCount(-1)
     }
 
     def execute(runnable: Runnable): Unit = {

--- a/main/eval/src/mill/eval/ExecutionContexts.scala
+++ b/main/eval/src/mill/eval/ExecutionContexts.scala
@@ -41,11 +41,8 @@ private object ExecutionContexts {
 
     val threadPool: ExecutorService = executor
 
-    private var threadCount = threadCount0
     def updateThreadCount(delta: Int): Unit = synchronized {
-      threadCount += delta
-      executor.setMaximumPoolSize(threadCount)
-      executor.setCorePoolSize(threadCount)
+      executor.setMaximumPoolSize(executor.getMaximumPoolSize + delta)
     }
     def blocking[T](t: => T): T = {
       updateThreadCount(1)

--- a/main/util/src/mill/util/PromptLogger.scala
+++ b/main/util/src/mill/util/PromptLogger.scala
@@ -86,8 +86,9 @@ private[mill] class PromptLogger(
 
   override def setPromptLeftHeader(s: String): Unit = synchronized { state.updateGlobal(s) }
   override def clearPromptStatuses(): Unit = synchronized { state.clearStatuses() }
-  override def removePromptLine(key: Seq[String]): Unit =
-    synchronized { state.updateCurrent(key, None) }
+  override def removePromptLine(key: Seq[String]): Unit = synchronized {
+    state.updateCurrent(key, None)
+  }
 
   def ticker(s: String): Unit = ()
   override def setPromptDetail(key: Seq[String], s: String): Unit = {
@@ -112,9 +113,8 @@ private[mill] class PromptLogger(
     synchronized {
       state.updateCurrent(key, Some(s"[${key.mkString("-")}] $message"))
       seenIdentifiers(key) = (verboseKeySuffix, message)
-      super.setPromptLine(key.map(infoColor(_).toString()), verboseKeySuffix, message)
-
     }
+
   def debug(s: String): Unit = synchronized { if (debugEnabled) systemStreams.err.println(s) }
 
   override def rawOutputStream: PrintStream = systemStreams0.out


### PR DESCRIPTION
* Swap from `ForkJoinPool` to `ThreadPoolExecutor`
    * `ForkJoinPool` does this weird thing where fork-join-tasks can be re-entrant at `join` points, resulting in weird scenarios where a mill-task that hits a yield point (e.g. inside Zinc / parallel-collections / FJP) can start running a second mill-task even before the first has finished, violating all sorts of invariants (# of running tasks exceeds `--jobs`, `FixSizeCache` semaphores get taken twice by the same thread, all sorts of craziness)
    * We replace `ForkJoinPool#ManagedBlocker` with our own manual logic increasing and decreasing the `ThreadPoolExecutor`s `maximumPoolSize` and `corePoolSize` in our `blocking{...}`  wrapper


* We need to `Thread#interrupt()` the `promptUpdaterThread` thread when we close the `PromptLogger`, so we don't need to wait the `promptUpdateInterval` (0.1ms for interactive, 60s for non-interactive) before exiting

This should fix some of the flakiness we've been seeing in master, that seems to have started from https://github.com/com-lihaoyi/mill/commit/05bef7ebd6aaa03365ecb68e32dcad43ba58462e (just eyeballing the CI history), and blocking our re-bootstrapping in https://github.com/com-lihaoyi/mill/pull/3637