### PR TITLE
Tweak CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -170,7 +170,6 @@ jobs:
           - java-version: 11 # Run this with Mill native launcher as a smoketest
             millargs: "'integration.invalidation.__.native.server.test'"
 
-
     uses: ./.github/workflows/post-build-selective.yml
     with:
       os: windows-latest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -72,7 +72,7 @@ jobs:
 
       - run: "echo temurin:17 > .mill-jvm-version"
 
-      - run: ./mill -i example.javalib.basic.__.local.server.test
+      - run: ./mill -i example.scalalib.__.local.server.test
 
   linux:
     needs: build-linux
@@ -99,10 +99,6 @@ jobs:
 
           - java-version: 17 # Run this with Mill native launcher as a smoketest
             millargs: "'example.javalib.__.native.server.test'"
-            install-android-sdk: false
-
-          - java-version: 17
-            millargs: "'example.scalalib.__.local.server.test'"
             install-android-sdk: false
 
           - java-version: 17

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -69,6 +69,10 @@ jobs:
 
       - run: "echo temurin:17 > .mill-jvm-version"
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - run: ./mill -i example.scalalib.__.local.server.test
 
   linux:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -170,8 +170,6 @@ jobs:
           - java-version: 11 # Run this with Mill native launcher as a smoketest
             millargs: "'integration.invalidation.__.native.server.test'"
 
-          - java-version: 11
-            millargs: "contrib.__.test"
 
     uses: ./.github/workflows/post-build-selective.yml
     with:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,12 +25,9 @@ name: Run Tests
 
 # We run full CI on push builds to main and on all pull requests
 #
-# Manual builds (workflow_dispatch) to the main branch are also published
-#
-# To maximize bug-catching changes while keeping CI times reasonable, we run:
-# - All tests on Linux/Java17
-# - Fewer tests on Linux/Java11 and Windows/Java17
-# - Fewest tests on Windows/Java11
+# To maximize bug-catching changes while keeping CI times reasonable, we run
+# all tests on Linux, scattered between Java 11/17, except for one job run
+# on MacOS instead and a subset of jobs also run on windows
 
 on:
   push:
@@ -157,6 +154,10 @@ jobs:
         include:
           # just run a subset of examples/ on Windows, because for some reason running
           # the whole suite can take hours on windows v.s. half an hour on linux
+          #
+          # * One job unit tests,
+          # * One job each for local/packaged/native tests
+          # * At least one job for each of fork/server tests, and example/integration tests
           - java-version: 11
             millargs: '"{main,scalalib,bsp}.__.test"'
 


### PR DESCRIPTION
* Drop windows `contrib.__.test` job; it's very slow (for some reason much slower than the linux version) and basically has never caught anything
* Move entire `example.scalalib.__.local.server.test` job onto mac, to exercise a wider set of functionality there, and remove the Linux version of the job