### PR TITLE
Update javet to 4.0.0

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -137,9 +137,9 @@ object Deps {
 
   val jgraphtCore = ivy"org.jgrapht:jgrapht-core:1.4.0" // 1.5.0+ dont support JDK8
   val javet = Seq(
-    ivy"com.caoccao.javet:javet:3.1.6",
-    ivy"com.caoccao.javet:javet-linux-arm64:3.1.6",
-    ivy"com.caoccao.javet:javet-macos:3.1.6"
+    ivy"com.caoccao.javet:javet:4.0.0",
+    ivy"com.caoccao.javet:javet-linux-arm64:4.0.0",
+    ivy"com.caoccao.javet:javet-macos:4.0.0"
   )
 
   val jline = ivy"org.jline:jline:3.26.3"


### PR DESCRIPTION
This is a major version change. I haven't tested manually, if it works. There is also PR #3810, which only bump to latest minor update.