### PR TITLE
Cleanup after native image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ node_modules/
 dist/
 build/
 *.bak
+mill-assembly.jar
+mill-native

--- a/build.mill
+++ b/build.mill
@@ -20,7 +20,6 @@ import $file.ci.shared
 import $file.ci.upload
 import $packages._
 
-def javaVersion = Task{ sys.props("java.version") }
 object Settings {
   val pomOrg = "com.lihaoyi"
   val githubOrg = "com-lihaoyi"

--- a/build.mill
+++ b/build.mill
@@ -20,6 +20,7 @@ import $file.ci.shared
 import $file.ci.upload
 import $packages._
 
+def javaVersion = Task{ sys.props("java.version") }
 object Settings {
   val pomOrg = "com.lihaoyi"
   val githubOrg = "com-lihaoyi"

--- a/ci/test-mill-bootstrap.sh
+++ b/ci/test-mill-bootstrap.sh
@@ -10,7 +10,7 @@ git stash -a
 ./mill -i dist.installLocal
 
 # Clean up
-git stash -a -m "preserve mill-release" -- target/mill-release
+git stash -a -m "preserve mill-release" -- ./mill-assembly.jar
 git stash -u
 git stash -a
 git stash pop "$(git stash list | grep "preserve mill-release" | head -n1 | sed -E 's/([^:]+):.*/\1/')"
@@ -19,5 +19,5 @@ git stash pop "$(git stash list | grep "preserve mill-release" | head -n1 | sed 
 ci/prepare-mill-bootstrap.sh
 
 # Run tests
-target/mill-release -i "__.compile"
-target/mill-release -i "example.scalalib.basic[1-simple].packaged.server.test"
+./mill-assembly.jar -i "__.compile"
+./mill-assembly.jar -i "example.scalalib.basic[1-simple].packaged.server.test"

--- a/ci/test-mill-release.sh
+++ b/ci/test-mill-release.sh
@@ -3,7 +3,7 @@
 set -eux
 
 # Build Mill
-./mill -i dist.assembly
+./mill -i dist.installLocal
 
 EXAMPLE=example/scalalib/basic/6-realistic
 
@@ -12,12 +12,12 @@ rm -rf $EXAMPLE/out
 test ! -d $EXAMPLE/out/foo/3.3.3/compile.dest
 test ! -f $EXAMPLE/out/bar/2.13.8/assembly.dest/out.jar
 
-(cd $EXAMPLE && ../../../../out/dist/assembly.dest/mill -i "foo[3.3.3].run")
+(cd $EXAMPLE && ../../../../mill-assembly.jar -i "foo[3.3.3].run")
 
 test -d $EXAMPLE/out/foo/3.3.3/compile.dest
 
-(cd $EXAMPLE && ../../../../out/dist/assembly.dest/mill show "bar[2.13.8].assembly")
+(cd $EXAMPLE && ../../../../mill-assembly.jar show "bar[2.13.8].assembly")
 
 test -f $EXAMPLE/out/bar/2.13.8/assembly.dest/out.jar
 
-(cd $EXAMPLE && ../../../../out/dist/assembly.dest/mill shutdown)
+(cd $EXAMPLE && ../../../../mill-assembly.jar shutdown)

--- a/dist/package.mill
+++ b/dist/package.mill
@@ -65,7 +65,6 @@ object `package` extends RootModule  with InstallModule {
    */
   object dist0 extends build.MillPublishJavaModule {
     // disable scalafix here because it crashes when a module has no sources
-    def fix(args: String*): Command[Unit] = Task.Command {}
     def moduleDeps = Seq(build.runner, build.idea)
 
     def testTransitiveDeps = build.runner.testTransitiveDeps() ++ Seq(

--- a/dist/package.mill
+++ b/dist/package.mill
@@ -6,9 +6,57 @@ import mill.api.JarManifest
 import de.tobiasroeser.mill.vcs.version.VcsVersion
 import $file.ci.upload
 
-import scala.util.{Properties, Using}
+import scala.util.Using
 
-object `package` extends RootModule with build.MillPublishJavaModule {
+trait InstallModule extends build.MillPublishJavaModule{
+  // All modules that we want to aggregate as part of this `dev` assembly.
+  // Excluding itself, and the `dist` module that uses it
+  lazy val allPublishModules = build.millInternal.modules.collect {
+    case m: PublishModule if (m ne build.dist) && (m ne build.dist.native) => m
+  }
+  def moduleDeps = Seq(build.runner, build.idea, build.main.init)
+
+  def jar: T[PathRef]
+
+  def executable = Task{
+    Task.traverse(allPublishModules)(m => m.publishLocalCached)()
+    jar()
+  }
+
+  def localBinName: String
+
+  /**
+   * Build and install Mill locally.
+   *
+   * @param binFile The location where the Mill binary should be installed
+   * @param ivyRepo The local Ivy repository where Mill modules should be published to
+   */
+  def installLocal(binFile: String = localBinName, ivyRepo: String = null) =
+    Task.Command {
+      PathRef(installLocalTask(Task.Anon(binFile), ivyRepo)())
+    }
+
+  val batExt = if (scala.util.Properties.isWin) ".bat" else ""
+
+  def installLocalCache() = Task.Command {
+    val path = installLocalTask(
+      Task.Anon((os.home / ".cache" / "mill" / "download" / (build.millVersion() + batExt)).toString())
+    )()
+    Task.log.outputStream.println(path.toString())
+    PathRef(path)
+  }
+
+  def installLocalTask(binFile: Task[String], ivyRepo: String = null): Task[os.Path] = Task.Anon {
+    val targetFile = os.Path(binFile(), Task.workspace)
+    if (os.exists(targetFile))
+      Task.log.info(s"Overwriting existing local Mill binary at ${targetFile}")
+    os.copy.over(executable().path, targetFile, createFolders = true)
+    Task.log.info(s"Published ${build.dist.allPublishModules.size} modules and installed ${targetFile}")
+    targetFile
+  }
+}
+
+object `package` extends RootModule  with InstallModule {
 
   /**
    * Version of [[dist]] meant for local integration testing within the Mill
@@ -38,9 +86,6 @@ object `package` extends RootModule with build.MillPublishJavaModule {
     )
   }
 
-  def jar = rawAssembly()
-  def moduleDeps = Seq(build.runner, build.idea, build.main.init)
-
   def testTransitiveDeps = dist0.testTransitiveDeps() ++ Seq(
     (s"com.lihaoyi-${build.dist.artifactId()}", dist0.runClasspath().map(_.path).mkString("\n"))
   )
@@ -67,6 +112,8 @@ object `package` extends RootModule with build.MillPublishJavaModule {
       )
   }
 
+  def localBinName = "mill-assembly.jar"
+
   def launcher = Task {
     val isWin = scala.util.Properties.isWin
     val outputPath = Task.dest / (if (isWin) "run.bat" else "run")
@@ -85,13 +132,7 @@ object `package` extends RootModule with build.MillPublishJavaModule {
     mill.scalalib.Assembly.Rule.ExcludePattern("mill/local-test-overrides/.*")
   )
 
-  // All modules that we want to aggregate as part of this `dev` assembly.
-  // Excluding itself, and the `dist` module that uses it
-  lazy val allPublishModules = build.millInternal.modules.collect {
-    case m: PublishModule if (m ne this) && (m ne build.dist) => m
-  }
-
-  def rawAssembly = Task {
+  def jar = Task {
     val version = build.millVersion()
     val devRunClasspath = runClasspath().map(_.path)
     val filename = if (scala.util.Properties.isWin) "mill.bat" else "mill"
@@ -111,12 +152,6 @@ object `package` extends RootModule with build.MillPublishJavaModule {
       Task.dest / filename
     )
     PathRef(Task.dest / filename)
-  }
-  def assembly = Task {
-    Task.traverse(allPublishModules.filter(_ != native))(m => m.publishLocalCached)()
-    val raw = rawAssembly().path
-    os.copy(raw, Task.dest / raw.last)
-    PathRef(Task.dest / raw.last)
   }
 
   def prependShellScript = Task {
@@ -227,39 +262,6 @@ object `package` extends RootModule with build.MillPublishJavaModule {
     )
   }
 
-  val batExt = if (scala.util.Properties.isWin) ".bat" else ""
-  val DefaultLocalMillReleasePath =
-    s"target/mill-release$batExt"
-
-  /**
-   * Build and install Mill locally.
-   *
-   * @param binFile The location where the Mill binary should be installed
-   * @param ivyRepo The local Ivy repository where Mill modules should be published to
-   */
-  def installLocal(binFile: String = DefaultLocalMillReleasePath, ivyRepo: String = null) =
-    Task.Command {
-      PathRef(installLocalTask(Task.Anon(binFile), ivyRepo)())
-    }
-
-  def installLocalCache() = Task.Command {
-    val path = installLocalTask(
-      Task.Anon((os.home / ".cache" / "mill" / "download" / (build.millVersion() + batExt)).toString())
-    )()
-    Task.log.outputStream.println(path.toString())
-    PathRef(path)
-  }
-
-  def installLocalTask(binFile: Task[String], ivyRepo: String = null): Task[os.Path] = Task.Anon {
-    val millBin = build.dist.assembly()
-    val targetFile = os.Path(binFile(), Task.workspace)
-    if (os.exists(targetFile))
-      Task.log.info(s"Overwriting existing local Mill binary at ${targetFile}")
-    os.copy.over(millBin.path, targetFile, createFolders = true)
-    Task.log.info(s"Published ${build.dist.allPublishModules.size} modules and installed ${targetFile}")
-    targetFile
-  }
-
   def millBootstrap = Task.Source(Task.workspace / "mill")
   def millBootstrapBat = Task.Source(Task.workspace / "mill.bat")
 
@@ -348,16 +350,14 @@ object `package` extends RootModule with build.MillPublishJavaModule {
     }
   }
 
-  object native extends build.MillPublishJavaModule with mill.scalalib.NativeImageModule {
-    def moduleDeps = build.dist.moduleDeps
-    def nativeImageExecutableName = if (Properties.isWin) "mill.exe" else "mill"
-
+  object native extends mill.scalalib.NativeImageModule with InstallModule {
     def artifactOsSuffix = T{
       val osName = System.getProperty("os.name").toLowerCase
       if (osName.contains("mac")) "mac"
       else if (osName.contains("windows")) "windows"
       else "linux"
     }
+
     def artifactCpuSuffix = T{ System.getProperty("os.arch") }
     def artifactName = s"${super.artifactName()}-${artifactOsSuffix()}-${artifactCpuSuffix()}"
 
@@ -365,8 +365,10 @@ object `package` extends RootModule with build.MillPublishJavaModule {
 
     def nativeImageClasspath = build.runner.client.runClasspath()
 
-    def rawNativeImage = Task {
-      val previous = super.nativeImage().path
+    def localBinName = "mill-native"
+
+    def jar = Task {
+      val previous = nativeImage().path
       val executable = Task.dest / previous.last
 
       Using(os.write.outputStream(executable)) { out =>
@@ -379,14 +381,7 @@ object `package` extends RootModule with build.MillPublishJavaModule {
       PathRef(executable)
     }
 
-    def nativeImage = Task {
-      Task.traverse(allPublishModules.filter(_ != native))(m => m.publishLocalCached)()
-      rawNativeImage()
-    }
-
-    def jar = rawNativeImage()
-
-    def nativeImageOptions = Seq("--no-fallback")
+    def nativeImageOptions = Seq("--no-fallback", "--enable-url-protocols=https")
 
     def zincWorker = ModuleRef(ZincWorkerGraalvm)
 

--- a/example/package.mill
+++ b/example/package.mill
@@ -198,7 +198,6 @@ object `package` extends RootModule with Module {
 
   trait ExampleCrossModule extends build.integration.IntegrationTestModule {
     // disable scalafix because these example modules don't have sources causing it to misbehave
-    def fix(args: String*): Command[Unit] = T.command {}
     def testRepoRoot: T[PathRef] = Task.Source(millSourcePath)
 
     def sources0 = Task.Sources(millSourcePath)

--- a/integration/invalidation/multi-level-editing/src/MultiLevelBuildTests.scala
+++ b/integration/invalidation/multi-level-editing/src/MultiLevelBuildTests.scala
@@ -110,8 +110,7 @@ trait MultiLevelBuildTests extends UtestIntegrationTestSuite {
     // restarts behave as expected:
     if (clientServerMode) {
       // Only one server should be running at any point in time
-      val Seq(serverHashFolder) = os.list(tester.workspacePath / "out" / "mill-server")
-      val Seq(serverFolder) = os.list(serverHashFolder)
+      val Seq(serverFolder) = os.list(tester.workspacePath / "out" / "mill-server")
 
       // client-server mode should never restart in these tests and preserve the same process,
       val currentServerId = os.read(serverFolder / "serverId")

--- a/integration/invalidation/multi-level-editing/src/MultiLevelBuildTests.scala
+++ b/integration/invalidation/multi-level-editing/src/MultiLevelBuildTests.scala
@@ -110,7 +110,8 @@ trait MultiLevelBuildTests extends UtestIntegrationTestSuite {
     // restarts behave as expected:
     if (clientServerMode) {
       // Only one server should be running at any point in time
-      val Seq(serverFolder) = os.list(tester.workspacePath / "out" / "mill-server")
+      val Seq(serverHashFolder) = os.list(tester.workspacePath / "out" / "mill-server")
+      val Seq(serverFolder) = os.list(serverHashFolder)
 
       // client-server mode should never restart in these tests and preserve the same process,
       val currentServerId = os.read(serverFolder / "serverId")

--- a/integration/invalidation/version-change/resources/build.mill
+++ b/integration/invalidation/version-change/resources/build.mill
@@ -1,0 +1,4 @@
+package build
+import mill._
+
+def javaVersion = Task{ sys.props("java.version") }

--- a/integration/invalidation/version-change/src/VersionChangeTests.scala
+++ b/integration/invalidation/version-change/src/VersionChangeTests.scala
@@ -15,7 +15,6 @@ object VersionChangeTests extends UtestIntegrationTestSuite {
       assert(!javaVersion1.out.contains("19.0.2"))
 
       os.write(workspacePath / ".mill-jvm-version", "temurin:19.0.2")
-      os.remove.all(workspacePath / "out")
 
       val javaVersion2 = eval(("show", "javaVersion"))
       assert(javaVersion2.out == "\"19.0.2\"")

--- a/integration/invalidation/version-change/src/VersionChangeTests.scala
+++ b/integration/invalidation/version-change/src/VersionChangeTests.scala
@@ -8,9 +8,6 @@ object VersionChangeTests extends UtestIntegrationTestSuite {
   val tests: Tests = Tests {
     test("simple") - integrationTest { tester =>
       import tester._
-      // Make sure the simplest case where we have a single task calling a single helper
-      // method is properly invalidated when either the task body, or the helper method's body
-      // is changed, or something changed in the constructor
       val javaVersion1 = eval(("show", "javaVersion"))
       assert(!javaVersion1.out.contains("19.0.2"))
 

--- a/integration/invalidation/version-change/src/VersionChangeTests.scala
+++ b/integration/invalidation/version-change/src/VersionChangeTests.scala
@@ -12,7 +12,7 @@ object VersionChangeTests extends UtestIntegrationTestSuite {
       // method is properly invalidated when either the task body, or the helper method's body
       // is changed, or something changed in the constructor
       val javaVersion1 = eval(("show", "javaVersion"))
-      assert(javaVersion1.out.contains("17.0.")
+      assert(javaVersion1.out.contains("17.0."))
 
       os.write(workspacePath / ".mill-jvm-version", "temurin:19.0.2")
       os.remove.all(workspacePath / "out")

--- a/integration/invalidation/version-change/src/VersionChangeTests.scala
+++ b/integration/invalidation/version-change/src/VersionChangeTests.scala
@@ -12,7 +12,7 @@ object VersionChangeTests extends UtestIntegrationTestSuite {
       // method is properly invalidated when either the task body, or the helper method's body
       // is changed, or something changed in the constructor
       val javaVersion1 = eval(("show", "javaVersion"))
-      assert(javaVersion1.out.contains("17.0."))
+      assert(!javaVersion1.out.contains("19.0.2"))
 
       os.write(workspacePath / ".mill-jvm-version", "temurin:19.0.2")
       os.remove.all(workspacePath / "out")

--- a/integration/invalidation/version-change/src/VersionChangeTests.scala
+++ b/integration/invalidation/version-change/src/VersionChangeTests.scala
@@ -1,0 +1,25 @@
+package mill.integration
+
+import mill.testkit.UtestIntegrationTestSuite
+
+import utest._
+
+object VersionChangeTests extends UtestIntegrationTestSuite {
+  val tests: Tests = Tests {
+    test("simple") - integrationTest { tester =>
+      import tester._
+      // Make sure the simplest case where we have a single task calling a single helper
+      // method is properly invalidated when either the task body, or the helper method's body
+      // is changed, or something changed in the constructor
+      val javaVersion1 = eval(("show", "javaVersion"))
+      assert(javaVersion1.out == "\"17.0.6\"")
+
+      os.write(workspacePath / ".mill-jvm-version", "temurin:19.0.2")
+      os.remove.all(workspacePath / "out")
+
+      val javaVersion2 = eval(("show", "javaVersion"))
+      assert(javaVersion2.out == "\"19.0.2\"")
+
+    }
+  }
+}

--- a/integration/invalidation/version-change/src/VersionChangeTests.scala
+++ b/integration/invalidation/version-change/src/VersionChangeTests.scala
@@ -12,7 +12,7 @@ object VersionChangeTests extends UtestIntegrationTestSuite {
       // method is properly invalidated when either the task body, or the helper method's body
       // is changed, or something changed in the constructor
       val javaVersion1 = eval(("show", "javaVersion"))
-      assert(javaVersion1.out == "\"17.0.6\"")
+      assert(javaVersion1.out.contains("17.0.")
 
       os.write(workspacePath / ".mill-jvm-version", "temurin:19.0.2")
       os.remove.all(workspacePath / "out")

--- a/integration/package.mill
+++ b/integration/package.mill
@@ -70,10 +70,10 @@ object `package` extends RootModule {
       def millIntegrationLauncher = build.dist.launcher()
     }
     object packaged extends IntegrationLauncherModule {
-      def millIntegrationLauncher = build.dist.assembly()
+      def millIntegrationLauncher = build.dist.executable()
     }
     object native extends IntegrationLauncherModule {
-      def millIntegrationLauncher = build.dist.native.nativeImage()
+      def millIntegrationLauncher = build.dist.native.executable()
     }
     trait IntegrationLauncherModule extends Module {
       def millIntegrationLauncher: T[PathRef]

--- a/main/client/src/mill/main/client/EnvVars.java
+++ b/main/client/src/mill/main/client/EnvVars.java
@@ -18,6 +18,7 @@ public class EnvVars {
    */
   public static final String MILL_SERVER_TIMEOUT_MILLIS = "MILL_SERVER_TIMEOUT_MILLIS";
 
+  public static final String MILL_JVM_VERSION_PATH = "MILL_JVM_VERSION_PATH";
   public static final String MILL_JVM_OPTS_PATH = "MILL_JVM_OPTS_PATH";
   public static final String MILL_OPTS_PATH = "MILL_OPTS_PATH";
 

--- a/main/client/src/mill/main/client/ServerLauncher.java
+++ b/main/client/src/mill/main/client/ServerLauncher.java
@@ -88,7 +88,9 @@ public abstract class ServerLauncher {
     int serverIndex = 0;
     while (serverIndex < serverProcessesLimit) { // Try each possible server process (-1 to -5)
       serverIndex++;
-      final Path serverDir = serverDir0.resolve(serverIndex + "");
+      final Path serverDir = serverDir0.getParent()
+          .resolve(serverDir0.getFileName() + "-" + serverIndex);
+
       Files.createDirectories(serverDir);
 
       try (Locks locks = memoryLocks != null

--- a/main/client/src/mill/main/client/ServerLauncher.java
+++ b/main/client/src/mill/main/client/ServerLauncher.java
@@ -88,8 +88,8 @@ public abstract class ServerLauncher {
     int serverIndex = 0;
     while (serverIndex < serverProcessesLimit) { // Try each possible server process (-1 to -5)
       serverIndex++;
-      final Path serverDir = serverDir0.getParent()
-          .resolve(serverDir0.getFileName() + "-" + serverIndex);
+      final Path serverDir =
+          serverDir0.getParent().resolve(serverDir0.getFileName() + "-" + serverIndex);
 
       Files.createDirectories(serverDir);
 

--- a/main/client/src/mill/main/client/ServerLauncher.java
+++ b/main/client/src/mill/main/client/ServerLauncher.java
@@ -1,14 +1,11 @@
 package mill.main.client;
 
-import static mill.main.client.OutFiles.*;
-
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.net.Socket;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Map;
 import mill.main.client.lock.Locks;
 import mill.main.client.lock.TryLocked;
@@ -81,21 +78,17 @@ public abstract class ServerLauncher {
     this.forceFailureForTestingMillisDelay = forceFailureForTestingMillisDelay;
   }
 
-  public Result acquireLocksAndRun(String outDir) throws Exception {
+  public Result acquireLocksAndRun(Path serverDir0) throws Exception {
 
     final boolean setJnaNoSys = System.getProperty("jna.nosys") == null;
     if (setJnaNoSys) {
       System.setProperty("jna.nosys", "true");
     }
 
-    final String versionAndJvmHomeEncoding =
-        Util.sha1Hash(BuildInfo.millVersion + System.getProperty("java.home"));
-
     int serverIndex = 0;
     while (serverIndex < serverProcessesLimit) { // Try each possible server process (-1 to -5)
       serverIndex++;
-      final Path serverDir =
-          Paths.get(outDir, millServer, versionAndJvmHomeEncoding + "-" + serverIndex);
+      final Path serverDir = serverDir0.resolve(serverIndex + "");
       Files.createDirectories(serverDir);
 
       try (Locks locks = memoryLocks != null

--- a/main/client/src/mill/main/client/Util.java
+++ b/main/client/src/mill/main/client/Util.java
@@ -152,7 +152,7 @@ public class Util {
     return String.format("%0" + (arr.length << 1) + "x", new BigInteger(1, arr));
   }
 
-  static String sha1Hash(String path) throws NoSuchAlgorithmException {
+  public static String sha1Hash(String path) throws NoSuchAlgorithmException {
     MessageDigest md = MessageDigest.getInstance("SHA1");
     md.reset();
     byte[] pathBytes = path.getBytes(StandardCharsets.UTF_8);

--- a/main/client/src/mill/main/client/Util.java
+++ b/main/client/src/mill/main/client/Util.java
@@ -1,7 +1,6 @@
 package mill.main.client;
 
 import java.io.Console;
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -11,6 +10,7 @@ import java.lang.reflect.Method;
 import java.math.BigInteger;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
@@ -166,9 +166,9 @@ public class Util {
    *
    * @return The non-empty lines of the files or an empty list, if the file does not exist
    */
-  public static List<String> readOptsFileLines(final File file) throws Exception {
+  public static List<String> readOptsFileLines(final Path file) throws Exception {
     final List<String> vmOptions = new LinkedList<>();
-    try (final Scanner sc = new Scanner(file)) {
+    try (final Scanner sc = new Scanner(file.toFile())) {
       final Map<String, String> env = System.getenv();
       while (sc.hasNextLine()) {
         String arg = sc.nextLine();

--- a/main/client/test/src/mill/main/client/MillEnvTests.java
+++ b/main/client/test/src/mill/main/client/MillEnvTests.java
@@ -2,7 +2,8 @@ package mill.main.client;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.Test;
@@ -11,7 +12,7 @@ public class MillEnvTests {
 
   @Test
   public void readOptsFileLinesWithoutFInalNewline() throws Exception {
-    File file = new File(
+    Path file = Paths.get(
         getClass().getClassLoader().getResource("file-wo-final-newline.txt").toURI());
     List<String> lines = Util.readOptsFileLines(file);
     assertEquals(

--- a/main/eval/src/mill/eval/GroupEvaluator.scala
+++ b/main/eval/src/mill/eval/GroupEvaluator.scala
@@ -80,7 +80,9 @@ private[mill] trait GroupEvaluator {
             .flatten
         )
 
-      val inputsHash = externalInputsHash + sideHashes + classLoaderSigHash + scriptsHash
+      val javaHomeHash = sys.props("java.home").hashCode
+      val inputsHash =
+        externalInputsHash + sideHashes + classLoaderSigHash + scriptsHash + javaHomeHash
 
       terminal match {
         case Terminal.Task(task) =>

--- a/main/server/test/src/mill/main/server/ClientServerTests.scala
+++ b/main/server/test/src/mill/main/server/ClientServerTests.scala
@@ -107,7 +107,7 @@ object ClientServerTests extends TestSuite {
             testLogEvenWhenServerIdWrong
           )).start()
         }
-      }.acquireLocksAndRun(outDir.relativeTo(os.pwd).toNIO)
+      }.acquireLocksAndRun((outDir / "server-0").relativeTo(os.pwd).toNIO)
 
       ClientResult(
         result.exitCode,

--- a/main/server/test/src/mill/main/server/ClientServerTests.scala
+++ b/main/server/test/src/mill/main/server/ClientServerTests.scala
@@ -107,7 +107,7 @@ object ClientServerTests extends TestSuite {
             testLogEvenWhenServerIdWrong
           )).start()
         }
-      }.acquireLocksAndRun(outDir.relativeTo(os.pwd).toString)
+      }.acquireLocksAndRun(outDir.relativeTo(os.pwd).toNIO)
 
       ClientResult(
         result.exitCode,

--- a/mill
+++ b/mill
@@ -102,9 +102,10 @@ if [ -z "${MILL_VERSION}" ] ; then
 fi
 
 MILL_NATIVE_SUFFIX="-native"
+FULL_MILL_VERSION=$MILL_VERSION
+
 case "$MILL_VERSION" in
     *"$MILL_NATIVE_SUFFIX")
-  FULL_MILL_VERSION=$MILL_VERSION
   MILL_VERSION=${MILL_VERSION%"$MILL_NATIVE_SUFFIX"}
   if [ "$(expr substr $(uname -s) 1 5 2>/dev/null)" = "Linux" ]; then
     ARTIFACT_SUFFIX="-native-linux-amd64"

--- a/mill
+++ b/mill
@@ -104,6 +104,7 @@ fi
 MILL_NATIVE_SUFFIX="-native"
 case "$MILL_VERSION" in
     *"$MILL_NATIVE_SUFFIX")
+  FULL_MILL_VERSION=$MILL_VERSION
   MILL_VERSION=${MILL_VERSION%"$MILL_NATIVE_SUFFIX"}
   if [ "$(expr substr $(uname -s) 1 5 2>/dev/null)" = "Linux" ]; then
     ARTIFACT_SUFFIX="-native-linux-amd64"
@@ -116,7 +117,7 @@ case "$MILL_VERSION" in
 esac
 
 
-MILL="${MILL_DOWNLOAD_PATH}/${MILL_VERSION}"
+MILL="${MILL_DOWNLOAD_PATH}/${FULL_MILL_VERSION}"
 
 try_to_use_system_mill() {
   if [ "$(uname)" != "Linux" ]; then

--- a/readme.adoc
+++ b/readme.adoc
@@ -177,12 +177,15 @@ remaining modules to `~/.ivy2/local`.
 This results in a more realistic test environment, but at the cost of taking tens-of-seconds
 more to run a test after making a code change.
 
-You can reproduce these tests manually using `dist.assembly`:
+You can reproduce these tests manually using `dist.installLocal`:
 
 [source,bash]
 ----
-./mill dist.assembly && (cd example/basic/1-simple && ../../../out/dist/assembly.dest/mill run --text hello)
+./mill dist.installLocal && (cd example/basic/1-simple && ../../../mill-assembly.jar run --text hello)
 ----
+
+ThYou can also use `dist.native.installLocal` for a Graal Native Image executable,
+which is slower to create but faster to start than the default executable assembly.
 
 There are two six of these tests, `.{local,assembly,native}.{server,fork}`.
 

--- a/readme.adoc
+++ b/readme.adoc
@@ -184,7 +184,7 @@ You can reproduce these tests manually using `dist.installLocal`:
 ./mill dist.installLocal && (cd example/basic/1-simple && ../../../mill-assembly.jar run --text hello)
 ----
 
-ThYou can also use `dist.native.installLocal` for a Graal Native Image executable,
+You can also use `dist.native.installLocal` for a Graal Native Image executable,
 which is slower to create but faster to start than the default executable assembly.
 
 There are two six of these tests, `.{local,assembly,native}.{server,fork}`.

--- a/runner/client/src/mill/runner/client/CoursierClient.scala
+++ b/runner/client/src/mill/runner/client/CoursierClient.scala
@@ -13,8 +13,10 @@ object CoursierClient {
         ArchiveCache().withCache(coursierCache0)
       )
       .withIndex(jvmIndex0(jvmIndexVersion))
+
     val javaHome = JavaHome()
       .withCache(jvmCache)
+
     javaHome.get(id).unsafeRun()(coursierCache0.ec)
   }
 

--- a/runner/client/src/mill/runner/client/CoursierClient.scala
+++ b/runner/client/src/mill/runner/client/CoursierClient.scala
@@ -18,6 +18,8 @@ object CoursierClient {
 
   def jvmIndex0(): Task[JvmIndex] = {
     val coursierCache0 = FileCache[Task]()
+      .withLogger(coursier.cache.loggers.RefreshLogger.create())
+
     JvmIndex.load(
       cache = coursierCache0,
       repositories = Resolve().repositories,

--- a/runner/client/src/mill/runner/client/CoursierClient.scala
+++ b/runner/client/src/mill/runner/client/CoursierClient.scala
@@ -11,8 +11,7 @@ object CoursierClient {
       .withArchiveCache(ArchiveCache().withCache(coursierCache0))
       .withIndex(jvmIndex0())
 
-    val javaHome = JavaHome()
-      .withCache(jvmCache)
+    val javaHome = JavaHome().withCache(jvmCache)
 
     javaHome.get(id).unsafeRun()(coursierCache0.ec)
   }

--- a/runner/client/src/mill/runner/client/CoursierClient.scala
+++ b/runner/client/src/mill/runner/client/CoursierClient.scala
@@ -5,14 +5,11 @@ import coursier.util.Task
 import coursier.Resolve
 
 object CoursierClient {
-  def resolveJavaHome(id: String,
-                      jvmIndexVersion: String = "latest.release"): java.io.File = {
+  def resolveJavaHome(id: String): java.io.File = {
     val coursierCache0 = FileCache[Task]()
     val jvmCache = JvmCache()
-      .withArchiveCache(
-        ArchiveCache().withCache(coursierCache0)
-      )
-      .withIndex(jvmIndex0(jvmIndexVersion))
+      .withArchiveCache(ArchiveCache().withCache(coursierCache0))
+      .withIndex(jvmIndex0())
 
     val javaHome = JavaHome()
       .withCache(jvmCache)
@@ -20,18 +17,15 @@ object CoursierClient {
     javaHome.get(id).unsafeRun()(coursierCache0.ec)
   }
 
-
-  def jvmIndex0(
-                 jvmIndexVersion: String = "latest.release"
-               ): Task[JvmIndex] = {
+  def jvmIndex0(): Task[JvmIndex] = {
     val coursierCache0 = FileCache[Task]()
     JvmIndex.load(
-      cache = coursierCache0, // the coursier.cache.Cache instance to use
-      repositories = Resolve().repositories, // repositories to use
+      cache = coursierCache0,
+      repositories = Resolve().repositories,
       indexChannel = JvmChannel.module(
         JvmChannel.centralModule(),
-        version = jvmIndexVersion
-      ) // use new indices published to Maven Central
+        version = mill.runner.client.Versions.coursierJvmIndexVersion
+      )
     )
   }
 }

--- a/runner/client/src/mill/runner/client/CoursierClient.scala
+++ b/runner/client/src/mill/runner/client/CoursierClient.scala
@@ -7,6 +7,7 @@ import coursier.Resolve
 object CoursierClient {
   def resolveJavaHome(id: String): java.io.File = {
     val coursierCache0 = FileCache[Task]()
+      .withLogger(coursier.cache.loggers.RefreshLogger.create())
     val jvmCache = JvmCache()
       .withArchiveCache(ArchiveCache().withCache(coursierCache0))
       .withIndex(jvmIndex0())

--- a/runner/client/src/mill/runner/client/CoursierClient.scala
+++ b/runner/client/src/mill/runner/client/CoursierClient.scala
@@ -10,24 +10,19 @@ object CoursierClient {
       .withLogger(coursier.cache.loggers.RefreshLogger.create())
     val jvmCache = JvmCache()
       .withArchiveCache(ArchiveCache().withCache(coursierCache0))
-      .withIndex(jvmIndex0())
+      .withIndex(
+        JvmIndex.load(
+          cache = coursierCache0,
+          repositories = Resolve().repositories,
+          indexChannel = JvmChannel.module(
+            JvmChannel.centralModule(),
+            version = mill.runner.client.Versions.coursierJvmIndexVersion
+          )
+        )
+      )
 
     val javaHome = JavaHome().withCache(jvmCache)
 
     javaHome.get(id).unsafeRun()(coursierCache0.ec)
-  }
-
-  def jvmIndex0(): Task[JvmIndex] = {
-    val coursierCache0 = FileCache[Task]()
-      .withLogger(coursier.cache.loggers.RefreshLogger.create())
-
-    JvmIndex.load(
-      cache = coursierCache0,
-      repositories = Resolve().repositories,
-      indexChannel = JvmChannel.module(
-        JvmChannel.centralModule(),
-        version = mill.runner.client.Versions.coursierJvmIndexVersion
-      )
-    )
   }
 }

--- a/runner/client/src/mill/runner/client/CoursierClient.scala
+++ b/runner/client/src/mill/runner/client/CoursierClient.scala
@@ -1,0 +1,35 @@
+package mill.runner.client
+import coursier.cache.{ArchiveCache, FileCache}
+import coursier.jvm.{JavaHome, JvmCache, JvmChannel, JvmIndex}
+import coursier.util.Task
+import coursier.Resolve
+
+object CoursierClient {
+  def resolveJavaHome(id: String,
+                      jvmIndexVersion: String = "latest.release"): java.io.File = {
+    val coursierCache0 = FileCache[Task]()
+    val jvmCache = JvmCache()
+      .withArchiveCache(
+        ArchiveCache().withCache(coursierCache0)
+      )
+      .withIndex(jvmIndex0(jvmIndexVersion))
+    val javaHome = JavaHome()
+      .withCache(jvmCache)
+    javaHome.get(id).unsafeRun()(coursierCache0.ec)
+  }
+
+
+  def jvmIndex0(
+                 jvmIndexVersion: String = "latest.release"
+               ): Task[JvmIndex] = {
+    val coursierCache0 = FileCache[Task]()
+    JvmIndex.load(
+      cache = coursierCache0, // the coursier.cache.Cache instance to use
+      repositories = Resolve().repositories, // repositories to use
+      indexChannel = JvmChannel.module(
+        JvmChannel.centralModule(),
+        version = jvmIndexVersion
+      ) // use new indices published to Maven Central
+    )
+  }
+}

--- a/runner/client/src/mill/runner/client/MillClientMain.java
+++ b/runner/client/src/mill/runner/client/MillClientMain.java
@@ -61,7 +61,7 @@ public class MillClientMain {
 
         final String versionAndJvmHomeEncoding =
             Util.sha1Hash(BuildInfo.millVersion + MillProcessLauncher.javaHome());
-        Path serverDir0 = Paths.get(OutFiles.out, versionAndJvmHomeEncoding);
+        Path serverDir0 = Paths.get(OutFiles.out, OutFiles.millServer, versionAndJvmHomeEncoding);
         int exitCode = launcher.acquireLocksAndRun(serverDir0).exitCode;
         if (exitCode == Util.ExitServerCodeWhenVersionMismatch()) {
           exitCode = launcher.acquireLocksAndRun(serverDir0).exitCode;

--- a/runner/client/src/mill/runner/client/MillClientMain.java
+++ b/runner/client/src/mill/runner/client/MillClientMain.java
@@ -3,6 +3,7 @@ package mill.runner.client;
 import static mill.runner.client.MillProcessLauncher.millOptsFile;
 
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import mill.main.client.*;
@@ -57,9 +58,13 @@ public class MillClientMain {
                 MillProcessLauncher.prepareMillRunFolder(serverDir);
               }
             };
-        int exitCode = launcher.acquireLocksAndRun(OutFiles.out).exitCode;
+
+        final String versionAndJvmHomeEncoding =
+            Util.sha1Hash(BuildInfo.millVersion + MillProcessLauncher.javaHome());
+        Path serverDir0 = Paths.get(OutFiles.out, versionAndJvmHomeEncoding);
+        int exitCode = launcher.acquireLocksAndRun(serverDir0).exitCode;
         if (exitCode == Util.ExitServerCodeWhenVersionMismatch()) {
-          exitCode = launcher.acquireLocksAndRun(OutFiles.out).exitCode;
+          exitCode = launcher.acquireLocksAndRun(serverDir0).exitCode;
         }
         System.exit(exitCode);
       } catch (ServerCouldNotBeStarted e) {

--- a/runner/client/src/mill/runner/client/MillProcessLauncher.java
+++ b/runner/client/src/mill/runner/client/MillProcessLauncher.java
@@ -111,7 +111,7 @@ public class MillProcessLauncher {
     if (javaHome == null || javaHome.isEmpty()){
         System.err.println("Downloading JDK " + jvmId);
         javaHome = CoursierClient
-            .resolveJavaHome(jvmId, "latest.release")
+            .resolveJavaHome(jvmId)
             .getAbsolutePath();
         System.err.println("Finished Downloading JDK " + jvmId + " to " + javaHome);
     }

--- a/runner/client/src/mill/runner/client/MillProcessLauncher.java
+++ b/runner/client/src/mill/runner/client/MillProcessLauncher.java
@@ -108,12 +108,10 @@ public class MillProcessLauncher {
   static String javaExe() {
     String javaHome = System.getProperty("java.home");
     String jvmId = "temurin:17";
-    if (javaHome == null || javaHome.isEmpty()){
-        System.err.println("Downloading JDK " + jvmId);
-        javaHome = CoursierClient
-            .resolveJavaHome(jvmId)
-            .getAbsolutePath();
-        System.err.println("Finished Downloading JDK " + jvmId + " to " + javaHome);
+    if (javaHome == null || javaHome.isEmpty()) {
+      System.err.println("Downloading JDK " + jvmId);
+      javaHome = CoursierClient.resolveJavaHome(jvmId).getAbsolutePath();
+      System.err.println("Finished Downloading JDK " + jvmId + " to " + javaHome);
     }
     final File exePath = new File(
         javaHome + File.separator + "bin" + File.separator + "java" + (isWin() ? ".exe" : ""));

--- a/runner/client/src/mill/runner/client/MillProcessLauncher.java
+++ b/runner/client/src/mill/runner/client/MillProcessLauncher.java
@@ -114,7 +114,9 @@ public class MillProcessLauncher {
         return exePath.getAbsolutePath();
       }
     }
-    return "java";
+    return CoursierClient
+        .resolveJavaHome("temurin:17", "latest.release")
+        .getAbsolutePath();
   }
 
   static String[] millClasspath() throws Exception {

--- a/runner/client/src/mill/runner/client/MillProcessLauncher.java
+++ b/runner/client/src/mill/runner/client/MillProcessLauncher.java
@@ -106,17 +106,19 @@ public class MillProcessLauncher {
   }
 
   static String javaExe() {
-    final String javaHome = System.getProperty("java.home");
-    if (javaHome != null && !javaHome.isEmpty()) {
-      final File exePath = new File(
-          javaHome + File.separator + "bin" + File.separator + "java" + (isWin() ? ".exe" : ""));
-      if (exePath.exists()) {
-        return exePath.getAbsolutePath();
-      }
+    String javaHome = System.getProperty("java.home");
+    String jvmId = "temurin:17";
+    if (javaHome == null || javaHome.isEmpty()){
+        System.err.println("Downloading JDK " + jvmId);
+        javaHome = CoursierClient
+            .resolveJavaHome(jvmId, "latest.release")
+            .getAbsolutePath();
+        System.err.println("Finished Downloading JDK " + jvmId + " to " + javaHome);
     }
-    return CoursierClient
-        .resolveJavaHome("temurin:17", "latest.release")
-        .getAbsolutePath();
+    final File exePath = new File(
+        javaHome + File.separator + "bin" + File.separator + "java" + (isWin() ? ".exe" : ""));
+
+    return exePath.getAbsolutePath();
   }
 
   static String[] millClasspath() throws Exception {

--- a/runner/client/src/mill/runner/client/MillProcessLauncher.java
+++ b/runner/client/src/mill/runner/client/MillProcessLauncher.java
@@ -113,7 +113,7 @@ public class MillProcessLauncher {
     return System.getProperty("os.name", "").startsWith("Windows");
   }
 
-  static String javaExe() throws IOException {
+  static String javaHome() throws IOException {
     String jvmId;
     Path millJvmVersionFile = millJvmVersionFile();
 
@@ -126,7 +126,12 @@ public class MillProcessLauncher {
 
     if (javaHome == null || javaHome.isEmpty()) javaHome = System.getProperty("java.home");
     if (javaHome == null || javaHome.isEmpty()) javaHome = System.getenv("JAVA_HOME");
-    if (javaHome == null || javaHome.isEmpty()) return "java";
+    return javaHome;
+  }
+
+  static String javaExe() throws IOException {
+    String javaHome = javaHome();
+    if (javaHome == null) return "java";
     else {
       final Path exePath = Paths.get(
           javaHome + File.separator + "bin" + File.separator + "java" + (isWin() ? ".exe" : ""));

--- a/runner/package.mill
+++ b/runner/package.mill
@@ -4,10 +4,14 @@ import mill._
 import mill.T
 
 object `package` extends RootModule with build.MillPublishScalaModule {
-  object client extends build.MillPublishJavaModule {
+  object client extends build.MillPublishScalaModule {
     def buildInfoPackageName = "mill.runner.client"
     def moduleDeps = Seq(build.main.client)
-    def ivyDeps = Agg(build.Deps.windowsAnsi)
+    def ivyDeps = Agg(
+      build.Deps.windowsAnsi,
+      build.Deps.coursier,
+      build.Deps.coursierJvm
+    )
   }
 
   def moduleDeps = Seq(

--- a/runner/package.mill
+++ b/runner/package.mill
@@ -33,7 +33,6 @@ object `package` extends RootModule with build.MillPublishScalaModule {
     build.main.server,
     client
   )
-  def skipPreviousVersions: T[Seq[String]] = Seq("0.11.0-M7")
 
   object linenumbers extends build.MillPublishScalaModule {
     def moduleDeps = Seq(build.main.client)

--- a/runner/package.mill
+++ b/runner/package.mill
@@ -4,6 +4,9 @@ import mill._
 import mill.contrib.buildinfo.BuildInfo
 object `package` extends RootModule with build.MillPublishScalaModule {
   object client extends build.MillPublishScalaModule with BuildInfo{
+    // Disable scalafix because it seems to misbehave and cause
+    // spurious errors when there are mixed Java/Scala sources
+    def fix(args: String*): Command[Unit] = T.command {}
     def buildInfoPackageName = "mill.runner.client"
     def moduleDeps = Seq(build.main.client)
     def ivyDeps = Agg(

--- a/runner/package.mill
+++ b/runner/package.mill
@@ -1,16 +1,19 @@
 package build.runner
 // imports
 import mill._
-import mill.T
-
+import mill.contrib.buildinfo.BuildInfo
 object `package` extends RootModule with build.MillPublishScalaModule {
-  object client extends build.MillPublishScalaModule {
+  object client extends build.MillPublishScalaModule with BuildInfo{
     def buildInfoPackageName = "mill.runner.client"
     def moduleDeps = Seq(build.main.client)
     def ivyDeps = Agg(
       build.Deps.windowsAnsi,
       build.Deps.coursier,
       build.Deps.coursierJvm
+    )
+    def buildInfoObjectName = "Versions"
+    def buildInfoMembers = Seq(
+      BuildInfo.Value("coursierJvmIndexVersion", build.Deps.coursierJvmIndexVersion)
     )
   }
 

--- a/runner/package.mill
+++ b/runner/package.mill
@@ -12,7 +12,8 @@ object `package` extends RootModule with build.MillPublishScalaModule {
     def ivyDeps = Agg(
       build.Deps.windowsAnsi,
       build.Deps.coursier,
-      build.Deps.coursierJvm
+      build.Deps.coursierJvm,
+      build.Deps.logback
     )
     def buildInfoObjectName = "Versions"
     def buildInfoMembers = Seq(

--- a/scalalib/src/mill/scalalib/NativeImageModule.scala
+++ b/scalalib/src/mill/scalalib/NativeImageModule.scala
@@ -19,7 +19,9 @@ import scala.util.Properties
  * }}}
  */
 @mill.api.experimental
-trait NativeImageModule extends RunModule with WithZincWorker {
+trait NativeImageModule extends WithZincWorker {
+  def runClasspath: T[Seq[PathRef]]
+  def finalMainClass: T[String]
 
   /**
    * [[https://www.graalvm.org/latest/reference-manual/native-image/#from-a-class Builds a native executable]] for this


### PR DESCRIPTION
* Bootstrap native image JVM using Coursier, rather than just hardcoding `java`
* Allow custom JVMs to be used for Mill server by specifying `.mill-jvm-version`
* Make sure we use separate download paths for `-native` and non`-native` mill executables
* Tidy up `dist/package.mill`
* Remove unnecessary `def fix` overrides now that `.fix` on empty modules no longer crashes