### PR TITLE
[WIP] Clean up `Jvm.scala`

### DIFF
--- a/main/api/src/mill/api/ClassLoader.scala
+++ b/main/api/src/mill/api/ClassLoader.scala
@@ -21,7 +21,7 @@ object ClassLoader {
       sharedLoader: java.lang.ClassLoader = getClass.getClassLoader,
       sharedPrefixes: Seq[String] = Seq(),
       logger: Option[mill.api.Logger] = None
-  )(implicit ctx: Ctx.Home): URLClassLoader = {
+  )(implicit ctx: Ctx.Home = null): URLClassLoader = {
     new URLClassLoader(
       makeUrls(urls).toArray,
       refinePlatformParent(parent)


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/3772.

Most of the various spawning helpers should be consolidated into four: `{call,spawn}{Subprocess,Classloader}`. 

The `Subprocess` method signatures should roughly follow the OS-Lib equivalents, with minimal tweaks to accommodate  JVM-specific use cases (e.g. main methods, classpaths)

The `Classloader` methods should mostly just take a classpath and give you a classloader to work with

The `new Thread("subprocess-shutdown")` logic probably should be pushed upstream https://github.com/com-lihaoyi/os-lib/pull/324