### PR TITLE
(0.12.x) Improvements precision of `testParallelism` scheduler lifetime management

### DIFF
--- a/main/api/src/mill/api/Ctx.scala
+++ b/main/api/src/mill/api/Ctx.scala
@@ -136,6 +136,7 @@ object Ctx {
     import scala.concurrent.ExecutionContext
     trait Api {
 
+      def blocking[T](t: => T): T
       /**
        * Awaits for the result for the given async future and returns the resultant value
        */

--- a/main/api/src/mill/api/Ctx.scala
+++ b/main/api/src/mill/api/Ctx.scala
@@ -137,6 +137,7 @@ object Ctx {
     trait Api {
 
       def blocking[T](t: => T): T
+
       /**
        * Awaits for the result for the given async future and returns the resultant value
        */

--- a/main/eval/src/mill/eval/ExecutionContexts.scala
+++ b/main/eval/src/mill/eval/ExecutionContexts.scala
@@ -20,6 +20,7 @@ private object ExecutionContexts {
     def reportFailure(cause: Throwable): Unit = {}
     def close(): Unit = () // do nothing
 
+    def blocking[T](t: => T): T = t
     def async[T](
         dest: Path,
         key: String,

--- a/scalalib/src/mill/scalalib/TestModuleUtil.scala
+++ b/scalalib/src/mill/scalalib/TestModuleUtil.scala
@@ -340,15 +340,8 @@ private final class TestModuleUtil(
       try {
         // Periodically check the claimLog file of every runner, and tick the executing test name
         executor.scheduleWithFixedDelay(
-          () => {
-            workerStatusMap.forEach { (claimLog, callback) =>
-              {
-                try {
-                  // the last one is always the latest
-                  os.read.lines(claimLog).lastOption.foreach(callback)
-                } finally ()
-              }
-            }
+          () => workerStatusMap.forEach { (claimLog, callback) =>
+            os.read.lines(claimLog).lastOption.foreach(callback) // the last one is always the latest
           },
           0,
           20,

--- a/scalalib/src/mill/scalalib/TestModuleUtil.scala
+++ b/scalalib/src/mill/scalalib/TestModuleUtil.scala
@@ -241,16 +241,16 @@ private final class TestModuleUtil(
     ) = {
       val claimFolder = base / "claim"
       os.makeDir.all(claimFolder)
-      val startingTestClass = try {
-        os
-          .list
-          .stream(testClassQueueFolder)
-          .map(TestRunnerUtils.claimFile(_, claimFolder))
-          .collectFirst { case Some(name) => name }
-      }
-      catch{
-        case e: Throwable => None
-      }
+      val startingTestClass =
+        try {
+          os
+            .list
+            .stream(testClassQueueFolder)
+            .map(TestRunnerUtils.claimFile(_, claimFolder))
+            .collectFirst { case Some(name) => name }
+        } catch {
+          case e: Throwable => None
+        }
 
       if (force || startingTestClass.nonEmpty) {
         startingTestClass.foreach(logger.ticker(_))
@@ -340,7 +340,6 @@ private final class TestModuleUtil(
         // use fewer longer-lived test subprocesses, minimizing JVM startup overhead
         priority = if (processIndex == 0) -1 else processIndex
       ) { logger =>
-
         val result = runTestRunnerSubprocess(
           processFolder,
           testClassesFolder,

--- a/scalalib/src/mill/scalalib/TestModuleUtil.scala
+++ b/scalalib/src/mill/scalalib/TestModuleUtil.scala
@@ -372,7 +372,7 @@ private final class TestModuleUtil(
               if (os.exists(t._1)) os.list(t._1 / "claim").size else 0
             )
             val expectedCounts = filteredClassLists.map(_.size)
-            claimedCounts.sum < expectedCounts.sum || subprocessFutures.exists(!_.isCompleted)
+            !(claimedCounts.sum == expectedCounts.sum || subprocessFutures.forall(_.isCompleted))
           }) Thread.sleep(1)
         }
         subprocessFutures.flatMap(_.value).map(_.get)

--- a/testrunner/src/mill/testrunner/Model.scala
+++ b/testrunner/src/mill/testrunner/Model.scala
@@ -17,7 +17,7 @@ import mill.api.internal
     // - Left(selectors: Seq[String]): - list of glob selectors, testrunner is given a list of glob selectors to run directly
     // - Right((selectorFolder: os.Path, baseFolder: os.Path)): - a pair of paths, testrunner will try to claim test glob from selectorFolder
     // and move it actomatically in to baseFolder and run it from there.
-    globSelectors: Either[Seq[String], (os.Path, os.Path)]
+    globSelectors: Either[Seq[String], (Option[String], os.Path, os.Path)]
 )
 
 @internal object TestArgs {

--- a/testrunner/src/mill/testrunner/TestRunnerMain0.scala
+++ b/testrunner/src/mill/testrunner/TestRunnerMain0.scala
@@ -37,11 +37,12 @@ import mill.util.PrintLogger
             cl = classLoader,
             testReporter = DummyTestReporter
           )(ctx)
-        case Right((testClassQueueFolder, claimFolder)) =>
+        case Right((startingTestClass, testClassQueueFolder, claimFolder)) =>
           TestRunnerUtils.queueTestFramework0(
             frameworkInstances = Framework.framework(testArgs.framework),
             testClassfilePath = Agg.from(testArgs.testCp),
             args = testArgs.arguments,
+            startingTestClass = startingTestClass,
             testClassQueueFolder = testClassQueueFolder,
             claimFolder = claimFolder,
             cl = classLoader,

--- a/testrunner/src/mill/testrunner/TestRunnerMain0.scala
+++ b/testrunner/src/mill/testrunner/TestRunnerMain0.scala
@@ -43,7 +43,7 @@ import mill.util.PrintLogger
             testClassfilePath = Agg.from(testArgs.testCp),
             args = testArgs.arguments,
             testClassQueueFolder = testClassQueueFolder,
-            queueFolder = claimFolder,
+            claimFolder = claimFolder,
             cl = classLoader,
             testReporter = DummyTestReporter
           )(ctx)

--- a/testrunner/src/mill/testrunner/TestRunnerUtils.scala
+++ b/testrunner/src/mill/testrunner/TestRunnerUtils.scala
@@ -229,11 +229,12 @@ import scala.jdk.CollectionConverters.IteratorHasAsScala
   }
 
   def runTasksFromQueue(
-                         testClasses: Loose.Agg[ClassWithFingerprint],
-                         testReporter: TestReporter,
-                         runner: Runner,
-                         claimFolder: os.Path,
-                         testClassQueueFolder: os.Path
+      startingTestClass: Option[String],
+      testClasses: Loose.Agg[ClassWithFingerprint],
+      testReporter: TestReporter,
+      runner: Runner,
+      claimFolder: os.Path,
+      testClassQueueFolder: os.Path
   )(implicit ctx: Ctx.Log with Ctx.Home): (String, Iterator[TestResult]) = {
     // Capture this value outside of the task event handler so it
     // isn't affected by a test framework's stream redirects
@@ -244,43 +245,49 @@ import scala.jdk.CollectionConverters.IteratorHasAsScala
 
     // append only log, used to communicate with parent about what test is being claimed
     // so that the parent can log the claimed test's name to its logger
-    val queueLog = claimFolder / os.up / s"${claimFolder.last}.log"
+
+    def runClaimedTestClass(testClassName: String) = {
+
+      System.err.println(s"Running Test Class $testClassName")
+      val taskDefs = globSelectorCache
+        .get(testClassName)
+        .map { case (cls, fingerprint) =>
+          val clsName = cls.getName.stripSuffix("$")
+          new TaskDef(clsName, fingerprint, false, Array(new SuiteSelector))
+        }
+
+      val tasks = runner.tasks(taskDefs.toArray)
+      executeTasks(tasks, testReporter, runner, events)
+    }
+
+    startingTestClass.foreach(runClaimedTestClass)
+
     for (file <- os.list(testClassQueueFolder)) {
-      val testClassName = file.last
-      val claimedFile = claimFolder / testClassName
-
-      // we can check for existence of claimedFile first, but it'll require another os call.
-      // it just better to let this call failed in that case.
-      val claimed =
-        os.exists(file) &&
-          scala.util.Try(os.move(file, claimedFile, atomicMove = true)).isSuccess
-
-      if (claimed) {
-        os.write.append(queueLog, s"$testClassName\n")
-        System.err.println(s"Running Test Class $testClassName")
-        val taskDefs = globSelectorCache
-          .get(testClassName)
-          .map { case (cls, fingerprint) =>
-            val clsName = cls.getName.stripSuffix("$")
-            new TaskDef(clsName, fingerprint, false, Array(new SuiteSelector))
-          }
-
-        val tasks = runner.tasks(taskDefs.toArray)
-        executeTasks(tasks, testReporter, runner, events)
-      }
+      for (claimedTestClass <- claimFile(file, claimFolder)) runClaimedTestClass(claimedTestClass)
     }
 
     handleRunnerDone(runner, events)
   }
+  def claimFile(file: os.Path, claimFolder: os.Path): Option[String] = {
+    Option.when(
+      os.exists(file) &&
+        scala.util.Try(os.move(file, claimFolder / file.last, atomicMove = true)).isSuccess
+    ) {
+      val queueLog = claimFolder / os.up / s"${claimFolder.last}.log"
+      os.write.append(queueLog, s"${file.last}\n")
+      file.last
+    }
+  }
 
   def queueTestFramework0(
-                           frameworkInstances: ClassLoader => Framework,
-                           testClassfilePath: Loose.Agg[Path],
-                           args: Seq[String],
-                           testClassQueueFolder: os.Path,
-                           claimFolder: os.Path,
-                           cl: ClassLoader,
-                           testReporter: TestReporter
+      frameworkInstances: ClassLoader => Framework,
+      testClassfilePath: Loose.Agg[Path],
+      args: Seq[String],
+      startingTestClass: Option[String],
+      testClassQueueFolder: os.Path,
+      claimFolder: os.Path,
+      cl: ClassLoader,
+      testReporter: TestReporter
   )(implicit ctx: Ctx.Log with Ctx.Home): (String, Seq[TestResult]) = {
 
     val framework = frameworkInstances(cl)
@@ -289,8 +296,14 @@ import scala.jdk.CollectionConverters.IteratorHasAsScala
 
     val testClasses = discoverTests(cl, framework, testClassfilePath)
 
-    val (doneMessage, results) =
-      runTasksFromQueue(testClasses, testReporter, runner, claimFolder, testClassQueueFolder)
+    val (doneMessage, results) = runTasksFromQueue(
+      startingTestClass,
+      testClasses,
+      testReporter,
+      runner,
+      claimFolder,
+      testClassQueueFolder
+    )
 
     (doneMessage, results.toSeq)
   }

--- a/testrunner/src/mill/testrunner/TestRunnerUtils.scala
+++ b/testrunner/src/mill/testrunner/TestRunnerUtils.scala
@@ -229,11 +229,11 @@ import scala.jdk.CollectionConverters.IteratorHasAsScala
   }
 
   def runTasksFromQueue(
-      testClasses: Loose.Agg[ClassWithFingerprint],
-      testReporter: TestReporter,
-      runner: Runner,
-      queueFolder: os.Path,
-      testClassQueueFolder: os.Path
+                         testClasses: Loose.Agg[ClassWithFingerprint],
+                         testReporter: TestReporter,
+                         runner: Runner,
+                         claimFolder: os.Path,
+                         testClassQueueFolder: os.Path
   )(implicit ctx: Ctx.Log with Ctx.Home): (String, Iterator[TestResult]) = {
     // Capture this value outside of the task event handler so it
     // isn't affected by a test framework's stream redirects
@@ -244,10 +244,10 @@ import scala.jdk.CollectionConverters.IteratorHasAsScala
 
     // append only log, used to communicate with parent about what test is being claimed
     // so that the parent can log the claimed test's name to its logger
-    val queueLog = queueFolder / os.up / s"${queueFolder.last}.log"
+    val queueLog = claimFolder / os.up / s"${claimFolder.last}.log"
     for (file <- os.list(testClassQueueFolder)) {
       val testClassName = file.last
-      val claimedFile = queueFolder / testClassName
+      val claimedFile = claimFolder / testClassName
 
       // we can check for existence of claimedFile first, but it'll require another os call.
       // it just better to let this call failed in that case.
@@ -274,13 +274,13 @@ import scala.jdk.CollectionConverters.IteratorHasAsScala
   }
 
   def queueTestFramework0(
-      frameworkInstances: ClassLoader => Framework,
-      testClassfilePath: Loose.Agg[Path],
-      args: Seq[String],
-      testClassQueueFolder: os.Path,
-      queueFolder: os.Path,
-      cl: ClassLoader,
-      testReporter: TestReporter
+                           frameworkInstances: ClassLoader => Framework,
+                           testClassfilePath: Loose.Agg[Path],
+                           args: Seq[String],
+                           testClassQueueFolder: os.Path,
+                           claimFolder: os.Path,
+                           cl: ClassLoader,
+                           testReporter: TestReporter
   )(implicit ctx: Ctx.Log with Ctx.Home): (String, Seq[TestResult]) = {
 
     val framework = frameworkInstances(cl)
@@ -290,7 +290,7 @@ import scala.jdk.CollectionConverters.IteratorHasAsScala
     val testClasses = discoverTests(cl, framework, testClassfilePath)
 
     val (doneMessage, results) =
-      runTasksFromQueue(testClasses, testReporter, runner, queueFolder, testClassQueueFolder)
+      runTasksFromQueue(testClasses, testReporter, runner, claimFolder, testClassQueueFolder)
 
     (doneMessage, results.toSeq)
   }


### PR DESCRIPTION
This PR improves the precision on how the parent `test` tasks and child `fork.async` tasks are created and terminated

* We allow the parent test task to terminate even when the child async tasks are still running, as long as all test classes are accounted for. 
    * That means that the remaining child tasks have no more work to do, and will anyway just immediately terminate when it's their turn to run

* We pre-claim the first test class in the parent Mill process before spawning the child process. This provides:
    * A smoother UI since the user won't see empty worker lines in the prompt that get filled in later: now all test worker lines immediately get a label of what test class they will run
    *  Faster feedback to `TestModuleUtild` that no more processes. Previously we would spawn a bunch of children that only later claim the test classes, meaning we only find out after spawning them if we actually didn't need so many. Now, test classes get claimed up front and if we don't need any more subprocesses the async task terminates early without spawning one

Tested this manually running 

```
/Users/lihaoyi/Github/mill/out/dist/launcher.dest/run 'codec-{dns,haproxy,http,http2,memcache,mqtt,redis,smtp,socks,stomp,xml}.test' + 'transport-{blockhound-tests,native-unix-common,sctp}.test'
```

on our example Netty build. Verified that the test parent task prompt lines that were previously hanging around longer than necessary no longer do so