### PR TITLE
Overhaul worker concurrency helpers with `mill.api.CacheFactory`

### DIFF
--- a/docs/modules/ROOT/pages/extending/running-jvm-code.adoc
+++ b/docs/modules/ROOT/pages/extending/running-jvm-code.adoc
@@ -48,8 +48,4 @@ include::partial$example/extending/jvmcode/5-module-classloader.adoc[]
 
 == Caching and Re-using JVM subprocesses and classloaders
 
-Java Virtual Machines are expensive to initialize and with a large memory footprint,
-therefore if you tend to be doing a lot of classloader or subprocess operations it
-makes sense to re-use the JVM. You can do this using the
-xref:fundamentals/tasks.adoc#_cachedfactory_workers[CachedFactory] helper class, which
-makes it easy to cache, re-use, and teardown these expensive long-lived components.
+include::partial$example/extending/jvmcode/6-module-cached-classloader.adoc[]

--- a/docs/modules/ROOT/pages/extending/running-jvm-code.adoc
+++ b/docs/modules/ROOT/pages/extending/running-jvm-code.adoc
@@ -45,3 +45,11 @@ include::partial$example/extending/jvmcode/4-module-run-task.adoc[]
 == Running a JavaModule in a Classloader
 
 include::partial$example/extending/jvmcode/5-module-classloader.adoc[]
+
+== Caching and Re-using JVM subprocesses and classloaders
+
+Java Virtual Machines are expensive to initialize and with a large memory footprint,
+therefore if you tend to be doing a lot of classloader or subprocess operations it
+makes sense to re-use the JVM. You can do this using the
+xref:fundamentals/tasks.adoc#_cachedfactory_workers[CachedFactory] helper class, which
+makes it easy to cache, re-use, and teardown these expensive long-lived components.

--- a/example/extending/jvmcode/3-worker/build.mill
+++ b/example/extending/jvmcode/3-worker/build.mill
@@ -20,7 +20,7 @@ def groovyClasspath: Task[Agg[PathRef]] = Task {
 }
 
 def groovyWorker: Worker[java.net.URLClassLoader] = Task.Worker {
-  mill.api.ClassLoader.create(groovyClasspath().map(_.path.toIO.toURL).toSeq, parent = null)
+  Jvm.spawnClassloader(groovyClasspath().map(_.path).toSeq)
 }
 
 trait GroovyGenerateJavaModule extends JavaModule {

--- a/example/extending/jvmcode/3-worker/build.mill
+++ b/example/extending/jvmcode/3-worker/build.mill
@@ -80,4 +80,5 @@ Contents of groovy-generated.html is <html><body><h1>Hello!</h1><p>Bar Groovy!</
 // the classloader contained within `groovyWorker` above is *initialized* in a single-thread,
 // but it may be *used* concurrently in a multi-threaded environment. Practically, that means
 // that the classes and methods you are invoking within the classloader do not make use of
-// un-synchronized global mutable variables.
+// un-synchronized global mutable variables. If the JVM logic within the classloader does
+// rely on mutable state, see <<Caching and Re-using JVM subprocesses and classloaders>> below

--- a/example/extending/jvmcode/6-module-cached-classloader/bar/src/Bar.java
+++ b/example/extending/jvmcode/6-module-cached-classloader/bar/src/Bar.java
@@ -1,0 +1,32 @@
+package bar;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class Bar {
+  static Path dest;
+  static String[] sources;
+  static Path sourcePath;
+  static String mangledText;
+  static Path fileDest;
+
+  public static void main(String[] args) throws IOException {
+    dest = Paths.get(args[0]);
+    sources = Arrays.<String>copyOfRange(args, 1, args.length);
+    for (String sourceStr : sources) {
+      sourcePath = Paths.get(sourceStr).toAbsolutePath();
+      try (Stream<Path> paths = Files.walk(sourcePath)) {
+        for (Path p : paths.collect(Collectors.toList())) {
+          if (p.toString().endsWith(".java")) {
+            mangledText = Files.readString(p).replace("hello", "HELLO");
+            fileDest = dest.resolve(sourcePath.relativize(p));
+            Files.write(fileDest, mangledText.getBytes());
+          }
+        }
+      }
+    }
+  }
+}

--- a/example/extending/jvmcode/6-module-cached-classloader/build.mill
+++ b/example/extending/jvmcode/6-module-cached-classloader/build.mill
@@ -1,0 +1,71 @@
+// Java Virtual Machines are expensive to initialize and with a large memory footprint,
+// therefore if you tend to be doing a lot of classloader or subprocess operations it
+// makes sense to re-use the JVM. You can do this using the
+// xref:fundamentals/tasks.adoc#_cachedfactory_workers[CachedFactory] helper class, which
+// makes it easy to cache, re-use, and teardown these expensive long-lived components.
+//
+// The example below is similar to <<Running a JavaModule in a Classloader>> above,
+// but in this case the `bar.Bar` class relies on class-level mutable state in its
+// implementation, and so sharing the same `URLClassLoader` across different
+// `foo*` tasks running on different threads is not thread-safe. To resolve this,
+// we make the `barWorker` contain an instance of `mill.api.CachedFactory`,
+// which ensures that the classloaders are created when necessary,
+// cached/re-used where possible, and torn down properly when no longer necessary.
+
+package build
+import mill._, scalalib._
+import mill.util.Jvm
+import mill.api.CachedFactory
+import java.net.URLClassLoader
+
+trait FooModule extends JavaModule {
+  def moduleDeps = Seq(bar)
+
+  def sources = Task {
+    barWorker().withValue(()) { classLoader =>
+      classLoader
+        .loadClass("bar.Bar")
+        .getMethod("main", classOf[Array[String]])
+        .invoke(null, Array(Task.dest.toString) ++ super.sources().map(_.path.toString))
+    }
+    Seq(PathRef(Task.dest))
+  }
+}
+
+object foo1 extends FooModule
+object foo2 extends FooModule
+object foo3 extends FooModule
+
+def barWorker: Worker[BarWorker] = Task.Worker {
+  new BarWorker(bar.runClasspath().map(_.path.toIO.toURL).toSeq)
+}
+
+class BarWorker(runClasspath: Seq[java.net.URL])(implicit ctx: mill.api.Ctx)
+    extends CachedFactory[Unit, URLClassLoader] {
+  def setup(key: Unit) = {
+    println("Setting up Classloader")
+    mill.api.ClassLoader.create(runClasspath, parent = null)
+  }
+  def teardown(key: Unit, value: URLClassLoader) = {
+    println("Tearing down Classloader")
+    value.close()
+  }
+  def maxCacheSize = 2
+}
+
+object bar extends JavaModule
+
+/** Usage
+
+> mill '{foo1,foo2,foo3}.run' # 3 classloaders are setup, one is torn down due to maxCacheSize
+Setting up Classloader
+Setting up Classloader
+Setting up Classloader
+Tearing down Classloader
+Foo.value: HELLO
+
+> mill clean # mill clean tears down the 2 remaining classloaders
+Tearing down Classloader
+Tearing down Classloader
+
+*/

--- a/example/extending/jvmcode/6-module-cached-classloader/build.mill
+++ b/example/extending/jvmcode/6-module-cached-classloader/build.mill
@@ -16,7 +16,7 @@ package build
 import mill._, scalalib._
 import mill.util.Jvm
 import mill.api.CachedFactory
-import java.net.URLClassLoader
+import java.net.{URL, URLClassLoader}
 
 trait FooModule extends JavaModule {
   def moduleDeps = Seq(bar)
@@ -37,14 +37,13 @@ object foo2 extends FooModule
 object foo3 extends FooModule
 
 def barWorker: Worker[BarWorker] = Task.Worker {
-  new BarWorker(bar.runClasspath().map(_.path.toIO.toURL).toSeq)
+  new BarWorker(bar.runClasspath().map(_.path).toSeq)
 }
 
-class BarWorker(runClasspath: Seq[java.net.URL])(implicit ctx: mill.api.Ctx)
-    extends CachedFactory[Unit, URLClassLoader] {
+class BarWorker(runClasspath: Seq[os.Path]) extends CachedFactory[Unit, URLClassLoader] {
   def setup(key: Unit) = {
     println("Setting up Classloader")
-    mill.api.ClassLoader.create(runClasspath, parent = null)
+    Jvm.spawnClassloader(runClasspath)
   }
   def teardown(key: Unit, value: URLClassLoader) = {
     println("Tearing down Classloader")

--- a/example/extending/jvmcode/6-module-cached-classloader/foo1/src/Foo.java
+++ b/example/extending/jvmcode/6-module-cached-classloader/foo1/src/Foo.java
@@ -1,0 +1,9 @@
+package foo;
+
+public class Foo {
+  public static final String value = "hello"; // Equivalent to val in Scala
+
+  public static void main(String[] args) {
+    System.out.println("Foo.value: " + Foo.value);
+  }
+}

--- a/example/extending/jvmcode/6-module-cached-classloader/foo2/src/Foo.java
+++ b/example/extending/jvmcode/6-module-cached-classloader/foo2/src/Foo.java
@@ -1,0 +1,9 @@
+package foo;
+
+public class Foo {
+  public static final String value = "hello"; // Equivalent to val in Scala
+
+  public static void main(String[] args) {
+    System.out.println("Foo.value: " + Foo.value);
+  }
+}

--- a/example/extending/jvmcode/6-module-cached-classloader/foo3/src/Foo.java
+++ b/example/extending/jvmcode/6-module-cached-classloader/foo3/src/Foo.java
@@ -1,0 +1,9 @@
+package foo;
+
+public class Foo {
+  public static final String value = "hello"; // Equivalent to val in Scala
+
+  public static void main(String[] args) {
+    System.out.println("Foo.value: " + Foo.value);
+  }
+}

--- a/example/fundamentals/tasks/6-workers/build.mill
+++ b/example/fundamentals/tasks/6-workers/build.mill
@@ -3,8 +3,14 @@
 // tasks in that they let you cache things, but the fact that they let you
 // cache the worker object in-memory allows for greater performance and
 // flexibility: you are no longer limited to caching only serializable data
-// and paying the cost of serializing it to disk every evaluation. This example
-// uses a Worker to provide simple in-memory caching for compressed files.
+// and paying the cost of serializing it to disk every evaluation.
+//
+// This example uses a Worker to provide simple two-level cache: in-memory caching
+// for compressed files, in addition to caching them on disk. This means that if the
+// Mill process is persistent (e.g. with `--watch`/`-w`) the cache lookups are instant,
+// but even if the Mill process is restarted it can load the cache values from disk
+// without having to recompute them:
+
 package build
 import mill._, scalalib._
 import java.util.Arrays
@@ -30,20 +36,25 @@ class CompressWorker(dest: os.Path) {
   val cache = collection.mutable.Map.empty[Int, Array[Byte]]
   def compress(name: String, bytes: Array[Byte]): Array[Byte] = {
     val hash = Arrays.hashCode(bytes)
-    if (!cache.contains(hash)) {
+    if (!synchronized(cache.contains(hash))) {
       val cachedPath = dest / hash.toHexString
       if (!os.exists(cachedPath)) {
         println("Compressing: " + name)
-        cache(hash) = compressBytes(bytes)
-        os.write(cachedPath, cache(hash))
+        val compressed = compressBytes(bytes)
+        synchronized {
+          cache(hash) = compressed
+          os.write(cachedPath, cache(hash))
+        }
       } else {
         println("Cached from disk: " + name)
-        cache(hash) = os.read.bytes(cachedPath)
+        synchronized {
+          cache(hash) = os.read.bytes(cachedPath)
+        }
       }
     } else {
       println("Cached from memory: " + name)
     }
-    cache(hash)
+    synchronized { cache(hash) }
   }
 }
 
@@ -67,7 +78,9 @@ def compressBytes(input: Array[Byte]) = {
 // but _usage_ of the worker's value may be done concurrently. The user of
 // `Task.Worker` is responsible for ensuring it's value is safe to use in a
 // multi-threaded environment via techniques like locks, atomics, or concurrent data
-// structures
+// structures. The example above uses `synchronized{}` around all access to the
+// shared `cache` state to allow the slow `compressBytes` operation to run in
+// parallel while the fast mutation of the `cache` is single-threaded.
 //
 // Workers live as long as the Mill process. By default, consecutive `mill`
 // commands in the same folder will re-use the same Mill process and workers,
@@ -111,6 +124,10 @@ Cached from disk: world.txt
 // https://github.com/scala-js/scala-js[Scala.js Optimizer].
 // This lets us keep them in-memory with warm caches and fast incremental execution.
 //
+// Like any other task, you can use `./mill clean` to wipe out any cached in-memory or
+// on-disk state belonging to workers. This may be necessary if your worker implementation
+// has bugs that cause the worker disk or in-memory data structures to get into a bad state.
+//
 // === `Autoclosable` Workers
 //
 // As <<Workers>> may also hold limited resources, it may be necessary to free up these resources once a worker is no longer needed.
@@ -128,3 +145,82 @@ class MyWorker() extends AutoCloseable {
 }
 
 def myWorker = Task.Worker { new MyWorker() }
+
+// === `CachedFactory` Workers
+//
+// One very common use case for workers is managing long-lived mutable state. The issue
+// with long-lived mutable state is that in the presence of parallelism (the default in
+// Mill), managing such state can be tricky:
+//
+// * If you allow unrestricted access to the mutable state across multiple threads,
+//   you are subject to race conditions and non-deterministic bugs
+//
+// * If you just synchronize/lock all access to the mutable state, you lose all benefits
+//   for parallelism
+//
+// * If you re-generate the mutable state each time for each thread, you lose the benefits
+//   of it being long lived
+//
+// The solution to these issues is to maintain an in-memory cache, with proper locking,
+// eviction, and invalidation. Doing so is tedious and error prone, and so Mill provides
+// the `CachedFactory` helper to make it easier. The example below re-implements the a simplified
+// version of `CompressWorker` we saw earlier, but using `CacheFactory` to cache, reset, and
+// re-use the `ByteArrayOutputStream` btween calls to `compressWorker2().compress`:
+//
+import mill._
+import java.lang.AutoCloseable
+import mill.api.CachedFactory
+import java.io.ByteArrayOutputStream
+
+def compressWorker2 = Task.Worker { new CompressWorker2(Task.dest) }
+class CompressWorker2(dest: os.Path) extends AutoCloseable {
+  object streamCache extends CachedFactory[Unit, ByteArrayOutputStream] {
+    def setup(key: Unit): ByteArrayOutputStream = new ByteArrayOutputStream()
+    def teardown(key: Unit, value: ByteArrayOutputStream): Unit = value.reset()
+    def maxCacheSize = 10
+  }
+
+  val cache = collection.mutable.Map.empty[Int, Array[Byte]]
+  def compress(name: String, bytes: Array[Byte]): Array[Byte] = {
+    val hash = Arrays.hashCode(bytes)
+    if (!synchronized(cache.contains(hash))) {
+      println("Compressing: " + name)
+      val compressed = streamCache.withValue(()) { bos => compressBytes2(bos, bytes) }
+      synchronized { cache(hash) = compressed }
+    } else {
+      println("Cached from memory: " + name)
+    }
+    synchronized { cache(hash) }
+  }
+
+  override def close() = { streamCache.close() }
+}
+
+def compressBytes2(bos: ByteArrayOutputStream, input: Array[Byte]) = {
+  bos.reset()
+  val gzip = new GZIPOutputStream(bos)
+  gzip.write(input)
+  gzip.close()
+  bos.toByteArray
+}
+
+// * `CachedFactory` takes two type parameters, a `K` key type and a `V` value type.
+//   In this case `K` is `Unit` since all `ByteArrayOutputStream`s are the same, but if you
+//   are caching things which take some kind of configuration (e.g. compilers with compiler
+//   flags) you can set `K` to be the config class so that values with different input
+//   configuration are cached separately.
+//
+// * `setup` creates the `ByteArrayOutputStream`, `maxCacheSize` configures the maximum
+//   number of cached entries to keep around while they are not in use, and when the count
+//   of cached entries exceeds that number `teardown` cleans them up
+//
+// * You should make sure that you wire up the worker's `AutoCloeable#close` method to
+//   `CachedFactory#close()`, so that when the worker is torn down all the respective
+//   cache entries are town down as well
+//
+// Although this example is synthetic (you don't actually need to reset, reuse, and teardown
+// `ByteArrayOutputStream`s) the same techniques would apply to any long-lived mutable state
+// or components you need to manage. This is especially important when
+// xref:extending/running-jvm-code.adoc[running JVM code in classloaders or subprocesses],
+// as those are both expensive to initialize and need to be properly closed or terminated
+// when you are done with them

--- a/example/fundamentals/tasks/6-workers/build.mill
+++ b/example/fundamentals/tasks/6-workers/build.mill
@@ -172,32 +172,37 @@ import java.lang.AutoCloseable
 import mill.api.CachedFactory
 import java.io.ByteArrayOutputStream
 
-def compressWorker2 = Task.Worker { new CompressWorker2(Task.dest) }
-class CompressWorker2(dest: os.Path) extends AutoCloseable {
-  object streamCache extends CachedFactory[Unit, ByteArrayOutputStream] {
-    def setup(key: Unit): ByteArrayOutputStream = new ByteArrayOutputStream()
-    def teardown(key: Unit, value: ByteArrayOutputStream): Unit = value.reset()
-    def maxCacheSize = 10
+def cachedCompressWorker = Task.Worker { new CachedCompressWorker(Task.dest) }
+class CachedCompressWorker(dest: os.Path) extends CachedFactory[Unit, ByteArrayOutputStream] {
+  def setup(key: Unit): ByteArrayOutputStream = {
+    println("setup ByteArrayOutputStream")
+    new ByteArrayOutputStream()
   }
+
+  def teardown(key: Unit, value: ByteArrayOutputStream): Unit = {
+    println("teardown ByteArrayOutputStream")
+    value.reset()
+  }
+
+  def maxCacheSize = 2
 
   val cache = collection.mutable.Map.empty[Int, Array[Byte]]
   def compress(name: String, bytes: Array[Byte]): Array[Byte] = {
     val hash = Arrays.hashCode(bytes)
     if (!synchronized(cache.contains(hash))) {
       println("Compressing: " + name)
-      val compressed = streamCache.withValue(()) { bos => compressBytes2(bos, bytes) }
+      val compressed = withValue(()) { bos => compressBytes2(bos, bytes) }
       synchronized { cache(hash) = compressed }
     } else {
       println("Cached from memory: " + name)
     }
     synchronized { cache(hash) }
   }
-
-  override def close() = { streamCache.close() }
 }
 
 def compressBytes2(bos: ByteArrayOutputStream, input: Array[Byte]) = {
   bos.reset()
+  Thread.sleep(1000) // Simulate a slow operation
   val gzip = new GZIPOutputStream(bos)
   gzip.write(input)
   gzip.close()
@@ -214,13 +219,48 @@ def compressBytes2(bos: ByteArrayOutputStream, input: Array[Byte]) = {
 //   number of cached entries to keep around while they are not in use, and when the count
 //   of cached entries exceeds that number `teardown` cleans them up
 //
-// * You should make sure that you wire up the worker's `AutoCloeable#close` method to
-//   `CachedFactory#close()`, so that when the worker is torn down all the respective
-//   cache entries are town down as well
-//
 // Although this example is synthetic (you don't actually need to reset, reuse, and teardown
 // `ByteArrayOutputStream`s) the same techniques would apply to any long-lived mutable state
 // or components you need to manage. This is especially important when
 // xref:extending/running-jvm-code.adoc[running JVM code in classloaders or subprocesses],
 // as those are both expensive to initialize and need to be properly closed or terminated
 // when you are done with them
+//
+// The above `cachedCompressWorker` can be used as shown below, with three
+// `def compressed*` tasks using it to call `.compress`:
+
+def compressed1 = Task {
+  cachedCompressWorker().compress("foo.txt", "I am cow".getBytes)
+}
+
+def compressed2 = Task {
+  cachedCompressWorker().compress("bar.txt", "Hear me moo".getBytes)
+}
+
+def compressed3 = Task {
+  cachedCompressWorker().compress("qux.txt", "I weigh twice as much as you".getBytes)
+}
+
+/** Usage
+
+> # 3 streams are created on demand, 1 is torn down afer due to maxCacheSize = 2 limit
+> ./mill show '{compressed1,compressed2,compressed3}'
+setup ByteArrayOutputStream
+setup ByteArrayOutputStream
+setup ByteArrayOutputStream
+Compressing: foo.txt
+Compressing: bar.txt
+Compressing: qux.txt
+teardown ByteArrayOutputStream
+{
+  "compressed1": ...
+  "compressed2": ...
+  "compressed3": ...
+}
+
+> # `clean` clears the CachedFactory and tears down the two streams in the cache
+> ./mill clean cachedCompressWorker
+teardown ByteArrayOutputStream
+teardown ByteArrayOutputStream
+
+*/

--- a/main/api/src/mill/api/CacheFactory.scala
+++ b/main/api/src/mill/api/CacheFactory.scala
@@ -1,0 +1,48 @@
+package mill.api
+
+/**
+ * Manage the setup, teardown, and caching of objects of type [[V]] safely
+ * in a multithreaded environment.
+ *
+ * The user provides the [[setup]] and [[teardown]] logic along with  a [[maxCacheSize]],
+ * and [[CacheFactory]] provides instances of [[V]] as requested using the [[withValue]]
+ * method. These instances are automatically constructed on-demand from the give key,
+ * cached with an LRU strategy, and destroyed when they are eventually evicted
+ *
+ * Intended for relatively small caches approximately O(num-threads) in size that
+ * will typically get used in a build system, not intended for caching large amounts of entries
+ */
+abstract class CacheFactory[K, V] {
+  def setup(key: K): V
+  def teardown(key: K, value: V): Unit
+  def maxCacheSize: Int
+
+  // A simple LRU cache data structure. Not optimized at
+  // all since this class is meant for small-scale usage
+  private var keyValues: List[(K, V)] = List.empty
+
+  def withValue[R](key: K)(block: V => R): R = {
+    val valueOpt: Option[V] = synchronized{
+      keyValues.iterator.zipWithIndex.collectFirst{case ((`key`, v), i) => (v, i)} match{
+        case None => None
+        case Some((v, i)) =>
+          keyValues = keyValues.patch(i, Nil, 1)
+          Some(v)
+      }
+    }
+
+    val value: V = valueOpt match{
+      case Some(v) => v
+      case None => setup(key)
+    }
+
+    try block(value)
+    finally {
+      synchronized{
+        val (newKeyValues, extra) = ((key, value) :: keyValues).splitAt(maxCacheSize)
+        keyValues = newKeyValues
+        for((k, v) <- extra) teardown(k, v)
+      }
+    }
+  }
+}

--- a/main/api/src/mill/api/CacheFactory.scala
+++ b/main/api/src/mill/api/CacheFactory.scala
@@ -22,8 +22,8 @@ abstract class CacheFactory[K, V] {
   private var keyValues: List[(K, V)] = List.empty
 
   def withValue[R](key: K)(block: V => R): R = {
-    val valueOpt: Option[V] = synchronized{
-      keyValues.iterator.zipWithIndex.collectFirst{case ((`key`, v), i) => (v, i)} match{
+    val valueOpt: Option[V] = synchronized {
+      keyValues.iterator.zipWithIndex.collectFirst { case ((`key`, v), i) => (v, i) } match {
         case None => None
         case Some((v, i)) =>
           keyValues = keyValues.patch(i, Nil, 1)
@@ -31,17 +31,17 @@ abstract class CacheFactory[K, V] {
       }
     }
 
-    val value: V = valueOpt match{
+    val value: V = valueOpt match {
       case Some(v) => v
       case None => setup(key)
     }
 
     try block(value)
     finally {
-      synchronized{
+      synchronized {
         val (newKeyValues, extra) = ((key, value) :: keyValues).splitAt(maxCacheSize)
         keyValues = newKeyValues
-        for((k, v) <- extra) teardown(k, v)
+        for ((k, v) <- extra) teardown(k, v)
       }
     }
   }

--- a/main/api/src/mill/api/CachedFactory.scala
+++ b/main/api/src/mill/api/CachedFactory.scala
@@ -5,14 +5,14 @@ package mill.api
  * in a multithreaded environment.
  *
  * The user provides the [[setup]] and [[teardown]] logic along with  a [[maxCacheSize]],
- * and [[CacheFactory]] provides instances of [[V]] as requested using the [[withValue]]
+ * and [[CachedFactory]] provides instances of [[V]] as requested using the [[withValue]]
  * method. These instances are automatically constructed on-demand from the give key,
  * cached with an LRU strategy, and destroyed when they are eventually evicted
  *
  * Intended for relatively small caches approximately O(num-threads) in size that
  * will typically get used in a build system, not intended for caching large amounts of entries
  */
-abstract class CacheFactory[K, V] {
+abstract class CachedFactory[K, V] extends AutoCloseable {
   def setup(key: K): V
   def teardown(key: K, value: V): Unit
   def maxCacheSize: Int
@@ -44,5 +44,8 @@ abstract class CacheFactory[K, V] {
         for ((k, v) <- extra) teardown(k, v)
       }
     }
+  }
+  def close(): Unit = synchronized {
+    for ((k, v) <- keyValues) teardown(k, v)
   }
 }

--- a/main/api/src/mill/api/FixSizedCache.scala
+++ b/main/api/src/mill/api/FixSizedCache.scala
@@ -12,6 +12,7 @@ import java.util.concurrent.{ConcurrentHashMap, Semaphore}
  *
  * @param perKeySize Cache Size per unique key
  */
+@deprecated("Use mill.api.CachedFactory instead", "Mill since 0.12.3")
 class FixSizedCache[T](perKeySize: Int) extends KeyedLockedCache[T] {
 
   // Cache Key -> (Semaphore, Array of cached elements)

--- a/main/api/src/mill/api/KeyedLockedCache.scala
+++ b/main/api/src/mill/api/KeyedLockedCache.scala
@@ -5,10 +5,12 @@ package mill.api
  * body function to be called with the value. [[KeyedLockedCache]] ensures that
  * the body function is called with the computed/cached value sequentially.
  */
+@deprecated("Use mill.api.CachedFactory instead", "Mill since 0.12.3")
 trait KeyedLockedCache[T] {
   def withCachedValue[V](key: Long)(f: => T)(f2: T => V): V
 }
 
+@deprecated("Use mill.api.CachedFactory instead", "Mill since 0.12.3")
 object KeyedLockedCache {
   class RandomBoundedCache[T](hotParallelism: Int, coldCacheSize: Int) extends KeyedLockedCache[T] {
     private val random = new scala.util.Random(313373)

--- a/main/api/test/src/mill/api/CachedFactoryTests.scala
+++ b/main/api/test/src/mill/api/CachedFactoryTests.scala
@@ -1,0 +1,139 @@
+package mill.api
+
+import utest._
+
+object CachedFactoryTests extends TestSuite {
+  val tests: Tests = Tests {
+    var resourceCount = 0
+    var closedResourceIds = Set.empty[Int]
+    class Resource {
+      resourceCount += 1
+      val id = resourceCount
+      def close() = closedResourceIds += id
+    }
+    class Cache(val maxCacheSize: Int) extends CachedFactory[Unit, Resource] {
+      def setup(key: Unit): Resource = new Resource
+
+      def teardown(key: Unit, value: Resource): Unit = value.close()
+    }
+    test("sizeZero") {
+      // with cache of size 0, cache entries are never re-used
+      object cache extends Cache(maxCacheSize = 0)
+
+      assert(closedResourceIds == Set())
+      assert(resourceCount == 0)
+      cache.withValue(()) { resource1 =>
+        assert(resource1.id == 1)
+        assert(closedResourceIds == Set())
+        assert(resourceCount == 1)
+        cache.withValue(()) { resource2 =>
+          assert(resource2.id == 2)
+          assert(closedResourceIds == Set())
+          assert(resourceCount == 2)
+        }
+
+        assert(closedResourceIds == Set(2))
+        assert(resourceCount == 2)
+
+        cache.withValue(()) { resource3 =>
+          assert(resource3.id == 3)
+          assert(closedResourceIds == Set(2))
+          assert(resourceCount == 3)
+        }
+
+        assert(closedResourceIds == Set(2, 3))
+        assert(resourceCount == 3)
+      }
+      assert(closedResourceIds == Set(1, 2, 3))
+      assert(resourceCount == 3)
+
+      // close() does nothing since all resources are already closed
+      cache.close()
+      assert(closedResourceIds == Set(1, 2, 3))
+      assert(resourceCount == 3)
+    }
+
+    test("sizeOne") {
+      // with cache of size 1, cache entries are sometimes re-used
+      object cache extends Cache(maxCacheSize = 1)
+
+      assert(closedResourceIds == Set())
+      assert(resourceCount == 0)
+      cache.withValue(()) { resource1 =>
+        assert(resource1.id == 1)
+        assert(closedResourceIds == Set())
+        assert(resourceCount == 1)
+        cache.withValue(()) { resource2 =>
+          assert(resource2.id == 2)
+          assert(closedResourceIds == Set())
+          assert(resourceCount == 2)
+        }
+
+        assert(closedResourceIds == Set())
+        assert(resourceCount == 2)
+
+        // Resource id=2 is the last one to be created and cached, and so
+        // gets re-used when withValue is asked for again
+        cache.withValue(()) { resource3 =>
+          assert(resource3.id == 2)
+          assert(closedResourceIds == Set())
+          assert(resourceCount == 2)
+        }
+
+        assert(closedResourceIds == Set())
+        assert(resourceCount == 2)
+      }
+
+      // When both id=1 and id=2 are done, one of them has to be torn down
+      // due to maxCacheSize=1, so 2 is turn down
+      assert(closedResourceIds == Set(2))
+      assert(resourceCount == 2)
+
+      // close() closes the 1 cached resource id=1 who was not yet torn down
+      cache.close()
+      assert(closedResourceIds == Set(1, 2))
+      assert(resourceCount == 2)
+    }
+    test("sizeTwo") {
+      // with cache of size 1, cache entries are always re-used for this small exmaple
+      object cache extends Cache(maxCacheSize = 2)
+
+      assert(closedResourceIds == Set())
+      assert(resourceCount == 0)
+      cache.withValue(()) { resource1 =>
+        assert(resource1.id == 1)
+        assert(closedResourceIds == Set())
+        assert(resourceCount == 1)
+        cache.withValue(()) { resource2 =>
+          assert(resource2.id == 2)
+          assert(closedResourceIds == Set())
+          assert(resourceCount == 2)
+        }
+
+        assert(closedResourceIds == Set())
+        assert(resourceCount == 2)
+
+        // Resource id=2 is the last one to be created and cached, and so
+        // gets re-used when withValue is asked for again
+        cache.withValue(()) { resource3 =>
+          assert(resource3.id == 2)
+          assert(closedResourceIds == Set())
+          assert(resourceCount == 2)
+        }
+
+        assert(closedResourceIds == Set())
+        assert(resourceCount == 2)
+      }
+
+      // Cache is big enough to fit both id=1 and id=2, so none of them get torn down
+      assert(closedResourceIds == Set())
+      assert(resourceCount == 2)
+
+      // close() closes the both cached resources id=1 and id=2 who were not yet torn down
+      cache.close()
+      assert(closedResourceIds == Set(1, 2))
+      assert(resourceCount == 2)
+    }
+
+  }
+}

--- a/main/util/src/mill/util/Jvm.scala
+++ b/main/util/src/mill/util/Jvm.scala
@@ -441,6 +441,19 @@ object Jvm extends CoursierSupport {
       body
     )
   }
+
+  def spawnClassloader(
+      classPath: Iterable[os.Path],
+      sharedPrefixes: Seq[String] = Nil,
+      parent: ClassLoader = null
+  ): java.net.URLClassLoader = {
+    mill.api.ClassLoader.create(
+      classPath.iterator.map(_.toNIO.toUri.toURL).toVector,
+      parent,
+      sharedPrefixes = sharedPrefixes
+    )(new Ctx.Home { override def home = os.home })
+  }
+
   def inprocess[T](
       classPath: Agg[os.Path],
       classLoaderOverrideSbtTesting: Boolean,

--- a/scalajslib/src/mill/scalajslib/worker/ScalaJSWorker.scala
+++ b/scalajslib/src/mill/scalajslib/worker/ScalaJSWorker.scala
@@ -2,32 +2,36 @@ package mill.scalajslib.worker
 
 import java.io.File
 import mill.scalajslib.api
-import mill.scalajslib.worker.{api => workerApi}
-import mill.api.{Ctx, Result, internal}
+import mill.scalajslib.worker.api as workerApi
+import mill.api.{CacheFactory, Ctx, Result, internal}
 import mill.define.{Discover, Worker}
-import mill.{Agg, Task}
+import mill.scalajslib.worker.api.ScalaJSWorkerApi
+import mill.{Agg, PathRef, Task}
+
+import java.net.URLClassLoader
 
 @internal
-private[scalajslib] class ScalaJSWorker extends AutoCloseable {
-  private var scalaJSWorkerInstanceCache = Option.empty[(Long, workerApi.ScalaJSWorkerApi)]
+private[scalajslib] class ScalaJSWorker(jobs: Int) extends AutoCloseable {
+  object scalaJSWorkerInstanceCache extends CacheFactory[Agg[mill.PathRef], (URLClassLoader, workerApi.ScalaJSWorkerApi)]{
+    override def setup(key: Agg[PathRef]) = {
+      val cl = mill.api.ClassLoader.create(
+        key.map(_.path.toIO.toURI.toURL).toVector,
+        getClass.getClassLoader
+      )(new Ctx.Home {override def home = os.home})
+      val bridge = cl
+        .loadClass("mill.scalajslib.worker.ScalaJSWorkerImpl")
+        .getDeclaredConstructor()
+        .newInstance()
+        .asInstanceOf[workerApi.ScalaJSWorkerApi]
 
-  private def bridge(toolsClasspath: Agg[mill.PathRef])(implicit ctx: Ctx.Home) = {
-    val classloaderSig = toolsClasspath.hashCode
-    scalaJSWorkerInstanceCache match {
-      case Some((sig, bridge)) if sig == classloaderSig => bridge
-      case _ =>
-        val cl = mill.api.ClassLoader.create(
-          toolsClasspath.map(_.path.toIO.toURI.toURL).toVector,
-          getClass.getClassLoader
-        )
-        val bridge = cl
-          .loadClass("mill.scalajslib.worker.ScalaJSWorkerImpl")
-          .getDeclaredConstructor()
-          .newInstance()
-          .asInstanceOf[workerApi.ScalaJSWorkerApi]
-        scalaJSWorkerInstanceCache = Some((classloaderSig, bridge))
-        bridge
+      (cl, bridge)
     }
+
+    override def teardown(key: Agg[PathRef], value: (URLClassLoader, workerApi.ScalaJSWorkerApi)): Unit = {
+      value._1.close()
+    }
+
+    override def maxCacheSize: Int = jobs
   }
 
   private def toWorkerApi(moduleKind: api.ModuleKind): workerApi.ModuleKind = moduleKind match {
@@ -172,32 +176,36 @@ private[scalajslib] class ScalaJSWorker extends AutoCloseable {
       importMap: Seq[api.ESModuleImportMapping],
       experimentalUseWebAssembly: Boolean
   )(implicit ctx: Ctx.Home): Result[api.Report] = {
-    bridge(toolsClasspath).link(
-      runClasspath = runClasspath.iterator.map(_.path.toNIO).toSeq,
-      dest = dest,
-      main = main,
-      forceOutJs = forceOutJs,
-      testBridgeInit = testBridgeInit,
-      isFullLinkJS = isFullLinkJS,
-      optimizer = optimizer,
-      sourceMap = sourceMap,
-      moduleKind = toWorkerApi(moduleKind),
-      esFeatures = toWorkerApi(esFeatures),
-      moduleSplitStyle = toWorkerApi(moduleSplitStyle),
-      outputPatterns = toWorkerApi(outputPatterns),
-      minify = minify,
-      importMap = importMap.map(toWorkerApi),
-      experimentalUseWebAssembly = experimentalUseWebAssembly
-    ) match {
-      case Right(report) => Result.Success(fromWorkerApi(report))
-      case Left(message) => Result.Failure(message)
+    scalaJSWorkerInstanceCache.withValue(toolsClasspath) { case (cl, bridge) =>
+      bridge.link(
+        runClasspath = runClasspath.iterator.map(_.path.toNIO).toSeq,
+        dest = dest,
+        main = main,
+        forceOutJs = forceOutJs,
+        testBridgeInit = testBridgeInit,
+        isFullLinkJS = isFullLinkJS,
+        optimizer = optimizer,
+        sourceMap = sourceMap,
+        moduleKind = toWorkerApi(moduleKind),
+        esFeatures = toWorkerApi(esFeatures),
+        moduleSplitStyle = toWorkerApi(moduleSplitStyle),
+        outputPatterns = toWorkerApi(outputPatterns),
+        minify = minify,
+        importMap = importMap.map(toWorkerApi),
+        experimentalUseWebAssembly = experimentalUseWebAssembly
+      ) match {
+        case Right(report) => Result.Success(fromWorkerApi(report))
+        case Left(message) => Result.Failure(message)
+      }
     }
   }
 
   def run(toolsClasspath: Agg[mill.PathRef], config: api.JsEnvConfig, report: api.Report)(
       implicit ctx: Ctx.Home
   ): Unit = {
-    bridge(toolsClasspath).run(toWorkerApi(config), toWorkerApi(report))
+    scalaJSWorkerInstanceCache.withValue(toolsClasspath) { case (cl, bridge) =>
+      bridge.run(toWorkerApi(config), toWorkerApi(report))
+    }
   }
 
   def getFramework(
@@ -206,21 +214,22 @@ private[scalajslib] class ScalaJSWorker extends AutoCloseable {
       frameworkName: String,
       report: api.Report
   )(implicit ctx: Ctx.Home): (() => Unit, sbt.testing.Framework) = {
-    bridge(toolsClasspath).getFramework(
-      toWorkerApi(config),
-      frameworkName,
-      toWorkerApi(report)
-    )
+    scalaJSWorkerInstanceCache.withValue(toolsClasspath) { case (cl, bridge) =>
+      bridge.getFramework(
+        toWorkerApi(config),
+        frameworkName,
+        toWorkerApi(report)
+      )
+    }
   }
 
   override def close(): Unit = {
-    scalaJSWorkerInstanceCache = None
   }
 }
 
 @internal
 private[scalajslib] object ScalaJSWorkerExternalModule extends mill.define.ExternalModule {
 
-  def scalaJSWorker: Worker[ScalaJSWorker] = Task.Worker { new ScalaJSWorker() }
+  def scalaJSWorker: Worker[ScalaJSWorker] = Task.Worker { new ScalaJSWorker(Task.ctx.asInstanceOf[mill.api.Ctx.Jobs].jobs) }
   lazy val millDiscover: Discover = Discover[this.type]
 }

--- a/scalajslib/src/mill/scalajslib/worker/ScalaJSWorker.scala
+++ b/scalajslib/src/mill/scalajslib/worker/ScalaJSWorker.scala
@@ -5,7 +5,6 @@ import mill.scalajslib.api
 import mill.scalajslib.worker.api as workerApi
 import mill.api.{CacheFactory, Ctx, Result, internal}
 import mill.define.{Discover, Worker}
-import mill.scalajslib.worker.api.ScalaJSWorkerApi
 import mill.{Agg, PathRef, Task}
 
 import java.net.URLClassLoader

--- a/scalalib/src/mill/scalalib/ZincWorkerModule.scala
+++ b/scalalib/src/mill/scalalib/ZincWorkerModule.scala
@@ -3,7 +3,7 @@ package mill.scalalib
 import coursier.Repository
 import mainargs.Flag
 import mill._
-import mill.api.{Ctx, FixSizedCache, KeyedLockedCache, PathRef, Result}
+import mill.api.{Ctx, PathRef, Result}
 import mill.define.{Discover, ExternalModule, Task}
 import mill.scalalib.Lib.resolveDependencies
 import mill.scalalib.api.ZincWorkerUtil.{isBinaryBridgeAvailable, isDotty, isDottyOrScala3}

--- a/scalalib/src/mill/scalalib/ZincWorkerModule.scala
+++ b/scalalib/src/mill/scalalib/ZincWorkerModule.scala
@@ -84,9 +84,7 @@ trait ZincWorkerModule extends mill.Module with OfflineSupportModule with Coursi
           String => PathRef
         ]
       ], // compilerBridge
-      classOf[(Agg[PathRef], String) => PathRef], // libraryJarNameGrep
-      classOf[(Agg[PathRef], String) => PathRef], // compilerJarNameGrep
-      classOf[KeyedLockedCache[_]], // compilerCache
+      classOf[Int], // jobs
       classOf[Boolean], // compileToJar
       classOf[Boolean], // zincLogDebug
       classOf[Option[PathRef]] // javaHome
@@ -102,9 +100,7 @@ trait ZincWorkerModule extends mill.Module with OfflineSupportModule with Coursi
               )
               .value
         )),
-        ZincWorkerUtil.grepJar(_, "scala-library", _, sources = false),
-        ZincWorkerUtil.grepJar(_, "scala-compiler", _, sources = false),
-        new FixSizedCache(jobs),
+        jobs,
         java.lang.Boolean.FALSE,
         java.lang.Boolean.valueOf(zincLogDebug()),
         javaHome()

--- a/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
+++ b/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
@@ -156,9 +156,9 @@ class ZincWorkerImpl(
 
     }
 
-    override def teardown(key: Seq[String], value: Compilers): Unit = ???
+    override def teardown(key: Seq[String], value: Compilers): Unit = ()
 
-    override def maxCacheSize: Int = ???
+    override def maxCacheSize: Int = jobs
   }
 
 

--- a/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
+++ b/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
@@ -1,40 +1,20 @@
 package mill.scalalib.worker
 
 import mill.api.Loose.Agg
-import mill.api.{CompileProblemReporter, KeyedLockedCache, PathRef, Result, internal}
+import mill.api.{CacheFactory, CompileProblemReporter, Ctx, KeyedLockedCache, PathRef, Result, internal}
 import mill.scalalib.api.{CompilationResult, Versions, ZincWorkerApi, ZincWorkerUtil}
-import sbt.internal.inc.{
-  Analysis,
-  CompileFailed,
-  FreshCompilerCache,
-  ManagedLoggedReporter,
-  MappedFileConverter,
-  ScalaInstance,
-  Stamps,
-  ZincUtil,
-  javac
-}
+import os.Path
+import sbt.internal.inc.{Analysis, CompileFailed, FreshCompilerCache, ManagedLoggedReporter, MappedFileConverter, ScalaInstance, Stamps, ZincUtil, javac}
 import sbt.internal.inc.classpath.ClasspathUtil
 import sbt.internal.inc.consistent.ConsistentFileAnalysisStore
 import sbt.internal.util.{ConsoleAppender, ConsoleOut}
 import sbt.mill.SbtLoggerUtils
 import xsbti.compile.analysis.ReadWriteMappers
-import xsbti.compile.{
-  AnalysisContents,
-  AnalysisStore,
-  AuxiliaryClassFileExtension,
-  ClasspathOptions,
-  CompileAnalysis,
-  CompileOrder,
-  Compilers,
-  IncOptions,
-  JavaTools,
-  MiniSetup,
-  PreviousResult
-}
+import xsbti.compile.{AnalysisContents, AnalysisStore, AuxiliaryClassFileExtension, ClasspathOptions, CompileAnalysis, CompileOrder, Compilers, IncOptions, JavaTools, MiniSetup, PreviousResult}
 import xsbti.{PathBasedFile, VirtualFile}
 
 import java.io.File
+import java.net.URLClassLoader
 import java.util.Optional
 import scala.collection.mutable
 import scala.ref.SoftReference
@@ -46,60 +26,147 @@ class ZincWorkerImpl(
       (ZincWorkerApi.Ctx, (String, String) => (Option[Agg[PathRef]], PathRef)),
       String => PathRef
     ],
-    libraryJarNameGrep: (Agg[PathRef], String) => PathRef,
-    compilerJarNameGrep: (Agg[PathRef], String) => PathRef,
-    compilerCache: KeyedLockedCache[Compilers],
+    jobs: Int,
     compileToJar: Boolean,
     zincLogDebug: Boolean,
     javaHome: Option[PathRef]
 ) extends ZincWorkerApi with AutoCloseable {
-  private val zincLogLevel = if (zincLogDebug) sbt.util.Level.Debug else sbt.util.Level.Info
-  private[this] val ic = new sbt.internal.inc.IncrementalCompilerImpl()
-  private val javaOnlyCompilersCache = mutable.Map.empty[Seq[String], SoftReference[Compilers]]
+  val libraryJarNameGrep: (Agg[PathRef], String) => PathRef =
+    ZincWorkerUtil.grepJar(_, "scala-library", _, sources = false)
 
-  private val filterJavacRuntimeOptions: String => Boolean = opt => opt.startsWith("-J")
+  case class CompileCacheKey(scalaVersion: String,
+                             compilerClasspath: Seq[PathRef],
+                             scalacPluginClasspath: Seq[PathRef],
+                             scalaOrganization: String,
+                             javacRuntimeOptions: Seq[String]) {
+    val combinedCompilerClasspath = compilerClasspath ++ scalacPluginClasspath
+    val compilersSig =
+      combinedCompilerClasspath.hashCode() + scalaVersion.hashCode() +
+        scalaOrganization.hashCode() + javacRuntimeOptions.hashCode()
+  }
+  object scalaCompilerCache extends CacheFactory[CompileCacheKey, (URLClassLoader, Compilers)] {
 
-  def javaOnlyCompilers(javacOptions: Seq[String]): Compilers = {
-    // Only options relevant for the compiler runtime influence the cached instance
-    val javacRuntimeOptions = javacOptions.filter(filterJavacRuntimeOptions)
+    override def maxCacheSize = jobs
 
-    javaOnlyCompilersCache.get(javacRuntimeOptions) match {
-      case Some(SoftReference(compilers)) => compilers
-      case _ =>
-        // Keep the classpath as written by the user
-        val classpathOptions = ClasspathOptions.of(
-          /*bootLibrary*/ false,
-          /*compiler*/ false,
-          /*extra*/ false,
-          /*autoBoot*/ false,
-          /*filterLibrary*/ false
-        )
+    override def setup(key: CompileCacheKey): (URLClassLoader, Compilers) = {
+      import key._
 
-        val dummyFile = new java.io.File("")
-        // Zinc does not have an entry point for Java-only compilation, so we need
-        // to make up a dummy ScalaCompiler instance.
-        val scalac = ZincUtil.scalaCompiler(
-          new ScalaInstance(
-            version = "",
-            loader = null,
-            loaderCompilerOnly = null,
-            loaderLibraryOnly = null,
-            libraryJars = Array(dummyFile),
-            compilerJars = Array(dummyFile),
-            allJars = new Array(0),
-            explicitActual = Some("")
-          ),
-          dummyFile,
-          classpathOptions // this is used for javac too
-        )
+      val combinedCompilerJars = combinedCompilerClasspath.iterator.map(_.path.toIO).toArray
 
-        val javaTools = getLocalOrCreateJavaTools(javacRuntimeOptions)
+      val compiledCompilerBridge = compileBridgeIfNeeded(
+        scalaVersion,
+        scalaOrganization,
+        compilerClasspath
+      )
+      val loader = getCachedClassLoader(compilersSig, combinedCompilerJars)
+      val scalaInstance = new ScalaInstance(
+        version = key.scalaVersion,
+        loader = loader,
+        loaderCompilerOnly = loader,
+        loaderLibraryOnly = ClasspathUtil.rootLoader,
+        libraryJars = Array(libraryJarNameGrep(
+          compilerClasspath,
+          // we don't support too outdated dotty versions
+          // and because there will be no scala 2.14, so hardcode "2.13." here is acceptable
+          if (ZincWorkerUtil.isDottyOrScala3(key.scalaVersion)) "2.13." else key.scalaVersion
+        ).path.toIO),
+        compilerJars = combinedCompilerJars,
+        allJars = combinedCompilerJars,
+        explicitActual = None
+      )
+      val compilers = ic.compilers(
+        javaTools = getLocalOrCreateJavaTools(javacRuntimeOptions),
+        scalac = ZincUtil.scalaCompiler(scalaInstance, compiledCompilerBridge.toIO)
+      )
+      (loader, compilers)
+    }
 
-        val compilers = ic.compilers(javaTools, scalac)
-        javaOnlyCompilersCache.update(javacRuntimeOptions, SoftReference(compilers))
-        compilers
+    override def teardown(key: CompileCacheKey, value: (URLClassLoader, Compilers)): Unit = {
+      import key._
+      classloaderCache.updateWith(compilersSig){
+        case Some((cl, 1)) =>
+          cl.close()
+          None
+        case Some((cl, n)) if n > 1 => Some((cl, n - 1))
+        // No other cases; n should never be zero or negative
+      }
     }
   }
+
+  private[this] val classloaderCache =
+    collection.mutable.LinkedHashMap.empty[Long, (URLClassLoader, Int)]
+
+  def getCachedClassLoader(compilersSig: Long, combinedCompilerJars: Array[java.io.File]): URLClassLoader = {
+    classloaderCache.synchronized {
+      classloaderCache.get(compilersSig) match {
+        case Some((cl, i)) =>
+          classloaderCache(compilersSig) = (cl, i + 1)
+          cl
+        case _ =>
+          // the Scala compiler must load the `xsbti.*` classes from the same loader as `ZincWorkerImpl`
+          val cl = mill.api.ClassLoader.create(
+            combinedCompilerJars.map(_.toURI.toURL).toSeq,
+            parent = null,
+            sharedLoader = getClass.getClassLoader,
+            sharedPrefixes = Seq("xsbti")
+          )(new Ctx.Home {override def home: Path = os.home})
+          classloaderCache.update(compilersSig, (cl, 1))
+          cl
+      }
+    }
+  }
+
+
+  object javaOnlyCompilerCache extends CacheFactory[Seq[String], Compilers]{
+
+    override def setup(key: Seq[String]): Compilers = {
+      // Only options relevant for the compiler runtime influence the cached instance
+      // Keep the classpath as written by the user
+      val classpathOptions = ClasspathOptions.of(
+        /*bootLibrary*/ false,
+        /*compiler*/ false,
+        /*extra*/ false,
+        /*autoBoot*/ false,
+        /*filterLibrary*/ false
+      )
+
+      val dummyFile = new java.io.File("")
+      // Zinc does not have an entry point for Java-only compilation, so we need
+      // to make up a dummy ScalaCompiler instance.
+      val scalac = ZincUtil.scalaCompiler(
+        new ScalaInstance(
+          version = "",
+          loader = null,
+          loaderCompilerOnly = null,
+          loaderLibraryOnly = null,
+          libraryJars = Array(dummyFile),
+          compilerJars = Array(dummyFile),
+          allJars = new Array(0),
+          explicitActual = Some("")
+        ),
+        dummyFile,
+        classpathOptions // this is used for javac too
+      )
+
+      val javaTools = getLocalOrCreateJavaTools(key)
+
+      val compilers = ic.compilers(javaTools, scalac)
+      compilers
+
+
+    }
+
+    override def teardown(key: Seq[String], value: Compilers): Unit = ???
+
+    override def maxCacheSize: Int = ???
+  }
+
+
+
+  private def zincLogLevel = if (zincLogDebug) sbt.util.Level.Debug else sbt.util.Level.Info
+  private[this] val ic = new sbt.internal.inc.IncrementalCompilerImpl()
+
+  private def filterJavacRuntimeOptions(opt: String): Boolean = opt.startsWith("-J")
 
   private def getLocalOrCreateJavaTools(javacRuntimeOptions: Seq[String]): JavaTools = {
     val javaHome = this.javaHome.map(_.path.toNIO)
@@ -317,18 +384,20 @@ class ZincWorkerImpl(
       reportCachedProblems: Boolean,
       incrementalCompilation: Boolean
   )(implicit ctx: ZincWorkerApi.Ctx): Result[CompilationResult] = {
-    compileInternal(
-      upstreamCompileOutput = upstreamCompileOutput,
-      sources = sources,
-      compileClasspath = compileClasspath,
-      javacOptions = javacOptions,
-      scalacOptions = Nil,
-      compilers = javaOnlyCompilers(javacOptions),
-      reporter = reporter,
-      reportCachedProblems = reportCachedProblems,
-      incrementalCompilation = incrementalCompilation,
-      auxiliaryClassFileExtensions = Seq.empty[String]
-    )
+    javaOnlyCompilerCache.withValue(javacOptions.filter(filterJavacRuntimeOptions)){ compilers =>
+      compileInternal(
+        upstreamCompileOutput = upstreamCompileOutput,
+        sources = sources,
+        compileClasspath = compileClasspath,
+        javacOptions = javacOptions,
+        scalacOptions = Nil,
+        compilers = compilers,
+        reporter = reporter,
+        reportCachedProblems = reportCachedProblems,
+        incrementalCompilation = incrementalCompilation,
+        auxiliaryClassFileExtensions = Seq.empty[String]
+      )
+    }
   }
 
   override def compileMixed(
@@ -368,74 +437,27 @@ class ZincWorkerImpl(
     }
   }
 
-  // for now this just grows unbounded; YOLO
-  // But at least we do not prevent unloading/garbage collecting of classloaders
-  private[this] val classloaderCache =
-    collection.mutable.LinkedHashMap.empty[Long, SoftReference[ClassLoader]]
-
-  def getCachedClassLoader(compilersSig: Long, combinedCompilerJars: Array[java.io.File])(implicit
-      ctx: ZincWorkerApi.Ctx
-  ): ClassLoader = {
-    classloaderCache.synchronized {
-      classloaderCache.get(compilersSig) match {
-        case Some(SoftReference(cl)) => cl
-        case _ =>
-          // the Scala compiler must load the `xsbti.*` classes from the same loader as `ZincWorkerImpl`
-          val sharedPrefixes = Seq("xsbti")
-          val cl = mill.api.ClassLoader.create(
-            combinedCompilerJars.map(_.toURI.toURL).toSeq,
-            parent = null,
-            sharedLoader = getClass.getClassLoader,
-            sharedPrefixes
-          )
-          classloaderCache.update(compilersSig, SoftReference(cl))
-          cl
-      }
-    }
-  }
-
   private def withCompilers[T](
       scalaVersion: String,
       scalaOrganization: String,
       compilerClasspath: Agg[PathRef],
       scalacPluginClasspath: Agg[PathRef],
       javacOptions: Seq[String]
-  )(f: Compilers => T)(implicit ctx: ZincWorkerApi.Ctx) = {
-    val combinedCompilerClasspath = compilerClasspath ++ scalacPluginClasspath
+  )(f: Compilers => T) = {
+
     val javacRuntimeOptions = javacOptions.filter(filterJavacRuntimeOptions)
-    val compilersSig =
-      combinedCompilerClasspath.hashCode() + scalaVersion.hashCode() +
-        scalaOrganization.hashCode() + javacRuntimeOptions.hashCode()
-    val combinedCompilerJars = combinedCompilerClasspath.iterator.map(_.path.toIO).toArray
 
-    val compiledCompilerBridge = compileBridgeIfNeeded(
-      scalaVersion,
-      scalaOrganization,
-      compilerClasspath
-    )
-
-    compilerCache.withCachedValue(compilersSig) {
-      val loader = getCachedClassLoader(compilersSig, combinedCompilerJars)
-      val scalaInstance = new ScalaInstance(
-        version = scalaVersion,
-        loader = loader,
-        loaderCompilerOnly = loader,
-        loaderLibraryOnly = ClasspathUtil.rootLoader,
-        libraryJars = Array(libraryJarNameGrep(
-          compilerClasspath,
-          // we don't support too outdated dotty versions
-          // and because there will be no scala 2.14, so hardcode "2.13." here is acceptable
-          if (ZincWorkerUtil.isDottyOrScala3(scalaVersion)) "2.13." else scalaVersion
-        ).path.toIO),
-        compilerJars = combinedCompilerJars,
-        allJars = combinedCompilerJars,
-        explicitActual = None
+    scalaCompilerCache.withValue(
+      CompileCacheKey(
+        scalaVersion,
+        compilerClasspath.toSeq,
+        scalacPluginClasspath.toSeq,
+        scalaOrganization,
+        javacRuntimeOptions
       )
-      ic.compilers(
-        javaTools = getLocalOrCreateJavaTools(javacRuntimeOptions),
-        scalac = ZincUtil.scalaCompiler(scalaInstance, compiledCompilerBridge.toIO)
-      )
-    }(f)
+    ) { case (loader, compilers) =>
+      f(compilers)
+    }
   }
 
   private def fileAnalysisStore(path: os.Path): AnalysisStore =
@@ -619,20 +641,12 @@ class ZincWorkerImpl(
   }
 
   override def close(): Unit = {
-    val closeableClassloaders = classloaderCache
-      .flatMap(_._2.get)
+    val urlClassLoaders = classloaderCache
+      .map(_._2._1)
       .collect { case v: AutoCloseable => v }
 
-    val urlClassLoaders =
-      classloaderCache.flatMap(_._2.get).collect { case t: java.net.URLClassLoader => t }
-
-    // Make sure we at least pick up all the URLClassLoaders, since we know those are
-    // AutoCloseable, although there may be other AutoCloseable classloaders as well
-    assert(urlClassLoaders.toSet[AutoCloseable].subsetOf(closeableClassloaders.toSet))
-
-    closeableClassloaders.foreach(_.close())
+    urlClassLoaders.foreach(_.close())
 
     classloaderCache.clear()
-    javaOnlyCompilersCache.clear()
   }
 }

--- a/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
+++ b/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
@@ -1,7 +1,7 @@
 package mill.scalalib.worker
 
 import mill.api.Loose.Agg
-import mill.api.{CacheFactory, CompileProblemReporter, Ctx, PathRef, Result, internal}
+import mill.api.{CachedFactory, CompileProblemReporter, Ctx, PathRef, Result, internal}
 import mill.scalalib.api.{CompilationResult, Versions, ZincWorkerApi, ZincWorkerUtil}
 import os.Path
 import sbt.internal.inc.{
@@ -67,7 +67,7 @@ class ZincWorkerImpl(
       combinedCompilerClasspath.hashCode() + scalaVersion.hashCode() +
         scalaOrganization.hashCode() + javacRuntimeOptions.hashCode()
   }
-  object scalaCompilerCache extends CacheFactory[CompileCacheKey, (URLClassLoader, Compilers)] {
+  object scalaCompilerCache extends CachedFactory[CompileCacheKey, (URLClassLoader, Compilers)] {
 
     override def maxCacheSize = jobs
 
@@ -142,7 +142,7 @@ class ZincWorkerImpl(
     }
   }
 
-  object javaOnlyCompilerCache extends CacheFactory[Seq[String], Compilers] {
+  object javaOnlyCompilerCache extends CachedFactory[Seq[String], Compilers] {
 
     override def setup(key: Seq[String]): Compilers = {
       // Only options relevant for the compiler runtime influence the cached instance

--- a/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
+++ b/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
@@ -155,7 +155,7 @@ trait ScalaNativeModule extends ScalaModule { outer =>
       bridgeFullClassPathValue: Agg[PathRef]
   ) {
     def apply[T](block: ScalaNativeWorkerApi => T): T = {
-      scalaNativeWorkerValue.scalaNativeInstanceCache.withValue(bridgeFullClassPathValue) {
+      scalaNativeWorkerValue.withValue(bridgeFullClassPathValue) {
         case (cl, bridge) => block(bridge)
       }
     }

--- a/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
+++ b/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
@@ -140,7 +140,7 @@ trait ScalaNativeModule extends ScalaModule { outer =>
 
   class ScalaNativeBridge(scalaNativeWorkerValue: ScalaNativeWorker,
                           bridgeFullClassPathValue: Agg[PathRef]) {
-    def apply[T](block: ScalaNativeWorkerApi => T) = {
+    def apply[T](block: ScalaNativeWorkerApi => T): T = {
       scalaNativeWorkerValue.scalaNativeInstanceCache.withValue(bridgeFullClassPathValue){
         case (cl, bridge) => block(bridge)
       }

--- a/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
+++ b/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
@@ -9,22 +9,14 @@ import mill.util.Jvm
 import mill.util.Util.millProjectModule
 import mill.scalalib.api.ZincWorkerUtil
 import mill.scalalib.bsp.{ScalaBuildTarget, ScalaPlatform}
-import mill.scalalib.{
-  BoundDep,
-  CrossVersion,
-  Dep,
-  DepSyntax,
-  Lib,
-  SbtModule,
-  ScalaModule,
-  TestModule
-}
+import mill.scalalib.{BoundDep, CrossVersion, Dep, DepSyntax, Lib, SbtModule, ScalaModule, TestModule}
 import mill.testrunner.{TestResult, TestRunner, TestRunnerUtils}
-import mill.scalanativelib.api._
-import mill.scalanativelib.worker.{ScalaNativeWorkerExternalModule, api => workerApi}
+import mill.scalanativelib.api.*
+import mill.scalanativelib.worker.{ScalaNativeWorker, ScalaNativeWorkerExternalModule, api as workerApi}
 import mill.T
 import mill.api.PathRef
 import mill.main.client.EnvVars
+import mill.scalanativelib.worker.api.ScalaNativeWorkerApi
 
 trait ScalaNativeModule extends ScalaModule { outer =>
   def scalaNativeVersion: T[String]
@@ -108,10 +100,6 @@ trait ScalaNativeModule extends ScalaModule { outer =>
     ).map(t => (scalaNativeWorkerClasspath() ++ t))
   }
 
-  private[scalanativelib] def scalaNativeBridge = Task.Anon {
-    ScalaNativeWorkerExternalModule.scalaNativeWorker().bridge(bridgeFullClassPath())
-  }
-
   override def scalacPluginIvyDeps: T[Agg[Dep]] = Task {
     super.scalacPluginIvyDeps() ++ Agg(
       ivy"org.scala-native:::nscplugin:${scalaNativeVersion()}"
@@ -149,18 +137,26 @@ trait ScalaNativeModule extends ScalaModule { outer =>
 
   def nativeWorkdir = Task { T.dest }
 
+
+  class ScalaNativeBridge(scalaNativeWorkerValue: ScalaNativeWorker,
+                          bridgeFullClassPathValue: Agg[PathRef]) {
+    def apply[T](block: ScalaNativeWorkerApi => T) = {
+      scalaNativeWorkerValue.scalaNativeInstanceCache.withValue(bridgeFullClassPathValue){
+        case (cl, bridge) => block(bridge)
+      }
+    }
+  }
+  private[scalanativelib] def withScalaNativeBridge[T] = Task.Anon{
+    new ScalaNativeBridge(ScalaNativeWorkerExternalModule.scalaNativeWorker(), bridgeFullClassPath())
+  }
   // Location of the clang compiler
   def nativeClang = Task {
-    os.Path(
-      scalaNativeBridge().discoverClang()
-    )
+    os.Path(withScalaNativeBridge().apply(_.discoverClang()))
   }
 
   // Location of the clang++ compiler
   def nativeClangPP = Task {
-    os.Path(
-      scalaNativeBridge().discoverClangPP()
-    )
+    os.Path(withScalaNativeBridge().apply(_.discoverClangPP()))
   }
 
   // GC choice, either "none", "boehm", "immix" or "commix"
@@ -169,21 +165,19 @@ trait ScalaNativeModule extends ScalaModule { outer =>
   }
 
   def nativeGC = Task {
-    nativeGCInput().getOrElse(
-      scalaNativeBridge().defaultGarbageCollector()
-    )
+    nativeGCInput().getOrElse(withScalaNativeBridge().apply(_.defaultGarbageCollector()))
   }
 
   def nativeTarget: T[Option[String]] = Task { None }
 
   // Options that are passed to clang during compilation
   def nativeCompileOptions = Task {
-    scalaNativeBridge().discoverCompileOptions()
+    withScalaNativeBridge().apply(_.discoverCompileOptions())
   }
 
   // Options that are passed to clang during linking
   def nativeLinkingOptions = Task {
-    scalaNativeBridge().discoverLinkingOptions()
+    withScalaNativeBridge().apply(_.discoverLinkingOptions())
   }
 
   // Whether to link `@stub` methods, or ignore them
@@ -229,8 +223,7 @@ trait ScalaNativeModule extends ScalaModule { outer =>
 
   private def nativeConfig: Task[NativeConfig] = Task.Anon {
     val classpath = runClasspath().map(_.path).filter(_.toIO.exists).toList
-
-    scalaNativeBridge().config(
+    withScalaNativeBridge().apply(_.config(
       finalMainClassOpt(),
       classpath.map(_.toIO),
       nativeWorkdir().toIO,
@@ -250,7 +243,7 @@ trait ScalaNativeModule extends ScalaModule { outer =>
       nativeMultithreading(),
       toWorkerApi(logLevel()),
       toWorkerApi(nativeBuildTarget())
-    ) match {
+    )) match {
       case Right(config) => Result.Success(NativeConfig(config))
       case Left(error) => Result.Failure(error)
     }
@@ -274,10 +267,10 @@ trait ScalaNativeModule extends ScalaModule { outer =>
 
   // Generates native binary
   def nativeLink = Task {
-    os.Path(scalaNativeBridge().nativeLink(
+    os.Path(withScalaNativeBridge().apply(_.nativeLink(
       nativeConfig().config,
       T.dest.toIO
-    ))
+    )))
   }
 
   // Runs the native binary
@@ -360,7 +353,7 @@ trait TestScalaNativeModule extends ScalaNativeModule with TestModule {
       globSelectors: Task[Seq[String]]
   ): Task[(String, Seq[TestResult])] = Task.Anon {
 
-    val (close, framework) = scalaNativeBridge().getFramework(
+    val (close, framework) = withScalaNativeBridge().apply(_.getFramework(
       nativeLink().toIO,
       forkEnv() ++
         Map(
@@ -369,6 +362,7 @@ trait TestScalaNativeModule extends ScalaNativeModule with TestModule {
         ),
       toWorkerApi(logLevel()),
       testFramework()
+    )
     )
 
     val (doneMsg, results) = TestRunner.runTestFramework(

--- a/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
+++ b/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
@@ -9,10 +9,23 @@ import mill.util.Jvm
 import mill.util.Util.millProjectModule
 import mill.scalalib.api.ZincWorkerUtil
 import mill.scalalib.bsp.{ScalaBuildTarget, ScalaPlatform}
-import mill.scalalib.{BoundDep, CrossVersion, Dep, DepSyntax, Lib, SbtModule, ScalaModule, TestModule}
+import mill.scalalib.{
+  BoundDep,
+  CrossVersion,
+  Dep,
+  DepSyntax,
+  Lib,
+  SbtModule,
+  ScalaModule,
+  TestModule
+}
 import mill.testrunner.{TestResult, TestRunner, TestRunnerUtils}
-import mill.scalanativelib.api.*
-import mill.scalanativelib.worker.{ScalaNativeWorker, ScalaNativeWorkerExternalModule, api as workerApi}
+import mill.scalanativelib.api._
+import mill.scalanativelib.worker.{
+  ScalaNativeWorker,
+  ScalaNativeWorkerExternalModule,
+  api => workerApi
+}
 import mill.T
 import mill.api.PathRef
 import mill.main.client.EnvVars
@@ -137,17 +150,21 @@ trait ScalaNativeModule extends ScalaModule { outer =>
 
   def nativeWorkdir = Task { T.dest }
 
-
-  class ScalaNativeBridge(scalaNativeWorkerValue: ScalaNativeWorker,
-                          bridgeFullClassPathValue: Agg[PathRef]) {
+  class ScalaNativeBridge(
+      scalaNativeWorkerValue: ScalaNativeWorker,
+      bridgeFullClassPathValue: Agg[PathRef]
+  ) {
     def apply[T](block: ScalaNativeWorkerApi => T): T = {
-      scalaNativeWorkerValue.scalaNativeInstanceCache.withValue(bridgeFullClassPathValue){
+      scalaNativeWorkerValue.scalaNativeInstanceCache.withValue(bridgeFullClassPathValue) {
         case (cl, bridge) => block(bridge)
       }
     }
   }
-  private[scalanativelib] def withScalaNativeBridge[T] = Task.Anon{
-    new ScalaNativeBridge(ScalaNativeWorkerExternalModule.scalaNativeWorker(), bridgeFullClassPath())
+  private[scalanativelib] def withScalaNativeBridge[T] = Task.Anon {
+    new ScalaNativeBridge(
+      ScalaNativeWorkerExternalModule.scalaNativeWorker(),
+      bridgeFullClassPath()
+    )
   }
   // Location of the clang compiler
   def nativeClang = Task {
@@ -362,8 +379,7 @@ trait TestScalaNativeModule extends ScalaNativeModule with TestModule {
         ),
       toWorkerApi(logLevel()),
       testFramework()
-    )
-    )
+    ))
 
     val (doneMsg, results) = TestRunner.runTestFramework(
       _ => framework,

--- a/scalanativelib/src/mill/scalanativelib/worker/ScalaNativeWorker.scala
+++ b/scalanativelib/src/mill/scalanativelib/worker/ScalaNativeWorker.scala
@@ -1,6 +1,6 @@
 package mill.scalanativelib.worker
 
-import mill.api.{CacheFactory, Ctx}
+import mill.api.{CachedFactory, Ctx}
 import mill.define.{Discover, Worker}
 import mill.{Agg, PathRef, Task}
 import mill.scalanativelib.worker.{api => workerApi}
@@ -9,7 +9,7 @@ import java.net.URLClassLoader
 
 private[scalanativelib] class ScalaNativeWorker(jobs: Int) extends AutoCloseable {
   object scalaNativeInstanceCache
-      extends CacheFactory[Agg[mill.PathRef], (URLClassLoader, workerApi.ScalaNativeWorkerApi)] {
+      extends CachedFactory[Agg[mill.PathRef], (URLClassLoader, workerApi.ScalaNativeWorkerApi)] {
     override def setup(key: Agg[PathRef]) = {
       val cl = mill.api.ClassLoader.create(
         key.map(_.path.toIO.toURI.toURL).toVector,

--- a/scalanativelib/src/mill/scalanativelib/worker/ScalaNativeWorker.scala
+++ b/scalanativelib/src/mill/scalanativelib/worker/ScalaNativeWorker.scala
@@ -1,46 +1,41 @@
 package mill.scalanativelib.worker
 
+import mill.api.{CacheFactory, Ctx}
 import mill.define.{Discover, Worker}
 import mill.{Agg, PathRef, Task}
-import mill.scalanativelib.worker.{api => workerApi}
+import mill.scalanativelib.worker.api as workerApi
 
-private[scalanativelib] class ScalaNativeWorker extends AutoCloseable {
-  private var scalaInstanceCache = Option.empty[(Long, workerApi.ScalaNativeWorkerApi)]
+import java.net.URLClassLoader
 
-  def bridge(toolsClasspath: Agg[PathRef])(implicit
-      ctx: mill.api.Ctx.Home
-  ): workerApi.ScalaNativeWorkerApi = {
-    val classloaderSig = toolsClasspath.hashCode
-    scalaInstanceCache match {
-      case Some((sig, bridge)) if sig == classloaderSig => bridge
-      case _ =>
-        val cl = mill.api.ClassLoader.create(
-          toolsClasspath.iterator.map(_.path.toIO.toURI.toURL).toVector,
-          getClass.getClassLoader
-        )
-        try {
-          val bridge = cl
-            .loadClass("mill.scalanativelib.worker.ScalaNativeWorkerImpl")
-            .getDeclaredConstructor()
-            .newInstance()
-            .asInstanceOf[workerApi.ScalaNativeWorkerApi]
-          scalaInstanceCache = Some((classloaderSig, bridge))
-          bridge
-        } catch {
-          case e: Exception =>
-            e.printStackTrace()
-            throw e
-        }
+private[scalanativelib] class ScalaNativeWorker(jobs: Int) extends AutoCloseable {
+  object scalaNativeInstanceCache extends CacheFactory[Agg[mill.PathRef], (URLClassLoader, workerApi.ScalaNativeWorkerApi)]{
+    override def setup(key: Agg[PathRef]) = {
+      val cl = mill.api.ClassLoader.create(
+        key.map(_.path.toIO.toURI.toURL).toVector,
+        getClass.getClassLoader
+      )(new Ctx.Home {override def home = os.home})
+      val bridge = cl
+        .loadClass("mill.scalanativelib.worker.ScalaNativeWorkerImpl")
+        .getDeclaredConstructor()
+        .newInstance()
+        .asInstanceOf[workerApi.ScalaNativeWorkerApi]
+      (cl, bridge)
     }
+
+    override def teardown(key: Agg[PathRef], value: (URLClassLoader, workerApi.ScalaNativeWorkerApi)): Unit = {
+      value._1.close()
+    }
+
+    override def maxCacheSize: Int = jobs
   }
+
 
   override def close(): Unit = {
     // drop instance
-    scalaInstanceCache = None
   }
 }
 
 private[scalanativelib] object ScalaNativeWorkerExternalModule extends mill.define.ExternalModule {
-  def scalaNativeWorker: Worker[ScalaNativeWorker] = Task.Worker { new ScalaNativeWorker() }
+  def scalaNativeWorker: Worker[ScalaNativeWorker] = Task.Worker { new ScalaNativeWorker(Task.ctx.asInstanceOf[mill.api.Ctx.Jobs].jobs) }
   lazy val millDiscover: Discover = Discover[this.type]
 }

--- a/scalanativelib/src/mill/scalanativelib/worker/ScalaNativeWorker.scala
+++ b/scalanativelib/src/mill/scalanativelib/worker/ScalaNativeWorker.scala
@@ -3,17 +3,18 @@ package mill.scalanativelib.worker
 import mill.api.{CacheFactory, Ctx}
 import mill.define.{Discover, Worker}
 import mill.{Agg, PathRef, Task}
-import mill.scalanativelib.worker.api as workerApi
+import mill.scalanativelib.worker.{api => workerApi}
 
 import java.net.URLClassLoader
 
 private[scalanativelib] class ScalaNativeWorker(jobs: Int) extends AutoCloseable {
-  object scalaNativeInstanceCache extends CacheFactory[Agg[mill.PathRef], (URLClassLoader, workerApi.ScalaNativeWorkerApi)]{
+  object scalaNativeInstanceCache
+      extends CacheFactory[Agg[mill.PathRef], (URLClassLoader, workerApi.ScalaNativeWorkerApi)] {
     override def setup(key: Agg[PathRef]) = {
       val cl = mill.api.ClassLoader.create(
         key.map(_.path.toIO.toURI.toURL).toVector,
         getClass.getClassLoader
-      )(new Ctx.Home {override def home = os.home})
+      )(new Ctx.Home { override def home = os.home })
       val bridge = cl
         .loadClass("mill.scalanativelib.worker.ScalaNativeWorkerImpl")
         .getDeclaredConstructor()
@@ -22,13 +23,15 @@ private[scalanativelib] class ScalaNativeWorker(jobs: Int) extends AutoCloseable
       (cl, bridge)
     }
 
-    override def teardown(key: Agg[PathRef], value: (URLClassLoader, workerApi.ScalaNativeWorkerApi)): Unit = {
+    override def teardown(
+        key: Agg[PathRef],
+        value: (URLClassLoader, workerApi.ScalaNativeWorkerApi)
+    ): Unit = {
       value._1.close()
     }
 
     override def maxCacheSize: Int = jobs
   }
-
 
   override def close(): Unit = {
     // drop instance
@@ -36,6 +39,7 @@ private[scalanativelib] class ScalaNativeWorker(jobs: Int) extends AutoCloseable
 }
 
 private[scalanativelib] object ScalaNativeWorkerExternalModule extends mill.define.ExternalModule {
-  def scalaNativeWorker: Worker[ScalaNativeWorker] = Task.Worker { new ScalaNativeWorker(Task.ctx.asInstanceOf[mill.api.Ctx.Jobs].jobs) }
+  def scalaNativeWorker: Worker[ScalaNativeWorker] =
+    Task.Worker { new ScalaNativeWorker(Task.ctx.asInstanceOf[mill.api.Ctx.Jobs].jobs) }
   lazy val millDiscover: Discover = Discover[this.type]
 }


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/3730

The old `FixSizedCache`/`KeyedLockedCache`/`RandomBoundedCache` were all a bit of a mess, and none of them provided one crucial component to long-lived cache entries: the ability to tear them down after you are done with them. This is necessary for a lot of long-lived components you may want to cache: classloaders, subprocesses, open file handles, etc. all need to be torn down after use. Also, their implementation was weird, probably overly convoluted, and not used consistently throughout Mill

This PR introduces a new `CachedFactory` class meant to replace the old ones. I use it in four places (ZincWorker Scala and Java compilers, ScalaJsWorker, ScalanativeWorker), and added docs so users can discover and use it too. It provides a hook for `def teardown`, which should hopefully fix some of the classloader leaks I've seen in our prior implementations (these normally manifest as CODE CACHE FULL, DISABLING JIT COMPILER warnings when doing large builds). The last previously-problematic worker defsite `VisualizeModule.worker` cannot be changed without breaking bincompat so I left it in place for now

`CachedFactory` also differs from the original implementation is that the cache contains the logic for `def setup`, rather than relying on the callsite of `.withCachedValue` to provide the setup and key together. This should be easier to understand and less likely to be mis-used, as the mapping from `key => value` is kept in one place, whereas previously every `withCachedValue` could have a different mapping.

Hopefully this new `CachedFactory` helper class can form the basis of how people define concurrency-friendly stateful workers going forward

Covered by some unit tests and example tests, as well as usage in the main `ZincWorker`/`ScalaJSWorker`/`ScalaNativeWorker` code paths