### PR TITLE
Make runtime deps transitive

### DIFF
--- a/integration/feature/full-run-logs/src/FullRunLogsTests.scala
+++ b/integration/feature/full-run-logs/src/FullRunLogsTests.scala
@@ -27,26 +27,26 @@ object FullRunLogsTests extends UtestIntegrationTestSuite {
 
       val res = eval(("--ticker", "true", "run", "--text", "hello"))
       res.isSuccess ==> true
-      assert(res.out == "[46] <h1>hello</h1>")
+      assert("\\[\\d+\\] <h1>hello</h1>".r.matches(res.out))
 
       val expectedErrorRegex =
         s"""==================================================== run --text hello ================================================
            |======================================================================================================================
-           |[build.mill-56/60] compile
-           |[build.mill-56] [info] compiling 1 Scala source to ${tester.workspacePath}/out/mill-build/compile.dest/classes ...
-           |[build.mill-56] [info] done compiling
-           |[40/46] compile
-           |[40] [info] compiling 1 Java source to ${tester.workspacePath}/out/compile.dest/classes ...
-           |[40] [info] done compiling
-           |[46/46] run
-           |[46/46] ============================================ run --text hello ============================================<seconds-digits>s
+           |[build.mill-<digits>/<digits>] compile
+           |[build.mill-<digits>] [info] compiling 1 Scala source to ${tester.workspacePath}/out/mill-build/compile.dest/classes ...
+           |[build.mill-<digits>] [info] done compiling
+           |[<digits>/<digits>] compile
+           |[<digits>] [info] compiling 1 Java source to ${tester.workspacePath}/out/compile.dest/classes ...
+           |[<digits>] [info] done compiling
+           |[<digits>/<digits>] run
+           |[<digits>/<digits>] ============================================ run --text hello ============================================<digits>s
            |======================================================================================================================"""
           .stripMargin
           .replaceAll("(\r\n)|\r", "\n")
           .replace('\\', '/')
-          .split("<seconds-digits>")
+          .split("<digits>")
           .map(java.util.regex.Pattern.quote)
-          .mkString("=? [\\d]+")
+          .mkString("=? ?[\\d]+")
 
       assert(expectedErrorRegex.r.matches(res.err.replace('\\', '/').replaceAll("(\r\n)|\r", "\n")))
     }

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -190,6 +190,16 @@ trait JavaModule
     moduleDeps
   }
 
+  /**
+   * Same as [[moduleDeps]] but checked to not contain cycles.
+   * Prefer this over using [[moduleDeps]] directly.
+   */
+  final def runModuleDepsChecked: Seq[JavaModule] = {
+    // trigger initialization to check for cycles
+    recRunModuleDeps
+    runModuleDeps
+  }
+
   /** Should only be called from [[moduleDepsChecked]] */
   private lazy val recModuleDeps: Seq[JavaModule] =
     ModuleUtils.recursive[JavaModule](
@@ -198,8 +208,25 @@ trait JavaModule
       _.moduleDeps
     )
 
-  /** The compile-only direct dependencies of this module. */
+  /** Should only be called from [[moduleDepsChecked]] */
+  private lazy val recRunModuleDeps: Seq[JavaModule] =
+    ModuleUtils.recursive[JavaModule](
+      (millModuleSegments ++ Seq(Segment.Label("moduleDeps"))).render,
+      this,
+      m => m.runModuleDeps ++ m.moduleDeps
+    )
+
+  /**
+   *  The compile-only direct dependencies of this module. These are *not*
+   *  transitive, and only take effect in the module that they are declared in.
+   */
   def compileModuleDeps: Seq[JavaModule] = Seq.empty
+
+  /**
+   * The runtime-only direct dependencies of this module. These *are* transitive,
+   * and so get propagated to downstream modules automatically
+   */
+  def runModuleDeps: Seq[JavaModule] = Seq.empty
 
   /** Same as [[compileModuleDeps]] but checked to not contain cycles. */
   final def compileModuleDepsChecked: Seq[JavaModule] = {
@@ -217,16 +244,22 @@ trait JavaModule
     )
 
   /** The direct and indirect dependencies of this module */
-  def recursiveModuleDeps: Seq[JavaModule] = {
-//    moduleDeps.flatMap(_.transitiveModuleDeps).distinct
-    recModuleDeps
-  }
+  def recursiveModuleDeps: Seq[JavaModule] = { recModuleDeps }
+
+  /** The direct and indirect runtime module dependencies of this module */
+  def recursiveRunModuleDeps: Seq[JavaModule] = { recRunModuleDeps }
 
   /**
    * Like `recursiveModuleDeps` but also include the module itself,
    * basically the modules whose classpath are needed at runtime
    */
   def transitiveModuleDeps: Seq[JavaModule] = Seq(this) ++ recursiveModuleDeps
+
+  /**
+   * Like `recursiveModuleDeps` but also include the module itself,
+   * basically the modules whose classpath are needed at runtime
+   */
+  def transitiveRunModuleDeps: Seq[JavaModule] = Seq(this) ++ recursiveRunModuleDeps
 
   /**
    * All direct and indirect module dependencies of this module, including
@@ -238,6 +271,17 @@ trait JavaModule
    */
   def transitiveModuleCompileModuleDeps: Seq[JavaModule] = {
     (moduleDepsChecked ++ compileModuleDepsChecked).flatMap(_.transitiveModuleDeps).distinct
+  }
+
+  /**
+   * All direct and indirect module dependencies of this module, including
+   * compile-only dependencies: basically the modules whose classpath are needed
+   * at runtime.
+   *
+   * Note that `runModuleDeps` are defined to be transitive
+   */
+  def transitiveModuleRunModuleDeps: Seq[JavaModule] = {
+    (runModuleDepsChecked ++ moduleDepsChecked).flatMap(_.transitiveRunModuleDeps).distinct
   }
 
   /** The compile-only transitive ivy dependencies of this module and all it's upstream compile-only modules. */
@@ -288,6 +332,17 @@ trait JavaModule
   }
 
   /**
+   * The transitive run ivy dependencies of this module and all it's upstream modules.
+   * This is calculated from [[runIvyDeps]], [[mandatoryIvyDeps]] and recursively from [[moduleDeps]].
+   */
+  def transitiveRunIvyDeps: T[Agg[BoundDep]] = Task {
+    runIvyDeps().map(bindDependency()) ++
+      T.traverse(moduleDepsChecked)(_.transitiveRunIvyDeps)().flatten ++
+      T.traverse(runModuleDepsChecked)(_.transitiveIvyDeps)().flatten ++
+      T.traverse(runModuleDepsChecked)(_.transitiveRunIvyDeps)().flatten
+  }
+
+  /**
    * The upstream compilation output of all this module's upstream modules
    */
   def upstreamCompileOutput: T[Seq[CompilationResult]] = Task {
@@ -298,7 +353,7 @@ trait JavaModule
    * The transitive version of `localClasspath`
    */
   def transitiveLocalClasspath: T[Agg[PathRef]] = Task {
-    T.traverse(transitiveModuleCompileModuleDeps)(_.localClasspath)().flatten
+    T.traverse(transitiveModuleRunModuleDeps)(_.localClasspath)().flatten
   }
 
   /**
@@ -493,7 +548,7 @@ trait JavaModule
    * excluding upstream modules and third-party dependencies, but including unmanaged dependencies.
    *
    * This is build from [[localCompileClasspath]] and [[localRunClasspath]]
-   * as the parts available "before compilation" and "after compiliation".
+   * as the parts available "before compilation" and "after compilation".
    *
    * Keep in sync with [[bspLocalClasspath]]
    */
@@ -563,7 +618,7 @@ trait JavaModule
 
   def resolvedRunIvyDeps: T[Agg[PathRef]] = Task {
     defaultResolver().resolveDeps(
-      runIvyDeps().map(bindDependency()) ++ transitiveIvyDeps(),
+      transitiveRunIvyDeps() ++ transitiveIvyDeps(),
       artifactTypes = Some(artifactTypes())
     )
   }
@@ -877,7 +932,7 @@ trait JavaModule
             printDepsTree(
               args.inverse.value,
               Task.Anon {
-                transitiveCompileIvyDeps() ++ runIvyDeps().map(bindDependency())
+                transitiveCompileIvyDeps() ++ transitiveRunIvyDeps()
               },
               validModules
             )()
@@ -890,7 +945,7 @@ trait JavaModule
           Task.Command {
             printDepsTree(
               args.inverse.value,
-              Task.Anon { runIvyDeps().map(bindDependency()) },
+              Task.Anon { transitiveRunIvyDeps() },
               validModules
             )()
           }
@@ -1046,7 +1101,7 @@ trait JavaModule
         },
         Task.Anon {
           defaultResolver().resolveDeps(
-            runIvyDeps().map(bindDependency()) ++ transitiveIvyDeps(),
+            transitiveRunIvyDeps() ++ transitiveIvyDeps(),
             sources = true
           )
         }

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -253,13 +253,13 @@ trait JavaModule
    * Like `recursiveModuleDeps` but also include the module itself,
    * basically the modules whose classpath are needed at runtime
    */
-  def transitiveModuleDeps: Seq[JavaModule] = Seq(this) ++ recursiveModuleDeps
+  def transitiveModuleDeps: Seq[JavaModule] = recursiveModuleDeps ++ Seq(this)
 
   /**
    * Like `recursiveModuleDeps` but also include the module itself,
    * basically the modules whose classpath are needed at runtime
    */
-  def transitiveRunModuleDeps: Seq[JavaModule] = Seq(this) ++ recursiveRunModuleDeps
+  def transitiveRunModuleDeps: Seq[JavaModule] = recursiveRunModuleDeps ++ Seq(this)
 
   /**
    * All direct and indirect module dependencies of this module, including

--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -481,7 +481,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
         )
       }
       val bind = bindDependency()
-      runIvyDeps().map(bind) ++ transitiveIvyDeps() ++
+      transitiveRunIvyDeps() ++ transitiveIvyDeps() ++
         Agg(ivy"com.lihaoyi:::ammonite:${ammVersion}").map(bind)
     }
   }

--- a/scalalib/test/src/mill/scalalib/ScalaIvyDepsTests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaIvyDepsTests.scala
@@ -17,6 +17,30 @@ object ScalaIvyDepsTests extends TestSuite {
     }
   }
 
+  object TransitiveRunIvyDeps extends TestBaseModule {
+    object upstream extends JavaModule {
+      def ivyDeps = Agg(ivy"org.slf4j:slf4j-api:2.0.16")
+      def runIvyDeps = Agg(ivy"ch.qos.logback:logback-classic:1.5.10")
+    }
+
+    object downstream extends JavaModule {
+      // Make sure runIvyDeps are transitively picked up from normal `moduleDeps`
+      def moduleDeps = Seq(upstream)
+    }
+  }
+
+  object TransitiveRunIvyDeps2 extends TestBaseModule {
+    object upstream extends JavaModule {
+      def ivyDeps = Agg(ivy"org.slf4j:slf4j-api:2.0.16")
+      def runIvyDeps = Agg(ivy"ch.qos.logback:logback-classic:1.5.10")
+    }
+
+    object downstream extends JavaModule {
+      // Make sure both ivyDeps and runIvyDeps are transitively picked up from `runModuleDeps`
+      def runModuleDeps = Seq(upstream)
+    }
+  }
+
   def tests: Tests = Tests {
 
     test("ivyDeps") - UnitTester(HelloWorldIvyDeps, resourcePath).scoped { eval =>
@@ -31,6 +55,24 @@ object ScalaIvyDepsTests extends TestSuite {
         result2.value.exists(_.path.last == "sourcecode_2.12-0.1.4.jar"),
         !result2.value.exists(_.path.last == "sourcecode_2.12-0.1.3.jar")
       )
+    }
+
+    test("transitiveRun") - UnitTester(TransitiveRunIvyDeps, resourcePath).scoped { eval =>
+      val Right(result2) = eval.apply(TransitiveRunIvyDeps.downstream.runClasspath)
+
+      assert(
+        result2.value.exists(_.path.last == "logback-classic-1.5.10.jar")
+      )
+    }
+
+    test("transitiveLocalRuntimeDepsRun") - UnitTester(TransitiveRunIvyDeps2, resourcePath).scoped {
+      eval =>
+        val Right(result2) = eval.apply(TransitiveRunIvyDeps2.downstream.runClasspath)
+
+        assert(
+          result2.value.exists(_.path.last == "logback-classic-1.5.10.jar"),
+          result2.value.exists(_.path.last == "slf4j-api-2.0.16.jar")
+        )
     }
 
   }

--- a/scalalib/test/src/mill/scalalib/ScalaMultiModuleClasspathsTests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaMultiModuleClasspathsTests.scala
@@ -59,232 +59,291 @@ object ScalaMultiModuleClasspathsTests extends TestSuite {
         def moduleDeps = Seq(bar)
       }
     }
+    object RuntimeMod extends Module {
+      object foo extends FooModule
+      object bar extends BarModule {
+        def runModuleDeps = Seq(foo)
+      }
+      object qux extends QuxModule {
+        def moduleDeps = Seq(bar)
+      }
+    }
+
   }
 
   def tests: Tests = Tests {
 
-    test("multiModuleClasspaths") {
-      // Make sure that a bunch of modules dependent on each other has their various
-      // {classpaths,moduleDeps,ivyDeps}x{run,compile,normal} properly aggregated
-      def check(
-          eval: UnitTester,
-          mod: ScalaModule,
-          expectedRunClasspath: Seq[String],
-          expectedCompileClasspath: Seq[String],
-          expectedLocalClasspath: Seq[String]
-      ) = {
-        val Right(runClasspathRes) = eval.apply(mod.runClasspath)
-        val Right(compileClasspathRes) = eval.apply(mod.compileClasspath)
-        val Right(upstreamAssemblyClasspathRes) = eval.apply(mod.upstreamAssemblyClasspath)
-        val Right(localClasspathRes) = eval.apply(mod.localClasspath)
+    // Make sure that a bunch of modules dependent on each other has their various
+    // {classpaths,moduleDeps,ivyDeps}x{run,compile,normal} properly aggregated
+    def check(
+        eval: UnitTester,
+        mod: ScalaModule,
+        expectedRunClasspath: Seq[String],
+        expectedCompileClasspath: Seq[String],
+        expectedLocalClasspath: Seq[String]
+    ) = {
+      val Right(runClasspathRes) = eval.apply(mod.runClasspath)
+      val Right(compileClasspathRes) = eval.apply(mod.compileClasspath)
+      val Right(upstreamAssemblyClasspathRes) = eval.apply(mod.upstreamAssemblyClasspath)
+      val Right(localClasspathRes) = eval.apply(mod.localClasspath)
 
-        val start = eval.evaluator.rootModule.millSourcePath
-        val startToken = Set("org", "com")
-        def simplify(cp: Seq[PathRef]) = {
-          cp.map(_.path).map { p =>
-            if (p.startsWith(start)) p.relativeTo(start).toString()
-            else p.segments.dropWhile(!startToken.contains(_)).mkString("/")
-          }
+      val start = eval.evaluator.rootModule.millSourcePath
+      val startToken = Set("org", "com")
+      def simplify(cp: Seq[PathRef]) = {
+        cp.map(_.path).map { p =>
+          if (p.startsWith(start)) p.relativeTo(start).toString()
+          else p.segments.dropWhile(!startToken.contains(_)).mkString("/")
         }
-
-        val simplerRunClasspath = simplify(runClasspathRes.value)
-        val simplerCompileClasspath = simplify(compileClasspathRes.value.toSeq)
-        val simplerLocalClasspath = simplify(localClasspathRes.value)
-
-        assert(expectedRunClasspath == simplerRunClasspath)
-        assert(expectedCompileClasspath == simplerCompileClasspath)
-        assert(expectedLocalClasspath == simplerLocalClasspath)
-        // invariant: the `upstreamAssemblyClasspath` used to make the `upstreamAssembly`
-        // and the `localClasspath` used to complete it to make the final `assembly` must
-        // have the same entries as the `runClasspath` used to execute things
-        assert(
-          runClasspathRes.value == upstreamAssemblyClasspathRes.value.toSeq ++ localClasspathRes.value
-        )
       }
 
-      test("modMod") - UnitTester(MultiModuleClasspaths, resourcePath).scoped { eval =>
-        // Make sure that `compileClasspath` has all the same things as `runClasspath`,
-        // but without the `/resources`
-        check(
-          eval,
-          MultiModuleClasspaths.ModMod.qux,
-          expectedRunClasspath = List(
-            // We pick up the oldest version of utest 0.7.0 from the current module, because
-            // utest is a `runIvyDeps` and not picked up transitively
-            "com/lihaoyi/utest_2.13/0.8.4/utest_2.13-0.8.4.jar",
-            // We pick up the newest version of sourcecode 0.2.4 from the upstream module, because
-            // sourcecode is a `ivyDeps` and `runIvyDeps` and those are picked up transitively
-            "com/lihaoyi/sourcecode_2.13/0.2.2/sourcecode_2.13-0.2.2.jar",
-            //
-            "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
-            "org/scala-sbt/test-interface/1.0/test-interface-1.0.jar",
-            "org/portable-scala/portable-scala-reflect_2.13/1.1.3/portable-scala-reflect_2.13-1.1.3.jar",
-            "org/scala-lang/scala-reflect/2.13.12/scala-reflect-2.13.12.jar",
-            //
-            "ModMod/bar/compile-resources",
-            "ModMod/bar/unmanaged",
-            "ModMod/bar/resources",
-            "out/ModMod/bar/compile.dest/classes",
-            //
-            "ModMod/foo/compile-resources",
-            "ModMod/foo/unmanaged",
-            "ModMod/foo/resources",
-            "out/ModMod/foo/compile.dest/classes",
-            //
-            "ModMod/qux/compile-resources",
-            "ModMod/qux/unmanaged",
-            "ModMod/qux/resources",
-            "out/ModMod/qux/compile.dest/classes"
-          ),
-          expectedCompileClasspath = List(
-            // Make sure we only have geny 0.6.4 from the current module, and not newer
-            // versions pulled in by the upstream modules, because as `compileIvyDeps` it
-            // is not picked up transitively
-            "com/lihaoyi/geny_2.13/0.4.0/geny_2.13-0.4.0.jar",
-            "com/lihaoyi/sourcecode_2.13/0.2.2/sourcecode_2.13-0.2.2.jar",
-            //
-            "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
-            //
-            "ModMod/bar/compile-resources",
-            "ModMod/bar/unmanaged",
-            "out/ModMod/bar/compile.dest/classes",
-            //
-            "ModMod/foo/compile-resources",
-            "ModMod/foo/unmanaged",
-            "out/ModMod/foo/compile.dest/classes",
-            //
-            "ModMod/qux/compile-resources",
-            "ModMod/qux/unmanaged"
-            // We do not include `qux/compile.dest/classes` here, because this is the input
-            // that is required to compile `qux` in the first place
-          ),
-          expectedLocalClasspath = List(
-            "ModMod/qux/compile-resources",
-            "ModMod/qux/unmanaged",
-            "ModMod/qux/resources",
-            "out/ModMod/qux/compile.dest/classes"
-          )
-        )
-      }
+      val simplerRunClasspath = simplify(runClasspathRes.value)
+      val simplerCompileClasspath = simplify(compileClasspathRes.value.toSeq)
+      val simplerLocalClasspath = simplify(localClasspathRes.value)
 
-      test("modCompile") - UnitTester(MultiModuleClasspaths, resourcePath).scoped { eval =>
-        // Mostly the same as `modMod` above, but with the dependency
-        // from `qux` to `bar` being a `compileModuleDeps`
-        check(
-          eval,
-          MultiModuleClasspaths.ModCompile.qux,
-          expectedRunClasspath = List(
-            // `utest` is a `runIvyDeps` and not picked up transitively
-            "com/lihaoyi/utest_2.13/0.8.4/utest_2.13-0.8.4.jar",
-            // Because `sourcecode` comes from `ivyDeps`, and the dependency from
-            // `qux` to `bar` is a `compileModuleDeps`, we do not include its
-            // dependencies for `qux`'s `runClasspath`
-            "com/lihaoyi/sourcecode_2.13/0.2.0/sourcecode_2.13-0.2.0.jar",
-            //
-            "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
-            "org/scala-sbt/test-interface/1.0/test-interface-1.0.jar",
-            "org/portable-scala/portable-scala-reflect_2.13/1.1.3/portable-scala-reflect_2.13-1.1.3.jar",
-            "org/scala-lang/scala-reflect/2.13.12/scala-reflect-2.13.12.jar",
-            //
-            "ModCompile/bar/compile-resources",
-            "ModCompile/bar/unmanaged",
-            "ModCompile/bar/resources",
-            "out/ModCompile/bar/compile.dest/classes",
-            //
-            "ModCompile/foo/compile-resources",
-            "ModCompile/foo/unmanaged",
-            "ModCompile/foo/resources",
-            "out/ModCompile/foo/compile.dest/classes",
-            //
-            "ModCompile/qux/compile-resources",
-            "ModCompile/qux/unmanaged",
-            "ModCompile/qux/resources",
-            "out/ModCompile/qux/compile.dest/classes"
-          ),
-          expectedCompileClasspath = List(
-            "com/lihaoyi/geny_2.13/0.4.0/geny_2.13-0.4.0.jar",
-            // `sourcecode` is a `ivyDeps` from a `compileModuleDeps, which still
-            // gets picked up transitively, but only for compilation. This is necessary
-            // in order to make sure that we can correctly compile against the upstream
-            // module's classes.
-            "com/lihaoyi/sourcecode_2.13/0.2.2/sourcecode_2.13-0.2.2.jar",
-            //
-            "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
-            //
-            "ModCompile/bar/compile-resources",
-            "ModCompile/bar/unmanaged",
-            "out/ModCompile/bar/compile.dest/classes",
-            //
-            "ModCompile/foo/compile-resources",
-            "ModCompile/foo/unmanaged",
-            "out/ModCompile/foo/compile.dest/classes",
-            //
-            "ModCompile/qux/compile-resources",
-            "ModCompile/qux/unmanaged"
-          ),
-          expectedLocalClasspath = List(
-            "ModCompile/qux/compile-resources",
-            "ModCompile/qux/unmanaged",
-            "ModCompile/qux/resources",
-            "out/ModCompile/qux/compile.dest/classes"
-          )
-        )
-      }
+      // pprint.log(simplerRunClasspath)
+      assert(expectedRunClasspath == simplerRunClasspath)
+      // pprint.log(simplerCompileClasspath)
+      assert(expectedCompileClasspath == simplerCompileClasspath)
+      // pprint.log(simplerLocalClasspath)
+      assert(expectedLocalClasspath == simplerLocalClasspath)
+      // invariant: the `upstreamAssemblyClasspath` used to make the `upstreamAssembly`
+      // and the `localClasspath` used to complete it to make the final `assembly` must
+      // have the same entries as the `runClasspath` used to execute things
+      assert(
+        runClasspathRes.value == upstreamAssemblyClasspathRes.value.toSeq ++ localClasspathRes.value
+      )
+    }
 
-      test("compileMod") - UnitTester(MultiModuleClasspaths, resourcePath).scoped { eval =>
-        // Both the `runClasspath` and `compileClasspath` should not have `foo` on the
-        // classpath, nor should it have the versions of libraries pulled in by `foo`
-        // (e.g. `sourcecode-0.2.4`), because it is a `compileModuleDep` of an upstream
-        // module and thus it is not transitive
-        check(
-          eval,
-          MultiModuleClasspaths.CompileMod.qux,
-          expectedRunClasspath = List(
-            "com/lihaoyi/utest_2.13/0.8.4/utest_2.13-0.8.4.jar",
-            // We pick up the version of `sourcecode` from `ivyDeps` from `bar` because
-            // we have a normal `moduleDeps` from `qux` to `bar`, but do not pick it up
-            // from `foo` because it's a `compileIvyDeps` from `bar` to `foo` and
-            // `compileIvyDeps` are not transitive
-            "com/lihaoyi/sourcecode_2.13/0.2.1/sourcecode_2.13-0.2.1.jar",
-            //
-            "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
-            "org/scala-sbt/test-interface/1.0/test-interface-1.0.jar",
-            "org/portable-scala/portable-scala-reflect_2.13/1.1.3/portable-scala-reflect_2.13-1.1.3.jar",
-            "org/scala-lang/scala-reflect/2.13.12/scala-reflect-2.13.12.jar",
-            //
-            "CompileMod/bar/compile-resources",
-            "CompileMod/bar/unmanaged",
-            "CompileMod/bar/resources",
-            "out/CompileMod/bar/compile.dest/classes",
-            //
-            "CompileMod/qux/compile-resources",
-            "CompileMod/qux/unmanaged",
-            "CompileMod/qux/resources",
-            "out/CompileMod/qux/compile.dest/classes"
-          ),
-          expectedCompileClasspath = List(
-            "com/lihaoyi/geny_2.13/0.4.0/geny_2.13-0.4.0.jar",
-            "com/lihaoyi/sourcecode_2.13/0.2.1/sourcecode_2.13-0.2.1.jar",
-            //
-            "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
-            // We do not include `foo`s compile output here, because `foo` is a
-            // `compileModuleDep` of `bar`, and `compileModuleDep`s are non-transitive
-            //
-            "CompileMod/bar/compile-resources",
-            "CompileMod/bar/unmanaged",
-            "out/CompileMod/bar/compile.dest/classes",
-            //
-            "CompileMod/qux/compile-resources",
-            "CompileMod/qux/unmanaged"
-          ),
-          expectedLocalClasspath = List(
-            "CompileMod/qux/compile-resources",
-            "CompileMod/qux/unmanaged",
-            "CompileMod/qux/resources",
-            "out/CompileMod/qux/compile.dest/classes"
-          )
+    test("modMod") - UnitTester(MultiModuleClasspaths, resourcePath).scoped { eval =>
+      // Make sure that `compileClasspath` has all the same things as `runClasspath`,
+      // but without the `/resources`
+      check(
+        eval,
+        MultiModuleClasspaths.ModMod.qux,
+        expectedRunClasspath = List(
+          // We pick up the oldest version of utest 0.7.0 from the current module, because
+          // utest is a `runIvyDeps` and not picked up transitively
+          "com/lihaoyi/utest_2.13/0.8.4/utest_2.13-0.8.4.jar",
+          // We pick up the newest version of sourcecode 0.2.4 from the upstream module, because
+          // sourcecode is a `ivyDeps` and `runIvyDeps` and those are picked up transitively
+          "com/lihaoyi/sourcecode_2.13/0.2.2/sourcecode_2.13-0.2.2.jar",
+          //
+          "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
+          "org/scala-sbt/test-interface/1.0/test-interface-1.0.jar",
+          "org/portable-scala/portable-scala-reflect_2.13/1.1.3/portable-scala-reflect_2.13-1.1.3.jar",
+          "org/scala-lang/scala-reflect/2.13.12/scala-reflect-2.13.12.jar",
+          //
+          "ModMod/bar/compile-resources",
+          "ModMod/bar/unmanaged",
+          "ModMod/bar/resources",
+          "out/ModMod/bar/compile.dest/classes",
+          //
+          "ModMod/foo/compile-resources",
+          "ModMod/foo/unmanaged",
+          "ModMod/foo/resources",
+          "out/ModMod/foo/compile.dest/classes",
+          //
+          "ModMod/qux/compile-resources",
+          "ModMod/qux/unmanaged",
+          "ModMod/qux/resources",
+          "out/ModMod/qux/compile.dest/classes"
+        ),
+        expectedCompileClasspath = List(
+          // Make sure we only have geny 0.6.4 from the current module, and not newer
+          // versions pulled in by the upstream modules, because as `compileIvyDeps` it
+          // is not picked up transitively
+          "com/lihaoyi/geny_2.13/0.4.0/geny_2.13-0.4.0.jar",
+          "com/lihaoyi/sourcecode_2.13/0.2.2/sourcecode_2.13-0.2.2.jar",
+          //
+          "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
+          //
+          "ModMod/bar/compile-resources",
+          "ModMod/bar/unmanaged",
+          "out/ModMod/bar/compile.dest/classes",
+          //
+          "ModMod/foo/compile-resources",
+          "ModMod/foo/unmanaged",
+          "out/ModMod/foo/compile.dest/classes",
+          //
+          "ModMod/qux/compile-resources",
+          "ModMod/qux/unmanaged"
+          // We do not include `qux/compile.dest/classes` here, because this is the input
+          // that is required to compile `qux` in the first place
+        ),
+        expectedLocalClasspath = List(
+          "ModMod/qux/compile-resources",
+          "ModMod/qux/unmanaged",
+          "ModMod/qux/resources",
+          "out/ModMod/qux/compile.dest/classes"
         )
-      }
+      )
+    }
+
+    test("modCompile") - UnitTester(MultiModuleClasspaths, resourcePath).scoped { eval =>
+      // Mostly the same as `modMod` above, but with the dependency
+      // from `qux` to `bar` being a `compileModuleDeps`
+      check(
+        eval,
+        MultiModuleClasspaths.ModCompile.qux,
+        expectedRunClasspath = List(
+          // `utest` is a `runIvyDeps` and not picked up transitively
+          "com/lihaoyi/utest_2.13/0.8.4/utest_2.13-0.8.4.jar",
+          // Because `sourcecode` comes from `ivyDeps`, and the dependency from
+          // `qux` to `bar` is a `compileModuleDeps`, we do not include its
+          // dependencies for `qux`'s `runClasspath`
+          "com/lihaoyi/sourcecode_2.13/0.2.0/sourcecode_2.13-0.2.0.jar",
+          //
+          "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
+          "org/scala-sbt/test-interface/1.0/test-interface-1.0.jar",
+          "org/portable-scala/portable-scala-reflect_2.13/1.1.3/portable-scala-reflect_2.13-1.1.3.jar",
+          "org/scala-lang/scala-reflect/2.13.12/scala-reflect-2.13.12.jar",
+          //
+          "ModCompile/bar/compile-resources",
+          "ModCompile/bar/unmanaged",
+          "ModCompile/bar/resources",
+          "out/ModCompile/bar/compile.dest/classes",
+          //
+          "ModCompile/foo/compile-resources",
+          "ModCompile/foo/unmanaged",
+          "ModCompile/foo/resources",
+          "out/ModCompile/foo/compile.dest/classes",
+          //
+          "ModCompile/qux/compile-resources",
+          "ModCompile/qux/unmanaged",
+          "ModCompile/qux/resources",
+          "out/ModCompile/qux/compile.dest/classes"
+        ),
+        expectedCompileClasspath = List(
+          "com/lihaoyi/geny_2.13/0.4.0/geny_2.13-0.4.0.jar",
+          // `sourcecode` is a `ivyDeps` from a `compileModuleDeps, which still
+          // gets picked up transitively, but only for compilation. This is necessary
+          // in order to make sure that we can correctly compile against the upstream
+          // module's classes.
+          "com/lihaoyi/sourcecode_2.13/0.2.2/sourcecode_2.13-0.2.2.jar",
+          //
+          "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
+          //
+          "ModCompile/bar/compile-resources",
+          "ModCompile/bar/unmanaged",
+          "out/ModCompile/bar/compile.dest/classes",
+          //
+          "ModCompile/foo/compile-resources",
+          "ModCompile/foo/unmanaged",
+          "out/ModCompile/foo/compile.dest/classes",
+          //
+          "ModCompile/qux/compile-resources",
+          "ModCompile/qux/unmanaged"
+        ),
+        expectedLocalClasspath = List(
+          "ModCompile/qux/compile-resources",
+          "ModCompile/qux/unmanaged",
+          "ModCompile/qux/resources",
+          "out/ModCompile/qux/compile.dest/classes"
+        )
+      )
+    }
+
+    test("compileMod") - UnitTester(MultiModuleClasspaths, resourcePath).scoped { eval =>
+      // Both the `runClasspath` and `compileClasspath` should not have `foo` on the
+      // classpath, nor should it have the versions of libraries pulled in by `foo`
+      // (e.g. `sourcecode-0.2.4`), because it is a `compileModuleDep` of an upstream
+      // module and thus it is not transitive
+      check(
+        eval,
+        MultiModuleClasspaths.CompileMod.qux,
+        expectedRunClasspath = List(
+          "com/lihaoyi/utest_2.13/0.8.4/utest_2.13-0.8.4.jar",
+          // We pick up the version of `sourcecode` from `ivyDeps` from `bar` because
+          // we have a normal `moduleDeps` from `qux` to `bar`, but do not pick it up
+          // from `foo` because it's a `compileIvyDeps` from `bar` to `foo` and
+          // `compileIvyDeps` are not transitive
+          "com/lihaoyi/sourcecode_2.13/0.2.1/sourcecode_2.13-0.2.1.jar",
+          //
+          "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
+          "org/scala-sbt/test-interface/1.0/test-interface-1.0.jar",
+          "org/portable-scala/portable-scala-reflect_2.13/1.1.3/portable-scala-reflect_2.13-1.1.3.jar",
+          "org/scala-lang/scala-reflect/2.13.12/scala-reflect-2.13.12.jar",
+          //
+          "CompileMod/bar/compile-resources",
+          "CompileMod/bar/unmanaged",
+          "CompileMod/bar/resources",
+          "out/CompileMod/bar/compile.dest/classes",
+          //
+          "CompileMod/qux/compile-resources",
+          "CompileMod/qux/unmanaged",
+          "CompileMod/qux/resources",
+          "out/CompileMod/qux/compile.dest/classes"
+        ),
+        expectedCompileClasspath = List(
+          "com/lihaoyi/geny_2.13/0.4.0/geny_2.13-0.4.0.jar",
+          "com/lihaoyi/sourcecode_2.13/0.2.1/sourcecode_2.13-0.2.1.jar",
+          //
+          "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
+          // We do not include `foo`s compile output here, because `foo` is a
+          // `compileModuleDep` of `bar`, and `compileModuleDep`s are non-transitive
+          //
+          "CompileMod/bar/compile-resources",
+          "CompileMod/bar/unmanaged",
+          "out/CompileMod/bar/compile.dest/classes",
+          //
+          "CompileMod/qux/compile-resources",
+          "CompileMod/qux/unmanaged"
+        ),
+        expectedLocalClasspath = List(
+          "CompileMod/qux/compile-resources",
+          "CompileMod/qux/unmanaged",
+          "CompileMod/qux/resources",
+          "out/CompileMod/qux/compile.dest/classes"
+        )
+      )
+    }
+    test("runMod") - UnitTester(MultiModuleClasspaths, resourcePath).scoped { eval =>
+      // Both the `runClasspath` and `compileClasspath` should not have `foo` on the
+      // classpath, nor should it have the versions of libraries pulled in by `foo`
+      // (e.g. `sourcecode-0.2.4`), because it is a `compileModuleDep` of an upstream
+      // module and thus it is not transitive
+      check(
+        eval,
+        MultiModuleClasspaths.RuntimeMod.qux,
+        expectedRunClasspath = List(
+          "com/lihaoyi/utest_2.13/0.8.4/utest_2.13-0.8.4.jar",
+          "com/lihaoyi/sourcecode_2.13/0.2.2/sourcecode_2.13-0.2.2.jar",
+          "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
+          "org/scala-sbt/test-interface/1.0/test-interface-1.0.jar",
+          "org/portable-scala/portable-scala-reflect_2.13/1.1.3/portable-scala-reflect_2.13-1.1.3.jar",
+          "org/scala-lang/scala-reflect/2.13.12/scala-reflect-2.13.12.jar",
+          "RuntimeMod/bar/compile-resources",
+          "RuntimeMod/bar/unmanaged",
+          "RuntimeMod/bar/resources",
+          "out/RuntimeMod/bar/compile.dest/classes",
+          "RuntimeMod/foo/compile-resources",
+          "RuntimeMod/foo/unmanaged",
+          "RuntimeMod/foo/resources",
+          "out/RuntimeMod/foo/compile.dest/classes",
+          "RuntimeMod/qux/compile-resources",
+          "RuntimeMod/qux/unmanaged",
+          "RuntimeMod/qux/resources",
+          "out/RuntimeMod/qux/compile.dest/classes"
+        ),
+        expectedCompileClasspath = List(
+          "com/lihaoyi/geny_2.13/0.4.0/geny_2.13-0.4.0.jar",
+          "com/lihaoyi/sourcecode_2.13/0.2.1/sourcecode_2.13-0.2.1.jar",
+          "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
+          // `bar` ends up here because it's a normal `moduleDep`, but not `foo` because
+          // it's a `runtimeModuleDep
+          "RuntimeMod/bar/compile-resources",
+          "RuntimeMod/bar/unmanaged",
+          "out/RuntimeMod/bar/compile.dest/classes",
+          "RuntimeMod/qux/compile-resources",
+          "RuntimeMod/qux/unmanaged"
+        ),
+        expectedLocalClasspath = List(
+          "RuntimeMod/qux/compile-resources",
+          "RuntimeMod/qux/unmanaged",
+          "RuntimeMod/qux/resources",
+          "out/RuntimeMod/qux/compile.dest/classes"
+        )
+      )
     }
   }
 }

--- a/scalalib/test/src/mill/scalalib/ScalaMultiModuleClasspathsTests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaMultiModuleClasspathsTests.scala
@@ -198,16 +198,6 @@ object ScalaMultiModuleClasspathsTests extends TestSuite {
           "org/portable-scala/portable-scala-reflect_2.13/1.1.3/portable-scala-reflect_2.13-1.1.3.jar",
           "org/scala-lang/scala-reflect/2.13.12/scala-reflect-2.13.12.jar",
           //
-          "ModCompile/bar/compile-resources",
-          "ModCompile/bar/unmanaged",
-          "ModCompile/bar/resources",
-          "out/ModCompile/bar/compile.dest/classes",
-          //
-          "ModCompile/foo/compile-resources",
-          "ModCompile/foo/unmanaged",
-          "ModCompile/foo/resources",
-          "out/ModCompile/foo/compile.dest/classes",
-          //
           "ModCompile/qux/compile-resources",
           "ModCompile/qux/unmanaged",
           "ModCompile/qux/resources",

--- a/scalalib/test/src/mill/scalalib/ScalaMultiModuleClasspathsTests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaMultiModuleClasspathsTests.scala
@@ -143,15 +143,15 @@ object ScalaMultiModuleClasspathsTests extends TestSuite {
           "org/portable-scala/portable-scala-reflect_2.13/1.1.3/portable-scala-reflect_2.13-1.1.3.jar",
           "org/scala-lang/scala-reflect/2.13.12/scala-reflect-2.13.12.jar",
           //
-          "ModMod/bar/compile-resources",
-          "ModMod/bar/unmanaged",
-          "ModMod/bar/resources",
-          "out/ModMod/bar/compile.dest/classes",
-          //
           "ModMod/foo/compile-resources",
           "ModMod/foo/unmanaged",
           "ModMod/foo/resources",
           "out/ModMod/foo/compile.dest/classes",
+          //
+          "ModMod/bar/compile-resources",
+          "ModMod/bar/unmanaged",
+          "ModMod/bar/resources",
+          "out/ModMod/bar/compile.dest/classes",
           //
           "ModMod/qux/compile-resources",
           "ModMod/qux/unmanaged",
@@ -167,13 +167,13 @@ object ScalaMultiModuleClasspathsTests extends TestSuite {
           //
           "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
           //
-          "ModMod/bar/compile-resources",
-          "ModMod/bar/unmanaged",
-          "out/ModMod/bar/compile.dest/classes",
-          //
           "ModMod/foo/compile-resources",
           "ModMod/foo/unmanaged",
           "out/ModMod/foo/compile.dest/classes",
+          //
+          "ModMod/bar/compile-resources",
+          "ModMod/bar/unmanaged",
+          "out/ModMod/bar/compile.dest/classes",
           //
           "ModMod/qux/compile-resources",
           "ModMod/qux/unmanaged"
@@ -223,13 +223,13 @@ object ScalaMultiModuleClasspathsTests extends TestSuite {
           //
           "org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
           //
-          "ModCompile/bar/compile-resources",
-          "ModCompile/bar/unmanaged",
-          "out/ModCompile/bar/compile.dest/classes",
-          //
           "ModCompile/foo/compile-resources",
           "ModCompile/foo/unmanaged",
           "out/ModCompile/foo/compile.dest/classes",
+          //
+          "ModCompile/bar/compile-resources",
+          "ModCompile/bar/unmanaged",
+          "out/ModCompile/bar/compile.dest/classes",
           //
           "ModCompile/qux/compile-resources",
           "ModCompile/qux/unmanaged"
@@ -308,14 +308,17 @@ object ScalaMultiModuleClasspathsTests extends TestSuite {
           "org/scala-sbt/test-interface/1.0/test-interface-1.0.jar",
           "org/portable-scala/portable-scala-reflect_2.13/1.1.3/portable-scala-reflect_2.13-1.1.3.jar",
           "org/scala-lang/scala-reflect/2.13.12/scala-reflect-2.13.12.jar",
-          "ModRun/bar/compile-resources",
-          "ModRun/bar/unmanaged",
-          "ModRun/bar/resources",
-          "out/ModRun/bar/compile.dest/classes",
+          //
           "ModRun/foo/compile-resources",
           "ModRun/foo/unmanaged",
           "ModRun/foo/resources",
           "out/ModRun/foo/compile.dest/classes",
+          //
+          "ModRun/bar/compile-resources",
+          "ModRun/bar/unmanaged",
+          "ModRun/bar/resources",
+          "out/ModRun/bar/compile.dest/classes",
+          //
           "ModRun/qux/compile-resources",
           "ModRun/qux/unmanaged",
           "ModRun/qux/resources",
@@ -348,14 +351,17 @@ object ScalaMultiModuleClasspathsTests extends TestSuite {
           "org/scala-sbt/test-interface/1.0/test-interface-1.0.jar",
           "org/portable-scala/portable-scala-reflect_2.13/1.1.3/portable-scala-reflect_2.13-1.1.3.jar",
           "org/scala-lang/scala-reflect/2.13.12/scala-reflect-2.13.12.jar",
-          "RunMod/bar/compile-resources",
-          "RunMod/bar/unmanaged",
-          "RunMod/bar/resources",
-          "out/RunMod/bar/compile.dest/classes",
+          //
           "RunMod/foo/compile-resources",
           "RunMod/foo/unmanaged",
           "RunMod/foo/resources",
           "out/RunMod/foo/compile.dest/classes",
+          //
+          "RunMod/bar/compile-resources",
+          "RunMod/bar/unmanaged",
+          "RunMod/bar/resources",
+          "out/RunMod/bar/compile.dest/classes",
+          //
           "RunMod/qux/compile-resources",
           "RunMod/qux/unmanaged",
           "RunMod/qux/resources",
@@ -370,6 +376,7 @@ object ScalaMultiModuleClasspathsTests extends TestSuite {
           "RunMod/bar/compile-resources",
           "RunMod/bar/unmanaged",
           "out/RunMod/bar/compile.dest/classes",
+          //
           "RunMod/qux/compile-resources",
           "RunMod/qux/unmanaged"
         ),


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/3761

* Introduce `runModuleDeps`, the runtime version of `moduleDeps` and `compileModuleDeps`

* We introduce `transitiveRunIvyDeps`, the runtime version of `transitiveIvyDeps`, and use it in most places as a replacement for `runIvyDeps`

* I also flipped the ordering of `transitiveModuleDeps`/`transitiveRunModuleDeps` to put `this` on the right/last, to follow the rest of the module resolution logic where "upstream" things come on the left/first in the classpath ordering

There are some behavioral changes, e.g. the A module's direct `compileModuleDeps` no longer end up on your `runClasspath`, as shown by the change in the test case `mill.scalalib.ScalaMultiModuleClasspathsTests.modCompile`. I think the new behavior is more correct than the old one?

One (benign?) consequence of this change is that the contents of the various `*run*` tasks now have considerable overlap with the non-`run` tasks, e.g. `transitiveRunIvyDeps` overlaps with `transitiveIvyDeps`. 

The way transitive runtime dependencies are now managed, both "`run{Module,Ivy}Dep` of `{module,ivy}Dep`" and "`{module,ivy}Dep` of `run{Module,Ivy}Dep`" are both aggregated into the run classpath. I'm not sure if this matches what Maven does (it does according to chatgpt!) but it seems reasonable to me

Added some additional unit tests to cover the new transitive behavior. The whole dependency-wiring stuff is pretty gnarly but hopefully the existing test suite will stop us from breaking too much (especially `mill.scalalib.ScalaMultiModuleClasspathsTests` which is pretty rigorous and we add to).

This is a binary-compatible but semantically incompatible change, would be good to get it into 0.12.0

Best reviewed with `Hide Whitespace` enabled