### PR TITLE
Move scope-related tasks together in JavaModule

### DIFF
--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -318,6 +318,18 @@ trait JavaModule
   def moduleDeps: Seq[JavaModule] = Seq.empty
 
   /**
+   *  The compile-only direct dependencies of this module. These are *not*
+   *  transitive, and only take effect in the module that they are declared in.
+   */
+  def compileModuleDeps: Seq[JavaModule] = Seq.empty
+
+  /**
+   * The runtime-only direct dependencies of this module. These *are* transitive,
+   * and so get propagated to downstream modules automatically
+   */
+  def runModuleDeps: Seq[JavaModule] = Seq.empty
+
+  /**
    * Same as [[moduleDeps]] but checked to not contain cycles.
    * Prefer this over using [[moduleDeps]] directly.
    */
@@ -325,6 +337,13 @@ trait JavaModule
     // trigger initialization to check for cycles
     recModuleDeps
     moduleDeps
+  }
+
+  /** Same as [[compileModuleDeps]] but checked to not contain cycles. */
+  final def compileModuleDepsChecked: Seq[JavaModule] = {
+    // trigger initialization to check for cycles
+    recCompileModuleDeps
+    compileModuleDeps
   }
 
   /**
@@ -345,39 +364,20 @@ trait JavaModule
       _.moduleDeps
     )
 
-  /** Should only be called from [[runModuleDepsChecked]] */
-  private lazy val recRunModuleDeps: Seq[JavaModule] =
-    ModuleUtils.recursive[JavaModule](
-      (millModuleSegments ++ Seq(Segment.Label("runModuleDeps"))).render,
-      this,
-      m => m.runModuleDeps ++ m.moduleDeps
-    )
-
-  /**
-   *  The compile-only direct dependencies of this module. These are *not*
-   *  transitive, and only take effect in the module that they are declared in.
-   */
-  def compileModuleDeps: Seq[JavaModule] = Seq.empty
-
-  /**
-   * The runtime-only direct dependencies of this module. These *are* transitive,
-   * and so get propagated to downstream modules automatically
-   */
-  def runModuleDeps: Seq[JavaModule] = Seq.empty
-
-  /** Same as [[compileModuleDeps]] but checked to not contain cycles. */
-  final def compileModuleDepsChecked: Seq[JavaModule] = {
-    // trigger initialization to check for cycles
-    recCompileModuleDeps
-    compileModuleDeps
-  }
-
   /** Should only be called from [[compileModuleDeps]] */
   private lazy val recCompileModuleDeps: Seq[JavaModule] =
     ModuleUtils.recursive[JavaModule](
       (millModuleSegments ++ Seq(Segment.Label("compileModuleDeps"))).render,
       this,
       _.compileModuleDeps
+    )
+
+  /** Should only be called from [[runModuleDepsChecked]] */
+  private lazy val recRunModuleDeps: Seq[JavaModule] =
+    ModuleUtils.recursive[JavaModule](
+      (millModuleSegments ++ Seq(Segment.Label("runModuleDeps"))).render,
+      this,
+      m => m.runModuleDeps ++ m.moduleDeps
     )
 
   /** The direct and indirect dependencies of this module */
@@ -419,13 +419,6 @@ trait JavaModule
    */
   def transitiveModuleRunModuleDeps: Seq[JavaModule] = {
     (runModuleDepsChecked ++ moduleDepsChecked).flatMap(_.transitiveRunModuleDeps).distinct
-  }
-
-  /** The compile-only transitive ivy dependencies of this module and all it's upstream compile-only modules. */
-  def transitiveCompileIvyDeps: T[Agg[BoundDep]] = Task {
-    // We never include compile-only dependencies transitively, but we must include normal transitive dependencies!
-    compileIvyDeps().map(bindDependency()) ++
-      T.traverse(compileModuleDepsChecked)(_.transitiveIvyDeps)().flatten
   }
 
   /**
@@ -496,6 +489,13 @@ trait JavaModule
       T.traverse(moduleDepsChecked)(_.transitiveIvyDeps)().flatten.map { dep =>
         dep.copy(dep = processDependency0(dep.dep))
       }
+  }
+
+  /** The compile-only transitive ivy dependencies of this module and all it's upstream compile-only modules. */
+  def transitiveCompileIvyDeps: T[Agg[BoundDep]] = Task {
+    // We never include compile-only dependencies transitively, but we must include normal transitive dependencies!
+    compileIvyDeps().map(bindDependency()) ++
+      T.traverse(compileModuleDepsChecked)(_.transitiveIvyDeps)().flatten
   }
 
   /**


### PR DESCRIPTION
With the main task first, the compile-only one second, and the runtime one third

This makes it easier to change these methods, add related ones, etc.

This is already part of https://github.com/com-lihaoyi/mill/pull/4068. Opening the PR here to make it easier to review the changes here, and those of https://github.com/com-lihaoyi/mill/pull/4068 if the one here gets merged