### PR TITLE
Don't unnecessarily force versions

### DIFF
--- a/libs/scalalib/src/mill/scalalib/Lib.scala
+++ b/libs/scalalib/src/mill/scalalib/Lib.scala
@@ -91,32 +91,32 @@ object Lib {
   def scalaCompilerMvnDeps(scalaOrganization: String, scalaVersion: String): Seq[Dep] =
     if (JvmWorkerUtil.isDotty(scalaVersion))
       Seq(
-        mvn"$scalaOrganization::dotty-compiler:$scalaVersion".forceVersion()
+        mvn"$scalaOrganization::dotty-compiler:$scalaVersion"
       )
     else if (JvmWorkerUtil.isScala3(scalaVersion))
       Seq(
-        mvn"$scalaOrganization::scala3-compiler:$scalaVersion".forceVersion()
+        mvn"$scalaOrganization::scala3-compiler:$scalaVersion"
       )
     else
       Seq(
-        mvn"$scalaOrganization:scala-compiler:$scalaVersion".forceVersion(),
-        mvn"$scalaOrganization:scala-reflect:$scalaVersion".forceVersion()
+        mvn"$scalaOrganization:scala-compiler:$scalaVersion",
+        mvn"$scalaOrganization:scala-reflect:$scalaVersion"
       )
 
   def scalaDocMvnDeps(scalaOrganization: String, scalaVersion: String): Seq[Dep] =
     if (JvmWorkerUtil.isDotty(scalaVersion))
       Seq(
-        mvn"$scalaOrganization::dotty-doc:$scalaVersion".forceVersion()
+        mvn"$scalaOrganization::dotty-doc:$scalaVersion"
       )
     else if (JvmWorkerUtil.isScala3Milestone(scalaVersion))
       Seq(
         // 3.0.0-RC1 > scalaVersion >= 3.0.0-M1 still uses dotty-doc, but under a different artifact name
-        mvn"$scalaOrganization::scala3-doc:$scalaVersion".forceVersion()
+        mvn"$scalaOrganization::scala3-doc:$scalaVersion"
       )
     else if (JvmWorkerUtil.isScala3(scalaVersion))
       Seq(
         // scalaVersion >= 3.0.0-RC1 uses scaladoc
-        mvn"$scalaOrganization::scaladoc:$scalaVersion".forceVersion()
+        mvn"$scalaOrganization::scaladoc:$scalaVersion"
       )
     else
       // in Scala <= 2.13, the scaladoc tool is included in the compiler
@@ -125,15 +125,15 @@ object Lib {
   def scalaRuntimeMvnDeps(scalaOrganization: String, scalaVersion: String): Seq[Dep] =
     if (JvmWorkerUtil.isDotty(scalaVersion)) {
       Seq(
-        mvn"$scalaOrganization::dotty-library:$scalaVersion".forceVersion()
+        mvn"$scalaOrganization::dotty-library:$scalaVersion"
       )
     } else if (JvmWorkerUtil.isScala3(scalaVersion))
       Seq(
-        mvn"$scalaOrganization::scala3-library:$scalaVersion".forceVersion()
+        mvn"$scalaOrganization::scala3-library:$scalaVersion"
       )
     else
       Seq(
-        mvn"$scalaOrganization:scala-library:$scalaVersion".forceVersion()
+        mvn"$scalaOrganization:scala-library:$scalaVersion"
       )
 
   def findSourceFiles(sources: Seq[PathRef], extensions: Seq[String]): Seq[os.Path] = {


### PR DESCRIPTION
It seems these `forceVersion` calls are unnecessary, these versions are either already forced via `ScalaModule#mapDependencies` (and if its branch's CI is happy, an upcoming PR of mine should move that to `ScalaModule#resolutionParams`), or don't need to be forced apparently (for the scaladoc stuff).