### PR TITLE
More cleanups for PromptLogger

### DIFF
--- a/main/api/src/mill/api/Logger.scala
+++ b/main/api/src/mill/api/Logger.scala
@@ -58,7 +58,7 @@ trait Logger extends AutoCloseable {
   ): Unit =
     ticker(s"${key.mkString("-")} $message")
   private[mill] def setPromptLine(): Unit = ()
-  private[mill] def setPromptLeftHeader(s: String): Unit = ()
+  private[mill] def setPromptHeaderPrefix(s: String): Unit = ()
   private[mill] def clearPromptStatuses(): Unit = ()
   private[mill] def removePromptLine(key: Seq[String]): Unit = ()
   private[mill] def removePromptLine(): Unit = ()

--- a/main/eval/src/mill/eval/EvaluatorCore.scala
+++ b/main/eval/src/mill/eval/EvaluatorCore.scala
@@ -111,7 +111,7 @@ private[mill] trait EvaluatorCore extends GroupEvaluator {
           )
 
           val verboseKeySuffix = s"/${terminals0.size}"
-          logger.setPromptLeftHeader(s"$countMsg$verboseKeySuffix")
+          logger.setPromptHeaderPrefix(s"$countMsg$verboseKeySuffix")
           if (failed.get()) None
           else {
             val upstreamResults = upstreamValues

--- a/main/util/src/mill/util/MultiLogger.scala
+++ b/main/util/src/mill/util/MultiLogger.scala
@@ -81,9 +81,9 @@ class MultiLogger(
     logger1.removePromptLine()
     logger2.removePromptLine()
   }
-  private[mill] override def setPromptLeftHeader(s: String): Unit = {
-    logger1.setPromptLeftHeader(s)
-    logger2.setPromptLeftHeader(s)
+  private[mill] override def setPromptHeaderPrefix(s: String): Unit = {
+    logger1.setPromptHeaderPrefix(s)
+    logger2.setPromptHeaderPrefix(s)
   }
 
   private[mill] override def withPromptPaused[T](t: => T): T = {

--- a/main/util/src/mill/util/PrefixLogger.scala
+++ b/main/util/src/mill/util/PrefixLogger.scala
@@ -107,7 +107,7 @@ class PrefixLogger(
   private[mill] override def removePromptLine(callKey: Seq[String]): Unit =
     logger0.removePromptLine(callKey)
   private[mill] override def removePromptLine(): Unit = removePromptLine(logPrefixKey)
-  private[mill] override def setPromptLeftHeader(s: String): Unit = logger0.setPromptLeftHeader(s)
+  private[mill] override def setPromptHeaderPrefix(s: String): Unit = logger0.setPromptHeaderPrefix(s)
   override def enableTicker = logger0.enableTicker
 
   private[mill] override def subLogger(

--- a/main/util/src/mill/util/PrefixLogger.scala
+++ b/main/util/src/mill/util/PrefixLogger.scala
@@ -107,7 +107,8 @@ class PrefixLogger(
   private[mill] override def removePromptLine(callKey: Seq[String]): Unit =
     logger0.removePromptLine(callKey)
   private[mill] override def removePromptLine(): Unit = removePromptLine(logPrefixKey)
-  private[mill] override def setPromptHeaderPrefix(s: String): Unit = logger0.setPromptHeaderPrefix(s)
+  private[mill] override def setPromptHeaderPrefix(s: String): Unit =
+    logger0.setPromptHeaderPrefix(s)
   override def enableTicker = logger0.enableTicker
 
   private[mill] override def subLogger(

--- a/main/util/src/mill/util/PromptLogger.scala
+++ b/main/util/src/mill/util/PromptLogger.scala
@@ -309,7 +309,7 @@ private[mill] object PromptLogger {
         statuses.toSeq.map { case (k, v) => (k.mkString("-"), v) },
         interactive = interactive,
         infoColor = infoColor,
-        ending = ending,
+        ending = ending
       )
 
       currentPromptBytes = renderPromptWrapped(currentPromptLines, interactive, ending).getBytes

--- a/main/util/src/mill/util/PromptLoggerUtil.scala
+++ b/main/util/src/mill/util/PromptLoggerUtil.scala
@@ -149,6 +149,26 @@ private object PromptLoggerUtil {
     header :: body ::: footer
   }
 
+  // Wrap the prompt in the necessary clear-screens/newlines/move-cursors
+  // according to whether it is interactive or ending
+  def renderPromptWrapped(currentPromptLines: Seq[String],
+                          interactive: Boolean,
+                          ending: Boolean) = {
+    if (!interactive) currentPromptLines.mkString("\n") + "\n"
+    else {
+      // For the ending prompt, leave the cursor at the bottom on a new line rather than
+      // scrolling back left/up. We do not want further output to overwrite the header as
+      // it will no longer re-render
+      val backUp =
+        if (ending) "\n"
+        else AnsiNav.left(9999) + AnsiNav.up(currentPromptLines.length - 1)
+
+      AnsiNav.clearScreen(0) +
+        currentPromptLines.mkString("\n") +
+        backUp
+    }
+  }
+
   def renderHeader(
       headerPrefix0: String,
       titleText0: String,
@@ -203,5 +223,18 @@ private object PromptLoggerUtil {
       else index -= 1
     }
     ???
+  }
+
+  private[mill] val seqStringOrdering = new Ordering[Seq[String]] {
+    def compare(xs: Seq[String], ys: Seq[String]): Int = {
+      val iter = xs.iterator.zip(ys)
+      while (iter.nonEmpty) {
+        val (x, y) = iter.next()
+        if (x > y) return 1
+        else if (y > x) return -1
+      }
+
+      return xs.lengthCompare(ys)
+    }
   }
 }

--- a/main/util/src/mill/util/PromptLoggerUtil.scala
+++ b/main/util/src/mill/util/PromptLoggerUtil.scala
@@ -155,7 +155,7 @@ private object PromptLoggerUtil {
       currentPromptLines: Seq[String],
       interactive: Boolean,
       ending: Boolean
-  ) = {
+  ): String = {
     if (!interactive) currentPromptLines.mkString("\n") + "\n"
     else {
       // For the ending prompt, leave the cursor at the bottom on a new line rather than

--- a/main/util/src/mill/util/PromptLoggerUtil.scala
+++ b/main/util/src/mill/util/PromptLoggerUtil.scala
@@ -151,9 +151,11 @@ private object PromptLoggerUtil {
 
   // Wrap the prompt in the necessary clear-screens/newlines/move-cursors
   // according to whether it is interactive or ending
-  def renderPromptWrapped(currentPromptLines: Seq[String],
-                          interactive: Boolean,
-                          ending: Boolean) = {
+  def renderPromptWrapped(
+      currentPromptLines: Seq[String],
+      interactive: Boolean,
+      ending: Boolean
+  ) = {
     if (!interactive) currentPromptLines.mkString("\n") + "\n"
     else {
       // For the ending prompt, leave the cursor at the bottom on a new line rather than

--- a/main/util/src/mill/util/ProxyLogger.scala
+++ b/main/util/src/mill/util/ProxyLogger.scala
@@ -35,7 +35,8 @@ class ProxyLogger(logger: Logger) extends Logger {
   override def rawOutputStream: PrintStream = logger.rawOutputStream
   private[mill] override def removePromptLine(key: Seq[String]): Unit = logger.removePromptLine(key)
   private[mill] override def removePromptLine(): Unit = logger.removePromptLine()
-  private[mill] override def setPromptHeaderPrefix(s: String): Unit = logger.setPromptHeaderPrefix(s)
+  private[mill] override def setPromptHeaderPrefix(s: String): Unit =
+    logger.setPromptHeaderPrefix(s)
   private[mill] override def withPromptPaused[T](t: => T): T = logger.withPromptPaused(t)
   private[mill] override def withPromptUnpaused[T](t: => T): T = logger.withPromptUnpaused(t)
 

--- a/main/util/src/mill/util/ProxyLogger.scala
+++ b/main/util/src/mill/util/ProxyLogger.scala
@@ -35,7 +35,7 @@ class ProxyLogger(logger: Logger) extends Logger {
   override def rawOutputStream: PrintStream = logger.rawOutputStream
   private[mill] override def removePromptLine(key: Seq[String]): Unit = logger.removePromptLine(key)
   private[mill] override def removePromptLine(): Unit = logger.removePromptLine()
-  private[mill] override def setPromptLeftHeader(s: String): Unit = logger.setPromptLeftHeader(s)
+  private[mill] override def setPromptHeaderPrefix(s: String): Unit = logger.setPromptHeaderPrefix(s)
   private[mill] override def withPromptPaused[T](t: => T): T = logger.withPromptPaused(t)
   private[mill] override def withPromptUnpaused[T](t: => T): T = logger.withPromptUnpaused(t)
 

--- a/main/util/test/src/mill/util/PromptLoggerTests.scala
+++ b/main/util/test/src/mill/util/PromptLoggerTests.scala
@@ -59,7 +59,7 @@ object PromptLoggerTests extends TestSuite {
 
         val (baos, promptLogger, prefixLogger) = setup(() => now, os.temp())
 
-        promptLogger.setPromptLeftHeader("123/456")
+        promptLogger.setPromptHeaderPrefix("123/456")
         promptLogger.setPromptLine(Seq("1"), "/456", "my-task")
 
         now += 10000
@@ -108,7 +108,7 @@ object PromptLoggerTests extends TestSuite {
         var now = 0L
         val (baos, promptLogger, prefixLogger) = setup(() => now, os.temp("80 40"))
 
-        promptLogger.setPromptLeftHeader("123/456")
+        promptLogger.setPromptHeaderPrefix("123/456")
         promptLogger.refreshPrompt()
         check(promptLogger, baos)(
           "  [123/456] ========================== TITLE =================================="
@@ -278,7 +278,7 @@ object PromptLoggerTests extends TestSuite {
         @volatile var now = 0L
         val (baos, promptLogger, prefixLogger) = setup(() => now, os.temp("80 40"))
 
-        promptLogger.setPromptLeftHeader("123/456")
+        promptLogger.setPromptHeaderPrefix("123/456")
         promptLogger.refreshPrompt()
         check(promptLogger, baos)(
           "  [123/456] ========================== TITLE =================================="
@@ -329,7 +329,7 @@ object PromptLoggerTests extends TestSuite {
         @volatile var now = 0L
         val (baos, promptLogger, prefixLogger) = setup(() => now, os.temp("80 40"))
 
-        promptLogger.setPromptLeftHeader("123/456")
+        promptLogger.setPromptHeaderPrefix("123/456")
         promptLogger.refreshPrompt()
 
         promptLogger.setPromptLine(Seq("1"), "/456", "my-task")


### PR DESCRIPTION
* Move more pure logic into `PromptLoggerUtil` static methods
* Make prompt line replacement logic more aggressive, such that even after dead lines finish transitioning they can be replaced, fixing an issue where the prompt height sometimes grew unnecessarily due to blank lines