### PR TITLE
Backport "Fix wildcard and type selector query bugs"

### DIFF
--- a/main/resolve/src/mill/resolve/ResolveCore.scala
+++ b/main/resolve/src/mill/resolve/ResolveCore.scala
@@ -117,7 +117,9 @@ private object ResolveCore {
                   tail,
                   r,
                   querySoFar ++ Seq(head),
-                  seenModules ++ moduleClasses(Set(current)),
+                  // `foo.__` wildcards can refer to `foo` as well, so make sure we don't
+                  // mark it as seen to avoid spurious cyclic module reference errors
+                  seenModules ++ moduleClasses(Option.when(r != current)(current)),
                   cache
                 )
               }
@@ -149,7 +151,6 @@ private object ResolveCore {
                     m.cls,
                     None,
                     current.segments,
-                    Nil,
                     seenModules,
                     cache
                   )
@@ -174,12 +175,17 @@ private object ResolveCore {
                   m.cls,
                   None,
                   current.segments,
-                  typePattern,
                   seenModules,
                   cache
                 )
 
-                transitiveOrErr.map(transitive => self ++ transitive)
+                transitiveOrErr.map(transitive =>
+                  (self ++ transitive).collect {
+                    case r @ Resolved.Module(segments, cls)
+                        if classMatchesTypePred(typePattern)(cls) =>
+                      r
+                  }
+                )
 
               case pattern if pattern.startsWith("_:") =>
                 val typePattern = pattern.split(":").drop(1)
@@ -188,9 +194,13 @@ private object ResolveCore {
                   m.cls,
                   None,
                   current.segments,
-                  typePattern,
                   cache
-                )
+                ).map {
+                  _.collect {
+                    case r @ Resolved.Module(segments, cls)
+                        if classMatchesTypePred(typePattern)(cls) => r
+                  }
+                }
 
               case _ =>
                 resolveDirectChildren(
@@ -289,15 +299,14 @@ private object ResolveCore {
       cls: Class[_],
       nameOpt: Option[String],
       segments: Segments,
-      typePattern: Seq[String],
       seenModules: Set[Class[_]],
       cache: Cache
   ): Either[String, Seq[Resolved]] = {
     if (seenModules.contains(cls)) Left(cyclicModuleErrorMsg(segments))
     else {
       val errOrDirect =
-        resolveDirectChildren(rootModule, cls, nameOpt, segments, typePattern, cache)
-      val directTraverse = resolveDirectChildren(rootModule, cls, nameOpt, segments, Nil, cache)
+        resolveDirectChildren(rootModule, cls, nameOpt, segments, cache)
+      val directTraverse = resolveDirectChildren(rootModule, cls, nameOpt, segments, cache)
 
       val errOrModules = directTraverse.map { modules =>
         modules.flatMap {
@@ -314,7 +323,6 @@ private object ResolveCore {
               m.cls,
               nameOpt,
               m.segments,
-              typePattern,
               seenModules + cls,
               cache
             ))
@@ -368,7 +376,6 @@ private object ResolveCore {
       cls: Class[_],
       nameOpt: Option[String],
       segments: Segments,
-      typePattern: Seq[String] = Nil,
       cache: Cache
   ): Either[String, Seq[Resolved]] = {
     val crossesOrErr = if (classOf[Cross[_]].isAssignableFrom(cls) && nameOpt.isEmpty) {
@@ -392,12 +399,9 @@ private object ResolveCore {
 
     for {
       crosses <- crossesOrErr
-      filteredCrosses = crosses.filter { c =>
-        classMatchesTypePred(typePattern)(c.cls)
-      }
-      direct0 <- resolveDirectChildren0(rootModule, segments, cls, nameOpt, typePattern, cache)
+      direct0 <- resolveDirectChildren0(rootModule, segments, cls, nameOpt, cache)
       direct <- Right(expandSegments(direct0))
-    } yield direct ++ filteredCrosses
+    } yield direct ++ crosses
   }
 
   def resolveDirectChildren0(
@@ -405,7 +409,6 @@ private object ResolveCore {
       segments: Segments,
       cls: Class[_],
       nameOpt: Option[String],
-      typePattern: Seq[String] = Nil,
       cache: Cache
   ): Either[String, Seq[(Resolved, Option[Module => Either[String, Module]])]] = {
     def namePred(n: String) = nameOpt.isEmpty || nameOpt.contains(n)
@@ -416,7 +419,6 @@ private object ResolveCore {
           case m: DynamicModule =>
             m.millModuleDirectChildren
               .filter(c => namePred(c.millModuleSegments.last.value))
-              .filter(c => classMatchesTypePred(typePattern)(c.getClass))
               .map(c =>
                 (
                   Resolved.Module(
@@ -431,7 +433,7 @@ private object ResolveCore {
         val reflectMemberObjects = Reflect
           .reflectNestedObjects02[Module](cls, namePred, cache.getMethods)
           .collect {
-            case (name, memberCls, getter) if classMatchesTypePred(typePattern)(memberCls) =>
+            case (name, memberCls, getter) =>
               val resolved = Resolved.Module(Segments.labels(cache.decode(name)), memberCls)
               val getter2 = Some((mod: Module) => catchWrapException(getter(mod)))
               (resolved, getter2)

--- a/main/resolve/test/src/mill/main/ResolveTests.scala
+++ b/main/resolve/test/src/mill/main/ResolveTests.scala
@@ -229,6 +229,15 @@ object ResolveTests extends TestSuite {
         )),
         Set("nested.single", "classInstance.single")
       )
+      test("wildcard4") - check(
+        "__.__.single",
+        Right(Set(
+          _.classInstance.single,
+          _.nested.single,
+          _.single
+        )),
+        Set("nested.single", "classInstance.single", "single")
+      )
     }
     test("doubleNested") {
       val check = new Checker(doubleNestedModule)
@@ -942,6 +951,15 @@ object ResolveTests extends TestSuite {
         "_:Module._",
         Right(Set(_.typeA.foo, _.typeB.bar, _.typeAB.foo, _.typeAB.bar, _.typeC.baz))
       )
+      test - {
+        val res = check.resolveMetadata(Seq("__:Module"))
+        assert(res == Right(List("", "typeA", "typeAB", "typeB", "typeC", "typeC.typeA")))
+      }
+      test - {
+        val res = check.resolveMetadata(Seq("_:Module"))
+        assert(res == Right(List("typeA", "typeAB", "typeB", "typeC")))
+      }
+
       // parens should work
       test - check(
         "(_:Module)._",


### PR DESCRIPTION
Backports https://github.com/com-lihaoyi/mill/pull/4861

Fixes https://github.com/com-lihaoyi/mill/issues/4536 and https://github.com/com-lihaoyi/mill/issues/4514 and https://github.com/com-lihaoyi/mill/issues/3618

- `__` was incorrectly adding the current module to `seenModules`, which causes problems when it recurses on the current module. This PR skips updating `seenModules` when recursing on the current module. There are probably other edge cases we haven't noticed in this cycling module graph detection logic, but for now this just fixes the reported issue and the test suite should give confidence we didn't regress anything

- `typePatterns` was incorrectly being resolved only on modules during the `__` wildcard resolution, and allowing tasks to pass through without filtering. This PR moves the filtering to after `resolveDirectChildren`/`resolveTransitiveChildren` has completed, ensuring we filter out unwanted tasks as well.

Added unit tests for these cases