### PR TITLE
Avoid hardcoded version in PalantirFormatModule

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -238,6 +238,7 @@ object Deps {
     val koverJvmAgent = ivy"org.jetbrains.kotlinx:kover-jvm-agent:$koverVersion"
     val ktfmt = ivy"com.facebook:ktfmt:0.53"
     val ktlint = ivy"com.pinterest.ktlint:ktlint-core:0.49.1"
+    val palantirFormat = ivy"com.palantir.javaformat:palantir-java-format:2.50.0"
     val sbtTestInterface = ivy"com.github.sbt:junit-interface:0.13.2"
 
     def all = Seq(
@@ -253,6 +254,7 @@ object Deps {
       koverJvmAgent,
       ktfmt,
       ktlint,
+      palantirFormat,
       sbtTestInterface
     )
   }

--- a/build.mill
+++ b/build.mill
@@ -238,7 +238,7 @@ object Deps {
     val koverJvmAgent = ivy"org.jetbrains.kotlinx:kover-jvm-agent:$koverVersion"
     val ktfmt = ivy"com.facebook:ktfmt:0.53"
     val ktlint = ivy"com.pinterest.ktlint:ktlint-core:0.49.1"
-    val palantirFormat = ivy"com.palantir.javaformat:palantir-java-format:2.50.0"
+    val palantirFormat = ivy"com.palantir.javaformat:palantir-java-format:2.51.0"
     val sbtTestInterface = ivy"com.github.sbt:junit-interface:0.13.2"
 
     def all = Seq(

--- a/scalalib/package.mill
+++ b/scalalib/package.mill
@@ -81,7 +81,8 @@ object `package` extends RootModule with build.MillStableScalaModule {
         "Dependency to jupiter-interface"
       ),
       BuildInfo.Value("errorProneVersion", build.Deps.RuntimeDeps.errorProneCore.version),
-      BuildInfo.Value("coursierJvmIndexVersion", build.Deps.coursierJvmIndexVersion)
+      BuildInfo.Value("coursierJvmIndexVersion", build.Deps.coursierJvmIndexVersion),
+      BuildInfo.Value("palantirFormatVersion", build.Deps.RuntimeDeps.palantirFormat.version)
     )
   }
 

--- a/scalalib/src/mill/javalib/palantirformat/PalantirFormatBaseModule.scala
+++ b/scalalib/src/mill/javalib/palantirformat/PalantirFormatBaseModule.scala
@@ -1,6 +1,7 @@
 package mill.javalib.palantirformat
 
-import mill.api.{PathRef}
+import mill.api.PathRef
+import mill.scalalib.api.Versions
 import mill.scalalib.{CoursierModule, DepSyntax}
 import mill.{T, Task}
 
@@ -45,6 +46,6 @@ trait PalantirFormatBaseModule extends CoursierModule {
    * Palantir Java Format version. Defaults to `2.50.0`.
    */
   def palantirformatVersion: T[String] = Task {
-    "2.50.0"
+    Versions.palantirFormatVersion
   }
 }

--- a/scalalib/src/mill/javalib/palantirformat/PalantirFormatBaseModule.scala
+++ b/scalalib/src/mill/javalib/palantirformat/PalantirFormatBaseModule.scala
@@ -43,7 +43,7 @@ trait PalantirFormatBaseModule extends CoursierModule {
   )
 
   /**
-   * Palantir Java Format version. Defaults to `2.50.0`.
+   * Palantir Java Format version. Defaults to the version used when Mill was built.
    */
   def palantirformatVersion: T[String] = Task {
     Versions.palantirFormatVersion

--- a/scalalib/src/mill/javalib/palantirformat/PalantirFormatModule.scala
+++ b/scalalib/src/mill/javalib/palantirformat/PalantirFormatModule.scala
@@ -1,11 +1,12 @@
-package mill
-package javalib.palantirformat
+package mill.javalib.palantirformat
 
-import mill.api.{PathRef}
-import mill.define.{Discover, ExternalModule}
+import mill.api.{Ctx, PathRef}
+import mill.define.{Discover, ExternalModule, TaskModule}
 import mill.main.Tasks
+import mill.main.TokenReaders.*
 import mill.scalalib.JavaModule
 import mill.util.Jvm
+import mill.{Command, T, Task}
 
 /**
  * Formats Java source files using [[https://github.com/palantir/palantir-java-format Palantir Java Format]].
@@ -76,7 +77,7 @@ object PalantirFormatModule extends ExternalModule with PalantirFormatBaseModule
       options: PathRef,
       classPath: Seq[PathRef],
       jvmArgs: Seq[String]
-  )(implicit ctx: api.Ctx): Unit = {
+  )(implicit ctx: Ctx): Unit = {
 
     val javaFiles = sources
       .iterator


### PR DESCRIPTION
Instead of a hardcoded version we use one defined in the outer Mill build.