### PR TITLE
Remove `T.*` APIs

### DIFF
--- a/contrib/docker/src/mill/contrib/docker/DockerModule.scala
+++ b/contrib/docker/src/mill/contrib/docker/DockerModule.scala
@@ -14,10 +14,10 @@ trait DockerModule { outer: JavaModule =>
      * Tags that should be applied to the built image
      * In the standard registry/repository:tag format
      */
-    def tags: T[Seq[String]] = T(List(outer.artifactName()))
+    def tags: T[Seq[String]] = Task { List(outer.artifactName()) }
     def labels: T[Map[String, String]] = Map.empty[String, String]
     def baseImage: T[String] = "gcr.io/distroless/java:latest"
-    def pullBaseImage: T[Boolean] = T(baseImage().endsWith(":latest"))
+    def pullBaseImage: T[Boolean] = Task { baseImage().endsWith(":latest") }
 
     /**
      * JVM runtime options. Each item of the Seq should consist of an option and its desired value, like

--- a/contrib/flyway/src/mill/contrib/flyway/FlywayModule.scala
+++ b/contrib/flyway/src/mill/contrib/flyway/FlywayModule.scala
@@ -18,8 +18,8 @@ trait FlywayModule extends JavaModule {
   import FlywayModule._
 
   def flywayUrl: T[String]
-  def flywayUser: T[String] = T("")
-  def flywayPassword: T[String] = T("")
+  def flywayUser: T[String] = Task { "" }
+  def flywayPassword: T[String] = Task { "" }
   def flywayFileLocations: T[Seq[PathRef]] = Task {
     resources().map(pr => PathRef(pr.path / "db/migration", pr.quick))
   }

--- a/contrib/proguard/readme.adoc
+++ b/contrib/proguard/readme.adoc
@@ -32,7 +32,7 @@ object foo extends ScalaModule with Proguard {
   override def obfuscate: T[Boolean] = Task { false }
 
   // https://github.com/Guardsquare/proguard/releases
-  override def proguardVersion = T("7.3.2")
+  override def proguardVersion = Task { "7.3.2" }
 
   // tell Proguard where to enter your app, so it can optimise outwards from there
   override def entryPoint = Task {

--- a/contrib/proguard/src/mill/contrib/proguard/Proguard.scala
+++ b/contrib/proguard/src/mill/contrib/proguard/Proguard.scala
@@ -156,7 +156,7 @@ trait Proguard extends ScalaModule {
     Task.log.warn(
       "Proguard is set to not warn about message: can't find referenced method 'void invoke()' in library class java.lang.invoke.MethodHandle"
     )
-    T.log.warn(
+    Task.log.warn(
       """Proguard is set to not warn about message: "scala.quoted.Type: can't find referenced class scala.AnyKind""""
     )
     Seq[String](

--- a/core/define/src/mill/define/TaskCtx.scala
+++ b/core/define/src/mill/define/TaskCtx.scala
@@ -55,7 +55,7 @@ object TaskCtx {
   }
 
   @compileTimeOnly(
-    "Target.ctx() / Task.ctx() / Task.* APIs can only be used with a Task{...} block"
+    "Task.ctx() / Task.* APIs can only be used with a Task{...} block"
   )
   @ImplicitStub
   implicit def taskCtx: TaskCtx = ???

--- a/core/define/test/src/mill/define/ApplicativeTests.scala
+++ b/core/define/test/src/mill/define/ApplicativeTests.scala
@@ -15,7 +15,7 @@ object ApplicativeTests extends TestSuite {
       value
     }
   }
-  @compileTimeOnly("Target.ctx() can only be used with a Task{...} block")
+  @compileTimeOnly("Task.ctx() can only be used with a Task{...} block")
   @ImplicitStub
   implicit def taskCtx: String = ???
 

--- a/core/util/src/mill/mill.scala
+++ b/core/util/src/mill/mill.scala
@@ -1,7 +1,5 @@
 package object mill extends mill.define.JsonFormatters with mill.util.TokenReaders0 {
-  val T = define.Target
   type T[+T] = define.Target[T]
-  val Target = define.Target
   type Target[+T] = define.Target[T]
   val PathRef = mill.define.PathRef
   type PathRef = mill.define.PathRef

--- a/dist/scripts/package.mill
+++ b/dist/scripts/package.mill
@@ -21,14 +21,14 @@ object `package` extends mill.Module { scripts =>
       "mill-best-version" -> "0.12.10", // TODO: build.millVersionTruth()
       "mill-download-cache-unix" -> "~/.cache/mill/download",
       "mill-download-cache-win" -> "%USERPROFILE%\\\\.mill\\\\download",
-      "template-file" -> templateFile().path.relativeTo(T.workspace).toString
+      "template-file" -> templateFile().path.relativeTo(Task.workspace).toString
     )
     def substitutionMarkers: T[(String, String)] = ("{{{", "}}}")
     def inRepoDir: Task[os.SubPath] = Task.Anon { os.sub / finalName() }
 
     /** Compiles the script from the [[templateFile]] and substitutes all [[substitutions]]. */
     def compile0: T[PathRef] = Task {
-      val script = T.dest / finalName()
+      val script = Task.dest / finalName()
       val template = templateFile().path
       val (start, end) = substitutionMarkers()
 
@@ -89,7 +89,7 @@ object `package` extends mill.Module { scripts =>
     Task.traverse(scriptsModules)(m =>
       Task.Anon {
         val script = m.compile0().path
-        val dest = T.workspace / m.inRepoDir()
+        val dest = Task.workspace / m.inRepoDir()
         if (os.isDir(dest)) {
           sys.error(s"Install destination is a directory: ${dest}")
         } else if (os.exists(dest)) {

--- a/example/package.mill
+++ b/example/package.mill
@@ -269,7 +269,7 @@ $txt
                 if (seenCode) ""
                 else {
                   val exampleDashed = examplePath.segments.mkString("-")
-                  val download = s"{mill-download-url}/$exampleDashed.zip[download]"
+                  val download = s"{mill-download-url}/mill-dist-${build.millVersion()}-$exampleDashed.zip[download]"
                   val browse = s"{mill-example-url}/$examplePath[browse]"
                   s".build.mill ($download, $browse)"
                 }

--- a/example/package.mill
+++ b/example/package.mill
@@ -269,7 +269,8 @@ $txt
                 if (seenCode) ""
                 else {
                   val exampleDashed = examplePath.segments.mkString("-")
-                  val download = s"{mill-download-url}/mill-dist-${build.millVersion()}-$exampleDashed.zip[download]"
+                  val download =
+                    s"{mill-download-url}/mill-dist-${build.millVersion()}-$exampleDashed.zip[download]"
                   val browse = s"{mill-example-url}/$examplePath[browse]"
                   s".build.mill ($download, $browse)"
                 }

--- a/example/thirdparty/ollama-js/build.mill
+++ b/example/thirdparty/ollama-js/build.mill
@@ -93,16 +93,16 @@ trait OllamaModule extends TypeScriptModule {
         p.last == "node_modules" ||
           p.last == "package-lock.json"
     )
-      .foreach(p => os.copy.over(p, T.dest / p.relativeTo(out), createFolders = true))
+      .foreach(p => os.copy.over(p, Task.dest / p.relativeTo(out), createFolders = true))
 
-    os.call("node_modules/.bin/unbuild", cwd = T.dest)
+    os.call("node_modules/.bin/unbuild", cwd = Task.dest)
 
     // prepare bundled ouptut to be used as `unmanagedDeps` in examples section.
-    os.makeDir.all(T.dest / "ollama")
-    os.copy(T.dest / "package.json", T.dest / "ollama" / "package.json")
-    os.copy(T.dest / "dist", T.dest / "ollama" / "dist")
+    os.makeDir.all(Task.dest / "ollama")
+    os.copy(Task.dest / "package.json", Task.dest / "ollama" / "package.json")
+    os.copy(Task.dest / "dist", Task.dest / "ollama" / "dist")
 
-    PathRef(T.dest / "ollama")
+    PathRef(Task.dest / "ollama")
   }
 }
 

--- a/integration/invalidation/codesig-scalamodule/src/CodeSigScalaModuleTests.scala
+++ b/integration/invalidation/codesig-scalamodule/src/CodeSigScalaModuleTests.scala
@@ -108,10 +108,10 @@ object CodeSigScalaModuleTests extends UtestIntegrationTestSuite {
           "\n\n\n" +
             s.replace("\n  def scalaVersion", "\n\n  def scalaVersion")
               .replace("\n  def sources = T{\n", "\n\n  def sources = T{\n\n")
-              .replace("\n  def compile = T {\n", "\n\n  def compile = T {\n\n")
+              .replace("\n  def compile = Task {\n", "\n\n  def compile = Task {\n\n")
               .replace(
-                "\n  def run(args: Task[Args] = T.task(Args())) = T.command {\n",
-                "\n\n  def run(args: Task[Args] = T.task(Args())) = T.command {\n\n"
+                "\n  def run(args: Task[Args] = Task.task(Args())) = Task.command {\n",
+                "\n\n  def run(args: Task[Args] = Task.task(Args())) = Task.command {\n\n"
               )
       )
       val mangledFoo6 = eval("foo.run")

--- a/integration/invalidation/invalidation/resources/-#!+→&%=~/package.mill
+++ b/integration/invalidation/invalidation/resources/-#!+→&%=~/package.mill
@@ -2,4 +2,4 @@ package build.`-#!+→&%=~`
 
 import mill._
 
-def input = T {}
+def input = Task {}

--- a/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
@@ -794,11 +794,11 @@ trait AndroidAppModule extends AndroidModule { outer =>
   }
 
   def androidModuleGeneratedDexVariants: Task[AndroidModuleGeneratedDexVariants] = Task {
-    val androidDebugDex = T.dest / "androidDebugDex.dest"
+    val androidDebugDex = Task.dest / "androidDebugDex.dest"
     os.makeDir(androidDebugDex)
-    val androidReleaseDex = T.dest / "androidReleaseDex.dest"
+    val androidReleaseDex = Task.dest / "androidReleaseDex.dest"
     os.makeDir(androidReleaseDex)
-    val mainDexListOutput = T.dest / "main-dex-list-output.txt"
+    val mainDexListOutput = Task.dest / "main-dex-list-output.txt"
 
     val proguardFileDebug = androidDebugDex / "proguard-rules.pro"
 
@@ -904,7 +904,7 @@ trait AndroidAppModule extends AndroidModule { outer =>
   // uses the d8 tool to generate the dex file, when minification is disabled
   private def androidD8Dex: T[(outPath: PathRef, dexCliArgs: Seq[String])] = Task {
 
-    val outPath = T.dest
+    val outPath = Task.dest
 
     val appCompiledFiles = (androidPackagedCompiledClasses() ++ androidPackagedClassfiles())
       .map(_.path.toString())
@@ -954,12 +954,12 @@ trait AndroidAppModule extends AndroidModule { outer =>
 
   // uses the R8 tool to generate the dex (to shrink and obfuscate)
   private def androidR8Dex: Task[(outPath: PathRef, dexCliArgs: Seq[String])] = Task {
-    val destDir = T.dest / "minify"
+    val destDir = Task.dest / "minify"
     os.makeDir.all(destDir)
 
     val outputPath = destDir
 
-    T.log.debug("outptuPath: " + outputPath)
+    Task.log.debug("outptuPath: " + outputPath)
 
     // Define diagnostic output file paths
     val mappingOut = destDir / "mapping.txt"

--- a/libs/androidlib/src/mill/androidlib/AndroidLibModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidLibModule.scala
@@ -94,7 +94,7 @@ trait AndroidLibModule extends AndroidModule with PublishModule {
   }
 
   def androidAar: T[PathRef] = Task {
-    val dest = T.dest
+    val dest = Task.dest
     val aarFile = dest / "library.aar"
     val compiledRes = dest / "compiled-res"
     val classesJar = dest / "classes.jar"

--- a/libs/androidlib/src/mill/androidlib/AndroidNativeAppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidNativeAppModule.scala
@@ -87,7 +87,7 @@ trait AndroidNativeAppModule extends AndroidAppModule {
         "-GNinja"
       ) ++ androidCMakeExtraArgs()
 
-      T.log.info(s"Calling CMake with arguments: ${cmakeArgs.mkString(" ")}")
+      Task.log.info(s"Calling CMake with arguments: ${cmakeArgs.mkString(" ")}")
 
       os.proc(cmakeArgs).call()
 

--- a/libs/javascriptlib/src/mill/javascriptlib/PublishModule.scala
+++ b/libs/javascriptlib/src/mill/javascriptlib/PublishModule.scala
@@ -53,9 +53,9 @@ trait PublishModule extends TypeScriptModule {
         )
         .cleanJson
 
-    os.write.over(T.dest / "package.json", updatedJson.render(2))
+    os.write.over(Task.dest / "package.json", updatedJson.render(2))
 
-    PathRef(T.dest)
+    PathRef(Task.dest)
   }
 
   // Compilation Options
@@ -103,9 +103,9 @@ trait PublishModule extends TypeScriptModule {
     mkTsconfig()
 
     // build declaration and out dir
-    os.call("node_modules/typescript/bin/tsc", cwd = T.dest)
+    os.call("node_modules/typescript/bin/tsc", cwd = Task.dest)
 
-    PathRef(T.dest)
+    PathRef(Task.dest)
   }
   // Compilation Options
 
@@ -174,13 +174,13 @@ trait PublishModule extends TypeScriptModule {
     val bundled = bundle().path / os.up
 
     os.walk(bundled)
-      .foreach(p => os.copy.over(p, T.dest / p.relativeTo(bundled), createFolders = true))
+      .foreach(p => os.copy.over(p, Task.dest / p.relativeTo(bundled), createFolders = true))
 
     // build package.json
-    os.copy.over(pubPackageJson().path / "package.json", T.dest / "package.json")
+    os.copy.over(pubPackageJson().path / "package.json", Task.dest / "package.json")
 
     // run npm publish
-    os.call(("npm", "publish"), stdout = os.Inherit, cwd = T.dest)
+    os.call(("npm", "publish"), stdout = os.Inherit, cwd = Task.dest)
     ()
   }
 

--- a/libs/javascriptlib/src/mill/javascriptlib/TestModule.scala
+++ b/libs/javascriptlib/src/mill/javascriptlib/TestModule.scala
@@ -40,7 +40,7 @@ object TestModule {
 
     def istanbulNycrcConfigBuilder: Task[PathRef] = Task.Anon {
       val fileName = ".nycrc"
-      val config = T.dest / fileName
+      val config = Task.dest / fileName
       val customConfig = Task.workspace / fileName
 
       val content =
@@ -132,7 +132,7 @@ object TestModule {
 
     def conf: Task[PathRef] = Task.Anon {
       val fileName = "jest.config.ts"
-      val config = T.dest / fileName
+      val config = Task.dest / fileName
       val customConfig = Task.workspace / fileName
 
       val content =
@@ -173,9 +173,9 @@ object TestModule {
       conf()
       coverageConf()
       createNodeModulesSymlink()
-      os.copy(super.compile().path, T.dest, mergeFolders = true, replaceExisting = true)
+      os.copy(super.compile().path, Task.dest, mergeFolders = true, replaceExisting = true)
 
-      PathRef(T.dest)
+      PathRef(Task.dest)
     }
 
     private def runTest: T[TestResult] = Task {
@@ -201,7 +201,7 @@ object TestModule {
     // with coverage
     def coverageConf: Task[PathRef] = Task.Anon {
       val fileName = "jest.config.coverage.ts"
-      val config = T.dest / fileName
+      val config = Task.dest / fileName
       val customConfig = Task.workspace / fileName
 
       val content =
@@ -284,14 +284,14 @@ object TestModule {
       conf()
       istanbulNycrcConfigBuilder()
       createNodeModulesSymlink()
-      os.copy(super.compile().path, T.dest, mergeFolders = true, replaceExisting = true)
+      os.copy(super.compile().path, Task.dest, mergeFolders = true, replaceExisting = true)
 
-      PathRef(T.dest)
+      PathRef(Task.dest)
     }
 
     // test-runner.js: run tests on ts files
     def conf: Task[PathRef] = Task.Anon {
-      val runner = T.dest / "test-runner.js"
+      val runner = Task.dest / "test-runner.js"
 
       val content =
         """|require('ts-node/register');
@@ -368,7 +368,7 @@ object TestModule {
 
     def conf: Task[PathRef] = Task.Anon {
       val fileName = "vitest.config.ts"
-      val config = T.dest / fileName
+      val config = Task.dest / fileName
       val customConfig = Task.workspace / fileName
 
       val content =
@@ -395,9 +395,9 @@ object TestModule {
       conf()
       coverageConf()
       createNodeModulesSymlink()
-      os.copy(super.compile().path, T.dest, mergeFolders = true, replaceExisting = true)
+      os.copy(super.compile().path, Task.dest, mergeFolders = true, replaceExisting = true)
 
-      PathRef(T.dest)
+      PathRef(Task.dest)
     }
 
     private def runTest: T[TestResult] = Task {
@@ -425,7 +425,7 @@ object TestModule {
     // coverage
     def coverageConf: Task[PathRef] = Task.Anon {
       val fileName = "vitest.config.coverage.ts"
-      val config = T.dest / fileName
+      val config = Task.dest / fileName
       val customConfig = Task.workspace / fileName
       val content =
         s"""|import { defineConfig } from 'vite';
@@ -500,7 +500,7 @@ object TestModule {
       }
 
     def conf: Task[PathRef] = Task.Anon {
-      val path = T.dest / "jasmine.json"
+      val path = Task.dest / "jasmine.json"
       os.write.over(
         path,
         ujson.write(
@@ -520,9 +520,9 @@ object TestModule {
       conf()
       istanbulNycrcConfigBuilder()
       createNodeModulesSymlink()
-      os.copy(super.compile().path, T.dest, mergeFolders = true, replaceExisting = true)
+      os.copy(super.compile().path, Task.dest, mergeFolders = true, replaceExisting = true)
 
-      PathRef(T.dest)
+      PathRef(Task.dest)
     }
 
     private def runTest: T[Unit] = Task {
@@ -667,16 +667,16 @@ object TestModule {
     def conf: Task[TestResult] = Task.Anon {
       os.copy.over(
         configSource().path,
-        T.dest / configSource().path.last
+        Task.dest / configSource().path.last
       )
     }
 
     override def compile: T[PathRef] = Task {
       conf()
       createNodeModulesSymlink()
-      os.copy(super.compile().path, T.dest, mergeFolders = true, replaceExisting = true)
+      os.copy(super.compile().path, Task.dest, mergeFolders = true, replaceExisting = true)
 
-      PathRef(T.dest)
+      PathRef(Task.dest)
     }
 
     private def runTest: T[TestResult] = Task {

--- a/libs/javascriptlib/src/mill/javascriptlib/TsLintModule.scala
+++ b/libs/javascriptlib/src/mill/javascriptlib/TsLintModule.scala
@@ -20,7 +20,7 @@ trait TsLintModule extends Module {
   }
 
   private def npmInstallLint: T[PathRef] = Task {
-    Try(os.copy.over(T.workspace / ".npmrc", Task.dest / ".npmrc")).getOrElse(())
+    Try(os.copy.over(Task.workspace / ".npmrc", Task.dest / ".npmrc")).getOrElse(())
     os.call((
       "npm",
       "install",
@@ -36,14 +36,14 @@ trait TsLintModule extends Module {
 
   // Handle config - prioritize eslint config
   private def fmtConfig: T[Seq[PathRef]] = Task.Sources(
-    T.workspace / "eslint.config.mjs",
-    T.workspace / "eslint.config.cjs",
-    T.workspace / "eslint.config.js",
-    T.workspace / ".eslintrc.js",
-    T.workspace / ".eslintrc.mjs",
-    T.workspace / ".eslintrc.cjs",
-    T.workspace / ".prettierrc",
-    T.workspace / ".prettierrc.json"
+    Task.workspace / "eslint.config.mjs",
+    Task.workspace / "eslint.config.cjs",
+    Task.workspace / "eslint.config.js",
+    Task.workspace / ".eslintrc.js",
+    Task.workspace / ".eslintrc.mjs",
+    Task.workspace / ".eslintrc.cjs",
+    Task.workspace / ".prettierrc",
+    Task.workspace / ".prettierrc.json"
   )
 
   private def resolvedFmtConfig: Task[Lint] = Task.Anon {
@@ -67,7 +67,7 @@ trait TsLintModule extends Module {
   def checkFormatEslint(args: mill.define.Args): Command[Unit] = Task.Command {
     resolvedFmtConfig() match {
       case Eslint =>
-        val cwd = T.workspace
+        val cwd = Task.workspace
         os.symlink(cwd / "node_modules", npmInstallLint().path / "node_modules")
         val eslint = npmInstallLint().path / "node_modules/.bin/eslint"
         val logPath = npmInstallLint().path / "eslint.log"
@@ -111,7 +111,7 @@ trait TsLintModule extends Module {
   def reformatEslint(args: mill.define.Args): Command[Unit] = Task.Command {
     resolvedFmtConfig() match {
       case Eslint =>
-        val cwd = T.workspace
+        val cwd = Task.workspace
         os.symlink(cwd / "node_modules", npmInstallLint().path / "node_modules")
         val eslint = npmInstallLint().path / "node_modules/.bin/eslint"
         val logPath = npmInstallLint().path / "eslint.log"
@@ -143,7 +143,7 @@ trait TsLintModule extends Module {
   def checkFormatPrettier(args: mill.define.Args): Command[Unit] = Task.Command {
     resolvedFmtConfig() match {
       case Prettier =>
-        val cwd = T.workspace
+        val cwd = Task.workspace
         val prettier = npmInstallLint().path / "node_modules/.bin/prettier"
         val logPath = npmInstallLint().path / "prettier.log"
         val defaultArgs = if (args.value.isEmpty) Seq("*/**/*.ts") else args.value
@@ -185,7 +185,7 @@ trait TsLintModule extends Module {
   def reformatPrettier(args: mill.define.Args): Command[Unit] = Task.Command {
     resolvedFmtConfig() match {
       case Prettier =>
-        val cwd = T.workspace
+        val cwd = Task.workspace
         val prettier = npmInstallLint().path / "node_modules/.bin/prettier"
         val logPath = npmInstallLint().path / "prettier.log"
         val defaultArgs = if (args.value.isEmpty) Seq("*/**/*.ts") else args.value
@@ -215,7 +215,7 @@ trait TsLintModule extends Module {
   }
 
   private def prettierIgnore: T[PathRef] = Task {
-    val config = T.dest / ".prettierignore"
+    val config = Task.dest / ".prettierignore"
     val content =
       s"""|node_modules
           |.git

--- a/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -181,7 +181,7 @@ trait KotlinModule extends JavaModule { outer =>
    * publishing to Maven Central. You can control Dokka version by using [[dokkaVersion]]
    * and option by using [[dokkaOptions]].
    */
-  override def docJar: T[PathRef] = T[PathRef] {
+  override def docJar: T[PathRef] = Task[PathRef] {
     val outDir = Task.dest
 
     val dokkaDir = outDir / "dokka"

--- a/libs/kotlinlib/src/mill/kotlinlib/ksp/KspModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/ksp/KspModule.scala
@@ -153,9 +153,9 @@ trait KspModule extends KotlinModule { outer =>
     val apClasspath = kotlinSymbolProcessorsResolved().map(_.path).mkString(File.pathSeparator)
 
     val kspProjectBasedDir = moduleDir
-    val kspOutputDir = T.dest / "generated/ksp/main"
+    val kspOutputDir = Task.dest / "generated/ksp/main"
 
-    val kspCachesDir = T.dest / "caches/main"
+    val kspCachesDir = Task.dest / "caches/main"
     val java = kspOutputDir / "java"
     val kotlin = kspOutputDir / "kotlin"
     val resources = kspOutputDir / "resources"
@@ -183,7 +183,7 @@ trait KspModule extends KotlinModule { outer =>
       s"Running Kotlin Symbol Processing for ${sourceFiles.size} Kotlin sources to ${kspOutputDir} ..."
     )
 
-    val compiledSources = T.dest / "compiled"
+    val compiledSources = Task.dest / "compiled"
     os.makeDir.all(compiledSources)
 
     val classpath = Seq(
@@ -197,7 +197,7 @@ trait KspModule extends KotlinModule { outer =>
 
     val compilerArgs: Seq[String] = classpath ++ kspCompilerArgs ++ sourceFiles.map(_.toString)
 
-    T.log.info(s"KSP arguments: ${compilerArgs.mkString(" ")}")
+    Task.log.info(s"KSP arguments: ${compilerArgs.mkString(" ")}")
 
     KotlinWorkerManager.kotlinWorker().withValue(kotlinCompilerClasspath().map(_.path)) {
       _._2.compile(KotlinWorkerTarget.Jvm, compilerArgs)

--- a/libs/main/src/mill/main/MainModule.scala
+++ b/libs/main/src/mill/main/MainModule.scala
@@ -117,7 +117,7 @@ trait MainModule extends BaseModule with MainModuleApi {
    */
   def show(evaluator: Evaluator, targets: String*): Command[ujson.Value] =
     Task.Command(exclusive = true) {
-      MainModule.show0(evaluator, targets, Target.log, mill.define.BuildCtx.evalWatch0) { res =>
+      MainModule.show0(evaluator, targets, Task.log, mill.define.BuildCtx.evalWatch0) { res =>
         res.flatMap(_._2) match {
           case Seq((k, singleValue)) => singleValue
           case multiple => ujson.Obj.from(multiple)
@@ -131,7 +131,7 @@ trait MainModule extends BaseModule with MainModuleApi {
    */
   def showNamed(evaluator: Evaluator, targets: String*): Command[ujson.Value] =
     Task.Command(exclusive = true) {
-      MainModule.show0(evaluator, targets, Target.log, mill.define.BuildCtx.evalWatch0) { res =>
+      MainModule.show0(evaluator, targets, Task.log, mill.define.BuildCtx.evalWatch0) { res =>
         ujson.Obj.from(res.flatMap(_._2))
       }
     }
@@ -191,7 +191,7 @@ trait MainModule extends BaseModule with MainModuleApi {
           }
 
           val existing = paths.filter(p => os.exists(p))
-          Target.log.debug(s"Cleaning ${existing.size} paths ...")
+          Task.log.debug(s"Cleaning ${existing.size} paths ...")
           existing.foreach(os.remove.all(_, ignoreErrors = true))
           existing.map(PathRef(_))
       }
@@ -205,7 +205,7 @@ trait MainModule extends BaseModule with MainModuleApi {
       VisualizeModule.visualize0(
         evaluator,
         targets,
-        Target.ctx(),
+        Task.ctx(),
         mill.main.VisualizeModule.worker()
       )
     }
@@ -220,7 +220,7 @@ trait MainModule extends BaseModule with MainModuleApi {
           VisualizeModule.visualize0(
             evaluator,
             targets,
-            Target.ctx(),
+            Task.ctx(),
             mill.main.VisualizeModule.worker(),
             Some(planResults.toList)
           )
@@ -231,8 +231,8 @@ trait MainModule extends BaseModule with MainModuleApi {
    * Shuts down mill's background daemon
    */
   def shutdown(): Command[Unit] = Task.Command(exclusive = true) {
-    Target.log.info("Shutting down Mill server...")
-    Target.ctx().systemExit(0)
+    Task.log.info("Shutting down Mill server...")
+    Task.ctx().systemExit(0)
     ()
   }
 

--- a/libs/main/src/mill/main/VisualizeModule.scala
+++ b/libs/main/src/mill/main/VisualizeModule.scala
@@ -80,7 +80,7 @@ object VisualizeModule extends ExternalModule {
   @deprecated("Use toolsClasspath instead", "0.13.0-M1")
   def classpath = toolsClasspath
 
-  def toolsClasspath: Target[Seq[PathRef]] = Target {
+  def toolsClasspath: Target[Seq[PathRef]] = Task {
     millProjectModule("mill-libs-graphviz", repositories)
   }
 

--- a/libs/pythonlib/src/mill/pythonlib/CoverageModule.scala
+++ b/libs/pythonlib/src/mill/pythonlib/CoverageModule.scala
@@ -36,7 +36,7 @@ trait CoverageModule extends PythonModule {
    * intentionally does not return a PathRef, since it will be populated from
    * other places.
    */
-  def coverageDataFile: T[os.Path] = Task { T.dest / "coverage" }
+  def coverageDataFile: T[os.Path] = Task { Task.dest / "coverage" }
 
   /**
    * The task to run to generate the coverage report.

--- a/libs/pythonlib/src/mill/pythonlib/RuffModule.scala
+++ b/libs/pythonlib/src/mill/pythonlib/RuffModule.scala
@@ -66,7 +66,7 @@ trait RuffModule extends PythonModule {
       (
         "-m", "ruff",
         "check",
-        "--cache-dir", T.dest / "cache",
+        "--cache-dir", Task.dest / "cache",
         configArgs(),
         ruffOptions(),
         args,
@@ -95,7 +95,7 @@ object RuffModule extends ExternalModule with RuffModule with TaskModule {
         configArgs(),
         ruffOptions(),
         ruffArgs.value,
-        T.sequence(sources.value)().flatten.map(_.path)
+        Task.sequence(sources.value)().flatten.map(_.path)
       ),
       // format: on
       workingDir = Task.dest
@@ -111,11 +111,11 @@ object RuffModule extends ExternalModule with RuffModule with TaskModule {
       (
         "-m", "ruff",
         "check",
-        "--cache-dir", T.dest / "cache",
+        "--cache-dir", Task.dest / "cache",
         configArgs(),
         ruffOptions(),
         ruffArgs.value,
-        T.sequence(sources.value)().flatten.map(_.path)
+        Task.sequence(sources.value)().flatten.map(_.path)
       ),
       // format: on
       workingDir = Task.dest

--- a/libs/scalalib/src/mill/scalalib/AssemblyModule.scala
+++ b/libs/scalalib/src/mill/scalalib/AssemblyModule.scala
@@ -150,7 +150,7 @@ trait AssemblyModule extends mill.define.Module {
 }
 object AssemblyModule extends ExternalModule with CoursierModule with OfflineSupportModule {
 
-  def jarjarabramsWorkerClasspath: T[Seq[PathRef]] = T {
+  def jarjarabramsWorkerClasspath: T[Seq[PathRef]] = Task {
     defaultResolver().classpath(Seq(
       Dep.millProjectModule("mill-libs-scalalib-jarjarabrams-worker")
     ))

--- a/libs/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/libs/scalalib/src/mill/scalalib/JavaModule.scala
@@ -1045,7 +1045,7 @@ trait JavaModule
    * The documentation jar, containing all the Javadoc/Scaladoc HTML files, for
    * publishing to Maven Central
    */
-  def docJar: T[PathRef] = T[PathRef] {
+  def docJar: T[PathRef] = Task[PathRef] {
     val outDir = Task.dest
 
     val javadocDir = outDir / "javadoc"

--- a/libs/scalalib/src/mill/scalalib/PublishModule.scala
+++ b/libs/scalalib/src/mill/scalalib/PublishModule.scala
@@ -375,7 +375,7 @@ trait PublishModule extends JavaModule { outer =>
       val publishTransitiveModuleDeps = (transitiveModuleDeps ++ transitiveRunModuleDeps).collect {
         case p: PublishModule => p
       }
-      Target.traverse(publishTransitiveModuleDeps.distinct) { publishMod =>
+      Task.traverse(publishTransitiveModuleDeps.distinct) { publishMod =>
         publishMod.publishLocalTask(localIvyRepo, sources, doc, transitive = false)
       }.map(_.flatten)
     } else {

--- a/libs/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/libs/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -426,7 +426,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase
   /**
    * Command-line options to pass to the Scala console
    */
-  def consoleScalacOptions: T[Seq[String]] = T(Seq.empty[String])
+  def consoleScalacOptions: T[Seq[String]] = Task { Seq.empty[String] }
 
   /**
    * Opens up a Scala console with your module and all dependencies present,
@@ -635,11 +635,11 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase
       if (isMixedProject) Seq.empty else Seq("-Ystop-after:semanticdb-typer")
 
     val additionalScalacOptions = if (JvmWorkerUtil.isScala3(sv)) {
-      Seq("-Xsemanticdb", s"-sourceroot:${T.workspace}")
+      Seq("-Xsemanticdb", s"-sourceroot:${Task.workspace}")
     } else {
       Seq(
         "-Yrangepos",
-        s"-P:semanticdb:sourceroot:${T.workspace}"
+        s"-P:semanticdb:sourceroot:${Task.workspace}"
       ) ++ stopAfterSemanticDbOpts
     }
 

--- a/libs/scalalib/src/mill/scalalib/TestModule.scala
+++ b/libs/scalalib/src/mill/scalalib/TestModule.scala
@@ -127,7 +127,7 @@ trait TestModule
    * When used in combination with [[testForkGrouping]], every JVM test running process
    * will guarantee to never claim tests from different test groups.
    */
-  def testParallelism: T[Boolean] = T(true)
+  def testParallelism: T[Boolean] = Task { true }
 
   /**
    * Discovers and runs the module's tests in a subprocess, reporting the
@@ -160,7 +160,7 @@ trait TestModule
    * Sets the file name for the generated JUnit-compatible test report.
    * If None is set, no file will be generated.
    */
-  def testReportXml: T[Option[String]] = T(Some("test-report.xml"))
+  def testReportXml: T[Option[String]] = Task { Some("test-report.xml") }
 
   def testLogLevel: T[TestReporter.LogLevel] = Task(TestReporter.LogLevel.Debug)
 

--- a/libs/scalalib/src/mill/scalalib/classgraph/ClassgraphWorkerModule.scala
+++ b/libs/scalalib/src/mill/scalalib/classgraph/ClassgraphWorkerModule.scala
@@ -9,7 +9,7 @@ import mill.util.Jvm
 
 trait ClassgraphWorkerModule extends CoursierModule with OfflineSupportModule {
 
-  def classgraphWorkerClasspath: T[Seq[PathRef]] = T {
+  def classgraphWorkerClasspath: T[Seq[PathRef]] = Task {
     defaultResolver().classpath(Seq(
       Dep.millProjectModule("mill-libs-scalalib-classgraph-worker")
     ))

--- a/libs/scalalib/src/mill/scalalib/scalafmt/ScalafmtModule.scala
+++ b/libs/scalalib/src/mill/scalalib/scalafmt/ScalafmtModule.scala
@@ -130,7 +130,7 @@ object ScalafmtModule extends ExternalModule with ScalafmtModule with TaskModule
       scalafmtMainClass,
       args,
       classPath = scalafmtClasspath().map(_.path),
-      cwd = T.workspace,
+      cwd = Task.workspace,
       stdin = os.Inherit,
       stdout = os.Inherit
     )

--- a/libs/scalalib/test/src/mill/javalib/errorprone/ErrorProneTests.scala
+++ b/libs/scalalib/test/src/mill/javalib/errorprone/ErrorProneTests.scala
@@ -1,6 +1,6 @@
 package mill.javalib.errorprone
 
-import mill.T
+import mill.{T, Task}
 import mill.define.Discover
 import mill.scalalib.JavaModule
 import mill.testkit.{TestRootModule, UnitTester}
@@ -16,9 +16,9 @@ object ErrorProneTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
   object errorProneCustom extends TestRootModule with JavaModule with ErrorProneModule {
-    override def errorProneOptions: T[Seq[String]] = T(Seq(
-      "-XepAllErrorsAsWarnings"
-    ))
+    override def errorProneOptions: T[Seq[String]] = Task {
+      Seq("-XepAllErrorsAsWarnings")
+    }
     lazy val millDiscover = Discover[this.type]
   }
 

--- a/libs/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
@@ -75,7 +75,7 @@ object HelloWorldTests extends TestSuite {
 
   object HelloWorldFatalWarnings extends TestRootModule {
     object core extends HelloWorldModule {
-      override def scalacOptions = T(Seq("-Ywarn-unused", "-Xfatal-warnings"))
+      override def scalacOptions = Task { Seq("-Ywarn-unused", "-Xfatal-warnings") }
     }
     lazy val millDiscover = Discover[this.type]
   }

--- a/libs/scalalib/test/src/mill/scalalib/ScalaAmmoniteTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/ScalaAmmoniteTests.scala
@@ -9,12 +9,12 @@ object ScalaAmmoniteTests extends TestSuite {
 
   object AmmoniteReplMainClass extends TestRootModule {
     object oldAmmonite extends ScalaModule {
-      override def scalaVersion = T("2.13.5")
-      override def ammoniteVersion = T("2.4.1")
+      override def scalaVersion = Task { "2.13.5" }
+      override def ammoniteVersion = Task { "2.4.1" }
     }
     object newAmmonite extends ScalaModule {
-      override def scalaVersion = T("2.13.5")
-      override def ammoniteVersion = T("2.5.0")
+      override def scalaVersion = Task { "2.13.5" }
+      override def ammoniteVersion = Task { "2.5.0" }
     }
     lazy val millDiscover = Discover[this.type]
   }

--- a/libs/scalalib/test/src/mill/scalalib/ScalaScaladocTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/ScalaScaladocTests.scala
@@ -10,7 +10,7 @@ object ScalaScaladocTests extends TestSuite {
 
   object HelloWorldWithDocVersion extends TestRootModule {
     object core extends HelloWorldModule {
-      override def scalacOptions = T(Seq("-Ywarn-unused", "-Xfatal-warnings"))
+      override def scalacOptions = Task { Seq("-Ywarn-unused", "-Xfatal-warnings") }
       override def scalaDocOptions = super.scalaDocOptions() ++ Seq("-doc-version", "1.2.3")
     }
 
@@ -19,8 +19,8 @@ object ScalaScaladocTests extends TestSuite {
 
   object HelloWorldOnlyDocVersion extends TestRootModule {
     object core extends HelloWorldModule {
-      override def scalacOptions = T(Seq("-Ywarn-unused", "-Xfatal-warnings"))
-      override def scalaDocOptions = T(Seq("-doc-version", "1.2.3"))
+      override def scalacOptions = Task { Seq("-Ywarn-unused", "-Xfatal-warnings") }
+      override def scalaDocOptions = Task { Seq("-doc-version", "1.2.3") }
     }
 
     lazy val millDiscover = Discover[this.type]
@@ -29,7 +29,7 @@ object ScalaScaladocTests extends TestSuite {
 
   object HelloWorldDocTitle extends TestRootModule {
     object core extends HelloWorldModule {
-      override def scalaDocOptions = T(Seq("-doc-title", "Hello World"))
+      override def scalaDocOptions = Task { Seq("-doc-title", "Hello World") }
     }
 
     lazy val millDiscover = Discover[this.type]

--- a/mill-build/src/millbuild/MillScalaModule.scala
+++ b/mill-build/src/millbuild/MillScalaModule.scala
@@ -12,13 +12,13 @@ import mill.scalalib.api.JvmWorkerUtil
 trait MillScalaModule extends ScalaModule with MillJavaModule /* with ScalafixModule*/ { outer =>
   def scalaVersion = Deps.scalaVersion
   def scalapVersion: T[String] = Deps.scala2Version
-  def scalafixScalaBinaryVersion = T {
+  def scalafixScalaBinaryVersion = Task {
     def sv = scalaVersion()
     if (JvmWorkerUtil.isScala3(sv)) "2.13"
     else JvmWorkerUtil.scalaBinaryVersion(sv)
   }
 
-  def scalafixConfig = T { Some(T.workspace / ".scalafix.conf") }
+  def scalafixConfig = Task { Some(Task.workspace / ".scalafix.conf") }
 
   def semanticDbVersion = Deps.semanticDBscala.version
 
@@ -61,7 +61,7 @@ trait MillScalaModule extends ScalaModule with MillJavaModule /* with ScalafixMo
       )
     )
 
-  def scalacPluginMvnDeps = T {
+  def scalacPluginMvnDeps = Task {
     val sv = scalaVersion()
     val binaryVersion = JvmWorkerUtil.scalaBinaryVersion(sv)
     val hasModuleDefs = binaryVersion == "2.13" || binaryVersion == "3"
@@ -70,7 +70,7 @@ trait MillScalaModule extends ScalaModule with MillJavaModule /* with ScalafixMo
       Option.when(hasModuleDefs)(Deps.millModuledefsPlugin)
   }
 
-  def mandatoryMvnDeps = T {
+  def mandatoryMvnDeps = Task {
     val sv = scalaVersion()
     val binaryVersion = JvmWorkerUtil.scalaBinaryVersion(sv)
     val hasModuleDefs = binaryVersion == "2.13" || binaryVersion == "3"
@@ -82,7 +82,7 @@ trait MillScalaModule extends ScalaModule with MillJavaModule /* with ScalafixMo
   lazy val test: MillScalaTests = new MillScalaTests {}
   trait MillScalaTests extends ScalaTests with MillJavaModule with MillBaseTestsModule
       /*with ScalafixModule*/ {
-    def scalafixConfig = T { Some(T.workspace / ".scalafix.conf") }
+    def scalafixConfig = Task { Some(Task.workspace / ".scalafix.conf") }
     def forkArgs = super.forkArgs() ++ outer.testArgs()
     def moduleDeps = outer.testModuleDeps
     def mvnDeps = super.mvnDeps() ++ outer.testMvnDeps()

--- a/mill-build/src/millbuild/MillStableScalaModule.scala
+++ b/mill-build/src/millbuild/MillStableScalaModule.scala
@@ -33,8 +33,8 @@ trait MillStableScalaModule extends MillPublishScalaModule /*with Mima*/ {
 
   def mimaExcludeAnnotations = Seq("mill.api.internal", "mill.api.experimental")
 //  def mimaCheckDirection = CheckDirection.Backward
-  def skipPreviousVersions: T[Seq[String]] = T {
-    T.log.info("Skipping mima for previous versions (!!1000s of errors due to Scala 3)")
-    mimaPreviousVersions() // T(Seq.empty[String])
+  def skipPreviousVersions: T[Seq[String]] = Task {
+    Task.log.info("Skipping mima for previous versions (!!1000s of errors due to Scala 3)")
+    mimaPreviousVersions() // Task {Seq.empty[String]}
   }*/
 }

--- a/website/docs/modules/ROOT/pages/extending/thirdparty-plugins.adoc
+++ b/website/docs/modules/ROOT/pages/extending/thirdparty-plugins.adoc
@@ -251,7 +251,7 @@ object hello extends ScalaModule with DockerNative {
   object dockerNative extends DockerNativeConfig {
     // Native Image parameters
     def nativeImageName         = "hello"
-    def nativeImageGraalVmJvmId = T("graalvm-java17:22.3.2")
+    def nativeImageGraalVmJvmId = Task {"graalvm-java17:22.3.2"}
     def nativeImageClassPath    = runClasspath()
     def nativeImageMainClass    = "com.domain.Hello.Hello"
     // GraalVM parameters depending on your application needs

--- a/website/package.mill
+++ b/website/package.mill
@@ -14,7 +14,7 @@ object `package` extends mill.Module {
   // consolidated documentation using the Scaladoc tool.
   object site extends UnidocModule {
     def unidocSourceFiles = Task {
-      (Seq(compile().classes) ++ T.traverse(moduleDeps)(_.compile)().map(_.classes))
+      (Seq(compile().classes) ++ Task.traverse(moduleDeps)(_.compile)().map(_.classes))
         .filter(pr => os.exists(pr.path))
         .flatMap(pr => os.walk(pr.path))
         .filter(_.ext == "tasty")
@@ -180,7 +180,7 @@ object `package` extends mill.Module {
       mainClass = "mill.main.graphviz.GraphvizTools",
       classPath = visualizeClassPath.toSeq,
       mainArgs = orderedDiagrams.map { case (p, i, src, dest) =>
-        T.log.debug(s"Rendering graphviz: ${p} (${i}) to ${dest}")
+        Task.log.debug(s"Rendering graphviz: ${p} (${i}) to ${dest}")
         s"$src;$dest;svg"
       }
     )


### PR DESCRIPTION
These were replaced by `Task.*` in 0.12.x, but kept around for compatibility. We should remove them in 1.0.0's cleanup