### PR TITLE
Remove dist/ from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ bsp.log
 lowered.hnir
 .dotty-ide*
 node_modules/
-dist/
 build/
 *.bak
 mill-assembly.jar


### PR DESCRIPTION
It seems some files used to be written there when running `./mill -i dist.installLocal` I think, but that's not the case anymore (unless I'm mistaken?). So there's no need to keep that entry there.

Having it there makes the global search of VSCode ignore that directory and its `package.mill` file, which can be a problem sometimes.