### PR TITLE
Add Kotlin-specific data in BSP build targets

### DIFF
--- a/bsp/src/mill/bsp/Constants.scala
+++ b/bsp/src/mill/bsp/Constants.scala
@@ -6,6 +6,6 @@ private[mill] object Constants {
   val bspProtocolVersion = BuildInfo.bsp4jVersion
   val bspWorkerImplClass = "mill.bsp.worker.BspWorkerImpl"
   val bspWorkerBuildInfoClass = "mill.bsp.worker.BuildInfo"
-  val languages: Seq[String] = Seq("java", "scala")
+  val languages: Seq[String] = Seq("java", "scala", "kotlin")
   val serverName = "mill-bsp"
 }

--- a/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -10,6 +10,7 @@ import mill.define.Segment.Label
 import mill.define.{Args, Discover, ExternalModule, Task}
 import mill.eval.Evaluator
 import mill.eval.Evaluator.TaskResult
+import mill.kotlinlib.bsp.KotlinBuildTarget
 import mill.main.MainModule
 import mill.runner.MillBuildRootModule
 import mill.scalalib.bsp.{BspModule, JvmBuildTarget, ScalaBuildTarget}
@@ -182,6 +183,16 @@ private class MillBuildServer(
           )
           for (jvmBuildTarget <- d.jvmBuildTarget)
             target.setJvmBuildTarget(MillBuildServer.jvmBuildTarget(jvmBuildTarget))
+          Some((dataKind, target))
+
+        case Some((dataKind, d: KotlinBuildTarget)) =>
+          val target = new protocol.KotlinBuildTarget(
+            d.languageVersion,
+            d.apiVersion,
+            d.kotlincOptions.asJava,
+            d.associates.map(uri => new BuildTargetIdentifier(uri.toASCIIString)).asJava,
+            d.jvmBuildTarget.map(MillBuildServer.jvmBuildTarget).orNull
+          )
           Some((dataKind, target))
 
         case Some((dataKind, d: JvmBuildTarget)) =>

--- a/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -175,14 +175,12 @@ private class MillBuildServer(
             bsp4j.ScalaPlatform.forValue(d.platform.number),
             d.jars.asJava
           )
+          for (jvmBuildTarget <- d.jvmBuildTarget)
+            target.setJvmBuildTarget(MillBuildServer.jvmBuildTarget(jvmBuildTarget))
           Some((dataKind, target))
 
         case Some((dataKind, d: JvmBuildTarget)) =>
-          val target = new bsp4j.JvmBuildTarget().tap { it =>
-            d.javaHome.foreach(jh => it.setJavaHome(jh.uri))
-            d.javaVersion.foreach(jv => it.setJavaVersion(jv))
-          }
-          Some((dataKind, target))
+          Some((dataKind, jvmBuildTarget(d)))
 
         case Some((dataKind, d)) =>
           debug(s"Unsupported dataKind=${dataKind} with value=${d}")
@@ -784,4 +782,10 @@ private object MillBuildServer {
       .toSeq
       .sortBy { case (k, _) => keyIndices(k) }
   }
+
+  def jvmBuildTarget(d: JvmBuildTarget): bsp4j.JvmBuildTarget =
+    new bsp4j.JvmBuildTarget().tap { it =>
+      d.javaHome.foreach(jh => it.setJavaHome(jh.uri))
+      d.javaVersion.foreach(jv => it.setJavaVersion(jv))
+    }
 }

--- a/bsp/worker/src/mill/bsp/worker/SyntheticRootBspBuildTargetData.scala
+++ b/bsp/worker/src/mill/bsp/worker/SyntheticRootBspBuildTargetData.scala
@@ -41,7 +41,9 @@ object SyntheticRootBspBuildTargetData {
       workspaceDir: os.Path
   ): Option[SyntheticRootBspBuildTargetData] = {
     def containsWorkspaceDir(path: Option[os.Path]) = path.exists(workspaceDir.startsWith)
-    if (existingModules.exists { m => containsWorkspaceDir(m.bspBuildTarget.baseDirectory) }) None
+    if (
+      existingModules.exists { m => containsWorkspaceDir(m.bspBuildTarget("", Nil).baseDirectory) }
+    ) None
     else Some(new SyntheticRootBspBuildTargetData(workspaceDir))
   }
 }

--- a/bsp/worker/src/mill/bsp/worker/Utils.scala
+++ b/bsp/worker/src/mill/bsp/worker/Utils.scala
@@ -5,6 +5,7 @@ import ch.epfl.scala.bsp4j.{
   BuildTarget,
   BuildTargetCapabilities,
   BuildTargetIdentifier,
+  InitializeBuildParams,
   OutputPathItem,
   OutputPathItemKind,
   StatusCode,
@@ -33,11 +34,15 @@ private object Utils {
   def getBspLoggedReporterPool(
       originId: String,
       bspIdsByModule: Map[BspModule, BuildTargetIdentifier],
+      clientParams: InitializeBuildParams,
       client: BuildClient
   ): Int => Option[CompileProblemReporter] = { moduleHashCode: Int =>
     bspIdsByModule.find(_._1.hashCode == moduleHashCode).map {
       case (module: JavaModule, targetId) =>
-        val buildTarget = module.bspBuildTarget
+        val buildTarget = module.bspBuildTarget(
+          clientParams.getDisplayName,
+          clientParams.getCapabilities.getLanguageIds.asScala.toSeq
+        )
         val taskId = new TaskId(module.compile.hashCode.toString)
         new BspCompileProblemReporter(
           client,

--- a/bsp/worker/src/mill/bsp/worker/protocol/KotlinBuildTarget.scala
+++ b/bsp/worker/src/mill/bsp/worker/protocol/KotlinBuildTarget.scala
@@ -1,0 +1,16 @@
+package mill.bsp.worker.protocol
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier
+import ch.epfl.scala.bsp4j.JvmBuildTarget
+
+import java.util.{List => JList}
+
+// based on https://github.com/JetBrains/hirschgarten/blob/da332f97a3ff34a2698b9edec58f66aab55d26e4/protocol/src/main/kotlin/org/jetbrains/bsp/protocol/KotlinBuildTarget.kt
+
+final class KotlinBuildTarget(
+    val languageVersion: String,
+    val apiVersion: String,
+    val kotlincOptions: JList[String],
+    val associates: JList[BuildTargetIdentifier],
+    val jvmBuildTarget: JvmBuildTarget
+)

--- a/build.mill
+++ b/build.mill
@@ -449,7 +449,8 @@ trait MillBaseTestsModule extends TestModule {
       s"-DTEST_SCALATEST_VERSION=${Deps.TestDeps.scalaTest.dep.version}",
       s"-DTEST_TEST_INTERFACE_VERSION=${Deps.sbtTestInterface.dep.version}",
       s"-DTEST_ZIOTEST_VERSION=${Deps.TestDeps.zioTest.dep.version}",
-      s"-DTEST_ZINC_VERSION=${Deps.zinc.dep.version}"
+      s"-DTEST_ZINC_VERSION=${Deps.zinc.dep.version}",
+      s"-DTEST_KOTLIN_VERSION=${Deps.kotlinCompiler.dep.version}"
     )
   }
 

--- a/integration/ide/bsp-server/resources/project/build.mill
+++ b/integration/ide/bsp-server/resources/project/build.mill
@@ -1,10 +1,13 @@
 package build
 
 import mill._
-import mill.scalalib._
 
-object `hello-java` extends JavaModule
+object `hello-java` extends scalalib.JavaModule
 
-object `hello-scala` extends ScalaModule {
+object `hello-scala` extends scalalib.ScalaModule {
   def scalaVersion = Option(System.getenv("TEST_SCALA_2_13_VERSION")).getOrElse(???)
+}
+
+object `hello-kotlin` extends kotlinlib.KotlinModule {
+  def kotlinVersion = Option(System.getenv("TEST_KOTLIN_VERSION")).getOrElse(???)
 }

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-compile-classpaths.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-compile-classpaths.json
@@ -10,6 +10,16 @@
     },
     {
       "target": {
+        "uri": "file:///workspace/hello-kotlin"
+      },
+      "classpath": [
+        "file:///coursier-cache/https/repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/<kotlin-version>/kotlin-stdlib-<kotlin-version>.jar",
+        "file:///coursier-cache/https/repo1.maven.org/maven2/org/jetbrains/annotations/<annotations-version>/annotations-<annotations-version>.jar",
+        "file:///workspace/hello-kotlin/compile-resources"
+      ]
+    },
+    {
+      "target": {
         "uri": "file:///workspace/hello-scala"
       },
       "classpath": [

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-dependency-modules.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-dependency-modules.json
@@ -8,6 +8,17 @@
     },
     {
       "target": {
+        "uri": "file:///workspace/hello-kotlin"
+      },
+      "modules": [
+        {
+          "name": "org.jetbrains.kotlin:kotlin-stdlib",
+          "version": "<kotlin-version>"
+        }
+      ]
+    },
+    {
+      "target": {
         "uri": "file:///workspace/hello-scala"
       },
       "modules": [

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-dependency-sources.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-dependency-sources.json
@@ -8,6 +8,15 @@
     },
     {
       "target": {
+        "uri": "file:///workspace/hello-kotlin"
+      },
+      "sources": [
+        "file:///coursier-cache/https/repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/<kotlin-version>/kotlin-stdlib-<kotlin-version>-sources.jar",
+        "file:///coursier-cache/https/repo1.maven.org/maven2/org/jetbrains/annotations/<annotations-version>/annotations-<annotations-version>-sources.jar"
+      ]
+    },
+    {
+      "target": {
         "uri": "file:///workspace/hello-scala"
       },
       "sources": [

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-javac-options.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-javac-options.json
@@ -12,6 +12,18 @@
     },
     {
       "target": {
+        "uri": "file:///workspace/hello-kotlin"
+      },
+      "options": [],
+      "classpath": [
+        "file:///coursier-cache/https/repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/<kotlin-version>/kotlin-stdlib-<kotlin-version>.jar",
+        "file:///coursier-cache/https/repo1.maven.org/maven2/org/jetbrains/annotations/<annotations-version>/annotations-<annotations-version>.jar",
+        "file:///workspace/hello-kotlin/compile-resources"
+      ],
+      "classDirectory": "file:///workspace/out/hello-kotlin/compile.dest/classes"
+    },
+    {
+      "target": {
         "uri": "file:///workspace/hello-scala"
       },
       "options": [],

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-jvm-run-environments.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-jvm-run-environments.json
@@ -16,6 +16,22 @@
     },
     {
       "target": {
+        "uri": "file:///workspace/hello-kotlin"
+      },
+      "classpath": [
+        "file:///coursier-cache/https/repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/<kotlin-version>/kotlin-stdlib-<kotlin-version>.jar",
+        "file:///coursier-cache/https/repo1.maven.org/maven2/org/jetbrains/annotations/<annotations-version>/annotations-<annotations-version>.jar",
+        "file:///workspace/hello-kotlin/compile-resources",
+        "file:///workspace/hello-kotlin/resources",
+        "file:///workspace/out/hello-kotlin/compile.dest/classes"
+      ],
+      "jvmOptions": [],
+      "workingDirectory": "/workspace",
+      "environmentVariables": {},
+      "mainClasses": []
+    },
+    {
+      "target": {
         "uri": "file:///workspace/hello-scala"
       },
       "classpath": [

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-jvm-test-environments.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-jvm-test-environments.json
@@ -16,6 +16,22 @@
     },
     {
       "target": {
+        "uri": "file:///workspace/hello-kotlin"
+      },
+      "classpath": [
+        "file:///coursier-cache/https/repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/<kotlin-version>/kotlin-stdlib-<kotlin-version>.jar",
+        "file:///coursier-cache/https/repo1.maven.org/maven2/org/jetbrains/annotations/<annotations-version>/annotations-<annotations-version>.jar",
+        "file:///workspace/hello-kotlin/compile-resources",
+        "file:///workspace/hello-kotlin/resources",
+        "file:///workspace/out/hello-kotlin/compile.dest/classes"
+      ],
+      "jvmOptions": [],
+      "workingDirectory": "/workspace",
+      "environmentVariables": {},
+      "mainClasses": []
+    },
+    {
+      "target": {
         "uri": "file:///workspace/hello-scala"
       },
       "classpath": [

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-output-paths.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-output-paths.json
@@ -8,6 +8,12 @@
     },
     {
       "target": {
+        "uri": "file:///workspace/hello-kotlin"
+      },
+      "outputPaths": []
+    },
+    {
+      "target": {
         "uri": "file:///workspace/hello-scala"
       },
       "outputPaths": []

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-resources.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-resources.json
@@ -8,6 +8,12 @@
     },
     {
       "target": {
+        "uri": "file:///workspace/hello-kotlin"
+      },
+      "resources": []
+    },
+    {
+      "target": {
         "uri": "file:///workspace/hello-scala"
       },
       "resources": []

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-scalac-options.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-scalac-options.json
@@ -12,6 +12,18 @@
     },
     {
       "target": {
+        "uri": "file:///workspace/hello-kotlin"
+      },
+      "options": [],
+      "classpath": [
+        "file:///coursier-cache/https/repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/<kotlin-version>/kotlin-stdlib-<kotlin-version>.jar",
+        "file:///coursier-cache/https/repo1.maven.org/maven2/org/jetbrains/annotations/<annotations-version>/annotations-<annotations-version>.jar",
+        "file:///workspace/hello-kotlin/compile-resources"
+      ],
+      "classDirectory": "file:///workspace/out/hello-kotlin/compile.dest/classes"
+    },
+    {
+      "target": {
         "uri": "file:///workspace/hello-scala"
       },
       "options": [],

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-sources.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-sources.json
@@ -14,6 +14,18 @@
     },
     {
       "target": {
+        "uri": "file:///workspace/hello-kotlin"
+      },
+      "sources": [
+        {
+          "uri": "file:///workspace/hello-kotlin/src",
+          "kind": 2,
+          "generated": false
+        }
+      ]
+    },
+    {
+      "target": {
         "uri": "file:///workspace/hello-scala"
       },
       "sources": [

--- a/integration/ide/bsp-server/resources/snapshots/initialize-build-result.json
+++ b/integration/ide/bsp-server/resources/snapshots/initialize-build-result.json
@@ -6,19 +6,22 @@
     "compileProvider": {
       "languageIds": [
         "java",
-        "scala"
+        "scala",
+        "kotlin"
       ]
     },
     "testProvider": {
       "languageIds": [
         "java",
-        "scala"
+        "scala",
+        "kotlin"
       ]
     },
     "runProvider": {
       "languageIds": [
         "java",
-        "scala"
+        "scala",
+        "kotlin"
       ]
     },
     "debugProvider": {

--- a/integration/ide/bsp-server/resources/snapshots/workspace-build-targets-intellij-scala.json
+++ b/integration/ide/bsp-server/resources/snapshots/workspace-build-targets-intellij-scala.json
@@ -47,22 +47,10 @@
         "canRun": true,
         "canDebug": false
       },
-      "dataKind": "kotlin",
+      "dataKind": "jvm",
       "data": {
-        "languageVersion": "<kotlin-version>",
-        "apiVersion": "<kotlin-version>",
-        "kotlincOptions": [
-          "-no-stdlib",
-          "-language-version",
-          "1.9",
-          "-api-version",
-          "1.9"
-        ],
-        "associates": [],
-        "jvmBuildTarget": {
-          "javaHome": "file:///java-home/",
-          "javaVersion": "<java-version>"
-        }
+        "javaHome": "file:///java-home/",
+        "javaVersion": "<java-version>"
       }
     },
     {

--- a/integration/ide/bsp-server/resources/snapshots/workspace-build-targets.json
+++ b/integration/ide/bsp-server/resources/snapshots/workspace-build-targets.json
@@ -28,6 +28,33 @@
     },
     {
       "id": {
+        "uri": "file:///workspace/hello-kotlin"
+      },
+      "displayName": "hello-kotlin",
+      "baseDirectory": "file:///workspace/hello-kotlin",
+      "tags": [
+        "library",
+        "application"
+      ],
+      "languageIds": [
+        "java",
+        "kotlin"
+      ],
+      "dependencies": [],
+      "capabilities": {
+        "canCompile": true,
+        "canTest": false,
+        "canRun": true,
+        "canDebug": false
+      },
+      "dataKind": "jvm",
+      "data": {
+        "javaHome": "file:///java-home/",
+        "javaVersion": "<java-version>"
+      }
+    },
+    {
+      "id": {
         "uri": "file:///workspace/hello-scala"
       },
       "displayName": "hello-scala",

--- a/integration/ide/bsp-server/resources/snapshots/workspace-build-targets.json
+++ b/integration/ide/bsp-server/resources/snapshots/workspace-build-targets.json
@@ -87,7 +87,11 @@
           "file:///coursier-cache/https/repo1.maven.org/maven2/io/github/java-diff-utils/java-diff-utils/<java-diff-utils-version>/java-diff-utils-<java-diff-utils-version>.jar",
           "file:///coursier-cache/https/repo1.maven.org/maven2/org/jline/jline/<jline-version>/jline-<jline-version>.jar",
           "file:///coursier-cache/https/repo1.maven.org/maven2/net/java/dev/jna/jna/<jna-version>/jna-<jna-version>.jar"
-        ]
+        ],
+        "jvmBuildTarget": {
+          "javaHome": "file:///java-home/",
+          "javaVersion": "<java-version>"
+        }
       }
     },
     {
@@ -121,7 +125,11 @@
           "file:///coursier-cache/https/repo1.maven.org/maven2/org/scala-lang/scala-compiler/<scala-version>/scala-compiler-<scala-version>.jar",
           "file:///coursier-cache/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/<scala-version>/scala-reflect-<scala-version>.jar",
           "file:///coursier-cache/https/repo1.maven.org/maven2/org/scala-lang/scala-library/<scala-version>/scala-library-<scala-version>.jar"
-        ]
+        ],
+        "jvmBuildTarget": {
+          "javaHome": "file:///java-home/",
+          "javaVersion": "<java-version>"
+        }
       }
     },
     {

--- a/integration/ide/bsp-server/src/BspServerTestUtil.scala
+++ b/integration/ide/bsp-server/src/BspServerTestUtil.scala
@@ -111,9 +111,13 @@ object BspServerTestUtil {
   trait MillBuildServer extends b.BuildServer with b.JvmBuildServer
       with b.JavaBuildServer with b.ScalaBuildServer
 
+  def defaultClientDisplayName = "Mill Integration"
+  def defaultClientSupportedLanguages = Seq("java", "scala", "kotlin")
   def withBspServer[T](
       workspacePath: os.Path,
-      millTestSuiteEnv: Map[String, String]
+      millTestSuiteEnv: Map[String, String],
+      clientDisplayName: String = defaultClientDisplayName,
+      clientSupportedLanguages: Seq[String] = defaultClientSupportedLanguages
   )(f: (MillBuildServer, b.InitializeBuildResult) => T): T = {
 
     val bspMetadataFile = workspacePath / Constants.bspDir / s"${Constants.serverName}.json"
@@ -163,11 +167,11 @@ object BspServerTestUtil {
 
       val initRes = buildServer.buildInitialize(
         new b.InitializeBuildParams(
-          "Mill Integration",
+          clientDisplayName,
           BuildInfo.millVersion,
           b.Bsp4j.PROTOCOL_VERSION,
           workspacePath.toNIO.toUri.toASCIIString,
-          new b.BuildClientCapabilities(List("java", "scala", "kotlin").asJava)
+          new b.BuildClientCapabilities(clientSupportedLanguages.asJava)
         )
       ).get()
 

--- a/integration/ide/bsp-server/src/BspServerTestUtil.scala
+++ b/integration/ide/bsp-server/src/BspServerTestUtil.scala
@@ -167,7 +167,7 @@ object BspServerTestUtil {
           BuildInfo.millVersion,
           b.Bsp4j.PROTOCOL_VERSION,
           workspacePath.toNIO.toUri.toASCIIString,
-          new b.BuildClientCapabilities(List("java", "scala").asJava)
+          new b.BuildClientCapabilities(List("java", "scala", "kotlin").asJava)
         )
       ).get()
 

--- a/integration/ide/bsp-server/src/BspServerTests.scala
+++ b/integration/ide/bsp-server/src/BspServerTests.scala
@@ -51,9 +51,30 @@ object BspServerTests extends UtestIntegrationTestSuite {
             }
         }
 
-        val normalizedLocalValues =
-          normalizeLocalValuesForTesting(workspacePath) ++ scalaTransitiveSubstitutions ++ Seq(
-            scalaVersion -> "<scala-version>"
+        val kotlinVersion = sys.props.getOrElse("TEST_KOTLIN_VERSION", ???)
+        val kotlinTransitiveSubstitutions = {
+          val scalaFetchRes = coursierapi.Fetch.create()
+            .addDependencies(coursierapi.Dependency.of(
+              "org.jetbrains.kotlin",
+              "kotlin-stdlib",
+              kotlinVersion
+            ))
+            .fetchResult()
+          scalaFetchRes.getDependencies.asScala
+            .filter(dep => dep.getModule.getOrganization != "org.jetbrains.kotlin")
+            .map { dep =>
+              def basePath(version: String) =
+                s"${dep.getModule.getOrganization.split('.').mkString("/")}/${dep.getModule.getName}/$version/${dep.getModule.getName}-$version"
+              basePath(dep.getVersion) -> basePath(s"<${dep.getModule.getName}-version>")
+            }
+        }
+
+        val normalizedLocalValues = normalizeLocalValuesForTesting(workspacePath) ++
+          scalaTransitiveSubstitutions ++
+          kotlinTransitiveSubstitutions ++
+          Seq(
+            scalaVersion -> "<scala-version>",
+            kotlinVersion -> "<kotlin-version>"
           )
 
         compareWithGsonSnapshot(

--- a/integration/package.mill
+++ b/integration/package.mill
@@ -76,7 +76,8 @@ object `package` extends RootModule {
     override def moduleDeps = super[IntegrationTestModule].moduleDeps
     def forkEnv = super.forkEnv() ++ Seq(
       "MILL_PROJECT_ROOT" -> T.workspace.toString,
-      "TEST_SCALA_2_13_VERSION" -> build.Deps.testScala213Version
+      "TEST_SCALA_2_13_VERSION" -> build.Deps.testScala213Version,
+      "TEST_KOTLIN_VERSION" -> build.Deps.kotlinCompiler.dep.version
     )
   }
   trait IdeIntegrationCrossModule extends IntegrationCrossModule {

--- a/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -316,7 +316,10 @@ trait KotlinModule extends JavaModule { outer =>
   private[kotlinlib] def internalReportOldProblems: Task[Boolean] = zincReportCachedProblems
 
   @internal
-  override def bspBuildTarget: BspBuildTarget = super.bspBuildTarget.copy(
+  def bspBuildTarget(
+      clientDisplayName: String,
+      clientSupportedLanguages: Seq[String]
+  ): BspBuildTarget = super.bspBuildTarget(clientDisplayName, clientSupportedLanguages).copy(
     languageIds = Seq(BspModule.LanguageId.Java, BspModule.LanguageId.Kotlin),
     canCompile = true,
     canRun = true

--- a/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -5,10 +5,11 @@
 package mill
 package kotlinlib
 
-import mill.api.{Loose, PathRef, Result}
+import mill.api.{Loose, PathRef, Result, internal}
 import mill.define.{Command, ModuleRef, Task}
 import mill.kotlinlib.worker.api.{KotlinWorker, KotlinWorkerTarget}
 import mill.scalalib.api.{CompilationResult, ZincWorkerApi}
+import mill.scalalib.bsp.{BspBuildTarget, BspModule}
 import mill.scalalib.{JavaModule, Lib, ZincWorkerModule}
 import mill.util.Jvm
 import mill.util.Util.millProjectModule
@@ -313,6 +314,13 @@ trait KotlinModule extends JavaModule { outer =>
   }
 
   private[kotlinlib] def internalReportOldProblems: Task[Boolean] = zincReportCachedProblems
+
+  @internal
+  override def bspBuildTarget: BspBuildTarget = super.bspBuildTarget.copy(
+    languageIds = Seq(BspModule.LanguageId.Java, BspModule.LanguageId.Kotlin),
+    canCompile = true,
+    canRun = true
+  )
 
   /**
    * A test sub-module linked to its parent module best suited for unit-tests.

--- a/kotlinlib/src/mill/kotlinlib/bsp/KotlinBuildTarget.scala
+++ b/kotlinlib/src/mill/kotlinlib/bsp/KotlinBuildTarget.scala
@@ -1,0 +1,13 @@
+package mill.kotlinlib.bsp
+
+import mill.scalalib.bsp.JvmBuildTarget
+
+import java.net.URI
+
+final case class KotlinBuildTarget(
+    languageVersion: String,
+    apiVersion: String,
+    kotlincOptions: Seq[String],
+    associates: Seq[URI],
+    jvmBuildTarget: Option[JvmBuildTarget]
+)

--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -323,7 +323,10 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
   }
 
   @internal
-  override def bspBuildTargetData: Task[Option[(String, AnyRef)]] = Task.Anon {
+  override def bspBuildTargetData(
+      clientDisplayName: String,
+      clientSupportedLanguages: Seq[String]
+  ): Task[Option[(String, AnyRef)]] = Task.Anon {
     Some((
       ScalaBuildTarget.dataKind,
       ScalaBuildTarget(

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -1050,7 +1050,10 @@ trait JavaModule
   }
 
   @internal
-  override def bspBuildTarget: BspBuildTarget = super.bspBuildTarget.copy(
+  def bspBuildTarget(
+      clientDisplayName: String,
+      clientSupportedLanguages: Seq[String]
+  ): BspBuildTarget = super.bspBuildTarget(clientDisplayName, clientSupportedLanguages).copy(
     languageIds = Seq(BspModule.LanguageId.Java),
     canCompile = true,
     canRun = true
@@ -1064,7 +1067,10 @@ trait JavaModule
     )
 
   @internal
-  override def bspBuildTargetData: Task[Option[(String, AnyRef)]] = Task.Anon {
+  override def bspBuildTargetData(
+      clientDisplayName: String,
+      clientSupportedLanguages: Seq[String]
+  ): Task[Option[(String, AnyRef)]] = Task.Anon {
     Some((JvmBuildTarget.dataKind, jvmBuildTarget))
   }
 }

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -1057,13 +1057,14 @@ trait JavaModule
   )
 
   @internal
+  def jvmBuildTarget: JvmBuildTarget =
+    JvmBuildTarget(
+      javaHome = Option(System.getProperty("java.home")).map(p => BspUri(os.Path(p))),
+      javaVersion = Option(System.getProperty("java.version"))
+    )
+
+  @internal
   override def bspBuildTargetData: Task[Option[(String, AnyRef)]] = Task.Anon {
-    Some((
-      JvmBuildTarget.dataKind,
-      JvmBuildTarget(
-        javaHome = Option(System.getProperty("java.home")).map(p => BspUri(os.Path(p))),
-        javaVersion = Option(System.getProperty("java.version"))
-      )
-    ))
+    Some((JvmBuildTarget.dataKind, jvmBuildTarget))
   }
 }

--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -8,14 +8,7 @@ import mill.util.Jvm.createJar
 import mill.api.Loose.Agg
 import mill.scalalib.api.{CompilationResult, Versions, ZincWorkerUtil}
 import mainargs.Flag
-import mill.scalalib.bsp.{
-  BspBuildTarget,
-  BspModule,
-  BspUri,
-  JvmBuildTarget,
-  ScalaBuildTarget,
-  ScalaPlatform
-}
+import mill.scalalib.bsp.{BspBuildTarget, BspModule, ScalaBuildTarget, ScalaPlatform}
 import mill.scalalib.dependency.versions.{ValidVersion, Version}
 
 import scala.reflect.internal.util.ScalaClassLoader
@@ -596,17 +589,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
         scalaBinaryVersion = ZincWorkerUtil.scalaBinaryVersion(scalaVersion()),
         platform = ScalaPlatform.JVM,
         jars = scalaCompilerClasspath().map(_.path.toNIO.toUri.toString).iterator.toSeq,
-        // this is what we want to use, but can't due to a resulting binary incompatibility
-        //        jvmBuildTarget = super.bspBuildTargetData().flatMap {
-        //          case (JvmBuildTarget.dataKind, bt: JvmBuildTarget) => Some(bt)
-        //          case _ => None
-        //        }
-        jvmBuildTarget = Some(
-          JvmBuildTarget(
-            javaHome = Option(System.getProperty("java.home")).map(p => BspUri(os.Path(p))),
-            javaVersion = Option(System.getProperty("java.version"))
-          )
-        )
+        jvmBuildTarget = Some(jvmBuildTarget)
       )
     ))
   }

--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -573,14 +573,20 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
   }
 
   @internal
-  override def bspBuildTarget: BspBuildTarget = super.bspBuildTarget.copy(
+  def bspBuildTarget(
+      clientDisplayName: String,
+      clientSupportedLanguages: Seq[String]
+  ): BspBuildTarget = super.bspBuildTarget(clientDisplayName, clientSupportedLanguages).copy(
     languageIds = Seq(BspModule.LanguageId.Java, BspModule.LanguageId.Scala),
     canCompile = true,
     canRun = true
   )
 
   @internal
-  override def bspBuildTargetData: Task[Option[(String, AnyRef)]] = Task.Anon {
+  override def bspBuildTargetData(
+      clientDisplayName: String,
+      clientSupportedLanguages: Seq[String]
+  ): Task[Option[(String, AnyRef)]] = Task.Anon {
     Some((
       "scala",
       ScalaBuildTarget(

--- a/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
+++ b/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
@@ -18,7 +18,10 @@ trait SemanticDbJavaModule extends CoursierModule {
   def zincIncrementalCompilation: T[Boolean]
   def allSourceFiles: T[Seq[PathRef]]
   def compile: T[mill.scalalib.api.CompilationResult]
-  def bspBuildTarget: BspBuildTarget
+  def bspBuildTarget(
+      clientDisplayName: String,
+      clientSupportedLanguages: Seq[String]
+  ): BspBuildTarget
   def javacOptions: T[Seq[String]]
   def mandatoryJavacOptions: T[Seq[String]]
   def compileClasspath: T[Agg[PathRef]]

--- a/scalalib/src/mill/scalalib/TestModule.scala
+++ b/scalalib/src/mill/scalalib/TestModule.scala
@@ -219,8 +219,11 @@ trait TestModule
     TestModule.handleResults(doneMsg, results, T.ctx(), testReportXml())
   }
 
-  override def bspBuildTarget: BspBuildTarget = {
-    val parent = super.bspBuildTarget
+  def bspBuildTarget(
+      clientDisplayName: String,
+      clientSupportedLanguages: Seq[String]
+  ): BspBuildTarget = {
+    val parent = super.bspBuildTarget(clientDisplayName, clientSupportedLanguages)
     parent.copy(
       canTest = true,
       tags = Seq(BspModule.Tag.Test)

--- a/scalalib/src/mill/scalalib/bsp/BspModule.scala
+++ b/scalalib/src/mill/scalalib/bsp/BspModule.scala
@@ -46,6 +46,7 @@ object BspModule {
   object LanguageId {
     val Java = "java"
     val Scala = "scala"
+    val Kotlin = "kotlin"
   }
 
   /** Used to define the [[BspBuildTarget.tags]] field. */

--- a/scalalib/src/mill/scalalib/bsp/BspModule.scala
+++ b/scalalib/src/mill/scalalib/bsp/BspModule.scala
@@ -17,7 +17,10 @@ trait BspModule extends Module {
 
   /** Use to fill most fields of `BuildTarget`. */
   @internal
-  def bspBuildTarget: BspBuildTarget = BspBuildTarget(
+  def bspBuildTarget(
+      clientDisplayName: String,
+      clientSupportedLanguages: Seq[String]
+  ): BspBuildTarget = BspBuildTarget(
     displayName = Some(bspDisplayName),
     baseDirectory = Some(millSourcePath),
     tags = Seq(Tag.Library, Tag.Application),
@@ -36,7 +39,10 @@ trait BspModule extends Module {
    * - [[ScalaBuildTarget]]
    */
   @internal
-  def bspBuildTargetData: Task[Option[(String, AnyRef)]] = Task.Anon { None }
+  def bspBuildTargetData(
+      clientDisplayName: String,
+      clientSupportedLanguages: Seq[String]
+  ): Task[Option[(String, AnyRef)]] = Task.Anon { None }
 
 }
 

--- a/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
+++ b/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
@@ -282,7 +282,10 @@ trait ScalaNativeModule extends ScalaModule { outer =>
   }
 
   @internal
-  override def bspBuildTargetData: Task[Option[(String, AnyRef)]] = Task.Anon {
+  override def bspBuildTargetData(
+      clientDisplayName: String,
+      clientSupportedLanguages: Seq[String]
+  ): Task[Option[(String, AnyRef)]] = Task.Anon {
     Some((
       ScalaBuildTarget.dataKind,
       ScalaBuildTarget(


### PR DESCRIPTION
This PR adds Kotlin-specific data in BSP build targets of KotlinModules. This is meant to comply with how intellij-bsp seems to expect Kotlin details. If the IntelliJ version we talk to via BSP doesn't seem to support such data (that is, it doesn't claim to support Kotlin via BSP), we keep trying to have intellij-scala handle Kotlin modules, like done in https://github.com/com-lihaoyi/mill/pull/3643.