### PR TITLE
[ISSUE-2981] Fix `semanticdbData` for mixed scala/java projects

### DIFF
--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -619,21 +619,22 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
     val hasJava = allSourceFiles().exists(_.path.ext == "java")
     val isMixedProject = hasScala && hasJava
     // See https://github.com/com-lihaoyi/mill/issues/2981
-    val stopAfterSemanticDbOpts = if(isMixedProject) Seq.empty else Seq("-Ystop-after:semanticdb-typer")
+    val stopAfterSemanticDbOpts =
+      if (isMixedProject) Seq.empty else Seq("-Ystop-after:semanticdb-typer")
 
     val additionalScalacOptions = if (ZincWorkerUtil.isScala3(sv)) {
-        Seq("-Xsemanticdb", s"-sourceroot:${T.workspace}")
-      } else {
-        Seq(
-          "-Yrangepos",
-          s"-P:semanticdb:sourceroot:${T.workspace}",
-        ) ++ stopAfterSemanticDbOpts
-      }
+      Seq("-Xsemanticdb", s"-sourceroot:${T.workspace}")
+    } else {
+      Seq(
+        "-Yrangepos",
+        s"-P:semanticdb:sourceroot:${T.workspace}"
+      ) ++ stopAfterSemanticDbOpts
+    }
 
     val scalacOptions = (
       allScalacOptions() ++
-      semanticDbEnablePluginScalacOptions() ++
-      additionalScalacOptions
+        semanticDbEnablePluginScalacOptions() ++
+        additionalScalacOptions
     )
       .filterNot(_ == "-Xfatal-warnings")
 

--- a/scalalib/test/resources/hello-world-mixed/core/src/Foo.scala
+++ b/scalalib/test/resources/hello-world-mixed/core/src/Foo.scala
@@ -1,0 +1,5 @@
+package foo
+
+object Foo {
+  val value = "hello"
+}

--- a/scalalib/test/resources/hello-world-mixed/core/src/JFoo.java
+++ b/scalalib/test/resources/hello-world-mixed/core/src/JFoo.java
@@ -1,0 +1,5 @@
+package foo;
+
+public class JFoo {
+    String value = foo.Foo.value();
+}

--- a/scalalib/test/src/mill/scalalib/ScalaMixedProjectSemanticDbTests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaMixedProjectSemanticDbTests.scala
@@ -1,0 +1,53 @@
+package mill.scalalib
+
+import mill.testkit.{TestBaseModule, UnitTester}
+import utest.*
+import mill.define.Discover
+import mill.main.TokenReaders._
+
+object ScalaMixedProjectSemanticDbTests extends TestSuite {
+
+  object SemanticWorld extends TestBaseModule {
+    object core extends HelloWorldTests.SemanticModule
+
+    lazy val millDiscover = Discover[this.type]
+  }
+
+  val resourcePath = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "hello-world-mixed"
+
+  def tests: Tests = Tests {
+
+    test("semanticDbData") {
+      def semanticDbFiles: Set[os.SubPath] = Set(
+        os.sub / "META-INF/semanticdb/core/src/Foo.scala.semanticdb",
+        os.sub / "META-INF/semanticdb/core/src/JFoo.java.semanticdb"
+      )
+
+      test("fromScratch") - UnitTester(SemanticWorld, sourceRoot = resourcePath).scoped { eval =>
+        {
+          println("first - expected full compile")
+          val Right(result) = eval.apply(SemanticWorld.core.semanticDbData): @unchecked
+
+          val dataPath = eval.outPath / "core/semanticDbData.dest/data"
+          val outputFiles =
+            os.walk(result.value.path).filter(os.isFile).map(_.relativeTo(result.value.path))
+
+          val expectedSemFiles = semanticDbFiles
+          assert(
+            result.value.path == dataPath,
+            outputFiles.nonEmpty,
+            outputFiles.toSet == expectedSemFiles,
+            result.evalCount > 0,
+            os.exists(dataPath / os.up / "zinc")
+          )
+        }
+        {
+          println("second - expected no compile")
+          // don't recompile if nothing changed
+          val Right(result2) = eval.apply(SemanticWorld.core.semanticDbData): @unchecked
+          assert(result2.evalCount == 0)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/2981

The approach taken is the first one suggested by @Lefou in the issue, namely detect whether the project is mixed, and avoid stopping the compilation after the semanticdb phase when it is the case.
