### PR TITLE
Add `Dep.millProjectModule` to refer to mill project modules (backport #4790)

### DIFF
--- a/bsp/src/mill/bsp/BSP.scala
+++ b/bsp/src/mill/bsp/BSP.scala
@@ -1,19 +1,18 @@
 package mill.bsp
 
 import mill.api.{Ctx, PathRef}
-import mill.{Agg, T, Task, given}
+import mill.{Agg, T, Task}
 import mill.define.{Command, Discover, ExternalModule}
 import mill.main.BuildInfo
 import mill.eval.Evaluator
-import mill.util.Util.millProjectModule
-import mill.scalalib.CoursierModule
+import mill.scalalib.{CoursierModule, Dep}
 
 object BSP extends ExternalModule with CoursierModule {
 
   lazy val millDiscover: Discover = Discover[this.type]
 
   private def bspWorkerLibs: T[Agg[PathRef]] = Task {
-    millProjectModule("mill-bsp-worker", repositoriesTask())
+    defaultResolver().classpath(Seq(Dep.millProjectModule("mill-bsp-worker")))
   }
 
   /**

--- a/contrib/playlib/src/mill/playlib/RouterModule.scala
+++ b/contrib/playlib/src/mill/playlib/RouterModule.scala
@@ -1,7 +1,6 @@
 package mill.playlib
 
 import mill.api.PathRef
-import mill.util.Util.millProjectModule
 import mill.playlib.api.RouteCompilerType
 import mill.scalalib._
 import mill.scalalib.api._
@@ -75,15 +74,16 @@ trait RouterModule extends ScalaModule with Version {
   }
 
   def playRouteCompilerWorkerClasspath = Task {
-    millProjectModule(
-      s"mill-contrib-playlib-worker-${playMinorVersion()}",
-      repositoriesTask(),
-      artifactSuffix = playMinorVersion() match {
+    val minorVersion = playMinorVersion()
+    val dep = Dep.millProjectModule(
+      s"mill-contrib-playlib-worker-${minorVersion}",
+      artifactSuffix = minorVersion match {
         case "2.6" => "_2.12"
         case "2.7" | "2.8" => "_2.13"
         case _ => "_2.13"
       }
     )
+    defaultResolver().classpath(Seq(dep))
   }
 
   def playRouterToolsClasspath = Task {

--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
@@ -7,7 +7,6 @@ import mill.contrib.scoverage.api.ScoverageReportWorkerApi2.ReportType
 import mill.main.BuildInfo
 import mill.scalalib.api.ZincWorkerUtil
 import mill.scalalib.{Dep, DepSyntax, JavaModule, ScalaModule}
-import mill.util.Util.millProjectModule
 
 /**
  * Adds targets to a [[mill.scalalib.ScalaModule]] to create test coverage reports.
@@ -121,12 +120,9 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
   }
 
   def scoverageReportWorkerClasspath: T[Agg[PathRef]] = Task {
-    val workerArtifact = "mill-contrib-scoverage-worker2"
-
-    millProjectModule(
-      workerArtifact,
-      repositoriesTask()
-    )
+    defaultResolver().classpath(Seq(
+      Dep.millProjectModule("mill-contrib-scoverage-worker2")
+    ))
   }
 
   /** Inner worker module. This is not an `object` to allow users to override and customize it. */

--- a/contrib/testng/test/src/mill/testng/TestNGTests.scala
+++ b/contrib/testng/test/src/mill/testng/TestNGTests.scala
@@ -1,9 +1,7 @@
-package mill
-package testng
+package mill.testng
 
-import mill.define.Target
-import mill.util.Util.millProjectModule
-import mill.scalalib._
+import mill.{Agg, Task}
+import mill.scalalib.*
 import mill.testkit.UnitTester
 import mill.testkit.TestBaseModule
 import utest.{TestSuite, Tests, assert, _}
@@ -13,23 +11,13 @@ object TestNGTests extends TestSuite {
   object demo extends TestBaseModule with JavaModule {
 
     object test extends JavaTests {
-      def testngClasspath = Task {
-        millProjectModule(
-          "mill-contrib-testng",
-          repositoriesTask(),
-          artifactSuffix = ""
-        )
-      }
-
-      override def runClasspath: T[Seq[PathRef]] =
-        Task { super.runClasspath() ++ testngClasspath() }
-      override def ivyDeps = Task {
-        super.ivyDeps() ++
-          Agg(
-            ivy"org.testng:testng:6.11",
-            ivy"de.tototec:de.tobiasroeser.lambdatest:0.8.0"
-          )
-      }
+      override def runIvyDeps = super.runIvyDeps() ++ Seq(
+        Dep.millProjectModule("mill-contrib-testng", artifactSuffix = "")
+      )
+      override def ivyDeps = super.ivyDeps() ++ Seq(
+        ivy"org.testng:testng:6.11",
+        ivy"de.tototec:de.tobiasroeser.lambdatest:0.8.0"
+      )
       override def testFramework = Task {
         "mill.testng.TestNGFramework"
       }

--- a/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -13,7 +13,6 @@ import mill.scalalib.api.{CompilationResult, ZincWorkerApi}
 import mill.scalalib.bsp.{BspBuildTarget, BspModule}
 import mill.scalalib.{JavaModule, Lib, ZincWorkerModule}
 import mill.util.Jvm
-import mill.util.Util.millProjectModule
 import mill.{Agg, T}
 
 import java.io.File

--- a/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -90,10 +90,9 @@ trait KotlinModule extends JavaModule { outer =>
   protected def kotlinWorkerRef: ModuleRef[KotlinWorkerModule] = ModuleRef(KotlinWorkerModule)
 
   private[kotlinlib] def kotlinWorkerClasspath = Task {
-    millProjectModule(
-      "mill-kotlinlib-worker-impl",
-      repositoriesTask()
-    )
+    defaultResolver().classpath(Seq(
+      Dep.millProjectModule("mill-kotlinlib-worker-impl")
+    ))
   }
 
   /**

--- a/main/init/src/mill/init/BuildGenException.scala
+++ b/main/init/src/mill/init/BuildGenException.scala
@@ -1,0 +1,6 @@
+package mill.init
+
+import scala.util.control.NoStackTrace
+
+@mill.api.experimental
+case class BuildGenException(message: String) extends Exception(message) with NoStackTrace

--- a/main/init/src/mill/init/BuildGenModule.scala
+++ b/main/init/src/mill/init/BuildGenModule.scala
@@ -1,22 +1,22 @@
 package mill.init
 
-import coursier.LocalRepositories
-import coursier.core.Repository
-import coursier.maven.MavenRepository
-import mill.api.{Loose, PathRef, Result}
+import mill.api.PathRef
 import mill.main.buildgen.BuildGenUtil
+import mill.scalalib.{CoursierModule, Dep}
 import mill.scalalib.scalafmt.ScalafmtWorkerModule
-import mill.util.{Jvm, Util}
-import mill.{Command, T, Task, TaskModule}
-
-import scala.util.control.NoStackTrace
+import mill.util.Jvm
+import mill.{Agg, Command, T, Task, TaskModule}
 
 @mill.api.experimental
-trait BuildGenModule extends TaskModule {
+trait BuildGenModule extends CoursierModule with TaskModule {
 
   def defaultCommandName(): String = "init"
 
-  def buildGenClasspath: T[Loose.Agg[PathRef]]
+  def buildGenDeps: T[Seq[Dep]] = Task { Seq.empty[Dep] }
+
+  def buildGenClasspath: T[Agg[PathRef]] = Task {
+    defaultResolver().classpath(buildGenDeps())
+  }
 
   def buildGenMainClass: T[String]
 
@@ -48,18 +48,3 @@ trait BuildGenModule extends TaskModule {
     }
   }
 }
-@mill.api.experimental
-object BuildGenModule {
-
-  def millModule(artifact: String): Result[Loose.Agg[PathRef]] =
-    Util.millProjectModule(artifact, millRepositories)
-
-  def millRepositories: Seq[Repository] = Seq(
-    LocalRepositories.ivy2Local,
-    MavenRepository("https://repo1.maven.org/maven2"),
-    MavenRepository("https://oss.sonatype.org/content/repositories/releases")
-  )
-}
-
-@mill.api.experimental
-case class BuildGenException(message: String) extends Exception(message) with NoStackTrace

--- a/main/init/src/mill/init/InitGradleModule.scala
+++ b/main/init/src/mill/init/InitGradleModule.scala
@@ -3,13 +3,14 @@ package mill.init
 import mill.T
 import mill.define.{Discover, ExternalModule}
 import mill.scalalib.Dep
+import mill.define.Target
 
 @mill.api.experimental
 object InitGradleModule extends ExternalModule with BuildGenModule {
 
   lazy val millDiscover: Discover = Discover[this.type]
 
-  override def buildGenDeps = super.buildGenDeps() ++ Seq(
+  override def buildGenDeps: Target[Seq[Dep]] = super.buildGenDeps() ++ Seq(
     Dep.millProjectModule("mill-main-init-gradle")
   )
 

--- a/main/init/src/mill/init/InitGradleModule.scala
+++ b/main/init/src/mill/init/InitGradleModule.scala
@@ -1,15 +1,17 @@
 package mill.init
 
 import mill.T
-import mill.api.{Loose, PathRef}
 import mill.define.{Discover, ExternalModule}
+import mill.scalalib.Dep
 
 @mill.api.experimental
 object InitGradleModule extends ExternalModule with BuildGenModule {
 
   lazy val millDiscover: Discover = Discover[this.type]
 
-  def buildGenClasspath: T[Loose.Agg[PathRef]] = BuildGenModule.millModule("mill-main-init-gradle")
+  override def buildGenDeps = super.buildGenDeps() ++ Seq(
+    Dep.millProjectModule("mill-main-init-gradle")
+  )
 
   def buildGenMainClass: T[String] = "mill.main.gradle.GradleBuildGenMain"
 }

--- a/main/init/src/mill/init/InitMavenModule.scala
+++ b/main/init/src/mill/init/InitMavenModule.scala
@@ -1,15 +1,17 @@
 package mill.init
 
 import mill.T
-import mill.api.{Loose, PathRef}
 import mill.define.{Discover, ExternalModule}
+import mill.scalalib.Dep
 
 @mill.api.experimental
 object InitMavenModule extends ExternalModule with BuildGenModule {
 
   lazy val millDiscover: Discover = Discover[this.type]
 
-  def buildGenClasspath: T[Loose.Agg[PathRef]] = BuildGenModule.millModule("mill-main-init-maven")
+  override def buildGenDeps = super.buildGenDeps() ++ Seq(
+    Dep.millProjectModule("mill-main-init-maven")
+  )
 
   def buildGenMainClass: T[String] = "mill.main.maven.MavenBuildGenMain"
 }

--- a/main/init/src/mill/init/InitMavenModule.scala
+++ b/main/init/src/mill/init/InitMavenModule.scala
@@ -3,13 +3,14 @@ package mill.init
 import mill.T
 import mill.define.{Discover, ExternalModule}
 import mill.scalalib.Dep
+import mill.define.Target
 
 @mill.api.experimental
 object InitMavenModule extends ExternalModule with BuildGenModule {
 
   lazy val millDiscover: Discover = Discover[this.type]
 
-  override def buildGenDeps = super.buildGenDeps() ++ Seq(
+  override def buildGenDeps: Target[Seq[Dep]] = super.buildGenDeps() ++ Seq(
     Dep.millProjectModule("mill-main-init-maven")
   )
 

--- a/main/init/src/mill/init/InitSbtModule.scala
+++ b/main/init/src/mill/init/InitSbtModule.scala
@@ -1,14 +1,16 @@
 package mill.init
 
 import mill.T
-import mill.api.{Loose, PathRef}
 import mill.define.{Discover, ExternalModule}
+import mill.scalalib.Dep
 
 @mill.api.experimental
 object InitSbtModule extends ExternalModule with BuildGenModule {
   lazy val millDiscover = Discover[this.type]
 
-  def buildGenClasspath: T[Loose.Agg[PathRef]] = BuildGenModule.millModule("mill-main-init-sbt")
+  override def buildGenDeps = super.buildGenDeps() ++ Seq(
+    Dep.millProjectModule("mill-main-init-sbt")
+  )
 
   def buildGenMainClass: T[String] = "mill.main.sbt.SbtBuildGenMain"
 }

--- a/main/init/src/mill/init/InitSbtModule.scala
+++ b/main/init/src/mill/init/InitSbtModule.scala
@@ -3,12 +3,13 @@ package mill.init
 import mill.T
 import mill.define.{Discover, ExternalModule}
 import mill.scalalib.Dep
+import mill.define.Target
 
 @mill.api.experimental
 object InitSbtModule extends ExternalModule with BuildGenModule {
   lazy val millDiscover = Discover[this.type]
 
-  override def buildGenDeps = super.buildGenDeps() ++ Seq(
+  override def buildGenDeps: Target[Seq[Dep]] = super.buildGenDeps() ++ Seq(
     Dep.millProjectModule("mill-main-init-sbt")
   )
 

--- a/main/src/mill/main/VisualizeModule.scala
+++ b/main/src/mill/main/VisualizeModule.scala
@@ -11,7 +11,6 @@ import mill.define.Worker
 import org.jgrapht.graph.{DefaultEdge, SimpleDirectedGraph}
 import guru.nidi.graphviz.attribute.Rank.RankDir
 import guru.nidi.graphviz.attribute.{Rank, Shape, Style}
-import mill.Agg
 import mill.eval.Graph
 
 object VisualizeModule extends ExternalModule with VisualizeModule {
@@ -30,7 +29,7 @@ trait VisualizeModule extends mill.define.TaskModule {
   @deprecated("Use toolsClasspath instead", "0.13.0-M1")
   def classpath: Target[Loose.Agg[PathRef]] = toolsClasspath
 
-  def toolsClasspath: Target[Agg[PathRef]] = Target {
+  def toolsClasspath: Target[Loose.Agg[PathRef]] = Target {
     millProjectModule("mill-main-graphviz", repositories)
   }
 

--- a/main/src/mill/main/VisualizeModule.scala
+++ b/main/src/mill/main/VisualizeModule.scala
@@ -11,6 +11,7 @@ import mill.define.Worker
 import org.jgrapht.graph.{DefaultEdge, SimpleDirectedGraph}
 import guru.nidi.graphviz.attribute.Rank.RankDir
 import guru.nidi.graphviz.attribute.{Rank, Shape, Style}
+import mill.Agg
 import mill.eval.Graph
 
 object VisualizeModule extends ExternalModule with VisualizeModule {
@@ -22,10 +23,14 @@ object VisualizeModule extends ExternalModule with VisualizeModule {
 
   lazy val millDiscover: Discover = Discover[this.type]
 }
+
 trait VisualizeModule extends mill.define.TaskModule {
   def repositories: Seq[Repository]
   def defaultCommandName() = "run"
-  def classpath: Target[Loose.Agg[PathRef]] = Target {
+  @deprecated("Use toolsClasspath instead", "0.13.0-M1")
+  def classpath: Target[Loose.Agg[PathRef]] = toolsClasspath
+
+  def toolsClasspath: Target[Agg[PathRef]] = Target {
     millProjectModule("mill-main-graphviz", repositories)
   }
 
@@ -104,7 +109,7 @@ trait VisualizeModule extends mill.define.TaskModule {
 
           mill.util.Jvm.callProcess(
             mainClass = "mill.main.graphviz.GraphvizTools",
-            classPath = classpath().map(_.path).toVector,
+            classPath = toolsClasspath().map(_.path).toVector,
             mainArgs = Seq(s"${os.temp(g.toString)};$dest;txt,dot,json,png,svg"),
             stdin = os.Inherit,
             stdout = os.Inherit

--- a/main/util/src/mill/util/MillModuleUtil.scala
+++ b/main/util/src/mill/util/MillModuleUtil.scala
@@ -1,0 +1,51 @@
+package mill.util
+
+import coursier.Repository
+
+import mill.api.{BuildInfo, PathRef, Result}
+import mill.api.Loose.Agg
+
+import java.nio.file.{Files, Paths}
+
+private[mill] object MillModuleUtil {
+
+  /**
+   * Deprecated helper method, intended to allow runtime resolution and in-development-tree testings of mill plugins possible.
+   * This design has issues and will probably be replaced.
+   */
+  @deprecated("Use Dep.millProjectModule instead", "Mill 0.13.0-M1")
+  private[mill] def millProjectModule(
+      artifact: String,
+      repositories: Seq[Repository],
+      // this should correspond to the mill runtime Scala version
+      artifactSuffix: String = "_3"
+  ): Result[Agg[PathRef]] = {
+
+    mill.util.Jvm.resolveDependencies(
+      repositories = repositories,
+      deps = Seq(
+        coursier.Dependency(
+          coursier.Module(
+            coursier.Organization("com.lihaoyi"),
+            coursier.ModuleName(artifact + artifactSuffix)
+          ),
+          coursier.VersionConstraint(BuildInfo.millVersion)
+        )
+      ),
+      force = Nil
+    ).map(_.map(_.withRevalidateOnce))
+  }
+
+  private val LongMillProps = new java.util.Properties()
+
+  {
+    val millOptionsPath = sys.props("MILL_OPTIONS_PATH")
+    if (millOptionsPath != null)
+      LongMillProps.load(Files.newInputStream(Paths.get(millOptionsPath)))
+  }
+
+  def millProperty(key: String): Option[String] =
+    Option(sys.props(key)) // System property has priority
+      .orElse(Option(LongMillProps.getProperty(key)))
+
+}

--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -50,10 +50,9 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
   }
 
   def scalaJSWorkerClasspath = Task {
-    mill.util.Util.millProjectModule(
-      artifact = s"mill-scalajslib-worker-${scalaJSWorkerVersion()}",
-      repositories = repositoriesTask()
-    )
+    defaultResolver().classpath(Seq(
+      Dep.millProjectModule(s"mill-scalajslib-worker-${scalaJSWorkerVersion()}")
+    ))
   }
 
   def scalaJSJsEnvIvyDeps: T[Agg[Dep]] = Task {

--- a/scalalib/src/mill/scalalib/CoursierModule.scala
+++ b/scalalib/src/mill/scalalib/CoursierModule.scala
@@ -35,10 +35,10 @@ trait CoursierModule extends mill.Module {
   }
 
   /**
-   * A `CoursierModule.Resolver` to resolve dependencies.
+   * A [[CoursierModule.Resolver]] to resolve dependencies.
    *
-   * Unlike `defaultResolver`, this resolver can resolve Mill modules too
-   * (obtained via `JavaModule#coursierDependency`).
+   * Unlike [[defaultResolver]], this resolver can resolve Mill modules too
+   * (obtained via [[JavaModule.coursierDependency]]).
    *
    * @return `CoursierModule.Resolver` instance
    */

--- a/scalalib/src/mill/scalalib/Dep.scala
+++ b/scalalib/src/mill/scalalib/Dep.scala
@@ -1,7 +1,7 @@
 package mill.scalalib
 
-import upickle.default.{macroRW, ReadWriter as RW}
-import mill.scalalib.CrossVersion.*
+import upickle.default.{macroRW, ReadWriter => RW}
+import mill.scalalib.CrossVersion._
 import coursier.core.{Configuration, Dependency, MinimizedExclusions}
 import mill.scalalib.api.{Versions, ZincWorkerUtil}
 import scala.annotation.unused
@@ -164,6 +164,7 @@ object Dep {
 
     prospective.filter(parse(_) == dep)
   }
+
   private val rw0: RW[Dep] = macroRW
 
   // Use literal JSON strings for common cases so that files
@@ -199,12 +200,19 @@ object Dep {
 
   /**
    * Convenience to access Mill modules as dependencies, e.g. to load the into worker classpaths.
-   * @param artifactName The module artifact name
+   *
+   * @param artifactName   The module artifact name
    * @param artifactSuffix The artifact suffix typically representing the Scala version.
    *                       Defaults to the Scala binary platform Mill runs on.
    */
-  private[mill] def millProjectModule(artifactName: String, artifactSuffix: String = "_2.13"): Dep =
-    ivy"com.lihaoyi:${artifactName}${artifactSuffix}:${Versions.millVersion}"
+  private[mill] def millProjectModule(
+      artifactName: String,
+      artifactSuffix: String = "_2.13"
+  ): Dep = {
+    // we don't use `ivy` string context here to avoid a cyclic dependency
+    val dep = s"com.lihaoyi:${artifactName}${artifactSuffix}:${Versions.millVersion}"
+    Dep.parse(dep)
+  }
 
 }
 
@@ -271,7 +279,8 @@ case class BoundDep(
     dep = dep.withMinimizedExclusions(
       dep.minimizedExclusions.join(MinimizedExclusions(
         exclusions.toSet.map[(coursier.Organization, coursier.ModuleName)] {
-          case (k: String, v: String) => (coursier.Organization(k), coursier.ModuleName(v))}
+          case (k: String, v: String) => (coursier.Organization(k), coursier.ModuleName(v))
+        }
       ))
     )
   )

--- a/scalalib/src/mill/scalalib/Dep.scala
+++ b/scalalib/src/mill/scalalib/Dep.scala
@@ -1,12 +1,10 @@
 package mill.scalalib
 
-import upickle.default.{macroRW, ReadWriter => RW}
-import mill.scalalib.CrossVersion._
-import coursier.core.Dependency
-import mill.scalalib.api.ZincWorkerUtil
-
+import upickle.default.{macroRW, ReadWriter as RW}
+import mill.scalalib.CrossVersion.*
+import coursier.core.{Configuration, Dependency, MinimizedExclusions}
+import mill.scalalib.api.{Versions, ZincWorkerUtil}
 import scala.annotation.unused
-import coursier.core.Configuration
 
 case class Dep(dep: coursier.Dependency, cross: CrossVersion, force: Boolean) {
   require(
@@ -199,6 +197,15 @@ object Dep {
     )
   }
 
+  /**
+   * Convenience to access Mill modules as dependencies, e.g. to load the into worker classpaths.
+   * @param artifactName The module artifact name
+   * @param artifactSuffix The artifact suffix typically representing the Scala version.
+   *                       Defaults to the Scala binary platform Mill runs on.
+   */
+  private[mill] def millProjectModule(artifactName: String, artifactSuffix: String = "_2.13"): Dep =
+    ivy"com.lihaoyi:${artifactName}${artifactSuffix}:${Versions.millVersion}"
+
 }
 
 sealed trait CrossVersion {
@@ -256,14 +263,16 @@ case class BoundDep(
 ) {
   def organization = dep.module.organization.value
   def name = dep.module.name.value
-  def version = dep.version
+  def version = dep.versionConstraint.asString
 
   def toDep: Dep = Dep(dep = dep, cross = CrossVersion.empty(false), force = force)
 
   def exclude(exclusions: (String, String)*): BoundDep = copy(
-    dep = dep.withExclusions(
-      dep.exclusions() ++
-        exclusions.map { case (k, v) => (coursier.Organization(k), coursier.ModuleName(v)) }
+    dep = dep.withMinimizedExclusions(
+      dep.minimizedExclusions.join(MinimizedExclusions(
+        exclusions.toSet.map[(coursier.Organization, coursier.ModuleName)] {
+          case (k: String, v: String) => (coursier.Organization(k), coursier.ModuleName(v))}
+      ))
     )
   )
 }

--- a/scalalib/src/mill/scalalib/ZincWorkerModule.scala
+++ b/scalalib/src/mill/scalalib/ZincWorkerModule.scala
@@ -9,7 +9,6 @@ import mill.scalalib.Lib.resolveDependencies
 import mill.scalalib.api.ZincWorkerUtil.{isBinaryBridgeAvailable, isDotty, isDottyOrScala3}
 import mill.scalalib.api.{Versions, ZincWorkerApi, ZincWorkerUtil}
 import mill.scalalib.CoursierModule.Resolver
-import mill.util.Util.millProjectModule
 
 /**
  * A default implementation of [[ZincWorkerModule]]
@@ -28,23 +27,27 @@ trait ZincWorkerModule extends mill.Module with OfflineSupportModule with Coursi
     mill.scalalib.api.Versions.coursierJvmIndexVersion
 
   def classpath: T[Agg[PathRef]] = Task {
-    millProjectModule("mill-scalalib-worker", repositoriesTask())
+    defaultResolver().classpath(Seq(
+      Dep.millProjectModule("mill-scalalib-worker")
+    ))
   }
 
   def scalalibClasspath: T[Agg[PathRef]] = Task {
-    millProjectModule("mill-scalalib", repositoriesTask())
+    defaultResolver().classpath(Seq(
+      Dep.millProjectModule("mill-scalalib")
+    ))
   }
 
   def testrunnerEntrypointClasspath: T[Agg[PathRef]] = Task {
-    millProjectModule("mill-testrunner-entrypoint", repositoriesTask(), artifactSuffix = "")
+    defaultResolver().classpath(Seq(
+      Dep.millProjectModule("mill-testrunner-entrypoint", artifactSuffix = "")
+    ))
   }
 
   def backgroundWrapperClasspath: T[Agg[PathRef]] = Task {
-    millProjectModule(
-      "mill-scalalib-backgroundwrapper",
-      repositoriesTask(),
-      artifactSuffix = ""
-    )
+    defaultResolver().classpath(Seq(
+      Dep.millProjectModule("mill-scalalib-backgroundwrapper", artifactSuffix = "")
+    ))
   }
 
   def zincLogDebug: T[Boolean] = Task.Input(Task.ctx().log.debugEnabled)

--- a/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
+++ b/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
@@ -5,7 +5,6 @@ import mainargs.Flag
 import mill.api.Loose.Agg
 import mill.api.{Result, internal}
 import mill.define.{Command, Task}
-import mill.util.Util.millProjectModule
 import mill.scalalib.api.ZincWorkerUtil
 import mill.scalalib.bsp.{ScalaBuildTarget, ScalaPlatform}
 import mill.scalalib.{CrossVersion, Dep, DepSyntax, Lib, SbtModule, ScalaModule, TestModule}
@@ -40,10 +39,9 @@ trait ScalaNativeModule extends ScalaModule { outer =>
     Task { ZincWorkerUtil.scalaNativeWorkerVersion(scalaNativeVersion()) }
 
   def scalaNativeWorkerClasspath = Task {
-    millProjectModule(
-      s"mill-scalanativelib-worker-${scalaNativeWorkerVersion()}",
-      repositoriesTask()
-    )
+    defaultResolver().classpath(Seq(
+      Dep.millProjectModule(s"mill-scalanativelib-worker-${scalaNativeWorkerVersion()}")
+    ))
   }
 
   def toolsIvyDeps = Task {


### PR DESCRIPTION
This is meant as a replacement for
`mill.util.ModuleUtils.millProjectModule`, which I annotated as deprecated.

The main motivation for this change is to handle mill module
dependencies more regular. Since they can be resolved together with
other dependencies, this should result in better conflict resolution.
The older API rather forces us to concat two potential redundant or
conflicting classpaths.

There is one last usage of the older `ModuleUtils.millProjectModule`
from `VisualizeModule`, which resides in `mill.main` and can't access
`CoursierModule` or `Dep`. Don't know how to best handle it.

Original pull request: https://github.com/com-lihaoyi/mill/pull/4790

