### PR TITLE
Fix java compile warning, again

### DIFF
--- a/runner/src/mill/runner/CodeGen.scala
+++ b/runner/src/mill/runner/CodeGen.scala
@@ -235,7 +235,7 @@ object CodeGen {
   def discoverSnippet(segments: Seq[String]): String = {
     if (segments.nonEmpty) ""
     else
-      """override lazy val millDiscover: _root_.mill.define.Discover = _root_.mill.define.Discover[this.type]
+      """@scala.annotation.nowarn override lazy val millDiscover: _root_.mill.define.Discover = _root_.mill.define.Discover[this.type]
         |""".stripMargin
 
   }


### PR DESCRIPTION
Follow up to https://github.com/com-lihaoyi/mill/pull/3711

I swear this annotation didn't work last time, and the `match` on the `discoveredModuleType` did. But not the `match` doesn't work, and the annotation seems to work again. I have no idea what's going on 