### PR TITLE
Try and fix synchronization problems in prompt logger

### DIFF
--- a/core/internal/src/mill/internal/PromptLogger.scala
+++ b/core/internal/src/mill/internal/PromptLogger.scala
@@ -114,9 +114,10 @@ private[mill] class PromptLogger(
       promptLineState.setCurrent(key, None)
     }
 
-    override def setPromptDetail(key: Seq[String], s: String): Unit = PromptLogger.this.synchronized {
-      promptLineState.setDetail(key, s)
-    }
+    override def setPromptDetail(key: Seq[String], s: String): Unit =
+      PromptLogger.this.synchronized {
+        promptLineState.setDetail(key, s)
+      }
 
     override def reportKey(key: Seq[String]): Unit = {
       val res = PromptLogger.this.synchronized {

--- a/core/internal/src/mill/internal/PromptLogger.scala
+++ b/core/internal/src/mill/internal/PromptLogger.scala
@@ -102,24 +102,24 @@ private[mill] class PromptLogger(
   def error(s: String): Unit = streams.err.println(s)
 
   object prompt extends Logger.Prompt {
-    override def setPromptHeaderPrefix(s: String): Unit = synchronized {
+    override def setPromptHeaderPrefix(s: String): Unit = PromptLogger.this.synchronized {
       promptLineState.setHeaderPrefix(s)
     }
 
-    override def clearPromptStatuses(): Unit = synchronized {
+    override def clearPromptStatuses(): Unit = PromptLogger.this.synchronized {
       promptLineState.clearStatuses()
     }
 
-    override def removePromptLine(key: Seq[String]): Unit = synchronized {
+    override def removePromptLine(key: Seq[String]): Unit = PromptLogger.this.synchronized {
       promptLineState.setCurrent(key, None)
     }
 
-    override def setPromptDetail(key: Seq[String], s: String): Unit = synchronized {
+    override def setPromptDetail(key: Seq[String], s: String): Unit = PromptLogger.this.synchronized {
       promptLineState.setDetail(key, s)
     }
 
     override def reportKey(key: Seq[String]): Unit = {
-      val res = synchronized {
+      val res = PromptLogger.this.synchronized {
         if (reportedIdentifiers(key)) None
         else {
           reportedIdentifiers.add(key)
@@ -135,7 +135,7 @@ private[mill] class PromptLogger(
     }
 
     override def setPromptLine(key: Seq[String], keySuffix: String, message: String): Unit =
-      synchronized {
+      PromptLogger.this.synchronized {
         promptLineState.setCurrent(key, Some(s"[${key.mkString("-")}] $message"))
         seenIdentifiers(key) = (keySuffix, message)
       }


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/4683

#4653 moved a bunch of methods into a nested `object`, but that makes the `synchronized` blocks have a different receiver than before, possibly resulting in race conditions. This PR explicitly qualifies the synchronized blocks to restore the old behavior.