### PR TITLE
Remove per-mill-version server dir 

### DIFF
--- a/example/depth/sandbox/1-task/build.mill
+++ b/example/depth/sandbox/1-task/build.mill
@@ -85,7 +85,7 @@ def externalPwdTask = Task { println(externalPwd.toString) }
 
 /** Usage
 > ./mill externalPwdTask
-.../out/mill-server/.../sandbox
+.../out/mill-server/sandbox
 */
 
 // === Limitations of Mill's Sandboxing

--- a/integration/invalidation/multi-level-editing/src/MultiLevelBuildTests.scala
+++ b/integration/invalidation/multi-level-editing/src/MultiLevelBuildTests.scala
@@ -108,7 +108,7 @@ trait MultiLevelBuildTests extends UtestIntegrationTestSuite {
     // restarts behave as expected:
     if (clientServerMode) {
       // Only one server should be running at any point in time
-      val Seq(serverFolder) = os.list(tester.workspacePath / "out/mill-server")
+      val serverFolder = tester.workspacePath / "out/mill-server"
 
       // client-server mode should never restart in these tests and preserve the same process,
       val currentServerId = os.read(serverFolder / "processId")

--- a/integration/invalidation/process-file-deleted-exit/src/ProcessFileDeletedExit.scala
+++ b/integration/invalidation/process-file-deleted-exit/src/ProcessFileDeletedExit.scala
@@ -45,9 +45,9 @@ object ProcessFileDeletedExit extends UtestIntegrationTestSuite {
         os.walk(processRoot).exists(_.last == "processId")
       }
 
-      if (tester.clientServerMode){
+      if (tester.clientServerMode) {
         os.remove(processRoot / "processId")
-      } else{
+      } else {
         os.list(processRoot).map { p =>
           os.remove(p / "processId")
         }

--- a/integration/invalidation/process-file-deleted-exit/src/ProcessFileDeletedExit.scala
+++ b/integration/invalidation/process-file-deleted-exit/src/ProcessFileDeletedExit.scala
@@ -45,8 +45,12 @@ object ProcessFileDeletedExit extends UtestIntegrationTestSuite {
         os.walk(processRoot).exists(_.last == "processId")
       }
 
-      os.list(processRoot).map { p =>
-        os.remove(p / "processId")
+      if (tester.clientServerMode){
+        os.remove(processRoot / "processId")
+      } else{
+        os.list(processRoot).map { p =>
+          os.remove(p / "processId")
+        }
       }
 
       eventually {

--- a/runner/client/src/mill/client/ServerLauncher.java
+++ b/runner/client/src/mill/client/ServerLauncher.java
@@ -82,7 +82,7 @@ public abstract class ServerLauncher {
     this.forceFailureForTestingMillisDelay = forceFailureForTestingMillisDelay;
   }
 
-  public Result run(Path serverDir) throws Exception {
+  public Result run(Path serverDir, String javaHome) throws Exception {
 
     Files.createDirectories(serverDir);
 
@@ -91,7 +91,7 @@ public abstract class ServerLauncher {
     Socket ioSocket = launchConnectToServer(serverDir);
 
     try {
-      Thread outPumperThread = startStreamPumpers(ioSocket);
+      Thread outPumperThread = startStreamPumpers(ioSocket, javaHome);
       forceTestFailure(serverDir);
       outPumperThread.join();
     } finally {
@@ -137,11 +137,12 @@ public abstract class ServerLauncher {
     }
   }
 
-  Thread startStreamPumpers(Socket ioSocket) throws Exception {
+  Thread startStreamPumpers(Socket ioSocket, String javaHome) throws Exception {
     InputStream outErr = ioSocket.getInputStream();
     OutputStream in = ioSocket.getOutputStream();
     in.write(Util.hasConsole() ? 1 : 0);
     ClientUtil.writeString(in, BuildInfo.millVersion);
+    ClientUtil.writeString(in, javaHome);
     ClientUtil.writeArgs(args, in);
     ClientUtil.writeMap(env, in);
     ProxyStream.Pumper outPumper = new ProxyStream.Pumper(outErr, stdout, stderr);

--- a/runner/launcher/src/mill/launcher/MillLauncherMain.java
+++ b/runner/launcher/src/mill/launcher/MillLauncherMain.java
@@ -59,9 +59,7 @@ public class MillLauncherMain {
               }
             };
 
-        final String versionAndJvmHomeEncoding =
-            Util.md5hex(mill.client.BuildInfo.millVersion + MillProcessLauncher.javaHome());
-        Path serverDir0 = Paths.get(OutFiles.out, OutFiles.millServer, versionAndJvmHomeEncoding);
+        Path serverDir0 = Paths.get(OutFiles.out, OutFiles.millServer);
         int exitCode = launcher.run(serverDir0).exitCode;
         if (exitCode == ClientUtil.ExitServerCodeWhenVersionMismatch()) {
           exitCode = launcher.run(serverDir0).exitCode;

--- a/runner/launcher/src/mill/launcher/MillLauncherMain.java
+++ b/runner/launcher/src/mill/launcher/MillLauncherMain.java
@@ -7,7 +7,6 @@ import java.util.Collections;
 import mill.client.*;
 import mill.client.lock.Locks;
 import mill.constants.OutFiles;
-import mill.constants.Util;
 
 /**
  * This is a Java implementation to speed up repetitive starts.

--- a/runner/launcher/src/mill/launcher/MillLauncherMain.java
+++ b/runner/launcher/src/mill/launcher/MillLauncherMain.java
@@ -60,9 +60,10 @@ public class MillLauncherMain {
             };
 
         Path serverDir0 = Paths.get(OutFiles.out, OutFiles.millServer);
-        int exitCode = launcher.run(serverDir0).exitCode;
+        String javaHome = MillProcessLauncher.javaHome();
+        int exitCode = launcher.run(serverDir0, javaHome).exitCode;
         if (exitCode == ClientUtil.ExitServerCodeWhenVersionMismatch()) {
-          exitCode = launcher.run(serverDir0).exitCode;
+          exitCode = launcher.run(serverDir0, javaHome).exitCode;
         }
         System.exit(exitCode);
       } catch (Exception e) {

--- a/runner/server/src/mill/server/Server.scala
+++ b/runner/server/src/mill/server/Server.scala
@@ -36,6 +36,8 @@ abstract class Server[T](
   var stateCache = stateCache0
   def stateCache0: T
 
+  var lastMillVersion = Option.empty[String]
+  var lastJavaVersion = Option.empty[String]
   val processId: String = Server.computeProcessId()
   def serverLog0(s: String): Unit = {
     if (os.exists(serverDir) || testLogEvenWhenServerIdWrong) {
@@ -165,6 +167,7 @@ abstract class Server[T](
 
       val interactive = socketIn.read() != 0
       val clientMillVersion = ClientUtil.readString(socketIn)
+      val clientJavaVersion = ClientUtil.readString(socketIn)
       val args = ClientUtil.parseArgs(socketIn)
       val env = ClientUtil.parseMap(socketIn)
       serverLog("args " + upickle.default.write(args))
@@ -176,23 +179,31 @@ abstract class Server[T](
       // that relies on that method
       val proxiedSocketInput = proxyInputStreamThroughPumper(socketIn)
 
-      val serverMillVersion = BuildInfo.millVersion
-      Server.withOutLock(
-        noBuildLock = false,
-        noWaitForBuildLock = false,
-        out = out,
-        targetsAndParams = Seq("checking server version"),
-        streams = new mill.api.SystemStreams(
-          new PrintStream(mill.api.DummyOutputStream),
-          new PrintStream(mill.api.DummyOutputStream),
-          mill.api.DummyInputStream
-        ),
-        outLock = outLock
-      ) {
-        if (clientMillVersion != serverMillVersion) {
-          stderr.println(
-            s"Mill version changed ($serverMillVersion -> $clientMillVersion), re-starting server"
-          )
+      val millVersionChanged = lastMillVersion.exists(_ != clientMillVersion)
+      val javaVersionChanged = lastJavaVersion.exists(_ != clientJavaVersion)
+      if (millVersionChanged || javaVersionChanged) {
+        Server.withOutLock(
+          noBuildLock = false,
+          noWaitForBuildLock = false,
+          out = out,
+          targetsAndParams = Seq("checking server mill version and java version"),
+          streams = new mill.api.SystemStreams(
+            new PrintStream(mill.api.DummyOutputStream),
+            new PrintStream(mill.api.DummyOutputStream),
+            mill.api.DummyInputStream
+          ),
+          outLock = outLock
+        ) {
+          if (millVersionChanged) {
+            stderr.println(
+              s"Mill version changed ($lastMillVersion -> $clientMillVersion), re-starting server"
+            )
+          }
+          if (javaVersionChanged) {
+            stderr.println(
+              s"Java version changed ($lastJavaVersion -> $clientJavaVersion), re-starting server"
+            )
+          }
           os.write(
             serverDir / ServerFiles.exitCode,
             ClientUtil.ExitServerCodeWhenVersionMismatch().toString.getBytes()
@@ -200,6 +211,8 @@ abstract class Server[T](
           System.exit(ClientUtil.ExitServerCodeWhenVersionMismatch())
         }
       }
+      lastMillVersion = Some(clientMillVersion)
+      lastJavaVersion = Some(clientJavaVersion)
       @volatile var done = false
       @volatile var idle = false
       val t = new Thread(

--- a/runner/server/src/mill/server/Server.scala
+++ b/runner/server/src/mill/server/Server.scala
@@ -185,7 +185,7 @@ abstract class Server[T](
         streams = new mill.api.SystemStreams(
           new PrintStream(mill.api.DummyOutputStream),
           new PrintStream(mill.api.DummyOutputStream),
-          mill.api.DummyInputStream,
+          mill.api.DummyInputStream
         ),
         outLock = outLock
       ) {

--- a/runner/server/test/src/mill/server/ClientServerTests.scala
+++ b/runner/server/test/src/mill/server/ClientServerTests.scala
@@ -24,6 +24,11 @@ object ClientServerTests extends TestSuite {
       testLogEvenWhenServerIdWrong: Boolean
   ) extends Server[Option[Int]](serverDir, 1000, locks, testLogEvenWhenServerIdWrong)
       with Runnable {
+
+    override def outLock = mill.client.lock.Lock.memory()
+
+    override def out = os.temp.dir()
+
     override def exitServer() = {
       serverLog("exiting server")
       super.exitServer()

--- a/runner/server/test/src/mill/server/ClientServerTests.scala
+++ b/runner/server/test/src/mill/server/ClientServerTests.scala
@@ -111,7 +111,7 @@ object ClientServerTests extends TestSuite {
             testLogEvenWhenServerIdWrong
           )).start()
         }
-      }.run((outDir / "server-0").relativeTo(os.pwd).toNIO)
+      }.run((outDir / "server-0").relativeTo(os.pwd).toNIO, "")
 
       ClientResult(
         result.exitCode,

--- a/testkit/src/mill/testkit/IntegrationTesterBase.scala
+++ b/testkit/src/mill/testkit/IntegrationTesterBase.scala
@@ -70,9 +70,9 @@ trait IntegrationTesterBase {
   def removeProcessIdFile(): Unit = {
     val outDir = os.Path(out, workspacePath)
     if (os.exists(outDir)) {
-      val serverPath0 = outDir / (if (clientServerMode) millServer else millNoServer)
+      val serverPath = outDir / (if (clientServerMode) millServer else millNoServer)
 
-      for (serverPath <- os.list.stream(serverPath0)) os.remove(serverPath / processId)
+      os.remove(serverPath / processId)
 
       Thread.sleep(500) // give a moment for the server to notice the file is gone and exit
     }

--- a/testkit/src/mill/testkit/IntegrationTesterBase.scala
+++ b/testkit/src/mill/testkit/IntegrationTesterBase.scala
@@ -70,10 +70,15 @@ trait IntegrationTesterBase {
   def removeProcessIdFile(): Unit = {
     val outDir = os.Path(out, workspacePath)
     if (os.exists(outDir)) {
-      val serverPath = outDir / (if (clientServerMode) millServer else millNoServer)
+      if (clientServerMode){
+        val serverPath = outDir / millServer
+        os.remove(serverPath / processId)
+      }else{
+        val serverPath0 = outDir / millNoServer
 
-      os.remove(serverPath / processId)
+        for (serverPath <- os.list.stream(serverPath0)) os.remove(serverPath / processId)
 
+      }
       Thread.sleep(500) // give a moment for the server to notice the file is gone and exit
     }
   }

--- a/testkit/src/mill/testkit/IntegrationTesterBase.scala
+++ b/testkit/src/mill/testkit/IntegrationTesterBase.scala
@@ -70,10 +70,10 @@ trait IntegrationTesterBase {
   def removeProcessIdFile(): Unit = {
     val outDir = os.Path(out, workspacePath)
     if (os.exists(outDir)) {
-      if (clientServerMode){
+      if (clientServerMode) {
         val serverPath = outDir / millServer
         os.remove(serverPath / processId)
-      }else{
+      } else {
         val serverPath0 = outDir / millNoServer
 
         for (serverPath <- os.list.stream(serverPath0)) os.remove(serverPath / processId)

--- a/testkit/test/src/mill/testkit/ExampleTesterTests.scala
+++ b/testkit/test/src/mill/testkit/ExampleTesterTests.scala
@@ -13,7 +13,7 @@ object ExampleTesterTests extends TestSuite {
         millExecutable = os.Path(sys.env("MILL_EXECUTABLE_PATH"))
       )
 
-      assert(os.exists(workspacePath / "out/mill-server"))
+      assert(os.exists(workspacePath / "out/mill-no-server"))
 
       assert(TestkitTestUtils.getProcessIdFiles(workspacePath).isEmpty)
     }

--- a/testkit/test/src/mill/testkit/ExampleTesterTests.scala
+++ b/testkit/test/src/mill/testkit/ExampleTesterTests.scala
@@ -13,7 +13,7 @@ object ExampleTesterTests extends TestSuite {
         millExecutable = os.Path(sys.env("MILL_EXECUTABLE_PATH"))
       )
 
-      assert(os.exists(workspacePath / "out/mill-no-server"))
+      assert(os.exists(workspacePath / "out/mill-server"))
 
       assert(TestkitTestUtils.getProcessIdFiles(workspacePath).isEmpty)
     }


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/5112

This PR also makes us take the lock when checking the Mill version, so when we exit we can be sure we are not interrupting any other concurrent launcher connected to the same daemon, and extends it to also exit when the Java home changes

We still maintain support for multiple processes in `--no-server` mode, since in that case you may have multiple clients running at the same time (e.g. waiting on `--watch`) and each client needs it's own corresponding server process