### PR TITLE
Avoid calling `Discover[T]` macro for sub-folder root modules

### DIFF
--- a/main/src/mill/main/RootModule.scala
+++ b/main/src/mill/main/RootModule.scala
@@ -60,9 +60,7 @@ object RootModule {
           fileName = millFile0,
           enclosing = Caller(null)
         )
-      ) with Module {
-    def millDiscover: Discover
-  }
+      ) with Module {}
 
   @deprecated
   abstract class Foreign(foreign0: Option[Segments])(implicit

--- a/runner/src/mill/runner/CodeGen.scala
+++ b/runner/src/mill/runner/CodeGen.scala
@@ -161,6 +161,12 @@ object CodeGen {
         newScriptCode = objectData.name.applyTo(newScriptCode, wrapperObjectName)
         newScriptCode = objectData.obj.applyTo(newScriptCode, "abstract class")
 
+        val millDiscover =
+          if (segments.nonEmpty) ""
+          else
+            """@_root_.scala.annotation.nowarn
+              |  override lazy val millDiscover: _root_.mill.define.Discover = _root_.mill.define.Discover[this.type]""".stripMargin
+
         s"""$pkgLine
            |$aliasImports
            |$prelude
@@ -168,8 +174,7 @@ object CodeGen {
            |$newScriptCode
            |object $wrapperObjectName extends $wrapperObjectName {
            |  $childAliases
-           |  @_root_.scala.annotation.nowarn
-           |  override lazy val millDiscover: _root_.mill.define.Discover = _root_.mill.define.Discover[this.type]
+           |  $millDiscover
            |}""".stripMargin
       case None =>
         s"""$pkgLine
@@ -216,16 +221,20 @@ object CodeGen {
         s"extends _root_.mill.runner.MillBuildRootModule() "
       }
     } else {
-
       s"extends _root_.mill.main.RootModule.Subfolder "
     }
+
+    val millDiscover =
+      if (segments.nonEmpty) ""
+      else
+        """@_root_.scala.annotation.nowarn
+          |  override lazy val millDiscover: _root_.mill.define.Discover = _root_.mill.define.Discover[this.type]""".stripMargin
 
     // User code needs to be put in a separate class for proper submodule
     // object initialization due to https://github.com/scala/scala3/issues/21444
     s"""object $wrapperObjectName extends $wrapperObjectName{
        |  $childAliases
-       |  @_root_.scala.annotation.nowarn
-       |  override lazy val millDiscover: _root_.mill.define.Discover = _root_.mill.define.Discover[this.type]
+       |  $millDiscover
        |}
        |abstract class $wrapperObjectName $extendsClause {""".stripMargin
 


### PR DESCRIPTION
They already get processed as part of the root `build.mill`'s `Discover[T]` macro call, so no need to duplicate the work