### PR TITLE
Backport "Avoid printing `AnsiNav.clearLine` in non-interactive PromptLogger to clean up CI logs" to 0.12.x

### DIFF
--- a/main/util/src/mill/util/PromptLogger.scala
+++ b/main/util/src/mill/util/PromptLogger.scala
@@ -296,7 +296,7 @@ private[mill] object PromptLogger {
           promptShown = false
         }
 
-        if (enableTicker && interactive()) {
+        if (interactive()) {
           // Clear each line as they are drawn, rather than relying on clearing
           // the entire screen before each batch of writes, to try and reduce the
           // amount of terminal flickering in slow terminals (e.g. windows)

--- a/main/util/src/mill/util/PromptLogger.scala
+++ b/main/util/src/mill/util/PromptLogger.scala
@@ -36,6 +36,8 @@ private[mill] class PromptLogger(
 
   readTerminalDims(terminfoPath).foreach(termDimensions = _)
 
+  def isInteractive() = termDimensions._1.nonEmpty
+
   private object promptLineState extends PromptLineState(
         titleText,
         currentTimeMillis(),
@@ -48,7 +50,7 @@ private[mill] class PromptLogger(
         enableTicker,
         systemStreams0,
         () => promptLineState.getCurrentPrompt(),
-        interactive = () => termDimensions._1.nonEmpty,
+        interactive = () => isInteractive(),
         paused = () => runningState.paused,
         synchronizer = this
       )
@@ -75,7 +77,7 @@ private[mill] class PromptLogger(
 
         val now = System.currentTimeMillis()
         if (
-          termDimensions._1.nonEmpty ||
+          isInteractive() ||
           (now - lastUpdate > nonInteractivePromptUpdateIntervalMillis)
         ) {
           lastUpdate = now
@@ -294,15 +296,19 @@ private[mill] object PromptLogger {
           promptShown = false
         }
 
-        // Clear each line as they are drawn, rather than relying on clearing
-        // the entire screen before each batch of writes, to try and reduce the
-        // amount of terminal flickering in slow terminals (e.g. windows)
-        // https://stackoverflow.com/questions/71452837/how-to-reduce-flicker-in-terminal-re-drawing
-        dest.write(
-          new String(buf, 0, end)
-            .replaceAll("(\r\n|\n|\t)", AnsiNav.clearLine(0) + "$1")
-            .getBytes
-        )
+        if (enableTicker && interactive()) {
+          // Clear each line as they are drawn, rather than relying on clearing
+          // the entire screen before each batch of writes, to try and reduce the
+          // amount of terminal flickering in slow terminals (e.g. windows)
+          // https://stackoverflow.com/questions/71452837/how-to-reduce-flicker-in-terminal-re-drawing
+          dest.write(
+            new String(buf, 0, end)
+              .replaceAll("(\r\n|\n|\t)", AnsiNav.clearLine(0) + "$1")
+              .getBytes
+          )
+        } else {
+          dest.write(new String(buf, 0, end).getBytes)
+        }
       }
     }
 


### PR DESCRIPTION
Backport of https://github.com/com-lihaoyi/mill/pull/4709