### PR TITLE
Fix classloading failure when rebootstrapping

### DIFF
--- a/main/api/src/mill/api/SystemStreams.scala
+++ b/main/api/src/mill/api/SystemStreams.scala
@@ -147,8 +147,14 @@ object SystemStreams {
   private[mill] object ThreadLocalStreams {
     val current = new DynamicVariable(original)
 
-    object Out extends PrintStream(new ProxyOutputStream { def delegate() = current.value.out })
-    object Err extends PrintStream(new ProxyOutputStream { def delegate() = current.value.err })
+    object Out extends PrintStream(new ProxyOutputStream {
+      val current = ThreadLocalStreams.current //
+      def delegate() = current.value.out
+    })
+    object Err extends PrintStream(new ProxyOutputStream {
+      val current = ThreadLocalStreams.current
+      def delegate() = current.value.err
+    })
     object In extends ProxyInputStream { def delegate() = current.value.in }
 
     abstract class ProxyOutputStream extends OutputStream {


### PR DESCRIPTION
This seems to fix the classloading problems we were having in https://github.com/com-lihaoyi/mill/pull/5132; reproduced the problem by doing
```
rm -rf out 
./mill dist.installLocal
rm -rf out 
./mill-assembly.jar '{main,scalalib,testrunner,bsp,testkit}.__.test'
```

And repeating that workflow on top of this PR seems to fix it. Must be some funky interaction between the class classloader  and the context classloader that causes the lazy instantiation of `mill.api.SystemStreams.ThreadLocalStreams` to fail during classloading, but forcing the classloading to happen ahead of time sand just keeping the long-lived reference seems to work

```
bsp.worker.docJar java.lang.reflect.InvocationTargetException
    java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
    java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    java.base/java.lang.reflect.Method.invoke(Method.java:569)
    mill.scalalib.worker.ZincWorkerImpl.$anonfun$docJar$2(ZincWorkerImpl.scala:262)
    scala.runtime.java8.JFunction0$mcZ$sp.apply(JFunction0$mcZ$sp.scala:17)
    mill.api.Retry.$anonfun$apply$1(Retry.scala:32)
    mill.api.Retry.$anonfun$apply$1$adapted(Retry.scala:32)
    mill.api.Retry.rec$1(Retry.scala:38)
    mill.api.Retry.rec$1(Retry.scala:50)
    mill.api.Retry.rec$1(Retry.scala:50)
    mill.api.Retry.indexed(Retry.scala:54)
    mill.api.Retry.apply(Retry.scala:32)
    mill.scalalib.worker.ZincWorkerImpl.$anonfun$docJar$1(ZincWorkerImpl.scala:232)
    mill.scalalib.worker.ZincWorkerImpl.$anonfun$docJar$1$adapted(ZincWorkerImpl.scala:228)
    mill.scalalib.worker.ZincWorkerImpl.$anonfun$withCompilers$2(ZincWorkerImpl.scala:479)
    mill.api.CachedFactory.withValue(CachedFactory.scala:39)
    mill.scalalib.worker.ZincWorkerImpl.withCompilers(ZincWorkerImpl.scala:478)
    mill.scalalib.worker.ZincWorkerImpl.docJar(ZincWorkerImpl.scala:228)
    mill.scalalib.ScalaModule.packageWithZinc$1(ScalaModule.scala:317)
    mill.scalalib.ScalaModule.$anonfun$docJar$2(ScalaModule.scala:410)
    mill.define.Task$TraverseCtx.evaluate(Task.scala:245)
java.lang.NoClassDefFoundError: mill/api/SystemStreams$ThreadLocalStreams$
    mill.api.SystemStreams$ThreadLocalStreams$Err$$anon$2.delegate(SystemStreams.scala:151)
    mill.api.SystemStreams$ThreadLocalStreams$Err$$anon$2.delegate(SystemStreams.scala:151)
    mill.api.SystemStreams$ThreadLocalStreams$ProxyOutputStream.write(SystemStreams.scala:156)
    java.base/java.io.PrintStream.write(PrintStream.java:568)
    java.base/sun.nio.cs.StreamEncoder.writeBytes(StreamEncoder.java:234)
    java.base/sun.nio.cs.StreamEncoder.implFlushBuffer(StreamEncoder.java:313)
    java.base/sun.nio.cs.StreamEncoder.implFlush(StreamEncoder.java:318)
    java.base/sun.nio.cs.StreamEncoder.flush(StreamEncoder.java:160)
    java.base/java.io.OutputStreamWriter.flush(OutputStreamWriter.java:248)
    java.base/java.io.BufferedWriter.flush(BufferedWriter.java:257)
    java.base/java.io.PrintWriter.newLine(PrintWriter.java:567)
    java.base/java.io.PrintWriter.println(PrintWriter.java:710)
    java.base/java.io.PrintWriter.println(PrintWriter.java:821)
    scala.tools.nsc.reporters.ConsoleReporter.finish(ConsoleReporter.scala:30)
    scala.tools.nsc.ScalaDocReporter.finish(ScalaDoc.scala:87)
    scala.tools.nsc.ScalaDoc.process(ScalaDoc.scala:57)
    java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
    java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    java.base/java.lang.reflect.Method.invoke(Method.java:569)
    mill.scalalib.worker.ZincWorkerImpl.$anonfun$docJar$2(ZincWorkerImpl.scala:262)
    scala.runtime.java8.JFunction0$mcZ$sp.apply(JFunction0$mcZ$sp.scala:17)
    mill.api.Retry.$anonfun$apply$1(Retry.scala:32)
    mill.api.Retry.$anonfun$apply$1$adapted(Retry.scala:32)
    mill.api.Retry.rec$1(Retry.scala:38)
    mill.api.Retry.rec$1(Retry.scala:50)
    mill.api.Retry.rec$1(Retry.scala:50)
    mill.api.Retry.indexed(Retry.scala:54)
    mill.api.Retry.apply(Retry.scala:32)
    mill.scalalib.worker.ZincWorkerImpl.$anonfun$docJar$1(ZincWorkerImpl.scala:232)
    mill.scalalib.worker.ZincWorkerImpl.$anonfun$docJar$1$adapted(ZincWorkerImpl.scala:228)
    mill.scalalib.worker.ZincWorkerImpl.$anonfun$withCompilers$2(ZincWorkerImpl.scala:479)
    mill.api.CachedFactory.withValue(CachedFactory.scala:39)
    mill.scalalib.worker.ZincWorkerImpl.withCompilers(ZincWorkerImpl.scala:478)
    mill.scalalib.worker.ZincWorkerImpl.docJar(ZincWorkerImpl.scala:228)
    mill.scalalib.ScalaModule.packageWithZinc$1(ScalaModule.scala:317)
    mill.scalalib.ScalaModule.$anonfun$docJar$2(ScalaModule.scala:410)
    mill.define.Task$TraverseCtx.evaluate(Task.scala:245)
java.lang.ClassNotFoundException: mill.api.SystemStreams$ThreadLocalStreams$
    mill.api.SystemStreams$ThreadLocalStreams$Err$$anon$2.delegate(SystemStreams.scala:151)
    mill.api.SystemStreams$ThreadLocalStreams$Err$$anon$2.delegate(SystemStreams.scala:151)
    mill.api.SystemStreams$ThreadLocalStreams$ProxyOutputStream.write(SystemStreams.scala:156)
    java.base/java.io.PrintStream.write(PrintStream.java:568)
    java.base/sun.nio.cs.StreamEncoder.writeBytes(StreamEncoder.java:234)
    java.base/sun.nio.cs.StreamEncoder.implFlushBuffer(StreamEncoder.java:313)
    java.base/sun.nio.cs.StreamEncoder.implFlush(StreamEncoder.java:318)
    java.base/sun.nio.cs.StreamEncoder.flush(StreamEncoder.java:160)
    java.base/java.io.OutputStreamWriter.flush(OutputStreamWriter.java:248)
    java.base/java.io.BufferedWriter.flush(BufferedWriter.java:257)
    java.base/java.io.PrintWriter.newLine(PrintWriter.java:567)
    java.base/java.io.PrintWriter.println(PrintWriter.java:710)
    java.base/java.io.PrintWriter.println(PrintWriter.java:821)
    scala.tools.nsc.reporters.ConsoleReporter.finish(ConsoleReporter.scala:30)
    scala.tools.nsc.ScalaDocReporter.finish(ScalaDoc.scala:87)
    scala.tools.nsc.ScalaDoc.process(ScalaDoc.scala:57)
    java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
    java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    java.base/java.lang.reflect.Method.invoke(Method.java:569)
    mill.scalalib.worker.ZincWorkerImpl.$anonfun$docJar$2(ZincWorkerImpl.scala:262)
    scala.runtime.java8.JFunction0$mcZ$sp.apply(JFunction0$mcZ$sp.scala:17)
    mill.api.Retry.$anonfun$apply$1(Retry.scala:32)
    mill.api.Retry.$anonfun$apply$1$adapted(Retry.scala:32)
    mill.api.Retry.rec$1(Retry.scala:38)
    mill.api.Retry.rec$1(Retry.scala:50)
    mill.api.Retry.rec$1(Retry.scala:50)
    mill.api.Retry.indexed(Retry.scala:54)
    mill.api.Retry.apply(Retry.scala:32)
    mill.scalalib.worker.ZincWorkerImpl.$anonfun$docJar$1(ZincWorkerImpl.scala:232)
    mill.scalalib.worker.ZincWorkerImpl.$anonfun$docJar$1$adapted(ZincWorkerImpl.scala:228)
    mill.scalalib.worker.ZincWorkerImpl.$anonfun$withCompilers$2(ZincWorkerImpl.scala:479)
    mill.api.CachedFactory.withValue(CachedFactory.scala:39)
    mill.scalalib.worker.ZincWorkerImpl.withCompilers(ZincWorkerImpl.scala:478)
    mill.scalalib.worker.ZincWorkerImpl.docJar(ZincWorkerImpl.scala:228)
    mill.scalalib.ScalaModule.packageWithZinc$1(ScalaModule.scala:317)
    mill.scalalib.ScalaModule.$anonfun$docJar$2(ScalaModule.scala:410)
    mill.define.Task$TraverseCtx.evaluate(Task.scala:245)
```