### PR TITLE
Mill 2.13 Compat: Add `Logger.streams`

### DIFF
--- a/bsp/src/mill/bsp/BspContext.scala
+++ b/bsp/src/mill/bsp/BspContext.scala
@@ -44,19 +44,21 @@ private[mill] class BspContext(
       logStream: Option[PrintStream],
       canReload: Boolean
   ): Either[String, BspServerHandle] = {
+    // avoid name collision
+    val outerStreams = streams
     val log: Logger = new Logger {
       override def colored: Boolean = false
       override def systemStreams: SystemStreams = new SystemStreams(
-        out = streams.out,
-        err = streams.err,
+        out = outerStreams.out,
+        err = outerStreams.err,
         in = DummyInputStream
       )
 
-      override def info(s: String): Unit = streams.err.println(s)
-      override def error(s: String): Unit = streams.err.println(s)
-      override def ticker(s: String): Unit = streams.err.println(s)
-      override def setPromptDetail(key: Seq[String], s: String): Unit = streams.err.println(s)
-      override def debug(s: String): Unit = streams.err.println(s)
+      override def info(s: String): Unit = outerStreams.err.println(s)
+      override def error(s: String): Unit = outerStreams.err.println(s)
+      override def ticker(s: String): Unit = outerStreams.err.println(s)
+      override def setPromptDetail(key: Seq[String], s: String): Unit = outerStreams.err.println(s)
+      override def debug(s: String): Unit = outerStreams.err.println(s)
 
       override def debugEnabled: Boolean = true
 

--- a/main/api/src/mill/api/Logger.scala
+++ b/main/api/src/mill/api/Logger.scala
@@ -1,6 +1,7 @@
 package mill.api
 
 import java.io.{InputStream, PrintStream}
+import scala.annotation.nowarn
 
 /**
  * The standard logging interface of the Mill build tool.
@@ -30,9 +31,14 @@ trait Logger extends AutoCloseable {
   def colored: Boolean
 
   private[mill] def unprefixedSystemStreams: SystemStreams = systemStreams
+  @deprecated("For read-access use `streams` instead", "Mill 0.12.11")
   def systemStreams: SystemStreams
+  @nowarn("cat=deprecation")
+  def streams = systemStreams
 
+  @deprecated("Use streams.err instead", "Mill 0.12.11")
   def errorStream: PrintStream = systemStreams.err
+  @deprecated("Use streams.out instead", "Mill 0.12.11")
   def outputStream: PrintStream = systemStreams.out
 
   /**


### PR DESCRIPTION
Allow users to replace the deprecated API calls `Logger.{input,error}Stream` with `Logger.streams.{out,err}`.

Tracker: https://github.com/com-lihaoyi/mill/issues/4716

