### PR TITLE
Allow users to override more UnidocModule parameters

### DIFF
--- a/scalalib/src/mill/scalalib/UnidocModule.scala
+++ b/scalalib/src/mill/scalalib/UnidocModule.scala
@@ -11,14 +11,19 @@ trait UnidocModule extends ScalaModule {
 
   def unidocVersion: T[Option[String]] = None
 
+  def unidocCompileClasspath = Task {
+    Seq(compile().classes) ++ T.traverse(moduleDeps)(_.compileClasspath)().flatten
+  }
+
+  def unidocSourceFiles = Task {
+    allSourceFiles() ++ T.traverse(moduleDeps)(_.allSourceFiles)().flatten
+  }
+
   def unidocCommon(local: Boolean) = Task.Anon {
-    def unidocCompileClasspath =
-      Seq(compile().classes) ++ T.traverse(moduleDeps)(_.compileClasspath)().flatten
 
-    val unidocSourceFiles =
-      allSourceFiles() ++ T.traverse(moduleDeps)(_.allSourceFiles)().flatten
+    val unidocSourceFiles0 = unidocSourceFiles()
 
-    T.log.info(s"Staging scaladoc for ${unidocSourceFiles.length} files")
+    T.log.info(s"Staging scaladoc for ${unidocSourceFiles0.length} files")
 
     // the details of the options and zincWorker call are significantly
     // different between scala-2 scaladoc and scala-3 scaladoc
@@ -29,7 +34,7 @@ trait UnidocModule extends ScalaModule {
       "-d",
       T.dest.toString,
       "-classpath",
-      unidocCompileClasspath.map(_.path).mkString(sys.props("path.separator"))
+      unidocCompileClasspath().map(_.path).mkString(sys.props("path.separator"))
     ) ++
       unidocVersion().toSeq.flatMap(Seq("-doc-version", _)) ++
       unidocSourceUrl().toSeq.flatMap { url =>
@@ -50,7 +55,7 @@ trait UnidocModule extends ScalaModule {
       scalaOrganization(),
       scalaDocClasspath(),
       scalacPluginClasspath(),
-      options ++ unidocSourceFiles.map(_.path.toString)
+      options ++ unidocSourceFiles0.map(_.path.toString)
     ) match {
       case true => mill.api.Result.Success(PathRef(T.dest))
       case false => mill.api.Result.Failure("unidoc generation failed")


### PR DESCRIPTION
Needed for https://github.com/com-lihaoyi/mill/pull/3950. It's running into a [scaladoc bug](https://github.com/scala/bug/issues/10028), and would need to exclude an internal dependency of coursier from the class path passed to scaladoc.

Once merged, Mill would need to be rebootstrapped on the latest nightly version, and https://github.com/com-lihaoyi/mill/pull/3950 would override `UnidocModule#unidocCompileClasspath` to exclude the JAR of coursier/dependency from it.