### PR TITLE
Create new automatic Github reelases with `prerelease` flag

### DIFF
--- a/dist/package.mill
+++ b/dist/package.mill
@@ -320,7 +320,7 @@ object `package` extends RootModule with build.MillPublishJavaModule {
       // TODO: check if the tag already exists (e.g. because we created it manually) and do not fail
       requests.post(
         s"https://api.github.com/repos/${build.Settings.githubOrg}/${build.Settings.githubRepo}/releases",
-        data = ujson.Obj("tag_name" -> releaseTag, "name" -> releaseTag),
+        data = ujson.Obj("tag_name" -> releaseTag, "name" -> releaseTag, "prerelease" -> true),
         headers = Seq("Authorization" -> ("token " + authKey))
       )
     }


### PR DESCRIPTION
This gives us a chance to manually announce release notifications, e.g. after some sanity checks or after Maven artifacts are available.

For pre-releases this is the right thing anyways.
