### PR TITLE
Update coursier to 2.1.16

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -116,7 +116,7 @@ object Deps {
   val asmTree = ivy"org.ow2.asm:asm-tree:9.7.1"
   val bloopConfig = ivy"ch.epfl.scala::bloop-config:1.5.5"
 
-  val coursier = ivy"io.get-coursier::coursier:2.1.14"
+  val coursier = ivy"io.get-coursier::coursier:2.1.16"
   val coursierInterface = ivy"io.get-coursier:interface:1.0.22"
 
   val cask = ivy"com.lihaoyi::cask:0.9.4"


### PR DESCRIPTION
Not `2.1.17` yet, I'd like to add a way for users to disable the new internal handling of BOMs when bumping to it