### PR TITLE
Publishing configuration for Graal native images

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -88,6 +88,43 @@ jobs:
 
       - run: ./mill -i mill.scalalib.PublishModule/
 
+  publish-sonatype-native:
+    # when in master repo, publish all tags and manual runs on main
+    if: github.repository == 'com-lihaoyi/mill'
+    needs: build-artifacts
+    runs-on: ${{ matrix.os }}
+
+    # only run one publish job for the same sha at the same time
+    # e.g. when a main-branch push is also tagged
+    concurrency: publish-sonatype-native-${{ github.sha }}
+    strategy:
+      matrix:
+        include:
+        - os: macos-latest
+        - os: ubuntu-latest
+    env:
+      MILL_STABLE_VERSION: 1
+      MILL_SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+      MILL_SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+      MILL_PGP_SECRET_BASE64: ${{ secrets.SONATYPE_PGP_SECRET }}
+      MILL_PGP_PASSPHRASE: ${{ secrets.SONATYPE_PGP_PASSWORD }}
+      LANG: "en_US.UTF-8"
+      LC_MESSAGES: "en_US.UTF-8"
+      LC_ALL: "en_US.UTF-8"
+
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+
+      - uses: coursier/cache-action@v6
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: temurin
+
+      - run: ./mill -i mill.scalalib.PublishModule/ dist.native.publishArtifacts
+
   release-github:
     # when in master repo, publish all tags and manual runs on main
     if: github.repository == 'com-lihaoyi/mill'

--- a/dist/package.mill
+++ b/dist/package.mill
@@ -352,6 +352,15 @@ object `package` extends RootModule with build.MillPublishJavaModule {
     def moduleDeps = build.dist.moduleDeps
     def nativeImageExecutableName = if (Properties.isWin) "mill.exe" else "mill"
 
+    def artifactOsSuffix = T{
+      val osName = System.getProperty("os.name").toLowerCase
+      if (osName.contains("mac")) "mac"
+      else if (osName.contains("windows")) "windows"
+      else "linux"
+    }
+    def artifactCpuSuffix = T{ System.getProperty("os.arch") }
+    def artifactName = s"${super.artifactName()}-${artifactOsSuffix()}-${artifactCpuSuffix()}"
+
     def mainClass = Some("mill.runner.client.MillClientMain")
 
     def nativeImageClasspath = build.runner.client.runClasspath()


### PR DESCRIPTION
* We need separate jobs per OS and CPU architecture because Graal cannot cross-build
* For now, I'm only publishing on the default CPU architecture per OS: x64 for linux, ARM for Mac
* Skipping Windows for now