### PR TITLE
Honor the NO_COLOR env variable

### DIFF
--- a/docs/modules/ROOT/pages/cli/flags.adoc
+++ b/docs/modules/ROOT/pages/cli/flags.adoc
@@ -27,7 +27,7 @@ To see a cheat sheet of all the command line flags that Mill supports, you can u
 
 ```scala
 $ ./mill --help
-Mill Build Tool, version 0.12.0
+Mill Build Tool, version 0.12.5-13-0e02e6
 Usage: mill [options] task [task-options] [+ task ...]
 
 task cheat sheet:
@@ -60,6 +60,7 @@ options:
   -b --bell            Ring the bell once if the run completes successfully, twice if it fails.
   --bsp                Enable BSP server mode.
   --color <bool>       Toggle colored output; by default enabled only if the console is interactive
+                       and NO_COLOR environment variable is not set
   -d --debug           Show debug output on STDOUT
   --disable-callgraph  Disables fine-grained invalidation of tasks based on analyzing code changes.
                        If passed, you need to manually run `clean` yourself after build changes.

--- a/runner/src/mill/runner/MillCliConfig.scala
+++ b/runner/src/mill/runner/MillCliConfig.scala
@@ -107,7 +107,7 @@ case class MillCliConfig(
     )
     leftoverArgs: Leftover[String] = Leftover(),
     @arg(doc =
-      """Toggle colored output; by default enabled only if the console is interactive and NO_COLOR environment variable is not set"""
+      """Toggle colored output; by default enabled only if the console is interactive and NO_COLOR environment variable is not set (following https://no-color.org spec)"""
     )
     color: Option[Boolean] = None,
     @arg(

--- a/runner/src/mill/runner/MillCliConfig.scala
+++ b/runner/src/mill/runner/MillCliConfig.scala
@@ -107,7 +107,7 @@ case class MillCliConfig(
     )
     leftoverArgs: Leftover[String] = Leftover(),
     @arg(doc =
-      """Toggle colored output; by default enabled only if the console is interactive and NO_COLOR environment variable is not set (following https://no-color.org spec)"""
+      """Toggle colored output; by default enabled only if the console is interactive and NO_COLOR environment variable is not set"""
     )
     color: Option[Boolean] = None,
     @arg(

--- a/runner/src/mill/runner/MillCliConfig.scala
+++ b/runner/src/mill/runner/MillCliConfig.scala
@@ -106,7 +106,9 @@ case class MillCliConfig(
       doc = """The name or a pattern of the tasks(s) you want to build."""
     )
     leftoverArgs: Leftover[String] = Leftover(),
-    @arg(doc = """Toggle colored output; by default enabled only if the console is interactive""")
+    @arg(doc =
+      """Toggle colored output; by default enabled only if the console is interactive and NO_COLOR environment variable is not set"""
+    )
     color: Option[Boolean] = None,
     @arg(
       name = "disable-callgraph",

--- a/runner/src/mill/runner/MillMain.scala
+++ b/runner/src/mill/runner/MillMain.scala
@@ -162,7 +162,8 @@ object MillMain {
             (false, RunnerState.empty)
 
           case Right(config) =>
-            val colored = config.color.getOrElse(mainInteractive)
+            val noColorViaEnv = env.get("NO_COLOR").exists(v => v != "")
+            val colored = config.color.getOrElse(mainInteractive && !noColorViaEnv)
             val colors = if (colored) mill.util.Colors.Default else mill.util.Colors.BlackWhite
 
             if (!config.silent.value) {

--- a/runner/src/mill/runner/MillMain.scala
+++ b/runner/src/mill/runner/MillMain.scala
@@ -162,7 +162,7 @@ object MillMain {
             (false, RunnerState.empty)
 
           case Right(config) =>
-            val noColorViaEnv = env.get("NO_COLOR").exists(v => v != "")
+            val noColorViaEnv = env.get("NO_COLOR").exists(_.nonEmpty)
             val colored = config.color.getOrElse(mainInteractive && !noColorViaEnv)
             val colors = if (colored) mill.util.Colors.Default else mill.util.Colors.BlackWhite
 


### PR DESCRIPTION
When the NO_COLOR env variable is set,
then avoid coloring the terminal.

--color argument does overrides the env variable

Inspired by https://no-color.org
and asked in discussion: https://github.com/com-lihaoyi/mill/discussions/4170