### PR TITLE
Privatize `mill.internal`-specific BSP methods, remove unused `upickle.default.ReadWriter[BspServerResult]`

### DIFF
--- a/bsp/src/mill/bsp/BSP.scala
+++ b/bsp/src/mill/bsp/BSP.scala
@@ -9,23 +9,6 @@ import Mirrors.autoMirror
 import mill.api.internal.{BspServerResult, internal}
 
 object BSP extends ExternalModule with CoursierModule {
-
-  implicit val jsonifyReloadWorkspace
-      : upickle.default.ReadWriter[BspServerResult.ReloadWorkspace.type] =
-    upickle.default.macroRW
-
-  implicit val jsonifyShutdown: upickle.default.ReadWriter[BspServerResult.Shutdown.type] =
-    upickle.default.macroRW
-
-  implicit val jsonifyFailure: upickle.default.ReadWriter[BspServerResult.Failure.type] =
-    upickle.default.macroRW
-
-  implicit val jsonify: upickle.default.ReadWriter[BspServerResult] =
-    upickle.default.macroRW
-
-  private given Root_BspServerResult: Mirrors.Root[BspServerResult] =
-    Mirrors.autoRoot[BspServerResult]
-
   lazy val millDiscover = Discover[this.type]
 
   private def bspWorkerLibs: T[Seq[PathRef]] = Task {

--- a/core/api/src/mill/api/internal/EvaluatorApi.scala
+++ b/core/api/src/mill/api/internal/EvaluatorApi.scala
@@ -11,7 +11,7 @@ trait EvaluatorApi extends AutoCloseable {
       selectiveExecution: Boolean = false
   ): Result[EvaluatorApi.Result[Any]]
 
-  def executeApi[T](
+  private[mill] def executeApi[T](
       targets: Seq[TaskApi[T]],
       reporter: Int => Option[CompileProblemReporter] = _ => Option.empty[CompileProblemReporter],
       testReporter: TestReporter = TestReporter.DummyTestReporter,
@@ -22,7 +22,7 @@ trait EvaluatorApi extends AutoCloseable {
 
   private[mill] def workerCache: mutable.Map[String, (Int, Val)]
 
-  def executeApi[T](targets: Seq[TaskApi[T]]): EvaluatorApi.Result[T]
+  private[mill] def executeApi[T](targets: Seq[TaskApi[T]]): EvaluatorApi.Result[T]
   private[mill] def baseLogger: Logger
   private[mill] def rootModule: BaseModuleApi
   private[mill] def outPathJava: java.nio.file.Path
@@ -48,9 +48,9 @@ object EvaluatorApi {
 
 trait ExecutionResultsApi {
   def results: Seq[ExecResult[Val]]
-  def transitiveResultsApi: Map[TaskApi[?], ExecResult[Val]]
+  private[mill] def transitiveResultsApi: Map[TaskApi[?], ExecResult[Val]]
 
-  def transitiveFailingApi: Map[TaskApi[?], ExecResult.Failing[Val]]
+  private[mill] def transitiveFailingApi: Map[TaskApi[?], ExecResult.Failing[Val]]
   def uncached: Seq[TaskApi[?]]
 
   def values: Seq[Val]

--- a/core/api/src/mill/api/internal/SemanticDbJavaModuleApi.scala
+++ b/core/api/src/mill/api/internal/SemanticDbJavaModuleApi.scala
@@ -3,7 +3,7 @@ package mill.api.internal
 import mill.api.BuildInfo
 
 trait SemanticDbJavaModuleApi {
-  def bspBuildTargetCompileSemanticDb: TaskApi[java.nio.file.Path]
+  private[mill] def bspBuildTargetCompileSemanticDb: TaskApi[java.nio.file.Path]
 }
 object SemanticDbJavaModuleApi {
   val buildTimeJavaSemanticDbVersion = BuildInfo.semanticDbJavaVersion

--- a/core/api/src/mill/api/internal/api.scala
+++ b/core/api/src/mill/api/internal/api.scala
@@ -8,80 +8,41 @@ trait NamedTaskApi[+T] extends TaskApi[T] {
 }
 trait ModuleApi {
   def moduleDirectChildren: Seq[ModuleApi]
-  def moduleDirJava: java.nio.file.Path
+  private[mill] def moduleDirJava: java.nio.file.Path
   def moduleSegments: Segments
 }
 trait JavaModuleApi extends ModuleApi {
-  def bspBuildTargetScalaMainClasses: TaskApi[(Seq[String], Seq[String], Map[String, String])]
+  private[mill] def bspBuildTargetScalaMainClasses
+      : TaskApi[(Seq[String], Seq[String], Map[String, String])]
   def recursiveModuleDeps: Seq[JavaModuleApi]
   def compileModuleDepsChecked: Seq[JavaModuleApi]
-  def bspRun(args: Seq[String]): TaskApi[Unit]
-  def bspBuildTargetSources: TaskApi[(Seq[java.nio.file.Path], Seq[java.nio.file.Path])]
-//  Task.Anon {
-//    module.sources().map(p => sourceItem(p.path, false)) ++
-//      module.generatedSources().map(p => sourceItem(p.path, true))
-//  }
+  private[mill] def bspRun(args: Seq[String]): TaskApi[Unit]
+  private[mill] def bspBuildTargetSources
+      : TaskApi[(Seq[java.nio.file.Path], Seq[java.nio.file.Path])]
 
-  def bspBuildTargetInverseSources[T](id: T, uri: String): TaskApi[Seq[T]]
-//  Task.Anon {
-//    val src = m.allSourceFiles()
-//    val found = src.map(sanitizeUri).contains(
-//      p.getTextDocument.getUri
-//    )
-//    if (found) Seq(id) else Seq()
-//  }
+  private[mill] def bspBuildTargetInverseSources[T](id: T, uri: String): TaskApi[Seq[T]]
 
-  def bspBuildTargetDependencySources(includeSources: Boolean)
+  private[mill] def bspBuildTargetDependencySources(includeSources: Boolean)
       : TaskApi[(Seq[java.nio.file.Path], Seq[java.nio.file.Path], Seq[String])]
-//  Task.Anon {
-//    (
-//      m.millResolver().classpath(
-//        Seq(
-//          m.coursierDependency.withConfiguration(coursier.core.Configuration.provided),
-//          m.coursierDependency
-//        ),
-//        sources = true
-//      ),
-//      m.unmanagedClasspath(),
-//      m.allRepositories()
-//    )
-//  }
 
-  def bspBuildTargetDependencyModules
+  private[mill] def bspBuildTargetDependencyModules
       : TaskApi[(Seq[(String, String, String)], Seq[java.nio.file.Path])]
-//  Task.Anon {
-//    (
-//      // full list of dependencies, including transitive ones
-//      m.millResolver()
-//        .resolution(
-//          Seq(
-//            m.coursierDependency.withConfiguration(coursier.core.Configuration.provided),
-//            m.coursierDependency
-//          )
-//        )
-//        .orderedDependencies,
-//      m.unmanagedClasspath()
-//    )
-//  }
 
-  def bspBuildTargetResources: TaskApi[Seq[java.nio.file.Path]]
-//  Task.Anon {
-//    m.resources()
-//  }
+  private[mill] def bspBuildTargetResources: TaskApi[Seq[java.nio.file.Path]]
 
-  def bspBuildTargetCompile: TaskApi[java.nio.file.Path]
+  private[mill] def bspBuildTargetCompile: TaskApi[java.nio.file.Path]
 
-  def bspBuildTargetJavacOptions(clientWantsSemanticDb: Boolean)
+  private[mill] def bspBuildTargetJavacOptions(clientWantsSemanticDb: Boolean)
       : TaskApi[EvaluatorApi => (java.nio.file.Path, Seq[String], Seq[String])]
 
-  def bspCompileClasspath: TaskApi[EvaluatorApi => Seq[String]]
+  private[mill] def bspCompileClasspath: TaskApi[EvaluatorApi => Seq[String]]
 
-  def bspBuildTargetScalacOptions(
+  private[mill] def bspBuildTargetScalacOptions(
       enableJvmCompileClasspathProvider: Boolean,
       clientWantsSemanticDb: Boolean
   ): TaskApi[(Seq[String], EvaluatorApi => Seq[String], EvaluatorApi => java.nio.file.Path)]
 
-  def genIdeaMetadata(
+  private[mill] def genIdeaMetadata(
       ideaConfigVersion: Int,
       evaluator: EvaluatorApi,
       path: mill.api.Segments
@@ -89,7 +50,7 @@ trait JavaModuleApi extends ModuleApi {
 
   def transitiveModuleCompileModuleDeps: Seq[JavaModuleApi]
   def skipIdea: Boolean
-  def intellijModulePathJava: java.nio.file.Path
+  private[mill] def intellijModulePathJava: java.nio.file.Path
   def buildLibraryPaths: TaskApi[Seq[java.nio.file.Path]]
 }
 object JavaModuleApi
@@ -101,12 +62,12 @@ trait TestModuleApi extends ModuleApi {
   def testLocal(args: String*): TaskApi[(String, Seq[Any])]
 }
 trait BspModuleApi extends ModuleApi {
-  def bspBuildTargetData: TaskApi[Option[(String, AnyRef)]]
-  def bspBuildTarget: BspBuildTarget
-  def bspDisplayName: String
+  private[mill] def bspBuildTargetData: TaskApi[Option[(String, AnyRef)]]
+  private[mill] def bspBuildTarget: BspBuildTarget
+  private[mill] def bspDisplayName: String
 }
 trait RunModuleApi extends ModuleApi {
-  def bspJvmRunTestEnvironment: TaskApi[(
+  private[mill] def bspJvmRunTestEnvironment: TaskApi[(
       Seq[java.nio.file.Path],
       Seq[String],
       java.nio.file.Path,

--- a/core/define/src/mill/define/Discover.scala
+++ b/core/define/src/mill/define/Discover.scala
@@ -101,11 +101,11 @@ object Discover {
       def filterDefs(methods: List[Symbol]): List[Symbol] =
         methods.filterNot { m =>
           m.isSuperAccessor
-            || m.hasAnnotation(deprecatedSym)
-            || m.flags.is(
+          || m.hasAnnotation(deprecatedSym)
+          || m.flags.is(
             Flags.Synthetic | Flags.Invisible | Flags.Private | Flags.Protected
           )
-            || m.privateWithin.nonEmpty // for some reason `Flags.Private` doesn't always work
+          || m.privateWithin.nonEmpty // for some reason `Flags.Private` doesn't always work
         }
 
       def sortedMethods(curCls: TypeRepr, sub: TypeRepr, methods: Seq[Symbol]): Seq[Symbol] =

--- a/core/define/src/mill/define/Discover.scala
+++ b/core/define/src/mill/define/Discover.scala
@@ -99,13 +99,14 @@ object Discover {
       }
 
       def filterDefs(methods: List[Symbol]): List[Symbol] =
-        methods.filterNot(m =>
+        methods.filterNot { m =>
           m.isSuperAccessor
             || m.hasAnnotation(deprecatedSym)
             || m.flags.is(
-              Flags.Synthetic | Flags.Invisible | Flags.Private | Flags.Protected
-            )
-        )
+            Flags.Synthetic | Flags.Invisible | Flags.Private | Flags.Protected
+          )
+            || m.privateWithin.nonEmpty // for some reason `Flags.Private` doesn't always work
+        }
 
       def sortedMethods(curCls: TypeRepr, sub: TypeRepr, methods: Seq[Symbol]): Seq[Symbol] =
         for {

--- a/core/define/src/mill/define/Evaluator.scala
+++ b/core/define/src/mill/define/Evaluator.scala
@@ -64,7 +64,7 @@ trait Evaluator extends AutoCloseable with EvaluatorApi {
    */
   def topoSorted(transitiveTargets: IndexedSeq[Task[?]]): mill.define.internal.TopoSorted
 
-  def executeApi[T](targets: Seq[TaskApi[T]]): Evaluator.Result[T] =
+  private[mill] def executeApi[T](targets: Seq[TaskApi[T]]): Evaluator.Result[T] =
     execute[T](targets.map(_.asInstanceOf[Task[T]]))
 
   def execute[T](
@@ -82,7 +82,7 @@ trait Evaluator extends AutoCloseable with EvaluatorApi {
       selectiveExecution: Boolean = false
   ): mill.api.Result[Evaluator.Result[Any]]
 
-  def executeApi[T](
+  private[mill] def executeApi[T](
       targets: Seq[TaskApi[T]],
       reporter: Int => Option[CompileProblemReporter] = _ => Option.empty[CompileProblemReporter],
       testReporter: TestReporter = TestReporter.DummyTestReporter,

--- a/core/define/src/mill/define/ExecutionResults.scala
+++ b/core/define/src/mill/define/ExecutionResults.scala
@@ -15,7 +15,7 @@ trait ExecutionResults extends ExecutionResultsApi {
    * tasks, and their results
    */
   def transitiveResults: Map[Task[?], ExecResult[Val]]
-  def transitiveResultsApi: Map[TaskApi[?], ExecResult[Val]] =
+  private[mill] def transitiveResultsApi: Map[TaskApi[?], ExecResult[Val]] =
     transitiveResults.asInstanceOf[Map[TaskApi[?], ExecResult[Val]]]
 
   /**
@@ -28,7 +28,7 @@ trait ExecutionResults extends ExecutionResultsApi {
    */
   def transitiveFailing: Map[Task[?], ExecResult.Failing[Val]] =
     transitiveResults.collect { case (k, v: ExecResult.Failing[Val]) => (k, v) }
-  def transitiveFailingApi: Map[TaskApi[?], ExecResult.Failing[Val]] =
+  private[mill] def transitiveFailingApi: Map[TaskApi[?], ExecResult.Failing[Val]] =
     transitiveFailing.asInstanceOf[Map[TaskApi[?], ExecResult.Failing[Val]]]
 
   /**

--- a/integration/ide/bsp-server/src/BspServerTestUtil.scala
+++ b/integration/ide/bsp-server/src/BspServerTestUtil.scala
@@ -18,7 +18,7 @@ object BspServerTestUtil {
 
   val updateSnapshots = false
 
-  def bsp4jVersion: String = sys.props.getOrElse("BSP4J_VERSION", ???)
+  private[mill] def bsp4jVersion: String = sys.props.getOrElse("BSP4J_VERSION", ???)
 
   trait DummyBuildClient extends b.BuildClient {
     def onBuildLogMessage(params: b.LogMessageParams): Unit = ()

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -1396,7 +1396,7 @@ trait JavaModule
   private[mill] def bspBuildTargetScalaMainClasses =
     Task.Anon((allLocalMainClasses(), forkArgs(), forkEnv()))
 
-  private[mill] def bspRun(args: Seq[String]): Command[Unit] = Task.Command {
+  private[mill] def bspRun(args: Seq[String]): Task[Unit] = Task.Anon {
     run(Task.Anon(Args(args)))()
   }
 

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -671,7 +671,7 @@ trait JavaModule
    * Keep in sync with [[transitiveLocalClasspath]]
    */
   @internal
-  def bspTransitiveLocalClasspath: T[Seq[UnresolvedPath]] = Task {
+  private[mill] def bspTransitiveLocalClasspath: T[Seq[UnresolvedPath]] = Task {
     Task.traverse(transitiveModuleCompileModuleDeps)(_.bspLocalClasspath)().flatten
   }
 
@@ -691,7 +691,7 @@ trait JavaModule
    * Keep in sync with [[transitiveCompileClasspath]]
    */
   @internal
-  def bspTransitiveCompileClasspath: T[Seq[UnresolvedPath]] = Task {
+  private[mill] def bspTransitiveCompileClasspath: T[Seq[UnresolvedPath]] = Task {
     Task.traverse(transitiveModuleCompileModuleDeps)(m =>
       Task.Anon {
         m.localCompileClasspath().map(p => UnresolvedPath.ResolvedPath(p.path)) ++
@@ -797,7 +797,7 @@ trait JavaModule
    * Keep in sync with [[compile]]
    */
   @internal
-  def bspCompileClassesPath: T[UnresolvedPath] =
+  private[mill] def bspCompileClassesPath: T[UnresolvedPath] =
     if (compile.ctx.enclosing == s"${classOf[JavaModule].getName}#compile") {
       Task {
         Task.log.debug(
@@ -829,7 +829,7 @@ trait JavaModule
    *
    * Keep in sync with [[localRunClasspath]]
    */
-  def bspLocalRunClasspath: T[Seq[UnresolvedPath]] = Task {
+  private[mill] def bspLocalRunClasspath: T[Seq[UnresolvedPath]] = Task {
     Seq.from(super.localRunClasspath() ++ resources())
       .map(p => UnresolvedPath.ResolvedPath(p.path)) ++
       Seq(bspCompileClassesPath())
@@ -855,7 +855,7 @@ trait JavaModule
    * Keep in sync with [[localClasspath]]
    */
   @internal
-  def bspLocalClasspath: T[Seq[UnresolvedPath]] = Task {
+  private[mill] def bspLocalClasspath: T[Seq[UnresolvedPath]] = Task {
     (localCompileClasspath()).map(p => UnresolvedPath.ResolvedPath(p.path)) ++
       bspLocalRunClasspath()
   }
@@ -876,7 +876,7 @@ trait JavaModule
    * Keep in sync with [[compileClasspath]]
    */
   @internal
-  def bspCompileClasspath: Task[EvaluatorApi => Seq[String]] = Task.Anon {
+  private[mill] def bspCompileClasspath: Task[EvaluatorApi => Seq[String]] = Task.Anon {
     (ev: EvaluatorApi) =>
       (resolvedIvyDeps().map(p => UnresolvedPath.ResolvedPath(p.path)) ++
         bspTransitiveCompileClasspath() ++
@@ -1272,7 +1272,7 @@ trait JavaModule
   )
 
   @internal
-  def bspJvmBuildTargetTask: Task[JvmBuildTarget] = Task.Anon {
+  private[mill] def bspJvmBuildTargetTask: Task[JvmBuildTarget] = Task.Anon {
     JvmBuildTarget(
       javaHome = jvmWorker()
         .javaHome()
@@ -1287,7 +1287,7 @@ trait JavaModule
     Some((JvmBuildTarget.dataKind, bspJvmBuildTargetTask()))
   }
 
-  def bspBuildTargetScalacOptions(
+  private[mill] def bspBuildTargetScalacOptions(
       enableJvmCompileClasspathProvider: Boolean,
       clientWantsSemanticDb: Boolean
   ) = {
@@ -1324,7 +1324,7 @@ trait JavaModule
     }
   }
 
-  def bspBuildTargetJavacOptions(clientWantsSemanticDb: Boolean) = {
+  private[mill] def bspBuildTargetJavacOptions(clientWantsSemanticDb: Boolean) = {
     val classesPathTask = this match {
       case sem: SemanticDbJavaModule if clientWantsSemanticDb =>
         sem.bspCompiledClassesAndSemanticDbFiles
@@ -1339,7 +1339,7 @@ trait JavaModule
     }
   }
 
-  def bspBuildTargetSources = Task.Anon {
+  private[mill] def bspBuildTargetSources = Task.Anon {
     Tuple2(sources().map(_.path.toNIO), generatedSources().map(_.path.toNIO))
   }
 
@@ -1350,13 +1350,14 @@ trait JavaModule
 
   def sanitizeUri(uri: PathRef): String = sanitizeUri(uri.path)
 
-  def bspBuildTargetInverseSources[T](id: T, searched: String): Task[Seq[T]] = Task.Anon {
-    val src = allSourceFiles()
-    val found = src.map(sanitizeUri).contains(searched)
-    if (found) Seq(id) else Seq()
-  }
+  private[mill] def bspBuildTargetInverseSources[T](id: T, searched: String): Task[Seq[T]] =
+    Task.Anon {
+      val src = allSourceFiles()
+      val found = src.map(sanitizeUri).contains(searched)
+      if (found) Seq(id) else Seq()
+    }
 
-  def bspBuildTargetDependencySources(includeSources: Boolean) = Task.Anon {
+  private[mill] def bspBuildTargetDependencySources(includeSources: Boolean) = Task.Anon {
     val repos = allRepositories()
     val buildSources = if (!includeSources) Nil
     else mill.scalalib.Lib
@@ -1376,7 +1377,7 @@ trait JavaModule
     )
   }
 
-  def bspBuildTargetDependencyModules = Task.Anon {
+  private[mill] def bspBuildTargetDependencyModules = Task.Anon {
     (
       // full list of dependencies, including transitive ones
       millResolver()
@@ -1392,17 +1393,18 @@ trait JavaModule
     )
   }
 
-  def bspBuildTargetScalaMainClasses = Task.Anon((allLocalMainClasses(), forkArgs(), forkEnv()))
+  private[mill] def bspBuildTargetScalaMainClasses =
+    Task.Anon((allLocalMainClasses(), forkArgs(), forkEnv()))
 
-  def bspRun(args: Seq[String]): Command[Unit] = Task.Command {
+  private[mill] def bspRun(args: Seq[String]): Command[Unit] = Task.Command {
     run(Task.Anon(Args(args)))()
   }
 
-  def bspBuildTargetResources = Task.Anon { resources().map(_.path.toNIO) }
+  private[mill] def bspBuildTargetResources = Task.Anon { resources().map(_.path.toNIO) }
 
-  def bspBuildTargetCompile = Task.Anon { compile().classes.path.toNIO }
+  private[mill] def bspBuildTargetCompile = Task.Anon { compile().classes.path.toNIO }
 
-  def genIdeaMetadata(
+  private[mill] def genIdeaMetadata(
       ideaConfigVersion: Int,
       evaluator: EvaluatorApi,
       path: Segments

--- a/scalalib/src/mill/scalalib/RunModule.scala
+++ b/scalalib/src/mill/scalalib/RunModule.scala
@@ -227,7 +227,7 @@ trait RunModule extends WithJvmWorker with RunModuleApi {
    */
   def launcher: T[PathRef] = Task { launcher0() }
 
-  def bspJvmRunTestEnvironment = {
+  private[mill] def bspJvmRunTestEnvironment = {
     val moduleSpecificTask = this match {
       case m: (TestModule & JavaModule) => m.getTestEnvironmentVars()
       case _ => allLocalMainClasses

--- a/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
+++ b/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
@@ -21,7 +21,7 @@ trait SemanticDbJavaModule extends CoursierModule with SemanticDbJavaModuleApi {
   def zincIncrementalCompilation: T[Boolean]
   def allSourceFiles: T[Seq[PathRef]]
   def compile: T[mill.scalalib.api.CompilationResult]
-  def bspBuildTarget: BspBuildTarget
+  private[mill] def bspBuildTarget: BspBuildTarget
   def javacOptions: T[Seq[String]]
   def mandatoryJavacOptions: T[Seq[String]]
   def compileClasspath: T[Seq[PathRef]]
@@ -138,7 +138,7 @@ trait SemanticDbJavaModule extends CoursierModule with SemanticDbJavaModuleApi {
   }
 
   // keep in sync with compiledClassesAndSemanticDbFiles
-  def bspCompiledClassesAndSemanticDbFiles: T[UnresolvedPath] = {
+  private[mill] def bspCompiledClassesAndSemanticDbFiles: T[UnresolvedPath] = {
     if (
       compiledClassesAndSemanticDbFiles.ctx.enclosing == s"${classOf[SemanticDbJavaModule].getName}#compiledClassesAndSemanticDbFiles"
     ) {
@@ -161,7 +161,7 @@ trait SemanticDbJavaModule extends CoursierModule with SemanticDbJavaModuleApi {
     }
   }
 
-  def bspBuildTargetCompileSemanticDb = Task.Anon {
+  private[mill] def bspBuildTargetCompileSemanticDb = Task.Anon {
     compiledClassesAndSemanticDbFiles().path.toNIO
   }
 }

--- a/scalalib/src/mill/scalalib/TestModule.scala
+++ b/scalalib/src/mill/scalalib/TestModule.scala
@@ -251,7 +251,7 @@ trait TestModule
     )
   }
 
-  def bspBuildTargetScalaTestClasses = this match {
+  private[mill] def bspBuildTargetScalaTestClasses = this match {
     case m: TestModule =>
       Task.Anon(Some((m.runClasspath(), m.testFramework(), m.testClasspath())))
     case _ =>

--- a/scalalib/src/mill/scalalib/bsp/BspModule.scala
+++ b/scalalib/src/mill/scalalib/bsp/BspModule.scala
@@ -7,16 +7,16 @@ import mill.api.internal.{BspBuildTarget, internal}
 
 trait BspModule extends mill.define.Module with mill.api.internal.BspModuleApi {
 
-  def bspDisplayName0: String = this.moduleSegments.render
+  private[mill] def bspDisplayName0: String = this.moduleSegments.render
 
-  def bspDisplayName: String = bspDisplayName0 match {
+  private[mill] def bspDisplayName: String = bspDisplayName0 match {
     case "" => "root-module"
     case n => n
   }
 
   /** Use to fill most fields of `BuildTarget`. */
   @internal
-  def bspBuildTarget: BspBuildTarget = BspBuildTarget(
+  private[mill] def bspBuildTarget: BspBuildTarget = BspBuildTarget(
     displayName = Some(bspDisplayName),
     baseDirectory = Some(moduleDir.toNIO),
     tags = Seq(Tag.Library, Tag.Application),
@@ -35,6 +35,6 @@ trait BspModule extends mill.define.Module with mill.api.internal.BspModuleApi {
    * - [[ScalaBuildTarget]]
    */
   @internal
-  def bspBuildTargetData: Task[Option[(String, AnyRef)]] = Task.Anon { None }
+  private[mill] def bspBuildTargetData: Task[Option[(String, AnyRef)]] = Task.Anon { None }
 
 }


### PR DESCRIPTION
I don't know if we want these to be exposed/override-able by users, but until we make a decision on that it's easiest just to make them all `private[mill]` for now