### PR TITLE
Share profile loggers between nested evaluations

### DIFF
--- a/integration/feature/full-run-logs/src/FullRunLogsTests.scala
+++ b/integration/feature/full-run-logs/src/FullRunLogsTests.scala
@@ -1,10 +1,12 @@
 package mill.integration
 
+import mill.main.client.OutFiles
 import mill.testkit.UtestIntegrationTestSuite
-import utest._
+import utest.*
 
-// Run simple commands on a simple build and check their entire output,
-// ensuring we don't get spurious warnings or logging messages slipping in
+// Run simple commands on a simple build and check their entire output and some
+// metadata files, ensuring we don't get spurious warnings or logging messages
+// slipping in and the important parts of the logs and output files are present
 object FullRunLogsTests extends UtestIntegrationTestSuite {
 
   def tests: Tests = Tests {
@@ -49,6 +51,21 @@ object FullRunLogsTests extends UtestIntegrationTestSuite {
           .mkString("=? ?[\\d]+")
 
       assert(expectedErrorRegex.r.matches(res.err.replace('\\', '/').replaceAll("(\r\n)|\r", "\n")))
+    }
+    test("show") - integrationTest { tester =>
+      import tester._
+
+      val res = eval(("show", "compile"))
+      val millProfile = ujson.read(os.read(workspacePath / OutFiles.out / "mill-profile.json")).arr
+      val millChromeProfile = ujson.read(os.read(workspacePath / OutFiles.out / "mill-chrome-profile.json")).arr
+      assert(millProfile.exists(_.obj("label").str == "compile"))
+      assert(millProfile.exists(_.obj("label").str == "compileClasspath"))
+      assert(millProfile.exists(_.obj("label").str == "ivyDeps"))
+      assert(millProfile.exists(_.obj("label").str == "javacOptions"))
+      assert(millChromeProfile.exists(_.obj("name").str == "compile"))
+      assert(millChromeProfile.exists(_.obj("name").str == "compileClasspath"))
+      assert(millChromeProfile.exists(_.obj("name").str == "ivyDeps"))
+      assert(millChromeProfile.exists(_.obj("name").str == "javacOptions"))
     }
   }
 }

--- a/integration/feature/full-run-logs/src/FullRunLogsTests.scala
+++ b/integration/feature/full-run-logs/src/FullRunLogsTests.scala
@@ -54,10 +54,14 @@ object FullRunLogsTests extends UtestIntegrationTestSuite {
     }
     test("show") - integrationTest { tester =>
       import tester._
-
-      val res = eval(("show", "compile"))
+      // Make sure when we have nested evaluations, e.g. due to usage of evaluator commands
+      // like `show`, both outer and inner evaluations hae their metadata end up in the
+      // same profile files so a user can see what's going on in either
+      eval(("show", "compile"))
       val millProfile = ujson.read(os.read(workspacePath / OutFiles.out / "mill-profile.json")).arr
-      val millChromeProfile = ujson.read(os.read(workspacePath / OutFiles.out / "mill-chrome-profile.json")).arr
+      val millChromeProfile =
+        ujson.read(os.read(workspacePath / OutFiles.out / "mill-chrome-profile.json")).arr
+      // Profile logs for the thing called by show
       assert(millProfile.exists(_.obj("label").str == "compile"))
       assert(millProfile.exists(_.obj("label").str == "compileClasspath"))
       assert(millProfile.exists(_.obj("label").str == "ivyDeps"))
@@ -66,6 +70,9 @@ object FullRunLogsTests extends UtestIntegrationTestSuite {
       assert(millChromeProfile.exists(_.obj("name").str == "compileClasspath"))
       assert(millChromeProfile.exists(_.obj("name").str == "ivyDeps"))
       assert(millChromeProfile.exists(_.obj("name").str == "javacOptions"))
+      // Profile logs for show itself
+      assert(millProfile.exists(_.obj("label").str == "show"))
+      assert(millChromeProfile.exists(_.obj("name").str == "show"))
     }
   }
 }

--- a/main/eval/src/mill/eval/Evaluator.scala
+++ b/main/eval/src/mill/eval/Evaluator.scala
@@ -67,6 +67,7 @@ trait Evaluator extends AutoCloseable {
     r =>
       new Exception(s"Failure during task evaluation: ${formatFailing(r)}")): Evaluator.EvalOrThrow
 
+  def close() = ()
 }
 
 object Evaluator {

--- a/main/eval/src/mill/eval/Evaluator.scala
+++ b/main/eval/src/mill/eval/Evaluator.scala
@@ -14,7 +14,7 @@ import scala.util.DynamicVariable
 /**
  * Public facing API of the Mill evaluation logic.
  */
-trait Evaluator {
+trait Evaluator extends AutoCloseable {
   def baseLogger: ColorLogger
   def rootModule: BaseModule
   def effectiveThreadCount: Int

--- a/main/eval/src/mill/eval/EvaluatorCore.scala
+++ b/main/eval/src/mill/eval/EvaluatorCore.scala
@@ -20,6 +20,7 @@ private[mill] trait EvaluatorCore extends GroupEvaluator {
   def baseLogger: ColorLogger
   protected[eval] def chromeProfileLogger: ChromeProfileLogger
   protected[eval] def profileLogger: ProfileLogger
+
   /**
    * @param goals The tasks that need to be evaluated
    * @param reporter A function that will accept a module id and provide a listener for build problems in that module
@@ -174,6 +175,11 @@ private[mill] trait EvaluatorCore extends GroupEvaluator {
               cached = res.cached
             )
 
+            mill.main.client.DebugLog.println("")
+            mill.main.client.DebugLog.println("PROFILE LOGGER " + System.identityHashCode(this))
+            mill.main.client.DebugLog.println("PROFILE LOGGER " + outPath)
+            mill.main.client.DebugLog.println("PROFILE LOGGER " + profileLogger)
+            mill.main.client.DebugLog.println("PROFILE LOGGER " + terminal.render)
             profileLogger.log(
               ProfileLogger.Timing(
                 terminal.render,
@@ -234,9 +240,6 @@ private[mill] trait EvaluatorCore extends GroupEvaluator {
       }
 
     val results: Map[Task[_], TaskResult[(Val, Int)]] = results0.toMap
-
-    chromeProfileLogger.close()
-    profileLogger.close()
 
     EvaluatorCore.Results(
       goals.indexed.map(results(_).map(_._1).result),

--- a/main/eval/src/mill/eval/EvaluatorCore.scala
+++ b/main/eval/src/mill/eval/EvaluatorCore.scala
@@ -5,7 +5,7 @@ import mill.api.Strict.Agg
 import mill.api._
 import mill.define._
 import mill.eval.Evaluator.TaskResult
-import mill.main.client.OutFiles._
+
 import mill.util._
 
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
@@ -18,7 +18,8 @@ import scala.concurrent._
 private[mill] trait EvaluatorCore extends GroupEvaluator {
 
   def baseLogger: ColorLogger
-
+  protected[eval] def chromeProfileLogger: ChromeProfileLogger
+  protected[eval] def profileLogger: ProfileLogger
   /**
    * @param goals The tasks that need to be evaluated
    * @param reporter A function that will accept a module id and provide a listener for build problems in that module
@@ -38,11 +39,7 @@ private[mill] trait EvaluatorCore extends GroupEvaluator {
         if (effectiveThreadCount == 1) ExecutionContexts.RunNow
         else new ExecutionContexts.ThreadPool(effectiveThreadCount)
 
-      def contextLoggerMsg(threadId: Int) =
-        if (effectiveThreadCount == 1) ""
-        else s"#${if (effectiveThreadCount > 9) f"$threadId%02d" else threadId} "
-
-      try evaluate0(goals, logger, reporter, testReporter, ec, contextLoggerMsg, serialCommandExec)
+      try evaluate0(goals, logger, reporter, testReporter, ec, serialCommandExec)
       finally ec.close()
     }
   }
@@ -68,12 +65,10 @@ private[mill] trait EvaluatorCore extends GroupEvaluator {
       reporter: Int => Option[CompileProblemReporter] = _ => Option.empty[CompileProblemReporter],
       testReporter: TestReporter = DummyTestReporter,
       ec: mill.api.Ctx.Fork.Impl,
-      contextLoggerMsg0: Int => String,
       serialCommandExec: Boolean
   ): Evaluator.Results = {
     os.makeDir.all(outPath)
-    val chromeProfileLogger = new ChromeProfileLogger(outPath / millChromeProfile)
-    val profileLogger = new ProfileLogger(outPath / millProfile)
+
     val threadNumberer = new ThreadNumberer()
     val (sortedGroups, transitive) = Plan.plan(goals)
     val interGroupDeps = findInterGroupDeps(sortedGroups)

--- a/main/eval/src/mill/eval/EvaluatorCore.scala
+++ b/main/eval/src/mill/eval/EvaluatorCore.scala
@@ -175,11 +175,6 @@ private[mill] trait EvaluatorCore extends GroupEvaluator {
               cached = res.cached
             )
 
-            mill.main.client.DebugLog.println("")
-            mill.main.client.DebugLog.println("PROFILE LOGGER " + System.identityHashCode(this))
-            mill.main.client.DebugLog.println("PROFILE LOGGER " + outPath)
-            mill.main.client.DebugLog.println("PROFILE LOGGER " + profileLogger)
-            mill.main.client.DebugLog.println("PROFILE LOGGER " + terminal.render)
             profileLogger.log(
               ProfileLogger.Timing(
                 terminal.render,

--- a/main/eval/src/mill/eval/EvaluatorImpl.scala
+++ b/main/eval/src/mill/eval/EvaluatorImpl.scala
@@ -38,7 +38,6 @@ private[mill] case class EvaluatorImpl(
 ) extends Evaluator with EvaluatorCore {
   import EvaluatorImpl._
 
-
   val pathsResolver: EvaluatorPathsResolver = EvaluatorPathsResolver.default(outPath)
 
   override def withBaseLogger(newBaseLogger: ColorLogger): Evaluator =
@@ -50,8 +49,6 @@ private[mill] case class EvaluatorImpl(
   override def plan(goals: Agg[Task[_]]): (MultiBiMap[Terminal, Task[_]], Agg[Task[_]]) = {
     Plan.plan(goals)
   }
-
-
 
   override def evaluate(
       goals: Strict.Agg[Task[_]],
@@ -71,52 +68,53 @@ private[mill] case class EvaluatorImpl(
       : Evaluator.EvalOrThrow =
     new EvalOrThrow(this, exceptionFactory)
 
-  override def close() = {
+  override def close(): Unit = {
     chromeProfileLogger.close()
     profileLogger.close()
   }
 }
 
 private[mill] object EvaluatorImpl {
-  def apply(
-             home: os.Path,
-             workspace: os.Path,
-             outPath: os.Path,
-             externalOutPath: os.Path,
-              rootModule: mill.define.BaseModule,
-              baseLogger: ColorLogger,
-              classLoaderSigHash: Int,
-              classLoaderIdentityHash: Int,
-              workerCache: mutable.Map[Segments, (Int, Val)] = mutable.Map.empty,
-              env: Map[String, String] = Evaluator.defaultEnv,
-              failFast: Boolean = true,
-              threadCount: Option[Int] = Some(1),
-              scriptImportGraph: Map[os.Path, (Int, Seq[os.Path])] = Map.empty,
-              methodCodeHashSignatures: Map[String, Int],
-              disableCallgraph: Boolean,
-              allowPositionalCommandArgs: Boolean,
-              systemExit: Int => Nothing,
-              exclusiveSystemStreams: SystemStreams) = new EvaluatorImpl(
+  def make(
+      home: os.Path,
+      workspace: os.Path,
+      outPath: os.Path,
+      externalOutPath: os.Path,
+      rootModule: mill.define.BaseModule,
+      baseLogger: ColorLogger,
+      classLoaderSigHash: Int,
+      classLoaderIdentityHash: Int,
+      workerCache: mutable.Map[Segments, (Int, Val)] = mutable.Map.empty,
+      env: Map[String, String] = Evaluator.defaultEnv,
+      failFast: Boolean = true,
+      threadCount: Option[Int] = Some(1),
+      scriptImportGraph: Map[os.Path, (Int, Seq[os.Path])] = Map.empty,
+      methodCodeHashSignatures: Map[String, Int],
+      disableCallgraph: Boolean,
+      allowPositionalCommandArgs: Boolean,
+      systemExit: Int => Nothing,
+      exclusiveSystemStreams: SystemStreams
+  ) = new EvaluatorImpl(
     home,
-      workspace,
-      outPath,
-      externalOutPath,
-      rootModule,
-      baseLogger,
-      classLoaderSigHash,
-      classLoaderIdentityHash,
-      workerCache,
-      env,
-      failFast,
-      threadCount,
-      scriptImportGraph,
-      methodCodeHashSignatures,
-      disableCallgraph,
-      allowPositionalCommandArgs,
-      systemExit,
-      exclusiveSystemStreams,
-      chromeProfileLogger = new ChromeProfileLogger(outPath / millChromeProfile),
-      profileLogger = new ProfileLogger(outPath / millProfile),
+    workspace,
+    outPath,
+    externalOutPath,
+    rootModule,
+    baseLogger,
+    classLoaderSigHash,
+    classLoaderIdentityHash,
+    workerCache,
+    env,
+    failFast,
+    threadCount,
+    scriptImportGraph,
+    methodCodeHashSignatures,
+    disableCallgraph,
+    allowPositionalCommandArgs,
+    systemExit,
+    exclusiveSystemStreams,
+    chromeProfileLogger = new ChromeProfileLogger(outPath / millChromeProfile),
+    profileLogger = new ProfileLogger(outPath / millProfile)
   )
 
   class EvalOrThrow(evaluator: Evaluator, exceptionFactory: Evaluator.Results => Throwable)

--- a/main/eval/src/mill/eval/EvaluatorImpl.scala
+++ b/main/eval/src/mill/eval/EvaluatorImpl.scala
@@ -4,6 +4,7 @@ import mill.api.{CompileProblemReporter, Strict, SystemStreams, TestReporter, Va
 import mill.api.Strict.Agg
 import mill.define._
 import mill.util._
+import mill.main.client.OutFiles._
 
 import scala.collection.mutable
 import scala.reflect.ClassTag
@@ -22,18 +23,21 @@ private[mill] case class EvaluatorImpl(
     baseLogger: ColorLogger,
     classLoaderSigHash: Int,
     classLoaderIdentityHash: Int,
-    workerCache: mutable.Map[Segments, (Int, Val)] = mutable.Map.empty,
-    env: Map[String, String] = Evaluator.defaultEnv,
-    failFast: Boolean = true,
-    threadCount: Option[Int] = Some(1),
-    scriptImportGraph: Map[os.Path, (Int, Seq[os.Path])] = Map.empty,
+    workerCache: mutable.Map[Segments, (Int, Val)],
+    env: Map[String, String],
+    failFast: Boolean,
+    threadCount: Option[Int],
+    scriptImportGraph: Map[os.Path, (Int, Seq[os.Path])],
     methodCodeHashSignatures: Map[String, Int],
     override val disableCallgraph: Boolean,
     override val allowPositionalCommandArgs: Boolean,
     val systemExit: Int => Nothing,
-    val exclusiveSystemStreams: SystemStreams
+    val exclusiveSystemStreams: SystemStreams,
+    protected[eval] val chromeProfileLogger: ChromeProfileLogger,
+    protected[eval] val profileLogger: ProfileLogger
 ) extends Evaluator with EvaluatorCore {
   import EvaluatorImpl._
+
 
   val pathsResolver: EvaluatorPathsResolver = EvaluatorPathsResolver.default(outPath)
 
@@ -46,6 +50,8 @@ private[mill] case class EvaluatorImpl(
   override def plan(goals: Agg[Task[_]]): (MultiBiMap[Terminal, Task[_]], Agg[Task[_]]) = {
     Plan.plan(goals)
   }
+
+
 
   override def evaluate(
       goals: Strict.Agg[Task[_]],
@@ -64,9 +70,55 @@ private[mill] case class EvaluatorImpl(
   override def evalOrThrow(exceptionFactory: Evaluator.Results => Throwable)
       : Evaluator.EvalOrThrow =
     new EvalOrThrow(this, exceptionFactory)
+
+  override def close() = {
+    chromeProfileLogger.close()
+    profileLogger.close()
+  }
 }
 
 private[mill] object EvaluatorImpl {
+  def apply(
+             home: os.Path,
+             workspace: os.Path,
+             outPath: os.Path,
+             externalOutPath: os.Path,
+              rootModule: mill.define.BaseModule,
+              baseLogger: ColorLogger,
+              classLoaderSigHash: Int,
+              classLoaderIdentityHash: Int,
+              workerCache: mutable.Map[Segments, (Int, Val)] = mutable.Map.empty,
+              env: Map[String, String] = Evaluator.defaultEnv,
+              failFast: Boolean = true,
+              threadCount: Option[Int] = Some(1),
+              scriptImportGraph: Map[os.Path, (Int, Seq[os.Path])] = Map.empty,
+              methodCodeHashSignatures: Map[String, Int],
+              disableCallgraph: Boolean,
+              allowPositionalCommandArgs: Boolean,
+              systemExit: Int => Nothing,
+              exclusiveSystemStreams: SystemStreams) = new EvaluatorImpl(
+    home,
+      workspace,
+      outPath,
+      externalOutPath,
+      rootModule,
+      baseLogger,
+      classLoaderSigHash,
+      classLoaderIdentityHash,
+      workerCache,
+      env,
+      failFast,
+      threadCount,
+      scriptImportGraph,
+      methodCodeHashSignatures,
+      disableCallgraph,
+      allowPositionalCommandArgs,
+      systemExit,
+      exclusiveSystemStreams,
+      chromeProfileLogger = new ChromeProfileLogger(outPath / millChromeProfile),
+      profileLogger = new ProfileLogger(outPath / millProfile),
+  )
+
   class EvalOrThrow(evaluator: Evaluator, exceptionFactory: Evaluator.Results => Throwable)
       extends Evaluator.EvalOrThrow {
     def apply[T: ClassTag](task: Task[T]): T =

--- a/main/eval/src/mill/eval/JsonArrayLogger.scala
+++ b/main/eval/src/mill/eval/JsonArrayLogger.scala
@@ -35,7 +35,7 @@ private class JsonArrayLogger[T: upickle.default.Writer](outPath: os.Path, inden
   }
 }
 
-private class ProfileLogger(outPath: os.Path)
+private[eval] class ProfileLogger(outPath: os.Path)
     extends JsonArrayLogger[ProfileLogger.Timing](outPath, indent = 2)
 
 private object ProfileLogger {
@@ -53,7 +53,7 @@ private object ProfileLogger {
   }
 }
 
-private class ChromeProfileLogger(outPath: os.Path)
+private[eval] class ChromeProfileLogger(outPath: os.Path)
     extends JsonArrayLogger[ChromeProfileLogger.TraceEvent](outPath, indent = -1) {
 
   def log(

--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -70,6 +70,9 @@ class MillBuildBootstrap(
   }
 
   def evaluateRec(depth: Int): RunnerState = {
+    mill.main.client.DebugLog.println(
+      "MillBuildBootstrap.evaluateRec " + depth + " " + targetsAndParams.mkString(" ")
+    )
     // println(s"+evaluateRec($depth) " + recRoot(projectRoot, depth))
     val prevFrameOpt = prevRunnerState.frames.lift(depth)
     val prevOuterFrameOpt = prevRunnerState.frames.lift(depth - 1)
@@ -177,8 +180,7 @@ class MillBuildBootstrap(
             .getOrElse(0),
           depth,
           actualBuildFileName = nestedState.buildFile
-        )){ evaluator =>
-
+        )) { evaluator =>
           if (depth != 0) {
             val retState = processRunClasspath(
               nestedState,
@@ -344,7 +346,7 @@ class MillBuildBootstrap(
           .mkString("/")
       )
 
-    mill.eval.EvaluatorImpl(
+    mill.eval.EvaluatorImpl.make(
       home,
       projectRoot,
       recOut(output, depth),

--- a/testkit/src/mill/testkit/IntegrationTester.scala
+++ b/testkit/src/mill/testkit/IntegrationTester.scala
@@ -3,6 +3,7 @@ package mill.testkit
 import mill.main.client.EnvVars.MILL_TEST_SUITE
 import mill.define.Segments
 import mill.eval.Evaluator
+import mill.main.client.OutFiles
 import mill.resolve.SelectMode
 import ujson.Value
 
@@ -110,7 +111,7 @@ object IntegrationTester {
           mill.resolve.ParseArgs.apply(Seq(selector0), SelectMode.Separated).getOrElse(???)
 
         val segments = selector._2.getOrElse(Segments()).value.flatMap(_.pathSegments)
-        os.read(workspacePath / "out" / segments.init / s"${segments.last}.json")
+        os.read(workspacePath / OutFiles.out / segments.init / s"${segments.last}.json")
       }
 
       /**

--- a/testkit/src/mill/testkit/UnitTester.scala
+++ b/testkit/src/mill/testkit/UnitTester.scala
@@ -86,7 +86,7 @@ class UnitTester(
     override def debug(s: String): Unit = super.debug(s"${prefix}: ${s}")
     override def ticker(s: String): Unit = super.ticker(s"${prefix}: ${s}")
   }
-  val evaluator: EvaluatorImpl = mill.eval.EvaluatorImpl(
+  val evaluator: EvaluatorImpl = mill.eval.EvaluatorImpl.make(
     mill.api.Ctx.defaultHome,
     module.millSourcePath,
     outPath,

--- a/testkit/src/mill/testkit/UnitTester.scala
+++ b/testkit/src/mill/testkit/UnitTester.scala
@@ -192,5 +192,6 @@ class UnitTester(
     for (case (_, Val(obsolete: AutoCloseable)) <- evaluator.workerCache.values) {
       obsolete.close()
     }
+    evaluator.close()
   }
 }


### PR DESCRIPTION
We broaden the scope of `profileLogger`/`chromeProfileLogger` from within `def evaluate` to instead last as long as the `Evaluator` itself, and share it with any sub-`Evaluator`s created e.g. to redirect output during `show`

`Evaluator` is now `AutoCloseable`, and needs to be closed after being used in `MillBuildBootstrap` and in `UnitTester`

For now I decided not to share the profilers between different evaluation levels of the meta-build, since they already don't overlap: one goes to `out/`, the parent to `out/mill-build/`, etc. We could do that if we think it would be useful to give people a consolidated profile, but it might be a bit more work (e.g. we would need to properly prefix entries in the profile to distinguish the different meta levels).

Added a unit test to ensure the `show compile` mill-profile and mill-chrome-profile contain the expected keys for both `show` and for `compile` and some of its upstream tasks

Fixes https://github.com/com-lihaoyi/mill/issues/3879