### PR TITLE
[BACKPORT] Separate resolvedRunIvyDeps and transitiveLocalClasspath into two stages when build assembly jar 

### DIFF
--- a/contrib/scoverage/test/src/mill/contrib/scoverage/HelloWorldTests.scala
+++ b/contrib/scoverage/test/src/mill/contrib/scoverage/HelloWorldTests.scala
@@ -1,13 +1,13 @@
 package mill.contrib.scoverage
 
-import mill._
-import mill.api.Result
+import mill.*
+import mill.api.ExecResult
 import mill.contrib.buildinfo.BuildInfo
+import mill.define.Discover
 import mill.scalalib.{DepSyntax, SbtModule, ScalaModule, TestModule}
 import mill.testkit.UnitTester
 import mill.testkit.TestBaseModule
-import utest._
-import utest.framework.TestPath
+import utest.*
 
 trait HelloWorldTests extends utest.TestSuite {
   def threadCount: Option[Int] = Some(1)
@@ -35,7 +35,7 @@ trait HelloWorldTests extends utest.TestSuite {
 
       def scoverageVersion = testScoverageVersion
 
-      override def unmanagedClasspath = Agg(PathRef(unmanagedFile))
+      override def unmanagedClasspath = Seq(PathRef(unmanagedFile))
 
       override def moduleDeps = Seq(other)
 
@@ -45,9 +45,11 @@ trait HelloWorldTests extends utest.TestSuite {
       )
 
       object test extends ScoverageTests with TestModule.ScalaTest {
-        override def ivyDeps = Agg(ivy"org.scalatest::scalatest:${testScalatestVersion}")
+        override def ivyDeps = Seq(ivy"org.scalatest::scalatest:${testScalatestVersion}")
       }
     }
+
+    lazy val millDiscover = Discover[this.type]
   }
 
   object HelloWorldSbt extends TestBaseModule {
@@ -56,16 +58,18 @@ trait HelloWorldTests extends utest.TestSuite {
       def scoverageVersion = testScoverageVersion
 
       object test extends SbtTests with ScoverageTests with TestModule.ScalaTest {
-        override def ivyDeps = Agg(ivy"org.scalatest::scalatest:${testScalatestVersion}")
+        override def ivyDeps = Seq(ivy"org.scalatest::scalatest:${testScalatestVersion}")
       }
     }
+
+    lazy val millDiscover = Discover[this.type]
   }
 
   def tests: utest.Tests = utest.Tests {
     test("HelloWorld") {
       test("core") {
         test("scoverageVersion") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
-          val Right(result) = eval.apply(HelloWorld.core.scoverageVersion)
+          val Right(result) = eval.apply(HelloWorld.core.scoverageVersion): @unchecked
 
           assert(
             result.value == testScoverageVersion,
@@ -75,7 +79,7 @@ trait HelloWorldTests extends utest.TestSuite {
         test("scoverage") {
           test("unmanagedClasspath") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
             val Right(result) =
-              eval.apply(HelloWorld.core.scoverage.unmanagedClasspath)
+              eval.apply(HelloWorld.core.scoverage.unmanagedClasspath): @unchecked
 
             assert(
               result.value.map(_.toString).iterator.exists(_.contains("unmanaged.xml")),
@@ -84,10 +88,10 @@ trait HelloWorldTests extends utest.TestSuite {
           }
           test("ivyDeps") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
             val Right(result) =
-              eval.apply(HelloWorld.core.scoverage.ivyDeps)
+              eval.apply(HelloWorld.core.scoverage.ivyDeps): @unchecked
 
-            val expected = if (isScala3) Agg.empty
-            else Agg(
+            val expected = if (isScala3) Seq.empty
+            else Seq(
               ivy"org.scoverage::scalac-scoverage-runtime:${testScoverageVersion}"
             )
 
@@ -98,19 +102,19 @@ trait HelloWorldTests extends utest.TestSuite {
           }
           test("scalacPluginIvyDeps") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
             val Right(result) =
-              eval.apply(HelloWorld.core.scoverage.scalacPluginIvyDeps)
+              eval.apply(HelloWorld.core.scoverage.scalacPluginIvyDeps): @unchecked
 
             val expected = (isScov3, isScala3) match {
-              case (true, true) => Agg.empty
+              case (true, true) => Seq.empty
               case (true, false) =>
-                Agg(
+                Seq(
                   ivy"org.scoverage:::scalac-scoverage-plugin:${testScoverageVersion}",
                   ivy"org.scoverage::scalac-scoverage-domain:${testScoverageVersion}",
                   ivy"org.scoverage::scalac-scoverage-serializer:${testScoverageVersion}",
                   ivy"org.scoverage::scalac-scoverage-reporter:${testScoverageVersion}"
                 )
               case (false, _) =>
-                Agg(
+                Seq(
                   ivy"org.scoverage:::scalac-scoverage-plugin:${testScoverageVersion}"
                 )
             }
@@ -120,7 +124,7 @@ trait HelloWorldTests extends utest.TestSuite {
             )
           }
           test("data") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
-            val Right(result) = eval.apply(HelloWorld.core.scoverage.data)
+            val Right(result) = eval.apply(HelloWorld.core.scoverage.data): @unchecked
 
             val resultPath = result.value.path.toIO.getPath.replace("""\""", "/")
             val expectedEnd = "/out/core/scoverage/data.dest"
@@ -131,7 +135,7 @@ trait HelloWorldTests extends utest.TestSuite {
             )
           }
           test("htmlReport") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
-            val Right(_) = eval.apply(HelloWorld.core.test.compile)
+            val Right(_) = eval.apply(HelloWorld.core.test.compile): @unchecked
             val res = eval.apply(HelloWorld.core.scoverage.htmlReport())
             if (
               res.isLeft && testScalaVersion.startsWith("3.2") && testScoverageVersion.startsWith(
@@ -141,13 +145,13 @@ trait HelloWorldTests extends utest.TestSuite {
               s"""Disabled for Scoverage ${testScoverageVersion} on Scala ${testScalaVersion}, as it fails with "No source root found" message"""
             } else {
               assert(res.isRight)
-              val Right(result) = res
+              val Right(result) = res: @unchecked
               assert(result.evalCount > 0)
               ""
             }
           }
           test("xmlReport") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
-            val Right(_) = eval.apply(HelloWorld.core.test.compile)
+            val Right(_) = eval.apply(HelloWorld.core.test.compile): @unchecked
             val res = eval.apply(HelloWorld.core.scoverage.xmlReport())
             if (
               res.isLeft && testScalaVersion.startsWith("3.2") && testScoverageVersion.startsWith(
@@ -157,13 +161,13 @@ trait HelloWorldTests extends utest.TestSuite {
               s"""Disabled for Scoverage ${testScoverageVersion} on Scala ${testScalaVersion}, as it fails with "No source root found" message"""
             } else {
               assert(res.isRight)
-              val Right(result) = res
+              val Right(result) = res: @unchecked
               assert(result.evalCount > 0)
               ""
             }
           }
           test("xmlCoberturaReport") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
-            val Right(_) = eval.apply(HelloWorld.core.test.compile)
+            val Right(_) = eval.apply(HelloWorld.core.test.compile): @unchecked
             val res = eval.apply(HelloWorld.core.scoverage.xmlCoberturaReport())
             if (
               res.isLeft && testScalaVersion.startsWith("3.2") && testScoverageVersion.startsWith(
@@ -173,21 +177,21 @@ trait HelloWorldTests extends utest.TestSuite {
               s"""Disabled for Scoverage ${testScoverageVersion} on Scala ${testScalaVersion}, as it fails with "No source root found" message"""
             } else {
               assert(res.isRight)
-              val Right(result) = res
+              val Right(result) = res: @unchecked
               assert(result.evalCount > 0)
               ""
             }
           }
           test("console") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
-            val Right(_) = eval.apply(HelloWorld.core.test.compile)
-            val Right(result) = eval.apply(HelloWorld.core.scoverage.consoleReport())
+            val Right(_) = eval.apply(HelloWorld.core.test.compile): @unchecked
+            val Right(result) = eval.apply(HelloWorld.core.scoverage.consoleReport()): @unchecked
             assert(result.evalCount > 0)
           }
         }
         test("test") - {
           test("upstreamAssemblyClasspath") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
             val Right(result) =
-              eval.apply(HelloWorld.core.scoverage.resolvedIvyAssemblyClasspath)
+              eval.apply(HelloWorld.core.scoverage.upstreamAssemblyClasspath): @unchecked
 
             val runtimeExistsOnClasspath =
               result.value.map(_.toString).iterator.exists(_.contains("scalac-scoverage-runtime"))
@@ -205,7 +209,7 @@ trait HelloWorldTests extends utest.TestSuite {
           }
           test("compileClasspath") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
             val Right(result) =
-              eval.apply(HelloWorld.core.scoverage.compileClasspath)
+              eval.apply(HelloWorld.core.scoverage.compileClasspath): @unchecked
 
             val runtimeExistsOnClasspath =
               result.value.map(_.toString).iterator.exists(_.contains("scalac-scoverage-runtime"))
@@ -222,7 +226,7 @@ trait HelloWorldTests extends utest.TestSuite {
             }
           }
           test("runClasspath") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
-            val Right(result) = eval.apply(HelloWorld.core.scoverage.runClasspath)
+            val Right(result) = eval.apply(HelloWorld.core.scoverage.runClasspath): @unchecked
 
             val runtimeExistsOnClasspath =
               result.value.map(_.toString).iterator.exists(_.contains("scalac-scoverage-runtime"))
@@ -245,19 +249,19 @@ trait HelloWorldTests extends utest.TestSuite {
     test("HelloWorldSbt") {
       test("scoverage") {
         test("htmlReport") - UnitTester(HelloWorld, sbtResourcePath).scoped { eval =>
-          val Right(_) = eval.apply(HelloWorldSbt.core.test.compile)
-          val Right(result) = eval.apply(HelloWorldSbt.core.scoverage.htmlReport())
+          val Right(_) = eval.apply(HelloWorldSbt.core.test.compile): @unchecked
+          val Right(result) = eval.apply(HelloWorldSbt.core.scoverage.htmlReport()): @unchecked
           assert(result.evalCount > 0)
         }
         test("xmlReport") - UnitTester(HelloWorld, sbtResourcePath).scoped { eval =>
-          val Right(_) = eval.apply(HelloWorldSbt.core.test.compile)
-          val Right(result) = eval.apply(HelloWorldSbt.core.scoverage.xmlReport())
+          val Right(_) = eval.apply(HelloWorldSbt.core.test.compile): @unchecked
+          val Right(result) = eval.apply(HelloWorldSbt.core.scoverage.xmlReport()): @unchecked
           assert(result.evalCount > 0)
         }
         test("console") - UnitTester(HelloWorld, sbtResourcePath).scoped { eval =>
-          val Right(_) = eval.apply(HelloWorldSbt.core.test.compile)
+          val Right(_) = eval.apply(HelloWorldSbt.core.test.compile): @unchecked
           val Right(result) =
-            eval.apply(HelloWorldSbt.core.scoverage.consoleReport())
+            eval.apply(HelloWorldSbt.core.scoverage.consoleReport()): @unchecked
           assert(result.evalCount > 0)
         }
       }
@@ -274,11 +278,13 @@ trait FailedWorldTests extends HelloWorldTests {
       val mod = HelloWorld
       test("shouldFail") {
         test("scoverageToolsCp") - UnitTester(mod, resourcePath).scoped { eval =>
-          val Left(Result.Failure(msg, _)) = eval.apply(mod.core.scoverageToolsClasspath)
+          val Left(ExecResult.Failure(msg)) =
+            eval.apply(mod.core.scoverageToolsClasspath): @unchecked
           assert(msg == errorMsg)
         }
         test("other") - UnitTester(mod, resourcePath).scoped { eval =>
-          val Left(Result.Failure(msg, _)) = eval.apply(mod.core.scoverage.xmlReport())
+          val Left(ExecResult.Failure(msg)) =
+            eval.apply(mod.core.scoverage.xmlReport()): @unchecked
           assert(msg == errorMsg)
         }
       }
@@ -290,11 +296,12 @@ trait FailedWorldTests extends HelloWorldTests {
           val res = eval.apply(mod.core.scoverageToolsClasspath)
           assert(res.isLeft)
           println(s"res: ${res}")
-          val Left(Result.Failure(msg, _)) = res
+          val Left(ExecResult.Failure(msg)) = res: @unchecked
           assert(msg == errorMsg)
         }
         test("other") - UnitTester(mod, resourcePath).scoped { eval =>
-          val Left(Result.Failure(msg, _)) = eval.apply(mod.core.scoverage.xmlReport())
+          val Left(ExecResult.Failure(msg)) =
+            eval.apply(mod.core.scoverage.xmlReport()): @unchecked
           assert(msg == errorMsg)
         }
       }

--- a/contrib/scoverage/test/src/mill/contrib/scoverage/HelloWorldTests.scala
+++ b/contrib/scoverage/test/src/mill/contrib/scoverage/HelloWorldTests.scala
@@ -187,7 +187,7 @@ trait HelloWorldTests extends utest.TestSuite {
         test("test") - {
           test("upstreamAssemblyClasspath") - UnitTester(HelloWorld, resourcePath).scoped { eval =>
             val Right(result) =
-              eval.apply(HelloWorld.core.scoverage.upstreamAssemblyClasspath)
+              eval.apply(HelloWorld.core.scoverage.resolvedIvyAssemblyClasspath)
 
             val runtimeExistsOnClasspath =
               result.value.map(_.toString).iterator.exists(_.contains("scalac-scoverage-runtime"))

--- a/scalalib/src/mill/scalalib/AssemblyModule.scala
+++ b/scalalib/src/mill/scalalib/AssemblyModule.scala
@@ -63,8 +63,8 @@ trait AssemblyModule extends mill.Module {
 
   private[mill] def assemblyRules0: Seq[Assembly.Rule] = Assembly.defaultRules
 
-  def resolvedIvyAssemblyClasspath: T[Seq[PathRef]]
-  
+  def resolvedIvyAssemblyClasspath: T[Agg[PathRef]]
+
   def upstreamAssemblyClasspath: T[Agg[PathRef]]
 
   def localClasspath: T[Seq[PathRef]]

--- a/scalalib/src/mill/scalalib/AssemblyModule.scala
+++ b/scalalib/src/mill/scalalib/AssemblyModule.scala
@@ -63,7 +63,9 @@ trait AssemblyModule extends mill.Module {
 
   private[mill] def assemblyRules0: Seq[Assembly.Rule] = Assembly.defaultRules
 
-  def resolvedIvyAssemblyClasspath: T[Agg[PathRef]]
+  def upstreamIvyAssemblyClasspath: T[Seq[PathRef]]
+
+  def upstreamLocalAssemblyClasspath: T[Seq[PathRef]]
 
   def upstreamAssemblyClasspath: T[Agg[PathRef]]
 
@@ -88,7 +90,7 @@ trait AssemblyModule extends mill.Module {
   private[mill] def upstreamAssembly2_0: T[Assembly] = Task {
     Assembly.create(
       destJar = Task.dest / "out.jar",
-      inputPaths = upstreamAssemblyClasspath().map(_.path),
+      inputPaths = upstreamLocalAssemblyClasspath().map(_.path),
       manifest = manifest(),
       base = Some(resolvedIvyAssembly().pathRef.path),
       assemblyRules = assemblyRules

--- a/scalalib/src/mill/scalalib/AssemblyModule.scala
+++ b/scalalib/src/mill/scalalib/AssemblyModule.scala
@@ -63,9 +63,9 @@ trait AssemblyModule extends mill.Module {
 
   private[mill] def assemblyRules0: Seq[Assembly.Rule] = Assembly.defaultRules
 
-  def upstreamIvyAssemblyClasspath: T[Seq[PathRef]]
+  def upstreamIvyAssemblyClasspath: T[Agg[PathRef]]
 
-  def upstreamLocalAssemblyClasspath: T[Seq[PathRef]]
+  def upstreamLocalAssemblyClasspath: T[Agg[PathRef]]
 
   def upstreamAssemblyClasspath: T[Agg[PathRef]]
 
@@ -81,7 +81,7 @@ trait AssemblyModule extends mill.Module {
   def resolvedIvyAssembly: T[Assembly] = Task {
     Assembly.create(
       destJar = Task.dest / "out.jar",
-      inputPaths = resolvedIvyAssemblyClasspath().map(_.path),
+      inputPaths = upstreamIvyAssemblyClasspath().map(_.path),
       manifest = manifest(),
       assemblyRules = assemblyRules
     )

--- a/scalalib/src/mill/scalalib/AssemblyModule.scala
+++ b/scalalib/src/mill/scalalib/AssemblyModule.scala
@@ -63,9 +63,9 @@ trait AssemblyModule extends mill.Module {
 
   private[mill] def assemblyRules0: Seq[Assembly.Rule] = Assembly.defaultRules
 
-  def upstreamIvyAssemblyClasspath: T[Agg[PathRef]]
+  def upstreamIvyAssemblyClasspath: T[Agg[PathRef]] = Agg.empty[PathRef]
 
-  def upstreamLocalAssemblyClasspath: T[Agg[PathRef]]
+  def upstreamLocalAssemblyClasspath: T[Agg[PathRef]] = upstreamAssemblyClasspath()
 
   def upstreamAssemblyClasspath: T[Agg[PathRef]]
 
@@ -133,7 +133,7 @@ trait AssemblyModule extends mill.Module {
     val problematicEntryCount = 65535
     if (
       prependScript.isDefined &&
-      (upstream.addedEntries + created.addedEntries) > problematicEntryCount
+      (resolvedIvyAssembly().addedEntries + upstream.addedEntries + created.addedEntries) > problematicEntryCount
     ) {
       Result.Failure(
         s"""The created assembly jar contains more than ${problematicEntryCount} ZIP entries.

--- a/scalalib/src/mill/scalalib/AssemblyModule.scala
+++ b/scalalib/src/mill/scalalib/AssemblyModule.scala
@@ -63,8 +63,16 @@ trait AssemblyModule extends mill.Module {
 
   private[mill] def assemblyRules0: Seq[Assembly.Rule] = Assembly.defaultRules
 
+  /**
+   * Upstream classfiles and resources from third-party libraries
+   * necessary to build an executable assembly
+   */
   def upstreamIvyAssemblyClasspath: T[Agg[PathRef]] = Agg.empty[PathRef]
 
+  /**
+   * Upstream classfiles and resources from locally-built modules
+   * necessary to build an executable assembly, but without this module's contribution
+   */
   def upstreamLocalAssemblyClasspath: T[Agg[PathRef]] = upstreamAssemblyClasspath()
 
   def upstreamAssemblyClasspath: T[Agg[PathRef]]

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -1022,6 +1022,7 @@ trait JavaModule
   def upstreamLocalAssemblyClasspath: T[Agg[PathRef]] = Task {
     transitiveLocalClasspath()
   }
+
   /**
    * All upstream classfiles and resources necessary to build and executable
    * assembly, but without this module's contribution

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -1028,7 +1028,7 @@ trait JavaModule
    * assembly, but without this module's contribution
    */
   def upstreamAssemblyClasspath: T[Agg[PathRef]] = Task {
-    transitiveLocalClasspath()
+    resolvedRunIvyDeps() ++ transitiveLocalClasspath()
   }
 
   def resolvedRunIvyDeps: T[Agg[PathRef]] = Task {

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -1015,10 +1015,13 @@ trait JavaModule
     )
   }
 
-  def resolvedIvyAssemblyClasspath: T[Agg[PathRef]] = Task {
+  def upstreamIvyAssemblyClasspath: T[Agg[PathRef]] = Task {
     resolvedRunIvyDeps()
   }
 
+  def upstreamLocalAssemblyClasspath: T[Agg[PathRef]] = Task {
+    transitiveLocalClasspath()
+  }
   /**
    * All upstream classfiles and resources necessary to build and executable
    * assembly, but without this module's contribution

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -1015,18 +1015,10 @@ trait JavaModule
     )
   }
 
-  /**
-   * Upstream classfiles and resources from third-party libraries
-   * necessary to build an executable assembly
-   */
   def upstreamIvyAssemblyClasspath: T[Agg[PathRef]] = Task {
     resolvedRunIvyDeps()
   }
 
-  /**
-   * Upstream classfiles and resources from locally-built modules
-   * necessary to build an executable assembly, but without this module's contribution
-   */
   def upstreamLocalAssemblyClasspath: T[Agg[PathRef]] = Task {
     transitiveLocalClasspath()
   }

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -1015,12 +1015,16 @@ trait JavaModule
     )
   }
 
+  def resolvedIvyAssemblyClasspath: T[Agg[PathRef]] = Task {
+    resolvedRunIvyDeps()
+  }
+
   /**
    * All upstream classfiles and resources necessary to build and executable
    * assembly, but without this module's contribution
    */
   def upstreamAssemblyClasspath: T[Agg[PathRef]] = Task {
-    resolvedRunIvyDeps() ++ transitiveLocalClasspath()
+    transitiveLocalClasspath()
   }
 
   def resolvedRunIvyDeps: T[Agg[PathRef]] = Task {

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -1015,10 +1015,18 @@ trait JavaModule
     )
   }
 
+  /**
+   * Upstream classfiles and resources from third-party libraries
+   * necessary to build an executable assembly
+   */
   def upstreamIvyAssemblyClasspath: T[Agg[PathRef]] = Task {
     resolvedRunIvyDeps()
   }
 
+  /**
+   * Upstream classfiles and resources from locally-built modules
+   * necessary to build an executable assembly, but without this module's contribution
+   */
   def upstreamLocalAssemblyClasspath: T[Agg[PathRef]] = Task {
     transitiveLocalClasspath()
   }


### PR DESCRIPTION
Backport of https://github.com/com-lihaoyi/mill/pull/4565