### PR TITLE
Split out `runner.meta` from `runner`

### DIFF
--- a/runner/meta/src/mill/runner/meta/CliImports.scala
+++ b/runner/meta/src/mill/runner/meta/CliImports.scala
@@ -1,5 +1,4 @@
-package mill.runner
-
+package mill.runner.meta
 import scala.util.DynamicVariable
 
 /**

--- a/runner/meta/src/mill/runner/meta/CodeGen.scala
+++ b/runner/meta/src/mill/runner/meta/CodeGen.scala
@@ -1,5 +1,4 @@
-package mill.runner
-
+package mill.runner.meta
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 import mill.constants.CodeGenConstants.*

--- a/runner/meta/src/mill/runner/meta/FileImportGraph.scala
+++ b/runner/meta/src/mill/runner/meta/FileImportGraph.scala
@@ -1,5 +1,4 @@
-package mill.runner
-
+package mill.runner.meta
 import mill.api.internal
 import mill.constants.CodeGenConstants.*
 import mill.constants.OutFiles.*

--- a/runner/meta/src/mill/runner/meta/MillBuildRootModule.scala
+++ b/runner/meta/src/mill/runner/meta/MillBuildRootModule.scala
@@ -1,5 +1,4 @@
-package mill.runner
-
+package mill.runner.meta
 import scala.jdk.CollectionConverters.ListHasAsScala
 import coursier.Repository
 import mill.*
@@ -13,7 +12,7 @@ import mill.constants.OutFiles.*
 import mill.constants.CodeGenConstants.buildFileExtensions
 import mill.util.BuildInfo
 import mill.define.RootModule0
-import mill.runner.worker.ScalaCompilerWorker
+import mill.runner.meta.ScalaCompilerWorker
 import mill.runner.worker.api.ScalaCompilerWorkerApi
 
 import scala.util.Try
@@ -122,7 +121,7 @@ class MillBuildRootModule()(implicit
       ) ++
       // only include mill-runner for meta-builds
       Option.when(rootModuleInfo.projectRoot / os.up != rootModuleInfo.topLevelProjectRoot) {
-        ivy"com.lihaoyi::mill-runner:${Versions.millVersion}"
+        ivy"com.lihaoyi::mill-runner-meta:${Versions.millVersion}"
       }
   }
 

--- a/runner/meta/src/mill/runner/meta/MillIvy.scala
+++ b/runner/meta/src/mill/runner/meta/MillIvy.scala
@@ -1,5 +1,4 @@
-package mill.runner
-
+package mill.runner.meta
 object MillIvy {
   def processMillIvyDepSignature(signatures: Set[String]): Set[String] = {
     val millSigs: Set[String] =

--- a/runner/meta/src/mill/runner/meta/ScalaCompilerWorker.scala
+++ b/runner/meta/src/mill/runner/meta/ScalaCompilerWorker.scala
@@ -1,5 +1,4 @@
-package mill.runner.worker
-
+package mill.runner.meta
 import mill.PathRef
 import mill.runner.worker.api.ScalaCompilerWorkerApi
 import mill.api.Result

--- a/runner/package.mill
+++ b/runner/package.mill
@@ -9,7 +9,7 @@ import mill.contrib.buildinfo.BuildInfo
  *
  * Mostly tested by [[build.integration]] and [[build.example]] tests.
  */
-object `package` extends RootModule with build.MillPublishScalaModule with BuildInfo {
+object `package` extends RootModule with build.MillPublishScalaModule {
   object api extends build.MillPublishScalaModule with BuildInfo {
     def moduleDeps = Seq(build.core.constants)
     def ivyDeps = Seq(build.Deps.sbtTestInterface)
@@ -84,25 +84,33 @@ object `package` extends RootModule with build.MillPublishScalaModule with Build
       )
     }
   }
+  object meta extends build.MillPublishScalaModule with BuildInfo {
+    def moduleDeps = Seq(
+      build.scalalib,
+      build.core.codesig,
+      build.runner.client,
+      `worker-api`,
+      build.main
+    )
+
+    def buildInfoPackageName = "mill.runner.meta"
+
+    def buildInfoMembers = Seq(
+      BuildInfo.Value(
+        "bootstrapDeps",
+        worker.bootstrapDeps().mkString(";"),
+        "Depedendencies used to bootstrap the scala compiler worker."
+      )
+    )
+  }
 
   def moduleDeps = Seq(
-    build.core,
-    build.main,
-    build.scalalib,
     build.bsp,
-    build.core.codesig,
+    build.core,
     build.runner.server,
     client,
-    `worker-api`
+    `worker-api`,
+    meta
   )
 
-  def buildInfoPackageName = "mill.runner.worker"
-
-  def buildInfoMembers = Seq(
-    BuildInfo.Value(
-      "bootstrapDeps",
-      worker.bootstrapDeps().mkString(";"),
-      "Depedendencies used to bootstrap the scala compiler worker."
-    )
-  )
 }

--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -8,11 +8,9 @@ import mill.runner.api.{RootModuleApi, EvaluatorApi}
 import mill.constants.CodeGenConstants.*
 import mill.api.{Logger, PathRef, Result, SystemStreams, Val, WorkspaceRoot, internal}
 import mill.define.{BaseModule, Evaluator, Segments, SelectMode}
-import mill.exec.JsonArrayLogger
 import mill.constants.OutFiles.{millBuild, millChromeProfile, millProfile, millRunnerState}
-import mill.eval.EvaluatorImpl
 import mill.runner.worker.api.MillScalaParser
-import mill.runner.worker.ScalaCompilerWorker
+import mill.runner.meta.{ScalaCompilerWorker, CliImports, FileImportGraph, MillBuildRootModule}
 
 import java.io.File
 import java.net.URLClassLoader

--- a/runner/src/mill/runner/MillMain.scala
+++ b/runner/src/mill/runner/MillMain.scala
@@ -21,7 +21,7 @@ import mill.api.{
 import mill.constants.{OutFiles, ServerFiles, Util}
 import mill.client.lock.Lock
 import mill.util.BuildInfo
-import mill.runner.worker.ScalaCompilerWorker
+import mill.runner.meta.ScalaCompilerWorker
 import mill.internal.{Colors, PromptLogger}
 
 import java.lang.reflect.InvocationTargetException


### PR DESCRIPTION
Part of https://github.com/com-lihaoyi/mill/issues/4885

`mill.runner.meta` contains `MillBuildRootModule` and other things on the `mill-build/build.mill` classpath, which is a subset of what is necessary in the main `mill.runner` entrypoint. `mill.runner` needs to depend on `mill.runner.meta` in order to use `MillBuildRootModule.BootstrapModule` to begin the bootstrapping process of the meta-build, but `mill.runner.meta` does not need to depend on `mill.runner` and it's associated modules like `mill.bsp`, `mill.core`, `mill.runner.server`, etc.