### PR TITLE
Add a default config for logback

### DIFF
--- a/dist/resources/logback.xml
+++ b/dist/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration debug="false" scan="false">
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <file>out/mill.log</file>
+      <encoder>
+        <pattern>%date %level [%thread] %logger{36} %msg%n</pattern>
+      </encoder>
+    </appender>
+    <root level="info">
+      <appender-ref ref="FILE" />
+    </root>
+</configuration>


### PR DESCRIPTION
Since we bundle the logback dependency, it runs with a built-in default config printing all messages with at least DEBUG level on the console. This can be very verbose.

This change includes a default config creating a log file `out/mill.log` in the current workind directory. Since Mill now always runs in a sandbox dir, this should not pollute the users working directory.

If a user wants to change the log configuration, she can provide an alternative config with `-Dlogback.configurationFile=/path/to/config.xml`

We add the config file `logback.xml` to the runtime resources of the `dist` module, so it is only on the classpath of the Mill assembly. Since this assembly isn't expected on the classpath of other tools or libraries, we should avoid accidental downstream logging configurations.

Fix https://github.com/com-lihaoyi/mill/issues/3671
