### PR TITLE
Update cask examples to use SocketUtils.getFreeTcpPort

### DIFF
--- a/example/scalalib/web/1-todo-webapp/build.mill
+++ b/example/scalalib/web/1-todo-webapp/build.mill
@@ -4,7 +4,7 @@ import mill._, scalalib._
 object `package` extends RootModule with ScalaModule {
   def scalaVersion = "2.13.8"
   def ivyDeps = Agg(
-    ivy"com.lihaoyi::cask:0.9.1",
+    ivy"com.lihaoyi::cask:0.9.6",
     ivy"com.lihaoyi::scalatags:0.12.0"
   )
 

--- a/example/scalalib/web/1-todo-webapp/test/src/WebAppTests.scala
+++ b/example/scalalib/web/1-todo-webapp/test/src/WebAppTests.scala
@@ -4,13 +4,14 @@ import utest._
 
 object WebAppTests extends TestSuite {
   def withServer[T](example: cask.main.Main)(f: String => T): T = {
+    val port = cask.util.SocketUtils.getFreeTcpPort
     val server = io.undertow.Undertow.builder
-      .addHttpListener(8181, "localhost")
+      .addHttpListener(port, "localhost")
       .setHandler(example.defaultHandler)
       .build
     server.start()
     val res =
-      try f("http://localhost:8181")
+      try f(s"http://localhost:$port")
       finally server.stop()
     res
   }

--- a/example/scalalib/web/2-webapp-cache-busting/build.mill
+++ b/example/scalalib/web/2-webapp-cache-busting/build.mill
@@ -5,7 +5,7 @@ import java.util.Arrays
 object `package` extends RootModule with ScalaModule {
   def scalaVersion = "2.13.8"
   def ivyDeps = Agg(
-    ivy"com.lihaoyi::cask:0.9.1",
+    ivy"com.lihaoyi::cask:0.9.6",
     ivy"com.lihaoyi::scalatags:0.12.0",
     ivy"com.lihaoyi::os-lib:0.10.7"
   )

--- a/example/scalalib/web/2-webapp-cache-busting/test/src/WebAppTests.scala
+++ b/example/scalalib/web/2-webapp-cache-busting/test/src/WebAppTests.scala
@@ -4,13 +4,14 @@ import utest._
 
 object WebAppTests extends TestSuite {
   def withServer[T](example: cask.main.Main)(f: String => T): T = {
+    val port = cask.util.SocketUtils.getFreeTcpPort
     val server = io.undertow.Undertow.builder
-      .addHttpListener(8182, "localhost")
+      .addHttpListener(port, "localhost")
       .setHandler(example.defaultHandler)
       .build
     server.start()
     val res =
-      try f("http://localhost:8182")
+      try f(s"http://localhost:$port")
       finally server.stop()
     res
   }

--- a/example/scalalib/web/4-webapp-scalajs/build.mill
+++ b/example/scalalib/web/4-webapp-scalajs/build.mill
@@ -5,7 +5,7 @@ object `package` extends RootModule with ScalaModule {
 
   def scalaVersion = "2.13.14"
   def ivyDeps = Agg(
-    ivy"com.lihaoyi::cask:0.9.1",
+    ivy"com.lihaoyi::cask:0.9.6",
     ivy"com.lihaoyi::scalatags:0.12.0"
   )
 

--- a/example/scalalib/web/4-webapp-scalajs/test/src/WebAppTests.scala
+++ b/example/scalalib/web/4-webapp-scalajs/test/src/WebAppTests.scala
@@ -4,13 +4,14 @@ import utest._
 
 object WebAppTests extends TestSuite {
   def withServer[T](example: cask.main.Main)(f: String => T): T = {
+    val port = cask.util.SocketUtils.getFreeTcpPort
     val server = io.undertow.Undertow.builder
-      .addHttpListener(8184, "localhost")
+      .addHttpListener(port, "localhost")
       .setHandler(example.defaultHandler)
       .build
     server.start()
     val res =
-      try f("http://localhost:8184")
+      try f(s"http://localhost:$port")
       finally server.stop()
     res
   }

--- a/example/scalalib/web/5-webapp-scalajs-shared/build.mill
+++ b/example/scalalib/web/5-webapp-scalajs-shared/build.mill
@@ -11,7 +11,7 @@ trait AppScalaJSModule extends AppScalaModule with ScalaJSModule {
 
 object `package` extends RootModule with AppScalaModule {
   def moduleDeps = Seq(shared.jvm)
-  def ivyDeps = Agg(ivy"com.lihaoyi::cask:0.9.1")
+  def ivyDeps = Agg(ivy"com.lihaoyi::cask:0.9.6")
 
   def resources = Task {
     os.makeDir(Task.dest / "webapp")

--- a/example/scalalib/web/5-webapp-scalajs-shared/test/src/WebAppTests.scala
+++ b/example/scalalib/web/5-webapp-scalajs-shared/test/src/WebAppTests.scala
@@ -4,13 +4,14 @@ import utest._
 
 object WebAppTests extends TestSuite {
   def withServer[T](example: cask.main.Main)(f: String => T): T = {
+    val port = cask.util.SocketUtils.getFreeTcpPort
     val server = io.undertow.Undertow.builder
-      .addHttpListener(8185, "localhost")
+      .addHttpListener(port, "localhost")
       .setHandler(example.defaultHandler)
       .build
     server.start()
     val res =
-      try f("http://localhost:8185")
+      try f(s"http://localhost:$port")
       finally server.stop()
     res
   }


### PR DESCRIPTION
Part of https://github.com/com-lihaoyi/mill/issues/3802  
After https://github.com/com-lihaoyi/cask/pull/158 is merged.