### PR TITLE
Add smoketest for incremental compilation of multi-file build

### DIFF
--- a/integration/invalidation/codesig-subfolder/src/CodeSigSubfolderTests.scala
+++ b/integration/invalidation/codesig-subfolder/src/CodeSigSubfolderTests.scala
@@ -46,8 +46,8 @@ object CodeSigSubfolderTests extends UtestIntegrationTestSuite {
       // Changing stuff in subfolder/package.mill does not invalidate unrelated tasks in build.mill
       val cached3 = eval("foo")
       assert(cached3.out == "")
-      // TODO: why is this compiling both sources when we only changed
-      // one file and did not change any public type signatures?
+      // This should only compile 1 source but it seems there's an upstream bug in Zinc
+      // https://github.com/sbt/zinc/issues/1461
       assert(cached3.err.contains("compiling 2 Scala sources"))
 
       modifyFile(
@@ -56,8 +56,8 @@ object CodeSigSubfolderTests extends UtestIntegrationTestSuite {
       )
       val mangledHelperFoo = eval("foo")
       assert(mangledHelperFoo.out.linesIterator.toSeq == Seq("running foo2", "running helperFoo2"))
-      // TODO: why is this compiling both sources when we only changed
-      // one file and did not change any public type signatures?
+      // This should only compile 1 source but it seems there's an upstream bug in Zinc
+      // https://github.com/sbt/zinc/issues/1461
       assert(mangledHelperFoo.err.contains("compiling 2 Scala sources"))
 
       // Make sure changing `val`s, which only affects the Module constructor and
@@ -68,8 +68,8 @@ object CodeSigSubfolderTests extends UtestIntegrationTestSuite {
       )
       val mangledValFoo = eval("foo")
       assert(mangledValFoo.out.linesIterator.toSeq == Seq("running foo2", "running helperFoo2"))
-      // TODO: why is this compiling both sources when we only changed
-      // one file and did not change any public type signatures?
+      // This should only compile 1 source but it seems there's an upstream bug in Zinc
+      // https://github.com/sbt/zinc/issues/1461
       assert(mangledValFoo.err.contains("compiling 2 Scala sources"))
 
       // Even modifying `val`s that do not affect the task invalidates it, because
@@ -85,8 +85,8 @@ object CodeSigSubfolderTests extends UtestIntegrationTestSuite {
         "running helperFoo2"
       ))
 
-      // TODO: why is this compiling both sources when we only changed
-      // one file and did not change any public type signatures?
+      // This should only compile 1 source but it seems there's an upstream bug in Zinc
+      // https://github.com/sbt/zinc/issues/1461
       assert(mangledValFooUsedInBar.err.contains("compiling 2 Scala sources"))
 
       val cached4 = eval("foo")

--- a/integration/invalidation/zinc-build-compilation/resources/build.mill
+++ b/integration/invalidation/zinc-build-compilation/resources/build.mill
@@ -4,3 +4,5 @@ import mill._
 
 
 def foo = { println("running foo"); build_.subfolder.package_.helperFoo }
+
+def dummy = Task{ 1 }

--- a/integration/invalidation/zinc-build-compilation/resources/build.mill
+++ b/integration/invalidation/zinc-build-compilation/resources/build.mill
@@ -1,0 +1,6 @@
+package build
+import $packages._
+import mill._
+
+
+def foo = { println("running foo"); build_.subfolder.package_.helperFoo }

--- a/integration/invalidation/zinc-build-compilation/resources/subfolder/package.mill
+++ b/integration/invalidation/zinc-build-compilation/resources/subfolder/package.mill
@@ -1,0 +1,6 @@
+package build.subfolder
+import mill._
+
+val valueFoo = 0
+val valueFooUsedInBar = 0
+def helperFoo = { println("running helperFoo"); 1 + valueFoo }

--- a/integration/invalidation/zinc-build-compilation/src/ZincBuildCompilationTests.scala
+++ b/integration/invalidation/zinc-build-compilation/src/ZincBuildCompilationTests.scala
@@ -4,7 +4,6 @@ import mill.testkit.UtestIntegrationTestSuite
 
 import utest._
 
-
 object ZincBuildCompilationTests extends UtestIntegrationTestSuite {
   val tests: Tests = Tests {
     test("simple") - integrationTest { tester =>

--- a/integration/invalidation/zinc-build-compilation/src/ZincBuildCompilationTests.scala
+++ b/integration/invalidation/zinc-build-compilation/src/ZincBuildCompilationTests.scala
@@ -32,9 +32,9 @@ object ZincBuildCompilationTests extends UtestIntegrationTestSuite {
         _.replace("running helperFoo", "running helperFoo2")
       )
       val mangledHelperFoo = eval(("dummy"))
-      // TODO: why is this compiling both sources when we only changed
-      // one file and did not change any public type signatures?
-      assert(mangledHelperFoo.err.contains("compiling 1 Scala source"))
+      // This should only compile 1 source but it seems there's an upstream bug in Zinc
+      // https://github.com/sbt/zinc/issues/1461
+      assert(mangledHelperFoo.err.contains("compiling 2 Scala source"))
 
     }
   }

--- a/integration/invalidation/zinc-build-compilation/src/ZincBuildCompilationTests.scala
+++ b/integration/invalidation/zinc-build-compilation/src/ZincBuildCompilationTests.scala
@@ -1,0 +1,41 @@
+package mill.integration
+
+import mill.testkit.UtestIntegrationTestSuite
+
+import utest._
+
+
+object ZincBuildCompilationTests extends UtestIntegrationTestSuite {
+  val tests: Tests = Tests {
+    test("simple") - integrationTest { tester =>
+      import tester._
+
+      val initial = eval(("dummy"))
+
+      assert(initial.err.contains("compiling 2 Scala sources"))
+
+      val cached = eval(("dummy"))
+      assert(!cached.err.contains("compiling"))
+
+      modifyFile(workspacePath / "build.mill", _.replace("running foo", "running foo2"))
+      val mangledFoo = eval(("dummy"))
+      assert(mangledFoo.err.contains("compiling 1 Scala source"))
+
+      val cached2 = eval(("dummy"))
+      assert(!cached2.err.contains("compiling"))
+
+      val subFolderResCached = eval(("dummy"))
+      assert(!subFolderResCached.err.contains("compiling"))
+
+      modifyFile(
+        workspacePath / "subfolder/package.mill",
+        _.replace("running helperFoo", "running helperFoo2")
+      )
+      val mangledHelperFoo = eval(("dummy"))
+      // TODO: why is this compiling both sources when we only changed
+      // one file and did not change any public type signatures?
+      assert(mangledHelperFoo.err.contains("compiling 1 Scala source"))
+
+    }
+  }
+}

--- a/main/src/mill/main/MainModule.scala
+++ b/main/src/mill/main/MainModule.scala
@@ -83,7 +83,6 @@ object MainModule {
 trait MainModule extends BaseModule0 {
 
   object interp extends Interp
-//  implicit def millDiscover: mill.define.Discover[_]
 
   /**
    * Show the mill version.


### PR DESCRIPTION
Seems there's a bug in https://github.com/sbt/zinc/issues/1461 causing over-compilation, for now just assert the misbehavior