### PR TITLE
Update jgrapht-core to 1.5.2

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -135,7 +135,7 @@ object Deps {
   )
   val junixsocket = ivy"com.kohlschutter.junixsocket:junixsocket-core:2.10.1"
 
-  val jgraphtCore = ivy"org.jgrapht:jgrapht-core:1.4.0" // 1.5.0+ dont support JDK8
+  val jgraphtCore = ivy"org.jgrapht:jgrapht-core:1.5.2"
   val javet = Seq(
     ivy"com.caoccao.javet:javet:3.1.6",
     ivy"com.caoccao.javet:javet-linux-arm64:3.1.6",


### PR DESCRIPTION
We no longer need to support Java 8 at runtime.