### PR TITLE
Read `JVM_OPTS` from environment variables

### DIFF
--- a/runner/client/src/mill/runner/client/MillProcessLauncher.java
+++ b/runner/client/src/mill/runner/client/MillProcessLauncher.java
@@ -226,6 +226,12 @@ public class MillProcessLauncher {
       vmOptions.add("-Djna.nosys=true");
     }
 
+      // Include JAVA_OPTS if present
+      String javaOpts = System.getenv("JAVA_OPTS");
+      if (javaOpts != null && !javaOpts.trim().isEmpty()) {
+          vmOptions.addAll(Arrays.asList(javaOpts.trim().split("\\s+")));
+      }
+
     // sys props
     final Properties sysProps = System.getProperties();
     for (final String k : sysProps.stringPropertyNames()) {

--- a/runner/client/src/mill/runner/client/MillProcessLauncher.java
+++ b/runner/client/src/mill/runner/client/MillProcessLauncher.java
@@ -226,11 +226,11 @@ public class MillProcessLauncher {
       vmOptions.add("-Djna.nosys=true");
     }
 
-      // Include JAVA_OPTS if present
-      String javaOpts = System.getenv("JAVA_OPTS");
-      if (javaOpts != null && !javaOpts.trim().isEmpty()) {
-          vmOptions.addAll(Arrays.asList(javaOpts.trim().split("\\s+")));
-      }
+    // Include JAVA_OPTS if present
+    String javaOpts = System.getenv("JAVA_OPTS");
+    if (javaOpts != null && !javaOpts.trim().isEmpty()) {
+      vmOptions.addAll(Arrays.asList(javaOpts.trim().split("\\s+")));
+    }
 
     // sys props
     final Properties sysProps = System.getProperties();


### PR DESCRIPTION
Solves Issue - https://github.com/com-lihaoyi/mill/issues/4826

**Description**

This PR enables `mill` build tool to read `JVM_OPTS` from the environment variables and adds it to the existing `vmOptions` list.
