### PR TITLE
Avoid inheriting stderr in `SelectiveExecutionTests.scala` to prevent flakiness from leaked processes

### DIFF
--- a/integration/invalidation/selective-execution/src/SelectiveExecutionTests.scala
+++ b/integration/invalidation/selective-execution/src/SelectiveExecutionTests.scala
@@ -268,7 +268,7 @@ object SelectiveExecutionWatchTests extends UtestIntegrationTestSuite {
               ("--watch", "{foo.fooCommand,bar.barCommand}"),
               check = true,
               stdout = os.ProcessOutput.Readlines { line => output0 = output0 :+ line },
-              stderr = os.Inherit
+              stderr = os.ProcessOutput.Readlines { line => System.err.println(line) }
             )
           }
 


### PR DESCRIPTION
Currently, the inherited `stderr` can remain open even as the spawned processes are killed, causing the test to hang on waiting for the `stderr` to close. This avoids inheriting stderr, so once the spawned processes dies the test can terminate cleanly