### PR TITLE
WIP: Added support for importing an SBT build

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -53,6 +53,8 @@ object Deps {
   // and then add to it `bridgeScalaVersions`
   val scalaVersion = "3.6.2"
   val scala2Version = "2.13.15"
+  // The Scala 2.12.x version to use for legacy support
+  val scala212Version = "2.12.20"
   // The Scala 2.12.x version to use for some workers
   val workerScalaVersion212 = "2.12.20"
 
@@ -220,6 +222,7 @@ object Deps {
     ivy"org.apache.maven.resolver:maven-resolver-transport-wagon:$mavenResolverVersion"
   val coursierJvmIndexVersion = "0.0.4-84-f852c6"
   val gradleApi = ivy"dev.gradleplugins:gradle-api:8.11.1"
+  val sbt = ivy"org.scala-sbt:sbt:1.10.10"
 
   object RuntimeDeps {
     val dokkaVersion = "2.0.0"

--- a/dist/package.mill
+++ b/dist/package.mill
@@ -75,6 +75,7 @@ object `package` extends RootModule with InstallModule {
       build.main.graphviz.testDep(),
       build.main.init.maven.testDep(),
       build.main.init.gradle.testDep(),
+      build.main.init.sbt.testDep(),
       build.scalalib.backgroundwrapper.testDep(),
       build.contrib.bloop.testDep(),
       build.contrib.buildinfo.testDep(),

--- a/integration/feature/init/src/MillInitSbtTests.scala
+++ b/integration/feature/init/src/MillInitSbtTests.scala
@@ -58,10 +58,12 @@ object MillInitSbtFs2Tests extends MillInitSbtTests {
     test - integrationTestGitRepo("https://github.com/typelevel/fs2", "tags/v3.11.0") { tester =>
       import tester.*
 
-      // meta-build fails:
-      // The package name `reactive-streams` will be encoded on the classpath, and can lead to undefined behaviour.
       val initRes = eval(initCmd(), stdout = os.Inherit, stderr = os.Inherit)
-      assert(!initRes.isSuccess)
+      assert(initRes.isSuccess)
+
+      // TODO resolve cross deps
+      val compileRes = eval("__.compile", stdout = os.Inherit, stderr = os.Inherit)
+      assert(!compileRes.isSuccess) // TODO check out
     }
   }
 }

--- a/integration/feature/init/src/MillInitSbtTests.scala
+++ b/integration/feature/init/src/MillInitSbtTests.scala
@@ -62,5 +62,6 @@ object MillInitSbtFs2Tests extends MillInitSbtTests {
       // The package name `reactive-streams` will be encoded on the classpath, and can lead to undefined behaviour.
       val initRes = eval(initCmd(), stdout = os.Inherit, stderr = os.Inherit)
       assert(!initRes.isSuccess)
+    }
   }
 }

--- a/integration/feature/init/src/MillInitSbtTests.scala
+++ b/integration/feature/init/src/MillInitSbtTests.scala
@@ -1,0 +1,66 @@
+package mill.integration
+
+import mill.testkit.{IntegrationTester, UtestIntegrationTestSuite}
+import utest.*
+
+abstract class MillInitSbtTests extends UtestIntegrationTestSuite {
+
+  def initCmd(args: String*): Seq[String] =
+    // TODO why is version required (on my machine only?)?
+    "init" +: "--sbt-version" +: "1.10.10" +: "--verbose" +: args
+
+  def integrationTestGitRepo[T](
+      url: String,
+      branch: String
+  )(f: IntegrationTester => T) = {
+    if (sys.env.contains("CI")) None // TODO setup CI
+    else Some(super.integrationTest { tester =>
+      val cwd = tester.workspacePath
+      val stderr = os.Pipe
+      os.proc("git", "init", ".").call(cwd = cwd, stderr = stderr)
+      os.proc("git", "remote", "add", "-f", "origin", url).call(cwd = cwd, stderr = stderr)
+      os.proc("git", "checkout", branch).call(cwd = cwd, stderr = stderr)
+      f(tester)
+    })
+  }
+}
+
+object MillInitSbtAirstreamTests extends MillInitSbtTests {
+
+  def tests: Tests = Tests {
+    // single Scala JS module
+    // custom repos
+    test - integrationTestGitRepo("https://github.com/raquo/Airstream", "tags/v17.2.0") {
+      tester =>
+        import tester.*
+
+        val initRes = eval(initCmd(), stdout = os.Inherit, stderr = os.Inherit)
+        assert(initRes.isSuccess)
+
+        val compileRes = eval("__.compile", stdout = os.Inherit, stderr = os.Inherit)
+        assert(compileRes.isSuccess) // TODO check out
+
+        val testRes = eval("__.test", stdout = os.Inherit, stderr = os.Inherit)
+        assert(testRes.isSuccess) // TODO check out
+
+        val publishLocalRes = eval("__.publishLocal", stdout = os.Inherit, stderr = os.Inherit)
+        assert(!publishLocalRes.isSuccess) // undefined: JsPromiseSignal.this.promise.then
+    }
+  }
+}
+
+object MillInitSbtFs2Tests extends MillInitSbtTests {
+
+  def tests: Tests = Tests {
+    // Full layout cross platform
+    // cross version specific sources
+    // non-cross platform project ("benchmark")
+    test - integrationTestGitRepo("https://github.com/typelevel/fs2", "tags/v3.11.0") { tester =>
+      import tester.*
+
+      // meta-build fails:
+      // The package name `reactive-streams` will be encoded on the classpath, and can lead to undefined behaviour.
+      val initRes = eval(initCmd(), stdout = os.Inherit, stderr = os.Inherit)
+      assert(!initRes.isSuccess)
+  }
+}

--- a/main/init/buildgen/src/mill/main/buildgen/BuildGenUtil.scala
+++ b/main/init/buildgen/src/mill/main/buildgen/BuildGenUtil.scala
@@ -1,14 +1,9 @@
 package mill.main.buildgen
 
 import mainargs.{Flag, arg}
+import mill.constants.CodeGenConstants.{nestedBuildFileNames, rootBuildFileNames, rootModuleAlias}
 import mill.constants.OutFiles
 import mill.main.buildgen.BuildObject.Companions
-import mill.constants.CodeGenConstants.{
-  buildFileExtensions,
-  nestedBuildFileNames,
-  rootBuildFileNames,
-  rootModuleAlias
-}
 import mill.runner.FileImportGraph.backtickWrap
 
 import scala.collection.immutable.SortedSet
@@ -138,7 +133,9 @@ object BuildGenUtil {
 
   def buildFiles(workspace: os.Path): geny.Generator[os.Path] =
     os.walk.stream(workspace, skip = (workspace / OutFiles.out).equals)
-      .filter(file => buildFileExtensions.contains(file.ext))
+      .filter(_.lastOpt.exists(name =>
+        rootBuildFileNames.contains(name) || rootBuildFileNames.contains(name)
+      ))
 
   def buildPackage(dirs: Seq[String]): String =
     (rootModuleAlias +: dirs).iterator.map(backtickWrap).mkString(".")

--- a/main/init/package.mill
+++ b/main/init/package.mill
@@ -1,11 +1,12 @@
 package build.main.init
 
 import mill._
-import scala.util.matching.Regex
+import mill.contrib.buildinfo.BuildInfo
+import mill.scalalib._
 
 object `package` extends RootModule with build.MillPublishScalaModule {
 
-  def moduleDeps = Seq(build.main, build.main.init.buildgen, build.scalalib)
+  def moduleDeps = Seq(buildgen, build.main, build.scalalib)
 
   override def resources = Task {
     super.resources() ++ Seq(exampleList())
@@ -62,6 +63,13 @@ object `package` extends RootModule with build.MillPublishScalaModule {
     PathRef(Task.dest)
   }
 
+  val millScalaVersion = build.Deps.scalaVersion
+  val sbtScala2Version = build.Deps.scala212Version
+  val initCrossScalaVersions = Seq(millScalaVersion, sbtScala2Version)
+  trait InitCrossScalaModule extends build.MillPublishScalaModule with CrossScalaModule {
+    def scalaVersion = crossScalaVersion
+  }
+
   object buildgen extends build.MillPublishScalaModule {
     def moduleDeps = Seq(build.runner)
     def testModuleDeps = super.testModuleDeps ++ Seq(build.scalalib)
@@ -85,5 +93,33 @@ object `package` extends RootModule with build.MillPublishScalaModule {
       build.Deps.mavenResolverTransportWagon
     )
     def testModuleDeps = super.testModuleDeps ++ Seq(build.scalalib, buildgen.test)
+  }
+  object sbt extends build.MillPublishScalaModule with BuildInfo {
+    def buildInfoPackageName = "mill.main.sbt"
+    def buildInfoMembers = Seq(
+      BuildInfo.Value("exporterAssemblyResource", s"/$exporterAssemblyName")
+    )
+    def moduleDeps = Seq(define(millScalaVersion), build.runner)
+    def resources = super.resources() ++ Seq(exporterAssemblyDir())
+
+    trait DefineModule extends InitCrossScalaModule {
+      def ivyDeps = Agg(build.Deps.osLib, build.Deps.upickle)
+    }
+    object define extends Cross[DefineModule](initCrossScalaVersions)
+
+    val exporterAssemblyName = "exporter-assembly.jar"
+    def exporterAssemblyDir = Task {
+      val dest = Task.dest
+      os.copy(exporter.assembly().path, dest / exporterAssemblyName)
+      PathRef(dest)
+    }
+
+    object exporter extends build.MillScalaModule {
+      def assemblyRules = Seq(Assembly.Rule.ExcludePattern("scala\\.*"))
+      def compileIvyDeps = Agg(build.Deps.sbt)
+      def moduleDeps = Seq(define(sbtScala2Version))
+      def scalaVersion = sbtScala2Version
+      def scalacOptions = super.scalacOptions().diff(Seq("-Xsource:3"))
+    }
   }
 }

--- a/main/init/sbt/define/src/mill/main/buildgen/BasicReadWriters.scala
+++ b/main/init/sbt/define/src/mill/main/buildgen/BasicReadWriters.scala
@@ -1,0 +1,8 @@
+package mill.main.buildgen
+
+import upickle.default.{readwriter, ReadWriter => RW}
+
+object BasicReadWriters {
+  implicit val relPath: RW[os.RelPath] = readwriter[String].bimap(_.toString(), os.RelPath(_))
+  implicit val subPath: RW[os.SubPath] = readwriter[String].bimap(_.toString(), os.SubPath(_))
+}

--- a/main/init/sbt/define/src/mill/main/buildgen/ir.scala
+++ b/main/init/sbt/define/src/mill/main/buildgen/ir.scala
@@ -1,0 +1,138 @@
+package mill.main.buildgen
+
+import mill.main.buildgen.BasicReadWriters.*
+import upickle.default.{macroRW, ReadWriter as RW}
+
+case class IrLicense(
+    id: String,
+    name: String,
+    url: String,
+    isOsiApproved: Boolean = false,
+    isFsfLibre: Boolean = false,
+    distribution: String = "repo"
+)
+object IrLicense {
+  implicit val rw: RW[IrLicense] = macroRW
+}
+
+case class IrVersionControl(
+    url: Option[String] = None,
+    connection: Option[String] = None,
+    developerConnection: Option[String] = None,
+    tag: Option[String] = None
+)
+object IrVersionControl {
+  implicit val rw: RW[IrVersionControl] = macroRW
+}
+
+case class IrDeveloper(
+    id: String,
+    name: String,
+    url: String,
+    organization: Option[String] = None,
+    organizationUrl: Option[String] = None
+)
+object IrDeveloper {
+  implicit val rw: RW[IrDeveloper] = macroRW
+}
+
+case class IrPomSettings(
+    description: String,
+    organization: String,
+    url: String,
+    licenses: Seq[IrLicense] = Nil,
+    versionControl: IrVersionControl = IrVersionControl(),
+    developers: Seq[IrDeveloper] = Nil
+)
+object IrPomSettings {
+  implicit val rw: RW[IrPomSettings] = macroRW
+}
+
+sealed trait IrCrossVersion
+object IrCrossVersion {
+  case class Constant(value: String = "", platformed: Boolean = false) extends IrCrossVersion
+  object Constant {
+    implicit def rw: RW[Constant] = macroRW
+  }
+  case class Binary(platformed: Boolean = false) extends IrCrossVersion
+  object Binary {
+    implicit def rw: RW[Binary] = macroRW
+  }
+  case class Full(platformed: Boolean = false) extends IrCrossVersion
+  object Full {
+    implicit def rw: RW[Full] = macroRW
+  }
+
+  implicit def rw: RW[IrCrossVersion] = RW.merge(Constant.rw, Binary.rw, Full.rw)
+}
+
+case class IrDep(
+    organization: String,
+    name: String,
+    version: String,
+    crossVersion: IrCrossVersion = IrCrossVersion.Constant(),
+    `type`: Option[String] = None,
+    classifier: Option[String] = None
+)
+object IrDep {
+
+  implicit val rw: RW[IrDep] = macroRW
+}
+
+sealed trait IrModuleConfig
+object IrModuleConfig {
+  implicit val rw: RW[IrModuleConfig] = macroRW
+}
+
+case class IrCoursierModuleConfig(
+    repositories: Seq[String] = Nil
+) extends IrModuleConfig
+object IrCoursierModuleConfig {
+  implicit val rw: RW[IrCoursierModuleConfig] = macroRW
+}
+
+case class IrJavaModuleConfig(
+    javacOptions: Seq[String] = Nil,
+    sources: Seq[os.RelPath] = Nil,
+    resources: Seq[os.RelPath] = Nil,
+    bomIvyDeps: Seq[IrDep] = Nil,
+    ivyDeps: Seq[IrDep] = Nil,
+    moduleDeps: Seq[os.SubPath] = Nil,
+    compileIvyDeps: Seq[IrDep] = Nil,
+    compileModuleDeps: Seq[os.SubPath] = Nil,
+    runIvyDeps: Seq[IrDep] = Nil,
+    runModuleDeps: Seq[os.SubPath] = Nil
+) extends IrModuleConfig
+object IrJavaModuleConfig {
+  implicit val rw: RW[IrJavaModuleConfig] = macroRW
+}
+
+case class IrPublishModuleConfig(
+    pomSettings: IrPomSettings,
+    publishVersion: String
+) extends IrModuleConfig
+object IrPublishModuleConfig {
+  implicit val rw: RW[IrPublishModuleConfig] = macroRW
+}
+
+case class IrScalaModuleConfig(
+    scalaVersion: String,
+    scalacOptions: Seq[String]
+) extends IrModuleConfig
+object IrScalaModuleConfig {
+  implicit val rw: RW[IrScalaModuleConfig] = macroRW
+}
+
+case class IrScalaJSModuleConfig(
+    scalaJSVersion: String
+) extends IrModuleConfig
+object IrScalaJSModuleConfig {
+  implicit val rw: RW[IrScalaJSModuleConfig] = macroRW
+}
+
+case class IrScalaNativeModuleConfig(
+    scalaNativeVersion: String
+) extends IrModuleConfig
+object IrScalaNativeModuleConfig {
+  implicit val rw: RW[IrScalaNativeModuleConfig] = macroRW
+}

--- a/main/init/sbt/define/src/mill/main/sbt/SbtProjectModel.scala
+++ b/main/init/sbt/define/src/mill/main/sbt/SbtProjectModel.scala
@@ -1,0 +1,23 @@
+package mill.main.sbt
+
+import mill.main.buildgen.*
+import mill.main.buildgen.BasicReadWriters.*
+import upickle.default.{macroRW, ReadWriter as RW}
+
+case class SbtProjectModel(
+    projectId: String,
+    moduleName: String,
+    baseDir: os.SubPath,
+    crossVersions: Seq[String],
+    crossPlatformBaseDir: Option[os.SubPath],
+    coursierConfig: IrCoursierModuleConfig,
+    javaConfig: IrJavaModuleConfig,
+    publishConfig: Option[IrPublishModuleConfig],
+    scalaConfig: IrScalaModuleConfig,
+    scalaJSConfig: Option[IrScalaJSModuleConfig],
+    scalaNativeConfig: Option[IrScalaNativeModuleConfig],
+    testJavaConfig: Option[IrJavaModuleConfig]
+)
+object SbtProjectModel {
+  implicit val rw: RW[SbtProjectModel] = macroRW
+}

--- a/main/init/sbt/exporter/src/mill/main/sbt/ApplyExport.scala
+++ b/main/init/sbt/exporter/src/mill/main/sbt/ApplyExport.scala
@@ -1,0 +1,38 @@
+package mill.main.sbt
+
+import sbt.{BuiltinCommands, GlobalScope, Project, ProjectRef, Scope, Select, State, Zero}
+
+/**
+ * SBT `apply` script that adds [[ExportKeys]] settings to a session.
+ *
+ * =Usage=
+ * [[ExportKeys.millInitExportFile]] must be defined before
+ * [[https://github.com/JetBrains/sbt-structure/#sideloading sideloading]].
+ * {{{
+ *   set SettingKey[File]("millInitExportFile") in Global := file(<path-to-file>)
+ *   apply -cp <path-to-jar> mill.main.sbt.ApplyExport
+ *   millInitExport
+ * }}}
+ */
+object ApplyExport extends (State => State) {
+
+  // https://github.com/JetBrains/sbt-structure/blob/master/extractor/src/main/scala/org/jetbrains/sbt/CreateTasks.scala
+  def apply(state: State) = {
+    val globalSettings = Seq(
+      ExportKeys.millInitExport := ExportTasks.millInitExport.value
+    )
+    val projectSettings = Seq(
+      ExportKeys.millInitProjectModel := ExportTasks.millInitProjectModel.value
+    )
+    val extracted = Project.extract(state)
+    def transformProject(ref: ProjectRef) = {
+      val projectScope = Scope(Select(ref), Zero, Zero, Zero)
+      val transformScope = Scope.resolveScope(projectScope, ref.build, extracted.rootProject)
+      Project.transform(transformScope, projectSettings)
+    }
+    val exportSettings =
+      sbt.inScope(GlobalScope)(globalSettings) ++
+        extracted.structure.allProjectRefs.flatMap(transformProject)
+    BuiltinCommands.reapply(extracted.session.appendRaw(exportSettings), extracted.structure, state)
+  }
+}

--- a/main/init/sbt/exporter/src/mill/main/sbt/ExportKeys.scala
+++ b/main/init/sbt/exporter/src/mill/main/sbt/ExportKeys.scala
@@ -1,0 +1,9 @@
+package mill.main.sbt
+
+import sbt.{File, settingKey, taskKey}
+
+object ExportKeys {
+  val millInitExport = taskKey[Unit]("")
+  val millInitExportFile = settingKey[File]("")
+  val millInitProjectModel = taskKey[SbtProjectModel]("")
+}

--- a/main/init/sbt/exporter/src/mill/main/sbt/ExportTasks.scala
+++ b/main/init/sbt/exporter/src/mill/main/sbt/ExportTasks.scala
@@ -1,0 +1,123 @@
+package mill.main.sbt
+
+import mill.main.buildgen._
+import sbt.{Def, _}
+
+object ExportTasks {
+
+  def millInitExport = Def.taskDyn {
+    val file = os.Path(ExportKeys.millInitExportFile.value)
+    require(os.exists(file), "millInitExportFile must be defined before calling millInitExport")
+
+    val state = Keys.state.value
+    val build = Project.structure(state)
+    def skip(ref: ProjectRef) =
+      build.allProjects.exists(p => p.id == ref.project && p.aggregate.nonEmpty)
+    Def.task {
+      val models = sbt.std.TaskExtra.joinTasks(
+        build.allProjectRefs.flatMap(ref =>
+          if (skip(ref)) None else (ref / ExportKeys.millInitProjectModel).get(build.data)
+        )
+      ).join.value
+
+      val out = os.write.outputStream(file)
+      try upickle.default.writeToOutputStream(models, out)
+      finally out.close()
+    }
+  }
+
+  def millInitProjectModel = Def.taskDyn {
+    val project = Keys.thisProject.value
+    val basePath = os.Path(project.base)
+
+    val state = Keys.state.value
+    val allProjectBaseDirs = Project.structure(state).allProjects.iterator
+      .map(p => p.id -> subPwd(p.base))
+      .toMap
+
+    val libDeps = Keys.libraryDependencies.value
+    val scalaJSConfig = libDeps.collectFirst {
+      case dep if dep.organization == "org.scala-js" && dep.name.startsWith("scalajs-library_") =>
+        IrScalaJSModuleConfig(dep.revision)
+    }
+    val scalaNativeConfig = libDeps.collectFirst {
+      case dep
+          if dep.organization == "org.scala-native" &&
+            dep.configurations.contains("plugin->default(compile)") =>
+        IrScalaNativeModuleConfig(dep.revision)
+    }
+
+    def relBase(files: Seq[File]) = files.iterator
+      .map(os.Path(_))
+      .filter(os.exists)
+      .map(_.relativeTo(basePath))
+      .toSeq
+
+    val platformed = scalaJSConfig.nonEmpty || scalaNativeConfig.nonEmpty
+    val ivyDeps = new IrCompat.ToDeps(libDeps.filterNot(IrCompat.skipDep), platformed)
+    val moduleDeps = new ToModuleDeps(project.dependencies, allProjectBaseDirs)
+    Def.task {
+      val coursierConfig = IrCoursierModuleConfig(
+        Keys.resolvers.value.collect(IrCompat.repository)
+      )
+
+      val javaConfig = IrJavaModuleConfig(
+        javacOptions = Keys.javacOptions.value,
+        sources = relBase((Compile / Keys.unmanagedSourceDirectories).value),
+        resources = relBase((Compile / Keys.unmanagedResourceDirectories).value),
+        ivyDeps = ivyDeps(None), // sbt.Compile is not marked explicitly
+        moduleDeps = moduleDeps(Compile),
+        compileIvyDeps = ivyDeps(Some(Provided.name)),
+        runIvyDeps = ivyDeps(Some(Runtime.name))
+      )
+      val scalaVersion = Keys.scalaVersion.value
+      val scalaConfig = IrScalaModuleConfig(
+        scalaVersion = scalaVersion,
+        scalacOptions = Keys.scalacOptions.value
+      )
+      val publishConfig =
+        if ((Keys.publish / Keys.skip).value) None
+        else Keys.projectInfo.?.value
+          .map(IrCompat.toPomSettings)
+          .map(IrPublishModuleConfig(_, Keys.version.value))
+
+      val testIvyDeps = ivyDeps(Some(Test.name))
+      val testJavaConfig =
+        if (testIvyDeps.isEmpty) None
+        else Some(IrJavaModuleConfig(
+          sources = relBase((Test / Keys.unmanagedSourceDirectories).value),
+          resources = relBase((Test / Keys.unmanagedResourceDirectories).value),
+          ivyDeps = testIvyDeps
+        ))
+
+      SbtProjectModel(
+        projectId = project.id,
+        moduleName = Keys.moduleName.value,
+        baseDir = subPwd(project.base),
+        crossVersions = IrCompat.crossVersions(scalaVersion, Keys.crossScalaVersions.value),
+        crossPlatformBaseDir = ThirdPartyKeys.crossProjectBaseDirectory.?.value.map(subPwd),
+        coursierConfig = coursierConfig,
+        javaConfig = javaConfig,
+        publishConfig = publishConfig,
+        scalaConfig = scalaConfig,
+        scalaJSConfig = scalaJSConfig,
+        scalaNativeConfig = scalaNativeConfig,
+        testJavaConfig = testJavaConfig
+      )
+    }
+  }
+
+  def subPwd(f: File) = os.Path(f).subRelativeTo(os.pwd)
+
+  class ToModuleDeps(
+      projectDependencies: Seq[ClasspathDep[ProjectRef]],
+      allProjectBaseDirs: Map[String, os.SubPath]
+  ) {
+
+    def apply(configuration: Configuration) = projectDependencies.iterator
+      .filter(_.configuration.forall(_.contains(configuration.name)))
+      .map(_.project.project)
+      .map(allProjectBaseDirs)
+      .toSeq
+  }
+}

--- a/main/init/sbt/exporter/src/mill/main/sbt/IrCompat.scala
+++ b/main/init/sbt/exporter/src/mill/main/sbt/IrCompat.scala
@@ -1,0 +1,109 @@
+package mill.main.sbt
+
+import mill.main.buildgen._
+import sbt.URL
+import sbt.librarymanagement._
+
+object IrCompat {
+
+  def crossVersions(scalaVersion: String, crossScalaVersions: Seq[String]) =
+    crossScalaVersions match {
+      case Seq(`scalaVersion`) => Nil
+      case _ => crossScalaVersions
+    }
+
+  def toLicense(l: (String, URL)) = {
+    val (name, url) = l
+    IrLicense(
+      id = name,
+      name = name,
+      url = url.toExternalForm
+    )
+  }
+
+  def toVersionControl(scm: Option[ScmInfo]) =
+    scm.fold(IrVersionControl()) { info =>
+      import info._
+      IrVersionControl(
+        url = Some(browseUrl.toExternalForm),
+        connection = Some(connection),
+        developerConnection = devConnection,
+        tag = None
+      )
+    }
+
+  def toDeveloper(dev: Developer) = {
+    import dev._
+    IrDeveloper(
+      id = id,
+      name = name,
+      url = url.toExternalForm
+    )
+  }
+
+  def toPomSettings(info: ModuleInfo) = {
+    import info._
+    IrPomSettings(
+      description = description,
+      organization = organizationName,
+      url = homepage.fold("")(_.toExternalForm),
+      licenses = licenses.map(toLicense),
+      versionControl = toVersionControl(scmInfo),
+      developers = developers.map(toDeveloper)
+    )
+  }
+
+  val repository: PartialFunction[Resolver, String] = {
+    case r: MavenRepository => r.root
+  }
+
+  def skipDep(moduleID: ModuleID) = {
+    val organization = moduleID.organization
+    val name = moduleID.name
+    organization match {
+      case "org.scala-lang" => true
+      case "org.scala-js" => name != "scalajs-dom"
+      case "org.scala-native" => true
+      case _ => false
+    }
+  }
+
+  class ToDeps(
+      libDeps: Seq[ModuleID],
+      platformed: Boolean,
+      disabled: CrossVersion = CrossVersion.disabled
+  ) {
+
+    def apply(configuration: Option[String]) =
+      libDeps.iterator
+        .filter(m => m.configurations == configuration)
+        .map(toDep)
+        .toSeq
+
+    def toDep(moduleId: ModuleID) = {
+      val crossVersion = moduleId.crossVersion match {
+        case `disabled` => IrCrossVersion.Constant(platformed = platformed)
+        case _: CrossVersion.Binary => IrCrossVersion.Binary(platformed)
+        case _: CrossVersion.Full => IrCrossVersion.Full(platformed)
+        case cv: CrossVersion.Constant => IrCrossVersion.Constant(cv.value, platformed)
+        case _: For3Use2_13 => IrCrossVersion.Constant("2.13", platformed)
+        case _: For2_13Use3 => IrCrossVersion.Constant("3", platformed)
+        case cv =>
+          println(s"ignoring cross version $cv for dependency $moduleId")
+          IrCrossVersion.Constant(platformed = platformed)
+      }
+
+      def moduleAttr[T](f: Artifact => T) = moduleId.explicitArtifacts.iterator
+        .collectFirst { case a if a.name == moduleId.name => f(a) }
+
+      IrDep(
+        organization = moduleId.organization,
+        name = moduleId.name,
+        version = moduleId.revision,
+        crossVersion = crossVersion,
+        `type` = moduleAttr(_.`type`),
+        classifier = moduleAttr(_.classifier).flatten
+      )
+    }
+  }
+}

--- a/main/init/sbt/exporter/src/mill/main/sbt/ThirdPartyKeys.scala
+++ b/main/init/sbt/exporter/src/mill/main/sbt/ThirdPartyKeys.scala
@@ -1,0 +1,9 @@
+package mill.main.sbt
+
+import sbt.{File, settingKey}
+
+object ThirdPartyKeys {
+
+  // https://github.com/portable-scala/sbt-crossproject/blob/7fbbf6be90e012b6f765647b113846b845719218/sbt-crossproject/src/main/scala/sbtcrossproject/CrossPlugin.scala#L68
+  val crossProjectBaseDirectory = settingKey[File]("base directory of the current cross project")
+}

--- a/main/init/sbt/src/mill/main/buildgen/BuildGenConstants.scala
+++ b/main/init/sbt/src/mill/main/buildgen/BuildGenConstants.scala
@@ -1,0 +1,18 @@
+package mill.main.buildgen
+
+object BuildGenConstants:
+
+  val rootMagicImport: String = "import $packages._"
+
+  val testRunnerModuleByOrg: Map[String, String] = Map(
+    "org.testng" -> "TestModule.TestNg",
+    "junit" -> "TestModule.Junit4",
+    "org.junit.jupiter" -> "TestModule.Junit5",
+    "org.scalatest" -> "TestModule.ScalaTest",
+    "org.specs2" -> "TestModule.Specs2",
+    "org.scalameta" -> "TestModule.Munit",
+    "com.disneystreaming" -> "TestModule.Weaver",
+    "dev.zio" -> "TestModule.ZioTest",
+    "org.scalacheck" -> "TestModule.ScalaCheck",
+    "com.lihaoyi" -> "TestModule.UTest"
+  )

--- a/main/init/sbt/src/mill/main/buildgen/BuildGenUtil.scala
+++ b/main/init/sbt/src/mill/main/buildgen/BuildGenUtil.scala
@@ -1,0 +1,12 @@
+package mill.main.buildgen
+
+import mill.constants.CodeGenConstants.{nestedBuildFileNames, rootBuildFileNames}
+import mill.constants.OutFiles
+
+object BuildGenUtil:
+
+  def buildFiles(workspace: os.Path = os.pwd): Seq[os.Path] =
+    os.walk(workspace, skip = (workspace / OutFiles.out).equals)
+      .filter(_.lastOpt.exists(name =>
+        rootBuildFileNames.contains(name) || nestedBuildFileNames.contains(name)
+      ))

--- a/main/init/sbt/src/mill/main/buildgen/BuildTreeWriter.scala
+++ b/main/init/sbt/src/mill/main/buildgen/BuildTreeWriter.scala
@@ -1,0 +1,266 @@
+package mill.main.buildgen
+
+import mill.constants.CodeGenConstants.{nestedBuildFileNames, rootBuildFileNames, rootModuleAlias}
+import mill.runner.FileImportGraph
+import mill.runner.FileImportGraph.backtickWrap
+
+class BuildTreeWriter(packages: Tree[MetaPackage], workspace: os.Path = os.pwd):
+
+  def write() =
+    packages.nodes.foreach: pkg =>
+      val fileName =
+        if os.sub == pkg.baseDir then rootBuildFileNames.get(0) else nestedBuildFileNames.get(0)
+      val subFile = pkg.baseDir / fileName
+      val contents = renderPackage(pkg)
+      println(s"writing build file $subFile")
+      os.write(workspace / subFile, contents)
+
+  // TODO mark private?
+  def renderAlias(baseDir: os.SubPath) =
+    if baseDir == os.sub then rootModuleAlias
+    else baseDir.segments0.iterator.map(backtickWrap).mkString(s"$rootModuleAlias.", ".", "")
+
+  def isCrossModule(baseDir: os.SubPath) =
+    def isCrossDepIn(baseDir: os.SubPath, module: MetaModule): Boolean =
+      if module.crossVersions.isEmpty then false
+      else
+        val newBase = baseDir / module.name
+        baseDir == newBase || module.nestedModules.exists(isCrossDepIn(newBase, _))
+
+    packages.nodes(using Tree.Traversal.BreadthFirst)
+      .filter: pkg =>
+        baseDir.startsWith(pkg.baseDir)
+      .exists: pkg =>
+        baseDir == pkg.baseDir ||
+          baseDir.startsWith(pkg.baseDir) && isCrossDepIn(pkg.baseDir, pkg.module)
+  end isCrossModule
+
+  def renderPackage(meta: MetaPackage) =
+    val linebreak =
+      s"""
+         |""".stripMargin
+    import meta.*
+    s"""package ${renderAlias(baseDir)}
+       |${imports.mkString(linebreak)}
+       |${renderModule(module, isPackage = true)}
+       |""".stripMargin
+
+  def renderModule(meta: MetaModule, isPackage: Boolean = false): String =
+    val linebreak =
+      s"""
+         |""".stripMargin
+    import meta.*
+    val objName = if isPackage then "`package`" else backtickWrap(name)
+    if crossVersions.isEmpty then
+      val objSupertypes = if isPackage then "RootModule" +: supertypes else supertypes
+      s"""object $objName ${renderExtends(objSupertypes)} {
+         |${renderModuleConfigs(moduleConfigs)}
+         |${nestedModules.iterator.map(renderModule(_)).mkString(linebreak)}
+         |}""".stripMargin
+    else
+      val crossModuleName = backtickWrap(s"${name.capitalize}Module")
+      val crossVarargs = crossVersions.mkString("\"", "\",\"", "\"")
+      val objExtends =
+        (if isPackage then "RootModule with " else "") +
+          s"Cross[$crossModuleName]($crossVarargs)"
+      s"""object $objName extends $objExtends
+         |trait $crossModuleName ${renderExtends(supertypes)} {
+         |${renderModuleConfigs(moduleConfigs)}
+         |${nestedModules.iterator.map(renderModule(_)).mkString(linebreak)}
+         |}
+         |""".stripMargin
+
+  def renderExtends(supertypes: Seq[String]) = supertypes match
+    case Seq() => ""
+    case Seq(head) => s"extends $head"
+    case head +: tail => tail.mkString(s"extends $head with ", " with ", "")
+
+  def renderModuleConfigs(irs: IterableOnce[IrModuleConfig]) =
+    irs.iterator
+      .map:
+        case ir: IrCoursierModuleConfig => renderCoursierModuleConfig(ir)
+        case ir: IrJavaModuleConfig => renderJavaModuleConfig(ir)
+        case ir: IrPublishModuleConfig => renderPublishModuleConfig(ir)
+        case ir: IrScalaModuleConfig => renderScalaModuleConfig(ir)
+        case ir: IrScalaJSModuleConfig => renderScalaJSModuleConfig(ir)
+        case ir: IrScalaNativeModuleConfig => renderScalaNativeModuleConfig(ir)
+      .mkString(s"""
+                   |""".stripMargin)
+
+  def renderCoursierModuleConfig(ir: IrCoursierModuleConfig) =
+    import ir.*
+    s"""${renderRepositories(repositories)}
+       |""".stripMargin
+
+  def renderJavaModuleConfig(ir: IrJavaModuleConfig) =
+    import ir.*
+    s"""${renderJavacOptions(javacOptions)}
+       |${renderSources(sources)}
+       |${renderResources(resources)}
+       |${renderIvyDeps(ivyDeps)}
+       |${renderModuleDeps(moduleDeps)}
+       |${renderCompileIvyDeps(compileIvyDeps)}
+       |${renderCompileModuleDeps(compileModuleDeps)}
+       |${renderRunIvyDeps(runIvyDeps)}
+       |${renderRunModuleDeps(runModuleDeps)}
+       |""".stripMargin
+
+  def renderPublishModuleConfig(ir: IrPublishModuleConfig) =
+    import ir.*
+    s"""${renderPomSettings(pomSettings)}
+       |${renderPublishVersion(publishVersion)}
+       |""".stripMargin
+
+  def renderScalaModuleConfig(ir: IrScalaModuleConfig) =
+    import ir.*
+    s"""${renderScalaVersion(scalaVersion)}
+       |${renderScalacOptions(scalacOptions)}
+       |""".stripMargin
+
+  def renderScalaJSModuleConfig(ir: IrScalaJSModuleConfig) =
+    import ir.*
+    s"""${renderScalaJSVersion(scalaJSVersion)}
+       |""".stripMargin
+
+  def renderScalaNativeModuleConfig(ir: IrScalaNativeModuleConfig) =
+    import ir.*
+    s"""${renderScalaNativeVersion(scalaNativeVersion)}
+       |""".stripMargin
+
+  def renderRepositories(strs: Seq[String]) =
+    if strs.isEmpty then ""
+    else
+      strs.mkString(
+        "def repositoriesTask = Task.Anon(super.repositoriesTask() ++ Seq(MavenRepository(\"",
+        "\"),MavenRepository(\"",
+        "\")))"
+      )
+
+  def renderJavacOptions(strs: Seq[String]) =
+    if strs.isEmpty then ""
+    else strs.mkString("def javacOptions = super.javacOptions() ++ Seq(\"", "\",\"", "\")")
+
+  def renderSources(rels: Seq[os.RelPath]) =
+    if rels.isEmpty then ""
+    else
+      rels
+        .mkString(
+          "def sources = Task.Sources(\"",
+          "\",\"",
+          "\")"
+        )
+
+  def renderResources(rels: Seq[os.RelPath]) =
+    if rels.isEmpty then ""
+    else
+      rels
+        .mkString(
+          "def resources = Task.Sources(\"",
+          "\",\"",
+          "\")"
+        )
+
+  def renderIvyDeps(deps: Seq[IrDep]) =
+    if deps.isEmpty then ""
+    else
+      deps.iterator
+        .map(renderDep)
+        .mkString(s"def ivyDeps = super.ivyDeps() ++ Agg(", ",", ")")
+
+  def renderModuleDeps(subs: Seq[os.SubPath]) =
+    if subs.isEmpty then ""
+    else
+      subs.iterator
+        .map(renderModuleDep)
+        .mkString(s"def moduleDeps = super.moduleDeps ++ Seq(", ",", ")")
+
+  def renderCompileIvyDeps(deps: Seq[IrDep]) =
+    if deps.isEmpty then ""
+    else
+      deps.iterator
+        .map(renderDep)
+        .mkString(s"def compileIvyDeps = super.compileIvyDeps() ++ Agg(", ",", ")")
+
+  def renderCompileModuleDeps(subs: Seq[os.SubPath]) =
+    if subs.isEmpty then ""
+    else
+      subs.iterator
+        .map(renderModuleDep)
+        .mkString(s"def compileModuleDeps = super.compileModuleDeps() ++ Seq(", ",", ")")
+
+  def renderRunIvyDeps(deps: Seq[IrDep]) =
+    if deps.isEmpty then ""
+    else
+      deps.iterator
+        .map(renderDep)
+        .mkString(s"def runIvyDeps = super.runIvyDeps() ++ Agg(", ",", ")")
+
+  def renderRunModuleDeps(subs: Seq[os.SubPath]) =
+    if subs.isEmpty then ""
+    else
+      subs.iterator
+        .map(renderModuleDep)
+        .mkString(s"def runModuleDeps = super.runModuleDeps() ++ Seq(", ",", ")")
+
+  def renderDep(ir: IrDep) =
+    import ir.*
+    val sepType = `type` match
+      case None | Some("jar") => ""
+      case value => s";type=$value"
+    val sepClassfier = classifier.fold("")(";classifier=" + _)
+    val attrs = sepType + sepClassfier
+    import IrCrossVersion.*
+    val encoded = ir.crossVersion match
+      case Constant("", false) => s"$organization:$name:$version;$attrs"
+      case Constant("", true) => s"$organization:$name::$version;$attrs"
+      case Binary(false) => s"$organization::$name:$version;$attrs"
+      case Binary(true) => s"$organization::$name::$version;$attrs"
+      case Full(false) => s"$organization:::$name:$version;$attrs"
+      case Full(true) => s"$organization:::$name::$version;$attrs"
+      case _: Constant => s"$organization:$name::$version;$attrs"
+    s"ivy\"$encoded\""
+
+  def renderModuleDep(baseDir: os.SubPath) =
+    val alias = renderAlias(baseDir)
+    if isCrossModule(baseDir) then alias + "()" else alias
+
+  def renderPomSettings(ir: IrPomSettings) =
+    def mkOpt(opt: Option[String]) = opt.fold("None")(s => s"Some(\"$s\")")
+
+    def mkSeq(it: IterableOnce[String]) = it.iterator.mkString("Seq(", ",", ")")
+
+    def renderLicense(ir: IrLicense) =
+      import ir.*
+      s"License(\"$id\",\"$name\",\"$url\",$isOsiApproved,$isFsfLibre,\"$distribution\")"
+
+    def renderVersionControl(ir: IrVersionControl) =
+      import ir.*
+      s"VersionControl(${mkOpt(url)},${mkOpt(connection)},${mkOpt(developerConnection)},${mkOpt(tag)})"
+
+    def renderDeveloper(ir: IrDeveloper) =
+      import ir.*
+      s"Developer(\"$id\",\"$name\",\"$url\",${mkOpt(organization)},${mkOpt(organizationUrl)})"
+
+    import ir.*
+    val lics = mkSeq(licenses.iterator.map(renderLicense))
+    val verc = renderVersionControl(versionControl)
+    val devs = mkSeq(developers.iterator.map(renderDeveloper))
+    s"def pomSettings = PomSettings(\"$description\",\"$organization\",\"$url\",$lics,$verc,$devs)"
+
+  def renderPublishVersion(str: String) =
+    s"def publishVersion = \"$str\""
+
+  def renderScalaVersion(str: String) =
+    s"def scalaVersion = \"$str\""
+
+  def renderScalacOptions(strs: Seq[String]) =
+    if strs.isEmpty then ""
+    else strs.mkString(s"def scalacOptions = super.scalacOptions() ++ Seq(\"", "\",\"", "\")")
+
+  def renderScalaJSVersion(str: String) =
+    s"def scalaJSVersion = \"$str\""
+
+  def renderScalaNativeVersion(str: String) =
+    s"def scalaNativeVersion = \"$str\""
+
+end BuildTreeWriter

--- a/main/init/sbt/src/mill/main/buildgen/Tree.scala
+++ b/main/init/sbt/src/mill/main/buildgen/Tree.scala
@@ -1,0 +1,70 @@
+package mill.main.buildgen
+
+import geny.Generator
+
+/**
+ * A recursive data structure that defines parent-child relationships between nodes.
+ *
+ * @param node the root node of this tree
+ * @param children the child subtrees of this tree
+ */
+case class Tree[+Node](node: Node, children: Seq[Tree[Node]] = Nil):
+
+  def map[Out](f: Node => Out): Tree[Out] =
+    transform[Out]((node, children) => Tree(f(node), children.iterator.toSeq))
+
+  def nodes(using Tree.Traversal): Generator[Node] =
+    subtrees.map(_.node)
+
+  def subtrees(using T: Tree.Traversal): Generator[Tree[Node]] =
+    T.subtrees(this)
+
+  def transform[Out](f: (Node, IterableOnce[Tree[Out]]) => Tree[Out]): Tree[Out] =
+    def recurse(tree: Tree[Node]): Tree[Out] =
+      f(tree.node, tree.children.iterator.map(recurse))
+    end recurse
+    recurse(this)
+
+object Tree:
+
+  def from[Input, Node](start: Input)(step: Input => (Node, IterableOnce[Input])): Tree[Node] =
+    def recurse(input: Input): Tree[Node] =
+      val (node, next) = step(input)
+      Tree(node, next.iterator.map(recurse).toSeq)
+    recurse(start)
+
+  sealed trait Traversal:
+    def subtrees[Node](root: Tree[Node]): Generator[Tree[Node]]
+
+  object Traversal:
+    given Traversal = DepthFirst
+
+    object BreadthFirst extends Traversal:
+
+      def subtrees[Node](root: Tree[Node]): Generator[Tree[Node]] = handleItem =>
+        @annotation.tailrec
+        def recurse(level: Seq[Tree[Node]]): Generator.Action =
+          var last: Generator.Action = Generator.Continue
+          var index = 0
+          while (last == Generator.Continue && index < level.length) {
+            last = handleItem(level(index))
+            index += 1
+          }
+          val nextLevel = level.flatMap(_.children)
+          if (last == Generator.Continue && nextLevel.nonEmpty) recurse(nextLevel) else last
+        end recurse
+        recurse(Seq(root))
+
+    object DepthFirst extends Traversal:
+
+      def subtrees[Node](root: Tree[Node]): Generator[Tree[Node]] = handleItem =>
+        def recurse(tree: Tree[Node]): Generator.Action =
+          var last: Generator.Action = Generator.Continue
+          var index = 0
+          while (last == Generator.Continue && index < tree.children.length) {
+            last = recurse(tree.children(index))
+            index += 1
+          }
+          if (last == Generator.Continue) handleItem(tree) else last
+        end recurse
+        recurse(root)

--- a/main/init/sbt/src/mill/main/buildgen/meta.scala
+++ b/main/init/sbt/src/mill/main/buildgen/meta.scala
@@ -1,0 +1,15 @@
+package mill.main.buildgen
+
+case class MetaModule(
+    name: String,
+    supertypes: Seq[String],
+    crossVersions: Seq[String] = Nil,
+    moduleConfigs: Seq[IrModuleConfig] = Nil,
+    nestedModules: Seq[MetaModule] = Nil
+)
+
+case class MetaPackage(
+    baseDir: os.SubPath,
+    imports: Seq[String],
+    module: MetaModule
+)

--- a/main/init/sbt/src/mill/main/sbt/SbtBuildGenMain.scala
+++ b/main/init/sbt/src/mill/main/sbt/SbtBuildGenMain.scala
@@ -1,0 +1,144 @@
+package mill.main.sbt
+
+import mainargs.*
+import mill.constants.Util
+import mill.main.buildgen.*
+import mill.util.Jvm
+import pprint.Util.literalize
+
+object SbtBuildGenMain:
+
+  def main(args0: Array[String]): Unit =
+    given SbtBuildGenArgs = ParserForClass[SbtBuildGenArgs].constructOrExit(args0.toSeq)
+    println("converting SBT build")
+    val assembly = extractExporterAssembly()
+    val projects = importSbtProjects(assembly)
+    val packages = toMetaTree(projects)
+    BuildTreeWriter(packages).write()
+
+  def extractExporterAssembly() =
+    val in = getClass.getResourceAsStream(BuildInfo.exporterAssemblyResource)
+    require(null != in, "exporter assembly must be on the classpath")
+    try os.temp(in, suffix = ".jar")
+    finally in.close()
+
+  def importSbtProjects(exporterAssembly: os.Path)(using args: SbtBuildGenArgs) =
+    import args.*
+    def systemSbt = if Util.isWindows then "sbt.bat" else "sbt"
+    val sbt = customSbt.getOrElse(systemSbt)
+    val env = jvmIdSbt.map(id => Map("JAVA_HOME" -> Jvm.resolveJavaHome(id).get.toString)).orNull
+    val stdout = if noLogSbt.value then os.Pipe else os.Inherit
+    val out = os.temp()
+    os.proc(
+      sbt,
+      sbtOptions.value,
+      s"set SettingKey[File](\"millInitExportFile\") in Global := file(${literalize(out.toString)})",
+      s"apply -cp ${literalize(exporterAssembly.toString)} mill.main.sbt.ApplyExport",
+      "millInitExport"
+    ).call(env = env, stdout = stdout)
+    upickle.default.read[Seq[SbtProjectModel]](out.toNIO)
+
+  def toMetaTree(projects: Seq[SbtProjectModel]) =
+    // group cross-platform projects with the "actual" base dir
+    val projectGroups = projects.groupBy: project =>
+      project.crossPlatformBaseDir.getOrElse(project.baseDir)
+
+    Tree.from(os.sub): nodeBaseDir =>
+      val node = toMetaPackage(nodeBaseDir, projectGroups.getOrElse(nodeBaseDir, Nil))
+      val children =
+        val children0 = projectGroups.keysIterator
+          .filter(_.segments0.length == nodeBaseDir.segments0.length + 1)
+        if children0.isEmpty then
+          projectGroups.keysIterator
+            .collect: // introduce empty `RootModule`(s) to reach deeply nested projects
+              case groupBaseDir if groupBaseDir.segments0.length > nodeBaseDir.segments0.length =>
+                nodeBaseDir / groupBaseDir.segments0.head
+        else children0
+      (node, children)
+  end toMetaTree
+
+  def toMetaPackage(baseDir: os.SubPath, projectGroup: Seq[SbtProjectModel]) =
+    val imports =
+      Seq( // TODO derive
+        "import coursier.maven.MavenRepository",
+        "import mill._",
+        "import mill.scalalib._",
+        "import mill.scalalib.publish._",
+        "import mill.scalajslib._",
+        "import mill.scalanativelib._"
+      )
+    projectGroup match
+      case Seq(project) => // not a cross-platform group
+        MetaPackage(
+          baseDir = baseDir,
+          imports = imports,
+          module = toMetaModule(project)
+        )
+      case _ =>
+        val name = baseDir.lastOpt.getOrElse("package")
+        val nestedModules = projectGroup.map(toMetaModule)
+        val module = MetaModule(
+          name = name,
+          supertypes = Nil,
+          nestedModules = nestedModules
+        )
+        MetaPackage(
+          baseDir = baseDir,
+          imports = imports,
+          module = module
+        )
+  end toMetaPackage
+
+  def toMetaModule(project: SbtProjectModel) =
+    import project.*
+    val name = baseDir.lastOpt.getOrElse(project.moduleName)
+    val supertypes =
+      val supertype0 =
+        if scalaJSConfig.nonEmpty then "ScalaJSModule"
+        else if scalaNativeConfig.nonEmpty then "ScalaNativeModule"
+        else "ScalaModule"
+      Seq(supertype0) ++
+        Option.when(crossVersions.nonEmpty)("CrossScalaModule") ++
+        Option.when(publishConfig.nonEmpty)("PublishModule")
+    val moduleConfigs = Seq.newBuilder[IrModuleConfig]
+      .+=(scalaConfig)
+      .++=(publishConfig)
+      .+=(javaConfig)
+      .+=(coursierConfig)
+      .++=(scalaJSConfig.orElse(scalaNativeConfig))
+      .result()
+    MetaModule(
+      name = name,
+      supertypes = supertypes,
+      crossVersions = crossVersions,
+      moduleConfigs = moduleConfigs,
+      nestedModules = Seq.from(toTestMetaModule(project))
+    )
+  end toMetaModule
+
+  def toTestMetaModule(project: SbtProjectModel) =
+    project.testJavaConfig.flatMap: javaModuleConfig =>
+      javaModuleConfig.ivyDeps
+        .collectFirst(BuildGenConstants.testRunnerModuleByOrg.compose(_.organization))
+        .map: runnerModule =>
+          val supertype =
+            if project.scalaJSConfig.nonEmpty then "ScalaJSTests"
+            else if project.scalaNativeConfig.nonEmpty then "ScalaNativeTests"
+            else "ScalaTests"
+          MetaModule(
+            name = "test",
+            supertypes = Seq(supertype, runnerModule),
+            moduleConfigs = Seq(javaModuleConfig)
+          )
+  end toTestMetaModule
+
+@main case class SbtBuildGenArgs(
+    @arg(doc = "distribution and version of custom JVM to run SBT")
+    jvmIdSbt: Option[String], // TODO is overkill?
+    @arg(doc = "hide SBT output")
+    noLogSbt: Flag,
+    @arg(doc = "custom SBT command")
+    customSbt: Option[String],
+    @arg(doc = "SBT command line options")
+    sbtOptions: Leftover[String]
+)

--- a/main/init/src/mill/init/InitSbtModule.scala
+++ b/main/init/src/mill/init/InitSbtModule.scala
@@ -1,0 +1,12 @@
+package mill.init
+
+import mill.define.{Discover, ExternalModule}
+
+object InitSbtModule extends ExternalModule with BuildGenModule {
+
+  lazy val millDiscover = Discover[this.type]
+
+  def buildGenClasspath = BuildGenModule.millModule("mill-main-init-sbt")
+
+  def buildGenMainClass = "mill.main.sbt.SbtBuildGenMain"
+}

--- a/main/src/mill/main/MainModule.scala
+++ b/main/src/mill/main/MainModule.scala
@@ -277,6 +277,11 @@ trait MainModule extends BaseModule {
             Seq("mill.init.InitGradleModule/init") ++ args,
             SelectMode.Separated
           )
+        else if (os.exists(os.pwd / "build.sbt"))
+          evaluator.evaluate(
+            Seq("mill.init.InitSbtModule/init") ++ args,
+            SelectMode.Separated
+          )
         else if (args.headOption.exists(_.toLowerCase.endsWith(".g8")))
           evaluator.evaluate(
             Seq("mill.scalalib.giter8.Giter8Module/init") ++ args,


### PR DESCRIPTION
This PR extends `mill init` with the ability to import a SBT project.
The basic functionality is working but the PR is not ready for review. I could use some help with testing on Windows though.

As part of this attempt,
- The IR types introduced in previous integrations were refactored and refined to improve maintainability and extensibility.
- A SBT `apply` script was added to extract project settings required to construct the Mill "meta-build" tree.
- The new setup was used to import the [Airstream](https://github.com/raquo/Airstream) project in an integration test. The (cross Scala, JS platform) project was successfully compiled and tested using Mill.

**Credits**
- Several techniques were borrowed from [sbt-structure](https://github.com/JetBrains/sbt-structure) and [sbt-bloop](https://github.com/scalacenter/bloop).
- The idea to include the exporter assembly in the published artifact was taken from #4586.

More to follow.