### PR TITLE
Use `Dep.version` where appropriate

### DIFF
--- a/bsp/package.mill
+++ b/bsp/package.mill
@@ -14,7 +14,7 @@ object `package` extends RootModule with build.MillPublishScalaModule with Build
     Seq(
       BuildInfo.Value(
         "bsp4jVersion",
-        build.Deps.bsp4j.dep.version,
+        build.Deps.bsp4j.version,
         "BSP4j version (BSP Protocol version)."
       )
     )
@@ -28,7 +28,7 @@ object `package` extends RootModule with build.MillPublishScalaModule with Build
       super.forkEnv()
     }
 
-    def forkArgs = super.forkArgs() ++ Seq(s"-DBSP4J_VERSION=${build.Deps.bsp4j.dep.version}")
+    def forkArgs = super.forkArgs() ++ Seq(s"-DBSP4J_VERSION=${build.Deps.bsp4j.version}")
   }
 
   object worker extends build.MillPublishScalaModule {

--- a/build.mill
+++ b/build.mill
@@ -422,7 +422,7 @@ trait MillJavaModule extends JavaModule {
         f.dep.module.organization.value == dep.module.organization.value &&
           f.dep.module.name.value == dep.module.name.value
       ).map { forced =>
-        val newDep = dep.withVersion(forced.dep.version)
+        val newDep = dep.withVersion(forced.version)
         Task.log.debug(s"Forcing version of ${dep.module} from ${dep.version} to ${newDep.version}")
         newDep
       }.getOrElse(dep)
@@ -564,12 +564,12 @@ trait MillBaseTestsModule extends TestModule {
       s"-DTEST_SCALA_3_3_VERSION=${Deps.testScala33Version}",
       s"-DTEST_SCALAJS_VERSION=${Deps.Scalajs_1.scalaJsVersion}",
       s"-DTEST_SCALANATIVE_0_5_VERSION=${Deps.Scalanative_0_5.scalanativeVersion}",
-      s"-DTEST_UTEST_VERSION=${Deps.TestDeps.utest.dep.version}",
-      s"-DTEST_SCALATEST_VERSION=${Deps.TestDeps.scalaTest.dep.version}",
-      s"-DTEST_TEST_INTERFACE_VERSION=${Deps.sbtTestInterface.dep.version}",
-      s"-DTEST_ZIOTEST_VERSION=${Deps.TestDeps.zioTest.dep.version}",
-      s"-DTEST_ZINC_VERSION=${Deps.zinc.dep.version}",
-      s"-DTEST_KOTLIN_VERSION=${Deps.kotlinCompiler.dep.version}"
+      s"-DTEST_UTEST_VERSION=${Deps.TestDeps.utest.version}",
+      s"-DTEST_SCALATEST_VERSION=${Deps.TestDeps.scalaTest.version}",
+      s"-DTEST_TEST_INTERFACE_VERSION=${Deps.sbtTestInterface.version}",
+      s"-DTEST_ZIOTEST_VERSION=${Deps.TestDeps.zioTest.version}",
+      s"-DTEST_ZINC_VERSION=${Deps.zinc.version}",
+      s"-DTEST_KOTLIN_VERSION=${Deps.kotlinCompiler.version}"
     )
   }
 

--- a/contrib/package.mill
+++ b/contrib/package.mill
@@ -118,7 +118,7 @@ object `package` extends RootModule {
     def testArgs = Task {
       super.testArgs() ++
         Seq(
-          s"-DMILL_SCOVERAGE2_VERSION=${build.Deps.scalacScoverage2Plugin.dep.version}"
+          s"-DMILL_SCOVERAGE2_VERSION=${build.Deps.scalacScoverage2Plugin.version}"
         )
     }
 
@@ -179,7 +179,7 @@ object `package` extends RootModule {
 
     def buildInfoPackageName = "mill.contrib.bloop"
     def buildInfoObjectName = "Versions"
-    def buildInfoMembers = Seq(BuildInfo.Value("bloop", build.Deps.bloopConfig.dep.version))
+    def buildInfoMembers = Seq(BuildInfo.Value("bloop", build.Deps.bloopConfig.version))
   }
 
   object artifactory extends ContribModule {

--- a/example/javalib/module/2-custom-tasks/build.mill
+++ b/example/javalib/module/2-custom-tasks/build.mill
@@ -7,9 +7,9 @@ object `package` extends RootModule with JavaModule {
 
   def generatedSources: T[Seq[PathRef]] = Task {
     val prettyIvyDeps = for (ivyDep <- ivyDeps()) yield {
-      val org = ivyDep.dep.module.organization.value
-      val name = ivyDep.dep.module.name.value
-      val version = ivyDep.dep.version
+      val org = ivyDep.organization
+      val name = ivyDep.name
+      val version = ivyDep.version
       s""" "$org:$name:$version" """
     }
     val ivyDepsString = prettyIvyDeps.mkString(" + \"\\n\" + \n")

--- a/example/kotlinlib/module/2-custom-tasks/build.mill
+++ b/example/kotlinlib/module/2-custom-tasks/build.mill
@@ -12,9 +12,9 @@ object `package` extends RootModule with KotlinModule {
 
   def generatedSources: T[Seq[PathRef]] = Task {
     val prettyIvyDeps = for (ivyDep <- ivyDeps()) yield {
-      val org = ivyDep.dep.module.organization.value
-      val name = ivyDep.dep.module.name.value
-      val version = ivyDep.dep.version
+      val org = ivyDep.organization
+      val name = ivyDep.name
+      val version = ivyDep.version
       s""" "$org:$name:$version" """
     }
     val ivyDepsString = prettyIvyDeps.mkString(" + \"\\n\" + \n")

--- a/example/scalalib/module/2-custom-tasks/build.mill
+++ b/example/scalalib/module/2-custom-tasks/build.mill
@@ -18,9 +18,9 @@ object `package` extends RootModule with ScalaModule {
 
   def generatedSources: T[Seq[PathRef]] = Task {
     val prettyIvyDeps = for (ivyDep <- ivyDeps()) yield {
-      val org = ivyDep.dep.module.organization.value
-      val name = ivyDep.dep.module.name.value
-      val version = ivyDep.dep.version
+      val org = ivyDep.organization
+      val name = ivyDep.name
+      val version = ivyDep.version
       s"""("$org", "$name", "$version")"""
     }
     os.write(

--- a/integration/package.mill
+++ b/integration/package.mill
@@ -99,7 +99,7 @@ object `package` extends RootModule {
     def forkEnv = super.forkEnv() ++ Seq(
       "MILL_PROJECT_ROOT" -> Task.workspace.toString,
       "TEST_SCALA_2_13_VERSION" -> build.Deps.testScala213Version,
-      "TEST_KOTLIN_VERSION" -> build.Deps.kotlinCompiler.dep.version
+      "TEST_KOTLIN_VERSION" -> build.Deps.kotlinCompiler.version
     )
   }
   trait IdeIntegrationCrossModule extends IntegrationCrossModule {

--- a/runner/src/mill/runner/MillMain.scala
+++ b/runner/src/mill/runner/MillMain.scala
@@ -367,7 +367,7 @@ object MillMain {
       serverDir: os.Path,
       colored: Boolean,
       colors: Colors
-  ): Logger with AutoCloseable = {
+  ): Logger & AutoCloseable = {
     new PromptLogger(
       colored = colored,
       enableTicker = enableTicker.getOrElse(true),

--- a/scalajslib/package.mill
+++ b/scalajslib/package.mill
@@ -18,7 +18,7 @@ object `package` extends RootModule with build.MillStableScalaModule with BuildI
 
     def formatDep(dep: Dep) = {
       val d = resolve(dep)
-      s"${d.dep.module.organization.value}:${d.dep.module.name.value}:${d.dep.version}"
+      s"${d.organization}:${d.name}:${d.version}"
     }
 
     Seq(

--- a/scalalib/package.mill
+++ b/scalalib/package.mill
@@ -42,20 +42,20 @@ object `package` extends RootModule with build.MillStableScalaModule {
 
     def buildInfoMembers = Seq(
       BuildInfo.Value("ammonite", build.Deps.ammoniteVersion, "Version of Ammonite."),
-      BuildInfo.Value("zinc", build.Deps.zinc.dep.version, "Version of Zinc"),
+      BuildInfo.Value("zinc", build.Deps.zinc.version, "Version of Zinc"),
       BuildInfo.Value(
         "scalafmtVersion",
-        build.Deps.scalafmtDynamic.dep.version,
+        build.Deps.scalafmtDynamic.version,
         "Version of Scalafmt"
       ),
       BuildInfo.Value(
         "semanticDBVersion",
-        build.Deps.semanticDBscala.dep.version,
+        build.Deps.semanticDBscala.version,
         "SemanticDB version."
       ),
       BuildInfo.Value(
         "semanticDbJavaVersion",
-        build.Deps.semanticDbJava.dep.version,
+        build.Deps.semanticDbJava.version,
         "Java SemanticDB plugin version."
       ),
       BuildInfo.Value(
@@ -93,7 +93,7 @@ object `package` extends RootModule with build.MillStableScalaModule {
     def buildInfoPackageName = "mill.scalalib.worker"
     def buildInfoObjectName = "Versions"
     def buildInfoMembers = Seq(
-      BuildInfo.Value("zinc", build.Deps.zinc.dep.version, "Version of Zinc.")
+      BuildInfo.Value("zinc", build.Deps.zinc.version, "Version of Zinc.")
     )
   }
 }

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -176,7 +176,7 @@ trait JavaModule
   def allBomDeps: Task[Seq[BomDependency]] = Task.Anon {
     val modVerOrMalformed =
       bomIvyDeps().map(bindDependency()).map { bomDep =>
-        val fromModVer = coursier.core.Dependency(bomDep.dep.module, bomDep.dep.version)
+        val fromModVer = coursier.core.Dependency(bomDep.dep.module, bomDep.version)
         if (fromModVer == bomDep.dep)
           Right(bomDep.dep.asBomDependency)
         else

--- a/scalalib/src/mill/scalalib/publish/settings.scala
+++ b/scalalib/src/mill/scalalib/publish/settings.scala
@@ -27,9 +27,9 @@ object Artifact {
     )
     Dependency(
       Artifact(
-        dep.dep.module.organization.value,
+        dep.organization,
         name,
-        dep.dep.version
+        dep.version
       ),
       Scope.Compile,
       dep.dep.optional,

--- a/website/package.mill
+++ b/website/package.mill
@@ -277,7 +277,7 @@ object `package` extends RootModule {
        |    mill-doc-url: ${if (authorMode) s"file://${Task.dest}/site" else build.Settings.docUrl}
        |    utest-github-url: https://github.com/com-lihaoyi/utest
        |    upickle-github-url: https://github.com/com-lihaoyi/upickle
-       |    mill-scip-version: ${build.Deps.DocDeps.millScip.dep.version}
+       |    mill-scip-version: ${build.Deps.DocDeps.millScip.version}
        |antora:
        |  extensions:
        |  - require: '@antora/lunr-extension'


### PR DESCRIPTION
Replace deeper calls into deprecated coursier API.