### PR TITLE
Minor changes

### DIFF
--- a/javascriptlib/src/mill/javascriptlib/PublishModule.scala
+++ b/javascriptlib/src/mill/javascriptlib/PublishModule.scala
@@ -10,8 +10,13 @@ trait PublishModule extends TypeScriptModule {
    *
    * This is an equivalent of a `package.json`
    */
-  override def npmDevDeps: T[Seq[String]] =
-    Task { Seq("glob@^10.4.5", "ts-patch@3.3.0", "typescript-transform-paths@3.5.3") }
+  override def npmDevDeps: T[Seq[String]] = Task {
+    Seq(
+      "glob@^10.4.5",
+      "ts-patch@3.3.0",
+      "typescript-transform-paths@3.5.3"
+    )
+  }
 
   def pubBundledOut: T[String] = Task { "dist" }
 

--- a/javascriptlib/src/mill/javascriptlib/TypeScriptModule.scala
+++ b/javascriptlib/src/mill/javascriptlib/TypeScriptModule.scala
@@ -108,7 +108,7 @@ trait TypeScriptModule extends Module { outer =>
   }
 
   // sources :)
-  def sources: T[Seq[PathRef]] = Task.Sources(moduleDir / "src")
+  def sources: T[Seq[PathRef]] = Task.Sources("src")
 
   def resources: T[Seq[PathRef]] = Task { Seq(PathRef(moduleDir / "resources")) }
 

--- a/main/src/mill/main/VcsVersion.scala
+++ b/main/src/mill/main/VcsVersion.scala
@@ -15,7 +15,7 @@ import scala.util.control.NonFatal
  * of commits since latest tag, and a `DIRTY` suffix for workspaces with
  * un-committed changes. Used via `VcsVersion.Module.vcsState.format()`
  *
- * Originally distributed under the Apache License
+ * Originally distributed under the Apache License, Version 2.0
  * as https://github.com/lefou/mill-vcs-version
  */
 

--- a/pythonlib/src/mill/pythonlib/PublishModule.scala
+++ b/pythonlib/src/mill/pythonlib/PublishModule.scala
@@ -18,7 +18,11 @@ trait PublishModule extends PythonModule {
   }
 
   override def pythonToolDeps = Task {
-    super.pythonToolDeps() ++ Seq("setuptools>=75.6.0", "build>=1.2.2", "twine>=5.1.1")
+    super.pythonToolDeps() ++ Seq(
+      "setuptools>=75.6.0",
+      "build>=1.2.2",
+      "twine>=5.1.1"
+    )
   }
 
   /**

--- a/pythonlib/src/mill/pythonlib/PythonModule.scala
+++ b/pythonlib/src/mill/pythonlib/PythonModule.scala
@@ -66,7 +66,10 @@ trait PythonModule extends PipModule with TaskModule { outer =>
   def mainScript: T[PathRef] = Task.Source { "src/main.py" }
 
   override def pythonToolDeps: T[Seq[String]] = Task {
-    super.pythonToolDeps() ++ Seq("mypy==1.13.0", "pex==2.24.1")
+    super.pythonToolDeps() ++ Seq(
+      "mypy==1.13.0",
+      "pex==2.24.1"
+    )
   }
 
   /**
@@ -160,7 +163,7 @@ trait PythonModule extends PipModule with TaskModule { outer =>
    */
   def run(args: mill.define.Args) = Task.Command {
     runner().run(
-      (
+      args = (
         mainScript().path,
         args.value
       )

--- a/scalalib/src/mill/javalib/android/AndroidModule.scala
+++ b/scalalib/src/mill/javalib/android/AndroidModule.scala
@@ -43,7 +43,7 @@ trait AndroidModule extends JavaModule {
       super.artifactTypes() + coursier.Type("aar")
     }
 
-  override def sources: T[Seq[PathRef]] = Task.Sources(moduleDir / "src/main/java")
+  override def sources: T[Seq[PathRef]] = Task.Sources("src/main/java")
 
   /**
    * Provides access to the Android SDK configuration.


### PR DESCRIPTION
- Use Task.Sources with sub path
- Added correct license version number
- Use relative source dir
- formatting
- Ignore test example.android.javalib[1-hello-world] on CI (again)
