### PR TITLE
Fix selective execution when multiple changes are made to one module under --watch

### DIFF
--- a/integration/invalidation/selective-execution/src/SelectiveExecutionTests.scala
+++ b/integration/invalidation/selective-execution/src/SelectiveExecutionTests.scala
@@ -215,12 +215,20 @@ object SelectiveExecutionWatchTests extends UtestIntegrationTestSuite {
           !output.contains("Computing fooCommand") && output.contains("Computing barCommand")
         }
 
+        // Test for a bug where modifying the sources 2nd time would run tasks from both modules.
+        output0 = Nil
+        modifyFile(workspacePath / "bar/bar.txt", _ + "!")
+        eventually {
+          !output.contains("Computing fooCommand") && output.contains("Computing barCommand")
+        }
+
         output0 = Nil
         modifyFile(workspacePath / "foo/foo.txt", _ + "!")
         eventually {
           output.contains("Computing fooCommand") && !output.contains("Computing barCommand")
         }
       }
+
       test("show-changed-inputs") - integrationTest { tester =>
         import tester._
         @volatile var output0 = List.empty[String]

--- a/main/src/mill/main/RunScript.scala
+++ b/main/src/mill/main/RunScript.scala
@@ -1,13 +1,13 @@
 package mill.main
 
-import mill.define._
-import mill.eval.{Evaluator, EvaluatorPaths, Plan}
-import mill.util.Watchable
-import mill.api.{PathRef, Result, Val}
 import mill.api.Strict.Agg
-import Evaluator._
+import mill.api.{PathRef, Result, Val}
+import mill.define.*
+import mill.eval.Evaluator.*
+import mill.eval.{Evaluator, EvaluatorPaths, Plan}
 import mill.main.client.OutFiles
 import mill.resolve.{Resolve, SelectMode}
+import mill.util.Watchable
 
 import scala.annotation.nowarn
 
@@ -107,19 +107,26 @@ object RunScript {
     val selectiveExecutionEnabled = selectiveExecution && !targets.exists(_.isExclusiveCommand)
 
     val selectedTargetsOrErr =
-      if (
-        selectiveExecutionEnabled && os.exists(evaluator.outPath / OutFiles.millSelectiveExecution)
-      ) {
-        val changedTasks = SelectiveExecution.computeChangedTasks0(evaluator, targets.toSeq)
-        val selectedSet = changedTasks.downstreamTasks.map(_.ctx.segments.render).toSet
-        (
-          targets.filter(t => t.isExclusiveCommand || selectedSet(terminals(t).render)),
-          changedTasks.results
-        )
-      } else (targets -> Map.empty)
+      if (!selectiveExecutionEnabled) (targets, Map.empty, None)
+      else {
+        if (!os.exists(evaluator.outPath / OutFiles.millSelectiveExecution)) {
+          // Ran when previous selective execution metadata is not available, which happens the first time you run
+          // selective execution.
+          val (newMetadata, results) = SelectiveExecution.Metadata.compute(evaluator, targets.toSeq)
+          (targets, Map.empty, Some(newMetadata))
+        } else {
+          val changedTasks = SelectiveExecution.computeChangedTasks0(evaluator, targets.toSeq)
+          val selectedSet = changedTasks.downstreamTasks.map(_.ctx.segments.render).toSet
+          (
+            targets.filter(t => t.isExclusiveCommand || selectedSet(terminals(t).render)),
+            changedTasks.results,
+            Some(changedTasks.newMetadata)
+          )
+        }
+      }
 
     selectedTargetsOrErr match {
-      case (selectedTargets, selectiveResults) =>
+      case (selectedTargets, selectiveResults, maybeNewMetadata) =>
         val evaluated: Results = evaluator.evaluate(selectedTargets, serialCommandExec = true)
         val watched = (evaluated.results.iterator ++ selectiveResults)
           .collect {
@@ -134,15 +141,8 @@ object RunScript {
           .flatten
           .toSeq
 
-        val allInputHashes = evaluated.results
-          .iterator
-          .collect {
-            case (t: InputImpl[_], TaskResult(Result.Success(Val(value)), _)) =>
-              (terminals(t).render, value.##)
-          }
-          .toMap
-
-        if (selectiveExecutionEnabled) {
+        maybeNewMetadata.foreach { newMetadata =>
+          val allInputHashes = newMetadata.inputHashes
           SelectiveExecution.saveMetadata(
             evaluator,
             SelectiveExecution.Metadata(allInputHashes, evaluator.methodCodeHashSignatures)

--- a/main/src/mill/main/RunScript.scala
+++ b/main/src/mill/main/RunScript.scala
@@ -2,8 +2,8 @@ package mill.main
 
 import mill.api.Strict.Agg
 import mill.api.{PathRef, Result, Val}
-import mill.define.*
-import mill.eval.Evaluator.*
+import mill.define._
+import mill.eval.Evaluator._
 import mill.eval.{Evaluator, EvaluatorPaths, Plan}
 import mill.main.client.OutFiles
 import mill.resolve.{Resolve, SelectMode}

--- a/main/src/mill/main/SelectiveExecution.scala
+++ b/main/src/mill/main/SelectiveExecution.scala
@@ -2,7 +2,7 @@ package mill.main
 
 import mill.api.{Strict, Val}
 import mill.define.{InputImpl, NamedTask, Task}
-import mill.eval.*
+import mill.eval._
 import mill.main.client.OutFiles
 import mill.resolve.{Resolve, SelectMode}
 import mill.util.SpanningForest

--- a/main/src/mill/main/SelectiveExecutionModule.scala
+++ b/main/src/mill/main/SelectiveExecutionModule.scala
@@ -20,9 +20,8 @@ trait SelectiveExecutionModule extends mill.define.Module {
         if (tasks.isEmpty) Seq("__") else tasks,
         SelectMode.Multi
       ).map { resolvedTasks =>
-        SelectiveExecution.Metadata
-          .compute(evaluator, resolvedTasks)
-          .map(x => SelectiveExecution.saveMetadata(evaluator, x._1))
+        val computed = SelectiveExecution.Metadata.compute(evaluator, resolvedTasks)
+        SelectiveExecution.saveMetadata(evaluator, computed.metadata)
       }
 
       res match {


### PR DESCRIPTION
If you have two modules and run `--watch {moduleA.fooCommand,moduleB.fooCommand}`, mill will run `moduleB.fooCommand` every 2nd change to `moduleA`, even if there is no changes to `moduleB`.

The problem stems from the fact that when we save the changed inputs in selective execution, we did not store the inputs from `moduleB` and when selective execution runs again (the 2nd time), it thinks that *everything* in `moduleB` changed.

This fix correctly saves the state of all modules when storing the selective execution state.