### PR TITLE
Don't fail semanticDbData if classes dir does not exist

### DIFF
--- a/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
+++ b/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
@@ -224,7 +224,7 @@ object SemanticDbJavaModule {
 
     // copy over all found semanticdb-files into the target directory
     // but with corrected directory layout
-    os.walk(classesDir, preOrder = true)
+    if (os.exists(classesDir)) os.walk(classesDir, preOrder = true)
       .filter(os.isFile)
       .foreach { p =>
         if (p.ext == "semanticdb") {


### PR DESCRIPTION
Fixes https://github.com/joan38/mill-scalafix/issues/213