### PR TITLE
Add test runner indicators

### DIFF
--- a/core/internal/src/mill/internal/PromptLoggerUtil.scala
+++ b/core/internal/src/mill/internal/PromptLoggerUtil.scala
@@ -60,10 +60,6 @@ private object PromptLoggerUtil {
     (AnsiNav.clearScreen(0) + AnsiNav.up(1) + "\n").getBytes
 
   def spaceNonEmpty(s: String) = if (s.isEmpty) "" else s" $s"
-  private def renderSecondsSuffix(millis: Long) = (millis / 1000).toInt match {
-    case 0 => ""
-    case n => s" ${n}s"
-  }
 
   def readTerminalDims(terminfoPath: os.Path): Option[(Option[Int], Option[Int])] = {
     try {
@@ -98,7 +94,7 @@ private object PromptLoggerUtil {
     val maxWidth = consoleWidth - 1
     // -1 to account for header
     val maxHeight = math.max(1, consoleHeight / 3 - 1)
-    val headerSuffix = renderSecondsSuffix(now - startTimeMillis)
+    val headerSuffix = mill.internal.Util.renderSecondsSuffix(now - startTimeMillis)
 
     val header = renderHeader(headerPrefix, titleText, headerSuffix, maxWidth)
 
@@ -120,7 +116,7 @@ private object PromptLoggerUtil {
               status.next
             else status.prev
             textOpt.map { t =>
-              val seconds = renderSecondsSuffix(now - t.startTimeMillis)
+              val seconds = mill.internal.Util.renderSecondsSuffix(now - t.startTimeMillis)
               val mainText = splitShorten(t.text + seconds, maxWidth)
 
               val detail = splitShorten(spaceNonEmpty(t.detail), maxWidth - mainText.length)

--- a/core/internal/src/mill/internal/Util.scala
+++ b/core/internal/src/mill/internal/Util.scala
@@ -4,4 +4,9 @@ private[mill] object Util {
   def leftPad(s: String, targetLength: Int, char: Char): String = {
     char.toString * (targetLength - s.length) + s
   }
+
+  def renderSecondsSuffix(millis: Long) = (millis / 1000).toInt match {
+    case 0 => ""
+    case n => s" ${n}s"
+  }
 }

--- a/scalalib/src/mill/scalalib/TestModule.scala
+++ b/scalalib/src/mill/scalalib/TestModule.scala
@@ -156,6 +156,7 @@ trait TestModule
     Task.Anon {
       val mainClass = "mill.testrunner.entrypoint.TestRunnerMain"
       val outputPath = Task.dest / "out.json"
+      val resultPath = Task.dest / "results.log"
       val selectors = Seq.empty
 
       val testArgs = TestArgs(
@@ -164,6 +165,7 @@ trait TestModule
         arguments = args(),
         sysProps = Map.empty,
         outputPath = outputPath,
+        resultPath = resultPath,
         colored = Task.log.prompt.colored,
         testCp = testClasspath().map(_.path),
         globSelectors = Left(selectors)

--- a/scalalib/src/mill/scalalib/TestModuleUtil.scala
+++ b/scalalib/src/mill/scalalib/TestModuleUtil.scala
@@ -225,6 +225,8 @@ private final class TestModuleUtil(
   )(implicit ctx: mill.api.Ctx) = {
 
     val workerStatusMap = new java.util.concurrent.ConcurrentHashMap[os.Path, String => Unit]()
+    val workerStatsSet = new java.util.concurrent.ConcurrentHashMap[os.Path, Unit]()
+    val testClassTimeMap = new java.util.concurrent.ConcurrentHashMap[String, Long]()
 
     def prepareTestClassesFolder(selectors2: Seq[String], base: os.Path): os.Path = {
       // test-classes folder is used to store the test classes for the children test runners to claim from
@@ -262,11 +264,15 @@ private final class TestModuleUtil(
         val claimLog = claimFolder / os.up / s"${claimFolder.last}.log"
         os.write.over(claimLog, Array.empty[Byte])
         workerStatusMap.put(claimLog, logger.ticker)
+        val claimStats = claimFolder / os.up / s"${claimFolder.last}.stats"
+        os.write.over(claimStats, upickle.default.write((0L, 0L)))
+        workerStatsSet.put(claimStats, ())
         val result = callTestRunnerSubprocess(
           base,
           Right((startingTestClass, testClassQueueFolder, claimFolder))
         )
         workerStatusMap.remove(claimLog)
+        // We don't remove workerStatsSet entry, as we still need them for calculation
         Some(result)
       } else {
         None
@@ -355,16 +361,36 @@ private final class TestModuleUtil(
       }
     }
 
+    val filteredClassCount = filteredClassLists.map(_.size).sum
     val executor = Executors.newScheduledThreadPool(1)
     val outputs =
       try {
-        // Periodically check the queueLog file of every runner, and tick the executing test name
+        // Periodically check the claim log and claim stats files of every runner, and tick the relevant infos
         executor.scheduleWithFixedDelay(
-          () =>
+          () => {
+            // reuse to reduce syscall, may not be as accurate as running `System.currentTimeMillis()` inside each entry
+            val now = System.currentTimeMillis()
             workerStatusMap.forEach { (claimLog, callback) =>
               // the last one is always the latest
-              os.read.lines(claimLog).lastOption.foreach(callback)
-            },
+              os.read.lines(claimLog).lastOption.foreach { currentTestClass =>
+                testClassTimeMap.putIfAbsent(currentTestClass, now)
+                val last = testClassTimeMap.get(currentTestClass)
+                val suffix = ((now - last) / 1000).toInt match {
+                  case 0 => ""
+                  case n => s" ${n}s"
+                }
+                callback(s"$currentTestClass$suffix")
+              }
+            }
+            var totalSuccess = 0L 
+            var totalFailure = 0L
+            workerStatsSet.forEach { (claimStats, _) =>
+              val (success, failure) = upickle.default.read[(Long, Long)](os.read.stream(claimStats))
+              totalSuccess += success
+              totalFailure += failure
+            }
+            ctx.log.ticker(s"${totalSuccess + totalFailure}/${filteredClassCount} completed, ${totalFailure} failures")
+          },
           0,
           20,
           java.util.concurrent.TimeUnit.MILLISECONDS
@@ -374,15 +400,20 @@ private final class TestModuleUtil(
           // We special-case this to avoid
           while ({
             val claimedCounts = subprocessFutures.flatMap(_.value).flatMap(_.toOption).map(_._1)
-            val expectedCounts = filteredClassLists.map(_.size)
             !(
-              (claimedCounts.sum == expectedCounts.sum && subprocessFutures.head.isCompleted) ||
+              (claimedCounts.sum == filteredClassCount && subprocessFutures.head.isCompleted) ||
                 subprocessFutures.forall(_.isCompleted)
             )
           }) Thread.sleep(1)
         }
         subprocessFutures.flatMap(_.value).map(_.get)
-      } finally executor.shutdown()
+      } finally {
+        executor.shutdown()
+        // help gc
+        workerStatusMap.clear()
+        workerStatsSet.clear()
+        testClassTimeMap.clear()
+      }
 
     val subprocessResult = {
       val failMap = mutable.Map.empty[String, String]

--- a/scalalib/src/mill/scalalib/TestModuleUtil.scala
+++ b/scalalib/src/mill/scalalib/TestModuleUtil.scala
@@ -272,7 +272,8 @@ private final class TestModuleUtil(
           Right((startingTestClass, testClassQueueFolder, claimFolder))
         )
         workerStatusMap.remove(claimLog)
-        // We don't remove workerStatsSet entry, as we still need them for calculation
+        // We don't remove workerStatsSet entry, as we still need them
+        // for calculation of total success/failure counts
         Some(result)
       } else {
         None
@@ -407,13 +408,7 @@ private final class TestModuleUtil(
           }) Thread.sleep(1)
         }
         subprocessFutures.flatMap(_.value).map(_.get)
-      } finally {
-        executor.shutdown()
-        // help gc
-        workerStatusMap.clear()
-        workerStatsSet.clear()
-        testClassTimeMap.clear()
-      }
+      } finally executor.shutdown()
 
     val subprocessResult = {
       val failMap = mutable.Map.empty[String, String]

--- a/scalalib/test/src/mill/scalalib/TestRunnerScalatestTests.scala
+++ b/scalalib/test/src/mill/scalalib/TestRunnerScalatestTests.scala
@@ -32,8 +32,8 @@ object TestRunnerScalatestTests extends TestSuite {
         3,
         Map(
           // No test grouping is triggered because we only run one test class
-          testrunner.scalatest -> Set("out.json", "sandbox", "test-report.xml", "testargs"),
-          testrunnerGrouping.scalatest -> Set("out.json", "sandbox", "test-report.xml", "testargs"),
+          testrunner.scalatest -> Set("out.json", "result.log", "sandbox", "test-report.xml", "testargs"),
+          testrunnerGrouping.scalatest -> Set("out.json", "result.log", "sandbox", "test-report.xml", "testargs"),
           testrunnerWorkStealing.scalatest -> Set("worker-0", "test-classes", "test-report.xml")
         )
       )
@@ -43,7 +43,7 @@ object TestRunnerScalatestTests extends TestSuite {
         Seq("*"),
         9,
         Map(
-          testrunner.scalatest -> Set("out.json", "sandbox", "test-report.xml", "testargs"),
+          testrunner.scalatest -> Set("out.json", "result.log", "sandbox", "test-report.xml", "testargs"),
           testrunnerGrouping.scalatest -> Set(
             "group-0-mill.scalalib.ScalaTestSpec",
             "mill.scalalib.ScalaTestSpec3",
@@ -76,7 +76,7 @@ object TestRunnerScalatestTests extends TestSuite {
         Seq("*", "--", "-z", "A Set 2"),
         3,
         Map(
-          testrunner.scalatest -> Set("out.json", "sandbox", "test-report.xml", "testargs"),
+          testrunner.scalatest -> Set("out.json", "result.log", "sandbox", "test-report.xml", "testargs"),
           testrunnerGrouping.scalatest -> Set(
             "group-0-mill.scalalib.ScalaTestSpec",
             "mill.scalalib.ScalaTestSpec3",

--- a/scalalib/test/src/mill/scalalib/TestRunnerScalatestTests.scala
+++ b/scalalib/test/src/mill/scalalib/TestRunnerScalatestTests.scala
@@ -32,8 +32,20 @@ object TestRunnerScalatestTests extends TestSuite {
         3,
         Map(
           // No test grouping is triggered because we only run one test class
-          testrunner.scalatest -> Set("out.json", "result.log", "sandbox", "test-report.xml", "testargs"),
-          testrunnerGrouping.scalatest -> Set("out.json", "result.log", "sandbox", "test-report.xml", "testargs"),
+          testrunner.scalatest -> Set(
+            "out.json",
+            "result.log",
+            "sandbox",
+            "test-report.xml",
+            "testargs"
+          ),
+          testrunnerGrouping.scalatest -> Set(
+            "out.json",
+            "result.log",
+            "sandbox",
+            "test-report.xml",
+            "testargs"
+          ),
           testrunnerWorkStealing.scalatest -> Set("worker-0", "test-classes", "test-report.xml")
         )
       )
@@ -43,7 +55,13 @@ object TestRunnerScalatestTests extends TestSuite {
         Seq("*"),
         9,
         Map(
-          testrunner.scalatest -> Set("out.json", "result.log", "sandbox", "test-report.xml", "testargs"),
+          testrunner.scalatest -> Set(
+            "out.json",
+            "result.log",
+            "sandbox",
+            "test-report.xml",
+            "testargs"
+          ),
           testrunnerGrouping.scalatest -> Set(
             "group-0-mill.scalalib.ScalaTestSpec",
             "mill.scalalib.ScalaTestSpec3",
@@ -76,7 +94,13 @@ object TestRunnerScalatestTests extends TestSuite {
         Seq("*", "--", "-z", "A Set 2"),
         3,
         Map(
-          testrunner.scalatest -> Set("out.json", "result.log", "sandbox", "test-report.xml", "testargs"),
+          testrunner.scalatest -> Set(
+            "out.json",
+            "result.log",
+            "sandbox",
+            "test-report.xml",
+            "testargs"
+          ),
           testrunnerGrouping.scalatest -> Set(
             "group-0-mill.scalalib.ScalaTestSpec",
             "mill.scalalib.ScalaTestSpec3",

--- a/scalalib/test/src/mill/scalalib/TestRunnerUtestTests.scala
+++ b/scalalib/test/src/mill/scalalib/TestRunnerUtestTests.scala
@@ -34,9 +34,9 @@ object TestRunnerUtestTests extends TestSuite {
         Seq("mill.scalalib.FooTests"),
         1,
         Map(
-          testrunner.utest -> Set("out.json", "sandbox", "test-report.xml", "testargs"),
+          testrunner.utest -> Set("out.json", "result.log", "sandbox", "test-report.xml", "testargs"),
           // When there is only one test group with test classes, we do not put it in a subfolder
-          testrunnerGrouping.utest -> Set("out.json", "sandbox", "test-report.xml", "testargs"),
+          testrunnerGrouping.utest -> Set("out.json", "result.log", "sandbox", "test-report.xml", "testargs"),
           testrunnerWorkStealing.utest -> Set("worker-0", "test-classes", "test-report.xml")
         )
       )
@@ -44,7 +44,7 @@ object TestRunnerUtestTests extends TestSuite {
         Seq("*Bar*", "*bar*"),
         2,
         Map(
-          testrunner.utest -> Set("out.json", "sandbox", "test-report.xml", "testargs"),
+          testrunner.utest -> Set("out.json", "result.log", "sandbox", "test-report.xml", "testargs"),
           // When there are multiple test groups with one test class each, we
           // put each test group in a subfolder with the number of the class
           testrunnerGrouping.utest -> Set(
@@ -59,7 +59,7 @@ object TestRunnerUtestTests extends TestSuite {
         Seq("*"),
         3,
         Map(
-          testrunner.utest -> Set("out.json", "sandbox", "test-report.xml", "testargs"),
+          testrunner.utest -> Set("out.json", "result.log", "sandbox", "test-report.xml", "testargs"),
           // When there are multiple test groups some with multiple test classes, we put each
           // test group in a subfolder with the index of the group, and for any test groups
           // with only one test class we append the name of the class

--- a/scalalib/test/src/mill/scalalib/TestRunnerUtestTests.scala
+++ b/scalalib/test/src/mill/scalalib/TestRunnerUtestTests.scala
@@ -34,9 +34,21 @@ object TestRunnerUtestTests extends TestSuite {
         Seq("mill.scalalib.FooTests"),
         1,
         Map(
-          testrunner.utest -> Set("out.json", "result.log", "sandbox", "test-report.xml", "testargs"),
+          testrunner.utest -> Set(
+            "out.json",
+            "result.log",
+            "sandbox",
+            "test-report.xml",
+            "testargs"
+          ),
           // When there is only one test group with test classes, we do not put it in a subfolder
-          testrunnerGrouping.utest -> Set("out.json", "result.log", "sandbox", "test-report.xml", "testargs"),
+          testrunnerGrouping.utest -> Set(
+            "out.json",
+            "result.log",
+            "sandbox",
+            "test-report.xml",
+            "testargs"
+          ),
           testrunnerWorkStealing.utest -> Set("worker-0", "test-classes", "test-report.xml")
         )
       )
@@ -44,7 +56,13 @@ object TestRunnerUtestTests extends TestSuite {
         Seq("*Bar*", "*bar*"),
         2,
         Map(
-          testrunner.utest -> Set("out.json", "result.log", "sandbox", "test-report.xml", "testargs"),
+          testrunner.utest -> Set(
+            "out.json",
+            "result.log",
+            "sandbox",
+            "test-report.xml",
+            "testargs"
+          ),
           // When there are multiple test groups with one test class each, we
           // put each test group in a subfolder with the number of the class
           testrunnerGrouping.utest -> Set(
@@ -59,7 +77,13 @@ object TestRunnerUtestTests extends TestSuite {
         Seq("*"),
         3,
         Map(
-          testrunner.utest -> Set("out.json", "result.log", "sandbox", "test-report.xml", "testargs"),
+          testrunner.utest -> Set(
+            "out.json",
+            "result.log",
+            "sandbox",
+            "test-report.xml",
+            "testargs"
+          ),
           // When there are multiple test groups some with multiple test classes, we put each
           // test group in a subfolder with the index of the group, and for any test groups
           // with only one test class we append the name of the class

--- a/testrunner/src/mill/testrunner/Model.scala
+++ b/testrunner/src/mill/testrunner/Model.scala
@@ -9,6 +9,7 @@ import mill.api.internal
     arguments: Seq[String],
     sysProps: Map[String, String],
     outputPath: os.Path,
+    resultPath: os.Path,
     colored: Boolean,
     testCp: Seq[os.Path],
     // globSelectors indicates the strategy for testrunner to find and run test classes

--- a/testrunner/src/mill/testrunner/TestRunnerMain0.scala
+++ b/testrunner/src/mill/testrunner/TestRunnerMain0.scala
@@ -17,7 +17,8 @@ import mill.api.{DummyTestReporter, internal}
             args = testArgs.arguments,
             classFilter = cls => filter(cls.getName),
             cl = classLoader,
-            testReporter = DummyTestReporter
+            testReporter = DummyTestReporter,
+            resultPathOpt = Some(testArgs.resultPath)
           )
         case Right((startingTestClass, testClassQueueFolder, claimFolder)) =>
           TestRunnerUtils.queueTestFramework0(
@@ -28,7 +29,8 @@ import mill.api.{DummyTestReporter, internal}
             testClassQueueFolder = testClassQueueFolder,
             claimFolder = claimFolder,
             cl = classLoader,
-            testReporter = DummyTestReporter
+            testReporter = DummyTestReporter,
+            resultPath = testArgs.resultPath
           )
       }
 

--- a/testrunner/src/mill/testrunner/TestRunnerUtils.scala
+++ b/testrunner/src/mill/testrunner/TestRunnerUtils.scala
@@ -150,7 +150,7 @@ import java.util.concurrent.atomic.AtomicBoolean
             event.status match {
               case Status.Error => taskStatus.set(false)
               case Status.Failure => taskStatus.set(false)
-              case _ => taskStatus.compareAndSet(true, true) // consider success as a default
+              case _ => () // consider success as a default
             }
             testReporter.logFinish(event)
           }

--- a/testrunner/src/mill/testrunner/TestRunnerUtils.scala
+++ b/testrunner/src/mill/testrunner/TestRunnerUtils.scala
@@ -120,7 +120,9 @@ import java.util.concurrent.atomic.AtomicBoolean
     val runner = framework.runner(args.toArray, Array[String](), cl)
     val testClasses = discoverTests(cl, framework, testClassfilePath)
 
-    val filteredTestClasses = testClasses.iterator.filter { case (cls, _) => classFilter(cls) }.toArray
+    val filteredTestClasses = testClasses.iterator.filter { case (cls, _) =>
+      classFilter(cls)
+    }.toArray
 
     val tasksArr = // each test class can have multiple test tasks ==> array of test classes will have this signature
       if (filteredTestClasses.isEmpty) {
@@ -233,10 +235,14 @@ import java.util.concurrent.atomic.AtomicBoolean
     var failureCounter = 0L
 
     val resultLog: () => Unit = resultPathOpt match {
-      case Some(resultPath) => () => os.write.over(resultPath, upickle.default.write((successCounter, failureCounter)))
-      case None => () => systemOut.println(s"Test result: ${successCounter + failureCounter} completed${ if failureCounter > 0 then s", ${failureCounter} failures." else "."}")
+      case Some(resultPath) =>
+        () => os.write.over(resultPath, upickle.default.write((successCounter, failureCounter)))
+      case None => () =>
+          systemOut.println(s"Test result: ${successCounter + failureCounter} completed${
+              if failureCounter > 0 then s", ${failureCounter} failures." else "."
+            }")
     }
-  
+
     tasksSeq.foreach { tasks =>
       val taskResult = executeTasks(tasks, testReporter, events, systemOut)
       if taskResult then successCounter += 1 else failureCounter += 1
@@ -260,7 +266,8 @@ import java.util.concurrent.atomic.AtomicBoolean
 
     val (runner, tasksArr) = getTestTasks(framework, args, classFilter, cl, testClassfilePath)
 
-    val (doneMessage, results) = runTasks(tasksArr.view.map(_.toSeq).toSeq, testReporter, runner, resultPathOpt)
+    val (doneMessage, results) =
+      runTasks(tasksArr.view.map(_.toSeq).toSeq, testReporter, runner, resultPathOpt)
 
     (doneMessage, results.toSeq)
   }
@@ -283,7 +290,7 @@ import java.util.concurrent.atomic.AtomicBoolean
       .toMap
     var successCounter = 0L
     var failureCounter = 0L
-    
+
     def runClaimedTestClass(testClassName: String) = {
 
       System.err.println(s"Running Test Class $testClassName")


### PR DESCRIPTION
/claim #4735

This PR add some calculation to add test progress & failure indicator for each test runner while `testParallelism` is set to `true`

<img width="724" alt="Screenshot 2025-03-16 at 23 50 22" src="https://github.com/user-attachments/assets/83cbf384-7fe0-469a-b0b3-43acceb702dc" />

To add progress indicators, this pull request introduces a new file within each worker's claim folder. This file is overwritten every time `runClaimedTestClass` is called. The parent process will checks these files in each worker, accumulates their contents, and outputs them via a `ticker`.

For test timing, this pull request uses a separate map, similar to `workerStatusMap`, to store the starting time. The time calculation is then straightforward, and the result is output via a `ticker` alongside the test class name.