### PR TITLE
Add kotlinx-html to `3-hello-kotlinjs` example

### DIFF
--- a/example/kotlinlib/web/3-hello-kotlinjs/build.mill
+++ b/example/kotlinlib/web/3-hello-kotlinjs/build.mill
@@ -1,9 +1,9 @@
 // KotlinJS support on Mill is still Work In Progress (WIP). As of time of writing it
-// does not support third-party dependencies, Kotlin 2.x with KMP KLIB files, Node.js/Webpack
-// test runners and reporting, etc.
+// Node.js/Webpack test runners and reporting, etc.
 //
-// The example below demonstrates only the minimal compilation, running, and testing of a single KotlinJS
-// module. For more details in fully developing KotlinJS support, see the following ticket:
+// The example below demonstrates only the minimal compilation, running, and testing of
+// a single KotlinJS module using a single third-party dependency. For more details in
+// fully developing KotlinJS support, see the following ticket:
 //
 // * https://github.com/com-lihaoyi/mill/issues/3611
 
@@ -14,6 +14,9 @@ object foo extends KotlinJSModule {
   def moduleKind = ModuleKind.ESModule
   def kotlinVersion = "1.9.25"
   def kotlinJSRunTarget = Some(RunTarget.Node)
+  def ivyDeps = Agg(
+    ivy"org.jetbrains.kotlinx:kotlinx-html-js:0.11.0",
+  )
   object test extends KotlinJSModule with KotlinJSKotlinXTests
 }
 
@@ -22,7 +25,7 @@ object foo extends KotlinJSModule {
 
 > mill foo.run
 Compiling 1 Kotlin sources to .../out/foo/compile.dest/classes...
-Hello, world
+<h1>Hello World</h1>
 stringifiedJsObject: ["hello","world","!"]
 
 > mill foo.test # Test is incorrect, `foo.test`` fails
@@ -30,13 +33,13 @@ Compiling 1 Kotlin sources to .../out/foo/test/compile.dest/classes...
 Linking IR to .../out/foo/test/linkBinary.dest/binaries
 produce executable: .../out/foo/test/linkBinary.dest/binaries
 ...
-error: AssertionError: Expected <Hello, world>, actual <Not hello, world>.
+error: AssertionError: Expected <<h1>Hello World</h1>>, actual <<h1>Hello World Wrong</h1>>.
 
 > cat out/foo/test/linkBinary.dest/binaries/test.js # Generated javascript on disk
-...assertEquals_0(getString(), 'Not hello, world');...
+...assertEquals_0(..., '<h1>Hello World Wrong<\/h1>');...
 ...
 
-> sed -i.bak 's/Not hello, world/Hello, world/g' foo/test/src/foo/HelloTests.kt
+> sed -i.bak 's/Hello World Wrong/Hello World/g' foo/test/src/foo/HelloTests.kt
 
 > mill foo.test # passes after fixing test
 

--- a/example/kotlinlib/web/3-hello-kotlinjs/foo/src/foo/Hello.kt
+++ b/example/kotlinlib/web/3-hello-kotlinjs/foo/src/foo/Hello.kt
@@ -1,11 +1,16 @@
 package foo
 
-fun getString() = "Hello, world"
+import kotlinx.html.*
+import kotlinx.html.stream.createHTML
 
 fun main() {
-    println(getString())
+    println(hello())
 
     val parsedJsonStr: dynamic = JSON.parse("""{"helloworld": ["hello", "world", "!"]}""")
     val stringifiedJsObject = JSON.stringify(parsedJsonStr.helloworld)
     println("stringifiedJsObject: " + stringifiedJsObject)
+}
+
+fun hello(): String {
+    return createHTML().h1 { +"Hello World" }.toString()
 }

--- a/example/kotlinlib/web/3-hello-kotlinjs/foo/test/src/foo/HelloTests.kt
+++ b/example/kotlinlib/web/3-hello-kotlinjs/foo/test/src/foo/HelloTests.kt
@@ -6,8 +6,10 @@ import kotlin.test.assertEquals
 class HelloTests {
 
     @Test
-    fun failure() {
-        assertEquals(getString(), "Not hello, world")
+    fun testHello() {
+      val result = hello()
+      assertEquals(result.trim(), "<h1>Hello World Wrong</h1>")
+      result
     }
 }
 


### PR DESCRIPTION
Takes advantage of the new klib support pulled in by https://github.com/com-lihaoyi/mill/pull/3705

We don't support the `module` file indirection, so for now we have to reference the `-js` version of the artifact directly