### PR TITLE
Fix hang on `mill.integration.invalidation[selective-execution]`

### DIFF
--- a/scalalib/src/mill/scalalib/TestModuleUtil.scala
+++ b/scalalib/src/mill/scalalib/TestModuleUtil.scala
@@ -70,7 +70,9 @@ private[scalalib] object TestModuleUtil {
         env = forkEnv ++ resourceEnv,
         mainArgs = Seq(testRunnerClasspathArg, argsFile.toString),
         cwd = if (testSandboxWorkingDir) sandbox else forkWorkingDir,
-        cpPassingJarPath = Some(os.temp(prefix = "run-", suffix = ".jar", deleteOnExit = false)),
+        cpPassingJarPath = Option.when(useArgsFile)(
+          os.temp(prefix = "run-", suffix = ".jar", deleteOnExit = false)
+        ),
         javaHome = javaHome,
         stdin = os.Inherit,
         stdout = os.Inherit


### PR DESCRIPTION
Should fix the rebootstrap problems found in https://github.com/com-lihaoyi/mill/pull/4545 and https://github.com/com-lihaoyi/mill/pull/4570 that seems to be caused by a mistake in this backport https://github.com/com-lihaoyi/mill/pull/4504. Not sure why this causes a hang, but for now just fixing it to revert to the previous semantics

Tested manually via

```bash
./mill dist.installLocal
git checkout main
./mill-assembly.jar 'integration.invalidation[selective-execution].local.fork.test' mill.integration.SelectiveExecutionWatchTests.watch.changed-code
```

Doing this manually on `0.12.x` hangs, whereas doing it on this PR succeeds