### PR TITLE
Remove repositories tasks ivy deps dependency 0.12.x

### DIFF
--- a/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -296,7 +296,7 @@ private class MillBuildServer(
         case m: JavaModule =>
           Task.Anon {
             (
-              m.defaultResolver().resolveDeps(
+              m.internalResolver().resolveDeps(
                 Seq(
                   m.coursierDependency.withConfiguration(coursier.core.Configuration.provided),
                   m.coursierDependency
@@ -304,7 +304,7 @@ private class MillBuildServer(
                 sources = true
               ),
               m.unmanagedClasspath(),
-              m.repositoriesTask()
+              m.allRepositoriesTask()
             )
           }
       }
@@ -339,7 +339,7 @@ private class MillBuildServer(
         Task.Anon {
           (
             // full list of dependencies, including transitive ones
-            m.defaultResolver().allDeps(
+            m.internalResolver().allDeps(
               Seq(
                 m.coursierDependency.withConfiguration(coursier.core.Configuration.provided),
                 m.coursierDependency

--- a/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
+++ b/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
@@ -390,7 +390,7 @@ class BloopImpl(evs: () => Seq[Evaluator], wd: os.Path) extends ExternalModule {
     }
 
     val bloopResolution: Task[BloopConfig.Resolution] = Task.Anon {
-      val repos = module.repositoriesTask()
+      val repos = module.allRepositoriesTask()
       // same as input of resolvedIvyDeps
       val coursierDeps = Seq(
         module.coursierDependency.withConfiguration(coursier.core.Configuration.provided),

--- a/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBModule.scala
+++ b/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBModule.scala
@@ -91,7 +91,7 @@ trait ScalaPBModule extends ScalaModule {
   }
 
   def scalaPBProtoClasspath: T[Agg[PathRef]] = Task {
-    defaultResolver().resolveDeps(
+    internalResolver().resolveDeps(
       Seq(
         coursierDependency.withConfiguration(coursier.core.Configuration.provided),
         coursierDependency

--- a/idea/src/mill/idea/GenIdeaImpl.scala
+++ b/idea/src/mill/idea/GenIdeaImpl.scala
@@ -114,7 +114,7 @@ case class GenIdeaImpl(
               GenIdeaException(
                 s"Failure during resolving repositories: ${Evaluator.formatFailing(r)}"
               )
-          )(modules.map(_._2.repositoriesTask))
+          )(modules.map(_._2.allRepositoriesTask))
         }
         Lib.resolveMillBuildDeps(moduleRepos.flatten, Option(ctx), useSources = true)
         Lib.resolveMillBuildDeps(moduleRepos.flatten, Option(ctx), useSources = false)
@@ -160,7 +160,7 @@ case class GenIdeaImpl(
             val extRunIvyDeps = mod.resolvedRunIvyDeps
 
             val externalSources = Task.Anon {
-              mod.resolveDeps(allIvyDeps, sources = true)()
+              mod.resolveDeps(allIvyDeps, sources = true, enableMillInternalDependencies = true)()
             }
 
             val (scalacPluginsIvyDeps, allScalacOptions, scalaVersion) = mod match {

--- a/scalalib/src/mill/javalib/revapi/RevapiModule.scala
+++ b/scalalib/src/mill/javalib/revapi/RevapiModule.scala
@@ -81,7 +81,7 @@ trait RevapiModule extends PublishModule {
   def revapiNewFiles: T[Agg[PathRef]] = Task {
     Agg(jar()) ++
       Task.traverse(recursiveModuleDeps)(_.jar)() ++
-      defaultResolver().resolveDeps(
+      internalResolver().resolveDeps(
         Seq(coursierDependency),
         artifactTypes = Some(revapiArtifactTypes())
       )

--- a/scalalib/src/mill/scalalib/CoursierModule.scala
+++ b/scalalib/src/mill/scalalib/CoursierModule.scala
@@ -33,6 +33,34 @@ trait CoursierModule extends mill.Module {
     Lib.depToDependencyJava(_: Dep)
   }
 
+  /**
+   * A `CoursierModule.Resolver` to resolve dependencies.
+   *
+   * Unlike `defaultResolver`, this resolver can resolve Mill internal modules
+   * (obtained via `JavaModule#coursierDependency`).
+   *
+   * @return `CoursierModule.Resolver` instance
+   */
+  def internalResolver: Task[CoursierModule.Resolver] = Task.Anon {
+    new CoursierModule.Resolver(
+      repositories = allRepositoriesTask(),
+      bind = bindDependency(),
+      mapDependencies = Some(mapDependencies()),
+      customizer = resolutionCustomizer(),
+      coursierCacheCustomizer = coursierCacheCustomizer(),
+      ctx = Some(implicitly[mill.api.Ctx.Log]),
+      resolutionParams = resolutionParams()
+    )
+  }
+
+  /**
+   * A `CoursierModule.Resolver` to resolve dependencies.
+   *
+   * Can be used to resolve external dependencies, if you need to download an external
+   * tool from Maven or Ivy repositories, by calling `CoursierModule.Resolver#resolveDeps`.
+   *
+   * @return `CoursierModule.Resolver` instance
+   */
   def defaultResolver: Task[CoursierModule.Resolver] = Task.Anon {
     new CoursierModule.Resolver(
       repositories = repositoriesTask(),
@@ -56,11 +84,15 @@ trait CoursierModule extends mill.Module {
   def resolveDeps(
       deps: Task[Agg[BoundDep]],
       sources: Boolean = false,
-      artifactTypes: Option[Set[Type]] = None
-  ): Task[Agg[PathRef]] =
+      artifactTypes: Option[Set[Type]] = None,
+      enableMillInternalDependencies: Boolean = false
+  ): Task[Agg[PathRef]] = {
+    val repositoriesTask0 =
+      if (enableMillInternalDependencies) allRepositoriesTask
+      else repositoriesTask
     Task.Anon {
       Lib.resolveDependencies(
-        repositories = repositoriesTask(),
+        repositories = repositoriesTask0(),
         deps = deps(),
         sources = sources,
         artifactTypes = artifactTypes,
@@ -70,6 +102,20 @@ trait CoursierModule extends mill.Module {
         ctx = Some(implicitly[mill.api.Ctx.Log])
       )
     }
+  }
+
+  // bin-compat shim
+  def resolveDeps(
+      deps: Task[Agg[BoundDep]],
+      sources: Boolean,
+      artifactTypes: Option[Set[Type]]
+  ): Task[Agg[PathRef]] =
+    resolveDeps(
+      deps,
+      sources,
+      artifactTypes,
+      enableMillInternalDependencies = false
+    )
 
   @deprecated("Use the override accepting artifactTypes", "Mill after 0.12.0-RC3")
   def resolveDeps(
@@ -94,6 +140,8 @@ trait CoursierModule extends mill.Module {
 
   /**
    * The repositories used to resolved dependencies with [[resolveDeps()]].
+   *
+   * See [[allRepositoriesTask]] if you need to resolve Mill internal modules.
    */
   def repositoriesTask: Task[Seq[Repository]] = Task.Anon {
     val resolve = Resolve()
@@ -101,7 +149,23 @@ trait CoursierModule extends mill.Module {
       resolve.finalRepositories.future()(resolve.cache.ec),
       Duration.Inf
     )
-    internalRepositories() ++ repos
+    repos
+  }
+
+  /**
+   * The repositories used to resolved dependencies
+   *
+   * Unlike [[repositoriesTask]], this includes the Mill internal repositories,
+   * which allow to resolve Mill internal modules (usually brought in via
+   * `JavaModule#coursierDependency`).
+   *
+   * Beware that this needs to evaluate `JavaModule#coursierProject` of all
+   * module dependencies of the current module, which itself evaluates `JavaModule#ivyDeps`
+   * and related tasks. You shouldn't depend on this task from implementations of `ivyDeps`,
+   * which would introduce cycles between Mill tasks.
+   */
+  def allRepositoriesTask: Task[Seq[Repository]] = Task.Anon {
+    internalRepositories() ++ repositoriesTask()
   }
 
   /**

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -638,11 +638,10 @@ trait JavaModule
    * Coursier project of this module and those of all its transitive module dependencies
    */
   def transitiveCoursierProjects: Task[Seq[cs.Project]] = Task {
-    Seq(coursierProject()) ++
-      Task.traverse(compileModuleDepsChecked)(_.transitiveCoursierProjects)().flatten ++
-      Task.traverse(moduleDepsChecked)(_.transitiveCoursierProjects)().flatten ++
-      Task.traverse(runModuleDepsChecked)(_.transitiveCoursierProjects)().flatten ++
-      Task.traverse(bomModuleDepsChecked)(_.transitiveCoursierProjects)().flatten
+    (Seq(coursierProject()) ++
+      Task.traverse(
+        (compileModuleDepsChecked ++ moduleDepsChecked ++ runModuleDepsChecked ++ bomModuleDepsChecked).distinct
+      )(_.transitiveCoursierProjects)().flatten).distinctBy(_.module)
   }
 
   /**

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -49,7 +49,7 @@ trait JavaModule
     override def resources = super[JavaModule].resources
     override def moduleDeps: Seq[JavaModule] = Seq(outer)
     override def repositoriesTask: Task[Seq[Repository]] = Task.Anon {
-      internalRepositories() ++ outer.repositoriesTask()
+      outer.repositoriesTask()
     }
     override def resolutionCustomizer: Task[Option[coursier.Resolution => coursier.Resolution]] =
       outer.resolutionCustomizer
@@ -1001,7 +1001,7 @@ trait JavaModule
    * Resolved dependencies
    */
   def resolvedIvyDeps: T[Agg[PathRef]] = Task {
-    defaultResolver().resolveDeps(
+    internalResolver().resolveDeps(
       Seq(
         BoundDep(
           coursierDependency.withConfiguration(cs.Configuration.provided),
@@ -1024,7 +1024,7 @@ trait JavaModule
   }
 
   def resolvedRunIvyDeps: T[Agg[PathRef]] = Task {
-    defaultResolver().resolveDeps(
+    internalResolver().resolveDeps(
       Seq(
         BoundDep(
           coursierDependency.withConfiguration(cs.Configuration.runtime),
@@ -1222,7 +1222,7 @@ trait JavaModule
       val dependencies =
         (additionalDeps() ++ Seq(BoundDep(coursierDependency, force = false))).iterator.to(Seq)
       val resolution: Resolution = Lib.resolveDependenciesMetadataSafe(
-        repositoriesTask(),
+        allRepositoriesTask(),
         dependencies,
         Some(mapDependencies()),
         customizer = resolutionCustomizer(),
@@ -1465,7 +1465,7 @@ trait JavaModule
     val tasks =
       if (all.value) Seq(
         Task.Anon {
-          defaultResolver().resolveDeps(
+          internalResolver().resolveDeps(
             Seq(
               coursierDependency.withConfiguration(cs.Configuration.provided),
               coursierDependency
@@ -1478,7 +1478,7 @@ trait JavaModule
           )
         },
         Task.Anon {
-          defaultResolver().resolveDeps(
+          internalResolver().resolveDeps(
             Seq(coursierDependency.withConfiguration(cs.Configuration.runtime)),
             sources = true
           )

--- a/scalalib/src/mill/scalalib/PublishModule.scala
+++ b/scalalib/src/mill/scalalib/PublishModule.scala
@@ -219,7 +219,7 @@ trait PublishModule extends JavaModule { outer =>
   @deprecated("Unused by Mill", "Mill after 0.12.5")
   def bomDetails: T[(Map[coursier.core.Module, String], coursier.core.DependencyManagement.Map)] =
     Task {
-      val (processedDeps, depMgmt) = defaultResolver().processDeps(
+      val (processedDeps, depMgmt) = internalResolver().processDeps(
         processedIvyDeps(),
         resolutionParams = resolutionParams(),
         boms = allBomDeps().toSeq.map(_.withConfig(Configuration.compile))
@@ -244,7 +244,7 @@ trait PublishModule extends JavaModule { outer =>
    * @return
    */
   private def ivy(hasJar: Boolean): Task[String] = Task.Anon {
-    val (results, bomDepMgmt) = defaultResolver().processDeps(
+    val (results, bomDepMgmt) = internalResolver().processDeps(
       Seq(
         BoundDep(
           coursierDependency.withConfiguration(Configuration.runtime),

--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -471,7 +471,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
   }
 
   def resolvedAmmoniteReplIvyDeps = Task {
-    defaultResolver().resolveDeps {
+    internalResolver().resolveDeps {
       val scaVersion = scalaVersion()
       val ammVersion = ammoniteVersion()
       if (scaVersion != BuildInfo.scalaVersion && ammVersion == Versions.ammonite) {


### PR DESCRIPTION
Same as #4465, but against the `0.12.x` branch

---

mill-scalablytyped (but possibly other plugins or user setups too) adds a dependency on `repositoriesTask` from `ivyDeps`. Since the introduction of `JavaModule#coursierProject`, Mill had a dependency the other way around, `repositoriesTask` depends on `ivyDeps`.

This creates a cycle, leading to StackOverflowException-s.

In order to work around that, this PR splits both `repositoriesTask` and `defaultResolver`, adding:
- `allRepositoriesTask`: basically `repositoriesTask`, with the Mill internal repository added
- `internalResolver`: same as `defaultResolver`, with the Mill internal repository added (via `allRepositoriesTask`)

If users need to resolve purely external modules (most common case it seems), they can keep using `repositoriesTask` or `defaultResolver`.

If they need to resolve some Mill internal modules (usually brought in via `JavaModule#coursierDependency`), they now need to use `allRepositoriesTask` and `internalResolver` instead of `repositoriesTask` and `defaultResolver`.

That way, no cycle is introduced when users only need to resolve external modules.

Fixes #4457