### PR TITLE
Minor improvements to native distribution size

### DIFF
--- a/dist/package.mill
+++ b/dist/package.mill
@@ -328,7 +328,7 @@ object `package` extends RootModule with InstallModule {
       PathRef(executable)
     }
 
-    def nativeImageOptions = Seq("--no-fallback", "--enable-url-protocols=https")
+    def nativeImageOptions = Seq("--no-fallback", "--enable-url-protocols=https", "-Os")
 
     def zincWorker = ModuleRef(ZincWorkerGraalvm)
 

--- a/main/package.mill
+++ b/main/package.mill
@@ -24,6 +24,7 @@ object `package` extends RootModule with build.MillStableScalaModule with BuildI
     build.Deps.logback,
     build.Deps.jgraphtCore,
     ivy"guru.nidi:graphviz-java-min-deps:0.18.1"
+      .exclude("guru.nidi.com.eclipsesource.j2v8" -> "j2v8_macosx_x86_64")
   )
 
   def compileIvyDeps = Task {

--- a/main/package.mill
+++ b/main/package.mill
@@ -24,6 +24,8 @@ object `package` extends RootModule with build.MillStableScalaModule with BuildI
     build.Deps.logback,
     build.Deps.jgraphtCore,
     ivy"guru.nidi:graphviz-java-min-deps:0.18.1"
+      // We only need the in-memory library for some stuff, and don't
+      // need the heavyweight v8 binary that comes bundled with it
       .exclude("guru.nidi.com.eclipsesource.j2v8" -> "j2v8_macosx_x86_64")
   )
 


### PR DESCRIPTION
* Exclude  the `j2v8` binary since we don't use it in the main classpath, brings the native dist from 106M to 100M
* Turn on `-Os` in the graal config to try and optimize for size, bringing the native dist from 100M to 97M

Probably a lot more we can improve, but this is a start. Current breakdown is

* ~50mb for the main assembly jar
* ~20mb from Graal native image overhead
* ~30mb from Coursier compiled to Graal native, from the dependency on `courser-jvm` that pulls in all of coursier's various modules

```
[1-5997] Build resources:
[1-5997]  - 24.18GB of memory (75.6% of 32.00GB system memory, determined at start)
[1-5997]  - 10 thread(s) (100.0% of 10 available processor(s), determined at start)
[1-5997] [2/8] Performing analysis...  [*****]                                                                   (18.4s @ 1.08GB)
[1-5997]    12,208 reachable types   (87.0% of   14,033 total)
[1-5997]    16,561 reachable fields  (54.7% of   30,261 total)
[1-5997]    60,078 reachable methods (52.3% of  114,815 total)
[1-5997]     3,169 types,    19 fields, and   712 methods registered for reflection
[1-5997]        62 types,    62 fields, and    55 methods registered for JNI access
[1-5997]         5 native libraries: -framework CoreServices, -framework Foundation, dl, pthread, z
[1-5997] [3/8] Building universe...                                                                               (2.8s @ 1.14GB)
[1-5997] [4/8] Parsing methods...      [*]                                                                        (1.5s @ 1.25GB)
[1-5997] [5/8] Inlining methods...     [***]                                                                      (1.0s @ 1.42GB)
[1-5997] [6/8] Compiling methods...    [****]                                                                    (12.3s @ 1.09GB)
[1-5997] [7/8] Laying out methods...   [**]                                                                       (3.8s @ 1.40GB)
[1-5997] [8/8] Creating image...       [**]                                                                       (3.2s @ 1.61GB)
[1-5997]   20.81MB (44.71%) for code area:    36,048 compilation units
[1-5997]   24.88MB (53.44%) for image heap:  279,060 objects and 134 resources
[1-5997]  881.53kB ( 1.85%) for other data
[1-5997]   46.55MB in total
[1-5997] ------------------------------------------------------------------------------------------------------------------------
[1-5997] Top 10 origins of code area:                                Top 10 object types in image heap:
[1-5997]   10.13MB java.base                                            5.49MB byte[] for code metadata
[1-5997]    2.49MB java.xml                                             4.84MB byte[] for java.lang.String
[1-5997]    1.51MB coursier-core_2.13-2.1.25-M4.jar                     3.12MB java.lang.Class
[1-5997]    1.39MB scala-library-2.13.16.jar                            2.54MB java.lang.String
[1-5997]    1.10MB svm.jar (Native Image)                               1.02MB com.oracle.svm.core.hub.DynamicHubCompanio
[1-5997]  584.09kB coursier-cache_2.13-2.1.25-M4.jar                  832.18kB byte[] for general heap data
[1-5997]  522.39kB coursier-util_2.13-2.1.25-M4.jar                   758.92kB byte[] for embedded resources
[1-5997]  348.37kB tika-core-3.1.0.jar                                636.39kB byte[] for reflection metadata
[1-5997]  302.40kB commons-compress-1.27.1.jar                        536.25kB java.lang.String[]
[1-5997]  298.05kB java.rmi                                           513.00kB int[][]
[1-5997]    1.98MB for 49 more packages                                 4.66MB for 3593 more object types
```