### PR TITLE
Fix kotlin 2.1.0 support by using  `K2JsCompiler` instead of `K2JsIrCompiler`

### DIFF
--- a/kotlinlib/test/src/mill/kotlinlib/HelloWorldTests.scala
+++ b/kotlinlib/test/src/mill/kotlinlib/HelloWorldTests.scala
@@ -8,11 +8,7 @@ import utest._
 
 object HelloWorldTests extends TestSuite {
 
-  val kotlinVersions = if (scala.util.Properties.isJavaAtLeast(9)) {
-    Seq("1.9.24", "2.0.20")
-  } else {
-    Seq("1.0.0", "1.9.24", "2.0.20")
-  }
+  val kotlinVersions = Seq("1.9.24", "2.0.20", "2.1.0")
 
   object HelloWorldKotlin extends TestBaseModule {
     trait MainCross extends KotlinModule with Cross.Module[String] {

--- a/kotlinlib/worker/impl/src/mill/kotlinlib/worker/impl/KotlinWorkerImpl.scala
+++ b/kotlinlib/worker/impl/src/mill/kotlinlib/worker/impl/KotlinWorkerImpl.scala
@@ -7,7 +7,7 @@ package mill.kotlinlib.worker.impl
 
 import mill.api.{Ctx, Result}
 import mill.kotlinlib.worker.api.{KotlinWorker, KotlinWorkerTarget}
-import org.jetbrains.kotlin.cli.js.K2JsIrCompiler
+import org.jetbrains.kotlin.cli.js.K2JSCompiler
 import org.jetbrains.kotlin.cli.jvm.K2JVMCompiler
 
 class KotlinWorkerImpl extends KotlinWorker {
@@ -17,7 +17,7 @@ class KotlinWorkerImpl extends KotlinWorker {
 
     val compiler = target match {
       case KotlinWorkerTarget.Jvm => new K2JVMCompiler()
-      case KotlinWorkerTarget.Js => new K2JsIrCompiler()
+      case KotlinWorkerTarget.Js => new K2JSCompiler()
     }
     val exitCode = compiler.exec(ctx.log.errorStream, args: _*)
     if (exitCode.getCode != 0) {


### PR DESCRIPTION
It seems this class was renamed in https://youtrack.jetbrains.com/issue/KT-70221

Updated the unit test to exercise `2.1.0`, fails before this change, passes with. The existing kotlin versions seem to continue working AFAICT