### PR TITLE
Backport "Fix main class discovery for `KotlinModule`"

### DIFF
--- a/example/kotlinlib/basic/1-simple/build.mill
+++ b/example/kotlinlib/basic/1-simple/build.mill
@@ -6,8 +6,6 @@ import mill._, kotlinlib._
 object foo extends KotlinModule {
   def kotlinVersion = "1.9.24"
 
-  def mainClass = Some("foo.FooKt")
-
   def ivyDeps = Agg(
     ivy"com.github.ajalt.clikt:clikt-jvm:4.4.0",
     ivy"org.jetbrains.kotlinx:kotlinx-html-jvm:0.11.0"

--- a/example/kotlinlib/basic/3-multi-module/build.mill
+++ b/example/kotlinlib/basic/3-multi-module/build.mill
@@ -13,7 +13,6 @@ trait MyModule extends KotlinModule {
 }
 
 object foo extends MyModule {
-  def mainClass = Some("foo.FooKt")
   def moduleDeps = Seq(bar)
   def ivyDeps = Agg(
     ivy"com.github.ajalt.clikt:clikt-jvm:4.4.0"

--- a/example/kotlinlib/basic/6-realistic/build.mill
+++ b/example/kotlinlib/basic/6-realistic/build.mill
@@ -28,8 +28,6 @@ trait MyModule extends KotlinModule with PublishModule {
 object foo extends MyModule {
   def moduleDeps = Seq(bar, qux)
 
-  def mainClass = Some("foo.FooKt")
-
   def generatedSources = Task {
     os.write(
       Task.dest / "Version.kt",

--- a/example/kotlinlib/dependencies/1-ivy-deps/build.mill
+++ b/example/kotlinlib/dependencies/1-ivy-deps/build.mill
@@ -6,8 +6,6 @@ object `package` extends RootModule with KotlinModule {
 
   def kotlinVersion = "1.9.24"
 
-  def mainClass = Some("foo.FooKt")
-
   def ivyDeps = Agg(
     ivy"com.fasterxml.jackson.core:jackson-databind:2.13.4"
   )

--- a/example/kotlinlib/dependencies/3-unmanaged-jars/build.mill
+++ b/example/kotlinlib/dependencies/3-unmanaged-jars/build.mill
@@ -6,8 +6,6 @@ object `package` extends RootModule with KotlinModule {
 
   def kotlinVersion = "1.9.24"
 
-  def mainClass = Some("foo.FooKt")
-
   def unmanagedClasspath = Task {
     if (!os.exists(millSourcePath / "lib")) Agg()
     else Agg.from(os.list(millSourcePath / "lib").map(PathRef(_)))

--- a/example/kotlinlib/dependencies/4-downloading-unmanaged-jars/build.mill
+++ b/example/kotlinlib/dependencies/4-downloading-unmanaged-jars/build.mill
@@ -6,8 +6,6 @@ object `package` extends RootModule with KotlinModule {
 
   def kotlinVersion = "1.9.24"
 
-  def mainClass = Some("foo.FooKt")
-
   def unmanagedClasspath = Task {
     os.write(
       Task.dest / "fastjavaio.jar",

--- a/example/kotlinlib/dependencies/5-repository-config/build.mill
+++ b/example/kotlinlib/dependencies/5-repository-config/build.mill
@@ -11,8 +11,6 @@ val sonatypeReleases = Seq(
 
 object foo extends KotlinModule {
 
-  def mainClass = Some("foo.FooKt")
-
   def kotlinVersion = "1.9.24"
 
   def ivyDeps = Agg(

--- a/example/kotlinlib/module/2-custom-tasks/build.mill
+++ b/example/kotlinlib/module/2-custom-tasks/build.mill
@@ -6,8 +6,6 @@ object `package` extends RootModule with KotlinModule {
 
   def kotlinVersion = "1.9.24"
 
-  def mainClass = Some("foo.FooKt")
-
   def ivyDeps = Agg(ivy"com.github.ajalt.clikt:clikt-jvm:4.4.0")
 
   def generatedSources: T[Seq[PathRef]] = Task {

--- a/example/kotlinlib/module/3-override-tasks/build.mill
+++ b/example/kotlinlib/module/3-override-tasks/build.mill
@@ -6,8 +6,6 @@ object foo extends KotlinModule {
 
   def kotlinVersion = "1.9.24"
 
-  def mainClass = Some("foo.FooKt")
-
   def sources = Task {
     os.write(
       Task.dest / "Foo.kt",

--- a/example/kotlinlib/module/4-compilation-execution-flags/build.mill
+++ b/example/kotlinlib/module/4-compilation-execution-flags/build.mill
@@ -6,8 +6,6 @@ object `package` extends RootModule with KotlinModule {
 
   def kotlinVersion = "1.9.24"
 
-  def mainClass = Some("foo.FooKt")
-
   def forkArgs = Seq("-Xmx4g", "-Dmy.jvm.property=hello")
   def forkEnv = Map("MY_ENV_VAR" -> "WORLD")
 

--- a/example/kotlinlib/publishing/1-assembly-config/build.mill
+++ b/example/kotlinlib/publishing/1-assembly-config/build.mill
@@ -7,8 +7,6 @@ object foo extends KotlinModule {
 
   def kotlinVersion = "1.9.24"
 
-  def mainClass = Some("foo.FooKt")
-
   def moduleDeps = Seq(bar)
   def assemblyRules = Seq(
     // all application.conf files will be concatenated into single file

--- a/example/kotlinlib/publishing/2-publish-module/build.mill
+++ b/example/kotlinlib/publishing/2-publish-module/build.mill
@@ -4,8 +4,6 @@ import mill._, kotlinlib._, publish._
 
 object foo extends KotlinModule with PublishModule {
 
-  def mainClass = Some("foo.FooKt")
-
   def kotlinVersion = "1.9.24"
 
   def publishVersion = "0.0.1"

--- a/example/kotlinlib/publishing/8-native-image-libs/build.mill
+++ b/example/kotlinlib/publishing/8-native-image-libs/build.mill
@@ -6,8 +6,6 @@ import mill.define.ModuleRef
 object foo extends KotlinModule with NativeImageModule {
   def kotlinVersion = "1.9.24"
 
-  def mainClass = Some("foo.FooKt")
-
   def nativeImageOptions = Seq(
     "--no-fallback",
     "-Os",

--- a/example/kotlinlib/testing/1-test-suite/build.mill
+++ b/example/kotlinlib/testing/1-test-suite/build.mill
@@ -4,8 +4,6 @@ import mill._, kotlinlib._
 
 object foo extends KotlinModule {
 
-  def mainClass = Some("foo.FooKt")
-
   def kotlinVersion = "1.9.24"
 
   object test extends KotlinTests {

--- a/example/kotlinlib/testing/4-test-parallel/build.mill
+++ b/example/kotlinlib/testing/4-test-parallel/build.mill
@@ -4,8 +4,6 @@ import mill._, kotlinlib._
 
 object foo extends KotlinModule {
 
-  def mainClass = Some("foo.FooKt")
-
   def kotlinVersion = "1.9.24"
 
   object test extends KotlinTests {

--- a/example/kotlinlib/testing/5-test-grouping/build.mill
+++ b/example/kotlinlib/testing/5-test-grouping/build.mill
@@ -4,8 +4,6 @@ import mill._, kotlinlib._
 
 object foo extends KotlinModule {
 
-  def mainClass = Some("foo.FooKt")
-
   def kotlinVersion = "1.9.24"
 
   object test extends KotlinTests {

--- a/example/kotlinlib/testing/6-test-group-parallel/build.mill
+++ b/example/kotlinlib/testing/6-test-group-parallel/build.mill
@@ -4,8 +4,6 @@ import mill._, kotlinlib._
 
 object foo extends KotlinModule {
 
-  def mainClass = Some("foo.FooKt")
-
   def kotlinVersion = "1.9.24"
 
   object test extends KotlinTests {

--- a/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -48,7 +48,7 @@ trait KotlinModule extends JavaModule { outer =>
    */
   def kotlinVersion: T[String]
 
-  def allLocalMainClasses0 = Task {
+  def allLocalMainClasses0: T[Seq[String]] = Task {
     zincWorker().worker().discoverMainClasses(localRunClasspath().map(_.path))
   }
 

--- a/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -48,6 +48,10 @@ trait KotlinModule extends JavaModule { outer =>
    */
   def kotlinVersion: T[String]
 
+  def allLocalMainClasses0 = Task {
+    zincWorker().worker().discoverMainClasses(localRunClasspath().map(_.path))
+  }
+
   /**
    * The dependencies of this module.
    * Defaults to add the kotlin-stdlib dependency matching the [[kotlinVersion]].

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -115,6 +115,8 @@ trait JavaModule
    */
   def mainClass: T[Option[String]] = None
 
+  def allLocalMainClasses0 = Task { zincWorker().worker().discoverMainClasses(compile()) }
+
   def finalMainClassOpt: T[Either[String, String]] = Task {
     mainClass() match {
       case Some(m) => Right(m)

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -121,19 +121,14 @@ trait JavaModule
     mainClass() match {
       case Some(m) => Right(m)
       case None =>
-        if (zincWorker().javaHome().isDefined) {
-          super[RunModule].finalMainClassOpt()
-        } else {
-          zincWorker().worker().discoverMainClasses(compile()) match {
-            case Seq() => Left("No main class specified or found")
-            case Seq(main) => Right(main)
-            case mains =>
-              Left(
-                s"Multiple main classes found (${mains.mkString(",")}) " +
-                  "please explicitly specify which one to use by overriding `mainClass` " +
-                  "or using `runMain <main-class> <...args>` instead of `run`"
-              )
-          }
+        allLocalMainClasses() match {
+          case Seq() => Left("No main class specified or found")
+          case Seq(main) => Right(main)
+          case mains =>
+            Left(
+              s"Multiple main classes found (${mains.mkString(",")}) " +
+                "please explicitly specify which one to use by overriding mainClass"
+            )
         }
     }
   }

--- a/scalalib/src/mill/scalalib/RunModule.scala
+++ b/scalalib/src/mill/scalalib/RunModule.scala
@@ -45,20 +45,27 @@ trait RunModule extends WithZincWorker {
    */
   def mainClass: T[Option[String]] = None
 
+  /**
+   * Same as [[allLocalMainClasses]], but only for modules with a custom
+   * JVM version configured
+   */
+  def allLocalMainClasses0: T[Seq[String]] = Task { Seq.empty[String] }
+
+  /**
+   * All main classes detected in this module that can serve as program entrypoints
+   */
   def allLocalMainClasses: T[Seq[String]] = Task {
-    val classpath = localRunClasspath().map(_.path)
-    if (zincWorker().javaHome().isDefined) {
+    if (zincWorker().javaHome().isEmpty) allLocalMainClasses0()
+    else {
       Jvm.callProcess(
         mainClass = "mill.scalalib.worker.DiscoverMainClassesMain",
         classPath = zincWorker().classpath().map(_.path).toVector,
-        mainArgs = Seq(classpath.mkString(",")),
+        mainArgs = Seq(localRunClasspath().map(_.path).mkString(",")),
         javaHome = zincWorker().javaHome().map(_.path),
         stdin = os.Inherit,
         stdout = os.Pipe,
         cwd = Task.dest
       ).out.lines()
-    } else {
-      zincWorker().worker().discoverMainClasses(classpath)
     }
   }
 


### PR DESCRIPTION
Backports https://github.com/com-lihaoyi/mill/pull/4797

Fixes https://github.com/com-lihaoyi/mill/issues/4772

Previously it inherited the Zinc-based main class discovery via JavaModule, which overrode the generic classpath-scanning approach from RunModule. This PR adjusts the overrides such the KotlinModule uses the disk-based discovery API.

Removed all the now-unnecessary def mainClass annotations in the kotlinlib example tests, except for the one in example/kotlinlib/module/1-common-config that is useful for educational purposes.
