### PR TITLE
Add TestModule#testLogLevel, make netty tests less verbose

### DIFF
--- a/example/thirdparty/netty/build.mill
+++ b/example/thirdparty/netty/build.mill
@@ -59,6 +59,8 @@ trait NettyBaseTestSuiteModule extends NettyBaseModule with TestModule.Junit5 {
     "-enableassertions"
   )
 
+  def testLogLevel = mill.api.TestReporter.LogLevel.Info
+
   def compile = Task {
     // Hack to satisfy fragile tests that look for /test-classes/ in the file paths
     val sup = super.compile()
@@ -636,16 +638,18 @@ object `transport-udt` extends NettyModule {
 
 > ./mill -j5 __.compile
 
-> ./mill 'codec-{dns,haproxy,http,http2,memcache,mqtt,redis,smtp,socks,stomp,xml}.test'
+> ./mill 'codec-stomp.test.testForked'
 ...Test io.netty.handler.codec.stomp.StompSubframeEncoderTest#testEscapeStompHeaders() started
-...Test io.netty.handler.codec.stomp.StompSubframeEncoderTest#testEscapeStompHeaders() finished...
 ...
 
-> ./mill 'transport-blockhound-tests.testForked'
+> ./mill 'codec-{dns,haproxy,http,http2,memcache,mqtt,redis,smtp,socks,xml}.test.testForked' -q +v
 
-> ./mill 'transport-{native-unix-common,sctp}.test'
+> ./mill 'transport-blockhound-tests.testForked' -q +v
+
+> ./mill 'transport-native-unix-common.test.testForked'
 ...Test io.netty.channel.unix.UnixChannelUtilTest#testUnPooledAllocatorIsBufferCopyNeededForWrite() started
-...Test io.netty.channel.unix.UnixChannelUtilTest#testUnPooledAllocatorIsBufferCopyNeededForWrite() finished...
 ...
+
+> ./mill 'transport-{native-unix-common,sctp}.test.testForked' -q +v
 
 */

--- a/example/thirdparty/netty/build.mill
+++ b/example/thirdparty/netty/build.mill
@@ -59,7 +59,7 @@ trait NettyBaseTestSuiteModule extends NettyBaseModule with TestModule.Junit5 {
     "-enableassertions"
   )
 
-  def testLogLevel = mill.api.TestReporter.LogLevel.Info
+  def testLogLevel = mill.runner.api.TestReporter.LogLevel.Info
 
   def compile = Task {
     // Hack to satisfy fragile tests that look for /test-classes/ in the file paths

--- a/runner/api/src/BuildReporter.scala
+++ b/runner/api/src/BuildReporter.scala
@@ -13,6 +13,39 @@ trait TestReporter {
 
   def logFinish(event: Event): Unit
 
+  def logLevel: TestReporter.LogLevel =
+    TestReporter.LogLevel.Info
+}
+
+object TestReporter {
+  enum LogLevel(val level: Int, val asString: String) extends Product with Serializable
+      with Comparable[LogLevel]:
+    case Error extends LogLevel(4, "error")
+    case Warn extends LogLevel(3, "warn")
+    case Info extends LogLevel(2, "info")
+    case Debug extends LogLevel(1, "debug")
+
+    def compareTo(other: LogLevel): Int =
+      level.compareTo(other.level)
+
+  object LogLevel {
+    def fromString(input: String): LogLevel =
+      input match {
+        case "error" => Error
+        case "warn" => Warn
+        case "info" => Info
+        case "debug" => Debug
+        case _ => sys.error(s"Unrecognized log level value: '$input'")
+      }
+  }
+
+  def apply(logLevel: LogLevel): TestReporter =
+    new DefaultImpl(logLevel)
+
+  private final class DefaultImpl(override val logLevel: LogLevel) extends TestReporter {
+    override def logStart(event: Event): Unit = {}
+    override def logFinish(event: Event): Unit = {}
+  }
 }
 
 /**

--- a/scalalib/src/mill/scalalib/JsonFormatters.scala
+++ b/scalalib/src/mill/scalalib/JsonFormatters.scala
@@ -3,6 +3,7 @@ package mill.scalalib
 import upickle.default.{ReadWriter => RW}
 import mill.api.Mirrors
 import mill.api.Mirrors.autoMirror
+import mill.runner.api.TestReporter
 
 trait JsonFormatters {
   import JsonFormatters.mirrors.given
@@ -116,6 +117,11 @@ trait JsonFormatters {
     )
   implicit lazy val projectFormat: RW[coursier.core.Project] = upickle.default.macroRW
 
+  implicit lazy val logLevelRW: upickle.default.ReadWriter[TestReporter.LogLevel] =
+    implicitly[upickle.default.ReadWriter[String]].bimap(
+      _.asString,
+      TestReporter.LogLevel.fromString(_)
+    )
 }
 object JsonFormatters extends JsonFormatters {
   private[mill] object mirrors {

--- a/scalalib/src/mill/scalalib/TestModule.scala
+++ b/scalalib/src/mill/scalalib/TestModule.scala
@@ -2,6 +2,7 @@ package mill.scalalib
 
 import mill.api.{Ctx, PathRef, Result}
 import mill.define.{Command, Task, TaskModule}
+import mill.runner.api.TestReporter
 import mill.scalalib.bsp.{BspBuildTarget, BspModule}
 import mill.testrunner.{Framework, TestArgs, TestResult, TestRunner}
 import mill.util.Jvm
@@ -146,6 +147,8 @@ trait TestModule
    */
   def testReportXml: T[Option[String]] = T(Some("test-report.xml"))
 
+  def testLogLevel: T[TestReporter.LogLevel] = Task(TestReporter.LogLevel.Debug)
+
   /**
    * Returns a Tuple where the first element is the main-class, second and third are main-class-arguments and the forth is classpath
    */
@@ -166,7 +169,8 @@ trait TestModule
         resultPath = resultPath,
         colored = Task.log.prompt.colored,
         testCp = testClasspath().map(_.path),
-        globSelectors = Left(selectors)
+        globSelectors = Left(selectors),
+        logLevel = testLogLevel()
       )
 
       val argsFile = Task.dest / "testargs"
@@ -216,7 +220,8 @@ trait TestModule
         forkWorkingDir(),
         testReportXml(),
         jvmWorker().javaHome().map(_.path),
-        testParallelism()
+        testParallelism(),
+        testLogLevel()
       )
       testModuleUtil.runTests()
     }

--- a/scalalib/src/mill/scalalib/TestModuleUtil.scala
+++ b/scalalib/src/mill/scalalib/TestModuleUtil.scala
@@ -2,6 +2,7 @@ package mill.scalalib
 
 import mill.api.{Ctx, PathRef, Result}
 import mill.constants.EnvVars
+import mill.runner.api.TestReporter
 import mill.testrunner.{TestArgs, TestResult, TestRunnerUtils}
 import mill.util.Jvm
 import mill.Task
@@ -32,7 +33,8 @@ private final class TestModuleUtil(
     forkWorkingDir: os.Path,
     testReportXml: Option[String],
     javaHome: Option[os.Path],
-    testParallelism: Boolean
+    testParallelism: Boolean,
+    testLogLevel: TestReporter.LogLevel
 )(implicit ctx: mill.api.Ctx) {
 
   private val (jvmArgs, props: Map[String, String]) =
@@ -139,7 +141,8 @@ private final class TestModuleUtil(
       resultPath = resultPath,
       colored = Task.log.prompt.colored,
       testCp = testClasspath.map(_.path),
-      globSelectors = selector
+      globSelectors = selector,
+      logLevel = testLogLevel
     )
 
     val argsFile = baseFolder / "testargs"

--- a/testrunner/src/mill/testrunner/Model.scala
+++ b/testrunner/src/mill/testrunner/Model.scala
@@ -2,6 +2,7 @@ package mill.testrunner
 
 import mill.api.JsonFormatters._
 import mill.api.internal
+import mill.runner.api.TestReporter
 
 @internal case class TestArgs(
     framework: String,
@@ -17,10 +18,16 @@ import mill.api.internal
     // - Left(selectors: Seq[String]): - list of glob selectors, testrunner is given a list of glob selectors to run directly
     // - Right((selectorFolder: os.Path, baseFolder: os.Path)): - a pair of paths, testrunner will try to claim test glob from selectorFolder
     // and move it actomatically in to baseFolder and run it from there.
-    globSelectors: Either[Seq[String], (Option[String], os.Path, os.Path)]
+    globSelectors: Either[Seq[String], (Option[String], os.Path, os.Path)],
+    logLevel: TestReporter.LogLevel
 )
 
 @internal object TestArgs {
+  implicit lazy val logLevelRW: upickle.default.ReadWriter[TestReporter.LogLevel] =
+    implicitly[upickle.default.ReadWriter[String]].bimap(
+      _.asString,
+      TestReporter.LogLevel.fromString(_)
+    )
   implicit def resultRW: upickle.default.ReadWriter[TestArgs] = upickle.default.macroRW
 }
 

--- a/testrunner/src/mill/testrunner/TestRunnerMain0.scala
+++ b/testrunner/src/mill/testrunner/TestRunnerMain0.scala
@@ -1,7 +1,7 @@
 package mill.testrunner
 
 import mill.api.internal
-import mill.runner.api.DummyTestReporter
+import mill.runner.api.TestReporter
 
 @internal object TestRunnerMain0 {
   def main0(args: Array[String], classLoader: ClassLoader): Unit = {
@@ -18,7 +18,7 @@ import mill.runner.api.DummyTestReporter
             args = testArgs.arguments,
             classFilter = cls => filter(cls.getName),
             cl = classLoader,
-            testReporter = DummyTestReporter,
+            testReporter = TestReporter(testArgs.logLevel),
             resultPathOpt = Some(testArgs.resultPath)
           )
         case Right((startingTestClass, testClassQueueFolder, claimFolder)) =>
@@ -30,7 +30,7 @@ import mill.runner.api.DummyTestReporter
             testClassQueueFolder = testClassQueueFolder,
             claimFolder = claimFolder,
             cl = classLoader,
-            testReporter = DummyTestReporter,
+            testReporter = TestReporter(testArgs.logLevel),
             resultPath = testArgs.resultPath
           )
       }


### PR DESCRIPTION
This adds a new `testLogLevel` task on `TestModule`, that allows users to silence test debug output. It's useful to make the netty tests less verbose, which is what the second commit does.

My goal here is to make the netty tests, that fail from time to time, stop unnecessarily flooding the CI output, like [they do sometimes](https://github.com/alexarchambault/mill/actions/runs/14306280494/job/40092395363).