### PR TITLE
Use `Task.offline` in dependency download examples

### DIFF
--- a/example/javalib/dependencies/4-downloading-unmanaged-jars/build.mill
+++ b/example/javalib/dependencies/4-downloading-unmanaged-jars/build.mill
@@ -4,12 +4,16 @@ import mill._, javalib._
 
 object `package` extends RootModule with JavaModule {
   def unmanagedClasspath = Task {
-    os.write(
-      Task.dest / "fastjavaio.jar",
-      requests.get.stream(
-        "https://github.com/williamfiset/FastJavaIO/releases/download/1.1/fastjavaio.jar"
+    if (Task.offline) Task.fail("Cannot download classpath when in offline-mode") // <1>
+    else {
+      os.write(
+        Task.dest / "fastjavaio.jar",
+        requests.get.stream(
+          "https://github.com/williamfiset/FastJavaIO/releases/download/1.1/fastjavaio.jar"
+        )
       )
-    )
-    Seq(PathRef(Task.dest / "fastjavaio.jar"))
+      Seq(PathRef(Task.dest / "fastjavaio.jar"))
+    }
   }
 }
+//// SNIPPET:END

--- a/example/kotlinlib/dependencies/4-downloading-unmanaged-jars/build.mill
+++ b/example/kotlinlib/dependencies/4-downloading-unmanaged-jars/build.mill
@@ -7,12 +7,17 @@ object `package` extends RootModule with KotlinModule {
   def kotlinVersion = "1.9.24"
 
   def unmanagedClasspath = Task {
-    os.write(
-      Task.dest / "fastjavaio.jar",
-      requests.get.stream(
-        "https://github.com/williamfiset/FastJavaIO/releases/download/1.1/fastjavaio.jar"
+    if (Task.offline) Task.fail("Cannot download classpath when in offline-mode") // <1>
+    else {
+      os.write(
+        Task.dest / "fastjavaio.jar",
+        requests.get.stream(
+          "https://github.com/williamfiset/FastJavaIO/releases/download/1.1/fastjavaio.jar"
+        )
       )
-    )
-    Seq(PathRef(Task.dest / "fastjavaio.jar"))
+      Seq(PathRef(Task.dest / "fastjavaio.jar"))
+    }
   }
 }
+
+// SNIPPET:END

--- a/example/pythonlib/dependencies/4-downloading-unmanaged-wheels/build.mill
+++ b/example/pythonlib/dependencies/4-downloading-unmanaged-wheels/build.mill
@@ -40,7 +40,6 @@ Hello, world!
 
 */
 
-
 // NOTE: An unmanaged wheel downloaded via `requests.get` is still unmanaged: even though you
 // downloaded it from somewhere, `requests.get` does not know how to pull in transitive
 // dependencies or de-duplicate different versions on the classpath. All the same caveats you need

--- a/example/pythonlib/dependencies/4-downloading-unmanaged-wheels/build.mill
+++ b/example/pythonlib/dependencies/4-downloading-unmanaged-wheels/build.mill
@@ -8,12 +8,18 @@ import mill._, pythonlib._
 
 object `package` extends RootModule with PythonModule {
   def unmanagedWheels = Task {
-    val name = "jinja2-3.1.4-py3-none-any.whl"
-    val url = s"https://github.com/pallets/jinja/releases/download/3.1.4/$name"
-    os.write(Task.dest / name, requests.get.stream(url))
-    Seq(PathRef(Task.dest / name))
+    if (Task.offline) Task.fail("Cannot download classpath when in offline-mode") // <1>
+    else {
+      val name = "jinja2-3.1.4-py3-none-any.whl"
+      val url = s"https://github.com/pallets/jinja/releases/download/3.1.4/$name"
+      os.write(Task.dest / name, requests.get.stream(url))
+      Seq(PathRef(Task.dest / name))
+    }
   }
 }
+
+// <1> Since Mill can also be run with the `--offline` option, we should make sure,
+// that we don't download anything when in offline mode.
 
 /** Usage
 
@@ -26,7 +32,15 @@ Hello, world!
 // once and re-used indefinitely after that. This is usually not a problem, because usually URLs
 // follow the rule that https://www.w3.org/Provider/Style/URI[Cool URIs don't change], and so files
 // downloaded from the same URL will always contain the same contents.
-//
+
+/** Usage
+
+> ./mill --offline run
+Hello, world!
+
+*/
+
+
 // NOTE: An unmanaged wheel downloaded via `requests.get` is still unmanaged: even though you
 // downloaded it from somewhere, `requests.get` does not know how to pull in transitive
 // dependencies or de-duplicate different versions on the classpath. All the same caveats you need

--- a/example/scalalib/dependencies/4-downloading-unmanaged-jars/build.mill
+++ b/example/scalalib/dependencies/4-downloading-unmanaged-jars/build.mill
@@ -57,4 +57,3 @@ I weigh twice as much as you
 // pull in transitive dependencies or de-duplicate different versions on the classpath
 // All the same caveats you need to worry about when dealing with xref:#_unmanaged_jars[unmanaged jars]
 // apply here as well.
-

--- a/example/scalalib/dependencies/4-downloading-unmanaged-jars/build.mill
+++ b/example/scalalib/dependencies/4-downloading-unmanaged-jars/build.mill
@@ -10,17 +10,23 @@ import mill._, scalalib._
 object `package` extends RootModule with ScalaModule {
   def scalaVersion = "2.13.8"
   def unmanagedClasspath = Task {
-    os.write(
-      Task.dest / "fastjavaio.jar",
-      requests.get.stream(
-        "https://github.com/williamfiset/FastJavaIO/releases/download/1.1/fastjavaio.jar"
+    if (Task.offline) Task.fail("Cannot download classpath when in offline-mode") // <1>
+    else {
+      os.write(
+        Task.dest / "fastjavaio.jar",
+        requests.get.stream(
+          "https://github.com/williamfiset/FastJavaIO/releases/download/1.1/fastjavaio.jar"
+        )
       )
-    )
-    Seq(PathRef(Task.dest / "fastjavaio.jar"))
+      Seq(PathRef(Task.dest / "fastjavaio.jar"))
+    }
   }
 }
 
 //// SNIPPET:END
+
+// <1> Since Mill can also be run with the `--offline` option, we should make sure,
+// that we don't download anything when in offline mode.
 
 /** Usage
 
@@ -36,9 +42,19 @@ I weigh twice as much as you
 // This is usually not a problem, because usually URLs follow the rule that
 // https://www.w3.org/Provider/Style/URI[Cool URIs don't change], and so jars
 // downloaded from the same URL will always contain the same contents.
+
+/** Usage
+
+> ./mill --offline run "textfile.txt"
+I am cow
+hear me moo
+I weigh twice as much as you
+*/
+
 //
 // NOTE: An unmanaged jar downloaded via `requests.get` is still unmanaged: even
 // though you downloaded it from somewhere, it `requests.get` does not know how to
 // pull in transitive dependencies or de-duplicate different versions on the classpath
 // All the same caveats you need to worry about when dealing with xref:#_unmanaged_jars[unmanaged jars]
 // apply here as well.
+


### PR DESCRIPTION
Show case how to respect the `Task.offline` state before downloading remote resources.