### PR TITLE
Parse YAML frontmatter only from file head

### DIFF
--- a/contrib/artifactory/readme.adoc
+++ b/contrib/artifactory/readme.adoc
@@ -7,7 +7,8 @@ This plugin allows publishing to Artifactory.
 
 [source,scala]
 ----
-import $ivy.`com.lihaoyi::mill-contrib-artifactory:`
+//| mvnDeps: ["com.lihaoyi::mill-contrib-artifactory:$MILL_VERSION"]
+
 import mill.contrib.artifactory.ArtifactoryPublishModule
 
 object mymodule extends ArtifactoryPublishModule {

--- a/contrib/bintray/readme.adoc
+++ b/contrib/bintray/readme.adoc
@@ -9,7 +9,8 @@ Make sure your module extends from `BintrayPublishModule`:
 
 [source,scala]
 ----
-import $ivy.`com.lihaoyi::mill-contrib-bintray:`
+//| mvnDeps: ["com.lihaoyi::mill-contrib-bintray:$MILL_VERSION"]
+
 import mill.contrib.bintray.BintrayPublishModule
 
 object mymodule extends BintrayPublishModule {

--- a/contrib/bloop/readme.adoc
+++ b/contrib/bloop/readme.adoc
@@ -25,8 +25,9 @@ the deserialised configuration for that particular module:
 .`build.mill`
 [source,scala]
 ----
+//| mvnDeps: ["com.lihaoyi::mill-contrib-bloop:$MILL_VERSION"]
+
 package build
-import $ivy.`com.lihaoyi::mill-contrib-bloop:`
 
 import mill._
 import mill.scalalib._

--- a/contrib/buildinfo/readme.adoc
+++ b/contrib/buildinfo/readme.adoc
@@ -12,8 +12,9 @@ Quickstart:
 .Example `build.mill` defining a Scala module with `BuildInfo`
 [source,scala]
 ----
+//| mvnDeps: ["com.lihaoyi::mill-contrib-buildinfo:$MILL_VERSION"]
 package build
-import $ivy.`com.lihaoyi::mill-contrib-buildinfo:`
+
 import mill.contrib.buildinfo.BuildInfo
 
 object project extends ScalaModule with BuildInfo {

--- a/contrib/codeartifact/readme.adoc
+++ b/contrib/codeartifact/readme.adoc
@@ -7,7 +7,8 @@ This plugin allows publishing to AWS Codeartifact.
 
 [source,scala]
 ----
-import $ivy.`com.lihaoyi::mill-contrib-codeartifact:`
+//| mvnDeps: ["com.lihaoyi::mill-contrib-codeartifact:$MILL_VERSION"]
+
 import mill.contrib.codeartifact.CodeartifactPublishModule
 
 object mymodule extends CodeartifactPublishModule {

--- a/contrib/docker/readme.adoc
+++ b/contrib/docker/readme.adoc
@@ -10,10 +10,11 @@ In the simplest configuration just extend `DockerModule` and declare a `DockerCo
 .`build.mill`
 [source,scala]
 ----
+//| mvnDeps: ["com.lihaoyi::mill-contrib-docker:$MILL_VERSION"]
+
 package build
 import mill._, scalalib._
 
-import $ivy.`com.lihaoyi::mill-contrib-docker:$MILL_VERSION`
 import contrib.docker.DockerModule
 
 object foo extends JavaModule with DockerModule {

--- a/contrib/flyway/readme.adoc
+++ b/contrib/flyway/readme.adoc
@@ -9,10 +9,11 @@ Configure flyway by overriding settings in your module. For example
 .`build.mill`
 [source,scala]
 ----
+//| mvnDeps: ["com.lihaoyi::mill-contrib-flyway:$MILL_VERSION"]
 package build
+
 import mill._, scalalib._
 
-import $ivy.`com.lihaoyi::mill-contrib-flyway:`
 import contrib.flyway.FlywayModule
 
 object foo extends ScalaModule with FlywayModule {

--- a/contrib/gitlab/readme.adoc
+++ b/contrib/gitlab/readme.adoc
@@ -15,9 +15,10 @@ Most trivial publish config is:
 .`build.mill`
 [source,scala]
 ----
+//| mvnDeps: ["com.lihaoyi::mill-contrib-gitlab:$MILL_VERSION"]
 package build
+
 import mill._, scalalib._, mill.scalalib.publish._
-import $ivy.`com.lihaoyi::mill-contrib-gitlab:`
 import mill.contrib.gitlab._
 
 object lib extends ScalaModule with GitlabPublishModule {
@@ -85,6 +86,8 @@ If the original search order is too wide, or you would like to add places to loo
 .`build.mill`
 [source,scala]
 ----
+//| mvnDeps: ["com.lihaoyi::mill-contrib-gitlab:$MILL_VERSION"]
+
 package build
 // Personal, Env, Deploy etc types
 import mill.contrib.gitlab.GitlabTokenLookup._

--- a/contrib/jmh/readme.adoc
+++ b/contrib/jmh/readme.adoc
@@ -8,10 +8,11 @@ Example configuration:
 .`build.mill`
 [source,scala]
 ----
+//| mvnDeps: ["com.lihaoyi::mill-contrib-jmh:$MILL_VERSION"]
 package build
+
 import mill._, scalalib._
 
-import $ivy.`com.lihaoyi::mill-contrib-jmh:`
 import contrib.jmh.JmhModule
 
 object foo extends ScalaModule with JmhModule {

--- a/contrib/playlib/readme.adoc
+++ b/contrib/playlib/readme.adoc
@@ -38,9 +38,11 @@ Twirl versions. You also need to define your own test object which extends the p
 .`build.mill`
 [source,scala]
 ----
+//| mvnDeps: ["com.lihaoyi::mill-contrib-playlib:$MILL_VERSION"]
 package build
+
 import mill._
-import $ivy.`com.lihaoyi::mill-contrib-playlib:`,  mill.playlib._
+import mill.playlib._
 
 object core extends PlayModule {
     // config
@@ -113,9 +115,11 @@ The `PlayApiModule` trait behaves the same as the `PlayModule` trait but it won'
 .`build.mill`
 [source,scala]
 ----
+//| mvnDeps: ["com.lihaoyi::mill-contrib-playlib:$MILL_VERSION"]
 package build
+
 import mill._
-import $ivy.`com.lihaoyi::mill-contrib-playlib:`,  mill.playlib._
+import mill.playlib._
 
 object core extends PlayApiModule {
     // config
@@ -151,9 +155,11 @@ like in the following example build:
 .`build.mill`
 [source,scala]
 ----
+//| mvnDeps: ["com.lihaoyi::mill-contrib-playlib:$MILL_VERSION"]
 package build
+
 import mill._
-import $ivy.`com.lihaoyi::mill-contrib-playlib:$MILL_VERSION`, mill.playlib._
+import mill.playlib._
 
 object core extends PlayApiModule {
     // config
@@ -193,9 +199,11 @@ Looking back at the sample build definition in <<_using_playmodule>>:
 .`build.mill`
 [source,scala]
 ----
+//| mvnDeps: ["com.lihaoyi::mill-contrib-playlib:$MILL_VERSION"]
 package build
+
 import mill._
-import $ivy.`com.lihaoyi::mill-contrib-playlib:`, mill.playlib._
+import mill.playlib._
 
 object core extends PlayModule {
     // config
@@ -234,9 +242,11 @@ by extending `RootModule0` in your build:
 .`build.mill`
 [source,scala]
 ----
+//| mvnDeps: ["com.lihaoyi::mill-contrib-playlib:$MILL_VERSION"]
 package build
+
 import mill._
-import $ivy.`com.lihaoyi::mill-contrib-playlib:`,  mill.playlib._
+import mill.playlib._
 
 object build extends RootModule with PlayModule {
 	// config

--- a/contrib/proguard/readme.adoc
+++ b/contrib/proguard/readme.adoc
@@ -19,8 +19,9 @@ Here is a simple example:
 .`build.mill`
 [source,scala]
 ----
+//| mvnDeps: ["com.lihaoyi::mill-contrib-proguard:$MILL_VERSION"]
 package build
-import $ivy.`com.lihaoyi::mill-contrib-proguard:`
+
 import contrib.proguard._
 
 object foo extends ScalaModule with Proguard {

--- a/contrib/scalapblib/readme.adoc
+++ b/contrib/scalapblib/readme.adoc
@@ -10,8 +10,9 @@ This creates a Scala module which compiles `.proto` files in the `protobuf` fold
 .`build.mill`
 [source,scala]
 ----
+//| mvnDeps: ["com.lihaoyi::mill-contrib-scalapblib:$MILL_VERSION"]
 package build
-import $ivy.`com.lihaoyi::mill-contrib-scalapblib:`
+
 import contrib.scalapblib._
 
 object example extends ScalaPBModule {
@@ -56,8 +57,9 @@ If you'd like to configure the https://scalapb.github.io/docs/scalapbc#passing-g
 .`build.mill`
 [source,scala]
 ----
+//| mvnDeps: ["com.lihaoyi::mill-contrib-scalapblib:$MILL_VERSION"]
 package build
-import $ivy.`com.lihaoyi::mill-contrib-scalapblib:`
+
 import contrib.scalapblib._
 
 object example extends ScalaPBModule {
@@ -72,8 +74,9 @@ If you'd like to pass additional arguments to the ScalaPB compiler directly, you
 .`build.mill`
 [source,scala]
 ----
+//| mvnDeps: ["com.lihaoyi::mill-contrib-scalapblib:$MILL_VERSION"]
 package build
-import $ivy.`com.lihaoyi::mill-contrib-scalapblib:$MILL_VERSION`
+
 import contrib.scalapblib._
 
 object example extends ScalaPBModule {

--- a/contrib/scoverage/readme.adoc
+++ b/contrib/scoverage/readme.adoc
@@ -14,8 +14,9 @@ module. Additionally, you must define a submodule that extends the
 .`build.mill`
 [source,scala]
 ----
+//| mvnDeps: ["com.lihaoyi::mill-contrib-scoverage:$MILL_VERSION"]
 package build
-import $ivy.`com.lihaoyi::mill-contrib-scoverage:`
+
 import mill.contrib.scoverage.ScoverageModule
 
 object foo extends ScoverageModule  {

--- a/contrib/sonatypecentral/readme.adoc
+++ b/contrib/sonatypecentral/readme.adoc
@@ -7,8 +7,9 @@ This plugin allows users to publish open-source packages to Maven Central via th
 Add the following to your `build.mill`:
 [source,scala]
 ----
+//| mvnDeps: ["com.lihaoyi::mill-contrib-sonatypecentral:$MILL_VERSION"]
 package build
-import $ivy.`com.lihaoyi::mill-contrib-sonatypecentral:`
+
 import mill.contrib.sonatypecentral.SonatypeCentralPublishModule
 
 object mymodule extends SonatypeCentralPublishModule {

--- a/contrib/twirllib/readme.adoc
+++ b/contrib/twirllib/readme.adoc
@@ -10,10 +10,11 @@ Also note that twirl templates get compiled into scala code, so you also need to
 .`build.mill`
 [source,scala]
 ----
+//| mvnDeps: ["com.lihaoyi::mill-contrib-twirl:$MILL_VERSION"]
 package build
-import mill.scalalib._
 
-import $ivy.`com.lihaoyi::mill-contrib-twirllib:`,  mill.twirllib._
+import mill.scalalib._
+import mill.twirllib._
 
 object app extends ScalaModule with TwirlModule {
 // ...
@@ -48,10 +49,11 @@ directory. This directory must be added to the generated sources of the module t
 .`build.mill`
 [source,scala]
 ----
+//| mvnDeps: ["com.lihaoyi::mill-contrib-twirl:$MILL_VERSION"]
 package build
-import mill.scalalib._
 
-import $ivy.`com.lihaoyi::mill-contrib-twirllib:`,  mill.twirllib._
+import mill.scalalib._
+import mill.twirllib._
 
 object app extends ScalaModule with TwirlModule {
   def twirlVersion = "1.5.1"
@@ -90,10 +92,11 @@ To add additional imports to all of the twirl templates, override `twirlImports`
 .`build.mill`
 [source,scala]
 ----
+//| mvnDeps: ["com.lihaoyi::mill-contrib-twirllib:$MILL_VERSION"]
 package build
-import mill.scalalib._
 
-import $ivy.`com.lihaoyi::mill-contrib-twirllib:`,  mill.twirllib._
+import mill.scalalib._
+import mill.twirllib._
 
 object app extends ScalaModule with TwirlModule {
   def twirlVersion = "1.5.1"
@@ -135,10 +138,11 @@ To add additional formats, override `twirlFormats` in your build:
 .`build.mill`
 [source,scala]
 ----
+//| mvnDeps: ["com.lihaoyi::mill-contrib-twirllib:$MILL_VERSION"]
 package build
-import mill.scalalib._
 
-import $ivy.`com.lihaoyi::mill-contrib-twirllib:`,  mill.twirllib._
+import mill.scalalib._
+import mill.twirllib._
 
 object app extends ScalaModule with TwirlModule {
   def twirlVersion = "1.5.1"

--- a/contrib/versionfile/readme.adoc
+++ b/contrib/versionfile/readme.adoc
@@ -13,8 +13,9 @@ Add a `VersionFileModule` to the `build.mill` file:
 
 [source,scala]
 ----
+//| mvnDeps: ["com.lihaoyi::mill-contrib-versiofile:$MILL_VERSION"]
 package build
-import $ivy.`com.lihaoyi::mill-contrib-versionfile:`
+
 import mill.contrib.versionfile.VersionFileModule
 
 object versionFile extends VersionFileModule
@@ -71,7 +72,8 @@ at the root of the project, you can override `millSourcePath`:
 
 [source,scala]
 ----
-import $ivy.`com.lihaoyi::mill-contrib-versionfile:`
+//| mvnDeps: ["com.lihaoyi::mill-contrib-versionfile:$MILL_VERSION"]
+
 import mill.contrib.versionfile.VersionFileModule
 
 object versionFile extends VersionFileModule {

--- a/core/constants/src/mill/constants/Util.java
+++ b/core/constants/src/mill/constants/Util.java
@@ -78,7 +78,7 @@ public class Util {
   public static String readYamlHeader(java.nio.file.Path buildFile) throws java.io.IOException {
     java.util.List<String> lines = java.nio.file.Files.readAllLines(buildFile);
     String yamlString = lines.stream()
-        .filter(line -> line.startsWith("//|"))
+        .takeWhile(line -> line.startsWith("//|"))
         .map(line -> line.substring(4)) // Remove the `//|` prefix
         .collect(java.util.stream.Collectors.joining("\n"));
 

--- a/example/extending/imports/1-mvn-deps/build.mill
+++ b/example/extending/imports/1-mvn-deps/build.mill
@@ -1,8 +1,8 @@
+//| mvnDeps: ["org.thymeleaf:thymeleaf:3.1.1.RELEASE"]
+
 // The following example shows how to import the library `org.thymeleaf:thymeleaf:3.1.1.RELEASE`
 // into your build, so you can use it at build-time to safely generate escaped HTML snippets
 // in your resource path for your application to use.
-
-//| mvnDeps: ["org.thymeleaf:thymeleaf:3.1.1.RELEASE"]
 
 package build
 import mill._, javalib._

--- a/example/extending/imports/2-mvn-deps-scala/build.mill
+++ b/example/extending/imports/2-mvn-deps-scala/build.mill
@@ -1,9 +1,10 @@
+//| mvnDeps: ["com.lihaoyi::scalatags:0.13.1"]
+
 // `//| mvnDeps:` can also be used with Scala libraries. The following example
 // replaces `org.thymeleaf:thymeleaf:3.1.1.RELEASE` above with `com.lihaoyi::scalatags:0.12.0`,
 // a HTML generation library that does the string concatenation/construction internally
 // and also escapes the input strings on your behalf:
 
-//| mvnDeps: ["com.lihaoyi::scalatags:0.13.1"]
 import mill._, scalalib._
 import scalatags.Text.all._
 

--- a/example/extending/plugins/7-writing-mill-plugins/myplugin/test/resources/example-test-project/build.mill
+++ b/example/extending/plugins/7-writing-mill-plugins/myplugin/test/resources/example-test-project/build.mill
@@ -1,6 +1,6 @@
-package build
 //| mvnDeps:
 //| - com.lihaoyi::myplugin::0.0.1
+package build
 
 import mill._, myplugin._
 

--- a/example/extending/plugins/7-writing-mill-plugins/myplugin/test/resources/integration-test-project/build.mill
+++ b/example/extending/plugins/7-writing-mill-plugins/myplugin/test/resources/integration-test-project/build.mill
@@ -1,6 +1,7 @@
-package build
 //| mvnDeps:
 //| - com.lihaoyi::myplugin::0.0.1
+package build
+
 import mill._, myplugin._
 
 object `package` extends RootModule with LineCountJavaModule {

--- a/example/fundamentals/cross/10-static-blog/build.mill
+++ b/example/fundamentals/cross/10-static-blog/build.mill
@@ -1,11 +1,13 @@
+//| mvnDeps:
+//| - com.lihaoyi::scalatags:0.13.1
+//| - com.atlassian.commonmark:commonmark:0.13.1
+
 // The following example demonstrates a use case: using cross modules to
 // turn files on disk into blog posts. To begin with, we xref:extending/import-mvn-plugins.adoc[import $ivy]
 // two third-party libraries - Commonmark and Scalatags - to deal with Markdown parsing and
 // HTML generation respectively:
 package build
-//| mvnDeps:
-//| - com.lihaoyi::scalatags:0.13.1
-//| - com.atlassian.commonmark:commonmark:0.13.1
+
 import scalatags.Text.all._
 import org.commonmark.parser.Parser
 import org.commonmark.renderer.html.HtmlRenderer

--- a/example/package.mill
+++ b/example/package.mill
@@ -280,10 +280,13 @@ $title
 [source,scala,subs="attributes,verbatim"]
 ----
 
-${if(seenFrontMatter) "" else {
-  seenFrontMatter = true
-  frontMatter
-}}
+${
+                  if (seenFrontMatter) ""
+                  else {
+                    seenFrontMatter = true
+                    frontMatter
+                  }
+                }
 
 $txt
 ----

--- a/example/package.mill
+++ b/example/package.mill
@@ -246,10 +246,14 @@ object `package` extends RootModule with Module {
 
     def rendered = Task {
       var seenCode = false
+      var seenFrontMatter = false
       val examplePath = moduleDir.subRelativeTo(Task.workspace)
+      val frontMatter = parsed().takeWhile(_._1 == "yaml").map(_._2).mkString("\n")
+      val withoutFrontMatter = parsed().dropWhile(_._1 == "yaml")
+
       os.write(
         Task.dest / "example.adoc",
-        parsed()
+        withoutFrontMatter
           .filter(_._2.nonEmpty)
           .map {
             case (s"see:$path", txt) =>
@@ -275,6 +279,11 @@ $txt
 $title
 [source,scala,subs="attributes,verbatim"]
 ----
+
+${if(seenFrontMatter) "" else {
+  seenFrontMatter = true
+  frontMatter
+}}
 
 $txt
 ----

--- a/example/scalalib/linting/2-contrib-scoverage/build.mill
+++ b/example/scalalib/linting/2-contrib-scoverage/build.mill
@@ -1,7 +1,8 @@
-package build
-import mill._, scalalib._
 //| mvnDeps:
 //| - com.lihaoyi::mill-contrib-scoverage:$MILL_VERSION
+package build
+
+import mill._, scalalib._
 
 import mill.contrib.scoverage._
 

--- a/example/thirdparty/commons-io/build.mill
+++ b/example/thirdparty/commons-io/build.mill
@@ -1,8 +1,9 @@
-package build
-import mill._, javalib._, publish._
-import mill.define.ModuleRef
 //| mvnDeps:
 //| - com.lihaoyi::mill-contrib-jmh:$MILL_VERSION
+package build
+
+import mill._, javalib._, publish._
+import mill.define.ModuleRef
 import contrib.jmh.JmhModule
 
 object `package` extends RootModule with PublishModule with MavenModule {

--- a/example/thirdparty/netty/build.mill
+++ b/example/thirdparty/netty/build.mill
@@ -1,9 +1,10 @@
-package build
-import mill._, javalib._
 //| mvnDeps:
 //| - org.codehaus.groovy:groovy:3.0.9
 //| - org.codehaus.groovy:groovy-ant:3.0.9
 //| - ant:ant-optional:1.5.3-1
+package build
+
+import mill._, javalib._
 
 // TODO:
 //   testsuite-shading

--- a/integration/feature/header-mvn-deps-worker-invalidation/resources/build.mill
+++ b/integration/feature/header-mvn-deps-worker-invalidation/resources/build.mill
@@ -1,4 +1,7 @@
+//| mvnDeps:
+//| - com.lihaoyi::mill-contrib-playlib:$MILL_VERSION
 package build
+
 // Test to make sure that the worker instances whose classes come from an
 // `//| mvnDeps:` dependency are properly invalidated when the `build.mill` is
 // modified and re-compiled, causing a new classloader to be created which
@@ -6,9 +9,6 @@ package build
 //
 // In this test case, `mill.playlib.RouteCompilerWorker` is the relevant worker
 // class, instantiated in `RouterModule.routeCompilerWorker`
-
-//| mvnDeps:
-//| - com.lihaoyi::mill-contrib-playlib:$MILL_VERSION
 
 import mill._
 import mill.playlib._

--- a/integration/feature/scoverage/resources/build.mill
+++ b/integration/feature/scoverage/resources/build.mill
@@ -1,11 +1,9 @@
-package build
-// Reproduction of issue https://github.com/com-lihaoyi/mill/issues/2579
-
-// mill plugins
 //| mvnDeps:
 //| - com.lihaoyi::mill-contrib-scoverage:$MILL_VERSION
+package build
 
-// imports
+// Reproduction of issue https://github.com/com-lihaoyi/mill/issues/2579
+
 import mill._
 import mill.contrib.scoverage.ScoverageModule
 import mill.scalalib._

--- a/integration/ide/bloop/resources/build.mill
+++ b/integration/ide/bloop/resources/build.mill
@@ -1,7 +1,7 @@
-package build
 // mill plugins
 //| mvnDeps:
 //| - com.lihaoyi::mill-contrib-bloop:$MILL_VERSION
+package build
 
 // imports
 import mill._

--- a/mill-build/src-testkit/mill/testkit/ExampleParser.scala
+++ b/mill-build/src-testkit/mill/testkit/ExampleParser.scala
@@ -3,7 +3,7 @@ package mill.testkit
 object ExampleParser {
   def apply(testRepoRoot: os.Path): Seq[(String, String)] = {
 
-    val states = collection.mutable.Buffer("scala")
+    val states = collection.mutable.Buffer("yaml")
     val chunks = collection.mutable.Buffer(collection.mutable.Buffer.empty[String])
 
     val rootBuildFileNames = Seq("build.sc", "build.mill", "build.mill.scala")
@@ -20,8 +20,9 @@ object ExampleParser {
         case s"/** See Also: $path */" =>
           (s"see:$path", Some(os.read(os.Path(path, testRepoRoot))))
         case s"*/" => ("scala", None)
+        case line @ s"//|$_" if states.last == "yaml" => ("yaml", Some(line))
         case s"//$rest" if !rest.startsWith("|") => ("comment", Some(rest.stripPrefix(" ")))
-        case l => (if (states.last == "comment") "scala" else states.last, Some(l))
+        case l => (if (Seq("comment", "yaml").contains(states.last)) "scala" else states.last, Some(l))
       }
 
       if (newState != states.last) {

--- a/mill-build/src-testkit/mill/testkit/ExampleParser.scala
+++ b/mill-build/src-testkit/mill/testkit/ExampleParser.scala
@@ -22,7 +22,8 @@ object ExampleParser {
         case s"*/" => ("scala", None)
         case line @ s"//|$_" if states.last == "yaml" => ("yaml", Some(line))
         case s"//$rest" if !rest.startsWith("|") => ("comment", Some(rest.stripPrefix(" ")))
-        case l => (if (Seq("comment", "yaml").contains(states.last)) "scala" else states.last, Some(l))
+        case l =>
+          (if (Seq("comment", "yaml").contains(states.last)) "scala" else states.last, Some(l))
       }
 
       if (newState != states.last) {


### PR DESCRIPTION
Adapt `ExampleParser` to also capture the YAML frontmatter.
Defer rendering of YAML frontmatter until the first Scala code block is rendered.
Revise all contrib plugin examples to use YAML frontmatter to load the plugin.

This supersedes https://github.com/com-lihaoyi/mill/pull/4984
