### PR TITLE
Third party example for android native: endless-tunnel

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -182,6 +182,11 @@ jobs:
             install-sbt: false
 
           - java-version: 17
+            millargs: "'example.thirdparty[android-endless-tunnel].local.server'"
+            install-android-sdk: true
+            install-sbt: false
+
+          - java-version: 17
             millargs: "'{example,integration}.migrating.__.local.server'"
             install-android-sdk: false
             install-sbt: true

--- a/example/package.mill
+++ b/example/package.mill
@@ -316,7 +316,8 @@ $txt
     "gatling" -> ("gatling/gatling", "3870fda86e6bca005fbd53108c60a65db36279b6"),
     "arrow" -> ("arrow-kt/arrow", "bc9bf92cc98e01c21bdd2bf8640cf7db0f97204a"),
     "ollama-js" -> ("ollama/ollama-js", "99293abe2c7c27ce7e76e8b4a98cae948f00058d"),
-    "androidtodo" -> ("android/architecture-samples", "b3437ab428f6fd91804b28801650d590ff52971c")
+    "androidtodo" -> ("android/architecture-samples", "b3437ab428f6fd91804b28801650d590ff52971c"),
+    "android-endless-tunnel" -> ("android/ndk-samples", "46ac919196faf1efcfe8018a0dcc79d4f8fbeca7")
   )
   object thirdparty extends Cross[ThirdPartyModule](build.listIn(moduleDir / "thirdparty"))
   trait ThirdPartyModule extends ExampleCrossModule {

--- a/example/thirdparty/android-endless-tunnel/build.mill
+++ b/example/thirdparty/android-endless-tunnel/build.mill
@@ -1,0 +1,88 @@
+// Native libraries are libraries written in C/C++  that are compiled to android code
+// and are used in the app. They are usually used for performance reasons or to use
+// libraries that are not available in Java/Kotlin.
+// This example shows how to use native libraries in the app.
+// The native library is a simple C++ library that returns a string "Hello from C++"
+// and is used in the app to show a toast with the string. In my example i used also
+// one of the core C/C++  libraires that can be used in the android and are already given ( <android/log.h> ).
+// There is a list of the core C/C++ libraries that can be used in the android here:
+// https://developer.android.com/ndk/reference
+
+package build
+
+import mill._, androidlib._, scalalib._
+
+object androidSdkModule0 extends AndroidSdkModule {
+  def buildToolsVersion = "35.0.0"
+}
+
+object `endless-tunnel` extends mill.define.Module {
+  object app extends AndroidNativeAppModule {
+
+    def androidSdkModule = mill.define.ModuleRef(androidSdkModule0)
+
+    def androidMinSdk = 19
+
+    def androidCompileSdk = 35
+
+    def androidApplicationId = "com.google.sample.tunnel"
+
+    def androidApplicationNamespace = "com.google.sample.tunnel"
+
+    override def androidNativeLibName: T[String] = "libgame"
+
+    /**
+     * Configuration for ReleaseKey
+     * WARNING: Replace these default values with secure and private credentials before using in production.
+     * Never use these defaults in a production environment as they are not secure.
+     * This is just for testing purposes.
+     */
+    def androidReleaseKeyAlias: T[Option[String]] = Task {
+      Some("releaseKey")
+    }
+
+    def androidReleaseKeyPass: T[Option[String]] = Task {
+      Some("MillBuildTool")
+    }
+
+    def androidReleaseKeyStorePass: T[Option[String]] = Task {
+      Some("MillBuildTool")
+    }
+
+    override def androidVirtualDeviceIdentifier: String = "cpp-test"
+
+    override def androidCMakeExtraArgs: T[Seq[String]] =
+      super.androidCMakeExtraArgs() ++ Seq("-DANDROID_STL=c++_static")
+
+  }
+}
+
+/** Usage
+
+> ./mill show endless-tunnel.app.androidApk
+".../out/endless-tunnel/app/androidApk.dest/app.apk"
+
+> ./mill show endless-tunnel.app.createAndroidVirtualDevice
+...Name: cpp-test, DeviceId: medium_phone...
+
+> ./mill show endless-tunnel.app.startAndroidEmulator
+
+> ./mill show endless-tunnel.app.androidInstall
+...All files should be loaded. Notifying the device...
+
+> ./mill show endless-tunnel.app.androidRun --activity android.app.NativeActivity
+[
+  "Starting: Intent { cmp=com.google.sample.tunnel/android.app.NativeActivity }",
+  "Status: ok",
+  "LaunchState: COLD",
+  "Activity: com.google.sample.tunnel/android.app.NativeActivity",
+  "TotalTime: ...",
+  "WaitTime: ...",
+  "Complete"
+]
+
+> ./mill show endless-tunnel.app.stopAndroidEmulator
+
+> ./mill show endless-tunnel.app.deleteAndroidVirtualDevice
+
+*/

--- a/example/thirdparty/android-endless-tunnel/build.mill
+++ b/example/thirdparty/android-endless-tunnel/build.mill
@@ -1,12 +1,5 @@
-// Native libraries are libraries written in C/C++  that are compiled to android code
-// and are used in the app. They are usually used for performance reasons or to use
-// libraries that are not available in Java/Kotlin.
-// This example shows how to use native libraries in the app.
-// The native library is a simple C++ library that returns a string "Hello from C++"
-// and is used in the app to show a toast with the string. In my example i used also
-// one of the core C/C++  libraires that can be used in the android and are already given ( <android/log.h> ).
-// There is a list of the core C/C++ libraries that can be used in the android here:
-// https://developer.android.com/ndk/reference
+// This is how endless-tunnel from android ndk-sample can be built with mill.
+// The original code is in https://github.com/android/ndk-samples/tree/main/endless-tunnel
 
 package build
 

--- a/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
@@ -666,7 +666,7 @@ trait AndroidAppModule extends AndroidModule { outer =>
     androidInstallTask()
   }
 
-  def androidInstallTask = Task.Anon {
+  def androidInstallTask: Task[String] = Task.Anon {
     val emulator = runningEmulator()
 
     os.call(
@@ -674,6 +674,33 @@ trait AndroidAppModule extends AndroidModule { outer =>
     )
 
     emulator
+  }
+
+  /**
+   * Run your application by providing the activity.
+   *
+   * E.g. `com.package.name.ActivityName`
+   *
+   * See also [[https://developer.android.com/tools/adb#am]] and [[https://developer.android.com/tools/adb#IntentSpec]]
+   * @param activity
+   * @return
+   */
+  def androidRun(activity: String): Command[Vector[String]] = Task.Command(exclusive = true) {
+    val emulator = runningEmulator()
+
+    os.call(
+      (
+        androidSdkModule().adbPath().path,
+        "-s",
+        emulator,
+        "shell",
+        "am",
+        "start",
+        "-n",
+        s"${androidApplicationNamespace}/${activity}",
+        "-W"
+      )
+    ).out.lines()
   }
 
   /**


### PR DESCRIPTION
Following the work on https://github.com/com-lihaoyi/mill/pull/5013 I've added a third party example for Android native. I included an `androidRun` command as a testing motivation . (which we can connect to run and subsequently to IDE BSP run in the future) 

The example increases confidence on building android native apps with mill and it is another milestone for Mill's android support .

https://github.com/user-attachments/assets/a442a185-4b45-4342-9d78-3c1fe726873b

