### PR TITLE
Cross-publish example and launcher artifacts to maven central

### DIFF
--- a/dist/package.mill
+++ b/dist/package.mill
@@ -338,7 +338,6 @@ object `package` extends RootModule with InstallModule {
       )
   }
 
-
   object native extends mill.scalalib.NativeImageModule with InstallModule {
     def artifactOsSuffix = T {
       val osName = System.getProperty("os.name").toLowerCase

--- a/dist/package.mill
+++ b/dist/package.mill
@@ -329,6 +329,16 @@ object `package` extends RootModule with InstallModule {
     longUrl
   }
 
+  def publishArtifacts = Task {
+    super.publishArtifacts()
+      .copy(payload =
+        super.publishArtifacts().payload ++
+          exampleZips().map(z => (z, z.path.last)) ++
+          Seq((bootstrapLauncher(), "mill"), (bootstrapLauncherBat(), "mill.bat"))
+      )
+  }
+
+
   object native extends mill.scalalib.NativeImageModule with InstallModule {
     def artifactOsSuffix = T {
       val osName = System.getProperty("os.name").toLowerCase


### PR DESCRIPTION
This is a step to moving them off of Github to Maven Central, where we have stronger guarantees (e.g. immutability) and a narrower service dependency list (Mill already depends on maven central anyway, and this removes the dependency on Github). With 0.13.0 I expect to remove these artifacts from Github Releases entirely



We still have some Github release download dependencies, e.g. some JVM downloads come from Github, but at least for things that are within our control it's better for them to be on maven central