### PR TITLE
Add Scala graal native image example with libraries

### DIFF
--- a/docs/modules/ROOT/pages/scalalib/publishing.adoc
+++ b/docs/modules/ROOT/pages/scalalib/publishing.adoc
@@ -30,3 +30,8 @@ For more details, see:
 == Building Native Image with Graal VM
 
 include::partial$example/scalalib/publishing/7-native-image.adoc[]
+
+For another example building a slightly less trivial project into a Graal native
+image, see below:
+
+include::partial$example/scalalib/publishing/8-native-image-config-scala.adoc[]

--- a/example/scalalib/publishing/8-native-image-config-scala/build.mill
+++ b/example/scalalib/publishing/8-native-image-config-scala/build.mill
@@ -37,7 +37,10 @@ object ZincWorkerGraalvm extends ZincWorkerModule {
 
 /** Usage
 
-> ./mill show foo.nativeImageTool
+> ./mill show foo.nativeImageTool # mac/linux
 ".../bin/native-image"
+
+> ./mill show foo.nativeImageTool # windows
+".../bin/native-image.cmd"
 
 */

--- a/example/scalalib/publishing/8-native-image-config-scala/build.mill
+++ b/example/scalalib/publishing/8-native-image-config-scala/build.mill
@@ -1,4 +1,3 @@
-
 package build
 import mill._, scalalib._
 import mill.define.ModuleRef

--- a/example/scalalib/publishing/8-native-image-config-scala/build.mill
+++ b/example/scalalib/publishing/8-native-image-config-scala/build.mill
@@ -1,0 +1,43 @@
+
+package build
+import mill._, scalalib._
+import mill.define.ModuleRef
+
+object foo extends ScalaModule with NativeImageModule {
+  def scalaVersion = "2.13.11"
+
+  def nativeImageOptions = Seq("--no-fallback")
+
+  def ivyDeps = Agg(
+    ivy"com.lihaoyi::scalatags:0.13.1",
+    ivy"com.lihaoyi::mainargs:0.6.2"
+  )
+
+  def zincWorker = ModuleRef(ZincWorkerGraalvm)
+}
+
+object ZincWorkerGraalvm extends ZincWorkerModule {
+  def jvmId = "graalvm-community:17.0.7"
+}
+
+// This example shows how to generate native images for projects using third-party
+// libraries, in this case Scalatags and Mainargs.
+/** Usage
+
+> ./mill show foo.nativeImage
+
+> ./out/foo/nativeImage.dest/native-executable --text hello-world
+<h1>hello-world</h1>
+
+*/
+
+// You can also access the `native-image` compiler directly via `show foo.nativeImageTool`
+// if you want to experiment it or view its `--help` text to see what you need to pass to
+// `nativeImageOptions`:
+
+/** Usage
+
+> ./mill show foo.nativeImageTool
+".../bin/native-image"
+
+*/

--- a/example/scalalib/publishing/8-native-image-config-scala/foo/src/Foo.scala
+++ b/example/scalalib/publishing/8-native-image-config-scala/foo/src/Foo.scala
@@ -1,0 +1,16 @@
+package foo
+import scalatags.Text.all._
+import mainargs.{main, ParserForMethods}
+
+object Foo {
+  def generateHtml(text: String) = {
+    h1(text).toString
+  }
+
+  @main
+  def main(text: String) = {
+    println(generateHtml(text))
+  }
+
+  def main(args: Array[String]): Unit = ParserForMethods(this).runOrExit(args)
+}


### PR DESCRIPTION
We already have an equivalent Java example, so this adds a Scala version. Still missing a Kotlin version but that can come later