### PR TITLE
Remove `InputPumper#runningCheck`

### DIFF
--- a/core/api/src/mill/api/SystemStreams.scala
+++ b/core/api/src/mill/api/SystemStreams.scala
@@ -63,7 +63,7 @@ object SystemStreams {
   private class PumpedProcessOutput(dest: OutputStream) extends os.ProcessOutput {
     def redirectTo = ProcessBuilder.Redirect.PIPE
     def processOutput(processOut: => os.SubProcess.OutputStream): Some[InputPumper] =
-      Some(new InputPumper(() => processOut.wrapped, () => dest, false, () => true))
+      Some(new InputPumper(() => processOut.wrapped, () => dest, false))
   }
   def withStreams[T](systemStreams: SystemStreams)(t: => T): T = {
     // If we are setting a stream back to its original value, make sure we reset

--- a/core/constants/src/mill/constants/InputPumper.java
+++ b/core/constants/src/mill/constants/InputPumper.java
@@ -9,22 +9,12 @@ public class InputPumper implements Runnable {
   private Supplier<OutputStream> dest0;
 
   private Boolean checkAvailable;
-  private java.util.function.BooleanSupplier runningCheck;
 
   public InputPumper(
       Supplier<InputStream> src, Supplier<OutputStream> dest, Boolean checkAvailable) {
-    this(src, dest, checkAvailable, () -> true);
-  }
-
-  public InputPumper(
-      Supplier<InputStream> src,
-      Supplier<OutputStream> dest,
-      Boolean checkAvailable,
-      java.util.function.BooleanSupplier runningCheck) {
     this.src0 = src;
     this.dest0 = dest;
     this.checkAvailable = checkAvailable;
-    this.runningCheck = runningCheck;
   }
 
   boolean running = true;
@@ -37,12 +27,10 @@ public class InputPumper implements Runnable {
     byte[] buffer = new byte[1024];
     try {
       while (running) {
-        if (!runningCheck.getAsBoolean()) {
-          running = false;
-          // We need to check `.available` and avoid calling `.read`, because if we call `.read`
-          // and there is nothing to read, it can unnecessarily delay the JVM exit by 350ms
-          // https://stackoverflow.com/questions/48951611/blocking-on-stdin-makes-java-process-take-350ms-more-to-exit
-        } else if (checkAvailable && src.available() == 0) Thread.sleep(1);
+        // We need to check `.available` and avoid calling `.read`, because if we call `.read`
+        // and there is nothing to read, it can unnecessarily delay the JVM exit by 350ms
+        // https://stackoverflow.com/questions/48951611/blocking-on-stdin-makes-java-process-take-350ms-more-to-exit
+        if (checkAvailable && src.available() == 0) Thread.sleep(1);
         else {
           int n;
           try {

--- a/scalajslib/worker/1/src/mill/scalajslib/worker/ScalaJSWorkerImpl.scala
+++ b/scalajslib/worker/1/src/mill/scalajslib/worker/ScalaJSWorkerImpl.scala
@@ -314,18 +314,13 @@ class ScalaJSWorkerImpl extends ScalaJSWorkerApi {
         .withOnOutputStream {
           case (Some(processOut), Some(processErr)) =>
             val sources = Seq(
-              (processOut, System.out, "spawnSubprocess.stdout", false, () => true),
-              (processErr, System.err, "spawnSubprocess.stderr", false, () => true)
+              (processOut, System.out, "spawnSubprocess.stdout", false),
+              (processErr, System.err, "spawnSubprocess.stderr", false)
             )
 
-            for ((std, dest, name, checkAvailable, runningCheck) <- sources) {
+            for ((std, dest, name, checkAvailable) <- sources) {
               val t = new Thread(
-                new InputPumper(
-                  () => std,
-                  () => dest,
-                  checkAvailable,
-                  () => runningCheck()
-                ),
+                new InputPumper(() => std, () => dest, checkAvailable),
                 name
               )
               t.setDaemon(true)


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/4097

Seems like `checkAvailable` is still used, so we can't remove it