### PR TITLE
Update coursier to 2.1.25-M2 (adds early Gradle Module support) - 0.12.x

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -117,9 +117,9 @@ object Deps {
   val asmTree = ivy"org.ow2.asm:asm-tree:9.7.1"
   val bloopConfig = ivy"ch.epfl.scala::bloop-config:1.5.5"
 
-  val coursierVersion = "2.1.24"
+  val coursierVersion = "2.1.25-M2"
   val coursier = ivy"io.get-coursier::coursier:$coursierVersion"
-  val coursierInterface = ivy"io.get-coursier:interface:1.0.27"
+  val coursierInterface = ivy"io.get-coursier:interface:1.0.29-M1"
   val coursierJvm = ivy"io.get-coursier::coursier-jvm:$coursierVersion"
 
   val cask = ivy"com.lihaoyi::cask:0.9.4"

--- a/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
+++ b/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
@@ -343,7 +343,7 @@ class BloopImpl(evs: () => Seq[Evaluator], wd: os.Path) extends ExternalModule {
       import scala.concurrent.ExecutionContext.Implicits.global
       val unresolved = Resolution(deps)
       val fetch =
-        ResolutionProcess.fetch(repos, coursier.cache.Cache.default.fetch)
+        ResolutionProcess.fetch0(repos, coursier.cache.Cache.default.fetch)
       val gatherTask =
         for {
           resolved <- unresolved.process.run(fetch)

--- a/scalalib/src/mill/scalalib/JsonFormatters.scala
+++ b/scalalib/src/mill/scalalib/JsonFormatters.scala
@@ -7,6 +7,30 @@ trait JsonFormatters {
   implicit lazy val extensionFormat: RW[coursier.core.Extension] = upickle.default.macroRW
 
   implicit lazy val modFormat: RW[coursier.Module] = upickle.default.macroRW
+  implicit lazy val versionConstraintFormat: RW[coursier.version.VersionConstraint] =
+    implicitly[RW[String]].bimap(
+      _.asString,
+      coursier.version.VersionConstraint(_)
+    )
+  implicit lazy val versionIntervalFormat0: RW[coursier.version.VersionInterval] =
+    upickle.default.macroRW
+  implicit lazy val versionFormat0: RW[coursier.version.Version] =
+    implicitly[RW[String]].bimap(
+      _.asString,
+      coursier.version.Version(_)
+    )
+  implicit lazy val variantSelectorFormat: RW[coursier.core.VariantSelector] =
+    RW.merge(
+      upickle.default.macroRW[coursier.core.VariantSelector.ConfigurationBased],
+      upickle.default.macroRW[coursier.core.VariantSelector.AttributesBased]
+    )
+  private implicit lazy val variantAttributesFormat: RW[coursier.core.Variant.Attributes] =
+    upickle.default.macroRW
+  implicit lazy val variantFormat: RW[coursier.core.Variant] =
+    RW.merge(
+      upickle.default.macroRW[coursier.core.Variant.Configuration],
+      variantAttributesFormat
+    )
   implicit lazy val bomDepFormat: RW[coursier.core.BomDependency] = upickle.default.macroRW
   implicit lazy val overridesFormat: RW[coursier.core.Overrides] =
     implicitly[RW[coursier.core.DependencyManagement.Map]].bimap(
@@ -48,11 +72,35 @@ trait JsonFormatters {
     )
   implicit lazy val snapshotVersioningFormat: RW[coursier.core.SnapshotVersioning] =
     upickle.default.macroRW
-  implicit lazy val versionsFormat: RW[coursier.core.Versions] = upickle.default.macroRW
+  implicit lazy val versionsFormat: RW[coursier.core.Versions] =
+    upickle.default.readwriter[ujson.Value].bimap[coursier.core.Versions](
+      versions =>
+        ujson.Obj(
+          "latest" -> versions.latest,
+          "release" -> versions.release,
+          "available" -> versions.available,
+          "lastUpdated" -> upickle.default.writeJs(versions.lastUpdated)
+        ),
+      json =>
+        coursier.core.Versions(
+          latest = json("latest").str,
+          release = json("release").str,
+          available = upickle.default.read[List[String]](json("available")),
+          lastUpdated =
+            upickle.default.read[Option[coursier.core.Versions.DateTime]](json("lastUpdated"))
+        )
+    )
   implicit lazy val versionsDateTimeFormat: RW[coursier.core.Versions.DateTime] =
     upickle.default.macroRW
   implicit lazy val activationFormat: RW[coursier.core.Activation] = upickle.default.macroRW
   implicit lazy val profileFormat: RW[coursier.core.Profile] = upickle.default.macroRW
+  private implicit lazy val variantPublicationFormat: RW[coursier.core.VariantPublication] =
+    upickle.default.macroRW
+  private implicit def attributesMapFormat[T: RW]: RW[Map[coursier.core.Variant.Attributes, T]] =
+    implicitly[RW[Map[String, T]]].bimap(
+      attrMap => attrMap.map { case (k, v) => k.variantName -> v },
+      strMap => strMap.map { case (k, v) => coursier.core.Variant.Attributes(k) -> v }
+    )
   implicit lazy val projectFormat: RW[coursier.core.Project] = upickle.default.macroRW
 
 }

--- a/scalalib/test/src/mill/scalalib/BomTests.scala
+++ b/scalalib/test/src/mill/scalalib/BomTests.scala
@@ -675,7 +675,7 @@ object BomTests extends TestSuite {
           val res = eval(modules.bom.placeholder.check.compileClasspath)
           assert(
             res.left.exists(_.toString.contains(
-              "not found: https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java//protobuf-java-.pom"
+              "No version available in (,)"
             ))
           )
         }


### PR DESCRIPTION
Report of #4591 against `0.12.x`