### PR TITLE
Refactor Jvm methods to match specified signatures

### DIFF
--- a/main/util/test/src/mill/util/JvmTests.scala
+++ b/main/util/test/src/mill/util/JvmTests.scala
@@ -28,6 +28,46 @@ object JvmTests extends TestSuite {
         Seq(dep1, dep2).map(_.toNIO.toUri().toURL().toExternalForm()).mkString(" "))
     }
 
+    test("call") {
+      val tmpDir = os.temp.dir()
+      val mainClass = "mill.util.TestMain"
+      val classPath = Agg(tmpDir)
+      val jvmArgs = Seq("-Xmx512m")
+      val mainArgs = Seq("arg1", "arg2")
+      val result = Jvm.call(mainClass, classPath, jvmArgs, mainArgs)
+      assert(result.exitCode == 0)
+    }
+
+    test("spawn") {
+      val tmpDir = os.temp.dir()
+      val mainClass = "mill.util.TestMain"
+      val classPath = Agg(tmpDir)
+      val jvmArgs = Seq("-Xmx512m")
+      val mainArgs = Seq("arg1", "arg2")
+      val process = Jvm.spawn(mainClass, classPath, jvmArgs, mainArgs)
+      assert(process.isAlive())
+      process.destroy()
+    }
+
+    test("callClassloader") {
+      val tmpDir = os.temp.dir()
+      val classPath = Agg(tmpDir)
+      val sharedPrefixes = Seq("mill.util")
+      val result = Jvm.callClassloader(classPath, sharedPrefixes) { cl =>
+        cl.loadClass("mill.util.TestMain")
+      }
+      assert(result.getName == "mill.util.TestMain")
+    }
+
+    test("spawnClassloader") {
+      val tmpDir = os.temp.dir()
+      val classPath = Agg(tmpDir)
+      val sharedPrefixes = Seq("mill.util")
+      val classLoader = Jvm.spawnClassloader(classPath, sharedPrefixes)
+      val result = classLoader.loadClass("mill.util.TestMain")
+      assert(result.getName == "mill.util.TestMain")
+    }
+
   }
 
 }


### PR DESCRIPTION
Related to #3772

Refactor `Jvm.scala` to consolidate subprocess and classloader spawning operations into four specified signatures.

* **Refactor `callSubprocess` method:**
  - Rename to `call`.
  - Update parameters to match the specified `call` signature.
  - Use `jvmCommandArgs` to generate command arguments.
  - Call `os.call` with the updated parameters.

* **Refactor `runSubprocess` method:**
  - Rename to `spawn`.
  - Update parameters to match the specified `spawn` signature.
  - Use `jvmCommandArgs` to generate command arguments.
  - Call `os.spawn` with the updated parameters.

* **Add `spawnClassloader` method:**
  - Create a new method to match the specified `spawnClassloader` signature.
  - Use `mill.api.ClassLoader.create` to create a classloader.

* **Add `callClassloader` method:**
  - Create a new method to match the specified `callClassloader` signature.
  - Use `spawnClassloader` to create a classloader and set it as the context classloader.
  - Execute the provided function with the new classloader and restore the old classloader afterward.

* **Add tests in `JvmTests.scala`:**
  - Add tests for the new `call` method.
  - Add tests for the new `spawn` method.
  - Add tests for the new `callClassloader` method.
  - Add tests for the new `spawnClassloader` method.

