### PR TITLE
Re-optimize Mill launch times

### DIFF
--- a/core/api/src/mill/api/internal/api.scala
+++ b/core/api/src/mill/api/internal/api.scala
@@ -174,3 +174,9 @@ object IdeaConfigFile {
   ): IdeaConfigFile =
     IdeaConfigFile(subPath, if (component == "") None else Option(component), config)
 }
+
+trait PathRefApi {
+  private[mill] def javaPath: java.nio.file.Path
+  def quick: Boolean
+  def sig: Int
+}

--- a/core/constants/src/mill/constants/Profiler.java
+++ b/core/constants/src/mill/constants/Profiler.java
@@ -1,0 +1,15 @@
+package mill.constants;
+
+/**
+ * A tiny class useful for peppering throughout a codebase to
+ * see where the time is being spent during interactive debugging
+ */
+public class Profiler {
+  long prev = System.currentTimeMillis();
+
+  public void tick(String s) {
+    long next = System.currentTimeMillis();
+    DebugLog.println(s + " " + (next - prev) + "ms");
+    prev = next;
+  }
+}

--- a/core/define/src/mill/define/PathRef.scala
+++ b/core/define/src/mill/define/PathRef.scala
@@ -1,6 +1,7 @@
 package mill.define
 
 import mill.api.DummyOutputStream
+import mill.api.internal.PathRefApi
 import upickle.default.ReadWriter as RW
 
 import java.nio.file as jnio
@@ -20,7 +21,8 @@ case class PathRef private[mill] (
     quick: Boolean,
     sig: Int,
     revalidate: PathRef.Revalidate
-) {
+) extends PathRefApi {
+  def javaPath = path.toNIO
 
   def recomputeSig(): Int = PathRef.apply(path, quick).sig
   def validate(): Boolean = recomputeSig() == sig

--- a/integration/invalidation/multi-level-editing/src/MultiLevelBuildTests.scala
+++ b/integration/invalidation/multi-level-editing/src/MultiLevelBuildTests.scala
@@ -67,7 +67,6 @@ trait MultiLevelBuildTests extends UtestIntegrationTestSuite {
     for ((expectedWatched0, (frame, path)) <- expected0.zip(loadFrames(tester, expected0.length))) {
       val frameWatched = frame
         .evalWatched
-        .map(_.path)
         .filter(_.startsWith(tester.workspacePath))
         .filter(!_.segments.contains("mill-launcher"))
         .sorted

--- a/runner/launcher/src/mill/launcher/MillProcessLauncher.java
+++ b/runner/launcher/src/mill/launcher/MillProcessLauncher.java
@@ -119,10 +119,12 @@ public class MillProcessLauncher {
 
                 if (!conf2.containsKey(key)) return new String[] {};
                 if (conf2.get(key) instanceof List) {
-                  return (String[]) ((List) conf2.get(key))
-                      .stream()
-                          .map(x -> mill.constants.Util.interpolateEnvVars(x.toString(), env))
-                          .toArray(String[]::new);
+                  List<String> list = (List<String>) conf2.get(key);
+                  String[] arr = new String[list.size()];
+                  for (int i = 0; i < arr.length; i++) {
+                    arr[i] = mill.constants.Util.interpolateEnvVars(list.get(i), env);
+                  }
+                  return arr;
                 } else {
                   return new String[] {
                     mill.constants.Util.interpolateEnvVars(conf2.get(key).toString(), env)
@@ -226,10 +228,12 @@ public class MillProcessLauncher {
     vmOptions.add("-XX:+HeapDumpOnOutOfMemoryError");
     vmOptions.add("-cp");
     String[] runnerClasspath = cachedComputedValue0(
-        "resolve-runner",
-        BuildInfo.millVersion,
-        () -> CoursierClient.resolveMillDaemon(),
-        arr -> Arrays.stream(arr).allMatch(s -> Files.exists(Paths.get(s))));
+        "resolve-runner", BuildInfo.millVersion, () -> CoursierClient.resolveMillDaemon(), arr -> {
+          for (String s : arr) {
+            if (!Files.exists(Paths.get(s))) return false;
+          }
+          return true;
+        });
     vmOptions.add(String.join(File.pathSeparator, runnerClasspath));
 
     return vmOptions;

--- a/runner/meta/src/mill/meta/MillBuildRootModule.scala
+++ b/runner/meta/src/mill/meta/MillBuildRootModule.scala
@@ -121,8 +121,8 @@ trait MillBuildRootModule()(implicit
 
   def millBuildRootModuleResult = Task {
     Tuple3(
-      runClasspath().map(_.path.toNIO.toString),
-      compile().classes.path.toNIO.toString,
+      runClasspath(),
+      compile().classes,
       codeSignatures()
     )
   }


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/5010, brings `./mill version` JVM launcher times down from ~400ms to ~100-150ms, and native launcher times down to ~50ms, in line with the 0.12.10 numbers. Still more optimization we can do, but this will do for now to close the original ticket.

1. Avoid redundantly hashing files to create `PathRef`s in `MillBuildBootstrap`, which was also expensively creating them all with `quick=false` even for expensive external jars. Instead, we make `PathRef` extend a shared `mill.api.internal.PathRefApi` trait that we can share across the classloader boundary (unlike `PathRef` itself which cannot be shared due to a dependencies on OS-Lib/uPickle), and use the existing `PathRef#sig` directly. This was the main culprit adding 250+ms every run on an empty repo from hashing and re-hashing mill jars in `~/.ivy2/local`

2. Remove some usages of Java streams in the `launcher` and just go back to for-loops to try and minimize classloading

