### PR TITLE
Propagate JAVA_OPTS to mill subprocess

### DIFF
--- a/integration/feature/java-opts/resources/build.mill
+++ b/integration/feature/java-opts/resources/build.mill
@@ -1,0 +1,5 @@
+import mill._
+
+def maxMemory = Task { Runtime.getRuntime().maxMemory }
+
+def testProperty = Task { sys.props.get("test.property").get.toInt }

--- a/integration/feature/java-opts/src/JavaOptsTests.scala
+++ b/integration/feature/java-opts/src/JavaOptsTests.scala
@@ -1,0 +1,27 @@
+package mill.integration
+
+import mill.testkit.UtestIntegrationTestSuite
+import utest.*
+
+object JavaOptsTests extends UtestIntegrationTestSuite {
+  val tests: Tests = Tests {
+    test("propagateJavaOpts") - integrationTest { tester =>
+      import tester.*
+
+      val n = 2L
+      val maxMemory = eval(("show", "maxMemory"), Map("JAVA_OPTS" -> s"-Xmx${n}G"))
+      assert(maxMemory.isSuccess)
+      assert(maxMemory.out.trim.toLong == n * 1024 * 1024 * 1024)
+    }
+
+    test("propagateJavaOptsProps") - integrationTest { tester =>
+      import tester.*
+
+      val propValue = 123
+      val testProperty =
+        eval(("show", "testProperty"), Map("JAVA_OPTS" -> s"-Dtest.property=$propValue"))
+      assert(testProperty.isSuccess)
+      assert(testProperty.out.trim.toInt == propValue)
+    }
+  }
+}

--- a/runner/client/src/mill/runner/client/MillProcessLauncher.java
+++ b/runner/client/src/mill/runner/client/MillProcessLauncher.java
@@ -73,6 +73,16 @@ public class MillProcessLauncher {
     Files.createDirectories(sandbox);
     builder.environment().put(EnvVars.MILL_WORKSPACE_ROOT, new File("").getCanonicalPath());
 
+    String jdkJavaOptions = System.getenv("JDK_JAVA_OPTIONS");
+    if (jdkJavaOptions == null) jdkJavaOptions = "";
+    String javaOpts = System.getenv("JAVA_OPTS");
+    if (javaOpts == null) javaOpts = "";
+
+    String opts = (jdkJavaOptions + " " + javaOpts).trim();
+    if (!opts.isEmpty()) {
+      builder.environment().put("JDK_JAVA_OPTIONS", opts);
+    }
+
     builder.directory(sandbox.toFile());
     return builder.start();
   }


### PR DESCRIPTION
Fix #4826

Propagate options specified in `JAVA_OPTS` to mill subprocess by appending them to `JDK_JAVA_OPTIONS` and setting `JDK_JAVA_OPTIONS` in the process env. Related discussion in the [APE PR](https://github.com/com-lihaoyi/mill/pull/4503#issuecomment-2665620418). The JVM will print `NOTE: Picked up JDK_JAVA_OPTIONS: ...` to stderr though.