### PR TITLE
Always check `available()` in `InputPumper` to avoid burning CPU

### DIFF
--- a/main/client/src/mill/main/client/InputPumper.java
+++ b/main/client/src/mill/main/client/InputPumper.java
@@ -38,7 +38,7 @@ public class InputPumper implements Runnable {
       while (running) {
         if (!runningCheck.getAsBoolean()) {
           running = false;
-        } else if (checkAvailable && src.available() == 0) Thread.sleep(1);
+        } else if (src.available() == 0) Thread.sleep(1);
         else {
           int n;
           try {

--- a/main/client/src/mill/main/client/InputPumper.java
+++ b/main/client/src/mill/main/client/InputPumper.java
@@ -36,9 +36,7 @@ public class InputPumper implements Runnable {
     byte[] buffer = new byte[1024];
     try {
       while (running) {
-        if (!runningCheck.getAsBoolean()) {
-          running = false;
-        } else if (src.available() == 0) Thread.sleep(1);
+        if (!runningCheck.getAsBoolean()) running = false;
         else {
           int n;
           try {
@@ -46,9 +44,9 @@ public class InputPumper implements Runnable {
           } catch (Exception e) {
             n = -1;
           }
-          if (n == -1) {
-            running = false;
-          } else {
+          if (n == -1) running = false;
+          else if (n == 0) Thread.sleep(1);
+          else {
             try {
               dest.write(buffer, 0, n);
               dest.flush();


### PR DESCRIPTION
Attempts to fix https://github.com/com-lihaoyi/mill/discussions/4092

Instead of checking `src.available() == 0`, we check for `src.read(buffer) == 0`, which should provide a more accurate measure