### PR TITLE
pythonlib: publish modules

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -33,6 +33,7 @@
 ** xref:android/kotlin.adoc[]
 ** xref:pythonlib/intro.adoc[]
 *** xref:pythonlib/dependencies.adoc[]
+*** xref:pythonlib/publishing.adoc[]
 * xref:comparisons/why-mill.adoc[]
 ** xref:comparisons/maven.adoc[]
 ** xref:comparisons/gradle.adoc[]

--- a/docs/modules/ROOT/pages/pythonlib/publishing.adoc
+++ b/docs/modules/ROOT/pages/pythonlib/publishing.adoc
@@ -1,0 +1,12 @@
+= Python Packaging & Publishing
+:page-aliases: Publishing_Python_Projects.adoc
+
+include::partial$gtag-config.adoc[]
+
+This page will discuss common topics around publishing your Python projects for others to use.
+
+include::partial$example/pythonlib/publishing/1-publish-module.adoc[]
+
+== Advanced Packaging
+
+include::partial$example/pythonlib/publishing/2-publish-module-advanced.adoc[]

--- a/example/package.mill
+++ b/example/package.mill
@@ -67,6 +67,7 @@ object `package` extends RootModule with Module {
   object pythonlib extends Module {
     object basic extends Cross[ExampleCrossModule](build.listIn(millSourcePath / "basic"))
     object dependencies extends Cross[ExampleCrossModule](build.listIn(millSourcePath / "dependencies"))
+    object publishing extends Cross[ExampleCrossModule](build.listIn(millSourcePath / "publishing"))
   }
 
   object cli extends Module{

--- a/example/pythonlib/publishing/1-publish-module/README.md
+++ b/example/pythonlib/publishing/1-publish-module/README.md
@@ -1,0 +1,10 @@
+This is an example package.
+
+```
+pip install testpkg-mill
+```
+
+```
+>>> import testpkg.greet
+testpkg.greet.hello("world")
+```

--- a/example/pythonlib/publishing/1-publish-module/build.mill
+++ b/example/pythonlib/publishing/1-publish-module/build.mill
@@ -1,0 +1,90 @@
+// All packaging and publishing functionality is defined in `PublishModule`.
+// Start by extending it.
+
+import mill._, pythonlib._
+
+object `package` extends RootModule with PythonModule with PublishModule {
+
+  // information about dependencies will be included in the published package
+  def pythonDeps = Seq("jinja2==3.1.4")
+
+  def publishMeta = PublishMeta(
+    name = "testpkg-mill",
+    description = "an example package",
+    requiresPython = ">= 3.12",
+    license = License.MIT,
+    authors = Seq(Developer("John Doe", "jdoe@example.org"))
+  )
+
+  // the version under which the package will be published
+  def publishVersion = "0.0.2"
+
+}
+
+// You'll need to define some metadata in the `publishMeta` and `publishVersion`
+// tasks. This metadata is roughly equivalent to what you'd define in a
+// https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#basic-information[`pyproject.toml` file].
+//
+// You'll also need to create a `readme` file, which will be bundled in the
+// final package and serves as the landing page seen on PyPI. By default, Mill
+// assumes a file starting with the string `readme` (in any capitalization), but
+// you can override it to whatever you please.
+
+// [NOTE]
+// ====
+// The version of your package is not included in `publishMeta`, but
+// rather in its own `publishVersion` task. This is done so that you can easily
+// override the task to automate the version, such as deriving it from source
+// control.
+// ====
+
+// == Building packages locally ==
+//
+// You can build a source distribution or wheel by running the following tasks:
+
+/** Usage
+> mill show sdist
+".../out/sdist.dest/dist/testpkg_mill-0.0.2.tar.gz"
+
+> mill show wheel
+".../out/wheel.dest/dist/testpkg_mill-0.0.2-py3-none-any.whl"
+*/
+
+// These files can then be `pip-installed` by other projects, or, if you're using Mill, you can
+// include them in your xref:pythonlib/dependencies.adoc#_unmanaged_wheels[unmanagedWheels] task.
+// Usually however, you'd want to publish them to a package index such as PyPI or your
+// organization's internal package repository.
+
+// == Uploading your packages to PyPI (or other repository)
+//
+// Uploading your packages to PyPI can be done by running `mill __.publish`.
+//
+// Mill uses https://twine.readthedocs.io/en/stable/[`twine`] to upload packages, and respects its
+// configuration. You can also configure it with environment variables, prefixed with `MILL_`.
+//
+// [source,bash]
+// ----
+// export MILL_TWINE_REPOSITORY_URL=https://test.pypi.org/legacy/
+// export MILL_TWINE_USERNAME=<username, not necessary for PyPI>
+// export MILL_TWINE_PASSWORD=<apitoken>
+// mill __.publish
+// ----
+//
+// [NOTE]
+// ====
+// Mill does not transitively upload all your packages, hence we
+// recommended to use `mill __.publish`, instead of `mill <module>.publish`.
+// While it's technically possible to upload packages of individual Mill modules
+// by calling their `publish` tasks separately, you'd usually want to ensure all
+// your dependencies are also published.
+// ====
+//
+// === Check before uploading
+//
+// Twine has a nice feature to check your artifacts before uploading them. You
+// can also do this with Mill, by running:
+
+/** Usage
+> mill __.checkPublish
+... PASSED
+*/

--- a/example/pythonlib/publishing/1-publish-module/src/testpkg/greet.py
+++ b/example/pythonlib/publishing/1-publish-module/src/testpkg/greet.py
@@ -1,0 +1,6 @@
+import jinja2
+
+def hello(name: str):
+    environment = jinja2.Environment()
+    template = environment.from_string("Hello, {{ name }}!")
+    return template.render(name=name)

--- a/example/pythonlib/publishing/2-publish-module-advanced/README.md
+++ b/example/pythonlib/publishing/2-publish-module-advanced/README.md
@@ -1,0 +1,1 @@
+This is an example package.

--- a/example/pythonlib/publishing/2-publish-module-advanced/build.mill
+++ b/example/pythonlib/publishing/2-publish-module-advanced/build.mill
@@ -1,0 +1,73 @@
+// Behind the scenes, Mill delegates most Python packaging tasks to other tools,
+// and only takes care of configuring them with information it has on your build.
+//
+// By default, it will:
+//
+// * create a synthetic `pyproject.toml` file from its own metadata
+//
+// * use `setuptools` to package the module
+//
+// * first create a source distribution and then use that to build a wheel (instead of building a wheel directly)
+//
+// While this should be sufficient for most projects, sometimes you need a little
+// customization.
+//
+// === Customizing the `pyproject.toml` and other build files
+//
+// If you're happy to use a PEP-518-compliant `pyproject.toml` to describe how to
+// package your published project, but would like some customization, you can amend
+// or override the `pyproject` task with your own metadata.
+//
+// You can also include additional files in the packaging process by adding them to
+// `buildFiles`. You can then reference these in your `pyproject.toml` file.
+//
+// The following example shows how to override the packaging process by providing a
+// custom `setup.py` file.
+
+import mill._, pythonlib._
+
+object `package` extends RootModule with PythonModule with PublishModule {
+
+  def publishMeta = PublishMeta(
+    name = "testpackage",
+    description = "an example package",
+    requiresPython = ">= 3.12",
+    license = License.MIT,
+    authors = Seq(Developer("John Doe", "jdoe@example.org"))
+  )
+
+  def publishVersion = "0.0.3"
+
+  // you could also reference an existing setup.py file directly, e.g.
+  // `def setup = Task.Source { millSourcePath / "setup.py" }`
+  def setup = Task {
+    val str =
+      s"""#from setuptools import setup
+          #
+          #print("hello from custom setup.py!")
+          #
+          ## empty setup, defers to using values in pyproject.toml
+          #setup()
+          #""".stripMargin('#')
+    os.write(Task.dest / "setup.py", str)
+    PathRef(Task.dest / "setup.py")
+  }
+
+  override def buildFiles = Task {
+    super.buildFiles() ++ Map("setup.py" -> setup())
+  }
+
+}
+
+/** Usage
+> mill sdist
+...
+hello from custom setup.py!
+...
+*/
+
+// === Changing the packaging process entirely
+//
+// In case customizing of `pyproject` is too cumbersome, or you cannot use it for
+// some reason, you can always override the `sdist` and `wheel` tasks with your own
+// packaging implementation. Publishing with `__.publish` will still work as usual.

--- a/example/pythonlib/publishing/2-publish-module-advanced/setup.py
+++ b/example/pythonlib/publishing/2-publish-module-advanced/setup.py
@@ -1,0 +1,6 @@
+from setuptools import setup
+
+print("hello from custom setup.py!")
+
+# empty setup, defers to using values in pyproject.toml
+setup()

--- a/pythonlib/package.mill
+++ b/pythonlib/package.mill
@@ -6,5 +6,7 @@ import mill._
 // TODO change MillPublishScalaModule to MillStableScalaModule after mill version with pythonlib is released,
 //  because currently there is no previous artifact version
 object `package` extends RootModule with build.MillPublishScalaModule {
-  def moduleDeps = Seq(build.main)
+  // we depend on scalalib for re-using some common infrastructure (e.g. License
+  // management of projects), NOT for reusing build logic
+  def moduleDeps = Seq(build.main, build.scalalib)
 }

--- a/pythonlib/src/mill/pythonlib/PublishModule.scala
+++ b/pythonlib/src/mill/pythonlib/PublishModule.scala
@@ -1,0 +1,268 @@
+package mill.pythonlib
+
+import mill.api.Result
+import mill.{PathRef, Task, T, Command}
+
+/**
+ * A python module which also defines how to build and publish source distributions and wheels.
+ */
+trait PublishModule extends PythonModule {
+
+  override def moduleDeps: Seq[PublishModule] = super.moduleDeps.map {
+    case m: PublishModule => m
+    case other =>
+      throw new Exception(
+        s"PublishModule moduleDeps need to be also PublishModules. $other is not a PublishModule"
+      )
+  }
+
+  override def pythonToolDeps = Task {
+    super.pythonToolDeps() ++ Seq("setuptools>=75.6.0", "build>=1.2.2", "twine>=5.1.1")
+  }
+
+  /**
+   * Metadata about your project, required to build and publish.
+   *
+   * This is roughly equivalent to what you'd find in the general section of a `pyproject.toml` file
+   * https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#about-your-project.
+   */
+  def publishMeta: T[PublishModule.PublishMeta]
+
+  /**
+   * The artifact version that this module would be published as.
+   */
+  def publishVersion: T[String]
+
+  /**
+   * The content of the PEP-518-compliant `pyproject.toml` file, which describes how to package this
+   * module into a distribution (sdist and wheel).
+   *
+   * By default, Mill will generate this file for you from the information it knows (e.g.
+   * dependencies declared in [[pythonDeps]] and metadata from [[publishMeta]]). It will use
+   * `setuptools` as the build backend, and `build` as the frontend.
+   *
+   * You can however override this task to read your own `pyproject.toml` file, if you need to. In
+   * this case, please note the following:
+   *
+   * - Mill will create a source distribution first, and then use that to build a binary
+   *   distribution (aka wheel). Going through this intermediary step, rather than building a wheel
+   *   directly, ensures that end users can rebuild wheels on their systems, for example if a
+   *   platform-dependent wheel is not available pre-made.
+   *
+   * - Hence, the source distribution will need to be "self contained". In particular this means
+   *   that you can't reference files by absolute path within it.
+   *
+   * - Mill creates a "staging" directory in the [[sdist]] task, which will be used to bundle
+   *   everything up into an sdist (via the `build` python command, although this is an
+   *   implementation detail). You can include additional files in this directory via the
+   *   [[buildFiles]] task.
+   */
+  def pyproject: T[String] = Task {
+    val moduleNames = Task.traverse(moduleDeps)(_.publishMeta)().map(_.name)
+    val moduleVersions = Task.traverse(moduleDeps)(_.publishVersion)()
+    val moduleRequires = moduleNames.zip(moduleVersions).map { case (n, v) => s"$n>=$v" }
+    val deps = (moduleRequires ++ pythonDeps()).map(s => s"\"$s\"").mkString(", ")
+
+    s"""|[project]
+        |name="${publishMeta().name}"
+        |version="${publishVersion()}"
+        |description="${publishMeta().description}"
+        |readme="${publishReadme().path.last}"
+        |dependencies=[${deps}]
+        |requires-python="${publishMeta().requiresPython}"
+        |license={text="${publishMeta().license.id}"}
+        |keywords=[${publishMeta().keywords.map(s => s"\"$s\"").mkString(",")}]
+        |classifiers=[${publishMeta().classifiers.map(s => s"\"$s\"").mkString(",")}]
+        |authors=[${publishMeta().authors.map(a =>
+         s"{name=\"${a.name}\", email=\"${a.email}\"}"
+       ).mkString(",")}]
+        |
+        |[project.urls]
+        |${publishMeta().urls.map(u => s"\"${u._1}\"=\"${u._2}\"").mkString("\n")}
+        |
+        |[build-system]
+        |requires=["setuptools"]
+        |build-backend="setuptools.build_meta"
+        |""".stripMargin
+  }
+
+  /**
+   * Files to be included in the directory used during the packaging process, apart from
+   * [[pyproject]].
+   *
+   * The format is `<destination path> -> <source path>`. Where `<destination path>` is relative to
+   * some build directory, where you'll also find `src` and `pyproject.toml`.
+   *
+   * @see [[pyproject]]
+   */
+  def buildFiles: T[Map[String, PathRef]] = Task {
+    Map(
+      publishReadme().path.last -> publishReadme()
+    )
+  }
+
+  /**
+   * The readme file to include in the published distribution.
+   */
+  def publishReadme: T[PathRef] = Task.Input {
+    val readme = if (os.exists(millSourcePath)) {
+      os.list(millSourcePath).find(_.last.toLowerCase().startsWith("readme"))
+    } else None
+    readme match {
+      case None =>
+        Result.Failure(
+          s"No readme file found in `${millSourcePath}`. A readme file is required for publishing distributions. " +
+            s"Please create a file named `${millSourcePath}/readme*` (any capitalization), or override the `publishReadme` task."
+        )
+      case Some(path) =>
+        Result.Success(PathRef(path))
+    }
+  }
+
+  /**
+   * Bundle everything up into a source distribution (sdist).
+   *
+   * @see [[pyproject]]
+   */
+  def sdist: T[PathRef] = Task {
+
+    // we use setup tools by default, which can only work with a single source directory, hence we
+    // flatten all source directories into a single hierarchy
+    val flattenedSrc = T.dest / "src"
+    for (dir <- (sources() ++ resources()); if os.exists(dir.path)) {
+      for (path <- os.list(dir.path)) {
+        os.copy.into(path, flattenedSrc, mergeFolders = true, createFolders = true)
+      }
+    }
+
+    // copy over other, non-source files
+    os.write(T.dest / "pyproject.toml", pyproject())
+    for ((dest, src) <- buildFiles()) {
+      os.copy(src.path, T.dest / os.SubPath(dest), createFolders = true, replaceExisting = true)
+    }
+
+    // we already do the isolation with mill
+    runner().run(("-m", "build", "--no-isolation", "--sdist"), workingDir = T.dest)
+    PathRef(os.list(T.dest / "dist").head)
+  }
+
+  /**
+   * Build a binary distribution of this module.
+   *
+   * @see [[pyproject]]
+   */
+  def wheel: T[PathRef] = Task {
+    val buildDir = T.dest / "extracted"
+
+    os.makeDir(buildDir)
+    os.call(
+      ("tar", "xf", sdist().path, "-C", buildDir),
+      cwd = T.dest
+    )
+    runner().run(
+      (
+        // format: off
+        "-m", "build",
+        "--no-isolation", // we already do the isolation with mill
+        "--wheel",
+        "--outdir", T.dest / "dist"
+        // format: on
+      ),
+      workingDir = os.list(buildDir).head // sdist archive contains a directory
+    )
+    PathRef(os.list(T.dest / "dist").head)
+  }
+
+  /** The repository (index) URL to publish packages to. */
+  def publishRepositoryUrl: T[String] = Task { "https://upload.pypi.org/" }
+
+  /** All artifacts that should be published. */
+  def publishArtifacts: T[Seq[PathRef]] = Task {
+    Seq(sdist(), wheel())
+  }
+
+  /** Run `twine check` to catch some common packaging errors. */
+  def checkPublish(): Command[Unit] = Task.Command {
+    runner().run(
+      (
+        // format: off
+        "-m", "twine",
+        "check",
+        publishArtifacts().map(_.path)
+        // format: on
+      )
+    )
+  }
+
+  /**
+   * Publish the [[sdist]] and [[wheel]] to the package repository (index)
+   * defined in this module.
+   *
+   * You can configure this command by setting any environment variables
+   * understood by `twine`, prefixed with `MILL_`. For example, to change the
+   * repository URL:
+   *
+   * ```
+   * MILL_TWINE_REPOSITORY_URL=https://test.pypi.org/legacy/
+   * ```
+   *
+   * @see [[publishRepositoryUrl]]
+   */
+  def publish(): Command[Unit] = Task.Command {
+    val env: Map[String, String] =
+      Map(
+        "TWINE_REPOSITORY_URL" -> publishRepositoryUrl()
+      ) ++
+        Task.env ++
+        Task.env.collect {
+          case (key, value) if key.startsWith("MILL_TWINE_") =>
+            key.drop(5) -> value // MILL_TWINE_* -> TWINE_*
+          case (key, value) => key -> value
+        }
+
+    runner().run(
+      (
+        // format: off
+        "-m", "twine",
+        "upload",
+        "--non-interactive",
+        publishArtifacts().map(_.path)
+        // format: on
+      ),
+      env = env
+    )
+  }
+
+}
+
+object PublishModule {
+
+  /**
+   * Static metadata about a project.
+   *
+   * This is roughly equivalent to what you'd find in the general section of a `pyproject.toml` file
+   * https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#about-your-project.
+   */
+  case class PublishMeta(
+      name: String,
+      description: String,
+      requiresPython: String,
+      license: mill.scalalib.publish.License,
+      authors: Seq[Developer],
+      keywords: Seq[String] = Seq(),
+      classifiers: Seq[String] = Seq(),
+      urls: Map[String, String] = Map()
+  )
+  object PublishMeta {
+    implicit val rw: upickle.default.ReadWriter[PublishMeta] = upickle.default.macroRW
+  }
+
+  case class Developer(
+      name: String,
+      email: String
+  )
+  object Developer {
+    implicit val rw: upickle.default.ReadWriter[Developer] = upickle.default.macroRW
+  }
+
+}

--- a/pythonlib/src/mill/pythonlib/package.scala
+++ b/pythonlib/src/mill/pythonlib/package.scala
@@ -1,0 +1,14 @@
+package mill
+
+package object pythonlib {
+
+  // These types are commonly used in python modules. Export them to make using
+  // them possible without an import.
+  type License = mill.scalalib.publish.License
+  val License = mill.scalalib.publish.License
+  type PublishMeta = PublishModule.PublishMeta
+  val PublishMeta = PublishModule.PublishMeta
+  type Developer = PublishModule.Developer
+  val Developer = PublishModule.Developer
+
+}


### PR DESCRIPTION
Adds the capability to build wheels and sdists, and publish them.

The idea is to roughly follow [Pant's approach to publishing python packages](https://www.pantsbuild.org/stable/docs/python/overview/building-distributions): act a build frontend which calls out to various specialized packaging tools.

Part of #3928 