### PR TITLE
Add Kotlin support for BuildInfo module (backport #4771)

### DIFF
--- a/contrib/buildinfo/readme.adoc
+++ b/contrib/buildinfo/readme.adoc
@@ -1,21 +1,22 @@
 = BuildInfo
 :page-aliases: Plugin_BuildInfo.adoc
 
-Generate scala code from your buildfile.
+Generate source code from your buildfile.
 This plugin generates a single object containing information from your build.
+It supports `Java`, `Scala` and `Kotlin` as a target language.
 
 To declare a module that uses BuildInfo you must extend the `mill.contrib.buildinfo.BuildInfo` trait when defining your module.
 
 Quickstart:
 
-.`build.mill`
+.Example `build.mill` defining a Scala module with `BuildInfo`
 [source,scala]
 ----
 package build
 import $ivy.`com.lihaoyi::mill-contrib-buildinfo:`
 import mill.contrib.buildinfo.BuildInfo
 
-object project extends BuildInfo with ScalaModule {
+object project extends ScalaModule with BuildInfo {
   val name = "project-name"
   val buildInfoPackageName = "com.organization"
   def buildInfoMembers = Seq(
@@ -37,15 +38,28 @@ def main = {
 }
 ----
 
-The above example uses `ScalaModule` but `BuildInfo` can also be used with `JavaModule`s
+The above example uses `ScalaModule` but `BuildInfo` can also be used with ``JavaModule``s or ``KotlinModule``s.
+
 
 == Configuration options
 
-* `def buildInfoMembers: T[Seq[BuildInfo.Value]]`
+`def buildInfoMembers: T[Seq[BuildInfo.Value]]`::
 The map containing all member names and values for the generated info object.
 
-* `def buildInfoObjectName: String`, default: `BuildInfo`
-The name of the object which contains all the members from `buildInfoMembers`.
+`def buildInfoObjectName: String = "BuildInfo`::
+The name of the BuildInfo data object which contains all the members from `buildInfoMembers`. Defaults to "BuildInfo".
 
-* `def buildInfoPackageName: String`
-The package name of the object.
+`def buildInfoPackageName: String`::
+The package name under which the BuildInfo data object will be stored.
+
+`def buildInfoStaticCompiled`::
+Enable to compile the BuildInfo values directly into the classfiles,
+rather than the default behavior of storing them as a JVM resource.
+Needed to use BuildInfo on Scala.js and Scala Native which does not support JVM resources.
+But can also be enabled on all platforms if wanted.
+
+`def buildInfoLanguage: BuildInfoLanguage`::
+The source language to use for the generated source file(s).
+One of `Java`, `Scala` or `Kotlin`.
+The default is derived from the used module.
+

--- a/contrib/buildinfo/src/mill/contrib/buildinfo/BuildInfo.scala
+++ b/contrib/buildinfo/src/mill/contrib/buildinfo/BuildInfo.scala
@@ -100,7 +100,7 @@ trait BuildInfo extends JavaModule {
 }
 
 object BuildInfo {
-  sealed case class Language(ext: String)
+  sealed abstract class Language(val ext: String)
   object Language {
     case object Java extends Language("java")
     case object Scala extends Language("scala")

--- a/contrib/buildinfo/src/mill/contrib/buildinfo/BuildInfo.scala
+++ b/contrib/buildinfo/src/mill/contrib/buildinfo/BuildInfo.scala
@@ -100,10 +100,11 @@ trait BuildInfo extends JavaModule {
 }
 
 object BuildInfo {
-  enum Language(val ext: String) {
-    case Java extends Language("java")
-    case Scala extends Language("scala")
-    case Kotlin extends Language("kt")
+  sealed case class Language(ext: String)
+  object Language {
+    case object Java extends Language("java")
+    case object Scala extends Language("scala")
+    case object Kotlin extends Language("kt")
   }
 
   case class Value(key: String, value: String, comment: String = "")

--- a/contrib/buildinfo/src/mill/contrib/buildinfo/BuildInfo.scala
+++ b/contrib/buildinfo/src/mill/contrib/buildinfo/BuildInfo.scala
@@ -2,6 +2,7 @@ package mill.contrib.buildinfo
 
 import mill.{T, Task}
 import mill.api.PathRef
+import mill.kotlinlib.KotlinModule
 import mill.scalalib.{JavaModule, ScalaModule}
 import mill.scalanativelib.ScalaNativeModule
 import mill.scalajslib.ScalaJSModule
@@ -9,7 +10,8 @@ import mill.scalajslib.ScalaJSModule
 trait BuildInfo extends JavaModule {
 
   /**
-   * The package name under which the BuildInfo data object will be stored.
+   * The name of the BuildInfo data object which contains all the members
+   * from [[buildInfoMembers]]. Defaults to "BuildInfo"
    */
   def buildInfoPackageName: String
 
@@ -27,6 +29,15 @@ trait BuildInfo extends JavaModule {
     case _: ScalaJSModule => true
     case _: ScalaNativeModule => true
     case _ => false
+  }
+
+  /**
+   * The source language to use for the generated source file(s).
+   */
+  def buildInfoLanguage: BuildInfo.Language = this match {
+    case _: ScalaModule => BuildInfo.Language.Scala
+    case _: KotlinModule => BuildInfo.Language.Kotlin
+    case _ => BuildInfo.Language.Java
   }
 
   /**
@@ -57,8 +68,6 @@ trait BuildInfo extends JavaModule {
     PathRef(Task.dest)
   }
 
-  private def isScala = this.isInstanceOf[ScalaModule]
-
   override def generatedSources = Task {
     super.generatedSources() ++ buildInfoSources()
   }
@@ -68,21 +77,20 @@ trait BuildInfo extends JavaModule {
     else {
       val code = if (buildInfoStaticCompiled) BuildInfo.staticCompiledCodegen(
         buildInfoMembers(),
-        isScala,
+        buildInfoLanguage,
         buildInfoPackageName,
         buildInfoObjectName
       )
       else BuildInfo.codegen(
         buildInfoMembers(),
-        isScala,
+        buildInfoLanguage,
         buildInfoPackageName,
         buildInfoObjectName
       )
 
-      val ext = if (isScala) "scala" else "java"
-
       os.write(
-        Task.dest / buildInfoPackageName.split('.') / s"${buildInfoObjectName}.$ext",
+        Task.dest / buildInfoPackageName.split('.') /
+          s"${buildInfoObjectName}.${buildInfoLanguage.ext}",
         code,
         createFolders = true
       )
@@ -92,66 +100,94 @@ trait BuildInfo extends JavaModule {
 }
 
 object BuildInfo {
+  enum Language(val ext: String) {
+    case Java extends Language("java")
+    case Scala extends Language("scala")
+    case Kotlin extends Language("kt")
+  }
+
   case class Value(key: String, value: String, comment: String = "")
   object Value {
     implicit val rw: upickle.default.ReadWriter[Value] = upickle.default.macroRW
   }
   def staticCompiledCodegen(
       buildInfoMembers: Seq[Value],
-      isScala: Boolean,
+      language: Language,
       buildInfoPackageName: String,
       buildInfoObjectName: String
   ): String = {
+
     val bindingsCode = buildInfoMembers
       .sortBy(_.key)
       .map {
         case v =>
-          if (isScala) s"""${commentStr(v)}val ${v.key} = ${pprint.Util.literalize(v.value)}"""
-          else s"""${commentStr(
-              v
-            )}public static java.lang.String ${v.key} = ${pprint.Util.literalize(v.value)};"""
+          language match {
+            case Language.Scala | Language.Kotlin =>
+              s"""${commentStr(v)}val ${v.key}: String = ${pprint.Util.literalize(v.value)}"""
+            case Language.Java => s"""${commentStr(
+                  v
+                )}public static java.lang.String ${v.key} = ${pprint.Util.literalize(v.value)};"""
+          }
       }
       .mkString("\n\n  ")
 
-    if (isScala) {
-      val mapEntries = buildInfoMembers
-        .map { case v => s""""${v.key}" -> ${v.key}""" }
-        .mkString(",\n")
+    language match {
+      case Language.Scala =>
+        val mapEntries = buildInfoMembers
+          .map { case v => s""""${v.key}" -> ${v.key}""" }
+          .mkString(",\n")
 
-      s"""
-         |package $buildInfoPackageName
-         |
-         |object $buildInfoObjectName {
-         |  $bindingsCode
-         |  val toMap = Map[String, String](
-         |    $mapEntries
-         |  )
-         |}
+        s"""
+           |package $buildInfoPackageName
+           |
+           |object $buildInfoObjectName {
+           |  $bindingsCode
+           |  val toMap = Map[String, String](
+           |    $mapEntries
+           |  )
+           |}
       """.stripMargin.trim
-    } else {
-      val mapEntries = buildInfoMembers
-        .map { case v => s"""map.put("${v.key}", ${v.key});""" }
-        .mkString(",\n")
 
-      s"""
-         |package $buildInfoPackageName;
-         |
-         |public class $buildInfoObjectName {
-         |  $bindingsCode
-         |
-         |  public static java.util.Map<java.lang.String, java.lang.String> toMap() {
-         |    java.util.Map<java.lang.String, java.lang.String> map = new java.util.HashMap<java.lang.String, java.lang.String>();
-         |    $mapEntries
-         |    return map;
-         |  }
-         |}
+      case Language.Kotlin =>
+        val mapEntries = buildInfoMembers
+          .map { case v => s""""${v.key}" to ${v.key}""" }
+          .mkString(",\n")
+
+        s"""
+           |package $buildInfoPackageName
+           |
+           |object $buildInfoObjectName {
+           |  $bindingsCode
+           |  val toMap: Map<String, String> = mapOf(
+           |    $mapEntries
+           |  )
+           |}
+      """.stripMargin.trim
+
+      case Language.Java =>
+        val mapEntries = buildInfoMembers
+          .map { case v => s"""map.put("${v.key}", ${v.key});""" }
+          .mkString(",\n")
+
+        s"""
+           |package $buildInfoPackageName;
+           |
+           |public class $buildInfoObjectName {
+           |  $bindingsCode
+           |
+           |  public static java.util.Map<java.lang.String, java.lang.String> toMap() {
+           |    java.util.Map<java.lang.String, java.lang.String> map = new java.util.HashMap<java.lang.String, java.lang.String>();
+           |    $mapEntries
+           |    return map;
+           |  }
+           |}
       """.stripMargin.trim
     }
   }
 
   def codegen(
       buildInfoMembers: Seq[Value],
-      isScala: Boolean,
+      language: Language,
       buildInfoPackageName: String,
       buildInfoObjectName: String
   ): String = {
@@ -159,66 +195,94 @@ object BuildInfo {
       .sortBy(_.key)
       .map {
         case v =>
-          if (isScala)
-            s"""${commentStr(v)}val ${v.key} = buildInfoProperties.getProperty("${v.key}")"""
-          else {
-            val propValue = s"""buildInfoProperties.getProperty("${v.key}")"""
-            s"""${commentStr(v)}public static final java.lang.String ${v.key} = $propValue;"""
+          language match {
+            case Language.Scala | Language.Kotlin =>
+              s"""${commentStr(v)}val ${v.key} = buildInfoProperties.getProperty("${v.key}")"""
+            case Language.Java =>
+              val propValue = s"""buildInfoProperties.getProperty("${v.key}")"""
+              s"""${commentStr(v)}public static final java.lang.String ${v.key} = $propValue;"""
           }
       }
       .mkString("\n\n  ")
 
-    if (isScala)
-      s"""
-         |package ${buildInfoPackageName}
-         |
-         |object $buildInfoObjectName {
-         |  private val buildInfoProperties: java.util.Properties = new java.util.Properties()
-         |
-         |  {
-         |    val buildInfoInputStream = getClass
-         |      .getResourceAsStream("${buildInfoObjectName}.buildinfo.properties")
-         |
-         |    if(buildInfoInputStream == null)
-         |      throw new RuntimeException("Could not load resource ${buildInfoObjectName}.buildinfo.properties")
-         |    else try {
-         |      buildInfoProperties.load(buildInfoInputStream)
-         |    } finally {
-         |      buildInfoInputStream.close()
-         |    }
-         |  }
-         |
-         |  $bindingsCode
-         |}
+    language match {
+      case Language.Scala =>
+        s"""
+           |package ${buildInfoPackageName}
+           |
+           |object $buildInfoObjectName {
+           |  private val buildInfoProperties: java.util.Properties = new java.util.Properties()
+           |
+           |  {
+           |    val buildInfoInputStream = getClass
+           |      .getResourceAsStream("${buildInfoObjectName}.buildinfo.properties")
+           |
+           |    if(buildInfoInputStream == null)
+           |      throw new RuntimeException("Could not load resource ${buildInfoObjectName}.buildinfo.properties")
+           |    else try {
+           |      buildInfoProperties.load(buildInfoInputStream)
+           |    } finally {
+           |      buildInfoInputStream.close()
+           |    }
+           |  }
+           |
+           |  $bindingsCode
+           |}
       """.stripMargin.trim
-    else
-      s"""
-         |package ${buildInfoPackageName};
-         |
-         |public class $buildInfoObjectName {
-         |  private static final java.util.Properties buildInfoProperties = new java.util.Properties();
-         |
-         |  static {
-         |    java.io.InputStream buildInfoInputStream = ${buildInfoObjectName}
-         |      .class
-         |      .getResourceAsStream("${buildInfoObjectName}.buildinfo.properties");
-         |
-         |    try {
-         |      buildInfoProperties.load(buildInfoInputStream);
-         |    } catch (java.io.IOException e) {
-         |      throw new RuntimeException(e);
-         |    } finally {
-         |      try {
-         |        buildInfoInputStream.close();
-         |      } catch (java.io.IOException e) {
-         |        throw new RuntimeException(e);
-         |      }
-         |    }
-         |  }
-         |
-         |  $bindingsCode
-         |}
+
+      case Language.Kotlin =>
+        s"""
+           |package ${buildInfoPackageName}
+           |
+           |object $buildInfoObjectName {
+           |  private val buildInfoProperties: java.util.Properties = java.util.Properties()
+           |
+           |  init {
+           |    val buildInfoInputStream = ${buildInfoObjectName}::class.java
+           |      .getResourceAsStream("${buildInfoObjectName}.buildinfo.properties")
+           |
+           |    if(buildInfoInputStream == null)
+           |      throw RuntimeException("Could not load resource ${buildInfoObjectName}.buildinfo.properties")
+           |    else try {
+           |      buildInfoProperties.load(buildInfoInputStream)
+           |    } finally {
+           |      buildInfoInputStream.close()
+           |    }
+           |  }
+           |
+           |  $bindingsCode
+           |}
       """.stripMargin.trim
+
+      case Language.Java =>
+        s"""
+           |package ${buildInfoPackageName};
+           |
+           |public class $buildInfoObjectName {
+           |  private static final java.util.Properties buildInfoProperties = new java.util.Properties();
+           |
+           |  static {
+           |    java.io.InputStream buildInfoInputStream = ${buildInfoObjectName}
+           |      .class
+           |      .getResourceAsStream("${buildInfoObjectName}.buildinfo.properties");
+           |
+           |    try {
+           |      buildInfoProperties.load(buildInfoInputStream);
+           |    } catch (java.io.IOException e) {
+           |      throw new RuntimeException(e);
+           |    } finally {
+           |      try {
+           |        buildInfoInputStream.close();
+           |      } catch (java.io.IOException e) {
+           |        throw new RuntimeException(e);
+           |      }
+           |    }
+           |  }
+           |
+           |  $bindingsCode
+           |}
+      """.stripMargin.trim
+    }
   }
 
   def commentStr(v: Value): String = {

--- a/contrib/buildinfo/test/resources/buildinfo/kotlin/src/Main.kt
+++ b/contrib/buildinfo/test/resources/buildinfo/kotlin/src/Main.kt
@@ -1,0 +1,13 @@
+package foo
+
+import java.nio.file.Files
+import java.nio.file.Paths
+
+object Main {
+    @kotlin.jvm.JvmStatic
+    fun main(args: Array<String>) {
+        val resultPath = Paths.get(args[0])
+        Files.createDirectories(resultPath.parent)
+        Files.write(resultPath, BuildInfo.scalaVersion.encodeToByteArray())
+    }
+}

--- a/contrib/buildinfo/test/src/mill/contrib/buildinfo/BuildInfoTests.scala
+++ b/contrib/buildinfo/test/src/mill/contrib/buildinfo/BuildInfoTests.scala
@@ -1,17 +1,20 @@
 package mill.contrib.buildinfo
 
-import mill._
+import mill.*
+import mill.contrib.buildinfo.BuildInfoTests.BuildInfoSettings.scalaVersion
+import mill.kotlinlib.KotlinModule
 import mill.scalalib.ScalaModule
 import mill.scalajslib.ScalaJSModule
 import mill.testkit.UnitTester
 import mill.testkit.TestBaseModule
 import os.Path
-import utest._
+import utest.*
 
 object BuildInfoTests extends TestSuite {
 
   val scalaVersionString = sys.props.getOrElse("TEST_SCALA_2_12_VERSION", ???)
   val scalaJSVersionString = sys.props.getOrElse("TEST_SCALAJS_VERSION", ???)
+  val kotlinVersionString = sys.props.getOrElse("TEST_KOTLIN_VERSION", ???)
 
   object EmptyBuildInfo extends TestBaseModule with BuildInfo with ScalaModule {
     def scalaVersion = scalaVersionString
@@ -84,6 +87,31 @@ object BuildInfoTests extends TestSuite {
     def buildInfoMembers = Seq(
       BuildInfo.Value("scalaVersion", "not-provided-for-java-modules")
     )
+  }
+
+  object BuildInfoKotlin extends TestBaseModule with KotlinModule with BuildInfo {
+    def kotlinVersion = kotlinVersionString
+    // FIXME: the mainClass should be found automatically
+    def mainClass = Some("foo.Main")
+    def buildInfoPackageName = "foo"
+    def buildInfoMembers = Seq(
+      BuildInfo.Value("scalaVersion", scalaVersion())
+    )
+
+    lazy val millDiscover = Discover[this.type]
+  }
+
+  object BuildInfoKotlinStatic extends TestBaseModule with KotlinModule with BuildInfo {
+    def kotlinVersion = kotlinVersionString
+    // FIXME: the mainClass should be found automatically
+    def mainClass = Some("foo.Main")
+    def buildInfoPackageName = "foo"
+    override def buildInfoStaticCompiled = true
+    def buildInfoMembers = Seq(
+      BuildInfo.Value("scalaVersion", scalaVersion())
+    )
+
+    lazy val millDiscover = Discover[this.type]
   }
 
   val testModuleSourcesPath: Path = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "buildinfo"
@@ -208,6 +236,33 @@ object BuildInfoTests extends TestSuite {
           os.exists(runResult),
           os.exists(generatedSrc),
           os.read(runResult) == "not-provided-for-java-modules"
+        )
+    }
+
+    test("kotlin") - UnitTester(BuildInfoKotlin, testModuleSourcesPath / "kotlin").scoped { eval =>
+      val runResult = eval.outPath / "hello-mill"
+      val Right(_) =
+        eval.apply(BuildInfoKotlin.run(Task.Anon(Args(runResult.toString)))): @unchecked
+
+      assert(
+        os.exists(runResult),
+        os.read(runResult) == scalaVersionString
+      )
+    }
+    test("kotlin-static") - UnitTester(
+      BuildInfoKotlinStatic,
+      testModuleSourcesPath / "kotlin"
+    ).scoped {
+      eval =>
+        val runResult = eval.outPath / "hello-mill"
+        val generatedSrc = eval.outPath / "buildInfoSources.dest/foo/BuildInfo.kt"
+        val Right(_) =
+          eval.apply(BuildInfoKotlinStatic.run(Task.Anon(Args(runResult.toString)))): @unchecked
+
+        assert(
+          os.exists(runResult),
+          os.exists(generatedSrc),
+          os.read(runResult) == scalaVersionString
         )
     }
 

--- a/contrib/buildinfo/test/src/mill/contrib/buildinfo/BuildInfoTests.scala
+++ b/contrib/buildinfo/test/src/mill/contrib/buildinfo/BuildInfoTests.scala
@@ -1,7 +1,6 @@
 package mill.contrib.buildinfo
 
 import mill.*
-import mill.contrib.buildinfo.BuildInfoTests.BuildInfoSettings.scalaVersion
 import mill.kotlinlib.KotlinModule
 import mill.scalalib.ScalaModule
 import mill.scalajslib.ScalaJSModule
@@ -95,10 +94,8 @@ object BuildInfoTests extends TestSuite {
     def mainClass = Some("foo.Main")
     def buildInfoPackageName = "foo"
     def buildInfoMembers = Seq(
-      BuildInfo.Value("scalaVersion", scalaVersion())
+      BuildInfo.Value("scalaVersion", scalaVersionString)
     )
-
-    lazy val millDiscover = Discover[this.type]
   }
 
   object BuildInfoKotlinStatic extends TestBaseModule with KotlinModule with BuildInfo {
@@ -108,10 +105,8 @@ object BuildInfoTests extends TestSuite {
     def buildInfoPackageName = "foo"
     override def buildInfoStaticCompiled = true
     def buildInfoMembers = Seq(
-      BuildInfo.Value("scalaVersion", scalaVersion())
+      BuildInfo.Value("scalaVersion", scalaVersionString)
     )
-
-    lazy val millDiscover = Discover[this.type]
   }
 
   val testModuleSourcesPath: Path = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "buildinfo"

--- a/contrib/package.mill
+++ b/contrib/package.mill
@@ -142,9 +142,15 @@ object `package` extends RootModule {
   }
 
   object buildinfo extends ContribModule {
-    def compileModuleDeps = Seq(build.scalalib, build.scalajslib, build.scalanativelib)
+    def compileModuleDeps =
+      Seq(build.scalalib, build.scalajslib, build.scalanativelib, build.kotlinlib)
     def testModuleDeps =
-      super.testModuleDeps ++ Seq(build.scalalib, build.scalajslib, build.scalanativelib)
+      super.testModuleDeps ++ Seq(
+        build.scalalib,
+        build.scalajslib,
+        build.scalanativelib,
+        build.kotlinlib
+      )
   }
 
   object proguard extends ContribModule {


### PR DESCRIPTION
Add support for Kotlin source file generator in `BuildInfo` module.

In addition to Java and Scala, `BuildInfo` now also supports a Kotlin
source generator.

The default generator is selected based on the module type, but can now
also be configured to a specific type. E.g. users of `ScalaModule` or
`KotlinModule` might want to generate a Java source file.

```scala
// Always generate a Java file
def buildInfoLanguage = BuildInfo.Language.Java
```

Or modules implementing `ScalaModule` and `KotlinModule` might want to
generate a Kotlin file instead of a Scala file.

Original pull request: https://github.com/com-lihaoyi/mill/pull/4771

