### PR TITLE
Avoid printing `AnsiNav.clearLine` in non-interactive PromptLogger to clean up CI logs

### DIFF
--- a/core/internal/src/mill/internal/PromptLogger.scala
+++ b/core/internal/src/mill/internal/PromptLogger.scala
@@ -130,7 +130,7 @@ private[mill] class PromptLogger(
         }
       }
       for ((keySuffix, message) <- res) {
-        if (prompt.enableTicker && isInteractive()) {
+        if (prompt.enableTicker) {
           streams.err.println(
             infoColor(s"[${key.mkString("-")}$keySuffix]${spaceNonEmpty(message)}")
           )


### PR DESCRIPTION
Otherwise previously viewing raw logs on github actions would show noisy `[0k`s everywhere