### PR TITLE
Add `Task.nonSelective` 

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -646,7 +646,7 @@ def formatDep(dep: Dep) = {
 def listIn(path: os.Path) = interp.watchValue(os.list(path).map(_.last))
 
 object idea extends MillPublishScalaModule {
-  def moduleDeps = Seq(build.scalalib, build.runner)
+  def moduleDeps = Seq(build.scalalib, build.scalajslib, build.scalanativelib, build.runner)
 }
 
 

--- a/dist/package.mill
+++ b/dist/package.mill
@@ -5,7 +5,20 @@ import mill.api.JarManifest
 import de.tobiasroeser.mill.vcs.version.VcsVersion
 import $file.ci.upload
 
-object `package` extends RootModule with build.MillPublishJavaModule {
+
+object `package` extends RootModule with DistModule{
+
+  object kotlinlib extends DistModule{
+    def moduleDeps = super.moduleDeps ++ Seq(build.kotlinlib)
+  }
+  object javascriptlib extends DistModule{
+    def moduleDeps = super.moduleDeps ++ Seq(build.javascriptlib)
+  }
+  object pythonlib extends DistModule{
+    def moduleDeps = super.moduleDeps ++ Seq(build.pythonlib)
+  }
+}
+trait DistModule extends build.MillPublishJavaModule {
 
   /**
    * Version of [[dist]] meant for local integration testing within the Mill
@@ -15,7 +28,12 @@ object `package` extends RootModule with build.MillPublishJavaModule {
   object dist0 extends build.MillPublishJavaModule {
     // disable scalafix here because it crashes when a module has no sources
     def fix(args: String*): Command[Unit] = Task.Command {}
-    def moduleDeps = Seq(build.runner, build.idea)
+    def moduleDeps = Seq(
+      build.runner,
+      build.idea,
+      build.scalajslib,
+      build.scalanativelib
+    )
 
     def testTransitiveDeps = build.runner.testTransitiveDeps() ++ Seq(
       build.main.graphviz.testDep(),

--- a/docs/modules/ROOT/pages/large/selective-execution.adoc
+++ b/docs/modules/ROOT/pages/large/selective-execution.adoc
@@ -53,3 +53,12 @@ def myProjectVersion: T[String] = Task.Input {
   whether on disk locally or printing it out (e.g via `cat`) on your CI machines to diagnose issues
   there. This would give you a richer view of what source tasks or inputs are the ones actually
   triggered the invalidation, and what tasks were just invalidated due to being downstream of them.
+
+
+== Non-Selective Tasks
+
+
+include::partial$example/large/selective/10-non-selective.adoc[]
+
+
+

--- a/example/large/selective/10-non-selective/build.mill
+++ b/example/large/selective/10-non-selective/build.mill
@@ -1,0 +1,49 @@
+// In some circumstances, you may want to disable selective execution for
+// certain task dependencies. For example, you may have a task that contains its own
+// test suite, and so exercising all downstream test suites during selective
+// execution would be redundant. You can make a task dependency not considered
+// during selective execution via `Task.NonSelective`:
+
+package build
+import mill._
+
+object qux extends mill.define.Module {
+  def quxSource = Task.Source(millSourcePath / "qux.txt")
+
+  def quxNonSelective = Task.nonSelective(quxSource)
+
+  def quxSelective = Task { quxSource() }
+
+  def quxCommandNonSelective() = Task.Command {
+    System.out.println("Computing quxCommandNonSelective")
+    quxNonSelective().path
+  }
+  def quxCommandSelective() = Task.Command {
+    System.out.println("Computing quxCommandSelective")
+    quxSelective().path
+  }
+}
+
+// In this example, `quxNonSelective` is an anonymous `Task.NonSelective`, meaning that
+// dependencies on `quxNonSelective` are not considered during selective execution. Thus,
+// if you make a change to `qux/qux.txt`, only `quxCommandSelective` is run, while
+// `quxCommandNonSelective` is ignored:
+
+/** Usage
+
+> ./mill selective.prepare qux._
+
+> echo "" >> qux/qux.txt
+
+> ./mill selective.resolve qux._ # does not resolve `quxCommandNonSelective`
+qux.quxSource
+qux.quxSelective
+qux.quxCommandSelective
+
+> ./mill selective.run qux._ # does not run `quxCommandNonSelective`
+Computing quxCommandSelective
+
+*/
+
+// `Task.NonSelective` can be used to wrap any task reference to ignore it during selective
+// execution.

--- a/example/package.mill
+++ b/example/package.mill
@@ -51,6 +51,18 @@ object `package` extends RootModule with Module {
     object publishing extends Cross[ExampleCrossModuleKotlin](build.listIn(millSourcePath / "publishing"))
     object web extends Cross[ExampleCrossModuleKotlin](build.listIn(millSourcePath / "web"))
   }
+
+  trait ExampleCrossModuleKotlin extends ExampleCrossModuleJava {
+
+    override def localLauncher = build.dist.kotlinlib.launcher()
+    override def lineTransform(line: String) = this.millModuleSegments.parts.last match {
+      case "1-test-suite" => line
+        .replace("mill bar.test bar.BarTests.hello", "kotest_filter_tests='hello' kotest_filter_specs='bar.BarTests' ./mill bar.test")
+        .replace("compiling 1 ... source...", "Compiling 1 ... source...")
+      case _ => line
+    }
+  }
+
   object scalalib extends Module {
     object basic extends Cross[ExampleCrossModule](build.listIn(millSourcePath / "basic"))
     object module extends Cross[ExampleCrossModule](build.listIn(millSourcePath / "module"))
@@ -61,15 +73,25 @@ object `package` extends RootModule with Module {
     object web extends Cross[ExampleCrossModule](build.listIn(millSourcePath / "web"))
     object native extends Cross[ExampleCrossModule](build.listIn(millSourcePath / "native"))
   }
+
   object javascriptlib extends Module {
-    object basic extends Cross[ExampleCrossModule](build.listIn(millSourcePath / "basic"))
-    object testing extends Cross[ExampleCrossModule](build.listIn(millSourcePath / "testing"))
+    object basic extends Cross[ExampleCrossModuleJavascript](build.listIn(millSourcePath / "basic"))
+    object testing extends Cross[ExampleCrossModuleJavascript](build.listIn(millSourcePath / "testing"))
   }
+
+  trait ExampleCrossModuleJavascript extends ExampleCrossModule{
+    override def localLauncher = build.dist.javascriptlib.launcher()
+  }
+
   object pythonlib extends Module {
-    object basic extends Cross[ExampleCrossModule](build.listIn(millSourcePath / "basic"))
-    object dependencies extends Cross[ExampleCrossModule](build.listIn(millSourcePath / "dependencies"))
-    object publishing extends Cross[ExampleCrossModule](build.listIn(millSourcePath / "publishing"))
-    object module extends Cross[ExampleCrossModule](build.listIn(millSourcePath / "module"))
+    object basic extends Cross[ExampleCrossModulePython](build.listIn(millSourcePath / "basic"))
+    object dependencies extends Cross[ExampleCrossModulePython](build.listIn(millSourcePath / "dependencies"))
+    object publishing extends Cross[ExampleCrossModulePython](build.listIn(millSourcePath / "publishing"))
+    object module extends Cross[ExampleCrossModulePython](build.listIn(millSourcePath / "module"))
+  }
+
+  trait ExampleCrossModulePython extends ExampleCrossModule{
+    override def localLauncher = build.dist.pythonlib.launcher()
   }
 
   object cli extends Module{
@@ -105,16 +127,6 @@ object `package` extends RootModule with Module {
     object jvmcode extends Cross[ExampleCrossModule](build.listIn(millSourcePath / "jvmcode"))
     object python extends Cross[ExampleCrossModule](build.listIn(millSourcePath / "python"))
     object typescript extends Cross[ExampleCrossModule](build.listIn(millSourcePath / "typescript"))
-  }
-
-  trait ExampleCrossModuleKotlin extends ExampleCrossModuleJava {
-
-    override def lineTransform(line: String) = this.millModuleSegments.parts.last match {
-      case "1-test-suite" => line
-        .replace("mill bar.test bar.BarTests.hello", "kotest_filter_tests='hello' kotest_filter_specs='bar.BarTests' ./mill bar.test")
-        .replace("compiling 1 ... source...", "Compiling 1 ... source...")
-      case _ => line
-    }
   }
 
   trait ExampleCrossModuleJava extends ExampleCrossModule {

--- a/integration/invalidation/selective-execution/resources/build.mill
+++ b/integration/invalidation/selective-execution/resources/build.mill
@@ -28,3 +28,19 @@ object bar extends mill.define.TaskModule {
 
   def defaultCommandName(): String = "barCommand"
 }
+object qux extends mill.define.Module {
+  def quxTask = Task.Source(millSourcePath / "qux.txt")
+
+  def quxNonSelective = Task.nonSelective(quxTask)
+  def quxSelective = Task{ quxTask() }
+
+  def quxCommandNonSelective() = Task.Command {
+    System.out.println("Computing quxCommandNonSelective")
+    quxNonSelective().path
+  }
+  def quxCommandSelective() = Task.Command {
+    System.out.println("Computing quxCommandSelective")
+    quxSelective().path
+  }
+
+}

--- a/integration/invalidation/selective-execution/resources/qux/qux.txt
+++ b/integration/invalidation/selective-execution/resources/qux/qux.txt
@@ -1,0 +1,1 @@
+Qux Contents

--- a/integration/invalidation/selective-execution/src/SelectiveExecutionTests.scala
+++ b/integration/invalidation/selective-execution/src/SelectiveExecutionTests.scala
@@ -266,5 +266,18 @@ object SelectiveExecutionTests extends UtestIntegrationTestSuite {
           Seq("bar.barCommandRenamed", "foo.fooCommand", "foo.fooTaskRenamed")
       )
     }
+    test("non-selective") - integrationTest { tester =>
+      import tester._
+      eval(("selective.prepare", "qux._"), check = true)
+
+      modifyFile(workspacePath / "qux" / "qux.txt", _ + "!")
+
+      val cached = eval(("selective.resolve", "qux._"))
+
+      assert(
+        cached.out.linesIterator.toSet ==
+          Set("qux.quxTask", "qux.quxSelective", "qux.quxCommandSelective")
+      )
+    }
   }
 }

--- a/integration/package.mill
+++ b/integration/package.mill
@@ -36,6 +36,8 @@ object `package` extends RootModule {
     def runClasspath: T[Seq[PathRef]]
     def localRunClasspath: T[Seq[PathRef]]
     def forkEnv: T[Map[String, String]]
+
+    def localLauncher = Task{ build.dist.launcher() }
     trait ModeModule extends build.MillBaseTestsModule {
 
       def mode: String = millModuleSegments.parts.last
@@ -54,9 +56,10 @@ object `package` extends RootModule {
 
       def forkArgs = Task { super.forkArgs() ++ build.dist.forkArgs() }
 
+
       def testReleaseEnv =
         if (mode == "local")
-          T { Map("MILL_INTEGRATION_LAUNCHER" -> build.dist.launcher().path.toString()) }
+          T { Map("MILL_INTEGRATION_LAUNCHER" -> localLauncher().path.toString()) }
         else T { Map("MILL_INTEGRATION_LAUNCHER" -> testMill().path.toString()) }
 
       def resources = IntegrationTestModule.this.resources()

--- a/main/src/mill/main/SelectiveExecution.scala
+++ b/main/src/mill/main/SelectiveExecution.scala
@@ -109,10 +109,12 @@ private[mill] object SelectiveExecution {
 
     val changedRootTasks = (changedInputNames ++ changedCodeNames)
       .flatMap(namesToTasks.get(_): Option[Task[_]])
+      .filter(_.selective)
 
     val allNodes = breadthFirst(terminals.map(_.task: Task[_]))(_.inputs)
     val downstreamEdgeMap = allNodes
       .flatMap(t => t.inputs.map(_ -> t))
+      .filter { t => t._1.selective && t._2.selective }
       .groupMap(_._1)(_._2)
 
     breadthFirst(changedRootTasks)(downstreamEdgeMap.getOrElse(_, Nil))

--- a/runner/package.mill
+++ b/runner/package.mill
@@ -9,17 +9,17 @@ object `package` extends RootModule with build.MillPublishScalaModule {
     def moduleDeps = Seq(build.main.client)
   }
 
+  def ivyDeps = Agg(
+    build.Deps.scalaparse
+  )
   def moduleDeps = Seq(
-    build.scalalib,
-    build.kotlinlib,
-    build.scalajslib,
-    build.scalanativelib,
-    build.javascriptlib,
-    build.pythonlib,
+
     build.bsp,
     linenumbers,
     build.main.codesig,
     build.main.server,
+    build.main,
+    build.scalalib,
     client
   )
   def skipPreviousVersions: T[Seq[String]] = Seq("0.11.0-M7")


### PR DESCRIPTION
This allows us to wrap task dependencies to not participate in selective execution.

For now this PR only implements it at the task-level, which will be sufficient for usage in Mill's own build's integration and example tests. Integrating it into `JavaModule` etc. is left for future followups