### PR TITLE
Move `KotlinWorker` over to `CachedFactory`

### DIFF
--- a/integration/feature/leak-hygiene/src/LeakHygieneTests.scala
+++ b/integration/feature/leak-hygiene/src/LeakHygieneTests.scala
@@ -66,7 +66,7 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
           checkClassloaders(tester)(
             "mill.codesig.ExternalSummary.apply upstreamClassloader" -> 1,
             "mill.daemon.MillBuildBootstrap#processRunClasspath classLoader cl" -> 1,
-            "mill.kotlinlib.KotlinModule#kotlinWorkerClassLoader" -> 1,
+            "mill.kotlinlib.KotlinWorkerFactory#setup cl" -> 1,
             "mill.meta.ScalaCompilerWorker.reflectUnsafe cl" -> 1,
             "mill.scalalib.JvmWorkerModule#worker cl" -> 2,
             "mill.scalalib.worker.JvmWorkerImpl#getCachedClassLoader cl" -> 2
@@ -92,7 +92,7 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
           checkClassloaders(tester)(
             "mill.codesig.ExternalSummary.apply upstreamClassloader" -> 1,
             "mill.daemon.MillBuildBootstrap#processRunClasspath classLoader cl" -> 1,
-            "mill.kotlinlib.KotlinModule#kotlinWorkerClassLoader" -> 1,
+            "mill.kotlinlib.KotlinWorkerFactory#setup cl" -> 1,
             "mill.meta.ScalaCompilerWorker.reflectUnsafe cl" -> 1,
             "mill.scalalib.JvmWorkerModule#worker cl" -> 2,
             "mill.scalalib.worker.JvmWorkerImpl#getCachedClassLoader cl" -> 2
@@ -139,7 +139,7 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
           tester.eval(("show", "__.compile"))
           checkClassloaders(tester)(
             "mill.daemon.MillBuildBootstrap#processRunClasspath classLoader cl" -> 1,
-            "mill.kotlinlib.KotlinModule#kotlinWorkerClassLoader" -> 1,
+            "mill.kotlinlib.KotlinWorkerFactory#setup cl" -> 1,
             "mill.meta.ScalaCompilerWorker.reflectUnsafe cl" -> 1,
             "mill.scalalib.JvmWorkerModule#worker cl" -> 2,
             "mill.scalalib.worker.JvmWorkerImpl#getCachedClassLoader cl" -> 1
@@ -165,7 +165,7 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
           tester.eval(("show", "__.compile"))
           checkClassloaders(tester)(
             "mill.daemon.MillBuildBootstrap#processRunClasspath classLoader cl" -> 1,
-            "mill.kotlinlib.KotlinModule#kotlinWorkerClassLoader" -> 1,
+            "mill.kotlinlib.KotlinWorkerFactory#setup cl" -> 1,
             "mill.meta.ScalaCompilerWorker.reflectUnsafe cl" -> 1,
             "mill.scalalib.JvmWorkerModule#worker cl" -> 2,
             "mill.scalalib.worker.JvmWorkerImpl#getCachedClassLoader cl" -> 1
@@ -193,7 +193,7 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
           val res = tester.eval(("show", "__.compile"))
           checkClassloaders(tester)(
             "mill.daemon.MillBuildBootstrap#processRunClasspath classLoader cl" -> 1,
-            "mill.kotlinlib.KotlinModule#kotlinWorkerClassLoader" -> 1,
+            "mill.kotlinlib.KotlinWorkerFactory#setup cl" -> 1,
             "mill.meta.ScalaCompilerWorker.reflectUnsafe cl" -> 1,
             "mill.scalalib.JvmWorkerModule#worker cl" -> 2,
             "mill.scalalib.worker.JvmWorkerImpl#getCachedClassLoader cl" -> 1
@@ -218,7 +218,7 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
         checkClassloaders(tester)(
           "leaked classloader" -> 1,
           "mill.daemon.MillBuildBootstrap#processRunClasspath classLoader cl" -> 1,
-          "mill.kotlinlib.KotlinModule#kotlinWorkerClassLoader" -> 1,
+          "mill.kotlinlib.KotlinWorkerFactory#setup cl" -> 1,
           "mill.meta.ScalaCompilerWorker.reflectUnsafe cl" -> 1,
           "mill.scalalib.JvmWorkerModule#worker cl" -> 2,
           "mill.scalalib.worker.JvmWorkerImpl#getCachedClassLoader cl" -> 1

--- a/libs/kotlinlib/src/mill/kotlinlib/ksp/KspModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/ksp/KspModule.scala
@@ -5,7 +5,7 @@ import mill.define.PathRef
 import mill.api.Result
 import mill.define.Task
 import mill.kotlinlib.worker.api.{KotlinWorker, KotlinWorkerTarget}
-import mill.kotlinlib.{Dep, DepSyntax, KotlinModule}
+import mill.kotlinlib.{Dep, DepSyntax, KotlinModule, KotlinWorkerManager}
 
 import java.io.File
 
@@ -200,7 +200,9 @@ trait KspModule extends KotlinModule { outer =>
 
     T.log.info(s"KSP arguments: ${compilerArgs.mkString(" ")}")
 
-    kotlinWorkerTask().compile(KotlinWorkerTarget.Jvm, compilerArgs)
+    KotlinWorkerManager.kotlinWorker().withValue(kotlinCompilerClasspath().map(_.path)) {
+      _._2.compile(KotlinWorkerTarget.Jvm, compilerArgs)
+    }
 
     GeneratedKSPSources(PathRef(java), PathRef(kotlin), PathRef(resources), PathRef(classes))
   }


### PR DESCRIPTION
This lets us re-use classloaders between modules while being safe w.r.t. parallelism and teardown

CC @lefou 