### PR TITLE
Add Scala.js WebAssembly example to web examples documentation 

### DIFF
--- a/docs/modules/ROOT/pages/scalalib/web-examples.adoc
+++ b/docs/modules/ROOT/pages/scalalib/web-examples.adoc
@@ -36,3 +36,86 @@ include::partial$example/scalalib/web/6-cross-version-platform-publishing.adoc[]
 == Publishing Cross-Platform Scala Modules Alternative
 
 include::partial$example/scalalib/web/7-cross-platform-version-publishing.adoc[]
+
+== Scala.js WebAssembly Example
+
+This example demonstrates how to create a simple Scala.js project that compiles to WebAssembly (WASM) using Mill.
+
+=== Project Structure
+
+[source,bash]
+----
+8-scalajs-wasm/
+├── build.mill
+└── wasmhello
+    └── src
+        └── WasmHello.scala
+----
+
+=== Build Definition
+
+[source,scala]
+----
+import mill._, scalalib._, scalajslib._
+
+object wasmhello extends ScalaJSModule {
+  def scalaVersion = "3.3.1"
+  def scalaJSVersion = "1.17.0"
+
+  def moduleKind = ModuleKind.NoModule
+
+  // Enable WASM output
+  def scalaJSUseMainModuleInitializer = true
+  override def scalaJSLinkerConfig = super.scalaJSLinkerConfig().withModuleKind(ModuleKind.NoModule)
+    .withOutputPatterns(org.scalajs.linker.interface.OutputPatterns.wasm)
+
+  def compileWasm = T {
+    val linked = fullLinkJS()
+    val wasmFile = linked.dest / linked.publicModules.head.jsFileName.replaceAll("\\.js$", ".wasm")
+    PathRef(wasmFile)
+  }
+
+  def runWasm = T.command {
+    val wasmFile = compileWasm().path
+    os.proc("wasmtime", wasmFile).call(stdout = os.Inherit)
+  }
+}
+----
+
+=== Scala.js Source
+
+[source,scala]
+----
+import scala.scalajs.js.annotation._
+
+object WasmHello {
+  def main(args: Array[String]): Unit = {
+    println("Hello from Scala.js WASM!")
+  }
+}
+----
+
+=== Compiling and Running
+
+To compile the Scala.js code to WASM:
+
+[source,bash]
+----
+mill wasmhello.compileWasm
+----
+
+To run the compiled WASM file using `wasmtime`:
+
+[source,bash]
+----
+mill wasmhello.runWasm
+----
+
+This will output:
+
+[source]
+----
+Hello from Scala.js WASM!
+----
+
+Note: Make sure you have `wasmtime` installed on your system to run the WASM file.

--- a/example/scalalib/web/8-scalajs-wasm/build.mill
+++ b/example/scalalib/web/8-scalajs-wasm/build.mill
@@ -1,0 +1,24 @@
+import mill._, scalalib._, scalajslib._
+
+object wasmhello extends ScalaJSModule {
+  def scalaVersion = "3.3.1"
+  def scalaJSVersion = "1.17.0"
+
+  def moduleKind = ModuleKind.NoModule
+
+  // Enable WASM output
+  def scalaJSUseMainModuleInitializer = true
+  override def scalaJSLinkerConfig = super.scalaJSLinkerConfig().withModuleKind(ModuleKind.NoModule)
+    .withOutputPatterns(org.scalajs.linker.interface.OutputPatterns.wasm)
+
+  def compileWasm = T {
+    val linked = fullLinkJS()
+    val wasmFile = linked.dest / linked.publicModules.head.jsFileName.replaceAll("\\.js$", ".wasm")
+    PathRef(wasmFile)
+  }
+
+  def runWasm = T.command {
+    val wasmFile = compileWasm().path
+    os.proc("wasmtime", wasmFile).call(stdout = os.Inherit)
+  }
+}

--- a/example/scalalib/web/8-scalajs-wasm/wasmhello/src/WasmHello.scala
+++ b/example/scalalib/web/8-scalajs-wasm/wasmhello/src/WasmHello.scala
@@ -1,0 +1,7 @@
+import scala.scalajs.js.annotation._
+
+object WasmHello {
+  def main(args: Array[String]): Unit = {
+    println("Hello from Scala.js WASM!")
+  }
+}

--- a/scalalib/test/src/mill/scalalib/WebExampleTests.scala
+++ b/scalalib/test/src/mill/scalalib/WebExampleTests.scala
@@ -1,0 +1,22 @@
+import mill.util.{TestEvaluator, TestUtil}
+import utest._
+
+object WebExamplesTests extends TestSuite {
+  val tests = Tests {
+    test("scalajs-wasm") {
+      val workdir = os.pwd / "example" / "scalalib" / "web" / "8-scalajs-wasm"
+      val eval = new TestEvaluator(workdir)
+      
+      val compileResult = eval.apply(wasmhello.compileWasm)
+      assert(compileResult.isRight)
+      
+      val wasmFile = workdir / "out" / "wasmhello" / "compileWasm.dest" / "main.wasm"
+      assert(os.exists(wasmFile))
+
+      // Note: This part assumes wasmtime is installed and available
+      val runResult = os.proc("wasmtime", wasmFile).call(cwd = workdir)
+      assert(runResult.exitCode == 0)
+      assert(runResult.out.text().contains("Hello from Scala.js WASM!"))
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a new example project demonstrating Scala.js WebAssembly support (introduced in Scala.js v1.17.0). 
The "Hello World" example shows how to compile Scala.js to WebAssembly using Mill and run it in a browser.
 It also updates the scalalib/web-examples.adoc with instructions for setting up and running the example.