### PR TITLE
Add `Task.fail` API to conveniently fail a task

### DIFF
--- a/androidlib/src/mill/androidlib/AndroidKotlinModule.scala
+++ b/androidlib/src/mill/androidlib/AndroidKotlinModule.scala
@@ -22,12 +22,12 @@ trait AndroidKotlinModule extends KotlinModule {
       if (kv.startsWith("1")) {
         // cut-off usages for Kotlin 1.x, because of the need to maintain the table of
         // Compose compiler version -> Kotlin version
-        Result.Failure("Compose can be used only with Kotlin version 2 or newer.")
+        Task.fail("Compose can be used only with Kotlin version 2 or newer.")
       } else {
-        Result.Success(deps ++ Seq(
+        deps ++ Seq(
           mvn"org.jetbrains.kotlin:kotlin-compose-compiler-plugin:${kotlinVersion()}"
-        ))
+        )
       }
-    } else Result.Success(deps)
+    } else deps
   }
 }

--- a/androidlib/src/mill/androidlib/AndroidSdkModule.scala
+++ b/androidlib/src/mill/androidlib/AndroidSdkModule.scala
@@ -73,11 +73,11 @@ trait AndroidSdkModule extends Module {
       }
     cache.file(Artifact(url)).run.unsafeRun()(cache.ec) match {
       case Right(file) =>
-        Result.Success(PathRef(os.Path(file)).withRevalidateOnce)
+        PathRef(os.Path(file)).withRevalidateOnce
       case Left(ex) if Task.offline =>
-        Result.Failure(s"Can't fetch bundle tools (from ${url}) while in offline mode.")
+        Task.fail(s"Can't fetch bundle tools (from ${url}) while in offline mode.")
       case Left(ex) =>
-        Result.Failure(ex.getMessage())
+        Task.fail(ex.getMessage())
 
     }
   }

--- a/contrib/artifactory/src/mill/contrib/artifactory/ArtifactoryPublishModule.scala
+++ b/contrib/artifactory/src/mill/contrib/artifactory/ArtifactoryPublishModule.scala
@@ -83,14 +83,14 @@ object ArtifactoryPublishModule extends ExternalModule {
         username <- Task.env.get("ARTIFACTORY_USERNAME")
         password <- Task.env.get("ARTIFACTORY_PASSWORD")
       } yield {
-        Result.Success(s"$username:$password")
+        s"$username:$password"
       }).getOrElse(
-        Result.Failure(
+        Task.fail(
           "Consider using ARTIFACTORY_USERNAME/ARTIFACTORY_PASSWORD environment variables or passing `credentials` argument"
         )
       )
     } else {
-      Result.Success(credentials)
+      credentials
     }
   }
 

--- a/contrib/bintray/src/mill/contrib/bintray/BintrayPublishModule.scala
+++ b/contrib/bintray/src/mill/contrib/bintray/BintrayPublishModule.scala
@@ -90,14 +90,14 @@ object BintrayPublishModule extends ExternalModule {
         username <- Task.env.get("BINTRAY_USERNAME")
         password <- Task.env.get("BINTRAY_PASSWORD")
       } yield {
-        Result.Success(s"$username:$password")
+        s"$username:$password"
       }).getOrElse(
-        Result.Failure(
+        Task.fail(
           "Consider using BINTRAY_USERNAME/BINTRAY_PASSWORD environment variables or passing `credentials` argument"
         )
       )
     } else {
-      Result.Success(credentials)
+      credentials
     }
   }
 

--- a/contrib/gitlab/src/mill/contrib/gitlab/GitlabMavenRepository.scala
+++ b/contrib/gitlab/src/mill/contrib/gitlab/GitlabMavenRepository.scala
@@ -19,10 +19,8 @@ trait GitlabMavenRepository {
 
     gitlabAuth match {
       case Result.Failure(msg) =>
-        Failure(
-          s"Token lookup for PACKAGE repository ($gitlabRepository) failed with $msg"
-        ): Result[MavenRepository]
-      case Result.Success(value) => Success(value)
+        Task.fail(s"Token lookup for PACKAGE repository ($gitlabRepository) failed with $msg")
+      case Result.Success(value) => value
     }
   }
 }

--- a/core/api/src/mill/api/Result.scala
+++ b/core/api/src/mill/api/Result.scala
@@ -16,7 +16,11 @@ sealed trait Result[+T] {
   def errorOpt: Option[String]
 }
 object Result {
-  implicit def create[T](value: T): Result[T] = Success(value)
+  implicit def create[T](value: T): Result[T] =
+    try Success(value)
+    catch {
+      case e: Result.Exception => Result.Failure(e.error)
+    }
 
   case class Success[+T](value: T) extends Result[T] {
 

--- a/core/define/src/mill/define/Task.scala
+++ b/core/define/src/mill/define/Task.scala
@@ -364,6 +364,8 @@ class TaskBase {
 
   def offline(implicit ctx: mill.define.TaskCtx): Boolean = ctx.offline
 
+  def fail(msg: String)(implicit ctx: mill.define.TaskCtx): Nothing = ctx.fail(msg)
+
   /**
    * Converts a `Seq[Task[T]]` into a `Task[Seq[T]]`
    */

--- a/core/define/src/mill/define/TaskCtx.scala
+++ b/core/define/src/mill/define/TaskCtx.scala
@@ -5,6 +5,7 @@ import mill.api.internal.{CompileProblemReporter, TestReporter}
 
 import scala.annotation.{StaticAnnotation, compileTimeOnly}
 import scala.language.implicitConversions
+import mill.api.Result
 
 /**
  * Represents the data and utilities that are contextually available inside the
@@ -17,7 +18,8 @@ trait TaskCtx extends TaskCtx.Dest
     with TaskCtx.Workspace
     with TaskCtx.Fork
     with TaskCtx.Jobs
-    with TaskCtx.Offline {
+    with TaskCtx.Offline
+    with TaskCtx.Fail {
   def reporter: Int => Option[CompileProblemReporter]
 
   def testReporter: TestReporter
@@ -48,6 +50,8 @@ object TaskCtx {
       if (index >= 0 && index < args.length) args(index).asInstanceOf[T]
       else throw new IndexOutOfBoundsException(s"Index $index outside of range 0 - ${args.length}")
     }
+
+    def fail(msg: String): Nothing = throw Result.Exception(msg)
   }
 
   @compileTimeOnly(
@@ -155,6 +159,16 @@ object TaskCtx {
 
   trait Offline {
     def offline: Boolean
+  }
+
+  trait Fail {
+
+    /**
+     * Fail this task with a message.
+     * This is a convenient alternative to returning [[Result.Failure]]
+     * which also requires the happy path to return [[Result.Success]].
+     */
+    def fail(msg: String): Nothing
   }
 
   @experimental

--- a/javascriptlib/src/mill/javascriptlib/TsLintModule.scala
+++ b/javascriptlib/src/mill/javascriptlib/TsLintModule.scala
@@ -56,10 +56,10 @@ trait TsLintModule extends Module {
 
     locs.find(p => os.exists(p.path)) match {
       case None =>
-        Result.Failure(
+        Task.fail(
           s"Lint couldn't find an eslint.config.(js|mjs|cjs) or a .eslintrc.(js|mjs|cjs) or a `.pretiierrc` file"
         )
-      case Some(c) => Result.Success(lintT(c.path))
+      case Some(c) => lintT(c.path)
     }
   }
 

--- a/kotlinlib/src/mill/kotlinlib/js/KotlinJsModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/js/KotlinJsModule.scala
@@ -131,12 +131,12 @@ trait KotlinJsModule extends KotlinModule { outer =>
       @arg(positional = true) mainClass: String,
       args: String*
   ): Command[Unit] = Task.Command[Unit] {
-    mill.api.Result.Failure("runMain is not supported in Kotlin/JS.")
+    Task.fail("runMain is not supported in Kotlin/JS.")
   }
 
   override def runMain(@arg(positional = true) mainClass: String, args: String*): Command[Unit] =
     Task.Command[Unit] {
-      mill.api.Result.Failure("runMain is not supported in Kotlin/JS.")
+      Task.fail("runMain is not supported in Kotlin/JS.")
     }
 
   protected[js] def kotlinJsFriendModule: Option[KotlinJsModule] = None
@@ -595,9 +595,9 @@ trait KotlinJsModule extends KotlinModule { outer =>
              |${failedTests.mkString("\n")}
              |
              |""".stripMargin
-        Result.Failure(failureMessage)
+        Task.fail(failureMessage)
       } else {
-        Result.Success((doneMessage, testResults))
+        (doneMessage, testResults)
       }
     }
 

--- a/kotlinlib/src/mill/kotlinlib/kover/KoverReportBaseModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/kover/KoverReportBaseModule.scala
@@ -5,7 +5,7 @@
 package mill.kotlinlib.kover
 
 import mill._
-import mill.api.Result.Success
+import mill.api.Result
 import mill.define.{PathRef}
 import mill.kotlinlib.{Dep, DepSyntax, Versions}
 import mill.scalalib.CoursierModule
@@ -18,7 +18,7 @@ trait KoverReportBaseModule extends CoursierModule {
    * Reads the Kover version from system environment variable `KOVER_VERSION` or defaults to a hardcoded version.
    */
   def koverVersion: T[String] = Task.Input {
-    Success[String](Task.env.getOrElse("KOVER_VERSION", Versions.koverVersion))
+    Result.Success[String](Task.env.getOrElse("KOVER_VERSION", Versions.koverVersion))
   }
 
   def koverCliDep: Target[Seq[Dep]] = Task {

--- a/main/src/mill/main/MainModule.scala
+++ b/main/src/mill/main/MainModule.scala
@@ -119,11 +119,11 @@ trait MainModule extends BaseModule with MainModuleApi {
             }
           }
           found match {
-            case None => Result.Failure(s"No path found between $src and $dest")
+            case None => Task.fail(s"No path found between $src and $dest")
             case Some(list) =>
               val labels = list.collect { case n: NamedTask[_] => n.ctx.segments.render }
               labels.foreach(println)
-              Result.Success(labels)
+              labels
           }
 
         case _ => ???

--- a/pythonlib/src/mill/pythonlib/PublishModule.scala
+++ b/pythonlib/src/mill/pythonlib/PublishModule.scala
@@ -115,12 +115,12 @@ trait PublishModule extends PythonModule {
     } else None
     readme match {
       case None =>
-        Result.Failure(
+        Task.fail(
           s"No readme file found in `${moduleDir}`. A readme file is required for publishing distributions. " +
             s"Please create a file named `${moduleDir}/readme*` (any capitalization), or override the `publishReadme` task."
         )
       case Some(path) =>
-        Result.Success(PathRef(path))
+        PathRef(path)
     }
   }
 

--- a/pythonlib/src/mill/pythonlib/PythonModule.scala
+++ b/pythonlib/src/mill/pythonlib/PythonModule.scala
@@ -215,10 +215,10 @@ trait PythonModule extends PipModule with TaskModule { outer =>
    */
   def console(): Command[Unit] = Task.Command(exclusive = true) {
     if (!mill.constants.Util.hasConsole()) {
-      Result.Failure("console needs to be run with the -i/--interactive flag")
+      Task.fail("console needs to be run with the -i/--interactive flag")
     } else {
       runner().run()
-      Result.Success(())
+      ()
     }
   }
 

--- a/runner/meta/src/mill/runner/meta/MillBuildRootModule.scala
+++ b/runner/meta/src/mill/runner/meta/MillBuildRootModule.scala
@@ -142,7 +142,7 @@ class MillBuildRootModule()(implicit
   }
   def generateScriptSources: T[Seq[PathRef]] = Task {
     val parsed = parseBuildFiles()
-    if (parsed.errors.nonEmpty) Result.Failure(parsed.errors.mkString("\n"))
+    if (parsed.errors.nonEmpty) Task.fail(parsed.errors.mkString("\n"))
     else {
       CodeGen.generateWrappedSources(
         rootModuleInfo.projectRoot / os.up,
@@ -153,7 +153,7 @@ class MillBuildRootModule()(implicit
         rootModuleInfo.output,
         compilerWorker()
       )
-      Result.Success(Seq(PathRef(Task.dest)))
+      Seq(PathRef(Task.dest))
     }
   }
 

--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -135,14 +135,14 @@ trait ScalaJSModule extends scalalib.ScalaModule with ScalaJSModuleApi { outer =
       Task.log.warn("Passing command line arguments to run is not supported by Scala.js.")
     }
     finalMainClassOpt() match {
-      case Left(err) => Result.Failure(err)
+      case Left(err) => Task.fail(err)
       case Right(_) =>
         ScalaJSWorkerExternalModule.scalaJSWorker().run(
           scalaJSToolsClasspath(),
           jsEnvConfig(),
           fastLinkJS()
         )
-        Result.Success(())
+        ()
     }
 
   }
@@ -151,12 +151,12 @@ trait ScalaJSModule extends scalalib.ScalaModule with ScalaJSModuleApi { outer =
       @arg(positional = true) mainClass: String,
       args: String*
   ): Command[Unit] = Task.Command[Unit] {
-    mill.api.Result.Failure("runMain is not supported in Scala.js")
+    Task.fail("runMain is not supported in Scala.js")
   }
 
   override def runMain(@arg(positional = true) mainClass: String, args: String*): Command[Unit] =
     Task.Command[Unit] {
-      mill.api.Result.Failure("runMain is not supported in Scala.js")
+      Task.fail("runMain is not supported in Scala.js")
     }
 
   private[scalajslib] def linkJs(

--- a/scalalib/src/mill/scalalib/AssemblyModule.scala
+++ b/scalalib/src/mill/scalalib/AssemblyModule.scala
@@ -131,7 +131,7 @@ trait AssemblyModule extends mill.define.Module {
     val problematicEntryCount = 65535
 
     if (prependScript.isDefined && created.entries > problematicEntryCount) {
-      Result.Failure(
+      Task.fail(
         s"""The created assembly jar contains more than ${problematicEntryCount} ZIP entries.
            |JARs of that size are known to not work correctly with a prepended shell script.
            |Either reduce the entries count of the assembly or disable the prepended shell script with:
@@ -140,7 +140,7 @@ trait AssemblyModule extends mill.define.Module {
            |""".stripMargin
       )
     } else {
-      Result.Success(created.pathRef)
+      created.pathRef
     }
   }
 }

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -1146,7 +1146,7 @@ trait JavaModule
 
       println(processedTree)
 
-      Result.Success(())
+      ()
     }
 
   /**
@@ -1206,7 +1206,7 @@ trait JavaModule
     } else {
       Task.Command {
         val msg = invalidModules.mkString("\n")
-        Result.Failure(msg)
+        Task.fail(msg)
       }
     }
   }

--- a/scalalib/src/mill/scalalib/PublishModule.scala
+++ b/scalalib/src/mill/scalalib/PublishModule.scala
@@ -353,7 +353,7 @@ trait PublishModule extends JavaModule { outer =>
       doc,
       transitive
     )()
-    Result.Success(())
+    ()
   }
 
   // bin-compat shim
@@ -660,9 +660,9 @@ object PublishModule extends ExternalModule with TaskModule {
       username <- Task.env.get(USERNAME_ENV_VARIABLE_NAME).orElse(Task.env.get("SONATYPE_USERNAME"))
       password <- Task.env.get(PASSWORD_ENV_VARIABLE_NAME).orElse(Task.env.get("SONATYPE_PASSWORD"))
     } yield {
-      Result.Success((username, password))
+      (username, password)
     }).getOrElse(
-      Result.Failure(
+      Task.fail(
         s"Consider using ${USERNAME_ENV_VARIABLE_NAME}/${PASSWORD_ENV_VARIABLE_NAME} environment variables or passing `sonatypeCreds` argument"
       )
     )
@@ -676,9 +676,9 @@ object PublishModule extends ExternalModule with TaskModule {
     } else {
       Task.Anon {
         if (sonatypeCreds.split(":").length >= 2) {
-          Result.Success(sonatypeCreds)
+          sonatypeCreds
         } else {
-          Result.Failure(
+          Task.fail(
             "Sonatype credentials must be set in the following format - username:password. Incorrect format received."
           )
         }

--- a/scalalib/src/mill/scalalib/RunModule.scala
+++ b/scalalib/src/mill/scalalib/RunModule.scala
@@ -77,8 +77,8 @@ trait RunModule extends WithJvmWorker with RunModuleApi {
 
   def finalMainClass: T[String] = Task {
     finalMainClassOpt() match {
-      case Right(main) => Result.Success(main)
-      case Left(msg) => Result.Failure(msg)
+      case Right(main) => main
+      case Left(msg) => Task.fail(msg)
     }
   }
 
@@ -133,11 +133,10 @@ trait RunModule extends WithJvmWorker with RunModuleApi {
    */
   def runForkedTask(mainClass: Task[String], args: Task[Args] = Task.Anon(Args())): Task[Unit] =
     Task.Anon {
-      try Result.Success(
-          runner().run(args = args().value, mainClass = mainClass(), workingDir = forkWorkingDir())
-        )
-      catch {
-        case NonFatal(_) => Result.Failure("Subprocess failed")
+      try {
+        runner().run(args = args().value, mainClass = mainClass(), workingDir = forkWorkingDir())
+      } catch {
+        case NonFatal(_) => Task.fail("Subprocess failed")
       }
     }
 

--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -435,7 +435,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase
    */
   def console(): Command[Unit] = Task.Command(exclusive = true) {
     if (!mill.constants.Util.hasConsole()) {
-      Result.Failure("console needs to be run with the -i/--interactive flag")
+      Task.fail("console needs to be run with the -i/--interactive flag")
     } else {
       val useJavaCp = "-usejavacp"
 
@@ -455,7 +455,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase
         stdin = os.Inherit,
         stdout = os.Inherit
       )
-      Result.Success(())
+      ()
     }
   }
 
@@ -512,7 +512,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase
    */
   def repl(replOptions: String*): Command[Unit] = Task.Command(exclusive = true) {
     if (Task.log.streams.in == DummyInputStream) {
-      Result.Failure("repl needs to be run with the -i/--interactive flag")
+      Task.fail("repl needs to be run with the -i/--interactive flag")
     } else {
       val mainClass = ammoniteMainClass()
       Task.log.debug(s"Using ammonite main class: ${mainClass}")
@@ -526,7 +526,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase
         stdin = os.Inherit,
         stdout = os.Inherit
       )
-      Result.Success(())
+      ()
     }
 
   }

--- a/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
+++ b/scalalib/src/mill/scalalib/SemanticDbJavaModule.scala
@@ -56,13 +56,13 @@ trait SemanticDbJavaModule extends CoursierModule with SemanticDbJavaModuleApi {
            |
            |def semanticDbVersion = ???
            |""".stripMargin
-      Result.Failure(msg)
+      Task.fail(msg)
     } else if (JvmWorkerUtil.isScala3(sv)) {
-      Result.Success(Seq.empty[Dep])
+      Seq.empty[Dep]
     } else {
-      Result.Success(Seq(
+      Seq(
         mvn"org.scalameta:semanticdb-scalac_${sv}:${semDbVersion}"
-      ))
+      )
     }
   }
 
@@ -75,11 +75,11 @@ trait SemanticDbJavaModule extends CoursierModule with SemanticDbJavaModuleApi {
            |
            |def semanticDbJavaVersion = ???
            |""".stripMargin
-      Result.Failure(msg)
+      Task.fail(msg)
     } else {
-      Result.Success(Seq(
+      Seq(
         mvn"com.sourcegraph:semanticdb-javac:${sv}"
-      ))
+      )
     }
   }
 

--- a/scalalib/src/mill/scalalib/UnidocModule.scala
+++ b/scalalib/src/mill/scalalib/UnidocModule.scala
@@ -57,8 +57,8 @@ trait UnidocModule extends ScalaModule {
       scalacPluginClasspath(),
       options ++ unidocSourceFiles0.map(_.path.toString)
     ) match {
-      case true => mill.api.Result.Success(PathRef(Task.dest))
-      case false => mill.api.Result.Failure("unidoc generation failed")
+      case true => PathRef(Task.dest)
+      case false => Task.fail("unidoc generation failed")
     }
   }
 

--- a/scalalib/src/mill/scalalib/scalafmt/ScalafmtModule.scala
+++ b/scalalib/src/mill/scalalib/scalafmt/ScalafmtModule.scala
@@ -40,18 +40,18 @@ trait ScalafmtModule extends JavaModule {
   private[ScalafmtModule] def resolvedScalafmtConfig: Task[PathRef] = Task.Anon {
     val locs = scalafmtConfig()
     locs.find(p => os.exists(p.path)) match {
-      case None => Result.Failure(
+      case None => Task.fail(
           s"None of the specified `scalafmtConfig` locations exist. Searched in: ${locs.map(_.path).mkString(", ")}"
         )
       case Some(c) if (os.read.lines.stream(c.path).find(_.trim.startsWith("version")).isEmpty) =>
-        Result.Failure(
+        Task.fail(
           s"""Found scalafmtConfig file does not specify the scalafmt version to use.
              |Please specify the scalafmt version in ${c.path}
              |Example:
              |version = "2.4.3"
              |""".stripMargin
         )
-      case Some(c) => Result.Success(c)
+      case Some(c) => c
     }
   }
 


### PR DESCRIPTION
Currently, to programmatically fail a task we can either throw an exception or return a `Result.Failure`, but both ways have downsides.

Throwing an exception is easy but seems unintentional from the outside.
Instead of given a nice error message, we see a exception message and a stack trace.
So, the nicer way is to return a `Result.Failure` with a nice message.
But if we want to return a `Result.Failure`, we also must wrap the intended result in a `Result.Success`,
which is inonvenient.

By using the new `Task.fail`, we throw an dedicated exception type which is autmatically converted into a `Result.Failure`,
but doesn't forces us to manually wrap any result into a `Result.Success`.

