### PR TITLE
Bump sbt-jupiter-interface to 0.13.x

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -203,7 +203,7 @@ object Deps {
     val dokkaCli = ivy"org.jetbrains.dokka:dokka-cli:$dokkaVersion"
     val errorProneCore = ivy"com.google.errorprone:error_prone_core:2.31.0"
     val freemarker = ivy"org.freemarker:freemarker:2.3.33"
-    val jupiterInterface = ivy"com.github.sbt.junit:jupiter-interface:0.11.4"
+    val jupiterInterface = ivy"com.github.sbt.junit:jupiter-interface:0.13.1"
     val kotlinxHtmlJvm = ivy"org.jetbrains.kotlinx:kotlinx-html-jvm:0.8.0"
     val koverCli = ivy"org.jetbrains.kotlinx:kover-cli:$koverVersion"
     val koverJvmAgent = ivy"org.jetbrains.kotlinx:kover-jvm-agent:$koverVersion"

--- a/testrunner/src/mill/testrunner/TestRunnerUtils.scala
+++ b/testrunner/src/mill/testrunner/TestRunnerUtils.scala
@@ -203,6 +203,7 @@ import scala.jdk.CollectionConverters.IteratorHasAsScala
 
     val (runner, tasks) = getTestTasks(framework, args, classFilter, cl, testClassfilePath)
 
+    pprint.log(tasks.map(_.taskDef()))
     val (doneMessage, results) = runTasks(tasks, testReporter, runner)
 
     (doneMessage, results.toSeq)


### PR DESCRIPTION
Copy of https://github.com/com-lihaoyi/mill/pull/3501 opened from a separate repo to avoid double testing

Seems like the issue is that the jupiter-test-interface is not configured correctly and is thus missing the test class name as part of the success error reporting

```bash
./mill -w 'example.javalib.testing[3-integration-suite].local.test'
```

```
[2951]   Test run started (JUnit Jupiter)
[2951]   Test run started (JUnit Jupiter)
[2951]   Test #helloworld() started
[2951]   Test #hello() started
[2951]   Test #helloworld() finished, took 0.014s
[2951]   Test #hello() finished, took 0.013s
[2951]   Test #world() started
[2951]   Test  finished, took 0.025s
[2951]   Test #world() finished, took 0.0s
[2951]   Test  finished, took 0.025s
[2951]   Test  finished, took 0.038s
[2951]   Test run finished: 0 failed, 0 ignored, 1 total, 0.05s
[2951]   Test  finished, took 0.037s
[2951]   Test run finished: 0 failed, 0 ignored, 2 total, 0.049s
```
