### PR TITLE
Don't publish jansi in ~/.ivy2/local in integration test

### DIFF
--- a/integration/migrating/init/src/MillInitMavenTests.scala
+++ b/integration/migrating/init/src/MillInitMavenTests.scala
@@ -40,7 +40,10 @@ object MillInitMavenJansiTests extends BuildGenTestSuite {
         testRes.isSuccess
       )
 
-      val publishLocalRes = eval("publishLocal")
+      // Publish things locally, under a directory that shouldn't outlive the test,
+      // so that we don't pollute the user's ~/.ivy2/local
+      val ivy2Repo = tester.baseWorkspacePath / "ivy2Local"
+      val publishLocalRes = eval(("publishLocal", "--localIvyRepo", ivy2Repo.toString))
       assert(
         publishLocalRes.err.contains("Publishing Artifact(org.fusesource.jansi,jansi,2.4.1)"),
         publishLocalRes.isSuccess


### PR DESCRIPTION
This makes a test in `MillInitMavenTests` test local publishing by writing to a throw away directory, rather than the user's `~/.ivy2/local`, where the written files might be a problem.