### PR TITLE
Fix `main` build and CI

### DIFF
--- a/scalajslib/package.mill
+++ b/scalajslib/package.mill
@@ -48,7 +48,7 @@ object `package` extends RootModule with build.MillStableScalaModule with BuildI
     def moduleDir: os.Path = super.moduleDir / scalajsWorkerVersion
     def compileModuleDeps = Seq(build.scalajslib.`worker-api`, build.core.constants, build.core.api)
     def mandatoryMvnDeps = Agg.empty[Dep]
-    def compileMvnDeps = super.mandatoryMvnDeps() ++ Agg(
+    def mvnDeps = super.mandatoryMvnDeps() ++ Agg(
       build.Deps.Scalajs_1.scalajsLinker,
       build.Deps.Scalajs_1.scalajsSbtTestAdapter,
       build.Deps.Scalajs_1.scalajsEnvNodejs,

--- a/scalajslib/package.mill
+++ b/scalajslib/package.mill
@@ -48,7 +48,8 @@ object `package` extends RootModule with build.MillStableScalaModule with BuildI
     def moduleDir: os.Path = super.moduleDir / scalajsWorkerVersion
     def compileModuleDeps = Seq(build.scalajslib.`worker-api`, build.core.constants, build.core.api)
     def mandatoryMvnDeps = Agg.empty[Dep]
-    def mvnDeps = super.mandatoryMvnDeps() ++ Agg(
+    def mvnDeps = Agg(build.Deps.scalafmtDynamic)
+    def compileMvnDeps = super.mandatoryMvnDeps() ++ Agg(
       build.Deps.Scalajs_1.scalajsLinker,
       build.Deps.Scalajs_1.scalajsSbtTestAdapter,
       build.Deps.Scalajs_1.scalajsEnvNodejs,


### PR DESCRIPTION
Not sure why these dependencies were listed as `compileMvnDeps` rather than just `mvnDeps`, but that seems to be the cause of the `java.lang.NoSuchMethodError`s that were plaguing CI since we removed scalafmt/parallel-collections from the classpath. Hopefully this helps make things work again

Seems like the `compile` prefix was added in https://github.com/com-lihaoyi/mill/pull/4162