### PR TITLE
Mill 0.13 Compat: Add `Module.{moduleDir,moduleInternal,moduleSegments}`

### DIFF
--- a/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -602,7 +602,7 @@ private class MillBuildServer(
             val mainModule = new MainModule {
               override implicit def millDiscover: Discover = Discover[this.type]
             }
-            val compileTargetName = (module.millModuleSegments ++ Label("compile")).render
+            val compileTargetName = (module.moduleSegments ++ Label("compile")).render
             debug(s"about to clean: ${compileTargetName}")
             val cleanTask = mainModule.clean(ev, Seq(compileTargetName): _*)
             val cleanResult = evaluate(
@@ -623,7 +623,7 @@ private class MillBuildServer(
             )
             else {
               val outPaths = ev.pathsResolver.resolveDest(
-                module.millModuleSegments ++ Label("compile")
+                module.moduleSegments ++ Label("compile")
               )
               val outPathSeq = Seq(outPaths.dest, outPaths.meta, outPaths.log)
 

--- a/bsp/worker/src/mill/bsp/worker/State.scala
+++ b/bsp/worker/src/mill/bsp/worker/State.scala
@@ -20,9 +20,9 @@ private class State(
         modules.collect {
           case m: BspModule =>
             val uri = Utils.sanitizeUri(
-              rootModule.millSourcePath /
+              rootModule.moduleDir /
                 m.millOuterCtx.foreign.fold(List.empty[String])(_.parts) /
-                m.millModuleSegments.parts
+                m.moduleSegments.parts
             )
 
             (new BuildTargetIdentifier(uri), (m, eval))

--- a/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
+++ b/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
@@ -507,7 +507,7 @@ class BloopImpl(
 
       BloopConfig.Project(
         name = name(module),
-        directory = module.millSourcePath.toNIO,
+        directory = module.moduleDir.toNIO,
         workspaceDir = Some(wd.toNIO),
         sources = mSources,
         sourcesGlobs = None,

--- a/contrib/playlib/src/mill/playlib/PlayModule.scala
+++ b/contrib/playlib/src/mill/playlib/PlayModule.scala
@@ -19,7 +19,7 @@ trait PlayApiModule extends Dependencies with Router with Server {
       }
       Agg(ivy"org.scalatestplus.play::scalatestplus-play::${scalatestPlusPlayVersion}")
     }
-    override def sources: Target[Seq[PathRef]] = Task.Sources { millSourcePath }
+    override def sources: Target[Seq[PathRef]] = Task.Sources(moduleDir)
   }
 
   def start(args: Task[Args] = Task.Anon(Args())) = Task.Command { run(args)() }

--- a/contrib/playlib/src/mill/playlib/Static.scala
+++ b/contrib/playlib/src/mill/playlib/Static.scala
@@ -25,7 +25,7 @@ trait Static extends ScalaModule {
   /**
    *  Directories to include assets from
    */
-  def assetSources = Task.Sources { millSourcePath / assetsPath() }
+  def assetSources = Task.Sources { moduleDir / assetsPath() }
 
   /*
   Collected static assets for the project

--- a/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBModule.scala
+++ b/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBModule.scala
@@ -53,7 +53,7 @@ trait ScalaPBModule extends ScalaModule {
   def scalaPBProtocPath: T[Option[String]] = Task { None }
 
   def scalaPBSources: T[Seq[PathRef]] = Task.Sources {
-    millSourcePath / "protobuf"
+    moduleDir / "protobuf"
   }
 
   def scalaPBOptions: T[String] = Task {

--- a/contrib/twirllib/src/mill/twirllib/TwirlModule.scala
+++ b/contrib/twirllib/src/mill/twirllib/TwirlModule.scala
@@ -25,9 +25,7 @@ trait TwirlModule extends mill.Module { twirlModule =>
     }
   }
 
-  def twirlSources: T[Seq[PathRef]] = Task.Sources {
-    millSourcePath / "views"
-  }
+  def twirlSources: T[Seq[PathRef]] = Task.Sources("views")
 
   /**
    * Replicate the logic from twirl build,

--- a/idea/src/mill/idea/GenIdeaImpl.scala
+++ b/idea/src/mill/idea/GenIdeaImpl.scala
@@ -981,7 +981,7 @@ case class GenIdeaImpl(
         {
       for ((((plugins, params), mods), i) <- settings.toSeq.zip(1 to settings.size))
         yield <profile name={s"mill $i"} modules={
-          mods.map(m => moduleName(m.millModuleSegments)).mkString(",")
+          mods.map(m => moduleName(m.moduleSegments)).mkString(",")
         }>
             <parameters>
               {
@@ -1006,7 +1006,7 @@ object GenIdeaImpl {
 
   /**
    * Create the module name (to be used by Idea) for the module based on it segments.
-   * @see [[Module.millModuleSegments]]
+   * @see [[Module.moduleSegments]]
    */
   def moduleName(p: Segments): String =
     p.value

--- a/idea/src/mill/idea/GenIdeaImpl.scala
+++ b/idea/src/mill/idea/GenIdeaImpl.scala
@@ -24,7 +24,7 @@ case class GenIdeaImpl(
 )(implicit ctx: Ctx) {
   import GenIdeaImpl._
 
-  val workDir: os.Path = evaluators.head.rootModule.millSourcePath
+  val workDir: os.Path = evaluators.head.rootModule.moduleDir
   val ideaDir: os.Path = workDir / ".idea"
 
   val ideaConfigVersion = 4
@@ -81,8 +81,8 @@ case class GenIdeaImpl(
       .flatMap { case (rootMod, transModules, ev, idx) =>
         transModules.collect {
           case m: Module =>
-            val rootSegs = rootMod.millSourcePath.relativeTo(workDir).segments
-            val modSegs = m.millModuleSegments.parts
+            val rootSegs = rootMod.moduleDir.relativeTo(workDir).segments
+            val modSegs = m.moduleSegments.parts
             val segments: Seq[String] = rootSegs ++ modSegs
             (Segments(segments.map(Segment.Label)), m, ev)
         }

--- a/javascriptlib/src/mill/javascriptlib/PublishModule.scala
+++ b/javascriptlib/src/mill/javascriptlib/PublishModule.scala
@@ -20,7 +20,7 @@ trait PublishModule extends TypeScriptModule {
 
   private def pubDeclarationOut: T[String] = Task { "declarations" }
 
-  override def mainFileName: T[String] = Task { s"${millSourcePath.last}.js" }
+  override def mainFileName: T[String] = Task { s"${moduleDir.last}.js" }
 
   // main file; defined with mainFileName
   def pubMain: T[String] =
@@ -82,7 +82,7 @@ trait PublishModule extends TypeScriptModule {
 
   // Compilation Options
   override def modulePaths: Task[Seq[(String, String)]] = Task.Anon {
-    val module = millSourcePath.last
+    val module = moduleDir.last
 
     Seq((s"$module/*", "typescript/src" + ":" + s"${pubDeclarationOut()}")) ++
       resources().map { rp =>
@@ -99,7 +99,7 @@ trait PublishModule extends TypeScriptModule {
   }
 
   private def pubModDeps: T[Seq[String]] = Task {
-    moduleDeps.map { _.millSourcePath.subRelativeTo(Task.workspace).segments.head }.distinct
+    moduleDeps.map { _.moduleDir.subRelativeTo(Task.workspace).segments.head }.distinct
   }
 
   private def pubModDepsSources: T[Seq[PathRef]] = Task {
@@ -155,8 +155,8 @@ trait PublishModule extends TypeScriptModule {
   }
 
   override def resources: T[Seq[PathRef]] = Task {
-    val modDepsResources = moduleDeps.map { x => PathRef(x.millSourcePath / "resources") }
-    Seq(PathRef(millSourcePath / "resources")) ++ modDepsResources
+    val modDepsResources = moduleDeps.map { x => PathRef(x.moduleDir / "resources") }
+    Seq(PathRef(moduleDir / "resources")) ++ modDepsResources
   }
 
   /**
@@ -171,7 +171,7 @@ trait PublishModule extends TypeScriptModule {
           os.walk(pr.path)
         ).filter(fileExt)
     } yield source.toString
-      .replaceFirst(millSourcePath.toString, "typescript")
+      .replaceFirst(moduleDir.toString, "typescript")
       .replaceFirst(
         project,
         "typescript"
@@ -190,14 +190,14 @@ trait PublishModule extends TypeScriptModule {
     val upstreams = (for {
       (res, mod) <- Task.traverse(moduleDeps)(_.resources)().zip(moduleDeps)
     } yield {
-      val relative = mod.millSourcePath.subRelativeTo(Task.workspace)
+      val relative = mod.moduleDir.subRelativeTo(Task.workspace)
       Seq((
-        mod.millSourcePath.subRelativeTo(Task.workspace).toString + "/*",
+        mod.moduleDir.subRelativeTo(Task.workspace).toString + "/*",
         s"typescript/$relative/src:${pubDeclarationOut()}"
       )) ++
         res.map { rp =>
           val resourceRoot = rp.path.last
-          val modName = mod.millSourcePath.subRelativeTo(Task.workspace).toString
+          val modName = mod.moduleDir.subRelativeTo(Task.workspace).toString
           // nb: resources are be moved in bundled stage
           (
             s"@$modName/$resourceRoot/*",
@@ -277,7 +277,7 @@ trait PublishModule extends TypeScriptModule {
         "files" -> pubAllSources()
       )
     )
-    os.copy(millSourcePath, publishDir().path / "typescript", mergeFolders = true)
+    os.copy(moduleDir, publishDir().path / "typescript", mergeFolders = true)
     pubCopyModDeps()
     pubGenSources()
     // Run type check, build declarations

--- a/javascriptlib/src/mill/javascriptlib/ReactScriptsModule.scala
+++ b/javascriptlib/src/mill/javascriptlib/ReactScriptsModule.scala
@@ -27,7 +27,7 @@ trait ReactScriptsModule extends TypeScriptModule {
     )
   }
 
-  override def sources: Target[PathRef] = Task.Source(millSourcePath)
+  override def sources: Target[PathRef] = Task.Source(moduleDir)
 
   def packageJestOptions: Target[ujson.Obj] = Task {
     ujson.Obj(

--- a/javascriptlib/src/mill/javascriptlib/TestModule.scala
+++ b/javascriptlib/src/mill/javascriptlib/TestModule.scala
@@ -95,7 +95,7 @@ object TestModule {
         val stuUpstreams = for {
           ((_, ts), mod) <- Task.traverse(moduleDeps)(_.compile)().zip(moduleDeps)
         } yield (
-          mod.millSourcePath.subRelativeTo(Task.workspace).toString + "/test/utils/*",
+          mod.moduleDir.subRelativeTo(Task.workspace).toString + "/test/utils/*",
           (ts.path / "test/src/utils").toString
         )
 

--- a/javascriptlib/src/mill/javascriptlib/TsLintModule.scala
+++ b/javascriptlib/src/mill/javascriptlib/TsLintModule.scala
@@ -73,7 +73,7 @@ trait TsLintModule extends Module {
         val replacements = Seq(
           s"$cwd/" -> "",
           "potentially fixable with the `--fix` option" ->
-            s"potentially fixable with running ${millSourcePath.last}.reformatAll"
+            s"potentially fixable with running ${moduleDir.last}.reformatAll"
         )
 
         os.remove(cwd / "node_modules")
@@ -154,7 +154,7 @@ trait TsLintModule extends Module {
             val lines = os.read.lines(logPath)
             val logMssg = lines.map(_.replace(
               "[warn] Code style issues found in the above file. Run Prettier with --write to fix.",
-              s"[warn] Code style issues found. Run ${millSourcePath.last}.reformatAll to fix."
+              s"[warn] Code style issues found. Run ${moduleDir.last}.reformatAll to fix."
             ))
             println(logMssg.mkString("\n"))
           case Failure(e: os.SubprocessException) if e.result.exitCode == 2 =>

--- a/javascriptlib/src/mill/javascriptlib/TypeScriptModule.scala
+++ b/javascriptlib/src/mill/javascriptlib/TypeScriptModule.scala
@@ -52,7 +52,7 @@ trait TypeScriptModule extends Module { outer =>
 
   def sources: T[PathRef] = Task.Source("src")
 
-  def resources: T[Seq[PathRef]] = Task { Seq(PathRef(millSourcePath / "resources")) }
+  def resources: T[Seq[PathRef]] = Task { Seq(PathRef(modules / "resources")) }
 
   def generatedSources: T[Seq[PathRef]] = Task { Seq[PathRef]() }
 
@@ -86,10 +86,10 @@ trait TypeScriptModule extends Module { outer =>
     val core = for {
       file <- allSources()
     } yield file.path match {
-      case coreS if coreS.startsWith(millSourcePath) =>
+      case coreS if coreS.startsWith(moduleDir) =>
         // core - regular sources
         // expected to exist within boundaries of `millSourcePath`
-        typescriptOut / coreS.relativeTo(millSourcePath)
+        typescriptOut / coreS.relativeTo(moduleDir)
       case otherS =>
         // sources defined by a modified source task
         // mv to compile source
@@ -137,13 +137,13 @@ trait TypeScriptModule extends Module { outer =>
       ((comp, ts, res), mod) <- Task.traverse(moduleDeps)(_.upstreams)().zip(moduleDeps)
     } yield {
       Seq((
-        mod.millSourcePath.subRelativeTo(Task.workspace).toString + "/*",
+        mod.moduleDir.subRelativeTo(Task.workspace).toString + "/*",
         (ts.path / "src").toString + ":" + (comp.path / "declarations").toString
       )) ++
         res.map { rp =>
           val resourceRoot = rp.path.last
           (
-            "@" + mod.millSourcePath.subRelativeTo(Task.workspace).toString + s"/$resourceRoot/*",
+            "@" + mod.moduleDir.subRelativeTo(Task.workspace).toString + s"/$resourceRoot/*",
             resourceRoot match {
               case s if s.contains(".dest") =>
                 rp.path.toString
@@ -159,7 +159,7 @@ trait TypeScriptModule extends Module { outer =>
   }
 
   def modulePaths: Task[Seq[(String, String)]] = Task.Anon {
-    val module = millSourcePath.last
+    val module = moduleDir.last
     val typescriptOut = Task.dest / "typescript"
     val declarationsOut = Task.dest / "declarations"
 
@@ -232,13 +232,13 @@ trait TypeScriptModule extends Module { outer =>
       )
     )
 
-    os.copy(millSourcePath, Task.dest / "typescript", mergeFolders = true)
+    os.copy(moduleDir, Task.dest / "typescript", mergeFolders = true)
     os.call(npmInstall().path / "node_modules/typescript/bin/tsc", cwd = Task.dest)
 
     (PathRef(Task.dest), PathRef(Task.dest / "typescript"))
   }
 
-  def mainFileName: T[String] = Task { s"${millSourcePath.last}.ts" }
+  def mainFileName: T[String] = Task { s"${moduleDir.last}.ts" }
 
   def mainFilePath: T[Path] = Task { compile()._2.path / "src" / mainFileName() }
 

--- a/javascriptlib/src/mill/javascriptlib/TypeScriptModule.scala
+++ b/javascriptlib/src/mill/javascriptlib/TypeScriptModule.scala
@@ -52,7 +52,7 @@ trait TypeScriptModule extends Module { outer =>
 
   def sources: T[PathRef] = Task.Source("src")
 
-  def resources: T[Seq[PathRef]] = Task { Seq(PathRef(modules / "resources")) }
+  def resources: T[Seq[PathRef]] = Task { Seq(PathRef(moduleDir / "resources")) }
 
   def generatedSources: T[Seq[PathRef]] = Task { Seq[PathRef]() }
 

--- a/kotlinlib/src/mill/kotlinlib/KotlinMavenModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/KotlinMavenModule.scala
@@ -11,7 +11,7 @@ trait KotlinMavenModule extends KotlinModule with MavenModule {
   override def sources = super.sources() ++ sources0()
 
   trait KotlinMavenTests extends KotlinTests with MavenTests {
-    override def intellijModulePath: os.Path = millSourcePath / "src/test"
+    override def intellijModulePath: os.Path = moduleDir / "src/test"
 
     private def sources0 = Task.Sources("src/test/kotlin")
     override def sources = super.sources() ++ sources0()

--- a/kotlinlib/src/mill/kotlinlib/PlatformKotlinModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/PlatformKotlinModule.scala
@@ -7,7 +7,7 @@ import mill.scalalib.PlatformModuleBase
  * It supports additional source directories per platform, e.g. `src-jvm/` or
  * `src-js/`.
  *
- * Adjusts the [[millSourcePath]] and [[artifactNameParts]] to ignore the last
+ * Adjusts the [[moduledir]] and [[artifactNameParts]] to ignore the last
  * path segment, which is assumed to be the name of the platform the module is
  * built against and not something that should affect the filesystem path or
  * artifact name

--- a/kotlinlib/src/mill/kotlinlib/android/AndroidAppKotlinModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/android/AndroidAppKotlinModule.scala
@@ -30,7 +30,7 @@ import mill.scalalib.TestModule.Junit5
 trait AndroidAppKotlinModule extends AndroidAppModule with KotlinModule { outer =>
 
   override def sources: T[Seq[PathRef]] =
-    super[AndroidAppModule].sources() :+ PathRef(millSourcePath / "src/main/kotlin")
+    super[AndroidAppModule].sources() :+ PathRef(moduleDir / "src/main/kotlin")
 
   override def kotlincPluginIvyDeps = Task {
     val kv = kotlinVersion()
@@ -57,7 +57,7 @@ trait AndroidAppKotlinModule extends AndroidAppModule with KotlinModule { outer 
 
   trait AndroidAppKotlinTests extends AndroidAppTests with KotlinTests {
     override def sources: T[Seq[PathRef]] =
-      super[AndroidAppTests].sources() ++ Seq(PathRef(outer.millSourcePath / "src/test/kotlin"))
+      super[AndroidAppTests].sources() ++ Seq(PathRef(outer.moduleDir / "src/test/kotlin"))
   }
 
   trait AndroidAppKotlinInstrumentedTests extends AndroidAppKotlinModule
@@ -68,7 +68,7 @@ trait AndroidAppKotlinModule extends AndroidAppModule with KotlinModule { outer 
 
     override def sources: T[Seq[PathRef]] =
       super[AndroidAppInstrumentedTests].sources() :+ PathRef(
-        outer.millSourcePath / "src/androidTest/kotlin"
+        outer.moduleDir / "src/androidTest/kotlin"
       )
   }
 
@@ -99,8 +99,8 @@ trait AndroidAppKotlinModule extends AndroidAppModule with KotlinModule { outer 
 
     override def sources: T[Seq[PathRef]] = Task.Sources(
       Seq(
-        PathRef(outer.millSourcePath / "src/screenshotTest/kotlin"),
-        PathRef(outer.millSourcePath / "src/screenshotTest/java")
+        PathRef(outer.moduleDir / "src/screenshotTest/kotlin"),
+        PathRef(outer.moduleDir / "src/screenshotTest/java")
       )
     )
 

--- a/kotlinlib/src/mill/kotlinlib/detekt/DetektModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/detekt/DetektModule.scala
@@ -31,7 +31,7 @@ trait DetektModule extends KotlinModule {
       mainClass = "io.gitlab.arturbosch.detekt.cli.Main",
       classPath = detektClasspath().map(_.path).toVector,
       mainArgs = args,
-      cwd = millSourcePath, // allow passing relative paths for sources like src/a/b
+      cwd = moduleDir, // allow passing relative paths for sources like src/a/b
       stdin = os.Inherit,
       stdout = os.Inherit,
       check = false

--- a/kotlinlib/src/mill/kotlinlib/ktfmt/KtfmtModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/ktfmt/KtfmtModule.scala
@@ -124,7 +124,7 @@ object KtfmtModule extends ExternalModule with KtfmtBaseModule with TaskModule {
       mainClass = "com.facebook.ktfmt.cli.Main",
       classPath = classPath.map(_.path).toVector,
       mainArgs = args.result(),
-      cwd = millSourcePath, // allow passing relative paths for sources like src/a/b
+      cwd = moduleDir, // allow passing relative paths for sources like src/a/b
       stdin = os.Inherit,
       stdout = os.Inherit,
       check = false

--- a/kotlinlib/src/mill/kotlinlib/ktlint/KtlintModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/ktlint/KtlintModule.scala
@@ -126,7 +126,7 @@ object KtlintModule extends ExternalModule with KtlintModule with TaskModule {
       mainClass = "com.pinterest.ktlint.Main",
       classPath = classPath.map(_.path).toVector,
       mainArgs = args.result(),
-      cwd = millSourcePath,
+      cwd = moduleDir,
       stdin = os.Inherit,
       stdout = os.Inherit,
       check = false

--- a/main/define/src/mill/define/Cross.scala
+++ b/main/define/src/mill/define/Cross.scala
@@ -23,7 +23,7 @@ object Cross {
      */
     trait CrossValue extends Module[T1] {
       def crossValue: T1 = Module.this.crossValue
-      override def crossWrapperSegments: List[String] = Module.this.millModuleSegments.parts
+      override def crossWrapperSegments: List[String] = Module.this.moduleSegments.parts
     }
   }
 

--- a/main/define/src/mill/define/Module.scala
+++ b/main/define/src/mill/define/Module.scala
@@ -32,7 +32,7 @@ trait Module extends Module.BaseClass {
   // We keep a private `lazy val` and a public `def` so
   // subclasses can call `super.millModuleDirectChildren`
   private lazy val millModuleDirectChildrenImpl: Seq[Module] =
-    millInternal.reflectNestedObjects[Module]().toSeq
+    moduleInternal.reflectNestedObjects[Module]().toSeq
 
   def millOuterCtx: Ctx
 
@@ -44,6 +44,7 @@ trait Module extends Module.BaseClass {
     case Segment.Label(s) => Seq(s)
     case Segment.Cross(_) => Seq.empty[String] // drop cross segments
   })
+  @nowarn("cat=deprecation")
   final def moduleDir = millSourcePath
 
   implicit def millModuleExternal: Ctx.External = Ctx.External(millOuterCtx.external)

--- a/main/define/src/mill/define/Module.scala
+++ b/main/define/src/mill/define/Module.scala
@@ -2,6 +2,7 @@ package mill.define
 
 import mill.api.internal
 
+import scala.annotation.nowarn
 import scala.reflect.ClassTag
 
 /**
@@ -20,7 +21,11 @@ trait Module extends Module.BaseClass {
    * that should not be needed by normal users of Mill
    */
   @internal
+  @deprecated("Use moduleInternal instead", "Mill 0.12.11")
   object millInternal extends Module.Internal(this)
+
+  @nowarn("cat=deprecation")
+  final def moduleInternal = millInternal
 
   def millModuleDirectChildren: Seq[Module] = millModuleDirectChildrenImpl
 
@@ -31,17 +36,25 @@ trait Module extends Module.BaseClass {
 
   def millOuterCtx: Ctx
 
+  @deprecated(
+    """For read-access use moduleDir instead. Calls like `Task.Sources(millSourcePath / "foo")` can be replace with `Task.Sources("foo")`""",
+    "Mill 0.12.11"
+  )
   def millSourcePath: os.Path = millOuterCtx.millSourcePath / (millOuterCtx.segment match {
     case Segment.Label(s) => Seq(s)
     case Segment.Cross(_) => Seq.empty[String] // drop cross segments
   })
+  final def moduleDir = millSourcePath
 
   implicit def millModuleExternal: Ctx.External = Ctx.External(millOuterCtx.external)
   implicit def millModuleShared: Ctx.Foreign = Ctx.Foreign(millOuterCtx.foreign)
   implicit def millModuleBasePath: Ctx.BasePath = Ctx.BasePath(millSourcePath)
+  @deprecated("For read-access use moduleSegments instead", "Mill 0.12.11")
   implicit def millModuleSegments: Segments = {
     millOuterCtx.segments ++ Seq(millOuterCtx.segment)
   }
+  @nowarn("cat=deprecation")
+  final def moduleSegments = millModuleSegments
 
   override def toString = millModuleSegments.render
 }

--- a/main/define/src/mill/define/Module.scala
+++ b/main/define/src/mill/define/Module.scala
@@ -56,7 +56,7 @@ trait Module extends Module.BaseClass {
   @nowarn("cat=deprecation")
   final def moduleSegments = millModuleSegments
 
-  override def toString = millModuleSegments.render
+  override def toString = moduleSegments.render
 }
 
 object Module {

--- a/main/define/src/mill/define/Module.scala
+++ b/main/define/src/mill/define/Module.scala
@@ -50,7 +50,8 @@ trait Module extends Module.BaseClass {
   implicit def millModuleExternal: Ctx.External = Ctx.External(millOuterCtx.external)
   implicit def millModuleShared: Ctx.Foreign = Ctx.Foreign(millOuterCtx.foreign)
   implicit def millModuleBasePath: Ctx.BasePath = Ctx.BasePath(moduleDir)
-  @deprecated("For read-access use moduleSegments instead", "Mill 0.12.11")
+  // @deprecated("For read-access use moduleSegments instead", "Mill 0.12.11")
+  // since this is an implicit, the deprecation warning would result in lots of spurious warnings
   implicit def millModuleSegments: Segments = {
     millOuterCtx.segments ++ Seq(millOuterCtx.segment)
   }

--- a/main/define/src/mill/define/Module.scala
+++ b/main/define/src/mill/define/Module.scala
@@ -48,7 +48,7 @@ trait Module extends Module.BaseClass {
 
   implicit def millModuleExternal: Ctx.External = Ctx.External(millOuterCtx.external)
   implicit def millModuleShared: Ctx.Foreign = Ctx.Foreign(millOuterCtx.foreign)
-  implicit def millModuleBasePath: Ctx.BasePath = Ctx.BasePath(millSourcePath)
+  implicit def millModuleBasePath: Ctx.BasePath = Ctx.BasePath(moduleDir)
   @deprecated("For read-access use moduleSegments instead", "Mill 0.12.11")
   implicit def millModuleSegments: Segments = {
     millOuterCtx.segments ++ Seq(millOuterCtx.segment)
@@ -81,10 +81,10 @@ object Module {
 
     lazy val modules: Seq[Module] = traverse(Seq(_))
     lazy val segmentsToModules: Map[Segments, Module] =
-      modules.map(m => (m.millModuleSegments, m)).toMap
+      modules.map(m => (m.moduleSegments, m)).toMap
 
     lazy val targets: Set[Target[_]] =
-      traverse { _.millInternal.reflectAll[Target[_]].toIndexedSeq }.toSet
+      traverse { _.moduleInternal.reflectAll[Target[_]].toIndexedSeq }.toSet
 
     def reflect[T: ClassTag](filter: String => Boolean): Seq[T] = {
       Reflect.reflect(

--- a/main/define/test/src/mill/define/DiscoverTests.scala
+++ b/main/define/test/src/mill/define/DiscoverTests.scala
@@ -7,7 +7,7 @@ object DiscoverTests extends TestSuite {
   val testGraphs = new TestGraphs
   val tests = Tests {
     def check[T <: Module](m: T)(targets: (T => Target[_])*) = {
-      val discovered = m.millInternal.targets
+      val discovered = m.moduleInternal.targets
       val expected = targets.map(_(m)).toSet
       assert(discovered == expected)
     }

--- a/main/init/src/mill/init/BuildGenModule.scala
+++ b/main/init/src/mill/init/BuildGenModule.scala
@@ -23,7 +23,7 @@ trait BuildGenModule extends CoursierModule with TaskModule {
   def buildGenScalafmtConfig: T[PathRef] = PathRef(BuildGenUtil.scalafmtConfigFile)
 
   def init(args: String*): Command[Unit] = Task.Command {
-    val root = millSourcePath
+    val root = moduleDir
 
     val mainClass = buildGenMainClass()
     val classPath = buildGenClasspath().map(_.path)

--- a/main/resolve/src/mill/resolve/Resolve.scala
+++ b/main/resolve/src/mill/resolve/Resolve.scala
@@ -78,7 +78,7 @@ object Resolve {
                 rootModule,
                 value.getClass,
                 Some(value.defaultCommandName()),
-                value.millModuleSegments,
+                value.moduleSegments,
                 cache = cache
               )
 

--- a/main/resolve/src/mill/resolve/ResolveCore.scala
+++ b/main/resolve/src/mill/resolve/ResolveCore.scala
@@ -232,7 +232,7 @@ private object ResolveCore {
                 case Right(searchModules) =>
                   recurse(
                     searchModules
-                      .map(m => Resolved.Module(m.millModuleSegments, m.getClass))
+                      .map(m => Resolved.Module(m.moduleSegments, m.getClass))
                   )
               }
 
@@ -254,7 +254,7 @@ private object ResolveCore {
           assert(s != "_", s)
           resolveDirectChildren0(
             rootModule,
-            current.millModuleSegments,
+            current.moduleSegments,
             current.getClass,
             Some(s),
             cache = cache
@@ -415,12 +415,12 @@ private object ResolveCore {
         instantiateModule(rootModule, segments, cache).map {
           case m: DynamicModule =>
             m.millModuleDirectChildren
-              .filter(c => namePred(c.millModuleSegments.last.value))
+              .filter(c => namePred(c.moduleSegments.last.value))
               .filter(c => classMatchesTypePred(typePattern)(c.getClass))
               .map(c =>
                 (
                   Resolved.Module(
-                    Segments.labels(c.millModuleSegments.last.value),
+                    Segments.labels(c.moduleSegments.last.value),
                     c.getClass
                   ),
                   Some((x: Module) => Right(c))

--- a/main/src/mill/main/MainModule.scala
+++ b/main/src/mill/main/MainModule.scala
@@ -267,7 +267,7 @@ trait MainModule extends BaseModule0 {
           if (seen(t)) Nil // do nothing
           else t match {
             case t: mill.define.Target[_]
-                if evaluator.rootModule.millInternal.targets.contains(t) =>
+                if evaluator.rootModule.moduleInternal.targets.contains(t) =>
               Seq(t.ctx.segments)
             case _ =>
               seen.add(t)

--- a/pythonlib/src/mill/pythonlib/PublishModule.scala
+++ b/pythonlib/src/mill/pythonlib/PublishModule.scala
@@ -105,14 +105,14 @@ trait PublishModule extends PythonModule {
    * The readme file to include in the published distribution.
    */
   def publishReadme: T[PathRef] = Task.Input {
-    val readme = if (os.exists(millSourcePath)) {
-      os.list(millSourcePath).find(_.last.toLowerCase().startsWith("readme"))
+    val readme = if (os.exists(moduleDir)) {
+      os.list(moduleDir).find(_.last.toLowerCase().startsWith("readme"))
     } else None
     readme match {
       case None =>
         Result.Failure(
-          s"No readme file found in `${millSourcePath}`. A readme file is required for publishing distributions. " +
-            s"Please create a file named `${millSourcePath}/readme*` (any capitalization), or override the `publishReadme` task."
+          s"No readme file found in `${moduleDir}`. A readme file is required for publishing distributions. " +
+            s"Please create a file named `${moduleDir}/readme*` (any capitalization), or override the `publishReadme` task."
         )
       case Some(path) =>
         Result.Success(PathRef(path))

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -34,7 +34,7 @@ abstract class MillBuildRootModule()(implicit
     .mkString("/")
 
   override def millSourcePath: os.Path = rootModuleInfo.projectRoot / os.up / millBuild
-  override def intellijModulePath: os.Path = millSourcePath / os.up
+  override def intellijModulePath: os.Path = moduleDir / os.up
 
   override def scalaVersion: T[String] = BuildInfo.scalaVersion
 

--- a/scalalib/src/mill/javalib/android/AndroidAppModule.scala
+++ b/scalalib/src/mill/javalib/android/AndroidAppModule.scala
@@ -130,7 +130,7 @@ trait AndroidAppModule extends JavaModule {
    * Users can customize the keystore file name to change this path.
    */
   def androidReleaseKeyPath: T[Option[PathRef]] = Task {
-    androidReleaseKeyName().map(name => PathRef(millSourcePath / name))
+    androidReleaseKeyName().map(name => PathRef(moduleDir / name))
   }
 
   /**
@@ -269,7 +269,7 @@ trait AndroidAppModule extends JavaModule {
    */
   override def resources: T[Seq[PathRef]] = Task {
     val libResFolders = androidUnpackArchives().flatMap(_.resources)
-    libResFolders :+ PathRef(millSourcePath / "src/main/res")
+    libResFolders :+ PathRef(moduleDir / "src/main/res")
   }
 
   @internal
@@ -279,7 +279,7 @@ trait AndroidAppModule extends JavaModule {
 
   @internal
   override def bspBuildTarget: BspBuildTarget = super.bspBuildTarget.copy(
-    baseDirectory = Some(millSourcePath / "src/main"),
+    baseDirectory = Some(moduleDir / "src/main"),
     tags = Seq("application")
   )
 
@@ -762,7 +762,7 @@ trait AndroidAppModule extends JavaModule {
     os.call(
       Seq(
         androidSdkModule().lintToolPath().path.toString,
-        (millSourcePath / "src/main").toString,
+        (moduleDir / "src/main").toString,
         "--classpath",
         cp,
         "--sources",
@@ -1047,7 +1047,7 @@ trait AndroidAppModule extends JavaModule {
   }
 
   trait AndroidAppTests extends JavaTests {
-    private def testPath = parent.millSourcePath / "src/test"
+    private def testPath = parent.moduleDir / "src/test"
 
     override def sources: T[Seq[PathRef]] = Seq(PathRef(testPath / "java"))
 
@@ -1061,7 +1061,7 @@ trait AndroidAppModule extends JavaModule {
   }
 
   trait AndroidAppInstrumentedTests extends AndroidAppModule with AndroidTestModule {
-    private def androidMainSourcePath = parent.millSourcePath
+    private def androidMainSourcePath = parent.moduleDir
     private def androidTestPath = androidMainSourcePath / "src/androidTest"
 
     override def moduleDeps: Seq[JavaModule] = Seq(parent)

--- a/scalalib/src/mill/javalib/checkstyle/CheckstyleModule.scala
+++ b/scalalib/src/mill/javalib/checkstyle/CheckstyleModule.scala
@@ -39,7 +39,7 @@ trait CheckstyleModule extends JavaModule {
       mainClass = "com.puppycrawl.tools.checkstyle.Main",
       classPath = checkstyleClasspath().map(_.path).toVector,
       mainArgs = args,
-      cwd = millSourcePath, // allow passing relative paths for sources like src/a/b
+      cwd = moduleDir, // allow passing relative paths for sources like src/a/b
       stdin = os.Inherit,
       stdout = os.Inherit,
       check = false

--- a/scalalib/src/mill/javalib/palantirformat/PalantirFormatModule.scala
+++ b/scalalib/src/mill/javalib/palantirformat/PalantirFormatModule.scala
@@ -40,9 +40,7 @@ trait PalantirFormatBaseModule extends CoursierModule {
   /**
    * Path to options file for Palantir Java Format CLI. Defaults to `millSourcePath` `/` `palantirformat.options`.
    */
-  def palantirformatOptions: T[PathRef] = Task.Source(
-    millSourcePath / "palantirformat.options"
-  )
+  def palantirformatOptions: T[PathRef] = Task.Source("palantirformat.options")
 
   /**
    * Palantir Java Format version. Defaults to `2.50.0`.
@@ -63,7 +61,7 @@ trait PalantirFormatModule extends JavaModule with PalantirFormatBaseModule {
    * @param check if an exception should be raised when formatting errors are found
    *              - when set, files are not formatted
    * @param sources list of file or folder path(s) to be processed
-   *                - path must be relative to [[millSourcePath]]
+   *                - path must be relative to [[moduleDir]]
    *                - when empty, all [[sources]] are processed
    */
   def palantirformat(
@@ -73,7 +71,7 @@ trait PalantirFormatModule extends JavaModule with PalantirFormatBaseModule {
 
     val _sources =
       if (sources.value.isEmpty) this.sources()
-      else sources.value.iterator.map(rel => PathRef(millSourcePath / os.RelPath(rel)))
+      else sources.value.iterator.map(rel => PathRef(moduleDir / os.RelPath(rel)))
 
     PalantirFormatModule.palantirAction(
       _sources,

--- a/scalalib/src/mill/scalalib/CrossModuleBase.scala
+++ b/scalalib/src/mill/scalalib/CrossModuleBase.scala
@@ -13,7 +13,7 @@ trait CrossModuleBase extends ScalaModule with Cross.Module[String] {
   protected def scalaVersionDirectoryNames: Seq[String] =
     ZincWorkerUtil.matchingVersions(crossScalaVersion)
 
-  override def crossWrapperSegments: List[String] = millModuleSegments.parts
+  override def crossWrapperSegments: List[String] = moduleSegments.parts
 
   override def artifactNameParts: T[Seq[String]] =
     super.artifactNameParts().patch(crossWrapperSegments.size - 1, Nil, 1)

--- a/scalalib/src/mill/scalalib/CrossSbtModule.scala
+++ b/scalalib/src/mill/scalalib/CrossSbtModule.scala
@@ -9,7 +9,7 @@ trait CrossSbtModule extends SbtModule with CrossModuleBase { outer =>
 
   override def sources: T[Seq[PathRef]] = Task.Sources {
     super.sources() ++ scalaVersionDirectoryNames.map(s =>
-      PathRef(millSourcePath / "src/main" / s"scala-$s")
+      PathRef(moduleDir / "src/main" / s"scala-$s")
     )
   }
 
@@ -20,7 +20,7 @@ trait CrossSbtModule extends SbtModule with CrossModuleBase { outer =>
     override def millSourcePath = outer.millSourcePath
     override def sources = Task.Sources {
       super.sources() ++ scalaVersionDirectoryNames.map(s =>
-        PathRef(millSourcePath / "src/test" / s"scala-$s")
+        PathRef(moduleDir / "src/test" / s"scala-$s")
       )
     }
   }

--- a/scalalib/src/mill/scalalib/CrossScalaModule.scala
+++ b/scalalib/src/mill/scalalib/CrossScalaModule.scala
@@ -15,6 +15,6 @@ import mill.{T, Task}
 trait CrossScalaModule extends ScalaModule with CrossModuleBase {
   override def sources: T[Seq[PathRef]] = Task.Sources {
     super.sources() ++
-      scalaVersionDirectoryNames.map(s => PathRef(millSourcePath / s"src-$s"))
+      scalaVersionDirectoryNames.map(s => PathRef(moduleDir / s"src-$s"))
   }
 }

--- a/scalalib/src/mill/scalalib/GenIdeaImpl.scala
+++ b/scalalib/src/mill/scalalib/GenIdeaImpl.scala
@@ -22,7 +22,7 @@ case class GenIdeaImpl(
 ) {
   import GenIdeaImpl._
 
-  val workDir: Path = rootModule.millSourcePath
+  val workDir: Path = rootModule.moduleDir
   val ideaDir: Path = workDir / ".idea"
 
   val ideaConfigVersion = 4

--- a/scalalib/src/mill/scalalib/GenIdeaImpl.scala
+++ b/scalalib/src/mill/scalalib/GenIdeaImpl.scala
@@ -91,7 +91,7 @@ object GenIdeaImpl {
 
   /**
    * Create the module name (to be used by Idea) for the module based on it segments.
-   * @see [[Module.millModuleSegments]]
+   * @see [[Module.moduleSegments]]
    */
   def moduleName(p: Segments): String = ???
   sealed trait ResolvedLibrary { def path: os.Path }

--- a/scalalib/src/mill/scalalib/GenIdeaModule.scala
+++ b/scalalib/src/mill/scalalib/GenIdeaModule.scala
@@ -10,7 +10,7 @@ import os.SubPath
 trait GenIdeaModule extends Module {
   import GenIdeaModule._
 
-  def intellijModulePath: os.Path = millSourcePath
+  def intellijModulePath: os.Path = moduleDir
 
   /**
    * Skip Idea project file generation.

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -39,7 +39,7 @@ trait JavaModule
     with AssemblyModule { outer =>
 
   override def zincWorker: ModuleRef[ZincWorkerModule] = super.zincWorker
-  @nowarn
+  @nowarn("cat=deprecation")
   type JavaTests = JavaModuleTests
   @deprecated("Use JavaTests instead", since = "Mill 0.11.10")
   trait JavaModuleTests extends JavaModule with TestModule {
@@ -355,7 +355,7 @@ trait JavaModule
   /** Should only be called from [[moduleDepsChecked]] */
   private lazy val recModuleDeps: Seq[JavaModule] =
     ModuleUtils.recursive[JavaModule](
-      (millModuleSegments ++ Seq(Segment.Label("moduleDeps"))).render,
+      (moduleSegments ++ Seq(Segment.Label("moduleDeps"))).render,
       this,
       _.moduleDeps
     )
@@ -363,7 +363,7 @@ trait JavaModule
   /** Should only be called from [[compileModuleDeps]] */
   private lazy val recCompileModuleDeps: Seq[JavaModule] =
     ModuleUtils.recursive[JavaModule](
-      (millModuleSegments ++ Seq(Segment.Label("compileModuleDeps"))).render,
+      (moduleSegments ++ Seq(Segment.Label("compileModuleDeps"))).render,
       this,
       _.compileModuleDeps
     )
@@ -371,7 +371,7 @@ trait JavaModule
   /** Should only be called from [[runModuleDepsChecked]] */
   private lazy val recRunModuleDeps: Seq[JavaModule] =
     ModuleUtils.recursive[JavaModule](
-      (millModuleSegments ++ Seq(Segment.Label("runModuleDeps"))).render,
+      (moduleSegments ++ Seq(Segment.Label("runModuleDeps"))).render,
       this,
       m => m.runModuleDeps ++ m.moduleDeps
     )
@@ -379,7 +379,7 @@ trait JavaModule
   /** Should only be called from [[bomModuleDepsChecked]] */
   private lazy val recBomModuleDeps: Seq[BomModule] =
     ModuleUtils.recursive[BomModule](
-      (millModuleSegments ++ Seq(Segment.Label("bomModuleDeps"))).render,
+      (moduleSegments ++ Seq(Segment.Label("bomModuleDeps"))).render,
       null,
       mod => if (mod == null) bomModuleDeps else mod.bomModuleDeps
     )
@@ -437,7 +437,7 @@ trait JavaModule
       val deps = (normalDeps ++ compileDeps ++ runModuleDeps).distinct
 
       val header = Option.when(includeHeader)(
-        s"${if (recursive) "Recursive module" else "Module"} dependencies of ${millModuleSegments.render}:"
+        s"${if (recursive) "Recursive module" else "Module"} dependencies of ${moduleSegments.render}:"
       ).toSeq
       val lines = deps.map { dep =>
         val isNormal = normalDeps.contains(dep)
@@ -446,7 +446,7 @@ trait JavaModule
           Option.when(!isNormal && runtimeDeps.contains(dep))("runtime")
         ).flatten
         val suffix = if (markers.isEmpty) "" else markers.mkString(" (", ",", ")")
-        "  " + dep.millModuleSegments.render + suffix
+        "  " + dep.moduleSegments.render + suffix
       }
       (header ++ lines).mkString("\n")
     }
@@ -479,7 +479,7 @@ trait JavaModule
     cs.Dependency(
       cs.Module(
         JavaModule.internalOrg,
-        coursier.core.ModuleName(millModuleSegments.parts.mkString("-")),
+        coursier.core.ModuleName(moduleSegments.parts.mkString("-")),
         Map.empty
       ),
       JavaModule.internalVersion
@@ -528,7 +528,7 @@ trait JavaModule
         val dep = coursier.core.Dependency(
           coursier.core.Module(
             coursier.core.Organization("mill-internal"),
-            coursier.core.ModuleName(modDep.millModuleSegments.parts.mkString("-")),
+            coursier.core.ModuleName(modDep.moduleSegments.parts.mkString("-")),
             Map.empty
           ),
           "0+mill-internal"
@@ -1437,7 +1437,7 @@ trait JavaModule
    */
   def artifactName: T[String] = artifactNameParts().mkString("-")
 
-  def artifactNameParts: T[Seq[String]] = millModuleSegments.parts
+  def artifactNameParts: T[Seq[String]] = moduleSegments.parts
 
   /**
    * The exact id of the artifact to be published. You probably don't want to override this.

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -59,7 +59,7 @@ trait JavaModule
     override def runUseArgsFile: T[Boolean] = Task { outer.runUseArgsFile() }
     override def sources = Task.Sources {
       for (src <- outer.sources()) yield {
-        PathRef(this.millSourcePath / src.path.relativeTo(outer.millSourcePath))
+        PathRef(this.moduleDir / src.path.relativeTo(outer.moduleDir))
       }
     }
 

--- a/scalalib/src/mill/scalalib/MavenModule.scala
+++ b/scalalib/src/mill/scalalib/MavenModule.scala
@@ -11,25 +11,17 @@ import scala.annotation.nowarn
  */
 trait MavenModule extends JavaModule { outer =>
 
-  override def sources = Task.Sources(
-    millSourcePath / "src/main/java"
-  )
-  override def resources = Task.Sources {
-    millSourcePath / "src/main/resources"
-  }
+  override def sources = Task.Sources("src/main/java")
+  override def resources = Task.Sources("src/main/resources")
 
-  @nowarn
+  @nowarn("cat=deprecation")
   type MavenTests = MavenModuleTests
   @deprecated("Use MavenTests instead", since = "Mill 0.11.10")
   trait MavenModuleTests extends JavaTests {
     override def millSourcePath = outer.millSourcePath
-    override def intellijModulePath: os.Path = outer.millSourcePath / "src/test"
+    override def intellijModulePath: os.Path = outer.moduleDir / "src/test"
 
-    override def sources = Task.Sources(
-      millSourcePath / "src/test/java"
-    )
-    override def resources = Task.Sources {
-      millSourcePath / "src/test/resources"
-    }
+    override def sources = Task.Sources("src/test/java")
+    override def resources = Task.Sources("src/test/resources")
   }
 }

--- a/scalalib/src/mill/scalalib/PlatformModuleBase.scala
+++ b/scalalib/src/mill/scalalib/PlatformModuleBase.scala
@@ -10,7 +10,7 @@ trait PlatformModuleBase extends JavaModule {
    * The platform suffix of this [[PlatformModuleBase]]. Useful if you want to
    * further customize the source paths or artifact names.
    */
-  def platformCrossSuffix: String = millModuleSegments
+  def platformCrossSuffix: String = moduleSegments
     .value
     .collect { case l: mill.define.Segment.Label => l.value }
     .last

--- a/scalalib/src/mill/scalalib/PlatformScalaModule.scala
+++ b/scalalib/src/mill/scalalib/PlatformScalaModule.scala
@@ -8,7 +8,7 @@ import mill.{PathRef, T, Task}
  * `src-js/` and can be used inside a [[CrossScalaModule.Base]], to get one
  * source folder per platform per version e.g. `src-2.12-jvm/`.
  *
- * Adjusts the [[millSourcePath]] and [[artifactNameParts]] to ignore the last
+ * Adjusts the [[moduleDir]] and [[artifactNameParts]] to ignore the last
  * path segment, which is assumed to be the name of the platform the module is
  * built against and not something that should affect the filesystem path or
  * artifact name

--- a/scalalib/src/mill/scalalib/PlatformScalaModule.scala
+++ b/scalalib/src/mill/scalalib/PlatformScalaModule.scala
@@ -22,7 +22,7 @@ trait PlatformScalaModule extends /* PlatformModuleBase with*/ ScalaModule {
    * The platform suffix of this [[PlatformScalaModule]]. Useful if you want to
    * further customize the source paths or artifact names.
    */
-  def platformScalaSuffix: String = millModuleSegments
+  def platformScalaSuffix: String = moduleSegments
     .value
     .collect { case l: mill.define.Segment.Label => l.value }
     .last

--- a/scalalib/src/mill/scalalib/SbtModule.scala
+++ b/scalalib/src/mill/scalalib/SbtModule.scala
@@ -10,8 +10,8 @@ import scala.annotation.nowarn
 trait SbtModule extends ScalaModule with MavenModule {
 
   override def sources = Task.Sources(
-    millSourcePath / "src/main/scala",
-    millSourcePath / "src/main/java"
+    "src/main/scala",
+    "src/main/java"
   )
 
   @nowarn
@@ -19,8 +19,8 @@ trait SbtModule extends ScalaModule with MavenModule {
   @deprecated("Use SbtTests instead", since = "Mill 0.11.10")
   trait SbtModuleTests extends ScalaTests with MavenTests {
     override def sources = Task.Sources(
-      millSourcePath / "src/test/scala",
-      millSourcePath / "src/test/java"
+      "src/test/scala",
+      "src/test/java"
     )
   }
 }

--- a/scalalib/src/mill/scalalib/bsp/BspModule.scala
+++ b/scalalib/src/mill/scalalib/bsp/BspModule.scala
@@ -19,7 +19,7 @@ trait BspModule extends Module {
   @internal
   def bspBuildTarget: BspBuildTarget = BspBuildTarget(
     displayName = Some(bspDisplayName),
-    baseDirectory = Some(millSourcePath),
+    baseDirectory = Some(moduleDir),
     tags = Seq(Tag.Library, Tag.Application),
     languageIds = Seq(),
     canCompile = false,

--- a/scalalib/src/mill/scalalib/dependency/versions/VersionsFinder.scala
+++ b/scalalib/src/mill/scalalib/dependency/versions/VersionsFinder.scala
@@ -17,7 +17,7 @@ private[dependency] object VersionsFinder {
       rootModule: BaseModule
   ): Seq[ModuleDependenciesVersions] = {
 
-    val javaModules = rootModule.millInternal.modules.collect {
+    val javaModules = rootModule.moduleInternal.modules.collect {
       case javaModule: JavaModule => javaModule
     }
 

--- a/scalalib/src/mill/scalalib/internal/ModuleUtils.scala
+++ b/scalalib/src/mill/scalalib/internal/ModuleUtils.scala
@@ -12,7 +12,7 @@ object ModuleUtils {
    * Computes a display name for a module which is also disambiguates foreign modules.
    */
   def moduleDisplayName(module: Module): String = {
-    (module.millModuleShared.value.getOrElse(Segments()) ++ module.millModuleSegments).render
+    (module.millModuleShared.value.getOrElse(Segments()) ++ module.moduleSegments).render
   }
 
   /**

--- a/testkit/src/mill/testkit/UnitTester.scala
+++ b/testkit/src/mill/testkit/UnitTester.scala
@@ -55,14 +55,14 @@ class UnitTester(
     env: Map[String, String],
     resetSourcePath: Boolean
 )(implicit fullName: sourcecode.FullName) extends AutoCloseable {
-  val outPath: os.Path = module.millSourcePath / "out"
+  val outPath: os.Path = module.moduleDir / "out"
 
   if (resetSourcePath) {
-    os.remove.all(module.millSourcePath)
-    os.makeDir.all(module.millSourcePath)
+    os.remove.all(module.moduleDir)
+    os.makeDir.all(module.moduleDir)
 
     for (sourceFileRoot <- Option(sourceRoot)) {
-      os.copy.over(sourceFileRoot, module.millSourcePath, createFolders = true)
+      os.copy.over(sourceFileRoot, module.moduleDir, createFolders = true)
     }
   }
 
@@ -88,7 +88,7 @@ class UnitTester(
   }
   val evaluator: EvaluatorImpl = mill.eval.EvaluatorImpl.make(
     mill.api.Ctx.defaultHome,
-    module.millSourcePath,
+    module.moduleDir,
     outPath,
     outPath,
     module,
@@ -135,7 +135,7 @@ class UnitTester(
           evaluated.rawValues.map(_.asInstanceOf[Result.Success[Val]].value.value),
           evaluated.evaluated.collect {
             case t: TargetImpl[_]
-                if module.millInternal.targets.contains(t)
+                if module.moduleInternal.targets.contains(t)
                   && !t.ctx.external => t
             case t: mill.define.Command[_] => t
           }.size
@@ -176,7 +176,7 @@ class UnitTester(
     val evaluated = evaluator.evaluate(targets)
       .evaluated
       .flatMap(_.asTarget)
-      .filter(module.millInternal.targets.contains)
+      .filter(module.moduleInternal.targets.contains)
       .filter(!_.isInstanceOf[InputImpl[_]])
     assert(
       evaluated.toSet == expected.toSet,


### PR DESCRIPTION
Allow users to replace deprecated API calls with their newer replacements.

Tracker: https://github.com/com-lihaoyi/mill/issues/4716
