### PR TITLE
Lift Kotlin 2+ version usage constraint for Kotlin/JS

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -187,7 +187,8 @@ object Deps {
   val requests = ivy"com.lihaoyi::requests:0.9.0"
   val logback = ivy"ch.qos.logback:logback-classic:1.5.7"
   val sonatypeCentralClient = ivy"com.lumidion::sonatype-central-client-requests:0.3.0"
-  val kotlinCompiler = ivy"org.jetbrains.kotlin:kotlin-compiler:1.9.24"
+  val kotlinVersion = "2.0.21"
+  val kotlinCompiler = ivy"org.jetbrains.kotlin:kotlin-compiler:$kotlinVersion"
 
   object RuntimeDeps {
     val errorProneCore = ivy"com.google.errorprone:error_prone_core:2.31.0"

--- a/kotlinlib/package.mill
+++ b/kotlinlib/package.mill
@@ -15,6 +15,7 @@ object `package` extends RootModule with build.MillPublishScalaModule with Build
   def buildInfoPackageName = "mill.kotlinlib"
   def buildInfoObjectName = "Versions"
   def buildInfoMembers = Seq(
+    BuildInfo.Value("kotlinVersion", build.Deps.kotlinVersion, "Version of Kotlin"),
     BuildInfo.Value("koverVersion", build.Deps.RuntimeDeps.koverVersion, "Version of Kover."),
     BuildInfo.Value("ktfmtVersion", build.Deps.RuntimeDeps.ktfmtVersion, "Version of Ktfmt."),
     BuildInfo.Value("detektVersion", build.Deps.RuntimeDeps.detektVersion, "Version of Detekt."),

--- a/kotlinlib/src/mill/kotlinlib/js/KotlinJSModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/js/KotlinJSModule.scala
@@ -114,8 +114,8 @@ trait KotlinJSModule extends KotlinModule { outer =>
 
     val linkResult = linkBinary().classes
     if (
-      moduleKind == ModuleKind.NoModule
-      && linkResult.path.toIO.listFiles().count(_.getName.endsWith(".js")) > 1
+      moduleKind == ModuleKind.NoModule &&
+      linkResult.path.toIO.listFiles().count(_.getName.endsWith(".js")) > 1
     ) {
       T.log.info("No module type is selected for the executable, but multiple .js files found in the output folder." +
         " This will probably lead to the dependency resolution failure.")
@@ -236,13 +236,12 @@ trait KotlinJSModule extends KotlinModule { outer =>
     val versionAllowed = kotlinVersion.split("\\.").map(_.toInt) match {
       case Array(1, 8, z) => z >= 20
       case Array(1, y, _) => y >= 9
-      case Array(2, _, _) => false
-      case _ => false
+      case _ => true
     }
     if (!versionAllowed) {
       // have to put this restriction, because for older versions some compiler options either didn't exist or
       // had different names. It is possible to go to the lower version supported with a certain effort.
-      ctx.log.error("Minimum supported Kotlin version for JS target is 1.8.20, maximum is 1.9.25")
+      ctx.log.error("Minimum supported Kotlin version for JS target is 1.8.20.")
       return Result.Aborted
     }
 
@@ -255,9 +254,6 @@ trait KotlinJSModule extends KotlinModule { outer =>
       case None => allKotlinSourceFiles.map(_.path.toIO.getAbsolutePath)
     }
 
-    // TODO: Cannot support Kotlin 2+, because it doesn't publish .jar anymore, but .klib files only. Coursier is not
-    //  able to work with that (unlike Gradle, which can leverage .module metadata).
-    // https://repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-js/2.0.20/
     val librariesCp = librariesClasspath.map(_.path)
       .filter(os.exists)
       .filter(isKotlinJsLibrary)

--- a/kotlinlib/test/resources/kotlin-js/qux/src/qux/ExternalDependency.kt
+++ b/kotlinlib/test/resources/kotlin-js/qux/src/qux/ExternalDependency.kt
@@ -1,0 +1,8 @@
+package qux
+
+import kotlinx.html.div
+import kotlinx.html.stream.createHTML
+
+fun doThing() {
+    println(createHTML().div { +"Hello" })
+}


### PR DESCRIPTION
Since `klib` files can be fetched now, it removes the constraint for the Kotlin 2+ version usage (where `stdlib` is now published only as `klib`).

I added a `kotlinVersion` to the build info, but it is not actually used anywhere in the module code (because the default version for the module is never specified), only in the test. 