### PR TITLE
[0.12.x] Support `nativeServiceProviders` in `ScalaNativeModule` (Backport #4736)

### DIFF
--- a/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
+++ b/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
@@ -227,6 +227,15 @@ trait ScalaNativeModule extends ScalaModule { outer =>
    */
   def nativeMultithreading: T[Option[Boolean]] = Task { None }
 
+  /**
+   * List of service providers which shall be allowed in the final binary.
+   * Example:
+   *   Map("java.nio.file.spi.FileSystemProvider" -> Seq("my.lib.MyCustomFileSystem"))
+   *   Makes the implementation for the FileSystemProvider trait in `my.lib.MyCustomFileSystem`
+   *   included in the binary for reflective instantiation.
+   */
+  def nativeServiceProviders: T[Map[String, Seq[String]]] = Task { Map.empty[String, Seq[String]] }
+
   private def nativeConfig: Task[NativeConfig] = Task.Anon {
     val classpath = runClasspath().map(_.path).filter(_.toIO.exists).toList
     withScalaNativeBridge.apply().apply(_.config(
@@ -247,6 +256,7 @@ trait ScalaNativeModule extends ScalaModule { outer =>
       nativeIncrementalCompilation(),
       nativeDump(),
       nativeMultithreading(),
+      nativeServiceProviders(),
       toWorkerApi(logLevel()),
       toWorkerApi(nativeBuildTarget())
     )) match {

--- a/scalanativelib/worker-api/src/mill/scalanativelib/worker/api/ScalaNativeWorkerApi.scala
+++ b/scalanativelib/worker-api/src/mill/scalanativelib/worker/api/ScalaNativeWorkerApi.scala
@@ -28,6 +28,7 @@ private[scalanativelib] trait ScalaNativeWorkerApi {
       nativeIncrementalCompilation: Boolean,
       nativeDump: Boolean,
       nativeMultithreading: Option[Boolean],
+      nativeServiceProviders: Map[String, Seq[String]],
       logLevel: NativeLogLevel,
       buildTarget: BuildTarget
   ): Either[String, Object]

--- a/scalanativelib/worker/0.5/src/mill/scalanativelib/worker/ScalaNativeWorkerImpl.scala
+++ b/scalanativelib/worker/0.5/src/mill/scalanativelib/worker/ScalaNativeWorkerImpl.scala
@@ -59,6 +59,7 @@ class ScalaNativeWorkerImpl extends mill.scalanativelib.worker.api.ScalaNativeWo
       nativeIncrementalCompilation: Boolean,
       nativeDump: Boolean,
       nativeMultithreading: Option[Boolean],
+      nativeServiceProviders: Map[String, Seq[String]],
       logLevel: NativeLogLevel,
       buildTarget: BuildTarget
   ): Either[String, Config] = {
@@ -83,6 +84,7 @@ class ScalaNativeWorkerImpl extends mill.scalanativelib.worker.api.ScalaNativeWo
         .withEmbedResources(nativeEmbedResources)
         .withIncrementalCompilation(nativeIncrementalCompilation)
         .withMultithreading(nativeMultithreading)
+        .withServiceProviders(nativeServiceProviders)
         .withBaseName("out")
 
     val config = Config.empty


### PR DESCRIPTION
Scala Native supports `ServiceProvider` which allows loading implementations for interfaces using reflection. To avoid bloating binaries with all available implementations, Scala Native requires to set at build time the implementations that are used. This PR adds support for it in Mill.

Pull Request: https://github.com/com-lihaoyi/mill/pull/4736
