### PR TITLE
Fix launch time regression in Scala 3 upgrade

### DIFF
--- a/core/client/src/mill/client/ClientUtil.java
+++ b/core/client/src/mill/client/ClientUtil.java
@@ -2,10 +2,7 @@ package mill.client;
 
 import java.io.*;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/core/client/src/mill/client/ClientUtil.java
+++ b/core/client/src/mill/client/ClientUtil.java
@@ -101,15 +101,6 @@ public class ClientUtil {
         + (in.read() & 0xFF);
   }
 
-  public static String sha1Hash(String path) throws NoSuchAlgorithmException {
-    MessageDigest md = MessageDigest.getInstance("SHA1");
-    md.reset();
-    byte[] pathBytes = path.getBytes(StandardCharsets.UTF_8);
-    md.update(pathBytes);
-    byte[] digest = md.digest();
-    return Util.hexArray(digest);
-  }
-
   /**
    * Reads a file, ignoring empty or comment lines, interpolating env variables.
    *

--- a/core/client/src/mill/client/Util.java
+++ b/core/client/src/mill/client/Util.java
@@ -22,9 +22,19 @@ public class Util {
     return hexArray(MessageDigest.getInstance("md5").digest(str.getBytes(StandardCharsets.UTF_8)));
   }
 
-  static String hexArray(byte[] arr) {
-    return String.format("%0" + (arr.length << 1) + "x", new BigInteger(1, arr));
+  static final String HEXES = "0123456789ABCDEF";
+  public static String hexArray( byte [] raw ) {
+    if ( raw == null ) {
+      return null;
+    }
+    final StringBuilder hex = new StringBuilder( 2 * raw.length );
+    for ( final byte b : raw ) {
+      hex.append(HEXES.charAt((b & 0xF0) >> 4))
+          .append(HEXES.charAt((b & 0x0F)));
+    }
+    return hex.toString();
   }
+
 
   /**
    * Determines if we have an interactive console attached to the application.

--- a/core/client/src/mill/client/Util.java
+++ b/core/client/src/mill/client/Util.java
@@ -3,7 +3,6 @@ package mill.client;
 import java.io.Console;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -22,19 +21,17 @@ public class Util {
     return hexArray(MessageDigest.getInstance("md5").digest(str.getBytes(StandardCharsets.UTF_8)));
   }
 
-  static final String HEXES = "0123456789ABCDEF";
-  public static String hexArray( byte [] raw ) {
-    if ( raw == null ) {
-      return null;
-    }
-    final StringBuilder hex = new StringBuilder( 2 * raw.length );
-    for ( final byte b : raw ) {
-      hex.append(HEXES.charAt((b & 0xF0) >> 4))
-          .append(HEXES.charAt((b & 0x0F)));
-    }
-    return hex.toString();
-  }
+  private static final char[] HEX_ARRAY = "0123456789abcdef".toCharArray();
 
+  public static String hexArray(byte[] bytes) {
+    char[] hexChars = new char[bytes.length * 2];
+    for (int i = 0; i < bytes.length; i++) {
+      int v = bytes[i] & 0xFF;
+      hexChars[i * 2] = HEX_ARRAY[v >>> 4];
+      hexChars[i * 2 + 1] = HEX_ARRAY[v & 0x0F];
+    }
+    return new String(hexChars);
+  }
 
   /**
    * Determines if we have an interactive console attached to the application.

--- a/runner/client/src/mill/runner/client/MillClientMain.java
+++ b/runner/client/src/mill/runner/client/MillClientMain.java
@@ -60,7 +60,7 @@ public class MillClientMain {
             };
 
         final String versionAndJvmHomeEncoding =
-            ClientUtil.sha1Hash(mill.client.BuildInfo.millVersion + MillProcessLauncher.javaHome());
+            Util.md5hex(mill.client.BuildInfo.millVersion + MillProcessLauncher.javaHome());
         Path serverDir0 = Paths.get(OutFiles.out, OutFiles.millServer, versionAndJvmHomeEncoding);
         int exitCode = launcher.acquireLocksAndRun(serverDir0).exitCode;
         if (exitCode == ClientUtil.ExitServerCodeWhenVersionMismatch()) {

--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -61,7 +61,7 @@ class MillBuildBootstrap(
   }
 
   def evaluate(): Watching.Result[RunnerState] = CliImports.withValue(imports) {
-    val runnerState = evaluateRec(0)(using parserBridge)
+    val runnerState = evaluateRec(0)
 
     for ((frame, depth) <- runnerState.frames.zipWithIndex) {
       os.write.over(
@@ -78,7 +78,7 @@ class MillBuildBootstrap(
     )
   }
 
-  def evaluateRec(depth: Int)(using parser: MillScalaParser): RunnerState = {
+  def evaluateRec(depth: Int): RunnerState = {
     // println(s"+evaluateRec($depth) " + recRoot(projectRoot, depth))
     val prevFrameOpt = prevRunnerState.frames.lift(depth)
     val prevOuterFrameOpt = prevRunnerState.frames.lift(depth - 1)
@@ -112,7 +112,7 @@ class MillBuildBootstrap(
         }
       } else {
         val parsedScriptFiles = FileImportGraph.parseBuildFiles(
-          parser,
+          parserBridge,
           projectRoot,
           recRoot(projectRoot, depth) / os.up,
           output

--- a/runner/src/mill/runner/MillMain.scala
+++ b/runner/src/mill/runner/MillMain.scala
@@ -95,7 +95,7 @@ object MillMain {
   }
 
   lazy val maybeScalaCompilerWorker = ScalaCompilerWorker.bootstrapWorker()
-  
+
   def main0(
       args: Array[String],
       stateCache: RunnerState,
@@ -201,7 +201,6 @@ object MillMain {
                   userSpecifiedProperties0 ++ config.extraSystemProperties
 
                 val threadCount = Some(maybeThreadCount.toOption.get)
-
 
                 if (maybeScalaCompilerWorker.isLeft) {
                   val err = maybeScalaCompilerWorker.left.get

--- a/runner/src/mill/runner/MillMain.scala
+++ b/runner/src/mill/runner/MillMain.scala
@@ -94,6 +94,8 @@ object MillMain {
     System.exit(if (result) 0 else 1)
   }
 
+  lazy val maybeScalaCompilerWorker = ScalaCompilerWorker.bootstrapWorker()
+  
   def main0(
       args: Array[String],
       stateCache: RunnerState,
@@ -200,7 +202,7 @@ object MillMain {
 
                 val threadCount = Some(maybeThreadCount.toOption.get)
 
-                val maybeScalaCompilerWorker = ScalaCompilerWorker.bootstrapWorker(config.home)
+
                 if (maybeScalaCompilerWorker.isLeft) {
                   val err = maybeScalaCompilerWorker.left.get
                   streams.err.println(err)

--- a/runner/src/mill/runner/worker/ScalaCompilerWorker.scala
+++ b/runner/src/mill/runner/worker/ScalaCompilerWorker.scala
@@ -80,9 +80,7 @@ private[runner] object ScalaCompilerWorker {
     }
   }
 
-  private def reflectUnsafe(classpath: IterableOnce[os.Path])(using
-      mill.api.Ctx.Home
-  ): ScalaCompilerWorkerApi =
+  private def reflectUnsafe(classpath: IterableOnce[os.Path]): ScalaCompilerWorkerApi =
     val cl = mill.util.Jvm.createClassLoader(
       classpath.toVector,
       getClass.getClassLoader
@@ -94,9 +92,7 @@ private[runner] object ScalaCompilerWorker {
       .asInstanceOf[ScalaCompilerWorkerApi]
     bridge
 
-  private def reflectEither(classpath: IterableOnce[os.Path])(using
-      mill.api.Ctx.Home
-  ): Either[String, ScalaCompilerWorkerApi] =
+  private def reflectEither(classpath: IterableOnce[os.Path]): Either[String, ScalaCompilerWorkerApi] =
     catchWrapException {
       reflectUnsafe(classpath)
     }
@@ -108,10 +104,7 @@ private[runner] object ScalaCompilerWorker {
       reflectUnsafe(classpath)
     }
 
-  def bootstrapWorker(home0: os.Path): Either[String, ResolvedWorker] = {
-    given mill.api.Ctx.Home = new mill.api.Ctx.Home {
-      def home = home0
-    }
+  def bootstrapWorker(): Either[String, ResolvedWorker] = {
     val classpath = bootstrapWorkerClasspath() match {
       case Result.Success(value) => Right(value)
       case Result.Failure(msg, _) => Left(msg)

--- a/runner/src/mill/runner/worker/ScalaCompilerWorker.scala
+++ b/runner/src/mill/runner/worker/ScalaCompilerWorker.scala
@@ -92,7 +92,8 @@ private[runner] object ScalaCompilerWorker {
       .asInstanceOf[ScalaCompilerWorkerApi]
     bridge
 
-  private def reflectEither(classpath: IterableOnce[os.Path]): Either[String, ScalaCompilerWorkerApi] =
+  private def reflectEither(classpath: IterableOnce[os.Path])
+      : Either[String, ScalaCompilerWorkerApi] =
     catchWrapException {
       reflectUnsafe(classpath)
     }


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/4498

Turns out we were instantiating a new Classloader to hold the Scala 3 compiler worker every run, which is expensive, even though the worker is the same every time. This PR moves the compile worker to a global `lazy val` so it can be reused.

Also replaced `hexArray` with a implementation that avoids `String.format` and `BigInteger`, because they were appearing in the Jprofiler profiles, and replaces a `sha1Hash` call with `md5hex` since the callsite doesn't require a cryptographic hash

Tested manually, makes warm launch times drop back to similar to 0.12.7 