### PR TITLE
Set `WebApp.scala` shutdown timeout to zero

### DIFF
--- a/example/scalalib/web/3-todo-http4s/src/WebApp.scala
+++ b/example/scalalib/web/3-todo-http4s/src/WebApp.scala
@@ -1,5 +1,6 @@
 package webapp
 
+import scala.concurrent.duration.Duration
 import scalatags.Text.all._
 import scalatags.Text.tags2
 import cats.effect._
@@ -17,7 +18,12 @@ object WebApp extends IOApp.Simple {
   case class Todo(checked: Boolean, text: String)
 
   def run = mkService.toResource.flatMap { service =>
-    EmberServerBuilder.default[IO].withHttpApp(service).withPort(port"8084").build
+    EmberServerBuilder
+      .default[IO]
+      .withHttpApp(service)
+      .withPort(port"8084")
+      .withShutdownTimeout(Duration.Zero)
+      .build
   }.useForever
 
   def mkService =


### PR DESCRIPTION
Otherwise it hangs for 30s when you try to kill the process, which slows down iterative development considerably