### PR TITLE
Make source path configurable in TestBaseModule

### DIFF
--- a/testkit/src/mill/testkit/TestBaseModule.scala
+++ b/testkit/src/mill/testkit/TestBaseModule.scala
@@ -3,17 +3,23 @@ package mill.testkit
 /**
  * A wrapper of [[mill.define.BaseModule]] meant for easy instantiation in test suites.
  */
-abstract class TestBaseModule(implicit
+abstract class TestBaseModule(
+    baseModuleSourcePath: os.Path
+)(implicit
     millModuleEnclosing0: sourcecode.Enclosing,
     millModuleLine0: sourcecode.Line,
     millModuleFile0: sourcecode.File
-) extends mill.define.BaseModule(
-      {
-        os.makeDir.all(os.pwd / "out/mill-test-base-module")
-        os.temp.dir(os.pwd / "out/mill-test-base-module", deleteOnExit = false)
-      }
-    )(
+) extends mill.define.BaseModule(millSourcePath0 = baseModuleSourcePath)(
       millModuleEnclosing0,
       millModuleLine0,
       millModuleFile0
-    ) {}
+    ) {
+  def this()(implicit
+      millModuleEnclosing0: sourcecode.Enclosing,
+      millModuleLine0: sourcecode.Line,
+      millModuleFile0: sourcecode.File
+  ) = this({
+    os.makeDir.all(os.pwd / "out/mill-test-base-module")
+    os.temp.dir(os.pwd / "out/mill-test-base-module", deleteOnExit = false)
+  })
+}


### PR DESCRIPTION
Make the mill source path configurable in TestBaseModule

Please open all PRs as drafts and ensure that your fork of Mill has 
`settings/actions` / `Allow all actions and reusable workflows` enabled to run CI on
your own fork of the Mill repo. Only once CI passes mark the PR as `Ready for review`
and CI will run on the main Mill repo before we merge it.
