### PR TITLE
Fixes for BSP import

### DIFF
--- a/bsp/src/mill/bsp/BspClasspathWorker.scala
+++ b/bsp/src/mill/bsp/BspClasspathWorker.scala
@@ -21,14 +21,13 @@ object BspClasspathWorker {
 
   def apply(
       workspace: os.Path,
-      log: Logger,
       workerLibs: Option[Seq[URL]] = None
   ): Result[BspClasspathWorker] = boundary {
     worker match {
       case Some(x) => Result.Success(x)
       case None =>
         val urls = workerLibs.map { urls =>
-          log.debug("Using direct submitted worker libs")
+          println("Using direct submitted worker libs")
           urls.map(url => os.Path(url.getPath))
         }.getOrElse {
           // load extra classpath entries from file
@@ -41,7 +40,7 @@ object BspClasspathWorker {
           // TODO: if outdated, we could regenerate the resource file and re-load the worker
 
           // read the classpath from resource file
-          log.debug(s"Reading worker classpath from file: ${cpFile}")
+          println(s"Reading worker classpath from file: ${cpFile}")
           os.read(cpFile).linesIterator.map(u => os.Path(new URL(u).getPath)).toSeq
         }
 

--- a/bsp/src/mill/bsp/BspClasspathWorker.scala
+++ b/bsp/src/mill/bsp/BspClasspathWorker.scala
@@ -10,7 +10,6 @@ private trait BspClasspathWorker {
   def startBspServer(
       topLevelBuildRoot: os.Path,
       streams: SystemStreams,
-      logStream: PrintStream,
       logDir: os.Path,
       canReload: Boolean
   ): Result[BspServerHandle]

--- a/bsp/worker/src/mill/bsp/worker/BspWorkerImpl.scala
+++ b/bsp/worker/src/mill/bsp/worker/BspWorkerImpl.scala
@@ -18,7 +18,6 @@ private class BspWorkerImpl() extends BspClasspathWorker {
   override def startBspServer(
       topLevelBuildRoot: os.Path,
       streams: SystemStreams,
-      logStream: PrintStream,
       logDir: os.Path,
       canReload: Boolean
   ): mill.api.Result[BspServerHandle] = {
@@ -31,7 +30,7 @@ private class BspWorkerImpl() extends BspClasspathWorker {
           bspVersion = Constants.bspProtocolVersion,
           serverVersion = BuildInfo.millVersion,
           serverName = Constants.serverName,
-          logStream = logStream,
+          logStream = streams.err,
           canReload = canReload,
           debugMessages = Option(System.getenv("MILL_BSP_DEBUG")).contains("true"),
           onShutdown = () => {

--- a/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -591,6 +591,7 @@ private class MillBuildServer(
       java.util.List[T],
       BspEvaluators
   ) => V): CompletableFuture[V] = {
+    mill.constants.DebugLog.println("completableTasksWithState " + hint)
     val prefix = hint.split(" ").head
     completable(hint) { (state: BspEvaluators) =>
       val ids = state.filterNonSynthetic(targetIds(state).asJava).asScala

--- a/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -741,7 +741,6 @@ private class MillBuildServer(
     debug("onRunReadStdin is current unsupported")
   }
 
-  val lock = new Object()
   private def evaluate(
       evaluator: EvaluatorApi,
       goals: Seq[TaskApi[?]],
@@ -750,27 +749,26 @@ private class MillBuildServer(
       logger: Logger = null
   ): ExecutionResultsApi = {
     val logger0 = Option(logger).getOrElse(evaluator.baseLogger)
-    lock.synchronized {
-      Server.withOutLock(
-        noBuildLock = false,
-        noWaitForBuildLock = false,
-        out = os.Path(evaluator.outPathJava),
-        targetsAndParams = goals.map {
-          case n: NamedTaskApi[_] => n.label
-          case t => t.toString
-        },
-        streams = logger0.streams
-      ) {
-        evaluator.executeApi(
-          goals,
-          reporter,
-          testReporter,
-          logger0,
-          serialCommandExec = false
-        ).executionResults
-      }
+    Server.withOutLock(
+      noBuildLock = false,
+      noWaitForBuildLock = false,
+      out = os.Path(evaluator.outPathJava),
+      targetsAndParams = goals.map {
+        case n: NamedTaskApi[_] => n.label
+        case t => t.toString
+      },
+      streams = logger0.streams
+    ) {
+      evaluator.executeApi(
+        goals,
+        reporter,
+        testReporter,
+        logger0,
+        serialCommandExec = false
+      ).executionResults
     }
   }
+
 
 }
 

--- a/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -591,7 +591,6 @@ private class MillBuildServer(
       java.util.List[T],
       BspEvaluators
   ) => V): CompletableFuture[V] = {
-    mill.constants.DebugLog.println("completableTasksWithState " + hint)
     val prefix = hint.split(" ").head
     completable(hint) { (state: BspEvaluators) =>
       val ids = state.filterNonSynthetic(targetIds(state).asJava).asScala

--- a/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -615,7 +615,7 @@ private class MillBuildServer(
 
           def logError(id: BuildTargetIdentifier, errorMsg: String): Unit = {
             val msg = s"Request '$prefix' failed for ${id.getUri}: ${errorMsg}"
-            debug(msg)
+            print(msg)
             client.onBuildLogMessage(new LogMessageParams(MessageType.ERROR, msg))
           }
 
@@ -633,9 +633,8 @@ private class MillBuildServer(
 
           resultsById.flatMap {
             case (id, values) =>
-              try {
-                Seq(f(ev, state, id, state.bspModulesById(id)._1, values))
-              } catch {
+              try Seq(f(ev, state, id, state.bspModulesById(id)._1, values))
+              catch {
                 case NonFatal(e) =>
                   logError(id, e.toString)
                   Seq()

--- a/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -660,10 +660,10 @@ private class MillBuildServer(
       hint: String,
       checkInitialized: Boolean = true
   )(f: BspEvaluators => V): CompletableFuture[V] = {
-    print(s"Entered ${hint}")
 
     val start = System.currentTimeMillis()
     val prefix = hint.split(" ").head
+    print(s"Entered ${prefix}")
     def took =
       print(s"${prefix} took ${System.currentTimeMillis() - start} msec")
 

--- a/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -769,7 +769,6 @@ private class MillBuildServer(
     }
   }
 
-
 }
 
 private object MillBuildServer {

--- a/build.mill
+++ b/build.mill
@@ -303,7 +303,7 @@ def millVersionIsStable: T[Boolean] = Task.Input {
 }
 
 def millVersionTruth: T[String] = Task.Input {
-  VcsVersion.calcVcsState(Task.log).copy(dirtyHash = None).format()
+  VcsVersion.calcVcsState(Task.log).format()
 }
 
 def millVersion: T[String] = Task {

--- a/core/constants/src/mill/constants/EnvVars.java
+++ b/core/constants/src/mill/constants/EnvVars.java
@@ -46,5 +46,4 @@ public class EnvVars {
    * e.g. to turn on additional testing/debug/log-related code
    */
   public static final String MILL_TEST_SUITE = "MILL_TEST_SUITE";
-
 }

--- a/core/constants/src/mill/constants/EnvVars.java
+++ b/core/constants/src/mill/constants/EnvVars.java
@@ -47,9 +47,4 @@ public class EnvVars {
    */
   public static final String MILL_TEST_SUITE = "MILL_TEST_SUITE";
 
-  /**
-   * Used to indicate to the Mill test suite which libraries should be resolved from
-   * the local disk and not from Maven Central
-   */
-  public static final String MILL_BUILD_LIBRARIES = "MILL_BUILD_LIBRARIES";
 }

--- a/core/define/src/mill/define/Evaluator.scala
+++ b/core/define/src/mill/define/Evaluator.scala
@@ -90,14 +90,16 @@ trait Evaluator extends AutoCloseable with EvaluatorApi {
       serialCommandExec: Boolean = false,
       selectiveExecution: Boolean = false
   ): EvaluatorApi.Result[T] = {
-    execute(
-      targets.map(_.asInstanceOf[Task[T]]),
-      reporter,
-      testReporter,
-      logger,
-      serialCommandExec,
-      selectiveExecution
-    )
+    os.checker.withValue(os.Checker.Nop) {
+      execute(
+        targets.map(_.asInstanceOf[Task[T]]),
+        reporter,
+        testReporter,
+        logger,
+        serialCommandExec,
+        selectiveExecution
+      )
+    }
   }
 
   /**

--- a/dist/package.mill
+++ b/dist/package.mill
@@ -106,29 +106,15 @@ object `package` extends RootModule with InstallModule {
     (s"com.lihaoyi-${build.dist.artifactId()}", dist0.runClasspath().map(_.path).mkString("\n"))
   )
 
-  def genTask(m: ScalaModule) = Task.Anon { Seq(m.jar(), m.sourceJar()) ++ m.runClasspath() }
-
   def localBinName = "mill-assembly.jar"
 
   def launcher = Task {
     val isWin = scala.util.Properties.isWin
     val outputPath = Task.dest / (if (isWin) "run.bat" else "run")
 
-    val genIdeaArgs =
-      genTask(build.core.define)() ++
-        genTask(build.core.exec)() ++
-        genTask(build.main)() ++
-        genTask(build.scalalib)() ++
-        genTask(build.kotlinlib)() ++
-        genTask(build.scalajslib)() ++
-        genTask(build.scalanativelib)() ++
-        genTask(build.javascriptlib)() ++
-        genTask(build.pythonlib)()
-
     val launcherForkArgs = testArgs() ++
       Seq(
         "-DMILL_CLASSPATH=" + runClasspath().map(_.path.toString).mkString(","),
-        "-DMILL_BUILD_LIBRARIES=" + genIdeaArgs.map(_.path).mkString(",")
       )
     val (millArgs, otherArgs) =
       launcherForkArgs.partition(arg =>

--- a/dist/package.mill
+++ b/dist/package.mill
@@ -114,7 +114,7 @@ object `package` extends RootModule with InstallModule {
 
     val launcherForkArgs = testArgs() ++
       Seq(
-        "-DMILL_CLASSPATH=" + runClasspath().map(_.path.toString).mkString(","),
+        "-DMILL_CLASSPATH=" + runClasspath().map(_.path.toString).mkString(",")
       )
     val (millArgs, otherArgs) =
       launcherForkArgs.partition(arg =>

--- a/main/src/mill/main/Inspect.scala
+++ b/main/src/mill/main/Inspect.scala
@@ -48,15 +48,12 @@ private object Inspect {
       // handle both Windows or Unix separators
       val fullFileName = ctx.fileName.replaceAll(raw"\\", "/")
       val basePath = WorkspaceRoot.workspaceRoot.toString.replaceAll(raw"\\", "/") + "/"
-      mill.constants.DebugLog.println("fullFileName " + fullFileName)
-      mill.constants.DebugLog.println("basePath " + basePath)
       val name =
         if (fullFileName.startsWith(basePath)) {
           fullFileName.drop(basePath.length)
         } else {
           fullFileName.split('/').last
         }
-      mill.constants.DebugLog.println("name " + name)
       s"${name}:${ctx.lineNum}"
     }
 

--- a/runner/src/mill/runner/MillMain.scala
+++ b/runner/src/mill/runner/MillMain.scala
@@ -254,7 +254,7 @@ object MillMain {
                             prevRunnerState,
                             Seq("version"),
                             splitStreams
-                          ).result,
+                          ).result
                       )
 
                       (true, RunnerState(None, Nil, None))
@@ -301,7 +301,7 @@ object MillMain {
 
   def runBspSession(
       streams0: SystemStreams,
-      runMillBootstrap: (Option[RunnerState], SystemStreams) => RunnerState,
+      runMillBootstrap: (Option[RunnerState], SystemStreams) => RunnerState
   ): Result[BspServerResult] = {
     val splitOut = new mill.internal.MultiStream(
       streams0.out,
@@ -347,7 +347,8 @@ object MillMain {
             while (repeatForBsp) {
               repeatForBsp = false
               val runnerState = runMillBootstrap(prevRunnerState, splitStreams)
-              val runSessionRes = bspServerHandle.runSession(runnerState.frames.flatMap(_.evaluator))
+              val runSessionRes =
+                bspServerHandle.runSession(runnerState.frames.flatMap(_.evaluator))
               prevRunnerState = Some(runnerState)
               repeatForBsp = runSessionRes == BspServerResult.ReloadWorkspace
               bspRes = Some(runSessionRes)
@@ -366,7 +367,6 @@ object MillMain {
         )
         runSessionRes
       } finally {
-
 
         splitErr.close()
         splitOut.close()

--- a/runner/src/mill/runner/MillServerMain.scala
+++ b/runner/src/mill/runner/MillServerMain.scala
@@ -64,7 +64,6 @@ class MillServerMain(
         stateCache = stateCache,
         mainInteractive = mainInteractive,
         streams0 = streams,
-        bspLog = None,
         env = env,
         setIdle = setIdle,
         userSpecifiedProperties0 = userSpecifiedProperties,


### PR DESCRIPTION
* Remove unused MILL_BUILD_LIBRARIES, seems we don't need it now since we only run the IDE integration tests in `.packaged` mode

* Need to move the `os.checker` inside the `EvaluatorImpl` so it runs in the right classloader

* Simplify logging in BSP server and make it work again. Fixes https://github.com/com-lihaoyi/mill/issues/4430, now we log more consistently to `out/mill-bsp/out.log` and `err.log`. Seems the previous assumption that `--bsp` was always the first argument stopped being true in IntelliJ at some point

Enough to import `example/scalalib/basic/1-simple`, as well `mill` itself. I'm able to run `mill.util.JvmTests` from the IntelliJ UI