### PR TITLE
Unify `visualize` and doc-site graphviz rendering into Javet subprocess

### DIFF
--- a/docs/modules/ROOT/pages/comparisons/maven.adoc
+++ b/docs/modules/ROOT/pages/comparisons/maven.adoc
@@ -569,8 +569,7 @@ def make = Task {
 }
 ```
 
-[graphviz]
-....
+```graphviz
 digraph G {
   rankdir=LR
   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -578,7 +577,7 @@ digraph G {
   cSources -> make
   cSources -> cHeaders
 }
-....
+```
 
 In Mill, we define the `makefile`, `cSources`, `cHeaders`, and `make` tasks. The bulk
 of the logic is in `def make`, which prepares the `makefile` and C sources,

--- a/docs/modules/ROOT/pages/depth/design-principles.adoc
+++ b/docs/modules/ROOT/pages/depth/design-principles.adoc
@@ -199,8 +199,7 @@ build-related questions listed above.
 
 === The Object Hierarchy
 
-[graphviz]
-....
+```graphviz
 digraph G {
   node [shape=box width=0 height=0 style=filled fillcolor=white]
   bgcolor=transparent
@@ -213,7 +212,7 @@ digraph G {
   foo2 -> "foo2.qux"  [style=dashed]
   foo2 -> "foo2.baz"  [style=dashed]
 }
-....
+```
 
 The module hierarchy is the graph of objects, starting from the root of the
 `build.mill` file, that extend `mill.Module`. At the leaves of the hierarchy are
@@ -239,8 +238,7 @@ are sure that it will never clash with any other ``Task``s data.
 
 === The Call Graph
 
-[graphviz]
-....
+```graphviz
 digraph G {
   rankdir=LR
   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -275,7 +273,7 @@ digraph G {
     "qux.sources" -> "qux.compile" -> "qux.classPath" -> "qux.assembly"
   }
 }
-....
+```
 
 The Scala call graph of "which task references which other task" is core to
 how Mill operates. This graph is reified via the `T {...}` macro to make it

--- a/docs/modules/ROOT/partials/Intro_to_Mill_Header.adoc
+++ b/docs/modules/ROOT/partials/Intro_to_Mill_Header.adoc
@@ -1,5 +1,4 @@
-[graphviz]
-....
+```graphviz
 digraph G {
   rankdir=LR
   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -24,7 +23,7 @@ digraph G {
     "bar.mainClass" -> "bar.assembly"
   }
 }
-....
+```
 
 {mill-github-url}[Mill] is a fast multi-language JVM build tool that supports {language}, making your
 common development workflows xref:comparisons/maven.adoc[5-10x faster to Maven], or

--- a/docs/package.mill
+++ b/docs/package.mill
@@ -92,29 +92,42 @@ object `package` extends RootModule {
 
     Graphviz.useEngine(new AbstractJsGraphvizEngine(true, () => new mill.main.graphviz.V8JavascriptEngine()) {})
 
-    for (p <- os.walk(T.dest) if p.ext == "adoc"){
-      val outputLines = collection.mutable.ArrayDeque.empty[String]
-      val graphvizLines = collection.mutable.ArrayDeque.empty[String]
-      var isGraphViz = false
+    def walkAllFiles(inputs: Map[(os.Path, Int), String]): Map[(os.Path, Int), String] = {
+      val output = collection.mutable.Map.empty[(os.Path, Int), String]
+      for (p <- os.walk(T.dest) if p.ext == "adoc"){
+        val outputLines = collection.mutable.ArrayDeque.empty[String]
+        val graphvizLines = collection.mutable.ArrayDeque.empty[String]
+        var isGraphViz = false
 
-      for(line <- os.read.lines(p)){
-        line match{
-          case "```graphviz" => isGraphViz = true
-          case "```" if graphvizLines.nonEmpty =>
-            isGraphViz = false
-            outputLines.append("++++")
-            outputLines.append(
-              Graphviz.fromString(graphvizLines.mkString).render(Format.SVG).toString
-            )
-            outputLines.append("++++")
-            graphvizLines.clear()
-          case _ =>
-            if (isGraphViz) graphvizLines.append(line)
-            else outputLines.append(line)
+        for((line, i) <- os.read.lines(p).zipWithIndex){
+          line match{
+            case "```graphviz" => isGraphViz = true
+            case "```" if isGraphViz =>
+              isGraphViz = false
+              if (inputs.isEmpty) output((p, i)) = graphvizLines.mkString("\n")
+              else {
+                outputLines.append("++++")
+                outputLines.append(inputs((p, i)))
+                outputLines.append("++++")
+              }
+
+              graphvizLines.clear()
+            case _ =>
+              if (isGraphViz) graphvizLines.append(line)
+              else outputLines.append(line)
+          }
         }
+        if (inputs.nonEmpty) os.write.over(p, outputLines.mkString("\n"))
       }
-      os.write.over(p, outputLines.mkString("\n"))
+      output.toMap
     }
+
+    val diagrams = walkAllFiles(Map())
+    val renderedDiagrams = diagrams
+      .map{case (k, s) => (k, Graphviz.fromString(s).render(Format.SVG).toString)}
+    pprint.log(diagrams.mapValues(_.size))
+    pprint.log(renderedDiagrams.mapValues(_.size))
+    walkAllFiles(renderedDiagrams)
 
     PathRef(T.dest)
   }

--- a/docs/package.mill
+++ b/docs/package.mill
@@ -97,7 +97,7 @@ object `package` extends RootModule {
       val graphvizLines = collection.mutable.ArrayDeque.empty[String]
       var isGraphViz = false
 
-      for((line, i) <- os.read.lines(p).zipWithIndex){
+      for(line <- os.read.lines(p)){
         line match{
           case "```graphviz" => isGraphViz = true
           case "```" if graphvizLines.nonEmpty =>

--- a/docs/package.mill
+++ b/docs/package.mill
@@ -1,8 +1,9 @@
 package build.docs
 import mill.util.Jvm
 import mill._, scalalib._
-import build.contrib
 import de.tobiasroeser.mill.vcs.version.VcsVersion
+import guru.nidi.graphviz.engine.AbstractJsGraphvizEngine
+import guru.nidi.graphviz.engine.{Format, Graphviz}
 
 /** Generates the mill documentation with Antora. */
 object `package` extends RootModule {
@@ -32,7 +33,6 @@ object `package` extends RootModule {
         "@antora/site-generator-default@3.1.9",
         "gitlab:antora/xref-validator",
         "@antora/lunr-extension@v1.0.0-alpha.6",
-        "asciidoctor-kroki@0.18.1"
       ),
       envArgs = Map(),
       workingDir = npmDir
@@ -89,6 +89,32 @@ object `package` extends RootModule {
       pagesWd / "contrib" / s"${name}.adoc",
       createFolders = true
     )
+
+    Graphviz.useEngine(new AbstractJsGraphvizEngine(true, () => new mill.main.graphviz.V8JavascriptEngine()) {})
+
+    for (p <- os.walk(T.dest) if p.ext == "adoc"){
+      val outputLines = collection.mutable.ArrayDeque.empty[String]
+      val graphvizLines = collection.mutable.ArrayDeque.empty[String]
+      var isGraphViz = false
+
+      for((line, i) <- os.read.lines(p).zipWithIndex){
+        line match{
+          case "```graphviz" => isGraphViz = true
+          case "```" if graphvizLines.nonEmpty =>
+            isGraphViz = false
+            outputLines.append("++++")
+            outputLines.append(
+              Graphviz.fromString(graphvizLines.mkString).render(Format.SVG).toString
+            )
+            outputLines.append("++++")
+            graphvizLines.clear()
+          case _ =>
+            if (isGraphViz) graphvizLines.append(line)
+            else outputLines.append(line)
+        }
+      }
+      os.write.over(p, outputLines.mkString("\n"))
+    }
 
     PathRef(T.dest)
   }
@@ -167,9 +193,6 @@ object `package` extends RootModule {
        |    utest-github-url: https://github.com/com-lihaoyi/utest
        |    upickle-github-url: https://github.com/com-lihaoyi/upickle
        |    mill-scip-version: ${build.Deps.DocDeps.millScip.dep.version}
-       |    kroki-fetch-diagram: true
-       |  extensions:
-       |  - asciidoctor-kroki
        |antora:
        |  extensions:
        |  - require: '@antora/lunr-extension'

--- a/docs/package.mill
+++ b/docs/package.mill
@@ -123,10 +123,11 @@ object `package` extends RootModule {
     }
 
     val diagrams = walkAllFiles(Map())
+    // Batch the rendering so later it can be done in one call to a single subprocess,
+    // minimizing per-subprocess overhead needed to spawn them over and over
     val renderedDiagrams = diagrams
       .map{case (k, s) => (k, Graphviz.fromString(s).render(Format.SVG).toString)}
-    pprint.log(diagrams.mapValues(_.size))
-    pprint.log(renderedDiagrams.mapValues(_.size))
+
     walkAllFiles(renderedDiagrams)
 
     PathRef(T.dest)

--- a/example/fundamentals/cross/1-simple/build.mill
+++ b/example/fundamentals/cross/1-simple/build.mill
@@ -9,12 +9,10 @@ trait FooModule extends Cross.Module[String] {
   def sources = Task.Sources(millSourcePath)
 }
 
-// [graphviz]
-// ....
+// ```graphviz
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
-
 //   subgraph cluster_2 {
 //     label="foo[2.12]"
 //     style=dashed
@@ -34,7 +32,7 @@ trait FooModule extends Cross.Module[String] {
 //     "foo[2.10].sources"
 //   }
 // }
-// ....
+// ```
 
 // Cross modules defined using the `Cross[T]` class allow you to define
 // multiple copies of the same module, differing only in some input key. This

--- a/example/fundamentals/cross/10-static-blog/build.mill
+++ b/example/fundamentals/cross/10-static-blog/build.mill
@@ -119,8 +119,7 @@ def dist = Task {
 // All caching, incremental re-computation, and parallelism is done using the
 // Mill task graph. For this simple example, the graph is as follows
 //
-// [graphviz]
-// ....
+// ```graphviz
 // digraph G {
 //   node [shape=box width=0 height=0]
 //   "1 - Foo.md" -> "post[1]\nrender"
@@ -133,7 +132,7 @@ def dist = Task {
 //   "index" -> "dist"
 //
 // }
-// ....
+// ```
 //
 // This example use case is taken from the following blog post, which contains
 // some extensions and fun exercises to further familiarize yourself with Mill

--- a/example/fundamentals/cross/3-outside-dependency/build.mill
+++ b/example/fundamentals/cross/3-outside-dependency/build.mill
@@ -11,8 +11,7 @@ def bar = Task { s"hello ${foo("2.10").suffix()}" }
 
 def qux = Task { s"hello ${foo("2.10").suffix()} world ${foo("2.12").suffix()}" }
 
-// [graphviz]
-// ....
+// ```graphviz
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -36,7 +35,7 @@ def qux = Task { s"hello ${foo("2.10").suffix()} world ${foo("2.12").suffix()}" 
 //   "foo[2.10].suffix" -> "qux"
 //   "foo[2.10].suffix" -> "bar"
 // }
-// ....
+// ```
 
 
 // Here, `def bar` uses `foo("2.10")` to reference the `"2.10"` instance of

--- a/example/fundamentals/cross/4-cross-dependencies/build.mill
+++ b/example/fundamentals/cross/4-cross-dependencies/build.mill
@@ -13,8 +13,7 @@ trait BarModule extends Cross.Module[String] {
   def bigSuffix = Task { "[[[" + foo(crossValue).suffix() + "]]]" }
 }
 
-// [graphviz]
-// ....
+// ```graphviz
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -52,7 +51,7 @@ trait BarModule extends Cross.Module[String] {
 //   "foo[2.11].suffix" -> "bar[2.11].bigSuffix"
 //   "foo[2.12].suffix" -> "bar[2.12].bigSuffix"
 // }
-// ....
+// ```
 
 // Rather than pssing in a literal `"2.10"` to the `foo` cross module, we pass
 // in the `crossValue` property that is available within every `Cross.Module`.

--- a/example/fundamentals/cross/5-multiple-cross-axes/build.mill
+++ b/example/fundamentals/cross/5-multiple-cross-axes/build.mill
@@ -17,8 +17,7 @@ trait FooModule extends Cross.Module2[String, String] {
 
 def bar = Task { s"hello ${foo("2.10", "jvm").suffix()}" }
 
-// [graphviz]
-// ....
+// ```graphviz
 //  digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -65,7 +64,7 @@ def bar = Task { s"hello ${foo("2.10", "jvm").suffix()}" }
 //
 //   "foo[2.10,jvm].suffix" -> bar
 // }
-// ....
+// ```
 //
 // This example shows off using a for-loop to generate a list of
 // cross-key-tuples, as a `Seq[(String, String)]` that we then pass it into the

--- a/example/fundamentals/cross/7-inner-cross-module/build.mill
+++ b/example/fundamentals/cross/7-inner-cross-module/build.mill
@@ -19,8 +19,7 @@ trait FooModule extends Cross.Module[String] {
 
 def baz = Task { s"hello ${foo("a").bar.param()}" }
 
-// [graphviz]
-// ....
+// ```graphviz
 // digraph G {
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
 //   "root-module" [style=dashed]
@@ -45,7 +44,7 @@ def baz = Task { s"hello ${foo("a").bar.param()}" }
 //   "..." [color=white]
 //   "foo[a].bar.name" -> "foo[a].bar.param" [constraint=false]
 // }
-// ....
+// ```
 //
 // You can use the `CrossValue` trait within any `Cross.Module` to
 // propagate the `crossValue` defined by an enclosing `Cross.Module` to some

--- a/example/fundamentals/modules/7-modules/build.mill
+++ b/example/fundamentals/modules/7-modules/build.mill
@@ -13,8 +13,7 @@ object foo extends Module {
   }
 }
 
-// [graphviz]
-// ....
+// ```graphviz
 // digraph G {
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
 //   "root-module" [style=dashed]
@@ -24,7 +23,8 @@ object foo extends Module {
 //   "root-module" -> foo -> "foo.qux" -> "foo.qux.baz"  [style=dashed]
 //   foo -> "foo.bar"  [style=dashed]
 // }
-// ....
+// ```
+//
 // You would be able to run the two tasks via `mill foo.bar` or `mill
 // foo.qux.baz`. You can use `mill show foo.bar` or `mill show foo.baz.qux` to
 // make Mill echo out the string value being returned by each Task. The two
@@ -76,8 +76,7 @@ object foo2 extends FooModule {
 // arrows representing the module tree, and the solid boxes and arrows representing
 // the task graph
 
-// [graphviz]
-// ....
+// ```graphviz
 // digraph G {
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
 //   bgcolor=transparent
@@ -93,7 +92,7 @@ object foo2 extends FooModule {
 //   "foo1.bar" -> "foo1.qux.super" -> "foo1.qux" [constraint=false]
 //   "foo2.bar" -> "foo2.qux" -> "foo2.baz" [constraint=false]
 // }
-// ....
+// ```
 
 // Note that the `override` keyword is optional in mill, as is `T{...}` wrapper.
 
@@ -139,8 +138,7 @@ object outer extends MyModule {
   object inner extends MyModule
 }
 
-// [graphviz]
-// ....
+// ```graphviz
 // digraph G {
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
 //   "root-module" [style=dashed]
@@ -155,7 +153,7 @@ object outer extends MyModule {
 //   outer -> "outer.sources"  [style=dashed]
 //   outer -> "outer.task"  [style=dashed]
 // }
-// ....
+// ```
 
 // * The `outer` module has a `millSourcePath` of `outer/`, and thus a
 //   `outer.sources` referencing `outer/sources/`

--- a/example/fundamentals/modules/8-diy-java-modules/build.mill
+++ b/example/fundamentals/modules/8-diy-java-modules/build.mill
@@ -34,8 +34,7 @@ trait DiyJavaModule extends Module{
 // edges (dashed) are not connected; that is because `DiyJavaModule` is abstract, and
 // needs to be inherited by a concrete `object` before it can be used.
 
-// [graphviz]
-// ....
+// ```graphviz
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -51,7 +50,7 @@ trait DiyJavaModule extends Module{
 //     "sources" -> "compile" -> "classPath" -> "assembly"
 //   }
 // }
-// ....
+// ```
 //
 // Some notable things to call out:
 //
@@ -87,8 +86,7 @@ object qux extends DiyJavaModule {
 // duplicated three times - once per module - with the tasks wired up between the modules
 // according to our overrides for `moduleDeps`
 
-// [graphviz]
-// ....
+// ```graphviz
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -123,7 +121,7 @@ object qux extends DiyJavaModule {
 //     "qux.sources" -> "qux.compile" -> "qux.classPath" -> "qux.assembly"
 //   }
 // }
-// ....
+// ```
 //
 // This simple set of `DiyJavaModule` can be used as follows:
 

--- a/example/fundamentals/tasks/1-task-graph/build.mill
+++ b/example/fundamentals/tasks/1-task-graph/build.mill
@@ -26,8 +26,7 @@ def assembly = Task {
 // This code defines the following task graph, with the boxes being the tasks
 // and the arrows representing the _data-flow_ between them:
 //
-// [graphviz]
-// ....
+// ```graphviz
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -35,7 +34,7 @@ def assembly = Task {
 //   resources -> assembly
 //   mainClass -> assembly
 // }
-// ....
+// ```
 //
 // This example does not use any of Mill's builtin support for building Java or
 // Scala projects, and instead builds a pipeline "from scratch" using Mill
@@ -66,8 +65,7 @@ My Example Text
 // * If the files in `sources` change, it will re-evaluate
 //  `compile`, and `assembly` (red)
 //
-// [graphviz]
-// ....
+// ```graphviz
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -80,13 +78,12 @@ My Example Text
 //   resources [fillcolor=lightgreen]
 //   mainClass [fillcolor=lightgreen]
 // }
-// ....
+// ```
 //
 // * If the files in `resources` change, it will only re-evaluate `assembly` (red)
 //   and use the cached output of `compile` (green)
 //
-// [graphviz]
-// ....
+// ```graphviz
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -99,5 +96,5 @@ My Example Text
 //   sources [fillcolor=lightgreen]
 //   mainClass [fillcolor=lightgreen]
 // }
-// ....
+// ```
 //

--- a/example/fundamentals/tasks/2-primary-tasks/build.mill
+++ b/example/fundamentals/tasks/2-primary-tasks/build.mill
@@ -38,15 +38,14 @@ def lineCount: T[Int] = Task {
     .sum
 }
 
-// [graphviz]
-// ....
+// ```graphviz
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
 //   sources -> allSources -> lineCount
 //   sources [color=white]
 // }
-// ....
+// ```
 //
 // ``Target``s are defined using the `def foo = Task {...}` syntax, and dependencies
 // on other tasks are defined using `foo()` to extract the value from them.
@@ -142,8 +141,7 @@ def jar = Task {
   PathRef(Task.dest / "foo.jar")
 }
 
-// [graphviz]
-// ....
+// ```graphviz
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -152,7 +150,7 @@ def jar = Task {
 //   allSources [color=white]
 //   resources [color=white]
 // }
-// ....
+// ```
 
 /** Usage
 
@@ -199,15 +197,14 @@ def hugeFileName = Task {
   else "<no-huge-file>"
 }
 
-// [graphviz]
-// ....
+// ```graphviz
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
 //   allSources -> largeFile-> hugeFileName
 //   allSources [color=white]
 // }
-// ....
+// ```
 
 /** Usage
 
@@ -242,15 +239,14 @@ def summarizeClassFileStats = Task {
   )
 }
 
-// [graphviz]
-// ....
+// ```graphviz
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
 //   classFiles -> summarizedClassFileStats
 //   classFiles [color=white]
 // }
-// ....
+// ```
 
 /** Usage
 
@@ -276,8 +272,7 @@ def run(mainClass: String, args: String*) = Task.Command {
     .call(stdout = os.Inherit)
 }
 
-// [graphviz]
-// ....
+// ```graphviz
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -286,7 +281,7 @@ def run(mainClass: String, args: String*) = Task.Command {
 //   classFiles [color=white]
 //   resources [color=white]
 // }
-// ....
+// ```
 
 // Defined using `Task.Command {...}` syntax, ``Command``s can run arbitrary code, with
 // dependencies declared using the same `foo()` syntax (e.g. `classFiles()` above).
@@ -373,15 +368,14 @@ trait Bar extends Foo {
 
 object bar extends Bar
 
-// [graphviz]
-// ....
+// ```graphviz
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
 //   "bar.sourceRoots.super" -> "bar.sourceRoots" -> "bar.sourceContents"
 //   "bar.additionalSources" -> "bar.sourceRoots"
 // }
-// ....
+// ```
 /** Usage
 
 > ./mill show bar.sourceContents # includes both source folders

--- a/example/scalalib/basic/2-custom-build-logic/build.mill
+++ b/example/scalalib/basic/2-custom-build-logic/build.mill
@@ -30,8 +30,7 @@ object `package` extends RootModule with ScalaModule {
 // it with the destination folder of the new `resources` task, which is wired
 // up to `lineCount`:
 //
-// [graphviz]
-// ....
+// ```graphviz
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -42,7 +41,7 @@ object `package` extends RootModule with ScalaModule {
 //   allSourceFiles [color=white]
 //   run [color=white]
 // }
-// ....
+// ```
 
 
 /** Usage

--- a/example/scalalib/basic/4-builtin-commands/build.mill
+++ b/example/scalalib/basic/4-builtin-commands/build.mill
@@ -287,11 +287,11 @@ foo.compileClasspath
 /** Usage
 > mill visualize foo._
 [
-  ".../out/visualize.dest/out.txt",
   ".../out/visualize.dest/out.dot",
   ".../out/visualize.dest/out.json",
   ".../out/visualize.dest/out.png",
-  ".../out/visualize.dest/out.svg"
+  ".../out/visualize.dest/out.svg",
+  ".../out/visualize.dest/out.txt"
 ]
 */
 //
@@ -312,11 +312,11 @@ foo.compileClasspath
 /** Usage
 > mill visualizePlan foo.run
 [
-  ".../out/visualizePlan.dest/out.txt",
   ".../out/visualizePlan.dest/out.dot",
   ".../out/visualizePlan.dest/out.json",
   ".../out/visualizePlan.dest/out.png",
-  ".../out/visualizePlan.dest/out.svg"
+  ".../out/visualizePlan.dest/out.svg",
+  ".../out/visualizePlan.dest/out.txt"
 ]
 */
 //

--- a/example/scalalib/module/2-custom-tasks/build.mill
+++ b/example/scalalib/module/2-custom-tasks/build.mill
@@ -57,9 +57,7 @@ object `package` extends RootModule with ScalaModule {
 // with the boxes representing tasks defined or overriden above and the un-boxed
 // labels representing existing Mill tasks:
 //
-// [graphviz]
-// ....
-//
+// ```graphviz
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0]
@@ -74,7 +72,7 @@ object `package` extends RootModule with ScalaModule {
 //   compile [color=white]
 //   "..." [color=white]
 // }
-// ....
+// ```
 //
 // Mill lets you define new cached Tasks using the `Task {...}` syntax,
 // depending on existing Tasks e.g. `foo.sources` via the `foo.sources()`

--- a/main/graphviz/src/mill/main/graphviz/GraphvizTools.scala
+++ b/main/graphviz/src/mill/main/graphviz/GraphvizTools.scala
@@ -17,23 +17,24 @@ object GraphvizTools {
 
     try {
       implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(executor)
-      val futures = for (arg <- args.toSeq) yield Future {
-        val Array(src, dest0, commaSepExtensions) = arg.split(";")
-        val extensions = commaSepExtensions.split(',')
-        val dest = os.Path(dest0)
-        import guru.nidi.graphviz.engine.{Format, Graphviz}
+      val futures =
+        for (arg <- args.toSeq) yield Future {
+          val Array(src, dest0, commaSepExtensions) = arg.split(";")
+          val extensions = commaSepExtensions.split(',')
+          val dest = os.Path(dest0)
+          import guru.nidi.graphviz.engine.{Format, Graphviz}
 
-        Graphviz.useEngine(new AbstractJsGraphvizEngine(true, () => new V8JavascriptEngine()) {})
-        val gv = Graphviz.fromFile(new java.io.File(src)).totalMemory(128 * 1024 * 1024)
+          Graphviz.useEngine(new AbstractJsGraphvizEngine(true, () => new V8JavascriptEngine()) {})
+          val gv = Graphviz.fromFile(new java.io.File(src)).totalMemory(128 * 1024 * 1024)
 
-        val outputs = extensions
-          .map(ext => Format.values().find(_.fileExtension == ext).head -> s"out.$ext")
+          val outputs = extensions
+            .map(ext => Format.values().find(_.fileExtension == ext).head -> s"out.$ext")
 
-        for ((fmt, name) <- outputs) gv.render(fmt).toFile((dest / name).toIO)
-      }
+          for ((fmt, name) <- outputs) gv.render(fmt).toFile((dest / name).toIO)
+        }
 
       Await.result(Future.sequence(futures), duration.Duration.Inf)
-    }finally executor.shutdown()
+    } finally executor.shutdown()
   }
 }
 

--- a/main/graphviz/src/mill/main/graphviz/GraphvizTools.scala
+++ b/main/graphviz/src/mill/main/graphviz/GraphvizTools.scala
@@ -3,72 +3,20 @@ package mill.main.graphviz
 import com.caoccao.javet.annotations.V8Function
 import com.caoccao.javet.interception.logging.JavetStandardConsoleInterceptor
 import com.caoccao.javet.interop.{V8Host, V8Runtime}
-import guru.nidi.graphviz.attribute.Rank.RankDir
-import guru.nidi.graphviz.attribute.{Rank, Shape, Style}
 import guru.nidi.graphviz.engine.{AbstractJavascriptEngine, AbstractJsGraphvizEngine, ResultHandler}
-import mill.api.PathRef
-import mill.define.NamedTask
-import org.jgrapht.graph.{DefaultEdge, SimpleDirectedGraph}
 import org.slf4j.LoggerFactory
 import org.slf4j.Logger
 
 object GraphvizTools {
 
-  def apply(targets: Seq[NamedTask[Any]], rs: Seq[NamedTask[Any]], dest: os.Path): Seq[PathRef] = {
-    val (sortedGroups, transitive) = mill.eval.Plan.plan(rs)
+  def main(args: Array[String]): Unit = {
+    val Array(src, dest0) = args
 
-    val goalSet = rs.toSet
+    val dest = os.Path(dest0)
     import guru.nidi.graphviz.engine.{Format, Graphviz}
-    import guru.nidi.graphviz.model.Factory._
-
-    val edgesIterator =
-      for ((k, vs) <- sortedGroups.items())
-        yield (
-          k,
-          for {
-            v <- vs.items
-            dest <- v.inputs.collect { case v: NamedTask[Any] => v }
-            if goalSet.contains(dest)
-          } yield dest
-        )
-
-    val edges = edgesIterator.map { case (k, v) => (k, v.toArray.distinct) }.toArray
-
-    val indexToTask = edges.flatMap { case (k, vs) => Iterator(k.task) ++ vs }.distinct
-    val taskToIndex = indexToTask.zipWithIndex.toMap
-
-    val jgraph = new SimpleDirectedGraph[Int, DefaultEdge](classOf[DefaultEdge])
-
-    for (i <- indexToTask.indices) jgraph.addVertex(i)
-    for ((src, dests) <- edges; dest <- dests) {
-      jgraph.addEdge(taskToIndex(src.task), taskToIndex(dest))
-    }
-
-    org.jgrapht.alg.TransitiveReduction.INSTANCE.reduce(jgraph)
-    val nodes = indexToTask.map(t =>
-      node(sortedGroups.lookupValue(t).render)
-        .`with` {
-          if (targets.contains(t)) Style.SOLID
-          else Style.DASHED
-        }
-        .`with`(Shape.BOX)
-    )
-
-    var g = graph("example1").directed
-    for (i <- indexToTask.indices) {
-      for {
-        e <- edges(i)._2
-        j = taskToIndex(e)
-        if jgraph.containsEdge(i, j)
-      } {
-        g = g.`with`(nodes(j).link(nodes(i)))
-      }
-    }
-
-    g = g.graphAttr().`with`(Rank.dir(RankDir.LEFT_TO_RIGHT))
 
     Graphviz.useEngine(new AbstractJsGraphvizEngine(true, () => new V8JavascriptEngine()) {})
-    val gv = Graphviz.fromGraph(g).totalMemory(128 * 1024 * 1024)
+    val gv = Graphviz.fromFile(new java.io.File(src)).totalMemory(128 * 1024 * 1024)
     val outputs = Seq(
       Format.PLAIN -> "out.txt",
       Format.XDOT -> "out.dot",

--- a/main/graphviz/src/mill/main/graphviz/GraphvizTools.scala
+++ b/main/graphviz/src/mill/main/graphviz/GraphvizTools.scala
@@ -10,25 +10,18 @@ import org.slf4j.Logger
 object GraphvizTools {
 
   def main(args: Array[String]): Unit = {
-    val Array(src, dest0) = args
-
+    val Array(src, dest0, commaSepExtensions) = args
+    val extensions = commaSepExtensions.split(',')
     val dest = os.Path(dest0)
     import guru.nidi.graphviz.engine.{Format, Graphviz}
 
     Graphviz.useEngine(new AbstractJsGraphvizEngine(true, () => new V8JavascriptEngine()) {})
     val gv = Graphviz.fromFile(new java.io.File(src)).totalMemory(128 * 1024 * 1024)
-    val outputs = Seq(
-      Format.PLAIN -> "out.txt",
-      Format.XDOT -> "out.dot",
-      Format.JSON -> "out.json",
-      Format.PNG -> "out.png",
-      Format.SVG -> "out.svg"
-    )
 
-    for ((fmt, name) <- outputs) {
-      gv.render(fmt).toFile((dest / name).toIO)
-    }
-    outputs.map(x => mill.PathRef(dest / x._2))
+    val outputs = extensions
+      .map(ext => Format.values().find(_.fileExtension == ext).head -> s"out.$ext")
+
+    for ((fmt, name) <- outputs) gv.render(fmt).toFile((dest / name).toIO)
   }
 }
 

--- a/main/package.mill
+++ b/main/package.mill
@@ -14,7 +14,9 @@ object `package` extends RootModule with build.MillStableScalaModule with BuildI
     build.Deps.coursierInterface,
     build.Deps.mainargs,
     build.Deps.requests,
-    build.Deps.logback
+    build.Deps.logback,
+    build.Deps.jgraphtCore,
+    ivy"guru.nidi:graphviz-java-min-deps:0.18.1"
   )
 
   def compileIvyDeps = Agg(build.Deps.scalaReflect(scalaVersion()))

--- a/main/src/mill/main/MainModule.scala
+++ b/main/src/mill/main/MainModule.scala
@@ -517,7 +517,7 @@ trait MainModule extends BaseModule0 {
     }
 
   private type VizWorker = (
-      LinkedBlockingQueue[(scala.Seq[_], scala.Seq[_], os.Path)],
+      LinkedBlockingQueue[(scala.Seq[NamedTask[Any]], scala.Seq[NamedTask[Any]], os.Path)],
       LinkedBlockingQueue[Result[scala.Seq[PathRef]]]
   )
 

--- a/main/src/mill/main/VisualizeModule.scala
+++ b/main/src/mill/main/VisualizeModule.scala
@@ -99,11 +99,7 @@ trait VisualizeModule extends mill.define.TaskModule {
           mill.util.Jvm.runSubprocess(
             "mill.main.graphviz.GraphvizTools",
             classpath().map(_.path),
-            mainArgs = Seq(
-              os.temp(g.toString).toString,
-              dest.toString,
-              "txt,dot,json,png,svg"
-            )
+            mainArgs = Seq(s"${os.temp(g.toString)};$dest;txt,dot,json,png,svg")
           )
 
           os.list(dest).sorted.map(PathRef(_))

--- a/main/src/mill/main/VisualizeModule.scala
+++ b/main/src/mill/main/VisualizeModule.scala
@@ -7,7 +7,7 @@ import coursier.maven.MavenRepository
 import mill.define.{Discover, ExternalModule, Target, NamedTask}
 import mill.util.Util.millProjectModule
 import mill.api.{Loose, Result, PathRef}
-import mill.define.{Task, Worker}
+import mill.define.Worker
 import org.jgrapht.graph.{DefaultEdge, SimpleDirectedGraph}
 import guru.nidi.graphviz.attribute.Rank.RankDir
 import guru.nidi.graphviz.attribute.{Rank, Shape, Style}
@@ -49,7 +49,6 @@ trait VisualizeModule extends mill.define.TaskModule {
           val (sortedGroups, transitive) = mill.eval.Plan.plan(rs)
 
           val goalSet = rs.toSet
-          import guru.nidi.graphviz.engine.{Format, Graphviz}
           import guru.nidi.graphviz.model.Factory._
           val edgesIterator =
             for ((k, vs) <- sortedGroups.items())
@@ -100,10 +99,14 @@ trait VisualizeModule extends mill.define.TaskModule {
           mill.util.Jvm.runSubprocess(
             "mill.main.graphviz.GraphvizTools",
             classpath().map(_.path),
-            mainArgs = Seq(os.temp(g.toString).toString, Task.dest.toString)
+            mainArgs = Seq(
+              os.temp(g.toString).toString,
+              dest.toString,
+              "txt,dot,json,png,svg"
+            )
           )
 
-          os.list(Task.dest).map(PathRef(_))
+          os.list(dest).sorted.map(PathRef(_))
         }
         out.put(res)
       }

--- a/main/src/mill/main/VisualizeModule.scala
+++ b/main/src/mill/main/VisualizeModule.scala
@@ -4,12 +4,13 @@ import java.util.concurrent.LinkedBlockingQueue
 import coursier.LocalRepositories
 import coursier.core.Repository
 import coursier.maven.MavenRepository
-import mill.define.{Discover, ExternalModule, Target}
-import mill.api.{PathRef, Result}
+import mill.define.{Discover, ExternalModule, Target, NamedTask}
 import mill.util.Util.millProjectModule
-import mill.api.Loose
-import mill.define.Worker
-import os.Path
+import mill.api.{Loose, Result, PathRef}
+import mill.define.{Task, Worker}
+import org.jgrapht.graph.{DefaultEdge, SimpleDirectedGraph}
+import guru.nidi.graphviz.attribute.Rank.RankDir
+import guru.nidi.graphviz.attribute.{Rank, Shape, Style}
 
 object VisualizeModule extends ExternalModule with VisualizeModule {
   def repositories: Seq[Repository] = Seq(
@@ -35,24 +36,74 @@ trait VisualizeModule extends mill.define.TaskModule {
    * can communicate via in/out queues.
    */
   def worker: Worker[(
-      LinkedBlockingQueue[(Seq[_], Seq[_], Path)],
+      LinkedBlockingQueue[(Seq[NamedTask[Any]], Seq[NamedTask[Any]], os.Path)],
       LinkedBlockingQueue[Result[Seq[PathRef]]]
   )] = Target.worker {
-    val in = new LinkedBlockingQueue[(Seq[_], Seq[_], os.Path)]()
+    val in = new LinkedBlockingQueue[(Seq[NamedTask[Any]], Seq[NamedTask[Any]], os.Path)]()
     val out = new LinkedBlockingQueue[Result[Seq[PathRef]]]()
 
-    val cl = mill.api.ClassLoader.create(
-      classpath().map(_.path.toNIO.toUri.toURL).toVector,
-      getClass.getClassLoader
-    )
     val visualizeThread = new java.lang.Thread(() =>
       while (true) {
         val res = Result.Success {
-          val (targets, tasks, dest) = in.take()
-          cl.loadClass("mill.main.graphviz.GraphvizTools")
-            .getMethod("apply", classOf[Seq[_]], classOf[Seq[_]], classOf[os.Path])
-            .invoke(null, targets, tasks, dest)
-            .asInstanceOf[Seq[PathRef]]
+          val (targets, rs, dest) = in.take()
+          val (sortedGroups, transitive) = mill.eval.Plan.plan(rs)
+
+          val goalSet = rs.toSet
+          import guru.nidi.graphviz.engine.{Format, Graphviz}
+          import guru.nidi.graphviz.model.Factory._
+          val edgesIterator =
+            for ((k, vs) <- sortedGroups.items())
+              yield (
+                k,
+                for {
+                  v <- vs.items
+                  dest <- v.inputs.collect { case v: mill.define.NamedTask[Any] => v }
+                  if goalSet.contains(dest)
+                } yield dest
+              )
+
+          val edges = edgesIterator.map { case (k, v) => (k, v.toArray.distinct) }.toArray
+
+          val indexToTask = edges.flatMap { case (k, vs) => Iterator(k.task) ++ vs }.distinct
+          val taskToIndex = indexToTask.zipWithIndex.toMap
+
+          val jgraph = new SimpleDirectedGraph[Int, DefaultEdge](classOf[DefaultEdge])
+
+          for (i <- indexToTask.indices) jgraph.addVertex(i)
+          for ((src, dests) <- edges; dest <- dests) {
+            jgraph.addEdge(taskToIndex(src.task), taskToIndex(dest))
+          }
+
+          org.jgrapht.alg.TransitiveReduction.INSTANCE.reduce(jgraph)
+          val nodes = indexToTask.map(t =>
+            node(sortedGroups.lookupValue(t).render)
+              .`with` {
+                if (targets.contains(t)) Style.SOLID
+                else Style.DASHED
+              }
+              .`with`(Shape.BOX)
+          )
+
+          var g = graph("example1").directed
+          for (i <- indexToTask.indices) {
+            for {
+              e <- edges(i)._2
+              j = taskToIndex(e)
+              if jgraph.containsEdge(i, j)
+            } {
+              g = g.`with`(nodes(j).link(nodes(i)))
+            }
+          }
+
+          g = g.graphAttr().`with`(Rank.dir(RankDir.LEFT_TO_RIGHT))
+
+          mill.util.Jvm.runSubprocess(
+            "mill.main.graphviz.GraphvizTools",
+            classpath().map(_.path),
+            mainArgs = Seq(os.temp(g.toString).toString, Task.dest.toString)
+          )
+
+          os.list(Task.dest).map(PathRef(_))
         }
         out.put(res)
       }

--- a/mill-build/build.sc
+++ b/mill-build/build.sc
@@ -9,6 +9,7 @@ object `package` extends MillBuildRootModule {
     ivy"net.sourceforge.htmlcleaner:htmlcleaner:2.29",
     // TODO: implement empty version for ivy deps as we do in import parser
     ivy"com.lihaoyi::mill-contrib-buildinfo:${mill.api.BuildInfo.millVersion}",
-    ivy"com.goyeau::mill-scalafix::0.4.1"
+    ivy"com.goyeau::mill-scalafix::0.4.1",
+    ivy"com.lihaoyi::mill-main-graphviz:${mill.api.BuildInfo.millVersion}"
   )
 }


### PR DESCRIPTION
* We cannot do Javet/Node/Graphviz rendering in-process because the native node.js binary necessary to run these things doesn't play well with Mill's classloader juggling, meaning if the `build.mill` gets recompiled in a long-running process it currently fails with a nasty LinkageError. This is an existing problem

```
lihaoyi mill$ ./mill  visualize dist._
...
[ [55/59] =========================================== visualize dist._ =============================================== 8s
  "/Users/lihaoyi/Github/mill/out/visualize.dest/out.txt",
  "/Users/lihaoyi/Github/mill/out/visualize.dest/out.dot",
  "/Users/lihaoyi/Github/mill/out/visualize.dest/out.json",
  "/Users/lihaoyi/Github/mill/out/visualize.dest/out.png",
  "/Users/lihaoyi/Github/mill/out/visualize.dest/out.svg"
]
[3/3] =============================================== visualize dist._ ============================================== 11s

lihaoyi mill$ echo "def hello = 1" >> build.mill

lihaoyi mill$ ./mill  visualize dist._
...
[2] Oct 09, 2024 10:55:57 AM com.caoccao.javet.utils.JavetDefaultLogger error
[2] SEVERE: Native Library /private/var/folders/rt/f1pd6fz92x3__6jg0cmgdd580000gn/T/javet/27157/libjavet-v8-macos-arm64.v.3.1.6.dylib already loaded in another classloader
[2] Oct 09, 2024 10:55:57 AM com.caoccao.javet.utils.JavetDefaultLogger error
[2] SEVERE: java.lang.UnsatisfiedLinkError: Native Library /private/var/folders/rt/f1pd6fz92x3__6jg0cmgdd580000gn/T/javet/27157/libjavet-v8-macos-arm64.v.3.1.6.dylib already loaded in another classloader
[2] 	at java.base/jdk.internal.loader.NativeLibraries.loadLibrary(NativeLibraries.java:201)
[2] 	at java.base/jdk.internal.loader.NativeLibraries.loadLibrary(NativeLibraries.java:174)
[2] 	at java.base/java.lang.ClassLoader.loadLibrary(ClassLoader.java:2389)
[2] 	at java.base/java.lang.Runtime.load0(Runtime.java:755)
[2] 	at java.base/java.lang.System.load(System.java:1953)
[2] 	at com.caoccao.javet.interop.loader.JavetLibLoader.load(JavetLibLoader.java:357)
[2] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[2] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
[2] 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[2] 	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
[2] 	at com.caoccao.javet.interop.JavetClassLoader.load(JavetClassLoader.java:104)
[2] 	at com.caoccao.javet.interop.V8Host.loadLibrary(V8Host.java:464)
[2] 	at com.caoccao.javet.interop.V8Host.<init>(V8Host.java:85)
[2] 	at com.caoccao.javet.interop.V8Host.<init>(V8Host.java:51)
[2] 	at com.caoccao.javet.interop.V8Host$V8InstanceHolder.<clinit>(V8Host.java:602)
[2] 	at com.caoccao.javet.interop.V8Host.getV8Instance(V8Host.java:134)
[2] 	at mill.main.graphviz.V8JavascriptEngine.<init>(GraphvizTools.scala:89)
[2] 	at mill.main.graphviz.GraphvizTools$$anon$1$$anonfun$$lessinit$greater$1.get(GraphvizTools.scala:70)
[2] 	at mill.main.graphviz.GraphvizTools$$anon$1$$anonfun$$lessinit$greater$1.get(GraphvizTools.scala:70)
[2] 	at guru.nidi.graphviz.engine.AbstractJsGraphvizEngine.engine(AbstractJsGraphvizEngine.java:65)
[2] 	at guru.nidi.graphviz.engine.AbstractJsGraphvizEngine.doInit(AbstractJsGraphvizEngine.java:49)
[2] 	at guru.nidi.graphviz.engine.AbstractGraphvizEngine.initTask(AbstractGraphvizEngine.java:50)
[2] 	at guru.nidi.graphviz.engine.AbstractGraphvizEngine.init(AbstractGraphvizEngine.java:42)
[2] 	at guru.nidi.graphviz.engine.Graphviz.doUseEngine(Graphviz.java:146)
[2] 	at guru.nidi.graphviz.engine.Graphviz.useEngine(Graphviz.java:138)
[2] 	at guru.nidi.graphviz.engine.Graphviz.useEngine(Graphviz.java:119)
[2] 	at mill.main.graphviz.GraphvizTools$.apply(GraphvizTools.scala:70)
[2] 	at mill.main.graphviz.GraphvizTools.apply(GraphvizTools.scala)
[2] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[2] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
[2] 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[2] 	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
[2] 	at mill.main.VisualizeModule.$anonfun$worker$5(VisualizeModule.scala:54)
[2] 	at java.base/java.lang.Thread.run(Thread.java:833)
[2]
```
* We remove the Antora Krokli from the docsite and just manually parse of the graphviz blocks and render them ourselves, to try and mitigate https://github.com/com-lihaoyi/mill/issues/3411