### PR TITLE
Improve `inspect`

### DIFF
--- a/integration/feature/docannotations/resources/build.mill
+++ b/integration/feature/docannotations/resources/build.mill
@@ -1,6 +1,7 @@
 package build
 import mill._
 import mill.scalalib._
+import $packages._
 
 trait JUnitTests extends TestModule.Junit4 {
 
@@ -41,7 +42,7 @@ object core extends JavaModule {
    * Core Task Docz!
    */
   def task = Task {
-    import collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     println(this.getClass.getClassLoader.getResources("scalac-plugin.xml").asScala.toList)
     "Hello!"
   }
@@ -55,7 +56,7 @@ object MyJavaTaskModule extends JavaModule {
     allSourceFiles().map(f => os.read.lines(f.path).size).sum
   }
   def task = Task {
-    import collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     println(this.getClass.getClassLoader.getResources("scalac-plugin.xml").asScala.toList)
     "Hello!"
   }

--- a/integration/feature/docannotations/resources/core3/package.mill
+++ b/integration/feature/docannotations/resources/core3/package.mill
@@ -1,0 +1,5 @@
+package build.core3
+
+import mill.javalib.JavaModule
+
+object `package` extends RootModule with JavaModule

--- a/integration/feature/docannotations/src/DocAnnotationsTests.scala
+++ b/integration/feature/docannotations/src/DocAnnotationsTests.scala
@@ -1,6 +1,5 @@
 package mill.integration
 
-import mill.testkit.IntegrationTester.EvalResult
 import mill.testkit.UtestIntegrationTestSuite
 import utest._
 

--- a/integration/feature/docannotations/src/DocAnnotationsTests.scala
+++ b/integration/feature/docannotations/src/DocAnnotationsTests.scala
@@ -1,5 +1,6 @@
 package mill.integration
 
+import mill.testkit.IntegrationTester.EvalResult
 import mill.testkit.UtestIntegrationTestSuite
 import utest._
 
@@ -8,10 +9,15 @@ object DocAnnotationsTests extends UtestIntegrationTestSuite {
     StringContext
       .glob(
         // Normalize the line separator to be `\n` for comparisons
-        glob.stripMargin.linesIterator.mkString("\n").split("\\.\\.\\."),
+        glob.stripMargin.linesIterator.mkString("\n").split("\\.\\.\\.").toIndexedSeq,
         input.linesIterator.mkString("\n")
       )
       .isDefined
+  }
+  def assertGlobMatches(glob: String, input: String): Unit = {
+    val matches = globMatches(glob, input)
+    if (!matches) Console.err.println("[[[" + input.split("\n").mkString("$\n") + "]]]")
+    assert(globMatches(glob, input))
   }
 
   val tests: Tests = Tests {
@@ -21,111 +27,99 @@ object DocAnnotationsTests extends UtestIntegrationTestSuite {
       assert(res.isSuccess == true)
 
       val inheritedIvyDeps = out("inspect").json.str
-      assert(
-        globMatches(
-          """core.test.ivyDeps(build.mill:...)
-            |    Overridden ivyDeps Docs!!!
-            |
-            |    Any ivy dependencies you want to add to this Module, in the format
-            |    ivy"org::name:version" for Scala dependencies or ivy"org:name:version"
-            |    for Java dependencies
-            |
-            |Inputs:
-            |""".stripMargin,
-          inheritedIvyDeps
-        )
+      assertGlobMatches(
+        """core.test.ivyDeps(build.mill:...)
+          |    Overridden ivyDeps Docs!!!
+          |
+          |    Any ivy dependencies you want to add to this Module, in the format
+          |    ivy"org::name:version" for Scala dependencies or ivy"org:name:version"
+          |    for Java dependencies
+          |
+          |Inputs:
+          |""".stripMargin,
+        inheritedIvyDeps
       )
 
       assert(eval(("inspect", "core.task")).isSuccess)
       val task = out("inspect").json.str
-      assert(
-        globMatches(
-          """core.task(build.mill:...)
-            |    Core Task Docz!
-            |
-            |Inputs:
-            |""",
-          task
-        )
+      assertGlobMatches(
+        """core.task(build.mill:...)
+          |    Core Task Docz!
+          |
+          |Inputs:
+          |""",
+        task
       )
 
       assert(eval(("inspect", "inspect")).isSuccess)
       val doc = out("inspect").json.str
-      assert(
-        globMatches(
-          """inspect(MainModule.scala:...)
-            |    Displays metadata about the given task without actually running it.
-            |
-            |    tasks <str>...
-            |
-            |Inputs:
-            |""".stripMargin,
-          doc
-        )
+      assertGlobMatches(
+        """inspect(MainModule.scala:...)
+          |    Displays metadata about the given task without actually running it.
+          |
+          |    tasks <str>...
+          |
+          |Inputs:
+          |""".stripMargin,
+        doc
       )
 
       assert(eval(("inspect", "core.run")).isSuccess)
       val run = out("inspect").json.str
 
-      assert(
-        globMatches(
-          """core.run(RunModule.scala:...)
-            |    Runs this module's code in a subprocess and waits for it to finish
-            |
-            |    args <str>...
-            |
-            |Inputs:
-            |    core.finalMainClassOpt
-            |    core.runClasspath
-            |    core.forkArgs
-            |    core.forkEnv
-            |    core.runUseArgsFile
-            |    core.finalMainClass
-            |    core.forkWorkingDir
-            |""",
-          run
-        )
+      assertGlobMatches(
+        """core.run(RunModule.scala:...)
+          |    Runs this module's code in a subprocess and waits for it to finish
+          |
+          |    args <str>...
+          |
+          |Inputs:
+          |    core.finalMainClassOpt
+          |    core.runClasspath
+          |    core.forkArgs
+          |    core.forkEnv
+          |    core.runUseArgsFile
+          |    core.finalMainClass
+          |    core.forkWorkingDir
+          |""",
+        run
       )
 
       assert(eval(("inspect", "core.ivyDepsTree")).isSuccess)
 
       val ivyDepsTree = out("inspect").json.str
 
-      assert(
-        globMatches(
-          """core.ivyDepsTree(JavaModule.scala:...)
-            |    Command to print the transitive dependency tree to STDOUT.
-            |
-            |    --inverse                Invert the tree representation, so that the root is on the bottom val
-            |                             inverse (will be forced when used with whatDependsOn)
-            |    --what-depends-on <str>  Possible list of modules (org:artifact) to target in the tree in order
-            |                             to see where a dependency stems from.
-            |    --with-compile           Include the compile-time only dependencies (`compileIvyDeps`, provided
-            |                             scope) into the tree.
-            |    --with-runtime           Include the runtime dependencies (`runIvyDeps`, runtime scope) into the
-            |                             tree.
-            |
-            |Inputs:
-            |    core.transitiveIvyDeps
-            |""".stripMargin,
-          ivyDepsTree
-        )
+      assertGlobMatches(
+        """core.ivyDepsTree(JavaModule.scala:...)
+          |    Command to print the transitive dependency tree to STDOUT.
+          |
+          |    --inverse                Invert the tree representation, so that the root is on the bottom val
+          |                             inverse (will be forced when used with whatDependsOn)
+          |    --what-depends-on <str>  Possible list of modules (org:artifact) to target in the tree in order
+          |                             to see where a dependency stems from.
+          |    --with-compile           Include the compile-time only dependencies (`compileIvyDeps`, provided
+          |                             scope) into the tree.
+          |    --with-runtime           Include the runtime dependencies (`runIvyDeps`, runtime scope) into the
+          |                             tree.
+          |
+          |Inputs:
+          |    core.transitiveIvyDeps
+          |""".stripMargin,
+        ivyDepsTree
       )
 
       assert(eval(("inspect", "core.test.theWorker")).isSuccess)
       val theWorkerInspect = out("inspect").json.str
 
-      assert(
-        globMatches(
-          """core.test.theWorker(build.mill:...)
-            |    -> The worker <-
-            |
-            |    *The worker*
-            |
-            |Inputs:
-            |""".stripMargin,
-          theWorkerInspect
-        )
+      assertGlobMatches(
+        """core.test.theWorker(build.mill:...)
+          |    -> The worker <-
+          |
+          |    *The worker*
+          |
+          |Inputs:
+          |""".stripMargin,
+        theWorkerInspect
       )
 
       // Make sure both kebab-case and camelCase flags work, even though the
@@ -135,49 +129,64 @@ object DocAnnotationsTests extends UtestIntegrationTestSuite {
 
       assert(eval(("inspect", "basic")).isSuccess)
       val basicInspect = out("inspect").json.str
-      assert(
-        globMatches(
-          """basic(build.mill:...)
-            |
-            |Inherited Modules: Module
-            |""",
-          basicInspect
-        )
+      assertGlobMatches(
+        """basic(build.mill:...)
+          |
+          |Inherited Modules:""",
+        basicInspect
       )
 
       assert(eval(("inspect", "core")).isSuccess)
       val coreInspect = out("inspect").json.str
-      assert(
-        globMatches(
-          """core(build.mill:...)
-            |    The Core Module Docz!
-            |
-            |Inherited Modules: JavaModule
-            |
-            |Default Task: core.run
-            |
-            |Tasks: core.task
-            |""",
-          coreInspect
-        )
+      assertGlobMatches(
+        """core(build.mill:...)
+          |    The Core Module Docz!
+          |
+          |Inherited Modules:
+          |    mill.scalalib.JavaModule
+          |
+          |Default Task: core.run
+          |
+          |Tasks (re-/defined):
+          |    core.task
+          |""",
+        coreInspect
       )
 
       assert(eval(("inspect", "MyJavaTaskModule")).isSuccess)
       val jtmInspect = out("inspect").json.str
-      assert(
-        globMatches(
-          """MyJavaTaskModule(build.mill:...)
-            |
-            |Inherited Modules: JavaModule
-            |
-            |Module Dependencies: core, core2
-            |
-            |Default Task: MyJavaTaskModule.run
-            |
-            |Tasks: MyJavaTaskModule.lineCount, MyJavaTaskModule.task
-            |""",
-          jtmInspect
-        )
+      assertGlobMatches(
+        """MyJavaTaskModule(build.mill:...)
+          |
+          |Inherited Modules:
+          |    mill.scalalib.JavaModule
+          |
+          |Module Dependencies:
+          |    core
+          |    core2
+          |
+          |Default Task: MyJavaTaskModule.run
+          |
+          |Tasks (re-/defined):
+          |    MyJavaTaskModule.lineCount
+          |    MyJavaTaskModule.task
+          |""",
+        jtmInspect
+      )
+
+      val core3Res = eval(("inspect", "core3"))
+      println(core3Res.err)
+      assert(core3Res.isSuccess)
+      val core3Inspect = out("inspect").json.str
+      assertGlobMatches(
+        """core3(core3/package.mill:...)
+          |
+          |Inherited Modules:
+          |    build_.core3.package_
+          |
+          |Default Task: core3.run
+          |""",
+        core3Inspect
       )
     }
   }

--- a/main/src/mill/main/MainModule.scala
+++ b/main/src/mill/main/MainModule.scala
@@ -1,7 +1,7 @@
 package mill.main
 
-import mill.api.{Ctx, *}
-import mill.define.{BaseModule0, Command, NamedTask, Segments, Target, Task, *}
+import mill.api.{Ctx, _}
+import mill.define.{BaseModule0, Command, NamedTask, Segments, Target, Task, _}
 import mill.eval.{Evaluator, EvaluatorPaths, Terminal}
 import mill.moduledefs.Scaladoc
 import mill.resolve.SelectMode.Separated

--- a/main/src/mill/main/MainModule.scala
+++ b/main/src/mill/main/MainModule.scala
@@ -216,7 +216,7 @@ trait MainModule extends BaseModule0 {
       def renderFileName(t: NamedTask[_]) = {
         // handle both Windows or Unix separators
         val fullFileName = t.ctx.fileName.replaceAll(raw"\\", "/")
-        val basePath = WorkspaceRoot.workspaceRoot.toString() + "/"
+        val basePath = WorkspaceRoot.workspaceRoot.toString().replaceAll(raw"\\", "/") + "/"
         val name =
           if (fullFileName.startsWith(basePath)) {
             fullFileName.drop(basePath.length)

--- a/main/src/mill/main/MainModule.scala
+++ b/main/src/mill/main/MainModule.scala
@@ -1,6 +1,5 @@
 package mill.main
 
-import mill.T
 import mill.api.{Ctx, *}
 import mill.define.{BaseModule0, Command, NamedTask, Segments, Target, Task, *}
 import mill.eval.{Evaluator, EvaluatorPaths, Terminal}
@@ -329,7 +328,7 @@ trait MainModule extends BaseModule0 {
           }
         }
 
-        val allInheritedModulesOpt = Option.when(T.log.debugEnabled) {
+        val allInheritedModulesOpt = Option.when(Target.log.debugEnabled) {
           allParents(parents.toList, Seq())
             .filter(parentFilter)
             .filterNot(inheritedModules.contains)

--- a/main/src/mill/main/MainModule.scala
+++ b/main/src/mill/main/MainModule.scala
@@ -194,7 +194,7 @@ trait MainModule extends BaseModule0 {
       }
     }
 
-  private val inspectItemIndent = "    ";
+  private lazy val inspectItemIndent = "    "
 
   /**
    * Displays metadata about the given task without actually running it.

--- a/main/test/src/mill/main/MainModuleTests.scala
+++ b/main/test/src/mill/main/MainModuleTests.scala
@@ -45,10 +45,11 @@ object MainModuleTests extends TestSuite {
     /** Sub module */
     object sub extends TaskModule {
       override def defaultCommandName(): String = "hello"
-      def hello() = Task.Command{
+      def hello() = Task.Command {
         println("hello")
       }
       def moduleDeps = Seq(subSub)
+
       /** SubSub module */
       object subSub extends Module
     }

--- a/testkit/src/mill/testkit/ExampleTester.scala
+++ b/testkit/src/mill/testkit/ExampleTester.scala
@@ -108,6 +108,11 @@ class ExampleTester(
       case s => s
     }
     Console.err.println(s"$workspacePath> $commandStr")
+    Console.err.println(
+      s"""--- Expected output ----------
+         |${expectedSnippets.mkString("\n")}
+         |------------------------------""".stripMargin
+    )
 
     val res = os.call(
       (bashExecutable, "-c", commandStr),


### PR DESCRIPTION
* Retain the full source location relative to the project directory.
* Inherited Modules now show the full class names instead of just a short names without the package.
* In debug mode, show all inherited modules, not only the directly declared ones.
* Also show compile and runtime module dependencies
* Reworked formatting for modules to be consistent with inspect for tasks
* Added a test for inspect modules

```
sub(main/test/src/mill/main/MainModuleTests.scala:46)
    Sub module
 
Inherited Modules:    
    mill.define.TaskModule

Module Dependencies:
    sub.subSub

Default Task: sub.hello

Tasks (re-/defined):
    sub.hello
```