### PR TITLE
Added permanent discord link

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-Please don't open issues for questions, but ask in our Discussions forum at https://github.com/com-lihaoyi/mill/discussions or Discord channel at https://discord.gg/MNAXQMAr
+Please don't open issues for questions, but ask in our Discussions forum at https://github.com/com-lihaoyi/mill/discussions or Discord channel at https://discord.gg/scala
 
 Mill installations via `coursier` or `cs` are unsupported.
 

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -1,6 +1,6 @@
 = Contributing to Mill
 :link-github: https://github.com/com-lihaoyi/mill
-:link-chat: https://discord.gg/MNAXQMAr
+:link-chat: https://discord.gg/scala
 
 Thank you for considering contributing to Mill.
 

--- a/docs/modules/ROOT/partials/Installation_IDE_Support.adoc
+++ b/docs/modules/ROOT/partials/Installation_IDE_Support.adoc
@@ -261,7 +261,7 @@ for some reason you don't want to use `.mill-jvm-opts` file name, add
 
 ---
 
-Come by our https://discord.gg/MNAXQMAr[Discord Channel]
+Come by our https://discord.gg/scala[Discord Channel]
 if you want to ask questions or say hi!
 
 

--- a/docs/supplemental-ui/partials/header-content.hbs
+++ b/docs/supplemental-ui/partials/header-content.hbs
@@ -20,7 +20,7 @@
         <a class="navbar-item" href="{{{or site.url (or siteRootUrl siteRootPath)}}}/api/latest/index.html">API</a>
         <a class="navbar-item" href="https://github.com/com-lihaoyi/mill/issues">Issues</a>
         <a class="navbar-item" href="https://github.com/com-lihaoyi/mill/discussions">Discuss</a>
-        <a class="navbar-item" href="https://discord.gg/MNAXQMAr">Chat</a>
+        <a class="navbar-item" href="https://discord.gg/scala">Chat</a>
 
             <!--
         <a class="navbar-item" href="#">Home</a>


### PR DESCRIPTION
Have replaced the discord links with https://discord.gg/scala (permanent link, never expires) 

Related #3590 