### PR TITLE
Filter out anonymous classes during test discovery

### DIFF
--- a/kotlinlib/test/resources/hello-world-kotlin/main/kotest/src/FooTest.kt
+++ b/kotlinlib/test/resources/hello-world-kotlin/main/kotest/src/FooTest.kt
@@ -1,0 +1,15 @@
+package hello.tests
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import hello.getHelloString
+
+class FooTest : FunSpec({
+    test("testFailure") {
+        getHelloString() shouldBe "Hello, world!"
+    }
+
+    test("testSuccess") {
+        getHelloString() shouldBe "WRONG!"
+    }
+})

--- a/testrunner/src/mill/testrunner/TestRunnerUtils.scala
+++ b/testrunner/src/mill/testrunner/TestRunnerUtils.scala
@@ -70,6 +70,12 @@ import scala.jdk.CollectionConverters.IteratorHasAsScala
             .flatten
         )
       }
+      // I think this is a bug in sbt-junit-interface. AFAICT, JUnit is not
+      // meant to pick up non-static inner classes as test suites, and doing
+      // so makes the jimfs test suite fail
+      //
+      // https://stackoverflow.com/a/17468590
+      .filter { case (c, f) => !c.isMemberClass && !c.isAnonymousClass }
 
     testClasses
   }
@@ -109,12 +115,6 @@ import scala.jdk.CollectionConverters.IteratorHasAsScala
 
     val runner = framework.runner(args.toArray, Array[String](), cl)
     val testClasses = discoverTests(cl, framework, testClassfilePath)
-      // I think this is a bug in sbt-junit-interface. AFAICT, JUnit is not
-      // meant to pick up non-static inner classes as test suites, and doing
-      // so makes the jimfs test suite fail
-      //
-      // https://stackoverflow.com/a/17468590
-      .filter { case (c, f) => !c.isMemberClass }
 
     val tasks = runner.tasks(
       for ((cls, fingerprint) <- testClasses.iterator.toArray if classFilter(cls))


### PR DESCRIPTION
Mitigates https://github.com/com-lihaoyi/mill/issues/3910 by hackily filtering out all anonymous classes, but non-anonymous non-test classes still cause the problem

Added a unit test to check this specific misbehavior