### PR TITLE
Reduce size of generated code in Discover macro

### DIFF
--- a/integration/feature/inspect/src/InspectTests.scala
+++ b/integration/feature/inspect/src/InspectTests.scala
@@ -63,7 +63,8 @@ object InspectTests extends UtestIntegrationTestSuite {
         doc
       )
 
-      assert(eval(("inspect", "core.run")).isSuccess)
+      val res2 = eval(("inspect", "core.run"))
+      assert(res2.isSuccess)
       val run = out("inspect").json.str
 
       assertGlobMatches(

--- a/integration/feature/scala-3-syntax/resources/sub/package.mill
+++ b/integration/feature/scala-3-syntax/resources/sub/package.mill
@@ -8,7 +8,7 @@ import mill.*
 assert(1 + 1 == 2)
 
 // modifiers also allowed at top-level
-private def subCommand(): Command[Unit] = Task.Command:
+def subCommand(): Command[Unit] = Task.Command:
   println("Hello, sub-world!")
 
 // top-level object with no extends clause

--- a/main/define/src/mill/define/Discover.scala
+++ b/main/define/src/mill/define/Discover.scala
@@ -138,13 +138,8 @@ object Discover {
                   ).asExprOf[mainargs.MainData[?, ?]]
                 catch {
                   case NonFatal(e) =>
-                    val (before, Array(after, _*)) = e.getStackTrace().span(e =>
-                      !(e.getClassName() == "mill.define.Discover$Router$" && e.getMethodName() == "applyImpl")
-                    ): @unchecked
-                    val trace =
-                      (before :+ after).map(_.toString).mkString("trace:\n", "\n", "\n...")
                     report.errorAndAbort(
-                      s"Error generating maindata for ${m.fullName}: ${e}\n$trace",
+                      s"Error generating maindata for ${m.fullName}: ${e}\n${e.getStackTrace().mkString("\n")}",
                       m.pos.getOrElse(Position.ofMacroExpansion)
                     )
                 }

--- a/main/define/src/mill/define/Discover.scala
+++ b/main/define/src/mill/define/Discover.scala
@@ -109,11 +109,10 @@ object Discover {
         for {
           curCls <- seen.toSeq.sortBy(_.typeSymbol.fullName)
         } yield {
-          val methods = filterDefs(curCls.typeSymbol.methodMembers)
           val declMethods = filterDefs(curCls.typeSymbol.declaredMethods)
           assertParamListCounts(
             curCls,
-            methods,
+            declMethods,
             (TypeRepr.of[mill.define.Command[?]], 1, "`Task.Command`"),
             (TypeRepr.of[mill.define.Target[?]], 0, "Target")
           )

--- a/main/define/src/mill/define/Discover.scala
+++ b/main/define/src/mill/define/Discover.scala
@@ -167,9 +167,7 @@ object Discover {
           }
       }
 
-      val expr = '{ new Discover(Map[Class[_], ClassInfo](${ Varargs(mappingExpr) }*)) }
-      // TODO: if needed for debugging, we can re-enable this
-      expr
+      '{ new Discover(Map[Class[_], ClassInfo](${ Varargs(mappingExpr) }*)) }
     }
   }
 }

--- a/main/define/src/mill/define/Discover.scala
+++ b/main/define/src/mill/define/Discover.scala
@@ -14,10 +14,10 @@ import scala.collection.mutable
  * the `Task.Command` methods we find. This mapping from `Class[_]` to `MainData`
  * can then be used later to look up the `MainData` for any module.
  */
-class Discover(val classInfo: Map[Class[_], Discover.Node])
+class Discover(val classInfo: Map[Class[_], Discover.ClassInfo])
 
 object Discover {
-  class Node(
+  class ClassInfo(
       val entryPoints: Seq[mainargs.MainData[_, _]],
       val declaredNames: Seq[String]
   )
@@ -156,13 +156,13 @@ object Discover {
           // the problem of generating a *huge* macro method body that finally exceeds the
           // JVM's maximum allowed method size
           '{
-            def func() = new Node(${ Expr.ofList(entryPoints.toList) }, ${ Expr(names) } )
+            def func() = new ClassInfo(${ Expr.ofList(entryPoints.toList) }, ${ Expr(names) } )
 
             (${Ref(defn.Predef_classOf).appliedToType(cls).asExprOf[Class[?]]}, func())
           }
       }
 
-      val expr = '{ new Discover(Map[Class[_], Node](${ Varargs(mappingExpr) }*)) }
+      val expr = '{ new Discover(Map[Class[_], ClassInfo](${ Varargs(mappingExpr) }*)) }
       // TODO: if needed for debugging, we can re-enable this
       expr
     }

--- a/main/define/src/mill/define/Discover.scala
+++ b/main/define/src/mill/define/Discover.scala
@@ -14,7 +14,18 @@ import scala.collection.mutable
  * the `Task.Command` methods we find. This mapping from `Class[_]` to `MainData`
  * can then be used later to look up the `MainData` for any module.
  */
-class Discover(val classInfo: Map[Class[_], Discover.ClassInfo])
+class Discover(val classInfo: Map[Class[_], Discover.ClassInfo]) {
+  def resolveEntrypoint(cls: Class[_], name: String) = {
+    val res = for {
+      (cls, node) <- classInfo
+      if cls.isAssignableFrom(cls)
+      ep <- node.entryPoints
+      if ep.name == name
+    } yield ep
+
+    res.headOption
+  }
+}
 
 object Discover {
   class ClassInfo(

--- a/main/define/src/mill/define/Discover.scala
+++ b/main/define/src/mill/define/Discover.scala
@@ -17,8 +17,8 @@ import scala.collection.mutable
 class Discover(val classInfo: Map[Class[_], Discover.ClassInfo]) {
   def resolveEntrypoint(cls: Class[_], name: String) = {
     val res = for {
-      (cls, node) <- classInfo
-      if cls.isAssignableFrom(cls)
+      (cls2, node) <- classInfo
+      if cls2.isAssignableFrom(cls)
       ep <- node.entryPoints
       if ep.name == name
     } yield ep

--- a/main/resolve/src/mill/resolve/Resolve.scala
+++ b/main/resolve/src/mill/resolve/Resolve.scala
@@ -142,7 +142,7 @@ object Resolve {
       val invoked = invokeCommand0(
         p,
         r.segments.last.value,
-        rootModule.millDiscover.asInstanceOf[Discover],
+        rootModule.millDiscover,
         args,
         nullCommandDefaults,
         allowPositionalCommandArgs
@@ -159,11 +159,8 @@ object Resolve {
       rest: Seq[String],
       nullCommandDefaults: Boolean,
       allowPositionalCommandArgs: Boolean
-  ): Iterable[Either[String, Command[_]]] = for {
-    (cls, node) <- discover.classInfo
-    if cls.isAssignableFrom(target.getClass)
-    ep <- node.entryPoints
-    if ep.name == name
+  ): Option[Either[String, Command[_]]] = for {
+    ep <- discover.resolveEntrypoint(target.getClass, name)
   } yield {
     def withNullDefault(a: mainargs.ArgSig): mainargs.ArgSig = {
       if (a.default.nonEmpty) a

--- a/main/resolve/src/mill/resolve/Resolve.scala
+++ b/main/resolve/src/mill/resolve/Resolve.scala
@@ -303,7 +303,7 @@ trait Resolve[T] {
       ) match {
         case ResolveCore.Success(value) => Right(value)
         case ResolveCore.NotFound(segments, found, next, possibleNexts) =>
-          val allPossibleNames = rootModule.millDiscover.allNames.toSet
+          val allPossibleNames = rootModule.millDiscover.classInfo.values.flatMap(_.declaredNames).toSet
           Left(ResolveNotFoundHandler(
             selector = sel,
             segments = segments,

--- a/main/resolve/src/mill/resolve/Resolve.scala
+++ b/main/resolve/src/mill/resolve/Resolve.scala
@@ -303,7 +303,8 @@ trait Resolve[T] {
       ) match {
         case ResolveCore.Success(value) => Right(value)
         case ResolveCore.NotFound(segments, found, next, possibleNexts) =>
-          val allPossibleNames = rootModule.millDiscover.classInfo.values.flatMap(_.declaredNames).toSet
+          val allPossibleNames =
+            rootModule.millDiscover.classInfo.values.flatMap(_.declaredNames).toSet
           Left(ResolveNotFoundHandler(
             selector = sel,
             segments = segments,

--- a/main/src/mill/main/MainModule.scala
+++ b/main/src/mill/main/MainModule.scala
@@ -265,15 +265,12 @@ trait MainModule extends BaseModule0 {
               val mainDataOpt = evaluator
                 .rootModule
                 .millDiscover
-                .classInfo
-                .get(t.ctx.enclosingCls)
-                .flatMap(_.entryPoints.find(_.name == t.ctx.segments.last.value))
-                .headOption
+                .resolveEntrypoint(t.ctx.enclosingCls, t.ctx.segments.last.value)
 
               mainDataOpt match {
                 case Some(mainData) if mainData.renderedArgSigs.nonEmpty =>
                   val rendered = mainargs.Renderer.formatMainMethodSignature(
-                    mainDataOpt.get,
+                    mainData,
                     leftIndent = 2,
                     totalWidth = 100,
                     leftColWidth = mainargs.Renderer.getLeftColWidth(mainData.renderedArgSigs),


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/3893

- Recurse over all module parent classes, in addition to member return types
- Remove `allNames`, since it can now be derived from the `declaredNames` of every module class
- Make `entryPoints` only store the entrypoints specifically declared for each class, and not those inherited

Reduces the size of `out/mill-build/compile.dest/classes//build_/package_$.class` in the Mill repo from 820K to 73K. Haven't measured but I would expect a decrease in compile times as well