### PR TITLE
fix: Use root qualifier in Discover macro

### DIFF
--- a/main/define/src/mill/define/Discover.scala
+++ b/main/define/src/mill/define/Discover.scala
@@ -152,7 +152,7 @@ object Discover {
       }
 
       c.Expr[Discover](
-        q"import mill.api.JsonFormatters._; _root_.mill.define.Discover.apply2(_root_.scala.collection.immutable.Map(..$mapping))"
+        q"import _root_.mill.api.JsonFormatters._; _root_.mill.define.Discover.apply2(_root_.scala.collection.immutable.Map(..$mapping))"
       )
     }
   }


### PR DESCRIPTION
without this in case there is another mill package (which is often the case for [plugins](https://github.com/disneystreaming/smithy4s/blob/series/0.18/modules/mill-codegen-plugin/src/smithy4s/codegen/mill/Smithy4sModule.scala#L17)) following error occurs during macro expansion:
```
[error] [millCodegenPlugin0_12] /home/kghost/workspace/smithy4s/modules/mill-codegen-plugin/src/smithy4s/codegen/LSP.scala:30:32: object define is not a member of package smithy4s.codegen.mill
[error] [millCodegenPlugin0_12]   lazy val millDiscover = mill.define.Discover[this.type]
[error] [millCodegenPlugin0_12]                                ^
[error] [millCodegenPlugin0_12] one error found
[error] [millCodegenPlugin0_12] (millCodegenPlugin0_12 / Compile / compileIncremental) Compilation failed
[error] Total time: 1 s, completed May 4, 2025, 12:34:05 AM
```