### PR TITLE
Fix a possible typo in "maven.adoc"

### DIFF
--- a/docs/modules/ROOT/pages/migrating/maven.adoc
+++ b/docs/modules/ROOT/pages/migrating/maven.adoc
@@ -18,7 +18,7 @@ This means that while small projects can be expected to complete without issue:
 
 include::partial$example/javalib/migrating/1-maven-complete.adoc[]
 
-More larger projects often require some manual tweaking in order to work:
+Larger projects often require some manual tweaking in order to work:
 
 include::partial$example/javalib/migrating/2-maven-incomplete.adoc[]
 


### PR DESCRIPTION
This is from reviewing #4363. I couldn't comment on this because it was not part of the changes.