### PR TITLE
Split launcher/daemon terminology from client/server

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -230,7 +230,7 @@ jobs:
             # These invalidation tests need to be exercised in both execution modes
             # to make sure they work with and without -i/--no-server being passed
           - java-version: 17
-            millargs: "'integration.invalidation.__.packaged.fork'"
+            millargs: "'integration.invalidation.__.packaged.nodaemon'"
             install-android-sdk: false
             install-sbt: false
 
@@ -264,15 +264,15 @@ jobs:
             install-sbt: false
 
           - java-version: 11
-            millargs: '"example.scalalib.{basic,publishing}.__.local.fork"'
+            millargs: '"example.scalalib.{basic,publishing}.__.local.nodaemon"'
             install-sbt: false
 
           - java-version: 11
-            millargs: '"example.migrating.{scalalib,javalib}.__.local.fork"'
+            millargs: '"example.migrating.{scalalib,javalib}.__.local.nodaemon"'
             install-sbt: true
 
           - java-version: 17
-            millargs: "'integration.{feature,failure}.__.packaged.fork'"
+            millargs: "'integration.{feature,failure}.__.packaged.nodaemon'"
             install-sbt: false
 
           - java-version: 11 # Run this with Mill native launcher as a smoketest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,7 +21,7 @@
 #      - uses: sbt/setup-sbt@v1
 #
 #
-#      - run:  ./mill 'integration.migrating[init].local.server.testOnly' mill.integration.MillInitSbtGatlingTests
+#      - run:  ./mill 'integration.migrating[init].local.daemon.testOnly' mill.integration.MillInitSbtGatlingTests
 #
 
 
@@ -91,15 +91,15 @@ jobs:
           # Run these with Mill native launcher as a smoketest
         include:
           - os: ubuntu-24.04-arm
-            millargs: "'example.thirdparty[fansi].native.server'"
+            millargs: "'example.thirdparty[fansi].native.daemon'"
             java-version: 17
 
           - os: macos-latest
-            millargs: "'example.thirdparty[acyclic].native.server'"
+            millargs: "'example.thirdparty[acyclic].native.daemon'"
             java-version: 11
 
           - os: macos-13
-            millargs: "'example.thirdparty[jimfs].native.server'"
+            millargs: "'example.thirdparty[jimfs].native.daemon'"
             java-version: 11
     steps:
       - uses: actions/checkout@v4
@@ -154,12 +154,12 @@ jobs:
             install-sbt: false
 
           - java-version: 17
-            millargs: "example.javalib.__.local.server"
+            millargs: "example.javalib.__.local.daemon"
             install-android-sdk: false
             install-sbt: false
 
           - java-version: 17
-            millargs: "example.kotlinlib.__.local.server"
+            millargs: "example.kotlinlib.__.local.daemon"
             install-android-sdk: false
             install-sbt: false
 
@@ -167,64 +167,64 @@ jobs:
           # is the same as that used in the `build-linux` job to avoid diverging code
           # hashes (https://github.com/com-lihaoyi/mill/pull/4410)
           - java-version: 11
-            millargs: "example.scalalib.__.native.server"
+            millargs: "example.scalalib.__.native.daemon"
             install-android-sdk: false
             install-sbt: false
 
           - java-version: 17
-            millargs: "'example.androidlib.__.local.server'"
+            millargs: "'example.androidlib.__.local.daemon'"
             install-android-sdk: true
             install-sbt: false
 
           - java-version: 17
-            millargs: "'example.thirdparty[androidtodo].local.server'"
+            millargs: "'example.thirdparty[androidtodo].local.daemon'"
             install-android-sdk: true
             install-sbt: false
 
           - java-version: 17
-            millargs: "'example.thirdparty[android-endless-tunnel].local.server'"
+            millargs: "'example.thirdparty[android-endless-tunnel].local.daemon'"
             install-android-sdk: true
             install-sbt: false
 
           - java-version: 17
-            millargs: "'{example,integration}.migrating.__.local.server'"
+            millargs: "'{example,integration}.migrating.__.local.daemon'"
             install-android-sdk: false
             install-sbt: true
 
           - java-version: 17
-            millargs: "'example.{pythonlib,javascriptlib}.__.local.server'"
+            millargs: "'example.{pythonlib,javascriptlib}.__.local.daemon'"
             install-android-sdk: false
             install-sbt: false
 
           - java-version: 11
-            millargs: "'example.thirdparty[{mockito,commons-io}].local.server'"
+            millargs: "'example.thirdparty[{mockito,commons-io}].local.daemon'"
             install-android-sdk: false
             install-sbt: false
 
           - java-version: 17
-            millargs: "'example.thirdparty[{netty,gatling}].local.server'"
+            millargs: "'example.thirdparty[{netty,gatling}].local.daemon'"
             install-android-sdk: false
             install-sbt: false
 
           - java-version: '17'
-            millargs: "'example.thirdparty[arrow].local.server'"
+            millargs: "'example.thirdparty[arrow].local.daemon'"
             install-android-sdk: false
             install-sbt: false
 
           - java-version: 11
-            millargs: "'example.{cli,fundamentals,depth,extending}.__.local.server'"
+            millargs: "'example.{cli,fundamentals,depth,extending}.__.local.daemon'"
             install-android-sdk: false
             install-sbt: false
 
           - java-version: 11
-            millargs: "'integration.{failure,feature,ide}.__.packaged.server'"
+            millargs: "'integration.{failure,feature,ide}.__.packaged.daemon'"
             install-android-sdk: false
             install-sbt: false
 
             # run this specifically in `native` mode to make sure our non-JVM native image
             # launcher is able to bootstrap everything necessary without a JVM installed
           - java-version: 17
-            millargs: "'integration.bootstrap[no-java-bootstrap].native.server'"
+            millargs: "'integration.bootstrap[no-java-bootstrap].native.daemon'"
             install-android-sdk: false
 
             # These invalidation tests need to be exercised in both execution modes
@@ -235,7 +235,7 @@ jobs:
             install-sbt: false
 
           - java-version: 17
-            millargs: "'integration.invalidation.__.packaged.server'"
+            millargs: "'integration.invalidation.__.packaged.daemon'"
             install-android-sdk: false
             install-sbt: false
 
@@ -276,11 +276,11 @@ jobs:
             install-sbt: false
 
           - java-version: 11 # Run this with Mill native launcher as a smoketest
-            millargs: "'integration.invalidation.__.native.server'"
+            millargs: "'integration.invalidation.__.native.daemon'"
             install-sbt: false
 
           - java-version: 17
-            millargs: "'integration.bootstrap[no-java-bootstrap].native.server'"
+            millargs: "'integration.bootstrap[no-java-bootstrap].native.daemon'"
 
     uses: ./.github/workflows/post-build-selective.yml
     with:

--- a/changelog.adoc
+++ b/changelog.adoc
@@ -150,7 +150,7 @@ to Coursier rather than implementing it in Mill {link-pr}/4145[#4145]
 
 * Honor the `NO_COLOR` env variable {link-pr}/4246[#4246]
 
-* Fix race condition that occasionally caused Mill's background server to exit and
+* Fix race condition that occasionally caused Mill's background daemon to exit and
 restart unnecessarily {link-pr}/4254[#4254]
 
 * Improvements to Mill's https://mill-build.org/mill/android/java.html[experimental

--- a/ci/test-mill-bootstrap.sh
+++ b/ci/test-mill-bootstrap.sh
@@ -24,4 +24,4 @@ rm -rf out
 
 # Run tests
 ./mill-assembly.jar -i "__.compile"
-./mill-assembly.jar -i "example.scalalib.basic[1-simple].packaged.server.testForked"
+./mill-assembly.jar -i "example.scalalib.basic[1-simple].packaged.daemon.testForked"

--- a/core/constants/src/mill/constants/DaemonFiles.java
+++ b/core/constants/src/mill/constants/DaemonFiles.java
@@ -1,22 +1,22 @@
 package mill.constants;
 
 /**
- * Central place containing all the files that live inside the `out/mill-server-*` folder
+ * Central place containing all the files that live inside the `out/mill-daemon-*` folder
  * and documentation about what they do
  */
-public class ServerFiles {
+public class DaemonFiles {
   public static final String processId = "processId";
   public static final String sandbox = "sandbox";
 
   /**
-   * Ensures only a single client is manipulating each mill-server folder at
+   * Ensures only a single client is manipulating each mill-daemon folder at
    * a time, either spawning the server or submitting a command. Also used by
    * the server to detect when a client disconnects, so it can terminate execution
    */
   public static final String clientLock = "clientLock";
 
   /**
-   * Lock file ensuring a single server is running in a particular mill-server
+   * Lock file ensuring a single server is running in a particular mill-daemon
    * folder. If multiple servers are spawned in the same folder, only one takes
    * the lock and the others fail to do so and terminate immediately.
    */

--- a/core/constants/src/mill/constants/DaemonFiles.java
+++ b/core/constants/src/mill/constants/DaemonFiles.java
@@ -9,18 +9,18 @@ public class DaemonFiles {
   public static final String sandbox = "sandbox";
 
   /**
-   * Ensures only a single client is manipulating each mill-daemon folder at
+   * Ensures only a single launcher is manipulating each mill-daemon folder at
    * a time, either spawning the server or submitting a command. Also used by
    * the server to detect when a client disconnects, so it can terminate execution
    */
-  public static final String clientLock = "clientLock";
+  public static final String launcherLock = "launcherLock";
 
   /**
    * Lock file ensuring a single server is running in a particular mill-daemon
    * folder. If multiple servers are spawned in the same folder, only one takes
    * the lock and the others fail to do so and terminate immediately.
    */
-  public static final String serverLock = "serverLock";
+  public static final String daemonLock = "daemonLock";
 
   /**
    * The port used to connect between server and client
@@ -28,7 +28,7 @@ public class DaemonFiles {
   public static final String socketPort = "socketPort";
 
   /**
-   * The pipe by which the client snd server exchange IO
+   * The pipe by which the launcher snd daemon exchange IO
    *
    * Use uniquely-named pipes based on the fully qualified path of the project folder
    * because on Windows the un-qualified name of the pipe must be globally unique

--- a/core/constants/src/mill/constants/EnvVars.java
+++ b/core/constants/src/mill/constants/EnvVars.java
@@ -17,7 +17,7 @@ public class EnvVars {
   public static final String MILL_TEST_RESOURCE_DIR = "MILL_TEST_RESOURCE_DIR";
 
   /**
-   * How long the Mill background server should run before timing out from inactivity
+   * How long the Mill background daemon should run before timing out from inactivity
    */
   public static final String MILL_SERVER_TIMEOUT_MILLIS = "MILL_SERVER_TIMEOUT_MILLIS";
 

--- a/core/constants/src/mill/constants/OutFiles.java
+++ b/core/constants/src/mill/constants/OutFiles.java
@@ -50,12 +50,12 @@ public class OutFiles {
    * Subfolder of `out/` that contains the machinery necessary for a single Mill background
    * server: metadata files, pipes, logs, etc.
    */
-  public static final String millServer = "mill-server";
+  public static final String millDaemon = "mill-daemon";
 
   /**
    * Subfolder of `out/` used to contain the Mill subprocess when run in no-server mode
    */
-  public static final String millNoServer = "mill-no-server";
+  public static final String millNoDaemon = "mill-no-deamon";
 
   /**
    * Lock file used for exclusive access to the Mill output directory

--- a/developer.adoc
+++ b/developer.adoc
@@ -27,8 +27,8 @@ The following table contains the main ways you can test the code in
 |===
 | Config | Automated Testing | Manual Testing | Manual Testing CI
 | In-Process Tests | `main.__.test`, `scalalib.test`, `contrib.buildinfo.test`, etc. |  |
-| Sub-Process w/o packaging/publishing| `example.\\__.local.server`, `integration.__.local.server` | `dist.run` | `test-mill-dev.sh`
-| Sub-Process w/ packaging/publishing | `example.\\__.packaged.server`, `integration.__.packaged.server` | `dist.assembly` | `test-mill-release.sh`
+| Sub-Process w/o packaging/publishing| `example.\\__.local.daemon`, `integration.__.local.daemon` | `dist.run` | `test-mill-dev.sh`
+| Sub-Process w/ packaging/publishing | `example.\\__.packaged.daemon`, `integration.__.packaged.daemon` | `dist.assembly` | `test-mill-release.sh`
 | Bootstrapping: Building Mill with your current checkout of Mill |  | `dist.installLocal` | `test-mill-bootstrap.sh`
 |===
 
@@ -60,7 +60,7 @@ and do not exercise the Mill script-file bootstrapping, transformation, and comp
 
 === Sub-Process Tests *without* Packaging/Publishing
 
-`example.\\__.local.server` and `integration.__.local.server` tests run Mill end-to-end in a subprocess,
+`example.\\__.local.daemon` and `integration.__.local.daemon` tests run Mill end-to-end in a subprocess,
 but *without* the expensive/slow steps of packaging the core packages into an assembly jar
 and publishing the remaining packages to
 `~/.ivy2/local`.
@@ -95,7 +95,7 @@ You can reproduce any of the tests manually using `dist.run`, e.g.
 
 [source,console]
 ----
-> ./mill "example.javalib.basic[1-simple].local.server"
+> ./mill "example.javalib.basic[1-simple].local.daemon"
 ----
 
 **Manual Test**
@@ -114,8 +114,8 @@ You can reproduce any of the tests manually using `dist.run`, e.g.
 
 === Sub-Process Tests *with* Packaging/Publishing
 
-`example.\\__.server`, `integration.__.server`, `example.\\__.fork` and
-`integration.__.fork` cover the same test cases as the `.local.server` tests described above, but
+`example.\\__.daemon`, `integration.__.daemon`, `example.\\__.fork` and
+`integration.__.fork` cover the same test cases as the `.local.daemon` tests described above, but
 they perform packaging of the Mill core modules into an assembly jar, and publish the
 remaining modules to `~/.ivy2/local`.
 This results in a more realistic test environment, but at the cost of taking tens-of-seconds
@@ -131,7 +131,7 @@ You can reproduce these tests manually using `dist.installLocal`:
 You can also use `dist.native.installLocal` for a Graal Native Image executable,
 which is slower to create but faster to start than the default executable assembly.
 
-There are two six of these tests, `.{local,assembly,native}.{server,fork}`.
+There are two six of these tests, `.{local,assembly,native}.{daemon,fork}`.
 
 The first label specifies how the Mill code is packaged before testing
 
@@ -148,13 +148,13 @@ This is the slowest mode is only really necessary for debugging Mill's Graal nat
 The second label specifies how the Mill process is managed during the test:
 
 
-1. `.server` test run the test cases with the default configuration, so consecutive commands
-run in the same long-lived background server process
+1. `.daemon` test run the test cases with the default configuration, so consecutive commands
+run in the same long-lived background daemon process
 
-2. `.fork` test run the test cases with `--no-server`, meaning each command runs in a newly
+2. `.fork` test run the test cases with `--no-daemon`, meaning each command runs in a newly
 spawned Mill process
 
-In general you should spend most of your time working with the `.local.server` version of the
+In general you should spend most of your time working with the `.local.daemon` version of the
 `example` and `integration` tests to save time, and only run the others if you have a specific
 thing you want to test that needs those code paths to run.
 

--- a/developer.adoc
+++ b/developer.adoc
@@ -114,8 +114,8 @@ You can reproduce any of the tests manually using `dist.run`, e.g.
 
 === Sub-Process Tests *with* Packaging/Publishing
 
-`example.\\__.daemon`, `integration.__.daemon`, `example.\\__.fork` and
-`integration.__.fork` cover the same test cases as the `.local.daemon` tests described above, but
+`example.\\__.daemon`, `integration.__.daemon`, `example.\\__.nodaemon` and
+`integration.__.nodaemon` cover the same test cases as the `.local.daemon` tests described above, but
 they perform packaging of the Mill core modules into an assembly jar, and publish the
 remaining modules to `~/.ivy2/local`.
 This results in a more realistic test environment, but at the cost of taking tens-of-seconds
@@ -151,7 +151,7 @@ The second label specifies how the Mill process is managed during the test:
 1. `.daemon` test run the test cases with the default configuration, so consecutive commands
 run in the same long-lived background daemon process
 
-2. `.fork` test run the test cases with `--no-daemon`, meaning each command runs in a newly
+2. `.nodaemon` test run the test cases with `--no-daemon`, meaning each command runs in a newly
 spawned Mill process
 
 In general you should spend most of your time working with the `.local.daemon` version of the

--- a/dist/scripts/src/mill.bat
+++ b/dist/scripts/src/mill.bat
@@ -272,11 +272,15 @@ if [%~1%]==[--bsp] (
       if [%~1%]==[--no-server] (
         set MILL_FIRST_ARG=%1%
       ) else (
-        if [%~1%]==[--repl] (
+        if [%~1%]==[--no-daemon] (
           set MILL_FIRST_ARG=%1%
         ) else (
-          if [%~1%]==[--help] (
+          if [%~1%]==[--repl] (
             set MILL_FIRST_ARG=%1%
+          ) else (
+            if [%~1%]==[--help] (
+              set MILL_FIRST_ARG=%1%
+            )
           )
         )
       )

--- a/dist/scripts/src/mill.sh
+++ b/dist/scripts/src/mill.sh
@@ -309,7 +309,7 @@ if [ -z "$MILL_MAIN_CLI" ] ; then
 fi
 
 MILL_FIRST_ARG=""
-if [ "$1" = "--bsp" ] || [ "$1" = "-i" ] || [ "$1" = "--interactive" ] || [ "$1" = "--no-server" ] || [ "$1" = "--repl" ] || [ "$1" = "--help" ] ; then
+if [ "$1" = "--bsp" ] || [ "$1" = "-i" ] || [ "$1" = "--interactive" ] || [ "$1" = "--no-server" ] || [ "$1" = "--no-daemon" ] || [ "$1" = "--repl" ] || [ "$1" = "--help" ] ; then
   # Need to preserve the first position of those listed options
   MILL_FIRST_ARG=$1
   shift

--- a/example/depth/sandbox/1-task/build.mill
+++ b/example/depth/sandbox/1-task/build.mill
@@ -78,14 +78,14 @@ def osProcTask = Task {
 //
 // Lastly, there is the possibily of calling `os.pwd` outside of a task. When outside of
 // a task there is no `.dest/` folder associated, so instead Mill will redirect `os.pwd`
-// towards an empty `sandbox/` folder in `out/mill-server/...`:
+// towards an empty `sandbox/` folder in `out/mill-daemon/...`:
 
 val externalPwd = os.pwd
 def externalPwdTask = Task { println(externalPwd.toString) }
 
 /** Usage
 > ./mill externalPwdTask
-.../out/mill-server/sandbox
+.../out/mill-daemon/sandbox
 */
 
 // === Limitations of Mill's Sandboxing

--- a/example/extending/plugins/7-writing-mill-plugins/myplugin/test/src/mill/testkit/ExampleTests.scala
+++ b/example/extending/plugins/7-writing-mill-plugins/myplugin/test/src/mill/testkit/ExampleTests.scala
@@ -10,7 +10,7 @@ object ExampleTests extends TestSuite {
 //      pprint.log(sys.env("MILL_LOCAL_TEST_OVERRIDE_CLASSPATH"))
       val resourceFolder = os.Path(sys.env("MILL_TEST_RESOURCE_DIR"))
       ExampleTester.run(
-        clientServerMode = true,
+        daemonMode = true,
         workspaceSourcePath = resourceFolder / "example-test-project",
         millExecutable = os.Path(sys.env("MILL_EXECUTABLE_PATH"))
       )

--- a/example/extending/plugins/7-writing-mill-plugins/myplugin/test/src/mill/testkit/ExampleTests.scala
+++ b/example/extending/plugins/7-writing-mill-plugins/myplugin/test/src/mill/testkit/ExampleTests.scala
@@ -6,8 +6,6 @@ object ExampleTests extends TestSuite {
 
   def tests: Tests = Tests {
     test("example") {
-//      pprint.log(sys.env("MILL_EXECUTABLE_PATH"))
-//      pprint.log(sys.env("MILL_LOCAL_TEST_OVERRIDE_CLASSPATH"))
       val resourceFolder = os.Path(sys.env("MILL_TEST_RESOURCE_DIR"))
       ExampleTester.run(
         daemonMode = true,

--- a/example/extending/plugins/7-writing-mill-plugins/myplugin/test/src/mill/testkit/IntegrationTests.scala
+++ b/example/extending/plugins/7-writing-mill-plugins/myplugin/test/src/mill/testkit/IntegrationTests.scala
@@ -13,7 +13,7 @@ object IntegrationTests extends TestSuite {
 //      pprint.log(sys.env("MILL_LOCAL_TEST_OVERRIDE_CLASSPATH"))
       val resourceFolder = os.Path(sys.env("MILL_TEST_RESOURCE_DIR"))
       val tester = new IntegrationTester(
-        clientServerMode = true,
+        daemonMode = true,
         workspaceSourcePath = resourceFolder / "integration-test-project",
         millExecutable = os.Path(sys.env("MILL_EXECUTABLE_PATH"))
       )

--- a/example/extending/plugins/7-writing-mill-plugins/myplugin/test/src/mill/testkit/IntegrationTests.scala
+++ b/example/extending/plugins/7-writing-mill-plugins/myplugin/test/src/mill/testkit/IntegrationTests.scala
@@ -9,8 +9,6 @@ object IntegrationTests extends TestSuite {
     println("initializing myplugin.IntegrationTest.tests")
 
     test("integration") {
-//      pprint.log(sys.env("MILL_EXECUTABLE_PATH"))
-//      pprint.log(sys.env("MILL_LOCAL_TEST_OVERRIDE_CLASSPATH"))
       val resourceFolder = os.Path(sys.env("MILL_TEST_RESOURCE_DIR"))
       val tester = new IntegrationTester(
         daemonMode = true,

--- a/example/fundamentals/out-dir/1-out-files/build.mill
+++ b/example/fundamentals/out-dir/1-out-files/build.mill
@@ -2,7 +2,7 @@
 //
 // The `out/` folder contains all the generated files & metadata for your build.
 // It holds some files needed to manage Mill's longer running server instances
-// (`out/mill-server/*`) as well as a directory and file structure resembling the
+// (`out/mill-daemon/*`) as well as a directory and file structure resembling the
 // project's module structure.
 //
 // For the purposes of this page, we will be using the following minimal Mill build
@@ -32,7 +32,7 @@ out/mill-dependency-tree.json
 out/mill-out-lock
 out/mill-invalidation-tree.json
 out/mill-chrome-profile.json
-out/mill-server/...
+out/mill-daemon/...
 
 */
 
@@ -107,7 +107,7 @@ out/mill-dependency-tree.json
 out/mill-invalidation-tree.json
 out/mill-profile.json
 out/mill-build
-out/mill-server
+out/mill-daemon
 
 */
 
@@ -278,7 +278,7 @@ out/mill-server
 // of thd same task-related and Mill-related files as the top-level `out/` folder, but
 // related for compiling your `build.mill` rather than compiling your project's source files.
 //
-// === `mill-server/`, `mill-no-server/`
+// === `mill-daemon/`, `mill-no-deamon/`
 //
 // Each Mill process needs to keep some temporary files in one of these directories.
 // Deleting it will also terminate the associated server instance, if it is still running.

--- a/example/fundamentals/tasks/6-workers/build.mill
+++ b/example/fundamentals/tasks/6-workers/build.mill
@@ -85,13 +85,13 @@ def compressBytes(input: Array[Byte]) = {
 //
 // Workers live as long as the Mill process. By default, consecutive `mill`
 // commands in the same folder will re-use the same Mill process and workers,
-// unless `--no-server` is passed which will terminate the Mill process and
+// unless `--no-daemon` is passed which will terminate the Mill process and
 // workers after every command. Commands run repeatedly using `--watch` will
 // also preserve the workers between them.
 //
 // Workers can also make use of their `Task.dest` folder as a cache that persist
 // when the worker shuts down, as a second layer of caching. The example usage
-// below demonstrates how using the `--no-server` flag will make the worker
+// below demonstrates how using the `--no-daemon` flag will make the worker
 // read from its disk cache, where it would have normally read from its
 // in-memory cache
 
@@ -110,11 +110,11 @@ Compressing: world.txt
 
 > sed -i.bak 's/Hello/HELLO/g' data/hello.txt
 
-> ./mill compressedData # not --no-server, we read the data from memory
+> ./mill compressedData # not --no-daemon, we read the data from memory
 Compressing: hello.txt
 Cached from memory: world.txt
 
-> ./mill compressedData # --no-server, we read the data from disk
+> ./mill compressedData # --no-daemon, we read the data from disk
 Compressing: hello.txt
 Cached from disk: world.txt
 

--- a/integration/failure/fatal-error/src/FatalErrorTests.scala
+++ b/integration/failure/fatal-error/src/FatalErrorTests.scala
@@ -14,7 +14,7 @@ object FatalErrorTests extends UtestIntegrationTestSuite {
 
       // Only run this test in client-server mode, since workers are not shutdown
       // with `close()` in no-server mode so the error does not trigger
-      if (clientServerMode) {
+      if (daemonMode) {
         // This worker invalidates re-evaluates every time due to being dependent on
         // an upstream `Task.Input`. Make sure that a fatal error in the `close()`
         // call does not hang the Mill process

--- a/integration/feature/leak-hygiene/src/LeakHygieneTests.scala
+++ b/integration/feature/leak-hygiene/src/LeakHygieneTests.scala
@@ -38,7 +38,7 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
 
   val tests: Tests = Tests {
     test - integrationTest { tester =>
-      if (clientServerMode) {
+      if (daemonMode) {
         checkClassloaders(tester)(
           "mill.daemon.MillBuildBootstrap#processRunClasspath classLoader cl" -> 1,
           "mill.codesig.ExternalSummary.apply upstreamClassloader" -> 1,

--- a/integration/feature/subprocess-stdout/src/SubprocessStdoutTests.scala
+++ b/integration/feature/subprocess-stdout/src/SubprocessStdoutTests.scala
@@ -61,7 +61,7 @@ object SubprocessStdoutTests extends UtestIntegrationTestSuite {
       // up in the console somewhere and not disappear
       //
       val res2 = eval("inheritRaw", mergeErrIntoOut = true).out
-      if (!tester.clientServerMode) {
+      if (!tester.daemonMode) {
         // For `fork` tests, which represent `-i`/`--interactive`/`--no-server`, the output should
         // be properly ordered since it all comes directly from the stdout/stderr of the same process
         assert(

--- a/integration/invalidation/multi-level-editing/src/MultiLevelBuildTests.scala
+++ b/integration/invalidation/multi-level-editing/src/MultiLevelBuildTests.scala
@@ -108,7 +108,7 @@ trait MultiLevelBuildTests extends UtestIntegrationTestSuite {
     // restarts behave as expected:
     if (clientServerMode) {
       // Only one server should be running at any point in time
-      val serverFolder = tester.workspacePath / "out/mill-server"
+      val serverFolder = tester.workspacePath / "out/mill-daemon"
 
       // client-server mode should never restart in these tests and preserve the same process,
       val currentServerId = os.read(serverFolder / "processId")

--- a/integration/invalidation/multi-level-editing/src/MultiLevelBuildTests.scala
+++ b/integration/invalidation/multi-level-editing/src/MultiLevelBuildTests.scala
@@ -106,7 +106,7 @@ trait MultiLevelBuildTests extends UtestIntegrationTestSuite {
 
     // Before checking classloaders, make sure we check to ensure server spawns and
     // restarts behave as expected:
-    if (clientServerMode) {
+    if (daemonMode) {
       // Only one server should be running at any point in time
       val serverFolder = tester.workspacePath / "out/mill-daemon"
 
@@ -128,7 +128,7 @@ trait MultiLevelBuildTests extends UtestIntegrationTestSuite {
       }
 
     val expectedChanged =
-      if (clientServerMode) expectedChanged0
+      if (daemonMode) expectedChanged0
       else expectedChanged0.map {
         case java.lang.Boolean.FALSE => true
         case n => n

--- a/integration/invalidation/multi-level-editing/src/MultiLevelBuildTests.scala
+++ b/integration/invalidation/multi-level-editing/src/MultiLevelBuildTests.scala
@@ -297,7 +297,7 @@ object MultiLevelBuildTestsParseErrorEdits extends MultiLevelBuildTests {
         // remain null, because none of the meta-builds can evaluate. Only once
         // all of them parse successfully do we get a new set of classloaders for
         // every level of the meta-build
-        if (tester.clientServerMode) checkChangedClassloaders(tester, null, null, false, false)
+        if (tester.daemonMode) checkChangedClassloaders(tester, null, null, false, false)
         else checkChangedClassloaders(tester, null, null, true, true)
 
         fixParseError(workspacePath / "build.mill")
@@ -309,7 +309,7 @@ object MultiLevelBuildTestsParseErrorEdits extends MultiLevelBuildTests {
           "mill-build/build.mill"
         )
         // checkWatchedFiles(tester, Nil, Nil, buildPaths2(tester), Nil)
-        if (tester.clientServerMode) checkChangedClassloaders(tester, null, null, null, false)
+        if (tester.daemonMode) checkChangedClassloaders(tester, null, null, null, false)
         else checkChangedClassloaders(tester, null, null, null, true)
 
         fixParseError(workspacePath / "mill-build/build.mill")
@@ -337,7 +337,7 @@ object MultiLevelBuildTestsParseErrorEdits extends MultiLevelBuildTests {
         causeParseError(workspacePath / "build.mill")
         evalCheckErr(tester, "\n1 tasks failed", "\ngeneratedScriptSources", "build.mill")
         // checkWatchedFiles(tester, Nil, buildPaths(tester), Nil, Nil)
-        if (tester.clientServerMode) checkChangedClassloaders(tester, null, null, true, false)
+        if (tester.daemonMode) checkChangedClassloaders(tester, null, null, true, false)
         else checkChangedClassloaders(tester, null, null, true, true)
 
         fixParseError(workspacePath / "build.mill")
@@ -349,7 +349,7 @@ object MultiLevelBuildTestsParseErrorEdits extends MultiLevelBuildTests {
           buildPaths2(tester),
           buildPaths3(tester)
         )
-        if (tester.clientServerMode) checkChangedClassloaders(tester, null, true, false, false)
+        if (tester.daemonMode) checkChangedClassloaders(tester, null, true, false, false)
         else checkChangedClassloaders(tester, null, false, false, false)
       }
     }

--- a/integration/invalidation/process-file-deleted-exit/src/ProcessFileDeletedExit.scala
+++ b/integration/invalidation/process-file-deleted-exit/src/ProcessFileDeletedExit.scala
@@ -9,7 +9,7 @@ import scala.concurrent.duration._
 import utest.asserts.{RetryMax, RetryInterval}
 
 /**
- * Make sure removing the `mill-server` or `mill-no-server` directory
+ * Make sure removing the `mill-daemon` or `mill-no-deamon` directory
  * kills any running process
  */
 object ProcessFileDeletedExit extends UtestIntegrationTestSuite {
@@ -19,8 +19,8 @@ object ProcessFileDeletedExit extends UtestIntegrationTestSuite {
     integrationTest { tester =>
       import tester._
 
-      assert(!os.exists(workspacePath / "out/mill-server"))
-      assert(!os.exists(workspacePath / "out/mill-no-server"))
+      assert(!os.exists(workspacePath / "out/mill-daemon"))
+      assert(!os.exists(workspacePath / "out/mill-no-deamon"))
 
       @volatile var watchTerminated = false
       Future {
@@ -32,14 +32,14 @@ object ProcessFileDeletedExit extends UtestIntegrationTestSuite {
         watchTerminated = true
       }
 
-      if (tester.clientServerMode) eventually { os.exists(workspacePath / "out/mill-server") }
-      else eventually { os.exists(workspacePath / "out/mill-no-server") }
+      if (tester.clientServerMode) eventually { os.exists(workspacePath / "out/mill-daemon") }
+      else eventually { os.exists(workspacePath / "out/mill-no-deamon") }
 
       assert(watchTerminated == false)
 
       val processRoot =
-        if (tester.clientServerMode) workspacePath / "out/mill-server"
-        else workspacePath / "out/mill-no-server"
+        if (tester.clientServerMode) workspacePath / "out/mill-daemon"
+        else workspacePath / "out/mill-no-deamon"
 
       eventually {
         os.walk(processRoot).exists(_.last == "processId")

--- a/integration/invalidation/process-file-deleted-exit/src/ProcessFileDeletedExit.scala
+++ b/integration/invalidation/process-file-deleted-exit/src/ProcessFileDeletedExit.scala
@@ -32,20 +32,20 @@ object ProcessFileDeletedExit extends UtestIntegrationTestSuite {
         watchTerminated = true
       }
 
-      if (tester.clientServerMode) eventually { os.exists(workspacePath / "out/mill-daemon") }
+      if (tester.daemonMode) eventually { os.exists(workspacePath / "out/mill-daemon") }
       else eventually { os.exists(workspacePath / "out/mill-no-deamon") }
 
       assert(watchTerminated == false)
 
       val processRoot =
-        if (tester.clientServerMode) workspacePath / "out/mill-daemon"
+        if (tester.daemonMode) workspacePath / "out/mill-daemon"
         else workspacePath / "out/mill-no-deamon"
 
       eventually {
         os.walk(processRoot).exists(_.last == "processId")
       }
 
-      if (tester.clientServerMode) {
+      if (tester.daemonMode) {
         os.remove(processRoot / "processId")
       } else {
         os.list(processRoot).map { p =>

--- a/integration/invalidation/run-background/src/RunBackgroundTests.scala
+++ b/integration/invalidation/run-background/src/RunBackgroundTests.scala
@@ -32,7 +32,7 @@ object RunBackgroundTests extends UtestIntegrationTestSuite {
       os.remove(stop)
       eval(("foo.runBackground", lock, stop))
       eventually { !probeLockAvailable(lock) }
-      if (tester.clientServerMode) eval("shutdown")
+      if (tester.daemonMode) eval("shutdown")
       continually { !probeLockAvailable(lock) }
       os.write(stop, "")
       eventually { probeLockAvailable(lock) }

--- a/integration/invalidation/watch-source-input/src/WatchSourceInputTests.scala
+++ b/integration/invalidation/watch-source-input/src/WatchSourceInputTests.scala
@@ -49,7 +49,7 @@ trait WatchTests extends UtestIntegrationTestSuite {
       .filter(!_.contains("Watching for changes"))
       .filter(!_.contains("[info] compiling"))
       .filter(!_.contains("[info] done compiling"))
-      .filter(!_.contains("mill-server/ exitCode file not found"))
+      .filter(!_.contains("mill-daemon/ exitCode file not found"))
 
     assert(out == expectedOut)
 

--- a/integration/package.mill
+++ b/integration/package.mill
@@ -80,7 +80,7 @@ object `package` extends mill.Module {
     trait IntegrationLauncherModule extends Module {
       def millIntegrationLauncher: T[PathRef]
       def millIntegrationIsPackagedLauncher: Task[Boolean]
-      object fork extends ModeModule {
+      object nodaemon extends ModeModule {
         def millIntegrationLauncher = IntegrationLauncherModule.this.millIntegrationLauncher
         def millIntegrationIsPackagedLauncher =
           IntegrationLauncherModule.this.millIntegrationIsPackagedLauncher

--- a/integration/package.mill
+++ b/integration/package.mill
@@ -42,7 +42,7 @@ object `package` extends mill.Module {
         super.forkEnv() ++
           IntegrationTestModule.this.forkEnv() ++
           Map(
-            "MILL_INTEGRATION_SERVER_MODE" -> (mode == "local" || mode == "server").toString,
+            "MILL_INTEGRATION_DAEMON_MODE" -> (mode == "daemon").toString,
             "MILL_INTEGRATION_IS_PACKAGED_LAUNCHER" -> millIntegrationIsPackagedLauncher().toString,
             "MILL_LAUNCHER" -> build.dist.bootstrapLauncher().path.toString,
             "MILL_LAUNCHER_BAT" -> build.dist.bootstrapLauncherBat().path.toString,
@@ -85,7 +85,7 @@ object `package` extends mill.Module {
         def millIntegrationIsPackagedLauncher =
           IntegrationLauncherModule.this.millIntegrationIsPackagedLauncher
       }
-      object server extends ModeModule {
+      object daemon extends ModeModule {
         def millIntegrationLauncher = IntegrationLauncherModule.this.millIntegrationLauncher
         def millIntegrationIsPackagedLauncher =
           IntegrationLauncherModule.this.millIntegrationIsPackagedLauncher

--- a/libs/main/src/mill/main/MainModule.scala
+++ b/libs/main/src/mill/main/MainModule.scala
@@ -255,7 +255,7 @@ trait MainModule extends BaseModule with MainModuleApi {
     }
 
   /**
-   * Shuts down mill's background server
+   * Shuts down mill's background daemon
    */
   def shutdown(): Command[Unit] = Task.Command(exclusive = true) {
     Target.log.info("Shutting down Mill server...")

--- a/libs/pythonlib/src/mill/pythonlib/PythonModule.scala
+++ b/libs/pythonlib/src/mill/pythonlib/PythonModule.scala
@@ -2,9 +2,9 @@ package mill.pythonlib
 
 import mill._
 import mill.api.Result
-import mill.util.{Jvm}
+import mill.constants.DaemonFiles
+import mill.util.Jvm
 import mill.define.TaskCtx
-import mill.constants.ServerFiles
 
 trait PythonModule extends PipModule with TaskModule { outer =>
 
@@ -199,8 +199,8 @@ trait PythonModule extends PipModule with TaskModule { outer =>
         // Hack to forward the background subprocess output to the Mill server process
         // stdout/stderr files, so the output will get properly slurped up by the Mill server
         // and shown to any connected Mill client even if the current command has completed
-        stdout = os.PathAppendRedirect(pwd0 / ".." / ServerFiles.stdout),
-        stderr = os.PathAppendRedirect(pwd0 / ".." / ServerFiles.stderr),
+        stdout = os.PathAppendRedirect(pwd0 / ".." / DaemonFiles.stdout),
+        stderr = os.PathAppendRedirect(pwd0 / ".." / DaemonFiles.stderr),
         javaHome = mill.scalalib.JvmWorkerModule.javaHome().map(_.path)
       )
     }

--- a/libs/scalalib/src/mill/scalalib/RunModule.scala
+++ b/libs/scalalib/src/mill/scalalib/RunModule.scala
@@ -6,8 +6,8 @@ import mainargs.arg
 import mill.define.JsonFormatters.pathReadWrite
 import mill.api.Result
 import mill.api.internal.RunModuleApi
+import mill.constants.DaemonFiles
 import mill.define.{ModuleCtx, PathRef, TaskCtx}
-import mill.constants.ServerFiles
 import mill.define.{Command, ModuleRef, Task}
 import mill.util.Jvm
 import mill.{Args, T}
@@ -320,8 +320,8 @@ object RunModule {
             // and shown to any connected Mill client even if the current command has completed
             val pwd0 = os.Path(java.nio.file.Paths.get(".").toAbsolutePath)
             (
-              os.PathAppendRedirect(pwd0 / ".." / ServerFiles.stdout),
-              os.PathAppendRedirect(pwd0 / ".." / ServerFiles.stderr)
+              os.PathAppendRedirect(pwd0 / ".." / DaemonFiles.stdout),
+              os.PathAppendRedirect(pwd0 / ".." / DaemonFiles.stderr)
             )
           } else {
             (dest / "stdout.log": os.ProcessOutput, dest / "stderr.log": os.ProcessOutput)

--- a/mill
+++ b/mill
@@ -309,7 +309,7 @@ if [ -z "$MILL_MAIN_CLI" ] ; then
 fi
 
 MILL_FIRST_ARG=""
-if [ "$1" = "--bsp" ] || [ "$1" = "-i" ] || [ "$1" = "--interactive" ] || [ "$1" = "--no-server" ] || [ "$1" = "--repl" ] || [ "$1" = "--help" ] ; then
+if [ "$1" = "--bsp" ] || [ "$1" = "-i" ] || [ "$1" = "--interactive" ] || [ "$1" = "--no-server" ] || [ "$1" = "--no-daemon" ] || [ "$1" = "--repl" ] || [ "$1" = "--help" ] ; then
   # Need to preserve the first position of those listed options
   MILL_FIRST_ARG=$1
   shift

--- a/mill.bat
+++ b/mill.bat
@@ -272,11 +272,15 @@ if [%~1%]==[--bsp] (
       if [%~1%]==[--no-server] (
         set MILL_FIRST_ARG=%1%
       ) else (
-        if [%~1%]==[--repl] (
+        if [%~1%]==[--no-daemon] (
           set MILL_FIRST_ARG=%1%
         ) else (
-          if [%~1%]==[--help] (
+          if [%~1%]==[--repl] (
             set MILL_FIRST_ARG=%1%
+          ) else (
+            if [%~1%]==[--help] (
+              set MILL_FIRST_ARG=%1%
+            )
           )
         )
       )

--- a/runner/client/src/mill/client/ServerLauncher.java
+++ b/runner/client/src/mill/client/ServerLauncher.java
@@ -16,7 +16,7 @@ import mill.constants.Util;
 
 /**
  * Client side code that interacts with `Server.scala` in order to launch a generic
- * long-lived background server.
+ * long-lived background daemon.
  *
  * The protocol is as follows:
  *

--- a/runner/client/src/mill/client/ServerLauncher.java
+++ b/runner/client/src/mill/client/ServerLauncher.java
@@ -21,17 +21,17 @@ import mill.constants.Util;
  * The protocol is as follows:
  *
  * - Client:
- *   - Take clientLock
- *   - If serverLock is not yet taken, it means server is not running, so spawn a server
+ *   - Take launcherLock
+ *   - If daemonLock is not yet taken, it means server is not running, so spawn a server
  *   - Wait for server socket to be available for connection
  * - Server:
- *   - Take serverLock.
+ *   - Take daemonLock.
  *     - If already taken, it means another server was running
  *       (e.g. spawned by a different client) so exit immediately
  * - Server: loop:
  *   - Listen for incoming client requests on serverSocket
  *   - Execute client request
- *   - If clientLock is released during execution, terminate server (otherwise
+ *   - If launcherLock is released during execution, terminate server (otherwise
  *     we have no safe way of terminating the in-process request, so the server
  *     may continue running for arbitrarily long with no client attached)
  *   - Send `ProxyStream.END` packet and call `clientSocket.close()`

--- a/runner/client/src/mill/client/lock/Locks.java
+++ b/runner/client/src/mill/client/lock/Locks.java
@@ -7,15 +7,15 @@ public final class Locks implements AutoCloseable {
   public final Lock launcherLock;
   public final Lock daemonLock;
 
-  public Locks(Lock clientLock, Lock serverLock) {
-    this.launcherLock = clientLock;
-    this.daemonLock = serverLock;
+  public Locks(Lock launcherLock, Lock daemonLock) {
+    this.launcherLock = launcherLock;
+    this.daemonLock = daemonLock;
   }
 
   public static Locks files(String daemonDir) throws Exception {
     return new Locks(
-        new FileLock(daemonDir + "/" + DaemonFiles.clientLock),
-        new FileLock(daemonDir + "/" + DaemonFiles.serverLock));
+        new FileLock(daemonDir + "/" + DaemonFiles.launcherLock),
+        new FileLock(daemonDir + "/" + DaemonFiles.daemonLock));
   }
 
   public static Locks memory() {

--- a/runner/client/src/mill/client/lock/Locks.java
+++ b/runner/client/src/mill/client/lock/Locks.java
@@ -1,21 +1,21 @@
 package mill.client.lock;
 
-import mill.constants.ServerFiles;
+import mill.constants.DaemonFiles;
 
 public final class Locks implements AutoCloseable {
 
-  public final Lock clientLock;
-  public final Lock serverLock;
+  public final Lock launcherLock;
+  public final Lock daemonLock;
 
   public Locks(Lock clientLock, Lock serverLock) {
-    this.clientLock = clientLock;
-    this.serverLock = serverLock;
+    this.launcherLock = clientLock;
+    this.daemonLock = serverLock;
   }
 
-  public static Locks files(String serverDir) throws Exception {
+  public static Locks files(String daemonDir) throws Exception {
     return new Locks(
-        new FileLock(serverDir + "/" + ServerFiles.clientLock),
-        new FileLock(serverDir + "/" + ServerFiles.serverLock));
+        new FileLock(daemonDir + "/" + DaemonFiles.clientLock),
+        new FileLock(daemonDir + "/" + DaemonFiles.serverLock));
   }
 
   public static Locks memory() {
@@ -24,7 +24,7 @@ public final class Locks implements AutoCloseable {
 
   @Override
   public void close() throws Exception {
-    clientLock.delete();
-    serverLock.delete();
+    launcherLock.delete();
+    daemonLock.delete();
   }
 }

--- a/runner/daemon/src/mill/daemon/MillCliConfig.scala
+++ b/runner/daemon/src/mill/daemon/MillCliConfig.scala
@@ -21,11 +21,11 @@ case class MillCliConfig(
     repl: Flag = Flag(),
     @arg(
       hidden = true,
-      doc = """Run without a background server. Must be the first argument."""
+      doc = """Run without a background daemon. Must be the first argument."""
     )
     noServer: Flag = Flag(),
     @arg(
-      doc = """Run without a background server. Must be the first argument."""
+      doc = """Run without a background daemon. Must be the first argument."""
     )
     noDaemon: Flag = Flag(),
     @arg(doc = """Enable BSP server mode.""")
@@ -164,7 +164,7 @@ case class MillCliConfig(
     )
     offline: Flag = Flag()
 ) {
-  def noDaemonEnabled = interactive.value || noServer.value || noDaemon.value || bsp.value 
+  def noDaemonEnabled = interactive.value || noServer.value || noDaemon.value || bsp.value
 }
 
 import mainargs.ParserForClass

--- a/runner/daemon/src/mill/daemon/MillCliConfig.scala
+++ b/runner/daemon/src/mill/daemon/MillCliConfig.scala
@@ -20,9 +20,14 @@ case class MillCliConfig(
     )
     repl: Flag = Flag(),
     @arg(
+      hidden = true,
       doc = """Run without a background server. Must be the first argument."""
     )
     noServer: Flag = Flag(),
+    @arg(
+      doc = """Run without a background server. Must be the first argument."""
+    )
+    noDaemon: Flag = Flag(),
     @arg(doc = """Enable BSP server mode.""")
     bsp: Flag,
     @arg(doc = """Create mill-bsp.json with Mill details under .bsp/""")
@@ -158,14 +163,16 @@ case class MillCliConfig(
           .stripMargin
     )
     offline: Flag = Flag()
-)
+) {
+  def noDaemonEnabled = interactive.value || noServer.value || noDaemon.value || bsp.value 
+}
 
 import mainargs.ParserForClass
 
 // We want this in a separate source file, but to avoid stale --help output due
 // to under-compilation, we have it in this file
 // see https://github.com/com-lihaoyi/mill/issues/2315
-object MillCliConfigParser {
+object MillCliConfig {
   val customName: String = s"Mill Build Tool, version ${mill.util.BuildInfo.millVersion}"
   val customDoc = """
 Usage: mill [options] task [task-options] [+ task ...]

--- a/runner/daemon/src/mill/daemon/MillCliConfig.scala
+++ b/runner/daemon/src/mill/daemon/MillCliConfig.scala
@@ -164,7 +164,8 @@ case class MillCliConfig(
     )
     offline: Flag = Flag()
 ) {
-  def noDaemonEnabled = interactive.value || noServer.value || noDaemon.value || bsp.value
+  def noDaemonEnabled =
+    Seq(interactive.value, noServer.value, noDaemon.value, bsp.value).count(identity)
 }
 
 import mainargs.ParserForClass

--- a/runner/daemon/src/mill/daemon/MillDaemonMain.scala
+++ b/runner/daemon/src/mill/daemon/MillDaemonMain.scala
@@ -3,7 +3,7 @@ package mill.daemon
 import mill.api.SystemStreams
 import mill.client.ClientUtil
 import mill.client.lock.{DoubleLock, Lock, Locks}
-import mill.constants.{OutFiles, ServerFiles}
+import mill.constants.{OutFiles, DaemonFiles}
 import sun.misc.{Signal, SignalHandler}
 
 import scala.util.Try
@@ -28,18 +28,18 @@ object MillDaemonMain {
       Try(System.getProperty("mill.server_timeout").toInt).getOrElse(30 * 60 * 1000) // 30 minutes
 
     new MillDaemonMain(
-      serverDir = os.Path(args0(0)),
+      daemonDir = os.Path(args0(0)),
       acceptTimeoutMillis = acceptTimeoutMillis,
       Locks.files(args0(0))
     ).run()
   }
 }
 class MillDaemonMain(
-    serverDir: os.Path,
+    daemonDir: os.Path,
     acceptTimeoutMillis: Int,
     locks: Locks
 ) extends mill.server.Server[RunnerState](
-      serverDir,
+      daemonDir,
       acceptTimeoutMillis,
       locks
     ) {
@@ -77,7 +77,7 @@ class MillDaemonMain(
         userSpecifiedProperties0 = userSpecifiedProperties,
         initialSystemProperties = initialSystemProperties,
         systemExit = systemExit,
-        serverDir = serverDir,
+        daemonDir = daemonDir,
         outLock = outLock
       )
     catch MillMain.handleMillException(streams.err, stateCache)

--- a/runner/daemon/src/mill/daemon/MillDaemonMain.scala
+++ b/runner/daemon/src/mill/daemon/MillDaemonMain.scala
@@ -14,7 +14,7 @@ object MillDaemonMain {
     //
     // This gets passed through from the client to server whenever the user
     // hits `Ctrl-C`, which by default kills the server, which defeats the purpose
-    // of running a background server. Furthermore, the background server already
+    // of running a background daemon. Furthermore, the background daemon already
     // can detect when the Mill client goes away, which is necessary to handle
     // the case when a Mill client that did *not* spawn the server gets `CTRL-C`ed
     Signal.handle(

--- a/runner/daemon/src/mill/daemon/MillMain.scala
+++ b/runner/daemon/src/mill/daemon/MillMain.scala
@@ -165,14 +165,14 @@ object MillMain {
               (true, RunnerState.empty)
 
             case Result.Success(config)
-                if config.noDaemonEnabled && streams.in.getClass == classOf[PipedInputStream] =>
+                if config.noDaemonEnabled > 0 && streams.in.getClass == classOf[PipedInputStream] =>
               // because we have stdin as dummy, we assume we were already started in server process
               streams.err.println(
                 "-i/--interactive/--no-daemon/--bsp must be passed in as the first argument"
               )
               (false, RunnerState.empty)
 
-            case Result.Success(config) if config.noDaemonEnabled =>
+            case Result.Success(config) if config.noDaemonEnabled > 1 =>
               streams.err.println(
                 "Only one of -i/--interactive, --no-daemon or --bsp may be given"
               )

--- a/runner/daemon/src/mill/daemon/MillMain.scala
+++ b/runner/daemon/src/mill/daemon/MillMain.scala
@@ -168,13 +168,13 @@ object MillMain {
                 if config.noDaemonEnabled && streams.in.getClass == classOf[PipedInputStream] =>
               // because we have stdin as dummy, we assume we were already started in server process
               streams.err.println(
-                "-i/--interactive/--no-server/--bsp must be passed in as the first argument"
+                "-i/--interactive/--no-daemon/--bsp must be passed in as the first argument"
               )
               (false, RunnerState.empty)
 
             case Result.Success(config) if config.noDaemonEnabled =>
               streams.err.println(
-                "Only one of -i/--interactive, --no-server or --bsp may be given"
+                "Only one of -i/--interactive, --no-daemon or --bsp may be given"
               )
               (false, RunnerState.empty)
 

--- a/runner/daemon/src/mill/daemon/MillMain.scala
+++ b/runner/daemon/src/mill/daemon/MillMain.scala
@@ -4,7 +4,7 @@ import mill.api.internal.{BspServerResult, internal}
 import mill.api.{Logger, MillException, Result, SystemStreams}
 import mill.bsp.BSP
 import mill.client.lock.Lock
-import mill.constants.{OutFiles, ServerFiles, Util}
+import mill.constants.{OutFiles, DaemonFiles, Util}
 import mill.{api, define}
 import mill.define.WorkspaceRoot
 import mill.internal.{Colors, MultiStream, PromptLogger}
@@ -49,7 +49,7 @@ object MillMain {
     val processId = Server.computeProcessId()
     val out = os.Path(OutFiles.out, WorkspaceRoot.workspaceRoot)
     Server.watchProcessIdFile(
-      out / OutFiles.millNoServer / processId / ServerFiles.processId,
+      out / OutFiles.millNoDaemon / processId / DaemonFiles.processId,
       processId,
       running = () => true,
       exit = msg => {
@@ -58,7 +58,7 @@ object MillMain {
       }
     )
 
-    val serverDir = os.Path(args.head)
+    val daemonDir = os.Path(args.head)
     val (result, _) =
       try main0(
           args = args.tail,
@@ -70,7 +70,7 @@ object MillMain {
           userSpecifiedProperties0 = Map(),
           initialSystemProperties = sys.props.toMap,
           systemExit = i => sys.exit(i),
-          serverDir = serverDir,
+          daemonDir = daemonDir,
           outLock = Lock.file((out / OutFiles.millOutLock).toString)
         )
       catch handleMillException(initialSystemStreams.err, ())
@@ -122,12 +122,12 @@ object MillMain {
       userSpecifiedProperties0: Map[String, String],
       initialSystemProperties: Map[String, String],
       systemExit: Int => Nothing,
-      serverDir: os.Path,
+      daemonDir: os.Path,
       outLock: Lock
   ): (Boolean, RunnerState) =
     mill.api.internal.MillScalaParser.current.withValue(MillScalaParserImpl) {
       os.SubProcess.env.withValue(env) {
-        val parserResult = MillCliConfigParser.parse(args)
+        val parserResult = MillCliConfig.parse(args)
         // Detect when we're running in BSP mode as early as possible,
         // and ensure we don't log to the default stdout or use the default
         // stdin, meant to be used for BSP JSONRPC communication, where those
@@ -143,7 +143,7 @@ object MillMain {
               (false, RunnerState.empty)
 
             case Result.Success(config) if config.help.value =>
-              streams.out.println(MillCliConfigParser.longUsageText)
+              streams.out.println(MillCliConfig.longUsageText)
               (true, RunnerState.empty)
 
             case Result.Success(config) if config.showVersion.value =>
@@ -165,21 +165,14 @@ object MillMain {
               (true, RunnerState.empty)
 
             case Result.Success(config)
-                if (
-                  config.interactive.value || config.noServer.value || config.bsp.value
-                ) && streams.in.getClass == classOf[PipedInputStream] =>
+                if config.noDaemonEnabled && streams.in.getClass == classOf[PipedInputStream] =>
               // because we have stdin as dummy, we assume we were already started in server process
               streams.err.println(
                 "-i/--interactive/--no-server/--bsp must be passed in as the first argument"
               )
               (false, RunnerState.empty)
 
-            case Result.Success(config)
-                if Seq(
-                  config.interactive.value,
-                  config.noServer.value,
-                  config.bsp.value
-                ).count(identity) > 1 =>
+            case Result.Success(config) if config.noDaemonEnabled =>
               streams.err.println(
                 "Only one of -i/--interactive, --no-server or --bsp may be given"
               )
@@ -245,7 +238,7 @@ object MillMain {
                   BSP.install(bspInstallModeJobCountOpt.get, config.debugLog.value, streams.err)
                   (true, stateCache)
                 } else if (!bspMode && config.leftoverArgs.value.isEmpty) {
-                  println(MillCliConfigParser.shortUsageText)
+                  println(MillCliConfig.shortUsageText)
 
                   (true, stateCache)
 
@@ -260,7 +253,7 @@ object MillMain {
                   val threadCount = Some(maybeThreadCount.toOption.get)
 
                   val out = os.Path(OutFiles.out, WorkspaceRoot.workspaceRoot)
-                  Using.resource(new TailManager(serverDir)) { tailManager =>
+                  Using.resource(new TailManager(daemonDir)) { tailManager =>
                     def runMillBootstrap(
                         enterKeyPressed: Boolean,
                         prevState: Option[RunnerState],
@@ -283,7 +276,7 @@ object MillMain {
                           else config.ticker
                             .orElse(config.enableTicker)
                             .orElse(Option.when(config.disableTicker.value)(false)),
-                        serverDir,
+                        daemonDir,
                         colored = colored,
                         colors = colors
                       )) { logger =>
@@ -469,7 +462,7 @@ object MillMain {
       streams: SystemStreams,
       config: MillCliConfig,
       enableTicker: Option[Boolean],
-      serverDir: os.Path,
+      daemonDir: os.Path,
       colored: Boolean,
       colors: Colors
   ): Logger & AutoCloseable = {
@@ -482,7 +475,7 @@ object MillMain {
       systemStreams0 = streams,
       debugEnabled = config.debugLog.value,
       titleText = config.leftoverArgs.value.mkString(" "),
-      terminfoPath = serverDir / ServerFiles.terminfo,
+      terminfoPath = daemonDir / DaemonFiles.terminfo,
       currentTimeMillis = () => System.currentTimeMillis()
     )
   }

--- a/runner/daemon/src/mill/daemon/TailManager.scala
+++ b/runner/daemon/src/mill/daemon/TailManager.scala
@@ -1,12 +1,12 @@
 package mill.daemon
 
 import mill.client.FileToStreamTailer
-import mill.constants.ServerFiles
+import mill.constants.DaemonFiles
 import mill.define.SystemStreams.ThreadLocalStreams
 
 import java.io.{OutputStream, PrintStream}
 
-class TailManager(serverDir: os.Path) extends AutoCloseable {
+class TailManager(daemonDir: os.Path) extends AutoCloseable {
   val tailerRefreshIntervalMillis = 2
 
   // We need to explicitly manage tailerOut/tailerErr ourselves, rather than relying
@@ -15,14 +15,14 @@ class TailManager(serverDir: os.Path) extends AutoCloseable {
   @volatile var tailerOut: OutputStream = System.out
   @volatile var tailerErr: OutputStream = System.err
   val stdoutTailer = new FileToStreamTailer(
-    (serverDir / ServerFiles.stdout).toIO,
+    (daemonDir / DaemonFiles.stdout).toIO,
     new PrintStream(new ThreadLocalStreams.ProxyOutputStream {
       def delegate(): OutputStream = tailerOut
     }),
     tailerRefreshIntervalMillis
   )
   val stderrTailer = new FileToStreamTailer(
-    (serverDir / ServerFiles.stderr).toIO,
+    (daemonDir / DaemonFiles.stderr).toIO,
     new PrintStream(new ThreadLocalStreams.ProxyOutputStream {
       def delegate(): OutputStream = tailerErr
     }),

--- a/runner/launcher/src/mill/launcher/MillLauncherMain.java
+++ b/runner/launcher/src/mill/launcher/MillLauncherMain.java
@@ -17,7 +17,7 @@ public class MillLauncherMain {
     boolean runNoServer = false;
     if (args.length > 0) {
       String firstArg = args[0];
-      runNoServer = Arrays.asList("--interactive", "--no-server", "--repl", "--bsp", "--help")
+      runNoServer = Arrays.asList("--interactive", "--no-server", "--no-daemon", "--repl", "--bsp", "--help")
               .contains(firstArg)
           || firstArg.startsWith("-i");
     }

--- a/runner/launcher/src/mill/launcher/MillLauncherMain.java
+++ b/runner/launcher/src/mill/launcher/MillLauncherMain.java
@@ -17,9 +17,10 @@ public class MillLauncherMain {
     boolean runNoServer = false;
     if (args.length > 0) {
       String firstArg = args[0];
-      runNoServer = Arrays.asList("--interactive", "--no-server", "--no-daemon", "--repl", "--bsp", "--help")
-              .contains(firstArg)
-          || firstArg.startsWith("-i");
+      runNoServer =
+          Arrays.asList("--interactive", "--no-server", "--no-daemon", "--repl", "--bsp", "--help")
+                  .contains(firstArg)
+              || firstArg.startsWith("-i");
     }
     if (!runNoServer) {
       // WSL2 has the directory /run/WSL/ and WSL1 not.

--- a/runner/launcher/src/mill/launcher/MillLauncherMain.java
+++ b/runner/launcher/src/mill/launcher/MillLauncherMain.java
@@ -49,20 +49,20 @@ public class MillLauncherMain {
                 optsArgs.toArray(new String[0]),
                 null,
                 -1) {
-              public void initServer(Path serverDir, Locks locks) throws Exception {
-                MillProcessLauncher.launchMillServer(serverDir);
+              public void initServer(Path daemonDir, Locks locks) throws Exception {
+                MillProcessLauncher.launchMillServer(daemonDir);
               }
 
-              public void prepareServerDir(Path serverDir) throws Exception {
-                MillProcessLauncher.prepareMillRunFolder(serverDir);
+              public void preparedaemonDir(Path daemonDir) throws Exception {
+                MillProcessLauncher.prepareMillRunFolder(daemonDir);
               }
             };
 
-        Path serverDir0 = Paths.get(OutFiles.out, OutFiles.millServer);
+        Path daemonDir0 = Paths.get(OutFiles.out, OutFiles.millDaemon);
         String javaHome = MillProcessLauncher.javaHome();
-        int exitCode = launcher.run(serverDir0, javaHome).exitCode;
+        int exitCode = launcher.run(daemonDir0, javaHome).exitCode;
         if (exitCode == ClientUtil.ExitServerCodeWhenVersionMismatch()) {
-          exitCode = launcher.run(serverDir0, javaHome).exitCode;
+          exitCode = launcher.run(daemonDir0, javaHome).exitCode;
         }
         System.exit(exitCode);
       } catch (Exception e) {

--- a/runner/launcher/src/mill/launcher/MillProcessLauncher.java
+++ b/runner/launcher/src/mill/launcher/MillProcessLauncher.java
@@ -17,14 +17,14 @@ import java.util.stream.Stream;
 import mill.client.ClientUtil;
 import mill.constants.BuildInfo;
 import mill.constants.CodeGenConstants;
+import mill.constants.DaemonFiles;
 import mill.constants.EnvVars;
-import mill.constants.ServerFiles;
 
 public class MillProcessLauncher {
 
   static int launchMillNoServer(String[] args) throws Exception {
     final String sig = String.format("%08x", UUID.randomUUID().hashCode());
-    final Path processDir = Paths.get(".").resolve(out).resolve(millNoServer).resolve(sig);
+    final Path processDir = Paths.get(".").resolve(out).resolve(millNoDaemon).resolve(sig);
 
     final List<String> l = new ArrayList<>();
     l.addAll(millLaunchJvmCommand());
@@ -56,23 +56,23 @@ public class MillProcessLauncher {
     }
   }
 
-  static void launchMillServer(Path serverDir) throws Exception {
+  static void launchMillServer(Path daemonDir) throws Exception {
     List<String> l = new ArrayList<>();
     l.addAll(millLaunchJvmCommand());
     l.add("mill.daemon.MillDaemonMain");
-    l.add(serverDir.toFile().getCanonicalPath());
+    l.add(daemonDir.toFile().getCanonicalPath());
 
     ProcessBuilder builder = new ProcessBuilder()
         .command(l)
-        .redirectOutput(serverDir.resolve(ServerFiles.stdout).toFile())
-        .redirectError(serverDir.resolve(ServerFiles.stderr).toFile());
+        .redirectOutput(daemonDir.resolve(DaemonFiles.stdout).toFile())
+        .redirectError(daemonDir.resolve(DaemonFiles.stderr).toFile());
 
-    configureRunMillProcess(builder, serverDir);
+    configureRunMillProcess(builder, daemonDir);
   }
 
-  static Process configureRunMillProcess(ProcessBuilder builder, Path serverDir) throws Exception {
+  static Process configureRunMillProcess(ProcessBuilder builder, Path daemonDir) throws Exception {
 
-    Path sandbox = serverDir.resolve(ServerFiles.sandbox);
+    Path sandbox = daemonDir.resolve(DaemonFiles.sandbox);
     Files.createDirectories(sandbox);
     builder.environment().put(EnvVars.MILL_WORKSPACE_ROOT, new File("").getCanonicalPath());
     builder.environment().put(EnvVars.MILL_EXECUTABLE_PATH, getExecutablePath());
@@ -314,7 +314,7 @@ public class MillProcessLauncher {
     canUseNativeTerminal = canUse;
   }
 
-  static void writeTerminalDims(boolean tputExists, Path serverDir) throws Exception {
+  static void writeTerminalDims(boolean tputExists, Path daemonDir) throws Exception {
     String str;
 
     try {
@@ -347,7 +347,7 @@ public class MillProcessLauncher {
     //
     String oldValue = memoizedTerminalDims.getAndSet(str);
     if ((oldValue == null) || !oldValue.equals(str)) {
-      Files.write(serverDir.resolve(ServerFiles.terminfo), str.getBytes());
+      Files.write(daemonDir.resolve(DaemonFiles.terminfo), str.getBytes());
     }
   }
 
@@ -361,21 +361,21 @@ public class MillProcessLauncher {
     }
   }
 
-  public static void prepareMillRunFolder(Path serverDir) throws Exception {
+  public static void prepareMillRunFolder(Path daemonDir) throws Exception {
     // Clear out run-related files from the server folder to make sure we
     // never hit issues where we are reading the files from a previous run
-    Files.deleteIfExists(serverDir.resolve(ServerFiles.terminfo));
+    Files.deleteIfExists(daemonDir.resolve(DaemonFiles.terminfo));
 
-    Path sandbox = serverDir.resolve(ServerFiles.sandbox);
+    Path sandbox = daemonDir.resolve(DaemonFiles.sandbox);
     Files.createDirectories(sandbox);
     boolean tputExists = checkTputExists();
 
-    writeTerminalDims(tputExists, serverDir);
+    writeTerminalDims(tputExists, daemonDir);
     Thread termInfoPropagatorThread = new Thread(
         () -> {
           try {
             while (true) {
-              writeTerminalDims(tputExists, serverDir);
+              writeTerminalDims(tputExists, daemonDir);
               Thread.sleep(100);
             }
           } catch (Exception e) {

--- a/runner/server/package.mill
+++ b/runner/server/package.mill
@@ -4,7 +4,7 @@ import mill._
 import millbuild.*
 
 /**
- * This module contains the core logic around the Mill background server,
+ * This module contains the core logic around the Mill background daemon,
  * and tests that exercise is together with [[build.core.constants]], without
  * any Mill-related business logic
  */

--- a/runner/server/src/mill/server/Server.scala
+++ b/runner/server/src/mill/server/Server.scala
@@ -271,7 +271,7 @@ abstract class Server[T](
       t.start()
 
       // We cannot simply use Lock#await here, because the filesystem doesn't
-      // realize the clientLock/serverLock are held by different threads in the
+      // realize the launcherLock/daemonLock are held by different threads in the
       // two processes and gives a spurious deadlock error
       while (!done && checkClientAlive()) Thread.sleep(1)
 

--- a/runner/server/test/src/mill/server/ClientServerTests.scala
+++ b/runner/server/test/src/mill/server/ClientServerTests.scala
@@ -3,7 +3,7 @@ package mill.server
 import mill.api.SystemStreams
 import mill.client.lock.Locks
 import mill.client.ServerLauncher
-import mill.constants.{ServerFiles, Util}
+import mill.constants.{DaemonFiles, Util}
 import utest.*
 
 import java.io.*
@@ -19,10 +19,10 @@ object ClientServerTests extends TestSuite {
   val ENDL = System.lineSeparator()
   class EchoServer(
       override val processId: String,
-      serverDir: os.Path,
+      daemonDir: os.Path,
       locks: Locks,
       testLogEvenWhenServerIdWrong: Boolean
-  ) extends Server[Option[Int]](serverDir, 1000, locks, testLogEvenWhenServerIdWrong)
+  ) extends Server[Option[Int]](daemonDir, 1000, locks, testLogEvenWhenServerIdWrong)
       with Runnable {
 
     override def outLock = mill.client.lock.Lock.memory()
@@ -100,13 +100,13 @@ object ClientServerTests extends TestSuite {
         memoryLock,
         forceFailureForTestingMillisDelay
       ) {
-        def prepareServerDir(serverDir: Path) = { /*do nothing*/ }
-        def initServer(serverDir: Path, locks: Locks) = {
+        def preparedaemonDir(daemonDir: Path) = { /*do nothing*/ }
+        def initServer(daemonDir: Path, locks: Locks) = {
           val processId = "server-" + nextServerId
           nextServerId += 1
           new Thread(new EchoServer(
             processId,
-            os.Path(serverDir, os.pwd),
+            os.Path(daemonDir, os.pwd),
             locks,
             testLogEvenWhenServerIdWrong
           )).start()
@@ -115,7 +115,7 @@ object ClientServerTests extends TestSuite {
 
       ClientResult(
         result.exitCode,
-        os.Path(result.serverDir, os.pwd),
+        os.Path(result.daemonDir, os.pwd),
         outDir,
         out.toString,
         err.toString
@@ -126,14 +126,14 @@ object ClientServerTests extends TestSuite {
 
   case class ClientResult(
       exitCode: Int,
-      serverDir: os.Path,
+      daemonDir: os.Path,
       outDir: os.Path,
       out: String,
       err: String
   ) {
     def logsFor(suffix: String) = {
       os.read
-        .lines(serverDir / ServerFiles.serverLog)
+        .lines(daemonDir / DaemonFiles.serverLog)
         .collect { case s if s.endsWith(" " + suffix) => s.dropRight(1 + suffix.length) }
     }
   }
@@ -218,9 +218,9 @@ object ClientServerTests extends TestSuite {
       // Mutiple server processes live in same out folder
       assert(resF1.outDir == resF2.outDir)
       assert(resF2.outDir == resF3.outDir)
-      // but the serverDir is placed in different subfolders
-      assert(resF1.serverDir == resF2.serverDir)
-      assert(resF2.serverDir == resF3.serverDir)
+      // but the daemonDir is placed in different subfolders
+      assert(resF1.daemonDir == resF2.daemonDir)
+      assert(resF2.daemonDir == resF3.daemonDir)
 
       assert(resF1.out == s"hello World$ENDL")
       assert(resF2.out == s"hello WORLD$ENDL")

--- a/testkit/src/mill/testkit/ExampleTester.scala
+++ b/testkit/src/mill/testkit/ExampleTester.scala
@@ -71,7 +71,7 @@ object ExampleTester {
 }
 
 class ExampleTester(
-    val clientServerMode: Boolean,
+    val daemonMode: Boolean,
     val workspaceSourcePath: os.Path,
     millExecutable: os.Path,
     bashExecutable: String = ExampleTester.defaultBashExecutable(),
@@ -91,15 +91,15 @@ class ExampleTester(
     val incorrectPlatform =
       (comment.exists(_.startsWith("windows")) && !isWindows) ||
         (comment.exists(_.startsWith("mac/linux")) && isWindows) ||
-        (comment.exists(_.startsWith("--no-server")) && clientServerMode) ||
-        (comment.exists(_.startsWith("not --no-server")) && !clientServerMode)
+        (comment.exists(_.startsWith("--no-daemon")) && daemonMode) ||
+        (comment.exists(_.startsWith("not --no-daemon")) && !daemonMode)
 
     if (!incorrectPlatform) {
       processCommand(expectedSnippets, commandHead.trim)
     }
   }
   private val millExt = if (isWindows) ".bat" else ""
-  private val clientServerFlag = if (clientServerMode) "" else "--no-server"
+  private val daemonFlag = if (daemonMode) "" else "--no-daemon"
 
   def processCommand(
       expectedSnippets: Vector[String],
@@ -107,8 +107,8 @@ class ExampleTester(
       check: Boolean = true
   ): Unit = {
     val commandStr = commandStr0 match {
-      case s"mill $rest" => s"./mill$millExt $clientServerFlag --disable-ticker $rest"
-      case s"./mill $rest" => s"./mill$millExt $clientServerFlag --disable-ticker $rest"
+      case s"mill $rest" => s"./mill$millExt $daemonFlag --disable-ticker $rest"
+      case s"./mill $rest" => s"./mill$millExt $daemonFlag --disable-ticker $rest"
       case s"curl $rest" => s"curl --retry 7 --retry-all-errors $rest"
       case s => s
     }
@@ -225,7 +225,7 @@ class ExampleTester(
           ex.printStackTrace(System.err)
       }
     } finally {
-      if (clientServerMode) processCommand(Vector(), "./mill shutdown", check = false)
+      if (daemonMode) processCommand(Vector(), "./mill shutdown", check = false)
       removeProcessIdFile()
     }
   }

--- a/testkit/src/mill/testkit/ExampleTester.scala
+++ b/testkit/src/mill/testkit/ExampleTester.scala
@@ -47,14 +47,14 @@ import utest.*
  */
 object ExampleTester {
   def run(
-      clientServerMode: Boolean,
-      workspaceSourcePath: os.Path,
-      millExecutable: os.Path,
-      bashExecutable: String = defaultBashExecutable(),
-      workspacePath: os.Path = os.pwd
+           daemonMode: Boolean,
+           workspaceSourcePath: os.Path,
+           millExecutable: os.Path,
+           bashExecutable: String = defaultBashExecutable(),
+           workspacePath: os.Path = os.pwd
   ): os.Path = {
     val tester = new ExampleTester(
-      clientServerMode,
+      daemonMode,
       workspaceSourcePath,
       millExecutable,
       bashExecutable,

--- a/testkit/src/mill/testkit/ExampleTester.scala
+++ b/testkit/src/mill/testkit/ExampleTester.scala
@@ -47,11 +47,11 @@ import utest.*
  */
 object ExampleTester {
   def run(
-           daemonMode: Boolean,
-           workspaceSourcePath: os.Path,
-           millExecutable: os.Path,
-           bashExecutable: String = defaultBashExecutable(),
-           workspacePath: os.Path = os.pwd
+      daemonMode: Boolean,
+      workspaceSourcePath: os.Path,
+      millExecutable: os.Path,
+      bashExecutable: String = defaultBashExecutable(),
+      workspacePath: os.Path = os.pwd
   ): os.Path = {
     val tester = new ExampleTester(
       daemonMode,

--- a/testkit/src/mill/testkit/IntegrationTestSuite.scala
+++ b/testkit/src/mill/testkit/IntegrationTestSuite.scala
@@ -19,7 +19,7 @@ trait IntegrationTestSuite {
    * are trying to test, and generally Mill builds are expected to behave the
    * same in both modes (except for performance differences due to in-memory caching)
    */
-  protected def clientServerMode: Boolean
+  protected def daemonMode: Boolean
 
   /**
    * Path to the Mill executable to use to run integration tests with
@@ -48,7 +48,7 @@ trait IntegrationTestSuite {
       timeoutMillis = 10.minutes.toMillis
     ) {
       val tester = new IntegrationTester(
-        clientServerMode,
+        daemonMode,
         workspaceSourcePath,
         millExecutable,
         debugLog,

--- a/testkit/src/mill/testkit/IntegrationTestSuite.scala
+++ b/testkit/src/mill/testkit/IntegrationTestSuite.scala
@@ -14,7 +14,7 @@ trait IntegrationTestSuite {
 
   /**
    * If `true`, run Mill subprocesss normally as a client to a long-lived
-   * background server. If `false`, run the Mill subprocess with `--no-server`
+   * background daemon. If `false`, run the Mill subprocess with `--no-server`
    * so it exits after every command. Both are useful depending on what you
    * are trying to test, and generally Mill builds are expected to behave the
    * same in both modes (except for performance differences due to in-memory caching)

--- a/testkit/src/mill/testkit/IntegrationTester.scala
+++ b/testkit/src/mill/testkit/IntegrationTester.scala
@@ -13,7 +13,7 @@ import ujson.Value
  * [[modifyFile]] or any of the OS-Lib `os.*` APIs on the [[workspacePath]] to modify
  * project files in the course of the test.
  *
- * @param clientServerMode Whether to run Mill in client-server mode. If `false`, Mill
+ * @param daemonMode Whether to run Mill in client-server mode. If `false`, Mill
  *                         is run with `--no-server`
  * @param workspaceSourcePath The folder in which the `build.mill` and project files being
  *                            tested comes from. These are copied into a temporary folder
@@ -21,7 +21,7 @@ import ujson.Value
  * @param millExecutable What Mill executable to use.
  */
 class IntegrationTester(
-    val clientServerMode: Boolean,
+    val daemonMode: Boolean,
     val workspaceSourcePath: os.Path,
     val millExecutable: os.Path,
     override val debugLog: Boolean = false,
@@ -46,7 +46,7 @@ object IntegrationTester {
     def millExecutable: os.Path
     def workspaceSourcePath: os.Path
 
-    val clientServerMode: Boolean
+    val daemonMode: Boolean
 
     def debugLog = false
 
@@ -69,7 +69,7 @@ object IntegrationTester {
         propagateEnv: Boolean = true,
         timeoutGracePeriod: Long = 100
     ): IntegrationTester.EvalResult = {
-      val serverArgs = Option.when(!clientServerMode)("--no-server")
+      val serverArgs = Option.when(!daemonMode)("--no-daemon")
 
       val debugArgs = Option.when(debugLog)("--debug")
 

--- a/testkit/src/mill/testkit/IntegrationTesterBase.scala
+++ b/testkit/src/mill/testkit/IntegrationTesterBase.scala
@@ -5,7 +5,7 @@ import mill.util.Retry
 
 trait IntegrationTesterBase {
   def workspaceSourcePath: os.Path
-  def clientServerMode: Boolean
+  def daemonMode: Boolean
 
   def propagateJavaHome: Boolean
 
@@ -70,7 +70,7 @@ trait IntegrationTesterBase {
   def removeProcessIdFile(): Unit = {
     val outDir = os.Path(out, workspacePath)
     if (os.exists(outDir)) {
-      if (clientServerMode) {
+      if (daemonMode) {
         val serverPath = outDir / millDaemon
         os.remove(serverPath / processId)
       } else {

--- a/testkit/src/mill/testkit/IntegrationTesterBase.scala
+++ b/testkit/src/mill/testkit/IntegrationTesterBase.scala
@@ -1,6 +1,6 @@
 package mill.testkit
-import mill.constants.OutFiles.{millServer, millNoServer, out}
-import mill.constants.ServerFiles.processId
+import mill.constants.OutFiles.{millDaemon, millNoDaemon, out}
+import mill.constants.DaemonFiles.processId
 import mill.util.Retry
 
 trait IntegrationTesterBase {
@@ -71,10 +71,10 @@ trait IntegrationTesterBase {
     val outDir = os.Path(out, workspacePath)
     if (os.exists(outDir)) {
       if (clientServerMode) {
-        val serverPath = outDir / millServer
+        val serverPath = outDir / millDaemon
         os.remove(serverPath / processId)
       } else {
-        val serverPath0 = outDir / millNoServer
+        val serverPath0 = outDir / millNoDaemon
 
         for (serverPath <- os.list.stream(serverPath0)) os.remove(serverPath / processId)
 

--- a/testkit/src/mill/testkit/UtestExampleTestSuite.scala
+++ b/testkit/src/mill/testkit/UtestExampleTestSuite.scala
@@ -9,7 +9,7 @@ import scala.concurrent.duration.DurationInt
 
 object UtestExampleTestSuite extends TestSuite {
   val workspaceSourcePath: os.Path = os.Path(sys.env("MILL_TEST_RESOURCE_DIR"))
-  val clientServerMode: Boolean = sys.env("MILL_INTEGRATION_SERVER_MODE").toBoolean
+  val daemonMode: Boolean = sys.env("MILL_INTEGRATION_DAEMON_MODE").toBoolean
 
   val millExecutable: os.Path = os.Path(System.getenv("MILL_INTEGRATION_LAUNCHER"), os.pwd)
   val tests: Tests = Tests {
@@ -22,7 +22,7 @@ object UtestExampleTestSuite extends TestSuite {
           timeoutMillis = 15.minutes.toMillis
         ) {
           ExampleTester.run(
-            clientServerMode,
+            daemonMode,
             workspaceSourcePath,
             millExecutable
           )

--- a/testkit/src/mill/testkit/UtestIntegrationTestSuite.scala
+++ b/testkit/src/mill/testkit/UtestIntegrationTestSuite.scala
@@ -2,7 +2,7 @@ package mill.testkit
 
 abstract class UtestIntegrationTestSuite extends utest.TestSuite with IntegrationTestSuite {
   protected def workspaceSourcePath: os.Path = os.Path(sys.env("MILL_TEST_RESOURCE_DIR"))
-  protected def clientServerMode: Boolean = sys.env("MILL_INTEGRATION_SERVER_MODE").toBoolean
+  protected def daemonMode: Boolean = sys.env("MILL_INTEGRATION_DAEMON_MODE").toBoolean
 
   /** Whether the Mill JARs are published locally alongside this Mill launcher */
   protected def isPackagedLauncher: Boolean =

--- a/testkit/test/resources/example-test-example-project/build.mill
+++ b/testkit/test/resources/example-test-example-project/build.mill
@@ -19,8 +19,8 @@ def testTask = Task { os.read(testSource().path).toUpperCase() }
 > cat out/testTask.json
 ..."HELLO WORLD SOURCE FILE!!!"...
 
-> ls out/mill-server # not --no-server, make sure `mill-server` is generated
+> ls out/mill-daemon # not --no-server, make sure `mill-daemon` is generated
 
-> ls out/mill-no-server # --no-server, make sure `mill-no-server` is generated
+> ls out/mill-no-deamon # --no-server, make sure `mill-no-deamon` is generated
 
 */

--- a/testkit/test/resources/example-test-example-project/build.mill
+++ b/testkit/test/resources/example-test-example-project/build.mill
@@ -19,8 +19,8 @@ def testTask = Task { os.read(testSource().path).toUpperCase() }
 > cat out/testTask.json
 ..."HELLO WORLD SOURCE FILE!!!"...
 
-> ls out/mill-daemon # not --no-server, make sure `mill-daemon` is generated
+> ls out/mill-daemon # not --no-daemon, make sure `mill-daemon` is generated
 
-> ls out/mill-no-deamon # --no-server, make sure `mill-no-deamon` is generated
+> ls out/mill-no-deamon # --no-daemon, make sure `mill-no-deamon` is generated
 
 */

--- a/testkit/test/src/mill/testkit/ExampleTesterTests.scala
+++ b/testkit/test/src/mill/testkit/ExampleTesterTests.scala
@@ -13,7 +13,7 @@ object ExampleTesterTests extends TestSuite {
         millExecutable = os.Path(sys.env("MILL_EXECUTABLE_PATH"))
       )
 
-      assert(os.exists(workspacePath / "out/mill-no-server"))
+      assert(os.exists(workspacePath / "out/mill-no-deamon"))
 
       assert(TestkitTestUtils.getProcessIdFiles(workspacePath).isEmpty)
     }
@@ -26,7 +26,7 @@ object ExampleTesterTests extends TestSuite {
         millExecutable = os.Path(sys.env("MILL_EXECUTABLE_PATH"))
       )
 
-      assert(os.exists(workspacePath / "out/mill-server"))
+      assert(os.exists(workspacePath / "out/mill-daemon"))
 
       assert(TestkitTestUtils.getProcessIdFiles(workspacePath).isEmpty)
     }

--- a/testkit/test/src/mill/testkit/ExampleTesterTests.scala
+++ b/testkit/test/src/mill/testkit/ExampleTesterTests.scala
@@ -18,7 +18,7 @@ object ExampleTesterTests extends TestSuite {
       assert(TestkitTestUtils.getProcessIdFiles(workspacePath).isEmpty)
     }
 
-    test("server") {
+    test("daemon") {
       val workspacePath = ExampleTester.run(
         clientServerMode = true,
         workspaceSourcePath =

--- a/testkit/test/src/mill/testkit/ExampleTesterTests.scala
+++ b/testkit/test/src/mill/testkit/ExampleTesterTests.scala
@@ -5,9 +5,9 @@ import utest._
 object ExampleTesterTests extends TestSuite {
 
   def tests: Tests = Tests {
-    test("fork") {
+    test("nodaemon") {
       val workspacePath = ExampleTester.run(
-        clientServerMode = false,
+        daemonMode = false,
         workspaceSourcePath =
           os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "example-test-example-project",
         millExecutable = os.Path(sys.env("MILL_EXECUTABLE_PATH"))
@@ -20,7 +20,7 @@ object ExampleTesterTests extends TestSuite {
 
     test("daemon") {
       val workspacePath = ExampleTester.run(
-        clientServerMode = true,
+        daemonMode = true,
         workspaceSourcePath =
           os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "example-test-example-project",
         millExecutable = os.Path(sys.env("MILL_EXECUTABLE_PATH"))

--- a/testkit/test/src/mill/testkit/IntegrationTesterTests.scala
+++ b/testkit/test/src/mill/testkit/IntegrationTesterTests.scala
@@ -26,7 +26,7 @@ trait IntegrationTesterTests extends TestSuite with IntegrationTestSuite {
         ) // no need to re-compile `build.mill`
         assert(tester.out("testTask").value[String] == "HELLO WORLD SOURCE FILE!!!")
 
-        val suffix = if (clientServerMode) "mill-daemon" else "mill-no-deamon"
+        val suffix = if (daemonMode) "mill-daemon" else "mill-no-deamon"
         assert(os.exists(tester.workspacePath / "out" / suffix))
 
         // Make sure processId file(s) is present while the test is running
@@ -44,8 +44,8 @@ trait IntegrationTesterTests extends TestSuite with IntegrationTestSuite {
   }
 }
 object IntegrationTesterTestsServer extends IntegrationTesterTests {
-  def clientServerMode = true
+  def daemonMode = true
 }
 object IntegrationTesterTestsFork extends IntegrationTesterTests {
-  def clientServerMode = false
+  def daemonMode = false
 }

--- a/testkit/test/src/mill/testkit/IntegrationTesterTests.scala
+++ b/testkit/test/src/mill/testkit/IntegrationTesterTests.scala
@@ -26,7 +26,7 @@ trait IntegrationTesterTests extends TestSuite with IntegrationTestSuite {
         ) // no need to re-compile `build.mill`
         assert(tester.out("testTask").value[String] == "HELLO WORLD SOURCE FILE!!!")
 
-        val suffix = if (clientServerMode) "mill-server" else "mill-no-server"
+        val suffix = if (clientServerMode) "mill-daemon" else "mill-no-deamon"
         assert(os.exists(tester.workspacePath / "out" / suffix))
 
         // Make sure processId file(s) is present while the test is running

--- a/testkit/test/src/mill/testkit/TestkitTestUtils.scala
+++ b/testkit/test/src/mill/testkit/TestkitTestUtils.scala
@@ -1,8 +1,9 @@
 package mill.testkit
-import mill.constants.ServerFiles
+
+import mill.constants.DaemonFiles
 object TestkitTestUtils {
   def getProcessIdFiles(workspacePath: os.Path) = {
     os.walk(workspacePath / "out")
-      .filter(_.last == ServerFiles.processId)
+      .filter(_.last == DaemonFiles.processId)
   }
 }

--- a/website/blog/modules/ROOT/pages/7-graal-native-executables.adoc
+++ b/website/blog/modules/ROOT/pages/7-graal-native-executables.adoc
@@ -424,7 +424,7 @@ _Native Image_
 ----
 $ ps aux | grep native-executable
 lihaoyi          43880  46.1  0.1 408681792  30176 s000  S+    3:40PM   0:05.84 ./out/foo/nativeImage.dest/native-executable --text hello-world
-lihaoyi          86276   0.0  2.1 420349904 720416 s000  S     3:14PM   1:00.88 /Library/Java/JavaVirtualMachines/amazon-corretto-17.jdk/Contents/Home/bin/java -cp /Users/lihaoyi/.cache/mill/download/0.12.5-68-e4bf78 mill.runner.MillDaemonMain /Users/lihaoyi/Github/mill/blog/modules/ROOT/attachments/7-graal-native-executables/out/mill-server/aa508f0984fd2811f6c6d8fae1362f1774e4f5f7-1
+lihaoyi          86276   0.0  2.1 420349904 720416 s000  S     3:14PM   1:00.88 /Library/Java/JavaVirtualMachines/amazon-corretto-17.jdk/Contents/Home/bin/java -cp /Users/lihaoyi/.cache/mill/download/0.12.5-68-e4bf78 mill.runner.MillDaemonMain /Users/lihaoyi/Github/mill/blog/modules/ROOT/attachments/7-graal-native-executables/out/mill-daemon/aa508f0984fd2811f6c6d8fae1362f1774e4f5f7-1
 lihaoyi          48496   0.0  0.0 408626896   1376 s002  S+    3:40PM   0:00.00 grep native-executable
 
 $ top | grep 43880

--- a/website/docs/modules/ROOT/pages/cli/flags.adoc
+++ b/website/docs/modules/ROOT/pages/cli/flags.adoc
@@ -76,7 +76,7 @@ options:
   -k --keep-going      Continue build, even after build failures.
   --meta-level <int>   Select a meta-level to run the given tasks. Level 0 is the main project in
                        `build.mill`, level 1 the first meta-build in `mill-build/build.mill`, etc.
-  --no-server          Run without a background server. Must be the first argument.
+  --no-server          Run without a background daemon. Must be the first argument.
   --offline            Try to work offline. This tells modules that support it to work offline and
                        avoid any access to the internet. This is on a best effort basis. There are
                        currently no guarantees that modules don't attempt to fetch remote sources.
@@ -99,7 +99,7 @@ This section covers some of the flags that are worth discussing in more detail
 This flag is necessary to run any interactive terminal programs using Mill: things like
 `ScalaModule#console`, `ScalaModule#repl`, and so on.
 
-By default, Mill runs tasks in a long-lived background server. While this is good for
+By default, Mill runs tasks in a long-lived background daemon. While this is good for
 performance (as it avoids paying the server startup time each command), it is incompatible
 with tasks like `.repl` which require a direct `stdin`/`stdout` forwarding connection to
 the user's terminal. `--interactive`/`-i` instead runs tasks in a short-lived background

--- a/website/docs/modules/ROOT/pages/depth/process-architecture.adoc
+++ b/website/docs/modules/ROOT/pages/depth/process-architecture.adoc
@@ -34,7 +34,7 @@ digraph G {
 
 
     subgraph cluster_mill_server_folder {
-      label = "mill-server/";
+      label = "mill-daemon/";
       "socketPort" [penwidth=0]
       "exitCode" [penwidth=0]
       "runArgs" [penwidth=0]
@@ -155,7 +155,7 @@ xref:depth/evaluation-model.adoc[].
 
 The `out/` directory is where most of Mill's state lives on disk, both build-task state
 such as the `foo/compile.json` metadata cache for `foo.compile`, or the `foo/compile.dest`
-which stores any generated files or binaries. It also contains `mill-server/` folder which
+which stores any generated files or binaries. It also contains `mill-daemon/` folder which
 is used to pass data back and forth between the client and server: the `runArgs`, `exitCode`,
 etc.
 

--- a/website/docs/modules/ROOT/pages/depth/process-architecture.adoc
+++ b/website/docs/modules/ROOT/pages/depth/process-architecture.adoc
@@ -13,21 +13,21 @@ digraph G {
   node [shape=box width=0 height=0 style=filled fillcolor=white]
   bgcolor=transparent
 
-  "client-stdin" [penwidth=0]
-  "client-stdout" [penwidth=0]
-  "client-stderr" [penwidth=0]
-  "client-exit" [penwidth=0]
-  "client-args" [penwidth=0]
+  "launcher-stdin" [penwidth=0]
+  "launcher-stdout" [penwidth=0]
+  "launcher-stderr" [penwidth=0]
+  "launcher-exit" [penwidth=0]
+  "launcher-args" [penwidth=0]
   subgraph cluster_client {
-      label = "mill client";
+      label = "mill launcher";
       "Socket"
       "MillLauncherMain"
   }
-  "client-stdin" -> "Socket"
-  "client-stderr" -> "Socket" [dir=back]
-  "client-stdout" -> "Socket" [dir=back]
-  "client-args" -> "MillLauncherMain"
-  "client-exit" -> "MillLauncherMain" [dir=back]
+  "launcher-stdin" -> "Socket"
+  "launcher-stderr" -> "Socket" [dir=back]
+  "launcher-stdout" -> "Socket" [dir=back]
+  "launcher-args" -> "MillLauncherMain"
+  "launcher-exit" -> "MillLauncherMain" [dir=back]
   "MillLauncherMain" -> "runArgs"
   subgraph cluster_out {
     label = "out/";
@@ -51,14 +51,14 @@ digraph G {
 
 
   subgraph cluster_server {
-    label = "mill server";
+    label = "mill daemon";
     "PromptLogger"
     "MillDaemonMain"
     "Evaluator"
     "ServerSocket"
 
-    "server-stdout" [penwidth=0]
-    "server-stderr" [penwidth=0]
+    "daemon-stdout" [penwidth=0]
+    "daemon-stderr" [penwidth=0]
     subgraph cluster_classloder {
       label = "URLClassLoader";
       subgraph cluster_build {
@@ -86,8 +86,8 @@ digraph G {
   "Socket" -> "socketPort"  [dir=both]
   "socketPort" -> "ServerSocket"  [dir=both]
 
-  "PromptLogger" -> "server-stderr" [dir=back]
-  "PromptLogger" -> "server-stdout" [dir=back]
+  "PromptLogger" -> "daemon-stderr" [dir=back]
+  "PromptLogger" -> "daemon-stdout" [dir=back]
   "compile.dest" -> "foo.compile"  [dir=both]
   "compile.json" -> "foo.compile"  [dir=both]
 
@@ -99,36 +99,36 @@ digraph G {
 
 == The Mill Client
 
-The Mill client is a small Java application that is responsible for launching
-and delegating work to the Mill server, a long-lived process. Each `./mill`
-command spawns a new Mill client, but generally re-uses the same Mill server where
-possible in order to reduce startup overhead and to allow the Mill server
+The Mill launcher is a small Java application that is responsible for launching
+and delegating work to the Mill daemon, a long-lived process. Each `./mill`
+command spawns a new Mill launcher, but generally re-uses the same Mill daemon where
+possible in order to reduce startup overhead and to allow the Mill daemon
 process to warm up and provide good performance
 
-* The Mill client takes all the inputs of a typical command-line application -
+* The Mill launcher takes all the inputs of a typical command-line application -
 stdin and command-line arguments - and proxies them to the long-lived Mill
-server process.
+daemon process.
 
-* It then takes the outputs from the Mill server - stdout, stderr,
+* It then takes the outputs from the Mill daemon - stdout, stderr,
 and finally the exitcode - and proxies those back to the calling process or terminal.
 
-In this way, the Mill client acts and behaves for most all intents and purposes
+In this way, the Mill launcher acts and behaves for most all intents and purposes
 as a normal CLI application, except it is really a thin wrapper around logic that
-is actually running in the long-lived Mill server.
+is actually running in the long-lived Mill daemon.
 
-The Mill server sometimes is shut down and needs to be restarted, e.g. if Mill
+The Mill daemon sometimes is shut down and needs to be restarted, e.g. if Mill
 version changed, or the user used `Ctrl-C` to interrupt the ongoing computation.
-In such a scenario, the Mill client will automatically restart the server the next
+In such a scenario, the Mill launcher will automatically restart the daemon the next
 time it is run, so apart from a slight performance penalty from starting a "cold"
-Mill server such shutdowns and restarts should be mostly invisibl to the user.
+Mill daemon such shutdowns and restarts should be mostly invisibl to the user.
 
-== The Mill Server
+== The Mill Daemon
 
-The Mill server is a long-lived process that the Mill client spawns.
-Only one Mill server should be running in a codebase at a time, and each server
+The Mill daemon is a long-lived process that the Mill launcher spawns.
+Only one Mill daemon should be running in a codebase at a time, and each daemon
 takes a filelock at startup time to enforce this mutual exclusion.
 
-The Mill server compiles your `build.mill` and `package.mill`, spawns a
+The Mill daemon compiles your `build.mill` and `package.mill`, spawns a
 `URLClassLoader` containing the compiled classfiles, and uses that to instantiate
 the variousxref:fundamentals/modules.adoc[] and xref:fundamentals/tasks.adoc[]
 dynamically in-memory. These are then used by the `Evaluator`, which resolves,
@@ -138,14 +138,14 @@ During execution, both standard output
 and standard error are captured during evaluation and forwarded to the `PromptLogger`.
 `PromptLogger` annotates the output stream with the line-prefixes, prompt, and ANSI
 terminal commands necessary to generate the dynamic prompt, and then forwards both
-streams multi-plexed over a single socket stream back to the Mill client. The client
+streams multi-plexed over a single socket stream back to the Mill launcher. The launcher
 then de-multiplexes the combined stream to split it back into output and error, which
-are then both forwarded to the process or terminal that invoked the Mill client.
+are then both forwarded to the process or terminal that invoked the Mill launcher.
 
-Lastly, when the Mill server completes its tasks, it writes the `exitCode` to a file
-that is then propagated back to the Mill client. The Mill client terminates with this
-exit code, but the Mill server remains alive and ready to serve to the next Mill
-client that connects to it
+Lastly, when the Mill daemon completes its tasks, it writes the `exitCode` to a file
+that is then propagated back to the Mill launcher. The Mill launcher terminates with this
+exit code, but the Mill daemon remains alive and ready to serve to the next Mill
+launcher that connects to it
 
 For a more detailed discussion of what exactly goes into "execution", see
 xref:depth/evaluation-model.adoc[].
@@ -156,7 +156,7 @@ xref:depth/evaluation-model.adoc[].
 The `out/` directory is where most of Mill's state lives on disk, both build-task state
 such as the `foo/compile.json` metadata cache for `foo.compile`, or the `foo/compile.dest`
 which stores any generated files or binaries. It also contains `mill-daemon/` folder which
-is used to pass data back and forth between the client and server: the `runArgs`, `exitCode`,
+is used to pass data back and forth between the launcher and daemon: the `runArgs`, `exitCode`,
 etc.
 
 Each task during evaluation reads and writes from its own designated paths in the `out/`


### PR DESCRIPTION
We always had two clients and two servers: previously `mill.main.client`/`mill.runner.client` and `mill.main.server`/`mill.runner.server`, and when you saw `client` or `server` it was never clear which one you were referring to. Furthermore, `client`/`server` was always very confusing since it brings to mind HTTP clients/server or network client/servers which Mill is not.

In `main` with #5062 we started using `client`/`server` to refer to the underlying protocol, while `launcher`/`daemon` referred to the high-level JVM processes. These are much better names for the two concepts, and avoid conflicting with the `client`/`server` terms used for the underlying protocol components

This PR standardizes our terminology to use `launcher`/`daemon` throughout the codebase, with the `.fork`/`.server` names in our integration tests renamed to `.nodaemon`/`.daemon`