### PR TITLE
Implement prepareOffline for ClassgraphWorkerModule

### DIFF
--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -1245,6 +1245,7 @@ trait JavaModule
     Task.Command {
       super.prepareOffline(all)()
       resolvedIvyDeps()
+      classgraphWorkerModule().prepareOffline(all)()
       jvmWorker().prepareOffline(all)()
       resolvedRunIvyDeps()
       Task.sequence(tasks)()

--- a/scalalib/src/mill/scalalib/classgraph/ClassgraphWorkerModule.scala
+++ b/scalalib/src/mill/scalalib/classgraph/ClassgraphWorkerModule.scala
@@ -1,16 +1,23 @@
 package mill.scalalib.classgraph
 
-import mill.{T, Task}
+import mainargs.Flag
+import mill.{Command, T, Task}
 import mill.api.{Ctx, PathRef}
 import mill.define.{Discover, ExternalModule, Worker}
-import mill.scalalib.{CoursierModule, Dep}
+import mill.scalalib.{CoursierModule, OfflineSupportModule, Dep}
 
-trait ClassgraphWorkerModule extends CoursierModule {
+trait ClassgraphWorkerModule extends CoursierModule with OfflineSupportModule {
 
   def classgraphWorkerClasspath: T[Seq[PathRef]] = T {
     defaultResolver().classpath(Seq(
       Dep.millProjectModule("mill-scalalib-classgraph-worker")
     ))
+  }
+
+  override def prepareOffline(all: Flag): Command[Unit] = Task.Command {
+    super.prepareOffline(all)()
+    classgraphWorkerClasspath()
+    ()
   }
 
   def classgraphWorker: Worker[ClassgraphWorker] = Task.Worker {


### PR DESCRIPTION
#4822 introduced `ClassgraphWorkerModule` and the corresponding package `classgraph-worker`, but `prepareOffline` does not install it, causing offline build to fail. This PR fixes that problem.