### PR TITLE
Fix doc publishing

### DIFF
--- a/website/package.mill
+++ b/website/package.mill
@@ -244,7 +244,7 @@ object `package` extends RootModule {
         "'" + _ + "'"
       ).mkString("[", ",", "]")}
        |      edit_url: false
-       |      start_path: website/antora
+       |      start_path: docs/antora
        |
        |${taggedSources.mkString("\n\n")}
        |


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/4547

The original PR https://github.com/com-lihaoyi/mill/pull/4510 was a bit too over-eager at find-replacing `docs/` in the codebase; in this case, it was configuration for old versions of Mill, whose `docs/` folders still have not changed.

Tested via `./mill -w website.githubPages`; fails without this PR, passes with. Was not caught on the PR last time because we only test the `website.fastPages` on PRs to reduce latencies
