### PR TITLE
Run android CI job without parallelism

### DIFF
--- a/.github/workflows/post-build-selective.yml
+++ b/.github/workflows/post-build-selective.yml
@@ -66,7 +66,11 @@ jobs:
 
       - run: ./mill -i -k selective.resolve ${{ inputs.millargs }}
 
+      - run: ./mill -i -j1 -k selective.run ${{ inputs.millargs }}
+        if: ${{ inputs.install-android-sdk }}
+
       - run: ./mill -i -k selective.run ${{ inputs.millargs }}
+        if: ${{ !inputs.install-android-sdk }}
 
       - run: 'taskkill -f -im java* && rm -rf out/mill-server/*'
         if: startsWith(inputs.os, 'windows')


### PR DESCRIPTION
Cherry-picked from https://github.com/com-lihaoyi/mill/pull/4188/files, hopefully improves some of the flakiness we've been seeing