### PR TITLE
Avoid `.stripMargin` when rendering documentation from example modules

### DIFF
--- a/example/package.mill
+++ b/example/package.mill
@@ -252,12 +252,13 @@ object `package` extends RootModule with Module {
           .filter(_._2.nonEmpty)
           .map {
             case (s"see:$path", txt) =>
+              // avoid .stripMargin, as the embedded content may contain the margin symbol
               s"""
-                 |.$path ({mill-example-url}/$examplePath/$path[browse])
-                 |[source,scala,subs="attributes,verbatim"]
-                 |----
-                 |$txt
-                 |----""".stripMargin
+.$path ({mill-example-url}/$examplePath/$path[browse])
+[source,scala,subs="attributes,verbatim"]
+----
+$txt
+----"""
             case ("scala", txt) =>
               val title =
                 if (seenCode) ""
@@ -268,21 +269,23 @@ object `package` extends RootModule with Module {
                   s".build.mill ($download, $browse)"
                 }
               seenCode = true
+              // avoid .stripMargin, as the embedded content may contain the margin symbol
               s"""
-                 |$title
-                 |[source,scala,subs="attributes,verbatim"]
-                 |----
-                 |
-                 |$txt
-                 |----
-                 |""".stripMargin
+$title
+[source,scala,subs="attributes,verbatim"]
+----
+
+$txt
+----
+"""
             case ("comment", txt) => txt + "\n"
             case ("example", txt) =>
+              // avoid .stripMargin, as the embedded content may contain the margin symbol
               s"""
-                 |[source,bash,subs="attributes,verbatim"]
-                 |----
-                 |$txt
-                 |----""".stripMargin
+[source,bash,subs="attributes,verbatim"]
+----
+$txt
+----"""
           }
           .mkString("\n")
       )


### PR DESCRIPTION
Since we use Scala string intrpolation as a low cost template engine,
we need to avoid `.stripMargin`, as it may over-eager strip margin symbols
from the interpolated variables.

Fix https://github.com/com-lihaoyi/mill/issues/4542
