### PR TITLE
Update coursier-interface to 1.0.25

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -118,7 +118,7 @@ object Deps {
 
   val coursierVersion = "2.1.19"
   val coursier = ivy"io.get-coursier::coursier:$coursierVersion"
-  val coursierInterface = ivy"io.get-coursier:interface:1.0.24"
+  val coursierInterface = ivy"io.get-coursier:interface:1.0.25"
   val coursierJvm = ivy"io.get-coursier::coursier-jvm:$coursierVersion"
 
   val cask = ivy"com.lihaoyi::cask:0.9.4"


### PR DESCRIPTION
Alongside https://github.com/com-lihaoyi/mill/pull/4037, my hope is that this addresses https://github.com/com-lihaoyi/mill/issues/3662 (because both coursier and coursier-interface include https://github.com/coursier/coursier/pull/3171 now)