### PR TITLE
Stabilize links to doc site versions

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -37,11 +37,7 @@ object Settings {
     "0.10.15",
   )
   val docTags: Seq[String] = Seq(
-    "0.11.10",
-    "0.11.11",
     "0.11.12",
-    "0.12.0",
-    "0.12.1",
     "0.12.2"
   )
   val mimaBaseVersions: Seq[String] =

--- a/build.mill
+++ b/build.mill
@@ -37,7 +37,11 @@ object Settings {
     "0.10.15",
   )
   val docTags: Seq[String] = Seq(
+    "0.11.10",
+    "0.11.11",
     "0.11.12",
+    "0.12.0",
+    "0.12.1",
     "0.12.2"
   )
   val mimaBaseVersions: Seq[String] =

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -57,6 +57,7 @@ To begin using Mill, check out the introductory documentation for each language:
 For a quick introduction of why you may care about Mill, see the following page:
 
 * xref:comparisons/why-mill.adoc[]
+* xref:comparisons/unique.adoc[]
 
 Or if you prefer a video introduction:
 

--- a/docs/package.mill
+++ b/docs/package.mill
@@ -163,7 +163,7 @@ object `package` extends RootModule {
     sanitizeAntoraYml(
       dest,
       "main-branch",
-      build.millVersion().split('.').dropRight(1).mkString("."),
+      build.millVersion().split('.').dropRight(1).mkString(".") + ".x",
       build.millLastTag()
     )
     PathRef(dest)

--- a/docs/package.mill
+++ b/docs/package.mill
@@ -160,7 +160,12 @@ object `package` extends RootModule {
   def devAntoraSources: T[PathRef] = Task {
     val dest = T.dest
     os.copy(source().path, dest, mergeFolders = true)
-    sanitizeAntoraYml(dest, "master", build.millVersion(), build.millLastTag())
+    sanitizeAntoraYml(
+      dest,
+      "main-branch",
+      build.millVersion().split('.').dropRight(1).mkString("."),
+      build.millLastTag()
+    )
     PathRef(dest)
   }
 
@@ -174,7 +179,7 @@ object `package` extends RootModule {
     val lines = os.read(dest / "antora.yml").linesIterator.map {
       case s"version:$_" =>
         if (isPreRelease)
-          s"version: '${version}'\ndisplay-version: '${millVersion}'\nprerelease: true"
+          s"version: '${version}'\ndisplay-version: 'main-branch'\nprerelease: true"
         else
           s"version: '${version}'\ndisplay-version: '${millVersion}'"
       case s"    mill-version:$_" => s"    mill-version: '$millVersion'"
@@ -242,13 +247,15 @@ object `package` extends RootModule {
 
   def oldDocSources: T[Seq[PathRef]] = Task {
     for (oldVersion <- build.Settings.docTags) yield {
+      val latest = build.Settings.docTags.last == oldVersion
       val checkout = T.dest / oldVersion
       os.proc("git", "clone", T.workspace / ".git", checkout).call(stdout = os.Inherit)
       os.proc("git", "checkout", oldVersion).call(cwd = checkout, stdout = os.Inherit)
       val outputFolder = checkout / "out" / "docs" / "source.dest"
       os.proc("./mill", "-i", "docs.source").call(cwd = checkout, stdout = os.Inherit)
       expandDiagramsInDirectoryAdocFile(outputFolder, mill.main.VisualizeModule.classpath().map(_.path))
-      sanitizeAntoraYml(outputFolder, oldVersion, oldVersion, oldVersion)
+      // Set the latest stable branch as the "master" docs that people default to
+      sanitizeAntoraYml(outputFolder, if (latest) "master" else oldVersion, oldVersion, oldVersion)
       PathRef(outputFolder)
     }
   }


### PR DESCRIPTION
* The latest stable version (now 0.12.2) now is the default documentation version linked under `/`
* Older stable versions (e.g. 0.11.12) now are linked under `/0.11.x/`
* The unstable main branch version is now linked under `/main-branch/`

This should ensure people go to the latest stable version of the docs easily, links to older stable versions remain stable, and the main branch docs are available if less convenient