### PR TITLE
Cleanups for `ServerLauncher.scala`

### DIFF
--- a/runner/client/src/mill/client/ServerCouldNotBeStarted.java
+++ b/runner/client/src/mill/client/ServerCouldNotBeStarted.java
@@ -1,7 +1,0 @@
-package mill.client;
-
-public class ServerCouldNotBeStarted extends Exception {
-  public ServerCouldNotBeStarted(String msg) {
-    super(msg);
-  }
-}

--- a/runner/client/src/mill/client/ServerLauncher.java
+++ b/runner/client/src/mill/client/ServerLauncher.java
@@ -50,7 +50,7 @@ public abstract class ServerLauncher {
 
   public abstract void initServer(Path serverDir, boolean b, Locks locks) throws Exception;
 
-  public abstract void preRun(Path serverDir) throws Exception;
+  public abstract void prepareServerDir(Path serverDir) throws Exception;
 
   InputStream stdin;
   PrintStream stdout;
@@ -88,7 +88,7 @@ public abstract class ServerLauncher {
 
     Files.createDirectories(serverDir);
 
-    preRun(serverDir);
+    prepareServerDir(serverDir);
 
     Socket ioSocket = launchConnectToServer(serverDir, setJnaNoSys);
 

--- a/runner/client/src/mill/client/lock/DoubleLock.java
+++ b/runner/client/src/mill/client/lock/DoubleLock.java
@@ -22,8 +22,10 @@ public class DoubleLock extends Lock {
     if (l1.isLocked() && l2.isLocked()) {
       return new DoubleTryLocked(l1, l2);
     } else {
-      l1.release();
+      // Unlock the locks in the opposite order in which we originally took them
       l2.release();
+      l1.release();
+
       return new DoubleTryLocked(null, null);
     }
   }
@@ -40,6 +42,7 @@ public class DoubleLock extends Lock {
 
   @Override
   public void close() throws Exception {
+    // Unlock the locks in the opposite order in which we originally took them
     lock2.close();
     lock1.close();
   }

--- a/runner/client/src/mill/client/lock/DoubleLock.java
+++ b/runner/client/src/mill/client/lock/DoubleLock.java
@@ -40,8 +40,8 @@ public class DoubleLock extends Lock {
 
   @Override
   public void close() throws Exception {
-    lock1.close();
     lock2.close();
+    lock1.close();
   }
 
   @Override

--- a/runner/client/src/mill/client/lock/MemoryLock.java
+++ b/runner/client/src/mill/client/lock/MemoryLock.java
@@ -20,8 +20,7 @@ class MemoryLock extends Lock {
   @Override
   public MemoryTryLocked tryLock() {
     MemoryTryLocked res =
-      innerLock.tryLock() ? new MemoryTryLocked(innerLock)
-      : new MemoryTryLocked(null);
+        innerLock.tryLock() ? new MemoryTryLocked(innerLock) : new MemoryTryLocked(null);
 
     return res;
   }

--- a/runner/client/src/mill/client/lock/MemoryLock.java
+++ b/runner/client/src/mill/client/lock/MemoryLock.java
@@ -19,8 +19,11 @@ class MemoryLock extends Lock {
 
   @Override
   public MemoryTryLocked tryLock() {
-    if (innerLock.tryLock()) return new MemoryTryLocked(innerLock);
-    else return new MemoryTryLocked(null);
+    MemoryTryLocked res =
+      innerLock.tryLock() ? new MemoryTryLocked(innerLock)
+      : new MemoryTryLocked(null);
+
+    return res;
   }
 
   @Override

--- a/runner/launcher/src/mill/launcher/MillLauncherMain.java
+++ b/runner/launcher/src/mill/launcher/MillLauncherMain.java
@@ -50,9 +50,8 @@ public class MillLauncherMain {
                 optsArgs.toArray(new String[0]),
                 null,
                 -1) {
-              public void initServer(Path serverDir, boolean setJnaNoSys, Locks locks)
-                  throws Exception {
-                MillProcessLauncher.launchMillServer(serverDir, setJnaNoSys);
+              public void initServer(Path serverDir, Locks locks) throws Exception {
+                MillProcessLauncher.launchMillServer(serverDir);
               }
 
               public void prepareServerDir(Path serverDir) throws Exception {

--- a/runner/launcher/src/mill/launcher/MillLauncherMain.java
+++ b/runner/launcher/src/mill/launcher/MillLauncherMain.java
@@ -68,17 +68,6 @@ public class MillLauncherMain {
           exitCode = launcher.run(serverDir0).exitCode;
         }
         System.exit(exitCode);
-      } catch (ServerCouldNotBeStarted e) {
-        // TODO: try to run in-process
-        System.err.println("Could not start a Mill server process.\n"
-            + "This could be caused by too many already running Mill instances "
-            + "or by an unsupported platform.\n"
-            + e.getMessage() + "\n");
-
-        System.err.println(
-            "Loading Mill in-process isn't possible.\n" + "Please check your Mill installation!");
-        throw e;
-
       } catch (Exception e) {
         System.err.println("Mill client failed with unknown exception");
         e.printStackTrace();

--- a/runner/launcher/src/mill/launcher/MillLauncherMain.java
+++ b/runner/launcher/src/mill/launcher/MillLauncherMain.java
@@ -63,9 +63,9 @@ public class MillLauncherMain {
         final String versionAndJvmHomeEncoding =
             Util.md5hex(mill.client.BuildInfo.millVersion + MillProcessLauncher.javaHome());
         Path serverDir0 = Paths.get(OutFiles.out, OutFiles.millServer, versionAndJvmHomeEncoding);
-        int exitCode = launcher.acquireLocksAndRun(serverDir0).exitCode;
+        int exitCode = launcher.run(serverDir0).exitCode;
         if (exitCode == ClientUtil.ExitServerCodeWhenVersionMismatch()) {
-          exitCode = launcher.acquireLocksAndRun(serverDir0).exitCode;
+          exitCode = launcher.run(serverDir0).exitCode;
         }
         System.exit(exitCode);
       } catch (ServerCouldNotBeStarted e) {

--- a/runner/launcher/src/mill/launcher/MillLauncherMain.java
+++ b/runner/launcher/src/mill/launcher/MillLauncherMain.java
@@ -55,7 +55,7 @@ public class MillLauncherMain {
                 MillProcessLauncher.launchMillServer(serverDir, setJnaNoSys);
               }
 
-              public void preRun(Path serverDir) throws Exception {
+              public void prepareServerDir(Path serverDir) throws Exception {
                 MillProcessLauncher.prepareMillRunFolder(serverDir);
               }
             };

--- a/runner/launcher/src/mill/launcher/MillProcessLauncher.java
+++ b/runner/launcher/src/mill/launcher/MillProcessLauncher.java
@@ -23,12 +23,11 @@ import mill.constants.ServerFiles;
 public class MillProcessLauncher {
 
   static int launchMillNoServer(String[] args) throws Exception {
-    final boolean setJnaNoSys = System.getProperty("jna.nosys") == null;
     final String sig = String.format("%08x", UUID.randomUUID().hashCode());
     final Path processDir = Paths.get(".").resolve(out).resolve(millNoServer).resolve(sig);
 
     final List<String> l = new ArrayList<>();
-    l.addAll(millLaunchJvmCommand(setJnaNoSys));
+    l.addAll(millLaunchJvmCommand());
     l.add("mill.daemon.MillMain");
     l.add(processDir.toAbsolutePath().toString());
     l.addAll(millOpts());
@@ -57,9 +56,9 @@ public class MillProcessLauncher {
     }
   }
 
-  static void launchMillServer(Path serverDir, boolean setJnaNoSys) throws Exception {
+  static void launchMillServer(Path serverDir) throws Exception {
     List<String> l = new ArrayList<>();
-    l.addAll(millLaunchJvmCommand(setJnaNoSys));
+    l.addAll(millLaunchJvmCommand());
     l.add("mill.daemon.MillServerMain");
     l.add(serverDir.toFile().getCanonicalPath());
 
@@ -202,16 +201,11 @@ public class MillProcessLauncher {
     }
   }
 
-  static List<String> millLaunchJvmCommand(boolean setJnaNoSys) throws Exception {
+  static List<String> millLaunchJvmCommand() throws Exception {
     final List<String> vmOptions = new ArrayList<>();
 
     // Java executable
     vmOptions.add(javaExe());
-
-    // jna
-    if (setJnaNoSys) {
-      vmOptions.add("-Djna.nosys=true");
-    }
 
     // sys props
     final Properties sysProps = System.getProperties();

--- a/runner/server/test/src/mill/server/ClientServerTests.scala
+++ b/runner/server/test/src/mill/server/ClientServerTests.scala
@@ -106,7 +106,7 @@ object ClientServerTests extends TestSuite {
             testLogEvenWhenServerIdWrong
           )).start()
         }
-      }.acquireLocksAndRun((outDir / "server-0").relativeTo(os.pwd).toNIO)
+      }.run((outDir / "server-0").relativeTo(os.pwd).toNIO)
 
       ClientResult(
         result.exitCode,

--- a/runner/server/test/src/mill/server/ClientServerTests.scala
+++ b/runner/server/test/src/mill/server/ClientServerTests.scala
@@ -96,7 +96,7 @@ object ClientServerTests extends TestSuite {
         forceFailureForTestingMillisDelay
       ) {
         def prepareServerDir(serverDir: Path) = { /*do nothing*/ }
-        def initServer(serverDir: Path, b: Boolean, locks: Locks) = {
+        def initServer(serverDir: Path, locks: Locks) = {
           val processId = "server-" + nextServerId
           nextServerId += 1
           new Thread(new EchoServer(

--- a/runner/server/test/src/mill/server/ClientServerTests.scala
+++ b/runner/server/test/src/mill/server/ClientServerTests.scala
@@ -95,7 +95,7 @@ object ClientServerTests extends TestSuite {
         memoryLock,
         forceFailureForTestingMillisDelay
       ) {
-        def preRun(serverDir: Path) = { /*do nothing*/ }
+        def prepareServerDir(serverDir: Path) = { /*do nothing*/ }
         def initServer(serverDir: Path, b: Boolean, locks: Locks) = {
           val processId = "server-" + nextServerId
           nextServerId += 1


### PR DESCRIPTION
* Fix `DoubleLock` hierarchical locking discipline. This makes the locking/unlocking order correct, and seems to make some non-deterministic `OverlappingFileLockException`s stop happening in my manual testing

* Re-organize `ServerLauncher.run`, folding in `acquireLocksAndRun` into the main `run` body and breaking out parts of it into helper methods. It could be greatly simplified since we no longer need to loop over the possible server dirs to claim one

* Remove `setJnaNoSys` handling, which I *think* is not necessary anymore now that we have cleaner classpath/process isolation between the Mill client and server