### PR TITLE
Rename `methodCodeHashSignatures` to `codeSignatures`

### DIFF
--- a/.github/actions/post-build-selective/action.yml
+++ b/.github/actions/post-build-selective/action.yml
@@ -26,7 +26,7 @@ runs:
 
     # This generates a lot of logs and slows down the github actions UI like crazy, 
     # so only uncomment it when really necessary
-    #- run: cat out/mill-build/methodCodeHashSignatures.dest/current/spanningInvalidationTree.json
+    #- run: cat out/mill-build/codeSignatures.dest/current/spanningInvalidationTree.json
     #  shell: bash
 
     - run: ./mill -i -k selective.resolveTree ${{ inputs.millargs }}

--- a/core/exec/src/mill/exec/CodeSigUtils.scala
+++ b/core/exec/src/mill/exec/CodeSigUtils.scala
@@ -47,9 +47,9 @@ private[mill] object CodeSigUtils {
     (classToTransitiveClasses, allTransitiveClassMethods)
   }
 
-  def constructorHashSignatures(methodCodeHashSignatures: Map[String, Int])
+  def constructorHashSignatures(codeSignatures: Map[String, Int])
       : Map[String, Seq[(String, Int)]] =
-    methodCodeHashSignatures
+    codeSignatures
       .toSeq
       .collect { case (method @ s"$prefix#<init>($args)void", hash) => (prefix, method, hash) }
       .groupMap(_._1)(t => (t._2, t._3))
@@ -58,7 +58,7 @@ private[mill] object CodeSigUtils {
       namedTask: => NamedTask[?],
       classToTransitiveClasses: => Map[Class[?], IndexedSeq[Class[?]]],
       allTransitiveClassMethods: => Map[Class[?], Map[String, java.lang.reflect.Method]],
-      methodCodeHashSignatures: => Map[String, Int],
+      codeSignatures: => Map[String, Int],
       constructorHashSignatures: => Map[String, Seq[(String, Int)]]
   ): Iterable[Int] = {
 
@@ -114,8 +114,8 @@ private[mill] object CodeSigUtils {
         }
       )
 
-    methodCodeHashSignatures.get(expectedName) ++
-      methodCodeHashSignatures.get(expectedName2) ++
+    codeSignatures.get(expectedName) ++
+      codeSignatures.get(expectedName2) ++
       constructorHashes
   }
 }

--- a/core/exec/src/mill/exec/Execution.scala
+++ b/core/exec/src/mill/exec/Execution.scala
@@ -29,7 +29,7 @@ private[mill] case class Execution(
     env: Map[String, String],
     failFast: Boolean,
     threadCount: Option[Int],
-    methodCodeHashSignatures: Map[String, Int],
+    codeSignatures: Map[String, Int],
     systemExit: Int => Nothing,
     exclusiveSystemStreams: SystemStreams
 ) extends GroupExecution with AutoCloseable {

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -28,12 +28,12 @@ private trait GroupExecution {
   def env: Map[String, String]
   def failFast: Boolean
   def threadCount: Option[Int]
-  def methodCodeHashSignatures: Map[String, Int]
+  def codeSignatures: Map[String, Int]
   def systemExit: Int => Nothing
   def exclusiveSystemStreams: SystemStreams
 
   lazy val constructorHashSignatures: Map[String, Seq[(String, Int)]] =
-    CodeSigUtils.constructorHashSignatures(methodCodeHashSignatures)
+    CodeSigUtils.constructorHashSignatures(codeSignatures)
 
   val effectiveThreadCount: Int =
     this.threadCount.getOrElse(Runtime.getRuntime().availableProcessors())
@@ -69,7 +69,7 @@ private trait GroupExecution {
               namedTask,
               classToTransitiveClasses,
               allTransitiveClassMethods,
-              methodCodeHashSignatures,
+              codeSignatures,
               constructorHashSignatures
             )
           }

--- a/core/src/mill/eval/Evaluator.scala
+++ b/core/src/mill/eval/Evaluator.scala
@@ -39,7 +39,7 @@ final class Evaluator private[mill] (
   private[mill] def workspace = execution.workspace
   private[mill] def baseLogger = execution.baseLogger
   private[mill] def outPath = execution.outPath
-  private[mill] def methodCodeHashSignatures = execution.methodCodeHashSignatures
+  private[mill] def codeSignatures = execution.codeSignatures
   private[mill] def rootModule = execution.rootModule
   private[mill] def workerCache = execution.workerCache
   private[mill] def env = execution.env
@@ -175,7 +175,7 @@ final class Evaluator private[mill] (
         if (selectiveExecutionEnabled) {
           SelectiveExecution.saveMetadata(
             this,
-            SelectiveExecution.Metadata(allInputHashes, methodCodeHashSignatures)
+            SelectiveExecution.Metadata(allInputHashes, codeSignatures)
           )
         }
 

--- a/example/fundamentals/out-dir/1-out-files/build.mill
+++ b/example/fundamentals/out-dir/1-out-files/build.mill
@@ -228,12 +228,12 @@ out/mill-server
 // Again, if there are multiple paths through which one task was invalidated by another,
 // one path is chosen arbitrarily to be shown in the spanning tree
 //
-// === `methodCodeHashSignatures spanningInvalidationTree`
+// === `codeSignatures spanningInvalidationTree`
 //
 // Sometimes invalidation can be caused by a code change in your `build.mill`/`package.mill`
 // files, rather than by a change in the project's source files or inputs. In such cases,
 // the root tasks in `mill-invalidation-tree.json` may not necessarily be inputs. In such
-// cases, you can look at `out/mill-build/methodCodeHashSignatures.dest/current/spanningInvalidationTree.json`
+// cases, you can look at `out/mill-build/codeSignatures.dest/current/spanningInvalidationTree.json`
 // to see an invalidation tree for how code changes in specfic methods propagate throughout
 // the `build.mill` codebase.
 
@@ -243,7 +243,7 @@ out/mill-server
 
 > ./mill foo.compile # compile after changing build.mill
 
-> cat out/mill-build/methodCodeHashSignatures.dest/current/spanningInvalidationTree.json
+> cat out/mill-build/codeSignatures.dest/current/spanningInvalidationTree.json
 {
 ...
     "def build_.package_$foo$#<init>(build_.package_)void": {

--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -169,7 +169,7 @@ class MillBuildBootstrap(
 
         Using.resource(makeEvaluator(
           prevFrameOpt.map(_.workerCache).getOrElse(Map.empty),
-          nestedState.frames.headOption.map(_.methodCodeHashSignatures).getOrElse(Map.empty),
+          nestedState.frames.headOption.map(_.codeSignatures).getOrElse(Map.empty),
           rootModule,
           // We want to use the grandparent buildHash, rather than the parent
           // buildHash, because the parent build changes are instead detected
@@ -228,7 +228,7 @@ class MillBuildBootstrap(
     evaluateWithWatches(
       rootModule,
       evaluator,
-      Seq("{runClasspath,compile,methodCodeHashSignatures}"),
+      Seq("{runClasspath,compile,codeSignatures}"),
       selectiveExecution = false
     ) match {
       case (Result.Failure(error), evalWatches, moduleWatches) =>
@@ -249,7 +249,7 @@ class MillBuildBootstrap(
             Result.Success(Seq(
               runClasspath: Seq[PathRef],
               compile: mill.scalalib.api.CompilationResult,
-              methodCodeHashSignatures: Map[String, Int]
+              codeSignatures: Map[String, Int]
             )),
             evalWatches,
             moduleWatches
@@ -286,7 +286,7 @@ class MillBuildBootstrap(
           evaluator.workerCache.toMap,
           evalWatches,
           moduleWatches,
-          methodCodeHashSignatures,
+          codeSignatures,
           Some(classLoader),
           runClasspath,
           Some(compile.classes),
@@ -333,7 +333,7 @@ class MillBuildBootstrap(
 
   def makeEvaluator(
       workerCache: Map[Segments, (Int, Val)],
-      methodCodeHashSignatures: Map[String, Int],
+      codeSignatures: Map[String, Int],
       rootModule: BaseModule,
       millClassloaderSigHash: Int,
       millClassloaderIdentityHash: Int,
@@ -369,7 +369,7 @@ class MillBuildBootstrap(
         env = env,
         failFast = !keepGoing,
         threadCount = threadCount,
-        methodCodeHashSignatures = methodCodeHashSignatures,
+        codeSignatures = codeSignatures,
         systemExit = systemExit,
         exclusiveSystemStreams = streams0
       )

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -138,7 +138,7 @@ abstract class MillBuildRootModule()(implicit
     }
   }
 
-  def methodCodeHashSignatures: T[Map[String, Int]] = Task(persistent = true) {
+  def codeSignatures: T[Map[String, Int]] = Task(persistent = true) {
     os.remove.all(Task.dest / "previous")
     if (os.exists(Task.dest / "current"))
       os.move.over(Task.dest / "current", Task.dest / "previous")

--- a/runner/src/mill/runner/RunnerState.scala
+++ b/runner/src/mill/runner/RunnerState.scala
@@ -58,7 +58,7 @@ object RunnerState {
       workerCache: Map[Segments, (Int, Val)],
       evalWatched: Seq[Watchable],
       moduleWatched: Seq[Watchable],
-      methodCodeHashSignatures: Map[String, Int],
+      codeSignatures: Map[String, Int],
       classLoaderOpt: Option[RunnerState.URLClassLoader],
       runClasspath: Seq[PathRef],
       compileOutput: Option[PathRef],

--- a/testkit/src/mill/testkit/UnitTester.scala
+++ b/testkit/src/mill/testkit/UnitTester.scala
@@ -103,7 +103,7 @@ class UnitTester(
     env = env,
     failFast = failFast,
     threadCount = threads,
-    methodCodeHashSignatures = Map(),
+    codeSignatures = Map(),
     systemExit = _ => ???,
     exclusiveSystemStreams = new SystemStreams(outStream, errStream, inStream)
   )

--- a/website/docs/modules/ROOT/pages/depth/caching.adoc
+++ b/website/docs/modules/ROOT/pages/depth/caching.adoc
@@ -71,7 +71,7 @@ this file groups together the un-cached files in a tree structure according to t
 task dependencies. It is useful to find the "root" uncached tasks, which are the cause
 of downstream tasks having their caches invalidated.
 
-* xref:fundamentals/out-dir.adoc#_methodcodehashsignatures_spanninginvalidationtree[methodCodeHashSignatures spanningInvalidationTree]:
+* xref:fundamentals/out-dir.adoc#_codeSignatures_spanninginvalidationtree[codeSignatures spanningInvalidationTree]:
 this file contains information about tasks whose caches were invalidated due to
 __code changes in the `build.mill` or `package.mill` files__, and again shows a tree
 of invalidated method signatures organized into a tree using their call graph dependenceis.


### PR DESCRIPTION
This simplifies the name and brings it inline with the internal terminology of the `codesig` module