### PR TITLE
Cleanup `Evaluator` public API

### DIFF
--- a/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -816,7 +816,7 @@ private class MillBuildServer(
       },
       streams = logger0.systemStreams
     ) {
-      evaluator.executeTasks(
+      evaluator.execution.executeTasks(
         goals,
         reporter,
         testReporter,

--- a/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -267,7 +267,7 @@ private class MillBuildServer(
       }.toSeq
 
       val ids = groupList(tasksEvaluators)(_._2)(_._1)
-        .flatMap { case (ev, ts) => ev.evalOrThrow()(ts) }
+        .flatMap { case (ev, ts) => ev.evaluateValues(ts) }
         .flatten
 
       new InverseSourcesResult(ids.asJava)
@@ -816,7 +816,7 @@ private class MillBuildServer(
       },
       streams = logger0.systemStreams
     ) {
-      evaluator.evaluate(
+      evaluator.executeTasks(
         goals,
         reporter,
         testReporter,

--- a/core/define/src/mill/define/internal/Applicative.scala
+++ b/core/define/src/mill/define/internal/Applicative.scala
@@ -100,23 +100,11 @@ object Applicative {
 
             t.tpe.asType match
               case '[tt] =>
-                // val tempName = c.freshName(TermName("tmp"))
-                // val tempSym = c.internal.newTermSymbol(c.internal.enclosingOwner, tempName)
-                // c.internal.setInfo(tempSym, t.tpe)
-                // val tempIdent = Ident(tempSym)
-                // c.internal.setType(tempIdent, t.tpe)
-                // c.internal.setFlag(tempSym, (1L << 44).asInstanceOf[c.universe.FlagSet])
-                // val itemsIdent = Ident(itemsSym)
-                // exprs.append(q"$fun")
                 exprs += fun
                 '{ $itemsRef(${ Expr(exprs.size - 1) }).asInstanceOf[tt] }.asTerm
           case t
               if t.symbol.exists
                 && t.symbol.annotations.exists(_.tpe =:= TypeRepr.of[mill.api.Ctx.ImplicitStub]) =>
-            // val tempIdent = Ident(ctxSym)
-            // c.internal.setType(tempIdent, t.tpe)
-            // c.internal.setFlag(ctxSym, (1L << 44).asInstanceOf[c.universe.FlagSet])
-            // tempIdent
             ctxRef.asTerm
 
           case t => super.transformTerm(t)(owner)

--- a/core/exec/src/mill/exec/Execution.scala
+++ b/core/exec/src/mill/exec/Execution.scala
@@ -14,23 +14,25 @@ import scala.concurrent._
 /**
  * Core logic of evaluating tasks, without any user-facing helper methods
  */
-private[mill] class Execution(val baseLogger: ColorLogger,
-                              val chromeProfileLogger: ChromeProfileLogger,
-                              val profileLogger: ProfileLogger,
-                              val home: os.Path,
-                              val workspace: os.Path,
-                              val outPath: os.Path,
-                              val externalOutPath: os.Path,
-                              val rootModule: BaseModule,
-                              val classLoaderSigHash: Int,
-                              val classLoaderIdentityHash: Int,
-                              val workerCache: mutable.Map[Segments, (Int, Val)],
-                              val env: Map[String, String],
-                              val failFast: Boolean,
-                              val threadCount: Option[Int],
-                              val methodCodeHashSignatures: Map[String, Int],
-                              val systemExit: Int => Nothing,
-                              val exclusiveSystemStreams: SystemStreams) extends GroupExecution {
+private[mill] case class Execution(val baseLogger: ColorLogger,
+                                   val chromeProfileLogger: ChromeProfileLogger,
+                                   val profileLogger: ProfileLogger,
+                                   val home: os.Path,
+                                   val workspace: os.Path,
+                                   val outPath: os.Path,
+                                   val externalOutPath: os.Path,
+                                   val rootModule: BaseModule,
+                                   val classLoaderSigHash: Int,
+                                   val classLoaderIdentityHash: Int,
+                                   val workerCache: mutable.Map[Segments, (Int, Val)],
+                                   val env: Map[String, String],
+                                   val failFast: Boolean,
+                                   val threadCount: Option[Int],
+                                   val methodCodeHashSignatures: Map[String, Int],
+                                   val systemExit: Int => Nothing,
+                                   val exclusiveSystemStreams: SystemStreams) extends GroupExecution with AutoCloseable{
+
+  def withBaseLogger(newBaseLogger: ColorLogger) = this.copy(baseLogger = newBaseLogger)
 
   /**
    * @param goals The tasks that need to be evaluated
@@ -265,6 +267,11 @@ private[mill] class Execution(val baseLogger: ColorLogger,
       getFailing(plan.sortedGroups, results).items().map { case (k, v) => (k, v.toSeq) }.toMap,
       results.map { case (k, v) => (k, v.map(_._1)) }
     )
+  }
+
+  def close(): Unit = {
+    chromeProfileLogger.close()
+    profileLogger.close()
   }
 }
 

--- a/core/exec/src/mill/exec/Execution.scala
+++ b/core/exec/src/mill/exec/Execution.scala
@@ -14,23 +14,25 @@ import scala.concurrent._
 /**
  * Core logic of evaluating tasks, without any user-facing helper methods
  */
-private[mill] case class Execution(val baseLogger: ColorLogger,
-                                   val chromeProfileLogger: ChromeProfileLogger,
-                                   val profileLogger: ProfileLogger,
-                                   val home: os.Path,
-                                   val workspace: os.Path,
-                                   val outPath: os.Path,
-                                   val externalOutPath: os.Path,
-                                   val rootModule: BaseModule,
-                                   val classLoaderSigHash: Int,
-                                   val classLoaderIdentityHash: Int,
-                                   val workerCache: mutable.Map[Segments, (Int, Val)],
-                                   val env: Map[String, String],
-                                   val failFast: Boolean,
-                                   val threadCount: Option[Int],
-                                   val methodCodeHashSignatures: Map[String, Int],
-                                   val systemExit: Int => Nothing,
-                                   val exclusiveSystemStreams: SystemStreams) extends GroupExecution with AutoCloseable{
+private[mill] case class Execution(
+    val baseLogger: ColorLogger,
+    val chromeProfileLogger: ChromeProfileLogger,
+    val profileLogger: ProfileLogger,
+    val home: os.Path,
+    val workspace: os.Path,
+    val outPath: os.Path,
+    val externalOutPath: os.Path,
+    val rootModule: BaseModule,
+    val classLoaderSigHash: Int,
+    val classLoaderIdentityHash: Int,
+    val workerCache: mutable.Map[Segments, (Int, Val)],
+    val env: Map[String, String],
+    val failFast: Boolean,
+    val threadCount: Option[Int],
+    val methodCodeHashSignatures: Map[String, Int],
+    val systemExit: Int => Nothing,
+    val exclusiveSystemStreams: SystemStreams
+) extends GroupExecution with AutoCloseable {
 
   def withBaseLogger(newBaseLogger: ColorLogger) = this.copy(baseLogger = newBaseLogger)
 

--- a/core/exec/src/mill/exec/ExecutionCore.scala
+++ b/core/exec/src/mill/exec/ExecutionCore.scala
@@ -25,7 +25,7 @@ private[mill] trait ExecutionCore extends GroupExecution {
    * @param reporter A function that will accept a module id and provide a listener for build problems in that module
    * @param testReporter Listener for test events like start, finish with success/error
    */
-  def evaluate(
+  def executeTasks(
       goals: Seq[Task[?]],
       reporter: Int => Option[CompileProblemReporter] = _ => Option.empty[CompileProblemReporter],
       testReporter: TestReporter = DummyTestReporter,
@@ -157,7 +157,7 @@ private[mill] trait ExecutionCore extends GroupExecution {
                   noPrefix = exclusive
                 )
 
-                val res = evaluateGroupCached(
+                val res = executeGroupCached(
                   terminal = terminal,
                   group = plan.sortedGroups.lookupKey(terminal).toSeq,
                   results = upstreamResults,

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -39,7 +39,7 @@ private[mill] trait GroupExecution {
     this.threadCount.getOrElse(Runtime.getRuntime().availableProcessors())
 
   // those result which are inputs but not contained in this terminal group
-  def evaluateGroupCached(
+  def executeGroupCached(
       terminal: Task[?],
       group: Seq[Task[?]],
       results: Map[Task[?], TaskResult[(Val, Int)]],
@@ -116,7 +116,7 @@ private[mill] trait GroupExecution {
               if (labelled.flushDest) os.remove.all(paths.dest)
 
               val (newResults, newEvaluated) =
-                evaluateGroup(
+                executeGroup(
                   group,
                   results,
                   inputsHash,
@@ -155,7 +155,7 @@ private[mill] trait GroupExecution {
               )
           }
         case task =>
-          val (newResults, newEvaluated) = evaluateGroup(
+          val (newResults, newEvaluated) = executeGroup(
             group,
             results,
             inputsHash,
@@ -181,7 +181,7 @@ private[mill] trait GroupExecution {
     }
   }
 
-  private def evaluateGroup(
+  private def executeGroup(
       group: Seq[Task[?]],
       results: Map[Task[?], TaskResult[(Val, Int)]],
       inputsHash: Int,

--- a/core/exec/test/src/mill/exec/Checker.scala
+++ b/core/exec/test/src/mill/exec/Checker.scala
@@ -23,7 +23,7 @@ class Checker[T <: mill.testkit.TestBaseModule](module: T, threadCount: Option[I
       secondRunNoOp: Boolean = true
   ) = {
 
-    val evaled = evaluator.executeTasks(Seq(target))
+    val evaled = evaluator.execution.executeTasks(Seq(target))
 
     val (matchingReturnedEvaled, extra) =
       evaled.evaluated.partition(expEvaled.contains)
@@ -36,7 +36,7 @@ class Checker[T <: mill.testkit.TestBaseModule](module: T, threadCount: Option[I
 
     // Second time the value is already cached, so no evaluation needed
     if (secondRunNoOp) {
-      val evaled2 = evaluator.executeTasks(Seq(target))
+      val evaled2 = evaluator.execution.executeTasks(Seq(target))
       val expectedSecondRunEvaluated = Seq()
       assert(
         evaled2.values.map(_.value) == evaled.values.map(_.value),

--- a/core/exec/test/src/mill/exec/Checker.scala
+++ b/core/exec/test/src/mill/exec/Checker.scala
@@ -8,7 +8,7 @@ import utest.*
 class Checker[T <: mill.testkit.TestBaseModule](module: T, threadCount: Option[Int] = Some(1)) {
   // Make sure data is persisted even if we re-create the evaluator each time
 
-  val evaluator = UnitTester(module, null, threads = threadCount).evaluator
+  val execution = UnitTester(module, null, threads = threadCount).execution
 
   def apply(
       target: Task[?],
@@ -23,7 +23,7 @@ class Checker[T <: mill.testkit.TestBaseModule](module: T, threadCount: Option[I
       secondRunNoOp: Boolean = true
   ) = {
 
-    val evaled = evaluator.execution.executeTasks(Seq(target))
+    val evaled = execution.executeTasks(Seq(target))
 
     val (matchingReturnedEvaled, extra) =
       evaled.evaluated.partition(expEvaled.contains)
@@ -36,7 +36,7 @@ class Checker[T <: mill.testkit.TestBaseModule](module: T, threadCount: Option[I
 
     // Second time the value is already cached, so no evaluation needed
     if (secondRunNoOp) {
-      val evaled2 = evaluator.execution.executeTasks(Seq(target))
+      val evaled2 = execution.executeTasks(Seq(target))
       val expectedSecondRunEvaluated = Seq()
       assert(
         evaled2.values.map(_.value) == evaled.values.map(_.value),

--- a/core/exec/test/src/mill/exec/Checker.scala
+++ b/core/exec/test/src/mill/exec/Checker.scala
@@ -23,7 +23,7 @@ class Checker[T <: mill.testkit.TestBaseModule](module: T, threadCount: Option[I
       secondRunNoOp: Boolean = true
   ) = {
 
-    val evaled = evaluator.evaluate(Seq(target))
+    val evaled = evaluator.executeTasks(Seq(target))
 
     val (matchingReturnedEvaled, extra) =
       evaled.evaluated.partition(expEvaled.contains)
@@ -36,7 +36,7 @@ class Checker[T <: mill.testkit.TestBaseModule](module: T, threadCount: Option[I
 
     // Second time the value is already cached, so no evaluation needed
     if (secondRunNoOp) {
-      val evaled2 = evaluator.evaluate(Seq(target))
+      val evaled2 = evaluator.executeTasks(Seq(target))
       val expectedSecondRunEvaluated = Seq()
       assert(
         evaled2.values.map(_.value) == evaled.values.map(_.value),

--- a/core/exec/test/src/mill/exec/EvaluationTests.scala
+++ b/core/exec/test/src/mill/exec/EvaluationTests.scala
@@ -162,14 +162,14 @@ class EvaluationTests(threadCount: Option[Int]) extends TestSuite {
 
         import separateGroups._
         val checker = new Checker(separateGroups)
-        val evaled1 = checker.evaluator.execution.executeTasks(Seq(right, left))
+        val evaled1 = checker.execution.executeTasks(Seq(right, left))
         val filtered1 = evaled1.evaluated.filter(_.isInstanceOf[TargetImpl[?]])
         assert(filtered1.toSeq.sortBy(_.toString) == Seq(change, left, right).sortBy(_.toString))
-        val evaled2 = checker.evaluator.execution.executeTasks(Seq(right, left))
+        val evaled2 = checker.execution.executeTasks(Seq(right, left))
         val filtered2 = evaled2.evaluated.filter(_.isInstanceOf[TargetImpl[?]])
         assert(filtered2 == Seq())
         change.counter += 1
-        val evaled3 = checker.evaluator.execution.executeTasks(Seq(right, left))
+        val evaled3 = checker.execution.executeTasks(Seq(right, left))
         val filtered3 = evaled3.evaluated.filter(_.isInstanceOf[TargetImpl[?]])
         assert(filtered3 == Seq(change, right))
 

--- a/core/exec/test/src/mill/exec/EvaluationTests.scala
+++ b/core/exec/test/src/mill/exec/EvaluationTests.scala
@@ -162,14 +162,14 @@ class EvaluationTests(threadCount: Option[Int]) extends TestSuite {
 
         import separateGroups._
         val checker = new Checker(separateGroups)
-        val evaled1 = checker.evaluator.evaluate(Seq(right, left))
+        val evaled1 = checker.evaluator.executeTasks(Seq(right, left))
         val filtered1 = evaled1.evaluated.filter(_.isInstanceOf[TargetImpl[?]])
         assert(filtered1.toSeq.sortBy(_.toString) == Seq(change, left, right).sortBy(_.toString))
-        val evaled2 = checker.evaluator.evaluate(Seq(right, left))
+        val evaled2 = checker.evaluator.executeTasks(Seq(right, left))
         val filtered2 = evaled2.evaluated.filter(_.isInstanceOf[TargetImpl[?]])
         assert(filtered2 == Seq())
         change.counter += 1
-        val evaled3 = checker.evaluator.evaluate(Seq(right, left))
+        val evaled3 = checker.evaluator.executeTasks(Seq(right, left))
         val filtered3 = evaled3.evaluated.filter(_.isInstanceOf[TargetImpl[?]])
         assert(filtered3 == Seq(change, right))
 

--- a/core/exec/test/src/mill/exec/EvaluationTests.scala
+++ b/core/exec/test/src/mill/exec/EvaluationTests.scala
@@ -162,14 +162,14 @@ class EvaluationTests(threadCount: Option[Int]) extends TestSuite {
 
         import separateGroups._
         val checker = new Checker(separateGroups)
-        val evaled1 = checker.evaluator.executeTasks(Seq(right, left))
+        val evaled1 = checker.evaluator.execution.executeTasks(Seq(right, left))
         val filtered1 = evaled1.evaluated.filter(_.isInstanceOf[TargetImpl[?]])
         assert(filtered1.toSeq.sortBy(_.toString) == Seq(change, left, right).sortBy(_.toString))
-        val evaled2 = checker.evaluator.executeTasks(Seq(right, left))
+        val evaled2 = checker.evaluator.execution.executeTasks(Seq(right, left))
         val filtered2 = evaled2.evaluated.filter(_.isInstanceOf[TargetImpl[?]])
         assert(filtered2 == Seq())
         change.counter += 1
-        val evaled3 = checker.evaluator.executeTasks(Seq(right, left))
+        val evaled3 = checker.evaluator.execution.executeTasks(Seq(right, left))
         val filtered3 = evaled3.evaluated.filter(_.isInstanceOf[TargetImpl[?]])
         assert(filtered3 == Seq(change, right))
 

--- a/core/exec/test/src/mill/exec/ModuleTests.scala
+++ b/core/exec/test/src/mill/exec/ModuleTests.scala
@@ -48,7 +48,7 @@ object ModuleTests extends TestSuite {
       val zresult = check.apply(Build.z)
       assert(
         zresult == Right(Result(30, 1)),
-        os.read(check.evaluator.outPath / "z.json").contains("30"),
+        os.read(check.execution.outPath / "z.json").contains("30"),
         os.read(
           check.outPath / "mill/exec/TestExternalModule/x.json"
         ).contains("13"),

--- a/core/exec/test/src/mill/exec/OverrideTests.scala
+++ b/core/exec/test/src/mill/exec/OverrideTests.scala
@@ -102,9 +102,9 @@ object OverrideTests extends TestSuite {
       val checker = new Checker(canOverrideSuper)
       checker(foo, Seq("base", "object"), Seq(foo), extraEvaled = -1)
 
-      val public = os.read(checker.evaluator.outPath / "foo.json")
+      val public = os.read(checker.execution.outPath / "foo.json")
       val overridden = os.read(
-        checker.evaluator.outPath / "foo.super/BaseModule.json"
+        checker.execution.outPath / "foo.super/BaseModule.json"
       )
       assert(
         public.contains("base"),
@@ -129,9 +129,9 @@ object OverrideTests extends TestSuite {
         secondRunNoOp = false
       )
 
-      val public = os.read(checker.evaluator.outPath / "cmd.json")
+      val public = os.read(checker.execution.outPath / "cmd.json")
       val overridden = os.read(
-        checker.evaluator.outPath / "cmd.super/BaseModule.json"
+        checker.execution.outPath / "cmd.super/BaseModule.json"
       )
       assert(
         public.contains("base1"),
@@ -155,14 +155,14 @@ object OverrideTests extends TestSuite {
       )
 
       assert(
-        os.read(checker.evaluator.outPath / "m/f.super/X.json")
+        os.read(checker.execution.outPath / "m/f.super/X.json")
           .contains(" 1,")
       )
       assert(
-        os.read(checker.evaluator.outPath / "m/f.super/A.json")
+        os.read(checker.execution.outPath / "m/f.super/A.json")
           .contains(" 3,")
       )
-      assert(os.read(checker.evaluator.outPath / "m/f.json").contains(" 6,"))
+      assert(os.read(checker.execution.outPath / "m/f.json").contains(" 6,"))
     }
     test("stackableOverrides2") {
       // When the supers have the same name, qualify them until they are distinct
@@ -177,14 +177,14 @@ object OverrideTests extends TestSuite {
       )
 
       assert(
-        os.read(checker.evaluator.outPath / "m/f.super/A/X.json")
+        os.read(checker.execution.outPath / "m/f.super/A/X.json")
           .contains(" 1,")
       )
       assert(
-        os.read(checker.evaluator.outPath / "m/f.super/B/X.json")
+        os.read(checker.execution.outPath / "m/f.super/B/X.json")
           .contains(" 3,")
       )
-      assert(os.read(checker.evaluator.outPath / "m/f.json").contains(" 6,"))
+      assert(os.read(checker.execution.outPath / "m/f.json").contains(" 6,"))
     }
     test("stackableOverrides3") {
       // When the supers have the same name, qualify them until they are distinct
@@ -199,14 +199,14 @@ object OverrideTests extends TestSuite {
       )
 
       assert(
-        os.read(checker.evaluator.outPath / "m/f.super/A/X.json")
+        os.read(checker.execution.outPath / "m/f.super/A/X.json")
           .contains(" 1,")
       )
       assert(
-        os.read(checker.evaluator.outPath / "m/f.super/X.json")
+        os.read(checker.execution.outPath / "m/f.super/X.json")
           .contains(" 3,")
       )
-      assert(os.read(checker.evaluator.outPath / "m/f.json").contains(" 6,"))
+      assert(os.read(checker.execution.outPath / "m/f.json").contains(" 6,"))
     }
     test("optionalOverride") {
       // Make sure that when a task is overriden, it always gets put in the same place on
@@ -217,14 +217,14 @@ object OverrideTests extends TestSuite {
       test {
         checker(m.f, 11, Seq(m.f), extraEvaled = -1)
         assert(
-          os.read(checker.evaluator.outPath / "m/f.super/X.json")
+          os.read(checker.execution.outPath / "m/f.super/X.json")
             .contains(" 1,")
         )
       }
       test {
         checker(m.g, 101, Seq(), extraEvaled = -1)
         assert(
-          os.read(checker.evaluator.outPath / "m/f.super/X.json")
+          os.read(checker.execution.outPath / "m/f.super/X.json")
             .contains(" 1,")
         )
       }

--- a/core/exec/test/src/mill/exec/TaskTests.scala
+++ b/core/exec/test/src/mill/exec/TaskTests.scala
@@ -169,7 +169,7 @@ trait TaskTests extends TestSuite {
 
     test("worker") {
       test("static") - withEnv { (build, check) =>
-        val wc = check.evaluator.workerCache
+        val wc = check.execution.workerCache
 
         check(build.staticWorkerDownstream) ==> Right(Result(2, 1))
         wc.size ==> 1
@@ -181,10 +181,10 @@ trait TaskTests extends TestSuite {
         wc.head ==> firstCached
       }
       test("staticButReevaluated") - withEnv { (build, check) =>
-        val wc = check.evaluator.workerCache
+        val wc = check.execution.workerCache
 
         check(build.staticWorkerDownstreamReeval) ==> Right(Result(2, 1))
-        check.evaluator.workerCache.size ==> 1
+        check.execution.workerCache.size ==> 1
         val firstCached = wc.head
 
         check(build.staticWorkerDownstreamReeval) ==> Right(Result(2, 1))
@@ -199,7 +199,7 @@ trait TaskTests extends TestSuite {
         check(build.changeOnceWorkerDownstream) ==> Right(Result(2, 0))
       }
       test("alwaysChanged") - withEnv { (build, check) =>
-        val wc = check.evaluator.workerCache
+        val wc = check.execution.workerCache
 
         check(build.noisyWorkerDownstream) ==> Right(Result(2, 1))
         wc.size ==> 1
@@ -215,7 +215,7 @@ trait TaskTests extends TestSuite {
         assert(wc.head != secondCached)
       }
       test("closableWorker") - withEnv { (build, check) =>
-        val wc = check.evaluator.workerCache
+        val wc = check.execution.workerCache
 
         check(build.noisyClosableWorkerDownstream) ==> Right(Result(2, 1))
         wc.size ==> 1

--- a/core/src/mill/eval/Evaluator.scala
+++ b/core/src/mill/eval/Evaluator.scala
@@ -1,17 +1,15 @@
 package mill.eval
 
-import mill.api.{ColorLogger, ExecResult, PathRef, Result, SystemStreams, Val}
+import mill.api.{ColorLogger, ExecResult, PathRef, Result, Val}
 import mill.client.OutFiles
 import mill.define.*
 import mill.exec.{
   Cached,
-  ChromeProfileLogger,
   ExecResults,
   Execution,
   ExecutionPaths,
   ExecutionPathsResolver,
   Plan,
-  ProfileLogger,
   TaskResult
 }
 import mill.define.Watchable
@@ -120,7 +118,8 @@ final case class Evaluator private[mill] (
 
     val selectedTargetsOrErr =
       if (selectiveExecutionEnabled && os.exists(outPath / OutFiles.millSelectiveExecution)) {
-        val (named, unnamed) = targets.partitionMap{case n: NamedTask[?] => Left(n); case t => Right(t)}
+        val (named, unnamed) =
+          targets.partitionMap { case n: NamedTask[?] => Left(n); case t => Right(t) }
         val changedTasks = SelectiveExecution.computeChangedTasks0(this, named)
 
         val selectedSet = changedTasks.downstreamTasks.map(_.ctx.segments.render).toSet
@@ -133,7 +132,8 @@ final case class Evaluator private[mill] (
 
     selectedTargetsOrErr match {
       case (selectedTargets, selectiveResults) =>
-        val evaluated: ExecResults = execution.executeTasks(selectedTargets, serialCommandExec = true)
+        val evaluated: ExecResults =
+          execution.executeTasks(selectedTargets, serialCommandExec = true)
         @scala.annotation.nowarn("msg=cannot be checked at runtime")
         val watched = (evaluated.results.iterator ++ selectiveResults)
           .collect {
@@ -183,7 +183,6 @@ final case class Evaluator private[mill] (
 }
 
 private[mill] object Evaluator {
-
 
   type TaskName = String
   // This needs to be a ThreadLocal because we need to pass it into the body of

--- a/core/src/mill/eval/Evaluator.scala
+++ b/core/src/mill/eval/Evaluator.scala
@@ -60,12 +60,7 @@ final case class Evaluator private[mill] (
   def withBaseLogger(newBaseLogger: ColorLogger): Evaluator =
     this.copy(baseLogger = newBaseLogger)
 
-  def withFailFast(newFailFast: Boolean): Evaluator =
-    this.copy(failFast = newFailFast)
-
-  def plan(goals: Seq[Task[?]]): Plan = {
-    Plan.plan(goals)
-  }
+  def plan(goals: Seq[Task[?]]): Plan = Plan.plan(goals)
 
   def evalOrThrow(exceptionFactory: ExecResults => Throwable =
     r =>

--- a/core/src/mill/eval/Evaluator.scala
+++ b/core/src/mill/eval/Evaluator.scala
@@ -101,7 +101,7 @@ final case class Evaluator private[mill] (
   def evaluateValues[T](tasks: Seq[Task[T]]): Seq[T] = {
     val (watches, res0) = evaluate(tasks).get
     val results = res0.get
-    results.map(_._1.asInstanceOf[T])
+    results.map(_._1.value.asInstanceOf[T])
   }
 
   /**
@@ -112,7 +112,7 @@ final case class Evaluator private[mill] (
   def evaluate(
       targets: Seq[Task[Any]],
       selectiveExecution: Boolean = false
-  ): (Seq[Watchable], Result[Seq[(Any, Option[(Evaluator.TaskName, ujson.Value)])]]) = {
+  ): (Seq[Watchable], Result[Seq[(Val, Option[(Evaluator.TaskName, ujson.Value)])]]) = {
 
     val selectiveExecutionEnabled = selectiveExecution && !targets.exists(_.isExclusiveCommand)
 
@@ -172,9 +172,9 @@ final case class Evaluator private[mill] (
                   val jsonFile = ExecutionPaths.resolveDestPaths(outPath, t).meta
                   val metadata = upickle.default.read[Cached](ujson.read(jsonFile.toIO))
                   Some((t.toString, metadata.value))
+                case _ => None
               }
             }
-
             watched -> Result.Success(evaluated.values.zip(nameAndJson))
           case n => watched -> Result.Failure(s"$n tasks failed\n$errorStr")
         }

--- a/core/src/mill/eval/SelectiveExecution.scala
+++ b/core/src/mill/eval/SelectiveExecution.scala
@@ -4,7 +4,7 @@ import mill.api.Val
 import mill.api.Result
 import mill.client.OutFiles
 import mill.define.{InputImpl, NamedTask, Task, SelectMode}
-import mill.exec.{CodeSigUtils, ExecutionCore, Plan, TaskResult}
+import mill.exec.{CodeSigUtils, Execution, Plan, TaskResult}
 import mill.internal.SpanningForest
 import mill.internal.SpanningForest.breadthFirst
 
@@ -31,7 +31,7 @@ private[mill] object SelectiveExecution {
         }
         .toMap
 
-      val results = evaluator.executeTasks(Seq.from(inputTasksToLabels.keys))
+      val results = evaluator.execution.executeTasks(Seq.from(inputTasksToLabels.keys))
 
       val inputHashes = results
         .results
@@ -174,7 +174,7 @@ private[mill] object SelectiveExecution {
       val plan = Plan.plan(Seq.from(changedTasks.downstreamTasks))
       val indexToTerminal = plan.sortedGroups.keys().toArray.filter(t => taskSet.contains(t))
 
-      val interGroupDeps = ExecutionCore.findInterGroupDeps(plan.sortedGroups)
+      val interGroupDeps = Execution.findInterGroupDeps(plan.sortedGroups)
 
       val reverseInterGroupDeps = SpanningForest.reverseEdges(interGroupDeps)
 

--- a/core/src/mill/eval/SelectiveExecution.scala
+++ b/core/src/mill/eval/SelectiveExecution.scala
@@ -31,7 +31,7 @@ private[mill] object SelectiveExecution {
         }
         .toMap
 
-      val results = evaluator.evaluate(Seq.from(inputTasksToLabels.keys))
+      val results = evaluator.executeTasks(Seq.from(inputTasksToLabels.keys))
 
       val inputHashes = results
         .results

--- a/idea/src/mill/idea/GenIdeaImpl.scala
+++ b/idea/src/mill/idea/GenIdeaImpl.scala
@@ -232,7 +232,7 @@ case class GenIdeaImpl(
 
     val resolvedModules: Seq[ResolvedModule] = {
       resolveTasks.toSeq.flatMap { case (evaluator, tasks) =>
-        evaluator.executeTasks(tasks) match {
+        evaluator.execution.executeTasks(tasks) match {
           case r if r.failing.nonEmpty =>
             throw GenIdeaException(
               s"Failure during resolving modules: ${Evaluator.formatFailing(r)}"

--- a/idea/src/mill/idea/GenIdeaImpl.scala
+++ b/idea/src/mill/idea/GenIdeaImpl.scala
@@ -109,12 +109,7 @@ case class GenIdeaImpl(
       if (!fetchMillModules) Nil
       else {
         val moduleRepos = modulesByEvaluator.toSeq.flatMap { case (ev, modules) =>
-          ev.evalOrThrow(
-            exceptionFactory = r =>
-              GenIdeaException(
-                s"Failure during resolving repositories: ${Evaluator.formatFailing(r)}"
-              )
-          )(modules.map(_._2.repositoriesTask))
+          ev.evaluateValues(modules.map(_._2.repositoriesTask))
         }
         Lib.resolveMillBuildDeps(moduleRepos.flatten, Option(ctx), useSources = true)
         Lib.resolveMillBuildDeps(moduleRepos.flatten, Option(ctx), useSources = false)
@@ -237,7 +232,7 @@ case class GenIdeaImpl(
 
     val resolvedModules: Seq[ResolvedModule] = {
       resolveTasks.toSeq.flatMap { case (evaluator, tasks) =>
-        evaluator.evaluate(tasks) match {
+        evaluator.executeTasks(tasks) match {
           case r if r.failing.nonEmpty =>
             throw GenIdeaException(
               s"Failure during resolving modules: ${Evaluator.formatFailing(r)}"
@@ -504,12 +499,7 @@ case class GenIdeaImpl(
           resourcesPathRefs: Seq[PathRef],
           generatedSourcePathRefs: Seq[PathRef],
           allSourcesPathRefs: Seq[PathRef]
-        ) = evaluator.evalOrThrow(
-          exceptionFactory = r =>
-            GenIdeaException(
-              s"Could not evaluate sources/resources of module `${mod}`: ${Evaluator.formatFailing(r)}"
-            )
-        )(Seq(
+        ) = evaluator.evaluateValues(Seq(
           mod.resources,
           mod.generatedSources,
           mod.allSources

--- a/main/init/test/src/mill/init/InitModuleTests.scala
+++ b/main/init/test/src/mill/init/InitModuleTests.scala
@@ -25,7 +25,7 @@ object InitModuleTests extends TestSuite {
         errStream = new PrintStream(errStream, true)
       )
       test("no args") {
-        val results = evaluator.evaluator.evaluate(Seq(initmodule.init(None)))
+        val results = evaluator.evaluator.executeTasks(Seq(initmodule.init(None)))
 
         assert(results.failing.size == 0)
 
@@ -40,7 +40,7 @@ object InitModuleTests extends TestSuite {
       }
       test("non existing example") {
         val nonExistingModuleId = "nonExistingExampleId"
-        val results = evaluator.evaluator.evaluate(Seq(initmodule.init(Some(nonExistingModuleId))))
+        val results = evaluator.evaluator.executeTasks(Seq(initmodule.init(Some(nonExistingModuleId))))
         assert(results.failing.size == 1)
         assert(errStream.toString.contains(initmodule.moduleNotExistMsg(nonExistingModuleId)))
       }

--- a/main/init/test/src/mill/init/InitModuleTests.scala
+++ b/main/init/test/src/mill/init/InitModuleTests.scala
@@ -40,7 +40,9 @@ object InitModuleTests extends TestSuite {
       }
       test("non existing example") {
         val nonExistingModuleId = "nonExistingExampleId"
-        val results = evaluator.evaluator.execution.executeTasks(Seq(initmodule.init(Some(nonExistingModuleId))))
+        val results = evaluator.evaluator.execution.executeTasks(Seq(
+          initmodule.init(Some(nonExistingModuleId))
+        ))
         assert(results.failing.size == 1)
         assert(errStream.toString.contains(initmodule.moduleNotExistMsg(nonExistingModuleId)))
       }

--- a/main/init/test/src/mill/init/InitModuleTests.scala
+++ b/main/init/test/src/mill/init/InitModuleTests.scala
@@ -25,7 +25,7 @@ object InitModuleTests extends TestSuite {
         errStream = new PrintStream(errStream, true)
       )
       test("no args") {
-        val results = evaluator.evaluator.executeTasks(Seq(initmodule.init(None)))
+        val results = evaluator.evaluator.execution.executeTasks(Seq(initmodule.init(None)))
 
         assert(results.failing.size == 0)
 
@@ -40,7 +40,7 @@ object InitModuleTests extends TestSuite {
       }
       test("non existing example") {
         val nonExistingModuleId = "nonExistingExampleId"
-        val results = evaluator.evaluator.executeTasks(Seq(initmodule.init(Some(nonExistingModuleId))))
+        val results = evaluator.evaluator.execution.executeTasks(Seq(initmodule.init(Some(nonExistingModuleId))))
         assert(results.failing.size == 1)
         assert(errStream.toString.contains(initmodule.moduleNotExistMsg(nonExistingModuleId)))
       }

--- a/main/src/mill/main/MainModule.scala
+++ b/main/src/mill/main/MainModule.scala
@@ -51,7 +51,7 @@ object MainModule {
       .asInstanceOf[ColorLogger]
 
     evaluator.withBaseLogger(redirectLogger)
-      .evaluateTasksNamed(
+      .resolveEvaluate(
         targets,
         Separated,
         selectiveExecution = evaluator.selectiveExecution
@@ -533,7 +533,7 @@ trait MainModule extends BaseModule {
     Task.Command(exclusive = true) {
       val evaluated =
         if (os.exists(os.pwd / "pom.xml"))
-          evaluator.evaluateTasksNamed(
+          evaluator.resolveEvaluate(
             Seq("mill.init.InitMavenModule/init") ++ args,
             SelectMode.Separated
           )
@@ -543,17 +543,17 @@ trait MainModule extends BaseModule {
           os.exists(os.pwd / "settings.gradle") ||
           os.exists(os.pwd / "settings.gradle.kts")
         )
-          evaluator.evaluateTasksNamed(
+          evaluator.resolveEvaluate(
             Seq("mill.init.InitGradleModule/init") ++ args,
             SelectMode.Separated
           )
         else if (args.headOption.exists(_.toLowerCase.endsWith(".g8")))
-          evaluator.evaluateTasksNamed(
+          evaluator.resolveEvaluate(
             Seq("mill.scalalib.giter8.Giter8Module/init") ++ args,
             SelectMode.Separated
           )
         else
-          evaluator.evaluateTasksNamed(
+          evaluator.resolveEvaluate(
             Seq("mill.init.InitModule/init") ++ args,
             SelectMode.Separated
           )

--- a/main/src/mill/main/MainModule.scala
+++ b/main/src/mill/main/MainModule.scala
@@ -472,7 +472,7 @@ trait MainModule extends BaseModule {
             workerSegments <- evaluator.workerCache.keys.toList
             if allSegments.exists(workerSegments.startsWith)
             case (_, Val(closeable: AutoCloseable)) <-
-              evaluator.mutableWorkerCache.remove(workerSegments)
+              evaluator.execution.workerCache.remove(workerSegments)
           } {
             closeable.close()
           }

--- a/main/src/mill/main/SelectiveExecutionModule.scala
+++ b/main/src/mill/main/SelectiveExecutionModule.scala
@@ -77,7 +77,7 @@ trait SelectiveExecutionModule extends mill.define.Module {
       } else {
         SelectiveExecution.resolve0(evaluator, tasks).flatMap { resolved =>
           if (resolved.isEmpty) Result.Success((Nil, Result.Success(Nil)))
-          else evaluator.evaluateTasksNamed(resolved.toSeq, SelectMode.Multi)
+          else evaluator.resolveEvaluate(resolved.toSeq, SelectMode.Multi)
         }.flatMap {
           case (watched, Result.Failure(err)) => Result.Failure(err)
           case (watched, Result.Success(res)) => Result.Success(())

--- a/main/test/src/mill/main/MainModuleTests.scala
+++ b/main/test/src/mill/main/MainModuleTests.scala
@@ -142,7 +142,8 @@ object MainModuleTests extends TestSuite {
 
     test("inspect") {
       test("single") - UnitTester(mainModule, null).scoped { eval =>
-        val res = eval.evaluator.execution.executeTasks(Seq(mainModule.inspect(eval.evaluator, "hello")))
+        val res =
+          eval.evaluator.execution.executeTasks(Seq(mainModule.inspect(eval.evaluator, "hello")))
         val ExecResult.Success(Val(value: String)) = res.rawValues.head: @unchecked
         assert(
           res.failing.size == 0,
@@ -152,7 +153,11 @@ object MainModuleTests extends TestSuite {
       }
       test("multi") - UnitTester(mainModule, null).scoped { eval =>
         val res =
-          eval.evaluator.execution.executeTasks(Seq(mainModule.inspect(eval.evaluator, "hello", "hello2")))
+          eval.evaluator.execution.executeTasks(Seq(mainModule.inspect(
+            eval.evaluator,
+            "hello",
+            "hello2"
+          )))
         val ExecResult.Success(Val(value: String)) = res.rawValues.head: @unchecked
         assert(
           res.failing.size == 0,
@@ -211,7 +216,10 @@ object MainModuleTests extends TestSuite {
       )
       test("single") {
         val results =
-          evaluator.evaluator.execution.executeTasks(Seq(mainModule.show(evaluator.evaluator, "hello")))
+          evaluator.evaluator.execution.executeTasks(Seq(mainModule.show(
+            evaluator.evaluator,
+            "hello"
+          )))
 
         assert(results.failing.size == 0)
 
@@ -293,7 +301,10 @@ object MainModuleTests extends TestSuite {
       val evaluator = UnitTester(mainModule, null)
       test("single") {
         val results =
-          evaluator.evaluator.execution.executeTasks(Seq(mainModule.showNamed(evaluator.evaluator, "hello")))
+          evaluator.evaluator.execution.executeTasks(Seq(mainModule.showNamed(
+            evaluator.evaluator,
+            "hello"
+          )))
 
         assert(results.failing.size == 0)
 
@@ -365,7 +376,8 @@ object MainModuleTests extends TestSuite {
           os.sub / "bar/target.dest/dummy.txt"
         )
 
-        val r2 = ev.evaluator.execution.executeTasks(Seq(cleanModule.clean(ev.evaluator, "foo.target")))
+        val r2 =
+          ev.evaluator.execution.executeTasks(Seq(cleanModule.clean(ev.evaluator, "foo.target")))
         assert(r2.failing.size == 0)
         checkExists(false)(
           os.sub / "foo/target.log",
@@ -425,15 +437,24 @@ object MainModuleTests extends TestSuite {
         assert(r1.failing.size == 0)
         assert(workers.size == 5)
 
-        val r2 = ev.evaluator.execution.executeTasks(Seq(workerModule.clean(ev.evaluator, "foo.theWorker")))
+        val r2 = ev.evaluator.execution.executeTasks(Seq(workerModule.clean(
+          ev.evaluator,
+          "foo.theWorker"
+        )))
         assert(r2.failing.size == 0)
         assert(workers.size == 4)
 
-        val r3 = ev.evaluator.execution.executeTasks(Seq(workerModule.clean(ev.evaluator, "bar.theWorker")))
+        val r3 = ev.evaluator.execution.executeTasks(Seq(workerModule.clean(
+          ev.evaluator,
+          "bar.theWorker"
+        )))
         assert(r3.failing.size == 0)
         assert(workers.size == 3)
 
-        val r4 = ev.evaluator.execution.executeTasks(Seq(workerModule.clean(ev.evaluator, "bazz[1].theWorker")))
+        val r4 = ev.evaluator.execution.executeTasks(Seq(workerModule.clean(
+          ev.evaluator,
+          "bazz[1].theWorker"
+        )))
         assert(r4.failing.size == 0)
         assert(workers.size == 2)
       }
@@ -504,7 +525,8 @@ object MainModuleTests extends TestSuite {
         assert(r3.failing.size == 0)
         assert(workers.size == 3)
 
-        val r4 = ev.evaluator.execution.executeTasks(Seq(workerModule.clean(ev.evaluator, "bazz[1]")))
+        val r4 =
+          ev.evaluator.execution.executeTasks(Seq(workerModule.clean(ev.evaluator, "bazz[1]")))
         assert(r4.failing.size == 0)
         assert(workers.size == 2)
       }

--- a/main/test/src/mill/main/MainModuleTests.scala
+++ b/main/test/src/mill/main/MainModuleTests.scala
@@ -142,7 +142,7 @@ object MainModuleTests extends TestSuite {
 
     test("inspect") {
       test("single") - UnitTester(mainModule, null).scoped { eval =>
-        val res = eval.evaluator.executeTasks(Seq(mainModule.inspect(eval.evaluator, "hello")))
+        val res = eval.evaluator.execution.executeTasks(Seq(mainModule.inspect(eval.evaluator, "hello")))
         val ExecResult.Success(Val(value: String)) = res.rawValues.head: @unchecked
         assert(
           res.failing.size == 0,
@@ -152,7 +152,7 @@ object MainModuleTests extends TestSuite {
       }
       test("multi") - UnitTester(mainModule, null).scoped { eval =>
         val res =
-          eval.evaluator.executeTasks(Seq(mainModule.inspect(eval.evaluator, "hello", "hello2")))
+          eval.evaluator.execution.executeTasks(Seq(mainModule.inspect(eval.evaluator, "hello", "hello2")))
         val ExecResult.Success(Val(value: String)) = res.rawValues.head: @unchecked
         assert(
           res.failing.size == 0,
@@ -211,7 +211,7 @@ object MainModuleTests extends TestSuite {
       )
       test("single") {
         val results =
-          evaluator.evaluator.executeTasks(Seq(mainModule.show(evaluator.evaluator, "hello")))
+          evaluator.evaluator.execution.executeTasks(Seq(mainModule.show(evaluator.evaluator, "hello")))
 
         assert(results.failing.size == 0)
 
@@ -234,7 +234,7 @@ object MainModuleTests extends TestSuite {
       }
       test("multi") {
         val results =
-          evaluator.evaluator.executeTasks(Seq(mainModule.show(
+          evaluator.evaluator.execution.executeTasks(Seq(mainModule.show(
             evaluator.evaluator,
             "hello",
             "+",
@@ -293,7 +293,7 @@ object MainModuleTests extends TestSuite {
       val evaluator = UnitTester(mainModule, null)
       test("single") {
         val results =
-          evaluator.evaluator.executeTasks(Seq(mainModule.showNamed(evaluator.evaluator, "hello")))
+          evaluator.evaluator.execution.executeTasks(Seq(mainModule.showNamed(evaluator.evaluator, "hello")))
 
         assert(results.failing.size == 0)
 
@@ -305,7 +305,7 @@ object MainModuleTests extends TestSuite {
       }
       test("multi") {
         val results =
-          evaluator.evaluator.executeTasks(Seq(mainModule.showNamed(
+          evaluator.evaluator.execution.executeTasks(Seq(mainModule.showNamed(
             evaluator.evaluator,
             "hello",
             "+",
@@ -346,17 +346,17 @@ object MainModuleTests extends TestSuite {
       }
 
       test("all") {
-        val r1 = ev.evaluator.executeTasks(Seq(cleanModule.all))
+        val r1 = ev.evaluator.execution.executeTasks(Seq(cleanModule.all))
         assert(r1.failing.size == 0)
         checkExists(true)(os.sub / "foo")
 
-        val r2 = ev.evaluator.executeTasks(Seq(cleanModule.clean(ev.evaluator)))
+        val r2 = ev.evaluator.execution.executeTasks(Seq(cleanModule.clean(ev.evaluator)))
         assert(r2.failing.size == 0)
         checkExists(false)(os.sub / "foo")
       }
 
       test("single-target") {
-        val r1 = ev.evaluator.executeTasks(Seq(cleanModule.all))
+        val r1 = ev.evaluator.execution.executeTasks(Seq(cleanModule.all))
         assert(r1.failing.size == 0)
         checkExists(true)(
           os.sub / "foo/target.json",
@@ -365,7 +365,7 @@ object MainModuleTests extends TestSuite {
           os.sub / "bar/target.dest/dummy.txt"
         )
 
-        val r2 = ev.evaluator.executeTasks(Seq(cleanModule.clean(ev.evaluator, "foo.target")))
+        val r2 = ev.evaluator.execution.executeTasks(Seq(cleanModule.clean(ev.evaluator, "foo.target")))
         assert(r2.failing.size == 0)
         checkExists(false)(
           os.sub / "foo/target.log",
@@ -379,7 +379,7 @@ object MainModuleTests extends TestSuite {
       }
 
       test("single-module") {
-        val r1 = ev.evaluator.executeTasks(Seq(cleanModule.all))
+        val r1 = ev.evaluator.execution.executeTasks(Seq(cleanModule.all))
         assert(r1.failing.size == 0)
         checkExists(true)(
           os.sub / "foo/target.json",
@@ -388,7 +388,7 @@ object MainModuleTests extends TestSuite {
           os.sub / "bar/target.dest/dummy.txt"
         )
 
-        val r2 = ev.evaluator.executeTasks(Seq(cleanModule.clean(ev.evaluator, "bar")))
+        val r2 = ev.evaluator.execution.executeTasks(Seq(cleanModule.clean(ev.evaluator, "bar")))
         assert(r2.failing.size == 0)
         checkExists(true)(
           os.sub / "foo/target.json",
@@ -407,11 +407,11 @@ object MainModuleTests extends TestSuite {
         val workerModule = new WorkerModule(workers)
         val ev = UnitTester(workerModule, null)
 
-        val r1 = ev.evaluator.executeTasks(Seq(workerModule.all))
+        val r1 = ev.evaluator.execution.executeTasks(Seq(workerModule.all))
         assert(r1.failing.size == 0)
         assert(workers.size == 5)
 
-        val r2 = ev.evaluator.executeTasks(Seq(workerModule.clean(ev.evaluator)))
+        val r2 = ev.evaluator.execution.executeTasks(Seq(workerModule.clean(ev.evaluator)))
         assert(r2.failing.size == 0)
         assert(workers.isEmpty)
       }
@@ -421,19 +421,19 @@ object MainModuleTests extends TestSuite {
         val workerModule = new WorkerModule(workers)
         val ev = UnitTester(workerModule, null)
 
-        val r1 = ev.evaluator.executeTasks(Seq(workerModule.all))
+        val r1 = ev.evaluator.execution.executeTasks(Seq(workerModule.all))
         assert(r1.failing.size == 0)
         assert(workers.size == 5)
 
-        val r2 = ev.evaluator.executeTasks(Seq(workerModule.clean(ev.evaluator, "foo.theWorker")))
+        val r2 = ev.evaluator.execution.executeTasks(Seq(workerModule.clean(ev.evaluator, "foo.theWorker")))
         assert(r2.failing.size == 0)
         assert(workers.size == 4)
 
-        val r3 = ev.evaluator.executeTasks(Seq(workerModule.clean(ev.evaluator, "bar.theWorker")))
+        val r3 = ev.evaluator.execution.executeTasks(Seq(workerModule.clean(ev.evaluator, "bar.theWorker")))
         assert(r3.failing.size == 0)
         assert(workers.size == 3)
 
-        val r4 = ev.evaluator.executeTasks(Seq(workerModule.clean(ev.evaluator, "bazz[1].theWorker")))
+        val r4 = ev.evaluator.execution.executeTasks(Seq(workerModule.clean(ev.evaluator, "bazz[1].theWorker")))
         assert(r4.failing.size == 0)
         assert(workers.size == 2)
       }
@@ -443,25 +443,25 @@ object MainModuleTests extends TestSuite {
         val workerModule = new WorkerModule(workers)
         val ev = UnitTester(workerModule, null)
 
-        ev.evaluator.executeTasks(Seq(workerModule.foo.theWorker))
+        ev.evaluator.execution.executeTasks(Seq(workerModule.foo.theWorker))
           .ensuring(_.failing.size == 0)
         assert(workers.size == 1)
 
         val originalFooWorker = workers.head
 
-        ev.evaluator.executeTasks(Seq(workerModule.bar.theWorker))
+        ev.evaluator.execution.executeTasks(Seq(workerModule.bar.theWorker))
           .ensuring(_.failing.size == 0)
         assert(workers.size == 2)
         assert(workers.exists(_ eq originalFooWorker))
 
         val originalBarWorker = workers.filter(_ ne originalFooWorker).head
 
-        ev.evaluator.executeTasks(Seq(workerModule.foo.theWorker))
+        ev.evaluator.execution.executeTasks(Seq(workerModule.foo.theWorker))
           .ensuring(_.failing.size == 0)
         assert(workers.size == 2)
         assert(workers.exists(_ eq originalFooWorker))
 
-        ev.evaluator.executeTasks(Seq(workerModule.bar.theWorker))
+        ev.evaluator.execution.executeTasks(Seq(workerModule.bar.theWorker))
           .ensuring(_.failing.size == 0)
         assert(workers.size == 2)
         assert(workers.exists(_ eq originalBarWorker))
@@ -471,7 +471,7 @@ object MainModuleTests extends TestSuite {
         assert(!originalFooWorker.closed)
         os.remove(outDir / "foo/theWorker.json")
 
-        ev.evaluator.executeTasks(Seq(workerModule.foo.theWorker))
+        ev.evaluator.execution.executeTasks(Seq(workerModule.foo.theWorker))
           .ensuring(_.failing.size == 0)
         assert(workers.size == 2)
         assert(!workers.exists(_ eq originalFooWorker))
@@ -480,7 +480,7 @@ object MainModuleTests extends TestSuite {
         assert(!originalBarWorker.closed)
         os.remove(outDir / "bar/theWorker.json")
 
-        ev.evaluator.executeTasks(Seq(workerModule.bar.theWorker))
+        ev.evaluator.execution.executeTasks(Seq(workerModule.bar.theWorker))
           .ensuring(_.failing.size == 0)
         assert(workers.size == 2)
         assert(!workers.exists(_ eq originalBarWorker))
@@ -492,19 +492,19 @@ object MainModuleTests extends TestSuite {
         val workerModule = new WorkerModule(workers)
         val ev = UnitTester(workerModule, null)
 
-        val r1 = ev.evaluator.executeTasks(Seq(workerModule.all))
+        val r1 = ev.evaluator.execution.executeTasks(Seq(workerModule.all))
         assert(r1.failing.size == 0)
         assert(workers.size == 5)
 
-        val r2 = ev.evaluator.executeTasks(Seq(workerModule.clean(ev.evaluator, "foo")))
+        val r2 = ev.evaluator.execution.executeTasks(Seq(workerModule.clean(ev.evaluator, "foo")))
         assert(r2.failing.size == 0)
         assert(workers.size == 4)
 
-        val r3 = ev.evaluator.executeTasks(Seq(workerModule.clean(ev.evaluator, "bar")))
+        val r3 = ev.evaluator.execution.executeTasks(Seq(workerModule.clean(ev.evaluator, "bar")))
         assert(r3.failing.size == 0)
         assert(workers.size == 3)
 
-        val r4 = ev.evaluator.executeTasks(Seq(workerModule.clean(ev.evaluator, "bazz[1]")))
+        val r4 = ev.evaluator.execution.executeTasks(Seq(workerModule.clean(ev.evaluator, "bazz[1]")))
         assert(r4.failing.size == 0)
         assert(workers.size == 2)
       }

--- a/main/test/src/mill/main/MainModuleTests.scala
+++ b/main/test/src/mill/main/MainModuleTests.scala
@@ -142,7 +142,7 @@ object MainModuleTests extends TestSuite {
 
     test("inspect") {
       test("single") - UnitTester(mainModule, null).scoped { eval =>
-        val res = eval.evaluator.evaluate(Seq(mainModule.inspect(eval.evaluator, "hello")))
+        val res = eval.evaluator.executeTasks(Seq(mainModule.inspect(eval.evaluator, "hello")))
         val ExecResult.Success(Val(value: String)) = res.rawValues.head: @unchecked
         assert(
           res.failing.size == 0,
@@ -152,7 +152,7 @@ object MainModuleTests extends TestSuite {
       }
       test("multi") - UnitTester(mainModule, null).scoped { eval =>
         val res =
-          eval.evaluator.evaluate(Seq(mainModule.inspect(eval.evaluator, "hello", "hello2")))
+          eval.evaluator.executeTasks(Seq(mainModule.inspect(eval.evaluator, "hello", "hello2")))
         val ExecResult.Success(Val(value: String)) = res.rawValues.head: @unchecked
         assert(
           res.failing.size == 0,
@@ -211,7 +211,7 @@ object MainModuleTests extends TestSuite {
       )
       test("single") {
         val results =
-          evaluator.evaluator.evaluate(Seq(mainModule.show(evaluator.evaluator, "hello")))
+          evaluator.evaluator.executeTasks(Seq(mainModule.show(evaluator.evaluator, "hello")))
 
         assert(results.failing.size == 0)
 
@@ -234,7 +234,7 @@ object MainModuleTests extends TestSuite {
       }
       test("multi") {
         val results =
-          evaluator.evaluator.evaluate(Seq(mainModule.show(
+          evaluator.evaluator.executeTasks(Seq(mainModule.show(
             evaluator.evaluator,
             "hello",
             "+",
@@ -293,7 +293,7 @@ object MainModuleTests extends TestSuite {
       val evaluator = UnitTester(mainModule, null)
       test("single") {
         val results =
-          evaluator.evaluator.evaluate(Seq(mainModule.showNamed(evaluator.evaluator, "hello")))
+          evaluator.evaluator.executeTasks(Seq(mainModule.showNamed(evaluator.evaluator, "hello")))
 
         assert(results.failing.size == 0)
 
@@ -305,7 +305,7 @@ object MainModuleTests extends TestSuite {
       }
       test("multi") {
         val results =
-          evaluator.evaluator.evaluate(Seq(mainModule.showNamed(
+          evaluator.evaluator.executeTasks(Seq(mainModule.showNamed(
             evaluator.evaluator,
             "hello",
             "+",
@@ -346,17 +346,17 @@ object MainModuleTests extends TestSuite {
       }
 
       test("all") {
-        val r1 = ev.evaluator.evaluate(Seq(cleanModule.all))
+        val r1 = ev.evaluator.executeTasks(Seq(cleanModule.all))
         assert(r1.failing.size == 0)
         checkExists(true)(os.sub / "foo")
 
-        val r2 = ev.evaluator.evaluate(Seq(cleanModule.clean(ev.evaluator)))
+        val r2 = ev.evaluator.executeTasks(Seq(cleanModule.clean(ev.evaluator)))
         assert(r2.failing.size == 0)
         checkExists(false)(os.sub / "foo")
       }
 
       test("single-target") {
-        val r1 = ev.evaluator.evaluate(Seq(cleanModule.all))
+        val r1 = ev.evaluator.executeTasks(Seq(cleanModule.all))
         assert(r1.failing.size == 0)
         checkExists(true)(
           os.sub / "foo/target.json",
@@ -365,7 +365,7 @@ object MainModuleTests extends TestSuite {
           os.sub / "bar/target.dest/dummy.txt"
         )
 
-        val r2 = ev.evaluator.evaluate(Seq(cleanModule.clean(ev.evaluator, "foo.target")))
+        val r2 = ev.evaluator.executeTasks(Seq(cleanModule.clean(ev.evaluator, "foo.target")))
         assert(r2.failing.size == 0)
         checkExists(false)(
           os.sub / "foo/target.log",
@@ -379,7 +379,7 @@ object MainModuleTests extends TestSuite {
       }
 
       test("single-module") {
-        val r1 = ev.evaluator.evaluate(Seq(cleanModule.all))
+        val r1 = ev.evaluator.executeTasks(Seq(cleanModule.all))
         assert(r1.failing.size == 0)
         checkExists(true)(
           os.sub / "foo/target.json",
@@ -388,7 +388,7 @@ object MainModuleTests extends TestSuite {
           os.sub / "bar/target.dest/dummy.txt"
         )
 
-        val r2 = ev.evaluator.evaluate(Seq(cleanModule.clean(ev.evaluator, "bar")))
+        val r2 = ev.evaluator.executeTasks(Seq(cleanModule.clean(ev.evaluator, "bar")))
         assert(r2.failing.size == 0)
         checkExists(true)(
           os.sub / "foo/target.json",
@@ -407,11 +407,11 @@ object MainModuleTests extends TestSuite {
         val workerModule = new WorkerModule(workers)
         val ev = UnitTester(workerModule, null)
 
-        val r1 = ev.evaluator.evaluate(Seq(workerModule.all))
+        val r1 = ev.evaluator.executeTasks(Seq(workerModule.all))
         assert(r1.failing.size == 0)
         assert(workers.size == 5)
 
-        val r2 = ev.evaluator.evaluate(Seq(workerModule.clean(ev.evaluator)))
+        val r2 = ev.evaluator.executeTasks(Seq(workerModule.clean(ev.evaluator)))
         assert(r2.failing.size == 0)
         assert(workers.isEmpty)
       }
@@ -421,19 +421,19 @@ object MainModuleTests extends TestSuite {
         val workerModule = new WorkerModule(workers)
         val ev = UnitTester(workerModule, null)
 
-        val r1 = ev.evaluator.evaluate(Seq(workerModule.all))
+        val r1 = ev.evaluator.executeTasks(Seq(workerModule.all))
         assert(r1.failing.size == 0)
         assert(workers.size == 5)
 
-        val r2 = ev.evaluator.evaluate(Seq(workerModule.clean(ev.evaluator, "foo.theWorker")))
+        val r2 = ev.evaluator.executeTasks(Seq(workerModule.clean(ev.evaluator, "foo.theWorker")))
         assert(r2.failing.size == 0)
         assert(workers.size == 4)
 
-        val r3 = ev.evaluator.evaluate(Seq(workerModule.clean(ev.evaluator, "bar.theWorker")))
+        val r3 = ev.evaluator.executeTasks(Seq(workerModule.clean(ev.evaluator, "bar.theWorker")))
         assert(r3.failing.size == 0)
         assert(workers.size == 3)
 
-        val r4 = ev.evaluator.evaluate(Seq(workerModule.clean(ev.evaluator, "bazz[1].theWorker")))
+        val r4 = ev.evaluator.executeTasks(Seq(workerModule.clean(ev.evaluator, "bazz[1].theWorker")))
         assert(r4.failing.size == 0)
         assert(workers.size == 2)
       }
@@ -443,25 +443,25 @@ object MainModuleTests extends TestSuite {
         val workerModule = new WorkerModule(workers)
         val ev = UnitTester(workerModule, null)
 
-        ev.evaluator.evaluate(Seq(workerModule.foo.theWorker))
+        ev.evaluator.executeTasks(Seq(workerModule.foo.theWorker))
           .ensuring(_.failing.size == 0)
         assert(workers.size == 1)
 
         val originalFooWorker = workers.head
 
-        ev.evaluator.evaluate(Seq(workerModule.bar.theWorker))
+        ev.evaluator.executeTasks(Seq(workerModule.bar.theWorker))
           .ensuring(_.failing.size == 0)
         assert(workers.size == 2)
         assert(workers.exists(_ eq originalFooWorker))
 
         val originalBarWorker = workers.filter(_ ne originalFooWorker).head
 
-        ev.evaluator.evaluate(Seq(workerModule.foo.theWorker))
+        ev.evaluator.executeTasks(Seq(workerModule.foo.theWorker))
           .ensuring(_.failing.size == 0)
         assert(workers.size == 2)
         assert(workers.exists(_ eq originalFooWorker))
 
-        ev.evaluator.evaluate(Seq(workerModule.bar.theWorker))
+        ev.evaluator.executeTasks(Seq(workerModule.bar.theWorker))
           .ensuring(_.failing.size == 0)
         assert(workers.size == 2)
         assert(workers.exists(_ eq originalBarWorker))
@@ -471,7 +471,7 @@ object MainModuleTests extends TestSuite {
         assert(!originalFooWorker.closed)
         os.remove(outDir / "foo/theWorker.json")
 
-        ev.evaluator.evaluate(Seq(workerModule.foo.theWorker))
+        ev.evaluator.executeTasks(Seq(workerModule.foo.theWorker))
           .ensuring(_.failing.size == 0)
         assert(workers.size == 2)
         assert(!workers.exists(_ eq originalFooWorker))
@@ -480,7 +480,7 @@ object MainModuleTests extends TestSuite {
         assert(!originalBarWorker.closed)
         os.remove(outDir / "bar/theWorker.json")
 
-        ev.evaluator.evaluate(Seq(workerModule.bar.theWorker))
+        ev.evaluator.executeTasks(Seq(workerModule.bar.theWorker))
           .ensuring(_.failing.size == 0)
         assert(workers.size == 2)
         assert(!workers.exists(_ eq originalBarWorker))
@@ -492,19 +492,19 @@ object MainModuleTests extends TestSuite {
         val workerModule = new WorkerModule(workers)
         val ev = UnitTester(workerModule, null)
 
-        val r1 = ev.evaluator.evaluate(Seq(workerModule.all))
+        val r1 = ev.evaluator.executeTasks(Seq(workerModule.all))
         assert(r1.failing.size == 0)
         assert(workers.size == 5)
 
-        val r2 = ev.evaluator.evaluate(Seq(workerModule.clean(ev.evaluator, "foo")))
+        val r2 = ev.evaluator.executeTasks(Seq(workerModule.clean(ev.evaluator, "foo")))
         assert(r2.failing.size == 0)
         assert(workers.size == 4)
 
-        val r3 = ev.evaluator.evaluate(Seq(workerModule.clean(ev.evaluator, "bar")))
+        val r3 = ev.evaluator.executeTasks(Seq(workerModule.clean(ev.evaluator, "bar")))
         assert(r3.failing.size == 0)
         assert(workers.size == 3)
 
-        val r4 = ev.evaluator.evaluate(Seq(workerModule.clean(ev.evaluator, "bazz[1]")))
+        val r4 = ev.evaluator.executeTasks(Seq(workerModule.clean(ev.evaluator, "bazz[1]")))
         assert(r4.failing.size == 0)
         assert(workers.size == 2)
       }

--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -349,26 +349,29 @@ class MillBuildBootstrap(
       )
 
     val outPath = recOut(output, depth)
+    val baseLogger = new PrefixLogger(logger, bootLogPrefix)
     new mill.eval.Evaluator(
-      home,
-      projectRoot,
-      outPath,
-      outPath,
-      rootModule,
-      new PrefixLogger(logger, bootLogPrefix),
-      classLoaderSigHash = millClassloaderSigHash,
-      classLoaderIdentityHash = millClassloaderIdentityHash,
-      workerCache = workerCache.to(collection.mutable.Map),
-      env = env,
-      failFast = !keepGoing,
-      threadCount = threadCount,
-      methodCodeHashSignatures = methodCodeHashSignatures,
       allowPositionalCommandArgs = allowPositionalCommandArgs,
-      systemExit = systemExit,
-      exclusiveSystemStreams = streams0,
-      selectiveExecution = selectiveExecution,
-      chromeProfileLogger = new ChromeProfileLogger(outPath / millChromeProfile),
-      profileLogger = new ProfileLogger(outPath / millProfile)
+      selectiveExecution = false,
+      execution = new mill.exec.Execution(
+        baseLogger = baseLogger,
+        chromeProfileLogger = new ChromeProfileLogger(outPath / millChromeProfile),
+        profileLogger = new ProfileLogger(outPath / millProfile),
+        home = home,
+        workspace = projectRoot,
+        outPath = outPath,
+        externalOutPath = outPath,
+        rootModule = rootModule,
+        classLoaderSigHash = millClassloaderSigHash,
+        classLoaderIdentityHash = millClassloaderIdentityHash,
+        workerCache = workerCache.to(collection.mutable.Map),
+        env = env,
+        failFast = !keepGoing,
+        threadCount = threadCount,
+        methodCodeHashSignatures = methodCodeHashSignatures,
+        systemExit = systemExit,
+        exclusiveSystemStreams = streams0,
+      )
     )
   }
 

--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -352,7 +352,7 @@ class MillBuildBootstrap(
     val baseLogger = new PrefixLogger(logger, bootLogPrefix)
     new mill.eval.Evaluator(
       allowPositionalCommandArgs = allowPositionalCommandArgs,
-      selectiveExecution = false,
+      selectiveExecution = selectiveExecution,
       execution = new mill.exec.Execution(
         baseLogger = baseLogger,
         chromeProfileLogger = new ChromeProfileLogger(outPath / millChromeProfile),

--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -454,7 +454,7 @@ object MillBuildBootstrap {
     rootModule.evalWatchedValues.clear()
     val evalTaskResult =
       mill.api.ClassLoader.withContextClassLoader(rootModule.getClass.getClassLoader) {
-        evaluator.evaluateTasksNamed(
+        evaluator.resolveEvaluate(
           targetsAndParams,
           SelectMode.Separated,
           selectiveExecution = selectiveExecution

--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -370,7 +370,7 @@ class MillBuildBootstrap(
         threadCount = threadCount,
         methodCodeHashSignatures = methodCodeHashSignatures,
         systemExit = systemExit,
-        exclusiveSystemStreams = streams0,
+        exclusiveSystemStreams = streams0
       )
     )
   }

--- a/scalalib/src/mill/scalalib/dependency/versions/VersionsFinder.scala
+++ b/scalalib/src/mill/scalalib/dependency/versions/VersionsFinder.scala
@@ -33,7 +33,7 @@ private[dependency] object VersionsFinder {
     // (see https://github.com/com-lihaoyi/mill/issues/3876).
     val clock = Clock.fixed(Instant.now(), ZoneId.systemDefault())
 
-    evaluator.evaluateValues{
+    evaluator.evaluateValues {
       val progress = new Progress(resolvedDependencies.map(_._3.size).sum)
       resolvedDependencies.map(resolveVersions(progress, clock))
     }

--- a/scalalib/src/mill/scalalib/dependency/versions/VersionsFinder.scala
+++ b/scalalib/src/mill/scalalib/dependency/versions/VersionsFinder.scala
@@ -21,7 +21,7 @@ private[dependency] object VersionsFinder {
       case javaModule: JavaModule => javaModule
     }
 
-    val resolvedDependencies = evaluator.evalOrThrow() {
+    val resolvedDependencies = evaluator.evaluateValues {
       val progress = new Progress(javaModules.size)
       javaModules.map(resolveDeps(progress))
     }
@@ -33,7 +33,7 @@ private[dependency] object VersionsFinder {
     // (see https://github.com/com-lihaoyi/mill/issues/3876).
     val clock = Clock.fixed(Instant.now(), ZoneId.systemDefault())
 
-    evaluator.evalOrThrow() {
+    evaluator.evaluateValues{
       val progress = new Progress(resolvedDependencies.map(_._3.size).sum)
       resolvedDependencies.map(resolveVersions(progress, clock))
     }

--- a/scalalib/test/src/mill/scalalib/giter8/Giter8Tests.scala
+++ b/scalalib/test/src/mill/scalalib/giter8/Giter8Tests.scala
@@ -28,7 +28,7 @@ object Giter8Tests extends TestSuite {
           "--name=hello", // skip user interaction
           "--description=hello_desc" // need to pass all args
         )
-        val res = evaluator.evaluator.executeTasks(Seq(g8Module.init(giter8Args*)))
+        val res = evaluator.evaluator.execution.executeTasks(Seq(g8Module.init(giter8Args*)))
 
         val files = Seq(
           os.sub / "build.mill",

--- a/scalalib/test/src/mill/scalalib/giter8/Giter8Tests.scala
+++ b/scalalib/test/src/mill/scalalib/giter8/Giter8Tests.scala
@@ -28,7 +28,7 @@ object Giter8Tests extends TestSuite {
           "--name=hello", // skip user interaction
           "--description=hello_desc" // need to pass all args
         )
-        val res = evaluator.evaluator.evaluate(Seq(g8Module.init(giter8Args*)))
+        val res = evaluator.evaluator.executeTasks(Seq(g8Module.init(giter8Args*)))
 
         val files = Seq(
           os.sub / "build.mill",

--- a/testkit/src/mill/testkit/UnitTester.scala
+++ b/testkit/src/mill/testkit/UnitTester.scala
@@ -131,7 +131,7 @@ class UnitTester(
       tasks: Seq[Task[?]],
       dummy: DummyImplicit = null
   ): Either[ExecResult.Failing[?], UnitTester.Result[Seq[?]]] = {
-    val evaluated = evaluator.evaluate(tasks)
+    val evaluated = evaluator.executeTasks(tasks)
 
     if (evaluated.failing.isEmpty) {
       Right(
@@ -163,7 +163,7 @@ class UnitTester(
       expectedRawValues: Seq[ExecResult[?]]
   ): Unit = {
 
-    val res = evaluator.evaluate(Seq(target))
+    val res = evaluator.executeTasks(Seq(target))
 
     val cleaned = res.rawValues.map {
       case ExecResult.Exception(ex, _) => ExecResult.Exception(ex, new OuterStack(Nil))
@@ -177,7 +177,7 @@ class UnitTester(
 
   def check(targets: Seq[Task[?]], expected: Seq[Task[?]]): Unit = {
 
-    val evaluated = evaluator.evaluate(targets)
+    val evaluated = evaluator.executeTasks(targets)
       .evaluated
       .flatMap(_.asTarget)
       .filter(module.moduleInternal.targets.contains)

--- a/testkit/src/mill/testkit/UnitTester.scala
+++ b/testkit/src/mill/testkit/UnitTester.scala
@@ -88,25 +88,30 @@ class UnitTester(
     override def ticker(s: String): Unit = super.ticker(s"${prefix}: ${s}")
   }
 
-  val evaluator: Evaluator = new mill.eval.Evaluator(
-    mill.api.Ctx.defaultHome,
-    module.moduleDir,
-    outPath,
-    outPath,
-    module,
-    logger,
-    0,
-    0,
+  val execution = new mill.exec.Execution(
+    baseLogger = logger,
+    chromeProfileLogger = new ChromeProfileLogger(outPath / millChromeProfile),
+    profileLogger = new ProfileLogger(outPath / millProfile),
+    home = mill.api.Ctx.defaultHome,
+    workspace = module.moduleDir,
+    outPath = outPath,
+    externalOutPath = outPath,
+    rootModule = module,
+    classLoaderSigHash = 0,
+    classLoaderIdentityHash = 0,
+    workerCache = collection.mutable.Map.empty,
+    env = env,
     failFast = failFast,
     threadCount = threads,
-    env = env,
     methodCodeHashSignatures = Map(),
-    allowPositionalCommandArgs = false,
     systemExit = _ => ???,
     exclusiveSystemStreams = new SystemStreams(outStream, errStream, inStream),
+  )
+
+  val evaluator: Evaluator = new mill.eval.Evaluator(
+    allowPositionalCommandArgs = false,
     selectiveExecution = false,
-    chromeProfileLogger = new ChromeProfileLogger(outPath / millChromeProfile),
-    profileLogger = new ProfileLogger(outPath / millProfile)
+    execution = execution
   )
 
   def apply(args: String*): Either[ExecResult.Failing[?], UnitTester.Result[Seq[?]]] = {

--- a/testkit/src/mill/testkit/UnitTester.scala
+++ b/testkit/src/mill/testkit/UnitTester.scala
@@ -105,7 +105,7 @@ class UnitTester(
     threadCount = threads,
     methodCodeHashSignatures = Map(),
     systemExit = _ => ???,
-    exclusiveSystemStreams = new SystemStreams(outStream, errStream, inStream),
+    exclusiveSystemStreams = new SystemStreams(outStream, errStream, inStream)
   )
 
   val evaluator: Evaluator = new mill.eval.Evaluator(

--- a/testkit/src/mill/testkit/UnitTester.scala
+++ b/testkit/src/mill/testkit/UnitTester.scala
@@ -131,7 +131,7 @@ class UnitTester(
       tasks: Seq[Task[?]],
       dummy: DummyImplicit = null
   ): Either[ExecResult.Failing[?], UnitTester.Result[Seq[?]]] = {
-    val evaluated = evaluator.executeTasks(tasks)
+    val evaluated = evaluator.execution.executeTasks(tasks)
 
     if (evaluated.failing.isEmpty) {
       Right(
@@ -163,7 +163,7 @@ class UnitTester(
       expectedRawValues: Seq[ExecResult[?]]
   ): Unit = {
 
-    val res = evaluator.executeTasks(Seq(target))
+    val res = evaluator.execution.executeTasks(Seq(target))
 
     val cleaned = res.rawValues.map {
       case ExecResult.Exception(ex, _) => ExecResult.Exception(ex, new OuterStack(Nil))
@@ -177,7 +177,7 @@ class UnitTester(
 
   def check(targets: Seq[Task[?]], expected: Seq[Task[?]]): Unit = {
 
-    val evaluated = evaluator.executeTasks(targets)
+    val evaluated = evaluator.execution.executeTasks(targets)
       .evaluated
       .flatMap(_.asTarget)
       .filter(module.moduleInternal.targets.contains)


### PR DESCRIPTION
* Fold `evalOrThrow` into normal `evaluate` code path, rename to `evaluateValues`
* Rename the various methods in `exec` from `evaluate` to `execute`
* Fold `MainModule.resolve*` into `Evaluator#resolve*`
* Break out an `mill.exec.Execution` object so that `Evaluator` doesn't need to directly inherit all of `ExecutionCore`/`GroupExecution`