### PR TITLE
More logger cleanups

### DIFF
--- a/bsp/src/mill/bsp/BspContext.scala
+++ b/bsp/src/mill/bsp/BspContext.scala
@@ -42,7 +42,6 @@ private[mill] class BspContext(
       canReload: Boolean
   ): Result[BspServerHandle] = {
     val log: Logger = new Logger {
-      override def colored: Boolean = false
       override def streams: SystemStreams = new SystemStreams(
         out = streams0.out,
         err = streams0.err,

--- a/bsp/worker/src/mill/bsp/worker/MillBspLogger.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBspLogger.scala
@@ -20,8 +20,6 @@ import mill.internal.ProxyLogger
 private class MillBspLogger(client: BuildClient, taskId: Int, logger: Logger)
     extends ProxyLogger(logger)
     with Logger {
-  override def infoColor = fansi.Color.Blue
-  override def errorColor = fansi.Color.Red
 
   override def ticker(s: String): Unit = {
     try {

--- a/core/api/src/mill/api/Logger.scala
+++ b/core/api/src/mill/api/Logger.scala
@@ -36,7 +36,7 @@ trait Logger {
 
   private[mill] def prompt: Logger.Prompt
 
-  private[mill] def withPromptLine[T](t: => T): T = {
+  private[mill] final def withPromptLine[T](t: => T): T = {
     prompt.setPromptLine(logPrefixKey, keySuffix, message)
     try t
     finally prompt.removePromptLine(logPrefixKey)

--- a/core/api/src/mill/api/Logger.scala
+++ b/core/api/src/mill/api/Logger.scala
@@ -25,9 +25,6 @@ import java.io.PrintStream
  * used to display the final `show` output for easy piping.
  */
 trait Logger {
-  def infoColor: fansi.Attrs = fansi.Attrs.Empty
-  def errorColor: fansi.Attrs = fansi.Attrs.Empty
-  def colored: Boolean
 
   private[mill] def unprefixedStreams: SystemStreams = streams
   def streams: SystemStreams
@@ -60,6 +57,7 @@ object Logger {
    * to logger unchanged without any customization.
    */
   trait Prompt {
+
     private[mill] def setPromptDetail(key: Seq[String], s: String): Unit
     private[mill] def reportKey(key: Seq[String]): Unit
     private[mill] def setPromptLine(key: Seq[String], keySuffix: String, message: String): Unit
@@ -72,6 +70,11 @@ object Logger {
     def debugEnabled: Boolean
 
     def enableTicker: Boolean
+
+    def infoColor: fansi.Attrs
+
+    def errorColor: fansi.Attrs
+    def colored: Boolean
   }
   object Prompt {
     class NoOp extends Prompt {
@@ -88,6 +91,9 @@ object Logger {
       def debugEnabled: Boolean = false
 
       def enableTicker: Boolean = false
+      def infoColor: fansi.Attrs = fansi.Attrs.Empty
+      def errorColor: fansi.Attrs = fansi.Attrs.Empty
+      def colored: Boolean = false
     }
   }
 }

--- a/core/api/src/mill/api/Logger.scala
+++ b/core/api/src/mill/api/Logger.scala
@@ -39,9 +39,6 @@ trait Logger {
 
   private[mill] def prompt: Logger.Prompt
 
-  private[mill] def subLogger(path: os.Path, keySuffix: String, message: String): Logger =
-    this
-
   private[mill] def withPromptLine[T](t: => T): T = {
     prompt.setPromptLine(logPrefixKey, keySuffix, message)
     try t

--- a/core/exec/src/mill/exec/ExecutionContexts.scala
+++ b/core/exec/src/mill/exec/ExecutionContexts.scala
@@ -1,5 +1,6 @@
 package mill.exec
 
+import mill.internal.PrefixLogger
 import os.Path
 
 import scala.concurrent.{Await, Future}
@@ -84,7 +85,7 @@ private object ExecutionContexts {
     def async[T](dest: Path, key: String, message: String)(t: => T)(implicit
         ctx: mill.api.Ctx
     ): Future[T] = {
-      val logger = ctx.log.subLogger(dest / os.up / s"${dest.last}.log", key, message)
+      val logger = new PrefixLogger(ctx.log, Seq(key), ctx.log.keySuffix, message)
 
       var destInitialized: Boolean = false
       def makeDest() = synchronized {

--- a/core/exec/src/mill/exec/ExecutionContexts.scala
+++ b/core/exec/src/mill/exec/ExecutionContexts.scala
@@ -1,6 +1,6 @@
 package mill.exec
 
-import mill.internal.PrefixLogger
+import mill.internal.{FileLogger, MultiLogger, PrefixLogger}
 import os.Path
 
 import scala.concurrent.{Await, Future}
@@ -85,7 +85,11 @@ private object ExecutionContexts {
     def async[T](dest: Path, key: String, message: String)(t: => T)(implicit
         ctx: mill.api.Ctx
     ): Future[T] = {
-      val logger = new PrefixLogger(ctx.log, Seq(key), ctx.log.keySuffix, message)
+      val logger = new MultiLogger(
+        new PrefixLogger(ctx.log, Seq(key), ctx.log.keySuffix, message),
+        new FileLogger(dest / os.up / s"${dest.last}.log", false),
+        ctx.log.streams.in
+      )
 
       var destInitialized: Boolean = false
       def makeDest() = synchronized {

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -377,9 +377,8 @@ private trait GroupExecution {
     logPath match {
       case None => (logger, None)
       case Some(path) =>
-        val fileLogger = new FileLogger(logger.colored, path)
+        val fileLogger = new FileLogger(path)
         val multiLogger = new MultiLogger(
-          logger.colored,
           logger,
           fileLogger,
           logger.streams.in

--- a/core/internal/src/mill/internal/FileLogger.scala
+++ b/core/internal/src/mill/internal/FileLogger.scala
@@ -6,7 +6,6 @@ import java.io.{OutputStream, PrintStream}
 import java.nio.file.{Files, StandardOpenOption}
 
 private[mill] class FileLogger(
-    override val colored: Boolean,
     file: os.Path,
     append: Boolean = false
 ) extends Logger with AutoCloseable {
@@ -52,6 +51,5 @@ private[mill] class FileLogger(
     if (outputStreamUsed)
       streams.out.close()
   }
-  def enableTicker = false
   def prompt = new Logger.Prompt.NoOp
 }

--- a/core/internal/src/mill/internal/FileLogger.scala
+++ b/core/internal/src/mill/internal/FileLogger.scala
@@ -54,7 +54,4 @@ private[mill] class FileLogger(
   }
   def enableTicker = false
   def prompt = new Logger.Prompt.NoOp
-  override def subLogger(path: os.Path, keySuffix: String, message: String): Logger = {
-    new FileLogger(colored, path, append)
-  }
 }

--- a/core/internal/src/mill/internal/MultiLogger.scala
+++ b/core/internal/src/mill/internal/MultiLogger.scala
@@ -6,7 +6,6 @@ import mill.api.{Logger, SystemStreams}
 import java.io.{InputStream, PrintStream}
 
 private[mill] class MultiLogger(
-    val colored: Boolean,
     val logger1: Logger,
     val logger2: Logger,
     val inStream0: InputStream
@@ -84,19 +83,21 @@ private[mill] class MultiLogger(
     override def enableTicker: Boolean = logger1.prompt.enableTicker || logger2.prompt.enableTicker
 
     override def debugEnabled: Boolean = logger1.prompt.debugEnabled || logger2.prompt.debugEnabled
+
+    override def infoColor: Attrs = logger1.prompt.infoColor ++ logger2.prompt.infoColor
+
+    override def errorColor: Attrs = logger1.prompt.errorColor ++ logger2.prompt.errorColor
+    override def colored: Boolean = logger1.prompt.colored || logger2.prompt.colored
   }
   def debug(s: String): Unit = {
     logger1.debug(s)
     logger2.debug(s)
   }
 
-  override def infoColor: Attrs = logger1.infoColor ++ logger2.infoColor
-  override def errorColor: Attrs = logger1.errorColor ++ logger2.errorColor
   private[mill] override def logPrefixKey = logger1.logPrefixKey ++ logger2.logPrefixKey
 
   override def withOutStream(outStream: PrintStream): Logger = {
     new MultiLogger(
-      colored,
       logger1.withOutStream(outStream),
       logger2.withOutStream(outStream),
       inStream0

--- a/core/internal/src/mill/internal/MultiLogger.scala
+++ b/core/internal/src/mill/internal/MultiLogger.scala
@@ -90,15 +90,6 @@ private[mill] class MultiLogger(
     logger2.debug(s)
   }
 
-  private[mill] override def subLogger(path: os.Path, key: String, message: String): Logger = {
-    new MultiLogger(
-      colored,
-      logger1.subLogger(path, key, message),
-      logger2.subLogger(path, key, message),
-      inStream0
-    )
-  }
-
   override def infoColor: Attrs = logger1.infoColor ++ logger2.infoColor
   override def errorColor: Attrs = logger1.errorColor ++ logger2.errorColor
   private[mill] override def logPrefixKey = logger1.logPrefixKey ++ logger2.logPrefixKey

--- a/core/internal/src/mill/internal/PrefixLogger.scala
+++ b/core/internal/src/mill/internal/PrefixLogger.scala
@@ -89,8 +89,4 @@ private[mill] class PrefixLogger(
       PrefixLogger.this.streams.in
     )
   }
-
-  private[mill] override def subLogger(path: os.Path, subKey: String, message: String): Logger = {
-    new PrefixLogger(this, Seq(subKey), keySuffix, message)
-  }
 }

--- a/core/internal/src/mill/internal/PrefixLogger.scala
+++ b/core/internal/src/mill/internal/PrefixLogger.scala
@@ -9,14 +9,14 @@ import java.io.PrintStream
  *
  * Generates log lines of the form
  *
- * [$logPrefixKey/$keySuffix] $message
- * [$logPrefixKey] ...logs...
- * [$logPrefixKey] ...logs...
- * [$logPrefixKey] ...logs...
+ * [$parentKeys-$key0/$keySuffix] $message
+ * [$parentKeys-$key0] ...logs...
+ * [$parentKeys-$key0] ...logs...
+ * [$parentKeys-$key0] ...logs...
  *
  * And a prompt line of the form
  *
- * [$logPrefixKey] $message
+ * [$parentKeys-$key0] $message
  */
 private[mill] class PrefixLogger(
     val logger0: Logger,

--- a/core/internal/src/mill/internal/PrefixLogger.scala
+++ b/core/internal/src/mill/internal/PrefixLogger.scala
@@ -36,14 +36,9 @@ private[mill] class PrefixLogger(
   override def toString: String =
     s"PrefixLogger($logger0, $key0)"
 
-  override def colored = logger0.colored
-
-  override def infoColor = logger0.infoColor
-  override def errorColor = logger0.errorColor
-
   def prefixPrintStream(stream: java.io.OutputStream) = {
     new PrintStream(new LinePrefixOutputStream(
-      infoColor(linePrefix).render,
+      prompt.infoColor(linePrefix).render,
       stream,
       () => prompt.reportKey(logPrefixKey)
     ))
@@ -62,11 +57,11 @@ private[mill] class PrefixLogger(
 
   override def info(s: String): Unit = {
     prompt.reportKey(logPrefixKey)
-    logger0.info("" + infoColor(linePrefix) + s)
+    logger0.info("" + prompt.infoColor(linePrefix) + s)
   }
   override def error(s: String): Unit = {
     prompt.reportKey(logPrefixKey)
-    logger0.error("" + infoColor(linePrefix) + s)
+    logger0.error("" + prompt.infoColor(linePrefix) + s)
   }
   override def ticker(s: String): Unit = prompt.setPromptDetail(logPrefixKey, s)
 
@@ -74,7 +69,7 @@ private[mill] class PrefixLogger(
 
   override def debug(s: String): Unit = {
     if (prompt.debugEnabled) prompt.reportKey(logPrefixKey)
-    logger0.debug("" + infoColor(linePrefix) + s)
+    logger0.debug("" + prompt.infoColor(linePrefix) + s)
   }
   override def withOutStream(outStream: PrintStream): Logger = new ProxyLogger(this) with Logger {
     override lazy val unprefixedStreams = new SystemStreams(

--- a/core/internal/src/mill/internal/PrintLogger.scala
+++ b/core/internal/src/mill/internal/PrintLogger.scala
@@ -5,10 +5,10 @@ import mill.api.{Logger, SystemStreams}
 import java.io.*
 
 private[mill] class PrintLogger(
-    override val colored: Boolean,
+    colored: Boolean,
     enableTicker: Boolean,
-    override val infoColor: fansi.Attrs,
-    override val errorColor: fansi.Attrs,
+    infoColor: fansi.Attrs,
+    errorColor: fansi.Attrs,
     val streams: SystemStreams,
     debugEnabled: Boolean,
     val context: String,
@@ -32,6 +32,11 @@ private[mill] class PrintLogger(
     }
 
     override def enableTicker: Boolean = PrintLogger.this.enableTicker
+
+    override def infoColor: fansi.Attrs = PrintLogger.this.infoColor
+
+    override def errorColor: fansi.Attrs = PrintLogger.this.errorColor
+    override def colored: Boolean = PrintLogger.this.colored
   }
   def ticker(s: String): Unit = synchronized {
     if (enableTicker) {

--- a/core/internal/src/mill/internal/PromptLogger.scala
+++ b/core/internal/src/mill/internal/PromptLogger.scala
@@ -17,10 +17,10 @@ import java.io.*
  * buffer to be read out and handled asynchronously.
  */
 private[mill] class PromptLogger(
-    override val colored: Boolean,
+    colored: Boolean,
     enableTicker: Boolean,
-    override val infoColor: fansi.Attrs,
-    override val errorColor: fansi.Attrs,
+    infoColor: fansi.Attrs,
+    errorColor: fansi.Attrs,
     systemStreams0: SystemStreams,
     debugEnabled: Boolean,
     titleText: String,
@@ -145,6 +145,10 @@ private[mill] class PromptLogger(
 
     def enableTicker = PromptLogger.this.enableTicker
     def debugEnabled = PromptLogger.this.debugEnabled
+
+    def infoColor: fansi.Attrs = PromptLogger.this.infoColor
+    def errorColor: fansi.Attrs = PromptLogger.this.errorColor
+    def colored: Boolean = PromptLogger.this.colored
   }
   def ticker(s: String): Unit = ()
 

--- a/core/internal/src/mill/internal/ProxyLogger.scala
+++ b/core/internal/src/mill/internal/ProxyLogger.scala
@@ -8,7 +8,6 @@ import mill.api.{Logger, SystemStreams}
  */
 private[mill] class ProxyLogger(logger: Logger) extends Logger {
   override def toString: String = s"ProxyLogger($logger)"
-  def colored = logger.colored
 
   lazy val streams = logger.streams
 
@@ -19,8 +18,6 @@ private[mill] class ProxyLogger(logger: Logger) extends Logger {
 
   def prompt = logger.prompt
 
-  override def infoColor: fansi.Attrs = logger.infoColor
-  override def errorColor: fansi.Attrs = logger.errorColor
   private[mill] override def logPrefixKey: Seq[String] = logger.logPrefixKey
   private[mill] override def unprefixedStreams: SystemStreams = logger.unprefixedStreams
 }

--- a/pythonlib/src/mill/pythonlib/PythonModule.scala
+++ b/pythonlib/src/mill/pythonlib/PythonModule.scala
@@ -132,7 +132,7 @@ trait PythonModule extends PipModule with TaskModule { outer =>
     Map(
       "PYTHONPATH" -> transitivePythonPath().map(_.path).mkString(java.io.File.pathSeparator),
       "PYTHONPYCACHEPREFIX" -> (Task.dest / "cache").toString,
-      if (Task.log.colored) { "FORCE_COLOR" -> "1" }
+      if (Task.log.prompt.colored) { "FORCE_COLOR" -> "1" }
       else { "NO_COLOR" -> "1" }
     )
   }

--- a/scalalib/src/mill/scalalib/TestModule.scala
+++ b/scalalib/src/mill/scalalib/TestModule.scala
@@ -155,7 +155,7 @@ trait TestModule
         arguments = args(),
         sysProps = Map.empty,
         outputPath = outputPath,
-        colored = Task.log.colored,
+        colored = Task.log.prompt.colored,
         testCp = testClasspath().map(_.path),
         globSelectors = selectors
       )

--- a/scalalib/src/mill/scalalib/TestModuleUtil.scala
+++ b/scalalib/src/mill/scalalib/TestModuleUtil.scala
@@ -51,7 +51,7 @@ private[scalalib] object TestModuleUtil {
         arguments = args,
         sysProps = props,
         outputPath = outputPath,
-        colored = Task.log.colored,
+        colored = Task.log.prompt.colored,
         testCp = testClasspath.map(_.path),
         globSelectors = selectors2
       )

--- a/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
+++ b/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
@@ -538,8 +538,8 @@ class ZincWorkerImpl(
     val consoleAppender = ConsoleAppender(
       "ZincLogAppender",
       ConsoleOut.printStreamOut(ctx.log.streams.err),
-      ctx.log.colored,
-      ctx.log.colored,
+      ctx.log.prompt.colored,
+      ctx.log.prompt.colored,
       _ => None
     )
     val loggerId = Thread.currentThread().getId.toString
@@ -548,12 +548,12 @@ class ZincWorkerImpl(
     def mkNewReporter(mapper: (xsbti.Position => xsbti.Position) | Null) = reporter match {
       case None =>
         new ManagedLoggedReporter(10, logger) with RecordingReporter
-          with TransformingReporter(ctx.log.colored, mapper) {}
+          with TransformingReporter(ctx.log.prompt.colored, mapper) {}
       case Some(forwarder) =>
         new ManagedLoggedReporter(10, logger)
           with ForwardingReporter(forwarder)
           with RecordingReporter
-          with TransformingReporter(ctx.log.colored, mapper) {}
+          with TransformingReporter(ctx.log.prompt.colored, mapper) {}
     }
     val analysisMap0 = upstreamCompileOutput.map(c => c.classes.path -> c.analysisFile).toMap
 
@@ -645,7 +645,7 @@ class ZincWorkerImpl(
     val scalaColorProp = "scala.color"
     val previousScalaColor = sys.props(scalaColorProp)
     try {
-      sys.props(scalaColorProp) = if (ctx.log.colored) "true" else "false"
+      sys.props(scalaColorProp) = if (ctx.log.prompt.colored) "true" else "false"
       val newResult = ic.compile(
         in = inputs,
         logger = logger


### PR DESCRIPTION
Another part of https://github.com/com-lihaoyi/mill/issues/3603

More narrowing of the `Logger` interface so we can figure out what really needs to be there

- Moved `colored`, `infoColor`, `errorColor` to the `prompt` object since it's not typically overriden
- Inlined the `subLogger` calls at its one call-site