### PR TITLE
Fixes for `mill init` example zip version and urls

### DIFF
--- a/dist/package.mill
+++ b/dist/package.mill
@@ -237,7 +237,7 @@ object `package` extends MillJavaModule with DistModule {
       os.copy(examplePath.path, Task.dest / exampleStr, createFolders = true)
       val ignoreErrorsOnCI = Task.dest / exampleStr / "ignoreErrorsOnCI"
       if (os.exists(ignoreErrorsOnCI)) os.remove(ignoreErrorsOnCI)
-      os.write(Task.dest / exampleStr / ".mill-version", build.millLastTag())
+      os.write(Task.dest / exampleStr / ".mill-version", build.millVersion())
       os.copy(bootstrapLauncher().path, Task.dest / exampleStr / "mill")
       os.copy(bootstrapLauncherBat().path, Task.dest / exampleStr / "mill.bat")
       val zip = Task.dest / s"$exampleStr.zip"

--- a/libs/init/package.mill
+++ b/libs/init/package.mill
@@ -19,7 +19,7 @@ object `package` extends MillPublishScalaModule {
     val data: Seq[(os.SubPath, String)] =
       build.dist.examplePathsWithArtifactName().map { case (pathRef, str) =>
         val downloadUrl =
-          s"${build.millDownloadUrl()}/mill-dist-${build.dist.artifactFileNamePrefix()}-$str.zip"
+          s"${build.millDownloadUrl()}/${build.dist.artifactFileNamePrefix()}-$str.zip"
         val subPath = pathRef.path.subRelativeTo(Task.workspace / "example")
         (subPath, downloadUrl)
       }


### PR DESCRIPTION
We were using the `lastTag` rather than the current `millVersion`, which made the `./mill` launcher use the last stable version rather than the example version, and the download URLs have an extra `mill-dist-` prefix