### PR TITLE
Generalize `.runBackground` to work with all kinds of subprocesses

### DIFF
--- a/main/util/src/mill/util/Jvm.scala
+++ b/main/util/src/mill/util/Jvm.scala
@@ -394,8 +394,8 @@ object Jvm extends CoursierSupport {
       cwd = workingDir,
       env = envArgs,
       stdin = if (backgroundOutputs.isEmpty) os.Inherit else "",
-      stdout = backgroundOutputs.map(_._1).getOrElse(os.Inherit),
-      stderr = backgroundOutputs.map(_._2).getOrElse(os.Inherit)
+      stdout = os.Inherit,
+      stderr = os.Inherit
     )
   }
 

--- a/main/util/src/mill/util/Jvm.scala
+++ b/main/util/src/mill/util/Jvm.scala
@@ -394,8 +394,8 @@ object Jvm extends CoursierSupport {
       cwd = workingDir,
       env = envArgs,
       stdin = if (backgroundOutputs.isEmpty) os.Inherit else "",
-      stdout = os.Inherit,
-      stderr = os.Inherit
+      stdout = backgroundOutputs.map(_._1).getOrElse(os.Inherit),
+      stderr = backgroundOutputs.map(_._2).getOrElse(os.Inherit)
     )
   }
 

--- a/pythonlib/package.mill
+++ b/pythonlib/package.mill
@@ -9,4 +9,5 @@ object `package` extends RootModule with build.MillPublishScalaModule {
   // we depend on scalalib for re-using some common infrastructure (e.g. License
   // management of projects), NOT for reusing build logic
   def moduleDeps = Seq(build.main, build.scalalib)
+  def testTransitiveDeps = super.testTransitiveDeps() ++ Seq(build.scalalib.backgroundwrapper.testDep())
 }

--- a/pythonlib/src/mill/pythonlib/PythonModule.scala
+++ b/pythonlib/src/mill/pythonlib/PythonModule.scala
@@ -105,7 +105,7 @@ trait PythonModule extends PipModule with TaskModule { outer =>
     )
   }
 
-  private def runnerEnvTask = Task.Anon{
+  private def runnerEnvTask = Task.Anon {
     Map(
       "PYTHONPATH" -> transitivePythonPath().map(_.path).mkString(java.io.File.pathSeparator),
       "PYTHONPYCACHEPREFIX" -> (T.dest / "cache").toString,
@@ -113,6 +113,7 @@ trait PythonModule extends PipModule with TaskModule { outer =>
       else { "NO_COLOR" -> "1" }
     )
   }
+
   /**
    * Run a typechecker on this module.
    */
@@ -142,6 +143,7 @@ trait PythonModule extends PipModule with TaskModule { outer =>
       )
     )
   }
+
   /**
    * Run the main python script of this module.
    *
@@ -168,7 +170,7 @@ trait PythonModule extends PipModule with TaskModule { outer =>
       background = true,
       useCpPassingJar = false,
       runBackgroundLogToConsole = true,
-      javaHome = mill.scalalib.ZincWorkerModule.javaHome().map(_.path),
+      javaHome = mill.scalalib.ZincWorkerModule.javaHome().map(_.path)
     )
     ()
   }

--- a/pythonlib/test/resources/run-background/foo/src/foo.py
+++ b/pythonlib/test/resources/run-background/foo/src/foo.py
@@ -4,7 +4,7 @@ import fcntl
 
 def main():
     with open(sys.argv[1], 'a+') as file:
-        fcntl.flock(file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        fcntl.lockf(file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
         time.sleep(9999)
 
 if __name__ == "__main__":

--- a/pythonlib/test/resources/run-background/foo/src/foo.py
+++ b/pythonlib/test/resources/run-background/foo/src/foo.py
@@ -1,0 +1,12 @@
+import sys
+import time
+import fcntl
+
+def main():
+    with open(sys.argv[1], 'a+') as file:
+        fcntl.flock(file, fcntl.LOCK_EX)
+        time.sleep(9999)
+
+if __name__ == "__main__":
+    main()
+

--- a/pythonlib/test/resources/run-background/foo/src/foo.py
+++ b/pythonlib/test/resources/run-background/foo/src/foo.py
@@ -4,7 +4,7 @@ import fcntl
 
 def main():
     with open(sys.argv[1], 'a+') as file:
-        fcntl.flock(file, fcntl.LOCK_EX)
+        fcntl.flock(file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
         time.sleep(9999)
 
 if __name__ == "__main__":

--- a/pythonlib/test/src/mill/pythonlib/RunBackgroundTests.scala
+++ b/pythonlib/test/src/mill/pythonlib/RunBackgroundTests.scala
@@ -28,15 +28,13 @@ object RunBackgroundTests extends TestSuite {
         if (System.currentTimeMillis() - now1 > maxSleep) throw new Exception(error)
       }
 
-      while(lock.probe()) sleepIfTimeAvailable("File never locked by python subprocess")
+      while (lock.probe()) sleepIfTimeAvailable("File never locked by python subprocess")
 
       os.remove.all(eval.outPath / "foo" / "runBackground.dest")
 
-      while(!lock.probe()) {
+      while (!lock.probe()) {
         sleepIfTimeAvailable("File never unlocked after runBackground.dest removed")
       }
     }
   }
 }
-
-

--- a/pythonlib/test/src/mill/pythonlib/RunBackgroundTests.scala
+++ b/pythonlib/test/src/mill/pythonlib/RunBackgroundTests.scala
@@ -1,0 +1,42 @@
+package mill.pythonlib
+
+import mill.testkit.{TestBaseModule, UnitTester}
+import utest.*
+import mill._
+
+object RunBackgroundTests extends TestSuite {
+
+  object HelloWorldPython extends TestBaseModule {
+    object foo extends PythonModule {
+      override def mainScript = T.source(millSourcePath / "src" / "foo.py")
+    }
+  }
+
+  val resourcePath = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "run-background"
+  def tests: Tests = Tests {
+    test("runBackground") {
+      val eval = UnitTester(HelloWorldPython, resourcePath)
+
+      val lockedFile = os.temp()
+      val Right(result) = eval.apply(HelloWorldPython.foo.runBackground(Args(lockedFile)))
+      val maxSleep = 20000
+      val now1 = System.currentTimeMillis()
+      val lock = mill.main.client.lock.Lock.file(lockedFile.toString())
+
+      def sleepIfTimeAvailable(error: String) = {
+        Thread.sleep(100)
+        if (System.currentTimeMillis() - now1 > maxSleep) throw new Exception(error)
+      }
+
+      while(lock.probe()) sleepIfTimeAvailable("File never locked by python subprocess")
+
+      os.remove.all(eval.outPath / "foo" / "runBackground.dest")
+
+      while(!lock.probe()) {
+        sleepIfTimeAvailable("File never unlocked after runBackground.dest removed")
+      }
+    }
+  }
+}
+
+

--- a/pythonlib/test/src/mill/pythonlib/RunBackgroundTests.scala
+++ b/pythonlib/test/src/mill/pythonlib/RunBackgroundTests.scala
@@ -28,6 +28,8 @@ object RunBackgroundTests extends TestSuite {
         if (System.currentTimeMillis() - now1 > maxSleep) throw new Exception(error)
       }
 
+      Thread.sleep(1000) // Make sure that the file remains locked even after a significant sleep
+
       while (lock.probe()) sleepIfTimeAvailable("File never locked by python subprocess")
 
       os.remove.all(eval.outPath / "foo" / "runBackground.dest")

--- a/scalalib/backgroundwrapper/src/mill/scalalib/backgroundwrapper/MillBackgroundWrapper.java
+++ b/scalalib/backgroundwrapper/src/mill/scalalib/backgroundwrapper/MillBackgroundWrapper.java
@@ -2,10 +2,7 @@ package mill.scalalib.backgroundwrapper;
 
 import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
+import java.nio.file.*;
 
 public class MillBackgroundWrapper {
   public static void main(String[] args) throws Exception {

--- a/scalalib/backgroundwrapper/src/mill/scalalib/backgroundwrapper/MillBackgroundWrapper.java
+++ b/scalalib/backgroundwrapper/src/mill/scalalib/backgroundwrapper/MillBackgroundWrapper.java
@@ -55,6 +55,29 @@ public class MillBackgroundWrapper {
     // Actually start the Java main method we wanted to run in the background
     String realMain = args[4];
     String[] realArgs = java.util.Arrays.copyOfRange(args, 5, args.length);
-    Class.forName(realMain).getMethod("main", String[].class).invoke(null, (Object) realArgs);
+    if (!realMain.equals("<subprocess>")){
+        Class.forName(realMain).getMethod("main", String[].class).invoke(null, (Object) realArgs);
+    } else {
+        Process subprocess = new ProcessBuilder()
+            .command(realArgs)
+            .inheritIO()
+            .start();
+
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            subprocess.destroy();
+
+            long now = System.currentTimeMillis();
+
+            while (subprocess.isAlive() && System.currentTimeMillis() - now < 100) {
+                try {
+                    Thread.sleep(1);
+                }catch (InterruptedException e){}
+                if (subprocess.isAlive()) {
+                    subprocess.destroyForcibly();
+                }
+            }
+        }));
+        System.exit(subprocess.waitFor());
+    }
   }
 }

--- a/scalalib/backgroundwrapper/src/mill/scalalib/backgroundwrapper/MillBackgroundWrapper.java
+++ b/scalalib/backgroundwrapper/src/mill/scalalib/backgroundwrapper/MillBackgroundWrapper.java
@@ -52,29 +52,27 @@ public class MillBackgroundWrapper {
     // Actually start the Java main method we wanted to run in the background
     String realMain = args[4];
     String[] realArgs = java.util.Arrays.copyOfRange(args, 5, args.length);
-    if (!realMain.equals("<subprocess>")){
-        Class.forName(realMain).getMethod("main", String[].class).invoke(null, (Object) realArgs);
+    if (!realMain.equals("<subprocess>")) {
+      Class.forName(realMain).getMethod("main", String[].class).invoke(null, (Object) realArgs);
     } else {
-        Process subprocess = new ProcessBuilder()
-            .command(realArgs)
-            .inheritIO()
-            .start();
+      Process subprocess = new ProcessBuilder().command(realArgs).inheritIO().start();
 
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            subprocess.destroy();
+      Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+        subprocess.destroy();
 
-            long now = System.currentTimeMillis();
+        long now = System.currentTimeMillis();
 
-            while (subprocess.isAlive() && System.currentTimeMillis() - now < 100) {
-                try {
-                    Thread.sleep(1);
-                }catch (InterruptedException e){}
-                if (subprocess.isAlive()) {
-                    subprocess.destroyForcibly();
-                }
-            }
-        }));
-        System.exit(subprocess.waitFor());
+        while (subprocess.isAlive() && System.currentTimeMillis() - now < 100) {
+          try {
+            Thread.sleep(1);
+          } catch (InterruptedException e) {
+          }
+          if (subprocess.isAlive()) {
+            subprocess.destroyForcibly();
+          }
+        }
+      }));
+      System.exit(subprocess.waitFor());
     }
   }
 }

--- a/scalalib/src/mill/scalalib/RunModule.scala
+++ b/scalalib/src/mill/scalalib/RunModule.scala
@@ -235,7 +235,6 @@ trait RunModule extends WithZincWorker {
 
 object RunModule {
 
-
   private[mill] def backgroundSetup(dest: os.Path): (Path, Path, String) = {
     val procUuid = java.util.UUID.randomUUID().toString
     val procUuidPath = dest / ".mill-background-process-uuid"

--- a/scalalib/src/mill/scalalib/RunModule.scala
+++ b/scalalib/src/mill/scalalib/RunModule.scala
@@ -166,7 +166,7 @@ trait RunModule extends WithZincWorker {
 
   def runBackgroundTask(mainClass: Task[String], args: Task[Args] = Task.Anon(Args())): Task[Unit] =
     Task.Anon {
-      val (procUuidPath, procLockfile, procUuid) = backgroundSetup(T.dest)
+      val (procUuidPath, procLockfile, procUuid) = RunModule.backgroundSetup(T.dest)
       runner().run(
         args = Seq(
           procUuidPath.toString,
@@ -207,7 +207,7 @@ trait RunModule extends WithZincWorker {
       runUseArgsFile: Boolean,
       backgroundOutputs: Option[Tuple2[ProcessOutput, ProcessOutput]]
   )(args: String*): Ctx => Result[Unit] = ctx => {
-    val (procUuidPath, procLockfile, procUuid) = backgroundSetup(taskDest)
+    val (procUuidPath, procLockfile, procUuid) = RunModule.backgroundSetup(taskDest)
     try Result.Success(
         Jvm.runSubprocessWithBackgroundOutputs(
           "mill.scalalib.backgroundwrapper.MillBackgroundWrapper",
@@ -231,16 +231,17 @@ trait RunModule extends WithZincWorker {
         Result.Failure("subprocess failed")
     }
   }
+}
 
-  private[this] def backgroundSetup(dest: os.Path): (Path, Path, String) = {
+object RunModule {
+
+
+  private[mill] def backgroundSetup(dest: os.Path): (Path, Path, String) = {
     val procUuid = java.util.UUID.randomUUID().toString
     val procUuidPath = dest / ".mill-background-process-uuid"
     val procLockfile = dest / ".mill-background-process-lock"
     (procUuidPath, procLockfile, procUuid)
   }
-}
-
-object RunModule {
   trait Runner {
     def run(
         args: os.Shellable,


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/657

We re-use `MillBackgroundWrapper` and extend it to optionally spawn subprocess instead of calling the in-process main method. There's a bit of overhead in the JVM wrapper, but we need some kind of process wrapper to manage the mutex and termination even when the Mill process terminates, and eventually when https://github.com/com-lihaoyi/mill/issues/4007 lands we can use that to provide lighter-weight wrappers. We add a shutdown hook and copy the termination grace-period logic from OS-Lib to try and gently kill the wrapped process when necessary

Integrated this into `PythonModule#runBackground` and added a unit test to verify the asynchronous launch, background existence (by checking that a file lock is taken) and termination on deletion. We can integrate this into `TypescriptModule` as well but punting that for later

The subprocess APIs are a mess but leaving that to fix in 0.13.0 https://github.com/com-lihaoyi/mill/issues/3772