### PR TITLE
Fix pumper thread leak

### DIFF
--- a/main/api/src/mill/api/SystemStreams.scala
+++ b/main/api/src/mill/api/SystemStreams.scala
@@ -78,9 +78,9 @@ object SystemStreams {
     // ensures that interactive applications involving console IO work, as the
     // presence of a `PumpedProcess` would cause most interactive CLIs (e.g.
     // scala console, REPL, etc.) to misbehave
-    val inheritIn =
+    val inheritIn: os.ProcessInput =
       if (systemStreams.in eq original.in) os.InheritRaw
-      else new PumpedProcessInput
+      else DummyInputStream
 
     val inheritOut =
       if (systemStreams.out eq original.out) os.InheritRaw

--- a/main/api/src/mill/api/SystemStreams.scala
+++ b/main/api/src/mill/api/SystemStreams.scala
@@ -78,6 +78,10 @@ object SystemStreams {
     // ensures that interactive applications involving console IO work, as the
     // presence of a `PumpedProcess` would cause most interactive CLIs (e.g.
     // scala console, REPL, etc.) to misbehave
+    //
+    // Use `DummyInputStream` for the `stdin` if we are not inheriting the raw streams,
+    // because otherwise sharing the same `stdin` stream between multiple concurrent
+    // tasks doesn't make sense (even though sharing the same `stdout` is generally fine)
     val inheritIn: os.ProcessInput =
       if (systemStreams.in eq original.in) os.InheritRaw
       else DummyInputStream

--- a/main/client/src/mill/main/client/InputPumper.java
+++ b/main/client/src/mill/main/client/InputPumper.java
@@ -36,16 +36,13 @@ public class InputPumper implements Runnable {
     byte[] buffer = new byte[1024];
     try {
       while (running) {
-        // We need to check `.available` and avoid calling `.read`, because if we call `.read`
-        // and there is nothing to read, it can unnecessarily delay the JVM exit by 350ms
-        // https://stackoverflow.com/questions/48951611/blocking-on-stdin-makes-java-process-take-350ms-more-to-exit
-        if (checkAvailable && src.available() == 0) {
-          // if `runningCheck` fails, we do not continue sleeping and waiting for input,
-          // and instead exit the loop since there is nothing to read now and there will be
-          // nothing to read going forward
-          if (!runningCheck.getAsBoolean()) running = false;
-          else Thread.sleep(1);
-        } else {
+        if (!runningCheck.getAsBoolean()) {
+          running = false;
+          // We need to check `.available` and avoid calling `.read`, because if we call `.read`
+          // and there is nothing to read, it can unnecessarily delay the JVM exit by 350ms
+          // https://stackoverflow.com/questions/48951611/blocking-on-stdin-makes-java-process-take-350ms-more-to-exit
+        } else if (checkAvailable && src.available() == 0) Thread.sleep(1);
+        else {
           int n;
           try {
             n = src.read(buffer);

--- a/main/client/src/mill/main/client/InputPumper.java
+++ b/main/client/src/mill/main/client/InputPumper.java
@@ -36,13 +36,16 @@ public class InputPumper implements Runnable {
     byte[] buffer = new byte[1024];
     try {
       while (running) {
-        if (!runningCheck.getAsBoolean()) {
-          running = false;
-          // We need to check `.available` and avoid calling `.read`, because if we call `.read`
-          // and there is nothing to read, it can unnecessarily delay the JVM exit by 350ms
-          // https://stackoverflow.com/questions/48951611/blocking-on-stdin-makes-java-process-take-350ms-more-to-exit
-        } else if (checkAvailable && src.available() == 0) Thread.sleep(1);
-        else {
+        // We need to check `.available` and avoid calling `.read`, because if we call `.read`
+        // and there is nothing to read, it can unnecessarily delay the JVM exit by 350ms
+        // https://stackoverflow.com/questions/48951611/blocking-on-stdin-makes-java-process-take-350ms-more-to-exit
+        if (checkAvailable && src.available() == 0) {
+          // if `runningCheck` fails, we do not continue sleeping and waiting for input,
+          // and instead exit the loop since there is nothing to read now and there will be
+          // nothing to read going forward
+          if (!runningCheck.getAsBoolean()) running = false;
+          else Thread.sleep(1);
+        } else {
           int n;
           try {
             n = src.read(buffer);


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/4184

The basic problem is that we are spawning an `PumpedProcessInput` from the Mill server's redirected `stdin` to the stdin of any subprocess we spawn, but the `PumpedProcessInput`'s `InputPumper` thread only terminates on the source stream closing, and we never close the redirected `stdin` of the Mill server.

Reading from the shared `stdin` from multiple tasks/threads concurrently doesn't really make sense, so we should probably not use `PumpedProcessInput` at all and just pass in a `DummyInputStream` with zero data. Interactive use cases like consoles and repl are handled by the `os.InheritRaw` codepath anyway and so won't be affected. `stdout`/`stderr` aren't affected, because having multiple tasks/threads writing lines to the same output stream is probably fine (although we could probably do a better job at ensuring it is done at a line-by-line granularity without splitting of lines between threads/tasks)

Tested manually, ran the commands in the linked issue and verified that without this PR the leaked thread can be seen in `jstack`, but after this PR the leaked thread is no longer present

This might also fix some of the cases where enter-on-rerun for `--watch` stops worked, perhaps because a leaked `InputPumper` is grabbing the `\n` character before it can be read by the `Watching.scala` logic