### PR TITLE
Fix NullPointerException when java home not provided

### DIFF
--- a/runner/client/src/mill/client/ClientUtil.java
+++ b/runner/client/src/mill/client/ClientUtil.java
@@ -79,10 +79,10 @@ public class ClientUtil {
   }
 
   public static void writeString(OutputStream outputStream, String string) throws IOException {
-    final byte[] bytes = string.getBytes(utf8);
     if (string == null) {
       writeInt(outputStream, -1);
     } else {
+      final byte[] bytes = string.getBytes(utf8);
       writeInt(outputStream, bytes.length);
       outputStream.write(bytes);
     }

--- a/runner/client/src/mill/client/ClientUtil.java
+++ b/runner/client/src/mill/client/ClientUtil.java
@@ -65,6 +65,7 @@ public class ClientUtil {
   public static String readString(InputStream inputStream) throws IOException {
     // Result is between 0 and 255, hence the loop.
     final int length = readInt(inputStream);
+    if (length == -1) return null;
     final byte[] arr = new byte[length];
     int total = 0;
     while (total < length) {
@@ -79,8 +80,12 @@ public class ClientUtil {
 
   public static void writeString(OutputStream outputStream, String string) throws IOException {
     final byte[] bytes = string.getBytes(utf8);
-    writeInt(outputStream, bytes.length);
-    outputStream.write(bytes);
+    if (string == null) {
+      writeInt(outputStream, -1);
+    } else {
+      writeInt(outputStream, bytes.length);
+      outputStream.write(bytes);
+    }
   }
 
   public static void writeInt(OutputStream out, int i) throws IOException {

--- a/runner/client/test/src/mill/client/ClientTests.java
+++ b/runner/client/test/src/mill/client/ClientTests.java
@@ -48,7 +48,7 @@ public class ClientTests {
   @Test
   public void readWriteString() throws Exception {
     String[] examples = {
-      "", "hello", "i am cow", "i am cow\nhear me moo\ni weight twice as much as you", "我是一个叉烧包",
+      "", "hello", "i am cow", "i am cow\nhear me moo\ni weight twice as much as you", "我是一个叉烧包", null
     };
     for (String example : examples) {
       checkStringRoundTrip(example);

--- a/runner/client/test/src/mill/client/ClientTests.java
+++ b/runner/client/test/src/mill/client/ClientTests.java
@@ -48,7 +48,12 @@ public class ClientTests {
   @Test
   public void readWriteString() throws Exception {
     String[] examples = {
-      "", "hello", "i am cow", "i am cow\nhear me moo\ni weight twice as much as you", "我是一个叉烧包", null
+      "",
+      "hello",
+      "i am cow",
+      "i am cow\nhear me moo\ni weight twice as much as you",
+      "我是一个叉烧包",
+      null
     };
     for (String example : examples) {
       checkStringRoundTrip(example);


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/5149

Someone I can't get a reliably repro of that failure, but this PR should theoretically fix the mechanism through which the failure happens by making the launcher-daemon protocol robust against null strings