### PR TITLE
installation-ide.adoc: mill.bsp.BSP/install

### DIFF
--- a/docs/modules/ROOT/pages/cli/installation-ide.adoc
+++ b/docs/modules/ROOT/pages/cli/installation-ide.adoc
@@ -62,6 +62,12 @@ as a drop-in replacement for `./mill` that supports running on all major platfor
 Mill supports IntelliJ and VSCode, both via the standard
 https://build-server-protocol.github.io/[Build Server Protocol]
 
+The first thing you need to do is to run this command to generat the BSP configuration files:
+[source,bash]
+----
+./mill mill.bsp.BSP/install
+----
+
 === IntelliJ
 
 To use Mill with IntelliJ, first ensure you have the free


### PR DESCRIPTION
Instructions to run `mill.bsp.BSP/install`. Without it, IntelliJ won't pick up the BSP model -- it won't show it as one of the possible ways how to import the project.