### PR TITLE
Add OS-X CI smoketest job

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -65,6 +65,19 @@ jobs:
 
       - run: ./mill -i docs.githubPages + docs.checkBrokenLinks
 
+  mac:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - run: ./mill -i example.javalib.basic.__.local.server.test
+
   linux:
     needs: build-linux
     strategy:


### PR DESCRIPTION
Now that we'll have an OS-X publishing job for native image, we need to make sure that some basic smoketests pass on PRs before we merge them 