### PR TITLE
Avoid writing some empty sections in POMs

### DIFF
--- a/scalalib/src/mill/scalalib/publish/Pom.scala
+++ b/scalalib/src/mill/scalalib/publish/Pom.scala
@@ -99,6 +99,18 @@ object Pom {
       bomDependencies: Agg[Dependency],
       dependencyManagement: Agg[Dependency]
   ): String = {
+    val developersSection =
+      if (pomSettings.developers.isEmpty) NodeSeq.Empty
+      else
+        <developers>
+          {pomSettings.developers.map(renderDeveloper)}
+        </developers>
+    val propertiesSection =
+      if (properties.isEmpty) NodeSeq.Empty
+      else
+        <properties>
+          {properties.map(renderProperty _).iterator}
+        </properties>
     val depMgmtSection =
       if (dependencyManagement.isEmpty) NodeSeq.Empty
       else
@@ -136,12 +148,8 @@ object Pom {
           {<tag>{pomSettings.versionControl.tag}</tag>.optional}
           {<url>{pomSettings.versionControl.browsableRepository}</url>.optional}
         </scm>
-        <developers>
-          {pomSettings.developers.map(renderDeveloper)}
-        </developers>
-        <properties>
-          {properties.map(renderProperty _).iterator}
-        </properties>
+        {developersSection}
+        {propertiesSection}
         <dependencies>
           {
         dependencies.map(renderDependency(_)).iterator ++

--- a/scalalib/src/mill/scalalib/publish/Pom.scala
+++ b/scalalib/src/mill/scalalib/publish/Pom.scala
@@ -99,6 +99,14 @@ object Pom {
       bomDependencies: Agg[Dependency],
       dependencyManagement: Agg[Dependency]
   ): String = {
+    val depMgmtSection =
+      if (dependencyManagement.isEmpty) NodeSeq.Empty
+      else
+        <dependencyManagement>
+          <dependencies>
+            {dependencyManagement.map(renderDependency(_)).iterator}
+          </dependencies>
+        </dependencyManagement>
     val xml =
       <project
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
@@ -140,11 +148,7 @@ object Pom {
           bomDependencies.map(renderDependency(_, isImport = true)).iterator
       }
         </dependencies>
-        <dependencyManagement>
-          <dependencies>
-            {dependencyManagement.map(renderDependency(_)).iterator}
-          </dependencies>
-        </dependencyManagement>
+        {depMgmtSection}
       </project>
 
     val pp = new PrettyPrinter(120, 4)


### PR DESCRIPTION
While looking at some Mill-generated POMs, some empty sections looked odd. This PR makes Mill avoid writing them.