### PR TITLE
Set context classloader during Mill evaluation

### DIFF
--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -407,8 +407,11 @@ object MillBuildBootstrap {
       targetsAndParams: Seq[String]
   ): (Either[String, Seq[Any]], Seq[Watchable], Seq[Watchable]) = {
     rootModule.evalWatchedValues.clear()
-    val evalTaskResult =
+    val previousClassloader = Thread.currentThread().getContextClassLoader
+    val evalTaskResult = try {
+      Thread.currentThread().setContextClassLoader(rootModule.getClass.getClassLoader)
       RunScript.evaluateTasksNamed(evaluator, targetsAndParams, SelectMode.Separated)
+    } finally Thread.currentThread().setContextClassLoader(previousClassloader)
     val moduleWatched = rootModule.watchedValues.toVector
     val addedEvalWatched = rootModule.evalWatchedValues.toVector
 

--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -408,10 +408,11 @@ object MillBuildBootstrap {
   ): (Either[String, Seq[Any]], Seq[Watchable], Seq[Watchable]) = {
     rootModule.evalWatchedValues.clear()
     val previousClassloader = Thread.currentThread().getContextClassLoader
-    val evalTaskResult = try {
-      Thread.currentThread().setContextClassLoader(rootModule.getClass.getClassLoader)
-      RunScript.evaluateTasksNamed(evaluator, targetsAndParams, SelectMode.Separated)
-    } finally Thread.currentThread().setContextClassLoader(previousClassloader)
+    val evalTaskResult =
+      try {
+        Thread.currentThread().setContextClassLoader(rootModule.getClass.getClassLoader)
+        RunScript.evaluateTasksNamed(evaluator, targetsAndParams, SelectMode.Separated)
+      } finally Thread.currentThread().setContextClassLoader(previousClassloader)
     val moduleWatched = rootModule.watchedValues.toVector
     val addedEvalWatched = rootModule.evalWatchedValues.toVector
 


### PR DESCRIPTION
Seems to be necessary for some of the libraries people `import $ivy`, such as Guardrail