### PR TITLE
feat: support test case selection in TestNG framework

### DIFF
--- a/contrib/testng/src/mill/testng/ResultEvent.java
+++ b/contrib/testng/src/mill/testng/ResultEvent.java
@@ -27,7 +27,7 @@ public class ResultEvent {
       }
 
       public Selector selector() {
-        return new SuiteSelector();
+        return new TestSelector(testNGResult.getName());
       }
 
       public Status status() {

--- a/contrib/testng/src/mill/testng/TestNGRunner.java
+++ b/contrib/testng/src/mill/testng/TestNGRunner.java
@@ -1,17 +1,17 @@
 package mill.testng;
 
 import com.beust.jcommander.JCommander;
+import java.util.ArrayList;
+import java.util.List;
 import org.testng.CommandLineArgs;
 import sbt.testing.EventHandler;
 import sbt.testing.Logger;
 import sbt.testing.Runner;
+import sbt.testing.Selector;
+import sbt.testing.SuiteSelector;
 import sbt.testing.Task;
 import sbt.testing.TaskDef;
 import sbt.testing.TestSelector;
-import sbt.testing.SuiteSelector;
-import sbt.testing.Selector;
-import java.util.ArrayList;
-import java.util.List;
 
 class TestNGTask implements Task {
 
@@ -60,7 +60,8 @@ public class TestNGRunner implements Runner {
       CommandLineArgs cliArgs = new CommandLineArgs();
       new JCommander(cliArgs).parse(args); // args is an output parameter of the constructor!
       cliArgs.testClass = taskDefs[i].fullyQualifiedName();
-      cliArgs.commandLineMethods = testMethods(taskDefs[i].selectors(), taskDefs[i].fullyQualifiedName());
+      cliArgs.commandLineMethods =
+          testMethods(taskDefs[i].selectors(), taskDefs[i].fullyQualifiedName());
       returnTasks[i] = new TestNGTask(taskDefs[i], testClassLoader, cliArgs);
     }
     return returnTasks;
@@ -69,9 +70,9 @@ public class TestNGRunner implements Runner {
   private List<String> testMethods(Selector[] selectors, String testClass) {
     ArrayList<String> testMethods = new ArrayList<String>();
     for (int i = 0; i < selectors.length; i += 1) {
-      if(selectors[i] instanceof TestSelector) {
+      if (selectors[i] instanceof TestSelector) {
         testMethods.add(testClass + "." + ((TestSelector) selectors[i]).testName());
-      } else if(selectors[i] instanceof SuiteSelector) {
+      } else if (selectors[i] instanceof SuiteSelector) {
         return new ArrayList<String>();
       }
     }

--- a/contrib/testng/src/mill/testng/TestNGRunner.java
+++ b/contrib/testng/src/mill/testng/TestNGRunner.java
@@ -7,6 +7,11 @@ import sbt.testing.Logger;
 import sbt.testing.Runner;
 import sbt.testing.Task;
 import sbt.testing.TaskDef;
+import sbt.testing.TestSelector;
+import sbt.testing.SuiteSelector;
+import sbt.testing.Selector;
+import java.util.ArrayList;
+import java.util.List;
 
 class TestNGTask implements Task {
 
@@ -55,9 +60,22 @@ public class TestNGRunner implements Runner {
       CommandLineArgs cliArgs = new CommandLineArgs();
       new JCommander(cliArgs).parse(args); // args is an output parameter of the constructor!
       cliArgs.testClass = taskDefs[i].fullyQualifiedName();
+      cliArgs.commandLineMethods = testMethods(taskDefs[i].selectors(), taskDefs[i].fullyQualifiedName());
       returnTasks[i] = new TestNGTask(taskDefs[i], testClassLoader, cliArgs);
     }
     return returnTasks;
+  }
+
+  private List<String> testMethods(Selector[] selectors, String testClass) {
+    ArrayList<String> testMethods = new ArrayList<String>();
+    for (int i = 0; i < selectors.length; i += 1) {
+      if(selectors[i] instanceof TestSelector) {
+        testMethods.add(testClass + "." + ((TestSelector) selectors[i]).testName());
+      } else if(selectors[i] instanceof SuiteSelector) {
+        return new ArrayList<String>();
+      }
+    }
+    return testMethods;
   }
 
   public String done() {


### PR DESCRIPTION
needed for: https://github.com/scalameta/metals/pull/7200

This allows to select and run single tests in Metals using TestNGFramework.
![TestNGSingleTest](https://github.com/user-attachments/assets/9038111e-ef84-46cd-9168-9a34a6112d5a)

Previously only whole suite selection was possible.

Tested it manually as visible on the GIF above.