### PR TITLE
Fix chart: foo.classpath should be contained in "foo" cluster

### DIFF
--- a/docs/modules/ROOT/partials/Intro_to_Mill_Header.adoc
+++ b/docs/modules/ROOT/partials/Intro_to_Mill_Header.adoc
@@ -11,7 +11,7 @@ digraph G {
 
     "foo.sources" -> "foo.compile" -> "foo.classPath" -> "foo.assembly"
     "foo.mainClass" -> "foo.assembly"
-    "foo.classpath"
+    "foo.classPath"
   }
   subgraph cluster_1 {
     style=dashed

--- a/docs/modules/ROOT/partials/Intro_to_Mill_Header.adoc
+++ b/docs/modules/ROOT/partials/Intro_to_Mill_Header.adoc
@@ -11,6 +11,7 @@ digraph G {
 
     "foo.sources" -> "foo.compile" -> "foo.classPath" -> "foo.assembly"
     "foo.mainClass" -> "foo.assembly"
+    "foo.classpath"
   }
   subgraph cluster_1 {
     style=dashed


### PR DESCRIPTION
Before:

![grafik](https://github.com/user-attachments/assets/8d9df8dc-21af-45dd-8f06-fd19e6bb9274)

After:

![grafik](https://github.com/user-attachments/assets/c76520c7-2e52-49ae-812d-85f7ab2340c5)
