### PR TITLE
Respect XDG_CACHE_HOME in JLineNativeLoader

### DIFF
--- a/runner/client/src/mill/runner/client/JLineNativeLoader.java
+++ b/runner/client/src/mill/runner/client/JLineNativeLoader.java
@@ -39,7 +39,14 @@ final class JLineNativeLoader {
         System.getProperty("os.name").toLowerCase(Locale.ROOT).startsWith("windows");
     final Path baseDir;
     if (isWindows) baseDir = Paths.get(System.getenv("UserProfile")).resolve(".mill/cache/");
-    else baseDir = Paths.get(System.getProperty("user.home")).resolve(".cache/mill/");
+    else {
+      final String xdgCacheHome = System.getenv("XDG_CACHE_HOME");
+      final Path cacheBase;
+      if (xdgCacheHome == null)
+        cacheBase = Paths.get(System.getProperty("user.home")).resolve(".cache");
+      else cacheBase = Paths.get(xdgCacheHome);
+      baseDir = cacheBase.resolve("mill");
+    }
     this.millJLineNativeDir = baseDir.resolve("jline/" + jlineNativeVersion);
     this.millJLineNativeLibLocation =
         millJLineNativeDir.resolve(OSInfo.getNativeLibFolderPathForCurrentOS() + "/"


### PR DESCRIPTION
Comes from https://github.com/com-lihaoyi/mill/pull/4917, but shouldn't be a problem