### PR TITLE
Consolidate build-global APIs in `mill.define.BuildCtx`

### DIFF
--- a/ci/mill-bootstrap.patch
+++ b/ci/mill-bootstrap.patch
@@ -1,0 +1,35 @@
+diff --git a/build.mill b/build.mill
+index 4465e163a55..6b8da38aae7 100644
+--- a/build.mill
++++ b/build.mill
+@@ -124,7 +124,7 @@ val bridgeScalaVersions = Seq(
+ // on the fly anyway. For publishing, we publish everything or a specific version
+ // if given.
+ val compilerBridgeScalaVersions =
+-  interp.watchValue(sys.env.get("MILL_COMPILER_BRIDGE_VERSIONS")) match {
++  mill.define.BuildCtx.watchValue(sys.env.get("MILL_COMPILER_BRIDGE_VERSIONS")) match {
+     case None | Some("") | Some("none") => Seq.empty[String]
+     case Some("all") => (essentialBridgeScalaVersions ++ bridgeScalaVersions).distinct
+     case Some("essential") => essentialBridgeScalaVersions
+@@ -181,7 +181,7 @@ def formatDep(dep: Dep) = {
+   s"${d.module.organization.value}:${d.module.name.value}:${d.versionConstraint.asString}"
+ }
+ 
+-def listIn(path: os.Path) = interp.watchValue(os.list(path).map(_.last))
++def listIn(path: os.Path) = mill.define.BuildCtx.watchValue(os.list(path).map(_.last))
+ 
+ val dummyDeps: Seq[Dep] = Seq(
+   Deps.DocDeps.millScip,
+diff --git a/runner/codesig/package.mill b/runner/codesig/package.mill
+index 3950422474a..1ed233d24f7 100644
+--- a/runner/codesig/package.mill
++++ b/runner/codesig/package.mill
+@@ -18,7 +18,7 @@ object `package` extends MillPublishScalaModule {
+ 
+   override lazy val test: CodeSigTests = new CodeSigTests {}
+   trait CodeSigTests extends MillScalaTests {
+-    val caseKeys = build.interp.watchValue(
++    val caseKeys = mill.define.BuildCtx.interp.watchValue(
+       os.walk(moduleDir / "cases", maxDepth = 3)
+         .map(_.subRelativeTo(moduleDir / "cases").segments)
+         .collect { case Seq(a, b, c) => s"$a-$b-$c" }

--- a/ci/mill-bootstrap.patch
+++ b/ci/mill-bootstrap.patch
@@ -29,7 +29,7 @@ index 3950422474a..1ed233d24f7 100644
    override lazy val test: CodeSigTests = new CodeSigTests {}
    trait CodeSigTests extends MillScalaTests {
 -    val caseKeys = build.interp.watchValue(
-+    val caseKeys = mill.define.BuildCtx.interp.watchValue(
++    val caseKeys = mill.define.BuildCtx.watchValue(
        os.walk(moduleDir / "cases", maxDepth = 3)
          .map(_.subRelativeTo(moduleDir / "cases").segments)
          .collect { case Seq(a, b, c) => s"$a-$b-$c" }

--- a/core/api/src/mill/api/internal/BuildFileApi.scala
+++ b/core/api/src/mill/api/internal/BuildFileApi.scala
@@ -1,0 +1,15 @@
+package mill.api.internal
+
+import mill.api.Watchable
+
+trait BuildFileApi {
+  def rootModule: RootModuleApi
+  def moduleWatchedValues: Seq[Watchable]
+  def evalWatchedValues: collection.mutable.Buffer[Watchable]
+}
+object BuildFileApi {
+  class Bootstrap(val rootModule: RootModuleApi) extends BuildFileApi {
+    def moduleWatchedValues = Nil
+    def evalWatchedValues = collection.mutable.Buffer[Watchable]()
+  }
+}

--- a/core/api/src/mill/api/internal/RootModuleApi.scala
+++ b/core/api/src/mill/api/internal/RootModuleApi.scala
@@ -1,9 +1,3 @@
 package mill.api.internal
 
-import mill.api.Watchable
-
-import scala.collection.mutable
-trait RootModuleApi {
-  protected[mill] def watchedValues: mutable.Buffer[Watchable]
-  protected[mill] def evalWatchedValues: mutable.Buffer[Watchable]
-}
+trait RootModuleApi {}

--- a/core/define/src/mill/define/BuildCtx.scala
+++ b/core/define/src/mill/define/BuildCtx.scala
@@ -2,7 +2,7 @@ package mill.define
 import collection.mutable
 import mill.api.Watchable
 import mill.constants.EnvVars
-object Project {
+object BuildCtx {
   val workspaceRoot: os.Path =
     sys.env.get(EnvVars.MILL_WORKSPACE_ROOT).fold(os.pwd)(os.Path(_, os.pwd))
 

--- a/core/define/src/mill/define/Evaluator.scala
+++ b/core/define/src/mill/define/Evaluator.scala
@@ -91,7 +91,7 @@ trait Evaluator extends AutoCloseable with EvaluatorApi {
       serialCommandExec: Boolean = false,
       selectiveExecution: Boolean = false
   ): EvaluatorApi.Result[T] = {
-    mill.define.withFilesystemCheckerDisabled {
+    mill.define.BuildCtx.withFilesystemCheckerDisabled {
       execute(
         targets.map(_.asInstanceOf[Task[T]]),
         reporter,

--- a/core/define/src/mill/define/Evaluator.scala
+++ b/core/define/src/mill/define/Evaluator.scala
@@ -91,7 +91,7 @@ trait Evaluator extends AutoCloseable with EvaluatorApi {
       serialCommandExec: Boolean = false,
       selectiveExecution: Boolean = false
   ): EvaluatorApi.Result[T] = {
-    os.checker.withValue(os.Checker.Nop) {
+    mill.define.withFilesystemCheckerDisabled {
       execute(
         targets.map(_.asInstanceOf[Task[T]]),
         reporter,

--- a/core/define/src/mill/define/ExternalModule.scala
+++ b/core/define/src/mill/define/ExternalModule.scala
@@ -13,7 +13,7 @@ abstract class ExternalModule(implicit
     millModuleEnclosing0: sourcecode.Enclosing,
     millModuleLine0: sourcecode.Line,
     millFile0: sourcecode.File
-) extends BaseModule(WorkspaceRoot.workspaceRoot, external0 = true)(
+) extends BaseModule(Project.workspaceRoot, external0 = true)(
       millModuleEnclosing0,
       millModuleLine0,
       millFile0

--- a/core/define/src/mill/define/ExternalModule.scala
+++ b/core/define/src/mill/define/ExternalModule.scala
@@ -13,7 +13,7 @@ abstract class ExternalModule(implicit
     millModuleEnclosing0: sourcecode.Enclosing,
     millModuleLine0: sourcecode.Line,
     millFile0: sourcecode.File
-) extends BaseModule(Project.workspaceRoot, external0 = true)(
+) extends BaseModule(BuildCtx.workspaceRoot, external0 = true)(
       millModuleEnclosing0,
       millModuleLine0,
       millFile0

--- a/core/define/src/mill/define/JsonFormatters.scala
+++ b/core/define/src/mill/define/JsonFormatters.scala
@@ -79,6 +79,6 @@ object JsonFormatters extends JsonFormatters {
   private object PathTokensReader0 extends mainargs.TokensReader.Simple[os.Path] {
     def shortName = "path"
     def read(strs: Seq[String]): Either[String, Path] =
-      Right(os.Path(strs.last, WorkspaceRoot.workspaceRoot))
+      Right(os.Path(strs.last, Project.workspaceRoot))
   }
 }

--- a/core/define/src/mill/define/JsonFormatters.scala
+++ b/core/define/src/mill/define/JsonFormatters.scala
@@ -79,6 +79,6 @@ object JsonFormatters extends JsonFormatters {
   private object PathTokensReader0 extends mainargs.TokensReader.Simple[os.Path] {
     def shortName = "path"
     def read(strs: Seq[String]): Either[String, Path] =
-      Right(os.Path(strs.last, Project.workspaceRoot))
+      Right(os.Path(strs.last, BuildCtx.workspaceRoot))
   }
 }

--- a/core/define/src/mill/define/Project.scala
+++ b/core/define/src/mill/define/Project.scala
@@ -1,7 +1,10 @@
 package mill.define
 
 import mill.constants.EnvVars
-object WorkspaceRoot {
+object Project {
   val workspaceRoot: os.Path =
     sys.env.get(EnvVars.MILL_WORKSPACE_ROOT).fold(os.pwd)(os.Path(_, os.pwd))
+
+  def withFilesystemCheckerDisabled[T](block: => T): T = 
+    os.checker.withValue(os.Checker.Nop) { block }
 }

--- a/core/define/src/mill/define/Project.scala
+++ b/core/define/src/mill/define/Project.scala
@@ -1,10 +1,36 @@
 package mill.define
-
+import collection.mutable
+import mill.api.Watchable
 import mill.constants.EnvVars
 object Project {
   val workspaceRoot: os.Path =
     sys.env.get(EnvVars.MILL_WORKSPACE_ROOT).fold(os.pwd)(os.Path(_, os.pwd))
 
-  def withFilesystemCheckerDisabled[T](block: => T): T = 
+  def withFilesystemCheckerDisabled[T](block: => T): T =
     os.checker.withValue(os.Checker.Nop) { block }
+
+  protected[mill] val watchedValues: mutable.Buffer[Watchable] = mutable.Buffer.empty[Watchable]
+  protected[mill] val evalWatchedValues: mutable.Buffer[Watchable] = mutable.Buffer.empty[Watchable]
+  def watchValue[T](v0: => T)(implicit fn: sourcecode.FileName, ln: sourcecode.Line): T = {
+    withFilesystemCheckerDisabled {
+      val v = v0
+      val watchable = Watchable.Value(
+        () => v0.hashCode,
+        v.hashCode(),
+        fn.value + ":" + ln.value
+      )
+      watchedValues.append(watchable)
+      v
+    }
+  }
+
+  def watch(p: os.Path): os.Path = {
+    val watchable = Watchable.Path(p.toNIO, false, PathRef(p).sig)
+    watchedValues.append(watchable)
+    p
+  }
+
+  def watch0(w: Watchable): Unit = watchedValues.append(w)
+
+  def evalWatch0(w: Watchable): Unit = evalWatchedValues.append(w)
 }

--- a/core/define/src/mill/define/internal/BuildFileCls.scala
+++ b/core/define/src/mill/define/internal/BuildFileCls.scala
@@ -3,7 +3,7 @@ package mill.define.internal
 class BuildFileCls(rootModule0: => mill.define.RootModule0) extends mill.api.internal.BuildFileApi {
   def value = this
   def checker = mill.define.internal.ResolveChecker(mill.define.BuildCtx.workspaceRoot)
-  def rootModule = os.checker.withValue(checker) { rootModule0 }
+  val rootModule = os.checker.withValue(checker) { rootModule0 }
 
   def moduleWatchedValues = mill.define.BuildCtx.watchedValues.toSeq
   def evalWatchedValues = mill.define.BuildCtx.evalWatchedValues

--- a/core/define/src/mill/define/internal/BuildFileCls.scala
+++ b/core/define/src/mill/define/internal/BuildFileCls.scala
@@ -1,0 +1,13 @@
+package mill.define.internal
+
+class BuildFileCls(rootModule0: => mill.define.RootModule0) extends mill.api.internal.BuildFileApi {
+  def value = this
+  def rootModule = os.checker.withValue(
+    mill.define.internal.ResolveChecker(mill.define.BuildCtx.workspaceRoot)
+  ) {
+    rootModule0
+  }
+
+  def moduleWatchedValues = mill.define.BuildCtx.watchedValues.toSeq
+  def evalWatchedValues = mill.define.BuildCtx.evalWatchedValues
+}

--- a/core/define/src/mill/define/internal/BuildFileCls.scala
+++ b/core/define/src/mill/define/internal/BuildFileCls.scala
@@ -2,11 +2,8 @@ package mill.define.internal
 
 class BuildFileCls(rootModule0: => mill.define.RootModule0) extends mill.api.internal.BuildFileApi {
   def value = this
-  def rootModule = os.checker.withValue(
-    mill.define.internal.ResolveChecker(mill.define.BuildCtx.workspaceRoot)
-  ) {
-    rootModule0
-  }
+  def checker = mill.define.internal.ResolveChecker(mill.define.BuildCtx.workspaceRoot)
+  def rootModule = os.checker.withValue(checker) { rootModule0 }
 
   def moduleWatchedValues = mill.define.BuildCtx.watchedValues.toSeq
   def evalWatchedValues = mill.define.BuildCtx.evalWatchedValues

--- a/core/internal/src/mill/internal/FileLogger.scala
+++ b/core/internal/src/mill/internal/FileLogger.scala
@@ -24,7 +24,7 @@ private[mill] class FileLogger(
     var folderCreated = false
     // Lazily create the folder and file that we're logging to, so as to avoid spamming the out/
     // folder with empty folders/files for the vast majority of tasks that do not have any logs
-    lazy val inner = mill.define.withFilesystemCheckerDisabled {
+    lazy val inner = mill.define.BuildCtx.withFilesystemCheckerDisabled {
       if (!os.exists(file / os.up)) os.makeDir.all(file / os.up)
       folderCreated = true
       Files.newOutputStream(file.toNIO, options*)

--- a/core/internal/src/mill/internal/FileLogger.scala
+++ b/core/internal/src/mill/internal/FileLogger.scala
@@ -24,7 +24,7 @@ private[mill] class FileLogger(
     var folderCreated = false
     // Lazily create the folder and file that we're logging to, so as to avoid spamming the out/
     // folder with empty folders/files for the vast majority of tasks that do not have any logs
-    lazy val inner = os.checker.withValue(os.Checker.Nop) {
+    lazy val inner = mill.define.withFilesystemCheckerDisabled {
       if (!os.exists(file / os.up)) os.makeDir.all(file / os.up)
       folderCreated = true
       Files.newOutputStream(file.toNIO, options*)

--- a/core/util/src/mill/util/Jvm.scala
+++ b/core/util/src/mill/util/Jvm.scala
@@ -549,7 +549,7 @@ object Jvm {
       artifactTypes,
       resolutionParams
     ).map { res =>
-      os.checker.withValue(os.Checker.Nop) {
+      mill.define.withFilesystemCheckerDisabled {
         res.files
           .map(os.Path(_))
           .map(PathRef(_, quick = true))

--- a/core/util/src/mill/util/Jvm.scala
+++ b/core/util/src/mill/util/Jvm.scala
@@ -549,7 +549,7 @@ object Jvm {
       artifactTypes,
       resolutionParams
     ).map { res =>
-      mill.define.withFilesystemCheckerDisabled {
+      mill.define.BuildCtx.withFilesystemCheckerDisabled {
         res.files
           .map(os.Path(_))
           .map(PathRef(_, quick = true))

--- a/dist/scripts/package.mill
+++ b/dist/scripts/package.mill
@@ -85,7 +85,7 @@ object `package` extends mill.Module { scripts =>
   }
   def scriptsModules: Seq[BootstrapScriptModule] = Seq(millSh, millBat)
 
-  def installInRepo() = Task.Command {
+  def installInRepo(): Command[Unit] = Task.Command {
     Task.traverse(scriptsModules)(m =>
       Task.Anon {
         val script = m.compile0().path

--- a/dist/scripts/package.mill
+++ b/dist/scripts/package.mill
@@ -28,41 +28,39 @@ object `package` extends mill.Module { scripts =>
 
     /** Compiles the script from the [[templateFile]] and substitutes all [[substitutions]]. */
     def compile0: T[PathRef] = Task {
-      os.checker.withValue(os.Checker.Nop) {
-        val script = T.dest / finalName()
-        val template = templateFile().path
-        val (start, end) = substitutionMarkers()
+      val script = T.dest / finalName()
+      val template = templateFile().path
+      val (start, end) = substitutionMarkers()
 
-        def pattern(key: String, quote: Boolean = true) =
-          s"""\\Q${start}\\E\\s*${if (quote) Pattern.quote(key) else key}\\s*\\Q${end}\\E""".r
-        val findAndReplace = substitutions().map((key, value) => (pattern(key), value))
-        val missing = pattern("[\\w+-_ ]+", false)
+      def pattern(key: String, quote: Boolean = true) =
+        s"""\\Q${start}\\E\\s*${if (quote) Pattern.quote(key) else key}\\s*\\Q${end}\\E""".r
+      val findAndReplace = substitutions().map((key, value) => (pattern(key), value))
+      val missing = pattern("[\\w+-_ ]+", false)
 
-        def substitute(line: String): String = {
-          val result = findAndReplace.foldLeft(line) { (line, r) =>
-            r._1.replaceAllIn(line, r._2)
-          }
-          missing.findFirstIn(result).foreach(m =>
-            throw RuntimeException(s"Detected unmatched substitution block: ${m}")
-          )
-          result
+      def substitute(line: String): String = {
+        val result = findAndReplace.foldLeft(line) { (line, r) =>
+          r._1.replaceAllIn(line, r._2)
         }
-
-        assert(os.exists(template))
-        Task.log.streams.out.println(s"Compiling script ${script}")
-        os.write(
-          target = script,
-          data = os.read.lines.stream(template).map(substitute).map(_ + '\n')
+        missing.findFirstIn(result).foreach(m =>
+          throw RuntimeException(s"Detected unmatched substitution block: ${m}")
         )
-        if (!scala.util.Properties.isWin) {
-          val p = os.perms(script) +
-            PosixFilePermission.OWNER_EXECUTE +
-            PosixFilePermission.GROUP_EXECUTE +
-            PosixFilePermission.OTHERS_EXECUTE
-          os.perms.set(script, p)
-        }
-        PathRef(script)
+        result
       }
+
+      assert(os.exists(template))
+      Task.log.streams.out.println(s"Compiling script ${script}")
+      os.write(
+        target = script,
+        data = os.read.lines.stream(template).map(substitute).map(_ + '\n')
+      )
+      if (!scala.util.Properties.isWin) {
+        val p = os.perms(script) +
+          PosixFilePermission.OWNER_EXECUTE +
+          PosixFilePermission.GROUP_EXECUTE +
+          PosixFilePermission.OTHERS_EXECUTE
+        os.perms.set(script, p)
+      }
+      PathRef(script)
     }
   }
 
@@ -87,24 +85,21 @@ object `package` extends mill.Module { scripts =>
   }
   def scriptsModules: Seq[BootstrapScriptModule] = Seq(millSh, millBat)
 
-  def installInRepo: T[Seq[PathRef]] = Task {
-    os.checker.withValue(os.Checker.Nop) {
-      Task.traverse(scriptsModules)(m =>
-        Task.Anon {
-          os.checker.withValue(os.Checker.Nop) {
-            val script = m.compile0().path
-            val dest = T.workspace / m.inRepoDir()
-            if (os.isDir(dest)) {
-              sys.error(s"Install destination is a directory: ${dest}")
-            } else if (os.exists(dest)) {
-              Task.log.warn(s"Overwriting file: ${dest}")
-            }
-            Task.log.info(s"Installing script: ${dest}")
-            os.copy.over(script, dest)
-            Result.Success(dest)
-          }
+  def installInRepo() = Task.Command {
+    Task.traverse(scriptsModules)(m =>
+      Task.Anon {
+        val script = m.compile0().path
+        val dest = T.workspace / m.inRepoDir()
+        if (os.isDir(dest)) {
+          sys.error(s"Install destination is a directory: ${dest}")
+        } else if (os.exists(dest)) {
+          Task.log.warn(s"Overwriting file: ${dest}")
         }
-      )().map(path => PathRef(path).withRevalidateOnce)
-    }
+        Task.log.info(s"Installing script: ${dest}")
+        os.copy.over(script, dest)
+        Result.Success(dest)
+
+      }
+    )().map(path => PathRef(path).withRevalidateOnce)
   }
 }

--- a/example/extending/python/4-python-libs-bundle/build.mill
+++ b/example/extending/python/4-python-libs-bundle/build.mill
@@ -41,7 +41,7 @@ trait PythonModule extends Module {
   def gatherScripts(upstream: Seq[(PathRef, PythonModule)]) = {
     for ((sourcesFolder, mod) <- upstream) {
       val destinationPath = os.pwd / mod.moduleDir.subRelativeTo(build.moduleDir)
-      os.checker.withValue(os.Checker.Nop) {
+      mill.define.withFilesystemCheckerDisabled {
         os.copy.over(sourcesFolder.path / os.up, destinationPath)
       }
     }

--- a/example/extending/python/4-python-libs-bundle/build.mill
+++ b/example/extending/python/4-python-libs-bundle/build.mill
@@ -41,7 +41,7 @@ trait PythonModule extends Module {
   def gatherScripts(upstream: Seq[(PathRef, PythonModule)]) = {
     for ((sourcesFolder, mod) <- upstream) {
       val destinationPath = os.pwd / mod.moduleDir.subRelativeTo(build.moduleDir)
-      mill.define.withFilesystemCheckerDisabled {
+      mill.define.BuildCtx.withFilesystemCheckerDisabled {
         os.copy.over(sourcesFolder.path / os.up, destinationPath)
       }
     }

--- a/example/fundamentals/cross/10-static-blog/build.mill
+++ b/example/fundamentals/cross/10-static-blog/build.mill
@@ -12,7 +12,7 @@ import scalatags.Text.all._
 import org.commonmark.parser.Parser
 import org.commonmark.renderer.html.HtmlRenderer
 
-// Next, we use `os.list` and `interp.watchValue` on the `post/` folder to
+// Next, we use `os.list` and `mill.define.BuildCtx.watchValue` on the `post/` folder to
 // build a `Cross[PostModule]` whose entries depend no the markdown files we
 // find in that folder. Each post has a `source` pointing at the markdown file,
 // and a `render` task that parses the file's markdown and generates a HTML
@@ -24,7 +24,7 @@ def mdNameToHtml(s: String) = s.toLowerCase.replace(".md", ".html")
 def mdNameToTitle(s: String) =
   s.split('-').drop(1).mkString(" ").stripSuffix(".md")
 
-val posts = interp.watchValue {
+val posts = mill.define.BuildCtx.watchValue {
   os.list(moduleDir / "post").map(_.last).sorted
 }
 

--- a/example/fundamentals/cross/9-dynamic-cross-modules/build.mill
+++ b/example/fundamentals/cross/9-dynamic-cross-modules/build.mill
@@ -1,7 +1,7 @@
 package build
 import mill._, scalalib._
 
-val moduleNames = interp.watchValue(os.list(moduleDir / "modules").map(_.last))
+val moduleNames = mill.define.BuildCtx.watchValue(os.list(moduleDir / "modules").map(_.last))
 
 object modules extends Cross[FolderModule](moduleNames)
 trait FolderModule extends ScalaModule with Cross.Module[String] {
@@ -15,7 +15,7 @@ trait FolderModule extends ScalaModule with Cross.Module[String] {
 // filesystem.
 //
 // In those cases, you can write arbitrary code to populate the cross-module
-// cases, as long as you wrap the value in a `interp.watchValue`. This ensures
+// cases, as long as you wrap the value in a `mill.define.BuildCtx.watchValue`. This ensures
 // that Mill is aware that the module structure depends on that value, and will
 // re-compute the value and re-create the module structure if the value changes.
 

--- a/example/thirdparty/acyclic/build.mill
+++ b/example/thirdparty/acyclic/build.mill
@@ -4,7 +4,7 @@ import mill._, scalalib._, publish._
 // acyclic test suite assumes files are on disk at specific paths relative to `os.pwd`.
 // To avoid changing the test code, we instead copy the necessary files into the `os.pwd`
 // when preparing the resources for test suite execution
-os.checker.withValue(os.Checker.Nop) {
+mill.define.withFilesystemCheckerDisabled {
   os.copy.over(
     interp.watch(mill.define.WorkspaceRoot.workspaceRoot / "acyclic"),
     os.pwd / "acyclic",

--- a/example/thirdparty/acyclic/build.mill
+++ b/example/thirdparty/acyclic/build.mill
@@ -6,7 +6,7 @@ import mill._, scalalib._, publish._
 // when preparing the resources for test suite execution
 mill.define.BuildCtx.withFilesystemCheckerDisabled {
   os.copy.over(
-    mill.define.BuildCtx.watch(mill.define.WorkspaceRoot.workspaceRoot / "acyclic"),
+    mill.define.BuildCtx.watch(mill.define.BuildCtx.workspaceRoot / "acyclic"),
     os.pwd / "acyclic",
     createFolders = true
   )

--- a/example/thirdparty/acyclic/build.mill
+++ b/example/thirdparty/acyclic/build.mill
@@ -6,7 +6,7 @@ import mill._, scalalib._, publish._
 // when preparing the resources for test suite execution
 mill.define.BuildCtx.withFilesystemCheckerDisabled {
   os.copy.over(
-    interp.watch(mill.define.WorkspaceRoot.workspaceRoot / "acyclic"),
+    mill.define.BuildCtx.watch(mill.define.WorkspaceRoot.workspaceRoot / "acyclic"),
     os.pwd / "acyclic",
     createFolders = true
   )

--- a/example/thirdparty/acyclic/build.mill
+++ b/example/thirdparty/acyclic/build.mill
@@ -4,7 +4,7 @@ import mill._, scalalib._, publish._
 // acyclic test suite assumes files are on disk at specific paths relative to `os.pwd`.
 // To avoid changing the test code, we instead copy the necessary files into the `os.pwd`
 // when preparing the resources for test suite execution
-mill.define.withFilesystemCheckerDisabled {
+mill.define.BuildCtx.withFilesystemCheckerDisabled {
   os.copy.over(
     interp.watch(mill.define.WorkspaceRoot.workspaceRoot / "acyclic"),
     os.pwd / "acyclic",

--- a/integration/failure/os-checker/src/OsCheckerTests.scala
+++ b/integration/failure/os-checker/src/OsCheckerTests.scala
@@ -33,7 +33,7 @@ object OsCheckerTests extends UtestIntegrationTestSuite {
       tester.modifyFile(workspacePath / "build.mill", _.replace("if (true)", "if (false)"))
       tester.modifyFile(
         workspacePath / "build.mill",
-        _ + "\nprintln(os.read(mill.define.WorkspaceRoot.workspaceRoot / \"build.mill\"))"
+        _ + "\nprintln(os.read(mill.define.BuildCtx.workspaceRoot / \"build.mill\"))"
       )
       val res4 = tester.eval("baz")
 

--- a/integration/ide/build-classpath-contents/src/BuildClasspathContentsTests.scala
+++ b/integration/ide/build-classpath-contents/src/BuildClasspathContentsTests.scala
@@ -1,4 +1,4 @@
-import mill.define.Project.workspaceRoot
+import mill.define.BuildCtx.workspaceRoot
 import mill.testkit.UtestIntegrationTestSuite
 import utest.*
 

--- a/integration/ide/build-classpath-contents/src/BuildClasspathContentsTests.scala
+++ b/integration/ide/build-classpath-contents/src/BuildClasspathContentsTests.scala
@@ -1,6 +1,6 @@
-import mill.define.WorkspaceRoot.workspaceRoot
+import mill.define.Project.workspaceRoot
 import mill.testkit.UtestIntegrationTestSuite
-import utest.{assert, *}
+import utest.*
 
 object BuildClasspathContentsTests extends UtestIntegrationTestSuite {
 

--- a/integration/invalidation/codesig-subfolder/src/CodeSigSubfolderTests.scala
+++ b/integration/invalidation/codesig-subfolder/src/CodeSigSubfolderTests.scala
@@ -25,7 +25,7 @@ object CodeSigSubfolderTests extends UtestIntegrationTestSuite {
       val initial = evalOuts("foo")
 
       assert(initial.out.linesIterator.toSeq == Seq("running foo", "running helperFoo"))
-      assert(initial.err.contains("compiling 30 Scala sources"))
+      assert(initial.err.contains("compiling 21 Scala sources"))
 
       val cached = evalOuts("foo")
       assert(cached.out == "")

--- a/integration/invalidation/watch-source-input/resources/build.mill
+++ b/integration/invalidation/watch-source-input/resources/build.mill
@@ -34,7 +34,7 @@ def lol = Task {
 
 def writeCompletionMarker(name: String) = {
 
-  mill.define.withFilesystemCheckerDisabled {
+  mill.define.BuildCtx.withFilesystemCheckerDisabled {
     Range(0, 10)
       .map(i => BuildCtx.workspaceRoot / "out" / s"$name$i")
       .find(!os.exists(_))
@@ -43,7 +43,7 @@ def writeCompletionMarker(name: String) = {
 }
 
 writeCompletionMarker("initialized")
-mill.define.withFilesystemCheckerDisabled {
+mill.define.BuildCtx.withFilesystemCheckerDisabled {
   if (os.read(moduleDir / "watchValue.txt").contains("exit")) {
     Thread.sleep(1000)
     System.exit(0)

--- a/integration/invalidation/watch-source-input/resources/build.mill
+++ b/integration/invalidation/watch-source-input/resources/build.mill
@@ -1,6 +1,6 @@
 package build
 import mill.*
-import mill.define.Project
+import mill.define.BuildCtx
 
 println("Setting up build.mill")
 
@@ -36,7 +36,7 @@ def writeCompletionMarker(name: String) = {
 
   mill.define.withFilesystemCheckerDisabled {
     Range(0, 10)
-      .map(i => Project.workspaceRoot / "out" / s"$name$i")
+      .map(i => BuildCtx.workspaceRoot / "out" / s"$name$i")
       .find(!os.exists(_))
       .foreach(os.write(_, ""))
   }

--- a/integration/invalidation/watch-source-input/resources/build.mill
+++ b/integration/invalidation/watch-source-input/resources/build.mill
@@ -19,7 +19,7 @@ def qux = Task {
   fooMsg + " " + barMsg
 }
 
-interp.watchValue(PathRef(moduleDir / "watchValue.txt"))
+mill.define.BuildCtx.watchValue(PathRef(moduleDir / "watchValue.txt"))
 
 def baz = Task.Input(PathRef(moduleDir / "baz.txt"))
 

--- a/integration/invalidation/watch-source-input/resources/build.mill
+++ b/integration/invalidation/watch-source-input/resources/build.mill
@@ -1,6 +1,6 @@
 package build
 import mill.*
-import mill.define.WorkspaceRoot
+import mill.define.Project
 
 println("Setting up build.mill")
 
@@ -34,16 +34,16 @@ def lol = Task {
 
 def writeCompletionMarker(name: String) = {
 
-  os.checker.withValue(os.Checker.Nop) {
+  mill.define.withFilesystemCheckerDisabled {
     Range(0, 10)
-      .map(i => WorkspaceRoot.workspaceRoot / "out" / s"$name$i")
+      .map(i => Project.workspaceRoot / "out" / s"$name$i")
       .find(!os.exists(_))
       .foreach(os.write(_, ""))
   }
 }
 
 writeCompletionMarker("initialized")
-os.checker.withValue(os.Checker.Nop) {
+mill.define.withFilesystemCheckerDisabled {
   if (os.read(moduleDir / "watchValue.txt").contains("exit")) {
     Thread.sleep(1000)
     System.exit(0)

--- a/integration/invalidation/watch-source-input/src/WatchSourceInputTests.scala
+++ b/integration/invalidation/watch-source-input/src/WatchSourceInputTests.scala
@@ -16,7 +16,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
  * 1. `Task.Source`
  * 2. `Task.Sources`
  * 3. `Task.Input`
- * 4. `interp.watchValue`
+ * 4. `mill.define.BuildCtx.watchValue`
  * 5. Implicitly watched files, like `build.mill`
  */
 trait WatchTests extends UtestIntegrationTestSuite {

--- a/integration/invalidation/zinc-build-compilation/src/ZincBuildCompilationTests.scala
+++ b/integration/invalidation/zinc-build-compilation/src/ZincBuildCompilationTests.scala
@@ -11,7 +11,7 @@ object ZincBuildCompilationTests extends UtestIntegrationTestSuite {
 
       val initial = eval(("dummy"))
 
-      assert(initial.err.contains("compiling 6 Scala sources"))
+      assert(initial.err.contains("compiling 5 Scala sources"))
 
       val cached = eval(("dummy"))
       assert(!cached.err.contains("compiling"))

--- a/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
@@ -838,7 +838,7 @@ trait AndroidAppModule extends AndroidModule { outer =>
       pf => androidProguardPath / pf
     }
     val userProguardFiles = proguardFilesFromReleaseSettings.localFiles
-    mill.define.withFilesystemCheckerDisabled {
+    mill.define.BuildCtx.withFilesystemCheckerDisabled {
       (defaultProguardFile.toSeq ++ userProguardFiles).map(PathRef(_))
     }
   }

--- a/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
@@ -838,7 +838,7 @@ trait AndroidAppModule extends AndroidModule { outer =>
       pf => androidProguardPath / pf
     }
     val userProguardFiles = proguardFilesFromReleaseSettings.localFiles
-    os.checker.withValue(os.Checker.Nop) {
+    mill.define.withFilesystemCheckerDisabled {
       (defaultProguardFile.toSeq ++ userProguardFiles).map(PathRef(_))
     }
   }

--- a/libs/javascriptlib/src/mill/javascriptlib/TypeScriptModule.scala
+++ b/libs/javascriptlib/src/mill/javascriptlib/TypeScriptModule.scala
@@ -152,7 +152,7 @@ trait TypeScriptModule extends Module { outer =>
     if (!os.exists(T.dest)) os.makeDir.all(T.dest)
 
     // Copy everything except "build.mill" and the "/out" directory from Task.workspace
-    os.checker.withValue(os.Checker.Nop) {
+    mill.define.withFilesystemCheckerDisabled {
       os.walk(moduleDir, skip = _.last == "out")
         .filter(_.last != "build.mill")
         .filter(_.last != "mill")
@@ -212,7 +212,7 @@ trait TypeScriptModule extends Module { outer =>
     targets.foreach { target =>
       val destination = T.dest / target
       os.makeDir.all(destination / os.up)
-      os.checker.withValue(os.Checker.Nop) {
+      mill.define.withFilesystemCheckerDisabled {
         os.copy(
           Task.workspace / target,
           destination,

--- a/libs/javascriptlib/src/mill/javascriptlib/TypeScriptModule.scala
+++ b/libs/javascriptlib/src/mill/javascriptlib/TypeScriptModule.scala
@@ -152,7 +152,7 @@ trait TypeScriptModule extends Module { outer =>
     if (!os.exists(T.dest)) os.makeDir.all(T.dest)
 
     // Copy everything except "build.mill" and the "/out" directory from Task.workspace
-    mill.define.withFilesystemCheckerDisabled {
+    mill.define.BuildCtx.withFilesystemCheckerDisabled {
       os.walk(moduleDir, skip = _.last == "out")
         .filter(_.last != "build.mill")
         .filter(_.last != "mill")
@@ -212,7 +212,7 @@ trait TypeScriptModule extends Module { outer =>
     targets.foreach { target =>
       val destination = T.dest / target
       os.makeDir.all(destination / os.up)
-      mill.define.withFilesystemCheckerDisabled {
+      mill.define.BuildCtx.withFilesystemCheckerDisabled {
         os.copy(
           Task.workspace / target,
           destination,

--- a/libs/kotlinlib/src/mill/kotlinlib/kover/KoverModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/kover/KoverModule.scala
@@ -103,7 +103,7 @@ trait KoverModule extends KotlinModule { outer =>
     override def forkArgs: T[Seq[String]] = Task {
       val argsFile = koverDataDir().path / "kover-agent.args"
       val content = s"report.file=${koverBinaryReport().path}"
-      mill.define.withFilesystemCheckerDisabled {
+      mill.define.BuildCtx.withFilesystemCheckerDisabled {
         os.write.over(argsFile, content)
       }
       super.forkArgs() ++

--- a/libs/kotlinlib/src/mill/kotlinlib/kover/KoverModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/kover/KoverModule.scala
@@ -103,7 +103,7 @@ trait KoverModule extends KotlinModule { outer =>
     override def forkArgs: T[Seq[String]] = Task {
       val argsFile = koverDataDir().path / "kover-agent.args"
       val content = s"report.file=${koverBinaryReport().path}"
-      os.checker.withValue(os.Checker.Nop) {
+      mill.define.withFilesystemCheckerDisabled {
         os.write.over(argsFile, content)
       }
       super.forkArgs() ++

--- a/libs/kotlinlib/src/mill/kotlinlib/ktlint/KtlintModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/ktlint/KtlintModule.scala
@@ -123,7 +123,7 @@ object KtlintModule extends ExternalModule with KtlintModule with TaskModule {
       .filter(f => os.exists(f) && (f.ext == "kt" || f.ext == "kts"))
       .map(_.toString())
 
-    val exitCode = os.checker.withValue(os.Checker.Nop) {
+    val exitCode = mill.define.withFilesystemCheckerDisabled {
       Jvm.callProcess(
         mainClass = "com.pinterest.ktlint.Main",
         classPath = classPath.map(_.path).toVector,

--- a/libs/kotlinlib/src/mill/kotlinlib/ktlint/KtlintModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/ktlint/KtlintModule.scala
@@ -123,7 +123,7 @@ object KtlintModule extends ExternalModule with KtlintModule with TaskModule {
       .filter(f => os.exists(f) && (f.ext == "kt" || f.ext == "kts"))
       .map(_.toString())
 
-    val exitCode = mill.define.withFilesystemCheckerDisabled {
+    val exitCode = mill.define.BuildCtx.withFilesystemCheckerDisabled {
       Jvm.callProcess(
         mainClass = "com.pinterest.ktlint.Main",
         classPath = classPath.map(_.path).toVector,

--- a/libs/main/src/mill/main/Inspect.scala
+++ b/libs/main/src/mill/main/Inspect.scala
@@ -47,7 +47,7 @@ private object Inspect {
     def renderFileName(ctx: mill.define.ModuleCtx) = {
       // handle both Windows or Unix separators
       val fullFileName = ctx.fileName.replaceAll(raw"\\", "/")
-      val basePath = WorkspaceRoot.workspaceRoot.toString.replaceAll(raw"\\", "/") + "/"
+      val basePath = Project.workspaceRoot.toString.replaceAll(raw"\\", "/") + "/"
       val name =
         if (fullFileName.startsWith(basePath)) {
           fullFileName.drop(basePath.length)

--- a/libs/main/src/mill/main/Inspect.scala
+++ b/libs/main/src/mill/main/Inspect.scala
@@ -47,7 +47,7 @@ private object Inspect {
     def renderFileName(ctx: mill.define.ModuleCtx) = {
       // handle both Windows or Unix separators
       val fullFileName = ctx.fileName.replaceAll(raw"\\", "/")
-      val basePath = Project.workspaceRoot.toString.replaceAll(raw"\\", "/") + "/"
+      val basePath = BuildCtx.workspaceRoot.toString.replaceAll(raw"\\", "/") + "/"
       val name =
         if (fullFileName.startsWith(basePath)) {
           fullFileName.drop(basePath.length)

--- a/libs/main/src/mill/main/MainModule.scala
+++ b/libs/main/src/mill/main/MainModule.scala
@@ -22,6 +22,7 @@ abstract class MainRootModule()(implicit
  * [[show]], [[inspect]], [[plan]], etc.
  */
 trait MainModule extends BaseModule with MainModuleApi {
+
   /**
    * Show the mill version.
    */

--- a/libs/main/src/mill/main/MainModule.scala
+++ b/libs/main/src/mill/main/MainModule.scala
@@ -116,7 +116,7 @@ trait MainModule extends BaseModule with MainModuleApi {
    */
   def show(evaluator: Evaluator, targets: String*): Command[ujson.Value] =
     Task.Command(exclusive = true) {
-      MainModule.show0(evaluator, targets, Target.log, interp.evalWatch0) { res =>
+      MainModule.show0(evaluator, targets, Target.log, mill.define.BuildCtx.evalWatch0) { res =>
         res.flatMap(_._2) match {
           case Seq((k, singleValue)) => singleValue
           case multiple => ujson.Obj.from(multiple)
@@ -130,7 +130,7 @@ trait MainModule extends BaseModule with MainModuleApi {
    */
   def showNamed(evaluator: Evaluator, targets: String*): Command[ujson.Value] =
     Task.Command(exclusive = true) {
-      MainModule.show0(evaluator, targets, Target.log, interp.evalWatch0) { res =>
+      MainModule.show0(evaluator, targets, Target.log, mill.define.BuildCtx.evalWatch0) { res =>
         ujson.Obj.from(res.flatMap(_._2))
       }
     }

--- a/libs/main/src/mill/main/MainModule.scala
+++ b/libs/main/src/mill/main/MainModule.scala
@@ -22,34 +22,6 @@ abstract class MainRootModule()(implicit
  * [[show]], [[inspect]], [[plan]], etc.
  */
 trait MainModule extends BaseModule with MainModuleApi {
-  protected[mill] val watchedValues: mutable.Buffer[Watchable] = mutable.Buffer.empty[Watchable]
-  protected[mill] val evalWatchedValues: mutable.Buffer[Watchable] = mutable.Buffer.empty[Watchable]
-  object interp {
-    def watchValue[T](v0: => T)(implicit fn: sourcecode.FileName, ln: sourcecode.Line): T = {
-      mill.define.withFilesystemCheckerDisabled {
-        val v = v0
-        val watchable = Watchable.Value(
-          () => v0.hashCode,
-          v.hashCode(),
-          fn.value + ":" + ln.value
-        )
-        watchedValues.append(watchable)
-        v
-      }
-    }
-
-    def watch(p: os.Path): os.Path = {
-      val watchable = Watchable.Path(p.toNIO, false, PathRef(p).sig)
-      watchedValues.append(watchable)
-      p
-    }
-
-    def watch0(w: Watchable): Unit = watchedValues.append(w)
-
-    def evalWatch0(w: Watchable): Unit = evalWatchedValues.append(w)
-
-  }
-
   /**
    * Show the mill version.
    */

--- a/libs/main/src/mill/main/MainModule.scala
+++ b/libs/main/src/mill/main/MainModule.scala
@@ -26,7 +26,7 @@ trait MainModule extends BaseModule with MainModuleApi {
   protected[mill] val evalWatchedValues: mutable.Buffer[Watchable] = mutable.Buffer.empty[Watchable]
   object interp {
     def watchValue[T](v0: => T)(implicit fn: sourcecode.FileName, ln: sourcecode.Line): T = {
-      os.checker.withValue(os.Checker.Nop) {
+      mill.define.withFilesystemCheckerDisabled {
         val v = v0
         val watchable = Watchable.Value(
           () => v0.hashCode,

--- a/libs/main/src/mill/main/VisualizeModule.scala
+++ b/libs/main/src/mill/main/VisualizeModule.scala
@@ -171,7 +171,7 @@ object VisualizeModule extends ExternalModule {
             stdout = os.Inherit
           )
 
-          os.checker.withValue(os.Checker.Nop) {
+          mill.define.withFilesystemCheckerDisabled {
             os.list(dest).sorted.map(PathRef(_))
           }
         }

--- a/libs/main/src/mill/main/VisualizeModule.scala
+++ b/libs/main/src/mill/main/VisualizeModule.scala
@@ -171,7 +171,7 @@ object VisualizeModule extends ExternalModule {
             stdout = os.Inherit
           )
 
-          mill.define.withFilesystemCheckerDisabled {
+          mill.define.BuildCtx.withFilesystemCheckerDisabled {
             os.list(dest).sorted.map(PathRef(_))
           }
         }

--- a/libs/pythonlib/src/mill/pythonlib/PythonModule.scala
+++ b/libs/pythonlib/src/mill/pythonlib/PythonModule.scala
@@ -179,7 +179,7 @@ trait PythonModule extends PipModule with TaskModule { outer =>
     val (procUuidPath, procLockfile, procUuid) = mill.scalalib.RunModule.backgroundSetup(Task.dest)
     val pwd0 = os.Path(java.nio.file.Paths.get(".").toAbsolutePath)
 
-    os.checker.withValue(os.Checker.Nop) {
+    mill.define.withFilesystemCheckerDisabled {
       Jvm.spawnProcess(
         mainClass = "mill.scalalib.backgroundwrapper.MillBackgroundWrapper",
         classPath = mill.scalalib.JvmWorkerModule.backgroundWrapperClasspath().map(_.path).toSeq,

--- a/libs/pythonlib/src/mill/pythonlib/PythonModule.scala
+++ b/libs/pythonlib/src/mill/pythonlib/PythonModule.scala
@@ -179,7 +179,7 @@ trait PythonModule extends PipModule with TaskModule { outer =>
     val (procUuidPath, procLockfile, procUuid) = mill.scalalib.RunModule.backgroundSetup(Task.dest)
     val pwd0 = os.Path(java.nio.file.Paths.get(".").toAbsolutePath)
 
-    mill.define.withFilesystemCheckerDisabled {
+    mill.define.BuildCtx.withFilesystemCheckerDisabled {
       Jvm.spawnProcess(
         mainClass = "mill.scalalib.backgroundwrapper.MillBackgroundWrapper",
         classPath = mill.scalalib.JvmWorkerModule.backgroundWrapperClasspath().map(_.path).toSeq,

--- a/libs/scalalib/src/mill/scalalib/RunModule.scala
+++ b/libs/scalalib/src/mill/scalalib/RunModule.scala
@@ -312,7 +312,7 @@ object RunModule {
       }
       val env = Option(forkEnv).getOrElse(forkEnv0)
 
-      mill.define.withFilesystemCheckerDisabled {
+      mill.define.BuildCtx.withFilesystemCheckerDisabled {
         if (background) {
           val (stdout, stderr) = if (runBackgroundLogToConsole) {
             // Hack to forward the background subprocess output to the Mill server process

--- a/libs/scalalib/src/mill/scalalib/RunModule.scala
+++ b/libs/scalalib/src/mill/scalalib/RunModule.scala
@@ -312,7 +312,7 @@ object RunModule {
       }
       val env = Option(forkEnv).getOrElse(forkEnv0)
 
-      os.checker.withValue(os.Checker.Nop) {
+      mill.define.withFilesystemCheckerDisabled {
         if (background) {
           val (stdout, stderr) = if (runBackgroundLogToConsole) {
             // Hack to forward the background subprocess output to the Mill server process

--- a/libs/scalalib/src/mill/scalalib/TestModuleUtil.scala
+++ b/libs/scalalib/src/mill/scalalib/TestModuleUtil.scala
@@ -157,7 +157,7 @@ private final class TestModuleUtil(
 
     os.makeDir.all(sandbox)
 
-    os.checker.withValue(os.Checker.Nop) {
+    mill.define.withFilesystemCheckerDisabled {
       Jvm.callProcess(
         mainClass = "mill.testrunner.entrypoint.TestRunnerMain",
         classPath = (runClasspath ++ testrunnerEntrypointClasspath).map(_.path),

--- a/libs/scalalib/src/mill/scalalib/TestModuleUtil.scala
+++ b/libs/scalalib/src/mill/scalalib/TestModuleUtil.scala
@@ -157,7 +157,7 @@ private final class TestModuleUtil(
 
     os.makeDir.all(sandbox)
 
-    mill.define.withFilesystemCheckerDisabled {
+    mill.define.BuildCtx.withFilesystemCheckerDisabled {
       Jvm.callProcess(
         mainClass = "mill.testrunner.entrypoint.TestRunnerMain",
         classPath = (runClasspath ++ testrunnerEntrypointClasspath).map(_.path),

--- a/mill
+++ b/mill
@@ -23,7 +23,7 @@
 # into a cache location (~/.cache/mill/download).
 #
 # Mill Project URL: https://github.com/com-lihaoyi/mill
-# Script Version: 1.0.0-M1-49-ac90e3
+# Script Version: 1.0.0-M1-21-7b6fae-DIRTY892b63e8
 #
 # If you want to improve this script, please also contribute your changes back!
 # This script was generated from: dist/scripts/src/mill.sh

--- a/mill.bat
+++ b/mill.bat
@@ -23,7 +23,7 @@ rem this script downloads a binary file from Maven Central or Github Pages (this
 rem into a cache location (%USERPROFILE%\.mill\download).
 rem
 rem Mill Project URL: https://github.com/com-lihaoyi/mill
-rem Script Version: 1.0.0-M1-49-ac90e3
+rem Script Version: 1.0.0-M1-21-7b6fae-DIRTY892b63e8
 rem
 rem If you want to improve this script, please also contribute your changes back!
 rem This script was generated from: dist/scripts/src/mill.bat
@@ -287,7 +287,6 @@ if [%~1%]==[--bsp] (
     )
   )
 )
-
 set "MILL_PARAMS=%*%"
 
 if not [!MILL_FIRST_ARG!]==[] (

--- a/runner/bsp/src/mill/bsp/BSP.scala
+++ b/runner/bsp/src/mill/bsp/BSP.scala
@@ -1,7 +1,7 @@
 package mill.bsp
 
 import mill.util.BuildInfo
-import mill.define.Project
+import mill.define.BuildCtx
 
 import java.io.PrintStream
 
@@ -23,7 +23,7 @@ private[mill] object BSP {
    */
   def install(jobs: Int, withDebug: Boolean, errStream: PrintStream): Unit = {
     // we create a json connection file
-    val bspFile = Project.workspaceRoot / Constants.bspDir / s"${Constants.serverName}.json"
+    val bspFile = BuildCtx.workspaceRoot / Constants.bspDir / s"${Constants.serverName}.json"
     if (os.exists(bspFile)) errStream.println(s"Overwriting BSP connection file: ${bspFile}")
     else errStream.println(s"Creating BSP connection file: ${bspFile}")
     if (withDebug) errStream.println(

--- a/runner/bsp/src/mill/bsp/BSP.scala
+++ b/runner/bsp/src/mill/bsp/BSP.scala
@@ -1,7 +1,7 @@
 package mill.bsp
 
 import mill.util.BuildInfo
-import mill.define.WorkspaceRoot
+import mill.define.Project
 
 import java.io.PrintStream
 
@@ -23,7 +23,7 @@ private[mill] object BSP {
    */
   def install(jobs: Int, withDebug: Boolean, errStream: PrintStream): Unit = {
     // we create a json connection file
-    val bspFile = WorkspaceRoot.workspaceRoot / Constants.bspDir / s"${Constants.serverName}.json"
+    val bspFile = Project.workspaceRoot / Constants.bspDir / s"${Constants.serverName}.json"
     if (os.exists(bspFile)) errStream.println(s"Overwriting BSP connection file: ${bspFile}")
     else errStream.println(s"Creating BSP connection file: ${bspFile}")
     if (withDebug) errStream.println(

--- a/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
+++ b/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
@@ -198,11 +198,7 @@ class MillBuildBootstrap(
               headerData = headerDataOpt.getOrElse("")
             )) { evaluator =>
               if (depth == requestedDepth) {
-                processFinalTargets(
-                  nestedState,
-                  buildFileApi,
-                  evaluator
-                )
+                processFinalTargets(nestedState, buildFileApi, evaluator)
               } else if (depth <= requestedDepth) nestedState
               else {
                 processRunClasspath(
@@ -323,6 +319,7 @@ class MillBuildBootstrap(
       buildFileApi: BuildFileApi,
       evaluator: EvaluatorApi
   ): RunnerState = {
+
     assert(nestedState.frames.forall(_.evaluator.isDefined))
 
     val (evaled, evalWatched, moduleWatches) = evaluateWithWatches(

--- a/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
+++ b/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
@@ -5,7 +5,7 @@ import mill.api.{Logger, Result, SystemStreams, Val}
 import mill.constants.CodeGenConstants.*
 import mill.constants.OutFiles.{millBuild, millRunnerState}
 import mill.define.internal.Watchable
-import mill.define.{PathRef, RootModule0, SelectMode, Project}
+import mill.define.{PathRef, RootModule0, SelectMode, BuildCtx}
 import mill.internal.PrefixLogger
 import mill.meta.{FileImportGraph, MillBuildRootModule}
 import mill.meta.CliImports
@@ -447,7 +447,7 @@ object MillBuildBootstrap {
     } else {
       if (seenClassLoaders.contains(ClassLoader.getSystemClassLoader)) {
         for (p <- System.getProperty("java.class.path").split(File.pathSeparatorChar)) {
-          val f = os.Path(p, Project.workspaceRoot)
+          val f = os.Path(p, BuildCtx.workspaceRoot)
           if (os.exists(f)) files.append(f)
         }
       }

--- a/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
+++ b/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
@@ -1,21 +1,21 @@
 package mill.daemon
 
-import mill.api.internal.{EvaluatorApi, RootModuleApi, internal, PathRefApi}
+import mill.api.internal.{BuildFileApi, EvaluatorApi, PathRefApi, RootModuleApi, internal}
 import mill.api.{Logger, Result, SystemStreams, Val}
 import mill.constants.CodeGenConstants.*
 import mill.constants.OutFiles.{millBuild, millRunnerState}
 import mill.define.internal.Watchable
-import mill.define.{PathRef, RootModule0, SelectMode, BuildCtx}
+import mill.define.{BuildCtx, PathRef, RootModule0, SelectMode}
 import mill.internal.PrefixLogger
 import mill.meta.{FileImportGraph, MillBuildRootModule}
 import mill.meta.CliImports
-import mill.api.internal.MillScalaParser
 import mill.util.BuildInfo
 
 import java.io.File
 import java.net.URLClassLoader
 import scala.jdk.CollectionConverters.ListHasAsScala
 import scala.util.Using
+import scala.collection.mutable.Buffer
 
 /**
  * Logic around bootstrapping Mill, creating a [[MillBuildRootModule.BootstrapModule]]
@@ -109,22 +109,15 @@ class MillBuildBootstrap(
           (res, None)
         }
       } else {
-        val parsedScriptFiles = FileImportGraph.parseBuildFiles(
-          projectRoot,
-          currentRoot / os.up,
-          output
-        )
+        val parsedScriptFiles = FileImportGraph
+          .parseBuildFiles(projectRoot, currentRoot / os.up, output)
 
         val state =
           if (os.exists(currentRoot)) evaluateRec(depth + 1)
           else {
             val bootstrapModule =
               new MillBuildRootModule.BootstrapModule()(
-                new RootModule0.Info(
-                  currentRoot,
-                  output,
-                  projectRoot
-                )
+                new RootModule0.Info(currentRoot, output, projectRoot)
               )
             RunnerState(Some(bootstrapModule), Nil, None, Some(parsedScriptFiles.buildFile))
           }
@@ -159,13 +152,14 @@ class MillBuildBootstrap(
         nestedState.add(frame = evalState, errorOpt = None)
       } else {
         val rootModuleRes = nestedState.frames.headOption match {
-          case None => Result.Success(nestedState.bootstrapModuleOpt.get)
+          case None =>
+            Result.Success(BuildFileApi.Bootstrap(nestedState.bootstrapModuleOpt.get))
           case Some(nestedFrame) => getRootModule(nestedFrame.classLoaderOpt.get)
         }
 
         rootModuleRes match {
           case Result.Failure(err) => nestedState.add(errorOpt = Some(err))
-          case Result.Success(rootModule) =>
+          case Result.Success((buildFileApi)) =>
 
             Using.resource(makeEvaluator(
               projectRoot,
@@ -181,7 +175,7 @@ class MillBuildBootstrap(
               offline,
               prevFrameOpt.map(_.workerCache).getOrElse(Map.empty),
               nestedState.frames.headOption.map(_.codeSignatures).getOrElse(Map.empty),
-              rootModule,
+              buildFileApi.rootModule,
               // We want to use the grandparent buildHash, rather than the parent
               // buildHash, because the parent build changes are instead detected
               // by analyzing the scriptImportGraph in a more fine-grained manner.
@@ -203,12 +197,17 @@ class MillBuildBootstrap(
               actualBuildFileName = nestedState.buildFile,
               headerData = headerDataOpt.getOrElse("")
             )) { evaluator =>
-              if (depth == requestedDepth) processFinalTargets(nestedState, rootModule, evaluator)
-              else if (depth <= requestedDepth) nestedState
+              if (depth == requestedDepth) {
+                processFinalTargets(
+                  nestedState,
+                  buildFileApi,
+                  evaluator
+                )
+              } else if (depth <= requestedDepth) nestedState
               else {
                 processRunClasspath(
                   nestedState,
-                  rootModule,
+                  buildFileApi,
                   evaluator,
                   prevFrameOpt,
                   prevOuterFrameOpt
@@ -233,13 +232,13 @@ class MillBuildBootstrap(
    */
   def processRunClasspath(
       nestedState: RunnerState,
-      rootModule: RootModuleApi,
+      buildFileApi: BuildFileApi,
       evaluator: EvaluatorApi,
       prevFrameOpt: Option[RunnerState.Frame],
       prevOuterFrameOpt: Option[RunnerState.Frame]
   ): RunnerState = {
     evaluateWithWatches(
-      rootModule,
+      buildFileApi,
       evaluator,
       Seq("millBuildRootModuleResult"),
       selectiveExecution = false
@@ -247,7 +246,7 @@ class MillBuildBootstrap(
       case (Result.Failure(error), evalWatches, moduleWatches) =>
         val evalState = RunnerState.Frame(
           evaluator.workerCache.toMap,
-          evalWatches,
+          buildFileApi.evalWatchedValues.toSeq,
           moduleWatches,
           Map.empty,
           None,
@@ -321,13 +320,13 @@ class MillBuildBootstrap(
    */
   def processFinalTargets(
       nestedState: RunnerState,
-      rootModule: RootModuleApi,
+      buildFileApi: BuildFileApi,
       evaluator: EvaluatorApi
   ): RunnerState = {
     assert(nestedState.frames.forall(_.evaluator.isDefined))
 
     val (evaled, evalWatched, moduleWatches) = evaluateWithWatches(
-      rootModule,
+      buildFileApi,
       evaluator,
       targetsAndParams,
       selectiveExecution
@@ -419,8 +418,8 @@ object MillBuildBootstrap {
   def classpath(classLoader: ClassLoader): Vector[os.Path] = {
 
     var current = classLoader
-    val files = collection.mutable.Buffer.empty[os.Path]
-    val seenClassLoaders = collection.mutable.Buffer.empty[ClassLoader]
+    val files = Buffer.empty[os.Path]
+    val seenClassLoaders = Buffer.empty[ClassLoader]
     while (current != null) {
       seenClassLoaders.append(current)
       current match {
@@ -485,12 +484,13 @@ object MillBuildBootstrap {
   }
 
   def evaluateWithWatches(
-      rootModule: RootModuleApi,
+      buildFileApi: BuildFileApi,
       evaluator: EvaluatorApi,
       targetsAndParams: Seq[String],
       selectiveExecution: Boolean
   ): (Result[Seq[Any]], Seq[Watchable], Seq[Watchable]) = {
-    rootModule.evalWatchedValues.clear()
+    import buildFileApi._
+    evalWatchedValues.clear()
     val evalTaskResult =
       mill.api.ClassLoader.withContextClassLoader(rootModule.getClass.getClassLoader) {
         evaluator.evaluate(
@@ -500,26 +500,26 @@ object MillBuildBootstrap {
         )
       }
 
-    val moduleWatched = rootModule.watchedValues.toVector
-    val addedEvalWatched = rootModule.evalWatchedValues.toVector
-
     evalTaskResult match {
-      case Result.Failure(msg) => (Result.Failure(msg), Nil, moduleWatched)
+      case Result.Failure(msg) => (Result.Failure(msg), Nil, moduleWatchedValues)
       case Result.Success(res: EvaluatorApi.Result[Any]) =>
         res.values match {
           case Result.Failure(msg) =>
-            (Result.Failure(msg), res.watchable ++ addedEvalWatched, moduleWatched)
+            (Result.Failure(msg), res.watchable ++ evalWatchedValues, moduleWatchedValues)
           case Result.Success(results) =>
-            (Result.Success(results), res.watchable ++ addedEvalWatched, moduleWatched)
+            (Result.Success(results), res.watchable ++ evalWatchedValues, moduleWatchedValues)
         }
     }
   }
 
-  def getRootModule(runClassLoader: URLClassLoader): Result[RootModuleApi] = {
-    val buildClass = runClassLoader.loadClass(s"$globalPackagePrefix.wrapper_object_getter")
+  def getRootModule(runClassLoader: URLClassLoader)
+      : Result[BuildFileApi] = {
+    val buildClass = runClassLoader.loadClass(s"$globalPackagePrefix.BuildFileImpl")
 
     val valueMethod = buildClass.getMethod("value")
-    mill.api.ExecResult.catchWrapException { valueMethod.invoke(null).asInstanceOf[RootModuleApi] }
+    mill.api.ExecResult.catchWrapException {
+      valueMethod.invoke(null).asInstanceOf[BuildFileApi]
+    }
   }
 
   def recRoot(projectRoot: os.Path, depth: Int): os.Path = {

--- a/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
+++ b/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
@@ -246,7 +246,7 @@ class MillBuildBootstrap(
       case (Result.Failure(error), evalWatches, moduleWatches) =>
         val evalState = RunnerState.Frame(
           evaluator.workerCache.toMap,
-          buildFileApi.evalWatchedValues.toSeq,
+          evalWatches,
           moduleWatches,
           Map.empty,
           None,
@@ -331,7 +331,6 @@ class MillBuildBootstrap(
       targetsAndParams,
       selectiveExecution
     )
-
     val evalState = RunnerState.Frame(
       evaluator.workerCache.toMap,
       evalWatched,

--- a/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
+++ b/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
@@ -5,10 +5,10 @@ import mill.api.{Logger, Result, SystemStreams, Val}
 import mill.constants.CodeGenConstants.*
 import mill.constants.OutFiles.{millBuild, millRunnerState}
 import mill.define.internal.Watchable
-import mill.define.{PathRef, RootModule0, SelectMode, WorkspaceRoot}
+import mill.define.{PathRef, RootModule0, SelectMode, Project}
 import mill.internal.PrefixLogger
 import mill.meta.{FileImportGraph, MillBuildRootModule}
-import mill.meta.{CliImports}
+import mill.meta.CliImports
 import mill.api.internal.MillScalaParser
 import mill.util.BuildInfo
 
@@ -447,7 +447,7 @@ object MillBuildBootstrap {
     } else {
       if (seenClassLoaders.contains(ClassLoader.getSystemClassLoader)) {
         for (p <- System.getProperty("java.class.path").split(File.pathSeparatorChar)) {
-          val f = os.Path(p, WorkspaceRoot.workspaceRoot)
+          val f = os.Path(p, Project.workspaceRoot)
           if (os.exists(f)) files.append(f)
         }
       }

--- a/runner/daemon/src/mill/daemon/MillDaemonMain.scala
+++ b/runner/daemon/src/mill/daemon/MillDaemonMain.scala
@@ -49,7 +49,7 @@ class MillDaemonMain(
   }
   def stateCache0 = RunnerState.empty
 
-  val out = os.Path(OutFiles.out, mill.define.Project.workspaceRoot)
+  val out = os.Path(OutFiles.out, mill.define.BuildCtx.workspaceRoot)
 
   val outLock = new DoubleLock(
     Lock.memory(),

--- a/runner/daemon/src/mill/daemon/MillDaemonMain.scala
+++ b/runner/daemon/src/mill/daemon/MillDaemonMain.scala
@@ -49,7 +49,7 @@ class MillDaemonMain(
   }
   def stateCache0 = RunnerState.empty
 
-  val out = os.Path(OutFiles.out, mill.define.WorkspaceRoot.workspaceRoot)
+  val out = os.Path(OutFiles.out, mill.define.Project.workspaceRoot)
 
   val outLock = new DoubleLock(
     Lock.memory(),

--- a/runner/daemon/src/mill/daemon/MillMain.scala
+++ b/runner/daemon/src/mill/daemon/MillMain.scala
@@ -6,7 +6,7 @@ import mill.bsp.BSP
 import mill.client.lock.Lock
 import mill.constants.{OutFiles, DaemonFiles, Util}
 import mill.{api, define}
-import mill.define.WorkspaceRoot
+import mill.define.Project
 import mill.internal.{Colors, MultiStream, PromptLogger}
 import mill.server.Server
 import mill.util.BuildInfo
@@ -47,7 +47,7 @@ object MillMain {
       io.github.alexarchambault.windowsansi.WindowsAnsi.setup()
 
     val processId = Server.computeProcessId()
-    val out = os.Path(OutFiles.out, WorkspaceRoot.workspaceRoot)
+    val out = os.Path(OutFiles.out, Project.workspaceRoot)
     Server.watchProcessIdFile(
       out / OutFiles.millNoDaemon / processId / DaemonFiles.processId,
       processId,
@@ -86,11 +86,11 @@ object MillMain {
       // In BSP mode, don't let anything other than the BSP server write to stdout and read from stdin
 
       val outFileStream = os.write.outputStream(
-        WorkspaceRoot.workspaceRoot / OutFiles.out / "mill-bsp/out.log",
+        Project.workspaceRoot / OutFiles.out / "mill-bsp/out.log",
         createFolders = true
       )
       val errFileStream = os.write.outputStream(
-        WorkspaceRoot.workspaceRoot / OutFiles.out / "mill-bsp/err.log",
+        Project.workspaceRoot / OutFiles.out / "mill-bsp/err.log",
         createFolders = true
       )
 
@@ -190,7 +190,7 @@ object MillMain {
                 if (colored) mill.internal.Colors.Default else mill.internal.Colors.BlackWhite
 
               if (!config.silent.value) {
-                checkMillVersionFromFile(WorkspaceRoot.workspaceRoot, streams.err)
+                checkMillVersionFromFile(Project.workspaceRoot, streams.err)
               }
 
               val maybeThreadCount =
@@ -252,7 +252,7 @@ object MillMain {
 
                   val threadCount = Some(maybeThreadCount.toOption.get)
 
-                  val out = os.Path(OutFiles.out, WorkspaceRoot.workspaceRoot)
+                  val out = os.Path(OutFiles.out, Project.workspaceRoot)
                   Using.resource(new TailManager(daemonDir)) { tailManager =>
                     def runMillBootstrap(
                         enterKeyPressed: Boolean,
@@ -287,7 +287,7 @@ object MillMain {
                           tailManager.withOutErr(logger.streams.out, logger.streams.err) {
 
                             new MillBuildBootstrap(
-                              projectRoot = WorkspaceRoot.workspaceRoot,
+                              projectRoot = Project.workspaceRoot,
                               output = out,
                               keepGoing = config.keepGoing.value,
                               imports = config.imports,
@@ -393,12 +393,12 @@ object MillMain {
   ): Result[BspServerResult] = {
     logStreams.err.println("Trying to load BSP server...")
 
-    val wsRoot = WorkspaceRoot.workspaceRoot
+    val wsRoot = Project.workspaceRoot
     val logDir = wsRoot / OutFiles.out / "mill-bsp"
     val bspServerHandleRes = {
       os.makeDir.all(logDir)
       mill.bsp.worker.BspWorkerImpl.startBspServer(
-        define.WorkspaceRoot.workspaceRoot,
+        define.Project.workspaceRoot,
         bspStreams,
         logDir,
         true,

--- a/runner/meta/src/mill/meta/CodeGen.scala
+++ b/runner/meta/src/mill/meta/CodeGen.scala
@@ -106,18 +106,13 @@ object CodeGen {
           millTopLevelProjectRoot = millTopLevelProjectRoot,
           output = output
         )
-        os.write(
-          supportDestDir / "MillMiscInfo.scala",
-          miscInfo,
-          createFolders = true
-        )
 
-        val wrapperObjectGetter = generateWrapperObjectGetter(pkg)
-        os.write(
-          supportDestDir / "BuildFileImpl.scala",
-          wrapperObjectGetter,
-          createFolders = true
-        )
+        os.write(supportDestDir / "MillMiscInfo.scala", miscInfo, createFolders = true)
+
+        if (scriptFolderPath == projectRoot){
+          val buildFileImplCode = generateBuildFileImpl(pkg)
+          os.write(supportDestDir / "BuildFileImpl.scala", buildFileImplCode, createFolders = true)
+        }
       }
 
       val parts =
@@ -183,7 +178,7 @@ object CodeGen {
         |""".stripMargin
   }
 
-  def generateWrapperObjectGetter(pkg: String) = {
+  def generateBuildFileImpl(pkg: String) = {
     s"""|$generatedFileHeader
         |package $pkg
         |

--- a/runner/meta/src/mill/meta/CodeGen.scala
+++ b/runner/meta/src/mill/meta/CodeGen.scala
@@ -109,7 +109,7 @@ object CodeGen {
 
         os.write(supportDestDir / "MillMiscInfo.scala", miscInfo, createFolders = true)
 
-        if (scriptFolderPath == projectRoot){
+        if (scriptFolderPath == projectRoot) {
           val buildFileImplCode = generateBuildFileImpl(pkg)
           os.write(supportDestDir / "BuildFileImpl.scala", buildFileImplCode, createFolders = true)
         }

--- a/runner/meta/src/mill/meta/CodeGen.scala
+++ b/runner/meta/src/mill/meta/CodeGen.scala
@@ -114,7 +114,7 @@ object CodeGen {
 
         val wrapperObjectGetter = generateWrapperObjectGetter(pkg)
         os.write(
-          supportDestDir / "wrapper_object_getter.scala",
+          supportDestDir / "BuildFileImpl.scala",
           wrapperObjectGetter,
           createFolders = true
         )
@@ -187,13 +187,7 @@ object CodeGen {
     s"""|$generatedFileHeader
         |package $pkg
         |
-        |object wrapper_object_getter {
-        |  def value = _root_.os.checker.withValue(
-        |    _root_.mill.define.internal.ResolveChecker(
-        |       _root_.mill.define.WorkspaceRoot.workspaceRoot
-        |    )
-        |  ){ ${CGConst.wrapperObjectName} }
-        |}
+        |object BuildFileImpl extends mill.define.internal.BuildFileCls(${CGConst.wrapperObjectName})
         |""".stripMargin
   }
 

--- a/runner/meta/src/mill/meta/MillBuildRootModule.scala
+++ b/runner/meta/src/mill/meta/MillBuildRootModule.scala
@@ -36,7 +36,7 @@ trait MillBuildRootModule()(implicit
 
   override def scalaVersion: T[String] = BuildInfo.scalaVersion
 
-  val scriptSourcesPaths = mill.define.withFilesystemCheckerDisabled {
+  val scriptSourcesPaths = mill.define.BuildCtx.withFilesystemCheckerDisabled {
     FileImportGraph
       .walkBuildFiles(rootModuleInfo.projectRoot / os.up, rootModuleInfo.output)
       .sorted
@@ -52,7 +52,7 @@ trait MillBuildRootModule()(implicit
 
   def parseBuildFiles: T[FileImportGraph] = Task {
     scriptSources()
-    mill.define.withFilesystemCheckerDisabled {
+    mill.define.BuildCtx.withFilesystemCheckerDisabled {
       MillBuildRootModule.parseBuildFiles(MillScalaParser.current.value, rootModuleInfo)
     }
   }

--- a/runner/meta/src/mill/meta/MillBuildRootModule.scala
+++ b/runner/meta/src/mill/meta/MillBuildRootModule.scala
@@ -36,7 +36,7 @@ trait MillBuildRootModule()(implicit
 
   override def scalaVersion: T[String] = BuildInfo.scalaVersion
 
-  val scriptSourcesPaths = os.checker.withValue(os.Checker.Nop) {
+  val scriptSourcesPaths = mill.define.withFilesystemCheckerDisabled {
     FileImportGraph
       .walkBuildFiles(rootModuleInfo.projectRoot / os.up, rootModuleInfo.output)
       .sorted
@@ -52,7 +52,7 @@ trait MillBuildRootModule()(implicit
 
   def parseBuildFiles: T[FileImportGraph] = Task {
     scriptSources()
-    os.checker.withValue(os.Checker.Nop) {
+    mill.define.withFilesystemCheckerDisabled {
       MillBuildRootModule.parseBuildFiles(MillScalaParser.current.value, rootModuleInfo)
     }
   }

--- a/website/docs/modules/ROOT/pages/depth/caching.adoc
+++ b/website/docs/modules/ROOT/pages/depth/caching.adoc
@@ -100,7 +100,7 @@ However, for code written in a typical Scala style (which tends to avoid side ef
 and limits filesystem operations to the `Task.dest` folder, this is not a problem at all.
 
 One thing to note is for code that runs during *Resolution*: any reading of
-external mutable state needs to be wrapped in an `interp.watchValue{...}`
+external mutable state needs to be wrapped in an `mill.define.BuildCtx.watchValue{...}`
 wrapper. This ensures that Mill knows where these external reads are, so that
 it can check if their value changed and if so re-instantiate `RootModule` with
 the new value.


### PR DESCRIPTION
This PR standardizes the location of APIs that are global to the build on `mill.define.BuildCtx`, meant to be analogous to `EvalCtx` and `ModuleCtx`. Previously they were scattered on `mill.define.WorkspaceApi`,`build.interp`, and some direct calls to `os.checker.withValue`. Now, they all are consolidated under `BuildCtx` where they can be discovered and documented.

Since the `watch` lists aren't conveniently bundled together with `RootModule` anymore, we cannot rely on `RootModuleApi` when passing them around `MillBuildBootstrap`, so I wrapped them in a `BuildFileApi` object to pass them around conveniently. This subsumes the previous `wrapper_object_getter` that we code-gened