### PR TITLE
Tag `core.eval`, `resolve`, and `exec` as non-stable `MillPublishScalaModule`s

### DIFF
--- a/core/eval/package.mill
+++ b/core/eval/package.mill
@@ -9,6 +9,6 @@ import millbuild.*
  * without any of the user-land logic or helpers necessary to build actual
  * codebases.
  */
-object `package` extends MillStableScalaModule {
+object `package` extends MillPublishScalaModule {
   def moduleDeps = Seq(build.core.define, build.core.exec, build.core.resolve)
 }

--- a/core/exec/package.mill
+++ b/core/exec/package.mill
@@ -7,7 +7,7 @@ import millbuild.*
  * This module contains code related to planning and execution of the Mill
  * task graph after it has been resolved.
  */
-object `package` extends MillStableScalaModule {
+object `package` extends MillPublishScalaModule {
   def moduleDeps = Seq(build.core.define, build.core.internal)
   def mvnDeps = Seq(Deps.snakeyamlEngine)
 }

--- a/core/resolve/package.mill
+++ b/core/resolve/package.mill
@@ -8,6 +8,6 @@ import millbuild.*
  * tokens like 'foo.{bar,qux}.baz' into Mill tasks that can be
  * executed via [[build.core.exec]]
  */
-object `package` extends MillStableScalaModule {
+object `package` extends MillPublishScalaModule {
   def moduleDeps = Seq(build.core.api, build.core.define, build.core.internal)
 }


### PR DESCRIPTION
These are no longer on the `build.mill` classpath since https://github.com/com-lihaoyi/mill/pull/4879 so they can evolve freely without backwards compatibility concerns