### PR TITLE
More documentation improvements for Mill parallelism and caching

### DIFF
--- a/website/docs/modules/ROOT/pages/depth/caching.adoc
+++ b/website/docs/modules/ROOT/pages/depth/caching.adoc
@@ -58,6 +58,26 @@ xref:depth/evaluation-model.adoc[Mill's Evaluation Model]:
   for the meta-build rather than the primary build. All the caching techniques described
   above apply the same for Mill's bootstrap builds as they do for the primary build.
 
+## Debugging Mill Caching Issues
+
+To dig into how Mill's execution caching, you can look at the following files:
+
+* xref:fundamentals/out-dir.adoc#_mill_profile_json[mill-profile.json]: this file
+is generated during every Mill evaluation, and contains a `"cached": boolean` flag
+for each task indicating whether or not that task was cached.
+
+* xref:fundamentals/out-dir.adoc#_mill_invalidation_tree_json[mill-invalidation-tree.json]:
+this file groups together the un-cached files in a tree structure according to their
+task dependencies. It is useful to find the "root" uncached tasks, which are the cause
+of downstream tasks having their caches invalidated.
+
+* xref:fundamentals/out-dir.adoc#_methodcodehashsignatures_spanninginvalidationtree[methodCodeHashSignatures spanningInvalidationTree]:
+this file contains information about tasks whose caches were invalidated due to
+__code changes in the `build.mill` or `package.mill` files__, and again shows a tree
+of invalidated method signatures organized into a tree using their call graph dependenceis.
+This is most useful to figure out why a code change in your `.mill` files ended up
+changing some task's code signature, causing it to miss the cache and be re-computed
+
 ## Consequences of Caching in Mill
 
 This approach to caching does assume a certain programming style inside your

--- a/website/docs/modules/ROOT/pages/depth/evaluation-model.adoc
+++ b/website/docs/modules/ROOT/pages/depth/evaluation-model.adoc
@@ -185,6 +185,11 @@ and `bar.assembly`, their upstream task graph requires tasks such as `foo.compil
 `bar.compile`, as well as our custom task `bar.lineCount` and our override of `bar.resources`.
 
 
+You can use xref:cli/builtin-commands.adoc#_plan[./mill plan] to see what tasks would be
+planned out for a given selector, or look at
+xref:fundamentals/out-dir.adoc#_mill_dependency_tree_json[mill-dependency-tree.json] after
+evaluation to see how how these upstream tasks are depended upon by the tasks you selected.
+
 === Execution
 
 The last phase is execution. Execution depends not only on the tasks you selected at the

--- a/website/docs/modules/ROOT/pages/depth/parallelism.adoc
+++ b/website/docs/modules/ROOT/pages/depth/parallelism.adoc
@@ -1,8 +1,14 @@
 = Parallelism in Mill
 
 By default, Mill will evaluate all tasks in parallel, with the number of concurrent
-tasks equal to the number of cores on your machine. Note that the actual amount
-of parallelism may depend on the structure of the build in question:
+tasks equal to the number of cores on your machine. You can use the
+xref:cli/flags.adoc#__jobs_j[--jobs]
+to configure explicitly how many concurrent tasks you wish to run, or `-j1` to disable
+parallelism and run on a single core.
+
+== When Can Tasks Be Parallelized?
+
+The actual amount of parallelism may depend on the structure of the build in question:
 
 - Tasks and modules that depend on each other have to run sequentially
 - Tasks and modules that are independent can run in parallel
@@ -10,9 +16,20 @@ of parallelism may depend on the structure of the build in question:
 In general, Mill is able to provide the most parallelism for "wide" builds
 with a lot of independent modules in a shallow hierarchy.
 
-You can use the xref:cli/flags.adoc#__jobs_j[--jobs]
-to configure explicitly how many concurrent tasks you wish to run, or `-j1` to disable
-parallelism and run on a single core.
+If you want to visualize the structure of your build graph, you can use
+xref:cli/builtin-commands.adoc#_visualize[./mill visualize] on the tasks you
+care about. e.g. if you want to visualize the relationship between the various
+`.compile` tasks:
+
+```scala
+$ ./mill visualize __.compile
+```
+
+`visualize` renders an SVG which lets you see how the various tasks you selected depend
+(or not depend) on one another. This can be very helpful to figure out where the
+bottlenecks in your build are, and from there come up with ideas of refactoring your
+build to improve parallelism.
+
 
 
 == Mill Chrome Profiles


### PR DESCRIPTION
Mostly adding cross-references to relevant builtin commands and out-dir files