### PR TITLE
Add stub `mill.define.Ctx` to trick IntelliJ into not erroring

### DIFF
--- a/example/javalib/basic/1-simple/build.mill
+++ b/example/javalib/basic/1-simple/build.mill
@@ -2,15 +2,18 @@
 package build
 import mill._, javalib._
 
-def a = Task { 1 }
-val arr = Array(a)
-def b = {
-  val c = 0
-  Task{
-    arr(c)()
+object foo extends JavaModule {
+  def ivyDeps = Agg(
+    ivy"net.sourceforge.argparse4j:argparse4j:0.9.0",
+    ivy"org.thymeleaf:thymeleaf:3.1.1.RELEASE"
+  )
+
+  object test extends JavaTests with TestModule.Junit4{
+    def ivyDeps = super.ivyDeps() ++ Agg(
+      ivy"com.google.guava:guava:33.3.0-jre"
+    )
   }
 }
-
 
 // This is a basic Mill build for a single `JavaModule`, with two
 // third-party dependencies and a test suite using the JUnit framework.

--- a/example/javalib/basic/1-simple/build.mill
+++ b/example/javalib/basic/1-simple/build.mill
@@ -2,18 +2,15 @@
 package build
 import mill._, javalib._
 
-object foo extends JavaModule {
-  def ivyDeps = Agg(
-    ivy"net.sourceforge.argparse4j:argparse4j:0.9.0",
-    ivy"org.thymeleaf:thymeleaf:3.1.1.RELEASE"
-  )
-
-  object test extends JavaTests with TestModule.Junit4{
-    def ivyDeps = super.ivyDeps() ++ Agg(
-      ivy"com.google.guava:guava:33.3.0-jre"
-    )
+def a = Task { 1 }
+val arr = Array(a)
+def b = {
+  val c = 0
+  Task{
+    arr(c)()
   }
 }
+
 
 // This is a basic Mill build for a single `JavaModule`, with two
 // third-party dependencies and a test suite using the JUnit framework.

--- a/main/define/src/mill/define/Cacher.scala
+++ b/main/define/src/mill/define/Cacher.scala
@@ -16,7 +16,7 @@ private[mill] object Cacher {
   def impl0[T: c.WeakTypeTag](c: Context)(t: c.Expr[T]): c.Expr[T] = {
     c.Expr[T](wrapCached[T](c)(t.tree))
   }
-  def wrapCached[R: c.WeakTypeTag](c: Context)(t: c.Tree) = {
+  def wrapCached[R: c.WeakTypeTag](c: Context)(t: c.Tree): c.universe.Tree = {
 
     import c.universe._
     val owner = c.internal.enclosingOwner

--- a/main/define/src/mill/define/Cacher.scala
+++ b/main/define/src/mill/define/Cacher.scala
@@ -1,0 +1,32 @@
+package mill.define
+
+import scala.collection.mutable
+import scala.reflect.macros.blackbox.Context
+
+private[mill] trait Cacher extends mill.moduledefs.Cacher {
+  private[this] lazy val cacherLazyMap = mutable.Map.empty[sourcecode.Enclosing, Any]
+
+  override protected[this] def cachedTarget[T](t: => T)(implicit c: sourcecode.Enclosing): T = synchronized {
+    cacherLazyMap.getOrElseUpdate(c, t).asInstanceOf[T]
+  }
+}
+
+private[mill] object Cacher {
+  def impl0[T: c.WeakTypeTag](c: Context)(t: c.Expr[T]): c.Expr[T] = {
+    c.Expr[T](wrapCached[T](c)(t.tree))
+  }
+  def wrapCached[R: c.WeakTypeTag](c: Context)(t: c.Tree) = {
+
+    import c.universe._
+    val owner = c.internal.enclosingOwner
+    val ownerIsCacherClass =
+      owner.owner.isClass &&
+        owner.owner.asClass.baseClasses.exists(_.fullName == "mill.define.Cacher")
+
+    if (ownerIsCacherClass && owner.isMethod) q"this.cachedTarget[${weakTypeTag[R]}]($t)"
+    else c.abort(
+      c.enclosingPosition,
+      "Task{} members must be defs defined in a Module class/trait/object body"
+    )
+  }
+}

--- a/main/define/src/mill/define/Cacher.scala
+++ b/main/define/src/mill/define/Cacher.scala
@@ -6,9 +6,10 @@ import scala.reflect.macros.blackbox.Context
 private[mill] trait Cacher extends mill.moduledefs.Cacher {
   private[this] lazy val cacherLazyMap = mutable.Map.empty[sourcecode.Enclosing, Any]
 
-  override protected[this] def cachedTarget[T](t: => T)(implicit c: sourcecode.Enclosing): T = synchronized {
-    cacherLazyMap.getOrElseUpdate(c, t).asInstanceOf[T]
-  }
+  override protected[this] def cachedTarget[T](t: => T)(implicit c: sourcecode.Enclosing): T =
+    synchronized {
+      cacherLazyMap.getOrElseUpdate(c, t).asInstanceOf[T]
+    }
 }
 
 private[mill] object Cacher {

--- a/main/define/src/mill/define/Ctx.scala
+++ b/main/define/src/mill/define/Ctx.scala
@@ -39,7 +39,7 @@ trait Ctx {
   private[mill] def withEnclosingModule(enclosingModule: Any): Ctx = this
 }
 
-object Ctx extends LowPriCtx{
+object Ctx extends LowPriCtx {
   private case class Impl(
       enclosing: String,
       lineNum: Int,
@@ -77,7 +77,6 @@ object Ctx extends LowPriCtx{
    */
   final case class Foreign(value: Option[Segments])
 
-
   implicit def make(implicit
       millModuleEnclosing0: sourcecode.Enclosing,
       millModuleLine0: sourcecode.Line,
@@ -108,10 +107,12 @@ object Ctx extends LowPriCtx{
   }
 }
 
-trait LowPriCtx{
+trait LowPriCtx {
   // Dummy `Ctx` available in implicit scope but never actually used.
   // as it is provided by the codegen. Defined for IDEs to think that one is available
   // and not show errors in build.mill/package.mill even though they can't see the codegen
-  @compileTimeOnly("implicit Ctx must be provided, can only use this inside an enclosing Mill module")
+  @compileTimeOnly(
+    "implicit Ctx must be provided, can only use this inside an enclosing Mill module"
+  )
   implicit def dummyInfo: Ctx = sys.error("implicit Ctx must be provided")
 }

--- a/main/define/src/mill/define/Ctx.scala
+++ b/main/define/src/mill/define/Ctx.scala
@@ -1,6 +1,6 @@
 package mill.define
 
-import scala.annotation.implicitNotFound
+import scala.annotation.{compileTimeOnly, implicitNotFound}
 
 /**
  * The contextual information provided by a [[mill.define.Module]].
@@ -39,7 +39,7 @@ trait Ctx {
   private[mill] def withEnclosingModule(enclosingModule: Any): Ctx = this
 }
 
-object Ctx {
+object Ctx extends LowPriCtx{
   private case class Impl(
       enclosing: String,
       lineNum: Int,
@@ -77,6 +77,7 @@ object Ctx {
    */
   final case class Foreign(value: Option[Segments])
 
+
   implicit def make(implicit
       millModuleEnclosing0: sourcecode.Enclosing,
       millModuleLine0: sourcecode.Line,
@@ -105,4 +106,12 @@ object Ctx {
       Seq()
     )
   }
+}
+
+trait LowPriCtx{
+  // Dummy `Ctx` available in implicit scope but never actually used.
+  // as it is provided by the codegen. Defined for IDEs to think that one is available
+  // and not show errors in build.mill/package.mill even though they can't see the codegen
+  @compileTimeOnly("implicit Ctx must be provided, can only use this inside an enclosing Mill module")
+  implicit def dummyInfo: Ctx = sys.error("implicit Ctx must be provided")
 }

--- a/main/define/src/mill/define/Ctx.scala
+++ b/main/define/src/mill/define/Ctx.scala
@@ -112,7 +112,7 @@ trait LowPriCtx {
   // as it is provided by the codegen. Defined for IDEs to think that one is available
   // and not show errors in build.mill/package.mill even though they can't see the codegen
   @compileTimeOnly(
-    "implicit Ctx must be provided, can only use this inside an enclosing Mill module"
+    "Modules and Tasks can only be defined within a mill Module"
   )
   implicit def dummyInfo: Ctx = sys.error("implicit Ctx must be provided")
 }

--- a/main/define/src/mill/define/Module.scala
+++ b/main/define/src/mill/define/Module.scala
@@ -55,7 +55,7 @@ object Module {
    * messes up the module discovery process
    */
   @internal
-  class BaseClass(implicit outerCtx0: mill.define.Ctx) extends mill.moduledefs.Cacher {
+  class BaseClass(implicit outerCtx0: mill.define.Ctx) extends mill.define.Cacher {
     def millOuterCtx = outerCtx0
   }
 

--- a/main/define/src/mill/define/Task.scala
+++ b/main/define/src/mill/define/Task.scala
@@ -359,7 +359,7 @@ object Target extends TaskBase {
 
       val lhs = Applicative.impl0[Task, T, mill.api.Ctx](c)(reify(Result.create(t.splice)).tree)
 
-      mill.moduledefs.Cacher.impl0[Target[T]](c)(
+      mill.define.Cacher.impl0[Target[T]](c)(
         reify(
           new TargetImpl[T](
             lhs.splice,
@@ -379,7 +379,7 @@ object Target extends TaskBase {
 
       val taskIsPrivate = isPrivateTargetOption(c)
 
-      mill.moduledefs.Cacher.impl0[Target[T]](c)(
+      mill.define.Cacher.impl0[Target[T]](c)(
         reify(
           new TargetImpl[T](
             Applicative.impl0[Task, T, mill.api.Ctx](c)(t.tree).splice,
@@ -398,7 +398,7 @@ object Target extends TaskBase {
 
       val taskIsPrivate = isPrivateTargetOption(c)
 
-      mill.moduledefs.Cacher.impl0[Target[T]](c)(
+      mill.define.Cacher.impl0[Target[T]](c)(
         reify {
           val s1 = Applicative.impl0[Task, T, mill.api.Ctx](c)(t.tree).splice
           val c1 = ctx.splice
@@ -421,7 +421,7 @@ object Target extends TaskBase {
 
       val taskIsPrivate = isPrivateTargetOption(c)
 
-      mill.moduledefs.Cacher.impl0[Target[T]](c)(
+      mill.define.Cacher.impl0[Target[T]](c)(
         reify(
           new TargetImpl[T](
             t.splice,
@@ -444,7 +444,7 @@ object Target extends TaskBase {
 
       val taskIsPrivate = isPrivateTargetOption(c)
 
-      mill.moduledefs.Cacher.impl0[SourcesImpl](c)(
+      mill.define.Cacher.impl0[SourcesImpl](c)(
         reify(
           new SourcesImpl(
             Target.sequence(c.Expr[List[Task[PathRef]]](q"_root_.scala.List(..$wrapped)").splice),
@@ -461,7 +461,7 @@ object Target extends TaskBase {
 
       val taskIsPrivate = isPrivateTargetOption(c)
 
-      mill.moduledefs.Cacher.impl0[SourcesImpl](c)(
+      mill.define.Cacher.impl0[SourcesImpl](c)(
         reify(
           new SourcesImpl(
             Applicative.impl0[Task, Seq[PathRef], mill.api.Ctx](c)(values.tree).splice,
@@ -483,7 +483,7 @@ object Target extends TaskBase {
 
       val taskIsPrivate = isPrivateTargetOption(c)
 
-      mill.moduledefs.Cacher.impl0[Target[PathRef]](c)(
+      mill.define.Cacher.impl0[Target[PathRef]](c)(
         reify(
           new SourceImpl(
             wrapped.splice,
@@ -500,7 +500,7 @@ object Target extends TaskBase {
 
       val taskIsPrivate = isPrivateTargetOption(c)
 
-      mill.moduledefs.Cacher.impl0[Target[PathRef]](c)(
+      mill.define.Cacher.impl0[Target[PathRef]](c)(
         reify(
           new SourceImpl(
             Applicative.impl0[Task, PathRef, mill.api.Ctx](c)(value.tree).splice,
@@ -519,7 +519,7 @@ object Target extends TaskBase {
 
       val taskIsPrivate = isPrivateTargetOption(c)
 
-      mill.moduledefs.Cacher.impl0[InputImpl[T]](c)(
+      mill.define.Cacher.impl0[InputImpl[T]](c)(
         reify(
           new InputImpl[T](
             Applicative.impl[Task, T, mill.api.Ctx](c)(value).splice,
@@ -598,7 +598,7 @@ object Target extends TaskBase {
 
       val taskIsPrivate = isPrivateTargetOption(c)
 
-      mill.moduledefs.Cacher.impl0[Worker[T]](c)(
+      mill.define.Cacher.impl0[Worker[T]](c)(
         reify(
           new Worker[T](t.splice, ctx.splice, taskIsPrivate.splice)
         )
@@ -611,7 +611,7 @@ object Target extends TaskBase {
 
       val taskIsPrivate = isPrivateTargetOption(c)
 
-      mill.moduledefs.Cacher.impl0[Worker[T]](c)(
+      mill.define.Cacher.impl0[Worker[T]](c)(
         reify(
           new Worker[T](
             Applicative.impl[Task, T, mill.api.Ctx](c)(t).splice,
@@ -630,7 +630,7 @@ object Target extends TaskBase {
 
       val taskIsPrivate = isPrivateTargetOption(c)
 
-      mill.moduledefs.Cacher.impl0[PersistentImpl[T]](c)(
+      mill.define.Cacher.impl0[PersistentImpl[T]](c)(
         reify(
           new PersistentImpl[T](
             Applicative.impl[Task, T, mill.api.Ctx](c)(t).splice,

--- a/main/define/test/src/mill/define/MacroErrorTests.scala
+++ b/main/define/test/src/mill/define/MacroErrorTests.scala
@@ -94,8 +94,9 @@ object MacroErrorTests extends TestSuite {
             }
           }
         """)
+        pprint.log(e)
         assert(e.msg.contains(
-          "Modules and Tasks can only be defined within a mill Module"
+          "Task{} members must be defs defined in a Cacher class/trait/object body"
         ))
       }
       test("neg") {
@@ -139,7 +140,7 @@ object MacroErrorTests extends TestSuite {
           }
         """)
         assert(borkedCachedDiamond1.msg.contains(
-          "Modules and Tasks can only be defined within a mill Module"
+          "Task{} members must be defs defined in a Cacher class/trait/object body"
         ))
       }
     }

--- a/main/define/test/src/mill/define/MacroErrorTests.scala
+++ b/main/define/test/src/mill/define/MacroErrorTests.scala
@@ -10,7 +10,7 @@ object MacroErrorTests extends TestSuite {
 
     test("errors") {
       val expectedMsg =
-        "Task{} members must be defs defined in a Cacher class/trait/object body"
+        "Task{} members must be defs defined in a Module class/trait/object body"
 
       val err = compileError("object Foo extends TestBaseModule{ val x = Task {1} }")
       assert(err.msg == expectedMsg)
@@ -99,14 +99,14 @@ object MacroErrorTests extends TestSuite {
       test("neg1") {
         val e = compileError("""def a = Task { 1 }""")
         assert(e.msg.contains(
-          "Task{} members must be defs defined in a Cacher class/trait/object body"
+          "Task{} members must be defs defined in a Module class/trait/object body"
         ))
       }
 
       test("neg2") {
         val e = compileError("object foo extends TestBaseModule{ val a = Task { 1 } }")
         assert(e.msg.contains(
-          "Task{} members must be defs defined in a Cacher class/trait/object body"
+          "Task{} members must be defs defined in a Module class/trait/object body"
         ))
       }
       test("neg3") {
@@ -150,7 +150,7 @@ object MacroErrorTests extends TestSuite {
           }
         """)
         assert(borkedCachedDiamond1.msg.contains(
-          "Task{} members must be defs defined in a Cacher class/trait/object body"
+          "Task{} members must be defs defined in a Module class/trait/object body"
         ))
       }
     }

--- a/main/define/test/src/mill/define/MacroErrorTests.scala
+++ b/main/define/test/src/mill/define/MacroErrorTests.scala
@@ -84,22 +84,32 @@ object MacroErrorTests extends TestSuite {
       // of our `Target#apply()` calls, but we cannot reference any values that
       // come from inside the Task{...} block
       test("pos") {
-        val e = compileError("""
-          val a = Task { 1 }
+        // This hsould compile
+        object foo extends TestBaseModule{
+          def a = Task { 1 }
           val arr = Array(a)
-          val b = {
+          def b = {
             val c = 0
             Task{
               arr(c)()
             }
           }
-        """)
-        pprint.log(e)
+        }
+      }
+      test("neg1") {
+        val e = compileError("""def a = Task { 1 }""")
         assert(e.msg.contains(
           "Task{} members must be defs defined in a Cacher class/trait/object body"
         ))
       }
-      test("neg") {
+
+      test("neg2") {
+        val e = compileError("object foo extends TestBaseModule{ val a = Task { 1 } }")
+        assert(e.msg.contains(
+          "Task{} members must be defs defined in a Cacher class/trait/object body"
+        ))
+      }
+      test("neg3") {
 
         val expectedMsg =
           "Target#apply() call cannot use `value n` defined within the Task{...} block"
@@ -115,7 +125,7 @@ object MacroErrorTests extends TestSuite {
         }""")
         assert(err.msg == expectedMsg)
       }
-      test("neg2") {
+      test("neg4") {
 
         val expectedMsg =
           "Target#apply() call cannot use `value x` defined within the Task{...} block"
@@ -130,7 +140,7 @@ object MacroErrorTests extends TestSuite {
         }""")
         assert(err.msg == expectedMsg)
       }
-      test("neg3") {
+      test("neg5") {
         val borkedCachedDiamond1 = utest.compileError("""
           object borkedCachedDiamond1 {
             def up = Task { TestUtil.test() }

--- a/main/define/test/src/mill/define/MacroErrorTests.scala
+++ b/main/define/test/src/mill/define/MacroErrorTests.scala
@@ -85,12 +85,12 @@ object MacroErrorTests extends TestSuite {
       // come from inside the Task{...} block
       test("pos") {
         // This hsould compile
-        object foo extends TestBaseModule{
+        object foo extends TestBaseModule {
           def a = Task { 1 }
           val arr = Array(a)
           def b = {
             val c = 0
-            Task{
+            Task {
               arr(c)()
             }
           }


### PR DESCRIPTION
Same as https://github.com/com-lihaoyi/mill/pull/3558, but for `mill.define.Ctx` rather than `mill.main.RootModule.Info`. Because it's provided by the enclosing code-generation, we need to trick IntelliJ into thinking there is something it can use, and so I define a low priority implicit to fall back upon if the main `def make` doesn't work (but `@compileTimeOnly` to show an error message if it ends up being needed)

I moved the bulk of the cacher logic from `mill-moduledefs` to `mill.define`. We just need a marker trait in `mill-moduledefs`, and having the rest of the logic in Mill itself simplifies maintenance and evolution of the code

Before
<img width="976" alt="Screenshot 2024-10-28 at 5 55 39 PM" src="https://github.com/user-attachments/assets/93bd9259-ab81-4e8c-9e71-21142fff107b">

After
<img width="976" alt="Screenshot 2024-10-28 at 5 54 22 PM" src="https://github.com/user-attachments/assets/7a5c6964-d212-4efa-805b-ea68917bdcbe">
