### PR TITLE
Use `check=true` for ktlint `checkFormatAll` run

### DIFF
--- a/kotlinlib/src/mill/kotlinlib/ktlint/KtlintModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/ktlint/KtlintModule.scala
@@ -87,7 +87,7 @@ object KtlintModule extends ExternalModule with KtlintModule with TaskModule {
         Tasks.resolveMainDefault("__.sources")
   ): Command[Unit] = Task.Command {
     ktlintAction(
-      KtlintArgs(format = false, check = false),
+      KtlintArgs(format = false, check = true),
       T.sequence(sources.value)().flatten,
       ktlintConfig(),
       ktlintOptions(),


### PR DESCRIPTION
Fix small typo made in https://github.com/com-lihaoyi/mill/pull/4201 - `checkFormalAll` task should fail in case of formatting violations.