### PR TITLE
Fix `transitiveCoursierProjects` cause OOM on large build (#4452)

### DIFF
--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -638,11 +638,10 @@ trait JavaModule
    * Coursier project of this module and those of all its transitive module dependencies
    */
   def transitiveCoursierProjects: Task[Seq[cs.Project]] = Task {
-    Seq(coursierProject()) ++
-      Task.traverse(compileModuleDepsChecked)(_.transitiveCoursierProjects)().flatten ++
-      Task.traverse(moduleDepsChecked)(_.transitiveCoursierProjects)().flatten ++
-      Task.traverse(runModuleDepsChecked)(_.transitiveCoursierProjects)().flatten ++
-      Task.traverse(bomModuleDepsChecked)(_.transitiveCoursierProjects)().flatten
+    (Seq(coursierProject()) ++
+      Task.traverse(
+        (compileModuleDepsChecked ++ moduleDepsChecked ++ runModuleDepsChecked ++ bomModuleDepsChecked).distinct
+      )(_.transitiveCoursierProjects)().flatten).distinctBy(_.module)
   }
 
   /**


### PR DESCRIPTION
Resolve #4451 

It seems that `transitiveCoursierProjects` is populated with repetitive transitive modules, that's why it only causes problem for large build.

Please open all PRs as drafts and ensure that your fork of Mill has 
`settings/actions` / `Allow all actions and reusable workflows` enabled to run CI on
your own fork of the Mill repo. Only once CI passes mark the PR as `Ready for review`
and CI will run on the main Mill repo before we merge it.
