### PR TITLE
Pass a classpath made for runtime to Kotlin JS linker

### DIFF
--- a/kotlinlib/src/mill/kotlinlib/js/KotlinJsModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/js/KotlinJsModule.scala
@@ -208,9 +208,11 @@ trait KotlinJsModule extends KotlinModule { outer =>
   def linkBinary: T[CompilationResult] = Task {
     kotlinJsCompile(
       outputMode = binaryKindToOutputMode(kotlinJsBinaryKind()),
+      // classpath with classes of this module's code
       irClasspath = Some(compile().classes),
       allKotlinSourceFiles = Seq.empty,
-      librariesClasspath = compileClasspath(),
+      // classpath of libraries to be used to run this module's code
+      librariesClasspath = upstreamAssemblyClasspath(),
       callMain = callMain(),
       moduleKind = moduleKind(),
       produceSourceMaps = kotlinJsSourceMap(),


### PR DESCRIPTION
The current code passes a class path made for compile time to the Kotlin JS linker. While it's not a problem with the current main branch that doesn't really make a difference between compile and runtime class paths, this will be a problem with https://github.com/com-lihaoyi/mill/pull/4028, that can bring less JARs in `compileClasspath` (while all JARs will be around in runtime targets, like `resolvedRunIvyDeps`, like currently)