### PR TITLE
Prefer `defaultResolver().classpath` over `Lib.resolveDependencies` (backport #4727)

### DIFF
--- a/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -303,7 +303,7 @@ private class MillBuildServer(
         case m: JavaModule =>
           Task.Anon {
             (
-              m.millResolver().resolveDeps(
+              m.millResolver().classpath(
                 Seq(
                   m.coursierDependency.withConfiguration(coursier.core.Configuration.provided),
                   m.coursierDependency

--- a/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -346,12 +346,14 @@ private class MillBuildServer(
         Task.Anon {
           (
             // full list of dependencies, including transitive ones
-            m.millResolver().allDeps(
-              Seq(
-                m.coursierDependency.withConfiguration(coursier.core.Configuration.provided),
-                m.coursierDependency
+            m.millResolver()
+              .resolution(
+                Seq(
+                  m.coursierDependency.withConfiguration(coursier.core.Configuration.provided),
+                  m.coursierDependency
+                )
               )
-            ),
+              .orderedDependencies,
             m.unmanagedClasspath()
           )
         }

--- a/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
+++ b/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
@@ -402,7 +402,7 @@ class BloopImpl(
 
     val millBuildDependencies: Task[List[BloopConfig.Module]] = Task.Anon {
 
-      val result = module.defaultResolver().getArtifacts(
+      val result = module.defaultResolver().artifacts(
         BuildInfo.millEmbeddedDeps
           .split(',')
           .filter(_.nonEmpty)

--- a/contrib/flyway/src/mill/contrib/flyway/FlywayModule.scala
+++ b/contrib/flyway/src/mill/contrib/flyway/FlywayModule.scala
@@ -29,7 +29,7 @@ trait FlywayModule extends JavaModule {
   def flywayDriverDeps: T[Agg[Dep]]
 
   def jdbcClasspath = Task {
-    defaultResolver().resolveDeps(flywayDriverDeps())
+    defaultResolver().classpath(flywayDriverDeps())
   }
 
   private def strToOptPair[A](key: String, v: String) =

--- a/contrib/jmh/src/mill/contrib/jmh/JmhModule.scala
+++ b/contrib/jmh/src/mill/contrib/jmh/JmhModule.scala
@@ -104,7 +104,7 @@ trait JmhModule extends JavaModule {
     }
 
   def generatorDeps = Task {
-    defaultResolver().resolveDeps(
+    defaultResolver().classpath(
       Agg(ivy"org.openjdk.jmh:jmh-generator-bytecode:${jmhGeneratorByteCodeVersion()}")
     )
   }

--- a/contrib/playlib/src/mill/playlib/RouterModule.scala
+++ b/contrib/playlib/src/mill/playlib/RouterModule.scala
@@ -46,7 +46,7 @@ trait RouterModule extends ScalaModule with Version {
   def generatorType: RouteCompilerType = RouteCompilerType.InjectedGenerator
 
   def routerClasspath: T[Agg[PathRef]] = Task {
-    defaultResolver().resolveDeps(
+    defaultResolver().classpath(
       playMinorVersion() match {
         case "2.6" | "2.7" | "2.8" =>
           Agg(ivy"com.typesafe.play::routes-compiler:${playVersion()}")

--- a/contrib/playlib/src/mill/playlib/Static.scala
+++ b/contrib/playlib/src/mill/playlib/Static.scala
@@ -5,7 +5,7 @@ import java.nio.file._
 import java.nio.file.attribute.BasicFileAttributes
 import java.util
 
-import mill.scalalib.{Lib, ScalaModule}
+import mill.scalalib.ScalaModule
 import mill.{PathRef, Task}
 
 trait Static extends ScalaModule {
@@ -49,15 +49,13 @@ trait Static extends ScalaModule {
   def webJarDeps = Task {
     ivyDeps()
       .filter(_.dep.module.organization.value == "org.webjars")
-      .map(bindDependency())
   }
 
   /**
    * jar files of web jars
    */
   def webJars = Task {
-    Lib.resolveDependencies(
-      repositoriesTask(),
+    defaultResolver().resolveDeps(
       webJarDeps()
     )
   }

--- a/contrib/playlib/src/mill/playlib/Static.scala
+++ b/contrib/playlib/src/mill/playlib/Static.scala
@@ -55,7 +55,7 @@ trait Static extends ScalaModule {
    * jar files of web jars
    */
   def webJars = Task {
-    defaultResolver().resolveDeps(
+    defaultResolver().classpath(
       webJarDeps()
     )
   }

--- a/contrib/proguard/src/mill/contrib/proguard/Proguard.scala
+++ b/contrib/proguard/src/mill/contrib/proguard/Proguard.scala
@@ -130,7 +130,7 @@ trait Proguard extends ScalaModule {
    * These are downloaded from JCenter and fed to `java -cp`
    */
   def proguardClasspath: T[Loose.Agg[PathRef]] = Task {
-    defaultResolver().resolveDeps(
+    defaultResolver().classpath(
       Agg(ivy"com.guardsquare:proguard-base:${proguardVersion()}")
     )
   }

--- a/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBModule.scala
+++ b/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBModule.scala
@@ -3,7 +3,6 @@ package contrib.scalapblib
 
 import coursier.core.Version
 import mill.api.{IO, Loose, PathRef}
-import mill.scalalib.Lib.resolveDependencies
 import mill.scalalib._
 
 import java.util.zip.ZipInputStream
@@ -76,10 +75,11 @@ trait ScalaPBModule extends ScalaModule {
   }
 
   def scalaPBClasspath: T[Loose.Agg[PathRef]] = Task {
-    resolveDependencies(
-      repositoriesTask(),
+    val scalaPBScalaVersion = "2.13.1"
+    defaultResolver().resolveDeps(
       Seq(ivy"com.thesamet.scalapb::scalapbc:${scalaPBVersion()}")
-        .map(Lib.depToBoundDep(_, "2.13.1"))
+        .map(Lib.depToBoundDep(_, scalaPBScalaVersion)),
+      resolutionParamsMapOpt = Some(_.withScalaVersion(scalaPBScalaVersion))
     )
   }
 

--- a/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBModule.scala
+++ b/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBModule.scala
@@ -76,7 +76,7 @@ trait ScalaPBModule extends ScalaModule {
 
   def scalaPBClasspath: T[Loose.Agg[PathRef]] = Task {
     val scalaPBScalaVersion = "2.13.1"
-    defaultResolver().resolveDeps(
+    defaultResolver().classpath(
       Seq(ivy"com.thesamet.scalapb::scalapbc:${scalaPBVersion()}")
         .map(Lib.depToBoundDep(_, scalaPBScalaVersion)),
       resolutionParamsMapOpt = Some(_.withScalaVersion(scalaPBScalaVersion))
@@ -91,7 +91,7 @@ trait ScalaPBModule extends ScalaModule {
   }
 
   def scalaPBProtoClasspath: T[Agg[PathRef]] = Task {
-    millResolver().resolveDeps(
+    millResolver().classpath(
       Seq(
         coursierDependency.withConfiguration(coursier.core.Configuration.provided),
         coursierDependency

--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
@@ -113,11 +113,11 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
 
   def scoverageToolsClasspath: T[Agg[PathRef]] = Task {
     scoverageReportWorkerClasspath() ++
-      defaultResolver().resolveDeps(scoverageReporterIvyDeps())
+      defaultResolver().classpath(scoverageReporterIvyDeps())
   }
 
   def scoverageClasspath: T[Agg[PathRef]] = Task {
-    defaultResolver().resolveDeps(scoveragePluginDeps())
+    defaultResolver().classpath(scoveragePluginDeps())
   }
 
   def scoverageReportWorkerClasspath: T[Agg[PathRef]] = Task {
@@ -207,7 +207,7 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
       val outerScoverageClassesPath = outer.scoverage.compile().classes
       (super.runClasspath().map { path =>
         if (outerClassesPath == path) outerScoverageClassesPath else path
-      } ++ defaultResolver().resolveDeps(outer.scoverageRuntimeDeps())).distinct
+      } ++ defaultResolver().classpath(outer.scoverageRuntimeDeps())).distinct
     }
   }
 }

--- a/contrib/twirllib/src/mill/twirllib/TwirlModule.scala
+++ b/contrib/twirllib/src/mill/twirllib/TwirlModule.scala
@@ -73,7 +73,7 @@ trait TwirlModule extends mill.Module { twirlModule =>
   lazy val twirlCoursierResolver: TwirlResolver = new TwirlResolver {}
 
   def twirlClasspath: T[Loose.Agg[PathRef]] = Task {
-    twirlCoursierResolver.defaultResolver().resolveDeps(twirlIvyDeps())
+    twirlCoursierResolver.defaultResolver().classpath(twirlIvyDeps())
   }
 
   def twirlImports: T[Seq[String]] = Task {

--- a/example/extending/jvmcode/1-subprocess/build.mill
+++ b/example/extending/jvmcode/1-subprocess/build.mill
@@ -19,7 +19,7 @@ import mill.util.Jvm
 
 object foo extends JavaModule {
   def groovyClasspath: Task[Agg[PathRef]] = Task {
-    defaultResolver().resolveDeps(Agg(ivy"org.codehaus.groovy:groovy:3.0.9"))
+    defaultResolver().classpath(Agg(ivy"org.codehaus.groovy:groovy:3.0.9"))
   }
 
   def groovyScript = Task.Source("generate.groovy")

--- a/example/extending/jvmcode/2-classloader/build.mill
+++ b/example/extending/jvmcode/2-classloader/build.mill
@@ -11,7 +11,7 @@ import mill.util.Jvm
 
 object foo extends JavaModule {
   def groovyClasspath: Task[Agg[PathRef]] = Task {
-    defaultResolver().resolveDeps(Agg(ivy"org.codehaus.groovy:groovy:3.0.9"))
+    defaultResolver().classpath(Agg(ivy"org.codehaus.groovy:groovy:3.0.9"))
   }
 
   def groovyScript = Task.Source("generate.groovy")

--- a/example/extending/jvmcode/3-worker/build.mill
+++ b/example/extending/jvmcode/3-worker/build.mill
@@ -16,7 +16,7 @@ import mill.util.Jvm
 object coursierModule extends CoursierModule
 
 def groovyClasspath: Task[Agg[PathRef]] = Task {
-  coursierModule.defaultResolver().resolveDeps(Agg(ivy"org.codehaus.groovy:groovy:3.0.9"))
+  coursierModule.defaultResolver().classpath(Agg(ivy"org.codehaus.groovy:groovy:3.0.9"))
 }
 
 def groovyWorker: Worker[java.net.URLClassLoader] = Task.Worker {

--- a/example/javalib/module/8-annotation-processors/build.mill
+++ b/example/javalib/module/8-annotation-processors/build.mill
@@ -37,7 +37,7 @@ object bar extends JavaModule {
   def compileIvyDeps = Agg(ivy"org.projectlombok:lombok:1.18.34")
 
   def processors = Task {
-    defaultResolver().resolveDeps(Agg(ivy"org.projectlombok:lombok:1.18.34"))
+    defaultResolver().classpath(Agg(ivy"org.projectlombok:lombok:1.18.34"))
   }
 
   def javacOptions = Seq(

--- a/example/javalib/web/4-hello-micronaut/build.mill
+++ b/example/javalib/web/4-hello-micronaut/build.mill
@@ -23,7 +23,7 @@ trait MicronautModule extends MavenModule {
   def micronautVersion: String
 
   def processors = Task {
-    defaultResolver().resolveDeps(
+    defaultResolver().classpath(
       Agg(
         ivy"io.micronaut.data:micronaut-data-processor:4.7.0",
         ivy"io.micronaut:micronaut-http-validation:$micronautVersion",

--- a/example/javalib/web/5-todo-micronaut/build.mill
+++ b/example/javalib/web/5-todo-micronaut/build.mill
@@ -36,7 +36,7 @@ trait MicronautModule extends MavenModule {
   def micronautVersion: String
 
   def processors = Task {
-    defaultResolver().resolveDeps(
+    defaultResolver().classpath(
       Agg(
         ivy"io.micronaut.data:micronaut-data-processor:4.7.0",
         ivy"io.micronaut:micronaut-http-validation:$micronautVersion",

--- a/example/kotlinlib/module/8-kotlin-compiler-plugins/build.mill
+++ b/example/kotlinlib/module/8-kotlin-compiler-plugins/build.mill
@@ -16,7 +16,7 @@ object foo extends KotlinModule {
   )
 
   def processors = Task {
-    defaultResolver().resolveDeps(
+    defaultResolver().classpath(
       Agg(
         ivy"org.jetbrains.kotlin:kotlin-serialization-compiler-plugin:1.9.24"
       )

--- a/example/kotlinlib/web/5-webapp-kotlinjs-shared/build.mill
+++ b/example/kotlinlib/web/5-webapp-kotlinjs-shared/build.mill
@@ -51,7 +51,7 @@ object `package` extends RootModule with AppKotlinModule {
 
     trait SharedModule extends AppKotlinModule with PlatformKotlinModule {
       def processors = Task {
-        defaultResolver().resolveDeps(
+        defaultResolver().classpath(
           Agg(
             ivy"org.jetbrains.kotlin:kotlin-serialization-compiler-plugin:${kotlinVersion()}"
           )

--- a/example/thirdparty/arrow/build.mill
+++ b/example/thirdparty/arrow/build.mill
@@ -296,7 +296,7 @@ object `package` extends RootModule {
         def moduleDeps = Seq(`arrow-core`.jvm)
         def compileIvyDeps = Agg(libraries.squareupRetrofitLib)
         def processors = Task {
-          defaultResolver().resolveDeps(Agg(libraries.kotlinxSerializationPlugin))
+          defaultResolver().classpath(Agg(libraries.kotlinxSerializationPlugin))
         }
 
         object test extends ArrowJvmTests {
@@ -349,7 +349,7 @@ object `package` extends RootModule {
         }
 
         def processors = Task {
-          defaultResolver().resolveDeps(Agg(libraries.kotlinxSerializationPlugin))
+          defaultResolver().classpath(Agg(libraries.kotlinxSerializationPlugin))
         }
       }
 

--- a/example/thirdparty/netty/build.mill
+++ b/example/thirdparty/netty/build.mill
@@ -569,7 +569,7 @@ object `transport-native-unix-common` extends NettyModule {
     val Seq(sourceJar) = defaultResolver().classpath(
       Seq(ivy"io.netty:netty-jni-util:0.0.9.Final"),
       sources = true
-    )
+    ).toSeq
 
     os.copy(makefile().path, Task.dest / "Makefile")
     os.copy(cSources().path, Task.dest / "src/main/c", createFolders = true)

--- a/example/thirdparty/netty/build.mill
+++ b/example/thirdparty/netty/build.mill
@@ -92,7 +92,7 @@ trait NettyJniModule extends NettyModule {
   }
   def clang = Task {
     val Seq(sourceJar) = defaultResolver()
-      .resolveDeps(
+      .classpath(
         Agg(ivy"io.netty:netty-jni-util:0.0.9.Final"),
         sources = true
       )
@@ -566,7 +566,7 @@ object `transport-native-unix-common` extends NettyModule {
   }
 
   def make = Task {
-    val Seq(sourceJar) = defaultResolver().resolveDeps(
+    val Seq(sourceJar) = defaultResolver().classpath(
       Seq(ivy"io.netty:netty-jni-util:0.0.9.Final"),
       sources = true
     )

--- a/example/thirdparty/netty/build.mill
+++ b/example/thirdparty/netty/build.mill
@@ -93,7 +93,7 @@ trait NettyJniModule extends NettyModule {
   def clang = Task {
     val Seq(sourceJar) = defaultResolver()
       .resolveDeps(
-        Agg(ivy"io.netty:netty-jni-util:0.0.9.Final").map(bindDependency()),
+        Agg(ivy"io.netty:netty-jni-util:0.0.9.Final"),
         sources = true
       )
       .toSeq
@@ -566,10 +566,10 @@ object `transport-native-unix-common` extends NettyModule {
   }
 
   def make = Task {
-    val Seq(sourceJar) = resolveDeps(
-      deps = Task.Anon(Agg(ivy"io.netty:netty-jni-util:0.0.9.Final").map(bindDependency())),
+    val Seq(sourceJar) = defaultResolver().resolveDeps(
+      Seq(ivy"io.netty:netty-jni-util:0.0.9.Final"),
       sources = true
-    )().toSeq
+    )
 
     os.copy(makefile().path, Task.dest / "Makefile")
     os.copy(cSources().path, Task.dest / "src/main/c", createFolders = true)

--- a/idea/src/mill/idea/GenIdeaImpl.scala
+++ b/idea/src/mill/idea/GenIdeaImpl.scala
@@ -147,7 +147,7 @@ case class GenIdeaImpl(
             }
 
             val externalLibraryDependencies = Task.Anon {
-              mod.defaultResolver().resolveDeps(mod.mandatoryIvyDeps())
+              mod.defaultResolver().classpath(mod.mandatoryIvyDeps())
             }
 
             val externalDependencies = Task.Anon {
@@ -155,12 +155,12 @@ case class GenIdeaImpl(
                 Task.traverse(mod.transitiveModuleDeps)(_.unmanagedClasspath)().flatten
             }
             val extCompileIvyDeps = Task.Anon {
-              mod.defaultResolver().resolveDeps(mod.compileIvyDeps())
+              mod.defaultResolver().classpath(mod.compileIvyDeps())
             }
             val extRunIvyDeps = mod.resolvedRunIvyDeps
 
             val externalSources = Task.Anon {
-              mod.millResolver().resolveDeps(allIvyDeps(), sources = true)
+              mod.millResolver().classpath(allIvyDeps(), sources = true)
             }
 
             val (scalacPluginsIvyDeps, allScalacOptions, scalaVersion) = mod match {
@@ -177,7 +177,7 @@ case class GenIdeaImpl(
             }
 
             val scalacPluginDependencies = Task.Anon {
-              mod.defaultResolver().resolveDeps(scalacPluginsIvyDeps())
+              mod.defaultResolver().classpath(scalacPluginsIvyDeps())
             }
 
             val facets = Task.Anon {

--- a/idea/src/mill/idea/GenIdeaImpl.scala
+++ b/idea/src/mill/idea/GenIdeaImpl.scala
@@ -160,7 +160,7 @@ case class GenIdeaImpl(
             val extRunIvyDeps = mod.resolvedRunIvyDeps
 
             val externalSources = Task.Anon {
-              mod.resolveDeps(allIvyDeps, sources = true, enableMillInternalDependencies = true)()
+              mod.millResolver().resolveDeps(allIvyDeps(), sources = true)
             }
 
             val (scalacPluginsIvyDeps, allScalacOptions, scalaVersion) = mod match {

--- a/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -97,7 +97,7 @@ trait KotlinModule extends JavaModule { outer =>
    * Default is derived from [[kotlinCompilerIvyDeps]].
    */
   def kotlinCompilerClasspath: T[Seq[PathRef]] = Task {
-    defaultResolver().resolveDeps(kotlinCompilerIvyDeps()).iterator.toSeq ++
+    defaultResolver().classpath(kotlinCompilerIvyDeps()).iterator.toSeq ++
       kotlinWorkerClasspath()
   }
 
@@ -209,7 +209,7 @@ trait KotlinModule extends JavaModule { outer =>
    * Classpath for running Dokka.
    */
   private def dokkaCliClasspath: T[Agg[PathRef]] = Task {
-    defaultResolver().resolveDeps(
+    defaultResolver().classpath(
       Agg(
         ivy"org.jetbrains.dokka:dokka-cli:${dokkaVersion()}"
       )
@@ -217,7 +217,7 @@ trait KotlinModule extends JavaModule { outer =>
   }
 
   private def dokkaPluginsClasspath: T[Agg[PathRef]] = Task {
-    defaultResolver().resolveDeps(
+    defaultResolver().classpath(
       Agg(
         ivy"org.jetbrains.dokka:dokka-base:${dokkaVersion()}",
         ivy"org.jetbrains.dokka:analysis-kotlin-descriptors:${dokkaVersion()}",

--- a/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -97,9 +97,8 @@ trait KotlinModule extends JavaModule { outer =>
    * Default is derived from [[kotlinCompilerIvyDeps]].
    */
   def kotlinCompilerClasspath: T[Seq[PathRef]] = Task {
-    resolveDeps(
-      Task.Anon { kotlinCompilerIvyDeps().map(bindDependency()) }
-    )().toSeq ++ kotlinWorkerClasspath()
+    defaultResolver().resolveDeps(kotlinCompilerIvyDeps()).iterator.toSeq ++
+      kotlinWorkerClasspath()
   }
 
   /**

--- a/kotlinlib/src/mill/kotlinlib/android/AndroidAppKotlinModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/android/AndroidAppKotlinModule.scala
@@ -52,7 +52,7 @@ trait AndroidAppKotlinModule extends AndroidAppModule with KotlinModule { outer 
     // Compose compiler version -> Kotlin version
     if (kotlinVersion().startsWith("1"))
       throw new IllegalStateException("Compose can be used only with Kotlin version 2 or newer.")
-    defaultResolver().resolveDeps(
+    defaultResolver().classpath(
       Agg(
         ivy"org.jetbrains.kotlin:kotlin-compose-compiler-plugin:${kotlinVersion()}"
       )
@@ -114,7 +114,7 @@ trait AndroidAppKotlinModule extends AndroidAppModule with KotlinModule { outer 
      * For more information see [[https://developer.android.com/studio/preview/compose-screenshot-testing]]
      */
     def composePreviewRenderer: T[Agg[PathRef]] = Task {
-      defaultResolver().resolveDeps(
+      defaultResolver().classpath(
         Agg(
           ivy"com.android.tools.compose:compose-preview-renderer:$composePreviewRendererVersion"
         )
@@ -122,7 +122,7 @@ trait AndroidAppKotlinModule extends AndroidAppModule with KotlinModule { outer 
     }
 
     final def layoutLibRenderer: T[Agg[PathRef]] = Task {
-      defaultResolver().resolveDeps(
+      defaultResolver().classpath(
         Agg(
           ivy"com.android.tools.layoutlib:layoutlib:$layoutLibVersion"
         )
@@ -130,7 +130,7 @@ trait AndroidAppKotlinModule extends AndroidAppModule with KotlinModule { outer 
     }
 
     final def layoutLibRuntime: T[Agg[PathRef]] = Task {
-      defaultResolver().resolveDeps(
+      defaultResolver().classpath(
         Agg(
           ivy"com.android.tools.layoutlib:layoutlib-runtime:$layoutLibVersion"
         )
@@ -138,7 +138,7 @@ trait AndroidAppKotlinModule extends AndroidAppModule with KotlinModule { outer 
     }
 
     final def layoutLibFrameworkRes: T[Agg[PathRef]] = Task {
-      defaultResolver().resolveDeps(
+      defaultResolver().classpath(
         Agg(
           ivy"com.android.tools.layoutlib:layoutlib-resources:$layoutLibVersion"
         )
@@ -312,7 +312,7 @@ trait AndroidAppKotlinModule extends AndroidAppModule with KotlinModule { outer 
       super.runClasspath() ++ androidPreviewScreenshotTestEngineClasspath() ++ compileClasspath()
 
     def androidPreviewScreenshotTestEngineClasspath: T[Agg[PathRef]] = Task {
-      defaultResolver().resolveDeps(
+      defaultResolver().classpath(
         Seq(
           ivy"com.android.tools.screenshot:screenshot-validation-junit-engine:0.0.1-alpha08"
         )

--- a/kotlinlib/src/mill/kotlinlib/detekt/DetektModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/detekt/DetektModule.scala
@@ -60,7 +60,7 @@ trait DetektModule extends KotlinModule {
    * Classpath for running Dekekt.
    */
   def detektClasspath: T[Loose.Agg[PathRef]] = Task {
-    defaultResolver().resolveDeps(
+    defaultResolver().classpath(
       Agg(ivy"io.gitlab.arturbosch.detekt:detekt-cli:${detektVersion()}")
     )
   }

--- a/kotlinlib/src/mill/kotlinlib/js/KotlinJsModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/js/KotlinJsModule.scala
@@ -691,7 +691,7 @@ trait KotlinJsModule extends KotlinModule { outer =>
     def kotestVersion: T[String] = "5.9.1"
 
     private def kotestProcessor = Task {
-      defaultResolver().resolveDeps(
+      defaultResolver().classpath(
         Agg(
           ivy"io.kotest:kotest-framework-multiplatform-plugin-embeddable-compiler-jvm:${kotestVersion()}"
         )

--- a/kotlinlib/src/mill/kotlinlib/kover/KoverModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/kover/KoverModule.scala
@@ -94,7 +94,7 @@ trait KoverModule extends KotlinModule { outer =>
 
     /** The Kover Agent is used at test-runtime. */
     private def koverAgentJar: T[PathRef] = Task {
-      val jars = defaultResolver().resolveDeps(koverAgentDep())
+      val jars = defaultResolver().classpath(koverAgentDep())
       jars.iterator.next()
     }
 

--- a/kotlinlib/src/mill/kotlinlib/kover/KoverReportBaseModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/kover/KoverReportBaseModule.scala
@@ -29,6 +29,6 @@ trait KoverReportBaseModule extends CoursierModule {
    * Classpath for running Kover.
    */
   def koverCliClasspath: T[Loose.Agg[PathRef]] = Task {
-    defaultResolver().resolveDeps(koverCliDep())
+    defaultResolver().classpath(koverCliDep())
   }
 }

--- a/kotlinlib/src/mill/kotlinlib/ktfmt/KtfmtModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/ktfmt/KtfmtModule.scala
@@ -14,7 +14,7 @@ trait KtfmtBaseModule extends JavaModule {
    * Classpath for running Ktfmt.
    */
   def ktfmtClasspath: T[Loose.Agg[PathRef]] = Task {
-    defaultResolver().resolveDeps(
+    defaultResolver().classpath(
       Agg(ivy"com.facebook:ktfmt:${ktfmtVersion()}")
     )
   }

--- a/kotlinlib/src/mill/kotlinlib/ktlint/KtlintModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/ktlint/KtlintModule.scala
@@ -31,7 +31,7 @@ trait KtlintModule extends JavaModule {
    * Classpath for running Ktlint.
    */
   def ktlintClasspath: T[Loose.Agg[PathRef]] = Task {
-    defaultResolver().resolveDeps(
+    defaultResolver().classpath(
       Agg(ivy"com.pinterest.ktlint:ktlint-cli:${ktlintVersion()}")
     )
   }

--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -4,7 +4,6 @@ package scalajslib
 import mainargs.{Flag, arg}
 import mill.api.{Loose, PathRef, Result, internal}
 import mill.scalalib.api.ZincWorkerUtil
-import mill.scalalib.Lib.resolveDependencies
 import mill.scalalib.{CrossVersion, Dep, DepSyntax, Lib, TestModule}
 import mill.testrunner.{TestResult, TestRunner, TestRunnerUtils}
 import mill.define.{Command, Task}
@@ -96,11 +95,9 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
         ) ++ scalaJSJsEnvIvyDeps()
     }
     // we need to use the scala-library of the currently running mill
-    resolveDependencies(
-      repositoriesTask(),
+    defaultResolver().resolveDeps(
       (commonDeps.iterator ++ envDeps ++ scalajsImportMapDeps)
-        .map(Lib.depToBoundDep(_, mill.main.BuildInfo.scalaVersion, "")),
-      ctx = Some(Task.log)
+        .map(Lib.depToBoundDep(_, mill.main.BuildInfo.scalaVersion, ""))
     )
   }
 

--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -95,7 +95,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
         ) ++ scalaJSJsEnvIvyDeps()
     }
     // we need to use the scala-library of the currently running mill
-    defaultResolver().resolveDeps(
+    defaultResolver().classpath(
       (commonDeps.iterator ++ envDeps ++ scalajsImportMapDeps)
         .map(Lib.depToBoundDep(_, mill.main.BuildInfo.scalaVersion, ""))
     )
@@ -360,7 +360,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
 trait TestScalaJSModule extends ScalaJSModule with TestModule {
   override def resources: T[Seq[PathRef]] = super[ScalaJSModule].resources
   def scalaJSTestDeps = Task {
-    defaultResolver().resolveDeps(
+    defaultResolver().classpath(
       Loose.Agg(
         ivy"org.scala-js::scalajs-library:${scalaJSVersion()}",
         ivy"org.scala-js::scalajs-test-bridge:${scalaJSVersion()}"

--- a/scalalib/src/mill/javalib/android/AndroidAppModule.scala
+++ b/scalalib/src/mill/javalib/android/AndroidAppModule.scala
@@ -573,7 +573,7 @@ trait AndroidAppModule extends JavaModule {
    * Classpath for the manifest merger run.
    */
   def manifestMergerClasspath: T[Agg[PathRef]] = Task {
-    defaultResolver().resolveDeps(
+    defaultResolver().classpath(
       Agg(
         ivy"com.android.tools.build:manifest-merger:${androidSdkModule().manifestMergerVersion()}"
       )

--- a/scalalib/src/mill/javalib/checkstyle/CheckstyleModule.scala
+++ b/scalalib/src/mill/javalib/checkstyle/CheckstyleModule.scala
@@ -79,7 +79,7 @@ trait CheckstyleModule extends JavaModule {
    * Classpath for running Checkstyle.
    */
   def checkstyleClasspath: T[Loose.Agg[PathRef]] = Task {
-    defaultResolver().resolveDeps(
+    defaultResolver().classpath(
       Agg(ivy"com.puppycrawl.tools:checkstyle:${checkstyleVersion()}")
     )
   }

--- a/scalalib/src/mill/javalib/errorprone/ErrorProneModule.scala
+++ b/scalalib/src/mill/javalib/errorprone/ErrorProneModule.scala
@@ -31,7 +31,7 @@ trait ErrorProneModule extends JavaModule {
    * The classpath of the `error-prone` compiler plugin.
    */
   def errorProneClasspath: T[Agg[PathRef]] = Task {
-    defaultResolver().resolveDeps(errorProneDeps())
+    defaultResolver().classpath(errorProneDeps())
   }
 
   /**

--- a/scalalib/src/mill/javalib/palantirformat/PalantirFormatModule.scala
+++ b/scalalib/src/mill/javalib/palantirformat/PalantirFormatModule.scala
@@ -13,7 +13,7 @@ trait PalantirFormatBaseModule extends CoursierModule {
    * Classpath for running Palantir Java Format.
    */
   def palantirformatClasspath: T[Loose.Agg[PathRef]] = Task {
-    defaultResolver().resolveDeps(
+    defaultResolver().classpath(
       Agg(ivy"com.palantir.javaformat:palantir-java-format:${palantirformatVersion()}")
     )
   }

--- a/scalalib/src/mill/javalib/revapi/RevapiModule.scala
+++ b/scalalib/src/mill/javalib/revapi/RevapiModule.scala
@@ -72,7 +72,7 @@ trait RevapiModule extends PublishModule {
   /** API archive and supplement files (dependencies) to compare against */
   def revapiOldFiles: T[Agg[PathRef]] = Task {
     val Artifact(group, id, version) = publishSelfDependency()
-    defaultResolver().resolveDeps(
+    defaultResolver().classpath(
       Seq(ivy"$group:$id:$version"),
       artifactTypes = Some(revapiArtifactTypes())
     )
@@ -82,7 +82,7 @@ trait RevapiModule extends PublishModule {
   def revapiNewFiles: T[Agg[PathRef]] = Task {
     Agg(jar()) ++
       Task.traverse(recursiveModuleDeps)(_.jar)() ++
-      millResolver().resolveDeps(
+      millResolver().classpath(
         Seq(coursierDependency),
         artifactTypes = Some(revapiArtifactTypes())
       )
@@ -102,7 +102,7 @@ trait RevapiModule extends PublishModule {
 
   /** Classpath containing the Revapi [[revapiCliVersion CLI]] */
   def revapiClasspath: T[Agg[PathRef]] = Task {
-    defaultResolver().resolveDeps(
+    defaultResolver().classpath(
       Agg(ivy"org.revapi:revapi-standalone:${revapiCliVersion()}")
     )
   }

--- a/scalalib/src/mill/scalalib/CoursierModule.scala
+++ b/scalalib/src/mill/scalalib/CoursierModule.scala
@@ -449,13 +449,7 @@ object CoursierModule {
      */
     def artifacts[T: CoursierModule.Resolvable](
         deps: IterableOnce[T],
-        sources: Boolean = false,
-        mapDependencies: Option[Dependency => Dependency] = None,
-        customizer: Option[Resolution => Resolution] = None,
-        ctx: Option[mill.api.Ctx.Log] = None,
-        coursierCacheCustomizer: Option[FileCache[Task] => FileCache[Task]] = None,
-        artifactTypes: Option[Set[Type]] = None,
-        resolutionParams: ResolutionParams = ResolutionParams()
+        sources: Boolean = false
     )(implicit ctx0: mill.api.Ctx.Log): coursier.Artifacts.Result = {
       val deps0 = deps
         .iterator

--- a/scalalib/src/mill/scalalib/CoursierModule.scala
+++ b/scalalib/src/mill/scalalib/CoursierModule.scala
@@ -444,7 +444,10 @@ object CoursierModule {
       resolution(deps).orderedDependencies
     }
 
-    def getArtifacts[T: CoursierModule.Resolvable](
+    /**
+     * Raw artifact results for the passed dependencies
+     */
+    def artifacts[T: CoursierModule.Resolvable](
         deps: IterableOnce[T],
         sources: Boolean = false,
         mapDependencies: Option[Dependency => Dependency] = None,

--- a/scalalib/src/mill/scalalib/CoursierModule.scala
+++ b/scalalib/src/mill/scalalib/CoursierModule.scala
@@ -292,7 +292,7 @@ object CoursierModule {
         mapDependencies
       ).getOrThrow
 
-    @deprecated("Use classpath instead", "Mill after 0.12.9")
+    @deprecated("Use classpath instead", "Mill 0.12.10")
     def resolveDeps[T: CoursierModule.Resolvable](
         deps: IterableOnce[T],
         sources: Boolean = false,
@@ -302,7 +302,7 @@ object CoursierModule {
     )(implicit ctx: mill.api.Ctx.Log): Agg[PathRef] =
       classpath(deps, sources, artifactTypes, resolutionParamsMapOpt, mapDependencies)
 
-    @deprecated("Use classpath instead", "Mill after 0.12.9")
+    @deprecated("Use classpath instead", "Mill 0.12.10")
     def resolveDeps[T: CoursierModule.Resolvable](
         deps: IterableOnce[T],
         sources: Boolean,
@@ -338,7 +338,7 @@ object CoursierModule {
         resolutionParams = resolutionParamsMapOpt.fold(resolutionParams)(_(resolutionParams))
       )
 
-    @deprecated("Use classpath instead", "Mill after 0.12.9")
+    @deprecated("Use classpath instead", "Mill 0.12.10")
     def resolveDeps[T: CoursierModule.Resolvable](
         deps: IterableOnce[T],
         sources: Boolean,
@@ -348,7 +348,7 @@ object CoursierModule {
       classpath(deps, sources, artifactTypes, None)
     }
 
-    @deprecated("Use classpath instead", "Mill after 0.12.9")
+    @deprecated("Use classpath instead", "Mill 0.12.10")
     def resolveDeps[T: CoursierModule.Resolvable](
         deps: IterableOnce[T],
         sources: Boolean
@@ -370,7 +370,7 @@ object CoursierModule {
      */
     @deprecated(
       "Use resolution instead, and extract the values you're interested in from it",
-      "Mill after 0.12.9"
+      "Mill 0.12.10"
     )
     def processDeps[T: CoursierModule.Resolvable](
         deps: IterableOnce[T],
@@ -435,7 +435,7 @@ object CoursierModule {
 
     @deprecated(
       "Use resolution instead, and call orderedDependencies on its returned value",
-      "Mill after 0.12.9"
+      "Mill 0.12.10"
     )
     def allDeps[T: CoursierModule.Resolvable](
         deps: IterableOnce[T]

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -1001,7 +1001,7 @@ trait JavaModule
    * Resolved dependencies
    */
   def resolvedIvyDeps: T[Agg[PathRef]] = Task {
-    millResolver().resolveDeps(
+    millResolver().classpath(
       Seq(
         BoundDep(
           coursierDependency.withConfiguration(cs.Configuration.provided),
@@ -1032,7 +1032,7 @@ trait JavaModule
   }
 
   def resolvedRunIvyDeps: T[Agg[PathRef]] = Task {
-    millResolver().resolveDeps(
+    millResolver().classpath(
       Seq(
         BoundDep(
           coursierDependency.withConfiguration(cs.Configuration.runtime),
@@ -1475,7 +1475,7 @@ trait JavaModule
     val tasks =
       if (all.value) Seq(
         Task.Anon {
-          millResolver().resolveDeps(
+          millResolver().classpath(
             Seq(
               coursierDependency.withConfiguration(cs.Configuration.provided),
               coursierDependency
@@ -1488,7 +1488,7 @@ trait JavaModule
           )
         },
         Task.Anon {
-          millResolver().resolveDeps(
+          millResolver().classpath(
             Seq(coursierDependency.withConfiguration(cs.Configuration.runtime)),
             sources = true
           )

--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -571,7 +571,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
       zincWorker().scalaCompilerBridgeJar(
         scalaVersion(),
         scalaOrganization(),
-        repositoriesTask()
+        defaultResolver()
       )
       Task.sequence(tasks)()
       ()

--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -172,7 +172,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
    */
   private def enablePluginScalacOptions: T[Seq[String]] = Task {
 
-    val resolvedJars = defaultResolver().resolveDeps(
+    val resolvedJars = defaultResolver().classpath(
       scalacPluginIvyDeps().map(_.exclude("*" -> "*"))
     )
     resolvedJars.iterator.map(jar => s"-Xplugin:${jar.path}").toSeq
@@ -182,7 +182,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
    * Scalac options to activate the compiler plugins for ScalaDoc generation.
    */
   private def enableScalaDocPluginScalacOptions: T[Seq[String]] = Task {
-    val resolvedJars = defaultResolver().resolveDeps(
+    val resolvedJars = defaultResolver().classpath(
       scalaDocPluginIvyDeps().map(_.exclude("*" -> "*"))
     )
     resolvedJars.iterator.map(jar => s"-Xplugin:${jar.path}").toSeq
@@ -222,14 +222,14 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
    * on maven central
    */
   def scalacPluginClasspath: T[Agg[PathRef]] = Task {
-    defaultResolver().resolveDeps(scalacPluginIvyDeps())
+    defaultResolver().classpath(scalacPluginIvyDeps())
   }
 
   /**
    * Classpath of the scaladoc (or dottydoc) tool.
    */
   def scalaDocClasspath: T[Agg[PathRef]] = Task {
-    defaultResolver().resolveDeps(
+    defaultResolver().classpath(
       Lib.scalaDocIvyDeps(scalaOrganization(), scalaVersion())
     )
   }
@@ -238,7 +238,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
    * The ivy coordinates of Scala's own standard library
    */
   def scalaDocPluginClasspath: T[Agg[PathRef]] = Task {
-    defaultResolver().resolveDeps(
+    defaultResolver().classpath(
       scalaDocPluginIvyDeps()
     )
   }
@@ -256,7 +256,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
    * Classpath of the Scala Compiler & any compiler plugins
    */
   def scalaCompilerClasspath: T[Agg[PathRef]] = Task {
-    defaultResolver().resolveDeps(
+    defaultResolver().classpath(
       Lib.scalaCompilerIvyDeps(scalaOrganization(), scalaVersion()) ++
         scalaLibraryIvyDeps()
     )
@@ -473,7 +473,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
   }
 
   def resolvedAmmoniteReplIvyDeps = Task {
-    millResolver().resolveDeps {
+    millResolver().classpath {
       val scaVersion = scalaVersion()
       val ammVersion = ammoniteVersion()
       if (scaVersion != BuildInfo.scalaVersion && ammVersion == Versions.ammonite) {
@@ -562,10 +562,10 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
     Task.Command {
       super.prepareOffline(all)()
       // resolve the compile bridge jar
-      defaultResolver().resolveDeps(
+      defaultResolver().classpath(
         scalacPluginIvyDeps()
       )
-      defaultResolver().resolveDeps(
+      defaultResolver().classpath(
         scalaDocPluginIvyDeps()
       )
       zincWorker().scalaCompilerBridgeJar(
@@ -607,7 +607,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
   override def semanticDbScalaVersion: T[String] = scalaVersion()
 
   override protected def semanticDbPluginClasspath = Task {
-    defaultResolver().resolveDeps(
+    defaultResolver().classpath(
       scalacPluginIvyDeps() ++ semanticDbPluginIvyDeps()
     )
   }

--- a/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
+++ b/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
@@ -84,18 +84,18 @@ trait SemanticDbJavaModule extends CoursierModule {
    * Scalac options to activate the compiler plugins.
    */
   protected def semanticDbEnablePluginScalacOptions: T[Seq[String]] = Task {
-    val resolvedJars = defaultResolver().resolveDeps(
+    val resolvedJars = defaultResolver().classpath(
       semanticDbPluginIvyDeps().map(_.exclude("*" -> "*"))
     )
     resolvedJars.iterator.map(jar => s"-Xplugin:${jar.path}").toSeq
   }
 
   protected def semanticDbPluginClasspath: T[Agg[PathRef]] = Task {
-    defaultResolver().resolveDeps(semanticDbPluginIvyDeps())
+    defaultResolver().classpath(semanticDbPluginIvyDeps())
   }
 
   protected def resolvedSemanticDbJavaPluginIvyDeps: T[Agg[PathRef]] = Task {
-    defaultResolver().resolveDeps(semanticDbJavaPluginIvyDeps())
+    defaultResolver().classpath(semanticDbJavaPluginIvyDeps())
   }
 
   def semanticDbData: T[PathRef] = Task(persistent = true) {

--- a/scalalib/src/mill/scalalib/ZincWorkerModule.scala
+++ b/scalalib/src/mill/scalalib/ZincWorkerModule.scala
@@ -106,7 +106,7 @@ trait ZincWorkerModule extends mill.Module with OfflineSupportModule with Coursi
     instance.asInstanceOf[ZincWorkerApi]
   }
 
-  @deprecated("Use the override accepting a Resolver instead", "Mill after 0.12.9")
+  @deprecated("Use the override accepting a Resolver instead", "Mill 0.12.10")
   def scalaCompilerBridgeJar(
       scalaVersion: String,
       scalaOrganization: String,
@@ -210,7 +210,7 @@ trait ZincWorkerModule extends mill.Module with OfflineSupportModule with Coursi
     (classpathOpt, bridgeJar)
   }
 
-  @deprecated("Use the override accepting a Resolver instead", "Mill after 0.12.9")
+  @deprecated("Use the override accepting a Resolver instead", "Mill 0.12.10")
   def compilerInterfaceClasspath(
       scalaVersion: String,
       scalaOrganization: String,

--- a/scalalib/src/mill/scalalib/ZincWorkerModule.scala
+++ b/scalalib/src/mill/scalalib/ZincWorkerModule.scala
@@ -165,7 +165,7 @@ trait ZincWorkerModule extends mill.Module with OfflineSupportModule with Coursi
       scalaVersion: String,
       scalaOrganization: String,
       resolver: Resolver
-  ): Result[(Option[Agg[PathRef]], PathRef)] = {
+  )(implicit ctx: Ctx.Log): Result[(Option[Agg[PathRef]], PathRef)] = {
     val (scalaVersion0, scalaBinaryVersion0) = scalaVersion match {
       case _ => (scalaVersion, ZincWorkerUtil.scalaBinaryVersion(scalaVersion))
     }
@@ -233,7 +233,7 @@ trait ZincWorkerModule extends mill.Module with OfflineSupportModule with Coursi
       scalaVersion: String,
       scalaOrganization: String,
       resolver: Resolver
-  ): Result[Agg[PathRef]] = {
+  )(implicit ctx: Ctx.Log): Result[Agg[PathRef]] = {
     resolver.resolveDeps(
       deps = Seq(ivy"org.scala-sbt:compiler-interface:${Versions.zinc}".bindDep("", "", "")),
       // Since Zinc 1.4.0, the compiler-interface depends on the Scala library

--- a/scalalib/src/mill/scalalib/ZincWorkerModule.scala
+++ b/scalalib/src/mill/scalalib/ZincWorkerModule.scala
@@ -196,7 +196,7 @@ trait ZincWorkerModule extends mill.Module with OfflineSupportModule with Coursi
 
     val useSources = !isBinaryBridgeAvailable(scalaVersion)
 
-    val deps = resolver.resolveDeps(
+    val deps = resolver.classpath(
       Seq(bridgeDep.bindDep("", "", "")),
       sources = useSources,
       mapDependencies = Some(overrideScalaLibrary(scalaVersion, scalaOrganization))
@@ -230,7 +230,7 @@ trait ZincWorkerModule extends mill.Module with OfflineSupportModule with Coursi
       scalaOrganization: String,
       resolver: Resolver
   )(implicit ctx: Ctx.Log): Agg[PathRef] = {
-    resolver.resolveDeps(
+    resolver.classpath(
       deps = Seq(ivy"org.scala-sbt:compiler-interface:${Versions.zinc}".bindDep("", "", "")),
       // Since Zinc 1.4.0, the compiler-interface depends on the Scala library
       // We need to override it with the scalaVersion and scalaOrganization of the module

--- a/scalalib/src/mill/scalalib/giter8/Giter8Module.scala
+++ b/scalalib/src/mill/scalalib/giter8/Giter8Module.scala
@@ -19,7 +19,7 @@ trait Giter8Module extends CoursierModule {
 
     val giter8Dependencies =
       try {
-        defaultResolver().resolveDeps {
+        defaultResolver().classpath {
           val scalaBinVersion = {
             val bv = ZincWorkerUtil.scalaBinaryVersion(BuildInfo.scalaVersion)
             if (bv == "3") "2.13" else bv

--- a/scalalib/test/src/mill/javalib/revapi/RevapiModuleTests.scala
+++ b/scalalib/test/src/mill/javalib/revapi/RevapiModuleTests.scala
@@ -97,10 +97,10 @@ object RevapiModuleTests extends TestSuite {
       override def publishVersion: T[String] = v1
 
       override def revapiOldFiles: T[Agg[PathRef]] = Task {
-        defaultResolver().resolveDeps(Seq(ivy"$group:$id:$v1"))
+        defaultResolver().classpath(Seq(ivy"$group:$id:$v1"))
       }
       override def revapiNewFiles: T[Agg[PathRef]] = Task {
-        defaultResolver().resolveDeps(Seq(ivy"$group:$id:$v2"))
+        defaultResolver().classpath(Seq(ivy"$group:$id:$v2"))
       }
       override def revapiConfigFiles: T[Seq[PathRef]] =
         Task.Sources(os.list(conf).iterator.filter(_.ext == "json").map(PathRef(_)).toSeq)

--- a/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
+++ b/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
@@ -95,7 +95,7 @@ trait ScalaNativeModule extends ScalaModule { outer =>
   }
 
   def bridgeFullClassPath: T[Agg[PathRef]] = Task {
-    scalaNativeWorkerClasspath() ++ defaultResolver().resolveDeps(
+    scalaNativeWorkerClasspath() ++ defaultResolver().classpath(
       toolsIvyDeps().map(Lib.depToBoundDep(_, mill.main.BuildInfo.scalaVersion, ""))
     )
   }

--- a/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
+++ b/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
@@ -95,11 +95,9 @@ trait ScalaNativeModule extends ScalaModule { outer =>
   }
 
   def bridgeFullClassPath: T[Agg[PathRef]] = Task {
-    Lib.resolveDependencies(
-      repositoriesTask(),
-      toolsIvyDeps().map(Lib.depToBoundDep(_, mill.main.BuildInfo.scalaVersion, "")),
-      ctx = Some(Task.log)
-    ).map(t => (scalaNativeWorkerClasspath() ++ t))
+    scalaNativeWorkerClasspath() ++ defaultResolver().resolveDeps(
+      toolsIvyDeps().map(Lib.depToBoundDep(_, mill.main.BuildInfo.scalaVersion, ""))
+    )
   }
 
   override def scalacPluginIvyDeps: T[Agg[Dep]] = Task {


### PR DESCRIPTION
Whenever possible, this tries to make modules defined in Mill use `CoursierModule#defaultResolver` or `CoursierModule#millResolver`  to resolve dependencies, rather than calling lower level helpers like `Lib. resolveDependencies`. The former automatically take into account customizations of resolution defined on `CoursierModule` and `JavaModule` (`repositoriesTask`, `mapDependencies`, etc.), while these have to be passed manually to `Lib.resolveDependencies`.

This helps when adding more parameters - these have to be passed to `defaultResolver` / `millResolver`, and that's it, rather than also having to inspect all calls to `Lib.resolveDependencies`, and passing the new parameter there too.

This also tries to make resolution log to the task logger of the task requesting the resolution, rather than the logger of `CoursierModule#{defaultResolver,millResolver}`.

---

Original pull request: https://github.com/com-lihaoyi/mill/pull/4727 

Pull request: https://github.com/com-lihaoyi/mill/pull/4784