### PR TITLE
Try and stabilize `integration.invalidation[bsp-server]` tests 

### DIFF
--- a/integration/ide/bsp-server/resources/snapshots/build-targets-compile-classpaths.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-compile-classpaths.json
@@ -2,6 +2,14 @@
   "items": [
     {
       "target": {
+        "uri": "file:///workspace/hello-java"
+      },
+      "classpath": [
+        "file:///workspace/hello-java/compile-resources"
+      ]
+    },
+    {
+      "target": {
         "uri": "file:///workspace/hello-kotlin"
       },
       "classpath": [
@@ -17,14 +25,6 @@
       "classpath": [
         "file:///coursier-cache/https/repo1.maven.org/maven2/org/scala-lang/scala-library/<scala-version>/scala-library-<scala-version>.jar",
         "file:///workspace/hello-scala/compile-resources"
-      ]
-    },
-    {
-      "target": {
-        "uri": "file:///workspace/hello-java"
-      },
-      "classpath": [
-        "file:///workspace/hello-java/compile-resources"
       ]
     }
   ]

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-dependency-modules.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-dependency-modules.json
@@ -2,6 +2,12 @@
   "items": [
     {
       "target": {
+        "uri": "file:///workspace/hello-java"
+      },
+      "modules": []
+    },
+    {
+      "target": {
         "uri": "file:///workspace/hello-kotlin"
       },
       "modules": [
@@ -21,12 +27,6 @@
           "version": "<scala-version>"
         }
       ]
-    },
-    {
-      "target": {
-        "uri": "file:///workspace/hello-java"
-      },
-      "modules": []
     }
   ]
 }

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-dependency-sources.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-dependency-sources.json
@@ -2,6 +2,12 @@
   "items": [
     {
       "target": {
+        "uri": "file:///workspace/hello-java"
+      },
+      "sources": []
+    },
+    {
+      "target": {
         "uri": "file:///workspace/hello-kotlin"
       },
       "sources": [
@@ -16,12 +22,6 @@
       "sources": [
         "file:///coursier-cache/https/repo1.maven.org/maven2/org/scala-lang/scala-library/<scala-version>/scala-library-<scala-version>-sources.jar"
       ]
-    },
-    {
-      "target": {
-        "uri": "file:///workspace/hello-java"
-      },
-      "sources": []
     }
   ]
 }

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-javac-options.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-javac-options.json
@@ -2,6 +2,16 @@
   "items": [
     {
       "target": {
+        "uri": "file:///workspace/hello-java"
+      },
+      "options": [],
+      "classpath": [
+        "file:///workspace/hello-java/compile-resources"
+      ],
+      "classDirectory": "file:///workspace/out/hello-java/compile.dest/classes"
+    },
+    {
+      "target": {
         "uri": "file:///workspace/hello-kotlin"
       },
       "options": [],
@@ -22,16 +32,6 @@
         "file:///workspace/hello-scala/compile-resources"
       ],
       "classDirectory": "file:///workspace/out/hello-scala/compile.dest/classes"
-    },
-    {
-      "target": {
-        "uri": "file:///workspace/hello-java"
-      },
-      "options": [],
-      "classpath": [
-        "file:///workspace/hello-java/compile-resources"
-      ],
-      "classDirectory": "file:///workspace/out/hello-java/compile.dest/classes"
     }
   ]
 }

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-jvm-run-environments.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-jvm-run-environments.json
@@ -2,6 +2,20 @@
   "items": [
     {
       "target": {
+        "uri": "file:///workspace/hello-java"
+      },
+      "classpath": [
+        "file:///workspace/hello-java/compile-resources",
+        "file:///workspace/hello-java/resources",
+        "file:///workspace/out/hello-java/compile.dest/classes"
+      ],
+      "jvmOptions": [],
+      "workingDirectory": "/workspace",
+      "environmentVariables": {},
+      "mainClasses": []
+    },
+    {
+      "target": {
         "uri": "file:///workspace/hello-kotlin"
       },
       "classpath": [
@@ -25,20 +39,6 @@
         "file:///workspace/hello-scala/compile-resources",
         "file:///workspace/hello-scala/resources",
         "file:///workspace/out/hello-scala/compile.dest/classes"
-      ],
-      "jvmOptions": [],
-      "workingDirectory": "/workspace",
-      "environmentVariables": {},
-      "mainClasses": []
-    },
-    {
-      "target": {
-        "uri": "file:///workspace/hello-java"
-      },
-      "classpath": [
-        "file:///workspace/hello-java/compile-resources",
-        "file:///workspace/hello-java/resources",
-        "file:///workspace/out/hello-java/compile.dest/classes"
       ],
       "jvmOptions": [],
       "workingDirectory": "/workspace",

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-jvm-test-environments.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-jvm-test-environments.json
@@ -2,6 +2,20 @@
   "items": [
     {
       "target": {
+        "uri": "file:///workspace/hello-java"
+      },
+      "classpath": [
+        "file:///workspace/hello-java/compile-resources",
+        "file:///workspace/hello-java/resources",
+        "file:///workspace/out/hello-java/compile.dest/classes"
+      ],
+      "jvmOptions": [],
+      "workingDirectory": "/workspace",
+      "environmentVariables": {},
+      "mainClasses": []
+    },
+    {
+      "target": {
         "uri": "file:///workspace/hello-kotlin"
       },
       "classpath": [
@@ -25,20 +39,6 @@
         "file:///workspace/hello-scala/compile-resources",
         "file:///workspace/hello-scala/resources",
         "file:///workspace/out/hello-scala/compile.dest/classes"
-      ],
-      "jvmOptions": [],
-      "workingDirectory": "/workspace",
-      "environmentVariables": {},
-      "mainClasses": []
-    },
-    {
-      "target": {
-        "uri": "file:///workspace/hello-java"
-      },
-      "classpath": [
-        "file:///workspace/hello-java/compile-resources",
-        "file:///workspace/hello-java/resources",
-        "file:///workspace/out/hello-java/compile.dest/classes"
       ],
       "jvmOptions": [],
       "workingDirectory": "/workspace",

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-output-paths.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-output-paths.json
@@ -2,6 +2,12 @@
   "items": [
     {
       "target": {
+        "uri": "file:///workspace/hello-java"
+      },
+      "outputPaths": []
+    },
+    {
+      "target": {
         "uri": "file:///workspace/hello-kotlin"
       },
       "outputPaths": []
@@ -9,12 +15,6 @@
     {
       "target": {
         "uri": "file:///workspace/hello-scala"
-      },
-      "outputPaths": []
-    },
-    {
-      "target": {
-        "uri": "file:///workspace/hello-java"
       },
       "outputPaths": []
     },

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-resources.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-resources.json
@@ -2,6 +2,12 @@
   "items": [
     {
       "target": {
+        "uri": "file:///workspace/hello-java"
+      },
+      "resources": []
+    },
+    {
+      "target": {
         "uri": "file:///workspace/hello-kotlin"
       },
       "resources": []
@@ -9,12 +15,6 @@
     {
       "target": {
         "uri": "file:///workspace/hello-scala"
-      },
-      "resources": []
-    },
-    {
-      "target": {
-        "uri": "file:///workspace/hello-java"
       },
       "resources": []
     },

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-scalac-options.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-scalac-options.json
@@ -2,6 +2,16 @@
   "items": [
     {
       "target": {
+        "uri": "file:///workspace/hello-java"
+      },
+      "options": [],
+      "classpath": [
+        "file:///workspace/hello-java/compile-resources"
+      ],
+      "classDirectory": "file:///workspace/out/hello-java/compile.dest/classes"
+    },
+    {
+      "target": {
         "uri": "file:///workspace/hello-kotlin"
       },
       "options": [],
@@ -22,16 +32,6 @@
         "file:///workspace/hello-scala/compile-resources"
       ],
       "classDirectory": "file:///workspace/out/hello-scala/compile.dest/classes"
-    },
-    {
-      "target": {
-        "uri": "file:///workspace/hello-java"
-      },
-      "options": [],
-      "classpath": [
-        "file:///workspace/hello-java/compile-resources"
-      ],
-      "classDirectory": "file:///workspace/out/hello-java/compile.dest/classes"
     }
   ]
 }

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-sources.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-sources.json
@@ -2,6 +2,18 @@
   "items": [
     {
       "target": {
+        "uri": "file:///workspace/hello-java"
+      },
+      "sources": [
+        {
+          "uri": "file:///workspace/hello-java/src",
+          "kind": 2,
+          "generated": false
+        }
+      ]
+    },
+    {
+      "target": {
         "uri": "file:///workspace/hello-kotlin"
       },
       "sources": [
@@ -19,18 +31,6 @@
       "sources": [
         {
           "uri": "file:///workspace/hello-scala/src",
-          "kind": 2,
-          "generated": false
-        }
-      ]
-    },
-    {
-      "target": {
-        "uri": "file:///workspace/hello-java"
-      },
-      "sources": [
-        {
-          "uri": "file:///workspace/hello-java/src",
           "kind": 2,
           "generated": false
         }

--- a/integration/ide/bsp-server/resources/snapshots/workspace-build-targets.json
+++ b/integration/ide/bsp-server/resources/snapshots/workspace-build-targets.json
@@ -2,6 +2,32 @@
   "targets": [
     {
       "id": {
+        "uri": "file:///workspace/hello-java"
+      },
+      "displayName": "hello-java",
+      "baseDirectory": "file:///workspace/hello-java",
+      "tags": [
+        "library",
+        "application"
+      ],
+      "languageIds": [
+        "java"
+      ],
+      "dependencies": [],
+      "capabilities": {
+        "canCompile": true,
+        "canTest": false,
+        "canRun": true,
+        "canDebug": false
+      },
+      "dataKind": "jvm",
+      "data": {
+        "javaHome": "file:///java-home/",
+        "javaVersion": "<java-version>"
+      }
+    },
+    {
+      "id": {
         "uri": "file:///workspace/hello-kotlin"
       },
       "displayName": "hello-kotlin",
@@ -66,32 +92,6 @@
           "javaHome": "file:///java-home/",
           "javaVersion": "<java-version>"
         }
-      }
-    },
-    {
-      "id": {
-        "uri": "file:///workspace/hello-java"
-      },
-      "displayName": "hello-java",
-      "baseDirectory": "file:///workspace/hello-java",
-      "tags": [
-        "library",
-        "application"
-      ],
-      "languageIds": [
-        "java"
-      ],
-      "dependencies": [],
-      "capabilities": {
-        "canCompile": true,
-        "canTest": false,
-        "canRun": true,
-        "canDebug": false
-      },
-      "dataKind": "jvm",
-      "data": {
-        "javaHome": "file:///java-home/",
-        "javaVersion": "<java-version>"
       }
     },
     {

--- a/integration/ide/bsp-server/src/BspServerTestUtil.scala
+++ b/integration/ide/bsp-server/src/BspServerTestUtil.scala
@@ -63,7 +63,7 @@ object BspServerTestUtil {
         value,
         implicitly[ClassTag[T]].runtimeClass
       )
-      lazy val expectedJsonStr = expectedValueOpt match{
+      lazy val expectedJsonStr = expectedValueOpt match {
         case Some(v) => gson.toJson(v, implicitly[ClassTag[T]].runtimeClass)
         case None => ""
       }
@@ -75,9 +75,10 @@ object BspServerTestUtil {
           false,
           if (exists) {
             val diff = os.call((
-              "git", "diff",
-              os.temp(jsonStr, suffix = "jsonStr"),
-              os.temp(expectedJsonStr, suffix = "expectedJsonStr")
+              "git",
+              "diff",
+              os.temp(jsonStr, suffix = s"${snapshotPath.last}-jsonStr"),
+              os.temp(expectedJsonStr, suffix = s"${snapshotPath.last}-expectedJsonStr")
             ))
             s"""Error: value differs from snapshot in $snapshotPath
                |

--- a/integration/ide/bsp-server/src/BspServerTestUtil.scala
+++ b/integration/ide/bsp-server/src/BspServerTestUtil.scala
@@ -63,21 +63,30 @@ object BspServerTestUtil {
         value,
         implicitly[ClassTag[T]].runtimeClass
       )
+      lazy val expectedJsonStr = expectedValueOpt match{
+        case Some(v) => gson.toJson(v, implicitly[ClassTag[T]].runtimeClass)
+        case None => ""
+      }
       if (updateSnapshots) {
         System.err.println(if (exists) s"Updating $snapshotPath" else s"Writing $snapshotPath")
         os.write.over(snapshotPath, normalizeLocalValues(jsonStr), createFolders = true)
       } else {
-        System.err.println("Expected JSON:")
-        System.err.println(jsonStr)
         Predef.assert(
           false,
-          if (exists)
+          if (exists) {
+            val diff = os.call((
+              "git", "diff",
+              os.temp(jsonStr, suffix = "jsonStr"),
+              os.temp(expectedJsonStr, suffix = "expectedJsonStr")
+            ))
             s"""Error: value differs from snapshot in $snapshotPath
                |
                |You might want to set BspServerTestUtil.updateSnapshots to true,
                |run this test again, and commit the updated test data files.
+               |
+               |$diff
                |""".stripMargin
-          else s"Error: no snapshot found at $snapshotPath"
+          } else s"Error: no snapshot found at $snapshotPath"
         )
       }
     } else if (updateSnapshots) {

--- a/main/define/src/mill/define/Reflect.scala
+++ b/main/define/src/mill/define/Reflect.scala
@@ -65,7 +65,10 @@ private[mill] object Reflect {
       }
     )
 
-    arr.reverseIterator.distinctBy(_.getName).toArray
+    val res = arr.reverseIterator.distinctBy(_.getName).toArray
+    // Sometimes `getMethods` returns stuff in odd orders, make sure to sort for determinism
+    res.sortInPlaceBy(_.getName)
+    res
   }
 
   // For some reason, this fails to pick up concrete `object`s nested directly within
@@ -99,6 +102,9 @@ private[mill] object Reflect {
 
         }
         .distinct
+
+    // Sometimes `getClasses` returns stuff in odd orders, make sure to sort for determinism
+    second.sortInPlaceBy(_._1)
 
     first ++ second
   }


### PR DESCRIPTION
It seems sometimes `reflect` was returning reflected modules in different orders, so we make sure to always sort them before returning