### PR TITLE
Use `ignoreErrors = true` to make `clean` work on `runBackground` subprocesses on windows

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -147,7 +147,7 @@ object Deps {
   val junitInterface = ivy"com.github.sbt:junit-interface:0.13.3"
   val commonsIo = ivy"commons-io:commons-io:2.18.0"
   val log4j2Core = ivy"org.apache.logging.log4j:log4j-core:2.24.3"
-  val osLib = ivy"com.lihaoyi::os-lib:0.11.4-M2"
+  val osLib = ivy"com.lihaoyi::os-lib:0.11.4-M4"
   val pprint = ivy"com.lihaoyi::pprint:0.9.0"
   val mainargs = ivy"com.lihaoyi::mainargs:0.7.6"
   val millModuledefsVersion = "0.11.2"

--- a/integration/invalidation/run-background/src/RunBackgroundTests.scala
+++ b/integration/invalidation/run-background/src/RunBackgroundTests.scala
@@ -38,20 +38,18 @@ object RunBackgroundTests extends UtestIntegrationTestSuite {
       eventually { probeLockAvailable(lock) }
     }
     test("clean") - integrationTest { tester =>
-      if (!mill.main.client.Util.isWindows) {
-        import tester._
-        val lock = os.temp()
-        val stop = os.temp()
-        os.remove(stop)
-        eval(("foo.runBackground", lock, stop))
-        eventually {
-          !probeLockAvailable(lock)
-        }
+      import tester._
+      val lock = os.temp()
+      val stop = os.temp()
+      os.remove(stop)
+      eval(("foo.runBackground", lock, stop))
+      eventually {
+        !probeLockAvailable(lock)
+      }
 
-        eval(("clean", "foo.runBackground"))
-        eventually {
-          probeLockAvailable(lock)
-        }
+      eval(("clean", "foo.runBackground"))
+      eventually {
+        probeLockAvailable(lock)
       }
     }
   }

--- a/main/src/mill/main/MainModule.scala
+++ b/main/src/mill/main/MainModule.scala
@@ -498,7 +498,7 @@ trait MainModule extends BaseModule0 {
 
           val existing = paths.filter(p => os.exists(p))
           Target.log.debug(s"Cleaning ${existing.size} paths ...")
-          existing.foreach(os.remove.all)
+          existing.foreach(os.remove.all(_, ignoreErrors = true))
           Result.Success(existing.map(PathRef(_)))
       }
     }


### PR DESCRIPTION
fixes https://github.com/com-lihaoyi/mill/issues/4260

With `ignoreErrors = true`, we ignore the `.mill-background-process-lock` file, and proceed to delete the `.mill-background-process-uuid` file, which is enough to make the process exit even if the un-used lock file is hanging around after