### PR TITLE
Add an `email` member to `Developer`

### DIFF
--- a/scalalib/src/mill/scalalib/publish/settings.scala
+++ b/scalalib/src/mill/scalalib/publish/settings.scala
@@ -67,20 +67,6 @@ case class Developer(
     organizationUrl: Option[String] = None
 ) derives RW
 
-object Developer {
-  @deprecated(
-    "This method is for backward compatibility. Use the one with `email` instead."
-  )
-  def apply(
-      id: String,
-      name: String,
-      url: String,
-      organization: Option[String],
-      organizationUrl: Option[String]
-  ) =
-    new Developer(id, name, None, url, organization, organizationUrl)
-}
-
 case class PomSettings(
     description: String,
     organization: String,

--- a/scalalib/src/mill/scalalib/publish/settings.scala
+++ b/scalalib/src/mill/scalalib/publish/settings.scala
@@ -61,10 +61,25 @@ case class Dependency(
 case class Developer(
     id: String,
     name: String,
+    email: Option[String] = None,
     url: String,
     organization: Option[String] = None,
     organizationUrl: Option[String] = None
 ) derives RW
+
+object Developer {
+  @deprecated(
+    "This method is for backward compatibility. Use the one with `email` instead."
+  )
+  def apply(
+      id: String,
+      name: String,
+      url: String,
+      organization: Option[String],
+      organizationUrl: Option[String]
+  ) =
+    new Developer(id, name, None, url, organization, organizationUrl)
+}
 
 case class PomSettings(
     description: String,


### PR DESCRIPTION
Similar to #4654. The `email` member is available in [Maven](https://maven.apache.org/pom.html#Developers), [Gradle](https://docs.gradle.org/current/dsl/org.gradle.api.publish.maven.MavenPomDeveloper.html#org.gradle.api.publish.maven.MavenPomDeveloper:email), and [sbt](https://github.com/sbt/librarymanagement/blob/9bcfbef2b7f4268fb48bbf6a1c17748f1e198eb1/core/src/main/contraband-scala/sbt/librarymanagement/Developer.scala). Shall we add it here too?

In sbt's official code, however, it's unclear to me why [they pass the (GitHub) ID to the `email` member](https://github.com/sbt/sbt/blob/3529e202799abc6a381a1f02cd527d7b8ff88034/build.sbt#L29-L40).

Compared to #4654, I don't think there is a way to make this change in a backward-compatible way with the default arguments though.

This is just a proposal so the changes are far from complete. Please let me know whether it's necessary.