### PR TITLE
Add the organization name and url/homepage members to `PomSettings`

### DIFF
--- a/scalalib/src/mill/scalalib/publish/settings.scala
+++ b/scalalib/src/mill/scalalib/publish/settings.scala
@@ -69,13 +69,32 @@ case class Developer(
 case class PomSettings(
     description: String,
     organization: String,
+    organizationName: String,
     url: String,
     licenses: Seq[License],
     versionControl: VersionControl,
-    developers: Seq[Developer],
-    @deprecated("Value will be ignored. Use PublishModule.pomPackagingType instead", "Mill 0.11.8")
-    packaging: String = PackagingType.Jar
+    developers: Seq[Developer]
 ) derives RW
+
+object PomSettings {
+  @deprecated(
+    "This method is for backward compatibility. Use the one with `organizationName` instead."
+  )
+  def apply(
+      description: String,
+      organization: String,
+      url: String,
+      licenses: Seq[License],
+      versionControl: VersionControl,
+      developers: Seq[Developer],
+      @deprecated(
+        "Value will be ignored. Use PublishModule.pomPackagingType instead",
+        "Mill 0.11.8"
+      )
+      packaging: String = PackagingType.Jar
+  ): PomSettings =
+    PomSettings(description, organization, "", url, licenses, versionControl, developers)
+}
 
 object PackagingType {
   val Pom = "pom"


### PR DESCRIPTION
The `PomSettings.organization` member corresponds to a Maven group. The organization name and url properties are available in [Maven](https://maven.apache.org/pom.html#Organization), [Gradle](https://docs.gradle.org/current/dsl/org.gradle.api.publish.maven.MavenPomOrganization.html), and [sbt](https://www.scala-sbt.org/1.x/docs/Howto-Project-Metadata.html#Set+the+project+organization). Shall we add them in `PomSettings` for Mill too?

I haven't added the `organizationUrl`/`organizationHomepage` member yet as I am not sure whether we stick to the former name (more similar to Maven and Gradle) or the latter (consistent with sbt). I have added a backward-comaptible companion object `apply` method for the code to work with minimal modification and haven't updated the callers yet.