### PR TITLE
Add file count to `PalantirFormatModule` output

### DIFF
--- a/example/javalib/linting/3-palantirformat/build.mill
+++ b/example/javalib/linting/3-palantirformat/build.mill
@@ -17,22 +17,22 @@ object `package` extends RootModule with PalantirFormatModule
 /** Usage
 
 > ./mill palantirformat --check    # check should fail initially
-...checking format in java sources ...
+...checking format in 1 java sources ...
 ...src/A.java
 error: ...palantirformat aborted due to format error(s) (or invalid plugin settings/palantirformat options)
 
 > ./mill palantirformat    # format all Java source files
-...formatting java sources ...
+...formatting 1 java sources ...
 
 > ./mill palantirformat --check    # check should succeed now
-...checking format in java sources ...
+...checking format in 1 java sources ...
 */
 // You can also use Palantir Java Format globally on all ``JavaModule``s in your build by running
 // `mill.javalib.palantirformat.PalantirFormatModule/`.
 
 /** Usage
 > ./mill mill.javalib.palantirformat.PalantirFormatModule/ # alternatively, use external module to check/format
-...formatting java sources ...
+...formatting 1 java sources ...
 */
 
 // If entering the long fully-qualified module name

--- a/scalalib/src/mill/javalib/palantirformat/PalantirFormatBaseModule.scala
+++ b/scalalib/src/mill/javalib/palantirformat/PalantirFormatBaseModule.scala
@@ -1,0 +1,50 @@
+package mill.javalib.palantirformat
+
+import mill.api.{Loose, PathRef}
+import mill.scalalib.{CoursierModule, DepSyntax}
+import mill.{Agg, T, Task}
+
+trait PalantirFormatBaseModule extends CoursierModule {
+
+  /**
+   * Classpath for running Palantir Java Format.
+   */
+  def palantirformatClasspath: T[Loose.Agg[PathRef]] = Task {
+    defaultResolver().resolveDeps(
+      Agg(ivy"com.palantir.javaformat:palantir-java-format:${palantirformatVersion()}")
+    )
+  }
+
+  /**
+   * JVM arguments for running Palantir Java Format. Defaults to values prescribed in
+   * "[[https://github.com/palantir/palantir-java-format/issues/548 Broken on Java 16]]".
+   */
+  def palantirformatJvmArgs: T[Seq[String]] = Task {
+    Seq(
+      "--add-exports",
+      "jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+      "--add-exports",
+      "jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+      "--add-exports",
+      "jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+      "--add-exports",
+      "jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+      "--add-exports",
+      "jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
+    )
+  }
+
+  /**
+   * Path to options file for Palantir Java Format CLI. Defaults to `millSourcePath` `/` `palantirformat.options`.
+   */
+  def palantirformatOptions: T[PathRef] = Task.Source(
+    millSourcePath / "palantirformat.options"
+  )
+
+  /**
+   * Palantir Java Format version. Defaults to `2.50.0`.
+   */
+  def palantirformatVersion: T[String] = Task {
+    "2.50.0"
+  }
+}

--- a/scalalib/src/mill/javalib/palantirformat/PalantirFormatModule.scala
+++ b/scalalib/src/mill/javalib/palantirformat/PalantirFormatModule.scala
@@ -7,51 +7,6 @@ import mill.main.Tasks
 import mill.scalalib.{CoursierModule, DepSyntax, JavaModule}
 import mill.util.Jvm
 
-trait PalantirFormatBaseModule extends CoursierModule {
-
-  /**
-   * Classpath for running Palantir Java Format.
-   */
-  def palantirformatClasspath: T[Loose.Agg[PathRef]] = Task {
-    defaultResolver().resolveDeps(
-      Agg(ivy"com.palantir.javaformat:palantir-java-format:${palantirformatVersion()}")
-    )
-  }
-
-  /**
-   * JVM arguments for running Palantir Java Format. Defaults to values prescribed in
-   * "[[https://github.com/palantir/palantir-java-format/issues/548 Broken on Java 16]]".
-   */
-  def palantirformatJvmArgs: T[Seq[String]] = Task {
-    Seq(
-      "--add-exports",
-      "jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
-      "--add-exports",
-      "jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
-      "--add-exports",
-      "jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
-      "--add-exports",
-      "jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
-      "--add-exports",
-      "jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
-    )
-  }
-
-  /**
-   * Path to options file for Palantir Java Format CLI. Defaults to `millSourcePath` `/` `palantirformat.options`.
-   */
-  def palantirformatOptions: T[PathRef] = Task.Source(
-    millSourcePath / "palantirformat.options"
-  )
-
-  /**
-   * Palantir Java Format version. Defaults to `2.50.0`.
-   */
-  def palantirformatVersion: T[String] = Task {
-    "2.50.0"
-  }
-}
-
 /**
  * Formats Java source files using [[https://github.com/palantir/palantir-java-format Palantir Java Format]].
  */
@@ -84,6 +39,7 @@ trait PalantirFormatModule extends JavaModule with PalantirFormatBaseModule {
     )
   }
 }
+
 object PalantirFormatModule extends ExternalModule with PalantirFormatBaseModule with TaskModule {
 
   override def defaultCommandName(): String = "formatAll"

--- a/scalalib/src/mill/javalib/palantirformat/PalantirFormatModule.scala
+++ b/scalalib/src/mill/javalib/palantirformat/PalantirFormatModule.scala
@@ -4,7 +4,7 @@ package javalib.palantirformat
 import mill.api.{Loose, PathRef}
 import mill.define.{Discover, ExternalModule}
 import mill.main.Tasks
-import mill.scalalib.{CoursierModule, DepSyntax, JavaModule}
+import mill.scalalib.JavaModule
 import mill.util.Jvm
 
 /**

--- a/scalalib/src/mill/scalalib/scalafmt/ScalafmtModule.scala
+++ b/scalalib/src/mill/scalalib/scalafmt/ScalafmtModule.scala
@@ -86,8 +86,9 @@ object ScalafmtModule extends ExternalModule with ScalafmtModule with TaskModule
         )
     }
 
-  def checkFormatAll(@arg(positional = true) sources: Tasks[Seq[PathRef]] =
-    Tasks.resolveMainDefault("__.sources")): Command[Unit] =
+  def checkFormatAll(
+      @arg(positional = true) sources: Tasks[Seq[PathRef]] = Tasks.resolveMainDefault("__.sources")
+  ): Command[Unit] =
     Task.Command {
       val files = Task.sequence(sources.value)().flatMap(filesToFormat)
       ScalafmtWorkerModule


### PR DESCRIPTION
Having a quick quantitative feedback what goes on is always nice and helps spotting issues.

For example, I tried to manually format the code base with two different source selectors, from which I assumed they should have the same effect. But they didn't. After this change, the difference would be obvious.

```
> mill mill.javalib.palantirformat.PalantirFormatModule/formatAll --check __:JavaModule.sources

[437] checking format in 109 java sources ...

> mill mill.javalib.palantirformat.PalantirFormatModule/formatAll --check __.sources

[947] checking format in 259 java sources ...
```

Obviously, there are Java sources in non-Java modules.