### PR TITLE
Use a single Mill server process

### DIFF
--- a/core/constants/src/mill/constants/OutFiles.java
+++ b/core/constants/src/mill/constants/OutFiles.java
@@ -60,7 +60,7 @@ public class OutFiles {
   /**
    * Lock file used for exclusive access to the Mill output directory
    */
-  public static final String millLock = "mill-lock";
+  public static final String millOutLock = "mill-out-lock";
 
   /**
    * Any active Mill command that is currently run, for debugging purposes

--- a/core/constants/src/mill/constants/ProxyStream.java
+++ b/core/constants/src/mill/constants/ProxyStream.java
@@ -43,6 +43,7 @@ public class ProxyStream {
       out.flush();
     }
   }
+
   public static void sendHeartbeat(OutputStream out) throws IOException {
     synchronized (out) {
       out.write(ProxyStream.HEARTBEAT);

--- a/core/constants/src/mill/constants/ServerFiles.java
+++ b/core/constants/src/mill/constants/ServerFiles.java
@@ -49,12 +49,6 @@ public class ServerFiles {
   public static final String serverLog = "server.log";
 
   /**
-   * File that the client writes to pass the arguments, environment variables,
-   * and other necessary metadata to the Mill server to kick off a run
-   */
-  public static final String runArgs = "runArgs";
-
-  /**
    * File the server writes to pass the exit code of a completed run back to the
    * client
    */

--- a/core/constants/src/mill/constants/ServerFiles.java
+++ b/core/constants/src/mill/constants/ServerFiles.java
@@ -20,7 +20,7 @@ public class ServerFiles {
    * folder. If multiple servers are spawned in the same folder, only one takes
    * the lock and the others fail to do so and terminate immediately.
    */
-  public static final String processLock = "processLock";
+  public static final String serverLock = "serverLock";
 
   /**
    * The port used to connect between server and client

--- a/example/fundamentals/out-dir/1-out-files/build.mill
+++ b/example/fundamentals/out-dir/1-out-files/build.mill
@@ -29,7 +29,7 @@ out/mill-build/...
 out/mill-profile.json
 out/mill-runner-state.json
 out/mill-dependency-tree.json
-out/mill-lock
+out/mill-out-lock
 out/mill-invalidation-tree.json
 out/mill-chrome-profile.json
 out/mill-server/...

--- a/runner/bsp/worker/src/mill/bsp/worker/BspWorkerImpl.scala
+++ b/runner/bsp/worker/src/mill/bsp/worker/BspWorkerImpl.scala
@@ -5,6 +5,7 @@ import mill.bsp.BuildInfo
 import mill.api.internal.{BspServerHandle, BspServerResult, EvaluatorApi}
 import mill.bsp.Constants
 import mill.api.{Result, SystemStreams}
+import mill.client.lock.Lock
 import org.eclipse.lsp4j.jsonrpc.Launcher
 
 import java.io.PrintWriter
@@ -17,7 +18,8 @@ object BspWorkerImpl {
       topLevelBuildRoot: os.Path,
       streams: SystemStreams,
       logDir: os.Path,
-      canReload: Boolean
+      canReload: Boolean,
+      outLock: Lock
   ): mill.api.Result[BspServerHandle] = {
 
     try {
@@ -33,7 +35,8 @@ object BspWorkerImpl {
           logStream = streams.err,
           canReload = canReload,
           debugMessages = Option(System.getenv("MILL_BSP_DEBUG")).contains("true"),
-          onShutdown = () => listening.cancel(true)
+          onShutdown = () => listening.cancel(true),
+          outLock = outLock
         ) with MillJvmBuildServer with MillJavaBuildServer with MillScalaBuildServer
 
       lazy val launcher = new Launcher.Builder[BuildClient]()

--- a/runner/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/runner/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -6,12 +6,14 @@ import com.google.gson.JsonObject
 import mill.api.*
 import mill.api.internal.{JvmBuildTarget, ScalaBuildTarget, *}
 import mill.api.Segment.Label
-import mill.bsp.{Constants}
+import mill.bsp.Constants
 import mill.bsp.worker.Utils.{makeBuildTarget, outputPaths, sanitizeUri}
+import mill.client.lock.Lock
 import mill.server.Server
 
 import java.io.PrintStream
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.locks.ReentrantLock
 import scala.collection.mutable
 import scala.concurrent.Promise
 import scala.jdk.CollectionConverters.*
@@ -28,7 +30,8 @@ private class MillBuildServer(
     logStream: PrintStream,
     canReload: Boolean,
     debugMessages: Boolean,
-    onShutdown: () => Unit
+    onShutdown: () => Unit,
+    outLock: Lock
 )(implicit ec: scala.concurrent.ExecutionContext) extends BuildServer {
 
   import MillBuildServer._
@@ -724,7 +727,8 @@ private class MillBuildServer(
         case n: NamedTaskApi[_] => n.label
         case t => t.toString
       },
-      streams = logger0.streams
+      streams = logger0.streams,
+      outLock = outLock
     ) {
       evaluator.executeApi(
         goals,

--- a/runner/client/src/mill/client/ServerLauncher.java
+++ b/runner/client/src/mill/client/ServerLauncher.java
@@ -148,6 +148,8 @@ public abstract class ServerLauncher {
         System.err.println("mill-server/ exitCode file not found");
         return 1;
       }
-    } finally ioSocket.close();
+    } finally {
+      ioSocket.close();
+    }
   }
 }

--- a/runner/client/src/mill/client/ServerLauncher.java
+++ b/runner/client/src/mill/client/ServerLauncher.java
@@ -45,7 +45,6 @@ public abstract class ServerLauncher {
     public Path serverDir;
   }
 
-  final int serverProcessesLimit = 5;
   final int serverInitWaitMillis = 10000;
 
   public abstract void initServer(Path serverDir, boolean b, Locks locks) throws Exception;

--- a/runner/client/src/mill/client/ServerLauncher.java
+++ b/runner/client/src/mill/client/ServerLauncher.java
@@ -148,9 +148,6 @@ public abstract class ServerLauncher {
         System.err.println("mill-server/ exitCode file not found");
         return 1;
       }
-    } finally {
-      System.out.println("ServerLauncher ioSocket.close()");
-      ioSocket.close();
-    }
+    } finally ioSocket.close();
   }
 }

--- a/runner/client/src/mill/client/ServerLauncher.java
+++ b/runner/client/src/mill/client/ServerLauncher.java
@@ -22,10 +22,10 @@ import mill.constants.Util;
  *
  * - Client:
  *   - Take clientLock
- *   - If processLock is not yet taken, it means server is not running, so spawn a server
+ *   - If serverLock is not yet taken, it means server is not running, so spawn a server
  *   - Wait for server socket to be available for connection
  * - Server:
- *   - Take processLock.
+ *   - Take serverLock.
  *     - If already taken, it means another server was running
  *       (e.g. spawned by a different client) so exit immediately
  * - Server: loop:
@@ -99,8 +99,8 @@ public abstract class ServerLauncher {
     try (Locks locks = memoryLock != null ? memoryLock : Locks.files(serverDir.toString());
         mill.client.lock.Locked locked = locks.clientLock.lock()) {
 
-      if (locks.processLock.probe()) initServer(serverDir, setJnaNoSys, locks);
-      while (locks.processLock.probe()) Thread.sleep(1);
+      if (locks.serverLock.probe()) initServer(serverDir, setJnaNoSys, locks);
+      while (locks.serverLock.probe()) Thread.sleep(1);
     }
     long retryStart = System.currentTimeMillis();
     Socket ioSocket = null;

--- a/runner/client/src/mill/client/ServerLauncher.java
+++ b/runner/client/src/mill/client/ServerLauncher.java
@@ -96,7 +96,7 @@ public abstract class ServerLauncher {
 
   int run(Path serverDir, boolean setJnaNoSys) throws Exception {
 
-    try (Locks locks = memoryLock != null? memoryLock: Locks.files(serverDir.toString());
+    try (Locks locks = memoryLock != null ? memoryLock : Locks.files(serverDir.toString());
         mill.client.lock.Locked locked = locks.clientLock.lock()) {
 
       if (locks.processLock.probe()) initServer(serverDir, setJnaNoSys, locks);
@@ -133,7 +133,6 @@ public abstract class ServerLauncher {
     inThread.setDaemon(true);
     outPumperThread.start();
     inThread.start();
-
 
     try {
       if (forceFailureForTestingMillisDelay > 0) {

--- a/runner/client/src/mill/client/lock/DoubleLock.java
+++ b/runner/client/src/mill/client/lock/DoubleLock.java
@@ -32,8 +32,11 @@ public class DoubleLock extends Lock {
   @Override
   public boolean probe() throws Exception {
     TryLocked tl = tryLock();
-    if (tl.isLocked()) return false;
-    else return true;
+    if (!tl.isLocked()) return true;
+    else {
+        tl.release();
+        return false;
+    }
   }
 
   @Override

--- a/runner/client/src/mill/client/lock/DoubleLock.java
+++ b/runner/client/src/mill/client/lock/DoubleLock.java
@@ -1,6 +1,5 @@
 package mill.client.lock;
 
-
 public class DoubleLock extends Lock {
 
   private final Lock lock1;
@@ -34,8 +33,8 @@ public class DoubleLock extends Lock {
     TryLocked tl = tryLock();
     if (!tl.isLocked()) return true;
     else {
-        tl.release();
-        return false;
+      tl.release();
+      return false;
     }
   }
 

--- a/runner/client/src/mill/client/lock/DoubleLock.java
+++ b/runner/client/src/mill/client/lock/DoubleLock.java
@@ -1,0 +1,49 @@
+package mill.client.lock;
+
+
+public class DoubleLock extends Lock {
+
+  private final Lock lock1;
+  private final Lock lock2;
+
+  public DoubleLock(Lock lock1, Lock lock2) throws Exception {
+    this.lock1 = lock1;
+    this.lock2 = lock2;
+  }
+
+  @Override
+  public Locked lock() throws Exception {
+    return new DoubleLocked(lock1.lock(), lock2.lock());
+  }
+
+  @Override
+  public TryLocked tryLock() throws Exception {
+    TryLocked l1 = lock1.tryLock();
+    TryLocked l2 = lock2.tryLock();
+    if (l1.isLocked() && l2.isLocked()) {
+      return new DoubleTryLocked(l1, l2);
+    } else {
+      l1.release();
+      l2.release();
+      return new DoubleTryLocked(null, null);
+    }
+  }
+
+  @Override
+  public boolean probe() throws Exception {
+    TryLocked tl = tryLock();
+    if (tl.isLocked()) return false;
+    else return true;
+  }
+
+  @Override
+  public void close() throws Exception {
+    lock1.close();
+    lock2.close();
+  }
+
+  @Override
+  public void delete() throws Exception {
+    close();
+  }
+}

--- a/runner/client/src/mill/client/lock/DoubleLocked.java
+++ b/runner/client/src/mill/client/lock/DoubleLocked.java
@@ -1,0 +1,18 @@
+package mill.client.lock;
+
+class DoubleLocked implements Locked {
+
+  protected final Locked lock1;
+  protected final Locked lock2;
+
+  public DoubleLocked(Locked lock1, Locked lock2) {
+    this.lock1 = lock1;
+    this.lock2 = lock2;
+  }
+
+  @Override
+  public void release() throws Exception {
+    this.lock1.release();
+    this.lock2.release();
+  }
+}

--- a/runner/client/src/mill/client/lock/DoubleTryLocked.java
+++ b/runner/client/src/mill/client/lock/DoubleTryLocked.java
@@ -1,0 +1,18 @@
+package mill.client.lock;
+
+class DoubleTryLocked extends DoubleLocked implements TryLocked {
+
+  public DoubleTryLocked(TryLocked lock1, TryLocked lock2) {
+    super(lock1, lock2);
+  }
+
+  @Override
+  public boolean isLocked() {
+    return lock1 != null && lock2 != null;
+  }
+
+  @Override
+  public void release() throws Exception {
+    if (isLocked()) super.release();
+  }
+}

--- a/runner/client/src/mill/client/lock/FileLock.java
+++ b/runner/client/src/mill/client/lock/FileLock.java
@@ -8,10 +8,12 @@ class FileLock extends Lock {
 
   private final RandomAccessFile raf;
   private final FileChannel chan;
+  private final String path;
 
   public FileLock(String path) throws Exception {
     raf = new RandomAccessFile(path, "rw");
     chan = raf.getChannel();
+    this.path = path;
   }
 
   @Override

--- a/runner/client/src/mill/client/lock/Locks.java
+++ b/runner/client/src/mill/client/lock/Locks.java
@@ -5,17 +5,17 @@ import mill.constants.ServerFiles;
 public final class Locks implements AutoCloseable {
 
   public final Lock clientLock;
-  public final Lock processLock;
+  public final Lock serverLock;
 
-  public Locks(Lock clientLock, Lock processLock) {
+  public Locks(Lock clientLock, Lock serverLock) {
     this.clientLock = clientLock;
-    this.processLock = processLock;
+    this.serverLock = serverLock;
   }
 
   public static Locks files(String serverDir) throws Exception {
     return new Locks(
         new FileLock(serverDir + "/" + ServerFiles.clientLock),
-        new FileLock(serverDir + "/" + ServerFiles.processLock));
+        new FileLock(serverDir + "/" + ServerFiles.serverLock));
   }
 
   public static Locks memory() {
@@ -25,6 +25,6 @@ public final class Locks implements AutoCloseable {
   @Override
   public void close() throws Exception {
     clientLock.delete();
-    processLock.delete();
+    serverLock.delete();
   }
 }

--- a/runner/daemon/src/mill/daemon/MillMain.scala
+++ b/runner/daemon/src/mill/daemon/MillMain.scala
@@ -59,6 +59,7 @@ object MillMain {
       }
     )
 
+    val serverDir = os.Path(args.head)
     val (result, _) =
       try main0(
           args = args.tail,
@@ -70,8 +71,8 @@ object MillMain {
           userSpecifiedProperties0 = Map(),
           initialSystemProperties = sys.props.toMap,
           systemExit = i => sys.exit(i),
-          serverDir = os.Path(args.head),
-          outLock = mill.client.lock.Locks.files(args.head).serverLock
+          serverDir = serverDir,
+          outLock = Lock.file((serverDir / OutFiles.millOutLock).toString)
         )
       catch handleMillException(initialSystemStreams.err, ())
 

--- a/runner/daemon/src/mill/daemon/MillMain.scala
+++ b/runner/daemon/src/mill/daemon/MillMain.scala
@@ -71,7 +71,7 @@ object MillMain {
           initialSystemProperties = sys.props.toMap,
           systemExit = i => sys.exit(i),
           serverDir = os.Path(args.head),
-          outLock = mill.client.lock.Locks.files(args.head).processLock
+          outLock = mill.client.lock.Locks.files(args.head).serverLock
         )
       catch handleMillException(initialSystemStreams.err, ())
 

--- a/runner/daemon/src/mill/daemon/MillMain.scala
+++ b/runner/daemon/src/mill/daemon/MillMain.scala
@@ -72,7 +72,7 @@ object MillMain {
           initialSystemProperties = sys.props.toMap,
           systemExit = i => sys.exit(i),
           serverDir = serverDir,
-          outLock = Lock.file((serverDir / OutFiles.millOutLock).toString)
+          outLock = Lock.file((out / OutFiles.millOutLock).toString)
         )
       catch handleMillException(initialSystemStreams.err, ())
 

--- a/runner/daemon/src/mill/daemon/MillServerMain.scala
+++ b/runner/daemon/src/mill/daemon/MillServerMain.scala
@@ -49,8 +49,8 @@ class MillServerMain(
   def stateCache0 = RunnerState.empty
 
   val outLock = new DoubleLock(
-    Locks.files(serverDir.toString).processLock,
-    Locks.memory().processLock
+    Locks.files(serverDir.toString).serverLock,
+    Locks.memory().serverLock
   )
 
   def main0(

--- a/runner/daemon/src/mill/daemon/MillServerMain.scala
+++ b/runner/daemon/src/mill/daemon/MillServerMain.scala
@@ -49,9 +49,11 @@ class MillServerMain(
   }
   def stateCache0 = RunnerState.empty
 
+  val out = os.Path(OutFiles.out, mill.define.WorkspaceRoot.workspaceRoot)
+
   val outLock = new DoubleLock(
     Lock.memory(),
-    Lock.file((serverDir / OutFiles.millOutLock).toString),
+    Lock.file((out / OutFiles.millOutLock).toString),
   )
 
   def main0(

--- a/runner/daemon/src/mill/daemon/MillServerMain.scala
+++ b/runner/daemon/src/mill/daemon/MillServerMain.scala
@@ -2,7 +2,8 @@ package mill.daemon
 
 import mill.api.SystemStreams
 import mill.client.ClientUtil
-import mill.client.lock.{DoubleLock, Locks}
+import mill.client.lock.{DoubleLock, Lock, Locks}
+import mill.constants.ServerFiles
 import sun.misc.{Signal, SignalHandler}
 
 import scala.util.Try
@@ -49,8 +50,8 @@ class MillServerMain(
   def stateCache0 = RunnerState.empty
 
   val outLock = new DoubleLock(
-    Locks.files(serverDir.toString).serverLock,
-    Locks.memory().serverLock
+    Lock.memory(),
+    Lock.file((serverDir / ServerFiles.serverLock).toString),
   )
 
   def main0(

--- a/runner/daemon/src/mill/daemon/MillServerMain.scala
+++ b/runner/daemon/src/mill/daemon/MillServerMain.scala
@@ -53,7 +53,7 @@ class MillServerMain(
 
   val outLock = new DoubleLock(
     Lock.memory(),
-    Lock.file((out / OutFiles.millOutLock).toString),
+    Lock.file((out / OutFiles.millOutLock).toString)
   )
 
   def main0(
@@ -65,7 +65,7 @@ class MillServerMain(
       setIdle: Boolean => Unit,
       userSpecifiedProperties: Map[String, String],
       initialSystemProperties: Map[String, String],
-      systemExit: Int => Nothing,
+      systemExit: Int => Nothing
   ): (Boolean, RunnerState) = {
     try MillMain.main0(
         args = args,

--- a/runner/daemon/src/mill/daemon/MillServerMain.scala
+++ b/runner/daemon/src/mill/daemon/MillServerMain.scala
@@ -3,7 +3,7 @@ package mill.daemon
 import mill.api.SystemStreams
 import mill.client.ClientUtil
 import mill.client.lock.{DoubleLock, Lock, Locks}
-import mill.constants.ServerFiles
+import mill.constants.{OutFiles, ServerFiles}
 import sun.misc.{Signal, SignalHandler}
 
 import scala.util.Try
@@ -51,7 +51,7 @@ class MillServerMain(
 
   val outLock = new DoubleLock(
     Lock.memory(),
-    Lock.file((serverDir / ServerFiles.serverLock).toString),
+    Lock.file((serverDir / OutFiles.millOutLock).toString),
   )
 
   def main0(

--- a/runner/launcher/src/mill/launcher/MillLauncherMain.java
+++ b/runner/launcher/src/mill/launcher/MillLauncherMain.java
@@ -48,7 +48,6 @@ public class MillLauncherMain {
                 System.err,
                 System.getenv(),
                 optsArgs.toArray(new String[0]),
-                null,
                 -1) {
               public void initServer(Path serverDir, boolean setJnaNoSys, Locks locks)
                   throws Exception {

--- a/runner/launcher/src/mill/launcher/MillLauncherMain.java
+++ b/runner/launcher/src/mill/launcher/MillLauncherMain.java
@@ -48,6 +48,7 @@ public class MillLauncherMain {
                 System.err,
                 System.getenv(),
                 optsArgs.toArray(new String[0]),
+                null,
                 -1) {
               public void initServer(Path serverDir, boolean setJnaNoSys, Locks locks)
                   throws Exception {

--- a/runner/launcher/src/mill/launcher/MillProcessLauncher.java
+++ b/runner/launcher/src/mill/launcher/MillProcessLauncher.java
@@ -366,7 +366,6 @@ public class MillProcessLauncher {
     // never hit issues where we are reading the files from a previous run
     Files.deleteIfExists(serverDir.resolve(ServerFiles.exitCode));
     Files.deleteIfExists(serverDir.resolve(ServerFiles.terminfo));
-    Files.deleteIfExists(serverDir.resolve(ServerFiles.runArgs));
 
     Path sandbox = serverDir.resolve(ServerFiles.sandbox);
     Files.createDirectories(sandbox);

--- a/runner/server/src/mill/server/Server.scala
+++ b/runner/server/src/mill/server/Server.scala
@@ -146,9 +146,10 @@ abstract class Server[T](
       try {
         ProxyStream.sendHeartbeat(currentOutErr)
         true
-      } catch {case e: Throwable =>
-        clientDisappeared = true
-        false
+      } catch {
+        case e: Throwable =>
+          clientDisappeared = true
+          false
       }
     }
     try {
@@ -181,7 +182,6 @@ abstract class Server[T](
         )
         System.exit(ClientUtil.ExitServerCodeWhenVersionMismatch())
       }
-
 
       @volatile var done = false
       @volatile var idle = false

--- a/runner/server/src/mill/server/Server.scala
+++ b/runner/server/src/mill/server/Server.scala
@@ -144,7 +144,7 @@ abstract class Server[T](
     // message to see if the socket can receive data.
     def checkClientAlive() = {
       try {
-        currentOutErr.write(ProxyStream.HEARTBEAT)
+        ProxyStream.sendHeartbeat(currentOutErr)
         true
       } catch {case e: Throwable =>
         clientDisappeared = true

--- a/runner/server/src/mill/server/Server.scala
+++ b/runner/server/src/mill/server/Server.scala
@@ -202,7 +202,7 @@ abstract class Server[T](
       // We cannot simply use Lock#await here, because the filesystem doesn't
       // realize the clientLock/serverLock are held by different threads in the
       // two processes and gives a spurious deadlock error
-      while (!done && !locks.clientLock.probe()) Thread.sleep(1)
+      while (!done && clientSocket.isConnected) Thread.sleep(1)
 
       if (!idle) {
         serverLog("client interrupted while server was executing command")

--- a/runner/server/src/mill/server/Server.scala
+++ b/runner/server/src/mill/server/Server.scala
@@ -67,11 +67,13 @@ abstract class Server[T](
               case None => false
               case Some(sock) =>
                 serverLog("handling run")
-                try handleRun(sock, initialSystemProperties)
-                catch {
-                  case e: Throwable =>
-                    serverLog(e.toString + "\n" + e.getStackTrace.mkString("\n"))
-                } finally sock.close();
+                new Thread(() =>
+                  try handleRun(sock, initialSystemProperties)
+                  catch {
+                    case e: Throwable =>
+                      serverLog(e.toString + "\n" + e.getStackTrace.mkString("\n"))
+                  } finally sock.close();
+                ).start()
                 true
             }
           }

--- a/runner/server/src/mill/server/Server.scala
+++ b/runner/server/src/mill/server/Server.scala
@@ -47,7 +47,7 @@ abstract class Server[T](
     val initialSystemProperties = sys.props.toMap
 
     try {
-      Server.tryLockBlock(locks.processLock) {
+      Server.tryLockBlock(locks.serverLock) {
         serverLog("server file locked")
         Server.watchProcessIdFile(
           serverDir / ServerFiles.processId,

--- a/runner/server/src/mill/server/Server.scala
+++ b/runner/server/src/mill/server/Server.scala
@@ -2,7 +2,7 @@ package mill.server
 
 import mill.api.SystemStreams
 import mill.constants.ProxyStream.Output
-import mill.client.lock.{Lock, Locks}
+import mill.client.lock.{DoubleLock, Lock, Locks}
 import mill.client.*
 import mill.constants.ServerFiles
 import mill.constants.InputPumper
@@ -317,12 +317,11 @@ object Server {
       noWaitForBuildLock: Boolean,
       out: os.Path,
       targetsAndParams: Seq[String],
-      streams: SystemStreams
+      streams: SystemStreams,
+      outLock: Lock
   )(t: => T): T = {
     if (noBuildLock) t
     else {
-      val outLock = Lock.file((out / OutFiles.millLock).toString)
-
       def activeTaskString =
         try os.read(out / OutFiles.millActiveCommand)
         catch {

--- a/runner/server/test/src/mill/server/ClientServerTests.scala
+++ b/runner/server/test/src/mill/server/ClientServerTests.scala
@@ -214,8 +214,8 @@ object ClientServerTests extends TestSuite {
       assert(resF1.outDir == resF2.outDir)
       assert(resF2.outDir == resF3.outDir)
       // but the serverDir is placed in different subfolders
-      assert(resF1.serverDir != resF2.serverDir)
-      assert(resF2.serverDir != resF3.serverDir)
+      assert(resF1.serverDir == resF2.serverDir)
+      assert(resF2.serverDir == resF3.serverDir)
 
       assert(resF1.out == s"hello World$ENDL")
       assert(resF2.out == s"hello WORLD$ENDL")

--- a/runner/server/test/src/mill/server/ClientServerTests.scala
+++ b/runner/server/test/src/mill/server/ClientServerTests.scala
@@ -238,12 +238,9 @@ object ClientServerTests extends TestSuite {
       val logLines = os.read.lines(os.Path(pathStr, os.pwd) / "server.log")
 
       assert(
-        logLines.takeRight(5) ==
+        logLines.takeRight(2) ==
           Seq(
             "server-0 client interrupted while server was executing command",
-            "server-0 exiting server",
-            "server-0 server loop ended",
-            "server-0 finally exitServer",
             "server-0 exiting server"
           )
       )

--- a/runner/server/test/src/mill/server/ClientServerTests.scala
+++ b/runner/server/test/src/mill/server/ClientServerTests.scala
@@ -76,7 +76,6 @@ object ClientServerTests extends TestSuite {
     os.makeDir.all(dest)
     val outDir = os.temp.dir(dest, deleteOnExit = false)
 
-    val memoryLocks = Array.fill(10)(Locks.memory());
 
     def apply(
         env: Map[String, String] = Map(),
@@ -92,7 +91,6 @@ object ClientServerTests extends TestSuite {
         new PrintStream(err),
         env.asJava,
         args,
-        memoryLocks,
         forceFailureForTestingMillisDelay
       ) {
         def preRun(serverDir: Path) = { /*do nothing*/ }

--- a/runner/server/test/src/mill/server/ClientServerTests.scala
+++ b/runner/server/test/src/mill/server/ClientServerTests.scala
@@ -76,6 +76,7 @@ object ClientServerTests extends TestSuite {
     os.makeDir.all(dest)
     val outDir = os.temp.dir(dest, deleteOnExit = false)
 
+    val memoryLock = Locks.memory()
 
     def apply(
         env: Map[String, String] = Map(),
@@ -91,6 +92,7 @@ object ClientServerTests extends TestSuite {
         new PrintStream(err),
         env.asJava,
         args,
+        memoryLock,
         forceFailureForTestingMillisDelay
       ) {
         def preRun(serverDir: Path) = { /*do nothing*/ }

--- a/runner/server/test/src/mill/server/ClientServerTests.scala
+++ b/runner/server/test/src/mill/server/ClientServerTests.scala
@@ -135,7 +135,7 @@ object ClientServerTests extends TestSuite {
 
   def tests = Tests {
 
-    test("hello") - retry(3) {
+    test("hello") - {
       // Continue logging when out folder is deleted so we can see the logs
       // and ensure the correct code path is taken as the server exits
       val tester = new Tester(testLogEvenWhenServerIdWrong = true)


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/5031

* We now only have a single server process running at a time, and no longer keep up to 5 separate `serverDir-1` to `serverDir-5` folders. Essentially we are migrating from the style of concurrency used by `gradle` and `mvnd` to the style of concurrency used by `bazel`

* We now only hold the `clientLock` until the server process is initialized (and has taken it's `processLock`) to avoid redundant initialization, and after that we release it to allow multiple clients to connect

* Since there is only one server and one `serverDir`, we have to remove several per-server files since there is no way to ensure they are unique in the presence of multiple clients
    * `runArgs` can no longer be a file, and instead we send its contents over the socket before starting the `InputPumper`

    * We can no longer rely on `clientLock` probing to check if the client has disconnected, and so we instead have the server send `ProxyStream.HEARTBEAT` bytes (127) and look for errors

* `Server#run` can no longer accept socket connections and process them in a single-threaded loop, and instead needs to spawn off threads to handle each connected socket

    * We cannot perform the mutex at the server/client/connection level because there are scenarios we want multiple clients connected at once, e.g. when one client is in `--watch` mode and idle we want to allow another client to proceed with execution. So locking needs to be done at a finer-grained granularity within the server

* The original `millLock` file (renamed `millOutLock`) has been combined with a `MemoryLock` via `DoubleLock`, which lets us check the memory-lock first to avoid taking the file-lock twice on the same JVM and causing a `OverlappingFileLockException`. We still need to keep the file-lock to provide mutex between server and no-server processes, or between multiple no-server processes

Now that things are in one process, that opens up the possibility of loosening the concurrency constraints in future, e.g. allowing multiple concurrent evaluations that do not interfere with each other.