### PR TITLE
Update coursier to 2.1.25-M11 and use short paths for GraalVM distributions (new attempt)

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -127,7 +127,7 @@ object Deps {
   val bloopConfig = mvn"ch.epfl.scala::bloop-config:1.5.5".withDottyCompat(scalaVersion)
 
   val classgraph = mvn"io.github.classgraph:classgraph:4.8.179"
-  val coursierVersion = "2.1.25-M4"
+  val coursierVersion = "2.1.25-M11"
   val coursier = mvn"io.get-coursier::coursier:$coursierVersion".withDottyCompat(scalaVersion)
   val coursierInterface = mvn"io.get-coursier:interface:1.0.29-M1"
   val coursierJvm =

--- a/ci/mill-bootstrap.patch
+++ b/ci/mill-bootstrap.patch
@@ -1,0 +1,89 @@
+diff --git a/dist/package.mill b/dist/package.mill
+index c16347a6a19..f1c2303e45b 100644
+--- a/dist/package.mill
++++ b/dist/package.mill
+@@ -336,84 +336,6 @@ object `package` extends InstallModule {
+ 
+     object JvmWorkerGraalvm extends JvmWorkerModule {
+       def jvmId = build.Settings.graalvmJvmId
+-
+-      import coursier.cache.{ArchiveCache, FileCache}
+-      import coursier.jvm.{JavaHome, JvmCache}
+-      import coursier.util.{Task => CsTask}
+-      import mill.api.Result
+-      import scala.util.Properties.isWin
+-
+-      def javaHome: T[Option[PathRef]] = Task {
+-        Option(jvmId()).filter(_ != "").map { id =>
+-          val path = resolveJavaHome(
+-            id = id,
+-            coursierCacheCustomizer = coursierCacheCustomizer(),
+-            ctx = Some(Task.ctx()),
+-            jvmIndexVersion = jvmIndexVersion(),
+-            useShortPaths = isWin && (
+-              jvmId().startsWith("graalvm") || jvmId().startsWith("liberica-nik")
+-            )
+-          ).get
+-          // Java home is externally managed, better revalidate it at least once
+-          PathRef(path, quick = true).withRevalidateOnce
+-        }
+-      }
+-
+-      def resolveJavaHome(
+-          id: String,
+-          ctx: Option[mill.define.TaskCtx] = None,
+-          coursierCacheCustomizer: Option[FileCache[CsTask] => FileCache[CsTask]] = None,
+-          jvmIndexVersion: String = mill.api.BuildInfo.coursierJvmIndexVersion,
+-          useShortPaths: Boolean = false
+-      ): Result[os.Path] = {
+-        val coursierCache0 =
+-          FileCache() // .withLogger(new CoursierTickerResolutionLogger(Task.ctx))
+-        val shortPathDirOpt = Option.when(useShortPaths) {
+-          if (isWin)
+-            // On Windows, prefer to use System.getenv over sys.env (or ctx.env for
+-            // now), as the former respects the case-insensitiveness of env vars on
+-            // Windows, while the latter doesn't
+-            os.Path(System.getenv("UserProfile")) / ".mill/cache/jvm"
+-          else {
+-            val cacheBase = ctx.map(_.env)
+-              .getOrElse(sys.env)
+-              .get("XDG_CACHE_HOME")
+-              .map(os.Path(_))
+-              .getOrElse(os.home / ".cache")
+-            cacheBase / "mill/jvm"
+-          }
+-        }
+-        val jvmCache = JvmCache()
+-          .withArchiveCache(
+-            ArchiveCache()
+-              .withCache(coursierCache0)
+-              // .withShortPathDirectory(shortPathDirOpt.map(_.toIO))
+-          )
+-          .withIndex(Jvm.jvmIndex0(ctx, coursierCacheCustomizer, jvmIndexVersion))
+-        val javaHome = JavaHome()
+-          .withCache(jvmCache)
+-          // when given a version like "17", always pick highest version in the index
+-          // rather than the highest already on disk
+-          .withUpdate(true)
+-        val file = os.Path(javaHome.get(id).unsafeRun()(coursierCache0.ec))
+-        val finalDir = shortPathDirOpt match {
+-          case None => file
+-          case Some(shortPathDir) =>
+-            val sha1 = {
+-              import java.math.BigInteger
+-              import java.security.MessageDigest
+-              val bytes = MessageDigest.getInstance("SHA-1").digest(file.toString.getBytes)
+-              val baseSha1 = new BigInteger(1, bytes).toString(16)
+-              "0" * (40 - baseSha1.length) + baseSha1
+-            }
+-            val dir = shortPathDir / sha1.take(8)
+-            os.copy(file, dir, createFolders = true)
+-            dir
+-        }
+-        Result.Success(finalDir)
+-
+-      }
+-
+     }
+   }
+ }

--- a/dist/package.mill
+++ b/dist/package.mill
@@ -336,6 +336,84 @@ object `package` extends InstallModule {
 
     object JvmWorkerGraalvm extends JvmWorkerModule {
       def jvmId = build.Settings.graalvmJvmId
+
+      import coursier.cache.{ArchiveCache, FileCache}
+      import coursier.jvm.{JavaHome, JvmCache}
+      import coursier.util.{Task => CsTask}
+      import mill.api.Result
+      import scala.util.Properties.isWin
+
+      def javaHome: T[Option[PathRef]] = Task {
+        Option(jvmId()).filter(_ != "").map { id =>
+          val path = resolveJavaHome(
+            id = id,
+            coursierCacheCustomizer = coursierCacheCustomizer(),
+            ctx = Some(Task.ctx()),
+            jvmIndexVersion = jvmIndexVersion(),
+            useShortPaths = isWin && (
+              jvmId().startsWith("graalvm") || jvmId().startsWith("liberica-nik")
+            )
+          ).get
+          // Java home is externally managed, better revalidate it at least once
+          PathRef(path, quick = true).withRevalidateOnce
+        }
+      }
+
+      def resolveJavaHome(
+          id: String,
+          ctx: Option[mill.define.TaskCtx] = None,
+          coursierCacheCustomizer: Option[FileCache[CsTask] => FileCache[CsTask]] = None,
+          jvmIndexVersion: String = mill.api.BuildInfo.coursierJvmIndexVersion,
+          useShortPaths: Boolean = false
+      ): Result[os.Path] = {
+        val coursierCache0 =
+          FileCache() // .withLogger(new CoursierTickerResolutionLogger(Task.ctx))
+        val shortPathDirOpt = Option.when(useShortPaths) {
+          if (isWin)
+            // On Windows, prefer to use System.getenv over sys.env (or ctx.env for
+            // now), as the former respects the case-insensitiveness of env vars on
+            // Windows, while the latter doesn't
+            os.Path(System.getenv("UserProfile")) / ".mill/cache/jvm"
+          else {
+            val cacheBase = ctx.map(_.env)
+              .getOrElse(sys.env)
+              .get("XDG_CACHE_HOME")
+              .map(os.Path(_))
+              .getOrElse(os.home / ".cache")
+            cacheBase / "mill/jvm"
+          }
+        }
+        val jvmCache = JvmCache()
+          .withArchiveCache(
+            ArchiveCache()
+              .withCache(coursierCache0)
+              // .withShortPathDirectory(shortPathDirOpt.map(_.toIO))
+          )
+          .withIndex(Jvm.jvmIndex0(ctx, coursierCacheCustomizer, jvmIndexVersion))
+        val javaHome = JavaHome()
+          .withCache(jvmCache)
+          // when given a version like "17", always pick highest version in the index
+          // rather than the highest already on disk
+          .withUpdate(true)
+        val file = os.Path(javaHome.get(id).unsafeRun()(coursierCache0.ec))
+        val finalDir = shortPathDirOpt match {
+          case None => file
+          case Some(shortPathDir) =>
+            val sha1 = {
+              import java.math.BigInteger
+              import java.security.MessageDigest
+              val bytes = MessageDigest.getInstance("SHA-1").digest(file.toString.getBytes)
+              val baseSha1 = new BigInteger(1, bytes).toString(16)
+              "0" * (40 - baseSha1.length) + baseSha1
+            }
+            val dir = shortPathDir / sha1.take(8)
+            os.copy(file, dir, createFolders = true)
+            dir
+        }
+        Result.Success(finalDir)
+
+      }
+
     }
   }
 }

--- a/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.iml
+++ b/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.iml
@@ -15,20 +15,21 @@
         <orderEntry type="library" name="asm-9.6.jar" level="project"/>
         <orderEntry type="library" name="asm-commons-9.6.jar" level="project"/>
         <orderEntry type="library" name="asm-tree-9.6.jar" level="project"/>
-        <orderEntry type="library" name="cache-util-2.1.25-M4.jar" level="project"/>
+        <orderEntry type="library" name="cache-util-2.1.25-M11.jar" level="project"/>
         <orderEntry type="library" name="commons-codec-1.17.0.jar" level="project"/>
         <orderEntry type="library" name="commons-compress-1.26.2.jar" level="project"/>
         <orderEntry type="library" name="commons-io-2.18.0.jar" level="project"/>
         <orderEntry type="library" name="commons-lang3-3.16.0.jar" level="project"/>
         <orderEntry type="library" name="concurrent-reference-hash-map-1.1.0.jar" level="project"/>
         <orderEntry type="library" name="config_2.13-1.1.3.jar" level="project"/>
-        <orderEntry type="library" name="coursier-cache_2.13-2.1.25-M4.jar" level="project"/>
-        <orderEntry type="library" name="coursier-core_2.13-2.1.25-M4.jar" level="project"/>
-        <orderEntry type="library" name="coursier-env_2.13-2.1.25-M4.jar" level="project"/>
-        <orderEntry type="library" name="coursier-jvm_2.13-2.1.25-M4.jar" level="project"/>
-        <orderEntry type="library" name="coursier-proxy-setup-2.1.25-M4.jar" level="project"/>
-        <orderEntry type="library" name="coursier-util_2.13-2.1.25-M4.jar" level="project"/>
-        <orderEntry type="library" name="coursier_2.13-2.1.25-M4.jar" level="project"/>
+        <orderEntry type="library" name="coursier-cache_2.13-2.1.25-M11.jar" level="project"/>
+        <orderEntry type="library" name="coursier-core_2.13-2.1.25-M11.jar" level="project"/>
+        <orderEntry type="library" name="coursier-env_2.13-2.1.25-M11.jar" level="project"/>
+        <orderEntry type="library" name="coursier-exec-2.1.25-M11.jar" level="project"/>
+        <orderEntry type="library" name="coursier-jvm_2.13-2.1.25-M11.jar" level="project"/>
+        <orderEntry type="library" name="coursier-proxy-setup-2.1.25-M11.jar" level="project"/>
+        <orderEntry type="library" name="coursier-util_2.13-2.1.25-M11.jar" level="project"/>
+        <orderEntry type="library" name="coursier_2.13-2.1.25-M11.jar" level="project"/>
         <orderEntry type="library" name="dependency_2.13-0.3.2.jar" level="project"/>
         <orderEntry type="library" name="fansi_3-0.5.0.jar" level="project"/>
         <orderEntry type="library" name="fastparse_3-3.1.1.jar" level="project"/>
@@ -49,7 +50,7 @@
         <orderEntry type="library" name="jline-native-3.29.0.jar" level="project"/>
         <orderEntry type="library" name="jna-5.17.0.jar" level="project"/>
         <orderEntry type="library" name="jna-platform-5.16.0.jar" level="project"/>
-        <orderEntry type="library" name="jsoniter-scala-core_2.13-2.13.5.2.jar" level="project"/>
+        <orderEntry type="library" name="jsoniter-scala-core_2.13-2.13.39.jar" level="project"/>
         <orderEntry type="library" name="jsr305-3.0.2.jar" level="project"/>
         <orderEntry type="library" name="jul-to-slf4j-1.7.30.jar" level="project"/>
         <orderEntry type="library" name="junit-4.13.2.jar" level="project"/>
@@ -118,6 +119,6 @@
         <orderEntry type="library" name="windows-jni-utils-0.3.3.jar" level="project"/>
         <orderEntry type="library" name="xbean-reflect-3.7.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="xz-1.9.jar" level="project"/>
-        <orderEntry type="library" scope="RUNTIME" name="zstd-jni-1.5.6-3.jar" level="project"/>
+        <orderEntry type="library" name="zstd-jni-1.5.7-2.jar" level="project"/>
     </component>
 </module>

--- a/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.mill-build.iml
+++ b/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.mill-build.iml
@@ -17,20 +17,21 @@
         <orderEntry type="library" name="asm-9.8.jar" level="project"/>
         <orderEntry type="library" name="asm-commons-9.6.jar" level="project"/>
         <orderEntry type="library" name="asm-tree-9.8.jar" level="project"/>
-        <orderEntry type="library" name="cache-util-2.1.25-M4.jar" level="project"/>
+        <orderEntry type="library" name="cache-util-2.1.25-M11.jar" level="project"/>
         <orderEntry type="library" name="commons-codec-1.17.0.jar" level="project"/>
         <orderEntry type="library" name="commons-compress-1.26.2.jar" level="project"/>
         <orderEntry type="library" name="commons-io-2.18.0.jar" level="project"/>
         <orderEntry type="library" name="commons-lang3-3.16.0.jar" level="project"/>
         <orderEntry type="library" name="concurrent-reference-hash-map-1.1.0.jar" level="project"/>
         <orderEntry type="library" name="config_2.13-1.1.3.jar" level="project"/>
-        <orderEntry type="library" name="coursier-cache_2.13-2.1.25-M4.jar" level="project"/>
-        <orderEntry type="library" name="coursier-core_2.13-2.1.25-M4.jar" level="project"/>
-        <orderEntry type="library" name="coursier-env_2.13-2.1.25-M4.jar" level="project"/>
-        <orderEntry type="library" name="coursier-jvm_2.13-2.1.25-M4.jar" level="project"/>
-        <orderEntry type="library" name="coursier-proxy-setup-2.1.25-M4.jar" level="project"/>
-        <orderEntry type="library" name="coursier-util_2.13-2.1.25-M4.jar" level="project"/>
-        <orderEntry type="library" name="coursier_2.13-2.1.25-M4.jar" level="project"/>
+        <orderEntry type="library" name="coursier-cache_2.13-2.1.25-M11.jar" level="project"/>
+        <orderEntry type="library" name="coursier-core_2.13-2.1.25-M11.jar" level="project"/>
+        <orderEntry type="library" name="coursier-env_2.13-2.1.25-M11.jar" level="project"/>
+        <orderEntry type="library" name="coursier-exec-2.1.25-M11.jar" level="project"/>
+        <orderEntry type="library" name="coursier-jvm_2.13-2.1.25-M11.jar" level="project"/>
+        <orderEntry type="library" name="coursier-proxy-setup-2.1.25-M11.jar" level="project"/>
+        <orderEntry type="library" name="coursier-util_2.13-2.1.25-M11.jar" level="project"/>
+        <orderEntry type="library" name="coursier_2.13-2.1.25-M11.jar" level="project"/>
         <orderEntry type="library" name="dependency_2.13-0.3.2.jar" level="project"/>
         <orderEntry type="library" name="fansi_3-0.5.0.jar" level="project"/>
         <orderEntry type="library" name="fastparse_3-3.1.1.jar" level="project"/>
@@ -50,7 +51,7 @@
         <orderEntry type="library" name="jline-native-3.29.0.jar" level="project"/>
         <orderEntry type="library" name="jna-5.17.0.jar" level="project"/>
         <orderEntry type="library" name="jna-platform-5.16.0.jar" level="project"/>
-        <orderEntry type="library" name="jsoniter-scala-core_2.13-2.13.5.2.jar" level="project"/>
+        <orderEntry type="library" name="jsoniter-scala-core_2.13-2.13.39.jar" level="project"/>
         <orderEntry type="library" name="jsr305-3.0.2.jar" level="project"/>
         <orderEntry type="library" name="jul-to-slf4j-1.7.30.jar" level="project"/>
         <orderEntry type="library" name="logback-classic-1.5.17.jar" level="project"/>
@@ -119,6 +120,6 @@
         <orderEntry type="library" name="windows-jni-utils-0.3.3.jar" level="project"/>
         <orderEntry type="library" name="xbean-reflect-3.7.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="xz-1.9.jar" level="project"/>
-        <orderEntry type="library" scope="RUNTIME" name="zstd-jni-1.5.6-3.jar" level="project"/>
+        <orderEntry type="library" name="zstd-jni-1.5.7-2.jar" level="project"/>
     </component>
 </module>

--- a/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/mill-build.iml
+++ b/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/mill-build.iml
@@ -15,20 +15,21 @@
         <orderEntry type="library" name="asm-9.6.jar" level="project"/>
         <orderEntry type="library" name="asm-commons-9.6.jar" level="project"/>
         <orderEntry type="library" name="asm-tree-9.6.jar" level="project"/>
-        <orderEntry type="library" name="cache-util-2.1.25-M4.jar" level="project"/>
+        <orderEntry type="library" name="cache-util-2.1.25-M11.jar" level="project"/>
         <orderEntry type="library" name="commons-codec-1.17.0.jar" level="project"/>
         <orderEntry type="library" name="commons-compress-1.26.2.jar" level="project"/>
         <orderEntry type="library" name="commons-io-2.18.0.jar" level="project"/>
         <orderEntry type="library" name="commons-lang3-3.16.0.jar" level="project"/>
         <orderEntry type="library" name="concurrent-reference-hash-map-1.1.0.jar" level="project"/>
         <orderEntry type="library" name="config_2.13-1.1.3.jar" level="project"/>
-        <orderEntry type="library" name="coursier-cache_2.13-2.1.25-M4.jar" level="project"/>
-        <orderEntry type="library" name="coursier-core_2.13-2.1.25-M4.jar" level="project"/>
-        <orderEntry type="library" name="coursier-env_2.13-2.1.25-M4.jar" level="project"/>
-        <orderEntry type="library" name="coursier-jvm_2.13-2.1.25-M4.jar" level="project"/>
-        <orderEntry type="library" name="coursier-proxy-setup-2.1.25-M4.jar" level="project"/>
-        <orderEntry type="library" name="coursier-util_2.13-2.1.25-M4.jar" level="project"/>
-        <orderEntry type="library" name="coursier_2.13-2.1.25-M4.jar" level="project"/>
+        <orderEntry type="library" name="coursier-cache_2.13-2.1.25-M11.jar" level="project"/>
+        <orderEntry type="library" name="coursier-core_2.13-2.1.25-M11.jar" level="project"/>
+        <orderEntry type="library" name="coursier-env_2.13-2.1.25-M11.jar" level="project"/>
+        <orderEntry type="library" name="coursier-exec-2.1.25-M11.jar" level="project"/>
+        <orderEntry type="library" name="coursier-jvm_2.13-2.1.25-M11.jar" level="project"/>
+        <orderEntry type="library" name="coursier-proxy-setup-2.1.25-M11.jar" level="project"/>
+        <orderEntry type="library" name="coursier-util_2.13-2.1.25-M11.jar" level="project"/>
+        <orderEntry type="library" name="coursier_2.13-2.1.25-M11.jar" level="project"/>
         <orderEntry type="library" name="dependency_2.13-0.3.2.jar" level="project"/>
         <orderEntry type="library" name="fansi_3-0.5.0.jar" level="project"/>
         <orderEntry type="library" name="fastparse_3-3.1.1.jar" level="project"/>
@@ -48,7 +49,7 @@
         <orderEntry type="library" name="jline-native-3.29.0.jar" level="project"/>
         <orderEntry type="library" name="jna-5.17.0.jar" level="project"/>
         <orderEntry type="library" name="jna-platform-5.16.0.jar" level="project"/>
-        <orderEntry type="library" name="jsoniter-scala-core_2.13-2.13.5.2.jar" level="project"/>
+        <orderEntry type="library" name="jsoniter-scala-core_2.13-2.13.39.jar" level="project"/>
         <orderEntry type="library" name="jsr305-3.0.2.jar" level="project"/>
         <orderEntry type="library" name="jul-to-slf4j-1.7.30.jar" level="project"/>
         <orderEntry type="library" name="logback-classic-1.5.17.jar" level="project"/>
@@ -114,6 +115,6 @@
         <orderEntry type="library" name="windows-jni-utils-0.3.3.jar" level="project"/>
         <orderEntry type="library" name="xbean-reflect-3.7.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="xz-1.9.jar" level="project"/>
-        <orderEntry type="library" scope="RUNTIME" name="zstd-jni-1.5.6-3.jar" level="project"/>
+        <orderEntry type="library" name="zstd-jni-1.5.7-2.jar" level="project"/>
     </component>
 </module>

--- a/libs/scalalib/src/mill/scalalib/JvmWorkerModule.scala
+++ b/libs/scalalib/src/mill/scalalib/JvmWorkerModule.scala
@@ -9,6 +9,8 @@ import mill.scalalib.api.JvmWorkerUtil.{isBinaryBridgeAvailable, isDotty, isDott
 import mill.scalalib.api.{Versions, JvmWorkerApi, JvmWorkerUtil}
 import mill.scalalib.CoursierModule.Resolver
 
+import scala.util.Properties
+
 /**
  * A default implementation of [[JvmWorkerModule]]
  */
@@ -51,6 +53,11 @@ trait JvmWorkerModule extends OfflineSupportModule with CoursierModule {
 
   def zincLogDebug: T[Boolean] = Task.Input(Task.ctx().log.debugEnabled)
 
+  def useShortJvmPath(jvmId: String): Boolean =
+    Properties.isWin && (
+      jvmId.startsWith("graalvm") || jvmId.startsWith("liberica-nik")
+    )
+
   /**
    * Optional custom Java Home for the JvmWorker to use
    *
@@ -63,7 +70,8 @@ trait JvmWorkerModule extends OfflineSupportModule with CoursierModule {
         id = id,
         coursierCacheCustomizer = coursierCacheCustomizer(),
         ctx = Some(Task.ctx()),
-        jvmIndexVersion = jvmIndexVersion()
+        jvmIndexVersion = jvmIndexVersion(),
+        useShortPaths = useShortJvmPath(id)
       ).get
       // Java home is externally managed, better revalidate it at least once
       PathRef(path, quick = true).withRevalidateOnce


### PR DESCRIPTION
New attempt at https://github.com/com-lihaoyi/mill/pull/4917

It seems the too long paths are being an issue as soon as we bump the coursier version ([this job](https://github.com/alexarchambault/mill/actions/runs/14705154651/attempts/1) only bumps the coursier version, and results in issues with too long GraalVM paths).

Unlike https://github.com/com-lihaoyi/mill/pull/4917, this not only uses short paths in examples and integration tests, but also in the Mill build itself. It seems this makes `dist.native.nativeImage` happy.