### PR TITLE
Replace waiting for android emulator with a sleep and a list device call to verify emulator is running

### DIFF
--- a/example/android/javalib/1-hello-world/build.mill
+++ b/example/android/javalib/1-hello-world/build.mill
@@ -123,8 +123,8 @@ object app extends AndroidAppModule {
 
 > ./mill show app.startAndroidEmulator
 
-> ./mill show app.waitForDevice
-...emulator-5554...
+> sleep 20 && ./mill show app.adbDevices
+...emulator-5554...device...
 
 > ./mill show app.it | grep '"OK (1 test)"'
 ..."OK (1 test)",

--- a/example/android/kotlinlib/1-hello-kotlin/build.mill
+++ b/example/android/kotlinlib/1-hello-kotlin/build.mill
@@ -119,13 +119,13 @@ object app extends AndroidAppKotlinModule {
 
 > ./mill app.createAndroidVirtualDevice
 
-> sleep 60 && ./mill show app.startAndroidEmulator
+> ./mill show app.startAndroidEmulator
 
-> ./mill show app.waitForDevice
-...emulator-5556...
+> sleep 20 && ./mill show app.adbDevices
+...emulator-5556...device...
 
 > ./mill show app.it | grep '"OK (1 test)"'
- ..."OK (1 test)",
+..."OK (1 test)",
 
 > cat out/app/it/test.json | grep '"OK (1 test)"'
 ..."OK (1 test)"...

--- a/scalalib/src/mill/javalib/android/AndroidAppModule.scala
+++ b/scalalib/src/mill/javalib/android/AndroidAppModule.scala
@@ -810,7 +810,7 @@ trait AndroidAppModule extends JavaModule {
    *
    * @return The log line that indicates the emulator is ready
    */
-  def startAndroidEmulator: T[Option[String]] = Task {
+  def startAndroidEmulator: T[String] = Task {
     val ciSettings = Seq(
       "-no-snapshot-save",
       "-no-window",
@@ -848,7 +848,11 @@ trait AndroidAppModule extends JavaModule {
 
     T.log.info(s"Emulator started with message $bootMessage")
 
-    bootMessage
+    bootMessage.get
+  }
+
+  def adbDevices: T[String] = Task {
+    os.call((androidSdkModule().adbPath().path, "devices", "-l")).out.text()
   }
 
   def waitForDevice: Target[String] = Task {


### PR DESCRIPTION
I've tried to replicate why the timeouts related to the android emulator that happen in github actions. It seems that  the `adb wait-for-device` is stuck although I cannot replicate it locally and the kotlin example does not suffer the same issue.

So for now, I added some wait time after start emulator and a call to `adb device` to verify the device is indeed present and it seems to be working.

This should work for the time being and make the job green until we create a better alternative.

Small change included: Since we throw an error if we don't detect the boot notification of start emulator, I changed the `startAndroidEmulator` signature from `Option[String]` to `String`

Linking the green job on my copy for reference: https://github.com/vaslabs-ltd/mill/actions/runs/12651834850/job/35253442650