### PR TITLE
Fix multiline ANSI color preservation in PromptLogger

### DIFF
--- a/core/internal/src/mill/internal/LinePrefixOutputStream.scala
+++ b/core/internal/src/mill/internal/LinePrefixOutputStream.scala
@@ -61,7 +61,7 @@ private[mill] class LinePrefixOutputStream(
     if (inEscapeSequence) {
       escapeSequenceBuffer.append(b.toChar)
       // Check if this is the end of the escape sequence
-      if ((b >= 0x40 && b <= 0x7E) && b != '[') {
+      if ((b >= 0x40 && b <= 0x7e) && b != '[') {
         inEscapeSequence = false
         val sequence = escapeSequenceBuffer.toString
         // Process the complete escape sequence
@@ -90,7 +90,7 @@ private[mill] class LinePrefixOutputStream(
     while (i < max) {
       writeLinePrefixIfNecessary()
       processEscapeSequence(b(i))
-      
+
       if (b(i) == '\n') {
         i += 1 // +1 to include the newline
         buffer.write(b, start, i - start)

--- a/core/internal/test/src/mill/internal/LinePrefixOutputStreamTests.scala
+++ b/core/internal/test/src/mill/internal/LinePrefixOutputStreamTests.scala
@@ -78,7 +78,7 @@ object LinePrefixOutputStreamTests extends TestSuite {
       val baos = new ByteArrayOutputStream()
       val lpos = new LinePrefixOutputStream("PREFIX", baos)
       
-      // Test with color spanning multiple lines
+      // Test with color spanning multiple lines.
       val redStart = "\u001b[31m" // Red color
       val reset = "\u001b[0m"     // Reset color
       val input = s"${redStart}hello\nworld\n!${reset}"
@@ -94,7 +94,7 @@ object LinePrefixOutputStreamTests extends TestSuite {
       val baos = new ByteArrayOutputStream()
       val lpos = new LinePrefixOutputStream("PREFIX", baos)
       
-      // Write the ANSI sequence in parts
+      // Write the ANSI sequence in parts.
       lpos.write("\u001b".getBytes())
       lpos.write("[".getBytes())
       lpos.write("31".getBytes())

--- a/core/internal/test/src/mill/internal/LinePrefixOutputStreamTests.scala
+++ b/core/internal/test/src/mill/internal/LinePrefixOutputStreamTests.scala
@@ -73,5 +73,56 @@ object LinePrefixOutputStreamTests extends TestSuite {
       }
 
     }
+
+    test("multilineAnsiColors") {
+      val baos = new ByteArrayOutputStream()
+      val lpos = new LinePrefixOutputStream("PREFIX", baos)
+      
+      // Test with color spanning multiple lines
+      val redStart = "\u001b[31m" // Red color
+      val reset = "\u001b[0m"     // Reset color
+      val input = s"${redStart}hello\nworld\n!${reset}"
+      
+      lpos.write(input.getBytes())
+      lpos.flush()
+      
+      val expected = s"PREFIX${redStart}hello\nPREFIX${redStart}world\nPREFIX${redStart}!${reset}"
+      assert(baos.toString == expected)
+    }
+
+    test("splitAnsiSequence") {
+      val baos = new ByteArrayOutputStream()
+      val lpos = new LinePrefixOutputStream("PREFIX", baos)
+      
+      // Write the ANSI sequence in parts
+      lpos.write("\u001b".getBytes())
+      lpos.write("[".getBytes())
+      lpos.write("31".getBytes())
+      lpos.write("m".getBytes())
+      lpos.write("hello\n".getBytes())
+      lpos.write("world".getBytes())
+      lpos.write("\u001b[0m".getBytes())
+      lpos.flush()
+      
+      val expected = s"PREFIX\u001b[31mhello\nPREFIX\u001b[31mworld\u001b[0m"
+      assert(baos.toString == expected)
+    }
+
+    test("multipleColors") {
+      val baos = new ByteArrayOutputStream()
+      val lpos = new LinePrefixOutputStream("PREFIX", baos)
+      
+      val red = "\u001b[31m"    // Red
+      val green = "\u001b[32m"  // Green
+      val blue = "\u001b[34m"   // Blue
+      val reset = "\u001b[0m"   // Reset
+      
+      val input = s"${red}hello${green}\nworld${blue}\n!${reset}"
+      lpos.write(input.getBytes())
+      lpos.flush()
+      
+      val expected = s"PREFIX${red}hello${green}\nPREFIX${green}world${blue}\nPREFIX${blue}!${reset}"
+      assert(baos.toString == expected)
+    }
   }
 }

--- a/core/internal/test/src/mill/internal/LinePrefixOutputStreamTests.scala
+++ b/core/internal/test/src/mill/internal/LinePrefixOutputStreamTests.scala
@@ -77,15 +77,15 @@ object LinePrefixOutputStreamTests extends TestSuite {
     test("multilineAnsiColors") {
       val baos = new ByteArrayOutputStream()
       val lpos = new LinePrefixOutputStream("PREFIX", baos)
-      
+
       // Test with color spanning multiple lines.
       val redStart = "\u001b[31m" // Red color
-      val reset = "\u001b[0m"     // Reset color
+      val reset = "\u001b[0m" // Reset color
       val input = s"${redStart}hello\nworld\n!${reset}"
-      
+
       lpos.write(input.getBytes())
       lpos.flush()
-      
+
       val expected = s"PREFIX${redStart}hello\nPREFIX${redStart}world\nPREFIX${redStart}!${reset}"
       assert(baos.toString == expected)
     }
@@ -93,7 +93,7 @@ object LinePrefixOutputStreamTests extends TestSuite {
     test("splitAnsiSequence") {
       val baos = new ByteArrayOutputStream()
       val lpos = new LinePrefixOutputStream("PREFIX", baos)
-      
+
       // Write the ANSI sequence in parts.
       lpos.write("\u001b".getBytes())
       lpos.write("[".getBytes())
@@ -103,7 +103,7 @@ object LinePrefixOutputStreamTests extends TestSuite {
       lpos.write("world".getBytes())
       lpos.write("\u001b[0m".getBytes())
       lpos.flush()
-      
+
       val expected = s"PREFIX\u001b[31mhello\nPREFIX\u001b[31mworld\u001b[0m"
       assert(baos.toString == expected)
     }
@@ -111,17 +111,18 @@ object LinePrefixOutputStreamTests extends TestSuite {
     test("multipleColors") {
       val baos = new ByteArrayOutputStream()
       val lpos = new LinePrefixOutputStream("PREFIX", baos)
-      
-      val red = "\u001b[31m"    // Red
-      val green = "\u001b[32m"  // Green
-      val blue = "\u001b[34m"   // Blue
-      val reset = "\u001b[0m"   // Reset
-      
+
+      val red = "\u001b[31m" // Red
+      val green = "\u001b[32m" // Green
+      val blue = "\u001b[34m" // Blue
+      val reset = "\u001b[0m" // Reset
+
       val input = s"${red}hello${green}\nworld${blue}\n!${reset}"
       lpos.write(input.getBytes())
       lpos.flush()
-      
-      val expected = s"PREFIX${red}hello${green}\nPREFIX${green}world${blue}\nPREFIX${blue}!${reset}"
+
+      val expected =
+        s"PREFIX${red}hello${green}\nPREFIX${green}world${blue}\nPREFIX${blue}!${reset}"
       assert(baos.toString == expected)
     }
   }


### PR DESCRIPTION
# Fix Multiline ANSI Color Preservation in PromptLogger

This PR fixes the issue with multiline ANSI colors not being properly preserved in Mill's PromptLogger.

## Changes

1. Enhanced `LinePrefixOutputStream` to better handle ANSI color codes:
   - Added tracking of both start and end colors for each line
   - Implemented proper ANSI escape sequence parsing
   - Improved color state management across line boundaries
   - Added buffer handling for split ANSI sequences

The issue with multiline ANSI colors not being properly preserved stems from several factors in the `LinePrefixOutputStream` implementation:

1. **Color State Tracking Limitation**: The original implementation only tracked the end-of-line color state (`endOfLastLineColor`), which was insufficient for handling complex multiline color sequences. This meant that when a color sequence spanned multiple lines, the color state could be lost or incorrectly applied after line breaks.

2. **ANSI Sequence Handling**: ANSI escape sequences could be split across multiple writes, causing the color codes to be processed incorrectly. The original implementation didn't maintain the partial sequence state between writes.

3. **Line Prefix Interference**: When adding line prefixes, the color state wasn't being properly reapplied, causing color sequences to be interrupted or reset unintentionally.

## Steps to Reproduce
The issue can be reproduced using multiline colored output in Mill tasks:

1. Create a Mill task that outputs multiline text with ANSI colors

2. The output shows incorrect color preservation:
- Colors might be reset after line breaks
- Line prefixes might interrupt color sequences
- Split ANSI sequences might not be handled correctly

## Solution Explanation
The fix addresses these issues through several key improvements:

1. **Enhanced Color State Management**:
   - Added tracking of both start and end colors for each line (`currentLineStartColor` and `currentLineEndColor`)
   - This ensures proper color state preservation across line boundaries
   - Colors are correctly reapplied after line prefixes

2. **Proper ANSI Sequence Handling**:
   - Added `escapeSequenceBuffer` to properly accumulate and process ANSI sequences
   - Implemented proper state machine for ANSI sequence parsing
   - Handles split sequences correctly across multiple writes


## Why This Fix is Correct
1. **Complete State Tracking**: By tracking both start and end colors of each line, we maintain full context of color state transitions.

2. **ANSI Spec Compliance**: The implementation now properly handles ANSI escape sequences according to spec, including:
   - Proper sequence parsing (ESC [ ... m)
   - Maintaining state between partial writes
   - Preserving nested and complex color combinations


## Related Issues

Fixes #4115 - Multiline ANSI colors are not properly preserved in Mill PromptLogger

<img width="1368" alt="image" src="https://github.com/user-attachments/assets/0b0a8659-76e6-4f63-bc2b-9d26af3319f6" />


<img width="1368" alt="image" src="https://github.com/user-attachments/assets/049c1143-9605-420a-a83d-e8786847531e" />