### PR TITLE
Fix Scaladoc capture on `RootModule`s

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -161,7 +161,7 @@ object Deps {
   val osLib = ivy"com.lihaoyi::os-lib:0.11.4"
   val pprint = ivy"com.lihaoyi::pprint:0.9.0"
   val mainargs = ivy"com.lihaoyi::mainargs:0.7.6"
-  val millModuledefsVersion = "0.11.3-M3"
+  val millModuledefsVersion = "0.11.3-M4"
   val millModuledefsString = s"com.lihaoyi::mill-moduledefs:${millModuledefsVersion}"
   val millModuledefs = ivy"${millModuledefsString}"
   val millModuledefsPlugin =

--- a/integration/feature/inspect/resources/core3/package.mill
+++ b/integration/feature/inspect/resources/core3/package.mill
@@ -2,4 +2,5 @@ package build.core3
 
 import mill.javalib.JavaModule
 
+/** Subfolder Module Scaladoc */
 object `package` extends RootModule with JavaModule

--- a/integration/feature/inspect/src/InspectTests.scala
+++ b/integration/feature/inspect/src/InspectTests.scala
@@ -185,11 +185,10 @@ object InspectTests extends UtestIntegrationTestSuite {
       )
 
       val core3Res = eval(("inspect", "core3"))
-      println(core3Res.err)
       assert(core3Res.isSuccess)
       val core3Inspect = out("inspect").json.str
       assertGlobMatches(
-        """core3(core3/package.mill:11)
+        """core3(core3/package.mill:6)
           |    Subfolder Module Scaladoc
           |
           |Inherited Modules:

--- a/integration/feature/inspect/src/InspectTests.scala
+++ b/integration/feature/inspect/src/InspectTests.scala
@@ -189,7 +189,8 @@ object InspectTests extends UtestIntegrationTestSuite {
       assert(core3Res.isSuccess)
       val core3Inspect = out("inspect").json.str
       assertGlobMatches(
-        """core3(core3/package.mill:5)
+        """core3(core3/package.mill:11)
+          |    Subfolder Module Scaladoc
           |
           |Inherited Modules:
           |    build_.core3.package_

--- a/main/src/mill/main/Inspect.scala
+++ b/main/src/mill/main/Inspect.scala
@@ -141,8 +141,16 @@ private object Inspect {
 
     def pprintModule(t: mill.resolve.Resolve.ModuleTask[?], evaluator: Evaluator): Tree.Lazy = {
       val cls = t.module.getClass
+      val companionClsName = cls.getName match{
+        case s"$prefix.package_$$" => Some(s"$prefix.package_")
+        case _ => None
+      }
+
+      val companionClsOpt = companionClsName.map(cls.getClassLoader.loadClass(_))
+
       val annotation = cls.getAnnotation(classOf[Scaladoc])
-      val scaladocOpt = Option(annotation).map(annotation =>
+      val companionAnnotation = companionClsOpt.map(_.getAnnotation(classOf[Scaladoc])).flatMap(Option(_))
+      val scaladocOpt = (Option(annotation) ++ companionAnnotation).map(annotation =>
         cleanupScaladoc(annotation.value).map("\n" + inspectItemIndent + _).mkString
       )
 

--- a/main/src/mill/main/Inspect.scala
+++ b/main/src/mill/main/Inspect.scala
@@ -144,7 +144,7 @@ private object Inspect {
 
       // For `RootModule`s named `package_`, the scaladoc annotation ends
       // up on the companion `class` rather than on the `object`.
-      val companionClsName = cls.getName match{
+      val companionClsName = cls.getName match {
         case s"$prefix.package_$$" => Some(s"$prefix.package_")
         case _ => None
       }
@@ -152,7 +152,8 @@ private object Inspect {
       val companionClsOpt = companionClsName.map(cls.getClassLoader.loadClass(_))
 
       val annotation = cls.getAnnotation(classOf[Scaladoc])
-      val companionAnnotation = companionClsOpt.map(_.getAnnotation(classOf[Scaladoc])).flatMap(Option(_))
+      val companionAnnotation =
+        companionClsOpt.map(_.getAnnotation(classOf[Scaladoc])).flatMap(Option(_))
       val scaladocOpt = (Option(annotation) ++ companionAnnotation).map(annotation =>
         cleanupScaladoc(annotation.value).map("\n" + inspectItemIndent + _).mkString
       )

--- a/main/src/mill/main/Inspect.scala
+++ b/main/src/mill/main/Inspect.scala
@@ -141,6 +141,9 @@ private object Inspect {
 
     def pprintModule(t: mill.resolve.Resolve.ModuleTask[?], evaluator: Evaluator): Tree.Lazy = {
       val cls = t.module.getClass
+
+      // For `RootModule`s named `package_`, the scaladoc annotation ends
+      // up on the companion `class` rather than on the `object`.
       val companionClsName = cls.getName match{
         case s"$prefix.package_$$" => Some(s"$prefix.package_")
         case _ => None

--- a/runner/src/mill/runner/CodeGen.scala
+++ b/runner/src/mill/runner/CodeGen.scala
@@ -205,17 +205,7 @@ object CodeGen {
 
         newScriptCode = objectData.parent.applyTo(newScriptCode, newParent)
         newScriptCode = objectData.name.applyTo(newScriptCode, wrapperObjectName)
-        // Make sure we put the `object` before the `class`, so that it can get
-        // the scaladoc for usage in `mill inspect`
-        newScriptCode = objectData.obj.applyTo(
-          newScriptCode,
-          s"""object $wrapperObjectName extends $wrapperObjectName {
-             |  ${childAliases.linesWithSeparators.mkString("  ")}
-             |  $exportSiblingScripts
-             |  ${millDiscover(segments.nonEmpty)}
-             |}
-             |abstract class""".stripMargin
-        )
+        newScriptCode = objectData.obj.applyTo(newScriptCode, "abstract class")
 
         s"""package $pkg
            |$miscInfo
@@ -224,7 +214,11 @@ object CodeGen {
            |$prelude
            |$markerComment
            |$newScriptCode
-           |""".stripMargin
+           |object $wrapperObjectName extends $wrapperObjectName {
+           |  ${childAliases.linesWithSeparators.mkString("  ")}
+           |  $exportSiblingScripts
+           |  ${millDiscover(segments.nonEmpty)}
+           |}""".stripMargin
 
       case None =>
         s"""package $pkg


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/4508

Due to how the codegen works, the scaladoc on `RootModule`s ends up on the generated companion class rather than on the `object`. The mill-moduledefs scaladoc plugin wasn't capturing Scaladoc on `class`s, which was fixed on https://github.com/com-lihaoyi/mill-moduledefs/commit/b0064b61c4e26e7abc155a87eb3bac2ca4477668. I then updated `Inspect.scala` to look for `RootModule` objects by name and try to fetch the scaladoc from the companion class

Tweaked the unit test to exercise this scenario