### PR TITLE
Update benchmarks for Mill 0.12.9-native

### DIFF
--- a/website/docs/modules/ROOT/pages/comparisons/gradle.adoc
+++ b/website/docs/modules/ROOT/pages/comparisons/gradle.adoc
@@ -62,18 +62,18 @@ configured similarly for both tools. This ensures the comparison is fair with bo
 same code and running the same tests in the same way.
 
 For the benchmarks below, each provided number is the median wall time of three consecutive runs
-on my M1 Macbook Pro. While ad-hoc, these benchmarks are enough to give you a flavor of how
-Mill's performance compares to Gradle:
+on my M1 Macbook Pro with Java 17 and Mill `0.12.9-native`. While ad-hoc, these benchmarks are
+enough to give you a flavor of how Mill's performance compares to Gradle:
 
 [cols="1,1,1,1"]
 |===
 | Benchmark | Gradle | Mill | Speedup
 
-| <<Sequential Clean Compile All>> | 17.6s | 5.40s | 3.3x
-| <<Parallel Clean Compile All>> | 12.3s | 3.57s | 3.4x
-| <<Clean Compile Single-Module>> | 4.41s | 1.20s | 3.7x
-| <<Incremental Compile Single-Module>> | 1.37s | 0.51s | 2.7x
-| <<No-Op Compile Single-Module>> | 0.94s | 0.46s | 2.0x
+| <<Sequential Clean Compile All>> | 17.6s | 5.86s | 3.0x
+| <<Parallel Clean Compile All>> | 12.3s | 3.75s | 3.3x
+| <<Clean Compile Single-Module>> | 4.41s | 1.30s | 3.4x
+| <<Incremental Compile Single-Module>> | 1.37s | 0.20s | 6.9x
+| <<No-Op Compile Single-Module>> | 0.94s | 0.11s | 8.5x
 |===
 
 The column on the right shows the speedups of how much faster Mill is compared to the
@@ -90,9 +90,9 @@ $ ./gradlew clean; time ./gradlew classes testClasses --no-build-cache
 17.4s
 
 $ ./mill clean; time ./mill -j 1 __.compile
-5.60s
-5.40s
-6.13s
+6.19s
+5.86s
+5.28s
 ```
 
 This benchmark measures the time taken to sequentially compiled all the Java code in
@@ -132,9 +132,9 @@ $ ./gradlew clean; time ./gradlew classes testClasses --no-build-cache
 11.4s
 
 $ ./mill clean; time ./mill __.compile
-3.59s
-3.57s
-3.45s
+3.75s
+3.74s
+3.86s
 ----
 
 This benchmark is identical to the <<Sequential Clean Compile All>> benchmark above, but enables
@@ -159,9 +159,9 @@ $ ./gradlew clean; time ./gradlew :classes --no-build-cache
 4.41s
 
 $ ./mill clean; time ./mill compile
-1.20s
-1.12s
 1.30s
+1.90s
+1.13s
 ----
 
 This benchmark indicates the use case of clean-compiling a single module. In this case,
@@ -183,9 +183,9 @@ $ echo "" >> src/main/java/org/mockito/BDDMockito.java; time ./gradlew :classes
 
 $ echo "" >> src/main/java/org/mockito/BDDMockito.java; time ./mill compile
 compiling 1 Java source to /Users/lihaoyi/Github/netty/out/common/compile.dest/classes ...
-0.52s
-0.51s
-0.52s
+0.23s
+0.20s
+0.20s
 ----
 
 This benchmark measures the common case of making a tiny change to a single file and
@@ -207,10 +207,10 @@ $ time ./gradlew :classes
 0.93s
 0.94s
 
-$ time ./mill common.compile
-0.46s
-0.50s
-0.45s
+$ time ./mill compile
+0.13s
+0.11s
+0.10s
 ----
 
 This benchmark is meant to measure the pure overhead of running the build tool: given a single

--- a/website/docs/modules/ROOT/pages/comparisons/maven.adoc
+++ b/website/docs/modules/ROOT/pages/comparisons/maven.adoc
@@ -67,19 +67,19 @@ The Mill build for Netty is much more performant than the default Maven build. T
 most workflows.
 
 For the benchmarks below, each provided number is the wall time of three consecutive runs
-on my M1 Macbook Pro. While ad-hoc, these benchmarks are enough to give you a flavor of how
-Mill's performance compares to Maven:
+on my M1 Macbook Pro using Java 17 and Mill `0.12.9-native`. While ad-hoc, these benchmarks
+are enough to give you a flavor of how Mill's performance compares to Maven:
 
 [cols="1,1,1,1"]
 |===
 | Benchmark | Maven | Mill | Speedup
 
 
-| <<Sequential Clean Compile All>> | 98.80s | 23.14s | 4.3x
-| <<Parallel Clean Compile All>> | 48.92s | 8.79s | 5.6x
-| <<Clean Compile Single-Module>> | 4.89s | 1.11s | 4.4x
-| <<Incremental Compile Single-Module>> | 6.82s | 0.54s | 12.6x
-| <<No-Op Compile Single-Module>> | 5.25s | 0.47s  | 11.2x
+| <<Sequential Clean Compile All>> | 98.80s | 23.41s | 4.2x
+| <<Parallel Clean Compile All>> | 48.92s | 9.29s | 5.3x
+| <<Clean Compile Single-Module>> | 4.89s | 0.88s | 5.6x
+| <<Incremental Compile Single-Module>> | 6.82s | 0.18s | 37.9x
+| <<No-Op Compile Single-Module>> | 5.25s | 0.12s  | 43.8x
 |===
 
 The column on the right shows the speedups of how much faster Mill is compared to the
@@ -98,9 +98,9 @@ $ ./mvnw clean; time ./mvnw -Pfast  -Dcheckstyle.skip -Denforcer.skip=true -Dski
 99.95s
 
 $ ./mill clean; time ./mill -j1 __.compile
-23.99s
-23.14s
-22.68s
+22.83s
+23.41s
+23.47s
 ----
 
 This benchmark exercises the simple "build everything from scratch" workflow, with all remote
@@ -143,15 +143,15 @@ In contrast, Mill builds do not rely on the local artifact cache, even though Mi
 to publish to it. That means Mill builds are able to work directly with classfiles on disk,
 simply referencing them and using them as-is without spending time packing and unpacking them
 into `.jar` files. Furthermore, even if we _did_ want Mill to generate the ``.jar``s, the
-overhead of doing so is just a few seconds, far less than the two entire minutes that
+overhead of doing so is just a few seconds, far less than the minutes that
 Maven's overhead adds to the clean build:
 
 [source,bash]
 ----
 $ ./mill clean; time ./mill -j1 __.jar
-32.58s
-24.90s
-23.35s
+26.74s
+26.02s
+26.53s
 ----
 
 From this benchmark, we can see that although both Mill and Maven are doing the same work,
@@ -171,9 +171,9 @@ $ ./mvnw clean; time ./mvnw -T 10 -Pfast -DskipTests  -Dcheckstyle.skip -Denforc
 49.50s
 
 $ ./mill clean; time ./mill __.compile
-9.07s
-8.79s
-7.93s
+10.95s
+8.51s
+9.29s
 ----
 
 This example compares Maven v.s. Mill, when performing the clean build on 10 threads.
@@ -196,9 +196,9 @@ $ ./mvnw clean; time ./mvnw -pl common -Pfast -DskipTests  -Dcheckstyle.skip -De
 4.89s
 
 $ ./mill clean common; time ./mill common.compile
-1.10s
-1.12s
-1.11s
+0.88s
+0.97s
+0.73s
 ----
 
 This exercise limits the comparison to compiling a single module, in this case `common/`,
@@ -229,9 +229,9 @@ $ echo "" >> common/src/main/java/io/netty/util/AbstractConstant.java
 $ time ./mill common.test.compile
 compiling 1 Java source to /Users/lihaoyi/Github/netty/out/common/compile.dest/classes ...
 
-0.78s
-0.54s
-0.51s
+0.18s
+0.18s
+0.21s
 ----
 
 This benchmark explores editing a single file and re-compiling `common/`.
@@ -329,9 +329,9 @@ $ time ./mvnw -pl common -Pfast -DskipTests  -Dcheckstyle.skip -Denforcer.skip=t
 5.26s
 
 $ time ./mill common.test.compile
-0.49s
-0.47s
-0.45s
+0.14s
+0.12s
+0.12s
 ----
 
 This last benchmark explores the boundaries of Maven and Mill: what happens if


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/4030

I left the Maven/Gradle numbers unchanged since I'm running on the same code/OS/hardware/JVM, and just updated the Mill numbers to use the newest version. Mostly unchanged for larger builds, though smaller builds benefit a lot from the new `-native` launcher