### PR TITLE
Use named tuples in Tasks

### DIFF
--- a/ci/mill-bootstrap.patch
+++ b/ci/mill-bootstrap.patch
@@ -20,6 +20,18 @@ index 4465e163a55..6b8da38aae7 100644
  
  val dummyDeps: Seq[Dep] = Seq(
    Deps.DocDeps.millScip,
+diff --git a/integration/package.mill b/integration/package.mill
+index a5183fc0a5a..4cb6f6689cd 100644
+--- a/integration/package.mill
++++ b/integration/package.mill
+@@ -14,6 +14,7 @@ import mill.T
+ import mill.define.Cross
+ import mill.testrunner.TestResult
+ import millbuild.*
++import upickle.implicits.namedTuples.default.given
+ 
+ object `package` extends mill.Module {
+   // We compile the test code once and then offer multiple modes to
 diff --git a/runner/codesig/package.mill b/runner/codesig/package.mill
 index 3950422474a..1ed233d24f7 100644
 --- a/runner/codesig/package.mill

--- a/contrib/testng/test/src/mill/testng/TestNGTests.scala
+++ b/contrib/testng/test/src/mill/testng/TestNGTests.scala
@@ -53,18 +53,18 @@ object TestNGTests extends TestSuite {
       eval =>
         val Right(result) = eval.apply(demo.test.testForked()): @unchecked
         val tres = result.value
-        assert(tres._2.size == 8)
+        assert(tres.results.size == 8)
     }
     test("noGrouping") - UnitTester(demo, resourcePath).scoped {
       eval =>
         val Right(result) = eval.apply(demo.testng.testForked()): @unchecked
-        val tres = result.value._2
+        val tres = result.value.results
         assert(tres.map(_.fullyQualifiedName).toSet == Set("foo.HelloTests", "foo.WorldTests"))
     }
     test("testForkGrouping") - UnitTester(demo, resourcePath).scoped {
       eval =>
         val Right(result) = eval.apply(demo.testngGrouping.testForked()): @unchecked
-        val tres = result.value._2
+        val tres = result.value.results
         assert(tres.map(_.fullyQualifiedName).toSet == Set("foo.HelloTests", "foo.WorldTests"))
     }
   }

--- a/core/api/src/mill/api/internal/api.scala
+++ b/core/api/src/mill/api/internal/api.scala
@@ -58,8 +58,9 @@ trait ScalaModuleApi extends JavaModuleApi
 trait ScalaJSModuleApi extends JavaModuleApi
 trait ScalaNativeModuleApi extends JavaModuleApi
 trait TestModuleApi extends ModuleApi {
-  def testLocal(args: String*): TaskApi[(String, Seq[Any])]
-  private[mill] def bspBuildTargetScalaTestClasses: TaskApi[(String, Seq[String])]
+  def testLocal(args: String*): TaskApi[(msg: String, results: Seq[Any])]
+  private[mill] def bspBuildTargetScalaTestClasses
+      : TaskApi[(frameworkName: String, classes: Seq[String])]
 }
 trait MainModuleApi extends ModuleApi {
   private[mill] def bspClean(

--- a/example/androidlib/java/1-hello-world/build.mill
+++ b/example/androidlib/java/1-hello-world/build.mill
@@ -120,9 +120,9 @@ object app extends AndroidAppModule {
 
 > ./mill show app.it
 ...
-[
-  "",
-  [
+{
+  "msg": "",
+  "results": [
     {
       "fullyQualifiedName": "com.helloworld.app.ExampleInstrumentedTest.useAppContext",
       "selector": "com.helloworld.app.ExampleInstrumentedTest.useAppContext",
@@ -130,7 +130,7 @@ object app extends AndroidAppModule {
       "status": "Success"
     }
   ]
-]
+}
 ...
 
 > cat out/app/it/testForked.dest/test-report.xml

--- a/example/androidlib/java/4-sum-lib-java/build.mill
+++ b/example/androidlib/java/4-sum-lib-java/build.mill
@@ -142,9 +142,9 @@ Publish ... to /home/.../.m2/repository/...
 
 > ./mill show app.test
 ...
-[
-  "",
-  [
+{
+  "msg": "",
+  "results": [
     {
       "fullyQualifiedName": "com.example.app.CalculatorUnitTest.textSize_isCorrect",
       "selector": "com.example.app.CalculatorUnitTest.textSize_isCorrect",
@@ -158,6 +158,6 @@ Publish ... to /home/.../.m2/repository/...
       "status": "Success"
     }
   ]
-]
+}
 ...
 */

--- a/example/androidlib/java/5-R8/build.mill
+++ b/example/androidlib/java/5-R8/build.mill
@@ -103,9 +103,9 @@ object app extends AndroidAppModule { // <2>
 
 > ./mill show app.it
 ...
-[
-  "",
-  [
+{
+  "msg": "",
+  "results": [
     {
       "fullyQualifiedName": "com.helloworld.app.ExampleInstrumentedTest.useAppContext",
       "selector": "com.helloworld.app.ExampleInstrumentedTest.useAppContext",
@@ -113,7 +113,7 @@ object app extends AndroidAppModule { // <2>
       "status": "Success"
     }
   ]
-]
+}
 
 
 > ./mill show app.stopAndroidEmulator

--- a/example/androidlib/java/6-native-libs/build.mill
+++ b/example/androidlib/java/6-native-libs/build.mill
@@ -77,9 +77,9 @@ object app extends AndroidNativeAppModule { // <1>
 
 > ./mill show app.it
 ...
-[
-  "",
-  [
+{
+  "msg": "",
+  "results": [
     {
       "fullyQualifiedName": "com.helloworld.app.ExampleInstrumentedTest.textViewDisplaysHelloFromCpp",
       "selector": "com.helloworld.app.ExampleInstrumentedTest.textViewDisplaysHelloFromCpp",
@@ -87,7 +87,7 @@ object app extends AndroidNativeAppModule { // <1>
       "status": "Success"
     }
   ]
-]
+}
 ...
 
 > ./mill show app.stopAndroidEmulator

--- a/example/androidlib/kotlin/1-hello-kotlin/build.mill
+++ b/example/androidlib/kotlin/1-hello-kotlin/build.mill
@@ -148,9 +148,9 @@ object app extends AndroidAppKotlinModule {
 
 > ./mill show app.it
 ...
-[
-  "",
-  [
+{
+  "msg": "",
+  "results": [
     {
       "fullyQualifiedName": "com.helloworld.app.ExampleInstrumentedTest.useAppContext",
       "selector": "com.helloworld.app.ExampleInstrumentedTest.useAppContext",
@@ -158,7 +158,7 @@ object app extends AndroidAppKotlinModule {
       "status": "Success"
     }
   ]
-]
+}
 ...
 
 > cat out/app/it/testForked.dest/test-report.xml

--- a/example/androidlib/kotlin/3-compose-screenshot-tests/build.mill
+++ b/example/androidlib/kotlin/3-compose-screenshot-tests/build.mill
@@ -70,9 +70,9 @@ object app extends AndroidAppKotlinModule {
 
 > ./mill show app.screenshotTest.testForked
 ...
-[
-  "",
-  [
+{
+  "msg": "",
+  "results": [
     {
       "fullyQualifiedName": "com.example.screenshottest.ExampleMessageCardScreenshots",
       "selector": "oMessageCardScreenshot()",
@@ -80,7 +80,7 @@ object app extends AndroidAppKotlinModule {
       "status": "Success"
     }
   ]
-]
+}
 ...
 
 > cat out/app/screenshotTest/testForked.dest/test-report.xml

--- a/example/androidlib/kotlin/4-sum-lib-kotlin/build.mill
+++ b/example/androidlib/kotlin/4-sum-lib-kotlin/build.mill
@@ -144,9 +144,9 @@ Publish ... to /home/.../.m2/repository/...
 
 > ./mill show app.test
 ...
-[
-  " ",
-  [
+{
+  "msg": " ",
+  "results": [
     {
       "fullyQualifiedName": "com.example.ExampleUnitTest.text_size_is_correct",
       "selector": "com.example.ExampleUnitTest.text_size_is_correct",
@@ -166,6 +166,6 @@ Publish ... to /home/.../.m2/repository/...
       "status": "Success"
     }
   ]
-]
+}
 ...
 */

--- a/example/kotlinlib/basic/7-dependency-injection/build.mill
+++ b/example/kotlinlib/basic/7-dependency-injection/build.mill
@@ -58,9 +58,9 @@ Random number: ...
 
 > ./mill show dagger.test
 ...
-[
-  "",
-  [
+{
+  "msg": "",
+  "results": [
     {
       "fullyQualifiedName": "com.example.dagger.TestConstantNumberGeneratorInjection",
       "selector": "SuiteSelector",
@@ -74,7 +74,7 @@ Random number: ...
       "status": "Success"
     }
   ]
-]
+}
 ...
 
 > ls out/dagger/test/generatedSourcesWithKSP.dest/generated/ksp/main/java/com/example/dagger/

--- a/example/thirdparty/arrow/build.mill
+++ b/example/thirdparty/arrow/build.mill
@@ -156,7 +156,7 @@ object `package` extends Module {
           if (modulesWithTestingEnabled(multiplatformRoot)) super.compile
           else Task { CompilationResult(Task.dest, PathRef(Task.dest)) }
 
-        override def testForked(args: String*): Command[(String, Seq[TestResult])] =
+        override def testForked(args: String*): Command[(msg: String, results: Seq[TestResult])] =
           if (modulesWithTestingEnabled(multiplatformRoot)) super.testForked(args: _*)
           else Task.Command { ("", Seq.empty[TestResult]) }
 
@@ -203,7 +203,7 @@ object `package` extends Module {
         if (modulesWithTestingEnabled(jvmRoot)) super.compile
         else Task { CompilationResult(Task.dest, PathRef(Task.dest)) }
 
-      override def testForked(args: String*): Command[(String, Seq[TestResult])] =
+      override def testForked(args: String*): Command[(msg: String, results: Seq[TestResult])] =
         if (modulesWithTestingEnabled(jvmRoot)) super.testForked(args: _*)
         else Task.Command { ("", Seq.empty[TestResult]) }
     }

--- a/libs/androidlib/src/mill/androidlib/AndroidAppBundle.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppBundle.scala
@@ -10,8 +10,8 @@ import os.zip.ZipSource
  */
 @mill.api.experimental
 trait AndroidAppBundle extends AndroidAppModule with JavaModule {
-
-  /**
+  
+    /**
    * Adds `--proto-format` option to AAPT commands.
    */
   override def androidAaptOptions: T[Seq[String]] = Task {
@@ -28,7 +28,7 @@ trait AndroidAppBundle extends AndroidAppModule with JavaModule {
    */
   def androidBundleZip: T[PathRef] = Task {
     val dexFile = androidDex().path
-    val resFile = androidCompiledResources()._1.path / "res.apk"
+    val resFile = androidCompiledResources().resApkFile.path
     val baseDir = Task.dest / "base"
     val appDir = Task.dest / "app"
 

--- a/libs/androidlib/src/mill/androidlib/AndroidAppBundle.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppBundle.scala
@@ -10,8 +10,8 @@ import os.zip.ZipSource
  */
 @mill.api.experimental
 trait AndroidAppBundle extends AndroidAppModule with JavaModule {
-  
-    /**
+
+  /**
    * Adds `--proto-format` option to AAPT commands.
    */
   override def androidAaptOptions: T[Seq[String]] = Task {

--- a/libs/androidlib/src/mill/androidlib/AndroidAppKotlinModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppKotlinModule.scala
@@ -202,7 +202,7 @@ trait AndroidAppKotlinModule extends AndroidKotlinModule with AndroidAppModule {
     }
 
     private def resourceApkPath: Task[PathRef] = Task {
-      PathRef(outer.androidCompiledResources()._1.path / "res.apk")
+      outer.androidCompiledResources().resApkFile
     }
 
     // TODO previews must be source controlled to be used as a base

--- a/libs/androidlib/src/mill/androidlib/AndroidAppKotlinModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppKotlinModule.scala
@@ -7,6 +7,7 @@ import mill.kotlinlib.{Dep, DepSyntax}
 import mill.scalalib.TestModule.Junit5
 import mill.scalalib.{JavaModule, TestModule}
 import mill.T
+import upickle.implicits.namedTuples.default.given
 
 /**
  * Trait for building Android applications using the Mill build tool.
@@ -190,7 +191,7 @@ trait AndroidAppKotlinModule extends AndroidKotlinModule with AndroidAppModule {
           outer.compile().classes.path.toString(),
           androidProcessedResources().path.toString
         ),
-        screenshots = androidDiscoveredPreviews()._2,
+        screenshots = androidDiscoveredPreviews().screenshotConfigs,
         namespace = androidApplicationNamespace,
         resourceApkPath = resourceApkPath().path.toString(),
         resultsFilePath = resultsFilePath.toString()
@@ -253,7 +254,10 @@ trait AndroidAppKotlinModule extends AndroidKotlinModule with AndroidAppModule {
     def androidScreenshotTestMethods: Seq[(String, Seq[String])]
 
     /* TODO enhance with hash (sha-1) and auto-detection/generation of methodFQN */
-    def androidDiscoveredPreviews: T[(PathRef, Seq[ComposeRenderer.Screenshot])] = Task {
+    def androidDiscoveredPreviews: T[(
+        previewsDiscoveredJsonFile: PathRef,
+        screenshotConfigs: Seq[ComposeRenderer.Screenshot]
+    )] = Task {
 
       val androidDiscoveredPreviewsPath = Task.dest / "previews_discovered.json"
 
@@ -271,7 +275,10 @@ trait AndroidAppKotlinModule extends AndroidKotlinModule with AndroidAppModule {
         upickle.default.write(Map("screenshots" -> screenshotConfigurations))
       )
 
-      PathRef(androidDiscoveredPreviewsPath) -> screenshotConfigurations
+      (
+        previewsDiscoveredJsonFile = PathRef(androidDiscoveredPreviewsPath),
+        screenshotConfigs = screenshotConfigurations
+      )
     }
 
     private def diffImageDirPath: Task[PathRef] = Task {
@@ -303,7 +310,7 @@ trait AndroidAppKotlinModule extends AndroidKotlinModule with AndroidAppModule {
      */
     private def testJvmArgs: T[Seq[String]] = Task {
       val params = Map(
-        "previews-discovered" -> androidDiscoveredPreviews()._1.path.toString(),
+        "previews-discovered" -> androidDiscoveredPreviews().previewsDiscoveredJsonFile.path.toString(),
         "referenceImageDirPath" -> screenshotResults().path.toString(),
         "diffImageDirPath" -> diffImageDirPath().path.toString,
         "renderResultsFilePath" -> androidScreenshotGeneratedResults().path.toString,

--- a/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
@@ -1168,7 +1168,7 @@ trait AndroidAppModule extends AndroidModule { outer =>
     override def testTask(
         args: Task[Seq[String]],
         globSelectors: Task[Seq[String]]
-    ): Task[(String, Seq[TestResult])] = Task.Anon {
+    ): Task[(msg: String, results: Seq[TestResult])] = Task.Anon {
       val device = androidTestInstall().apply()
 
       val instrumentOutput = os.proc(

--- a/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
@@ -10,6 +10,7 @@ import mill.testrunner.TestResult
 import mill.util.Jvm
 import os.{Path, RelPath, zip}
 import upickle.default.*
+import upickle.implicits.namedTuples.default.given
 
 import scala.jdk.OptionConverters.RichOptional
 import scala.xml.{Attribute, Elem, NodeBuffer, Null, Text, XML}
@@ -227,7 +228,7 @@ trait AndroidAppModule extends AndroidModule { outer =>
   def androidUnsignedApk: T[PathRef] = Task {
     val unsignedApk = Task.dest / "app.unsigned.apk"
 
-    os.copy(androidCompiledResources()._1.path / "res.apk", unsignedApk)
+    os.copy(androidCompiledResources().resApkFile.path, unsignedApk)
     val dexFiles = os.walk(androidDex().path)
       .filter(_.ext == "dex")
       .map(os.zip.ZipSource.fromPath)
@@ -807,7 +808,7 @@ trait AndroidAppModule extends AndroidModule { outer =>
       .flatMap(_.proguardRules)
       .map(p => os.read(p.path))
       .appendedAll(mainDexPlatformRules)
-      .appended(os.read(androidCompiledResources()._1.path / "main-dex-rules.pro"))
+      .appended(os.read(androidCompiledResources().mainDexRulesProFile.path))
       .mkString("\n")
     os.write(proguardFileDebug, knownProguardRulesDebug)
 
@@ -819,7 +820,7 @@ trait AndroidAppModule extends AndroidModule { outer =>
       .flatMap(_.proguardRules)
       .map(p => os.read(p.path))
       .appendedAll(mainDexPlatformRules)
-      .appended(os.read(androidCompiledResources()._1.path / "main-dex-rules.pro"))
+      .appended(os.read(androidCompiledResources().mainDexRulesProFile.path))
       .mkString("\n")
     os.write(proguardFileRelease, knownProguardRulesRelease)
 
@@ -886,23 +887,22 @@ trait AndroidAppModule extends AndroidModule { outer =>
 
     val buildSettings: AndroidBuildTypeSettings = androidBuildSettings()
 
-    val (outPath, dexCliArgs) = {
-      if (buildSettings.isMinifyEnabled) {
+    val dex =
+      if (buildSettings.isMinifyEnabled)
         androidR8Dex()
-      } else
+      else
         androidD8Dex()
-    }
 
-    Task.log.debug("Building dex with command: " + dexCliArgs.mkString(" "))
+    Task.log.debug("Building dex with command: " + dex.dexCliArgs.mkString(" "))
 
-    os.call(dexCliArgs)
+    os.call(dex.dexCliArgs)
 
-    outPath
+    dex.outPath
 
   }
 
   // uses the d8 tool to generate the dex file, when minification is disabled
-  private def androidD8Dex: T[(PathRef, Seq[String])] = Task {
+  private def androidD8Dex: T[(outPath: PathRef, dexCliArgs: Seq[String])] = Task {
 
     val outPath = T.dest
 
@@ -920,7 +920,7 @@ trait AndroidAppModule extends AndroidModule { outer =>
       .flatMap(_.proguardRules)
       .map(p => os.read(p.path))
       .appendedAll(mainDexPlatformRules)
-      .appended(os.read(androidCompiledResources()._1.path / "main-dex-rules.pro"))
+      .appended(os.read(androidCompiledResources().mainDexRulesProFile.path))
       .mkString("\n")
     os.write(proguardFile, knownProguardRules)
 
@@ -953,7 +953,7 @@ trait AndroidAppModule extends AndroidModule { outer =>
   }
 
   // uses the R8 tool to generate the dex (to shrink and obfuscate)
-  private def androidR8Dex: Task[(PathRef, Seq[String])] = Task {
+  private def androidR8Dex: Task[(outPath: PathRef, dexCliArgs: Seq[String])] = Task {
     val destDir = T.dest / "minify"
     os.makeDir.all(destDir)
 

--- a/libs/kotlinlib/src/mill/kotlinlib/js/KotlinJsModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/js/KotlinJsModule.scala
@@ -14,6 +14,7 @@ import mill.testrunner.TestResult
 import mill.util.Jvm
 import mill.{Args, T}
 import sbt.testing.Status
+import upickle.implicits.namedTuples.default.given
 
 import java.io.{File, FileNotFoundException}
 import java.util.zip.ZipFile
@@ -539,7 +540,7 @@ trait KotlinJsModule extends KotlinModule { outer =>
 
     override def kotlinJsSplitPerModule = false
 
-    override def testLocal(args: String*): Command[(String, Seq[TestResult])] =
+    override def testLocal(args: String*): Command[(msg: String, results: Seq[TestResult])] =
       Task.Command {
         this.testForked(args*)()
       }
@@ -549,7 +550,7 @@ trait KotlinJsModule extends KotlinModule { outer =>
     override protected def testTask(
         args: Task[Seq[String]],
         globSelectors: Task[Seq[String]]
-    ): Task[(String, Seq[TestResult])] = Task.Anon {
+    ): Task[(msg: String, results: Seq[TestResult])] = Task.Anon {
       val runTarget = kotlinJsRunTarget()
       if (runTarget.isEmpty) {
         throw new IllegalStateException(
@@ -616,7 +617,7 @@ trait KotlinJsModule extends KotlinModule { outer =>
              |""".stripMargin
         Task.fail(failureMessage)
       } else {
-        (doneMessage, testResults)
+        (msg = doneMessage, results = testResults)
       }
     }
 

--- a/libs/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/libs/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -11,6 +11,7 @@ import mill.scalajslib.api.*
 import mill.scalajslib.worker.{ScalaJSWorker, ScalaJSWorkerExternalModule}
 import mill.api.internal.{ScalaBuildTarget, ScalaJSModuleApi, ScalaPlatform, internal}
 import mill.T
+import upickle.implicits.namedTuples.default.given
 
 trait ScalaJSModule extends scalalib.ScalaModule with ScalaJSModuleApi { outer =>
 
@@ -376,13 +377,13 @@ trait TestScalaJSModule extends ScalaJSModule with TestModule {
     )
   }
 
-  override def testLocal(args: String*): Command[(String, Seq[TestResult])] =
+  override def testLocal(args: String*): Command[(msg: String, results: Seq[TestResult])] =
     Task.Command { testForked(args*)() }
 
   override protected def testTask(
       args: Task[Seq[String]],
       globSelectors: Task[Seq[String]]
-  ): Task[(String, Seq[TestResult])] = Task.Anon {
+  ): Task[(msg: String, results: Seq[TestResult])] = Task.Anon {
 
     val (close, framework) = ScalaJSWorkerExternalModule.scalaJSWorker().getFramework(
       scalaJSToolsClasspath(),

--- a/libs/scalajslib/test/src/mill/scalajslib/MultiModuleTests.scala
+++ b/libs/scalajslib/test/src/mill/scalajslib/MultiModuleTests.scala
@@ -57,8 +57,8 @@ object MultiModuleTests extends TestSuite {
 
         assert(
           result.evalCount > 0,
-          result.value._2.size == 3,
-          result.value._2.forall(_.status == "Success")
+          result.value.results.size == 3,
+          result.value.results.forall(_.status == "Success")
         )
       }
     }

--- a/libs/scalajslib/test/src/mill/scalajslib/UtestTests.scala
+++ b/libs/scalajslib/test/src/mill/scalajslib/UtestTests.scala
@@ -8,7 +8,7 @@ import utest._
 
 object UtestTests extends TestSuite {
   import CompileLinkTests._
-  def runTests(testTask: define.NamedTask[(String, Seq[TestResult])])
+  def runTests(testTask: define.NamedTask[(msg: String, results: Seq[TestResult])])
       : Unit =
     UnitTester(HelloJSWorld, millSourcePath).scoped { eval =>
       val Left(ExecResult.Failure(_)) = eval(testTask): @unchecked

--- a/libs/scalalib/src/mill/scalalib/TestModuleUtil.scala
+++ b/libs/scalalib/src/mill/scalalib/TestModuleUtil.scala
@@ -50,7 +50,7 @@ private final class TestModuleUtil(
     EnvVars.MILL_WORKSPACE_ROOT -> Task.workspace.toString
   )
 
-  def runTests(): Result[(String, Seq[TestResult])] = {
+  def runTests(): Result[(msg: String, results: Seq[TestResult])] = {
     val globFilter = TestRunnerUtils.globFilter(selectors)
 
     def doesNotMatchError = new Result.Exception(
@@ -524,12 +524,12 @@ private[scalalib] object TestModuleUtil {
       doneMsg: String,
       results: Seq[TestResult],
       ctx: Option[TaskCtx.Env]
-  ): Result[(String, Seq[TestResult])] = {
+  ): Result[(msg: String, results: Seq[TestResult])] = {
 
     val badTests: Seq[TestResult] =
       results.filter(x => Set("Error", "Failure").contains(x.status))
     if (badTests.isEmpty) {
-      Result.Success((doneMsg, results))
+      Result.Success((msg = doneMsg, results = results))
     } else {
       val reportCount =
         if (ctx.fold(false)(_.env.contains("CI"))) badTests.length
@@ -553,7 +553,7 @@ private[scalalib] object TestModuleUtil {
       ctx: TaskCtx.Env & TaskCtx.Dest,
       testReportXml: Option[String],
       props: Option[Map[String, String]] = None
-  ): Result[(String, Seq[TestResult])] = {
+  ): Result[(msg: String, results: Seq[TestResult])] = {
     for {
       fileName <- testReportXml
       path = ctx.dest / fileName

--- a/libs/scalalib/test/src/mill/javalib/junit5/JUnit5Tests.scala
+++ b/libs/scalalib/test/src/mill/javalib/junit5/JUnit5Tests.scala
@@ -28,7 +28,7 @@ object JUnit5Tests extends TestSuite {
       UnitTester(module, testModuleSourcesPath).scoped { eval =>
         val res = eval(module.test.testForked(""))
         assert(res.isRight)
-        assert(res.toOption.get.value._2.forall(_.fullyQualifiedName == "qux.QuxTests"))
+        assert(res.toOption.get.value.results.forall(_.fullyQualifiedName == "qux.QuxTests"))
       }
     }
   }

--- a/libs/scalalib/test/src/mill/scalalib/HelloJavaTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/HelloJavaTests.scala
@@ -172,16 +172,16 @@ object HelloJavaTests extends TestSuite {
         val Right(result2) = eval.apply(HelloJava.app.test.testForked()): @unchecked
 
         assert(
-          result2.value._2(0).fullyQualifiedName == "hello.MyAppTests.appTest",
-          result2.value._2(0).status == "Success",
-          result2.value._2(1).fullyQualifiedName == "hello.MyAppTests.coreTest",
-          result2.value._2(1).status == "Success"
+          result2.value.results(0).fullyQualifiedName == "hello.MyAppTests.appTest",
+          result2.value.results(0).status == "Success",
+          result2.value.results(1).fullyQualifiedName == "hello.MyAppTests.coreTest",
+          result2.value.results(1).status == "Success"
         )
 
         val Right(result3) = eval.apply(HelloJava.app.testJunit5.testForked()): @unchecked
 
         val testResults =
-          result3.value._2.map(t => (t.fullyQualifiedName, t.selector, t.status)).sorted
+          result3.value.results.map(t => (t.fullyQualifiedName, t.selector, t.status)).sorted
         val expected = Seq(
           ("hello.Junit5TestsA", "coreTest()", "Success"),
           ("hello.Junit5TestsA", "palindromes(String):1", "Success"),

--- a/libs/scalalib/test/src/mill/scalalib/ScalaScalacheckTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/ScalaScalacheckTests.scala
@@ -27,7 +27,7 @@ object ScalaScalacheckTests extends TestSuite {
       val Right(result) = eval.apply(HelloScalacheck.foo.test.testForked()): @unchecked
       assert(
         result.evalCount > 0,
-        result.value._2.map(_.selector) == Seq(
+        result.value.results.map(_.selector) == Seq(
           "String.startsWith",
           "String.endsWith",
           "String.substring",

--- a/libs/scalalib/test/src/mill/scalalib/TestRunnerScalatestTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/TestRunnerScalatestTests.scala
@@ -10,7 +10,7 @@ object TestRunnerScalatestTests extends TestSuite {
   override def tests: Tests = Tests {
     test("test") - UnitTester(testrunner, resourcePath).scoped { eval =>
       val Right(result) = eval(testrunner.scalatest.testForked()): @unchecked
-      assert(result.value._2.size == 9)
+      assert(result.value.results.size == 9)
       junitReportIn(eval.outPath, "scalatest").shouldHave(9 -> Status.Success)
     }
     test("discoveredTestClasses") - UnitTester(testrunner, resourcePath).scoped { eval =>

--- a/libs/scalalib/test/src/mill/scalalib/TestRunnerTestUtils.scala
+++ b/libs/scalalib/test/src/mill/scalalib/TestRunnerTestUtils.scala
@@ -106,7 +106,7 @@ object TestRunnerTestUtils {
         }
         // Regardless of whether tests are grouped or not, the same
         // number of test results appear at the end
-        assert(testOnly._2.size == size)
+        assert(testOnly.results.size == size)
       }
     }
   }

--- a/libs/scalalib/test/src/mill/scalalib/TestRunnerZiotestTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/TestRunnerZiotestTests.scala
@@ -9,7 +9,7 @@ object TestRunnerZiotestTests extends TestSuite {
   override def tests: Tests = Tests {
     test("test") - UnitTester(testrunner, resourcePath).scoped { eval =>
       val Right(result) = eval(testrunner.ziotest.testForked()): @unchecked
-      assert(result.value._2.size == 1)
+      assert(result.value.results.size == 1)
       junitReportIn(eval.outPath, "ziotest").shouldHave(1 -> Status.Success)
     }
     test("discoveredTestClasses") - UnitTester(testrunner, resourcePath).scoped { eval =>

--- a/libs/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
+++ b/libs/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
@@ -17,7 +17,7 @@ import mill.scalanativelib.worker.{
 import mill.T
 import mill.constants.EnvVars
 import mill.scalanativelib.worker.api.ScalaNativeWorkerApi
-import upickle.implicits.namedTuples.default.given 
+import upickle.implicits.namedTuples.default.given
 
 trait ScalaNativeModule extends ScalaModule with ScalaNativeModuleApi { outer =>
   def scalaNativeVersion: T[String]

--- a/libs/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
+++ b/libs/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
@@ -17,6 +17,7 @@ import mill.scalanativelib.worker.{
 import mill.T
 import mill.constants.EnvVars
 import mill.scalanativelib.worker.api.ScalaNativeWorkerApi
+import upickle.implicits.namedTuples.default.given 
 
 trait ScalaNativeModule extends ScalaModule with ScalaNativeModuleApi { outer =>
   def scalaNativeVersion: T[String]
@@ -370,12 +371,12 @@ trait ScalaNativeModule extends ScalaModule with ScalaNativeModuleApi { outer =>
 
 trait TestScalaNativeModule extends ScalaNativeModule with TestModule {
   override def resources: T[Seq[PathRef]] = super[ScalaNativeModule].resources
-  override def testLocal(args: String*): Command[(String, Seq[TestResult])] =
+  override def testLocal(args: String*): Command[(msg: String, results: Seq[TestResult])] =
     Task.Command { testForked(args*)() }
   override protected def testTask(
       args: Task[Seq[String]],
       globSelectors: Task[Seq[String]]
-  ): Task[(String, Seq[TestResult])] = Task.Anon {
+  ): Task[(msg: String, results: Seq[TestResult])] = Task.Anon {
 
     val (close, framework) = withScalaNativeBridge.apply().apply(_.getFramework(
       nativeLink().path.toIO,

--- a/libs/scalanativelib/test/src/mill/scalanativelib/TestingTests.scala
+++ b/libs/scalanativelib/test/src/mill/scalanativelib/TestingTests.scala
@@ -11,7 +11,7 @@ object TestingTests extends TestSuite {
   import CompileRunTests._
   def tests: Tests = Tests {
 
-    def runTests(testTask: define.NamedTask[(String, Seq[TestResult])])
+    def runTests(testTask: define.NamedTask[(msg: String, results: Seq[TestResult])])
         : Unit =
       UnitTester(HelloNativeWorld, millSourcePath).scoped { eval =>
         val Left(ExecResult.Failure(_)) = eval(testTask): @unchecked

--- a/runner/idea/src/mill/idea/GenIdeaImpl.scala
+++ b/runner/idea/src/mill/idea/GenIdeaImpl.scala
@@ -46,7 +46,7 @@ class GenIdeaImpl(
       .getOrElse(("JDK_1_8", "1.8 (1)"))
 
     println("Analyzing modules ...")
-    val layout: Seq[(subPath : SubPath, xml : Node)] =
+    val layout: Seq[(subPath: SubPath, xml: Node)] =
       xmlFileLayout(evaluators, jdkInfo)
 
     println("Cleaning obsolete IDEA project files ...")

--- a/runner/meta/src/mill/meta/MillBuildRootModule.scala
+++ b/runner/meta/src/mill/meta/MillBuildRootModule.scala
@@ -90,7 +90,7 @@ trait MillBuildRootModule()(implicit
   override def platformSuffix: T[String] = s"_mill${BuildInfo.millBinPlatform}"
 
   override def generatedSources: T[Seq[PathRef]] = Task {
-    generatedScriptSources()._2
+    generatedScriptSources().support
   }
 
   /**
@@ -224,7 +224,7 @@ trait MillBuildRootModule()(implicit
       // the real input-sources
       allSources() ++
         // also sources, but derived from `scriptSources`
-        generatedScriptSources()._1
+        generatedScriptSources().wrapped
 
     val candidates =
       Lib.findSourceFiles(allMillSources, Seq("scala", "java") ++ buildFileExtensions.asScala.toSeq)
@@ -313,7 +313,7 @@ trait MillBuildRootModule()(implicit
 
 object MillBuildRootModule {
 
-  type GeneratedScriptSourcesResult = (Seq[PathRef], Seq[PathRef])
+  type GeneratedScriptSourcesResult = (wrapped: Seq[PathRef], support: Seq[PathRef])
 
   class BootstrapModule()(implicit
       rootModuleInfo: RootModule0.Info

--- a/runner/meta/src/mill/meta/MillBuildRootModule.scala
+++ b/runner/meta/src/mill/meta/MillBuildRootModule.scala
@@ -10,6 +10,7 @@ import mill.scalalib.{Dep, DepSyntax, Lib, ScalaModule}
 import mill.scalalib.api.{CompilationResult, Versions}
 import mill.util.BuildInfo
 import mill.api.internal.MillScalaParser
+import upickle.implicits.namedTuples.default.given
 
 import scala.jdk.CollectionConverters.ListHasAsScala
 
@@ -96,10 +97,11 @@ trait MillBuildRootModule()(implicit
   /**
    * Additional script files, we generate, since not all Mill source
    * files (e.g. `.sc` and `.mill`) can be fed to the compiler as-is.
-   * The wrapped files aren't supposed to appear under [[generatedSources]] and [[allSources]],
+   *
+   * The `wrapped` files aren't supposed to appear under [[generatedSources]] and [[allSources]],
    * since they are derived from [[sources]] and would confuse any further tooling like IDEs.
    */
-  def generatedScriptSources: T[MillBuildRootModule.GeneratedScriptSourcesResult] = Task {
+  def generatedScriptSources: Target[(wrapped: Seq[PathRef], support: Seq[PathRef])] = Task {
     val wrapped = Task.dest / "wrapped"
     val support = Task.dest / "support"
 
@@ -115,7 +117,7 @@ trait MillBuildRootModule()(implicit
         rootModuleInfo.output,
         MillScalaParser.current.value
       )
-      (Seq(PathRef(wrapped)), Seq(PathRef(support)))
+      (wrapped = Seq(PathRef(wrapped)), support = Seq(PathRef(support)))
     }
   }
 
@@ -312,8 +314,6 @@ trait MillBuildRootModule()(implicit
 }
 
 object MillBuildRootModule {
-
-  type GeneratedScriptSourcesResult = (wrapped: Seq[PathRef], support: Seq[PathRef])
 
   class BootstrapModule()(implicit
       rootModuleInfo: RootModule0.Info


### PR DESCRIPTION
Use named tuples where we use tuples in Task types. The following task were changed:

* `TestModule.test*` tasks now return `(msg: String, results: Seq[TestResult])`

* `AndroidAppKotlinModule.androidDiscoveredPreviews` now returns `(previewsDiscoveredJsonFile: PathRef, screenshotConfigs: Seq[ComposeRenderer.Screenshot])`
* `AndroidAppModule.android{D,R}8Dex` now returns `(outPath: PathRef, dexCliArgs: Seq[String])`
* `AndroidModule.androidCompiledResources` now returns named tuple and includes all relevant resources directly.

* Also use some named tuples in `GenIdeaImpl`, which hopefully improve reading/editing it.