### PR TITLE
GenIdea: Handle failure when evaluating module sources/resources (backport #3754)

### DIFF
--- a/idea/src/mill/idea/GenIdeaImpl.scala
+++ b/idea/src/mill/idea/GenIdeaImpl.scala
@@ -499,15 +499,16 @@ case class GenIdeaImpl(
           resourcesPathRefs: Seq[PathRef],
           generatedSourcePathRefs: Seq[PathRef],
           allSourcesPathRefs: Seq[PathRef]
-        ) = evaluator.evaluate(
-          Agg(
-            mod.resources,
-            mod.generatedSources,
-            mod.allSources
-          )
-        )
-          .values
-          .map(_.value)
+        ) = evaluator.evalOrThrow(
+          exceptionFactory = r =>
+            GenIdeaException(
+              s"Could not evaluate sources/resouces of module `${mod}`: ${Evaluator.formatFailing(r)}"
+            )
+        )(Seq(
+          mod.resources,
+          mod.generatedSources,
+          mod.allSources
+        ))
 
         val generatedSourcePaths = generatedSourcePathRefs.map(_.path)
         val normalSourcePaths = (allSourcesPathRefs


### PR DESCRIPTION
We simply don't swallow the error but propagate it.

Fix https://github.com/com-lihaoyi/mill/issues/3168

Backport of pull request: https://github.com/com-lihaoyi/mill/pull/3754
