### PR TITLE
Use layered class loaders rather than "shared" class loader hack for class loader isolation

### DIFF
--- a/contrib/flyway/src/mill/contrib/flyway/FlywayModule.scala
+++ b/contrib/flyway/src/mill/contrib/flyway/FlywayModule.scala
@@ -36,7 +36,7 @@ trait FlywayModule extends JavaModule {
       .map(key -> _)
 
   def flywayClassloader = Task.Worker {
-    mill.util.Jvm.createClassLoader(jdbcClasspath().map(_.path))
+    mill.util.Jvm.createIsolatedClassLoader(jdbcClasspath().map(_.path))
   }
   def flywayInstance = Task.Worker {
     val jdbcClassloader = flywayClassloader()

--- a/contrib/playlib/src/mill/playlib/RouteCompilerWorker.scala
+++ b/contrib/playlib/src/mill/playlib/RouteCompilerWorker.scala
@@ -24,7 +24,7 @@ private[playlib] class RouteCompilerWorker {
     ctx.log.debug("Loading classes from\n" + toolsClassPath.mkString("\n"))
     mill.util.Jvm.withClassLoader(
       toolsClassPath,
-      null,
+      parent = null,
       sharedLoader = getClass().getClassLoader(),
       sharedPrefixes = Seq("mill.playlib.api.")
     ) { cl =>

--- a/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBWorker.scala
+++ b/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBWorker.scala
@@ -18,7 +18,7 @@ class ScalaPBWorker {
           otherArgs: Seq[String]
       ): Unit = {
         val pbcClasspath = scalaPBClasspath.map(_.path).toVector
-        mill.util.Jvm.withClassLoader(pbcClasspath, null) { cl =>
+        mill.util.Jvm.withIsolatedClassLoader(pbcClasspath) { cl =>
           val scalaPBCompilerClass = cl.loadClass("scalapb.ScalaPBC")
           val mainMethod = scalaPBCompilerClass.getMethod("main", classOf[Array[java.lang.String]])
           val opts = if (scalaPBOptions.isEmpty) "" else scalaPBOptions + ":"

--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageReportWorker.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageReportWorker.scala
@@ -35,10 +35,7 @@ class ScoverageReportWorker {
       )(implicit
           ctx: TaskCtx
       ): Unit = {
-        mill.util.Jvm.withClassLoader(
-          classpath.map(_.path).toVector,
-          getClass.getClassLoader
-        ) { cl =>
+        mill.util.Jvm.withClassLoader(classpath.map(_.path).toVector) { cl =>
 
           val worker =
             cl

--- a/contrib/twirllib/src/mill/twirllib/TwirlModule.scala
+++ b/contrib/twirllib/src/mill/twirllib/TwirlModule.scala
@@ -80,7 +80,7 @@ trait TwirlModule extends mill.Module { twirlModule =>
   }
 
   def twirlClassLoader = Task.Worker {
-    mill.util.Jvm.createClassLoader(
+    mill.util.Jvm.createIsolatedClassLoader(
       twirlClasspath().map(_.path)
     )
   }

--- a/core/api/src/mill/api/MillURLClassLoader.scala
+++ b/core/api/src/mill/api/MillURLClassLoader.scala
@@ -52,6 +52,7 @@ object MillURLClassLoader {
     openClassloaders.synchronized {
       // println(s"removeOpenClassLoader ${classPath.hashCode}\n  " + new Exception().getStackTrace.mkString("\n  "))
       openClassloaders.updateWith(label) {
+        case None => None
         case Some(1) => None
         case Some(n) => Some(n - 1)
       }

--- a/dist/package.mill
+++ b/dist/package.mill
@@ -297,7 +297,10 @@ object `package` extends MillJavaModule with DistModule {
     def nativeImageOptions = Seq(
       "--no-fallback",
       "--enable-url-protocols=https",
-      "-Os"
+      "-Os",
+      // these two are necessary to use coursier bootstrap generation
+      "-H:IncludeResources=bootstrap.*\\.jar",
+      "-H:IncludeResources=coursier/launcher/.*\\.bat"
       // Enable JVisualVM support
       // https://www.graalvm.org/latest/tools/visualvm/#using-visualvm-with-graalvm-native-executables
       // "--enable-monitoring=jvmstat,heapdump"

--- a/example/extending/jvmcode/2-classloader/build.mill
+++ b/example/extending/jvmcode/2-classloader/build.mill
@@ -17,7 +17,7 @@ object foo extends JavaModule {
   def groovyScript = Task.Source("generate.groovy")
 
   def groovyGeneratedResources = Task {
-    Jvm.withClassLoader(classPath = groovyClasspath().map(_.path).toSeq) { classLoader =>
+    Jvm.withIsolatedClassLoader(groovyClasspath().map(_.path).toSeq) { classLoader =>
       classLoader
         .loadClass("groovy.ui.GroovyMain")
         .getMethod("main", classOf[Array[String]])

--- a/example/extending/jvmcode/3-worker/build.mill
+++ b/example/extending/jvmcode/3-worker/build.mill
@@ -20,7 +20,7 @@ def groovyClasspath: Task[Seq[PathRef]] = Task {
 }
 
 def groovyWorker: Worker[java.net.URLClassLoader] = Task.Worker {
-  Jvm.createClassLoader(groovyClasspath().map(_.path).toSeq)
+  Jvm.createIsolatedClassLoader(groovyClasspath().map(_.path).toSeq)
 }
 
 trait GroovyGenerateJavaModule extends JavaModule {

--- a/example/extending/jvmcode/5-module-classloader/build.mill
+++ b/example/extending/jvmcode/5-module-classloader/build.mill
@@ -12,7 +12,7 @@ object foo extends JavaModule {
   def moduleDeps = Seq(bar)
 
   def sources = Task {
-    Jvm.withClassLoader(classPath = bar.runClasspath().map(_.path)) { classLoader =>
+    Jvm.withIsolatedClassLoader(bar.runClasspath().map(_.path)) { classLoader =>
       classLoader
         .loadClass("bar.Bar")
         .getMethod("main", classOf[Array[String]])

--- a/example/extending/jvmcode/6-module-cached-classloader/build.mill
+++ b/example/extending/jvmcode/6-module-cached-classloader/build.mill
@@ -43,7 +43,7 @@ def barWorker: Worker[BarWorker] = Task.Worker {
 class BarWorker(runClasspath: Seq[os.Path]) extends CachedFactory[Unit, URLClassLoader] {
   def setup(key: Unit) = {
     println("Setting up Classloader")
-    Jvm.createClassLoader(runClasspath)
+    Jvm.createIsolatedClassLoader(runClasspath)
   }
   def teardown(key: Unit, value: URLClassLoader) = {
     println("Tearing down Classloader")

--- a/integration/feature/leak-hygiene/resources/build.mill
+++ b/integration/feature/leak-hygiene/resources/build.mill
@@ -55,6 +55,6 @@ def countThreads() = Task.Command {
 
 def leakThreadClassloader() = Task.Command {
   new Thread(() => Thread.sleep(9999999), "leaked thread").start()
-  mill.util.Jvm.createClassLoader(Nil, label = "leaked classloader")
+  mill.util.Jvm.createIsolatedClassLoader(Nil, label = "leaked classloader")
   ()
 }

--- a/libs/kotlinlib/src/mill/kotlinlib/KotlinWorkerManager.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/KotlinWorkerManager.scala
@@ -15,7 +15,7 @@ class KotlinWorkerFactory()(implicit ctx: TaskCtx)
     extends CachedFactory[Seq[os.Path], (URLClassLoader, KotlinWorker)] {
 
   def setup(key: Seq[os.Path]) = {
-    val cl = mill.util.Jvm.createClassLoader(key, getClass.getClassLoader)
+    val cl = mill.util.Jvm.createClassLoader(key)
     val worker =
       try KotlinWorkerManager.get(cl)
       catch { case e => e.printStackTrace(); ??? }

--- a/libs/scalajslib/src/mill/scalajslib/worker/ScalaJSWorker.scala
+++ b/libs/scalajslib/src/mill/scalajslib/worker/ScalaJSWorker.scala
@@ -16,10 +16,7 @@ import java.net.URLClassLoader
 private[scalajslib] class ScalaJSWorker(jobs: Int)
     extends CachedFactory[Seq[mill.PathRef], (URLClassLoader, workerApi.ScalaJSWorkerApi)] {
   override def setup(key: Seq[PathRef]) = {
-    val cl = mill.util.Jvm.createClassLoader(
-      key.map(_.path).toVector,
-      getClass.getClassLoader
-    )
+    val cl = mill.util.Jvm.createClassLoader(key.map(_.path).toVector)
     val bridge = cl
       .loadClass("mill.scalajslib.worker.ScalaJSWorkerImpl")
       .getDeclaredConstructor()

--- a/libs/scalalib/src/mill/javalib/spring/boot/SpringBootToolsModule.scala
+++ b/libs/scalalib/src/mill/javalib/spring/boot/SpringBootToolsModule.scala
@@ -33,10 +33,7 @@ trait SpringBootToolsModule extends CoursierModule {
   }
 
   def springBootToolsClassLoader: Worker[ClassLoader] = Task.Worker {
-    mill.util.Jvm.createClassLoader(
-      springBootToolsClasspath().map(_.path),
-      getClass().getClassLoader()
-    )
+    mill.util.Jvm.createClassLoader(springBootToolsClasspath().map(_.path))
   }
 
   def springBootToolsWorker: Worker[SpringBootTools] = Task.Worker {

--- a/libs/scalalib/src/mill/scalalib/AssemblyModule.scala
+++ b/libs/scalalib/src/mill/scalalib/AssemblyModule.scala
@@ -164,10 +164,7 @@ object AssemblyModule extends ExternalModule with CoursierModule with OfflineSup
   }
 
   private[mill] def jarjarabramsWorkerClassloader: Worker[ClassLoader] = Task.Worker {
-    Jvm.createClassLoader(
-      classPath = jarjarabramsWorkerClasspath().map(_.path),
-      parent = getClass().getClassLoader()
-    )
+    Jvm.createClassLoader(jarjarabramsWorkerClasspath().map(_.path))
   }
 
   def jarjarabramsWorker: Worker[(Seq[(String, String)], String, UnopenedInputStream) => Option[(

--- a/libs/scalalib/src/mill/scalalib/JvmWorkerModule.scala
+++ b/libs/scalalib/src/mill/scalalib/JvmWorkerModule.scala
@@ -81,10 +81,7 @@ trait JvmWorkerModule extends OfflineSupportModule with CoursierModule {
   def worker: Worker[JvmWorkerApi] = Task.Worker {
     val jobs = Task.ctx().jobs
 
-    val cl = mill.util.Jvm.createClassLoader(
-      classpath().map(_.path).toSeq,
-      getClass.getClassLoader
-    )
+    val cl = mill.util.Jvm.createClassLoader(classpath().map(_.path).toSeq)
 
     val cls = cl.loadClass("mill.scalalib.worker.JvmWorkerImpl")
     val instance = cls.getConstructor(

--- a/libs/scalalib/src/mill/scalalib/RunModule.scala
+++ b/libs/scalalib/src/mill/scalalib/RunModule.scala
@@ -153,9 +153,7 @@ trait RunModule extends WithJvmWorker with RunModuleApi {
 
   def runLocalTask(mainClass: Task[String], args: Task[Args] = Task.Anon(Args())): Task[Unit] =
     Task.Anon {
-      Jvm.withClassLoader(
-        classPath = runClasspath().map(_.path).toVector
-      ) { classloader =>
+      Jvm.withIsolatedClassLoader(runClasspath().map(_.path).toVector) { classloader =>
         RunModule.getMainMethod(mainClass(), classloader).invoke(null, args().value.toArray)
       }
     }

--- a/libs/scalalib/src/mill/scalalib/TestModule.scala
+++ b/libs/scalalib/src/mill/scalalib/TestModule.scala
@@ -264,10 +264,13 @@ trait TestModule
   }
 
   private[mill] def bspBuildTargetScalaTestClasses = Task.Anon {
+    val hasTwoClassLoaders =
+      classOf[sbt.testing.Framework].getClassLoader != getClass.getClassLoader
     val (frameworkName, classFingerprint) =
       mill.util.Jvm.withClassLoader(
         classPath = runClasspath().map(_.path),
-        sharedPrefixes = Seq("sbt.testing.")
+        parent = if (hasTwoClassLoaders) classOf[sbt.testing.Framework].getClassLoader else null,
+        sharedPrefixes = if (hasTwoClassLoaders) Nil else Seq("sbt.testing.")
       ) { classLoader =>
         val framework = Framework.framework(testFramework())(classLoader)
         framework.name() -> mill.testrunner.TestRunnerUtils
@@ -372,9 +375,12 @@ object TestModule {
      * override this method.
      */
     override def discoveredTestClasses: T[Seq[String]] = Task {
+      val hasTwoClassLoaders =
+        classOf[sbt.testing.Framework].getClassLoader != getClass.getClassLoader
       Jvm.withClassLoader(
         classPath = runClasspath().map(_.path).toVector,
-        sharedPrefixes = Seq("sbt.testing.")
+        parent = if (hasTwoClassLoaders) classOf[sbt.testing.Framework].getClassLoader else null,
+        sharedPrefixes = if (hasTwoClassLoaders) Nil else Seq("sbt.testing.")
       ) { classLoader =>
         val builderClass: Class[?] =
           classLoader.loadClass("com.github.sbt.junit.jupiter.api.JupiterTestCollector$Builder")

--- a/libs/scalalib/src/mill/scalalib/classgraph/ClassgraphWorkerModule.scala
+++ b/libs/scalalib/src/mill/scalalib/classgraph/ClassgraphWorkerModule.scala
@@ -23,10 +23,7 @@ trait ClassgraphWorkerModule extends CoursierModule with OfflineSupportModule {
   }
 
   private def classgraphWorkerClassloader: Worker[ClassLoader] = Task.Worker {
-    Jvm.createClassLoader(
-      classPath = classgraphWorkerClasspath().map(_.path),
-      parent = getClass().getClassLoader()
-    )
+    Jvm.createClassLoader(classgraphWorkerClasspath().map(_.path))
   }
 
   def classgraphWorker: Worker[ClassgraphWorker] = Task.Worker {

--- a/libs/scalalib/src/mill/scalalib/scalafmt/ScalafmtWorker.scala
+++ b/libs/scalalib/src/mill/scalalib/scalafmt/ScalafmtWorker.scala
@@ -19,7 +19,7 @@ object ScalafmtWorkerModule extends ExternalModule with JavaModule {
   }
 
   def scalafmtClassLoader: Worker[java.net.URLClassLoader] = Task.Worker {
-    mill.util.Jvm.createClassLoader(scalafmtClasspath().map(_.path))
+    mill.util.Jvm.createIsolatedClassLoader(scalafmtClasspath().map(_.path))
   }
 
   def worker: Worker[ScalafmtWorker] = Task.Worker { new ScalafmtWorker(scalafmtClassLoader()) }

--- a/libs/scalalib/worker/src/mill/scalalib/worker/JvmWorkerImpl.scala
+++ b/libs/scalalib/worker/src/mill/scalalib/worker/JvmWorkerImpl.scala
@@ -349,9 +349,11 @@ class JvmWorkerImpl(
           if (JvmWorkerUtil.isDottyOrScala3(scalaVersion)) "dotty.tools.dotc.Main"
           else "scala.tools.nsc.Main"
         )
-        compilerMain
-          .getMethod("process", classOf[Array[String]])
-          .invoke(null, argsArray ++ Array("-nowarn"))
+        mill.api.ClassLoader.withContextClassLoader(classloader) {
+          compilerMain
+            .getMethod("process", classOf[Array[String]])
+            .invoke(null, argsArray ++ Array("-nowarn"))
+        }
       } else {
         throw new IllegalArgumentException("Currently not implemented case.")
       }

--- a/libs/scalalib/worker/src/mill/scalalib/worker/JvmWorkerImpl.scala
+++ b/libs/scalalib/worker/src/mill/scalalib/worker/JvmWorkerImpl.scala
@@ -152,6 +152,7 @@ class JvmWorkerImpl(
             else
               mill.util.Jvm.createClassLoader(
                 combinedCompilerJars.map(os.Path(_)).toSeq,
+                parent = null,
                 sharedLoader = getClass.getClassLoader,
                 sharedPrefixes = Seq("xsbti")
               )
@@ -306,9 +307,8 @@ class JvmWorkerImpl(
     os.makeDir.all(compileDest)
 
     val sourceFolder = os.unzip(compilerBridgeSourcesJar, workingDir / "unpacked")
-    val classloader = mill.util.Jvm.createClassLoader(
-      compilerClasspath.map(_.path).toSeq,
-      null
+    val classloader = mill.util.Jvm.createIsolatedClassLoader(
+      compilerClasspath.map(_.path).toSeq
     )
 
     try {

--- a/libs/scalanativelib/src/mill/scalanativelib/worker/ScalaNativeWorker.scala
+++ b/libs/scalanativelib/src/mill/scalanativelib/worker/ScalaNativeWorker.scala
@@ -11,10 +11,7 @@ import java.net.URLClassLoader
 private[scalanativelib] class ScalaNativeWorker(jobs: Int)
     extends CachedFactory[Seq[mill.PathRef], (URLClassLoader, workerApi.ScalaNativeWorkerApi)] {
   override def setup(key: Seq[PathRef]) = {
-    val cl = mill.util.Jvm.createClassLoader(
-      key.map(_.path).toVector,
-      getClass.getClassLoader
-    )
+    val cl = mill.util.Jvm.createClassLoader(key.map(_.path).toVector)
     val bridge = cl
       .loadClass("mill.scalanativelib.worker.ScalaNativeWorkerImpl")
       .getDeclaredConstructor()

--- a/libs/testrunner/src/mill/testrunner/DiscoverTestsMain.scala
+++ b/libs/testrunner/src/mill/testrunner/DiscoverTestsMain.scala
@@ -12,9 +12,12 @@ import os.Path
     main0(runCp, testCp, framework).foreach(println)
   }
   def main0(runCp: Seq[os.Path], testCp: Seq[os.Path], framework: String): Seq[String] = {
+    val hasTwoClassLoaders =
+      classOf[sbt.testing.Framework].getClassLoader != getClass.getClassLoader
     mill.util.Jvm.withClassLoader(
       classPath = runCp,
-      sharedPrefixes = Seq("sbt.testing.")
+      parent = if (hasTwoClassLoaders) classOf[sbt.testing.Framework].getClassLoader else null,
+      sharedPrefixes = if (hasTwoClassLoaders) Nil else Seq("sbt.testing.")
     ) { classLoader =>
       TestRunnerUtils
         .discoverTests(classLoader, Framework.framework(framework)(classLoader), testCp)

--- a/libs/testrunner/src/mill/testrunner/GetTestTasksMain.scala
+++ b/libs/testrunner/src/mill/testrunner/GetTestTasksMain.scala
@@ -24,10 +24,13 @@ import os.Path
       selectors: Seq[String],
       args: Seq[String]
   ): Seq[String] = {
+    val hasTwoClassLoaders =
+      classOf[sbt.testing.Framework].getClassLoader != getClass.getClassLoader
     val globFilter = TestRunnerUtils.globFilter(selectors)
     mill.util.Jvm.withClassLoader(
       classPath = runCp,
-      sharedPrefixes = Seq("sbt.testing.")
+      parent = if (hasTwoClassLoaders) classOf[sbt.testing.Framework].getClassLoader else null,
+      sharedPrefixes = if (hasTwoClassLoaders) Nil else Seq("sbt.testing.")
     ) { classLoader =>
       TestRunnerUtils
         .getTestTasks0(

--- a/libs/testrunner/src/mill/testrunner/TestRunner.scala
+++ b/libs/testrunner/src/mill/testrunner/TestRunner.scala
@@ -14,9 +14,12 @@ import mill.util.Jvm
       testReporter: TestReporter,
       classFilter: Class[?] => Boolean = _ => true
   )(implicit ctx: TaskCtx.Log): (String, Seq[mill.testrunner.TestResult]) = {
+    val hasTwoClassLoaders =
+      classOf[sbt.testing.Framework].getClassLoader != getClass.getClassLoader
     Jvm.withClassLoader(
       classPath = entireClasspath.toVector,
-      sharedPrefixes = Seq("sbt.testing.")
+      parent = if (hasTwoClassLoaders) classOf[sbt.testing.Framework].getClassLoader else null,
+      sharedPrefixes = if (hasTwoClassLoaders) Nil else Seq("sbt.testing.")
     ) { classLoader =>
       TestRunnerUtils.runTestFramework0(
         frameworkInstances,

--- a/mill-build/src/millbuild/Deps.scala
+++ b/mill-build/src/millbuild/Deps.scala
@@ -90,6 +90,8 @@ object Deps {
   val coursierInterface = mvn"io.get-coursier:interface:1.0.29-M1"
   val coursierJvm =
     mvn"io.get-coursier::coursier-jvm:$coursierVersion".withDottyCompat(scalaVersion)
+  val coursierLauncher =
+    mvn"io.get-coursier::coursier-launcher:$coursierVersion".withDottyCompat(scalaVersion)
 
   val cask = mvn"com.lihaoyi::cask:0.9.4"
   val castor = mvn"com.lihaoyi::castor:0.3.0"

--- a/runner/client/src/mill/client/ServerLauncher.java
+++ b/runner/client/src/mill/client/ServerLauncher.java
@@ -47,7 +47,12 @@ public abstract class ServerLauncher {
 
   final int serverInitWaitMillis = 10000;
 
-  public abstract void initServer(Path daemonDir, Locks locks) throws Exception;
+  /**
+   * Starts a Mill server
+   *
+   * @return the server process if available, or null
+   */
+  public abstract Process initServer(Path daemonDir, Locks locks) throws Exception;
 
   public abstract void preparedaemonDir(Path daemonDir) throws Exception;
 
@@ -108,8 +113,33 @@ public abstract class ServerLauncher {
     try (Locks locks = memoryLock != null ? memoryLock : Locks.files(daemonDir.toString());
         mill.client.lock.Locked locked = locks.launcherLock.lock()) {
 
-      if (locks.daemonLock.probe()) initServer(daemonDir, locks);
-      while (locks.daemonLock.probe()) Thread.sleep(1);
+      Process serverProcess = null;
+
+      if (locks.daemonLock.probe()) serverProcess = initServer(daemonDir, locks);
+      while (locks.daemonLock.probe()) {
+        if (serverProcess != null && !serverProcess.isAlive()) {
+          System.err.println("Mill server exited!");
+          Path stdout = daemonDir.toAbsolutePath().resolve(DaemonFiles.stdout);
+          Path stderr = daemonDir.toAbsolutePath().resolve(DaemonFiles.stderr);
+          if (Files.exists(stdout) && Files.size(stdout) > 0) {
+            System.err.println("Server stdout:");
+            System.err.println();
+            System.err.write(Files.readAllBytes(stdout));
+          } else {
+            System.err.println("No server stdout");
+          }
+          if (Files.exists(stderr) && Files.size(stderr) > 0) {
+            System.err.println();
+            System.err.println("Server stderr:");
+            System.err.println();
+            System.err.write(Files.readAllBytes(stderr));
+          } else {
+            System.err.println("No server stderr");
+          }
+          System.exit(1);
+        }
+        Thread.sleep(1);
+      }
     }
     long retryStart = System.currentTimeMillis();
     Socket ioSocket = null;

--- a/runner/codesig/src/mill/codesig/ExternalSummary.scala
+++ b/runner/codesig/src/mill/codesig/ExternalSummary.scala
@@ -27,10 +27,7 @@ object ExternalSummary {
       localSummary: LocalSummary,
       upstreamClasspath: Seq[os.Path]
   )(implicit st: SymbolTable): ExternalSummary = {
-    val upstreamClassloader = mill.util.Jvm.createClassLoader(
-      upstreamClasspath,
-      getClass.getClassLoader
-    )
+    val upstreamClassloader = mill.util.Jvm.createClassLoader(upstreamClasspath)
 
     val allDirectAncestors = localSummary.mapValuesOnly(_.directAncestors).flatten
 

--- a/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
+++ b/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
@@ -296,6 +296,7 @@ class MillBuildBootstrap(
             else
               mill.util.Jvm.createClassLoader(
                 runClasspath.map(p => os.Path(p.javaPath)),
+                parent = null,
                 sharedLoader = classOf[MillBuildBootstrap].getClassLoader,
                 sharedPrefixes = Seq("java.", "javax.", "scala.", "mill.api")
               )

--- a/runner/launcher/package.mill
+++ b/runner/launcher/package.mill
@@ -17,6 +17,7 @@ object `package` extends MillPublishScalaModule with BuildInfo {
     Deps.nativeTerminal,
     Deps.coursier,
     Deps.coursierInterface,
+    Deps.coursierLauncher,
     Deps.coursierJvm,
     Deps.logback,
     Deps.snakeyamlEngine,

--- a/runner/launcher/src/mill/launcher/CoursierClient.scala
+++ b/runner/launcher/src/mill/launcher/CoursierClient.scala
@@ -127,6 +127,7 @@ object CoursierClient {
     launcher.toNIO
   }
 
+  /** Files refered to by this launcher */
   def launcherEntries(launcher: java.nio.file.Path): Array[java.nio.file.Path] =
     Using.resource(new ZipFile(launcher.toFile)) { zf =>
       Iterator.from(0)

--- a/runner/launcher/src/mill/launcher/MillLauncherMain.java
+++ b/runner/launcher/src/mill/launcher/MillLauncherMain.java
@@ -50,8 +50,8 @@ public class MillLauncherMain {
                 optsArgs.toArray(new String[0]),
                 null,
                 -1) {
-              public void initServer(Path daemonDir, Locks locks) throws Exception {
-                MillProcessLauncher.launchMillServer(daemonDir);
+              public Process initServer(Path daemonDir, Locks locks) throws Exception {
+                return MillProcessLauncher.launchMillServer(daemonDir);
               }
 
               public void preparedaemonDir(Path daemonDir) throws Exception {

--- a/runner/launcher/src/mill/launcher/MillProcessLauncher.java
+++ b/runner/launcher/src/mill/launcher/MillProcessLauncher.java
@@ -75,7 +75,8 @@ public class MillProcessLauncher {
     Path sandbox = daemonDir.resolve(DaemonFiles.sandbox);
     Files.createDirectories(sandbox);
     builder.environment().put(EnvVars.MILL_WORKSPACE_ROOT, new File("").getCanonicalPath());
-    builder.environment().put(EnvVars.MILL_EXECUTABLE_PATH, getExecutablePath());
+    if (System.getenv(EnvVars.MILL_EXECUTABLE_PATH) == null)
+      builder.environment().put(EnvVars.MILL_EXECUTABLE_PATH, getExecutablePath());
 
     String jdkJavaOptions = System.getenv("JDK_JAVA_OPTIONS");
     if (jdkJavaOptions == null) jdkJavaOptions = "";

--- a/runner/launcher/src/mill/launcher/MillProcessLauncher.java
+++ b/runner/launcher/src/mill/launcher/MillProcessLauncher.java
@@ -55,7 +55,7 @@ public class MillProcessLauncher {
     }
   }
 
-  static void launchMillServer(Path daemonDir) throws Exception {
+  static Process launchMillServer(Path daemonDir) throws Exception {
     List<String> l = new ArrayList<>();
     l.addAll(millLaunchJvmCommand(true));
     l.add(daemonDir.toFile().getCanonicalPath());
@@ -65,7 +65,7 @@ public class MillProcessLauncher {
         .redirectOutput(daemonDir.resolve(DaemonFiles.stdout).toFile())
         .redirectError(daemonDir.resolve(DaemonFiles.stderr).toFile());
 
-    configureRunMillProcess(builder, daemonDir);
+    return configureRunMillProcess(builder, daemonDir);
   }
 
   static Process configureRunMillProcess(ProcessBuilder builder, Path daemonDir) throws Exception {

--- a/runner/server/test/src/mill/server/ClientServerTests.scala
+++ b/runner/server/test/src/mill/server/ClientServerTests.scala
@@ -110,6 +110,7 @@ object ClientServerTests extends TestSuite {
             locks,
             testLogEvenWhenServerIdWrong
           )).start()
+          null
         }
       }.run((outDir / "server-0").relativeTo(os.pwd).toNIO, "")
 


### PR DESCRIPTION
This PR makes Mill start its daemon with the help of [coursier bootstraps](https://almond.sh/docs/install-advanced.html#isolation-of-almond-internal-dependencies), to isolate some Mill dependencies. These bootstraps are generated so that they load Mill using three class loaders:
- a first one with `org.scala-sbt:compiler-interface` and `org.scala-sbt:test-interface`
- a second one, with the first as parent, that loads the `core-api` module of Mill (alongside its dependencies)
- a third one, loading the rest of the Mill class path

The first class loader is the parent of the second one, and the second one is the parent of the third one.

When loading scala-compiler JARs (in `JvmWorkerImpl#scalaCompilerCache`) or test frameworks (like in `TestModule#bspBuildTargetScalaTestClasses`, to discover tests from within the Mill process, but it's also done in other places), Mill uses the first class loader as a parent loader for the class loader that loads scala-compiler or the class path that has tests. That way, the compiler-interface and test-interface classes are shared between Mill's internals and scalac or the test class path.

When loading the build class path in `MillBuildBootstrap#processRunClasspath`, Mill uses the second class loader, so that the core-api class path is shared between Mill's internals and the user build, but the rest of the Mill class path is hidden from user builds.

This has two benefits, compared to what's done without this PR:
- avoiding mistakes or issues that can arise with the use of package prefixes to hide classes (like done [here](https://github.com/com-lihaoyi/mill/blob/aa7125f81d4952717fa42e863e0311b2b39d1631/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala#L284-L289))
- make the class loader hierarchy more "standard", consisting solely of `URLClassLoader`s (and the JVM's app and bootstrap loaders), so that it's easier to inspect by users if they need to

Initially, these development were motivated by suspicious things seen around `SystemStreams.ThreadLocalStreams.current` involving thread local variables, in https://github.com/com-lihaoyi/mill/pull/5154, but it turns out the changes in the PR here are not necessary to address these issues.

So this PR only makes things safer or more standard, but it isn't required for any feature as I initially thought. If you've seen anything suspicious with the handling of class loaders, it might be helpful…