### PR TITLE
Fix wildcard and type selector query bugs

### DIFF
--- a/core/resolve/src/mill/resolve/ResolveCore.scala
+++ b/core/resolve/src/mill/resolve/ResolveCore.scala
@@ -182,9 +182,9 @@ private object ResolveCore {
                 )
 
                 transitiveOrErr.map(transitive =>
-                  (self ++ transitive).collect{
+                  (self ++ transitive).collect {
                     case r @ Resolved.Module(segments, cls)
-                      if classMatchesTypePred(typePattern)(cls) =>
+                        if classMatchesTypePred(typePattern)(cls) =>
                       r
                   }
                 )
@@ -197,10 +197,10 @@ private object ResolveCore {
                   None,
                   current.segments,
                   cache
-                ).map{
-                  _.collect{
+                ).map {
+                  _.collect {
                     case r @ Resolved.Module(segments, cls)
-                      if classMatchesTypePred(typePattern)(cls) => r
+                        if classMatchesTypePred(typePattern)(cls) => r
                   }
                 }
 

--- a/core/resolve/src/mill/resolve/ResolveCore.scala
+++ b/core/resolve/src/mill/resolve/ResolveCore.scala
@@ -119,7 +119,9 @@ private object ResolveCore {
                   tail,
                   r,
                   querySoFar ++ Seq(head),
-                  seenModules ++ moduleClasses(Set(current)),
+                  // `foo.__` wildcards can refer to `foo` as well, so make sure we don't
+                  // mark it as seen to avoid spurious cyclic module reference errors
+                  seenModules ++ moduleClasses(Option.when(r != current)(current)),
                   cache
                 )
               }

--- a/core/resolve/test/src/mill/resolve/ResolveTests.scala
+++ b/core/resolve/test/src/mill/resolve/ResolveTests.scala
@@ -212,6 +212,15 @@ object ResolveTests extends TestSuite {
         )),
         Set("nested.single", "classInstance.single")
       )
+      test("wildcard4") - check(
+        "__.__.single",
+        Result.Success(Set(
+          _.classInstance.single,
+          _.nested.single,
+          _.single
+        )),
+        Set("nested.single", "classInstance.single", "single")
+      )
     }
     test("doubleNested") {
       val check = new Checker(doubleNestedModule)

--- a/core/resolve/test/src/mill/resolve/TypeSelectorTests.scala
+++ b/core/resolve/test/src/mill/resolve/TypeSelectorTests.scala
@@ -112,6 +112,14 @@ object TypeSelectorTests extends TestSuite {
         "_:Module._",
         Result.Success(Set(_.typeA.foo, _.typeB.bar, _.typeAB.foo, _.typeAB.bar, _.typeC.baz))
       )
+      test - {
+        val res = check.resolveMetadata(Seq("__:Module"))
+        assert(res == Result.Success(List("", "typeA", "typeAB", "typeB", "typeC", "typeC.typeA")))
+      }
+      test - {
+        val res = check.resolveMetadata(Seq("_:Module"))
+        assert(res == Result.Success(List("typeA", "typeAB", "typeB", "typeC")))
+      }
       // parens should work
       test - check(
         "(_:Module)._",


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/4536 and https://github.com/com-lihaoyi/mill/issues/4514 and https://github.com/com-lihaoyi/mill/issues/3618

- `__` was incorrectly adding the current module to `seenModules`, which causes problems when it recurses on the current module. This PR skips updating `seenModules` when recursing on the current module. There are probably other edge cases we haven't noticed in this cycling module graph detection logic, but for now this just fixes the reported issue and the test suite should give confidence we didn't regress anything

- `typePatterns` was incorrectly being resolved only on modules during the `__` wildcard resolution, and allowing tasks to pass through without filtering. This PR moves the filtering to after `resolveDirectChildren`/`resolveTransitiveChildren` has completed, ensuring we filter out unwanted tasks as well.

Added unit tests for these cases