### PR TITLE
Add nice error when non-exclusive task depends on exclusive task

### DIFF
--- a/integration/failure/non-exclusive-depends-on-exclusive/resources/build.mill
+++ b/integration/failure/non-exclusive-depends-on-exclusive/resources/build.mill
@@ -1,0 +1,13 @@
+package build
+import mill._, mill.eval.Evaluator
+
+def foo = Task{1}
+def cleanClientWrong(ev: Evaluator) = Task.Command {
+  clean(ev, "foo")()
+  println("cleanClientWrong done")
+}
+
+def cleanClientRight(ev: Evaluator) = Task.Command(exclusive = true) {
+  clean(ev, "foo")()
+  println("cleanClientRight done")
+}

--- a/integration/failure/non-exclusive-depends-on-exclusive/src/NonExclusiveDependsOnExclusive.scala
+++ b/integration/failure/non-exclusive-depends-on-exclusive/src/NonExclusiveDependsOnExclusive.scala
@@ -9,7 +9,9 @@ object NonExclusiveDependsOnExclusive extends UtestIntegrationTestSuite {
     test("wrong") - integrationTest { tester =>
       val res = tester.eval("cleanClientWrong")
       assert(res.isSuccess == false)
-      assert(res.err.contains("Non-exclusive task cleanClientWrong cannot depend on exclusive task clean"))
+      assert(res.err.contains(
+        "Non-exclusive task cleanClientWrong cannot depend on exclusive task clean"
+      ))
       assert(!res.out.contains("cleanClientWrong done"))
     }
     test("right") - integrationTest { tester =>

--- a/integration/failure/non-exclusive-depends-on-exclusive/src/NonExclusiveDependsOnExclusive.scala
+++ b/integration/failure/non-exclusive-depends-on-exclusive/src/NonExclusiveDependsOnExclusive.scala
@@ -1,0 +1,22 @@
+package mill.integration
+
+import mill.testkit.UtestIntegrationTestSuite
+
+import utest._
+
+object NonExclusiveDependsOnExclusive extends UtestIntegrationTestSuite {
+  val tests: Tests = Tests {
+    test("wrong") - integrationTest { tester =>
+      val res = tester.eval("cleanClientWrong")
+      assert(res.isSuccess == false)
+      assert(res.err.contains("Non-exclusive task cleanClientWrong cannot depend on exclusive task clean"))
+      assert(!res.out.contains("cleanClientWrong done"))
+    }
+    test("right") - integrationTest { tester =>
+      val res = tester.eval("cleanClientRight")
+      assert(res.isSuccess == true)
+      assert(res.out.contains("cleanClientRight done"))
+
+    }
+  }
+}

--- a/main/eval/src/mill/eval/EvaluatorCore.scala
+++ b/main/eval/src/mill/eval/EvaluatorCore.scala
@@ -99,24 +99,25 @@ private[mill] trait EvaluatorCore extends GroupEvaluator {
       // due to the topological order of traversal.
       for (terminal <- terminals) {
         val deps = interGroupDeps(terminal)
-        def isExclusiveCommand(t: Task[_]) = t match{
+        def isExclusiveCommand(t: Task[_]) = t match {
           case c: Command[_] if c.exclusive => true
           case _ => false
         }
 
         val group = sortedGroups.lookupKey(terminal)
-        val exclusiveDeps =  deps.filter(d => isExclusiveCommand(d.task))
+        val exclusiveDeps = deps.filter(d => isExclusiveCommand(d.task))
 
-        if (!isExclusiveCommand(terminal.task) && exclusiveDeps.nonEmpty){
+        if (!isExclusiveCommand(terminal.task) && exclusiveDeps.nonEmpty) {
           val failure = Result.Failure(
             s"Non-exclusive task ${terminal.render} cannot depend on exclusive task " +
-            exclusiveDeps.map(_.render).mkString(", ")
+              exclusiveDeps.map(_.render).mkString(", ")
           )
-          val taskResults = group.map(t => (t, TaskResult[(Val, Int)](failure, () => failure))).toMap
+          val taskResults =
+            group.map(t => (t, TaskResult[(Val, Int)](failure, () => failure))).toMap
           futures(terminal) = Future.successful(
             Some(GroupEvaluator.Results(taskResults, group.toSeq, false, -1, -1))
           )
-        }else {
+        } else {
           futures(terminal) = Future.sequence(deps.map(futures)).map { upstreamValues =>
             val countMsg = mill.util.Util.leftPad(
               count.getAndIncrement().toString,
@@ -138,7 +139,6 @@ private[mill] trait EvaluatorCore extends GroupEvaluator {
                 case Terminal.Task(task) => None
                 case t: Terminal.Labelled[_] => Some(Terminal.printTerm(t))
               }
-
 
               // should we log progress?
               val logRun = targetLabel.isDefined && {


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/3875

I placed a check to raise an error when a non-exclusive task depends on an exclusive task. 

We could place this check any time from task instantiation to just before the `NoSuchElementException` gets thrown. I ended up putting it as late as possible, such that the failure is localized, which allows other un-related parts of the build to proceed despite the failure, as well as allowing other errors in the build to be reported in parallel (rather than having to re-run the build over and over after fixing each one to see the next one)

Covered with an integration test that asserts on the error message. Best reviewed with Ignore Whitespace