### PR TITLE
Make `--no-server` mode also terminate on removal of `processId` file, use it in integration test cleanup 

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,25 +1,25 @@
 # Uncommment this to replace the rest of the file when you want to debug stuff in CI
-
-
-name: Run Debug
-
-on:
-  push:
-  pull_request:
-  workflow_dispatch:
-
-jobs:
-  debug-windows:
-#    runs-on: ubuntu-latest
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v4
-        with: { fetch-depth: 1 }
-
-      - run: ./mill 'integration.invalidation[process-file-deleted-exit].native.server.test'
-        env:
-          COURSIER_ARCHIVE_CACHE: "C:/coursier-arc"
-
+#
+#
+#name: Run Debug
+#
+#on:
+#  push:
+#  pull_request:
+#  workflow_dispatch:
+#
+#jobs:
+#  debug-windows:
+##    runs-on: ubuntu-latest
+#    runs-on: windows-latest
+#    steps:
+#      - uses: actions/checkout@v4
+#        with: { fetch-depth: 1 }
+#
+#      - run: ./mill scalalib.test mill.scalalib.LauncherTests.launcher
+#        env:
+#          COURSIER_ARCHIVE_CACHE: "C:/coursier-arc"
+#
 
 # We run full CI on push builds to main and on all pull requests
 #
@@ -27,239 +27,239 @@ jobs:
 # all tests on Linux, scattered between Java 11/17, except for one job run
 # on MacOS instead and a subset of jobs also run on windows
 
-#
-#name: Run Tests
-#
-#on:
-#  push:
-#    branches-ignore:
-#      - '**-patch-**'
-#  pull_request:
-#    types:
-#      - opened
-#      - reopened
-#      - synchronize
-#      - ready_for_review
-#  workflow_dispatch:
-#
-## cancel older runs of a pull request;
-## this will not cancel anything for normal git pushes
-#concurrency:
-#  # * For runs on other repos, always use the `ref_name` so each branch only can have one concurrent run
-#  # * For runs on `com-lihaoyi/mill`, use `head_ref` to allow one concurrent run per PR, but `run_id` to
-#  #   allow multiple concurrent runs in master
-#  group: cancel-old-pr-runs-${{ github.workflow }}-${{ (github.repository != 'com-lihaoyi/mill' && github.ref_name) || (github.head_ref || github.run_id) }}
-#  cancel-in-progress: true
-#
-#jobs:
-#  # Jobs are listed in rough order of priority: if multiple jobs fail, the first job
-#  # in the list should be the one that's most worth looking into
-#  build-linux:
-#    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
-#    uses: ./.github/workflows/pre-build.yml
-#    with:
-#      os: ubuntu-latest
-#      shell: bash
-#
-#  build-windows:
-#    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
-#    uses: ./.github/workflows/pre-build.yml
-#    with:
-#      os: windows-latest
-#      shell: powershell
-#
-#  test-docs:
-#    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v4
-#        with: { fetch-depth: 1 }
-#
-#      - run: ./mill -i website.fastPages + website.checkBrokenLinks
-#
-#  cross-plat:
-#    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
-#    runs-on: ${{ matrix.os }}
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#          # Run these with Mill native launcher as a smoketest
-#        include:
-#          - os: ubuntu-24.04-arm
-#            millargs: "'example.thirdparty[fansi].native.server.test'"
-#            java-version: 17
-#
-#          - os: macos-latest
-#            millargs: "'example.thirdparty[acyclic].native.server.test'"
-#            java-version: 11
-#
-#          - os: macos-13
-#            millargs: "'example.thirdparty[jimfs].native.server.test'"
-#            java-version: 11
-#    steps:
-#      - uses: actions/checkout@v4
-#        with: { fetch-depth: 1 }
-#
-#      - uses: ./.github/actions/pre-build-setup
-#        with:
-#          os: ${{ matrix.os }}
-#          java-version: ${{ matrix.java-version }}
-#          shell: bash
-#
-#      - uses: ./.github/actions/post-build-setup
-#        with:
-#          java-version: ${{ matrix.java-version }}
-#          os: ${{ matrix.os }}
-#
-#      - uses: ./.github/actions/post-build-selective
-#        with:
-#          millargs: ${{ matrix.millargs }}
-#          coursierarchive: ""
-#          install-android-sdk: false
-#          shell: bash
-#
-#  linux:
-#    needs: build-linux
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#
-#        include:
-#          # For most tests, run them arbitrarily on Java 11 or Java 17 on Linux, and
-#          # on the opposite version on Windows below, so we get decent coverage of
-#          # each test on each Java version and each operating system
-#          # We also try to group tests together to manually balance out the runtimes of each jobs
-#          - java-version: 17
-#            millargs: "'{core,main,scalalib,testrunner,bsp,testkit}.__.test'"
-#            install-android-sdk: false
-#
-#          - java-version: 11
-#            millargs: "'{scalajslib,scalanativelib,kotlinlib,pythonlib,javascriptlib}.__.test'"
-#            install-android-sdk: false
-#
-#          - java-version: 17
-#            millargs: "contrib.__.test"
-#            install-android-sdk: false
-#
-#          - java-version: 17
-#            millargs: "example.javalib.__.local.server.test"
-#            install-android-sdk: false
-#
-#          - java-version: 17
-#            millargs: "example.kotlinlib.__.local.server.test"
-#            install-android-sdk: false
-#
-#          # Run this one using `.native` as a smoketest. Also make sure the java-version
-#          # is the same as that used in the `build-linux` job to avoid diverging code
-#          # hashes (https://github.com/com-lihaoyi/mill/pull/4410)
-#          - java-version: 11
-#            millargs: "example.scalalib.__.native.server.test"
-#            install-android-sdk: false
-#
-#          - java-version: 17
-#            millargs: "'example.android.__.local.server.test'"
-#            install-android-sdk: true
-#
-#          - java-version: 17
-#            millargs: "'example.{pythonlib,javascriptlib}.__.local.server.test'"
-#            install-android-sdk: false
-#
-#          - java-version: 11
-#            millargs: "'example.thirdparty[{mockito,commons-io}].local.server.test'"
-#            install-android-sdk: false
-#
-#          - java-version: 17
-#            millargs: "'example.thirdparty[{netty,gatling}].local.server.test'"
-#            install-android-sdk: false
-#
-#          - java-version: '17'
-#            millargs: "'example.thirdparty[arrow].local.server.test'"
-#            install-android-sdk: false
-#
-#          - java-version: 11
-#            millargs: "'example.{cli,fundamentals,depth,extending}.__.local.server.test'"
-#            install-android-sdk: false
-#
-#          - java-version: 11
-#            millargs: "'integration.{failure,feature,ide}.__.packaged.server.test'"
-#            install-android-sdk: false
-#
-#            # These invalidation tests need to be exercised in both execution modes
-#            # to make sure they work with and without -i/--no-server being passed
-#          - java-version: 17
-#            millargs: "'integration.invalidation.__.packaged.fork.test'"
-#            install-android-sdk: false
-#
-#          - java-version: 17
-#            millargs: "'integration.invalidation.__.packaged.server.test'"
-#            install-android-sdk: false
-#
-#    uses: ./.github/workflows/post-build-selective.yml
-#    with:
-#      install-android-sdk: ${{ matrix.install-android-sdk }}
-#      java-version: ${{ matrix.java-version }}
-#      millargs: ${{ matrix.millargs }}
-#      shell: bash
-#
-#  windows:
-#    needs: build-windows
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        include:
-#          # just run a subset of examples/ on Windows, because for some reason running
-#          # the whole suite can take hours on windows v.s. half an hour on linux
-#          #
-#          # * One job unit tests,
-#          # * One job each for local/packaged/native tests
-#          # * At least one job for each of fork/server tests, and example/integration tests
-#          - java-version: 11
-#            millargs: '"{main,scalalib,bsp}.__.test"'
-#
-#          - java-version: 11
-#            millargs: '"example.scalalib.{basic,publishing}.__.local.fork.test"'
-#
-#          - java-version: 17
-#            millargs: "'integration.{feature,failure}.__.packaged.fork.test'"
-#
-#          - java-version: 11 # Run this with Mill native launcher as a smoketest
-#            millargs: "'integration.invalidation.__.native.server.test'"
-#
-#    uses: ./.github/workflows/post-build-selective.yml
-#    with:
-#      os: windows-latest
-#      java-version: ${{ matrix.java-version }}
-#      millargs: ${{ matrix.millargs }}
-#      # Provide a shorter coursier archive folder to avoid hitting path-length bugs when
-#      # running the graal native image binary on windows
-#      coursierarchive: "C:/coursier-arc"
-#      shell: powershell
-#
-#  itest:
-#    needs: build-linux
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        include:
-#          # bootstrap tests
-#          - java-version: 11 # Have one job on oldest JVM
-#            buildcmd: ci/test-dist-run.sh && ci/test-install-local.sh && ./mill -i -k __:^IntegrationCrossModule:^TestModule.ivyDepsTree && ./mill -i -k __:^IntegrationCrossModule:^TestModule.ivyDepsTree --withRuntime
-#          - java-version: 17 # Have one job on default JVM
-#            buildcmd: ci/test-mill-bootstrap.sh
-#
-#    uses: ./.github/workflows/post-build-raw.yml
-#    with:
-#      java-version: ${{ matrix.java-version }}
-#      buildcmd: ${{ matrix.buildcmd }}
-#
-#  # Scalafmt, Mima, and Scalafix job runs last because it's the least important:
-#  # usually just an automated or mechanical manual fix to do before merging
-#  lint-autofix:
-#    needs: build-linux
-#    uses: ./.github/workflows/post-build-raw.yml
-#    with:
-#      java-version: '17'
-#      buildcmd: |
-#        set -eux
-#        ./mill -i mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll + __.mimaReportBinaryIssues + __.fix --check + mill.javalib.palantirformat.PalantirFormatModule/ --check + mill.kotlinlib.ktlint.KtlintModule/checkFormatAll
-#        ./mill -i --meta-level 1 mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll
+
+name: Run Tests
+
+on:
+  push:
+    branches-ignore:
+      - '**-patch-**'
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+  workflow_dispatch:
+
+# cancel older runs of a pull request;
+# this will not cancel anything for normal git pushes
+concurrency:
+  # * For runs on other repos, always use the `ref_name` so each branch only can have one concurrent run
+  # * For runs on `com-lihaoyi/mill`, use `head_ref` to allow one concurrent run per PR, but `run_id` to
+  #   allow multiple concurrent runs in master
+  group: cancel-old-pr-runs-${{ github.workflow }}-${{ (github.repository != 'com-lihaoyi/mill' && github.ref_name) || (github.head_ref || github.run_id) }}
+  cancel-in-progress: true
+
+jobs:
+  # Jobs are listed in rough order of priority: if multiple jobs fail, the first job
+  # in the list should be the one that's most worth looking into
+  build-linux:
+    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
+    uses: ./.github/workflows/pre-build.yml
+    with:
+      os: ubuntu-latest
+      shell: bash
+
+  build-windows:
+    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
+    uses: ./.github/workflows/pre-build.yml
+    with:
+      os: windows-latest
+      shell: powershell
+
+  test-docs:
+    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 1 }
+
+      - run: ./mill -i website.fastPages + website.checkBrokenLinks
+
+  cross-plat:
+    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+          # Run these with Mill native launcher as a smoketest
+        include:
+          - os: ubuntu-24.04-arm
+            millargs: "'example.thirdparty[fansi].native.server.test'"
+            java-version: 17
+
+          - os: macos-latest
+            millargs: "'example.thirdparty[acyclic].native.server.test'"
+            java-version: 11
+
+          - os: macos-13
+            millargs: "'example.thirdparty[jimfs].native.server.test'"
+            java-version: 11
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 1 }
+
+      - uses: ./.github/actions/pre-build-setup
+        with:
+          os: ${{ matrix.os }}
+          java-version: ${{ matrix.java-version }}
+          shell: bash
+
+      - uses: ./.github/actions/post-build-setup
+        with:
+          java-version: ${{ matrix.java-version }}
+          os: ${{ matrix.os }}
+
+      - uses: ./.github/actions/post-build-selective
+        with:
+          millargs: ${{ matrix.millargs }}
+          coursierarchive: ""
+          install-android-sdk: false
+          shell: bash
+
+  linux:
+    needs: build-linux
+    strategy:
+      fail-fast: false
+      matrix:
+
+        include:
+          # For most tests, run them arbitrarily on Java 11 or Java 17 on Linux, and
+          # on the opposite version on Windows below, so we get decent coverage of
+          # each test on each Java version and each operating system
+          # We also try to group tests together to manually balance out the runtimes of each jobs
+          - java-version: 17
+            millargs: "'{core,main,scalalib,testrunner,bsp,testkit}.__.test'"
+            install-android-sdk: false
+
+          - java-version: 11
+            millargs: "'{scalajslib,scalanativelib,kotlinlib,pythonlib,javascriptlib}.__.test'"
+            install-android-sdk: false
+
+          - java-version: 17
+            millargs: "contrib.__.test"
+            install-android-sdk: false
+
+          - java-version: 17
+            millargs: "example.javalib.__.local.server.test"
+            install-android-sdk: false
+
+          - java-version: 17
+            millargs: "example.kotlinlib.__.local.server.test"
+            install-android-sdk: false
+
+          # Run this one using `.native` as a smoketest. Also make sure the java-version
+          # is the same as that used in the `build-linux` job to avoid diverging code
+          # hashes (https://github.com/com-lihaoyi/mill/pull/4410)
+          - java-version: 11
+            millargs: "example.scalalib.__.native.server.test"
+            install-android-sdk: false
+
+          - java-version: 17
+            millargs: "'example.android.__.local.server.test'"
+            install-android-sdk: true
+
+          - java-version: 17
+            millargs: "'example.{pythonlib,javascriptlib}.__.local.server.test'"
+            install-android-sdk: false
+
+          - java-version: 11
+            millargs: "'example.thirdparty[{mockito,commons-io}].local.server.test'"
+            install-android-sdk: false
+
+          - java-version: 17
+            millargs: "'example.thirdparty[{netty,gatling}].local.server.test'"
+            install-android-sdk: false
+
+          - java-version: '17'
+            millargs: "'example.thirdparty[arrow].local.server.test'"
+            install-android-sdk: false
+
+          - java-version: 11
+            millargs: "'example.{cli,fundamentals,depth,extending}.__.local.server.test'"
+            install-android-sdk: false
+
+          - java-version: 11
+            millargs: "'integration.{failure,feature,ide}.__.packaged.server.test'"
+            install-android-sdk: false
+
+            # These invalidation tests need to be exercised in both execution modes
+            # to make sure they work with and without -i/--no-server being passed
+          - java-version: 17
+            millargs: "'integration.invalidation.__.packaged.fork.test'"
+            install-android-sdk: false
+
+          - java-version: 17
+            millargs: "'integration.invalidation.__.packaged.server.test'"
+            install-android-sdk: false
+
+    uses: ./.github/workflows/post-build-selective.yml
+    with:
+      install-android-sdk: ${{ matrix.install-android-sdk }}
+      java-version: ${{ matrix.java-version }}
+      millargs: ${{ matrix.millargs }}
+      shell: bash
+
+  windows:
+    needs: build-windows
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # just run a subset of examples/ on Windows, because for some reason running
+          # the whole suite can take hours on windows v.s. half an hour on linux
+          #
+          # * One job unit tests,
+          # * One job each for local/packaged/native tests
+          # * At least one job for each of fork/server tests, and example/integration tests
+          - java-version: 11
+            millargs: '"{main,scalalib,bsp}.__.test"'
+
+          - java-version: 11
+            millargs: '"example.scalalib.{basic,publishing}.__.local.fork.test"'
+
+          - java-version: 17
+            millargs: "'integration.{feature,failure}.__.packaged.fork.test'"
+
+          - java-version: 11 # Run this with Mill native launcher as a smoketest
+            millargs: "'integration.invalidation.__.native.server.test'"
+
+    uses: ./.github/workflows/post-build-selective.yml
+    with:
+      os: windows-latest
+      java-version: ${{ matrix.java-version }}
+      millargs: ${{ matrix.millargs }}
+      # Provide a shorter coursier archive folder to avoid hitting path-length bugs when
+      # running the graal native image binary on windows
+      coursierarchive: "C:/coursier-arc"
+      shell: powershell
+
+  itest:
+    needs: build-linux
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # bootstrap tests
+          - java-version: 11 # Have one job on oldest JVM
+            buildcmd: ci/test-dist-run.sh && ci/test-install-local.sh && ./mill -i -k __:^IntegrationCrossModule:^TestModule.ivyDepsTree && ./mill -i -k __:^IntegrationCrossModule:^TestModule.ivyDepsTree --withRuntime
+          - java-version: 17 # Have one job on default JVM
+            buildcmd: ci/test-mill-bootstrap.sh
+
+    uses: ./.github/workflows/post-build-raw.yml
+    with:
+      java-version: ${{ matrix.java-version }}
+      buildcmd: ${{ matrix.buildcmd }}
+
+  # Scalafmt, Mima, and Scalafix job runs last because it's the least important:
+  # usually just an automated or mechanical manual fix to do before merging
+  lint-autofix:
+    needs: build-linux
+    uses: ./.github/workflows/post-build-raw.yml
+    with:
+      java-version: '17'
+      buildcmd: |
+        set -eux
+        ./mill -i mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll + __.mimaReportBinaryIssues + __.fix --check + mill.javalib.palantirformat.PalantirFormatModule/ --check + mill.kotlinlib.ktlint.KtlintModule/checkFormatAll
+        ./mill -i --meta-level 1 mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,25 +1,25 @@
 # Uncommment this to replace the rest of the file when you want to debug stuff in CI
-#
-#
-#name: Run Debug
-#
-#on:
-#  push:
-#  pull_request:
-#  workflow_dispatch:
-#
-#jobs:
-#  debug-windows:
-##    runs-on: ubuntu-latest
-#    runs-on: windows-latest
-#    steps:
-#      - uses: actions/checkout@v4
-#        with: { fetch-depth: 1 }
-#
-#      - run: ./mill scalalib.test mill.scalalib.LauncherTests.launcher
-#        env:
-#          COURSIER_ARCHIVE_CACHE: "C:/coursier-arc"
-#
+
+
+name: Run Debug
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  debug-windows:
+#    runs-on: ubuntu-latest
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 1 }
+
+      - run: ./mill 'integration.invalidation[process-file-deleted-exit].native.server.test'
+        env:
+          COURSIER_ARCHIVE_CACHE: "C:/coursier-arc"
+
 
 # We run full CI on push builds to main and on all pull requests
 #
@@ -27,239 +27,239 @@
 # all tests on Linux, scattered between Java 11/17, except for one job run
 # on MacOS instead and a subset of jobs also run on windows
 
-
-name: Run Tests
-
-on:
-  push:
-    branches-ignore:
-      - '**-patch-**'
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
-  workflow_dispatch:
-
-# cancel older runs of a pull request;
-# this will not cancel anything for normal git pushes
-concurrency:
-  # * For runs on other repos, always use the `ref_name` so each branch only can have one concurrent run
-  # * For runs on `com-lihaoyi/mill`, use `head_ref` to allow one concurrent run per PR, but `run_id` to
-  #   allow multiple concurrent runs in master
-  group: cancel-old-pr-runs-${{ github.workflow }}-${{ (github.repository != 'com-lihaoyi/mill' && github.ref_name) || (github.head_ref || github.run_id) }}
-  cancel-in-progress: true
-
-jobs:
-  # Jobs are listed in rough order of priority: if multiple jobs fail, the first job
-  # in the list should be the one that's most worth looking into
-  build-linux:
-    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
-    uses: ./.github/workflows/pre-build.yml
-    with:
-      os: ubuntu-latest
-      shell: bash
-
-  build-windows:
-    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
-    uses: ./.github/workflows/pre-build.yml
-    with:
-      os: windows-latest
-      shell: powershell
-
-  test-docs:
-    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with: { fetch-depth: 1 }
-
-      - run: ./mill -i website.fastPages + website.checkBrokenLinks
-
-  cross-plat:
-    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-          # Run these with Mill native launcher as a smoketest
-        include:
-          - os: ubuntu-24.04-arm
-            millargs: "'example.thirdparty[fansi].native.server.test'"
-            java-version: 17
-
-          - os: macos-latest
-            millargs: "'example.thirdparty[acyclic].native.server.test'"
-            java-version: 11
-
-          - os: macos-13
-            millargs: "'example.thirdparty[jimfs].native.server.test'"
-            java-version: 11
-    steps:
-      - uses: actions/checkout@v4
-        with: { fetch-depth: 1 }
-
-      - uses: ./.github/actions/pre-build-setup
-        with:
-          os: ${{ matrix.os }}
-          java-version: ${{ matrix.java-version }}
-          shell: bash
-
-      - uses: ./.github/actions/post-build-setup
-        with:
-          java-version: ${{ matrix.java-version }}
-          os: ${{ matrix.os }}
-
-      - uses: ./.github/actions/post-build-selective
-        with:
-          millargs: ${{ matrix.millargs }}
-          coursierarchive: ""
-          install-android-sdk: false
-          shell: bash
-
-  linux:
-    needs: build-linux
-    strategy:
-      fail-fast: false
-      matrix:
-
-        include:
-          # For most tests, run them arbitrarily on Java 11 or Java 17 on Linux, and
-          # on the opposite version on Windows below, so we get decent coverage of
-          # each test on each Java version and each operating system
-          # We also try to group tests together to manually balance out the runtimes of each jobs
-          - java-version: 17
-            millargs: "'{core,main,scalalib,testrunner,bsp,testkit}.__.test'"
-            install-android-sdk: false
-
-          - java-version: 11
-            millargs: "'{scalajslib,scalanativelib,kotlinlib,pythonlib,javascriptlib}.__.test'"
-            install-android-sdk: false
-
-          - java-version: 17
-            millargs: "contrib.__.test"
-            install-android-sdk: false
-
-          - java-version: 17
-            millargs: "example.javalib.__.local.server.test"
-            install-android-sdk: false
-
-          - java-version: 17
-            millargs: "example.kotlinlib.__.local.server.test"
-            install-android-sdk: false
-
-          # Run this one using `.native` as a smoketest. Also make sure the java-version
-          # is the same as that used in the `build-linux` job to avoid diverging code
-          # hashes (https://github.com/com-lihaoyi/mill/pull/4410)
-          - java-version: 11
-            millargs: "example.scalalib.__.native.server.test"
-            install-android-sdk: false
-
-          - java-version: 17
-            millargs: "'example.android.__.local.server.test'"
-            install-android-sdk: true
-
-          - java-version: 17
-            millargs: "'example.{pythonlib,javascriptlib}.__.local.server.test'"
-            install-android-sdk: false
-
-          - java-version: 11
-            millargs: "'example.thirdparty[{mockito,commons-io}].local.server.test'"
-            install-android-sdk: false
-
-          - java-version: 17
-            millargs: "'example.thirdparty[{netty,gatling}].local.server.test'"
-            install-android-sdk: false
-
-          - java-version: '17'
-            millargs: "'example.thirdparty[arrow].local.server.test'"
-            install-android-sdk: false
-
-          - java-version: 11
-            millargs: "'example.{cli,fundamentals,depth,extending}.__.local.server.test'"
-            install-android-sdk: false
-
-          - java-version: 11
-            millargs: "'integration.{failure,feature,ide}.__.packaged.server.test'"
-            install-android-sdk: false
-
-            # These invalidation tests need to be exercised in both execution modes
-            # to make sure they work with and without -i/--no-server being passed
-          - java-version: 17
-            millargs: "'integration.invalidation.__.packaged.fork.test'"
-            install-android-sdk: false
-
-          - java-version: 17
-            millargs: "'integration.invalidation.__.packaged.server.test'"
-            install-android-sdk: false
-
-    uses: ./.github/workflows/post-build-selective.yml
-    with:
-      install-android-sdk: ${{ matrix.install-android-sdk }}
-      java-version: ${{ matrix.java-version }}
-      millargs: ${{ matrix.millargs }}
-      shell: bash
-
-  windows:
-    needs: build-windows
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # just run a subset of examples/ on Windows, because for some reason running
-          # the whole suite can take hours on windows v.s. half an hour on linux
-          #
-          # * One job unit tests,
-          # * One job each for local/packaged/native tests
-          # * At least one job for each of fork/server tests, and example/integration tests
-          - java-version: 11
-            millargs: '"{main,scalalib,bsp}.__.test"'
-
-          - java-version: 11
-            millargs: '"example.scalalib.{basic,publishing}.__.local.fork.test"'
-
-          - java-version: 17
-            millargs: "'integration.{feature,failure}.__.packaged.fork.test'"
-
-          - java-version: 11 # Run this with Mill native launcher as a smoketest
-            millargs: "'integration.invalidation.__.native.server.test'"
-
-    uses: ./.github/workflows/post-build-selective.yml
-    with:
-      os: windows-latest
-      java-version: ${{ matrix.java-version }}
-      millargs: ${{ matrix.millargs }}
-      # Provide a shorter coursier archive folder to avoid hitting path-length bugs when
-      # running the graal native image binary on windows
-      coursierarchive: "C:/coursier-arc"
-      shell: powershell
-
-  itest:
-    needs: build-linux
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # bootstrap tests
-          - java-version: 11 # Have one job on oldest JVM
-            buildcmd: ci/test-dist-run.sh && ci/test-install-local.sh && ./mill -i -k __:^IntegrationCrossModule:^TestModule.ivyDepsTree && ./mill -i -k __:^IntegrationCrossModule:^TestModule.ivyDepsTree --withRuntime
-          - java-version: 17 # Have one job on default JVM
-            buildcmd: ci/test-mill-bootstrap.sh
-
-    uses: ./.github/workflows/post-build-raw.yml
-    with:
-      java-version: ${{ matrix.java-version }}
-      buildcmd: ${{ matrix.buildcmd }}
-
-  # Scalafmt, Mima, and Scalafix job runs last because it's the least important:
-  # usually just an automated or mechanical manual fix to do before merging
-  lint-autofix:
-    needs: build-linux
-    uses: ./.github/workflows/post-build-raw.yml
-    with:
-      java-version: '17'
-      buildcmd: |
-        set -eux
-        ./mill -i mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll + __.mimaReportBinaryIssues + __.fix --check + mill.javalib.palantirformat.PalantirFormatModule/ --check + mill.kotlinlib.ktlint.KtlintModule/checkFormatAll
-        ./mill -i --meta-level 1 mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll
+#
+#name: Run Tests
+#
+#on:
+#  push:
+#    branches-ignore:
+#      - '**-patch-**'
+#  pull_request:
+#    types:
+#      - opened
+#      - reopened
+#      - synchronize
+#      - ready_for_review
+#  workflow_dispatch:
+#
+## cancel older runs of a pull request;
+## this will not cancel anything for normal git pushes
+#concurrency:
+#  # * For runs on other repos, always use the `ref_name` so each branch only can have one concurrent run
+#  # * For runs on `com-lihaoyi/mill`, use `head_ref` to allow one concurrent run per PR, but `run_id` to
+#  #   allow multiple concurrent runs in master
+#  group: cancel-old-pr-runs-${{ github.workflow }}-${{ (github.repository != 'com-lihaoyi/mill' && github.ref_name) || (github.head_ref || github.run_id) }}
+#  cancel-in-progress: true
+#
+#jobs:
+#  # Jobs are listed in rough order of priority: if multiple jobs fail, the first job
+#  # in the list should be the one that's most worth looking into
+#  build-linux:
+#    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
+#    uses: ./.github/workflows/pre-build.yml
+#    with:
+#      os: ubuntu-latest
+#      shell: bash
+#
+#  build-windows:
+#    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
+#    uses: ./.github/workflows/pre-build.yml
+#    with:
+#      os: windows-latest
+#      shell: powershell
+#
+#  test-docs:
+#    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v4
+#        with: { fetch-depth: 1 }
+#
+#      - run: ./mill -i website.fastPages + website.checkBrokenLinks
+#
+#  cross-plat:
+#    if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
+#    runs-on: ${{ matrix.os }}
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#          # Run these with Mill native launcher as a smoketest
+#        include:
+#          - os: ubuntu-24.04-arm
+#            millargs: "'example.thirdparty[fansi].native.server.test'"
+#            java-version: 17
+#
+#          - os: macos-latest
+#            millargs: "'example.thirdparty[acyclic].native.server.test'"
+#            java-version: 11
+#
+#          - os: macos-13
+#            millargs: "'example.thirdparty[jimfs].native.server.test'"
+#            java-version: 11
+#    steps:
+#      - uses: actions/checkout@v4
+#        with: { fetch-depth: 1 }
+#
+#      - uses: ./.github/actions/pre-build-setup
+#        with:
+#          os: ${{ matrix.os }}
+#          java-version: ${{ matrix.java-version }}
+#          shell: bash
+#
+#      - uses: ./.github/actions/post-build-setup
+#        with:
+#          java-version: ${{ matrix.java-version }}
+#          os: ${{ matrix.os }}
+#
+#      - uses: ./.github/actions/post-build-selective
+#        with:
+#          millargs: ${{ matrix.millargs }}
+#          coursierarchive: ""
+#          install-android-sdk: false
+#          shell: bash
+#
+#  linux:
+#    needs: build-linux
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#
+#        include:
+#          # For most tests, run them arbitrarily on Java 11 or Java 17 on Linux, and
+#          # on the opposite version on Windows below, so we get decent coverage of
+#          # each test on each Java version and each operating system
+#          # We also try to group tests together to manually balance out the runtimes of each jobs
+#          - java-version: 17
+#            millargs: "'{core,main,scalalib,testrunner,bsp,testkit}.__.test'"
+#            install-android-sdk: false
+#
+#          - java-version: 11
+#            millargs: "'{scalajslib,scalanativelib,kotlinlib,pythonlib,javascriptlib}.__.test'"
+#            install-android-sdk: false
+#
+#          - java-version: 17
+#            millargs: "contrib.__.test"
+#            install-android-sdk: false
+#
+#          - java-version: 17
+#            millargs: "example.javalib.__.local.server.test"
+#            install-android-sdk: false
+#
+#          - java-version: 17
+#            millargs: "example.kotlinlib.__.local.server.test"
+#            install-android-sdk: false
+#
+#          # Run this one using `.native` as a smoketest. Also make sure the java-version
+#          # is the same as that used in the `build-linux` job to avoid diverging code
+#          # hashes (https://github.com/com-lihaoyi/mill/pull/4410)
+#          - java-version: 11
+#            millargs: "example.scalalib.__.native.server.test"
+#            install-android-sdk: false
+#
+#          - java-version: 17
+#            millargs: "'example.android.__.local.server.test'"
+#            install-android-sdk: true
+#
+#          - java-version: 17
+#            millargs: "'example.{pythonlib,javascriptlib}.__.local.server.test'"
+#            install-android-sdk: false
+#
+#          - java-version: 11
+#            millargs: "'example.thirdparty[{mockito,commons-io}].local.server.test'"
+#            install-android-sdk: false
+#
+#          - java-version: 17
+#            millargs: "'example.thirdparty[{netty,gatling}].local.server.test'"
+#            install-android-sdk: false
+#
+#          - java-version: '17'
+#            millargs: "'example.thirdparty[arrow].local.server.test'"
+#            install-android-sdk: false
+#
+#          - java-version: 11
+#            millargs: "'example.{cli,fundamentals,depth,extending}.__.local.server.test'"
+#            install-android-sdk: false
+#
+#          - java-version: 11
+#            millargs: "'integration.{failure,feature,ide}.__.packaged.server.test'"
+#            install-android-sdk: false
+#
+#            # These invalidation tests need to be exercised in both execution modes
+#            # to make sure they work with and without -i/--no-server being passed
+#          - java-version: 17
+#            millargs: "'integration.invalidation.__.packaged.fork.test'"
+#            install-android-sdk: false
+#
+#          - java-version: 17
+#            millargs: "'integration.invalidation.__.packaged.server.test'"
+#            install-android-sdk: false
+#
+#    uses: ./.github/workflows/post-build-selective.yml
+#    with:
+#      install-android-sdk: ${{ matrix.install-android-sdk }}
+#      java-version: ${{ matrix.java-version }}
+#      millargs: ${{ matrix.millargs }}
+#      shell: bash
+#
+#  windows:
+#    needs: build-windows
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        include:
+#          # just run a subset of examples/ on Windows, because for some reason running
+#          # the whole suite can take hours on windows v.s. half an hour on linux
+#          #
+#          # * One job unit tests,
+#          # * One job each for local/packaged/native tests
+#          # * At least one job for each of fork/server tests, and example/integration tests
+#          - java-version: 11
+#            millargs: '"{main,scalalib,bsp}.__.test"'
+#
+#          - java-version: 11
+#            millargs: '"example.scalalib.{basic,publishing}.__.local.fork.test"'
+#
+#          - java-version: 17
+#            millargs: "'integration.{feature,failure}.__.packaged.fork.test'"
+#
+#          - java-version: 11 # Run this with Mill native launcher as a smoketest
+#            millargs: "'integration.invalidation.__.native.server.test'"
+#
+#    uses: ./.github/workflows/post-build-selective.yml
+#    with:
+#      os: windows-latest
+#      java-version: ${{ matrix.java-version }}
+#      millargs: ${{ matrix.millargs }}
+#      # Provide a shorter coursier archive folder to avoid hitting path-length bugs when
+#      # running the graal native image binary on windows
+#      coursierarchive: "C:/coursier-arc"
+#      shell: powershell
+#
+#  itest:
+#    needs: build-linux
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        include:
+#          # bootstrap tests
+#          - java-version: 11 # Have one job on oldest JVM
+#            buildcmd: ci/test-dist-run.sh && ci/test-install-local.sh && ./mill -i -k __:^IntegrationCrossModule:^TestModule.ivyDepsTree && ./mill -i -k __:^IntegrationCrossModule:^TestModule.ivyDepsTree --withRuntime
+#          - java-version: 17 # Have one job on default JVM
+#            buildcmd: ci/test-mill-bootstrap.sh
+#
+#    uses: ./.github/workflows/post-build-raw.yml
+#    with:
+#      java-version: ${{ matrix.java-version }}
+#      buildcmd: ${{ matrix.buildcmd }}
+#
+#  # Scalafmt, Mima, and Scalafix job runs last because it's the least important:
+#  # usually just an automated or mechanical manual fix to do before merging
+#  lint-autofix:
+#    needs: build-linux
+#    uses: ./.github/workflows/post-build-raw.yml
+#    with:
+#      java-version: '17'
+#      buildcmd: |
+#        set -eux
+#        ./mill -i mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll + __.mimaReportBinaryIssues + __.fix --check + mill.javalib.palantirformat.PalantirFormatModule/ --check + mill.kotlinlib.ktlint.KtlintModule/checkFormatAll
+#        ./mill -i --meta-level 1 mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll

--- a/core/constants/src/mill/constants/ServerFiles.java
+++ b/core/constants/src/mill/constants/ServerFiles.java
@@ -5,7 +5,7 @@ package mill.constants;
  * and documentation about what they do
  */
 public class ServerFiles {
-  public static final String serverId = "serverId";
+  public static final String processId = "processId";
   public static final String sandbox = "sandbox";
 
   /**

--- a/integration/failure/fatal-error/src/FatalErrorTests.scala
+++ b/integration/failure/fatal-error/src/FatalErrorTests.scala
@@ -4,7 +4,7 @@ import mill.testkit.UtestIntegrationTestSuite
 
 import utest._
 
-object CompileErrorTests extends UtestIntegrationTestSuite {
+object FatalErrorTests extends UtestIntegrationTestSuite {
   val tests: Tests = Tests {
     test - integrationTest { tester =>
       val res = tester.eval("fatalTask")

--- a/integration/invalidation/multi-level-editing/src/MultiLevelBuildTests.scala
+++ b/integration/invalidation/multi-level-editing/src/MultiLevelBuildTests.scala
@@ -113,7 +113,7 @@ trait MultiLevelBuildTests extends UtestIntegrationTestSuite {
       val Seq(serverFolder) = os.list(tester.workspacePath / "out/mill-server")
 
       // client-server mode should never restart in these tests and preserve the same process,
-      val currentServerId = os.read(serverFolder / "serverId")
+      val currentServerId = os.read(serverFolder / "processId")
       assert(currentServerId == savedServerId || savedServerId == "")
       savedServerId = currentServerId
     }

--- a/integration/invalidation/process-file-deleted-exit/resources/build.mill
+++ b/integration/invalidation/process-file-deleted-exit/resources/build.mill
@@ -1,2 +1,4 @@
 package build
 import mill._
+
+def foo = Task { 123 }

--- a/integration/invalidation/process-file-deleted-exit/resources/build.mill
+++ b/integration/invalidation/process-file-deleted-exit/resources/build.mill
@@ -1,0 +1,2 @@
+package build
+import mill._

--- a/integration/invalidation/process-file-deleted-exit/src/ProcessFileDeletedExit.scala
+++ b/integration/invalidation/process-file-deleted-exit/src/ProcessFileDeletedExit.scala
@@ -1,0 +1,49 @@
+package mill.integration
+
+import mill.constants.Util
+import mill.testkit.{UtestIntegrationTestSuite, IntegrationTester}
+import utest._
+
+import scala.collection.mutable
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration.Duration
+import scala.concurrent.duration.SECONDS
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import utest.asserts.{RetryMax, RetryInterval}
+
+/**
+ * Make sure removing the `mill-server` or `mill-no-server` directory
+ * kills any running process
+ */
+object ProcessFileDeletedExit extends UtestIntegrationTestSuite {
+  implicit val retryMax: RetryMax = RetryMax(10.seconds)
+  implicit val retryInterval: RetryInterval = RetryInterval(1.seconds)
+  val tests: Tests = Tests {
+    integrationTest { tester =>
+      import tester._
+
+      assert(!os.exists(workspacePath / "out/mill-server"))
+      assert(!os.exists(workspacePath / "out/mill-no-server"))
+
+      @volatile var watchTerminated = false
+      Future {
+        eval(
+          ("--watch", "version"),
+          stdout = os.ProcessOutput.Readlines { println(_) },
+          stderr = os.ProcessOutput.Readlines { println(_) }
+        )
+        watchTerminated = true
+      }
+
+      if (clientServerMode) eventually {os.exists(workspacePath / "out/mill-server") }
+      else eventually{os.exists(workspacePath / "out/mill-no-server")}
+      assert(watchTerminated == false)
+
+      if (clientServerMode) os.remove.all(workspacePath / "out/mill-server")
+      else os.remove.all(workspacePath / "out/mill-no-server")
+
+      eventually { watchTerminated == true }
+    }
+  }
+}

--- a/integration/invalidation/process-file-deleted-exit/src/ProcessFileDeletedExit.scala
+++ b/integration/invalidation/process-file-deleted-exit/src/ProcessFileDeletedExit.scala
@@ -25,7 +25,7 @@ object ProcessFileDeletedExit extends UtestIntegrationTestSuite {
       @volatile var watchTerminated = false
       Future {
         eval(
-          ("--watch", "version"),
+          ("--watch", "foo"),
           stdout = os.ProcessOutput.Readlines { println(_) },
           stderr = os.ProcessOutput.Readlines { println(_) }
         )
@@ -34,10 +34,14 @@ object ProcessFileDeletedExit extends UtestIntegrationTestSuite {
 
       if (tester.clientServerMode) eventually { os.exists(workspacePath / "out/mill-server") }
       else eventually { os.exists(workspacePath / "out/mill-no-server") }
+
       assert(watchTerminated == false)
 
-      if (tester.clientServerMode) os.remove.all(workspacePath / "out/mill-server")
-      else os.remove.all(workspacePath / "out/mill-no-server")
+      val processRoot =
+        if (tester.clientServerMode) workspacePath / "out/mill-server"
+        else workspacePath / "out/mill-no-server"
+
+      os.list(processRoot).map(p => os.remove(p / "processId"))
 
       eventually { watchTerminated == true }
     }

--- a/integration/invalidation/process-file-deleted-exit/src/ProcessFileDeletedExit.scala
+++ b/integration/invalidation/process-file-deleted-exit/src/ProcessFileDeletedExit.scala
@@ -1,13 +1,9 @@
 package mill.integration
 
-import mill.constants.Util
 import mill.testkit.{UtestIntegrationTestSuite, IntegrationTester}
 import utest._
 
-import scala.collection.mutable
-import scala.concurrent.{Await, Future}
-import scala.concurrent.duration.Duration
-import scala.concurrent.duration.SECONDS
+import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import utest.asserts.{RetryMax, RetryInterval}
@@ -36,11 +32,11 @@ object ProcessFileDeletedExit extends UtestIntegrationTestSuite {
         watchTerminated = true
       }
 
-      if (clientServerMode) eventually {os.exists(workspacePath / "out/mill-server") }
-      else eventually{os.exists(workspacePath / "out/mill-no-server")}
+      if (tester.clientServerMode) eventually { os.exists(workspacePath / "out/mill-server") }
+      else eventually { os.exists(workspacePath / "out/mill-no-server") }
       assert(watchTerminated == false)
 
-      if (clientServerMode) os.remove.all(workspacePath / "out/mill-server")
+      if (tester.clientServerMode) os.remove.all(workspacePath / "out/mill-server")
       else os.remove.all(workspacePath / "out/mill-no-server")
 
       eventually { watchTerminated == true }

--- a/runner/client/src/mill/runner/client/MillProcessLauncher.java
+++ b/runner/client/src/mill/runner/client/MillProcessLauncher.java
@@ -42,7 +42,7 @@ public class MillProcessLauncher {
       interrupted = true;
       throw e;
     } finally {
-      if (!interrupted) {
+      if (!interrupted && Files.exists(processDir)) {
         // cleanup if process terminated for sure
         Files.walk(processDir)
             // depth-first

--- a/runner/server/src/mill/main/server/Server.scala
+++ b/runner/server/src/mill/main/server/Server.scala
@@ -257,10 +257,12 @@ object Server {
 
   }
 
-  def watchProcessIdFile(processIdFile: os.Path,
-                         processId: String,
-                         running: () => Boolean,
-                         exit: String => Unit): Unit = {
+  def watchProcessIdFile(
+      processIdFile: os.Path,
+      processId: String,
+      running: () => Boolean,
+      exit: String => Unit
+  ): Unit = {
     os.write.over(processIdFile, processId)
 
     val processIdThread = new Thread(

--- a/runner/server/src/mill/main/server/Server.scala
+++ b/runner/server/src/mill/main/server/Server.scala
@@ -263,7 +263,7 @@ object Server {
       running: () => Boolean,
       exit: String => Unit
   ): Unit = {
-    os.write.over(processIdFile, processId)
+    os.write.over(processIdFile, processId, createFolders = true)
 
     val processIdThread = new Thread(
       () =>

--- a/runner/server/src/mill/main/server/Server.scala
+++ b/runner/server/src/mill/main/server/Server.scala
@@ -275,6 +275,7 @@ object Server {
         },
       "Process ID Checker Thread: " + processIdFile
     )
+    processIdThread.setDaemon(true)
     processIdThread.start()
   }
 

--- a/runner/server/src/mill/main/server/Server.scala
+++ b/runner/server/src/mill/main/server/Server.scala
@@ -31,14 +31,14 @@ abstract class Server[T](
   var stateCache = stateCache0
   def stateCache0: T
 
-  val serverId: String = Server.computeProcessId()
+  val processId: String = Server.computeProcessId()
   def serverLog0(s: String): Unit = {
     if (os.exists(serverDir) || testLogEvenWhenServerIdWrong) {
       os.write.append(serverDir / ServerFiles.serverLog, s"$s\n", createFolders = true)
     }
   }
 
-  def serverLog(s: String): Unit = serverLog0(s"$serverId $s")
+  def serverLog(s: String): Unit = serverLog0(s"$processId $s")
 
   def run(): Unit = {
     serverLog("running server in " + serverDir)
@@ -48,8 +48,8 @@ abstract class Server[T](
       Server.tryLockBlock(locks.processLock) {
         serverLog("server file locked")
         Server.watchProcessIdFile(
-          serverDir / ServerFiles.serverId,
-          serverId,
+          serverDir / ServerFiles.processId,
+          processId,
           running = () => running,
           exit = msg => {
             serverLog(msg)
@@ -247,11 +247,11 @@ object Server {
   }
   def checkProcessIdFile(processIdFile: os.Path, processId: String): Option[String] = {
     Try(os.read(processIdFile)) match {
-      case scala.util.Failure(e) => Some(s"serverId file missing")
+      case scala.util.Failure(e) => Some(s"processId file missing")
 
       case scala.util.Success(s) =>
         Option.when(s != processId) {
-          s"serverId file contents $s does not match serverId $processId"
+          s"processId file contents $s does not match processId $processId"
         }
     }
 

--- a/runner/server/src/mill/main/server/Server.scala
+++ b/runner/server/src/mill/main/server/Server.scala
@@ -31,7 +31,7 @@ abstract class Server[T](
   var stateCache = stateCache0
   def stateCache0: T
 
-  val serverId: String = java.lang.Long.toHexString(scala.util.Random.nextLong())
+  val serverId: String = Server.computeProcessId()
   def serverLog0(s: String): Unit = {
     if (os.exists(serverDir) || testLogEvenWhenServerIdWrong) {
       os.write.append(serverDir / ServerFiles.serverLog, s"$s\n", createFolders = true)
@@ -47,7 +47,15 @@ abstract class Server[T](
     try {
       Server.tryLockBlock(locks.processLock) {
         serverLog("server file locked")
-        watchServerIdFile()
+        Server.watchProcessIdFile(
+          serverDir / ServerFiles.serverId,
+          serverId,
+          running = () => running,
+          exit = msg => {
+            serverLog(msg)
+            exitServer()
+          }
+        )
         val serverSocket = new java.net.ServerSocket(0, 0, InetAddress.getByName(null))
         os.write.over(serverDir / ServerFiles.socketPort, serverSocket.getLocalPort.toString)
         serverLog("listening on port " + serverSocket.getLocalPort)
@@ -88,35 +96,6 @@ abstract class Server[T](
     pumperThread.setDaemon(true)
     pumperThread.start()
     pipedInput
-  }
-
-  def watchServerIdFile(): Unit = {
-    os.write.over(serverDir / ServerFiles.serverId, serverId)
-
-    val serverIdThread = new Thread(
-      () =>
-        while (running) {
-          checkServerIdFile() match {
-            case None => Thread.sleep(100)
-            case Some(msg) =>
-              serverLog(msg)
-              exitServer()
-          }
-        },
-      "Server ID Checker Thread: " + serverDir
-    )
-    serverIdThread.start()
-  }
-  def checkServerIdFile(): Option[String] = {
-    Try(os.read(serverDir / ServerFiles.serverId)) match {
-      case scala.util.Failure(e) => Some(s"serverId file missing")
-
-      case scala.util.Success(s) =>
-        Option.when(s != serverId) {
-          s"serverId file contents $s does not match serverId $serverId"
-        }
-    }
-
   }
 
   def interruptWithTimeout[T](close: () => Unit, t: () => T): Option[T] = {
@@ -261,11 +240,40 @@ abstract class Server[T](
 }
 
 object Server {
+  def computeProcessId() = {
+    java.lang.Long.toHexString(scala.util.Random.nextLong()) +
+      "-pid" +
+      ProcessHandle.current().pid()
+  }
+  def checkProcessIdFile(processIdFile: os.Path, processId: String): Option[String] = {
+    Try(os.read(processIdFile)) match {
+      case scala.util.Failure(e) => Some(s"serverId file missing")
 
-  def lockBlock[T](lock: Lock)(t: => T): T = {
-    val l = lock.lock()
-    try t
-    finally l.release()
+      case scala.util.Success(s) =>
+        Option.when(s != processId) {
+          s"serverId file contents $s does not match serverId $processId"
+        }
+    }
+
+  }
+
+  def watchProcessIdFile(processIdFile: os.Path,
+                         processId: String,
+                         running: () => Boolean,
+                         exit: String => Unit): Unit = {
+    os.write.over(processIdFile, processId)
+
+    val processIdThread = new Thread(
+      () =>
+        while (running()) {
+          checkProcessIdFile(processIdFile, processId) match {
+            case None => Thread.sleep(100)
+            case Some(msg) => exit(msg)
+          }
+        },
+      "Process ID Checker Thread: " + processIdFile
+    )
+    processIdThread.start()
   }
 
   def tryLockBlock[T](lock: Lock)(t: => T): Option[T] = {

--- a/runner/server/test/src/mill/main/server/ClientServerTests.scala
+++ b/runner/server/test/src/mill/main/server/ClientServerTests.scala
@@ -18,7 +18,7 @@ object ClientServerTests extends TestSuite {
 
   val ENDL = System.lineSeparator()
   class EchoServer(
-      override val serverId: String,
+      override val processId: String,
       serverDir: os.Path,
       locks: Locks,
       testLogEvenWhenServerIdWrong: Boolean
@@ -97,10 +97,10 @@ object ClientServerTests extends TestSuite {
       ) {
         def preRun(serverDir: Path) = { /*do nothing*/ }
         def initServer(serverDir: Path, b: Boolean, locks: Locks) = {
-          val serverId = "server-" + nextServerId
+          val processId = "server-" + nextServerId
           nextServerId += 1
           new Thread(new EchoServer(
-            serverId,
+            processId,
             os.Path(serverDir, os.pwd),
             locks,
             testLogEvenWhenServerIdWrong
@@ -173,7 +173,7 @@ object ClientServerTests extends TestSuite {
         os.remove.all(res3.outDir)
         Thread.sleep(1000)
 
-        assert(res3.logsFor("serverId file missing") == Seq("server-1"))
+        assert(res3.logsFor("processId file missing") == Seq("server-1"))
         assert(res3.logsFor("exiting server") == Seq("server-1", "server-1"))
       }
     }

--- a/runner/src/mill/runner/MillMain.scala
+++ b/runner/src/mill/runner/MillMain.scala
@@ -76,7 +76,7 @@ object MillMain {
     val processId = mill.main.server.Server.computeProcessId()
     val out = os.Path(OutFiles.out, WorkspaceRoot.workspaceRoot)
     mill.main.server.Server.watchProcessIdFile(
-      out / OutFiles.millNoServer / ServerFiles.processId,
+      out / OutFiles.millNoServer / processId / ServerFiles.processId,
       processId,
       running = () => true,
       exit = msg => {

--- a/runner/src/mill/runner/MillMain.scala
+++ b/runner/src/mill/runner/MillMain.scala
@@ -73,6 +73,18 @@ object MillMain {
     if (Properties.isWin && Util.hasConsole())
       io.github.alexarchambault.windowsansi.WindowsAnsi.setup()
 
+    val processId = mill.main.server.Server.computeProcessId()
+    val out = os.Path(OutFiles.out, WorkspaceRoot.workspaceRoot)
+    mill.main.server.Server.watchProcessIdFile(
+      out / OutFiles.millNoServer / ServerFiles.serverId,
+      processId,
+      running = () => true,
+      exit = msg => {
+        System.err.println(msg)
+        System.exit(0)
+      }
+    )
+
     val (result, _) =
       try main0(
           args = args.tail,

--- a/runner/src/mill/runner/MillMain.scala
+++ b/runner/src/mill/runner/MillMain.scala
@@ -76,7 +76,7 @@ object MillMain {
     val processId = mill.main.server.Server.computeProcessId()
     val out = os.Path(OutFiles.out, WorkspaceRoot.workspaceRoot)
     mill.main.server.Server.watchProcessIdFile(
-      out / OutFiles.millNoServer / ServerFiles.serverId,
+      out / OutFiles.millNoServer / ServerFiles.processId,
       processId,
       running = () => true,
       exit = msg => {

--- a/testkit/src/mill/testkit/ExampleTester.scala
+++ b/testkit/src/mill/testkit/ExampleTester.scala
@@ -52,14 +52,16 @@ object ExampleTester {
       millExecutable: os.Path,
       bashExecutable: String = defaultBashExecutable(),
       workspacePath: os.Path = os.pwd
-  ): Unit = {
-    new ExampleTester(
+  ): os.Path = {
+    val tester = new ExampleTester(
       clientServerMode,
       workspaceSourcePath,
       millExecutable,
       bashExecutable,
       workspacePath
-    ).run()
+    )
+    tester.run()
+    tester.workspacePath
   }
 
   def defaultBashExecutable(): String = {
@@ -193,7 +195,7 @@ class ExampleTester(
     expected.linesIterator.exists(globMatches(_, filtered))
   }
 
-  def run(): Any = {
+  def run(): Unit = {
     os.makeDir.all(workspacePath)
     val parsed = ExampleParser(workspaceSourcePath)
     val usageComment = parsed.collect { case ("example", txt) => txt }.mkString("\n\n")

--- a/testkit/src/mill/testkit/ExampleTester.scala
+++ b/testkit/src/mill/testkit/ExampleTester.scala
@@ -96,6 +96,7 @@ class ExampleTester(
     }
   }
   private val millExt = if (isWindows) ".bat" else ""
+  private val clientServerFlag = if (clientServerMode) "" else "--no-server"
 
   def processCommand(
       expectedSnippets: Vector[String],
@@ -103,8 +104,8 @@ class ExampleTester(
       check: Boolean = true
   ): Unit = {
     val commandStr = commandStr0 match {
-      case s"mill $rest" => s"./mill$millExt --disable-ticker $rest"
-      case s"./mill $rest" => s"./mill$millExt --disable-ticker $rest"
+      case s"mill $rest" => s"./mill$millExt $clientServerFlag --disable-ticker $rest"
+      case s"./mill $rest" => s"./mill$millExt $clientServerFlag --disable-ticker $rest"
       case s"curl $rest" => s"curl --retry 7 --retry-all-errors $rest"
       case s => s
     }

--- a/testkit/src/mill/testkit/ExampleTester.scala
+++ b/testkit/src/mill/testkit/ExampleTester.scala
@@ -204,7 +204,7 @@ class ExampleTester(
       for (commandBlock <- commandBlocks) processCommandBlock(commandBlock)
     } finally {
       if (clientServerMode) processCommand(Vector(), "./mill shutdown", check = false)
-      removeServerIdFile()
+      removeProcessIdFile()
     }
   }
 }

--- a/testkit/src/mill/testkit/IntegrationTester.scala
+++ b/testkit/src/mill/testkit/IntegrationTester.scala
@@ -157,7 +157,7 @@ object IntegrationTester {
         )
       }
 
-      removeServerIdFile()
+      removeProcessIdFile()
     }
   }
 

--- a/testkit/src/mill/testkit/IntegrationTesterBase.scala
+++ b/testkit/src/mill/testkit/IntegrationTesterBase.scala
@@ -59,11 +59,10 @@ trait IntegrationTesterBase {
    * Remove any ID files to try and force them to exit
    */
   def removeServerIdFile(): Unit = {
-    val serverPath0 = os.Path(out, workspacePath) / millServer
-    if (clientServerMode) {
-      for (serverPath <- os.list.stream(serverPath0)) os.remove(serverPath / serverId)
+    val serverPath0 = os.Path(out, workspacePath) / (if (clientServerMode) millServer else millNoServer)
 
-      Thread.sleep(500) // give a moment for the server to notice the file is gone and exit
-    }
+    for (serverPath <- os.list.stream(serverPath0)) os.remove(serverPath / serverId)
+
+    Thread.sleep(500) // give a moment for the server to notice the file is gone and exit
   }
 }

--- a/testkit/src/mill/testkit/IntegrationTesterBase.scala
+++ b/testkit/src/mill/testkit/IntegrationTesterBase.scala
@@ -59,11 +59,13 @@ trait IntegrationTesterBase {
    * Remove any ID files to try and force them to exit
    */
   def removeProcessIdFile(): Unit = {
-    val serverPath0 =
-      os.Path(out, workspacePath) / (if (clientServerMode) millServer else millNoServer)
+    val outDir = os.Path(out, workspacePath)
+    if (os.exists(outDir)) {
+      val serverPath0 = outDir / (if (clientServerMode) millServer else millNoServer)
 
-    for (serverPath <- os.list.stream(serverPath0)) os.remove(serverPath / processId)
+      for (serverPath <- os.list.stream(serverPath0)) os.remove(serverPath / processId)
 
-    Thread.sleep(500) // give a moment for the server to notice the file is gone and exit
+      Thread.sleep(500) // give a moment for the server to notice the file is gone and exit
+    }
   }
 }

--- a/testkit/src/mill/testkit/IntegrationTesterBase.scala
+++ b/testkit/src/mill/testkit/IntegrationTesterBase.scala
@@ -1,6 +1,6 @@
 package mill.testkit
 import mill.constants.OutFiles.{millServer, millNoServer, out}
-import mill.constants.ServerFiles.serverId
+import mill.constants.ServerFiles.processId
 import mill.util.Retry
 
 trait IntegrationTesterBase {
@@ -58,11 +58,11 @@ trait IntegrationTesterBase {
   /**
    * Remove any ID files to try and force them to exit
    */
-  def removeServerIdFile(): Unit = {
+  def removeProcessIdFile(): Unit = {
     val serverPath0 =
       os.Path(out, workspacePath) / (if (clientServerMode) millServer else millNoServer)
 
-    for (serverPath <- os.list.stream(serverPath0)) os.remove(serverPath / serverId)
+    for (serverPath <- os.list.stream(serverPath0)) os.remove(serverPath / processId)
 
     Thread.sleep(500) // give a moment for the server to notice the file is gone and exit
   }

--- a/testkit/src/mill/testkit/IntegrationTesterBase.scala
+++ b/testkit/src/mill/testkit/IntegrationTesterBase.scala
@@ -59,7 +59,8 @@ trait IntegrationTesterBase {
    * Remove any ID files to try and force them to exit
    */
   def removeServerIdFile(): Unit = {
-    val serverPath0 = os.Path(out, workspacePath) / (if (clientServerMode) millServer else millNoServer)
+    val serverPath0 =
+      os.Path(out, workspacePath) / (if (clientServerMode) millServer else millNoServer)
 
     for (serverPath <- os.list.stream(serverPath0)) os.remove(serverPath / serverId)
 

--- a/testkit/src/mill/testkit/IntegrationTesterBase.scala
+++ b/testkit/src/mill/testkit/IntegrationTesterBase.scala
@@ -1,5 +1,5 @@
 package mill.testkit
-import mill.constants.OutFiles.{millServer, out}
+import mill.constants.OutFiles.{millServer, millNoServer, out}
 import mill.constants.ServerFiles.serverId
 import mill.util.Retry
 

--- a/testkit/test/resources/example-test-example-project/build.mill
+++ b/testkit/test/resources/example-test-example-project/build.mill
@@ -19,4 +19,8 @@ def testTask = Task { os.read(testSource().path).toUpperCase() }
 > cat out/testTask.json
 ..."HELLO WORLD SOURCE FILE!!!"...
 
+> ls out/mill-server # not --no-server, make sure `mill-server` is generated
+
+> ls out/mill-no-server # --no-server, make sure `mill-no-server` is generated
+
 */

--- a/testkit/test/src/mill/testkit/ExampleTesterTests.scala
+++ b/testkit/test/src/mill/testkit/ExampleTesterTests.scala
@@ -6,20 +6,29 @@ object ExampleTesterTests extends TestSuite {
 
   def tests: Tests = Tests {
     test("fork") {
-      ExampleTester.run(
+      val workspacePath = ExampleTester.run(
         clientServerMode = false,
         workspaceSourcePath =
           os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "example-test-example-project",
         millExecutable = os.Path(sys.env("MILL_EXECUTABLE_PATH"))
       )
+
+      assert(os.exists(workspacePath / "out/mill-no-server"))
+
+      assert(TestkitTestUtils.getProcessIdFiles(workspacePath).isEmpty)
     }
+
     test("server") {
-      ExampleTester.run(
+      val workspacePath = ExampleTester.run(
         clientServerMode = true,
         workspaceSourcePath =
           os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "example-test-example-project",
         millExecutable = os.Path(sys.env("MILL_EXECUTABLE_PATH"))
       )
+
+      assert(os.exists(workspacePath / "out/mill-server"))
+
+      assert(TestkitTestUtils.getProcessIdFiles(workspacePath).isEmpty)
     }
   }
 }

--- a/testkit/test/src/mill/testkit/ExampleTesterTests.scala
+++ b/testkit/test/src/mill/testkit/ExampleTesterTests.scala
@@ -5,7 +5,15 @@ import utest._
 object ExampleTesterTests extends TestSuite {
 
   def tests: Tests = Tests {
-    test("example") {
+    test("fork") {
+      ExampleTester.run(
+        clientServerMode = false,
+        workspaceSourcePath =
+          os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "example-test-example-project",
+        millExecutable = os.Path(sys.env("MILL_EXECUTABLE_PATH"))
+      )
+    }
+    test("server") {
       ExampleTester.run(
         clientServerMode = true,
         workspaceSourcePath =

--- a/testkit/test/src/mill/testkit/IntegrationTesterTests.scala
+++ b/testkit/test/src/mill/testkit/IntegrationTesterTests.scala
@@ -1,6 +1,5 @@
 package mill.testkit
 
-import mill.constants.ServerFiles
 import utest.*
 
 trait IntegrationTesterTests extends TestSuite with IntegrationTestSuite {
@@ -26,14 +25,17 @@ trait IntegrationTesterTests extends TestSuite with IntegrationTestSuite {
 
         val suffix = if (clientServerMode) "mill-server" else "mill-no-server"
         assert(os.exists(tester.workspacePath / "out" / suffix))
+
+        // Make sure processId file(s) is present while the test is running
+        val processIdFiles = TestkitTestUtils.getProcessIdFiles(tester.workspacePath)
+        assert(processIdFiles.nonEmpty)
         tester.workspacePath
       }
 
       // Make sure processId file is correctly removed to ensure the Mill
       // server process shuts down
-      val remainingProcessIdFiles =
-        os.walk(workspacePath / "out").filter(_.last == ServerFiles.processId)
-      assert(remainingProcessIdFiles.isEmpty)
+      val processIdFiles = TestkitTestUtils.getProcessIdFiles(workspacePath)
+      assert(processIdFiles.isEmpty)
 
     }
   }

--- a/testkit/test/src/mill/testkit/IntegrationTesterTests.scala
+++ b/testkit/test/src/mill/testkit/IntegrationTesterTests.scala
@@ -26,7 +26,7 @@ trait IntegrationTesterTests extends TestSuite with IntegrationTestSuite {
 
         val suffix = if (clientServerMode) "mill-server" else "mill-no-server"
         assert(os.exists(tester.workspacePath / "out" / suffix))
-         tester.workspacePath
+        tester.workspacePath
       }
 
       // Make sure processId file is correctly removed to ensure the Mill
@@ -38,9 +38,9 @@ trait IntegrationTesterTests extends TestSuite with IntegrationTestSuite {
     }
   }
 }
-object IntegrationTesterTestsServer extends IntegrationTesterTests{
+object IntegrationTesterTestsServer extends IntegrationTesterTests {
   def clientServerMode = true
 }
-object IntegrationTesterTestsFork extends IntegrationTesterTests{
+object IntegrationTesterTestsFork extends IntegrationTesterTests {
   def clientServerMode = false
 }

--- a/testkit/test/src/mill/testkit/IntegrationTesterTests.scala
+++ b/testkit/test/src/mill/testkit/IntegrationTesterTests.scala
@@ -27,11 +27,11 @@ object IntegrationTesterTests extends TestSuite with IntegrationTestSuite {
         tester.workspacePath
       }
 
-      // Make sure serverId file is correctly removed to ensure the Mill
+      // Make sure processId file is correctly removed to ensure the Mill
       // server process shuts down
-      val remainingServerIdFiles =
-        os.walk(workspacePath / "out").filter(_.last == ServerFiles.serverId)
-      assert(remainingServerIdFiles.isEmpty)
+      val remainingProcessIdFiles =
+        os.walk(workspacePath / "out").filter(_.last == ServerFiles.processId)
+      assert(remainingProcessFiles.isEmpty)
 
     }
   }

--- a/testkit/test/src/mill/testkit/IntegrationTesterTests.scala
+++ b/testkit/test/src/mill/testkit/IntegrationTesterTests.scala
@@ -3,8 +3,8 @@ package mill.testkit
 import mill.constants.ServerFiles
 import utest.*
 
-object IntegrationTesterTests extends TestSuite with IntegrationTestSuite {
-  def clientServerMode = true
+trait IntegrationTesterTests extends TestSuite with IntegrationTestSuite {
+
   def workspaceSourcePath =
     os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "integration-test-example-project"
   def millExecutable = os.Path(sys.env("MILL_EXECUTABLE_PATH"))
@@ -24,7 +24,9 @@ object IntegrationTesterTests extends TestSuite with IntegrationTestSuite {
         assert(!res2.err.contains("compiling 1 Scala source")) // no need to re-compile `build.mill`
         assert(tester.out("testTask").value[String] == "HELLO WORLD SOURCE FILE!!!")
 
-        tester.workspacePath
+        val suffix = if (clientServerMode) "mill-server" else "mill-no-server"
+        assert(os.exists(tester.workspacePath / "out" / suffix))
+         tester.workspacePath
       }
 
       // Make sure processId file is correctly removed to ensure the Mill
@@ -35,4 +37,10 @@ object IntegrationTesterTests extends TestSuite with IntegrationTestSuite {
 
     }
   }
+}
+object IntegrationTesterTestsServer extends IntegrationTesterTests{
+  def clientServerMode = true
+}
+object IntegrationTesterTestsFork extends IntegrationTesterTests{
+  def clientServerMode = false
 }

--- a/testkit/test/src/mill/testkit/IntegrationTesterTests.scala
+++ b/testkit/test/src/mill/testkit/IntegrationTesterTests.scala
@@ -31,7 +31,7 @@ object IntegrationTesterTests extends TestSuite with IntegrationTestSuite {
       // server process shuts down
       val remainingProcessIdFiles =
         os.walk(workspacePath / "out").filter(_.last == ServerFiles.processId)
-      assert(remainingProcessFiles.isEmpty)
+      assert(remainingProcessIdFiles.isEmpty)
 
     }
   }

--- a/testkit/test/src/mill/testkit/TestkitTestUtils.scala
+++ b/testkit/test/src/mill/testkit/TestkitTestUtils.scala
@@ -1,0 +1,8 @@
+package mill.testkit
+import mill.constants.ServerFiles
+object TestkitTestUtils {
+  def getProcessIdFiles(workspacePath: os.Path) = {
+    os.walk(workspacePath / "out")
+      .filter(_.last == ServerFiles.processId)
+  }
+}


### PR DESCRIPTION
This attempts to fix some of the residual flakiness encountered in https://github.com/com-lihaoyi/mill/pull/4570

Somehow the recursive process termination we pulled in from upstream https://github.com/com-lihaoyi/os-lib/pull/359 only works some of the time, and other times the processes get leaked. This PR extends the `serverId`-file-deleted shutdown logic we already used for client-server mode and enables it for `--no-server` mode as well. This lets us put an additional guardrail in our `IntegrationTester#close` to delete any such files, to try and force any Mill processes to terminate.

Added an additional integration test to exercise this behavior

Also fixed a bug in `ExampleTester` not honoring the `clientServerMode` flag, and update `testkit.test` to assert on those behaviors