### PR TITLE
Fix potential ArrayIndexOutOfBoundsException (backports #4769)

### DIFF
--- a/main/util/src/mill/util/LinePrefixOutputStream.scala
+++ b/main/util/src/mill/util/LinePrefixOutputStream.scala
@@ -42,7 +42,7 @@ class LinePrefixOutputStream(
       val bufferString = buffer.toString
       if (bufferString.length > 0) {
         val s = fansi.Str.apply(bufferString, errorMode = fansi.ErrorMode.Sanitize)
-        endOfLastLineColor = s.getColor(s.length - 1)
+        endOfLastLineColor = s.getColor(math.max(0, s.length - 1))
       }
     }
     out.synchronized { buffer.writeTo(out) }


### PR DESCRIPTION
Fix https://github.com/com-lihaoyi/mill/issues/4768

Ensure we don't use a negative index in case a string is empty.

Original Pull request: https://github.com/com-lihaoyi/mill/pull/4769

