### PR TITLE
Test PR for intel mac-13 job

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -121,8 +121,6 @@ jobs:
 
       - run: "echo temurin:11 > .mill-jvm-version"
 
-      - run: "echo 0.12.5-150-31d41c > .mill-version"
-
       - run: ./mill -i mill.scalalib.PublishModule/ --publishArtifacts dist.native.publishArtifacts
 
   release-github:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -84,13 +84,15 @@ jobs:
           # Run these with Mill native launcher as a smoketest
         include:
           - os: ubuntu-24.04-arm
-            millargs: example.javalib.__.local.server.test
+            millargs: "'example.thirdparty[fansi].local.server.test'"
             java-version: 17
+
           - os: macos-latest
-            millargs: example.scalalib.__.native.server.test
+            millargs: "'example.thirdparty[acyclic].local.server.test'"
             java-version: 11
+
           - os: macos-13
-            millargs: "'integration.{failure,feature,ide}.__.packaged.server.test'"
+            millargs: "'example.thirdparty[jimfs].local.server.test'"
             java-version: 11
     steps:
       - uses: actions/checkout@v4
@@ -138,7 +140,15 @@ jobs:
             install-android-sdk: false
 
           - java-version: 17
+            millargs: "example.javalib.__.local.server.test"
+            install-android-sdk: false
+
+          - java-version: 17
             millargs: "example.kotlinlib.__.native.server.test"
+            install-android-sdk: false
+
+          - java-version: 17
+            millargs: "example.scalalib.__.native.server.test"
             install-android-sdk: false
 
           - java-version: 17
@@ -150,11 +160,11 @@ jobs:
             install-android-sdk: false
 
           - java-version: 11
-            millargs: "'example.thirdparty[{mockito,acyclic,commons-io}].local.server.test'"
+            millargs: "'example.thirdparty[{mockito,commons-io}].local.server.test'"
             install-android-sdk: false
 
           - java-version: 17
-            millargs: "'example.thirdparty[{fansi,jimfs,netty,gatling}].local.server.test'"
+            millargs: "'example.thirdparty[{netty,gatling}].local.server.test'"
             install-android-sdk: false
 
           - java-version: '17'
@@ -163,6 +173,10 @@ jobs:
 
           - java-version: 11
             millargs: "'example.{cli,fundamentals,depth,extending}.__.local.server.test'"
+            install-android-sdk: false
+
+          - java-version: 11
+            millargs: "'integration.{failure,feature,ide}.__.packaged.server.test'"
             install-android-sdk: false
 
             # These invalidation tests need to be exercised in both execution modes

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -90,7 +90,7 @@ jobs:
             millargs: example.scalalib.__.native.server.test
             java-version: 11
           - os: macos-13
-            millargs: example.kotlinlib.__.native.server.test
+            millargs: "'example.thirdparty[{mockito,acyclic,commons-io}].local.server.test'"
             java-version: 11
     steps:
       - uses: actions/checkout@v4
@@ -138,15 +138,15 @@ jobs:
             install-android-sdk: false
 
           - java-version: 17
+            millargs: "example.kotlinlib.__.native.server.test"
+            install-android-sdk: false
+
+          - java-version: 17
             millargs: "'example.android.__.local.server.test'"
             install-android-sdk: true
 
           - java-version: 17
             millargs: "'example.{pythonlib,javascriptlib}.__.local.server.test'"
-            install-android-sdk: false
-
-          - java-version: 11
-            millargs: "'example.thirdparty[{mockito,acyclic,commons-io}].local.server.test'"
             install-android-sdk: false
 
           - java-version: 17

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -90,7 +90,7 @@ jobs:
             millargs: example.scalalib.__.native.server.test
             java-version: 11
           - os: macos-13
-            millargs: "'example.thirdparty[{mockito,acyclic,commons-io}].local.server.test'"
+            millargs: "'integration.{failure,feature,ide}.__.packaged.server.test'"
             java-version: 11
     steps:
       - uses: actions/checkout@v4
@@ -149,6 +149,10 @@ jobs:
             millargs: "'example.{pythonlib,javascriptlib}.__.local.server.test'"
             install-android-sdk: false
 
+          - java-version: 11
+            millargs: "'example.thirdparty[{mockito,acyclic,commons-io}].local.server.test'"
+            install-android-sdk: false
+
           - java-version: 17
             millargs: "'example.thirdparty[{fansi,jimfs,netty,gatling}].local.server.test'"
             install-android-sdk: false
@@ -160,11 +164,7 @@ jobs:
           - java-version: 11
             millargs: "'example.{cli,fundamentals,depth,extending}.__.local.server.test'"
             install-android-sdk: false
-            # Most of these integration tests should not depend on which mode they
-            # are run in, so just run them in `local`
-          - java-version: '17'
-            millargs: "'integration.{failure,feature,ide}.__.packaged.server.test'"
-            install-android-sdk: false
+
             # These invalidation tests need to be exercised in both execution modes
             # to make sure they work with and without -i/--no-server being passed
           - java-version: 17

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -84,15 +84,15 @@ jobs:
           # Run these with Mill native launcher as a smoketest
         include:
           - os: ubuntu-24.04-arm
-            millargs: "'example.thirdparty[fansi].local.server.test'"
+            millargs: "'example.thirdparty[fansi].native.server.test'"
             java-version: 17
 
           - os: macos-latest
-            millargs: "'example.thirdparty[acyclic].local.server.test'"
+            millargs: "'example.thirdparty[acyclic].native.server.test'"
             java-version: 11
 
           - os: macos-13
-            millargs: "'example.thirdparty[jimfs].local.server.test'"
+            millargs: "'example.thirdparty[jimfs].native.server.test'"
             java-version: 11
     steps:
       - uses: actions/checkout@v4

--- a/example/kotlinlib/basic/1-simple/build.mill
+++ b/example/kotlinlib/basic/1-simple/build.mill
@@ -1,11 +1,9 @@
 //// SNIPPET:BUILD
 
 package build
-
 import mill._, kotlinlib._
 
 object foo extends KotlinModule {
-
   def kotlinVersion = "1.9.24"
 
   def mainClass = Some("foo.FooKt")

--- a/example/kotlinlib/basic/1-simple/build.mill
+++ b/example/kotlinlib/basic/1-simple/build.mill
@@ -1,6 +1,7 @@
 //// SNIPPET:BUILD
 
 package build
+
 import mill._, kotlinlib._
 
 object foo extends KotlinModule {


### PR DESCRIPTION
The mac-latest and mac-13 workers seem significantly slower than the default linux worker, so just run a single thirdparty example as a smoketest on each one