### PR TITLE
Fix testForked?

### DIFF
--- a/scalalib/src/mill/scalalib/TestModule.scala
+++ b/scalalib/src/mill/scalalib/TestModule.scala
@@ -71,7 +71,7 @@ trait TestModule
    */
   def testForked(args: String*): Command[(String, Seq[TestResult])] =
     Task.Command {
-      testTask(Task.Anon { args }, Task.Anon { Seq.empty[String] })()
+      testTask(Task.Anon { Seq.empty[String] }, Task.Anon { args })()
     }
 
   def getTestEnvironmentVars(args: String*): Command[(String, String, String, Seq[String])] = {


### PR DESCRIPTION
Checking what the CI says for now. Locally for me, this fixes things like
```text
$ ./mill 'scalalib.test' "mill.scalalib.HelloJavaTests"
```
(after re-bootstrapping)

That is, the selector is taken into account as a selector, while without these changes, I get things like
```text
[1427/1427] scalalib.test.test
[1427] utest.NoSuchTestException: [mill.scalalib.HelloJavaTests]
[1427] 	at utest.runner.BaseRunner.tasks(BaseRunner.scala:74)
[1427] 	at mill.testrunner.TestRunnerUtils$.$anonfun$getTestTasks$2(TestRunnerUtils.scala:137)
[1427] 	at scala.collection.ArrayOps$.map$extension(ArrayOps.scala:936)
[1427] 	at mill.testrunner.TestRunnerUtils$.getTestTasks(TestRunnerUtils.scala:131)
[1427] 	at mill.testrunner.TestRunnerUtils$.runTestFramework0(TestRunnerUtils.scala:269)
[1427] 	at mill.testrunner.TestRunnerMain0$.main0(TestRunnerMain0.scala:40)
[1427] 	at mill.testrunner.TestRunnerMain0.main0(TestRunnerMain0.scala)
[1427] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[1427] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
[1427] 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[1427] 	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
[1427] 	at mill.testrunner.entrypoint.TestRunnerMain.main(TestRunnerMain.java:42)
[1427] utest.NoSuchTestException: [mill.scalalib.HelloJavaTests]
```

Note that I only get the stacktrace above when disabling test parallelism. With test parallelism enabled, we don't get any stack trace, and get instead
```text
mill-server/ exitCode file not found
```