### PR TITLE
Revert os-lib to 0.11.4-M2

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -148,7 +148,7 @@ object Deps {
   val junitInterface = ivy"com.github.sbt:junit-interface:0.13.3"
   val commonsIo = ivy"commons-io:commons-io:2.18.0"
   val log4j2Core = ivy"org.apache.logging.log4j:log4j-core:2.24.3"
-  val osLib = ivy"com.lihaoyi::os-lib:0.11.4-M4"
+  val osLib = ivy"com.lihaoyi::os-lib:0.11.4-M2"
   val pprint = ivy"com.lihaoyi::pprint:0.9.0"
   val mainargs = ivy"com.lihaoyi::mainargs:0.7.6"
   val millModuledefsVersion = "0.11.2"


### PR DESCRIPTION
This is causing our plugins to fail due to https://github.com/com-lihaoyi/os-lib/issues/349

Please open all PRs as drafts and ensure that your fork of Mill has 
`settings/actions` / `Allow all actions and reusable workflows` enabled to run CI on
your own fork of the Mill repo. Only once CI passes mark the PR as `Ready for review`
and CI will run on the main Mill repo before we merge it.
