### PR TITLE
Fix spawning of terminfo thread in server mode

### DIFF
--- a/main/client/src/mill/main/client/ServerLauncher.java
+++ b/main/client/src/mill/main/client/ServerLauncher.java
@@ -52,6 +52,7 @@ public abstract class ServerLauncher {
     final int serverProcessesLimit = 5;
     final int serverInitWaitMillis = 10000;
     public abstract void initServer(Path serverDir, boolean b, Locks locks) throws Exception;
+    public abstract void preRun(Path serverDir) throws Exception;
     InputStream stdin;
     PrintStream stdout;
     PrintStream stderr;
@@ -101,6 +102,7 @@ public abstract class ServerLauncher {
             ) {
                 if (clientLocked.isLocked()) {
                     Result result = new Result();
+                    preRun(serverDir);
                     result.exitCode = run(serverDir, setJnaNoSys, locks);
                     result.serverDir = serverDir;
                     return result;

--- a/main/server/test/src/mill/main/server/ClientServerTests.scala
+++ b/main/server/test/src/mill/main/server/ClientServerTests.scala
@@ -96,7 +96,7 @@ object ClientServerTests extends TestSuite {
         memoryLocks,
         forceFailureForTestingMillisDelay
       ) {
-        def preRun(serverDir: Path) = {/*donothin*/}
+        def preRun(serverDir: Path) = { /*donothin*/ }
         def initServer(serverDir: Path, b: Boolean, locks: Locks) = {
           val serverId = "server-" + nextServerId
           nextServerId += 1

--- a/main/server/test/src/mill/main/server/ClientServerTests.scala
+++ b/main/server/test/src/mill/main/server/ClientServerTests.scala
@@ -96,6 +96,7 @@ object ClientServerTests extends TestSuite {
         memoryLocks,
         forceFailureForTestingMillisDelay
       ) {
+        def preRun(serverDir: Path) = {/*donothin*/}
         def initServer(serverDir: Path, b: Boolean, locks: Locks) = {
           val serverId = "server-" + nextServerId
           nextServerId += 1

--- a/main/server/test/src/mill/main/server/ClientServerTests.scala
+++ b/main/server/test/src/mill/main/server/ClientServerTests.scala
@@ -96,7 +96,7 @@ object ClientServerTests extends TestSuite {
         memoryLocks,
         forceFailureForTestingMillisDelay
       ) {
-        def preRun(serverDir: Path) = { /*donothin*/ }
+        def preRun(serverDir: Path) = { /*do nothing*/ }
         def initServer(serverDir: Path, b: Boolean, locks: Locks) = {
           val serverId = "server-" + nextServerId
           nextServerId += 1

--- a/runner/client/src/mill/runner/client/MillClientMain.java
+++ b/runner/client/src/mill/runner/client/MillClientMain.java
@@ -40,6 +40,9 @@ public class MillClientMain {
                 public void initServer(Path serverDir, boolean setJnaNoSys, Locks locks) throws Exception{
                     MillProcessLauncher.launchMillServer(serverDir, setJnaNoSys);
                 }
+                public void preRun(Path serverDir) throws Exception {
+                    MillProcessLauncher.runTermInfoThread(serverDir);
+                }
             };
             int exitCode = launcher.acquireLocksAndRun(OutFiles.out).exitCode;
             if (exitCode == Util.ExitServerCodeWhenVersionMismatch()) {

--- a/runner/client/src/mill/runner/client/MillClientMain.java
+++ b/runner/client/src/mill/runner/client/MillClientMain.java
@@ -1,14 +1,13 @@
 package mill.runner.client;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
-
-import mill.main.client.*;
+import mill.main.client.ServerLauncher;
+import mill.main.client.Util;
 import mill.main.client.lock.Locks;
-import org.jline.terminal.Terminal;
-import org.jline.terminal.TerminalBuilder;
+import mill.main.client.OutFiles;
+import mill.main.client.ServerCouldNotBeStarted;
 
 /**
  * This is a Java implementation to speed up repetitive starts.
@@ -37,13 +36,9 @@ public class MillClientMain {
             MillNoServerLauncher.runMain(args);
         } else try {
             // start in client-server mode
-
             ServerLauncher launcher = new ServerLauncher(System.in, System.out, System.err, System.getenv(), args, null, -1){
                 public void initServer(Path serverDir, boolean setJnaNoSys, Locks locks) throws Exception{
                     MillProcessLauncher.launchMillServer(serverDir, setJnaNoSys);
-                }
-                public void preRun(Path serverDir) throws Exception {
-                    MillProcessLauncher.runTermInfoThread(serverDir);
                 }
             };
             int exitCode = launcher.acquireLocksAndRun(OutFiles.out).exitCode;
@@ -66,4 +61,5 @@ public class MillClientMain {
             }
         }
     }
+
 }

--- a/runner/client/src/mill/runner/client/MillClientMain.java
+++ b/runner/client/src/mill/runner/client/MillClientMain.java
@@ -1,13 +1,14 @@
 package mill.runner.client;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
-import mill.main.client.ServerLauncher;
-import mill.main.client.Util;
+
+import mill.main.client.*;
 import mill.main.client.lock.Locks;
-import mill.main.client.OutFiles;
-import mill.main.client.ServerCouldNotBeStarted;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
 
 /**
  * This is a Java implementation to speed up repetitive starts.
@@ -36,9 +37,13 @@ public class MillClientMain {
             MillNoServerLauncher.runMain(args);
         } else try {
             // start in client-server mode
+
             ServerLauncher launcher = new ServerLauncher(System.in, System.out, System.err, System.getenv(), args, null, -1){
                 public void initServer(Path serverDir, boolean setJnaNoSys, Locks locks) throws Exception{
                     MillProcessLauncher.launchMillServer(serverDir, setJnaNoSys);
+                }
+                public void preRun(Path serverDir) throws Exception {
+                    MillProcessLauncher.runTermInfoThread(serverDir);
                 }
             };
             int exitCode = launcher.acquireLocksAndRun(OutFiles.out).exitCode;
@@ -61,5 +66,4 @@ public class MillClientMain {
             }
         }
     }
-
 }


### PR DESCRIPTION
Previously we only spawned the terminfo updater when spawning the Mill server process, but that only handles the no-server case and first-time-spawning-server case, without handling the subsequently-re-use-server case. 

This moves the logic into a helper method so we can call it from both server and no-server launchers at the first point at which we have a dedicated `serverDir` available. Since the `serverDIr` is only available deep inside the `ServerLauncher` object, as it needs to do the work of testing different locks to pick a server, we add a `preRun` hook that we can override to start the terminfo updater thread