### PR TITLE
Fix `semanticDbData` for mill-build

### DIFF
--- a/integration/feature/plugin-classpath/src/MillPluginClasspathTest.scala
+++ b/integration/feature/plugin-classpath/src/MillPluginClasspathTest.scala
@@ -69,6 +69,13 @@ object MillPluginClasspathTest extends UtestIntegrationTestSuite {
         ))
       }
     }
+    test("semanticDbData") - integrationTest { tester =>
+      import tester._
+      retry(3) {
+        val res1 = eval(("--meta-level", "1", "semanticDbData"))
+        assert(res1.isSuccess)
+      }
+    }
 
   }
 }

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -253,6 +253,9 @@ abstract class MillBuildRootModule()(implicit
   override def scalacPluginClasspath: T[Agg[PathRef]] =
     super.scalacPluginClasspath() ++ lineNumberPluginClasspath()
 
+  override protected def semanticDbPluginClasspath: T[Agg[PathRef]] =
+    super.semanticDbPluginClasspath() ++ lineNumberPluginClasspath()
+
   def lineNumberPluginClasspath: T[Agg[PathRef]] = Task {
     millProjectModule("mill-runner-linenumbers", repositoriesTask())
   }


### PR DESCRIPTION
When we override `scalacPluginClasspath` we need to remeber to also override `semanticDbPluginClasspath`

Fixes #3666

Pull Request: https://github.com/com-lihaoyi/mill/pull/3673