### PR TITLE
Restrict `os.read` within a Task to only allow reading from upstream task `PathRef`s

### DIFF
--- a/contrib/scalapblib/test/src/mill/contrib/scalapblib/TutorialTests.scala
+++ b/contrib/scalapblib/test/src/mill/contrib/scalapblib/TutorialTests.scala
@@ -56,8 +56,8 @@ object TutorialTests extends TestSuite {
       }
 
       override def scalaPBSearchDeps = true
-      override def scalaPBIncludePath = Seq(
-        PathRef(moduleDir / "protobuf/tutorial")
+      override def scalaPBIncludePath = Task.Sources(
+        moduleDir / "protobuf/tutorial"
       )
     }
     lazy val millDiscover = Discover[this.type]

--- a/core/define/src/mill/define/internal/ResolveChecker.scala
+++ b/core/define/src/mill/define/internal/ResolveChecker.scala
@@ -1,10 +1,10 @@
 package mill.define.internal
 
-object ResolveChecker extends os.Checker {
+class ResolveChecker(workspace: os.Path) extends os.Checker {
   def onRead(path: os.ReadablePath): Unit = ()
 
   def onWrite(path: os.Path): Unit = {
-    sys.error(s"Writing to $path not allowed during resolution phase")
+    sys.error(s"Writing to ${path.relativeTo(workspace)} not allowed during resolution phase")
   }
 
   def withResolveChecker[T](f: () => T): T = {

--- a/core/eval/src/mill/eval/EvaluatorImpl.scala
+++ b/core/eval/src/mill/eval/EvaluatorImpl.scala
@@ -54,7 +54,7 @@ final class EvaluatorImpl private[mill] (
       allowPositionalCommandArgs: Boolean = false,
       resolveToModuleTasks: Boolean = false
   ): mill.api.Result[List[Segments]] = {
-    os.checker.withValue(ResolveChecker) {
+    os.checker.withValue(ResolveChecker(workspace)) {
       Resolve.Segments.resolve(
         rootModule,
         scriptArgs,
@@ -75,7 +75,7 @@ final class EvaluatorImpl private[mill] (
       allowPositionalCommandArgs: Boolean = false,
       resolveToModuleTasks: Boolean = false
   ): mill.api.Result[List[NamedTask[?]]] = {
-    os.checker.withValue(ResolveChecker) {
+    os.checker.withValue(ResolveChecker(workspace)) {
       Evaluator.currentEvaluator0.withValue(this) {
         Resolve.Tasks.resolve(
           rootModule,
@@ -93,7 +93,7 @@ final class EvaluatorImpl private[mill] (
       allowPositionalCommandArgs: Boolean = false,
       resolveToModuleTasks: Boolean = false
   ): mill.api.Result[List[Either[Module, NamedTask[?]]]] = {
-    os.checker.withValue(ResolveChecker) {
+    os.checker.withValue(ResolveChecker(workspace)) {
       Evaluator.currentEvaluator0.withValue(this) {
         Resolve.Inspect.resolve(
           rootModule,
@@ -242,7 +242,7 @@ final class EvaluatorImpl private[mill] (
       selectMode: SelectMode,
       selectiveExecution: Boolean = false
   ): mill.api.Result[Evaluator.Result[Any]] = {
-    val resolved = os.checker.withValue(ResolveChecker) {
+    val resolved = os.checker.withValue(ResolveChecker(workspace)) {
       Evaluator.currentEvaluator0.withValue(this) {
         Resolve.Tasks.resolve(
           rootModule,

--- a/core/exec/src/mill/exec/Execution.scala
+++ b/core/exec/src/mill/exec/Execution.scala
@@ -166,7 +166,7 @@ private[mill] case class Execution(
             .toMap
 
           futures(terminal) = Future.successful(
-            Some(GroupExecution.Results(taskResults, group.toSeq, false, -1, -1, false))
+            Some(GroupExecution.Results(taskResults, group.toSeq, false, -1, -1, false, Nil))
           )
         } else {
           futures(terminal) = Future.sequence(deps.map(futures)).map { upstreamValues =>
@@ -185,6 +185,11 @@ private[mill] case class Execution(
                   .iterator
                   .flatMap(_.iterator.flatMap(_.newResults))
                   .toMap
+
+                val upstreamPathRefs = upstreamValues
+                  .iterator
+                  .flatMap(_.iterator.flatMap(_.serializedPaths))
+                  .toSeq
 
                 val startTime = System.nanoTime() / 1000
 
@@ -219,7 +224,8 @@ private[mill] case class Execution(
                   allTransitiveClassMethods,
                   forkExecutionContext,
                   exclusive,
-                  offline
+                  offline,
+                  upstreamPathRefs
                 )
 
                 // Count new failures - if there are upstream failures, tasks should be skipped, not failed

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -320,10 +320,7 @@ private trait GroupExecution {
             } ++
               paths.map(_.dest)
 
-          lazy val validReadDests = group.collect {
-            case n: NamedTask[_] =>
-              ExecutionPaths.resolve(outPath, n.ctx.segments).dest
-          } ++ validWriteDests
+          lazy val validReadDests = validWriteDests ++ upstreamPathRefs.map(_.path)
 
           val executionChecker = new os.Checker {
             def onRead(path: os.ReadablePath): Unit = path match {

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -320,11 +320,11 @@ private trait GroupExecution {
             } ++
               paths.map(_.dest)
 
-          mill.constants.DebugLog(results.keys.toString())
           lazy val validReadDests = group.collect {
             case n: NamedTask[_] =>
               ExecutionPaths.resolve(outPath, n.ctx.segments).dest
-          } ++ upstreamPathRefs.map(_.path)
+          } ++ validWriteDests
+
           val executionChecker = new os.Checker {
             def onRead(path: os.ReadablePath): Unit = path match {
               case path: os.Path =>

--- a/example/androidlib/java/1-hello-world/build.mill
+++ b/example/androidlib/java/1-hello-world/build.mill
@@ -30,7 +30,7 @@ object app extends AndroidAppModule {
    * Never use these defaults in a production environment as they are not secure.
    * This is just for testing purposes.
    */
-  def androidReleaseKeyName: T[Option[String]] = Task { Some("releaseKey.jks") }
+  def androidReleaseKeyName: Option[String] = Some("releaseKey.jks")
   def androidReleaseKeyAlias: T[Option[String]] = Task { Some("releaseKey") }
   def androidReleaseKeyPass: T[Option[String]] = Task { Some("MillBuildTool") }
   def androidReleaseKeyStorePass: T[Option[String]] = Task { Some("MillBuildTool") }

--- a/example/androidlib/java/2-app-bundle/build.mill
+++ b/example/androidlib/java/2-app-bundle/build.mill
@@ -26,7 +26,7 @@ object bundle extends AndroidAppBundle {
   def androidApplicationId = "com.helloworld.app"
   def androidApplicationNamespace = "com.helloworld.app"
 
-  def androidReleaseKeyName: T[Option[String]] = Task { Some("releaseKey.jks") }
+  def androidReleaseKeyName: Option[String] = Some("releaseKey.jks")
   def androidReleaseKeyAlias: T[Option[String]] = Task { Some("releaseKey") }
   def androidReleaseKeyPass: T[Option[String]] = Task { Some("MillBuildTool") }
   def androidReleaseKeyStorePass: T[Option[String]] = Task { Some("MillBuildTool") }

--- a/example/androidlib/java/3-linting/build.mill
+++ b/example/androidlib/java/3-linting/build.mill
@@ -29,7 +29,8 @@ object app extends AndroidAppModule {
   def androidLintConfigPath = Task.Sources { "lint.xml" }
 
   // Set path to the custom `baseline.xml` file. It is usually at the root of the project
-  def androidLintBaselinePath = Task.Sources { "lint-baseline.xml" }
+  def androidLintBaselinePath0 = Task.Sources { "lint-baseline.xml" }
+  def androidLintBaselinePath = Task{ androidLintBaselinePath0().headOption }
 
   // Set the linting report to be generated as both text and html files
   def androidLintReportFormat =

--- a/example/androidlib/java/3-linting/build.mill
+++ b/example/androidlib/java/3-linting/build.mill
@@ -26,7 +26,8 @@ object app extends AndroidAppModule {
   def androidApplicationNamespace = "com.helloworld.app"
 
   // Set path to the custom `lint.xml` config file. It is usually at the root of the project
-  def androidLintConfigPath = Task.Sources { "lint.xml" }
+  def androidLintConfigPath0 = Task.Sources { "lint.xml" }
+  def androidLintConfigPath = Task {androidLintConfigPath0().headOption}
 
   // Set path to the custom `baseline.xml` file. It is usually at the root of the project
   def androidLintBaselinePath0 = Task.Sources { "lint-baseline.xml" }

--- a/example/androidlib/java/3-linting/build.mill
+++ b/example/androidlib/java/3-linting/build.mill
@@ -27,11 +27,11 @@ object app extends AndroidAppModule {
 
   // Set path to the custom `lint.xml` config file. It is usually at the root of the project
   def androidLintConfigPath0 = Task.Sources { "lint.xml" }
-  def androidLintConfigPath = Task {androidLintConfigPath0().headOption}
+  def androidLintConfigPath = Task { androidLintConfigPath0().headOption }
 
   // Set path to the custom `baseline.xml` file. It is usually at the root of the project
   def androidLintBaselinePath0 = Task.Sources { "lint-baseline.xml" }
-  def androidLintBaselinePath = Task{ androidLintBaselinePath0().headOption }
+  def androidLintBaselinePath = Task { androidLintBaselinePath0().headOption }
 
   // Set the linting report to be generated as both text and html files
   def androidLintReportFormat =

--- a/example/androidlib/java/3-linting/build.mill
+++ b/example/androidlib/java/3-linting/build.mill
@@ -26,10 +26,10 @@ object app extends AndroidAppModule {
   def androidApplicationNamespace = "com.helloworld.app"
 
   // Set path to the custom `lint.xml` config file. It is usually at the root of the project
-  def androidLintConfigPath = Task { Some(PathRef(moduleDir / "lint.xml")) }
+  def androidLintConfigPath = Task.Sources { "lint.xml" }
 
   // Set path to the custom `baseline.xml` file. It is usually at the root of the project
-  def androidLintBaselinePath = Task { Some(PathRef(moduleDir / "lint-baseline.xml")) }
+  def androidLintBaselinePath = Task.Sources { "lint-baseline.xml" }
 
   // Set the linting report to be generated as both text and html files
   def androidLintReportFormat =

--- a/example/androidlib/java/5-R8/build.mill
+++ b/example/androidlib/java/5-R8/build.mill
@@ -37,7 +37,7 @@ object app extends AndroidAppModule { // <2>
    * Never use these defaults in a production environment as they are not secure.
    * This is just for testing purposes.
    */
-  def androidReleaseKeyName: T[Option[String]] = Task { Some("releaseKey.jks") }
+  def androidReleaseKeyName: Option[String] = Some("releaseKey.jks")
   def androidReleaseKeyAlias: T[Option[String]] = Task { Some("releaseKey") }
   def androidReleaseKeyPass: T[Option[String]] = Task { Some("MillBuildTool") }
   def androidReleaseKeyStorePass: T[Option[String]] = Task { Some("MillBuildTool") }

--- a/example/androidlib/kotlin/1-hello-kotlin/build.mill
+++ b/example/androidlib/kotlin/1-hello-kotlin/build.mill
@@ -34,7 +34,7 @@ object app extends AndroidAppKotlinModule {
    * Never use these defaults in a production environment as they are not secure.
    * This is just for testing purposes.
    */
-  def androidReleaseKeyName: T[Option[String]] = Task { Some("releaseKey.jks") }
+  def androidReleaseKeyName: Option[String] = Some("releaseKey.jks")
   def androidReleaseKeyAlias: T[Option[String]] = Task { Some("releaseKey") }
   def androidReleaseKeyPass: T[Option[String]] = Task { Some("MillBuildTool") }
   def androidReleaseKeyStorePass: T[Option[String]] = Task { Some("MillBuildTool") }

--- a/example/androidlib/kotlin/4-sum-lib-kotlin/build.mill
+++ b/example/androidlib/kotlin/4-sum-lib-kotlin/build.mill
@@ -46,7 +46,7 @@ object lib extends AndroidLibKotlinModule with PublishModule {
    * Never use these defaults in a production environment as they are not secure.
    * This is just for testing purposes.
    */
-  def androidReleaseKeyName: T[Option[String]] = Task { Some("releaseKey.jks") }
+  def androidReleaseKeyName: Option[String] = Some("releaseKey.jks")
   def androidReleaseKeyAlias: T[Option[String]] = Task { Some("releaseKey") }
   def androidReleaseKeyPass: T[Option[String]] = Task { Some("MillBuildTool") }
   def androidReleaseKeyStorePass: T[Option[String]] = Task { Some("MillBuildTool") }

--- a/example/depth/sandbox/1-task/build.mill
+++ b/example/depth/sandbox/1-task/build.mill
@@ -41,6 +41,15 @@ def bannedReadTask = Task {
 error: ...Reading from build.mill not allowed during execution phase
 */
 
+def bannedReadTask2 = Task {
+  os.read(Task.workspace / "out/foo/tDestTask.json")
+}
+
+/** Usage
+> ./mill bannedReadTask2
+error: ...Reading from out/foo/tDestTask.json not allowed during execution phase
+*/
+
 // === Task `os.pwd` redirection
 // Mill also redirects the `os.pwd` property from https://github.com/com-lihaoyi/os-lib[OS-Lib],
 // such that that also points towards a running task's own `.dest/` folder

--- a/example/depth/sandbox/1-task/build.mill
+++ b/example/depth/sandbox/1-task/build.mill
@@ -23,6 +23,24 @@ object foo extends Module {
 .../out/foo/tDestTask.dest
 */
 
+def bannedWriteTask = Task {
+  os.write(Task.workspace / "banned-path", "hello")
+}
+
+/** Usage
+> ./mill bannedWriteTask
+error: ...Writing to banned-path not allowed during execution phase
+*/
+
+def bannedReadTask = Task {
+  os.read(Task.workspace / "build.mill")
+}
+
+/** Usage
+> ./mill bannedReadTask
+error: ...Reading from build.mill not allowed during execution phase
+*/
+
 // === Task `os.pwd` redirection
 // Mill also redirects the `os.pwd` property from https://github.com/com-lihaoyi/os-lib[OS-Lib],
 // such that that also points towards a running task's own `.dest/` folder

--- a/example/extending/python/4-python-libs-bundle/build.mill
+++ b/example/extending/python/4-python-libs-bundle/build.mill
@@ -41,7 +41,9 @@ trait PythonModule extends Module {
   def gatherScripts(upstream: Seq[(PathRef, PythonModule)]) = {
     for ((sourcesFolder, mod) <- upstream) {
       val destinationPath = os.pwd / mod.moduleDir.subRelativeTo(build.moduleDir)
-      os.copy.over(sourcesFolder.path / os.up, destinationPath)
+      os.checker.withValue(os.Checker.Nop) {
+        os.copy.over(sourcesFolder.path / os.up, destinationPath)
+      }
     }
   }
 

--- a/example/javalib/dependencies/3-unmanaged-jars/build.mill
+++ b/example/javalib/dependencies/3-unmanaged-jars/build.mill
@@ -3,8 +3,9 @@ package build
 import mill._, javalib._
 
 object `package` extends JavaModule {
+  def lib = Task.Source("lib")
   def unmanagedClasspath = Task {
-    if (!os.exists(moduleDir / "lib")) Seq()
-    else Seq.from(os.list(moduleDir / "lib").map(PathRef(_)))
+    if (!os.exists(lib().path)) Seq()
+    else Seq.from(os.list(lib().path).map(PathRef(_)))
   }
 }

--- a/example/javalib/publishing/3-revapi/build.mill
+++ b/example/javalib/publishing/3-revapi/build.mill
@@ -14,14 +14,12 @@ object bar extends JavaModule with RevapiModule {
     developers = Seq(Developer("lihaoyi", "Li Haoyi", "https://github.com/lihaoyi"))
   )
 
-  override def revapiConfigFiles: T[Seq[PathRef]] =
-    // add Revapi config JSON file(s)
-    Task.Sources("conf/revapi.json")
+  // add Revapi config JSON file(s)
+  override def revapiConfigFiles: T[Seq[PathRef]] = Task.Sources("conf/revapi.json")
 
-  override def revapiClasspath: T[Seq[PathRef]] = Task {
-    // add folder containing logback.xml
-    super.revapiClasspath() ++ Seq(PathRef(moduleDir / "conf"))
-  }
+  // add folder containing logback.xml
+  override def revapiClasspath = Task { super.revapiClasspath() ++ confClasspath()}
+  def confClasspath = Task.Sources("conf")
 }
 
 // This example uses the `revapi` task, provided by the `RevapiModule`, to run an

--- a/example/javalib/publishing/3-revapi/build.mill
+++ b/example/javalib/publishing/3-revapi/build.mill
@@ -18,7 +18,7 @@ object bar extends JavaModule with RevapiModule {
   override def revapiConfigFiles: T[Seq[PathRef]] = Task.Sources("conf/revapi.json")
 
   // add folder containing logback.xml
-  override def revapiClasspath = Task { super.revapiClasspath() ++ confClasspath()}
+  override def revapiClasspath = Task { super.revapiClasspath() ++ confClasspath() }
   def confClasspath = Task.Sources("conf")
 }
 

--- a/example/javascriptlib/dependencies/2-unmanaged-packages/build.mill
+++ b/example/javascriptlib/dependencies/2-unmanaged-packages/build.mill
@@ -3,7 +3,7 @@ import mill._, javascriptlib._
 
 object foo extends TypeScriptModule {
   def unmanagedDepsFolder = Task.Source("lib")
-  def unmanagedDeps = Task { Seq.from(os.list(unmanagedDepsFolder()).map(PathRef(_))) }
+  def unmanagedDeps = Task { Seq.from(os.list(unmanagedDepsFolder().path).map(PathRef(_))) }
 }
 
 // You can override `unmanagedDeps` to point to a

--- a/example/javascriptlib/dependencies/2-unmanaged-packages/build.mill
+++ b/example/javascriptlib/dependencies/2-unmanaged-packages/build.mill
@@ -3,7 +3,7 @@ import mill._, javascriptlib._
 
 object foo extends TypeScriptModule {
   def unmanagedDepsFolder = Task.Source("lib")
-  def unmanagedDeps = Task{ Seq.from(os.list(unmanagedDepsFolder()).map(PathRef(_))) }
+  def unmanagedDeps = Task { Seq.from(os.list(unmanagedDepsFolder()).map(PathRef(_))) }
 }
 
 // You can override `unmanagedDeps` to point to a

--- a/example/javascriptlib/dependencies/2-unmanaged-packages/build.mill
+++ b/example/javascriptlib/dependencies/2-unmanaged-packages/build.mill
@@ -2,7 +2,8 @@ package build
 import mill._, javascriptlib._
 
 object foo extends TypeScriptModule {
-  def unmanagedDeps = Seq.from(os.list(moduleDir / "lib").map(PathRef(_)))
+  def unmanagedDepsFolder = Task.Source("lib")
+  def unmanagedDeps = Task{ Seq.from(os.list(unmanagedDepsFolder()).map(PathRef(_))) }
 }
 
 // You can override `unmanagedDeps` to point to a

--- a/example/javascriptlib/dependencies/4-repository-config/build.mill
+++ b/example/javascriptlib/dependencies/4-repository-config/build.mill
@@ -22,10 +22,10 @@ Sorted with lodash: [a,b,e,k,l,m,o,p]
 {
   version: '4.17.21',
   resolved: 'https://registry.npmmirror.com/lodash/-/lodash-4.17.21.tgz',
-  integrity: ...,
+  integrity: ...
 ...
 }
 
 > cd out/foo/npmInstall.dest && npm config get registry
-https://registry.npmmirror.com
+https://registry.npmmirror.com...
 */

--- a/example/javascriptlib/module/1-common-config/build.mill
+++ b/example/javascriptlib/module/1-common-config/build.mill
@@ -9,7 +9,9 @@ object foo extends TypeScriptModule {
 
   def sources = Task { super.sources() ++ customSource() }
 
-  def resources = super.resources() ++ Seq(PathRef(moduleDir / "custom-resources"))
+  def customResources = Task.Sources("custom-resources")
+
+  def resources = super.resources() ++ customResources()
 
   def generatedSources = Task {
     for (name <- Seq("A", "B", "C")) os.write(

--- a/example/kotlinlib/dependencies/3-unmanaged-jars/build.mill
+++ b/example/kotlinlib/dependencies/3-unmanaged-jars/build.mill
@@ -6,8 +6,9 @@ object `package` extends KotlinModule {
 
   def kotlinVersion = "1.9.24"
 
+  def lib = Task.Source("lib")
   def unmanagedClasspath = Task {
-    if (!os.exists(moduleDir / "lib")) Seq()
-    else Seq.from(os.list(moduleDir / "lib").map(PathRef(_)))
+    if (!os.exists(lib().path)) Seq()
+    else Seq.from(os.list(lib().path).map(PathRef(_)))
   }
 }

--- a/example/kotlinlib/linting/2-ktlint/build.mill
+++ b/example/kotlinlib/linting/2-ktlint/build.mill
@@ -9,7 +9,8 @@ import kotlinlib.ktlint.KtlintModule
 object `package` extends KotlinModule with KtlintModule {
   def kotlinVersion = "1.9.24"
 
-  def ktlintConfig = Some(PathRef(Task.workspace / ".editorconfig"))
+  def ktlintConfig0 = Task.Source(Task.workspace / ".editorconfig")
+  def ktlintConfig = Some(ktlintConfig0())
 }
 
 // This example shows how to use the https://github.com/pinterest/ktlint[KtLint]

--- a/example/scalalib/dependencies/3-unmanaged-jars/build.mill
+++ b/example/scalalib/dependencies/3-unmanaged-jars/build.mill
@@ -12,9 +12,10 @@ import mill._, scalalib._
 
 object `package` extends ScalaModule {
   def scalaVersion = "2.13.8"
+  def lib = Task.Source("lib")
   def unmanagedClasspath = Task {
-    if (!os.exists(moduleDir / "lib")) Seq()
-    else Seq.from(os.list(moduleDir / "lib").map(PathRef(_)))
+    if (!os.exists(lib().path)) Seq()
+    else Seq.from(os.list(lib().path).map(PathRef(_)))
   }
 }
 

--- a/example/thirdparty/mockito/build.mill
+++ b/example/thirdparty/mockito/build.mill
@@ -46,7 +46,7 @@ trait MockitoModule extends MavenModule {
   def testFramework = "com.novocode.junit.JUnitFramework"
   def testForkArgs: T[Seq[String]] = Seq.empty[String]
 
-  def testFilteredSources: T[Seq[PathRef]] = Task { Seq.empty[PathRef] }
+  def testFilteredSources: T[Seq[os.Path]] = Task { Seq.empty[os.Path] }
 
   object test extends MavenTests {
     def moduleDeps = super.moduleDeps ++ MockitoModule.this.testModuleDeps
@@ -57,7 +57,7 @@ trait MockitoModule extends MavenModule {
       val base = super.allSourceFiles()
       val filtered = testFilteredSources().toSet
       if (filtered.isEmpty) base
-      else base.filterNot(filtered.contains)
+      else base.filterNot(pr => filtered.contains(pr.path))
     }
     def mvnDeps =
       testMvnDeps() ++
@@ -104,11 +104,11 @@ object `package` extends MockitoModule {
     super.resources() ++ Seq(PathRef(Task.dest))
   }
 
-  def testFilteredSources: T[Seq[PathRef]] = Task {
+  def testFilteredSources = Task {
     // test `add_listeners_concurrently_sanity_check` is flaky
-    Seq(PathRef(
+    Seq(
       moduleDir / "src/test/java/org/mockitousage/debugging/StubbingLookupListenerCallbackTest.java"
-    ))
+    )
   }
 
   object subprojects extends Module {

--- a/integration/failure/os-checker/src/OsCheckerTests.scala
+++ b/integration/failure/os-checker/src/OsCheckerTests.scala
@@ -13,14 +13,14 @@ object OsCheckerTests extends UtestIntegrationTestSuite {
       val sep = if (mill.constants.Util.isWindows) "\\" else "/"
       assert(res.isSuccess == false)
       assert(res.err.contains(
-        s"Writing to $workspacePath${sep}foo not allowed during resolution phase"
+        s"Writing to foo not allowed during resolution phase"
       ))
 
       val res2 = tester.eval("qux")
 
       assert(res2.isSuccess == false)
       assert(res2.err.contains(
-        s"Writing to $workspacePath${sep}file.txt not allowed during execution phase"
+        s"Writing to file.txt not allowed during execution phase"
       ))
 
       tester.modifyFile(workspacePath / "build.mill", _.replace("if (false)", "if (true)"))
@@ -28,7 +28,7 @@ object OsCheckerTests extends UtestIntegrationTestSuite {
 
       assert(res3.isSuccess == false)
       assert(res3.err.contains(
-        s"Writing to $workspacePath not allowed during resolution phase"
+        s"Writing to  not allowed during resolution phase"
       ))
 
     }

--- a/libs/androidlib/src/mill/androidlib/AndroidAppKotlinModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppKotlinModule.scala
@@ -27,12 +27,14 @@ import mill.T
 @mill.api.experimental
 trait AndroidAppKotlinModule extends AndroidAppModule with AndroidKotlinModule { outer =>
 
+  def kotlinSources = Task.Sources("src/main/kotlin")
   override def sources: T[Seq[PathRef]] =
-    super[AndroidAppModule].sources() :+ PathRef(moduleDir / "src/main/kotlin")
+    super[AndroidAppModule].sources() ++ kotlinSources()
 
   trait AndroidAppKotlinTests extends AndroidAppTests with KotlinTests {
+    def kotlinSources = Task.Sources("src/test/kotlin")
     override def sources: T[Seq[PathRef]] =
-      super[AndroidAppTests].sources() ++ Seq(PathRef(outer.moduleDir / "src/test/kotlin"))
+      super[AndroidAppTests].sources() ++ kotlinSources()
   }
 
   trait AndroidAppKotlinInstrumentedTests extends AndroidAppKotlinModule
@@ -42,9 +44,8 @@ trait AndroidAppKotlinModule extends AndroidAppModule with AndroidKotlinModule {
     override final def androidSdkModule = outer.androidSdkModule
 
     override def sources: T[Seq[PathRef]] =
-      super[AndroidAppInstrumentedTests].sources() :+ PathRef(
-        outer.moduleDir / "src/androidTest/kotlin"
-      )
+      def kotlinSources = Task.Sources("src/androidTest/kotlin")
+      super[AndroidAppInstrumentedTests].sources() ++ kotlinSources()
   }
 
   trait AndroidAppKotlinScreenshotTests extends AndroidAppKotlinModule with TestModule with Junit5 {

--- a/libs/androidlib/src/mill/androidlib/AndroidAppKotlinModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppKotlinModule.scala
@@ -43,8 +43,8 @@ trait AndroidAppKotlinModule extends AndroidAppModule with AndroidKotlinModule {
     override final def kotlinVersion = outer.kotlinVersion
     override final def androidSdkModule = outer.androidSdkModule
 
+    def kotlinSources = Task.Sources("src/androidTest/kotlin")
     override def sources: T[Seq[PathRef]] =
-      def kotlinSources = Task.Sources("src/androidTest/kotlin")
       super[AndroidAppInstrumentedTests].sources() ++ kotlinSources()
   }
 

--- a/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
@@ -833,8 +833,9 @@ trait AndroidAppModule extends AndroidModule { outer =>
       pf => androidProguardPath / pf
     }
     val userProguardFiles = proguardFilesFromReleaseSettings.localFiles
-
-    (defaultProguardFile.toSeq ++ userProguardFiles).map(PathRef(_))
+    os.checker.withValue(os.Checker.Nop) {
+      (defaultProguardFile.toSeq ++ userProguardFiles).map(PathRef(_))
+    }
   }
 
   /**

--- a/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
@@ -363,9 +363,7 @@ trait AndroidAppModule extends AndroidModule { outer =>
   /**
    * Name of the release keystore file. Default is not set.
    */
-  def androidReleaseKeyName: T[Option[String]] = Task {
-    None
-  }
+  def androidReleaseKeyName: Option[String] = None
 
   /**
    * Password for the release key. Default is not set.
@@ -669,8 +667,9 @@ trait AndroidAppModule extends AndroidModule { outer =>
    * Default os.Path to the keystore file, derived from `androidReleaseKeyName()`.
    * Users can customize the keystore file name to change this path.
    */
-  def androidReleaseKeyPath: T[Option[PathRef]] = Task {
-    androidReleaseKeyName().map(name => PathRef(moduleDir / name))
+  def androidReleaseKeyPath: T[Seq[PathRef]] = {
+    val subPaths = androidReleaseKeyName.map(os.sub / _).toSeq
+    Task.Sources(subPaths: _*)
   }
 
   /*
@@ -716,12 +715,8 @@ trait AndroidAppModule extends AndroidModule { outer =>
   }
 
   protected def androidKeystore: T[PathRef] = Task {
-    val pathRef = if (androidIsDebug()) {
-      androidDebugKeystore()
-    } else {
-      androidReleaseKeyPath().get
-    }
-    pathRef
+    if (androidIsDebug()) androidDebugKeystore()
+    else androidReleaseKeyPath().head
   }
 
   // TODO consider managing with proguard and/or r8
@@ -1096,10 +1091,10 @@ trait AndroidAppModule extends AndroidModule { outer =>
     override def androidApplicationNamespace: String = outer.androidApplicationNamespace
 
     override def androidReleaseKeyAlias: T[Option[String]] = outer.androidReleaseKeyAlias()
-    override def androidReleaseKeyName: T[Option[String]] = outer.androidReleaseKeyName()
+    override def androidReleaseKeyName: T[Option[String]] = outer.androidReleaseKeyName
     override def androidReleaseKeyPass: T[Option[String]] = outer.androidReleaseKeyPass()
     override def androidReleaseKeyStorePass: T[Option[String]] = outer.androidReleaseKeyStorePass()
-    override def androidReleaseKeyPath: T[Option[PathRef]] = outer.androidReleaseKeyPath()
+    override def androidReleaseKeyPath: T[Seq[PathRef]] = outer.androidReleaseKeyPath()
 
     override def androidEmulatorPort: String = outer.androidEmulatorPort
 

--- a/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
@@ -1091,7 +1091,7 @@ trait AndroidAppModule extends AndroidModule { outer =>
     override def androidApplicationNamespace: String = outer.androidApplicationNamespace
 
     override def androidReleaseKeyAlias: T[Option[String]] = outer.androidReleaseKeyAlias()
-    override def androidReleaseKeyName: T[Option[String]] = outer.androidReleaseKeyName
+    override def androidReleaseKeyName: Option[String] = outer.androidReleaseKeyName
     override def androidReleaseKeyPass: T[Option[String]] = outer.androidReleaseKeyPass()
     override def androidReleaseKeyStorePass: T[Option[String]] = outer.androidReleaseKeyStorePass()
     override def androidReleaseKeyPath: T[Seq[PathRef]] = outer.androidReleaseKeyPath()

--- a/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
@@ -141,8 +141,10 @@ trait AndroidAppModule extends AndroidModule { outer =>
    */
   override def resources: T[Seq[PathRef]] = Task {
     val libResFolders = androidUnpackArchives().flatMap(_.resources)
-    libResFolders :+ PathRef(moduleDir / "src/main/res")
+    libResFolders :+ resFolder()
   }
+
+  def resFolder = Task.Source(moduleDir / "src/main/res")
 
   @internal
   override def bspCompileClasspath = Task.Anon { (ev: EvaluatorApi) =>

--- a/libs/androidlib/src/mill/androidlib/AndroidLibKotlinModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidLibKotlinModule.scala
@@ -1,12 +1,12 @@
 package mill.androidlib
 
-import mill.T
+import mill.{T, Task}
 import mill.define.PathRef
 
 trait AndroidLibKotlinModule extends AndroidLibModule with AndroidKotlinModule { outer =>
 
-  override def sources: T[Seq[PathRef]] =
-    super[AndroidLibModule].sources() :+ PathRef(moduleDir / "src/main/kotlin")
+  def kotlinSources = Task.Sources("src/main/kotlin")
+  override def sources: T[Seq[PathRef]] = super[AndroidLibModule].sources() ++ kotlinSources()
 
   trait AndroidLibKotlinTests extends AndroidLibTests with KotlinTests {
     override def sources: T[Seq[PathRef]] =

--- a/libs/javascriptlib/src/mill/javascriptlib/TypeScriptModule.scala
+++ b/libs/javascriptlib/src/mill/javascriptlib/TypeScriptModule.scala
@@ -162,7 +162,9 @@ trait TypeScriptModule extends Module { outer =>
         val destination = T.dest / relativePath
 
         if (os.isDir(path)) os.makeDir.all(destination)
-        else os.copy.over(path, destination)
+        else os.checker.withValue(os.Checker.Nop) {
+          os.copy.over(path, destination)
+        }
       }
 
     object IsSrcDirectory {

--- a/libs/javascriptlib/src/mill/javascriptlib/TypeScriptModule.scala
+++ b/libs/javascriptlib/src/mill/javascriptlib/TypeScriptModule.scala
@@ -88,8 +88,9 @@ trait TypeScriptModule extends Module { outer =>
     )
   }
 
+  def npmRc = Task.Source(Task.workspace / ".npmrc")
   def npmInstall: T[PathRef] = Task {
-    Try(os.copy.over(Task.workspace / ".npmrc", Task.dest / ".npmrc")).getOrElse(())
+    if (os.exists(npmRc().path)) os.copy.over(npmRc().path, Task.dest / ".npmrc")
 
     // build package.json with
     mkPackageJson()

--- a/libs/javascriptlib/src/mill/javascriptlib/TypeScriptModule.scala
+++ b/libs/javascriptlib/src/mill/javascriptlib/TypeScriptModule.scala
@@ -11,6 +11,8 @@ trait TypeScriptModule extends Module { outer =>
   // custom module names
   def moduleName: String = super.toString
 
+  def moduleDirSources = Task.Sources(moduleDir)
+
   override def toString: String = moduleName
 
   def moduleDeps: Seq[TypeScriptModule] = Nil
@@ -110,7 +112,7 @@ trait TypeScriptModule extends Module { outer =>
   // sources :)
   def sources: T[Seq[PathRef]] = Task.Sources("src")
 
-  def resources: T[Seq[PathRef]] = Task { Seq(PathRef(moduleDir / "resources")) }
+  def resources: T[Seq[PathRef]] = Task.Sources("resources")
 
   def generatedSources: T[Seq[PathRef]] = Task { Seq[PathRef]() }
 

--- a/libs/kotlinlib/src/mill/kotlinlib/detekt/DetektModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/detekt/DetektModule.scala
@@ -70,9 +70,7 @@ trait DetektModule extends KotlinModule {
   /**
    * Detekt configuration file. Defaults to `detekt-config.yml`.
    */
-  def detektConfig: T[PathRef] = Task {
-    PathRef(Task.workspace / "detekt-config.yml")
-  }
+  def detektConfig: T[PathRef] = Task.Source(Task.workspace / "detekt-config.yml")
 
   /**
    * Detekt version.

--- a/libs/kotlinlib/src/mill/kotlinlib/ktlint/KtlintModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/ktlint/KtlintModule.scala
@@ -36,12 +36,12 @@ trait KtlintModule extends JavaModule {
     )
   }
 
+
+  def ktlintConfig0 = Task.Source(Task.workspace / ".editorconfig")
   /**
    * Ktlint configuration file.
    */
-  def ktlintConfig: T[Option[PathRef]] = Task {
-    Some(PathRef(Task.workspace / ".editorconfig"))
-  }
+  def ktlintConfig: T[Option[PathRef]] = Task { Some(ktlintConfig0()) }
 
   /**
    * Ktlint version.

--- a/libs/kotlinlib/src/mill/kotlinlib/ktlint/KtlintModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/ktlint/KtlintModule.scala
@@ -36,8 +36,8 @@ trait KtlintModule extends JavaModule {
     )
   }
 
-
   def ktlintConfig0 = Task.Source(Task.workspace / ".editorconfig")
+
   /**
    * Ktlint configuration file.
    */

--- a/libs/main/src/mill/main/VisualizeModule.scala
+++ b/libs/main/src/mill/main/VisualizeModule.scala
@@ -171,7 +171,9 @@ object VisualizeModule extends ExternalModule {
             stdout = os.Inherit
           )
 
-          os.list(dest).sorted.map(PathRef(_))
+          os.checker.withValue(os.Checker.Nop) {
+            os.list(dest).sorted.map(PathRef(_))
+          }
         }
         out.put(res)
       }

--- a/libs/scalalib/src/mill/javalib/checkstyle/CheckstyleModule.scala
+++ b/libs/scalalib/src/mill/javalib/checkstyle/CheckstyleModule.scala
@@ -91,8 +91,8 @@ trait CheckstyleModule extends JavaModule {
   /**
    * Checkstyle configuration file. Defaults to `checkstyle-config.xml`.
    */
-  def checkstyleConfig: T[PathRef] = Task {
-    PathRef(Task.workspace / "checkstyle-config.xml")
+  def checkstyleConfig: T[PathRef] = Task.Source {
+    Task.workspace / "checkstyle-config.xml"
   }
 
   /**

--- a/runner/meta/src/mill/runner/meta/CodeGen.scala
+++ b/runner/meta/src/mill/runner/meta/CodeGen.scala
@@ -185,7 +185,7 @@ object CodeGen {
          |$importSiblingScripts
          |$prelude
          |object wrapper_object_getter {
-         |  def value = os.checker.withValue(mill.define.internal.ResolveChecker){ $wrapperObjectName }
+         |  def value = os.checker.withValue(mill.define.internal.ResolveChecker(mill.define.WorkspaceRoot.workspaceRoot)){ $wrapperObjectName }
          |}
          |object $wrapperObjectName extends $wrapperObjectName {
          |  ${childAliases.linesWithSeparators.mkString("  ")}


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/5023, the last bullet of https://github.com/com-lihaoyi/mill/issues/3746 we had punted on earlier

With this PR:

1. A normal `Task` can only read from sub-paths of `PathRef`s returned by the upstream tasks it depends on. 
2. Like the write restrictions implemented earlier, we do not restrict `Command`s (since those are expected to do arbitrary side-effecting things), 
3. For reads we are also lenient for `InputImpl`s and their sub-types `SourceImpl`s and `SourcesImpl`s (since those are the roots of the build graph and so are expected to read from arbitrary files)

To implement this, we need some way to traverse the return value of upstream tasks. This is done by instrumenting the `PathRef.jsonFormatter` that is called during the recursive serialization/deserialization of task return values during cache saves and loads. There is no other place for us to put this logic unless we add a second typeclass that task return values would have to implement, so this hackery piggy-backing on JSON serialization and de-serialization will have to do for now

Added a single example test case to make sure this catches things, relying on the bulk of the existing test suite to ensure this doesn't break things. Also had to fix a bunch of existing violations of this rule, mostly by adjusting the code to use the proper pattern, but for some violations I just grandfathered them in for now. Definitely seems like a good guardrail to have given how often we screw it up ourselves in Mill's own repo

For now this only limits reads during the _execution_ phase, and does not limit reads during the _resolution_ phase. That can come in a follow up