### PR TITLE
Fix race condition in DoubleLocked#release

### DIFF
--- a/runner/client/src/mill/client/lock/DoubleLocked.java
+++ b/runner/client/src/mill/client/lock/DoubleLocked.java
@@ -12,7 +12,7 @@ class DoubleLocked implements Locked {
 
   @Override
   public void release() throws Exception {
-    this.lock1.release();
     this.lock2.release();
+    this.lock1.release();
   }
 }

--- a/runner/daemon/src/mill/daemon/MillDaemonMain.scala
+++ b/runner/daemon/src/mill/daemon/MillDaemonMain.scala
@@ -52,7 +52,7 @@ class MillDaemonMain(
   val out = os.Path(OutFiles.out, mill.define.BuildCtx.workspaceRoot)
 
   val outLock = new DoubleLock(
-    Lock.memory(),
+    MillMain.outMemoryLock,
     Lock.file((out / OutFiles.millOutLock).toString)
   )
 


### PR DESCRIPTION
This PR makes some uses of `DoubleLock` safer, and fixes a race condition with it.

`DoubleLock` is basically used as a wrapper around a file lock (second lock), using it alongside a memory lock (first lock), that acts as a mutex for it. That way, the same JVM process doesn't try to acquire the file lock twice at the same time in a given JVM, which `java.nio.channels.FileChannel` doesn't allow (it throws an `OverlappingFileLockException` in that case).

This PR makes sure `MillMain` and `MillDaemonMain` use the same `Lock.memory()` instance as a guard when trying to acquire a lock for the output directory. This doesn't solve the issue I was running into (see below), but seems to be safer nonetheless.

It also tries to dispose of locks in `DoubleLock` in case calls to `Lock#{lock,tryLock}` throw.

Lastly, it releases the two locks in `DoubleLocked` in the reverse order that they were acquired. This fixes the test case below. Doing so fixes a race condition, where
- a first thread acquires the lock
- a second one tries to acquire it, and waits for it
- the first thread releases the lock

During the third step, releasing the memory lock before the file lock makes the second thread acquire the memory lock, and then possibly try to acquire the file lock, before the first thread is done releasing the file lock. The JVM doesn't allow this, and the second thread gets an `OverlappingFileLockException`.

See the discussion in https://github.com/com-lihaoyi/mill/pull/5152 too

This fixes
```text
$ ./mill 'integration.feature[output-directory].packaged.daemon.testForked' "mill.integration.OutputDirectoryLockTests.basic"
```
for me, locally.