### PR TITLE
Split out `downloadTestRepo` from `testRepoRoot` in mill's own build

### DIFF
--- a/example/package.mill
+++ b/example/package.mill
@@ -286,23 +286,25 @@ object `package` extends RootModule with Module {
     val (repoPath, repoHash) = repoInfo(crossValue)
     def repoSlug = repoPath.split("/").last
 
-    def testRepoRoot = Task {
+    def downloadedRepo = Task{
       shared.downloadTestRepo(repoPath, repoHash, T.dest)
       val wrapperFolder = T.dest / s"$repoSlug-$repoHash"
+      PathRef(wrapperFolder)
+    }
 
-      os.makeDir(T.dest / "merged")
-      os.copy(wrapperFolder, T.dest / "merged", mergeFolders = true)
-      os.remove.all(wrapperFolder)
+    def testRepoRoot = Task {
+      val wrapperFolder = downloadedRepo().path
+      os.copy(wrapperFolder, T.dest, mergeFolders = true)
       os.copy(
         super.testRepoRoot().path,
-        T.dest / "merged",
+        T.dest,
         mergeFolders = true,
         replaceExisting = true
       )
-      os.remove.all(T.dest / "merged" / ".mill-version")
+      os.remove.all(T.dest / ".mill-version")
 
-      os.remove.all(T.dest / "merged" / "build.sc")
-      PathRef(T.dest / "merged")
+      os.remove.all(T.dest / "build.sc")
+      PathRef(T.dest)
     }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/4176. `testRepoRoot.super` always needs to re-evaluate, because it is a `Task.Source`. But if we split the `downloadTestRepo` call into a separate cached task that ensures the download is cached and can be re-used every time our `testRepoRoot` override needs to re-evaluate