### PR TITLE
Pass Mill source JARs to Bloop

### DIFF
--- a/contrib/bloop/src/mill/contrib/bloop/Bloop.scala
+++ b/contrib/bloop/src/mill/contrib/bloop/Bloop.scala
@@ -8,5 +8,6 @@ import mill.api.WorkspaceRoot
  */
 object Bloop extends BloopImpl(
       () => Evaluator.allBootstrapEvaluators.value.value,
-      WorkspaceRoot.workspaceRoot
+      WorkspaceRoot.workspaceRoot,
+      addMillSources = None
     )

--- a/contrib/bloop/test/src/mill/contrib/bloop/BloopTests.scala
+++ b/contrib/bloop/test/src/mill/contrib/bloop/BloopTests.scala
@@ -18,7 +18,11 @@ object BloopTests extends TestSuite {
 
   val unitTester = UnitTester(build, null)
   val workdir = unitTester.evaluator.rootModule.millSourcePath
-  val testBloop = new BloopImpl(() => Seq(unitTester.evaluator), workdir)
+  val testBloop = new BloopImpl(
+    () => Seq(unitTester.evaluator),
+    workdir,
+    addMillSources = None
+  )
 
   object build extends TestBaseModule {
     object scalaModule extends scalalib.ScalaModule with testBloop.Module {

--- a/developer.adoc
+++ b/developer.adoc
@@ -168,7 +168,7 @@ To test bootstrapping of Mill's own Mill build using a version of Mill built fro
 ci/patch-mill-bootstrap.sh
 ----
 
-This creates a standalone assembly at `target/mill-release` you can use, which references jars
+This creates a standalone assembly at `mill-assembly.jar` you can use, which references jars
 published locally in your `~/.ivy2/local` cache, and applies any necessary patches to
 `build.mill` to deal with changes in Mill between the version specified in `.config/mill-version`
 that is normally used to build Mill and the `HEAD` version your assembly was created from.

--- a/integration/ide/bloop/src/BloopTests.scala
+++ b/integration/ide/bloop/src/BloopTests.scala
@@ -25,6 +25,23 @@ object BloopTests extends UtestIntegrationTestSuite {
         assert(config("project")("sources").arr.exists(path =>
           os.Path(path.str).last == "build.mill"
         ))
+
+        if (isPackagedLauncher) {
+          val modules = config("project")("resolution")("modules").arr
+
+          def sourceJars(org: String, namePrefix: String) = modules
+            .filter(mod => mod("organization").str == org && mod("name").str.startsWith(namePrefix))
+            .flatMap(_("artifacts").arr)
+            .filter(_("classifier").strOpt.contains("sources"))
+            .flatMap(_("path").strOpt)
+            .filter(_.endsWith("-sources.jar"))
+            .distinct
+
+          val millScalaLibSourceJars = sourceJars("com.lihaoyi", "mill-scalalib_")
+          assert(millScalaLibSourceJars.nonEmpty)
+          val coursierCacheSourceJars = sourceJars("io.get-coursier", "coursier-cache_")
+          assert(coursierCacheSourceJars.nonEmpty)
+        }
       }
     }
   }

--- a/integration/ide/bloop/src/BloopTests.scala
+++ b/integration/ide/bloop/src/BloopTests.scala
@@ -15,13 +15,6 @@ object BloopTests extends UtestIntegrationTestSuite {
         assert(installResult)
         assert(os.exists(workspacePath / ".bloop/root-module.json"))
       }
-      test("mill-build module bloop config should be created") - integrationTest { tester =>
-        import tester._
-        val installResult: Boolean = eval("mill.contrib.bloop.Bloop/install").isSuccess
-        val millBuildJsonFile = workspacePath / ".bloop/mill-build-.json"
-        assert(installResult)
-        assert(os.exists(millBuildJsonFile))
-      }
 
       test("mill-build config should contain build.mill source") - integrationTest { tester =>
         import tester._

--- a/integration/ide/bloop/src/BloopTests.scala
+++ b/integration/ide/bloop/src/BloopTests.scala
@@ -37,8 +37,10 @@ object BloopTests extends UtestIntegrationTestSuite {
             .filter(_.endsWith("-sources.jar"))
             .distinct
 
+          // Look for one of Mill's own source JARs
           val millScalaLibSourceJars = sourceJars("com.lihaoyi", "mill-scalalib_")
           assert(millScalaLibSourceJars.nonEmpty)
+          // Look for a source JAR of a dependency
           val coursierCacheSourceJars = sourceJars("io.get-coursier", "coursier-cache_")
           assert(coursierCacheSourceJars.nonEmpty)
         }

--- a/integration/package.mill
+++ b/integration/package.mill
@@ -49,12 +49,14 @@ object `package` extends RootModule {
           IntegrationTestModule.this.forkEnv() ++
           Map(
             "MILL_INTEGRATION_SERVER_MODE" -> (mode == "local" || mode == "server").toString,
+            "MILL_INTEGRATION_IS_PACKAGED_LAUNCHER" -> millIntegrationIsPackagedLauncher().toString,
             "MILL_LAUNCHER" -> build.dist.bootstrapLauncher().path.toString,
             "MILL_LAUNCHER_BAT" -> build.dist.bootstrapLauncherBat().path.toString,
             "MILL_INTEGRATION_LAUNCHER" -> millIntegrationLauncher().path.toString
           )
 
       def millIntegrationLauncher: T[PathRef]
+      def millIntegrationIsPackagedLauncher: Task[Boolean]
 
       def forkArgs = Task { super.forkArgs() ++ build.dist.forkArgs() }
 
@@ -72,20 +74,26 @@ object `package` extends RootModule {
 
     object local extends IntegrationLauncherModule {
       def millIntegrationLauncher = build.dist.launcher()
+      def millIntegrationIsPackagedLauncher = Task(false)
     }
     object packaged extends IntegrationLauncherModule {
       def millIntegrationLauncher = build.dist.executable()
+      def millIntegrationIsPackagedLauncher = Task(true)
     }
     object native extends IntegrationLauncherModule {
       def millIntegrationLauncher = build.dist.native.executable()
+      def millIntegrationIsPackagedLauncher = Task(true)
     }
     trait IntegrationLauncherModule extends Module {
       def millIntegrationLauncher: T[PathRef]
+      def millIntegrationIsPackagedLauncher: Task[Boolean]
       object fork extends ModeModule {
         def millIntegrationLauncher = IntegrationLauncherModule.this.millIntegrationLauncher
+        def millIntegrationIsPackagedLauncher = IntegrationLauncherModule.this.millIntegrationIsPackagedLauncher
       }
       object server extends ModeModule {
         def millIntegrationLauncher = IntegrationLauncherModule.this.millIntegrationLauncher
+        def millIntegrationIsPackagedLauncher = IntegrationLauncherModule.this.millIntegrationIsPackagedLauncher
       }
     }
   }

--- a/integration/package.mill
+++ b/integration/package.mill
@@ -56,6 +56,7 @@ object `package` extends RootModule {
           )
 
       def millIntegrationLauncher: T[PathRef]
+      /** Whether the Mill JARs are published locally alongside this Mill launcher */
       def millIntegrationIsPackagedLauncher: Task[Boolean]
 
       def forkArgs = Task { super.forkArgs() ++ build.dist.forkArgs() }

--- a/integration/package.mill
+++ b/integration/package.mill
@@ -56,6 +56,7 @@ object `package` extends RootModule {
           )
 
       def millIntegrationLauncher: T[PathRef]
+
       /** Whether the Mill JARs are published locally alongside this Mill launcher */
       def millIntegrationIsPackagedLauncher: Task[Boolean]
 
@@ -90,11 +91,13 @@ object `package` extends RootModule {
       def millIntegrationIsPackagedLauncher: Task[Boolean]
       object fork extends ModeModule {
         def millIntegrationLauncher = IntegrationLauncherModule.this.millIntegrationLauncher
-        def millIntegrationIsPackagedLauncher = IntegrationLauncherModule.this.millIntegrationIsPackagedLauncher
+        def millIntegrationIsPackagedLauncher =
+          IntegrationLauncherModule.this.millIntegrationIsPackagedLauncher
       }
       object server extends ModeModule {
         def millIntegrationLauncher = IntegrationLauncherModule.this.millIntegrationLauncher
-        def millIntegrationIsPackagedLauncher = IntegrationLauncherModule.this.millIntegrationIsPackagedLauncher
+        def millIntegrationIsPackagedLauncher =
+          IntegrationLauncherModule.this.millIntegrationIsPackagedLauncher
       }
     }
   }

--- a/main/package.mill
+++ b/main/package.mill
@@ -62,7 +62,10 @@ object `package` extends RootModule with build.MillStableScalaModule with BuildI
         ) { mod =>
           Task.Anon {
             val selfDep = mod.publishSelfDependency()
-            (mod.coursierDependency.module.repr, s"${selfDep.group}:${selfDep.id}")
+            (
+              s"${mod.coursierDependency.module.repr}:${mod.coursierDependency.version}",
+              s"${selfDep.group}:${selfDep.id}:${selfDep.version}"
+            )
           }
         }().toMap
 
@@ -75,7 +78,7 @@ object `package` extends RootModule with build.MillStableScalaModule with BuildI
           dist.coursierCacheCustomizer()
         )
         result.getOrThrow.orderedDependencies
-          .map(_.module.repr)
+          .map(dep => s"${dep.module.repr}:${dep.version}")
           .distinct
           .map(mod => internalToPublishedModuleMap.getOrElse(mod, mod))
           .mkString(",")

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -226,8 +226,8 @@ abstract class MillBuildRootModule()(implicit
       .split(',')
       .filter(_.nonEmpty)
       .map { str =>
-        str.split(":", 2) match {
-          case Array(org, name) => (org, name)
+        str.split(":", 3) match {
+          case Array(org, name, _) => (org, name)
           case other =>
             sys.error(
               s"Unexpected misshapen entry in BuildInfo.millEmbeddedDeps ('$str', expected 'org:name')"

--- a/scalalib/src/mill/scalalib/CoursierModule.scala
+++ b/scalalib/src/mill/scalalib/CoursierModule.scala
@@ -11,6 +11,7 @@ import scala.annotation.nowarn
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import mill.Agg
+import mill.util.Jvm
 
 /**
  * This module provides the capability to resolve (transitive) dependencies from (remote) repositories.
@@ -379,6 +380,28 @@ object CoursierModule {
       ).getOrThrow
 
       res.orderedDependencies
+    }
+
+    def getArtifacts[T: CoursierModule.Resolvable](
+        deps: IterableOnce[T],
+        sources: Boolean = false,
+        mapDependencies: Option[Dependency => Dependency] = None,
+        customizer: Option[Resolution => Resolution] = None,
+        ctx: Option[mill.api.Ctx.Log] = None,
+        coursierCacheCustomizer: Option[FileCache[Task] => FileCache[Task]] = None,
+        artifactTypes: Option[Set[Type]] = None,
+        resolutionParams: ResolutionParams = ResolutionParams()
+    ): coursier.Artifacts.Result = {
+      val deps0 = deps
+        .iterator
+        .map(implicitly[CoursierModule.Resolvable[T]].bind(_, bind))
+        .toSeq
+      Jvm.getArtifacts(
+        repositories,
+        deps0.map(_.dep),
+        sources = sources,
+        ctx = ctx
+      ).getOrThrow
     }
   }
 

--- a/testkit/src/mill/testkit/UtestIntegrationTestSuite.scala
+++ b/testkit/src/mill/testkit/UtestIntegrationTestSuite.scala
@@ -7,6 +7,8 @@ import scala.concurrent.{ExecutionContext, Future}
 abstract class UtestIntegrationTestSuite extends utest.TestSuite with IntegrationTestSuite {
   protected def workspaceSourcePath: os.Path = os.Path(sys.env("MILL_TEST_RESOURCE_DIR"))
   protected def clientServerMode: Boolean = sys.env("MILL_INTEGRATION_SERVER_MODE").toBoolean
+
+  /** Whether the Mill JARs are published locally alongside this Mill launcher */
   protected def isPackagedLauncher: Boolean =
     sys.env("MILL_INTEGRATION_IS_PACKAGED_LAUNCHER").toBoolean
   protected def millExecutable: os.Path =

--- a/testkit/src/mill/testkit/UtestIntegrationTestSuite.scala
+++ b/testkit/src/mill/testkit/UtestIntegrationTestSuite.scala
@@ -7,6 +7,8 @@ import scala.concurrent.{ExecutionContext, Future}
 abstract class UtestIntegrationTestSuite extends utest.TestSuite with IntegrationTestSuite {
   protected def workspaceSourcePath: os.Path = os.Path(sys.env("MILL_TEST_RESOURCE_DIR"))
   protected def clientServerMode: Boolean = sys.env("MILL_INTEGRATION_SERVER_MODE").toBoolean
+  protected def isPackagedLauncher: Boolean =
+    sys.env("MILL_INTEGRATION_IS_PACKAGED_LAUNCHER").toBoolean
   protected def millExecutable: os.Path =
     os.Path(System.getenv("MILL_INTEGRATION_LAUNCHER"), os.pwd)
 


### PR DESCRIPTION
The goal of this PR is to pass source JARs corresponding to the Mill class path to Bloop. These are added in the root modules, where they're needed to get go-to-source to work for Mill build files.