### PR TITLE
Fix: Stop minifying in `fastLinkJS`

### DIFF
--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -315,7 +315,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
   def scalaJSOutputPatterns: T[OutputPatterns] = Task { OutputPatterns.Defaults }
 
   /**
-   * Apply Scala.js-specific minification of the produced .js files.
+   * Apply Scala.js-specific minification of the produced .js files in fullLinkJS.
    *
    *  When enabled, the linker more aggressively reduces the size of the
    *  generated code, at the cost of readability and debuggability. It does

--- a/scalajslib/worker/1/src/mill/scalajslib/worker/ScalaJSWorkerImpl.scala
+++ b/scalajslib/worker/1/src/mill/scalajslib/worker/ScalaJSWorkerImpl.scala
@@ -151,7 +151,8 @@ class ScalaJSWorkerImpl extends ScalaJSWorkerApi {
         else withModuleSplitStyle
 
       val withMinify =
-        if (minorIsGreaterThanOrEqual(16)) withOutputPatterns.withMinify(input.minify)
+        if (minorIsGreaterThanOrEqual(16))
+          withOutputPatterns.withMinify(input.minify && input.isFullLinkJS)
         else withOutputPatterns
 
       val withWasm =


### PR DESCRIPTION
The alternative to this is to make `scalaJSMinify` an anonymous task, which is not binary compatible (we can have this change in a future major version).
Mill doesn't have `fastLinkJS` and `fullLinkJS` scopes as Sbt which makes it difficult to have specific settings for `fullLinkJS` only. This PR makes Mill behave like 99% of people want, which is what Sbt does by default. The downside is that it's now impossible to test what happens with minify on `fastLinkJS``, but the workaround is to directly test on `fullLinkJS` in that scenario.