### PR TITLE
Add `Dep.millProjectModule` to refer to mill project modules

### DIFF
--- a/bsp/src/mill/bsp/BSP.scala
+++ b/bsp/src/mill/bsp/BSP.scala
@@ -4,15 +4,14 @@ import mill.api.{Ctx, PathRef}
 import mill.{T, Task, given}
 import mill.define.{Command, Discover, Evaluator, ExternalModule}
 import mill.main.BuildInfo
-import mill.util.MillModuleUtil.millProjectModule
-import mill.scalalib.CoursierModule
+import mill.scalalib.{CoursierModule, Dep}
 
 object BSP extends ExternalModule with CoursierModule {
 
   lazy val millDiscover = Discover[this.type]
 
   private def bspWorkerLibs: T[Seq[PathRef]] = Task {
-    millProjectModule("mill-bsp-worker", repositoriesTask())
+    defaultResolver().resolveDeps(Seq(Dep.millProjectModule("mill-bsp-worker")))
   }
 
   /**

--- a/bsp/src/mill/bsp/BSP.scala
+++ b/bsp/src/mill/bsp/BSP.scala
@@ -11,7 +11,7 @@ object BSP extends ExternalModule with CoursierModule {
   lazy val millDiscover = Discover[this.type]
 
   private def bspWorkerLibs: T[Seq[PathRef]] = Task {
-    defaultResolver().resolveDeps(Seq(Dep.millProjectModule("mill-bsp-worker")))
+    defaultResolver().classpath(Seq(Dep.millProjectModule("mill-bsp-worker")))
   }
 
   /**

--- a/contrib/playlib/src/mill/playlib/RouterModule.scala
+++ b/contrib/playlib/src/mill/playlib/RouterModule.scala
@@ -1,7 +1,6 @@
 package mill.playlib
 
 import mill.api.PathRef
-import mill.util.MillModuleUtil.millProjectModule
 import mill.playlib.api.RouteCompilerType
 import mill.scalalib._
 import mill.scalalib.api._
@@ -75,15 +74,16 @@ trait RouterModule extends ScalaModule with Version {
   }
 
   def playRouteCompilerWorkerClasspath = Task {
-    millProjectModule(
-      s"mill-contrib-playlib-worker-${playMinorVersion()}",
-      repositoriesTask(),
-      artifactSuffix = playMinorVersion() match {
+    val minorVersion = playMinorVersion()
+    val dep = Dep.millProjectModule(
+      s"mill-contrib-playlib-worker-${minorVersion}",
+      artifactSuffix = minorVersion match {
         case "2.6" => "_2.12"
         case "2.7" | "2.8" => "_2.13"
         case _ => "_3"
       }
     )
+    defaultResolver().resolveDeps(Seq(dep))
   }
 
   def playRouterToolsClasspath = Task {

--- a/contrib/playlib/src/mill/playlib/RouterModule.scala
+++ b/contrib/playlib/src/mill/playlib/RouterModule.scala
@@ -83,7 +83,7 @@ trait RouterModule extends ScalaModule with Version {
         case _ => "_3"
       }
     )
-    defaultResolver().resolveDeps(Seq(dep))
+    defaultResolver().classpath(Seq(dep))
   }
 
   def playRouterToolsClasspath = Task {

--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
@@ -7,7 +7,6 @@ import mill.contrib.scoverage.api.ScoverageReportWorkerApi2.ReportType
 import mill.main.BuildInfo
 import mill.scalalib.api.ZincWorkerUtil
 import mill.scalalib.{Dep, DepSyntax, JavaModule, ScalaModule}
-import mill.util.MillModuleUtil.millProjectModule
 
 /**
  * Adds targets to a [[mill.scalalib.ScalaModule]] to create test coverage reports.
@@ -121,12 +120,9 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
   }
 
   def scoverageReportWorkerClasspath: T[Seq[PathRef]] = Task {
-    val workerArtifact = "mill-contrib-scoverage-worker2"
-
-    millProjectModule(
-      workerArtifact,
-      repositoriesTask()
-    )
+      defaultResolver().resolveDeps(Seq(
+        Dep.millProjectModule("mill-contrib-scoverage-worker2")
+      ))
   }
 
   /** Inner worker module. This is not an `object` to allow users to override and customize it. */

--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
@@ -120,7 +120,7 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
   }
 
   def scoverageReportWorkerClasspath: T[Seq[PathRef]] = Task {
-    defaultResolver().resolveDeps(Seq(
+    defaultResolver().classpath(Seq(
       Dep.millProjectModule("mill-contrib-scoverage-worker2")
     ))
   }

--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
@@ -120,9 +120,9 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
   }
 
   def scoverageReportWorkerClasspath: T[Seq[PathRef]] = Task {
-      defaultResolver().resolveDeps(Seq(
-        Dep.millProjectModule("mill-contrib-scoverage-worker2")
-      ))
+    defaultResolver().resolveDeps(Seq(
+      Dep.millProjectModule("mill-contrib-scoverage-worker2")
+    ))
   }
 
   /** Inner worker module. This is not an `object` to allow users to override and customize it. */

--- a/contrib/testng/test/src/mill/testng/TestNGTests.scala
+++ b/contrib/testng/test/src/mill/testng/TestNGTests.scala
@@ -1,8 +1,7 @@
-package mill
-package testng
+package mill.testng
 
+import mill.*
 import mill.define.{Discover, Target}
-import mill.util.MillModuleUtil.millProjectModule
 import mill.scalalib.*
 import mill.testkit.UnitTester
 import mill.testkit.TestBaseModule
@@ -13,23 +12,13 @@ object TestNGTests extends TestSuite {
   object demo extends TestBaseModule with JavaModule {
 
     object test extends JavaTests {
-      def testngClasspath = Task {
-        millProjectModule(
-          "mill-contrib-testng",
-          repositoriesTask(),
-          artifactSuffix = ""
-        )
-      }
-
-      override def runClasspath: T[Seq[PathRef]] =
-        Task { super.runClasspath() ++ testngClasspath() }
-      override def ivyDeps = Task {
-        super.ivyDeps() ++
-          Seq(
-            ivy"org.testng:testng:6.11",
-            ivy"de.tototec:de.tobiasroeser.lambdatest:0.8.0"
-          )
-      }
+      override def runIvyDeps = super.runIvyDeps() ++ Seq(
+        Dep.millProjectModule("mill-contrib-testng", artifactSuffix = "")
+      )
+      override def ivyDeps = super.ivyDeps() ++ Seq(
+        ivy"org.testng:testng:6.11",
+        ivy"de.tototec:de.tobiasroeser.lambdatest:0.8.0"
+      )
       override def testFramework = Task {
         "mill.testng.TestNGFramework"
       }

--- a/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -87,7 +87,7 @@ trait KotlinModule extends JavaModule { outer =>
   protected def kotlinWorkerRef: ModuleRef[KotlinWorkerModule] = ModuleRef(KotlinWorkerModule)
 
   private[kotlinlib] def kotlinWorkerClasspath = Task {
-    defaultResolver().resolveDeps(Seq(
+    defaultResolver().classpath(Seq(
       Dep.millProjectModule("mill-kotlinlib-worker-impl")
     ))
   }

--- a/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -13,7 +13,6 @@ import mill.scalalib.api.{CompilationResult, ZincWorkerApi}
 import mill.scalalib.bsp.{BspBuildTarget, BspModule}
 import mill.scalalib.{JavaModule, Lib, ZincWorkerModule}
 import mill.util.Jvm
-import mill.util.MillModuleUtil.millProjectModule
 import mill.T
 
 import java.io.File
@@ -88,10 +87,9 @@ trait KotlinModule extends JavaModule { outer =>
   protected def kotlinWorkerRef: ModuleRef[KotlinWorkerModule] = ModuleRef(KotlinWorkerModule)
 
   private[kotlinlib] def kotlinWorkerClasspath = Task {
-    millProjectModule(
-      "mill-kotlinlib-worker-impl",
-      repositoriesTask()
-    )
+    defaultResolver().resolveDep(Seq(
+      Dep.millProjectModule("mill-kotlinlib-worker-impl")
+    ))
   }
 
   /**

--- a/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -87,7 +87,7 @@ trait KotlinModule extends JavaModule { outer =>
   protected def kotlinWorkerRef: ModuleRef[KotlinWorkerModule] = ModuleRef(KotlinWorkerModule)
 
   private[kotlinlib] def kotlinWorkerClasspath = Task {
-    defaultResolver().resolveDep(Seq(
+    defaultResolver().resolveDeps(Seq(
       Dep.millProjectModule("mill-kotlinlib-worker-impl")
     ))
   }

--- a/main/init/src/mill/init/BuildGenException.scala
+++ b/main/init/src/mill/init/BuildGenException.scala
@@ -1,0 +1,6 @@
+package mill.init
+
+import scala.util.control.NoStackTrace
+
+@mill.api.experimental
+case class BuildGenException(message: String) extends Exception(message) with NoStackTrace

--- a/main/init/src/mill/init/BuildGenModule.scala
+++ b/main/init/src/mill/init/BuildGenModule.scala
@@ -15,7 +15,7 @@ trait BuildGenModule extends CoursierModule with TaskModule {
   def buildGenDeps: T[Seq[Dep]] = Task { Seq.empty[Dep] }
 
   def buildGenClasspath: T[Seq[PathRef]] = Task {
-    defaultResolver().resolveDeps(buildGenDeps())
+    defaultResolver().classpath(buildGenDeps())
   }
 
   def buildGenMainClass: T[String]

--- a/main/init/src/mill/init/BuildGenModule.scala
+++ b/main/init/src/mill/init/BuildGenModule.scala
@@ -1,22 +1,22 @@
 package mill.init
 
-import coursier.LocalRepositories
-import coursier.core.Repository
-import coursier.maven.MavenRepository
 import mill.api.{PathRef, Result}
 import mill.main.buildgen.BuildGenUtil
+import mill.scalalib.{CoursierModule, Dep}
 import mill.scalalib.scalafmt.ScalafmtWorkerModule
-import mill.util.{Jvm, MillModuleUtil}
+import mill.util.Jvm
 import mill.{Command, T, Task, TaskModule}
 
-import scala.util.control.NoStackTrace
-
 @mill.api.experimental
-trait BuildGenModule extends TaskModule {
+trait BuildGenModule extends CoursierModule with TaskModule {
 
   def defaultCommandName(): String = "init"
 
-  def buildGenClasspath: T[Seq[PathRef]]
+  def buildGenDeps: T[Seq[Dep]] = Task { Seq.empty[Dep] }
+
+  def buildGenClasspath: T[Seq[PathRef]] = Task {
+    defaultResolver().resolveDeps(buildGenDeps())
+  }
 
   def buildGenMainClass: T[String]
 
@@ -48,18 +48,5 @@ trait BuildGenModule extends TaskModule {
     }
   }
 }
-@mill.api.experimental
-object BuildGenModule {
 
-  def millModule(artifact: String): Result[Seq[PathRef]] =
-    MillModuleUtil.millProjectModule(artifact, millRepositories)
 
-  def millRepositories: Seq[Repository] = Seq(
-    LocalRepositories.ivy2Local,
-    MavenRepository("https://repo1.maven.org/maven2"),
-    MavenRepository("https://oss.sonatype.org/content/repositories/releases")
-  )
-}
-
-@mill.api.experimental
-case class BuildGenException(message: String) extends Exception(message) with NoStackTrace

--- a/main/init/src/mill/init/BuildGenModule.scala
+++ b/main/init/src/mill/init/BuildGenModule.scala
@@ -48,5 +48,3 @@ trait BuildGenModule extends CoursierModule with TaskModule {
     }
   }
 }
-
-

--- a/main/init/src/mill/init/InitGradleModule.scala
+++ b/main/init/src/mill/init/InitGradleModule.scala
@@ -1,15 +1,18 @@
 package mill.init
 
 import mill.T
-import mill.api.{PathRef}
+import mill.api.PathRef
 import mill.define.{Discover, ExternalModule}
+import mill.scalalib.Dep
 
 @mill.api.experimental
 object InitGradleModule extends ExternalModule with BuildGenModule {
 
   lazy val millDiscover = Discover[this.type]
 
-  def buildGenClasspath: T[Seq[PathRef]] = BuildGenModule.millModule("mill-main-init-gradle")
+  override def buildGenDeps = super.buildGenDeps() ++ Seq(
+    Dep.millProjectModule("mill-main-init-gradle")
+  )
 
   def buildGenMainClass: T[String] = "mill.main.gradle.GradleBuildGenMain"
 }

--- a/main/init/src/mill/init/InitGradleModule.scala
+++ b/main/init/src/mill/init/InitGradleModule.scala
@@ -1,7 +1,6 @@
 package mill.init
 
 import mill.T
-import mill.api.PathRef
 import mill.define.{Discover, ExternalModule}
 import mill.scalalib.Dep
 

--- a/main/init/src/mill/init/InitMavenModule.scala
+++ b/main/init/src/mill/init/InitMavenModule.scala
@@ -1,15 +1,18 @@
 package mill.init
 
 import mill.T
-import mill.api.{PathRef}
+import mill.api.PathRef
 import mill.define.{Discover, ExternalModule}
+import mill.scalalib.Dep
 
 @mill.api.experimental
 object InitMavenModule extends ExternalModule with BuildGenModule {
 
   lazy val millDiscover = Discover[this.type]
 
-  def buildGenClasspath: T[Seq[PathRef]] = BuildGenModule.millModule("mill-main-init-maven")
+  override def buildGenDeps = super.buildGenDeps() ++ Seq(
+    Dep.millProjectModule("mill-main-init-maven")
+  )
 
   def buildGenMainClass: T[String] = "mill.main.maven.MavenBuildGenMain"
 }

--- a/main/init/src/mill/init/InitMavenModule.scala
+++ b/main/init/src/mill/init/InitMavenModule.scala
@@ -1,7 +1,6 @@
 package mill.init
 
 import mill.T
-import mill.api.PathRef
 import mill.define.{Discover, ExternalModule}
 import mill.scalalib.Dep
 

--- a/main/init/src/mill/init/InitSbtModule.scala
+++ b/main/init/src/mill/init/InitSbtModule.scala
@@ -1,14 +1,16 @@
 package mill.init
 
 import mill.T
-import mill.api.PathRef
 import mill.define.{Discover, ExternalModule}
+import mill.scalalib.Dep
 
 @mill.api.experimental
 object InitSbtModule extends ExternalModule with BuildGenModule {
   lazy val millDiscover = Discover[this.type]
 
-  def buildGenClasspath: T[Seq[PathRef]] = BuildGenModule.millModule("mill-main-init-sbt")
+  override def buildGenDeps = super.buildGenDeps() ++ Seq(
+    Dep.millProjectModule("mill-main-init-sbt")
+  )
 
   def buildGenMainClass: T[String] = "mill.main.sbt.SbtBuildGenMain"
 }

--- a/main/src/mill/main/VisualizeModule.scala
+++ b/main/src/mill/main/VisualizeModule.scala
@@ -58,7 +58,7 @@ object VisualizeModule extends ExternalModule {
     }
   }
 
-  def classpath: Target[Seq[PathRef]] = Target {
+  def toolsClasspath: Target[Seq[PathRef]] = Target {
     millProjectModule("mill-main-graphviz", repositories)
   }
 
@@ -137,7 +137,7 @@ object VisualizeModule extends ExternalModule {
 
           mill.util.Jvm.callProcess(
             mainClass = "mill.main.graphviz.GraphvizTools",
-            classPath = classpath().map(_.path).toVector,
+            classPath = toolsClasspath().map(_.path).toVector,
             mainArgs = Seq(s"${os.temp(g.toString)};$dest;txt,dot,json,png,svg"),
             stdin = os.Inherit,
             stdout = os.Inherit

--- a/main/src/mill/main/VisualizeModule.scala
+++ b/main/src/mill/main/VisualizeModule.scala
@@ -58,6 +58,9 @@ object VisualizeModule extends ExternalModule {
     }
   }
 
+  @deprecated("Use toolsClasspath instead", "0.13.0-M1")
+  def classpath = toolsClasspath
+
   def toolsClasspath: Target[Seq[PathRef]] = Target {
     millProjectModule("mill-main-graphviz", repositories)
   }

--- a/main/util/src/mill/util/MillModuleUtil.scala
+++ b/main/util/src/mill/util/MillModuleUtil.scala
@@ -13,7 +13,7 @@ private[mill] object MillModuleUtil {
    * This design has issues and will probably be replaced.
    */
   @deprecated("Use Dep.millProjectModule instead", "Mill 0.13.0-M1")
-  def millProjectModule(
+  private[mill] def millProjectModule(
       artifact: String,
       repositories: Seq[Repository],
       // this should correspond to the mill runtime Scala version
@@ -28,7 +28,7 @@ private[mill] object MillModuleUtil {
             coursier.Organization("com.lihaoyi"),
             coursier.ModuleName(artifact + artifactSuffix)
           ),
-          BuildInfo.millVersion
+          coursier.VersionConstraint(BuildInfo.millVersion)
         )
       ),
       force = Nil

--- a/main/util/src/mill/util/MillModuleUtil.scala
+++ b/main/util/src/mill/util/MillModuleUtil.scala
@@ -12,6 +12,7 @@ private[mill] object MillModuleUtil {
    * Deprecated helper method, intended to allow runtime resolution and in-development-tree testings of mill plugins possible.
    * This design has issues and will probably be replaced.
    */
+  @deprecated("Use Dep.millProjectModule instead", "Mill 0.13.0-M1")
   def millProjectModule(
       artifact: String,
       repositories: Seq[Repository],

--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -44,7 +44,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
   }
 
   def scalaJSWorkerClasspath = Task {
-    defaultResolver().resolveDeps(Seq(
+    defaultResolver().classpath(Seq(
       Dep.millProjectModule(s"mill-scalajslib-worker-${scalaJSWorkerVersion()}")
     ))
   }

--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -11,7 +11,6 @@ import mill.scalajslib.api.*
 import mill.scalajslib.worker.{ScalaJSWorker, ScalaJSWorkerExternalModule}
 import mill.scalalib.bsp.{ScalaBuildTarget, ScalaPlatform}
 import mill.T
-import mill.util.MillModuleUtil
 
 trait ScalaJSModule extends scalalib.ScalaModule { outer =>
 
@@ -45,10 +44,9 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
   }
 
   def scalaJSWorkerClasspath = Task {
-    MillModuleUtil.millProjectModule(
-      artifact = s"mill-scalajslib-worker-${scalaJSWorkerVersion()}",
-      repositories = repositoriesTask()
-    )
+    defaultResolver().resolveDeps(Seq(
+      Dep.millProjectModule(s"mill-scalajslib-worker-${scalaJSWorkerVersion()}")
+    ))
   }
 
   def scalaJSJsEnvIvyDeps: T[Seq[Dep]] = Task {

--- a/scalalib/src/mill/scalalib/CoursierModule.scala
+++ b/scalalib/src/mill/scalalib/CoursierModule.scala
@@ -28,10 +28,10 @@ trait CoursierModule extends mill.Module {
   }
 
   /**
-   * A `CoursierModule.Resolver` to resolve dependencies.
+   * A [[CoursierModule.Resolver]] to resolve dependencies.
    *
-   * Unlike `defaultResolver`, this resolver can resolve Mill modules too
-   * (obtained via `JavaModule#coursierDependency`).
+   * Unlike [[defaultResolver]], this resolver can resolve Mill modules too
+   * (obtained via [[JavaModule.coursierDependency]]).
    *
    * @return `CoursierModule.Resolver` instance
    */

--- a/scalalib/src/mill/scalalib/Dep.scala
+++ b/scalalib/src/mill/scalalib/Dep.scala
@@ -2,11 +2,9 @@ package mill.scalalib
 
 import upickle.default.{macroRW, ReadWriter as RW}
 import mill.scalalib.CrossVersion.*
-import coursier.core.Dependency
+import coursier.core.{Configuration, Dependency, MinimizedExclusions}
 import mill.scalalib.api.{Versions, ZincWorkerUtil}
 import scala.annotation.unused
-
-import coursier.core.Configuration
 
 case class Dep(dep: coursier.Dependency, cross: CrossVersion, force: Boolean) {
   require(
@@ -270,9 +268,10 @@ case class BoundDep(
   def toDep: Dep = Dep(dep = dep, cross = CrossVersion.empty(false), force = force)
 
   def exclude(exclusions: (String, String)*): BoundDep = copy(
-    dep = dep.withExclusions(
-      dep.exclusions() ++
-        exclusions.map { case (k, v) => (coursier.Organization(k), coursier.ModuleName(v)) }
+    dep = dep.withMinimizedExclusions(
+      dep.minimizedExclusions.join(MinimizedExclusions(
+        exclusions.toSet.map { case (k, v) => (coursier.Organization(k), coursier.ModuleName(v)) }
+      ))
     )
   )
 }

--- a/scalalib/src/mill/scalalib/Dep.scala
+++ b/scalalib/src/mill/scalalib/Dep.scala
@@ -1,11 +1,11 @@
 package mill.scalalib
 
-import upickle.default.{macroRW, ReadWriter => RW}
-import mill.scalalib.CrossVersion._
+import upickle.default.{macroRW, ReadWriter as RW}
+import mill.scalalib.CrossVersion.*
 import coursier.core.Dependency
-import mill.scalalib.api.ZincWorkerUtil
-
+import mill.scalalib.api.{Versions, ZincWorkerUtil}
 import scala.annotation.unused
+
 import coursier.core.Configuration
 
 case class Dep(dep: coursier.Dependency, cross: CrossVersion, force: Boolean) {
@@ -198,6 +198,12 @@ object Dep {
       force
     )
   }
+
+  /**
+   * Convenience to access Mill modules as dependencies, e.g. to load the into worker classpaths.
+   */
+  private[mill] def millProjectModule(artifactName: String): Dep =
+    ivy"com.lihaoyi:${artifactName}_3:${Versions.millVersion}"
 
 }
 

--- a/scalalib/src/mill/scalalib/Dep.scala
+++ b/scalalib/src/mill/scalalib/Dep.scala
@@ -201,9 +201,12 @@ object Dep {
 
   /**
    * Convenience to access Mill modules as dependencies, e.g. to load the into worker classpaths.
+   * @param artifactName The module artifact name
+   * @param artifactSuffix The artifact suffix typically representing the Scala version.
+   *                       Defaults to the Scala binary platform Mill runs on.
    */
-  private[mill] def millProjectModule(artifactName: String): Dep =
-    ivy"com.lihaoyi:${artifactName}_3:${Versions.millVersion}"
+  private[mill] def millProjectModule(artifactName: String, artifactSuffix: String = "_3"): Dep =
+    ivy"com.lihaoyi:${artifactName}${artifactSuffix}:${Versions.millVersion}"
 
 }
 

--- a/scalalib/src/mill/scalalib/ZincWorkerModule.scala
+++ b/scalalib/src/mill/scalalib/ZincWorkerModule.scala
@@ -7,7 +7,6 @@ import mill.api.{Ctx, PathRef, Result}
 import mill.define.{Discover, ExternalModule, Task}
 import mill.scalalib.api.ZincWorkerUtil.{isBinaryBridgeAvailable, isDotty, isDottyOrScala3}
 import mill.scalalib.api.{Versions, ZincWorkerApi, ZincWorkerUtil}
-import mill.util.MillModuleUtil.millProjectModule
 import mill.scalalib.CoursierModule.Resolver
 
 /**
@@ -27,23 +26,27 @@ trait ZincWorkerModule extends mill.Module with OfflineSupportModule with Coursi
     mill.scalalib.api.Versions.coursierJvmIndexVersion
 
   def classpath: T[Seq[PathRef]] = Task {
-    millProjectModule("mill-scalalib-worker", repositoriesTask())
+    defaultResolver().classpath(Seq(
+      Dep.millProjectModule("mill-scalalib-worker")
+    ))
   }
 
   def scalalibClasspath: T[Seq[PathRef]] = Task {
-    millProjectModule("mill-scalalib", repositoriesTask())
+    defaultResolver().classpath(Seq(
+      Dep.millProjectModule("mill-scalalib")
+    ))
   }
 
   def testrunnerEntrypointClasspath: T[Seq[PathRef]] = Task {
-    millProjectModule("mill-testrunner-entrypoint", repositoriesTask(), artifactSuffix = "")
+    defaultResolver().classpath(Seq(
+      Dep.millProjectModule("mill-testrunner-entrypoint", artifactSuffix = "")
+    ))
   }
 
   def backgroundWrapperClasspath: T[Seq[PathRef]] = Task {
-    millProjectModule(
-      "mill-scalalib-backgroundwrapper",
-      repositoriesTask(),
-      artifactSuffix = ""
-    )
+    defaultResolver().classpath(Seq(
+      Dep.millProjectModule("mill-scalalib-backgroundwrapper", artifactSuffix = "")
+    ))
   }
 
   def zincLogDebug: T[Boolean] = Task.Input(Task.ctx().log.debugEnabled)

--- a/scalalib/src/mill/scalalib/ZincWorkerModule.scala
+++ b/scalalib/src/mill/scalalib/ZincWorkerModule.scala
@@ -1,6 +1,5 @@
 package mill.scalalib
 
-import coursier.Repository
 import mainargs.Flag
 import mill._
 import mill.api.{Ctx, PathRef, Result}

--- a/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
+++ b/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
@@ -37,7 +37,7 @@ trait ScalaNativeModule extends ScalaModule { outer =>
     Task { ZincWorkerUtil.scalaNativeWorkerVersion(scalaNativeVersion()) }
 
   def scalaNativeWorkerClasspath = Task {
-    defaultResolver().resolveDeps(Seq(
+    defaultResolver().classpath(Seq(
       Dep.millProjectModule(s"mill-scalanativelib-worker-${scalaNativeWorkerVersion()}")
     ))
   }

--- a/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
+++ b/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
@@ -5,7 +5,6 @@ import mainargs.Flag
 
 import mill.api.{Result, internal}
 import mill.define.{Command, Task}
-import mill.util.MillModuleUtil.millProjectModule
 import mill.scalalib.api.ZincWorkerUtil
 import mill.scalalib.bsp.{ScalaBuildTarget, ScalaPlatform}
 import mill.scalalib.{CrossVersion, Dep, DepSyntax, Lib, SbtModule, ScalaModule, TestModule}
@@ -38,10 +37,9 @@ trait ScalaNativeModule extends ScalaModule { outer =>
     Task { ZincWorkerUtil.scalaNativeWorkerVersion(scalaNativeVersion()) }
 
   def scalaNativeWorkerClasspath = Task {
-    millProjectModule(
-      s"mill-scalanativelib-worker-${scalaNativeWorkerVersion()}",
-      repositoriesTask()
-    )
+    defaultResolver().resolveDeps(Seq(
+      Dep.millProjectModule(s"mill-scalanativelib-worker-${scalaNativeWorkerVersion()}")
+    ))
   }
 
   def toolsIvyDeps = Task {


### PR DESCRIPTION
This is meant as a replacement for `mill.util.ModuleUtils.millProjectModule`.

The main motivation for this change is to handle mill module dependencies more regular. Since they can be resolved together with other dependencies, this should result in better conflict resolution. The older API rather forces us to concat two potential redundant or conflicting classpaths. 

There is one last usage of the older `ModuleUtils.millProjectModule` from `VisualizeModule`, which resides in `mill.main` and can't access `CoursierModule` or `Dep`. Don't know how to best handle it.