### PR TITLE
Replace direct discord invite link with link to scala discord and instructions to join channel

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -1,6 +1,6 @@
 = Contributing to Mill
 :link-github: https://github.com/com-lihaoyi/mill
-:link-chat: https://discord.gg/xJCYRVMS
+
 
 Thank you for considering contributing to Mill.
 
@@ -16,6 +16,6 @@ Here are some direct links:
 * {link-github}/discussions[Discussion Forum on GitHub] - A place to ask question and discuss all kind of questions around Mill
 * {link-github}/issues[Issue Tracker on GitHub] - Our issue tracker for bugs and features
 * {link-github}/pulls[Pull Requests on GitHub] - All new features and bug fixes find their way into Mill via a pull request. You can also sketch new ideas by creating a draft pull requests.
-{link-chat}[Discord Chat] - You can also join our chat room if you like more direct communication or to just say hello
+
 
 To build docs locally, `mill docs.localPages`. The last line of the command tells you where to browse the generated pages. From there you can follow the breadcrumbs.

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -107,3 +107,7 @@ they are interesting:
 
 * https://www.youtube.com/watch?v=UsXgCeU-ovI[Video: A Deep Dive into the Mill Build Tool]
 
+To engage Mill with the community, you can use the channels below:
+
+* https://github.com/com-lihaoyi/mill/discussions[Mill Github Discussions]
+* https://discord.com/invite/scala[Scala Discord], in the TOOLING#mill channel

--- a/docs/supplemental-ui/partials/header-content.hbs
+++ b/docs/supplemental-ui/partials/header-content.hbs
@@ -20,7 +20,7 @@
         <a class="navbar-item" href="{{{or site.url (or siteRootUrl siteRootPath)}}}/api/latest/index.html">API</a>
         <a class="navbar-item" href="https://github.com/com-lihaoyi/mill/issues">Issues</a>
         <a class="navbar-item" href="https://github.com/com-lihaoyi/mill/discussions">Discuss</a>
-        <a class="navbar-item" href="https://discord.gg/xJCYRVMS">Chat</a>
+
 
             <!--
         <a class="navbar-item" href="#">Home</a>


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/3864

Somehow the direct channel links always expire even when specifically configured not to