### PR TITLE
Add latest unstable release to docsite

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -45,10 +45,14 @@ def millVersion: T[String] = Task {
   } else "SNAPSHOT"
 }
 
-def millLastTagTruth: T[String] = Task {
-  VcsVersion.calcVcsState(Task.log).lastTag.getOrElse(
-    sys.error("No (last) git tag found. Your git history seems incomplete!")
-  )
+def latestUnstableVersion = Task.Input {
+  val mavenMetadataXml = requests
+    .get("https://repo1.maven.org/maven2/com/lihaoyi/mill-dist/maven-metadata.xml")
+    .text()
+
+  val xml = scala.xml.XML.loadString(mavenMetadataXml)
+
+  (xml \\ "version").map(_.text).last
 }
 
 def millLastTag: T[String] = Task {

--- a/website/docs/modules/ROOT/pages/index.adoc
+++ b/website/docs/modules/ROOT/pages/index.adoc
@@ -1,7 +1,7 @@
 = Mill: A Better JVM Build Tool
 
 https://github.com/com-lihaoyi/mill/blob/main/changelog.adoc[image:https://img.shields.io/maven-central/v/com.lihaoyi/mill-dist?label=stable-version&versionPrefix={mill-version}&versionSuffix={mill-version}[d]]
-https://central.sonatype.com/artifact/com.lihaoyi/mill-dist[image:https://img.shields.io/maven-central/v/com.lihaoyi/mill-dist?label=unstable-version&versionPrefix=0.12.[Maven Central Version]]
+https://central.sonatype.com/artifact/com.lihaoyi/mill-dist[image:https://img.shields.io/maven-central/v/com.lihaoyi/mill-dist?label=unstable-dev-version[Maven Central Version]]
 
 Mill is a JVM build tool that supports Java, Scala, and Kotlin:
 

--- a/website/package.mill
+++ b/website/package.mill
@@ -299,42 +299,68 @@ object `package` extends mill.Module {
        |""".stripMargin
   }
 
-  def oldDocSources: T[Seq[PathRef]] = Task {
-    val versionLabels =
-      Settings.docTags.map { v =>
-        (v, v.split('.').dropRight(1).mkString(".") + ".x")
-      }.dropRight(1) ++
-        // Set the latest stable branch as the "master" docs that people default to
-        Seq(
-          (build.latestUnstableVersion().split('-').last, "dev-" + build.latestUnstableVersion()),
-          (Settings.docTags.last, "master")
-        )
+  val versionLabels =
+    Settings.docTags.map { v =>
+      (v, v, v, v.split('.').dropRight(1).mkString(".") + ".x", false)
+    }.dropRight(1) ++
+      // Set the latest stable branch as the "master" docs that people default to
+      Seq(
+        (Settings.docTags.last, Settings.docTags.last, Settings.docTags.last, "master", false),
+        ("dev", "dev", "dev", "dev", true)
+      )
 
-    for ((millVersion, antoraVersion) <- versionLabels) yield {
+  def oldDocSources = Task {
+    Task.traverse(oldDocs.items.map(_.module))(_.value.oldDocSource)()
+  }
+
+  object oldDocs extends Cross[OldDocModule](versionLabels)
+  trait OldDocModule extends Cross.Module5[String, String, String, String, Boolean] {
+
+    def oldDocSource: T[PathRef] = Task {
+      val millVersion =
+        if (crossValue == "dev") build.latestUnstableVersion()
+        else crossValue
+
+      val gitVersion =
+        if (crossValue2 == "dev") build.latestUnstableVersion().split('-').last
+        else crossValue2
+
+      val displayVersion =
+        if (crossValue3 == "dev") "dev-" + build.latestUnstableVersion()
+        else crossValue3
+
+      val antoraVersion = if (crossValue4 == "dev") displayVersion else crossValue4
+
+      val newWebsiteTask: Boolean = crossValue5
+
       val checkout = Task.dest / millVersion
       os.proc("git", "clone", Task.workspace / ".git", checkout).call(stdout = os.Inherit)
-      os.proc("git", "checkout", millVersion).call(cwd = checkout, stdout = os.Inherit)
-      val outputFolder = checkout / "out/docs/source.dest"
-      os.proc("./mill", "-i", "docs.source").call(cwd = checkout, stdout = os.Inherit)
+      os.proc("git", "checkout", gitVersion).call(cwd = checkout, stdout = os.Inherit)
+      val outputFolder = if (newWebsiteTask) {
+        os.proc("./mill", "-i", "website.source").call(cwd = checkout, stdout = os.Inherit)
+        checkout / "out/website/source.dest"
+      } else {
+        os.proc("./mill", "-i", "docs.source").call(cwd = checkout, stdout = os.Inherit)
+        checkout / "out/docs/source.dest"
+      }
+
       expandDiagramsInDirectoryAdocFile(
         outputFolder,
         mill.main.VisualizeModule.toolsClasspath().map(_.path)
       )
 
-      val useOldDownloadUrl = Version.OsgiOrdering.lt(
-        Version.parse(millVersion),
-        Version.parse("0.12.6")
-      )
+      val useOldDownloadUrl =
+        if (antoraVersion.startsWith("dev-")) false
+        else Version.OsgiOrdering.lt(Version.parse(millVersion), Version.parse("0.12.6"))
 
       val millDownloadUrl =
         if (useOldDownloadUrl) s"${Settings.projectUrl}/releases/download/$millVersion"
         else s"${build.millDownloadPrefix()}/$millVersion"
 
-      sanitizeAntoraYml(outputFolder, antoraVersion, millVersion, millVersion, millDownloadUrl)
+      sanitizeAntoraYml(outputFolder, antoraVersion, displayVersion, millVersion, millDownloadUrl)
       PathRef(outputFolder)
     }
   }
-
   def githubPages: T[PathRef] = Task {
     generatePages(authorMode = false).apply().apply(oldDocSources().map(_.path))
   }

--- a/website/package.mill
+++ b/website/package.mill
@@ -305,7 +305,10 @@ object `package` extends mill.Module {
         (v, v.split('.').dropRight(1).mkString(".") + ".x")
       }.dropRight(1) ++
         // Set the latest stable branch as the "master" docs that people default to
-        Seq((Settings.docTags.last, "master"))
+        Seq(
+          (build.latestUnstableVersion().split('-').last, "dev-" + build.latestUnstableVersion()),
+          (Settings.docTags.last, "master")
+        )
 
     for ((millVersion, antoraVersion) <- versionLabels) yield {
       val checkout = Task.dest / millVersion


### PR DESCRIPTION
This isn't stored in any tag in the Git repo, so we need to fetch it from Maven Central's `maven-metadata.xml` in an input task

I also broke up the `oldDocSources` into multiple smaller tasks using a `Cross` module, so we can get some parallelism on what is typically a pretty slow code path