### PR TITLE
Fail on missing interpolatable variables

### DIFF
--- a/core/constants/package.mill
+++ b/core/constants/package.mill
@@ -10,7 +10,10 @@ import mill.scalalib._
  */
 object `package` extends RootModule with build.MillPublishJavaModule with BuildInfo {
   def buildInfoPackageName = "mill.constants"
-  def buildInfoMembers = Seq(BuildInfo.Value("millVersion", build.millVersion(), "Mill version."))
+  def buildInfoMembers = Seq(
+    BuildInfo.Value("millVersion", build.millVersion(), "Mill version."),
+    BuildInfo.Value("millBinPlatform", build.millBinPlatform(), "Mill binary platform version.")
+  )
 
   object test extends JavaTests with TestModule.Junit4 {
     def mvnDeps = Agg(build.Deps.junitInterface, build.Deps.commonsIo)

--- a/core/constants/src/mill/constants/Util.java
+++ b/core/constants/src/mill/constants/Util.java
@@ -95,21 +95,16 @@ public class Util {
    * @throws IllegalArgumentException if a variable is missing.
    */
   public static String interpolateEnvVars(String input, Map<String, String> env0) {
-    return interpolateEnvVars(
-      input,
-      env0,
-      var -> { throw new IllegalArgumentException("Cannot interpolate missing env var '" + var + "'"); }
-    );
+    return interpolateEnvVars(input, env0, var -> {
+      throw new IllegalArgumentException("Cannot interpolate missing env var '" + var + "'");
+    });
   }
 
   /**
    * Interpolate variables in the form of <code>${VARIABLE}</code> based on the given Map <code>env</code>.
    */
   public static String interpolateEnvVars(
-    String input,
-    Map<String, String> env0,
-    Function<String, String> onMissing
-  ) {
+      String input, Map<String, String> env0, Function<String, String> onMissing) {
     Matcher matcher = envInterpolatorPattern.matcher(input);
     // StringBuilder to store the result after replacing
     StringBuffer result = new StringBuffer();

--- a/core/constants/src/mill/constants/Util.java
+++ b/core/constants/src/mill/constants/Util.java
@@ -8,6 +8,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -91,9 +92,24 @@ public class Util {
 
   /**
    * Interpolate variables in the form of <code>${VARIABLE}</code> based on the given Map <code>env</code>.
-   * Missing vars will be replaced by the empty string.
+   * @throws IllegalArgumentException if a variable is missing.
    */
   public static String interpolateEnvVars(String input, Map<String, String> env0) {
+    return interpolateEnvVars(
+      input,
+      env0,
+      var -> { throw new IllegalArgumentException("Cannot interpolate missing env var '" + var + "'"); }
+    );
+  }
+
+  /**
+   * Interpolate variables in the form of <code>${VARIABLE}</code> based on the given Map <code>env</code>.
+   */
+  public static String interpolateEnvVars(
+    String input,
+    Map<String, String> env0,
+    Function<String, String> onMissing
+  ) {
     Matcher matcher = envInterpolatorPattern.matcher(input);
     // StringBuilder to store the result after replacing
     StringBuffer result = new StringBuffer();
@@ -101,7 +117,6 @@ public class Util {
     Map<String, String> env = new java.util.HashMap<>();
     env.putAll(env0);
 
-    env.put("MILL_VERSION", mill.constants.BuildInfo.millVersion);
     while (matcher.find()) {
       String match = matcher.group(1);
       if (match == null) match = matcher.group(2);
@@ -110,7 +125,7 @@ public class Util {
       } else {
         String envVarValue;
         mill.constants.DebugLog.println("MATCH " + match);
-        envVarValue = env.containsKey(match) ? env.get(match) : "";
+        envVarValue = env.containsKey(match) ? env.get(match) : onMissing.apply(match);
         matcher.appendReplacement(result, envVarValue);
       }
     }

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -11,7 +11,6 @@ import java.lang.reflect.Method
 import scala.collection.mutable
 import scala.util.control.NonFatal
 import scala.util.hashing.MurmurHash3
-import mill.api.{SystemStreams => _, _}
 import mill.api.internal.{EvaluatorApi, BaseModuleApi, CompileProblemReporter, TestReporter}
 
 /**
@@ -40,7 +39,9 @@ private trait GroupExecution {
     // recursively convert java data structure to ujson.Value
     val envWithPwd = env ++ Seq(
       "PWD" -> workspace.toString,
-      "PWD_URI" -> workspace.toNIO.toUri.toString
+      "PWD_URI" -> workspace.toNIO.toUri.toString,
+      "MILL_VERSION" -> mill.constants.BuildInfo.millVersion,
+      "MILL_BIN_PLATFORM" -> mill.constants.BuildInfo.millBinPlatform
     )
     def rec(x: Any): ujson.Value = {
       import collection.JavaConverters._

--- a/runner/client/src/mill/runner/client/MillProcessLauncher.java
+++ b/runner/client/src/mill/runner/client/MillProcessLauncher.java
@@ -98,11 +98,13 @@ public class MillProcessLauncher {
     // Hardcode support for PWD because the graal native launcher has it set to the
     // working dir of the enclosing process, when we want it to be set to the working
     // dir of the current process
-    env.put("PWD", new java.io.File(".").getAbsoluteFile().getCanonicalPath());
+    final String workspaceDir = new java.io.File(".").getAbsoluteFile().getCanonicalPath();
+    env.put("PWD", workspaceDir);
+    env.put("WORKSPACE", workspaceDir);
     env.put("MILL_VERSION", mill.constants.BuildInfo.millVersion);
     env.put("MILL_BIN_PLATFORM", mill.constants.BuildInfo.millBinPlatform);
 
-    if (Files.exists(configFile)) return ClientUtil.readOptsFileLines(configFile.toAbsolutePath());
+    if (Files.exists(configFile)) return ClientUtil.readOptsFileLines(configFile.toAbsolutePath(), env);
     else {
       for (String rootBuildFileName : CodeGenConstants.rootBuildFileNames) {
         Path buildFile = Paths.get(rootBuildFileName);

--- a/runner/client/src/mill/runner/client/MillProcessLauncher.java
+++ b/runner/client/src/mill/runner/client/MillProcessLauncher.java
@@ -104,7 +104,8 @@ public class MillProcessLauncher {
     env.put("MILL_VERSION", mill.constants.BuildInfo.millVersion);
     env.put("MILL_BIN_PLATFORM", mill.constants.BuildInfo.millBinPlatform);
 
-    if (Files.exists(configFile)) return ClientUtil.readOptsFileLines(configFile.toAbsolutePath(), env);
+    if (Files.exists(configFile))
+      return ClientUtil.readOptsFileLines(configFile.toAbsolutePath(), env);
     else {
       for (String rootBuildFileName : CodeGenConstants.rootBuildFileNames) {
         Path buildFile = Paths.get(rootBuildFileName);

--- a/runner/client/src/mill/runner/client/MillProcessLauncher.java
+++ b/runner/client/src/mill/runner/client/MillProcessLauncher.java
@@ -12,7 +12,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import mill.client.ClientUtil;

--- a/runner/client/src/mill/runner/client/MillProcessLauncher.java
+++ b/runner/client/src/mill/runner/client/MillProcessLauncher.java
@@ -12,6 +12,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import mill.client.ClientUtil;
@@ -98,8 +99,10 @@ public class MillProcessLauncher {
     // Hardcode support for PWD because the graal native launcher has it set to the
     // working dir of the enclosing process, when we want it to be set to the working
     // dir of the current process
-
     env.put("PWD", new java.io.File(".").getAbsoluteFile().getCanonicalPath());
+    env.put("MILL_VERSION", mill.constants.BuildInfo.millVersion);
+    env.put("MILL_BIN_PLATFORM", mill.constants.BuildInfo.millBinPlatform);
+
     if (Files.exists(configFile)) return ClientUtil.readOptsFileLines(configFile.toAbsolutePath());
     else {
       for (String rootBuildFileName : CodeGenConstants.rootBuildFileNames) {

--- a/runner/server/client/src/mill/client/ClientUtil.java
+++ b/runner/server/client/src/mill/client/ClientUtil.java
@@ -102,7 +102,8 @@ public class ClientUtil {
    *
    * @return The non-empty lines of the files or an empty list, if the file does not exist
    */
-  public static List<String> readOptsFileLines(final Path file, Map<String, String> env) throws Exception {
+  public static List<String> readOptsFileLines(final Path file, Map<String, String> env)
+      throws Exception {
     final List<String> vmOptions = new LinkedList<>();
     try (final Scanner sc = new Scanner(file.toFile(), StandardCharsets.UTF_8)) {
       while (sc.hasNextLine()) {

--- a/runner/server/client/src/mill/client/ClientUtil.java
+++ b/runner/server/client/src/mill/client/ClientUtil.java
@@ -102,10 +102,9 @@ public class ClientUtil {
    *
    * @return The non-empty lines of the files or an empty list, if the file does not exist
    */
-  public static List<String> readOptsFileLines(final Path file) throws Exception {
+  public static List<String> readOptsFileLines(final Path file, Map<String, String> env) throws Exception {
     final List<String> vmOptions = new LinkedList<>();
     try (final Scanner sc = new Scanner(file.toFile(), StandardCharsets.UTF_8)) {
-      final Map<String, String> env = System.getenv();
       while (sc.hasNextLine()) {
         String arg = sc.nextLine();
         String trimmed = arg.trim();

--- a/runner/server/client/test/src/mill/client/MillEnvTests.java
+++ b/runner/server/client/test/src/mill/client/MillEnvTests.java
@@ -7,7 +7,6 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-
 import org.junit.Test;
 
 public class MillEnvTests {

--- a/runner/server/client/test/src/mill/client/MillEnvTests.java
+++ b/runner/server/client/test/src/mill/client/MillEnvTests.java
@@ -6,15 +6,18 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+
 import org.junit.Test;
 
 public class MillEnvTests {
 
   @Test
-  public void readOptsFileLinesWithoutFInalNewline() throws Exception {
+  public void readOptsFileLinesWithoutFinalNewline() throws Exception {
     Path file = Paths.get(
         getClass().getClassLoader().getResource("file-wo-final-newline.txt").toURI());
-    List<String> lines = ClientUtil.readOptsFileLines(file);
+    Map<String, String> env = Map.of();
+    List<String> lines = ClientUtil.readOptsFileLines(file, env);
     assertEquals(
         lines, Arrays.asList("-DPROPERTY_PROPERLY_SET_VIA_JVM_OPTS=value-from-file", "-Xss120m"));
   }


### PR DESCRIPTION
Interpolating missing variable to the empty string (`""`) is error prone, possibly dangerous and hard to debug. Hence, this change makes it a hard failure when a variable is missing.