### PR TITLE
Part of Android Studio Integration: Fix apk installation failure

### DIFF
--- a/scalalib/src/mill/javalib/android/AndroidAppModule.scala
+++ b/scalalib/src/mill/javalib/android/AndroidAppModule.scala
@@ -897,10 +897,12 @@ trait AndroidAppModule extends JavaModule {
   private def androidDebugKeystore: Task[PathRef] = Task(persistent = true) {
     val debugFileName = "mill-debug.jks"
     val globalDebugFileLocation = os.home / ".android"
+
+
     if (!os.exists(globalDebugFileLocation)) {
       os.makeDir(globalDebugFileLocation)
     }
-    // TODO maybe we need a file lock here
+
     val debugKeystoreFile = os.home / ".android" / debugFileName
 
     if (!os.exists(debugKeystoreFile)) {

--- a/scalalib/src/mill/javalib/android/AndroidAppModule.scala
+++ b/scalalib/src/mill/javalib/android/AndroidAppModule.scala
@@ -898,7 +898,6 @@ trait AndroidAppModule extends JavaModule {
     val debugFileName = "mill-debug.jks"
     val globalDebugFileLocation = os.home / ".android"
 
-
     if (!os.exists(globalDebugFileLocation)) {
       os.makeDir(globalDebugFileLocation)
     }

--- a/scalalib/src/mill/javalib/android/AndroidAppModule.scala
+++ b/scalalib/src/mill/javalib/android/AndroidAppModule.scala
@@ -927,6 +927,7 @@ trait AndroidAppModule extends JavaModule {
         debugKeyPass
       ))
     }
+
     val debugKeystoreTaskFile = T.dest / debugFileName
 
     os.copy(debugKeystoreFile, debugKeystoreTaskFile)

--- a/scalalib/src/mill/javalib/android/AndroidAppModule.scala
+++ b/scalalib/src/mill/javalib/android/AndroidAppModule.scala
@@ -896,13 +896,13 @@ trait AndroidAppModule extends JavaModule {
 
   private def androidDebugKeystore: Task[PathRef] = Task(persistent = true) {
     val debugFileName = "mill-debug.jks"
-    val globalDebugFileLocation = os.home / ".android"
+    val globalDebugFileLocation = os.home / ".mill-android"
 
     if (!os.exists(globalDebugFileLocation)) {
       os.makeDir(globalDebugFileLocation)
     }
 
-    val debugKeystoreFile = os.home / ".android" / debugFileName
+    val debugKeystoreFile = globalDebugFileLocation / debugFileName
 
     if (!os.exists(debugKeystoreFile)) {
       // TODO test on windows and mac and/or change implementation with java APIs

--- a/scalalib/src/mill/javalib/android/AndroidAppModule.scala
+++ b/scalalib/src/mill/javalib/android/AndroidAppModule.scala
@@ -895,30 +895,30 @@ trait AndroidAppModule extends JavaModule {
   }
 
   private def androidDebugKeystore: T[PathRef] = Task(persistent = true) {
-    // TODO store this key outside of the build file structure, because once build folders are deleted, new key will
-    //  be created, so app will have another signature leading to the need to remove app from the device/emulator
-    //  before installing a new build, which is annoying.
-    val debugKeystoreFile = T.dest / "debugKeyStore.jks"
-    os.call((
-      "keytool",
-      "-genkeypair",
-      "-keystore",
-      debugKeystoreFile,
-      "-alias",
-      debugKeyAlias,
-      "-dname",
-      "CN=MILL, OU=MILL, O=MILL, L=MILL, S=MILL, C=MILL",
-      "-validity",
-      "10000",
-      "-keyalg",
-      "RSA",
-      "-keysize",
-      "2048",
-      "-storepass",
-      debugKeyStorePass,
-      "-keypass",
-      debugKeyPass
-    ))
+    // TODO maybe we need a file lock here
+    val debugKeystoreFile = os.home / ".android" / "mill-debug.jks"
+    if (!os.exists(debugKeystoreFile)) {
+      os.call((
+        "keytool",
+        "-genkeypair",
+        "-keystore",
+        debugKeystoreFile,
+        "-alias",
+        debugKeyAlias,
+        "-dname",
+        "CN=MILL, OU=MILL, O=MILL, L=MILL, S=MILL, C=MILL",
+        "-validity",
+        "10000",
+        "-keyalg",
+        "RSA",
+        "-keysize",
+        "2048",
+        "-storepass",
+        debugKeyStorePass,
+        "-keypass",
+        debugKeyPass
+      ))
+    }
     PathRef(debugKeystoreFile)
   }
 

--- a/scalalib/src/mill/javalib/android/AndroidAppModule.scala
+++ b/scalalib/src/mill/javalib/android/AndroidAppModule.scala
@@ -896,6 +896,10 @@ trait AndroidAppModule extends JavaModule {
 
   private def androidDebugKeystore: Task[PathRef] = Task(persistent = true) {
     val debugFileName = "mill-debug.jks"
+    val globalDebugFileLocation = os.home / ".android"
+    if (!os.exists(globalDebugFileLocation)) {
+      os.makeDir(globalDebugFileLocation)
+    }
     // TODO maybe we need a file lock here
     val debugKeystoreFile = os.home / ".android" / debugFileName
 

--- a/scalalib/src/mill/javalib/android/AndroidAppModule.scala
+++ b/scalalib/src/mill/javalib/android/AndroidAppModule.scala
@@ -894,7 +894,7 @@ trait AndroidAppModule extends JavaModule {
     emulator
   }
 
-  private def androidDebugKeystore: T[PathRef] = Task(persistent = true) {
+  private def androidDebugKeystore(): PathRef = {
     // TODO maybe we need a file lock here
     val debugKeystoreFile = os.home / ".android" / "mill-debug.jks"
     if (!os.exists(debugKeystoreFile)) {

--- a/scalalib/src/mill/javalib/android/AndroidAppModule.scala
+++ b/scalalib/src/mill/javalib/android/AndroidAppModule.scala
@@ -894,10 +894,13 @@ trait AndroidAppModule extends JavaModule {
     emulator
   }
 
-  private def androidDebugKeystore(): PathRef = {
+  private def androidDebugKeystore: Task[PathRef] = Task(persistent = true) {
+    val debugFileName = "mill-debug.jks"
     // TODO maybe we need a file lock here
-    val debugKeystoreFile = os.home / ".android" / "mill-debug.jks"
+    val debugKeystoreFile = os.home / ".android" / debugFileName
+
     if (!os.exists(debugKeystoreFile)) {
+      // TODO test on windows and mac and/or change implementation with java APIs
       os.call((
         "keytool",
         "-genkeypair",
@@ -919,7 +922,11 @@ trait AndroidAppModule extends JavaModule {
         debugKeyPass
       ))
     }
-    PathRef(debugKeystoreFile)
+    val debugKeystoreTaskFile = T.dest / debugFileName
+
+    os.copy(debugKeystoreFile, debugKeystoreTaskFile)
+
+    PathRef(debugKeystoreTaskFile)
   }
 
   protected def androidKeystore: T[PathRef] = Task {


### PR DESCRIPTION
### Motivation 
The following small PR is part of integrating android studio with mill, so it is focused on developer experience. This was already mentioned as a TODO in the androidDebugKeystore method. The screenshot below is with an attempt to hook together android studio and mill and deleting the out directory, then trying to run the bsp test (work pending)

![image](https://github.com/user-attachments/assets/90688bcc-b919-41ee-bd43-6a65436d7485)

So far, the debug keystore, is stored in the task destination directory, which makes it ephemeral, even for a local development device, as out directory can be wiped frequently.

### Advice needed

We followed a similar approach that gradle and android studio use, excluding the lock file. So I'm marking this PR as draft and asking for opinions on:
1. should we handle multi-process access to the debug keystore (i.e. use a file lock)?
2. is it a problem that we break sandbox (we already do with android emulator) and if it is, should we maintain the current functionality for mill sandbox?


### Context

As part of Android studio integration, we are trying to make the bsp integration work for Mill Android module. With some crude adjustments, some functionality starts working (e.g. change bspCompileClasspath to be in sync with compile classpath) and then configure the testTask to work properly with test results etc (work pending). 

The aim is to find small things that are not working and send small PRs instead of an uber PR in the end.


This is co-authored with @irodotos7

### Update

For now, I've kept the keystore in debug destination, but its original location is the global one (so it's copied over), so the persistent is still working, but now it is also idempotent (assuming the original file in global position is not changed) . Not sure if this is actually needed, I think just having the global dest is much simpler but let's see how it goes and how this evolves