### PR TITLE
fix the screenshot tests problem

### DIFF
--- a/libs/androidlib/src/mill/androidlib/AndroidAppKotlinModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppKotlinModule.scala
@@ -57,6 +57,11 @@ trait AndroidAppKotlinModule extends AndroidAppModule with AndroidKotlinModule {
 
     override def androidApplicationId: String = outer.androidApplicationId
 
+    /**
+     * Screenshot tests cannot be run in parallel for now
+     */
+    override def testParallelism: T[Boolean] = Task { false }
+
     override def androidApplicationNamespace: String = outer.androidApplicationNamespace
 
     override def androidCompileSdk: T[Int] = outer.androidCompileSdk()


### PR DESCRIPTION
## Problem

Screenshot tests stopped running after some commits

## Solution

After pair programming with @vaslabs we used git bisect and found that the problem was on the commit c58cb616fd35c93e89f5cec55a7b70443f827c52  Turn on `testEnableWorkStrealing` by default (#4681)

For now, we disabled the testParallel for the screenshotTests
 