### PR TITLE
Fix Scoverage report generation in Scala 3

### DIFF
--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
@@ -174,7 +174,10 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
       Task {
         val extras =
           if (isScala3()) {
-            Seq(s"-coverage-out:${data().path.toIO.getPath()}")
+            Seq(
+              s"-coverage-out:${data().path.toIO.getPath()}",
+              s"-sourceroot:${T.workspace}"
+            )
           } else {
             Seq(
               s"-P:scoverage:dataDir:${data().path.toIO.getPath()}",


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/3857. We were missing one of the necessary flags, which is documented in https://dotty.epfl.ch/docs/internals/coverage.html

Manually tested, reproduced the problem and verified the fix. I'm not sure why the existing unit tests didn't catch it, must be something to do with how the sandbox is set up for unit tests vs in real usage. I'm not sure if it's worth introducing an integration test just for this so just leaving it at manual testing for now