### PR TITLE
Fix selective testing of native example tests by adding jvm version override

### DIFF
--- a/.github/actions/post-build-selective/action.yml
+++ b/.github/actions/post-build-selective/action.yml
@@ -21,6 +21,9 @@ runs:
     - uses: actions/setup-node@v4
       with: { node-version: '22' }
 
+    - run: cat .mill-jvm-version
+      shell: ${{ inputs.shell }}
+
     - run: ./mill -i -k selective.resolve ${{ inputs.millargs }}
       shell: ${{ inputs.shell }}
 

--- a/.github/actions/pre-build-setup/action.yml
+++ b/.github/actions/pre-build-setup/action.yml
@@ -63,3 +63,6 @@ runs:
         include-hidden-files: true
 
     - uses: actions/checkout@v4
+
+    - run: echo temurin:${{ inputs.java-version }} > .mill-jvm-version
+      shell: bash

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -139,7 +139,7 @@ jobs:
             millargs: "contrib.__.test"
             install-android-sdk: false
 
-          - java-version: 17
+          - java-version: 11
             millargs: "example.javalib.__.native.server.test"
             install-android-sdk: false
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -140,7 +140,7 @@ jobs:
             install-android-sdk: false
 
           - java-version: 17
-            millargs: "example.javalib.__.local.server.test"
+            millargs: "example.javalib.__.native.server.test"
             install-android-sdk: false
 
           - java-version: 17

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -139,6 +139,9 @@ jobs:
             millargs: "contrib.__.test"
             install-android-sdk: false
 
+          # Run this one using `.native` as a smoketest. Also make sure the java-version
+          # is the same as that used in the `build-linux` job to avoid diverging code
+          # hashes (https://github.com/com-lihaoyi/mill/pull/4410)
           - java-version: 11
             millargs: "example.javalib.__.native.server.test"
             install-android-sdk: false


### PR DESCRIPTION
Minimized in https://github.com/com-lihaoyi/mill/pull/4357, it appears the difference in behavior comes from different JVM versions being used during `selective.prepare` and `selective.{resolve,run}` phases