### PR TITLE
Fix `dist.run` stdout forwarding

### DIFF
--- a/dist/package.mill
+++ b/dist/package.mill
@@ -202,7 +202,8 @@ object `package` extends RootModule with InstallModule {
             env = forkEnv() ++ Map(
               "MILL_LOCAL_TEST_OVERRIDE_CLASSPATH" -> build.dist.localTestOverridesClasspath().path.toString
             ),
-            cwd = wd
+            cwd = wd,
+            stdout = os.Inherit
           )
           mill.api.Result.Success(())
         } catch {


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/4863

Seems like it was broken by #4837 which replaced `Jvm.runSubprocess` with `os.call`, which unfortunately had different stream forwarding defaults. This class of problem should be impossible in future thanks to https://github.com/com-lihaoyi/mill/pull/4456 from @sake92 which standardizing the stream forwarding defaults of `Jvm.*Process` APIs with `os.*`