### PR TITLE
GenIdea: Filter out scala3-library_3 for Scala-js-SDK library entry

### DIFF
--- a/idea/src/mill/idea/GenIdeaImpl.scala
+++ b/idea/src/mill/idea/GenIdeaImpl.scala
@@ -591,12 +591,17 @@ case class GenIdeaImpl(
             val languageLevel =
               scalaVersion.map(_.split("[.]", 3).take(2).mkString("Scala_", "_", ""))
 
+            val cpFilter: os.Path => Boolean = mod match {
+              case _: ScalaJSModule => entry => !entry.last.startsWith("scala3-library_3")
+              case _ => _ => true
+            }
+
             Tuple2(
               os.sub / "libraries" / libraryNameToFileSystemPathPart(nameAndVersion, "xml"),
               scalaSdkTemplate(
                 name = nameAndVersion,
                 languageLevel = languageLevel,
-                scalaCompilerClassPath = compilerClasspath,
+                scalaCompilerClassPath = compilerClasspath.filter(cpFilter),
                 // FIXME: fill in these fields
                 compilerBridgeJar = None,
                 scaladocExtraClasspath = None

--- a/integration/ide/gen-idea/resources/hello-idea/idea/libraries/scala_js_SDK_3_3_1.xml
+++ b/integration/ide/gen-idea/resources/hello-idea/idea/libraries/scala_js_SDK_3_3_1.xml
@@ -14,7 +14,6 @@
                 <root url="file://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.10/scala-library-2.13.10.jar"/>
                 <root url="file://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/scala-lang/scala3-compiler_3/3.3.1/scala3-compiler_3-3.3.1.jar"/>
                 <root url="file://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/scala-lang/scala3-interfaces/3.3.1/scala3-interfaces-3.3.1.jar"/>
-                <root url="file://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/scala-lang/scala3-library_3/3.3.1/scala3-library_3-3.3.1.jar"/>
                 <root url="file://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/scala-lang/scala3-library_sjs1_3/3.3.1/scala3-library_sjs1_3-3.3.1.jar"/>
                 <root url="file://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/scala-lang/tasty-core_3/3.3.1/tasty-core_3-3.3.1.jar"/>
                 <root url="file://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/scala-sbt/compiler-interface/1.3.5/compiler-interface-1.3.5.jar"/>


### PR DESCRIPTION
IntelliJ IDEA doesn't have proper Scala.JS support but complains about multiple Scala library jars on the compiler classpath. Users reported that removing the scala3-library_3 fixes the issue. This PR applies this to `GenIdea`.

Hopefully fix https://github.com/com-lihaoyi/mill/issues/3344
