### PR TITLE
Disable scala-steward action

### DIFF
--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -1,6 +1,6 @@
 on:
-  schedule:
-    - cron: '0 0 * * *' # daily
+#  schedule:
+#    - cron: '0 0 * * *' # daily
   workflow_dispatch:
 
 name: Scala Steward


### PR DESCRIPTION
It does not trigger other actions somehow, so we don't get any feedback if bumps are working. It's also redundant to the Scala Steward runs by https://github.com/scala-steward.

Keep the `workflow_dispatch` setup nevertheless, to be able to run Scala Steward in case the official service fails again, since we see more error message when running it manually.
