### PR TITLE
Add `arrow-kt` example

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -74,6 +74,8 @@ jobs:
             millargs: "'example.thirdparty[{mockito,acyclic,commons-io}].local.testCached'"
           - java-version: 17
             millargs: "'example.thirdparty[{fansi,jimfs,netty,gatling}].local.testCached'"
+          - java-version: '17'
+            millargs: "'example.thirdparty[arrow].local.testCached'"
           - java-version: '11'
             millargs: "'example.{depth,extending}.__.local.testCached'"
 

--- a/example/package.mill
+++ b/example/package.mill
@@ -240,7 +240,8 @@ object `package` extends RootModule with Module {
     "commons-io" -> ("apache/commons-io", "b91a48074231ef813bc9b91a815d77f6343ff8f0"),
     "netty" -> ("netty/netty", "20a790ed362a3c11e0e990b58598e4ac6aa88bef"),
     "mockito" -> ("mockito/mockito", "97f3574cc07fdf36f1f76ba7332ac57675e140b1"),
-    "gatling" -> ("gatling/gatling", "3870fda86e6bca005fbd53108c60a65db36279b6")
+    "gatling" -> ("gatling/gatling", "3870fda86e6bca005fbd53108c60a65db36279b6"),
+    "arrow" -> ("arrow-kt/arrow", "bc9bf92cc98e01c21bdd2bf8640cf7db0f97204a")
   )
   object thirdparty extends Cross[ThirdPartyModule](build.listIn(millSourcePath / "thirdparty"))
   trait ThirdPartyModule extends ExampleCrossModule {

--- a/example/thirdparty/arrow/build.mill
+++ b/example/thirdparty/arrow/build.mill
@@ -127,18 +127,11 @@ object `package` extends RootModule {
       s"-Xcommon-sources=${files.mkString(",")}"
     }
 
-    trait ArrowPlatformModule extends KotlinMavenModule {  outer =>
+    trait ArrowPlatformModule extends KotlinMavenModule with PlatformKotlinModule {  outer =>
       def kotlinVersion = libraries.versions.kotlin
       def kotlinLanguageVersion = majorVersion(kotlinVersion())
       def kotlinApiVersion = majorVersion(kotlinVersion())
       def kotlinExplicitApi = ArrowMultiplatformModule.this.kotlinExplicitApi
-
-      def platformCrossSuffix: String = millModuleSegments
-        .value
-        .collect { case l: mill.define.Segment.Label => l.value }
-        .last
-
-      override def millSourcePath = super.millSourcePath / os.up
 
       override def sources: T[Seq[PathRef]] = Task.Sources {
         val sourcesRootPath = millSourcePath / "src"

--- a/example/thirdparty/arrow/build.mill
+++ b/example/thirdparty/arrow/build.mill
@@ -154,7 +154,9 @@ object `package` extends RootModule {
         sources
       }
 
-      override def kotlincOptions = super.kotlincOptions() ++ Seq("-Xexpect-actual-classes")
+      override def kotlincOptions =
+        super.kotlincOptions() ++
+        Seq("-Xexpect-actual-classes", commonSourcesArg(sources(), "commonMain"))
 
       trait ArrowPlatformTests extends KotlinMavenTests{
 
@@ -178,7 +180,6 @@ object `package` extends RootModule {
     def jvm: ArrowPlatformJvmModule
 
     trait ArrowPlatformJvmModule extends ArrowPlatformModule with KoverModule {
-      def kotlincOptions = super.kotlincOptions() ++ Seq(commonSourcesArg(sources(), "commonMain"))
       def test: ArrowPlatformJvmTests
       trait ArrowPlatformJvmTests extends KotlinMavenTests with  KoverTests with TestModule.Junit5  with ArrowPlatformTests{
       }
@@ -186,9 +187,7 @@ object `package` extends RootModule {
 
     def js: ArrowPlatformJsModule
     trait ArrowPlatformJsModule extends ArrowPlatformModule with KotlinJsModule {
-      def kotlincOptions = super.kotlincOptions() ++ Seq(
-        commonSourcesArg(sources(), "commonMain")
-      )
+
       def kotlinJsRunTarget = Some(RunTarget.Node)
 
       def test: ArrowPlatformJsTests
@@ -465,7 +464,7 @@ object `package` extends RootModule {
               libraries.kotestAssertionsCoreJs,
               libraries.kotestPropertyJs
             )
-            def testTimeout = 60_000L
+            def testTimeout = 120_000L
           }
         }
 

--- a/example/thirdparty/arrow/build.mill
+++ b/example/thirdparty/arrow/build.mill
@@ -112,15 +112,8 @@ object `package` extends RootModule {
   // TODO add more targets once available
   trait ArrowMultiplatformModule extends CoursierModule { multiplatformRoot =>
 
-    def jsTestModuleDeps: Seq[KotlinJsModule] = Nil
-    def jvmTestModuleDeps: Seq[KotlinModule] = Nil
-    def jsTestIvyDeps: T[Agg[Dep]] = Agg.empty[Dep]
-    def jvmTestIvyDeps: T[Agg[Dep]] = Agg.empty[Dep]
 
-    def jsTestKotlincOptions: T[Seq[String]] = Seq.empty[String]
-    def jvmTestKotlincOptions: T[Seq[String]] = Seq.empty[String]
 
-    def jsTestTimeout: T[Long] = 30_000L
 
     def explicitApi: T[Boolean] = true
 
@@ -172,13 +165,9 @@ object `package` extends RootModule {
 
     def jvm: ArrowPlatformJvmModule
     trait ArrowPlatformJvmModule extends ArrowPlatformModule with KoverModule { outer =>
-      def kotlincOptions = super.kotlincOptions() ++ Seq(
-        commonSourcesArg(sources(), "commonMain")
-      )
-      object test extends KotlinTests with KoverTests with TestModule.Junit5 {
-        def ivyDeps = super.ivyDeps() ++ jvmTestIvyDeps()
-        def moduleDeps = super.moduleDeps ++ jvmTestModuleDeps
-        def kotlincOptions = super.kotlincOptions() ++ jvmTestKotlincOptions()
+      def kotlincOptions = super.kotlincOptions() ++ Seq(commonSourcesArg(sources(), "commonMain"))
+      def test: ArrowPlatformJvmTests
+      trait ArrowPlatformJvmTests extends KotlinTests with KoverTests with TestModule.Junit5 {
         override def sources: T[Seq[PathRef]] = Task.Sources {
           val sourcesRootPath = outer.millSourcePath / "src"
           Seq("common", outer.platformCrossSuffix)
@@ -204,11 +193,9 @@ object `package` extends RootModule {
       )
       def kotlinJsRunTarget = Some(RunTarget.Node)
 
-      object test extends KotlinTestPackageTests {
-        def ivyDeps = super.ivyDeps() ++ jsTestIvyDeps()
-        def moduleDeps = super.moduleDeps ++ jsTestModuleDeps
-        def kotlincOptions = super.kotlincOptions() ++ jsTestKotlincOptions()
-        def testTimeout = jsTestTimeout
+      def test: ArrowPlatformJsTests
+      trait ArrowPlatformJsTests extends KotlinTestPackageTests {
+        def testTimeout = 30_000L
         override def sources: T[Seq[PathRef]] = Task.Sources {
           val sourcesRootPath = outer.millSourcePath / "src"
           Seq("common", outer.platformCrossSuffix)
@@ -230,12 +217,6 @@ object `package` extends RootModule {
 
   trait ArrowJvmModule extends KotlinModule with KoverModule { jvmRoot =>
 
-    def testModuleDeps: Seq[KotlinModule] = Nil
-    def testRunModuleDeps: Seq[KotlinModule] = Nil
-    def testIvyDeps: T[Agg[Dep]] = Agg.empty[Dep]
-    def testCompileIvyDeps: T[Agg[Dep]] = Agg.empty[Dep]
-    def testKotlincOptions: T[Seq[String]] = Seq.empty[String]
-
     def kotlinVersion = libraries.versions.kotlin
     def explicitApi = true
     def languageVersion = majorVersion(kotlinVersion())
@@ -247,19 +228,14 @@ object `package` extends RootModule {
     override def resources: T[Seq[PathRef]] = Task.Sources {
       millSourcePath / "src" / "main" / "resources"
     }
-
-    object test extends KotlinTests with KoverTests with TestModule.Junit5 {
+    def test: ArrowJvmTests
+    trait ArrowJvmTests extends KotlinTests with KoverTests with TestModule.Junit5 {
       override def sources: T[Seq[PathRef]] = Task.Sources {
         millSourcePath / os.up / "src" / "test" / "kotlin"
       }
       override def resources: T[Seq[PathRef]] = Task.Sources {
         millSourcePath / os.up / "src" / "test" / "resources"
       }
-      def moduleDeps = super.moduleDeps ++ testModuleDeps
-      def runModuleDeps = super.runModuleDeps ++ testRunModuleDeps
-      def ivyDeps = super.ivyDeps() ++ testIvyDeps()
-      def compileIvyDeps = super.compileIvyDeps() ++ testCompileIvyDeps()
-      def kotlincOptions = super.kotlincOptions() ++ testKotlincOptions()
       override def compile: T[CompilationResult] = if (!modulesWithTestingEnabled.contains(jvmRoot))
         Task { CompilationResult(T.dest, PathRef(T.dest)) }
       else super.compile
@@ -273,68 +249,88 @@ object `package` extends RootModule {
   object `arrow-libs` extends Module {
     object core extends Module {
       object `arrow-annotations` extends ArrowMultiplatformModule{
-        object jvm extends ArrowPlatformJvmModule
-        object js extends ArrowPlatformJsModule
+        object jvm extends ArrowPlatformJvmModule{
+          object test extends ArrowPlatformJvmTests
+        }
+        object js extends ArrowPlatformJsModule{
+          object test extends ArrowPlatformJsTests
+        }
       }
       object `arrow-atomic` extends ArrowMultiplatformModule {
-        object jvm extends ArrowPlatformJvmModule
-        object js extends ArrowPlatformJsModule
-        def jvmTestModuleDeps = Seq(fx.`arrow-fx-coroutines`.jvm)
-        def jvmTestIvyDeps = Agg(
-          libraries.kotlinTestJunit5,
-          libraries.coroutinesTestJvm,
-          libraries.kotestAssertionsCoreJvm,
-          libraries.kotestPropertyJvm
-        )
-        def jsTestModuleDeps = Seq(fx.`arrow-fx-coroutines`.js)
-        def jsTestIvyDeps = Agg(
-          libraries.coroutinesTestJs,
-          libraries.kotestAssertionsCoreJs,
-          libraries.kotestPropertyJs
-        )
+        object jvm extends ArrowPlatformJvmModule{
+          object test extends ArrowPlatformJvmTests{
+            def moduleDeps = super.moduleDeps ++ Seq(fx.`arrow-fx-coroutines`.jvm)
+            def ivyDeps = super.ivyDeps() ++ Agg(
+              libraries.kotlinTestJunit5,
+              libraries.coroutinesTestJvm,
+              libraries.kotestAssertionsCoreJvm,
+              libraries.kotestPropertyJvm
+            )
+          }
+        }
+        object js extends ArrowPlatformJsModule{
+          object test extends ArrowPlatformJsTests{
+            def moduleDeps = super.moduleDeps ++ Seq(fx.`arrow-fx-coroutines`.js)
+            def ivyDeps = super.ivyDeps() ++ Agg(
+              libraries.coroutinesTestJs,
+              libraries.kotestAssertionsCoreJs,
+              libraries.kotestPropertyJs
+            )
+          }
+        }
+
+
+
       }
       object `arrow-autoclose` extends ArrowMultiplatformModule {
         object jvm extends ArrowPlatformJvmModule{
           def moduleDeps = super.moduleDeps ++ Seq(`arrow-atomic`.jvm)
+          object test extends ArrowPlatformJvmTests{
+            def moduleDeps = super.moduleDeps ++ Seq(fx.`arrow-fx-coroutines`.jvm)
+            def ivyDeps = super.ivyDeps() ++ Agg(
+              libraries.kotlinTestJunit5,
+              libraries.coroutinesTestJvm,
+              libraries.kotestAssertionsCoreJvm
+            )
+            def kotlincOptions = super.kotlincOptions() ++ Seq("-Xcontext-receivers")
+          }
         }
         object js extends ArrowPlatformJsModule{
           def moduleDeps = super.moduleDeps ++ Seq(`arrow-atomic`.js)
+          object test extends ArrowPlatformJsTests{
+            def moduleDeps = super.moduleDeps ++ Seq(fx.`arrow-fx-coroutines`.js)
+            def ivyDeps = super.ivyDeps() ++ Agg(
+              libraries.coroutinesTestJs,
+              libraries.kotestAssertionsCoreJs
+            )
+          }
         }
-
-        def jvmTestModuleDeps = Seq(fx.`arrow-fx-coroutines`.jvm)
-        def jvmTestIvyDeps = Agg(
-          libraries.kotlinTestJunit5,
-          libraries.coroutinesTestJvm,
-          libraries.kotestAssertionsCoreJvm
-        )
-        def jvmTestKotlincOptions = Seq("-Xcontext-receivers")
-        def jsTestModuleDeps = Seq(fx.`arrow-fx-coroutines`.js)
-        def jsTestIvyDeps = Agg(
-          libraries.coroutinesTestJs,
-          libraries.kotestAssertionsCoreJs
-        )
       }
+
       object `arrow-cache4k` extends ArrowMultiplatformModule {
         object jvm extends ArrowPlatformJvmModule{
           def moduleDeps = super.moduleDeps ++ Seq(`arrow-core`.jvm)
           def ivyDeps = super.ivyDeps() ++ Agg(libraries.cache4kJvm)
+          object test extends ArrowPlatformJvmTests
         }
         object js extends ArrowPlatformJsModule{
           def moduleDeps = super.moduleDeps ++ Seq(`arrow-core`.js)
           def ivyDeps = super.ivyDeps() ++ Agg(libraries.cache4kJs)
+          object test extends ArrowPlatformJsTests
         }
-
-
       }
+
       object `arrow-core-high-arity` extends ArrowMultiplatformModule {
         object jvm extends ArrowPlatformJvmModule{
           def moduleDeps = super.moduleDeps ++ Seq(`arrow-core`.jvm)
+          object test extends ArrowPlatformJvmTests
         }
         object js extends ArrowPlatformJsModule{
           def moduleDeps = super.moduleDeps ++ Seq(`arrow-core`.js)
+          object test extends ArrowPlatformJsTests
         }
-
       }
+
       object `arrow-core-retrofit` extends ArrowJvmModule {
         def moduleDeps = Seq(`arrow-core`.jvm)
         def compileIvyDeps = Agg(libraries.squareupRetrofitLib)
@@ -342,124 +338,136 @@ object `package` extends RootModule {
           defaultResolver().resolveDeps(Agg(libraries.kotlinxSerializationPlugin))
         }
 
-        def testKotlincOptions = Seq(s"-Xplugin=${processors().head.path}")
-        def testModuleDeps = Seq(`arrow-core`.jvm)
-        def testIvyDeps = Agg(
-          libraries.kotlinTestJunit5,
-          libraries.coroutinesTestJvm,
-          libraries.kotestAssertionsCoreJvm,
-          libraries.kotestPropertyJvm,
-          libraries.squareupOkhttpMockWebServer,
-          libraries.squareupRetrofitConverterGson,
-          libraries.squareupRetrofitConverterMoshi,
-          libraries.kotlinxSerializationJson,
-          libraries.squareupRetrofitConverterKotlinxSerialization,
-          libraries.squareupMoshiKotlin
-        )
+        object test extends ArrowJvmTests{
+          def kotlincOptions = super.kotlincOptions() ++ Seq(s"-Xplugin=${processors().head.path}")
+          def moduleDeps = super.moduleDeps ++ Seq(`arrow-core`.jvm)
+          def ivyDeps = super.ivyDeps() ++ Agg(
+            libraries.kotlinTestJunit5,
+            libraries.coroutinesTestJvm,
+            libraries.kotestAssertionsCoreJvm,
+            libraries.kotestPropertyJvm,
+            libraries.squareupOkhttpMockWebServer,
+            libraries.squareupRetrofitConverterGson,
+            libraries.squareupRetrofitConverterMoshi,
+            libraries.kotlinxSerializationJson,
+            libraries.squareupRetrofitConverterKotlinxSerialization,
+            libraries.squareupMoshiKotlin
+          )
+        }
       }
       object `arrow-core-serialization` extends ArrowMultiplatformModule {
         object jvm extends ArrowPlatformJvmModule{
           def moduleDeps = super.moduleDeps ++ Seq(`arrow-core`.jvm)
           def ivyDeps = super.ivyDeps() ++ Agg(libraries.kotlinxSerializationCoreJvm)
+          object test extends ArrowPlatformJvmTests{
+            def ivyDeps = super.ivyDeps() ++ Agg(
+              libraries.kotlinTestJunit5,
+              libraries.kotlinxSerializationJson,
+              libraries.coroutinesTestJvm,
+              libraries.kotestAssertionsCoreJvm,
+              libraries.kotestPropertyJvm
+            )
+            def kotlincOptions = super.kotlincOptions() ++ Seq(s"-Xplugin=${processors().head.path}")
+          }
         }
         object js extends ArrowPlatformJsModule{
           def moduleDeps = super.moduleDeps ++ Seq(`arrow-core`.js)
           def ivyDeps = super.ivyDeps() ++ Agg(libraries.kotlinxSerializationCoreJs)
+          object test extends ArrowPlatformJsTests{
+            def ivyDeps = super.ivyDeps() ++ Agg(
+              libraries.kotlinxSerializationJsonJs,
+              libraries.coroutinesTestJs,
+              libraries.kotestAssertionsCoreJs,
+              libraries.kotestPropertyJs
+            )
+            def kotlincOptions = super.kotlincOptions() ++ Seq(s"-Xplugin=${processors().head.path}")
+            def testTimeout = 60_000L
+          }
         }
-
-
-        def jvmTestIvyDeps = Agg(
-          libraries.kotlinTestJunit5,
-          libraries.kotlinxSerializationJson,
-          libraries.coroutinesTestJvm,
-          libraries.kotestAssertionsCoreJvm,
-          libraries.kotestPropertyJvm
-        )
-
-
-        def jsTestIvyDeps = Agg(
-          libraries.kotlinxSerializationJsonJs,
-          libraries.coroutinesTestJs,
-          libraries.kotestAssertionsCoreJs,
-          libraries.kotestPropertyJs
-        )
 
         def processors = Task {
           defaultResolver().resolveDeps(Agg(libraries.kotlinxSerializationPlugin))
         }
-        def jsTestKotlincOptions = Seq(s"-Xplugin=${processors().head.path}")
-        def jvmTestKotlincOptions = Seq(s"-Xplugin=${processors().head.path}")
-        def jsTestTimeout = 60_000L
       }
+
       object `arrow-core` extends ArrowMultiplatformModule {
         object jvm extends ArrowPlatformJvmModule{
           def moduleDeps = super.moduleDeps ++ Seq(`arrow-atomic`.jvm, `arrow-annotations`.jvm)
           def ivyDeps = super.ivyDeps() ++ Agg(libraries.kotlinxSerializationCoreJvm)
           def kotlincOptions = super.kotlincOptions() ++ Seq("-Xcontext-receivers")
+          object test extends ArrowPlatformJvmTests{
+            def moduleDeps = super.moduleDeps ++ Seq(fx.`arrow-fx-coroutines`.jvm)
+
+            def ivyDeps = super.ivyDeps() ++ Agg(
+              libraries.kotlinTestJunit5,
+              libraries.coroutinesTestJvm,
+              libraries.kotestAssertionsCoreJvm,
+              libraries.kotestPropertyJvm
+            )
+          }
         }
         object js extends ArrowPlatformJsModule{
           def moduleDeps = super.moduleDeps ++ Seq(`arrow-atomic`.js, `arrow-annotations`.js)
           def ivyDeps = super.ivyDeps() ++ Agg(libraries.kotlinxSerializationCoreJs)
+          object test extends ArrowPlatformJsTests {
+            def moduleDeps = super.moduleDeps ++ Seq(fx.`arrow-fx-coroutines`.js)
+            def ivyDeps = super.ivyDeps() ++ Agg(
+              libraries.coroutinesTestJs,
+              libraries.kotestAssertionsCoreJs,
+              libraries.kotestPropertyJs
+            )
+            def testTimeout = 300_000L
+          }
         }
-
-
-        def jvmTestModuleDeps = Seq(fx.`arrow-fx-coroutines`.jvm)
-        def jvmTestIvyDeps = Agg(
-          libraries.kotlinTestJunit5,
-          libraries.coroutinesTestJvm,
-          libraries.kotestAssertionsCoreJvm,
-          libraries.kotestPropertyJvm
-        )
-
-        def jsTestModuleDeps = Seq(fx.`arrow-fx-coroutines`.js)
-        def jsTestIvyDeps = Agg(
-          libraries.coroutinesTestJs,
-          libraries.kotestAssertionsCoreJs,
-          libraries.kotestPropertyJs
-        )
-        def jsTestTimeout = 300_000L
       }
+
       object `arrow-eval` extends ArrowMultiplatformModule {
         object jvm extends ArrowPlatformJvmModule{
           def moduleDeps = super.moduleDeps ++ Seq(`arrow-core`.jvm)
+          object test extends ArrowPlatformJvmTests{
+            def ivyDeps = super.ivyDeps() ++ Agg(
+              libraries.kotlinTestJunit5,
+              libraries.kotestAssertionsCoreJvm,
+              libraries.kotestPropertyJvm
+            )
+          }
         }
         object js extends ArrowPlatformJsModule{
           def moduleDeps = super.moduleDeps ++ Seq(`arrow-core`.js)
+          object test extends ArrowPlatformJsTests{
+            def ivyDeps = super.ivyDeps() ++ Agg(
+              libraries.kotestAssertionsCoreJs,
+              libraries.kotestPropertyJs
+            )
+          }
         }
-
-
-        def jvmTestIvyDeps = Agg(
-          libraries.kotlinTestJunit5,
-          libraries.kotestAssertionsCoreJvm,
-          libraries.kotestPropertyJvm
-        )
-        def jsTestIvyDeps = Agg(
-          libraries.kotestAssertionsCoreJs,
-          libraries.kotestPropertyJs
-        )
       }
+
       object `arrow-functions` extends ArrowMultiplatformModule {
         object jvm extends ArrowPlatformJvmModule{
           def moduleDeps = super.moduleDeps ++ Seq(`arrow-atomic`.jvm, `arrow-annotations`.jvm)
+          object test extends ArrowPlatformJvmTests{
+            def moduleDeps = super.moduleDeps ++ Seq(fx.`arrow-fx-coroutines`.jvm)
+
+            def ivyDeps = super.ivyDeps() ++ Agg(
+              libraries.kotlinTestJunit5,
+              libraries.coroutinesTestJvm,
+              libraries.kotestAssertionsCoreJvm,
+              libraries.kotestPropertyJvm
+            )
+          }
         }
         object js extends ArrowPlatformJsModule{
           def moduleDeps = super.moduleDeps ++ Seq(`arrow-atomic`.js, `arrow-annotations`.js)
+          object test extends ArrowPlatformJsTests{
+            def moduleDeps = super.moduleDeps ++ Seq(fx.`arrow-fx-coroutines`.js)
+            def ivyDeps = super.ivyDeps() ++ Agg(
+              libraries.coroutinesTestJs,
+              libraries.kotestAssertionsCoreJs,
+              libraries.kotestPropertyJs
+            )
+          }
         }
-
-
-        def jvmTestModuleDeps = Seq(fx.`arrow-fx-coroutines`.jvm)
-        def jvmTestIvyDeps = Agg(
-          libraries.kotlinTestJunit5,
-          libraries.coroutinesTestJvm,
-          libraries.kotestAssertionsCoreJvm,
-          libraries.kotestPropertyJvm
-        )
-        def jsTestModuleDeps = Seq(fx.`arrow-fx-coroutines`.js)
-        def jsTestIvyDeps = Agg(
-          libraries.coroutinesTestJs,
-          libraries.kotestAssertionsCoreJs,
-          libraries.kotestPropertyJs
-        )
       }
     }
 
@@ -468,78 +476,99 @@ object `package` extends RootModule {
         object jvm extends ArrowPlatformJvmModule{
           def moduleDeps = super.moduleDeps ++ Seq(core.`arrow-atomic`.jvm, `arrow-fx-coroutines`.jvm)
           def ivyDeps = super.ivyDeps() ++ Agg(libraries.coroutinesCoreJvm)
+          object test extends ArrowPlatformJvmTests{
+            def ivyDeps = super.ivyDeps() ++ Agg(
+              libraries.kotlinTestJunit5,
+              libraries.coroutinesTestJvm,
+              libraries.kotestAssertionsCoreJvm,
+              libraries.kotestPropertyJvm
+            )
+          }
         }
         object js extends ArrowPlatformJsModule{
           def moduleDeps = super.moduleDeps ++ Seq(core.`arrow-atomic`.js, `arrow-fx-coroutines`.js)
           def ivyDeps = super.ivyDeps() ++ Agg(libraries.coroutinesCoreJs)
+          object test extends ArrowPlatformJsTests{
+            def ivyDeps = super.ivyDeps() ++ Agg(
+              libraries.coroutinesTestJs,
+              libraries.kotestAssertionsCoreJs,
+              libraries.kotestPropertyJs
+            )
+            def testTimeout = 60_000L
+          }
         }
 
-        def jvmTestIvyDeps = Agg(
-          libraries.kotlinTestJunit5,
-          libraries.coroutinesTestJvm,
-          libraries.kotestAssertionsCoreJvm,
-          libraries.kotestPropertyJvm
-        )
-        def jsTestIvyDeps = Agg(
-          libraries.coroutinesTestJs,
-          libraries.kotestAssertionsCoreJs,
-          libraries.kotestPropertyJs
-        )
 
-        def jsTestTimeout = 60_000L
       }
       object `arrow-fx-coroutines` extends ArrowMultiplatformModule {
         object jvm extends ArrowPlatformJvmModule{
           def moduleDeps = super.moduleDeps ++ Seq(core.`arrow-core`.jvm, core.`arrow-autoclose`.jvm)
           def ivyDeps = super.ivyDeps() ++ Agg(libraries.coroutinesCoreJvm)
+          object test extends ArrowPlatformJvmTests{
+            def moduleDeps = super.moduleDeps ++ Seq(core.`arrow-core`.jvm, core.`arrow-atomic`.jvm)
+
+
+            def ivyDeps = super.ivyDeps() ++ Agg(
+              libraries.kotlinTestJunit5,
+              libraries.coroutinesTestJvm,
+              libraries.kotestAssertionsCoreJvm,
+              libraries.kotestPropertyJvm
+            )
+          }
         }
         object js extends ArrowPlatformJsModule{
           def moduleDeps = super.moduleDeps ++ Seq(core.`arrow-core`.js, core.`arrow-autoclose`.js)
           def ivyDeps = super.ivyDeps() ++ Agg(libraries.coroutinesCoreJs)
+          object test extends ArrowPlatformJsTests{
+            def moduleDeps = super.moduleDeps ++ Seq(core.`arrow-core`.js, core.`arrow-atomic`.js)
+            def ivyDeps = super.ivyDeps() ++ Agg(
+              libraries.coroutinesTestJs,
+              libraries.kotestAssertionsCoreJs,
+              libraries.kotestPropertyJs
+            )
+            def testTimeout = 60_000L
+          }
         }
 
-        def jvmTestModuleDeps = Seq(core.`arrow-core`.jvm, core.`arrow-atomic`.jvm)
-        def jsTestModuleDeps = Seq(core.`arrow-core`.js, core.`arrow-atomic`.js)
-        def jvmTestIvyDeps = Agg(
-          libraries.kotlinTestJunit5,
-          libraries.coroutinesTestJvm,
-          libraries.kotestAssertionsCoreJvm,
-          libraries.kotestPropertyJvm
-        )
-        def jsTestIvyDeps = Agg(
-          libraries.coroutinesTestJs,
-          libraries.kotestAssertionsCoreJs,
-          libraries.kotestPropertyJs
-        )
-        def jsTestTimeout = 60_000L
+
+
+
       }
       object `arrow-fx-stm` extends ArrowMultiplatformModule {
         object jvm extends ArrowPlatformJvmModule{
           def moduleDeps = super.moduleDeps ++ Seq(core.`arrow-core`.jvm)
           def ivyDeps = super.ivyDeps() ++ Agg(libraries.coroutinesCoreJvm)
           def kotlincOptions = super.kotlincOptions() ++ additionalKotlincOptions
+          object test extends ArrowPlatformJvmTests{
+            def moduleDeps = super.moduleDeps ++ Seq(`arrow-fx-coroutines`.jvm)
+            def ivyDeps = super.ivyDeps() ++ Agg(
+              libraries.kotlinTestJunit5,
+              libraries.coroutinesTestJvm,
+              libraries.kotestAssertionsCoreJvm,
+              libraries.kotestPropertyJvm
+            )
+          }
         }
         object js extends ArrowPlatformJsModule{
           def moduleDeps = super.moduleDeps ++ Seq(core.`arrow-core`.js)
           def ivyDeps = super.ivyDeps() ++ Agg(libraries.coroutinesCoreJs)
           def kotlincOptions = super.kotlincOptions() ++ additionalKotlincOptions
+          object test extends ArrowPlatformJsTests{
+            def moduleDeps = super.moduleDeps ++ Seq(`arrow-fx-coroutines`.js)
+
+
+
+            def ivyDeps = super.ivyDeps() ++ Agg(
+              libraries.coroutinesTestJs,
+              libraries.kotestAssertionsCoreJs,
+              libraries.kotestPropertyJs
+            )
+            def testTimeout = 60_000L
+          }
         }
         val additionalKotlincOptions = Seq("-Xconsistent-data-class-copy-visibility")
 
-        def jvmTestModuleDeps = Seq(`arrow-fx-coroutines`.jvm)
-        def jsTestModuleDeps = Seq(`arrow-fx-coroutines`.js)
-        def jvmTestIvyDeps = Agg(
-          libraries.kotlinTestJunit5,
-          libraries.coroutinesTestJvm,
-          libraries.kotestAssertionsCoreJvm,
-          libraries.kotestPropertyJvm
-        )
-        def jsTestIvyDeps = Agg(
-          libraries.coroutinesTestJs,
-          libraries.kotestAssertionsCoreJs,
-          libraries.kotestPropertyJs
-        )
-        def jsTestTimeout = 60_000L
+
       }
     }
 
@@ -549,53 +578,62 @@ object `package` extends RootModule {
       object `arrow-optics-ksp-plugin` extends ArrowJvmModule {
         def explicitApi = false
         def ivyDeps = Agg(libraries.ksp)
-        def testIvyDeps = Agg(
-          libraries.kotlinTestJunit5,
-          libraries.coroutinesTestJvm,
-          libraries.kotestAssertionsCoreJvm,
-          libraries.kotestPropertyJvm,
-          libraries.classgraph,
-          libraries.kotlinCompileTesting,
-          libraries.kotlinCompileTestingKsp
-        )
 
-        def testRunModuleDeps = Seq(
-          core.`arrow-annotations`.jvm,
-          core.`arrow-core`.jvm,
-          `arrow-optics`.jvm
-        )
+        object test extends ArrowJvmTests{
+          def ivyDeps = super.ivyDeps() ++ Agg(
+            libraries.kotlinTestJunit5,
+            libraries.coroutinesTestJvm,
+            libraries.kotestAssertionsCoreJvm,
+            libraries.kotestPropertyJvm,
+            libraries.classgraph,
+            libraries.kotlinCompileTesting,
+            libraries.kotlinCompileTestingKsp
+          )
+
+          def runModuleDeps = super.runModuleDeps ++ Seq(
+            core.`arrow-annotations`.jvm,
+            core.`arrow-core`.jvm,
+            `arrow-optics`.jvm
+          )
+        }
       }
       object `arrow-optics-reflect` extends ArrowJvmModule {
         def moduleDeps = Seq(core.`arrow-core`.jvm, `arrow-optics`.jvm)
         def ivyDeps = Agg(libraries.kotlinReflect)
-        def testIvyDeps = Agg(
-          libraries.kotlinTestJunit5,
-          libraries.coroutinesTestJvm,
-          libraries.kotestAssertionsCoreJvm,
-          libraries.kotestPropertyJvm
-        )
+
+        object test extends ArrowJvmTests{
+          def ivyDeps = super.ivyDeps() ++ Agg(
+            libraries.kotlinTestJunit5,
+            libraries.coroutinesTestJvm,
+            libraries.kotestAssertionsCoreJvm,
+            libraries.kotestPropertyJvm
+          )
+        }
       }
       object `arrow-optics` extends ArrowMultiplatformModule {
         object jvm extends ArrowPlatformJvmModule{
           def moduleDeps = super.moduleDeps ++ Seq(core.`arrow-core`.jvm)
+          object test extends ArrowPlatformJvmTests{
+            def kotlincOptions = super.kotlincOptions() ++ Seq(commonSourcesArg(jvm.test.sources(), "commonTest"))
+            def ivyDeps = super.ivyDeps() ++ Agg(
+              libraries.kotlinTestJunit5,
+              libraries.coroutinesTestJvm,
+              libraries.kotestAssertionsCoreJvm,
+              libraries.kotestPropertyJvm
+            )
+          }
         }
         object js extends ArrowPlatformJsModule{
           def moduleDeps = super.moduleDeps ++ Seq(core.`arrow-core`.js)
+          object test extends ArrowPlatformJsTests{
+            def kotlincOptions = super.kotlincOptions() ++ Seq(commonSourcesArg(js.test.sources(), "commonTest"))
+            def ivyDeps = super.ivyDeps() ++ Agg(
+              libraries.coroutinesTestJs,
+              libraries.kotestAssertionsCoreJs,
+              libraries.kotestPropertyJs
+            )
+          }
         }
-        def jvmTestKotlincOptions = Seq(commonSourcesArg(jvm.test.sources(), "commonTest"))
-        def jsTestKotlincOptions = Seq(commonSourcesArg(js.test.sources(), "commonTest"))
-
-        def jvmTestIvyDeps = Agg(
-          libraries.kotlinTestJunit5,
-          libraries.coroutinesTestJvm,
-          libraries.kotestAssertionsCoreJvm,
-          libraries.kotestPropertyJvm
-        )
-        def jsTestIvyDeps = Agg(
-          libraries.coroutinesTestJs,
-          libraries.kotestAssertionsCoreJs,
-          libraries.kotestPropertyJs
-        )
       }
     }
 
@@ -604,21 +642,26 @@ object `package` extends RootModule {
         object jvm extends ArrowPlatformJvmModule{
           def moduleDeps = super.moduleDeps ++ Seq(core.`arrow-core`.jvm)
           def ivyDeps = super.ivyDeps() ++ Agg(libraries.coroutinesCoreJvm)
+          object test extends ArrowPlatformJvmTests{
+            def moduleDeps = super.moduleDeps ++ Seq(fx.`arrow-fx-coroutines`.jvm)
+
+            def ivyDeps = super.ivyDeps() ++ Agg(
+              libraries.kotlinTestJunit5,
+              libraries.coroutinesTestJvm
+            )
+          }
         }
         object js extends ArrowPlatformJsModule{
           def moduleDeps = super.moduleDeps ++ Seq(core.`arrow-core`.js)
           def ivyDeps = super.ivyDeps() ++ Agg(libraries.coroutinesCoreJs)
-        }
+          object test extends ArrowPlatformJsTests{
+            def moduleDeps = super.moduleDeps ++Seq(fx.`arrow-fx-coroutines`.js)
 
-        def jvmTestModuleDeps = Seq(fx.`arrow-fx-coroutines`.jvm)
-        def jvmTestIvyDeps = Agg(
-          libraries.kotlinTestJunit5,
-          libraries.coroutinesTestJvm
-        )
-        def jsTestModuleDeps = Seq(fx.`arrow-fx-coroutines`.js)
-        def jsTestIvyDeps = Agg(
-          libraries.coroutinesTestJs
-        )
+            def ivyDeps = super.ivyDeps() ++ Agg(
+              libraries.coroutinesTestJs
+            )
+          }
+        }
       }
     }
   }

--- a/example/thirdparty/arrow/build.mill
+++ b/example/thirdparty/arrow/build.mill
@@ -1,0 +1,590 @@
+package build
+
+import mill._, kotlinlib._, kotlinlib.js._
+import mill.scalalib.CoursierModule
+import mill.api.Result
+import mill.testrunner.TestResult
+import mill.scalalib.api.CompilationResult
+import mill.kotlinlib.kover.KoverModule
+
+object libraries {
+
+  object versions {
+    val coroutines = "1.9.0"
+    val classgraph = "4.8.177"
+    val dokka = "1.9.20"
+    val kotest = "5.9.1"
+    val kotlin = "2.0.21"
+    val kotlinCompileTesting = "0.5.1"
+    val kspVersion = "2.0.21-1.0.25"
+    val kotlinxSerialization = "1.7.3"
+    val mockWebServer = "4.12.0"
+    val retrofit = "2.11.0"
+    val moshi = "1.15.1"
+    val cache4k = "0.13.0"
+    // not used yet
+    val compose = "1.7.4"
+    val composePlugin = "1.7.0"
+    val agp = "8.7.1"
+    val androidCompileSdk = "34"
+  }
+
+  // libraries
+  val coroutinesCoreJvm =
+    ivy"org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:${versions.coroutines}"
+  val coroutinesCoreJs =
+    ivy"org.jetbrains.kotlinx:kotlinx-coroutines-core-js:${versions.coroutines}"
+  val coroutinesTestJvm =
+    ivy"org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm:${versions.coroutines}"
+  val coroutinesTestJs =
+    ivy"org.jetbrains.kotlinx:kotlinx-coroutines-test-js:${versions.coroutines}"
+  val kotestAssertionsCoreJvm = ivy"io.kotest:kotest-assertions-core-jvm:${versions.kotest}"
+  val kotestAssertionsCoreJs = ivy"io.kotest:kotest-assertions-core-js:${versions.kotest}"
+  val kotestPropertyJvm = ivy"io.kotest:kotest-property-jvm:${versions.kotest}"
+  val kotestPropertyJs = ivy"io.kotest:kotest-property-js:${versions.kotest}"
+  val kotlinReflect = ivy"org.jetbrains.kotlin:kotlin-reflect:${versions.kotlin}"
+  val kotlinStdlib = ivy"org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"
+  val kotlinTestJunit5 = ivy"org.jetbrains.kotlin:kotlin-test-junit5:${versions.kotlin}"
+  val kotlinTestJs = ivy"org.jetbrains.kotlin:kotlin-test-js:${versions.kotlin}"
+  val kotlinxSerializationCoreJvm =
+    ivy"org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:${versions.kotlinxSerialization}"
+  val kotlinxSerializationCoreJs =
+    ivy"org.jetbrains.kotlinx:kotlinx-serialization-core-js:${versions.kotlinxSerialization}"
+  val kotlinxSerializationJson =
+    ivy"org.jetbrains.kotlinx:kotlinx-serialization-json:${versions.kotlinxSerialization}"
+  val kotlinxSerializationJsonJs =
+    ivy"org.jetbrains.kotlinx:kotlinx-serialization-json-js:${versions.kotlinxSerialization}"
+  val squareupOkhttpMockWebServer =
+    ivy"com.squareup.okhttp3:mockwebserver:${versions.mockWebServer}"
+  val squareupRetrofitLib = ivy"com.squareup.retrofit2:retrofit:${versions.retrofit}"
+  val squareupRetrofitConverterGson =
+    ivy"com.squareup.retrofit2:converter-gson:${versions.retrofit}"
+  val squareupRetrofitConverterMoshi =
+    ivy"com.squareup.retrofit2:converter-moshi:${versions.retrofit}"
+  val squareupRetrofitConverterKotlinxSerialization =
+    ivy"com.squareup.retrofit2:converter-kotlinx-serialization:${versions.retrofit}"
+  val squareupMoshiKotlin = ivy"com.squareup.moshi:moshi-kotlin:${versions.moshi}"
+  val ksp = ivy"com.google.devtools.ksp:symbol-processing-api:${versions.kspVersion}"
+  val kspGradlePlugin =
+    ivy"com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin:${versions.kspVersion}"
+  val classgraph = ivy"io.github.classgraph:classgraph:${versions.classgraph}"
+  val composeRuntime = ivy"androidx.compose.runtime:runtime:${versions.compose}"
+  val kotlinCompileTesting = ivy"dev.zacsweers.kctfork:core:${versions.kotlinCompileTesting}"
+  val kotlinCompileTestingKsp = ivy"dev.zacsweers.kctfork:ksp:${versions.kotlinCompileTesting}"
+  val cache4kJs = ivy"io.github.reactivecircus.cache4k:cache4k-js:${versions.cache4k}"
+  val cache4kJvm = ivy"io.github.reactivecircus.cache4k:cache4k-jvm:${versions.cache4k}"
+
+  // plugins
+  val kotlinxSerializationPlugin =
+    ivy"org.jetbrains.kotlin:kotlin-serialization-compiler-plugin:${versions.kotlin}"
+}
+
+object `package` extends RootModule {
+
+  // comment to disable test for the module
+  val modulesWithTestingEnabled = Set[CoursierModule](
+// these modules don't have hand-written tests
+//    `arrow-libs`.core.`arrow-annotations`,
+//    `arrow-libs`.core.`arrow-cache4k`,
+//    `arrow-libs`.core.`arrow-core-high-arity`,
+
+    `arrow-libs`.core.`arrow-atomic`,
+    `arrow-libs`.core.`arrow-autoclose`,
+    `arrow-libs`.core.`arrow-core-retrofit`,
+    `arrow-libs`.core.`arrow-core-serialization`,
+    `arrow-libs`.core.`arrow-core`,
+    `arrow-libs`.core.`arrow-eval`,
+    `arrow-libs`.core.`arrow-functions`,
+    `arrow-libs`.fx.`arrow-collectors`,
+    `arrow-libs`.fx.`arrow-fx-coroutines`,
+    `arrow-libs`.fx.`arrow-fx-stm`,
+// Cannot test this one - it relies on the module dependency in the .jar format, while Mill provides .class files
+//    `arrow-libs`.optics.`arrow-optics-ksp-plugin`,
+    `arrow-libs`.optics.`arrow-optics-reflect`,
+    `arrow-libs`.optics.`arrow-optics`,
+
+    `arrow-libs`.resilience.`arrow-resilience`
+  )
+
+  def majorVersion(version: String): String = version.split("\\.", 3).take(2).mkString(".")
+
+  // TODO support Kotlin Multiplatform hierarchies
+  // TODO add more targets once available
+  trait ArrowMultiplatformModule extends CoursierModule { multiplatformRoot =>
+
+    def jsModuleDeps: Seq[KotlinJsModule] = Nil
+    def jvmModuleDeps: Seq[KotlinModule] = Nil
+    def jsTestModuleDeps: Seq[KotlinJsModule] = Nil
+    def jvmTestModuleDeps: Seq[KotlinModule] = Nil
+    def jsIvyDeps: T[Agg[Dep]] = Agg.empty[Dep]
+    def jvmIvyDeps: T[Agg[Dep]] = Agg.empty[Dep]
+    def jsTestIvyDeps: T[Agg[Dep]] = Agg.empty[Dep]
+    def jvmTestIvyDeps: T[Agg[Dep]] = Agg.empty[Dep]
+    def jsCompileIvyDeps: T[Agg[Dep]] = Agg.empty[Dep]
+    def jvmCompileIvyDeps: T[Agg[Dep]] = Agg.empty[Dep]
+
+    def jsKotlincOptions: T[Seq[String]] = Seq.empty[String]
+    def jvmKotlincOptions: T[Seq[String]] = Seq.empty[String]
+    def jsTestKotlincOptions: T[Seq[String]] = Seq.empty[String]
+    def jvmTestKotlincOptions: T[Seq[String]] = Seq.empty[String]
+
+    def jsTestTimeout: T[Long] = 30_000L
+
+    def explicitApi: T[Boolean] = true
+
+    protected def commonSourcesArg(sources: Seq[PathRef], commonSourcesDirName: String): String = {
+      val files = os.walk(
+        sources
+          .map(_.path)
+          .filter(_.toString().contains(commonSourcesDirName))
+          .head
+      )
+        .filter(_.toIO.isFile)
+      // TODO this is to prevent compilation failure in cases when there is actual declaration in Foo.kt and expect
+      //  declaration in Foo.kt instead of Foo.[jvm,js,...].kt, because in this case symbols belong to the same module.
+      // This is allowed with `-Xcommon-sources` flag, but probably will be prohibited in the future.
+      // Ideally, it should be in the [[KotlinModule]] directly, but this implies [[KotlinModule]] should know where
+      // common sources are, making some assumptions about layout.
+      s"-Xcommon-sources=${files.mkString(",")}"
+    }
+
+    trait ArrowPlatformModule extends KotlinModule {
+      def kotlinVersion = libraries.versions.kotlin
+      def languageVersion = majorVersion(kotlinVersion())
+      def apiVersion = majorVersion(kotlinVersion())
+      def explicitApi = ArrowMultiplatformModule.this.explicitApi
+
+      def platformCrossSuffix: String = millModuleSegments
+        .value
+        .collect { case l: mill.define.Segment.Label => l.value }
+        .last
+
+      override def millSourcePath = super.millSourcePath / os.up
+
+      override def sources: T[Seq[PathRef]] = Task.Sources {
+        val sourcesRootPath = millSourcePath / "src"
+        var sources = Seq("common", platformCrossSuffix)
+          .map(platform => PathRef(sourcesRootPath / s"${platform}Main" / "kotlin"))
+          .filter(p => os.exists(p.path))
+        if (platformCrossSuffix != "jvm") {
+          val nonJvmSourcesPath = sourcesRootPath / "nonJvmMain" / "kotlin"
+          if (os.exists(nonJvmSourcesPath)) {
+            sources ++= Seq(PathRef(nonJvmSourcesPath))
+          }
+        }
+        sources
+      }
+
+      override def kotlincOptions = super.kotlincOptions() ++ Seq("-Xexpect-actual-classes")
+    }
+
+    object jvm extends ArrowPlatformModule with KoverModule { outer =>
+      def ivyDeps = super.ivyDeps() ++ jvmIvyDeps()
+      def compileIvyDeps = super.compileIvyDeps() ++ jvmCompileIvyDeps()
+      def moduleDeps = super.moduleDeps ++ jvmModuleDeps
+      def kotlincOptions = super.kotlincOptions() ++ Seq(
+        commonSourcesArg(sources(), "commonMain")
+      ) ++ jvmKotlincOptions()
+      object test extends KotlinTests with KoverTests with TestModule.Junit5 {
+        def ivyDeps = super.ivyDeps() ++ jvmTestIvyDeps()
+        def moduleDeps = super.moduleDeps ++ jvmTestModuleDeps
+        def kotlincOptions = super.kotlincOptions() ++ jvmTestKotlincOptions()
+        override def sources: T[Seq[PathRef]] = Task.Sources {
+          val sourcesRootPath = outer.millSourcePath / "src"
+          Seq("common", outer.platformCrossSuffix)
+            .map(platform => PathRef(sourcesRootPath / s"${platform}Test" / "kotlin"))
+            .filter(p => os.exists(p.path))
+        }
+
+        override def compile: T[CompilationResult] =
+          if (!modulesWithTestingEnabled.contains(multiplatformRoot))
+            Task { CompilationResult(T.dest, PathRef(T.dest)) }
+          else super.compile
+        override def test(args: String*): Command[(String, Seq[TestResult])] =
+          if (!modulesWithTestingEnabled.contains(multiplatformRoot))
+            Task.Command { ("", Seq.empty[TestResult]) }
+          else super.test(args: _*)
+      }
+    }
+
+    object js extends ArrowPlatformModule with KotlinJsModule { outer =>
+      def ivyDeps = super.ivyDeps() ++ jsIvyDeps()
+      def compileIvyDeps = super.compileIvyDeps() ++ jsCompileIvyDeps()
+      def moduleDeps = super.moduleDeps ++ jsModuleDeps
+      def kotlincOptions = super.kotlincOptions() ++ Seq(
+        commonSourcesArg(sources(), "commonMain")
+      ) ++ jsKotlincOptions()
+      def kotlinJsRunTarget = Some(RunTarget.Node)
+
+      object test extends KotlinTestPackageTests {
+        def ivyDeps = super.ivyDeps() ++ jsTestIvyDeps()
+        def moduleDeps = super.moduleDeps ++ jsTestModuleDeps
+        def kotlincOptions = super.kotlincOptions() ++ jsTestKotlincOptions()
+        def testTimeout = jsTestTimeout
+        override def sources: T[Seq[PathRef]] = Task.Sources {
+          val sourcesRootPath = outer.millSourcePath / "src"
+          Seq("common", outer.platformCrossSuffix)
+            .map(platform => PathRef(sourcesRootPath / s"${platform}Test" / "kotlin"))
+            .filter(p => os.exists(p.path))
+        }
+
+        override def compile: T[CompilationResult] =
+          if (!modulesWithTestingEnabled.contains(multiplatformRoot))
+            Task { CompilationResult(T.dest, PathRef(T.dest)) }
+          else super.compile
+        override def test(args: String*): Command[(String, Seq[TestResult])] =
+          if (!modulesWithTestingEnabled.contains(multiplatformRoot))
+            Task.Command { ("", Seq.empty[TestResult]) }
+          else super.test(args: _*)
+      }
+    }
+  }
+
+  trait ArrowJvmModule extends KotlinModule with KoverModule { jvmRoot =>
+
+    def testModuleDeps: Seq[KotlinModule] = Nil
+    def testRunModuleDeps: Seq[KotlinModule] = Nil
+    def testIvyDeps: T[Agg[Dep]] = Agg.empty[Dep]
+    def testCompileIvyDeps: T[Agg[Dep]] = Agg.empty[Dep]
+    def testKotlincOptions: T[Seq[String]] = Seq.empty[String]
+
+    def kotlinVersion = libraries.versions.kotlin
+    def explicitApi = true
+    def languageVersion = majorVersion(kotlinVersion())
+    def apiVersion = majorVersion(kotlinVersion())
+
+    override def sources: T[Seq[PathRef]] = Task.Sources {
+      millSourcePath / "src" / "main" / "kotlin"
+    }
+    override def resources: T[Seq[PathRef]] = Task.Sources {
+      millSourcePath / "src" / "main" / "resources"
+    }
+
+    object test extends KotlinTests with KoverTests with TestModule.Junit5 {
+      override def sources: T[Seq[PathRef]] = Task.Sources {
+        millSourcePath / os.up / "src" / "test" / "kotlin"
+      }
+      override def resources: T[Seq[PathRef]] = Task.Sources {
+        millSourcePath / os.up / "src" / "test" / "resources"
+      }
+      def moduleDeps = super.moduleDeps ++ testModuleDeps
+      def runModuleDeps = super.runModuleDeps ++ testRunModuleDeps
+      def ivyDeps = super.ivyDeps() ++ testIvyDeps()
+      def compileIvyDeps = super.compileIvyDeps() ++ testCompileIvyDeps()
+      def kotlincOptions = super.kotlincOptions() ++ testKotlincOptions()
+      override def compile: T[CompilationResult] = if (!modulesWithTestingEnabled.contains(jvmRoot))
+        Task { CompilationResult(T.dest, PathRef(T.dest)) }
+      else super.compile
+      override def test(args: String*): Command[(String, Seq[TestResult])] =
+        if (!modulesWithTestingEnabled.contains(jvmRoot))
+          Task.Command { ("", Seq.empty[TestResult]) }
+        else super.test(args: _*)
+    }
+  }
+
+  object `arrow-libs` extends Module {
+    object core extends Module {
+      object `arrow-annotations` extends ArrowMultiplatformModule
+      object `arrow-atomic` extends ArrowMultiplatformModule {
+        def jvmTestModuleDeps = Seq(fx.`arrow-fx-coroutines`.jvm)
+        def jvmTestIvyDeps = Agg(
+          libraries.kotlinTestJunit5,
+          libraries.coroutinesTestJvm,
+          libraries.kotestAssertionsCoreJvm,
+          libraries.kotestPropertyJvm
+        )
+        def jsTestModuleDeps = Seq(fx.`arrow-fx-coroutines`.js)
+        def jsTestIvyDeps = Agg(
+          libraries.coroutinesTestJs,
+          libraries.kotestAssertionsCoreJs,
+          libraries.kotestPropertyJs
+        )
+      }
+      object `arrow-autoclose` extends ArrowMultiplatformModule {
+        def jvmModuleDeps = Seq(`arrow-atomic`.jvm)
+        def jvmTestModuleDeps = Seq(fx.`arrow-fx-coroutines`.jvm)
+        def jvmTestIvyDeps = Agg(
+          libraries.kotlinTestJunit5,
+          libraries.coroutinesTestJvm,
+          libraries.kotestAssertionsCoreJvm
+        )
+        def jvmTestKotlincOptions = Seq("-Xcontext-receivers")
+        def jsModuleDeps = Seq(`arrow-atomic`.js)
+        def jsTestModuleDeps = Seq(fx.`arrow-fx-coroutines`.js)
+        def jsTestIvyDeps = Agg(
+          libraries.coroutinesTestJs,
+          libraries.kotestAssertionsCoreJs
+        )
+      }
+      object `arrow-cache4k` extends ArrowMultiplatformModule {
+        def jvmModuleDeps = Seq(`arrow-core`.jvm)
+        def jvmIvyDeps = Agg(libraries.cache4kJvm)
+        def jsModuleDeps = Seq(`arrow-core`.js)
+        def jsIvyDeps = Agg(libraries.cache4kJs)
+      }
+      object `arrow-core-high-arity` extends ArrowMultiplatformModule {
+        def jvmModuleDeps = Seq(`arrow-core`.jvm)
+        def jsModuleDeps = Seq(`arrow-core`.js)
+      }
+      object `arrow-core-retrofit` extends ArrowJvmModule {
+        def moduleDeps = Seq(`arrow-core`.jvm)
+        def compileIvyDeps = Agg(libraries.squareupRetrofitLib)
+        def processors = Task {
+          defaultResolver().resolveDeps(Agg(libraries.kotlinxSerializationPlugin))
+        }
+
+        def testKotlincOptions = Seq(s"-Xplugin=${processors().head.path}")
+        def testModuleDeps = Seq(`arrow-core`.jvm)
+        def testIvyDeps = Agg(
+          libraries.kotlinTestJunit5,
+          libraries.coroutinesTestJvm,
+          libraries.kotestAssertionsCoreJvm,
+          libraries.kotestPropertyJvm,
+          libraries.squareupOkhttpMockWebServer,
+          libraries.squareupRetrofitConverterGson,
+          libraries.squareupRetrofitConverterMoshi,
+          libraries.kotlinxSerializationJson,
+          libraries.squareupRetrofitConverterKotlinxSerialization,
+          libraries.squareupMoshiKotlin
+        )
+      }
+      object `arrow-core-serialization` extends ArrowMultiplatformModule {
+        def jvmModuleDeps = Seq(`arrow-core`.jvm)
+        def jvmIvyDeps = Agg(libraries.kotlinxSerializationCoreJvm)
+        def jvmTestIvyDeps = Agg(
+          libraries.kotlinTestJunit5,
+          libraries.kotlinxSerializationJson,
+          libraries.coroutinesTestJvm,
+          libraries.kotestAssertionsCoreJvm,
+          libraries.kotestPropertyJvm
+        )
+        def jsModuleDeps = Seq(`arrow-core`.js)
+        def jsIvyDeps = Agg(libraries.kotlinxSerializationCoreJs)
+        def jsTestIvyDeps = Agg(
+          libraries.kotlinxSerializationJsonJs,
+          libraries.coroutinesTestJs,
+          libraries.kotestAssertionsCoreJs,
+          libraries.kotestPropertyJs
+        )
+
+        def processors = Task {
+          defaultResolver().resolveDeps(Agg(libraries.kotlinxSerializationPlugin))
+        }
+        def jsTestKotlincOptions = Seq(s"-Xplugin=${processors().head.path}")
+        def jvmTestKotlincOptions = Seq(s"-Xplugin=${processors().head.path}")
+        def jsTestTimeout = 60_000L
+      }
+      object `arrow-core` extends ArrowMultiplatformModule {
+        def jvmModuleDeps = Seq(`arrow-atomic`.jvm, `arrow-annotations`.jvm)
+        def jvmIvyDeps = Agg(libraries.kotlinxSerializationCoreJvm)
+        def jvmTestModuleDeps = Seq(fx.`arrow-fx-coroutines`.jvm)
+        def jvmTestIvyDeps = Agg(
+          libraries.kotlinTestJunit5,
+          libraries.coroutinesTestJvm,
+          libraries.kotestAssertionsCoreJvm,
+          libraries.kotestPropertyJvm
+        )
+        def jvmKotlincOptions = Seq("-Xcontext-receivers")
+        def jsModuleDeps = Seq(`arrow-atomic`.js, `arrow-annotations`.js)
+        def jsIvyDeps = Agg(libraries.kotlinxSerializationCoreJs)
+        def jsTestModuleDeps = Seq(fx.`arrow-fx-coroutines`.js)
+        def jsTestIvyDeps = Agg(
+          libraries.coroutinesTestJs,
+          libraries.kotestAssertionsCoreJs,
+          libraries.kotestPropertyJs
+        )
+        def jsTestTimeout = 300_000L
+      }
+      object `arrow-eval` extends ArrowMultiplatformModule {
+        def jvmModuleDeps = Seq(`arrow-core`.jvm)
+        def jsModuleDeps = Seq(`arrow-core`.js)
+        def jvmTestIvyDeps = Agg(
+          libraries.kotlinTestJunit5,
+          libraries.kotestAssertionsCoreJvm,
+          libraries.kotestPropertyJvm
+        )
+        def jsTestIvyDeps = Agg(
+          libraries.kotestAssertionsCoreJs,
+          libraries.kotestPropertyJs
+        )
+      }
+      object `arrow-functions` extends ArrowMultiplatformModule {
+        def jvmModuleDeps = Seq(`arrow-atomic`.jvm, `arrow-annotations`.jvm)
+        def jsModuleDeps = Seq(`arrow-atomic`.js, `arrow-annotations`.js)
+        def jvmTestModuleDeps = Seq(fx.`arrow-fx-coroutines`.jvm)
+        def jvmTestIvyDeps = Agg(
+          libraries.kotlinTestJunit5,
+          libraries.coroutinesTestJvm,
+          libraries.kotestAssertionsCoreJvm,
+          libraries.kotestPropertyJvm
+        )
+        def jsTestModuleDeps = Seq(fx.`arrow-fx-coroutines`.js)
+        def jsTestIvyDeps = Agg(
+          libraries.coroutinesTestJs,
+          libraries.kotestAssertionsCoreJs,
+          libraries.kotestPropertyJs
+        )
+      }
+    }
+
+    object fx extends Module {
+      object `arrow-collectors` extends ArrowMultiplatformModule {
+        def jvmModuleDeps = Seq(core.`arrow-atomic`.jvm, `arrow-fx-coroutines`.jvm)
+        def jvmIvyDeps = Agg(libraries.coroutinesCoreJvm)
+        def jsModuleDeps = Seq(core.`arrow-atomic`.js, `arrow-fx-coroutines`.js)
+        def jsIvyDeps = Agg(libraries.coroutinesCoreJs)
+
+        def jvmTestIvyDeps = Agg(
+          libraries.kotlinTestJunit5,
+          libraries.coroutinesTestJvm,
+          libraries.kotestAssertionsCoreJvm,
+          libraries.kotestPropertyJvm
+        )
+        def jsTestIvyDeps = Agg(
+          libraries.coroutinesTestJs,
+          libraries.kotestAssertionsCoreJs,
+          libraries.kotestPropertyJs
+        )
+
+        def jsTestTimeout = 60_000L
+      }
+      object `arrow-fx-coroutines` extends ArrowMultiplatformModule {
+        def jvmModuleDeps = Seq(core.`arrow-core`.jvm, core.`arrow-autoclose`.jvm)
+        def jvmIvyDeps = Agg(libraries.coroutinesCoreJvm)
+        def jsModuleDeps = Seq(core.`arrow-core`.js, core.`arrow-autoclose`.js)
+        def jsIvyDeps = Agg(libraries.coroutinesCoreJs)
+
+        def jvmTestModuleDeps = Seq(core.`arrow-core`.jvm, core.`arrow-atomic`.jvm)
+        def jsTestModuleDeps = Seq(core.`arrow-core`.js, core.`arrow-atomic`.js)
+        def jvmTestIvyDeps = Agg(
+          libraries.kotlinTestJunit5,
+          libraries.coroutinesTestJvm,
+          libraries.kotestAssertionsCoreJvm,
+          libraries.kotestPropertyJvm
+        )
+        def jsTestIvyDeps = Agg(
+          libraries.coroutinesTestJs,
+          libraries.kotestAssertionsCoreJs,
+          libraries.kotestPropertyJs
+        )
+        def jsTestTimeout = 60_000L
+      }
+      object `arrow-fx-stm` extends ArrowMultiplatformModule {
+        val additionalKotlincOptions = Seq("-Xconsistent-data-class-copy-visibility")
+        def jvmModuleDeps = Seq(core.`arrow-core`.jvm)
+        def jvmIvyDeps = Agg(libraries.coroutinesCoreJvm)
+        def jsModuleDeps = Seq(core.`arrow-core`.js)
+        def jsIvyDeps = Agg(libraries.coroutinesCoreJs)
+        def jvmKotlincOptions = additionalKotlincOptions
+        def jsKotlincOptions = additionalKotlincOptions
+
+        def jvmTestModuleDeps = Seq(`arrow-fx-coroutines`.jvm)
+        def jsTestModuleDeps = Seq(`arrow-fx-coroutines`.js)
+        def jvmTestIvyDeps = Agg(
+          libraries.kotlinTestJunit5,
+          libraries.coroutinesTestJvm,
+          libraries.kotestAssertionsCoreJvm,
+          libraries.kotestPropertyJvm
+        )
+        def jsTestIvyDeps = Agg(
+          libraries.coroutinesTestJs,
+          libraries.kotestAssertionsCoreJs,
+          libraries.kotestPropertyJs
+        )
+        def jsTestTimeout = 60_000L
+      }
+    }
+
+    object optics extends Module {
+      // TODO requires better Android support
+      //  object `arrow-optics-compose` extends Module
+      object `arrow-optics-ksp-plugin` extends ArrowJvmModule {
+        def explicitApi = false
+        def ivyDeps = Agg(libraries.ksp)
+        def testIvyDeps = Agg(
+          libraries.kotlinTestJunit5,
+          libraries.coroutinesTestJvm,
+          libraries.kotestAssertionsCoreJvm,
+          libraries.kotestPropertyJvm,
+          libraries.classgraph,
+          libraries.kotlinCompileTesting,
+          libraries.kotlinCompileTestingKsp
+        )
+
+        def testRunModuleDeps = Seq(
+          core.`arrow-annotations`.jvm,
+          core.`arrow-core`.jvm,
+          `arrow-optics`.jvm
+        )
+      }
+      object `arrow-optics-reflect` extends ArrowJvmModule {
+        def moduleDeps = Seq(core.`arrow-core`.jvm, `arrow-optics`.jvm)
+        def ivyDeps = Agg(libraries.kotlinReflect)
+        def testIvyDeps = Agg(
+          libraries.kotlinTestJunit5,
+          libraries.coroutinesTestJvm,
+          libraries.kotestAssertionsCoreJvm,
+          libraries.kotestPropertyJvm
+        )
+      }
+      object `arrow-optics` extends ArrowMultiplatformModule {
+        def jvmModuleDeps = Seq(core.`arrow-core`.jvm)
+        def jsModuleDeps = Seq(core.`arrow-core`.js)
+        def jvmTestKotlincOptions = Seq(commonSourcesArg(jvm.test.sources(), "commonTest"))
+        def jsTestKotlincOptions = Seq(commonSourcesArg(js.test.sources(), "commonTest"))
+
+        def jvmTestIvyDeps = Agg(
+          libraries.kotlinTestJunit5,
+          libraries.coroutinesTestJvm,
+          libraries.kotestAssertionsCoreJvm,
+          libraries.kotestPropertyJvm
+        )
+        def jsTestIvyDeps = Agg(
+          libraries.coroutinesTestJs,
+          libraries.kotestAssertionsCoreJs,
+          libraries.kotestPropertyJs
+        )
+      }
+    }
+
+    object resilience extends Module {
+      object `arrow-resilience` extends ArrowMultiplatformModule {
+        def jvmModuleDeps = Seq(core.`arrow-core`.jvm)
+        def jvmIvyDeps = Agg(libraries.coroutinesCoreJvm)
+        def jsModuleDeps = Seq(core.`arrow-core`.js)
+        def jsIvyDeps = Agg(libraries.coroutinesCoreJs)
+
+        def jvmTestModuleDeps = Seq(fx.`arrow-fx-coroutines`.jvm)
+        def jvmTestIvyDeps = Agg(
+          libraries.kotlinTestJunit5,
+          libraries.coroutinesTestJvm
+        )
+        def jsTestModuleDeps = Seq(fx.`arrow-fx-coroutines`.js)
+        def jsTestIvyDeps = Agg(
+          libraries.coroutinesTestJs
+        )
+      }
+    }
+  }
+}
+
+/** Usage
+
+> sed -i.bak 's/.cause.shouldBeInstanceOf<SocketException>()/.cause.shouldBeInstanceOf<java.io.IOException>()/g' arrow-libs/core/arrow-core-retrofit/src/test/kotlin/arrow/retrofit/adapter/either/networkhandling/NetworkEitherCallAdapterTest.kt # fix wrong assertion
+
+> ./mill -j5 __.compile
+Compiling 6 Kotlin sources to ...arrow-libs/resilience/arrow-resilience/jvm/compile.dest/classes ...
+Compiling 6 Kotlin sources to ...resilience/arrow-resilience/js/compile.dest/classes ...
+Compiling 11 Kotlin sources to ...fx/arrow-fx-stm/jvm/compile.dest/classes ...
+Compiling 11 Kotlin sources to ...fx/arrow-fx-stm/js/compile.dest/classes ...
+
+> ./mill __.test
+Test arrow.resilience...
+Test arrow.collectors...
+Test arrow.core...
+
+> ./mill mill.kotlinlib.kover.Kover/htmlReportAll
+
+> ./mill __:^TestModule.docJar
+
+*/

--- a/example/thirdparty/arrow/build.mill
+++ b/example/thirdparty/arrow/build.mill
@@ -112,19 +112,13 @@ object `package` extends RootModule {
   // TODO add more targets once available
   trait ArrowMultiplatformModule extends CoursierModule { multiplatformRoot =>
 
-
-
-
-    def explicitApi: T[Boolean] = true
+    def kotlinExplicitApi: T[Boolean] = true
 
     protected def commonSourcesArg(sources: Seq[PathRef], commonSourcesDirName: String): String = {
-      val files = os.walk(
+      val files =
         sources
-          .map(_.path)
-          .filter(_.toString().contains(commonSourcesDirName))
-          .head
-      )
-        .filter(_.toIO.isFile)
+          .flatMap(pr => os.walk(pr.path))
+          .filter(p => p.segments.contains(commonSourcesDirName) && os.isFile(p))
       // TODO this is to prevent compilation failure in cases when there is actual declaration in Foo.kt and expect
       //  declaration in Foo.kt instead of Foo.[jvm,js,...].kt, because in this case symbols belong to the same module.
       // This is allowed with `-Xcommon-sources` flag, but probably will be prohibited in the future.
@@ -133,11 +127,11 @@ object `package` extends RootModule {
       s"-Xcommon-sources=${files.mkString(",")}"
     }
 
-    trait ArrowPlatformModule extends KotlinModule {
+    trait ArrowPlatformModule extends KotlinMavenModule {  outer =>
       def kotlinVersion = libraries.versions.kotlin
-      def languageVersion = majorVersion(kotlinVersion())
-      def apiVersion = majorVersion(kotlinVersion())
-      def explicitApi = ArrowMultiplatformModule.this.explicitApi
+      def kotlinLanguageVersion = majorVersion(kotlinVersion())
+      def kotlinApiVersion = majorVersion(kotlinVersion())
+      def kotlinExplicitApi = ArrowMultiplatformModule.this.kotlinExplicitApi
 
       def platformCrossSuffix: String = millModuleSegments
         .value
@@ -161,88 +155,65 @@ object `package` extends RootModule {
       }
 
       override def kotlincOptions = super.kotlincOptions() ++ Seq("-Xexpect-actual-classes")
-    }
 
-    def jvm: ArrowPlatformJvmModule
-    trait ArrowPlatformJvmModule extends ArrowPlatformModule with KoverModule { outer =>
-      def kotlincOptions = super.kotlincOptions() ++ Seq(commonSourcesArg(sources(), "commonMain"))
-      def test: ArrowPlatformJvmTests
-      trait ArrowPlatformJvmTests extends KotlinTests with KoverTests with TestModule.Junit5 {
+      trait ArrowPlatformTests extends KotlinMavenTests{
+
+        override def compile: T[CompilationResult] =
+          if (modulesWithTestingEnabled(multiplatformRoot)) super.compile
+          else Task { CompilationResult(T.dest, PathRef(T.dest)) }
+
+        override def test(args: String*): Command[(String, Seq[TestResult])] =
+          if (modulesWithTestingEnabled(multiplatformRoot)) super.test(args: _*)
+          else Task.Command { ("", Seq.empty[TestResult]) }
+
         override def sources: T[Seq[PathRef]] = Task.Sources {
           val sourcesRootPath = outer.millSourcePath / "src"
           Seq("common", outer.platformCrossSuffix)
             .map(platform => PathRef(sourcesRootPath / s"${platform}Test" / "kotlin"))
             .filter(p => os.exists(p.path))
         }
+      }
+    }
 
-        override def compile: T[CompilationResult] =
-          if (!modulesWithTestingEnabled.contains(multiplatformRoot))
-            Task { CompilationResult(T.dest, PathRef(T.dest)) }
-          else super.compile
-        override def test(args: String*): Command[(String, Seq[TestResult])] =
-          if (!modulesWithTestingEnabled.contains(multiplatformRoot))
-            Task.Command { ("", Seq.empty[TestResult]) }
-          else super.test(args: _*)
+    def jvm: ArrowPlatformJvmModule
+
+    trait ArrowPlatformJvmModule extends ArrowPlatformModule with KoverModule {
+      def kotlincOptions = super.kotlincOptions() ++ Seq(commonSourcesArg(sources(), "commonMain"))
+      def test: ArrowPlatformJvmTests
+      trait ArrowPlatformJvmTests extends KotlinMavenTests with  KoverTests with TestModule.Junit5  with ArrowPlatformTests{
       }
     }
 
     def js: ArrowPlatformJsModule
-    trait ArrowPlatformJsModule extends ArrowPlatformModule with KotlinJsModule { outer =>
+    trait ArrowPlatformJsModule extends ArrowPlatformModule with KotlinJsModule {
       def kotlincOptions = super.kotlincOptions() ++ Seq(
         commonSourcesArg(sources(), "commonMain")
       )
       def kotlinJsRunTarget = Some(RunTarget.Node)
 
       def test: ArrowPlatformJsTests
-      trait ArrowPlatformJsTests extends KotlinTestPackageTests {
+      trait ArrowPlatformJsTests extends KotlinMavenTests with KotlinTestPackageTests with ArrowPlatformTests{
         def testTimeout = 30_000L
-        override def sources: T[Seq[PathRef]] = Task.Sources {
-          val sourcesRootPath = outer.millSourcePath / "src"
-          Seq("common", outer.platformCrossSuffix)
-            .map(platform => PathRef(sourcesRootPath / s"${platform}Test" / "kotlin"))
-            .filter(p => os.exists(p.path))
-        }
-
-        override def compile: T[CompilationResult] =
-          if (!modulesWithTestingEnabled.contains(multiplatformRoot))
-            Task { CompilationResult(T.dest, PathRef(T.dest)) }
-          else super.compile
-        override def test(args: String*): Command[(String, Seq[TestResult])] =
-          if (!modulesWithTestingEnabled.contains(multiplatformRoot))
-            Task.Command { ("", Seq.empty[TestResult]) }
-          else super.test(args: _*)
       }
     }
   }
 
-  trait ArrowJvmModule extends KotlinModule with KoverModule { jvmRoot =>
+  trait ArrowJvmModule extends KotlinMavenModule with KoverModule { jvmRoot =>
 
     def kotlinVersion = libraries.versions.kotlin
-    def explicitApi = true
-    def languageVersion = majorVersion(kotlinVersion())
-    def apiVersion = majorVersion(kotlinVersion())
+    def kotlinExplicitApi = true
+    def kotlinLanguageVersion = majorVersion(kotlinVersion())
+    def kotlinApiVersion = majorVersion(kotlinVersion())
 
-    override def sources: T[Seq[PathRef]] = Task.Sources {
-      millSourcePath / "src" / "main" / "kotlin"
-    }
-    override def resources: T[Seq[PathRef]] = Task.Sources {
-      millSourcePath / "src" / "main" / "resources"
-    }
     def test: ArrowJvmTests
-    trait ArrowJvmTests extends KotlinTests with KoverTests with TestModule.Junit5 {
-      override def sources: T[Seq[PathRef]] = Task.Sources {
-        millSourcePath / os.up / "src" / "test" / "kotlin"
-      }
-      override def resources: T[Seq[PathRef]] = Task.Sources {
-        millSourcePath / os.up / "src" / "test" / "resources"
-      }
-      override def compile: T[CompilationResult] = if (!modulesWithTestingEnabled.contains(jvmRoot))
-        Task { CompilationResult(T.dest, PathRef(T.dest)) }
-      else super.compile
+    trait ArrowJvmTests extends KotlinMavenTests with KoverTests with TestModule.Junit5 {
+      override def compile: T[CompilationResult] =
+        if (modulesWithTestingEnabled(jvmRoot)) super.compile
+        else Task { CompilationResult(T.dest, PathRef(T.dest)) }
+
       override def test(args: String*): Command[(String, Seq[TestResult])] =
-        if (!modulesWithTestingEnabled.contains(jvmRoot))
-          Task.Command { ("", Seq.empty[TestResult]) }
-        else super.test(args: _*)
+        if (modulesWithTestingEnabled(jvmRoot)) super.test(args: _*)
+        else Task.Command { ("", Seq.empty[TestResult]) }
     }
   }
 
@@ -576,7 +547,7 @@ object `package` extends RootModule {
       // TODO requires better Android support
       //  object `arrow-optics-compose` extends Module
       object `arrow-optics-ksp-plugin` extends ArrowJvmModule {
-        def explicitApi = false
+        def kotlinExplicitApi = false
         def ivyDeps = Agg(libraries.ksp)
 
         object test extends ArrowJvmTests{

--- a/example/thirdparty/arrow/build.mill
+++ b/example/thirdparty/arrow/build.mill
@@ -112,19 +112,11 @@ object `package` extends RootModule {
   // TODO add more targets once available
   trait ArrowMultiplatformModule extends CoursierModule { multiplatformRoot =>
 
-    def jsModuleDeps: Seq[KotlinJsModule] = Nil
-    def jvmModuleDeps: Seq[KotlinModule] = Nil
     def jsTestModuleDeps: Seq[KotlinJsModule] = Nil
     def jvmTestModuleDeps: Seq[KotlinModule] = Nil
-    def jsIvyDeps: T[Agg[Dep]] = Agg.empty[Dep]
-    def jvmIvyDeps: T[Agg[Dep]] = Agg.empty[Dep]
     def jsTestIvyDeps: T[Agg[Dep]] = Agg.empty[Dep]
     def jvmTestIvyDeps: T[Agg[Dep]] = Agg.empty[Dep]
-    def jsCompileIvyDeps: T[Agg[Dep]] = Agg.empty[Dep]
-    def jvmCompileIvyDeps: T[Agg[Dep]] = Agg.empty[Dep]
 
-    def jsKotlincOptions: T[Seq[String]] = Seq.empty[String]
-    def jvmKotlincOptions: T[Seq[String]] = Seq.empty[String]
     def jsTestKotlincOptions: T[Seq[String]] = Seq.empty[String]
     def jvmTestKotlincOptions: T[Seq[String]] = Seq.empty[String]
 
@@ -178,13 +170,11 @@ object `package` extends RootModule {
       override def kotlincOptions = super.kotlincOptions() ++ Seq("-Xexpect-actual-classes")
     }
 
-    object jvm extends ArrowPlatformModule with KoverModule { outer =>
-      def ivyDeps = super.ivyDeps() ++ jvmIvyDeps()
-      def compileIvyDeps = super.compileIvyDeps() ++ jvmCompileIvyDeps()
-      def moduleDeps = super.moduleDeps ++ jvmModuleDeps
+    def jvm: ArrowPlatformJvmModule
+    trait ArrowPlatformJvmModule extends ArrowPlatformModule with KoverModule { outer =>
       def kotlincOptions = super.kotlincOptions() ++ Seq(
         commonSourcesArg(sources(), "commonMain")
-      ) ++ jvmKotlincOptions()
+      )
       object test extends KotlinTests with KoverTests with TestModule.Junit5 {
         def ivyDeps = super.ivyDeps() ++ jvmTestIvyDeps()
         def moduleDeps = super.moduleDeps ++ jvmTestModuleDeps
@@ -207,13 +197,11 @@ object `package` extends RootModule {
       }
     }
 
-    object js extends ArrowPlatformModule with KotlinJsModule { outer =>
-      def ivyDeps = super.ivyDeps() ++ jsIvyDeps()
-      def compileIvyDeps = super.compileIvyDeps() ++ jsCompileIvyDeps()
-      def moduleDeps = super.moduleDeps ++ jsModuleDeps
+    def js: ArrowPlatformJsModule
+    trait ArrowPlatformJsModule extends ArrowPlatformModule with KotlinJsModule { outer =>
       def kotlincOptions = super.kotlincOptions() ++ Seq(
         commonSourcesArg(sources(), "commonMain")
-      ) ++ jsKotlincOptions()
+      )
       def kotlinJsRunTarget = Some(RunTarget.Node)
 
       object test extends KotlinTestPackageTests {
@@ -284,8 +272,13 @@ object `package` extends RootModule {
 
   object `arrow-libs` extends Module {
     object core extends Module {
-      object `arrow-annotations` extends ArrowMultiplatformModule
+      object `arrow-annotations` extends ArrowMultiplatformModule{
+        object jvm extends ArrowPlatformJvmModule
+        object js extends ArrowPlatformJsModule
+      }
       object `arrow-atomic` extends ArrowMultiplatformModule {
+        object jvm extends ArrowPlatformJvmModule
+        object js extends ArrowPlatformJsModule
         def jvmTestModuleDeps = Seq(fx.`arrow-fx-coroutines`.jvm)
         def jvmTestIvyDeps = Agg(
           libraries.kotlinTestJunit5,
@@ -301,7 +294,13 @@ object `package` extends RootModule {
         )
       }
       object `arrow-autoclose` extends ArrowMultiplatformModule {
-        def jvmModuleDeps = Seq(`arrow-atomic`.jvm)
+        object jvm extends ArrowPlatformJvmModule{
+          def moduleDeps = super.moduleDeps ++ Seq(`arrow-atomic`.jvm)
+        }
+        object js extends ArrowPlatformJsModule{
+          def moduleDeps = super.moduleDeps ++ Seq(`arrow-atomic`.js)
+        }
+
         def jvmTestModuleDeps = Seq(fx.`arrow-fx-coroutines`.jvm)
         def jvmTestIvyDeps = Agg(
           libraries.kotlinTestJunit5,
@@ -309,7 +308,6 @@ object `package` extends RootModule {
           libraries.kotestAssertionsCoreJvm
         )
         def jvmTestKotlincOptions = Seq("-Xcontext-receivers")
-        def jsModuleDeps = Seq(`arrow-atomic`.js)
         def jsTestModuleDeps = Seq(fx.`arrow-fx-coroutines`.js)
         def jsTestIvyDeps = Agg(
           libraries.coroutinesTestJs,
@@ -317,14 +315,25 @@ object `package` extends RootModule {
         )
       }
       object `arrow-cache4k` extends ArrowMultiplatformModule {
-        def jvmModuleDeps = Seq(`arrow-core`.jvm)
-        def jvmIvyDeps = Agg(libraries.cache4kJvm)
-        def jsModuleDeps = Seq(`arrow-core`.js)
-        def jsIvyDeps = Agg(libraries.cache4kJs)
+        object jvm extends ArrowPlatformJvmModule{
+          def moduleDeps = super.moduleDeps ++ Seq(`arrow-core`.jvm)
+          def ivyDeps = super.ivyDeps() ++ Agg(libraries.cache4kJvm)
+        }
+        object js extends ArrowPlatformJsModule{
+          def moduleDeps = super.moduleDeps ++ Seq(`arrow-core`.js)
+          def ivyDeps = super.ivyDeps() ++ Agg(libraries.cache4kJs)
+        }
+
+
       }
       object `arrow-core-high-arity` extends ArrowMultiplatformModule {
-        def jvmModuleDeps = Seq(`arrow-core`.jvm)
-        def jsModuleDeps = Seq(`arrow-core`.js)
+        object jvm extends ArrowPlatformJvmModule{
+          def moduleDeps = super.moduleDeps ++ Seq(`arrow-core`.jvm)
+        }
+        object js extends ArrowPlatformJsModule{
+          def moduleDeps = super.moduleDeps ++ Seq(`arrow-core`.js)
+        }
+
       }
       object `arrow-core-retrofit` extends ArrowJvmModule {
         def moduleDeps = Seq(`arrow-core`.jvm)
@@ -349,8 +358,16 @@ object `package` extends RootModule {
         )
       }
       object `arrow-core-serialization` extends ArrowMultiplatformModule {
-        def jvmModuleDeps = Seq(`arrow-core`.jvm)
-        def jvmIvyDeps = Agg(libraries.kotlinxSerializationCoreJvm)
+        object jvm extends ArrowPlatformJvmModule{
+          def moduleDeps = super.moduleDeps ++ Seq(`arrow-core`.jvm)
+          def ivyDeps = super.ivyDeps() ++ Agg(libraries.kotlinxSerializationCoreJvm)
+        }
+        object js extends ArrowPlatformJsModule{
+          def moduleDeps = super.moduleDeps ++ Seq(`arrow-core`.js)
+          def ivyDeps = super.ivyDeps() ++ Agg(libraries.kotlinxSerializationCoreJs)
+        }
+
+
         def jvmTestIvyDeps = Agg(
           libraries.kotlinTestJunit5,
           libraries.kotlinxSerializationJson,
@@ -358,8 +375,8 @@ object `package` extends RootModule {
           libraries.kotestAssertionsCoreJvm,
           libraries.kotestPropertyJvm
         )
-        def jsModuleDeps = Seq(`arrow-core`.js)
-        def jsIvyDeps = Agg(libraries.kotlinxSerializationCoreJs)
+
+
         def jsTestIvyDeps = Agg(
           libraries.kotlinxSerializationJsonJs,
           libraries.coroutinesTestJs,
@@ -375,8 +392,17 @@ object `package` extends RootModule {
         def jsTestTimeout = 60_000L
       }
       object `arrow-core` extends ArrowMultiplatformModule {
-        def jvmModuleDeps = Seq(`arrow-atomic`.jvm, `arrow-annotations`.jvm)
-        def jvmIvyDeps = Agg(libraries.kotlinxSerializationCoreJvm)
+        object jvm extends ArrowPlatformJvmModule{
+          def moduleDeps = super.moduleDeps ++ Seq(`arrow-atomic`.jvm, `arrow-annotations`.jvm)
+          def ivyDeps = super.ivyDeps() ++ Agg(libraries.kotlinxSerializationCoreJvm)
+          def kotlincOptions = super.kotlincOptions() ++ Seq("-Xcontext-receivers")
+        }
+        object js extends ArrowPlatformJsModule{
+          def moduleDeps = super.moduleDeps ++ Seq(`arrow-atomic`.js, `arrow-annotations`.js)
+          def ivyDeps = super.ivyDeps() ++ Agg(libraries.kotlinxSerializationCoreJs)
+        }
+
+
         def jvmTestModuleDeps = Seq(fx.`arrow-fx-coroutines`.jvm)
         def jvmTestIvyDeps = Agg(
           libraries.kotlinTestJunit5,
@@ -384,9 +410,7 @@ object `package` extends RootModule {
           libraries.kotestAssertionsCoreJvm,
           libraries.kotestPropertyJvm
         )
-        def jvmKotlincOptions = Seq("-Xcontext-receivers")
-        def jsModuleDeps = Seq(`arrow-atomic`.js, `arrow-annotations`.js)
-        def jsIvyDeps = Agg(libraries.kotlinxSerializationCoreJs)
+
         def jsTestModuleDeps = Seq(fx.`arrow-fx-coroutines`.js)
         def jsTestIvyDeps = Agg(
           libraries.coroutinesTestJs,
@@ -396,8 +420,14 @@ object `package` extends RootModule {
         def jsTestTimeout = 300_000L
       }
       object `arrow-eval` extends ArrowMultiplatformModule {
-        def jvmModuleDeps = Seq(`arrow-core`.jvm)
-        def jsModuleDeps = Seq(`arrow-core`.js)
+        object jvm extends ArrowPlatformJvmModule{
+          def moduleDeps = super.moduleDeps ++ Seq(`arrow-core`.jvm)
+        }
+        object js extends ArrowPlatformJsModule{
+          def moduleDeps = super.moduleDeps ++ Seq(`arrow-core`.js)
+        }
+
+
         def jvmTestIvyDeps = Agg(
           libraries.kotlinTestJunit5,
           libraries.kotestAssertionsCoreJvm,
@@ -409,8 +439,14 @@ object `package` extends RootModule {
         )
       }
       object `arrow-functions` extends ArrowMultiplatformModule {
-        def jvmModuleDeps = Seq(`arrow-atomic`.jvm, `arrow-annotations`.jvm)
-        def jsModuleDeps = Seq(`arrow-atomic`.js, `arrow-annotations`.js)
+        object jvm extends ArrowPlatformJvmModule{
+          def moduleDeps = super.moduleDeps ++ Seq(`arrow-atomic`.jvm, `arrow-annotations`.jvm)
+        }
+        object js extends ArrowPlatformJsModule{
+          def moduleDeps = super.moduleDeps ++ Seq(`arrow-atomic`.js, `arrow-annotations`.js)
+        }
+
+
         def jvmTestModuleDeps = Seq(fx.`arrow-fx-coroutines`.jvm)
         def jvmTestIvyDeps = Agg(
           libraries.kotlinTestJunit5,
@@ -429,10 +465,14 @@ object `package` extends RootModule {
 
     object fx extends Module {
       object `arrow-collectors` extends ArrowMultiplatformModule {
-        def jvmModuleDeps = Seq(core.`arrow-atomic`.jvm, `arrow-fx-coroutines`.jvm)
-        def jvmIvyDeps = Agg(libraries.coroutinesCoreJvm)
-        def jsModuleDeps = Seq(core.`arrow-atomic`.js, `arrow-fx-coroutines`.js)
-        def jsIvyDeps = Agg(libraries.coroutinesCoreJs)
+        object jvm extends ArrowPlatformJvmModule{
+          def moduleDeps = super.moduleDeps ++ Seq(core.`arrow-atomic`.jvm, `arrow-fx-coroutines`.jvm)
+          def ivyDeps = super.ivyDeps() ++ Agg(libraries.coroutinesCoreJvm)
+        }
+        object js extends ArrowPlatformJsModule{
+          def moduleDeps = super.moduleDeps ++ Seq(core.`arrow-atomic`.js, `arrow-fx-coroutines`.js)
+          def ivyDeps = super.ivyDeps() ++ Agg(libraries.coroutinesCoreJs)
+        }
 
         def jvmTestIvyDeps = Agg(
           libraries.kotlinTestJunit5,
@@ -449,10 +489,14 @@ object `package` extends RootModule {
         def jsTestTimeout = 60_000L
       }
       object `arrow-fx-coroutines` extends ArrowMultiplatformModule {
-        def jvmModuleDeps = Seq(core.`arrow-core`.jvm, core.`arrow-autoclose`.jvm)
-        def jvmIvyDeps = Agg(libraries.coroutinesCoreJvm)
-        def jsModuleDeps = Seq(core.`arrow-core`.js, core.`arrow-autoclose`.js)
-        def jsIvyDeps = Agg(libraries.coroutinesCoreJs)
+        object jvm extends ArrowPlatformJvmModule{
+          def moduleDeps = super.moduleDeps ++ Seq(core.`arrow-core`.jvm, core.`arrow-autoclose`.jvm)
+          def ivyDeps = super.ivyDeps() ++ Agg(libraries.coroutinesCoreJvm)
+        }
+        object js extends ArrowPlatformJsModule{
+          def moduleDeps = super.moduleDeps ++ Seq(core.`arrow-core`.js, core.`arrow-autoclose`.js)
+          def ivyDeps = super.ivyDeps() ++ Agg(libraries.coroutinesCoreJs)
+        }
 
         def jvmTestModuleDeps = Seq(core.`arrow-core`.jvm, core.`arrow-atomic`.jvm)
         def jsTestModuleDeps = Seq(core.`arrow-core`.js, core.`arrow-atomic`.js)
@@ -470,13 +514,17 @@ object `package` extends RootModule {
         def jsTestTimeout = 60_000L
       }
       object `arrow-fx-stm` extends ArrowMultiplatformModule {
+        object jvm extends ArrowPlatformJvmModule{
+          def moduleDeps = super.moduleDeps ++ Seq(core.`arrow-core`.jvm)
+          def ivyDeps = super.ivyDeps() ++ Agg(libraries.coroutinesCoreJvm)
+          def kotlincOptions = super.kotlincOptions() ++ additionalKotlincOptions
+        }
+        object js extends ArrowPlatformJsModule{
+          def moduleDeps = super.moduleDeps ++ Seq(core.`arrow-core`.js)
+          def ivyDeps = super.ivyDeps() ++ Agg(libraries.coroutinesCoreJs)
+          def kotlincOptions = super.kotlincOptions() ++ additionalKotlincOptions
+        }
         val additionalKotlincOptions = Seq("-Xconsistent-data-class-copy-visibility")
-        def jvmModuleDeps = Seq(core.`arrow-core`.jvm)
-        def jvmIvyDeps = Agg(libraries.coroutinesCoreJvm)
-        def jsModuleDeps = Seq(core.`arrow-core`.js)
-        def jsIvyDeps = Agg(libraries.coroutinesCoreJs)
-        def jvmKotlincOptions = additionalKotlincOptions
-        def jsKotlincOptions = additionalKotlincOptions
 
         def jvmTestModuleDeps = Seq(`arrow-fx-coroutines`.jvm)
         def jsTestModuleDeps = Seq(`arrow-fx-coroutines`.js)
@@ -528,8 +576,12 @@ object `package` extends RootModule {
         )
       }
       object `arrow-optics` extends ArrowMultiplatformModule {
-        def jvmModuleDeps = Seq(core.`arrow-core`.jvm)
-        def jsModuleDeps = Seq(core.`arrow-core`.js)
+        object jvm extends ArrowPlatformJvmModule{
+          def moduleDeps = super.moduleDeps ++ Seq(core.`arrow-core`.jvm)
+        }
+        object js extends ArrowPlatformJsModule{
+          def moduleDeps = super.moduleDeps ++ Seq(core.`arrow-core`.js)
+        }
         def jvmTestKotlincOptions = Seq(commonSourcesArg(jvm.test.sources(), "commonTest"))
         def jsTestKotlincOptions = Seq(commonSourcesArg(js.test.sources(), "commonTest"))
 
@@ -549,10 +601,14 @@ object `package` extends RootModule {
 
     object resilience extends Module {
       object `arrow-resilience` extends ArrowMultiplatformModule {
-        def jvmModuleDeps = Seq(core.`arrow-core`.jvm)
-        def jvmIvyDeps = Agg(libraries.coroutinesCoreJvm)
-        def jsModuleDeps = Seq(core.`arrow-core`.js)
-        def jsIvyDeps = Agg(libraries.coroutinesCoreJs)
+        object jvm extends ArrowPlatformJvmModule{
+          def moduleDeps = super.moduleDeps ++ Seq(core.`arrow-core`.jvm)
+          def ivyDeps = super.ivyDeps() ++ Agg(libraries.coroutinesCoreJvm)
+        }
+        object js extends ArrowPlatformJsModule{
+          def moduleDeps = super.moduleDeps ++ Seq(core.`arrow-core`.js)
+          def ivyDeps = super.ivyDeps() ++ Agg(libraries.coroutinesCoreJs)
+        }
 
         def jvmTestModuleDeps = Seq(fx.`arrow-fx-coroutines`.jvm)
         def jvmTestIvyDeps = Agg(

--- a/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -326,10 +326,10 @@ trait KotlinModule extends JavaModule { outer =>
   def kotlincOptions: T[Seq[String]] = Task {
     val options = Seq.newBuilder[String]
     options += "-no-stdlib"
-    val kotlinkotlinLanguageVersion = kotlinLanguageVersion()
-    if (!kotlinkotlinLanguageVersion.isBlank) {
+    val languageVersion = kotlinLanguageVersion()
+    if (!languageVersion.isBlank) {
       options += "-language-version"
-      options += kotlinkotlinLanguageVersion
+      options += languageVersion
     }
     val kotlinkotlinApiVersion = kotlinApiVersion()
     if (!kotlinkotlinApiVersion.isBlank) {

--- a/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -171,7 +171,7 @@ trait KotlinModule extends JavaModule { outer =>
         Seq(
           s"-sourceSet",
           Seq(
-            s"-src ${docSources().map(_.path).mkString(";")}",
+            s"-src ${docSources().map(_.path).filter(os.exists).mkString(";")}",
             s"-displayName $dokkaSourceSetDisplayName",
             s"-classpath $depClasspath",
             s"-analysisPlatform $dokkaAnalysisPlatform"

--- a/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -67,17 +67,17 @@ trait KotlinModule extends JavaModule { outer =>
   /**
    * The compiler language version. Default is not set.
    */
-  def languageVersion: T[String] = Task { "" }
+  def kotlinLanguageVersion: T[String] = Task { "" }
 
   /**
    * The compiler API version. Default is not set.
    */
-  def apiVersion: T[String] = Task { "" }
+  def kotlinApiVersion: T[String] = Task { "" }
 
   /**
    * Flag to use explicit API check in the compiler. Default is `false`.
    */
-  def explicitApi: T[Boolean] = Task { false }
+  def kotlinExplicitApi: T[Boolean] = Task { false }
 
   type CompileProblemReporter = mill.api.CompileProblemReporter
 
@@ -283,7 +283,7 @@ trait KotlinModule extends JavaModule { outer =>
             "-classpath",
             compileCp.iterator.mkString(File.pathSeparator)
           ),
-          when(explicitApi())(
+          when(kotlinExplicitApi())(
             "-Xexplicit-api=strict"
           ),
           kotlincOptions(),
@@ -326,15 +326,15 @@ trait KotlinModule extends JavaModule { outer =>
   def kotlincOptions: T[Seq[String]] = Task {
     val options = Seq.newBuilder[String]
     options += "-no-stdlib"
-    val kotlinLanguageVersion = languageVersion()
-    if (!kotlinLanguageVersion.isBlank) {
+    val kotlinkotlinLanguageVersion = kotlinLanguageVersion()
+    if (!kotlinkotlinLanguageVersion.isBlank) {
       options += "-language-version"
-      options += kotlinLanguageVersion
+      options += kotlinkotlinLanguageVersion
     }
-    val kotlinApiVersion = apiVersion()
-    if (!kotlinApiVersion.isBlank) {
+    val kotlinkotlinApiVersion = kotlinApiVersion()
+    if (!kotlinkotlinApiVersion.isBlank) {
       options += "-api-version"
-      options += kotlinApiVersion
+      options += kotlinkotlinApiVersion
     }
     options.result()
   }
@@ -371,7 +371,7 @@ trait KotlinModule extends JavaModule { outer =>
    * A test sub-module linked to its parent module best suited for unit-tests.
    */
   trait KotlinTests extends JavaTests with KotlinModule {
-    override def explicitApi: T[Boolean] = false
+    override def kotlinExplicitApi: T[Boolean] = false
     override def kotlinVersion: T[String] = Task { outer.kotlinVersion() }
     override def kotlinCompilerVersion: T[String] = Task { outer.kotlinCompilerVersion() }
     override def kotlincOptions: T[Seq[String]] = Task {

--- a/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -40,7 +40,7 @@ trait KotlinModule extends JavaModule { outer =>
    * Subset of [[allSourceFiles]].
    */
   def allKotlinSourceFiles: T[Seq[PathRef]] = Task {
-    allSourceFiles().filter(path => Seq("kt", "kts").exists(path.path.ext.toLowerCase() == _))
+    allSourceFiles().filter(path => Seq("kt", "kts").contains(path.path.ext.toLowerCase()))
   }
 
   /**
@@ -63,6 +63,21 @@ trait KotlinModule extends JavaModule { outer =>
    * Default is derived from [[kotlinVersion]].
    */
   def kotlinCompilerVersion: T[String] = Task { kotlinVersion() }
+
+  /**
+   * The compiler language version. Default is not set.
+   */
+  def languageVersion: T[String] = Task { "" }
+
+  /**
+   * The compiler API version. Default is not set.
+   */
+  def apiVersion: T[String] = Task { "" }
+
+  /**
+   * Flag to use explicit API check in the compiler. Default is `false`.
+   */
+  def explicitApi: T[Boolean] = Task { false }
 
   type CompileProblemReporter = mill.api.CompileProblemReporter
 
@@ -145,10 +160,11 @@ trait KotlinModule extends JavaModule { outer =>
         dokkaPluginsClasspath().map(_.path).mkString(";")
       )
 
+      // TODO need to provide source sets for the module deps
       val options = dokkaOptions() ++
         Seq("-outputDir", dokkaDir.toString()) ++
         pluginClasspathOption ++
-        Seq("-sourceSet", s"-src $millSourcePath")
+        docSources().flatMap(pathRef => Seq("-sourceSet", s"-src ${pathRef.path}"))
 
       T.log.info("dokka options: " + options)
 
@@ -244,10 +260,17 @@ trait KotlinModule extends JavaModule { outer =>
         val compilerArgs: Seq[String] = Seq(
           // destdir
           Seq("-d", classes.toString()),
+          // apply multi-platform support (expect/actual)
+          // TODO if there is penalty for activating it in the compiler, put it behind configuration flag
+          Seq("-Xmulti-platform"),
           // classpath
           when(compileCp.iterator.nonEmpty)(
             "-classpath",
             compileCp.iterator.mkString(File.pathSeparator)
+          ),
+          when(explicitApi())(
+            "-Xexplicit-api",
+            "strict"
           ),
           kotlincOptions(),
           extraKotlinArgs,
@@ -287,13 +310,19 @@ trait KotlinModule extends JavaModule { outer =>
    * Additional Kotlin compiler options to be used by [[compile]].
    */
   def kotlincOptions: T[Seq[String]] = Task {
-    Seq("-no-stdlib") ++
-      when(!kotlinVersion().startsWith("1.0"))(
-        "-language-version",
-        kotlinVersion().split("[.]", 3).take(2).mkString("."),
-        "-api-version",
-        kotlinVersion().split("[.]", 3).take(2).mkString(".")
-      )
+    val options = Seq.newBuilder[String]
+    options += "-no-stdlib"
+    val kotlinLanguageVersion = languageVersion()
+    if (!kotlinLanguageVersion.isBlank) {
+      options += "-language-version"
+      options += kotlinLanguageVersion
+    }
+    val kotlinApiVersion = apiVersion()
+    if (!kotlinApiVersion.isBlank) {
+      options += "-api-version"
+      options += kotlinApiVersion
+    }
+    options.result()
   }
 
   private[kotlinlib] def internalCompileJavaFiles(
@@ -328,9 +357,13 @@ trait KotlinModule extends JavaModule { outer =>
    * A test sub-module linked to its parent module best suited for unit-tests.
    */
   trait KotlinTests extends JavaTests with KotlinModule {
+    override def explicitApi: T[Boolean] = false
     override def kotlinVersion: T[String] = Task { outer.kotlinVersion() }
     override def kotlinCompilerVersion: T[String] = Task { outer.kotlinCompilerVersion() }
-    override def kotlincOptions: T[Seq[String]] = Task { outer.kotlincOptions() }
+    override def kotlincOptions: T[Seq[String]] = Task {
+      outer.kotlincOptions().filterNot(_.startsWith("-Xcommon-sources")) ++
+        Seq(s"-Xfriend-paths=${outer.compile().classes.path.toString()}")
+    }
   }
 
 }

--- a/kotlinlib/src/mill/kotlinlib/js/KotlinJsModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/js/KotlinJsModule.scala
@@ -246,6 +246,9 @@ trait KotlinJsModule extends KotlinModule { outer =>
 
   // region private
 
+  protected override def dokkaAnalysisPlatform = "js"
+  protected override def dokkaSourceSetDisplayName = "js"
+
   private[kotlinlib] def kotlinJsCompile(
       outputMode: OutputMode,
       allKotlinSourceFiles: Seq[PathRef],
@@ -365,7 +368,7 @@ trait KotlinJsModule extends KotlinModule { outer =>
       case None => Seq.empty
     })
     if (explicitApi) {
-      innerCompilerArgs ++= Seq("-Xexplicit-api", "strict")
+      innerCompilerArgs ++= Seq("-Xexplicit-api=strict")
     }
 
     val compilerArgs: Seq[String] = Seq(

--- a/kotlinlib/src/mill/kotlinlib/js/KotlinJsModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/js/KotlinJsModule.scala
@@ -99,7 +99,7 @@ trait KotlinJsModule extends KotlinModule { outer =>
       kotlinVersion = kotlinVersion(),
       destinationRoot = T.dest,
       artifactId = artifactId(),
-      explicitApi = explicitApi(),
+      explicitApi = kotlinExplicitApi(),
       extraKotlinArgs = kotlincOptions(),
       worker = kotlinWorkerTask()
     )
@@ -196,7 +196,7 @@ trait KotlinJsModule extends KotlinModule { outer =>
       kotlinVersion = kotlinVersion(),
       destinationRoot = T.dest,
       artifactId = artifactId(),
-      explicitApi = explicitApi(),
+      explicitApi = kotlinExplicitApi(),
       extraKotlinArgs = kotlincOptions() ++ extraKotlinArgs,
       worker = kotlinWorkerTask()
     )
@@ -221,7 +221,7 @@ trait KotlinJsModule extends KotlinModule { outer =>
       kotlinVersion = kotlinVersion(),
       destinationRoot = T.dest,
       artifactId = artifactId(),
-      explicitApi = explicitApi(),
+      explicitApi = kotlinExplicitApi(),
       extraKotlinArgs = kotlincOptions(),
       worker = kotlinWorkerTask()
     )

--- a/kotlinlib/src/mill/kotlinlib/js/KotlinJsModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/js/KotlinJsModule.scala
@@ -2,7 +2,7 @@ package mill.kotlinlib.js
 
 import mainargs.arg
 import mill.api.{PathRef, Result}
-import mill.define.{Command, Segment, Task}
+import mill.define.{Command, Task}
 import mill.kotlinlib.worker.api.{KotlinWorker, KotlinWorkerTarget}
 import mill.kotlinlib.{Dep, DepSyntax, KotlinModule}
 import mill.scalalib.Lib
@@ -72,9 +72,9 @@ trait KotlinJsModule extends KotlinModule { outer =>
     T.traverse(transitiveModuleCompileModuleDeps)(m =>
       Task.Anon {
         val transitiveModuleArtifactPath =
-          (if (m.isInstanceOf[KotlinJsModule]) {
-             m.asInstanceOf[KotlinJsModule].createKlib(T.dest, m.compile().classes)
-           } else m.compile().classes)
+          if (m.isInstanceOf[KotlinJsModule] && m != friendModule.orNull) {
+            m.asInstanceOf[KotlinJsModule].klib()
+          } else m.compile().classes
         m.localCompileClasspath() ++ Agg(transitiveModuleArtifactPath)
       }
     )().flatten
@@ -98,6 +98,8 @@ trait KotlinJsModule extends KotlinModule { outer =>
       esTarget = kotlinJsESTarget(),
       kotlinVersion = kotlinVersion(),
       destinationRoot = T.dest,
+      artifactId = artifactId(),
+      explicitApi = explicitApi(),
       extraKotlinArgs = kotlincOptions(),
       worker = kotlinWorkerTask()
     )
@@ -113,6 +115,7 @@ trait KotlinJsModule extends KotlinModule { outer =>
       moduleKind = moduleKind(),
       binaryDir = linkBinary().classes.path,
       runTarget = kotlinJsRunTarget(),
+      artifactId = artifactId(),
       envArgs = T.env,
       workingDir = T.dest
     ).map(_ => ()).getOrThrow
@@ -130,12 +133,15 @@ trait KotlinJsModule extends KotlinModule { outer =>
       mill.api.Result.Failure("runMain is not supported in Kotlin/JS.")
     }
 
+  protected[js] def friendModule: Option[KotlinJsModule] = None
+
   protected[js] def runJsBinary(
       args: Args = Args(),
       binaryKind: Option[BinaryKind],
       moduleKind: ModuleKind,
       binaryDir: os.Path,
       runTarget: Option[RunTarget],
+      artifactId: String,
       envArgs: Map[String, String] = Map.empty[String, String],
       workingDir: os.Path
   )(implicit ctx: mill.api.Ctx): Result[Int] = {
@@ -153,7 +159,7 @@ trait KotlinJsModule extends KotlinModule { outer =>
 
     runTarget match {
       case Some(RunTarget.Node) =>
-        val binaryPath = (binaryDir / s"${moduleName()}.${moduleKind.extension}")
+        val binaryPath = (binaryDir / s"$artifactId.${moduleKind.extension}")
           .toIO.getAbsolutePath
         Jvm.runSubprocessWithResult(
           commandArgs = Seq(
@@ -189,6 +195,8 @@ trait KotlinJsModule extends KotlinModule { outer =>
       esTarget = kotlinJsESTarget(),
       kotlinVersion = kotlinVersion(),
       destinationRoot = T.dest,
+      artifactId = artifactId(),
+      explicitApi = explicitApi(),
       extraKotlinArgs = kotlincOptions() ++ extraKotlinArgs,
       worker = kotlinWorkerTask()
     )
@@ -212,25 +220,31 @@ trait KotlinJsModule extends KotlinModule { outer =>
       esTarget = kotlinJsESTarget(),
       kotlinVersion = kotlinVersion(),
       destinationRoot = T.dest,
+      artifactId = artifactId(),
+      explicitApi = explicitApi(),
       extraKotlinArgs = kotlincOptions(),
       worker = kotlinWorkerTask()
     )
   }
 
-  // endregion
-
-  // region private
-
-  private def createKlib(destFolder: os.Path, irPathRef: PathRef): PathRef = {
-    val outputPath = destFolder / s"${moduleName()}.klib"
+  /**
+   * A klib containing only this module's resources and compiled IR files,
+   * without those from upstream modules and dependencies
+   */
+  def klib: T[PathRef] = Task {
+    val outputPath = T.dest / s"${artifactId()}.klib"
     Jvm.createJar(
       outputPath,
-      Agg(irPathRef.path),
+      Agg(compile().classes.path),
       mill.api.JarManifest.MillDefault,
       fileFilter = (_, _) => true
     )
     PathRef(outputPath)
   }
+
+  // endregion
+
+  // region private
 
   private[kotlinlib] def kotlinJsCompile(
       outputMode: OutputMode,
@@ -246,6 +260,8 @@ trait KotlinJsModule extends KotlinModule { outer =>
       esTarget: Option[String],
       kotlinVersion: String,
       destinationRoot: os.Path,
+      artifactId: String,
+      explicitApi: Boolean,
       extraKotlinArgs: Seq[String],
       worker: KotlinWorker
   )(implicit ctx: mill.api.Ctx): Result[CompilationResult] = {
@@ -291,8 +307,7 @@ trait KotlinJsModule extends KotlinModule { outer =>
         }
       )
     }
-    // what is the better way to find a module simple name, without root path?
-    innerCompilerArgs ++= Seq("-ir-output-name", moduleName())
+    innerCompilerArgs ++= Seq("-ir-output-name", s"$artifactId")
     if (produceSourceMaps) {
       innerCompilerArgs += "-source-map"
       innerCompilerArgs ++= Seq(
@@ -315,8 +330,12 @@ trait KotlinJsModule extends KotlinModule { outer =>
     innerCompilerArgs += "-Xir-only"
     if (splitPerModule) {
       innerCompilerArgs += s"-Xir-per-module"
-      innerCompilerArgs += s"-Xir-per-module-output-name=${fullModuleName()}"
+      // should be unique among all the modules loaded in the consumer classpath
+      innerCompilerArgs += s"-Xir-per-module-output-name=$artifactId"
     }
+    // apply multi-platform support (expect/actual)
+    // TODO if there is penalty for activating it in the compiler, put it behind configuration flag
+    innerCompilerArgs += "-Xmulti-platform"
     val outputArgs = outputMode match {
       case OutputMode.KlibFile =>
         Seq(
@@ -339,11 +358,15 @@ trait KotlinJsModule extends KotlinModule { outer =>
     }
 
     innerCompilerArgs ++= outputArgs
-    innerCompilerArgs += s"-Xir-module-name=${moduleName()}"
+    // should be unique among all the modules loaded in the consumer classpath
+    innerCompilerArgs += s"-Xir-module-name=$artifactId"
     innerCompilerArgs ++= (esTarget match {
       case Some(x) => Seq("-target", x)
       case None => Seq.empty
     })
+    if (explicitApi) {
+      innerCompilerArgs ++= Seq("-Xexplicit-api", "strict")
+    }
 
     val compilerArgs: Seq[String] = Seq(
       innerCompilerArgs.result(),
@@ -368,7 +391,7 @@ trait KotlinJsModule extends KotlinModule { outer =>
     }
 
     val artifactLocation = outputMode match {
-      case OutputMode.KlibFile => compileDestination / s"${moduleName()}.klib"
+      case OutputMode.KlibFile => compileDestination / s"$artifactId.klib"
       case OutputMode.KlibDir => compileDestination
       case OutputMode.Js => compileDestination
     }
@@ -391,19 +414,6 @@ trait KotlinJsModule extends KotlinModule { outer =>
       case Some(BinaryKind.Library) => OutputMode.KlibFile
       case Some(BinaryKind.Executable) => OutputMode.Js
     }
-
-  // these 2 exist to ignore values added to the display name in case of the cross-modules
-  // we already have cross-modules in the paths, so we don't need them here
-  private def fullModuleNameSegments() = {
-    millModuleSegments.value
-      .collect { case label: Segment.Label => label.value } match {
-      case Nil => Seq("root")
-      case segments => segments
-    }
-  }
-
-  protected[js] def moduleName(): String = fullModuleNameSegments().last
-  protected[js] def fullModuleName(): String = fullModuleNameSegments().mkString("-")
 
   // **NOTE**: This logic may (and probably is) be incomplete
   private def isKotlinJsLibrary(path: os.Path)(implicit ctx: mill.api.Ctx): Boolean = {
@@ -428,6 +438,15 @@ trait KotlinJsModule extends KotlinModule { outer =>
     }
   }
 
+  override def artifactId: T[String] = Task {
+    val name = super.artifactId()
+    if (name.isEmpty) {
+      "root"
+    } else {
+      name
+    }
+  }
+
   // endregion
 
   // region Tests module
@@ -436,9 +455,14 @@ trait KotlinJsModule extends KotlinModule { outer =>
    * Generic trait to run tests for Kotlin/JS which doesn't specify test
    * framework. For the particular implementation see [[KotlinTestPackageTests]] or [[KotestTests]].
    */
-  trait KotlinJsTests extends KotlinTests with KotlinJsModule {
+  trait KotlinJsTests extends KotlinJsModule with KotlinTests {
 
     private val defaultXmlReportName = "test-report.xml"
+
+    /**
+     * Test timeout in milliseconds. Default is 2000.
+     */
+    def testTimeout: T[Long] = Task { 2000L }
 
     // region private
 
@@ -473,6 +497,17 @@ trait KotlinJsModule extends KotlinModule { outer =>
 
     // endregion
 
+    override def kotlincOptions: T[Seq[String]] = Task {
+      super.kotlincOptions().map { item =>
+        if (item.startsWith("-Xfriend-paths=")) {
+          // JVM -> JS option name
+          item.replace("-Xfriend-paths=", "-Xfriend-modules=")
+        } else {
+          item
+        }
+      }
+    }
+
     override def testFramework = ""
 
     override def kotlinJsRunTarget: T[Option[RunTarget]] = outer.kotlinJsRunTarget()
@@ -486,10 +521,18 @@ trait KotlinJsModule extends KotlinModule { outer =>
         this.test(args: _*)()
       }
 
+    override protected[js] def friendModule: Option[KotlinJsModule] = Some(outer)
+
     override protected def testTask(
         args: Task[Seq[String]],
         globSelectors: Task[Seq[String]]
     ): Task[(String, Seq[TestResult])] = Task.Anon {
+      val runTarget = kotlinJsRunTarget()
+      if (runTarget.isEmpty) {
+        throw new IllegalStateException(
+          "Cannot run Kotlin/JS tests, because run target is not specified."
+        )
+      }
       runJsBinary(
         // TODO add runner to be able to use test selector
         args = Args(args() ++ Seq(
@@ -498,6 +541,8 @@ trait KotlinJsModule extends KotlinModule { outer =>
           "--require",
           sourceMapSupportModule().path.toString(),
           mochaModule().path.toString(),
+          "--timeout",
+          testTimeout().toString,
           "--reporter",
           "xunit",
           "--reporter-option",
@@ -506,7 +551,8 @@ trait KotlinJsModule extends KotlinModule { outer =>
         binaryKind = Some(BinaryKind.Executable),
         moduleKind = moduleKind(),
         binaryDir = linkBinary().classes.path,
-        runTarget = kotlinJsRunTarget(),
+        runTarget = runTarget,
+        artifactId = artifactId(),
         envArgs = T.env,
         workingDir = T.dest
       )

--- a/kotlinlib/test/src/mill/kotlinlib/js/KotlinJsLinkTests.scala
+++ b/kotlinlib/test/src/mill/kotlinlib/js/KotlinJsLinkTests.scala
@@ -15,6 +15,8 @@ object KotlinJsLinkTests extends TestSuite {
     override def splitPerModule: T[Boolean] = crossValue
     override def kotlinJsBinaryKind: T[Option[BinaryKind]] = Some(BinaryKind.Executable)
     override def moduleDeps = Seq(module.bar)
+    // drop cross-value
+    override def artifactNameParts = super.artifactNameParts().dropRight(1)
   }
 
   object module extends TestBaseModule {


### PR DESCRIPTION
This PR partially addresses #3670: it contains working example, but doesn't contain any docs.

This example contains compilation and test execution for all the modules of https://github.com/arrow-kt/arrow for the JVM and JS (Node) targets, except [arrow-optics-compose](https://github.com/arrow-kt/arrow/tree/main/arrow-libs/optics/arrow-optics-compose) module (it requires better Android support by Mill).

Full example run takes 6 minutes on my machine, so it is extracted into a dedicated CI job.

The following Gradle plugins are not added to the example build script, because their respective tooling is Gradle-dependent (no raw-jar or CLI):

* https://github.com/xvik/gradle-animalsniffer-plugin (although maybe it is possible to use options from https://www.mojohaus.org/animal-sniffer/)
* https://github.com/Kotlin/kotlinx-knit
* https://github.com/Kotlin/binary-compatibility-validator
* https://github.com/diffplug/spotless

There is also no publication support in this example (requires Kotlin Multiplatform publishing support, see https://github.com/com-lihaoyi/mill/issues/3867)

I faced the following issues while writing this example:

* There is quite a lot of duplication for JVM/JS configuration, because there is no support of [Kotlin Multiplatform hierarchies](https://kotlinlang.org/docs/multiplatform-hierarchy.html)
* Each Maven or Module dependency should be with JS/JVM/etc. target qualifier, which also quite explodes amount of code to be written. This is also a question of Kotlin Multiplatform hierarchies support and resolution.
* Until KMP hierarchies and target resolution support is not implemented, adding a new compilation target will bring quite a lot of new code in the build script. And there is a lot of targets in Arrow: https://github.com/arrow-kt/arrow-gradle-config/blob/97ba7b5eab810a336cf4070eb717f05533d208a8/arrow-gradle-config-kotlin/src/main/kotlin/io.arrow-kt.arrow-gradle-config-kotlin.gradle.kts#L34-L69
* There is no possibility to disable tests for the particular module (so I had to use a hack with overriding `compile` / `test` tasks) - this is because tests is dedicated module, but if comes as a part of the trait, we cannot add / remove it dynamically. Having such control is handy when certain multiplatform modules have a common trait for the main compilation unit, but some of them may have no tests.

Regarding docs: I think it is too early to write any comparison with Gradle, because clearly new functionality will be added to the Kotlin support in Mill which will affect overall execution time and also the comparison should be done not only for JVM targets, but for Kotlin/JS and Kotlin/Native targets as well. And ideally it should be a defined methodology for such testing (for example, certain Gradle plugins should be removed from the Arrow Gradle build script, to have the same set as Mill build script; compiler execution time should be excluded (it may be different because of the different flags passed to it under the hood)).

So I propose to open a dedicated bounty for writing such doc.