### PR TITLE
Use pre-published 2.13.16 zinc compiler bridge

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -393,7 +393,8 @@ val bridgeScalaVersions = Seq(
   "2.13.12",
   "2.13.13",
   "2.13.14",
-  "2.13.15"
+  "2.13.15",
+  "2.13.16"
 )
 
 // We limit the number of compiler bridges to compile and publish for local


### PR DESCRIPTION
Recently published in https://github.com/com-lihaoyi/mill/actions/runs/14896055766/job/41838705072

This speeds up our test suite considerably from not constantly re-compiling these scala sources