### PR TITLE
Run `-rewrite -source 3.6-migration`, enable Scalafix in tests

### DIFF
--- a/.scalafix-test.conf
+++ b/.scalafix-test.conf
@@ -1,5 +1,4 @@
 rules = [
     RemoveUnused,
     NoAutoTupling
-    # ExplicitResultTypes
 ]

--- a/.scalafix-test.conf
+++ b/.scalafix-test.conf
@@ -1,4 +1,0 @@
-rules = [
-    RemoveUnused,
-    NoAutoTupling
-]

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,5 +1,4 @@
 rules = [
     RemoveUnused,
     NoAutoTupling
-    ExplicitResultTypes
 ]

--- a/bsp/src/mill/bsp/BspWorker.scala
+++ b/bsp/src/mill/bsp/BspWorker.scala
@@ -17,7 +17,7 @@ private trait BspWorker {
 
 private object BspWorker {
 
-  private[this] var worker: Option[BspWorker] = None
+  private var worker: Option[BspWorker] = None
 
   def apply(
       workspace: os.Path,

--- a/bsp/worker/src/mill/bsp/worker/BspTestReporter.scala
+++ b/bsp/worker/src/mill/bsp/worker/BspTestReporter.scala
@@ -65,7 +65,7 @@ private class BspTestReporter(
 
   // Compute the display name of the test / test suite
   // to which the given event relates
-  private[this] def getDisplayName(e: Event): String = {
+  private def getDisplayName(e: Event): String = {
     e.selector() match {
       case s: NestedSuiteSelector => s.suiteId()
       case s: NestedTestSelector => s.suiteId() + "." + s.testName()

--- a/bsp/worker/src/mill/bsp/worker/BspWorkerImpl.scala
+++ b/bsp/worker/src/mill/bsp/worker/BspWorkerImpl.scala
@@ -56,7 +56,7 @@ private class BspWorkerImpl() extends BspWorker {
       }
 
       val bspServerHandle = new BspServerHandle {
-        private[this] var lastResult0: Option[BspServerResult] = None
+        private var lastResult0: Option[BspServerResult] = None
 
         override def runSession(evaluators: Seq[Evaluator]): BspServerResult = {
           lastResult0 = None

--- a/bsp/worker/src/mill/bsp/worker/MillJvmBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillJvmBuildServer.scala
@@ -72,7 +72,7 @@ private trait MillJvmBuildServer extends JvmBuildServer { this: MillBuildServer 
             ev,
             state,
             id,
-            _: TestModule with JavaModule,
+            _: (TestModule & JavaModule),
             (
               _,
               forkArgs,

--- a/bsp/worker/src/mill/bsp/worker/MillScalaBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillScalaBuildServer.scala
@@ -118,7 +118,7 @@ private trait MillScalaBuildServer extends ScalaBuildServer { this: MillBuildSer
       }
     ) {
       case (ev, state, id, m: TestModule, Some((classpath, testFramework, testClasspath))) =>
-        val (frameworkName, classFingerprint): (String, Agg[(Class[_], Fingerprint)]) =
+        val (frameworkName, classFingerprint): (String, Agg[(Class[?], Fingerprint)]) =
           Jvm.withClassLoader(
             classPath = classpath.map(_.path).toVector,
             sharedPrefixes = Seq("sbt.testing.")
@@ -130,7 +130,7 @@ private trait MillScalaBuildServer extends ScalaBuildServer { this: MillBuildSer
               Agg.from(testClasspath.map(_.path))
             )
             (framework.name(), discoveredTests)
-          }
+          }: @unchecked
         val classes = Seq.from(classFingerprint.map(classF => classF._1.getName.stripSuffix("$")))
         new ScalaTestClassesItem(id, classes.asJava).tap { it =>
           it.setFramework(frameworkName)

--- a/bsp/worker/src/mill/bsp/worker/Utils.scala
+++ b/bsp/worker/src/mill/bsp/worker/Utils.scala
@@ -106,9 +106,9 @@ private object Utils {
     else Nil
   }
 
-  private[this] def getStatusCodePerTask(
+  private def getStatusCodePerTask(
       results: Evaluator.Results,
-      task: mill.define.Task[_]
+      task: mill.define.Task[?]
   ): StatusCode = {
     results.results(task).result match {
       case Success(_) => StatusCode.OK

--- a/build.mill
+++ b/build.mill
@@ -484,7 +484,7 @@ trait MillScalaModule extends ScalaModule with MillJavaModule with ScalafixModul
     ) ++ (
       if (ZincWorkerUtil.isScala3(scalaVersion())) Seq(
         // "-Werror",
-        "-Wunused:all",
+        "-Wunused:all"
         // "-no-indent",
         // "-Wvalue-discard",
         // "-Wshadow:all",
@@ -524,7 +524,8 @@ trait MillScalaModule extends ScalaModule with MillJavaModule with ScalafixModul
 
   /** Default tests module. */
   lazy val test: MillScalaTests = new MillScalaTests {}
-  trait MillScalaTests extends ScalaTests with MillJavaModule with MillBaseTestsModule with ScalafixModule{
+  trait MillScalaTests extends ScalaTests with MillJavaModule with MillBaseTestsModule
+      with ScalafixModule {
     def scalafixConfig = T { Some(T.workspace / ".scalafix.conf") }
     def forkArgs = super.forkArgs() ++ outer.testArgs()
     def moduleDeps = outer.testModuleDeps

--- a/build.mill
+++ b/build.mill
@@ -492,7 +492,7 @@ trait MillScalaModule extends ScalaModule with MillJavaModule with ScalafixModul
         // "-Wsafe-init",
         // "-Wnonunit-statement",
         // "-Wimplausible-patterns",
-        "-rewrite", "-source", "3.4-migration"
+//        "-rewrite", "-source", "3.4-migration"
       )
       else Seq(
         "-P:acyclic:force",

--- a/build.mill
+++ b/build.mill
@@ -491,7 +491,7 @@ trait MillScalaModule extends ScalaModule with MillJavaModule with ScalafixModul
         // "-Wsafe-init",
         // "-Wnonunit-statement",
         // "-Wimplausible-patterns",
-//        "-rewrite", "-source", "3.4-migration"
+        // "-rewrite", "-source", "3.6-migration"
       )
       else Seq(
         "-P:acyclic:force",

--- a/build.mill
+++ b/build.mill
@@ -472,9 +472,8 @@ trait MillScalaModule extends ScalaModule with MillJavaModule with ScalafixModul
     else ZincWorkerUtil.scalaBinaryVersion(sv)
   }
 
-  def scalafixConfig = T {
-    if (ZincWorkerUtil.isScala3(scalaVersion())) Some(T.workspace / ".scalafix-3.conf") else None
-  }
+  def scalafixConfig = T { Some(T.workspace / ".scalafix.conf") }
+
   def semanticDbVersion = Deps.semanticDBscala.version
 
   def scaladocOptions = Seq("-Xsource:3")
@@ -526,7 +525,7 @@ trait MillScalaModule extends ScalaModule with MillJavaModule with ScalafixModul
   /** Default tests module. */
   lazy val test: MillScalaTests = new MillScalaTests {}
   trait MillScalaTests extends ScalaTests with MillJavaModule with MillBaseTestsModule with ScalafixModule{
-    def scalafixConfig = Some(Task.workspace / ".scalafix-test.conf")
+    def scalafixConfig = T { Some(T.workspace / ".scalafix.conf") }
     def forkArgs = super.forkArgs() ++ outer.testArgs()
     def moduleDeps = outer.testModuleDeps
     def ivyDeps = super.ivyDeps() ++ outer.testIvyDeps()

--- a/build.mill
+++ b/build.mill
@@ -485,13 +485,14 @@ trait MillScalaModule extends ScalaModule with MillJavaModule with ScalafixModul
     ) ++ (
       if (ZincWorkerUtil.isScala3(scalaVersion())) Seq(
         // "-Werror",
-        "-Wunused:all"
+        "-Wunused:all",
         // "-no-indent",
         // "-Wvalue-discard",
         // "-Wshadow:all",
         // "-Wsafe-init",
         // "-Wnonunit-statement",
         // "-Wimplausible-patterns",
+        "-rewrite", "-source", "3.4-migration"
       )
       else Seq(
         "-P:acyclic:force",

--- a/build.mill
+++ b/build.mill
@@ -525,7 +525,8 @@ trait MillScalaModule extends ScalaModule with MillJavaModule with ScalafixModul
 
   /** Default tests module. */
   lazy val test: MillScalaTests = new MillScalaTests {}
-  trait MillScalaTests extends ScalaTests with MillJavaModule with MillBaseTestsModule {
+  trait MillScalaTests extends ScalaTests with MillJavaModule with MillBaseTestsModule with ScalafixModule{
+    def scalafixConfig = Some(Task.workspace / ".scalafix-test.conf")
     def forkArgs = super.forkArgs() ++ outer.testArgs()
     def moduleDeps = outer.testModuleDeps
     def ivyDeps = super.ivyDeps() ++ outer.testIvyDeps()

--- a/ci/mill-bootstrap.patch
+++ b/ci/mill-bootstrap.patch
@@ -1,5 +1,5 @@
 diff --git a/build.mill b/build.mill
-index 4f66e7cfeb7..1c608ae4d86 100644
+index 70cfce14468..8ea29a961ab 100644
 --- a/build.mill
 +++ b/build.mill
 @@ -1,9 +1,9 @@
@@ -48,7 +48,16 @@ index 4f66e7cfeb7..1c608ae4d86 100644
    def scalaVersion = Deps.scalaVersion
    def scalapVersion: T[String] = Deps.scala2Version
    def scalafixScalaBinaryVersion = T {
-@@ -561,7 +561,8 @@ trait MillBaseTestsModule extends TestModule {
+@@ -525,7 +525,7 @@ trait MillScalaModule extends ScalaModule with MillJavaModule with ScalafixModul
+   /** Default tests module. */
+   lazy val test: MillScalaTests = new MillScalaTests {}
+   trait MillScalaTests extends ScalaTests with MillJavaModule with MillBaseTestsModule
+-      with ScalafixModule {
++      /*with ScalafixModule*/ {
+     def scalafixConfig = T { Some(T.workspace / ".scalafix.conf") }
+     def forkArgs = super.forkArgs() ++ outer.testArgs()
+     def moduleDeps = outer.testModuleDeps
+@@ -565,7 +565,8 @@ trait MillBaseTestsModule extends TestModule {
  trait MillPublishScalaModule extends MillScalaModule with MillPublishJavaModule
  
  /** Publishable module which contains strictly handled API. */
@@ -58,7 +67,7 @@ index 4f66e7cfeb7..1c608ae4d86 100644
    import com.github.lolgab.mill.mima._
    override def mimaBinaryIssueFilters: T[Seq[ProblemFilter]] = Seq(
      // (5x) MIMA doesn't properly ignore things which are nested inside other private things
-@@ -691,7 +692,7 @@ trait MillStableScalaModule extends MillPublishScalaModule with Mima {
+@@ -695,7 +696,7 @@ trait MillStableScalaModule extends MillPublishScalaModule with Mima {
    def skipPreviousVersions: T[Seq[String]] = T {
      T.log.info("Skipping mima for previous versions (!!1000s of errors due to Scala 3)")
      mimaPreviousVersions() // T(Seq.empty[String])
@@ -68,7 +77,7 @@ index 4f66e7cfeb7..1c608ae4d86 100644
  
  object bridge extends Cross[BridgeModule](compilerBridgeScalaVersions)
 diff --git a/dist/package.mill b/dist/package.mill
-index 67d3f94c143..98733778894 100644
+index 5b8d77f5180..72f4963ce5f 100644
 --- a/dist/package.mill
 +++ b/dist/package.mill
 @@ -3,7 +3,7 @@ import mill._, scalalib._, publish._
@@ -111,8 +120,28 @@ index 67d3f94c143..98733778894 100644
      ()
    }
  
+diff --git a/mill-build/build.mill b/mill-build/build.mill
+index 957d929826d..112f1aaccb8 100644
+--- a/mill-build/build.mill
++++ b/mill-build/build.mill
+@@ -4,12 +4,12 @@ import mill.scalalib._
+ 
+ object `package` extends MillBuildRootModule {
+   override def ivyDeps = Agg(
+-    ivy"de.tototec::de.tobiasroeser.mill.vcs.version::0.4.1",
+-    ivy"com.github.lolgab::mill-mima::0.1.1",
++//    ivy"de.tototec::de.tobiasroeser.mill.vcs.version::0.4.1",
++//    ivy"com.github.lolgab::mill-mima::0.1.1",
+     ivy"net.sourceforge.htmlcleaner:htmlcleaner:2.29",
+     // TODO: implement empty version for ivy deps as we do in import parser
+     ivy"com.lihaoyi::mill-contrib-buildinfo:${mill.api.BuildInfo.millVersion}",
+-    ivy"com.goyeau::mill-scalafix::0.5.0",
++//    ivy"com.goyeau::mill-scalafix::0.5.0",
+     ivy"com.lihaoyi::mill-main-graphviz:${mill.api.BuildInfo.millVersion}",
+     // TODO: document, why we have this dependency
+     ivy"org.jsoup:jsoup:1.18.1"
 diff --git a/website/package.mill b/website/package.mill
-index d558389312e..11f8e5c3ce9 100644
+index eb4f1515dee..a49e72e84fe 100644
 --- a/website/package.mill
 +++ b/website/package.mill
 @@ -40,8 +40,8 @@ object `package` extends RootModule {
@@ -164,23 +193,3 @@ index d558389312e..11f8e5c3ce9 100644
        mainArgs = orderedDiagrams.map { case (p, i, src, dest) => s"$src;$dest;svg" }
      )
  
-diff --git a/mill-build/build.mill b/mill-build/build.mill
-index 957d929826d..112f1aaccb8 100644
---- a/mill-build/build.mill
-+++ b/mill-build/build.mill
-@@ -4,12 +4,12 @@ import mill.scalalib._
- 
- object `package` extends MillBuildRootModule {
-   override def ivyDeps = Agg(
--    ivy"de.tototec::de.tobiasroeser.mill.vcs.version::0.4.1",
--    ivy"com.github.lolgab::mill-mima::0.1.1",
-+//    ivy"de.tototec::de.tobiasroeser.mill.vcs.version::0.4.1",
-+//    ivy"com.github.lolgab::mill-mima::0.1.1",
-     ivy"net.sourceforge.htmlcleaner:htmlcleaner:2.29",
-     // TODO: implement empty version for ivy deps as we do in import parser
-     ivy"com.lihaoyi::mill-contrib-buildinfo:${mill.api.BuildInfo.millVersion}",
--    ivy"com.goyeau::mill-scalafix::0.5.0",
-+//    ivy"com.goyeau::mill-scalafix::0.5.0",
-     ivy"com.lihaoyi::mill-main-graphviz:${mill.api.BuildInfo.millVersion}",
-     // TODO: document, why we have this dependency
-     ivy"org.jsoup:jsoup:1.18.1"

--- a/contrib/artifactory/src/mill/contrib/artifactory/ArtifactoryPublishModule.scala
+++ b/contrib/artifactory/src/mill/contrib/artifactory/ArtifactoryPublishModule.scala
@@ -73,7 +73,7 @@ object ArtifactoryPublishModule extends ExternalModule {
       connectTimeout,
       Task.log
     ).publishAll(
-      artifacts: _*
+      artifacts*
     )
   }
 

--- a/contrib/bintray/src/mill/contrib/bintray/BintrayPublishModule.scala
+++ b/contrib/bintray/src/mill/contrib/bintray/BintrayPublishModule.scala
@@ -80,7 +80,7 @@ object BintrayPublishModule extends ExternalModule {
       connectTimeout,
       Task.log
     ).publishAll(
-      Task.sequence(publishArtifacts.value)(): _*
+      Task.sequence(publishArtifacts.value)()*
     )
   }
 

--- a/contrib/buildinfo/test/src/mill/contrib/buildinfo/BuildInfoTests.scala
+++ b/contrib/buildinfo/test/src/mill/contrib/buildinfo/BuildInfoTests.scala
@@ -185,7 +185,7 @@ object BuildInfoTests extends TestSuite {
 
     test("scalajs") - UnitTester(BuildInfoScalaJS, testModuleSourcesPath / "scala-simple").scoped {
       eval =>
-        val runResult = eval.outPath / "hello-mill"
+        eval.outPath / "hello-mill"
         assert(eval.apply(BuildInfoScalaJS.fastLinkJS).isRight)
     }
 

--- a/contrib/buildinfo/test/src/mill/contrib/buildinfo/BuildInfoTests.scala
+++ b/contrib/buildinfo/test/src/mill/contrib/buildinfo/BuildInfoTests.scala
@@ -116,13 +116,13 @@ object BuildInfoTests extends TestSuite {
       EmptyBuildInfo,
       testModuleSourcesPath / "scala"
     ).scoped { eval =>
-      val Right(_) = eval.apply(EmptyBuildInfo.buildInfoSources)
+      val Right(_) = eval.apply(EmptyBuildInfo.buildInfoSources): @unchecked
       assert(!os.exists(buildInfoSourcePath(eval)))
     }
 
     test("fileGeneration") - UnitTester(BuildInfoComment, testModuleSourcesPath / "scala").scoped {
       eval =>
-        val Right(_) = eval.apply(BuildInfoComment.compile)
+        val Right(_) = eval.apply(BuildInfoComment.compile): @unchecked
 
         // Make sure that the buildinfo Scala file buildinfo is created and buildinfo
         // resource file is *not* created when we compile the Scala code
@@ -145,7 +145,7 @@ object BuildInfoTests extends TestSuite {
         }
 
         // But becomes created once we package the jar for running
-        val Right(_) = eval.apply(BuildInfoComment.jar)
+        val Right(_) = eval.apply(BuildInfoComment.jar): @unchecked
 
         val expectedResource = "mill.contrib.buildinfo.BuildInfo for foo."
 
@@ -158,7 +158,7 @@ object BuildInfoTests extends TestSuite {
       BuildInfoSettings,
       testModuleSourcesPath / "scala"
     ).scoped { eval =>
-      val Right(result) = eval.apply(BuildInfoSettings.buildInfoSources)
+      val Right(result) = eval.apply(BuildInfoSettings.buildInfoSources): @unchecked
       val path = result.value.head.path
 
       assert(os.exists(path / "foo/bar.scala"))
@@ -168,14 +168,14 @@ object BuildInfoTests extends TestSuite {
     }
 
     test("compile") - UnitTester(BuildInfoPlain, testModuleSourcesPath / "scala").scoped { eval =>
-      val Right(_) = eval.apply(BuildInfoPlain.compile)
+      val Right(_) = eval.apply(BuildInfoPlain.compile): @unchecked
       assert(true)
     }
 
     test("run") - UnitTester(BuildInfoPlain, testModuleSourcesPath / "scala").scoped { eval =>
       val runResult = eval.outPath / "hello-mill"
       val Right(_) =
-        eval.apply(BuildInfoPlain.run(Task.Anon(Args(runResult.toString))))
+        eval.apply(BuildInfoPlain.run(Task.Anon(Args(runResult.toString)))): @unchecked
 
       assert(
         os.exists(runResult),
@@ -195,7 +195,7 @@ object BuildInfoTests extends TestSuite {
       val runResult = eval.outPath / "hello-mill"
 
       val Right(_) =
-        eval.apply(BuildInfoStatic.run(Task.Anon(Args(runResult.toString))))
+        eval.apply(BuildInfoStatic.run(Task.Anon(Args(runResult.toString)))): @unchecked
 
       assert(os.exists(buildInfoSourcePath(eval)))
       assert(!os.exists(buildInfoResourcePath(eval)))
@@ -206,7 +206,7 @@ object BuildInfoTests extends TestSuite {
     test("java") - UnitTester(BuildInfoJava, testModuleSourcesPath / "java").scoped { eval =>
       val runResult = eval.outPath / "hello-mill"
       val Right(_) =
-        eval.apply(BuildInfoJava.run(Task.Anon(Args(runResult.toString))))
+        eval.apply(BuildInfoJava.run(Task.Anon(Args(runResult.toString)))): @unchecked
 
       assert(
         os.exists(runResult),
@@ -219,7 +219,7 @@ object BuildInfoTests extends TestSuite {
         val runResult = eval.outPath / "hello-mill"
         val generatedSrc = eval.outPath / "buildInfoSources.dest/foo/BuildInfo.java"
         val Right(_) =
-          eval.apply(BuildInfoJavaStatic.run(Task.Anon(Args(runResult.toString))))
+          eval.apply(BuildInfoJavaStatic.run(Task.Anon(Args(runResult.toString)))): @unchecked
 
         assert(
           os.exists(runResult),
@@ -233,7 +233,7 @@ object BuildInfoTests extends TestSuite {
       testModuleSourcesPath / "scala"
     ).scoped { eval =>
       val buildInfoGeneratedSourcesFolder = eval.outPath / "buildInfoSources.dest"
-      val Right(result) = eval.apply(BuildInfoPlain.generatedSources)
+      val Right(result) = eval.apply(BuildInfoPlain.generatedSources): @unchecked
       assert(
         result.value.size == 1,
         os.isDir(result.value.head.path),

--- a/contrib/codeartifact/src/mill/contrib/codeartifact/CodeartifactPublishModule.scala
+++ b/contrib/codeartifact/src/mill/contrib/codeartifact/CodeartifactPublishModule.scala
@@ -53,7 +53,7 @@ object CodeartifactPublishModule extends ExternalModule {
         connectTimeout,
         Task.log
       ).publishAll(
-        artifacts: _*
+        artifacts*
       )
     }
 

--- a/contrib/docker/test/src/mill/contrib/docker/DockerModuleTest.scala
+++ b/contrib/docker/test/src/mill/contrib/docker/DockerModuleTest.scala
@@ -4,7 +4,6 @@ package contrib.docker
 import mill.scalalib.JavaModule
 import mill.api.Result
 import mill.define.Discover
-import mill.util.TestUtil
 import mill.testkit.UnitTester
 import mill.testkit.TestBaseModule
 import os.Path

--- a/contrib/docker/test/src/mill/contrib/docker/DockerModuleTest.scala
+++ b/contrib/docker/test/src/mill/contrib/docker/DockerModuleTest.scala
@@ -87,12 +87,12 @@ object DockerModuleTest extends TestSuite {
 
     test("docker build") {
       test("default options") - workspaceTest(Docker) { eval =>
-        val Right(result) = eval(Docker.dockerDefault.build)
+        val Right(result) = eval(Docker.dockerDefault.build): @unchecked
         assert(result.value == List(testArtifactName))
       }
 
       test("all options") - workspaceTest(Docker) { eval =>
-        val Right(result) = eval(Docker.dockerAll.build)
+        val Right(result) = eval(Docker.dockerAll.build): @unchecked
         assert(result.value == List(testArtifactName))
       }
 
@@ -100,7 +100,7 @@ object DockerModuleTest extends TestSuite {
         // since stdout and stderr are inherited we can only test
         // that docker fails with wrong DOCKER_HOST
         val Left(Result.Exception(error: os.SubprocessException, _)) =
-          eval(Docker.dockerEnv.build)
+          eval(Docker.dockerEnv.build): @unchecked
         val message = error.getMessage
         assert(message == "Result of docker…: 1\n")
       }
@@ -108,7 +108,7 @@ object DockerModuleTest extends TestSuite {
 
     test("dockerfile contents") {
       test("default options") - UnitTester(Docker, null).scoped { eval =>
-        val Right(result) = eval(Docker.dockerDefault.dockerfile)
+        val Right(result) = eval(Docker.dockerDefault.dockerfile): @unchecked
         val expected = multilineRegex.replaceAllIn(
           """
             |FROM gcr.io/distroless/java:latest
@@ -124,7 +124,7 @@ object DockerModuleTest extends TestSuite {
       }
 
       test("all options") - UnitTester(Docker, null).scoped { eval =>
-        val Right(result) = eval(Docker.dockerAll.dockerfile)
+        val Right(result) = eval(Docker.dockerAll.dockerfile): @unchecked
         val expected = multilineRegex.replaceAllIn(
           """
             |FROM docker.io/openjdk:11
@@ -149,7 +149,7 @@ object DockerModuleTest extends TestSuite {
       }
 
       test("extra jvm options") - UnitTester(Docker, null).scoped { eval =>
-        val Right(result) = eval(Docker.dockerJvmOptions.dockerfile)
+        val Right(result) = eval(Docker.dockerJvmOptions.dockerfile): @unchecked
         val expected = multilineRegex.replaceAllIn(
           """
             |FROM gcr.io/distroless/java:latest

--- a/contrib/flyway/src/mill/contrib/flyway/ConsoleLog.scala
+++ b/contrib/flyway/src/mill/contrib/flyway/ConsoleLog.scala
@@ -56,5 +56,5 @@ class ConsoleLog(val level: ConsoleLog.Level.Level) extends Log {
  * Log Creator for the Command-Line console.
  */
 class ConsoleLogCreator(val level: ConsoleLog.Level.Level) extends LogCreator {
-  override def createLogger(clazz: Class[_]): Log = new ConsoleLog(level)
+  override def createLogger(clazz: Class[?]): Log = new ConsoleLog(level)
 }

--- a/contrib/flyway/src/mill/contrib/flyway/FlywayModule.scala
+++ b/contrib/flyway/src/mill/contrib/flyway/FlywayModule.scala
@@ -48,7 +48,7 @@ trait FlywayModule extends JavaModule {
 
     Flyway
       .configure(jdbcClassloader)
-      .locations(flywayFileLocations().map("filesystem:" + _.path): _*)
+      .locations(flywayFileLocations().map("filesystem:" + _.path)*)
       .configuration(configProps.asJava)
       .load
   }

--- a/contrib/flyway/test/src/mill/contrib/flyway/BuildTest.scala
+++ b/contrib/flyway/test/src/mill/contrib/flyway/BuildTest.scala
@@ -26,17 +26,17 @@ object BuildTest extends TestSuite {
 
   def tests = Tests {
     test("clean") - UnitTester(Build, null).scoped { eval =>
-      val Right(result) = eval(Build.build.flywayClean())
+      val Right(result) = eval(Build.build.flywayClean()): @unchecked
       assert(result.evalCount > 0)
     }
 
     test("migrate") - UnitTester(Build, null).scoped { eval =>
-      val Right(result) = eval(Build.build.flywayMigrate())
+      val Right(result) = eval(Build.build.flywayMigrate()): @unchecked
       assert(
         result.evalCount > 0,
         result.value.migrationsExecuted == 1
       )
-      val Right(resultAgain) = eval(Build.build.flywayMigrate())
+      val Right(resultAgain) = eval(Build.build.flywayMigrate()): @unchecked
       assert(
         resultAgain.evalCount > 0,
         resultAgain.value.migrationsExecuted == 0
@@ -44,7 +44,7 @@ object BuildTest extends TestSuite {
     }
 
     test("info") - UnitTester(Build, null).scoped { eval =>
-      val Right(result) = eval(Build.build.flywayInfo())
+      val Right(result) = eval(Build.build.flywayInfo()): @unchecked
       assert(result.evalCount > 0)
     }
   }

--- a/contrib/gitlab/src/mill/contrib/gitlab/GitlabPublishModule.scala
+++ b/contrib/gitlab/src/mill/contrib/gitlab/GitlabPublishModule.scala
@@ -72,7 +72,7 @@ object GitlabPublishModule extends ExternalModule {
       repo,
       Task.log
     ).publishAll(
-      artifacts: _*
+      artifacts*
     )
   }
 

--- a/contrib/gitlab/test/src/mill/contrib/gitlab/GitlabModuleTests.scala
+++ b/contrib/gitlab/test/src/mill/contrib/gitlab/GitlabModuleTests.scala
@@ -1,12 +1,11 @@
 package mill.contrib.gitlab
 
-import mill.{T, Task}
+import mill.T
 import mill.api.Result.Failure
 import mill.define.Discover
 import mill.scalalib.publish.PomSettings
 import mill.testkit.UnitTester
 import mill.testkit.TestBaseModule
-import utest.framework.TestPath
 import utest.{TestSuite, Tests, assertMatch, test}
 import mill.main.TokenReaders._
 object GitlabModuleTests extends TestSuite {

--- a/contrib/jmh/src/mill/contrib/jmh/JmhModule.scala
+++ b/contrib/jmh/src/mill/contrib/jmh/JmhModule.scala
@@ -51,7 +51,7 @@ trait JmhModule extends JavaModule {
       ()
     }
 
-  def listJmhBenchmarks(args: String*) = runJmh(("-l" +: args): _*)
+  def listJmhBenchmarks(args: String*) = runJmh(("-l" +: args)*)
 
   def compileGeneratedSources =
     Task {

--- a/contrib/jmh/test/src/mill/contrib/jmh/JmhModuleTest.scala
+++ b/contrib/jmh/test/src/mill/contrib/jmh/JmhModuleTest.scala
@@ -26,7 +26,7 @@ object JmhModuleTest extends TestSuite {
       test("listJmhBenchmarks") - UnitTester(jmh, testModuleSourcesPath).scoped { eval =>
         val paths = EvaluatorPaths.resolveDestPaths(eval.outPath, jmh.listJmhBenchmarks())
         val outFile = paths.dest / "benchmarks.out"
-        val Right(result) = eval(jmh.listJmhBenchmarks("-o", outFile.toString))
+        val Right(result) = eval(jmh.listJmhBenchmarks("-o", outFile.toString)): @unchecked
         val expected =
           """Benchmarks:
             |mill.contrib.jmh.Bench2.log

--- a/contrib/jmh/test/src/mill/contrib/jmh/JmhModuleTest.scala
+++ b/contrib/jmh/test/src/mill/contrib/jmh/JmhModuleTest.scala
@@ -8,7 +8,6 @@ import mill.testkit.UnitTester
 import mill.testkit.TestBaseModule
 import os.Path
 import utest.*
-import utest.framework.TestPath
 
 object JmhModuleTest extends TestSuite {
 

--- a/contrib/playlib/test/src/mill/playlib/PlayModuleTests.scala
+++ b/contrib/playlib/test/src/mill/playlib/PlayModuleTests.scala
@@ -27,15 +27,15 @@ object PlayModuleTests extends TestSuite with PlayTestSuite {
       test("fromBuild") {
         matrix.foreach { case (scalaVersion, playVersion) =>
           UnitTester(playmulti, resourcePath).scoped { eval =>
-            val Right(conf) = eval.apply(playmulti.core(scalaVersion, playVersion).conf)
-            val Right(app) = eval.apply(playmulti.core(scalaVersion, playVersion).app)
-            val Right(sources) = eval.apply(playmulti.core(scalaVersion, playVersion).sources)
+            val Right(conf) = eval.apply(playmulti.core(scalaVersion, playVersion).conf): @unchecked
+            val Right(app) = eval.apply(playmulti.core(scalaVersion, playVersion).app): @unchecked
+            val Right(sources) = eval.apply(playmulti.core(scalaVersion, playVersion).sources): @unchecked
             val Right(resources) =
-              eval.apply(playmulti.core(scalaVersion, playVersion).resources)
+              eval.apply(playmulti.core(scalaVersion, playVersion).resources): @unchecked
             val Right(testSources) =
-              eval.apply(playmulti.core(scalaVersion, playVersion).test.sources)
+              eval.apply(playmulti.core(scalaVersion, playVersion).test.sources): @unchecked
             val Right(testResources) =
-              eval.apply(playmulti.core(scalaVersion, playVersion).test.resources)
+              eval.apply(playmulti.core(scalaVersion, playVersion).test.resources): @unchecked
             assert(
               conf.value.map(_.path.relativeTo(playmulti.millSourcePath).toString()) == Seq(
                 "core/conf"
@@ -65,7 +65,7 @@ object PlayModuleTests extends TestSuite with PlayTestSuite {
         matrix.foreach { case (scalaVersion, playVersion) =>
           UnitTester(playmulti, resourcePath).scoped { eval =>
             val Right(result) =
-              eval.apply(playmulti.core(scalaVersion, playVersion).ivyDeps)
+              eval.apply(playmulti.core(scalaVersion, playVersion).ivyDeps): @unchecked
             val expectedModules = Seq[String](
               "play",
               "play-guice",
@@ -84,7 +84,7 @@ object PlayModuleTests extends TestSuite with PlayTestSuite {
       test("resolvedRunIvyDeps") {
         matrix.foreach { case (scalaVersion, playVersion) =>
           UnitTester(playmulti, resourcePath).scoped { eval =>
-            val Right(_) = eval.apply(playmulti.core(scalaVersion, playVersion).resolvedRunIvyDeps)
+            val Right(_) = eval.apply(playmulti.core(scalaVersion, playVersion).resolvedRunIvyDeps): @unchecked
           }
         }
       }
@@ -94,7 +94,7 @@ object PlayModuleTests extends TestSuite with PlayTestSuite {
         skipUnsupportedVersions(playVersion) {
           UnitTester(playmulti, resourcePath).scoped { eval =>
             val eitherResult = eval.apply(playmulti.core(scalaVersion, playVersion).compile)
-            val Right(result) = eitherResult
+            val Right(result) = eitherResult: @unchecked
             val outputClassFiles =
               os.walk(result.value.classes.path).filter(f => os.isFile(f) && f.ext == "class")
 
@@ -128,7 +128,7 @@ object PlayModuleTests extends TestSuite with PlayTestSuite {
 
             // don't recompile if nothing changed
             val Right(result2) =
-              eval.apply(playmulti.core(scalaVersion, playVersion).compile)
+              eval.apply(playmulti.core(scalaVersion, playVersion).compile): @unchecked
             assert(result2.evalCount == 0)
           }
         }

--- a/contrib/playlib/test/src/mill/playlib/PlayModuleTests.scala
+++ b/contrib/playlib/test/src/mill/playlib/PlayModuleTests.scala
@@ -29,7 +29,8 @@ object PlayModuleTests extends TestSuite with PlayTestSuite {
           UnitTester(playmulti, resourcePath).scoped { eval =>
             val Right(conf) = eval.apply(playmulti.core(scalaVersion, playVersion).conf): @unchecked
             val Right(app) = eval.apply(playmulti.core(scalaVersion, playVersion).app): @unchecked
-            val Right(sources) = eval.apply(playmulti.core(scalaVersion, playVersion).sources): @unchecked
+            val Right(sources) =
+              eval.apply(playmulti.core(scalaVersion, playVersion).sources): @unchecked
             val Right(resources) =
               eval.apply(playmulti.core(scalaVersion, playVersion).resources): @unchecked
             val Right(testSources) =
@@ -84,7 +85,8 @@ object PlayModuleTests extends TestSuite with PlayTestSuite {
       test("resolvedRunIvyDeps") {
         matrix.foreach { case (scalaVersion, playVersion) =>
           UnitTester(playmulti, resourcePath).scoped { eval =>
-            val Right(_) = eval.apply(playmulti.core(scalaVersion, playVersion).resolvedRunIvyDeps): @unchecked
+            val Right(_) =
+              eval.apply(playmulti.core(scalaVersion, playVersion).resolvedRunIvyDeps): @unchecked
           }
         }
       }

--- a/contrib/playlib/test/src/mill/playlib/PlaySingleApiModuleTests.scala
+++ b/contrib/playlib/test/src/mill/playlib/PlaySingleApiModuleTests.scala
@@ -21,7 +21,7 @@ object PlaySingleApiModuleTests extends TestSuite with PlayTestSuite {
   def tests: Tests = Tests {
     test("playVersion") {
       test("fromBuild") - UnitTester(playsingleapi, resourcePath).scoped { eval =>
-        val Right(result) = eval.apply(playsingleapi.playVersion)
+        val Right(result) = eval.apply(playsingleapi.playVersion): @unchecked
         assert(
           result.value == testPlay28,
           result.evalCount > 0
@@ -30,12 +30,12 @@ object PlaySingleApiModuleTests extends TestSuite with PlayTestSuite {
     }
     test("layout") {
       test("fromBuild") - UnitTester(playsingleapi, resourcePath).scoped { eval =>
-        val Right(conf) = eval.apply(playsingleapi.conf)
-        val Right(app) = eval.apply(playsingleapi.app)
-        val Right(sources) = eval.apply(playsingleapi.sources)
-        val Right(resources) = eval.apply(playsingleapi.resources)
-        val Right(testSources) = eval.apply(playsingleapi.test.sources)
-        val Right(testResources) = eval.apply(playsingleapi.test.resources)
+        val Right(conf) = eval.apply(playsingleapi.conf): @unchecked
+        val Right(app) = eval.apply(playsingleapi.app): @unchecked
+        val Right(sources) = eval.apply(playsingleapi.sources): @unchecked
+        val Right(resources) = eval.apply(playsingleapi.resources): @unchecked
+        val Right(testSources) = eval.apply(playsingleapi.test.sources): @unchecked
+        val Right(testResources) = eval.apply(playsingleapi.test.resources): @unchecked
         assert(
           conf.value.map(_.path.relativeTo(playsingleapi.millSourcePath).toString()) == Seq(
             "conf"
@@ -58,7 +58,7 @@ object PlaySingleApiModuleTests extends TestSuite with PlayTestSuite {
     }
     test("compile") - UnitTester(playsingleapi, resourcePath).scoped { eval =>
       val eitherResult = eval.apply(playsingleapi.compile)
-      val Right(result) = eitherResult
+      val Right(result) = eitherResult: @unchecked
       val outputFiles = os.walk(result.value.classes.path).filter(os.isFile)
       val expectedClassfiles = Seq[os.RelPath](
         os.RelPath("controllers/HomeController.class"),
@@ -83,7 +83,7 @@ object PlaySingleApiModuleTests extends TestSuite with PlayTestSuite {
         result.evalCount > 0
       )
 
-      val Right(result2) = eval.apply(playsingleapi.compile)
+      val Right(result2) = eval.apply(playsingleapi.compile): @unchecked
 
       assert(result2.evalCount == 0)
     }

--- a/contrib/playlib/test/src/mill/playlib/PlaySingleApiModuleTests.scala
+++ b/contrib/playlib/test/src/mill/playlib/PlaySingleApiModuleTests.scala
@@ -1,6 +1,6 @@
 package mill.playlib
 
-import mill.{T, Task}
+import mill.Task
 import mill.testkit.{TestBaseModule, UnitTester}
 import utest.{TestSuite, Tests, assert, _}
 import mill.define.Discover

--- a/contrib/playlib/test/src/mill/playlib/PlaySingleModuleTests.scala
+++ b/contrib/playlib/test/src/mill/playlib/PlaySingleModuleTests.scala
@@ -1,7 +1,7 @@
 package mill.playlib
 
 import mill.define.Discover
-import mill.{T, Task}
+import mill.Task
 import mill.testkit.{TestBaseModule, UnitTester}
 import utest.{TestSuite, Tests, assert, _}
 import mill.main.TokenReaders._

--- a/contrib/playlib/test/src/mill/playlib/PlaySingleModuleTests.scala
+++ b/contrib/playlib/test/src/mill/playlib/PlaySingleModuleTests.scala
@@ -21,12 +21,12 @@ object PlaySingleModuleTests extends TestSuite with PlayTestSuite {
   def tests: Tests = Tests {
     test("layout") {
       test("fromBuild") - UnitTester(playsingle, resourcePath).scoped { eval =>
-        val Right(conf) = eval.apply(playsingle.conf)
-        val Right(app) = eval.apply(playsingle.app)
-        val Right(sources) = eval.apply(playsingle.sources)
-        val Right(resources) = eval.apply(playsingle.resources)
-        val Right(testSources) = eval.apply(playsingle.test.sources)
-        val Right(testResources) = eval.apply(playsingle.test.resources)
+        val Right(conf) = eval.apply(playsingle.conf): @unchecked
+        val Right(app) = eval.apply(playsingle.app): @unchecked
+        val Right(sources) = eval.apply(playsingle.sources): @unchecked
+        val Right(resources) = eval.apply(playsingle.resources): @unchecked
+        val Right(testSources) = eval.apply(playsingle.test.sources): @unchecked
+        val Right(testResources) = eval.apply(playsingle.test.resources): @unchecked
         assert(
           conf.value.map(_.path.relativeTo(playsingle.millSourcePath).toString()) == Seq("conf"),
           app.value.map(_.path.relativeTo(playsingle.millSourcePath).toString()) == Seq("app"),
@@ -45,7 +45,7 @@ object PlaySingleModuleTests extends TestSuite with PlayTestSuite {
     }
     test("compile") - UnitTester(playsingle, resourcePath).scoped { eval =>
       val eitherResult = eval.apply(playsingle.compile)
-      val Right(result) = eitherResult
+      val Right(result) = eitherResult: @unchecked
       val outputFiles = os.walk(result.value.classes.path).filter(os.isFile)
       val expectedClassfiles = Seq[os.RelPath](
         os.RelPath("controllers/HomeController.class"),
@@ -75,7 +75,7 @@ object PlaySingleModuleTests extends TestSuite with PlayTestSuite {
       )
 
       // don't recompile if nothing changed
-      val Right(result2) = eval.apply(playsingle.compile)
+      val Right(result2) = eval.apply(playsingle.compile): @unchecked
       // assert(unchangedEvalCount == 0)
     }
   }

--- a/contrib/playlib/test/src/mill/playlib/RouterModuleTests.scala
+++ b/contrib/playlib/test/src/mill/playlib/RouterModuleTests.scala
@@ -34,7 +34,7 @@ object RouterModuleTests extends TestSuite with PlayTestSuite {
         skipUnsupportedVersions(playVersion) {
           UnitTester(HelloWorld, resourcePath).scoped { eval =>
             val eitherResult = eval.apply(HelloWorld.core(scalaVersion, playVersion).compileRouter)
-            val Right(result) = eitherResult
+            val Right(result) = eitherResult: @unchecked
             val outputFiles = os.walk(result.value.classes.path).filter(os.isFile)
             val expectedClassfiles = Seq[os.RelPath](
               os.RelPath("controllers/ReverseRoutes.scala"),
@@ -57,7 +57,7 @@ object RouterModuleTests extends TestSuite with PlayTestSuite {
 
             // don't recompile if nothing changed
             val Right(result2) =
-              eval.apply(HelloWorld.core(scalaVersion, playVersion).compileRouter)
+              eval.apply(HelloWorld.core(scalaVersion, playVersion).compileRouter): @unchecked
 
             assert(result2.evalCount == 0)
           }
@@ -70,7 +70,7 @@ object RouterModuleTests extends TestSuite with PlayTestSuite {
           UnitTester(HelloWorld, invalidResourcePath).scoped { eval =>
             val project = HelloWorld.core(scalaVersion, playVersion)
             val eitherResult = eval.apply(project.compileRouter)
-            val Left(Failure(message, x)) = eitherResult
+            val Left(Failure(message, x)) = eitherResult: @unchecked
             val playExpectedMessage =
               if !playVersion.startsWith("2.7.") && !playVersion.startsWith("2.8.") then {
                 "HTTP Verb (GET, POST, ...), include (->), comment (#), or modifier line (+) expected"
@@ -97,7 +97,7 @@ object RouterModuleTests extends TestSuite with PlayTestSuite {
         skipUnsupportedVersions(playVersion) {
           UnitTester(HelloWorld, invalidSubResourcePath).scoped { eval =>
             val eitherResult = eval.apply(HelloWorld.core(scalaVersion, playVersion).compileRouter)
-            val Left(Failure(message, x)) = eitherResult
+            val Left(Failure(message, x)) = eitherResult: @unchecked
             val playExpectedMessage =
               if !playVersion.startsWith("2.7.") && !playVersion.startsWith("2.8.") then {
                 "HTTP Verb (GET, POST, ...), include (->), comment (#), or modifier line (+) expected"

--- a/contrib/proguard/test/src/mill/contrib/proguard/ProguardTests.scala
+++ b/contrib/proguard/test/src/mill/contrib/proguard/ProguardTests.scala
@@ -31,7 +31,7 @@ object ProguardTests extends TestSuite {
     test("Proguard module") {
       test("should download proguard jars") - UnitTester(proguard, testModuleSourcesPath).scoped {
         eval =>
-          val Right(result) = eval.apply(proguard.proguardClasspath)
+          val Right(result) = eval.apply(proguard.proguardClasspath): @unchecked
           assert(
             result.value.iterator.toSeq.nonEmpty,
             result.value.iterator.toSeq.head.path.toString().contains("proguard-base")

--- a/contrib/proguard/test/src/mill/contrib/proguard/ProguardTests.scala
+++ b/contrib/proguard/test/src/mill/contrib/proguard/ProguardTests.scala
@@ -8,7 +8,6 @@ import mill.testkit.UnitTester
 import mill.testkit.TestBaseModule
 import os.Path
 import utest.*
-import utest.framework.TestPath
 
 object ProguardTests extends TestSuite {
 

--- a/contrib/scalapblib/test/src/mill/contrib/scalapblib/TutorialTests.scala
+++ b/contrib/scalapblib/test/src/mill/contrib/scalapblib/TutorialTests.scala
@@ -5,7 +5,6 @@ import mill.api.PathRef
 import mill.define.Discover
 import mill.testkit.UnitTester
 import mill.testkit.TestBaseModule
-import utest.framework.TestPath
 import utest.{TestSuite, Tests, assert, *}
 
 object TutorialTests extends TestSuite {

--- a/contrib/scalapblib/test/src/mill/contrib/scalapblib/TutorialTests.scala
+++ b/contrib/scalapblib/test/src/mill/contrib/scalapblib/TutorialTests.scala
@@ -87,7 +87,7 @@ object TutorialTests extends TestSuite {
     test("scalapbVersion") {
 
       test("fromBuild") - UnitTester(Tutorial, resourcePath).scoped { eval =>
-        val Right(result) = eval.apply(Tutorial.core.scalaPBVersion)
+        val Right(result) = eval.apply(Tutorial.core.scalaPBVersion): @unchecked
 
         assert(
           result.value == testScalaPbVersion,
@@ -99,7 +99,7 @@ object TutorialTests extends TestSuite {
     test("compileScalaPB") {
       test("calledDirectly") - UnitTester(Tutorial, resourcePath).scoped { eval =>
         if (!mill.main.client.Util.isWindows) {
-          val Right(result) = eval.apply(Tutorial.core.compileScalaPB)
+          val Right(result) = eval.apply(Tutorial.core.compileScalaPB): @unchecked
 
           val outPath = protobufOutPath(eval)
 
@@ -116,7 +116,7 @@ object TutorialTests extends TestSuite {
           )
 
           // don't recompile if nothing changed
-          val Right(result2) = eval.apply(Tutorial.core.compileScalaPB)
+          val Right(result2) = eval.apply(Tutorial.core.compileScalaPB): @unchecked
 
           assert(result2.evalCount == 0)
         }
@@ -127,7 +127,7 @@ object TutorialTests extends TestSuite {
         resourcePath
       ).scoped { eval =>
         if (!mill.main.client.Util.isWindows) {
-          val Right(result) = eval.apply(TutorialWithSpecificSources.core.compileScalaPB)
+          val Right(result) = eval.apply(TutorialWithSpecificSources.core.compileScalaPB): @unchecked
 
           val outPath = protobufOutPath(eval)
 
@@ -149,7 +149,7 @@ object TutorialTests extends TestSuite {
           )
 
           // don't recompile if nothing changed
-          val Right(result2) = eval.apply(Tutorial.core.compileScalaPB)
+          val Right(result2) = eval.apply(Tutorial.core.compileScalaPB): @unchecked
 
           assert(result2.evalCount == 0)
         }

--- a/contrib/scalapblib/test/src/mill/contrib/scalapblib/TutorialTests.scala
+++ b/contrib/scalapblib/test/src/mill/contrib/scalapblib/TutorialTests.scala
@@ -127,7 +127,8 @@ object TutorialTests extends TestSuite {
         resourcePath
       ).scoped { eval =>
         if (!mill.main.client.Util.isWindows) {
-          val Right(result) = eval.apply(TutorialWithSpecificSources.core.compileScalaPB): @unchecked
+          val Right(result) =
+            eval.apply(TutorialWithSpecificSources.core.compileScalaPB): @unchecked
 
           val outPath = protobufOutPath(eval)
 

--- a/contrib/scoverage/test/src/mill/contrib/scoverage/HelloWorldTests.scala
+++ b/contrib/scoverage/test/src/mill/contrib/scoverage/HelloWorldTests.scala
@@ -279,7 +279,8 @@ trait FailedWorldTests extends HelloWorldTests {
       val mod = HelloWorld
       test("shouldFail") {
         test("scoverageToolsCp") - UnitTester(mod, resourcePath).scoped { eval =>
-          val Left(Result.Failure(msg, _)) = eval.apply(mod.core.scoverageToolsClasspath): @unchecked
+          val Left(Result.Failure(msg, _)) =
+            eval.apply(mod.core.scoverageToolsClasspath): @unchecked
           assert(msg == errorMsg)
         }
         test("other") - UnitTester(mod, resourcePath).scoped { eval =>

--- a/contrib/scoverage/test/src/mill/contrib/scoverage/HelloWorldTests.scala
+++ b/contrib/scoverage/test/src/mill/contrib/scoverage/HelloWorldTests.scala
@@ -8,7 +8,6 @@ import mill.scalalib.{DepSyntax, SbtModule, ScalaModule, TestModule}
 import mill.testkit.UnitTester
 import mill.testkit.TestBaseModule
 import utest.*
-import utest.framework.TestPath
 
 trait HelloWorldTests extends utest.TestSuite {
   def threadCount: Option[Int] = Some(1)

--- a/contrib/scoverage/test/src/mill/contrib/scoverage/HelloWorldTests.scala
+++ b/contrib/scoverage/test/src/mill/contrib/scoverage/HelloWorldTests.scala
@@ -70,7 +70,7 @@ trait HelloWorldTests extends utest.TestSuite {
     test("HelloWorld") {
       test("core") {
         test("scoverageVersion") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
-          val Right(result) = eval.apply(HelloWorld.core.scoverageVersion)
+          val Right(result) = eval.apply(HelloWorld.core.scoverageVersion): @unchecked
 
           assert(
             result.value == testScoverageVersion,
@@ -80,7 +80,7 @@ trait HelloWorldTests extends utest.TestSuite {
         test("scoverage") {
           test("unmanagedClasspath") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
             val Right(result) =
-              eval.apply(HelloWorld.core.scoverage.unmanagedClasspath)
+              eval.apply(HelloWorld.core.scoverage.unmanagedClasspath): @unchecked
 
             assert(
               result.value.map(_.toString).iterator.exists(_.contains("unmanaged.xml")),
@@ -89,7 +89,7 @@ trait HelloWorldTests extends utest.TestSuite {
           }
           test("ivyDeps") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
             val Right(result) =
-              eval.apply(HelloWorld.core.scoverage.ivyDeps)
+              eval.apply(HelloWorld.core.scoverage.ivyDeps): @unchecked
 
             val expected = if (isScala3) Agg.empty
             else Agg(
@@ -103,7 +103,7 @@ trait HelloWorldTests extends utest.TestSuite {
           }
           test("scalacPluginIvyDeps") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
             val Right(result) =
-              eval.apply(HelloWorld.core.scoverage.scalacPluginIvyDeps)
+              eval.apply(HelloWorld.core.scoverage.scalacPluginIvyDeps): @unchecked
 
             val expected = (isScov3, isScala3) match {
               case (true, true) => Agg.empty
@@ -125,7 +125,7 @@ trait HelloWorldTests extends utest.TestSuite {
             )
           }
           test("data") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
-            val Right(result) = eval.apply(HelloWorld.core.scoverage.data)
+            val Right(result) = eval.apply(HelloWorld.core.scoverage.data): @unchecked
 
             val resultPath = result.value.path.toIO.getPath.replace("""\""", "/")
             val expectedEnd = "/out/core/scoverage/data.dest"
@@ -136,7 +136,7 @@ trait HelloWorldTests extends utest.TestSuite {
             )
           }
           test("htmlReport") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
-            val Right(_) = eval.apply(HelloWorld.core.test.compile)
+            val Right(_) = eval.apply(HelloWorld.core.test.compile): @unchecked
             val res = eval.apply(HelloWorld.core.scoverage.htmlReport())
             if (
               res.isLeft && testScalaVersion.startsWith("3.2") && testScoverageVersion.startsWith(
@@ -146,13 +146,13 @@ trait HelloWorldTests extends utest.TestSuite {
               s"""Disabled for Scoverage ${testScoverageVersion} on Scala ${testScalaVersion}, as it fails with "No source root found" message"""
             } else {
               assert(res.isRight)
-              val Right(result) = res
+              val Right(result) = res: @unchecked
               assert(result.evalCount > 0)
               ""
             }
           }
           test("xmlReport") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
-            val Right(_) = eval.apply(HelloWorld.core.test.compile)
+            val Right(_) = eval.apply(HelloWorld.core.test.compile): @unchecked
             val res = eval.apply(HelloWorld.core.scoverage.xmlReport())
             if (
               res.isLeft && testScalaVersion.startsWith("3.2") && testScoverageVersion.startsWith(
@@ -162,13 +162,13 @@ trait HelloWorldTests extends utest.TestSuite {
               s"""Disabled for Scoverage ${testScoverageVersion} on Scala ${testScalaVersion}, as it fails with "No source root found" message"""
             } else {
               assert(res.isRight)
-              val Right(result) = res
+              val Right(result) = res: @unchecked
               assert(result.evalCount > 0)
               ""
             }
           }
           test("xmlCoberturaReport") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
-            val Right(_) = eval.apply(HelloWorld.core.test.compile)
+            val Right(_) = eval.apply(HelloWorld.core.test.compile): @unchecked
             val res = eval.apply(HelloWorld.core.scoverage.xmlCoberturaReport())
             if (
               res.isLeft && testScalaVersion.startsWith("3.2") && testScoverageVersion.startsWith(
@@ -178,21 +178,21 @@ trait HelloWorldTests extends utest.TestSuite {
               s"""Disabled for Scoverage ${testScoverageVersion} on Scala ${testScalaVersion}, as it fails with "No source root found" message"""
             } else {
               assert(res.isRight)
-              val Right(result) = res
+              val Right(result) = res: @unchecked
               assert(result.evalCount > 0)
               ""
             }
           }
           test("console") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
-            val Right(_) = eval.apply(HelloWorld.core.test.compile)
-            val Right(result) = eval.apply(HelloWorld.core.scoverage.consoleReport())
+            val Right(_) = eval.apply(HelloWorld.core.test.compile): @unchecked
+            val Right(result) = eval.apply(HelloWorld.core.scoverage.consoleReport()): @unchecked
             assert(result.evalCount > 0)
           }
         }
         test("test") - {
           test("upstreamAssemblyClasspath") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
             val Right(result) =
-              eval.apply(HelloWorld.core.scoverage.upstreamAssemblyClasspath)
+              eval.apply(HelloWorld.core.scoverage.upstreamAssemblyClasspath): @unchecked
 
             val runtimeExistsOnClasspath =
               result.value.map(_.toString).iterator.exists(_.contains("scalac-scoverage-runtime"))
@@ -210,7 +210,7 @@ trait HelloWorldTests extends utest.TestSuite {
           }
           test("compileClasspath") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
             val Right(result) =
-              eval.apply(HelloWorld.core.scoverage.compileClasspath)
+              eval.apply(HelloWorld.core.scoverage.compileClasspath): @unchecked
 
             val runtimeExistsOnClasspath =
               result.value.map(_.toString).iterator.exists(_.contains("scalac-scoverage-runtime"))
@@ -227,7 +227,7 @@ trait HelloWorldTests extends utest.TestSuite {
             }
           }
           test("runClasspath") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
-            val Right(result) = eval.apply(HelloWorld.core.scoverage.runClasspath)
+            val Right(result) = eval.apply(HelloWorld.core.scoverage.runClasspath): @unchecked
 
             val runtimeExistsOnClasspath =
               result.value.map(_.toString).iterator.exists(_.contains("scalac-scoverage-runtime"))
@@ -250,19 +250,19 @@ trait HelloWorldTests extends utest.TestSuite {
     test("HelloWorldSbt") {
       test("scoverage") {
         test("htmlReport") - UnitTester(HelloWorld, sbtResourcePath).scoped { eval =>
-          val Right(_) = eval.apply(HelloWorldSbt.core.test.compile)
-          val Right(result) = eval.apply(HelloWorldSbt.core.scoverage.htmlReport())
+          val Right(_) = eval.apply(HelloWorldSbt.core.test.compile): @unchecked
+          val Right(result) = eval.apply(HelloWorldSbt.core.scoverage.htmlReport()): @unchecked
           assert(result.evalCount > 0)
         }
         test("xmlReport") - UnitTester(HelloWorld, sbtResourcePath).scoped { eval =>
-          val Right(_) = eval.apply(HelloWorldSbt.core.test.compile)
-          val Right(result) = eval.apply(HelloWorldSbt.core.scoverage.xmlReport())
+          val Right(_) = eval.apply(HelloWorldSbt.core.test.compile): @unchecked
+          val Right(result) = eval.apply(HelloWorldSbt.core.scoverage.xmlReport()): @unchecked
           assert(result.evalCount > 0)
         }
         test("console") - UnitTester(HelloWorld, sbtResourcePath).scoped { eval =>
-          val Right(_) = eval.apply(HelloWorldSbt.core.test.compile)
+          val Right(_) = eval.apply(HelloWorldSbt.core.test.compile): @unchecked
           val Right(result) =
-            eval.apply(HelloWorldSbt.core.scoverage.consoleReport())
+            eval.apply(HelloWorldSbt.core.scoverage.consoleReport()): @unchecked
           assert(result.evalCount > 0)
         }
       }
@@ -279,11 +279,11 @@ trait FailedWorldTests extends HelloWorldTests {
       val mod = HelloWorld
       test("shouldFail") {
         test("scoverageToolsCp") - UnitTester(mod, resourcePath).scoped { eval =>
-          val Left(Result.Failure(msg, _)) = eval.apply(mod.core.scoverageToolsClasspath)
+          val Left(Result.Failure(msg, _)) = eval.apply(mod.core.scoverageToolsClasspath): @unchecked
           assert(msg == errorMsg)
         }
         test("other") - UnitTester(mod, resourcePath).scoped { eval =>
-          val Left(Result.Failure(msg, _)) = eval.apply(mod.core.scoverage.xmlReport())
+          val Left(Result.Failure(msg, _)) = eval.apply(mod.core.scoverage.xmlReport()): @unchecked
           assert(msg == errorMsg)
         }
       }
@@ -295,11 +295,11 @@ trait FailedWorldTests extends HelloWorldTests {
           val res = eval.apply(mod.core.scoverageToolsClasspath)
           assert(res.isLeft)
           println(s"res: ${res}")
-          val Left(Result.Failure(msg, _)) = res
+          val Left(Result.Failure(msg, _)) = res: @unchecked
           assert(msg == errorMsg)
         }
         test("other") - UnitTester(mod, resourcePath).scoped { eval =>
-          val Left(Result.Failure(msg, _)) = eval.apply(mod.core.scoverage.xmlReport())
+          val Left(Result.Failure(msg, _)) = eval.apply(mod.core.scoverage.xmlReport()): @unchecked
           assert(msg == errorMsg)
         }
       }

--- a/contrib/sonatypecentral/src/mill/contrib/sonatypecentral/SonatypeCentralPublishModule.scala
+++ b/contrib/sonatypecentral/src/mill/contrib/sonatypecentral/SonatypeCentralPublishModule.scala
@@ -104,7 +104,7 @@ object SonatypeCentralPublishModule extends ExternalModule {
     publisher.publishAll(
       getPublishingTypeFromReleaseFlag(shouldRelease),
       finalBundleName,
-      artifacts: _*
+      artifacts*
     )
   }
 

--- a/contrib/testng/test/src/mill/testng/TestNGTests.scala
+++ b/contrib/testng/test/src/mill/testng/TestNGTests.scala
@@ -54,7 +54,7 @@ object TestNGTests extends TestSuite {
 
   def tests: Tests = Tests {
     test("demo") - UnitTester(demo, resourcePath).scoped { eval =>
-      val Right(result) = eval.apply(demo.test.testFramework)
+      val Right(result) = eval.apply(demo.test.testFramework): @unchecked
       assert(
         result.value == "mill.testng.TestNGFramework",
         result.evalCount > 0
@@ -62,19 +62,19 @@ object TestNGTests extends TestSuite {
     }
     test("Test case lookup from inherited annotations") - UnitTester(demo, resourcePath).scoped {
       eval =>
-        val Right(result) = eval.apply(demo.test.test())
+        val Right(result) = eval.apply(demo.test.test()): @unchecked
         val tres = result.value
         assert(tres._2.size == 8)
     }
     test("noGrouping") - UnitTester(demo, resourcePath).scoped {
       eval =>
-        val Right(result) = eval.apply(demo.testng.test())
+        val Right(result) = eval.apply(demo.testng.test()): @unchecked
         val tres = result.value._2
         assert(tres.map(_.fullyQualifiedName).toSet == Set("foo.HelloTests", "foo.WorldTests"))
     }
     test("testForkGrouping") - UnitTester(demo, resourcePath).scoped {
       eval =>
-        val Right(result) = eval.apply(demo.testngGrouping.test())
+        val Right(result) = eval.apply(demo.testngGrouping.test()): @unchecked
         val tres = result.value._2
         assert(tres.map(_.fullyQualifiedName).toSet == Set("foo.HelloTests", "foo.WorldTests"))
     }

--- a/contrib/twirllib/src/mill/twirllib/TwirlWorker.scala
+++ b/contrib/twirllib/src/mill/twirllib/TwirlWorker.scala
@@ -13,9 +13,9 @@ import scala.util.matching.Regex
 
 class TwirlWorker {
 
-  private var twirlInstanceCache = Option.empty[(Int, (TwirlWorkerApi, Class[_]))]
+  private var twirlInstanceCache = Option.empty[(Int, (TwirlWorkerApi, Class[?]))]
 
-  private def twirlCompilerAndClass(twirlClasspath: Agg[PathRef]): (TwirlWorkerApi, Class[_]) = {
+  private def twirlCompilerAndClass(twirlClasspath: Agg[PathRef]): (TwirlWorkerApi, Class[?]) = {
     val classloaderSig = twirlClasspath.hashCode
     twirlInstanceCache match {
       case Some((sig, instance)) if sig == classloaderSig => instance
@@ -124,7 +124,7 @@ class TwirlWorker {
   private def twirl(twirlClasspath: Agg[PathRef]): TwirlWorkerApi =
     twirlCompilerAndClass(twirlClasspath)._1
 
-  private def twirlClass(twirlClasspath: Agg[PathRef]): Class[_] =
+  private def twirlClass(twirlClasspath: Agg[PathRef]): Class[?] =
     twirlCompilerAndClass(twirlClasspath)._2
 
   def defaultImports(twirlClasspath: Agg[PathRef]): Seq[String] =

--- a/contrib/twirllib/test/src/mill/twirllib/HelloWorldTests.scala
+++ b/contrib/twirllib/test/src/mill/twirllib/HelloWorldTests.scala
@@ -72,7 +72,7 @@ trait HelloWorldTests extends TestSuite {
 
       test("fromBuild") - UnitTester(HelloWorld, resourcePath / "hello-world").scoped { eval =>
         val Right(result) =
-          eval.apply(HelloWorld.core.twirlVersion)
+          eval.apply(HelloWorld.core.twirlVersion): @unchecked
 
         assert(
           result.value == testTwirlVersion,
@@ -85,7 +85,7 @@ trait HelloWorldTests extends TestSuite {
         UnitTester(HelloWorld, resourcePath / "hello-world", debugEnabled = true).scoped { eval =>
           val res = eval.apply(HelloWorld.core.compileTwirl)
           assert(res.isRight)
-          val Right(result) = res
+          val Right(result) = res: @unchecked
 
           val outputFiles = os.walk(result.value.classes.path).filter(_.last.endsWith(".scala"))
           val expectedClassfiles = compileClassfiles.map(
@@ -113,7 +113,7 @@ trait HelloWorldTests extends TestSuite {
 
           // don't recompile if nothing changed
           val Right(result2) =
-            eval.apply(HelloWorld.core.compileTwirl)
+            eval.apply(HelloWorld.core.compileTwirl): @unchecked
 
           assert(result2.evalCount == 0)
         }
@@ -126,7 +126,7 @@ trait HelloWorldTests extends TestSuite {
           HelloWorldWithInclusiveDot,
           sourceRoot = resourcePath / "hello-world-inclusive-dot"
         ).scoped { eval =>
-          val Right(result) = eval.apply(HelloWorldWithInclusiveDot.core.compileTwirl)
+          val Right(result) = eval.apply(HelloWorldWithInclusiveDot.core.compileTwirl): @unchecked
 
           val outputFiles = os.walk(result.value.classes.path).filter(_.last.endsWith(".scala"))
           val expectedClassfiles = compileClassfiles.map(name =>
@@ -152,7 +152,7 @@ trait HelloWorldTests extends TestSuite {
 
           // don't recompile if nothing changed
           val Right(result2) =
-            eval.apply(HelloWorld.core.compileTwirl)
+            eval.apply(HelloWorld.core.compileTwirl): @unchecked
 
           assert(result2.evalCount == 0)
         }

--- a/contrib/twirllib/test/src/mill/twirllib/HelloWorldTests.scala
+++ b/contrib/twirllib/test/src/mill/twirllib/HelloWorldTests.scala
@@ -3,7 +3,6 @@ package mill.twirllib
 import mill.define.Discover
 import mill.testkit.UnitTester
 import mill.testkit.TestBaseModule
-import utest.framework.TestPath
 import utest.{TestSuite, Tests, assert, *}
 
 trait HelloWorldTests extends TestSuite {

--- a/contrib/versionfile/test/src/mill/contrib/versionfile/VersionFileModuleTests.scala
+++ b/contrib/versionfile/test/src/mill/contrib/versionfile/VersionFileModuleTests.scala
@@ -1,9 +1,8 @@
 package mill.contrib.versionfile
 
-import mill.{T, Task}
+import mill.Task
 import mill.testkit.{UnitTester, TestBaseModule}
-import utest.{TestSuite, Tests, assert, assertMatch, test}
-import utest.framework.TestPath
+import utest.{TestSuite, Tests, assert, test}
 import mill.main.TokenReaders._
 import mill.define.Discover
 object VersionFileModuleTests extends TestSuite {

--- a/contrib/versionfile/test/src/mill/contrib/versionfile/VersionFileModuleTests.scala
+++ b/contrib/versionfile/test/src/mill/contrib/versionfile/VersionFileModuleTests.scala
@@ -32,7 +32,7 @@ object VersionFileModuleTests extends TestSuite {
   }
 
   def workspaceTest(versions: Version*)(test: UnitTester => Any): Unit =
-    workspaceTest0(versions: _*)(eval => _ => test(eval))
+    workspaceTest0(versions*)(eval => _ => test(eval))
 
   //  check version file ends with newline
   def workspaceTestEndsWithNewline0(versions: Version*)(test: UnitTester => Version => Any)
@@ -44,7 +44,7 @@ object VersionFileModuleTests extends TestSuite {
   }
 
   def workspaceTestEndsWithNewline(versions: Version*)(test: UnitTester => Any): Unit =
-    workspaceTestEndsWithNewline0(versions: _*)(eval => _ => test(eval))
+    workspaceTestEndsWithNewline0(versions*)(eval => _ => test(eval))
 
   def tests: Tests = Tests {
 
@@ -54,37 +54,37 @@ object VersionFileModuleTests extends TestSuite {
 
       val versions = Seq(Version.Release(1, 2, 3), Version.Snapshot(1, 2, 3))
 
-      test("currentVersion") - workspaceTest0(versions: _*) { eval => expectedVersion =>
-        val Right(out) = eval(TestModule.versionFile.currentVersion)
+      test("currentVersion") - workspaceTest0(versions*) { eval => expectedVersion =>
+        val Right(out) = eval(TestModule.versionFile.currentVersion): @unchecked
         assert(out.value == expectedVersion)
       }
 
-      test("releaseVersion") - workspaceTest(versions: _*) { eval =>
-        val Right(out) = eval(TestModule.versionFile.releaseVersion)
+      test("releaseVersion") - workspaceTest(versions*) { eval =>
+        val Right(out) = eval(TestModule.versionFile.releaseVersion): @unchecked
         assert(out.value == Version.Release(1, 2, 3))
       }
 
-      test("nextVersion") - workspaceTest(versions: _*) { eval =>
-        val Right(out) = eval(TestModule.versionFile.nextVersion(minor))
+      test("nextVersion") - workspaceTest(versions*) { eval =>
+        val Right(out) = eval(TestModule.versionFile.nextVersion(minor)): @unchecked
         assert(out.value == Version.Snapshot(1, 3, 0))
       }
 
       test("currentVersion - file ends with newline") - workspaceTestEndsWithNewline0(
-        versions: _*
+        versions*
       ) { eval => expectedVersion =>
-        val Right(out) = eval(TestModule.versionFile.currentVersion)
+        val Right(out) = eval(TestModule.versionFile.currentVersion): @unchecked
         assert(out.value == expectedVersion)
       }
 
-      test("releaseVersion - file ends with newline") - workspaceTestEndsWithNewline(versions: _*) {
+      test("releaseVersion - file ends with newline") - workspaceTestEndsWithNewline(versions*) {
         eval =>
-          val Right(out) = eval(TestModule.versionFile.releaseVersion)
+          val Right(out) = eval(TestModule.versionFile.releaseVersion): @unchecked
           assert(out.value == Version.Release(1, 2, 3))
       }
 
-      test("nextVersion - file ends with newline") - workspaceTestEndsWithNewline(versions: _*) {
+      test("nextVersion - file ends with newline") - workspaceTestEndsWithNewline(versions*) {
         eval =>
-          val Right(out) = eval(TestModule.versionFile.nextVersion(minor))
+          val Right(out) = eval(TestModule.versionFile.nextVersion(minor)): @unchecked
           assert(out.value == Version.Snapshot(1, 3, 0))
       }
     }
@@ -93,25 +93,25 @@ object VersionFileModuleTests extends TestSuite {
 
       val versions = Seq(Version.Release(1, 2, 3), Version.Snapshot(1, 2, 3))
 
-      test("setReleaseVersion") - workspaceTest(versions: _*) { eval =>
-        val Right(expected) = eval(TestModule.versionFile.releaseVersion)
+      test("setReleaseVersion") - workspaceTest(versions*) { eval =>
+        val Right(expected) = eval(TestModule.versionFile.releaseVersion): @unchecked
         eval(TestModule.versionFile.setReleaseVersion())
-        val Right(actual) = eval(TestModule.versionFile.currentVersion)
+        val Right(actual) = eval(TestModule.versionFile.currentVersion): @unchecked
         assert(expected.value == actual.value)
       }
 
-      test("setNextVersion") - workspaceTest(versions: _*) { eval =>
+      test("setNextVersion") - workspaceTest(versions*) { eval =>
         val bump = minor
-        val Right(expected) = eval(TestModule.versionFile.nextVersion(bump))
+        val Right(expected) = eval(TestModule.versionFile.nextVersion(bump)): @unchecked
         eval(TestModule.versionFile.setNextVersion(bump))
-        val Right(actual) = eval(TestModule.versionFile.currentVersion)
+        val Right(actual) = eval(TestModule.versionFile.currentVersion): @unchecked
         assert(expected.value == actual.value)
       }
 
-      test("setVersion") - workspaceTest(versions: _*) { eval =>
+      test("setVersion") - workspaceTest(versions*) { eval =>
         val expected = Version.Release(1, 2, 4)
         eval(TestModule.versionFile.setVersion(Task.Anon(expected)))
-        val Right(actual) = eval(TestModule.versionFile.currentVersion)
+        val Right(actual) = eval(TestModule.versionFile.currentVersion): @unchecked
         assert(actual.value == expected)
       }
 
@@ -121,8 +121,8 @@ object VersionFileModuleTests extends TestSuite {
 
       val versions = Seq(Version.Release(1, 2, 3), Version.Snapshot(1, 2, 3))
 
-      test("tag") - workspaceTest0(versions: _*) { eval => version =>
-        val Right(out) = eval(TestModule.versionFile.tag)
+      test("tag") - workspaceTest0(versions*) { eval => version =>
+        val Right(out) = eval(TestModule.versionFile.tag): @unchecked
         val commitMessage = TestModule.versionFile.generateCommitMessage(version)
         assert(
           out.value ==
@@ -134,8 +134,8 @@ object VersionFileModuleTests extends TestSuite {
 
       }
 
-      test("push") - workspaceTest0(versions: _*) { eval => version =>
-        val Right(out) = eval(TestModule.versionFile.push)
+      test("push") - workspaceTest0(versions*) { eval => version =>
+        val Right(out) = eval(TestModule.versionFile.push): @unchecked
         val commitMessage = TestModule.versionFile.generateCommitMessage(version)
         assert(
           out.value ==

--- a/core/define/src/mill/define/Cross.scala
+++ b/core/define/src/mill/define/Cross.scala
@@ -123,7 +123,7 @@ object Cross {
   }
 
   class Factory[T: ClassTag](
-      val makeList: Seq[(Class[_], mill.define.Ctx => T)],
+      val makeList: Seq[(Class[?], mill.define.Ctx => T)],
       val crossValuesListLists: Seq[Seq[Any]],
       val crossSegmentsList: Seq[Seq[String]],
       val crossValuesRaw: Seq[Any]
@@ -137,12 +137,12 @@ object Cross {
      * expression of type `Any`, but type-checking on the macro-expanded code
      * provides some degree of type-safety.
      */
-    implicit inline def make[M <: Module[_]](inline t: Any): Factory[M] = ${
+    implicit inline def make[M <: Module[?]](inline t: Any): Factory[M] = ${
       macros.CrossMacros.makeImpl[M]('t)
     }
   }
 
-  trait Resolver[-T <: Cross.Module[_]] {
+  trait Resolver[-T <: Cross.Module[?]] {
     def resolve[V <: T](c: Cross[V]): V
   }
 }
@@ -159,7 +159,7 @@ object Cross {
  * }
  * }}}
  */
-class Cross[M <: Cross.Module[_]](factories: Cross.Factory[M]*)(implicit
+class Cross[M <: Cross.Module[?]](factories: Cross.Factory[M]*)(implicit
     ctx: mill.define.Ctx
 ) extends mill.define.Module {
 
@@ -167,7 +167,7 @@ class Cross[M <: Cross.Module[_]](factories: Cross.Factory[M]*)(implicit
     def crossValues: List[Any]
     def crossSegments: List[String]
     def module: Lazy[M]
-    def cls: Class[_]
+    def cls: Class[?]
   }
 
   val items: List[Item] = {
@@ -258,7 +258,7 @@ class Cross[M <: Cross.Module[_]](factories: Cross.Factory[M]*)(implicit
    * scope. This is often the first cross module whose cross-version is
    * compatible with the current module.
    */
-  def apply[V >: M <: Cross.Module[_]]()(implicit resolver: Cross.Resolver[V]): M = {
+  def apply[V >: M <: Cross.Module[?]]()(implicit resolver: Cross.Resolver[V]): M = {
     resolver.resolve(this.asInstanceOf[Cross[V]]).asInstanceOf[M]
   }
 }

--- a/core/define/src/mill/define/Ctx.scala
+++ b/core/define/src/mill/define/Ctx.scala
@@ -44,7 +44,7 @@ trait Ctx {
   /**
    * The `class` or `trait` that lexically surrounds this definition
    */
-  def enclosingCls: Class[_]
+  def enclosingCls: Class[?]
 
   /**
    * The runtime [[Module]] object that contains this definition

--- a/core/define/src/mill/define/Discover.scala
+++ b/core/define/src/mill/define/Discover.scala
@@ -14,8 +14,8 @@ import scala.collection.mutable
  * the `Task.Command` methods we find. This mapping from `Class[_]` to `MainData`
  * can then be used later to look up the `MainData` for any module.
  */
-class Discover(val classInfo: Map[Class[_], Discover.ClassInfo]) {
-  def resolveEntrypoint(cls: Class[_], name: String) = {
+class Discover(val classInfo: Map[Class[?], Discover.ClassInfo]) {
+  def resolveEntrypoint(cls: Class[?], name: String) = {
     val res = for {
       (cls2, node) <- classInfo
       if cls2.isAssignableFrom(cls)
@@ -29,7 +29,7 @@ class Discover(val classInfo: Map[Class[_], Discover.ClassInfo]) {
 
 object Discover {
   class ClassInfo(
-      val entryPoints: Seq[mainargs.MainData[_, _]],
+      val entryPoints: Seq[mainargs.MainData[?, ?]],
       val declaredTasks: Seq[TaskInfo]
   ) {
     lazy val declaredTaskNameSet = declaredTasks.map(_.name).toSet
@@ -178,7 +178,7 @@ object Discover {
           }
       }
 
-      '{ new Discover(Map[Class[_], ClassInfo](${ Varargs(mappingExpr) }*)) }
+      '{ new Discover(Map[Class[?], ClassInfo](${ Varargs(mappingExpr) }*)) }
     }
   }
 }

--- a/core/define/src/mill/define/EnclosingClass.scala
+++ b/core/define/src/mill/define/EnclosingClass.scala
@@ -2,7 +2,7 @@ package mill.define
 
 import scala.quoted.*
 
-case class EnclosingClass(value: Class[_])
+case class EnclosingClass(value: Class[?])
 object EnclosingClass {
   def apply()(implicit c: EnclosingClass) = c.value
   inline given generate: EnclosingClass = ${ impl }

--- a/core/define/src/mill/define/Module.scala
+++ b/core/define/src/mill/define/Module.scala
@@ -44,7 +44,7 @@ trait Module extends Module.BaseClass with OverrideMapping.Wrapper {
 
   override def toString = millModuleSegments.render
 
-  private[mill] val linearized: Seq[Class[_]] = OverrideMapping.computeLinearization(this.getClass)
+  private[mill] val linearized: Seq[Class[?]] = OverrideMapping.computeLinearization(this.getClass)
 }
 
 object Module {
@@ -71,8 +71,8 @@ object Module {
     lazy val segmentsToModules: Map[Segments, Module] =
       modules.map(m => (m.millModuleSegments, m)).toMap
 
-    lazy val targets: Set[Target[_]] =
-      traverse { _.millInternal.reflectAll[Target[_]].toIndexedSeq }.toSet
+    lazy val targets: Set[Target[?]] =
+      traverse { _.millInternal.reflectAll[Target[?]].toIndexedSeq }.toSet
 
     def reflect[T: ClassTag](filter: String => Boolean): Seq[T] = {
       Reflect.reflect(

--- a/core/define/src/mill/define/OverrideMapping.scala
+++ b/core/define/src/mill/define/OverrideMapping.scala
@@ -16,14 +16,14 @@ import scala.collection.JavaConverters.*
  */
 object OverrideMapping {
   trait Wrapper {
-    private[mill] def linearized: Seq[Class[_]]
+    private[mill] def linearized: Seq[Class[?]]
   }
 
   def computeSegments(
       enclosingValue: OverrideMapping.Wrapper,
       discover: Discover,
       lastSegmentStr: String,
-      enclosingClassValue: Class[_]
+      enclosingClassValue: Class[?]
   ) = {
     Option(enclosingValue) match {
       case Some(value) =>
@@ -42,13 +42,13 @@ object OverrideMapping {
     }
   }
 
-  def computeLinearization(cls: Class[_]): Seq[Class[_]] = {
+  def computeLinearization(cls: Class[?]): Seq[Class[?]] = {
     // Manually reproduce the linearization order described in
     //
     // https://stackoverflow.com/questions/34242536/linearization-order-in-scala
-    val seen = collection.mutable.Set[Class[_]]()
+    val seen = collection.mutable.Set[Class[?]]()
 
-    def rec(cls: Class[_]): Seq[Class[_]] = {
+    def rec(cls: Class[?]): Seq[Class[?]] = {
       val parents = Option(cls.getSuperclass) ++ cls.getInterfaces
       parents.iterator.flatMap(rec(_)).toSeq ++ Option.when(seen.add(cls))(cls)
     }

--- a/core/define/src/mill/define/Reflect.scala
+++ b/core/define/src/mill/define/Reflect.scala
@@ -22,7 +22,7 @@ private[mill] object Reflect {
     true
   }
 
-  def getMethods(cls: Class[_], decode: String => String): Array[(Method, String)] =
+  def getMethods(cls: Class[?], decode: String => String): Array[(Method, String)] =
     for {
       m <- cls.getMethods
       n = decode(m.getName)
@@ -30,16 +30,16 @@ private[mill] object Reflect {
     } yield (m, n)
 
   private val classSeqOrdering =
-    Ordering.Implicits.seqOrdering[Seq, Class[_]]((c1, c2) =>
+    Ordering.Implicits.seqOrdering[Seq, Class[?]]((c1, c2) =>
       if (c1 == c2) 0 else if (c1.isAssignableFrom(c2)) 1 else -1
     )
 
   def reflect(
-      outer: Class[_],
-      inner: Class[_],
+      outer: Class[?],
+      inner: Class[?],
       filter: String => Boolean,
       noParams: Boolean,
-      getMethods: Class[_] => Array[(java.lang.reflect.Method, String)]
+      getMethods: Class[?] => Array[(java.lang.reflect.Method, String)]
   ): Array[java.lang.reflect.Method] = {
     val arr: Array[java.lang.reflect.Method] = getMethods(outer)
       .collect {
@@ -82,9 +82,9 @@ private[mill] object Reflect {
   // another top-level concrete `object`. This is fine for now, since Mill's Ammonite
   // script/REPL runner always wraps user code in a wrapper object/trait
   def reflectNestedObjects0[T: ClassTag](
-      outerCls: Class[_],
+      outerCls: Class[?],
       filter: String => Boolean = Function.const(true),
-      getMethods: Class[_] => Array[(java.lang.reflect.Method, String)]
+      getMethods: Class[?] => Array[(java.lang.reflect.Method, String)]
   ): Array[(String, java.lang.reflect.Member)] = {
 
     val first = reflect(
@@ -117,10 +117,10 @@ private[mill] object Reflect {
   }
 
   def reflectNestedObjects02[T: ClassTag](
-      outerCls: Class[_],
+      outerCls: Class[?],
       filter: String => Boolean = Function.const(true),
-      getMethods: Class[_] => Array[(java.lang.reflect.Method, String)]
-  ): Array[(String, Class[_], Any => T)] = {
+      getMethods: Class[?] => Array[(java.lang.reflect.Method, String)]
+  ): Array[(String, Class[?], Any => T)] = {
     reflectNestedObjects0[T](outerCls, filter, getMethods).map {
       case (name, m: java.lang.reflect.Method) =>
         (name, m.getReturnType, (outer: Any) => m.invoke(outer).asInstanceOf[T])

--- a/core/define/test/src/mill/define/CacherTests.scala
+++ b/core/define/test/src/mill/define/CacherTests.scala
@@ -2,7 +2,7 @@ package mill.define
 
 import mill.testkit.UnitTester
 import mill.testkit.TestBaseModule
-import mill.{T, Task}
+import mill.Task
 import mill.api.Result.Success
 import utest._
 import utest.framework.TestPath

--- a/core/define/test/src/mill/define/DiscoverTests.scala
+++ b/core/define/test/src/mill/define/DiscoverTests.scala
@@ -6,7 +6,7 @@ import utest._
 object DiscoverTests extends TestSuite {
   val testGraphs = new TestGraphs
   val tests = Tests {
-    def check[T <: Module](m: T)(targets: (T => Target[_])*) = {
+    def check[T <: Module](m: T)(targets: (T => Target[?])*) = {
       val discovered = m.millInternal.targets
       val expected = targets.map(_(m)).toSet
       assert(discovered == expected)

--- a/core/define/test/src/mill/define/MacroErrorTests.scala
+++ b/core/define/test/src/mill/define/MacroErrorTests.scala
@@ -1,8 +1,6 @@
 package mill.define
 
 import utest._
-import mill.{T, Module}
-import mill.util.TestUtil
 import mill.testkit.TestBaseModule
 object MacroErrorTests extends TestSuite {
 

--- a/core/eval/src/mill/eval/CodeSigUtils.scala
+++ b/core/eval/src/mill/eval/CodeSigUtils.scala
@@ -8,8 +8,8 @@ import java.lang.reflect.Method
 
 private[mill] object CodeSigUtils {
   def precomputeMethodNamesPerClass(transitiveNamed: Strict.Agg[NamedTask[?]])
-      : (Map[Class[_], IndexedSeq[Class[_]]], Map[Class[_], Map[String, Method]]) = {
-    def resolveTransitiveParents(c: Class[_]): Iterator[Class[_]] = {
+      : (Map[Class[?], IndexedSeq[Class[?]]], Map[Class[?], Map[String, Method]]) = {
+    def resolveTransitiveParents(c: Class[?]): Iterator[Class[?]] = {
       Iterator(c) ++
         Option(c.getSuperclass).iterator.flatMap(resolveTransitiveParents) ++
         c.getInterfaces.iterator.flatMap(resolveTransitiveParents)
@@ -55,7 +55,7 @@ private[mill] object CodeSigUtils {
       .groupMap(_._1)(t => (t._2, t._3))
 
   def codeSigForTask(
-      namedTask: => NamedTask[_],
+      namedTask: => NamedTask[?],
       classToTransitiveClasses: => Map[Class[?], IndexedSeq[Class[?]]],
       allTransitiveClassMethods: => Map[Class[?], Map[String, java.lang.reflect.Method]],
       methodCodeHashSignatures: => Map[String, Int],

--- a/core/eval/src/mill/eval/Evaluator.scala
+++ b/core/eval/src/mill/eval/Evaluator.scala
@@ -33,7 +33,7 @@ trait Evaluator extends AutoCloseable {
   def disableCallgraphInvalidation: Boolean = false
 
   def evaluate(
-      goals: Agg[Task[_]],
+      goals: Agg[Task[?]],
       reporter: Int => Option[CompileProblemReporter] = _ => Option.empty[CompileProblemReporter],
       testReporter: TestReporter = DummyTestReporter,
       logger: ColorLogger = baseLogger,
@@ -43,7 +43,7 @@ trait Evaluator extends AutoCloseable {
   def withBaseLogger(newBaseLogger: ColorLogger): Evaluator
   def withFailFast(newFailFast: Boolean): Evaluator
   def allowPositionalCommandArgs: Boolean = false
-  def plan(goals: Agg[Task[_]]): Plan
+  def plan(goals: Agg[Task[?]]): Plan
 
   /**
    * Evaluate given task(s) and return the successful result(s), or throw an exception.
@@ -58,10 +58,10 @@ trait Evaluator extends AutoCloseable {
 object Evaluator {
   trait Results {
     def rawValues: Seq[Result[Val]]
-    def evaluated: Agg[Task[_]]
-    def transitive: Agg[Task[_]]
-    def failing: MultiBiMap[Task[_], Result.Failing[Val]]
-    def results: collection.Map[Task[_], TaskResult[Val]]
+    def evaluated: Agg[Task[?]]
+    def transitive: Agg[Task[?]]
+    def failing: MultiBiMap[Task[?], Result.Failing[Val]]
+    def results: collection.Map[Task[?], TaskResult[Val]]
     def values: Seq[Val] = rawValues.collect { case Result.Success(v) => v }
   }
 

--- a/core/eval/src/mill/eval/EvaluatorImpl.scala
+++ b/core/eval/src/mill/eval/EvaluatorImpl.scala
@@ -46,7 +46,7 @@ private[mill] case class EvaluatorImpl(
   override def withFailFast(newFailFast: Boolean): Evaluator =
     this.copy(failFast = newFailFast)
 
-  override def plan(goals: Agg[Task[_]]): Plan = {
+  override def plan(goals: Agg[Task[?]]): Plan = {
     Plan.plan(goals)
   }
 
@@ -113,7 +113,7 @@ private[mill] object EvaluatorImpl {
           throw exceptionFactory(r)
         case r =>
           // Input is a single-item Agg, so we also expect a single-item result
-          val Seq(Val(e: T)) = r.values
+          val Seq(Val(e: T)) = r.values: @unchecked
           e
       }
 

--- a/core/eval/src/mill/eval/EvaluatorLogs.scala
+++ b/core/eval/src/mill/eval/EvaluatorLogs.scala
@@ -9,8 +9,8 @@ import scala.jdk.CollectionConverters.EnumerationHasAsScala
 
 private[mill] object EvaluatorLogs {
   def logDependencyTree(
-      interGroupDeps: Map[Task[_], Seq[Task[_]]],
-      indexToTerminal: Array[Task[_]],
+      interGroupDeps: Map[Task[?], Seq[Task[?]]],
+      indexToTerminal: Array[Task[?]],
       outPath: os.Path
   ): Unit = {
     val (vertexToIndex, edgeIndices) =
@@ -24,11 +24,11 @@ private[mill] object EvaluatorLogs {
     )
   }
   def logInvalidationTree(
-      interGroupDeps: Map[Task[_], Seq[Task[_]]],
-      indexToTerminal: Array[Task[_]],
+      interGroupDeps: Map[Task[?], Seq[Task[?]]],
+      indexToTerminal: Array[Task[?]],
       outPath: os.Path,
-      uncached: ConcurrentHashMap[Task[_], Unit],
-      changedValueHash: ConcurrentHashMap[Task[_], Unit]
+      uncached: ConcurrentHashMap[Task[?], Unit],
+      changedValueHash: ConcurrentHashMap[Task[?], Unit]
   ): Unit = {
     val reverseInterGroupDeps = SpanningForest.reverseEdges(interGroupDeps)
 
@@ -55,7 +55,7 @@ private[mill] object EvaluatorLogs {
             // from the invalidation tree, because most of them are un-interesting and the
             // user really only cares about (a) inputs that cause downstream tasks to invalidate
             // or (b) non-input tasks that were invalidated alone (e.g. due to a codesig change)
-            !uncachedTask.isInstanceOf[InputImpl[_]] || edgeSourceIndices(uncachedIndex)
+            !uncachedTask.isInstanceOf[InputImpl[?]] || edgeSourceIndices(uncachedIndex)
           ) {
             uncachedIndex
           }

--- a/core/eval/src/mill/eval/EvaluatorPaths.scala
+++ b/core/eval/src/mill/eval/EvaluatorPaths.scala
@@ -41,7 +41,7 @@ object EvaluatorPaths {
   }
   def resolveDestPaths(
       workspacePath: os.Path,
-      task: NamedTask[_]
+      task: NamedTask[?]
   ): EvaluatorPaths = resolveDestPaths(workspacePath, task.ctx.segments)
 
   // case-insensitive match on reserved names

--- a/core/eval/src/mill/eval/EvaluatorPathsResolver.scala
+++ b/core/eval/src/mill/eval/EvaluatorPathsResolver.scala
@@ -3,7 +3,7 @@ package mill.eval
 import mill.define.{NamedTask, Segments}
 
 trait EvaluatorPathsResolver {
-  def resolveDest(task: NamedTask[_]): EvaluatorPaths = resolveDest(task.ctx.segments)
+  def resolveDest(task: NamedTask[?]): EvaluatorPaths = resolveDest(task.ctx.segments)
   def resolveDest(segments: Segments): EvaluatorPaths
 }
 

--- a/core/eval/src/mill/eval/GroupEvaluator.scala
+++ b/core/eval/src/mill/eval/GroupEvaluator.scala
@@ -43,16 +43,16 @@ private[mill] trait GroupEvaluator {
 
   // those result which are inputs but not contained in this terminal group
   def evaluateGroupCached(
-      terminal: Task[_],
-      group: Agg[Task[_]],
-      results: Map[Task[_], TaskResult[(Val, Int)]],
+      terminal: Task[?],
+      group: Agg[Task[?]],
+      results: Map[Task[?], TaskResult[(Val, Int)]],
       countMsg: String,
       verboseKeySuffix: String,
       zincProblemReporter: Int => Option[CompileProblemReporter],
       testReporter: TestReporter,
       logger: ColorLogger,
-      classToTransitiveClasses: Map[Class[_], IndexedSeq[Class[_]]],
-      allTransitiveClassMethods: Map[Class[_], Map[String, Method]],
+      classToTransitiveClasses: Map[Class[?], IndexedSeq[Class[?]]],
+      allTransitiveClassMethods: Map[Class[?], Map[String, Method]],
       executionContext: mill.api.Ctx.Fork.Api,
       exclusive: Boolean
   ): GroupEvaluator.Results = {
@@ -104,7 +104,7 @@ private[mill] trait GroupEvaluator {
           cachedValueAndHash match {
             case Some((v, hashCode)) =>
               val res = Result.Success((v, hashCode))
-              val newResults: Map[Task[_], TaskResult[(Val, Int)]] =
+              val newResults: Map[Task[?], TaskResult[(Val, Int)]] =
                 Map(labelled -> TaskResult(res, () => res))
 
               GroupEvaluator.Results(
@@ -159,7 +159,7 @@ private[mill] trait GroupEvaluator {
               GroupEvaluator.Results(
                 newResults,
                 newEvaluated.toSeq,
-                cached = if (labelled.isInstanceOf[InputImpl[_]]) null else false,
+                cached = if (labelled.isInstanceOf[InputImpl[?]]) null else false,
                 inputsHash,
                 cached.map(_._1).getOrElse(-1),
                 !cached.map(_._3).contains(valueHash)
@@ -194,8 +194,8 @@ private[mill] trait GroupEvaluator {
   }
 
   private def evaluateGroup(
-      group: Agg[Task[_]],
-      results: Map[Task[_], TaskResult[(Val, Int)]],
+      group: Agg[Task[?]],
+      results: Map[Task[?], TaskResult[(Val, Int)]],
       inputsHash: Int,
       paths: Option[EvaluatorPaths],
       maybeTargetLabel: Option[String],
@@ -206,11 +206,11 @@ private[mill] trait GroupEvaluator {
       logger: mill.api.Logger,
       executionContext: mill.api.Ctx.Fork.Api,
       exclusive: Boolean
-  ): (Map[Task[_], TaskResult[(Val, Int)]], mutable.Buffer[Task[_]]) = {
+  ): (Map[Task[?], TaskResult[(Val, Int)]], mutable.Buffer[Task[?]]) = {
 
     def computeAll() = {
-      val newEvaluated = mutable.Buffer.empty[Task[_]]
-      val newResults = mutable.Map.empty[Task[_], Result[(Val, Int)]]
+      val newEvaluated = mutable.Buffer.empty[Task[?]]
+      val newResults = mutable.Map.empty[Task[?], Result[(Val, Int)]]
 
       val nonEvaluatedTargets = group.indexed.filterNot(results.contains)
       val multiLogger = resolveLogger(paths.map(_.log), logger)
@@ -291,7 +291,7 @@ private[mill] trait GroupEvaluator {
     val (newResults, newEvaluated) = computeAll()
 
     if (!failFast) maybeTargetLabel.foreach { targetLabel =>
-      val taskFailed = newResults.exists(task => !task._2.isInstanceOf[Success[_]])
+      val taskFailed = newResults.exists(task => !task._2.isInstanceOf[Success[?]])
       if (taskFailed) {
         logger.error(s"[$counterMsg] $targetLabel failed")
       }
@@ -329,7 +329,7 @@ private[mill] trait GroupEvaluator {
       hashCode: Int,
       metaPath: os.Path,
       inputsHash: Int,
-      labelled: NamedTask[_]
+      labelled: NamedTask[?]
   ): Unit = {
     for (w <- labelled.asWorker)
       workerCache.synchronized {
@@ -379,7 +379,7 @@ private[mill] trait GroupEvaluator {
   private def loadCachedJson(
       logger: ColorLogger,
       inputsHash: Int,
-      labelled: NamedTask[_],
+      labelled: NamedTask[?],
       paths: EvaluatorPaths
   ): Option[(Int, Option[Val], Int)] = {
     for {
@@ -408,13 +408,13 @@ private[mill] trait GroupEvaluator {
     )
   }
 
-  def getValueHash(v: Val, task: Task[_], inputsHash: Int): Int = {
-    if (task.isInstanceOf[Worker[_]]) inputsHash else v.##
+  def getValueHash(v: Val, task: Task[?], inputsHash: Int): Int = {
+    if (task.isInstanceOf[Worker[?]]) inputsHash else v.##
   }
   private def loadUpToDateWorker(
       logger: ColorLogger,
       inputsHash: Int,
-      labelled: NamedTask[_],
+      labelled: NamedTask[?],
       forceDiscard: Boolean
   ): Option[Val] = {
     labelled.asWorker
@@ -455,8 +455,8 @@ private[mill] trait GroupEvaluator {
 private[mill] object GroupEvaluator {
 
   case class Results(
-      newResults: Map[Task[_], TaskResult[(Val, Int)]],
-      newEvaluated: Seq[Task[_]],
+      newResults: Map[Task[?], TaskResult[(Val, Int)]],
+      newEvaluated: Seq[Task[?]],
       cached: java.lang.Boolean,
       inputsHash: Int,
       previousInputsHash: Int,

--- a/core/eval/src/mill/eval/JsonArrayLogger.scala
+++ b/core/eval/src/mill/eval/JsonArrayLogger.scala
@@ -15,7 +15,7 @@ private class JsonArrayLogger[T: upickle.default.Writer](outPath: os.Path, inden
       Seq(StandardOpenOption.TRUNCATE_EXISTING)
     ).flatten
     os.makeDir.all(outPath / os.up)
-    new PrintStream(Files.newOutputStream(outPath.toNIO, options: _*))
+    new PrintStream(Files.newOutputStream(outPath.toNIO, options*))
   }
 
   def log(t: T): Unit = synchronized {
@@ -40,10 +40,10 @@ private class JsonArrayLogger[T: upickle.default.Writer](outPath: os.Path, inden
 private[eval] class ProfileLogger(outPath: os.Path)
     extends JsonArrayLogger[ProfileLogger.Timing](outPath, indent = 2) {
   def log(
-      terminal: Task[_],
+      terminal: Task[?],
       duration: Long,
       res: GroupEvaluator.Results,
-      deps: Seq[Task[_]]
+      deps: Seq[Task[?]]
   ): Unit = {
     log(
       ProfileLogger.Timing(
@@ -79,7 +79,7 @@ private[eval] class ChromeProfileLogger(outPath: os.Path)
     extends JsonArrayLogger[ChromeProfileLogger.TraceEvent](outPath, indent = -1) {
 
   def log(
-      terminal: Task[_],
+      terminal: Task[?],
       cat: String,
       startTime: Long,
       duration: Long,

--- a/core/eval/src/mill/eval/Plan.scala
+++ b/core/eval/src/mill/eval/Plan.scala
@@ -5,14 +5,14 @@ import mill.internal.MultiBiMap
 
 private[mill] class Plan(
     val transitive: Agg[Task[?]],
-    val sortedGroups: MultiBiMap[Task[_], Task[_]]
+    val sortedGroups: MultiBiMap[Task[?], Task[?]]
 )
 private[mill] object Plan {
-  def plan(goals: Agg[Task[_]]): Plan = {
+  def plan(goals: Agg[Task[?]]): Plan = {
     val transitive = Plan.transitiveTargets(goals)
     val topoSorted = Plan.topoSorted(transitive)
 
-    val sortedGroups: MultiBiMap[Task[_], Task[_]] =
+    val sortedGroups: MultiBiMap[Task[?], Task[?]] =
       Plan.groupAroundImportantTargets(topoSorted) {
         // important: all named tasks and those explicitly requested
         case t: NamedTask[Any] => t
@@ -28,20 +28,20 @@ private[mill] object Plan {
    *
    * @see [[Plan.topoSorted]]
    */
-  class TopoSorted(val values: Agg[Task[_]])
+  class TopoSorted(val values: Agg[Task[?]])
 
   def groupAroundImportantTargets[T](topoSortedTargets: TopoSorted)(important: PartialFunction[
-    Task[_],
+    Task[?],
     T
-  ]): MultiBiMap[T, Task[_]] = {
+  ]): MultiBiMap[T, Task[?]] = {
 
-    val output = new MultiBiMap.Mutable[T, Task[_]]()
+    val output = new MultiBiMap.Mutable[T, Task[?]]()
     for (
       (target, t) <- topoSortedTargets.values.flatMap(t => important.lift(t).map((t, _))).iterator
     ) {
 
-      val transitiveTargets = new Agg.Mutable[Task[_]]
-      def rec(t: Task[_]): Unit = {
+      val transitiveTargets = new Agg.Mutable[Task[?]]
+      def rec(t: Task[?]): Unit = {
         if (transitiveTargets.contains(t)) () // do nothing
         else if (important.isDefinedAt(t) && t != target) () // do nothing
         else {
@@ -59,10 +59,10 @@ private[mill] object Plan {
    * Collects all transitive dependencies (targets) of the given targets,
    * including the given targets.
    */
-  def transitiveTargets(sourceTargets: Agg[Task[_]]): Agg[Task[_]] = {
+  def transitiveTargets(sourceTargets: Agg[Task[?]]): Agg[Task[?]] = {
     transitiveNodes(sourceTargets)(_.inputs)
   }
-  def transitiveNamed(sourceTargets: Agg[Task[_]]): Agg[NamedTask[_]] = {
+  def transitiveNamed(sourceTargets: Agg[Task[?]]): Agg[NamedTask[?]] = {
     transitiveTargets(sourceTargets).collect { case t: NamedTask[?] => t }
   }
 
@@ -88,7 +88,7 @@ private[mill] object Plan {
    * Takes the given targets, finds all the targets they transitively depend
    * on, and sort them topologically. Fails if there are dependency cycles
    */
-  def topoSorted(transitiveTargets: Agg[Task[_]]): TopoSorted = {
+  def topoSorted(transitiveTargets: Agg[Task[?]]): TopoSorted = {
 
     val indexed = transitiveTargets.indexed
     val targetIndices = indexed.zipWithIndex.toMap

--- a/core/eval/test/src/mill/eval/Checker.scala
+++ b/core/eval/test/src/mill/eval/Checker.scala
@@ -1,14 +1,9 @@
 package mill.eval
 
-import mill.util.TestUtil.Test
-import mill.define.{Discover, TargetImpl, Task}
-import mill.{T, Module}
-import mill.util.{TestGraphs, TestUtil}
+import mill.define.Task
 import mill.testkit.{TestBaseModule, UnitTester}
 import mill.api.Strict.Agg
-import os.SubPath
 import utest.*
-import utest.framework.TestPath
 
 class Checker[T <: mill.testkit.TestBaseModule](module: T, threadCount: Option[Int] = Some(1)) {
   // Make sure data is persisted even if we re-create the evaluator each time

--- a/core/eval/test/src/mill/eval/Checker.scala
+++ b/core/eval/test/src/mill/eval/Checker.scala
@@ -16,9 +16,9 @@ class Checker[T <: mill.testkit.TestBaseModule](module: T, threadCount: Option[I
   val evaluator = UnitTester(module, null, threads = threadCount).evaluator
 
   def apply(
-      target: Task[_],
+      target: Task[?],
       expValue: Any,
-      expEvaled: Agg[Task[_]],
+      expEvaled: Agg[Task[?]],
       // How many "other" tasks were evaluated other than those listed above.
       // Pass in -1 to skip the check entirely
       extraEvaled: Int = 0,

--- a/core/eval/test/src/mill/eval/CrossTests.scala
+++ b/core/eval/test/src/mill/eval/CrossTests.scala
@@ -37,8 +37,10 @@ object CrossTests extends TestSuite {
 
       val Right(Result("Param Value: a", _)) = check(crossExtension.myCross("a").param1): @unchecked
 
-      val Right(Result("Param Value: a", _)) = check(crossExtension.myCrossExtended("a", 1).param1): @unchecked
-      val Right(Result("Param Value: 2", _)) = check(crossExtension.myCrossExtended("b", 2).param2): @unchecked
+      val Right(Result("Param Value: a", _)) =
+        check(crossExtension.myCrossExtended("a", 1).param1): @unchecked
+      val Right(Result("Param Value: 2", _)) =
+        check(crossExtension.myCrossExtended("b", 2).param2): @unchecked
 
       val Right(Result("Param Value: a", _)) =
         check(crossExtension.myCrossExtendedAgain("a", 1, true).param1): @unchecked
@@ -74,7 +76,8 @@ object CrossTests extends TestSuite {
       val Right(Result("211_js", 1)) = check(doubleCross.cross("211", "js").suffix): @unchecked
       val Right(Result("212_jvm", 1)) = check(doubleCross.cross("212", "jvm").suffix): @unchecked
       val Right(Result("212_js", 1)) = check(doubleCross.cross("212", "js").suffix): @unchecked
-      val Right(Result("212_native", 1)) = check(doubleCross.cross("212", "native").suffix): @unchecked
+      val Right(Result("212_native", 1)) =
+        check(doubleCross.cross("212", "native").suffix): @unchecked
     }
 
     test("innerCrossModule") {
@@ -88,36 +91,55 @@ object CrossTests extends TestSuite {
       val Right(Result("baz b", 1)) = check(innerCrossModule.myCross2("b", 2).baz.bar): @unchecked
       val Right(Result("baz 2", 1)) = check(innerCrossModule.myCross2("b", 2).baz.qux): @unchecked
 
-      val Right(Result("foo a", 1)) = check(innerCrossModule.myCross3("a", 1, true).foo.bar): @unchecked
-      val Right(Result("foo 1", 1)) = check(innerCrossModule.myCross3("a", 1, true).foo.qux): @unchecked
-      val Right(Result("foo true", 1)) = check(innerCrossModule.myCross3("a", 1, true).foo.lol): @unchecked
-      val Right(Result("baz b", 1)) = check(innerCrossModule.myCross3("b", 2, false).baz.bar): @unchecked
-      val Right(Result("baz 2", 1)) = check(innerCrossModule.myCross3("b", 2, false).baz.qux): @unchecked
-      val Right(Result("baz false", 1)) = check(innerCrossModule.myCross3("b", 2, false).baz.lol): @unchecked
+      val Right(Result("foo a", 1)) =
+        check(innerCrossModule.myCross3("a", 1, true).foo.bar): @unchecked
+      val Right(Result("foo 1", 1)) =
+        check(innerCrossModule.myCross3("a", 1, true).foo.qux): @unchecked
+      val Right(Result("foo true", 1)) =
+        check(innerCrossModule.myCross3("a", 1, true).foo.lol): @unchecked
+      val Right(Result("baz b", 1)) =
+        check(innerCrossModule.myCross3("b", 2, false).baz.bar): @unchecked
+      val Right(Result("baz 2", 1)) =
+        check(innerCrossModule.myCross3("b", 2, false).baz.qux): @unchecked
+      val Right(Result("baz false", 1)) =
+        check(innerCrossModule.myCross3("b", 2, false).baz.lol): @unchecked
     }
 
     test("nestedCrosses") {
       val check = UnitTester(nestedCrosses, null)
 
-      val Right(Result("210_jvm", 1)) = check(nestedCrosses.cross("210").cross2("jvm").suffix): @unchecked
-      val Right(Result("210_js", 1)) = check(nestedCrosses.cross("210").cross2("js").suffix): @unchecked
-      val Right(Result("211_jvm", 1)) = check(nestedCrosses.cross("211").cross2("jvm").suffix): @unchecked
-      val Right(Result("211_js", 1)) = check(nestedCrosses.cross("211").cross2("js").suffix): @unchecked
-      val Right(Result("212_jvm", 1)) = check(nestedCrosses.cross("212").cross2("jvm").suffix): @unchecked
-      val Right(Result("212_js", 1)) = check(nestedCrosses.cross("212").cross2("js").suffix): @unchecked
-      val Right(Result("212_native", 1)) = check(nestedCrosses.cross("212").cross2("native").suffix): @unchecked
+      val Right(Result("210_jvm", 1)) =
+        check(nestedCrosses.cross("210").cross2("jvm").suffix): @unchecked
+      val Right(Result("210_js", 1)) =
+        check(nestedCrosses.cross("210").cross2("js").suffix): @unchecked
+      val Right(Result("211_jvm", 1)) =
+        check(nestedCrosses.cross("211").cross2("jvm").suffix): @unchecked
+      val Right(Result("211_js", 1)) =
+        check(nestedCrosses.cross("211").cross2("js").suffix): @unchecked
+      val Right(Result("212_jvm", 1)) =
+        check(nestedCrosses.cross("212").cross2("jvm").suffix): @unchecked
+      val Right(Result("212_js", 1)) =
+        check(nestedCrosses.cross("212").cross2("js").suffix): @unchecked
+      val Right(Result("212_native", 1)) =
+        check(nestedCrosses.cross("212").cross2("native").suffix): @unchecked
     }
 
     test("nestedTaskCrosses") {
       val model = TestGraphs.nestedTaskCrosses
       val check = UnitTester(model, null)
 
-      val Right(Result("210_jvm_1", 1)) = check(model.cross1("210").cross2("jvm").suffixCmd("1")): @unchecked
-      val Right(Result("210_js_2", 1)) = check(model.cross1("210").cross2("js").suffixCmd("2")): @unchecked
-      val Right(Result("211_jvm_3", 1)) = check(model.cross1("211").cross2("jvm").suffixCmd("3")): @unchecked
-      val Right(Result("211_js_4", 1)) = check(model.cross1("211").cross2("js").suffixCmd("4")): @unchecked
-      val Right(Result("212_jvm_5", 1)) = check(model.cross1("212").cross2("jvm").suffixCmd("5")): @unchecked
-      val Right(Result("212_js_6", 1)) = check(model.cross1("212").cross2("js").suffixCmd("6")): @unchecked
+      val Right(Result("210_jvm_1", 1)) =
+        check(model.cross1("210").cross2("jvm").suffixCmd("1")): @unchecked
+      val Right(Result("210_js_2", 1)) =
+        check(model.cross1("210").cross2("js").suffixCmd("2")): @unchecked
+      val Right(Result("211_jvm_3", 1)) =
+        check(model.cross1("211").cross2("jvm").suffixCmd("3")): @unchecked
+      val Right(Result("211_js_4", 1)) =
+        check(model.cross1("211").cross2("js").suffixCmd("4")): @unchecked
+      val Right(Result("212_jvm_5", 1)) =
+        check(model.cross1("212").cross2("jvm").suffixCmd("5")): @unchecked
+      val Right(Result("212_js_6", 1)) =
+        check(model.cross1("212").cross2("js").suffixCmd("6")): @unchecked
       val Right(Result("212_native_7", 1)) =
         check(model.cross1("212").cross2("native").suffixCmd("7")): @unchecked
     }

--- a/core/eval/test/src/mill/eval/CrossTests.scala
+++ b/core/eval/test/src/mill/eval/CrossTests.scala
@@ -19,107 +19,107 @@ object CrossTests extends TestSuite {
     test("singleCross") {
       val check = UnitTester(singleCross, null)
 
-      val Right(Result("210", 1)) = check(singleCross.cross("210").suffix)
-      val Right(Result("211", 1)) = check(singleCross.cross("211").suffix)
-      val Right(Result("212", 1)) = check(singleCross.cross("212").suffix)
+      val Right(Result("210", 1)) = check(singleCross.cross("210").suffix): @unchecked
+      val Right(Result("211", 1)) = check(singleCross.cross("211").suffix): @unchecked
+      val Right(Result("212", 1)) = check(singleCross.cross("212").suffix): @unchecked
     }
 
     test("nonStringCross") {
       val check = UnitTester(nonStringCross, null)
 
-      val Right(Result(210, 1)) = check(nonStringCross.cross(210).suffix)
-      val Right(Result(211, 1)) = check(nonStringCross.cross(211).suffix)
-      val Right(Result(212, 1)) = check(nonStringCross.cross(212).suffix)
+      val Right(Result(210, 1)) = check(nonStringCross.cross(210).suffix): @unchecked
+      val Right(Result(211, 1)) = check(nonStringCross.cross(211).suffix): @unchecked
+      val Right(Result(212, 1)) = check(nonStringCross.cross(212).suffix): @unchecked
     }
 
     test("crossExtension") {
       val check = UnitTester(crossExtension, null)
 
-      val Right(Result("Param Value: a", _)) = check(crossExtension.myCross("a").param1)
+      val Right(Result("Param Value: a", _)) = check(crossExtension.myCross("a").param1): @unchecked
 
-      val Right(Result("Param Value: a", _)) = check(crossExtension.myCrossExtended("a", 1).param1)
-      val Right(Result("Param Value: 2", _)) = check(crossExtension.myCrossExtended("b", 2).param2)
+      val Right(Result("Param Value: a", _)) = check(crossExtension.myCrossExtended("a", 1).param1): @unchecked
+      val Right(Result("Param Value: 2", _)) = check(crossExtension.myCrossExtended("b", 2).param2): @unchecked
 
       val Right(Result("Param Value: a", _)) =
-        check(crossExtension.myCrossExtendedAgain("a", 1, true).param1)
+        check(crossExtension.myCrossExtendedAgain("a", 1, true).param1): @unchecked
 
       val Right(Result("Param Value: 2", _)) =
-        check(crossExtension.myCrossExtendedAgain("b", 2, false).param2)
+        check(crossExtension.myCrossExtendedAgain("b", 2, false).param2): @unchecked
 
       val Right(Result("Param Value: true", _)) =
-        check(crossExtension.myCrossExtendedAgain("a", 1, true).param3)
+        check(crossExtension.myCrossExtendedAgain("a", 1, true).param3): @unchecked
 
       val Right(Result("Param Value: false", _)) =
-        check(crossExtension.myCrossExtendedAgain("b", 2, false).param3)
+        check(crossExtension.myCrossExtendedAgain("b", 2, false).param3): @unchecked
     }
 
     test("crossResolved") {
       val check = UnitTester(crossResolved, null)
 
-      val Right(Result("2.10", 1)) = check(crossResolved.foo("2.10").suffix)
-      val Right(Result("2.11", 1)) = check(crossResolved.foo("2.11").suffix)
-      val Right(Result("2.12", 1)) = check(crossResolved.foo("2.12").suffix)
+      val Right(Result("2.10", 1)) = check(crossResolved.foo("2.10").suffix): @unchecked
+      val Right(Result("2.11", 1)) = check(crossResolved.foo("2.11").suffix): @unchecked
+      val Right(Result("2.12", 1)) = check(crossResolved.foo("2.12").suffix): @unchecked
 
-      val Right(Result("_2.10", 1)) = check(crossResolved.bar("2.10").longSuffix)
-      val Right(Result("_2.11", 1)) = check(crossResolved.bar("2.11").longSuffix)
-      val Right(Result("_2.12", 1)) = check(crossResolved.bar("2.12").longSuffix)
+      val Right(Result("_2.10", 1)) = check(crossResolved.bar("2.10").longSuffix): @unchecked
+      val Right(Result("_2.11", 1)) = check(crossResolved.bar("2.11").longSuffix): @unchecked
+      val Right(Result("_2.12", 1)) = check(crossResolved.bar("2.12").longSuffix): @unchecked
     }
 
     test("doubleCross") {
       val check = UnitTester(doubleCross, null)
 
-      val Right(Result("210_jvm", 1)) = check(doubleCross.cross("210", "jvm").suffix)
-      val Right(Result("210_js", 1)) = check(doubleCross.cross("210", "js").suffix)
-      val Right(Result("211_jvm", 1)) = check(doubleCross.cross("211", "jvm").suffix)
-      val Right(Result("211_js", 1)) = check(doubleCross.cross("211", "js").suffix)
-      val Right(Result("212_jvm", 1)) = check(doubleCross.cross("212", "jvm").suffix)
-      val Right(Result("212_js", 1)) = check(doubleCross.cross("212", "js").suffix)
-      val Right(Result("212_native", 1)) = check(doubleCross.cross("212", "native").suffix)
+      val Right(Result("210_jvm", 1)) = check(doubleCross.cross("210", "jvm").suffix): @unchecked
+      val Right(Result("210_js", 1)) = check(doubleCross.cross("210", "js").suffix): @unchecked
+      val Right(Result("211_jvm", 1)) = check(doubleCross.cross("211", "jvm").suffix): @unchecked
+      val Right(Result("211_js", 1)) = check(doubleCross.cross("211", "js").suffix): @unchecked
+      val Right(Result("212_jvm", 1)) = check(doubleCross.cross("212", "jvm").suffix): @unchecked
+      val Right(Result("212_js", 1)) = check(doubleCross.cross("212", "js").suffix): @unchecked
+      val Right(Result("212_native", 1)) = check(doubleCross.cross("212", "native").suffix): @unchecked
     }
 
     test("innerCrossModule") {
       val check = UnitTester(innerCrossModule, null)
 
-      val Right(Result("foo a", 1)) = check(innerCrossModule.myCross("a").foo.bar)
-      val Right(Result("baz b", 1)) = check(innerCrossModule.myCross("b").baz.bar)
+      val Right(Result("foo a", 1)) = check(innerCrossModule.myCross("a").foo.bar): @unchecked
+      val Right(Result("baz b", 1)) = check(innerCrossModule.myCross("b").baz.bar): @unchecked
 
-      val Right(Result("foo a", 1)) = check(innerCrossModule.myCross2("a", 1).foo.bar)
-      val Right(Result("foo 1", 1)) = check(innerCrossModule.myCross2("a", 1).foo.qux)
-      val Right(Result("baz b", 1)) = check(innerCrossModule.myCross2("b", 2).baz.bar)
-      val Right(Result("baz 2", 1)) = check(innerCrossModule.myCross2("b", 2).baz.qux)
+      val Right(Result("foo a", 1)) = check(innerCrossModule.myCross2("a", 1).foo.bar): @unchecked
+      val Right(Result("foo 1", 1)) = check(innerCrossModule.myCross2("a", 1).foo.qux): @unchecked
+      val Right(Result("baz b", 1)) = check(innerCrossModule.myCross2("b", 2).baz.bar): @unchecked
+      val Right(Result("baz 2", 1)) = check(innerCrossModule.myCross2("b", 2).baz.qux): @unchecked
 
-      val Right(Result("foo a", 1)) = check(innerCrossModule.myCross3("a", 1, true).foo.bar)
-      val Right(Result("foo 1", 1)) = check(innerCrossModule.myCross3("a", 1, true).foo.qux)
-      val Right(Result("foo true", 1)) = check(innerCrossModule.myCross3("a", 1, true).foo.lol)
-      val Right(Result("baz b", 1)) = check(innerCrossModule.myCross3("b", 2, false).baz.bar)
-      val Right(Result("baz 2", 1)) = check(innerCrossModule.myCross3("b", 2, false).baz.qux)
-      val Right(Result("baz false", 1)) = check(innerCrossModule.myCross3("b", 2, false).baz.lol)
+      val Right(Result("foo a", 1)) = check(innerCrossModule.myCross3("a", 1, true).foo.bar): @unchecked
+      val Right(Result("foo 1", 1)) = check(innerCrossModule.myCross3("a", 1, true).foo.qux): @unchecked
+      val Right(Result("foo true", 1)) = check(innerCrossModule.myCross3("a", 1, true).foo.lol): @unchecked
+      val Right(Result("baz b", 1)) = check(innerCrossModule.myCross3("b", 2, false).baz.bar): @unchecked
+      val Right(Result("baz 2", 1)) = check(innerCrossModule.myCross3("b", 2, false).baz.qux): @unchecked
+      val Right(Result("baz false", 1)) = check(innerCrossModule.myCross3("b", 2, false).baz.lol): @unchecked
     }
 
     test("nestedCrosses") {
       val check = UnitTester(nestedCrosses, null)
 
-      val Right(Result("210_jvm", 1)) = check(nestedCrosses.cross("210").cross2("jvm").suffix)
-      val Right(Result("210_js", 1)) = check(nestedCrosses.cross("210").cross2("js").suffix)
-      val Right(Result("211_jvm", 1)) = check(nestedCrosses.cross("211").cross2("jvm").suffix)
-      val Right(Result("211_js", 1)) = check(nestedCrosses.cross("211").cross2("js").suffix)
-      val Right(Result("212_jvm", 1)) = check(nestedCrosses.cross("212").cross2("jvm").suffix)
-      val Right(Result("212_js", 1)) = check(nestedCrosses.cross("212").cross2("js").suffix)
-      val Right(Result("212_native", 1)) = check(nestedCrosses.cross("212").cross2("native").suffix)
+      val Right(Result("210_jvm", 1)) = check(nestedCrosses.cross("210").cross2("jvm").suffix): @unchecked
+      val Right(Result("210_js", 1)) = check(nestedCrosses.cross("210").cross2("js").suffix): @unchecked
+      val Right(Result("211_jvm", 1)) = check(nestedCrosses.cross("211").cross2("jvm").suffix): @unchecked
+      val Right(Result("211_js", 1)) = check(nestedCrosses.cross("211").cross2("js").suffix): @unchecked
+      val Right(Result("212_jvm", 1)) = check(nestedCrosses.cross("212").cross2("jvm").suffix): @unchecked
+      val Right(Result("212_js", 1)) = check(nestedCrosses.cross("212").cross2("js").suffix): @unchecked
+      val Right(Result("212_native", 1)) = check(nestedCrosses.cross("212").cross2("native").suffix): @unchecked
     }
 
     test("nestedTaskCrosses") {
       val model = TestGraphs.nestedTaskCrosses
       val check = UnitTester(model, null)
 
-      val Right(Result("210_jvm_1", 1)) = check(model.cross1("210").cross2("jvm").suffixCmd("1"))
-      val Right(Result("210_js_2", 1)) = check(model.cross1("210").cross2("js").suffixCmd("2"))
-      val Right(Result("211_jvm_3", 1)) = check(model.cross1("211").cross2("jvm").suffixCmd("3"))
-      val Right(Result("211_js_4", 1)) = check(model.cross1("211").cross2("js").suffixCmd("4"))
-      val Right(Result("212_jvm_5", 1)) = check(model.cross1("212").cross2("jvm").suffixCmd("5"))
-      val Right(Result("212_js_6", 1)) = check(model.cross1("212").cross2("js").suffixCmd("6"))
+      val Right(Result("210_jvm_1", 1)) = check(model.cross1("210").cross2("jvm").suffixCmd("1")): @unchecked
+      val Right(Result("210_js_2", 1)) = check(model.cross1("210").cross2("js").suffixCmd("2")): @unchecked
+      val Right(Result("211_jvm_3", 1)) = check(model.cross1("211").cross2("jvm").suffixCmd("3")): @unchecked
+      val Right(Result("211_js_4", 1)) = check(model.cross1("211").cross2("js").suffixCmd("4")): @unchecked
+      val Right(Result("212_jvm_5", 1)) = check(model.cross1("212").cross2("jvm").suffixCmd("5")): @unchecked
+      val Right(Result("212_js_6", 1)) = check(model.cross1("212").cross2("js").suffixCmd("6")): @unchecked
       val Right(Result("212_native_7", 1)) =
-        check(model.cross1("212").cross2("native").suffixCmd("7"))
+        check(model.cross1("212").cross2("native").suffixCmd("7")): @unchecked
     }
   }
 }

--- a/core/eval/test/src/mill/eval/EvaluationTests.scala
+++ b/core/eval/test/src/mill/eval/EvaluationTests.scala
@@ -2,13 +2,10 @@ package mill.eval
 
 import mill.util.TestUtil.Test
 import mill.define.{Discover, TargetImpl, Task}
-import mill.{T, Module}
 import mill.util.{TestGraphs, TestUtil}
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.TestBaseModule
 import mill.api.Strict.Agg
-import os.SubPath
 import utest.*
-import utest.framework.TestPath
 
 object EvaluationTestsThreads1 extends EvaluationTests(threadCount = Some(1))
 object EvaluationTestsThreads4 extends EvaluationTests(threadCount = Some(3))

--- a/core/eval/test/src/mill/eval/EvaluationTests.scala
+++ b/core/eval/test/src/mill/eval/EvaluationTests.scala
@@ -165,14 +165,14 @@ class EvaluationTests(threadCount: Option[Int]) extends TestSuite {
         import separateGroups._
         val checker = new Checker(separateGroups)
         val evaled1 = checker.evaluator.evaluate(Agg(right, left))
-        val filtered1 = evaled1.evaluated.filter(_.isInstanceOf[TargetImpl[_]])
+        val filtered1 = evaled1.evaluated.filter(_.isInstanceOf[TargetImpl[?]])
         assert(filtered1.toSeq.sortBy(_.toString) == Seq(change, left, right).sortBy(_.toString))
         val evaled2 = checker.evaluator.evaluate(Agg(right, left))
-        val filtered2 = evaled2.evaluated.filter(_.isInstanceOf[TargetImpl[_]])
+        val filtered2 = evaled2.evaluated.filter(_.isInstanceOf[TargetImpl[?]])
         assert(filtered2 == Agg())
         change.counter += 1
         val evaled3 = checker.evaluator.evaluate(Agg(right, left))
-        val filtered3 = evaled3.evaluated.filter(_.isInstanceOf[TargetImpl[_]])
+        val filtered3 = evaled3.evaluated.filter(_.isInstanceOf[TargetImpl[?]])
         assert(filtered3 == Agg(change, right))
 
       }

--- a/core/eval/test/src/mill/eval/FailureTests.scala
+++ b/core/eval/test/src/mill/eval/FailureTests.scala
@@ -1,6 +1,6 @@
 package mill.eval
 
-import mill.{T, Task}
+import mill.Task
 import mill.testkit.UnitTester
 import mill.testkit.TestBaseModule
 import mill.api.Result.OuterStack

--- a/core/eval/test/src/mill/eval/JavaCompileJarTests.scala
+++ b/core/eval/test/src/mill/eval/JavaCompileJarTests.scala
@@ -77,7 +77,7 @@ object JavaCompileJarTests extends TestSuite {
         sourceRoot = javacSrcPath
       )
       def eval[T](t: Task[T]) = evaluator.apply(t)
-      def check(targets: Agg[Task[_]], expected: Agg[Task[_]]) = evaluator.check(targets, expected)
+      def check(targets: Agg[Task[?]], expected: Agg[Task[?]]) = evaluator.check(targets, expected)
 
       def append(path: os.SubPath, txt: String) = os.write.append(millSourcePath / path, txt)
 
@@ -174,14 +174,14 @@ object JavaCompileJarTests extends TestSuite {
       for (i <- 0 until 3) {
         // Build.run is not cached, so every time we eval it, it has to
         // re-evaluate
-        val Right(result) = eval(Build.run("test.Foo"))
+        val Right(result) = eval(Build.run("test.Foo")): @unchecked
         assert(
           result.value.out.text() == s"${31337 + 271828}${System.lineSeparator}",
           result.evalCount == 1
         )
       }
 
-      val Left(mill.api.Result.Exception(ex, _)) = eval(Build.run("test.BarFour"))
+      val Left(mill.api.Result.Exception(ex, _)) = eval(Build.run("test.BarFour")): @unchecked
 
       assert(ex.getMessage.contains("Could not find or load main class"))
 
@@ -195,12 +195,12 @@ object JavaCompileJarTests extends TestSuite {
         }
         """
       )
-      val Right(result2) = eval(Build.run("test.BarFour"))
+      val Right(result2) = eval(Build.run("test.BarFour")): @unchecked
       assert(
         result2.value.out.text() == "New Cls!" + System.lineSeparator,
         result2.evalCount == 3
       )
-      val Right(result3) = eval(Build.run("test.BarFour"))
+      val Right(result3) = eval(Build.run("test.BarFour")): @unchecked
       assert(
         result3.value.out.text() == "New Cls!" + System.lineSeparator,
         result3.evalCount == 1

--- a/core/eval/test/src/mill/eval/JavaCompileJarTests.scala
+++ b/core/eval/test/src/mill/eval/JavaCompileJarTests.scala
@@ -1,8 +1,7 @@
 package mill.eval
 
-import mill.util.{Jvm, TestUtil}
+import mill.util.Jvm
 import mill.api.Ctx.Dest
-import mill.{T, Task}
 import mill.testkit.UnitTester
 import mill.testkit.TestBaseModule
 import mill.api.Strict.Agg
@@ -10,7 +9,6 @@ import mill.api.{JarManifest, Loose}
 import utest.*
 import mill.*
 import mill.define.{Discover, Task}
-import mill.main.TokenReaders.*
 
 object JavaCompileJarTests extends TestSuite {
   def compileAll(sources: mill.api.Loose.Agg[mill.api.PathRef])(implicit ctx: Dest) = {

--- a/core/eval/test/src/mill/eval/ModuleTests.scala
+++ b/core/eval/test/src/mill/eval/ModuleTests.scala
@@ -3,7 +3,7 @@ package mill.eval
 import mill.testkit.UnitTester
 import mill.testkit.UnitTester.Result
 import mill.testkit.TestBaseModule
-import mill.{T, Task}
+import mill.Task
 import mill.define.Discover
 
 import utest._

--- a/core/eval/test/src/mill/eval/OverrideTests.scala
+++ b/core/eval/test/src/mill/eval/OverrideTests.scala
@@ -1,14 +1,11 @@
 package mill.eval
 
-import mill.util.TestUtil.Test
 import mill.define.{Discover, TargetImpl, Task}
-import mill.{T, Module}
-import mill.util.{TestGraphs, TestUtil}
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.Module
+import mill.util.TestGraphs
+import mill.testkit.TestBaseModule
 import mill.api.Strict.Agg
-import os.SubPath
 import utest.*
-import utest.framework.TestPath
 
 object OverrideTests extends TestSuite {
   trait BaseModule extends Module {
@@ -95,7 +92,6 @@ object OverrideTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
   val tests = Tests {
-    import TestGraphs._
     import utest._
 
     test("overrideSuperTask") {

--- a/core/eval/test/src/mill/eval/OverrideTests.scala
+++ b/core/eval/test/src/mill/eval/OverrideTests.scala
@@ -2,7 +2,6 @@ package mill.eval
 
 import mill.define.{Discover, TargetImpl, Task}
 import mill.Module
-import mill.util.TestGraphs
 import mill.testkit.TestBaseModule
 import mill.api.Strict.Agg
 import utest.*

--- a/core/eval/test/src/mill/eval/PlanTests.scala
+++ b/core/eval/test/src/mill/eval/PlanTests.scala
@@ -13,7 +13,7 @@ object PlanTests extends TestSuite {
     import TestGraphs._
 
     test("topoSortedTransitiveTargets") {
-      def check(targets: Agg[Task[_]], expected: Agg[Task[_]]) = {
+      def check(targets: Agg[Task[?]], expected: Agg[Task[?]]) = {
         val result = Plan.topoSorted(Plan.transitiveTargets(targets)).values
         TestUtil.checkTopological(result)
         assert(result == expected)
@@ -58,7 +58,7 @@ object PlanTests extends TestSuite {
     test("groupAroundNamedTargets") {
       def check[T, R <: Target[Int]](base: T)(
           target: T => R,
-          important0: Agg[T => Target[_]],
+          important0: Agg[T => Target[?]],
           expected: Agg[(R, Int)]
       ) = {
 
@@ -66,7 +66,7 @@ object PlanTests extends TestSuite {
 
         val important = important0.map(_(base))
         val grouped = Plan.groupAroundImportantTargets(topoSorted) {
-          case t: TargetImpl[_] if important.contains(t) => t: Target[_]
+          case t: TargetImpl[_] if important.contains(t) => t: Target[?]
         }
         val flattened = Agg.from(grouped.values().flatMap(_.items))
 
@@ -75,7 +75,7 @@ object PlanTests extends TestSuite {
           val grouping = grouped.lookupKey(terminal)
           assert(
             grouping.size == expectedSize,
-            grouping.flatMap(_.asTarget: Option[Target[_]]).filter(important.contains) == Agg(
+            grouping.flatMap(_.asTarget: Option[Target[?]]).filter(important.contains) == Agg(
               terminal
             )
           )
@@ -138,7 +138,7 @@ object PlanTests extends TestSuite {
       )
     }
     test("multiTerminalGroupCounts") {
-      def countGroups(goals: Task[_]*) = {
+      def countGroups(goals: Task[?]*) = {
 
         val topoSorted = Plan.topoSorted(
           Plan.transitiveTargets(Agg.from(goals))

--- a/core/eval/test/src/mill/eval/TaskTests.scala
+++ b/core/eval/test/src/mill/eval/TaskTests.scala
@@ -48,7 +48,7 @@ trait TaskTests extends TestSuite {
         def apply(v1: Int) = input() + v1
       }
     }
-    def noisyClosableWorker: Worker[(Int => Int) with AutoCloseable] = Task.Worker {
+    def noisyClosableWorker: Worker[(Int => Int) & AutoCloseable] = Task.Worker {
       new Function1[Int, Int] with AutoCloseable {
         override def apply(v1: Int) = input() + v1
         override def close(): Unit = workerCloseCount += 1

--- a/core/eval/test/src/mill/eval/TaskTests.scala
+++ b/core/eval/test/src/mill/eval/TaskTests.scala
@@ -1,7 +1,7 @@
 package mill.eval
 
 import utest.*
-import mill.{T, Task}
+import mill.Task
 import mill.define.{Discover, Module, Worker}
 import mill.testkit.UnitTester
 import mill.testkit.UnitTester.Result

--- a/core/internal/src/mill/internal/FileLogger.scala
+++ b/core/internal/src/mill/internal/FileLogger.scala
@@ -12,7 +12,7 @@ class FileLogger(
     append: Boolean = false
 ) extends Logger {
   override def toString: String = s"FileLogger($file)"
-  private[this] var outputStreamUsed: Boolean = false
+  private var outputStreamUsed: Boolean = false
 
   lazy val fileStream: PrintStream = {
 
@@ -29,7 +29,7 @@ class FileLogger(
     lazy val inner = {
       if (!os.exists(file / os.up)) os.makeDir.all(file / os.up)
       folderCreated = true
-      Files.newOutputStream(file.toNIO, options: _*)
+      Files.newOutputStream(file.toNIO, options*)
     }
     new PrintStream(new OutputStream {
       override def write(b: Int): Unit = inner.write(b)

--- a/core/internal/src/mill/internal/LinePrefixOutputStream.scala
+++ b/core/internal/src/mill/internal/LinePrefixOutputStream.scala
@@ -16,9 +16,9 @@ class LinePrefixOutputStream(
     reportPrefix: () => Unit
 ) extends FilterOutputStream(out) {
   def this(linePrefix: String, out: OutputStream) = this(linePrefix, out, () => ())
-  private[this] val linePrefixBytes = linePrefix.getBytes("UTF-8")
-  private[this] val linePrefixNonEmpty = linePrefixBytes.length != 0
-  private[this] var isNewLine = true
+  private val linePrefixBytes = linePrefix.getBytes("UTF-8")
+  private val linePrefixNonEmpty = linePrefixBytes.length != 0
+  private var isNewLine = true
   val buffer = new ByteArrayOutputStream()
 
   // Make sure we preserve the end-of-line ANSI colors every time we write out the buffer, and
@@ -26,7 +26,7 @@ class LinePrefixOutputStream(
   // not muck up the rendering of color sequences that affect multiple lines in the terminal
   private var endOfLastLineColor: Long = 0
   override def write(b: Array[Byte]): Unit = write(b, 0, b.length)
-  private[this] def writeLinePrefixIfNecessary(): Unit = {
+  private def writeLinePrefixIfNecessary(): Unit = {
     if (isNewLine && linePrefixNonEmpty) {
       isNewLine = false
       buffer.write(linePrefixBytes)

--- a/core/internal/src/mill/internal/MultiBiMap.scala
+++ b/core/internal/src/mill/internal/MultiBiMap.scala
@@ -26,8 +26,8 @@ trait MultiBiMap[K, V] {
 object MultiBiMap {
 
   class Mutable[K, V]() extends MultiBiMap[K, V] {
-    private[this] val valueToKey = mutable.LinkedHashMap.empty[V, K]
-    private[this] val keyToValues = mutable.LinkedHashMap.empty[K, Agg.Mutable[V]]
+    private val valueToKey = mutable.LinkedHashMap.empty[V, K]
+    private val keyToValues = mutable.LinkedHashMap.empty[K, Agg.Mutable[V]]
     def containsValue(v: V): Boolean = valueToKey.contains(v)
     def lookupKey(k: K): Agg.Mutable[V] = keyToValues(k)
     def lookupKeyOpt(k: K): Option[Agg.Mutable[V]] = keyToValues.get(k)

--- a/core/internal/src/mill/internal/PrintLogger.scala
+++ b/core/internal/src/mill/internal/PrintLogger.scala
@@ -94,7 +94,7 @@ object PrintLogger {
   class StateStream(wrapped: OutputStream, setprintLoggerState0: State.Value => Unit)
       extends OutputStream {
 
-    private[this] def setprintLoggerState(c: Char) = setprintLoggerState0(
+    private def setprintLoggerState(c: Char) = setprintLoggerState0(
       c match {
         case '\n' => State.Newline
         case '\r' => State.Newline

--- a/core/internal/src/mill/internal/PromptLoggerUtil.scala
+++ b/core/internal/src/mill/internal/PromptLoggerUtil.scala
@@ -66,7 +66,7 @@ private object PromptLoggerUtil {
 
   def readTerminalDims(terminfoPath: os.Path): Option[(Option[Int], Option[Int])] = {
     try {
-      val s"$termWidth0 $termHeight0" = os.read(terminfoPath)
+      val s"$termWidth0 $termHeight0" = os.read(terminfoPath): @unchecked
       Some(
         Tuple2(
           termWidth0.toInt match {

--- a/core/internal/test/src/mill/internal/PromptLoggerTests.scala
+++ b/core/internal/test/src/mill/internal/PromptLoggerTests.scala
@@ -2,7 +2,6 @@ package mill.internal
 
 import mill.api.SystemStreams
 import mill.main.client.ProxyStream
-import mill.internal.{PrefixLogger, PromptLogger, TestTerminal}
 import utest.*
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, PrintStream}

--- a/core/internal/test/src/mill/internal/PromptLoggerUtilTests.scala
+++ b/core/internal/test/src/mill/internal/PromptLoggerUtilTests.scala
@@ -144,7 +144,7 @@ object PromptLoggerUtilTests extends TestSuite {
           startTimeMillis = now - 1337000,
           headerPrefix = "123/456",
           titleText = titleText,
-          statuses = SortedMap(statuses.map { case (k, v) => (k.toString, v) }: _*),
+          statuses = SortedMap(statuses.map { case (k, v) => (k.toString, v) }*),
           interactive = interactive,
           infoColor = fansi.Attrs.Empty
         )

--- a/core/resolve/src/mill/resolve/Resolve.scala
+++ b/core/resolve/src/mill/resolve/Resolve.scala
@@ -113,11 +113,11 @@ object Resolve {
       r: Resolved.NamedTask,
       p: Module,
       cache: ResolveCore.Cache
-  ): Either[String, NamedTask[_]] = {
+  ): Either[String, NamedTask[?]] = {
     val definition = Reflect
       .reflect(
         p.getClass,
-        classOf[NamedTask[_]],
+        classOf[NamedTask[?]],
         _ == r.segments.last.value,
         true,
         getMethods = cache.getMethods
@@ -125,7 +125,7 @@ object Resolve {
       .head
 
     ResolveCore.catchWrapException(
-      definition.invoke(p).asInstanceOf[NamedTask[_]]
+      definition.invoke(p).asInstanceOf[NamedTask[?]]
     )
   }
 
@@ -158,14 +158,14 @@ object Resolve {
       rest: Seq[String],
       nullCommandDefaults: Boolean,
       allowPositionalCommandArgs: Boolean
-  ): Option[Either[String, Command[_]]] = for {
+  ): Option[Either[String, Command[?]]] = for {
     ep <- discover.resolveEntrypoint(target.getClass, name)
   } yield {
     def withNullDefault(a: mainargs.ArgSig): mainargs.ArgSig = {
       if (a.default.nonEmpty) a
       else if (nullCommandDefaults) {
         a.copy(default =
-          if (a.reader.isInstanceOf[SimpleTaskTokenReader[_]])
+          if (a.reader.isInstanceOf[SimpleTaskTokenReader[?]])
             Some(_ => mill.define.Task.Anon(null))
           else Some(_ => null)
         )
@@ -183,7 +183,7 @@ object Resolve {
       allowRepeats = false,
       allowLeftover = ep.argSigs0.exists(_.reader.isLeftover),
       nameMapper = mainargs.Util.kebabCaseNameMapper
-    ).flatMap { (grouped: TokenGrouping[_]) =>
+    ).flatMap { (grouped: TokenGrouping[?]) =>
       val mainData = ep.asInstanceOf[MainData[Any, Any]]
       val mainDataWithDefaults = mainData
         .copy(argSigs0 = mainData.argSigs0.map(withNullDefault))

--- a/core/resolve/test/src/mill/resolve/Checker.scala
+++ b/core/resolve/test/src/mill/resolve/Checker.scala
@@ -11,13 +11,13 @@ class Checker[T <: mill.define.BaseModule](module: T) {
 
   def apply(
       selectorString: String,
-      expected0: Either[String, Set[T => NamedTask[_]]],
+      expected0: Either[String, Set[T => NamedTask[?]]],
       expectedMetadata: Set[String] = Set()
   ) = checkSeq(Seq(selectorString), expected0, expectedMetadata)
 
   def checkSeq(
       selectorStrings: Seq[String],
-      expected0: Either[String, Set[T => NamedTask[_]]],
+      expected0: Either[String, Set[T => NamedTask[?]]],
       expectedMetadata: Set[String] = Set()
   ) = {
     val expected = expected0.map(_.map(_(module)))
@@ -38,7 +38,7 @@ class Checker[T <: mill.define.BaseModule](module: T) {
 
   def checkSeq0(
       selectorStrings: Seq[String],
-      check: Either[String, List[NamedTask[_]]] => Boolean,
+      check: Either[String, List[NamedTask[?]]] => Boolean,
       checkMetadata: Either[String, List[String]] => Boolean = _ => true
   ) = {
 

--- a/core/resolve/test/src/mill/resolve/Checker.scala
+++ b/core/resolve/test/src/mill/resolve/Checker.scala
@@ -1,10 +1,6 @@
 package mill.resolve
 
-import mill.define.{Discover, ModuleRef, NamedTask, TaskModule}
-import mill.testkit.TestBaseModule
-import mill.util.TestGraphs
-import mill.util.TestGraphs.*
-import mill.{Cross, Module, Task}
+import mill.define.NamedTask
 import utest.*
 
 class Checker[T <: mill.define.BaseModule](module: T) {

--- a/core/resolve/test/src/mill/resolve/ErrorTests.scala
+++ b/core/resolve/test/src/mill/resolve/ErrorTests.scala
@@ -206,7 +206,7 @@ object ErrorTests extends TestSuite {
     }
   }
 
-  def isShortError(x: Either[String, _], s: String) =
+  def isShortError(x: Either[String, ?], s: String) =
     x.left.exists(_.contains(s)) &&
       // Make sure the stack traces are truncated and short-ish, and do not
       // contain the entire Mill internal call stack at point of failure

--- a/core/resolve/test/src/mill/resolve/ErrorTests.scala
+++ b/core/resolve/test/src/mill/resolve/ErrorTests.scala
@@ -1,6 +1,6 @@
 package mill.resolve
 
-import mill.define.{Discover, ModuleRef, NamedTask, TaskModule}
+import mill.define.{Discover, ModuleRef}
 import mill.testkit.TestBaseModule
 import mainargs.arg
 import mill.{Cross, Module, Task}

--- a/core/resolve/test/src/mill/resolve/ExpandBracesTests.scala
+++ b/core/resolve/test/src/mill/resolve/ExpandBracesTests.scala
@@ -7,7 +7,7 @@ object ExpandBracesTests extends TestSuite {
   val tests = Tests {
     test("expandBraces") {
       def check(input: String, expectedExpansion: List[String]) = {
-        val Right(expanded) = ExpandBraces.expandBraces(input)
+        val Right(expanded) = ExpandBraces.expandBraces(input): @unchecked
 
         assert(expanded == expectedExpansion)
       }
@@ -50,7 +50,7 @@ object ExpandBracesTests extends TestSuite {
         val malformed = Seq("core.{compile", "core.{compile,test]")
 
         malformed.foreach { m =>
-          val Left(error) = ExpandBraces.expandBraces(m)
+          val Left(error) = ExpandBraces.expandBraces(m): @unchecked
           assert(error.contains("Parsing exception"))
         }
       }

--- a/core/resolve/test/src/mill/resolve/ModuleTests.scala
+++ b/core/resolve/test/src/mill/resolve/ModuleTests.scala
@@ -162,8 +162,6 @@ object ModuleTests extends TestSuite {
       x.left.exists(_.linesIterator.size < 25)
 
   val tests = Tests {
-    val graphs = new mill.util.TestGraphs()
-
     test("cross") {
       test("single") {
         val check = new Checker(singleCross)

--- a/core/resolve/test/src/mill/resolve/ModuleTests.scala
+++ b/core/resolve/test/src/mill/resolve/ModuleTests.scala
@@ -163,7 +163,6 @@ object ModuleTests extends TestSuite {
 
   val tests = Tests {
     val graphs = new mill.util.TestGraphs()
-    import graphs.*
 
     test("cross") {
       test("single") {

--- a/core/resolve/test/src/mill/resolve/ModuleTests.scala
+++ b/core/resolve/test/src/mill/resolve/ModuleTests.scala
@@ -155,7 +155,7 @@ object ModuleTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  def isShortError(x: Either[String, _], s: String) =
+  def isShortError(x: Either[String, ?], s: String) =
     x.left.exists(_.contains(s)) &&
       // Make sure the stack traces are truncated and short-ish, and do not
       // contain the entire Mill internal call stack at point of failure
@@ -503,8 +503,8 @@ object ModuleTests extends TestSuite {
       val check = new Checker(duplicates)
 
       def segments(
-          found: Either[String, List[NamedTask[_]]],
-          expected: Either[String, List[NamedTask[_]]]
+          found: Either[String, List[NamedTask[?]]],
+          expected: Either[String, List[NamedTask[?]]]
       ) = {
         found.map(_.map(_.ctx.segments)) == expected.map(_.map(_.ctx.segments))
       }

--- a/core/resolve/test/src/mill/resolve/ParseArgsTests.scala
+++ b/core/resolve/test/src/mill/resolve/ParseArgsTests.scala
@@ -95,7 +95,7 @@ object ParseArgsTests extends TestSuite {
           multiSelect: Boolean
       ) = {
         val Right((selectors0, args) :: _) =
-          ParseArgs(input, if (multiSelect) SelectMode.Multi else SelectMode.Separated)
+          ParseArgs(input, if (multiSelect) SelectMode.Multi else SelectMode.Separated): @unchecked
 
         val selectors = selectors0.map {
           case (Some(v1), Some(v2)) => (Some(v1.value), v2.value)
@@ -233,7 +233,7 @@ object ParseArgsTests extends TestSuite {
           input: Seq[String],
           expectedSelectorArgPairs: Seq[(Seq[(Option[Seq[Segment]], Seq[Segment])], Seq[String])]
       ) = {
-        val Right(parsed) = ParseArgs(input, selectMode)
+        val Right(parsed) = ParseArgs(input, selectMode): @unchecked
         val actual = parsed.map {
           case (selectors0, args) =>
             val selectors = selectors0.map {

--- a/core/resolve/test/src/mill/resolve/ResolveTests.scala
+++ b/core/resolve/test/src/mill/resolve/ResolveTests.scala
@@ -1,10 +1,10 @@
 package mill.resolve
 
-import mill.define.{Discover, NamedTask, TaskModule, ModuleRef}
+import mill.define.Discover
 import mill.util.TestGraphs
 import mill.util.TestGraphs._
 import mill.testkit.TestBaseModule
-import mill.{Task, Module, Cross}
+import mill.{Task, Module}
 import utest._
 object ResolveTests extends TestSuite {
 

--- a/core/resolve/test/src/mill/resolve/ResolveTests.scala
+++ b/core/resolve/test/src/mill/resolve/ResolveTests.scala
@@ -20,7 +20,7 @@ object ResolveTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  def isShortError(x: Either[String, _], s: String) =
+  def isShortError(x: Either[String, ?], s: String) =
     x.left.exists(_.contains(s)) &&
       // Make sure the stack traces are truncated and short-ish, and do not
       // contain the entire Mill internal call stack at point of failure

--- a/core/resolve/test/src/mill/resolve/TypeSelectorTests.scala
+++ b/core/resolve/test/src/mill/resolve/TypeSelectorTests.scala
@@ -73,7 +73,7 @@ object TypeSelectorTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  def isShortError(x: Either[String, _], s: String) =
+  def isShortError(x: Either[String, ?], s: String) =
     x.left.exists(_.contains(s)) &&
       // Make sure the stack traces are truncated and short-ish, and do not
       // contain the entire Mill internal call stack at point of failure

--- a/core/resolve/test/src/mill/resolve/TypeSelectorTests.scala
+++ b/core/resolve/test/src/mill/resolve/TypeSelectorTests.scala
@@ -79,7 +79,6 @@ object TypeSelectorTests extends TestSuite {
       x.left.exists(_.linesIterator.size < 25)
 
   val tests = Tests {
-    val graphs = new mill.util.TestGraphs()
     test("typeSelector") {
       val check = new Checker(TypedModules)
       test - check(

--- a/core/resolve/test/src/mill/resolve/TypeSelectorTests.scala
+++ b/core/resolve/test/src/mill/resolve/TypeSelectorTests.scala
@@ -2,7 +2,6 @@ package mill.resolve
 
 import mill.define.Discover
 import mill.testkit.TestBaseModule
-import mill.util.TestGraphs
 import mill.{Cross, Module, Task}
 import utest.*
 

--- a/core/resolve/test/src/mill/resolve/TypeSelectorTests.scala
+++ b/core/resolve/test/src/mill/resolve/TypeSelectorTests.scala
@@ -1,9 +1,8 @@
 package mill.resolve
 
-import mill.define.{Discover, ModuleRef, NamedTask, TaskModule}
+import mill.define.Discover
 import mill.testkit.TestBaseModule
 import mill.util.TestGraphs
-import mill.util.TestGraphs.*
 import mill.{Cross, Module, Task}
 import utest.*
 
@@ -81,7 +80,6 @@ object TypeSelectorTests extends TestSuite {
 
   val tests = Tests {
     val graphs = new mill.util.TestGraphs()
-    import graphs.*
     test("typeSelector") {
       val check = new Checker(TypedModules)
       test - check(

--- a/core/server/test/src/mill/main/server/ClientServerTests.scala
+++ b/core/server/test/src/mill/main/server/ClientServerTests.scala
@@ -236,7 +236,7 @@ object ClientServerTests extends TestSuite {
         tester.apply(args = Array(" World"), forceFailureForTestingMillisDelay = 100)
       }
 
-      val s"Force failure for testing: $pathStr" = res1.getMessage
+      val s"Force failure for testing: $pathStr" = res1.getMessage: @unchecked
       Thread.sleep(100) // give a moment for logs to all turn up on disk
       val logLines = os.read.lines(os.Path(pathStr, os.pwd) / "server.log")
 

--- a/core/server/test/src/mill/main/server/ClientServerTests.scala
+++ b/core/server/test/src/mill/main/server/ClientServerTests.scala
@@ -230,8 +230,6 @@ object ClientServerTests extends TestSuite {
       // to interrupt such an execution. The two options are to leave the server running
       // for an unbounded duration, or kill the server process and take a performance hit
       // on the next cold startup. Mill chooses the second option.
-      import concurrent._
-      import concurrent.ExecutionContext.Implicits.global
       val res1 = intercept[Exception] {
         tester.apply(args = Array(" World"), forceFailureForTestingMillisDelay = 100)
       }

--- a/idea/src/mill/idea/GenIdeaImpl.scala
+++ b/idea/src/mill/idea/GenIdeaImpl.scala
@@ -657,7 +657,7 @@ case class GenIdeaImpl(
       attributes1 = attribute1,
       example.scope,
       minimizeEmpty = true,
-      child = element.childs.map(ideaConfigElementTemplate): _*
+      child = element.childs.map(ideaConfigElementTemplate)*
     )
   }
 

--- a/integration/failure/missing-build-file/src/MissingBuildFileTests.scala
+++ b/integration/failure/missing-build-file/src/MissingBuildFileTests.scala
@@ -10,7 +10,7 @@ object MissingBuildFileTests extends UtestIntegrationTestSuite {
       val res = tester.eval(("resolve", "_"))
       assert(!res.isSuccess)
       val s"${prefix}No build file (build.mill, build.mill.scala, build.sc) found in $msg. Are you in a Mill project directory?" =
-        res.err
+        res.err: @unchecked
     }
   }
 }

--- a/javascriptlib/test/src/mill/javascriptlib/HelloWorldTests.scala
+++ b/javascriptlib/test/src/mill/javascriptlib/HelloWorldTests.scala
@@ -31,7 +31,7 @@ object HelloWorldTests extends TestSuite {
       val baos = new ByteArrayOutputStream()
       val eval = UnitTester(HelloWorldJavascript, resourcePath, outStream = new PrintStream(baos))
 
-      val Right(result) = eval.apply(HelloWorldJavascript.qux.run(Args("James")))
+      val Right(result) = eval.apply(HelloWorldJavascript.qux.run(Args("James"))): @unchecked
 
       assert(baos.toString() == "Hello James Qux\n")
     }

--- a/kotlinlib/src/mill/kotlinlib/KotlinWorkerManagerImpl.scala
+++ b/kotlinlib/src/mill/kotlinlib/KotlinWorkerManagerImpl.scala
@@ -13,7 +13,7 @@ import java.net.{URL, URLClassLoader}
 
 class KotlinWorkerManagerImpl(ctx: Ctx) extends KotlinWorkerManager with AutoCloseable {
 
-  private[this] var workerCache: Map[Seq[PathRef], (KotlinWorker, Int)] = Map.empty
+  private var workerCache: Map[Seq[PathRef], (KotlinWorker, Int)] = Map.empty
 
   override def get(toolsClasspath: Seq[PathRef])(implicit ctx: Ctx): KotlinWorker = {
     val toolsCp = toolsClasspath.distinct

--- a/kotlinlib/src/mill/kotlinlib/js/KotlinJsModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/js/KotlinJsModule.scala
@@ -524,7 +524,7 @@ trait KotlinJsModule extends KotlinModule { outer =>
 
     override def testLocal(args: String*): Command[(String, Seq[TestResult])] =
       Task.Command {
-        this.test(args: _*)()
+        this.test(args*)()
       }
 
     override protected[js] def friendModule: Option[KotlinJsModule] = Some(outer)

--- a/kotlinlib/test/src/mill/kotlinlib/HelloWorldTests.scala
+++ b/kotlinlib/test/src/mill/kotlinlib/HelloWorldTests.scala
@@ -40,7 +40,7 @@ object HelloWorldTests extends TestSuite {
       val eval = testEval()
 
       HelloWorldKotlin.main.crossModules.foreach(m => {
-        val Right(result) = eval.apply(m.compile)
+        val Right(result) = eval.apply(m.compile): @unchecked
 
         assert(
           os.walk(result.value.classes.path).exists(_.last == "HelloKt.class")
@@ -51,7 +51,7 @@ object HelloWorldTests extends TestSuite {
       val eval = testEval()
 
       HelloWorldKotlin.main.crossModules.foreach(m => {
-        val Right(result1) = eval.apply(m.test.compile)
+        val Right(result1) = eval.apply(m.test.compile): @unchecked
 
         assert(
           os.walk(result1.value.classes.path).exists(_.last == "HelloTest.class")
@@ -62,7 +62,7 @@ object HelloWorldTests extends TestSuite {
       val eval = testEval()
 
       HelloWorldKotlin.main.crossModules.foreach(m => {
-        val Left(Result.Failure(_, Some(v1))) = eval.apply(m.test.test())
+        val Left(Result.Failure(_, Some(v1))) = eval.apply(m.test.test()): @unchecked
 
         assert(
           v1._2(0).fullyQualifiedName == "hello.tests.HelloTest.testFailure",
@@ -76,10 +76,10 @@ object HelloWorldTests extends TestSuite {
       val eval = testEval()
 
       HelloWorldKotlin.main.crossModules.foreach(m => {
-        val Right(discovered) = eval.apply(m.kotest.discoveredTestClasses)
+        val Right(discovered) = eval.apply(m.kotest.discoveredTestClasses): @unchecked
         assert(discovered.value == Seq("hello.tests.FooTest"))
 
-        val Left(Result.Failure(_, Some(v1))) = eval.apply(m.kotest.test())
+        val Left(Result.Failure(_, Some(v1))) = eval.apply(m.kotest.test()): @unchecked
 
         assert(
           v1._2(0).fullyQualifiedName == "hello.tests.FooTest",
@@ -96,15 +96,15 @@ object HelloWorldTests extends TestSuite {
 
       HelloWorldKotlin.main.crossModules.foreach(m => {
 
-        val Right(_) = eval.apply(m.compile)
+        val Right(_) = eval.apply(m.compile): @unchecked
 
         os.write.over(mainJava, os.read(mainJava) + "}")
 
-        val Left(_) = eval.apply(m.compile)
+        val Left(_) = eval.apply(m.compile): @unchecked
 
         os.write.over(mainJava, os.read(mainJava).dropRight(1))
 
-        val Right(_) = eval.apply(m.compile)
+        val Right(_) = eval.apply(m.compile): @unchecked
       })
     }
   }

--- a/kotlinlib/test/src/mill/kotlinlib/MixedHelloWorldTests.scala
+++ b/kotlinlib/test/src/mill/kotlinlib/MixedHelloWorldTests.scala
@@ -40,7 +40,7 @@ object MixedHelloWorldTests extends TestSuite {
       val eval = testEval()
 
       MixedHelloWorldKotlin.main.crossModules.foreach(m => {
-        val Right(result) = eval.apply(m.compile)
+        val Right(result) = eval.apply(m.compile): @unchecked
 
         assert(
           os.walk(result.value.classes.path).exists(_.last == "KotlinHelloKt.class"),
@@ -52,7 +52,7 @@ object MixedHelloWorldTests extends TestSuite {
       val eval = testEval()
 
       MixedHelloWorldKotlin.main.crossModules.foreach(m => {
-        val Right(result1) = eval.apply(m.test.compile)
+        val Right(result1) = eval.apply(m.test.compile): @unchecked
 
         assert(
           os.walk(result1.value.classes.path).exists(_.last == "HelloTest.class")
@@ -63,7 +63,7 @@ object MixedHelloWorldTests extends TestSuite {
       val eval = testEval()
       MixedHelloWorldKotlin.main.crossModules.foreach(m => {
 
-        val Left(Result.Failure(_, Some(v1))) = eval.apply(m.test.test())
+        val Left(Result.Failure(_, Some(v1))) = eval.apply(m.test.test()): @unchecked
 
         assert(
           v1._2(0).fullyQualifiedName == "hello.tests.HelloTest.testFailure",
@@ -81,15 +81,15 @@ object MixedHelloWorldTests extends TestSuite {
         val mainJava =
           MixedHelloWorldKotlin.millSourcePath / "main/src/hello/KotlinHello.kt"
 
-        val Right(_) = eval.apply(m.compile)
+        val Right(_) = eval.apply(m.compile): @unchecked
 
         os.write.over(mainJava, os.read(mainJava) + "}")
 
-        val Left(_) = eval.apply(m.compile)
+        val Left(_) = eval.apply(m.compile): @unchecked
 
         os.write.over(mainJava, os.read(mainJava).dropRight(1))
 
-        val Right(_) = eval.apply(m.compile)
+        val Right(_) = eval.apply(m.compile): @unchecked
       })
     }
   }

--- a/kotlinlib/test/src/mill/kotlinlib/contrib/kover/KoverModuleTests.scala
+++ b/kotlinlib/test/src/mill/kotlinlib/contrib/kover/KoverModuleTests.scala
@@ -4,7 +4,6 @@ import mill.define.Discover
 import mill.main.TokenReaders._
 import mill.kotlinlib.{DepSyntax, KotlinModule}
 import mill.kotlinlib.TestModule
-import mill.kotlinlib.kover.{Kover, KoverModule}
 import mill.testkit.{TestBaseModule, UnitTester}
 import mill.{Agg, T, Task, api}
 import utest.{TestSuite, Tests, assert, test}

--- a/kotlinlib/test/src/mill/kotlinlib/contrib/kover/KoverModuleTests.scala
+++ b/kotlinlib/test/src/mill/kotlinlib/contrib/kover/KoverModuleTests.scala
@@ -66,7 +66,7 @@ object KoverModuleTests extends TestSuite {
             )
         )
 
-      val Right(result) = eval(Kover.xmlReportAll(eval.evaluator))
+      val Right(result) = eval(Kover.xmlReportAll(eval.evaluator)): @unchecked
 
       val xmlReportPath = result.value.path
       assert(os.exists(xmlReportPath))
@@ -89,9 +89,9 @@ object KoverModuleTests extends TestSuite {
 
       val eval = UnitTester(module, resourcePath)
 
-      val Right(_) = eval(module.foo.test.test())
+      val Right(_) = eval(module.foo.test.test()): @unchecked
 
-      val Right(result) = eval(module.foo.kover.xmlReport())
+      val Right(result) = eval(module.foo.kover.xmlReport()): @unchecked
 
       val xmlReportPath = result.value.path
       assert(os.exists(xmlReportPath))
@@ -119,9 +119,9 @@ object KoverModuleTests extends TestSuite {
 
       val eval = UnitTester(module, resourcePath)
 
-      val Right(_) = eval(module.foo.test.test())
+      val Right(_) = eval(module.foo.test.test()): @unchecked
 
-      val Right(result) = eval(module.foo.kover.htmlReport())
+      val Right(result) = eval(module.foo.kover.htmlReport()): @unchecked
 
       val htmlReportPath = result.value.path
       assert(os.exists(htmlReportPath))

--- a/kotlinlib/test/src/mill/kotlinlib/contrib/ktfmt/KtfmtModuleTests.scala
+++ b/kotlinlib/test/src/mill/kotlinlib/contrib/ktfmt/KtfmtModuleTests.scala
@@ -117,7 +117,7 @@ object KtfmtModuleTests extends TestSuite {
         case failure => throw failure
       },
       { _ =>
-        val Right(sources) = eval(module.sources)
+        val Right(sources) = eval(module.sources): @unchecked
 
         sources.value.flatMap(ref => walkFiles(ref.path))
       }
@@ -145,7 +145,7 @@ object KtfmtModuleTests extends TestSuite {
         case failure => throw failure
       },
       { _ =>
-        val Right(sources) = eval(module.sources)
+        val Right(sources) = eval(module.sources): @unchecked
         sources.value.flatMap(ref => walkFiles(ref.path))
       }
     )

--- a/kotlinlib/test/src/mill/kotlinlib/js/KotlinJsCompileTests.scala
+++ b/kotlinlib/test/src/mill/kotlinlib/js/KotlinJsCompileTests.scala
@@ -32,7 +32,7 @@ object KotlinJsCompileTests extends TestSuite {
     test("compile") {
       val eval = testEval()
 
-      val Right(result) = eval.apply(module.foo.compile)
+      val Right(result) = eval.apply(module.foo.compile): @unchecked
 
       val irDir = result.value.classes.path
       assert(
@@ -48,15 +48,15 @@ object KotlinJsCompileTests extends TestSuite {
 
       val compilationUnit = module.foo.millSourcePath / "src/foo/Hello.kt"
 
-      val Right(_) = eval.apply(module.foo.compile)
+      val Right(_) = eval.apply(module.foo.compile): @unchecked
 
       os.write.over(compilationUnit, os.read(compilationUnit) + "}")
 
-      val Left(_) = eval.apply(module.foo.compile)
+      val Left(_) = eval.apply(module.foo.compile): @unchecked
 
       os.write.over(compilationUnit, os.read(compilationUnit).dropRight(1))
 
-      val Right(_) = eval.apply(module.foo.compile)
+      val Right(_) = eval.apply(module.foo.compile): @unchecked
     }
   }
 

--- a/kotlinlib/test/src/mill/kotlinlib/js/KotlinJsKotestModuleTests.scala
+++ b/kotlinlib/test/src/mill/kotlinlib/js/KotlinJsKotestModuleTests.scala
@@ -43,7 +43,7 @@ object KotlinJsKotestModuleTests extends TestSuite {
 
       val command = module.foo.test.test()
       val Left(Result.Failure(failureMessage, Some((doneMessage, testResults)))) =
-        eval.apply(command)
+        eval.apply(command): @unchecked
 
       val xmlReport =
         EvaluatorPaths.resolveDestPaths(eval.outPath, command).dest / "test-report.xml"

--- a/kotlinlib/test/src/mill/kotlinlib/js/KotlinJsKotlinTestPackageModuleTests.scala
+++ b/kotlinlib/test/src/mill/kotlinlib/js/KotlinJsKotlinTestPackageModuleTests.scala
@@ -44,7 +44,7 @@ object KotlinJsKotlinTestPackageModuleTests extends TestSuite {
 
       val command = module.foo.test.test()
       val Left(Result.Failure(failureMessage, Some((doneMessage, testResults)))) =
-        eval.apply(command)
+        eval.apply(command): @unchecked
 
       val xmlReport =
         EvaluatorPaths.resolveDestPaths(eval.outPath, command).dest / "test-report.xml"

--- a/kotlinlib/test/src/mill/kotlinlib/js/KotlinJsKotlinVersionsTests.scala
+++ b/kotlinlib/test/src/mill/kotlinlib/js/KotlinJsKotlinVersionsTests.scala
@@ -49,13 +49,13 @@ object KotlinJsKotlinVersionsTests extends TestSuite {
     test("compile with lowest Kotlin version") {
       val eval = testEval()
 
-      val Right(_) = eval.apply(module.foo(kotlinLowestVersion).compile)
+      val Right(_) = eval.apply(module.foo(kotlinLowestVersion).compile): @unchecked
     }
 
     test("compile with highest Kotlin version") {
       val eval = testEval()
 
-      val Right(_) = eval.apply(module.foo(kotlinHighestVersion).compile)
+      val Right(_) = eval.apply(module.foo(kotlinHighestVersion).compile): @unchecked
     }
   }
 

--- a/kotlinlib/test/src/mill/kotlinlib/js/KotlinJsLinkTests.scala
+++ b/kotlinlib/test/src/mill/kotlinlib/js/KotlinJsLinkTests.scala
@@ -37,7 +37,7 @@ object KotlinJsLinkTests extends TestSuite {
     test("link { per module }") {
       val eval = testEval()
 
-      val Right(result) = eval.apply(module.foo(true).linkBinary)
+      val Right(result) = eval.apply(module.foo(true).linkBinary): @unchecked
 
       val binariesDir = result.value.classes.path
       assert(
@@ -54,7 +54,7 @@ object KotlinJsLinkTests extends TestSuite {
     test("link { fat }") {
       val eval = testEval()
 
-      val Right(result) = eval.apply(module.foo(false).linkBinary)
+      val Right(result) = eval.apply(module.foo(false).linkBinary): @unchecked
 
       val binariesDir = result.value.classes.path
       assert(

--- a/kotlinlib/test/src/mill/kotlinlib/js/KotlinJsNodeRunTests.scala
+++ b/kotlinlib/test/src/mill/kotlinlib/js/KotlinJsNodeRunTests.scala
@@ -56,14 +56,14 @@ object KotlinJsNodeRunTests extends TestSuite {
       val eval = testEval()
 
       // plain modules cannot handle the dependencies, so if there are multiple js files, it will fail
-      val Left(_) = eval.apply(module.foo(true, "plain").run())
+      val Left(_) = eval.apply(module.foo(true, "plain").run()): @unchecked
     }
 
     test("split - es module") {
       val eval = testEval()
 
       val command = module.foo(true, "es").run()
-      val Right(_) = eval.apply(command)
+      val Right(_) = eval.apply(command): @unchecked
 
       assertLogContains(eval, command, expectedSuccessOutput)
     }
@@ -72,14 +72,14 @@ object KotlinJsNodeRunTests extends TestSuite {
       val eval = testEval()
 
       // amd modules have "define" method, it is not known by Node.js
-      val Left(_) = eval.apply(module.foo(true, "amd").run())
+      val Left(_) = eval.apply(module.foo(true, "amd").run()): @unchecked
     }
 
     test("split - commonjs module") {
       val eval = testEval()
 
       val command = module.foo(true, "commonjs").run()
-      val Right(_) = eval.apply(command)
+      val Right(_) = eval.apply(command): @unchecked
 
       assertLogContains(eval, command, expectedSuccessOutput)
     }
@@ -88,7 +88,7 @@ object KotlinJsNodeRunTests extends TestSuite {
       val eval = testEval()
 
       val command = module.foo(true, "umd").run()
-      val Right(_) = eval.apply(command)
+      val Right(_) = eval.apply(command): @unchecked
 
       assertLogContains(eval, command, expectedSuccessOutput)
     }
@@ -96,7 +96,7 @@ object KotlinJsNodeRunTests extends TestSuite {
     test("split - no module") {
       val eval = testEval()
 
-      val Left(_) = eval.apply(module.foo(true, "no").run())
+      val Left(_) = eval.apply(module.foo(true, "no").run()): @unchecked
     }
 
     // endregion
@@ -107,7 +107,7 @@ object KotlinJsNodeRunTests extends TestSuite {
       val eval = testEval()
 
       val command = module.foo(false, "plain").run()
-      val Right(_) = eval.apply(command)
+      val Right(_) = eval.apply(command): @unchecked
 
       assertLogContains(eval, command, expectedSuccessOutput)
     }
@@ -116,7 +116,7 @@ object KotlinJsNodeRunTests extends TestSuite {
       val eval = testEval()
 
       val command = module.foo(false, "es").run()
-      val Right(_) = eval.apply(command)
+      val Right(_) = eval.apply(command): @unchecked
 
       assertLogContains(eval, command, expectedSuccessOutput)
     }
@@ -125,14 +125,14 @@ object KotlinJsNodeRunTests extends TestSuite {
       val eval = testEval()
 
       // amd modules have "define" method, it is not known by Node.js
-      val Left(_) = eval.apply(module.foo(false, "amd").run())
+      val Left(_) = eval.apply(module.foo(false, "amd").run()): @unchecked
     }
 
     test("no split - commonjs module") {
       val eval = testEval()
 
       val command = module.foo(false, "commonjs").run()
-      val Right(_) = eval.apply(command)
+      val Right(_) = eval.apply(command): @unchecked
 
       assertLogContains(eval, command, expectedSuccessOutput)
     }
@@ -141,7 +141,7 @@ object KotlinJsNodeRunTests extends TestSuite {
       val eval = testEval()
 
       val command = module.foo(false, "umd").run()
-      val Right(_) = eval.apply(command)
+      val Right(_) = eval.apply(command): @unchecked
 
       assertLogContains(eval, command, expectedSuccessOutput)
     }
@@ -150,7 +150,7 @@ object KotlinJsNodeRunTests extends TestSuite {
       val eval = testEval()
 
       val command = module.foo(false, "no").run()
-      val Right(_) = eval.apply(command)
+      val Right(_) = eval.apply(command): @unchecked
 
       assertLogContains(eval, command, expectedSuccessOutput)
     }

--- a/kotlinlib/worker/impl/src/mill/kotlinlib/worker/impl/KotlinWorkerImpl.scala
+++ b/kotlinlib/worker/impl/src/mill/kotlinlib/worker/impl/KotlinWorkerImpl.scala
@@ -19,7 +19,7 @@ class KotlinWorkerImpl extends KotlinWorker {
       case KotlinWorkerTarget.Jvm => new K2JVMCompiler()
       case KotlinWorkerTarget.Js => new K2JSCompiler()
     }
-    val exitCode = compiler.exec(ctx.log.errorStream, args: _*)
+    val exitCode = compiler.exec(ctx.log.errorStream, args*)
     if (exitCode.getCode != 0) {
       Result.Failure(s"Kotlin compiler failed with exit code ${exitCode.getCode} ($exitCode)")
     } else {

--- a/main/init/maven/src/mill/main/maven/Resolver.scala
+++ b/main/init/maven/src/mill/main/maven/Resolver.scala
@@ -23,7 +23,7 @@ class Resolver(
     remotes: Seq[RemoteRepository],
     context: String
 ) extends ModelResolver {
-  private[this] var repositories = remotes
+  private var repositories = remotes
 
   override def resolveModel(groupId: String, artifactId: String, version: String): ModelSource = {
     val artifact = new DefaultArtifact(groupId, artifactId, "", "pom", version)

--- a/main/init/test/src/mill/init/InitModuleTests.scala
+++ b/main/init/test/src/mill/init/InitModuleTests.scala
@@ -33,7 +33,7 @@ object InitModuleTests extends TestSuite {
 
         assert(results.failing.keyCount == 0)
 
-        val Result.Success(Val(value)) = results.rawValues.head
+        val Result.Success(Val(value)) = results.rawValues.head: @unchecked
         val consoleShown = outStream.toString
 
         val examplesList: Seq[String] = value.asInstanceOf[Seq[String]]

--- a/main/init/test/src/mill/init/InitModuleTests.scala
+++ b/main/init/test/src/mill/init/InitModuleTests.scala
@@ -1,16 +1,13 @@
 package mill.init
 
-import mill.api.{PathRef, Result, Val}
-import mill.{Agg, T}
-import mill.define.{Cross, Discover, Module, Task}
-import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.api.{Result, Val}
+import mill.Agg
+import mill.define.Discover
 import mill.testkit.UnitTester
 import mill.testkit.TestBaseModule
 import utest._
 
 import java.io.{ByteArrayOutputStream, PrintStream}
-import scala.util.Using
 
 object InitModuleTests extends TestSuite {
 

--- a/main/src/mill/main/MainModule.scala
+++ b/main/src/mill/main/MainModule.scala
@@ -81,7 +81,7 @@ object MainModule {
   def plan0(
       evaluator: Evaluator,
       tasks: Seq[String]
-  ): Either[String, Array[NamedTask[_]]] = {
+  ): Either[String, Array[NamedTask[?]]] = {
     Resolve.Tasks.resolve(
       evaluator.rootModule,
       tasks,
@@ -170,9 +170,9 @@ trait MainModule extends BaseModule {
       resolved match {
         case Left(err) => Result.Failure(err)
         case Right(Seq(src1, dest1)) =>
-          val queue = collection.mutable.Queue[List[Task[_]]](List(src1))
-          var found = Option.empty[List[Task[_]]]
-          val seen = collection.mutable.Set.empty[Task[_]]
+          val queue = collection.mutable.Queue[List[Task[?]]](List(src1))
+          var found = Option.empty[List[Task[?]]]
+          val seen = collection.mutable.Set.empty[Task[?]]
           while (queue.nonEmpty && found.isEmpty) {
             val current = queue.dequeue()
             if (current.head == dest1) found = Some(current)
@@ -209,7 +209,7 @@ trait MainModule extends BaseModule {
 
       /** Find a parent classes of the given class queue. */
       @tailrec
-      def resolveParents(queue: List[Class[_]], seen: Seq[Class[_]] = Seq()): Seq[Class[_]] = {
+      def resolveParents(queue: List[Class[?]], seen: Seq[Class[?]] = Seq()): Seq[Class[?]] = {
         queue match {
           case Nil => seen
           case cand :: rest if seen.contains(cand) => resolveParents(rest, seen)
@@ -219,7 +219,7 @@ trait MainModule extends BaseModule {
         }
       }
 
-      def renderFileName(t: NamedTask[_]) = {
+      def renderFileName(t: NamedTask[?]) = {
         // handle both Windows or Unix separators
         val fullFileName = t.ctx.fileName.replaceAll(raw"\\", "/")
         val basePath = WorkspaceRoot.workspaceRoot.toString().replaceAll(raw"\\", "/") + "/"
@@ -232,10 +232,10 @@ trait MainModule extends BaseModule {
         s"${name}:${t.ctx.lineNum}"
       }
 
-      def pprintTask(t: NamedTask[_], evaluator: Evaluator): Tree.Lazy = {
-        val seen = mutable.Set.empty[Task[_]]
+      def pprintTask(t: NamedTask[?], evaluator: Evaluator): Tree.Lazy = {
+        val seen = mutable.Set.empty[Task[?]]
 
-        def rec(t: Task[_]): Seq[Segments] = {
+        def rec(t: Task[?]): Seq[Segments] = {
           if (seen(t)) Nil // do nothing
           else t match {
             case t: mill.define.Target[_]
@@ -312,14 +312,14 @@ trait MainModule extends BaseModule {
         }
       }
 
-      def pprintModule(t: ModuleTask[_], evaluator: Evaluator): Tree.Lazy = {
+      def pprintModule(t: ModuleTask[?], evaluator: Evaluator): Tree.Lazy = {
         val cls = t.module.getClass
         val annotation = cls.getAnnotation(classOf[Scaladoc])
         val scaladocOpt = Option(annotation).map(annotation =>
           Util.cleanupScaladoc(annotation.value).map("\n" + inspectItemIndent + _).mkString
         )
 
-        def parentFilter(parent: Class[_]) =
+        def parentFilter(parent: Class[?]) =
           classOf[Module].isAssignableFrom(parent) && classOf[Module] != parent
 
         val parents = (Option(cls.getSuperclass).toSeq ++ cls.getInterfaces).distinct
@@ -613,7 +613,7 @@ trait MainModule extends BaseModule {
       targets: Seq[String],
       ctx: mill.api.Ctx,
       vizWorker: VizWorker,
-      planTasks: Option[List[NamedTask[_]]] = None
+      planTasks: Option[List[NamedTask[?]]] = None
   ): Result[Seq[PathRef]] = {
     def callVisualizeModule(
         tasks: List[NamedTask[Any]],

--- a/main/src/mill/main/Subfolder.scala
+++ b/main/src/mill/main/Subfolder.scala
@@ -17,7 +17,7 @@ abstract class SubfolderModule()(implicit
         millModuleEnclosing0 = subFolderInfo.segments.mkString("."),
         millModuleLine0 = millModuleLine0,
         millModuleBasePath0 = Ctx.BasePath(subFolderInfo.millSourcePath0 / os.up),
-        segments0 = Segments.labels(subFolderInfo.segments.init: _*),
+        segments0 = Segments.labels(subFolderInfo.segments.init*),
         external0 = Ctx.External(false),
         fileName = millFile0,
         enclosingModule = Caller(null),

--- a/main/src/mill/main/TokenReaders.scala
+++ b/main/src/mill/main/TokenReaders.scala
@@ -37,7 +37,7 @@ private[mill] class AllEvaluatorsTokenReader[T]()
     Right(Evaluator.allBootstrapEvaluators.value)
 }
 
-private class LeftoverTaskTokenReader[T](tokensReaderOfT: TokensReader.Leftover[T, _])
+private class LeftoverTaskTokenReader[T](tokensReaderOfT: TokensReader.Leftover[T, ?])
     extends mainargs.TokensReader.Leftover[Task[T], T] {
   def read(strs: Seq[String]): Either[String, Task[T]] =
     tokensReaderOfT.read(strs).map(t => mill.define.Task.Anon(t))

--- a/main/src/mill/package.scala
+++ b/main/src/mill/package.scala
@@ -6,7 +6,7 @@ package object mill extends mill.api.JsonFormatters with mill.main.TokenReaders0
   val PathRef = mill.api.PathRef
   type PathRef = mill.api.PathRef
   type Module = define.Module
-  type Cross[T <: Cross.Module[_]] = define.Cross[T]
+  type Cross[T <: Cross.Module[?]] = define.Cross[T]
   val Cross = define.Cross
   type Agg[T] = mill.api.Loose.Agg[T]
   val Agg = mill.api.Loose.Agg

--- a/main/test/src/mill/main/MainModuleTests.scala
+++ b/main/test/src/mill/main/MainModuleTests.scala
@@ -143,7 +143,7 @@ object MainModuleTests extends TestSuite {
     test("inspect") {
       test("single") - UnitTester(mainModule, null).scoped { eval =>
         val res = eval.evaluator.evaluate(Agg(mainModule.inspect(eval.evaluator, "hello")))
-        val Result.Success(Val(value: String)) = res.rawValues.head
+        val Result.Success(Val(value: String)) = res.rawValues.head: @unchecked
         assert(
           res.failing.keyCount == 0,
           value.startsWith("hello("),
@@ -153,7 +153,7 @@ object MainModuleTests extends TestSuite {
       test("multi") - UnitTester(mainModule, null).scoped { eval =>
         val res =
           eval.evaluator.evaluate(Agg(mainModule.inspect(eval.evaluator, "hello", "hello2")))
-        val Result.Success(Val(value: String)) = res.rawValues.head
+        val Result.Success(Val(value: String)) = res.rawValues.head: @unchecked
         assert(
           res.failing.keyCount == 0,
           value.startsWith("hello("),
@@ -162,9 +162,9 @@ object MainModuleTests extends TestSuite {
         )
       }
       test("command") - UnitTester(mainModule, null).scoped { eval =>
-        val Right(result) = eval.apply("inspect", "helloCommand")
+        val Right(result) = eval.apply("inspect", "helloCommand"): @unchecked
 
-        val Seq(res: String) = result.value
+        val Seq(res: String) = result.value: @unchecked
         assert(
           res.startsWith("helloCommand("),
           res.contains("MainModuleTests.scala:"),
@@ -172,9 +172,9 @@ object MainModuleTests extends TestSuite {
         )
       }
       test("worker") - UnitTester(mainModule, null).scoped { eval =>
-        val Right(result) = eval.apply("inspect", "helloWorker")
+        val Right(result) = eval.apply("inspect", "helloWorker"): @unchecked
 
-        val Seq(res: String) = result.value
+        val Seq(res: String) = result.value: @unchecked
         assert(
           res.startsWith("helloWorker("),
           res.contains("MainModuleTests.scala:"),
@@ -183,9 +183,9 @@ object MainModuleTests extends TestSuite {
         )
       }
       test("module") - UnitTester(mainModule, null).scoped { eval =>
-        val Right(result) = eval.apply("inspect", "sub")
+        val Right(result) = eval.apply("inspect", "sub"): @unchecked
 
-        val Seq(res: String) = result.value
+        val Seq(res: String) = result.value: @unchecked
         assert(
           res.startsWith("sub("),
           res.contains("MainModuleTests.scala:"),
@@ -215,7 +215,7 @@ object MainModuleTests extends TestSuite {
 
         assert(results.failing.keyCount == 0)
 
-        val Result.Success(Val(value)) = results.rawValues.head
+        val Result.Success(Val(value)) = results.rawValues.head: @unchecked
 
         val shown = ujson.read(outStream.toByteArray)
         val expected = ujson.Arr.from(Seq("hello", "world"))
@@ -243,7 +243,7 @@ object MainModuleTests extends TestSuite {
 
         assert(results.failing.keyCount == 0)
 
-        val Result.Success(Val(value)) = results.rawValues.head
+        val Result.Success(Val(value)) = results.rawValues.head: @unchecked
 
         val shown = ujson.read(outStream.toByteArray)
 
@@ -266,22 +266,22 @@ object MainModuleTests extends TestSuite {
       }
 
       test("command") {
-        val Left(Result.Failure(failureMsg, _)) = evaluator.apply("show", "helloCommand")
+        val Left(Result.Failure(failureMsg, _)) = evaluator.apply("show", "helloCommand"): @unchecked
         assert(
           failureMsg.contains("Expected Signature: helloCommand"),
           failureMsg.contains("-x <int>"),
           failureMsg.contains("-y <str>")
         )
         val Right(result) =
-          evaluator.apply("show", "helloCommand", "-x", "1337", "-y", "lol")
+          evaluator.apply("show", "helloCommand", "-x", "1337", "-y", "lol"): @unchecked
 
         val Seq(res) = result.value
         assert(res == ujson.Arr(1337, "lol", ujson.Arr("hello", "world")))
       }
 
       test("worker") {
-        val Right(result) = evaluator.apply("show", "helloWorker")
-        val Seq(res: ujson.Obj) = result.value
+        val Right(result) = evaluator.apply("show", "helloWorker"): @unchecked
+        val Seq(res: ujson.Obj) = result.value: @unchecked
         assert(res("toString").str == "theHelloWorker")
         assert(res("worker").str == "helloWorker")
         assert(res("inputsHash").numOpt.isDefined)
@@ -296,7 +296,7 @@ object MainModuleTests extends TestSuite {
 
         assert(results.failing.keyCount == 0)
 
-        val Result.Success(Val(value)) = results.rawValues.head
+        val Result.Success(Val(value)) = results.rawValues.head: @unchecked
 
         assert(value == ujson.Obj.from(Map(
           "hello" -> ujson.Arr.from(Seq("hello", "world"))
@@ -313,7 +313,7 @@ object MainModuleTests extends TestSuite {
 
         assert(results.failing.keyCount == 0)
 
-        val Result.Success(Val(value)) = results.rawValues.head
+        val Result.Success(Val(value)) = results.rawValues.head: @unchecked
 
         assert(value == ujson.Obj.from(Map(
           "hello" -> ujson.Arr.from(Seq("hello", "world")),
@@ -324,9 +324,9 @@ object MainModuleTests extends TestSuite {
 
     test("resolve") {
       UnitTester(mainModule, null).scoped { eval =>
-        val Right(result) = eval.apply("resolve", "_")
+        val Right(result) = eval.apply("resolve", "_"): @unchecked
 
-        val Seq(res: Seq[String]) = result.value
+        val Seq(res: Seq[String]) = result.value: @unchecked
         assert(res.contains("hello"))
         assert(res.contains("hello2"))
         assert(res.contains("helloCommand"))

--- a/main/test/src/mill/main/MainModuleTests.scala
+++ b/main/test/src/mill/main/MainModuleTests.scala
@@ -266,7 +266,8 @@ object MainModuleTests extends TestSuite {
       }
 
       test("command") {
-        val Left(Result.Failure(failureMsg, _)) = evaluator.apply("show", "helloCommand"): @unchecked
+        val Left(Result.Failure(failureMsg, _)) =
+          evaluator.apply("show", "helloCommand"): @unchecked
         assert(
           failureMsg.contains("Expected Signature: helloCommand"),
           failureMsg.contains("-x <int>"),

--- a/main/test/src/mill/main/MainModuleTests.scala
+++ b/main/test/src/mill/main/MainModuleTests.scala
@@ -1,7 +1,7 @@
 package mill.main
 
 import mill.api.{PathRef, Result, Val}
-import mill.{Agg, T, Task, given}
+import mill.{Agg, Task, given}
 import mill.define.{Cross, Discover, Module, TaskModule}
 import mill.main.client.OutFiles
 import mill.testkit.UnitTester

--- a/main/test/src/mill/util/TestGraphs.scala
+++ b/main/test/src/mill/util/TestGraphs.scala
@@ -2,8 +2,8 @@ package mill.util
 import TestUtil.test
 import mainargs.arg
 import mill.testkit.TestBaseModule
-import mill.define.{Command, Cross, Discover, DynamicModule, ModuleRef, TaskModule}
-import mill.{Module, T, Task}
+import mill.define.{Command, Cross, Discover, TaskModule}
+import mill.{Module, Task}
 
 /**
  * Example dependency graphs for us to use in our test suite.

--- a/main/test/src/mill/util/TestGraphs.scala
+++ b/main/test/src/mill/util/TestGraphs.scala
@@ -155,7 +155,7 @@ object TestGraphs {
     def single = Task { 1 }
     def invisible: Any = Task { 2 }
     def invisible2: mill.define.Task[Int] = Task { 3 }
-    def invisible3: mill.define.Task[_] = Task { 4 }
+    def invisible3: mill.define.Task[?] = Task { 4 }
   }
 
   object nestedModule extends TestBaseModule {

--- a/main/test/src/mill/util/TestUtil.scala
+++ b/main/test/src/mill/util/TestUtil.scala
@@ -54,8 +54,8 @@ object TestUtil {
     override def sideHash = testTask.sideHash
   }
 
-  def checkTopological(targets: Agg[Task[_]]) = {
-    val seen = mutable.Set.empty[Task[_]]
+  def checkTopological(targets: Agg[Task[?]]) = {
+    val seen = mutable.Set.empty[Task[?]]
     for (t <- targets.indexed.reverseIterator) {
       seen.add(t)
       for (upstream <- t.inputs) {

--- a/main/util/src/mill/util/CoursierSupport.scala
+++ b/main/util/src/mill/util/CoursierSupport.scala
@@ -262,7 +262,7 @@ trait CoursierSupport {
     val coursierCache0 = coursierCache(ctx, coursierCacheCustomizer)
 
     val resolutionParams0 = resolutionParams
-      .addForceVersion(forceVersions.toSeq: _*)
+      .addForceVersion(forceVersions.toSeq*)
 
     val testOverridesRepo =
       new TestOverridesRepo(os.resource(getClass.getClassLoader) / "mill/local-test-overrides")

--- a/main/util/src/mill/util/Version.scala
+++ b/main/util/src/mill/util/Version.scala
@@ -145,7 +145,7 @@ object Version {
   )(implicit
       ordering: Ordering[Version]
   ): String =
-    chooseNewest(parse(version), versions.map(parse): _*).toString()
+    chooseNewest(parse(version), versions.map(parse)*).toString()
 
   def chooseNewest(
       version: Version,

--- a/main/util/test/src/mill/util/PipeStreamsTests.scala
+++ b/main/util/test/src/mill/util/PipeStreamsTests.scala
@@ -39,7 +39,7 @@ object PipeStreamsTests extends TestSuite {
       val chunkSize = 20
       val chunkCount = 100
       assert(pipe.bufferSize < chunkSize * chunkCount) // ensure it gets filled
-      val writer = Future {
+      Future {
         for (i <- Range(0, chunkCount)) {
           pipe.output.write(Array.fill(chunkSize)(i.toByte))
         }

--- a/main/util/test/src/mill/util/RetryTests.scala
+++ b/main/util/test/src/mill/util/RetryTests.scala
@@ -1,6 +1,5 @@
 package mill.util
 
-import mill.util.Retry
 import utest.*
 
 object RetryTests extends TestSuite {

--- a/pythonlib/src/mill/pythonlib/CoverageModule.scala
+++ b/pythonlib/src/mill/pythonlib/CoverageModule.scala
@@ -45,7 +45,7 @@ trait CoverageModule extends PythonModule {
    * [[coverageDataFile]]. It is required that this file be readable as soon
    * as this task returns.
    */
-  def coverageTask: Task[_]
+  def coverageTask: Task[?]
 
   private case class CoverageReporter(
       interp: os.Path,

--- a/pythonlib/test/src/mill/pythonlib/HelloWorldTests.scala
+++ b/pythonlib/test/src/mill/pythonlib/HelloWorldTests.scala
@@ -30,7 +30,7 @@ object HelloWorldTests extends TestSuite {
       val baos = new ByteArrayOutputStream()
       val eval = UnitTester(HelloWorldPython, resourcePath, outStream = new PrintStream(baos))
 
-      val Right(result) = eval.apply(HelloWorldPython.qux.run(Args()))
+      val Right(result) = eval.apply(HelloWorldPython.qux.run(Args())): @unchecked
 
       assert(baos.toString().contains("Hello,  Qux!\n"))
     }

--- a/pythonlib/test/src/mill/pythonlib/RunBackgroundTests.scala
+++ b/pythonlib/test/src/mill/pythonlib/RunBackgroundTests.scala
@@ -20,7 +20,7 @@ object RunBackgroundTests extends TestSuite {
       val eval = UnitTester(HelloWorldPython, resourcePath)
 
       val lockedFile = os.temp()
-      val Right(result) = eval.apply(HelloWorldPython.foo.runBackground(Args(lockedFile)))
+      val Right(result) = eval.apply(HelloWorldPython.foo.runBackground(Args(lockedFile))): @unchecked
       val maxSleep = 20000
       val now1 = System.currentTimeMillis()
       val lock = mill.main.client.lock.Lock.file(lockedFile.toString())

--- a/pythonlib/test/src/mill/pythonlib/RunBackgroundTests.scala
+++ b/pythonlib/test/src/mill/pythonlib/RunBackgroundTests.scala
@@ -20,7 +20,8 @@ object RunBackgroundTests extends TestSuite {
       val eval = UnitTester(HelloWorldPython, resourcePath)
 
       val lockedFile = os.temp()
-      val Right(result) = eval.apply(HelloWorldPython.foo.runBackground(Args(lockedFile))): @unchecked
+      val Right(result) =
+        eval.apply(HelloWorldPython.foo.runBackground(Args(lockedFile))): @unchecked
       val maxSleep = 20000
       val now1 = System.currentTimeMillis()
       val lock = mill.main.client.lock.Lock.file(lockedFile.toString())

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -154,8 +154,8 @@ abstract class MillBuildRootModule()(implicit
           // graph evaluator without needing to be accounted for in the post-compile
           // bytecode callgraph analysis.
           def isSimpleTarget(desc: mill.codesig.JvmModel.Desc) =
-            (desc.ret.pretty == classOf[mill.define.Target[_]].getName ||
-              desc.ret.pretty == classOf[mill.define.Worker[_]].getName) &&
+            (desc.ret.pretty == classOf[mill.define.Target[?]].getName ||
+              desc.ret.pretty == classOf[mill.define.Worker[?]].getName) &&
               desc.args.isEmpty
 
           // We avoid ignoring method calls that are simple trait forwarders, because
@@ -190,7 +190,7 @@ abstract class MillBuildRootModule()(implicit
           // part of the `millbuild.build#<init>` transitive call graph they would normally
           // be counted as
           def isCommand =
-            calledSig.desc.ret.pretty == classOf[mill.define.Command[_]].getName
+            calledSig.desc.ret.pretty == classOf[mill.define.Command[?]].getName
 
           // Skip calls to `millDiscover`. `millDiscover` is bundled as part of `RootModule` for
           // convenience, but it should really never be called by any normal Mill module/task code,
@@ -258,7 +258,7 @@ abstract class MillBuildRootModule()(implicit
   }
 
   override def bindDependency: Task[Dep => BoundDep] = Task.Anon { (dep: Dep) =>
-    super.bindDependency.apply().apply(dep).exclude(resolveDepsExclusions(): _*)
+    super.bindDependency.apply().apply(dep).exclude(resolveDepsExclusions()*)
   }
 
   override def unmanagedClasspath: T[Agg[PathRef]] = Task {

--- a/runner/src/mill/runner/MillCliConfig.scala
+++ b/runner/src/mill/runner/MillCliConfig.scala
@@ -188,7 +188,7 @@ options:
 
   import mill.api.JsonFormatters._
 
-  private[this] lazy val parser: ParserForClass[MillCliConfig] =
+  private lazy val parser: ParserForClass[MillCliConfig] =
     mainargs.ParserForClass[MillCliConfig]
 
   lazy val shortUsageText: String =

--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -378,7 +378,7 @@ trait TestScalaJSModule extends ScalaJSModule with TestModule {
   }
 
   override def testLocal(args: String*): Command[(String, Seq[TestResult])] =
-    Task.Command { test(args: _*)() }
+    Task.Command { test(args*)() }
 
   override protected def testTask(
       args: Task[Seq[String]],

--- a/scalajslib/test/src/mill/scalajslib/CompileLinkTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/CompileLinkTests.scala
@@ -86,11 +86,11 @@ object CompileLinkTests extends TestSuite {
     val jsFile =
       if (legacy) {
         val task = if (optimize) module.fullLinkJS else module.fastLinkJS
-        val Right(result) = eval(task)
+        val Right(result) = eval(task): @unchecked
         result.value.dest.path
       } else {
         val task = if (optimize) module.fullLinkJS else module.fastLinkJS
-        val Right(result) = eval(task)
+        val Right(result) = eval(task): @unchecked
         result.value.dest.path / result.value.publicModules.head.jsFileName
       }
     val output = ScalaJsUtils.runJS(jsFile)
@@ -109,7 +109,7 @@ object CompileLinkTests extends TestSuite {
     test("compile") - UnitTester(HelloJSWorld, millSourcePath).scoped { eval =>
       def testCompileFromScratch(scalaVersion: String, scalaJSVersion: String): Unit = {
         val Right(result) =
-          eval(HelloJSWorld.build(scalaVersion, scalaJSVersion).compile)
+          eval(HelloJSWorld.build(scalaVersion, scalaJSVersion).compile): @unchecked
 
         val outPath = result.value.classes.path
         val outputFiles = os.walk(outPath)
@@ -121,7 +121,7 @@ object CompileLinkTests extends TestSuite {
 
         // don't recompile if nothing changed
         val Right(result2) =
-          eval(HelloJSWorld.build(scalaVersion, scalaJSVersion).compile)
+          eval(HelloJSWorld.build(scalaVersion, scalaJSVersion).compile): @unchecked
         assert(result2.evalCount == 0)
       }
 

--- a/scalajslib/test/src/mill/scalajslib/EsModuleRemapTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/EsModuleRemapTests.scala
@@ -53,7 +53,7 @@ object EsModuleRemapTests extends TestSuite {
     test("should remap the esmodule") {
       val evaluator = UnitTester(EsModuleRemap, millSourcePath)
       val Right(result) =
-        evaluator(EsModuleRemap.fastLinkJS)
+        evaluator(EsModuleRemap.fastLinkJS): @unchecked
       val publicModules = result.value.publicModules.toSeq
       assert(publicModules.length == 1)
       val main = publicModules.head
@@ -66,7 +66,7 @@ object EsModuleRemapTests extends TestSuite {
 
     test("should throw for older scalaJS versions") {
       val evaluator = UnitTester(EsModuleRemap, millSourcePath)
-      val Left(Result.Exception(ex, _)) = evaluator(OldJsModule.fastLinkJS)
+      val Left(Result.Exception(ex, _)) = evaluator(OldJsModule.fastLinkJS): @unchecked
       val error = ex.getMessage
       assert(error == "scalaJSImportMap is not supported with Scala.js < 1.16.")
     }

--- a/scalajslib/test/src/mill/scalajslib/JarPublishRunTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/JarPublishRunTests.scala
@@ -20,7 +20,7 @@ object JarPublishRunTests extends TestSuite {
       test("containsSJSIRs") - UnitTester(HelloJSWorld, millSourcePath).scoped { eval =>
         val (scala, scalaJS) = HelloJSWorld.matrix.head
         val Right(result) =
-          eval(HelloJSWorld.build(scala, scalaJS).jar)
+          eval(HelloJSWorld.build(scala, scalaJS).jar): @unchecked
         val jar = result.value.path
         val jarFile = new JarFile(jar.toIO)
         try {
@@ -35,7 +35,7 @@ object JarPublishRunTests extends TestSuite {
           val Right(result) = eval(HelloJSWorld.build(
             scalaVersion,
             scalaJSVersion
-          ).artifactMetadata)
+          ).artifactMetadata): @unchecked
           assert(result.value.id == artifactId)
         }
       test("artifactId_10") {
@@ -57,7 +57,7 @@ object JarPublishRunTests extends TestSuite {
       UnitTester(HelloJSWorld, millSourcePath).scoped { eval =>
         val task = HelloJSWorld.build(scalaVersion, scalaJSVersion).run()
 
-        val Right(result) = eval(task)
+        val Right(result) = eval(task): @unchecked
 
         val paths = EvaluatorPaths.resolveDestPaths(eval.outPath, task)
         val log = os.read(paths.log)

--- a/scalajslib/test/src/mill/scalajslib/JarPublishRunTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/JarPublishRunTests.scala
@@ -1,12 +1,8 @@
 package mill.scalajslib
 
 import mill._
-import mill.define.Discover
 import mill.eval.EvaluatorPaths
-import mill.scalalib.api.ZincWorkerUtil
-import mill.scalalib.publish.{Developer, License, PomSettings, VersionControl}
-import mill.scalalib.{DepSyntax, PublishModule, ScalaModule, TestModule}
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.UnitTester
 import utest._
 
 import java.util.jar.JarFile

--- a/scalajslib/test/src/mill/scalajslib/MultiModuleTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/MultiModuleTests.scala
@@ -40,7 +40,7 @@ object MultiModuleTests extends TestSuite {
   def tests: Tests = Tests {
     def checkOpt(optimize: Boolean) = {
       val task = if (optimize) MultiModule.client.fullLinkJS else MultiModule.client.fastLinkJS
-      val Right(result) = evaluator(task)
+      val Right(result) = evaluator(task): @unchecked
 
       val runOutput = ScalaJsUtils.runJS(result.value.dest.path / "main.js")
       assert(
@@ -53,7 +53,7 @@ object MultiModuleTests extends TestSuite {
     test("fullOpt") - checkOpt(optimize = true)
 
     test("test") {
-      val Right(result) = evaluator(MultiModule.client.test.test())
+      val Right(result) = evaluator(MultiModule.client.test.test()): @unchecked
 
       assert(
         result.evalCount > 0,
@@ -65,7 +65,7 @@ object MultiModuleTests extends TestSuite {
     test("run") {
       val command = MultiModule.client.run()
 
-      val Right(result) = evaluator(command)
+      val Right(result) = evaluator(command): @unchecked
 
       val paths = EvaluatorPaths.resolveDestPaths(evaluator.outPath, command)
       val log = os.read(paths.log)

--- a/scalajslib/test/src/mill/scalajslib/NodeJSConfigTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/NodeJSConfigTests.scala
@@ -64,7 +64,7 @@ object NodeJSConfigTests extends TestSuite {
   val mainObject = helloWorldEvaluator.outPath / "src/Main.scala"
 
   def tests: Tests = Tests {
-    def checkLog(command: define.Command[_], nodeArgs: List[String], notNodeArgs: List[String]) = {
+    def checkLog(command: define.Command[?], nodeArgs: List[String], notNodeArgs: List[String]) = {
       helloWorldEvaluator(command)
       val paths = EvaluatorPaths.resolveDestPaths(helloWorldEvaluator.outPath, command)
       val log = os.read(paths.log)

--- a/scalajslib/test/src/mill/scalajslib/OutputPatternsTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/OutputPatternsTests.scala
@@ -31,7 +31,7 @@ object OutputPatternsTests extends TestSuite {
   val tests: Tests = Tests {
     test("output patterns") {
       val Right(result) =
-        evaluator(OutputPatternsModule.build.fastLinkJS)
+        evaluator(OutputPatternsModule.build.fastLinkJS): @unchecked
       val publicModules = result.value.publicModules.toSeq
       assert(publicModules.length == 1)
       val main = publicModules(0)

--- a/scalajslib/test/src/mill/scalajslib/ScalaTestsErrorTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/ScalaTestsErrorTests.scala
@@ -3,7 +3,6 @@ package mill.scalajslib
 import mill.define.Discover
 import mill.scalalib.TestModule
 import mill.testkit.TestBaseModule
-import mill.util.TestUtil
 import utest._
 
 object ScalaTestsErrorTests extends TestSuite {

--- a/scalajslib/test/src/mill/scalajslib/SmallModulesForTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/SmallModulesForTests.scala
@@ -29,7 +29,7 @@ object SmallModulesForTests extends TestSuite {
     test("ModuleSplitStyle.SmallModulesFor") {
       println(evaluator(SmallModulesForModule.sources))
 
-      val Right(result) = evaluator(SmallModulesForModule.fastLinkJS)
+      val Right(result) = evaluator(SmallModulesForModule.fastLinkJS): @unchecked
       val publicModules = result.value.publicModules
       test("it should have a single publicModule") {
         assert(publicModules.size == 1)

--- a/scalajslib/test/src/mill/scalajslib/SourceMapTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/SourceMapTests.scala
@@ -28,7 +28,7 @@ object SourceMapTests extends TestSuite {
   val tests: Tests = Tests {
     test("should disable source maps") {
       val Right(result) =
-        evaluator(SourceMapModule.build.fastLinkJS)
+        evaluator(SourceMapModule.build.fastLinkJS): @unchecked
       val publicModules = result.value.publicModules.toSeq
       assert(publicModules.length == 1)
       val main = publicModules.head

--- a/scalajslib/test/src/mill/scalajslib/TopLevelExportsTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/TopLevelExportsTests.scala
@@ -27,7 +27,7 @@ object TopLevelExportsTests extends TestSuite {
     test("top level exports") {
       println(evaluator(TopLevelExportsModule.sources))
       val Right(result) =
-        evaluator(TopLevelExportsModule.fastLinkJS)
+        evaluator(TopLevelExportsModule.fastLinkJS): @unchecked
       val publicModules = result.value.publicModules.toSeq
       assert(publicModules.length == 2)
       val b = publicModules(0)

--- a/scalajslib/test/src/mill/scalajslib/UtestTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/UtestTests.scala
@@ -19,7 +19,7 @@ object UtestTests extends TestSuite {
   def runTests(testTask: define.NamedTask[(String, Seq[TestResult])])
       : Map[String, Map[String, TestResult]] =
     UnitTester(HelloJSWorld, millSourcePath).scoped { eval =>
-      val Left(Result.Failure(_, Some(res))) = eval(testTask)
+      val Left(Result.Failure(_, Some(res))) = eval(testTask): @unchecked
 
       val (doneMsg, testResults) = res
       testResults
@@ -78,8 +78,8 @@ object UtestTests extends TestSuite {
 
     def checkInheritedTargets[A](target: ScalaJSModule => T[A], expected: A) =
       UnitTester(HelloJSWorld, millSourcePath).scoped { eval =>
-        val Right(mainResult) = eval(target(HelloJSWorld.inherited))
-        val Right(testResult) = eval(target(HelloJSWorld.inherited.test))
+        val Right(mainResult) = eval(target(HelloJSWorld.inherited)): @unchecked
+        val Right(testResult) = eval(target(HelloJSWorld.inherited.test)): @unchecked
         assert(mainResult.value == expected)
         assert(testResult.value == expected)
       }

--- a/scalajslib/test/src/mill/scalajslib/UtestTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/UtestTests.scala
@@ -2,17 +2,10 @@ package mill.scalajslib
 
 import mill._
 import mill.api.Result
-import mill.define.Discover
-import mill.eval.EvaluatorPaths
-import mill.scalalib.api.ZincWorkerUtil
-import mill.scalalib.publish.{Developer, License, PomSettings, VersionControl}
-import mill.scalalib.{DepSyntax, PublishModule, ScalaModule, TestModule}
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.UnitTester
 import mill.testrunner.TestResult
 import utest._
 
-import java.util.jar.JarFile
-import scala.jdk.CollectionConverters._
 
 object UtestTests extends TestSuite {
   import CompileLinkTests._

--- a/scalajslib/test/src/mill/scalajslib/UtestTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/UtestTests.scala
@@ -6,7 +6,6 @@ import mill.testkit.UnitTester
 import mill.testrunner.TestResult
 import utest._
 
-
 object UtestTests extends TestSuite {
   import CompileLinkTests._
   def runTests(testTask: define.NamedTask[(String, Seq[TestResult])])

--- a/scalajslib/test/src/mill/scalajslib/WasmTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/WasmTests.scala
@@ -49,7 +49,7 @@ object WasmTests extends TestSuite {
     test("should emit wasm") {
       val evaluator = UnitTester(Wasm, millSourcePath)
       val Right(result) =
-        evaluator(Wasm.fastLinkJS)
+        evaluator(Wasm.fastLinkJS): @unchecked
       val publicModules = result.value.publicModules.toSeq
       val path = result.value.dest.path
       val main = publicModules.head
@@ -64,7 +64,7 @@ object WasmTests extends TestSuite {
 
     test("wasm is runnable") {
       val evaluator = UnitTester(Wasm, millSourcePath)
-      val Right(result) = evaluator(Wasm.fastLinkJS)
+      val Right(result) = evaluator(Wasm.fastLinkJS): @unchecked
       val path = result.value.dest.path
       os.proc("node", "--experimental-wasm-exnref", "main.js").call(
         cwd = path,
@@ -78,7 +78,7 @@ object WasmTests extends TestSuite {
 
     test("should throw for older scalaJS versions") {
       val evaluator = UnitTester(OldWasmModule, millSourcePath)
-      val Left(Result.Exception(ex, _)) = evaluator(OldWasmModule.fastLinkJS)
+      val Left(Result.Exception(ex, _)) = evaluator(OldWasmModule.fastLinkJS): @unchecked
       val error = ex.getMessage
       assert(error == "Emitting wasm is not supported with Scala.js < 1.17")
     }

--- a/scalalib/api/src/mill/scalalib/api/ZincWorkerApi.scala
+++ b/scalalib/api/src/mill/scalalib/api/ZincWorkerApi.scala
@@ -4,7 +4,7 @@ import mill.api.{CompileProblemReporter, PathRef}
 import mill.api.Loose.Agg
 
 object ZincWorkerApi {
-  type Ctx = mill.api.Ctx.Dest with mill.api.Ctx.Log with mill.api.Ctx.Home
+  type Ctx = mill.api.Ctx.Dest & mill.api.Ctx.Log & mill.api.Ctx.Home
 }
 trait ZincWorkerApi {
 

--- a/scalalib/src/mill/scalalib/Assembly.scala
+++ b/scalalib/src/mill/scalalib/Assembly.scala
@@ -181,7 +181,7 @@ object Assembly {
       prependShellScript: String = "",
       base: Option[os.Path] = None,
       assemblyRules: Seq[Assembly.Rule] = Assembly.defaultRules
-  )(implicit ctx: Ctx.Dest with Ctx.Log): PathRef = {
+  )(implicit ctx: Ctx.Dest & Ctx.Log): PathRef = {
     create(
       destJar = ctx.dest / "out.jar",
       inputPaths = inputPaths,

--- a/scalalib/src/mill/scalalib/Dep.scala
+++ b/scalalib/src/mill/scalalib/Dep.scala
@@ -28,8 +28,8 @@ case class Dep(dep: coursier.Dependency, cross: CrossVersion, force: Boolean) {
         exclusions.map { case (k, v) => (coursier.Organization(k), coursier.ModuleName(v)) }
     )
   )
-  def excludeOrg(organizations: String*): Dep = exclude(organizations.map(_ -> "*"): _*)
-  def excludeName(names: String*): Dep = exclude(names.map("*" -> _): _*)
+  def excludeOrg(organizations: String*): Dep = exclude(organizations.map(_ -> "*")*)
+  def excludeName(names: String*): Dep = exclude(names.map("*" -> _)*)
   def toDependency(binaryVersion: String, fullVersion: String, platformSuffix: String): Dependency =
     dep.withModule(
       dep.module.withName(
@@ -128,7 +128,7 @@ object Dep {
       case Array(a, "", "", b, "", c) => Dep(a, b, c, cross = Full(platformed = true))
       case _ => throw new Exception(s"Unable to parse signature: [$signature]")
     })
-      .exclude(exclusions.sorted: _*)
+      .exclude(exclusions.sorted*)
       .configure(attributes = attributes)
   }
 

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -1260,7 +1260,7 @@ trait JavaModule
       args: String*
   ): Command[Unit] = {
     // overridden here for binary compatibility (0.11.x)
-    super.runMainBackground(mainClass, args: _*)
+    super.runMainBackground(mainClass, args*)
   }
 
   /**
@@ -1271,7 +1271,7 @@ trait JavaModule
       args: String*
   ): Command[Unit] = {
     // overridden here for binary compatibility (0.11.x)
-    super.runMainLocal(mainClass, args: _*)
+    super.runMainLocal(mainClass, args*)
   }
 
   /**
@@ -1279,7 +1279,7 @@ trait JavaModule
    */
   override def runMain(@arg(positional = true) mainClass: String, args: String*): Command[Unit] = {
     // overridden here for binary compatibility (0.11.x)
-    super.runMain(mainClass, args: _*)
+    super.runMain(mainClass, args*)
   }
 
   /**

--- a/scalalib/src/mill/scalalib/Lib.scala
+++ b/scalalib/src/mill/scalalib/Lib.scala
@@ -173,7 +173,7 @@ object Lib {
           customizer = None,
           coursierCacheCustomizer = None,
           ctx = ctx
-        )
+        ): @unchecked
         res.items.toList.map(_.path)
     }
   }

--- a/scalalib/src/mill/scalalib/PublishModule.scala
+++ b/scalalib/src/mill/scalalib/PublishModule.scala
@@ -185,7 +185,7 @@ trait PublishModule extends JavaModule { outer =>
     )(_.artifactMetadata)().map { a =>
       Dependency(a, Scope.Import)
     }
-    Agg(fromBomMods: _*) ++
+    Agg(fromBomMods*) ++
       bomIvyDeps().map(resolvePublishDependency.apply().apply(_))
   }
 
@@ -305,9 +305,9 @@ trait PublishModule extends JavaModule { outer =>
       pomPackagingType match {
         case PackagingType.Pom => Task.Anon(Seq())
         case _ => Task.Anon(Seq(
-            (jar(), PublishInfo.jar _),
-            (sourceJar(), PublishInfo.sourcesJar _),
-            (docJar(), PublishInfo.docJar _)
+            (jar(), PublishInfo.jar),
+            (sourceJar(), PublishInfo.sourcesJar),
+            (docJar(), PublishInfo.docJar)
           ))
       }
     }
@@ -596,7 +596,7 @@ object PublishModule extends ExternalModule with TaskModule {
       stagingRelease
     ).publishAll(
       release,
-      x: _*
+      x*
     )
   }
 

--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -134,13 +134,13 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
       if (sv.startsWith("2.")) {
         // Scala 2.x
         val mainClass = cl.loadClass("scala.tools.nsc.Main")
-        val mainMethod = mainClass.getMethod("process", Seq(classOf[Array[String]]): _*)
+        val mainMethod = mainClass.getMethod("process", Seq(classOf[Array[String]])*)
         val exitVal = mainMethod.invoke(null, options.toArray)
         handleResult(true)(exitVal)
       } else {
         // Scala 3.x
         val mainClass = cl.loadClass("dotty.tools.dotc.Main")
-        val mainMethod = mainClass.getMethod("process", Seq(classOf[Array[String]]): _*)
+        val mainMethod = mainClass.getMethod("process", Seq(classOf[Array[String]])*)
         val resultClass = cl.loadClass("dotty.tools.dotc.reporting.Reporter")
         val hasErrorsMethod = resultClass.getMethod("hasErrors")
         val exitVal = mainMethod.invoke(null, options.toArray)

--- a/scalalib/src/mill/scalalib/TestModule.scala
+++ b/scalalib/src/mill/scalalib/TestModule.scala
@@ -288,7 +288,7 @@ object TestModule {
         classPath = runClasspath().map(_.path).toVector,
         sharedPrefixes = Seq("sbt.testing.")
       ) { classLoader =>
-        val builderClass: Class[_] =
+        val builderClass: Class[?] =
           classLoader.loadClass("com.github.sbt.junit.jupiter.api.JupiterTestCollector$Builder")
         val builder = builderClass.getConstructor().newInstance()
 
@@ -312,7 +312,7 @@ object TestModule {
 
         val items = resultClass.getMethod(
           "getDiscoveredTests"
-        ).invoke(result).asInstanceOf[java.util.List[_]]
+        ).invoke(result).asInstanceOf[java.util.List[?]]
         val itemClass =
           classLoader.loadClass("com.github.sbt.junit.jupiter.api.JupiterTestCollector$Item")
 
@@ -385,7 +385,7 @@ object TestModule {
   def handleResults(
       doneMsg: String,
       results: Seq[TestResult],
-      ctx: Ctx.Env with Ctx.Dest,
+      ctx: Ctx.Env & Ctx.Dest,
       testReportXml: Option[String],
       props: Option[Map[String, String]] = None
   ): Result[(String, Seq[TestResult])] =

--- a/scalalib/src/mill/scalalib/TestModuleUtil.scala
+++ b/scalalib/src/mill/scalalib/TestModuleUtil.scala
@@ -227,7 +227,7 @@ private[scalalib] object TestModuleUtil {
   private[scalalib] def handleResults(
       doneMsg: String,
       results: Seq[TestResult],
-      ctx: Ctx.Env with Ctx.Dest,
+      ctx: Ctx.Env & Ctx.Dest,
       testReportXml: Option[String],
       props: Option[Map[String, String]] = None
   ): Result[(String, Seq[TestResult])] = {

--- a/scalalib/src/mill/scalalib/dependency/DependencyUpdatesImpl.scala
+++ b/scalalib/src/mill/scalalib/dependency/DependencyUpdatesImpl.scala
@@ -14,7 +14,7 @@ object DependencyUpdatesImpl {
 
   def apply(
       evaluator: Evaluator,
-      ctx: Log with Home,
+      ctx: Log & Home,
       rootModule: BaseModule,
       discover: Discover,
       allowPreRelease: Boolean

--- a/scalalib/src/mill/scalalib/dependency/versions/Version.scala
+++ b/scalalib/src/mill/scalalib/dependency/versions/Version.scala
@@ -157,21 +157,21 @@ private[dependency] object VersionOrdering extends Ordering[Version] {
     if (a == b) None
     else
       (parsePart(a) zip parsePart(b)) map {
-        case (Left(x), Left(y)) => x compareTo y
+        case (Left(x), Left(y)) => x `compareTo` y
         case (Left(_), Right(_)) => -1
         case (Right(_), Left(_)) => 1
-        case (Right(x), Right(y)) => x compareTo y
-      } find (0 != _) orElse Some(a compareTo b)
+        case (Right(x), Right(y)) => x `compareTo` y
+      } find (0 != _) orElse Some(a `compareTo` b)
   }
 
   private def compareNumericParts(a: List[Long], b: List[Long]): Option[Int] =
     (a, b) match {
       case (ah :: at, bh :: bt) =>
-        toOpt(ah compareTo bh) orElse compareNumericParts(at, bt)
+        toOpt(ah `compareTo` bh) orElse compareNumericParts(at, bt)
       case (ah :: at, Nil) =>
-        toOpt(ah compareTo 0L) orElse compareNumericParts(at, Nil)
+        toOpt(ah `compareTo` 0L) orElse compareNumericParts(at, Nil)
       case (Nil, bh :: bt) =>
-        toOpt(0L compareTo bh) orElse compareNumericParts(Nil, bt)
+        toOpt(0L `compareTo` bh) orElse compareNumericParts(Nil, bt)
       case (Nil, Nil) =>
         None
     }
@@ -190,7 +190,7 @@ private[dependency] object VersionOrdering extends Ordering[Version] {
 
   def compare(x: Version, y: Version): Int = (x, y) match {
     case (InvalidVersion(a), InvalidVersion(b)) =>
-      a compareTo b
+      a `compareTo` b
     case (InvalidVersion(_), _) =>
       -1
     case (_, InvalidVersion(_)) =>

--- a/scalalib/src/mill/scalalib/dependency/versions/VersionsFinder.scala
+++ b/scalalib/src/mill/scalalib/dependency/versions/VersionsFinder.scala
@@ -13,7 +13,7 @@ private[dependency] object VersionsFinder {
 
   def findVersions(
       evaluator: Evaluator,
-      ctx: Log with Home,
+      ctx: Log & Home,
       rootModule: BaseModule
   ): Seq[ModuleDependenciesVersions] = {
 

--- a/scalalib/src/mill/scalalib/publish/Pom.scala
+++ b/scalalib/src/mill/scalalib/publish/Pom.scala
@@ -67,7 +67,7 @@ object Pom {
       if (properties.isEmpty) NodeSeq.Empty
       else
         <properties>
-          {properties.map(renderProperty _).iterator}
+          {properties.map(renderProperty).iterator}
         </properties>
     val depMgmtSection =
       if (dependencyManagement.isEmpty) NodeSeq.Empty

--- a/scalalib/test/src/mill/javalib/checkstyle/CheckstyleModuleTest.scala
+++ b/scalalib/test/src/mill/javalib/checkstyle/CheckstyleModuleTest.scala
@@ -147,7 +147,7 @@ object CheckstyleModuleTest extends TestSuite {
       module,
       modulePath,
       violations,
-      CheckstyleArgs(check, stdout, Leftover(sources: _*))
+      CheckstyleArgs(check, stdout, Leftover(sources*))
     )
   }
 
@@ -174,12 +174,12 @@ object CheckstyleModuleTest extends TestSuite {
       module,
       modulePath,
       violations,
-      CheckstyleArgs(check, stdout, Leftover(sources: _*))
+      CheckstyleArgs(check, stdout, Leftover(sources*))
     )
   }
 
   def testModule(
-      module: TestBaseModule with CheckstyleModule,
+      module: TestBaseModule & CheckstyleModule,
       modulePath: os.Path,
       violations: Seq[String],
       args: CheckstyleArgs
@@ -194,7 +194,7 @@ object CheckstyleModuleTest extends TestSuite {
 
         numViolations.value == violations.length && {
 
-          val Right(report) = eval(module.checkstyleOutput)
+          val Right(report) = eval(module.checkstyleOutput): @unchecked
 
           if (os.exists(report.value.path)) {
             violations.isEmpty || {

--- a/scalalib/test/src/mill/javalib/checkstyle/CheckstyleXsltModuleTest.scala
+++ b/scalalib/test/src/mill/javalib/checkstyle/CheckstyleXsltModuleTest.scala
@@ -48,7 +48,7 @@ object CheckstyleXsltModuleTest extends TestSuite {
     testModule(module, modulePath)
   }
 
-  def testModule(module: TestBaseModule with CheckstyleXsltModule, modulePath: os.Path): Boolean = {
+  def testModule(module: TestBaseModule & CheckstyleXsltModule, modulePath: os.Path): Boolean = {
     val eval = UnitTester(module, modulePath)
 
     eval(module.checkstyle(CheckstyleArgs(check = false, sources = Leftover()))).fold(
@@ -58,7 +58,7 @@ object CheckstyleXsltModuleTest extends TestSuite {
       },
       _ => {
 
-        val Right(reports) = eval(module.checkstyleXsltReports)
+        val Right(reports) = eval(module.checkstyleXsltReports): @unchecked
 
         reports.value.forall(report => os.exists(report.output.path))
       }

--- a/scalalib/test/src/mill/javalib/errorprone/ErrorProneTests.scala
+++ b/scalalib/test/src/mill/javalib/errorprone/ErrorProneTests.scala
@@ -40,7 +40,7 @@ object ErrorProneTests extends TestSuite {
       }
       test("compileWarn") {
         val eval = UnitTester(errorProneCustom, testModuleSourcesPath, debugEnabled = true)
-        val Right(opts) = eval(errorProneCustom.mandatoryJavacOptions)
+        val Right(opts) = eval(errorProneCustom.mandatoryJavacOptions): @unchecked
         assert(opts.value.exists(_.contains("-XepAllErrorsAsWarnings")))
         val res = eval(errorProneCustom.compile)
         assert(res.isRight)

--- a/scalalib/test/src/mill/javalib/palantirformat/PalantirFormatModuleTest.scala
+++ b/scalalib/test/src/mill/javalib/palantirformat/PalantirFormatModuleTest.scala
@@ -106,13 +106,13 @@ object PalantirFormatModuleTest extends TestSuite {
 
     val eval = UnitTester(module, moduleRoot)
 
-    eval(module.palantirformat(mainargs.Flag(check), mainargs.Leftover(sources: _*))).fold(
+    eval(module.palantirformat(mainargs.Flag(check), mainargs.Leftover(sources*))).fold(
       {
         case api.Result.Exception(cause, _) => throw cause
         case failure => throw failure
       },
       { _ =>
-        val Right(sources) = eval(module.sources)
+        val Right(sources) = eval(module.sources): @unchecked
 
         sources.value.flatMap(ref => walkFiles(ref.path))
       }
@@ -133,7 +133,7 @@ object PalantirFormatModuleTest extends TestSuite {
         case failure => throw failure
       },
       { _ =>
-        val Right(sources) = eval(module.sources)
+        val Right(sources) = eval(module.sources): @unchecked
         sources.value.map(_.path).flatMap(walkFiles(_))
       }
     )

--- a/scalalib/test/src/mill/javalib/revapi/RevapiModuleTests.scala
+++ b/scalalib/test/src/mill/javalib/revapi/RevapiModuleTests.scala
@@ -84,7 +84,7 @@ object RevapiModuleTests extends TestSuite {
     eval(module1.publishLocal())
 
     eval = UnitTester(module2, root2)
-    val Right(dir) = eval(module2.revapi())
+    val Right(dir) = eval(module2.revapi()): @unchecked
     dir.value.path
   }
 
@@ -118,7 +118,7 @@ object RevapiModuleTests extends TestSuite {
     }
 
     val eval = UnitTester(module, os.temp.dir())
-    val Right(dir) = eval(module.revapi())
+    val Right(dir) = eval(module.revapi()): @unchecked
     dir.value.path
   }
 }

--- a/scalalib/test/src/mill/scalalib/AssemblyExeTests.scala
+++ b/scalalib/test/src/mill/scalalib/AssemblyExeTests.scala
@@ -16,7 +16,7 @@ object AssemblyExeTests extends TestSuite with AssemblyTestUtils {
     test("Assembly") {
       test("exe") {
         test("small") - UnitTester(TestCase, sourceRoot = sources).scoped { eval =>
-          val Right(result) = eval(TestCase.exe.small.assembly)
+          val Right(result) = eval(TestCase.exe.small.assembly): @unchecked
           val originalPath = result.value.path
           val resolvedPath =
             if (Properties.isWin) {
@@ -28,7 +28,7 @@ object AssemblyExeTests extends TestSuite with AssemblyTestUtils {
         }
 
         test("large-should-fail") - UnitTester(TestCase, sourceRoot = sources).scoped { eval =>
-          val Left(Result.Failure(msg, Some(res))) = eval(TestCase.exe.large.assembly)
+          val Left(Result.Failure(msg, Some(res))) = eval(TestCase.exe.large.assembly): @unchecked
           val expectedMsg =
             """The created assembly jar contains more than 65535 ZIP entries.
               |JARs of that size are known to not work correctly with a prepended shell script.

--- a/scalalib/test/src/mill/scalalib/AssemblyExeTests.scala
+++ b/scalalib/test/src/mill/scalalib/AssemblyExeTests.scala
@@ -2,7 +2,7 @@ package mill.scalalib
 
 import scala.util.Properties
 import mill.api.Result
-import mill.testkit.{UnitTester, TestBaseModule}
+import mill.testkit.UnitTester
 import utest._
 
 // Ensure the assembly is runnable, even if we have assembled lots of dependencies into it

--- a/scalalib/test/src/mill/scalalib/AssemblyNoExeTests.scala
+++ b/scalalib/test/src/mill/scalalib/AssemblyNoExeTests.scala
@@ -1,6 +1,6 @@
 package mill.scalalib
 
-import mill.testkit.{UnitTester, TestBaseModule}
+import mill.testkit.UnitTester
 import utest._
 
 object AssemblyNoExeTests extends TestSuite with AssemblyTestUtils {

--- a/scalalib/test/src/mill/scalalib/AssemblyNoExeTests.scala
+++ b/scalalib/test/src/mill/scalalib/AssemblyNoExeTests.scala
@@ -9,12 +9,12 @@ object AssemblyNoExeTests extends TestSuite with AssemblyTestUtils {
     test("Assembly") {
       test("noExe") {
         test("small") - UnitTester(TestCase, sourceRoot = sources).scoped { eval =>
-          val Right(result) = eval(TestCase.noExe.small.assembly)
+          val Right(result) = eval(TestCase.noExe.small.assembly): @unchecked
           runAssembly(result.value.path, TestCase.millSourcePath)
 
         }
         test("large") - UnitTester(TestCase, sourceRoot = sources).scoped { eval =>
-          val Right(result) = eval(TestCase.noExe.large.assembly)
+          val Right(result) = eval(TestCase.noExe.large.assembly): @unchecked
           runAssembly(result.value.path, TestCase.millSourcePath)
 
         }

--- a/scalalib/test/src/mill/scalalib/AssemblyTestUtils.scala
+++ b/scalalib/test/src/mill/scalalib/AssemblyTestUtils.scala
@@ -3,7 +3,7 @@ package mill.scalalib
 import mill.*
 import mill.define.Discover
 import mill.util.Jvm
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.TestBaseModule
 
 trait AssemblyTestUtils {
 

--- a/scalalib/test/src/mill/scalalib/BomTests.scala
+++ b/scalalib/test/src/mill/scalalib/BomTests.scala
@@ -642,7 +642,7 @@ object BomTests extends TestSuite {
   }
 
   def isInClassPath(
-      module: JavaModule with PublishModule,
+      module: JavaModule & PublishModule,
       jarName: String,
       dependencyModules: Seq[PublishModule] = Nil,
       jarCheck: Option[String => Boolean] = None,

--- a/scalalib/test/src/mill/scalalib/CoursierMirrorTests.scala
+++ b/scalalib/test/src/mill/scalalib/CoursierMirrorTests.scala
@@ -3,9 +3,7 @@ package mill.scalalib
 import mill.define.Discover
 import mill.testkit.UnitTester
 import mill.testkit.TestBaseModule
-import mill.eval.Evaluator
 import utest.*
-import utest.framework.TestPath
 import mill.main.TokenReaders._
 
 object CoursierMirrorTests extends TestSuite {

--- a/scalalib/test/src/mill/scalalib/CoursierMirrorTests.scala
+++ b/scalalib/test/src/mill/scalalib/CoursierMirrorTests.scala
@@ -23,7 +23,7 @@ object CoursierMirrorTests extends TestSuite {
   def tests: Tests = Tests {
     sys.props("coursier.mirrors") = (resourcePath / "mirror.properties").toString
     test("readMirror") - UnitTester(CoursierTest, resourcePath).scoped { eval =>
-      val Right(result) = eval.apply(CoursierTest.core.repositoriesTask)
+      val Right(result) = eval.apply(CoursierTest.core.repositoriesTask): @unchecked
       val centralReplaced = result.value.exists { repo =>
         repo.repr.contains("https://repo.maven.apache.org/maven2")
       }

--- a/scalalib/test/src/mill/scalalib/CoursierParametersTests.scala
+++ b/scalalib/test/src/mill/scalalib/CoursierParametersTests.scala
@@ -34,7 +34,7 @@ object CoursierParametersTests extends TestSuite {
 
   def tests: Tests = Tests {
     test("coursierParams") - UnitTester(CoursierTest, null).scoped { eval =>
-      val Right(result) = eval.apply(CoursierTest.core.compileClasspath)
+      val Right(result) = eval.apply(CoursierTest.core.compileClasspath): @unchecked
       val classPath = result.value.toSeq.map(_.path)
       val pprintVersion = classPath
         .map(_.last)

--- a/scalalib/test/src/mill/scalalib/CoursierParametersTests.scala
+++ b/scalalib/test/src/mill/scalalib/CoursierParametersTests.scala
@@ -1,6 +1,5 @@
 package mill.scalalib
 
-import coursier.util.StringInterpolators.SafeModule
 import mill.Agg
 import mill.define.{Discover, Task}
 import mill.testkit.UnitTester

--- a/scalalib/test/src/mill/scalalib/CrossVersionTests.scala
+++ b/scalalib/test/src/mill/scalalib/CrossVersionTests.scala
@@ -152,7 +152,7 @@ object CrossVersionTests extends TestSuite {
       }
     }
 
-    val Right(libs) = eval.apply(mod.compileClasspath)
+    val Right(libs) = eval.apply(mod.compileClasspath): @unchecked
 
     val libNames = libs.value.map(l => l.path.last).filter(_.endsWith(".jar")).toSeq.sorted
     assert(libNames == expectedLibs.sorted)

--- a/scalalib/test/src/mill/scalalib/CycleTests.scala
+++ b/scalalib/test/src/mill/scalalib/CycleTests.scala
@@ -4,7 +4,6 @@ import mill.api.BuildScriptException
 import mill.define.Discover
 import mill.testkit.UnitTester
 import mill.testkit.TestBaseModule
-import utest.framework.TestPath
 import utest.{TestSuite, Tests, assert, intercept, test}
 import mill.main.TokenReaders._
 

--- a/scalalib/test/src/mill/scalalib/DottyDocTests.scala
+++ b/scalalib/test/src/mill/scalalib/DottyDocTests.scala
@@ -40,7 +40,7 @@ object DottyDocTests extends TestSuite {
 
   def tests: Tests = Tests {
     test("static") - UnitTester(StaticDocsModule, resourcePath).scoped { eval =>
-      val Right(_) = eval.apply(StaticDocsModule.static.docJar)
+      val Right(_) = eval.apply(StaticDocsModule.static.docJar): @unchecked
       val dest = eval.outPath / "static/docJar.dest"
       assert(
         os.exists(dest / "out.jar"), // final jar should exist
@@ -52,7 +52,7 @@ object DottyDocTests extends TestSuite {
       )
     }
     test("empty") - UnitTester(EmptyDocsModule, resourcePath).scoped { eval =>
-      val Right(_) = eval.apply(EmptyDocsModule.empty.docJar)
+      val Right(_) = eval.apply(EmptyDocsModule.empty.docJar): @unchecked
       val dest = eval.outPath / "empty/docJar.dest"
       assert(
         os.exists(dest / "out.jar"),
@@ -60,7 +60,7 @@ object DottyDocTests extends TestSuite {
       )
     }
     test("multiple") - UnitTester(MultiDocsModule, resourcePath).scoped { eval =>
-      val Right(_) = eval.apply(MultiDocsModule.multidocs.docJar)
+      val Right(_) = eval.apply(MultiDocsModule.multidocs.docJar): @unchecked
       val dest = eval.outPath / "multidocs/docJar.dest"
       assert(
         os.exists(dest / "out.jar"), // final jar should exist

--- a/scalalib/test/src/mill/scalalib/DottyDocTests.scala
+++ b/scalalib/test/src/mill/scalalib/DottyDocTests.scala
@@ -3,7 +3,6 @@ package mill.scalalib
 import mill.*
 import mill.define.Discover
 import utest.*
-import utest.framework.TestPath
 import mill.testkit.UnitTester
 import mill.testkit.TestBaseModule
 

--- a/scalalib/test/src/mill/scalalib/HelloJavaTests.scala
+++ b/scalalib/test/src/mill/scalalib/HelloJavaTests.scala
@@ -5,7 +5,7 @@ import mill.api.Result
 import mill.testkit.UnitTester
 import mill.testkit.TestBaseModule
 import utest.*
-import mill.define.{Discover, ModuleRef}
+import mill.define.Discover
 
 object HelloJavaTests extends TestSuite {
 

--- a/scalalib/test/src/mill/scalalib/HelloJavaTests.scala
+++ b/scalalib/test/src/mill/scalalib/HelloJavaTests.scala
@@ -34,9 +34,9 @@ object HelloJavaTests extends TestSuite {
     test("compile") {
       val eval = testEval()
 
-      val Right(result1) = eval.apply(HelloJava.core.compile)
-      val Right(result2) = eval.apply(HelloJava.core.compile)
-      val Right(result3) = eval.apply(HelloJava.app.compile)
+      val Right(result1) = eval.apply(HelloJava.core.compile): @unchecked
+      val Right(result2) = eval.apply(HelloJava.core.compile): @unchecked
+      val Right(result3) = eval.apply(HelloJava.app.compile): @unchecked
 
       assert(
         result1.value == result2.value,
@@ -56,7 +56,7 @@ object HelloJavaTests extends TestSuite {
 
       test("fromScratch") {
         val eval = testEval()
-        val Right(result) = eval.apply(HelloJava.core.semanticDbData)
+        val Right(result) = eval.apply(HelloJava.core.semanticDbData): @unchecked
 
         val outputFiles =
           os.walk(result.value.path).filter(os.isFile).map(_.relativeTo(result.value.path))
@@ -70,7 +70,7 @@ object HelloJavaTests extends TestSuite {
         )
 
         // don't recompile if nothing changed
-        val Right(result2) = eval.apply(HelloJava.core.semanticDbData)
+        val Right(result2) = eval.apply(HelloJava.core.semanticDbData): @unchecked
         assert(result2.evalCount == 0)
       }
       test("incremental") {
@@ -103,7 +103,7 @@ object HelloJavaTests extends TestSuite {
             |""".stripMargin,
           createFolders = true
         )
-        val Right(result) = eval.apply(HelloJava.core.semanticDbData)
+        val Right(result) = eval.apply(HelloJava.core.semanticDbData): @unchecked
 
         val dataPath = eval.outPath / "core/semanticDbData.dest/data"
         val outputFiles =
@@ -124,7 +124,7 @@ object HelloJavaTests extends TestSuite {
         os.remove(secondFile)
         os.write.append(thirdFile, "  ")
 
-        val Right(result2) = eval.apply(HelloJava.core.semanticDbData)
+        val Right(result2) = eval.apply(HelloJava.core.semanticDbData): @unchecked
         val files2 =
           os.walk(result2.value.path).filter(os.isFile).map(_.relativeTo(result2.value.path))
         assert(
@@ -136,14 +136,14 @@ object HelloJavaTests extends TestSuite {
     test("docJar") {
       test("withoutArgsFile") {
         val eval = testEval()
-        val Right(result) = eval.apply(HelloJava.core.docJar)
+        val Right(result) = eval.apply(HelloJava.core.docJar): @unchecked
         assert(
           os.proc("jar", "tf", result.value.path).call().out.lines().contains("hello/Core.html")
         )
       }
       test("withArgsFile") {
         val eval = testEval()
-        val Right(result) = eval.apply(HelloJava.app.docJar)
+        val Right(result) = eval.apply(HelloJava.app.docJar): @unchecked
         assert(
           os.proc("jar", "tf", result.value.path).call().out.lines().contains("hello/Main.html")
         )
@@ -152,7 +152,7 @@ object HelloJavaTests extends TestSuite {
     test("test") - {
       val eval = testEval()
 
-      val Left(Result.Failure(ref1, Some(v1))) = eval.apply(HelloJava.core.test.test())
+      val Left(Result.Failure(ref1, Some(v1))) = eval.apply(HelloJava.core.test.test()): @unchecked
 
       assert(
         v1._2(0).fullyQualifiedName == "hello.MyCoreTests.java11Test",
@@ -163,7 +163,7 @@ object HelloJavaTests extends TestSuite {
         v1._2(3).status == "Failure"
       )
 
-      val Right(result2) = eval.apply(HelloJava.app.test.test())
+      val Right(result2) = eval.apply(HelloJava.app.test.test()): @unchecked
 
       assert(
         result2.value._2(0).fullyQualifiedName == "hello.MyAppTests.appTest",
@@ -172,7 +172,7 @@ object HelloJavaTests extends TestSuite {
         result2.value._2(1).status == "Success"
       )
 
-      val Right(result3) = eval.apply(HelloJava.app.testJunit5.test())
+      val Right(result3) = eval.apply(HelloJava.app.testJunit5.test()): @unchecked
 
       val testResults =
         result3.value._2.map(t => (t.fullyQualifiedName, t.selector, t.status)).sorted
@@ -192,24 +192,24 @@ object HelloJavaTests extends TestSuite {
       val mainJava = HelloJava.millSourcePath / "app/src/Main.java"
       val coreJava = HelloJava.millSourcePath / "core/src/Core.java"
 
-      val Right(_) = eval.apply(HelloJava.core.compile)
-      val Right(_) = eval.apply(HelloJava.app.compile)
+      val Right(_) = eval.apply(HelloJava.core.compile): @unchecked
+      val Right(_) = eval.apply(HelloJava.app.compile): @unchecked
 
       os.write.over(mainJava, os.read(mainJava) + "}")
 
-      val Right(_) = eval.apply(HelloJava.core.compile)
-      val Left(_) = eval.apply(HelloJava.app.compile)
+      val Right(_) = eval.apply(HelloJava.core.compile): @unchecked
+      val Left(_) = eval.apply(HelloJava.app.compile): @unchecked
 
       os.write.over(coreJava, os.read(coreJava) + "}")
 
-      val Left(_) = eval.apply(HelloJava.core.compile)
-      val Left(_) = eval.apply(HelloJava.app.compile)
+      val Left(_) = eval.apply(HelloJava.core.compile): @unchecked
+      val Left(_) = eval.apply(HelloJava.app.compile): @unchecked
 
       os.write.over(mainJava, os.read(mainJava).dropRight(1))
       os.write.over(coreJava, os.read(coreJava).dropRight(1))
 
-      val Right(_) = eval.apply(HelloJava.core.compile)
-      val Right(_) = eval.apply(HelloJava.app.compile)
+      val Right(_) = eval.apply(HelloJava.core.compile): @unchecked
+      val Right(_) = eval.apply(HelloJava.app.compile): @unchecked
     }
   }
 }

--- a/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
+++ b/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
@@ -123,7 +123,7 @@ object HelloWorldTests extends TestSuite {
     test("scalaVersion") {
 
       test("fromBuild") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
-        val Right(result) = eval.apply(HelloWorld.core.scalaVersion)
+        val Right(result) = eval.apply(HelloWorld.core.scalaVersion): @unchecked
 
         assert(
           result.value == scala212Version,
@@ -131,7 +131,7 @@ object HelloWorldTests extends TestSuite {
         )
       }
       test("override") - UnitTester(HelloWorldScalaOverride, resourcePath).scoped { eval =>
-        val Right(result) = eval.apply(HelloWorldScalaOverride.core.scalaVersion)
+        val Right(result) = eval.apply(HelloWorldScalaOverride.core.scalaVersion): @unchecked
 
         assert(
           result.value == scala213Version,
@@ -142,7 +142,7 @@ object HelloWorldTests extends TestSuite {
 
     test("scalacOptions") {
       test("emptyByDefault") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
-        val Right(result) = eval.apply(HelloWorld.core.scalacOptions)
+        val Right(result) = eval.apply(HelloWorld.core.scalacOptions): @unchecked
 
         assert(
           result.value.isEmpty,
@@ -150,7 +150,7 @@ object HelloWorldTests extends TestSuite {
         )
       }
       test("override") - UnitTester(HelloWorldFatalWarnings, resourcePath).scoped { eval =>
-        val Right(result) = eval.apply(HelloWorldFatalWarnings.core.scalacOptions)
+        val Right(result) = eval.apply(HelloWorldFatalWarnings.core.scalacOptions): @unchecked
 
         assert(
           result.value == Seq("-Ywarn-unused", "-Xfatal-warnings"),
@@ -161,7 +161,7 @@ object HelloWorldTests extends TestSuite {
 
     test("compile") {
       test("fromScratch") - UnitTester(HelloWorld, sourceRoot = resourcePath).scoped { eval =>
-        val Right(result) = eval.apply(HelloWorld.core.compile)
+        val Right(result) = eval.apply(HelloWorld.core.compile): @unchecked
 
         val classesPath = eval.outPath / "core/compile.dest/classes"
         val analysisFile = result.value.analysisFile
@@ -176,7 +176,7 @@ object HelloWorldTests extends TestSuite {
         )
 
         // don't recompile if nothing changed
-        val Right(result2) = eval.apply(HelloWorld.core.compile)
+        val Right(result2) = eval.apply(HelloWorld.core.compile): @unchecked
 
         assert(result2.evalCount == 0)
 
@@ -191,7 +191,7 @@ object HelloWorldTests extends TestSuite {
         HelloWorldNonPrecompiledBridge,
         sourceRoot = resourcePath
       ).scoped { eval =>
-        val Right(result) = eval.apply(HelloWorldNonPrecompiledBridge.core.compile)
+        val Right(result) = eval.apply(HelloWorldNonPrecompiledBridge.core.compile): @unchecked
 
         val classesPath = eval.outPath / "core/compile.dest/classes"
 
@@ -207,7 +207,7 @@ object HelloWorldTests extends TestSuite {
         )
 
         // don't recompile if nothing changed
-        val Right(result2) = eval.apply(HelloWorldNonPrecompiledBridge.core.compile)
+        val Right(result2) = eval.apply(HelloWorldNonPrecompiledBridge.core.compile): @unchecked
 
         assert(result2.evalCount == 0)
 
@@ -219,18 +219,18 @@ object HelloWorldTests extends TestSuite {
       }
 
       test("recompileOnChange") - UnitTester(HelloWorld, sourceRoot = resourcePath).scoped { eval =>
-        val Right(result) = eval.apply(HelloWorld.core.compile)
+        val Right(result) = eval.apply(HelloWorld.core.compile): @unchecked
         assert(result.evalCount > 0)
 
         os.write.append(HelloWorld.millSourcePath / "core/src/Main.scala", "\n")
 
-        val Right(result2) = eval.apply(HelloWorld.core.compile)
+        val Right(result2) = eval.apply(HelloWorld.core.compile): @unchecked
         assert(result2.evalCount > 0, result2.evalCount < result.evalCount)
       }
       test("failOnError") - UnitTester(HelloWorld, sourceRoot = resourcePath).scoped { eval =>
         os.write.append(HelloWorld.millSourcePath / "core/src/Main.scala", "val x: ")
 
-        val Left(Result.Failure("Compilation failed", _)) = eval.apply(HelloWorld.core.compile)
+        val Left(Result.Failure("Compilation failed", _)) = eval.apply(HelloWorld.core.compile): @unchecked
 
         val paths = EvaluatorPaths.resolveDestPaths(eval.outPath, HelloWorld.core.compile)
 
@@ -246,7 +246,7 @@ object HelloWorldTests extends TestSuite {
           )
         )
 
-        val Right(_) = eval.apply(HelloWorld.core.compile)
+        val Right(_) = eval.apply(HelloWorld.core.compile): @unchecked
       }
       test("passScalacOptions") - UnitTester(
         HelloWorldFatalWarnings,
@@ -254,20 +254,20 @@ object HelloWorldTests extends TestSuite {
       ).scoped { eval =>
         // compilation fails because of "-Xfatal-warnings" flag
         val Left(Result.Failure("Compilation failed", _)) =
-          eval.apply(HelloWorldFatalWarnings.core.compile)
+          eval.apply(HelloWorldFatalWarnings.core.compile): @unchecked
       }
     }
 
     test("artifactNameCross") - UnitTester(CrossHelloWorld, sourceRoot = resourcePath).scoped {
       eval =>
         val Right(result) =
-          eval.apply(CrossHelloWorld.core(scala213Version).artifactName)
+          eval.apply(CrossHelloWorld.core(scala213Version).artifactName): @unchecked
         assert(result.value == "core")
     }
 
     test("jar") {
       test("nonEmpty") - UnitTester(HelloWorldWithMain, resourcePath).scoped { eval =>
-        val Right(result) = eval.apply(HelloWorldWithMain.core.jar)
+        val Right(result) = eval.apply(HelloWorldWithMain.core.jar): @unchecked
 
         assert(
           os.exists(result.value.path),

--- a/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
+++ b/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
@@ -230,7 +230,8 @@ object HelloWorldTests extends TestSuite {
       test("failOnError") - UnitTester(HelloWorld, sourceRoot = resourcePath).scoped { eval =>
         os.write.append(HelloWorld.millSourcePath / "core/src/Main.scala", "val x: ")
 
-        val Left(Result.Failure("Compilation failed", _)) = eval.apply(HelloWorld.core.compile): @unchecked
+        val Left(Result.Failure("Compilation failed", _)) =
+          eval.apply(HelloWorld.core.compile): @unchecked
 
         val paths = EvaluatorPaths.resolveDestPaths(eval.outPath, HelloWorld.core.compile)
 

--- a/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
+++ b/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
@@ -1,18 +1,16 @@
 package mill.scalalib
 
-import java.io.{ByteArrayOutputStream, PrintStream}
+import java.io.ByteArrayOutputStream
 import java.util.jar.JarFile
 import scala.jdk.CollectionConverters.*
-import scala.util.{Properties, Using}
+import scala.util.Using
 import mill.*
 import mill.api.Result
-import mill.define.{Discover, NamedTask}
-import mill.eval.{Evaluator, EvaluatorPaths}
+import mill.define.Discover
+import mill.eval.EvaluatorPaths
 import mill.testkit.UnitTester
 import mill.testkit.TestBaseModule
-import mill.util.TestUtil
 import utest.*
-import utest.framework.TestPath
 
 object HelloWorldTests extends TestSuite {
 

--- a/scalalib/test/src/mill/scalalib/JavaHomeTests.scala
+++ b/scalalib/test/src/mill/scalalib/JavaHomeTests.scala
@@ -107,7 +107,8 @@ object JavaHomeTests extends TestSuite {
         val eval = UnitTester(HelloJavaJavaHome11Override, resourcePath)
 
         val path = eval.evaluator.workspace / "java.version"
-        val Right(_) = eval.apply(HelloJavaJavaHome11Override.core.run(Task.Anon(Args(path)))): @unchecked
+        val Right(_) =
+          eval.apply(HelloJavaJavaHome11Override.core.run(Task.Anon(Args(path)))): @unchecked
 
         assert(
           os.read(path).startsWith("11.")
@@ -117,7 +118,8 @@ object JavaHomeTests extends TestSuite {
         val eval = UnitTester(HelloJavaJavaHome17Override, resourcePath)
 
         val path = eval.evaluator.workspace / "java.version"
-        val Right(_) = eval.apply(HelloJavaJavaHome17Override.core.run(Task.Anon(Args(path)))): @unchecked
+        val Right(_) =
+          eval.apply(HelloJavaJavaHome17Override.core.run(Task.Anon(Args(path)))): @unchecked
 
         assert(
           os.read(path).startsWith("17.")

--- a/scalalib/test/src/mill/scalalib/JavaHomeTests.scala
+++ b/scalalib/test/src/mill/scalalib/JavaHomeTests.scala
@@ -76,7 +76,7 @@ object JavaHomeTests extends TestSuite {
       test("compile11") {
         val eval = UnitTester(HelloJavaJavaHome11Override, resourcePath)
 
-        val Right(result) = eval.apply(HelloJavaJavaHome11Override.core.compile)
+        val Right(result) = eval.apply(HelloJavaJavaHome11Override.core.compile): @unchecked
 
         val coreClassFile = os.walk(result.value.classes.path).find(_.last == "Core.class")
 
@@ -91,7 +91,7 @@ object JavaHomeTests extends TestSuite {
       test("compile17") {
         val eval = UnitTester(HelloJavaJavaHome17Override, resourcePath)
 
-        val Right(result) = eval.apply(HelloJavaJavaHome17Override.core.compile)
+        val Right(result) = eval.apply(HelloJavaJavaHome17Override.core.compile): @unchecked
 
         val coreClassFile = os.walk(result.value.classes.path).find(_.last == "Core.class")
 
@@ -107,7 +107,7 @@ object JavaHomeTests extends TestSuite {
         val eval = UnitTester(HelloJavaJavaHome11Override, resourcePath)
 
         val path = eval.evaluator.workspace / "java.version"
-        val Right(_) = eval.apply(HelloJavaJavaHome11Override.core.run(Task.Anon(Args(path))))
+        val Right(_) = eval.apply(HelloJavaJavaHome11Override.core.run(Task.Anon(Args(path)))): @unchecked
 
         assert(
           os.read(path).startsWith("11.")
@@ -117,7 +117,7 @@ object JavaHomeTests extends TestSuite {
         val eval = UnitTester(HelloJavaJavaHome17Override, resourcePath)
 
         val path = eval.evaluator.workspace / "java.version"
-        val Right(_) = eval.apply(HelloJavaJavaHome17Override.core.run(Task.Anon(Args(path))))
+        val Right(_) = eval.apply(HelloJavaJavaHome17Override.core.run(Task.Anon(Args(path)))): @unchecked
 
         assert(
           os.read(path).startsWith("17.")
@@ -127,7 +127,7 @@ object JavaHomeTests extends TestSuite {
         val eval = UnitTester(HelloJavaJavaHome11Override, resourcePath)
 
         val Left(Result.Failure(ref1, Some(v1))) =
-          eval.apply(HelloJavaJavaHome11Override.core.test.test())
+          eval.apply(HelloJavaJavaHome11Override.core.test.test()): @unchecked
 
         assert(
           v1._2(0).fullyQualifiedName == "hello.MyCoreTests.java11Test",
@@ -140,7 +140,7 @@ object JavaHomeTests extends TestSuite {
         val eval = UnitTester(HelloJavaJavaHome17Override, resourcePath)
 
         val Left(Result.Failure(ref1, Some(v1))) =
-          eval.apply(HelloJavaJavaHome17Override.core.test.test())
+          eval.apply(HelloJavaJavaHome17Override.core.test.test()): @unchecked
 
         assert(
           v1._2(0).fullyQualifiedName == "hello.MyCoreTests.java11Test",
@@ -157,14 +157,14 @@ object JavaHomeTests extends TestSuite {
         val baos = new ByteArrayOutputStream()
         val eval =
           UnitTester(JavaJdk11DoesntCompile, resourcePathCompile, errStream = new PrintStream(baos))
-        val Left(result) = eval.apply(JavaJdk11DoesntCompile.javamodule.compile)
+        val Left(result) = eval.apply(JavaJdk11DoesntCompile.javamodule.compile): @unchecked
         assert(baos.toString.contains("cannot find symbol"))
         assert(baos.toString.contains("method indent"))
       }
 
       test("jdk17java") {
         val eval = UnitTester(JavaJdk17Compiles, resourcePathCompile)
-        val Right(result) = eval.apply(JavaJdk17Compiles.javamodule.compile)
+        val Right(result) = eval.apply(JavaJdk17Compiles.javamodule.compile): @unchecked
       }
 
       // This doesn't work because Zinc doesn't apply the javaHome config to
@@ -177,7 +177,7 @@ object JavaHomeTests extends TestSuite {
 
       test("jdk17scala") {
         val eval = UnitTester(JavaJdk17Compiles, resourcePathCompile)
-        val Right(result) = eval.apply(JavaJdk17Compiles.scalamodule.compile)
+        val Right(result) = eval.apply(JavaJdk17Compiles.scalamodule.compile): @unchecked
       }
     }
 

--- a/scalalib/test/src/mill/scalalib/LauncherTests.scala
+++ b/scalalib/test/src/mill/scalalib/LauncherTests.scala
@@ -24,7 +24,7 @@ object LauncherTests extends TestSuite {
     def check(executableTask: mill.define.Target[mill.api.PathRef], copyBat: Boolean = false) = {
       val eval = UnitTester(HelloJava, resourcePath)
 
-      val Right(result1) = eval.apply(executableTask)
+      val Right(result1) = eval.apply(executableTask): @unchecked
 
       val executable =
         if (mill.util.Util.windowsPlatform && copyBat) {
@@ -44,7 +44,7 @@ object LauncherTests extends TestSuite {
         .out.text()
       assert(text2.contains("test.property 123"))
       assert(!text2.contains(customJavaVersion))
-      val Right(javaHome) = eval.apply(HelloJava.ZincWorkerJava.javaHome)
+      val Right(javaHome) = eval.apply(HelloJava.ZincWorkerJava.javaHome): @unchecked
 
       val text3 = os
         .call(executable, env = Map("JAVA_HOME" -> javaHome.value.get.path.toString))

--- a/scalalib/test/src/mill/scalalib/PublishModuleTests.scala
+++ b/scalalib/test/src/mill/scalalib/PublishModuleTests.scala
@@ -15,7 +15,6 @@ import mill.scalalib.publish.{
 import mill.testkit.UnitTester
 import mill.testkit.TestBaseModule
 import utest.*
-import utest.framework.TestPath
 import mill.main.TokenReaders._
 import java.io.PrintStream
 import scala.jdk.CollectionConverters.*

--- a/scalalib/test/src/mill/scalalib/PublishModuleTests.scala
+++ b/scalalib/test/src/mill/scalalib/PublishModuleTests.scala
@@ -123,7 +123,7 @@ object PublishModuleTests extends TestSuite {
         HelloWorldWithPublish,
         resourcePath
       ).scoped { eval =>
-        val Right(result) = eval.apply(HelloWorldWithPublish.core.pom)
+        val Right(result) = eval.apply(HelloWorldWithPublish.core.pom): @unchecked
 
         assert(
           os.exists(result.value.path),
@@ -139,7 +139,7 @@ object PublishModuleTests extends TestSuite {
         )
       }
       test("versionScheme") - UnitTester(HelloWorldWithPublish, resourcePath).scoped { eval =>
-        val Right(result) = eval.apply(HelloWorldWithPublish.core.pom)
+        val Right(result) = eval.apply(HelloWorldWithPublish.core.pom): @unchecked
 
         assert(
           os.exists(result.value.path),
@@ -165,7 +165,7 @@ object PublishModuleTests extends TestSuite {
           )
         ).scoped { eval =>
           val Right(result) =
-            eval.apply(HelloWorldWithPublish.core.checkSonatypeCreds(""))
+            eval.apply(HelloWorldWithPublish.core.checkSonatypeCreds("")): @unchecked
 
           assert(
             result.value == "user:password",
@@ -186,7 +186,7 @@ object PublishModuleTests extends TestSuite {
         ).scoped { eval =>
           val directValue = "direct:value"
           val Right(result) =
-            eval.apply(HelloWorldWithPublish.core.checkSonatypeCreds(directValue))
+            eval.apply(HelloWorldWithPublish.core.checkSonatypeCreds(directValue)): @unchecked
 
           assert(
             result.value == directValue,
@@ -198,7 +198,7 @@ object PublishModuleTests extends TestSuite {
         "should throw exception if neither environment variables or direct argument were not passed"
       ) - UnitTester(HelloWorldWithPublish, resourcePath).scoped { eval =>
         val Left(Result.Failure(msg, None)) =
-          eval.apply(HelloWorldWithPublish.core.checkSonatypeCreds(""))
+          eval.apply(HelloWorldWithPublish.core.checkSonatypeCreds("")): @unchecked
 
         assert(
           msg.contains(
@@ -213,7 +213,7 @@ object PublishModuleTests extends TestSuite {
         HelloWorldWithPublish,
         resourcePath
       ).scoped { eval =>
-        val Right(result) = eval.apply(HelloWorldWithPublish.core.ivy)
+        val Right(result) = eval.apply(HelloWorldWithPublish.core.ivy): @unchecked
 
         assert(
           os.exists(result.value.path),
@@ -231,7 +231,7 @@ object PublishModuleTests extends TestSuite {
 
     test("pom-packaging-type") - {
       test("pom") - UnitTester(PomOnly, resourcePath).scoped { eval =>
-        val Right(result) = eval.apply(PomOnly.core.pom)
+        val Right(result) = eval.apply(PomOnly.core.pom): @unchecked
 //
 //        assert(
 //          os.exists(result.path),

--- a/scalalib/test/src/mill/scalalib/ResolveDepsTests.scala
+++ b/scalalib/test/src/mill/scalalib/ResolveDepsTests.scala
@@ -61,14 +61,14 @@ object ResolveDepsTests extends TestSuite {
   val tests = Tests {
     test("resolveValidDeps") {
       val deps = Agg(ivy"com.lihaoyi::pprint:0.5.3")
-      val Success(paths) = evalDeps(deps)
+      val Success(paths) = evalDeps(deps): @unchecked
       assert(paths.nonEmpty)
     }
 
     test("resolveValidDepsWithClassifier") {
       val deps = Agg(ivy"org.lwjgl:lwjgl:3.1.1;classifier=natives-macos")
       assertRoundTrip(deps, simplified = true)
-      val Success(paths) = evalDeps(deps)
+      val Success(paths) = evalDeps(deps): @unchecked
       assert(paths.nonEmpty)
       assert(paths.items.next().path.toString.contains("natives-macos"))
     }
@@ -76,7 +76,7 @@ object ResolveDepsTests extends TestSuite {
     test("resolveTransitiveRuntimeDeps") {
       val deps = Agg(ivy"org.mockito:mockito-core:2.7.22")
       assertRoundTrip(deps, simplified = true)
-      val Success(paths) = evalDeps(deps)
+      val Success(paths) = evalDeps(deps): @unchecked
       assert(paths.nonEmpty)
       assert(paths.exists(_.path.toString.contains("objenesis")))
       assert(paths.exists(_.path.toString.contains("byte-buddy")))
@@ -85,14 +85,14 @@ object ResolveDepsTests extends TestSuite {
     test("excludeTransitiveDeps") {
       val deps = Agg(ivy"com.lihaoyi::pprint:0.5.3".exclude("com.lihaoyi" -> "fansi_2.12"))
       assertRoundTrip(deps, simplified = true)
-      val Success(paths) = evalDeps(deps)
+      val Success(paths) = evalDeps(deps): @unchecked
       assert(!paths.exists(_.path.toString.contains("fansi_2.12")))
     }
 
     test("excludeTransitiveDepsByOrg") {
       val deps = Agg(ivy"com.lihaoyi::pprint:0.5.3".excludeOrg("com.lihaoyi"))
       assertRoundTrip(deps, simplified = true)
-      val Success(paths) = evalDeps(deps)
+      val Success(paths) = evalDeps(deps): @unchecked
       assert(!paths.exists(path =>
         path.path.toString.contains("com/lihaoyi") && !path.path.toString.contains("pprint_2.12")
       ))
@@ -101,39 +101,39 @@ object ResolveDepsTests extends TestSuite {
     test("excludeTransitiveDepsByName") {
       val deps = Agg(ivy"com.lihaoyi::pprint:0.5.3".excludeName("fansi_2.12"))
       assertRoundTrip(deps, simplified = true)
-      val Success(paths) = evalDeps(deps)
+      val Success(paths) = evalDeps(deps): @unchecked
       assert(!paths.exists(_.path.toString.contains("fansi_2.12")))
     }
 
     test("errOnInvalidOrgDeps") {
       val deps = Agg(ivy"xxx.yyy.invalid::pprint:0.5.3")
       assertRoundTrip(deps, simplified = true)
-      val Failure(errMsg, _) = evalDeps(deps)
+      val Failure(errMsg, _) = evalDeps(deps): @unchecked
       assert(errMsg.contains("xxx.yyy.invalid"))
     }
 
     test("errOnInvalidVersionDeps") {
       val deps = Agg(ivy"com.lihaoyi::pprint:invalid.version.num")
       assertRoundTrip(deps, simplified = true)
-      val Failure(errMsg, _) = evalDeps(deps)
+      val Failure(errMsg, _) = evalDeps(deps): @unchecked
       assert(errMsg.contains("invalid.version.num"))
     }
 
     test("errOnPartialSuccess") {
       val deps = Agg(ivy"com.lihaoyi::pprint:0.5.3", ivy"fake::fake:fake")
       assertRoundTrip(deps, simplified = true)
-      val Failure(errMsg, _) = evalDeps(deps)
+      val Failure(errMsg, _) = evalDeps(deps): @unchecked
       assert(errMsg.contains("fake"))
     }
 
     test("pomArtifactType") {
       val sources = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "pomArtifactType"
       UnitTester(TestCase, sourceRoot = sources).scoped { eval =>
-        val Right(compileResult) = eval(TestCase.pomStuff.compileClasspath)
+        val Right(compileResult) = eval(TestCase.pomStuff.compileClasspath): @unchecked
         val compileCp = compileResult.value.toSeq.map(_.path)
         assert(compileCp.exists(_.lastOpt.contains("hadoop-yarn-server-3.4.0.pom")))
 
-        val Right(runResult) = eval(TestCase.pomStuff.runClasspath)
+        val Right(runResult) = eval(TestCase.pomStuff.runClasspath): @unchecked
         val runCp = runResult.value.toSeq.map(_.path)
         assert(runCp.exists(_.lastOpt.contains("hadoop-yarn-server-3.4.0.pom")))
       }

--- a/scalalib/test/src/mill/scalalib/ScalaAmmoniteTests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaAmmoniteTests.scala
@@ -22,9 +22,11 @@ object ScalaAmmoniteTests extends TestSuite {
   def tests: Tests = Tests {
 
     test("replAmmoniteMainClass") - UnitTester(AmmoniteReplMainClass, null).scoped { eval =>
-      val Right(result) = eval.apply(AmmoniteReplMainClass.oldAmmonite.ammoniteMainClass): @unchecked
+      val Right(result) =
+        eval.apply(AmmoniteReplMainClass.oldAmmonite.ammoniteMainClass): @unchecked
       assert(result.value == "ammonite.Main")
-      val Right(result2) = eval.apply(AmmoniteReplMainClass.newAmmonite.ammoniteMainClass): @unchecked
+      val Right(result2) =
+        eval.apply(AmmoniteReplMainClass.newAmmonite.ammoniteMainClass): @unchecked
       assert(result2.value == "ammonite.AmmoniteMain")
     }
 

--- a/scalalib/test/src/mill/scalalib/ScalaAmmoniteTests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaAmmoniteTests.scala
@@ -22,9 +22,9 @@ object ScalaAmmoniteTests extends TestSuite {
   def tests: Tests = Tests {
 
     test("replAmmoniteMainClass") - UnitTester(AmmoniteReplMainClass, null).scoped { eval =>
-      val Right(result) = eval.apply(AmmoniteReplMainClass.oldAmmonite.ammoniteMainClass)
+      val Right(result) = eval.apply(AmmoniteReplMainClass.oldAmmonite.ammoniteMainClass): @unchecked
       assert(result.value == "ammonite.Main")
-      val Right(result2) = eval.apply(AmmoniteReplMainClass.newAmmonite.ammoniteMainClass)
+      val Right(result2) = eval.apply(AmmoniteReplMainClass.newAmmonite.ammoniteMainClass): @unchecked
       assert(result2.value == "ammonite.AmmoniteMain")
     }
 

--- a/scalalib/test/src/mill/scalalib/ScalaAssemblyAppendTests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaAssemblyAppendTests.scala
@@ -12,7 +12,7 @@ object ScalaAssemblyAppendTests extends TestSuite with ScalaAssemblyTestUtils {
   def tests: Tests = Tests {
     def checkAppend[M <: mill.testkit.TestBaseModule](module: M, target: Target[PathRef]) =
       UnitTester(module, resourcePath).scoped { eval =>
-        val Right(result) = eval.apply(target)
+        val Right(result) = eval.apply(target): @unchecked
 
         Using.resource(new JarFile(result.value.path.toIO)) { jarFile =>
           assert(jarEntries(jarFile).contains("reference.conf"))
@@ -41,7 +41,7 @@ object ScalaAssemblyAppendTests extends TestSuite with ScalaAssemblyTestUtils {
       module,
       sourceRoot = helloWorldMultiResourcePath
     ).scoped { eval =>
-      val Right(result) = eval.apply(target)
+      val Right(result) = eval.apply(target): @unchecked
 
       Using.resource(new JarFile(result.value.path.toIO)) { jarFile =>
         assert(jarEntries(jarFile).contains("reference.conf"))
@@ -67,7 +67,7 @@ object ScalaAssemblyAppendTests extends TestSuite with ScalaAssemblyTestUtils {
       module,
       sourceRoot = helloWorldMultiResourcePath
     ).scoped { eval =>
-      val Right(result) = eval.apply(target)
+      val Right(result) = eval.apply(target): @unchecked
 
       Using.resource(new JarFile(result.value.path.toIO)) { jarFile =>
         assert(jarEntries(jarFile).contains("without-new-line.conf"))

--- a/scalalib/test/src/mill/scalalib/ScalaAssemblyAppendTests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaAssemblyAppendTests.scala
@@ -1,7 +1,7 @@
 package mill.scalalib
 
 import mill._
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.UnitTester
 import utest._
 
 import java.util.jar.JarFile

--- a/scalalib/test/src/mill/scalalib/ScalaAssemblyExcludeTests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaAssemblyExcludeTests.scala
@@ -14,7 +14,7 @@ object ScalaAssemblyExcludeTests extends TestSuite with ScalaAssemblyTestUtils {
         target: Target[PathRef],
         resourcePath: os.Path = resourcePath
     ) = UnitTester(module, resourcePath).scoped { eval =>
-      val Right(result) = eval.apply(target)
+      val Right(result) = eval.apply(target): @unchecked
 
       Using.resource(new JarFile(result.value.path.toIO)) { jarFile =>
         assert(!jarEntries(jarFile).contains("reference.conf"))
@@ -45,7 +45,7 @@ object ScalaAssemblyExcludeTests extends TestSuite with ScalaAssemblyTestUtils {
         target: Target[PathRef],
         resourcePath: os.Path = resourcePath
     ) = UnitTester(module, resourcePath).scoped { eval =>
-      val Right(result) = eval.apply(target)
+      val Right(result) = eval.apply(target): @unchecked
       Using.resource(new JarFile(result.value.path.toIO)) { jarFile =>
         assert(!jarEntries(jarFile).contains("akka/http/scaladsl/model/HttpEntity.class"))
         assert(
@@ -64,14 +64,14 @@ object ScalaAssemblyExcludeTests extends TestSuite with ScalaAssemblyTestUtils {
         HelloWorldAkkaHttpRelocate,
         sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "hello-world-deps"
       ).scoped { eval =>
-        val Right(result) = eval.apply(HelloWorldAkkaHttpRelocate.core.runMain("Main"))
+        val Right(result) = eval.apply(HelloWorldAkkaHttpRelocate.core.runMain("Main")): @unchecked
         assert(result.evalCount > 0)
       }
     }
 
     test("writeDownstreamWhenNoRule") {
       test("withDeps") - UnitTester(HelloWorldAkkaHttpNoRules, null).scoped { eval =>
-        val Right(result) = eval.apply(HelloWorldAkkaHttpNoRules.core.assembly)
+        val Right(result) = eval.apply(HelloWorldAkkaHttpNoRules.core.assembly): @unchecked
 
         Using.resource(new JarFile(result.value.path.toIO)) { jarFile =>
           assert(jarEntries(jarFile).contains("reference.conf"))
@@ -96,7 +96,7 @@ object ScalaAssemblyExcludeTests extends TestSuite with ScalaAssemblyTestUtils {
         HelloWorldMultiNoRules,
         sourceRoot = helloWorldMultiResourcePath
       ).scoped { eval =>
-        val Right(result) = eval.apply(HelloWorldMultiNoRules.core.assembly)
+        val Right(result) = eval.apply(HelloWorldMultiNoRules.core.assembly): @unchecked
 
         Using.resource(new JarFile(result.value.path.toIO)) { jarFile =>
           assert(jarEntries(jarFile).contains("reference.conf"))

--- a/scalalib/test/src/mill/scalalib/ScalaAssemblyExcludeTests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaAssemblyExcludeTests.scala
@@ -1,7 +1,7 @@
 package mill.scalalib
 
 import mill._
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.UnitTester
 import utest._
 
 import java.util.jar.JarFile

--- a/scalalib/test/src/mill/scalalib/ScalaAssemblyTestUtils.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaAssemblyTestUtils.scala
@@ -1,11 +1,8 @@
 package mill.scalalib
 
 import mill.*
-import mill.testkit.{TestBaseModule, UnitTester}
-import utest.*
+import mill.testkit.TestBaseModule
 import mill.main.TokenReaders._
-import java.util.jar.JarFile
-import scala.util.Using
 import HelloWorldTests.*
 import mill.define.Discover
 trait ScalaAssemblyTestUtils {

--- a/scalalib/test/src/mill/scalalib/ScalaAssemblyTests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaAssemblyTests.scala
@@ -14,7 +14,8 @@ object ScalaAssemblyTests extends TestSuite with ScalaAssemblyTestUtils {
     test("assembly") {
       test("assembly") - UnitTester(HelloWorldTests.HelloWorldWithMain, resourcePath).scoped {
         eval =>
-          val Right(result) = eval.apply(HelloWorldTests.HelloWorldWithMain.core.assembly): @unchecked
+          val Right(result) =
+            eval.apply(HelloWorldTests.HelloWorldWithMain.core.assembly): @unchecked
           assert(
             os.exists(result.value.path),
             result.evalCount > 0

--- a/scalalib/test/src/mill/scalalib/ScalaAssemblyTests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaAssemblyTests.scala
@@ -14,7 +14,7 @@ object ScalaAssemblyTests extends TestSuite with ScalaAssemblyTestUtils {
     test("assembly") {
       test("assembly") - UnitTester(HelloWorldTests.HelloWorldWithMain, resourcePath).scoped {
         eval =>
-          val Right(result) = eval.apply(HelloWorldTests.HelloWorldWithMain.core.assembly)
+          val Right(result) = eval.apply(HelloWorldTests.HelloWorldWithMain.core.assembly): @unchecked
           assert(
             os.exists(result.value.path),
             result.evalCount > 0
@@ -33,7 +33,7 @@ object ScalaAssemblyTests extends TestSuite with ScalaAssemblyTestUtils {
       }
 
       test("run") - UnitTester(HelloWorldTests.HelloWorldWithMain, resourcePath).scoped { eval =>
-        val Right(result) = eval.apply(HelloWorldTests.HelloWorldWithMain.core.assembly)
+        val Right(result) = eval.apply(HelloWorldTests.HelloWorldWithMain.core.assembly): @unchecked
 
         assert(
           os.exists(result.value.path),

--- a/scalalib/test/src/mill/scalalib/ScalaAssemblyTests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaAssemblyTests.scala
@@ -1,11 +1,10 @@
 package mill.scalalib
 
 import mill._
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.UnitTester
 import utest._
 
 import java.util.jar.JarFile
-import scala.util.Using
 import HelloWorldTests._
 object ScalaAssemblyTests extends TestSuite with ScalaAssemblyTestUtils {
 

--- a/scalalib/test/src/mill/scalalib/ScalaColorOutputTests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaColorOutputTests.scala
@@ -32,7 +32,7 @@ object ScalaColorOutputTests extends TestSuite {
         errStream = new PrintStream(errStream, true)
       ).scoped { eval =>
         val Left(Result.Failure("Compilation failed", _)) =
-          eval.apply(HelloWorldColorOutput.core.compile)
+          eval.apply(HelloWorldColorOutput.core.compile): @unchecked
         val output = errStream.toString
         assert(output.contains(s"${Console.RED}!${Console.RESET}${Console.BLUE}I"))
         assert(output.contains(

--- a/scalalib/test/src/mill/scalalib/ScalaDoc3Tests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaDoc3Tests.scala
@@ -41,7 +41,7 @@ object ScalaDoc3Tests extends TestSuite {
 
   def tests: Tests = Tests {
     test("static") - UnitTester(StaticDocsModule, resourcePath).scoped { eval =>
-      val Right(_) = eval.apply(StaticDocsModule.static.docJar)
+      val Right(_) = eval.apply(StaticDocsModule.static.docJar): @unchecked
       val dest = eval.outPath / "static/docJar.dest"
       assert(
         os.exists(dest / "out.jar"), // final jar should exist
@@ -53,7 +53,7 @@ object ScalaDoc3Tests extends TestSuite {
       )
     }
     test("empty") - UnitTester(EmptyDocsModule, resourcePath).scoped { eval =>
-      val Right(_) = eval.apply(EmptyDocsModule.empty.docJar)
+      val Right(_) = eval.apply(EmptyDocsModule.empty.docJar): @unchecked
       val dest = eval.outPath / "empty/docJar.dest"
       assert(
         os.exists(dest / "out.jar"),
@@ -61,7 +61,7 @@ object ScalaDoc3Tests extends TestSuite {
       )
     }
     test("multiple") - UnitTester(MultiDocsModule, resourcePath).scoped { eval =>
-      val Right(_) = eval.apply(MultiDocsModule.multidocs.docJar)
+      val Right(_) = eval.apply(MultiDocsModule.multidocs.docJar): @unchecked
       val dest = eval.outPath / "multidocs/docJar.dest"
       assert(
         os.exists(dest / "out.jar"), // final jar should exist

--- a/scalalib/test/src/mill/scalalib/ScalaDoc3Tests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaDoc3Tests.scala
@@ -3,7 +3,6 @@ package mill.scalalib
 import mill.*
 import mill.define.Discover
 import utest.*
-import utest.framework.TestPath
 import mill.testkit.UnitTester
 import mill.testkit.TestBaseModule
 

--- a/scalalib/test/src/mill/scalalib/ScalaDotty213Tests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaDotty213Tests.scala
@@ -22,7 +22,7 @@ object ScalaDotty213Tests extends TestSuite {
       Dotty213,
       sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "dotty213"
     ).scoped { eval =>
-      val Right(result) = eval.apply(Dotty213.foo.run())
+      val Right(result) = eval.apply(Dotty213.foo.run()): @unchecked
       assert(result.evalCount > 0)
     }
 

--- a/scalalib/test/src/mill/scalalib/ScalaFlagsTests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaFlagsTests.scala
@@ -28,7 +28,7 @@ object ScalaFlagsTests extends TestSuite {
         HelloWorldFlags,
         sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "hello-world-flags"
       ).scoped { eval =>
-        val Right(result) = eval.apply(HelloWorldFlags.core.runMain("Main"))
+        val Right(result) = eval.apply(HelloWorldFlags.core.runMain("Main")): @unchecked
         assert(result.evalCount > 0)
       }
       // make sure flags are passed during ScalaDoc generation
@@ -36,7 +36,7 @@ object ScalaFlagsTests extends TestSuite {
         HelloWorldFlags,
         sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "hello-world-flags"
       ).scoped { eval =>
-        val Right(result) = eval.apply(HelloWorldFlags.core.docJar)
+        val Right(result) = eval.apply(HelloWorldFlags.core.docJar): @unchecked
         assert(result.evalCount > 0)
       }
     }

--- a/scalalib/test/src/mill/scalalib/ScalaIvyDepsTests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaIvyDepsTests.scala
@@ -50,13 +50,13 @@ object ScalaIvyDepsTests extends TestSuite {
   def tests: Tests = Tests {
 
     test("ivyDeps") - UnitTester(HelloWorldIvyDeps, resourcePath).scoped { eval =>
-      val Right(result) = eval.apply(HelloWorldIvyDeps.moduleA.runClasspath)
+      val Right(result) = eval.apply(HelloWorldIvyDeps.moduleA.runClasspath): @unchecked
       assert(
         result.value.exists(_.path.last == "sourcecode_2.12-0.1.3.jar"),
         !result.value.exists(_.path.last == "sourcecode_2.12-0.1.4.jar")
       )
 
-      val Right(result2) = eval.apply(HelloWorldIvyDeps.moduleB.runClasspath)
+      val Right(result2) = eval.apply(HelloWorldIvyDeps.moduleB.runClasspath): @unchecked
       assert(
         result2.value.exists(_.path.last == "sourcecode_2.12-0.1.4.jar"),
         !result2.value.exists(_.path.last == "sourcecode_2.12-0.1.3.jar")
@@ -64,7 +64,7 @@ object ScalaIvyDepsTests extends TestSuite {
     }
 
     test("transitiveRun") - UnitTester(TransitiveRunIvyDeps, resourcePath).scoped { eval =>
-      val Right(result2) = eval.apply(TransitiveRunIvyDeps.downstream.runClasspath)
+      val Right(result2) = eval.apply(TransitiveRunIvyDeps.downstream.runClasspath): @unchecked
 
       assert(
         result2.value.exists(_.path.last == "logback-classic-1.5.10.jar")
@@ -73,7 +73,7 @@ object ScalaIvyDepsTests extends TestSuite {
 
     test("transitiveLocalRuntimeDepsRun") - UnitTester(TransitiveRunIvyDeps2, resourcePath).scoped {
       eval =>
-        val Right(result2) = eval.apply(TransitiveRunIvyDeps2.downstream.runClasspath)
+        val Right(result2) = eval.apply(TransitiveRunIvyDeps2.downstream.runClasspath): @unchecked
 
         assert(
           result2.value.exists(_.path.last == "logback-classic-1.5.10.jar"),

--- a/scalalib/test/src/mill/scalalib/ScalaMacrosTests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaMacrosTests.scala
@@ -44,7 +44,7 @@ object ScalaMacrosTests extends TestSuite {
         ).scoped { eval =>
           if (Properties.isJavaAtLeast(17)) "skipped on Java 17+"
           else {
-            val Right(result) = eval.apply(mod.core.runMain("Main"))
+            val Right(result) = eval.apply(mod.core.runMain("Main")): @unchecked
             assert(result.evalCount > 0)
           }
         }
@@ -55,7 +55,7 @@ object ScalaMacrosTests extends TestSuite {
         ).scoped { eval =>
           if (Properties.isJavaAtLeast(17)) "skipped on Java 17+"
           else {
-            val Right(result) = eval.apply(mod.core.docJar)
+            val Right(result) = eval.apply(mod.core.docJar): @unchecked
             assert(result.evalCount > 0)
           }
         }
@@ -67,7 +67,7 @@ object ScalaMacrosTests extends TestSuite {
           mod,
           sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "hello-world-macros"
         ).scoped { eval =>
-          val Right(result) = eval.apply(mod.core.runMain("Main"))
+          val Right(result) = eval.apply(mod.core.runMain("Main")): @unchecked
           assert(result.evalCount > 0)
         }
         // make sure macros are applied when compiling during scaladoc generation
@@ -75,7 +75,7 @@ object ScalaMacrosTests extends TestSuite {
           mod,
           sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "hello-world-macros"
         ).scoped { eval =>
-          val Right(result) = eval.apply(mod.core.docJar)
+          val Right(result) = eval.apply(mod.core.docJar): @unchecked
           assert(result.evalCount > 0)
         }
       }

--- a/scalalib/test/src/mill/scalalib/ScalaMultiModuleClasspathsTests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaMultiModuleClasspathsTests.scala
@@ -96,7 +96,8 @@ object ScalaMultiModuleClasspathsTests extends TestSuite {
     ) = {
       val Right(runClasspathRes) = eval.apply(mod.runClasspath): @unchecked
       val Right(compileClasspathRes) = eval.apply(mod.compileClasspath): @unchecked
-      val Right(upstreamAssemblyClasspathRes) = eval.apply(mod.upstreamAssemblyClasspath): @unchecked
+      val Right(upstreamAssemblyClasspathRes) =
+        eval.apply(mod.upstreamAssemblyClasspath): @unchecked
       val Right(localClasspathRes) = eval.apply(mod.localClasspath): @unchecked
 
       val start = eval.evaluator.rootModule.millSourcePath

--- a/scalalib/test/src/mill/scalalib/ScalaMultiModuleClasspathsTests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaMultiModuleClasspathsTests.scala
@@ -94,10 +94,10 @@ object ScalaMultiModuleClasspathsTests extends TestSuite {
         expectedCompileClasspath: Seq[String],
         expectedLocalClasspath: Seq[String]
     ) = {
-      val Right(runClasspathRes) = eval.apply(mod.runClasspath)
-      val Right(compileClasspathRes) = eval.apply(mod.compileClasspath)
-      val Right(upstreamAssemblyClasspathRes) = eval.apply(mod.upstreamAssemblyClasspath)
-      val Right(localClasspathRes) = eval.apply(mod.localClasspath)
+      val Right(runClasspathRes) = eval.apply(mod.runClasspath): @unchecked
+      val Right(compileClasspathRes) = eval.apply(mod.compileClasspath): @unchecked
+      val Right(upstreamAssemblyClasspathRes) = eval.apply(mod.upstreamAssemblyClasspath): @unchecked
+      val Right(localClasspathRes) = eval.apply(mod.localClasspath): @unchecked
 
       val start = eval.evaluator.rootModule.millSourcePath
       val startToken = Set("org", "com")

--- a/scalalib/test/src/mill/scalalib/ScalaRunTests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaRunTests.scala
@@ -35,7 +35,7 @@ object ScalaRunTests extends TestSuite {
         val runResult = eval.outPath / "core/runMain.dest/hello-mill"
 
         val Right(result) =
-          eval.apply(HelloWorldTests.HelloWorld.core.runMain("Main", runResult.toString))
+          eval.apply(HelloWorldTests.HelloWorld.core.runMain("Main", runResult.toString)): @unchecked
         assert(result.evalCount > 0)
 
         assert(
@@ -50,7 +50,7 @@ object ScalaRunTests extends TestSuite {
 
           val Right(result) = eval.apply(
             HelloWorldTests.CrossHelloWorld.core(v).runMain("Shim", runResult.toString)
-          )
+          ): @unchecked
 
           assert(result.evalCount > 0)
 
@@ -77,7 +77,7 @@ object ScalaRunTests extends TestSuite {
         resourcePath
       ).scoped { eval =>
         val Left(Result.Failure("Subprocess failed", _)) =
-          eval.apply(HelloWorldTests.HelloWorld.core.runMain("Invalid"))
+          eval.apply(HelloWorldTests.HelloWorld.core.runMain("Invalid")): @unchecked
       }
       test("notRunWhenCompileFailed") - UnitTester(
         HelloWorldTests.HelloWorld,
@@ -89,7 +89,7 @@ object ScalaRunTests extends TestSuite {
         )
 
         val Left(Result.Failure("Compilation failed", _)) =
-          eval.apply(HelloWorldTests.HelloWorld.core.runMain("Main"))
+          eval.apply(HelloWorldTests.HelloWorld.core.runMain("Main")): @unchecked
 
       }
     }
@@ -99,7 +99,7 @@ object ScalaRunTests extends TestSuite {
         val runResult = eval.outPath / "core/run.dest/hello-mill"
         val Right(result) = eval.apply(
           HelloWorldWithMain.core.run(Task.Anon(Args(runResult.toString)))
-        )
+        ): @unchecked
 
         assert(result.evalCount > 0)
 
@@ -112,7 +112,7 @@ object ScalaRunTests extends TestSuite {
         HelloWorldWithoutMain,
         sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "hello-world-no-main"
       ).scoped { eval =>
-        val Left(Result.Failure(_, None)) = eval.apply(HelloWorldWithoutMain.core.run())
+        val Left(Result.Failure(_, None)) = eval.apply(HelloWorldWithoutMain.core.run()): @unchecked
       }
 
       test("runDiscoverMainClass") - UnitTester(HelloWorldWithoutMain, resourcePath).scoped {
@@ -122,7 +122,7 @@ object ScalaRunTests extends TestSuite {
           val runResult = eval.outPath / "core/run.dest/hello-mill"
           val Right(result) = eval.apply(
             HelloWorldWithoutMain.core.run(Task.Anon(Args(runResult.toString)))
-          )
+          ): @unchecked
 
           assert(result.evalCount > 0)
 
@@ -138,7 +138,7 @@ object ScalaRunTests extends TestSuite {
         val runResult = eval.outPath / "core/run.dest/hello-mill"
         val Right(result) = eval.apply(
           HelloWorldWithMain.core.runLocal(Task.Anon(Args(runResult.toString)))
-        )
+        ): @unchecked
 
         assert(result.evalCount > 0)
 
@@ -151,7 +151,7 @@ object ScalaRunTests extends TestSuite {
         val runResult = eval.outPath / "core/run.dest/hello-mill"
         val Right(result) = eval.apply(
           HelloWorldDefaultMain.core.runLocal(Task.Anon(Args(runResult.toString)))
-        )
+        ): @unchecked
 
         assert(result.evalCount > 0)
 
@@ -164,7 +164,7 @@ object ScalaRunTests extends TestSuite {
         HelloWorldWithoutMain,
         sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "hello-world-no-main"
       ).scoped { eval =>
-        val Left(Result.Failure(_, None)) = eval.apply(HelloWorldWithoutMain.core.runLocal())
+        val Left(Result.Failure(_, None)) = eval.apply(HelloWorldWithoutMain.core.runLocal()): @unchecked
       }
     }
   }

--- a/scalalib/test/src/mill/scalalib/ScalaRunTests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaRunTests.scala
@@ -35,7 +35,10 @@ object ScalaRunTests extends TestSuite {
         val runResult = eval.outPath / "core/runMain.dest/hello-mill"
 
         val Right(result) =
-          eval.apply(HelloWorldTests.HelloWorld.core.runMain("Main", runResult.toString)): @unchecked
+          eval.apply(HelloWorldTests.HelloWorld.core.runMain(
+            "Main",
+            runResult.toString
+          )): @unchecked
         assert(result.evalCount > 0)
 
         assert(
@@ -164,7 +167,8 @@ object ScalaRunTests extends TestSuite {
         HelloWorldWithoutMain,
         sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "hello-world-no-main"
       ).scoped { eval =>
-        val Left(Result.Failure(_, None)) = eval.apply(HelloWorldWithoutMain.core.runLocal()): @unchecked
+        val Left(Result.Failure(_, None)) =
+          eval.apply(HelloWorldWithoutMain.core.runLocal()): @unchecked
       }
     }
   }

--- a/scalalib/test/src/mill/scalalib/ScalaScalacheckTests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaScalacheckTests.scala
@@ -24,7 +24,7 @@ object ScalaScalacheckTests extends TestSuite {
       HelloScalacheck,
       sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "hello-scalacheck"
     ).scoped { eval =>
-      val Right(result) = eval.apply(HelloScalacheck.foo.test.test())
+      val Right(result) = eval.apply(HelloScalacheck.foo.test.test()): @unchecked
       assert(
         result.evalCount > 0,
         result.value._2.map(_.selector) == Seq(

--- a/scalalib/test/src/mill/scalalib/ScalaScaladocTests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaScaladocTests.scala
@@ -77,14 +77,16 @@ object ScalaScaladocTests extends TestSuite {
         sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "hello-world"
       ).scoped { eval =>
         // scaladoc generation fails because of "-Xfatal-warnings" flag
-        val Left(Result.Failure(_, None)) = eval.apply(HelloWorldWithDocVersion.core.docJar): @unchecked
+        val Left(Result.Failure(_, None)) =
+          eval.apply(HelloWorldWithDocVersion.core.docJar): @unchecked
       }
       test("docJarOnlyVersion") - UnitTester(
         HelloWorldOnlyDocVersion,
         sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "hello-world"
       ).scoped { eval =>
         // `docJar` requires the `compile` task to succeed (since the addition of Scaladoc 3)
-        val Left(Result.Failure(_, None)) = eval.apply(HelloWorldOnlyDocVersion.core.docJar): @unchecked
+        val Left(Result.Failure(_, None)) =
+          eval.apply(HelloWorldOnlyDocVersion.core.docJar): @unchecked
       }
     }
 

--- a/scalalib/test/src/mill/scalalib/ScalaScaladocTests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaScaladocTests.scala
@@ -39,21 +39,21 @@ object ScalaScaladocTests extends TestSuite {
 
     test("scalaDocOptions") {
       test("emptyByDefault") - UnitTester(HelloWorldTests.HelloWorld, resourcePath).scoped { eval =>
-        val Right(result) = eval.apply(HelloWorldTests.HelloWorld.core.scalaDocOptions)
+        val Right(result) = eval.apply(HelloWorldTests.HelloWorld.core.scalaDocOptions): @unchecked
         assert(
           result.value.isEmpty,
           result.evalCount > 0
         )
       }
       test("override") - UnitTester(HelloWorldDocTitle, resourcePath).scoped { eval =>
-        val Right(result) = eval.apply(HelloWorldDocTitle.core.scalaDocOptions)
+        val Right(result) = eval.apply(HelloWorldDocTitle.core.scalaDocOptions): @unchecked
         assert(
           result.value == Seq("-doc-title", "Hello World"),
           result.evalCount > 0
         )
       }
       test("extend") - UnitTester(HelloWorldWithDocVersion, resourcePath).scoped { eval =>
-        val Right(result) = eval.apply(HelloWorldWithDocVersion.core.scalaDocOptions)
+        val Right(result) = eval.apply(HelloWorldWithDocVersion.core.scalaDocOptions): @unchecked
         assert(
           result.value == Seq("-Ywarn-unused", "-Xfatal-warnings", "-doc-version", "1.2.3"),
           result.evalCount > 0
@@ -64,7 +64,7 @@ object ScalaScaladocTests extends TestSuite {
         HelloWorldDocTitle,
         sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "hello-world"
       ).scoped { eval =>
-        val Right(result) = eval.apply(HelloWorldDocTitle.core.docJar)
+        val Right(result) = eval.apply(HelloWorldDocTitle.core.docJar): @unchecked
         assert(
           result.evalCount > 0,
           os.read(eval.outPath / "core/docJar.dest/javadoc/index.html").contains(
@@ -77,14 +77,14 @@ object ScalaScaladocTests extends TestSuite {
         sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "hello-world"
       ).scoped { eval =>
         // scaladoc generation fails because of "-Xfatal-warnings" flag
-        val Left(Result.Failure(_, None)) = eval.apply(HelloWorldWithDocVersion.core.docJar)
+        val Left(Result.Failure(_, None)) = eval.apply(HelloWorldWithDocVersion.core.docJar): @unchecked
       }
       test("docJarOnlyVersion") - UnitTester(
         HelloWorldOnlyDocVersion,
         sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "hello-world"
       ).scoped { eval =>
         // `docJar` requires the `compile` task to succeed (since the addition of Scaladoc 3)
-        val Left(Result.Failure(_, None)) = eval.apply(HelloWorldOnlyDocVersion.core.docJar)
+        val Left(Result.Failure(_, None)) = eval.apply(HelloWorldOnlyDocVersion.core.docJar): @unchecked
       }
     }
 

--- a/scalalib/test/src/mill/scalalib/ScalaSemanticDbTests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaSemanticDbTests.scala
@@ -26,7 +26,7 @@ object ScalaSemanticDbTests extends TestSuite {
       test("fromScratch") - UnitTester(SemanticWorld, sourceRoot = resourcePath).scoped { eval =>
         {
           println("first - expected full compile")
-          val Right(result) = eval.apply(SemanticWorld.core.semanticDbData)
+          val Right(result) = eval.apply(SemanticWorld.core.semanticDbData): @unchecked
 
           val dataPath = eval.outPath / "core/semanticDbData.dest/data"
           val outputFiles =
@@ -44,7 +44,7 @@ object ScalaSemanticDbTests extends TestSuite {
         {
           println("second - expected no compile")
           // don't recompile if nothing changed
-          val Right(result2) = eval.apply(SemanticWorld.core.semanticDbData)
+          val Right(result2) = eval.apply(SemanticWorld.core.semanticDbData): @unchecked
           assert(result2.evalCount == 0)
         }
       }
@@ -71,7 +71,7 @@ object ScalaSemanticDbTests extends TestSuite {
 
         {
           println("first - expected full compile")
-          val Right(result) = eval.apply(SemanticWorld.core.semanticDbData)
+          val Right(result) = eval.apply(SemanticWorld.core.semanticDbData): @unchecked
 
           val dataPath = eval.outPath / "core/semanticDbData.dest/data"
           val outputFiles =
@@ -87,7 +87,7 @@ object ScalaSemanticDbTests extends TestSuite {
         // change nothing
         {
           println("second - expect no compile due to Mill caching")
-          val Right(result2) = eval.apply(SemanticWorld.core.semanticDbData)
+          val Right(result2) = eval.apply(SemanticWorld.core.semanticDbData): @unchecked
           assert(result2.evalCount == 0)
         }
 
@@ -96,7 +96,7 @@ object ScalaSemanticDbTests extends TestSuite {
           println("third - expect inc compile of one file\n")
           os.write.append(extraFiles.head._1, "  ")
 
-          val Right(result) = eval.apply(SemanticWorld.core.semanticDbData)
+          val Right(result) = eval.apply(SemanticWorld.core.semanticDbData): @unchecked
           val outputFiles =
             os.walk(result.value.path).filter(os.isFile).map(_.relativeTo(result.value.path))
           val expectedFiles = semanticDbFiles ++ extraFiles.map(_._2)
@@ -110,7 +110,7 @@ object ScalaSemanticDbTests extends TestSuite {
           println("fourth - expect inc compile with one deleted file")
           os.remove(extraFiles.head._1)
 
-          val Right(result) = eval.apply(SemanticWorld.core.semanticDbData)
+          val Right(result) = eval.apply(SemanticWorld.core.semanticDbData): @unchecked
           val outputFiles =
             os.walk(result.value.path).filter(os.isFile).map(_.relativeTo(result.value.path))
           val expectedFiles = semanticDbFiles ++ extraFiles.map(_._2).drop(1)

--- a/scalalib/test/src/mill/scalalib/ScalaSemanticDbTests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaSemanticDbTests.scala
@@ -1,6 +1,5 @@
 package mill.scalalib
 
-import mill.scalalib.HelloWorldTests.SemanticModule
 import mill.testkit.{TestBaseModule, UnitTester}
 import utest.*
 import HelloWorldTests.*

--- a/scalalib/test/src/mill/scalalib/ScalaTypeLevelTests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaTypeLevelTests.scala
@@ -31,7 +31,7 @@ object ScalaTypeLevelTests extends TestSuite {
 
     test("scalacPluginClasspath") {
       test("withMacroParadise") - UnitTester(HelloWorldTypeLevel, resourcePath).scoped { eval =>
-        val Right(result) = eval.apply(HelloWorldTypeLevel.foo.scalacPluginClasspath)
+        val Right(result) = eval.apply(HelloWorldTypeLevel.foo.scalacPluginClasspath): @unchecked
         assert(
           result.value.nonEmpty,
           result.value.iterator.exists { pathRef => pathRef.path.segments.contains("scalamacros") },
@@ -42,7 +42,7 @@ object ScalaTypeLevelTests extends TestSuite {
 
     test("scalaDocPluginClasspath") {
       test("extend") - UnitTester(HelloWorldTypeLevel, sourceRoot = resourcePath).scoped { eval =>
-        val Right(result) = eval.apply(HelloWorldTypeLevel.foo.scalaDocPluginClasspath)
+        val Right(result) = eval.apply(HelloWorldTypeLevel.foo.scalaDocPluginClasspath): @unchecked
         assert(
           result.value.iterator.nonEmpty,
           result.value.iterator.exists { pathRef => pathRef.path.segments.contains("scalamacros") },
@@ -59,7 +59,7 @@ object ScalaTypeLevelTests extends TestSuite {
         HelloWorldTypeLevel.foo.compileClasspath
       )
       for (cp <- classPathsToCheck) {
-        val Right(result) = eval.apply(cp)
+        val Right(result) = eval.apply(cp): @unchecked
         assert(
           // Make sure every relevant piece org.scala-lang has been substituted for org.typelevel
           !result.value.map(_.toString).exists(x =>

--- a/scalalib/test/src/mill/scalalib/ScalaValidatedPathRefTests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaValidatedPathRefTests.scala
@@ -33,15 +33,15 @@ object ScalaValidatedPathRefTests extends TestSuite {
         def check(t: Target[PathRef], flip: Boolean) = UnitTester(ValidatedTarget, null).scoped {
           eval =>
             // we reconstruct faulty behavior
-            val Right(result) = eval.apply(t)
+            val Right(result) = eval.apply(t): @unchecked
             assert(
-              result.value.path.last == (t.asInstanceOf[NamedTask[_]].label + ".dest"),
+              result.value.path.last == (t.asInstanceOf[NamedTask[?]].label + ".dest"),
               os.exists(result.value.path)
             )
             os.remove.all(result.value.path)
-            val Right(result2) = eval.apply(t)
+            val Right(result2) = eval.apply(t): @unchecked
             assert(
-              result2.value.path.last == (t.asInstanceOf[NamedTask[_]].label + ".dest"),
+              result2.value.path.last == (t.asInstanceOf[NamedTask[?]].label + ".dest"),
               // as the result was cached but not checked, this path is missing
               os.exists(result2.value.path) == flip
             )
@@ -53,15 +53,15 @@ object ScalaValidatedPathRefTests extends TestSuite {
         def check(t: Target[Seq[PathRef]], flip: Boolean) =
           UnitTester(ValidatedTarget, null).scoped { eval =>
             // we reconstruct faulty behavior
-            val Right(result) = eval.apply(t)
+            val Right(result) = eval.apply(t): @unchecked
             assert(
-              result.value.map(_.path.last) == Seq(t.asInstanceOf[NamedTask[_]].label + ".dest"),
+              result.value.map(_.path.last) == Seq(t.asInstanceOf[NamedTask[?]].label + ".dest"),
               result.value.forall(p => os.exists(p.path))
             )
             result.value.foreach(p => os.remove.all(p.path))
-            val Right(result2) = eval.apply(t)
+            val Right(result2) = eval.apply(t): @unchecked
             assert(
-              result2.value.map(_.path.last) == Seq(t.asInstanceOf[NamedTask[_]].label + ".dest"),
+              result2.value.map(_.path.last) == Seq(t.asInstanceOf[NamedTask[?]].label + ".dest"),
               // as the result was cached but not checked, this path is missing
               result2.value.forall(p => os.exists(p.path) == flip)
             )
@@ -73,15 +73,15 @@ object ScalaValidatedPathRefTests extends TestSuite {
         def check(t: Target[Agg[PathRef]], flip: Boolean) =
           UnitTester(ValidatedTarget, null).scoped { eval =>
             // we reconstruct faulty behavior
-            val Right(result) = eval.apply(t)
+            val Right(result) = eval.apply(t): @unchecked
             assert(
-              result.value.map(_.path.last) == Agg(t.asInstanceOf[NamedTask[_]].label + ".dest"),
+              result.value.map(_.path.last) == Agg(t.asInstanceOf[NamedTask[?]].label + ".dest"),
               result.value.forall(p => os.exists(p.path))
             )
             result.value.foreach(p => os.remove.all(p.path))
-            val Right(result2) = eval.apply(t)
+            val Right(result2) = eval.apply(t): @unchecked
             assert(
-              result2.value.map(_.path.last) == Agg(t.asInstanceOf[NamedTask[_]].label + ".dest"),
+              result2.value.map(_.path.last) == Agg(t.asInstanceOf[NamedTask[?]].label + ".dest"),
               // as the result was cached but not checked, this path is missing
               result2.value.forall(p => os.exists(p.path) == flip)
             )
@@ -93,15 +93,15 @@ object ScalaValidatedPathRefTests extends TestSuite {
         def check(t: Target[Tuple1[PathRef]], flip: Boolean) =
           UnitTester(ValidatedTarget, null).scoped { eval =>
             // we reconstruct faulty behavior
-            val Right(result) = eval.apply(t)
+            val Right(result) = eval.apply(t): @unchecked
             assert(
-              result.value._1.path.last == (t.asInstanceOf[NamedTask[_]].label + ".dest"),
+              result.value._1.path.last == (t.asInstanceOf[NamedTask[?]].label + ".dest"),
               os.exists(result.value._1.path)
             )
             os.remove.all(result.value._1.path)
-            val Right(result2) = eval.apply(t)
+            val Right(result2) = eval.apply(t): @unchecked
             assert(
-              result2.value._1.path.last == (t.asInstanceOf[NamedTask[_]].label + ".dest"),
+              result2.value._1.path.last == (t.asInstanceOf[NamedTask[?]].label + ".dest"),
               // as the result was cached but not checked, this path is missing
               os.exists(result2.value._1.path) == flip
             )

--- a/scalalib/test/src/mill/scalalib/ScalaVersionsRangesTests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaVersionsRangesTests.scala
@@ -5,7 +5,6 @@ import mill.define.Discover
 import mill.testkit.UnitTester
 import mill.testkit.TestBaseModule
 import utest.*
-import utest.framework.TestPath
 
 object ScalaVersionsRangesTests extends TestSuite {
   object ScalaVersionsRanges extends TestBaseModule {

--- a/scalalib/test/src/mill/scalalib/ScalaVersionsRangesTests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaVersionsRangesTests.scala
@@ -28,7 +28,7 @@ object ScalaVersionsRangesTests extends TestSuite {
       resourcePath
     ).scoped { eval =>
       ScalaVersionsRanges.core.crossModules.map { c =>
-        val Right(_) = eval(c.run())
+        val Right(_) = eval(c.run()): @unchecked
       }
     }
     test("test with Scala 2.12- and 2.13+ specific code") - UnitTester(
@@ -36,7 +36,7 @@ object ScalaVersionsRangesTests extends TestSuite {
       resourcePath
     ).scoped { eval =>
       ScalaVersionsRanges.core.crossModules.map { c =>
-        val Right(_) = eval(c.test.test())
+        val Right(_) = eval(c.test.test()): @unchecked
       }
     }
   }

--- a/scalalib/test/src/mill/scalalib/TestClassLoaderTests.scala
+++ b/scalalib/test/src/mill/scalalib/TestClassLoaderTests.scala
@@ -1,12 +1,11 @@
 package mill.scalalib
 
 import mill.define.Discover
-import mill.{Agg, T, Task}
+import mill.{Agg, Task}
 import mill.testkit.UnitTester
 import mill.testkit.TestBaseModule
 import mill.main.TokenReaders._
 import utest.*
-import utest.framework.TestPath
 
 object TestClassLoaderTests extends TestSuite {
   object testclassloader extends TestBaseModule with ScalaModule {

--- a/scalalib/test/src/mill/scalalib/TestRunnerScalatestTests.scala
+++ b/scalalib/test/src/mill/scalalib/TestRunnerScalatestTests.scala
@@ -9,12 +9,12 @@ object TestRunnerScalatestTests extends TestSuite {
   import TestRunnerTestUtils._
   override def tests: Tests = Tests {
     test("test") - UnitTester(testrunner, resourcePath).scoped { eval =>
-      val Right(result) = eval(testrunner.scalatest.test())
+      val Right(result) = eval(testrunner.scalatest.test()): @unchecked
       assert(result.value._2.size == 9)
       junitReportIn(eval.outPath, "scalatest").shouldHave(9 -> Status.Success)
     }
     test("discoveredTestClasses") - UnitTester(testrunner, resourcePath).scoped { eval =>
-      val Right(result) = eval.apply(testrunner.scalatest.discoveredTestClasses)
+      val Right(result) = eval.apply(testrunner.scalatest.discoveredTestClasses): @unchecked
       val expected = Seq(
         "mill.scalalib.ScalaTestSpec",
         "mill.scalalib.ScalaTestSpec2",
@@ -91,7 +91,7 @@ object TestRunnerScalatestTests extends TestSuite {
             "tagged",
             "-l",
             "tagged"
-          ))
+          )): @unchecked
         assert(msg.contains("Test selector does not match any test"))
       }
     }

--- a/scalalib/test/src/mill/scalalib/TestRunnerTestUtils.scala
+++ b/scalalib/test/src/mill/scalalib/TestRunnerTestUtils.scala
@@ -91,7 +91,7 @@ object TestRunnerTestUtils {
         expectedFileListing: Map[TestModule, Set[String]] = Map()
     ) = {
       testOnly0 { (eval, mod) =>
-        val Right(result) = eval.apply(m(mod).testOnly(args: _*))
+        val Right(result) = eval.apply(m(mod).testOnly(args*)): @unchecked
         val testOnly = result.value
         if (expectedFileListing.nonEmpty) {
           val dest = eval.outPath / m(mod).toString / "testOnly.dest"

--- a/scalalib/test/src/mill/scalalib/TestRunnerTestUtils.scala
+++ b/scalalib/test/src/mill/scalalib/TestRunnerTestUtils.scala
@@ -5,12 +5,11 @@ import mill.define.Discover
 import mill.testkit.UnitTester
 import mill.testkit.TestBaseModule
 import mill.main.TokenReaders._
-import mill.{Agg, T, Task}
+import mill.{Agg, Task}
 import os.Path
 import sbt.testing.Status
 import utest.*
 
-import java.io.{ByteArrayOutputStream, PrintStream}
 import scala.xml.{Elem, NodeSeq, XML}
 
 object TestRunnerTestUtils {

--- a/scalalib/test/src/mill/scalalib/TestRunnerTests.scala
+++ b/scalalib/test/src/mill/scalalib/TestRunnerTests.scala
@@ -19,7 +19,7 @@ object TestRunnerTests extends TestSuite {
           outStream = new PrintStream(outStream, true),
           sourceRoot = resourcePath
         ).scoped { eval =>
-          val Left(Result.Failure(msg, _)) = eval(testrunner.doneMessageFailure.test())
+          val Left(Result.Failure(msg, _)) = eval(testrunner.doneMessageFailure.test()): @unchecked
           val stdout = new String(outStream.toByteArray)
           assert(stdout.contains("test failure done message"))
           junitReportIn(eval.outPath, "doneMessageFailure").shouldHave(1 -> Status.Failure)
@@ -32,14 +32,14 @@ object TestRunnerTests extends TestSuite {
           outStream = new PrintStream(outStream, true),
           sourceRoot = resourcePath
         ).scoped { eval =>
-          val Right(_) = eval(testrunner.doneMessageSuccess.test())
+          val Right(_) = eval(testrunner.doneMessageSuccess.test()): @unchecked
           val stdout = new String(outStream.toByteArray)
           assert(stdout.contains("test success done message"))
         }
       }
 
       test("null") - UnitTester(testrunner, resourcePath).scoped { eval =>
-        val Right(_) = eval(testrunner.doneMessageNull.test())
+        val Right(_) = eval(testrunner.doneMessageNull.test()): @unchecked
       }
     }
   }

--- a/scalalib/test/src/mill/scalalib/TestRunnerUtestTests.scala
+++ b/scalalib/test/src/mill/scalalib/TestRunnerUtestTests.scala
@@ -11,7 +11,7 @@ object TestRunnerUtestTests extends TestSuite {
   import TestRunnerTestUtils._
   override def tests: Tests = Tests {
     test("test case lookup") - UnitTester(testrunner, resourcePath).scoped { eval =>
-      val Right(result) = eval.apply(testrunner.utest.test())
+      val Right(result) = eval.apply(testrunner.utest.test()): @unchecked
       val test = result.value.asInstanceOf[(String, Seq[mill.testrunner.TestResult])]
       assert(
         test._2.size == 3
@@ -19,7 +19,7 @@ object TestRunnerUtestTests extends TestSuite {
       junitReportIn(eval.outPath, "utest").shouldHave(3 -> Status.Success)
     }
     test("discoveredTestClasses") - UnitTester(testrunner, resourcePath).scoped { eval =>
-      val Right(result) = eval.apply(testrunner.utest.discoveredTestClasses)
+      val Right(result) = eval.apply(testrunner.utest.discoveredTestClasses): @unchecked
       val expected = Seq(
         "mill.scalalib.BarTests",
         "mill.scalalib.FooTests",
@@ -72,7 +72,7 @@ object TestRunnerUtestTests extends TestSuite {
       )
       test("noMatch") - tester.testOnly0 { (eval, mod) =>
         val Left(Result.Failure(msg, _)) =
-          eval.apply(mod.utest.testOnly("noMatch", "noMatch*2"))
+          eval.apply(mod.utest.testOnly("noMatch", "noMatch*2")): @unchecked
         assert(
           msg == "Test selector does not match any test: noMatch noMatch*2\nRun discoveredTestClasses to see available tests"
         )

--- a/scalalib/test/src/mill/scalalib/TestRunnerUtestTests.scala
+++ b/scalalib/test/src/mill/scalalib/TestRunnerUtestTests.scala
@@ -5,7 +5,6 @@ import mill.testkit.UnitTester
 import sbt.testing.Status
 import utest._
 
-import java.io.{ByteArrayOutputStream, PrintStream}
 
 object TestRunnerUtestTests extends TestSuite {
   import TestRunnerTestUtils._

--- a/scalalib/test/src/mill/scalalib/TestRunnerUtestTests.scala
+++ b/scalalib/test/src/mill/scalalib/TestRunnerUtestTests.scala
@@ -5,7 +5,6 @@ import mill.testkit.UnitTester
 import sbt.testing.Status
 import utest._
 
-
 object TestRunnerUtestTests extends TestSuite {
   import TestRunnerTestUtils._
   override def tests: Tests = Tests {

--- a/scalalib/test/src/mill/scalalib/TestRunnerZiotestTests.scala
+++ b/scalalib/test/src/mill/scalalib/TestRunnerZiotestTests.scala
@@ -8,12 +8,12 @@ object TestRunnerZiotestTests extends TestSuite {
   import TestRunnerTestUtils._
   override def tests: Tests = Tests {
     test("test") - UnitTester(testrunner, resourcePath).scoped { eval =>
-      val Right(result) = eval(testrunner.ziotest.test())
+      val Right(result) = eval(testrunner.ziotest.test()): @unchecked
       assert(result.value._2.size == 1)
       junitReportIn(eval.outPath, "ziotest").shouldHave(1 -> Status.Success)
     }
     test("discoveredTestClasses") - UnitTester(testrunner, resourcePath).scoped { eval =>
-      val Right(result) = eval.apply(testrunner.ziotest.discoveredTestClasses)
+      val Right(result) = eval.apply(testrunner.ziotest.discoveredTestClasses): @unchecked
       val expected = Seq("mill.scalalib.ZioTestSpec")
       assert(result.value == expected)
       expected

--- a/scalalib/test/src/mill/scalalib/bsp/BspModuleTests.scala
+++ b/scalalib/test/src/mill/scalalib/bsp/BspModuleTests.scala
@@ -2,12 +2,11 @@ package mill.scalalib.bsp
 
 import mill.define.{Cross, Discover}
 import mill.eval.EvaluatorPaths
-import mill.{Agg, T, Task}
+import mill.{Agg, T}
 import mill.scalalib.{DepSyntax, JavaModule, ScalaModule}
 import mill.testkit.UnitTester
 import mill.testkit.TestBaseModule
 import os.FilePath
-import utest.framework.TestPath
 import utest.{TestSuite, Tests, test, *}
 import mill.main.TokenReaders._
 

--- a/scalalib/test/src/mill/scalalib/bsp/BspModuleTests.scala
+++ b/scalalib/test/src/mill/scalalib/bsp/BspModuleTests.scala
@@ -48,7 +48,7 @@ object BspModuleTests extends TestSuite {
       test("single module") - UnitTester(MultiBase, null).scoped { eval =>
         val Right(result) = eval.apply(
           MultiBase.HelloBsp.bspCompileClasspath
-        )
+        ): @unchecked
 
         val relResult =
           result.value.iterator.map(_.resolve(eval.evaluator.pathsResolver).last).toSeq.sorted
@@ -66,7 +66,7 @@ object BspModuleTests extends TestSuite {
       test("dependent module") - UnitTester(MultiBase, null).scoped { eval =>
         val Right(result) = eval.apply(
           MultiBase.HelloBsp2.bspCompileClasspath
-        )
+        ): @unchecked
 
         val relResults: Seq[FilePath] = result.value.iterator.map { p =>
           val path = p.resolve(eval.evaluator.pathsResolver)
@@ -97,7 +97,7 @@ object BspModuleTests extends TestSuite {
             val start = System.currentTimeMillis()
             val Right(_) = eval.apply(
               InterDeps.Mod(entry).compileClasspath
-            )
+            ): @unchecked
             val timeSpent = System.currentTimeMillis() - start
             assert(timeSpent < maxTime)
             s"${timeSpent} msec"
@@ -111,7 +111,7 @@ object BspModuleTests extends TestSuite {
             val start = System.currentTimeMillis()
             val Right(_) = eval.apply(
               InterDeps.Mod(entry).bspCompileClasspath
-            )
+            ): @unchecked
             val timeSpent = System.currentTimeMillis() - start
             assert(timeSpent < maxTime)
             s"${timeSpent} msec"

--- a/scalalib/test/src/mill/scalalib/dependency/metadata/MetadataLoaderFactoryTests.scala
+++ b/scalalib/test/src/mill/scalalib/dependency/metadata/MetadataLoaderFactoryTests.scala
@@ -47,7 +47,7 @@ object MetadataLoaderFactoryTests extends TestSuite {
       val Right(ivyRepo) = IvyRepository.parse(
         "https://dl.bintray.com/sbt/sbt-plugin-releases/" + coursier.ivy.Pattern.default.string,
         dropInfoAttributes = true
-      )
+      ): @unchecked
       assertMatch(MetadataLoaderFactory(ivyRepo)) { case None => }
     }
     test("otherRepository") {

--- a/scalalib/test/src/mill/scalalib/giter8/Giter8Tests.scala
+++ b/scalalib/test/src/mill/scalalib/giter8/Giter8Tests.scala
@@ -29,7 +29,7 @@ object Giter8Tests extends TestSuite {
           "--name=hello", // skip user interaction
           "--description=hello_desc" // need to pass all args
         )
-        val res = evaluator.evaluator.evaluate(Agg(g8Module.init(giter8Args: _*)))
+        val res = evaluator.evaluator.evaluate(Agg(g8Module.init(giter8Args*)))
 
         val files = Seq(
           os.sub / "build.mill",

--- a/scalalib/test/src/mill/scalalib/giter8/Giter8Tests.scala
+++ b/scalalib/test/src/mill/scalalib/giter8/Giter8Tests.scala
@@ -5,7 +5,6 @@ import mill.testkit.TestBaseModule
 import utest.*
 import mill.api.Loose.Agg
 import mill.define.Discover
-import os.Path
 
 object Giter8Tests extends TestSuite {
 

--- a/scalalib/test/src/mill/scalalib/publish/PomTests.scala
+++ b/scalalib/test/src/mill/scalalib/publish/PomTests.scala
@@ -275,7 +275,7 @@ object PomTests extends TestSuite {
       PackagingType.Jar,
       None,
       Agg.empty[Dependency],
-      Agg(depMgmt: _*)
+      Agg(depMgmt*)
     ))
 
   def singleText(seq: NodeSeq) =

--- a/scalalib/test/src/mill/scalalib/scalafmt/ScalafmtTests.scala
+++ b/scalalib/test/src/mill/scalalib/scalafmt/ScalafmtTests.scala
@@ -7,7 +7,6 @@ import mill.scalalib.ScalaModule
 import mill.testkit.UnitTester
 import mill.testkit.TestBaseModule
 import utest.*
-import utest.framework.TestPath
 
 object ScalafmtTests extends TestSuite {
 

--- a/scalalib/test/src/mill/scalalib/scalafmt/ScalafmtTests.scala
+++ b/scalalib/test/src/mill/scalalib/scalafmt/ScalafmtTests.scala
@@ -45,7 +45,7 @@ object ScalafmtTests extends TestSuite {
           val before = getProjectFiles(ScalafmtTestModule.core, eval)
 
           // first reformat
-          val Right(_) = eval.apply(reformatCommand)
+          val Right(_) = eval.apply(reformatCommand): @unchecked
 
           val firstReformat = getProjectFiles(ScalafmtTestModule.core, eval)
 
@@ -73,7 +73,7 @@ object ScalafmtTests extends TestSuite {
           }
 
           // cached reformat
-          val Right(_) = eval.apply(reformatCommand)
+          val Right(_) = eval.apply(reformatCommand): @unchecked
 
           val cached = getProjectFiles(ScalafmtTestModule.core, eval)
 
@@ -89,7 +89,7 @@ object ScalafmtTests extends TestSuite {
           // reformat after change
           os.write.over(cached("Main.scala").path, cached("Main.scala").content + "\n object Foo")
 
-          val Right(_) = eval.apply(reformatCommand)
+          val Right(_) = eval.apply(reformatCommand): @unchecked
 
           val afterChange = getProjectFiles(ScalafmtTestModule.core, eval)
 
@@ -114,10 +114,10 @@ object ScalafmtTests extends TestSuite {
 
   case class FileInfo(content: String, modifyTime: Long, path: os.Path)
 
-  def getProjectFiles(m: ScalaModule with BuildSrcModule, eval: UnitTester) = {
-    val Right(sourcesRes) = eval.apply(m.sources)
-    val Right(resourcesRes) = eval.apply(m.resources)
-    val Right(buildSourcesRes) = eval.apply(m.buildSources)
+  def getProjectFiles(m: ScalaModule & BuildSrcModule, eval: UnitTester) = {
+    val Right(sourcesRes) = eval.apply(m.sources): @unchecked
+    val Right(resourcesRes) = eval.apply(m.resources): @unchecked
+    val Right(buildSourcesRes) = eval.apply(m.buildSources): @unchecked
 
     val sourcesFiles = sourcesRes.value.flatMap(p => os.walk(p.path))
     val resourcesFiles = resourcesRes.value.flatMap(p => os.walk(p.path))

--- a/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
+++ b/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
@@ -120,7 +120,7 @@ class ZincWorkerImpl(
     }
   }
 
-  private[this] val classloaderCache =
+  private val classloaderCache =
     collection.mutable.LinkedHashMap.empty[Long, (URLClassLoader, Int)]
 
   def getCachedClassLoader(
@@ -190,7 +190,7 @@ class ZincWorkerImpl(
   }
 
   private def zincLogLevel = if (zincLogDebug) sbt.util.Level.Debug else sbt.util.Level.Info
-  private[this] val ic = new sbt.internal.inc.IncrementalCompilerImpl()
+  private val ic = new sbt.internal.inc.IncrementalCompilerImpl()
 
   private def filterJavacRuntimeOptions(opt: String): Boolean = opt.startsWith("-J")
 

--- a/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
+++ b/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
@@ -366,7 +366,7 @@ trait ScalaNativeModule extends ScalaModule { outer =>
 trait TestScalaNativeModule extends ScalaNativeModule with TestModule {
   override def resources: T[Seq[PathRef]] = super[ScalaNativeModule].resources
   override def testLocal(args: String*): Command[(String, Seq[TestResult])] =
-    Task.Command { test(args: _*)() }
+    Task.Command { test(args*)() }
   override protected def testTask(
       args: Task[Seq[String]],
       globSelectors: Task[Seq[String]]

--- a/scalanativelib/test/src/mill/scalanativelib/CompileRunTests.scala
+++ b/scalanativelib/test/src/mill/scalanativelib/CompileRunTests.scala
@@ -6,7 +6,6 @@ import mill.define.Discover
 import mill.eval.EvaluatorPaths
 import mill.scalalib.api.ZincWorkerUtil
 import mill.scalalib.{DepSyntax, PublishModule, ScalaModule, TestModule}
-import mill.testrunner.TestResult
 import mill.scalalib.publish.{Developer, License, PomSettings, VersionControl}
 import mill.scalanativelib.api._
 import mill.testkit.UnitTester

--- a/scalanativelib/test/src/mill/scalanativelib/CompileRunTests.scala
+++ b/scalanativelib/test/src/mill/scalanativelib/CompileRunTests.scala
@@ -92,7 +92,7 @@ object CompileRunTests extends TestSuite {
             scalaVersion,
             scalaNativeVersion,
             mode
-          ).compile)
+          ).compile): @unchecked
 
         val outPath = result.value.classes.path
         val outputFiles = os.walk(outPath).filter(os.isFile).map(_.last).toSet
@@ -108,7 +108,7 @@ object CompileRunTests extends TestSuite {
             scalaVersion,
             scalaNativeVersion,
             mode
-          ).compile)
+          ).compile): @unchecked
         assert(result2.evalCount == 0)
       }
 
@@ -124,7 +124,7 @@ object CompileRunTests extends TestSuite {
             scala213,
             scalaNative05,
             ReleaseMode.Debug
-          ).jar)
+          ).jar): @unchecked
         val jar = result.value.path
         val entries = new JarFile(jar.toIO).entries().asScala.map(_.getName)
         assert(entries.contains("hello/Main$.nir"))
@@ -135,7 +135,7 @@ object CompileRunTests extends TestSuite {
       UnitTester(HelloNativeWorld, millSourcePath).scoped { eval =>
         val task =
           HelloNativeWorld.build(scalaVersion, scalaNativeVersion, mode).nativeLink
-        val Right(result) = eval(task)
+        val Right(result) = eval(task): @unchecked
 
         val paths = EvaluatorPaths.resolveDestPaths(eval.outPath, task)
         val stdout = os.proc(paths.dest / "out").call().out.lines()

--- a/scalanativelib/test/src/mill/scalanativelib/ExclusionsTests.scala
+++ b/scalanativelib/test/src/mill/scalanativelib/ExclusionsTests.scala
@@ -31,7 +31,7 @@ object ExclusionsTests extends TestSuite {
 
   val tests: Tests = Tests {
     test("scala3 scala native libraries are excluded in Scala 2.13") {
-      val Right(result) = exclusionsEvaluator(Exclusions.scala213.resolvedIvyDeps)
+      val Right(result) = exclusionsEvaluator(Exclusions.scala213.resolvedIvyDeps): @unchecked
       val jars = result.value.iterator.map(_.path.last).toSet
       assert(jars.contains("nativelib_native0.4_2.13-0.4.3.jar"))
       assert(!jars.contains("nativelib_native0.4_3-0.4.3.jar"))
@@ -39,7 +39,7 @@ object ExclusionsTests extends TestSuite {
       assert(!jars.contains("clib_native0.4_3-0.4.3.jar"))
     }
     test("scala2.13 scala native libraries are excluded in Scala 3") {
-      val Right(result) = exclusionsEvaluator(Exclusions.scala3.resolvedIvyDeps)
+      val Right(result) = exclusionsEvaluator(Exclusions.scala3.resolvedIvyDeps): @unchecked
       val jars = result.value.iterator.map(_.path.last).toSet
       assert(jars.contains("nativelib_native0.4_3-0.4.3.jar"))
       assert(!jars.contains("nativelib_native0.4_2.13-0.4.3.jar"))

--- a/scalanativelib/test/src/mill/scalanativelib/FeaturesTests.scala
+++ b/scalanativelib/test/src/mill/scalanativelib/FeaturesTests.scala
@@ -18,8 +18,8 @@ object FeaturesTests extends TestSuite {
 
   val tests: Tests = Tests {
     test("incremental compilation works") - UnitTester(Features, millSourcePath).scoped { eval =>
-      val Right(_) = eval(Features.nativeLink)
-      val Right(result) = eval(Features.nativeWorkdir)
+      val Right(_) = eval(Features.nativeLink): @unchecked
+      val Right(result) = eval(Features.nativeWorkdir): @unchecked
       assert(os.walk(result.value).exists(_.ext == "ll"))
     }
   }

--- a/scalanativelib/test/src/mill/scalanativelib/TestingTests.scala
+++ b/scalanativelib/test/src/mill/scalanativelib/TestingTests.scala
@@ -14,7 +14,7 @@ object TestingTests extends TestSuite {
     def runTests(testTask: define.NamedTask[(String, Seq[TestResult])])
         : Map[String, Map[String, TestResult]] =
       UnitTester(HelloNativeWorld, millSourcePath).scoped { eval =>
-        val Left(Result.Failure(_, Some(res))) = eval(testTask)
+        val Left(Result.Failure(_, Some(res))) = eval(testTask): @unchecked
 
         val (doneMsg, testResults) = res
         testResults
@@ -58,8 +58,8 @@ object TestingTests extends TestSuite {
 
     def checkInheritedTargets[A](target: ScalaNativeModule => T[A], expected: A) =
       UnitTester(HelloNativeWorld, millSourcePath).scoped { eval =>
-        val Right(mainResult) = eval(target(HelloNativeWorld.inherited))
-        val Right(testResult) = eval(target(HelloNativeWorld.inherited.test))
+        val Right(mainResult) = eval(target(HelloNativeWorld.inherited)): @unchecked
+        val Right(testResult) = eval(target(HelloNativeWorld.inherited.test)): @unchecked
         assert(mainResult.value == expected)
         assert(testResult.value == expected)
       }

--- a/testkit/src/mill/testkit/UnitTester.scala
+++ b/testkit/src/mill/testkit/UnitTester.scala
@@ -106,7 +106,7 @@ class UnitTester(
     selectiveExecution = false
   )
 
-  def apply(args: String*): Either[Result.Failing[_], UnitTester.Result[Seq[_]]] = {
+  def apply(args: String*): Either[Result.Failing[?], UnitTester.Result[Seq[?]]] = {
     mill.eval.Evaluator.currentEvaluator.withValue(evaluator) {
       Resolve.Tasks.resolve(evaluator.rootModule, args, SelectMode.Separated)
     } match {
@@ -124,9 +124,9 @@ class UnitTester(
   }
 
   def apply(
-      tasks: Seq[Task[_]],
+      tasks: Seq[Task[?]],
       dummy: DummyImplicit = null
-  ): Either[Result.Failing[_], UnitTester.Result[Seq[_]]] = {
+  ): Either[Result.Failing[?], UnitTester.Result[Seq[?]]] = {
     val evaluated = evaluator.evaluate(tasks)
 
     if (evaluated.failing.keyCount == 0) {
@@ -155,7 +155,7 @@ class UnitTester(
     }
   }
 
-  def fail(target: Target[_], expectedFailCount: Int, expectedRawValues: Seq[Result[_]]): Unit = {
+  def fail(target: Target[?], expectedFailCount: Int, expectedRawValues: Seq[Result[?]]): Unit = {
 
     val res = evaluator.evaluate(Agg(target))
 
@@ -171,13 +171,13 @@ class UnitTester(
 
   }
 
-  def check(targets: Agg[Task[_]], expected: Agg[Task[_]]): Unit = {
+  def check(targets: Agg[Task[?]], expected: Agg[Task[?]]): Unit = {
 
     val evaluated = evaluator.evaluate(targets)
       .evaluated
       .flatMap(_.asTarget)
       .filter(module.millInternal.targets.contains)
-      .filter(!_.isInstanceOf[InputImpl[_]])
+      .filter(!_.isInstanceOf[InputImpl[?]])
     assert(
       evaluated.toSet == expected.toSet,
       s"evaluated is not equal expected. evaluated=${evaluated}, expected=${expected}"

--- a/testkit/test/src/mill/testkit/UnitTesterTests.scala
+++ b/testkit/test/src/mill/testkit/UnitTesterTests.scala
@@ -16,7 +16,7 @@ object UnitTesterTests extends TestSuite {
       }
 
       UnitTester(build, resourcePath).scoped { eval =>
-        val Right(result) = eval(build.testTask)
+        val Right(result) = eval(build.testTask): @unchecked
         assert(result.value == "test")
       }
     }
@@ -30,7 +30,7 @@ object UnitTesterTests extends TestSuite {
       }
 
       UnitTester(build, resourcePath).scoped { eval =>
-        val Right(result) = eval(build.testTask)
+        val Right(result) = eval(build.testTask): @unchecked
         assert(result.value == "HELLO WORLD SOURCE FILE")
       }
     }

--- a/testrunner/src/mill/testrunner/TestRunner.scala
+++ b/testrunner/src/mill/testrunner/TestRunner.scala
@@ -12,8 +12,8 @@ import mill.util.Jvm
       testClassfilePath: Agg[os.Path],
       args: Seq[String],
       testReporter: TestReporter,
-      classFilter: Class[_] => Boolean = _ => true
-  )(implicit ctx: Ctx.Log with Ctx.Home): (String, Seq[mill.testrunner.TestResult]) = {
+      classFilter: Class[?] => Boolean = _ => true
+  )(implicit ctx: Ctx.Log & Ctx.Home): (String, Seq[mill.testrunner.TestResult]) = {
     Jvm.withClassLoader(
       classPath = entireClasspath.toVector,
       sharedPrefixes = Seq("sbt.testing.")

--- a/testrunner/src/mill/testrunner/TestRunnerUtils.scala
+++ b/testrunner/src/mill/testrunner/TestRunnerUtils.scala
@@ -36,7 +36,7 @@ import scala.jdk.CollectionConverters.IteratorHasAsScala
       cl: ClassLoader,
       framework: Framework,
       classpath: Loose.Agg[os.Path]
-  ): Loose.Agg[(Class[_], Fingerprint)] = {
+  ): Loose.Agg[(Class[?], Fingerprint)] = {
 
     val fingerprints = framework.fingerprints()
 
@@ -45,7 +45,7 @@ import scala.jdk.CollectionConverters.IteratorHasAsScala
       // the tests to run Instead just don't run anything
       .filter(os.exists(_))
       .flatMap { base =>
-        Loose.Agg.from[(Class[_], Fingerprint)](
+        Loose.Agg.from[(Class[?], Fingerprint)](
           listClassFiles(base).map { path =>
             val cls = cl.loadClass(path.stripSuffix(".class").replace('/', '.'))
             val publicConstructorCount =
@@ -82,10 +82,10 @@ import scala.jdk.CollectionConverters.IteratorHasAsScala
 
   def matchFingerprints(
       cl: ClassLoader,
-      cls: Class[_],
+      cls: Class[?],
       fingerprints: Array[Fingerprint],
       isModule: Boolean
-  ): Option[(Class[_], Fingerprint)] = {
+  ): Option[(Class[?], Fingerprint)] = {
     fingerprints.find {
       case f: SubclassFingerprint =>
         f.isModule == isModule &&
@@ -108,7 +108,7 @@ import scala.jdk.CollectionConverters.IteratorHasAsScala
   def getTestTasks(
       framework: Framework,
       args: Seq[String],
-      classFilter: Class[_] => Boolean,
+      classFilter: Class[?] => Boolean,
       cl: ClassLoader,
       testClassfilePath: Loose.Agg[Path]
   ): (Runner, Array[Task]) = {
@@ -130,7 +130,7 @@ import scala.jdk.CollectionConverters.IteratorHasAsScala
   }
 
   def runTasks(tasks: Seq[Task], testReporter: TestReporter, runner: Runner)(implicit
-      ctx: Ctx.Log with Ctx.Home
+      ctx: Ctx.Log & Ctx.Home
   ): (String, Iterator[TestResult]) = {
     val events = new ConcurrentLinkedQueue[Event]()
     val doneMessage = {
@@ -194,10 +194,10 @@ import scala.jdk.CollectionConverters.IteratorHasAsScala
       frameworkInstances: ClassLoader => Framework,
       testClassfilePath: Loose.Agg[Path],
       args: Seq[String],
-      classFilter: Class[_] => Boolean,
+      classFilter: Class[?] => Boolean,
       cl: ClassLoader,
       testReporter: TestReporter
-  )(implicit ctx: Ctx.Log with Ctx.Home): (String, Seq[TestResult]) = {
+  )(implicit ctx: Ctx.Log & Ctx.Home): (String, Seq[TestResult]) = {
 
     val framework = frameworkInstances(cl)
 
@@ -212,7 +212,7 @@ import scala.jdk.CollectionConverters.IteratorHasAsScala
       frameworkInstances: ClassLoader => Framework,
       testClassfilePath: Loose.Agg[Path],
       args: Seq[String],
-      classFilter: Class[_] => Boolean,
+      classFilter: Class[?] => Boolean,
       cl: ClassLoader
   ): Array[String] = {
     val framework = frameworkInstances(cl)


### PR DESCRIPTION
This wipes out the bulk of the annoying warnings that scroll past when compiling

There are still a few residual warnings, but I'll tackle those in a follow up