### PR TITLE
Add a `sourceGenerators` task to help out IDE config generation

### DIFF
--- a/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -232,6 +232,7 @@ private class MillBuildServer(
       targetIds = _ => sourcesParams.getTargets.asScala.toSeq,
       tasks = {
         case module: MillBuildRootModule =>
+          // TODO
           Task.Anon {
             module.sources().map(p => sourceItem(p.path, false)) ++
               module.generatedSources().map(p => sourceItem(p.path, true))

--- a/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -232,15 +232,16 @@ private class MillBuildServer(
       targetIds = _ => sourcesParams.getTargets.asScala.toSeq,
       tasks = {
         case module: MillBuildRootModule =>
-          // TODO
           Task.Anon {
             module.sources().map(p => sourceItem(p.path, false)) ++
-              module.generatedSources().map(p => sourceItem(p.path, true))
+              module.generatedSources().map(p => sourceItem(p.path, true)) ++
+              module.predictedGeneratedSourceRoots().map(p => sourceItem(p.path, true))
           }
         case module: JavaModule =>
           Task.Anon {
             module.sources().map(p => sourceItem(p.path, false)) ++
-              module.generatedSources().map(p => sourceItem(p.path, true))
+              module.generatedSources().map(p => sourceItem(p.path, true)) ++
+              module.predictedGeneratedSourceRoots().map(p => sourceItem(p.path, true))
           }
       }
     ) {

--- a/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -235,13 +235,13 @@ private class MillBuildServer(
           Task.Anon {
             module.sources().map(p => sourceItem(p.path, false)) ++
               module.generatedSources().map(p => sourceItem(p.path, true)) ++
-              module.predictedGeneratedSourceRoots().map(p => sourceItem(p.path, true))
+              module.predictedGeneratedSources().map(p => sourceItem(p.path, true))
           }
         case module: JavaModule =>
           Task.Anon {
             module.sources().map(p => sourceItem(p.path, false)) ++
               module.generatedSources().map(p => sourceItem(p.path, true)) ++
-              module.predictedGeneratedSourceRoots().map(p => sourceItem(p.path, true))
+              module.predictedGeneratedSources().map(p => sourceItem(p.path, true))
           }
       }
     ) {

--- a/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -235,7 +235,7 @@ private class MillBuildServer(
           Task.Anon {
             module.sources().map(p => sourceItem(p.path, false)) ++
               module.generatedSources().map(p => sourceItem(p.path, true)) ++
-              module.predictedGeneratedSources().map(p => sourceItem(p.path, true))
+              module.predictedGeneratedSources().map(p => sourceItem(p, true))
           }
         case module: JavaModule =>
           Task.Anon {

--- a/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -14,7 +14,7 @@ import mill.eval.Evaluator.TaskResult
 import mill.main.MainModule
 import mill.runner.MillBuildRootModule
 import mill.scalalib.bsp.{BspModule, JvmBuildTarget, ScalaBuildTarget}
-import mill.scalalib.{JavaModule, SemanticDbJavaModule, TestModule}
+import mill.scalalib.{JavaModule, DeferredGeneratedSourcesModule, SemanticDbJavaModule, TestModule}
 import mill.util.ColorLogger
 import mill.given
 
@@ -231,7 +231,7 @@ private class MillBuildServer(
       hint = s"buildTargetSources ${sourcesParams}",
       targetIds = _ => sourcesParams.getTargets.asScala.toSeq,
       tasks = {
-        case module: MillBuildRootModule =>
+        case module: DeferredGeneratedSourcesModule =>
           Task.Anon {
             module.sources().map(p => sourceItem(p.path, false)) ++
               module.generatedSources().map(p => sourceItem(p.path, true)) ++
@@ -240,8 +240,7 @@ private class MillBuildServer(
         case module: JavaModule =>
           Task.Anon {
             module.sources().map(p => sourceItem(p.path, false)) ++
-              module.generatedSources().map(p => sourceItem(p.path, true)) ++
-              module.predictedGeneratedSources().map(p => sourceItem(p.path, true))
+              module.generatedSources().map(p => sourceItem(p.path, true))
           }
       }
     ) {

--- a/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
+++ b/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
@@ -116,19 +116,15 @@ class BloopImpl(evs: () => Seq[Evaluator], wd: os.Path) extends ExternalModule {
     JavaModuleUtils.transitiveModules(mod, accept)
   }
 
-  private def modulesToOutFolderMap: Map[JavaModule, os.Path] = {
+  protected def computeModules: Seq[JavaModule] = {
     val evals = evs()
     evals.flatMap { eval =>
       if (eval != null)
         JavaModuleUtils.transitiveModules(eval.rootModule, accept)
-          .collect { case jm: JavaModule => (jm, eval.outPath) }
+          .collect { case jm: JavaModule => jm }
       else
         Seq.empty
-    }.toMap
-  }
-
-  protected def computeModules: Seq[JavaModule] = {
-    modulesToOutFolderMap.keys.toSeq
+    }
   }
 
   // class-based pattern matching against path-dependant types doesn't seem to work.

--- a/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
+++ b/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
@@ -437,7 +437,7 @@ class BloopImpl(evs: () => Seq[Evaluator], wd: os.Path) extends ExternalModule {
         .map(_.toNIO)
         .toList
 
-      val mAllSources = mSources ++ mGeneratedSourceRoots
+      mSources ++ mGeneratedSourceRoots
 
       val tags =
         module match { case _: TestModule => List(BloopTag.Test); case _ => List(BloopTag.Library) }

--- a/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
+++ b/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
@@ -143,11 +143,11 @@ class BloopImpl(evs: () => Seq[Evaluator], wd: os.Path) extends ExternalModule {
       case m: DeferredGeneratedSourcesModule =>
         // We're not using `allSources` here, one purpose. See https://github.com/com-lihaoyi/mill/discussions/4530
         m.ideSources.map { paths =>
-          name(m) -> paths.map(_.path)
+          name(m) -> paths
         }
       case other =>
-        other.allSources.map { paths =>
-          name(other) -> paths.map(_.path)
+        other.allSources.map { pathRefs =>
+          name(other) -> pathRefs.map(_.path)
         }
     }()
     Result.Success(sources.toMap)

--- a/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
+++ b/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
@@ -139,11 +139,16 @@ class BloopImpl(evs: () => Seq[Evaluator], wd: os.Path) extends ExternalModule {
    * from module#sources in bloopInstall
    */
   def moduleSourceMap = Task.Input {
-    val sources = Task.traverse(computeModules) { m =>
-      // We're not using `allSources` here, one purpose. See https://github.com/com-lihaoyi/mill/discussions/4530
-      m.ideSources.map { paths =>
-        name(m) -> paths.map(_.path)
-      }
+    val sources = Task.traverse(computeModules) {
+      case m: DeferredGeneratedSourcesModule =>
+        // We're not using `allSources` here, one purpose. See https://github.com/com-lihaoyi/mill/discussions/4530
+        m.ideSources.map { paths =>
+          name(m) -> paths.map(_.path)
+        }
+      case other =>
+        other.allSources.map { paths =>
+          name(other) -> paths.map(_.path)
+        }
     }()
     Result.Success(sources.toMap)
   }

--- a/contrib/bloop/test/src/mill/contrib/bloop/BloopTests.scala
+++ b/contrib/bloop/test/src/mill/contrib/bloop/BloopTests.scala
@@ -41,7 +41,7 @@ object BloopTests extends TestSuite {
         ivy"org.postgresql:postgresql:42.3.3"
       )
 
-      def someGeneratedSource = Task(generatedSourceRoots = Seq(os.SubPath("scala"))) {
+      def someGeneratedSource = Task(deferredGeneratedSourceRoots = Seq(os.SubPath("scala"))) {
         val contents = """|package foo
                           |
                           |case class GeneratedFoo()
@@ -58,7 +58,7 @@ object BloopTests extends TestSuite {
         crash()
       }
 
-      def sourceGenerators = List(someGeneratedSource, someBuggyGeneratedSource)
+      def deferredGeneratedSourceTasks = List(someGeneratedSource, someBuggyGeneratedSource)
 
       object test extends ScalaTests with TestModule.Utest
     }
@@ -149,7 +149,7 @@ object BloopTests extends TestSuite {
           workdir / "scalaModule/src",
           unitTester.outPath / "scalaModule" / "someGeneratedSource.dest" / "scala",
           // Despite the task being buggy, the Bloop configuration is still produced.
-          // The task is not setting `generatedSourceRoots` explicitly, which is interpreted
+          // The task is not setting `deferredGeneratedSourceRoots` explicitly, which is interpreted
           // as the corresponding T.dest being the source root.
           unitTester.outPath / "scalaModule" / "someBuggyGeneratedSource.dest"
         ))

--- a/contrib/bloop/test/src/mill/contrib/bloop/BloopTests.scala
+++ b/contrib/bloop/test/src/mill/contrib/bloop/BloopTests.scala
@@ -20,8 +20,9 @@ object BloopTests extends TestSuite {
   val workdir = unitTester.evaluator.rootModule.millSourcePath
   val testBloop = new BloopImpl(() => Seq(unitTester.evaluator), workdir)
 
-  object build extends TestBaseModule with DeferredGeneratedSourcesModule {
-    object scalaModule extends scalalib.ScalaModule with testBloop.Module {
+  object build extends TestBaseModule {
+    object scalaModule extends scalalib.ScalaModule with testBloop.Module
+        with DeferredGeneratedSourcesModule {
       def scalaVersion = "2.12.8"
       val bloopVersion = mill.contrib.bloop.Versions.bloop
       override def mainClass = Some("foo.bar.Main")

--- a/contrib/bloop/test/src/mill/contrib/bloop/BloopTests.scala
+++ b/contrib/bloop/test/src/mill/contrib/bloop/BloopTests.scala
@@ -20,7 +20,7 @@ object BloopTests extends TestSuite {
   val workdir = unitTester.evaluator.rootModule.millSourcePath
   val testBloop = new BloopImpl(() => Seq(unitTester.evaluator), workdir)
 
-  object build extends TestBaseModule {
+  object build extends TestBaseModule with DeferredGeneratedSourcesModule {
     object scalaModule extends scalalib.ScalaModule with testBloop.Module {
       def scalaVersion = "2.12.8"
       val bloopVersion = mill.contrib.bloop.Versions.bloop
@@ -58,7 +58,8 @@ object BloopTests extends TestSuite {
         crash()
       }
 
-      def deferredGeneratedSourceTasks = List(someGeneratedSource, someBuggyGeneratedSource)
+      override def deferredGeneratedSourceTasks =
+        List(someGeneratedSource, someBuggyGeneratedSource)
 
       object test extends ScalaTests with TestModule.Utest
     }

--- a/example/fundamentals/out-dir/1-out-files/build.mill
+++ b/example/fundamentals/out-dir/1-out-files/build.mill
@@ -181,7 +181,8 @@ out/mill-server
     "foo.allSourceFiles": {
       "foo.allSources": {
         "foo.sources": {},
-        "foo.generatedSources": {}
+        "foo.generatedSources": {},
+        "foo.generatedSourceRoots": {}
       }
     },
     "foo.compileClasspath": {

--- a/example/fundamentals/out-dir/1-out-files/build.mill
+++ b/example/fundamentals/out-dir/1-out-files/build.mill
@@ -181,8 +181,7 @@ out/mill-server
     "foo.allSourceFiles": {
       "foo.allSources": {
         "foo.sources": {},
-        "foo.generatedSources": {},
-        "foo.deferredGeneratedSources": {}
+        "foo.generatedSources": {}
       }
     },
     "foo.compileClasspath": {

--- a/example/fundamentals/out-dir/1-out-files/build.mill
+++ b/example/fundamentals/out-dir/1-out-files/build.mill
@@ -182,7 +182,7 @@ out/mill-server
       "foo.allSources": {
         "foo.sources": {},
         "foo.generatedSources": {},
-        "foo.generatedSourceRoots": {}
+        "foo.deferredGeneratedSources": {}
       }
     },
     "foo.compileClasspath": {

--- a/idea/src/mill/idea/GenIdeaImpl.scala
+++ b/idea/src/mill/idea/GenIdeaImpl.scala
@@ -503,7 +503,7 @@ case class GenIdeaImpl(
         val Seq(
           resourcesPathRefs: Seq[PathRef],
           generatedSourcePathRefs: Seq[PathRef],
-          allSourcesPathRefs: Seq[PathRef]
+          ideSourcesPathRefs: Seq[PathRef]
         ) = evaluator.evalOrThrow(
           exceptionFactory = r =>
             GenIdeaException(
@@ -512,11 +512,13 @@ case class GenIdeaImpl(
         )(Seq(
           mod.resources,
           mod.generatedSources,
-          mod.allSources
+          // Using `ideSources` instead of `allSources` to prevent the whole process crashing
+          // in case of mis-configured (or buggy) source-generators.
+          mod.ideSources
         ))
 
         val generatedSourcePaths = generatedSourcePathRefs.map(_.path)
-        val normalSourcePaths = (allSourcesPathRefs
+        val normalSourcePaths = (ideSourcesPathRefs
           .map(_.path)
           .toSet -- generatedSourcePaths.toSet).toSeq
 

--- a/idea/src/mill/idea/GenIdeaImpl.scala
+++ b/idea/src/mill/idea/GenIdeaImpl.scala
@@ -500,6 +500,10 @@ case class GenIdeaImpl(
             evaluator,
             scalaVersion
           ) =>
+        val ideSources = mod match {
+          case deferred: DeferredGeneratedSourcesModule => deferred.ideSources
+          case other => other.allSources
+        }
         val Seq(
           resourcesPathRefs: Seq[PathRef],
           generatedSourcePathRefs: Seq[PathRef],
@@ -514,7 +518,7 @@ case class GenIdeaImpl(
           mod.generatedSources,
           // Using `ideSources` instead of `allSources` to prevent the whole process crashing
           // in case of mis-configured (or buggy) source-generators.
-          mod.ideSources
+          ideSources
         ))
 
         val generatedSourcePaths = generatedSourcePathRefs.map(_.path)

--- a/idea/src/mill/idea/GenIdeaImpl.scala
+++ b/idea/src/mill/idea/GenIdeaImpl.scala
@@ -502,12 +502,12 @@ case class GenIdeaImpl(
           ) =>
         val ideSources = mod match {
           case deferred: DeferredGeneratedSourcesModule => deferred.ideSources
-          case other => other.allSources
+          case other => other.allSources.map(_.map(_.path))
         }
         val Seq(
           resourcesPathRefs: Seq[PathRef],
           generatedSourcePathRefs: Seq[PathRef],
-          ideSourcesPathRefs: Seq[PathRef]
+          ideSourcesPaths: Seq[os.Path]
         ) = evaluator.evalOrThrow(
           exceptionFactory = r =>
             GenIdeaException(
@@ -522,9 +522,7 @@ case class GenIdeaImpl(
         ))
 
         val generatedSourcePaths = generatedSourcePathRefs.map(_.path)
-        val normalSourcePaths = (ideSourcesPathRefs
-          .map(_.path)
-          .toSet -- generatedSourcePaths.toSet).toSeq
+        val normalSourcePaths = (ideSourcesPaths.toSet -- generatedSourcePaths.toSet).toSeq
 
         val sanizedDeps: Seq[ScopedOrd[String]] = {
           resolvedDeps

--- a/integration/ide/bsp-server/resources/project/build.mill
+++ b/integration/ide/bsp-server/resources/project/build.mill
@@ -7,12 +7,36 @@ object `hello-java` extends scalalib.JavaModule
 
 // testing a simple Scala module
 object `hello-scala` extends scalalib.ScalaModule {
+
   def scalaVersion = Option(System.getenv("TEST_SCALA_2_13_VERSION")).getOrElse(???)
+
 }
 
 // testing a simple Kotlin module
 object `hello-kotlin` extends kotlinlib.KotlinModule {
   def kotlinVersion = Option(System.getenv("TEST_KOTLIN_VERSION")).getOrElse(???)
+}
+
+// testing a java module with source generators
+object `hello-sourcegen` extends scalalib.JavaModule {
+  def someGeneratedSource = Task(generatedSourceRoots = Seq(os.SubPath("java"))) {
+    val contents = """|package foo;
+                      |
+                      |class GeneratedFoo {
+                      |}
+                      |""".stripMargin
+    os.write(T.dest / "java" / "GeneratedFoo.java", contents)
+  }
+
+  /**
+   * We're adding a buggy task to check its generated source folders
+   * will be configured for Bloop even if the task crashes
+   */
+  def someBuggyGeneratedSource: T[Unit] = T {
+    def crash(): Unit = throw new Exception("Boom")
+    crash()
+  }
+  def sourceGenerators = List(someGeneratedSource, someBuggyGeneratedSource)
 }
 
 // testing a two-module setup, with one module depending on the other,

--- a/integration/ide/bsp-server/resources/project/build.mill
+++ b/integration/ide/bsp-server/resources/project/build.mill
@@ -30,7 +30,7 @@ object `hello-sourcegen` extends scalalib.JavaModule {
 
   /**
    * We're adding a buggy task to check its generated source folders
-   * will be configured for Bloop even if the task crashes
+   * will be configured for BSP even if the task crashes
    */
   def someBuggyGeneratedSource: T[Unit] = T {
     def crash(): Unit = throw new Exception("Boom")

--- a/integration/ide/bsp-server/resources/project/build.mill
+++ b/integration/ide/bsp-server/resources/project/build.mill
@@ -19,7 +19,7 @@ object `hello-kotlin` extends kotlinlib.KotlinModule {
 
 // testing a java module with source generators
 object `hello-sourcegen` extends scalalib.JavaModule {
-  def someGeneratedSource = Task(generatedSourceRoots = Seq(os.SubPath("java"))) {
+  def someGeneratedSource = Task(deferredGeneratedSourceRoots = Seq(os.SubPath("java"))) {
     val contents = """|package foo;
                       |
                       |class GeneratedFoo {
@@ -36,7 +36,7 @@ object `hello-sourcegen` extends scalalib.JavaModule {
     def crash(): Unit = throw new Exception("Boom")
     crash()
   }
-  def sourceGenerators = List(someGeneratedSource, someBuggyGeneratedSource)
+  override def deferredGeneratedSourceTasks = List(someGeneratedSource, someBuggyGeneratedSource)
 }
 
 // testing a two-module setup, with one module depending on the other,

--- a/integration/ide/bsp-server/resources/project/build.mill
+++ b/integration/ide/bsp-server/resources/project/build.mill
@@ -18,7 +18,7 @@ object `hello-kotlin` extends kotlinlib.KotlinModule {
 }
 
 // testing a java module with source generators
-object `hello-sourcegen` extends scalalib.JavaModule {
+object `hello-sourcegen` extends scalalib.DeferredGeneratedSourcesModule {
   def someGeneratedSource = Task(deferredGeneratedSourceRoots = Seq(os.SubPath("java"))) {
     val contents = """|package foo;
                       |

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-compile-classpaths.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-compile-classpaths.json
@@ -49,6 +49,14 @@
         "file:///coursier-cache/https/repo1.maven.org/maven2/org/scala-lang/scala-library/<scala-version>/scala-library-<scala-version>.jar",
         "file:///workspace/hello-scala/compile-resources"
       ]
+    },
+    {
+      "target": {
+        "uri": "file:///workspace/hello-sourcegen"
+      },
+      "classpath": [
+        "file:///workspace/hello-sourcegen/compile-resources"
+      ]
     }
   ]
 }

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-dependency-modules.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-dependency-modules.json
@@ -65,6 +65,12 @@
           "version": "<scala-version>"
         }
       ]
+    },
+    {
+      "target": {
+        "uri": "file:///workspace/hello-sourcegen"
+      },
+      "modules": []
     }
   ]
 }

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-dependency-sources.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-dependency-sources.json
@@ -41,6 +41,12 @@
       "sources": [
         "file:///coursier-cache/https/repo1.maven.org/maven2/org/scala-lang/scala-library/<scala-version>/scala-library-<scala-version>-sources.jar"
       ]
+    },
+    {
+      "target": {
+        "uri": "file:///workspace/hello-sourcegen"
+      },
+      "sources": []
     }
   ]
 }

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-javac-options.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-javac-options.json
@@ -59,6 +59,16 @@
         "file:///workspace/hello-scala/compile-resources"
       ],
       "classDirectory": "file:///workspace/out/hello-scala/compile.dest/classes"
+    },
+    {
+      "target": {
+        "uri": "file:///workspace/hello-sourcegen"
+      },
+      "options": [],
+      "classpath": [
+        "file:///workspace/hello-sourcegen/compile-resources"
+      ],
+      "classDirectory": "file:///workspace/out/hello-sourcegen/compile.dest/classes"
     }
   ]
 }

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-output-paths.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-output-paths.json
@@ -32,6 +32,12 @@
     },
     {
       "target": {
+        "uri": "file:///workspace/hello-sourcegen"
+      },
+      "outputPaths": []
+    },
+    {
+      "target": {
         "uri": "file:///workspace/mill-build"
       },
       "outputPaths": []

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-resources.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-resources.json
@@ -32,6 +32,12 @@
     },
     {
       "target": {
+        "uri": "file:///workspace/hello-sourcegen"
+      },
+      "resources": []
+    },
+    {
+      "target": {
         "uri": "file:///workspace/mill-build"
       },
       "resources": []

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-scalac-options.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-scalac-options.json
@@ -59,6 +59,16 @@
         "file:///workspace/hello-scala/compile-resources"
       ],
       "classDirectory": "file:///workspace/out/hello-scala/compile.dest/classes"
+    },
+    {
+      "target": {
+        "uri": "file:///workspace/hello-sourcegen"
+      },
+      "options": [],
+      "classpath": [
+        "file:///workspace/hello-sourcegen/compile-resources"
+      ],
+      "classDirectory": "file:///workspace/out/hello-sourcegen/compile.dest/classes"
     }
   ]
 }

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-sources.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-sources.json
@@ -62,6 +62,28 @@
     },
     {
       "target": {
+        "uri": "file:///workspace/hello-sourcegen"
+      },
+      "sources": [
+        {
+          "uri": "file:///workspace/hello-sourcegen/src",
+          "kind": 2,
+          "generated": false
+        },
+        {
+          "uri": "file:///workspace/out/hello-sourcegen/someGeneratedSource.dest/java",
+          "kind": 2,
+          "generated": true
+        },
+        {
+          "uri": "file:///workspace/out/hello-sourcegen/someBuggyGeneratedSource.dest",
+          "kind": 2,
+          "generated": true
+        }
+      ]
+    },
+    {
+      "target": {
         "uri": "file:///workspace/mill-build"
       },
       "sources": [

--- a/integration/ide/bsp-server/resources/snapshots/workspace-build-targets.json
+++ b/integration/ide/bsp-server/resources/snapshots/workspace-build-targets.json
@@ -152,6 +152,32 @@
     },
     {
       "id": {
+        "uri": "file:///workspace/hello-sourcegen"
+      },
+      "displayName": "hello-sourcegen",
+      "baseDirectory": "file:///workspace/hello-sourcegen",
+      "tags": [
+        "library",
+        "application"
+      ],
+      "languageIds": [
+        "java"
+      ],
+      "dependencies": [],
+      "capabilities": {
+        "canCompile": true,
+        "canTest": false,
+        "canRun": true,
+        "canDebug": false
+      },
+      "dataKind": "jvm",
+      "data": {
+        "javaHome": "java-home",
+        "javaVersion": "<java-version>"
+      }
+    },
+    {
+      "id": {
         "uri": "file:///workspace/mill-build"
       },
       "displayName": "mill-build/",

--- a/integration/ide/gen-idea/resources/hello-idea/build.mill
+++ b/integration/ide/gen-idea/resources/hello-idea/build.mill
@@ -28,6 +28,29 @@ object HelloIdea extends HelloIdeaModule {
   }
 }
 
+object HelloIdeaSourceGen extends scalalib.ScalaModule {
+  def scalaVersion = "2.12.5"
+
+  def someGeneratedSource = Task(generatedSourceRoots = Seq(os.SubPath("scala"))) {
+    val contents = """|package foo
+                      |
+                      |case class GeneratedFoo()
+                      |""".stripMargin
+    os.write(T.dest / "scala" / "GeneratedFoo.scala", contents)
+  }
+
+  /**
+   * We're adding a buggy task to check its generated source folders
+   * will be configured for Idea even if the task crashes
+   */
+  def someBuggyGeneratedSource: T[Unit] = T {
+    def crash(): Unit = throw new Exception("Boom")
+    crash()
+  }
+
+  def sourceGenerators = List(someGeneratedSource, someBuggyGeneratedSource)
+}
+
 object HiddenIdea extends HelloIdeaModule {
   override def skipIdea = true
 }

--- a/integration/ide/gen-idea/resources/hello-idea/build.mill
+++ b/integration/ide/gen-idea/resources/hello-idea/build.mill
@@ -3,7 +3,7 @@ import mill.api.Loose.Agg
 import mill.define.Target
 import mill._
 import mill.scalajslib.ScalaJSModule
-import mill.scalalib.{Dep, DepSyntax, JavaModule, TestModule}
+import mill.scalalib.{Dep, DepSyntax, DeferredGeneratedSourcesModule, JavaModule, TestModule}
 
 trait HelloIdeaModule extends scalalib.ScalaModule {
   def scalaVersion = "2.12.5"
@@ -28,7 +28,9 @@ object HelloIdea extends HelloIdeaModule {
   }
 }
 
-object HelloIdeaSourceGen extends scalalib.ScalaModule {
+object HelloIdeaSourceGen extends scalalib.ScalaModule
+    with scalalib.DeferredGeneratedSourcesModule {
+
   def scalaVersion = "2.12.5"
 
   def someGeneratedSource = Task(deferredGeneratedSourceRoots = Seq(os.SubPath("scala"))) {

--- a/integration/ide/gen-idea/resources/hello-idea/build.mill
+++ b/integration/ide/gen-idea/resources/hello-idea/build.mill
@@ -31,7 +31,7 @@ object HelloIdea extends HelloIdeaModule {
 object HelloIdeaSourceGen extends scalalib.ScalaModule {
   def scalaVersion = "2.12.5"
 
-  def someGeneratedSource = Task(generatedSourceRoots = Seq(os.SubPath("scala"))) {
+  def someGeneratedSource = Task(deferredGeneratedSourceRoots = Seq(os.SubPath("scala"))) {
     val contents = """|package foo
                       |
                       |case class GeneratedFoo()
@@ -48,7 +48,7 @@ object HelloIdeaSourceGen extends scalalib.ScalaModule {
     crash()
   }
 
-  def sourceGenerators = List(someGeneratedSource, someBuggyGeneratedSource)
+  override def deferredGeneratedSourceTasks = List(someGeneratedSource, someBuggyGeneratedSource)
 }
 
 object HiddenIdea extends HelloIdeaModule {

--- a/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/helloideasourcegen.iml
+++ b/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/helloideasourcegen.iml
@@ -1,0 +1,20 @@
+<module type="JAVA_MODULE" version="4">
+    <component name="NewModuleRootManager">
+        <output url="file://$MODULE_DIR$/../../out/HelloIdeaSourceGen/ideaCompileOutput.dest/classes"/>
+        <exclude-output/>
+        <content url="file://$MODULE_DIR$/../../out/HelloIdeaSourceGen/someBuggyGeneratedSource.dest">
+            <sourceFolder url="file://$MODULE_DIR$/../../out/HelloIdeaSourceGen/someBuggyGeneratedSource.dest" isTestSource="false"/>
+        </content>
+        <content url="file://$MODULE_DIR$/../../out/HelloIdeaSourceGen/someGeneratedSource.dest/scala">
+            <sourceFolder url="file://$MODULE_DIR$/../../out/HelloIdeaSourceGen/someGeneratedSource.dest/scala" isTestSource="false"/>
+        </content>
+        <content url="file://$MODULE_DIR$/../../HelloIdeaSourceGen">
+            <sourceFolder url="file://$MODULE_DIR$/../../HelloIdeaSourceGen/src" isTestSource="false"/>
+            <sourceFolder url="file://$MODULE_DIR$/../../HelloIdeaSourceGen/resources" type="java-resource"/>
+        </content>
+        <orderEntry type="inheritedJdk"/>
+        <orderEntry type="sourceFolder" forTests="false"/>
+        <orderEntry type="library" name="scala-SDK-2.12.5" level="project"/>
+        <orderEntry type="library" name="scala-library-2.12.5.jar" level="project"/>
+    </component>
+</module>

--- a/integration/ide/gen-idea/resources/hello-idea/idea/modules.xml
+++ b/integration/ide/gen-idea/resources/hello-idea/idea/modules.xml
@@ -7,6 +7,7 @@
             <module fileurl="file://$PROJECT_DIR$/.idea/mill_modules/helloidea.test.iml" filepath="$PROJECT_DIR$/.idea/mill_modules/helloidea.test.iml"/>
             <module fileurl="file://$PROJECT_DIR$/.idea/mill_modules/helloideajs.iml" filepath="$PROJECT_DIR$/.idea/mill_modules/helloideajs.iml"/>
             <module fileurl="file://$PROJECT_DIR$/.idea/mill_modules/helloideajs.test.iml" filepath="$PROJECT_DIR$/.idea/mill_modules/helloideajs.test.iml"/>
+            <module fileurl="file://$PROJECT_DIR$/.idea/mill_modules/helloideasourcegen.iml" filepath="$PROJECT_DIR$/.idea/mill_modules/helloideasourcegen.iml"/>
             <module fileurl="file://$PROJECT_DIR$/.idea/mill_modules/mill-build.iml" filepath="$PROJECT_DIR$/.idea/mill_modules/mill-build.iml"/>
             <module fileurl="file://$PROJECT_DIR$/.idea/mill_modules/modulea.iml" filepath="$PROJECT_DIR$/.idea/mill_modules/modulea.iml"/>
             <module fileurl="file://$PROJECT_DIR$/.idea/mill_modules/moduleb.iml" filepath="$PROJECT_DIR$/.idea/mill_modules/moduleb.iml"/>

--- a/main/api/src/mill/api/Ctx.scala
+++ b/main/api/src/mill/api/Ctx.scala
@@ -99,6 +99,17 @@ object Ctx {
     def workspace: os.Path
   }
 
+  /**
+   * Access to the project out directory.
+   */
+  trait Out {
+
+    /**
+     * This is the path pointing to the `out` directory.
+     */
+    def out: os.Path
+  }
+
   def defaultHome: os.Path = os.home / ".mill/ammonite"
 
   /**
@@ -177,6 +188,7 @@ class Ctx(
     val reporter: Int => Option[CompileProblemReporter],
     val testReporter: TestReporter,
     val workspace: os.Path,
+    val out: os.Path,
     val systemExit: Int => Nothing,
     @experimental val fork: Ctx.Fork.Api
 ) extends Ctx.Dest
@@ -184,6 +196,7 @@ class Ctx(
     with Ctx.Args
     with Ctx.Home
     with Ctx.Env
+    with Ctx.Out
     with Ctx.Workspace {
 
   def this(
@@ -196,7 +209,46 @@ class Ctx(
       testReporter: TestReporter,
       workspace: os.Path
   ) = {
-    this(args, dest0, log, home, env, reporter, testReporter, workspace, _ => ???, null)
+    this(
+      args,
+      dest0,
+      log,
+      home,
+      env,
+      reporter,
+      testReporter,
+      workspace,
+      workspace / "out",
+      _ => ???,
+      null
+    )
+  }
+
+  def this(
+      args: IndexedSeq[?],
+      dest0: () => os.Path,
+      log: Logger,
+      home: os.Path,
+      env: Map[String, String],
+      reporter: Int => Option[CompileProblemReporter],
+      testReporter: TestReporter,
+      workspace: os.Path,
+      systemExit: Int => Nothing,
+      fork: Ctx.Fork.Api
+  ) = {
+    this(
+      args,
+      dest0,
+      log,
+      home,
+      env,
+      reporter,
+      testReporter,
+      workspace,
+      workspace / "out",
+      systemExit,
+      fork
+    )
   }
   def dest: os.Path = dest0()
   def arg[T](index: Int): T = {

--- a/main/define/src/mill/define/Task.scala
+++ b/main/define/src/mill/define/Task.scala
@@ -198,10 +198,20 @@ object Task extends TaskBase {
       persistent: Boolean = false,
       generatedSourceRoots: Seq[os.SubPath] = Seq.empty
   ): ApplyFactory = new ApplyFactory(persistent, generatedSourceRoots)
+
+  // Kept for bincompat reasons
+  protected def apply(
+      t: NamedParameterOnlyDummy,
+      persistent: Boolean
+  ): ApplyFactory = new ApplyFactory(persistent, Seq.empty)
+
   class ApplyFactory private[mill] (
       val persistent: Boolean,
       val generatedSourceRoots: Seq[os.SubPath]
   ) extends TaskBase.TraverseCtxHolder {
+    // Kept for bincompat reasons
+    protected def this(persistent: Boolean) = this(persistent, Seq.empty)
+
     def apply[T](t: Result[T])(implicit
         rw: RW[T],
         ctx: mill.define.Ctx

--- a/main/define/src/mill/define/Task.scala
+++ b/main/define/src/mill/define/Task.scala
@@ -424,10 +424,11 @@ object Target extends TaskBase {
           val c1 = ctx.splice
           val r1 = rw.splice
           val t1 = taskIsPrivate.splice
-          if (c.prefix.splice.asInstanceOf[Task.ApplyFactory].persistent) {
-            new PersistentImpl[T](s1, c1, r1, t1)
+          val applyFactory = c.prefix.splice.asInstanceOf[Task.ApplyFactory]
+          if (applyFactory.persistent) {
+            new PersistentImpl[T](s1, c1, r1, t1, applyFactory.generatedSourceRoots)
           } else {
-            new TargetImpl[T](s1, c1, r1, t1)
+            new TargetImpl[T](s1, c1, r1, t1, applyFactory.generatedSourceRoots)
           }
         }
       )

--- a/main/define/src/mill/define/Task.scala
+++ b/main/define/src/mill/define/Task.scala
@@ -41,7 +41,7 @@ abstract class Task[+T] extends Task.Ops[T] with Applyable[Task, T] {
    * A list of paths under the `Task.dest` folder that should be considered root source directories
    * when generating configuration for IDEs.
    */
-  def generatedSourceRoots: Seq[os.SubPath] = Seq.empty
+  def deferredGeneratedSourceRoots: Seq[os.SubPath] = Seq.empty
 
   def asTarget: Option[Target[T]] = None
   def asCommand: Option[Command[T]] = None
@@ -196,8 +196,8 @@ object Task extends TaskBase {
   def apply(
       t: NamedParameterOnlyDummy = new NamedParameterOnlyDummy,
       persistent: Boolean = false,
-      generatedSourceRoots: Seq[os.SubPath] = Seq.empty
-  ): ApplyFactory = new ApplyFactory(persistent, generatedSourceRoots)
+      deferredGeneratedSourceRoots: Seq[os.SubPath] = Seq.empty
+  ): ApplyFactory = new ApplyFactory(persistent, deferredGeneratedSourceRoots)
 
   // Kept for bincompat reasons
   protected def apply(
@@ -207,7 +207,7 @@ object Task extends TaskBase {
 
   class ApplyFactory private[mill] (
       val persistent: Boolean,
-      val generatedSourceRoots: Seq[os.SubPath]
+      val deferredGeneratedSourceRoots: Seq[os.SubPath]
   ) extends TaskBase.TraverseCtxHolder {
     // Kept for bincompat reasons
     protected def this(persistent: Boolean) = this(persistent, Seq.empty)
@@ -436,9 +436,9 @@ object Target extends TaskBase {
           val t1 = taskIsPrivate.splice
           val applyFactory = c.prefix.splice.asInstanceOf[Task.ApplyFactory]
           if (applyFactory.persistent) {
-            new PersistentImpl[T](s1, c1, r1, t1, applyFactory.generatedSourceRoots)
+            new PersistentImpl[T](s1, c1, r1, t1, applyFactory.deferredGeneratedSourceRoots)
           } else {
-            new TargetImpl[T](s1, c1, r1, t1, applyFactory.generatedSourceRoots)
+            new TargetImpl[T](s1, c1, r1, t1, applyFactory.deferredGeneratedSourceRoots)
           }
         }
       )
@@ -830,7 +830,7 @@ class TargetImpl[+T](
     val ctx0: mill.define.Ctx,
     val readWriter: RW[_],
     val isPrivate: Option[Boolean],
-    override val generatedSourceRoots: Seq[os.SubPath]
+    override val deferredGeneratedSourceRoots: Seq[os.SubPath]
 ) extends Target[T] {
 
   // Added for bincompat
@@ -851,8 +851,8 @@ class PersistentImpl[+T](
     ctx0: mill.define.Ctx,
     readWriter: RW[_],
     isPrivate: Option[Boolean],
-    generatedSourceRoots: Seq[os.SubPath]
-) extends TargetImpl[T](t, ctx0, readWriter, isPrivate, generatedSourceRoots) {
+    deferredGeneratedSourceRoots: Seq[os.SubPath]
+) extends TargetImpl[T](t, ctx0, readWriter, isPrivate, deferredGeneratedSourceRoots) {
   // Added for bincompat
   def this(t: Task[T], ctx0: mill.define.Ctx, readWriter: RW[_], isPrivate: Option[Boolean]) =
     this(t, ctx0, readWriter, isPrivate, Seq.empty)

--- a/main/define/src/mill/define/Task.scala
+++ b/main/define/src/mill/define/Task.scala
@@ -793,6 +793,11 @@ class TaskBase extends Applicative.Applyer[Task, Task, Result, mill.api.Ctx]
   def workspace(implicit ctx: mill.api.Ctx): os.Path = ctx.workspace
 
   /**
+   * This is the `os.Path` pointing to the project's `out` directory.
+   */
+  def out(implicit ctx: mill.api.Ctx): os.Path = ctx.out
+
+  /**
    * Provides the `.fork.async` and `.fork.await` APIs for spawning and joining
    * async futures within your task in a Mill-friendly manner.
    */

--- a/scalalib/src/mill/scalalib/DeferredGeneratedSourcesModule.scala
+++ b/scalalib/src/mill/scalalib/DeferredGeneratedSourcesModule.scala
@@ -1,0 +1,69 @@
+package mill.scalalib
+
+import mill.*
+import mill.define.NamedTask
+
+/**
+ * A trait holding methods for expressing deferred source generators,
+ * which are useful for wiring in source-generation logic the output
+ * of which can be predicted without execution.
+ *
+ * This is useful for preventing IDE-integration (BSP/Idea/Bloop) from
+ * failing when the code-generation task fails for one reason or another.
+ */
+trait DeferredGeneratedSourcesModule extends JavaModule {
+
+  /**
+   * A set of tasks producing generated code. The difference between this and
+   * [[generatedSources]] lies in the fact that IDE-related tasks
+   * (BSP/Bloop/GenIdea) will not run the tasks, but will use them to statically
+   * determine the location of the source code they will produce by looking up their
+   * [[Task#deferredGeneratedSourceRoots]], knowing that these roots will be present under
+   * the dest directories once the task is run.
+   */
+  def deferredGeneratedSourceTasks: Seq[NamedTask[_]] = Seq.empty
+
+  private def predictGeneratedSourceRoots(task: NamedTask[_])(out: os.Path): Seq[os.Path] = {
+    val dest = mill
+      .eval
+      .EvaluatorPaths
+      .resolveDestPaths(out, task)
+      .dest
+    val explicitSourceRoots = task.deferredGeneratedSourceRoots
+    if (explicitSourceRoots.isEmpty) Seq(dest)
+    else explicitSourceRoots.map(subPath => dest / subPath)
+  }
+
+  /**
+   * Computes the list of source roots that will be produced by [[deferredGeneratedSourceTasks]] without
+   * actually running the generators in question.
+   */
+  final def predictedGeneratedSources: T[Seq[PathRef]] = T {
+    val out = T.out
+    deferredGeneratedSourceTasks.flatMap(t => predictGeneratedSourceRoots(t)(out)).map(PathRef(_))
+  }
+
+  /**
+   * Runs the lazy source generators, returning references to the expanded generated source roots
+   * they are supposed to have written code in.
+   */
+  final def deferredGeneratedSources: T[Seq[PathRef]] = T {
+    val out = T.out
+    T.sequence {
+      deferredGeneratedSourceTasks.asInstanceOf[Seq[T[Any]]].map { t =>
+        t.map((_: Any) => (out: os.Path) => predictGeneratedSourceRoots(t)(out))
+      }
+    }().flatMap(_.apply(out)).map(PathRef(_))
+  }
+
+  /**
+   * Task that IDE-configuration tasks should rely on, as they avoid eagerly
+   * running source generators referenced by [[deferredGeneratedSourceTasks]]
+   */
+  def ideSources: T[Seq[PathRef]] =
+    Task { sources() ++ generatedSources() ++ predictedGeneratedSources() }
+
+  override def allSources: T[Seq[PathRef]] =
+    Task { sources() ++ generatedSources() ++ deferredGeneratedSources() }
+
+}

--- a/scalalib/src/mill/scalalib/DeferredGeneratedSourcesModule.scala
+++ b/scalalib/src/mill/scalalib/DeferredGeneratedSourcesModule.scala
@@ -38,9 +38,9 @@ trait DeferredGeneratedSourcesModule extends JavaModule {
    * Computes the list of source roots that will be produced by [[deferredGeneratedSourceTasks]] without
    * actually running the generators in question.
    */
-  final def predictedGeneratedSources: T[Seq[PathRef]] = T {
+  final def predictedGeneratedSources: T[Seq[os.Path]] = T {
     val out = T.out
-    deferredGeneratedSourceTasks.flatMap(t => predictGeneratedSourceRoots(t)(out)).map(PathRef(_))
+    deferredGeneratedSourceTasks.flatMap(t => predictGeneratedSourceRoots(t)(out))
   }
 
   /**
@@ -60,8 +60,8 @@ trait DeferredGeneratedSourcesModule extends JavaModule {
    * Task that IDE-configuration tasks should rely on, as they avoid eagerly
    * running source generators referenced by [[deferredGeneratedSourceTasks]]
    */
-  def ideSources: T[Seq[PathRef]] =
-    Task { sources() ++ generatedSources() ++ predictedGeneratedSources() }
+  def ideSources: T[Seq[os.Path]] =
+    Task { sources().map(_.path) ++ generatedSources().map(_.path) ++ predictedGeneratedSources() }
 
   override def allSources: T[Seq[PathRef]] =
     Task { sources() ++ generatedSources() ++ deferredGeneratedSources() }

--- a/scalalib/src/mill/scalalib/DeferredGeneratedSourcesModule.scala
+++ b/scalalib/src/mill/scalalib/DeferredGeneratedSourcesModule.scala
@@ -1,6 +1,6 @@
 package mill.scalalib
 
-import mill.*
+import mill._
 import mill.define.NamedTask
 
 /**

--- a/scalalib/src/mill/scalalib/DeferredGeneratedSourcesModule.scala
+++ b/scalalib/src/mill/scalalib/DeferredGeneratedSourcesModule.scala
@@ -1,6 +1,7 @@
 package mill.scalalib
 
 import mill._
+import mill.api.experimental
 import mill.define.NamedTask
 
 /**
@@ -11,6 +12,7 @@ import mill.define.NamedTask
  * This is useful for preventing IDE-integration (BSP/Idea/Bloop) from
  * failing when the code-generation task fails for one reason or another.
  */
+@experimental
 trait DeferredGeneratedSourcesModule extends JavaModule {
 
   /**

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -889,6 +889,13 @@ trait JavaModule
   }
 
   /**
+   * Task that IDE-configuration tasks should rely on, as they avoid eagerly
+   * running source generators referenced by [[deferredSourceGenerators]]
+   */
+  def ideSources: T[Seq[PathRef]] =
+    Task { sources() ++ generatedSources() ++ allDeferredSourceRoots() }
+
+  /**
    * The folders containing all source files fed into the compiler
    */
   def allSources: T[Seq[PathRef]] =

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -11,7 +11,7 @@ import coursier.{Repository, Type}
 import mainargs.{Flag, arg}
 import mill.Agg
 import mill.api.{Ctx, JarManifest, MillException, PathRef, Result, internal}
-import mill.define.{Command, ModuleRef, NamedTask, Segment, Task, TaskModule}
+import mill.define.{Command, ModuleRef, Segment, Task, TaskModule}
 import mill.scalalib.internal.ModuleUtils
 import mill.scalalib.api.CompilationResult
 import mill.scalalib.bsp.{BspBuildTarget, BspModule, BspUri, JvmBuildTarget}
@@ -848,60 +848,9 @@ trait JavaModule
   def generatedSources: T[Seq[PathRef]] = Task { Seq.empty[PathRef] }
 
   /**
-   * A set of tasks producing generated code. The difference between this and
-   * [[generatedSources]] lies in the fact that IDE-related tasks
-   * (BSP/Bloop/GenIdea) will not run the tasks, but will use them to statically
-   * determine the location of the source code they will produce by looking up their
-   * [[Task#deferredGeneratedSourceRoots]], knowing that these roots will be present under
-   * the dest directories once the task is run.
-   */
-  def deferredGeneratedSourceTasks: Seq[NamedTask[_]] = Seq.empty
-
-  private def predictGeneratedSourceRoots(task: NamedTask[_])(workspace: os.Path): Seq[os.Path] = {
-    val dest = mill
-      .eval
-      .EvaluatorPaths
-      .resolveDestPaths(workspace / "out", task)
-      .dest
-    val explicitSourceRoots = task.deferredGeneratedSourceRoots
-    if (explicitSourceRoots.isEmpty) Seq(dest)
-    else explicitSourceRoots.map(subPath => dest / subPath)
-  }
-
-  /**
-   * Computes the list of source roots that will be produced by [[deferredGeneratedSourceTasks]] without
-   * actually running the generators in question.
-   */
-  def predictedGeneratedSources: T[Seq[PathRef]] = T {
-    val ws = T.workspace
-    deferredGeneratedSourceTasks.flatMap(t => predictGeneratedSourceRoots(t)(ws)).map(PathRef(_))
-  }
-
-  /**
-   * Runs the lazy source generators, returning references to the expanded generated source roots
-   * they are supposed to have written code in.
-   */
-  final def deferredGeneratedSources: T[Seq[PathRef]] = T {
-    val ws = T.workspace
-    T.sequence {
-      deferredGeneratedSourceTasks.asInstanceOf[Seq[T[Any]]].map { t =>
-        t.map((_: Any) => (ws: os.Path) => predictGeneratedSourceRoots(t)(ws))
-      }
-    }().flatMap(_.apply(ws)).map(PathRef(_))
-  }
-
-  /**
-   * Task that IDE-configuration tasks should rely on, as they avoid eagerly
-   * running source generators referenced by [[deferredGeneratedSourceTasks]]
-   */
-  def ideSources: T[Seq[PathRef]] =
-    Task { sources() ++ generatedSources() ++ predictedGeneratedSources() }
-
-  /**
    * The folders containing all source files fed into the compiler
    */
-  def allSources: T[Seq[PathRef]] =
-    Task { sources() ++ generatedSources() ++ deferredGeneratedSources() }
+  def allSources: T[Seq[PathRef]] = Task { sources() ++ generatedSources() }
 
   /**
    * All individual source files fed into the Java compiler


### PR DESCRIPTION
Context : https://github.com/com-lihaoyi/mill/discussions/4530

* Adds a `DeferredGeneratedSourcesModule` that extends `JavaModule`, providing a `def deferredGeneratedSourceTasks` alternative to `generatedSources`. This allows BSP/GenIdea/Bloop to predict source roots without actually running the code generation logic. 
* Adds a `def out` to the `Ctx` class, allowing to query the location `out` folder within tasks. 
* Adds unit tests / integration tests where relevant 

#### Previous description (kept for the record) : 

@lihaoyi, I want to open this PR to continue the discussion. At the time of writing this, this adds a `generatedSourceRoots` parameter for tasks, as you've described, and uses it to compute the source directories for the bloop configuration, as opposed to actually running the `allSources` task. A similar change would need to be achieved in `GenIdea` and `BSP`. 

So now, the problem I see is as follows : in order for this to be useful, it needs to be applied to all source generators provided OOTB by the mill codebase, but also third party providers of source-generator (like smithy4s), as the ability to jump to the sources is paramount for the user experience in IDEs. 

Applying this change is a fair bit of work in this codebase, and a big ask for the larger ecosystem, and although I think SBT's approach of treating all source generators lazily is preferable to mill's current approach of running all source generators eagerly, I don't think I can weigh the benefits of changing the approach against the cost induced by breaking IDE behaviour for existing plugins. 

With that in mind here's what I think would be a good mitigation : 

```scala
// Rather than traversing the transitive inputs of `allSources`, we define this setting as a way to register lazy 
// source generators. We force the contract to return `Unit` to prevent the assumption that a returned `PathRef` would be
// added to the sources. 
def lazySourceGenerators = Seq[T[Unit]] 
 
 // Runs the lazy source generators, returning path refs computed from their `generatedSourceRoots`. 
 // When the tasks don't have `generatedSourceRoots` set, we assume that the `T.dest` is to be added as source root. 
 final def runLazySourceGenerators : T[Seq[PathRef]] = ???
 
// Does not run the lazy source generators, but rather computes the source roots they'll generate code in. 
// Wrapped in T because the evaluator is needed to get the T.dest of the lazy source generators. I presume that is 
// something we could thread in through the ctx (like `def destOf(task: T[_]) : Path`)  
final def lazyGeneratedSourceRoots: T[Seq[Path]] = ???
 
 // Keeps the current behaviour intact 
def allSources = T {
    sources() ++ generatedSources() ++ runLazySourceGenerators()
} 
```

The `Bloop`, `GenIdea` and `BSP` then get amended to call `sources()`, `generatedSources()` and `lazyGeneratedSourceRoots()`, but avoids `runLazySourceGenerators`. 

This approach would allow to alleviate the pain point raised in the discussion above, whilst retaining the current behaviour of the ecosystem. Mill plugin providers could be encouraged to use `runLazySourceGenerators` instead of `generatedSources`, but users would have a recourse to turn eager source generators into lazy ones if they need it to be (provided a `withGeneratedSourceRoots` is provided to them, that is) 