### PR TITLE
Check if rt.jar is still necessary

### DIFF
--- a/main/api/src/mill/api/ClassLoader.scala
+++ b/main/api/src/mill/api/ClassLoader.scala
@@ -2,8 +2,6 @@ package mill.api
 
 import java.net.{URL, URLClassLoader}
 
-
-
 /**
  * Utilities for creating classloaders for running compiled Java/Scala code in
  * isolated classpaths.

--- a/main/api/src/mill/api/ClassLoader.scala
+++ b/main/api/src/mill/api/ClassLoader.scala
@@ -2,10 +2,7 @@ package mill.api
 
 import java.net.{URL, URLClassLoader}
 
-import java.nio.file.{FileAlreadyExistsException, FileSystemException}
 
-import mill.java9rtexport.Export
-import scala.util.Properties
 
 /**
  * Utilities for creating classloaders for running compiled Java/Scala code in

--- a/runner/src/mill/runner/MillMain.scala
+++ b/runner/src/mill/runner/MillMain.scala
@@ -6,7 +6,6 @@ import java.nio.file.StandardOpenOption
 import java.util.Locale
 import scala.jdk.CollectionConverters.*
 import scala.util.Properties
-import mill.java9rtexport.Export
 import mill.api.{MillException, SystemStreams, WorkspaceRoot, internal}
 import mill.bsp.{BspContext, BspServerResult}
 import mill.main.BuildInfo

--- a/runner/src/mill/runner/MillMain.scala
+++ b/runner/src/mill/runner/MillMain.scala
@@ -195,16 +195,6 @@ object MillMain {
 
                 val threadCount = Some(maybeThreadCount.toOption.get)
 
-                if (mill.main.client.Util.isJava9OrAbove) {
-                  val rt = config.home / Export.rtJarName
-                  if (!os.exists(rt)) {
-                    streams.err.println(
-                      s"Preparing Java ${System.getProperty("java.version")} runtime; this may take a minute or two ..."
-                    )
-                    Export.rtTo(rt.toIO, false)
-                  }
-                }
-
                 val bspContext =
                   if (bspMode) Some(new BspContext(streams, bspLog, config.home)) else None
 


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/4164

It's been around since we used to use Ammonite to compile scripts, and IIRC was necessary to make the in-memory Scala compiler work. We no longer go through that code path, so maybe we can get rid of it? AFAIK we now only use the Scala compiler through Zinc which manages this stuff itself