### PR TITLE
Show the correct buildfile name in the progress

### DIFF
--- a/integration/failure/missing-build-file/src/MissingBuildFileTests.scala
+++ b/integration/failure/missing-build-file/src/MissingBuildFileTests.scala
@@ -9,7 +9,8 @@ object MissingBuildFileTests extends UtestIntegrationTestSuite {
     test - integrationTest { tester =>
       val res = tester.eval(("resolve", "_"))
       assert(!res.isSuccess)
-      val s"${prefix}build.mill file not found in $msg. Are you in a Mill project folder?" = res.err
+      val s"${prefix}No build file (build.mill, build.mill.scala, build.sc) found in $msg. Are you in a Mill project directory?" =
+        res.err
     }
   }
 }

--- a/runner/src/mill/runner/FileImportGraph.scala
+++ b/runner/src/mill/runner/FileImportGraph.scala
@@ -21,7 +21,8 @@ case class FileImportGraph(
     repos: Seq[(String, os.Path)],
     ivyDeps: Set[String],
     errors: Seq[String],
-    millImport: Boolean
+    millImport: Boolean,
+    buildFile: String
 )
 
 /**
@@ -215,7 +216,8 @@ object FileImportGraph {
       seenRepo.toSeq,
       seenIvy.toSet,
       errors.toSeq,
-      millImport
+      millImport,
+      foundRootBuildFileName
     )
   }
 

--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -337,7 +337,11 @@ class MillBuildBootstrap(
 
     val bootLogPrefix: Seq[String] =
       if (depth == 0) Nil
-      else Seq((Seq.fill(depth - 1)(millBuild) ++ Seq(actualBuildFileName.getOrElse("<build>"))).mkString("/"))
+      else Seq(
+        (Seq.fill(depth - 1)(millBuild) ++
+          Seq(actualBuildFileName.getOrElse("<build>")))
+          .mkString("/")
+      )
 
     mill.eval.EvaluatorImpl(
       home,

--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -88,7 +88,7 @@ class MillBuildBootstrap(
         ) state
         else {
           val msg =
-            s"No build file (${rootBuildFileNames.mkString(", ")}) found in $projectRoot. Are you in a Mill project folder?"
+            s"No build file (${rootBuildFileNames.mkString(", ")}) found in $projectRoot. Are you in a Mill project directory?"
           if (needBuildFile) {
             RunnerState(None, Nil, Some(msg), None)
           } else {

--- a/runner/src/mill/runner/MillMain.scala
+++ b/runner/src/mill/runner/MillMain.scala
@@ -262,7 +262,7 @@ object MillMain {
                               prevRunnerState = prevState.getOrElse(stateCache),
                               logger = logger,
                               disableCallgraph = config.disableCallgraph.value,
-                              needBuildSc = needBuildSc(config),
+                              needBuildFile = needBuildFile(config),
                               requestedMetaLevel = config.metaLevel,
                               config.allowPositional.value,
                               systemExit = systemExit,
@@ -373,7 +373,7 @@ object MillMain {
   /**
    * Determine, whether we need a `build.mill` or not.
    */
-  private def needBuildSc(config: MillCliConfig): Boolean = {
+  private def needBuildFile(config: MillCliConfig): Boolean = {
     // Tasks, for which running Mill without an existing buildfile is allowed.
     val noBuildFileTaskWhitelist = Seq(
       "init",

--- a/runner/src/mill/runner/RunnerState.scala
+++ b/runner/src/mill/runner/RunnerState.scala
@@ -30,7 +30,8 @@ import mill.main.RootModule
 case class RunnerState(
     bootstrapModuleOpt: Option[RootModule],
     frames: Seq[RunnerState.Frame],
-    errorOpt: Option[String]
+    errorOpt: Option[String],
+    buildFile: Option[String] = None
 ) {
   def add(
       frame: RunnerState.Frame = RunnerState.Frame.empty,


### PR DESCRIPTION
Instead of always using `build.mill` we now use the actual buildfile name in the progress logger.

```
> mill resolve _
[build.sc-57/61] compile
...

> mv build.sc build.mill.scala

> mill resolve _
[build.mill.scala-57/61] compile
...
```

Fix https://github.com/com-lihaoyi/mill/issues/3831
