### PR TITLE
Remove prompt update hash check

### DIFF
--- a/main/util/src/mill/util/PromptLogger.scala
+++ b/main/util/src/mill/util/PromptLogger.scala
@@ -327,8 +327,6 @@ private[mill] object PromptLogger {
       currentTimeMillis: () => Long,
       infoColor: fansi.Attrs
   ) {
-    private var lastRenderedPromptHash = 0
-
     private val statuses = collection.mutable.SortedMap
       .empty[Seq[String], Status](PromptLoggerUtil.seqStringOrdering)
 
@@ -410,9 +408,7 @@ private[mill] object PromptLogger {
       // For non-interactive jobs, we only want to print the new prompt if the contents
       // differs from the previous prompt, since the prompts do not overwrite each other
       // in log files and printing large numbers of identical prompts is spammy and useless
-      lazy val statusesHashCode = statuses.hashCode
-      if (consoleDims()._1.nonEmpty || statusesHashCode != lastRenderedPromptHash) {
-        lastRenderedPromptHash = statusesHashCode
+      if (consoleDims()._1.nonEmpty) {
         updatePromptBytes(ending)
       }
     }

--- a/main/util/src/mill/util/PromptLogger.scala
+++ b/main/util/src/mill/util/PromptLogger.scala
@@ -338,7 +338,7 @@ private[mill] object PromptLogger {
 
     def getCurrentPrompt() = currentPromptBytes
 
-    private def updatePromptBytes(ending: Boolean = false) = {
+    def updatePrompt(ending: Boolean = false) = {
       val now = currentTimeMillis()
       for (k <- statuses.keySet) {
         val removedTime = statuses(k).beginTransitionTime
@@ -401,15 +401,6 @@ private[mill] object PromptLogger {
             if (stillTransitioning(existing)) existing.copy(next = sOptEntry)
             else existing.copy(next = sOptEntry, beginTransitionTime = now, prev = existing.next)
           )
-      }
-    }
-
-    def updatePrompt(ending: Boolean = false): Unit = {
-      // For non-interactive jobs, we only want to print the new prompt if the contents
-      // differs from the previous prompt, since the prompts do not overwrite each other
-      // in log files and printing large numbers of identical prompts is spammy and useless
-      if (consoleDims()._1.nonEmpty) {
-        updatePromptBytes(ending)
       }
     }
   }

--- a/main/util/src/mill/util/PromptLogger.scala
+++ b/main/util/src/mill/util/PromptLogger.scala
@@ -338,7 +338,7 @@ private[mill] object PromptLogger {
 
     def getCurrentPrompt() = currentPromptBytes
 
-    def updatePrompt(ending: Boolean = false) = {
+    def updatePrompt(ending: Boolean = false): Unit = {
       val now = currentTimeMillis()
       for (k <- statuses.keySet) {
         val removedTime = statuses(k).beginTransitionTime


### PR DESCRIPTION
The logic was incorrect: we still need to re-calculate the prompt even if the statuses don't change, because the wall clock time changes and so the second tickers need to be updated