### PR TITLE
Be more resilient when reading previous code hash signatures

### DIFF
--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -171,12 +171,12 @@ abstract class MillBuildRootModule()(implicit
         },
         logger = new mill.codesig.Logger(Option.when(debugEnabled)(T.dest / "current")),
         prevTransitiveCallGraphHashesOpt = () =>
-          Option(os.exists(T.dest / "previous/result.json")).filter(identity)
-            .flatMap(_ =>
+          Option(T.dest / "previous/result.json").filter(os.exists)
+            .flatMap(prev =>
               Try {
                 // This can fail when the previous run was ran by a different Mill version
                 upickle.default.read[Map[String, Int]](
-                  os.read.stream(T.dest / "previous/result.json")
+                  os.read.stream(prev)
                 )
               }.toOption
             )

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -171,11 +171,15 @@ abstract class MillBuildRootModule()(implicit
         },
         logger = new mill.codesig.Logger(Option.when(debugEnabled)(T.dest / "current")),
         prevTransitiveCallGraphHashesOpt = () =>
-          Option.when(os.exists(T.dest / "previous/result.json"))(
-            upickle.default.read[Map[String, Int]](
-              os.read.stream(T.dest / "previous/result.json")
+          Option(os.exists(T.dest / "previous/result.json")).filter(_)
+            .flatMap(_ =>
+              Try {
+                // This can fail when the previous run was ran by a different Mill version
+                upickle.default.read[Map[String, Int]](
+                  os.read.stream(T.dest / "previous/result.json")
+                )
+              }.toOption
             )
-          )
       )
 
     val result = codesig.transitiveCallGraphHashes

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -171,7 +171,7 @@ abstract class MillBuildRootModule()(implicit
         },
         logger = new mill.codesig.Logger(Option.when(debugEnabled)(T.dest / "current")),
         prevTransitiveCallGraphHashesOpt = () =>
-          Option(os.exists(T.dest / "previous/result.json")).filter(x => x)
+          Option(os.exists(T.dest / "previous/result.json")).filter(identity)
             .flatMap(_ =>
               Try {
                 // This can fail when the previous run was ran by a different Mill version

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -171,7 +171,7 @@ abstract class MillBuildRootModule()(implicit
         },
         logger = new mill.codesig.Logger(Option.when(debugEnabled)(T.dest / "current")),
         prevTransitiveCallGraphHashesOpt = () =>
-          Option(os.exists(T.dest / "previous/result.json")).filter(_)
+          Option(os.exists(T.dest / "previous/result.json")).filter(x => x)
             .flatMap(_ =>
               Try {
                 // This can fail when the previous run was ran by a different Mill version


### PR DESCRIPTION
I saw exceptions originating here when I changed between Mill versions. I think, this happen, when we made an incompatible change. Since this is no real breakage, but only some dropping of optimizations, I think we better recover without interruption than breaking in front of the user without any guidance (e.g. removing `out/mill-build`) how to solve.

Now, we just ignore the previous state.

Here's the stack trace:

```
> mill __.compile
Downloading mill 0.12.0 from https://repo1.maven.org/maven2/com/lihaoyi/mill-dist/0.12.0/mill-dist-0.12.0.jar ...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 64.6M  100 64.6M    0     0   676k      0  0:01:37  0:01:37 --:--:--  761k
[61/61] =============================================================================================================== __.compile ================================================================================================================= 3s
1 tasks failed
methodCodeHashSignatures os.ResourceNotFoundException: java.net.URLClassLoader@70691692/mill/runner/MillBuildRootModule$MillMiscInfo.class
    os.ResourcePath.getInputStream(ResourcePath.scala:21)
    os.read$inputStream$.apply(ReadWriteOps.scala:245)
    mill.codesig.ExternalSummary$.load0$1(ExternalSummary.scala:55)
    mill.codesig.ExternalSummary$.$anonfun$apply$6(ExternalSummary.scala:48)
    scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
    scala.collection.mutable.HashMap.getOrElse(HashMap.scala:451)
    mill.codesig.ExternalSummary$.load$1(ExternalSummary.scala:48)
    mill.codesig.ExternalSummary$.$anonfun$apply$9(ExternalSummary.scala:69)
    mill.codesig.ExternalSummary$.$anonfun$apply$9$adapted(ExternalSummary.scala:69)
    scala.collection.immutable.BitmapIndexedSetNode.foreach(HashSet.scala:951)
    scala.collection.immutable.HashSet.foreach(HashSet.scala:958)
    mill.codesig.ExternalSummary$.apply(ExternalSummary.scala:69)
    mill.codesig.CodeSig$.compute(CodeSig.scala:17)
    mill.runner.MillBuildRootModule.$anonfun$methodCodeHashSignatures$2(MillBuildRootModule.scala:173)
```

