### PR TITLE
Detect when `resolve` needs `ModuleRef` when likely cyclic references

### DIFF
--- a/main/resolve/src/mill/resolve/Resolve.scala
+++ b/main/resolve/src/mill/resolve/Resolve.scala
@@ -73,7 +73,7 @@ object Resolve {
                 rootModule,
                 value.getClass,
                 Some(value.defaultCommandName()),
-                value.millModuleSegments,
+                value.millModuleSegments
               )
 
               directChildrenOrErr.flatMap(directChildren =>

--- a/main/resolve/src/mill/resolve/Resolve.scala
+++ b/main/resolve/src/mill/resolve/Resolve.scala
@@ -284,7 +284,8 @@ trait Resolve[T] {
         rootModule = rootModule,
         remainingQuery = sel.value.toList,
         current = rootResolved,
-        querySoFar = Segments()
+        querySoFar = Segments(),
+        seenModules = Set.empty
       ) match {
         case ResolveCore.Success(value) => Right(value)
         case ResolveCore.NotFound(segments, found, next, possibleNexts) =>

--- a/main/resolve/src/mill/resolve/Resolve.scala
+++ b/main/resolve/src/mill/resolve/Resolve.scala
@@ -73,7 +73,7 @@ object Resolve {
                 rootModule,
                 value.getClass,
                 Some(value.defaultCommandName()),
-                value.millModuleSegments
+                value.millModuleSegments,
               )
 
               directChildrenOrErr.flatMap(directChildren =>

--- a/main/resolve/src/mill/resolve/ResolveCore.scala
+++ b/main/resolve/src/mill/resolve/ResolveCore.scala
@@ -101,7 +101,7 @@ private object ResolveCore {
                     None,
                     current.segments,
                     Nil,
-                    Set.empty // TODO: We should pass the seenModules set
+                    Set.empty
                   )
 
                 transitiveOrErr.map(transitive => self ++ transitive)
@@ -124,7 +124,7 @@ private object ResolveCore {
                   None,
                   current.segments,
                   typePattern,
-                  Set.empty // TODO: We should pass the seenModules set
+                  Set.empty
                 )
 
                 transitiveOrErr.map(transitive => self ++ transitive)
@@ -341,7 +341,8 @@ private object ResolveCore {
         case (Resolved.Module(s, cls), _) => Resolved.Module(segments ++ s, cls)
         case (Resolved.NamedTask(s), _) => Resolved.NamedTask(segments ++ s)
         case (Resolved.Command(s), _) => Resolved.Command(segments ++ s)
-      }.toSet ++ filteredCrosses
+      }
+        .toSet ++ filteredCrosses
     }
   }
 

--- a/main/resolve/src/mill/resolve/ResolveCore.scala
+++ b/main/resolve/src/mill/resolve/ResolveCore.scala
@@ -88,7 +88,7 @@ private object ResolveCore {
             checkedSearchModules0 <- checkedSearchModules
             searchModules <- Right(checkedSearchModules0)
           } yield {
-            searchModules.map(r => resolve(rootModule, tail, r, querySoFar ++ Seq(head), seenModules ++ moduleClasses(Set(r))))
+            searchModules.map(r => resolve(rootModule, tail, r, querySoFar ++ Seq(head), seenModules ++ moduleClasses(Set(current))))
               .partitionMap { case s: Success => Right(s.value); case f: Failed => Left(f) }
           }
 

--- a/main/resolve/src/mill/resolve/ResolveCore.scala
+++ b/main/resolve/src/mill/resolve/ResolveCore.scala
@@ -260,7 +260,7 @@ private object ResolveCore {
     }
 
     if (seenModules.contains(cls)) {
-      Left(s"Cyclic module reference detected: ${cls.getName}, it's required to wrap it in ModuleRef. See documentation: https://mill-build.org/mill/0.12.1/fundamentals/modules.html#_abstract_modules_references")
+      Left(s"Cyclic module reference detected: ${cls.getName}, it's required to wrap it in ModuleRef.")
     } else {
       val errOrIndirect0 = errOrModules match {
         case Right(modules) =>

--- a/main/resolve/test/src/mill/main/ResolveTests.scala
+++ b/main/resolve/test/src/mill/main/ResolveTests.scala
@@ -1111,24 +1111,24 @@ object ResolveTests extends TestSuite {
       )
     }
     test("cyclicModuleRefInitError") {
-      val check = new Checker(cyclicModuleRefInitError)
+      val check = new Checker(TestGraphs.CyclicModuleRefInitError)
       test - check.checkSeq0(
         Seq("__"),
         isShortError(_, "Cyclic module reference detected")
       )
     }
     test("nonCyclicModules") {
-      val check = new Checker(nonCyclicModules)
+      val check = new Checker(TestGraphs.NonCyclicModules)
       test - check(
         "__",
-        Right(Set()) // TODO: complete this
+        Right(Set(_.foo))
       )
     }
     test("moduleRefWithNonModuleRefChild") {
-      val check = new Checker(moduleRefWithNonModuleRefChild)
+      val check = new Checker(TestGraphs.ModuleRefWithNonModuleRefChild)
       test - check(
         "__",
-        Right(Set()) // TODO: complete this
+        Right(Set(_.foo))
       )
     }
   }

--- a/main/resolve/test/src/mill/main/ResolveTests.scala
+++ b/main/resolve/test/src/mill/main/ResolveTests.scala
@@ -1126,7 +1126,7 @@ object ResolveTests extends TestSuite {
       )
       test - check.checkSeq0(
         Seq("myA.a.__"),
-        isShortError(_, "Cyclic module reference detected at myA.a.a,")
+        isShortError(_, "Cyclic module reference detected at myA.a,")
       )
       test - check.checkSeq0(
         Seq("myA.a._"),
@@ -1160,7 +1160,7 @@ object ResolveTests extends TestSuite {
       )
       test - check.checkSeq0(
         Seq("A.b.__.a.b"),
-        isShortError(_, "Cyclic module reference detected at A.b.a.b,")
+        isShortError(_, "Cyclic module reference detected at A.b.a,")
       )
     }
     test("crossedCyclicModuleRefInitError") {

--- a/main/resolve/test/src/mill/main/ResolveTests.scala
+++ b/main/resolve/test/src/mill/main/ResolveTests.scala
@@ -1112,11 +1112,9 @@ object ResolveTests extends TestSuite {
     }
     test("cyclicModuleRefInitError") {
       val check = new Checker(cyclicModuleRefInitError)
-      test - check(
-        "__",
-        Left(
-          "blah blah blah." // TODO: complete this
-        )
+      test - check.checkSeq0(
+        Seq("__"),
+        isShortError(_, "Cyclic module reference detected")
       )
     }
     test("nonCyclicModules") {

--- a/main/resolve/test/src/mill/main/ResolveTests.scala
+++ b/main/resolve/test/src/mill/main/ResolveTests.scala
@@ -1116,6 +1116,14 @@ object ResolveTests extends TestSuite {
         Seq("__"),
         isShortError(_, "Cyclic module reference detected")
       )
+      test - check.checkSeq0(
+        Seq("myA.__"),
+        isShortError(_, "Cyclic module reference detected")
+      )
+      test - check.checkSeq0(
+        Seq("myA.a.__"),
+        isShortError(_, "Cyclic module reference detected")
+      )
     }
     test("cyclicModuleRefInitError2") {
       val check = new Checker(TestGraphs.CyclicModuleRefInitError2)
@@ -1128,6 +1136,14 @@ object ResolveTests extends TestSuite {
       val check = new Checker(TestGraphs.CyclicModuleRefInitError3)
       test - check.checkSeq0(
         Seq("__"),
+        isShortError(_, "Cyclic module reference detected")
+      )
+      test - check.checkSeq0(
+        Seq("A.__"),
+        isShortError(_, "Cyclic module reference detected")
+      )
+      test - check.checkSeq0(
+        Seq("A.b.__.a.b"),
         isShortError(_, "Cyclic module reference detected")
       )
     }

--- a/main/resolve/test/src/mill/main/ResolveTests.scala
+++ b/main/resolve/test/src/mill/main/ResolveTests.scala
@@ -1114,7 +1114,7 @@ object ResolveTests extends TestSuite {
       val check = new Checker(TestGraphs.CyclicModuleRefInitError)
       test - check.checkSeq0(
         Seq("__"),
-        isShortError(_, "Cyclic module reference detected")
+        isShortError(_, "Cyclic module reference detected at myA.a,")
       )
       test - check(
         "_",
@@ -1122,52 +1122,52 @@ object ResolveTests extends TestSuite {
       )
       test - check.checkSeq0(
         Seq("myA.__"),
-        isShortError(_, "Cyclic module reference detected")
+        isShortError(_, "Cyclic module reference detected at myA.a,")
       )
       test - check.checkSeq0(
         Seq("myA.a.__"),
-        isShortError(_, "Cyclic module reference detected")
+        isShortError(_, "Cyclic module reference detected at myA.a.a,")
       )
       test - check.checkSeq0(
         Seq("myA.a._"),
-        isShortError(_, "Cyclic module reference detected")
+        isShortError(_, "Cyclic module reference detected at myA.a.a,")
       )
       test - check.checkSeq0(
         Seq("myA.a._.a"),
-        isShortError(_, "Cyclic module reference detected")
+        isShortError(_, "Cyclic module reference detected at myA.a.a,")
       )
       test - check.checkSeq0(
         Seq("myA.a.b.a"),
-        isShortError(_, "Cyclic module reference detected")
+        isShortError(_, "Cyclic module reference detected at myA.a.b.a,")
       )
     }
     test("cyclicModuleRefInitError2") {
       val check = new Checker(TestGraphs.CyclicModuleRefInitError2)
       test - check.checkSeq0(
         Seq("__"),
-        isShortError(_, "Cyclic module reference detected")
+        isShortError(_, "Cyclic module reference detected at A.myA.a,")
       )
     }
     test("cyclicModuleRefInitError3") {
       val check = new Checker(TestGraphs.CyclicModuleRefInitError3)
       test - check.checkSeq0(
         Seq("__"),
-        isShortError(_, "Cyclic module reference detected")
+        isShortError(_, "Cyclic module reference detected at A.b.a,")
       )
       test - check.checkSeq0(
         Seq("A.__"),
-        isShortError(_, "Cyclic module reference detected")
+        isShortError(_, "Cyclic module reference detected at A.b.a,")
       )
       test - check.checkSeq0(
         Seq("A.b.__.a.b"),
-        isShortError(_, "Cyclic module reference detected")
+        isShortError(_, "Cyclic module reference detected at A.b.a.b,")
       )
     }
     test("crossedCyclicModuleRefInitError") {
       val check = new Checker(TestGraphs.CrossedCyclicModuleRefInitError)
       test - check.checkSeq0(
         Seq("__"),
-        isShortError(_, "Cyclic module reference detected")
+        isShortError(_, "Cyclic module reference detected at cross[210].c2[210].c1,")
       )
     }
     test("nonCyclicModules") {

--- a/main/resolve/test/src/mill/main/ResolveTests.scala
+++ b/main/resolve/test/src/mill/main/ResolveTests.scala
@@ -1124,12 +1124,13 @@ object ResolveTests extends TestSuite {
         Seq("myA.__"),
         isShortError(_, "Cyclic module reference detected")
       )
-      test - check(
-        "myA.a._",
-        Right(Set(_.foo))
-      )
       test - check.checkSeq0(
         Seq("myA.a.__"),
+        isShortError(_, "Cyclic module reference detected")
+      )
+      // FIXME: Cannot test like this because it "Cannot find default task to evaluate"
+      test - check.checkSeq0(
+        Seq("myA.a._"),
         isShortError(_, "Cyclic module reference detected")
       )
 //      // FIXME: Cannot test like this because it "Cannot find default task to evaluate"

--- a/main/resolve/test/src/mill/main/ResolveTests.scala
+++ b/main/resolve/test/src/mill/main/ResolveTests.scala
@@ -1128,21 +1128,18 @@ object ResolveTests extends TestSuite {
         Seq("myA.a.__"),
         isShortError(_, "Cyclic module reference detected")
       )
-      // FIXME: Cannot test like this because it "Cannot find default task to evaluate"
       test - check.checkSeq0(
         Seq("myA.a._"),
         isShortError(_, "Cyclic module reference detected")
       )
-//      // FIXME: Cannot test like this because it "Cannot find default task to evaluate"
-//      test - check(
-//        "myA.a._.a",
-//        Right(Set(_.foo))
-//      )
-//      // FIXME: Cannot test like this because it "Cannot find default task to evaluate"
-//      test - check.checkSeq0(
-//        Seq("myA.a.b.a"),
-//        isShortError(_, "Cyclic module reference detected")
-//      )
+      test - check.checkSeq0(
+        Seq("myA.a._.a"),
+        isShortError(_, "Cyclic module reference detected")
+      )
+      test - check.checkSeq0(
+        Seq("myA.a.b.a"),
+        isShortError(_, "Cyclic module reference detected")
+      )
     }
     test("cyclicModuleRefInitError2") {
       val check = new Checker(TestGraphs.CyclicModuleRefInitError2)
@@ -1191,6 +1188,10 @@ object ResolveTests extends TestSuite {
       val check = new Checker(TestGraphs.ModuleRefCycle)
       test - check(
         "__",
+        Right(Set(_.foo))
+      )
+      test - check(
+        "__._",
         Right(Set(_.foo))
       )
     }

--- a/main/resolve/test/src/mill/main/ResolveTests.scala
+++ b/main/resolve/test/src/mill/main/ResolveTests.scala
@@ -1152,5 +1152,12 @@ object ResolveTests extends TestSuite {
         Right(Set(_.foo))
       )
     }
+    test("moduleRefCycle") {
+      val check = new Checker(TestGraphs.ModuleRefCycle)
+      test - check(
+        "__",
+        Right(Set(_.foo))
+      )
+    }
   }
 }

--- a/main/resolve/test/src/mill/main/ResolveTests.scala
+++ b/main/resolve/test/src/mill/main/ResolveTests.scala
@@ -1116,14 +1116,32 @@ object ResolveTests extends TestSuite {
         Seq("__"),
         isShortError(_, "Cyclic module reference detected")
       )
+      test - check(
+        "_",
+        Right(Set(_.foo))
+      )
       test - check.checkSeq0(
         Seq("myA.__"),
         isShortError(_, "Cyclic module reference detected")
+      )
+      test - check(
+        "myA.a._",
+        Right(Set(_.foo))
       )
       test - check.checkSeq0(
         Seq("myA.a.__"),
         isShortError(_, "Cyclic module reference detected")
       )
+//      // FIXME: Cannot test like this because it "Cannot find default task to evaluate"
+//      test - check(
+//        "myA.a._.a",
+//        Right(Set(_.foo))
+//      )
+//      // FIXME: Cannot test like this because it "Cannot find default task to evaluate"
+//      test - check.checkSeq0(
+//        Seq("myA.a.b.a"),
+//        isShortError(_, "Cyclic module reference detected")
+//      )
     }
     test("cyclicModuleRefInitError2") {
       val check = new Checker(TestGraphs.CyclicModuleRefInitError2)

--- a/main/resolve/test/src/mill/main/ResolveTests.scala
+++ b/main/resolve/test/src/mill/main/ResolveTests.scala
@@ -1131,6 +1131,13 @@ object ResolveTests extends TestSuite {
         isShortError(_, "Cyclic module reference detected")
       )
     }
+    test("crossedCyclicModuleRefInitError") {
+      val check = new Checker(TestGraphs.CrossedCyclicModuleRefInitError)
+      test - check.checkSeq0(
+        Seq("__"),
+        isShortError(_, "Cyclic module reference detected")
+      )
+    }
     test("nonCyclicModules") {
       val check = new Checker(TestGraphs.NonCyclicModules)
       test - check(

--- a/main/resolve/test/src/mill/main/ResolveTests.scala
+++ b/main/resolve/test/src/mill/main/ResolveTests.scala
@@ -1110,5 +1110,28 @@ object ResolveTests extends TestSuite {
         Right(Set(_.concrete.tests.inner.foo, _.concrete.tests.inner.innerer.bar))
       )
     }
+    test("cyclicModuleRefInitError") {
+      val check = new Checker(cyclicModuleRefInitError)
+      test - check(
+        "__",
+        Left(
+          "blah blah blah." // TODO: complete this
+        )
+      )
+    }
+    test("nonCyclicModules") {
+      val check = new Checker(nonCyclicModules)
+      test - check(
+        "__",
+        Right(Set()) // TODO: complete this
+      )
+    }
+    test("moduleRefWithNonModuleRefChild") {
+      val check = new Checker(moduleRefWithNonModuleRefChild)
+      test - check(
+        "__",
+        Right(Set()) // TODO: complete this
+      )
+    }
   }
 }

--- a/main/resolve/test/src/mill/main/ResolveTests.scala
+++ b/main/resolve/test/src/mill/main/ResolveTests.scala
@@ -1117,6 +1117,20 @@ object ResolveTests extends TestSuite {
         isShortError(_, "Cyclic module reference detected")
       )
     }
+    test("cyclicModuleRefInitError2") {
+      val check = new Checker(TestGraphs.CyclicModuleRefInitError2)
+      test - check.checkSeq0(
+        Seq("__"),
+        isShortError(_, "Cyclic module reference detected")
+      )
+    }
+    test("cyclicModuleRefInitError3") {
+      val check = new Checker(TestGraphs.CyclicModuleRefInitError3)
+      test - check.checkSeq0(
+        Seq("__"),
+        isShortError(_, "Cyclic module reference detected")
+      )
+    }
     test("nonCyclicModules") {
       val check = new Checker(TestGraphs.NonCyclicModules)
       test - check(

--- a/main/test/src/mill/util/TestGraphs.scala
+++ b/main/test/src/mill/util/TestGraphs.scala
@@ -242,18 +242,18 @@ class TestGraphs() {
 
   // The module names repeat, but it's not actually cyclic and is meant to confuse the cycle detection.
   object nonCyclicModules extends TestBaseModule {
-    object A extends TestBaseModule {
+    object A extends Module {
       def b = B
     }
-    object B extends TestBaseModule {
-      object A extends TestBaseModule {
+    object B extends Module {
+      object A extends Module {
         def b = B
       }
       def a = A
 
-      object B extends TestBaseModule {
-        object B extends TestBaseModule {}
-        object A extends TestBaseModule {
+      object B extends Module {
+        object B extends Module {}
+        object A extends Module {
           def b = B
         }
         def a = A

--- a/main/test/src/mill/util/TestGraphs.scala
+++ b/main/test/src/mill/util/TestGraphs.scala
@@ -700,6 +700,21 @@ object TestGraphs {
     }
   }
 
+  object CrossedCyclicModuleRefInitError extends TestBaseModule {
+    object cross extends mill.Cross[Cross]("210", "211", "212")
+    trait Cross extends Cross.Module[String] {
+      def suffix = Task { crossValue }
+      def c2 = cross2
+    }
+
+    object cross2 extends mill.Cross[Cross2]("210", "211", "212")
+    trait Cross2 extends Cross.Module[String] {
+      override def millSourcePath = super.millSourcePath / crossValue
+      def suffix = Task { crossValue }
+      def c1 = cross
+    }
+  }
+
   // The module names repeat, but it's not actually cyclic and is meant to confuse the cycle detection.
   object NonCyclicModules extends TestBaseModule {
     def foo = Task { "foo" }

--- a/main/test/src/mill/util/TestGraphs.scala
+++ b/main/test/src/mill/util/TestGraphs.scala
@@ -685,6 +685,21 @@ object TestGraphs {
     }
   }
 
+  object CyclicModuleRefInitError2 extends TestBaseModule {
+    // The cycle is in the child
+    def A = CyclicModuleRefInitError
+  }
+
+  object CyclicModuleRefInitError3 extends TestBaseModule {
+    // The cycle is in directly here
+    object A extends Module {
+      def b = B
+    }
+    object B extends Module {
+      def a = A
+    }
+  }
+
   // The module names repeat, but it's not actually cyclic and is meant to confuse the cycle detection.
   object NonCyclicModules extends TestBaseModule {
     def foo = Task { "foo" }

--- a/main/test/src/mill/util/TestGraphs.scala
+++ b/main/test/src/mill/util/TestGraphs.scala
@@ -747,4 +747,16 @@ object TestGraphs {
 
     object A extends TestBaseModule {}
   }
+
+  object ModuleRefCycle extends TestBaseModule {
+    def foo = Task { "foo" }
+
+    // The cycle is in directly here
+    object A extends Module {
+      def b = ModuleRef(B)
+    }
+    object B extends Module {
+      def a = ModuleRef(A)
+    }
+  }
 }

--- a/main/test/src/mill/util/TestGraphs.scala
+++ b/main/test/src/mill/util/TestGraphs.scala
@@ -669,9 +669,11 @@ object TestGraphs {
 
   object CyclicModuleRefInitError extends TestBaseModule {
     import mill.Agg
+    def foo = Task { "foo" }
 
     // See issue: https://github.com/com-lihaoyi/mill/issues/3715
     trait CommonModule extends TestBaseModule {
+      def foo = Task { "foo" }
       def moduleDeps: Seq[CommonModule] = Seq.empty
       def a = myA
       def b = myB

--- a/main/test/src/mill/util/TestGraphs.scala
+++ b/main/test/src/mill/util/TestGraphs.scala
@@ -222,53 +222,6 @@ class TestGraphs() {
     override lazy val millDiscover = Discover[this.type]
   }
 
-  object cyclicModuleRefInitError extends TestBaseModule {
-    import mill.Agg
-
-    // See issue: https://github.com/com-lihaoyi/mill/issues/3715
-    trait CommonModule extends TestBaseModule {
-      def moduleDeps: Seq[CommonModule] = Seq.empty
-      def a = myA
-      def b = myB
-    }
-
-    object myA extends A
-    trait A extends CommonModule
-    object myB extends B
-    trait B extends CommonModule {
-      override def moduleDeps = super.moduleDeps ++ Agg(a)
-    }
-  }
-
-  // The module names repeat, but it's not actually cyclic and is meant to confuse the cycle detection.
-  object nonCyclicModules extends TestBaseModule {
-    object A extends Module {
-      def b = B
-    }
-    object B extends Module {
-      object A extends Module {
-        def b = B
-      }
-      def a = A
-
-      object B extends Module {
-        object B extends Module {}
-        object A extends Module {
-          def b = B
-        }
-        def a = A
-      }
-    }
-  }
-
-  // This edge case shouldn't be an error
-  object moduleRefWithNonModuleRefChild extends TestBaseModule {
-    def aRef = A
-    def a = ModuleRef(A)
-
-    object A extends TestBaseModule {}
-  }
-
   object overrideModule extends TestBaseModule {
     trait Base extends Module {
       lazy val inner: BaseInnerModule = new BaseInnerModule {}
@@ -714,4 +667,54 @@ object TestGraphs {
     }
   }
 
+  object CyclicModuleRefInitError extends TestBaseModule {
+    import mill.Agg
+
+    // See issue: https://github.com/com-lihaoyi/mill/issues/3715
+    trait CommonModule extends TestBaseModule {
+      def moduleDeps: Seq[CommonModule] = Seq.empty
+      def a = myA
+      def b = myB
+    }
+
+    object myA extends A
+    trait A extends CommonModule
+    object myB extends B
+    trait B extends CommonModule {
+      override def moduleDeps = super.moduleDeps ++ Agg(a)
+    }
+  }
+
+  // The module names repeat, but it's not actually cyclic and is meant to confuse the cycle detection.
+  object NonCyclicModules extends TestBaseModule {
+    def foo = Task { "foo" }
+
+    object A extends Module {
+      def b = B
+    }
+    object B extends Module {
+      object A extends Module {
+        def b = B
+      }
+      def a = A
+
+      object B extends Module {
+        object B extends Module {}
+        object A extends Module {
+          def b = B
+        }
+        def a = A
+      }
+    }
+  }
+
+  // This edge case shouldn't be an error
+  object ModuleRefWithNonModuleRefChild extends TestBaseModule {
+    def foo = Task { "foo" }
+
+    def aRef = A
+    def a = ModuleRef(A)
+
+    object A extends TestBaseModule {}
+  }
 }

--- a/scalalib/src/mill/scalalib/internal/ModuleUtils.scala
+++ b/scalalib/src/mill/scalalib/internal/ModuleUtils.scala
@@ -25,7 +25,7 @@ object ModuleUtils {
    * @param deps A function provided the direct dependencies
    * @throws BuildScriptException if there were cycles in the dependencies
    */
-  // FIMXE: Remove or consolidate with copy in ZincModuleImpl
+  // FIMXE: Remove or consolidate with copy in ZincWorkerImpl
   def recursive[T](name: String, start: T, deps: T => Seq[T]): Seq[T] = {
 
     @tailrec def rec(

--- a/scalalib/src/mill/scalalib/internal/ModuleUtils.scala
+++ b/scalalib/src/mill/scalalib/internal/ModuleUtils.scala
@@ -25,7 +25,7 @@ object ModuleUtils {
    * @param deps A function provided the direct dependencies
    * @throws BuildScriptException if there were cycles in the dependencies
    */
-  // FIMXE: Remove or consolidate with copy in ZincWorkerImpl
+  // FIMXE: Remove or consolidate with copy in ZincModuleImpl
   def recursive[T](name: String, start: T, deps: T => Seq[T]): Seq[T] = {
 
     @tailrec def rec(


### PR DESCRIPTION
This completes #3715 with all the cycle cases I could think of.

It also touches `resolveDirectChildren` where I made some changes that I would help with readability. I thought I was going to need to build on those but didn't. These can be reverted if it's unwanted.