### PR TITLE
Simplify Applicative.scala

### DIFF
--- a/core/define/src/mill/define/Task.scala
+++ b/core/define/src/mill/define/Task.scala
@@ -42,7 +42,6 @@ abstract class Task[+T] extends Task.Ops[T] with Applyable[Task, T] {
   def asTarget: Option[Target[T]] = None
   def asCommand: Option[Command[T]] = None
   def asWorker: Option[Worker[T]] = None
-  def self: Task[T] = this
   def isExclusiveCommand: Boolean = this match {
     case c: Command[_] if c.exclusive => true
     case _ => false
@@ -300,7 +299,7 @@ object Target extends TaskBase {
  * define the tasks, while methods like `Task.`[[dest]], `Task.`[[log]] or
  * `Task.`[[env]] provide the core APIs that are provided to a task implementation
  */
-class TaskBase extends Applicative.Applyer[Task, Task, Result, mill.api.Ctx] {
+class TaskBase extends Applicative.Applyer[Task, Result, mill.api.Ctx] {
 
   /**
    * `Task.dest` is a unique `os.Path` (e.g. `out/classFiles.dest/` or `out/run.dest/`)

--- a/core/define/src/mill/define/Task.scala
+++ b/core/define/src/mill/define/Task.scala
@@ -299,7 +299,7 @@ object Target extends TaskBase {
  * define the tasks, while methods like `Task.`[[dest]], `Task.`[[log]] or
  * `Task.`[[env]] provide the core APIs that are provided to a task implementation
  */
-class TaskBase extends Applicative.Applyer[Task, Result, mill.api.Ctx] {
+class TaskBase extends Applicative.Applyer[mill.api.Ctx] {
 
   /**
    * `Task.dest` is a unique `os.Path` (e.g. `out/classFiles.dest/` or `out/run.dest/`)

--- a/core/define/src/mill/define/internal/Applicative.scala
+++ b/core/define/src/mill/define/internal/Applicative.scala
@@ -34,7 +34,7 @@ object Applicative {
 
   type Id[+T] = T
 
-  trait Applyer[T[_], Z[_], Ctx] {
+  trait Applyer[Ctx] {
     def ctx()(implicit c: Ctx): Ctx = c
   }
 

--- a/core/define/src/mill/define/internal/Applicative.scala
+++ b/core/define/src/mill/define/internal/Applicative.scala
@@ -17,19 +17,10 @@ import scala.quoted.*
  */
 @internal
 object Applicative {
-  trait ApplyHandler[M[+_]] {
 
-    /**
-     * Extracts the current value [[T]] out of the wrapping [[M[T]]
-     */
-    def apply[T](t: M[T]): T
-  }
-  object ApplyHandler {
-    @compileTimeOnly("Target#apply() can only be used with a Task{...} block")
-    implicit def defaultApplyHandler[M[+_]]: ApplyHandler[M] = ???
-  }
   trait Applyable[M[+_], +T] { this: M[T] =>
-    def apply()(implicit handler: ApplyHandler[M]): T = handler(this)
+    @compileTimeOnly("Target#apply() can only be used with a Task{...} block")
+    def apply(): T = ???
   }
 
   type Id[+T] = T
@@ -82,8 +73,7 @@ object Applicative {
       val treeMap = new TreeMap {
 
         override def transformTerm(tree: Term)(owner: Symbol): Term = tree match
-          // case t @ '{$fun.apply()($handler)}
-          case t @ Apply(Apply(sel @ Select(fun, "apply"), Nil), List(handler))
+          case t @ Apply(sel @ Select(fun, "apply"), Nil)
               if sel.symbol == targetApplySym =>
             val localDefs = extractDefs(fun)
             visitAllTrees(t) { x =>

--- a/core/define/src/mill/define/internal/Applicative.scala
+++ b/core/define/src/mill/define/internal/Applicative.scala
@@ -28,14 +28,13 @@ object Applicative {
     @compileTimeOnly("Target#apply() can only be used with a Task{...} block")
     implicit def defaultApplyHandler[M[+_]]: ApplyHandler[M] = ???
   }
-  trait Applyable[M[+_], +T] {
-    def self: M[T]
-    def apply()(implicit handler: ApplyHandler[M]): T = handler(self)
+  trait Applyable[M[+_], +T] { this: M[T] =>
+    def apply()(implicit handler: ApplyHandler[M]): T = handler(this)
   }
 
   type Id[+T] = T
 
-  trait Applyer[W[_], T[_], Z[_], Ctx] {
+  trait Applyer[T[_], Z[_], Ctx] {
     def ctx()(implicit c: Ctx): Ctx = c
   }
 

--- a/core/define/test/src/mill/define/ApplicativeTests.scala
+++ b/core/define/test/src/mill/define/ApplicativeTests.scala
@@ -24,57 +24,57 @@ object ApplicativeTests extends TestSuite {
 
     test("selfContained") {
 
-      test("simple") - assert(Opt("lol " + 1) == Some("lol 1"))
-      test("singleSome") - assert(Opt("lol " + Some("hello")()) == Some("lol hello"))
-      test("twoSomes") - assert(Opt(Some("lol ")() + Some("hello")()) == Some("lol hello"))
-      test("singleNone") - assert(Opt("lol " + None()) == None)
-      test("twoNones") - assert(Opt("lol " + None() + None()) == None)
+      test("simple") - assert(Opt("lol " + 1) == Opt.some("lol 1"))
+      test("singleSome") - assert(Opt("lol " + Opt.some("hello")()) == Opt.some("lol hello"))
+      test("twoSomes") - assert(Opt(Opt.some("lol ")() + Opt.some("hello")()) == Opt.some("lol hello"))
+      test("singleNone") - assert(Opt("lol " + Opt.none()) == Opt.none)
+      test("twoNones") - assert(Opt("lol " + Opt.none() + Opt.none()) == Opt.none)
       test("moreThan22") {
         assert(
           Opt(
             "lol " +
-              None() + None() + None() + None() + None() +
-              None() + None() + None() + None() + Some(" world")() +
-              None() + None() + None() + None() + None() +
-              None() + None() + None() + None() + None() +
-              None() + None() + None() + None() + Some(" moo")()
-          ) == None
+              Opt.none() + Opt.none() + Opt.none() + Opt.none() + Opt.none() +
+              Opt.none() + Opt.none() + Opt.none() + Opt.none() + Opt.some(" world")() +
+              Opt.none() + Opt.none() + Opt.none() + Opt.none() + Opt.none() +
+              Opt.none() + Opt.none() + Opt.none() + Opt.none() + Opt.none() +
+              Opt.none() + Opt.none() + Opt.none() + Opt.none() + Opt.some(" moo")()
+          ) == Opt.none
         )
         assert(
           Opt(
             "lol " +
-              Some("a")() + Some("b")() + Some("c")() + Some("d")() + Some("e")() +
-              Some("a")() + Some("b")() + Some("c")() + Some("d")() + Some("e")() +
-              Some("a")() + Some("b")() + Some("c")() + Some("d")() + Some("e")() +
-              Some("a")() + Some("b")() + Some("c")() + Some("d")() + Some("e")() +
-              Some("a")() + Some("b")() + Some("c")() + Some("d")() + Some("e")() +
-              Some("a")() + Some("b")() + Some("c")() + Some("d")() + Some("e")() +
-              Some("a")() + Some("b")() + Some("c")() + Some("d")() + Some("e")() +
-              Some("a")() + Some("b")() + Some("c")() + Some("d")() + Some("e")() +
-              Some("a")() + Some("b")() + Some("c")() + Some("d")() + Some("e")() +
-              Some("a")() + Some("b")() + Some("c")() + Some("d")() + Some("e")()
-          ) == Some("lol abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde")
+              Opt.some("a")() + Opt.some("b")() + Opt.some("c")() + Opt.some("d")() + Opt.some("e")() +
+              Opt.some("a")() + Opt.some("b")() + Opt.some("c")() + Opt.some("d")() + Opt.some("e")() +
+              Opt.some("a")() + Opt.some("b")() + Opt.some("c")() + Opt.some("d")() + Opt.some("e")() +
+              Opt.some("a")() + Opt.some("b")() + Opt.some("c")() + Opt.some("d")() + Opt.some("e")() +
+              Opt.some("a")() + Opt.some("b")() + Opt.some("c")() + Opt.some("d")() + Opt.some("e")() +
+              Opt.some("a")() + Opt.some("b")() + Opt.some("c")() + Opt.some("d")() + Opt.some("e")() +
+              Opt.some("a")() + Opt.some("b")() + Opt.some("c")() + Opt.some("d")() + Opt.some("e")() +
+              Opt.some("a")() + Opt.some("b")() + Opt.some("c")() + Opt.some("d")() + Opt.some("e")() +
+              Opt.some("a")() + Opt.some("b")() + Opt.some("c")() + Opt.some("d")() + Opt.some("e")() +
+              Opt.some("a")() + Opt.some("b")() + Opt.some("c")() + Opt.some("d")() + Opt.some("e")()
+          ) == Opt.some("lol abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde")
         )
       }
     }
     test("context") {
-      assert(Opt(Opt.ctx() + Some("World")()) == Some("hellooooWorld"))
+      assert(Opt(Opt.ctx() + Opt.some("World")()) == Opt.some("hellooooWorld"))
     }
     test("capturing") {
       val lol = "lol "
       def hell(o: String) = "hell" + o
-      test("simple") - assert(Opt(lol + 1) == Some("lol 1"))
-      test("singleSome") - assert(Opt(lol + Some(hell("o"))()) == Some("lol hello"))
-      test("twoSomes") - assert(Opt(Some(lol)() + Some(hell("o"))()) == Some("lol hello"))
-      test("singleNone") - assert(Opt(lol + None()) == None)
-      test("twoNones") - assert(Opt(lol + None() + None()) == None)
+      test("simple") - assert(Opt(lol + 1) == Opt.some("lol 1"))
+      test("singleSome") - assert(Opt(lol + Opt.some(hell("o"))()) == Opt.some("lol hello"))
+      test("twoSomes") - assert(Opt(Opt.some(lol)() + Opt.some(hell("o"))()) == Opt.some("lol hello"))
+      test("singleNone") - assert(Opt(lol + Opt.none()) == Opt.none)
+      test("twoNones") - assert(Opt(lol + Opt.none() + Opt.none()) == Opt.none)
     }
     test("allowedLocalDef") {
       // Although x is defined inside the Opt{...} block, it is also defined
       // within the LHS of the Applyable#apply call, so it is safe to life it
       // out into the `zipMap` arguments list.
-      val res = Opt { "lol " + Some("hello").flatMap(x => Some(x)).apply() }
-      assert(res == Some("lol hello"))
+      val res = Opt { "lol " + new Opt(Some("hello").flatMap(x => Some(x))).apply() }
+      assert(res == Opt.some("lol hello"))
     }
     test("upstreamAlwaysEvaluated") {
       // Whether or not control-flow reaches the Applyable#apply call inside an
@@ -84,7 +84,7 @@ object ApplicativeTests extends TestSuite {
       def up = Opt { "lol " + counter() }
       val down = Opt { if ("lol".length > 10) up() else "fail" }
       assert(
-        down == Some("fail"),
+        down == Opt.some("fail"),
         counter.value == 1
       )
     }
@@ -96,7 +96,7 @@ object ApplicativeTests extends TestSuite {
       def runTwice[T](t: => T) = (t, t)
       val down = Opt { runTwice(up()) }
       assert(
-        down == Some(("lol 1", "lol 1")),
+        down == Opt.some(("lol 1", "lol 1")),
         counter.value == 1
       )
     }
@@ -108,8 +108,8 @@ object ApplicativeTests extends TestSuite {
       val down1 = Opt { (() => up())() }
       val down2 = Opt { Seq(1, 2, 3).map(n => up() * n) }
       assert(
-        down1 == Some("hello1"),
-        down2 == Some(Seq("hello2", "hello2hello2", "hello2hello2hello2"))
+        down1 == Opt.some("hello1"),
+        down2 == Opt.some(Seq("hello2", "hello2hello2", "hello2hello2hello2"))
       )
     }
     test("appliesEvaluatedOncePerLexicalCallsite") {
@@ -120,7 +120,7 @@ object ApplicativeTests extends TestSuite {
       val counter = new Counter()
       def up = Opt { s"hello${counter()}" }
       val down = Opt { Seq(1, 2, 3).map(n => n + up() + up()) }
-      assert(down == Some(Seq("1hello1hello2", "2hello1hello2", "3hello1hello2")))
+      assert(down == Opt.some(Seq("1hello1hello2", "2hello1hello2", "3hello1hello2")))
     }
     test("appliesEvaluateBeforehand") {
       // Every Applyable#apply() within a Opt{...} block evaluates before any
@@ -135,7 +135,7 @@ object ApplicativeTests extends TestSuite {
         val three = up()
         (res, one, two, three)
       }
-      assert(down == Some((4, 1, 2, 3)))
+      assert(down == Opt.some((4, 1, 2, 3)))
     }
   }
 }

--- a/core/define/test/src/mill/define/ApplicativeTests.scala
+++ b/core/define/test/src/mill/define/ApplicativeTests.scala
@@ -7,7 +7,6 @@ import scala.annotation.compileTimeOnly
 import scala.language.implicitConversions
 
 object ApplicativeTests extends TestSuite {
-  implicit def optionToOpt[T](o: Option[T]): Opt[T] = new Opt(o)
 
   class Counter {
     var value = 0

--- a/core/define/test/src/mill/define/ApplicativeTests.scala
+++ b/core/define/test/src/mill/define/ApplicativeTests.scala
@@ -26,7 +26,9 @@ object ApplicativeTests extends TestSuite {
 
       test("simple") - assert(Opt("lol " + 1) == Opt.some("lol 1"))
       test("singleSome") - assert(Opt("lol " + Opt.some("hello")()) == Opt.some("lol hello"))
-      test("twoSomes") - assert(Opt(Opt.some("lol ")() + Opt.some("hello")()) == Opt.some("lol hello"))
+      test("twoSomes") - assert(
+        Opt(Opt.some("lol ")() + Opt.some("hello")()) == Opt.some("lol hello")
+      )
       test("singleNone") - assert(Opt("lol " + Opt.none()) == Opt.none)
       test("twoNones") - assert(Opt("lol " + Opt.none() + Opt.none()) == Opt.none)
       test("moreThan22") {
@@ -43,16 +45,19 @@ object ApplicativeTests extends TestSuite {
         assert(
           Opt(
             "lol " +
-              Opt.some("a")() + Opt.some("b")() + Opt.some("c")() + Opt.some("d")() + Opt.some("e")() +
-              Opt.some("a")() + Opt.some("b")() + Opt.some("c")() + Opt.some("d")() + Opt.some("e")() +
-              Opt.some("a")() + Opt.some("b")() + Opt.some("c")() + Opt.some("d")() + Opt.some("e")() +
-              Opt.some("a")() + Opt.some("b")() + Opt.some("c")() + Opt.some("d")() + Opt.some("e")() +
-              Opt.some("a")() + Opt.some("b")() + Opt.some("c")() + Opt.some("d")() + Opt.some("e")() +
-              Opt.some("a")() + Opt.some("b")() + Opt.some("c")() + Opt.some("d")() + Opt.some("e")() +
-              Opt.some("a")() + Opt.some("b")() + Opt.some("c")() + Opt.some("d")() + Opt.some("e")() +
-              Opt.some("a")() + Opt.some("b")() + Opt.some("c")() + Opt.some("d")() + Opt.some("e")() +
-              Opt.some("a")() + Opt.some("b")() + Opt.some("c")() + Opt.some("d")() + Opt.some("e")() +
-              Opt.some("a")() + Opt.some("b")() + Opt.some("c")() + Opt.some("d")() + Opt.some("e")()
+              Opt.some("a")() + Opt.some("b")() + Opt.some("c")() + Opt.some("d")() +
+              Opt.some("e")() + Opt.some("a")() + Opt.some("b")() + Opt.some("c")() +
+              Opt.some("d")() + Opt.some("e")() + Opt.some("a")() + Opt.some("b")() +
+              Opt.some("c")() + Opt.some("d")() + Opt.some("e")() + Opt.some("a")() +
+              Opt.some("b")() + Opt.some("c")() + Opt.some("d")() + Opt.some("e")() +
+              Opt.some("a")() + Opt.some("b")() + Opt.some("c")() + Opt.some("d")() +
+              Opt.some("e")() + Opt.some("a")() + Opt.some("b")() + Opt.some("c")() +
+              Opt.some("d")() + Opt.some("e")() + Opt.some("a")() + Opt.some("b")() +
+              Opt.some("c")() + Opt.some("d")() + Opt.some("e")() + Opt.some("a")() +
+              Opt.some("b")() + Opt.some("c")() + Opt.some("d")() + Opt.some("e")() +
+              Opt.some("a")() + Opt.some("b")() + Opt.some("c")() + Opt.some("d")() +
+              Opt.some("e")() + Opt.some("a")() + Opt.some("b")() + Opt.some("c")() +
+              Opt.some("d")() + Opt.some("e")()
           ) == Opt.some("lol abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde")
         )
       }
@@ -65,7 +70,9 @@ object ApplicativeTests extends TestSuite {
       def hell(o: String) = "hell" + o
       test("simple") - assert(Opt(lol + 1) == Opt.some("lol 1"))
       test("singleSome") - assert(Opt(lol + Opt.some(hell("o"))()) == Opt.some("lol hello"))
-      test("twoSomes") - assert(Opt(Opt.some(lol)() + Opt.some(hell("o"))()) == Opt.some("lol hello"))
+      test("twoSomes") - assert(
+        Opt(Opt.some(lol)() + Opt.some(hell("o"))()) == Opt.some("lol hello")
+      )
       test("singleNone") - assert(Opt(lol + Opt.none()) == Opt.none)
       test("twoNones") - assert(Opt(lol + Opt.none() + Opt.none()) == Opt.none)
     }

--- a/core/define/test/src/mill/define/ApplicativeTestsBase.scala
+++ b/core/define/test/src/mill/define/ApplicativeTestsBase.scala
@@ -6,7 +6,7 @@ import scala.quoted.*
 
 class Opt[+T](val self: Option[T]) extends Applicative.Applyable[Opt, T]
 object Opt extends Applicative.Applyer[String] {
-  def none: Opt[Nothing ] = new Opt(None)
+  def none: Opt[Nothing] = new Opt(None)
   def some[T](t: T): Opt[T] = new Opt(Some(t))
   val injectedCtx = "helloooo"
   inline def apply[T](inline t: T): Opt[T] =
@@ -19,9 +19,9 @@ object Opt extends Applicative.Applyer[String] {
       else Some(f(xs.map(_.self.get).toVector, Opt.injectedCtx))
     )
   }
-  def applyImpl[T: Type](t: Expr[T])
-                        (caller: Expr[Applicative.Applyer[String]])
-                        (using Quotes): Expr[Opt[T]] =
+  def applyImpl[T: Type](t: Expr[T])(caller: Expr[Applicative.Applyer[String]])(using
+      Quotes
+  ): Expr[Opt[T]] =
     Applicative.impl[Opt, Opt, Applicative.Id, T, String](
       (args, fn) => '{ traverseCtx($args)($fn) },
       t

--- a/core/define/test/src/mill/define/ApplicativeTestsBase.scala
+++ b/core/define/test/src/mill/define/ApplicativeTestsBase.scala
@@ -5,7 +5,7 @@ import mill.define.internal.Applicative
 import scala.quoted.*
 
 class Opt[+T](val self: Option[T]) extends Applicative.Applyable[Opt, T]
-object Opt extends Applicative.Applyer[Opt, Applicative.Id, String] {
+object Opt extends Applicative.Applyer[String] {
   def none: Opt[Nothing ] = new Opt(None)
   def some[T](t: T): Opt[T] = new Opt(Some(t))
   val injectedCtx = "helloooo"
@@ -19,11 +19,9 @@ object Opt extends Applicative.Applyer[Opt, Applicative.Id, String] {
       else Some(f(xs.map(_.self.get).toVector, Opt.injectedCtx))
     )
   }
-  def applyImpl[T: Type](t: Expr[T])(caller: Expr[Applicative.Applyer[
-    Opt,
-    Applicative.Id,
-    String
-  ]])(using Quotes): Expr[Opt[T]] =
+  def applyImpl[T: Type](t: Expr[T])
+                        (caller: Expr[Applicative.Applyer[String]])
+                        (using Quotes): Expr[Opt[T]] =
     Applicative.impl[Opt, Opt, Applicative.Id, T, String](
       (args, fn) => '{ traverseCtx($args)($fn) },
       t

--- a/core/define/test/src/mill/define/ApplicativeTestsBase.scala
+++ b/core/define/test/src/mill/define/ApplicativeTestsBase.scala
@@ -4,7 +4,7 @@ import mill.define.internal.Applicative
 
 import scala.quoted.*
 
-class Opt[+T](val self: Option[T]) extends Applicative.Applyable[Opt, T]
+case class Opt[+T](val self: Option[T]) extends Applicative.Applyable[Opt, T]
 object Opt extends Applicative.Applyer[String] {
   def none: Opt[Nothing] = new Opt(None)
   def some[T](t: T): Opt[T] = new Opt(Some(t))

--- a/core/define/test/src/mill/define/ApplicativeTestsBase.scala
+++ b/core/define/test/src/mill/define/ApplicativeTestsBase.scala
@@ -4,25 +4,27 @@ import mill.define.internal.Applicative
 
 import scala.quoted.*
 
-class Opt[+T](val self: Option[T]) extends Applicative.Applyable[Option, T]
-object Opt extends Applicative.Applyer[Opt, Option, Applicative.Id, String] {
-
+class Opt[+T](val self: Option[T]) extends Applicative.Applyable[Opt, T]
+object Opt extends Applicative.Applyer[Opt, Applicative.Id, String] {
+  def none: Opt[Nothing ] = new Opt(None)
+  def some[T](t: T): Opt[T] = new Opt(Some(t))
   val injectedCtx = "helloooo"
-  inline def apply[T](inline t: T): Option[T] =
+  inline def apply[T](inline t: T): Opt[T] =
     ${ applyImpl[T]('t)('this) }
 
   def traverseCtx[I, R](xs: Seq[Opt[I]])(f: (Seq[I], String) => Applicative.Id[R])
-      : Option[R] = {
-    if (xs.exists(_.self.isEmpty)) None
-    else Some(f(xs.map(_.self.get).toVector, Opt.injectedCtx))
+      : Opt[R] = {
+    new Opt(
+      if (xs.exists(_.self.isEmpty)) None
+      else Some(f(xs.map(_.self.get).toVector, Opt.injectedCtx))
+    )
   }
   def applyImpl[T: Type](t: Expr[T])(caller: Expr[Applicative.Applyer[
     Opt,
-    Option,
     Applicative.Id,
     String
-  ]])(using Quotes): Expr[Option[T]] =
-    Applicative.impl[Option, Opt, Applicative.Id, T, String](
+  ]])(using Quotes): Expr[Opt[T]] =
+    Applicative.impl[Opt, Opt, Applicative.Id, T, String](
       (args, fn) => '{ traverseCtx($args)($fn) },
       t
     )

--- a/core/define/test/src/mill/define/Opt.scala
+++ b/core/define/test/src/mill/define/Opt.scala
@@ -9,7 +9,7 @@ object Opt extends Applicative.Applyer[String] {
   def none: Opt[Nothing] = new Opt(None)
   def some[T](t: T): Opt[T] = new Opt(Some(t))
   val injectedCtx = "helloooo"
-  
+
   inline def apply[T](inline t: T): Opt[T] = ${ applyImpl[T]('t)('this) }
 
   def traverseCtx[I, R](xs: Seq[Opt[I]])(f: (Seq[I], String) => Applicative.Id[R])

--- a/core/define/test/src/mill/define/Opt.scala
+++ b/core/define/test/src/mill/define/Opt.scala
@@ -4,13 +4,13 @@ import mill.define.internal.Applicative
 
 import scala.quoted.*
 
-case class Opt[+T](val self: Option[T]) extends Applicative.Applyable[Opt, T]
+case class Opt[+T](self: Option[T]) extends Applicative.Applyable[Opt, T]
 object Opt extends Applicative.Applyer[String] {
   def none: Opt[Nothing] = new Opt(None)
   def some[T](t: T): Opt[T] = new Opt(Some(t))
   val injectedCtx = "helloooo"
-  inline def apply[T](inline t: T): Opt[T] =
-    ${ applyImpl[T]('t)('this) }
+  
+  inline def apply[T](inline t: T): Opt[T] = ${ applyImpl[T]('t)('this) }
 
   def traverseCtx[I, R](xs: Seq[Opt[I]])(f: (Seq[I], String) => Applicative.Id[R])
       : Opt[R] = {


### PR DESCRIPTION
This PR removes some of the divergence between the test implementation `Opt` and the real implementation `Task`, and simplifies the underlying abstraction by dropping unnecessary type parameters and members