### PR TITLE
Reduce Java Heap for Mill Client

### DIFF
--- a/dist/package.mill
+++ b/dist/package.mill
@@ -129,7 +129,11 @@ object `package` extends RootModule with InstallModule {
       .mkString("\r\n")
 
     os.write(vmOptionsFile, millOptionsContent)
-    val jvmArgs = otherArgs ++ List(s"-DMILL_OPTIONS_PATH=$vmOptionsFile")
+    val jvmArgs = otherArgs ++ List(
+      // Avoid reserving a lot of memory for the client, as the client only forward information
+      "-Xmx32m",
+      s"-DMILL_OPTIONS_PATH=$vmOptionsFile"
+    )
     val classpath = runClasspath().map(_.path.toString)
     val classpathJar = Task.dest / "classpath.jar"
     Jvm.createClasspathPassingJar(classpathJar, runClasspath().map(_.path))


### PR DESCRIPTION
The Mill Client only forwards requests and therefore does not need much memory.
However, Java doesn't know that an allocates a large heap based on the machines memory size.

Therefore, give a way lower heap limit,
creating a leaner client memory wise.

Example on my machine:
- Before: A Mill client reserved ~500MByte
- After: A Mill client reserves the specified 24Mbyte

This is mostly relevant for a long running mill client (examples  `--watch` clients, `-i --no-build-lock` and --bsp`).