### PR TITLE
Add Kotlin BSP integration test

### DIFF
--- a/bsp/src/mill/bsp/Constants.scala
+++ b/bsp/src/mill/bsp/Constants.scala
@@ -6,6 +6,6 @@ private[mill] object Constants {
   val bspProtocolVersion = BuildInfo.bsp4jVersion
   val bspWorkerImplClass = "mill.bsp.worker.BspWorkerImpl"
   val bspWorkerBuildInfoClass = "mill.bsp.worker.BuildInfo"
-  val languages: Seq[String] = Seq("java", "scala")
+  val languages: Seq[String] = Seq("java", "scala", "kotlin")
   val serverName = "mill-bsp"
 }

--- a/build.mill
+++ b/build.mill
@@ -449,7 +449,8 @@ trait MillBaseTestsModule extends TestModule {
       s"-DTEST_SCALATEST_VERSION=${Deps.TestDeps.scalaTest.dep.version}",
       s"-DTEST_TEST_INTERFACE_VERSION=${Deps.sbtTestInterface.dep.version}",
       s"-DTEST_ZIOTEST_VERSION=${Deps.TestDeps.zioTest.dep.version}",
-      s"-DTEST_ZINC_VERSION=${Deps.zinc.dep.version}"
+      s"-DTEST_ZINC_VERSION=${Deps.zinc.dep.version}",
+      s"-DTEST_KOTLIN_VERSION=${Deps.kotlinCompiler.dep.version}"
     )
   }
 

--- a/integration/ide/bsp-server/resources/project/build.mill
+++ b/integration/ide/bsp-server/resources/project/build.mill
@@ -1,10 +1,13 @@
 package build
 
 import mill._
-import mill.scalalib._
 
-object `hello-java` extends JavaModule
+object `hello-java` extends scalalib.JavaModule
 
-object `hello-scala` extends ScalaModule {
+object `hello-scala` extends scalalib.ScalaModule {
   def scalaVersion = Option(System.getenv("TEST_SCALA_2_13_VERSION")).getOrElse(???)
+}
+
+object `hello-kotlin` extends kotlinlib.KotlinModule {
+  def kotlinVersion = Option(System.getenv("TEST_KOTLIN_VERSION")).getOrElse(???)
 }

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-compile-classpaths.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-compile-classpaths.json
@@ -10,6 +10,16 @@
     },
     {
       "target": {
+        "uri": "file:///workspace/hello-kotlin"
+      },
+      "classpath": [
+        "file:///coursier-cache/https/repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/<kotlin-version>/kotlin-stdlib-<kotlin-version>.jar",
+        "file:///coursier-cache/https/repo1.maven.org/maven2/org/jetbrains/annotations/<annotations-version>/annotations-<annotations-version>.jar",
+        "file:///workspace/hello-kotlin/compile-resources"
+      ]
+    },
+    {
+      "target": {
         "uri": "file:///workspace/hello-scala"
       },
       "classpath": [

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-dependency-modules.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-dependency-modules.json
@@ -8,6 +8,17 @@
     },
     {
       "target": {
+        "uri": "file:///workspace/hello-kotlin"
+      },
+      "modules": [
+        {
+          "name": "org.jetbrains.kotlin:kotlin-stdlib",
+          "version": "<kotlin-version>"
+        }
+      ]
+    },
+    {
+      "target": {
         "uri": "file:///workspace/hello-scala"
       },
       "modules": [

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-dependency-sources.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-dependency-sources.json
@@ -8,6 +8,15 @@
     },
     {
       "target": {
+        "uri": "file:///workspace/hello-kotlin"
+      },
+      "sources": [
+        "file:///coursier-cache/https/repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/<kotlin-version>/kotlin-stdlib-<kotlin-version>-sources.jar",
+        "file:///coursier-cache/https/repo1.maven.org/maven2/org/jetbrains/annotations/<annotations-version>/annotations-<annotations-version>-sources.jar"
+      ]
+    },
+    {
+      "target": {
         "uri": "file:///workspace/hello-scala"
       },
       "sources": [

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-javac-options.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-javac-options.json
@@ -12,6 +12,18 @@
     },
     {
       "target": {
+        "uri": "file:///workspace/hello-kotlin"
+      },
+      "options": [],
+      "classpath": [
+        "file:///coursier-cache/https/repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/<kotlin-version>/kotlin-stdlib-<kotlin-version>.jar",
+        "file:///coursier-cache/https/repo1.maven.org/maven2/org/jetbrains/annotations/<annotations-version>/annotations-<annotations-version>.jar",
+        "file:///workspace/hello-kotlin/compile-resources"
+      ],
+      "classDirectory": "file:///workspace/out/hello-kotlin/compile.dest/classes"
+    },
+    {
+      "target": {
         "uri": "file:///workspace/hello-scala"
       },
       "options": [],

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-jvm-run-environments.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-jvm-run-environments.json
@@ -16,6 +16,22 @@
     },
     {
       "target": {
+        "uri": "file:///workspace/hello-kotlin"
+      },
+      "classpath": [
+        "file:///coursier-cache/https/repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/<kotlin-version>/kotlin-stdlib-<kotlin-version>.jar",
+        "file:///coursier-cache/https/repo1.maven.org/maven2/org/jetbrains/annotations/<annotations-version>/annotations-<annotations-version>.jar",
+        "file:///workspace/hello-kotlin/compile-resources",
+        "file:///workspace/hello-kotlin/resources",
+        "file:///workspace/out/hello-kotlin/compile.dest/classes"
+      ],
+      "jvmOptions": [],
+      "workingDirectory": "/workspace",
+      "environmentVariables": {},
+      "mainClasses": []
+    },
+    {
+      "target": {
         "uri": "file:///workspace/hello-scala"
       },
       "classpath": [

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-jvm-test-environments.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-jvm-test-environments.json
@@ -16,6 +16,22 @@
     },
     {
       "target": {
+        "uri": "file:///workspace/hello-kotlin"
+      },
+      "classpath": [
+        "file:///coursier-cache/https/repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/<kotlin-version>/kotlin-stdlib-<kotlin-version>.jar",
+        "file:///coursier-cache/https/repo1.maven.org/maven2/org/jetbrains/annotations/<annotations-version>/annotations-<annotations-version>.jar",
+        "file:///workspace/hello-kotlin/compile-resources",
+        "file:///workspace/hello-kotlin/resources",
+        "file:///workspace/out/hello-kotlin/compile.dest/classes"
+      ],
+      "jvmOptions": [],
+      "workingDirectory": "/workspace",
+      "environmentVariables": {},
+      "mainClasses": []
+    },
+    {
+      "target": {
         "uri": "file:///workspace/hello-scala"
       },
       "classpath": [

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-output-paths.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-output-paths.json
@@ -8,6 +8,12 @@
     },
     {
       "target": {
+        "uri": "file:///workspace/hello-kotlin"
+      },
+      "outputPaths": []
+    },
+    {
+      "target": {
         "uri": "file:///workspace/hello-scala"
       },
       "outputPaths": []

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-resources.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-resources.json
@@ -8,6 +8,12 @@
     },
     {
       "target": {
+        "uri": "file:///workspace/hello-kotlin"
+      },
+      "resources": []
+    },
+    {
+      "target": {
         "uri": "file:///workspace/hello-scala"
       },
       "resources": []

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-scalac-options.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-scalac-options.json
@@ -12,6 +12,18 @@
     },
     {
       "target": {
+        "uri": "file:///workspace/hello-kotlin"
+      },
+      "options": [],
+      "classpath": [
+        "file:///coursier-cache/https/repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/<kotlin-version>/kotlin-stdlib-<kotlin-version>.jar",
+        "file:///coursier-cache/https/repo1.maven.org/maven2/org/jetbrains/annotations/<annotations-version>/annotations-<annotations-version>.jar",
+        "file:///workspace/hello-kotlin/compile-resources"
+      ],
+      "classDirectory": "file:///workspace/out/hello-kotlin/compile.dest/classes"
+    },
+    {
+      "target": {
         "uri": "file:///workspace/hello-scala"
       },
       "options": [],

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-sources.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-sources.json
@@ -14,6 +14,18 @@
     },
     {
       "target": {
+        "uri": "file:///workspace/hello-kotlin"
+      },
+      "sources": [
+        {
+          "uri": "file:///workspace/hello-kotlin/src",
+          "kind": 2,
+          "generated": false
+        }
+      ]
+    },
+    {
+      "target": {
         "uri": "file:///workspace/hello-scala"
       },
       "sources": [

--- a/integration/ide/bsp-server/resources/snapshots/initialize-build-result.json
+++ b/integration/ide/bsp-server/resources/snapshots/initialize-build-result.json
@@ -6,19 +6,22 @@
     "compileProvider": {
       "languageIds": [
         "java",
-        "scala"
+        "scala",
+        "kotlin"
       ]
     },
     "testProvider": {
       "languageIds": [
         "java",
-        "scala"
+        "scala",
+        "kotlin"
       ]
     },
     "runProvider": {
       "languageIds": [
         "java",
-        "scala"
+        "scala",
+        "kotlin"
       ]
     },
     "debugProvider": {

--- a/integration/ide/bsp-server/resources/snapshots/workspace-build-targets.json
+++ b/integration/ide/bsp-server/resources/snapshots/workspace-build-targets.json
@@ -28,6 +28,33 @@
     },
     {
       "id": {
+        "uri": "file:///workspace/hello-kotlin"
+      },
+      "displayName": "hello-kotlin",
+      "baseDirectory": "file:///workspace/hello-kotlin",
+      "tags": [
+        "library",
+        "application"
+      ],
+      "languageIds": [
+        "java",
+        "kotlin"
+      ],
+      "dependencies": [],
+      "capabilities": {
+        "canCompile": true,
+        "canTest": false,
+        "canRun": true,
+        "canDebug": false
+      },
+      "dataKind": "jvm",
+      "data": {
+        "javaHome": "file:///java-home/",
+        "javaVersion": "<java-version>"
+      }
+    },
+    {
+      "id": {
         "uri": "file:///workspace/hello-scala"
       },
       "displayName": "hello-scala",

--- a/integration/ide/bsp-server/src/BspServerTestUtil.scala
+++ b/integration/ide/bsp-server/src/BspServerTestUtil.scala
@@ -167,7 +167,7 @@ object BspServerTestUtil {
           BuildInfo.millVersion,
           b.Bsp4j.PROTOCOL_VERSION,
           workspacePath.toNIO.toUri.toASCIIString,
-          new b.BuildClientCapabilities(List("java", "scala").asJava)
+          new b.BuildClientCapabilities(List("java", "scala", "kotlin").asJava)
         )
       ).get()
 

--- a/integration/ide/bsp-server/src/BspServerTests.scala
+++ b/integration/ide/bsp-server/src/BspServerTests.scala
@@ -15,7 +15,7 @@ object BspServerTests extends UtestIntegrationTestSuite {
   override protected def workspaceSourcePath: os.Path =
     super.workspaceSourcePath / "project"
 
-  def substitutions(
+  def transitiveDependenciesSubstitutions(
       dependency: coursierapi.Dependency,
       filter: coursierapi.Dependency => Boolean
   ): Seq[(String, String)] = {
@@ -51,7 +51,7 @@ object BspServerTests extends UtestIntegrationTestSuite {
         millTestSuiteEnv
       ) { (buildServer, initRes) =>
         val scalaVersion = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
-        val scalaTransitiveSubstitutions = substitutions(
+        val scalaTransitiveSubstitutions = transitiveDependenciesSubstitutions(
           coursierapi.Dependency.of(
             "org.scala-lang",
             "scala-compiler",
@@ -61,7 +61,7 @@ object BspServerTests extends UtestIntegrationTestSuite {
         )
 
         val kotlinVersion = sys.props.getOrElse("TEST_KOTLIN_VERSION", ???)
-        val kotlinTransitiveSubstitutions = substitutions(
+        val kotlinTransitiveSubstitutions = transitiveDependenciesSubstitutions(
           coursierapi.Dependency.of(
             "org.jetbrains.kotlin",
             "kotlin-stdlib",

--- a/integration/ide/bsp-server/src/BspServerTests.scala
+++ b/integration/ide/bsp-server/src/BspServerTests.scala
@@ -51,9 +51,30 @@ object BspServerTests extends UtestIntegrationTestSuite {
             }
         }
 
-        val normalizedLocalValues =
-          normalizeLocalValuesForTesting(workspacePath) ++ scalaTransitiveSubstitutions ++ Seq(
-            scalaVersion -> "<scala-version>"
+        val kotlinVersion = sys.props.getOrElse("TEST_KOTLIN_VERSION", ???)
+        val kotlinTransitiveSubstitutions = {
+          val scalaFetchRes = coursierapi.Fetch.create()
+            .addDependencies(coursierapi.Dependency.of(
+              "org.jetbrains.kotlin",
+              "kotlin-stdlib",
+              kotlinVersion
+            ))
+            .fetchResult()
+          scalaFetchRes.getDependencies.asScala
+            .filter(dep => dep.getModule.getOrganization != "org.jetbrains.kotlin")
+            .map { dep =>
+              def basePath(version: String) =
+                s"${dep.getModule.getOrganization.split('.').mkString("/")}/${dep.getModule.getName}/$version/${dep.getModule.getName}-$version"
+              basePath(dep.getVersion) -> basePath(s"<${dep.getModule.getName}-version>")
+            }
+        }
+
+        val normalizedLocalValues = normalizeLocalValuesForTesting(workspacePath) ++
+          scalaTransitiveSubstitutions ++
+          kotlinTransitiveSubstitutions ++
+          Seq(
+            scalaVersion -> "<scala-version>",
+            kotlinVersion -> "<kotlin-version>"
           )
 
         compareWithGsonSnapshot(

--- a/integration/package.mill
+++ b/integration/package.mill
@@ -76,7 +76,8 @@ object `package` extends RootModule {
     override def moduleDeps = super[IntegrationTestModule].moduleDeps
     def forkEnv = super.forkEnv() ++ Seq(
       "MILL_PROJECT_ROOT" -> T.workspace.toString,
-      "TEST_SCALA_2_13_VERSION" -> build.Deps.testScala213Version
+      "TEST_SCALA_2_13_VERSION" -> build.Deps.testScala213Version,
+      "TEST_KOTLIN_VERSION" -> build.Deps.kotlinCompiler.dep.version
     )
   }
   trait IdeIntegrationCrossModule extends IntegrationCrossModule {

--- a/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -5,10 +5,11 @@
 package mill
 package kotlinlib
 
-import mill.api.{Loose, PathRef, Result}
+import mill.api.{Loose, PathRef, Result, internal}
 import mill.define.{Command, ModuleRef, Task}
 import mill.kotlinlib.worker.api.{KotlinWorker, KotlinWorkerTarget}
 import mill.scalalib.api.{CompilationResult, ZincWorkerApi}
+import mill.scalalib.bsp.{BspBuildTarget, BspModule}
 import mill.scalalib.{JavaModule, Lib, ZincWorkerModule}
 import mill.util.Jvm
 import mill.util.Util.millProjectModule
@@ -313,6 +314,13 @@ trait KotlinModule extends JavaModule { outer =>
   }
 
   private[kotlinlib] def internalReportOldProblems: Task[Boolean] = zincReportCachedProblems
+
+  @internal
+  override def bspBuildTarget: BspBuildTarget = super.bspBuildTarget.copy(
+    languageIds = Seq(BspModule.LanguageId.Java, BspModule.LanguageId.Kotlin),
+    canCompile = true,
+    canRun = true
+  )
 
   /**
    * A test sub-module linked to its parent module best suited for unit-tests.

--- a/scalalib/src/mill/scalalib/bsp/BspModule.scala
+++ b/scalalib/src/mill/scalalib/bsp/BspModule.scala
@@ -46,6 +46,7 @@ object BspModule {
   object LanguageId {
     val Java = "java"
     val Scala = "scala"
+    val Kotlin = "kotlin"
   }
 
   /** Used to define the [[BspBuildTarget.tags]] field. */


### PR DESCRIPTION
This PR adds non-regression integration tests for Kotlin support via BSP. Kotlin modules are currently advertized as Java ones, and IntelliJ seems to handle fine Kotlin sources in those (using non-experimental BSP support).