### PR TITLE
readme.adoc: Restore `rm` command in bash snippet

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -226,7 +226,7 @@ In case of troubles with caching and/or incremental compilation, you can always 
 
 [source,bash]
 ----
-os.remove.all -rf out/
+rm -rf out/
 ----
 
 == Project Layout


### PR DESCRIPTION
`os.remove.all` had replaced it accidentally in https://github.com/nafg/mill/commit/bc9dc386625021fec517f2dbf0644ccafe1e32c2#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15