### PR TITLE
More fixes for codesig stability of multi-file builds

### DIFF
--- a/integration/invalidation/codesig-subfolder/src/CodeSigSubfolderTests.scala
+++ b/integration/invalidation/codesig-subfolder/src/CodeSigSubfolderTests.scala
@@ -85,7 +85,7 @@ object CodeSigSubfolderTests extends UtestIntegrationTestSuite {
       assert(mangledValFooUsedInBar.err.contains("compiling 1 Scala source"))
     }
 
-    test("subfolder-renames-same-order") - integrationTest{ tester =>
+    test("subfolder-renames-same-order") - integrationTest { tester =>
       import tester._
       val cached4 = eval("foo")
       assert(cached4.out.contains("running foo"))
@@ -100,7 +100,7 @@ object CodeSigSubfolderTests extends UtestIntegrationTestSuite {
       val cached5 = eval("foo")
       assert(!cached5.out.contains("running foo"))
     }
-    test("subfolder-renames-reorder") - integrationTest{ tester =>
+    test("subfolder-renames-reorder") - integrationTest { tester =>
       import tester._
       val cached4 = eval("foo")
       assert(cached4.out.contains("running foo"))

--- a/integration/invalidation/codesig-subfolder/src/CodeSigSubfolderTests.scala
+++ b/integration/invalidation/codesig-subfolder/src/CodeSigSubfolderTests.scala
@@ -83,10 +83,37 @@ object CodeSigSubfolderTests extends UtestIntegrationTestSuite {
       ))
 
       assert(mangledValFooUsedInBar.err.contains("compiling 1 Scala source"))
+    }
 
+    test("subfolder-renames-same-order") - integrationTest{ tester =>
+      import tester._
       val cached4 = eval("foo")
-      assert(cached4.out == "")
-      assert(!cached4.err.contains("compiling"))
+      assert(cached4.out.contains("running foo"))
+
+      // Make sure if we rename a subfolder without re-ordering it
+      // alphabetically, it does not cause spurious invalidations
+      modifyFile(
+        workspacePath / "subfolder9/package.mill",
+        _.replace("package build.subfolder9", "package build.z_subfolder9")
+      )
+      os.move(workspacePath / "subfolder9", workspacePath / "z_subfolder9")
+      val cached5 = eval("foo")
+      assert(!cached5.out.contains("running foo"))
+    }
+    test("subfolder-renames-reorder") - integrationTest{ tester =>
+      import tester._
+      val cached4 = eval("foo")
+      assert(cached4.out.contains("running foo"))
+
+      // Make sure if we rename a subfolder while moving it to the top of
+      // the list alphabetically, it does not cause spurious invalidations
+      modifyFile(
+        workspacePath / "subfolder9/package.mill",
+        _.replace("package build.subfolder9", "package build.a_subfolder9")
+      )
+      os.move(workspacePath / "subfolder9", workspacePath / "a_subfolder9")
+      val cached5 = eval("foo")
+      assert(!cached5.out.contains("running foo"))
     }
   }
 }

--- a/main/codesig/src/LocalSummary.scala
+++ b/main/codesig/src/LocalSummary.scala
@@ -179,9 +179,13 @@ object LocalSummary {
         name: String,
         descriptor: String
     ): Unit = {
-      if (name.startsWith("bitmap$") && (opcode == Opcodes.GETSTATIC || opcode == Opcodes.GETFIELD)) {
+      val isBitmap = name match {
+        case s"bitmap$$$n" => n.forall(_.isDigit)
+        case _ => false
+      }
+      if (isBitmap && (opcode == Opcodes.GETSTATIC || opcode == Opcodes.GETFIELD)) {
         inLazyValCheck = true
-      } else if (name.startsWith("bitmap$") && (opcode == Opcodes.PUTSTATIC || opcode == Opcodes.PUTFIELD)) {
+      } else if (isBitmap && (opcode == Opcodes.PUTSTATIC || opcode == Opcodes.PUTFIELD)) {
         inLazyValCheck = false
       } else {
         hash(opcode)

--- a/main/codesig/src/LocalSummary.scala
+++ b/main/codesig/src/LocalSummary.scala
@@ -165,18 +165,30 @@ object LocalSummary {
 
     def discardPreviousInsn(): Unit = insnSigs(insnSigs.size - 1) = 0
 
+    /**
+     * Hack to skip the bitmap loading and comparison of Scala `lazy val`s. These
+     * snippets of code have constants that differ based on the ordering of the
+     * `lazy val` definitions, but this is invisible to the outside world, so we
+     * hack [[MyMethodVisitor]] to try and identify and skip those snippets of bytecode
+     */
+    var inLazyValCheck = false
+
     override def visitFieldInsn(
         opcode: Int,
         owner: String,
         name: String,
         descriptor: String
     ): Unit = {
-      hash(opcode)
-      hash(owner.hashCode)
-      hash(name.hashCode)
-      hash(descriptor.hashCode)
-      completeHash()
-      clinitCall(owner)
+      if (name.startsWith("bitmap$") && opcode == Opcodes.GETSTATIC || opcode == Opcodes.GETFIELD) {
+        inLazyValCheck = true
+      } else {
+        hash(opcode)
+        hash(owner.hashCode)
+        hash(name.hashCode)
+        hash(descriptor.hashCode)
+        completeHash()
+        clinitCall(owner)
+      }
     }
 
     override def visitIincInsn(varIndex: Int, increment: Int): Unit = {
@@ -186,14 +198,18 @@ object LocalSummary {
     }
 
     override def visitInsn(opcode: Int): Unit = {
-      hash(opcode)
-      completeHash()
+      if (!inLazyValCheck) {
+        hash(opcode)
+        completeHash()
+      }
     }
 
     override def visitIntInsn(opcode: Int, operand: Int): Unit = {
-      hash(opcode)
-      hash(operand)
-      completeHash()
+      if (!inLazyValCheck) {
+        hash(opcode)
+        hash(operand)
+        completeHash()
+      }
     }
 
     override def visitInvokeDynamicInsn(
@@ -228,6 +244,7 @@ object LocalSummary {
     }
 
     override def visitJumpInsn(opcode: Int, label: Label): Unit = {
+      if (inLazyValCheck) inLazyValCheck = false
       hashlabel(label)
       hash(opcode)
       completeHash()
@@ -337,6 +354,7 @@ object LocalSummary {
     }
 
     override def visitEnd(): Unit = {
+      assert(!inLazyValCheck)
       clsVisitor.classCallGraph.addOne((methodSig, outboundCalls.toSet))
       clsVisitor.classMethodHashes.addOne((
         methodSig,

--- a/main/codesig/src/LocalSummary.scala
+++ b/main/codesig/src/LocalSummary.scala
@@ -179,8 +179,10 @@ object LocalSummary {
         name: String,
         descriptor: String
     ): Unit = {
-      if (name.startsWith("bitmap$") && opcode == Opcodes.GETSTATIC || opcode == Opcodes.GETFIELD) {
+      if (name.startsWith("bitmap$") && (opcode == Opcodes.GETSTATIC || opcode == Opcodes.GETFIELD)) {
         inLazyValCheck = true
+      } else if (name.startsWith("bitmap$") && (opcode == Opcodes.PUTSTATIC || opcode == Opcodes.PUTFIELD)) {
+        inLazyValCheck = false
       } else {
         hash(opcode)
         hash(owner.hashCode)

--- a/runner/src/mill/runner/CodeGen.scala
+++ b/runner/src/mill/runner/CodeGen.scala
@@ -61,7 +61,7 @@ object CodeGen {
           val comment = "// subfolder module reference"
           val lhs = backtickWrap(c)
           val rhs = s"${pkgSelector2(Some(c))}.package_"
-          s"final lazy val $lhs: $rhs.type = $rhs $comment"
+          s"final def $lhs: $rhs.type = $rhs $comment"
         }
         .mkString("\n")
 

--- a/runner/src/mill/runner/CodeGen.scala
+++ b/runner/src/mill/runner/CodeGen.scala
@@ -61,7 +61,7 @@ object CodeGen {
           val comment = "// subfolder module reference"
           val lhs = backtickWrap(c)
           val rhs = s"${pkgSelector2(Some(c))}.package_"
-          s"final def $lhs: $rhs.type = $rhs $comment"
+          s"final lazy val $lhs: $rhs.type = $rhs $comment"
         }
         .mkString("\n")
 

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -169,7 +169,14 @@ abstract class MillBuildRootModule()(implicit
           def isCommand =
             calledSig.desc.ret.pretty == classOf[mill.define.Command[_]].getName
 
-          (isSimpleTarget && !isForwarderCallsite) || isCommand
+          // Skip calls to `millDiscover`. `millDiscover` is bundled as part of `RootModule` for
+          // convenience, but it should really never be called by any normal Mill module/task code,
+          // and is only used by downstream code in `mill.eval`/`mill.resolve`. Thus although CodeSig's
+          // conservative analysis considers potential calls from `build_.package_$#<init>` to
+          // `millDiscover()`, we can safely ignore that possibility
+          def isMillDiscover = calledSig.name == "millDiscover$lzycompute"
+
+          (isSimpleTarget && !isForwarderCallsite) || isCommand || isMillDiscover
         },
         logger = new mill.codesig.Logger(Option.when(debugEnabled)(T.dest / "current")),
         prevTransitiveCallGraphHashesOpt = () =>


### PR DESCRIPTION
We tweak the codegen and codesig analysis to avoid unnecessarily invalidating the code signatures when the set of sub-folder `package.mill` files change. Follow up of https://github.com/com-lihaoyi/mill/pull/4113

Covered by additional integration tests