### PR TITLE
Fix support for older Mill version in bootstrap scripts

### DIFF
--- a/ci/mill.ps1
+++ b/ci/mill.ps1
@@ -134,4 +134,5 @@ if ($null -ne $remainingArgs) {
     }
 }
 
+# -D mill.main.cli is for compatibility with Mill 0.10.9 - 0.13.0-M2
 & $MILL $MILL_FIRST_ARG -D "mill.main.cli=$MILL_MAIN_CLI" $REMAINING_ARGUMENTS

--- a/ci/mill.ps1
+++ b/ci/mill.ps1
@@ -122,7 +122,7 @@ if (-not (Test-Path -Path $MILL -PathType Leaf)) {
     Invoke-WebRequest -Uri $DOWNLOAD_URL -OutFile $MILL
 }
 
-
+$MILL_MAIN_CLI = $Env:MILL_MAIN_CLI ?? $PSCommandPath
 
 $MILL_FIRST_ARG = $null
 $REMAINING_ARGUMENTS = $remainingArgs
@@ -134,4 +134,4 @@ if ($null -ne $remainingArgs) {
     }
 }
 
-& $MILL $MILL_FIRST_ARG $REMAINING_ARGUMENTS
+& $MILL $MILL_FIRST_ARG -D "mill.main.cli=$MILL_MAIN_CLI" $REMAINING_ARGUMENTS

--- a/mill
+++ b/mill
@@ -23,7 +23,7 @@
 # into a cache location (~/.cache/mill/download).
 #
 # Mill Project URL: https://github.com/com-lihaoyi/mill
-# Script Version: 0.13.0-M2-3-ba7090
+# Script Version: 0.13.0-M2-63-e8edbd
 #
 # If you want to improve this script, please also contribute your changes back!
 # This script was generated from: scripts/src/mill.sh
@@ -311,6 +311,7 @@ unset OLD_MILL
 unset MILL_VERSION
 unset MILL_REPO_URL
 
+# -D mill.main.cli is for compatibility with Mill 0.10.9 - 0.13.0-M2
 # We don't quote MILL_FIRST_ARG on purpose, so we can expand the empty value without quotes
 # shellcheck disable=SC2086
 exec "${MILL}" $MILL_FIRST_ARG -D "mill.main.cli=${MILL_MAIN_CLI}" "$@"

--- a/mill
+++ b/mill
@@ -294,6 +294,10 @@ if [ ! -s "${MILL}" ] ; then
   fi
 fi
 
+if [ -z "$MILL_MAIN_CLI" ] ; then
+  MILL_MAIN_CLI="${0}"
+fi
+
 MILL_FIRST_ARG=""
 if [ "$1" = "--bsp" ] || [ "$1" = "-i" ] || [ "$1" = "--interactive" ] || [ "$1" = "--no-server" ] || [ "$1" = "--repl" ] || [ "$1" = "--help" ] ; then
   # Need to preserve the first position of those listed options
@@ -309,4 +313,4 @@ unset MILL_REPO_URL
 
 # We don't quote MILL_FIRST_ARG on purpose, so we can expand the empty value without quotes
 # shellcheck disable=SC2086
-exec "${MILL}" $MILL_FIRST_ARG "$@"
+exec "${MILL}" $MILL_FIRST_ARG -D "mill.main.cli=${MILL_MAIN_CLI}" "$@"

--- a/mill.bat
+++ b/mill.bat
@@ -23,7 +23,7 @@ rem this script downloads a binary file from Maven Central or Github Pages (this
 rem into a cache location (%USERPROFILE%\.mill\download).
 rem
 rem Mill Project URL: https://github.com/com-lihaoyi/mill
-rem Script Version: 0.13.0-M2-3-ba7090
+rem Script Version: 0.13.0-M2-63-e8edbd
 rem
 rem If you want to improve this script, please also contribute your changes back!
 rem This script was generated from: scripts/src/mill.bat
@@ -267,4 +267,5 @@ if not [!MILL_FIRST_ARG!]==[] (
   )
 )
 
+rem -D mill.main.cli is for compatibility with Mill 0.10.9 - 0.13.0-M2
 "%MILL%" %MILL_FIRST_ARG% -D "mill.main.cli=%MILL_MAIN_CLI%" %MILL_PARAMS%

--- a/mill.bat
+++ b/mill.bat
@@ -42,6 +42,9 @@ if [!GITHUB_RELEASE_CDN!]==[] (
     set "GITHUB_RELEASE_CDN="
 )
 
+if [!MILL_MAIN_CLI!]==[] (
+    set "MILL_MAIN_CLI=%~f0"
+)
 
 set "MILL_REPO_URL=https://github.com/com-lihaoyi/mill"
 
@@ -264,4 +267,4 @@ if not [!MILL_FIRST_ARG!]==[] (
   )
 )
 
-"%MILL%" %MILL_FIRST_ARG%  %MILL_PARAMS%
+"%MILL%" %MILL_FIRST_ARG% -D "mill.main.cli=%MILL_MAIN_CLI%" %MILL_PARAMS%

--- a/scripts/package.mill
+++ b/scripts/package.mill
@@ -76,18 +76,18 @@ object `package` extends mill.Module { scripts =>
   def installInRepo: T[Seq[PathRef]] = Task {
     Task.traverse(scriptsModules)(m =>
       Task.Anon {
-        val script = m.compile0().path
-        val dest = T.workspace / m.inRepoDir()
-        if (os.isDir(dest)) {
-          sys.error(s"Install destination is a directory: ${dest}")
-        } else if (os.exists(dest)) {
-          Task.log.warn(s"Overwriting file: ${dest}")
-        }
-        Task.log.info(s"Installing script: ${dest}")
         os.checker.withValue(os.Checker.Nop) {
+          val script = m.compile0().path
+          val dest = T.workspace / m.inRepoDir()
+          if (os.isDir(dest)) {
+            sys.error(s"Install destination is a directory: ${dest}")
+          } else if (os.exists(dest)) {
+            Task.log.warn(s"Overwriting file: ${dest}")
+          }
+          Task.log.info(s"Installing script: ${dest}")
           os.copy.over(script, dest)
+          Result.Success(dest)
         }
-        Result.Success(dest)
       }
     )().map(path => PathRef(path).withRevalidateOnce)
   }

--- a/scripts/package.mill
+++ b/scripts/package.mill
@@ -26,39 +26,41 @@ object `package` extends mill.Module { scripts =>
 
     /** Compiles the script from the [[templateFile]] and substitutes all [[substitutions]]. */
     def compile0: T[PathRef] = Task {
-      val script = T.dest / finalName()
-      val template = templateFile().path
-      val (start, end) = substitutionMarkers()
+      os.checker.withValue(os.Checker.Nop) {
+        val script = T.dest / finalName()
+        val template = templateFile().path
+        val (start, end) = substitutionMarkers()
 
-      def pattern(key: String, quote: Boolean = true) =
-        s"""\\Q${start}\\E\\s*${if (quote) Pattern.quote(key) else key}\\s*\\Q${end}\\E""".r
-      val findAndReplace = substitutions().map((key, value) => (pattern(key), value))
-      val missing = pattern("[\\w+-_ ]+", false)
+        def pattern(key: String, quote: Boolean = true) =
+          s"""\\Q${start}\\E\\s*${if (quote) Pattern.quote(key) else key}\\s*\\Q${end}\\E""".r
+        val findAndReplace = substitutions().map((key, value) => (pattern(key), value))
+        val missing = pattern("[\\w+-_ ]+", false)
 
-      def substitute(line: String): String = {
-        val result = findAndReplace.foldLeft(line) { (line, r) =>
-          r._1.replaceAllIn(line, r._2)
+        def substitute(line: String): String = {
+          val result = findAndReplace.foldLeft(line) { (line, r) =>
+            r._1.replaceAllIn(line, r._2)
+          }
+          missing.findFirstIn(result).foreach(m =>
+            throw RuntimeException(s"Detected unmatched substitution block: ${m}")
+          )
+          result
         }
-        missing.findFirstIn(result).foreach(m =>
-          throw RuntimeException(s"Detected unmatched substitution block: ${m}")
-        )
-        result
-      }
 
-      assert(os.exists(template))
-      Task.log.streams.out.println(s"Compiling script ${script}")
-      os.write(
-        target = script,
-        data = os.read.lines.stream(template).map(substitute).map(_ + '\n')
-      )
-      if (!scala.util.Properties.isWin) {
-        val p = os.perms(script) +
-          PosixFilePermission.OWNER_EXECUTE +
-          PosixFilePermission.GROUP_EXECUTE +
-          PosixFilePermission.OTHERS_EXECUTE
-        os.perms.set(script, p)
+        assert(os.exists(template))
+        Task.log.streams.out.println(s"Compiling script ${script}")
+        os.write(
+          target = script,
+          data = os.read.lines.stream(template).map(substitute).map(_ + '\n')
+        )
+        if (!scala.util.Properties.isWin) {
+          val p = os.perms(script) +
+            PosixFilePermission.OWNER_EXECUTE +
+            PosixFilePermission.GROUP_EXECUTE +
+            PosixFilePermission.OTHERS_EXECUTE
+          os.perms.set(script, p)
+        }
+        PathRef(script)
       }
-      PathRef(script)
     }
   }
 
@@ -74,22 +76,23 @@ object `package` extends mill.Module { scripts =>
   def scriptsModules: Seq[BootstrapScriptModule] = Seq(millSh, millBat)
 
   def installInRepo: T[Seq[PathRef]] = Task {
-    Task.traverse(scriptsModules)(m =>
-      Task.Anon {
-        os.checker.withValue(os.Checker.Nop) {
-          val script = m.compile0().path
-          val dest = T.workspace / m.inRepoDir()
-          if (os.isDir(dest)) {
-            sys.error(s"Install destination is a directory: ${dest}")
-          } else if (os.exists(dest)) {
-            Task.log.warn(s"Overwriting file: ${dest}")
+    os.checker.withValue(os.Checker.Nop) {
+      Task.traverse(scriptsModules)(m =>
+        Task.Anon {
+          os.checker.withValue(os.Checker.Nop) {
+            val script = m.compile0().path
+            val dest = T.workspace / m.inRepoDir()
+            if (os.isDir(dest)) {
+              sys.error(s"Install destination is a directory: ${dest}")
+            } else if (os.exists(dest)) {
+              Task.log.warn(s"Overwriting file: ${dest}")
+            }
+            Task.log.info(s"Installing script: ${dest}")
+            os.copy.over(script, dest)
+            Result.Success(dest)
           }
-          Task.log.info(s"Installing script: ${dest}")
-          os.copy.over(script, dest)
-          Result.Success(dest)
         }
-      }
-    )().map(path => PathRef(path).withRevalidateOnce)
+      )().map(path => PathRef(path).withRevalidateOnce)
+    }
   }
-
 }

--- a/scripts/src/mill.bat
+++ b/scripts/src/mill.bat
@@ -42,6 +42,10 @@ if [!GITHUB_RELEASE_CDN!]==[] (
     set "GITHUB_RELEASE_CDN="
 )
 
+if [!MILL_MAIN_CLI!]==[] (
+    set "MILL_MAIN_CLI=%~f0"
+)
+
 set "MILL_REPO_URL={{{ mill-repo-url }}}"
 
 SET MILL_BUILD_SCRIPT=
@@ -263,4 +267,4 @@ if not [!MILL_FIRST_ARG!]==[] (
   )
 )
 
-"%MILL%" %MILL_FIRST_ARG% %MILL_PARAMS%
+"%MILL%" %MILL_FIRST_ARG% -D "mill.main.cli=%MILL_MAIN_CLI%" %MILL_PARAMS%

--- a/scripts/src/mill.bat
+++ b/scripts/src/mill.bat
@@ -267,4 +267,5 @@ if not [!MILL_FIRST_ARG!]==[] (
   )
 )
 
+rem -D mill.main.cli is for compatibility with Mill 0.10.9 - 0.13.0-M2
 "%MILL%" %MILL_FIRST_ARG% -D "mill.main.cli=%MILL_MAIN_CLI%" %MILL_PARAMS%

--- a/scripts/src/mill.sh
+++ b/scripts/src/mill.sh
@@ -311,6 +311,7 @@ unset OLD_MILL
 unset MILL_VERSION
 unset MILL_REPO_URL
 
+# -D mill.main.cli is for compatibility with Mill 0.10.9 - 0.13.0-M2
 # We don't quote MILL_FIRST_ARG on purpose, so we can expand the empty value without quotes
 # shellcheck disable=SC2086
 exec "${MILL}" $MILL_FIRST_ARG -D "mill.main.cli=${MILL_MAIN_CLI}" "$@"

--- a/scripts/src/mill.sh
+++ b/scripts/src/mill.sh
@@ -294,6 +294,10 @@ if [ ! -s "${MILL}" ] ; then
   fi
 fi
 
+if [ -z "$MILL_MAIN_CLI" ] ; then
+  MILL_MAIN_CLI="${0}"
+fi
+
 MILL_FIRST_ARG=""
 if [ "$1" = "--bsp" ] || [ "$1" = "-i" ] || [ "$1" = "--interactive" ] || [ "$1" = "--no-server" ] || [ "$1" = "--repl" ] || [ "$1" = "--help" ] ; then
   # Need to preserve the first position of those listed options
@@ -309,4 +313,4 @@ unset MILL_REPO_URL
 
 # We don't quote MILL_FIRST_ARG on purpose, so we can expand the empty value without quotes
 # shellcheck disable=SC2086
-exec "${MILL}" $MILL_FIRST_ARG  "$@"
+exec "${MILL}" $MILL_FIRST_ARG -D "mill.main.cli=${MILL_MAIN_CLI}" "$@"


### PR DESCRIPTION
Fix https://github.com/com-lihaoyi/mill/issues/5076

Although this property is no longer in use,
we still need it for older Mill versions,
including the latest available stable Mill release `0.12.10`.

This reverts some changes from PR https://github.com/com-lihaoyi/mill/pull/5061

