### PR TITLE
Use adoc syntax to mark graphviz blocks in examples

### DIFF
--- a/example/extending/python/1-hello-python/build.mill
+++ b/example/extending/python/1-hello-python/build.mill
@@ -34,14 +34,15 @@ def typeCheck: T[Unit] = Task {
 
 // At this point, we have a minimal working build, with a build graph that looks like this:
 //
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
 //   pythonExe -> typeCheck
 //   sources -> typeCheck
 // }
-// ```
+// ....
 
 // Here is the `main.py` file
 /** See Also: src/main.py */
@@ -64,7 +65,8 @@ def run(args: mill.define.Args) = Task.Command {
 // Note that we use `stdout = os.Inherit` since we want to display any output to the user,
 // rather than capturing it for use in our command.
 
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -76,7 +78,7 @@ def run(args: mill.define.Args) = Task.Command {
 //   mainFileName [color=green, penwidth=3]
 //   run [color=green, penwidth=3]
 // }
-// ```
+// ....
 //
 // Note that like many optionally-typed languages, The `run` and `typeCheck` tasks are
 // independent: you can run a Python program without needing to typecheck it first. This is

--- a/example/extending/python/2-python-modules/build.mill
+++ b/example/extending/python/2-python-modules/build.mill
@@ -70,7 +70,8 @@ Hello, Mill Qux!
 
 // After this step, we have a build graph that looks like this:
 
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -102,7 +103,7 @@ Hello, Mill Qux!
 //     "foo.mainFileName" -> "foo.run"
 //   }
 // }
-// ```
+// ....
 
 // Right now, the three ``PythonModule``s are independent. Next we will look into
 // how to allow them to depend on each other using `moduleDeps`.

--- a/example/extending/python/3-python-module-deps/build.mill
+++ b/example/extending/python/3-python-module-deps/build.mill
@@ -86,7 +86,8 @@ Add: 10 + 20 = 30 | Multiply: 10 * 20 = 200 | Divide: 10 / 20 = 0.5
 
 // Task dependency graph, showing `foo` and `bar` tasks feeding into `qux`:
 //
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -122,7 +123,7 @@ Add: 10 + 20 = 30 | Multiply: 10 * 20 = 200 | Divide: 10 / 20 = 0.5
 //   "foo.typeCheck" -> "qux.typeCheck"  [color=green, penwidth=3]
 //   "foo.sources" -> "qux.run"  [color=green, penwidth=3]
 // }
-// ```
+// ....
 
 // Next, we will add support for depending on external Python libraries from
 // https://pypi.org/[PyPI], and bundling via https://pypi.org/project/pex/[PEX]

--- a/example/extending/python/4-python-libs-bundle/build.mill
+++ b/example/extending/python/4-python-libs-bundle/build.mill
@@ -124,7 +124,8 @@ Numpy : Sum: 150 | Pandas: Mean: 30.0, Max: 50
 // The final module tree and task graph is now as follows, with the additional dependencies
 // tasks with upstream and the bundle tasks downstream:
 //
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -176,4 +177,4 @@ Numpy : Sum: 150 | Pandas: Mean: 30.0, Max: 50
 //   "foo.sources" -> "qux.run"
 //   "foo.sources" -> "qux.bundle" [color=green, penwidth=3]
 // }
-// ```
+// ....

--- a/example/extending/typescript/1-hello-typescript/build.mill
+++ b/example/extending/typescript/1-hello-typescript/build.mill
@@ -66,14 +66,15 @@ def compile = Task {
 }
 // At this point, we have a minimal working build, with a build graph that looks like this:
 //
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
 //   npmInstall -> compile
 //   sources -> allSources -> compile
 // }
-// ```
+// ....
 //
 // Given an input file below, we can run
 // `mill compile` and demonstrate it is installing typescript locally and using it to compile
@@ -117,7 +118,8 @@ def run(args: mill.define.Args) = Task.Command {
 // Note that we use `stdout = os.Inherit` since we want to display any output to
 // the user, rather than capturing it for use in our command.
 //
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -127,7 +129,7 @@ def run(args: mill.define.Args) = Task.Command {
 //   mainFileName [color=green, penwidth=3]
 //   run [color=green, penwidth=3]
 // }
-// ```
+// ....
 
 /** Usage
 > mill run James Bond

--- a/example/extending/typescript/2-typescript-modules/build.mill
+++ b/example/extending/typescript/2-typescript-modules/build.mill
@@ -61,7 +61,8 @@ Hello James Qux
 // At this point, we have multiple ``TypeScriptModule``s, with `bar` nested inside `foo`,
 // but they are each independent and do not depend on one another.
 
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -87,7 +88,7 @@ Hello James Qux
 //     "foo.mainFileName" -> "foo.run"
 //   }
 // }
-// ```
+// ....
 //
 // Next, we will look at how to wire them up using
 // `moduleDeps`.

--- a/example/extending/typescript/3-module-deps/build.mill
+++ b/example/extending/typescript/3-module-deps/build.mill
@@ -103,7 +103,8 @@ Hello James Bond Professor
 // `foo.compile` and `bar.compile` now being fed into `qux.compile` (and
 // ultimately `qux.run`):
 //
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -131,4 +132,4 @@ Hello James Bond Professor
 //   "bar.compile" -> "qux.compile"  [color=green, penwidth=3]
 //   "foo.compile" -> "qux.compile"  [color=green, penwidth=3]
 // }
-// ```
+// ....

--- a/example/extending/typescript/4-npm-deps-bundle/build.mill
+++ b/example/extending/typescript/4-npm-deps-bundle/build.mill
@@ -127,7 +127,8 @@ Hello James Bond Professor
 // The final module tree and task graph is now as follows, with the
 // additional `npmDeps` tasks upstream and the `bundle` tasks downstream:
 
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -172,4 +173,4 @@ Hello James Bond Professor
 //   "foo.npmDeps" -> "qux.npmDeps" [color=green, penwidth=3]
 //   "bar.npmDeps" -> "qux.npmDeps" [color=green, penwidth=3]
 // }
-// ```
+// ....

--- a/example/fundamentals/cross/1-simple/build.mill
+++ b/example/fundamentals/cross/1-simple/build.mill
@@ -9,7 +9,8 @@ trait FooModule extends Cross.Module[String] {
   def sources = Task.Sources(moduleDir)
 }
 
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -32,7 +33,7 @@ trait FooModule extends Cross.Module[String] {
 //     "foo[2.10].sources"
 //   }
 // }
-// ```
+// ....
 
 // Cross modules defined using the `Cross[T]` class allow you to define
 // multiple copies of the same module, differing only in some input key. This

--- a/example/fundamentals/cross/10-static-blog/build.mill
+++ b/example/fundamentals/cross/10-static-blog/build.mill
@@ -119,7 +119,8 @@ def dist = Task {
 // All caching, incremental re-computation, and parallelism is done using the
 // Mill task graph. For this simple example, the graph is as follows
 //
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   node [shape=box width=0 height=0]
 //   "1 - Foo.md" -> "post[1]\nrender"
@@ -132,7 +133,7 @@ def dist = Task {
 //   "index" -> "dist"
 //
 // }
-// ```
+// ....
 //
 // This example use case is taken from the following blog post, which contains
 // some extensions and fun exercises to further familiarize yourself with Mill

--- a/example/fundamentals/cross/3-outside-dependency/build.mill
+++ b/example/fundamentals/cross/3-outside-dependency/build.mill
@@ -13,7 +13,8 @@ def bar = Task { s"hello ${foo("2.10").suffix()}" }
 
 def qux = Task { s"hello ${foo("2.10").suffix()} world ${foo("2.12").suffix()}" }
 
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -37,7 +38,7 @@ def qux = Task { s"hello ${foo("2.10").suffix()} world ${foo("2.12").suffix()}" 
 //   "foo[2.10].suffix" -> "qux"
 //   "foo[2.10].suffix" -> "bar"
 // }
-// ```
+// ....
 
 // Here, `def bar` uses `foo("2.10")` to reference the `"2.10"` instance of
 // `FooModule`. You can refer to whatever versions of the cross-module you want,

--- a/example/fundamentals/cross/4-cross-dependencies/build.mill
+++ b/example/fundamentals/cross/4-cross-dependencies/build.mill
@@ -13,7 +13,8 @@ trait BarModule extends Cross.Module[String] {
   def bigSuffix = Task { "[[[" + foo(crossValue).suffix() + "]]]" }
 }
 
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -51,7 +52,7 @@ trait BarModule extends Cross.Module[String] {
 //   "foo[2.11].suffix" -> "bar[2.11].bigSuffix"
 //   "foo[2.12].suffix" -> "bar[2.12].bigSuffix"
 // }
-// ```
+// ....
 
 // Rather than passing in a literal `"2.10"` to the `foo` cross module, we pass
 // in the `crossValue` property that is available within every `Cross.Module`.

--- a/example/fundamentals/cross/5-multiple-cross-axes/build.mill
+++ b/example/fundamentals/cross/5-multiple-cross-axes/build.mill
@@ -17,7 +17,8 @@ trait FooModule extends Cross.Module2[String, String] {
 
 def bar = Task { s"hello ${foo("2.10", "jvm").suffix()}" }
 
-// ```graphviz
+// [graphviz]
+// ....
 //  digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -64,7 +65,7 @@ def bar = Task { s"hello ${foo("2.10", "jvm").suffix()}" }
 //
 //   "foo[2.10,jvm].suffix" -> bar
 // }
-// ```
+// ....
 //
 // This example shows off using a for-loop to generate a list of
 // cross-key-tuples, as a `Seq[(String, String)]` that we then pass it into the

--- a/example/fundamentals/cross/7-inner-cross-module/build.mill
+++ b/example/fundamentals/cross/7-inner-cross-module/build.mill
@@ -19,7 +19,8 @@ trait FooModule extends Cross.Module[String] {
 
 def baz = Task { s"hello ${foo("a").bar.param()}" }
 
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
 //   "root-module" [style=dashed]
@@ -44,7 +45,7 @@ def baz = Task { s"hello ${foo("a").bar.param()}" }
 //   "..." [color=white]
 //   "foo[a].bar.name" -> "foo[a].bar.param" [constraint=false]
 // }
-// ```
+// ....
 //
 // You can use the `CrossValue` trait within any `Cross.Module` to
 // propagate the `crossValue` defined by an enclosing `Cross.Module` to some

--- a/example/fundamentals/modules/6-modules/build.mill
+++ b/example/fundamentals/modules/6-modules/build.mill
@@ -13,7 +13,8 @@ object foo extends Module {
   }
 }
 
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
 //   "root-module" [style=dashed]
@@ -23,7 +24,7 @@ object foo extends Module {
 //   "root-module" -> foo -> "foo.qux" -> "foo.qux.baz"  [style=dashed]
 //   foo -> "foo.bar"  [style=dashed]
 // }
-// ```
+// ....
 //
 // * You can run the two tasks via `mill foo.bar` or `mill
 // foo.qux.baz`.
@@ -80,7 +81,8 @@ object foo2 extends FooModule {
 // arrows representing the module tree, and the solid boxes and arrows representing
 // the task graph
 
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
 //   bgcolor=transparent
@@ -96,7 +98,7 @@ object foo2 extends FooModule {
 //   "foo1.bar" -> "foo1.super.qux" -> "foo1.qux" [constraint=false]
 //   "foo2.bar" -> "foo2.qux" -> "foo2.baz" [constraint=false]
 // }
-// ```
+// ....
 
 // Note that the `override` keyword is optional in mill, as is `T{...}` wrapper.
 
@@ -141,7 +143,8 @@ object outer extends MyModule {
   object inner extends MyModule
 }
 
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
 //   "root-module" [style=dashed]
@@ -156,7 +159,7 @@ object outer extends MyModule {
 //   outer -> "outer.sources"  [style=dashed]
 //   outer -> "outer.task"  [style=dashed]
 // }
-// ```
+// ....
 
 // * The `outer` module has a `moduleDir` of `outer/`, and thus a
 //   `outer.sources` referencing `outer/sources/`
@@ -255,14 +258,15 @@ trait Bar extends Foo {
 
 object bar extends Bar
 
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
 //   "bar.sourceRoots.super" -> "bar.sourceRoots" -> "bar.sourceContents"
 //   "bar.additionalSources" -> "bar.sourceRoots"
 // }
-// ```
+// ....
 /** Usage
 
 > ./mill show bar.sourceContents # includes both source folders

--- a/example/fundamentals/modules/8-diy-java-modules/build.mill
+++ b/example/fundamentals/modules/8-diy-java-modules/build.mill
@@ -34,7 +34,8 @@ trait DiyJavaModule extends Module {
 // edges (dashed) are not connected; that is because `DiyJavaModule` is abstract, and
 // needs to be inherited by a concrete `object` before it can be used.
 
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -50,7 +51,7 @@ trait DiyJavaModule extends Module {
 //     "sources" -> "compile" -> "classPath" -> "assembly"
 //   }
 // }
-// ```
+// ....
 //
 // Some notable things to call out:
 //
@@ -86,7 +87,8 @@ object qux extends DiyJavaModule {
 // duplicated three times - once per module - with the tasks wired up between the modules
 // according to our overrides for `moduleDeps`
 
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -121,7 +123,7 @@ object qux extends DiyJavaModule {
 //     "qux.sources" -> "qux.compile" -> "qux.classPath" -> "qux.assembly"
 //   }
 // }
-// ```
+// ....
 //
 // This simple set of `DiyJavaModule` can be used as follows:
 

--- a/example/fundamentals/tasks/1-task-graph/build.mill
+++ b/example/fundamentals/tasks/1-task-graph/build.mill
@@ -34,7 +34,8 @@ def run(args: String*) = Task.Command {
 // This code defines the following task graph, with the boxes being the tasks
 // and the arrows representing the _data-flow_ between them:
 //
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -43,7 +44,7 @@ def run(args: String*) = Task.Command {
 //   mainClass -> assembly
 //   assembly -> run
 // }
-// ```
+// ....
 //
 // This example does not use any of Mill's builtin support for building Java or
 // Scala projects, and instead builds a pipeline "from scratch" using Mill
@@ -78,7 +79,8 @@ My Example Text
 // * If the files in `sources` change, it will re-evaluate
 //  `compile`, and `assembly` (red)
 //
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -92,12 +94,13 @@ My Example Text
 //   resources [fillcolor=lightgreen]
 //   mainClass [fillcolor=lightgreen]
 // }
-// ```
+// ....
 //
 // * If the files in `resources` change, it will only re-evaluate `assembly` (red)
 //   and use the cached output of `compile` (green)
 //
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -111,12 +114,13 @@ My Example Text
 //   sources [fillcolor=lightgreen]
 //   mainClass [fillcolor=lightgreen]
 // }
-// ```
+// ....
 //
 // `run` behaves differently from `assembly`: as a `Task.Command` it is executed
 // every time you run it, even if none of it's upstream ``Task``s or ``Source``s changed.
 //
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -131,7 +135,7 @@ My Example Text
 //   sources [fillcolor=lightgreen]
 //   mainClass [fillcolor=lightgreen]
 // }
-// ```
+// ....
 //
 // `Command` outputs are never cached, and thus can never be
 // re-used. The only times ``Command``s may be

--- a/example/fundamentals/tasks/2-primary-tasks/build.mill
+++ b/example/fundamentals/tasks/2-primary-tasks/build.mill
@@ -38,14 +38,15 @@ def lineCount: T[Int] = Task {
     .sum
 }
 
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
 //   sources -> allSources -> lineCount
 //   sources [color=white]
 // }
-// ```
+// ....
 //
 // ``Tasks``s are defined using the `def foo = Task {...}` syntax, and dependencies
 // on other tasks are defined using `foo()` to extract the value from them.
@@ -143,7 +144,8 @@ def jar = Task {
   PathRef(Task.dest / "foo.jar")
 }
 
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -152,7 +154,7 @@ def jar = Task {
 //   allSources [color=white]
 //   resources [color=white]
 // }
-// ```
+// ....
 
 /** Usage
 
@@ -188,14 +190,15 @@ def hugeFileName = Task {
   else "<no-huge-file>"
 }
 
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
 //   allSources -> largeFile-> hugeFileName
 //   allSources [color=white]
 // }
-// ```
+// ....
 
 // CAUTION: The graph of inter-dependent tasks is evaluated in topological order; that
 // means that the body of a task will not even begin to evaluate if one of its
@@ -242,14 +245,15 @@ def summarizeClassFileStats = Task {
   )
 }
 
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
 //   classFiles -> summarizedClassFileStats
 //   classFiles [color=white]
 // }
-// ```
+// ....
 
 /** Usage
 
@@ -277,7 +281,8 @@ def run(mainClass: String, args: String*) = Task.Command {
     .call(stdout = os.Inherit)
 }
 
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -286,7 +291,7 @@ def run(mainClass: String, args: String*) = Task.Command {
 //   classFiles [color=white]
 //   resources [color=white]
 // }
-// ```
+// ....
 
 // Defined using `Task.Command {...}` syntax, ``Command``s can run arbitrary code, with
 // dependencies declared using the same `foo()` syntax (e.g. `classFiles()` above).

--- a/example/javascriptlib/module/2-custom-tasks/build.mill
+++ b/example/javascriptlib/module/2-custom-tasks/build.mill
@@ -31,7 +31,8 @@ object foo extends TypeScriptModule {
 // with the boxes representing tasks defined or overridden above and the un-boxed
 // labels representing existing Mill tasks:
 //
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0]
@@ -45,7 +46,7 @@ object foo extends TypeScriptModule {
 //
 //   "..." [color=white]
 // }
-// ```
+// ....
 //
 // Mill lets you define new cached Tasks using the `Task {...}` syntax,
 // depending on existing Tasks e.g. `foo.sources` via the `foo.sources()`

--- a/example/large/selective/9-selective-execution/build.mill
+++ b/example/large/selective/9-selective-execution/build.mill
@@ -47,7 +47,8 @@ object bar extends MyModule
 
 object qux extends MyModule
 
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -56,14 +57,15 @@ object qux extends MyModule
 //   bar -> foo
 //   foo -> "foo.test"
 // }
-// ```
+// ....
 //
 //
 // In this example, `qux.test` starts off failing with an error, while `foo.test` and
 // `bar.test` pass successfully. Normally, running `__.test` will run all three test
 // suites and show both successes and the one failure:
 //
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -75,7 +77,7 @@ object qux extends MyModule
 //   "bar.test"  [color=red penwidth=2]
 //   "foo.test"  [color=red penwidth=2]
 // }
-// ```
+// ....
 
 /** Usage
 
@@ -119,7 +121,8 @@ Test run bar.BarTests finished: 0 failed, 0 ignored, 1 total, ...
 // As we only touched ``bar``'s source files, we only need to run tests for
 //
 //
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -132,7 +135,7 @@ Test run bar.BarTests finished: 0 failed, 0 ignored, 1 total, ...
 //   "bar.test" [color=red penwidth=2]
 //   "foo.test" [color=red penwidth=2]
 // }
-// ```
+// ....
 //
 // For a more detailed report of how the changed inputs resulted in the selected tasks
 // being chosen, you can also use `selective.resolveChanged` to print out the upstream

--- a/example/pythonlib/basic/2-custom-build-logic/build.mill
+++ b/example/pythonlib/basic/2-custom-build-logic/build.mill
@@ -34,7 +34,8 @@ object foo extends PythonModule {
 // provided by `PythonModule` (labelled `resources.super` below), replacing it with the
 // `destination` folder of the new `resources` task, which is wired up to `lineCount`:
 //
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -45,7 +46,7 @@ object foo extends PythonModule {
 //   allSourceFiles [color=white]
 //   run [color=white]
 // }
-// ```
+// ....
 
 /** Usage
 

--- a/example/pythonlib/module/2-custom-tasks/build.mill
+++ b/example/pythonlib/module/2-custom-tasks/build.mill
@@ -55,7 +55,8 @@ object foo extends PythonModule {
 // with the boxes representing tasks defined or overridden above and the un-boxed
 // labels representing existing Mill tasks:
 //
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0]
@@ -69,7 +70,7 @@ object foo extends PythonModule {
 //
 //   "..." [color=white]
 // }
-// ```
+// ....
 //
 // Mill lets you define new cached Tasks using the `Task {...}` syntax,
 // depending on existing Tasks e.g. `foo.sources` via the `foo.sources()`

--- a/example/pythonlib/testing/2-test-deps/build.mill
+++ b/example/pythonlib/testing/2-test-deps/build.mill
@@ -32,14 +32,15 @@ object bar extends PythonModule {
 // In this example, not only does `foo` depend on `bar`, but we also make
 // `foo.test` depend on `bar.test`.
 //
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0]
 //   "bar" -> "bar.test" -> "foo.test"
 //   "bar" -> "foo" -> "foo.test"
 // }
-// ```
+// ....
 //
 // That lets `foo.test` make use of the
 // `BarTestUtils` class that `bar.test` defines, allowing us to re-use this

--- a/example/scalalib/basic/2-custom-build-logic/build.mill
+++ b/example/scalalib/basic/2-custom-build-logic/build.mill
@@ -31,7 +31,8 @@ object foo extends ScalaModule {
 // folder of the new task which contains a `lint-count.txt` file we write.
 //
 
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -41,7 +42,7 @@ object foo extends ScalaModule {
 //   allSourceFiles [color=white]
 //   run [color=white]
 // }
-// ```
+// ....
 //
 // * `os.read.lines` and `os.write` come
 // from the https://github.com/com-lihaoyi/os-lib[OS-Lib] library, which is

--- a/example/scalalib/module/2-custom-tasks/build.mill
+++ b/example/scalalib/module/2-custom-tasks/build.mill
@@ -57,7 +57,8 @@ object `package` extends RootModule with ScalaModule {
 // with the boxes representing tasks defined or overridden above and the un-boxed
 // labels representing existing Mill tasks:
 //
-// ```graphviz
+// [graphviz]
+// ....
 // digraph G {
 //   rankdir=LR
 //   node [shape=box width=0 height=0]
@@ -72,7 +73,7 @@ object `package` extends RootModule with ScalaModule {
 //   compile [color=white]
 //   "..." [color=white]
 // }
-// ```
+// ....
 //
 // Mill lets you define new cached Tasks using the `Task {...}` syntax,
 // depending on existing Tasks e.g. `foo.sources` via the `foo.sources()`

--- a/website/blog/modules/ROOT/pages/3-selective-testing.adoc
+++ b/website/blog/modules/ROOT/pages/3-selective-testing.adoc
@@ -36,7 +36,8 @@ These modules may depend on each other as shown in the diagram below,
 with the various `backend_service` and `frontend_web` codebases
 grouped into `deployments`, and the `_utils` files shared between them:
 
-```graphviz
+[graphviz]
+....
 digraph G {
   rankdir=LR
   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -54,7 +55,7 @@ digraph G {
   staging_environment -> end_to_end_test_2
   staging_environment -> end_to_end_test_3
 }
-```
+....
 
 These various modules would typically each have their own test suite, which
 for simplicity I left out of the diagrams.
@@ -170,7 +171,8 @@ test. For example, if we make a change to `backend_service_1`, we need to run th
 `backend_service_1` as well as the integration tests for `deployment_1`:
 
 
-```graphviz
+[graphviz]
+....
 digraph G {
   rankdir=LR
   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -186,13 +188,14 @@ digraph G {
   deployment_1 [color=red, penwidth=2]
   backend_service_1 -> deployment_1 [color=red, penwidth=2]
 }
-```
+....
 
 On the other hand, if we make a change to `frontend_web_utils`, we need to run the unit tests
 for `frontend_web_1` and `frontend_web_2`, as well as the integration tests for `deployment_1`
 and `deployment_2`, but _not_ `deployment_3` since (in this example) it doesn't depend on any frontend codebase:
 
-```graphviz
+[graphviz]
+....
 digraph G {
   rankdir=LR
   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -209,7 +212,7 @@ digraph G {
   backend_service_utils -> backend_service_2 -> deployment_2
   backend_service_utils -> backend_service_1 -> deployment_1
 }
-```
+....
 
 This kind of dependency-based selective test execution is generally straightforward:
 
@@ -297,7 +300,8 @@ you touch any line of code is extremely expensive and wasteful.
 
 For example, touching `backend_service_1` is enough to trigger all the `end_to_end` tests:
 
-```graphviz
+[graphviz]
+....
 digraph G {
   rankdir=LR
   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -324,11 +328,12 @@ digraph G {
   staging_environment -> end_to_end_test_2 [color=red, penwidth=2]
   staging_environment -> end_to_end_test_3 [color=red, penwidth=2]
 }
-```
+....
 
 Touching `frontend_web_2` is also enough to trigger all the `end_to_end` tests:
 
-```graphviz
+[graphviz]
+....
 digraph G {
   rankdir=LR
   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -357,7 +362,7 @@ digraph G {
   staging_environment -> end_to_end_test_2 [color=red, penwidth=2]
   staging_environment -> end_to_end_test_3 [color=red, penwidth=2]
 }
-```
+....
 
 The two examples above demonstrate both failure modes:
 
@@ -397,7 +402,8 @@ module's test suite. e.g. if we set `N = 1`, then a change to `backend_service_1
 will only run tests for `backend_service_1` and `deployment_1`, but not the ``end_to_end_test``s
 downstream of the `staging_environment`:
 
-```graphviz
+[graphviz]
+....
 digraph G {
   rankdir=LR
   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -419,7 +425,7 @@ digraph G {
   staging_environment -> end_to_end_test_2
   staging_environment -> end_to_end_test_3
 }
-```
+....
 
 At my last job, we picked `N = 8` somewhat arbitrarily, but as a heuristic there is
 no "right" answer, and the exact choice can be chosen to tradeoff between thoroughness
@@ -435,7 +441,8 @@ tests for the `deployment_1` module. We represent this by rendering `staging_env
 in dashed lines below, and adding additional arrows representing the hard-coded dependency
 from `deployment_1` to `end_to_end_test_1`:
 
-```graphviz
+[graphviz]
+....
 digraph G {
   rankdir=LR
   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -464,7 +471,7 @@ digraph G {
   end_to_end_test_2
   deployment_3 -> end_to_end_test_3
 }
-```
+....
 
 This approach does work, as developers usually have _some_ idea of what tests
 should be run to exercise their application code. But maintaining these hard-coded

--- a/website/blog/modules/ROOT/pages/5-executable-jars.adoc
+++ b/website/blog/modules/ROOT/pages/5-executable-jars.adoc
@@ -147,7 +147,8 @@ A https://en.wikipedia.org/wiki/ZIP_(file_format)[zip file] is an archive made o
 concatenated together followed by a "central directory" containing the _reverse offsets_ of
 every file within the archive, relative to the central directory.
 
-```graphviz
+[graphviz]
+....
 digraph G {
   label="archive.zip"
   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -156,7 +157,7 @@ digraph G {
   zip:f2:n -> zip:f0:n
   zip:f2:n -> zip:f3:n
 }
-```
+....
 
 The typical way someone reads from a zip file is a follows:
 
@@ -176,7 +177,8 @@ beginning of the file_! The zip data can be at the end of an arbitrarily long fi
 as long as programs can scan to the end of the zip to find the central directory, they
 will be able to extract the zip.
 
-```graphviz
+[graphviz]
+....
 digraph G {
   node [shape=box width=0 height=0 style=filled fillcolor=white]
   label="archive.zip"
@@ -187,7 +189,7 @@ digraph G {
   zip:f2:n -> zip:f0:n
   zip:f2:n -> zip:f3:n
 }
-```
+....
 
 Thus, we can actually use the `.zip` format in two ways:
 
@@ -205,7 +207,8 @@ So we can prepend a bash script to our `.jar` file to
 * Pass any of the current executable's command-line arguments `"$@"`as the Java program's command-line arguments
 * Allow configuration of the `java` process (since we're no longer calling it ourselves) via a `JAVA_OPTS` environment variable
 
-```graphviz
+[graphviz]
+....
 digraph G {
   label="out.jar"
   left [shape=plaintext label="bash script starts executing at start of file\nruns `java` passing itself as the classpath"]
@@ -219,7 +222,7 @@ digraph G {
   left -> zip:fe:n [color=red penwidth=3]
   zip:f2:s -> right [dir=back color=red penwidth=3]
 }
-```
+....
 
 If you use `less out.jar` to look at what's inside the Jar file, it looks like this:
 

--- a/website/blog/modules/ROOT/pages/6-garbage-collector-perf.adoc
+++ b/website/blog/modules/ROOT/pages/6-garbage-collector-perf.adoc
@@ -32,16 +32,17 @@ At its core, a garbage collector helps manage the free memory of a program, ofte
 _heap_. The memory of a program can be modelled as a linear sequence of storage locations, e.g.
 below where we have 16 slots in memory:
 
-```graphviz
+[graphviz]
+....
 digraph G {
-  
+
   node [shape=box width=0 height=0 style=filled fillcolor=white]
   heap [shape=record label="HEAP | <f0> | <f1> | <f2> | <f3> | <f4> | <f5> | <f6> | <f7> | <f8> | <f9> | <f10> | <f11> | <f12> | <f13> | <f14> | <f15>"]
 
   heap:f0:s -> alloc:n [dir=back, style=dotted]
   alloc [label = "free memory", shape=plaintext]
 }
-```
+....
 
 These storage locations can contain objects (below named `foo`, `bar`, `qux`, `baz`) that take
 up memory and may reference other objects (solid arrows). Furthermore, the values may be referenced from outside
@@ -49,10 +50,10 @@ the heap (dashed lines), e.g. from the "stack" which represents
 local variables in methods that are currently being run (shown below) or from static global
 variables (not shown). We keep a `free-memory` pointer to the first empty slot on the right.
 
-
-```graphviz
+[graphviz]
+....
 digraph G {
-  
+
   node [shape=box width=0 height=0 style=filled fillcolor=white]
   heap [shape=record label="HEAP | <f0> foo | <f1> bar | <f2> qux | <f3> baz | <f4> | <f5> | <f6> | <f7> | <f8> | <f9> | <f10> | <f11> | <f12> | <f13> | <f14> | <f15>"]
   heap:f0:s -> heap:f1:s
@@ -65,12 +66,13 @@ digraph G {
   stack:f0 -> heap:f1 [dir=none, style=dashed]
   stack:f1 -> heap:f2 [dir=none, style=dashed]
 }
-```
+....
 
 If we want to allocate a new object `new1`, we can simply put it at the location of
 the `free-memory` pointer (green below), and bump the pointer 1 slot to the right
 
-```graphviz
+[graphviz]
+....
 digraph G {
 
   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -86,7 +88,7 @@ digraph G {
   stack:f1 -> heap:f2 [dir=none, style=dashed]
   stack:f2 -> heap:f4 [dir=none, style=dashed,  color=green, penwidth=3]
 }
-```
+....
 
 Similarly, objects may stop being referenced, e.g. `bar` below no longer has a reference
 pointing at it from the stack. This may happen because a local variable on the stack is
@@ -94,7 +96,8 @@ set to `null`, or because a method call returned and the local variables associa
 it are no longer necessary
 
 
-```graphviz
+[graphviz]
+....
 digraph G {
 
   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -109,7 +112,7 @@ digraph G {
   stack:f1 -> heap:f2 [dir=none, style=dashed]
   stack:f2 -> heap:f4 [dir=none, style=dashed]
 }
-```
+....
 
 For the purposes of this example, we show all objects on the heap taking up 1 slot, but
 in real programs the size of each object may vary depending on the fields it has
@@ -121,7 +124,8 @@ The simplest kind of garbage collector splits the 16-slot heap we saw earlier in
 two 8-slot halves. If we want to allocate 4 more objects (`new2`, to `new5`), but
 there are only 3 slots left in that half of the heap, we will need to do a collection:
 
-```graphviz
+[graphviz]
+....
 digraph G {
   
   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -139,13 +143,14 @@ digraph G {
   stack:f1 -> heap1:f2 [dir=none, style=dashed]
   stack:f2 -> heap1:f4 [dir=none, style=dashed]
 }
-```
+....
 
 To do a collection, the GC first starts from all non-heap
 references (e.g. the `STACK` references above) often called "GC roots". It then traces
 the graph of references, highlighted red below:
 
-```graphviz
+[graphviz]
+....
 digraph G {
   
   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -162,7 +167,7 @@ digraph G {
   stack:f1 -> heap1:f2 [dir=none, style=dashed, color=red, penwidth=3]
   stack:f2 -> heap1:f4 [dir=none, style=dashed, color=red, penwidth=3]
 }
-```
+....
 
 Here, we can see that `foo` is not referenced ("garbage"), `qux` and `new1` are referenced directly from the
 `STACK`, and `baz` is referenced indirectly from `qux`. `bar` is referenced by `foo`, but
@@ -172,7 +177,8 @@ We then copy all objects we traced (often called the _live-set_) from `HALF1` to
 appropriately. Now `HALF2` is the half of the heap in use, and `HALF1` can be reset to empty.
 
 
-```graphviz
+[graphviz]
+....
 digraph G {
 
   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -188,12 +194,13 @@ digraph G {
   stack:f0 -> heap2:f0 [dir=none, style=dashed, color=red, penwidth=3]
   stack:f1 -> heap2:f2 [dir=none, style=dashed, color=red, penwidth=3]
 }
-```
+....
 
 This collection has freed up 5 slots, so we now have space to allocate the
 4 `new2` to `new5` objects we wanted (green) starting from our `free-memory` pointer:
 
-```graphviz
+[graphviz]
+....
 digraph G {
   
   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -213,7 +220,7 @@ digraph G {
   stack:f2 -> heap2:f3 [dir=none, style=dashed, color=green, penwidth=3]
   stack:f6 -> heap2:f6 [dir=none, style=dashed, color=green, penwidth=3]
 }
-```
+....
 
 You may notice that the objects `foo` and `bar` disappeared. This is because `foo` and `bar`
 were not referenced directly or indirectly by any GC roots: they were unreachable, and thus
@@ -225,7 +232,8 @@ As your program executes, the methods actively running may change, and thus the 
 (both from stack to heap and between entries on your heap) may change. For example, we may
 stop referencing `qux`, which also means that `baz` is now unreachable:
 
-```graphviz
+[graphviz]
+....
 digraph G {
   
   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -247,7 +255,7 @@ digraph G {
 
 
 }
-```
+....
 
 Although `qux` and `baz` are now "garbage", they still take up space in the heap. Thus, if we want
 to allocate two new objects (e.g. `new6` and `new7`), and there is only one slot left on the heap (above),
@@ -257,7 +265,8 @@ from `HALF2` to `HALF1`,
 adjusting any references to now use `HALF1` as the new heap, and clearing anything that was left
 behind in `HALF2`. This then gives us enough space to allocate `new6` and `new7` (below in green):
 
-```graphviz
+[graphviz]
+....
 digraph G {
   
   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -280,7 +289,7 @@ digraph G {
   heap1:f7:s -> alloc:n [dir=back, style=dotted]
   alloc [label = "free memory", shape=plaintext]
 }
-```
+....
 
 This process can repeat as many times as necessary: as long as there are _some_ objects
 that are unreachable, you can run a collection and copy the "live" objects to the other
@@ -333,7 +342,8 @@ We can see this in the heap diagrams: the tracing garbage collector heaps above 
 single block of empty space to the right, and had the `new` objects allocated in ascending order
 from left-to-right:
 
-```graphviz
+[graphviz]
+....
 digraph G {
 
   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -349,7 +359,7 @@ digraph G {
   heap1:f5:s -> alloc:n [dir=back, style=dotted]
   alloc [label = "free memory", shape=plaintext]
 }
-```
+....
 
 
 In contrast,
@@ -357,7 +367,8 @@ reference counted heaps (e.g. below) tend to get fragmented, with free space sca
 and the allocated objects jumbled up in no particular order
 
 
-```graphviz
+[graphviz]
+....
 digraph G {
 
   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -370,7 +381,7 @@ digraph G {
   heap:f1:s -> heap:f5:s
   stack:f4 -> heap:f6 [dir=none, style=dashed]
 }
-```
+....
 
 
 There are two main ways this affect performance:
@@ -398,7 +409,8 @@ For example, consider the following heap, identical to the one we started with, 
 additional edge from `bar` to `foo` (green), and with the edge from the stack to `bar` removed:
 
 
-```graphviz
+[graphviz]
+....
 digraph G {
 
   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -411,7 +423,7 @@ digraph G {
   stack [shape=record label="STACK | <f0> | <f1> | <f2> | <f3> | <f4> | <f5> | <f6> | <f7> "]
   stack:f1 -> heap:f2 [dir=none, style=dashed, color=red, penwidth=3]
 }
-```
+....
 
 * With reference counting, even though `foo` and `bar` cannot be reached by any external reference -
 they are "garbage" - each one still has a reference pointing at it from the other. Thus
@@ -502,7 +514,7 @@ Even from this theoretical analysis, we have already found a number of surprisin
 in how GCs perform over time. Let's now see how this applies to some real-world garbage
 collectors included with the Java Virtual Machine
 
-## Benchmarking JVM Garbage Collectors
+== Benchmarking JVM Garbage Collectors
 
 Now that we have run through a theoretical introduction and analysis of how GCs work
 and how we would expect them to perform, let's look at some small Java programs and

--- a/website/blog/modules/ROOT/pages/8-what-is-a-build-tool.adoc
+++ b/website/blog/modules/ROOT/pages/8-what-is-a-build-tool.adoc
@@ -327,7 +327,8 @@ At their core, most build steps are of the form
 
 Which can be visualized as a node in a graph
 
-```graphviz
+[graphviz]
+....
 digraph G {
   rankdir=LR
   node [shape=box width=0 height=0]
@@ -336,13 +337,14 @@ digraph G {
   tool -> output
   output[shape=none]
 }
-```
+....
 
 If we consider the tasks we looked at earlier, it might form a graph as shown below,
 where the boxes are the tasks, non-boxed text labels are the input files, and the
 arrows are the dataflow between them
 
-```graphviz
+[graphviz]
+....
 digraph G {
   rankdir=LR
   node [shape=box width=0 height=0]
@@ -359,7 +361,7 @@ digraph G {
   sources [shape=none]
   static_input_files [shape=none]
 }
-```
+....
 
 ### Ordering on the Build Graph
 
@@ -368,7 +370,8 @@ their magic. For example, if you ask to run `unit_test` (blue), then the build t
 can traverse the graph edges (red) to find it needs to ensure `compile`, `code_gen`, and
 `resolve_deps` need to be run (red)
 
-```graphviz
+[graphviz]
+....
 digraph G {
   rankdir=LR
   node [shape=box width=0 height=0]
@@ -390,7 +393,7 @@ digraph G {
   compile [fillcolor=lightpink style=filled]
   unit_test [fillcolor=lightblue style=filled]
 }
-```
+....
 
 Furthermore, the build tool is able to figure out what tasks need to run in what
 order, simply by doing a topological sort of the subset it needs. In this case,
@@ -405,7 +408,8 @@ If you then subsequently ask to run `integration_test`, the build tool can see t
 `compile`, `code_gen`, and `resolve_deps` were run earlier and can be re-used (green)
 while `package` and `asset_pipeline` need to be run
 
-```graphviz
+[graphviz]
+....
 digraph G {
   rankdir=LR
   node [shape=box width=0 height=0]
@@ -429,7 +433,7 @@ digraph G {
   asset_pipeline [fillcolor=lightpink style=filled]
   integration_test [fillcolor=lightblue style=filled]
 }
-```
+....
 
 If you then change a source file in `sources` and ask to run `integration_test`
 again, the build tool can again traverse the graph edges and see that:
@@ -439,7 +443,8 @@ again, the build tool can again traverse the graph edges and see that:
 - `unit_test` is not needed for `integration_test`, and so can be ignored
 
 
-```graphviz
+[graphviz]
+....
 digraph G {
   rankdir=LR
   node [shape=box width=0 height=0]
@@ -462,7 +467,7 @@ digraph G {
   package [fillcolor=lightpink style=filled]
   integration_test [fillcolor=lightblue style=filled]
 }
-```
+....
 
 Thus, having a model of the build graph is fundamental to how most build
 tools work their magic. When the user asks to run `unit_test` or `integration_test`,
@@ -482,7 +487,8 @@ of `unit_test` and `integration_test`. From the build graph, Mill is able to det
 - `unit_test` (blue) can run in parallel with `asset_pipeline`, `package` or `integration_test`,
   but only can start once `compile` is complete
 
-```graphviz
+[graphviz]
+....
 digraph G {
   rankdir=LR
   node [shape=box width=0 height=0]
@@ -506,7 +512,8 @@ digraph G {
   integration_test [style=filled fillcolor=lightpink]
   unit_test [style=filled fillcolor=lightblue]
 }
-```
+....
+
 
 Most modern build tools do this kind of graph-based parallelism automatically.
 In contrast to most programming languages and application frameworks where you need
@@ -544,7 +551,8 @@ cc_binary(
 )
 ```
 
-```graphviz
+[graphviz]
+....
 digraph G {
   rankdir=LR
   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -552,7 +560,7 @@ digraph G {
   "//main:hello-greet" -> "//main:hello-world"
   "main/hello-world.cc" -> "//main:hello-world"
 }
-```
+....
 
 In Bazel, the implementation of what rules like `cc_library` actually _do_ is
 done by upstream build libraries implemented in Java or Starlark. You can
@@ -581,7 +589,8 @@ val packageApp = tasks.register<Zip>("packageApp") {
 }
 ```
 
-```graphviz
+[graphviz]
+....
 digraph G {
   rankdir=LR
   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -589,7 +598,7 @@ digraph G {
   "tasks.jar" -> packageApp
   "configurations.runClassPath" -> packageApp
 }
-```
+....
 
 `packageApp` depends on the `run.sh` source file, the output of the tasks
 `tasks.jar` and `configurations.runClasspath`, and some other miscellanious configuration.
@@ -620,7 +629,8 @@ override def resources = Task {
 }
 ```
 
-```graphviz
+[graphviz]
+....
 digraph G {
   rankdir=LR
   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -630,7 +640,7 @@ digraph G {
   allSourceFiles [color=white]
   run [color=white]
 }
-```
+....
 
 Perhaps the most interesting thing about Mill is that you can write arbitrary code as
 part of your ``def``s: above you can see the code for iterating over files, counting

--- a/website/blog/modules/ROOT/pages/8-what-is-a-build-tool.adoc
+++ b/website/blog/modules/ROOT/pages/8-what-is-a-build-tool.adoc
@@ -1,6 +1,6 @@
 // tag::header[]
 
-# What does a Build Tool do?
+= What does a Build Tool do?
 :author: Li Haoyi
 :revdate: 13 February 2025
 
@@ -19,7 +19,7 @@ how they work under the hood.
 // end::header[]
 
 
-## What is a Build Tool?
+== What is a Build Tool?
 
 A build tool is a program that automates selecting which tools or tasks to
 run - and how to run them - whenever you want to do something in your codebase.
@@ -31,7 +31,7 @@ job of the build tool is to help decide what work needs to be done to accomplish
 you want, and how best to perform that work with caching and parallelism to complete it
 as quickly and as efficiently as possible.
 
-### Build Tools as Task Orchestrators
+=== Build Tools as Task Orchestrators
 
 For example, in a real-world project, before _running your code_ you may first need to:
 
@@ -68,7 +68,7 @@ ways, and it is the job of the build tool to take what you (as a developer) want
 to do, and select _which_ tasks to run and _how_ to run them in order to accomplish
 what you want.
 
-### Build Tools across Languages
+=== Build Tools across Languages
 
 Although programming languages are very different, developers in all languages have similar
 requirements. Thus most languages have one-or-more build tools, that then integrate with
@@ -121,7 +121,7 @@ xref:mill:ROOT:pythonlib/intro.adoc[Python], and (experimentally)
 xref:mill:ROOT:javascriptlib/intro.adoc[Javascript], allowing it to be used
 for https://mill-build.org/mill/main-branch/large/multi-language-builds.html[Multi-Language Builds].
 
-### Build Tools for Small Codebases
+=== Build Tools for Small Codebases
 
 Most projects start off small, and while they _can_ use a build tool, do not _need_ one.
 A single-file program or script can get by with using its language's built-in CLI
@@ -169,7 +169,7 @@ and as the codebase grows (as they tend to do) the build tool becomes even more
 necessary over time.
 
 
-### Build Tools vs Build Scripts
+=== Build Tools vs Build Scripts
 
 One common alternative to build tools is to write scripts to help manage the development
 of the project: e.g. you may find a `dev/` folder full of scripts like `run-tests.sh` or
@@ -211,7 +211,7 @@ Bash or Python enough to get the ordering/parallelism/caching they need, they pr
 shouldn't _actually do it_ and just use an off-the-shelf build tool which
 has all these problems already solved.
 
-### Build Tools as Custom Task Runtimes
+=== Build Tools as Custom Task Runtimes
 
 Most codebases have some amount of custom tasks and workflows. While many workflows
 are standardized - e.g. using the same Java compiler, Python interpreter, etc. -
@@ -257,7 +257,7 @@ a non-trivial amount of custom logic, it becomes very important. Providing
 a safe, easy-to-use way to customize your build is thus a big benefit of using
 a build tool, one that gets increasingly important as the project grows.
 
-### Build Tools for Large Codebases and Monorepos
+=== Build Tools for Large Codebases and Monorepos
 
 Twice now we've mentioned that build tools get more important as projects grow,
 so it's worth calling out the need for build tools on very-large-codebases:
@@ -300,7 +300,7 @@ _"monorepo build tool"_ provides and why they are necessary:
 
 * xref:2-monorepo-build-tool.adoc[Why Use a Monorepo Build Tool?]
 
-## How Build Tools Work: The Build Graph
+== How Build Tools Work: The Build Graph
 
 After all this talk about what a build tool is and why you would need one,
 it is worth exploring how most modern build tools work. At their core,
@@ -363,7 +363,7 @@ digraph G {
 }
 ....
 
-### Ordering on the Build Graph
+=== Ordering on the Build Graph
 
 It is from this graph representation that most build tools are able to work
 their magic. For example, if you ask to run `unit_test` (blue), then the build tool
@@ -400,7 +400,7 @@ order, simply by doing a topological sort of the subset it needs. In this case,
 it knows that `resolve_deps` and `code_gen` must both finish running before
 `compile` can begin, and `compile` must finish running before `unit_test` can begin.
 
-### Caching and Invalidation via the Build Graph
+=== Caching and Invalidation via the Build Graph
 
 
 
@@ -475,7 +475,7 @@ the build tool can simply traversal build graph to automatically determine which
 tasks need to run in order to do that, and which tasks have earlier output that can
 be re-used.
 
-### Parallelism on the Build Graph
+=== Parallelism on the Build Graph
 
 Apart from caching, the build graph is also useful for automatically parallelizing your build tasks.
 For example, consider a case where we want to do a clean build (i.e. no caching)
@@ -522,14 +522,14 @@ with threads, locks, semaphores, futures, actors, and so on. You just define the
 shape of the build graph using whatever configuration format or language the build
 tool provides, and you get parallelism for free.
 
-### Languages for defining your Build Graph
+=== Languages for defining your Build Graph
 
 Every build tool provides some format for defining the build graph data structure.
 There isn't any industry-wide standard text format for graph data structures, so each build
 tool comes up with something on their own. Here we'll look at how it is done in
 a few common build tools:
 
-#### Bazel
+==== Bazel
 
 Bazel uses the https://bazel.build/rules/language[Starlark language], a dialect of Python.
 Below I show an example `BUILD` file from their https://bazel.build/start/cpp[documentation on using Bazel for C/C++].
@@ -537,7 +537,8 @@ The Python functions like `cc_library` or `cc_binary` are called _rules_ and by 
 the function you create a `target` with the given `name` and dependencies on upstream
 targets (`deps`) and source files (`srcs`):
 
-```python
+[source,python]
+----
 cc_library(
     name = "hello-greet",
     srcs = ["hello-greet.cc"],
@@ -549,7 +550,7 @@ cc_binary(
     srcs = ["hello-world.cc"],
     deps = [":hello-greet"],
 )
-```
+----
 
 [graphviz]
 ....
@@ -569,13 +570,14 @@ or use other people's rules from one of the
 `rules_{lang}` repos on https://github.com/bazel-contrib[Bazel-Contrib],
 if you need functionality that Bazel does not come built in with
 
-#### Gradle
+==== Gradle
 
 Gradle lets you define custom tasks in either Kotlin or Groovy. Below I show an
 https://docs.gradle.org/current/userguide/implementing_custom_tasks.html[example custom task from their documentation]
 written in Kotlin, that adds a new `packageApp` task:
 
-```kotlin
+[source,kotlin]
+----
 val packageApp = tasks.register<Zip>("packageApp") {
     from(layout.projectDirectory.file("run.sh"))                // input - run.sh file
     from(tasks.jar) {                                           // input - jar task output
@@ -587,7 +589,7 @@ val packageApp = tasks.register<Zip>("packageApp") {
     destinationDirectory.set(layout.buildDirectory.dir("dist")) // output - location of the zip file
     archiveFileName.set("myApplication.zip")                    // output - name of the zip file
 }
-```
+----
 
 [graphviz]
 ....
@@ -615,8 +617,8 @@ normal method ``def``s to define xref:mill:ROOT:javalib/intro.adoc#_custom_build
 in your build graph. The different methods can call each other, e.g. `def resources` below can
 call `lineCount()` or `super.resources()`, and these method calls become the edges in your build graph:
 
-
-```scala
+[source,scala]
+----
 /** Total number of lines in module source files */
 def lineCount = Task {
   allSourceFiles().map(f => os.read.lines(f.path).size).sum
@@ -627,7 +629,7 @@ override def resources = Task {
   os.write(Task.dest / "line-count.txt", "" + lineCount())
   super.resources() ++ Seq(PathRef(Task.dest))
 }
-```
+----
 
 [graphviz]
 ....
@@ -677,7 +679,7 @@ you want in your build tool.
 
 
 
-## Conclusion
+== Conclusion
 
 Although modern build tools may look very different on the surface, most of them
 are surprisingly similar once you peek under the covers. Bazel's StarLark config,

--- a/website/docs/modules/ROOT/pages/comparisons/maven.adoc
+++ b/website/docs/modules/ROOT/pages/comparisons/maven.adoc
@@ -588,7 +588,8 @@ def make = Task {
 }
 ----
 
-```graphviz
+[graphviz]
+....
 digraph G {
   rankdir=LR
   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -596,7 +597,7 @@ digraph G {
   cSources -> make
   cSources -> cHeaders
 }
-```
+....
 
 In Mill, we define the `makefile`, `cSources`, `cHeaders`, and `make` tasks. The bulk
 of the logic is in `def make`, which prepares the `makefile` and C sources,

--- a/website/docs/modules/ROOT/pages/comparisons/unique.adoc
+++ b/website/docs/modules/ROOT/pages/comparisons/unique.adoc
@@ -202,7 +202,8 @@ def assembly = Task {
 This code defines the following task graph, with the boxes being the tasks
 and the arrows representing the _data-flow_ between them:
 
-```graphviz
+[graphviz]
+....
 digraph G {
   rankdir=LR
   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -210,7 +211,7 @@ digraph G {
   resources -> assembly
   mainClass -> assembly
 }
-```
+....
 
 This example does not use any of Mill's builtin support for building Java or
 Scala projects, and instead builds a pipeline "from scratch" using Mill

--- a/website/docs/modules/ROOT/pages/depth/design-principles.adoc
+++ b/website/docs/modules/ROOT/pages/depth/design-principles.adoc
@@ -201,7 +201,8 @@ build-related questions listed above.
 
 === The Object Hierarchy
 
-```graphviz
+[graphviz]
+....
 digraph G {
   node [shape=box width=0 height=0 style=filled fillcolor=white]
   bgcolor=transparent
@@ -214,7 +215,7 @@ digraph G {
   foo2 -> "foo2.qux"  [style=dashed]
   foo2 -> "foo2.baz"  [style=dashed]
 }
-```
+....
 
 The module hierarchy is the graph of objects, starting from the root of the
 `build.mill` file, that extend `mill.Module`. At the leaves of the hierarchy are
@@ -240,7 +241,8 @@ are sure that it will never clash with any other ``Task``s data.
 
 === The Call Graph
 
-```graphviz
+[graphviz]
+....
 digraph G {
   rankdir=LR
   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -275,7 +277,7 @@ digraph G {
     "qux.sources" -> "qux.compile" -> "qux.classPath" -> "qux.assembly"
   }
 }
-```
+....
 
 The Scala call graph of "which task references which other task" is core to
 how Mill operates. This graph is reified via the `Task {...}` macro to make it

--- a/website/docs/modules/ROOT/pages/depth/execution-model.adoc
+++ b/website/docs/modules/ROOT/pages/depth/execution-model.adoc
@@ -121,7 +121,8 @@ files generated in the <<Compilation>> step above, instantiates the xref:fundame
 and xref:fundamentals/tasks.adoc[Tasks] as necessary, and returns a list of the final tasks that
 were selected by selector:
 
-```graphviz
+[graphviz]
+....
 digraph G {
   node [shape=box width=0 height=0 style=filled fillcolor=white]
   bgcolor=transparent
@@ -129,7 +130,7 @@ digraph G {
   build -> foo -> "foo.assembly"
   build -> bar -> "bar.assembly"
 }
-```
+....
 
 Mill starts from the `RootModule` instantiated after <<Compilation>>, and uses
 Java reflection to walk the tree of modules and tasks to find the tasks that match

--- a/website/docs/modules/ROOT/pages/depth/execution-model.adoc
+++ b/website/docs/modules/ROOT/pages/depth/execution-model.adoc
@@ -148,7 +148,8 @@ build graph that includes all transitive upstream dependencies. This is done by
 traversing the graph of task dependencies, and generates a (simplified) task graph
 as shown below:
 
-```graphviz
+[graphviz]
+....
 digraph G {
   rankdir=LR
   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -176,7 +177,7 @@ digraph G {
   "foo.classPath" -> "bar.compile" [constraint=false]
   "foo.classPath" -> "bar.classPath"
 }
-```
+....
 
 In this graph, we can see that even though <<Resolution>> only selected `foo.assembly`
 and `bar.assembly`, their upstream task graph requires tasks such as `foo.compile`,
@@ -194,7 +195,8 @@ changes may have their value loaded from cache (if already evaluated earlier) or
 For example, a change to `foo/src/*.java` would affect the `foo.sources` task, which
 would invalidate and cause evaluation of the tasks highlighted in red below:
 
-```graphviz
+[graphviz]
+....
 digraph G {
   rankdir=LR
   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -230,12 +232,13 @@ digraph G {
   "foo.classPath" -> "bar.compile" [constraint=false]
   "foo.classPath" -> "bar.classPath"  [color=red, penwidth=2]
 }
-```
+....
 
 On the other hand a change to `bar/src/*.java` would affect the `bar.sources` task, which
 would invalidate and cause evaluation of the tasks highlighted in red below:
 
-```graphviz
+[graphviz]
+....
 digraph G {
   rankdir=LR
   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -268,7 +271,7 @@ digraph G {
   "foo.classPath" -> "bar.compile" [constraint=false]
   "foo.classPath" -> "bar.classPath"
 }
-```
+....
 
 In the example changing `bar/src/*.java`, Mill may also take the opportunity to parallelize
 things:

--- a/website/docs/modules/ROOT/pages/depth/process-architecture.adoc
+++ b/website/docs/modules/ROOT/pages/depth/process-architecture.adoc
@@ -6,7 +6,8 @@ This page goes into detail of how the Mill process and application is structured
 At a high-level, a simplified version of the main components and data-flows within
 a running Mill process is shown below:
 
-```graphviz
+[graphviz]
+....
 digraph G {
   rankdir=LR
   node [shape=box width=0 height=0 style=filled fillcolor=white]
@@ -93,7 +94,7 @@ digraph G {
   "assembly.dest" -> "foo.assembly"  [dir=both]
   "assembly.json" -> "foo.assembly"  [dir=both]
 }
-```
+....
 
 
 == The Mill Client

--- a/website/package.mill
+++ b/website/package.mill
@@ -132,8 +132,13 @@ object `package` extends RootModule {
             case "```graphviz" => isGraphViz = true
             case "```" | "...." if isGraphViz =>
               isGraphViz = false
+              // if there is no pre-rendered svg, we add the extracted graphviz to the output
               if (inputs.isEmpty) output((p, i)) = graphvizLines.mkString("\n")
               else {
+                // we have a pre-rendered svg and insert it here
+                outputLines.append("////")
+                outputLines.append(graphvizLines.mkString("\n"))
+                outputLines.append("////")
                 outputLines.append("++++")
                 outputLines.append("<div class=\"paragraph\">")
                 outputLines.append("<center>")
@@ -154,6 +159,10 @@ object `package` extends RootModule {
       output.toMap
     }
 
+    // we walk 2 time over the adoc files,
+    // first, we extract the diagrams and write them to a temp dir, where we run graphviz tool on them
+    // second, we scan adoc files again and put the rendered diagrams in place of their sources
+
     val diagrams = walkAllFiles(Map())
     // Batch the rendering so later it can be done in one call to a single subprocess,
     // minimizing per-subprocess overhead needed to spawn them over and over
@@ -164,7 +173,10 @@ object `package` extends RootModule {
     mill.util.Jvm.runSubprocess(
       "mill.main.graphviz.GraphvizTools",
       visualizeClassPath,
-      mainArgs = orderedDiagrams.map { case (p, i, src, dest) => s"$src;$dest;svg" }
+      mainArgs = orderedDiagrams.map { case (p, i, src, dest) =>
+        T.log.debug(s"Rendering graphviz: ${p} (${i}) to ${dest}")
+        s"$src;$dest;svg"
+      }
     )
 
     walkAllFiles(orderedDiagrams.map { case (p, i, src, dest) =>


### PR DESCRIPTION
Fixed graphviz block to use AsciiDoc syntax, and other fixes.

