### PR TITLE
Simplify codegen prelude implicits

### DIFF
--- a/integration/failure/root-module-compile-error/src/RootModuleCompileErrorTests.scala
+++ b/integration/failure/root-module-compile-error/src/RootModuleCompileErrorTests.scala
@@ -25,7 +25,7 @@ object RootModuleCompileErrorTests extends UtestIntegrationTestSuite {
       )
       assert(
         res.err.contains(
-          """abstract class package_  extends RootModule.Subfolder with UnknownFooModule {"""
+          """abstract class package_  extends Subfolder with UnknownFooModule {"""
         )
       )
 

--- a/integration/failure/root-module-compile-error/src/RootModuleCompileErrorTests.scala
+++ b/integration/failure/root-module-compile-error/src/RootModuleCompileErrorTests.scala
@@ -20,7 +20,7 @@ object RootModuleCompileErrorTests extends UtestIntegrationTestSuite {
       )
       assert(
         res.err.replace('\\', '/').contains(
-          """foo/package.mill:6:60: not found: type UnknownFooModule"""
+          """foo/package.mill:6:65: not found: type UnknownFooModule"""
         )
       )
       assert(

--- a/integration/failure/root-module-compile-error/src/RootModuleCompileErrorTests.scala
+++ b/integration/failure/root-module-compile-error/src/RootModuleCompileErrorTests.scala
@@ -25,7 +25,7 @@ object RootModuleCompileErrorTests extends UtestIntegrationTestSuite {
       )
       assert(
         res.err.contains(
-          """abstract class package_  extends Subfolder with UnknownFooModule {"""
+          """abstract class package_  extends mill.main.SubfolderModule with UnknownFooModule {"""
         )
       )
 

--- a/main/src/mill/main/RootModule.scala
+++ b/main/src/mill/main/RootModule.scala
@@ -18,7 +18,7 @@ abstract class RootModule()(implicit
     millModuleEnclosing0: sourcecode.Enclosing,
     millModuleLine0: sourcecode.Line,
     millFile0: sourcecode.File
-) extends mill.define.BaseModule(baseModuleInfo.millSourcePath0)(
+) extends mill.define.BaseModule(baseModuleInfo.projectRoot)(
       millModuleEnclosing0,
       millModuleLine0,
       millFile0,
@@ -33,7 +33,26 @@ abstract class RootModule()(implicit
 
 @internal
 object RootModule {
-  case class Info(millSourcePath0: os.Path, discover: Discover)
+  class Info(val enclosingClasspath: Seq[os.Path],
+             val projectRoot: os.Path,
+             val output: os.Path,
+             val topLevelProjectRoot: os.Path){
+    def this(
+      enclosingClasspath0: Seq[String],
+      projectRoot0: String,
+      output0: String,
+      topLevelProjectRoot0: String
+    ) = this(
+      enclosingClasspath0.map(os.Path(_)),
+      os.Path(projectRoot0),
+      os.Path(output0),
+      os.Path(topLevelProjectRoot0)
+    )
+
+    implicit val millMiscInfo: Info = this
+
+  }
+
   object Info {
     // Dummy `RootModule.Info` available in implicit scope but never actually used.
     // as it is provided by the codegen. Defined for IDEs to think that one is available
@@ -70,7 +89,7 @@ object RootModule {
       millModuleEnclosing0: sourcecode.Enclosing,
       millModuleLine0: sourcecode.Line,
       millFile0: sourcecode.File
-  ) extends BaseModule(baseModuleInfo.millSourcePath0, foreign0 = foreign0)(
+  ) extends BaseModule(baseModuleInfo.projectRoot, foreign0 = foreign0)(
         millModuleEnclosing0,
         millModuleLine0,
         millFile0,

--- a/main/src/mill/main/RootModule.scala
+++ b/main/src/mill/main/RootModule.scala
@@ -33,15 +33,17 @@ abstract class RootModule()(implicit
 
 @internal
 object RootModule {
-  class Info(val enclosingClasspath: Seq[os.Path],
-             val projectRoot: os.Path,
-             val output: os.Path,
-             val topLevelProjectRoot: os.Path){
+  class Info(
+      val enclosingClasspath: Seq[os.Path],
+      val projectRoot: os.Path,
+      val output: os.Path,
+      val topLevelProjectRoot: os.Path
+  ) {
     def this(
-      enclosingClasspath0: Seq[String],
-      projectRoot0: String,
-      output0: String,
-      topLevelProjectRoot0: String
+        enclosingClasspath0: Seq[String],
+        projectRoot0: String,
+        output0: String,
+        topLevelProjectRoot0: String
     ) = this(
       enclosingClasspath0.map(os.Path(_)),
       os.Path(projectRoot0),
@@ -61,8 +63,7 @@ object RootModule {
     implicit def dummyInfo: Info = sys.error("implicit RootModule.Info must be provided")
   }
 
-  class SubFolderInfo(val value: os.Path,
-                      val millSourcePath0: Seq[String]){
+  class SubFolderInfo(val value: os.Path, val millSourcePath0: Seq[String]) {
     implicit val subFolderInfo: SubFolderInfo = this
   }
 

--- a/main/src/mill/main/RootModule.scala
+++ b/main/src/mill/main/RootModule.scala
@@ -1,7 +1,7 @@
 package mill.main
 
 import mill.api.internal
-import mill.define.{BaseModule, Ctx, Caller, Discover, Module, Segments}
+import mill.define.{Caller, Discover}
 import scala.annotation.compileTimeOnly
 
 /**

--- a/main/src/mill/main/RootModule.scala
+++ b/main/src/mill/main/RootModule.scala
@@ -42,19 +42,21 @@ object RootModule {
     implicit def dummyInfo: Info = sys.error("implicit RootModule.Info must be provided")
   }
 
-  case class SubFolderInfo(value: Seq[String])
+  class SubFolderInfo(val value: os.Path,
+                      val millSourcePath0: Seq[String]){
+    implicit val subFolderInfo: SubFolderInfo = this
+  }
 
   abstract class Subfolder()(implicit
-      baseModuleInfo: RootModule.Info,
       millModuleLine0: sourcecode.Line,
       millFile0: sourcecode.File,
       subFolderInfo: SubFolderInfo
   ) extends Module.BaseClass()(
         Ctx.make(
-          millModuleEnclosing0 = subFolderInfo.value.mkString("."),
+          millModuleEnclosing0 = subFolderInfo.millSourcePath0.mkString("."),
           millModuleLine0 = millModuleLine0,
-          millModuleBasePath0 = Ctx.BasePath(baseModuleInfo.millSourcePath0 / os.up),
-          segments0 = Segments.labels(subFolderInfo.value.init: _*),
+          millModuleBasePath0 = Ctx.BasePath(subFolderInfo.value / os.up),
+          segments0 = Segments.labels(subFolderInfo.millSourcePath0.init: _*),
           external0 = Ctx.External(false),
           foreign0 = Ctx.Foreign(None),
           fileName = millFile0,

--- a/main/src/mill/main/RootModule.scala
+++ b/main/src/mill/main/RootModule.scala
@@ -52,7 +52,6 @@ object RootModule {
     )
 
     implicit val millMiscInfo: Info = this
-
   }
 
   object Info {
@@ -62,38 +61,4 @@ object RootModule {
     @compileTimeOnly("RootModule can only be instantiated in a build.mill or package.mill file")
     implicit def dummyInfo: Info = sys.error("implicit RootModule.Info must be provided")
   }
-
-  class SubFolderInfo(val value: os.Path, val millSourcePath0: Seq[String]) {
-    implicit val subFolderInfo: SubFolderInfo = this
-  }
-
-  abstract class Subfolder()(implicit
-      millModuleLine0: sourcecode.Line,
-      millFile0: sourcecode.File,
-      subFolderInfo: SubFolderInfo
-  ) extends Module.BaseClass()(
-        Ctx.make(
-          millModuleEnclosing0 = subFolderInfo.millSourcePath0.mkString("."),
-          millModuleLine0 = millModuleLine0,
-          millModuleBasePath0 = Ctx.BasePath(subFolderInfo.value / os.up),
-          segments0 = Segments.labels(subFolderInfo.millSourcePath0.init: _*),
-          external0 = Ctx.External(false),
-          foreign0 = Ctx.Foreign(None),
-          fileName = millFile0,
-          enclosing = Caller(null)
-        )
-      ) with Module {}
-
-  @deprecated
-  abstract class Foreign(foreign0: Option[Segments])(implicit
-      baseModuleInfo: RootModule.Info,
-      millModuleEnclosing0: sourcecode.Enclosing,
-      millModuleLine0: sourcecode.Line,
-      millFile0: sourcecode.File
-  ) extends BaseModule(baseModuleInfo.projectRoot, foreign0 = foreign0)(
-        millModuleEnclosing0,
-        millModuleLine0,
-        millFile0,
-        Caller(null)
-      ) with mill.main.MainModule
 }

--- a/main/src/mill/main/Subfolder.scala
+++ b/main/src/mill/main/Subfolder.scala
@@ -1,0 +1,26 @@
+package mill.main;
+import mill._
+import mill.define.{Caller, Ctx, Segments}
+object Subfolder{
+
+  class Info(val value: os.Path, val millSourcePath0: Seq[String]) {
+    implicit val subFolderInfo: Info = this
+  }
+}
+
+  abstract class Subfolder()(implicit
+      millModuleLine0: sourcecode.Line,
+      millFile0: sourcecode.File,
+      subFolderInfo: Subfolder.Info
+  ) extends mill.define.Module.BaseClass()(
+        Ctx.make(
+          millModuleEnclosing0 = subFolderInfo.millSourcePath0.mkString("."),
+          millModuleLine0 = millModuleLine0,
+          millModuleBasePath0 = Ctx.BasePath(subFolderInfo.value / os.up),
+          segments0 = Segments.labels(subFolderInfo.millSourcePath0.init: _*),
+          external0 = Ctx.External(false),
+          foreign0 = Ctx.Foreign(None),
+          fileName = millFile0,
+          enclosing = Caller(null)
+        )
+      ) with Module {}

--- a/main/src/mill/main/Subfolder.scala
+++ b/main/src/mill/main/Subfolder.scala
@@ -1,26 +1,26 @@
 package mill.main;
 import mill._
 import mill.define.{Caller, Ctx, Segments}
-object Subfolder{
+object SubfolderModule {
 
   class Info(val value: os.Path, val millSourcePath0: Seq[String]) {
     implicit val subFolderInfo: Info = this
   }
 }
 
-  abstract class Subfolder()(implicit
-      millModuleLine0: sourcecode.Line,
-      millFile0: sourcecode.File,
-      subFolderInfo: Subfolder.Info
-  ) extends mill.define.Module.BaseClass()(
-        Ctx.make(
-          millModuleEnclosing0 = subFolderInfo.millSourcePath0.mkString("."),
-          millModuleLine0 = millModuleLine0,
-          millModuleBasePath0 = Ctx.BasePath(subFolderInfo.value / os.up),
-          segments0 = Segments.labels(subFolderInfo.millSourcePath0.init: _*),
-          external0 = Ctx.External(false),
-          foreign0 = Ctx.Foreign(None),
-          fileName = millFile0,
-          enclosing = Caller(null)
-        )
-      ) with Module {}
+abstract class SubfolderModule()(implicit
+    millModuleLine0: sourcecode.Line,
+    millFile0: sourcecode.File,
+    subFolderInfo: SubfolderModule.Info
+) extends mill.define.Module.BaseClass()(
+      Ctx.make(
+        millModuleEnclosing0 = subFolderInfo.millSourcePath0.mkString("."),
+        millModuleLine0 = millModuleLine0,
+        millModuleBasePath0 = Ctx.BasePath(subFolderInfo.value / os.up),
+        segments0 = Segments.labels(subFolderInfo.millSourcePath0.init: _*),
+        external0 = Ctx.External(false),
+        foreign0 = Ctx.Foreign(None),
+        fileName = millFile0,
+        enclosing = Caller(null)
+      )
+    ) with Module {}

--- a/main/src/mill/main/Subfolder.scala
+++ b/main/src/mill/main/Subfolder.scala
@@ -1,9 +1,9 @@
 package mill.main;
 import mill._
 import mill.define.{Caller, Ctx, Segments}
-object SubfolderModule {
 
-  class Info(val value: os.Path, val millSourcePath0: Seq[String]) {
+object SubfolderModule {
+  class Info(val millSourcePath0: os.Path, val segments: Seq[String]) {
     implicit val subFolderInfo: Info = this
   }
 }
@@ -14,10 +14,10 @@ abstract class SubfolderModule()(implicit
     subFolderInfo: SubfolderModule.Info
 ) extends mill.define.Module.BaseClass()(
       Ctx.make(
-        millModuleEnclosing0 = subFolderInfo.millSourcePath0.mkString("."),
+        millModuleEnclosing0 = subFolderInfo.segments.mkString("."),
         millModuleLine0 = millModuleLine0,
-        millModuleBasePath0 = Ctx.BasePath(subFolderInfo.value / os.up),
-        segments0 = Segments.labels(subFolderInfo.millSourcePath0.init: _*),
+        millModuleBasePath0 = Ctx.BasePath(subFolderInfo.millSourcePath0 / os.up),
+        segments0 = Segments.labels(subFolderInfo.segments.init: _*),
         external0 = Ctx.External(false),
         foreign0 = Ctx.Foreign(None),
         fileName = millFile0,

--- a/runner/src/mill/runner/CodeGen.scala
+++ b/runner/src/mill/runner/CodeGen.scala
@@ -180,7 +180,7 @@ object CodeGen {
     }
   }
 
-  def subfolderBuildPrelude(scriptFolderPath: os.Path, segments: Seq[String]) = {
+  def subfolderBuildPrelude(scriptFolderPath: os.Path, segments: Seq[String]): String = {
     s"""object MillMiscSubFolderInfo
        |extends mill.main.RootModule.SubFolderInfo(
        |  os.Path(${literalize(scriptFolderPath.toString)}),
@@ -198,7 +198,7 @@ object CodeGen {
   ): String = {
     s"""import _root_.mill.runner.MillBuildRootModule
        |@_root_.scala.annotation.nowarn
-       |object MillMiscInfo extends MillBuildRootModule.MillMiscInfo(
+       |object MillMiscInfo extends mill.main.RootModule.Info(
        |  ${enclosingClasspath.map(p => literalize(p.toString))},
        |  ${literalize(scriptFolderPath.toString)},
        |  ${literalize(output.toString)},

--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -6,7 +6,7 @@ import mill.main.client.CodeGenConstants.*
 import mill.api.{PathRef, SystemStreams, Val, internal}
 import mill.eval.Evaluator
 import mill.resolve.SelectMode
-import mill.define.{BaseModule, Discover, Segments}
+import mill.define.{BaseModule, Segments}
 import mill.main.client.OutFiles.{millBuild, millRunnerState}
 
 import java.net.URLClassLoader

--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -1,11 +1,10 @@
 package mill.runner
 
 import mill.util.{ColorLogger, PrefixLogger, Watchable}
-import mill.main.BuildInfo
-import mill.main.client.CodeGenConstants._
+import mill.main.{BuildInfo, RootModule, RunScript}
+import mill.main.client.CodeGenConstants.*
 import mill.api.{PathRef, SystemStreams, Val, internal}
 import mill.eval.Evaluator
-import mill.main.RunScript
 import mill.resolve.SelectMode
 import mill.define.{BaseModule, Discover, Segments}
 import mill.main.client.OutFiles.{millBuild, millRunnerState}
@@ -111,15 +110,12 @@ class MillBuildBootstrap(
         if (parsedScriptFiles.millImport) evaluateRec(depth + 1)
         else {
           val bootstrapModule =
-            new MillBuildRootModule.BootstrapModule(
-              projectRoot,
-              recRoot(projectRoot, depth),
-              output,
-              millBootClasspath
-            )(
-              mill.main.RootModule.Info(
+            new MillBuildRootModule.BootstrapModule()(
+              new RootModule.Info(
+                millBootClasspath,
                 recRoot(projectRoot, depth),
-                Discover[MillBuildRootModule.BootstrapModule]
+                output,
+                projectRoot
               )
             )
           RunnerState(Some(bootstrapModule), Nil, None)

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -25,17 +25,16 @@ import mill.define.Target
  */
 @internal
 abstract class MillBuildRootModule()(implicit
-    baseModuleInfo: RootModule.Info,
-    millBuildRootModuleInfo: MillBuildRootModule.Info
+    rootModuleInfo: RootModule.Info,
 ) extends RootModule() with ScalaModule {
-  override def bspDisplayName0: String = millBuildRootModuleInfo
+  override def bspDisplayName0: String = rootModuleInfo
     .projectRoot
-    .relativeTo(millBuildRootModuleInfo.topLevelProjectRoot)
+    .relativeTo(rootModuleInfo.topLevelProjectRoot)
     .segments
     .++(super.bspDisplayName0.split("/"))
     .mkString("/")
 
-  override def millSourcePath: os.Path = millBuildRootModuleInfo.projectRoot / os.up / millBuild
+  override def millSourcePath: os.Path = rootModuleInfo.projectRoot / os.up / millBuild
   override def intellijModulePath: os.Path = millSourcePath / os.up
 
   override def scalaVersion: T[String] = BuildInfo.scalaVersion
@@ -45,7 +44,7 @@ abstract class MillBuildRootModule()(implicit
    * @see [[generateScriptSources]]
    */
   def scriptSources: Target[Seq[PathRef]] = Task.Sources {
-    MillBuildRootModule.parseBuildFiles(millBuildRootModuleInfo)
+    MillBuildRootModule.parseBuildFiles(rootModuleInfo)
       .seenScripts
       .keys.map(PathRef(_))
       .toSeq
@@ -53,7 +52,7 @@ abstract class MillBuildRootModule()(implicit
 
   def parseBuildFiles: T[FileImportGraph] = Task {
     scriptSources()
-    MillBuildRootModule.parseBuildFiles(millBuildRootModuleInfo)
+    MillBuildRootModule.parseBuildFiles(rootModuleInfo)
   }
 
   override def repositoriesTask: Task[Seq[Repository]] = {
@@ -116,13 +115,13 @@ abstract class MillBuildRootModule()(implicit
     if (parsed.errors.nonEmpty) Result.Failure(parsed.errors.mkString("\n"))
     else {
       CodeGen.generateWrappedSources(
-        millBuildRootModuleInfo.projectRoot / os.up,
+        rootModuleInfo.projectRoot / os.up,
         scriptSources(),
         parsed.seenScripts,
         T.dest,
-        millBuildRootModuleInfo.enclosingClasspath,
-        millBuildRootModuleInfo.topLevelProjectRoot,
-        millBuildRootModuleInfo.output
+        rootModuleInfo.enclosingClasspath,
+        rootModuleInfo.topLevelProjectRoot,
+        rootModuleInfo.output
       )
       Result.Success(Seq(PathRef(T.dest)))
     }
@@ -212,7 +211,7 @@ abstract class MillBuildRootModule()(implicit
   }
 
   def enclosingClasspath: Target[Seq[PathRef]] = Task.Sources {
-    millBuildRootModuleInfo.enclosingClasspath.map(p => mill.api.PathRef(p, quick = true))
+    rootModuleInfo.enclosingClasspath.map(p => mill.api.PathRef(p, quick = true))
   }
 
   /**
@@ -266,22 +265,8 @@ abstract class MillBuildRootModule()(implicit
 
 object MillBuildRootModule {
 
-  class BootstrapModule(
-      topLevelProjectRoot0: os.Path,
-      projectRoot: os.Path,
-      output: os.Path,
-      enclosingClasspath: Seq[os.Path]
-  )(implicit baseModuleInfo: RootModule.Info) extends MillBuildRootModule()(
-        implicitly,
-        MillBuildRootModule.Info(
-          enclosingClasspath,
-          projectRoot,
-          output,
-          topLevelProjectRoot0
-        )
-      ) {
-
-    override lazy val millDiscover: Discover = baseModuleInfo.discover
+  class BootstrapModule()(implicit rootModuleInfo: RootModule.Info) extends MillBuildRootModule() {
+    override lazy val millDiscover: Discover = Discover[this.type]
   }
 
   case class Info(
@@ -291,29 +276,11 @@ object MillBuildRootModule {
       topLevelProjectRoot: os.Path
   )
 
-  def parseBuildFiles(millBuildRootModuleInfo: MillBuildRootModule.Info): FileImportGraph = {
+  def parseBuildFiles(millBuildRootModuleInfo: RootModule.Info): FileImportGraph = {
     FileImportGraph.parseBuildFiles(
       millBuildRootModuleInfo.topLevelProjectRoot,
       millBuildRootModuleInfo.projectRoot / os.up,
       millBuildRootModuleInfo.output
-    )
-  }
-
-  class MillMiscInfo(
-      enclosingClasspath: Seq[String],
-      projectRoot: String,
-      output: String,
-      topLevelProjectRoot: String
-  ) {
-    implicit lazy val millBuildRootModuleInfo: MillBuildRootModule.Info = MillBuildRootModule.Info(
-      enclosingClasspath.map(os.Path(_)),
-      os.Path(projectRoot),
-      os.Path(output),
-      os.Path(topLevelProjectRoot)
-    )
-    implicit lazy val millBaseModuleInfo: RootModule.Info = RootModule.Info(
-      millBuildRootModuleInfo.projectRoot,
-      null
     )
   }
 }

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -25,7 +25,7 @@ import mill.define.Target
  */
 @internal
 abstract class MillBuildRootModule()(implicit
-    rootModuleInfo: RootModule.Info,
+    rootModuleInfo: RootModule.Info
 ) extends RootModule() with ScalaModule {
   override def bspDisplayName0: String = rootModuleInfo
     .projectRoot

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -303,8 +303,7 @@ object MillBuildRootModule {
       enclosingClasspath: Seq[String],
       projectRoot: String,
       output: String,
-      topLevelProjectRoot: String,
-      segments: Seq[String]
+      topLevelProjectRoot: String
   ) {
     implicit lazy val millBuildRootModuleInfo: MillBuildRootModule.Info = MillBuildRootModule.Info(
       enclosingClasspath.map(os.Path(_)),
@@ -315,9 +314,6 @@ object MillBuildRootModule {
     implicit lazy val millBaseModuleInfo: RootModule.Info = RootModule.Info(
       millBuildRootModuleInfo.projectRoot,
       null
-    )
-    implicit lazy val subfolderInfo: RootModule.SubFolderInfo = RootModule.SubFolderInfo(
-      segments
     )
   }
 }


### PR DESCRIPTION
Removed `MillBuildRootModule.Info` and `MillBuildRootModule.MillMiscInfo` and consolidated them into `RootModule.Info` and `SubfolderModule.Info`. Shouldn't affect anything semantically, just removes some unnecessary indirection that wasn't doing anything but packing and unpacking the same few values