### PR TITLE
Use a `-native` suffix when installing a native image into the local cache (backport #4808)

### DIFF
--- a/dist/package.mill
+++ b/dist/package.mill
@@ -25,6 +25,8 @@ trait InstallModule extends build.MillPublishJavaModule {
 
   def localBinName: String
 
+  def cacheBinarySuffix: String = ""
+
   /**
    * Build and install Mill locally.
    *
@@ -41,7 +43,7 @@ trait InstallModule extends build.MillPublishJavaModule {
   def installLocalCache() = Task.Command {
     val path = installLocalTask(
       Task.Anon(
-        (os.home / ".cache/mill/download" / (build.millVersion() + batExt)).toString()
+        (os.home / ".cache/mill/download" / (build.millVersion() + cacheBinarySuffix + batExt)).toString()
       )
     )()
     Task.log.outputStream.println(path.toString())
@@ -306,6 +308,8 @@ object `package` extends RootModule with InstallModule {
     def nativeImageClasspath = build.runner.client.runClasspath()
 
     def localBinName = "mill-native"
+
+    def cacheBinarySuffix = "-native"
 
     def executableRaw = Task {
       val previous = nativeImage().path


### PR DESCRIPTION
Backport Pull request: https://github.com/com-lihaoyi/mill/pull/4808

