### PR TITLE
Try to fix deprecated discover warning

### DIFF
--- a/main/define/src/mill/define/Discover.scala
+++ b/main/define/src/mill/define/Discover.scala
@@ -144,8 +144,17 @@ object Discover {
         // by wrapping the `overridesRoutes` in a lambda function we kind of work around
         // the problem of generating a *huge* macro method body that finally exceeds the
         // JVM's maximum allowed method size
+
+        val lhs = discoveredModuleType match{
+          case tt: ThisType => q"classOf[${tt.sym}]"
+          case tr: TypeRef => q"classOf[${tr.pre}]"
+          case _ => q"classOf[$discoveredModuleType]"
+        }
+        println()
+        pprint.log(discoveredModuleType)
+        pprint.log(lhs)
         val overridesLambda = q"(() => $overridesRoutes)()"
-        val lhs = q"classOf[${discoveredModuleType.typeSymbol.asClass}]"
+
         q"$lhs -> $overridesLambda"
       }
 

--- a/main/define/src/mill/define/Discover.scala
+++ b/main/define/src/mill/define/Discover.scala
@@ -144,12 +144,12 @@ object Discover {
         val lhs0 = discoveredModuleType match {
           // Explicitly do not de-alias type refs, so type aliases to deprecated
           // types do not result in spurious deprecation warnings appearing
-          case tr: TypeRef => tr.pre
+          case tr: TypeRef => tr
           // Other types are fine
-          case _ => discoveredModuleType
+          case _ => discoveredModuleType.typeSymbol.asClass.toType
         }
 
-        val lhs = q"classOf[${lhs0.typeSymbol.asClass}]"
+        val lhs = q"classOf[$lhs0]"
 
         // by wrapping the `overridesRoutes` in a lambda function we kind of work around
         // the problem of generating a *huge* macro method body that finally exceeds the

--- a/main/define/src/mill/define/Discover.scala
+++ b/main/define/src/mill/define/Discover.scala
@@ -150,9 +150,7 @@ object Discover {
           case tr: TypeRef => q"classOf[${tr.pre}]"
           case _ => q"classOf[$discoveredModuleType]"
         }
-        println()
-        pprint.log(discoveredModuleType)
-        pprint.log(lhs)
+
         val overridesLambda = q"(() => $overridesRoutes)()"
 
         q"$lhs -> $overridesLambda"

--- a/main/define/src/mill/define/Discover.scala
+++ b/main/define/src/mill/define/Discover.scala
@@ -141,7 +141,7 @@ object Discover {
         }
         if overridesRoutes._1.nonEmpty || overridesRoutes._2.nonEmpty || overridesRoutes._3.nonEmpty
       } yield {
-        val lhs0 = discoveredModuleType match{
+        val lhs0 = discoveredModuleType match {
           // Explicitly do not de-alias type refs, so type aliases to deprecated
           // types do not result in spurious deprecation warnings appearing
           case tr: TypeRef => tr.pre

--- a/main/define/src/mill/define/Discover.scala
+++ b/main/define/src/mill/define/Discover.scala
@@ -146,8 +146,12 @@ object Discover {
         // JVM's maximum allowed method size
 
         val lhs = discoveredModuleType match{
-          case tt: ThisType => q"classOf[${tt.sym}]"
+          // Explicitly do not de-alias type refs, so type aliases to deprecated
+          // types do not result in spurious deprecation warnings appearing
           case tr: TypeRef => q"classOf[${tr.pre}]"
+          // Singleton value types need to be extracted this way for some reason
+          case tt: ThisType => q"classOf[${tt.sym}]"
+          // Other types are fine
           case _ => q"classOf[$discoveredModuleType]"
         }
 

--- a/runner/src/mill/runner/CodeGen.scala
+++ b/runner/src/mill/runner/CodeGen.scala
@@ -232,7 +232,7 @@ object CodeGen {
 
   }
 
-  def discoverSnippet(segments: Seq[String]) = {
+  def discoverSnippet(segments: Seq[String]): String = {
     if (segments.nonEmpty) ""
     else
       """override lazy val millDiscover: _root_.mill.define.Discover = _root_.mill.define.Discover[this.type]

--- a/runner/src/mill/runner/CodeGen.scala
+++ b/runner/src/mill/runner/CodeGen.scala
@@ -161,11 +161,7 @@ object CodeGen {
         newScriptCode = objectData.name.applyTo(newScriptCode, wrapperObjectName)
         newScriptCode = objectData.obj.applyTo(newScriptCode, "abstract class")
 
-        val millDiscover =
-          if (segments.nonEmpty) ""
-          else
-            """@_root_.scala.annotation.nowarn
-              |  override lazy val millDiscover: _root_.mill.define.Discover = _root_.mill.define.Discover[this.type]""".stripMargin
+        val millDiscover = discoverSnippet(segments)
 
         s"""$pkgLine
            |$aliasImports
@@ -224,11 +220,7 @@ object CodeGen {
       s"extends _root_.mill.main.RootModule.Subfolder "
     }
 
-    val millDiscover =
-      if (segments.nonEmpty) ""
-      else
-        """@_root_.scala.annotation.nowarn
-          |  override lazy val millDiscover: _root_.mill.define.Discover = _root_.mill.define.Discover[this.type]""".stripMargin
+    val millDiscover = discoverSnippet(segments)
 
     // User code needs to be put in a separate class for proper submodule
     // object initialization due to https://github.com/scala/scala3/issues/21444
@@ -237,6 +229,14 @@ object CodeGen {
        |  $millDiscover
        |}
        |abstract class $wrapperObjectName $extendsClause {""".stripMargin
+
+  }
+
+  def discoverSnippet(segments: Seq[String]) = {
+    if (segments.nonEmpty) ""
+    else
+      """override lazy val millDiscover: _root_.mill.define.Discover = _root_.mill.define.Discover[this.type]
+        |""".stripMargin
 
   }
 


### PR DESCRIPTION
fixes https://github.com/com-lihaoyi/mill/issues/3385

Somehow the `@nowarn` annotations don't seem to work after we moved the `millDiscover` definition into the main module body (???) so instead of relying on those I try to fix the deprecated warning in the `Discover` macro itself by identifying type annotations and explicitly asking not to dereference them

Manually tested by running the commands below, observed that no deprecation warning was printed

```
rm -rf /Users/lihaoyi/Github/mill/example/javalib/basic/1-simple/out
./mill -i dist.run example/javalib/basic/1-simple -i run -t hello
```