### PR TITLE
(Backport) Rename `PackageDefaultExternalObject` to the `package` objects

### DIFF
--- a/bsp/src/mill/bsp/BSP.scala
+++ b/bsp/src/mill/bsp/BSP.scala
@@ -7,7 +7,7 @@ import mill.main.BuildInfo
 import mill.eval.Evaluator
 import mill.scalalib.{CoursierModule, Dep}
 
-object PackageDefaultExternalModule extends ExternalModule.Alias(BSP)
+object `package` extends ExternalModule.Alias(BSP)
 object BSP extends ExternalModule with CoursierModule {
 
   lazy val millDiscover: Discover = Discover[this.type]

--- a/bsp/src/mill/bsp/BSP.scala
+++ b/bsp/src/mill/bsp/BSP.scala
@@ -7,7 +7,6 @@ import mill.main.BuildInfo
 import mill.eval.Evaluator
 import mill.scalalib.{CoursierModule, Dep}
 
-object `package` extends ExternalModule.Alias(BSP)
 object BSP extends ExternalModule with CoursierModule {
 
   lazy val millDiscover: Discover = Discover[this.type]

--- a/bsp/src/mill/bsp/package.scala
+++ b/bsp/src/mill/bsp/package.scala
@@ -1,0 +1,5 @@
+package mill.bsp
+
+import mill.define.ExternalModule
+
+object `package` extends ExternalModule.Alias(BSP)

--- a/contrib/artifactory/src/mill/contrib/artifactory/ArtifactoryPublishModule.scala
+++ b/contrib/artifactory/src/mill/contrib/artifactory/ArtifactoryPublishModule.scala
@@ -41,7 +41,6 @@ trait ArtifactoryPublishModule extends PublishModule {
   }
 }
 
-object `package` extends ExternalModule.Alias(ArtifactoryPublishModule)
 object ArtifactoryPublishModule extends ExternalModule {
 
   /**

--- a/contrib/artifactory/src/mill/contrib/artifactory/ArtifactoryPublishModule.scala
+++ b/contrib/artifactory/src/mill/contrib/artifactory/ArtifactoryPublishModule.scala
@@ -41,7 +41,7 @@ trait ArtifactoryPublishModule extends PublishModule {
   }
 }
 
-object PackageDefaultExternalModule extends ExternalModule.Alias(ArtifactoryPublishModule)
+object `package` extends ExternalModule.Alias(ArtifactoryPublishModule)
 object ArtifactoryPublishModule extends ExternalModule {
 
   /**

--- a/contrib/artifactory/src/mill/contrib/artifactory/package.scala
+++ b/contrib/artifactory/src/mill/contrib/artifactory/package.scala
@@ -1,0 +1,5 @@
+package mill.contrib.artifactory
+
+import mill.define.ExternalModule
+
+object `package` extends ExternalModule.Alias(ArtifactoryPublishModule)

--- a/contrib/bintray/src/mill/contrib/bintray/BintrayPublishModule.scala
+++ b/contrib/bintray/src/mill/contrib/bintray/BintrayPublishModule.scala
@@ -50,7 +50,6 @@ trait BintrayPublishModule extends PublishModule {
   }
 }
 
-object `package` extends ExternalModule.Alias(BintrayPublishModule)
 object BintrayPublishModule extends ExternalModule {
 
   /**

--- a/contrib/bintray/src/mill/contrib/bintray/BintrayPublishModule.scala
+++ b/contrib/bintray/src/mill/contrib/bintray/BintrayPublishModule.scala
@@ -50,7 +50,7 @@ trait BintrayPublishModule extends PublishModule {
   }
 }
 
-object PackageDefaultExternalModule extends ExternalModule.Alias(BintrayPublishModule)
+object `package` extends ExternalModule.Alias(BintrayPublishModule)
 object BintrayPublishModule extends ExternalModule {
 
   /**

--- a/contrib/bintray/src/mill/contrib/bintray/package.scala
+++ b/contrib/bintray/src/mill/contrib/bintray/package.scala
@@ -1,0 +1,5 @@
+package mill.contrib.bintray
+
+import mill.define.ExternalModule
+
+object `package` extends ExternalModule.Alias(BintrayPublishModule)

--- a/contrib/codeartifact/src/mill/contrib/codeartifact/CodeartifactPublishModule.scala
+++ b/contrib/codeartifact/src/mill/contrib/codeartifact/CodeartifactPublishModule.scala
@@ -32,7 +32,6 @@ trait CodeartifactPublishModule extends PublishModule {
     }
 }
 
-object `package` extends ExternalModule.Alias(CodeartifactPublishModule)
 object CodeartifactPublishModule extends ExternalModule {
   def publishAll(
       credentials: String,

--- a/contrib/codeartifact/src/mill/contrib/codeartifact/CodeartifactPublishModule.scala
+++ b/contrib/codeartifact/src/mill/contrib/codeartifact/CodeartifactPublishModule.scala
@@ -32,7 +32,7 @@ trait CodeartifactPublishModule extends PublishModule {
     }
 }
 
-object PackageDefaultExternalModule extends ExternalModule.Alias(CodeartifactPublishModule)
+object `package` extends ExternalModule.Alias(CodeartifactPublishModule)
 object CodeartifactPublishModule extends ExternalModule {
   def publishAll(
       credentials: String,

--- a/contrib/codeartifact/src/mill/contrib/codeartifact/package.scala
+++ b/contrib/codeartifact/src/mill/contrib/codeartifact/package.scala
@@ -1,0 +1,5 @@
+package mill.contrib.codeartifact
+
+import mill.define.ExternalModule
+
+object `package` extends ExternalModule.Alias(CodeartifactPublishModule)

--- a/contrib/gitlab/src/mill/contrib/gitlab/GitlabPublishModule.scala
+++ b/contrib/gitlab/src/mill/contrib/gitlab/GitlabPublishModule.scala
@@ -49,7 +49,6 @@ trait GitlabPublishModule extends PublishModule { outer =>
   }
 }
 
-object `package` extends ExternalModule.Alias(GitlabPublishModule)
 object GitlabPublishModule extends ExternalModule {
 
   def publishAll(

--- a/contrib/gitlab/src/mill/contrib/gitlab/GitlabPublishModule.scala
+++ b/contrib/gitlab/src/mill/contrib/gitlab/GitlabPublishModule.scala
@@ -49,7 +49,7 @@ trait GitlabPublishModule extends PublishModule { outer =>
   }
 }
 
-object PackageDefaultExternalModule extends ExternalModule.Alias(GitlabPublishModule)
+object `package` extends ExternalModule.Alias(GitlabPublishModule)
 object GitlabPublishModule extends ExternalModule {
 
   def publishAll(

--- a/contrib/gitlab/src/mill/contrib/gitlab/package.scala
+++ b/contrib/gitlab/src/mill/contrib/gitlab/package.scala
@@ -1,0 +1,5 @@
+package mill.contrib.gitlab
+
+import mill.define.ExternalModule
+
+object `package` extends ExternalModule.Alias(GitlabPublishModule)

--- a/contrib/sonatypecentral/src/mill/contrib/sonatypecentral/SonatypeCentralPublishModule.scala
+++ b/contrib/sonatypecentral/src/mill/contrib/sonatypecentral/SonatypeCentralPublishModule.scala
@@ -60,7 +60,7 @@ trait SonatypeCentralPublishModule extends PublishModule {
     }
 }
 
-object PackageDefaultExternalModule extends ExternalModule.Alias(SonatypeCentralPublishModule)
+object `package` extends ExternalModule.Alias(SonatypeCentralPublishModule)
 object SonatypeCentralPublishModule extends ExternalModule {
 
   val defaultCredentials: String = ""

--- a/contrib/sonatypecentral/src/mill/contrib/sonatypecentral/SonatypeCentralPublishModule.scala
+++ b/contrib/sonatypecentral/src/mill/contrib/sonatypecentral/SonatypeCentralPublishModule.scala
@@ -60,7 +60,6 @@ trait SonatypeCentralPublishModule extends PublishModule {
     }
 }
 
-object `package` extends ExternalModule.Alias(SonatypeCentralPublishModule)
 object SonatypeCentralPublishModule extends ExternalModule {
 
   val defaultCredentials: String = ""

--- a/contrib/sonatypecentral/src/mill/contrib/sonatypecentral/package.scala
+++ b/contrib/sonatypecentral/src/mill/contrib/sonatypecentral/package.scala
@@ -1,0 +1,5 @@
+package mill.contrib.sonatypecentral
+
+import mill.define.ExternalModule
+
+object `package` extends ExternalModule.Alias(SonatypeCentralPublishModule)

--- a/contrib/versionfile/src/mill/contrib/versionfile/VersionFileModule.scala
+++ b/contrib/versionfile/src/mill/contrib/versionfile/VersionFileModule.scala
@@ -80,7 +80,7 @@ trait VersionFileModule extends Module {
     )
 }
 
-object PackageDefaultExternalModule extends define.ExternalModule.Alias(VersionFileModule)
+object `package` extends define.ExternalModule.Alias(VersionFileModule)
 object VersionFileModule extends define.ExternalModule {
 
   /** Executes the given processes. */

--- a/idea/src/mill/idea/GenIdea.scala
+++ b/idea/src/mill/idea/GenIdea.scala
@@ -8,7 +8,7 @@ import mill.eval.Evaluator
 
 import scala.util.control.NonFatal
 
-object PackageDefaultExternalModule extends ExternalModule.Alias(GenIdea)
+object `package` extends ExternalModule.Alias(GenIdea)
 object GenIdea extends ExternalModule with mill.define.TaskModule {
   def defaultCommandName() = "idea"
   def idea(allBootstrapEvaluators: Evaluator.AllBootstrapEvaluators): Command[Unit] = Task.Command {

--- a/idea/src/mill/idea/GenIdea.scala
+++ b/idea/src/mill/idea/GenIdea.scala
@@ -8,7 +8,6 @@ import mill.eval.Evaluator
 
 import scala.util.control.NonFatal
 
-object `package` extends ExternalModule.Alias(GenIdea)
 object GenIdea extends ExternalModule with mill.define.TaskModule {
   def defaultCommandName() = "idea"
   def idea(allBootstrapEvaluators: Evaluator.AllBootstrapEvaluators): Command[Unit] = Task.Command {

--- a/idea/src/mill/idea/package.scala
+++ b/idea/src/mill/idea/package.scala
@@ -1,5 +1,5 @@
 package mill.idea
 
-import mill.define.Discover
+import mill.define.ExternalModule
 
 object `package` extends ExternalModule.Alias(GenIdea)

--- a/idea/src/mill/idea/package.scala
+++ b/idea/src/mill/idea/package.scala
@@ -1,0 +1,5 @@
+package mill.idea
+
+import mill.define.Discover
+
+object `package` extends ExternalModule.Alias(GenIdea)

--- a/kotlinlib/src/mill/kotlinlib/kover/KoverModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/kover/KoverModule.scala
@@ -114,7 +114,7 @@ trait KoverModule extends KotlinModule { outer =>
   }
 }
 
-object PackageDefaultExternalModule extends ExternalModule.Alias(Kover)
+object `package` extends ExternalModule.Alias(Kover)
 
 /**
  * Allows the aggregation of coverage reports across multi-module projects.

--- a/kotlinlib/src/mill/kotlinlib/kover/KoverModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/kover/KoverModule.scala
@@ -114,8 +114,6 @@ trait KoverModule extends KotlinModule { outer =>
   }
 }
 
-object `package` extends ExternalModule.Alias(Kover)
-
 /**
  * Allows the aggregation of coverage reports across multi-module projects.
  *

--- a/kotlinlib/src/mill/kotlinlib/kover/package.scala
+++ b/kotlinlib/src/mill/kotlinlib/kover/package.scala
@@ -1,0 +1,9 @@
+/*
+ * Some parts of this code are taken from lefou/mill-jacoco. Copyright 2021-Present Tobias Roeser.
+ */
+
+package mill.kotlinlib.kover
+
+import mill.define.ExternalModule
+
+object `package` extends ExternalModule.Alias(Kover)

--- a/kotlinlib/src/mill/kotlinlib/ktfmt/KtfmtModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/ktfmt/KtfmtModule.scala
@@ -35,7 +35,7 @@ trait KtfmtBaseModule extends JavaModule {
   }
 }
 
-object PackageDefaultExternalModule extends ExternalModule.Alias(KtfmtModule)
+object `package` extends ExternalModule.Alias(KtfmtModule)
 
 /**
  * Performs formatting checks on Kotlin source files using [[https://github.com/facebook/ktfmt Ktfmt]].

--- a/kotlinlib/src/mill/kotlinlib/ktfmt/KtfmtModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/ktfmt/KtfmtModule.scala
@@ -35,8 +35,6 @@ trait KtfmtBaseModule extends JavaModule {
   }
 }
 
-object `package` extends ExternalModule.Alias(KtfmtModule)
-
 /**
  * Performs formatting checks on Kotlin source files using [[https://github.com/facebook/ktfmt Ktfmt]].
  */

--- a/kotlinlib/src/mill/kotlinlib/ktfmt/package.scala
+++ b/kotlinlib/src/mill/kotlinlib/ktfmt/package.scala
@@ -1,0 +1,5 @@
+package mill.kotlinlib.ktfmt
+
+import mill.define.ExternalModule
+
+object `package` extends ExternalModule.Alias(KtfmtModule)

--- a/kotlinlib/src/mill/kotlinlib/ktlint/KtlintModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/ktlint/KtlintModule.scala
@@ -58,8 +58,6 @@ trait KtlintModule extends JavaModule {
   }
 }
 
-object `package` extends ExternalModule.Alias(KtlintModule)
-
 object KtlintModule extends ExternalModule with KtlintModule with TaskModule {
   override def defaultCommandName(): String = "reformatAll"
 

--- a/kotlinlib/src/mill/kotlinlib/ktlint/KtlintModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/ktlint/KtlintModule.scala
@@ -58,7 +58,7 @@ trait KtlintModule extends JavaModule {
   }
 }
 
-object PackageDefaultExternalModule extends ExternalModule.Alias(KtlintModule)
+object `package` extends ExternalModule.Alias(KtlintModule)
 
 object KtlintModule extends ExternalModule with KtlintModule with TaskModule {
   override def defaultCommandName(): String = "reformatAll"

--- a/kotlinlib/src/mill/kotlinlib/ktlint/package.scala
+++ b/kotlinlib/src/mill/kotlinlib/ktlint/package.scala
@@ -1,0 +1,6 @@
+package mill.kotlinlib.ktlint
+
+import mill.define.ExternalModule
+
+object `package` extends ExternalModule.Alias(KtlintModule)
+

--- a/kotlinlib/src/mill/kotlinlib/ktlint/package.scala
+++ b/kotlinlib/src/mill/kotlinlib/ktlint/package.scala
@@ -3,4 +3,3 @@ package mill.kotlinlib.ktlint
 import mill.define.ExternalModule
 
 object `package` extends ExternalModule.Alias(KtlintModule)
-

--- a/main/eval/test/src/mill/eval/ModuleTests.scala
+++ b/main/eval/test/src/mill/eval/ModuleTests.scala
@@ -9,7 +9,7 @@ import mill.define.ExternalModule
 
 import utest._
 
-object PackageDefaultExternalModule extends ExternalModule.Alias(TestExternalModule)
+object `package` extends ExternalModule.Alias(TestExternalModule)
 object TestExternalModule extends mill.define.ExternalModule with mill.define.TaskModule {
   def defaultCommandName() = "x"
   def x = Task { 13 }

--- a/main/resolve/src/mill/resolve/Resolve.scala
+++ b/main/resolve/src/mill/resolve/Resolve.scala
@@ -385,7 +385,7 @@ trait Resolve[T] {
             catch {
               case e: ClassNotFoundException =>
                 try Right(rootModule.getClass.getClassLoader.loadClass(
-                    scoping.render + ".PackageDefaultExternalModule$"
+                    scoping.render + ".package$"
                   ))
                 catch {
                   case e: ClassNotFoundException =>

--- a/scalalib/src/mill/javalib/palantirformat/PalantirFormatModule.scala
+++ b/scalalib/src/mill/javalib/palantirformat/PalantirFormatModule.scala
@@ -83,7 +83,6 @@ trait PalantirFormatModule extends JavaModule with PalantirFormatBaseModule {
   }
 }
 
-object `package` extends ExternalModule.Alias(PalantirFormatModule)
 object PalantirFormatModule extends ExternalModule with PalantirFormatBaseModule with TaskModule {
 
   override def defaultCommandName(): String = "formatAll"

--- a/scalalib/src/mill/javalib/palantirformat/PalantirFormatModule.scala
+++ b/scalalib/src/mill/javalib/palantirformat/PalantirFormatModule.scala
@@ -83,7 +83,7 @@ trait PalantirFormatModule extends JavaModule with PalantirFormatBaseModule {
   }
 }
 
-object PackageDefaultExternalModule extends ExternalModule.Alias(PalantirFormatModule)
+object `package` extends ExternalModule.Alias(PalantirFormatModule)
 object PalantirFormatModule extends ExternalModule with PalantirFormatBaseModule with TaskModule {
 
   override def defaultCommandName(): String = "formatAll"

--- a/scalalib/src/mill/javalib/palantirformat/package.scala
+++ b/scalalib/src/mill/javalib/palantirformat/package.scala
@@ -1,0 +1,5 @@
+package mill.javalib.palantirformat
+
+import mill.define.ExternalModule
+
+object `package` extends ExternalModule.Alias(PalantirFormatModule)

--- a/scalalib/src/mill/scalalib/scalafmt/ScalafmtModule.scala
+++ b/scalalib/src/mill/scalalib/scalafmt/ScalafmtModule.scala
@@ -71,7 +71,6 @@ trait ScalafmtModule extends JavaModule {
 
 }
 
-object `package` extends ExternalModule.Alias(ScalafmtModule)
 object ScalafmtModule extends ExternalModule with ScalafmtModule with TaskModule {
   override def defaultCommandName(): String = "reformatAll"
 

--- a/scalalib/src/mill/scalalib/scalafmt/ScalafmtModule.scala
+++ b/scalalib/src/mill/scalalib/scalafmt/ScalafmtModule.scala
@@ -71,7 +71,7 @@ trait ScalafmtModule extends JavaModule {
 
 }
 
-object PackageDefaultExternalModule extends ExternalModule.Alias(ScalafmtModule)
+object `package` extends ExternalModule.Alias(ScalafmtModule)
 object ScalafmtModule extends ExternalModule with ScalafmtModule with TaskModule {
   override def defaultCommandName(): String = "reformatAll"
 

--- a/scalalib/src/mill/scalalib/scalafmt/package.scala
+++ b/scalalib/src/mill/scalalib/scalafmt/package.scala
@@ -1,0 +1,5 @@
+package mill.scalalib.scalafmt
+
+import mill.define.ExternalModule
+
+object `package` extends ExternalModule.Alias(ScalafmtModule)


### PR DESCRIPTION
Backport of https://github.com/com-lihaoyi/mill/pull/4922

This allows the shorter syntax e.g. `mill.scalalib.scalafmt.scalafmt` to be called programmatically, and brings them in line with Scala `package object`s and Mill's existing `RootModule`s 