### PR TITLE
Drop unnecessary filter on artifacts

### DIFF
--- a/main/util/src/mill/util/CoursierSupport.scala
+++ b/main/util/src/mill/util/CoursierSupport.scala
@@ -104,7 +104,7 @@ trait CoursierSupport {
             Agg.from(
               res.files
                 .map(os.Path(_))
-                .filter(path => path.ext == "jar" && resolveFilter(path))
+                .filter(resolveFilter)
                 .map(PathRef(_, quick = true))
             ) ++ localTestDeps.flatten
           )


### PR DESCRIPTION
Artifacts should already be filtered by `coursier.Artifacts` (via classifiers and artifact types stuff), no need to filter them further