### PR TITLE
Fix down download URLs to use stable versions

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -304,10 +304,10 @@ def millLastTag: T[String] = Task.Input {
 }
 
 def millDownloadPrefix = Task {
-  s"https://repo1.maven.org/maven2/com/lihaoyi/mill-dist/"
+  s"https://repo1.maven.org/maven2/com/lihaoyi/mill-dist"
 }
 def millDownloadUrl = Task {
-  s"https://repo1.maven.org/maven2/com/lihaoyi/mill-dist/${millLastTag()}"
+  s"${millDownloadPrefix()}/${millLastTag()}"
 }
 
 def millBinPlatform: T[String] = Task {

--- a/website/docs/modules/ROOT/pages/cli/installation-ide.adoc
+++ b/website/docs/modules/ROOT/pages/cli/installation-ide.adoc
@@ -22,11 +22,11 @@ bootstrap script, included. You can also download the boostrap script manually:
 # Mac/Linux
 curl -L {mill-download-url}/mill -o mill
 chmod +x mill
-echo {mill-last-tag} > .mill-version
+echo {mill-version} > .mill-version
 
 # Windows
 curl -L {mill-download-url}/mill.bat -o mill.bat
-echo {mill-last-tag} > .mill-version
+echo {mill-version} > .mill-version
 ----
 
 Downloading a `mill` bootstrap script to the root of your project repository helps make it easier for
@@ -63,7 +63,7 @@ Mill version:
 
 [source,bash,subs="verbatim,attributes"]
 ----
-echo {mill-last-tag}-native > .mill-version
+echo {version}-native > .mill-version
 ----
 
 Using the `-native` suffix should provide a faster CLI experience than using Mill's default
@@ -376,7 +376,7 @@ emerge dev-java/mill-bin
 === Windows
 
 To get started, download Mill from
-{mill-github-url}/releases/download/{mill-last-tag}/{mill-last-tag}-assembly[Github releases], and save it as `mill.bat`.
+{mill-github-url}/releases/download/{version}/{version}-assembly[Github releases], and save it as `mill.bat`.
 
 If you're using https://scoop.sh[Scoop] you can install Mill via
 
@@ -421,7 +421,7 @@ To get started, download Mill and install it into your HOME ".local/bin" via the
 
 [source,bash,subs="verbatim,attributes"]
 ----
-sh -c "curl -L {mill-github-url}/releases/download/{mill-last-tag}/{mill-last-tag} > ~/.local/bin/mill && chmod +x ~/.local/bin/mill"
+sh -c "curl -L {mill-github-url}/releases/download/{version}/{version} > ~/.local/bin/mill && chmod +x ~/.local/bin/mill"
 ----
 
 === Coursier (unsupported)

--- a/website/package.mill
+++ b/website/package.mill
@@ -207,7 +207,7 @@ object `package` extends RootModule {
       dest: os.Path,
       version: String,
       displayVersion: String,
-      millLastTag: String,
+      millVersion: String,
       millDownloadUrl: String
   ): Unit = {
     val isPreRelease = version == "main-branch" || Seq("-M", "-RC").exists(version.contains)
@@ -215,14 +215,13 @@ object `package` extends RootModule {
     val lines = os.read(dest / "antora.yml").linesIterator.map {
       case s"version:$_" =>
         s"version: '$version'\ndisplay-version: '$displayVersion'$preReleaseSuffix"
-      case s"    mill-version:$_" => s"    mill-version: '$millLastTag'"
-      case s"    mill-last-tag:$_" => s"    mill-last-tag: '$millLastTag'"
+      case s"    mill-version:$_" => s"    mill-version: '$millVersion'"
       case l => l
     }
 
     val newLines = Seq(
       s"    mill-download-url: $millDownloadUrl",
-      s"    mill-example-url: ${build.Settings.projectUrl}/blob/$millLastTag/"
+      s"    mill-example-url: ${build.Settings.projectUrl}/blob/$millVersion"
     )
 
     os.write.over(dest / "antora.yml", (lines ++ newLines).mkString("\n"))
@@ -293,14 +292,13 @@ object `package` extends RootModule {
   def oldDocSources: T[Seq[PathRef]] = Task {
     val versionLabels =
       build.Settings.docTags.map { v =>
-        val xVersion = v.split('.').dropRight(1).mkString(".") + ".x"
-        (v, xVersion, xVersion)
+        (v, v.split('.').dropRight(1).mkString(".") + ".x")
       }.dropRight(1) ++
         // Set the latest stable branch as the "master" docs that people default to
-        Seq((build.Settings.docTags.last, "master", build.Settings.docTags.last))
+        Seq((build.Settings.docTags.last, "master"))
 
-    for ((millVersion, antoraVersion, displayVersion) <- versionLabels) yield {
-      val checkout = Task.dest / displayVersion
+    for ((millVersion, antoraVersion) <- versionLabels) yield {
+      val checkout = Task.dest / millVersion
       os.proc("git", "clone", Task.workspace / ".git", checkout).call(stdout = os.Inherit)
       os.proc("git", "checkout", millVersion).call(cwd = checkout, stdout = os.Inherit)
       val outputFolder = checkout / "out/docs/source.dest"
@@ -319,7 +317,7 @@ object `package` extends RootModule {
         if (useOldDownloadUrl) s"${build.Settings.projectUrl}/releases/download/$millVersion"
         else s"${build.millDownloadPrefix()}/$millVersion"
 
-      sanitizeAntoraYml(outputFolder, antoraVersion, displayVersion, millVersion, millDownloadUrl)
+      sanitizeAntoraYml(outputFolder, antoraVersion, millVersion, millVersion, millDownloadUrl)
       PathRef(outputFolder)
     }
   }

--- a/website/package.mill
+++ b/website/package.mill
@@ -295,14 +295,14 @@ object `package` extends RootModule {
       build.Settings.docTags.map { v =>
         val xVersion = v.split('.').dropRight(1).mkString(".") + ".x"
         (v, xVersion, xVersion)
-      } ++
+      }.dropRight(1) ++
         // Set the latest stable branch as the "master" docs that people default to
-        Seq((build.Settings.docTags.last, "master", s"latest-${build.Settings.docTags.last}"))
+        Seq((build.Settings.docTags.last, "master", build.Settings.docTags.last))
 
-    for ((millLastTag, version, displayVersion) <- versionLabels) yield {
+    for ((millVersion, antoraVersion, displayVersion) <- versionLabels) yield {
       val checkout = Task.dest / displayVersion
       os.proc("git", "clone", Task.workspace / ".git", checkout).call(stdout = os.Inherit)
-      os.proc("git", "checkout", millLastTag).call(cwd = checkout, stdout = os.Inherit)
+      os.proc("git", "checkout", millVersion).call(cwd = checkout, stdout = os.Inherit)
       val outputFolder = checkout / "out/docs/source.dest"
       os.proc("./mill", "-i", "docs.source").call(cwd = checkout, stdout = os.Inherit)
       expandDiagramsInDirectoryAdocFile(
@@ -310,18 +310,16 @@ object `package` extends RootModule {
         mill.main.VisualizeModule.classpath().map(_.path)
       )
 
+      val useOldDownloadUrl = Ordering.Implicits.seqOrdering[Seq, String].lt(
+        millVersion.split('.'),
+        Seq("0", "12", "6")
+      )
+
       val millDownloadUrl =
-        if (
-          Ordering.Implicits.seqOrdering[Seq, String].lt(
-            millLastTag.split('.'),
-            Seq("0", "12", "6")
-          )
-        ) {
-          s"${build.Settings.projectUrl}/releases/download/$millLastTag"
-        } else {
-          build.millDownloadUrl()
-        }
-      sanitizeAntoraYml(outputFolder, version, displayVersion, millLastTag, millDownloadUrl)
+        if (useOldDownloadUrl) s"${build.Settings.projectUrl}/releases/download/$millVersion"
+        else s"${build.millDownloadPrefix()}/$millVersion"
+
+      sanitizeAntoraYml(outputFolder, antoraVersion, displayVersion, millVersion, millDownloadUrl)
       PathRef(outputFolder)
     }
   }


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/4668

We were incorrectly using `build.millDownloadUrl()` which contains the unstable current last tag, rather than the last stable version from `docTags.last`

Tested manually via ` MILL_STABLE_VERSION=1 ./mill -i -w website.githubPages`, verified the generated links point at the right place

Also did some cleanups to try and make this area of the code less confusing