### PR TITLE
Handle OverlappingFileLockException in FileLock

### DIFF
--- a/main/client/src/mill/main/client/lock/FileLock.java
+++ b/main/client/src/mill/main/client/lock/FileLock.java
@@ -2,6 +2,7 @@ package mill.main.client.lock;
 
 import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
+import java.nio.channels.OverlappingFileLockException;
 
 class FileLock extends Lock {
 
@@ -18,7 +19,14 @@ class FileLock extends Lock {
   }
 
   public TryLocked tryLock() throws Exception {
-    return new FileTryLocked(chan.tryLock());
+    java.nio.channels.FileLock lock = null;
+    try {
+      lock = chan.tryLock();
+    }
+    catch (OverlappingFileLockException ex) {
+      // file already locked by this JVM
+    }
+    return new FileTryLocked(lock);
   }
 
   public boolean probe() throws Exception {

--- a/main/client/src/mill/main/client/lock/FileLock.java
+++ b/main/client/src/mill/main/client/lock/FileLock.java
@@ -22,8 +22,7 @@ class FileLock extends Lock {
     java.nio.channels.FileLock lock = null;
     try {
       lock = chan.tryLock();
-    }
-    catch (OverlappingFileLockException ex) {
+    } catch (OverlappingFileLockException ex) {
       // file already locked by this JVM
     }
     return new FileTryLocked(lock);


### PR DESCRIPTION
I've been getting exceptions such as these lately, using Mill `0.12.5`:
```text
An unexpected error occurred java.nio.channels.OverlappingFileLockException
java.base/sun.nio.ch.FileLockTable.checkList(FileLockTable.java:229)
java.base/sun.nio.ch.FileLockTable.add(FileLockTable.java:123)
java.base/sun.nio.ch.FileChannelImpl.tryLock(FileChannelImpl.java:1522)
java.base/java.nio.channels.FileChannel.tryLock(FileChannel.java:1360)
mill.main.client.lock.FileLock.tryLock(FileLock.java:21)
mill.runner.MillMain$.withOutLock(MillMain.scala:447)
mill.runner.MillMain$.$anonfun$main0$9(MillMain.scala:247)
mill.runner.MillMain$.$anonfun$main0$9$adapted(MillMain.scala:225)
mill.runner.Watching$.watchLoop(Watching.scala:29)
mill.runner.MillMain$.$anonfun$main0$8(MillMain.scala:277)
mill.runner.MillMain$.$anonfun$main0$8$adapted(MillMain.scala:213)
scala.util.Using$.resource(Using.scala:296)
```

This ought to fix them.