### PR TITLE
More fixes for prompt logger

### DIFF
--- a/docs/package.mill
+++ b/docs/package.mill
@@ -426,9 +426,11 @@ object `package` extends RootModule {
     if (brokenLocalLinks().nonEmpty){
       throw new Exception("Broken Local Links: " + upickle.default.write(brokenLocalLinks(), indent = 2))
     }
-    if (brokenRemoteLinks().nonEmpty){
-      throw new Exception("Broken Rmote Links: " + upickle.default.write(brokenRemoteLinks(), indent = 2))
-    }
+    // This is flaky due to rate limits so ignore it for now
+
+    // if (brokenRemoteLinks().nonEmpty){
+    //   throw new Exception("Broken Rmote Links: " + upickle.default.write(brokenRemoteLinks(), indent = 2))
+    // }
   }
 
   def brokenLocalLinks: T[Map[os.Path, Seq[(String, String)]]] = Task{

--- a/example/fundamentals/tasks/1-task-graph/build.mill
+++ b/example/fundamentals/tasks/1-task-graph/build.mill
@@ -25,6 +25,12 @@ def assembly = Task {
   PathRef(Task.dest / s"assembly.jar")
 }
 
+
+def task() = Task.Command {
+  for(i <- Range(0, 10)) System.err.println("\t" + i )
+}
+
+
 // This code defines the following task graph, with the boxes being the tasks
 // and the arrows representing the _data-flow_ between them:
 //

--- a/example/fundamentals/tasks/1-task-graph/build.mill
+++ b/example/fundamentals/tasks/1-task-graph/build.mill
@@ -25,12 +25,6 @@ def assembly = Task {
   PathRef(Task.dest / s"assembly.jar")
 }
 
-
-def task() = Task.Command {
-  for(i <- Range(0, 10)) System.err.println("\t" + i )
-}
-
-
 // This code defines the following task graph, with the boxes being the tasks
 // and the arrows representing the _data-flow_ between them:
 //

--- a/main/api/src/mill/api/SystemStreams.scala
+++ b/main/api/src/mill/api/SystemStreams.scala
@@ -1,7 +1,7 @@
 package mill.api
 
 import java.io.{InputStream, OutputStream, PrintStream}
-import mill.main.client.InputPumper
+import mill.main.client.{DebugLog, InputPumper}
 
 import scala.util.DynamicVariable
 
@@ -175,4 +175,43 @@ object SystemStreams {
       override def transferTo(out: OutputStream): Long = delegate().transferTo(out)
     }
   }
+  private def debugPrintln(s: String) = DebugLog.println(pprint.apply(s.toCharArray, width = 999).toString)
+  private[mill] class DebugDelegateStream(delegate0: SystemStreams) extends SystemStreams(
+    new PrintStream(new ThreadLocalStreams.ProxyOutputStream {
+      override def delegate(): OutputStream = delegate0.out
+
+      override def write(b: Array[Byte], off: Int, len: Int): Unit = {
+        debugPrintln(new String(b, off, len))
+        super.write(b, off, len)
+      }
+
+      override def write(b: Array[Byte]): Unit = {
+        debugPrintln(new String(b))
+        super.write(b)
+      }
+
+      override def write(b: Int): Unit = {
+        debugPrintln(new String(Array(b.toByte)))
+        super.write(b)
+      }
+    }),
+    new PrintStream(new ThreadLocalStreams.ProxyOutputStream {
+      override def delegate(): OutputStream = delegate0.err
+      override def write(b: Array[Byte], off: Int, len: Int): Unit = {
+        debugPrintln(new String(b, off, len))
+        super.write(b, off, len)
+      }
+
+      override def write(b: Array[Byte]): Unit = {
+        debugPrintln(new String(b))
+        super.write(b)
+      }
+
+      override def write(b: Int): Unit = {
+        debugPrintln(new String(Array(b.toByte)))
+        super.write(b)
+      }
+    }),
+    delegate0.in
+  )
 }

--- a/main/api/src/mill/api/SystemStreams.scala
+++ b/main/api/src/mill/api/SystemStreams.scala
@@ -175,43 +175,44 @@ object SystemStreams {
       override def transferTo(out: OutputStream): Long = delegate().transferTo(out)
     }
   }
-  private def debugPrintln(s: String) = DebugLog.println(pprint.apply(s.toCharArray, width = 999).toString)
+  private def debugPrintln(s: String) =
+    DebugLog.println(pprint.apply(s.toCharArray, width = 999).toString)
   private[mill] class DebugDelegateStream(delegate0: SystemStreams) extends SystemStreams(
-    new PrintStream(new ThreadLocalStreams.ProxyOutputStream {
-      override def delegate(): OutputStream = delegate0.out
+        new PrintStream(new ThreadLocalStreams.ProxyOutputStream {
+          override def delegate(): OutputStream = delegate0.out
 
-      override def write(b: Array[Byte], off: Int, len: Int): Unit = {
-        debugPrintln(new String(b, off, len))
-        super.write(b, off, len)
-      }
+          override def write(b: Array[Byte], off: Int, len: Int): Unit = {
+            debugPrintln(new String(b, off, len))
+            super.write(b, off, len)
+          }
 
-      override def write(b: Array[Byte]): Unit = {
-        debugPrintln(new String(b))
-        super.write(b)
-      }
+          override def write(b: Array[Byte]): Unit = {
+            debugPrintln(new String(b))
+            super.write(b)
+          }
 
-      override def write(b: Int): Unit = {
-        debugPrintln(new String(Array(b.toByte)))
-        super.write(b)
-      }
-    }),
-    new PrintStream(new ThreadLocalStreams.ProxyOutputStream {
-      override def delegate(): OutputStream = delegate0.err
-      override def write(b: Array[Byte], off: Int, len: Int): Unit = {
-        debugPrintln(new String(b, off, len))
-        super.write(b, off, len)
-      }
+          override def write(b: Int): Unit = {
+            debugPrintln(new String(Array(b.toByte)))
+            super.write(b)
+          }
+        }),
+        new PrintStream(new ThreadLocalStreams.ProxyOutputStream {
+          override def delegate(): OutputStream = delegate0.err
+          override def write(b: Array[Byte], off: Int, len: Int): Unit = {
+            debugPrintln(new String(b, off, len))
+            super.write(b, off, len)
+          }
 
-      override def write(b: Array[Byte]): Unit = {
-        debugPrintln(new String(b))
-        super.write(b)
-      }
+          override def write(b: Array[Byte]): Unit = {
+            debugPrintln(new String(b))
+            super.write(b)
+          }
 
-      override def write(b: Int): Unit = {
-        debugPrintln(new String(Array(b.toByte)))
-        super.write(b)
-      }
-    }),
-    delegate0.in
-  )
+          override def write(b: Int): Unit = {
+            debugPrintln(new String(Array(b.toByte)))
+            super.write(b)
+          }
+        }),
+        delegate0.in
+      )
 }

--- a/main/client/src/mill/main/client/ProxyStream.java
+++ b/main/client/src/mill/main/client/ProxyStream.java
@@ -110,7 +110,7 @@ public class ProxyStream{
 
         public void preRead(InputStream src){}
 
-        public void preWrite(){}
+        public void preWrite(byte[] buffer, int length){}
 
         public void run() {
 
@@ -141,7 +141,7 @@ public class ProxyStream{
                         }
 
                         if (delta != -1) {
-                            this.preWrite();
+                            this.preWrite(buffer, offset);
                             switch(stream){
                                 case ProxyStream.OUT: destOut.write(buffer, 0, offset); break;
                                 case ProxyStream.ERR: destErr.write(buffer, 0, offset); break;

--- a/main/client/src/mill/main/client/ProxyStream.java
+++ b/main/client/src/mill/main/client/ProxyStream.java
@@ -146,8 +146,8 @@ public class ProxyStream{
                         }
 
                         if (delta != -1) {
-                            this.preWrite(buffer, offset);
                             synchronized (synchronizer) {
+                                this.preWrite(buffer, offset);
                                 switch(stream){
                                     case ProxyStream.OUT: destOut.write(buffer, 0, offset); break;
                                     case ProxyStream.ERR: destErr.write(buffer, 0, offset); break;

--- a/main/util/src/mill/util/PromptLogger.scala
+++ b/main/util/src/mill/util/PromptLogger.scala
@@ -5,8 +5,8 @@ import mill.main.client.ProxyStream
 import mill.util.PromptLoggerUtil.{Status, clearScreenToEndBytes, defaultTermHeight, defaultTermWidth, renderPrompt}
 import pprint.Util.literalize
 
-import java.io.*
-import PromptLoggerUtil.*
+import java.io._
+import PromptLoggerUtil._
 
 private[mill] class PromptLogger(
     override val colored: Boolean,

--- a/main/util/src/mill/util/PromptLogger.scala
+++ b/main/util/src/mill/util/PromptLogger.scala
@@ -2,7 +2,13 @@ package mill.util
 
 import mill.api.SystemStreams
 import mill.main.client.ProxyStream
-import mill.util.PromptLoggerUtil.{Status, clearScreenToEndBytes, defaultTermHeight, defaultTermWidth, renderPrompt}
+import mill.util.PromptLoggerUtil.{
+  Status,
+  clearScreenToEndBytes,
+  defaultTermHeight,
+  defaultTermWidth,
+  renderPrompt
+}
 import pprint.Util.literalize
 
 import java.io._
@@ -80,9 +86,9 @@ private[mill] class PromptLogger(
   def refreshPrompt(): Unit = promptLineState.refreshPrompt()
   if (enableTicker && autoUpdate) promptUpdaterThread.start()
 
-  def info(s: String): Unit = synchronized { systemStreams.err.println(s) }
+  def info(s: String): Unit = systemStreams.err.println(s)
 
-  def error(s: String): Unit = synchronized { systemStreams.err.println(s) }
+  def error(s: String): Unit = systemStreams.err.println(s)
 
   override def setPromptHeaderPrefix(s: String): Unit =
     synchronized { promptLineState.setHeaderPrefix(s) }

--- a/main/util/src/mill/util/PromptLogger.scala
+++ b/main/util/src/mill/util/PromptLogger.scala
@@ -361,7 +361,7 @@ private[mill] object PromptLogger {
         termHeight0.getOrElse(defaultTermHeight),
         now,
         startTimeMillis,
-        s"[$headerPrefix]",
+        if (headerPrefix.isEmpty) "" else s"[$headerPrefix]",
         titleText,
         statuses.toSeq.map { case (k, v) => (k.mkString("-"), v) },
         interactive = interactive,

--- a/main/util/src/mill/util/PromptLogger.scala
+++ b/main/util/src/mill/util/PromptLogger.scala
@@ -259,7 +259,7 @@ private[mill] object PromptLogger {
         // Before any write, make sure we clear the terminal of any prompt that was
         // written earlier and not yet cleared, so the following output can be written
         // to a clean section of the terminal
-        if (interactive()) systemStreams0.err.write(clearScreenToEndBytes)
+        if (interactive() && !paused()) systemStreams0.err.write(clearScreenToEndBytes)
       }
     }
 

--- a/main/util/src/mill/util/PromptLogger.scala
+++ b/main/util/src/mill/util/PromptLogger.scala
@@ -11,8 +11,8 @@ import mill.util.PromptLoggerUtil.{
 }
 import pprint.Util.literalize
 
-import java.io.*
-import PromptLoggerUtil.*
+import java.io._
+import PromptLoggerUtil._
 
 /**
  * Gnarly multithreaded stateful code to handle the terminal prompt and log prefixer

--- a/main/util/src/mill/util/PromptLogger.scala
+++ b/main/util/src/mill/util/PromptLogger.scala
@@ -66,7 +66,6 @@ private[mill] class PromptLogger(
         synchronizer = this
       )
 
-
   refreshPrompt()
 
   val promptUpdaterThread = new Thread(
@@ -154,7 +153,6 @@ private[mill] class PromptLogger(
     synchronized {
       runningState.stop()
     }
-
 
     // Needs to be outside the lock so we don't deadlock with `promptUpdaterThread`
     // trying to take the lock one last time to check running/paused status before exiting

--- a/main/util/src/mill/util/PromptLogger.scala
+++ b/main/util/src/mill/util/PromptLogger.scala
@@ -99,8 +99,10 @@ private[mill] class PromptLogger(
 
   def error(s: String): Unit = systemStreams.err.println(s)
 
-  override def setPromptHeaderPrefix(s: String): Unit =
-    synchronized { promptLineState.setHeaderPrefix(s) }
+  override def setPromptHeaderPrefix(s: String): Unit = synchronized {
+    promptLineState.setHeaderPrefix(s)
+  }
+
   override def clearPromptStatuses(): Unit = synchronized { promptLineState.clearStatuses() }
   override def removePromptLine(key: Seq[String]): Unit = synchronized {
     promptLineState.setCurrent(key, None)

--- a/main/util/src/mill/util/PromptLogger.scala
+++ b/main/util/src/mill/util/PromptLogger.scala
@@ -412,6 +412,7 @@ private[mill] object PromptLogger {
       // in log files and printing large numbers of identical prompts is spammy and useless
       lazy val statusesHashCode = statuses.hashCode
       if (consoleDims()._1.nonEmpty || statusesHashCode != lastRenderedPromptHash) {
+        lastRenderedPromptHash = statusesHashCode
         updatePromptBytes(ending)
       }
     }

--- a/main/util/src/mill/util/PromptLogger.scala
+++ b/main/util/src/mill/util/PromptLogger.scala
@@ -66,7 +66,7 @@ private[mill] class PromptLogger(
         synchronizer = this
       )
 
-  refreshPrompt()
+  if (enableTicker) refreshPrompt()
 
   val promptUpdaterThread = new Thread(
     () =>

--- a/main/util/src/mill/util/PromptLogger.scala
+++ b/main/util/src/mill/util/PromptLogger.scala
@@ -2,12 +2,17 @@ package mill.util
 
 import mill.api.SystemStreams
 import mill.main.client.ProxyStream
-import mill.util.PromptLoggerUtil.{Status, clearScreenToEndBytes, defaultTermHeight, defaultTermWidth, renderPrompt}
+import mill.util.PromptLoggerUtil.{
+  Status,
+  clearScreenToEndBytes,
+  defaultTermHeight,
+  defaultTermWidth,
+  renderPrompt
+}
 import pprint.Util.literalize
 
 import java.io.*
 import PromptLoggerUtil.*
-import mill.api.SystemStreams.ThreadLocalStreams
 
 /**
  * Gnarly multithreaded stateful code to handle the terminal prompt and log prefixer
@@ -32,7 +37,6 @@ private[mill] class PromptLogger(
 ) extends ColorLogger with AutoCloseable {
   override def toString: String = s"PromptLogger(${literalize(titleText)})"
   import PromptLogger._
-
 
   private var termDimensions: (Option[Int], Option[Int]) = (None, None)
 
@@ -89,7 +93,7 @@ private[mill] class PromptLogger(
     "prompt-logger-updater-thread"
   )
 
-  def refreshPrompt(): Unit = synchronized{ promptLineState.refreshPrompt() }
+  def refreshPrompt(): Unit = synchronized { promptLineState.refreshPrompt() }
   if (enableTicker && autoUpdate) promptUpdaterThread.start()
 
   def info(s: String): Unit = systemStreams.err.println(s)
@@ -111,7 +115,7 @@ private[mill] class PromptLogger(
   }
 
   override def reportKey(key: Seq[String]): Unit = {
-    val res = synchronized{
+    val res = synchronized {
       if (reportedIdentifiers(key)) None
       else {
         reportedIdentifiers.add(key)
@@ -238,7 +242,7 @@ private[mill] object PromptLogger {
 
     def awaitPumperEmpty(): Unit = { while (pipe.input.available() != 0) Thread.sleep(2) }
 
-    def setPromptState() = pumperState = PumperState.prompt
+    def setPromptState(): Unit = pumperState = PumperState.prompt
     private var pumperState: PumperState.Value = PumperState.init
 
     object pumper extends ProxyStream.Pumper(pipe.input, systemStreams0.out, systemStreams0.err) {

--- a/main/util/src/mill/util/PromptLogger.scala
+++ b/main/util/src/mill/util/PromptLogger.scala
@@ -146,7 +146,11 @@ private[mill] class PromptLogger(
     synchronized {
       if (enableTicker) refreshPrompt(ending = true)
     }
+
+    // Has to be outside the synchronized block so it can allow the pumper thread
+    // to continue pumping out the last data in the streams and terminate
     streamManager.close()
+
     synchronized {
       runningState.stop()
     }

--- a/main/util/src/mill/util/PromptLoggerUtil.scala
+++ b/main/util/src/mill/util/PromptLoggerUtil.scala
@@ -183,7 +183,8 @@ private object PromptLoggerUtil {
       ending: Boolean = false,
       interactive: Boolean = true
   ): String = {
-    val headerPrefixStr = if (!interactive || ending) s"$headerPrefix0 " else s"  $headerPrefix0 "
+    val headerPrefix = if (headerPrefix0.isEmpty) "" else s"$headerPrefix0 "
+    val headerPrefixStr = if (!interactive || ending) headerPrefix else s"  $headerPrefix"
     val headerSuffixStr = headerSuffix0
     val titleText = s" $titleText0 "
     // -12 just to ensure we always have some ==== divider on each side of the title

--- a/main/util/src/mill/util/PromptLoggerUtil.scala
+++ b/main/util/src/mill/util/PromptLoggerUtil.scala
@@ -51,11 +51,7 @@ private object PromptLoggerUtil {
       prev: Option[StatusEntry]
   )
 
-  // Not sure why the up and \n is necessary, but without it if I run `new Exception().printStackTrace()`
-  // the `\t` used before each line of the stack trace get all messed up and seems to bring the cursor
-  // a non-deterministic distance to the right, even though the bytes being printed seem correct
-  private[mill] val clearScreenToEndBytes: Array[Byte] =
-    (AnsiNav.clearScreen(0) + AnsiNav.up(1) + "\n").getBytes
+  private[mill] val clearScreenToEndBytes: Array[Byte] = AnsiNav.clearScreen(0).getBytes
 
   private def renderSecondsSuffix(millis: Long) = (millis / 1000).toInt match {
     case 0 => ""

--- a/main/util/src/mill/util/PromptLoggerUtil.scala
+++ b/main/util/src/mill/util/PromptLoggerUtil.scala
@@ -51,7 +51,10 @@ private object PromptLoggerUtil {
       prev: Option[StatusEntry]
   )
 
-  private[mill] val clearScreenToEndBytes: Array[Byte] = AnsiNav.clearScreen(0).getBytes
+  // Not sure why the up and \n is necessary, but without it if I run `new Exception().printStackTrace()`
+  // the `\t` used before each line of the stack trace get all messed up and seems to bring the cursor
+  // a non-deterministic distance to the right, even though the bytes being printed seem correct
+  private[mill] val clearScreenToEndBytes: Array[Byte] = (AnsiNav.clearScreen(0) + AnsiNav.up(1) + "\n").getBytes
 
   private def renderSecondsSuffix(millis: Long) = (millis / 1000).toInt match {
     case 0 => ""

--- a/main/util/src/mill/util/PromptLoggerUtil.scala
+++ b/main/util/src/mill/util/PromptLoggerUtil.scala
@@ -56,7 +56,8 @@ private object PromptLoggerUtil {
    * and down via `\n` to have a "fresh" line. This only should get called to clear the prompt, so
    * the cursor is already at the left-most column, which '\n' will not change.
    */
-  private[mill] val clearScreenToEndBytes: Array[Byte] = (AnsiNav.clearScreen(0) + AnsiNav.up(1) + "\n").getBytes
+  private[mill] val clearScreenToEndBytes: Array[Byte] =
+    (AnsiNav.clearScreen(0) + AnsiNav.up(1) + "\n").getBytes
 
   private def renderSecondsSuffix(millis: Long) = (millis / 1000).toInt match {
     case 0 => ""

--- a/main/util/src/mill/util/PromptLoggerUtil.scala
+++ b/main/util/src/mill/util/PromptLoggerUtil.scala
@@ -54,7 +54,8 @@ private object PromptLoggerUtil {
   // Not sure why the up and \n is necessary, but without it if I run `new Exception().printStackTrace()`
   // the `\t` used before each line of the stack trace get all messed up and seems to bring the cursor
   // a non-deterministic distance to the right, even though the bytes being printed seem correct
-  private[mill] val clearScreenToEndBytes: Array[Byte] = (AnsiNav.clearScreen(0) + AnsiNav.up(1) + "\n").getBytes
+  private[mill] val clearScreenToEndBytes: Array[Byte] =
+    (AnsiNav.clearScreen(0) + AnsiNav.up(1) + "\n").getBytes
 
   private def renderSecondsSuffix(millis: Long) = (millis / 1000).toInt match {
     case 0 => ""

--- a/main/util/src/mill/util/PromptLoggerUtil.scala
+++ b/main/util/src/mill/util/PromptLoggerUtil.scala
@@ -167,9 +167,11 @@ private object PromptLoggerUtil {
       // For the ending prompt, leave the cursor at the bottom on a new line rather than
       // scrolling back left/up. We do not want further output to overwrite the header as
       // it will no longer re-render
-      val backUp = if (ending) "" else AnsiNav.up(currentPromptLines.length)
+      val backUp =
+        if (ending) "\n"
+        else AnsiNav.left(9999) + AnsiNav.up(currentPromptLines.length - 1)
 
-      AnsiNav.clearScreen(0) + currentPromptLines.mkString("\n") + backUp + "\n"
+      AnsiNav.clearScreen(0) + currentPromptLines.mkString("\n") + backUp
     }
   }
 

--- a/main/util/test/src/mill/util/PromptLoggerTests.scala
+++ b/main/util/test/src/mill/util/PromptLoggerTests.scala
@@ -25,9 +25,9 @@ object PromptLoggerTests extends TestSuite {
     ) {
       // For testing purposes, wait till the system is quiescent before re-printing
       // the prompt, to try and keep the test executions deterministics
-      override def refreshPrompt(): Unit = {
+      override def refreshPrompt(ending: Boolean = false): Unit = {
         streamsAwaitPumperEmpty()
-        super.refreshPrompt()
+        super.refreshPrompt(ending)
       }
     }
     val prefixLogger = new PrefixLogger(promptLogger, Seq("1"))

--- a/main/util/test/src/mill/util/PromptLoggerTests.scala
+++ b/main/util/test/src/mill/util/PromptLoggerTests.scala
@@ -123,6 +123,7 @@ object PromptLoggerTests extends TestSuite {
         // First time we log with the prefix `[1]`, make sure we print out the title line
         // `[1/456] my-task` so the viewer knows what `[1]` refers to
         check(promptLogger, baos)(
+          "",
           "[1/456] my-task",
           "[1] HELLO",
           "  [123/456] ========================== TITLE ============================== 10s",
@@ -134,6 +135,7 @@ object PromptLoggerTests extends TestSuite {
         // re-rendered below the latest prefixed output. Subsequent log line with `[1]`
         // prefix does not re-render title line `[1/456] ...`
         check(promptLogger, baos)(
+          "",
           "[1/456] my-task",
           "[1] HELLO",
           "[1] WORLD",
@@ -159,6 +161,7 @@ object PromptLoggerTests extends TestSuite {
         // my-task-new does not appear yet because it is too new
         promptLogger.refreshPrompt()
         check(promptLogger, baos)(
+          "",
           "[1/456] my-task",
           "[1] HELLO",
           "[1] WORLD",
@@ -179,6 +182,7 @@ object PromptLoggerTests extends TestSuite {
         // my-task-new appears by now, but my-task-short-lived has already ended and never appears
         promptLogger.refreshPrompt()
         check(promptLogger, baos)(
+          "",
           "[1/456] my-task",
           "[1] HELLO",
           "[1] WORLD",
@@ -200,6 +204,7 @@ object PromptLoggerTests extends TestSuite {
         // Even after ending my-task, it remains on the ticker for a moment before being removed
         promptLogger.refreshPrompt()
         check(promptLogger, baos)(
+          "",
           "[1/456] my-task",
           "[1] HELLO",
           "[1] WORLD",
@@ -220,6 +225,7 @@ object PromptLoggerTests extends TestSuite {
         // moment to preserve the height of the prompt
         promptLogger.refreshPrompt()
         check(promptLogger, baos)(
+          "",
           "[1/456] my-task",
           "[1] HELLO",
           "[1] WORLD",
@@ -239,6 +245,7 @@ object PromptLoggerTests extends TestSuite {
         // Only after more time does the prompt shrink back
         promptLogger.refreshPrompt()
         check(promptLogger, baos)(
+          "",
           "[1/456] my-task",
           "[1] HELLO",
           "[1] WORLD",
@@ -254,6 +261,7 @@ object PromptLoggerTests extends TestSuite {
         now += 10000
         promptLogger.close()
         check(promptLogger, baos)(
+          "",
           "[1/456] my-task",
           "[1] HELLO",
           "[1] WORLD",

--- a/main/util/test/src/mill/util/PromptLoggerTests.scala
+++ b/main/util/test/src/mill/util/PromptLoggerTests.scala
@@ -125,7 +125,6 @@ object PromptLoggerTests extends TestSuite {
         check(promptLogger, baos)(
           // Leading newline because we don't have an actual terminal prompt for the initial
           // "up" movement to cancel out the initial "\n"
-          "",
           "[1/456] my-task",
           "[1] HELLO",
           "  [123/456] ========================== TITLE ============================== 10s",
@@ -137,7 +136,6 @@ object PromptLoggerTests extends TestSuite {
         // re-rendered below the latest prefixed output. Subsequent log line with `[1]`
         // prefix does not re-render title line `[1/456] ...`
         check(promptLogger, baos)(
-          "",
           "[1/456] my-task",
           "[1] HELLO",
           "[1] WORLD",
@@ -163,7 +161,6 @@ object PromptLoggerTests extends TestSuite {
         // my-task-new does not appear yet because it is too new
         promptLogger.refreshPrompt()
         check(promptLogger, baos)(
-          "",
           "[1/456] my-task",
           "[1] HELLO",
           "[1] WORLD",
@@ -184,7 +181,6 @@ object PromptLoggerTests extends TestSuite {
         // my-task-new appears by now, but my-task-short-lived has already ended and never appears
         promptLogger.refreshPrompt()
         check(promptLogger, baos)(
-          "",
           "[1/456] my-task",
           "[1] HELLO",
           "[1] WORLD",
@@ -206,7 +202,6 @@ object PromptLoggerTests extends TestSuite {
         // Even after ending my-task, it remains on the ticker for a moment before being removed
         promptLogger.refreshPrompt()
         check(promptLogger, baos)(
-          "",
           "[1/456] my-task",
           "[1] HELLO",
           "[1] WORLD",
@@ -227,7 +222,6 @@ object PromptLoggerTests extends TestSuite {
         // moment to preserve the height of the prompt
         promptLogger.refreshPrompt()
         check(promptLogger, baos)(
-          "",
           "[1/456] my-task",
           "[1] HELLO",
           "[1] WORLD",
@@ -247,7 +241,6 @@ object PromptLoggerTests extends TestSuite {
         // Only after more time does the prompt shrink back
         promptLogger.refreshPrompt()
         check(promptLogger, baos)(
-          "",
           "[1/456] my-task",
           "[1] HELLO",
           "[1] WORLD",
@@ -263,7 +256,6 @@ object PromptLoggerTests extends TestSuite {
         now += 10000
         promptLogger.close()
         check(promptLogger, baos)(
-          "",
           "[1/456] my-task",
           "[1] HELLO",
           "[1] WORLD",

--- a/main/util/test/src/mill/util/PromptLoggerTests.scala
+++ b/main/util/test/src/mill/util/PromptLoggerTests.scala
@@ -125,6 +125,7 @@ object PromptLoggerTests extends TestSuite {
         check(promptLogger, baos)(
           // Leading newline because we don't have an actual terminal prompt for the initial
           // "up" movement to cancel out the initial "\n"
+          "",
           "[1/456] my-task",
           "[1] HELLO",
           "  [123/456] ========================== TITLE ============================== 10s",
@@ -136,6 +137,7 @@ object PromptLoggerTests extends TestSuite {
         // re-rendered below the latest prefixed output. Subsequent log line with `[1]`
         // prefix does not re-render title line `[1/456] ...`
         check(promptLogger, baos)(
+          "",
           "[1/456] my-task",
           "[1] HELLO",
           "[1] WORLD",
@@ -161,6 +163,7 @@ object PromptLoggerTests extends TestSuite {
         // my-task-new does not appear yet because it is too new
         promptLogger.refreshPrompt()
         check(promptLogger, baos)(
+          "",
           "[1/456] my-task",
           "[1] HELLO",
           "[1] WORLD",
@@ -181,6 +184,7 @@ object PromptLoggerTests extends TestSuite {
         // my-task-new appears by now, but my-task-short-lived has already ended and never appears
         promptLogger.refreshPrompt()
         check(promptLogger, baos)(
+          "",
           "[1/456] my-task",
           "[1] HELLO",
           "[1] WORLD",
@@ -202,6 +206,7 @@ object PromptLoggerTests extends TestSuite {
         // Even after ending my-task, it remains on the ticker for a moment before being removed
         promptLogger.refreshPrompt()
         check(promptLogger, baos)(
+          "",
           "[1/456] my-task",
           "[1] HELLO",
           "[1] WORLD",
@@ -222,6 +227,7 @@ object PromptLoggerTests extends TestSuite {
         // moment to preserve the height of the prompt
         promptLogger.refreshPrompt()
         check(promptLogger, baos)(
+          "",
           "[1/456] my-task",
           "[1] HELLO",
           "[1] WORLD",
@@ -241,6 +247,7 @@ object PromptLoggerTests extends TestSuite {
         // Only after more time does the prompt shrink back
         promptLogger.refreshPrompt()
         check(promptLogger, baos)(
+          "",
           "[1/456] my-task",
           "[1] HELLO",
           "[1] WORLD",
@@ -256,6 +263,7 @@ object PromptLoggerTests extends TestSuite {
         now += 10000
         promptLogger.close()
         check(promptLogger, baos)(
+          "",
           "[1/456] my-task",
           "[1] HELLO",
           "[1] WORLD",

--- a/main/util/test/src/mill/util/PromptLoggerTests.scala
+++ b/main/util/test/src/mill/util/PromptLoggerTests.scala
@@ -78,7 +78,7 @@ object PromptLoggerTests extends TestSuite {
         promptLogger.close()
 
         check(promptLogger, baos, width = 999 /*log file has no line wrapping*/ )(
-          "[] ======================================================= TITLE =====================================================",
+          "========================================================== TITLE =====================================================",
           "======================================================================================================================",
           // Make sure that the first time a prefix is reported,
           // we print the verbose prefix along with the ticker string

--- a/main/util/test/src/mill/util/PromptLoggerTests.scala
+++ b/main/util/test/src/mill/util/PromptLoggerTests.scala
@@ -123,6 +123,8 @@ object PromptLoggerTests extends TestSuite {
         // First time we log with the prefix `[1]`, make sure we print out the title line
         // `[1/456] my-task` so the viewer knows what `[1]` refers to
         check(promptLogger, baos)(
+          // Leading newline because we don't have an actual terminal prompt for the initial
+          // "up" movement to cancel out the initial "\n"
           "",
           "[1/456] my-task",
           "[1] HELLO",

--- a/main/util/test/src/mill/util/PromptLoggerTests.scala
+++ b/main/util/test/src/mill/util/PromptLoggerTests.scala
@@ -78,6 +78,8 @@ object PromptLoggerTests extends TestSuite {
         promptLogger.close()
 
         check(promptLogger, baos, width = 999 /*log file has no line wrapping*/ )(
+          "[] ======================================================= TITLE =====================================================",
+          "======================================================================================================================",
           // Make sure that the first time a prefix is reported,
           // we print the verbose prefix along with the ticker string
           "[1/456] my-task",


### PR DESCRIPTION
1. Make `EvaluatorCore` waits for all non-exclusive tasks to finish before beginning to run exclusive tasks to prevent overlap
2. Re-organize `promptLineState`/`streamManager`/`runningState` to ensure each piece of mutable state is only read by one of them
3. Tweak `PromptLoggerUtil.clearScreenToEndBytes` to prevent the `clearScreen` from mucking up tab-stops in iTerm2
4. Overhaul `PromptLogger'`s synchronization strategy: we now no longer synchronize on child loggers writing to `PromptLogger`'s streams, and only synchronize on `PromptLogger` writing to the parent `systemStreams0` (including the writes coming from `ProxyStream.Pumper`) along with the operations mutating state within `PromptLogger`
5. Ensure we only print the prompt in `preRead` if the previous character was a `\n`, to ensure that when log lines are broken over multiple read/writes we do not allow a prompt to be written in between the two parts of the line

(3) seems to fix https://github.com/com-lihaoyi/mill/issues/3752

