### PR TITLE
Simplify handling of `MillBuildRootModule` in `CodeGen`

### DIFF
--- a/example/extending/metabuild/4-meta-build/mill-build/build.mill
+++ b/example/extending/metabuild/4-meta-build/mill-build/build.mill
@@ -1,5 +1,6 @@
 package build
 import mill._, scalalib._
+import mill.runner.meta.MillBuildRootModule
 
 object `package` extends MillBuildRootModule {
   val scalatagsVersion = "0.13.1"

--- a/example/extending/metabuild/5-meta-shared-sources/mill-build/build.mill
+++ b/example/extending/metabuild/5-meta-shared-sources/mill-build/build.mill
@@ -1,4 +1,5 @@
 package build
 import mill._
+import mill.runner.meta.MillBuildRootModule
 
 object `package` extends MillBuildRootModule

--- a/integration/failure/root-module-compile-error/src/RootModuleCompileErrorTests.scala
+++ b/integration/failure/root-module-compile-error/src/RootModuleCompileErrorTests.scala
@@ -26,13 +26,13 @@ object RootModuleCompileErrorTests extends UtestIntegrationTestSuite {
 
       locally {
         // For now these error messages still show generated/mangled code; not ideal, but it'll do
-        assert(res.err.replace('\\', '/').contains("""foo/package.mill:6:85"""))
+        assert(res.err.replace('\\', '/').contains("""foo/package.mill:6:92"""))
         assert(res.err.contains("""Not found: type UnknownFooModule"""))
         assert(res.err.contains(
-          """abstract class package_  extends mill.main.SubfolderModule(build.millDiscover) with UnknownFooModule {"""
+          """abstract class package_  extends _root_.mill.main.SubfolderModule(build.millDiscover) with UnknownFooModule {"""
         ))
         assert(res.err.contains(
-          """                                                                ^^^^^^^^^^^^^^^^"""
+          """                                                                                           ^^^^^^^^^^^^^^^^"""
         ))
       }
 

--- a/integration/feature/scala-3-syntax/resources/mill-build/build.mill
+++ b/integration/feature/scala-3-syntax/resources/mill-build/build.mill
@@ -3,7 +3,7 @@ package build
 import mill.*
 import mill.scalalib.*
 
-object `package` extends MillBuildRootModule:
+object `package` extends mill.runner.meta.MillBuildRootModule:
   def mvnDeps = Seq(
     mvn"org.scala-lang::toolkit:0.5.0"
   )

--- a/integration/ide/build-classpath-contents/resources/mill-build/build.mill
+++ b/integration/ide/build-classpath-contents/resources/mill-build/build.mill
@@ -1,5 +1,6 @@
 package build
 import mill.*
 import mill.scalalib.*
+import mill.runner.meta.MillBuildRootModule
 
 object `package` extends MillBuildRootModule

--- a/integration/ide/gen-idea/resources/extended/mill-build/build.mill
+++ b/integration/ide/gen-idea/resources/extended/mill-build/build.mill
@@ -1,5 +1,6 @@
 import mill._
 import mill.scalalib._
+import mill.runner.meta.MillBuildRootModule
 
 object `package` extends MillBuildRootModule {
   def mvnDeps = Seq(mvn"org.scalameta::munit:0.7.29")

--- a/integration/invalidation/multi-level-editing/resources/mill-build/build.mill
+++ b/integration/invalidation/multi-level-editing/resources/mill-build/build.mill
@@ -1,6 +1,7 @@
 package build
 
 import mill._, scalalib._
+import mill.runner.meta.MillBuildRootModule
 
 object `package` extends MillBuildRootModule {
   def mvnDeps = Seq(mvn"com.lihaoyi::scalatags:${constant.MetaConstant.scalatagsVersion}")

--- a/integration/invalidation/multi-level-editing/resources/mill-build/mill-build/build.mill
+++ b/integration/invalidation/multi-level-editing/resources/mill-build/mill-build/build.mill
@@ -1,6 +1,7 @@
 package build
 // build.mill
 import mill._, scalalib._
+import mill.runner.meta.MillBuildRootModule
 
 object `package` extends MillBuildRootModule {
   def generatedSources = Task {

--- a/runner/meta/src/mill/runner/meta/CodeGen.scala
+++ b/runner/meta/src/mill/runner/meta/CodeGen.scala
@@ -53,15 +53,15 @@ object CodeGen {
       def pkgSelector0(pre: Option[String], s: Option[String]) =
         (pre ++ pkgSegments ++ s).map(backtickWrap).mkString(".")
       def pkgSelector2(s: Option[String]) = s"_root_.${pkgSelector0(Some(globalPackagePrefix), s)}"
-      val (childSels, childAliases0) = childNames
+      val childAliases0 = childNames
         .map { c =>
           // Dummy references to sub-modules. Just used as metadata for the discover and
           // resolve logic to traverse, cannot actually be evaluated and used
           val comment = "// subfolder module reference"
           val lhs = backtickWrap(c)
           val rhs = s"${pkgSelector2(Some(c))}.package_"
-          (rhs, s"final lazy val $lhs: $rhs.type = $rhs $comment")
-        }.unzip
+          s"final lazy val $lhs: $rhs.type = $rhs $comment"
+        }
       val childAliases = childAliases0.mkString("\n")
 
       val pkg = pkgSelector0(Some(globalPackagePrefix), None)

--- a/runner/meta/src/mill/runner/meta/CodeGen.scala
+++ b/runner/meta/src/mill/runner/meta/CodeGen.scala
@@ -239,8 +239,7 @@ object CodeGen {
       scriptFolderPath: os.Path,
       segments: Seq[String]
   ): String = {
-    s"""object MillMiscInfo
-       |extends mill.main.SubfolderModule.Info(
+    s"""object MillMiscInfo extends mill.main.SubfolderModule.Info(
        |  os.Path(${literalize(scriptFolderPath.toString)}),
        |  _root_.scala.Seq(${segments.map(pprint.Util.literalize(_)).mkString(", ")})
        |)

--- a/runner/meta/src/mill/runner/meta/CodeGen.scala
+++ b/runner/meta/src/mill/runner/meta/CodeGen.scala
@@ -182,6 +182,7 @@ object CodeGen {
     val newParent =
       if (segments.isEmpty) "_root_.mill.main.MainRootModule"
       else "_root_.mill.main.SubfolderModule(build.millDiscover)"
+
     objectData.find(o => o.name.text == "`package`") match {
       case Some(objectData) =>
 

--- a/runner/meta/src/mill/runner/meta/CodeGen.scala
+++ b/runner/meta/src/mill/runner/meta/CodeGen.scala
@@ -62,7 +62,7 @@ object CodeGen {
           val rhs = s"${pkgSelector2(Some(c))}.package_"
           s"final lazy val $lhs: $rhs.type = $rhs $comment"
         }
-      val childAliases = childAliases0.mkString("\n")
+        .mkString("\n")
 
       val pkg = pkgSelector0(Some(globalPackagePrefix), None)
 

--- a/runner/meta/src/mill/runner/meta/MillBuildRootModule.scala
+++ b/runner/meta/src/mill/runner/meta/MillBuildRootModule.scala
@@ -22,10 +22,10 @@ import scala.jdk.CollectionConverters.ListHasAsScala
  * calls within the scripts.
  */
 @internal
-class MillBuildRootModule()(implicit
+trait MillBuildRootModule()(implicit
     rootModuleInfo: RootModule0.Info,
     scalaCompilerResolver: ScalaCompilerWorker.Resolver
-) extends mill.main.MainRootModule() with ScalaModule {
+) extends ScalaModule {
   override def bspDisplayName0: String = rootModuleInfo
     .projectRoot
     .relativeTo(rootModuleInfo.topLevelProjectRoot)
@@ -296,7 +296,7 @@ object MillBuildRootModule {
   class BootstrapModule()(implicit
       rootModuleInfo: RootModule0.Info,
       scalaCompilerResolver: ScalaCompilerWorker.Resolver
-  ) extends MillBuildRootModule() {
+  ) extends mill.main.MainRootModule() with MillBuildRootModule() {
     override lazy val millDiscover = Discover[this.type]
   }
 


### PR DESCRIPTION
* Now that we are on Scala 3, `MillBuildRootModule` can be a `trait` like most other modules and still take implicit parameters

* That allows us to remove the special casing of `MillBuildRootModule` in codegen, since it can now stack with the default `MainRootModule` that non-meta-build root modules inherit from

* We can also remove the synthetic `import _root_.mill.runner.meta.MillBuildRootModule` that we were previously injecting into the scope, since now it is just another stackable trait like any other

* Also tidied up `CodeGen.scala` a bit to reduce duplication