### PR TITLE
Improve debug logging for `integration.ide[bsp-server].local`

### DIFF
--- a/integration/ide/bsp-server/src/BspServerTestUtil.scala
+++ b/integration/ide/bsp-server/src/BspServerTestUtil.scala
@@ -63,7 +63,7 @@ object BspServerTestUtil {
         value,
         implicitly[ClassTag[T]].runtimeClass
       )
-      lazy val expectedJsonStr = expectedValueOpt match{
+      lazy val expectedJsonStr = expectedValueOpt match {
         case Some(v) => gson.toJson(v, implicitly[ClassTag[T]].runtimeClass)
         case None => ""
       }
@@ -75,9 +75,10 @@ object BspServerTestUtil {
           false,
           if (exists) {
             val diff = os.call((
-              "git", "diff",
-              os.temp(jsonStr, suffix = "jsonStr"),
-              os.temp(expectedJsonStr, suffix = "expectedJsonStr")
+              "git",
+              "diff",
+              os.temp(jsonStr, suffix = s"${snapshotPath.last}-jsonStr"),
+              os.temp(expectedJsonStr, suffix = s"${snapshotPath.last}-expectedJsonStr")
             ))
             s"""Error: value differs from snapshot in $snapshotPath
                |

--- a/integration/ide/bsp-server/src/BspServerTestUtil.scala
+++ b/integration/ide/bsp-server/src/BspServerTestUtil.scala
@@ -63,21 +63,30 @@ object BspServerTestUtil {
         value,
         implicitly[ClassTag[T]].runtimeClass
       )
+      lazy val expectedJsonStr = expectedValueOpt match{
+        case Some(v) => gson.toJson(v, implicitly[ClassTag[T]].runtimeClass)
+        case None => ""
+      }
       if (updateSnapshots) {
         System.err.println(if (exists) s"Updating $snapshotPath" else s"Writing $snapshotPath")
         os.write.over(snapshotPath, normalizeLocalValues(jsonStr), createFolders = true)
       } else {
-        System.err.println("Expected JSON:")
-        System.err.println(jsonStr)
         Predef.assert(
           false,
-          if (exists)
+          if (exists) {
+            val diff = os.call((
+              "git", "diff",
+              os.temp(jsonStr, suffix = "jsonStr"),
+              os.temp(expectedJsonStr, suffix = "expectedJsonStr")
+            ))
             s"""Error: value differs from snapshot in $snapshotPath
                |
                |You might want to set BspServerTestUtil.updateSnapshots to true,
                |run this test again, and commit the updated test data files.
+               |
+               |$diff
                |""".stripMargin
-          else s"Error: no snapshot found at $snapshotPath"
+          } else s"Error: no snapshot found at $snapshotPath"
         )
       }
     } else if (updateSnapshots) {


### PR DESCRIPTION
Added some logging and reproduced the failure locally, indicating the flakiness is caused it is a sequence ordering instability in the return value of `workspaceBuildTargets`

```diff
[3387-1] X mill.integration.BspServerTests.requestSnapshots 32882ms 
[3387-1]   os.SubprocessException: Result of git…: 1
[3387-1]   diff --git a/var/folders/rt/f1pd6fz92x3__6jg0cmgdd580000gn/T/2103572287842600910jsonStr b/var/folders/rt/f1pd6fz92x3__6jg0cmgdd580000gn/T/16267358687599680664expectedJsonStr
[3387-1]   index 8935f3ef329..3ac57e39baa 100644
[3387-1]   --- a/var/folders/rt/f1pd6fz92x3__6jg0cmgdd580000gn/T/2103572287842600910jsonStr
[3387-1]   +++ b/var/folders/rt/f1pd6fz92x3__6jg0cmgdd580000gn/T/16267358687599680664expectedJsonStr
[3387-1]   @@ -2,16 +2,17 @@
[3387-1]      "targets": [
[3387-1]        {
[3387-1]          "id": {
[3387-1]   -        "uri": "file:///Users/lihaoyi/Github/mill/out/integration/ide/bsp-server/local/test.dest/mill.integration.BspServerTests/sandbox/run-1/hello-java"
[3387-1]   +        "uri": "file:///Users/lihaoyi/Github/mill/out/integration/ide/bsp-server/local/test.dest/mill.integration.BspServerTests/sandbox/run-1/hello-kotlin"
[3387-1]          },
[3387-1]   -      "displayName": "hello-java",
[3387-1]   -      "baseDirectory": "file:///Users/lihaoyi/Github/mill/out/integration/ide/bsp-server/local/test.dest/mill.integration.BspServerTests/sandbox/run-1/hello-java",
[3387-1]   +      "displayName": "hello-kotlin",
[3387-1]   +      "baseDirectory": "file:///Users/lihaoyi/Github/mill/out/integration/ide/bsp-server/local/test.dest/mill.integration.BspServerTests/sandbox/run-1/hello-kotlin",
[3387-1]          "tags": [
[3387-1]            "library",
[3387-1]            "application"
[3387-1]          ],
[3387-1]          "languageIds": [
[3387-1]   -        "java"
[3387-1]   +        "java",
[3387-1]   +        "kotlin"
[3387-1]          ],
[3387-1]          "dependencies": [],
[3387-1]          "capabilities": {
[3387-1]   @@ -69,17 +70,16 @@
[3387-1]        },
[3387-1]        {
[3387-1]          "id": {
[3387-1]   -        "uri": "file:///Users/lihaoyi/Github/mill/out/integration/ide/bsp-server/local/test.dest/mill.integration.BspServerTests/sandbox/run-1/hello-kotlin"
[3387-1]   +        "uri": "file:///Users/lihaoyi/Github/mill/out/integration/ide/bsp-server/local/test.dest/mill.integration.BspServerTests/sandbox/run-1/hello-java"
[3387-1]          },
[3387-1]   -      "displayName": "hello-kotlin",
[3387-1]   -      "baseDirectory": "file:///Users/lihaoyi/Github/mill/out/integration/ide/bsp-server/local/test.dest/mill.integration.BspServerTests/sandbox/run-1/hello-kotlin",
[3387-1]   +      "displayName": "hello-java",
[3387-1]   +      "baseDirectory": "file:///Users/lihaoyi/Github/mill/out/integration/ide/bsp-server/local/test.dest/mill.integration.BspServerTests/sandbox/run-1/hello-java",
[3387-1]          "tags": [
[3387-1]            "library",
[3387-1]            "application"
[3387-1]          ],
[3387-1]          "languageIds": [
[3387-1]   -        "java",
[3387-1]   -        "kotlin"
[3387-1]   +        "java"
[3387-1]          ],
[3387-1]          "dependencies": [],
[3387-1]          "capabilities": {
[3387-1]     os.proc.call(ProcessOps.scala:230)
[3387-1]     os.call$.apply(ProcessOps.scala:42)
[3387-1]     mill.integration.BspServerTestUtil$.$anonfun$compareWithGsonSnapshot$4(BspServerTestUtil.scala:77)
[3387-1]     scala.Predef$.assert(Predef.scala:279)
[3387-1]     mill.integration.BspServerTestUtil$.compareWithGsonSnapshot(BspServerTestUtil.scala:76)
[3387-1]     mill.integration.BspServerTests$.$anonfun$tests$4(BspServerTests.scala:91)
[3387-1]     mill.integration.BspServerTests$.$anonfun$tests$4$adapted(BspServerTests.scala:52)
[3387-1]     mill.integration.BspServerTestUtil$.withBspServer(BspServerTestUtil.scala:184)
[3387-1]     mill.integration.BspServerTests$.$anonfun$tests$3(BspServerTests.scala:52)
[3387-1]     mill.integration.BspServerTests$.$anonfun$tests$3$adapted(BspServerTests.scala:39)
[3387-1]     mill.testkit.IntegrationTestSuite.integrationTest(IntegrationTestSuite.scala:20)
[3387-1]     mill.testkit.IntegrationTestSuite.integrationTest$(IntegrationTestSuite.scala:12)
[3387-1]     mill.testkit.UtestIntegrationTestSuite.integrationTest(UtestIntegrationTestSuite.scala:7)
[3387-1]     mill.integration.BspServerTests$.$anonfun$tests$2(BspServerTests.scala:39)
```