### PR TITLE
Fix Prompt Logger

### DIFF
--- a/main/client/src/mill/main/client/ServerLauncher.java
+++ b/main/client/src/mill/main/client/ServerLauncher.java
@@ -116,11 +116,6 @@ public abstract class ServerLauncher {
   }
 
   int run(Path serverDir, boolean setJnaNoSys, Locks locks) throws Exception {
-    // Clear out run-related files from the server folder to make sure we
-    // never hit issues where we are reading the files from a previous run
-    Files.deleteIfExists(serverDir.resolve(ServerFiles.exitCode));
-    Files.deleteIfExists(serverDir.resolve(ServerFiles.terminfo));
-    Files.deleteIfExists(serverDir.resolve(ServerFiles.runArgs));
 
     try (OutputStream f = Files.newOutputStream(serverDir.resolve(ServerFiles.runArgs))) {
       f.write(System.console() != null ? 1 : 0);

--- a/runner/client/src/mill/runner/client/MillClientMain.java
+++ b/runner/client/src/mill/runner/client/MillClientMain.java
@@ -54,7 +54,7 @@ public class MillClientMain {
               }
 
               public void preRun(Path serverDir) throws Exception {
-                MillProcessLauncher.runTermInfoThread(serverDir);
+                MillProcessLauncher.prepareMillRunFolder(serverDir);
               }
             };
         int exitCode = launcher.acquireLocksAndRun(OutFiles.out).exitCode;

--- a/runner/client/src/mill/runner/client/MillProcessLauncher.java
+++ b/runner/client/src/mill/runner/client/MillProcessLauncher.java
@@ -33,7 +33,7 @@ public class MillProcessLauncher {
     boolean interrupted = false;
 
     try {
-      MillProcessLauncher.runTermInfoThread(processDir);
+      MillProcessLauncher.prepareMillRunFolder(processDir);
       Process p = configureRunMillProcess(builder, processDir);
       return p.waitFor();
 
@@ -255,7 +255,13 @@ public class MillProcessLauncher {
     }
   }
 
-  public static void runTermInfoThread(Path serverDir) throws Exception {
+  public static void prepareMillRunFolder(Path serverDir) throws Exception {
+    // Clear out run-related files from the server folder to make sure we
+    // never hit issues where we are reading the files from a previous run
+    Files.deleteIfExists(serverDir.resolve(ServerFiles.exitCode));
+    Files.deleteIfExists(serverDir.resolve(ServerFiles.terminfo));
+    Files.deleteIfExists(serverDir.resolve(ServerFiles.runArgs));
+
     Path sandbox = serverDir.resolve(ServerFiles.sandbox);
     Files.createDirectories(sandbox);
     boolean tputExists = checkTputExists();


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/4133

The problem was that the cleanup-process-folder logic running in `ServerLauncher#run` was taking place after the `terminfo` file was initially created in `runTermInfoThread`, resulting in it wiping out the `terminfo` file that then never gets re-created until you resize the terminal. 

This PR moves the cleanup logic to always run just before the `terminfo` file is created, renaming `runTermInfoThread` into `prepareMillRunFolder` and making it responsible for both cleanup of the mill process folder as well as initialization with new `terminfo` metadata