### PR TITLE
Add `sourcecode.Enclosing` to `Task.Anon#toString` and `sourcecode.Name` to BSP `mill-active-command`s

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1,4 +1,4 @@
-//| mill-version: 1.0.0-M1
+//| mill-version: 1.0.0-M1-19-af86a0-jvm
 //| mill-jvm-opts: ["-XX:NonProfiledCodeHeapSize=250m", "-XX:ReservedCodeCacheSize=500m"]
 //| mill-opts: ["--jobs=0.5C"]
 

--- a/build.mill
+++ b/build.mill
@@ -1,4 +1,4 @@
-//| mill-version: 1.0.0-M1
+//| mill-version: 1.0.0-M1-10-a9cbfd-jvm
 //| mill-jvm-opts: ["-XX:NonProfiledCodeHeapSize=250m", "-XX:ReservedCodeCacheSize=500m"]
 //| mill-opts: ["--jobs=0.5C"]
 

--- a/build.mill
+++ b/build.mill
@@ -1,4 +1,4 @@
-//| mill-version: 1.0.0-M1-19-af86a0-jvm
+//| mill-version: 1.0.0-M1
 //| mill-jvm-opts: ["-XX:NonProfiledCodeHeapSize=250m", "-XX:ReservedCodeCacheSize=500m"]
 //| mill-opts: ["--jobs=0.5C"]
 

--- a/build.mill
+++ b/build.mill
@@ -1,4 +1,4 @@
-//| mill-version: 1.0.0-M1-10-a9cbfd-jvm
+//| mill-version: 1.0.0-M1
 //| mill-jvm-opts: ["-XX:NonProfiledCodeHeapSize=250m", "-XX:ReservedCodeCacheSize=500m"]
 //| mill-opts: ["--jobs=0.5C"]
 

--- a/runner/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/runner/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -717,16 +717,13 @@ private class MillBuildServer(
       reporter: Int => Option[CompileProblemReporter] = _ => Option.empty[CompileProblemReporter],
       testReporter: TestReporter = TestReporter.DummyTestReporter,
       logger: Logger = null
-  ): ExecutionResultsApi = {
+  )(name: sourcecode.Name): ExecutionResultsApi = {
     val logger0 = Option(logger).getOrElse(evaluator.baseLogger)
     Server.withOutLock(
       noBuildLock = false,
       noWaitForBuildLock = false,
       out = os.Path(evaluator.outPathJava),
-      targetsAndParams = goals.map {
-        case n: NamedTaskApi[_] => n.label
-        case t => t.toString
-      },
+      targetsAndParams = Seq(name.value),
       streams = logger0.streams,
       outLock = outLock
     ) {

--- a/runner/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/runner/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -723,7 +723,7 @@ private class MillBuildServer(
       noBuildLock = false,
       noWaitForBuildLock = false,
       out = os.Path(evaluator.outPathJava),
-      targetsAndParams = Seq(name.value),
+      targetsAndParams = Seq("BSP:" + name.value),
       streams = logger0.streams,
       outLock = outLock
     ) {

--- a/runner/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/runner/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -723,7 +723,7 @@ private class MillBuildServer(
       noBuildLock = false,
       noWaitForBuildLock = false,
       out = os.Path(evaluator.outPathJava),
-      targetsAndParams = Seq("BSP:" + name.value),
+      millActiveCommandMessage = "BSP:" + name.value,
       streams = logger0.streams,
       outLock = outLock
     ) {

--- a/runner/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/runner/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -717,7 +717,7 @@ private class MillBuildServer(
       reporter: Int => Option[CompileProblemReporter] = _ => Option.empty[CompileProblemReporter],
       testReporter: TestReporter = TestReporter.DummyTestReporter,
       logger: Logger = null
-  )(name: sourcecode.Name): ExecutionResultsApi = {
+  )(implicit name: sourcecode.Name): ExecutionResultsApi = {
     val logger0 = Option(logger).getOrElse(evaluator.baseLogger)
     Server.withOutLock(
       noBuildLock = false,

--- a/runner/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/runner/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -723,7 +723,7 @@ private class MillBuildServer(
       noBuildLock = false,
       noWaitForBuildLock = false,
       out = os.Path(evaluator.outPathJava),
-      millActiveCommandMessage = "BSP:" + name.value,
+      millActiveCommandMessage = "IDE-BSP:" + name.value,
       streams = logger0.streams,
       outLock = outLock
     ) {

--- a/runner/daemon/src/mill/daemon/MillMain.scala
+++ b/runner/daemon/src/mill/daemon/MillMain.scala
@@ -340,7 +340,8 @@ object MillMain {
                     config.leftoverArgs.value == Seq("mill.idea.GenIdea/idea") ||
                     config.leftoverArgs.value == Seq("mill.idea.GenIdea/")
                   ) {
-                    val runnerState = runMillBootstrap(false, None, Seq("version"), streams, "IDE-BSP:initialize")
+                    val runnerState =
+                      runMillBootstrap(false, None, Seq("version"), streams, "IDE-BSP:initialize")
                     new mill.idea.GenIdeaImpl(
                       runnerState.result.frames.flatMap(_.evaluator)
                     ).run()

--- a/runner/daemon/src/mill/daemon/MillMain.scala
+++ b/runner/daemon/src/mill/daemon/MillMain.scala
@@ -328,8 +328,9 @@ object MillMain {
                         runMillBootstrap(
                           false,
                           prevRunnerState,
-                          "BSP:initialize",
+                          Seq("version"),
                           streams,
+                          "BSP:initialize"
                         ).result,
                       outLock
                     )
@@ -339,7 +340,7 @@ object MillMain {
                     config.leftoverArgs.value == Seq("mill.idea.GenIdea/idea") ||
                     config.leftoverArgs.value == Seq("mill.idea.GenIdea/")
                   ) {
-                    val runnerState = runMillBootstrap(false, None, "BSP:initialize", streams)
+                    val runnerState = runMillBootstrap(false, None, Seq("version"), streams, "BSP:initialize")
                     new mill.idea.GenIdeaImpl(
                       runnerState.result.frames.flatMap(_.evaluator)
                     ).run()

--- a/runner/daemon/src/mill/daemon/MillMain.scala
+++ b/runner/daemon/src/mill/daemon/MillMain.scala
@@ -265,12 +265,13 @@ object MillMain {
                       enterKeyPressed: Boolean,
                       prevState: Option[RunnerState],
                       targetsAndParams: Seq[String],
-                      streams: SystemStreams
+                      streams: SystemStreams,
+                      millActiveCommandMessage: String
                   ) = Server.withOutLock(
                     config.noBuildLock.value,
                     config.noWaitForBuildLock.value,
                     out,
-                    targetsAndParams,
+                    millActiveCommandMessage,
                     streams,
                     outLock
                   ) {
@@ -327,8 +328,8 @@ object MillMain {
                         runMillBootstrap(
                           false,
                           prevRunnerState,
-                          Seq("version"),
-                          streams
+                          "BSP:initialize",
+                          streams,
                         ).result,
                       outLock
                     )
@@ -338,7 +339,7 @@ object MillMain {
                     config.leftoverArgs.value == Seq("mill.idea.GenIdea/idea") ||
                     config.leftoverArgs.value == Seq("mill.idea.GenIdea/")
                   ) {
-                    val runnerState = runMillBootstrap(false, None, Seq("version"), streams)
+                    val runnerState = runMillBootstrap(false, None, "BSP:initialize", streams)
                     new mill.idea.GenIdeaImpl(
                       runnerState.result.frames.flatMap(_.evaluator)
                     ).run()
@@ -359,7 +360,8 @@ object MillMain {
                           enterKeyPressed,
                           prevState,
                           config.leftoverArgs.value,
-                          streams
+                          streams,
+                          config.leftoverArgs.value.mkString(" ")
                         )
                       },
                       colors = colors

--- a/runner/daemon/src/mill/daemon/MillMain.scala
+++ b/runner/daemon/src/mill/daemon/MillMain.scala
@@ -330,7 +330,7 @@ object MillMain {
                           prevRunnerState,
                           Seq("version"),
                           streams,
-                          "BSP:initialize"
+                          "IDE-BSP:initialize"
                         ).result,
                       outLock
                     )
@@ -340,7 +340,7 @@ object MillMain {
                     config.leftoverArgs.value == Seq("mill.idea.GenIdea/idea") ||
                     config.leftoverArgs.value == Seq("mill.idea.GenIdea/")
                   ) {
-                    val runnerState = runMillBootstrap(false, None, Seq("version"), streams, "BSP:initialize")
+                    val runnerState = runMillBootstrap(false, None, Seq("version"), streams, "IDE-BSP:initialize")
                     new mill.idea.GenIdeaImpl(
                       runnerState.result.frames.flatMap(_.evaluator)
                     ).run()

--- a/runner/server/src/mill/server/Server.scala
+++ b/runner/server/src/mill/server/Server.scala
@@ -186,7 +186,7 @@ abstract class Server[T](
           noBuildLock = false,
           noWaitForBuildLock = false,
           out = out,
-          targetsAndParams = Seq("checking server mill version and java version"),
+          targetsAndParams = "checking server mill version and java version",
           streams = new mill.api.SystemStreams(
             new PrintStream(mill.api.DummyOutputStream),
             new PrintStream(mill.api.DummyOutputStream),

--- a/runner/server/src/mill/server/Server.scala
+++ b/runner/server/src/mill/server/Server.scala
@@ -346,7 +346,7 @@ object Server {
       noBuildLock: Boolean,
       noWaitForBuildLock: Boolean,
       out: os.Path,
-      targetsAndParams: Seq[String],
+      millActiveCommandMessage: String,
       streams: SystemStreams,
       outLock: Lock
   )(t: => T): T = {
@@ -369,7 +369,7 @@ object Server {
           outLock.lock()
         }
       } { _ =>
-        os.write.over(out / OutFiles.millActiveCommand, targetsAndParams.mkString(" "))
+        os.write.over(out / OutFiles.millActiveCommand, millActiveCommandMessage)
         try t
         finally os.remove.all(out / OutFiles.millActiveCommand)
       }

--- a/runner/server/src/mill/server/Server.scala
+++ b/runner/server/src/mill/server/Server.scala
@@ -186,7 +186,7 @@ abstract class Server[T](
           noBuildLock = false,
           noWaitForBuildLock = false,
           out = out,
-          targetsAndParams = "checking server mill version and java version",
+          millActiveCommandMessage = "checking server mill version and java version",
           streams = new mill.api.SystemStreams(
             new PrintStream(mill.api.DummyOutputStream),
             new PrintStream(mill.api.DummyOutputStream),


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/5038

Adding the `sourcecode.Enclosing` is not pretty, but it's better than what it was before, as at least the `Task.Anon(...)` parens contain some useful information (albeit a bit verbosely):

```
Another Mill process is running 'Task.Anon@8a58691(mill.scalalib.ScalaModule#bspBuildTargetData) Task.Anon@637be5e2(mill.scalalib.ScalaModule#bspBuildTargetData) Task.Anon@18e95310(mill.scalalib.ScalaModule#bspBuildTargetData) Task.Anon@1df556d4(mill.scalalib.ScalaModule#bspBuildTargetData) Task.Anon@39c0caf5(mill.scalalib.ScalaModule#bspBuildTargetData) Task.Anon@5a87cda(mill.scalalib.ScalaModule#bspBuildTargetData) Task.Anon@578bceac(mill.scalalib.ScalaModule#bspBuildTargetData) 

... 

Task.Anon@33d116e7(mill.scalalib.ScalaModule#bspBuildTargetData) Task.Anon@730966fe(mill.scalalib.ScalaModule#bspBuildTargetData) Task.Anon@38f88c94(mill.scalalib.ScalaModule#bspBuildTargetData) Task.Anon@7594cab7(mill.scalalib.ScalaModule#bspBuildTargetData) Task.Anon@4e499ccc(mill.scalalib.ScalaModule#bspBuildTargetData) Task.Anon@76cf3d6d(mill.scalalib.ScalaModule#bspBuildTargetData) Task.Anon@a2f930c(mill.scalalib.ScalaModule#bspBuildTargetData) Task.Anon@59bd318c(mill.scalalib.ScalaModule#bspBuildTargetData) Task.Anon@5b10798b(mill.scalalib.ScalaModule#bspBuildTargetData) Task.Anon@54bb13d1(mill.scalalib.ScalaModule#bspBuildTargetData) Task.Anon@22fa5db9(mill.scalalib.ScalaModule#bspBuildTargetData) Task.Anon@12fb293b(mill.scalalib.ScalaModule#bspBuildTargetData) Task.Anon@4a7fc6ce(mill.scalalib.ScalaModule#bspBuildTargetData) Task.Anon@46d661cb(mill.scalalib.ScalaModule#bspBuildTargetData) Task.Anon@36b1eb3d(mill.scalalib.ScalaModule#bspBuildTargetData) Task.Anon@7d48ae21(mill.scalalib.ScalaModule#bspBuildTargetData) Task.Anon@49355ef0(mill.scalalib.ScalaModule#bspBuildTargetData) Task.Anon@3c18b624(mill.scalalib.ScalaModule#bspBuildTargetData) Task.Anon@5494a99(mill.scalalib.ScalaModule#bspBuildTargetData) Task.Anon@3d48d5b7(mill.scalalib.ScalaModule#bspBuildTargetData) Task.Anon@5e69ce30(mill.scalalib.ScalaModule#bspBuildTargetData)', waiting for it to be done...
```

As a further improvement, I tweaked the call to `withOutLock` in `MillBuildServer` to use `sourcecode.Name` instead of the `Task#toString`s for its `mill-active-command` message (we already use it extensively to label messages in the BSP logs) and customized it for places where it previously just showed `version`. Now the command line messages when Mill is waiting for your IDE is a lot better:

```
lihaoyi mill$ ./mill version
Another Mill process is running 'IDE-BSP:initialize', waiting for it to be done...

lihaoyi mill$ ./mill version
Another Mill process is running 'IDE-BSP:workspaceBuildTargets', waiting for it to be done...

lihaoyi mill$ ./mill version
Another Mill process is running 'IDE-BSP:buildTargetSources', waiting for it to be done...

lihaoyi mill$ ./mill version
Another Mill process is running 'IDE-BSP:buildTargetDependencySources', waiting for it to be done...
```