### PR TITLE
Added module docs for selective execution

### DIFF
--- a/example/large/selective/9-selective-execution/build.mill
+++ b/example/large/selective/9-selective-execution/build.mill
@@ -10,11 +10,11 @@
 //
 // * `mill selective.run <selector>`: run on the codebase after the code change,
 // runs tasks in the given `<selector>` which are affected by the code changes
-// that have happen since `selective.prepare` was run
+// that have happened since `selective.prepare` was run
 //
 // * `mill selective.resolve <selector>`: a dry-run version of `selective.run`, prints
 // out the tasks in `<selector>` that are affected by the code changes and would have
-// run, without actually tunning them.
+// run, without actually running them.
 //
 // For example, if you want to run all tests related to the code changes in a pull
 // request branch, you can do that as follows:

--- a/libs/main/src/mill/main/MainModule.scala
+++ b/libs/main/src/mill/main/MainModule.scala
@@ -323,7 +323,25 @@ trait MainModule extends BaseModule with MainModuleApi {
 
   /**
    * Commands related to selective execution, where Mill runs tasks selectively
-   * depending on what task inputs or implementations changed
+   * depending on what task inputs or implementations changed.
+   *
+   * Read more about it at: https://mill-build.org/mill/large/selective-execution.html
+   *
+   * Here are the essential commands:
+   *
+   * - `mill selective.prepare <selector>`:
+   *   run on the codebase before the code change,
+   *   stores a snapshot of task inputs and implementations
+   *
+   * - `mill selective.run <selector>`:
+   *   run on the codebase after the code change,
+   *   runs tasks in the given `<selector>` which are affected by the code changes
+   *   that have happened since `selective.prepare` was run
+   *
+   * - `mill selective.resolve <selector>`:
+   *   a dry-run version of `selective.run`,
+   *   prints out the tasks in `<selector>`` that are affected by the code changes
+   *   and would have run, without actually running them.
    */
   lazy val selective: SelectiveExecutionModule = new SelectiveExecutionModule {}
 

--- a/libs/main/src/mill/main/MainModule.scala
+++ b/libs/main/src/mill/main/MainModule.scala
@@ -340,7 +340,7 @@ trait MainModule extends BaseModule with MainModuleApi {
    *
    * - `mill selective.resolve <selector>`:
    *   a dry-run version of `selective.run`,
-   *   prints out the tasks in `<selector>`` that are affected by the code changes
+   *   prints out the tasks in `<selector>` that are affected by the code changes
    *   and would have run, without actually running them.
    */
   lazy val selective: SelectiveExecutionModule = new SelectiveExecutionModule {}

--- a/libs/main/src/mill/main/SelectiveExecutionModule.scala
+++ b/libs/main/src/mill/main/SelectiveExecutionModule.scala
@@ -5,6 +5,27 @@ import mill.constants.OutFiles
 import mill.define.{Command, Evaluator, Task}
 import mill.define.SelectMode
 
+/**
+ * Mill Module to support selective test execution in large projects.
+ *
+ * Read more about it at: https://mill-build.org/mill/large/selective-execution.html
+ *
+ * Here are the essential commands:
+ *
+ * - `mill selective.prepare <selector>`:
+ *   run on the codebase before the code change,
+ *   stores a snapshot of task inputs and implementations
+ *
+ * - `mill selective.run <selector>`:
+ *   run on the codebase after the code change,
+ *   runs tasks in the given `<selector>` which are affected by the code changes
+ *   that have happened since `selective.prepare` was run
+ *
+ * - `mill selective.resolve <selector>`:
+ *   a dry-run version of `selective.run`,
+ *   prints out the tasks in `<selector>`` that are affected by the code changes
+ *   and would have run, without actually running them.
+ */
 trait SelectiveExecutionModule extends mill.define.Module {
 
   /**


### PR DESCRIPTION
The hope is, to have some meaningfull `mill inspect selective` output, but it seems, inspect does not output the Scaladoc for modules yet.

Fixed some typos along the way.
