### PR TITLE
Speed up task resolution and planning logic 

### DIFF
--- a/example/thirdparty/mockito/build.mill
+++ b/example/thirdparty/mockito/build.mill
@@ -226,7 +226,7 @@ object `package` extends RootModule with MockitoModule {
 //      def testIvyDeps = Agg(libraries.junit4, libraries.osgi)
 //      def testRuntimeIvyDeps = Agg(libraries.equinox)
 //      trait BundleModule extends MockitoModule{
-//        def bundleName: String = millModuleSegments.parts.last
+//        def bundleName: String = millModuleSegments.last.value
 //        override def millSourcePath = `osgi-test`.millSourcePath
 //        def sources = Task.Sources(millSourcePath / "src" / bundleName / "java")
 //

--- a/example/thirdparty/netty/build.mill
+++ b/example/thirdparty/netty/build.mill
@@ -77,7 +77,7 @@ trait NettyModule extends NettyBaseModule {
     def ivyDeps = super.ivyDeps() ++ testIvyDeps()
     def forkWorkingDir = NettyModule.this.millSourcePath
     def forkArgs = super.forkArgs() ++ Seq(
-      "-Dnativeimage.handlerMetadataArtifactId=netty-" + NettyModule.this.millModuleSegments.parts.last
+      "-Dnativeimage.handlerMetadataArtifactId=netty-" + NettyModule.this.millModuleSegments.last.value
     )
 
   }

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-compile-classpaths.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-compile-classpaths.json
@@ -2,14 +2,6 @@
   "items": [
     {
       "target": {
-        "uri": "file:///workspace/hello-java"
-      },
-      "classpath": [
-        "file:///workspace/hello-java/compile-resources"
-      ]
-    },
-    {
-      "target": {
         "uri": "file:///workspace/hello-kotlin"
       },
       "classpath": [
@@ -25,6 +17,14 @@
       "classpath": [
         "file:///coursier-cache/https/repo1.maven.org/maven2/org/scala-lang/scala-library/<scala-version>/scala-library-<scala-version>.jar",
         "file:///workspace/hello-scala/compile-resources"
+      ]
+    },
+    {
+      "target": {
+        "uri": "file:///workspace/hello-java"
+      },
+      "classpath": [
+        "file:///workspace/hello-java/compile-resources"
       ]
     }
   ]

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-dependency-modules.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-dependency-modules.json
@@ -2,12 +2,6 @@
   "items": [
     {
       "target": {
-        "uri": "file:///workspace/hello-java"
-      },
-      "modules": []
-    },
-    {
-      "target": {
         "uri": "file:///workspace/hello-kotlin"
       },
       "modules": [
@@ -27,6 +21,12 @@
           "version": "<scala-version>"
         }
       ]
+    },
+    {
+      "target": {
+        "uri": "file:///workspace/hello-java"
+      },
+      "modules": []
     }
   ]
 }

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-dependency-sources.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-dependency-sources.json
@@ -2,12 +2,6 @@
   "items": [
     {
       "target": {
-        "uri": "file:///workspace/hello-java"
-      },
-      "sources": []
-    },
-    {
-      "target": {
         "uri": "file:///workspace/hello-kotlin"
       },
       "sources": [
@@ -22,6 +16,12 @@
       "sources": [
         "file:///coursier-cache/https/repo1.maven.org/maven2/org/scala-lang/scala-library/<scala-version>/scala-library-<scala-version>-sources.jar"
       ]
+    },
+    {
+      "target": {
+        "uri": "file:///workspace/hello-java"
+      },
+      "sources": []
     }
   ]
 }

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-javac-options.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-javac-options.json
@@ -2,16 +2,6 @@
   "items": [
     {
       "target": {
-        "uri": "file:///workspace/hello-java"
-      },
-      "options": [],
-      "classpath": [
-        "file:///workspace/hello-java/compile-resources"
-      ],
-      "classDirectory": "file:///workspace/out/hello-java/compile.dest/classes"
-    },
-    {
-      "target": {
         "uri": "file:///workspace/hello-kotlin"
       },
       "options": [],
@@ -32,6 +22,16 @@
         "file:///workspace/hello-scala/compile-resources"
       ],
       "classDirectory": "file:///workspace/out/hello-scala/compile.dest/classes"
+    },
+    {
+      "target": {
+        "uri": "file:///workspace/hello-java"
+      },
+      "options": [],
+      "classpath": [
+        "file:///workspace/hello-java/compile-resources"
+      ],
+      "classDirectory": "file:///workspace/out/hello-java/compile.dest/classes"
     }
   ]
 }

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-jvm-run-environments.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-jvm-run-environments.json
@@ -2,20 +2,6 @@
   "items": [
     {
       "target": {
-        "uri": "file:///workspace/hello-java"
-      },
-      "classpath": [
-        "file:///workspace/hello-java/compile-resources",
-        "file:///workspace/hello-java/resources",
-        "file:///workspace/out/hello-java/compile.dest/classes"
-      ],
-      "jvmOptions": [],
-      "workingDirectory": "/workspace",
-      "environmentVariables": {},
-      "mainClasses": []
-    },
-    {
-      "target": {
         "uri": "file:///workspace/hello-kotlin"
       },
       "classpath": [
@@ -39,6 +25,20 @@
         "file:///workspace/hello-scala/compile-resources",
         "file:///workspace/hello-scala/resources",
         "file:///workspace/out/hello-scala/compile.dest/classes"
+      ],
+      "jvmOptions": [],
+      "workingDirectory": "/workspace",
+      "environmentVariables": {},
+      "mainClasses": []
+    },
+    {
+      "target": {
+        "uri": "file:///workspace/hello-java"
+      },
+      "classpath": [
+        "file:///workspace/hello-java/compile-resources",
+        "file:///workspace/hello-java/resources",
+        "file:///workspace/out/hello-java/compile.dest/classes"
       ],
       "jvmOptions": [],
       "workingDirectory": "/workspace",

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-jvm-test-environments.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-jvm-test-environments.json
@@ -2,20 +2,6 @@
   "items": [
     {
       "target": {
-        "uri": "file:///workspace/hello-java"
-      },
-      "classpath": [
-        "file:///workspace/hello-java/compile-resources",
-        "file:///workspace/hello-java/resources",
-        "file:///workspace/out/hello-java/compile.dest/classes"
-      ],
-      "jvmOptions": [],
-      "workingDirectory": "/workspace",
-      "environmentVariables": {},
-      "mainClasses": []
-    },
-    {
-      "target": {
         "uri": "file:///workspace/hello-kotlin"
       },
       "classpath": [
@@ -39,6 +25,20 @@
         "file:///workspace/hello-scala/compile-resources",
         "file:///workspace/hello-scala/resources",
         "file:///workspace/out/hello-scala/compile.dest/classes"
+      ],
+      "jvmOptions": [],
+      "workingDirectory": "/workspace",
+      "environmentVariables": {},
+      "mainClasses": []
+    },
+    {
+      "target": {
+        "uri": "file:///workspace/hello-java"
+      },
+      "classpath": [
+        "file:///workspace/hello-java/compile-resources",
+        "file:///workspace/hello-java/resources",
+        "file:///workspace/out/hello-java/compile.dest/classes"
       ],
       "jvmOptions": [],
       "workingDirectory": "/workspace",

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-output-paths.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-output-paths.json
@@ -2,12 +2,6 @@
   "items": [
     {
       "target": {
-        "uri": "file:///workspace/hello-java"
-      },
-      "outputPaths": []
-    },
-    {
-      "target": {
         "uri": "file:///workspace/hello-kotlin"
       },
       "outputPaths": []
@@ -15,6 +9,12 @@
     {
       "target": {
         "uri": "file:///workspace/hello-scala"
+      },
+      "outputPaths": []
+    },
+    {
+      "target": {
+        "uri": "file:///workspace/hello-java"
       },
       "outputPaths": []
     },

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-resources.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-resources.json
@@ -2,12 +2,6 @@
   "items": [
     {
       "target": {
-        "uri": "file:///workspace/hello-java"
-      },
-      "resources": []
-    },
-    {
-      "target": {
         "uri": "file:///workspace/hello-kotlin"
       },
       "resources": []
@@ -15,6 +9,12 @@
     {
       "target": {
         "uri": "file:///workspace/hello-scala"
+      },
+      "resources": []
+    },
+    {
+      "target": {
+        "uri": "file:///workspace/hello-java"
       },
       "resources": []
     },

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-scalac-options.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-scalac-options.json
@@ -2,16 +2,6 @@
   "items": [
     {
       "target": {
-        "uri": "file:///workspace/hello-java"
-      },
-      "options": [],
-      "classpath": [
-        "file:///workspace/hello-java/compile-resources"
-      ],
-      "classDirectory": "file:///workspace/out/hello-java/compile.dest/classes"
-    },
-    {
-      "target": {
         "uri": "file:///workspace/hello-kotlin"
       },
       "options": [],
@@ -32,6 +22,16 @@
         "file:///workspace/hello-scala/compile-resources"
       ],
       "classDirectory": "file:///workspace/out/hello-scala/compile.dest/classes"
+    },
+    {
+      "target": {
+        "uri": "file:///workspace/hello-java"
+      },
+      "options": [],
+      "classpath": [
+        "file:///workspace/hello-java/compile-resources"
+      ],
+      "classDirectory": "file:///workspace/out/hello-java/compile.dest/classes"
     }
   ]
 }

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-sources.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-sources.json
@@ -2,18 +2,6 @@
   "items": [
     {
       "target": {
-        "uri": "file:///workspace/hello-java"
-      },
-      "sources": [
-        {
-          "uri": "file:///workspace/hello-java/src",
-          "kind": 2,
-          "generated": false
-        }
-      ]
-    },
-    {
-      "target": {
         "uri": "file:///workspace/hello-kotlin"
       },
       "sources": [
@@ -31,6 +19,18 @@
       "sources": [
         {
           "uri": "file:///workspace/hello-scala/src",
+          "kind": 2,
+          "generated": false
+        }
+      ]
+    },
+    {
+      "target": {
+        "uri": "file:///workspace/hello-java"
+      },
+      "sources": [
+        {
+          "uri": "file:///workspace/hello-java/src",
           "kind": 2,
           "generated": false
         }

--- a/integration/ide/bsp-server/resources/snapshots/workspace-build-targets.json
+++ b/integration/ide/bsp-server/resources/snapshots/workspace-build-targets.json
@@ -2,32 +2,6 @@
   "targets": [
     {
       "id": {
-        "uri": "file:///workspace/hello-java"
-      },
-      "displayName": "hello-java",
-      "baseDirectory": "file:///workspace/hello-java",
-      "tags": [
-        "library",
-        "application"
-      ],
-      "languageIds": [
-        "java"
-      ],
-      "dependencies": [],
-      "capabilities": {
-        "canCompile": true,
-        "canTest": false,
-        "canRun": true,
-        "canDebug": false
-      },
-      "dataKind": "jvm",
-      "data": {
-        "javaHome": "file:///java-home/",
-        "javaVersion": "<java-version>"
-      }
-    },
-    {
-      "id": {
         "uri": "file:///workspace/hello-kotlin"
       },
       "displayName": "hello-kotlin",
@@ -92,6 +66,32 @@
           "javaHome": "file:///java-home/",
           "javaVersion": "<java-version>"
         }
+      }
+    },
+    {
+      "id": {
+        "uri": "file:///workspace/hello-java"
+      },
+      "displayName": "hello-java",
+      "baseDirectory": "file:///workspace/hello-java",
+      "tags": [
+        "library",
+        "application"
+      ],
+      "languageIds": [
+        "java"
+      ],
+      "dependencies": [],
+      "capabilities": {
+        "canCompile": true,
+        "canTest": false,
+        "canRun": true,
+        "canDebug": false
+      },
+      "dataKind": "jvm",
+      "data": {
+        "javaHome": "file:///java-home/",
+        "javaVersion": "<java-version>"
       }
     },
     {

--- a/integration/invalidation/selective-execution/src/SelectiveExecutionTests.scala
+++ b/integration/invalidation/selective-execution/src/SelectiveExecutionTests.scala
@@ -58,7 +58,8 @@ object SelectiveExecutionTests extends UtestIntegrationTestSuite {
       // `selective.resolve` or `selective.run` and thingsstill work
       import tester._
 
-      eval(("selective.prepare", "{foo.fooCommand,bar.barCommand}"), check = true)
+      // `selective.prepare` defaults to `__` if no selector is passed
+      eval(("selective.prepare"), check = true)
       modifyFile(workspacePath / "bar/bar.txt", _ + "!")
 
       val resolve = eval(("selective.resolve", "bar.barCommand"), check = true)

--- a/main/define/src/mill/define/Module.scala
+++ b/main/define/src/mill/define/Module.scala
@@ -79,7 +79,7 @@ object Module {
         implicitly[ClassTag[T]].runtimeClass,
         filter,
         noParams = true,
-          Reflect.getMethods(_, scala.reflect.NameTransformer.decode)
+        Reflect.getMethods(_, scala.reflect.NameTransformer.decode)
       )
         .map(_.invoke(outer).asInstanceOf[T])
     }
@@ -89,10 +89,10 @@ object Module {
     def reflectNestedObjects[T: ClassTag](filter: String => Boolean = Function.const(true))
         : Seq[T] = {
       Reflect.reflectNestedObjects02(
-          outer.getClass,
-          filter,
-          Reflect.getMethods(_, scala.reflect.NameTransformer.decode)
-        )
+        outer.getClass,
+        filter,
+        Reflect.getMethods(_, scala.reflect.NameTransformer.decode)
+      )
         .map { case (name, cls, getter) => getter(outer) }
     }
   }

--- a/main/define/src/mill/define/Module.scala
+++ b/main/define/src/mill/define/Module.scala
@@ -79,7 +79,7 @@ object Module {
         implicitly[ClassTag[T]].runtimeClass,
         filter,
         noParams = true,
-        scala.reflect.NameTransformer.decode
+          Reflect.getMethods(_, scala.reflect.NameTransformer.decode)
       )
         .map(_.invoke(outer).asInstanceOf[T])
     }
@@ -91,7 +91,7 @@ object Module {
       Reflect.reflectNestedObjects02(
           outer.getClass,
           filter,
-          scala.reflect.NameTransformer.decode
+          Reflect.getMethods(_, scala.reflect.NameTransformer.decode)
         )
         .map { case (name, cls, getter) => getter(outer) }
     }

--- a/main/define/src/mill/define/Module.scala
+++ b/main/define/src/mill/define/Module.scala
@@ -78,7 +78,8 @@ object Module {
         outer.getClass,
         implicitly[ClassTag[T]].runtimeClass,
         filter,
-        noParams = true
+        noParams = true,
+        scala.reflect.NameTransformer.decode
       )
         .map(_.invoke(outer).asInstanceOf[T])
     }
@@ -87,7 +88,11 @@ object Module {
 
     def reflectNestedObjects[T: ClassTag](filter: String => Boolean = Function.const(true))
         : Seq[T] = {
-      Reflect.reflectNestedObjects02(outer.getClass, filter)
+      Reflect.reflectNestedObjects02(
+          outer.getClass,
+          filter,
+          scala.reflect.NameTransformer.decode
+        )
         .map { case (name, cls, getter) => getter(outer) }
     }
   }

--- a/main/define/src/mill/define/Reflect.scala
+++ b/main/define/src/mill/define/Reflect.scala
@@ -64,7 +64,7 @@ private[mill] object Reflect {
       }
     )
 
-    arr.reverse.distinctBy(_.getName)
+    arr.reverseIterator.distinctBy(_.getName).toArray
   }
 
   // For some reason, this fails to pick up concrete `object`s nested directly within

--- a/main/define/src/mill/define/Reflect.scala
+++ b/main/define/src/mill/define/Reflect.scala
@@ -1,6 +1,7 @@
 package mill.define
 
 import scala.reflect.ClassTag
+import java.lang.reflect.Method
 
 private[mill] object Reflect {
   import java.lang.reflect.Modifier
@@ -21,7 +22,7 @@ private[mill] object Reflect {
     true
   }
 
-  def getMethods(cls: Class[_], decode: String => String) =
+  def getMethods(cls: Class[_], decode: String => String): Array[(Method, String)] =
     for {
       m <- cls.getMethods
       n = decode(m.getName)

--- a/main/define/src/mill/define/Segment.scala
+++ b/main/define/src/mill/define/Segment.scala
@@ -8,6 +8,11 @@ sealed trait Segment {
 }
 
 object Segment {
+  import scala.math.Ordering.Implicits.seqOrdering
+  implicit def ordering: Ordering[Segment] = Ordering.by {
+    case Label(value) => (value, Nil)
+    case Cross(value) => ("", value)
+  }
   final case class Label(value: String) extends Segment
   final case class Cross(value: Seq[String]) extends Segment
 }

--- a/main/define/src/mill/define/Segments.scala
+++ b/main/define/src/mill/define/Segments.scala
@@ -1,5 +1,7 @@
 package mill.define
 
+import scala.math.Ordering.Implicits.seqOrdering
+
 /**
  * Models a path with the Mill build hierarchy, e.g. `amm.util[2.11].test.compile`.
  * Segments must start with a [[Segment.Label]].
@@ -52,9 +54,11 @@ case class Segments private (value: Seq[Segment]) {
     case Segment.Cross(_) :: _ =>
       throw new IllegalArgumentException("Segments must start with a Label, but found a Cross.")
   }
+  override lazy val hashCode = value.hashCode()
 }
 
 object Segments {
+  implicit def ordering: Ordering[Segments] = Ordering.by(_.value)
   def apply(): Segments = new Segments(Nil)
   def apply(items: Seq[Segment]): Segments = new Segments(items)
   def labels(values: String*): Segments = Segments(values.map(Segment.Label))

--- a/main/define/src/mill/define/Segments.scala
+++ b/main/define/src/mill/define/Segments.scala
@@ -17,6 +17,12 @@ case class Segments private (value: Seq[Segment]) {
   def startsWith(prefix: Segments): Boolean =
     value.startsWith(prefix.value)
 
+  def last: Segment.Label = value.last match {
+    case l: Segment.Label => l
+    case _ =>
+      throw new IllegalArgumentException("Segments must start with a Label, but found a Cross.")
+  }
+
   def parts: List[String] = value.toList match {
     case Nil => Nil
     case Segment.Label(head) :: rest =>

--- a/main/define/src/mill/define/Segments.scala
+++ b/main/define/src/mill/define/Segments.scala
@@ -54,7 +54,7 @@ case class Segments private (value: Seq[Segment]) {
     case Segment.Cross(_) :: _ =>
       throw new IllegalArgumentException("Segments must start with a Label, but found a Cross.")
   }
-  override lazy val hashCode = value.hashCode()
+  override lazy val hashCode: Int = value.hashCode()
 }
 
 object Segments {

--- a/main/resolve/src/mill/resolve/ParseArgs.scala
+++ b/main/resolve/src/mill/resolve/ParseArgs.scala
@@ -95,7 +95,7 @@ object ParseArgs {
 
   private def selector[_p: P]: P[(Option[Segments], Option[Segments])] = {
     def wildcard = P("__" | "_")
-    def label = mill.define.Reflect.ident
+    def label = P(CharsWhileIn("a-zA-Z0-9_\\-")).!
 
     def typeQualifier(simple: Boolean) = {
       val maxSegments = if (simple) 0 else Int.MaxValue

--- a/main/resolve/src/mill/resolve/Resolve.scala
+++ b/main/resolve/src/mill/resolve/Resolve.scala
@@ -310,10 +310,9 @@ trait Resolve[T] {
       }
 
     resolved
-      .map(_.sortBy(_.segments))
-      .flatMap(handleResolved(
+      .flatMap(r => handleResolved(
         rootModule,
-        _,
+        r.sortBy(_.segments),
         args,
         sel,
         nullCommandDefaults,

--- a/main/resolve/src/mill/resolve/Resolve.scala
+++ b/main/resolve/src/mill/resolve/Resolve.scala
@@ -310,7 +310,7 @@ trait Resolve[T] {
       }
 
     resolved
-      .map(_.toSeq.sortBy(_.segments.render))
+      .map(_.sortBy(_.segments))
       .flatMap(handleResolved(
         rootModule,
         _,

--- a/main/resolve/src/mill/resolve/Resolve.scala
+++ b/main/resolve/src/mill/resolve/Resolve.scala
@@ -52,10 +52,10 @@ object Resolve {
 
         case r: Resolved.Command =>
           val instantiated = ResolveCore
-            .instantiateModule0(rootModule, r.segments.init)
-            .flatMap { case (mod, rootMod) =>
+            .instantiateModule(rootModule, r.segments.init)
+            .flatMap { mod =>
               instantiateCommand(
-                rootMod,
+                rootModule,
                 r,
                 mod,
                 args,

--- a/main/resolve/src/mill/resolve/Resolve.scala
+++ b/main/resolve/src/mill/resolve/Resolve.scala
@@ -116,7 +116,13 @@ object Resolve {
       cache: ResolveCore.Cache
   ): Either[String, NamedTask[_]] = {
     val definition = Reflect
-      .reflect(p.getClass, classOf[NamedTask[_]], _ == r.segments.last.value, true, getMethods = cache.getMethods)
+      .reflect(
+        p.getClass,
+        classOf[NamedTask[_]],
+        _ == r.segments.last.value,
+        true,
+        getMethods = cache.getMethods
+      )
       .head
 
     ResolveCore.catchWrapException(
@@ -310,16 +316,18 @@ trait Resolve[T] {
       }
 
     resolved
-      .flatMap(r => handleResolved(
-        rootModule,
-        r.sortBy(_.segments),
-        args,
-        sel,
-        nullCommandDefaults,
-        allowPositionalCommandArgs,
-        resolveToModuleTasks,
-        cache = cache
-      ))
+      .flatMap(r =>
+        handleResolved(
+          rootModule,
+          r.sortBy(_.segments),
+          args,
+          sel,
+          nullCommandDefaults,
+          allowPositionalCommandArgs,
+          resolveToModuleTasks,
+          cache = cache
+        )
+      )
   }
 
   private[mill] def deduplicate(items: List[T]): List[T] = items

--- a/main/resolve/src/mill/resolve/Resolve.scala
+++ b/main/resolve/src/mill/resolve/Resolve.scala
@@ -50,7 +50,7 @@ object Resolve {
         case r: Resolved.NamedTask =>
           val instantiated = ResolveCore
             .instantiateModule(rootModule, r.segments.init, cache)
-            .flatMap(instantiateNamedTask(r, _, cache.decode))
+            .flatMap(instantiateNamedTask(r, _, cache))
           instantiated.map(Some(_))
 
         case r: Resolved.Command =>
@@ -82,7 +82,7 @@ object Resolve {
 
               directChildrenOrErr.flatMap(directChildren =>
                 directChildren.head match {
-                  case r: Resolved.NamedTask => instantiateNamedTask(r, value, cache.decode).map(Some(_))
+                  case r: Resolved.NamedTask => instantiateNamedTask(r, value, cache).map(Some(_))
                   case r: Resolved.Command =>
                     instantiateCommand(
                       rootModule,
@@ -113,10 +113,10 @@ object Resolve {
   private def instantiateNamedTask(
       r: Resolved.NamedTask,
       p: Module,
-      decode: String => String
+      cache: ResolveCore.Cache
   ): Either[String, NamedTask[_]] = {
     val definition = Reflect
-      .reflect(p.getClass, classOf[NamedTask[_]], _ == r.segments.last.value, true, decode)
+      .reflect(p.getClass, classOf[NamedTask[_]], _ == r.segments.last.value, true, getMethods = cache.getMethods)
       .head
 
     ResolveCore.catchWrapException(

--- a/main/resolve/src/mill/resolve/ResolveCore.scala
+++ b/main/resolve/src/mill/resolve/ResolveCore.scala
@@ -409,12 +409,12 @@ private object ResolveCore {
         instantiateModule(rootModule, segments, cache).map {
           case m: DynamicModule =>
             m.millModuleDirectChildren
-              .filter(c => namePred(c.millModuleSegments.parts.last))
+              .filter(c => namePred(c.millModuleSegments.last.value))
               .filter(c => classMatchesTypePred(typePattern)(c.getClass))
               .map(c =>
                 (
                   Resolved.Module(
-                    Segments.labels(c.millModuleSegments.parts.last),
+                    Segments.labels(c.millModuleSegments.last.value),
                     c.getClass
                   ),
                   Some((x: Module) => Right(c))
@@ -423,7 +423,7 @@ private object ResolveCore {
         }
       } else Right {
         val reflectMemberObjects = Reflect
-          .reflectNestedObjects02[Module](cls, namePred)
+          .reflectNestedObjects02[Module](cls, namePred, cache.decode)
           .collect {
             case (name, memberCls, getter) if classMatchesTypePred(typePattern)(memberCls) =>
               val resolved = Resolved.Module(Segments.labels(cache.decode(name)), memberCls)
@@ -436,14 +436,14 @@ private object ResolveCore {
     }
 
     val namedTasks = Reflect
-      .reflect(cls, classOf[NamedTask[_]], namePred, noParams = true)
+      .reflect(cls, classOf[NamedTask[_]], namePred, noParams = true, cache.decode)
       .map { m =>
         Resolved.NamedTask(Segments.labels(cache.decode(m.getName))) ->
           None
       }
 
     val commands = Reflect
-      .reflect(cls, classOf[Command[_]], namePred, noParams = false)
+      .reflect(cls, classOf[Command[_]], namePred, noParams = false, cache.decode)
       .map(m => cache.decode(m.getName))
       .map { name => Resolved.Command(Segments.labels(name)) -> None }
 

--- a/main/resolve/src/mill/resolve/ResolveCore.scala
+++ b/main/resolve/src/mill/resolve/ResolveCore.scala
@@ -4,6 +4,7 @@ import mill.define._
 import mill.util.EitherOps
 
 import java.lang.reflect.InvocationTargetException
+import java.lang.reflect.Method
 
 /**
  * Takes a single list of segments, without braces but including wildcards, and
@@ -68,7 +69,7 @@ private object ResolveCore {
       decodedNames.getOrElseUpdate(s, scala.reflect.NameTransformer.decode(s))
     }
 
-    def getMethods(cls: Class[_]) = {
+    def getMethods(cls: Class[_]): Array[(Method, String)] = {
       methods.getOrElseUpdate(cls.getName, Reflect.getMethods(cls, decode))
     }
   }

--- a/main/resolve/src/mill/resolve/ResolveCore.scala
+++ b/main/resolve/src/mill/resolve/ResolveCore.scala
@@ -94,7 +94,7 @@ private object ResolveCore {
       remainingQuery: List[Segment],
       current: Resolved,
       querySoFar: Segments,
-      seenModules: Set[Class[_]] = Set.empty,
+      seenModules: Set[Class[_]],
       cache: Cache
   ): Result = {
     def moduleClasses(resolved: Iterable[Resolved]): Set[Class[_]] = {

--- a/main/resolve/src/mill/resolve/ResolveCore.scala
+++ b/main/resolve/src/mill/resolve/ResolveCore.scala
@@ -57,9 +57,13 @@ private object ResolveCore {
    * just cache all module instantiations and re-use them to avoid repeatedly instantiating the
    * same module
    */
-  class Cache(val instantiatedModules: collection.mutable.Map[Segments, Either[String, Module]] = collection.mutable.Map(),
-              decodedNames: collection.mutable.Map[String, String] = collection.mutable.Map(),
-              methods: collection.mutable.Map[String, Array[(java.lang.reflect.Method, String)]] = collection.mutable.Map()) {
+  class Cache(
+      val instantiatedModules: collection.mutable.Map[Segments, Either[String, Module]] =
+        collection.mutable.Map(),
+      decodedNames: collection.mutable.Map[String, String] = collection.mutable.Map(),
+      methods: collection.mutable.Map[String, Array[(java.lang.reflect.Method, String)]] =
+        collection.mutable.Map()
+  ) {
     def decode(s: String): String = {
       decodedNames.getOrElseUpdate(s, scala.reflect.NameTransformer.decode(s))
     }
@@ -157,7 +161,7 @@ private object ResolveCore {
                   m.cls,
                   None,
                   current.segments,
-                  cache = cache,
+                  cache = cache
                 )
 
               case pattern if pattern.startsWith("__:") =>
@@ -242,9 +246,8 @@ private object ResolveCore {
       rootModule: BaseModule,
       segments: Segments,
       cache: Cache
-  ): Either[String, Module] = cache.instantiatedModules.getOrElseUpdate (
-    segments,
-    {
+  ): Either[String, Module] = cache.instantiatedModules.getOrElseUpdate(
+    segments, {
       segments.value.foldLeft[Either[String, Module]](Right(rootModule)) {
         case (Right(current), Segment.Label(s)) =>
           assert(s != "_", s)
@@ -291,7 +294,8 @@ private object ResolveCore {
   ): Either[String, Seq[Resolved]] = {
     if (seenModules.contains(cls)) Left(cyclicModuleErrorMsg(segments))
     else {
-      val errOrDirect = resolveDirectChildren(rootModule, cls, nameOpt, segments, typePattern, cache)
+      val errOrDirect =
+        resolveDirectChildren(rootModule, cls, nameOpt, segments, typePattern, cache)
       val directTraverse = resolveDirectChildren(rootModule, cls, nameOpt, segments, Nil, cache)
 
       val errOrModules = directTraverse.map { modules =>

--- a/main/resolve/src/mill/resolve/ResolveCore.scala
+++ b/main/resolve/src/mill/resolve/ResolveCore.scala
@@ -62,7 +62,7 @@ private object ResolveCore {
       val instantiatedModules: collection.mutable.Map[Segments, Either[String, Module]] =
         collection.mutable.Map(),
       decodedNames: collection.mutable.Map[String, String] = collection.mutable.Map(),
-      methods: collection.mutable.Map[String, Array[(java.lang.reflect.Method, String)]] =
+      methods: collection.mutable.Map[Class[_], Array[(java.lang.reflect.Method, String)]] =
         collection.mutable.Map()
   ) {
     def decode(s: String): String = {
@@ -70,7 +70,7 @@ private object ResolveCore {
     }
 
     def getMethods(cls: Class[_]): Array[(Method, String)] = {
-      methods.getOrElseUpdate(cls.getName, Reflect.getMethods(cls, decode))
+      methods.getOrElseUpdate(cls, Reflect.getMethods(cls, decode))
     }
   }
 

--- a/main/src/mill/main/MainModule.scala
+++ b/main/src/mill/main/MainModule.scala
@@ -249,7 +249,7 @@ trait MainModule extends BaseModule0 {
                 .millDiscover
                 .value
                 .get(t.ctx.enclosingCls)
-                .flatMap(_._2.find(_.name == t.ctx.segments.parts.last))
+                .flatMap(_._2.find(_.name == t.ctx.segments.last.value))
                 .headOption
 
               mainDataOpt match {

--- a/main/src/mill/main/SelectiveExecution.scala
+++ b/main/src/mill/main/SelectiveExecution.scala
@@ -11,7 +11,7 @@ private[mill] object SelectiveExecution {
   implicit val rw: upickle.default.ReadWriter[Metadata] = upickle.default.macroRW
 
   object Metadata {
-    def apply(evaluator: Evaluator, tasks: Seq[String]): Either[String, Metadata] = {
+    def compute(evaluator: Evaluator, tasks: Seq[String]): Either[String, Metadata] = {
       for (transitive <- plan0(evaluator, tasks)) yield {
         val inputTasksToLabels: Map[Task[_], String] = transitive
           .collect { case Terminal.Labelled(task: InputImpl[_], segments) =>

--- a/main/src/mill/main/SelectiveExecution.scala
+++ b/main/src/mill/main/SelectiveExecution.scala
@@ -143,7 +143,7 @@ private[mill] object SelectiveExecution {
     if (oldMetadataTxt == "") Right(tasks.toSet)
     else {
       val oldMetadata = upickle.default.read[SelectiveExecution.Metadata](oldMetadataTxt)
-      for (newMetadata <- SelectiveExecution.Metadata(evaluator, tasks)) yield {
+      for (newMetadata <- SelectiveExecution.Metadata.compute(evaluator, tasks)) yield {
         SelectiveExecution.computeDownstream(evaluator, tasks, oldMetadata, newMetadata)
           .collect { case n: NamedTask[_] => n.ctx.segments.render }
           .toSet

--- a/main/src/mill/main/SelectiveExecutionModule.scala
+++ b/main/src/mill/main/SelectiveExecutionModule.scala
@@ -16,7 +16,8 @@ trait SelectiveExecutionModule extends mill.define.Module {
    */
   def prepare(evaluator: Evaluator, tasks: String*): Command[Unit] =
     Task.Command(exclusive = true) {
-      val res: Either[String, Unit] = SelectiveExecution.Metadata(evaluator, tasks)
+      val res: Either[String, Unit] = SelectiveExecution.Metadata
+        .compute(evaluator, if (tasks.isEmpty) Seq("__") else tasks)
         .map(SelectiveExecution.saveMetadata(evaluator, _))
 
       res match {


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/4129 and https://github.com/com-lihaoyi/mill/issues/4026. We never really looked at performance at this stuff before, but in order to support `selective.prepare __` (the default of `selective.prepare`) we need to improve these bottlenecks 

* Introduces the `ResolveCore#Cache` class that holds mutable dictionaries to memo-ize various expensive parts of the task resolution logic

* Lots of micro-optimizations in various places: cache `Segments#hashCode`, avoid calling `Segments#render` for sorting or `Segments#part` for taking the last part, etc.

Brings down `time ./mill plan __` from ~60s to ~3s