### PR TITLE
Download test repos via coursier

### DIFF
--- a/ci/shared.mill
+++ b/ci/shared.mill
@@ -1,8 +1,15 @@
 package build.ci
 
+import coursier.cache.FileCache
+import coursier.util.Artifact
 
-
-def downloadTestRepo(label: String, commit: String, dest: os.Path) = {
-  os.unzip.stream(requests.get.stream(s"https://github.com/$label/archive/$commit.zip"), dest)
+def downloadTestRepo(label: String, commit: String, dest: os.Path)(implicit ctx: mill.api.Ctx.Log) = {
+  val cache = FileCache()
+  // Uncomment when rebootstrapping Mill, to get better logging
+  //   .withLogger(mill.util.CoursierSupport.millLogger())
+  val file = cache.file(Artifact(s"https://github.com/$label/archive/$commit.zip"))
+    .run.unsafeRun()(cache.ec)
+    .fold(ex => throw new Exception(ex), identity)
+  os.unzip(os.Path(file), dest)
   dest
 }

--- a/main/util/src/mill/util/CoursierSupport.scala
+++ b/main/util/src/mill/util/CoursierSupport.scala
@@ -341,6 +341,9 @@ trait CoursierSupport {
 
 object CoursierSupport {
 
+  def millLogger()(implicit ctx: Ctx.Log): CacheLogger =
+    new TickerResolutionLogger(ctx)
+
   /**
    * A Coursier Cache.Logger implementation that updates the ticker with the count and
    * overall byte size of artifacts being downloaded.


### PR DESCRIPTION
So that the repo archives are cached, and the tasks that use them work offline.

That's useful to build the website while being offline, for example.