### PR TITLE
Add coursier jvm-index version to dummy dep list for updates

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -191,7 +191,8 @@ val dummyDeps: Seq[Dep] = Seq(
   Deps.TestDeps.zioTest,
   Deps.acyclic,
   Deps.scalacScoverage2Plugin,
-  mvn"com.lihaoyi:::ammonite:${Deps.ammoniteVersion}"
+  mvn"com.lihaoyi:::ammonite:${Deps.ammoniteVersion}",
+  mvn"io.get-coursier.jvm.indices:index-darwin-arm64:${Deps.coursierJvmIndexVersion}"
 ) ++ Deps.transitiveDeps ++ Deps.RuntimeDeps.all
 
 implicit object DepSegment extends Cross.ToSegments[Dep]({ dep =>


### PR DESCRIPTION
This ought to make Scala Steward send updates for the [coursier jvm-index version](https://github.com/com-lihaoyi/mill/blob/a5c41ce47643f8f3630fb220d0d659cf8c20e9ab/mill-build/src/millbuild/Deps.scala#L182) we're using