### PR TITLE
Android/cleanup app release install

### DIFF
--- a/example/androidlib/java/1-hello-world/app/src/main/AndroidManifest.xml
+++ b/example/androidlib/java/1-hello-world/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0">
-    <uses-sdk android:minSdkVersion="9" android:targetSdkVersion="35"/>
     <application android:label="@string/app_name" android:theme="@android:style/Theme.Light.NoTitleBar" android:debuggable="true">
         <activity android:name=".MainActivity"
                 android:exported="true">
@@ -9,7 +8,4 @@
             </intent-filter>
         </activity>
     </application>
-    <instrumentation
-            android:name="androidx.test.runner.AndroidJUnitRunner"
-            android:targetPackage="com.helloworld.app" />
 </manifest>

--- a/example/androidlib/java/1-hello-world/build.mill
+++ b/example/androidlib/java/1-hello-world/build.mill
@@ -45,8 +45,6 @@ object app extends AndroidAppModule {
 
     def androidSdkModule = mill.define.ModuleRef(androidSdkModule0)
 
-    override def instrumentationPackage = "com.helloworld.app"
-
     /* TODO currently the dependency resolution ignores the platform type and kotlinx-coroutines-core has
      * conflicting classes with kotlinx-coroutines-core-jvm . Remove the exclusions once the dependency
      * resolution resolves conflicts between androidJvm and jvm platform types
@@ -141,7 +139,7 @@ object app extends AndroidAppModule {
 ]
 ...
 
-> cat out/app/it/testTask.dest/test-report.xml
+> cat out/app/it/testForked.dest/test-report.xml
 ...
 <?xml version='1.0' encoding='UTF-8'?>
 <testsuites tests="1" failures="0" errors="0" skipped="0" time="...">

--- a/example/androidlib/java/2-app-bundle/bundle/src/main/AndroidManifest.xml
+++ b/example/androidlib/java/2-app-bundle/bundle/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0">
-    <uses-sdk android:minSdkVersion="9" android:targetSdkVersion="35"/>
     <application android:label="@string/app_name" android:theme="@android:style/Theme.Light.NoTitleBar" android:debuggable="true">
         <activity android:name=".MainActivity"
                 android:exported="true">

--- a/example/androidlib/java/3-linting/app/src/main/AndroidManifest.xml
+++ b/example/androidlib/java/3-linting/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0">
-    <uses-sdk android:minSdkVersion="9" android:targetSdkVersion="35"/>
     <application android:label="@string/app_name" android:theme="@android:style/Theme.Light.NoTitleBar" android:debuggable="true">
         <activity android:name=".MainActivity"
                 android:exported="true">

--- a/example/androidlib/java/3-linting/build.mill
+++ b/example/androidlib/java/3-linting/build.mill
@@ -67,7 +67,7 @@ lint.xml
 src
 
 > cat out/app/androidLintRun.dest/report.txt # Display content of the linting report
-AndroidManifest.xml:3: ...Error: Avoid hardcoding the debug mode; leaving it out allows debug and release builds to automatically assign one [HardcodedDebugMode]
+AndroidManifest.xml:2: ...Error: Avoid hardcoding the debug mode; leaving it out allows debug and release builds to automatically assign one [HardcodedDebugMode]
 
 > sed -i.bak 's/ android:debuggable="true"//g' app/src/main/AndroidManifest.xml # Fix the HardcodedDebugMode warning issue from `AndroidManifest.xml`
 
@@ -91,7 +91,7 @@ AndroidManifest.xml:3: ...Error: Avoid hardcoding the debug mode; leaving it out
 > ./mill app.androidLintRun # Rerun it for new changes to reflect
 
 > cat out/app/androidLintRun.dest/report.txt # Output the changes in the report
-AndroidManifest.xml:3: ...Warning: Should explicitly set android:icon, there is no default [MissingApplicationIcon]
+AndroidManifest.xml:2: ...Warning: Should explicitly set android:icon, there is no default [MissingApplicationIcon]
 
 > sed -i.bak 's/severity="warning"/severity="ignore"/g' app/lint.xml # Revert the severity level of `MissingApplicationIcon`
 

--- a/example/androidlib/java/4-sum-lib-java/app/src/main/AndroidManifest.xml
+++ b/example/androidlib/java/4-sum-lib-java/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0">
-    <uses-sdk android:minSdkVersion="9" android:targetSdkVersion="35"/>
     <application android:label="Calculator" android:theme="@android:style/Theme.Light.NoTitleBar" android:debuggable="true">
         <activity android:name=".Main"
                 android:exported="true">

--- a/example/androidlib/java/4-sum-lib-java/build.mill
+++ b/example/androidlib/java/4-sum-lib-java/build.mill
@@ -28,6 +28,8 @@ object lib extends AndroidLibModule with PublishModule {
   def androidMinSdk = 19
   def androidCompileSdk = 35
 
+  def androidLibPackage = "com.example"
+
   def publishVersion = "0.0.1"
   def pomSettings = PomSettings(
     description = "sumlib",

--- a/example/androidlib/java/4-sum-lib-java/lib/src/main/AndroidManifest.xml
+++ b/example/androidlib/java/4-sum-lib-java/lib/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example" android:versionCode="1" android:versionName="1.0">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0">
 
 </manifest>

--- a/example/androidlib/java/5-R8/app/src/main/AndroidManifest.xml
+++ b/example/androidlib/java/5-R8/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.helloworld.app" android:versionCode="1" android:versionName="1.0">
-    <uses-sdk android:minSdkVersion="9" android:targetSdkVersion="35"/>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0">
     <application android:label="@string/app_name" android:theme="@android:style/Theme.Light.NoTitleBar" android:debuggable="true">
         <activity android:name=".MainActivity"
                 android:exported="true">
@@ -9,7 +8,4 @@
             </intent-filter>
         </activity>
     </application>
-    <instrumentation
-            android:name="androidx.test.runner.AndroidJUnitRunner"
-            android:targetPackage="com.helloworld.app" />
 </manifest>

--- a/example/androidlib/java/5-R8/app/test-proguard-rules.pro
+++ b/example/androidlib/java/5-R8/app/test-proguard-rules.pro
@@ -9,6 +9,7 @@
 # Keep all annotation metadata (needed for reflection-based test frameworks)
 -keepattributes *Annotation*
 
+-keep class com.helloworld.app.** { *; }
 # Keep all Espresso framework classes and specifically ensure that the idling resources aren’t stripped
 -keep class androidx.test.espresso.** { *; }
 -keep class androidx.test.espresso.IdlingRegistry { *; }

--- a/example/androidlib/java/5-R8/build.mill
+++ b/example/androidlib/java/5-R8/build.mill
@@ -43,6 +43,16 @@ object app extends AndroidAppModule { // <2>
   def androidReleaseKeyStorePass: T[Option[String]] = Task { Some("MillBuildTool") }
 
   override def androidVirtualDeviceIdentifier: String = "java-test"
+  override def androidIsDebug: T[Boolean] = Task { false }
+
+  override def androidReleaseSettings: T[AndroidBuildTypeSettings] = Task {
+    super.androidReleaseSettings().withProguardLocalFiles(
+      Seq(
+        moduleDir / "proguard-rules.pro",
+        moduleDir / "test-proguard-rules.pro"
+      )
+    )
+  }
 
   // Unit tests for the application
   object test extends AndroidAppTests with TestModule.Junit4 {
@@ -80,15 +90,16 @@ object app extends AndroidAppModule { // <2>
 /** Usage
 
 > ./mill show app.androidApk
-".../out/app/androidApk.dest/app.apk"
 
 > ./mill show app.createAndroidVirtualDevice
 ...Name: java-test, DeviceId: medium_phone...
 
 > ./mill show app.startAndroidEmulator
 
-> ./mill show app.androidReleaseInstall
+> ./mill show app.androidInstall
 ...All files should be loaded. Notifying the device...
+
+> ./mill show app.it
 
 > ./mill show app.stopAndroidEmulator
 
@@ -96,9 +107,9 @@ object app extends AndroidAppModule { // <2>
 
 */
 
-// R8 will run automatically when you run the `androidReleaseInstall` task.
-// If you want to create the APK without R8, you can use the `androidApk` task to create the not-optimized APK. You can also
+// R8 will run automatically when you run the `androidInstall` task with androidIsDebug set to false.
+// If you want to create the APK without R8, you can set the androidReleaseSettings isMinifyEnabled to false. You can also
 // run the `andoidInstall` task that will automaticaly run the `androidApk` and also install it in the emulator.
-// The `androidReleaseInstall` task will install the optimized APK on the emulator.
+// The release settings used in `androidInstall` task will install the optimized APK on the emulator.
 // So first you need to create the emulator and start it.
 // After the emulator is started, you can run the `androidReleaseInstall` task and see the app in the emulator.

--- a/example/androidlib/java/5-R8/build.mill
+++ b/example/androidlib/java/5-R8/build.mill
@@ -48,8 +48,7 @@ object app extends AndroidAppModule { // <2>
   override def androidReleaseSettings: T[AndroidBuildTypeSettings] = Task {
     super.androidReleaseSettings().withProguardLocalFiles(
       Seq(
-        moduleDir / "proguard-rules.pro",
-        moduleDir / "test-proguard-rules.pro"
+        moduleDir / "proguard-rules.pro"
       )
     )
   }
@@ -64,7 +63,14 @@ object app extends AndroidAppModule { // <2>
   // Instrumented tests (runs on emulator)
   object it extends AndroidAppInstrumentedTests with AndroidTestModule.AndroidJUnit {
     def androidSdkModule = mill.define.ModuleRef(androidSdkModule0)
-    override def instrumentationPackage = "com.helloworld.app"
+
+    override def androidIsDebug: T[Boolean] = Task {
+      false
+    }
+
+    override def androidReleaseSettings: T[AndroidBuildTypeSettings] = Task {
+      AndroidBuildTypeSettings(isMinifyEnabled = false)
+    }
 
     /* TODO currently the dependency resolution ignores the platform type and kotlinx-coroutines-core has
      * conflicting classes with kotlinx-coroutines-core-jvm . Remove the exclusions once the dependency
@@ -98,8 +104,6 @@ object app extends AndroidAppModule { // <2>
 
 > ./mill show app.androidInstall
 ...All files should be loaded. Notifying the device...
-
-> ./mill show app.it
 
 > ./mill show app.stopAndroidEmulator
 

--- a/example/androidlib/java/5-R8/build.mill
+++ b/example/androidlib/java/5-R8/build.mill
@@ -105,6 +105,21 @@ object app extends AndroidAppModule { // <2>
 > ./mill show app.androidInstall
 ...All files should be loaded. Notifying the device...
 
+> ./mill show app.it
+...
+[
+  "",
+  [
+    {
+      "fullyQualifiedName": "com.helloworld.app.ExampleInstrumentedTest.useAppContext",
+      "selector": "com.helloworld.app.ExampleInstrumentedTest.useAppContext",
+      "duration": ...,
+      "status": "Success"
+    }
+  ]
+]
+
+
 > ./mill show app.stopAndroidEmulator
 
 > ./mill show app.deleteAndroidVirtualDevice

--- a/example/androidlib/kotlin/1-hello-kotlin/app/proguard-rules.pro
+++ b/example/androidlib/kotlin/1-hello-kotlin/app/proguard-rules.pro
@@ -13,12 +13,10 @@
 #   public *;
 #}
 
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+# Suppress warnings
+-ignorewarnings
 
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
--renamesourcefileattribute SourceFilex
+# Keep all annotation metadata (needed for reflection-based test frameworks)
+-keepattributes *Annotation*
 
 -keep class com.helloworld.** { *; }

--- a/example/androidlib/kotlin/1-hello-kotlin/app/src/main/AndroidManifest.xml
+++ b/example/androidlib/kotlin/1-hello-kotlin/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0">
-    <uses-sdk android:minSdkVersion="9" android:targetSdkVersion="35"/>
     <application android:label="@string/app_name" android:theme="@android:style/Theme.Light.NoTitleBar" android:debuggable="true">
         <activity android:name=".MainActivity"
                 android:exported="true">
@@ -9,8 +8,4 @@
             </intent-filter>
         </activity>
     </application>
-    <!-- TODO this needs to be constructed by Mill's integration tests (android tests) -->
-    <instrumentation
-            android:name="androidx.test.runner.AndroidJUnitRunner"
-            android:targetPackage="com.helloworld.app" />
 </manifest>

--- a/example/androidlib/kotlin/1-hello-kotlin/app/test-proguard-rules.pro
+++ b/example/androidlib/kotlin/1-hello-kotlin/app/test-proguard-rules.pro
@@ -11,6 +11,7 @@
 
 # Keep all Espresso framework classes and specifically ensure that the idling resources aren’t stripped
 -keep class androidx.test.espresso.** { *; }
+-keep class androidx.test.** { *; }
 -keep class androidx.test.espresso.IdlingRegistry { *; }
 -keep class androidx.test.espresso.IdlingResource { *; }
 

--- a/example/androidlib/kotlin/1-hello-kotlin/build.mill
+++ b/example/androidlib/kotlin/1-hello-kotlin/build.mill
@@ -47,8 +47,6 @@ object app extends AndroidAppKotlinModule {
 
   object it extends AndroidAppKotlinInstrumentedTests with AndroidTestModule.AndroidJUnit {
 
-    override def instrumentationPackage = "com.helloworld.app"
-
     /* TODO currently the dependency resolution ignores the platform type and kotlinx-coroutines-core has
      * conflicting classes with kotlinx-coroutines-core-jvm . Remove the exclusions once the dependency
      * resolution resolves conflicts between androidJvm and jvm platform types
@@ -156,7 +154,7 @@ object app extends AndroidAppKotlinModule {
 ]
 ...
 
-> cat out/app/it/testTask.dest/test-report.xml
+> cat out/app/it/testForked.dest/test-report.xml
 ...
 <?xml version='1.0' encoding='UTF-8'?>
 <testsuites tests="1" failures="0" errors="0" skipped="0" time="...">

--- a/example/androidlib/kotlin/1-hello-kotlin/build.mill
+++ b/example/androidlib/kotlin/1-hello-kotlin/build.mill
@@ -41,11 +41,36 @@ object app extends AndroidAppKotlinModule {
   override def androidVirtualDeviceIdentifier: String = "kotlin-test"
   override def androidEmulatorPort: String = "5556"
 
+  override def androidIsDebug: T[Boolean] = Task { false }
+
+  override def androidReleaseSettings: T[AndroidBuildTypeSettings] = Task {
+    super.androidReleaseSettings()
+      .withDefaultProguardFile("proguard-android.txt")
+      .withProguardLocalFiles(
+        Seq(
+          moduleDir / "proguard-rules.pro"
+        )
+      )
+  }
+
   object test extends AndroidAppKotlinTests with TestModule.Junit4 {
     def junit4Version = "4.13.2"
   }
 
   object it extends AndroidAppKotlinInstrumentedTests with AndroidTestModule.AndroidJUnit {
+
+    // TODO currently instrumented tests debug mode
+    // is coupled with the app debug mode. Fix so
+    // that instrumented tests can be built with debug
+    // configuration but the apk signature will match
+    // the app apk
+    override def androidIsDebug: T[Boolean] = Task {
+      false
+    }
+
+    override def androidReleaseSettings: T[AndroidBuildTypeSettings] = Task {
+      AndroidBuildTypeSettings(isMinifyEnabled = false)
+    }
 
     /* TODO currently the dependency resolution ignores the platform type and kotlinx-coroutines-core has
      * conflicting classes with kotlinx-coroutines-core-jvm . Remove the exclusions once the dependency
@@ -72,18 +97,6 @@ object app extends AndroidAppKotlinModule {
 
 > ./mill show app.androidApk
 ".../out/app/androidApk.dest/app.apk"
-
-> ./mill show app.createAndroidVirtualDevice
-...Name: kotlin-test, DeviceId: medium_phone...
-
-> ./mill show app.startAndroidEmulator
-
-> ./mill show app.androidInstall
-...All files should be loaded. Notifying the device...
-
-> ./mill show app.stopAndroidEmulator
-
-> ./mill show app.deleteAndroidVirtualDevice
 
 */
 

--- a/example/androidlib/kotlin/1-hello-kotlin/build.mill
+++ b/example/androidlib/kotlin/1-hello-kotlin/build.mill
@@ -80,7 +80,7 @@ object app extends AndroidAppKotlinModule {
 
 > ./mill show app.startAndroidEmulator
 
-> ./mill show app.androidReleaseInstall
+> ./mill show app.androidInstall
 ...All files should be loaded. Notifying the device...
 
 > ./mill show app.stopAndroidEmulator

--- a/example/androidlib/kotlin/3-compose-screenshot-tests/app/src/main/AndroidManifest.xml
+++ b/example/androidlib/kotlin/3-compose-screenshot-tests/app/src/main/AndroidManifest.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--    Adopted from AGP screenshot test template, a sample can be found in-->
 <!--    https://github.com/vaslabs-ltd/android-screenshot-test-sample/blob/main/app/src/main/AndroidManifest.xml-->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.screenshottest">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/example/androidlib/kotlin/4-sum-lib-kotlin/app/src/main/AndroidManifest.xml
+++ b/example/androidlib/kotlin/4-sum-lib-kotlin/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0">
-    <uses-sdk android:minSdkVersion="9" android:targetSdkVersion="35"/>
     <application android:label="@string/app_name" android:theme="@android:style/Theme.Light.NoTitleBar" android:debuggable="true">
         <activity android:name=".MainActivity"
                 android:exported="true">

--- a/example/androidlib/kotlin/4-sum-lib-kotlin/build.mill
+++ b/example/androidlib/kotlin/4-sum-lib-kotlin/build.mill
@@ -28,6 +28,8 @@ object lib extends AndroidLibKotlinModule with PublishModule {
   def androidCompileSdk = 35
   def kotlinVersion = "2.0.20"
 
+  def androidLibPackage = "com.example"
+
   def publishVersion = "0.0.1"
   def pomSettings = PomSettings(
     description = "sumlib",

--- a/example/androidlib/kotlin/4-sum-lib-kotlin/lib/src/main/AndroidManifest.xml
+++ b/example/androidlib/kotlin/4-sum-lib-kotlin/lib/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example" android:versionCode="1" android:versionName="1.0">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0">
 
 </manifest>

--- a/example/thirdparty/androidtodo/build.mill
+++ b/example/thirdparty/androidtodo/build.mill
@@ -111,10 +111,9 @@ object app extends AndroidAppKotlinModule with AndroidBuildConfig with AndroidHi
     )
   }
 
-  object androidTest extends AndroidAppKotlinInstrumentedTests with AndroidTestModule.AndroidJUnit {
-    override def instrumentationPackage = "com.example.android"
-
-  }
+  // TODO support instrumented tests on Hilt setups
+  object androidTest extends AndroidAppKotlinInstrumentedTests
+      with AndroidTestModule.AndroidJUnit {}
 
 }
 

--- a/libs/androidlib/src/mill/androidlib/AndroidAppKotlinModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppKotlinModule.scala
@@ -66,8 +66,6 @@ trait AndroidAppKotlinModule extends AndroidAppModule with AndroidKotlinModule {
 
     override def androidCompileSdk: T[Int] = outer.androidCompileSdk()
 
-    override def androidMergedManifest: T[PathRef] = outer.androidMergedManifest()
-
     override def androidSdkModule: ModuleRef[AndroidSdkModule] = outer.androidSdkModule
 
     // FIXME: avoid hardcoded version

--- a/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
@@ -217,6 +217,7 @@ trait AndroidAppModule extends AndroidModule { outer =>
       .map(PathRef(_))
       .toSeq
   }
+
   /**
    * Packages DEX files and Android resources into an unsigned APK.
    *
@@ -699,7 +700,7 @@ trait AndroidAppModule extends AndroidModule { outer =>
     pathRef
   }
 
-  //TODO consider managing with proguard and/or r8
+  // TODO consider managing with proguard and/or r8
   private def isExcludedFromPackaging(relPath: RelPath): Boolean = {
     val topPath = relPath.segments.head
     // TODO do this better
@@ -797,7 +798,6 @@ trait AndroidAppModule extends AndroidModule { outer =>
     )
   }
 
-
   /**
    * Provides the output path for the generated main-dex list file, which is used
    * during the DEX generation process.
@@ -858,7 +858,7 @@ trait AndroidAppModule extends AndroidModule { outer =>
       if (buildSettings.isMinifyEnabled) {
         androidR8Dex()
       } else
-        androidD8DexArgs()
+        androidD8Dex()
     }
 
     Task.log.debug("Building dex with command: " + dexCliArgs.mkString(" "))
@@ -869,9 +869,8 @@ trait AndroidAppModule extends AndroidModule { outer =>
 
   }
 
-
   // uses the d8 tool to generate the dex file, when minification is disabled
-  private def androidD8DexArgs: T[(PathRef, Seq[String])] = Task {
+  private def androidD8Dex: T[(PathRef, Seq[String])] = Task {
 
     val outPath = T.dest
 
@@ -922,7 +921,6 @@ trait AndroidAppModule extends AndroidModule { outer =>
 
     PathRef(outPath) -> d8Args
   }
-
 
   // uses the R8 tool to generate the dex (to shrink and obfuscate)
   private def androidR8Dex: Task[(PathRef, Seq[String])] = Task {
@@ -1066,7 +1064,7 @@ trait AndroidAppModule extends AndroidModule { outer =>
     override def androidCompileSdk: T[Int] = outer.androidCompileSdk()
     override def androidMinSdk: T[Int] = outer.androidMinSdk()
     override def androidTargetSdk: T[Int] = outer.androidTargetSdk()
-    
+
     override def androidIsDebug: T[Boolean] = Task { true }
 
     override def androidApplicationId: String = outer.androidApplicationId

--- a/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
@@ -834,6 +834,13 @@ trait AndroidAppModule extends AndroidModule { outer =>
     (defaultProguardFile.toSeq ++ userProguardFiles).map(PathRef(_))
   }
 
+  /**
+   * The default release settings with the following settings:
+   * - minifyEnabled=true
+   * - shrinkEnabled=true
+   * - proguardFiles=proguard-android-optimize.txt
+   * @return
+   */
   def androidReleaseSettings: T[AndroidBuildTypeSettings] = Task {
     AndroidBuildTypeSettings(
       isMinifyEnabled = true,
@@ -1118,7 +1125,7 @@ trait AndroidAppModule extends AndroidModule { outer =>
       val manifestWithInstrumentation = {
         val instrumentation =
           <instrumentation android:name={testFrameworkName} android:targetPackage={
-            instrumentationPackage
+            androidApplicationNamespace
           }/>
         baseManifestElem.copy(child = baseManifestElem.child ++ instrumentation)
       }
@@ -1131,8 +1138,6 @@ trait AndroidAppModule extends AndroidModule { outer =>
     override def androidVirtualDeviceIdentifier: String = outer.androidVirtualDeviceIdentifier
     override def androidEmulatorArchitecture: String = outer.androidEmulatorArchitecture
 
-    def instrumentationPackage: String = outer.androidApplicationNamespace
-
     def testFramework: T[String]
 
     /**
@@ -1141,9 +1146,7 @@ trait AndroidAppModule extends AndroidModule { outer =>
      */
     def androidTestInstall(): Command[String] = Task.Command {
 
-      val emulator = runningEmulator()
-
-      androidInstallTask()
+      val emulator = outer.androidInstallTask()
 
       os.call(
         (

--- a/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
@@ -81,6 +81,7 @@ trait AndroidAppModule extends AndroidModule { outer =>
 
   /**
    * Provides os.Path to an XML file containing configuration and metadata about your android application.
+   * TODO dynamically add android:debuggable
    */
   override def androidManifest: T[PathRef] = Task {
     val manifestFromSourcePath = moduleDir / "src/main/AndroidManifest.xml"
@@ -1108,8 +1109,7 @@ trait AndroidAppModule extends AndroidModule { outer =>
 
     /**
      * The android manifest of the instrumented tests
-     * has a different package from the app to differantiate installations
-     * (e.g. the test apk can have different signing keys from the app apk)
+     * has a different package from the app to differentiate installations
      * @return
      */
     override def androidManifest: T[PathRef] = Task {
@@ -1143,7 +1143,7 @@ trait AndroidAppModule extends AndroidModule { outer =>
 
       val emulator = runningEmulator()
 
-      outer.androidInstallTask()
+      androidInstallTask()
 
       os.call(
         (

--- a/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
@@ -66,6 +66,12 @@ trait AndroidAppModule extends AndroidModule { outer =>
   def androidApplicationNamespace: String
 
   /**
+   * In the case of android apps this the [[androidApplicationNamespace]].
+   * @return
+   */
+  protected override def androidGeneratedResourcesPackage: String = androidApplicationNamespace
+
+  /**
    * Android Application Id which is typically package.main .
    * Can be used for build variants.
    *

--- a/libs/androidlib/src/mill/androidlib/AndroidBuildTypeSettings.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidBuildTypeSettings.scala
@@ -9,25 +9,25 @@ import mill.define.JsonFormatters.pathReadWrite
  *
  * Useful for getting different packaging strategies for code shrinking and
  * supporting build variants
- *
  */
 case class AndroidBuildTypeSettings(
-  isMinifyEnabled: Boolean = false,
-  isShrinkEnabled: Boolean = false,
-  enableDesugaring: Boolean = false,
-  proguardFiles: ProguardFiles = ProguardFiles()
+    isMinifyEnabled: Boolean = false,
+    isShrinkEnabled: Boolean = false,
+    enableDesugaring: Boolean = false,
+    proguardFiles: ProguardFiles = ProguardFiles()
 ) {
   def withProguardLocalFiles(localFiles: Seq[os.Path]): AndroidBuildTypeSettings =
     copy(proguardFiles = proguardFiles.copy(localFiles = localFiles))
 }
 
 case class ProguardFiles(
-  defaultProguardFile: Option[String] = None,
-  localFiles: Seq[os.Path] = List.empty
+    defaultProguardFile: Option[String] = None,
+    localFiles: Seq[os.Path] = List.empty
 )
 
 object AndroidBuildTypeSettings {
-  implicit val resultRW: upickle.default.ReadWriter[AndroidBuildTypeSettings] = upickle.default.macroRW
+  implicit val resultRW: upickle.default.ReadWriter[AndroidBuildTypeSettings] =
+    upickle.default.macroRW
 }
 
 object ProguardFiles {

--- a/libs/androidlib/src/mill/androidlib/AndroidBuildTypeSettings.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidBuildTypeSettings.scala
@@ -1,0 +1,35 @@
+package mill.androidlib
+
+import mill.define.JsonFormatters.pathReadWrite
+
+/**
+ * Build type settings for
+ * various packaging configurations.
+ * See also [[https://developer.android.com/build/build-variants#build-types]]
+ *
+ * Useful for getting different packaging strategies for code shrinking and
+ * supporting build variants
+ *
+ */
+case class AndroidBuildTypeSettings(
+  isMinifyEnabled: Boolean = false,
+  isShrinkEnabled: Boolean = false,
+  enableDesugaring: Boolean = false,
+  proguardFiles: ProguardFiles = ProguardFiles()
+) {
+  def withProguardLocalFiles(localFiles: Seq[os.Path]): AndroidBuildTypeSettings =
+    copy(proguardFiles = proguardFiles.copy(localFiles = localFiles))
+}
+
+case class ProguardFiles(
+  defaultProguardFile: Option[String] = None,
+  localFiles: Seq[os.Path] = List.empty
+)
+
+object AndroidBuildTypeSettings {
+  implicit val resultRW: upickle.default.ReadWriter[AndroidBuildTypeSettings] = upickle.default.macroRW
+}
+
+object ProguardFiles {
+  implicit val resultRW: upickle.default.ReadWriter[ProguardFiles] = upickle.default.macroRW
+}

--- a/libs/androidlib/src/mill/androidlib/AndroidBuildTypeSettings.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidBuildTypeSettings.scala
@@ -18,6 +18,9 @@ case class AndroidBuildTypeSettings(
 ) {
   def withProguardLocalFiles(localFiles: Seq[os.Path]): AndroidBuildTypeSettings =
     copy(proguardFiles = proguardFiles.copy(localFiles = localFiles))
+
+  def withDefaultProguardFile(fileName: String): AndroidBuildTypeSettings =
+    copy(proguardFiles = proguardFiles.copy(defaultProguardFile = Some(fileName)))
 }
 
 case class ProguardFiles(

--- a/libs/androidlib/src/mill/androidlib/AndroidModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidModule.scala
@@ -376,13 +376,25 @@ trait AndroidModule extends JavaModule {
   }
 
   /** All individual classfiles inherited from the classpath that will be included into the dex */
-  def inheritedClassFiles: T[Seq[PathRef]] = Task {
+  def androidPackagedClassfiles: T[Seq[PathRef]] = Task {
     compileClasspath()
       .map(_.path).filter(os.isDir)
       .flatMap(os.walk(_))
       .filter(os.isFile)
       .filter(_.ext == "class")
       .map(PathRef(_))
+  }
+
+  def androidPackagedCompiledClasses: T[Seq[PathRef]] = Task {
+    os.walk(compile().classes.path)
+      .filter(_.ext == "class")
+      .map(PathRef(_))
+  }
+
+  def androidPackagedDeps: T[Seq[PathRef]] = Task {
+    compileClasspath()
+      .filter(_ != androidSdkModule().androidJarPath())
+      .filter(_.path.ext == "jar")
   }
 
   /** Additional library classes provided */

--- a/libs/androidlib/src/mill/androidlib/AndroidModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidModule.scala
@@ -46,7 +46,7 @@ trait AndroidModule extends JavaModule {
   def androidSdkModule: ModuleRef[AndroidSdkModule]
 
   /**
-   * Provides os.Path to an XML file containing configuration and metadata about your android application.
+   * Provides os.Path to an XML file containing configuration and metadata about your android library.
    */
   def androidManifest: Task[PathRef] = Task.Source("src/main/AndroidManifest.xml")
 
@@ -245,6 +245,9 @@ trait AndroidModule extends JavaModule {
     libClasses :+ PathRef(mainRClassPath)
   }
 
+  /** In which package to place the generated R sources */
+  protected def androidGeneratedResourcesPackage: String
+
   /**
    * Compiles Android resources and generates `R.java` and `res.apk`.
    *
@@ -314,6 +317,8 @@ trait AndroidModule extends JavaModule {
       androidSdkModule().androidJarPath().path.toString,
       "--manifest",
       androidMergedManifest().path.toString,
+      "--custom-package",
+      androidGeneratedResourcesPackage,
       "--java",
       rClassDir.toString,
       "--min-sdk-version",

--- a/libs/androidlib/src/mill/androidlib/AndroidModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidModule.scala
@@ -55,7 +55,9 @@ trait AndroidModule extends JavaModule {
    *
    * This option will probably go away in the future once build variants are supported.
    */
-  def androidIsDebug: T[Boolean] = true
+  def androidIsDebug: T[Boolean] = {
+    true
+  }
 
   /**
    * The minimum SDK version to use. Default is 1.

--- a/libs/androidlib/src/mill/androidlib/AndroidModuleGeneratedDexVariants.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidModuleGeneratedDexVariants.scala
@@ -1,0 +1,15 @@
+package mill.androidlib
+
+import mill.define.PathRef
+
+case class AndroidModuleGeneratedDexVariants(
+                                          androidDebugDex: PathRef,
+                                          androidReleaseDex: PathRef,
+                                          mainDexListOutput: PathRef
+                                        )
+
+object AndroidModuleGeneratedDexVariants {
+  implicit def resultRW: upickle.default.ReadWriter[AndroidModuleGeneratedDexVariants] =
+    upickle.default.macroRW
+}
+

--- a/libs/androidlib/src/mill/androidlib/AndroidModuleGeneratedDexVariants.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidModuleGeneratedDexVariants.scala
@@ -3,13 +3,12 @@ package mill.androidlib
 import mill.define.PathRef
 
 case class AndroidModuleGeneratedDexVariants(
-                                          androidDebugDex: PathRef,
-                                          androidReleaseDex: PathRef,
-                                          mainDexListOutput: PathRef
-                                        )
+    androidDebugDex: PathRef,
+    androidReleaseDex: PathRef,
+    mainDexListOutput: PathRef
+)
 
 object AndroidModuleGeneratedDexVariants {
   implicit def resultRW: upickle.default.ReadWriter[AndroidModuleGeneratedDexVariants] =
     upickle.default.macroRW
 }
-

--- a/libs/androidlib/src/mill/androidlib/AndroidSdkModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidSdkModule.scala
@@ -199,6 +199,14 @@ trait AndroidSdkModule extends Module {
   }
 
   /**
+   * Location of the default proguard optimisation config. 
+   * See also [[https://developer.android.com/build/shrink-code]]
+   */
+  def androidProguardPath: T[PathRef] = Task {
+    PathRef(sdkPath().path / "tools/proguard")
+  }
+
+  /**
    * Provides the path for the Android SDK Manager tool
    *
    * @return A task containing a [[PathRef]] pointing to the SDK directory.

--- a/libs/androidlib/src/mill/androidlib/AndroidSdkModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidSdkModule.scala
@@ -199,7 +199,7 @@ trait AndroidSdkModule extends Module {
   }
 
   /**
-   * Location of the default proguard optimisation config. 
+   * Location of the default proguard optimisation config.
    * See also [[https://developer.android.com/build/shrink-code]]
    */
   def androidProguardPath: T[PathRef] = Task {


### PR DESCRIPTION
## Summary

- **better organisation** between androidmodule and androidappmodule (separate properly what things are used in apps and things that are shared between lib building and app building)
- R8 and D8 **dex generation** depending on build type settings
- **Instrumented tests** now use the android application namespace and id and adding a "variant" indicator
- introduced a lite version of **build type settings** with main motivation to control r8 and d8 but also serve as a scaffolding for build variants
- **Android manifest** has less hardcoded parameters (uses-sdk and instrumentation tags are now generated)
- Minor change into **testTask** to keep it consistent with the rest of modules(Task.Anon) and thus the test-report is now in `testForked.dest`

## R8 and Proguard

Followed similar configuration style with gradle

![image](https://github.com/user-attachments/assets/c2c99135-6381-4c91-9ce2-ac5e666f5a33)

Although there's still work to be done in that area, if minification is enabled, we use the R8 tool to generate the dex otherwise the d8 (which also uses proguard for now) . This needs further work and clarification as AGP seems to be using R8 by default when minification is enabled, otherwise d8 is used.

Proguard default files are also fetched (as an opt-in setting) from the Android SDK directories

## Build settings

I've introduced a first very minimal step for doing build variants, mainly out of necessity to manage R8 and D8 variations better, but this will be expanded once we need to fully support build variants.

The settings so far concerned the R8 use case at hand and it's a case class that has the parameters to feed proguard files and flags into R8.

## R8 enhancements

Extending the work from https://github.com/com-lihaoyi/mill/pull/4892 , I've made some  usability enhancements and enriched the examples to demonstrate how instrumented tests can be used alongside R8 and release builds.

I think R8 now can be fairly usable to generate minified and optimised release builds without getting in the middle of development (e.g. running tests and testing in the emulator) although more work needs to be done towards that area, but we'll follow up after we do more exploratory usability testing!

## Future work

Following this work, we can move to complete the work on architecture samples by testing instrumented tests, unit tests and later on debug variants.

The cleanup also reduced a lot of duplication between `AndroidAppModule` and `AndroidModule` so it will make our development efforts a bit easier to add more features!

More discovery work will follow to align the instrumented test apk installation more in line with AGP