### PR TITLE
CI: Limit the dependency trees to essential modules

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -243,7 +243,7 @@ jobs:
         include:
           # bootstrap tests
           - java-version: 11 # Have one job on oldest JVM
-            buildcmd: ci/test-dist-run.sh && ci/test-install-local.sh && ./mill -i -k __.ivyDepsTree && ./mill -i -k __.ivyDepsTree --withRuntime
+            buildcmd: ci/test-dist-run.sh && ci/test-install-local.sh && ./mill -i -k __:^IntegrationCrossModule:^TestModule.ivyDepsTree && ./mill -i -k __:^IntegrationCrossModule:^TestModule.ivyDepsTree --withRuntime
           - java-version: 17 # Have one job on default JVM
             buildcmd: ci/test-mill-bootstrap.sh
 


### PR DESCRIPTION
Exclude all integration and test modules.
