### PR TITLE
Clean up `Task.scala`

### DIFF
--- a/core/define/src/mill/define/Task.scala
+++ b/core/define/src/mill/define/Task.scala
@@ -340,7 +340,7 @@ object Target extends TaskBase {
     ): Expr[Target[T]] = {
       val taskIsPrivate = isPrivateTargetOption()
       val lhs = appImpl[T](traverseCtxExpr(caller), t)
-      Cacher.impl0[Target[T]]('{ new TargetImpl[T]($lhs, $ctx, $rw, $taskIsPrivate) })
+      Cacher.impl0('{ new TargetImpl[T]($lhs, $ctx, $rw, $taskIsPrivate) })
     }
 
     def persistentTargetResultImpl[T: Type](using

--- a/core/define/src/mill/define/Task.scala
+++ b/core/define/src/mill/define/Task.scala
@@ -65,18 +65,22 @@ object Task extends TaskBase {
   inline def Sources(inline values: Result[os.Path]*)(implicit
       inline ctx: mill.define.Ctx
   ): Target[Seq[PathRef]] = ${
-    Target.Internal.sourcesImpl2('{Result.sequence(values.map(_.map(PathRef(_))))})('ctx, 'this)
+    TaskMacros.sourcesImpl('{ Result.sequence(values.map(_.map(PathRef(_)))) })('ctx, 'this)
   }
 
   inline def Sources(inline values: Result[Seq[PathRef]])(implicit
       inline ctx: mill.define.Ctx
   ): Target[Seq[PathRef]] =
-    ${ Target.Internal.sourcesImpl2('values)('ctx, 'this) }
+    ${ TaskMacros.sourcesImpl('values)('ctx, 'this) }
 
   inline def Sources(inline values: os.SubPath*)(implicit
       inline ctx: mill.define.Ctx,
       dummy: Boolean = true
-  ): Target[Seq[PathRef]] = ${ Target.Internal.sourcesImpl3('values)('ctx, 'this) }
+  ): Target[Seq[PathRef]] = ${
+    TaskMacros.sourcesImpl(
+      '{ values.map(sub => PathRef(ctx.millSourcePath / os.up / os.PathChunk.SubPathChunk(sub))) }
+    )('ctx, 'this)
+  }
 
   /**
    * Similar to [[Source]], but only for a single source file or folder. Defined
@@ -85,18 +89,18 @@ object Task extends TaskBase {
   inline def Source(inline value: Result[os.Path])(implicit
       inline ctx: mill.define.Ctx
   ): Target[PathRef] =
-    ${ Target.Internal.sourceImpl2('{value.map(PathRef(_))})('ctx, 'this) }
+    ${ TaskMacros.sourceImpl('{ value.map(PathRef(_)) })('ctx, 'this) }
 
   @annotation.targetName("SourceRef")
   inline def Source(inline value: Result[PathRef])(implicit
       inline ctx: mill.define.Ctx
   ): Target[PathRef] =
-    ${ Target.Internal.sourceImpl2('value)('ctx, 'this) }
+    ${ TaskMacros.sourceImpl('value)('ctx, 'this) }
 
   inline def Source(inline value: os.SubPath)(implicit
       inline ctx: mill.define.Ctx
   ): Target[PathRef] =
-    ${ Target.Internal.sourceImpl3('value)('ctx, 'this) }
+    ${ TaskMacros.sourceImpl('{ PathRef(ctx.millSourcePath / os.up / value) })('ctx, 'this) }
 
   /**
    * [[InputImpl]]s, normally defined using `Task.Input`, are [[NamedTask]]s that
@@ -118,7 +122,7 @@ object Task extends TaskBase {
       inline w: upickle.default.Writer[T],
       inline ctx: mill.define.Ctx
   ): Target[T] =
-    ${ Target.Internal.inputImpl[T]('value)('w, 'ctx, 'this) }
+    ${ TaskMacros.inputImpl[T]('value)('w, 'ctx, 'this) }
 
   /**
    * [[Command]]s are only [[NamedTask]]s defined using
@@ -130,7 +134,7 @@ object Task extends TaskBase {
   inline def Command[T](inline t: Result[T])(implicit
       inline w: W[T],
       inline ctx: mill.define.Ctx
-  ): Command[T] = ${ Target.Internal.commandImpl[T]('t)('w, 'ctx, 'this, exclusive = '{false}) }
+  ): Command[T] = ${ TaskMacros.commandImpl[T]('t)('w, 'ctx, 'this, exclusive = '{ false }) }
 
   /**
    * @param exclusive Exclusive commands run serially at the end of an evaluation,
@@ -148,7 +152,7 @@ object Task extends TaskBase {
     inline def apply[T](inline t: Result[T])(implicit
         inline w: W[T],
         inline ctx: mill.define.Ctx
-    ): Command[T] = ${ Target.Internal.commandImpl[T]('t)('w, 'ctx, 'this, '{this.exclusive}) }
+    ): Command[T] = ${ TaskMacros.commandImpl[T]('t)('w, 'ctx, 'this, '{ this.exclusive }) }
   }
 
   /**
@@ -166,7 +170,7 @@ object Task extends TaskBase {
    * what in-memory state the worker may have.
    */
   inline def Worker[T](inline t: Result[T])(implicit inline ctx: mill.define.Ctx): Worker[T] =
-    ${ Target.Internal.workerImpl2[T]('t)('ctx, 'this) }
+    ${ TaskMacros.workerImpl2[T]('t)('ctx, 'this) }
 
   /**
    * Creates an anonymous `Task`. These depend on other tasks and
@@ -175,13 +179,13 @@ object Task extends TaskBase {
    * implement `Task{...}` targets.
    */
   inline def Anon[T](inline t: Result[T]): Task[T] =
-    ${ Target.Internal.anonTaskImpl[T]('t)('this) }
+    ${ TaskMacros.anonTaskImpl[T]('t)('this) }
 
   inline def apply[T](inline t: Result[T])(implicit
       inline rw: RW[T],
       inline ctx: mill.define.Ctx
   ): Target[T] =
-    ${ Target.Internal.targetResultImpl[T]('t)('rw, 'ctx, 'this) }
+    ${ TaskMacros.targetResultImpl[T]('t)('rw, 'ctx, 'this) }
 
   /**
    * Persistent tasks are defined using
@@ -204,7 +208,7 @@ object Task extends TaskBase {
     inline def apply[T](inline t: Result[T])(implicit
         inline rw: RW[T],
         inline ctx: mill.define.Ctx
-    ): Target[T] = ${ Target.Internal.persistentTargetResultImpl[T]('t)('rw, 'ctx, 'this) }
+    ): Target[T] = ${ TaskMacros.persistentTargetResultImpl[T]('t)('rw, 'ctx, 'this) }
   }
 
   abstract class Ops[+T] { this: Task[T] =>
@@ -296,174 +300,14 @@ object Target extends TaskBase {
       inline rw: RW[T],
       inline ctx: mill.define.Ctx
   ): Target[T] =
-    ${ Internal.targetResultImpl[T]('{ Result.Success(t) })('rw, 'ctx, 'this) }
+    ${ TaskMacros.targetResultImpl[T]('{ Result.Success(t) })('rw, 'ctx, 'this) }
 
   implicit inline def apply[T](inline t: Result[T])(implicit
       inline rw: RW[T],
       inline ctx: mill.define.Ctx
   ): Target[T] =
-    ${ Internal.targetResultImpl[T]('t)('rw, 'ctx, 'this) }
+    ${ TaskMacros.targetResultImpl[T]('t)('rw, 'ctx, 'this) }
 
-  object Internal {
-    def appImpl[T: Type](using
-                          Quotes
-                         )(
-                           traverseCtx: (Expr[Seq[Task[Any]]], Expr[(IndexedSeq[Any], mill.api.Ctx) => Result[T]]) => Expr[Task[T]],
-                           t: Expr[Result[T]]
-                         ): Expr[Task[T]]
-    = Applicative.impl[Task, Task, Result, T, mill.api.Ctx](traverseCtx, t)
-
-    private def isPrivateTargetOption()(using Quotes): Expr[Option[Boolean]] =
-      Cacher.withMacroOwner {
-        owner =>
-          import quotes.reflect.*
-          if owner.flags.is(Flags.Private) then Expr(Some(true))
-          else Expr(Some(false))
-      }
-
-    private def traverseCtxExpr[R: Type](caller: Expr[TraverseCtxHolder])(
-        args: Expr[Seq[Task[Any]]],
-        fn: Expr[(IndexedSeq[Any], mill.api.Ctx) => Result[R]]
-    )(using Quotes): Expr[Task[R]] =
-      '{ $caller.traverseCtx[Any, R]($args)($fn) }
-
-    def anonTaskImpl[T: Type](t: Expr[Result[T]])(
-        caller: Expr[TraverseCtxHolder]
-    )(using Quotes): Expr[Task[T]] = {
-      appImpl[T](traverseCtxExpr(caller), t)
-    }
-
-    def targetResultImpl[T: Type](using
-        Quotes
-    )(t: Expr[Result[T]])(
-        rw: Expr[RW[T]],
-        ctx: Expr[mill.define.Ctx],
-        caller: Expr[TraverseCtxHolder]
-    ): Expr[Target[T]] = {
-      val taskIsPrivate = isPrivateTargetOption()
-      val lhs = appImpl[T](traverseCtxExpr(caller), t)
-      Cacher.impl0('{ new TargetImpl[T]($lhs, $ctx, $rw, $taskIsPrivate) })
-    }
-
-    def persistentTargetResultImpl[T: Type](using
-        Quotes
-    )(t: Expr[Result[T]])(
-        rw: Expr[RW[T]],
-        ctx: Expr[mill.define.Ctx],
-        caller: Expr[Task.ApplyFactory]
-    ): Expr[Target[T]] = {
-      val taskIsPrivate = isPrivateTargetOption()
-      val lhs = appImpl[T](traverseCtxExpr(caller), t)
-
-      Cacher.impl0(
-        '{
-          if $caller.persistent then new PersistentImpl[T]($lhs, $ctx, $rw, $taskIsPrivate)
-          else new TargetImpl[T]($lhs,  $ctx,  $rw,  $taskIsPrivate)
-        }
-      )
-    }
-
-    def sourcesImpl2(using
-        Quotes
-    )(
-        values: Expr[Result[Seq[PathRef]]]
-    )(
-        ctx: Expr[mill.define.Ctx],
-        caller: Expr[TraverseCtxHolder]
-    ): Expr[Target[Seq[PathRef]]] = {
-      val taskIsPrivate = isPrivateTargetOption()
-      val lhs = appImpl[Seq[PathRef]](traverseCtxExpr(caller), values)
-
-      Cacher.impl0('{ new SourcesImpl($lhs, $ctx, $taskIsPrivate) })
-    }
-
-    def sourcesImpl3(using
-        Quotes
-    )(values: Expr[Seq[os.SubPath]])(
-        ctx: Expr[mill.define.Ctx],
-        caller: Expr[TraverseCtxHolder]
-    ): Expr[Target[Seq[PathRef]]] = {
-
-      val unwrapped = Varargs.unapply(values).get
-
-      val wrapped =
-        for (value <- unwrapped.toList)
-          yield appImpl[PathRef](
-            traverseCtxExpr(caller),
-            '{ PathRef($ctx.millSourcePath / os.up / os.PathChunk.SubPathChunk($value)) }
-          )
-
-      val taskIsPrivate = isPrivateTargetOption()
-
-      Cacher.impl0(
-        '{ new SourcesImpl(Target.sequence(${Expr.ofList(wrapped) }), $ctx, $taskIsPrivate) }
-      )
-    }
-
-    def sourceImpl2(using
-        Quotes
-    )(value: Expr[Result[PathRef]])(
-        ctx: Expr[mill.define.Ctx],
-        caller: Expr[TraverseCtxHolder]
-    ): Expr[Target[PathRef]] = {
-      val taskIsPrivate = isPrivateTargetOption()
-      val lhs = appImpl[PathRef](traverseCtxExpr(caller), value)
-      Cacher.impl0('{ new SourceImpl($lhs, $ctx, $taskIsPrivate) })
-    }
-
-    def sourceImpl3(using
-        Quotes
-    )(value: Expr[os.SubPath])(
-        ctx: Expr[mill.define.Ctx],
-        caller: Expr[TraverseCtxHolder]
-    ): Expr[Target[PathRef]] = {
-      val wrapped =
-        appImpl[PathRef](
-          traverseCtxExpr(caller),
-          '{ PathRef($ctx.millSourcePath / os.up / os.PathChunk.SubPathChunk($value)) }
-        )
-
-      val taskIsPrivate = isPrivateTargetOption()
-      Cacher.impl0('{ new SourceImpl($wrapped, $ctx, $taskIsPrivate) })
-    }
-
-    def inputImpl[T: Type](using
-        Quotes
-    )(value: Expr[Result[T]])(
-        w: Expr[upickle.default.Writer[T]],
-        ctx: Expr[mill.define.Ctx],
-        caller: Expr[TraverseCtxHolder]
-    ): Expr[Target[T]] = {
-      val taskIsPrivate = isPrivateTargetOption()
-      val lhs = appImpl[T](traverseCtxExpr(caller), value)
-      Cacher.impl0('{ new InputImpl[T]($lhs, $ctx, $w, $taskIsPrivate) })
-    }
-
-
-    def commandImpl[T: Type](using
-                             Quotes
-    )(t: Expr[Result[T]])(
-        w: Expr[W[T]],
-        ctx: Expr[mill.define.Ctx],
-        caller: Expr[TraverseCtxHolder],
-        exclusive: Expr[Boolean]
-    ): Expr[Command[T]] = {
-      val taskIsPrivate = isPrivateTargetOption()
-      val lhs = appImpl[T](traverseCtxExpr(caller), t)
-      '{ new Command[T]($lhs, $ctx, $w, $taskIsPrivate, exclusive = $exclusive) }
-    }
-
-    def workerImpl2[T: Type](using
-        Quotes
-    )(t: Expr[Result[T]])(
-        ctx: Expr[mill.define.Ctx],
-        caller: Expr[TraverseCtxHolder]
-    ): Expr[Worker[T]] = {
-      val taskIsPrivate = isPrivateTargetOption()
-      val lhs = appImpl[T](traverseCtxExpr(caller), t)
-      Cacher.impl0('{ new Worker[T]($lhs, $ctx, $taskIsPrivate) })
-    }
-  }
 }
 
 /**
@@ -627,9 +471,130 @@ class InputImpl[T](
 }
 
 class SourcesImpl(t: Task[Seq[PathRef]], ctx0: mill.define.Ctx, isPrivate: Option[Boolean])
-    extends InputImpl[Seq[PathRef]](t, ctx0, upickle.default.readwriter[Seq[PathRef]], isPrivate) {
-}
+    extends InputImpl[Seq[PathRef]](t, ctx0, upickle.default.readwriter[Seq[PathRef]], isPrivate) {}
 
 class SourceImpl(t: Task[PathRef], ctx0: mill.define.Ctx, isPrivate: Option[Boolean])
-    extends InputImpl[PathRef](t, ctx0, upickle.default.readwriter[PathRef], isPrivate) {
+    extends InputImpl[PathRef](t, ctx0, upickle.default.readwriter[PathRef], isPrivate) {}
+
+object TaskMacros {
+  def appImpl[T: Type](using
+      Quotes
+  )(
+      traverseCtx: (
+          Expr[Seq[Task[Any]]],
+          Expr[(IndexedSeq[Any], mill.api.Ctx) => Result[T]]
+      ) => Expr[Task[T]],
+      t: Expr[Result[T]]
+  ): Expr[Task[T]] = Applicative.impl[Task, Task, Result, T, mill.api.Ctx](traverseCtx, t)
+
+  private def isPrivateTargetOption()(using Quotes): Expr[Option[Boolean]] =
+    Cacher.withMacroOwner {
+      owner =>
+        import quotes.reflect.*
+        if owner.flags.is(Flags.Private) then Expr(Some(true))
+        else Expr(Some(false))
+    }
+
+  private def traverseCtxExpr[R: Type](caller: Expr[TraverseCtxHolder])(
+      args: Expr[Seq[Task[Any]]],
+      fn: Expr[(IndexedSeq[Any], mill.api.Ctx) => Result[R]]
+  )(using Quotes): Expr[Task[R]] =
+    '{ $caller.traverseCtx[Any, R]($args)($fn) }
+
+  def anonTaskImpl[T: Type](t: Expr[Result[T]])(
+      caller: Expr[TraverseCtxHolder]
+  )(using Quotes): Expr[Task[T]] = {
+    appImpl[T](traverseCtxExpr(caller), t)
+  }
+
+  def targetResultImpl[T: Type](using
+      Quotes
+  )(t: Expr[Result[T]])(
+      rw: Expr[RW[T]],
+      ctx: Expr[mill.define.Ctx],
+      caller: Expr[TraverseCtxHolder]
+  ): Expr[Target[T]] = {
+    val taskIsPrivate = isPrivateTargetOption()
+    val lhs = appImpl[T](traverseCtxExpr(caller), t)
+    Cacher.impl0('{ new TargetImpl[T]($lhs, $ctx, $rw, $taskIsPrivate) })
+  }
+
+  def persistentTargetResultImpl[T: Type](using
+      Quotes
+  )(t: Expr[Result[T]])(
+      rw: Expr[RW[T]],
+      ctx: Expr[mill.define.Ctx],
+      caller: Expr[Task.ApplyFactory]
+  ): Expr[Target[T]] = {
+    val taskIsPrivate = isPrivateTargetOption()
+    val lhs = appImpl[T](traverseCtxExpr(caller), t)
+
+    Cacher.impl0(
+      '{
+        if $caller.persistent then new PersistentImpl[T]($lhs, $ctx, $rw, $taskIsPrivate)
+        else new TargetImpl[T]($lhs, $ctx, $rw, $taskIsPrivate)
+      }
+    )
+  }
+
+  def sourcesImpl(using
+      Quotes
+  )(
+      values: Expr[Result[Seq[PathRef]]]
+  )(
+      ctx: Expr[mill.define.Ctx],
+      caller: Expr[TraverseCtxHolder]
+  ): Expr[Target[Seq[PathRef]]] = {
+    val taskIsPrivate = isPrivateTargetOption()
+    val lhs = appImpl[Seq[PathRef]](traverseCtxExpr(caller), values)
+
+    Cacher.impl0('{ new SourcesImpl($lhs, $ctx, $taskIsPrivate) })
+  }
+
+  def sourceImpl(using
+      Quotes
+  )(value: Expr[Result[PathRef]])(
+      ctx: Expr[mill.define.Ctx],
+      caller: Expr[TraverseCtxHolder]
+  ): Expr[Target[PathRef]] = {
+    val taskIsPrivate = isPrivateTargetOption()
+    val lhs = appImpl[PathRef](traverseCtxExpr(caller), value)
+    Cacher.impl0('{ new SourceImpl($lhs, $ctx, $taskIsPrivate) })
+  }
+
+  def inputImpl[T: Type](using
+      Quotes
+  )(value: Expr[Result[T]])(
+      w: Expr[upickle.default.Writer[T]],
+      ctx: Expr[mill.define.Ctx],
+      caller: Expr[TraverseCtxHolder]
+  ): Expr[Target[T]] = {
+    val taskIsPrivate = isPrivateTargetOption()
+    val lhs = appImpl[T](traverseCtxExpr(caller), value)
+    Cacher.impl0('{ new InputImpl[T]($lhs, $ctx, $w, $taskIsPrivate) })
+  }
+
+  def commandImpl[T: Type](using
+      Quotes
+  )(t: Expr[Result[T]])(
+      w: Expr[W[T]],
+      ctx: Expr[mill.define.Ctx],
+      caller: Expr[TraverseCtxHolder],
+      exclusive: Expr[Boolean]
+  ): Expr[Command[T]] = {
+    val taskIsPrivate = isPrivateTargetOption()
+    val lhs = appImpl[T](traverseCtxExpr(caller), t)
+    '{ new Command[T]($lhs, $ctx, $w, $taskIsPrivate, exclusive = $exclusive) }
+  }
+
+  def workerImpl2[T: Type](using
+      Quotes
+  )(t: Expr[Result[T]])(
+      ctx: Expr[mill.define.Ctx],
+      caller: Expr[TraverseCtxHolder]
+  ): Expr[Worker[T]] = {
+    val taskIsPrivate = isPrivateTargetOption()
+    val lhs = appImpl[T](traverseCtxExpr(caller), t)
+    Cacher.impl0('{ new Worker[T]($lhs, $ctx, $taskIsPrivate) })
+  }
 }

--- a/core/define/src/mill/define/Task.scala
+++ b/core/define/src/mill/define/Task.scala
@@ -377,7 +377,7 @@ object Target extends TaskBase {
       val taskIsPrivate = isPrivateTargetOption()
 
       Cacher.impl0(
-        '{ new SourcesImpl(Target.sequence(List(${ Varargs(wrapped) }*)), $ctx, $taskIsPrivate) }
+        '{ new SourcesImpl(Target.sequence(${Expr.ofList(wrapped)}), $ctx, $taskIsPrivate) }
       )
     }
 
@@ -414,7 +414,7 @@ object Target extends TaskBase {
       val taskIsPrivate = isPrivateTargetOption()
 
       Cacher.impl0(
-        '{ new SourcesImpl(Target.sequence(List(${ Varargs(wrapped) }*)), $ctx, $taskIsPrivate) }
+        '{ new SourcesImpl(Target.sequence(${Expr.ofList(wrapped) }), $ctx, $taskIsPrivate) }
       )
     }
 

--- a/core/define/src/mill/define/Task.scala
+++ b/core/define/src/mill/define/Task.scala
@@ -660,5 +660,5 @@ class SourcesImpl(t: Task[Seq[PathRef]], ctx0: mill.define.Ctx, isPrivate: Optio
 }
 
 class SourceImpl(t: Task[PathRef], ctx0: mill.define.Ctx, isPrivate: Option[Boolean])
-    extends InputImpl[PathRef](t, ctx0, upickle.default.readwriter[Seq[PathRef]], isPrivate) {
+    extends InputImpl[PathRef](t, ctx0, upickle.default.readwriter[PathRef], isPrivate) {
 }

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -113,7 +113,7 @@ private[mill] trait GroupExecution {
 
             case _ =>
               // uncached
-              if (labelled.flushDest) os.remove.all(paths.dest)
+              if (!labelled.persistent) os.remove.all(paths.dest)
 
               val (newResults, newEvaluated) =
                 executeGroup(

--- a/main/test/src/mill/util/TestUtil.scala
+++ b/main/test/src/mill/util/TestUtil.scala
@@ -37,7 +37,8 @@ object TestUtil {
         null,
         ctx0,
         upickle.default.readwriter[Int],
-        None
+        None,
+        persistent = false
       ) {
     override def evaluate(args: mill.api.Ctx) = testTask.evaluate(args)
     override val inputs = taskInputs


### PR DESCRIPTION
For now mostly superficial cleanups: reducing duplication, extracting helpers, renaming `Target.Internal` to `TaskMacros`, etc. But this should pave the way for more cleanup in follow up PRs

