### PR TITLE
Remove `PublishModule.publishSelfDependency` in favor of `artifactMetadata`

### DIFF
--- a/core/util/package.mill
+++ b/core/util/package.mill
@@ -48,7 +48,7 @@ object `package` extends MillStableScalaModule with BuildInfo {
           distAllDeps.collect { case m: PublishModule => m }
         ) { mod =>
           Task.Anon {
-            val selfDep = mod.publishSelfDependency()
+            val selfDep = mod.artifactMetadata()
             (
               s"${mod.coursierDependency.module.repr}:${mod.coursierDependency.versionConstraint.asString}",
               s"${selfDep.group}:${selfDep.id}:${selfDep.version}"

--- a/libs/scalalib/package.mill
+++ b/libs/scalalib/package.mill
@@ -97,7 +97,7 @@ object `package` extends MillStableScalaModule {
       BuildInfo.Value("springBuildToolsVersion", Deps.springBootTools.version),
       BuildInfo.Value(
         "millSpringBootWorkerDep", {
-          val dep = `spring-boot-worker`.publishSelfDependency()
+          val dep = `spring-boot-worker`.artifactMetadata()
           s"${dep.group}:${dep.id}:${dep.version}"
         },
         "The dependency containing the worker implementation to be loaded at runtime."

--- a/libs/scalalib/src/mill/javalib/revapi/RevapiModule.scala
+++ b/libs/scalalib/src/mill/javalib/revapi/RevapiModule.scala
@@ -72,7 +72,7 @@ trait RevapiModule extends PublishModule {
 
   /** API archive and supplement files (dependencies) to compare against */
   def revapiOldFiles: T[Seq[PathRef]] = Task {
-    val Artifact(group, id, version) = publishSelfDependency()
+    val Artifact(group, id, version) = artifactMetadata()
     defaultResolver().classpath(
       Seq(mvn"$group:$id:$version"),
       artifactTypes = Some(revapiArtifactTypes())

--- a/libs/scalalib/src/mill/scalalib/PublishModule.scala
+++ b/libs/scalalib/src/mill/scalalib/PublishModule.scala
@@ -79,8 +79,9 @@ trait PublishModule extends JavaModule { outer =>
    */
   def versionScheme: T[Option[VersionScheme]] = Task { None }
 
+  @deprecated("Use artifactMetadata instead", since = "0.12.12")
   def publishSelfDependency: T[Artifact] = Task {
-    Artifact(pomSettings().organization, artifactId(), publishVersion())
+    artifactMetadata()
   }
 
   def publishMvnDeps
@@ -119,13 +120,13 @@ trait PublishModule extends JavaModule { outer =>
           .filter(!ivyPomDeps.contains(_))
 
         val modulePomDeps = Task.sequence(moduleDepsChecked.collect {
-          case m: PublishModule => m.publishSelfDependency
+          case m: PublishModule => m.artifactMetadata
         })()
         val compileModulePomDeps = Task.sequence(compileModuleDepsChecked.collect {
-          case m: PublishModule => m.publishSelfDependency
+          case m: PublishModule => m.artifactMetadata
         })()
         val runModulePomDeps = Task.sequence(runModuleDepsChecked.collect {
-          case m: PublishModule => m.publishSelfDependency
+          case m: PublishModule => m.artifactMetadata
         })()
 
         ivyPomDeps ++
@@ -150,13 +151,13 @@ trait PublishModule extends JavaModule { outer =>
       .filter(!ivyPomDeps.contains(_))
 
     val modulePomDeps = Task.sequence(moduleDepsChecked.collect {
-      case m: PublishModule => m.publishSelfDependency
+      case m: PublishModule => m.artifactMetadata
     })()
     val compileModulePomDeps = Task.sequence(compileModuleDepsChecked.collect {
-      case m: PublishModule => m.publishSelfDependency
+      case m: PublishModule => m.artifactMetadata
     })()
     val runModulePomDeps = Task.sequence(runModuleDepsChecked.collect {
-      case m: PublishModule => m.publishSelfDependency
+      case m: PublishModule => m.artifactMetadata
     })()
 
     ivyPomDeps ++

--- a/libs/scalalib/src/mill/scalalib/PublishModule.scala
+++ b/libs/scalalib/src/mill/scalalib/PublishModule.scala
@@ -79,11 +79,6 @@ trait PublishModule extends JavaModule { outer =>
    */
   def versionScheme: T[Option[VersionScheme]] = Task { None }
 
-  @deprecated("Use artifactMetadata instead", since = "0.12.12")
-  def publishSelfDependency: T[Artifact] = Task {
-    artifactMetadata()
-  }
-
   def publishMvnDeps
       : Task[(Map[coursier.core.Module, String], DependencyManagement.Map) => Seq[Dependency]] =
     Task.Anon {

--- a/runner/bsp/package.mill
+++ b/runner/bsp/package.mill
@@ -11,7 +11,7 @@ object `package` extends MillPublishScalaModule with BuildInfo {
   def buildInfoPackageName = "mill.bsp"
 
   def buildInfoMembers = Task {
-    val workerDep = worker.publishSelfDependency()
+    val workerDep = worker.artifactMetadata()
     Seq(
       BuildInfo.Value(
         "bsp4jVersion",


### PR DESCRIPTION
* Remove `PublishModule.publishSelfDependency`. It is identical to `artifactMetadata`, which has the arguably better name.

* Don't use deprecated task in build script.

* Fix https://github.com/com-lihaoyi/mill/issues/5116

* To prepare the removal, we deprecated it in for Mill 0.12.12 to prepare the removal. See https://github.com/com-lihaoyi/mill/pull/5117