### PR TITLE
Try and speed up proguard contrib module/tests by re-using global java runtime jar

### DIFF
--- a/contrib/proguard/src/mill/contrib/proguard/Proguard.scala
+++ b/contrib/proguard/src/mill/contrib/proguard/Proguard.scala
@@ -65,18 +65,8 @@ trait Proguard extends ScalaModule {
    * Keep in sync with [[javaHome]].
    */
   def java9RtJar: T[Seq[PathRef]] = Task {
-    if (mill.main.client.Util.isJava9OrAbove) {
-      val rt = T.dest / Export.rtJarName
-      if (!os.exists(rt)) {
-        T.log.outputStream.println(
-          s"Preparing Java runtime JAR; this may take a minute or two ..."
-        )
-        Export.rtTo(rt.toIO, false)
-      }
-      Seq(PathRef(rt))
-    } else {
-      Seq()
-    }
+    if (mill.main.client.Util.isJava9OrAbove) Seq(PathRef(T.home / Export.rtJarName))
+    else Seq()
   }
 
   /**


### PR DESCRIPTION
Proguard is a long pole in the windows contrib test job, hopefully this makes it a bit faster

Seems to cut a few minutes; previously it ran in 12-17min, with this PR it ran in 10+ min