### PR TITLE
Fix JavaModule.artifactTypes

### DIFF
--- a/integration/feature/docannotations/src/DocAnnotationsTests.scala
+++ b/integration/feature/docannotations/src/DocAnnotationsTests.scala
@@ -93,7 +93,7 @@ object DocAnnotationsTests extends UtestIntegrationTestSuite {
 
       assert(
         globMatches(
-          """core.ivyDepsTree(JavaModule.scala:893)
+          """core.ivyDepsTree(JavaModule.scala:896)
             |    Command to print the transitive dependency tree to STDOUT.
             |
             |    --inverse                Invert the tree representation, so that the root is on the bottom val

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -545,7 +545,10 @@ trait JavaModule
    * Resolved dependencies based on [[transitiveIvyDeps]] and [[transitiveCompileIvyDeps]].
    */
   def resolvedIvyDeps: T[Agg[PathRef]] = Task {
-    defaultResolver().resolveDeps(transitiveCompileIvyDeps() ++ transitiveIvyDeps())
+    defaultResolver().resolveDeps(
+      transitiveCompileIvyDeps() ++ transitiveIvyDeps(),
+      artifactTypes = Some(artifactTypes())
+    )
   }
 
   /**

--- a/scalalib/test/src/mill/scalalib/ResolveDepsTests.scala
+++ b/scalalib/test/src/mill/scalalib/ResolveDepsTests.scala
@@ -36,7 +36,8 @@ object ResolveDepsTests extends TestSuite {
         // Dependency whose packaging is "pom", as it's meant to be used
         // as a "parent dependency" by other dependencies, rather than be pulled
         // as we do here. We do it anyway, to check that pulling the "pom" artifact
-        // type brings that dependency POM file in the class path.
+        // type brings that dependency POM file in the class path. We need a dependency
+        // that has a "pom" packaging for that.
         ivy"org.apache.hadoop:hadoop-yarn-server:3.4.0"
       )
       def artifactTypes = super.artifactTypes() + coursier.Type("pom")

--- a/scalalib/test/src/mill/scalalib/ResolveDepsTests.scala
+++ b/scalalib/test/src/mill/scalalib/ResolveDepsTests.scala
@@ -33,6 +33,10 @@ object ResolveDepsTests extends TestSuite {
   object TestCase extends TestBaseModule {
     object pomStuff extends JavaModule {
       def ivyDeps = Agg(
+        // Dependency whose packaging is "pom", as it's meant to be used
+        // as a "parent dependency" by other dependencies, rather than be pulled
+        // as we do here. We do it anyway, to check that pulling the "pom" artifact
+        // type brings that dependency POM file in the class path.
         ivy"org.apache.hadoop:hadoop-yarn-server:3.4.0"
       )
       def artifactTypes = super.artifactTypes() + coursier.Type("pom")

--- a/scalalib/test/src/mill/scalalib/ResolveDepsTests.scala
+++ b/scalalib/test/src/mill/scalalib/ResolveDepsTests.scala
@@ -110,9 +110,13 @@ object ResolveDepsTests extends TestSuite {
     test("pomArtifactType") {
       val sources = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "pomArtifactType"
       UnitTester(TestCase, sourceRoot = sources).scoped { eval =>
-        val Right(result) = eval(TestCase.pomStuff.compileClasspath)
-        val cp = result.value.toSeq.map(_.path)
-        assert(cp.exists(_.lastOpt.contains("hadoop-yarn-server-3.4.0.pom")))
+        val Right(compileResult) = eval(TestCase.pomStuff.compileClasspath)
+        val compileCp = compileResult.value.toSeq.map(_.path)
+        assert(compileCp.exists(_.lastOpt.contains("hadoop-yarn-server-3.4.0.pom")))
+
+        val Right(runResult) = eval(TestCase.pomStuff.runClasspath)
+        val runCp = runResult.value.toSeq.map(_.path)
+        assert(runCp.exists(_.lastOpt.contains("hadoop-yarn-server-3.4.0.pom")))
       }
     }
   }


### PR DESCRIPTION
Follow-up of https://github.com/com-lihaoyi/mill/pull/3703 that added `JavaModule.artifactTypes`. `JavaModule` performs two dependency resolutions: one for `compileClasspath`, the other for `runClasspath`. https://github.com/com-lihaoyi/mill/pull/3703 used `artifactTypes` in the `runClasspath` one, but not in the `compileClasspath` one. The PR here fixes that, and adds unit tests for both paths.

This addresses the issues found around https://github.com/com-lihaoyi/mill/pull/3696#issuecomment-2405891608.