### PR TITLE
Default KtlintModule to .editorconfig explicitly

### DIFF
--- a/kotlinlib/src/mill/kotlinlib/ktlint/KtlintModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/ktlint/KtlintModule.scala
@@ -32,7 +32,7 @@ trait KtlintModule extends JavaModule {
    * Ktlint configuration file.
    */
   def ktlintConfig: T[Option[PathRef]] = Task {
-    Some(PathRef(millSourcePath / ".editorconfig"))
+    Some(PathRef(Task.workspace / ".editorconfig"))
   }
 
   /**

--- a/kotlinlib/src/mill/kotlinlib/ktlint/KtlintModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/ktlint/KtlintModule.scala
@@ -32,14 +32,14 @@ trait KtlintModule extends JavaModule {
    * Ktlint configuration file.
    */
   def ktlintConfig: T[Option[PathRef]] = Task {
-    None
+    Some(PathRef(millSourcePath / ".editorconfig"))
   }
 
   /**
    * Ktlint version.
    */
   def ktlintVersion: T[String] = Task {
-    "1.3.1"
+    "1.4.1"
   }
 
   /**


### PR DESCRIPTION
For some reason `ktlint` behaves differently if it's config is set vs unset to it's default of `.editorconfig`.

It seems to be unable to disable `ktlint` when not explicitly set, so I think we should set it instead.

Why not bump the version while we're at it?