### PR TITLE
Wrong paths inside diagnostics sent from bsp-server

### DIFF
--- a/integration/ide/bsp-server/src/BspServerTestUtil.scala
+++ b/integration/ide/bsp-server/src/BspServerTestUtil.scala
@@ -112,7 +112,8 @@ object BspServerTestUtil {
 
   def withBspServer[T](
       workspacePath: os.Path,
-      millTestSuiteEnv: Map[String, String]
+      millTestSuiteEnv: Map[String, String],
+      client: b.BuildClient = DummyBuildClient
   )(f: (MillBuildServer, b.InitializeBuildResult) => T): T = {
 
     val bspMetadataFile = workspacePath / Constants.bspDir / s"${Constants.serverName}.json"
@@ -138,8 +139,6 @@ object BspServerTestUtil {
         else os.Inherit,
       env = millTestSuiteEnv
     )
-
-    val client: b.BuildClient = DummyBuildClient
 
     var success = false
     try {

--- a/integration/ide/bsp-server/src/BspServerTests.scala
+++ b/integration/ide/bsp-server/src/BspServerTests.scala
@@ -36,6 +36,33 @@ object BspServerTests extends UtestIntegrationTestSuite {
   }
 
   def tests: Tests = Tests {
+    test("diagnostics test") - integrationTest { tester =>
+      import tester._
+      eval(
+        "--bsp-install",
+        stdout = os.Inherit,
+        stderr = os.Inherit,
+        check = true,
+        env = Map("MILL_MAIN_CLI" -> tester.millExecutable.toString)
+      )
+
+      val client = new DummyBuildClient {
+        override def onBuildPublishDiagnostics(params: b.PublishDiagnosticsParams): Unit =
+          // 4. assert that received params are correct and they contain correct paths
+          ()
+      }
+
+      withBspServer(
+        workspacePath,
+        millTestSuiteEnv,
+        client
+      ) { (buildServer, initRes) =>
+        // 1. Trigger build to compile current build.mill file
+        val result = buildServer.workspaceBuildTargets().get()
+        // 2. adjust file to have typo in module trait name e.g BazeModule instead of BaseModule
+        // 3. rerun build
+      }
+    }
     test("requestSnapshots") - integrationTest { tester =>
       import tester._
       eval(


### PR DESCRIPTION
fixes #4988 

Hi folks, I have started to look into issue of wrong diagnostics reporting from mill by trying first to implement possible test case. I wrote an approximate test scenario with some missing bits I'm not sure how to implement yet, I would appreciate any advice on how to move forward, my current questions are:
1. Is this the right place to write such a test case?
2. What would be the right way to introduce new `mill.build` file into the test without touching existing one from resources
3. Is there any common way to change build.mill file in the middle of test execution?
