### PR TITLE
Move `ScalaFmt` into its own classloader

### DIFF
--- a/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/mill-build.iml
+++ b/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/mill-build.iml
@@ -19,7 +19,6 @@
         <orderEntry type="library" name="commons-io-2.18.0.jar" level="project"/>
         <orderEntry type="library" name="commons-lang3-3.16.0.jar" level="project"/>
         <orderEntry type="library" name="concurrent-reference-hash-map-1.1.0.jar" level="project"/>
-        <orderEntry type="library" name="config-1.4.3.jar" level="project"/>
         <orderEntry type="library" name="config_2.13-1.1.3.jar" level="project"/>
         <orderEntry type="library" name="coursier-cache_2.13-2.1.25-M4.jar" level="project"/>
         <orderEntry type="library" name="coursier-core_2.13-2.1.25-M4.jar" level="project"/>
@@ -92,15 +91,11 @@
         <orderEntry type="library" name="scala-collection-compat_3-2.12.0.jar" level="project"/>
         <orderEntry type="library" scope="PROVIDED" name="scala-library-2.13.12.jar" level="project"/>
         <orderEntry type="library" name="scala-library-2.13.16.jar" level="project"/>
-        <orderEntry type="library" name="scala-parallel-collections_2.13-1.1.0.jar" level="project"/>
         <orderEntry type="library" name="scala-reflect-2.13.15.jar" level="project"/>
         <orderEntry type="library" name="scala-xml_2.13-2.3.0.jar" level="project"/>
         <orderEntry type="library" name="scala-xml_3-2.3.0.jar" level="project"/>
         <orderEntry type="library" scope="PROVIDED" name="scala3-library_3-3.3.3.jar" level="project"/>
         <orderEntry type="library" name="scala3-library_3-3.6.4.jar" level="project"/>
-        <orderEntry type="library" name="scalafmt-dynamic_2.13-3.8.5.jar" level="project"/>
-        <orderEntry type="library" name="scalafmt-interfaces-3.8.5.jar" level="project"/>
-        <orderEntry type="library" name="scalafmt-sysops_2.13-3.8.5.jar" level="project"/>
         <orderEntry type="library" name="scalaparse_3-3.1.1.jar" level="project"/>
         <orderEntry type="library" name="slf4j-api-2.0.17.jar" level="project"/>
         <orderEntry type="library" name="sourcecode_3-0.4.3-M5.jar" level="project"/>

--- a/scalalib/package.mill
+++ b/scalalib/package.mill
@@ -18,7 +18,7 @@ object `package` extends RootModule with build.MillStableScalaModule {
 
   def moduleDeps = Seq(build.core.util, build.scalalib.api, build.testrunner)
   def mvnDeps = {
-    Agg(build.Deps.scalafmtDynamic, build.Deps.scalaXml) ++ {
+    Agg(build.Deps.scalaXml) ++ {
       // despite compiling with Scala 3, we need to include scala-reflect
       // for the scala.reflect.internal.util.ScalaClassLoader
       // used in ScalaModule.scalacHelp,


### PR DESCRIPTION
Cuts `mill-assembly.jar` from 55mb to 53mb, so ~2mb of savings, with a somewhat cleaner classpath. the `scalafmt-dynamic` code will be downloaded on-demand