### PR TITLE
Fix ANSI color sequences that apply to multiple lines in the terminal logs

### DIFF
--- a/main/util/src/mill/util/LinePrefixOutputStream.scala
+++ b/main/util/src/mill/util/LinePrefixOutputStream.scala
@@ -30,7 +30,8 @@ class LinePrefixOutputStream(
     if (isNewLine && linePrefixNonEmpty) {
       isNewLine = false
       buffer.write(linePrefixBytes)
-      if (linePrefixNonEmpty) buffer.write(fansi.Attrs.emitAnsiCodes(0, endOfLastLineColor).getBytes())
+      if (linePrefixNonEmpty)
+        buffer.write(fansi.Attrs.emitAnsiCodes(0, endOfLastLineColor).getBytes())
     }
   }
 
@@ -39,7 +40,7 @@ class LinePrefixOutputStream(
 
     if (linePrefixNonEmpty) {
       val s = fansi.Str.apply(buffer.toString, errorMode = fansi.ErrorMode.Sanitize)
-      endOfLastLineColor = s.getColor(s.length-1)
+      endOfLastLineColor = s.getColor(s.length - 1)
     }
     out.synchronized { buffer.writeTo(out) }
     buffer.reset()

--- a/main/util/src/mill/util/LinePrefixOutputStream.scala
+++ b/main/util/src/mill/util/LinePrefixOutputStream.scala
@@ -40,7 +40,7 @@ class LinePrefixOutputStream(
 
     if (linePrefixNonEmpty) {
       val bufferString = buffer.toString
-      if (bufferString.length > 0){
+      if (bufferString.length > 0) {
         val s = fansi.Str.apply(bufferString, errorMode = fansi.ErrorMode.Sanitize)
         endOfLastLineColor = s.getColor(s.length - 1)
       }

--- a/main/util/src/mill/util/LinePrefixOutputStream.scala
+++ b/main/util/src/mill/util/LinePrefixOutputStream.scala
@@ -30,14 +30,17 @@ class LinePrefixOutputStream(
     if (isNewLine && linePrefixNonEmpty) {
       isNewLine = false
       buffer.write(linePrefixBytes)
-      buffer.write(fansi.Attrs.emitAnsiCodes(0, endOfLastLineColor).getBytes())
+      if (linePrefixNonEmpty) buffer.write(fansi.Attrs.emitAnsiCodes(0, endOfLastLineColor).getBytes())
     }
   }
 
   def writeOutBuffer(): Unit = {
     if (buffer.size() > 0) reportPrefix()
-    val s = fansi.Str.apply(buffer.toString, errorMode = fansi.ErrorMode.Sanitize)
-    endOfLastLineColor = s.getColor(s.length-1)
+
+    if (linePrefixNonEmpty) {
+      val s = fansi.Str.apply(buffer.toString, errorMode = fansi.ErrorMode.Sanitize)
+      endOfLastLineColor = s.getColor(s.length-1)
+    }
     out.synchronized { buffer.writeTo(out) }
     buffer.reset()
   }

--- a/main/util/src/mill/util/LinePrefixOutputStream.scala
+++ b/main/util/src/mill/util/LinePrefixOutputStream.scala
@@ -20,7 +20,11 @@ class LinePrefixOutputStream(
   private[this] val linePrefixNonEmpty = linePrefixBytes.length != 0
   private[this] var isNewLine = true
   val buffer = new ByteArrayOutputStream()
-  var endOfLastLineColor: Long = 0
+
+  // Make sure we preserve the end-of-line ANSI colors every time we write out the buffer, and
+  // re-apply them after every line prefix. This helps ensure the line prefix color/resets does
+  // not muck up the rendering of color sequences that affect multiple lines in the terminal
+  private var endOfLastLineColor: Long = 0
   override def write(b: Array[Byte]): Unit = write(b, 0, b.length)
   private[this] def writeLinePrefixIfNecessary(): Unit = {
     if (isNewLine && linePrefixNonEmpty) {

--- a/main/util/src/mill/util/LinePrefixOutputStream.scala
+++ b/main/util/src/mill/util/LinePrefixOutputStream.scala
@@ -41,7 +41,7 @@ class LinePrefixOutputStream(
     if (linePrefixNonEmpty) {
       val bufferString = buffer.toString
       if (bufferString.length > 0){
-        val s = fansi.Str.apply(buffer.toString, errorMode = fansi.ErrorMode.Sanitize)
+        val s = fansi.Str.apply(bufferString, errorMode = fansi.ErrorMode.Sanitize)
         endOfLastLineColor = s.getColor(s.length - 1)
       }
     }

--- a/main/util/src/mill/util/LinePrefixOutputStream.scala
+++ b/main/util/src/mill/util/LinePrefixOutputStream.scala
@@ -39,8 +39,11 @@ class LinePrefixOutputStream(
     if (buffer.size() > 0) reportPrefix()
 
     if (linePrefixNonEmpty) {
-      val s = fansi.Str.apply(buffer.toString, errorMode = fansi.ErrorMode.Sanitize)
-      endOfLastLineColor = s.getColor(s.length - 1)
+      val bufferString = buffer.toString
+      if (bufferString.length > 0){
+        val s = fansi.Str.apply(buffer.toString, errorMode = fansi.ErrorMode.Sanitize)
+        endOfLastLineColor = s.getColor(s.length - 1)
+      }
     }
     out.synchronized { buffer.writeTo(out) }
     buffer.reset()


### PR DESCRIPTION
Previously the `linePrefix` would end with `RESET` and wipe out the colors after each line; now we parse each line and look at the ending color and print that at the start of the next line. There'll be some overhead, but `fansi.Str` is pretty fast so hopefully it's OK

Tested manually, we can see the multi-line ansi colors that were problematic earlier now work, both preserving color, going from color to non-color and color to non-color

<img width="976" alt="Screenshot 2024-10-21 at 6 52 15 PM" src="https://github.com/user-attachments/assets/3e21eb71-9e17-419c-8c23-194b959bfa44">


Fixes https://github.com/com-lihaoyi/mill/issues/3793