### PR TITLE
Eliminate sleep from android emulator doc examples

### DIFF
--- a/.github/workflows/post-build-selective.yml
+++ b/.github/workflows/post-build-selective.yml
@@ -60,6 +60,10 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
+      - name: Cleanup any previous avd's to avoid signing key conflicts
+        if : ${{ inputs.install-android-sdk }}
+        run: rm -rf /home/runner/.config/.android/avd
+
       - name: Set AVD environment variable globally
         if: ${{ inputs.install-android-sdk }}
         run: echo "ANDROID_AVD_HOME=/home/runner/.config/.android/avd" >> $GITHUB_ENV

--- a/example/android/javalib/1-hello-world/build.mill
+++ b/example/android/javalib/1-hello-world/build.mill
@@ -123,7 +123,7 @@ object app extends AndroidAppModule {
 
 > ./mill show app.startAndroidEmulator
 
-> sleep 20 && ./mill show app.adbDevices
+> ./mill show app.adbDevices
 ...emulator-5554...device...
 
 > ./mill show app.it | grep '"OK (1 test)"'

--- a/example/android/kotlinlib/1-hello-kotlin/build.mill
+++ b/example/android/kotlinlib/1-hello-kotlin/build.mill
@@ -121,7 +121,7 @@ object app extends AndroidAppKotlinModule {
 
 > ./mill show app.startAndroidEmulator
 
-> sleep 20 && ./mill show app.adbDevices
+> ./mill show app.adbDevices
 ...emulator-5556...device...
 
 > ./mill show app.it | grep '"OK (1 test)"'

--- a/scalalib/src/mill/javalib/android/AndroidAppBundle.scala
+++ b/scalalib/src/mill/javalib/android/AndroidAppBundle.scala
@@ -3,6 +3,7 @@ package mill.javalib.android
 import mill._
 import mill.scalalib._
 import mill.api.PathRef
+import os.zip.ZipSource
 
 /**
  * A Trait for Android App Bundle Creation
@@ -54,7 +55,7 @@ trait AndroidAppBundle extends AndroidAppModule with JavaModule {
       }
     }
 
-    os.zip(Task.dest / "bundle.zip", Seq(baseDir))
+    os.zip(Task.dest / "bundle.zip", os.list(baseDir).map(ZipSource.fromPath))
 
     PathRef(Task.dest / "bundle.zip")
   }


### PR DESCRIPTION
### Summary

This should fix the android job back to green and has some improvements on handling the android emulator in the CI (and locally) , part of which eliminates the need for sleep hack in documentation examples.

Job reference on my fork can be found [here](https://github.com/vaslabs-ltd/mill/actions/runs/12688329695/job/35364858469) . ~~Sometimes the device may be stuck in unauthorized, I don't know the reason yet and can't yet replicate it locally .~~


#### Unauthorized issue

In https://github.com/ReactiveCircus/android-emulator-runner, it seems that the same issue occurs when caching is used. ~~I'm wondering if there's any implicit caching that I have missed in the github actions~~

After experimenting with https://github.com/vaslabs-ltd/test-android-emulator , it seems that the runner avd directory is polluted. Although I'm not sure why, deleting it (at least in test-android-emulator) fixes the unauthorized issue . I've added the same in the github action here

### Improvements

- Removed the need for sleep in doc examples by implementing a new wait for device boot flag, that's used internally by startAndroidEmulator in addition to listening for the booted log message. Having both can help identify potential issues locally or in a CI . `Task.Command(exclusive = true)` as suggested by @lihaoyi seems to have made it very stable

### Fixes

- Fixed the bundle failing for the manifest/AndroidManifest.xml error message by flattening the zip file. I am not sure when this broke, but bundle is not in my radar in the immediate future, so my focus was to keep it green for now. Bundle build tool also seems to be marked as experimental, not that it's an issue, just a mention.


### Note

For the wait, I initially had it in a task and used a while loop but changed my mind and having it outside of task context seems easier to control the behaviour . I can convert it into a tailrec function if you prefer that style


EDIT: changed the outcome of unauthorized after some experimentation on a clean repo
