### PR TITLE
[WIP] split out ZincWorkerImpl into a separate subprocess

### DIFF
--- a/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -347,7 +347,7 @@ trait KotlinModule extends JavaModule { outer =>
       javacOptions: Seq[String],
       compileProblemReporter: Option[CompileProblemReporter],
       reportOldProblems: Boolean
-  )(implicit ctx: ZincWorkerApi.Ctx): Result[CompilationResult] = {
+  ): Result[CompilationResult] = {
     worker.compileJava(
       upstreamCompileOutput = upstreamCompileOutput,
       sources = javaSourceFiles,

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -301,7 +301,8 @@ abstract class MillBuildRootModule()(implicit
         reporter = T.reporter.apply(hashCode),
         reportCachedProblems = zincReportCachedProblems(),
         incrementalCompilation = zincIncrementalCompilation(),
-        auxiliaryClassFileExtensions = zincAuxiliaryClassFileExtensions()
+        auxiliaryClassFileExtensions = zincAuxiliaryClassFileExtensions(),
+        compilerBridge = bridgeJarTask().path
       )
   }
 

--- a/scalalib/api/src/mill/scalalib/api/ZincWorkerApi.scala
+++ b/scalalib/api/src/mill/scalalib/api/ZincWorkerApi.scala
@@ -6,7 +6,6 @@ import mill.api.Loose.Agg
 import scala.annotation.nowarn
 
 object ZincWorkerApi {
-  type Ctx = mill.api.Ctx.Dest with mill.api.Ctx.Log with mill.api.Ctx.Home
 }
 trait ZincWorkerApi {
 
@@ -19,7 +18,7 @@ trait ZincWorkerApi {
       reporter: Option[CompileProblemReporter],
       reportCachedProblems: Boolean,
       incrementalCompilation: Boolean
-  )(implicit ctx: ZincWorkerApi.Ctx): mill.api.Result[CompilationResult] =
+  ): mill.api.Result[CompilationResult] =
     compileJava(
       upstreamCompileOutput = upstreamCompileOutput,
       sources = sources,
@@ -38,7 +37,7 @@ trait ZincWorkerApi {
       javacOptions: Seq[String],
       reporter: Option[CompileProblemReporter],
       reportCachedProblems: Boolean
-  )(implicit ctx: ZincWorkerApi.Ctx): mill.api.Result[CompilationResult] =
+  ): mill.api.Result[CompilationResult] =
     compileJava(
       upstreamCompileOutput = upstreamCompileOutput,
       sources = sources,
@@ -63,8 +62,9 @@ trait ZincWorkerApi {
       reporter: Option[CompileProblemReporter],
       reportCachedProblems: Boolean,
       incrementalCompilation: Boolean,
-      auxiliaryClassFileExtensions: Seq[String]
-  )(implicit ctx: ZincWorkerApi.Ctx): mill.api.Result[CompilationResult] =
+      auxiliaryClassFileExtensions: Seq[String],
+      compilerBridge: os.Path
+  ): mill.api.Result[CompilationResult] =
     compileMixed(
       upstreamCompileOutput = upstreamCompileOutput,
       sources = sources,
@@ -78,70 +78,8 @@ trait ZincWorkerApi {
       reporter = reporter,
       reportCachedProblems = reportCachedProblems,
       incrementalCompilation = incrementalCompilation,
-      auxiliaryClassFileExtensions = auxiliaryClassFileExtensions
-    )
-
-  /** Compile a mixed Scala/Java or Scala-only project */
-  @deprecated("Use override with `incrementalCompilation` parameter", "Mill 0.11.6")
-  def compileMixed(
-      upstreamCompileOutput: Seq[CompilationResult],
-      sources: Agg[os.Path],
-      compileClasspath: Agg[os.Path],
-      javacOptions: Seq[String],
-      scalaVersion: String,
-      scalaOrganization: String,
-      scalacOptions: Seq[String],
-      compilerClasspath: Agg[PathRef],
-      scalacPluginClasspath: Agg[PathRef],
-      reporter: Option[CompileProblemReporter],
-      reportCachedProblems: Boolean
-  )(implicit ctx: ZincWorkerApi.Ctx): mill.api.Result[CompilationResult] =
-    compileMixed(
-      upstreamCompileOutput = upstreamCompileOutput,
-      sources = sources,
-      compileClasspath = compileClasspath,
-      javacOptions = javacOptions,
-      scalaVersion = scalaVersion,
-      scalaOrganization = scalaOrganization,
-      scalacOptions = scalacOptions,
-      compilerClasspath = compilerClasspath,
-      scalacPluginClasspath = scalacPluginClasspath,
-      reporter = reporter,
-      reportCachedProblems = reportCachedProblems,
-      incrementalCompilation = true,
-      auxiliaryClassFileExtensions = Seq.empty[String]
-    )
-
-  /** Compile a mixed Scala/Java or Scala-only project */
-  @deprecated("Use override with `auxiliaryClassFileExtensions` parameter", "Mill 0.11.8")
-  def compileMixed(
-      upstreamCompileOutput: Seq[CompilationResult],
-      sources: Agg[os.Path],
-      compileClasspath: Agg[os.Path],
-      javacOptions: Seq[String],
-      scalaVersion: String,
-      scalaOrganization: String,
-      scalacOptions: Seq[String],
-      compilerClasspath: Agg[PathRef],
-      scalacPluginClasspath: Agg[PathRef],
-      reporter: Option[CompileProblemReporter],
-      reportCachedProblems: Boolean,
-      incrementalCompilation: Boolean
-  )(implicit ctx: ZincWorkerApi.Ctx): mill.api.Result[CompilationResult] =
-    compileMixed(
-      upstreamCompileOutput = upstreamCompileOutput,
-      sources = sources,
-      compileClasspath = compileClasspath,
-      javacOptions = javacOptions,
-      scalaVersion = scalaVersion,
-      scalaOrganization = scalaOrganization,
-      scalacOptions = scalacOptions,
-      compilerClasspath = compilerClasspath,
-      scalacPluginClasspath = scalacPluginClasspath,
-      reporter = reporter,
-      reportCachedProblems = reportCachedProblems,
-      incrementalCompilation = incrementalCompilation,
-      auxiliaryClassFileExtensions = Seq.empty[String]
+      auxiliaryClassFileExtensions = auxiliaryClassFileExtensions,
+      compilerBridge = compilerBridge
     )
 
   /**
@@ -154,8 +92,9 @@ trait ZincWorkerApi {
       scalaOrganization: String,
       compilerClasspath: Agg[PathRef],
       scalacPluginClasspath: Agg[PathRef],
-      args: Seq[String]
-  )(implicit ctx: ZincWorkerApi.Ctx): Boolean
+      args: Seq[String],
+      compilerBridge: os.Path
+  ): Boolean
 
   /**
    * Discover main classes by inspecting the classpath.

--- a/scalalib/src/mill/scalalib/UnidocModule.scala
+++ b/scalalib/src/mill/scalalib/UnidocModule.scala
@@ -50,7 +50,8 @@ trait UnidocModule extends ScalaModule {
       scalaOrganization(),
       scalaDocClasspath(),
       scalacPluginClasspath(),
-      options ++ unidocSourceFiles.map(_.path.toString)
+      options ++ unidocSourceFiles.map(_.path.toString),
+      compilerBridge = bridgeJarTask().path
     ) match {
       case true => mill.api.Result.Success(PathRef(T.dest))
       case false => mill.api.Result.Failure("unidoc generation failed")


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/3982. Doesn't yet implement the subprocess management, but for now just refactors `ZincWorkerImpl#<init>` and `ZincWorkerApi` to work with simple serializable data types which is a pre-requisite for sending them over a subprocess boundary

Needs to wait to 0.13.0 due to API breakage