### PR TITLE
Allow `Task.Source`/`Task.Sources` to be constructed directly from subpath string literals

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -158,7 +158,7 @@ object Deps {
   val junitInterface = ivy"com.github.sbt:junit-interface:0.13.3"
   val commonsIo = ivy"commons-io:commons-io:2.18.0"
   val log4j2Core = ivy"org.apache.logging.log4j:log4j-core:2.24.3"
-  val osLib = ivy"com.lihaoyi::os-lib:0.11.4-M5"
+  val osLib = ivy"com.lihaoyi::os-lib:0.11.4-M6"
   val pprint = ivy"com.lihaoyi::pprint:0.9.0"
   val mainargs = ivy"com.lihaoyi::mainargs:0.7.6"
   val millModuledefsVersion = "0.11.3-M3"
@@ -398,7 +398,7 @@ trait MillJavaModule extends JavaModule {
 
   def writeLocalTestOverrides = Task.Anon {
     for ((k, v) <- testTransitiveDeps()) {
-      os.write(Task.dest / "mill" / "local-test-overrides" / k, v, createFolders = true)
+      os.write(Task.dest / "mill/local-test-overrides" / k, v, createFolders = true)
     }
     Seq(PathRef(Task.dest))
   }

--- a/contrib/playlib/src/mill/playlib/Layout.scala
+++ b/contrib/playlib/src/mill/playlib/Layout.scala
@@ -5,8 +5,8 @@ import mill.scalalib._
 
 private[playlib] trait Layout extends JavaModule {
 
-  def conf = Task.Sources { millSourcePath / "conf" }
-  def app = Task.Sources { millSourcePath / "app" }
+  def conf = Task.Sources { "conf" }
+  def app = Task.Sources { "app" }
 
   override def sources = Task { app() }
   override def resources = Task { conf() }

--- a/contrib/playlib/src/mill/playlib/RouterModule.scala
+++ b/contrib/playlib/src/mill/playlib/RouterModule.scala
@@ -9,7 +9,7 @@ import mill.{Agg, T, Task}
 
 trait RouterModule extends ScalaModule with Version {
 
-  def routes: T[Seq[PathRef]] = Task.Sources { millSourcePath / "routes" }
+  def routes: T[Seq[PathRef]] = Task.Sources { "routes" }
 
   def routeFiles = Task {
     val paths = routes().flatMap(file => os.walk(file.path))

--- a/contrib/playlib/src/mill/playlib/Static.scala
+++ b/contrib/playlib/src/mill/playlib/Static.scala
@@ -25,7 +25,7 @@ trait Static extends ScalaModule {
   /**
    *  Directories to include assets from
    */
-  def assetSources = Task.Sources { millSourcePath / assetsPath() }
+  def assetSources = Task.Sources { os.sub / assetsPath() }
 
   /*
   Collected static assets for the project

--- a/contrib/versionfile/src/mill/contrib/versionfile/VersionFileModule.scala
+++ b/contrib/versionfile/src/mill/contrib/versionfile/VersionFileModule.scala
@@ -5,7 +5,7 @@ import mill._
 trait VersionFileModule extends Module {
 
   /** The file containing the current version. */
-  def versionFile: T[PathRef] = Task.Source(millSourcePath / "version")
+  def versionFile: T[PathRef] = Task.Source("version")
 
   /** The current version. */
   def currentVersion: T[Version] = Task { Version.of(os.read(versionFile().path).trim) }

--- a/dist/package.mill
+++ b/dist/package.mill
@@ -41,7 +41,7 @@ trait InstallModule extends build.MillPublishJavaModule {
   def installLocalCache() = Task.Command {
     val path = installLocalTask(
       Task.Anon(
-        (os.home / ".cache" / "mill" / "download" / (build.millVersion() + batExt)).toString()
+        (os.home / ".cache/mill/download" / (build.millVersion() + batExt)).toString()
       )
     )()
     Task.log.outputStream.println(path.toString())

--- a/docs/modules/ROOT/pages/comparisons/maven.adoc
+++ b/docs/modules/ROOT/pages/comparisons/maven.adoc
@@ -391,7 +391,7 @@ import $ivy.`ant:ant-optional:1.5.3-1`
 
 object common extends NettyModule{
   ...
-  def script = Task.Source(millSourcePath / "src" / "main" / "script")
+  def script = Task.Source("src" / "main" / "script")
   def generatedSources0 = Task {
     val shell = new groovy.lang.GroovyShell()
     val context = new java.util.HashMap[String, Object]
@@ -520,8 +520,8 @@ with the `make` command essentially being a bash script wrapped in layers of XML
 In contrast, the Mill configuration for this logic is as follows:
 
 ```scala
-def makefile = Task.Source(millSourcePath / "Makefile")
-def cSources = Task.Source(millSourcePath / "src" / "main" / "c")
+def makefile = Task.Source("Makefile")
+def cSources = Task.Source("src" / "main" / "c")
 def cHeaders = Task {
   for(p <- os.walk(cSources().path) if p.ext == "h"){
     os.copy(p, Task.dest / p.relativeTo(cSources().path), createFolders = true)

--- a/docs/modules/ROOT/pages/comparisons/unique.adoc
+++ b/docs/modules/ROOT/pages/comparisons/unique.adoc
@@ -176,8 +176,8 @@ them into classfiles, and then the `jar` executable to package them together int
 ```scala
 def mainClass: T[Option[String]] = Some("foo.Foo")
 
-def sources = Task.Source(millSourcePath / "src")
-def resources = Task.Source(millSourcePath / "resources")
+def sources = Task.Source("src")
+def resources = Task.Source("resources")
 
 def compile = Task {
   val allSources = os.walk(sources().path)

--- a/docs/package.mill
+++ b/docs/package.mill
@@ -68,7 +68,7 @@ object `package` extends RootModule {
       envArgs = Map("CI" -> "true"),
       workingDir = workDir
     )
-    PathRef(workDir / "build" / "site")
+    PathRef(workDir / "build/site")
   }
 
   def source0 = Task.Source(millSourcePath)
@@ -76,8 +76,8 @@ object `package` extends RootModule {
   def source = Task {
     os.copy(source0().path, Task.dest, mergeFolders = true)
 
-    val pagesWd = Task.dest / "modules" / "ROOT" / "pages"
-    val partialsWd = Task.dest / "modules" / "ROOT" / "partials"
+    val pagesWd = Task.dest / "modules/ROOT/pages"
+    val partialsWd = Task.dest / "modules/ROOT/partials"
 
     os.copy(projectChangelog().path, partialsWd / "project-changelog.adoc", createFolders = true)
 
@@ -291,7 +291,7 @@ object `package` extends RootModule {
       val checkout = Task.dest / displayVersion
       os.proc("git", "clone", Task.workspace / ".git", checkout).call(stdout = os.Inherit)
       os.proc("git", "checkout", millLastTag).call(cwd = checkout, stdout = os.Inherit)
-      val outputFolder = checkout / "out" / "docs" / "source.dest"
+      val outputFolder = checkout / "out/docs/source.dest"
       os.proc("./mill", "-i", "docs.source").call(cwd = checkout, stdout = os.Inherit)
       expandDiagramsInDirectoryAdocFile(
         outputFolder,
@@ -367,7 +367,7 @@ object `package` extends RootModule {
     // only copy the "api" sub-dir; api docs contains a top-level index.html with we don't want
     val unidocSrc = if (authorMode) site.unidocLocal().path else site.unidocSite().path
     Task.log.errorStream.println(s"Copying API docs from ${unidocSrc} ...")
-    os.copy(unidocSrc, siteDir / "api" / "latest", createFolders = true)
+    os.copy(unidocSrc, siteDir / "api/latest", createFolders = true)
 
     PathRef(siteDir)
   }

--- a/example/extending/jvmcode/1-subprocess/build.mill
+++ b/example/extending/jvmcode/1-subprocess/build.mill
@@ -22,7 +22,7 @@ object foo extends JavaModule {
     defaultResolver().resolveDeps(Agg(ivy"org.codehaus.groovy:groovy:3.0.9"))
   }
 
-  def groovyScript = Task.Source(millSourcePath / "generate.groovy")
+  def groovyScript = Task.Source("generate.groovy")
 
   def groovyGeneratedResources = Task {
     Jvm.runSubprocess(

--- a/example/extending/jvmcode/2-classloader/build.mill
+++ b/example/extending/jvmcode/2-classloader/build.mill
@@ -14,7 +14,7 @@ object foo extends JavaModule {
     defaultResolver().resolveDeps(Agg(ivy"org.codehaus.groovy:groovy:3.0.9"))
   }
 
-  def groovyScript = Task.Source(millSourcePath / "generate.groovy")
+  def groovyScript = Task.Source("generate.groovy")
 
   def groovyGeneratedResources = Task {
     Jvm.runClassloader(classPath = groovyClasspath().map(_.path)) { classLoader =>

--- a/example/extending/jvmcode/3-worker/build.mill
+++ b/example/extending/jvmcode/3-worker/build.mill
@@ -24,7 +24,7 @@ def groovyWorker: Worker[java.net.URLClassLoader] = Task.Worker {
 }
 
 trait GroovyGenerateJavaModule extends JavaModule {
-  def groovyScript = Task.Source(millSourcePath / "generate.groovy")
+  def groovyScript = Task.Source("generate.groovy")
 
   def groovyGeneratedResources = Task {
     mill.api.ClassLoader.withContextClassLoader(groovyWorker()) {

--- a/example/extending/python/1-hello-python/build.mill
+++ b/example/extending/python/1-hello-python/build.mill
@@ -9,7 +9,7 @@ import mill._
 def pythonExe: T[PathRef] = Task {
 
   os.call(("python3", "-m", "venv", Task.dest / "venv"))
-  val python = Task.dest / "venv" / "bin" / "python3"
+  val python = Task.dest / "venv/bin/python3"
   os.call((python, "-m", "pip", "install", "mypy==1.13.0"))
 
   PathRef(python)
@@ -19,7 +19,7 @@ def pythonExe: T[PathRef] = Task {
 
 // The `sources` task specifies the directory for Python source files (`src` folder).
 
-def sources: T[PathRef] = Task.Source(millSourcePath / "src")
+def sources: T[PathRef] = Task.Source("src")
 
 // === Type Checking
 

--- a/example/extending/python/2-python-modules/build.mill
+++ b/example/extending/python/2-python-modules/build.mill
@@ -8,13 +8,13 @@ import mill._
 
 trait PythonModule extends Module {
 
-  def sources: T[PathRef] = Task.Source(millSourcePath / "src")
+  def sources: T[PathRef] = Task.Source("src")
   def mainFileName: T[String] = Task { "main.py" }
 
   def pythonExe: T[PathRef] = Task {
 
     os.call(("python3", "-m", "venv", Task.dest / "venv"))
-    val python = Task.dest / "venv" / "bin" / "python3"
+    val python = Task.dest / "venv/bin/python3"
     os.call((python, "-m", "pip", "install", "mypy==1.13.0"))
 
     PathRef(python)

--- a/example/extending/python/3-python-module-deps/build.mill
+++ b/example/extending/python/3-python-module-deps/build.mill
@@ -13,13 +13,13 @@ trait PythonModule extends Module {
   // List of module dependencies required by this module.
   def moduleDeps: Seq[PythonModule] = Nil
 
-  def sources: T[PathRef] = Task.Source(millSourcePath / "src")
+  def sources: T[PathRef] = Task.Source("src")
   def mainFileName: T[String] = Task { "main.py" }
 
   def pythonExe: T[PathRef] = Task {
 
     os.call(("python3", "-m", "venv", Task.dest / "venv"))
-    val python = Task.dest / "venv" / "bin" / "python3"
+    val python = Task.dest / "venv/bin/python3"
     os.call((python, "-m", "pip", "install", "mypy==1.13.0"))
 
     PathRef(python)

--- a/example/extending/python/4-python-libs-bundle/build.mill
+++ b/example/extending/python/4-python-libs-bundle/build.mill
@@ -11,7 +11,7 @@ import mill._
 trait PythonModule extends Module {
   def moduleDeps: Seq[PythonModule] = Nil
   def mainFileName: T[String] = Task { "main.py" }
-  def sources: T[PathRef] = Task.Source(millSourcePath / "src")
+  def sources: T[PathRef] = Task.Source("src")
 
   def pythonDeps: T[Seq[String]] = Task { Seq.empty[String] }
 
@@ -22,7 +22,7 @@ trait PythonModule extends Module {
 
   def pythonExe: T[PathRef] = Task {
     os.call(("python3", "-m", "venv", Task.dest / "venv"))
-    val python = Task.dest / "venv" / "bin" / "python3"
+    val python = Task.dest / "venv/bin/python3"
     os.call((python, "-m", "pip", "install", "mypy==1.13.0", "pex==2.24.1", transitivePythonDeps()))
 
     PathRef(python)

--- a/example/extending/typescript/1-hello-typescript/build.mill
+++ b/example/extending/typescript/1-hello-typescript/build.mill
@@ -39,7 +39,7 @@ def npmInstall = Task {
 // e.g. someone can later easily override `allSources` to add additional filtering
 // on exactly which files within the source root they wish to pick up.
 
-def sources = Task.Source(millSourcePath / "src")
+def sources = Task.Source("src")
 def allSources = Task {
   os.walk(sources().path).filter(_.ext == "ts").map(PathRef(_))
 }

--- a/example/extending/typescript/2-typescript-modules/build.mill
+++ b/example/extending/typescript/2-typescript-modules/build.mill
@@ -13,7 +13,7 @@ trait TypeScriptModule extends Module {
     PathRef(Task.dest)
   }
 
-  def sources = Task.Source(millSourcePath / "src")
+  def sources = Task.Source("src")
   def allSources = Task {
     os.walk(sources().path).filter(_.ext == "ts").map(PathRef(_))
   }

--- a/example/extending/typescript/3-module-deps/build.mill
+++ b/example/extending/typescript/3-module-deps/build.mill
@@ -22,7 +22,7 @@ trait TypeScriptModule extends Module {
     PathRef(Task.dest)
   }
 
-  def sources = Task.Source(millSourcePath / "src")
+  def sources = Task.Source("src")
   def allSources = Task { os.walk(sources().path).filter(_.ext == "ts").map(PathRef(_)) }
 
   def compile: T[(PathRef, PathRef)] = Task {

--- a/example/extending/typescript/4-npm-deps-bundle/build.mill
+++ b/example/extending/typescript/4-npm-deps-bundle/build.mill
@@ -39,7 +39,7 @@ trait TypeScriptModule extends Module {
     PathRef(Task.dest)
   }
 
-  def sources = Task.Source(millSourcePath / "src")
+  def sources = Task.Source("src")
   def allSources = Task { os.walk(sources().path).filter(_.ext == "ts").map(PathRef(_)) }
 
   def compile: T[(PathRef, PathRef)] = Task {

--- a/example/fundamentals/cross/10-static-blog/build.mill
+++ b/example/fundamentals/cross/10-static-blog/build.mill
@@ -26,14 +26,14 @@ val posts = interp.watchValue {
 
 object post extends Cross[PostModule](posts)
 trait PostModule extends Cross.Module[String] {
-  def source = Task.Source(millSourcePath / crossValue)
+  def source = Task.Source(crossValue)
   def render = Task {
     val doc = Parser.builder().build().parse(os.read(source().path))
     val title = mdNameToTitle(crossValue)
     val rendered = doctype("html")(
       html(
         body(
-          h1(a("Blog", href := "../index.html"), " / ", title),
+          h1(a("Blog", href := "../index.html"), /, title),
           raw(HtmlRenderer.builder().build().render(doc))
         )
       )

--- a/example/fundamentals/cross/10-static-blog/build.mill
+++ b/example/fundamentals/cross/10-static-blog/build.mill
@@ -26,7 +26,7 @@ val posts = interp.watchValue {
 
 object post extends Cross[PostModule](posts)
 trait PostModule extends Cross.Module[String] {
-  def source = Task.Source(crossValue)
+  def source = Task.Source(millSourcePath / crossValue)
   def render = Task {
     val doc = Parser.builder().build().parse(os.read(source().path))
     val title = mdNameToTitle(crossValue)

--- a/example/fundamentals/cross/10-static-blog/build.mill
+++ b/example/fundamentals/cross/10-static-blog/build.mill
@@ -33,7 +33,7 @@ trait PostModule extends Cross.Module[String] {
     val rendered = doctype("html")(
       html(
         body(
-          h1(a("Blog", href := "../index.html"), /, title),
+          h1(a("Blog", href := "../index.html"), " / ", title),
           raw(HtmlRenderer.builder().build().render(doc))
         )
       )

--- a/example/fundamentals/modules/6-modules/build.mill
+++ b/example/fundamentals/modules/6-modules/build.mill
@@ -238,7 +238,7 @@ object outer2 extends MyModule {
 //
 
 trait Foo extends Module {
-  def sourceRoots = Task.Sources(millSourcePath / "src")
+  def sourceRoots = Task.Sources("src")
   def sourceContents = Task {
     sourceRoots()
       .flatMap(pref => os.walk(pref.path))
@@ -249,7 +249,7 @@ trait Foo extends Module {
 }
 
 trait Bar extends Foo {
-  def additionalSources = Task.Sources(millSourcePath / "src2")
+  def additionalSources = Task.Sources("src2")
   def sourceRoots = Task { super.sourceRoots() ++ additionalSources() }
 }
 

--- a/example/fundamentals/modules/6-modules/build.mill
+++ b/example/fundamentals/modules/6-modules/build.mill
@@ -133,7 +133,7 @@ object foo2 extends FooModule {
 // module expects its input files to be on disk.
 
 trait MyModule extends Module {
-  def sources = Task.Source(millSourcePath / "sources")
+  def sources = Task.Source("sources")
   def task = Task { "hello " + os.list(sources().path).map(os.read(_)).mkString(" ") }
 }
 

--- a/example/fundamentals/modules/8-diy-java-modules/build.mill
+++ b/example/fundamentals/modules/8-diy-java-modules/build.mill
@@ -9,7 +9,7 @@ trait DiyJavaModule extends Module {
   def mainClass: T[Option[String]] = None
 
   def upstream: T[Seq[PathRef]] = Task { Task.traverse(moduleDeps)(_.classPath)().flatten }
-  def sources = Task.Source(millSourcePath / "src")
+  def sources = Task.Source("src")
 
   def compile = Task {
     val allSources = os.walk(sources().path)

--- a/example/fundamentals/tasks/1-task-graph/build.mill
+++ b/example/fundamentals/tasks/1-task-graph/build.mill
@@ -6,8 +6,8 @@ import mill._
 
 def mainClass: T[Option[String]] = Some("foo.Foo")
 
-def sources = Task.Source(millSourcePath / "src")
-def resources = Task.Source(millSourcePath / "resources")
+def sources = Task.Source("src")
+def resources = Task.Source("resources")
 
 def compile = Task {
   val allSources = os.walk(sources().path)

--- a/example/fundamentals/tasks/2-primary-tasks/build.mill
+++ b/example/fundamentals/tasks/2-primary-tasks/build.mill
@@ -9,8 +9,8 @@ package build
 
 import mill.{Module, T, _}
 
-def sources = Task.Source { millSourcePath / "src" }
-def resources = Task.Source { millSourcePath / "resources" }
+def sources = Task.Source { "src" }
+def resources = Task.Source { "resources" }
 
 // ``Source``s are defined using `Task.Source{...}` taking one `os.Path`, or `Task.Sources{...}`,
 // taking multiple ``os.Path``s as arguments. A ``Source``'s:

--- a/example/fundamentals/tasks/3-anonymous-tasks/build.mill
+++ b/example/fundamentals/tasks/3-anonymous-tasks/build.mill
@@ -5,7 +5,7 @@
 package build
 import mill._, define.Task
 
-def data = Task.Source(millSourcePath / "data")
+def data = Task.Source("data")
 
 def anonTask(fileName: String): Task[String] = Task.Anon {
   os.read(data().path / fileName)

--- a/example/fundamentals/tasks/5-persistent-tasks/build.mill
+++ b/example/fundamentals/tasks/5-persistent-tasks/build.mill
@@ -17,7 +17,7 @@ import java.util.Arrays
 import java.io.ByteArrayOutputStream
 import java.util.zip.GZIPOutputStream
 
-def data = Task.Source(millSourcePath / "data")
+def data = Task.Source("data")
 
 def compressedData = Task(persistent = true) {
   println("Evaluating compressedData")

--- a/example/fundamentals/tasks/6-workers/build.mill
+++ b/example/fundamentals/tasks/6-workers/build.mill
@@ -25,7 +25,7 @@ import java.util.Arrays
 import java.io.ByteArrayOutputStream
 import java.util.zip.GZIPOutputStream
 
-def data = Task.Source(millSourcePath / "data")
+def data = Task.Source("data")
 
 def compressWorker = Task.Worker { new CompressWorker(Task.dest) }
 

--- a/example/javalib/module/15-jni/build.mill
+++ b/example/javalib/module/15-jni/build.mill
@@ -6,7 +6,7 @@ import mill._, javalib._, util.Jvm
 
 object `package` extends RootModule with JavaModule {
   // Additional source folder to put C sources
-  def nativeSources = Task.Sources(millSourcePath / "native-src")
+  def nativeSources = Task.Sources("native-src")
 
   // Auto-generate JNI `.h` files from Java classes using Javac
   def nativeHeaders = Task {

--- a/example/javalib/module/7-resources/build.mill
+++ b/example/javalib/module/7-resources/build.mill
@@ -4,7 +4,7 @@ import mill._, javalib._
 
 object foo extends JavaModule {
   object test extends JavaTests with TestModule.Junit4 {
-    def otherFiles = Task.Source(millSourcePath / "other-files")
+    def otherFiles = Task.Source("other-files")
 
     def forkEnv = super.forkEnv() ++ Map(
       "OTHER_FILES_DIR" -> otherFiles().path.toString

--- a/example/javalib/publishing/3-revapi/build.mill
+++ b/example/javalib/publishing/3-revapi/build.mill
@@ -16,7 +16,7 @@ object bar extends JavaModule with RevapiModule {
 
   override def revapiConfigFiles: T[Seq[PathRef]] =
     // add Revapi config JSON file(s)
-    Task.Sources(millSourcePath / "conf/revapi.json")
+    Task.Sources("conf/revapi.json")
 
   override def revapiClasspath: T[Agg[PathRef]] = Task {
     // add folder containing logback.xml

--- a/example/javascriptlib/module/1-common-config/build.mill
+++ b/example/javascriptlib/module/1-common-config/build.mill
@@ -6,7 +6,7 @@ import mill.javascriptlib._
 object foo extends TypeScriptModule {
 
   def customSource = Task {
-    Seq(PathRef(millSourcePath / "custom-src" / "foo2.ts"))
+    Seq(PathRef(millSourcePath / "custom-src/foo2.ts"))
   }
 
   def allSources = super.allSources() ++ customSource()

--- a/example/javascriptlib/module/5-resources/build.mill
+++ b/example/javascriptlib/module/5-resources/build.mill
@@ -5,7 +5,7 @@ import ujson._
 
 object foo extends TypeScriptModule {
   object test extends TypeScriptTests with TestModule.Jest {
-    def otherFiles = Task.Source(millSourcePath / "other-files")
+    def otherFiles = Task.Source("other-files")
 
     def forkEnv = super.forkEnv() + ("OTHER_FILES_DIR" -> otherFiles().path.toString)
   }

--- a/example/kotlinlib/module/15-jni/build.mill
+++ b/example/kotlinlib/module/15-jni/build.mill
@@ -8,7 +8,7 @@ object `package` extends RootModule with KotlinModule {
   def kotlinVersion = "1.9.24"
 
   // Additional source folder to put C sources
-  def nativeSources = Task.Sources(millSourcePath / "native-src")
+  def nativeSources = Task.Sources("native-src")
 
   // Compile C
   def nativeCompiled = Task {

--- a/example/kotlinlib/module/7-resources/build.mill
+++ b/example/kotlinlib/module/7-resources/build.mill
@@ -7,7 +7,7 @@ object foo extends KotlinModule {
   def kotlinVersion = "1.9.24"
 
   object test extends KotlinTests with TestModule.Junit5 {
-    def otherFiles = Task.Source(millSourcePath / "other-files")
+    def otherFiles = Task.Source("other-files")
 
     def forkEnv = super.forkEnv() ++ Map(
       "OTHER_FILES_DIR" -> otherFiles().path.toString

--- a/example/pythonlib/basic/1-simple/build.mill
+++ b/example/pythonlib/basic/1-simple/build.mill
@@ -3,7 +3,7 @@ import mill._, pythonlib._
 
 object foo extends PythonModule {
 
-  def mainScript = Task.Source { millSourcePath / "src" / "foo.py" }
+  def mainScript = Task.Source { "src/foo.py" }
 
   def pythonDeps = Seq("Jinja2==3.1.4")
 

--- a/example/pythonlib/basic/2-custom-build-logic/build.mill
+++ b/example/pythonlib/basic/2-custom-build-logic/build.mill
@@ -7,7 +7,7 @@ import mill._, pythonlib._
 
 object foo extends PythonModule {
 
-  def mainScript = Task.Source { millSourcePath / "src" / "foo.py" }
+  def mainScript = Task.Source { "src/foo.py" }
 
   /** All Python source files in this module, recursively from the source directories.*/
   def allSourceFiles: T[Seq[PathRef]] = Task {

--- a/example/pythonlib/basic/3-multi-module/build.mill
+++ b/example/pythonlib/basic/3-multi-module/build.mill
@@ -8,11 +8,11 @@ trait MyModule extends PythonModule {
 
 object foo extends MyModule {
   def moduleDeps = Seq(bar)
-  def mainScript = Task.Source { millSourcePath / "src" / "foo.py" }
+  def mainScript = Task.Source { "src/foo.py" }
 }
 
 object bar extends MyModule {
-  def mainScript = Task.Source { millSourcePath / "src" / "bar.py" }
+  def mainScript = Task.Source { "src/bar.py" }
   def pythonDeps = Seq("Jinja2==3.1.4")
 }
 

--- a/example/pythonlib/module/1-common-config/build.mill
+++ b/example/pythonlib/module/1-common-config/build.mill
@@ -12,7 +12,7 @@ object foo extends PythonModule {
   def pythonDeps = Seq("MarkupSafe==3.0.2", "Jinja2==3.1.4")
 
   // choose a main Script to run if there are multiple present
-  def mainScript = Task.Source { millSourcePath / "custom-src" / "foo2.py" }
+  def mainScript = Task.Source { "custom-src/foo2.py" }
 
   // Add (or replace) source folders for the module to use
   def sources = Task.Sources {

--- a/example/pythonlib/module/2-custom-tasks/build.mill
+++ b/example/pythonlib/module/2-custom-tasks/build.mill
@@ -15,7 +15,7 @@ object foo extends PythonModule {
 
   def pythonDeps = Seq("argparse==1.4.0", "jinja2==3.1.4")
 
-  def mainScript = Task.Source { millSourcePath / "src" / "foo.py" }
+  def mainScript = Task.Source { "src/foo.py" }
 
   def generatedSources: T[Seq[PathRef]] = Task {
     val destPath = Task.dest / "generatedSources"

--- a/example/pythonlib/module/4-compilation-execution-flags/build.mill
+++ b/example/pythonlib/module/4-compilation-execution-flags/build.mill
@@ -2,7 +2,7 @@ package build
 import mill._, pythonlib._
 
 object `package` extends RootModule with PythonModule {
-  def mainScript = Task.Source { millSourcePath / "src" / "foo.py" }
+  def mainScript = Task.Source { "src/foo.py" }
   def pythonOptions = Seq("-Wall", "-Xdev")
   def forkEnv = Map("MY_ENV_VAR" -> "HELLO MILL!")
 }

--- a/example/pythonlib/module/5-resources/build.mill
+++ b/example/pythonlib/module/5-resources/build.mill
@@ -2,13 +2,13 @@ package build
 import mill._, pythonlib._
 
 object foo extends PythonModule {
-  def mainScript = Task.Source { millSourcePath / "src" / "foo.py" }
+  def mainScript = Task.Source { "src/foo.py" }
 
   def resources = Task.Sources { super.resources() ++ Seq(PathRef(millSourcePath / "custom")) }
 
   object test extends PythonTests with TestModule.Unittest {
 
-    def otherFiles = Task.Source(millSourcePath / "other-files")
+    def otherFiles = Task.Source("other-files")
 
     def forkEnv: T[Map[String, String]] =
       super.forkEnv() ++ Map("OTHER_FILES_DIR" -> otherFiles().path.toString)

--- a/example/pythonlib/module/6-pex-config/build.mill
+++ b/example/pythonlib/module/6-pex-config/build.mill
@@ -7,7 +7,7 @@ import mill._, pythonlib._
 
 object foo extends PythonModule {
   // This Script will be the entry point for the bundle
-  def mainScript = Task.Source { millSourcePath / "src" / "foo.py" }
+  def mainScript = Task.Source { "src/foo.py" }
 
   // These Dependencies will be used in the bundle
   def pythonDeps = Seq("pyfiglet==1.0.2", "termcolor==2.5.0")

--- a/example/pythonlib/publishing/2-publish-module-advanced/build.mill
+++ b/example/pythonlib/publishing/2-publish-module-advanced/build.mill
@@ -39,7 +39,7 @@ object `package` extends RootModule with PythonModule with PublishModule {
   def publishVersion = "0.0.3"
 
   // you could also reference an existing setup.py file directly, e.g.
-  // `def setup = Task.Source { millSourcePath / "setup.py" }`
+  // `def setup = Task.Source {"setup.py" }`
   def setup = Task {
     val str =
       s"""#from setuptools import setup

--- a/example/pythonlib/testing/1-test-suite/build.mill
+++ b/example/pythonlib/testing/1-test-suite/build.mill
@@ -2,9 +2,9 @@ package build
 import mill._, pythonlib._
 
 object foo extends PythonModule {
-  def mainScript = Task.Source { millSourcePath / "src/foo.py" }
+  def mainScript = Task.Source { "src/foo.py" }
   object test extends PythonTests with TestModule.Unittest {
-    def mainScript = Task.Source { millSourcePath / "src/test_foo.py" }
+    def mainScript = Task.Source { "src/test_foo.py" }
   }
 }
 
@@ -51,7 +51,7 @@ OK
 // details on how to use each one from the command line.
 
 object bar extends PythonModule {
-  def mainScript = Task.Source { millSourcePath / "src/bar.py" }
+  def mainScript = Task.Source { "src/bar.py" }
   object test extends PythonTests with TestModule.Pytest
 }
 

--- a/example/pythonlib/testing/2-test-deps/build.mill
+++ b/example/pythonlib/testing/2-test-deps/build.mill
@@ -6,7 +6,7 @@ import mill._, pythonlib._
 
 object foo extends PythonModule {
 
-  def mainScript = Task.Source { millSourcePath / "src/foo.py" }
+  def mainScript = Task.Source { "src/foo.py" }
 
   def moduleDeps = Seq(bar)
 
@@ -23,7 +23,7 @@ object foo extends PythonModule {
 
 object bar extends PythonModule {
 
-  def mainScript = Task.Source { millSourcePath / "src/bar.py" }
+  def mainScript = Task.Source { "src/bar.py" }
 
   object test extends PythonTests with TestModule.Unittest
 

--- a/example/pythonlib/testing/3-integration-suite/build.mill
+++ b/example/pythonlib/testing/3-integration-suite/build.mill
@@ -7,7 +7,7 @@ import mill._, pythonlib._
 
 object foo extends PythonModule {
 
-  def mainScript = Task.Source { millSourcePath / "src/foo.py" }
+  def mainScript = Task.Source { "src/foo.py" }
 
   object test extends PythonTests with TestModule.Unittest
 

--- a/example/pythonlib/web/1-hello-flask/build.mill
+++ b/example/pythonlib/web/1-hello-flask/build.mill
@@ -6,7 +6,7 @@ import mill._, pythonlib._
 
 object foo extends PythonModule {
 
-  def mainScript = Task.Source { millSourcePath / "src/foo.py" }
+  def mainScript = Task.Source { "src/foo.py" }
 
   def pythonDeps = Seq("flask==3.1.0")
 

--- a/example/pythonlib/web/2-todo-flask/build.mill
+++ b/example/pythonlib/web/2-todo-flask/build.mill
@@ -7,7 +7,7 @@ import mill._, pythonlib._
 
 object todo extends PythonModule {
 
-  def mainScript = Task.Source { millSourcePath / "src/app.py" }
+  def mainScript = Task.Source { "src/app.py" }
 
   def pythonDeps = Seq("flask==3.1.0", "Flask-SQLAlchemy==3.1.1", "Flask-WTF==1.2.2")
 

--- a/example/pythonlib/web/3-hello-django/build.mill
+++ b/example/pythonlib/web/3-hello-django/build.mill
@@ -6,7 +6,7 @@ import mill._, pythonlib._
 
 object foo extends PythonModule {
 
-  def mainScript = Task.Source { millSourcePath / "src/manage.py" }
+  def mainScript = Task.Source { "src/manage.py" }
 
   def pythonDeps = Seq("django==5.1.4")
 

--- a/example/pythonlib/web/4-todo-django/build.mill
+++ b/example/pythonlib/web/4-todo-django/build.mill
@@ -6,7 +6,7 @@ import mill._, pythonlib._
 
 object todo extends PythonModule {
 
-  def mainScript = Task.Source { millSourcePath / "src/manage.py" }
+  def mainScript = Task.Source { "src/manage.py" }
 
   def pythonDeps = Seq("django==5.1.4")
 

--- a/example/scalalib/module/7-resources/build.mill
+++ b/example/scalalib/module/7-resources/build.mill
@@ -12,7 +12,7 @@ object foo extends ScalaModule {
     def ivyDeps = Agg(ivy"com.lihaoyi::utest:0.8.5")
     def testFramework = "utest.runner.Framework"
 
-    def otherFiles = Task.Source(millSourcePath / "other-files")
+    def otherFiles = Task.Source("other-files")
 
     def forkEnv = super.forkEnv() ++ Map(
       "OTHER_FILES_DIR" -> otherFiles().path.toString

--- a/example/thirdparty/acyclic/build.mill
+++ b/example/thirdparty/acyclic/build.mill
@@ -39,7 +39,7 @@ trait AcyclicModule extends CrossScalaModule with PublishModule {
   def compileIvyDeps = Agg(Deps.scalaCompiler(crossScalaVersion))
 
   object test extends ScalaTests with TestModule.Utest {
-    def sources = Task.Sources(millSourcePath / "src", millSourcePath / "resources")
+    def sources = Task.Sources("src", "resources")
     def ivyDeps = Agg(Deps.utest, Deps.scalaCompiler(crossScalaVersion))
   }
 }

--- a/example/thirdparty/arrow/build.mill
+++ b/example/thirdparty/arrow/build.mill
@@ -135,10 +135,10 @@ object `package` extends RootModule {
       override def sources: T[Seq[PathRef]] = Task.Sources {
         val sourcesRootPath = millSourcePath / "src"
         var sources = Seq("common", platformCrossSuffix)
-          .map(platform => PathRef(sourcesRootPath / s"${platform}Main" / "kotlin"))
+          .map(platform => PathRef(sourcesRootPath / s"${platform}Main/kotlin"))
           .filter(p => os.exists(p.path))
         if (platformCrossSuffix != "jvm") {
-          val nonJvmSourcesPath = sourcesRootPath / "nonJvmMain" / "kotlin"
+          val nonJvmSourcesPath = sourcesRootPath / "nonJvmMain/kotlin"
           if (os.exists(nonJvmSourcesPath)) {
             sources ++= Seq(PathRef(nonJvmSourcesPath))
           }
@@ -163,7 +163,7 @@ object `package` extends RootModule {
         override def sources: T[Seq[PathRef]] = Task.Sources {
           val sourcesRootPath = outer.millSourcePath / "src"
           Seq("common", outer.platformCrossSuffix)
-            .map(platform => PathRef(sourcesRootPath / s"${platform}Test" / "kotlin"))
+            .map(platform => PathRef(sourcesRootPath / s"${platform}Test/kotlin"))
             .filter(p => os.exists(p.path))
         }
       }

--- a/example/thirdparty/arrow/build.mill
+++ b/example/thirdparty/arrow/build.mill
@@ -135,7 +135,7 @@ object `package` extends RootModule {
       override def sources: T[Seq[PathRef]] = Task.Sources {
         val sourcesRootPath = millSourcePath / "src"
         var sources = Seq("common", platformCrossSuffix)
-          .map(platform => PathRef(sourcesRootPath / s"${platform}Main/kotlin"))
+          .map(platform => PathRef(sourcesRootPath / s"${platform}Main" / "kotlin"))
           .filter(p => os.exists(p.path))
         if (platformCrossSuffix != "jvm") {
           val nonJvmSourcesPath = sourcesRootPath / "nonJvmMain/kotlin"
@@ -163,7 +163,7 @@ object `package` extends RootModule {
         override def sources: T[Seq[PathRef]] = Task.Sources {
           val sourcesRootPath = outer.millSourcePath / "src"
           Seq("common", outer.platformCrossSuffix)
-            .map(platform => PathRef(sourcesRootPath / s"${platform}Test/kotlin"))
+            .map(platform => PathRef(sourcesRootPath / s"${platform}Test" / "kotlin"))
             .filter(p => os.exists(p.path))
         }
       }

--- a/example/thirdparty/netty/build.mill
+++ b/example/thirdparty/netty/build.mill
@@ -456,7 +456,7 @@ object `testsuite-native` extends NettyTestSuiteModule {
     `transport-native-epoll`
   )
   def testModuleDeps = Seq(`resolver-dns-classes-macos`)
-  override def sources = Task.Sources(millSourcePath / "src/test/java")
+  override def sources = Task.Sources("src/test/java")
 }
 
 object `testsuite-native-image` extends NettyTestSuiteModule {
@@ -493,7 +493,7 @@ object `testsuite-osgi` extends NettyTestSuiteModule {
     `transport-udt`
   )
 
-  override def sources = Task.Sources(millSourcePath / "src/test/java")
+  override def sources = Task.Sources("src/test/java")
 
   def ivyDeps = super.ivyDeps() ++ Agg(
     ivy"org.apache.felix:org.apache.felix.configadmin:1.9.14",
@@ -506,7 +506,7 @@ object `testsuite-osgi` extends NettyTestSuiteModule {
 
 object `testsuite-shading` extends NettyTestSuiteModule {
   def moduleDeps = Seq(common)
-  override def sources = Task.Sources(millSourcePath / "src/test/java")
+  override def sources = Task.Sources("src/test/java")
 }
 
 object transport extends NettyModule {

--- a/example/thirdparty/netty/build.mill
+++ b/example/thirdparty/netty/build.mill
@@ -85,7 +85,7 @@ trait NettyModule extends NettyBaseModule {
 
 trait NettyJniModule extends NettyModule {
   def jniLibraryName: T[String]
-  def cSources = Task.Source(millSourcePath / "src/main/c")
+  def cSources = Task.Source("src/main/c")
   def resources = Task {
     os.copy(clang().path, Task.dest / "META-INF/native" / jniLibraryName(), createFolders = true)
     Seq(PathRef(Task.dest))
@@ -245,7 +245,7 @@ object common extends NettyModule {
     ivy"org.jctools:jctools-core:4.0.5"
   )
 
-  def script = Task.Source(millSourcePath / "src/main/script")
+  def script = Task.Source("src/main/script")
   def generatedSources0 = Task {
     val shell = new groovy.lang.GroovyShell()
 
@@ -556,8 +556,8 @@ object `transport-native-unix-common` extends NettyModule {
   def moduleDeps = Seq(common, buffer, transport)
   def ivyDeps = Agg(ivy"org.junit.jupiter:junit-jupiter-api:5.9.0")
 
-  def makefile = Task.Source(millSourcePath / "Makefile")
-  def cSources = Task.Source(millSourcePath / "src/main/c")
+  def makefile = Task.Source("Makefile")
+  def cSources = Task.Source("src/main/c")
   def cHeaders = Task {
     for (p <- os.walk(cSources().path) if p.ext == "h") {
       os.copy(p, Task.dest / p.relativeTo(cSources().path), createFolders = true)

--- a/integration/ide/gen-idea/resources/extended/build.mill
+++ b/integration/ide/gen-idea/resources/extended/build.mill
@@ -52,7 +52,7 @@ trait HelloWorldModule extends scalalib.ScalaModule {
         Seq(
           // whole file
           IdeaConfigFile(
-            os.sub / "runConfigurations" / "testrun.xml",
+            os.sub / "runConfigurations/testrun.xml",
             None,
             Seq(Element("test"))
           ),

--- a/integration/invalidation/multi-level-editing/src/MultiLevelBuildTests.scala
+++ b/integration/invalidation/multi-level-editing/src/MultiLevelBuildTests.scala
@@ -110,7 +110,7 @@ trait MultiLevelBuildTests extends UtestIntegrationTestSuite {
     // restarts behave as expected:
     if (clientServerMode) {
       // Only one server should be running at any point in time
-      val Seq(serverFolder) = os.list(tester.workspacePath / "out" / "mill-server")
+      val Seq(serverFolder) = os.list(tester.workspacePath / "out/mill-server")
 
       // client-server mode should never restart in these tests and preserve the same process,
       val currentServerId = os.read(serverFolder / "serverId")

--- a/integration/invalidation/selective-execution/resources/build.mill
+++ b/integration/invalidation/selective-execution/resources/build.mill
@@ -1,7 +1,7 @@
 import mill._
 
 object foo extends Module {
-  def fooTask = Task.Source(millSourcePath / "foo.txt")
+  def fooTask = Task.Source("foo.txt")
 
   def fooHelper(p: os.Path) = {
     "fooHelper " + os.read(p)
@@ -15,7 +15,7 @@ object foo extends Module {
 
 object bar extends mill.define.TaskModule {
   // make sure it works with private tasks as well
-  private def barTask = Task.Source(millSourcePath / "bar.txt")
+  private def barTask = Task.Source("bar.txt")
 
   def barHelper(p: os.Path) = {
     "barHelper " + os.read(p)

--- a/integration/invalidation/watch-source-input/resources/build.mill
+++ b/integration/invalidation/watch-source-input/resources/build.mill
@@ -4,7 +4,7 @@ import mill._
 println("Setting up build.mill")
 
 def foo = Task.Sources(millSourcePath / "foo1.txt", millSourcePath / "foo2.txt")
-def bar = Task.Source(millSourcePath / "bar.txt")
+def bar = Task.Source("bar.txt")
 
 def qux = Task {
   val fooMsg = "Running qux foo contents " + foo().map(p => os.read(p.path)).mkString(" ")

--- a/integration/invalidation/watch-source-input/resources/build.mill
+++ b/integration/invalidation/watch-source-input/resources/build.mill
@@ -3,7 +3,7 @@ import mill._
 
 println("Setting up build.mill")
 
-def foo = Task.Sources(millSourcePath / "foo1.txt", millSourcePath / "foo2.txt")
+def foo = Task.Sources("foo1.txt", "foo2.txt")
 def bar = Task.Source("bar.txt")
 
 def qux = Task {

--- a/javascriptlib/src/mill/javascriptlib/PublishModule.scala
+++ b/javascriptlib/src/mill/javascriptlib/PublishModule.scala
@@ -131,7 +131,7 @@ trait PublishModule extends TypeScriptModule {
   private def pubGenSources: T[Unit] = Task {
     val allGeneratedSources = pubBaseModeGenSources() ++ pubModDepsGenSources()
     allGeneratedSources.foreach { target =>
-      val destination = publishDir().path / "typescript" / "generatedSources" / target.path.last
+      val destination = publishDir().path / "typescript/generatedSources" / target.path.last
       os.makeDir.all(destination / os.up)
       os.copy.over(
         target.path,

--- a/javascriptlib/src/mill/javascriptlib/ReactScriptsModule.scala
+++ b/javascriptlib/src/mill/javascriptlib/ReactScriptsModule.scala
@@ -71,7 +71,7 @@ trait ReactScriptsModule extends TypeScriptModule {
     val npm = npmInstall().path
     val combinedPaths = compilerOptionsPaths() ++ Seq(
       "*" -> npm / "node_modules",
-      "typescript" -> npm / "node_modules" / "typescript"
+      "typescript" -> npm / "node_modules/typescript"
     )
 
     val combinedCompilerOptions: Map[String, ujson.Value] = compilerOptions() ++ Map(
@@ -108,7 +108,7 @@ trait ReactScriptsModule extends TypeScriptModule {
   override def bundle: Target[PathRef] = Task {
     val compiled = compile()._1.path
     os.call(
-      ("node", compiled / "node_modules" / "react-scripts" / "bin" / "react-scripts.js", "build"),
+      ("node", compiled / "node_modules/react-scripts/bin/react-scripts.js", "build"),
       cwd = compiled,
       stdout = os.Inherit,
       env = forkEnv()
@@ -142,7 +142,7 @@ trait ReactScriptsModule extends TypeScriptModule {
     os.call(
       (
         "node",
-        (compiled / "node_modules" / "react-scripts" / "bin" / "react-scripts.js").toString,
+        (compiled / "node_modules/react-scripts/bin/react-scripts.js").toString,
         "test",
         "--watchAll=false"
       ),

--- a/javascriptlib/src/mill/javascriptlib/RsWithServeModule.scala
+++ b/javascriptlib/src/mill/javascriptlib/RsWithServeModule.scala
@@ -15,7 +15,7 @@ trait RsWithServeModule extends ReactScriptsModule {
     val env = forkEnv()
     os.call(
       (
-        (compiled / "node_modules" / "serve" / "bin" / "serve.js").toString,
+        (compiled / "node_modules/serve/bin/serve.js").toString,
         "-s",
         build,
         "-l",

--- a/javascriptlib/src/mill/javascriptlib/TypeScriptModule.scala
+++ b/javascriptlib/src/mill/javascriptlib/TypeScriptModule.scala
@@ -50,7 +50,7 @@ trait TypeScriptModule extends Module { outer =>
     PathRef(Task.dest)
   }
 
-  def sources: T[PathRef] = Task.Source(millSourcePath / "src")
+  def sources: T[PathRef] = Task.Source("src")
 
   def resources: T[Seq[PathRef]] = Task { Seq(PathRef(millSourcePath / "resources")) }
 

--- a/kotlinlib/src/mill/kotlinlib/KotlinMavenModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/KotlinMavenModule.scala
@@ -8,22 +8,22 @@ import mill.javalib.MavenModule
  */
 trait KotlinMavenModule extends KotlinModule with MavenModule {
   override def sources = Task.Sources(
-    millSourcePath / "src/main/java",
-    millSourcePath / "src/main/kotlin"
+    "src/main/java",
+    "src/main/kotlin"
   )
   override def resources = Task.Sources {
-    millSourcePath / "src/main/resources"
+    "src/main/resources"
   }
 
   trait KotlinMavenTests extends KotlinTests with MavenTests {
     override def intellijModulePath: os.Path = millSourcePath / "src/test"
 
     override def sources = Task.Sources(
-      millSourcePath / "src/test/java",
-      millSourcePath / "src/test/kotlin"
+      "src/test/java",
+      "src/test/kotlin"
     )
     override def resources = Task.Sources {
-      millSourcePath / "src/test/resources"
+      "src/test/resources"
     }
   }
 }

--- a/kotlinlib/src/mill/kotlinlib/js/KotlinJsModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/js/KotlinJsModule.scala
@@ -486,11 +486,11 @@ trait KotlinJsModule extends KotlinModule { outer =>
     // otherwise with random versions there is a possibility to have conflict
     // between the versions of the shared transitive deps
     private def mochaModule = Task {
-      PathRef(nodeModulesDir().path / "node_modules" / "mocha" / "bin" / "mocha.js")
+      PathRef(nodeModulesDir().path / "node_modules/mocha/bin/mocha.js")
     }
 
     private def sourceMapSupportModule = Task {
-      PathRef(nodeModulesDir().path / "node_modules" / "source-map-support" / "register.js")
+      PathRef(nodeModulesDir().path / "node_modules/source-map-support/register.js")
     }
 
     // endregion

--- a/kotlinlib/test/src/mill/kotlinlib/HelloWorldTests.scala
+++ b/kotlinlib/test/src/mill/kotlinlib/HelloWorldTests.scala
@@ -92,7 +92,7 @@ object HelloWorldTests extends TestSuite {
     test("failures") {
       val eval = testEval()
 
-      val mainJava = HelloWorldKotlin.millSourcePath / "main" / "src" / "Hello.kt"
+      val mainJava = HelloWorldKotlin.millSourcePath / "main/src/Hello.kt"
 
       HelloWorldKotlin.main.crossModules.foreach(m => {
 

--- a/kotlinlib/test/src/mill/kotlinlib/MixedHelloWorldTests.scala
+++ b/kotlinlib/test/src/mill/kotlinlib/MixedHelloWorldTests.scala
@@ -79,7 +79,7 @@ object MixedHelloWorldTests extends TestSuite {
       MixedHelloWorldKotlin.main.crossModules.foreach(m => {
 
         val mainJava =
-          MixedHelloWorldKotlin.millSourcePath / "main" / "src" / "hello" / "KotlinHello.kt"
+          MixedHelloWorldKotlin.millSourcePath / "main/src/hello/KotlinHello.kt"
 
         val Right(_) = eval.apply(m.compile)
 

--- a/kotlinlib/test/src/mill/kotlinlib/contrib/kover/KoverModuleTests.scala
+++ b/kotlinlib/test/src/mill/kotlinlib/contrib/kover/KoverModuleTests.scala
@@ -15,7 +15,7 @@ object KoverModuleTests extends TestSuite {
 
   val kotlinVersion = "1.9.24"
 
-  val resourcePath = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "contrib" / "kover"
+  val resourcePath = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "contrib/kover"
 
   object module extends TestBaseModule {
 

--- a/kotlinlib/test/src/mill/kotlinlib/contrib/ktfmt/KtfmtModuleTests.scala
+++ b/kotlinlib/test/src/mill/kotlinlib/contrib/ktfmt/KtfmtModuleTests.scala
@@ -20,7 +20,7 @@ object KtfmtModuleTests extends TestSuite {
   def tests: Tests = Tests {
 
     val (before, after) = {
-      val root = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "contrib" / "ktfmt"
+      val root = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "contrib/ktfmt"
       (root / "before", root / "after")
     }
 
@@ -28,7 +28,7 @@ object KtfmtModuleTests extends TestSuite {
       assert(
         checkState(
           afterFormat(before, style = "kotlin"),
-          after / "style" / "kotlin"
+          after / "style/kotlin"
         )
       )
     }
@@ -37,7 +37,7 @@ object KtfmtModuleTests extends TestSuite {
       assert(
         checkState(
           afterFormat(before, style = "google"),
-          after / "style" / "google"
+          after / "style/google"
         )
       )
     }
@@ -46,7 +46,7 @@ object KtfmtModuleTests extends TestSuite {
       assert(
         checkState(
           afterFormat(before, style = "meta"),
-          after / "style" / "meta"
+          after / "style/meta"
         )
       )
     }
@@ -68,7 +68,7 @@ object KtfmtModuleTests extends TestSuite {
     test("ktfmt - explicit files") {
       checkState(
         afterFormat(before, sources = Seq(module.sources)),
-        after / "style" / "kotlin"
+        after / "style/kotlin"
       )
     }
 
@@ -77,7 +77,7 @@ object KtfmtModuleTests extends TestSuite {
       assert(
         checkState(
           afterFormatAll(before),
-          after / "style" / "kotlin"
+          after / "style/kotlin"
         )
       )
     }

--- a/kotlinlib/test/src/mill/kotlinlib/js/KotlinJsCompileTests.scala
+++ b/kotlinlib/test/src/mill/kotlinlib/js/KotlinJsCompileTests.scala
@@ -37,8 +37,8 @@ object KotlinJsCompileTests extends TestSuite {
       val irDir = result.value.classes.path
       assert(
         os.isDir(irDir),
-        os.exists(irDir / "default" / "manifest"),
-        os.exists(irDir / "default" / "linkdata" / "package_foo"),
+        os.exists(irDir / "default/manifest"),
+        os.exists(irDir / "default/linkdata/package_foo"),
         !os.walk(irDir).exists(_.ext == "klib")
       )
     }
@@ -46,7 +46,7 @@ object KotlinJsCompileTests extends TestSuite {
     test("failures") {
       val eval = testEval()
 
-      val compilationUnit = module.foo.millSourcePath / "src" / "foo" / "Hello.kt"
+      val compilationUnit = module.foo.millSourcePath / "src/foo/Hello.kt"
 
       val Right(_) = eval.apply(module.foo.compile)
 

--- a/main/eval/test/src/mill/eval/JavaCompileJarTests.scala
+++ b/main/eval/test/src/mill/eval/JavaCompileJarTests.scala
@@ -28,9 +28,9 @@ object JavaCompileJarTests extends TestSuite {
 
     test("javac") {
       object Build extends TestBaseModule {
-        def sourceRootPath = millSourcePath / "src"
-        def readmePath = millSourcePath / "readme.md"
-        def resourceRootPath = millSourcePath / "resources"
+        def sourceRootPath: os.SubPath = "src"
+        def readmePath: os.SubPath = "readme.md"
+        def resourceRootPath: os.SubPath = "resources"
 
         // sourceRoot -> allSources -> classFiles
         //                                |
@@ -74,7 +74,7 @@ object JavaCompileJarTests extends TestSuite {
       def eval[T](t: Task[T]) = evaluator.apply(t)
       def check(targets: Agg[Task[_]], expected: Agg[Task[_]]) = evaluator.check(targets, expected)
 
-      def append(path: os.Path, txt: String) = os.write.append(path, txt)
+      def append(path: os.SubPath, txt: String) = os.write.append(millSourcePath / path, txt)
 
       check(
         targets = Agg(jar),

--- a/main/init/maven/src/mill/main/maven/Modeler.scala
+++ b/main/init/maven/src/mill/main/maven/Modeler.scala
@@ -64,7 +64,7 @@ object Modeler {
   }
 
   def defaultLocalRepository: LocalRepository =
-    new LocalRepository((os.home / ".m2" / "repository").toIO)
+    new LocalRepository((os.home / ".m2/repository").toIO)
 
   def defaultRemoteRepositories: Seq[RemoteRepository] =
     Seq(

--- a/pythonlib/src/mill/pythonlib/PythonModule.scala
+++ b/pythonlib/src/mill/pythonlib/PythonModule.scala
@@ -43,7 +43,7 @@ trait PythonModule extends PipModule with TaskModule { outer =>
    */
   def pythonExe: T[PathRef] = Task {
     os.call((hostPythonCommand(), "-m", "venv", Task.dest / "venv"))
-    val python = Task.dest / "venv" / "bin" / "python3"
+    val python = Task.dest / "venv/bin/python3"
     os.call((python, "-m", "pip", "install", pipInstallArgs().args), stdout = os.Inherit)
     PathRef(python)
   }
@@ -53,17 +53,17 @@ trait PythonModule extends PipModule with TaskModule { outer =>
    *
    * Python modules will be defined relative to these directories.
    */
-  def sources: T[Seq[PathRef]] = Task.Sources { millSourcePath / "src" }
+  def sources: T[Seq[PathRef]] = Task.Sources { "src" }
 
   /**
    * The folders where the resource files for this module live.
    */
-  def resources: T[Seq[PathRef]] = Task.Sources { millSourcePath / "resources" }
+  def resources: T[Seq[PathRef]] = Task.Sources { "resources" }
 
   /**
    * The python script to run. This file may not exist if this module is only a library.
    */
-  def mainScript: T[PathRef] = Task.Source { millSourcePath / "src" / "main.py" }
+  def mainScript: T[PathRef] = Task.Source { "src/main.py" }
 
   override def pythonToolDeps: T[Seq[String]] = Task {
     super.pythonToolDeps() ++ Seq("mypy==1.13.0", "pex==2.24.1")

--- a/pythonlib/src/mill/pythonlib/RuffModule.scala
+++ b/pythonlib/src/mill/pythonlib/RuffModule.scala
@@ -17,7 +17,7 @@ trait RuffModule extends PythonModule {
    * Configuration file to use when running ruff. If this file does not exist,
    * ruff will use the default settings.
    */
-  def ruffConfigFile: T[PathRef] = Task.Source(millSourcePath / "ruff.toml")
+  def ruffConfigFile: T[PathRef] = Task.Source("ruff.toml")
 
   /**
    * Global command line options to pass to ruff. These are passed in before any

--- a/pythonlib/test/src/mill/pythonlib/HelloWorldTests.scala
+++ b/pythonlib/test/src/mill/pythonlib/HelloWorldTests.scala
@@ -17,7 +17,7 @@ object HelloWorldTests extends TestSuite {
 
     object qux extends PythonModule {
       override def moduleDeps: Seq[PythonModule] = Seq(foo)
-      override def mainScript = Task.Source(millSourcePath / "src" / "qux.py")
+      override def mainScript = Task.Source("src/qux.py")
       object test extends PythonTests with TestModule.Unittest
     }
 

--- a/pythonlib/test/src/mill/pythonlib/RunBackgroundTests.scala
+++ b/pythonlib/test/src/mill/pythonlib/RunBackgroundTests.scala
@@ -9,7 +9,7 @@ object RunBackgroundTests extends TestSuite {
 
   object HelloWorldPython extends TestBaseModule {
     object foo extends PythonModule {
-      override def mainScript = Task.Source(millSourcePath / "src" / "foo.py")
+      override def mainScript = Task.Source("src/foo.py")
     }
     lazy val millDiscover = Discover[this.type]
   }
@@ -34,7 +34,7 @@ object RunBackgroundTests extends TestSuite {
 
       while (lock.probe()) sleepIfTimeAvailable("File never locked by python subprocess")
 
-      os.remove.all(eval.outPath / "foo" / "runBackground.dest")
+      os.remove.all(eval.outPath / "foo/runBackground.dest")
 
       while (!lock.probe()) {
         sleepIfTimeAvailable("File never unlocked after runBackground.dest removed")

--- a/scalalib/src/mill/javalib/android/AndroidAppModule.scala
+++ b/scalalib/src/mill/javalib/android/AndroidAppModule.scala
@@ -99,7 +99,7 @@ trait AndroidAppModule extends JavaModule {
   /**
    * Provides os.Path to an XML file containing configuration and metadata about your android application.
    */
-  def androidManifest: Task[PathRef] = Task.Source(millSourcePath / "src/main/AndroidManifest.xml")
+  def androidManifest: Task[PathRef] = Task.Source("src/main/AndroidManifest.xml")
 
   /**
    * Name of the release keystore file. Default is not set.

--- a/scalalib/src/mill/javalib/android/AndroidSdkModule.scala
+++ b/scalalib/src/mill/javalib/android/AndroidSdkModule.scala
@@ -86,7 +86,7 @@ trait AndroidSdkModule extends Module {
    */
   def lintToolPath: T[PathRef] = Task {
     installAndroidSdkComponents()
-    PathRef(sdkPath().path / "cmdline-tools" / "latest" / "bin" / "lint")
+    PathRef(sdkPath().path / "cmdline-tools/latest/bin/lint")
   }
 
   /**
@@ -290,7 +290,7 @@ trait AndroidSdkModule extends Module {
             case _ => false
           })
           .maxBy(_._2.head.toInt)._1
-        sdkManagerPath = latestCmdlineToolsPath / "bin" / "sdkmanager"
+        sdkManagerPath = latestCmdlineToolsPath / "bin/sdkmanager"
       }
     }
     Some(sdkManagerPath).filter(os.exists)

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -827,20 +827,20 @@ trait JavaModule
   /**
    * The folders where the source files for this module live
    */
-  def sources: T[Seq[PathRef]] = Task.Sources { millSourcePath / "src" }
+  def sources: T[Seq[PathRef]] = Task.Sources { "src" }
 
   /**
    * The folders where the resource files for this module live.
    * If you need resources to be seen by the compiler, use [[compileResources]].
    */
-  def resources: T[Seq[PathRef]] = Task.Sources { millSourcePath / "resources" }
+  def resources: T[Seq[PathRef]] = Task.Sources { "resources" }
 
   /**
    * The folders where the compile time resource files for this module live.
    * If your resources files do not necessarily need to be seen by the compiler,
    * you should use [[resources]] instead.
    */
-  def compileResources: T[Seq[PathRef]] = Task.Sources { millSourcePath / "compile-resources" }
+  def compileResources: T[Seq[PathRef]] = Task.Sources { "compile-resources" }
 
   /**
    * Folders containing source files that are generated rather than

--- a/scalalib/test/src/mill/javalib/palantirformat/PalantirFormatModuleTest.scala
+++ b/scalalib/test/src/mill/javalib/palantirformat/PalantirFormatModuleTest.scala
@@ -12,7 +12,7 @@ object PalantirFormatModuleTest extends TestSuite {
   def tests: Tests = Tests {
 
     val (before, after) = {
-      val root = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "javalib" / "palantirformat"
+      val root = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "javalib/palantirformat"
       (root / "before", root / "after")
     }
 

--- a/scalalib/test/src/mill/javalib/revapi/RevapiModuleTests.scala
+++ b/scalalib/test/src/mill/javalib/revapi/RevapiModuleTests.scala
@@ -13,7 +13,7 @@ object RevapiModuleTests extends TestSuite {
 
   def tests: Tests = Tests {
 
-    val root = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "javalib" / "revapi"
+    val root = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "javalib/revapi"
     val conf = root / "conf"
     val textReport = "report.txt"
 

--- a/scalalib/test/src/mill/scalalib/TestRunnerTestUtils.scala
+++ b/scalalib/test/src/mill/scalalib/TestRunnerTestUtils.scala
@@ -113,7 +113,7 @@ object TestRunnerTestUtils {
       moduleName: String,
       action: String = "test"
   ): JUnitReportMatch = {
-    val reportPath: Path = outPath / moduleName / s"$action.dest/test-report.xml"
+    val reportPath: Path = outPath / moduleName / s"$action.dest" / "test-report.xml"
     val reportXML = XML.loadFile(reportPath.toIO)
     new JUnitReportMatch {
       override def shouldHave(statuses: (Int, Status)*): Unit = {

--- a/scalalib/test/src/mill/scalalib/TestRunnerTestUtils.scala
+++ b/scalalib/test/src/mill/scalalib/TestRunnerTestUtils.scala
@@ -113,7 +113,7 @@ object TestRunnerTestUtils {
       moduleName: String,
       action: String = "test"
   ): JUnitReportMatch = {
-    val reportPath: Path = outPath / moduleName / s"$action.dest" / "test-report.xml"
+    val reportPath: Path = outPath / moduleName / s"$action.dest/test-report.xml"
     val reportXML = XML.loadFile(reportPath.toIO)
     new JUnitReportMatch {
       override def shouldHave(statuses: (Int, Status)*): Unit = {

--- a/testkit/package.mill
+++ b/testkit/package.mill
@@ -8,7 +8,7 @@ object `package` extends RootModule with build.MillPublishScalaModule {
 
   def sources =
     super.sources() ++
-      Seq(PathRef(build.millSourcePath / "mill-build" / "src"))
+      Seq(PathRef(build.millSourcePath / "mill-build/src"))
 
   def forkEnv =
     super.forkEnv() ++ Map("MILL_EXECUTABLE_PATH" -> build.dist.launcher().path.toString())

--- a/testkit/test/resources/example-test-example-project/build.mill
+++ b/testkit/test/resources/example-test-example-project/build.mill
@@ -1,7 +1,7 @@
 package build
 import mill._
 
-def testSource = Task.Source(millSourcePath / "source-file.txt")
+def testSource = Task.Source("source-file.txt")
 def testTask = Task { os.read(testSource().path).toUpperCase() }
 
 /** Usage

--- a/testkit/test/resources/integration-test-example-project/build.mill
+++ b/testkit/test/resources/integration-test-example-project/build.mill
@@ -1,5 +1,5 @@
 package build
 import mill._
 
-def testSource = Task.Source(millSourcePath / "source-file.txt")
+def testSource = Task.Source("source-file.txt")
 def testTask = Task { os.read(testSource().path).toUpperCase() }

--- a/testkit/test/src/mill/testkit/UnitTesterTests.scala
+++ b/testkit/test/src/mill/testkit/UnitTesterTests.scala
@@ -23,7 +23,7 @@ object UnitTesterTests extends TestSuite {
 
     test("sources") {
       object build extends TestBaseModule {
-        def testSource = Task.Source(millSourcePath / "source-file.txt")
+        def testSource = Task.Source("source-file.txt")
         def testTask = Task { os.read(testSource().path).toUpperCase() }
 
         lazy val millDiscover = Discover[this.type]


### PR DESCRIPTION
First step in https://github.com/com-lihaoyi/mill/issues/4447, by providing an alternative to the previous `os.Path` APIs. 

Effectively this allows us to replace

```scala
def mainScript = Task.Source { millSourcePath / "src/foo.py" }
```

with

```scala
def mainScript = Task.Source { "src/foo.py" }
```

Pulls in https://github.com/com-lihaoyi/os-lib/pull/353 from upstream to make constructing `os.SubPath`s more ergonomic by eliding the lead `os.sub /` prefix in the case of literal strings while still maintaining a degree of safety:

* "outer" paths starting with `..`s and absolute paths starting with `/` are rejected at compile time 
* Only literal strings are converted implicitly, anything non-literal needs to be an explicit `os.SubPath`


For now we provide this as an alternative to passing in an absolute `os.Path`, but probably 99% of scenarios should be using this sub-path API rather than absolute paths since (a) it's more concise and (b) your sources should be within your `millSourcePath` anyway. I'm not sure we can get rid of the `os.Path`-taking API entirely, but we can definitely de-prioritize it and call it `SourcesUnsafe` or something so that anyone who needs it can use it but most people won't use it accidentally