### PR TITLE
Use minDependencies instead of orderedDependencies in allDeps

### DIFF
--- a/scalalib/src/mill/scalalib/CoursierModule.scala
+++ b/scalalib/src/mill/scalalib/CoursierModule.scala
@@ -300,7 +300,7 @@ object CoursierModule {
      */
     def allDeps[T: CoursierModule.Resolvable](
         deps: IterableOnce[T]
-    ): Seq[coursier.core.Dependency] = {
+    ): Set[coursier.core.Dependency] = {
       val deps0 = deps
         .iterator
         .map(implicitly[CoursierModule.Resolvable[T]].bind(_, bind))
@@ -316,7 +316,7 @@ object CoursierModule {
         boms = Nil
       ).get
 
-      res.orderedDependencies
+      res.minDependencies
     }
 
     def getArtifacts[T: CoursierModule.Resolvable](


### PR DESCRIPTION
We have a plugin that was doing:
```scala
  defaultResolver()
    .allDeps(dependencies)
    .find(_.module.name.value == "flink-core")
    .getOrElse(
      throw new IllegalStateException("Dependency flink-core not found to determine the Flink version")
    )
```
And it's not working anymore. I noticed with `minDependencies` it works. I don't understand everything so maybe @alexarchambault can provide a review?