### PR TITLE
Jslib Restructure

### DIFF
--- a/example/extending/typescript/1-hello-typescript/build.mill
+++ b/example/extending/typescript/1-hello-typescript/build.mill
@@ -136,5 +136,5 @@ Hello James Bond
 */
 
 // So that's a minimal example of implementing a single TypeScript to JavaScript build
-// pipeline locally. Next, we will look at turning it into a `TypeScriptModule` that
+// pipeline locally. Next, we will look at turning it into a `TscModule` that
 // can be re-used

--- a/example/extending/typescript/2-typescript-modules/build.mill
+++ b/example/extending/typescript/2-typescript-modules/build.mill
@@ -1,13 +1,13 @@
 // In this example, we will explore how to take the one-off typescript build pipeline
-// we wrote above, and turn it into a re-usable `TypeScriptModule`.
+// we wrote above, and turn it into a re-usable `TscModule`.
 //
 // To do this, we take all the code we wrote earlier and surround it with
-// `trait TypeScriptModule extends Module` wrapper:
+// `trait TscModule extends Module` wrapper:
 
 package build
 import mill._
 
-trait TypeScriptModule extends Module {
+trait TscModule extends Module {
   def npmInstall = Task {
     os.call(("npm", "install", "--save-dev", "typescript@5.6.3", "@types/node@22.7.8"))
     PathRef(Task.dest)
@@ -35,10 +35,10 @@ trait TypeScriptModule extends Module {
 // We can then instantiate the module three times. Module can be adjacent or nested,
 // as shown belo:
 
-object foo extends TypeScriptModule {
-  object bar extends TypeScriptModule
+object foo extends TscModule {
+  object bar extends TscModule
 }
-object qux extends TypeScriptModule
+object qux extends TscModule
 
 /** See Also: foo/src/foo.ts */
 /** See Also: foo/bar/src/bar.ts */
@@ -58,7 +58,7 @@ Hello James Qux
 
 */
 
-// At this point, we have multiple ``TypeScriptModule``s, with `bar` nested inside `foo`,
+// At this point, we have multiple ``TscModule``s, with `bar` nested inside `foo`,
 // but they are each independent and do not depend on one another.
 
 // ```graphviz

--- a/example/extending/typescript/3-module-deps/build.mill
+++ b/example/extending/typescript/3-module-deps/build.mill
@@ -1,4 +1,4 @@
-// This example extends `TypeScriptModule` to support `moduleDeps`.
+// This example extends `TscModule` to support `moduleDeps`.
 //
 // 1. The `def compile` task is considerably fleshed out: rather than using command
 //    line flags, we generate a `tsconfig.json` file using the `ujson.Obj`/`ujson.Arr`
@@ -7,15 +7,15 @@
 // 2. `def compile` now returns two `PathRef`s: one containing the `.js` output to use in
 //    `def run`, and one containing the `.d.ts` output to use in downstream ``compile``s.
 //
-// 2. `def moduleDeps` is used to allow different ``TypeScriptModule``s to depend on each
+// 2. `def moduleDeps` is used to allow different ``TscModule``s to depend on each
 //    other, and we use `Task.traverse` to combine the upstream `compiledDefinitions` for
 //    use in `compile`, and `compiledJavascript` for use in `run`
 
 package build
 import mill._
 
-trait TypeScriptModule extends Module {
-  def moduleDeps: Seq[TypeScriptModule] = Nil
+trait TscModule extends Module {
+  def moduleDeps: Seq[TscModule] = Nil
 
   def npmInstall = Task {
     os.call(("npm", "install", "--save-dev", "typescript@5.6.3", "@types/node@22.7.8"))
@@ -76,13 +76,13 @@ trait TypeScriptModule extends Module {
 // is a common pattern when defining language modules, whose module-level dependencies need
 // to be translated into task-level dependencies
 //
-// Again, we can instantiate `TypeScriptModule` three times, but now `foo/src/foo.ts`
+// Again, we can instantiate `TscModule` three times, but now `foo/src/foo.ts`
 // and `foo/bar/src/bar.ts` export their APIs which are then imported in `qux/src/qux.ts`:
 
-object foo extends TypeScriptModule {
-  object bar extends TypeScriptModule
+object foo extends TscModule {
+  object bar extends TscModule
 }
-object qux extends TypeScriptModule {
+object qux extends TscModule {
   def moduleDeps = Seq(foo, foo.bar)
 }
 

--- a/example/extending/typescript/4-npm-deps-bundle/build.mill
+++ b/example/extending/typescript/4-npm-deps-bundle/build.mill
@@ -1,4 +1,4 @@
-// This example expands `TypeScriptModule` in two ways:
+// This example expands `TscModule` in two ways:
 //
 // 1. Previously, `def npmInstall` was hardcoded to
 //    install `typescript` and `@types/node`, because that was what was needed
@@ -10,15 +10,15 @@
 //    as in `def run` in order to provide the necessary files to the `node` runtime.
 //
 // 2. We include `esbuild@0.24.0` as part of our `npm install`, for use in a `def bundle`
-//    task that uses it to call `esbuild` to bundle our 3 ``TypeScriptModule``s into a single
+//    task that uses it to call `esbuild` to bundle our 3 ``TscModule``s into a single
 //    `bundle.js` file. The logic shared between `def run` and `def bundle` has been extracted
 //    into a `def prepareRun` task.
 
 package build
 import mill._
 
-trait TypeScriptModule extends Module {
-  def moduleDeps: Seq[TypeScriptModule] = Nil
+trait TscModule extends Module {
+  def moduleDeps: Seq[TscModule] = Nil
 
   def npmDeps: T[Seq[String]] = Task { Seq.empty[String] }
 
@@ -98,16 +98,16 @@ trait TypeScriptModule extends Module {
   }
 }
 
-object foo extends TypeScriptModule {
-  object bar extends TypeScriptModule {
+object foo extends TscModule {
+  object bar extends TscModule {
     def npmDeps = Seq("immutable@4.3.7")
   }
 }
-object qux extends TypeScriptModule {
+object qux extends TscModule {
   def moduleDeps = Seq(foo, foo.bar)
 }
 
-// We can now not only invoke the `qux.run` to run the `TypeScriptModule` immediately
+// We can now not only invoke the `qux.run` to run the `TscModule` immediately
 // using `node`, we can also use `qux.bundle` to generate a `bundle.js` file we can run
 // standalone using `node`:
 

--- a/example/javascriptlib/basic/1-simple/build.mill
+++ b/example/javascriptlib/basic/1-simple/build.mill
@@ -2,7 +2,7 @@ package build
 
 import mill._, javascriptlib._
 
-object foo extends TypeScriptModule {
+object foo extends TscModule {
   def npmDeps = Seq("immutable@4.3.7")
   object test extends TypeScriptTests with TestModule.Jest
 }

--- a/example/javascriptlib/basic/3-custom-build-logic/build.mill
+++ b/example/javascriptlib/basic/3-custom-build-logic/build.mill
@@ -5,8 +5,12 @@ import mill._, javascriptlib._
 object foo extends TypeScriptModule {
 
   /** Total number of lines in module source files */
-  def lineCount = Task {
-    allSources().map(f => os.read.lines(f.path).size).sum
+  def lineCount: T[Int] = Task {
+    sources()
+      .flatMap(pathRef => os.walk(pathRef.path))
+      .filter(_.ext == "ts")
+      .map(os.read.lines(_).size)
+      .sum
   }
 
   /** Generate resource using lineCount of sources */

--- a/example/javascriptlib/basic/3-custom-build-logic/build.mill
+++ b/example/javascriptlib/basic/3-custom-build-logic/build.mill
@@ -2,7 +2,7 @@ package build
 
 import mill._, javascriptlib._
 
-object foo extends TypeScriptModule {
+object foo extends TscModule {
 
   /** Total number of lines in module source files */
   def lineCount: T[Int] = Task {

--- a/example/javascriptlib/basic/3-custom-build-logic/foo/src/foo.ts
+++ b/example/javascriptlib/basic/3-custom-build-logic/foo/src/foo.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs/promises';
 
-const Resources: string = process.env.RESOURCESDEST || "@foo/resources.dest" // `RESOURCES` is generated on bundle
+const Resources: string = process.env.RESOURCESDEST || "@foo/resources" // `RESOURCES` is generated on bundle
 const LineCount = require.resolve(`${Resources}/line-count.txt`);
 
 export default class Foo {

--- a/example/javascriptlib/basic/4-multi-modules/build.mill
+++ b/example/javascriptlib/basic/4-multi-modules/build.mill
@@ -2,14 +2,14 @@ package build
 
 import mill._, javascriptlib._
 
-object foo extends TypeScriptModule {
-  object bar extends TypeScriptModule {
+object foo extends TscModule {
+  object bar extends TscModule {
     def npmDeps = Seq("immutable@4.3.7")
   }
 
 }
 
-object qux extends TypeScriptModule {
+object qux extends TscModule {
   def moduleDeps = Seq(foo, foo.bar)
   object test extends TypeScriptTests with TestModule.Jest
 }

--- a/example/javascriptlib/basic/5-client-server-hello/build.mill
+++ b/example/javascriptlib/basic/5-client-server-hello/build.mill
@@ -3,7 +3,7 @@ import mill._, javascriptlib._
 
 object client extends ReactScriptsModule
 
-object server extends TypeScriptModule {
+object server extends TscModule {
 
   /** Bundle client as resource */
   def resources = Task {

--- a/example/javascriptlib/basic/5-client-server-hello/server/src/server.ts
+++ b/example/javascriptlib/basic/5-client-server-hello/server/src/server.ts
@@ -2,7 +2,7 @@ import * as http from 'http';
 import * as fs from 'fs';
 import * as path from 'path';
 
-const Resources: string = (process.env.RESOURCESDEST || "@server/resources.dest") + "/build" // `RESOURCES` is generated on bundle
+const Resources: string = (process.env.RESOURCESDEST || "@server/resources") + "/build" // `RESOURCES` is generated on bundle
 const Client = require.resolve(`${Resources}/index.html`);
 
 const server = http.createServer((req, res) => {

--- a/example/javascriptlib/basic/6-client-server-realistic/build.mill
+++ b/example/javascriptlib/basic/6-client-server-realistic/build.mill
@@ -3,7 +3,7 @@ import mill._, javascriptlib._
 
 object client extends ReactScriptsModule
 
-object server extends TypeScriptModule {
+object server extends TscModule {
   def npmDeps =
     Seq("@types/cors@^2.8.17", "@types/express@^5.0.0", "cors@^2.8.5", "express@^4.21.1")
 

--- a/example/javascriptlib/basic/6-client-server-realistic/server/src/server.ts
+++ b/example/javascriptlib/basic/6-client-server-realistic/server/src/server.ts
@@ -1,9 +1,8 @@
 import express, {Express} from 'express';
 import cors from 'cors';
-import path from 'path'
 import api from "./api"
 
-const Resources: string = (process.env.RESOURCESDEST || "@server/resources.dest") + "/build" // `RESOURCES` is generated on bundle
+const Resources: string = (process.env.RESOURCESDEST || "@server/resources") + "/build" // `RESOURCES` is generated on bundle
 const Client = require.resolve(`${Resources}/index.html`);
 const BuildPath = Client.replace(/index\.html$/, "");
 const app: Express = express();

--- a/example/javascriptlib/dependencies/1-npm-deps/build.mill
+++ b/example/javascriptlib/dependencies/1-npm-deps/build.mill
@@ -1,7 +1,7 @@
 package build
 import mill._, javascriptlib._
 
-object foo extends TypeScriptModule {
+object foo extends TscModule {
   def npmDeps = Seq("lodash@4.17.21")
   def npmDevDeps = Seq("@types/lodash@4.17.13")
 }

--- a/example/javascriptlib/dependencies/2-unmanaged-packages/build.mill
+++ b/example/javascriptlib/dependencies/2-unmanaged-packages/build.mill
@@ -1,7 +1,7 @@
 package build
 import mill._, javascriptlib._
 
-object foo extends TypeScriptModule {
+object foo extends TscModule {
   def unmanagedDeps = Seq.from(os.list(moduleDir / "lib").map(PathRef(_)))
 }
 

--- a/example/javascriptlib/dependencies/3-downloading-unmanaged-packages/build.mill
+++ b/example/javascriptlib/dependencies/3-downloading-unmanaged-packages/build.mill
@@ -6,7 +6,7 @@
 package build
 import mill._, javascriptlib._
 
-object foo extends TypeScriptModule {
+object foo extends TscModule {
   def unmanagedDeps = Task {
     val name = "lodash-4.17.21.tgz"
     val url = "https://github.com/lodash/lodash/archive/refs/tags/4.17.21.tar.gz"

--- a/example/javascriptlib/dependencies/4-repository-config/build.mill
+++ b/example/javascriptlib/dependencies/4-repository-config/build.mill
@@ -1,7 +1,7 @@
 package build
 import mill._, javascriptlib._
 
-object foo extends TypeScriptModule {
+object foo extends TscModule {
   def npmDeps = Seq("lodash@4.17.21")
   def npmDevDeps = Seq("@types/lodash@4.17.13")
 }

--- a/example/javascriptlib/linting/1-linting/build.mill
+++ b/example/javascriptlib/linting/1-linting/build.mill
@@ -2,7 +2,7 @@ package build
 
 import mill._, javascriptlib._
 
-object foo extends TypeScriptModule with TsLintModule
+object foo extends TscModule with TsLintModule
 
 // Mill supports code linting via `eslint` https://eslint.org out of the box.
 // You can lint your projects code by providing a configuration for eslint and running `mill _.checkFormatAll`.

--- a/example/javascriptlib/linting/2-autoformatting/build.mill
+++ b/example/javascriptlib/linting/2-autoformatting/build.mill
@@ -2,7 +2,7 @@ package build
 
 import mill._, javascriptlib._
 
-object foo extends TypeScriptModule with TsLintModule
+object foo extends TscModule with TsLintModule
 
 // Mill supports code auto formatting via `eslint` https://eslint.org and `prettier` https://prettier.io/docs/en.
 // You can reformat your projects code by providing a configuration for your preferred formtter then running

--- a/example/javascriptlib/linting/3-code-coverage/build.mill
+++ b/example/javascriptlib/linting/3-code-coverage/build.mill
@@ -2,19 +2,19 @@ package build
 
 import mill._, javascriptlib._
 
-object foo extends TypeScriptModule {
+object foo extends TscModule {
   object test extends TypeScriptTests with TestModule.Jest
 }
 
-object bar extends TypeScriptModule {
+object bar extends TscModule {
   object test extends TypeScriptTests with TestModule.Mocha
 }
 
-object baz extends TypeScriptModule {
+object baz extends TscModule {
   object test extends TypeScriptTests with TestModule.Vitest
 }
 
-object qux extends TypeScriptModule {
+object qux extends TscModule {
   object test extends TypeScriptTests with TestModule.Jasmine
 }
 

--- a/example/javascriptlib/module/1-common-config/build.mill
+++ b/example/javascriptlib/module/1-common-config/build.mill
@@ -3,7 +3,7 @@ package build
 import mill._
 import mill.javascriptlib._
 
-object foo extends TypeScriptModule {
+object foo extends TscModule {
 
   def customSource = Task {
     Seq(PathRef(moduleDir / "custom-src/foo2.ts"))

--- a/example/javascriptlib/module/1-common-config/build.mill
+++ b/example/javascriptlib/module/1-common-config/build.mill
@@ -9,7 +9,7 @@ object foo extends TypeScriptModule {
     Seq(PathRef(moduleDir / "custom-src/foo2.ts"))
   }
 
-  def allSources = super.allSources() ++ customSource()
+  def sources = Task.Sources(super.sources() ++ customSource())
 
   def resources = super.resources() ++ Seq(PathRef(moduleDir / "custom-resources"))
 

--- a/example/javascriptlib/module/2-custom-tasks/build.mill
+++ b/example/javascriptlib/module/2-custom-tasks/build.mill
@@ -5,8 +5,12 @@ import mill._, javascriptlib._
 object foo extends TypeScriptModule {
 
   /** Total number of lines in module source files */
-  def lineCount = Task {
-    allSources().map(f => os.read.lines(f.path).size).sum
+  def lineCount: T[Int] = Task {
+    sources()
+      .flatMap(pathRef => os.walk(pathRef.path))
+      .filter(_.ext == "ts")
+      .map(os.read.lines(_).size)
+      .sum
   }
 
   def generatedSources = Task {

--- a/example/javascriptlib/module/2-custom-tasks/build.mill
+++ b/example/javascriptlib/module/2-custom-tasks/build.mill
@@ -2,7 +2,7 @@ package build
 
 import mill._, javascriptlib._
 
-object foo extends TypeScriptModule {
+object foo extends TscModule {
 
   /** Total number of lines in module source files */
   def lineCount: T[Int] = Task {

--- a/example/javascriptlib/module/3-override-tasks/build.mill
+++ b/example/javascriptlib/module/3-override-tasks/build.mill
@@ -3,7 +3,7 @@ package build
 import mill._
 import mill.javascriptlib._
 
-object `package` extends RootModule with TypeScriptModule {
+object `package` extends RootModule with TscModule {
   def moduleName = "foo"
 
   def sources = Task {

--- a/example/javascriptlib/module/3-override-tasks/build.mill
+++ b/example/javascriptlib/module/3-override-tasks/build.mill
@@ -3,7 +3,9 @@ package build
 import mill._
 import mill.javascriptlib._
 
-object foo extends TypeScriptModule {
+object `package` extends RootModule with TypeScriptModule {
+  def moduleName = "foo"
+
   def sources = Task {
     val srcPath = Task.dest / "src"
     val filePath = srcPath / "foo.ts"
@@ -18,7 +20,7 @@ object foo extends TypeScriptModule {
       """.stripMargin
     )
 
-    PathRef(Task.dest)
+    Seq(PathRef(Task.dest))
   }
 
   def compile = Task {
@@ -46,7 +48,7 @@ object foo extends TypeScriptModule {
 
 /** Usage
 
-> mill foo.run "added tags"
+> mill run "added tags"
 Compiling...
 Hello World!
 Running... added tags

--- a/example/javascriptlib/module/3-override-tasks/foo/readme.md
+++ b/example/javascriptlib/module/3-override-tasks/foo/readme.md
@@ -1,1 +1,0 @@
-Generate source directory from build.mill

--- a/example/javascriptlib/module/4-compilation-execution-flags/build.mill
+++ b/example/javascriptlib/module/4-compilation-execution-flags/build.mill
@@ -3,7 +3,7 @@ package build
 import mill._
 import mill.javascriptlib._
 
-object foo extends TypeScriptModule {
+object foo extends TscModule {
   def compilerOptions =
     super.compilerOptions() + (
       "skipLibCheck" -> ujson.True,

--- a/example/javascriptlib/module/5-resources/build.mill
+++ b/example/javascriptlib/module/5-resources/build.mill
@@ -3,7 +3,7 @@ package build
 import mill._, javascriptlib._
 import ujson._
 
-object foo extends TypeScriptModule {
+object foo extends TscModule {
   object test extends TypeScriptTests with TestModule.Jest {
     def otherFiles = Task.Source("other-files")
 

--- a/example/javascriptlib/module/5-resources/foo/src/foo.ts
+++ b/example/javascriptlib/module/5-resources/foo/src/foo.ts
@@ -3,6 +3,8 @@ import * as fs from 'fs/promises';
 const Resources: string = process.env.RESOURCES || "@foo/resources" // `RESOURCES` is generated on bundle
 const File = require.resolve(`${Resources}/file.txt`);
 
+console.log(File);
+
 export default class Foo {
     static async resourceText(): Promise<string> {
         return await fs.readFile(File, 'utf8')

--- a/example/javascriptlib/module/6-executable-config/build.mill
+++ b/example/javascriptlib/module/6-executable-config/build.mill
@@ -3,7 +3,7 @@ package build
 import mill._
 import mill.javascriptlib._
 
-object foo extends TypeScriptModule {
+object foo extends TscModule {
   def bundleFlags =
     Map(
       "platform" -> ujson.Str("node"),

--- a/example/javascriptlib/publishing/2-realistic/build.mill
+++ b/example/javascriptlib/publishing/2-realistic/build.mill
@@ -2,8 +2,8 @@ package build
 
 import mill._, javascriptlib._
 
-object foo extends TypeScriptModule {
-  object bar extends TypeScriptModule {
+object foo extends TscModule {
+  object bar extends TscModule {
     def npmDeps = Seq("immutable@4.3.7")
   }
 

--- a/example/javascriptlib/testing/1-test-suite/build.mill
+++ b/example/javascriptlib/testing/1-test-suite/build.mill
@@ -2,19 +2,19 @@ package build
 
 import mill._, javascriptlib._
 
-object bar extends TypeScriptModule {
+object bar extends TscModule {
   object test extends TypeScriptTests with TestModule.Jest
 }
 
-object baz extends TypeScriptModule {
+object baz extends TscModule {
   object test extends TypeScriptTests with TestModule.Vitest
 }
 
-object foo extends TypeScriptModule {
+object foo extends TscModule {
   object test extends TypeScriptTests with TestModule.Mocha
 }
 
-object qux extends TypeScriptModule {
+object qux extends TscModule {
   object test extends TypeScriptTests with TestModule.Jasmine
 }
 

--- a/example/javascriptlib/testing/2-test-deps/build.mill
+++ b/example/javascriptlib/testing/2-test-deps/build.mill
@@ -2,12 +2,12 @@ package build
 
 import mill._, javascriptlib._
 
-object bar extends TypeScriptModule {
+object bar extends TscModule {
   def npmDeps = Seq("immutable@4.3.7")
   object test extends TypeScriptTests with TestModule.Jest
 }
 
-object foo extends TypeScriptModule {
+object foo extends TscModule {
   def moduleDeps = Seq(bar)
   object test extends TypeScriptTests with TestModule.Jest
 }

--- a/example/javascriptlib/testing/3-integration-suite-cypress/build.mill
+++ b/example/javascriptlib/testing/3-integration-suite-cypress/build.mill
@@ -4,7 +4,7 @@ import mill._, javascriptlib._
 
 object client extends ReactScriptsModule
 
-object server extends TypeScriptModule {
+object server extends TscModule {
 
   def npmDeps =
     Seq("@types/cors@^2.8.17", "@types/express@^5.0.0", "cors@^2.8.5", "express@^4.21.1")

--- a/example/javascriptlib/testing/3-integration-suite-cypress/server/src/server.ts
+++ b/example/javascriptlib/testing/3-integration-suite-cypress/server/src/server.ts
@@ -1,7 +1,7 @@
 import express, {Express} from 'express';
 import cors from 'cors';
 
-const Resources: string = (process.env.RESOURCESDEST || "@server/resources.dest") + "/build" // `RESOURCES` is generated on bundle
+const Resources: string = (process.env.RESOURCESDEST || "@server/resources") + "/build" // `RESOURCES` is generated on bundle
 const Client = require.resolve(`${Resources}/index.html`);
 
 const app: Express = express();

--- a/example/javascriptlib/testing/3-integration-suite-playwright/build.mill
+++ b/example/javascriptlib/testing/3-integration-suite-playwright/build.mill
@@ -4,7 +4,7 @@ import mill._, javascriptlib._
 
 object client extends ReactScriptsModule
 
-object server extends TypeScriptModule {
+object server extends TscModule {
 
   def npmDeps =
     Seq("@types/cors@^2.8.17", "@types/express@^5.0.0", "cors@^2.8.5", "express@^4.21.1")

--- a/example/javascriptlib/testing/3-integration-suite-playwright/server/src/server.ts
+++ b/example/javascriptlib/testing/3-integration-suite-playwright/server/src/server.ts
@@ -1,7 +1,7 @@
 import express, {Express} from 'express';
 import cors from 'cors';
 
-const Resources: string = (process.env.RESOURCESDEST || "@server/resources.dest") + "/build" // `RESOURCES` is generated on bundle
+const Resources: string = (process.env.RESOURCESDEST || "@server/resources") + "/build" // `RESOURCES` is generated on bundle
 const Client = require.resolve(`${Resources}/index.html`);
 
 const app: Express = express();

--- a/javascriptlib/src/mill/javascriptlib/PublishModule.scala
+++ b/javascriptlib/src/mill/javascriptlib/PublishModule.scala
@@ -20,11 +20,9 @@ trait PublishModule extends TypeScriptModule {
 
   private def pubDeclarationOut: T[String] = Task { "declarations" }
 
-  override def mainFileName: T[String] = Task { s"${moduleDir.last}.js" }
-
   // main file; defined with mainFileName
   def pubMain: T[String] =
-    Task { pubBundledOut() + "/src/" + mainFileName() }
+    Task { pubBundledOut() + "/src/" + mainFileName().replaceAll("\\.ts", "js") }
 
   private def pubMainType: T[String] = Task {
     pubMain().replaceFirst(pubBundledOut(), pubDeclarationOut()).replaceAll("\\.js", ".d.ts")
@@ -42,7 +40,7 @@ trait PublishModule extends TypeScriptModule {
   }
 
   private def pubTypesVersion: T[Map[String, Seq[String]]] = Task {
-    pubAllSources().map { source =>
+    tscAllSources().map { source =>
       val dist = source.replaceFirst("typescript", pubBundledOut())
       val declarations = source.replaceFirst("typescript", pubDeclarationOut())
       ("./" + dist).replaceAll("\\.ts", "") -> Seq(declarations.replaceAll("\\.ts", ".d.ts"))
@@ -50,15 +48,14 @@ trait PublishModule extends TypeScriptModule {
   }
 
   // build package.json from publishMeta
-  // mv to publishDir.dest
-  def pubbPackageJson: T[PathRef] = Task { // PathRef
+  // mv to compileDir.dest
+  def pubPackageJson: T[PathRef] = Task { // PathRef
     def splitDeps(input: String): (String, String) = {
       input.split("@", 3).toList match {
         case first :: second :: tail if input.startsWith("@") =>
           ("@" + first + "@" + second, tail.mkString)
         case first :: tail =>
           (first, tail.mkString)
-        case _ => ???
       }
     }
 
@@ -82,151 +79,6 @@ trait PublishModule extends TypeScriptModule {
   // Package.Json construction
 
   // Compilation Options
-  override def modulePaths: Task[Seq[(String, String)]] = Task.Anon {
-    val module = moduleDir.last
-
-    Seq((s"$module/*", "typescript/src" + ":" + s"${pubDeclarationOut()}")) ++
-      resources().map { rp =>
-        val resourceRoot = rp.path.last
-        val result = (
-          s"@$module/$resourceRoot/*",
-          resourceRoot match {
-            case s if s.contains(".dest") => rp.path.toString
-            case _ => s"typescript/$resourceRoot"
-          }
-        )
-        result
-      }
-  }
-
-  private def pubModDeps: T[Seq[String]] = Task {
-    moduleDeps.map { _.moduleDir.subRelativeTo(Task.workspace).segments.head }.distinct
-  }
-
-  private def pubModDepsSources: T[Seq[PathRef]] = Task {
-    Task.traverse(moduleDeps)(_.sources)()
-  }
-
-  private def pubBaseModeGenSources: T[Seq[PathRef]] = Task {
-    for {
-      pr <- generatedSources()
-      file <- os.walk(pr.path)
-      if file.ext == "ts"
-    } yield PathRef(file)
-  }
-
-  private def pubModDepsGenSources: T[Seq[PathRef]] = Task {
-    Task.traverse(moduleDeps)(_.generatedSources)().flatMap { modSource =>
-      val fileExt: Path => Boolean = _.ext == "ts"
-      for {
-        pr <- modSource
-        file <- os.walk(pr.path)
-        if fileExt(file)
-      } yield PathRef(file)
-    }
-  }
-
-  // mv generated sources for base mod and its deps
-  private def pubGenSources: T[Unit] = Task {
-    val allGeneratedSources = pubBaseModeGenSources() ++ pubModDepsGenSources()
-    allGeneratedSources.foreach { target =>
-      val destination = publishDir().path / "typescript/generatedSources" / target.path.last
-      os.makeDir.all(destination / os.up)
-      os.copy.over(
-        target.path,
-        destination
-      )
-    }
-  }
-
-  private def pubCopyModDeps: T[Unit] = Task {
-    val targets = pubModDeps()
-
-    targets.foreach { target =>
-      val destination = publishDir().path / "typescript" / target
-      os.makeDir.all(destination / os.up)
-      os.copy(
-        Task.workspace / target,
-        destination,
-        mergeFolders = true
-      )
-    }
-  }
-
-  override def resources: T[Seq[PathRef]] = Task {
-    val modDepsResources = moduleDeps.map { x => PathRef(x.moduleDir / "resources") }
-    Seq(PathRef(moduleDir / "resources")) ++ modDepsResources
-  }
-
-  /**
-   * Generate sources relative to publishDir / "typescript"
-   */
-  private def pubAllSources: T[IndexedSeq[String]] = Task {
-    val project = Task.workspace.toString
-    val fileExt: Path => Boolean = _.ext == "ts"
-    (for {
-      source <-
-        os.walk(sources().path) ++ pubModDepsSources().toIndexedSeq.flatMap(pr =>
-          os.walk(pr.path)
-        ).filter(fileExt)
-    } yield source.toString
-      .replaceFirst(moduleDir.toString, "typescript")
-      .replaceFirst(
-        project,
-        "typescript"
-      )) ++ (pubBaseModeGenSources() ++ pubModDepsGenSources()).map(pr =>
-      "typescript/generatedSources/" + pr.path.last
-    )
-
-  }
-
-  override def generatedSourcesPathsBuilder: T[Seq[(String, String)]] = Task {
-    Seq("@generated/*" -> "typescript/generatedSources")
-  }
-
-  override def upstreamPathsBuilder: Task[Seq[(String, String)]] = Task.Anon {
-
-    val upstreams = (for {
-      (res, mod) <- Task.traverse(moduleDeps)(_.resources)().zip(moduleDeps)
-    } yield {
-      val relative = mod.moduleDir.subRelativeTo(Task.workspace)
-      Seq((
-        mod.moduleDir.subRelativeTo(Task.workspace).toString + "/*",
-        s"typescript/$relative/src:${pubDeclarationOut()}"
-      )) ++
-        res.map { rp =>
-          val resourceRoot = rp.path.last
-          val modName = mod.moduleDir.subRelativeTo(Task.workspace).toString
-          // nb: resources are be moved in bundled stage
-          (
-            s"@$modName/$resourceRoot/*",
-            resourceRoot match {
-              case s if s.contains(".dest") =>
-                rp.path.toString
-              case _ => s"typescript/$modName/$resourceRoot"
-            }
-          )
-        }
-
-    }).flatten
-
-    upstreams
-  }
-
-  override def typeRoots: T[ujson.Value] = Task {
-    ujson.Arr(
-      "node_modules/@types",
-      "declarations"
-    )
-  }
-
-  override def declarationDir: T[ujson.Value] = Task {
-    ujson.Str("declarations")
-  }
-
-  override def compilerOptionsPaths: Task[Map[String, String]] =
-    Task.Anon { Map.empty[String, String] }
-
   override def compilerOptions: T[Map[String, ujson.Value]] = Task {
     Map(
       "declarationMap" -> ujson.Bool(true),
@@ -259,34 +111,15 @@ trait PublishModule extends TypeScriptModule {
 
   private def pubSymLink: Task[Unit] = Task {
     pubTsPatchInstall() // patch typescript compiler => use custom transformers
-    os.symlink(publishDir().path / "node_modules", npmInstall().path / "node_modules")
 
     if (os.exists(npmInstall().path / ".npmrc"))
-      os.symlink(publishDir().path / ".npmrc", npmInstall().path / ".npmrc")
+      os.symlink(compileDir().path / ".npmrc", npmInstall().path / ".npmrc")
   }
 
   override def compile: T[(PathRef, PathRef)] = Task {
     pubSymLink()
-    os.write(
-      publishDir().path / "tsconfig.json",
-      ujson.Obj(
-        "compilerOptions" -> ujson.Obj.from(
-          compilerOptionsBuilder().toSeq ++ Seq("typeRoots" -> typeRoots())
-        ),
-        "files" -> pubAllSources()
-      )
-    )
-    os.copy(moduleDir, publishDir().path / "typescript", mergeFolders = true)
-    pubCopyModDeps()
-    pubGenSources()
-    // Run type check, build declarations
-    os.call(
-      ("node", npmInstall().path / "node_modules/typescript/bin/tsc"),
-      cwd = publishDir().path
-    )
-    (publishDir(), PathRef(publishDir().path / "typescript"))
+    super.compile()
   }
-
   // Compilation Options
 
   // EsBuild - Copying Resources
@@ -305,7 +138,7 @@ trait PublishModule extends TypeScriptModule {
           s"""    copyStaticFiles({
              |      src: ${ujson.Str(rp.toString)},
              |      dest: ${ujson.Str(
-              publishDir().path.toString + "/" + pubBundledOut() + "/" + rp.last
+              compileDir().path.toString + "/" + pubBundledOut() + "/" + rp.last
             )},
              |      dereference: true,
              |      preserveTimestamps: true,
@@ -367,18 +200,15 @@ trait PublishModule extends TypeScriptModule {
 
   // EsBuild - END
 
-  // publishDir; is used to process and compile files for publishing
-  def publishDir: T[PathRef] = Task { PathRef(Task.dest) }
-
   def publish(): Command[Unit] = Task.Command {
     // build package.json
-    os.move(pubbPackageJson().path / "package.json", publishDir().path / "package.json")
+    os.move(pubPackageJson().path / "package.json", compileDir().path / "package.json")
 
     // bundle code for publishing
     bundle()
 
     // run npm publish
-    os.call(("npm", "publish"), stdout = os.Inherit, cwd = publishDir().path)
+    os.call(("npm", "publish"), stdout = os.Inherit, cwd = compileDir().path)
     ()
   }
 

--- a/javascriptlib/src/mill/javascriptlib/PublishModule.scala
+++ b/javascriptlib/src/mill/javascriptlib/PublishModule.scala
@@ -4,7 +4,7 @@ import mill.*
 import os.*
 import mill.scalalib.publish.licenseFormat
 
-trait PublishModule extends TypeScriptModule {
+trait PublishModule extends TscModule {
 
   /**
    * Metadata about your project, required to publish.

--- a/javascriptlib/src/mill/javascriptlib/ReactScriptsModule.scala
+++ b/javascriptlib/src/mill/javascriptlib/ReactScriptsModule.scala
@@ -3,7 +3,7 @@ import mill.*
 import os.*
 
 // create-react-app: https://create-react-app.dev/docs/documentation-intro
-trait ReactScriptsModule extends TypeScriptModule {
+trait ReactScriptsModule extends TscModule {
   override def npmDeps: T[Seq[String]] = Task {
     Seq(
       "react@18.3.1",

--- a/javascriptlib/src/mill/javascriptlib/ReactScriptsModule.scala
+++ b/javascriptlib/src/mill/javascriptlib/ReactScriptsModule.scala
@@ -27,7 +27,7 @@ trait ReactScriptsModule extends TypeScriptModule {
     )
   }
 
-  override def sources: Target[PathRef] = Task.Source(moduleDir)
+  override def sources: Target[Seq[PathRef]] = Task.Sources(moduleDir)
 
   def packageJestOptions: Target[ujson.Obj] = Task {
     ujson.Obj(
@@ -64,14 +64,14 @@ trait ReactScriptsModule extends TypeScriptModule {
     )
   }
 
-  override def compilerOptionsPaths: Task[Map[String, String]] =
-    Task.Anon { Map("app/*" -> "src/app/*") }
+  override def compilerOptionsPaths: T[Map[String, String]] =
+    Task { Map("app/*" -> "src/app/*") }
 
   override def compilerOptionsBuilder: Task[Map[String, ujson.Value]] = Task.Anon {
     val npm = npmInstall().path
     val combinedPaths = compilerOptionsPaths() ++ Seq(
       "*" -> npm / "node_modules",
-      "typescript" -> npm / "node_modules/typescript"
+      "typescript" -> npm / "node_modules" / "typescript"
     )
 
     val combinedCompilerOptions: Map[String, ujson.Value] = compilerOptions() ++ Map(
@@ -84,7 +84,7 @@ trait ReactScriptsModule extends TypeScriptModule {
   // build react project via react scripts
   override def compile: T[(PathRef, PathRef)] = Task {
     // copy src files
-    os.copy(sources().path, Task.dest, mergeFolders = true)
+    sources().foreach(source => os.copy(source.path, Task.dest, mergeFolders = true))
     copyNodeModules()
 
     // mk tsconfig.json
@@ -92,7 +92,7 @@ trait ReactScriptsModule extends TypeScriptModule {
       Task.dest / "tsconfig.json",
       ujson.Obj(
         "compilerOptions" -> ujson.Obj.from(compilerOptionsBuilder().toSeq),
-        "include" -> ujson.Arr((sources().path / "src").toString)
+        "include" -> ujson.Arr(sources().map(source => (source.path / "src").toString))
       )
     )
 
@@ -108,7 +108,7 @@ trait ReactScriptsModule extends TypeScriptModule {
   override def bundle: Target[PathRef] = Task {
     val compiled = compile()._1.path
     os.call(
-      ("node", compiled / "node_modules/react-scripts/bin/react-scripts.js", "build"),
+      ("node", compiled / "node_modules" / "react-scripts" / "bin" / "react-scripts.js", "build"),
       cwd = compiled,
       stdout = os.Inherit,
       env = forkEnv()
@@ -142,7 +142,7 @@ trait ReactScriptsModule extends TypeScriptModule {
     os.call(
       (
         "node",
-        (compiled / "node_modules/react-scripts/bin/react-scripts.js").toString,
+        (compiled / "node_modules" / "react-scripts" / "bin" / "react-scripts.js").toString,
         "test",
         "--watchAll=false"
       ),

--- a/javascriptlib/src/mill/javascriptlib/TestModule.scala
+++ b/javascriptlib/src/mill/javascriptlib/TestModule.scala
@@ -24,7 +24,7 @@ trait TestModule extends TaskModule {
 object TestModule {
   type TestResult = Unit
 
-  trait Coverage extends TypeScriptModule with TestModule {
+  trait Coverage extends TscModule with TestModule {
     override def npmDevDeps: T[Seq[String]] = Task {
       super.npmDevDeps() ++ Seq("serve@14.2.4")
     }
@@ -80,7 +80,7 @@ object TestModule {
     }
   }
 
-  trait Shared extends TypeScriptModule {
+  trait Shared extends TscModule {
     override def upstreamPathsBuilder: T[Seq[(String, String)]] =
       Task {
         val stuUpstreams = for {
@@ -105,8 +105,8 @@ object TestModule {
     def getPathToTest: T[String] = Task { compile()._2.path.toString + s"/$testDir" }
   }
 
-  trait IntegrationSuite extends TypeScriptModule {
-    def service: TypeScriptModule
+  trait IntegrationSuite extends TscModule {
+    def service: TscModule
 
     def port: T[String]
   }
@@ -542,7 +542,7 @@ object TestModule {
 
   }
 
-  trait Cypress extends TypeScriptModule with IntegrationSuite with TestModule {
+  trait Cypress extends TscModule with IntegrationSuite with TestModule {
     override def npmDevDeps: T[Seq[String]] = Task {
       Seq(
         "cypress@13.17.0"
@@ -623,7 +623,7 @@ object TestModule {
 
   }
 
-  trait PlayWright extends TypeScriptModule with IntegrationSuite with TestModule {
+  trait PlayWright extends TscModule with IntegrationSuite with TestModule {
     override def npmDevDeps: T[Seq[String]] = Task {
       super.npmDevDeps() ++ Seq(
         "playwright@1.49.0",

--- a/javascriptlib/src/mill/javascriptlib/TsLintModule.scala
+++ b/javascriptlib/src/mill/javascriptlib/TsLintModule.scala
@@ -34,7 +34,8 @@ trait TsLintModule extends Module {
     T.workspace / "eslint.config.mjs",
     T.workspace / "eslint.config.cjs",
     T.workspace / "eslint.config.js",
-    T.workspace / ".prettierrc"
+    T.workspace / ".prettierrc",
+    T.workspace / ".prettierrc.json"
   )
 
   private def resolvedFmtConfig: Task[Lint] = Task.Anon {

--- a/javascriptlib/src/mill/javascriptlib/TscModule.scala
+++ b/javascriptlib/src/mill/javascriptlib/TscModule.scala
@@ -6,21 +6,21 @@ import os.*
 import scala.annotation.tailrec
 import scala.util.Try
 
-trait TypeScriptModule extends Module { outer =>
+trait TscModule extends Module { outer =>
   // custom module names
   def moduleName: String = super.toString
 
   override def toString: String = moduleName
 
-  def moduleDeps: Seq[TypeScriptModule] = Nil
+  def moduleDeps: Seq[TscModule] = Nil
 
   // recursively retrieve dependecies of all module dependencies
-  def recModuleDeps: Seq[TypeScriptModule] = {
+  def recModuleDeps: Seq[TscModule] = {
     @tailrec
     def recModuleDeps_(
-        t: Seq[TypeScriptModule],
-        acc: Seq[TypeScriptModule]
-    ): Seq[TypeScriptModule] = {
+        t: Seq[TscModule],
+        acc: Seq[TscModule]
+    ): Seq[TscModule] = {
       if (t.isEmpty) acc
       else {
         val currentMod = t.head
@@ -627,8 +627,8 @@ trait TypeScriptModule extends Module { outer =>
 
   private[javascriptlib] def outerModuleName: Option[String] = None
 
-  trait TypeScriptTests extends TypeScriptModule {
-    override def moduleDeps: Seq[TypeScriptModule] = Seq(outer) ++ outer.moduleDeps
+  trait TypeScriptTests extends TscModule {
+    override def moduleDeps: Seq[TscModule] = Seq(outer) ++ outer.moduleDeps
 
     override def outerModuleName: Option[String] = Some(outer.moduleName)
 

--- a/javascriptlib/src/mill/javascriptlib/TypeScriptModule.scala
+++ b/javascriptlib/src/mill/javascriptlib/TypeScriptModule.scala
@@ -3,12 +3,38 @@ package mill.javascriptlib
 import mill.*
 import os.*
 
+import scala.annotation.tailrec
 import scala.util.Try
 
 trait TypeScriptModule extends Module { outer =>
+  // custom module names
+  def moduleName: String = super.toString
+
+  override def toString: String = moduleName
+
   def moduleDeps: Seq[TypeScriptModule] = Nil
 
+  // recursively retrieve dependecies of all module dependencies
+  def recModuleDeps: Seq[TypeScriptModule] = {
+    @tailrec
+    def recModuleDeps_(
+        t: Seq[TypeScriptModule],
+        acc: Seq[TypeScriptModule]
+    ): Seq[TypeScriptModule] = {
+      if (t.isEmpty) acc
+      else {
+        val currentMod = t.head
+        val cmModDeps = currentMod.moduleDeps
+        recModuleDeps_(t.tail ++ cmModDeps, cmModDeps ++ acc)
+      }
+    }
+
+    recModuleDeps_(moduleDeps, moduleDeps).distinct
+  }
+
   def npmDeps: T[Seq[String]] = Task { Seq.empty[String] }
+
+  def enableEsm: T[Boolean] = Task { false }
 
   def npmDevDeps: T[Seq[String]] = Task { Seq.empty[String] }
 
@@ -43,6 +69,7 @@ trait TypeScriptModule extends Module { outer =>
       "@esbuild-plugins/tsconfig-paths@0.1.2",
       "esbuild-copy-static-files@0.1.0",
       "tsconfig-paths@4.2.0",
+      Seq(if (enableEsm()) Some("@swc/core@1.10.12") else None).flatten,
       transitiveNpmDeps(),
       transitiveNpmDevDeps(),
       transitiveUnmanagedDeps().map(_.path.toString)
@@ -50,147 +77,328 @@ trait TypeScriptModule extends Module { outer =>
     PathRef(Task.dest)
   }
 
-  def sources: T[PathRef] = Task.Source("src")
+  // sources :)
+  def sources: T[Seq[PathRef]] = Task.Sources(moduleDir / "src")
 
   def resources: T[Seq[PathRef]] = Task { Seq(PathRef(moduleDir / "resources")) }
 
   def generatedSources: T[Seq[PathRef]] = Task { Seq[PathRef]() }
 
-  def allSources: T[IndexedSeq[PathRef]] =
-    Task {
-      val fileExt: Path => Boolean = _.ext == "ts"
-      os.walk(sources().path).filter(fileExt).map(PathRef(_))
-    }
+  private def tscModDepsResources: T[Seq[(PathRef, Seq[PathRef])]] =
+    Task
+      .traverse(recModuleDeps)(_.resources)()
+      .zip(recModuleDeps)
+      .map { case (r, m) => (PathRef(m.moduleDir), r) }
 
-  // Generate coverage directories for TestModule
-  private[javascriptlib] def coverageDirs: T[Seq[String]] = Task {
-    Task.traverse(moduleDeps)(mod => {
-      Task.Anon {
-        val comp = mod.compile()
-        val generated = mod.generatedSources()
-        val combined = Seq(comp._2) ++ generated
+  private def tscModDepsSources: T[Seq[(PathRef, Seq[PathRef])]] =
+    Task
+      .traverse(recModuleDeps)(_.sources)()
+      .zip(recModuleDeps)
+      .map { case (s, m) => (PathRef(m.moduleDir), s) }
 
-        combined.map(_.path.subRelativeTo(Task.workspace / "out").toString + "/**/**/*.ts")
-      }
-    })().flatten
-  }
-
-  private[javascriptlib] def compiledSources: Task[IndexedSeq[PathRef]] = Task.Anon {
-    val generated = for {
+  private def tscCoreGenSources: T[Seq[PathRef]] = Task {
+    for {
       pr <- generatedSources()
       file <- os.walk(pr.path)
       if file.ext == "ts"
-    } yield file
+    } yield PathRef(file)
+  }
 
-    val typescriptOut = Task.dest / "typescript"
-    val core = for {
-      file <- allSources()
-    } yield file.path match {
-      case coreS if coreS.startsWith(moduleDir) =>
-        // core - regular sources
-        // expected to exist within boundaries of `millSourcePath`
-        typescriptOut / coreS.relativeTo(moduleDir)
-      case otherS =>
-        // sources defined by a modified source task
-        // mv to compile source
-        val destinationDir = Task.dest / "typescript/src"
-        val fileName = otherS.last
-        val destinationFile = destinationDir / fileName
-        os.makeDir.all(destinationDir)
-        os.copy.over(otherS, destinationFile)
-        destinationFile
+  private def tscModDepsGenSources: T[Seq[(PathRef, Seq[PathRef])]] =
+    Task
+      .traverse(recModuleDeps)(_.generatedSources)()
+      .zip(recModuleDeps)
+      .map { case (s, m) =>
+        (
+          PathRef(m.moduleDir),
+          s.flatMap { genS => os.walk(genS.path).filter(_.ext == "ts").map(PathRef(_)) }
+        )
+      }
+
+  def tscCopySources: T[Unit] = Task {
+    val dest = compileDir().path / "typescript"
+    val coreTarget = dest / "src"
+
+    if (!os.exists(dest)) os.makeDir.all(dest)
+
+    // Copy everything except "build.mill" and the "/out" directory from Task.workspace
+    os.walk(moduleDir, skip = _.last == "out").filter(_.last != "build.mill").foreach { path =>
+      val relativePath = path.relativeTo(moduleDir)
+      val destination = dest / relativePath
+
+      if (os.isDir(path)) os.makeDir.all(destination)
+      else os.copy.over(path, destination)
     }
 
-    // symlink node_modules for generated sources
-    // remove `node_module/<package>` package import format
-    generatedSources().foreach(source =>
-      os.call(
-        ("ln", "-s", npmInstall().path.toString + "/node_modules/", "node_modules"),
-        cwd = source.path
-      )
-    )
+    object IsSrcDirectory {
+      def unapply(path: Path): Option[Path] =
+        if (os.isDir(path) && path.last == "src") Some(path) else None
+    }
 
-    (core ++ generated).map(PathRef(_))
+    // handle copy `/out/<mod>/<source.dest>/src` directories
+    def copySrcDirectory(srcDir: Path, targetDir: Path): Unit = {
+      os.list(srcDir).foreach { srcFile =>
+        os.copy.over(srcFile, targetDir / srcFile.last, createFolders = true)
+      }
+    }
+
+    //  handle sources generated in /out (eg: `out/<mod>/sources.dest`)
+    def copyOutSources(sources: Seq[PathRef], target: Path): Unit = {
+
+      def copySource(source: PathRef): Unit = {
+        if (!source.path.startsWith(Task.workspace / "out")) () // Guard clause
+        else os.list(source.path).foreach {
+          case IsSrcDirectory(srcDir) => copySrcDirectory(srcDir, target)
+          case path => os.copy.over(path, target / path.last, createFolders = true)
+        }
+      }
+
+      sources.foreach(copySource)
+    }
+
+    // core
+    copyOutSources(sources(), coreTarget)
+
+    // mod deps
+    tscModDepsSources()
+      .foreach { case (mod, sources_) =>
+        copyOutSources(sources_, dest / mod.path.relativeTo(Task.workspace) / "src")
+      }
+
   }
+
+  private def tscCopyModDeps: T[Unit] = Task {
+    val targets =
+      recModuleDeps.map { _.moduleDir.subRelativeTo(Task.workspace).segments.head }.distinct
+
+    targets.foreach { target =>
+      val destination = compileDir().path / "typescript" / target
+      os.makeDir.all(destination / os.up)
+      os.copy(
+        Task.workspace / target,
+        destination,
+        mergeFolders = true
+      )
+    }
+  }
+
+  // mv generated sources for base mod and its deps
+  private def tscCopyGenSources: T[Unit] = Task {
+    tscCoreGenSources().foreach { target =>
+      val destination = compileDir().path / "typescript" / "generatedSources" / target.path.last
+      os.makeDir.all(destination / os.up)
+      os.copy.over(
+        target.path,
+        destination
+      )
+    }
+
+    tscModDepsGenSources().foreach { case (mod, source_) =>
+      source_.foreach { target =>
+        val modDir = mod.path.relativeTo(Task.workspace)
+        val destination =
+          compileDir().path / "typescript" / modDir / "generatedSources" / target.path.last
+        os.makeDir.all(destination / os.up)
+        os.copy.over(
+          target.path,
+          destination
+        )
+      }
+    }
+
+  }
+
+  /**
+   * Link all external resources eg: `out/<mod>/resources.dest`
+   * to `moduleDir / src / resources`
+   */
+  private def tscLinkResources: T[Unit] = Task {
+    val dest = compileDir().path / "typescript/resources"
+    if (!os.exists(dest)) os.makeDir.all(dest)
+
+    val externalResource: PathRef => Boolean = p =>
+      p.path.startsWith(Task.workspace / "out") &&
+        os.exists(p.path) &&
+        os.isDir(p.path)
+
+    def linkResource(resources_ : Seq[PathRef], dest: Path): Unit = {
+      resources_
+        .filter(externalResource)
+        .flatMap(p => os.list(p.path)) // Get all items from valid directories
+        .foreach(item => os.copy.over(item, dest / item.last, createFolders = true))
+    }
+
+    linkResource(resources(), dest)
+
+    tscModDepsResources().foreach { case (mod, r) =>
+      val modDir = mod.path.relativeTo(Task.workspace)
+      val modDest = compileDir().path / "typescript" / modDir / "resources"
+      if (!os.exists(modDest)) os.makeDir.all(modDest)
+      linkResource(r, modDest)
+    }
+  }
+
+  def tscAllSources: T[IndexedSeq[String]] = Task {
+    val fileExt: Path => Boolean = _.ext == "ts"
+
+    def relativeToTS(base: Path, path: Path, prefix: Option[String] = None): Option[String] =
+      prefix match {
+        case Some(value) => Some(s"typescript/$value/${path.relativeTo(base)}")
+        case None => Some(s"typescript/${path.relativeTo(base)}")
+      }
+
+    def handleOutTS(base: Path, path: Path, prefix: Option[String] = None): Option[String] = {
+      val segments = path.relativeTo(base).segments
+      val externalSourceDir = base / segments.head
+      prefix match {
+        case Some(_) => relativeToTS(externalSourceDir, path, prefix)
+        case None => relativeToTS(externalSourceDir, path)
+      }
+    }
+
+    def relativeToTypescript(base: Path, path: Path, prefix: String): Option[String] =
+      Some(s"typescript/$prefix/${path.relativeTo(base)}")
+
+    def handleOutPath(base: Path, path: Path, prefix: String): Option[String] = {
+      val segments = path.relativeTo(base).segments
+      val externalSourceDir = base / segments.head
+      relativeToTypescript(externalSourceDir, path, prefix)
+    }
+
+    val cores = sources()
+      .toIndexedSeq
+      .flatMap(pr => if (isDir(pr.path)) os.walk(pr.path) else Seq(pr.path))
+      .filter(fileExt)
+      .flatMap { p =>
+        p match {
+          case _ if p.startsWith(moduleDir) && !p.startsWith(moduleDir / "out") =>
+            relativeToTS(moduleDir, p)
+          case _ if p.startsWith(Task.workspace / "out" / moduleName) =>
+            handleOutTS(Task.workspace / "out" / moduleName, p)
+          case _ if p.startsWith(Task.workspace / "out") =>
+            handleOutTS(Task.workspace / "out", p)
+          case _ => None
+        }
+      }
+
+    val modDeps = tscModDepsSources()
+      .toIndexedSeq
+      .flatMap { case (mod, source_) =>
+        source_
+          .flatMap(pr => if (isDir(pr.path)) os.walk(pr.path) else Seq(pr.path))
+          .filter(fileExt)
+          .flatMap { p =>
+            val modDir = mod.path.relativeTo(Task.workspace)
+            val modmoduleDir = Task.workspace / modDir
+            val modOutPath = Task.workspace / "out" / modDir
+
+            p match {
+              case _ if p.startsWith(modmoduleDir) =>
+                relativeToTypescript(modmoduleDir, p, modDir.toString)
+              case _ if p.startsWith(modOutPath) =>
+                handleOutPath(modOutPath, p, modDir.toString)
+              case _ => None
+            }
+
+          }
+      }
+
+    val coreGenSources = tscCoreGenSources()
+      .toIndexedSeq
+      .map(pr => "typescript/generatedSources/" + pr.path.last)
+
+    val modGenSources = tscModDepsGenSources()
+      .toIndexedSeq
+      .flatMap { case (mod, source_) =>
+        val modDir = mod.path.relativeTo(Task.workspace)
+        source_.map(s"typescript/$modDir/generatedSources/" + _.path.last)
+      }
+
+    cores ++ modDeps ++ coreGenSources ++ modGenSources
+
+  }
+
+  // sources
+
+  // compile :)
+  def declarationDir: T[ujson.Value] = Task { ujson.Str("declarations") }
 
   // specify tsconfig.compilerOptions
   def compilerOptions: T[Map[String, ujson.Value]] = Task {
     Map(
+      "skipLibCheck" -> ujson.Bool(true),
       "esModuleInterop" -> ujson.Bool(true),
       "declaration" -> ujson.Bool(true),
-      "emitDeclarationOnly" -> ujson.Bool(true)
-    )
+      "emitDeclarationOnly" -> ujson.Bool(true),
+      "baseUrl" -> ujson.Str("."),
+      "rootDir" -> ujson.Str("typescript")
+    ) ++ Seq(
+      if (enableEsm()) Some("module" -> ujson.Str("nodenext")) else None,
+      if (enableEsm()) Some("moduleResolution" -> ujson.Str("nodenext")) else None
+    ).flatten
   }
 
   // specify tsconfig.compilerOptions.Paths
-  def compilerOptionsPaths: Task[Map[String, String]] = Task.Anon { Map.empty[String, String] }
+  def compilerOptionsPaths: T[Map[String, String]] = Task { Map.empty[String, String] }
 
-  def upstreams: T[(PathRef, PathRef, Seq[PathRef])] = Task {
-    val comp = compile()
-
-    (comp._1, comp._2, resources())
-  }
-
-  def upstreamPathsBuilder: Task[Seq[(String, String)]] = Task.Anon {
-
+  def upstreamPathsBuilder: T[Seq[(String, String)]] = Task {
     val upstreams = (for {
-      ((comp, ts, res), mod) <- Task.traverse(moduleDeps)(_.upstreams)().zip(moduleDeps)
+      (res, mod) <- Task.traverse(recModuleDeps)(_.resources)().zip(recModuleDeps)
     } yield {
-      Seq((
-        mod.moduleDir.subRelativeTo(Task.workspace).toString + "/*",
-        (ts.path / "src").toString + ":" + (comp.path / "declarations").toString
-      )) ++
-        res.map { rp =>
-          val resourceRoot = rp.path.last
-          (
-            "@" + mod.moduleDir.subRelativeTo(Task.workspace).toString + s"/$resourceRoot/*",
-            resourceRoot match {
-              case s if s.contains(".dest") =>
-                rp.path.toString
-              case _ =>
-                (ts.path / resourceRoot).toString
-            }
-          )
+      val prefix = mod.moduleName.replaceAll("\\.", "/")
+      val customResource: PathRef => Boolean = pathRef =>
+        pathRef.path.startsWith(Task.workspace / "out" / mod.moduleName) || !pathRef.path.equals(
+          mod.moduleDir / "src" / "resources"
+        )
+
+      val customResources = res
+        .filter(customResource)
+        .map { pathRef =>
+          val resourceRoot = pathRef.path.last
+          s"@$prefix/$resourceRoot/*" -> s"typescript/$prefix/$resourceRoot"
         }
+
+      Seq(
+        (
+          prefix + "/*",
+          s"typescript/$prefix/src" + ":" + s"declarations/$prefix"
+        ),
+        (s"@$prefix/resources/*", s"typescript/$prefix/resources")
+      ) ++ customResources
 
     }).flatten
 
     upstreams
   }
 
-  def modulePaths: Task[Seq[(String, String)]] = Task.Anon {
-    val module = moduleDir.last
-    val typescriptOut = Task.dest / "typescript"
-    val declarationsOut = Task.dest / "declarations"
+  def modulePaths: T[Seq[(String, String)]] = Task {
+    val customResource: PathRef => Boolean = pathRef =>
+      pathRef.path.startsWith(Task.workspace / "out") || !pathRef.path.equals(
+        moduleDir / "src" / "resources"
+      )
 
-    Seq((s"$module/*", (typescriptOut / "src").toString + ":" + declarationsOut.toString)) ++
-      resources().map { rp =>
-        val resourceRoot = rp.path.last
-        val result = (
-          s"@$module/$resourceRoot/*",
-          resourceRoot match {
-            case s if s.contains(".dest") => rp.path.toString
-            case _ =>
-              (typescriptOut / resourceRoot).toString
-          }
-        )
-        result
+    val customResources = resources()
+      .filter(customResource)
+      .map { pathRef =>
+        val resourceRoot = pathRef.path.last
+        s"@$moduleName/$resourceRoot/*" -> s"typescript/$resourceRoot"
       }
+
+    Seq(
+      (s"$moduleName/*", "typescript/src" + ":" + "declarations"),
+      (s"@$moduleName/resources/*", "typescript/resources")
+    ) ++ customResources
   }
 
   def typeRoots: Task[ujson.Value] = Task.Anon {
     ujson.Arr(
       "node_modules/@types",
-      (Task.dest / "declarations").toString
+      "declarations"
     )
   }
 
-  def declarationDir: Task[ujson.Value] = Task.Anon {
-    ujson.Str((Task.dest / "declarations").toString)
-  }
-
   def generatedSourcesPathsBuilder: T[Seq[(String, String)]] = Task {
-    generatedSources().map(p => ("@generated/*", p.path.toString))
+    Seq(("@generated/*", "typescript/generatedSources"))
   }
 
   def compilerOptionsBuilder: Task[Map[String, ujson.Value]] = Task.Anon {
@@ -212,33 +420,56 @@ trait TypeScriptModule extends Module { outer =>
     combinedCompilerOptions
   }
 
-  // create a symlink for node_modules in compile.dest
-  // removes need for node_modules prefix in import statements `node_modules/<some-package>`
-  // import * as somepackage from "<some-package>"
-  private def symLink: Task[Unit] = Task.Anon {
-    os.symlink(Task.dest / "node_modules", npmInstall().path / "node_modules")
-    os.symlink(Task.dest / "package-lock.json", npmInstall().path / "package-lock.json")
+  /**
+   * create a symlink for node_modules in compile.dest
+   * removes need for node_modules prefix in import statements `node_modules/<some-package>`
+   * import * as somepackage from "<some-package>"
+   */
+  private def symLink: T[Unit] = Task {
+    os.symlink(compileDir().path / "node_modules", npmInstall().path / "node_modules")
+    os.symlink(compileDir().path / "package-lock.json", npmInstall().path / "package-lock.json")
   }
+
+  def compileDir: T[PathRef] = Task { PathRef(Task.dest) }
 
   def compile: T[(PathRef, PathRef)] = Task {
     symLink()
     os.write(
-      Task.dest / "tsconfig.json",
+      compileDir().path / "tsconfig.json",
       ujson.Obj(
         "compilerOptions" -> ujson.Obj.from(
           compilerOptionsBuilder().toSeq ++ Seq("typeRoots" -> typeRoots())
         ),
-        "files" -> compiledSources().map(_.path.toString)
+        "files" -> tscAllSources()
       )
     )
 
-    os.copy(moduleDir, Task.dest / "typescript", mergeFolders = true)
-    os.call(npmInstall().path / "node_modules/typescript/bin/tsc", cwd = Task.dest)
-
-    (PathRef(Task.dest), PathRef(Task.dest / "typescript"))
+    tscCopySources()
+    tscCopyModDeps()
+    tscCopyGenSources()
+    tscLinkResources()
+    // Run type check, build declarations
+    os.call(
+      ("node", npmInstall().path / "node_modules/typescript/bin/tsc"),
+      cwd = compileDir().path
+    )
+    (PathRef(compileDir().path), PathRef(compileDir().path / "typescript"))
   }
 
-  def mainFileName: T[String] = Task { s"${moduleDir.last}.ts" }
+  // compile
+
+  // additional ts-config options
+  def options: T[Map[String, ujson.Value]] = Task {
+    Seq(
+      Some("exclude" -> ujson.Arr.from(Seq("node_modules", "**/node_modules/*"))),
+      if (enableEsm()) Some("ts-node" -> ujson.Obj("esm" -> ujson.True, "swc" -> ujson.True))
+      else None
+    ).flatten.toMap: Map[String, ujson.Value]
+  }
+
+  // Execution :)
+
+  def mainFileName: T[String] = Task { s"$moduleName.ts" }
 
   def mainFilePath: T[Path] = Task { compile()._2.path / "src" / mainFileName() }
 
@@ -257,24 +488,43 @@ trait TypeScriptModule extends Module { outer =>
     val execFlags: Seq[String] = executionFlags().map {
       case (key, "") => s"--$key"
       case (key, value) => s"--$key=$value"
+      case _ => ""
     }.toSeq
 
+    val shellable: Shellable = if (!enableEsm()) (
+      "node",
+      execFlags,
+      tsnode,
+      "-r",
+      tsconfigpaths,
+      mainFile,
+      computedArgs(),
+      args.value
+    )
+    else (
+      "node",
+      execFlags,
+      "--loader",
+      "ts-node/esm",
+      "-r",
+      "tsconfig-paths/register",
+      "--no-warnings=ExperimentalWarning",
+      mainFile,
+      computedArgs(),
+      args.value
+    )
+
     os.call(
-      (
-        "node",
-        execFlags,
-        tsnode,
-        "-r",
-        tsconfigpaths,
-        mainFile,
-        computedArgs(),
-        args.value
-      ),
+      shellable,
       stdout = os.Inherit,
       env = env,
       cwd = compile()._1.path
     )
   }
+
+  // Execution
+
+  // bundle :)
 
   def bundleExternal: T[Seq[ujson.Value]] = Task { Seq(ujson.Str("fs"), ujson.Str("path")) }
 
@@ -286,8 +536,10 @@ trait TypeScriptModule extends Module { outer =>
     )
   }
 
-  // configure esbuild with @esbuild-plugins/tsconfig-paths
-  // include .d.ts files
+  /**
+   * configure esbuild with `@esbuild-plugins/tsconfig-paths`
+   * include .d.ts files
+   */
   def bundleScriptBuilder: Task[String] = Task.Anon {
     val bundle = (Task.dest / "bundle.js").toString
     val rps = resources().map { p => p.path }.filter(os.exists)
@@ -367,8 +619,119 @@ trait TypeScriptModule extends Module { outer =>
     PathRef(bundle)
   }
 
+  // bundle
+
+  // test methods :)
+
+  private[javascriptlib] def coverageDirs: T[Seq[String]] = Task { Seq.empty[String] }
+
+  private[javascriptlib] def outerModuleName: Option[String] = None
+
   trait TypeScriptTests extends TypeScriptModule {
     override def moduleDeps: Seq[TypeScriptModule] = Seq(outer) ++ outer.moduleDeps
+
+    override def outerModuleName: Option[String] = Some(outer.moduleName)
+
+    override def declarationDir: T[ujson.Value] = Task {
+      ujson.Str((outer.compileDir().path / "declarations").toString)
+    }
+
+    override def sources: T[Seq[PathRef]] = Task.Sources(moduleDir)
+
+    def allSources: T[IndexedSeq[PathRef]] =
+      Task {
+        val fileExt: Path => Boolean = _.ext == "ts"
+        sources()
+          .toIndexedSeq
+          .flatMap(pr => os.walk(pr.path))
+          .filter(fileExt)
+          .map(PathRef(_))
+      }
+
+    def testResourcesPath: T[Seq[(String, String)]] = Task {
+      Seq((
+        "@test/resources/*",
+        s"typescript/test/resources"
+      ))
+    }
+
+    override def compilerOptionsBuilder: T[Map[String, ujson.Value]] = Task {
+      val combinedPaths =
+        outer.upstreamPathsBuilder() ++
+          upstreamPathsBuilder() ++
+          outer.generatedSourcesPathsBuilder() ++
+          outer.modulePaths() ++
+          outer.compilerOptionsPaths().toSeq ++
+          testResourcesPath()
+
+      val combinedCompilerOptions: Map[String, ujson.Value] =
+        outer.compilerOptions() ++ compilerOptions() ++ Map(
+          "declarationDir" -> outer.declarationDir(),
+          "paths" -> ujson.Obj.from(combinedPaths.map { case (k, v) =>
+            val splitValues =
+              v.split(":").map(s => s"$s/*") // Split by ":" and append "/*" to each part
+            (k, ujson.Arr.from(splitValues))
+          })
+        )
+
+      combinedCompilerOptions
+    }
+
+    override def compile: T[(PathRef, PathRef)] = Task {
+      outer.compile()
+
+      val files: IndexedSeq[String] = allSources()
+        .map(x => "typescript/test/" + x.path.relativeTo(moduleDir)) ++
+        outer.tscAllSources()
+
+      // mv compileDir<outer> to compilerDir<test>
+      os.list(outer.compileDir().path)
+        .filter(item =>
+          item.last != "tsconfig.json" &&
+            item.last != "package-lock.json" &&
+            !(item.last == "node_modules" && os.isDir(
+              item
+            ))
+        )
+        .foreach(item => os.copy.over(item, compileDir().path / item.last, createFolders = true))
+
+      os.symlink(compileDir().path / "node_modules", npmInstall().path / "node_modules")
+      os.symlink(compileDir().path / "package-lock.json", npmInstall().path / "package-lock.json")
+
+      // inject test specific tsconfig into compileDir<outer> test config
+      os.write(
+        compileDir().path / "tsconfig.json",
+        ujson.Obj(
+          "compilerOptions" -> ujson.Obj.from(
+            compilerOptionsBuilder().toSeq ++ Seq("typeRoots" -> outer.typeRoots())
+          ),
+          "files" -> files
+        )
+      )
+
+      (PathRef(compileDir().path), PathRef(compileDir().path / "typescript"))
+    }
+
+    override def npmInstall: T[PathRef] = Task {
+      os.call(
+        (
+          "npm",
+          "install",
+          "--userconfig",
+          ".npmrc",
+          "--save-dev",
+          transitiveNpmDeps(),
+          transitiveNpmDevDeps(),
+          transitiveUnmanagedDeps().map(_.path.toString)
+        ),
+        cwd = outer.npmInstall().path
+      )
+      outer.npmInstall()
+    }
+
+    override private[javascriptlib] def coverageDirs: T[Seq[String]] =
+      Task { outer.tscAllSources() }
+
   }
 
 }

--- a/javascriptlib/test/src/mill/javascriptlib/HelloWorldTests.scala
+++ b/javascriptlib/test/src/mill/javascriptlib/HelloWorldTests.scala
@@ -10,15 +10,15 @@ import java.io.{ByteArrayOutputStream, PrintStream}
 object HelloWorldTests extends TestSuite {
 
   object HelloWorldJavascript extends TestBaseModule {
-    object foo extends TypeScriptModule {
-      object bar extends TypeScriptModule {}
+    object foo extends TscModule {
+      object bar extends TscModule {}
 
-      override def moduleDeps: Seq[TypeScriptModule] = Seq(bar)
+      override def moduleDeps: Seq[TscModule] = Seq(bar)
 
     }
 
-    object qux extends TypeScriptModule {
-      override def moduleDeps: Seq[TypeScriptModule] = Seq(foo, foo.bar)
+    object qux extends TscModule {
+      override def moduleDeps: Seq[TscModule] = Seq(foo, foo.bar)
     }
 
     lazy val millDiscover = Discover[this.type]

--- a/website/docs/modules/ROOT/pages/extending/example-typescript-support.adoc
+++ b/website/docs/modules/ROOT/pages/extending/example-typescript-support.adoc
@@ -3,7 +3,7 @@
 
 
 This section walks through the process of adding support for a new programming
-language to Mill. We will be adding a small `trait TypeScriptModule` with the
+language to Mill. We will be adding a small `trait TscModule` with the
 ability to resolve dependencies, typecheck local code, and optimize a final
 bundle.
 
@@ -30,10 +30,10 @@ include::partial$example/extending/typescript/4-npm-deps-bundle.adoc[]
 
 
 
-As mentioned earlier, the `TypeScriptModule` examples on this page are meant for
+As mentioned earlier, the `TscModule` examples on this page are meant for
 demo purposes: to show what it looks like to add support in Mill for a new
 programming language toolchain. It would take significantly more work to flesh out
-the featureset and performance of `TypeScriptModule` to be usable in a real world
+the featur eset and performance of `TscModule` to be usable in a real world
 build. But this should be enough to get you started working with Mill to add support
 to any language you need: whether it's TypeScript or some other language, most programming
 language toolchains have similar concepts of `compile`, `run`, `bundle`, etc.


### PR DESCRIPTION
- [x] allow use of `package` RootModule with TscModule
- [x] allow use of relative paths
- [x] add esm support; use swc-core for compiling