### PR TITLE
Backport "Standardize on filesystem-based main class discovery"

### DIFF
--- a/scalalib/test/src/mill/scalalib/ScalaRunTests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaRunTests.scala
@@ -23,7 +23,6 @@ object ScalaRunTests extends TestSuite {
   }
 
   def tests: Tests = Tests {
-
     test("runMain") {
       test("runMainObject") - UnitTester(HelloWorldTests.HelloWorld, resourcePath).scoped { eval =>
         val runResult = eval.outPath / "core/runMain.dest/hello-mill"

--- a/scalalib/test/src/mill/scalalib/ScalaRunTests.scala
+++ b/scalalib/test/src/mill/scalalib/ScalaRunTests.scala
@@ -23,6 +23,7 @@ object ScalaRunTests extends TestSuite {
   }
 
   def tests: Tests = Tests {
+
     test("runMain") {
       test("runMainObject") - UnitTester(HelloWorldTests.HelloWorld, resourcePath).scoped { eval =>
         val runResult = eval.outPath / "core/runMain.dest/hello-mill"


### PR DESCRIPTION
Backport of https://github.com/com-lihaoyi/mill/pull/4810

`DiscoverMainClassesMain` was previous missing top-level classes, which this PR fixes by replacing its unnecessarily complicated recursion code