### PR TITLE
align SonatypeCentralPublishModule with SonatypePublisher

### DIFF
--- a/contrib/sonatypecentral/readme.adoc
+++ b/contrib/sonatypecentral/readme.adoc
@@ -29,7 +29,7 @@ $ mill -i \
 mill.contrib.sonatypecentral.SonatypeCentralPublishModule/publishAll \
 --username myusername \
 --password mypassword \
---gpgArgs --passphrase=$GPG_PASSPHRASE,--no-tty,--pinentry-mode,loopback,--batch,--yes,-a,-b \
+--gpgArgs --passphrase=$MILL_PGP_PASSPHRASE,--no-tty,--pinentry-mode,loopback,--batch,--yes,-a,-b \
 --publishArtifacts __.publishArtifacts \
 --readTimeout  36000 \
 --awaitTimeout 36000 \
@@ -68,7 +68,7 @@ The `mill.contrib.sonatypecentral.SonatypeCentralPublishModule/publishAll` metho
 
 `password`: The password for calling the Sonatype Central publishing api. Defaults to the `SONATYPE_PASSWORD` environment variable if unset. If neither the parameter nor the environment variable are set, an error will be thrown. +
 
-`gpgArgs`: Arguments to pass to the gpg package for signing artifacts. _Default: `--batch, --yes, -a, -b`._ +
+`gpgArgs`: Arguments to pass to the gpg package for signing artifacts. Uses the `MILL_PGP_PASSPHRASE` environment variable if set. _Default: `[--passphrase=$MILL_PGP_PASSPHRASE], --no-tty, --pinentry-mode, loopback, --batch, --yes, -a, -b`._ +
 
 `publishArtifacts`: The command for generating all publishable artifacts (ex. `__.publishArtifacts`). Required. +
 


### PR DESCRIPTION
In the current version the SonatypeCentralPublishModule has non intented behaviour with PublishModule.defaultGpgArgs.

It will default to the args without a passphrase and afterwards ignore the passphrase env. var as a gpgarg is already set.
To get the "correct" behaviour one has to override the args with an empty string to then pick up the "PGP_PASSPHRASE" env. arg.

Also changed the env. name to match the one from SonaTypePublisher "PGP_PASSPHRASE" -> "MILL_PGP_PASSPHRASE".

Currently pgp and gpg are getting used both in terms of naming - guessing going for gpg in the future might be more clear.