### PR TITLE
Review and fix proguard contrib plugin

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -241,6 +241,7 @@ object Deps {
     val ktfmt = ivy"com.facebook:ktfmt:0.53"
     val ktlint = ivy"com.pinterest.ktlint:ktlint-core:0.49.1"
     val palantirFormat = ivy"com.palantir.javaformat:palantir-java-format:2.51.0"
+    val proguard = ivy"com.guardsquare:proguard-base:7.7.0"
     val revApi = ivy"org.revapi:revapi-standalone:0.12.0"
     val sbtTestInterface = ivy"com.github.sbt:junit-interface:0.13.2"
 
@@ -258,6 +259,7 @@ object Deps {
       ktfmt,
       ktlint,
       palantirFormat,
+      proguard,
       revApi,
       sbtTestInterface
     )
@@ -571,7 +573,8 @@ trait MillBaseTestsModule extends TestModule {
       s"-DTEST_ZIOTEST_VERSION=${Deps.TestDeps.zioTest.version}",
       s"-DTEST_ZINC_VERSION=${Deps.zinc.version}",
       s"-DTEST_KOTLIN_VERSION=${Deps.kotlinCompiler.version}",
-      s"-DTEST_SBT_VERSION=${Deps.sbt.version}"
+      s"-DTEST_SBT_VERSION=${Deps.sbt.version}",
+      s"-DTEST_PROGUARD_VERSION=${Deps.RuntimeDeps.proguard.version}"
     )
   }
 

--- a/contrib/proguard/src/mill/contrib/proguard/Proguard.scala
+++ b/contrib/proguard/src/mill/contrib/proguard/Proguard.scala
@@ -110,8 +110,6 @@ trait Proguard extends ScalaModule {
       classPath = proguardClasspath().map(_.path).toVector,
       mainArgs = args,
       cwd = Task.dest
-//      stdin = os.Inherit,
-//      stdout = os.Inherit
     )
 
     // the call above already throws an exception on a non-zero exit code,

--- a/contrib/proguard/src/mill/contrib/proguard/Proguard.scala
+++ b/contrib/proguard/src/mill/contrib/proguard/Proguard.scala
@@ -21,12 +21,7 @@ trait Proguard extends ScalaModule {
    * The version of proguard to download from Maven.
    * https://mvnrepository.com/artifact/com.guardsquare/proguard-base
    */
-  def proguardVersion: T[String] = Task {
-    Task.log.error(
-      "Using default proguard version is deprecated. Please override target proguardVersion to specify the version."
-    )
-    "7.2.2"
-  }
+  def proguardVersion: T[String]
 
   /** Run the "shrink" step in the proguard pipeline. Defaults to true. */
   def shrink: T[Boolean] = Task { true }
@@ -114,9 +109,9 @@ trait Proguard extends ScalaModule {
       mainClass = "proguard.ProGuard",
       classPath = proguardClasspath().map(_.path).toVector,
       mainArgs = args,
-      cwd = Task.dest,
-      stdin = os.Inherit,
-      stdout = os.Inherit
+      cwd = Task.dest
+//      stdin = os.Inherit,
+//      stdout = os.Inherit
     )
 
     // the call above already throws an exception on a non-zero exit code,
@@ -126,12 +121,11 @@ trait Proguard extends ScalaModule {
 
   /**
    * The location of the proguard jar files.
-   * These are downloaded from JCenter and fed to `java -cp`
    */
   def proguardClasspath: T[Seq[PathRef]] = Task {
-    defaultResolver().resolveDeps(
-      Seq(ivy"com.guardsquare:proguard-base:${proguardVersion()}")
-    )
+    defaultResolver().resolveDeps(Seq(
+      ivy"com.guardsquare:proguard-base:${proguardVersion()}"
+    ))
   }
 
   private def steps: T[Seq[String]] = Task {
@@ -161,10 +155,10 @@ trait Proguard extends ScalaModule {
    * These are fed as-is to the proguard command.
    */
   def additionalOptions: T[Seq[String]] = Task {
-    Task.log.error(
+    Task.log.warn(
       "Proguard is set to not warn about message: can't find referenced method 'void invoke()' in library class java.lang.invoke.MethodHandle"
     )
-    T.log.error(
+    T.log.warn(
       """Proguard is set to not warn about message: "scala.quoted.Type: can't find referenced class scala.AnyKind""""
     )
     Seq[String](

--- a/contrib/proguard/test/resources/proguard/src/Main.scala
+++ b/contrib/proguard/test/resources/proguard/src/Main.scala
@@ -1,3 +1,7 @@
 import java.nio.file.{Files, Paths}
 
-object Main extends App {}
+object Main {
+  def main(args: Array[String]): Unit = {
+    Console.println("Hello " + args.mkString(" ") + "!")
+  }
+}

--- a/contrib/proguard/test/src/mill/contrib/proguard/ProguardTests.scala
+++ b/contrib/proguard/test/src/mill/contrib/proguard/ProguardTests.scala
@@ -1,12 +1,9 @@
 package mill.contrib.proguard
 
-import java.io.File
-
 import mill.*
 import mill.define.{Discover, Target}
 import mill.scalalib.ScalaModule
-import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.{TestBaseModule, UnitTester}
 import mill.util.Jvm
 import os.Path
 import utest.*
@@ -15,9 +12,13 @@ object ProguardTests extends TestSuite {
 
   object proguard extends TestBaseModule with ScalaModule with Proguard {
     // TODO: This test works for a Scala 2.13 App, but not for a Scala 3 App, probably due to tasty files
-    override def scalaVersion: T[String] = T(sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???))
-//    override def scalaVersion: T[String] = T(sys.props.getOrElse("TEST_SCALA_3_VERSION", ???))
-    def proguardVersion = "7.7.0"
+    override def scalaVersion: T[String] = Task.Input {
+      sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
+    }
+    def proguardVersion = Task.Input {
+      sys.props.getOrElse("TEST_PROGUARD_VERSION", ???)
+    }
+
     lazy val millDiscover = Discover[this.type]
   }
 

--- a/contrib/proguard/test/src/mill/contrib/proguard/ProguardTests.scala
+++ b/contrib/proguard/test/src/mill/contrib/proguard/ProguardTests.scala
@@ -55,7 +55,6 @@ object ProguardTests extends TestSuite {
 
       test("should create a proguarded jar") - UnitTester(proguard, testModuleSourcesPath).scoped {
         eval =>
-          // Not sure why this is broken in Scala 3
           val Right(result) = eval.apply(proguard.proguard): @unchecked
           assert(os.exists(result.value.path))
 

--- a/contrib/proguard/test/src/mill/contrib/proguard/ProguardTests.scala
+++ b/contrib/proguard/test/src/mill/contrib/proguard/ProguardTests.scala
@@ -1,26 +1,23 @@
 package mill.contrib.proguard
 
+import java.io.File
+
 import mill.*
 import mill.define.{Discover, Target}
-import mill.util.MillModuleUtil.millProjectModule
 import mill.scalalib.ScalaModule
 import mill.testkit.UnitTester
 import mill.testkit.TestBaseModule
+import mill.util.Jvm
 import os.Path
 import utest.*
 
 object ProguardTests extends TestSuite {
 
   object proguard extends TestBaseModule with ScalaModule with Proguard {
-    override def scalaVersion: T[String] = T(sys.props.getOrElse("MILL_SCALA_3_NEXT_VERSION", ???))
-
-    def proguardContribClasspath = Task {
-      millProjectModule("mill-contrib-proguard", repositoriesTask())
-    }
-
-    override def runClasspath: T[Seq[PathRef]] =
-      Task { super.runClasspath() ++ proguardContribClasspath() }
-
+    // TODO: This test works for a Scala 2.13 App, but not for a Scala 3 App, probably due to tasty files
+    override def scalaVersion: T[String] = T(sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???))
+//    override def scalaVersion: T[String] = T(sys.props.getOrElse("TEST_SCALA_3_VERSION", ???))
+    def proguardVersion = "7.7.0"
     lazy val millDiscover = Discover[this.type]
   }
 
@@ -37,11 +34,40 @@ object ProguardTests extends TestSuite {
           )
       }
 
-      test("should create a proguarded jar") - UnitTester(proguard, testModuleSourcesPath).scoped {
-        _ =>
+      test("assembly jar") - UnitTester(proguard, testModuleSourcesPath).scoped {
+        eval =>
           // Not sure why this is broken in Scala 3
-          // val Right(result) = eval.apply(proguard.proguard)
-          //          assert(os.exists(result.value.path))
+          val Right(result) = eval.apply(proguard.assembly): @unchecked
+          assert(os.exists(result.value.path))
+
+          val res = os.call(
+            cmd = (Jvm.javaExe, "-jar", result.value.path, "world"),
+            mergeErrIntoOut = true,
+            check = false
+          )
+          assert(
+            res.exitCode == 0,
+            res.out.text().contains("Hello world!")
+          )
+          s"jar size: ${os.size(result.value.path)}"
+      }
+
+      test("should create a proguarded jar") - UnitTester(proguard, testModuleSourcesPath).scoped {
+        eval =>
+          // Not sure why this is broken in Scala 3
+          val Right(result) = eval.apply(proguard.proguard): @unchecked
+          assert(os.exists(result.value.path))
+
+          val res = os.call(
+            cmd = (Jvm.javaExe, "-jar", result.value.path, "proguarded", "world"),
+            mergeErrIntoOut = true,
+            check = false
+          )
+          assert(
+            res.exitCode == 0,
+            res.out.text().contains("Hello proguarded world!")
+          )
+          s"jar size: ${os.size(result.value.path)}"
       }
     }
   }


### PR DESCRIPTION
Removed hardcoded `proguardVersion`.
Re-enabled and overhauled tests.
Manage versions used in tests from Mill build.