### PR TITLE
Tighten up `mill-runner-meta` dependencies

### DIFF
--- a/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.iml
+++ b/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.iml
@@ -10,7 +10,114 @@
         </content>
         <orderEntry type="inheritedJdk"/>
         <orderEntry type="sourceFolder" forTests="false"/>
-        <orderEntry type="library" name="scala-SDK-<!-- IGNORE -->" level="project"/>
-<!-- IGNORE -->
+        <orderEntry type="library" name="scala-SDK-3.6.2" level="project"/>
+        <orderEntry type="library" name="aircompressor-0.27.jar" level="project"/>
+        <orderEntry type="library" name="asm-9.6.jar" level="project"/>
+        <orderEntry type="library" name="asm-commons-9.6.jar" level="project"/>
+        <orderEntry type="library" name="asm-tree-9.6.jar" level="project"/>
+        <orderEntry type="library" name="cache-util-2.1.25-M4.jar" level="project"/>
+        <orderEntry type="library" name="commons-codec-1.17.0.jar" level="project"/>
+        <orderEntry type="library" name="commons-compress-1.26.2.jar" level="project"/>
+        <orderEntry type="library" name="commons-io-2.18.0.jar" level="project"/>
+        <orderEntry type="library" name="commons-lang3-3.16.0.jar" level="project"/>
+        <orderEntry type="library" name="concurrent-reference-hash-map-1.1.0.jar" level="project"/>
+        <orderEntry type="library" name="config_2.13-1.1.3.jar" level="project"/>
+        <orderEntry type="library" name="coursier-cache_2.13-2.1.25-M4.jar" level="project"/>
+        <orderEntry type="library" name="coursier-core_2.13-2.1.25-M4.jar" level="project"/>
+        <orderEntry type="library" name="coursier-env_2.13-2.1.25-M4.jar" level="project"/>
+        <orderEntry type="library" name="coursier-jvm_2.13-2.1.25-M4.jar" level="project"/>
+        <orderEntry type="library" name="coursier-proxy-setup-2.1.25-M4.jar" level="project"/>
+        <orderEntry type="library" name="coursier-util_2.13-2.1.25-M4.jar" level="project"/>
+        <orderEntry type="library" name="coursier_2.13-2.1.25-M4.jar" level="project"/>
+        <orderEntry type="library" name="dependency_2.13-0.3.2.jar" level="project"/>
+        <orderEntry type="library" name="fansi_3-0.5.0.jar" level="project"/>
+        <orderEntry type="library" name="fastparse_3-3.1.1.jar" level="project"/>
+        <orderEntry type="library" name="geny_3-1.1.1.jar" level="project"/>
+        <orderEntry type="library" name="graphviz-java-0.18.1.jar" level="project"/>
+        <orderEntry type="library" name="graphviz-java-min-deps-0.18.1.jar" level="project"/>
+        <orderEntry type="library" name="hamcrest-core-1.3.jar" level="project"/>
+        <orderEntry type="library" name="interface-1.0.29-M1.jar" level="project"/>
+        <orderEntry type="library" name="is-terminal-0.1.2.jar" level="project"/>
+        <orderEntry type="library" name="jansi-2.4.1.jar" level="project"/>
+        <orderEntry type="library" name="jarjar-1.14.1.jar" level="project"/>
+        <orderEntry type="library" name="jarjar-abrams-core_2.13-1.14.1.jar" level="project"/>
+        <orderEntry type="library" name="javax.inject-1.jar" level="project"/>
+        <orderEntry type="library" name="jcl-over-slf4j-1.7.30.jar" level="project"/>
+        <orderEntry type="library" name="jgrapht-core-1.4.0.jar" level="project"/>
+        <orderEntry type="library" name="jheaps-0.11.jar" level="project"/>
+        <orderEntry type="library" name="jline-3.28.0.jar" level="project"/>
+        <orderEntry type="library" name="jline-native-3.29.0.jar" level="project"/>
+        <orderEntry type="library" name="jna-5.17.0.jar" level="project"/>
+        <orderEntry type="library" name="jna-platform-5.16.0.jar" level="project"/>
+        <orderEntry type="library" name="jsoniter-scala-core_2.13-2.13.5.2.jar" level="project"/>
+        <orderEntry type="library" name="jsr305-3.0.2.jar" level="project"/>
+        <orderEntry type="library" name="jul-to-slf4j-1.7.30.jar" level="project"/>
+        <orderEntry type="library" name="junit-4.13.2.jar" level="project"/>
+        <orderEntry type="library" name="junit-interface-0.7.29.jar" level="project"/>
+        <orderEntry type="library" name="logback-classic-1.5.17.jar" level="project"/>
+        <orderEntry type="library" name="logback-core-1.5.17.jar" level="project"/>
+        <orderEntry type="library" name="mainargs_3-0.7.6.jar" level="project"/>
+        <orderEntry type="library" name="mill-androidlib_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-bsp_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-core-api_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-core-constants.jar" level="project"/>
+        <orderEntry type="library" name="mill-core-define_3.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-core-eval_3.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-core-exec_3.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-core-internal_3.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-core-resolve_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-core-util_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-idea_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-javascriptlib_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-kotlinlib-worker_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-kotlinlib_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-main-init_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-main_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-moduledefs_3-0.11.3-M5.jar" level="project"/>
+        <orderEntry type="library" name="mill-pythonlib_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-scalajslib-worker-api_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-scalajslib_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-scalalib-api_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-scalalib_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-scalanativelib-worker-api_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-scalanativelib_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-testrunner-entrypoint.jar" level="project"/>
+        <orderEntry type="library" name="mill-testrunner_3.jar" level="project"/>
+        <orderEntry type="library" name="munit_3-0.7.29.jar" level="project"/>
+        <orderEntry type="library" name="native-terminal-no-ffm-0.0.9.1.jar" level="project"/>
+        <orderEntry type="library" name="os-lib_3-0.11.5-M2.jar" level="project"/>
+        <orderEntry type="library" name="plexus-archiver-4.10.0.jar" level="project"/>
+        <orderEntry type="library" name="plexus-classworlds-2.6.0.jar" level="project"/>
+        <orderEntry type="library" name="plexus-container-default-2.1.1.jar" level="project"/>
+        <orderEntry type="library" name="plexus-io-3.5.0.jar" level="project"/>
+        <orderEntry type="library" name="plexus-utils-4.0.1.jar" level="project"/>
+        <orderEntry type="library" name="pprint_3-0.9.0.jar" level="project"/>
+        <orderEntry type="library" name="requests_3-0.9.0.jar" level="project"/>
+        <orderEntry type="library" name="scala-collection-compat_2.13-2.13.0.jar" level="project"/>
+        <orderEntry type="library" name="scala-collection-compat_3-2.12.0.jar" level="project"/>
+        <orderEntry type="library" scope="PROVIDED" name="scala-library-2.13.12.jar" level="project"/>
+        <orderEntry type="library" name="scala-library-2.13.16.jar" level="project"/>
+        <orderEntry type="library" name="scala-reflect-2.13.15.jar" level="project"/>
+        <orderEntry type="library" name="scala-xml_2.13-2.3.0.jar" level="project"/>
+        <orderEntry type="library" name="scala-xml_3-2.3.0.jar" level="project"/>
+        <orderEntry type="library" scope="PROVIDED" name="scala3-library_3-3.3.3.jar" level="project"/>
+        <orderEntry type="library" name="scala3-library_3-3.6.4.jar" level="project"/>
+        <orderEntry type="library" name="scalaparse_3-3.1.1.jar" level="project"/>
+        <orderEntry type="library" name="slf4j-api-2.0.17.jar" level="project"/>
+        <orderEntry type="library" name="sourcecode_3-0.4.3-M5.jar" level="project"/>
+        <orderEntry type="library" name="specification-level_2.13-1.1.3.jar" level="project"/>
+        <orderEntry type="library" name="test-interface-1.0.jar" level="project"/>
+        <orderEntry type="library" name="tika-core-3.1.0.jar" level="project"/>
+        <orderEntry type="library" name="ujson_3-4.1.0.jar" level="project"/>
+        <orderEntry type="library" name="upack_3-4.1.0.jar" level="project"/>
+        <orderEntry type="library" name="upickle-core_3-4.1.0.jar" level="project"/>
+        <orderEntry type="library" name="upickle-implicits_3-4.1.0.jar" level="project"/>
+        <orderEntry type="library" name="upickle_3-4.1.0.jar" level="project"/>
+        <orderEntry type="library" name="versions_2.13-0.5.1.jar" level="project"/>
+        <orderEntry type="library" name="windows-ansi-0.0.6.jar" level="project"/>
+        <orderEntry type="library" name="windows-jni-utils-0.3.3.jar" level="project"/>
+        <orderEntry type="library" name="xbean-reflect-3.7.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="xz-1.9.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="zstd-jni-1.5.6-3.jar" level="project"/>
     </component>
 </module>

--- a/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.mill-build.iml
+++ b/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.mill-build.iml
@@ -10,6 +10,113 @@
         </content>
         <orderEntry type="inheritedJdk"/>
         <orderEntry type="sourceFolder" forTests="false"/>
-<!-- IGNORE -->
+        <orderEntry type="library" name="scala-SDK-3.6.2" level="project"/>
+        <orderEntry type="library" name="aircompressor-0.27.jar" level="project"/>
+        <orderEntry type="library" name="asm-9.7.1.jar" level="project"/>
+        <orderEntry type="library" name="asm-commons-9.6.jar" level="project"/>
+        <orderEntry type="library" name="asm-tree-9.7.1.jar" level="project"/>
+        <orderEntry type="library" name="cache-util-2.1.25-M4.jar" level="project"/>
+        <orderEntry type="library" name="commons-codec-1.17.0.jar" level="project"/>
+        <orderEntry type="library" name="commons-compress-1.26.2.jar" level="project"/>
+        <orderEntry type="library" name="commons-io-2.18.0.jar" level="project"/>
+        <orderEntry type="library" name="commons-lang3-3.16.0.jar" level="project"/>
+        <orderEntry type="library" name="concurrent-reference-hash-map-1.1.0.jar" level="project"/>
+        <orderEntry type="library" name="config_2.13-1.1.3.jar" level="project"/>
+        <orderEntry type="library" name="coursier-cache_2.13-2.1.25-M4.jar" level="project"/>
+        <orderEntry type="library" name="coursier-core_2.13-2.1.25-M4.jar" level="project"/>
+        <orderEntry type="library" name="coursier-env_2.13-2.1.25-M4.jar" level="project"/>
+        <orderEntry type="library" name="coursier-jvm_2.13-2.1.25-M4.jar" level="project"/>
+        <orderEntry type="library" name="coursier-proxy-setup-2.1.25-M4.jar" level="project"/>
+        <orderEntry type="library" name="coursier-util_2.13-2.1.25-M4.jar" level="project"/>
+        <orderEntry type="library" name="coursier_2.13-2.1.25-M4.jar" level="project"/>
+        <orderEntry type="library" name="dependency_2.13-0.3.2.jar" level="project"/>
+        <orderEntry type="library" name="fansi_3-0.5.0.jar" level="project"/>
+        <orderEntry type="library" name="fastparse_3-3.1.1.jar" level="project"/>
+        <orderEntry type="library" name="geny_3-1.1.1.jar" level="project"/>
+        <orderEntry type="library" name="graphviz-java-0.18.1.jar" level="project"/>
+        <orderEntry type="library" name="graphviz-java-min-deps-0.18.1.jar" level="project"/>
+        <orderEntry type="library" name="interface-1.0.29-M1.jar" level="project"/>
+        <orderEntry type="library" name="is-terminal-0.1.2.jar" level="project"/>
+        <orderEntry type="library" name="jansi-2.4.1.jar" level="project"/>
+        <orderEntry type="library" name="jarjar-1.14.1.jar" level="project"/>
+        <orderEntry type="library" name="jarjar-abrams-core_2.13-1.14.1.jar" level="project"/>
+        <orderEntry type="library" name="javax.inject-1.jar" level="project"/>
+        <orderEntry type="library" name="jcl-over-slf4j-1.7.30.jar" level="project"/>
+        <orderEntry type="library" name="jgrapht-core-1.4.0.jar" level="project"/>
+        <orderEntry type="library" name="jheaps-0.11.jar" level="project"/>
+        <orderEntry type="library" name="jline-3.28.0.jar" level="project"/>
+        <orderEntry type="library" name="jline-native-3.29.0.jar" level="project"/>
+        <orderEntry type="library" name="jna-5.17.0.jar" level="project"/>
+        <orderEntry type="library" name="jna-platform-5.16.0.jar" level="project"/>
+        <orderEntry type="library" name="jsoniter-scala-core_2.13-2.13.5.2.jar" level="project"/>
+        <orderEntry type="library" name="jsr305-3.0.2.jar" level="project"/>
+        <orderEntry type="library" name="jul-to-slf4j-1.7.30.jar" level="project"/>
+        <orderEntry type="library" name="logback-classic-1.5.17.jar" level="project"/>
+        <orderEntry type="library" name="logback-core-1.5.17.jar" level="project"/>
+        <orderEntry type="library" name="mainargs_3-0.7.6.jar" level="project"/>
+        <orderEntry type="library" name="mill-androidlib_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-bsp_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-core-api_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-core-codesig_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-core-constants.jar" level="project"/>
+        <orderEntry type="library" name="mill-core-define_3.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-core-eval_3.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-core-exec_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-core-internal_3.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-core-resolve_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-core-util_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-idea_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-javascriptlib_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-kotlinlib-worker_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-kotlinlib_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-main-init_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-main_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-moduledefs_3-0.11.3-M5.jar" level="project"/>
+        <orderEntry type="library" name="mill-pythonlib_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-runner-meta_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-runner-worker-api_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-scalajslib-worker-api_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-scalajslib_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-scalalib-api_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-scalalib_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-scalanativelib-worker-api_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-scalanativelib_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-testrunner-entrypoint.jar" level="project"/>
+        <orderEntry type="library" name="mill-testrunner_3.jar" level="project"/>
+        <orderEntry type="library" name="native-terminal-no-ffm-0.0.9.1.jar" level="project"/>
+        <orderEntry type="library" name="os-lib_3-0.11.5-M2.jar" level="project"/>
+        <orderEntry type="library" name="plexus-archiver-4.10.0.jar" level="project"/>
+        <orderEntry type="library" name="plexus-classworlds-2.6.0.jar" level="project"/>
+        <orderEntry type="library" name="plexus-container-default-2.1.1.jar" level="project"/>
+        <orderEntry type="library" name="plexus-io-3.5.0.jar" level="project"/>
+        <orderEntry type="library" name="plexus-utils-4.0.1.jar" level="project"/>
+        <orderEntry type="library" name="pprint_3-0.9.0.jar" level="project"/>
+        <orderEntry type="library" name="requests_3-0.9.0.jar" level="project"/>
+        <orderEntry type="library" name="scala-collection-compat_2.13-2.13.0.jar" level="project"/>
+        <orderEntry type="library" name="scala-collection-compat_3-2.12.0.jar" level="project"/>
+        <orderEntry type="library" scope="PROVIDED" name="scala-library-2.13.12.jar" level="project"/>
+        <orderEntry type="library" name="scala-library-2.13.16.jar" level="project"/>
+        <orderEntry type="library" name="scala-reflect-2.13.15.jar" level="project"/>
+        <orderEntry type="library" name="scala-xml_2.13-2.3.0.jar" level="project"/>
+        <orderEntry type="library" name="scala-xml_3-2.3.0.jar" level="project"/>
+        <orderEntry type="library" scope="PROVIDED" name="scala3-library_3-3.3.3.jar" level="project"/>
+        <orderEntry type="library" name="scala3-library_3-3.6.4.jar" level="project"/>
+        <orderEntry type="library" name="scalaparse_3-3.1.1.jar" level="project"/>
+        <orderEntry type="library" name="slf4j-api-2.0.17.jar" level="project"/>
+        <orderEntry type="library" name="sourcecode_3-0.4.3-M5.jar" level="project"/>
+        <orderEntry type="library" name="specification-level_2.13-1.1.3.jar" level="project"/>
+        <orderEntry type="library" name="test-interface-1.0.jar" level="project"/>
+        <orderEntry type="library" name="tika-core-3.1.0.jar" level="project"/>
+        <orderEntry type="library" name="ujson_3-4.1.0.jar" level="project"/>
+        <orderEntry type="library" name="upack_3-4.1.0.jar" level="project"/>
+        <orderEntry type="library" name="upickle-core_3-4.1.0.jar" level="project"/>
+        <orderEntry type="library" name="upickle-implicits_3-4.1.0.jar" level="project"/>
+        <orderEntry type="library" name="upickle_3-4.1.0.jar" level="project"/>
+        <orderEntry type="library" name="versions_2.13-0.5.1.jar" level="project"/>
+        <orderEntry type="library" name="windows-ansi-0.0.6.jar" level="project"/>
+        <orderEntry type="library" name="windows-jni-utils-0.3.3.jar" level="project"/>
+        <orderEntry type="library" name="xbean-reflect-3.7.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="xz-1.9.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="zstd-jni-1.5.6-3.jar" level="project"/>
     </component>
 </module>

--- a/runner/package.mill
+++ b/runner/package.mill
@@ -66,7 +66,6 @@ object `package` extends RootModule with build.MillPublishScalaModule {
   }
   object meta extends build.MillPublishScalaModule with BuildInfo {
     def moduleDeps = Seq(
-      build.scalalib,
       build.core.codesig,
       `worker-api`,
       build.main

--- a/runner/package.mill
+++ b/runner/package.mill
@@ -68,7 +68,6 @@ object `package` extends RootModule with build.MillPublishScalaModule {
     def moduleDeps = Seq(
       build.scalalib,
       build.core.codesig,
-      build.runner.client,
       `worker-api`,
       build.main
     )


### PR DESCRIPTION
Also enabled assertions for the meta-build in the `GenIdeaExtended` tests, so we have some test coverage of what's on the classpath for the meta-build