### PR TITLE
Break out separate `Caching in Mill` and `Parallelism in Mill` pages

### DIFF
--- a/example/scalalib/basic/2-custom-build-logic/build.mill
+++ b/example/scalalib/basic/2-custom-build-logic/build.mill
@@ -80,8 +80,8 @@ Inputs:
 // xref:cli/builtin-commands.adoc#_visualize[mill visualize].
 //
 // Custom user-defined tasks in Mill such as `def lineCount` above benefit from all
-// the same things that built-in tasks do: automatic caching (in the
-// xref:fundamentals/out-dir.adoc[out/ folder]), parallelism (configurable via xref:cli/flags.adoc#_jobs_j[-j/--jobs
+// the same things that built-in tasks do: automatic xref:depth/caching.adoc[caching] (in the
+// xref:fundamentals/out-dir.adoc[out/ folder]), xref:depth/parallelism.adoc[parallelism] (configurable via xref:cli/flags.adoc#_jobs_j[-j/--jobs
 // flag]), inspectability (via xref:cli/builtin-commands.adoc#_show[show] and xref:cli/builtin-commands.adoc#_inspect[inspect]), and so on.
 // While these things may not matter for such a simple example that runs
 // quickly, they ensure that custom build logic remains performant and

--- a/website/docs/modules/ROOT/nav.adoc
+++ b/website/docs/modules/ROOT/nav.adoc
@@ -112,9 +112,11 @@
 // but people developing Mill plugins or working on particularly large or
 // sophisticated Mill builds will need to understand.
 * Mill In Depth
-** xref:depth/sandboxing.adoc[]
-** xref:depth/execution-model.adoc[]
+** xref:depth/evaluation-model.adoc[]
+** xref:depth/caching.adoc[]
+** xref:depth/parallelism.adoc[]
 ** xref:depth/process-architecture.adoc[]
+** xref:depth/sandboxing.adoc[]
 ** xref:depth/design-principles.adoc[]
 ** xref:depth/why-scala.adoc[]
 // Reference pages that a typical user would not typically read top-to-bottom,

--- a/website/docs/modules/ROOT/pages/cli/flags.adoc
+++ b/website/docs/modules/ROOT/pages/cli/flags.adoc
@@ -135,9 +135,8 @@ forcefully terminating the previous process even though it may be still alive:
 
 === `--jobs`/`-j`
 
-By default, Mill will evaluate all tasks in parallel, with the number of concurrent
-tasks equal to the number of cores on your machine. You can use the `--jobs` (`-j`) to configure
-explicitly how many concurrent tasks you wish to run. To disable parallel execution use `-j1`.
+Configures how much xref:depth/parallelism.adoc[Parallelism] Mill should run with.
+Defaults to the number of cores available on your system.
 
 Example: Use up to 4 parallel threads to compile all modules:
 
@@ -151,18 +150,6 @@ You can also set Mill's parallelism to some multiple of the number of cores, e.g
 These can be useful as xref:_repo_level_mill_options[] to configure an appropriate level
 of parallelism that scales based on the number of cores available (which might differ
 between e.g. developer laptops and CI machines)
-
-Every `mill` run generates an output file in `out/mill-chrome-profile.json` that can be
-loaded into the Chrome browser's `chrome://tracing` page for visualization.
-This can make it much easier to analyze your parallel runs to find out what's
-taking the most time:
-
-image::basic/ChromeTracing.png[ChromeTracing.png]
-
-Note that the maximal possible parallelism depends both on the number of cores
-available as well as the task and module structure of your project, as tasks that
-depend on one another other cannot be processed in parallel
-
 
 [#_repo_level_mill_options]
 == Repo-Level Mill Options

--- a/website/docs/modules/ROOT/pages/comparisons/gradle.adoc
+++ b/website/docs/modules/ROOT/pages/comparisons/gradle.adoc
@@ -18,7 +18,7 @@ does so with much less fixed overhead. This means less time waiting for your bui
 tool, and more time for the things that really matter to your project.
 
 * **Mill enforces best practices by default**.
-xref:depth/execution-model.adoc#_caching_in_mill[All parts of a Mill build are cached and incremental by default].
+xref:depth/evaluation-model.adoc#_caching_in_mill[All parts of a Mill build are cached and incremental by default].
 All Mill tasks write their output to xref:fundamentals/out-dir.adoc[a standard place].
 All task inter-dependencies are automatically captured without manual annotation. Where Gradle requires
 considerable effort and expertise to understand your build and set it up in the right way, Mill's

--- a/website/docs/modules/ROOT/pages/comparisons/unique.adoc
+++ b/website/docs/modules/ROOT/pages/comparisons/unique.adoc
@@ -484,7 +484,7 @@ functionality, but at 10% the complexity:
 * Bazel itself is not getting any simpler over time - instead is getting more complex with
   additional features and functionality, as tends to happen to projects over time
 
-Mill provides many of the same things Bazel does: automatic xref:depth/execution-model.adoc[caching],
+Mill provides many of the same things Bazel does: automatic xref:depth/evaluation-model.adoc[caching],
 parallelization, xref:depth/sandboxing.adoc[sandboxing],
 xref:extending/import-ivy-plugins.adoc[extensibility]. Mill
 can already work with a wide variety of programming languages,

--- a/website/docs/modules/ROOT/pages/depth/caching.adoc
+++ b/website/docs/modules/ROOT/pages/depth/caching.adoc
@@ -1,0 +1,86 @@
+= Caching in Mill
+
+Mill has a multi-layered approach to caching: every step in the
+xref:depth/evaluation-model.adoc[Mill Evaluation Model] is cached if possible,
+re-using prior results rather than computing them from scratch. This helps ensure
+the overall workflow remains fast even for large projects.
+
+## Caching Per Phase
+
+This section will discuss the caching that Mill performs in each phase of
+xref:depth/evaluation-model.adoc[Mill's Evaluation Model]:
+
+### Compilation
+
+* If there were changes in `build.mill` or `package.mill` files, compilation is done
+  incrementally using the Scala incremental compiler https://github.com/sbt/zinc[Zinc].
+  Typically, this limits compilation to the `.mill` files you changed, though the
+  exact about of caching and reuse that occurs may vary depending on the nature
+  of the code change.
+
+* If no `.mill` files were changed, this phase is skipped entirely.
+
+### Resolution
+
+* In the common case where the `build.mill` and `package.mill` files were not
+  changed - and re-compilation of th `.mill` files did not occur - any `Module`
+  objects instantiated during previous resolutions are kept around and re-used.
+
+* If re-compilation of `.mill` files did occur due to a code change, then
+  all `Module` objects are discarded along with their enclosing classloader,
+  and re-instantiated using the latest code
+
+### Planning
+
+* Planning is relatively quick most of the time, and is not currently cached.
+
+### Execution
+
+* Mill ``Task``s are evaluated in dependency order
+
+* Default cached xref:fundamentals/tasks.adoc#_tasks[Task]s only re-evaluate if their
+  input ``Task``s have their value change.
+
+* xref:fundamentals/tasks.adoc#_persistent_tasks[Persistent Tasks]s preserve the `Task.dest`
+  folder on disk between runs, allowing for finer-grained caching than Mill's default task-by-task
+  caching and invalidation
+
+* xref:fundamentals/tasks.adoc#_workers[Worker]s are kept in-memory between runs where possible, and only
+  invalidated if their input ``Task``s change as well.
+
+* ``Task``s in general are invalidated if the code they depend on changes,
+  at a method-level granularity via callgraph reachability analysis. See
+  https://github.com/com-lihaoyi/mill/pull/2417[#2417] for more details
+
+### Bootstrapping
+
+* Mill's bootstrapping process essentially involves running the four phases above, but
+  for the meta-build rather than the primary build. All the caching techniques described
+  above apply the same for Mill's bootstrap builds as they do for the primary build.
+
+## Consequences of Caching in Mill
+
+This approach to caching does assume a certain programming style inside your
+Mill build:
+
+- Mill may-or-may-not instantiate the modules in your `build.mill` the first time
+  you run something (due to laziness)
+
+- Mill may-or-may-not *re*-instantiate the modules in your `build.mill` in subsequent runs
+  (due to caching)
+
+- Mill may-or-may-not re-execute any particular task depending on caching,
+  but your code needs to work either way.
+
+- Execution of any task may-or-may-not happen in parallel with other unrelated
+  tasks, and may happen in arbitrary order
+
+Your build code code needs to work regardless of which order they are executed in.
+However, for code written in a typical Scala style (which tends to avoid side effects),
+and limits filesystem operations to the `Task.dest` folder, this is not a problem at all.
+
+One thing to note is for code that runs during *Resolution*: any reading of
+external mutable state needs to be wrapped in an `interp.watchValue{...}`
+wrapper. This ensures that Mill knows where these external reads are, so that
+it can check if their value changed and if so re-instantiate `RootModule` with
+the new value.

--- a/website/docs/modules/ROOT/pages/depth/evaluation-model.adoc
+++ b/website/docs/modules/ROOT/pages/depth/evaluation-model.adoc
@@ -1,5 +1,5 @@
-= The Mill Execution Model
-:page-aliases: The_Mill_Evaluation_Model.adoc, depth/evaluation-model.adoc
+= The Mill Evaluation Model
+:page-aliases: The_Mill_Evaluation_Model.adoc, depth/execution-model.adoc
 
 
 
@@ -185,7 +185,7 @@ and `bar.assembly`, their upstream task graph requires tasks such as `foo.compil
 `bar.compile`, as well as our custom task `bar.lineCount` and our override of `bar.resources`.
 
 
-=== Evaluation
+=== Execution
 
 The last phase is execution. Execution depends not only on the tasks you selected at the
 command line, and those discovered during <<Resolution>>, but also what input files changed
@@ -340,7 +340,7 @@ build. For example:
    during <<Resolution>>
 
 2. You can have arbitrary code inside of ``Task``s, to perform your build
-   actions. This code runs during <<Evaluation>>
+   actions. This code runs during <<Execution>>
 
 3. *But* your code inside of ``Task``s cannot influence the shape of the task
    graph or module hierarchy, as all <<Resolution>> logic happens first
@@ -359,76 +359,3 @@ and visualize their module hierarchy and task graph without running them: using
 xref:cli/builtin-commands.adoc#_inspect[inspect], xref:cli/builtin-commands.adoc#_plan[plan],
 xref:cli/builtin-commands.adoc#_visualize[visualize], etc.. This helps keep your
 Mill build discoverable even as the `build.mill` codebase grows.
-
-== Caching in Mill
-
-Apart from fine-grained caching of ``Task``s during *Evaluation*, Mill also
-performs incremental evaluation of the other phases. This helps ensure
-the overall workflow remains fast even for large projects:
-
-1. <<Compilation>>:
-
-    * Done on-demand and incrementally using the Scala
-      incremental compiler https://github.com/sbt/zinc[Zinc].
-
-    * If some of the files `build.mill` imported changed but not others, only the
-      changed files are re-compiled before the `RootModule` is re-instantiated
-
-    * In the common case where `build.mill` was not changed at all, this step is
-      skipped entirely and the `RootModule` object simply re-used from the last
-      run.
-
-2. <<Resolution>>:
-
-    * If the `RootModule` was re-used, then all
-      previously-instantiated modules are simply-re-used
-
-    * Any modules that are lazily instantiated during <<Resolution>> are
-      also re-used.
-
-3. <<Planning>>
-
-    * Planning is relatively quick most of the time, and is not currently cached.
-
-4. <<Evaluation>>:
-
-    * ``Task``s are evaluated in dependency order
-
-    * xref:fundamentals/tasks.adoc#_tasks[Cached Task]s only re-evaluate if their input ``Task``s
-     change.
-
-    * xref:fundamentals/tasks.adoc#_persistent_tasks[Persistent Tasks]s preserve the `Task.dest`
-      folder on disk between runs, allowing for finer-grained caching than Mill's default task-by-task
-      caching and invalidation
-
-    * xref:fundamentals/tasks.adoc#_workers[Worker]s are kept in-memory between runs where possible, and only
-      invalidated if their input ``Task``s change as well.
-
-    * ``Task``s in general are invalidated if the code they depend on changes,
-      at a method-level granularity via callgraph reachability analysis. See
-      https://github.com/com-lihaoyi/mill/pull/2417[#2417] for more details
-
-This approach to caching does assume a certain programming style inside your
-Mill build:
-
-- Mill may-or-may-not instantiate the modules in your `build.mill` the first time
-  you run something (due to laziness)
-
-- Mill may-or-may-not *re*-instantiate the modules in your `build.mill` in subsequent runs
-  (due to caching)
-
-- Mill may-or-may-not re-execute any particular task depending on caching,
-  but your code needs to work either way.
-
-- Execution of any task may-or-may-not happen in parallel with other unrelated
-  tasks, and may happen in arbitrary order
-
-Your build code code needs to work regardless of which order they are executed in.
-However, for code written in a typical Scala style (which tends to avoid side effects),
-and limits filesystem operations to the `Task.dest` folder, this is not a problem at all.
-
-One thing to note is for code that runs during *Resolution*: any reading of
-external mutable state needs to be wrapped in an `interp.watchValue{...}`
-wrapper. This ensures that Mill knows where these external reads are, so that
-it can check if their value changed and if so re-instantiate `RootModule` with
-the new value.

--- a/website/docs/modules/ROOT/pages/depth/parallelism.adoc
+++ b/website/docs/modules/ROOT/pages/depth/parallelism.adoc
@@ -1,0 +1,60 @@
+= Parallelism in Mill
+
+By default, Mill will evaluate all tasks in parallel, with the number of concurrent
+tasks equal to the number of cores on your machine. Note that the actual amount
+of parallelism may depend on the structure of the build in question:
+
+- Tasks and modules that depend on each other have to run sequentially
+- Tasks and modules that are independent can run in parallel
+
+In general, Mill is able to provide the most parallelism for "wide" builds
+with a lot of independent modules in a shallow hierarchy.
+
+You can use the xref:cli/flags.adoc#__jobs_j[--jobs]
+to configure explicitly how many concurrent tasks you wish to run, or `-j1` to disable
+parallelism and run on a single core.
+
+
+== Mill Chrome Profiles
+
+Every `mill` run generates an output file in `out/mill-chrome-profile.json` that can be
+loaded into the Chrome browser's `chrome://tracing` page for visualization. This can make
+it much easier to analyze your parallel runs to find out what's taking the most time:
+
+image::basic/ChromeTracing.png[ChromeTracing.png]
+
+The chrome profile is great for finding bottlenecks in your parallel builds, since you
+can usually see if there's a task taking a long time before downstream tasks can begin.
+These "long poll" tasks are usually good targets for optimization: e.g. a long `compile`
+task may be improved by breaking down its module into smaller modules that can `compile`
+independently and in parallel.
+
+== Consequences of Parallelism in Mill
+
+Mill running tasks in parallel means that you have to take care that your
+code is _thread safe_. Your build will have multiple tasks running in parallel,
+and if your tasks are using shared mutable state then there is risk of race
+conditions and non-deterministic bugs. This is usually not a problem for
+most Mill code following the standard conventions, but it is worth taking note of:
+
+* For code written in a typical Scala style, which focuses on immutable values and
+  pure functions, the code is typically thread safe by default. "Local" mutability
+  e.g. within a function does not cause issues either
+
+* For tasks writing to the filesystem, make sure you only write to `Task.dest`, which
+  is a dedicated folder assigned to each task. This ensures that you do not have multiple
+  tasks writing to the same files in parallel, allowing these filesystem writes to
+  be safe and race-free even in the presence of parallelism
+
+* For long-lived in-memory xref:fundamentals/tasks.adoc#_workers[Workers], the value is
+  _initialized_ in a single-thread, but may be _used_ from multiple threads concurrently.
+  The onus is on the implementer to ensure that the worker values are safe to be used
+  concurrently from multiple tasks: whether by wrapping mutating operations in
+  `synchronized` blocks, using concurrent data structures like ``ConcurrentHashMap``s,
+  or Mill helpers like xref:fundamentals/tasks.adoc#_cachedfactory_workers[CachedFactory].
+
+
+
+== (Experimental) Forking Concurrent Futures within Tasks
+
+include::partial$example/fundamentals/tasks/7-forking-futures.adoc[]

--- a/website/docs/modules/ROOT/pages/depth/process-architecture.adoc
+++ b/website/docs/modules/ROOT/pages/depth/process-architecture.adoc
@@ -148,7 +148,7 @@ exit code, but the Mill server remains alive and ready to serve to the next Mill
 client that connects to it
 
 For a more detailed discussion of what exactly goes into "execution", see
-xref:depth/execution-model.adoc[].
+xref:depth/evaluation-model.adoc[].
 
 
 == The Out Folder

--- a/website/docs/modules/ROOT/pages/fundamentals/tasks.adoc
+++ b/website/docs/modules/ROOT/pages/fundamentals/tasks.adoc
@@ -54,6 +54,3 @@ include::partial$example/fundamentals/tasks/6-workers.adoc[]
 
 include::partial$example/fundamentals/tasks/3-anonymous-tasks.adoc[]
 
-== (Experimental) Forking Concurrent Futures within Tasks
-
-include::partial$example/fundamentals/tasks/7-forking-futures.adoc[]

--- a/website/docs/modules/ROOT/pages/index.adoc
+++ b/website/docs/modules/ROOT/pages/index.adoc
@@ -43,8 +43,8 @@ JVM build tools have a reputation for being sluggish and confusing. Mill tries t
 offer a better alternative, letting your build system take full advantage of the
 Java platform's performance and usability:
 
-* *Performance*: Mill has automatically xref:depth/execution-model.adoc#_caching_in_mill[caching]
-and xref:cli/flags.adoc#_jobs_j[parallelization] of build tasks to keep local development fast,
+* *Performance*: Mill has automatically xref:depth/caching.adoc[caching]
+and xref:depth/parallelism.adoc[parallelization] of build tasks to keep local development fast,
 xref:blog::9-mill-faster-assembly-jars.adoc[incremental assemblies] to speed up manual testing
 workflows, and xref:large/selective-execution.adoc[selective execution] to keep
 CI validation times short by only running the tests necessary to validate a code change.


### PR DESCRIPTION
First step to fix https://github.com/com-lihaoyi/mill/issues/4603.

The pages are pretty thin, but can be fleshed out over time