### PR TITLE
Remove requirement to `extends RootModule`

### DIFF
--- a/example/extending/metabuild/4-meta-build/build.mill
+++ b/example/extending/metabuild/4-meta-build/build.mill
@@ -3,7 +3,7 @@ package build
 import mill._, scalalib._
 import scalatags.Text.all._
 
-object `package` extends RootModule with ScalaModule {
+object `package` extends ScalaModule {
   def scalaVersion = "2.13.4"
   def mvnDeps = Seq(
     mvn"com.lihaoyi::scalatags:${millbuild.DepVersions.scalatagsVersion}",

--- a/example/extending/metabuild/5-meta-shared-sources/build.mill
+++ b/example/extending/metabuild/5-meta-shared-sources/build.mill
@@ -2,7 +2,7 @@ package build
 
 import mill._, scalalib._
 
-object `package` extends RootModule with ScalaModule {
+object `package` extends ScalaModule {
   def scalaVersion = millbuild.ScalaVersion.myScalaVersion
   // Add (or replace) source folders for the module to use
   def customSources = Task.Sources("mill-build/src")

--- a/example/extending/plugins/7-writing-mill-plugins/myplugin/test/resources/example-test-project/build.mill
+++ b/example/extending/plugins/7-writing-mill-plugins/myplugin/test/resources/example-test-project/build.mill
@@ -4,7 +4,7 @@ package build
 
 import mill._, myplugin._
 
-object `package` extends RootModule with LineCountJavaModule {
+object `package` extends LineCountJavaModule {
   def lineCountResourceFileName = "line-count.txt"
 }
 

--- a/example/extending/plugins/7-writing-mill-plugins/myplugin/test/resources/integration-test-project/build.mill
+++ b/example/extending/plugins/7-writing-mill-plugins/myplugin/test/resources/integration-test-project/build.mill
@@ -4,6 +4,6 @@ package build
 
 import mill._, myplugin._
 
-object `package` extends RootModule with LineCountJavaModule {
+object `package` extends LineCountJavaModule {
   def lineCountResourceFileName = "line-count.txt"
 }

--- a/example/fundamentals/modules/7-root-module/build.mill
+++ b/example/fundamentals/modules/7-root-module/build.mill
@@ -4,7 +4,7 @@
 package build
 import mill._, javalib._
 
-object `package` extends RootModule with JavaModule {
+object `package` extends JavaModule {
   def mvnDeps = Seq(
     mvn"net.sourceforge.argparse4j:argparse4j:0.9.0",
     mvn"org.thymeleaf:thymeleaf:3.1.1.RELEASE"

--- a/example/javalib/dependencies/1-mvn-deps/build.mill
+++ b/example/javalib/dependencies/1-mvn-deps/build.mill
@@ -2,7 +2,7 @@
 package build
 import mill._, javalib._
 
-object `package` extends RootModule with JavaModule {
+object `package` extends JavaModule {
   def mvnDeps = Seq(
     mvn"com.fasterxml.jackson.core:jackson-databind:2.13.4"
   )

--- a/example/javalib/dependencies/3-unmanaged-jars/build.mill
+++ b/example/javalib/dependencies/3-unmanaged-jars/build.mill
@@ -2,7 +2,7 @@
 package build
 import mill._, javalib._
 
-object `package` extends RootModule with JavaModule {
+object `package` extends JavaModule {
   def unmanagedClasspath = Task {
     if (!os.exists(moduleDir / "lib")) Seq()
     else Seq.from(os.list(moduleDir / "lib").map(PathRef(_)))

--- a/example/javalib/dependencies/4-downloading-unmanaged-jars/build.mill
+++ b/example/javalib/dependencies/4-downloading-unmanaged-jars/build.mill
@@ -2,7 +2,7 @@
 package build
 import mill._, javalib._
 
-object `package` extends RootModule with JavaModule {
+object `package` extends JavaModule {
   def unmanagedClasspath = Task {
     if (Task.offline) Task.fail("Cannot download classpath when in offline-mode") // <1>
     else {

--- a/example/javalib/linting/1-error-prone/build.mill
+++ b/example/javalib/linting/1-error-prone/build.mill
@@ -8,7 +8,7 @@ package build
 
 import mill._, javalib._, errorprone._
 
-object `package` extends RootModule with JavaModule with ErrorProneModule {
+object `package` extends JavaModule with ErrorProneModule {
   def errorProneOptions = Seq("-XepAllErrorsAsWarnings")
 }
 

--- a/example/javalib/linting/2-checkstyle/build.mill
+++ b/example/javalib/linting/2-checkstyle/build.mill
@@ -4,7 +4,7 @@
 package build
 import mill._, javalib._, checkstyle._
 
-object `package` extends RootModule with CheckstyleModule {
+object `package` extends CheckstyleModule {
   def checkstyleVersion = "9.3"
 }
 

--- a/example/javalib/linting/3-palantirformat/build.mill
+++ b/example/javalib/linting/3-palantirformat/build.mill
@@ -5,7 +5,7 @@ package build
 import mill._
 import mill.javalib.palantirformat._
 
-object `package` extends RootModule with PalantirFormatModule
+object `package` extends PalantirFormatModule
 
 /** See Also: src/A.java */
 

--- a/example/javalib/module/1-common-config/build.mill
+++ b/example/javalib/module/1-common-config/build.mill
@@ -2,7 +2,7 @@
 package build
 import mill._, javalib._
 
-object `package` extends RootModule with JavaModule {
+object `package` extends JavaModule {
   // You can have arbitrary numbers of third-party dependencies
   def mvnDeps = Seq(
     mvn"org.thymeleaf:thymeleaf:3.1.1.RELEASE"

--- a/example/javalib/module/11-main-class/build.mill
+++ b/example/javalib/module/11-main-class/build.mill
@@ -2,6 +2,6 @@
 package build
 import mill._, javalib._
 
-object `package` extends RootModule with JavaModule {
+object `package` extends JavaModule {
   def mainClass = Some("foo.Qux")
 }

--- a/example/javalib/module/15-jni/build.mill
+++ b/example/javalib/module/15-jni/build.mill
@@ -4,7 +4,7 @@
 package build
 import mill._, javalib._, util.Jvm
 
-object `package` extends RootModule with JavaModule {
+object `package` extends JavaModule {
   // Additional source folder to put C sources
   def nativeSources = Task.Sources("native-src")
 

--- a/example/javalib/module/2-custom-tasks/build.mill
+++ b/example/javalib/module/2-custom-tasks/build.mill
@@ -2,7 +2,7 @@
 package build
 import mill._, javalib._
 
-object `package` extends RootModule with JavaModule {
+object `package` extends JavaModule {
   def mvnDeps = Seq(mvn"net.sourceforge.argparse4j:argparse4j:0.9.0")
 
   def generatedSources: T[Seq[PathRef]] = Task {

--- a/example/javalib/module/4-compilation-execution-flags/build.mill
+++ b/example/javalib/module/4-compilation-execution-flags/build.mill
@@ -2,7 +2,7 @@
 package build
 import mill._, javalib._
 
-object `package` extends RootModule with JavaModule {
+object `package` extends JavaModule {
   def forkArgs = Seq("-Xmx4g", "-Dmy.jvm.property=hello")
   def forkEnv = Map("MY_ENV_VAR" -> "WORLD")
   def javacOptions = Seq("-deprecation")

--- a/example/javalib/web/1-hello-jetty/build.mill
+++ b/example/javalib/web/1-hello-jetty/build.mill
@@ -1,7 +1,7 @@
 package build
 import mill._, javalib._
 
-object `package` extends RootModule with JavaModule {
+object `package` extends JavaModule {
   def mvnDeps = Seq(
     mvn"org.eclipse.jetty:jetty-server:9.4.43.v20210629",
     mvn"javax.servlet:javax.servlet-api:4.0.1"

--- a/example/javalib/web/2-hello-spring-boot/build.mill
+++ b/example/javalib/web/2-hello-spring-boot/build.mill
@@ -1,7 +1,7 @@
 package build
 import mill._, javalib._
 
-object `package` extends RootModule with JavaModule {
+object `package` extends JavaModule {
   def mvnDeps = Seq(
     mvn"org.springframework.boot:spring-boot-starter-web:2.5.6",
     mvn"org.springframework.boot:spring-boot-starter-actuator:2.5.6"

--- a/example/javalib/web/3-todo-spring-boot/build.mill
+++ b/example/javalib/web/3-todo-spring-boot/build.mill
@@ -1,7 +1,7 @@
 package build
 import mill._, javalib._
 
-object `package` extends RootModule with JavaModule {
+object `package` extends JavaModule {
   def mvnDeps = Seq(
     mvn"org.springframework.boot:spring-boot-starter-data-jpa:2.5.4",
     mvn"org.springframework.boot:spring-boot-starter-thymeleaf:2.5.4",

--- a/example/javalib/web/4-hello-micronaut/build.mill
+++ b/example/javalib/web/4-hello-micronaut/build.mill
@@ -1,7 +1,7 @@
 package build
 import mill._, javalib._
 
-object `package` extends RootModule with MicronautModule {
+object `package` extends MicronautModule {
   def micronautVersion = "4.5.3"
   def mvnDeps = Seq(
     mvn"io.micronaut:micronaut-http-server-netty:$micronautVersion",

--- a/example/javalib/web/5-todo-micronaut/build.mill
+++ b/example/javalib/web/5-todo-micronaut/build.mill
@@ -1,7 +1,7 @@
 package build
 import mill._, javalib._
 
-object `package` extends RootModule with MicronautModule {
+object `package` extends MicronautModule {
   def micronautVersion = "4.4.3"
   def runMvnDeps = Seq(
     mvn"ch.qos.logback:logback-classic:1.5.3",

--- a/example/javascriptlib/module/3-override-tasks/build.mill
+++ b/example/javascriptlib/module/3-override-tasks/build.mill
@@ -3,7 +3,7 @@ package build
 import mill._
 import mill.javascriptlib._
 
-object `package` extends RootModule with TypeScriptModule {
+object `package` extends TypeScriptModule {
   def moduleName = "foo"
 
   def sources = Task {

--- a/example/javascriptlib/module/7-root-module/build.mill
+++ b/example/javascriptlib/module/7-root-module/build.mill
@@ -5,7 +5,7 @@ package build
 
 import mill._, javascriptlib._
 
-object `package` extends RootModule with TypeScriptModule {
+object `package` extends TypeScriptModule {
   def moduleName = "foo"
   def npmDeps = Seq("immutable@4.3.7")
   object test extends TypeScriptTests with TestModule.Jest

--- a/example/kotlinlib/dependencies/1-mvn-deps/build.mill
+++ b/example/kotlinlib/dependencies/1-mvn-deps/build.mill
@@ -2,7 +2,7 @@
 package build
 import mill._, kotlinlib._
 
-object `package` extends RootModule with KotlinModule {
+object `package` extends KotlinModule {
 
   def kotlinVersion = "1.9.24"
 

--- a/example/kotlinlib/dependencies/3-unmanaged-jars/build.mill
+++ b/example/kotlinlib/dependencies/3-unmanaged-jars/build.mill
@@ -2,7 +2,7 @@
 package build
 import mill._, kotlinlib._
 
-object `package` extends RootModule with KotlinModule {
+object `package` extends KotlinModule {
 
   def kotlinVersion = "1.9.24"
 

--- a/example/kotlinlib/dependencies/4-downloading-unmanaged-jars/build.mill
+++ b/example/kotlinlib/dependencies/4-downloading-unmanaged-jars/build.mill
@@ -2,7 +2,7 @@
 package build
 import mill._, kotlinlib._
 
-object `package` extends RootModule with KotlinModule {
+object `package` extends KotlinModule {
 
   def kotlinVersion = "1.9.24"
 

--- a/example/kotlinlib/linting/1-detekt/build.mill
+++ b/example/kotlinlib/linting/1-detekt/build.mill
@@ -4,7 +4,7 @@ import mill._
 import kotlinlib.KotlinModule
 import kotlinlib.detekt.DetektModule
 
-object `package` extends RootModule with KotlinModule with DetektModule {
+object `package` extends KotlinModule with DetektModule {
   def kotlinVersion = "1.9.24"
 }
 

--- a/example/kotlinlib/linting/2-ktlint/build.mill
+++ b/example/kotlinlib/linting/2-ktlint/build.mill
@@ -6,7 +6,7 @@ import mill.util.Jvm
 import kotlinlib.KotlinModule
 import kotlinlib.ktlint.KtlintModule
 
-object `package` extends RootModule with KotlinModule with KtlintModule {
+object `package` extends KotlinModule with KtlintModule {
   def kotlinVersion = "1.9.24"
 
   def ktlintConfig = Some(PathRef(Task.workspace / ".editorconfig"))

--- a/example/kotlinlib/linting/3-ktfmt/build.mill
+++ b/example/kotlinlib/linting/3-ktfmt/build.mill
@@ -6,7 +6,7 @@ import mill.util.Jvm
 import kotlinlib.KotlinModule
 import kotlinlib.ktfmt.KtfmtModule
 
-object `package` extends RootModule with KotlinModule with KtfmtModule {
+object `package` extends KotlinModule with KtfmtModule {
   def kotlinVersion = "1.9.24"
 }
 

--- a/example/kotlinlib/linting/4-kover/build.mill
+++ b/example/kotlinlib/linting/4-kover/build.mill
@@ -3,7 +3,7 @@ package build
 import mill._, kotlinlib._
 import kotlinlib.kover.KoverModule
 
-object `package` extends RootModule with KotlinModule with KoverModule {
+object `package` extends KotlinModule with KoverModule {
 
   trait KotestTests extends TestModule.Junit5 {
     override def forkArgs: T[Seq[String]] = Task {

--- a/example/kotlinlib/module/1-common-config/build.mill
+++ b/example/kotlinlib/module/1-common-config/build.mill
@@ -2,7 +2,7 @@
 package build
 import mill._, kotlinlib._
 
-object `package` extends RootModule with KotlinModule {
+object `package` extends KotlinModule {
   // You can have arbitrary numbers of third-party dependencies
   def mvnDeps = Seq(
     mvn"org.jetbrains.kotlinx:kotlinx-html-jvm:0.11.0"

--- a/example/kotlinlib/module/11-main-class/build.mill
+++ b/example/kotlinlib/module/11-main-class/build.mill
@@ -2,7 +2,7 @@
 package build
 import mill._, kotlinlib._
 
-object `package` extends RootModule with KotlinModule {
+object `package` extends KotlinModule {
 
   def kotlinVersion = "1.9.24"
 

--- a/example/kotlinlib/module/15-jni/build.mill
+++ b/example/kotlinlib/module/15-jni/build.mill
@@ -1,7 +1,7 @@
 package build
 import mill._, kotlinlib._, util.Jvm
 
-object `package` extends RootModule with KotlinModule {
+object `package` extends KotlinModule {
 
   def mainClass = Some("foo.HelloWorldKt")
 

--- a/example/kotlinlib/module/2-custom-tasks/build.mill
+++ b/example/kotlinlib/module/2-custom-tasks/build.mill
@@ -2,7 +2,7 @@
 package build
 import mill._, kotlinlib._
 
-object `package` extends RootModule with KotlinModule {
+object `package` extends KotlinModule {
 
   def kotlinVersion = "1.9.24"
 

--- a/example/kotlinlib/module/4-compilation-execution-flags/build.mill
+++ b/example/kotlinlib/module/4-compilation-execution-flags/build.mill
@@ -2,7 +2,7 @@
 package build
 import mill._, kotlinlib._
 
-object `package` extends RootModule with KotlinModule {
+object `package` extends KotlinModule {
 
   def kotlinVersion = "1.9.24"
 

--- a/example/kotlinlib/web/1-hello-ktor/build.mill
+++ b/example/kotlinlib/web/1-hello-ktor/build.mill
@@ -2,7 +2,7 @@
 package build
 import mill._, kotlinlib._
 
-object `package` extends RootModule with KotlinModule {
+object `package` extends KotlinModule {
 
   def kotlinVersion = "1.9.24"
 

--- a/example/kotlinlib/web/2-todo-ktor/build.mill
+++ b/example/kotlinlib/web/2-todo-ktor/build.mill
@@ -4,7 +4,7 @@
 package build
 import mill._, kotlinlib._
 
-object `package` extends RootModule with KotlinModule {
+object `package` extends KotlinModule {
 
   def kotlinVersion = "1.9.24"
 

--- a/example/kotlinlib/web/3-hello-kotlinjs/build.mill
+++ b/example/kotlinlib/web/3-hello-kotlinjs/build.mill
@@ -10,7 +10,7 @@
 package build
 import mill._, kotlinlib._, kotlinlib.js._
 
-object `package` extends RootModule with KotlinJsModule {
+object `package` extends KotlinJsModule {
   override def kotlinJsModuleKind = ModuleKind.ESModule
   override def kotlinVersion = "1.9.25"
   override def kotlinJsRunTarget = Some(RunTarget.Node)

--- a/example/kotlinlib/web/4-webapp-kotlinjs/build.mill
+++ b/example/kotlinlib/web/4-webapp-kotlinjs/build.mill
@@ -7,7 +7,7 @@ package build
 
 import mill._, kotlinlib._, kotlinlib.js._
 
-object `package` extends RootModule with KotlinModule {
+object `package` extends KotlinModule {
 
   override def kotlinVersion = "1.9.24"
   def ktorVersion = "2.3.12"

--- a/example/kotlinlib/web/5-webapp-kotlinjs-shared/build.mill
+++ b/example/kotlinlib/web/5-webapp-kotlinjs-shared/build.mill
@@ -13,7 +13,7 @@ trait AppKotlinModule extends KotlinModule {
 
 trait AppKotlinJsModule extends AppKotlinModule with KotlinJsModule
 
-object `package` extends RootModule with AppKotlinModule {
+object `package` extends AppKotlinModule {
 
   def ktorVersion = "2.3.12"
   def kotlinHtmlVersion = "0.11.0"

--- a/example/kotlinlib/web/6-hello-spring-boot/build.mill
+++ b/example/kotlinlib/web/6-hello-spring-boot/build.mill
@@ -1,7 +1,7 @@
 package build
 import mill._, kotlinlib._
 
-object `package` extends RootModule with KotlinModule {
+object `package` extends KotlinModule {
 
   def kotlinVersion = "1.9.24"
 

--- a/example/kotlinlib/web/7-todo-spring-boot/build.mill
+++ b/example/kotlinlib/web/7-todo-spring-boot/build.mill
@@ -1,7 +1,7 @@
 package build
 import mill._, kotlinlib._
 
-object `package` extends RootModule with KotlinModule {
+object `package` extends KotlinModule {
   def kotlinVersion = "1.9.24"
 
   def mainClass = Some("com.example.TodomvcApplicationKt")

--- a/example/large/multifile/10-multi-file-builds/foo/package.mill
+++ b/example/large/multifile/10-multi-file-builds/foo/package.mill
@@ -1,7 +1,7 @@
 package build.foo
 import mill._, scalalib._
 
-object `package` extends RootModule with build.MyModule {
+object `package` extends build.MyModule {
   def moduleDeps = Seq(build.bar.qux.mymodule)
   def mvnDeps = Seq(mvn"com.lihaoyi::mainargs:0.4.0")
 }

--- a/example/large/multifile/11-helper-files/build.mill
+++ b/example/large/multifile/11-helper-files/build.mill
@@ -5,7 +5,7 @@
 package build
 import mill._, scalalib._
 
-object `package` extends RootModule with MyModule {
+object `package` extends MyModule {
   def forkEnv = Map(
     "MY_SCALA_VERSION" -> build.scalaVersion(),
     "MY_PROJECT_VERSION" -> foo.myProjectVersion

--- a/example/large/multifile/11-helper-files/foo/package.mill
+++ b/example/large/multifile/11-helper-files/foo/package.mill
@@ -1,6 +1,6 @@
 package build.foo
 import mill._, scalalib._
-object `package` extends RootModule with build.MyModule {
+object `package` extends build.MyModule {
   def forkEnv = Map(
     "MY_SCALA_VERSION" -> build.myScalaVersion,
     "MY_PROJECT_VERSION" -> myProjectVersion

--- a/example/large/multifile/12-helper-files-mill-scala/build.mill.scala
+++ b/example/large/multifile/12-helper-files-mill-scala/build.mill.scala
@@ -1,7 +1,7 @@
 package build
 import mill._, scalalib._
 
-object `package` extends RootModule with MyModule {
+object `package` extends MyModule {
   def forkEnv = Map(
     "MY_SCALA_VERSION" -> build.scalaVersion(),
     "MY_PROJECT_VERSION" -> build.foo.myProjectVersion

--- a/example/large/multifile/12-helper-files-mill-scala/foo/package.mill.scala
+++ b/example/large/multifile/12-helper-files-mill-scala/foo/package.mill.scala
@@ -1,6 +1,6 @@
 package build.foo
 import mill._, scalalib._
-object `package` extends RootModule with build.MyModule {
+object `package` extends build.MyModule {
   def forkEnv = Map(
     "MY_SCALA_VERSION" -> build.myScalaVersion,
     "MY_PROJECT_VERSION" -> myProjectVersion

--- a/example/pythonlib/dependencies/1-pip-deps/build.mill
+++ b/example/pythonlib/dependencies/1-pip-deps/build.mill
@@ -1,7 +1,7 @@
 package build
 import mill._, pythonlib._
 
-object `package` extends RootModule with PythonModule {
+object `package` extends PythonModule {
   def pythonDeps = Seq(
     "numpy==2.1.2",
     "pandas~=2.2.3",

--- a/example/pythonlib/dependencies/2-pip-requirements/build.mill
+++ b/example/pythonlib/dependencies/2-pip-requirements/build.mill
@@ -4,7 +4,7 @@
 package build
 import mill._, pythonlib._
 
-object `package` extends RootModule with PythonModule {
+object `package` extends PythonModule {
   def pythonRequirementFiles = Task.Sources {
     moduleDir / "requirements.txt"
   }

--- a/example/pythonlib/dependencies/3-unmanaged-wheels/build.mill
+++ b/example/pythonlib/dependencies/3-unmanaged-wheels/build.mill
@@ -6,7 +6,7 @@
 package build
 import mill._, pythonlib._
 
-object `package` extends RootModule with PythonModule {
+object `package` extends PythonModule {
   def unmanagedWheels: T[Seq[PathRef]] = Task.Input {
     Seq.from(os.list(moduleDir / "lib").map(PathRef(_)))
   }

--- a/example/pythonlib/dependencies/4-downloading-unmanaged-wheels/build.mill
+++ b/example/pythonlib/dependencies/4-downloading-unmanaged-wheels/build.mill
@@ -6,7 +6,7 @@
 package build
 import mill._, pythonlib._
 
-object `package` extends RootModule with PythonModule {
+object `package` extends PythonModule {
   def unmanagedWheels = Task {
     if (Task.offline) Task.fail("Cannot download classpath when in offline-mode") // <1>
     else {

--- a/example/pythonlib/dependencies/6-debugging/build.mill
+++ b/example/pythonlib/dependencies/6-debugging/build.mill
@@ -5,7 +5,7 @@
 package build
 import mill._, pythonlib._
 
-object `package` extends RootModule with PythonModule {
+object `package` extends PythonModule {
   def pythonDeps = Seq(
     "numpy==2.1.2",
     "pandas~=2.2.3",

--- a/example/pythonlib/linting/1-ruff-format/build.mill
+++ b/example/pythonlib/linting/1-ruff-format/build.mill
@@ -3,7 +3,7 @@
 package build
 import mill._, pythonlib._
 
-object `package` extends RootModule with PythonModule with RuffModule
+object `package` extends PythonModule with RuffModule
 
 // You can reformat your project's code by running the `ruffFormat` task.
 

--- a/example/pythonlib/linting/2-ruff-check/build.mill
+++ b/example/pythonlib/linting/2-ruff-check/build.mill
@@ -1,7 +1,7 @@
 package build
 import mill._, pythonlib._
 
-object `package` extends RootModule with PythonModule with RuffModule {}
+object `package` extends PythonModule with RuffModule {}
 
 /** See Also: src/main.py */
 

--- a/example/pythonlib/linting/3-coverage/build.mill
+++ b/example/pythonlib/linting/3-coverage/build.mill
@@ -5,7 +5,7 @@
 
 import mill._, pythonlib._
 
-object `package` extends RootModule with PythonModule {
+object `package` extends PythonModule {
 
   object test extends PythonTests with TestModule.Pytest with CoverageTests
 

--- a/example/pythonlib/module/4-compilation-execution-flags/build.mill
+++ b/example/pythonlib/module/4-compilation-execution-flags/build.mill
@@ -1,7 +1,7 @@
 package build
 import mill._, pythonlib._
 
-object `package` extends RootModule with PythonModule {
+object `package` extends PythonModule {
   def mainScript = Task.Source { "src/foo.py" }
   def pythonOptions = Seq("-Wall", "-Xdev")
   def forkEnv = Map("MY_ENV_VAR" -> "HELLO MILL!")

--- a/example/pythonlib/publishing/1-publish-module/build.mill
+++ b/example/pythonlib/publishing/1-publish-module/build.mill
@@ -3,7 +3,7 @@
 
 import mill._, pythonlib._
 
-object `package` extends RootModule with PythonModule with PublishModule {
+object `package` extends PythonModule with PublishModule {
 
   // information about dependencies will be included in the published package
   def pythonDeps = Seq("jinja2==3.1.4")

--- a/example/pythonlib/publishing/2-publish-module-advanced/build.mill
+++ b/example/pythonlib/publishing/2-publish-module-advanced/build.mill
@@ -26,7 +26,7 @@
 
 import mill._, pythonlib._
 
-object `package` extends RootModule with PythonModule with PublishModule {
+object `package` extends PythonModule with PublishModule {
 
   def publishMeta = PublishMeta(
     name = "testpackage",

--- a/example/scalalib/dependencies/1-mvn-deps/build.mill
+++ b/example/scalalib/dependencies/1-mvn-deps/build.mill
@@ -2,7 +2,7 @@
 package build
 import mill._, scalalib._
 
-object `package` extends RootModule with ScalaModule {
+object `package` extends ScalaModule {
   def scalaVersion = "2.12.17"
   def mvnDeps = Seq(
     mvn"com.lihaoyi::upickle:3.1.0",

--- a/example/scalalib/dependencies/3-unmanaged-jars/build.mill
+++ b/example/scalalib/dependencies/3-unmanaged-jars/build.mill
@@ -10,7 +10,7 @@
 package build
 import mill._, scalalib._
 
-object `package` extends RootModule with ScalaModule {
+object `package` extends ScalaModule {
   def scalaVersion = "2.13.8"
   def unmanagedClasspath = Task {
     if (!os.exists(moduleDir / "lib")) Seq()

--- a/example/scalalib/dependencies/4-downloading-unmanaged-jars/build.mill
+++ b/example/scalalib/dependencies/4-downloading-unmanaged-jars/build.mill
@@ -7,7 +7,7 @@
 package build
 import mill._, scalalib._
 
-object `package` extends RootModule with ScalaModule {
+object `package` extends ScalaModule {
   def scalaVersion = "2.13.8"
   def unmanagedClasspath = Task {
     if (Task.offline) Task.fail("Cannot download classpath when in offline-mode") // <1>

--- a/example/scalalib/linting/1-scalafmt/build.mill
+++ b/example/scalalib/linting/1-scalafmt/build.mill
@@ -1,7 +1,7 @@
 package build
 import mill._, scalalib._
 
-object `package` extends RootModule with ScalaModule {
+object `package` extends ScalaModule {
   def scalaVersion = "2.13.11"
 }
 

--- a/example/scalalib/linting/2-contrib-scoverage/build.mill
+++ b/example/scalalib/linting/2-contrib-scoverage/build.mill
@@ -6,7 +6,7 @@ import mill._, scalalib._
 
 import mill.contrib.scoverage._
 
-object `package` extends RootModule with ScoverageModule {
+object `package` extends ScoverageModule {
   def scoverageVersion = "2.1.0"
   def scalaVersion = "2.13.11"
   def mvnDeps = Seq(

--- a/example/scalalib/linting/3-acyclic/build.mill
+++ b/example/scalalib/linting/3-acyclic/build.mill
@@ -17,7 +17,7 @@
 package build
 import mill._, scalalib._
 
-object `package` extends RootModule with ScalaModule {
+object `package` extends ScalaModule {
   def scalaVersion = "2.13.11"
   def compileMvnDeps = Seq(mvn"com.lihaoyi:::acyclic:0.3.15")
   def scalacPluginMvnDeps = Seq(mvn"com.lihaoyi:::acyclic:0.3.15")

--- a/example/scalalib/module/1-common-config/build.mill
+++ b/example/scalalib/module/1-common-config/build.mill
@@ -9,7 +9,7 @@
 package build
 import mill._, scalalib._
 
-object `package` extends RootModule with ScalaModule {
+object `package` extends ScalaModule {
   def scalaVersion = "2.13.8"
 
   // You can have arbitrary numbers of third-party dependencies

--- a/example/scalalib/module/11-main-class/build.mill
+++ b/example/scalalib/module/11-main-class/build.mill
@@ -2,7 +2,7 @@
 package build
 import mill._, scalalib._
 
-object `package` extends RootModule with ScalaModule {
+object `package` extends ScalaModule {
   def scalaVersion = "2.13.8"
   def mainClass = Some("foo.Qux")
 }

--- a/example/scalalib/module/2-custom-tasks/build.mill
+++ b/example/scalalib/module/2-custom-tasks/build.mill
@@ -12,7 +12,7 @@
 package build
 import mill._, scalalib._
 
-object `package` extends RootModule with ScalaModule {
+object `package` extends ScalaModule {
   def scalaVersion = "2.13.8"
   def mvnDeps = Seq(mvn"com.lihaoyi::mainargs:0.4.0")
 

--- a/example/scalalib/module/4-compilation-execution-flags/build.mill
+++ b/example/scalalib/module/4-compilation-execution-flags/build.mill
@@ -2,7 +2,7 @@
 package build
 import mill._, scalalib._
 
-object `package` extends RootModule with ScalaModule {
+object `package` extends ScalaModule {
   def scalaVersion = "2.13.8"
   def scalacOptions = Seq("-Ydelambdafy:inline")
   def forkArgs = Seq("-Xmx4g", "-Dmy.jvm.property=hello")

--- a/example/scalalib/module/8-scala-compiler-plugins/build.mill
+++ b/example/scalalib/module/8-scala-compiler-plugins/build.mill
@@ -1,7 +1,7 @@
 package build
 import mill._, scalalib._
 
-object `package` extends RootModule with ScalaModule {
+object `package` extends ScalaModule {
   def scalaVersion = "2.13.8"
 
   def compileMvnDeps = Seq(mvn"com.lihaoyi:::acyclic:0.3.6")

--- a/example/scalalib/native/1-simple/build.mill
+++ b/example/scalalib/native/1-simple/build.mill
@@ -1,7 +1,7 @@
 package build
 import mill._, scalalib._, scalanativelib._
 
-object `package` extends RootModule with ScalaNativeModule {
+object `package` extends ScalaNativeModule {
   def scalaVersion = "3.3.4"
   def scalaNativeVersion = "0.5.5"
 

--- a/example/scalalib/native/2-interop/build.mill
+++ b/example/scalalib/native/2-interop/build.mill
@@ -1,7 +1,7 @@
 package build
 import mill._, scalalib._, scalanativelib._
 
-object `package` extends RootModule with ScalaNativeModule {
+object `package` extends ScalaNativeModule {
   def scalaVersion = "3.3.4"
   def scalaNativeVersion = "0.5.5"
 

--- a/example/scalalib/native/4-common-config/build.mill
+++ b/example/scalalib/native/4-common-config/build.mill
@@ -1,7 +1,7 @@
 package build
 import mill._, scalalib._, scalanativelib._, scalanativelib.api._
 
-object `package` extends RootModule with ScalaNativeModule {
+object `package` extends ScalaNativeModule {
   def scalaVersion = "3.3.4"
   def scalaNativeVersion = "0.5.5"
 

--- a/example/scalalib/spark/3-semi-realistic/build.mill
+++ b/example/scalalib/spark/3-semi-realistic/build.mill
@@ -1,7 +1,7 @@
 package build
 import mill._, scalalib._
 
-object `package` extends RootModule with ScalaModule {
+object `package` extends ScalaModule {
   def scalaVersion = "2.12.15"
   def mvnDeps = Seq(
     mvn"org.apache.spark::spark-core:3.5.4",

--- a/example/scalalib/web/1-todo-webapp/build.mill
+++ b/example/scalalib/web/1-todo-webapp/build.mill
@@ -1,7 +1,7 @@
 package build
 import mill._, scalalib._
 
-object `package` extends RootModule with ScalaModule {
+object `package` extends ScalaModule {
   def scalaVersion = "2.13.8"
   def mvnDeps = Seq(
     mvn"com.lihaoyi::cask:0.9.1",

--- a/example/scalalib/web/2-webapp-cache-busting/build.mill
+++ b/example/scalalib/web/2-webapp-cache-busting/build.mill
@@ -2,7 +2,7 @@ package build
 import mill._, scalalib._
 import java.util.Arrays
 
-object `package` extends RootModule with ScalaModule {
+object `package` extends ScalaModule {
   def scalaVersion = "2.13.8"
   def mvnDeps = Seq(
     mvn"com.lihaoyi::cask:0.9.1",

--- a/example/scalalib/web/3-todo-http4s/build.mill
+++ b/example/scalalib/web/3-todo-http4s/build.mill
@@ -1,7 +1,7 @@
 package build
 import mill._, scalalib._
 
-object `package` extends RootModule with ScalaModule {
+object `package` extends ScalaModule {
   def scalaVersion = "2.13.8"
   def mvnDeps = Seq(
     mvn"org.http4s::http4s-ember-server::0.23.30",

--- a/example/scalalib/web/5-webapp-scalajs/build.mill
+++ b/example/scalalib/web/5-webapp-scalajs/build.mill
@@ -1,7 +1,7 @@
 package build
 import mill._, scalalib._, scalajslib._
 
-object `package` extends RootModule with ScalaModule {
+object `package` extends ScalaModule {
 
   def scalaVersion = "2.13.14"
   def mvnDeps = Seq(

--- a/example/scalalib/web/6-webapp-scalajs-shared/build.mill
+++ b/example/scalalib/web/6-webapp-scalajs-shared/build.mill
@@ -9,7 +9,7 @@ trait AppScalaJSModule extends AppScalaModule with ScalaJSModule {
   def scalaJSVersion = "1.16.0"
 }
 
-object `package` extends RootModule with AppScalaModule {
+object `package` extends AppScalaModule {
   def moduleDeps = Seq(shared.jvm)
   def mvnDeps = Seq(mvn"com.lihaoyi::cask:0.9.1")
 

--- a/example/thirdparty/arrow/build.mill
+++ b/example/thirdparty/arrow/build.mill
@@ -79,7 +79,7 @@ object libraries {
     mvn"org.jetbrains.kotlin:kotlin-serialization-compiler-plugin:${versions.kotlin}"
 }
 
-object `package` extends RootModule {
+object `package` extends Module {
 
   // comment to disable test for the module
   val modulesWithTestingEnabled = Set[CoursierModule](

--- a/example/thirdparty/commons-io/build.mill
+++ b/example/thirdparty/commons-io/build.mill
@@ -6,7 +6,7 @@ import mill._, javalib._, publish._
 import mill.define.ModuleRef
 import contrib.jmh.JmhModule
 
-object `package` extends RootModule with PublishModule with MavenModule {
+object `package` extends PublishModule with MavenModule {
 
   object JvmWorkerJava11 extends JvmWorkerModule {
     def jvmId = "temurin:11.0.24"

--- a/example/thirdparty/mockito/build.mill
+++ b/example/thirdparty/mockito/build.mill
@@ -70,7 +70,7 @@ trait MockitoModule extends MavenModule {
   }
 }
 
-object `package` extends RootModule with MockitoModule {
+object `package` extends MockitoModule {
 
   object JvmWorkerJava11 extends JvmWorkerModule {
     def jvmId = "temurin:11.0.24"

--- a/example/thirdparty/ollama-js/build.mill
+++ b/example/thirdparty/ollama-js/build.mill
@@ -131,7 +131,7 @@ trait Examples extends TypeScriptModule {
   }
 }
 
-object `package` extends RootModule with OllamaModule with TsLintModule {
+object `package` extends OllamaModule with TsLintModule {
   def npmLintDeps = Seq(
     "prettier@3.2.4",
     "eslint@8.29.0",

--- a/integration/failure/invalid-meta-module/src/InvalidMetaModuleTests.scala
+++ b/integration/failure/invalid-meta-module/src/InvalidMetaModuleTests.scala
@@ -9,8 +9,7 @@ object InvalidMetaModuleTests extends UtestIntegrationTestSuite {
     test("success") - integrationTest { tester =>
       val res = tester.eval(("resolve", "_"))
       assert(res.isSuccess == false)
-      assert(res.err.contains("object `package` "))
-      assert(res.err.contains("must extend `MillBuildRootModule`"))
+      assert(res.err.contains(" object `package` in mill-build/build.mill must extend a subclass of `MillBuildRootModule`"))
     }
   }
 }

--- a/integration/failure/invalid-meta-module/src/InvalidMetaModuleTests.scala
+++ b/integration/failure/invalid-meta-module/src/InvalidMetaModuleTests.scala
@@ -9,7 +9,9 @@ object InvalidMetaModuleTests extends UtestIntegrationTestSuite {
     test("success") - integrationTest { tester =>
       val res = tester.eval(("resolve", "_"))
       assert(res.isSuccess == false)
-      assert(res.err.contains(" object `package` in mill-build/build.mill must extend a subclass of `MillBuildRootModule`"))
+      assert(res.err.contains(
+        " object `package` in mill-build/build.mill must extend a subclass of `MillBuildRootModule`"
+      ))
     }
   }
 }

--- a/integration/failure/invalid-root-module/src/InvalidRootModuleTests.scala
+++ b/integration/failure/invalid-root-module/src/InvalidRootModuleTests.scala
@@ -9,7 +9,9 @@ object InvalidRootModuleTests extends UtestIntegrationTestSuite {
     test("success") - integrationTest { tester =>
       val res = tester.eval(("resolve", "_"))
       assert(res.isSuccess == false)
-      assert(res.err.contains("object `package` in build.mill must extend a subclass of `mill.Module`"))
+      assert(
+        res.err.contains("object `package` in build.mill must extend a subclass of `mill.Module`")
+      )
     }
   }
 }

--- a/integration/failure/invalid-root-module/src/InvalidRootModuleTests.scala
+++ b/integration/failure/invalid-root-module/src/InvalidRootModuleTests.scala
@@ -9,8 +9,7 @@ object InvalidRootModuleTests extends UtestIntegrationTestSuite {
     test("success") - integrationTest { tester =>
       val res = tester.eval(("resolve", "_"))
       assert(res.isSuccess == false)
-      assert(res.err.contains("object `package` in "))
-      assert(res.err.contains("must extend `RootModule`"))
+      assert(res.err.contains("object `package` in build.mill must extend a subclass of `mill.Module`"))
     }
   }
 }

--- a/integration/failure/invalid-subfolder-root-module/src/InvalidSubfolderRootModuleTests.scala
+++ b/integration/failure/invalid-subfolder-root-module/src/InvalidSubfolderRootModuleTests.scala
@@ -9,7 +9,9 @@ object InvalidSubfolderRootModuleTests extends UtestIntegrationTestSuite {
     test("success") - integrationTest { tester =>
       val res = tester.eval(("resolve", "_"))
       assert(res.isSuccess == false)
-      assert(res.err.contains("object `package` in sub/package.mill must extend a subclass of `mill.Module`"))
+      assert(res.err.contains(
+        "object `package` in sub/package.mill must extend a subclass of `mill.Module`"
+      ))
     }
   }
 }

--- a/integration/failure/invalid-subfolder-root-module/src/InvalidSubfolderRootModuleTests.scala
+++ b/integration/failure/invalid-subfolder-root-module/src/InvalidSubfolderRootModuleTests.scala
@@ -9,8 +9,7 @@ object InvalidSubfolderRootModuleTests extends UtestIntegrationTestSuite {
     test("success") - integrationTest { tester =>
       val res = tester.eval(("resolve", "_"))
       assert(res.isSuccess == false)
-      assert(res.err.contains("object `package` "))
-      assert(res.err.contains("must extend `RootModule`"))
+      assert(res.err.contains("object `package` in sub/package.mill must extend a subclass of `mill.Module`"))
     }
   }
 }

--- a/integration/failure/root-module-compile-error/resources/build.mill
+++ b/integration/failure/root-module-compile-error/resources/build.mill
@@ -4,7 +4,7 @@ import mill._
 
 object before extends UnknownBeforeModule
 
-object `package` extends RootModule with UnknownRootModule {
+object `package` extends UnknownRootModule {
   def scalaVersion = unknownRootInternalDef
 }
 

--- a/integration/failure/root-module-compile-error/resources/foo/package.mill
+++ b/integration/failure/root-module-compile-error/resources/foo/package.mill
@@ -3,7 +3,7 @@ import mill._
 
 object before extends UnknownBeforeFooModule
 
-object `package` extends RootModule with UnknownFooModule {
+object `package` extends UnknownFooModule {
   def scalaVersion = unknownFooInternalDef
 }
 

--- a/integration/feature/cross-file-references/resources/build.mill
+++ b/integration/feature/cross-file-references/resources/build.mill
@@ -2,7 +2,7 @@ package build
 
 import mill.*
 
-object `package` extends RootModule with ModuleB {
+object `package` extends ModuleB {
   object local extends build.nested.ModuleB
   object local2 extends build.nested.ModuleC
   def qux = Task { build.nested.foo() }

--- a/integration/feature/cross-file-references/resources/nested/package.mill
+++ b/integration/feature/cross-file-references/resources/nested/package.mill
@@ -2,7 +2,7 @@ package build.nested
 
 import mill.*
 
-object `package` extends RootModule with ModuleB {
+object `package` extends ModuleB {
   object local extends build.ModuleB
   object local2 extends build.ModuleC
   def qux = Task { build.foo() }

--- a/integration/feature/full-run-logs/resources/build.mill
+++ b/integration/feature/full-run-logs/resources/build.mill
@@ -1,7 +1,7 @@
 package build
 import mill._, javalib._
 
-object `package` extends RootModule with JavaModule {
+object `package` extends JavaModule {
   def mvnDeps = Seq(
     mvn"net.sourceforge.argparse4j:argparse4j:0.9.0",
     mvn"org.thymeleaf:thymeleaf:3.1.1.RELEASE",

--- a/integration/feature/inspect/resources/core3/package.mill
+++ b/integration/feature/inspect/resources/core3/package.mill
@@ -3,4 +3,4 @@ package build.core3
 import mill.javalib.JavaModule
 
 /** Subfolder Module Scaladoc */
-object `package` extends RootModule with JavaModule
+object `package` extends JavaModule

--- a/integration/feature/keyword-module/resources/for/package.mill
+++ b/integration/feature/keyword-module/resources/for/package.mill
@@ -1,6 +1,6 @@
 package build.`for`
 import mill._, scalalib._
 
-object `package` extends Module {
+object `package` extends RootModule {
   def task = Task { true }
 }

--- a/integration/feature/keyword-module/resources/for/package.mill
+++ b/integration/feature/keyword-module/resources/for/package.mill
@@ -1,6 +1,6 @@
 package build.`for`
 import mill._, scalalib._
 
-object `package` extends RootModule {
+object `package` extends Module {
   def task = Task { true }
 }

--- a/integration/feature/keyword-module/resources/if/package.mill
+++ b/integration/feature/keyword-module/resources/if/package.mill
@@ -1,6 +1,6 @@
 package build.`if`
 import mill._, scalalib._
 
-object `package` extends Module {
+object `package` extends RootModule {
   def task = Task { true }
 }

--- a/integration/feature/keyword-module/resources/if/package.mill
+++ b/integration/feature/keyword-module/resources/if/package.mill
@@ -1,6 +1,6 @@
 package build.`if`
 import mill._, scalalib._
 
-object `package` extends RootModule {
+object `package` extends Module {
   def task = Task { true }
 }

--- a/integration/feature/keyword-module/resources/import/package.mill
+++ b/integration/feature/keyword-module/resources/import/package.mill
@@ -1,6 +1,6 @@
 package build.`import`
 import mill._, scalalib._
 
-object `package` extends RootModule {
+object `package` extends Module {
   def task = Task { true }
 }

--- a/integration/feature/keyword-module/resources/import/package.mill
+++ b/integration/feature/keyword-module/resources/import/package.mill
@@ -1,6 +1,6 @@
 package build.`import`
 import mill._, scalalib._
 
-object `package` extends Module {
+object `package` extends RootModule {
   def task = Task { true }
 }

--- a/integration/feature/keyword-module/resources/null/package.mill
+++ b/integration/feature/keyword-module/resources/null/package.mill
@@ -1,6 +1,6 @@
 package build.`null`
 import mill._, scalalib._
 
-object `package` extends Module {
+object `package` extends RootModule {
   def task = Task { true }
 }

--- a/integration/feature/keyword-module/resources/null/package.mill
+++ b/integration/feature/keyword-module/resources/null/package.mill
@@ -1,6 +1,6 @@
 package build.`null`
 import mill._, scalalib._
 
-object `package` extends RootModule {
+object `package` extends Module {
   def task = Task { true }
 }

--- a/integration/feature/keyword-module/resources/this/package.mill
+++ b/integration/feature/keyword-module/resources/this/package.mill
@@ -1,6 +1,6 @@
 package build.`this`
 import mill._, scalalib._
 
-object `package` extends Module {
+object `package` extends RootModule {
   def task = Task { true }
 }

--- a/integration/feature/keyword-module/resources/this/package.mill
+++ b/integration/feature/keyword-module/resources/this/package.mill
@@ -1,6 +1,6 @@
 package build.`this`
 import mill._, scalalib._
 
-object `package` extends RootModule {
+object `package` extends Module {
   def task = Task { true }
 }

--- a/integration/feature/output-directory/resources/build.mill
+++ b/integration/feature/output-directory/resources/build.mill
@@ -3,7 +3,7 @@ package build
 import mill._
 import mill.scalalib._
 
-object `package` extends RootModule with ScalaModule {
+object `package` extends ScalaModule {
   def scalaVersion = scala.util.Properties.versionNumberString
 
   def hello = Task {

--- a/integration/feature/root-cross-module/resources/bar/package.mill
+++ b/integration/feature/root-cross-module/resources/bar/package.mill
@@ -3,7 +3,7 @@ package build.bar
 import mill._
 import scalalib._
 
-object `package` extends RootModule with Cross[FooModule]("3.6.2", "2.13.16") {}
+object `package` extends Cross[FooModule]("3.6.2", "2.13.16") {}
 
 trait FooModule extends CrossScalaModule {
   def foo = Task { true }

--- a/integration/feature/root-cross-module/resources/build.mill
+++ b/integration/feature/root-cross-module/resources/build.mill
@@ -2,7 +2,7 @@ package build
 
 import mill._, scalalib._
 
-object `package` extends RootModule with Cross[FooModule]("3.6.2", "2.13.16") {
+object `package` extends Cross[FooModule]("3.6.2", "2.13.16") {
   object baz extends Cross[FooModule]("3.6.2", "2.13.16") {}
 }
 

--- a/integration/feature/run-background/resources/build.mill
+++ b/integration/feature/run-background/resources/build.mill
@@ -1,6 +1,6 @@
 import mill._, javalib._
 import mainargs.arg
-object `package` extends RootModule with JavaModule {
+object `package` extends JavaModule {
   def runMainBackground(@arg(positional = true) mainClass: String, args: String*): Command[Unit] =
     Task.Command {
       val res = super.runMainBackground(mainClass, args: _*)()

--- a/integration/ide/bloop/resources/build.mill
+++ b/integration/ide/bloop/resources/build.mill
@@ -7,4 +7,4 @@ package build
 import mill._
 import mill.scalalib._
 
-object `package` extends RootModule with JavaModule
+object `package` extends JavaModule

--- a/integration/ide/bsp-modules/resources/proj1/package.mill
+++ b/integration/ide/bsp-modules/resources/proj1/package.mill
@@ -2,6 +2,6 @@ package build.proj1
 import mill._
 import mill.scalalib._
 
-object `package` extends RootModule with ScalaModule {
+object `package` extends ScalaModule {
   def scalaVersion = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
 }

--- a/integration/ide/bsp-modules/resources/proj2/package.mill
+++ b/integration/ide/bsp-modules/resources/proj2/package.mill
@@ -2,6 +2,6 @@ package build.proj2
 import mill._
 import mill.scalalib._
 
-object `package` extends RootModule with ScalaModule {
+object `package` extends ScalaModule {
   def scalaVersion = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
 }

--- a/integration/ide/bsp-modules/resources/proj3/package.mill
+++ b/integration/ide/bsp-modules/resources/proj3/package.mill
@@ -2,6 +2,6 @@ package build.proj3
 import mill._
 import mill.scalalib._
 
-object `package` extends RootModule with ScalaModule {
+object `package` extends ScalaModule {
   def scalaVersion = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
 }

--- a/integration/invalidation/invalidation/resources/-#+&%/package.mill
+++ b/integration/invalidation/invalidation/resources/-#+&%/package.mill
@@ -1,6 +1,6 @@
 package build.`-#+&%`
 import mill._
 
-object `package` extends RootModule {
+object `package` extends Module {
   def input = Task {}
 }

--- a/integration/invalidation/invalidation/resources/-#+&%/package.mill
+++ b/integration/invalidation/invalidation/resources/-#+&%/package.mill
@@ -1,6 +1,6 @@
 package build.`-#+&%`
 import mill._
 
-object `package` extends Module {
+object `package` extends RootModule {
   def input = Task {}
 }

--- a/integration/package.mill
+++ b/integration/package.mill
@@ -14,7 +14,7 @@ import mill.T
 import mill.define.Cross
 import mill.testrunner.TestResult
 
-object `package` extends Module {
+object `package` extends RootModule {
   // We compile the test code once and then offer multiple modes to
   // test it in the `test` CrossModule. We pass `test`'s sources to `lib` to
   // and pass `lib`'s compile output back to `test`.

--- a/integration/package.mill
+++ b/integration/package.mill
@@ -14,7 +14,7 @@ import mill.T
 import mill.define.Cross
 import mill.testrunner.TestResult
 
-object `package` extends RootModule {
+object `package` extends Module {
   // We compile the test code once and then offer multiple modes to
   // test it in the `test` CrossModule. We pass `test`'s sources to `lib` to
   // and pass `lib`'s compile output back to `test`.

--- a/runner/meta/src/mill/runner/meta/CodeGen.scala
+++ b/runner/meta/src/mill/runner/meta/CodeGen.scala
@@ -219,21 +219,22 @@ object CodeGen {
             ()
         }
 
-        newScriptCode = objectData.name.applyTo(newScriptCode, wrapperObjectName)
-
-        newScriptCode = objectData.obj.applyTo(newScriptCode, "abstract class")
-
         newScriptCode = objectData.parent.applyTo(
           newScriptCode,
           if (objectData.parent.text == null) {
             throw new Result.Exception(
               s"object `package` in ${scriptPath.relativeTo(millTopLevelProjectRoot)} " +
-              "must extend a subclass of `mill.Module`"
+                "must extend a subclass of `mill.Module`"
             )
           }
           else if (objectData.parent.text == expectedParent) newParent
           else newParent + " with " + objectData.parent.text
         )
+
+        newScriptCode = objectData.name.applyTo(newScriptCode, wrapperObjectName)
+
+        newScriptCode = objectData.obj.applyTo(newScriptCode, "abstract class")
+
 
         s"""$headerCode
            |$markerComment

--- a/runner/meta/src/mill/runner/meta/CodeGen.scala
+++ b/runner/meta/src/mill/runner/meta/CodeGen.scala
@@ -169,7 +169,7 @@ object CodeGen {
       if (projectRoot != millTopLevelProjectRoot) "MillBuildRootModule" else "RootModule"
 
     val expectedModuleMsg =
-      if (projectRoot != millTopLevelProjectRoot) "MillBuildRootModule" else "Module"
+      if (projectRoot != millTopLevelProjectRoot) "MillBuildRootModule" else "mill.Module"
 
     val misnamed =
       objectData.filter(o => o.name.text != "`package`" && o.parent.text == expectedParent)

--- a/runner/meta/src/mill/runner/meta/CodeGen.scala
+++ b/runner/meta/src/mill/runner/meta/CodeGen.scala
@@ -168,9 +168,9 @@ object CodeGen {
     val expectedParent =
       if (projectRoot != millTopLevelProjectRoot) "MillBuildRootModule" else "RootModule"
 
-    if (objectData.exists(o => o.name.text == "`package`" && o.parent.text != expectedParent)) {
-      throw new Result.Exception(s"object `package` in $scriptPath must extend `$expectedParent`")
-    }
+//    if (objectData.exists(o => o.name.text == "`package`" && o.parent.text != expectedParent)) {
+//      throw new Result.Exception(s"object `package` in $scriptPath must extend `$expectedParent`")
+//    }
     val misnamed =
       objectData.filter(o => o.name.text != "`package`" && o.parent.text == expectedParent)
     if (misnamed.nonEmpty) {
@@ -194,9 +194,7 @@ object CodeGen {
          |}
          |""".stripMargin
 
-    objectData.find(o =>
-      o.name.text == "`package`" && (o.parent.text == "RootModule" || o.parent.text == "MillBuildRootModule")
-    ) match {
+    objectData.find(o => o.name.text == "`package`") match {
       case Some(objectData) =>
         val newParent =
           if (segments.isEmpty) expectedParent else s"mill.main.SubfolderModule(build.millDiscover)"
@@ -224,7 +222,12 @@ object CodeGen {
             ()
         }
 
-        newScriptCode = objectData.parent.applyTo(newScriptCode, newParent)
+        newScriptCode = objectData.parent.applyTo(
+          newScriptCode,
+          if (objectData.parent.text == expectedParent) newParent
+          else newParent + " with " + objectData.parent.text
+        )
+
         newScriptCode = objectData.name.applyTo(newScriptCode, wrapperObjectName)
         newScriptCode = objectData.obj.applyTo(newScriptCode, "abstract class")
 

--- a/runner/meta/src/mill/runner/meta/CodeGen.scala
+++ b/runner/meta/src/mill/runner/meta/CodeGen.scala
@@ -226,15 +226,13 @@ object CodeGen {
               s"object `package` in ${scriptPath.relativeTo(millTopLevelProjectRoot)} " +
                 "must extend a subclass of `mill.Module`"
             )
-          }
-          else if (objectData.parent.text == expectedParent) newParent
+          } else if (objectData.parent.text == expectedParent) newParent
           else newParent + " with " + objectData.parent.text
         )
 
         newScriptCode = objectData.name.applyTo(newScriptCode, wrapperObjectName)
 
         newScriptCode = objectData.obj.applyTo(newScriptCode, "abstract class")
-
 
         s"""$headerCode
            |$markerComment

--- a/runner/meta/src/mill/runner/meta/CodeGen.scala
+++ b/runner/meta/src/mill/runner/meta/CodeGen.scala
@@ -168,6 +168,9 @@ object CodeGen {
     val expectedParent =
       if (projectRoot != millTopLevelProjectRoot) "MillBuildRootModule" else "RootModule"
 
+    val expectedModuleMsg =
+      if (projectRoot != millTopLevelProjectRoot) "MillBuildRootModule" else "Module"
+
     val misnamed =
       objectData.filter(o => o.name.text != "`package`" && o.parent.text == expectedParent)
     if (misnamed.nonEmpty) {
@@ -224,7 +227,7 @@ object CodeGen {
           if (objectData.parent.text == null) {
             throw new Result.Exception(
               s"object `package` in ${scriptPath.relativeTo(millTopLevelProjectRoot)} " +
-                "must extend a subclass of `mill.Module`"
+                s"must extend a subclass of `$expectedModuleMsg`"
             )
           } else if (objectData.parent.text == expectedParent) newParent
           else newParent + " with " + objectData.parent.text


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/4971

With this PR, any top-level `object package` in a `build.mill` or `package.mill` file has the `extends RootModule` or `extends SubfolderModule` automatically inserted. 

Before this PR we were already over-writing the `extends RootModule` with the correct type, so this just makes it insert the correct type even when `extends RootModule` is not provided (although we still require that it extends some kind of `mill.Module`). 

If there is an existing `extends RootModule`, we accept that for now to ease in the migration