### PR TITLE
More fixes for prompt logger

### DIFF
--- a/main/util/src/mill/util/PromptLogger.scala
+++ b/main/util/src/mill/util/PromptLogger.scala
@@ -74,8 +74,10 @@ private[mill] class PromptLogger(
         readTerminalDims(terminfoPath).foreach(termDimensions = _)
 
         val now = System.currentTimeMillis()
-        if (termDimensions._1.nonEmpty ||
-          (now - lastUpdate > nonInteractivePromptUpdateIntervalMillis)){
+        if (
+          termDimensions._1.nonEmpty ||
+          (now - lastUpdate > nonInteractivePromptUpdateIntervalMillis)
+        ) {
           lastUpdate = now
           synchronized {
             if (!runningState.paused && !runningState.stopped) refreshPrompt()

--- a/runner/client/src/mill/runner/client/MillClientMain.java
+++ b/runner/client/src/mill/runner/client/MillClientMain.java
@@ -6,7 +6,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
-
 import mill.main.client.*;
 import mill.main.client.lock.Locks;
 

--- a/runner/client/src/mill/runner/client/MillClientMain.java
+++ b/runner/client/src/mill/runner/client/MillClientMain.java
@@ -2,13 +2,12 @@ package mill.runner.client;
 
 import static mill.runner.client.MillProcessLauncher.millOptsFile;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
-import mill.main.client.OutFiles;
-import mill.main.client.ServerCouldNotBeStarted;
-import mill.main.client.ServerLauncher;
-import mill.main.client.Util;
+
+import mill.main.client.*;
 import mill.main.client.lock.Locks;
 
 /**
@@ -57,6 +56,8 @@ public class MillClientMain {
               }
 
               public void preRun(Path serverDir) throws Exception {
+                Path sandbox = serverDir.resolve(ServerFiles.sandbox);
+                Files.createDirectories(sandbox);
                 MillProcessLauncher.runTermInfoThread(serverDir);
               }
             };

--- a/runner/client/src/mill/runner/client/MillClientMain.java
+++ b/runner/client/src/mill/runner/client/MillClientMain.java
@@ -55,8 +55,6 @@ public class MillClientMain {
               }
 
               public void preRun(Path serverDir) throws Exception {
-                Path sandbox = serverDir.resolve(ServerFiles.sandbox);
-                Files.createDirectories(sandbox);
                 MillProcessLauncher.runTermInfoThread(serverDir);
               }
             };

--- a/runner/client/src/mill/runner/client/MillClientMain.java
+++ b/runner/client/src/mill/runner/client/MillClientMain.java
@@ -2,7 +2,6 @@ package mill.runner.client;
 
 import static mill.runner.client.MillProcessLauncher.millOptsFile;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;

--- a/runner/client/src/mill/runner/client/MillProcessLauncher.java
+++ b/runner/client/src/mill/runner/client/MillProcessLauncher.java
@@ -230,20 +230,20 @@ public class MillProcessLauncher {
     Files.write(serverDir.resolve(ServerFiles.terminfo), str.getBytes());
   }
 
-  public static boolean checkTputExists(){
-      try {
-          getTerminalDim("cols", false);
-          getTerminalDim("lines", false);
-          return true;
-      } catch (Exception e) {
-          return false;
-      }
+  public static boolean checkTputExists() {
+    try {
+      getTerminalDim("cols", false);
+      getTerminalDim("lines", false);
+      return true;
+    } catch (Exception e) {
+      return false;
+    }
   }
-  
-  public static void runTermInfoThread(Path serverDir) throws Exception {
-      boolean tputExists = checkTputExists();
 
-      writeTerminalDims(tputExists, serverDir);
+  public static void runTermInfoThread(Path serverDir) throws Exception {
+    boolean tputExists = checkTputExists();
+
+    writeTerminalDims(tputExists, serverDir);
     Thread termInfoPropagatorThread = new Thread(
         () -> {
           try {

--- a/runner/client/src/mill/runner/client/MillProcessLauncher.java
+++ b/runner/client/src/mill/runner/client/MillProcessLauncher.java
@@ -32,6 +32,8 @@ public class MillProcessLauncher {
     boolean interrupted = false;
 
     try {
+      Path sandbox = processDir.resolve(ServerFiles.sandbox);
+      Files.createDirectories(sandbox);
       MillProcessLauncher.runTermInfoThread(processDir);
       Process p = configureRunMillProcess(builder, processDir);
       return p.waitFor();

--- a/runner/client/src/mill/runner/client/MillProcessLauncher.java
+++ b/runner/client/src/mill/runner/client/MillProcessLauncher.java
@@ -32,8 +32,8 @@ public class MillProcessLauncher {
     boolean interrupted = false;
 
     try {
-      Process p = configureRunMillProcess(builder, processDir);
       MillProcessLauncher.runTermInfoThread(processDir);
+      Process p = configureRunMillProcess(builder, processDir);
       return p.waitFor();
 
     } catch (InterruptedException e) {
@@ -230,18 +230,23 @@ public class MillProcessLauncher {
     Files.write(serverDir.resolve(ServerFiles.terminfo), str.getBytes());
   }
 
+  public static boolean checkTputExists(){
+      try {
+          getTerminalDim("cols", false);
+          getTerminalDim("lines", false);
+          return true;
+      } catch (Exception e) {
+          return false;
+      }
+  }
+  
   public static void runTermInfoThread(Path serverDir) throws Exception {
+      boolean tputExists = checkTputExists();
+
+      writeTerminalDims(tputExists, serverDir);
     Thread termInfoPropagatorThread = new Thread(
         () -> {
           try {
-            boolean tputExists;
-            try {
-              getTerminalDim("cols", false);
-              getTerminalDim("lines", false);
-              tputExists = true;
-            } catch (Exception e) {
-              tputExists = false;
-            }
             while (true) {
               writeTerminalDims(tputExists, serverDir);
               Thread.sleep(100);

--- a/runner/client/src/mill/runner/client/MillProcessLauncher.java
+++ b/runner/client/src/mill/runner/client/MillProcessLauncher.java
@@ -32,8 +32,6 @@ public class MillProcessLauncher {
     boolean interrupted = false;
 
     try {
-      Path sandbox = processDir.resolve(ServerFiles.sandbox);
-      Files.createDirectories(sandbox);
       MillProcessLauncher.runTermInfoThread(processDir);
       Process p = configureRunMillProcess(builder, processDir);
       return p.waitFor();
@@ -243,6 +241,8 @@ public class MillProcessLauncher {
   }
 
   public static void runTermInfoThread(Path serverDir) throws Exception {
+    Path sandbox = serverDir.resolve(ServerFiles.sandbox);
+    Files.createDirectories(sandbox);
     boolean tputExists = checkTputExists();
 
     writeTerminalDims(tputExists, serverDir);


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/4074

We shouldn't sleep for `nonInteractivePromptUpdateIntervalMillis` every time `readTerminalDims` fails, because that means if there's a transient failure it doesn't check again for 60s during which there is no prompt shown

Instead, we always check after `promptUpdateIntervalMillis` seconds, and but only refresh the prompt if `now - lastUpdate > nonInteractivePromptUpdateIntervalMillis`

Also we make sure we call `writeTerminalDims` at least once before we start the Mill background process, rather than relying on the background thread to reach that code path in time

Either of these fixes alone should solve the issue, but might as well do both