### PR TITLE
Fix android example test exclusive flag

### DIFF
--- a/example/package.mill
+++ b/example/package.mill
@@ -26,9 +26,9 @@ object `package` extends RootModule with Module {
     .collect { case m: ExampleCrossModule => m }
 
   object android extends Module {
-    object javalib extends Cross[ExampleCrossModuleJava](build.listIn(millSourcePath / "javalib"))
+    object javalib extends Cross[ExampleCrossModuleAndroid](build.listIn(millSourcePath / "javalib"))
     object kotlinlib
-        extends Cross[ExampleCrossModuleJava](build.listIn(millSourcePath / "kotlinlib"))
+        extends Cross[ExampleCrossModuleAndroid](build.listIn(millSourcePath / "kotlinlib"))
   }
   object javalib extends Module {
 

--- a/example/package.mill
+++ b/example/package.mill
@@ -26,7 +26,8 @@ object `package` extends RootModule with Module {
     .collect { case m: ExampleCrossModule => m }
 
   object android extends Module {
-    object javalib extends Cross[ExampleCrossModuleAndroid](build.listIn(millSourcePath / "javalib"))
+    object javalib
+        extends Cross[ExampleCrossModuleAndroid](build.listIn(millSourcePath / "javalib"))
     object kotlinlib
         extends Cross[ExampleCrossModuleAndroid](build.listIn(millSourcePath / "kotlinlib"))
   }


### PR DESCRIPTION
The earlier PR defined `ExampleCrossModuleAndroid` but didn't use it