### PR TITLE
Mill 1.0 compat: Add `mvn` string interpolator for `ivy` dependencies

### DIFF
--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -98,7 +98,10 @@ abstract class MillBuildRootModule()(implicit
 
   override def runIvyDeps = Task {
     val imports = cliImports()
-    val ivyImports = imports.collect { case s"ivy:$rest" | s"mvn:$rest" => rest }
+    val ivyImports = imports.collect {
+      case s"ivy:$rest" => rest
+      case s"mvn:$rest" => rest
+    }
     Agg.from(
       MillIvy.processMillIvyDepSignature(ivyImports.toSet)
         .map(mill.scalalib.Dep.parse)

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -98,7 +98,7 @@ abstract class MillBuildRootModule()(implicit
 
   override def runIvyDeps = Task {
     val imports = cliImports()
-    val ivyImports = imports.collect { case s"ivy:$rest" => rest }
+    val ivyImports = imports.collect { case s"ivy:$rest" | s"mvn:$rest" => rest }
     Agg.from(
       MillIvy.processMillIvyDepSignature(ivyImports.toSet)
         .map(mill.scalalib.Dep.parse)

--- a/runner/src/mill/runner/MillCliConfig.scala
+++ b/runner/src/mill/runner/MillCliConfig.scala
@@ -78,7 +78,7 @@ case class MillCliConfig(
     threadCountRaw: Option[String] = None,
     @arg(
       name = "import",
-      doc = """Additional ivy dependencies to load into mill, e.g. plugins."""
+      doc = """Additional ivy/mvn dependencies to load into mill, e.g. plugins."""
     )
     imports: Seq[String] = Nil,
     @arg(

--- a/scalalib/src/mill/scalalib/package.scala
+++ b/scalalib/src/mill/scalalib/package.scala
@@ -10,6 +10,9 @@ package object scalalib extends mill.scalalib.JsonFormatters {
           ctx.parts.drop(args.length)
       ).mkString
     }
+
+    // Forward-compatibility with Mill 1.0
+    def mvn(args: Any*): Dep = ivy(args: _*)
   }
 
   @nowarn("cat=deprecation")


### PR DESCRIPTION
Fix https://github.com/com-lihaoyi/mill/issues/5004

This also backports https://github.com/com-lihaoyi/mill/pull/5006 ands support for the `mvn:` prefix in the `--import` CLI option.
