### PR TITLE
Add a logger to Retry, and make the integration tests Retry effective

### DIFF
--- a/main/util/test/src/mill/util/RetryTests.scala
+++ b/main/util/test/src/mill/util/RetryTests.scala
@@ -7,7 +7,7 @@ object RetryTests extends TestSuite {
     test("fail") {
       var count = 0
       try {
-        Retry() {
+        Retry(Retry.printStreamLogger(System.err)) {
           count += 1
           throw new Exception("boom")
         }
@@ -20,7 +20,7 @@ object RetryTests extends TestSuite {
     }
     test("succeed") {
       var count = 0
-      Retry() {
+      Retry(Retry.printStreamLogger(System.err)) {
         count += 1
         if (count < 3) throw new Exception("boom")
       }
@@ -30,6 +30,7 @@ object RetryTests extends TestSuite {
       var count = 0
       try {
         Retry(
+          Retry.printStreamLogger(System.err),
           filter = {
             case (i, ex: RuntimeException) => true
             case _ => false
@@ -49,7 +50,7 @@ object RetryTests extends TestSuite {
       test("fail") {
         var count = 0
         try {
-          Retry(timeoutMillis = 100) {
+          Retry(Retry.printStreamLogger(System.err), timeoutMillis = 100) {
             count += 1
             Thread.sleep(1000)
           }
@@ -62,7 +63,7 @@ object RetryTests extends TestSuite {
       }
       test("success") {
         var count = 0
-        Retry(timeoutMillis = 100) {
+        Retry(Retry.printStreamLogger(System.err), timeoutMillis = 100) {
           count += 1
           if (count < 3) Thread.sleep(1000)
         }

--- a/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
+++ b/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
@@ -231,7 +231,7 @@ class ZincWorkerImpl(
     ) { (compilers: Compilers) =>
       // Not sure why dotty scaladoc is flaky, but add retries to workaround it
       // https://github.com/com-lihaoyi/mill/issues/4556
-      mill.util.Retry(count = 2) {
+      mill.util.Retry(mill.util.Retry.ctxLogger, count = 2) {
         if (
           ZincWorkerUtil.isDotty(scalaVersion) || ZincWorkerUtil.isScala3Milestone(scalaVersion)
         ) {

--- a/testkit/src/mill/testkit/IntegrationTesterBase.scala
+++ b/testkit/src/mill/testkit/IntegrationTesterBase.scala
@@ -39,7 +39,7 @@ trait IntegrationTesterBase {
   def initWorkspace(): Unit = {
     println(s"Copying integration test sources from $workspaceSourcePath to $workspacePath")
     os.makeDir.all(workspacePath)
-    Retry() {
+    Retry(Retry.printStreamLogger(System.err)) {
       val tmp = os.temp.dir()
       val outDir = os.Path(out, workspacePath)
       if (os.exists(outDir)) os.move.into(outDir, tmp)

--- a/testkit/src/mill/testkit/UtestExampleTestSuite.scala
+++ b/testkit/src/mill/testkit/UtestExampleTestSuite.scala
@@ -14,6 +14,7 @@ object UtestExampleTestSuite extends TestSuite {
 
     test("exampleTest") {
       Retry(
+        Retry.printStreamLogger(System.err),
         count = if (sys.env.contains("CI")) 1 else 0,
         timeoutMillis = 15.minutes.toMillis
       ) {

--- a/testkit/src/mill/testkit/UtestIntegrationTestSuite.scala
+++ b/testkit/src/mill/testkit/UtestIntegrationTestSuite.scala
@@ -1,9 +1,5 @@
 package mill.testkit
 
-import mill.util.Retry
-import scala.concurrent.duration.DurationInt
-import scala.concurrent.{ExecutionContext, Future}
-
 abstract class UtestIntegrationTestSuite extends utest.TestSuite with IntegrationTestSuite {
   protected def workspaceSourcePath: os.Path = os.Path(sys.env("MILL_TEST_RESOURCE_DIR"))
   protected def clientServerMode: Boolean = sys.env("MILL_INTEGRATION_SERVER_MODE").toBoolean
@@ -13,16 +9,4 @@ abstract class UtestIntegrationTestSuite extends utest.TestSuite with Integratio
     sys.env("MILL_INTEGRATION_IS_PACKAGED_LAUNCHER").toBoolean
   protected def millExecutable: os.Path =
     os.Path(System.getenv("MILL_INTEGRATION_LAUNCHER"), os.pwd)
-
-  override def utestWrap(path: Seq[String], runBody: => Future[Any])(implicit
-      ec: ExecutionContext
-  ): Future[Any] = {
-    Retry(
-      Retry.printStreamLogger(System.err),
-      count = if (sys.env.contains("CI")) 1 else 0,
-      timeoutMillis = 10.minutes.toMillis
-    ) {
-      super.utestWrap(path, runBody)
-    }
-  }
 }

--- a/testkit/src/mill/testkit/UtestIntegrationTestSuite.scala
+++ b/testkit/src/mill/testkit/UtestIntegrationTestSuite.scala
@@ -18,6 +18,7 @@ abstract class UtestIntegrationTestSuite extends utest.TestSuite with Integratio
       ec: ExecutionContext
   ): Future[Any] = {
     Retry(
+      Retry.printStreamLogger(System.err),
       count = if (sys.env.contains("CI")) 1 else 0,
       timeoutMillis = 10.minutes.toMillis
     ) {


### PR DESCRIPTION
This adds a `logger: String => Unit` argument to `Retry`, so that we can know in the logs (CI logs say) if a retry did happen. Two helpers are added to help users pass that new argument: `Retry.ctxLogger` that uses `Task.ctx`, and `Retry.printStream` if one wants to log with `System.err` for example.

Also, this moves the `Retry` of integration tests from `UtestIntegrationTestSuite` to `IntegrationTestSuite#integrationTest`. In the former location, it was wrapping a `Future`, which `Retry` doesn't handle, so that the retry actually had no effect I think.

Lastly, this ignores `TimeoutException`s for example tests that have a `ignoreErrorsOnCI` file (introduced in https://github.com/com-lihaoyi/mill/pull/4751).