### PR TITLE
Handle case of .mill-version with Windows line ends

### DIFF
--- a/mill
+++ b/mill
@@ -12,9 +12,9 @@ fi
 
 if [ -z "$MILL_VERSION" ] ; then
   if [ -f ".mill-version" ] ; then
-    MILL_VERSION="$(head -n 1 .mill-version 2> /dev/null)"
+    MILL_VERSION="$(tr '\r' '\n' < .mill-version | head -n 1 2> /dev/null)"
   elif [ -f ".config/mill-version" ] ; then
-    MILL_VERSION="$(head -n 1 .config/mill-version 2> /dev/null)"
+    MILL_VERSION="$(tr '\r' '\n' < .config/mill-version | head -n 1 2> /dev/null)"
   elif [ -f "mill" ] && [ "$0" != "mill" ] ; then
     MILL_VERSION=$(grep -F "DEFAULT_MILL_VERSION=" "mill" | head -n 1 | cut -d= -f2)
   else


### PR DESCRIPTION
This is a precaution for cases when the `.mill-version` file can contain a Windows line end `\r\n` instead of the typical Unix line end `\n`. Without this fix, in such situation the script breaks in a spectacular and surprising way.

The error it was giving looked like this:
```sh
$ mill __.compile
curl: (3) URL using bad/illegal format or missing URL
```
Where `mill` is pointing to the wrapper script that I'm changing in this PR