### PR TITLE
Cleanup MillBuildServer

### DIFF
--- a/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -414,7 +414,7 @@ private class MillBuildServer(
     }
 
   override def buildTargetTest(testParams: TestParams): CompletableFuture[TestResult] =
-    handlerEvaluators(){ state =>
+    handlerEvaluators() { state =>
       testParams.setTargets(state.filterNonSynthetic(testParams.getTargets))
       val millBuildTargetIds = state
         .rootModules
@@ -569,7 +569,9 @@ private class MillBuildServer(
       BuildTargetIdentifier,
       BspModuleApi,
       W
-  ) => T)(agg: java.util.List[T] => V)(implicit name: sourcecode.Name)
+  ) => T)(agg: java.util.List[T] => V)(implicit
+      name: sourcecode.Name
+  )
       : CompletableFuture[V] =
     handlerTasksEvaluators[T, V, W](targetIds, tasks)(block)((l, _) => agg(l))
 
@@ -642,15 +644,14 @@ private class MillBuildServer(
   val requestLock = new java.util.concurrent.locks.ReentrantLock()
 
   protected def handlerEvaluators[V](
-                                 checkInitialized: Boolean = true
-                               )(block: BspEvaluators => V)(implicit name: sourcecode.Name): CompletableFuture[V] = {
+      checkInitialized: Boolean = true
+  )(block: BspEvaluators => V)(implicit name: sourcecode.Name): CompletableFuture[V] = {
     handler0[BspEvaluators, V](checkInitialized, bspEvaluators.future)(block)(name)
   }
 
-
   protected def handlerRaw[V](
-                                       checkInitialized: Boolean = true
-                                     )(block: => V)(implicit name: sourcecode.Name): CompletableFuture[V] = {
+      checkInitialized: Boolean = true
+  )(block: => V)(implicit name: sourcecode.Name): CompletableFuture[V] = {
     handler0[Unit, V](checkInitialized, scala.concurrent.Future.successful(()))(_ => block)(name)
   }
 

--- a/bsp/worker/src/mill/bsp/worker/MillJavaBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillJavaBuildServer.scala
@@ -17,7 +17,6 @@ private trait MillJavaBuildServer extends JavaBuildServer { this: MillBuildServe
   override def buildTargetJavacOptions(javacOptionsParams: JavacOptionsParams)
       : CompletableFuture[JavacOptionsResult] =
     completableTasks(
-      s"buildTargetJavacOptions ${javacOptionsParams}",
       targetIds = _ => javacOptionsParams.getTargets.asScala,
       tasks = { case m: JavaModuleApi =>
         m.bspBuildTargetJavacOptions(sessionInfo.clientWantsSemanticDb)

--- a/bsp/worker/src/mill/bsp/worker/MillJavaBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillJavaBuildServer.scala
@@ -16,7 +16,7 @@ private trait MillJavaBuildServer extends JavaBuildServer { this: MillBuildServe
 
   override def buildTargetJavacOptions(javacOptionsParams: JavacOptionsParams)
       : CompletableFuture[JavacOptionsResult] =
-    completableTasks(
+    handlerTasks(
       targetIds = _ => javacOptionsParams.getTargets.asScala,
       tasks = { case m: JavaModuleApi =>
         m.bspBuildTargetJavacOptions(sessionInfo.clientWantsSemanticDb)

--- a/bsp/worker/src/mill/bsp/worker/MillJvmBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillJvmBuildServer.scala
@@ -24,7 +24,6 @@ private trait MillJvmBuildServer extends JvmBuildServer { this: MillBuildServer 
   override def buildTargetJvmRunEnvironment(params: JvmRunEnvironmentParams)
       : CompletableFuture[JvmRunEnvironmentResult] = {
     jvmRunTestEnvironment(
-      s"buildTarget/jvmRunEnvironment ${params}",
       params.getTargets.asScala,
       new JvmRunEnvironmentResult(_)
     )
@@ -33,19 +32,16 @@ private trait MillJvmBuildServer extends JvmBuildServer { this: MillBuildServer 
   override def buildTargetJvmTestEnvironment(params: JvmTestEnvironmentParams)
       : CompletableFuture[JvmTestEnvironmentResult] = {
     jvmRunTestEnvironment(
-      s"buildTarget/jvmTestEnvironment ${params}",
       params.getTargets.asScala,
       new JvmTestEnvironmentResult(_)
     )
   }
 
   def jvmRunTestEnvironment[V](
-      name: String,
       targetIds: collection.Seq[BuildTargetIdentifier],
       agg: java.util.List[JvmEnvironmentItem] => V
-  ): CompletableFuture[V] = {
+  )(implicit name: sourcecode.Name): CompletableFuture[V] = {
     completableTasks(
-      name,
       targetIds = _ => targetIds,
       tasks = { case m: RunModuleApi => m.bspJvmRunTestEnvironment }
     ) {
@@ -109,7 +105,6 @@ private trait MillJvmBuildServer extends JvmBuildServer { this: MillBuildServer 
   override def buildTargetJvmCompileClasspath(params: JvmCompileClasspathParams)
       : CompletableFuture[JvmCompileClasspathResult] =
     completableTasks(
-      hint = "buildTarget/jvmCompileClasspath",
       targetIds = _ => params.getTargets.asScala,
       tasks = {
         case m: JavaModuleApi => m.bspCompileClasspath

--- a/bsp/worker/src/mill/bsp/worker/MillJvmBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillJvmBuildServer.scala
@@ -41,7 +41,7 @@ private trait MillJvmBuildServer extends JvmBuildServer { this: MillBuildServer 
       targetIds: collection.Seq[BuildTargetIdentifier],
       agg: java.util.List[JvmEnvironmentItem] => V
   )(implicit name: sourcecode.Name): CompletableFuture[V] = {
-    completableTasks(
+    handlerTasks(
       targetIds = _ => targetIds,
       tasks = { case m: RunModuleApi => m.bspJvmRunTestEnvironment }
     ) {
@@ -104,7 +104,7 @@ private trait MillJvmBuildServer extends JvmBuildServer { this: MillBuildServer 
 
   override def buildTargetJvmCompileClasspath(params: JvmCompileClasspathParams)
       : CompletableFuture[JvmCompileClasspathResult] =
-    completableTasks(
+    handlerTasks(
       targetIds = _ => params.getTargets.asScala,
       tasks = {
         case m: JavaModuleApi => m.bspCompileClasspath

--- a/bsp/worker/src/mill/bsp/worker/MillScalaBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillScalaBuildServer.scala
@@ -26,7 +26,6 @@ private trait MillScalaBuildServer extends ScalaBuildServer { this: MillBuildSer
   override def buildTargetScalacOptions(p: ScalacOptionsParams)
       : CompletableFuture[ScalacOptionsResult] =
     completableTasks(
-      hint = s"buildTarget/scalacOptions ${p}",
       targetIds = _ => p.getTargets.asScala.toSeq,
       tasks = {
         case m: JavaModuleApi =>
@@ -58,7 +57,6 @@ private trait MillScalaBuildServer extends ScalaBuildServer { this: MillBuildSer
   override def buildTargetScalaMainClasses(p: ScalaMainClassesParams)
       : CompletableFuture[ScalaMainClassesResult] =
     completableTasks(
-      hint = "buildTarget/scalaMainClasses",
       targetIds = _ => p.getTargets.asScala.toSeq,
       tasks = { case m: JavaModuleApi => m.bspBuildTargetScalaMainClasses }
     ) {
@@ -82,7 +80,6 @@ private trait MillScalaBuildServer extends ScalaBuildServer { this: MillBuildSer
   override def buildTargetScalaTestClasses(p: ScalaTestClassesParams)
       : CompletableFuture[ScalaTestClassesResult] =
     completableTasks(
-      s"buildTarget/scalaTestClasses ${p}",
       targetIds = _ => p.getTargets.asScala.toSeq,
       tasks = {
         case m: TestModuleApi => m.bspBuildTargetScalaTestClasses

--- a/bsp/worker/src/mill/bsp/worker/MillScalaBuildServer.scala
+++ b/bsp/worker/src/mill/bsp/worker/MillScalaBuildServer.scala
@@ -25,7 +25,7 @@ private trait MillScalaBuildServer extends ScalaBuildServer { this: MillBuildSer
 
   override def buildTargetScalacOptions(p: ScalacOptionsParams)
       : CompletableFuture[ScalacOptionsResult] =
-    completableTasks(
+    handlerTasks(
       targetIds = _ => p.getTargets.asScala.toSeq,
       tasks = {
         case m: JavaModuleApi =>
@@ -56,7 +56,7 @@ private trait MillScalaBuildServer extends ScalaBuildServer { this: MillBuildSer
 
   override def buildTargetScalaMainClasses(p: ScalaMainClassesParams)
       : CompletableFuture[ScalaMainClassesResult] =
-    completableTasks(
+    handlerTasks(
       targetIds = _ => p.getTargets.asScala.toSeq,
       tasks = { case m: JavaModuleApi => m.bspBuildTargetScalaMainClasses }
     ) {
@@ -79,7 +79,7 @@ private trait MillScalaBuildServer extends ScalaBuildServer { this: MillBuildSer
 
   override def buildTargetScalaTestClasses(p: ScalaTestClassesParams)
       : CompletableFuture[ScalaTestClassesResult] =
-    completableTasks(
+    handlerTasks(
       targetIds = _ => p.getTargets.asScala.toSeq,
       tasks = {
         case m: TestModuleApi => m.bspBuildTargetScalaTestClasses


### PR DESCRIPTION
1. Use the existing `Executor` rather than `ExecutionContexts.global`
2. Consolidate `completable` and `completableNoState` into using the same shared helper
3. Rename all the `completable*` methods to `handler*` 
4. Remove explicit `hint` strings and use `sourcecode.Name` instead
