### PR TITLE
Fix Detekt tests

### DIFF
--- a/kotlinlib/src/mill/kotlinlib/detekt/DetektModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/detekt/DetektModule.scala
@@ -21,7 +21,7 @@ trait DetektModule extends KotlinModule {
 
   private def detekt0() = T.task {
 
-    val args = detektOptions() ++ Seq("-i", PathRef(T.workspace).path.toString()) ++
+    val args = detektOptions() ++ Seq("-i", T.workspace.toString()) ++
       Seq("-c", detektConfig().path.toString())
 
     T.log.info("running detekt ...")


### PR DESCRIPTION
Somehow the `PathRef(T.workspace).path` is causing issues, but it's totally redundant since we can just use `T.workspace`. Walking the `out/` folder filesystem and hashing stuff seems to be causing problems with the file locks we use to ensure mutual exclusion


Seems to make `example.kotlinlib.linting[1-detekt].local.test` pass reliably where previously it was very flaky