### PR TITLE
Update LocalIvyPublisher.scala to also check for IVY_HOME env var

### DIFF
--- a/scalalib/src/mill/scalalib/publish/LocalIvyPublisher.scala
+++ b/scalalib/src/mill/scalalib/publish/LocalIvyPublisher.scala
@@ -56,5 +56,5 @@ object LocalIvyPublisher
         .map(os.Path(_))
         .getOrElse(sys.env.get("IVY_HOME")
                    .map(os.Path(_))
-                   .getOrElse(os.home / ".ivy2") / "local"
+                   .getOrElse(os.home / ".ivy2") / "local")
     )

--- a/scalalib/src/mill/scalalib/publish/LocalIvyPublisher.scala
+++ b/scalalib/src/mill/scalalib/publish/LocalIvyPublisher.scala
@@ -52,9 +52,7 @@ class LocalIvyPublisher(localIvyRepo: os.Path) {
 
 object LocalIvyPublisher
     extends LocalIvyPublisher(
-      sys.props.get("ivy.home")
-        .map(os.Path(_))
-        .getOrElse(sys.env.get("IVY_HOME")
-                   .map(os.Path(_))
-                   .getOrElse(os.home / ".ivy2") / "local")
+      sys.props.get("ivy.home").map(os.Path(_))
+        .getOrElse(sys.env.get("IVY_HOME").map(os.Path(_))
+          .getOrElse(os.home / ".ivy2") / "local")
     )

--- a/scalalib/src/mill/scalalib/publish/LocalIvyPublisher.scala
+++ b/scalalib/src/mill/scalalib/publish/LocalIvyPublisher.scala
@@ -56,5 +56,5 @@ object LocalIvyPublisher
         .map(os.Path(_))
         .getOrElse(sys.env.get("IVY_HOME")
                    .map(os.Path(_))
-                   .getOfElse(os.home / ".ivy2") / "local"
+                   .getOrElse(os.home / ".ivy2") / "local"
     )

--- a/scalalib/src/mill/scalalib/publish/LocalIvyPublisher.scala
+++ b/scalalib/src/mill/scalalib/publish/LocalIvyPublisher.scala
@@ -54,5 +54,7 @@ object LocalIvyPublisher
     extends LocalIvyPublisher(
       sys.props.get("ivy.home")
         .map(os.Path(_))
-        .getOrElse(os.home / ".ivy2") / "local"
+        .getOrElse(sys.env.get("IVY_HOME")
+                   .map(os.Path(_))
+                   .getOfElse(os.home / ".ivy2") / "local"
     )


### PR DESCRIPTION
We should also be checking for `IVY_HOME` that might be different from the assumed default `~/.ivy2` for some folks. Done in the same manner that we're checking for passed in props.

This probably should also be done for m2 as well with `MAVEN_LOCAL_REPO` rather than assuming and hardcoding the default.