### PR TITLE
Fix Junit5 compile classpath access

### DIFF
--- a/scalalib/src/mill/scalalib/TestModule.scala
+++ b/scalalib/src/mill/scalalib/TestModule.scala
@@ -280,7 +280,7 @@ object TestModule {
       super.mandatoryIvyDeps() ++ Seq(ivy"${mill.scalalib.api.Versions.jupiterInterface}")
     }
 
-    private val classesDir: Task[Option[os.Path]] = this match {
+    private def classesDir: Task[Option[os.Path]] = this match {
       case withCompileTask: JavaModule => Task.Anon {
           Some(withCompileTask.compile().classes.path)
         }


### PR DESCRIPTION
The Kotlin Arrow example build just hang with task `arrow-libs.optics.arrow-optics.jvm.test.compile`.

