### PR TITLE
Adjust logback outfile file upon startup

### DIFF
--- a/runner/client/src/mill/runner/client/MillClientMain.java
+++ b/runner/client/src/mill/runner/client/MillClientMain.java
@@ -17,6 +17,10 @@ import mill.constants.Util;
  */
 public class MillClientMain {
   public static void main(String[] args) throws Exception {
+
+    if (System.getProperty("mill.log.file") == null)
+      System.setProperty("mill.log.file", OutFiles.out + "/mill.log");
+
     boolean runNoServer = false;
     if (args.length > 0) {
       String firstArg = args[0];

--- a/runner/resources/logback.xml
+++ b/runner/resources/logback.xml
@@ -1,6 +1,6 @@
 <configuration debug="false" scan="false">
   <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-    <file>out/mill.log</file>
+    <file>${mill.log.file:-out/mill.log}</file>
       <encoder>
         <pattern>%date %level [%thread] %logger{36} %msg%n</pattern>
       </encoder>

--- a/runner/src/mill/runner/MillServerMain.scala
+++ b/runner/src/mill/runner/MillServerMain.scala
@@ -23,6 +23,8 @@ object MillServerMain {
       }
     )
 
+    MillMain.adjustLogbackOutputFile()
+
     val acceptTimeoutMillis =
       Try(System.getProperty("mill.server_timeout").toInt).getOrElse(30 * 60 * 1000) // 30 minutes
 


### PR DESCRIPTION
If anything in Mill logs with slf4j, logback is in charge of handling those logs. If ever the Mill out directory is customized, we need to adjust the logback log file location too, so that logs aren't written to the default `out/mill.log`.