### PR TITLE
Rename `TestBaseModule` to `TestRootModule`

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -137,7 +137,7 @@ published with some other suffix via `def extraPublish`
 * Improve performances of Bloop/install ({link-pr}/4600[#4600]) ({link-pr}/4628[#4628])
 * Pass Mill source JARs to Bloop ({link-pr}/4608[#4608])
 * Optimize BSP initialization stuff ({link-pr}/4698[#4698])
-* Make source path configurable in TestBaseModule ({link-pr}/4703[#4703])
+* Make source path configurable in TestRootModule ({link-pr}/4703[#4703])
 
 _For details refer to
 {link-milestone}/{milestone}?closed=1[milestone {milestone-name}]

--- a/contrib/bloop/test/src/mill/contrib/bloop/BloopTests.scala
+++ b/contrib/bloop/test/src/mill/contrib/bloop/BloopTests.scala
@@ -7,7 +7,7 @@
 //import mill.define.Discover
 //import mill.scalanativelib.api.ReleaseMode
 //import mill.testkit.UnitTester
-//import mill.testkit.TestBaseModule
+//import mill.testkit.TestRootModule
 //import os.Path
 //import upickle.default._
 //import utest._
@@ -25,7 +25,7 @@
 //    addMillSources = None
 //  )
 //
-//  object build extends TestBaseModule {
+//  object build extends TestRootModule {
 //    object scalaModule extends scalalib.ScalaModule with testBloop.Module {
 //      def scalaVersion = "2.12.8"
 //      val bloopVersion = mill.contrib.bloop.Versions.bloop

--- a/contrib/buildinfo/test/src/mill/contrib/buildinfo/BuildInfoTests.scala
+++ b/contrib/buildinfo/test/src/mill/contrib/buildinfo/BuildInfoTests.scala
@@ -6,7 +6,7 @@ import mill.kotlinlib.KotlinModule
 import mill.scalalib.ScalaModule
 import mill.scalajslib.ScalaJSModule
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import mill.define.Discover
 import os.Path
 import utest.*
@@ -17,7 +17,7 @@ object BuildInfoTests extends TestSuite {
   val scalaJSVersionString = sys.props.getOrElse("TEST_SCALAJS_VERSION", ???)
   val kotlinVersionString = sys.props.getOrElse("TEST_KOTLIN_VERSION", ???)
 
-  object EmptyBuildInfo extends TestBaseModule with BuildInfo with ScalaModule {
+  object EmptyBuildInfo extends TestRootModule with BuildInfo with ScalaModule {
     def scalaVersion = scalaVersionString
     def buildInfoPackageName = "foo"
     def buildInfoMembers = Seq.empty[BuildInfo.Value]
@@ -25,7 +25,7 @@ object BuildInfoTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object BuildInfoPlain extends TestBaseModule with BuildInfo with ScalaModule {
+  object BuildInfoPlain extends TestRootModule with BuildInfo with ScalaModule {
     def scalaVersion = scalaVersionString
     def buildInfoPackageName = "foo"
     def buildInfoMembers = Seq(
@@ -35,7 +35,7 @@ object BuildInfoTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object BuildInfoScalaJS extends TestBaseModule with BuildInfo with ScalaJSModule {
+  object BuildInfoScalaJS extends TestRootModule with BuildInfo with ScalaJSModule {
     def scalaVersion = scalaVersionString
     def scalaJSVersion = scalaJSVersionString
     def buildInfoPackageName = "foo"
@@ -46,7 +46,7 @@ object BuildInfoTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object BuildInfoComment extends TestBaseModule with BuildInfo with ScalaModule {
+  object BuildInfoComment extends TestRootModule with BuildInfo with ScalaModule {
     def scalaVersion = scalaVersionString
     def buildInfoPackageName = "foo"
     def buildInfoMembers = Seq(
@@ -65,7 +65,7 @@ object BuildInfoTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object BuildInfoStatic extends TestBaseModule with BuildInfo with ScalaModule {
+  object BuildInfoStatic extends TestRootModule with BuildInfo with ScalaModule {
     def scalaVersion = scalaVersionString
     def buildInfoPackageName = "foo"
     override def buildInfoStaticCompiled = true
@@ -76,7 +76,7 @@ object BuildInfoTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object BuildInfoSettings extends TestBaseModule with BuildInfo with ScalaModule {
+  object BuildInfoSettings extends TestRootModule with BuildInfo with ScalaModule {
     def scalaVersion = scalaVersionString
     def buildInfoPackageName = "foo"
     override def buildInfoObjectName = "bar"
@@ -87,7 +87,7 @@ object BuildInfoTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object BuildInfoJava extends TestBaseModule with BuildInfo {
+  object BuildInfoJava extends TestRootModule with BuildInfo {
     def buildInfoPackageName = "foo"
     def buildInfoMembers = Seq(
       BuildInfo.Value("scalaVersion", "not-provided-for-java-modules")
@@ -96,7 +96,7 @@ object BuildInfoTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object BuildInfoJavaStatic extends TestBaseModule with BuildInfo {
+  object BuildInfoJavaStatic extends TestRootModule with BuildInfo {
     def buildInfoPackageName = "foo"
     override def buildInfoStaticCompiled = true
     def buildInfoMembers = Seq(
@@ -106,7 +106,7 @@ object BuildInfoTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object BuildInfoKotlin extends TestBaseModule with KotlinModule with BuildInfo {
+  object BuildInfoKotlin extends TestRootModule with KotlinModule with BuildInfo {
     def kotlinVersion = kotlinVersionString
     // FIXME: the mainClass should be found automatically
     def mainClass = Some("foo.Main")
@@ -118,7 +118,7 @@ object BuildInfoTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object BuildInfoKotlinStatic extends TestBaseModule with KotlinModule with BuildInfo {
+  object BuildInfoKotlinStatic extends TestRootModule with KotlinModule with BuildInfo {
     def kotlinVersion = kotlinVersionString
     // FIXME: the mainClass should be found automatically
     def mainClass = Some("foo.Main")

--- a/contrib/docker/test/src/mill/contrib/docker/DockerModuleTest.scala
+++ b/contrib/docker/test/src/mill/contrib/docker/DockerModuleTest.scala
@@ -5,7 +5,7 @@ import mill.scalalib.JavaModule
 import mill.api.ExecResult
 import mill.define.Discover
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import os.Path
 import utest.*
 import utest.framework.TestPath
@@ -16,7 +16,7 @@ object DockerModuleTest extends TestSuite {
     if (isInstalled("podman")) "podman"
     else "docker"
 
-  object Docker extends TestBaseModule with JavaModule with DockerModule {
+  object Docker extends TestRootModule with JavaModule with DockerModule {
 
     override def artifactName = testArtifactName
 
@@ -62,7 +62,7 @@ object DockerModuleTest extends TestSuite {
     os.proc(getPathCmd, executable).call(check = false).exitCode == 0
   }
 
-  private def workspaceTest(m: mill.testkit.TestBaseModule)(t: UnitTester => Unit)(
+  private def workspaceTest(m: mill.testkit.TestRootModule)(t: UnitTester => Unit)(
       implicit tp: TestPath
   ): Unit = {
     if (isInstalled(testExecutable) && !scala.util.Properties.isWin)

--- a/contrib/flyway/test/src/mill/contrib/flyway/BuildTest.scala
+++ b/contrib/flyway/test/src/mill/contrib/flyway/BuildTest.scala
@@ -4,12 +4,12 @@ import mill.*
 import mill.define.Discover
 import mill.scalalib.*
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import utest.{TestSuite, Tests, assert, *}
 
 object BuildTest extends TestSuite {
 
-  object Build extends TestBaseModule {
+  object Build extends TestRootModule {
     object build extends FlywayModule {
 
       val resourceFolder = os.Path(sys.env("MILL_TEST_RESOURCE_DIR"))

--- a/contrib/gitlab/test/src/mill/contrib/gitlab/GitlabModuleTests.scala
+++ b/contrib/gitlab/test/src/mill/contrib/gitlab/GitlabModuleTests.scala
@@ -5,7 +5,7 @@ import mill.api.ExecResult.Failure
 import mill.define.Discover
 import mill.scalalib.publish.PomSettings
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import utest.{TestSuite, Tests, assertMatch, test}
 import mill.util.TokenReaders._
 object GitlabModuleTests extends TestSuite {
@@ -14,7 +14,7 @@ object GitlabModuleTests extends TestSuite {
     override def tokenSearchOrder = Seq.empty
   }
 
-  object GitlabModule extends TestBaseModule with GitlabPublishModule {
+  object GitlabModule extends TestRootModule with GitlabPublishModule {
     override def publishRepository: ProjectRepository =
       ProjectRepository("http://gitlab.local", 0)
 
@@ -30,7 +30,7 @@ object GitlabModuleTests extends TestSuite {
 
   // GitlabMavenRepository does not need to be a module, but it needs to be invoked from one.
   // So for test purposes we make a module with it to get a Ctx for evaluation
-  object GLMvnRepo extends TestBaseModule with GitlabMavenRepository {
+  object GLMvnRepo extends TestRootModule with GitlabMavenRepository {
     override def gitlabRepository: GitlabPackageRepository =
       InstanceRepository("https://gl.local")
 

--- a/contrib/jmh/test/src/mill/contrib/jmh/JmhModuleTest.scala
+++ b/contrib/jmh/test/src/mill/contrib/jmh/JmhModuleTest.scala
@@ -5,13 +5,13 @@ import mill.define.Discover
 import mill.define.ExecutionPaths
 import mill.scalalib.ScalaModule
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import os.Path
 import utest.*
 
 object JmhModuleTest extends TestSuite {
 
-  object jmh extends TestBaseModule with ScalaModule with JmhModule {
+  object jmh extends TestRootModule with ScalaModule with JmhModule {
 
     override def scalaVersion = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
     override def jmhCoreVersion = "1.35"

--- a/contrib/playlib/test/src/mill/playlib/PlayModuleTests.scala
+++ b/contrib/playlib/test/src/mill/playlib/PlayModuleTests.scala
@@ -2,13 +2,13 @@ package mill
 package playlib
 
 import mill.scalalib.api.JvmWorkerUtil
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import utest.{TestSuite, Tests, assert, _}
 import mill.define.Discover
 
 object PlayModuleTests extends TestSuite with PlayTestSuite {
 
-  object playmulti extends TestBaseModule {
+  object playmulti extends TestRootModule {
     object core extends Cross[CoreCrossModule](matrix)
     trait CoreCrossModule extends PlayModule with Cross.Module2[String, String] {
       val (crossScalaVersion, crossPlayVersion) = (crossValue, crossValue2)

--- a/contrib/playlib/test/src/mill/playlib/PlaySingleApiModuleTests.scala
+++ b/contrib/playlib/test/src/mill/playlib/PlaySingleApiModuleTests.scala
@@ -1,13 +1,13 @@
 package mill.playlib
 
 import mill.Task
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import utest.{TestSuite, Tests, assert, _}
 import mill.define.Discover
 import mill.util.TokenReaders._
 object PlaySingleApiModuleTests extends TestSuite with PlayTestSuite {
 
-  object playsingleapi extends TestBaseModule with PlayApiModule {
+  object playsingleapi extends TestRootModule with PlayApiModule {
     override val moduleDir = os.temp() // workaround problem in `SingleModule`
     override def playVersion = Task { testPlay28 }
     override def scalaVersion = Task { "2.13.12" }

--- a/contrib/playlib/test/src/mill/playlib/PlaySingleModuleTests.scala
+++ b/contrib/playlib/test/src/mill/playlib/PlaySingleModuleTests.scala
@@ -2,12 +2,12 @@ package mill.playlib
 
 import mill.define.Discover
 import mill.Task
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import utest.{TestSuite, Tests, assert, _}
 import mill.util.TokenReaders._
 object PlaySingleModuleTests extends TestSuite with PlayTestSuite {
 
-  object playsingle extends TestBaseModule with PlayModule {
+  object playsingle extends TestRootModule with PlayModule {
     override val moduleDir = os.temp() // workaround problem in `SingleModule`
     override def playVersion = Task { testPlay28 }
     override def scalaVersion = Task { sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???) }

--- a/contrib/playlib/test/src/mill/playlib/RouterModuleTests.scala
+++ b/contrib/playlib/test/src/mill/playlib/RouterModuleTests.scala
@@ -3,12 +3,12 @@ package mill.playlib
 import mill.api.ExecResult
 import mill.define.{Cross, Discover}
 import mill.scalalib.ScalaModule
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import utest.{TestSuite, Tests, assert, _}
 import mill.util.TokenReaders._
 object RouterModuleTests extends TestSuite with PlayTestSuite {
 
-  trait HelloBase extends TestBaseModule
+  trait HelloBase extends TestRootModule
 
   trait HelloWorldModule extends mill.playlib.RouterModule with ScalaModule
 

--- a/contrib/proguard/test/src/mill/contrib/proguard/ProguardTests.scala
+++ b/contrib/proguard/test/src/mill/contrib/proguard/ProguardTests.scala
@@ -3,14 +3,14 @@ package mill.contrib.proguard
 import mill.*
 import mill.define.{Discover, Target}
 import mill.scalalib.ScalaModule
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import mill.util.Jvm
 import os.Path
 import utest.*
 
 object ProguardTests extends TestSuite {
 
-  object proguard extends TestBaseModule with ScalaModule with Proguard {
+  object proguard extends TestRootModule with ScalaModule with Proguard {
     // TODO: This test works for a Scala 2.13 App, but not for a Scala 3 App, probably due to tasty files
     override def scalaVersion: T[String] = Task.Input {
       sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)

--- a/contrib/scalapblib/test/src/mill/contrib/scalapblib/TutorialTests.scala
+++ b/contrib/scalapblib/test/src/mill/contrib/scalapblib/TutorialTests.scala
@@ -5,13 +5,13 @@ import mill.define.PathRef
 import mill.constants.Util
 import mill.define.Discover
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import utest.{TestSuite, Tests, assert, *}
 
 object TutorialTests extends TestSuite {
   val testScalaPbVersion = "0.11.7"
 
-  trait TutorialBase extends TestBaseModule
+  trait TutorialBase extends TestRootModule
 
   trait TutorialModule extends ScalaPBModule {
     def scalaVersion = sys.props.getOrElse("TEST_SCALA_2_12_VERSION", ???)

--- a/contrib/scoverage/test/src/mill/contrib/scoverage/HelloWorldTests.scala
+++ b/contrib/scoverage/test/src/mill/contrib/scoverage/HelloWorldTests.scala
@@ -6,7 +6,7 @@ import mill.contrib.buildinfo.BuildInfo
 import mill.define.Discover
 import mill.scalalib.{DepSyntax, SbtModule, ScalaModule, TestModule}
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import utest.*
 
 trait HelloWorldTests extends utest.TestSuite {
@@ -25,7 +25,7 @@ trait HelloWorldTests extends utest.TestSuite {
   val sbtResourcePath = resourcePath / os.up / "hello-world-sbt"
   val unmanagedFile = resourcePath / "unmanaged.xml"
 
-  object HelloWorld extends TestBaseModule {
+  object HelloWorld extends TestRootModule {
     object other extends ScalaModule {
       def scalaVersion = testScalaVersion
     }
@@ -52,7 +52,7 @@ trait HelloWorldTests extends utest.TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object HelloWorldSbt extends TestBaseModule {
+  object HelloWorldSbt extends TestRootModule {
     object core extends SbtModule with ScoverageModule {
       def scalaVersion = testScalaVersion
       def scoverageVersion = testScoverageVersion

--- a/contrib/testng/test/src/mill/testng/TestNGTests.scala
+++ b/contrib/testng/test/src/mill/testng/TestNGTests.scala
@@ -4,12 +4,12 @@ import mill.*
 import mill.define.{Discover, Target}
 import mill.scalalib.*
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import utest.*
 
 object TestNGTests extends TestSuite {
 
-  object demo extends TestBaseModule with JavaModule {
+  object demo extends TestRootModule with JavaModule {
 
     object test extends JavaTests {
       override def runMvnDeps = super.runMvnDeps() ++ Seq(

--- a/contrib/twirllib/test/src/mill/twirllib/HelloWorldTests.scala
+++ b/contrib/twirllib/test/src/mill/twirllib/HelloWorldTests.scala
@@ -2,7 +2,7 @@ package mill.twirllib
 
 import mill.define.Discover
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import utest.{TestSuite, Tests, assert, *}
 
 trait HelloWorldTests extends TestSuite {
@@ -13,7 +13,7 @@ trait HelloWorldTests extends TestSuite {
     def twirlVersion = testTwirlVersion
   }
 
-  object HelloWorld extends TestBaseModule {
+  object HelloWorld extends TestRootModule {
 
     object core extends HelloWorldModule {
       override def twirlImports = super.twirlImports() ++ testAdditionalImports
@@ -24,7 +24,7 @@ trait HelloWorldTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object HelloWorldWithInclusiveDot extends TestBaseModule {
+  object HelloWorldWithInclusiveDot extends TestRootModule {
 
     object core extends HelloWorldModule {
       override def twirlInclusiveDot: Boolean = true

--- a/contrib/versionfile/test/src/mill/contrib/versionfile/VersionFileModuleTests.scala
+++ b/contrib/versionfile/test/src/mill/contrib/versionfile/VersionFileModuleTests.scala
@@ -1,18 +1,18 @@
 package mill.contrib.versionfile
 
 import mill.Task
-import mill.testkit.{UnitTester, TestBaseModule}
+import mill.testkit.{UnitTester, TestRootModule}
 import utest.{TestSuite, Tests, assert, test}
 import mill.util.TokenReaders._
 import mill.define.Discover
 object VersionFileModuleTests extends TestSuite {
 
-  object TestModule extends TestBaseModule {
+  object TestModule extends TestRootModule {
     case object versionFile extends VersionFileModule
     lazy val millDiscover = Discover[this.type]
   }
 
-  def evaluator[T, M <: mill.testkit.TestBaseModule](
+  def evaluator[T, M <: mill.testkit.TestRootModule](
       m: M,
       vf: M => VersionFileModule,
       versionText: String

--- a/core/define/test/src/mill/define/BasePathTests.scala
+++ b/core/define/test/src/mill/define/BasePathTests.scala
@@ -1,12 +1,12 @@
 package mill.define
 
 import mill.util.TestGraphs
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import utest._
 
 object BasePathTests extends TestSuite {
 
-  object overriddenBasePath extends TestBaseModule {
+  object overriddenBasePath extends TestRootModule {
     override def moduleDir = os.pwd / "overriddenBasePathRootValue"
     object nested extends Module {
       override def moduleDir = super.moduleDir / "overriddenBasePathNested"

--- a/core/define/test/src/mill/define/CacherTests.scala
+++ b/core/define/test/src/mill/define/CacherTests.scala
@@ -1,7 +1,7 @@
 package mill.define
 
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import mill.Task
 import mill.api.Result.Success
 import utest._
@@ -11,7 +11,7 @@ object CacherTests extends TestSuite {
   object Base extends Base {
     lazy val millDiscover = Discover[this.type]
   }
-  trait Base extends TestBaseModule {
+  trait Base extends TestRootModule {
     def value = Task { 1 }
     def result = Task { Success(1) }
   }
@@ -30,7 +30,7 @@ object CacherTests extends TestSuite {
   }
 
   val tests = Tests {
-    def eval[T <: mill.testkit.TestBaseModule, V](mapping: T, v: Task[V])(implicit tp: TestPath) = {
+    def eval[T <: mill.testkit.TestRootModule, V](mapping: T, v: Task[V])(implicit tp: TestPath) = {
       UnitTester(mapping, null).scoped { evaluator =>
         evaluator(v).toOption.get.value
       }

--- a/core/define/test/src/mill/define/MacroErrorTests.scala
+++ b/core/define/test/src/mill/define/MacroErrorTests.scala
@@ -1,7 +1,7 @@
 package mill.define
 
 import utest._
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 object MacroErrorTests extends TestSuite {
 
   val tests = Tests {
@@ -10,14 +10,14 @@ object MacroErrorTests extends TestSuite {
       val expectedMsg =
         "Task{} members must be defs defined in a Module class/trait/object body"
 
-      val err = compileError("object Foo extends TestBaseModule{ val x = Task {1} }")
+      val err = compileError("object Foo extends TestRootModule{ val x = Task {1} }")
       assert(err.msg == expectedMsg)
     }
 
     test("badParameterSets") {
       test("command") {
         val e = compileError("""
-          object foo extends TestBaseModule{
+          object foo extends TestRootModule{
             def w = Task.Command{1}
             lazy val millDiscover = Discover[this.type]
           }
@@ -31,7 +31,7 @@ object MacroErrorTests extends TestSuite {
 
       test("target") {
         val e = compileError("""
-          object foo extends TestBaseModule{
+          object foo extends TestRootModule{
             def x() = Task {1}
             lazy val millDiscover = Discover[this.type]
           }
@@ -44,7 +44,7 @@ object MacroErrorTests extends TestSuite {
       }
       test("input") {
         val e = compileError("""
-          object foo extends TestBaseModule{
+          object foo extends TestRootModule{
             def y() = Task.Input{1}
             lazy val millDiscover = Discover[this.type]
           }
@@ -57,7 +57,7 @@ object MacroErrorTests extends TestSuite {
       }
       test("sources") {
         val e = compileError("""
-          object foo extends TestBaseModule{
+          object foo extends TestRootModule{
             def z() = Task.Sources{os.pwd}
             lazy val millDiscover = Discover[this.type]
           }
@@ -70,7 +70,7 @@ object MacroErrorTests extends TestSuite {
       }
       test("persistent") {
         val e = compileError("""
-          object foo extends TestBaseModule{
+          object foo extends TestRootModule{
             def a() = Task(persistent = true){1}
             lazy val millDiscover = Discover[this.type]
           }
@@ -88,7 +88,7 @@ object MacroErrorTests extends TestSuite {
       // come from inside the Task{...} block
       test("pos") {
         // This should compile
-        object foo extends TestBaseModule {
+        object foo extends TestRootModule {
           def a = Task { 1 }
           val arr = Array(a)
           def b = {
@@ -108,7 +108,7 @@ object MacroErrorTests extends TestSuite {
       }
 
       test("neg2") {
-        val e = compileError("object foo extends TestBaseModule{ val a = Task { 1 } }")
+        val e = compileError("object foo extends TestRootModule{ val a = Task { 1 } }")
         assert(e.msg.contains(
           "Task{} members must be defs defined in a Module class/trait/object body"
         ))
@@ -118,7 +118,7 @@ object MacroErrorTests extends TestSuite {
         val expectedMsg =
           "Target#apply() call cannot use `val n` defined within the Task{...} block"
         val err = compileError("""
-          object foo extends TestBaseModule{
+          object foo extends TestRootModule{
             def a = Task { 1 }
             val arr = Array(a)
             def b = {
@@ -137,7 +137,7 @@ object MacroErrorTests extends TestSuite {
         val expectedMsg =
           "Target#apply() call cannot use `val x` defined within the Task{...} block"
         val err = compileError("""
-          object foo extends TestBaseModule{
+          object foo extends TestRootModule{
             def a = Task { 1 }
             val arr = Array(a)
             def b = {
@@ -168,7 +168,7 @@ object MacroErrorTests extends TestSuite {
     test("badCrossKeys") {
       val error = utest.compileError(
         """
-        object foo extends TestBaseModule{
+        object foo extends TestRootModule{
           object cross extends Cross[MyCrossModule](Seq(1, 2, 3))
           trait MyCrossModule extends Cross.Module[String]
           lazy val millDiscover = Discover[this.type]
@@ -183,7 +183,7 @@ object MacroErrorTests extends TestSuite {
     test("badCrossKeys2") {
       val error = utest.compileError(
         """
-        object foo extends TestBaseModule{
+        object foo extends TestRootModule{
           object cross extends Cross[MyCrossModule](Seq((1, 2), (2, 2), (3, 3)))
           trait MyCrossModule extends Cross.Module2[String, Boolean]
           lazy val millDiscover = Discover[this.type]
@@ -204,7 +204,7 @@ object MacroErrorTests extends TestSuite {
     test("invalidCrossType") {
       val error = utest.compileError(
         """
-        object foo extends TestBaseModule{
+        object foo extends TestRootModule{
           object cross extends Cross[MyCrossModule](null.asInstanceOf[sun.misc.Unsafe])
           trait MyCrossModule extends Cross.Module[sun.misc.Unsafe]
           lazy val millDiscover = Discover[this.type]

--- a/core/exec/test/src/mill/exec/Checker.scala
+++ b/core/exec/test/src/mill/exec/Checker.scala
@@ -1,11 +1,11 @@
 package mill.exec
 
 import mill.define.Task
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 
 import utest.*
 
-class Checker[T <: mill.testkit.TestBaseModule](
+class Checker[T <: mill.testkit.TestRootModule](
     module: T,
     threadCount: Option[Int] = Some(1),
     sourceRoot: os.Path = null

--- a/core/exec/test/src/mill/exec/CrossTests.scala
+++ b/core/exec/test/src/mill/exec/CrossTests.scala
@@ -2,7 +2,7 @@ package mill.exec
 
 import mill.define.Discover
 import mill.{Cross, Task}
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import mill.testkit.UnitTester.Result
 import mill.util.TestGraphs
 import mill.util.TestGraphs.{crossResolved, doubleCross, nestedCrosses, nonStringCross, singleCross}
@@ -10,7 +10,7 @@ import utest.*
 
 object CrossTests extends TestSuite {
 
-  object crossExtension extends TestBaseModule {
+  object crossExtension extends TestRootModule {
     object myCross extends Cross[MyCrossModule]("a", "b")
     trait MyCrossModule extends Cross.Module[String] {
       def param1 = Task { "Param Value: " + crossValue }
@@ -30,7 +30,7 @@ object CrossTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object innerCrossModule extends TestBaseModule {
+  object innerCrossModule extends TestRootModule {
     object myCross extends Cross[MyCrossModule]("a", "b")
     trait MyCrossModule extends Cross.Module[String] {
       object foo extends CrossValue {

--- a/core/exec/test/src/mill/exec/ExecutionTests.scala
+++ b/core/exec/test/src/mill/exec/ExecutionTests.scala
@@ -2,12 +2,12 @@ package mill.exec
 
 import mill.define.{Discover, TargetImpl, Task}
 import mill.util.TestGraphs
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import mill.{PathRef, exec}
 import utest.*
 
 object ExecutionTests extends TestSuite {
-  object traverseBuild extends TestBaseModule {
+  object traverseBuild extends TestRootModule {
     trait TaskModule extends mill.Module {
       def x = 1
       def task = Task { x }
@@ -26,13 +26,13 @@ object ExecutionTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object anonTaskFailure extends TestBaseModule {
+  object anonTaskFailure extends TestRootModule {
     def anon = Task.Anon[Int] { throw new Exception("boom") }
 
     def task = Task[Int] { anon() }
     lazy val millDiscover = Discover[this.type]
   }
-  class Checker[T <: mill.testkit.TestBaseModule](module: T)
+  class Checker[T <: mill.testkit.TestRootModule](module: T)
       extends exec.Checker(module)
 
   val tests = Tests {
@@ -45,7 +45,7 @@ object ExecutionTests extends TestSuite {
     }
 
     test("source") {
-      object build extends TestBaseModule {
+      object build extends TestRootModule {
         def source = Task.Source { "hello/world.txt" }
         def task = Task { os.read(source().path) + " !" }
         lazy val millDiscover = Discover[this.type]
@@ -80,7 +80,7 @@ object ExecutionTests extends TestSuite {
       )
     }
     test("sources") {
-      object build extends TestBaseModule {
+      object build extends TestRootModule {
         def source = Task.Sources("hello/world.txt", "hello/world2.txt")
         def task = Task { source().map(pr => os.read(pr.path)).mkString + "!" }
         lazy val millDiscover = Discover[this.type]
@@ -126,7 +126,7 @@ object ExecutionTests extends TestSuite {
 
     test("input") {
       var x = 10
-      object build extends TestBaseModule {
+      object build extends TestRootModule {
         def input = Task.Input { x }
         def task = Task { input() + 1 }
         lazy val millDiscover = Discover[this.type]
@@ -150,7 +150,7 @@ object ExecutionTests extends TestSuite {
 
     test("dest") {
       var x = 10
-      object build extends TestBaseModule {
+      object build extends TestRootModule {
         def input = Task.Input { x }
         def task = Task {
           assert(!os.exists(Task.dest / "file.txt"))
@@ -182,7 +182,7 @@ object ExecutionTests extends TestSuite {
 
     test("persistent") {
       var x = 10
-      object build extends TestBaseModule {
+      object build extends TestRootModule {
         def input = Task.Input { x }
         def task = Task(persistent = true) {
           val file = Task.dest / "file.txt"
@@ -222,7 +222,7 @@ object ExecutionTests extends TestSuite {
         var closed = false
       }
 
-      object build extends TestBaseModule {
+      object build extends TestRootModule {
         def input = Task.Input { x }
         def worker = Task.Worker { new MyWorker(input()) }
         lazy val millDiscover = Discover[this.type]
@@ -246,7 +246,7 @@ object ExecutionTests extends TestSuite {
     test("command") {
       var x = 10
       var y = 0
-      object build extends TestBaseModule {
+      object build extends TestRootModule {
         def input = Task.Input { x }
         def command(n: Int) = Task.Command { y += input() + n }
         lazy val millDiscover = Discover[this.type]
@@ -268,7 +268,7 @@ object ExecutionTests extends TestSuite {
     test("anon") {
       var x = 10
       var y = 0
-      object build extends TestBaseModule {
+      object build extends TestRootModule {
         def input = Task.Input { x }
         def anon = Task.Anon { y += input() }
         lazy val millDiscover = Discover[this.type]
@@ -290,7 +290,7 @@ object ExecutionTests extends TestSuite {
     test("error") {
       var x = 10
       var y = 0
-      object build extends TestBaseModule {
+      object build extends TestRootModule {
         def input = Task.Input { x }
         def task = Task { y += 100 / input() }
         lazy val millDiscover = Discover[this.type]
@@ -307,7 +307,7 @@ object ExecutionTests extends TestSuite {
     }
 
     test("sequence") {
-      object build extends TestBaseModule {
+      object build extends TestRootModule {
         def task1 = Task { 1 }
         def task2 = Task { 10 }
         def task3 = Task { 100 }
@@ -325,7 +325,7 @@ object ExecutionTests extends TestSuite {
     }
 
     test("zip") {
-      object build extends TestBaseModule {
+      object build extends TestRootModule {
         def task1 = Task { 1 }
         def task2 = Task { 10 }
         def task4 = task1.zip(task2)
@@ -337,7 +337,7 @@ object ExecutionTests extends TestSuite {
     }
 
     test("map") {
-      object build extends TestBaseModule {
+      object build extends TestRootModule {
         def task1 = Task { 1 }
         def task2 = task1.map(_ + 10)
 
@@ -375,7 +375,7 @@ object ExecutionTests extends TestSuite {
 
     test("nullTasks") {
 
-      object nullTasks extends TestBaseModule {
+      object nullTasks extends TestRootModule {
         val nullString: String = null
         def nullTask1 = Task.Anon { nullString }
         def nullTask2 = Task.Anon { nullTask1() }

--- a/core/exec/test/src/mill/exec/JavaCompileJarTests.scala
+++ b/core/exec/test/src/mill/exec/JavaCompileJarTests.scala
@@ -3,7 +3,7 @@ package mill.exec
 import mill.util.Jvm
 import mill.define.TaskCtx.Dest
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 
 import mill.util.JarManifest
 
@@ -26,7 +26,7 @@ object JavaCompileJarTests extends TestSuite {
   val tests = Tests {
 
     test("javac") {
-      object Build extends TestBaseModule {
+      object Build extends TestRootModule {
         def sourceRootPath: os.SubPath = "src"
         def readmePath: os.SubPath = "readme.md"
         def resourceRootPath: os.SubPath = "resources"

--- a/core/exec/test/src/mill/exec/ModuleTests.scala
+++ b/core/exec/test/src/mill/exec/ModuleTests.scala
@@ -2,7 +2,7 @@ package mill.exec
 
 import mill.testkit.UnitTester
 import mill.testkit.UnitTester.Result
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import mill.Task
 import mill.define.Discover
 import mill.define.ExternalModule
@@ -25,7 +25,7 @@ object TestExternalModule extends mill.define.ExternalModule with mill.define.Ta
 }
 
 object ModuleTests extends TestSuite {
-  object Build extends TestBaseModule {
+  object Build extends TestRootModule {
     def z = Task { TestExternalModule.x() + TestExternalModule.inner.y() }
     lazy val millDiscover = Discover[this.type]
   }

--- a/core/exec/test/src/mill/exec/OverrideTests.scala
+++ b/core/exec/test/src/mill/exec/OverrideTests.scala
@@ -2,7 +2,7 @@ package mill.exec
 
 import mill.define.{Discover, TargetImpl, Task}
 import mill.Module
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 
 import utest.*
 
@@ -12,13 +12,13 @@ object OverrideTests extends TestSuite {
     def cmd(i: Int) = Task.Command { Seq("base" + i) }
   }
 
-  object canOverrideSuper extends TestBaseModule with BaseModule {
+  object canOverrideSuper extends TestRootModule with BaseModule {
     override def foo = Task { super.foo() ++ Seq("object") }
     override def cmd(i: Int) = Task.Command { super.cmd(i)() ++ Seq("object" + i) }
     lazy val millDiscover = Discover[this.type]
   }
 
-  object StackableOverrides extends TestBaseModule {
+  object StackableOverrides extends TestRootModule {
     trait X extends Module {
       def f = Task { 1 }
     }
@@ -33,7 +33,7 @@ object OverrideTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object StackableOverrides2 extends TestBaseModule {
+  object StackableOverrides2 extends TestRootModule {
     object A extends Module {
       trait X extends Module {
         def f = Task { 1 }
@@ -51,7 +51,7 @@ object OverrideTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object StackableOverrides3 extends TestBaseModule {
+  object StackableOverrides3 extends TestRootModule {
     object A extends Module {
       trait X extends Module {
         def f = Task { 1 }
@@ -67,7 +67,7 @@ object OverrideTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object OptionalOverride extends TestBaseModule {
+  object OptionalOverride extends TestRootModule {
     trait X extends Module {
       def f = Task { 1 }
     }
@@ -78,7 +78,7 @@ object OverrideTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object PrivateTasksInMixedTraits extends TestBaseModule {
+  object PrivateTasksInMixedTraits extends TestRootModule {
     trait M1 extends Module {
       private def foo = Task { "foo-m1" }
       def bar = Task { foo() }

--- a/core/exec/test/src/mill/exec/TaskTests.scala
+++ b/core/exec/test/src/mill/exec/TaskTests.scala
@@ -5,12 +5,12 @@ import mill.Task
 import mill.define.{Discover, Module, Worker}
 import mill.testkit.UnitTester
 import mill.testkit.UnitTester.Result
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import utest.framework.TestPath
 import mill.api.ExecResult
 
 trait TaskTests extends TestSuite {
-  trait SuperBuild extends TestBaseModule {
+  trait SuperBuild extends TestRootModule {
 
     var superBuildInputCount = 0
 

--- a/core/resolve/test/src/mill/resolve/ErrorTests.scala
+++ b/core/resolve/test/src/mill/resolve/ErrorTests.scala
@@ -1,7 +1,7 @@
 package mill.resolve
 
 import mill.define.{Discover, ModuleRef}
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import mainargs.arg
 import mill.{Cross, Module, Task}
 import utest.*
@@ -10,7 +10,7 @@ import mill.api.Result
 object ErrorTests extends TestSuite {
   // Wrapper class so that module initialization errors are not fatal
   class ErrorGraphs {
-    object moduleInitError extends TestBaseModule {
+    object moduleInitError extends TestRootModule {
       def rootTarget = Task { println("Running rootTarget"); "rootTarget Result" }
       def rootCommand(@arg(positional = true) s: String) =
         Task.Command { println(s"Running rootCommand $s") }
@@ -38,7 +38,7 @@ object ErrorTests extends TestSuite {
       lazy val millDiscover = Discover[this.type]
     }
 
-    object moduleDependencyInitError extends TestBaseModule {
+    object moduleDependencyInitError extends TestRootModule {
 
       object foo extends Module {
         def fooTarget = Task { println(s"Running fooTarget"); 123 }
@@ -61,7 +61,7 @@ object ErrorTests extends TestSuite {
       lazy val millDiscover = Discover[this.type]
     }
 
-    object crossModuleSimpleInitError extends TestBaseModule {
+    object crossModuleSimpleInitError extends TestRootModule {
       object myCross extends Cross[MyCross](1, 2, 3, 4) {
         throw new Exception(s"MyCross Boom")
       }
@@ -71,7 +71,7 @@ object ErrorTests extends TestSuite {
 
       lazy val millDiscover = Discover[this.type]
     }
-    object crossModulePartialInitError extends TestBaseModule {
+    object crossModulePartialInitError extends TestRootModule {
       object myCross extends Cross[MyCross](1, 2, 3, 4)
       trait MyCross extends Cross.Module[Int] {
         if (crossValue > 2) throw new Exception(s"MyCross Boom $crossValue")
@@ -80,7 +80,7 @@ object ErrorTests extends TestSuite {
 
       lazy val millDiscover = Discover[this.type]
     }
-    object crossModuleSelfInitError extends TestBaseModule {
+    object crossModuleSelfInitError extends TestRootModule {
       object myCross extends Cross[MyCross](1, 2, 3, throw new Exception(s"MyCross Boom"))
       trait MyCross extends Cross.Module[Int] {
         def foo = Task { crossValue }
@@ -89,7 +89,7 @@ object ErrorTests extends TestSuite {
       lazy val millDiscover = Discover[this.type]
     }
 
-    object crossModuleParentInitError extends TestBaseModule {
+    object crossModuleParentInitError extends TestRootModule {
       object parent extends Module {
         throw new Exception(s"Parent Boom")
         object myCross extends Cross[MyCross](1, 2, 3, 4)
@@ -102,7 +102,7 @@ object ErrorTests extends TestSuite {
     }
 
     // The module names repeat, but it's not actually cyclic and is meant to confuse the cycle detection.
-    object NonCyclicModules extends TestBaseModule {
+    object NonCyclicModules extends TestRootModule {
       def foo = Task { "foo" }
 
       object A extends Module {
@@ -126,7 +126,7 @@ object ErrorTests extends TestSuite {
       lazy val millDiscover = Discover[this.type]
     }
 
-    object CyclicModuleRefInitError extends TestBaseModule {
+    object CyclicModuleRefInitError extends TestRootModule {
       def foo = Task { "foo" }
 
       // See issue: https://github.com/com-lihaoyi/mill/issues/3715
@@ -146,13 +146,13 @@ object ErrorTests extends TestSuite {
       lazy val millDiscover = Discover[this.type]
     }
 
-    object CyclicModuleRefInitError2 extends TestBaseModule {
+    object CyclicModuleRefInitError2 extends TestRootModule {
       // The cycle is in the child
       def A = CyclicModuleRefInitError
       lazy val millDiscover = Discover[this.type]
     }
 
-    object CyclicModuleRefInitError3 extends TestBaseModule {
+    object CyclicModuleRefInitError3 extends TestRootModule {
       // The cycle is in directly here
       object A extends Module {
         def b = B
@@ -163,7 +163,7 @@ object ErrorTests extends TestSuite {
       lazy val millDiscover = Discover[this.type]
     }
 
-    object CrossedCyclicModuleRefInitError extends TestBaseModule {
+    object CrossedCyclicModuleRefInitError extends TestRootModule {
       object cross extends mill.Cross[Cross]("210", "211", "212")
       trait Cross extends Cross.Module[String] {
         def suffix = Task { crossValue }
@@ -180,7 +180,7 @@ object ErrorTests extends TestSuite {
     }
 
     // This edge case shouldn't be an error
-    object ModuleRefWithNonModuleRefChild extends TestBaseModule {
+    object ModuleRefWithNonModuleRefChild extends TestRootModule {
       def foo = Task { "foo" }
 
       def aRef = A
@@ -191,7 +191,7 @@ object ErrorTests extends TestSuite {
       lazy val millDiscover = Discover[this.type]
     }
 
-    object ModuleRefCycle extends TestBaseModule {
+    object ModuleRefCycle extends TestRootModule {
       def foo = Task { "foo" }
 
       // The cycle is in directly here

--- a/core/resolve/test/src/mill/resolve/ModuleTests.scala
+++ b/core/resolve/test/src/mill/resolve/ModuleTests.scala
@@ -2,7 +2,7 @@ package mill.resolve
 
 import mill.api.Result
 import mill.define.{Discover, ModuleRef, NamedTask, TaskModule}
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import mill.define.DynamicModule
 import mill.util.TestGraphs
 import mill.util.TestGraphs.*
@@ -11,7 +11,7 @@ import utest.*
 
 object ModuleTests extends TestSuite {
 
-  object duplicates extends TestBaseModule {
+  object duplicates extends TestRootModule {
     object wrapper extends Module {
       object test1 extends Module {
         def test1 = Task {}
@@ -37,7 +37,7 @@ object ModuleTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object TypedModules extends TestBaseModule {
+  object TypedModules extends TestRootModule {
     trait TypeA extends Module {
       def foo = Task { "foo" }
     }
@@ -58,7 +58,7 @@ object ModuleTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object TypedCrossModules extends TestBaseModule {
+  object TypedCrossModules extends TestRootModule {
     trait TypeA extends Cross.Module[String] {
       def foo = Task { crossValue }
     }
@@ -84,7 +84,7 @@ object ModuleTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object TypedInnerModules extends TestBaseModule {
+  object TypedInnerModules extends TestRootModule {
     trait TypeA extends Module {
       def foo = Task { "foo" }
     }
@@ -101,7 +101,7 @@ object ModuleTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object AbstractModule extends TestBaseModule {
+  object AbstractModule extends TestRootModule {
     trait Abstract extends Module {
       lazy val tests: Tests = new Tests {}
       trait Tests extends Module {}
@@ -121,7 +121,7 @@ object ModuleTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object overrideModule extends TestBaseModule {
+  object overrideModule extends TestRootModule {
     trait Base extends Module {
       lazy val inner: BaseInnerModule = new BaseInnerModule {}
       lazy val ignored: ModuleRef[BaseInnerModule] = ModuleRef(new BaseInnerModule {})
@@ -140,7 +140,7 @@ object ModuleTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object dynamicModule extends TestBaseModule {
+  object dynamicModule extends TestRootModule {
     object normal extends DynamicModule {
       object inner extends Module {
         def target = Task { 1 }

--- a/core/resolve/test/src/mill/resolve/ResolveTests.scala
+++ b/core/resolve/test/src/mill/resolve/ResolveTests.scala
@@ -4,12 +4,12 @@ import mill.api.Result
 import mill.define.Discover
 import mill.util.TestGraphs
 import mill.util.TestGraphs.*
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import mill.{Module, Task}
 import utest.*
 object ResolveTests extends TestSuite {
 
-  object doubleNestedModule extends TestBaseModule {
+  object doubleNestedModule extends TestRootModule {
     def single = Task { 5 }
     object nested extends Module {
       def single = Task { 7 }

--- a/core/resolve/test/src/mill/resolve/TypeSelectorTests.scala
+++ b/core/resolve/test/src/mill/resolve/TypeSelectorTests.scala
@@ -2,13 +2,13 @@ package mill.resolve
 
 import mill.define.Discover
 import mill.api.Result
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import mill.{Cross, Module, Task}
 import utest.*
 
 object TypeSelectorTests extends TestSuite {
 
-  object TypedModules extends TestBaseModule {
+  object TypedModules extends TestRootModule {
     trait TypeA extends Module {
       def foo = Task { "foo" }
     }
@@ -29,7 +29,7 @@ object TypeSelectorTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object TypedCrossModules extends TestBaseModule {
+  object TypedCrossModules extends TestRootModule {
     trait TypeA extends Cross.Module[String] {
       def foo = Task { crossValue }
     }
@@ -55,7 +55,7 @@ object TypeSelectorTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object TypedInnerModules extends TestBaseModule {
+  object TypedInnerModules extends TestRootModule {
     trait TypeA extends Module {
       def foo = Task { "foo" }
     }

--- a/example/extending/plugins/7-writing-mill-plugins/build.mill
+++ b/example/extending/plugins/7-writing-mill-plugins/build.mill
@@ -114,9 +114,9 @@ compiling 1 Scala source...
 //
 // == Unit Tests
 //
-// These are tests that run in-process, with the Mill `build.mill` defined as a `TestBaseModule`,
+// These are tests that run in-process, with the Mill `build.mill` defined as a `TestRootModule`,
 // and using a `UnitTester` to run its tasks and inspect their output. `UnitTester` is provided
-// a path to a folder on disk containing the files that are to be built with the given `TestBaseModule`,
+// a path to a folder on disk containing the files that are to be built with the given `TestRootModule`,
 // and can be used to evaluate tasks (by direct reference or by string-selector) and inspect
 // the results in-memory:
 

--- a/example/extending/plugins/7-writing-mill-plugins/myplugin/test/src/mill/testkit/UnitTests.scala
+++ b/example/extending/plugins/7-writing-mill-plugins/myplugin/test/src/mill/testkit/UnitTests.scala
@@ -1,6 +1,6 @@
 package myplugin
 
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import mill.define.Discover
 import mill.PathRef
 import mill.util.TokenReaders._
@@ -9,7 +9,7 @@ import utest._
 object UnitTests extends TestSuite {
   def tests: Tests = Tests {
     test("unit") {
-      object build extends TestBaseModule with LineCountJavaModule {
+      object build extends TestRootModule with LineCountJavaModule {
         def lineCountResourceFileName = "line-count.txt"
 
         lazy val millDiscover = Discover[this.type]

--- a/libs/init/buildgen/test/src/mill/main/buildgen/BuildGenChecker.scala
+++ b/libs/init/buildgen/test/src/mill/main/buildgen/BuildGenChecker.scala
@@ -3,7 +3,7 @@ package mill.main.buildgen
 import mill.constants.{CodeGenConstants, OutFiles}
 import mill.define.Discover
 import mill.scalalib.scalafmt.ScalafmtModule
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import mill.{PathRef, T}
 import utest.framework.TestPath
 import mill.util.TokenReaders._
@@ -28,7 +28,7 @@ class BuildGenChecker(sourceRoot: os.Path, scalafmtConfigFile: os.Path) {
 
     // fmt
     val files = mill.init.Util.buildFiles(testRoot).map(PathRef(_)).toSeq
-    object module extends TestBaseModule with ScalafmtModule {
+    object module extends TestRootModule with ScalafmtModule {
       override def filesToFormat(sources: Seq[PathRef]): Seq[PathRef] = files
 
       override def scalafmtConfig: T[Seq[PathRef]] = Seq(PathRef(scalafmtConfigFile))

--- a/libs/init/test/src/mill/init/InitModuleTests.scala
+++ b/libs/init/test/src/mill/init/InitModuleTests.scala
@@ -3,7 +3,7 @@ package mill.init
 import mill.api.Val
 import mill.define.Discover
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import utest._
 
 import java.io.{ByteArrayOutputStream, OutputStream, PrintStream}
@@ -13,7 +13,7 @@ import scala.util.Properties
 
 object InitModuleTests extends TestSuite {
 
-  object initmodule extends TestBaseModule with InitModule {
+  object initmodule extends TestRootModule with InitModule {
     lazy val millDiscover = Discover[this.type]
   }
 

--- a/libs/javascriptlib/test/src/mill/javascriptlib/HelloWorldTests.scala
+++ b/libs/javascriptlib/test/src/mill/javascriptlib/HelloWorldTests.scala
@@ -2,14 +2,14 @@ package mill.javascriptlib
 
 import mill.*
 import mill.define.Discover
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import utest.*
 
 import java.io.{ByteArrayOutputStream, PrintStream}
 
 object HelloWorldTests extends TestSuite {
 
-  object HelloWorldJavascript extends TestBaseModule {
+  object HelloWorldJavascript extends TestRootModule {
     object foo extends TypeScriptModule {
       object bar extends TypeScriptModule {}
 

--- a/libs/kotlinlib/test/src/mill/kotlinlib/HelloKotlinTests.scala
+++ b/libs/kotlinlib/test/src/mill/kotlinlib/HelloKotlinTests.scala
@@ -2,7 +2,7 @@ package mill
 package kotlinlib
 
 import mill.scalalib.TestModule
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import mill.api.ExecResult
 import mill.define.Discover
 import utest.*
@@ -16,7 +16,7 @@ object HelloKotlinTests extends TestSuite {
 
   val junit5Version = sys.props.getOrElse("TEST_JUNIT5_VERSION", "5.9.1")
 
-  object HelloKotlin extends TestBaseModule {
+  object HelloKotlin extends TestRootModule {
     // crossValue - test different Kotlin versions
     // crossValue2 - test with/without the kotlin embeddable compiler
     trait KotlinVersionCross extends KotlinModule with Cross.Module2[String, Boolean] {

--- a/libs/kotlinlib/test/src/mill/kotlinlib/MixedHelloWorldTests.scala
+++ b/libs/kotlinlib/test/src/mill/kotlinlib/MixedHelloWorldTests.scala
@@ -4,7 +4,7 @@ package kotlinlib
 import mill.api.ExecResult
 import mill.define.Discover
 import mill.scalalib.TestModule
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import utest.*
 
 object MixedHelloWorldTests extends TestSuite {
@@ -15,7 +15,7 @@ object MixedHelloWorldTests extends TestSuite {
     Seq("1.0.0", "1.9.24", "2.0.20")
   }
 
-  object MixedHelloWorldKotlin extends TestBaseModule {
+  object MixedHelloWorldKotlin extends TestRootModule {
     trait MainCross extends KotlinModule with Cross.Module[String] {
       def kotlinVersion = crossValue
 

--- a/libs/kotlinlib/test/src/mill/kotlinlib/contrib/kover/KoverModuleTests.scala
+++ b/libs/kotlinlib/test/src/mill/kotlinlib/contrib/kover/KoverModuleTests.scala
@@ -4,7 +4,7 @@ import mill.define.Discover
 import mill.util.TokenReaders._
 import mill.kotlinlib.{DepSyntax, KotlinModule}
 import mill.kotlinlib.TestModule
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import mill.{T, Task, api}
 import utest.{TestSuite, Tests, assert, test}
 
@@ -16,7 +16,7 @@ object KoverModuleTests extends TestSuite {
 
   val resourcePath = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "contrib/kover"
 
-  object module extends TestBaseModule {
+  object module extends TestRootModule {
 
     trait KotestTestModule extends TestModule.Junit5 {
       override def forkArgs: T[Seq[String]] = Task {

--- a/libs/kotlinlib/test/src/mill/kotlinlib/contrib/ktfmt/KtfmtModuleTests.scala
+++ b/libs/kotlinlib/test/src/mill/kotlinlib/contrib/ktfmt/KtfmtModuleTests.scala
@@ -4,14 +4,14 @@ import mill.define.Discover
 import mill.{PathRef, T, api}
 import mill.kotlinlib.KotlinModule
 import mill.util.Tasks
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import utest.{TestSuite, Tests, assert, test}
 import mill.util.TokenReaders._
 object KtfmtModuleTests extends TestSuite {
 
   val kotlinVersion = "1.9.24"
 
-  object module extends TestBaseModule with KotlinModule with KtfmtModule {
+  object module extends TestRootModule with KotlinModule with KtfmtModule {
     override def kotlinVersion: T[String] = KtfmtModuleTests.kotlinVersion
 
     lazy val millDiscover = Discover[this.type]
@@ -121,7 +121,7 @@ object KtfmtModuleTests extends TestSuite {
 
   def afterFormatAll(modulesRoot: os.Path, format: Boolean = true): Seq[os.Path] = {
 
-    object module extends TestBaseModule with KotlinModule {
+    object module extends TestRootModule with KotlinModule {
       override def kotlinVersion: T[String] = KtfmtModuleTests.kotlinVersion
 
       lazy val millDiscover = Discover[this.type]

--- a/libs/kotlinlib/test/src/mill/kotlinlib/js/KotlinJsCompileTests.scala
+++ b/libs/kotlinlib/test/src/mill/kotlinlib/js/KotlinJsCompileTests.scala
@@ -3,7 +3,7 @@ package kotlinlib
 package js
 
 import mill.define.Discover
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import utest.{TestSuite, Tests, assert, test}
 
 object KotlinJsCompileTests extends TestSuite {
@@ -12,7 +12,7 @@ object KotlinJsCompileTests extends TestSuite {
 
   private val resourcePath = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "kotlin-js"
 
-  object module extends TestBaseModule {
+  object module extends TestRootModule {
 
     object bar extends KotlinJsModule {
       def kotlinVersion = KotlinJsCompileTests.kotlinVersion

--- a/libs/kotlinlib/test/src/mill/kotlinlib/js/KotlinJsKotestModuleTests.scala
+++ b/libs/kotlinlib/test/src/mill/kotlinlib/js/KotlinJsKotestModuleTests.scala
@@ -4,7 +4,7 @@ package kotlinlib.js
 import mill.api.ExecResult
 import mill.define.Discover
 import mill.define.ExecutionPaths
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import utest.{TestSuite, Tests, assert, test}
 
 object KotlinJsKotestModuleTests extends TestSuite {
@@ -13,7 +13,7 @@ object KotlinJsKotestModuleTests extends TestSuite {
   private val testKotlinVersion = "1.9.25"
   val testKotestVersion = sys.props.getOrElse("TEST_KOTEST_VERSION", ???)
 
-  object module extends TestBaseModule {
+  object module extends TestRootModule {
 
     object bar extends KotlinJsModule {
       def kotlinVersion = testKotlinVersion

--- a/libs/kotlinlib/test/src/mill/kotlinlib/js/KotlinJsKotlinTestPackageModuleTests.scala
+++ b/libs/kotlinlib/test/src/mill/kotlinlib/js/KotlinJsKotlinTestPackageModuleTests.scala
@@ -5,7 +5,7 @@ package js
 import mill.api.ExecResult
 import mill.define.Discover
 import mill.define.ExecutionPaths
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import utest.{TestSuite, Tests, assert, test}
 
 object KotlinJsKotlinTestPackageModuleTests extends TestSuite {
@@ -14,7 +14,7 @@ object KotlinJsKotlinTestPackageModuleTests extends TestSuite {
 
   private val kotlinVersion = "1.9.25"
 
-  object module extends TestBaseModule {
+  object module extends TestRootModule {
 
     object bar extends KotlinJsModule {
       def kotlinVersion = KotlinJsKotlinTestPackageModuleTests.kotlinVersion

--- a/libs/kotlinlib/test/src/mill/kotlinlib/js/KotlinJsKotlinVersionsTests.scala
+++ b/libs/kotlinlib/test/src/mill/kotlinlib/js/KotlinJsKotlinVersionsTests.scala
@@ -2,7 +2,7 @@ package mill
 package kotlinlib
 package js
 
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import mill.Cross
 import mill.define.Discover
 import utest.{TestSuite, Tests, test}
@@ -35,7 +35,7 @@ object KotlinJsKotlinVersionsTests extends TestSuite {
     }
   }
 
-  object module extends TestBaseModule {
+  object module extends TestRootModule {
     object foo extends Cross[KotlinJsFooCrossModule](kotlinVersions)
     object bar extends Cross[KotlinJsCrossModule](kotlinVersions)
     object qux extends Cross[KotlinJsQuxCrossModule](kotlinVersions)

--- a/libs/kotlinlib/test/src/mill/kotlinlib/js/KotlinJsLinkTests.scala
+++ b/libs/kotlinlib/test/src/mill/kotlinlib/js/KotlinJsLinkTests.scala
@@ -1,7 +1,7 @@
 package mill.kotlinlib.js
 
 import mill.define.Discover
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import mill.{Cross, T}
 import utest.{TestSuite, Tests, assert, test}
 import mill.util.TokenReaders._
@@ -20,7 +20,7 @@ object KotlinJsLinkTests extends TestSuite {
     override def artifactNameParts = super.artifactNameParts().dropRight(1)
   }
 
-  object module extends TestBaseModule {
+  object module extends TestRootModule {
 
     object bar extends KotlinJsModule {
       def kotlinVersion = KotlinJsLinkTests.kotlinVersion

--- a/libs/kotlinlib/test/src/mill/kotlinlib/js/KotlinJsNodeRunTests.scala
+++ b/libs/kotlinlib/test/src/mill/kotlinlib/js/KotlinJsNodeRunTests.scala
@@ -4,7 +4,7 @@ package js
 
 import mill.define.Discover
 import mill.define.ExecutionPaths
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import utest.{TestSuite, Tests, test}
 
 object KotlinJsNodeRunTests extends TestSuite {
@@ -13,7 +13,7 @@ object KotlinJsNodeRunTests extends TestSuite {
   private val kotlinVersion = "1.9.25"
   private val expectedSuccessOutput = "Hello, world"
 
-  object module extends TestBaseModule {
+  object module extends TestRootModule {
 
     private val matrix = for {
       splits <- Seq(true, false)

--- a/libs/main/test/src/mill/main/MainModuleTests.scala
+++ b/libs/main/test/src/mill/main/MainModuleTests.scala
@@ -5,7 +5,7 @@ import mill.constants.OutFiles
 import mill.{Task, given}
 import mill.define.{PathRef, Cross, Discover, Module, TaskModule}
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import utest.{TestSuite, Tests, assert, test}
 
 import java.io.{ByteArrayOutputStream, OutputStream, PrintStream}
@@ -15,7 +15,7 @@ import scala.util.Properties
 
 object MainModuleTests extends TestSuite {
 
-  object mainModule extends TestBaseModule with MainModule {
+  object mainModule extends TestRootModule with MainModule {
     def hello = Task {
       System.out.println("Hello System Stdout")
       System.err.println("Hello System Stderr")
@@ -59,7 +59,7 @@ object MainModuleTests extends TestSuite {
     override lazy val millDiscover = Discover[this.type]
   }
 
-  object cleanModule extends TestBaseModule with MainModule {
+  object cleanModule extends TestRootModule with MainModule {
 
     trait Cleanable extends Module {
       def target = Task {
@@ -109,7 +109,7 @@ object MainModuleTests extends TestSuite {
       s"TestWorker($name)@${Integer.toHexString(System.identityHashCode(this))}"
   }
 
-  class WorkerModule(workers: mutable.HashSet[TestWorker]) extends TestBaseModule with MainModule {
+  class WorkerModule(workers: mutable.HashSet[TestWorker]) extends TestRootModule with MainModule {
 
     trait Cleanable extends Module {
       def theWorker = Task.Worker {

--- a/libs/main/test/src/mill/util/TestGraphs.scala
+++ b/libs/main/test/src/mill/util/TestGraphs.scala
@@ -1,6 +1,6 @@
 package mill.util
 import mainargs.arg
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import mill.define.{Command, Cross, Discover, TaskModule}
 import mill.{Module, Task}
 
@@ -9,11 +9,11 @@ import mill.{Module, Task}
  */
 
 object TestGraphs {
-  object singleton extends TestBaseModule {
+  object singleton extends TestRootModule {
     def single = Task { 123 }
     lazy val millDiscover = Discover[this.type]
   }
-  object bactickIdentifiers extends TestBaseModule {
+  object bactickIdentifiers extends TestRootModule {
     def `up-target` = Task { 1 }
     def `a-down-target` = Task { `up-target`() + 2 }
     def `invisible&` = Task { 3 }
@@ -26,14 +26,14 @@ object TestGraphs {
   }
 
   // up---down
-  object pair extends TestBaseModule {
+  object pair extends TestRootModule {
     def up = Task { 1 }
     def down = Task { up() + 10 }
     lazy val millDiscover = Discover[this.type]
   }
 
   // up---o---down
-  object anonTriple extends TestBaseModule {
+  object anonTriple extends TestRootModule {
     def up = Task { 1 }
     def anon = Task.Anon { up() + 10 }
     def down = Task { anon() + 100 }
@@ -45,7 +45,7 @@ object TestGraphs {
   // up    down
   //   \   /
   //   right
-  object diamond extends TestBaseModule {
+  object diamond extends TestRootModule {
     def up = Task { 1 }
     def left = Task { up() + 10 }
     def right = Task { up() + 100 }
@@ -58,7 +58,7 @@ object TestGraphs {
   // up   down
   //   \ /
   //    o
-  object anonDiamond extends TestBaseModule {
+  object anonDiamond extends TestRootModule {
     def up = Task { 1 }
     val left = Task.Anon { up() + 10 }
     val right = Task.Anon { up() + 100 }
@@ -70,7 +70,7 @@ object TestGraphs {
   //  task1 -------- right
   //               _/
   // change - task2
-  object separateGroups extends TestBaseModule {
+  object separateGroups extends TestRootModule {
     val task1 = Task.Anon { 1 }
     def left = Task { task1() + 10 }
     val change = Task.Anon { 100 }
@@ -83,7 +83,7 @@ object TestGraphs {
   //      _ left _
   //     /        \
   // task -------- right
-  object triangleTask extends TestBaseModule {
+  object triangleTask extends TestRootModule {
     val task = Task.Anon { 1 }
     def left = Task { task() }
     def right = Task { task() + left() + 1 }
@@ -93,7 +93,7 @@ object TestGraphs {
   //      _ left
   //     /
   // task -------- right
-  object multiTerminalGroup extends TestBaseModule {
+  object multiTerminalGroup extends TestRootModule {
     val task = Task.Anon { 1 }
     def left = Task { task() }
     def right = Task { task() }
@@ -103,7 +103,7 @@ object TestGraphs {
   //       _ left _____________
   //      /        \           \
   // task1 -------- right ----- task2
-  object multiTerminalBoundary extends TestBaseModule {
+  object multiTerminalBoundary extends TestRootModule {
     val task1 = Task.Anon { 1 }
     def left = Task { task1() }
     def right = Task { task1() + left() + 1 }
@@ -118,7 +118,7 @@ object TestGraphs {
     def invisible3: mill.define.Task[?] = Task { 4 }
   }
 
-  object nestedModule extends TestBaseModule {
+  object nestedModule extends TestRootModule {
     def single = Task { 5 }
     def invisible: Any = Task { 6 }
     object nested extends Module {
@@ -140,11 +140,11 @@ object TestGraphs {
   }
 
   // Make sure nested objects inherited from traits work
-  object TraitWithModuleObject extends TestBaseModule with TraitWithModule {
+  object TraitWithModuleObject extends TestRootModule with TraitWithModule {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object singleCross extends TestBaseModule {
+  object singleCross extends TestRootModule {
     object cross extends mill.Cross[Cross]("210", "211", "212")
     trait Cross extends Cross.Module[String] {
       def suffix = Task { crossValue }
@@ -158,7 +158,7 @@ object TestGraphs {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object nonStringCross extends TestBaseModule {
+  object nonStringCross extends TestRootModule {
     object cross extends mill.Cross[Cross](210, 211, 212)
     trait Cross extends Cross.Module[Int] {
       def suffix = Task { crossValue }
@@ -173,7 +173,7 @@ object TestGraphs {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object crossResolved extends TestBaseModule {
+  object crossResolved extends TestRootModule {
     trait MyModule extends Cross.Module[String] {
       implicit object resolver extends mill.define.Cross.Resolver[MyModule] {
         def resolve[V <: MyModule](c: Cross[V]): V = c.valuesToModules(List(crossValue))
@@ -191,7 +191,7 @@ object TestGraphs {
     }
     lazy val millDiscover = Discover[this.type]
   }
-  object doubleCross extends TestBaseModule {
+  object doubleCross extends TestRootModule {
     val crossMatrix = for {
       scalaVersion <- Seq("210", "211", "212")
       platform <- Seq("jvm", "js", "native")
@@ -205,7 +205,7 @@ object TestGraphs {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object nestedCrosses extends TestBaseModule {
+  object nestedCrosses extends TestRootModule {
     object cross extends mill.Cross[Cross]("210", "211", "212") {
       override def defaultCrossSegments: Seq[String] = Seq("212")
     }
@@ -220,7 +220,7 @@ object TestGraphs {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object nestedTaskCrosses extends TestBaseModule {
+  object nestedTaskCrosses extends TestRootModule {
     // this is somehow necessary to let Discover see our inner (default) commands
     // I expected, that the identical inherited `millDiscover` is enough, but it isn't
     lazy val millDiscover = Discover[this.type]

--- a/libs/pythonlib/test/src/mill/pythonlib/HelloWorldTests.scala
+++ b/libs/pythonlib/test/src/mill/pythonlib/HelloWorldTests.scala
@@ -2,14 +2,14 @@ package mill
 package pythonlib
 
 import mill.define.Discover
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import utest.*
 
 import java.io.{ByteArrayOutputStream, PrintStream}
 
 object HelloWorldTests extends TestSuite {
 
-  object HelloWorldPython extends TestBaseModule {
+  object HelloWorldPython extends TestRootModule {
     object foo extends PythonModule {
       override def moduleDeps: Seq[PythonModule] = Seq(bar)
       object bar extends PythonModule

--- a/libs/pythonlib/test/src/mill/pythonlib/RunBackgroundTests.scala
+++ b/libs/pythonlib/test/src/mill/pythonlib/RunBackgroundTests.scala
@@ -1,6 +1,6 @@
 package mill.pythonlib
 
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import utest.*
 import mill.*
 import mill.client.lock.Lock
@@ -8,7 +8,7 @@ import mill.define.Discover
 
 object RunBackgroundTests extends TestSuite {
 
-  object HelloWorldPython extends TestBaseModule {
+  object HelloWorldPython extends TestRootModule {
     object foo extends PythonModule {
       override def mainScript = Task.Source("src/foo.py")
     }

--- a/libs/scalajslib/test/src/mill/scalajslib/CompileLinkTests.scala
+++ b/libs/scalajslib/test/src/mill/scalajslib/CompileLinkTests.scala
@@ -5,7 +5,7 @@ import mill.define.Discover
 import mill.scalalib.{DepSyntax, PublishModule, ScalaModule, TestModule}
 import mill.scalalib.publish.{Developer, License, PomSettings, VersionControl}
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import utest._
 
 import mill.scalalib.api.JvmWorkerUtil
@@ -20,7 +20,7 @@ object CompileLinkTests extends TestSuite {
     override def mainClass = Some("Main")
   }
 
-  object HelloJSWorld extends TestBaseModule {
+  object HelloJSWorld extends TestRootModule {
     val scalaVersions = Seq("2.13.3", "3.0.0-RC1", "2.12.12")
     val scalaJSVersions = Seq("1.8.0", "1.0.1")
     val matrix = for {

--- a/libs/scalajslib/test/src/mill/scalajslib/EsModuleRemapTests.scala
+++ b/libs/scalajslib/test/src/mill/scalajslib/EsModuleRemapTests.scala
@@ -3,7 +3,7 @@ package mill.scalajslib
 import mill.api.ExecResult
 import mill.define.Discover
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import utest._
 import mill.define.Target
 import mill.T
@@ -12,7 +12,7 @@ import mill.scalajslib.api._
 object EsModuleRemapTests extends TestSuite {
   val remapTo = "https://cdn.jsdelivr.net/gh/stdlib-js/array-base-linspace@esm/index.mjs"
 
-  object EsModuleRemap extends TestBaseModule with ScalaJSModule {
+  object EsModuleRemap extends TestRootModule with ScalaJSModule {
     override def scalaVersion = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
 
     override def scalaJSVersion = "1.16.0"
@@ -31,7 +31,7 @@ object EsModuleRemapTests extends TestSuite {
     }
   }
 
-  object OldJsModule extends TestBaseModule with ScalaJSModule {
+  object OldJsModule extends TestRootModule with ScalaJSModule {
     override def scalaVersion = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
     override def scalaJSVersion = "1.15.0"
     override def scalaJSSourceMap = false

--- a/libs/scalajslib/test/src/mill/scalajslib/FullOptESModuleTests.scala
+++ b/libs/scalajslib/test/src/mill/scalajslib/FullOptESModuleTests.scala
@@ -3,12 +3,12 @@ package mill.scalajslib
 import mill.define.Discover
 import mill.scalajslib.api._
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import utest._
 
 object FullOptESModuleTests extends TestSuite {
 
-  object FullOptESModuleModule extends TestBaseModule {
+  object FullOptESModuleModule extends TestRootModule {
 
     object fullOptESModuleModule extends ScalaJSModule {
       override def scalaVersion = "2.13.4"

--- a/libs/scalajslib/test/src/mill/scalajslib/MultiModuleTests.scala
+++ b/libs/scalajslib/test/src/mill/scalajslib/MultiModuleTests.scala
@@ -4,12 +4,12 @@ import mill._
 import mill.define.Discover
 import mill.define.ExecutionPaths
 import mill.scalalib._
-import mill.testkit.{UnitTester, TestBaseModule}
+import mill.testkit.{UnitTester, TestRootModule}
 import utest._
 object MultiModuleTests extends TestSuite {
   val sourcePath = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "multi-module"
 
-  object MultiModule extends TestBaseModule {
+  object MultiModule extends TestRootModule {
     trait BaseModule extends ScalaJSModule {
       def scalaVersion = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
       def scalaJSVersion = sys.props.getOrElse("TEST_SCALAJS_VERSION", ???)

--- a/libs/scalajslib/test/src/mill/scalajslib/NodeJSConfigTests.scala
+++ b/libs/scalajslib/test/src/mill/scalajslib/NodeJSConfigTests.scala
@@ -5,7 +5,7 @@ import mill.define.Discover
 import mill.define.ExecutionPaths
 import mill.scalalib.{ScalaModule, TestModule}
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import utest._
 import mill.scalajslib.api._
 
@@ -29,7 +29,7 @@ object NodeJSConfigTests extends TestSuite {
     override def mainClass = Some("Main")
   }
 
-  object HelloJSWorld extends TestBaseModule {
+  object HelloJSWorld extends TestRootModule {
     val matrix = for {
       scala <- Seq(scalaVersion)
       nodeArgs <- Seq(nodeArgsEmpty, nodeArgs2G)

--- a/libs/scalajslib/test/src/mill/scalajslib/OutputPatternsTests.scala
+++ b/libs/scalajslib/test/src/mill/scalajslib/OutputPatternsTests.scala
@@ -3,12 +3,12 @@ package mill.scalajslib
 import mill.define.Discover
 import mill.scalajslib.api._
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import utest._
 
 object OutputPatternsTests extends TestSuite {
 
-  object OutputPatternsModule extends TestBaseModule {
+  object OutputPatternsModule extends TestRootModule {
 
     object build extends ScalaJSModule {
       override def scalaVersion = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)

--- a/libs/scalajslib/test/src/mill/scalajslib/ScalaTestsErrorTests.scala
+++ b/libs/scalajslib/test/src/mill/scalajslib/ScalaTestsErrorTests.scala
@@ -2,11 +2,11 @@ package mill.scalajslib
 
 import mill.define.Discover
 import mill.scalalib.TestModule
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import utest._
 
 object ScalaTestsErrorTests extends TestSuite {
-  object ScalaTestsError extends TestBaseModule {
+  object ScalaTestsError extends TestRootModule {
     object scalaTestsError extends ScalaJSModule {
       def scalaVersion = sys.props.getOrElse("TEST_SCALA_3_3_VERSION", ???)
       def scalaJSVersion = sys.props.getOrElse("TEST_SCALAJS_VERSION", ???)

--- a/libs/scalajslib/test/src/mill/scalajslib/SmallModulesForTests.scala
+++ b/libs/scalajslib/test/src/mill/scalajslib/SmallModulesForTests.scala
@@ -3,11 +3,11 @@ package mill.scalajslib
 import mill.define.Discover
 import mill.scalajslib.api._
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import utest._
 
 object SmallModulesForTests extends TestSuite {
-  object SmallModulesForModule extends TestBaseModule with ScalaJSModule {
+  object SmallModulesForModule extends TestRootModule with ScalaJSModule {
 
     override def scalaVersion = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
     override def scalaJSVersion =

--- a/libs/scalajslib/test/src/mill/scalajslib/SourceMapTests.scala
+++ b/libs/scalajslib/test/src/mill/scalajslib/SourceMapTests.scala
@@ -2,11 +2,11 @@ package mill.scalajslib
 
 import mill.define.Discover
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import utest._
 
 object SourceMapTests extends TestSuite {
-  object SourceMapModule extends TestBaseModule {
+  object SourceMapModule extends TestRootModule {
 
     object build extends ScalaJSModule {
       override def scalaVersion = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)

--- a/libs/scalajslib/test/src/mill/scalajslib/TopLevelExportsTests.scala
+++ b/libs/scalajslib/test/src/mill/scalajslib/TopLevelExportsTests.scala
@@ -3,11 +3,11 @@ package mill.scalajslib
 import mill.define.Discover
 import mill.scalajslib.api._
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import utest._
 
 object TopLevelExportsTests extends TestSuite {
-  object TopLevelExportsModule extends TestBaseModule with ScalaJSModule {
+  object TopLevelExportsModule extends TestRootModule with ScalaJSModule {
     override def scalaVersion = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
     override def scalaJSVersion =
       sys.props.getOrElse("TEST_SCALAJS_VERSION", ???) // at least "1.8.0"

--- a/libs/scalajslib/test/src/mill/scalajslib/WasmTests.scala
+++ b/libs/scalajslib/test/src/mill/scalajslib/WasmTests.scala
@@ -3,7 +3,7 @@ package mill.scalajslib
 import mill.api.ExecResult
 import mill.define.Discover
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import utest._
 import mill.scalajslib.api._
 import mill.T
@@ -11,7 +11,7 @@ import mill.T
 object WasmTests extends TestSuite {
   val remapTo = "https://cdn.jsdelivr.net/gh/stdlib-js/array-base-linspace@esm/index.mjs"
 
-  object Wasm extends TestBaseModule with ScalaJSModule {
+  object Wasm extends TestRootModule with ScalaJSModule {
     override def scalaVersion = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
 
     override def scalaJSVersion = "1.17.0"
@@ -28,7 +28,7 @@ object WasmTests extends TestSuite {
     }
   }
 
-  object OldWasmModule extends TestBaseModule with ScalaJSModule {
+  object OldWasmModule extends TestRootModule with ScalaJSModule {
     override def scalaVersion = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
     override def scalaJSVersion = "1.16.0"
 

--- a/libs/scalalib/test/src/mill/javalib/checkstyle/CheckstyleModuleTest.scala
+++ b/libs/scalalib/test/src/mill/javalib/checkstyle/CheckstyleModuleTest.scala
@@ -4,7 +4,7 @@ import mill._
 import mainargs.Leftover
 import mill.define.Discover
 import mill.scalalib.{JavaModule, ScalaModule}
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import utest._
 
 object CheckstyleModuleTest extends TestSuite {
@@ -136,7 +136,7 @@ object CheckstyleModuleTest extends TestSuite {
       sources: Seq[String] = Seq.empty
   ): Boolean = {
 
-    object module extends TestBaseModule with JavaModule with CheckstyleModule {
+    object module extends TestRootModule with JavaModule with CheckstyleModule {
       override def checkstyleFormat: T[String] = format
       override def checkstyleOptions: T[Seq[String]] = options
       override def checkstyleVersion: T[String] = version
@@ -162,7 +162,7 @@ object CheckstyleModuleTest extends TestSuite {
       sources: Seq[String] = Seq.empty
   ): Boolean = {
 
-    object module extends TestBaseModule with ScalaModule with CheckstyleModule {
+    object module extends TestRootModule with ScalaModule with CheckstyleModule {
       override def checkstyleFormat: T[String] = format
       override def checkstyleOptions: T[Seq[String]] = options
       override def checkstyleVersion: T[String] = version
@@ -179,7 +179,7 @@ object CheckstyleModuleTest extends TestSuite {
   }
 
   def testModule(
-      module: TestBaseModule & CheckstyleModule,
+      module: TestRootModule & CheckstyleModule,
       modulePath: os.Path,
       violations: Seq[String],
       args: CheckstyleArgs

--- a/libs/scalalib/test/src/mill/javalib/checkstyle/CheckstyleXsltModuleTest.scala
+++ b/libs/scalalib/test/src/mill/javalib/checkstyle/CheckstyleXsltModuleTest.scala
@@ -4,7 +4,7 @@ import mill.*
 import mainargs.Leftover
 import mill.define.Discover
 import mill.scalalib.{JavaModule, ScalaModule}
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import utest.*
 
 object CheckstyleXsltModuleTest extends TestSuite {
@@ -31,7 +31,7 @@ object CheckstyleXsltModuleTest extends TestSuite {
 
   def testJava(modulePath: os.Path): Boolean = {
 
-    object module extends TestBaseModule with JavaModule with CheckstyleXsltModule {
+    object module extends TestRootModule with JavaModule with CheckstyleXsltModule {
       lazy val millDiscover = Discover[this.type]
     }
 
@@ -40,7 +40,7 @@ object CheckstyleXsltModuleTest extends TestSuite {
 
   def testScala(modulePath: os.Path): Boolean = {
 
-    object module extends TestBaseModule with ScalaModule with CheckstyleXsltModule {
+    object module extends TestRootModule with ScalaModule with CheckstyleXsltModule {
       override def scalaVersion: T[String] = sys.props("MILL_SCALA_2_13_VERSION")
       lazy val millDiscover = Discover[this.type]
     }
@@ -48,7 +48,7 @@ object CheckstyleXsltModuleTest extends TestSuite {
     testModule(module, modulePath)
   }
 
-  def testModule(module: TestBaseModule & CheckstyleXsltModule, modulePath: os.Path): Boolean = {
+  def testModule(module: TestRootModule & CheckstyleXsltModule, modulePath: os.Path): Boolean = {
     UnitTester(module, modulePath).scoped { eval =>
       eval(module.checkstyle(CheckstyleArgs(check = false, sources = Leftover()))).get
 

--- a/libs/scalalib/test/src/mill/javalib/errorprone/ErrorProneTests.scala
+++ b/libs/scalalib/test/src/mill/javalib/errorprone/ErrorProneTests.scala
@@ -3,19 +3,19 @@ package mill.javalib.errorprone
 import mill.T
 import mill.define.Discover
 import mill.scalalib.JavaModule
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import os.Path
 import utest.*
 import mill.util.TokenReaders._
 object ErrorProneTests extends TestSuite {
 
-  object noErrorProne extends TestBaseModule with JavaModule {
+  object noErrorProne extends TestRootModule with JavaModule {
     lazy val millDiscover = Discover[this.type]
   }
-  object errorProne extends TestBaseModule with JavaModule with ErrorProneModule {
+  object errorProne extends TestRootModule with JavaModule with ErrorProneModule {
     lazy val millDiscover = Discover[this.type]
   }
-  object errorProneCustom extends TestBaseModule with JavaModule with ErrorProneModule {
+  object errorProneCustom extends TestRootModule with JavaModule with ErrorProneModule {
     override def errorProneOptions: T[Seq[String]] = T(Seq(
       "-XepAllErrorsAsWarnings"
     ))

--- a/libs/scalalib/test/src/mill/javalib/junit5/JUnit5Tests.scala
+++ b/libs/scalalib/test/src/mill/javalib/junit5/JUnit5Tests.scala
@@ -3,13 +3,13 @@ package mill.javalib.junit5
 import mill.define.Discover
 import mill.scalalib.JavaModule
 import mill.scalalib.TestModule
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import utest.*
 import mill.util.TokenReaders._
 
 object JUnit5Tests extends TestSuite {
 
-  object module extends TestBaseModule with JavaModule {
+  object module extends TestRootModule with JavaModule {
     object test extends JavaTests with TestModule.Junit5
     lazy val millDiscover = Discover[this.type]
   }

--- a/libs/scalalib/test/src/mill/javalib/palantirformat/PalantirFormatModuleTest.scala
+++ b/libs/scalalib/test/src/mill/javalib/palantirformat/PalantirFormatModuleTest.scala
@@ -4,7 +4,7 @@ package javalib.palantirformat
 import mill.define.Discover
 import mill.util.Tasks
 import mill.scalalib.ScalaModule
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import utest.*
 
 object PalantirFormatModuleTest extends TestSuite {
@@ -98,7 +98,7 @@ object PalantirFormatModuleTest extends TestSuite {
       sources: Seq[String] = Seq.empty
   ): Seq[os.Path] = {
 
-    object module extends TestBaseModule with ScalaModule with PalantirFormatModule {
+    object module extends TestRootModule with ScalaModule with PalantirFormatModule {
       override def palantirformatVersion: T[String] = version
       override def scalaVersion: T[String] = sys.props("MILL_SCALA_2_13_VERSION")
       lazy val millDiscover = Discover[this.type]
@@ -118,7 +118,7 @@ object PalantirFormatModuleTest extends TestSuite {
 
   def afterFormatAll(modulesRoot: os.Path, check: Boolean = false): Seq[os.Path] = {
 
-    object module extends TestBaseModule with ScalaModule {
+    object module extends TestRootModule with ScalaModule {
       override def scalaVersion: T[String] = sys.props("MILL_SCALA_2_13_VERSION")
 
       lazy val millDiscover = Discover[this.type]

--- a/libs/scalalib/test/src/mill/javalib/revapi/RevapiModuleTests.scala
+++ b/libs/scalalib/test/src/mill/javalib/revapi/RevapiModuleTests.scala
@@ -4,7 +4,7 @@ import mill.define.PathRef
 import mill.define.Discover
 import mill.javalib.*
 import mill.scalalib.publish.{PomSettings, VersionControl}
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import mill.{T, Task}
 import utest.*
 import mill.util.TokenReaders._
@@ -61,7 +61,7 @@ object RevapiModuleTests extends TestSuite {
       root2: os.Path,
       conf: os.Path
   ): os.Path = {
-    trait module extends TestBaseModule with PublishModule {
+    trait module extends TestRootModule with PublishModule {
       override def artifactName = name
       override def pomSettings: T[PomSettings] =
         PomSettings("", "mill.revapi.local", "", Seq(), VersionControl(), Seq())
@@ -99,7 +99,7 @@ object RevapiModuleTests extends TestSuite {
       conf: os.Path
   ): os.Path = {
 
-    object module extends TestBaseModule with RevapiModule {
+    object module extends TestRootModule with RevapiModule {
       override def artifactName = id
       override def pomSettings: T[PomSettings] =
         PomSettings("", group, "", Seq(), VersionControl(), Seq())

--- a/libs/scalalib/test/src/mill/scalalib/AssemblyTestUtils.scala
+++ b/libs/scalalib/test/src/mill/scalalib/AssemblyTestUtils.scala
@@ -3,11 +3,11 @@ package mill.scalalib
 import mill.*
 import mill.define.Discover
 import mill.util.Jvm
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 
 trait AssemblyTestUtils {
 
-  object TestCase extends TestBaseModule {
+  object TestCase extends TestRootModule {
     trait Setup extends ScalaModule {
       def scalaVersion = "2.13.11"
 

--- a/libs/scalalib/test/src/mill/scalalib/BomTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/BomTests.scala
@@ -3,7 +3,7 @@ package scalalib
 
 import mill.define.Discover
 import mill.scalalib.publish.*
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import utest.*
 
 import scala.jdk.CollectionConverters.*
@@ -22,7 +22,7 @@ object BomTests extends TestSuite {
     def publishVersion = "0.1.0-SNAPSHOT"
   }
 
-  object modules extends TestBaseModule {
+  object modules extends TestRootModule {
     object bom extends Module {
       object placeholder extends JavaModule with TestPublishModule {
         // Empty version in mvnDeps should be filled with BOM

--- a/libs/scalalib/test/src/mill/scalalib/CoursierMirrorTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/CoursierMirrorTests.scala
@@ -2,7 +2,7 @@ package mill.scalalib
 
 import mill.define.Discover
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import utest.*
 import mill.util.TokenReaders._
 
@@ -10,7 +10,7 @@ object CoursierMirrorTests extends TestSuite {
 
   val resourcePath = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "coursier"
 
-  object CoursierTest extends TestBaseModule {
+  object CoursierTest extends TestRootModule {
     object core extends ScalaModule {
       def scalaVersion = "2.13.12"
     }

--- a/libs/scalalib/test/src/mill/scalalib/CoursierParametersTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/CoursierParametersTests.scala
@@ -2,7 +2,7 @@ package mill.scalalib
 
 import mill.define.{Discover, Task}
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import mill.util.TokenReaders._
 import utest.*
 
@@ -10,7 +10,7 @@ object CoursierParametersTests extends TestSuite {
 
   val resourcePath = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "coursier"
 
-  object CoursierTest extends TestBaseModule {
+  object CoursierTest extends TestRootModule {
     object core extends ScalaModule {
       def scalaVersion = "2.13.12"
       def mvnDeps = Task {

--- a/libs/scalalib/test/src/mill/scalalib/CrossVersionTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/CrossVersionTests.scala
@@ -4,13 +4,13 @@ import mill.define.Discover
 import mill.define.ExecutionPaths
 import mill.util.TokenReaders.*
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import utest.*
 import utest.framework.TestPath
 
 object CrossVersionTests extends TestSuite {
 
-  object TestCases extends TestBaseModule {
+  object TestCases extends TestRootModule {
 
     object StandaloneScala213 extends ScalaModule {
       val tree =

--- a/libs/scalalib/test/src/mill/scalalib/CycleTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/CycleTests.scala
@@ -3,13 +3,13 @@ package mill.scalalib
 import mill.api.BuildScriptException
 import mill.define.Discover
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import utest.{TestSuite, Tests, assert, intercept, test}
 import mill.util.TokenReaders._
 
 object CycleTests extends TestSuite {
 
-  object CycleBase extends TestBaseModule {
+  object CycleBase extends TestRootModule {
     // See issue: https://github.com/com-lihaoyi/mill/issues/2341
     object a extends ScalaModule {
       override def moduleDeps = Seq(a)

--- a/libs/scalalib/test/src/mill/scalalib/DottyDocTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/DottyDocTests.scala
@@ -4,11 +4,11 @@ import mill.*
 import mill.define.Discover
 import utest.*
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 
 object DottyDocTests extends TestSuite {
   // a project with static docs
-  object StaticDocsModule extends TestBaseModule {
+  object StaticDocsModule extends TestRootModule {
     object static extends ScalaModule {
       def scalaVersion = "0.24.0-RC1"
     }
@@ -16,7 +16,7 @@ object DottyDocTests extends TestSuite {
   }
 
   // a project without static docs (i.e. only api docs, no markdown files)
-  object EmptyDocsModule extends TestBaseModule {
+  object EmptyDocsModule extends TestRootModule {
     object empty extends ScalaModule {
       def scalaVersion = "0.24.0-RC1"
     }
@@ -24,7 +24,7 @@ object DottyDocTests extends TestSuite {
   }
 
   // a project with multiple static doc folders
-  object MultiDocsModule extends TestBaseModule {
+  object MultiDocsModule extends TestRootModule {
     object multidocs extends ScalaModule {
       def scalaVersion = "0.24.0-RC1"
       def docResources = Task.Sources(

--- a/libs/scalalib/test/src/mill/scalalib/HelloJavaTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/HelloJavaTests.scala
@@ -3,13 +3,13 @@ package scalalib
 
 import mill.api.ExecResult
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import utest.*
 import mill.define.Discover
 
 object HelloJavaTests extends TestSuite {
 
-  object HelloJava extends TestBaseModule {
+  object HelloJava extends TestRootModule {
     object core extends JavaModule {
       override def docJarUseArgsFile = false
       object test extends JavaTests with TestModule.Junit4

--- a/libs/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
@@ -9,7 +9,7 @@ import mill.api.ExecResult
 import mill.define.Discover
 import mill.define.ExecutionPaths
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import utest.*
 
 object HelloWorldTests extends TestSuite {
@@ -35,18 +35,18 @@ object HelloWorldTests extends TestSuite {
     override def mainClass: T[Option[String]] = Some("Main")
   }
 
-  object HelloWorld extends TestBaseModule {
+  object HelloWorld extends TestRootModule {
     object core extends HelloWorldModule
     lazy val millDiscover = Discover[this.type]
   }
-  object HelloWorldNonPrecompiledBridge extends TestBaseModule {
+  object HelloWorldNonPrecompiledBridge extends TestRootModule {
     object core extends HelloWorldModule {
       override def scalaVersion = "2.12.1"
     }
     lazy val millDiscover = Discover[this.type]
 
   }
-  object CrossHelloWorld extends TestBaseModule {
+  object CrossHelloWorld extends TestRootModule {
     object core extends Cross[HelloWorldCross](
           scala2123Version,
           scala212Version,
@@ -56,31 +56,31 @@ object HelloWorldTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object HelloWorldDefaultMain extends TestBaseModule {
+  object HelloWorldDefaultMain extends TestRootModule {
     object core extends HelloWorldModule
     lazy val millDiscover = Discover[this.type]
   }
 
-  object HelloWorldWithoutMain extends TestBaseModule {
+  object HelloWorldWithoutMain extends TestRootModule {
     object core extends HelloWorldModule {
       override def mainClass = None
     }
     lazy val millDiscover = Discover[this.type]
   }
 
-  object HelloWorldWithMain extends TestBaseModule {
+  object HelloWorldWithMain extends TestRootModule {
     object core extends HelloWorldModuleWithMain
     lazy val millDiscover = Discover[this.type]
   }
 
-  object HelloWorldFatalWarnings extends TestBaseModule {
+  object HelloWorldFatalWarnings extends TestRootModule {
     object core extends HelloWorldModule {
       override def scalacOptions = T(Seq("-Ywarn-unused", "-Xfatal-warnings"))
     }
     lazy val millDiscover = Discover[this.type]
   }
 
-  object HelloWorldScalaOverride extends TestBaseModule {
+  object HelloWorldScalaOverride extends TestRootModule {
     object core extends HelloWorldModule {
       override def scalaVersion: T[String] = scala213Version
     }

--- a/libs/scalalib/test/src/mill/scalalib/JavaHomeTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/JavaHomeTests.scala
@@ -2,7 +2,7 @@ package mill.scalalib
 
 import mill.define.{Args, Discover, ModuleRef, Task}
 import mill.api.ExecResult
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import mill.util.TokenReaders.*
 import utest.*
 
@@ -10,7 +10,7 @@ import java.io.{ByteArrayOutputStream, PrintStream}
 
 object JavaHomeTests extends TestSuite {
 
-  object HelloJavaJavaHome11Override extends TestBaseModule {
+  object HelloJavaJavaHome11Override extends TestRootModule {
     object JvmWorkerJava11 extends JvmWorkerModule {
       def jvmId = "temurin:11.0.24"
     }
@@ -24,7 +24,7 @@ object JavaHomeTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object HelloJavaJavaHome17Override extends TestBaseModule {
+  object HelloJavaJavaHome17Override extends TestRootModule {
     object JvmWorkerJava17 extends JvmWorkerModule {
       def jvmId = "temurin:17.0.9"
     }
@@ -37,7 +37,7 @@ object JavaHomeTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object JavaJdk11DoesntCompile extends TestBaseModule {
+  object JavaJdk11DoesntCompile extends TestRootModule {
     object JvmWorkerJava extends JvmWorkerModule {
       def jvmId = "temurin:11.0.25"
     }
@@ -52,7 +52,7 @@ object JavaHomeTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object JavaJdk17Compiles extends TestBaseModule {
+  object JavaJdk17Compiles extends TestRootModule {
     object JvmWorkerJava extends JvmWorkerModule {
       def jvmId = "temurin:17.0.13"
     }

--- a/libs/scalalib/test/src/mill/scalalib/LauncherTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/LauncherTests.scala
@@ -1,14 +1,14 @@
 package mill.scalalib
 
 import mill.define.{Discover, PathRef}
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import utest.*
 import mill.util.TokenReaders.*
 
 object LauncherTests extends TestSuite {
 
   val customJavaVersion = "19.0.2"
-  object HelloJava extends TestBaseModule with JavaModule {
+  object HelloJava extends TestRootModule with JavaModule {
     object JvmWorkerJava extends JvmWorkerModule {
       def jvmId = s"temurin:$customJavaVersion"
     }

--- a/libs/scalalib/test/src/mill/scalalib/PublishModuleTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/PublishModuleTests.scala
@@ -13,7 +13,7 @@ import mill.scalalib.publish.{
   VersionScheme
 }
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import utest.*
 import mill.util.TokenReaders._
 import java.io.PrintStream
@@ -32,7 +32,7 @@ object PublishModuleTests extends TestSuite {
     }
   }
 
-  object HelloWorldWithPublish extends TestBaseModule {
+  object HelloWorldWithPublish extends TestRootModule {
     object core extends HelloScalaModule with PublishModule {
       override def artifactName = "hello-world"
       override def publishVersion = "0.0.1"
@@ -55,7 +55,7 @@ object PublishModuleTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object PomOnly extends TestBaseModule {
+  object PomOnly extends TestRootModule {
     object core extends JavaModule with PublishModule {
       override def pomPackagingType: String = PackagingType.Pom
       override def artifactName = "pom-only"
@@ -82,7 +82,7 @@ object PublishModuleTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object compileAndRuntimeStuff extends TestBaseModule {
+  object compileAndRuntimeStuff extends TestRootModule {
     def organization = "com.lihaoyi.pubmodtests"
     def version = "0.1.0-SNAPSHOT"
     trait TestPublishModule extends PublishModule {

--- a/libs/scalalib/test/src/mill/scalalib/ResolveDepsTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/ResolveDepsTests.scala
@@ -8,7 +8,7 @@ import mill.define.{PathRef}
 import mill.api.{Result}
 
 import mill.define.{Discover, Task}
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import utest.*
 import mill.util.TokenReaders._
 object ResolveDepsTests extends TestSuite {
@@ -35,7 +35,7 @@ object ResolveDepsTests extends TestSuite {
     }
   }
 
-  object TestCase extends TestBaseModule {
+  object TestCase extends TestRootModule {
     object pomStuff extends JavaModule {
       def mvnDeps = Seq(
         // Dependency whose packaging is "pom", as it's meant to be used

--- a/libs/scalalib/test/src/mill/scalalib/ScalaAmmoniteTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/ScalaAmmoniteTests.scala
@@ -2,12 +2,12 @@ package mill.scalalib
 
 import mill.*
 import mill.define.Discover
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import utest.*
 
 object ScalaAmmoniteTests extends TestSuite {
 
-  object AmmoniteReplMainClass extends TestBaseModule {
+  object AmmoniteReplMainClass extends TestRootModule {
     object oldAmmonite extends ScalaModule {
       override def scalaVersion = T("2.13.5")
       override def ammoniteVersion = T("2.4.1")

--- a/libs/scalalib/test/src/mill/scalalib/ScalaAssemblyAppendTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/ScalaAssemblyAppendTests.scala
@@ -10,7 +10,7 @@ import HelloWorldTests._
 
 object ScalaAssemblyAppendTests extends TestSuite with ScalaAssemblyTestUtils {
   def tests: Tests = Tests {
-    def checkAppend[M <: mill.testkit.TestBaseModule](module: M, target: Target[PathRef]) =
+    def checkAppend[M <: mill.testkit.TestRootModule](module: M, target: Target[PathRef]) =
       UnitTester(module, resourcePath).scoped { eval =>
         val Right(result) = eval.apply(target): @unchecked
 
@@ -34,7 +34,7 @@ object ScalaAssemblyAppendTests extends TestSuite with ScalaAssemblyTestUtils {
         }
       }
 
-    def checkAppendMulti[M <: mill.testkit.TestBaseModule](
+    def checkAppendMulti[M <: mill.testkit.TestRootModule](
         module: M,
         target: Target[PathRef]
     ): Unit = UnitTester(
@@ -60,7 +60,7 @@ object ScalaAssemblyAppendTests extends TestSuite with ScalaAssemblyTestUtils {
       }
     }
 
-    def checkAppendWithSeparator[M <: mill.testkit.TestBaseModule](
+    def checkAppendWithSeparator[M <: mill.testkit.TestRootModule](
         module: M,
         target: Target[PathRef]
     ): Unit = UnitTester(

--- a/libs/scalalib/test/src/mill/scalalib/ScalaAssemblyExcludeTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/ScalaAssemblyExcludeTests.scala
@@ -9,7 +9,7 @@ import scala.util.Using
 import HelloWorldTests._
 object ScalaAssemblyExcludeTests extends TestSuite with ScalaAssemblyTestUtils {
   def tests: Tests = Tests {
-    def checkExclude[M <: mill.testkit.TestBaseModule](
+    def checkExclude[M <: mill.testkit.TestRootModule](
         module: M,
         target: Target[PathRef],
         resourcePath: os.Path = resourcePath
@@ -40,7 +40,7 @@ object ScalaAssemblyExcludeTests extends TestSuite with ScalaAssemblyTestUtils {
       resourcePath = helloWorldMultiResourcePath
     )
 
-    def checkRelocate[M <: mill.testkit.TestBaseModule](
+    def checkRelocate[M <: mill.testkit.TestRootModule](
         module: M,
         target: Target[PathRef],
         resourcePath: os.Path = resourcePath

--- a/libs/scalalib/test/src/mill/scalalib/ScalaAssemblyTestUtils.scala
+++ b/libs/scalalib/test/src/mill/scalalib/ScalaAssemblyTestUtils.scala
@@ -1,7 +1,7 @@
 package mill.scalalib
 
 import mill.*
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import mill.util.TokenReaders._
 import HelloWorldTests.*
 import mill.define.Discover
@@ -9,7 +9,7 @@ trait ScalaAssemblyTestUtils {
 
   val akkaHttpDeps = Seq(mvn"com.typesafe.akka::akka-http:10.0.13")
 
-  object HelloWorldAkkaHttpAppend extends TestBaseModule {
+  object HelloWorldAkkaHttpAppend extends TestRootModule {
     object core extends HelloWorldModuleWithMain {
       override def mvnDeps = akkaHttpDeps
       override def assemblyRules = Seq(Assembly.Rule.Append("reference.conf"))
@@ -18,7 +18,7 @@ trait ScalaAssemblyTestUtils {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object HelloWorldAkkaHttpExclude extends TestBaseModule {
+  object HelloWorldAkkaHttpExclude extends TestRootModule {
     object core extends HelloWorldModuleWithMain {
       override def mvnDeps = akkaHttpDeps
       override def assemblyRules = Seq(Assembly.Rule.Exclude("reference.conf"))
@@ -28,7 +28,7 @@ trait ScalaAssemblyTestUtils {
 
   }
 
-  object HelloWorldAkkaHttpAppendPattern extends TestBaseModule {
+  object HelloWorldAkkaHttpAppendPattern extends TestRootModule {
     object core extends HelloWorldModuleWithMain {
       override def mvnDeps = akkaHttpDeps
       override def assemblyRules = Seq(Assembly.Rule.AppendPattern(".*.conf"))
@@ -38,7 +38,7 @@ trait ScalaAssemblyTestUtils {
 
   }
 
-  object HelloWorldAkkaHttpExcludePattern extends TestBaseModule {
+  object HelloWorldAkkaHttpExcludePattern extends TestRootModule {
     object core extends HelloWorldModuleWithMain {
       override def mvnDeps = akkaHttpDeps
       override def assemblyRules = Seq(Assembly.Rule.ExcludePattern(".*.conf"))
@@ -47,7 +47,7 @@ trait ScalaAssemblyTestUtils {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object HelloWorldAkkaHttpRelocate extends TestBaseModule {
+  object HelloWorldAkkaHttpRelocate extends TestRootModule {
     object core extends HelloWorldModuleWithMain {
       override def mvnDeps = akkaHttpDeps
       override def assemblyRules = Seq(Assembly.Rule.Relocate("akka.**", "shaded.akka.@1"))
@@ -56,7 +56,7 @@ trait ScalaAssemblyTestUtils {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object HelloWorldAkkaHttpNoRules extends TestBaseModule {
+  object HelloWorldAkkaHttpNoRules extends TestRootModule {
     object core extends HelloWorldModuleWithMain {
       override def mvnDeps = akkaHttpDeps
       override def assemblyRules = Seq.empty
@@ -65,7 +65,7 @@ trait ScalaAssemblyTestUtils {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object HelloWorldMultiAppend extends TestBaseModule {
+  object HelloWorldMultiAppend extends TestRootModule {
     object core extends HelloWorldModuleWithMain {
       override def moduleDeps = Seq(model)
       override def assemblyRules = Seq(Assembly.Rule.Append("reference.conf"))
@@ -75,7 +75,7 @@ trait ScalaAssemblyTestUtils {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object HelloWorldMultiExclude extends TestBaseModule {
+  object HelloWorldMultiExclude extends TestRootModule {
     object core extends HelloWorldModuleWithMain {
       override def moduleDeps = Seq(model)
       override def assemblyRules = Seq(Assembly.Rule.Exclude("reference.conf"))
@@ -85,7 +85,7 @@ trait ScalaAssemblyTestUtils {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object HelloWorldMultiAppendPattern extends TestBaseModule {
+  object HelloWorldMultiAppendPattern extends TestRootModule {
     object core extends HelloWorldModuleWithMain {
       override def moduleDeps = Seq(model)
       override def assemblyRules = Seq(Assembly.Rule.AppendPattern(".*.conf"))
@@ -95,7 +95,7 @@ trait ScalaAssemblyTestUtils {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object HelloWorldMultiAppendByPatternWithSeparator extends TestBaseModule {
+  object HelloWorldMultiAppendByPatternWithSeparator extends TestRootModule {
     object core extends HelloWorldModuleWithMain {
       override def moduleDeps = Seq(model)
       override def assemblyRules = Seq(Assembly.Rule.AppendPattern(".*.conf", "\n"))
@@ -105,7 +105,7 @@ trait ScalaAssemblyTestUtils {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object HelloWorldMultiExcludePattern extends TestBaseModule {
+  object HelloWorldMultiExcludePattern extends TestRootModule {
     object core extends HelloWorldModuleWithMain {
       override def moduleDeps = Seq(model)
       override def assemblyRules = Seq(Assembly.Rule.ExcludePattern(".*.conf"))
@@ -115,7 +115,7 @@ trait ScalaAssemblyTestUtils {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object HelloWorldMultiNoRules extends TestBaseModule {
+  object HelloWorldMultiNoRules extends TestRootModule {
     object core extends HelloWorldModuleWithMain {
       override def moduleDeps = Seq(model)
       override def assemblyRules = Seq.empty

--- a/libs/scalalib/test/src/mill/scalalib/ScalaColorOutputTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/ScalaColorOutputTests.scala
@@ -1,7 +1,7 @@
 package mill.scalalib
 
 import mill.api.ExecResult
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import utest.*
 
 import java.io.{ByteArrayOutputStream, PrintStream}
@@ -10,7 +10,7 @@ import mill.define.Discover
 import mill.util.TokenReaders._
 object ScalaColorOutputTests extends TestSuite {
 
-  object HelloWorldColorOutput extends TestBaseModule {
+  object HelloWorldColorOutput extends TestRootModule {
     object core extends ScalaModule {
       def scalaVersion = scala213Version
 

--- a/libs/scalalib/test/src/mill/scalalib/ScalaCrossVersionTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/ScalaCrossVersionTests.scala
@@ -1,14 +1,14 @@
 package mill.scalalib
 
 import mill.*
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import utest.*
 import HelloWorldTests.*
 import mill.define.Discover
 
 object ScalaCrossVersionTests extends TestSuite {
 
-  object CrossModuleDeps extends TestBaseModule {
+  object CrossModuleDeps extends TestRootModule {
     object stable extends Cross[Stable](scala212Version, scala32Version)
     trait Stable extends CrossScalaModule
 

--- a/libs/scalalib/test/src/mill/scalalib/ScalaDoc3Tests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/ScalaDoc3Tests.scala
@@ -4,11 +4,11 @@ import mill.*
 import mill.define.Discover
 import utest.*
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 
 object ScalaDoc3Tests extends TestSuite {
   // a project with static docs
-  object StaticDocsModule extends TestBaseModule {
+  object StaticDocsModule extends TestRootModule {
     object static extends ScalaModule {
       def scalaVersion = "3.0.0-RC1"
     }
@@ -16,7 +16,7 @@ object ScalaDoc3Tests extends TestSuite {
   }
 
   // a project without static docs (i.e. only api docs, no markdown files)
-  object EmptyDocsModule extends TestBaseModule {
+  object EmptyDocsModule extends TestRootModule {
     object empty extends ScalaModule {
       def scalaVersion = "3.0.0-RC1"
     }
@@ -25,7 +25,7 @@ object ScalaDoc3Tests extends TestSuite {
   }
 
   // a project with multiple static doc folders
-  object MultiDocsModule extends TestBaseModule {
+  object MultiDocsModule extends TestRootModule {
     object multidocs extends ScalaModule {
       def scalaVersion = "3.0.0-RC1"
       def docResources = Task.Sources(

--- a/libs/scalalib/test/src/mill/scalalib/ScalaDotty213Tests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/ScalaDotty213Tests.scala
@@ -2,11 +2,11 @@ package mill.scalalib
 
 import mill.*
 import mill.define.Discover
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import utest.*
 
 object ScalaDotty213Tests extends TestSuite {
-  object Dotty213 extends TestBaseModule {
+  object Dotty213 extends TestRootModule {
     object foo extends ScalaModule {
       def scalaVersion = "0.18.1-RC1"
       override def mvnDeps =

--- a/libs/scalalib/test/src/mill/scalalib/ScalaFlagsTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/ScalaFlagsTests.scala
@@ -1,6 +1,6 @@
 package mill.scalalib
 
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import utest.*
 import HelloWorldTests.*
 import mill.define.Discover
@@ -8,7 +8,7 @@ import mill.util.TokenReaders._
 
 object ScalaFlagsTests extends TestSuite {
 
-  object HelloWorldFlags extends TestBaseModule {
+  object HelloWorldFlags extends TestRootModule {
     object core extends ScalaModule {
       def scalaVersion = scala212Version
 

--- a/libs/scalalib/test/src/mill/scalalib/ScalaIvyDepsTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/ScalaIvyDepsTests.scala
@@ -1,13 +1,13 @@
 package mill.scalalib
 
 import mill.*
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import utest.*
 import HelloWorldTests.*
 import mill.define.Discover
 object ScalaMvnDepsTests extends TestSuite {
 
-  object HelloWorldMvnDeps extends TestBaseModule {
+  object HelloWorldMvnDeps extends TestRootModule {
     object moduleA extends HelloWorldTests.HelloWorldModule {
       override def mvnDeps = Seq(mvn"com.lihaoyi::sourcecode:0.1.3")
     }
@@ -19,7 +19,7 @@ object ScalaMvnDepsTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object TransitiveRunMvnDeps extends TestBaseModule {
+  object TransitiveRunMvnDeps extends TestRootModule {
     object upstream extends JavaModule {
       def mvnDeps = Seq(mvn"org.slf4j:slf4j-api:2.0.16")
       def runMvnDeps = Seq(mvn"ch.qos.logback:logback-classic:1.5.10")
@@ -33,7 +33,7 @@ object ScalaMvnDepsTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object TransitiveRunMvnDeps2 extends TestBaseModule {
+  object TransitiveRunMvnDeps2 extends TestRootModule {
     object upstream extends JavaModule {
       def mvnDeps = Seq(mvn"org.slf4j:slf4j-api:2.0.16")
       def runMvnDeps = Seq(mvn"ch.qos.logback:logback-classic:1.5.10")
@@ -47,7 +47,7 @@ object ScalaMvnDepsTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object MvnDepsRepositoriesTaskDep extends TestBaseModule {
+  object MvnDepsRepositoriesTaskDep extends TestRootModule {
     object module extends JavaModule {
       def repositoriesTask = Task.Anon {
         super.repositoriesTask() ++ Seq(

--- a/libs/scalalib/test/src/mill/scalalib/ScalaMacrosTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/ScalaMacrosTests.scala
@@ -1,7 +1,7 @@
 package mill.scalalib
 
 import mill.*
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import utest.*
 
 import scala.util.Properties
@@ -9,7 +9,7 @@ import HelloWorldTests.*
 import mill.define.Discover
 object ScalaMacrosTests extends TestSuite {
 
-  object HelloWorldMacros212 extends TestBaseModule {
+  object HelloWorldMacros212 extends TestRootModule {
     object core extends ScalaModule {
       override def scalaVersion = scala212Version
       override def mvnDeps = Seq(
@@ -22,7 +22,7 @@ object ScalaMacrosTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object HelloWorldMacros213 extends TestBaseModule {
+  object HelloWorldMacros213 extends TestRootModule {
     object core extends ScalaModule {
       override def scalaVersion = scala213Version
       override def mvnDeps = Seq(mvn"com.github.julien-truffaut::monocle-macro::2.1.0")

--- a/libs/scalalib/test/src/mill/scalalib/ScalaMixedProjectSemanticDbTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/ScalaMixedProjectSemanticDbTests.scala
@@ -1,13 +1,13 @@
 package mill.scalalib
 
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import utest.*
 import mill.define.Discover
 import mill.util.TokenReaders._
 
 object ScalaMixedProjectSemanticDbTests extends TestSuite {
 
-  object SemanticWorld extends TestBaseModule {
+  object SemanticWorld extends TestRootModule {
     object core extends HelloWorldTests.SemanticModule
 
     lazy val millDiscover = Discover[this.type]

--- a/libs/scalalib/test/src/mill/scalalib/ScalaMultiModuleClasspathsTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/ScalaMultiModuleClasspathsTests.scala
@@ -1,14 +1,14 @@
 package mill.scalalib
 
 import mill._
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import utest._
 import mill.define.Discover
 import mill.util.TokenReaders._
 import HelloWorldTests._
 object ScalaMultiModuleClasspathsTests extends TestSuite {
 
-  object MultiModuleClasspaths extends TestBaseModule {
+  object MultiModuleClasspaths extends TestRootModule {
     trait FooModule extends ScalaModule {
       def scalaVersion = "2.13.12"
 

--- a/libs/scalalib/test/src/mill/scalalib/ScalaRunTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/ScalaRunTests.scala
@@ -2,19 +2,19 @@ package mill.scalalib
 
 import mill.*
 import mill.api.ExecResult
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import utest.*
 import HelloWorldTests.*
 import mill.define.Discover
 object ScalaRunTests extends TestSuite {
 
-  object HelloWorldDefaultMain extends TestBaseModule {
+  object HelloWorldDefaultMain extends TestRootModule {
     object core extends HelloWorldTests.HelloWorldModule
 
     lazy val millDiscover = Discover[this.type]
   }
 
-  object HelloWorldWithoutMain extends TestBaseModule {
+  object HelloWorldWithoutMain extends TestRootModule {
     object core extends HelloWorldTests.HelloWorldModule {
       override def mainClass = None
     }
@@ -22,7 +22,7 @@ object ScalaRunTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object HelloWorldWithMain extends TestBaseModule {
+  object HelloWorldWithMain extends TestRootModule {
     object core extends HelloWorldTests.HelloWorldModuleWithMain
 
     lazy val millDiscover = Discover[this.type]

--- a/libs/scalalib/test/src/mill/scalalib/ScalaScalacheckTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/ScalaScalacheckTests.scala
@@ -1,13 +1,13 @@
 package mill.scalalib
 
 import mill.*
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import utest.*
 import HelloWorldTests.*
 import mill.define.Discover
 object ScalaScalacheckTests extends TestSuite {
 
-  object HelloScalacheck extends TestBaseModule {
+  object HelloScalacheck extends TestRootModule {
     object foo extends ScalaModule {
       def scalaVersion = scala212Version
       object test extends ScalaTests {

--- a/libs/scalalib/test/src/mill/scalalib/ScalaScaladocTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/ScalaScaladocTests.scala
@@ -2,13 +2,13 @@ package mill.scalalib
 
 import mill.*
 import mill.api.ExecResult
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import utest.*
 import HelloWorldTests.*
 import mill.define.Discover
 object ScalaScaladocTests extends TestSuite {
 
-  object HelloWorldWithDocVersion extends TestBaseModule {
+  object HelloWorldWithDocVersion extends TestRootModule {
     object core extends HelloWorldModule {
       override def scalacOptions = T(Seq("-Ywarn-unused", "-Xfatal-warnings"))
       override def scalaDocOptions = super.scalaDocOptions() ++ Seq("-doc-version", "1.2.3")
@@ -17,7 +17,7 @@ object ScalaScaladocTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object HelloWorldOnlyDocVersion extends TestBaseModule {
+  object HelloWorldOnlyDocVersion extends TestRootModule {
     object core extends HelloWorldModule {
       override def scalacOptions = T(Seq("-Ywarn-unused", "-Xfatal-warnings"))
       override def scalaDocOptions = T(Seq("-doc-version", "1.2.3"))
@@ -27,7 +27,7 @@ object ScalaScaladocTests extends TestSuite {
 
   }
 
-  object HelloWorldDocTitle extends TestBaseModule {
+  object HelloWorldDocTitle extends TestRootModule {
     object core extends HelloWorldModule {
       override def scalaDocOptions = T(Seq("-doc-title", "Hello World"))
     }

--- a/libs/scalalib/test/src/mill/scalalib/ScalaSemanticDbTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/ScalaSemanticDbTests.scala
@@ -1,6 +1,6 @@
 package mill.scalalib
 
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import utest.*
 import HelloWorldTests.*
 import mill.define.Discover
@@ -8,7 +8,7 @@ import mill.util.TokenReaders._
 
 object ScalaSemanticDbTests extends TestSuite {
 
-  object SemanticWorld extends TestBaseModule {
+  object SemanticWorld extends TestRootModule {
     object core extends SemanticModule
 
     lazy val millDiscover = Discover[this.type]

--- a/libs/scalalib/test/src/mill/scalalib/ScalaTypeLevelTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/ScalaTypeLevelTests.scala
@@ -1,13 +1,13 @@
 package mill.scalalib
 
 import mill.*
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import utest.*
 import HelloWorldTests.*
 import mill.define.Discover
 object ScalaTypeLevelTests extends TestSuite {
 
-  object HelloWorldTypeLevel extends TestBaseModule {
+  object HelloWorldTypeLevel extends TestRootModule {
     object foo extends ScalaModule {
       override def scalaVersion = "2.11.8"
       override def scalaOrganization = "org.typelevel"

--- a/libs/scalalib/test/src/mill/scalalib/ScalaValidatedPathRefTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/ScalaValidatedPathRefTests.scala
@@ -3,11 +3,11 @@ package mill.scalalib
 import mill.*
 import mill.define.{Discover, NamedTask}
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import utest.*
 object ScalaValidatedPathRefTests extends TestSuite {
 
-  object ValidatedTarget extends TestBaseModule {
+  object ValidatedTarget extends TestRootModule {
     private def mkDirWithFile = Task.Anon {
       os.write(Task.dest / "dummy", "dummy", createFolders = true)
       PathRef(Task.dest)

--- a/libs/scalalib/test/src/mill/scalalib/ScalaVersionsRangesTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/ScalaVersionsRangesTests.scala
@@ -3,11 +3,11 @@ package mill.scalalib
 import mill.*
 import mill.define.Discover
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import utest.*
 
 object ScalaVersionsRangesTests extends TestSuite {
-  object ScalaVersionsRanges extends TestBaseModule {
+  object ScalaVersionsRanges extends TestRootModule {
     object core extends Cross[CoreCrossModule]("2.12.13", "2.13.5", "3.3.3")
     trait CoreCrossModule extends CrossScalaModule
         with CrossScalaVersionRanges {

--- a/libs/scalalib/test/src/mill/scalalib/TestClassLoaderTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/TestClassLoaderTests.scala
@@ -2,12 +2,12 @@ package mill.scalalib
 
 import mill.define.Discover
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import mill.util.TokenReaders.*
 import utest.*
 
 object TestClassLoaderTests extends TestSuite {
-  object testclassloader extends TestBaseModule with ScalaModule {
+  object testclassloader extends TestRootModule with ScalaModule {
     def scalaVersion = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
 
     object test extends ScalaTests with TestModule.Utest {

--- a/libs/scalalib/test/src/mill/scalalib/TestRunnerParallelismTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/TestRunnerParallelismTests.scala
@@ -2,12 +2,12 @@ package mill.scalalib
 
 import mill.T
 import mill.define.Discover
-import mill.testkit.{TestBaseModule, UnitTester}
+import mill.testkit.{TestRootModule, UnitTester}
 import utest.*
 import mill.util.TokenReaders.*
 
 object TestRunnerParallelismTests extends TestSuite {
-  object utestSingleTest extends TestBaseModule with ScalaModule with TestModule.Utest {
+  object utestSingleTest extends TestRootModule with ScalaModule with TestModule.Utest {
     override def scalaVersion: T[String] = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
 
     override def utestVersion = sys.props.getOrElse("TEST_UTEST_VERSION", ???)

--- a/libs/scalalib/test/src/mill/scalalib/TestRunnerTestUtils.scala
+++ b/libs/scalalib/test/src/mill/scalalib/TestRunnerTestUtils.scala
@@ -3,7 +3,7 @@ package mill.scalalib
 import mill.api.Result
 import mill.define.Discover
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import mill.util.TokenReaders._
 import mill.Task
 import os.Path
@@ -35,7 +35,7 @@ object TestRunnerTestUtils {
     lazy val millDiscover = Discover[this.type]
   }
 
-  trait TestRunnerTestModule extends TestBaseModule with ScalaModule {
+  trait TestRunnerTestModule extends TestRootModule with ScalaModule {
     def computeTestForkGrouping(x: Seq[String]): Seq[Seq[String]]
     def enableParallelism: Boolean
     def scalaVersion = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)

--- a/libs/scalalib/test/src/mill/scalalib/bsp/BspModuleTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/bsp/BspModuleTests.scala
@@ -5,7 +5,7 @@ import mill.define.ExecutionPaths
 import mill.T
 import mill.scalalib.{DepSyntax, JavaModule, ScalaModule}
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import os.FilePath
 import utest.*
 import mill.util.TokenReaders._
@@ -14,7 +14,7 @@ object BspModuleTests extends TestSuite {
 
   val testScalaVersion = sys.props.getOrElse("TEST_SCALA_2_13_VERSION", ???)
 
-  object MultiBase extends TestBaseModule {
+  object MultiBase extends TestRootModule {
     object HelloBsp extends ScalaModule {
       def scalaVersion = testScalaVersion
       override def mvnDeps = Seq(mvn"org.slf4j:slf4j-api:1.7.34")
@@ -27,7 +27,7 @@ object BspModuleTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object InterDeps extends TestBaseModule {
+  object InterDeps extends TestRootModule {
     val maxCrossCount = 15
     val configs = 1.to(maxCrossCount)
     object Mod extends Cross[ModCross](configs)

--- a/libs/scalalib/test/src/mill/scalalib/giter8/Giter8Tests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/giter8/Giter8Tests.scala
@@ -1,7 +1,7 @@
 package mill.scalalib.giter8
 
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import utest.*
 
 import mill.define.Discover
@@ -17,7 +17,7 @@ object Giter8Tests extends TestSuite {
             template.replace("file:", "file://")
           } else template
 
-        object g8Module extends TestBaseModule with Giter8Module {
+        object g8Module extends TestRootModule with Giter8Module {
           lazy val millDiscover = Discover[this.type]
         }
 

--- a/libs/scalalib/test/src/mill/scalalib/scalafmt/ScalafmtTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/scalafmt/ScalafmtTests.scala
@@ -5,7 +5,7 @@ import mill.define.Discover
 import mill.util.Tasks
 import mill.scalalib.ScalaModule
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import utest.*
 
 object ScalafmtTests extends TestSuite {
@@ -16,7 +16,7 @@ object ScalafmtTests extends TestSuite {
     def buildSources: T[Seq[PathRef]]
   }
 
-  object ScalafmtTestModule extends TestBaseModule {
+  object ScalafmtTestModule extends TestRootModule {
     object core extends ScalaModule with ScalafmtModule with BuildSrcModule {
       def scalaVersion: T[String] = sys.props.getOrElse("TEST_SCALA_2_12_VERSION", ???)
 

--- a/libs/scalanativelib/test/src/mill/scalanativelib/CompileRunTests.scala
+++ b/libs/scalanativelib/test/src/mill/scalanativelib/CompileRunTests.scala
@@ -8,7 +8,7 @@ import mill.scalalib.{PublishModule, ScalaModule, TestModule}
 import mill.scalalib.publish.{Developer, License, PomSettings, VersionControl}
 import mill.scalanativelib.api._
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import utest._
 
 import java.util.jar.JarFile
@@ -31,7 +31,7 @@ object CompileRunTests extends TestSuite {
   val scalaNative05 = sys.props.getOrElse("TEST_SCALANATIVE_0_5_VERSION", ???)
   val testUtestVersion = sys.props.getOrElse("TEST_UTEST_VERSION", ???)
 
-  object HelloNativeWorld extends TestBaseModule {
+  object HelloNativeWorld extends TestRootModule {
     implicit object ReleaseModeToSegments
         extends Cross.ToSegments[ReleaseMode](v => List(v.toString))
 

--- a/libs/scalanativelib/test/src/mill/scalanativelib/ExclusionsTests.scala
+++ b/libs/scalanativelib/test/src/mill/scalanativelib/ExclusionsTests.scala
@@ -4,11 +4,11 @@ import mill.given
 import mill.scalalib._
 import mill.define.Discover
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import utest._
 
 object ExclusionsTests extends TestSuite {
-  object Exclusions extends TestBaseModule {
+  object Exclusions extends TestRootModule {
     object scala213 extends ScalaNativeModule {
       def scalaNativeVersion = "0.4.3"
       def scalaVersion = "2.13.10"

--- a/libs/scalanativelib/test/src/mill/scalanativelib/FeaturesTests.scala
+++ b/libs/scalanativelib/test/src/mill/scalanativelib/FeaturesTests.scala
@@ -3,11 +3,11 @@ package mill.scalanativelib
 import mill.given
 import mill.define.Discover
 import mill.testkit.UnitTester
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import utest._
 
 object FeaturesTests extends TestSuite {
-  object Features extends TestBaseModule with ScalaNativeModule {
+  object Features extends TestRootModule with ScalaNativeModule {
     def scalaNativeVersion = "0.5.0"
     def scalaVersion = "2.13.10"
     def nativeIncrementalCompilation = true

--- a/libs/scalanativelib/test/src/mill/scalanativelib/ScalaTestsErrorTests.scala
+++ b/libs/scalanativelib/test/src/mill/scalanativelib/ScalaTestsErrorTests.scala
@@ -3,11 +3,11 @@ package mill.scalanativelib
 import mill._
 import mill.define.Discover
 import mill.scalalib.TestModule
-import mill.testkit.TestBaseModule
+import mill.testkit.TestRootModule
 import utest._
 
 object ScalaTestsErrorTests extends TestSuite {
-  object ScalaTestsError extends TestBaseModule {
+  object ScalaTestsError extends TestRootModule {
     object scalaTestsError extends ScalaNativeModule {
       def scalaVersion = sys.props.getOrElse("TEST_SCALA_3_3_VERSION", ???)
       def scalaNativeVersion = sys.props.getOrElse("TEST_SCALANATIVE_0_4_VERSION", ???)

--- a/testkit/src/mill/testkit/TestBaseModule.scala
+++ b/testkit/src/mill/testkit/TestBaseModule.scala
@@ -3,7 +3,7 @@ package mill.testkit
 /**
  * A wrapper of [[mill.define.BaseModule]] meant for easy instantiation in test suites.
  */
-abstract class TestBaseModule(
+abstract class TestRootModule(
     baseModuleSourcePath: os.Path
 )(implicit
     millModuleEnclosing0: sourcecode.Enclosing,

--- a/testkit/src/mill/testkit/UnitTester.scala
+++ b/testkit/src/mill/testkit/UnitTester.scala
@@ -13,7 +13,7 @@ import java.io.{InputStream, PrintStream}
 object UnitTester {
   case class Result[T](value: T, evalCount: Int)
   def apply(
-      module: mill.testkit.TestBaseModule,
+      module: mill.testkit.TestRootModule,
       sourceRoot: os.Path,
       failFast: Boolean = false,
       threads: Option[Int] = Some(1),
@@ -45,7 +45,7 @@ object UnitTester {
  * @param threads explicitly used nr. of parallel threads
  */
 class UnitTester(
-    module: mill.testkit.TestBaseModule,
+    module: mill.testkit.TestRootModule,
     sourceRoot: os.Path,
     failFast: Boolean,
     threads: Option[Int],

--- a/testkit/test/src/mill/testkit/UnitTesterTests.scala
+++ b/testkit/test/src/mill/testkit/UnitTesterTests.scala
@@ -9,7 +9,7 @@ object UnitTesterTests extends TestSuite {
   val resourcePath = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "unit-test-example-project"
   def tests: Tests = Tests {
     test("simple") {
-      object build extends TestBaseModule {
+      object build extends TestRootModule {
         def testTask = Task { "test" }
 
         lazy val millDiscover = Discover[this.type]
@@ -22,7 +22,7 @@ object UnitTesterTests extends TestSuite {
     }
 
     test("sources") {
-      object build extends TestBaseModule {
+      object build extends TestRootModule {
         def testSource = Task.Source("source-file.txt")
         def testTask = Task { os.read(testSource().path).toUpperCase() }
 


### PR DESCRIPTION
Follow up from https://github.com/com-lihaoyi/mill/issues/5141

The term `TestBaseModule` is a bit ambiguous, since it seems like a "base class" that all test modules should inherit, when only the root module should inherit it. Naming it `TestRootModule` should avoid that confusion