### PR TITLE
Failing test for broken ANSI escape handling in `LinePrefixOutputStream`

### DIFF
--- a/core/internal/test/src/mill/internal/LinePrefixOutputStreamTests.scala
+++ b/core/internal/test/src/mill/internal/LinePrefixOutputStreamTests.scala
@@ -75,32 +75,34 @@ object LinePrefixOutputStreamTests extends TestSuite {
     }
 
     test("colors") {
-      val baos = new ByteArrayOutputStream()
-      val lpos = new LinePrefixOutputStream("PREFIX", baos)
-      lpos.write(fansi.Color.Red("hello").render.getBytes)
-      lpos.write('\n')
-      lpos.flush()
-      lpos.write(fansi.Color.Green("world").render.getBytes)
-      lpos.write('\n')
-      lpos.flush()
-
-      val blueText = fansi.Color.Blue("one\ntwo\nthree\nfour\nfive").render.getBytes
-
-      blueText.grouped(7).foreach { chunk =>
-        lpos.write(chunk)
+      for(chunkSize <- Seq(1, 2, 3, 4, 5, 6, 7)) {
+        val baos = new ByteArrayOutputStream()
+        val lpos = new LinePrefixOutputStream("PREFIX", baos)
+        lpos.write(fansi.Color.Red("hello").render.getBytes)
+        lpos.write('\n')
         lpos.flush()
+        lpos.write(fansi.Color.Green("world").render.getBytes)
+        lpos.write('\n')
+        lpos.flush()
+
+        val blueText = fansi.Color.Blue("one\ntwo\nthree\nfour\nfive").render.getBytes
+
+        blueText.grouped(chunkSize).foreach { chunk =>
+          lpos.write(chunk)
+          lpos.flush()
+        }
+
+        val expected =
+          "PREFIX" + fansi.Color.Red("hello").render + "\n" +
+            "PREFIX" + fansi.Color.Green("world").render + "\n" +
+            "PREFIX" + fansi.Color.Blue("one\n") +
+            "PREFIX" + fansi.Color.Blue("two\n") +
+            "PREFIX" + fansi.Color.Blue("three\n") +
+            "PREFIX" + fansi.Color.Blue("four\n") +
+            "PREFIX" + fansi.Color.Blue("five")
+
+        assert(baos.toString == expected)
       }
-
-      val expected =
-        "PREFIX" + fansi.Color.Red("hello").render + "\n" +
-          "PREFIX" + fansi.Color.Green("world").render + "\n" +
-          "PREFIX" + fansi.Color.Blue("one\n") +
-          "PREFIX" + fansi.Color.Blue("two\n") +
-          "PREFIX" + fansi.Color.Blue("three\n") +
-          "PREFIX" + fansi.Color.Blue("four\n") +
-          "PREFIX" + fansi.Color.Blue("five")
-
-      assert(baos.toString == expected)
     }
 
   }


### PR DESCRIPTION
If the ANSI escape is split over multiple writes, the current color tracking fails