### PR TITLE
Properly close `ZincWorkerImpl` classloader when worker shuts down

### DIFF
--- a/scalalib/src/mill/scalalib/ZincWorkerModule.scala
+++ b/scalalib/src/mill/scalalib/ZincWorkerModule.scala
@@ -87,7 +87,8 @@ trait ZincWorkerModule extends mill.Module with OfflineSupportModule with Coursi
       classOf[Int], // jobs
       classOf[Boolean], // compileToJar
       classOf[Boolean], // zincLogDebug
-      classOf[Option[PathRef]] // javaHome
+      classOf[Option[PathRef]], // javaHome
+      classOf[() => Unit]
     )
       .newInstance(
         Left((
@@ -103,7 +104,8 @@ trait ZincWorkerModule extends mill.Module with OfflineSupportModule with Coursi
         jobs,
         java.lang.Boolean.FALSE,
         java.lang.Boolean.valueOf(zincLogDebug()),
-        javaHome()
+        javaHome(),
+        () => cl.close()
       )
     instance.asInstanceOf[ZincWorkerApi]
   }

--- a/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
+++ b/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
@@ -51,7 +51,8 @@ class ZincWorkerImpl(
     jobs: Int,
     compileToJar: Boolean,
     zincLogDebug: Boolean,
-    javaHome: Option[PathRef]
+    javaHome: Option[PathRef],
+    close0: () => Unit
 ) extends ZincWorkerApi with AutoCloseable {
   val libraryJarNameGrep: (Agg[PathRef], String) => PathRef =
     ZincWorkerUtil.grepJar(_, "scala-library", _, sources = false)
@@ -685,5 +686,6 @@ class ZincWorkerImpl(
     urlClassLoaders.foreach(_.close())
 
     classloaderCache.clear()
+    close0()
   }
 }


### PR DESCRIPTION
Previously we closed the nested classloaders, but the classloader we used to spawn `ZincWorkerImpl` itself was leaked