### PR TITLE
Test Draft PR

### DIFF
--- a/.github/workflows/draft-ci.yml
+++ b/.github/workflows/draft-ci.yml
@@ -14,11 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions: write-all
     steps:
-      - name: Debug Echos
-        run: |
-          echo ${{ github.event.action }}
-          echo ${{ github.event.action == 'ready_for_review' }}
-          echo "${{ github.event.pull_request.head.repo.html_url }}/commits/${{github.event.pull_request.head.ref}}"
       - name: Create status
         run: |
           curl --request POST \
@@ -27,7 +22,7 @@ jobs:
           --header 'content-type: application/json' \
           --data '{
             "state": "${{(github.event.action != 'ready_for_review' && github.event.pull_request.draft) && 'pending' || 'success'}}",
-            "context": "Draft CI / link",
+            "context": "Draft CI / run",
             "target_url": ${{(github.event.action != 'ready_for_review' && github.event.pull_request.draft) && format('"{0}/commits/{1}"', github.event.pull_request.head.repo.html_url, github.event.pull_request.head.ref) || 'null'}},
             "description": "${{(github.event.action != 'ready_for_review' && github.event.pull_request.draft) && 'use CI on your repo fork (link on right) until this PR is ready for review' || 'PR is ready for review, running CI in Mill repo'}}"
             }' \

--- a/.github/workflows/pre-build.yml
+++ b/.github/workflows/pre-build.yml
@@ -29,6 +29,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.base_ref }}
+        if: ${{ !(github.event.action == 'push' && github.repository != 'com-lihaoyi/mill') }}
+
+      - run: git
+        with:
+          ref: main
+          repository: https://github.com/com-lihaoyi/mill
+        if: ${{ github.event.action == 'push' && github.repository != 'com-lihaoyi/mill' }}
 
       - run: echo temurin:${{ inputs.java-version }} > .mill-jvm-version
 
@@ -40,7 +47,7 @@ jobs:
       - run: cat .mill-jvm-version
 
       - run: ./mill -i -k selective.prepare ${{ inputs.prepareargs }}
-        if: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-all-tests') }}
+        if: ${{ (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-all-tests')) || github.repository != 'com-lihaoyi/mill' }}
 
       - uses: actions/upload-artifact@v4.6.0
         with:

--- a/.github/workflows/pre-build.yml
+++ b/.github/workflows/pre-build.yml
@@ -31,7 +31,7 @@ jobs:
           ref: ${{ github.base_ref }}
         if: ${{ !(github.event.action == 'push' && github.repository != 'com-lihaoyi/mill') }}
 
-      - run: git
+      - uses: actions/checkout@v4
         with:
           ref: main
           repository: https://github.com/com-lihaoyi/mill

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       REPO_DEPLOY_KEY: ${{ secrets.REPO_DEPLOY_KEY }}
+      MILL_STABLE_VERSION: 1
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -84,8 +84,6 @@ jobs:
 
       - run: ./mill -i example.scalalib.__.local.server.test
 
-    strategy: { matrix: { include: [ dummy: 1 ] } } # dummy matrix to make job not show up in UI if skipped
-
   linux:
     needs: build-linux
     strategy:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -60,7 +60,8 @@ jobs:
       os: ubuntu-latest
     strategy:
       matrix:
-        dummy: 1
+        include:
+          - dummy: 1
 
   build-windows:
     needs: main-ci
@@ -69,7 +70,8 @@ jobs:
       os: windows-latest
     strategy:
       matrix:
-        dummy: 1
+        include:
+          - dummy: 1
 
   test-docs:
     needs: main-ci
@@ -81,7 +83,8 @@ jobs:
       - run: ./mill -i docs.fastPages + docs.checkBrokenLinks
     strategy:
       matrix:
-        dummy: 1
+        include:
+          - dummy: 1
 
   mac:
     needs: main-ci
@@ -99,7 +102,8 @@ jobs:
       - run: ./mill -i example.scalalib.__.local.server.test
     strategy:
       matrix:
-        dummy: 1
+        include:
+          - dummy: 1
 
   linux:
     needs: build-linux

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -58,20 +58,16 @@ jobs:
     uses: ./.github/workflows/pre-build.yml
     with:
       os: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - dummy: 1
+    # dummy matrix to make job not show up in UI if skipped
+    strategy: {matrix: {include: [dummy: 1]}}
 
   build-windows:
     needs: main-ci
     uses: ./.github/workflows/pre-build.yml
     with:
       os: windows-latest
-    strategy:
-      matrix:
-        include:
-          - dummy: 1
+    # dummy matrix to make job not show up in UI if skipped
+    strategy: { matrix: { include: [ dummy: 1 ] } }
 
   test-docs:
     needs: main-ci
@@ -81,10 +77,8 @@ jobs:
         with: { fetch-depth: 1 }
 
       - run: ./mill -i docs.fastPages + docs.checkBrokenLinks
-    strategy:
-      matrix:
-        include:
-          - dummy: 1
+    # dummy matrix to make job not show up in UI if skipped
+    strategy: { matrix: { include: [ dummy: 1 ] } }
 
   mac:
     needs: main-ci
@@ -100,10 +94,8 @@ jobs:
           node-version: '22'
 
       - run: ./mill -i example.scalalib.__.local.server.test
-    strategy:
-      matrix:
-        include:
-          - dummy: 1
+    # dummy matrix to make job not show up in UI if skipped
+    strategy: { matrix: { include: [ dummy: 1 ] } }
 
   linux:
     needs: build-linux

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with: { fetch-depth: 0 }
+        with: { fetch-depth: 1 }
 
       - run: ./mill -i docs.fastPages + docs.checkBrokenLinks
 
@@ -74,7 +74,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
-        with: { fetch-depth: 0 }
+        with: { fetch-depth: 1 }
 
       - run: "echo temurin:17 > .mill-jvm-version"
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -56,16 +56,14 @@ jobs:
   # in the list should be the one that's most worth looking into
   build-linux:
     uses: ./.github/workflows/pre-build.yml
-    with: {os: ubuntu-latest}
-
-    strategy: {matrix: {include: [dummy: 1]}} # dummy matrix to make job not show up in UI if skipped
+    with:
+      os: ubuntu-latest
 
   build-windows:
     needs: main-ci
     uses: ./.github/workflows/pre-build.yml
-    with: {os: windows-latest}
-
-    strategy: { matrix: { include: [ dummy: 1 ] } } # dummy matrix to make job not show up in UI if skipped
+    with:
+      os: windows-latest
 
   test-docs:
     needs: main-ci
@@ -75,8 +73,6 @@ jobs:
         with: { fetch-depth: 1 }
 
       - run: ./mill -i docs.fastPages + docs.checkBrokenLinks
-
-    strategy: { matrix: { include: [ dummy: 1 ] } } # dummy matrix to make job not show up in UI if skipped
 
   mac:
     needs: main-ci
@@ -228,5 +224,3 @@ jobs:
     with:
       java-version: '17'
       buildcmd: ./mill -i mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll __.sources + __.mimaReportBinaryIssues + __.fix --check + mill.javalib.palantirformat.PalantirFormatModule/ --check + mill.kotlinlib.ktlint.KtlintModule/checkFormatAll
-
-    strategy: { matrix: { include: [ dummy: 1 ] } } # dummy matrix to make job not show up in UI if skipped

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -55,16 +55,21 @@ jobs:
   # Jobs are listed in rough order of priority: if multiple jobs fail, the first job
   # in the list should be the one that's most worth looking into
   build-linux:
-
     uses: ./.github/workflows/pre-build.yml
     with:
       os: ubuntu-latest
+    strategy:
+      matrix:
+        dummy: 1
 
   build-windows:
     needs: main-ci
     uses: ./.github/workflows/pre-build.yml
     with:
       os: windows-latest
+    strategy:
+      matrix:
+        dummy: 1
 
   test-docs:
     needs: main-ci
@@ -74,6 +79,9 @@ jobs:
         with: { fetch-depth: 1 }
 
       - run: ./mill -i docs.fastPages + docs.checkBrokenLinks
+    strategy:
+      matrix:
+        dummy: 1
 
   mac:
     needs: main-ci
@@ -89,6 +97,9 @@ jobs:
           node-version: '22'
 
       - run: ./mill -i example.scalalib.__.local.server.test
+    strategy:
+      matrix:
+        dummy: 1
 
   linux:
     needs: build-linux

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -56,16 +56,14 @@ jobs:
   # in the list should be the one that's most worth looking into
   build-linux:
     uses: ./.github/workflows/pre-build.yml
-    with:
-      os: ubuntu-latest
+    with: {os: ubuntu-latest}
 
     strategy: {matrix: {include: [dummy: 1]}} # dummy matrix to make job not show up in UI if skipped
 
   build-windows:
     needs: main-ci
     uses: ./.github/workflows/pre-build.yml
-    with:
-      os: windows-latest
+    with: {os: windows-latest}
 
     strategy: { matrix: { include: [ dummy: 1 ] } } # dummy matrix to make job not show up in UI if skipped
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -46,22 +46,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  main-ci:
+    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
+    runs-on: ubuntu-latest
   # Jobs are listed in rough order of priority: if multiple jobs fail, the first job
   # in the list should be the one that's most worth looking into
   build-linux:
-    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
+
     uses: ./.github/workflows/pre-build.yml
     with:
       os: ubuntu-latest
 
   build-windows:
-    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
+    needs: main-ci
     uses: ./.github/workflows/pre-build.yml
     with:
       os: windows-latest
 
   test-docs:
-    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
+    needs: main-ci
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -70,7 +73,7 @@ jobs:
       - run: ./mill -i docs.fastPages + docs.checkBrokenLinks
 
   mac:
-    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
+    needs: main-ci
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo "hello world"
-        
+
   # Jobs are listed in rough order of priority: if multiple jobs fail, the first job
   # in the list should be the one that's most worth looking into
   build-linux:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -49,6 +49,9 @@ jobs:
   main-ci:
     if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
+    steps:
+      - run: echo "hello world"
+        
   # Jobs are listed in rough order of priority: if multiple jobs fail, the first job
   # in the list should be the one that's most worth looking into
   build-linux:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -58,16 +58,16 @@ jobs:
     uses: ./.github/workflows/pre-build.yml
     with:
       os: ubuntu-latest
-    # dummy matrix to make job not show up in UI if skipped
-    strategy: {matrix: {include: [dummy: 1]}}
+
+    strategy: {matrix: {include: [dummy: 1]}} # dummy matrix to make job not show up in UI if skipped
 
   build-windows:
     needs: main-ci
     uses: ./.github/workflows/pre-build.yml
     with:
       os: windows-latest
-    # dummy matrix to make job not show up in UI if skipped
-    strategy: { matrix: { include: [ dummy: 1 ] } }
+
+    strategy: { matrix: { include: [ dummy: 1 ] } } # dummy matrix to make job not show up in UI if skipped
 
   test-docs:
     needs: main-ci
@@ -77,8 +77,8 @@ jobs:
         with: { fetch-depth: 1 }
 
       - run: ./mill -i docs.fastPages + docs.checkBrokenLinks
-    # dummy matrix to make job not show up in UI if skipped
-    strategy: { matrix: { include: [ dummy: 1 ] } }
+
+    strategy: { matrix: { include: [ dummy: 1 ] } } # dummy matrix to make job not show up in UI if skipped
 
   mac:
     needs: main-ci
@@ -94,8 +94,8 @@ jobs:
           node-version: '22'
 
       - run: ./mill -i example.scalalib.__.local.server.test
-    # dummy matrix to make job not show up in UI if skipped
-    strategy: { matrix: { include: [ dummy: 1 ] } }
+
+    strategy: { matrix: { include: [ dummy: 1 ] } } # dummy matrix to make job not show up in UI if skipped
 
   linux:
     needs: build-linux

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -228,3 +228,5 @@ jobs:
     with:
       java-version: '17'
       buildcmd: ./mill -i mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll __.sources + __.mimaReportBinaryIssues + __.fix --check + mill.javalib.palantirformat.PalantirFormatModule/ --check + mill.kotlinlib.ktlint.KtlintModule/checkFormatAll
+
+    strategy: { matrix: { include: [ dummy: 1 ] } } # dummy matrix to make job not show up in UI if skipped

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -45,26 +45,23 @@ concurrency:
   group: cancel-old-pr-runs-${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
-env:
-  RUN_MAIN_CI: ${{ (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false) }}
-
 jobs:
   # Jobs are listed in rough order of priority: if multiple jobs fail, the first job
   # in the list should be the one that's most worth looking into
   build-linux:
-    if: ${{ env.RUN_MAIN_CI }}
+    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
     uses: ./.github/workflows/pre-build.yml
     with:
       os: ubuntu-latest
 
   build-windows:
-    if: ${{ env.RUN_MAIN_CI }}
+    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
     uses: ./.github/workflows/pre-build.yml
     with:
       os: windows-latest
 
   test-docs:
-    if: ${{ env.RUN_MAIN_CI }}
+    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -73,7 +70,7 @@ jobs:
       - run: ./mill -i docs.fastPages + docs.checkBrokenLinks
 
   mac:
-    if: ${{ env.RUN_MAIN_CI }}
+    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -45,28 +45,26 @@ concurrency:
   group: cancel-old-pr-runs-${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
-jobs:
-  main-ci:
-    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "hello world"
+env:
+  RUN_MAIN_CI: ${{ (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false) }}
 
+jobs:
   # Jobs are listed in rough order of priority: if multiple jobs fail, the first job
   # in the list should be the one that's most worth looking into
   build-linux:
+    if: env.RUN_MAIN_CI
     uses: ./.github/workflows/pre-build.yml
     with:
       os: ubuntu-latest
 
   build-windows:
-    needs: main-ci
+    if: env.RUN_MAIN_CI
     uses: ./.github/workflows/pre-build.yml
     with:
       os: windows-latest
 
   test-docs:
-    needs: main-ci
+    if: env.RUN_MAIN_CI
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -75,7 +73,7 @@ jobs:
       - run: ./mill -i docs.fastPages + docs.checkBrokenLinks
 
   mac:
-    needs: main-ci
+    if: env.RUN_MAIN_CI
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -52,19 +52,19 @@ jobs:
   # Jobs are listed in rough order of priority: if multiple jobs fail, the first job
   # in the list should be the one that's most worth looking into
   build-linux:
-    if: env.RUN_MAIN_CI
+    if: ${{ env.RUN_MAIN_CI }}
     uses: ./.github/workflows/pre-build.yml
     with:
       os: ubuntu-latest
 
   build-windows:
-    if: env.RUN_MAIN_CI
+    if: ${{ env.RUN_MAIN_CI }}
     uses: ./.github/workflows/pre-build.yml
     with:
       os: windows-latest
 
   test-docs:
-    if: env.RUN_MAIN_CI
+    if: ${{ env.RUN_MAIN_CI }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -73,7 +73,7 @@ jobs:
       - run: ./mill -i docs.fastPages + docs.checkBrokenLinks
 
   mac:
-    if: env.RUN_MAIN_CI
+    if: ${{ env.RUN_MAIN_CI }}
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
 
-      - run: ./mill -i docs.githubPages + docs.checkBrokenLinks
+      - run: ./mill -i docs.fastPages + docs.checkBrokenLinks
 
   mac:
     if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)

--- a/build.mill
+++ b/build.mill
@@ -272,9 +272,11 @@ def millVersion: T[String] = Task.Input {
 }
 
 def millLastTag: T[String] = Task {
-  VcsVersion.vcsState().lastTag.getOrElse(
-    sys.error("No (last) git tag found. Your git history seems incomplete!")
-  )
+  if (Task.env.contains("MILL_STABLE_VERSION")) {
+    VcsVersion.vcsState().lastTag.getOrElse(
+      sys.error("No (last) git tag found. Your git history seems incomplete!")
+    )
+  } else "SNAPSHOT"
 }
 
 def millBinPlatform: T[String] = Task {


### PR DESCRIPTION
* Try to consolidate `Draft CI / link` and `Draft CI / run` statuses
* Remove debug echoes
* Make selective testing work on draft PRs running on user forks
* Make `millLastTag` rely on `MILL_STABLE_VERSION=1`, update `publish-docs` with that env var, and make `mac`  nad `test-docs` jobs do shallow clones
* Consolidate `action == ready_for_review`/`draft == false` checks under a single `main-ci` job that everyone else depends on