### PR TITLE
Add Mill 0.13 forward compatibility: `mill.util.JarManifest`

### DIFF
--- a/main/api/src/mill/api/JarManifest.scala
+++ b/main/api/src/mill/api/JarManifest.scala
@@ -10,6 +10,7 @@ import java.util.jar.{Attributes, Manifest}
  * @param main   the main manifest attributes
  * @param groups additional attributes for named entries
  */
+@deprecated("Use mill.uitl.JarManifest instead", "Mill 0.12.10")
 final class JarManifest private (
     val main: Map[String, String],
     val groups: Map[String, Map[String, String]]
@@ -44,6 +45,7 @@ final class JarManifest private (
   }
 }
 
+@deprecated("Use mill.uitl.JarManifest instead", "Mill 0.12.10")
 object JarManifest {
 
   final val Empty: JarManifest = JarManifest()

--- a/main/util/src/mill/util/package.scala
+++ b/main/util/src/mill/util/package.scala
@@ -1,0 +1,10 @@
+package mill
+
+import scala.annotation.nowarn
+
+package object util {
+  @nowarn("cat=deprecation")
+  type JarManifest = mill.api.JarManifest
+  @nowarn("cat=deprecation")
+  val JarManifest = mill.api.JarManifest
+}


### PR DESCRIPTION
JarManifest will be moved from mill.api.JarManifest in Mill 0.12 to mill.util.JarManifest in Mill 0.13.

This change already adds the new (by delegating to the old) and deprecates the old API, to assist in migration.

Tracker issue: https://github.com/com-lihaoyi/mill/issues/4716

