### PR TITLE
Fix color prompt logging for broken log lines

### DIFF
--- a/core/internal/src/mill/internal/LinePrefixOutputStream.scala
+++ b/core/internal/src/mill/internal/LinePrefixOutputStream.scala
@@ -32,13 +32,10 @@ private[mill] class LinePrefixOutputStream(
       buffer.write(fansi.Attrs.emitAnsiCodes(endOfLastLineColor, 0).getBytes())
 
       buffer.write(linePrefixBytes)
-      if (linePrefixNonEmpty) writePreviousColor()
+      if (linePrefixNonEmpty) {
+        buffer.write(fansi.Attrs.emitAnsiCodes(0, endOfLastLineColor).getBytes())
+      }
     }
-  }
-
-  def writePreviousColor() = {
-
-    buffer.write(fansi.Attrs.emitAnsiCodes(0, endOfLastLineColor).getBytes())
   }
 
   def writeOutBuffer(): Unit = {

--- a/core/internal/test/src/mill/internal/LinePrefixOutputStreamTests.scala
+++ b/core/internal/test/src/mill/internal/LinePrefixOutputStreamTests.scala
@@ -73,5 +73,36 @@ object LinePrefixOutputStreamTests extends TestSuite {
       }
 
     }
+
+
+    test("colors") {
+      val baos = new ByteArrayOutputStream()
+      val lpos = new LinePrefixOutputStream("PREFIX", baos)
+      lpos.write(fansi.Color.Red("hello").render.getBytes)
+      lpos.write('\n')
+      lpos.flush()
+      lpos.write(fansi.Color.Green("world").render.getBytes)
+      lpos.write('\n')
+      lpos.flush()
+
+      val blueText = fansi.Color.Blue("one\ntwo\nthree\nfour\nfive").render.getBytes
+
+      blueText.grouped(7).foreach {chunk =>
+        lpos.write(chunk)
+        lpos.flush()
+      }
+
+      val expected =
+        "PREFIX" + fansi.Color.Red("hello").render + "\n" +
+        "PREFIX" + fansi.Color.Green("world").render + "\n" +
+        "PREFIX" + fansi.Color.Blue("one\n") +
+        "PREFIX" + fansi.Color.Blue("two\n") +
+        "PREFIX" + fansi.Color.Blue("three\n") +
+        "PREFIX" + fansi.Color.Blue("four\n") +
+        "PREFIX" + fansi.Color.Blue("five")
+
+      assert(baos.toString == expected)
+    }
+
   }
 }

--- a/core/internal/test/src/mill/internal/LinePrefixOutputStreamTests.scala
+++ b/core/internal/test/src/mill/internal/LinePrefixOutputStreamTests.scala
@@ -74,7 +74,6 @@ object LinePrefixOutputStreamTests extends TestSuite {
 
     }
 
-
     test("colors") {
       val baos = new ByteArrayOutputStream()
       val lpos = new LinePrefixOutputStream("PREFIX", baos)
@@ -87,19 +86,19 @@ object LinePrefixOutputStreamTests extends TestSuite {
 
       val blueText = fansi.Color.Blue("one\ntwo\nthree\nfour\nfive").render.getBytes
 
-      blueText.grouped(7).foreach {chunk =>
+      blueText.grouped(7).foreach { chunk =>
         lpos.write(chunk)
         lpos.flush()
       }
 
       val expected =
         "PREFIX" + fansi.Color.Red("hello").render + "\n" +
-        "PREFIX" + fansi.Color.Green("world").render + "\n" +
-        "PREFIX" + fansi.Color.Blue("one\n") +
-        "PREFIX" + fansi.Color.Blue("two\n") +
-        "PREFIX" + fansi.Color.Blue("three\n") +
-        "PREFIX" + fansi.Color.Blue("four\n") +
-        "PREFIX" + fansi.Color.Blue("five")
+          "PREFIX" + fansi.Color.Green("world").render + "\n" +
+          "PREFIX" + fansi.Color.Blue("one\n") +
+          "PREFIX" + fansi.Color.Blue("two\n") +
+          "PREFIX" + fansi.Color.Blue("three\n") +
+          "PREFIX" + fansi.Color.Blue("four\n") +
+          "PREFIX" + fansi.Color.Blue("five")
 
       assert(baos.toString == expected)
     }


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/4115

The problem was that we were only re-applying the Ansi colors after printing the `LinePrefixOutputStream` prefix. This misses the case where a single log line is broken into multiple `writeOutBuffer` calls, e.g. if it arrives at `LinePrefixOutputStream` as multiple separate `write` calls due to the vagaries of upstream buffering:

1. The first call will correctly set the `endOfLastLineColor`
2. The second call will not include the `endOfLastLineColor` when rendering its own `bufferString`, and thus when it calculates the next `endOfLastLineColor` it will find it to be the 0 (no colors)
3. The third call, perhaps on the following line, will find `endOfLastLineColor` to be 0 and render without colors

This PR fixes it by rendering the `endOfLastLineColor` color before the current `bufferString` when computing the next `endOfLastLineColor`

Tested manually by applying the following diff

```diff
diff --git a/example/scalalib/basic/1-simple/build.mill b/example/scalalib/basic/1-simple/build.mill
index ec8f500294a..c17187f6cae 100644
--- a/example/scalalib/basic/1-simple/build.mill
+++ b/example/scalalib/basic/1-simple/build.mill
@@ -7,7 +7,8 @@ object foo extends ScalaModule {
   def scalaVersion = "2.13.11"
   def mvnDeps = Seq(
     mvn"com.lihaoyi::scalatags:0.13.1",
-    mvn"com.lihaoyi::mainargs:0.6.2"
+    mvn"com.lihaoyi::mainargs:0.6.2",
+    mvn"com.lihaoyi::pprint:0.8.1",
   )
 
   object test extends ScalaTests {
diff --git a/example/scalalib/basic/1-simple/foo/test/src/FooTests.scala b/example/scalalib/basic/1-simple/foo/test/src/FooTests.scala
index 9dcd8bf4e04..d07166df1fe 100644
--- a/example/scalalib/basic/1-simple/foo/test/src/FooTests.scala
+++ b/example/scalalib/basic/1-simple/foo/test/src/FooTests.scala
@@ -15,4 +15,17 @@ object FooTests extends TestSuite {
       result
     }
   }
+
+  def main(args: Array[String]): Unit = {
+    val text = Seq
+      .tabulate(10){i => s"$i" * 100 + "\n"}
+      .mkString
+
+    pprint.log(text, height=9999)
+    pprint.PPrinter.BlackWhite.log(text, height=9999)
+    pprint.log(text, height=9999)
+    pprint.PPrinter.BlackWhite.log(text, height=9999)
+    pprint.log(text, height=9999)
+    pprint.PPrinter.BlackWhite.log(text, height=9999)
+  }
 }

```

And then running
```
./mill -w show dist.launcher
cd example/scalalib/basic/1-simple         
/Users/lihaoyi/Github/mill/out/dist/launcher.dest/run -i foo.test.run
```

Previously the colors in the first and third color `pprint` strings would be skipped after the first few lines. With this patch, the colors continue unbroken

Also added a small unit test `mill.internal.LinePrefixOutputStreamTests.colors`

We still do not handle the case where the ANSI escape itself is split into multiple writes. Leaving that for future work