### PR TITLE
NIT Use allIvyDeps task where it seems it's meant to be used

### DIFF
--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -327,7 +327,7 @@ trait JavaModule
    * This is calculated from [[ivyDeps]], [[mandatoryIvyDeps]] and recursively from [[moduleDeps]].
    */
   def transitiveIvyDeps: T[Agg[BoundDep]] = Task {
-    (ivyDeps() ++ mandatoryIvyDeps()).map(bindDependency()) ++
+    allIvyDeps().map(bindDependency()) ++
       T.traverse(moduleDepsChecked)(_.transitiveIvyDeps)().flatten
   }
 

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -139,7 +139,7 @@ trait JavaModule
    * Aggregation of mandatoryIvyDeps and ivyDeps.
    * In most cases, instead of overriding this Target you want to override `ivyDeps` instead.
    */
-  def allIvyDeps: T[Agg[Dep]] = Task { mandatoryIvyDeps() ++ ivyDeps() }
+  def allIvyDeps: T[Agg[Dep]] = Task { ivyDeps() ++ mandatoryIvyDeps() }
 
   /**
    * Same as `ivyDeps`, but only present at compile time. Useful for e.g.


### PR DESCRIPTION
I was looking at this file, and it feels `allIvyDeps` was meant to be used in `transitiveIvyDeps `, but isn't. This fixes that. (Unless `allIvyDeps` is somehow scheduled for deletion?)