### PR TITLE
Rename KotlinModuleTests to KotlinTests

### DIFF
--- a/example/kotlinlib/basic/1-simple/build.mill
+++ b/example/kotlinlib/basic/1-simple/build.mill
@@ -13,7 +13,7 @@ object `package` extends RootModule with KotlinModule {
     ivy"org.jetbrains.kotlinx:kotlinx-html-jvm:0.11.0"
   )
 
-  object test extends KotlinModuleTests with TestModule.Junit5 {
+  object test extends KotlinTests with TestModule.Junit5 {
     def ivyDeps = super.ivyDeps() ++ Agg(
       ivy"io.kotest:kotest-runner-junit5-jvm:5.9.1"
     )

--- a/example/kotlinlib/basic/2-custom-build-logic/build.mill
+++ b/example/kotlinlib/basic/2-custom-build-logic/build.mill
@@ -19,7 +19,7 @@ object `package` extends RootModule with KotlinModule {
     Seq(PathRef(Task.dest))
   }
 
-  object test extends KotlinModuleTests with TestModule.Junit5 {
+  object test extends KotlinTests with TestModule.Junit5 {
     def ivyDeps = super.ivyDeps() ++ Agg(
       ivy"io.kotest:kotest-runner-junit5-jvm:5.9.1"
     )

--- a/example/kotlinlib/basic/3-multi-module/build.mill
+++ b/example/kotlinlib/basic/3-multi-module/build.mill
@@ -22,7 +22,7 @@ object bar extends MyModule {
     ivy"org.jetbrains.kotlinx:kotlinx-html-jvm:0.11.0"
   )
 
-  object test extends KotlinModuleTests with TestModule.Junit5 {
+  object test extends KotlinTests with TestModule.Junit5 {
     def ivyDeps = super.ivyDeps() ++ Agg(
       ivy"io.kotest:kotest-runner-junit5-jvm:5.9.1"
     )

--- a/example/kotlinlib/basic/4-builtin-commands/build.mill
+++ b/example/kotlinlib/basic/4-builtin-commands/build.mill
@@ -21,7 +21,7 @@ object bar extends MyModule {
     ivy"org.jetbrains.kotlinx:kotlinx-html-jvm:0.11.0"
   )
 
-  object test extends KotlinModuleTests with TestModule.Junit5 {
+  object test extends KotlinTests with TestModule.Junit5 {
     def ivyDeps = super.ivyDeps() ++ Agg(
       ivy"io.kotest:kotest-runner-junit5-jvm:5.9.1"
     )

--- a/example/kotlinlib/builds/4-realistic/build.mill
+++ b/example/kotlinlib/builds/4-realistic/build.mill
@@ -18,7 +18,7 @@ trait MyModule extends KotlinModule with PublishModule {
 
   def ivyDeps = Agg(ivy"org.jetbrains.kotlinx:kotlinx-html-jvm:0.11.0")
 
-  object test extends KotlinModuleTests with TestModule.Junit5 {
+  object test extends KotlinTests with TestModule.Junit5 {
     def ivyDeps = super.ivyDeps() ++ Agg(
       ivy"io.kotest:kotest-runner-junit5-jvm:5.9.1"
     )

--- a/example/kotlinlib/linting/4-kover/build.mill
+++ b/example/kotlinlib/linting/4-kover/build.mill
@@ -19,11 +19,11 @@ object `package` extends RootModule with KotlinModule with KoverModule {
 
   override def koverVersion = "0.8.3"
 
-  object test extends KotlinModuleTests with KotestTests with KoverTests
+  object test extends KotlinTests with KotestTests with KoverTests
 
   object bar extends KotlinModule with KoverModule {
     def kotlinVersion = "1.9.24"
-    object test extends KotlinModuleTests with KotestTests with KoverTests
+    object test extends KotlinTests with KotestTests with KoverTests
   }
 }
 

--- a/example/kotlinlib/module/15-jni/build.mill
+++ b/example/kotlinlib/module/15-jni/build.mill
@@ -29,7 +29,7 @@ object `package` extends RootModule with KotlinModule {
 
   def forkEnv = Map("HELLO_WORLD_BINARY" -> nativeCompiled().path.toString)
 
-  object test extends KotlinModuleTests with TestModule.Junit5 {
+  object test extends KotlinTests with TestModule.Junit5 {
     def ivyDeps = super.ivyDeps() ++ Agg(
       ivy"io.kotest:kotest-runner-junit5-jvm:5.9.1"
     )

--- a/example/kotlinlib/module/7-resources/build.mill
+++ b/example/kotlinlib/module/7-resources/build.mill
@@ -6,7 +6,7 @@ object foo extends KotlinModule {
 
   def kotlinVersion = "1.9.24"
 
-  object test extends KotlinModuleTests with TestModule.Junit5 {
+  object test extends KotlinTests with TestModule.Junit5 {
     def otherFiles = T.source(millSourcePath / "other-files")
 
     def forkEnv = super.forkEnv() ++ Map(

--- a/example/kotlinlib/module/8-kotlin-compiler-plugins/build.mill
+++ b/example/kotlinlib/module/8-kotlin-compiler-plugins/build.mill
@@ -27,7 +27,7 @@ object foo extends KotlinModule {
     s"-Xplugin=${processors().head.path}"
   )
 
-  object test extends KotlinModuleTests with TestModule.Junit5 {
+  object test extends KotlinTests with TestModule.Junit5 {
     def ivyDeps = super.ivyDeps() ++ Agg(
       ivy"io.kotest:kotest-runner-junit5-jvm:5.9.1"
     )

--- a/example/kotlinlib/testing/1-test-suite/build.mill
+++ b/example/kotlinlib/testing/1-test-suite/build.mill
@@ -8,7 +8,7 @@ object foo extends KotlinModule {
 
   def kotlinVersion = "1.9.24"
 
-  object test extends KotlinModuleTests {
+  object test extends KotlinTests {
     def testFramework = "com.github.sbt.junit.jupiter.api.JupiterFramework"
     def ivyDeps = Agg(
       ivy"com.github.sbt.junit:jupiter-interface:0.11.4",
@@ -31,7 +31,7 @@ object bar extends KotlinModule {
 
   def kotlinVersion = "1.9.24"
 
-  object test extends KotlinModuleTests with TestModule.Junit5 {
+  object test extends KotlinTests with TestModule.Junit5 {
     def ivyDeps = super.ivyDeps() ++ Agg(
       ivy"io.kotest:kotest-runner-junit5-jvm:5.9.1",
       ivy"org.mockito.kotlin:mockito-kotlin:5.4.0"

--- a/example/kotlinlib/testing/2-test-deps/build.mill
+++ b/example/kotlinlib/testing/2-test-deps/build.mill
@@ -8,7 +8,7 @@ object qux extends KotlinModule {
 
   def moduleDeps = Seq(baz)
 
-  object test extends KotlinModuleTests with TestModule.Junit5 {
+  object test extends KotlinTests with TestModule.Junit5 {
     def moduleDeps = super.moduleDeps ++ Seq(baz.test)
     def ivyDeps = super.ivyDeps() ++ Agg(
       ivy"io.kotest:kotest-runner-junit5-jvm:5.9.1",
@@ -21,7 +21,7 @@ object baz extends KotlinModule {
 
   def kotlinVersion = "1.9.24"
 
-  object test extends KotlinModuleTests with TestModule.Junit5 {
+  object test extends KotlinTests with TestModule.Junit5 {
     def ivyDeps = super.ivyDeps() ++ Agg(
       ivy"io.kotest:kotest-runner-junit5-jvm:5.9.1",
       ivy"com.google.guava:guava:33.3.0-jre"

--- a/example/kotlinlib/testing/3-integration-suite/build.mill
+++ b/example/kotlinlib/testing/3-integration-suite/build.mill
@@ -5,12 +5,12 @@ object qux extends KotlinModule {
 
   def kotlinVersion = "1.9.24"
 
-  object test extends KotlinModuleTests with TestModule.Junit5 {
+  object test extends KotlinTests with TestModule.Junit5 {
     def ivyDeps = super.ivyDeps() ++ Agg(
       ivy"io.kotest:kotest-runner-junit5-jvm:5.9.1"
     )
   }
-  object integration extends KotlinModuleTests with TestModule.Junit5 {
+  object integration extends KotlinTests with TestModule.Junit5 {
     def ivyDeps = super.ivyDeps() ++ Agg(
       ivy"io.kotest:kotest-runner-junit5-jvm:5.9.1"
     )

--- a/example/kotlinlib/testing/4-test-grouping/build.mill
+++ b/example/kotlinlib/testing/4-test-grouping/build.mill
@@ -8,7 +8,7 @@ object foo extends KotlinModule {
 
   def kotlinVersion = "1.9.24"
 
-  object test extends KotlinModuleTests {
+  object test extends KotlinTests {
     def testFramework = "com.github.sbt.junit.jupiter.api.JupiterFramework"
     def ivyDeps = Agg(
       ivy"com.github.sbt.junit:jupiter-interface:0.11.4",

--- a/example/kotlinlib/web/1-hello-ktor/build.mill
+++ b/example/kotlinlib/web/1-hello-ktor/build.mill
@@ -13,7 +13,7 @@ object `package` extends RootModule with KotlinModule {
     ivy"io.ktor:ktor-server-netty-jvm:2.3.12"
   )
 
-  object test extends KotlinModuleTests with TestModule.Junit5 {
+  object test extends KotlinTests with TestModule.Junit5 {
     def ivyDeps = super.ivyDeps() ++ Agg(
       ivy"io.kotest:kotest-runner-junit5-jvm:5.9.1", 
       ivy"io.ktor:ktor-server-test-host-jvm:2.3.12"

--- a/kotlinlib/src/mill/kotlinlib/KotlinMavenModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/KotlinMavenModule.scala
@@ -15,7 +15,7 @@ trait KotlinMavenModule extends KotlinModule with MavenModule {
     millSourcePath / "src/main/resources"
   }
 
-  trait KotlinMavenModuleTests extends KotlinModuleTests with MavenTests {
+  trait KotlinMavenModuleTests extends KotlinTests with MavenTests {
     override def intellijModulePath: os.Path = millSourcePath / "src/test"
 
     override def sources = T.sources(

--- a/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -329,7 +329,7 @@ trait KotlinModule extends JavaModule { outer =>
   /**
    * A test sub-module linked to its parent module best suited for unit-tests.
    */
-  trait KotlinModuleTests extends JavaModuleTests with KotlinModule {
+  trait KotlinTests extends JavaModuleTests with KotlinModule {
     override def kotlinVersion: T[String] = Task { outer.kotlinVersion() }
     override def kotlinCompilerVersion: T[String] = Task { outer.kotlinCompilerVersion() }
     override def kotlincOptions: T[Seq[String]] = Task { outer.kotlincOptions() }

--- a/kotlinlib/src/mill/kotlinlib/kover/KoverModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/kover/KoverModule.scala
@@ -35,7 +35,7 @@ import java.util.Locale
  * object foo extends KotlinModule with KoverModule {
  *   def kotlinVersion = "2.0.20"
  *
- *   object test extends KotlinModuleTests with KoverTests
+ *   object test extends KotlinTests with KoverTests
  * }
  * }}}
  *

--- a/kotlinlib/test/src/mill/kotlinlib/HelloWorldTests.scala
+++ b/kotlinlib/test/src/mill/kotlinlib/HelloWorldTests.scala
@@ -19,7 +19,7 @@ object HelloWorldTests extends TestSuite {
       def kotlinVersion = crossValue
       override def mainClass = Some("hello.HelloKt")
 
-      object test extends KotlinModuleTests with TestModule.Junit4 {
+      object test extends KotlinTests with TestModule.Junit4 {
         override def ivyDeps = super.ivyDeps() ++ Agg(
           ivy"org.jetbrains.kotlin:kotlin-test-junit:${this.kotlinVersion()}"
         )

--- a/kotlinlib/test/src/mill/kotlinlib/MixedHelloWorldTests.scala
+++ b/kotlinlib/test/src/mill/kotlinlib/MixedHelloWorldTests.scala
@@ -19,7 +19,7 @@ object MixedHelloWorldTests extends TestSuite {
       def kotlinVersion = crossValue
       override def mainClass = Some("hello.JavaHello")
 
-      object test extends KotlinModuleTests with TestModule.Junit4 {
+      object test extends KotlinTests with TestModule.Junit4 {
         override def ivyDeps = super.ivyDeps() ++ Agg(
           ivy"org.jetbrains.kotlin:kotlin-test-junit:${this.kotlinVersion()}"
         )

--- a/kotlinlib/test/src/mill/kotlinlib/contrib/kover/KoverModuleTests.scala
+++ b/kotlinlib/test/src/mill/kotlinlib/contrib/kover/KoverModuleTests.scala
@@ -29,18 +29,18 @@ object KoverModuleTests extends TestSuite {
 
     object foo extends KotlinModule with KoverModule {
       def kotlinVersion = KoverModuleTests.kotlinVersion
-      object test extends KotlinModuleTests with module.KotestTestModule with KoverTests
+      object test extends KotlinTests with module.KotestTestModule with KoverTests
     }
 
     object bar extends KotlinModule with KoverModule {
       def kotlinVersion = KoverModuleTests.kotlinVersion
-      object test extends KotlinModuleTests with module.KotestTestModule with KoverTests
+      object test extends KotlinTests with module.KotestTestModule with KoverTests
     }
 
     // module not instrumented with Kover
     object qux extends KotlinModule {
       def kotlinVersion = KoverModuleTests.kotlinVersion
-      object test extends KotlinModuleTests with module.KotestTestModule
+      object test extends KotlinTests with module.KotestTestModule
     }
   }
 


### PR DESCRIPTION
This brings them in line with where we want to bring the other testing traits, e.g. `JavaModuleTests` -> `JavaTests` and `ScalaModuleTests` -> `ScalaTests`. Since `KotlinModuleTests` hasn't been published yet, we are free to rename it