### PR TITLE
Fix curl check in Windows wrapper script

### DIFF
--- a/mill.bat
+++ b/mill.bat
@@ -140,7 +140,7 @@ if not exist "%MILL%" (
 
     for /F "delims=- tokens=1" %%A in ("!MILL_VERSION!") do set MILL_VERSION_BASE=%%A
     for /F "delims=- tokens=2" %%A in ("!MILL_VERSION!") do set MILL_VERSION_MILESTONE=%%A
-	set VERSION_MILESTONE_START=!MILL_VERSION_MILESTONE:~0,1!
+    set VERSION_MILESTONE_START=!MILL_VERSION_MILESTONE:~0,1!
     if [!VERSION_MILESTONE_START!]==[M] (
         set MILL_VERSION_TAG="!MILL_VERSION_BASE!-!MILL_VERSION_MILESTONE!"
     ) else (
@@ -162,7 +162,7 @@ if not exist "%MILL%" (
     rem curl is bundled with recent Windows 10
     rem but I don't think we can expect all the users to have it in 2019
     where /Q curl
-    if %ERRORLEVEL% EQU 0 (
+    if !ERRORLEVEL! EQU 0 (
         curl -f -L "!DOWNLOAD_URL!" -o "!DOWNLOAD_FILE!"
     ) else (
         rem bitsadmin seems to be available on Windows 7


### PR DESCRIPTION
The curl check in the `mill.bat` wrapper script is actually broken:

```batch
if not exist "%MILL%" (
    ...
    where /Q curl
    if %ERRORLEVEL% EQU 0 (
        curl -f -L "!DOWNLOAD_URL!" -o "!DOWNLOAD_FILE!"
    )
```

The `%ERRORLEVEL%` is inside of nested `if`, so it will be the value of `ERRORLEVEL` when `if not exist "%MILL%"` is executed, not the result of `where /Q curl`. It should be replaced with `!ERRORLEVEL!` to get the correct result.

Some minor indentation fixes are also included.