### PR TITLE
Fix/actually limit memory for client

### DIFF
--- a/dist/package.mill
+++ b/dist/package.mill
@@ -284,7 +284,7 @@ object `package` extends MillJavaModule with DistModule {
     def nativeImageOptions = Seq(
       "--no-fallback",
       "--enable-url-protocols=https",
-      "-Os",
+      "-Os"
       // Enable JVisualVM support
       // https://www.graalvm.org/latest/tools/visualvm/#using-visualvm-with-graalvm-native-executables
       // "--enable-monitoring=jvmstat,heapdump"

--- a/dist/package.mill
+++ b/dist/package.mill
@@ -84,7 +84,7 @@ object `package` extends MillJavaModule with DistModule {
 
   private def millClientJvmArgs = Seq(
     // Avoid reserving a lot of memory for the client, as the client only forward information
-    "-Xmx32m",
+    "-Xmx32m"
   )
 
   def launcher = Task {
@@ -282,7 +282,9 @@ object `package` extends MillJavaModule with DistModule {
     }
 
     def nativeImageOptions = Seq(
-      "--no-fallback", "--enable-url-protocols=https", "-Os",
+      "--no-fallback",
+      "--enable-url-protocols=https",
+      "-Os",
       // Enable JVisualVM support
       // https://www.graalvm.org/latest/tools/visualvm/#using-visualvm-with-graalvm-native-executables
       "--enable-monitoring=jvmstat,heapdump"

--- a/dist/package.mill
+++ b/dist/package.mill
@@ -84,7 +84,7 @@ object `package` extends MillJavaModule with DistModule {
 
   private def millClientJvmArgs = Seq(
     // Avoid reserving a lot of memory for the client, as the client only forward information
-    "-Xmx64m"
+    "-Xmx128m"
   )
 
   def launcher = Task {

--- a/dist/package.mill
+++ b/dist/package.mill
@@ -82,6 +82,11 @@ object `package` extends MillJavaModule with DistModule {
 
   def localBinName = "mill-assembly.jar"
 
+  private def millClientJvmArgs = Seq(
+    // Avoid reserving a lot of memory for the client, as the client only forward information
+    "-Xmx32m",
+  )
+
   def launcher = Task {
     val isWin = scala.util.Properties.isWin
     val outputPath = Task.dest / (if (isWin) "run.bat" else "run")
@@ -102,9 +107,7 @@ object `package` extends MillJavaModule with DistModule {
       .mkString("\r\n")
 
     os.write(vmOptionsFile, millOptionsContent)
-    val jvmArgs = otherArgs ++ List(
-      // Avoid reserving a lot of memory for the client, as the client only forward information
-      "-Xmx32m",
+    val jvmArgs = otherArgs ++ millClientJvmArgs ++ List(
       s"-DMILL_OPTIONS_PATH=$vmOptionsFile"
     )
     val classpath = runClasspath().map(_.path.toString)
@@ -129,7 +132,7 @@ object `package` extends MillJavaModule with DistModule {
     mill.scalalib.Assembly.Rule.ExcludePattern("mill/local-test-overrides/.*")
   )
 
-  def forkArgs = Seq(
+  def forkArgs = millClientJvmArgs ++ Seq(
     // Workaround for Zinc/JNA bug
     // https://github.com/sbt/sbt/blame/6718803ee6023ab041b045a6988fafcfae9d15b5/main/src/main/scala/sbt/Main.scala#L130
     "-Djna.nosys=true"

--- a/dist/package.mill
+++ b/dist/package.mill
@@ -281,7 +281,12 @@ object `package` extends MillJavaModule with DistModule {
       PathRef(executable)
     }
 
-    def nativeImageOptions = Seq("--no-fallback", "--enable-url-protocols=https", "-Os")
+    def nativeImageOptions = Seq(
+      "--no-fallback", "--enable-url-protocols=https", "-Os",
+      // Enable JVisualVM support
+      // https://www.graalvm.org/latest/tools/visualvm/#using-visualvm-with-graalvm-native-executables
+      "--enable-monitoring=jvmstat,heapdump"
+    )
 
     def jvmWorker = ModuleRef(JvmWorkerGraalvm)
 

--- a/dist/package.mill
+++ b/dist/package.mill
@@ -287,7 +287,7 @@ object `package` extends MillJavaModule with DistModule {
       "-Os",
       // Enable JVisualVM support
       // https://www.graalvm.org/latest/tools/visualvm/#using-visualvm-with-graalvm-native-executables
-      "--enable-monitoring=jvmstat,heapdump"
+      // "--enable-monitoring=jvmstat,heapdump"
     )
 
     def jvmWorker = ModuleRef(JvmWorkerGraalvm)

--- a/dist/package.mill
+++ b/dist/package.mill
@@ -84,7 +84,7 @@ object `package` extends MillJavaModule with DistModule {
 
   private def millClientJvmArgs = Seq(
     // Avoid reserving a lot of memory for the client, as the client only forward information
-    "-Xmx32m"
+    "-Xmx64m"
   )
 
   def launcher = Task {


### PR DESCRIPTION
Properly implements fix done in https://github.com/com-lihaoyi/mill/pull/4163

Also adds JVisualVM support for native mill image.

Tested manually by launching both the JVM and native versions and looking at the memory usage during compilation via JVisualVM