### PR TITLE
Pass BSP JvmBuildTarget stuff to ScalaBuildTarget

### DIFF
--- a/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -175,14 +175,12 @@ private class MillBuildServer(
             bsp4j.ScalaPlatform.forValue(d.platform.number),
             d.jars.asJava
           )
+          for (jvmBuildTarget <- d.jvmBuildTarget)
+            target.setJvmBuildTarget(MillBuildServer.jvmBuildTarget(jvmBuildTarget))
           Some((dataKind, target))
 
         case Some((dataKind, d: JvmBuildTarget)) =>
-          val target = new bsp4j.JvmBuildTarget().tap { it =>
-            d.javaHome.foreach(jh => it.setJavaHome(jh.uri))
-            d.javaVersion.foreach(jv => it.setJavaVersion(jv))
-          }
-          Some((dataKind, target))
+          Some((dataKind, jvmBuildTarget(d)))
 
         case Some((dataKind, d)) =>
           debug(s"Unsupported dataKind=${dataKind} with value=${d}")
@@ -784,4 +782,10 @@ private object MillBuildServer {
       .toSeq
       .sortBy { case (k, _) => keyIndices(k) }
   }
+
+  def jvmBuildTarget(d: JvmBuildTarget): bsp4j.JvmBuildTarget =
+    new bsp4j.JvmBuildTarget().tap { it =>
+      d.javaHome.foreach(jh => it.setJavaHome(jh.uri))
+      d.javaVersion.foreach(jv => it.setJavaVersion(jv))
+    }
 }

--- a/integration/ide/bsp-server/resources/snapshots/workspace-build-targets.json
+++ b/integration/ide/bsp-server/resources/snapshots/workspace-build-targets.json
@@ -60,7 +60,11 @@
           "file:///coursier-cache/https/repo1.maven.org/maven2/io/github/java-diff-utils/java-diff-utils/<java-diff-utils-version>/java-diff-utils-<java-diff-utils-version>.jar",
           "file:///coursier-cache/https/repo1.maven.org/maven2/org/jline/jline/<jline-version>/jline-<jline-version>.jar",
           "file:///coursier-cache/https/repo1.maven.org/maven2/net/java/dev/jna/jna/<jna-version>/jna-<jna-version>.jar"
-        ]
+        ],
+        "jvmBuildTarget": {
+          "javaHome": "file:///java-home/",
+          "javaVersion": "<java-version>"
+        }
       }
     },
     {
@@ -94,7 +98,11 @@
           "file:///coursier-cache/https/repo1.maven.org/maven2/org/scala-lang/scala-compiler/<scala-version>/scala-compiler-<scala-version>.jar",
           "file:///coursier-cache/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/<scala-version>/scala-reflect-<scala-version>.jar",
           "file:///coursier-cache/https/repo1.maven.org/maven2/org/scala-lang/scala-library/<scala-version>/scala-library-<scala-version>.jar"
-        ]
+        ],
+        "jvmBuildTarget": {
+          "javaHome": "file:///java-home/",
+          "javaVersion": "<java-version>"
+        }
       }
     },
     {

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -1057,7 +1057,7 @@ trait JavaModule
   )
 
   @internal
-  def jvmBuildTarget: JvmBuildTarget =
+  def bspJvmBuildTarget: JvmBuildTarget =
     JvmBuildTarget(
       javaHome = Option(System.getProperty("java.home")).map(p => BspUri(os.Path(p))),
       javaVersion = Option(System.getProperty("java.version"))
@@ -1065,6 +1065,6 @@ trait JavaModule
 
   @internal
   override def bspBuildTargetData: Task[Option[(String, AnyRef)]] = Task.Anon {
-    Some((JvmBuildTarget.dataKind, jvmBuildTarget))
+    Some((JvmBuildTarget.dataKind, bspJvmBuildTarget))
   }
 }

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -1057,13 +1057,14 @@ trait JavaModule
   )
 
   @internal
+  def jvmBuildTarget: JvmBuildTarget =
+    JvmBuildTarget(
+      javaHome = Option(System.getProperty("java.home")).map(p => BspUri(os.Path(p))),
+      javaVersion = Option(System.getProperty("java.version"))
+    )
+
+  @internal
   override def bspBuildTargetData: Task[Option[(String, AnyRef)]] = Task.Anon {
-    Some((
-      JvmBuildTarget.dataKind,
-      JvmBuildTarget(
-        javaHome = Option(System.getProperty("java.home")).map(p => BspUri(os.Path(p))),
-        javaVersion = Option(System.getProperty("java.version"))
-      )
-    ))
+    Some((JvmBuildTarget.dataKind, jvmBuildTarget))
   }
 }

--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -8,14 +8,7 @@ import mill.util.Jvm.createJar
 import mill.api.Loose.Agg
 import mill.scalalib.api.{CompilationResult, Versions, ZincWorkerUtil}
 import mainargs.Flag
-import mill.scalalib.bsp.{
-  BspBuildTarget,
-  BspModule,
-  BspUri,
-  JvmBuildTarget,
-  ScalaBuildTarget,
-  ScalaPlatform
-}
+import mill.scalalib.bsp.{BspBuildTarget, BspModule, ScalaBuildTarget, ScalaPlatform}
 import mill.scalalib.dependency.versions.{ValidVersion, Version}
 
 import scala.reflect.internal.util.ScalaClassLoader
@@ -596,17 +589,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
         scalaBinaryVersion = ZincWorkerUtil.scalaBinaryVersion(scalaVersion()),
         platform = ScalaPlatform.JVM,
         jars = scalaCompilerClasspath().map(_.path.toNIO.toUri.toString).iterator.toSeq,
-        // this is what we want to use, but can't due to a resulting binary incompatibility
-        //        jvmBuildTarget = super.bspBuildTargetData().flatMap {
-        //          case (JvmBuildTarget.dataKind, bt: JvmBuildTarget) => Some(bt)
-        //          case _ => None
-        //        }
-        jvmBuildTarget = Some(
-          JvmBuildTarget(
-            javaHome = Option(System.getProperty("java.home")).map(p => BspUri(os.Path(p))),
-            javaVersion = Option(System.getProperty("java.version"))
-          )
-        )
+        jvmBuildTarget = Some(jvmBuildTarget)
       )
     ))
   }

--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -589,7 +589,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
         scalaBinaryVersion = ZincWorkerUtil.scalaBinaryVersion(scalaVersion()),
         platform = ScalaPlatform.JVM,
         jars = scalaCompilerClasspath().map(_.path.toNIO.toUri.toString).iterator.toSeq,
-        jvmBuildTarget = Some(jvmBuildTarget)
+        jvmBuildTarget = Some(bspJvmBuildTarget)
       )
     ))
   }


### PR DESCRIPTION
This adds the JVM we use in the Scala details in BSP build targets. I don't think Metals uses that for now, and I don't know about IntelliJ. But they might in the future.