### PR TITLE
CI: Reuse built artifacts in publish jobs (sonatype, github)

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -21,9 +21,33 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build-artifacts:
+    # when in master repo, publish all tags and manual runs on main
+    if: github.repository == 'com-lihaoyi/mill'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with: {fetch-depth: 0}
+
+      - uses: coursier/cache-action@v6
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: temurin
+
+      - run: ./mill -i __.publishArtifacts
+
+      - uses: actions/upload-artifact@v4.4.3
+        with:
+          path: .
+          include-hidden-files: true
+
   publish-sonatype:
     # when in master repo, publish all tags and manual runs on main
     if: github.repository == 'com-lihaoyi/mill'
+    needs: build-artifacts
     runs-on: ubuntu-latest
 
     # only run one publish job for the same sha at the same time
@@ -40,8 +64,9 @@ jobs:
       LC_ALL: "en_US.UTF-8"
 
     steps:
-      - uses: actions/checkout@v4
-        with: {fetch-depth: 0}
+      - uses: actions/download-artifact@v4
+        with:
+          path: .
 
       - uses: coursier/cache-action@v6
 
@@ -62,8 +87,9 @@ jobs:
       REPO_ACCESS_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v4
-        with: {fetch-depth: 0}
+      - uses: actions/download-artifact@v4
+        with:
+          path: .
 
       - uses: coursier/cache-action@v6
 

--- a/.github/workflows/run-mill-action.yml
+++ b/.github/workflows/run-mill-action.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Run Mill '${{ inputs.millargs }}'
         # Mill tests are pretty heavy so run them only 3x parallel on 4 core Github Actions runners
-        run:  ./mill -i -j3 -k ${{ inputs.millargs }}
+        run: ./mill -i -j3 -k ${{ inputs.millargs }}
         if: inputs.millargs != '' && !startsWith(inputs.os, 'windows')
 
       - name: Run Mill (on Windows) '${{ inputs.millargs }}'


### PR DESCRIPTION
This should avoid duplicated build work.
It also makes sure, we publish identical jars everywhere.
Potentially needed GHA Job retries will be faster too.

This is untested. We should do at least one manual run before we tag the next release.
