### PR TITLE
This is a forkArg not a compiler option

### DIFF
--- a/contrib/jmh/src/mill/contrib/jmh/JmhModule.scala
+++ b/contrib/jmh/src/mill/contrib/jmh/JmhModule.scala
@@ -72,7 +72,7 @@ trait JmhModule extends JavaModule {
   def generateBenchmarkSources =
     Task {
       val dest = T.ctx().dest
-      val javacOpts = javacOptions().toSeq
+      val forkedArgs = forkArgs().toSeq
       val sourcesDir = dest / "jmh_sources"
       val resourcesDir = dest / "jmh_resources"
 
@@ -90,7 +90,7 @@ trait JmhModule extends JavaModule {
           resourcesDir.toString,
           "default"
         ),
-        jvmArgs = javacOpts
+        jvmArgs = forkedArgs
       )
 
       (sourcesDir, resourcesDir)


### PR DESCRIPTION
Attempt 3 to make this trivial change. No rebasing this time.

The previous solution works, because both are a list of strings in the end, but I think this revised version more correctly follows mill nomenclature as forkedArgs rather than compiler flags. 

Apologies for the spamminess. 