### PR TITLE
Bump uPickle to 4.2.1, test namedtuple integration

### DIFF
--- a/core/define/package.mill
+++ b/core/define/package.mill
@@ -24,6 +24,7 @@ object `package` extends MillStableScalaModule {
     Deps.osLib,
     Deps.mainargs,
     Deps.upickle,
+    Deps.upickleNamedTuples,
     Deps.pprint,
     Deps.fansi,
     Deps.mainargs,

--- a/integration/feature/scala-3-syntax/resources/build.mill
+++ b/integration/feature/scala-3-syntax/resources/build.mill
@@ -40,8 +40,8 @@ object `package` extends mill.Module:
     end today
   end DayModule
 
-  def namedTupleTask = Task{
-    (hello="world", i=Seq("am", "cow"))
+  def namedTupleTask = Task {
+    (hello = "world", i = Seq("am", "cow"))
   }
 
 end `package`

--- a/integration/feature/scala-3-syntax/resources/build.mill
+++ b/integration/feature/scala-3-syntax/resources/build.mill
@@ -4,6 +4,7 @@ import mill.{Task, Command, Cross}, Task.Anon
 
 import build.Box
 import build.{given Box[Int]}
+import upickle.implicits.namedTuples.default.given
 
 given Cross.ToSegments[DayValue](d => List(d.toString))
 
@@ -38,5 +39,9 @@ object `package` extends mill.Module:
       println(s"Today is $myDay")
     end today
   end DayModule
+
+  def namedTupleTask = Task{
+    (hello="world", i=Seq("am", "cow"))
+  }
 
 end `package`

--- a/integration/feature/scala-3-syntax/src/Scala3SyntaxTests.scala
+++ b/integration/feature/scala-3-syntax/src/Scala3SyntaxTests.scala
@@ -22,14 +22,8 @@ object Scala3SyntaxTests extends UtestIntegrationTestSuite {
       val res3 = eval(("show", "namedTupleTask"))
       assert(res3.isSuccess)
       assert(
-        res3.out ==
-        """{
-          |  "hello": "world",
-          |  "i": [
-          |    "am",
-          |    "cow"
-          |  ]
-          |}""".stripMargin
+        ujson.read(res3.out) ==
+          ujson.read("""{"hello": "world", "i": ["am", "cow"]}""")
       )
     }
   }

--- a/integration/feature/scala-3-syntax/src/Scala3SyntaxTests.scala
+++ b/integration/feature/scala-3-syntax/src/Scala3SyntaxTests.scala
@@ -19,6 +19,18 @@ object Scala3SyntaxTests extends UtestIntegrationTestSuite {
       val res2 = eval("someTopLevelCommand")
       assert(res2.isSuccess)
       assert(res2.out == "Hello, world! Box[Int] 42")
+      val res3 = eval(("show", "namedTupleTask"))
+      assert(res3.isSuccess)
+      assert(
+        res3.out ==
+        """{
+          |  "hello": "world",
+          |  "i": [
+          |    "am",
+          |    "cow"
+          |  ]
+          |}""".stripMargin
+      )
     }
   }
 }

--- a/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.iml
+++ b/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.iml
@@ -106,11 +106,12 @@
         <orderEntry type="library" name="specification-level_2.13-1.1.3.jar" level="project"/>
         <orderEntry type="library" name="test-interface-1.0.jar" level="project"/>
         <orderEntry type="library" name="tika-core-3.1.0.jar" level="project"/>
-        <orderEntry type="library" name="ujson_3-4.1.0.jar" level="project"/>
-        <orderEntry type="library" name="upack_3-4.1.0.jar" level="project"/>
-        <orderEntry type="library" name="upickle-core_3-4.1.0.jar" level="project"/>
-        <orderEntry type="library" name="upickle-implicits_3-4.1.0.jar" level="project"/>
-        <orderEntry type="library" name="upickle_3-4.1.0.jar" level="project"/>
+        <orderEntry type="library" name="ujson_3-4.2.1.jar" level="project"/>
+        <orderEntry type="library" name="upack_3-4.2.1.jar" level="project"/>
+        <orderEntry type="library" name="upickle-core_3-4.2.1.jar" level="project"/>
+        <orderEntry type="library" name="upickle-implicits-named-tuples_3-4.2.1.jar" level="project"/>
+        <orderEntry type="library" name="upickle-implicits_3-4.2.1.jar" level="project"/>
+        <orderEntry type="library" name="upickle_3-4.2.1.jar" level="project"/>
         <orderEntry type="library" name="versions_2.13-0.5.1.jar" level="project"/>
         <orderEntry type="library" name="windows-ansi-0.0.6.jar" level="project"/>
         <orderEntry type="library" name="windows-jni-utils-0.3.3.jar" level="project"/>

--- a/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.mill-build.iml
+++ b/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.mill-build.iml
@@ -108,11 +108,12 @@
         <orderEntry type="library" name="specification-level_2.13-1.1.3.jar" level="project"/>
         <orderEntry type="library" name="test-interface-1.0.jar" level="project"/>
         <orderEntry type="library" name="tika-core-3.1.0.jar" level="project"/>
-        <orderEntry type="library" name="ujson_3-4.1.0.jar" level="project"/>
-        <orderEntry type="library" name="upack_3-4.1.0.jar" level="project"/>
-        <orderEntry type="library" name="upickle-core_3-4.1.0.jar" level="project"/>
-        <orderEntry type="library" name="upickle-implicits_3-4.1.0.jar" level="project"/>
-        <orderEntry type="library" name="upickle_3-4.1.0.jar" level="project"/>
+        <orderEntry type="library" name="ujson_3-4.2.1.jar" level="project"/>
+        <orderEntry type="library" name="upack_3-4.2.1.jar" level="project"/>
+        <orderEntry type="library" name="upickle-core_3-4.2.1.jar" level="project"/>
+        <orderEntry type="library" name="upickle-implicits-named-tuples_3-4.2.1.jar" level="project"/>
+        <orderEntry type="library" name="upickle-implicits_3-4.2.1.jar" level="project"/>
+        <orderEntry type="library" name="upickle_3-4.2.1.jar" level="project"/>
         <orderEntry type="library" name="versions_2.13-0.5.1.jar" level="project"/>
         <orderEntry type="library" name="windows-ansi-0.0.6.jar" level="project"/>
         <orderEntry type="library" name="windows-jni-utils-0.3.3.jar" level="project"/>

--- a/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/mill-build.iml
+++ b/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/mill-build.iml
@@ -102,11 +102,12 @@
         <orderEntry type="library" name="specification-level_2.13-1.1.3.jar" level="project"/>
         <orderEntry type="library" name="test-interface-1.0.jar" level="project"/>
         <orderEntry type="library" name="tika-core-3.1.0.jar" level="project"/>
-        <orderEntry type="library" name="ujson_3-4.1.0.jar" level="project"/>
-        <orderEntry type="library" name="upack_3-4.1.0.jar" level="project"/>
-        <orderEntry type="library" name="upickle-core_3-4.1.0.jar" level="project"/>
-        <orderEntry type="library" name="upickle-implicits_3-4.1.0.jar" level="project"/>
-        <orderEntry type="library" name="upickle_3-4.1.0.jar" level="project"/>
+        <orderEntry type="library" name="ujson_3-4.2.1.jar" level="project"/>
+        <orderEntry type="library" name="upack_3-4.2.1.jar" level="project"/>
+        <orderEntry type="library" name="upickle-core_3-4.2.1.jar" level="project"/>
+        <orderEntry type="library" name="upickle-implicits-named-tuples_3-4.2.1.jar" level="project"/>
+        <orderEntry type="library" name="upickle-implicits_3-4.2.1.jar" level="project"/>
+        <orderEntry type="library" name="upickle_3-4.2.1.jar" level="project"/>
         <orderEntry type="library" name="versions_2.13-0.5.1.jar" level="project"/>
         <orderEntry type="library" name="windows-ansi-0.0.6.jar" level="project"/>
         <orderEntry type="library" name="windows-jni-utils-0.3.3.jar" level="project"/>

--- a/mill-build/src/millbuild/Deps.scala
+++ b/mill-build/src/millbuild/Deps.scala
@@ -151,7 +151,8 @@ object Deps {
   val semanticDbJava = mvn"com.sourcegraph:semanticdb-java:0.10.3"
   val sourcecode = mvn"com.lihaoyi::sourcecode:0.4.3-M5"
   val springBootTools = mvn"org.springframework.boot:spring-boot-loader-tools:3.4.5"
-  val upickle = mvn"com.lihaoyi::upickle:4.1.0"
+  val upickle = mvn"com.lihaoyi::upickle:4.2.1"
+  val upickleNamedTuples = mvn"com.lihaoyi::upickle-implicits-named-tuples:4.2.1"
   // Using "native-terminal-no-ffm" rather than just "native-terminal", as the GraalVM releases currently
   // lacks support for FFM on Mac ARM. That should be fixed soon, see oracle/graal#8113.
   val nativeTerminal = mvn"io.github.alexarchambault.native-terminal:native-terminal-no-ffm:0.0.9.1"


### PR DESCRIPTION
Pulls in @bishabosha's work in https://github.com/com-lihaoyi/upickle/pull/662, which gives us an opt-in implicit for Scala >=3.7.0 that lets us serialize named tuples as JSON dictionaries

CC @lefou 