### PR TITLE
Re-implement cached JVM existence check in Mill client

### DIFF
--- a/runner/client/src/mill/runner/client/MillProcessLauncher.java
+++ b/runner/client/src/mill/runner/client/MillProcessLauncher.java
@@ -11,6 +11,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 import mill.client.ClientUtil;
@@ -174,8 +175,14 @@ public class MillProcessLauncher {
 
     if (jvmId != null) {
       final String jvmIdFinal = jvmId;
-      javaHome = cachedComputedValue("java-home", jvmId, () ->
-          new String[] {CoursierClient.resolveJavaHome(jvmIdFinal).getAbsolutePath()})[0];
+      javaHome = cachedComputedValue0(
+          "java-home",
+          jvmId,
+          () -> new String[] {CoursierClient.resolveJavaHome(jvmIdFinal).getAbsolutePath()},
+          // Make sure we check to see if the saved java home exists before using
+          // it, since it may have been since uninstalled, or the `out/` folder
+          // may have been transferred to a different machine
+          arr -> Files.exists(Paths.get(arr[0])))[0];
     }
 
     if (javaHome == null || javaHome.isEmpty()) javaHome = System.getProperty("java.home");
@@ -229,6 +236,11 @@ public class MillProcessLauncher {
   }
 
   static String[] cachedComputedValue(String name, String key, Supplier<String[]> block) {
+    return cachedComputedValue0(name, key, block, arr -> true);
+  }
+
+  static String[] cachedComputedValue0(
+      String name, String key, Supplier<String[]> block, Function<String[], Boolean> validate) {
     try {
       Path cacheFile = Paths.get(".").resolve(out).resolve("mill-" + name);
       String[] value = null;
@@ -239,6 +251,8 @@ public class MillProcessLauncher {
           for (int i = 0; i < value.length; i++) value[i] = Escaping.unliteralize(value[i]);
         }
       }
+
+      if (!validate.apply(value)) value = null;
 
       if (value == null) {
         value = block.get();

--- a/runner/client/src/mill/runner/client/MillProcessLauncher.java
+++ b/runner/client/src/mill/runner/client/MillProcessLauncher.java
@@ -252,7 +252,7 @@ public class MillProcessLauncher {
         }
       }
 
-      if (!validate.apply(value)) value = null;
+      if (value != null && !validate.apply(value)) value = null;
 
       if (value == null) {
         value = block.get();


### PR DESCRIPTION
This was lost in the churn of https://github.com/com-lihaoyi/mill/pull/5025, and re-implementing it should fix the re-bootstrapping problems we hit in https://github.com/com-lihaoyi/mill/pull/5050