### PR TITLE
Add bootstrapped runner jars existence check

### DIFF
--- a/runner/client/src/mill/runner/client/MillProcessLauncher.java
+++ b/runner/client/src/mill/runner/client/MillProcessLauncher.java
@@ -228,8 +228,11 @@ public class MillProcessLauncher {
 
     vmOptions.add("-XX:+HeapDumpOnOutOfMemoryError");
     vmOptions.add("-cp");
-    String[] runnerClasspath = cachedComputedValue(
-        "resolve-runner", BuildInfo.millVersion, () -> CoursierClient.resolveMillRunner());
+    String[] runnerClasspath = cachedComputedValue0(
+        "resolve-runner",
+        BuildInfo.millVersion,
+        () -> CoursierClient.resolveMillRunner(),
+        arr -> Arrays.stream(arr).allMatch(s -> Files.exists(Paths.get(s))));
     vmOptions.add(String.join(File.pathSeparator, runnerClasspath));
 
     return vmOptions;


### PR DESCRIPTION
Same as https://github.com/com-lihaoyi/mill/pull/5051 but for the runner jars instead of the JVM itself. Similarly, we want to make sure the cached metadata refers to files that actually exist, and if not we should re-run the resolution