### PR TITLE
Upstream Mill's `dist.launcherScript` into `mill.util.Jvm.launcherUniversalScript`

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,25 +1,25 @@
 # Uncommment this to replace the rest of the file when you want to debug stuff in CI
-
-
-name: Run Debug
-
-on:
-  push:
-  pull_request:
-  workflow_dispatch:
-
-jobs:
-  debug-windows:
-#    runs-on: ubuntu-latest
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v4
-        with: { fetch-depth: 1 }
-
-      - run: ./mill scalalib.test mill.scalalib.LauncherTests.launcher
-        env:
-          COURSIER_ARCHIVE_CACHE: "C:/coursier-arc"
-
+#
+#
+#name: Run Debug
+#
+#on:
+#  push:
+#  pull_request:
+#  workflow_dispatch:
+#
+#jobs:
+#  debug-windows:
+##    runs-on: ubuntu-latest
+#    runs-on: windows-latest
+#    steps:
+#      - uses: actions/checkout@v4
+#        with: { fetch-depth: 1 }
+#
+#      - run: ./mill scalalib.test mill.scalalib.LauncherTests.launcher
+#        env:
+#          COURSIER_ARCHIVE_CACHE: "C:/coursier-arc"
+#
 
 # We run full CI on push builds to main and on all pull requests
 #
@@ -27,197 +27,197 @@ jobs:
 # all tests on Linux, scattered between Java 11/17, except for one job run
 # on MacOS instead and a subset of jobs also run on windows
 
-#
-#name: Run Tests
-#
-#on:
-#  push:
-#  pull_request:
-#    types:
-#      - opened
-#      - reopened
-#      - synchronize
-#      - ready_for_review
-#  workflow_dispatch:
-#
-## cancel older runs of a pull request;
-## this will not cancel anything for normal git pushes
-#concurrency:
-#  # * For runs on other repos, always use the `ref_name` so each branch only can have one concurrent run
-#  # * For runs on `com-lihaoyi/mill`, use `head_ref` to allow one concurrent run per PR, but `run_id` to
-#  #   allow multiple concurrent runs in master
-#  group: cancel-old-pr-runs-${{ github.workflow }}-${{ (github.repository != 'com-lihaoyi/mill' && github.ref_name) || (github.head_ref || github.run_id) }}
-#  cancel-in-progress: true
-#
-#jobs:
-#  # Jobs are listed in rough order of priority: if multiple jobs fail, the first job
-#  # in the list should be the one that's most worth looking into
-#  build-linux:
-#    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
-#    uses: ./.github/workflows/pre-build.yml
-#    with:
-#      os: ubuntu-latest
-#
-#  build-windows:
-#    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
-#    uses: ./.github/workflows/pre-build.yml
-#    with:
-#      os: windows-latest
-#
-#  test-docs:
-#    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v4
-#        with: { fetch-depth: 1 }
-#
-#      - run: ./mill -i docs.fastPages + docs.checkBrokenLinks
-#
-#  mac:
-#    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
-#    runs-on: macos-latest
-#    steps:
-#      - uses: actions/checkout@v4
-#        with: { fetch-depth: 1 }
-#
-#      - run: "echo temurin:17 > .mill-jvm-version"
-#
-#      - uses: actions/setup-node@v4
-#        with:
-#          node-version: '22'
-#
-#      - run: ./mill -i example.scalalib.__.local.server.test
-#
-#  linux:
-#    needs: build-linux
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#
-#        include:
-#          # For most tests, run them arbitrarily on Java 11 or Java 17 on Linux, and
-#          # on the opposite version on Windows below, so we get decent coverage of
-#          # each test on each Java version and each operating system
-#          # We also try to group tests together to manually balance out the runtimes of each jobs
-#          - java-version: 17
-#            millargs: "'{main,scalalib,testrunner,bsp,testkit}.__.test'"
-#            install-android-sdk: false
-#
-#          - java-version: 11
-#            millargs: "'{scalajslib,scalanativelib,kotlinlib,pythonlib,javascriptlib}.__.test'"
-#            install-android-sdk: false
-#
-#          - java-version: 17
-#            millargs: "contrib.__.test"
-#            install-android-sdk: false
-#
-#          - java-version: 17 # Run this with Mill native launcher as a smoketest
-#            millargs: "'example.javalib.__.native.server.test'"
-#            install-android-sdk: false
-#
-#          - java-version: 17
-#            millargs: "'example.kotlinlib.__.local.server.test'"
-#            install-android-sdk: false
-#
-#          - java-version: 17
-#            millargs: "'example.android.__.local.server.test'"
-#            install-android-sdk: true
-#
-#          - java-version: 17
-#            millargs: "'example.{pythonlib,javascriptlib}.__.local.server.test'"
-#            install-android-sdk: false
-#
-#          - java-version: 11
-#            millargs: "'example.thirdparty[{mockito,acyclic,commons-io}].local.server.test'"
-#            install-android-sdk: false
-#
-#          - java-version: 17
-#            millargs: "'example.thirdparty[{fansi,jimfs,netty,gatling}].local.server.test'"
-#            install-android-sdk: false
-#
-#          - java-version: '17'
-#            millargs: "'example.thirdparty[arrow].local.server.test'"
-#            install-android-sdk: false
-#
-#          - java-version: 11
-#            millargs: "'example.{cli,fundamentals,depth,extending}.__.local.server.test'"
-#            install-android-sdk: false
-#            # Most of these integration tests should not depend on which mode they
-#            # are run in, so just run them in `local`
-#          - java-version: '17'
-#            millargs: "'integration.{failure,feature,ide}.__.packaged.server.test'"
-#            install-android-sdk: false
-#            # These invalidation tests need to be exercised in both execution modes
-#            # to make sure they work with and without -i/--no-server being passed
-#          - java-version: 17
-#            millargs: "'integration.invalidation.__.packaged.fork.test'"
-#            install-android-sdk: false
-#
-#          - java-version: 17
-#            millargs: "'integration.invalidation.__.packaged.server.test'"
-#            install-android-sdk: false
-#
-#    uses: ./.github/workflows/post-build-selective.yml
-#    with:
-#      install-android-sdk: ${{ matrix.install-android-sdk }}
-#      java-version: ${{ matrix.java-version }}
-#      millargs: ${{ matrix.millargs }}
-#
-#  windows:
-#    needs: build-windows
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        include:
-#          # just run a subset of examples/ on Windows, because for some reason running
-#          # the whole suite can take hours on windows v.s. half an hour on linux
-#          #
-#          # * One job unit tests,
-#          # * One job each for local/packaged/native tests
-#          # * At least one job for each of fork/server tests, and example/integration tests
-#          - java-version: 11
-#            millargs: '"{main,scalalib,bsp}.__.test"'
-#
-#          - java-version: 11
-#            millargs: '"example.scalalib.{basic,publishing}.__.local.fork.test"'
-#
-#          - java-version: 17
-#            millargs: "'integration.{feature,failure}.__.packaged.fork.test'"
-#
-#          - java-version: 11 # Run this with Mill native launcher as a smoketest
-#            millargs: "'integration.invalidation.__.native.server.test'"
-#
-#    uses: ./.github/workflows/post-build-selective.yml
-#    with:
-#      os: windows-latest
-#      java-version: ${{ matrix.java-version }}
-#      millargs: ${{ matrix.millargs }}
-#      # Provide a shorter coursier archive folder to avoid hitting path-length bugs when
-#      # running the graal native image binary on windows
-#      coursierarchive: "C:/coursier-arc"
-#
-#  itest:
-#    needs: build-linux
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        include:
-#          # bootstrap tests
-#          - java-version: 11 # Have one job on oldest JVM
-#            buildcmd: ci/test-mill-dev.sh && ci/test-mill-release.sh && ./mill -i -k __.ivyDepsTree && ./mill -i -k __.ivyDepsTree --withRuntime
-#          - java-version: 17 # Have one job on default JVM
-#            buildcmd: ci/test-mill-bootstrap.sh
-#
-#    uses: ./.github/workflows/post-build-raw.yml
-#    with:
-#      java-version: ${{ matrix.java-version }}
-#      buildcmd: ${{ matrix.buildcmd }}
-#
-#  # Scalafmt, Mima, and Scalafix job runs last because it's the least important:
-#  # usually just an automated or mechanical manual fix to do before merging
-#  lint-autofix:
-#    needs: build-linux
-#    uses: ./.github/workflows/post-build-raw.yml
-#    with:
-#      java-version: '17'
-#      buildcmd: ./mill -i mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll __.sources + __.mimaReportBinaryIssues + __.fix --check + mill.javalib.palantirformat.PalantirFormatModule/ --check + mill.kotlinlib.ktlint.KtlintModule/checkFormatAll
+
+name: Run Tests
+
+on:
+  push:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+  workflow_dispatch:
+
+# cancel older runs of a pull request;
+# this will not cancel anything for normal git pushes
+concurrency:
+  # * For runs on other repos, always use the `ref_name` so each branch only can have one concurrent run
+  # * For runs on `com-lihaoyi/mill`, use `head_ref` to allow one concurrent run per PR, but `run_id` to
+  #   allow multiple concurrent runs in master
+  group: cancel-old-pr-runs-${{ github.workflow }}-${{ (github.repository != 'com-lihaoyi/mill' && github.ref_name) || (github.head_ref || github.run_id) }}
+  cancel-in-progress: true
+
+jobs:
+  # Jobs are listed in rough order of priority: if multiple jobs fail, the first job
+  # in the list should be the one that's most worth looking into
+  build-linux:
+    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
+    uses: ./.github/workflows/pre-build.yml
+    with:
+      os: ubuntu-latest
+
+  build-windows:
+    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
+    uses: ./.github/workflows/pre-build.yml
+    with:
+      os: windows-latest
+
+  test-docs:
+    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 1 }
+
+      - run: ./mill -i docs.fastPages + docs.checkBrokenLinks
+
+  mac:
+    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 1 }
+
+      - run: "echo temurin:17 > .mill-jvm-version"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - run: ./mill -i example.scalalib.__.local.server.test
+
+  linux:
+    needs: build-linux
+    strategy:
+      fail-fast: false
+      matrix:
+
+        include:
+          # For most tests, run them arbitrarily on Java 11 or Java 17 on Linux, and
+          # on the opposite version on Windows below, so we get decent coverage of
+          # each test on each Java version and each operating system
+          # We also try to group tests together to manually balance out the runtimes of each jobs
+          - java-version: 17
+            millargs: "'{main,scalalib,testrunner,bsp,testkit}.__.test'"
+            install-android-sdk: false
+
+          - java-version: 11
+            millargs: "'{scalajslib,scalanativelib,kotlinlib,pythonlib,javascriptlib}.__.test'"
+            install-android-sdk: false
+
+          - java-version: 17
+            millargs: "contrib.__.test"
+            install-android-sdk: false
+
+          - java-version: 17 # Run this with Mill native launcher as a smoketest
+            millargs: "'example.javalib.__.native.server.test'"
+            install-android-sdk: false
+
+          - java-version: 17
+            millargs: "'example.kotlinlib.__.local.server.test'"
+            install-android-sdk: false
+
+          - java-version: 17
+            millargs: "'example.android.__.local.server.test'"
+            install-android-sdk: true
+
+          - java-version: 17
+            millargs: "'example.{pythonlib,javascriptlib}.__.local.server.test'"
+            install-android-sdk: false
+
+          - java-version: 11
+            millargs: "'example.thirdparty[{mockito,acyclic,commons-io}].local.server.test'"
+            install-android-sdk: false
+
+          - java-version: 17
+            millargs: "'example.thirdparty[{fansi,jimfs,netty,gatling}].local.server.test'"
+            install-android-sdk: false
+
+          - java-version: '17'
+            millargs: "'example.thirdparty[arrow].local.server.test'"
+            install-android-sdk: false
+
+          - java-version: 11
+            millargs: "'example.{cli,fundamentals,depth,extending}.__.local.server.test'"
+            install-android-sdk: false
+            # Most of these integration tests should not depend on which mode they
+            # are run in, so just run them in `local`
+          - java-version: '17'
+            millargs: "'integration.{failure,feature,ide}.__.packaged.server.test'"
+            install-android-sdk: false
+            # These invalidation tests need to be exercised in both execution modes
+            # to make sure they work with and without -i/--no-server being passed
+          - java-version: 17
+            millargs: "'integration.invalidation.__.packaged.fork.test'"
+            install-android-sdk: false
+
+          - java-version: 17
+            millargs: "'integration.invalidation.__.packaged.server.test'"
+            install-android-sdk: false
+
+    uses: ./.github/workflows/post-build-selective.yml
+    with:
+      install-android-sdk: ${{ matrix.install-android-sdk }}
+      java-version: ${{ matrix.java-version }}
+      millargs: ${{ matrix.millargs }}
+
+  windows:
+    needs: build-windows
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # just run a subset of examples/ on Windows, because for some reason running
+          # the whole suite can take hours on windows v.s. half an hour on linux
+          #
+          # * One job unit tests,
+          # * One job each for local/packaged/native tests
+          # * At least one job for each of fork/server tests, and example/integration tests
+          - java-version: 11
+            millargs: '"{main,scalalib,bsp}.__.test"'
+
+          - java-version: 11
+            millargs: '"example.scalalib.{basic,publishing}.__.local.fork.test"'
+
+          - java-version: 17
+            millargs: "'integration.{feature,failure}.__.packaged.fork.test'"
+
+          - java-version: 11 # Run this with Mill native launcher as a smoketest
+            millargs: "'integration.invalidation.__.native.server.test'"
+
+    uses: ./.github/workflows/post-build-selective.yml
+    with:
+      os: windows-latest
+      java-version: ${{ matrix.java-version }}
+      millargs: ${{ matrix.millargs }}
+      # Provide a shorter coursier archive folder to avoid hitting path-length bugs when
+      # running the graal native image binary on windows
+      coursierarchive: "C:/coursier-arc"
+
+  itest:
+    needs: build-linux
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # bootstrap tests
+          - java-version: 11 # Have one job on oldest JVM
+            buildcmd: ci/test-mill-dev.sh && ci/test-mill-release.sh && ./mill -i -k __.ivyDepsTree && ./mill -i -k __.ivyDepsTree --withRuntime
+          - java-version: 17 # Have one job on default JVM
+            buildcmd: ci/test-mill-bootstrap.sh
+
+    uses: ./.github/workflows/post-build-raw.yml
+    with:
+      java-version: ${{ matrix.java-version }}
+      buildcmd: ${{ matrix.buildcmd }}
+
+  # Scalafmt, Mima, and Scalafix job runs last because it's the least important:
+  # usually just an automated or mechanical manual fix to do before merging
+  lint-autofix:
+    needs: build-linux
+    uses: ./.github/workflows/post-build-raw.yml
+    with:
+      java-version: '17'
+      buildcmd: ./mill -i mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll __.sources + __.mimaReportBinaryIssues + __.fix --check + mill.javalib.palantirformat.PalantirFormatModule/ --check + mill.kotlinlib.ktlint.KtlintModule/checkFormatAll

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,27 +1,25 @@
 # Uncommment this to replace the rest of the file when you want to debug stuff in CI
 
-#
-#name: Run Debug
-#
-#on:
-#  push:
-#  pull_request:
-#  workflow_dispatch:
-#
-#jobs:
-#  debug-windows:
-##    runs-on: ubuntu-latest
-#    runs-on: windows-latest
-#    steps:
-#      - uses: actions/checkout@v4
-#        with: { fetch-depth: 1 }
-#
-#      - run: ./mill 'example.scalalib.basic[1-simple].packaged.fork.test'
-#        env:
-#          COURSIER_ARCHIVE_CACHE: "C:/coursier-arc"
 
+name: Run Debug
 
-name: Run Tests
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  debug-windows:
+#    runs-on: ubuntu-latest
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 1 }
+
+      - run: ./mill scalalib.test mill.scalalib.LauncherTests.launcher
+        env:
+          COURSIER_ARCHIVE_CACHE: "C:/coursier-arc"
+
 
 # We run full CI on push builds to main and on all pull requests
 #
@@ -29,194 +27,197 @@ name: Run Tests
 # all tests on Linux, scattered between Java 11/17, except for one job run
 # on MacOS instead and a subset of jobs also run on windows
 
-on:
-  push:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
-  workflow_dispatch:
-
-# cancel older runs of a pull request;
-# this will not cancel anything for normal git pushes
-concurrency:
-  # * For runs on other repos, always use the `ref_name` so each branch only can have one concurrent run
-  # * For runs on `com-lihaoyi/mill`, use `head_ref` to allow one concurrent run per PR, but `run_id` to
-  #   allow multiple concurrent runs in master
-  group: cancel-old-pr-runs-${{ github.workflow }}-${{ (github.repository != 'com-lihaoyi/mill' && github.ref_name) || (github.head_ref || github.run_id) }}
-  cancel-in-progress: true
-
-jobs:
-  # Jobs are listed in rough order of priority: if multiple jobs fail, the first job
-  # in the list should be the one that's most worth looking into
-  build-linux:
-    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
-    uses: ./.github/workflows/pre-build.yml
-    with:
-      os: ubuntu-latest
-
-  build-windows:
-    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
-    uses: ./.github/workflows/pre-build.yml
-    with:
-      os: windows-latest
-
-  test-docs:
-    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with: { fetch-depth: 1 }
-
-      - run: ./mill -i docs.fastPages + docs.checkBrokenLinks
-
-  mac:
-    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v4
-        with: { fetch-depth: 1 }
-
-      - run: "echo temurin:17 > .mill-jvm-version"
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-
-      - run: ./mill -i example.scalalib.__.local.server.test
-
-  linux:
-    needs: build-linux
-    strategy:
-      fail-fast: false
-      matrix:
-
-        include:
-          # For most tests, run them arbitrarily on Java 11 or Java 17 on Linux, and
-          # on the opposite version on Windows below, so we get decent coverage of
-          # each test on each Java version and each operating system
-          # We also try to group tests together to manually balance out the runtimes of each jobs
-          - java-version: 17
-            millargs: "'{main,scalalib,testrunner,bsp,testkit}.__.test'"
-            install-android-sdk: false
-
-          - java-version: 11
-            millargs: "'{scalajslib,scalanativelib,kotlinlib,pythonlib,javascriptlib}.__.test'"
-            install-android-sdk: false
-
-          - java-version: 17
-            millargs: "contrib.__.test"
-            install-android-sdk: false
-
-          - java-version: 17 # Run this with Mill native launcher as a smoketest
-            millargs: "'example.javalib.__.native.server.test'"
-            install-android-sdk: false
-
-          - java-version: 17
-            millargs: "'example.kotlinlib.__.local.server.test'"
-            install-android-sdk: false
-
-          - java-version: 17
-            millargs: "'example.android.__.local.server.test'"
-            install-android-sdk: true
-
-          - java-version: 17
-            millargs: "'example.{pythonlib,javascriptlib}.__.local.server.test'"
-            install-android-sdk: false
-
-          - java-version: 11
-            millargs: "'example.thirdparty[{mockito,acyclic,commons-io}].local.server.test'"
-            install-android-sdk: false
-
-          - java-version: 17
-            millargs: "'example.thirdparty[{fansi,jimfs,netty,gatling}].local.server.test'"
-            install-android-sdk: false
-
-          - java-version: '17'
-            millargs: "'example.thirdparty[arrow].local.server.test'"
-            install-android-sdk: false
-
-          - java-version: 11
-            millargs: "'example.{cli,fundamentals,depth,extending}.__.local.server.test'"
-            install-android-sdk: false
-            # Most of these integration tests should not depend on which mode they
-            # are run in, so just run them in `local`
-          - java-version: '17'
-            millargs: "'integration.{failure,feature,ide}.__.packaged.server.test'"
-            install-android-sdk: false
-            # These invalidation tests need to be exercised in both execution modes
-            # to make sure they work with and without -i/--no-server being passed
-          - java-version: 17
-            millargs: "'integration.invalidation.__.packaged.fork.test'"
-            install-android-sdk: false
-
-          - java-version: 17
-            millargs: "'integration.invalidation.__.packaged.server.test'"
-            install-android-sdk: false
-
-    uses: ./.github/workflows/post-build-selective.yml
-    with:
-      install-android-sdk: ${{ matrix.install-android-sdk }}
-      java-version: ${{ matrix.java-version }}
-      millargs: ${{ matrix.millargs }}
-
-  windows:
-    needs: build-windows
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # just run a subset of examples/ on Windows, because for some reason running
-          # the whole suite can take hours on windows v.s. half an hour on linux
-          #
-          # * One job unit tests,
-          # * One job each for local/packaged/native tests
-          # * At least one job for each of fork/server tests, and example/integration tests
-          - java-version: 11
-            millargs: '"{main,scalalib,bsp}.__.test"'
-
-          - java-version: 11
-            millargs: '"example.scalalib.{basic,publishing}.__.local.fork.test"'
-
-          - java-version: 17
-            millargs: "'integration.{feature,failure}.__.packaged.fork.test'"
-
-          - java-version: 11 # Run this with Mill native launcher as a smoketest
-            millargs: "'integration.invalidation.__.native.server.test'"
-
-    uses: ./.github/workflows/post-build-selective.yml
-    with:
-      os: windows-latest
-      java-version: ${{ matrix.java-version }}
-      millargs: ${{ matrix.millargs }}
-      # Provide a shorter coursier archive folder to avoid hitting path-length bugs when
-      # running the graal native image binary on windows
-      coursierarchive: "C:/coursier-arc"
-
-  itest:
-    needs: build-linux
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # bootstrap tests
-          - java-version: 11 # Have one job on oldest JVM
-            buildcmd: ci/test-mill-dev.sh && ci/test-mill-release.sh && ./mill -i -k __.ivyDepsTree && ./mill -i -k __.ivyDepsTree --withRuntime
-          - java-version: 17 # Have one job on default JVM
-            buildcmd: ci/test-mill-bootstrap.sh
-
-    uses: ./.github/workflows/post-build-raw.yml
-    with:
-      java-version: ${{ matrix.java-version }}
-      buildcmd: ${{ matrix.buildcmd }}
-
-  # Scalafmt, Mima, and Scalafix job runs last because it's the least important:
-  # usually just an automated or mechanical manual fix to do before merging
-  lint-autofix:
-    needs: build-linux
-    uses: ./.github/workflows/post-build-raw.yml
-    with:
-      java-version: '17'
-      buildcmd: ./mill -i mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll __.sources + __.mimaReportBinaryIssues + __.fix --check + mill.javalib.palantirformat.PalantirFormatModule/ --check + mill.kotlinlib.ktlint.KtlintModule/checkFormatAll
+#
+#name: Run Tests
+#
+#on:
+#  push:
+#  pull_request:
+#    types:
+#      - opened
+#      - reopened
+#      - synchronize
+#      - ready_for_review
+#  workflow_dispatch:
+#
+## cancel older runs of a pull request;
+## this will not cancel anything for normal git pushes
+#concurrency:
+#  # * For runs on other repos, always use the `ref_name` so each branch only can have one concurrent run
+#  # * For runs on `com-lihaoyi/mill`, use `head_ref` to allow one concurrent run per PR, but `run_id` to
+#  #   allow multiple concurrent runs in master
+#  group: cancel-old-pr-runs-${{ github.workflow }}-${{ (github.repository != 'com-lihaoyi/mill' && github.ref_name) || (github.head_ref || github.run_id) }}
+#  cancel-in-progress: true
+#
+#jobs:
+#  # Jobs are listed in rough order of priority: if multiple jobs fail, the first job
+#  # in the list should be the one that's most worth looking into
+#  build-linux:
+#    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
+#    uses: ./.github/workflows/pre-build.yml
+#    with:
+#      os: ubuntu-latest
+#
+#  build-windows:
+#    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
+#    uses: ./.github/workflows/pre-build.yml
+#    with:
+#      os: windows-latest
+#
+#  test-docs:
+#    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v4
+#        with: { fetch-depth: 1 }
+#
+#      - run: ./mill -i docs.fastPages + docs.checkBrokenLinks
+#
+#  mac:
+#    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
+#    runs-on: macos-latest
+#    steps:
+#      - uses: actions/checkout@v4
+#        with: { fetch-depth: 1 }
+#
+#      - run: "echo temurin:17 > .mill-jvm-version"
+#
+#      - uses: actions/setup-node@v4
+#        with:
+#          node-version: '22'
+#
+#      - run: ./mill -i example.scalalib.__.local.server.test
+#
+#  linux:
+#    needs: build-linux
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#
+#        include:
+#          # For most tests, run them arbitrarily on Java 11 or Java 17 on Linux, and
+#          # on the opposite version on Windows below, so we get decent coverage of
+#          # each test on each Java version and each operating system
+#          # We also try to group tests together to manually balance out the runtimes of each jobs
+#          - java-version: 17
+#            millargs: "'{main,scalalib,testrunner,bsp,testkit}.__.test'"
+#            install-android-sdk: false
+#
+#          - java-version: 11
+#            millargs: "'{scalajslib,scalanativelib,kotlinlib,pythonlib,javascriptlib}.__.test'"
+#            install-android-sdk: false
+#
+#          - java-version: 17
+#            millargs: "contrib.__.test"
+#            install-android-sdk: false
+#
+#          - java-version: 17 # Run this with Mill native launcher as a smoketest
+#            millargs: "'example.javalib.__.native.server.test'"
+#            install-android-sdk: false
+#
+#          - java-version: 17
+#            millargs: "'example.kotlinlib.__.local.server.test'"
+#            install-android-sdk: false
+#
+#          - java-version: 17
+#            millargs: "'example.android.__.local.server.test'"
+#            install-android-sdk: true
+#
+#          - java-version: 17
+#            millargs: "'example.{pythonlib,javascriptlib}.__.local.server.test'"
+#            install-android-sdk: false
+#
+#          - java-version: 11
+#            millargs: "'example.thirdparty[{mockito,acyclic,commons-io}].local.server.test'"
+#            install-android-sdk: false
+#
+#          - java-version: 17
+#            millargs: "'example.thirdparty[{fansi,jimfs,netty,gatling}].local.server.test'"
+#            install-android-sdk: false
+#
+#          - java-version: '17'
+#            millargs: "'example.thirdparty[arrow].local.server.test'"
+#            install-android-sdk: false
+#
+#          - java-version: 11
+#            millargs: "'example.{cli,fundamentals,depth,extending}.__.local.server.test'"
+#            install-android-sdk: false
+#            # Most of these integration tests should not depend on which mode they
+#            # are run in, so just run them in `local`
+#          - java-version: '17'
+#            millargs: "'integration.{failure,feature,ide}.__.packaged.server.test'"
+#            install-android-sdk: false
+#            # These invalidation tests need to be exercised in both execution modes
+#            # to make sure they work with and without -i/--no-server being passed
+#          - java-version: 17
+#            millargs: "'integration.invalidation.__.packaged.fork.test'"
+#            install-android-sdk: false
+#
+#          - java-version: 17
+#            millargs: "'integration.invalidation.__.packaged.server.test'"
+#            install-android-sdk: false
+#
+#    uses: ./.github/workflows/post-build-selective.yml
+#    with:
+#      install-android-sdk: ${{ matrix.install-android-sdk }}
+#      java-version: ${{ matrix.java-version }}
+#      millargs: ${{ matrix.millargs }}
+#
+#  windows:
+#    needs: build-windows
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        include:
+#          # just run a subset of examples/ on Windows, because for some reason running
+#          # the whole suite can take hours on windows v.s. half an hour on linux
+#          #
+#          # * One job unit tests,
+#          # * One job each for local/packaged/native tests
+#          # * At least one job for each of fork/server tests, and example/integration tests
+#          - java-version: 11
+#            millargs: '"{main,scalalib,bsp}.__.test"'
+#
+#          - java-version: 11
+#            millargs: '"example.scalalib.{basic,publishing}.__.local.fork.test"'
+#
+#          - java-version: 17
+#            millargs: "'integration.{feature,failure}.__.packaged.fork.test'"
+#
+#          - java-version: 11 # Run this with Mill native launcher as a smoketest
+#            millargs: "'integration.invalidation.__.native.server.test'"
+#
+#    uses: ./.github/workflows/post-build-selective.yml
+#    with:
+#      os: windows-latest
+#      java-version: ${{ matrix.java-version }}
+#      millargs: ${{ matrix.millargs }}
+#      # Provide a shorter coursier archive folder to avoid hitting path-length bugs when
+#      # running the graal native image binary on windows
+#      coursierarchive: "C:/coursier-arc"
+#
+#  itest:
+#    needs: build-linux
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        include:
+#          # bootstrap tests
+#          - java-version: 11 # Have one job on oldest JVM
+#            buildcmd: ci/test-mill-dev.sh && ci/test-mill-release.sh && ./mill -i -k __.ivyDepsTree && ./mill -i -k __.ivyDepsTree --withRuntime
+#          - java-version: 17 # Have one job on default JVM
+#            buildcmd: ci/test-mill-bootstrap.sh
+#
+#    uses: ./.github/workflows/post-build-raw.yml
+#    with:
+#      java-version: ${{ matrix.java-version }}
+#      buildcmd: ${{ matrix.buildcmd }}
+#
+#  # Scalafmt, Mima, and Scalafix job runs last because it's the least important:
+#  # usually just an automated or mechanical manual fix to do before merging
+#  lint-autofix:
+#    needs: build-linux
+#    uses: ./.github/workflows/post-build-raw.yml
+#    with:
+#      java-version: '17'
+#      buildcmd: ./mill -i mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll __.sources + __.mimaReportBinaryIssues + __.fix --check + mill.javalib.palantirformat.PalantirFormatModule/ --check + mill.kotlinlib.ktlint.KtlintModule/checkFormatAll

--- a/main/util/src/mill/util/Jvm.scala
+++ b/main/util/src/mill/util/Jvm.scala
@@ -565,6 +565,7 @@ object Jvm extends CoursierSupport {
     ).filterNot(_.isEmpty).mkString("\n")
   }
 
+  @deprecated("Use the other override instead", "0.12.6")
   def launcherUniversalScript(
       mainClass: String,
       shellClassPath: Agg[String],
@@ -572,6 +573,7 @@ object Jvm extends CoursierSupport {
       jvmArgs: Seq[String],
       shebang: Boolean = false
   ): String = {
+    launcherUniversalScript(mainClass, shellClassPath, cmdClassPath, jvmArgs, shebang, Nil, Nil)
     universalScript(
       shellCommands =
         s"""exec java ${jvmArgs.mkString(" ")} $$JAVA_OPTS -cp "${shellClassPath.iterator.mkString(
@@ -584,6 +586,47 @@ object Jvm extends CoursierSupport {
       shebang = shebang
     )
   }
+
+  def launcherUniversalScript(
+                      mainClass: String,
+                      shellClassPath: Agg[String],
+                      cmdClassPath: Agg[String],
+                      jvmArgs: Seq[String],
+                      shebang: Boolean = false,
+                      shellJvmArgs: Seq[String] = Nil,
+                      cmdJvmArgs: Seq[String] = Nil
+                    ) = {
+
+    universalScript(
+      shellCommands = {
+        val jvmArgsStr = (jvmArgs ++ shellJvmArgs).mkString(" ")
+        val classpathStr = shellClassPath.mkString(":")
+
+        s"""if [ -z "$$JAVA_HOME" ] ; then
+           |  JAVACMD="java"
+           |else
+           |  JAVACMD="$$JAVA_HOME/bin/java"
+           |fi
+           |
+           |exec "$$JAVACMD" $jvmArgsStr $$JAVA_OPTS -cp "$classpathStr" $mainClass "$$@"
+           |""".stripMargin
+      },
+      cmdCommands = {
+        val jvmArgsStr = (jvmArgs ++ cmdJvmArgs).mkString(" ")
+        val classpathStr = cmdClassPath.mkString(";")
+        s"""setlocal EnableDelayedExpansion
+           |set "JAVACMD=java.exe"
+           |if not "%JAVA_HOME%"=="" set "JAVACMD=%JAVA_HOME%\\bin\\java.exe"
+           |
+           |"%JAVACMD%" $jvmArgsStr %JAVA_OPTS% -cp "$classpathStr" $mainClass %*
+           |
+           |endlocal
+           |""".stripMargin
+      },
+      shebang = shebang
+    )
+  }
+
   def createLauncher(mainClass: String, classPath: Agg[os.Path], jvmArgs: Seq[String])(implicit
       ctx: Ctx.Dest
   ): PathRef = {

--- a/main/util/src/mill/util/Jvm.scala
+++ b/main/util/src/mill/util/Jvm.scala
@@ -577,14 +577,14 @@ object Jvm extends CoursierSupport {
   }
 
   def launcherUniversalScript(
-                      mainClass: String,
-                      shellClassPath: Agg[String],
-                      cmdClassPath: Agg[String],
-                      jvmArgs: Seq[String],
-                      shebang: Boolean = false,
-                      shellJvmArgs: Seq[String] = Nil,
-                      cmdJvmArgs: Seq[String] = Nil
-                    ) = {
+      mainClass: String,
+      shellClassPath: Agg[String],
+      cmdClassPath: Agg[String],
+      jvmArgs: Seq[String],
+      shebang: Boolean = false,
+      shellJvmArgs: Seq[String] = Nil,
+      cmdJvmArgs: Seq[String] = Nil
+  ) = {
 
     universalScript(
       shellCommands = {

--- a/main/util/src/mill/util/Jvm.scala
+++ b/main/util/src/mill/util/Jvm.scala
@@ -571,35 +571,43 @@ object Jvm extends CoursierSupport {
       shellClassPath: Agg[String],
       cmdClassPath: Agg[String],
       jvmArgs: Seq[String],
-      shebang: Boolean
+      shebang: Boolean = false
   ): String = {
     launcherUniversalScript(mainClass, shellClassPath, cmdClassPath, jvmArgs, shebang, Nil, Nil)
   }
 
   def launcherUniversalScript(
-      mainClass: String,
-      shellClassPath: Agg[String],
-      cmdClassPath: Agg[String],
-      jvmArgs: Seq[String],
-      shebang: Boolean = false,
-      shellJvmArgs: Seq[String] = Nil,
-      cmdJvmArgs: Seq[String] = Nil
-  ) = {
+                      mainClass: String,
+                      shellClassPath: Agg[String],
+                      cmdClassPath: Agg[String],
+                      jvmArgs: Seq[String],
+                      shebang: Boolean = false,
+                      shellJvmArgs: Seq[String] = Nil,
+                      cmdJvmArgs: Seq[String] = Nil
+                    ) = {
 
     universalScript(
       shellCommands = {
         val jvmArgsStr = (jvmArgs ++ shellJvmArgs).mkString(" ")
         val classpathStr = shellClassPath.mkString(":")
 
-        s"""exec java $jvmArgsStr $$JAVA_OPTS -cp "$classpathStr" $mainClass "$$@"
+        s"""if [ -z "$$JAVA_HOME" ] ; then
+           |  JAVACMD="java"
+           |else
+           |  JAVACMD="$$JAVA_HOME/bin/java"
+           |fi
+           |
+           |exec "$$JAVACMD" $jvmArgsStr $$JAVA_OPTS -cp "$classpathStr" $mainClass "$$@"
            |""".stripMargin
       },
       cmdCommands = {
         val jvmArgsStr = (jvmArgs ++ cmdJvmArgs).mkString(" ")
         val classpathStr = cmdClassPath.mkString(";")
         s"""setlocal EnableDelayedExpansion
+           |set "JAVACMD=java.exe"
+           |if not "%JAVA_HOME%"=="" set "JAVACMD=%JAVA_HOME%\\bin\\java.exe"
            |
-           |java $jvmArgsStr %JAVA_OPTS% -cp "$classpathStr" $mainClass %*
+           |"%JAVACMD%" $jvmArgsStr %JAVA_OPTS% -cp "$classpathStr" $mainClass %*
            |
            |endlocal
            |""".stripMargin

--- a/main/util/src/mill/util/Jvm.scala
+++ b/main/util/src/mill/util/Jvm.scala
@@ -584,7 +584,7 @@ object Jvm extends CoursierSupport {
       shebang: Boolean = false,
       shellJvmArgs: Seq[String] = Nil,
       cmdJvmArgs: Seq[String] = Nil
-  ) = {
+  ): String = {
 
     universalScript(
       shellCommands = {

--- a/main/util/src/mill/util/Jvm.scala
+++ b/main/util/src/mill/util/Jvm.scala
@@ -571,7 +571,7 @@ object Jvm extends CoursierSupport {
       shellClassPath: Agg[String],
       cmdClassPath: Agg[String],
       jvmArgs: Seq[String],
-      shebang: Boolean = false
+      shebang: Boolean
   ): String = {
     launcherUniversalScript(mainClass, shellClassPath, cmdClassPath, jvmArgs, shebang, Nil, Nil)
   }

--- a/readme.adoc
+++ b/readme.adoc
@@ -25,7 +25,6 @@ https://www.patreon.com/lihaoyi[image:https://img.shields.io/badge/patreon-spons
 Mill is a fast JVM build tool that supports Java and Scala. Mill aims to make your 
 project’s build process performant, maintainable, and flexible.
 
-== Documentation
 
 If you want to use Mill in your own projects, check out our documentation:
 
@@ -50,6 +49,9 @@ object bar extends ScalaModule {
 If you use Mill and like it, you will probably enjoy the following book by the Author:
 
 * https://www.handsonscala.com/[_Hands-on Scala Programming_]
+
+
+== Developer Documentation
 
 The remainder of this readme is developer-documentation targeted at people who wish to work
 on Mill's own codebase. The developer docs assume you have read through the user-facing
@@ -280,6 +282,23 @@ To run all autofixes and autoformatters:
 ```bash
 ./mill __.fix + mill.javalib.palantirformat.PalantirFormatModule/ + mill.scalalib.scalafmt.ScalafmtModule/ + mill.kotlinlib.ktlint.KtlintModule/
 ```
+
+== Continuous Integration & Testing
+
+* Mill's pull-request validation runs with
+  https://mill-build.org/mill/large/selective-execution.html[Selective Test Execution]
+  enabled; this automatically selects the tests to run based on the code or build configuration
+  that changed in that PR. To disable this, you can label your PR with `run-all-tests`, which
+  will run all tests on a PR regardless of what code was changed
+
+* Mill tests draft PRs _on contributor forks_ of the repository, so please make sure Github
+  Actions are enabled on your fork. Once you are happy with your draft, mark it `ready_for_review`
+  and it will run CI on Mill's repository before merging
+
+* If you need to debug things in CI, you can comment/uncomment the two sections of
+  `.github/workflows/run-tests.yml` in order to skip the main CI jobs and only run the command(s)
+  you need, on the OS you want to test on. This can greatly speed up the debugging process
+  compared to running the full suite every time you make a change.
 
 == Project Layout
 

--- a/scalalib/test/resources/launcher/src/Main.java
+++ b/scalalib/test/resources/launcher/src/Main.java
@@ -1,0 +1,7 @@
+package launcher;
+public class Main {
+  public static void main(String[] args) {
+    System.out.println("test.property " + System.getProperty("test.property"));
+      System.out.println("java.home " + System.getProperty("java.home"));
+  }
+}

--- a/scalalib/test/src/mill/scalalib/LauncherTests.scala
+++ b/scalalib/test/src/mill/scalalib/LauncherTests.scala
@@ -17,31 +17,41 @@ object LauncherTests extends TestSuite {
   val resourcePath = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "launcher"
 
   def tests: Tests = Tests {
-    def check(executable: mill.define.Target[mill.api.PathRef]) = {
+    def check(executableTask: mill.define.Target[mill.api.PathRef], copyBat: Boolean = false) = {
       val eval = UnitTester(HelloJava, resourcePath)
 
-      val Right(result1) = eval.apply(executable)
+      val Right(result1) = eval.apply(executableTask)
 
-      val text = os.call(result1.value.path).out.text()
+      val executable =
+        if (mill.util.Util.windowsPlatform && copyBat){
+          val prev = result1.value.path
+          val next = prev / ".." / s"${prev.baseName}.bat"
+          os.copy(prev, next)
+          next
+        }else result1.value.path
+
+      val text = os.call(executable).out.text()
       assert(text.contains("test.property null"))
       assert(text.contains("java.home"))
       assert(!text.contains(customJavaVersion))
 
-      val text2 =
-        os.call(result1.value.path, env = Map("JAVA_OPTS" -> "-Dtest.property=123")).out.text()
+      val text2 = os
+        .call(executable, env = Map("JAVA_OPTS" -> "-Dtest.property=123"))
+        .out.text()
       assert(text2.contains("test.property 123"))
       assert(!text2.contains(customJavaVersion))
       val Right(javaHome) = eval.apply(HelloJava.ZincWorkerJava.javaHome)
 
-      val text3 = os.call(
-        result1.value.path,
-        env = Map("JAVA_HOME" -> javaHome.value.get.path.toString)
-      ).out.text()
+
+      val text3 = os
+        .call(executable, env = Map("JAVA_HOME" -> javaHome.value.get.path.toString))
+        .out.text()
       assert(text3.contains("java.home"))
       assert(text3.contains(customJavaVersion))
     }
 
     test("launcher") - check(HelloJava.launcher)
-    test("assembly") - check(HelloJava.assembly)
+    // Windows requires that you copy the `.jar` file to a `.bat` extension before running it
+    test("assembly") - check(HelloJava.assembly, copyBat = true)
   }
 }

--- a/scalalib/test/src/mill/scalalib/LauncherTests.scala
+++ b/scalalib/test/src/mill/scalalib/LauncherTests.scala
@@ -6,7 +6,7 @@ import utest._
 object LauncherTests extends TestSuite {
 
   val customJavaVersion = "19.0.2"
-  object HelloJava extends TestBaseModule with JavaModule{
+  object HelloJava extends TestBaseModule with JavaModule {
     object ZincWorkerJava extends ZincWorkerModule {
       def jvmId = s"temurin:$customJavaVersion"
     }
@@ -25,12 +25,16 @@ object LauncherTests extends TestSuite {
       assert(text.contains("java.home"))
       assert(!text.contains(customJavaVersion))
 
-      val text2 = os.call(result1.value.path, env = Map("JAVA_OPTS" -> "-Dtest.property=123")).out.text()
+      val text2 =
+        os.call(result1.value.path, env = Map("JAVA_OPTS" -> "-Dtest.property=123")).out.text()
       assert(text2.contains("test.property 123"))
       assert(!text2.contains(customJavaVersion))
       val Right(javaHome) = eval.apply(HelloJava.ZincWorkerJava.javaHome)
 
-      val text3 = os.call(result1.value.path, env = Map("JAVA_HOME" -> javaHome.value.get.path.toString)).out.text()
+      val text3 = os.call(
+        result1.value.path,
+        env = Map("JAVA_HOME" -> javaHome.value.get.path.toString)
+      ).out.text()
       assert(text3.contains("java.home"))
       assert(text3.contains(customJavaVersion))
     }

--- a/scalalib/test/src/mill/scalalib/LauncherTests.scala
+++ b/scalalib/test/src/mill/scalalib/LauncherTests.scala
@@ -10,6 +10,8 @@ object LauncherTests extends TestSuite {
     object ZincWorkerJava extends ZincWorkerModule {
       def jvmId = s"temurin:$customJavaVersion"
     }
+
+    def javacOptions = Seq("-target", "1.8", "-source", "1.8")
   }
 
   val resourcePath = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "launcher"

--- a/scalalib/test/src/mill/scalalib/LauncherTests.scala
+++ b/scalalib/test/src/mill/scalalib/LauncherTests.scala
@@ -23,12 +23,12 @@ object LauncherTests extends TestSuite {
       val Right(result1) = eval.apply(executableTask)
 
       val executable =
-        if (mill.util.Util.windowsPlatform && copyBat){
+        if (mill.util.Util.windowsPlatform && copyBat) {
           val prev = result1.value.path
           val next = prev / ".." / s"${prev.baseName}.bat"
           os.copy(prev, next)
           next
-        }else result1.value.path
+        } else result1.value.path
 
       val text = os.call(executable).out.text()
       assert(text.contains("test.property null"))
@@ -41,7 +41,6 @@ object LauncherTests extends TestSuite {
       assert(text2.contains("test.property 123"))
       assert(!text2.contains(customJavaVersion))
       val Right(javaHome) = eval.apply(HelloJava.ZincWorkerJava.javaHome)
-
 
       val text3 = os
         .call(executable, env = Map("JAVA_HOME" -> javaHome.value.get.path.toString))

--- a/scalalib/test/src/mill/scalalib/LauncherTests.scala
+++ b/scalalib/test/src/mill/scalalib/LauncherTests.scala
@@ -1,0 +1,41 @@
+package mill.scalalib
+
+import mill.testkit.{TestBaseModule, UnitTester}
+import utest._
+
+object LauncherTests extends TestSuite {
+
+  val customJavaVersion = "19.0.2"
+  object HelloJava extends TestBaseModule with JavaModule{
+    object ZincWorkerJava extends ZincWorkerModule {
+      def jvmId = s"temurin:$customJavaVersion"
+    }
+  }
+
+  val resourcePath = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "launcher"
+
+  def tests: Tests = Tests {
+    def check(executable: mill.define.Target[mill.api.PathRef]) = {
+      val eval = UnitTester(HelloJava, resourcePath)
+
+      val Right(result1) = eval.apply(executable)
+
+      val text = os.call(result1.value.path).out.text()
+      assert(text.contains("test.property null"))
+      assert(text.contains("java.home"))
+      assert(!text.contains(customJavaVersion))
+
+      val text2 = os.call(result1.value.path, env = Map("JAVA_OPTS" -> "-Dtest.property=123")).out.text()
+      assert(text2.contains("test.property 123"))
+      assert(!text2.contains(customJavaVersion))
+      val Right(javaHome) = eval.apply(HelloJava.ZincWorkerJava.javaHome)
+
+      val text3 = os.call(result1.value.path, env = Map("JAVA_HOME" -> javaHome.value.get.path.toString)).out.text()
+      assert(text3.contains("java.home"))
+      assert(text3.contains(customJavaVersion))
+    }
+
+    test("launcher") - check(HelloJava.launcher)
+    test("assembly") - check(HelloJava.assembly)
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/4302

We largely copy the existing implementation `dist/package.mill`. Once we rebootstrap, we can cut over to the new `Jvm.*` implementation and remove the version in `dist/`. Added some unit tests to exercise the `JAVA_HOME`/`JAVA_OPTS` handling