### PR TITLE
Make `runBackground` use process IDs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@ end_of_line = lf
 insert_final_newline = true
 charset = utf-8
 indent_style = space
-indent_size = 4
+indent_size = 2
 
 [*.scala]
 end_of_line = lf

--- a/core/define/src/mill/define/Task.scala
+++ b/core/define/src/mill/define/Task.scala
@@ -124,7 +124,8 @@ object Task extends TaskBase {
   inline def Command[T](inline t: Result[T])(implicit
       inline w: Writer[T],
       inline ctx: ModuleCtx
-  ): Command[T] = ${ TaskMacros.commandImpl[T]('t)('w, 'ctx, exclusive = '{ false }, persistent = '{ false }) }
+  ): Command[T] =
+    ${ TaskMacros.commandImpl[T]('t)('w, 'ctx, exclusive = '{ false }, persistent = '{ false }) }
 
   /**
    * @param exclusive Exclusive commands run serially at the end of an evaluation,
@@ -145,7 +146,8 @@ object Task extends TaskBase {
     inline def apply[T](inline t: Result[T])(implicit
         inline w: Writer[T],
         inline ctx: ModuleCtx
-    ): Command[T] = ${ TaskMacros.commandImpl[T]('t)('w, 'ctx, '{ this.exclusive }, '{ this.persistent }) }
+    ): Command[T] =
+      ${ TaskMacros.commandImpl[T]('t)('w, 'ctx, '{ this.exclusive }, '{ this.persistent }) }
   }
 
   /**
@@ -565,7 +567,15 @@ private object TaskMacros {
     appImpl[Command, T](
       (in, ev) =>
         '{
-          new Command[T]($in, $ev, $ctx, $w, ${ taskIsPrivate() }, exclusive = $exclusive, persistent = $persistent)
+          new Command[T](
+            $in,
+            $ev,
+            $ctx,
+            $w,
+            ${ taskIsPrivate() },
+            exclusive = $exclusive,
+            persistent = $persistent
+          )
         },
       t
     )

--- a/core/define/src/mill/define/Task.scala
+++ b/core/define/src/mill/define/Task.scala
@@ -124,7 +124,7 @@ object Task extends TaskBase {
   inline def Command[T](inline t: Result[T])(implicit
       inline w: Writer[T],
       inline ctx: ModuleCtx
-  ): Command[T] = ${ TaskMacros.commandImpl[T]('t)('w, 'ctx, exclusive = '{ false }) }
+  ): Command[T] = ${ TaskMacros.commandImpl[T]('t)('w, 'ctx, exclusive = '{ false }, persistent = '{ false }) }
 
   /**
    * @param exclusive Exclusive commands run serially at the end of an evaluation,
@@ -133,16 +133,19 @@ object Task extends TaskBase {
    *                  These are normally used for "top level" commands which are
    *                  run directly to perform some action or display some output
    *                  to the user.
+   * @param persistent If true the `Task.dest` directory is not cleaned between
+   *                   runs.
    */
   def Command(
       t: NamedParameterOnlyDummy = new NamedParameterOnlyDummy,
-      exclusive: Boolean = false
-  ): CommandFactory = new CommandFactory(exclusive)
-  class CommandFactory private[mill] (val exclusive: Boolean) {
+      exclusive: Boolean = false,
+      persistent: Boolean = false
+  ): CommandFactory = new CommandFactory(exclusive = exclusive, persistent = persistent)
+  class CommandFactory private[mill] (val exclusive: Boolean, val persistent: Boolean) {
     inline def apply[T](inline t: Result[T])(implicit
         inline w: Writer[T],
         inline ctx: ModuleCtx
-    ): Command[T] = ${ TaskMacros.commandImpl[T]('t)('w, 'ctx, '{ this.exclusive }) }
+    ): Command[T] = ${ TaskMacros.commandImpl[T]('t)('w, 'ctx, '{ this.exclusive }, '{ this.persistent }) }
   }
 
   /**
@@ -400,7 +403,8 @@ class Command[+T](
     val ctx0: mill.define.ModuleCtx,
     val writer: Writer[?],
     val isPrivate: Option[Boolean],
-    val exclusive: Boolean
+    val exclusive: Boolean,
+    override val persistent: Boolean
 ) extends NamedTask[T] {
 
   override def asCommand: Some[Command[T]] = Some(this)
@@ -555,12 +559,13 @@ private object TaskMacros {
   )(t: Expr[Result[T]])(
       w: Expr[Writer[T]],
       ctx: Expr[mill.define.ModuleCtx],
-      exclusive: Expr[Boolean]
+      exclusive: Expr[Boolean],
+      persistent: Expr[Boolean]
   ): Expr[Command[T]] = {
     appImpl[Command, T](
       (in, ev) =>
         '{
-          new Command[T]($in, $ev, $ctx, $w, ${ taskIsPrivate() }, exclusive = $exclusive)
+          new Command[T]($in, $ev, $ctx, $w, ${ taskIsPrivate() }, exclusive = $exclusive, persistent = $persistent)
         },
       t
     )

--- a/integration/invalidation/run-background/src/RunBackgroundTests.scala
+++ b/integration/invalidation/run-background/src/RunBackgroundTests.scala
@@ -56,7 +56,7 @@ object RunBackgroundTests extends UtestIntegrationTestSuite {
           "first process should be exited after second process is running"
         )
 
-        if (tester.clientServerMode) eval("shutdown")
+        if (tester.daemonMode) eval("shutdown")
         continually { !probeLockAvailable(lock2) }
         os.write(stop, "")
         eventually { probeLockAvailable(lock2) }

--- a/integration/invalidation/run-background/src/RunBackgroundTests.scala
+++ b/integration/invalidation/run-background/src/RunBackgroundTests.scala
@@ -39,24 +39,28 @@ object RunBackgroundTests extends UtestIntegrationTestSuite {
     }
 
     test("sequential") - integrationTest { tester =>
-      import tester._
-      val lock1 = os.temp()
-      val lock2 = os.temp()
-      val stop = os.temp()
-      os.remove(stop)
-      eval(("foo.runBackground", lock1, stop))
-      eventually { !probeLockAvailable(lock1) }
-      eval(("foo.runBackground", lock2, stop))
-      eventually { !probeLockAvailable(lock2) }
-      Predef.assert(
-        probeLockAvailable(lock1),
-        "first process should be exited after second process is running"
-      )
+      // This test fails on Windows. We will need to look into it, but it also does not work on `main` branch, so it's
+      // not a regression, thus we'll leave it for now.
+      if (!scala.util.Properties.isWin) {
+        import tester._
+        val lock1 = os.temp()
+        val lock2 = os.temp()
+        val stop = os.temp()
+        os.remove(stop)
+        eval(("foo.runBackground", lock1, stop))
+        eventually { !probeLockAvailable(lock1) }
+        eval(("foo.runBackground", lock2, stop))
+        eventually { !probeLockAvailable(lock2) }
+        Predef.assert(
+          probeLockAvailable(lock1),
+          "first process should be exited after second process is running"
+        )
 
-      if (tester.clientServerMode) eval("shutdown")
-      continually { !probeLockAvailable(lock2) }
-      os.write(stop, "")
-      eventually { probeLockAvailable(lock2) }
+        if (tester.clientServerMode) eval("shutdown")
+        continually { !probeLockAvailable(lock2) }
+        os.write(stop, "")
+        eventually { probeLockAvailable(lock2) }
+      }
     }
 
     test("clean") - integrationTest { tester =>

--- a/integration/invalidation/run-background/src/RunBackgroundTests.scala
+++ b/integration/invalidation/run-background/src/RunBackgroundTests.scala
@@ -37,7 +37,7 @@ object RunBackgroundTests extends UtestIntegrationTestSuite {
       os.write(stop, "")
       eventually { probeLockAvailable(lock) }
     }
-    
+
     test("sequential") - integrationTest { tester =>
       import tester._
       val lock1 = os.temp()
@@ -48,14 +48,17 @@ object RunBackgroundTests extends UtestIntegrationTestSuite {
       eventually { !probeLockAvailable(lock1) }
       eval(("foo.runBackground", lock2, stop))
       eventually { !probeLockAvailable(lock2) }
-      Predef.assert(probeLockAvailable(lock1), "first process should be exited after second process is running")
-      
+      Predef.assert(
+        probeLockAvailable(lock1),
+        "first process should be exited after second process is running"
+      )
+
       if (tester.clientServerMode) eval("shutdown")
       continually { !probeLockAvailable(lock2) }
       os.write(stop, "")
       eventually { probeLockAvailable(lock2) }
     }
-    
+
     test("clean") - integrationTest { tester =>
       import tester._
       val lock = os.temp()

--- a/libs/pythonlib/src/mill/pythonlib/PythonModule.scala
+++ b/libs/pythonlib/src/mill/pythonlib/PythonModule.scala
@@ -176,7 +176,7 @@ trait PythonModule extends PipModule with TaskModule { outer =>
    * @see [[mainScript]]
    */
   def runBackground(args: mill.define.Args) = Task.Command {
-    val (procUuidPath, procLockfile, procUuid) = mill.scalalib.RunModule.backgroundSetup(Task.dest)
+    val backgroundPaths = mill.scalalib.RunModule.BackgroundPaths(Task.dest)
     val pwd0 = os.Path(java.nio.file.Paths.get(".").toAbsolutePath)
 
     os.checker.withValue(os.Checker.Nop) {
@@ -185,11 +185,7 @@ trait PythonModule extends PipModule with TaskModule { outer =>
         classPath = mill.scalalib.JvmWorkerModule.backgroundWrapperClasspath().map(_.path).toSeq,
         jvmArgs = Nil,
         env = runnerEnvTask(),
-        mainArgs = Seq(
-          procUuidPath.toString,
-          procLockfile.toString,
-          procUuid,
-          "500",
+        mainArgs = backgroundPaths.toArgs ++ Seq(
           "<subprocess>",
           pythonExe().path.toString,
           mainScript().path.toString

--- a/libs/pythonlib/src/mill/pythonlib/PythonModule.scala
+++ b/libs/pythonlib/src/mill/pythonlib/PythonModule.scala
@@ -175,7 +175,7 @@ trait PythonModule extends PipModule with TaskModule { outer =>
    *
    * @see [[mainScript]]
    */
-  def runBackground(args: mill.define.Args) = Task.Command {
+  def runBackground(args: mill.define.Args) = Task.Command(persistent = true) {
     val backgroundPaths = mill.scalalib.RunModule.BackgroundPaths(Task.dest)
     val pwd0 = os.Path(java.nio.file.Paths.get(".").toAbsolutePath)
 

--- a/libs/scalalib/backgroundwrapper/src/mill/scalalib/backgroundwrapper/MillBackgroundWrapper.java
+++ b/libs/scalalib/backgroundwrapper/src/mill/scalalib/backgroundwrapper/MillBackgroundWrapper.java
@@ -3,18 +3,26 @@ package mill.scalalib.backgroundwrapper;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
-import java.nio.file.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
 import java.util.Optional;
 
 @SuppressWarnings("BusyWait")
 public class MillBackgroundWrapper {
+  private static final long NS_IN_S = 1_000_000_000;
 
   public static void main(String[] args) throws Exception {
     var newestProcessIdPath = Paths.get(args[0]);
     var currentlyRunningProccesIdPath = Paths.get(args[1]);
     var procLockfile = Paths.get(args[2]);
-    var realMain = args[3];
-    var realArgs = java.util.Arrays.copyOfRange(args, 4, args.length);
+    var logPath = Paths.get(args[3]);
+    var realMain = args[4];
+    var realArgs = java.util.Arrays.copyOfRange(args, 5, args.length);
 
     // The following code should handle this scenario, when we have 2 processes contending for the
     // lock.
@@ -39,41 +47,82 @@ public class MillBackgroundWrapper {
     // Indicate to the previous process that we want to take over.
     var myPid = ProcessHandle.current().pid();
     var myPidStr = "" + myPid;
-    Files.writeString(newestProcessIdPath, myPidStr, StandardOpenOption.CREATE);
+    log(logPath, myPid, "Starting. Writing my PID to " + newestProcessIdPath);
+    Files.writeString(
+      newestProcessIdPath,
+      myPidStr,
+      StandardOpenOption.CREATE,
+      StandardOpenOption.TRUNCATE_EXISTING);
 
     // Take a lock on `procLockfile` to ensure that only one
     // `runBackground` process  is running at any point in time.
+    log(logPath, myPid, "Acquiring lock on " + procLockfile);
+
     //noinspection resource - this is intentional, file is released when process dies.
     RandomAccessFile raf = new RandomAccessFile(procLockfile.toFile(), "rw");
     FileChannel chan = raf.getChannel();
     if (chan.tryLock() == null) {
-      System.err.println("Waiting for runBackground lock to be available");
+      var startTimeNanos = System.nanoTime();
+      System.err.println("[mill:runBackground] Waiting for runBackground lock to be available");
       // this is intentional, lock is released when process dies.
       //noinspection ResultOfMethodCallIgnored
       chan.lock();
+      var delta = (System.nanoTime() - startTimeNanos) / NS_IN_S;
+      System.err.println("[mill:runBackground] Lock acquired after " + delta + "s");
     }
+    log(logPath, myPid, "Lock acquired");
 
     var oldProcessPid = readPreviousPid(currentlyRunningProccesIdPath);
-    oldProcessPid.ifPresent(MillBackgroundWrapper::waitForPreviousProcessToTerminate);
-    Files.writeString(currentlyRunningProccesIdPath, myPidStr, StandardOpenOption.CREATE);
+    log(logPath, myPid, "Old process PID: " + oldProcessPid);
+    oldProcessPid.ifPresent((oldPid) -> {
+      var startTimeNanos = System.nanoTime();
+      log(logPath, myPid, "Waiting for old process to terminate");
+      var processExisted = waitForPreviousProcessToTerminate(oldPid);
+      if (processExisted) {
+        log(
+          logPath,
+          myPid,
+          "Old process terminated in " + (System.nanoTime() - startTimeNanos) / NS_IN_S + "s");
+      } else {
+        log(logPath, myPid, "Old process was already terminated.");
+      }
+    });
+
+    log(logPath, myPid, "Writing my PID to " + currentlyRunningProccesIdPath);
+    Files.writeString(
+      currentlyRunningProccesIdPath,
+      myPidStr,
+      StandardOpenOption.CREATE,
+      StandardOpenOption.TRUNCATE_EXISTING);
 
     // Start the thread to watch for updates on the process marker file,
     // so we can exit if it is deleted or replaced
-    var startTime = System.currentTimeMillis();
-    checkIfWeStillNeedToBeRunning(startTime, newestProcessIdPath, myPidStr);
+    var startTimeNanos = System.nanoTime(); // use nanoTime as it is monotonic
+    checkIfWeStillNeedToBeRunning(logPath, startTimeNanos, newestProcessIdPath, myPid);
     var watcher = new Thread(() -> {
-      while (true) checkIfWeStillNeedToBeRunning(startTime, newestProcessIdPath, myPidStr);
+      while (true)
+        checkIfWeStillNeedToBeRunning(logPath, startTimeNanos, newestProcessIdPath, myPid);
     });
     watcher.setDaemon(true);
     watcher.start();
 
     // Actually start the Java main method we wanted to run in the background
     if (!realMain.equals("<subprocess>")) {
+      log(
+        logPath,
+        myPid,
+        "Running main method " + realMain + " with args " + Arrays.toString(realArgs));
       Class.forName(realMain).getMethod("main", String[].class).invoke(null, (Object) realArgs);
     } else {
+      log(logPath, myPid, "Running subprocess with args " + Arrays.toString(realArgs));
       Process subprocess = new ProcessBuilder().command(realArgs).inheritIO().start();
+      log(
+        logPath,
+        myPid,
+        "Subprocess started with PID " + subprocess.pid() + ", waiting for it to exit");
 
       Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+        log(logPath, myPid, "Shutdown hook called, terminating subprocess");
         subprocess.destroy();
 
         long now = System.currentTimeMillis();
@@ -87,25 +136,39 @@ public class MillBackgroundWrapper {
           }
         }
         if (subprocess.isAlive()) {
+          log(logPath, myPid, "Forcing subprocess termination");
           subprocess.destroyForcibly();
         }
       }));
-      System.exit(subprocess.waitFor());
+
+      log(logPath, myPid, "Waiting for subprocess to terminate");
+      var exitCode = subprocess.waitFor();
+      log(logPath, myPid, "Subprocess terminated with exit code " + exitCode);
+      System.exit(exitCode);
     }
   }
 
   private static void checkIfWeStillNeedToBeRunning(
-      long startTime, Path newestProcessIdPath, String myPidStr) {
-    long delta = (System.currentTimeMillis() - startTime) / 1000;
+    Path logPath, long startTimeNanos, Path newestProcessIdPath, long myPid) {
+    var delta = (System.nanoTime() - startTimeNanos) / NS_IN_S;
+    var myPidStr = "" + myPid;
     try {
       Thread.sleep(50);
-      String token = Files.readString(newestProcessIdPath);
-      if (!token.equals(myPidStr)) {
-        System.err.println("runBackground exiting after " + delta + "s");
+      var token = Files.readString(newestProcessIdPath);
+      if (!myPidStr.equals(token)) {
+        log(
+          logPath,
+          myPid,
+          "New process started, exiting. Token file (" + newestProcessIdPath + ") contents: \""
+            + token + "\"");
+        System.err.println(
+          "[mill:runBackground] Background process has been replaced with a new process (PID: "
+            + token + "), exiting after " + delta + "s");
         System.exit(0);
       }
     } catch (Exception e) {
-      System.err.println("runBackground exiting after " + delta + "s");
+      log(logPath, myPid, "Check if we still need to be running failed, exiting. Exception: " + e);
+      System.err.println("[mill:runBackground] Background process exiting after " + delta + "s");
       System.exit(0);
     }
   }
@@ -119,17 +182,32 @@ public class MillBackgroundWrapper {
     }
   }
 
-  static void waitForPreviousProcessToTerminate(long pid) {
+  /** Returns true if the process with the given PID has terminated, false if the process did not exist. */
+  static boolean waitForPreviousProcessToTerminate(long pid) {
     var maybeOldProcess = ProcessHandle.of(pid);
-    if (maybeOldProcess.isEmpty()) return;
+    if (maybeOldProcess.isEmpty()) return false;
     var oldProcess = maybeOldProcess.get();
 
     try {
       while (oldProcess.isAlive()) {
         Thread.sleep(50);
       }
+      return true;
     } catch (InterruptedException e) {
       throw new RuntimeException(e);
+    }
+  }
+
+  static void log(Path logFile, long myPid, String message) {
+    var timestamp = DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(LocalDateTime.now());
+    try {
+      Files.writeString(
+        logFile,
+        "[" + timestamp + "] " + myPid + ": " + message + "\n",
+        StandardOpenOption.CREATE,
+        StandardOpenOption.APPEND);
+    } catch (IOException e) {
+      // do nothing
     }
   }
 }

--- a/libs/scalalib/backgroundwrapper/src/mill/scalalib/backgroundwrapper/MillBackgroundWrapper.java
+++ b/libs/scalalib/backgroundwrapper/src/mill/scalalib/backgroundwrapper/MillBackgroundWrapper.java
@@ -48,8 +48,8 @@ public class MillBackgroundWrapper {
     FileChannel chan = raf.getChannel();
     if (chan.tryLock() == null) {
       System.err.println("Waiting for runBackground lock to be available");
-      //noinspection ResultOfMethodCallIgnored - this is intentional, lock is released when process
-      // dies.
+      // this is intentional, lock is released when process dies.
+      //noinspection ResultOfMethodCallIgnored
       chan.lock();
     }
 

--- a/libs/scalalib/backgroundwrapper/src/mill/scalalib/backgroundwrapper/MillBackgroundWrapper.java
+++ b/libs/scalalib/backgroundwrapper/src/mill/scalalib/backgroundwrapper/MillBackgroundWrapper.java
@@ -5,7 +5,6 @@ import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
 import java.nio.file.*;
 import java.util.Optional;
-import java.util.function.Consumer;
 
 @SuppressWarnings("BusyWait")
 public class MillBackgroundWrapper {
@@ -17,19 +16,24 @@ public class MillBackgroundWrapper {
     var realMain = args[3];
     var realArgs = java.util.Arrays.copyOfRange(args, 4, args.length);
 
-    // The following code should handle this scenario, when we have 2 processes contending for the lock.
+    // The following code should handle this scenario, when we have 2 processes contending for the
+    // lock.
     //
-    // This can happen if a new MillBackgroundWrapper is launched while the previous one is still running due to rapid
+    // This can happen if a new MillBackgroundWrapper is launched while the previous one is still
+    // running due to rapid
     // changes in the source code.
     //
     // Process 1 starts, writes newest_pid=1, claims lock, writes currently_running_pid = 1
     // Process 2 starts, writes newest_pid=2, tries to claim lock but is blocked
-    // Process 3 starts at the same time as process 2, writes newest_pid=3, tries to claim lock but is blocked
+    // Process 3 starts at the same time as process 2, writes newest_pid=3, tries to claim lock but
+    // is blocked
     //
     // Process 1 reads newest_pid=3, terminates, releases lock
-    // Process 2 claims lock, reads currently_running_pid = 1, waits for process 1 to die, writes currently_running_pid = 2
+    // Process 2 claims lock, reads currently_running_pid = 1, waits for process 1 to die, writes
+    // currently_running_pid = 2
     // Process 2 reads newest_pid=3, terminates, releases lock
-    // Process 3 claims lock, reads currently_running_pid = 2, waits for process 2 to die, writes currently_running_pid = 3, then starts
+    // Process 3 claims lock, reads currently_running_pid = 2, waits for process 2 to die, writes
+    // currently_running_pid = 3, then starts
     // Process 3 reads newest_pid=3, continues running
 
     // Indicate to the previous process that we want to take over.
@@ -44,7 +48,8 @@ public class MillBackgroundWrapper {
     FileChannel chan = raf.getChannel();
     if (chan.tryLock() == null) {
       System.err.println("Waiting for runBackground lock to be available");
-      //noinspection ResultOfMethodCallIgnored - this is intentional, lock is released when process dies.
+      //noinspection ResultOfMethodCallIgnored - this is intentional, lock is released when process
+      // dies.
       chan.lock();
     }
 
@@ -89,7 +94,8 @@ public class MillBackgroundWrapper {
     }
   }
 
-  private static void checkIfWeStillNeedToBeRunning(long startTime, Path newestProcessIdPath, String myPidStr) {
+  private static void checkIfWeStillNeedToBeRunning(
+      long startTime, Path newestProcessIdPath, String myPidStr) {
     long delta = (System.currentTimeMillis() - startTime) / 1000;
     try {
       Thread.sleep(50);

--- a/libs/scalalib/backgroundwrapper/src/mill/scalalib/backgroundwrapper/MillBackgroundWrapper.java
+++ b/libs/scalalib/backgroundwrapper/src/mill/scalalib/backgroundwrapper/MillBackgroundWrapper.java
@@ -49,10 +49,10 @@ public class MillBackgroundWrapper {
     var myPidStr = "" + myPid;
     log(logPath, myPid, "Starting. Writing my PID to " + newestProcessIdPath);
     Files.writeString(
-      newestProcessIdPath,
-      myPidStr,
-      StandardOpenOption.CREATE,
-      StandardOpenOption.TRUNCATE_EXISTING);
+        newestProcessIdPath,
+        myPidStr,
+        StandardOpenOption.CREATE,
+        StandardOpenOption.TRUNCATE_EXISTING);
 
     // Take a lock on `procLockfile` to ensure that only one
     // `runBackground` process  is running at any point in time.
@@ -80,9 +80,9 @@ public class MillBackgroundWrapper {
       var processExisted = waitForPreviousProcessToTerminate(oldPid);
       if (processExisted) {
         log(
-          logPath,
-          myPid,
-          "Old process terminated in " + (System.nanoTime() - startTimeNanos) / NS_IN_S + "s");
+            logPath,
+            myPid,
+            "Old process terminated in " + (System.nanoTime() - startTimeNanos) / NS_IN_S + "s");
       } else {
         log(logPath, myPid, "Old process was already terminated.");
       }
@@ -90,10 +90,10 @@ public class MillBackgroundWrapper {
 
     log(logPath, myPid, "Writing my PID to " + currentlyRunningProccesIdPath);
     Files.writeString(
-      currentlyRunningProccesIdPath,
-      myPidStr,
-      StandardOpenOption.CREATE,
-      StandardOpenOption.TRUNCATE_EXISTING);
+        currentlyRunningProccesIdPath,
+        myPidStr,
+        StandardOpenOption.CREATE,
+        StandardOpenOption.TRUNCATE_EXISTING);
 
     // Start the thread to watch for updates on the process marker file,
     // so we can exit if it is deleted or replaced
@@ -109,17 +109,17 @@ public class MillBackgroundWrapper {
     // Actually start the Java main method we wanted to run in the background
     if (!realMain.equals("<subprocess>")) {
       log(
-        logPath,
-        myPid,
-        "Running main method " + realMain + " with args " + Arrays.toString(realArgs));
+          logPath,
+          myPid,
+          "Running main method " + realMain + " with args " + Arrays.toString(realArgs));
       Class.forName(realMain).getMethod("main", String[].class).invoke(null, (Object) realArgs);
     } else {
       log(logPath, myPid, "Running subprocess with args " + Arrays.toString(realArgs));
       Process subprocess = new ProcessBuilder().command(realArgs).inheritIO().start();
       log(
-        logPath,
-        myPid,
-        "Subprocess started with PID " + subprocess.pid() + ", waiting for it to exit");
+          logPath,
+          myPid,
+          "Subprocess started with PID " + subprocess.pid() + ", waiting for it to exit");
 
       Runtime.getRuntime().addShutdownHook(new Thread(() -> {
         log(logPath, myPid, "Shutdown hook called, terminating subprocess");
@@ -149,7 +149,7 @@ public class MillBackgroundWrapper {
   }
 
   private static void checkIfWeStillNeedToBeRunning(
-    Path logPath, long startTimeNanos, Path newestProcessIdPath, long myPid) {
+      Path logPath, long startTimeNanos, Path newestProcessIdPath, long myPid) {
     var delta = (System.nanoTime() - startTimeNanos) / NS_IN_S;
     var myPidStr = "" + myPid;
     try {
@@ -157,13 +157,13 @@ public class MillBackgroundWrapper {
       var token = Files.readString(newestProcessIdPath);
       if (!myPidStr.equals(token)) {
         log(
-          logPath,
-          myPid,
-          "New process started, exiting. Token file (" + newestProcessIdPath + ") contents: \""
-            + token + "\"");
+            logPath,
+            myPid,
+            "New process started, exiting. Token file (" + newestProcessIdPath + ") contents: \""
+                + token + "\"");
         System.err.println(
-          "[mill:runBackground] Background process has been replaced with a new process (PID: "
-            + token + "), exiting after " + delta + "s");
+            "[mill:runBackground] Background process has been replaced with a new process (PID: "
+                + token + "), exiting after " + delta + "s");
         System.exit(0);
       }
     } catch (Exception e) {
@@ -202,10 +202,10 @@ public class MillBackgroundWrapper {
     var timestamp = DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(LocalDateTime.now());
     try {
       Files.writeString(
-        logFile,
-        "[" + timestamp + "] " + myPid + ": " + message + "\n",
-        StandardOpenOption.CREATE,
-        StandardOpenOption.APPEND);
+          logFile,
+          "[" + timestamp + "] " + myPid + ": " + message + "\n",
+          StandardOpenOption.CREATE,
+          StandardOpenOption.APPEND);
     } catch (IOException e) {
       // do nothing
     }

--- a/libs/scalalib/backgroundwrapper/src/mill/scalalib/backgroundwrapper/MillBackgroundWrapper.java
+++ b/libs/scalalib/backgroundwrapper/src/mill/scalalib/backgroundwrapper/MillBackgroundWrapper.java
@@ -1,57 +1,68 @@
 package mill.scalalib.backgroundwrapper;
 
+import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
 import java.nio.file.*;
+import java.util.Optional;
+import java.util.function.Consumer;
 
+@SuppressWarnings("BusyWait")
 public class MillBackgroundWrapper {
-  public static void main(String[] args) throws Exception {
-    Path procUuidPath = Paths.get(args[0]);
-    Path procLockfile = Paths.get(args[1]);
-    String procUuid = args[2];
-    int lockDelay = Integer.parseInt(args[3]);
 
-    Files.writeString(procUuidPath, procUuid, StandardOpenOption.CREATE);
+  public static void main(String[] args) throws Exception {
+    var newestProcessIdPath = Paths.get(args[0]);
+    var currentlyRunningProccesIdPath = Paths.get(args[1]);
+    var procLockfile = Paths.get(args[2]);
+    var realMain = args[3];
+    var realArgs = java.util.Arrays.copyOfRange(args, 4, args.length);
+
+    // The following code should handle this scenario, when we have 2 processes contending for the lock.
+    //
+    // This can happen if a new MillBackgroundWrapper is launched while the previous one is still running due to rapid
+    // changes in the source code.
+    //
+    // Process 1 starts, writes newest_pid=1, claims lock, writes currently_running_pid = 1
+    // Process 2 starts, writes newest_pid=2, tries to claim lock but is blocked
+    // Process 3 starts at the same time as process 2, writes newest_pid=3, tries to claim lock but is blocked
+    //
+    // Process 1 reads newest_pid=3, terminates, releases lock
+    // Process 2 claims lock, reads currently_running_pid = 1, waits for process 1 to die, writes currently_running_pid = 2
+    // Process 2 reads newest_pid=3, terminates, releases lock
+    // Process 3 claims lock, reads currently_running_pid = 2, waits for process 2 to die, writes currently_running_pid = 3, then starts
+    // Process 3 reads newest_pid=3, continues running
+
+    // Indicate to the previous process that we want to take over.
+    var myPid = ProcessHandle.current().pid();
+    var myPidStr = "" + myPid;
+    Files.writeString(newestProcessIdPath, myPidStr, StandardOpenOption.CREATE);
 
     // Take a lock on `procLockfile` to ensure that only one
     // `runBackground` process  is running at any point in time.
+    //noinspection resource - this is intentional, file is released when process dies.
     RandomAccessFile raf = new RandomAccessFile(procLockfile.toFile(), "rw");
     FileChannel chan = raf.getChannel();
     if (chan.tryLock() == null) {
       System.err.println("Waiting for runBackground lock to be available");
+      //noinspection ResultOfMethodCallIgnored - this is intentional, lock is released when process dies.
       chan.lock();
     }
 
-    // For some reason even after the previous process exits things like sockets
-    // may still take time to free, so sleep for a configurable duration before proceeding
-    Thread.sleep(lockDelay);
+    var oldProcessPid = readPreviousPid(currentlyRunningProccesIdPath);
+    oldProcessPid.ifPresent(MillBackgroundWrapper::waitForPreviousProcessToTerminate);
+    Files.writeString(currentlyRunningProccesIdPath, myPidStr, StandardOpenOption.CREATE);
 
     // Start the thread to watch for updates on the process marker file,
     // so we can exit if it is deleted or replaced
-    long startTime = System.currentTimeMillis();
-    Thread watcher = new Thread(() -> {
-      while (true) {
-        long delta = (System.currentTimeMillis() - startTime) / 1000;
-        try {
-          Thread.sleep(1);
-          String token = Files.readString(procUuidPath);
-          if (!token.equals(procUuid)) {
-            System.err.println("runBackground exiting after " + delta + "s");
-            System.exit(0);
-          }
-        } catch (Exception e) {
-          System.err.println("runBackground exiting after " + delta + "s");
-          System.exit(0);
-        }
-      }
+    var startTime = System.currentTimeMillis();
+    checkIfWeStillNeedToBeRunning(startTime, newestProcessIdPath, myPidStr);
+    var watcher = new Thread(() -> {
+      while (true) checkIfWeStillNeedToBeRunning(startTime, newestProcessIdPath, myPidStr);
     });
-
     watcher.setDaemon(true);
     watcher.start();
 
     // Actually start the Java main method we wanted to run in the background
-    String realMain = args[4];
-    String[] realArgs = java.util.Arrays.copyOfRange(args, 5, args.length);
     if (!realMain.equals("<subprocess>")) {
       Class.forName(realMain).getMethod("main", String[].class).invoke(null, (Object) realArgs);
     } else {
@@ -62,17 +73,57 @@ public class MillBackgroundWrapper {
 
         long now = System.currentTimeMillis();
 
+        // If the process does not shut down withing 100ms kill it forcibly.
         while (subprocess.isAlive() && System.currentTimeMillis() - now < 100) {
           try {
             Thread.sleep(1);
           } catch (InterruptedException e) {
+            // do nothing
           }
-          if (subprocess.isAlive()) {
-            subprocess.destroyForcibly();
-          }
+        }
+        if (subprocess.isAlive()) {
+          subprocess.destroyForcibly();
         }
       }));
       System.exit(subprocess.waitFor());
+    }
+  }
+
+  private static void checkIfWeStillNeedToBeRunning(long startTime, Path newestProcessIdPath, String myPidStr) {
+    long delta = (System.currentTimeMillis() - startTime) / 1000;
+    try {
+      Thread.sleep(50);
+      String token = Files.readString(newestProcessIdPath);
+      if (!token.equals(myPidStr)) {
+        System.err.println("runBackground exiting after " + delta + "s");
+        System.exit(0);
+      }
+    } catch (Exception e) {
+      System.err.println("runBackground exiting after " + delta + "s");
+      System.exit(0);
+    }
+  }
+
+  static Optional<Long> readPreviousPid(Path pidFilePath) {
+    try {
+      var pidStr = Files.readString(pidFilePath);
+      return Optional.of(Long.parseLong(pidStr));
+    } catch (IOException | NumberFormatException e) {
+      return Optional.empty();
+    }
+  }
+
+  static void waitForPreviousProcessToTerminate(long pid) {
+    var maybeOldProcess = ProcessHandle.of(pid);
+    if (maybeOldProcess.isEmpty()) return;
+    var oldProcess = maybeOldProcess.get();
+
+    try {
+      while (oldProcess.isAlive()) {
+        Thread.sleep(50);
+      }
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
     }
   }
 }

--- a/libs/scalalib/src/mill/scalalib/RunModule.scala
+++ b/libs/scalalib/src/mill/scalalib/RunModule.scala
@@ -350,9 +350,9 @@ object RunModule {
   }
 
   case class BackgroundPaths(
-    newestPidPath: os.Path,
-    currentlyRunningPidPath: os.Path,
-    lockPath: os.Path
+      newestPidPath: os.Path,
+      currentlyRunningPidPath: os.Path,
+      lockPath: os.Path
   ) {
     def toArgs: Seq[String] =
       Seq(newestPidPath.toString, currentlyRunningPidPath.toString, lockPath.toString)
@@ -362,7 +362,7 @@ object RunModule {
       BackgroundPaths(
         newestPidPath = (dest / ".mill-background-process-newest-pid"),
         currentlyRunningPidPath = (dest / ".mill-background-process-currently-running-pid"),
-        lockPath = (dest / ".mill-background-process-lock"),
+        lockPath = (dest / ".mill-background-process-lock")
       )
     }
   }

--- a/mill-build/src/millbuild/MillPublishJavaModule.scala
+++ b/mill-build/src/millbuild/MillPublishJavaModule.scala
@@ -22,7 +22,7 @@ trait MillPublishJavaModule extends MillJavaModule with PublishModule {
     "info.releaseNotesURL" -> Settings.changelogUrl
   )
   def pomSettings = MillPublishJavaModule.commonPomSettings(artifactName())
-  def javacOptions = Seq("-source", "1.8", "-target", "1.8", "-encoding", "UTF-8")
+  def javacOptions = Seq("-source", "11", "-target", "11", "-encoding", "UTF-8")
 }
 
 object MillPublishJavaModule {

--- a/website/docs/modules/ROOT/pages/cli/flags.adoc
+++ b/website/docs/modules/ROOT/pages/cli/flags.adoc
@@ -134,6 +134,13 @@ forcefully terminating the previous process even though it may be still alive:
 > mill -w foo.runBackground
 ----
 
+Note that even if you interrupt mill watch via CTRL+C, the server spawned by runBackground still runs in the background.
+To actually stop the background server use:
+
+[source,console]
+----
+> mill clean foo.runBackground
+----
 
 === `--jobs`/`-j`
 


### PR DESCRIPTION
Currently the `runBackground` uses file locks and generated UUIDs for coordination.

This sometimes leads to the cases where a new background process is launched while the old one is still running because the JVM seems to release file locks before network sockets.

Because Mill now uses JDK 11, we can use it's APIs to transition to process id based watching, which should alleviate this problem.

`0.12.x` branch backport: https://github.com/com-lihaoyi/mill/pull/5120