### PR TITLE
(0.12.x) Provide a proper error to tell people to run `init -i` when using a g8 template

### DIFF
--- a/main/src/mill/main/MainModule.scala
+++ b/main/src/mill/main/MainModule.scala
@@ -587,7 +587,9 @@ trait MainModule extends BaseModule0 {
           )
         else if (args.headOption.exists(_.toLowerCase.endsWith(".g8")))
           if (!Util.isInteractive()) {
-            Left("init with a .g8 template needs to be run with the -i/--interactive flag")
+            Left(
+              "initializing a repo with a .g8 template needs to be run with the -i/--interactive flag"
+            )
           } else RunScript.evaluateTasksNamed(
             evaluator,
             Seq("mill.scalalib.giter8.Giter8Module/init") ++ args,
@@ -600,9 +602,9 @@ trait MainModule extends BaseModule0 {
             SelectMode.Separated
           )
       evaluated match {
-        case Left(failStr) => throw new Exception(failStr)
-        case Right((_, Right(Seq((_, Some((_, jsonableResult))))))) => jsonableResult
-        case Right((_, Left(failStr))) => throw new Exception(failStr)
+        case Left(failStr) => Result.Failure(failStr)
+        case Right((_, Right(Seq((_, Some((_, jsonableResult))))))) => Result.Success(jsonableResult)
+        case Right((_, Left(failStr))) => Result.Failure(failStr)
       }
     }
 

--- a/main/src/mill/main/MainModule.scala
+++ b/main/src/mill/main/MainModule.scala
@@ -603,7 +603,8 @@ trait MainModule extends BaseModule0 {
           )
       evaluated match {
         case Left(failStr) => Result.Failure(failStr)
-        case Right((_, Right(Seq((_, Some((_, jsonableResult))))))) => Result.Success(jsonableResult)
+        case Right((_, Right(Seq((_, Some((_, jsonableResult))))))) =>
+          Result.Success(jsonableResult)
         case Right((_, Left(failStr))) => Result.Failure(failStr)
       }
     }

--- a/main/src/mill/main/MainModule.scala
+++ b/main/src/mill/main/MainModule.scala
@@ -586,7 +586,9 @@ trait MainModule extends BaseModule0 {
             SelectMode.Separated
           )
         else if (args.headOption.exists(_.toLowerCase.endsWith(".g8")))
-          RunScript.evaluateTasksNamed(
+          if (!Util.isInteractive()) {
+            Left("init with a .g8 template needs to be run with the -i/--interactive flag")
+          } else RunScript.evaluateTasksNamed(
             evaluator,
             Seq("mill.scalalib.giter8.Giter8Module/init") ++ args,
             SelectMode.Separated


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/4596

Tested manually to verify we get a proper error message when `-i` is not given, and the error tells the user to pass `-i`