### PR TITLE
Use priority queue to run Mill executor tasks, prioritizing first async task and de-prioritizing subsequent ones

### DIFF
--- a/core/api/src/mill/api/Ctx.scala
+++ b/core/api/src/mill/api/Ctx.scala
@@ -180,13 +180,13 @@ object Ctx {
        *                terminal prompt to display what this future is currently computing.
        * @param t The body of the async future
        */
-      def async[T](dest: os.Path, key: String, message: String)(t: Logger => T)(implicit
+      def async[T](dest: os.Path, key: String, message: String, priority: Int)(t: Logger => T)(implicit
           ctx: mill.api.Ctx
       ): Future[T]
 
-      @inline def async[T](dest: os.Path, key: String, message: String)(t: => T)(implicit
+      @inline def async[T](dest: os.Path, key: String, message: String, priority: Int)(t: => T)(implicit
           ctx: mill.api.Ctx
-      ): Future[T] = async(dest, key, message)(_ => t)
+      ): Future[T] = async(dest, key, message, priority)(_ => t)
     }
 
     trait Impl extends Api with ExecutionContext with AutoCloseable {

--- a/core/api/src/mill/api/Ctx.scala
+++ b/core/api/src/mill/api/Ctx.scala
@@ -178,25 +178,19 @@ object Ctx {
        *            terminal to allow them to be distinguished from other logs
        * @param message A one-line summary of what this async future is doing, used in the
        *                terminal prompt to display what this future is currently computing.
+       * @param priority 0 means the same priority as other Mill tasks, negative values <0
+       *                 mean increasingly high priority, positive values >0 mean increasingly
+       *                 low priority
        * @param t The body of the async future
        */
       def async[T](
           dest: os.Path,
           key: String,
           message: String,
-          priority: Int
+          priority: Int = 0
       )(t: Logger => T)(implicit
           ctx: mill.api.Ctx
       ): Future[T]
-
-      @inline def async[T](
-          dest: os.Path,
-          key: String,
-          message: String,
-          priority: Int
-      )(t: => T)(implicit
-          ctx: mill.api.Ctx
-      ): Future[T] = async(dest, key, message, priority)(_ => t)
     }
 
     trait Impl extends Api with ExecutionContext with AutoCloseable {

--- a/core/api/src/mill/api/Ctx.scala
+++ b/core/api/src/mill/api/Ctx.scala
@@ -180,11 +180,21 @@ object Ctx {
        *                terminal prompt to display what this future is currently computing.
        * @param t The body of the async future
        */
-      def async[T](dest: os.Path, key: String, message: String, priority: Int)(t: Logger => T)(implicit
+      def async[T](
+          dest: os.Path,
+          key: String,
+          message: String,
+          priority: Int
+      )(t: Logger => T)(implicit
           ctx: mill.api.Ctx
       ): Future[T]
 
-      @inline def async[T](dest: os.Path, key: String, message: String, priority: Int)(t: => T)(implicit
+      @inline def async[T](
+          dest: os.Path,
+          key: String,
+          message: String,
+          priority: Int
+      )(t: => T)(implicit
           ctx: mill.api.Ctx
       ): Future[T] = async(dest, key, message, priority)(_ => t)
     }

--- a/core/exec/src/mill/exec/ExecutionContexts.scala
+++ b/core/exec/src/mill/exec/ExecutionContexts.scala
@@ -100,7 +100,7 @@ private object ExecutionContexts {
           // to break ties between instances with the same priority. This index is assigned
           // when a task is submitted, so it should more or less follow insertion order,
           // and is a `Long` which should be big enough never to overflow
-          assert(this.priorityRunnableIndex != o.priorityRunnableIndex)
+          assert(this == o || this.priorityRunnableIndex != o.priorityRunnableIndex)
           this.priorityRunnableIndex.compareTo(o.priorityRunnableIndex)
         case n => n
       }

--- a/core/exec/src/mill/exec/ExecutionContexts.scala
+++ b/core/exec/src/mill/exec/ExecutionContexts.scala
@@ -131,7 +131,7 @@ private object ExecutionContexts {
       }
       val promise = concurrent.Promise[T]
       val runnable = new PriorityRunnable(
-        priority = 0,
+        priority = priority,
         run0 = () => {
           val result = scala.util.Try(logger.withPromptLine {
             os.dynamicPwdFunction.withValue(() => makeDest()) {

--- a/core/exec/src/mill/exec/ExecutionContexts.scala
+++ b/core/exec/src/mill/exec/ExecutionContexts.scala
@@ -5,7 +5,13 @@ import os.Path
 
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration.Duration
-import java.util.concurrent.{ExecutorService, LinkedBlockingDeque, PriorityBlockingQueue, ThreadPoolExecutor, TimeUnit}
+import java.util.concurrent.{
+  ExecutorService,
+  LinkedBlockingDeque,
+  PriorityBlockingQueue,
+  ThreadPoolExecutor,
+  TimeUnit
+}
 import mill.api.Logger
 
 private object ExecutionContexts {
@@ -68,11 +74,12 @@ private object ExecutionContexts {
       lazy val submitterStreams = new mill.api.SystemStreams(System.out, System.err, System.in)
       executor.execute(new PriorityRunnable(
         0,
-        () => os.dynamicPwdFunction.withValue(() => submitterPwd) {
-          mill.api.SystemStreams.withStreams(submitterStreams) {
-            runnable.run()
+        () =>
+          os.dynamicPwdFunction.withValue(() => submitterPwd) {
+            mill.api.SystemStreams.withStreams(submitterStreams) {
+              runnable.run()
+            }
           }
-        }
       ))
 
     }
@@ -89,10 +96,11 @@ private object ExecutionContexts {
      * prioritize this runnable over most other tasks, while priorities >0 can be used to
      * de-prioritize it.
      */
-    class PriorityRunnable(val priority: Int, run0: () => Unit) extends Runnable with Comparable[PriorityRunnable]{
+    class PriorityRunnable(val priority: Int, run0: () => Unit) extends Runnable
+        with Comparable[PriorityRunnable] {
       def run() = run0()
       val priorityRunnableIndex: Long = priorityRunnableCount.getAndIncrement()
-      override def compareTo(o: PriorityRunnable): Int = priority.compareTo(o.priority) match{
+      override def compareTo(o: PriorityRunnable): Int = priority.compareTo(o.priority) match {
         case 0 =>
           // `Comparable` wants a *total* ordering, so we need to use `priorityRunnableIndex`
           // to break ties between instances with the same priority. This index is assigned

--- a/core/exec/src/mill/exec/ExecutionContexts.scala
+++ b/core/exec/src/mill/exec/ExecutionContexts.scala
@@ -5,13 +5,7 @@ import os.Path
 
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration.Duration
-import java.util.concurrent.{
-  ExecutorService,
-  LinkedBlockingDeque,
-  PriorityBlockingQueue,
-  ThreadPoolExecutor,
-  TimeUnit
-}
+import java.util.concurrent.{PriorityBlockingQueue, ThreadPoolExecutor, TimeUnit}
 import mill.api.Logger
 
 private object ExecutionContexts {

--- a/core/exec/src/mill/exec/ExecutionContexts.scala
+++ b/core/exec/src/mill/exec/ExecutionContexts.scala
@@ -5,7 +5,7 @@ import os.Path
 
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration.Duration
-import java.util.concurrent.{ExecutorService, LinkedBlockingDeque, ThreadPoolExecutor, TimeUnit}
+import java.util.concurrent.{ExecutorService, LinkedBlockingDeque, PriorityBlockingQueue, ThreadPoolExecutor, TimeUnit}
 import mill.api.Logger
 
 private object ExecutionContexts {
@@ -21,7 +21,7 @@ private object ExecutionContexts {
     def reportFailure(cause: Throwable): Unit = {}
     def close(): Unit = () // do nothing
 
-    def async[T](dest: Path, key: String, message: String)(t: Logger => T)(implicit
+    def async[T](dest: Path, key: String, message: String, priority: Int)(t: Logger => T)(implicit
         ctx: mill.api.Ctx
     ): Future[T] =
       Future.successful(t(ctx.log))
@@ -33,7 +33,7 @@ private object ExecutionContexts {
    */
   class ThreadPool(threadCount0: Int) extends mill.api.Ctx.Fork.Impl {
     def await[T](t: Future[T]): T = blocking { Await.result(t, Duration.Inf) }
-    val executor: ThreadPoolExecutor = new ThreadPoolExecutor(
+    private val executor: ThreadPoolExecutor = new ThreadPoolExecutor(
       threadCount0,
       threadCount0,
       0,
@@ -42,14 +42,8 @@ private object ExecutionContexts {
       // operations reversed, providing elements in a LIFO order. This ensures that
       // child `fork.async` tasks always take priority over parent tasks, avoiding
       // large numbers of blocked parent tasks from piling up
-      new LinkedBlockingDeque[Runnable]() {
-        override def poll(): Runnable = super.pollLast()
-        override def poll(timeout: Long, unit: TimeUnit): Runnable = super.pollLast(timeout, unit)
-        override def take(): Runnable = super.takeLast()
-      }
+      new PriorityBlockingQueue[Runnable]()
     )
-
-    val threadPool: ExecutorService = executor
 
     def updateThreadCount(delta: Int): Unit = synchronized {
       if (delta > 0) {
@@ -72,26 +66,50 @@ private object ExecutionContexts {
       // context which submitted it
       lazy val submitterPwd = os.pwd
       lazy val submitterStreams = new mill.api.SystemStreams(System.out, System.err, System.in)
-      threadPool.submit(new Runnable {
-        def run() = {
-          os.dynamicPwdFunction.withValue(() => submitterPwd) {
-            mill.api.SystemStreams.withStreams(submitterStreams) {
-              runnable.run()
-            }
+      executor.execute(new PriorityRunnable(
+        0,
+        () => os.dynamicPwdFunction.withValue(() => submitterPwd) {
+          mill.api.SystemStreams.withStreams(submitterStreams) {
+            runnable.run()
           }
         }
-      })
+      ))
+
     }
 
     def reportFailure(t: Throwable): Unit = {}
-    def close(): Unit = threadPool.shutdown()
+    def close(): Unit = executor.shutdown()
+
+    val priorityRunnableCount = java.util.concurrent.atomic.AtomicLong()
+
+    /**
+     * Subclass of [[java.lang.Runnable]] that assigns a priority to execute it
+     *
+     * Priority 0 is the default priority of all Mill task, priorities <0 can be used to
+     * prioritize this runnable over most other tasks, while priorities >0 can be used to
+     * de-prioritize it.
+     */
+    class PriorityRunnable(val priority: Int, run0: () => Unit) extends Runnable with Comparable[PriorityRunnable]{
+      def run() = run0()
+      val priorityRunnableIndex: Long = priorityRunnableCount.getAndIncrement()
+      override def compareTo(o: PriorityRunnable): Int = priority.compareTo(o.priority) match{
+        case 0 =>
+          // `Comparable` wants a *total* ordering, so we need to use `priorityRunnableIndex`
+          // to break ties between instances with the same priority. This index is assigned
+          // when a task is submitted, so it should more or less follow insertion order,
+          // and is a `Long` which should be big enough never to overflow
+          assert(this.priorityRunnableIndex != o.priorityRunnableIndex)
+          this.priorityRunnableIndex.compareTo(o.priorityRunnableIndex)
+        case n => n
+      }
+    }
 
     /**
      * A variant of `scala.concurrent.Future{...}` that sets the `pwd` to a different
      * folder [[dest]] and duplicates the logging streams to [[dest]].log while evaluating
      * [[t]], to avoid conflict with other tasks that may be running concurrently
      */
-    def async[T](dest: Path, key: String, message: String)(t: Logger => T)(implicit
+    def async[T](dest: Path, key: String, message: String, priority: Int)(t: Logger => T)(implicit
         ctx: mill.api.Ctx
     ): Future[T] = {
       val logger = new MultiLogger(
@@ -109,15 +127,23 @@ private object ExecutionContexts {
 
         dest
       }
-      Future {
-        logger.withPromptLine {
-          os.dynamicPwdFunction.withValue(() => makeDest()) {
-            mill.api.SystemStreams.withStreams(logger.streams) {
-              t(logger)
+      val promise = concurrent.Promise[T]
+      val runnable = new PriorityRunnable(
+        priority = 0,
+        run0 = () => {
+          val result = scala.util.Try(logger.withPromptLine {
+            os.dynamicPwdFunction.withValue(() => makeDest()) {
+              mill.api.SystemStreams.withStreams(logger.streams) {
+                t(logger)
+              }
             }
-          }
+          })
+          promise.complete(result)
         }
-      }(this)
+      )
+
+      executor.execute(runnable)
+      promise.future
     }
   }
 }

--- a/example/fundamentals/tasks/7-forking-futures/build.mill
+++ b/example/fundamentals/tasks/7-forking-futures/build.mill
@@ -9,18 +9,20 @@ import mill._
 
 def taskSpawningFutures = Task {
   val f1 = Task.fork.async(dest = Task.dest / "future-1", key = "1", message = "First Future") {
-    println("Running First Future inside " + os.pwd)
-    Thread.sleep(3000)
-    val res = 1
-    println("Finished First Future")
-    res
+    logger =>
+      println("Running First Future inside " + os.pwd)
+      Thread.sleep(3000)
+      val res = 1
+      println("Finished First Future")
+      res
   }
   val f2 = Task.fork.async(dest = Task.dest / "future-2", key = "2", message = "Second Future") {
-    println("Running Second Future inside " + os.pwd)
-    Thread.sleep(3000)
-    val res = 2
-    println("Finished Second Future")
-    res
+    logger =>
+      println("Running Second Future inside " + os.pwd)
+      Thread.sleep(3000)
+      val res = 2
+      println("Finished Second Future")
+      res
   }
 
   Task.fork.await(f1) + Task.fork.await(f2)
@@ -44,6 +46,12 @@ Finished Second Future
 // - `key` is a short prefix prepended to log lines to let you easily identify the future's
 //    log lines and distinguish them from logs of other futures and tasks running concurrently
 // - `message` is a one-line description of what the future is doing
+// - `priority`: 0 means the same priority as other Mill tasks, negative values <0
+//   mean increasingly high priority, positive values >0 mean increasingly
+//   low priority
+//
+// Each block spawned by `Task.fork.async` is assigned a dedicated `logger` with its own
+// `.log` file and terminal UI integration
 //
 // Futures spawned by `Task.fork.async` count towards Mill's `-j`/`--jobs` concurrency limit
 // (which defaults to one-per-core), so you can freely use `Task.fork.async` without worrying

--- a/scalalib/src/mill/scalalib/TestModuleUtil.scala
+++ b/scalalib/src/mill/scalalib/TestModuleUtil.scala
@@ -198,8 +198,9 @@ private final class TestModuleUtil(
           // tasks. This minimizes the number of blocked tasks since Mill tasks can be
           // blocked on test subprocesses, but not vice versa, so better to schedule
           // the test subprocesses first
-          Task.fork.async(Task.dest / folderName, paddedIndex, groupPromptMessage, priority = -1) { log =>
-            (folderName, callTestRunnerSubprocess(Task.dest / folderName, Left(testClassList)))
+          Task.fork.async(Task.dest / folderName, paddedIndex, groupPromptMessage, priority = -1) {
+            log =>
+              (folderName, callTestRunnerSubprocess(Task.dest / folderName, Left(testClassList)))
           }
         }
 
@@ -313,7 +314,8 @@ private final class TestModuleUtil(
 
       Task.fork.async(
         processFolder,
-        label, "",
+        label,
+        "",
         // With the test queue scheduler, prioritize the *first* test subprocess
         // over other Mill tasks via `priority = -1`, but de-prioritize the others
         // increasingly according to their processIndex. This should help Mill

--- a/scalalib/src/mill/scalalib/TestModuleUtil.scala
+++ b/scalalib/src/mill/scalalib/TestModuleUtil.scala
@@ -194,7 +194,7 @@ private final class TestModuleUtil(
               s"group-$paddedIndex-${multiple.head}"
           }
 
-          Task.fork.async(Task.dest / folderName, paddedIndex, groupPromptMessage, 0) {
+          Task.fork.async(Task.dest / folderName, paddedIndex, groupPromptMessage, -1) {
             (folderName, callTestRunnerSubprocess(Task.dest / folderName, Left(testClassList)))
           }
         }

--- a/scalalib/src/mill/scalalib/TestModuleUtil.scala
+++ b/scalalib/src/mill/scalalib/TestModuleUtil.scala
@@ -198,7 +198,7 @@ private final class TestModuleUtil(
           // tasks. This minimizes the number of blocked tasks since Mill tasks can be
           // blocked on test subprocesses, but not vice versa, so better to schedule
           // the test subprocesses first
-          Task.fork.async(Task.dest / folderName, paddedIndex, groupPromptMessage, priority = -1) {
+          Task.fork.async(Task.dest / folderName, paddedIndex, groupPromptMessage, priority = -1) { log =>
             (folderName, callTestRunnerSubprocess(Task.dest / folderName, Left(testClassList)))
           }
         }

--- a/scalalib/src/mill/scalalib/TestModuleUtil.scala
+++ b/scalalib/src/mill/scalalib/TestModuleUtil.scala
@@ -194,7 +194,7 @@ private final class TestModuleUtil(
               s"group-$paddedIndex-${multiple.head}"
           }
 
-          Task.fork.async(Task.dest / folderName, paddedIndex, groupPromptMessage) {
+          Task.fork.async(Task.dest / folderName, paddedIndex, groupPromptMessage, 0) {
             (folderName, callTestRunnerSubprocess(Task.dest / folderName, Left(testClassList)))
           }
         }
@@ -307,7 +307,7 @@ private final class TestModuleUtil(
         if (groupFolderData.size == 1) paddedProcessIndex
         else s"$paddedGroupIndex-$paddedProcessIndex"
 
-      Task.fork.async(processFolder, label, "") { logger =>
+      Task.fork.async(processFolder, label, "", if (processIndex == 0) -1 else processIndex) { logger =>
         // force run when processIndex == 0 (first subprocess), even if there are no tests to run
         // to force the process to go through the test framework setup/teardown logic
         groupName -> runTestRunnerSubprocess(

--- a/scalalib/src/mill/scalalib/TestModuleUtil.scala
+++ b/scalalib/src/mill/scalalib/TestModuleUtil.scala
@@ -307,15 +307,16 @@ private final class TestModuleUtil(
         if (groupFolderData.size == 1) paddedProcessIndex
         else s"$paddedGroupIndex-$paddedProcessIndex"
 
-      Task.fork.async(processFolder, label, "", if (processIndex == 0) -1 else processIndex) { logger =>
-        // force run when processIndex == 0 (first subprocess), even if there are no tests to run
-        // to force the process to go through the test framework setup/teardown logic
-        groupName -> runTestRunnerSubprocess(
-          processFolder,
-          testClassesFolder,
-          force = processIndex == 0,
-          logger
-        )
+      Task.fork.async(processFolder, label, "", if (processIndex == 0) -1 else processIndex) {
+        logger =>
+          // force run when processIndex == 0 (first subprocess), even if there are no tests to run
+          // to force the process to go through the test framework setup/teardown logic
+          groupName -> runTestRunnerSubprocess(
+            processFolder,
+            testClassesFolder,
+            force = processIndex == 0,
+            logger
+          )
       }
     }
 

--- a/scalalib/src/mill/scalalib/TestModuleUtil.scala
+++ b/scalalib/src/mill/scalalib/TestModuleUtil.scala
@@ -194,7 +194,11 @@ private final class TestModuleUtil(
               s"group-$paddedIndex-${multiple.head}"
           }
 
-          Task.fork.async(Task.dest / folderName, paddedIndex, groupPromptMessage, -1) {
+          // set priority = -1 to always prioritize test subprocesses over normal Mill
+          // tasks. This minimizes the number of blocked tasks since Mill tasks can be
+          // blocked on test subprocesses, but not vice versa, so better to schedule
+          // the test subprocesses first
+          Task.fork.async(Task.dest / folderName, paddedIndex, groupPromptMessage, priority = -1) {
             (folderName, callTestRunnerSubprocess(Task.dest / folderName, Left(testClassList)))
           }
         }
@@ -307,7 +311,15 @@ private final class TestModuleUtil(
         if (groupFolderData.size == 1) paddedProcessIndex
         else s"$paddedGroupIndex-$paddedProcessIndex"
 
-      Task.fork.async(processFolder, label, "", if (processIndex == 0) -1 else processIndex) {
+      Task.fork.async(
+        processFolder,
+        label, "",
+        // With the test queue scheduler, prioritize the *first* test subprocess
+        // over other Mill tasks via `priority = -1`, but de-prioritize the others
+        // increasingly according to their processIndex. This should help Mill
+        // use fewer longer-lived test subprocesses, minimizing JVM startup overhead
+        priority = if (processIndex == 0) -1 else processIndex
+      ) {
         logger =>
           // force run when processIndex == 0 (first subprocess), even if there are no tests to run
           // to force the process to go through the test framework setup/teardown logic


### PR DESCRIPTION
This is a follow up improvement to https://github.com/com-lihaoyi/mill/pull/4701 which uses an explicit priority queue rather than relying on ad-hoc LIFO ordering. By prioritizing the first async task and de-prioritizing subsequent async tasks, this encourages Mill to re-use the same async task JVM to do more work, minimizing JVM startup overhead

When testing this out on the Netty example, `testParallelism` prioritizing the first testrunner JVM over all others does seem to make a material difference. I manually performed did ad-hoc benchmarks of the time taken to run the following command, basically running all the tests that we run in the example integration test:

```
 /Users/lihaoyi/Github/mill/out/dist/launcher.dest/run 'codec-{dns,haproxy,http,http2,memcache,mqtt,redis,smtp,socks,stomp,xml}.test' + 'transport-{blockhound-tests,native-unix-common,sctp}.test'
```

- `priority = -1` (`fork.async`s always run before other tasks): ~20s
- `priority = 1` (`fork.async`s always run after other tasks): ~20s
- `priority = if (processIndex == 0) -1 else processIndex` (The first `fork.async` in a test module runs before all other tasks, subsequent `fork.async`s run after all other tasks): ~11s

- As a comparison, `testForkGrouping` with 1-element groups: 50s

Notably, this first-JVM priority has similar timings with `testParallelism = false` on this benchmark, where the previous approach had some penalty (though not as bad as `testForkGrouping`). With these improvements, the parallel test runner should be self-tuning enough to turn on by default (https://github.com/com-lihaoyi/mill/pull/4614) without needing manual configuration in most cases

This also lays the foundation to other prioritization strategies later. For example, we may want to prioritize historically-slower tasks over faster tasks, all else being equal, to avoid long-running stragglers delaying a command from completing after everything else has finished. But such improvements can come later