### PR TITLE
Clean up main method discovery logic

### DIFF
--- a/scalalib/api/src/mill/scalalib/api/ZincWorkerApi.scala
+++ b/scalalib/api/src/mill/scalalib/api/ZincWorkerApi.scala
@@ -51,8 +51,5 @@ trait ZincWorkerApi {
   /**
    * Discover main classes by inspecting the classpath.
    */
-  def discoverMainClasses(classpath: Seq[os.Path]): Seq[String] = {
-    // We need this default-impl to keep binary compatibility (0.11.x)
-    Seq.empty
-  }
+  def discoverMainClasses(classpath: Seq[os.Path]): Seq[String]
 }

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -99,40 +99,7 @@ trait JavaModule
     Artifact.fromDepJava(_: Dep)
   }
 
-  /**
-   * Allows you to specify an explicit main class to use for the `run` command.
-   * If none is specified, the classpath is searched for an appropriate main
-   * class to use if one exists
-   */
-  def mainClass: T[Option[String]] = None
-
-  def finalMainClassOpt: T[Either[String, String]] = Task {
-    mainClass() match {
-      case Some(m) => Right(m)
-      case None =>
-        if (zincWorker().javaHome().isDefined) {
-          super[RunModule].finalMainClassOpt()
-        } else {
-          zincWorker().worker().discoverMainClasses(compile()) match {
-            case Seq() => Left("No main class specified or found")
-            case Seq(main) => Right(main)
-            case mains =>
-              Left(
-                s"Multiple main classes found (${mains.mkString(",")}) " +
-                  "please explicitly specify which one to use by overriding `mainClass` " +
-                  "or using `runMain <main-class> <...args>` instead of `run`"
-              )
-          }
-        }
-    }
-  }
-
-  def finalMainClass: T[String] = Task {
-    finalMainClassOpt() match {
-      case Right(main) => Result.Success(main)
-      case Left(msg) => Result.Failure(msg)
-    }
-  }
+  def allLocalMainClasses = Task{ zincWorker().worker().discoverMainClasses(compile()) }
 
   /**
    * Mandatory ivy dependencies that are typically always required and shouldn't be removed by

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -99,7 +99,7 @@ trait JavaModule
     Artifact.fromDepJava(_: Dep)
   }
 
-  def allLocalMainClasses = Task{ zincWorker().worker().discoverMainClasses(compile()) }
+  def allLocalMainClasses = Task { zincWorker().worker().discoverMainClasses(compile()) }
 
   /**
    * Mandatory ivy dependencies that are typically always required and shouldn't be removed by

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -99,7 +99,7 @@ trait JavaModule
     Artifact.fromDepJava(_: Dep)
   }
 
-  def allLocalMainClasses = Task { zincWorker().worker().discoverMainClasses(compile()) }
+  def allLocalMainClasses0 = Task { zincWorker().worker().discoverMainClasses(compile()) }
 
   /**
    * Mandatory ivy dependencies that are typically always required and shouldn't be removed by

--- a/scalalib/src/mill/scalalib/RunModule.scala
+++ b/scalalib/src/mill/scalalib/RunModule.scala
@@ -45,22 +45,7 @@ trait RunModule extends WithZincWorker {
    */
   def mainClass: T[Option[String]] = None
 
-  def allLocalMainClasses: T[Seq[String]] = Task {
-    val classpath = localRunClasspath().map(_.path)
-    if (zincWorker().javaHome().isDefined) {
-      Jvm.callProcess(
-        mainClass = "mill.scalalib.worker.DiscoverMainClassesMain",
-        classPath = zincWorker().classpath().map(_.path).toVector,
-        mainArgs = Seq(classpath.mkString(",")),
-        javaHome = zincWorker().javaHome().map(_.path),
-        stdin = os.Inherit,
-        stdout = os.Pipe,
-        cwd = Task.dest
-      ).out.lines()
-    } else {
-      zincWorker().worker().discoverMainClasses(classpath)
-    }
-  }
+  def allLocalMainClasses: T[Seq[String]] = Seq.empty[String]
 
   def finalMainClassOpt: T[Either[String, String]] = Task {
     mainClass() match {
@@ -72,7 +57,8 @@ trait RunModule extends WithZincWorker {
           case mains =>
             Left(
               s"Multiple main classes found (${mains.mkString(",")}) " +
-                "please explicitly specify which one to use by overriding mainClass"
+                "please explicitly specify which one to use by overriding `mainClass` " +
+                "or using `runMain <main-class> <...args>` instead of `run`"
             )
         }
     }

--- a/scalalib/src/mill/scalalib/RunModule.scala
+++ b/scalalib/src/mill/scalalib/RunModule.scala
@@ -46,20 +46,7 @@ trait RunModule extends WithZincWorker {
   def mainClass: T[Option[String]] = None
 
   def allLocalMainClasses: T[Seq[String]] = Task {
-    val classpath = localRunClasspath().map(_.path)
-    if (zincWorker().javaHome().isDefined) {
-      Jvm.callProcess(
-        mainClass = "mill.scalalib.worker.DiscoverMainClassesMain",
-        classPath = zincWorker().classpath().map(_.path).toVector,
-        mainArgs = Seq(classpath.mkString(",")),
-        javaHome = zincWorker().javaHome().map(_.path),
-        stdin = os.Inherit,
-        stdout = os.Pipe,
-        cwd = Task.dest
-      ).out.lines()
-    } else {
-      zincWorker().worker().discoverMainClasses(classpath)
-    }
+    zincWorker().worker().discoverMainClasses(localRunClasspath().map(_.path))
   }
 
   def finalMainClassOpt: T[Either[String, String]] = Task {


### PR DESCRIPTION
This PR removes the task definitions from `JavaModule` that have already been moved into `RunModule`, encapsulating the difference between `JavaModule` and other `RunModule`s that do not use Zinc (e.g. `KotlinModule`) in the `def allLocalMainClasses` task.

This should be semantically identical as before, just with a bit less indirection