### PR TITLE
Revert "Always check `available()` in `InputPumper` to avoid burning CPU (#4095)"

### DIFF
--- a/main/client/src/mill/main/client/InputPumper.java
+++ b/main/client/src/mill/main/client/InputPumper.java
@@ -38,9 +38,9 @@ public class InputPumper implements Runnable {
       while (running) {
         if (!runningCheck.getAsBoolean()) {
           running = false;
-          // We need to check `.available` and avoid calling `.read`, because if
-          // we call `.read` and there is nothing to read, it can unnecessarily delay
-          // the JVM exit by 350ms https://stackoverflow.com/questions/48951611/blocking-on-stdin-makes-java-process-take-350ms-more-to-exit
+          // We need to check `.available` and avoid calling `.read`, because if we call `.read`
+          // and there is nothing to read, it can unnecessarily delay the JVM exit by 350ms
+          // https://stackoverflow.com/questions/48951611/blocking-on-stdin-makes-java-process-take-350ms-more-to-exit
         } else if (checkAvailable && src.available() == 0) Thread.sleep(1);
         else {
           int n;

--- a/main/client/src/mill/main/client/InputPumper.java
+++ b/main/client/src/mill/main/client/InputPumper.java
@@ -49,9 +49,9 @@ public class InputPumper implements Runnable {
           } catch (Exception e) {
             n = -1;
           }
-          if (n == -1) {
-            running = false;
-          } else {
+          if (n == -1) running = false;
+          else if (n == 0) Thread.sleep(1);
+          else {
             try {
               dest.write(buffer, 0, n);
               dest.flush();

--- a/main/client/src/mill/main/client/InputPumper.java
+++ b/main/client/src/mill/main/client/InputPumper.java
@@ -36,7 +36,9 @@ public class InputPumper implements Runnable {
     byte[] buffer = new byte[1024];
     try {
       while (running) {
-        if (!runningCheck.getAsBoolean()) running = false;
+        if (!runningCheck.getAsBoolean()) {
+          running = false;
+        } else if (checkAvailable && src.available() == 0) Thread.sleep(1);
         else {
           int n;
           try {
@@ -44,9 +46,9 @@ public class InputPumper implements Runnable {
           } catch (Exception e) {
             n = -1;
           }
-          if (n == -1) running = false;
-          else if (n == 0) Thread.sleep(1);
-          else {
+          if (n == -1) {
+            running = false;
+          } else {
             try {
               dest.write(buffer, 0, n);
               dest.flush();

--- a/main/client/src/mill/main/client/InputPumper.java
+++ b/main/client/src/mill/main/client/InputPumper.java
@@ -38,6 +38,9 @@ public class InputPumper implements Runnable {
       while (running) {
         if (!runningCheck.getAsBoolean()) {
           running = false;
+          // We need to check `.available` and avoid calling `.read`, because if
+          // we call `.read` and there is nothing to read, it can unnecessarily delay
+          // the JVM exit by 350ms https://stackoverflow.com/questions/48951611/blocking-on-stdin-makes-java-process-take-350ms-more-to-exit
         } else if (checkAvailable && src.available() == 0) Thread.sleep(1);
         else {
           int n;


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/4158

This hits some JVM limitations that significantly slow down the process exit, unnecessarily. Added a comment to the code so we don't forget again