### PR TITLE
Move JSON logging to a separate thread

### DIFF
--- a/main/eval/src/mill/eval/EvaluatorCore.scala
+++ b/main/eval/src/mill/eval/EvaluatorCore.scala
@@ -72,190 +72,190 @@ private[mill] trait EvaluatorCore extends GroupEvaluator {
       serialCommandExec: Boolean
   ): Evaluator.Results = {
     os.makeDir.all(outPath)
-    val chromeProfileLogger = new ChromeProfileLogger(outPath / millChromeProfile)
-    val profileLogger = new ProfileLogger(outPath / millProfile)
     val threadNumberer = new ThreadNumberer()
-    val (sortedGroups, transitive) = Plan.plan(goals)
-    val interGroupDeps = findInterGroupDeps(sortedGroups)
-    val terminals0 = sortedGroups.keys().toVector
-    val failed = new AtomicBoolean(false)
-    val count = new AtomicInteger(1)
+    scala.util.Using.resources(
+      new ChromeProfileLogger(outPath / millChromeProfile),
+      new ProfileLogger(outPath / millProfile)
+    ) { (chromeProfileLogger, profileLogger) =>
+      val (sortedGroups, transitive) = Plan.plan(goals)
+      val interGroupDeps = findInterGroupDeps(sortedGroups)
+      val terminals0 = sortedGroups.keys().toVector
+      val failed = new AtomicBoolean(false)
+      val count = new AtomicInteger(1)
 
-    val futures = mutable.Map.empty[Terminal, Future[Option[GroupEvaluator.Results]]]
+      val futures = mutable.Map.empty[Terminal, Future[Option[GroupEvaluator.Results]]]
 
-    // Prepare a lookup tables up front of all the method names that each class owns,
-    // and the class hierarchy, so during evaluation it is cheap to look up what class
-    // each target belongs to determine of the enclosing class code signature changed.
-    val (classToTransitiveClasses, allTransitiveClassMethods) =
-      precomputeMethodNamesPerClass(sortedGroups)
+      // Prepare a lookup tables up front of all the method names that each class owns,
+      // and the class hierarchy, so during evaluation it is cheap to look up what class
+      // each target belongs to determine of the enclosing class code signature changed.
+      val (classToTransitiveClasses, allTransitiveClassMethods) =
+        precomputeMethodNamesPerClass(sortedGroups)
 
-    def evaluateTerminals(
-        terminals: Seq[Terminal],
-        forkExecutionContext: mill.api.Ctx.Fork.Impl,
-        exclusive: Boolean
-    ) = {
-      implicit val taskExecutionContext =
-        if (exclusive) ExecutionContexts.RunNow else forkExecutionContext
-      // We walk the task graph in topological order and schedule the futures
-      // to run asynchronously. During this walk, we store the scheduled futures
-      // in a dictionary. When scheduling each future, we are guaranteed that the
-      // necessary upstream futures will have already been scheduled and stored,
-      // due to the topological order of traversal.
-      for (terminal <- terminals) {
-        val deps = interGroupDeps(terminal)
-        futures(terminal) = Future.sequence(deps.map(futures)).map { upstreamValues =>
-          val countMsg = mill.util.Util.leftPad(
-            count.getAndIncrement().toString,
-            terminals.length.toString.length,
-            '0'
-          )
-
-          val verboseKeySuffix = s"/${terminals0.size}"
-          logger.setPromptHeaderPrefix(s"$countMsg$verboseKeySuffix")
-          if (failed.get()) None
-          else {
-            val upstreamResults = upstreamValues
-              .iterator
-              .flatMap(_.iterator.flatMap(_.newResults))
-              .toMap
-
-            val startTime = System.nanoTime() / 1000
-            val targetLabel = terminal match {
-              case Terminal.Task(task) => None
-              case t: Terminal.Labelled[_] => Some(Terminal.printTerm(t))
-            }
-
-            val group = sortedGroups.lookupKey(terminal)
-
-            // should we log progress?
-            val logRun = targetLabel.isDefined && {
-              val inputResults = for {
-                target <- group.indexed.filterNot(upstreamResults.contains)
-                item <- target.inputs.filterNot(group.contains)
-              } yield upstreamResults(item).map(_._1)
-              inputResults.forall(_.result.isInstanceOf[Result.Success[_]])
-            }
-
-            val tickerPrefix = terminal.render.collect {
-              case targetLabel if logRun && logger.enableTicker => targetLabel
-            }
-
-            val contextLogger = new PrefixLogger(
-              logger0 = logger,
-              key0 = if (!logger.enableTicker) Nil else Seq(countMsg),
-              verboseKeySuffix = verboseKeySuffix,
-              message = tickerPrefix,
-              noPrefix = exclusive
+      def evaluateTerminals(
+                             terminals: Seq[Terminal],
+                             forkExecutionContext: mill.api.Ctx.Fork.Impl,
+                             exclusive: Boolean
+                           ) = {
+        implicit val taskExecutionContext =
+          if (exclusive) ExecutionContexts.RunNow else forkExecutionContext
+        // We walk the task graph in topological order and schedule the futures
+        // to run asynchronously. During this walk, we store the scheduled futures
+        // in a dictionary. When scheduling each future, we are guaranteed that the
+        // necessary upstream futures will have already been scheduled and stored,
+        // due to the topological order of traversal.
+        for (terminal <- terminals) {
+          val deps = interGroupDeps(terminal)
+          futures(terminal) = Future.sequence(deps.map(futures)).map { upstreamValues =>
+            val countMsg = mill.util.Util.leftPad(
+              count.getAndIncrement().toString,
+              terminals.length.toString.length,
+              '0'
             )
 
-            val res = evaluateGroupCached(
-              terminal = terminal,
-              group = sortedGroups.lookupKey(terminal),
-              results = upstreamResults,
-              countMsg = countMsg,
-              verboseKeySuffix = verboseKeySuffix,
-              zincProblemReporter = reporter,
-              testReporter = testReporter,
-              logger = contextLogger,
-              classToTransitiveClasses,
-              allTransitiveClassMethods,
-              forkExecutionContext,
-              exclusive
-            )
+            val verboseKeySuffix = s"/${terminals0.size}"
+            logger.setPromptHeaderPrefix(s"$countMsg$verboseKeySuffix")
+            if (failed.get()) None
+            else {
+              val upstreamResults = upstreamValues
+                .iterator
+                .flatMap(_.iterator.flatMap(_.newResults))
+                .toMap
 
-            if (failFast && res.newResults.values.exists(_.result.asSuccess.isEmpty))
-              failed.set(true)
+              val startTime = System.nanoTime() / 1000
+              val targetLabel = terminal match {
+                case Terminal.Task(task) => None
+                case t: Terminal.Labelled[_] => Some(Terminal.printTerm(t))
+              }
 
-            val endTime = System.nanoTime() / 1000
+              val group = sortedGroups.lookupKey(terminal)
 
-            val duration = endTime - startTime
+              // should we log progress?
+              val logRun = targetLabel.isDefined && {
+                val inputResults = for {
+                  target <- group.indexed.filterNot(upstreamResults.contains)
+                  item <- target.inputs.filterNot(group.contains)
+                } yield upstreamResults(item).map(_._1)
+                inputResults.forall(_.result.isInstanceOf[Result.Success[_]])
+              }
 
-            chromeProfileLogger.log(
-              task = Terminal.printTerm(terminal),
-              cat = "job",
-              startTime = startTime,
-              duration = duration,
-              threadId = threadNumberer.getThreadId(Thread.currentThread()),
-              cached = res.cached
-            )
+              val tickerPrefix = terminal.render.collect {
+                case targetLabel if logRun && logger.enableTicker => targetLabel
+              }
 
-            profileLogger.log(
-              ProfileLogger.Timing(
-                terminal.render,
-                (duration / 1000).toInt,
-                res.cached,
-                deps.map(_.render),
-                res.inputsHash,
-                res.previousInputsHash
+              val contextLogger = new PrefixLogger(
+                logger0 = logger,
+                key0 = if (!logger.enableTicker) Nil else Seq(countMsg),
+                verboseKeySuffix = verboseKeySuffix,
+                message = tickerPrefix,
+                noPrefix = exclusive
               )
-            )
 
-            Some(res)
+              val res = evaluateGroupCached(
+                terminal = terminal,
+                group = sortedGroups.lookupKey(terminal),
+                results = upstreamResults,
+                countMsg = countMsg,
+                verboseKeySuffix = verboseKeySuffix,
+                zincProblemReporter = reporter,
+                testReporter = testReporter,
+                logger = contextLogger,
+                classToTransitiveClasses,
+                allTransitiveClassMethods,
+                forkExecutionContext,
+                exclusive
+              )
+
+              if (failFast && res.newResults.values.exists(_.result.asSuccess.isEmpty))
+                failed.set(true)
+
+              val endTime = System.nanoTime() / 1000
+
+              val duration = endTime - startTime
+
+              chromeProfileLogger.log(
+                task = Terminal.printTerm(terminal),
+                cat = "job",
+                startTime = startTime,
+                duration = duration,
+                threadId = threadNumberer.getThreadId(Thread.currentThread()),
+                cached = res.cached
+              )
+
+              profileLogger.log(
+                ProfileLogger.Timing(
+                  terminal.render,
+                  (duration / 1000).toInt,
+                  res.cached,
+                  deps.map(_.render),
+                  res.inputsHash,
+                  res.previousInputsHash
+                )
+              )
+
+              Some(res)
+            }
           }
         }
       }
-    }
 
-    val tasks0 = terminals0.filter {
-      case Terminal.Labelled(c: Command[_], _) => false
-      case _ => true
-    }
-
-    val (_, tasksTransitive0) = Plan.plan(Agg.from(tasks0.map(_.task)))
-
-    val tasksTransitive = tasksTransitive0.toSet
-    val (tasks, leafExclusiveCommands) = terminals0.partition {
-      case Terminal.Labelled(t, _) =>
-        if (tasksTransitive.contains(t)) true
-        else t match {
-          case t: Command[_] => !t.exclusive
-          case _ => false
-        }
-      case _ => !serialCommandExec
-    }
-
-    // Run all non-command tasks according to the threads
-    // given but run the commands in linear order
-    evaluateTerminals(
-      tasks,
-      ec,
-      exclusive = false
-    )
-
-    evaluateTerminals(leafExclusiveCommands, ec, exclusive = true)
-
-    logger.clearPromptStatuses()
-    val finishedOptsMap = terminals0
-      .map(t => (t, Await.result(futures(t), duration.Duration.Inf)))
-      .toMap
-
-    val results0: Vector[(Task[_], TaskResult[(Val, Int)])] = terminals0
-      .flatMap { t =>
-        sortedGroups.lookupKey(t).flatMap { t0 =>
-          finishedOptsMap(t) match {
-            case None => Some((t0, TaskResult(Aborted, () => Aborted)))
-            case Some(res) => res.newResults.get(t0).map(r => (t0, r))
-          }
-        }
+      val tasks0 = terminals0.filter {
+        case Terminal.Labelled(c: Command[_], _) => false
+        case _ => true
       }
 
-    val results: Map[Task[_], TaskResult[(Val, Int)]] = results0.toMap
+      val (_, tasksTransitive0) = Plan.plan(Agg.from(tasks0.map(_.task)))
 
-    chromeProfileLogger.close()
-    profileLogger.close()
+      val tasksTransitive = tasksTransitive0.toSet
+      val (tasks, leafExclusiveCommands) = terminals0.partition {
+        case Terminal.Labelled(t, _) =>
+          if (tasksTransitive.contains(t)) true
+          else t match {
+            case t: Command[_] => !t.exclusive
+            case _ => false
+          }
+        case _ => !serialCommandExec
+      }
 
-    EvaluatorCore.Results(
-      goals.indexed.map(results(_).map(_._1).result),
-      // result of flatMap may contain non-distinct entries,
-      // so we manually clean it up before converting to a `Strict.Agg`
-      // see https://github.com/com-lihaoyi/mill/issues/2958
-      Strict.Agg.from(
-        finishedOptsMap.values.flatMap(_.toSeq.flatMap(_.newEvaluated)).iterator.distinct
-      ),
-      transitive,
-      getFailing(sortedGroups, results),
-      results.map { case (k, v) => (k, v.map(_._1)) }
-    )
+      // Run all non-command tasks according to the threads
+      // given but run the commands in linear order
+      evaluateTerminals(
+        tasks,
+        ec,
+        exclusive = false
+      )
+
+      evaluateTerminals(leafExclusiveCommands, ec, exclusive = true)
+
+      logger.clearPromptStatuses()
+      val finishedOptsMap = terminals0
+        .map(t => (t, Await.result(futures(t), duration.Duration.Inf)))
+        .toMap
+
+      val results0: Vector[(Task[_], TaskResult[(Val, Int)])] = terminals0
+        .flatMap { t =>
+          sortedGroups.lookupKey(t).flatMap { t0 =>
+            finishedOptsMap(t) match {
+              case None => Some((t0, TaskResult(Aborted, () => Aborted)))
+              case Some(res) => res.newResults.get(t0).map(r => (t0, r))
+            }
+          }
+        }
+
+      val results: Map[Task[_], TaskResult[(Val, Int)]] = results0.toMap
+
+      EvaluatorCore.Results(
+        goals.indexed.map(results(_).map(_._1).result),
+        // result of flatMap may contain non-distinct entries,
+        // so we manually clean it up before converting to a `Strict.Agg`
+        // see https://github.com/com-lihaoyi/mill/issues/2958
+        Strict.Agg.from(
+          finishedOptsMap.values.flatMap(_.toSeq.flatMap(_.newEvaluated)).iterator.distinct
+        ),
+        transitive,
+        getFailing(sortedGroups, results),
+        results.map { case (k, v) => (k, v.map(_._1)) }
+      )
+    }
   }
 
   private def precomputeMethodNamesPerClass(sortedGroups: MultiBiMap[Terminal, Task[_]]) = {


### PR DESCRIPTION
`JsonArrayLogger#log` appears significantly in the jprofiler traces. 

I use a `SynchronousQueue` to limit how much the background thread can fall behind, but at least in non-contested scenarios we have a separate thread running the logging process so the main worker threads do not need to block on the logging completing