### PR TITLE
Manually stop scalac timers

### DIFF
--- a/integration/feature/leak-hygiene/src/LeakHygieneTests.scala
+++ b/integration/feature/leak-hygiene/src/LeakHygieneTests.scala
@@ -23,15 +23,19 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
     assert(read == expected)
   }
 
-  def checkThreads(tester: IntegrationTester, allowTimers: Boolean = false)(expected: String*) = {
+  def checkThreads(tester: IntegrationTester, allowTimers: Boolean = true)(expected: String*) = {
     val out = tester.eval(("show", "countThreads")).out
     val read = upickle.default.read[Seq[String]](out)
     val filtered = read.filter {
       case s"coursier-pool-$_" => false
       case s"scala-execution-context-$_" => false
+
+      // Timers are expected most of the time due to https://github.com/com-lihaoyi/mill/issues/5083,
+      // but sometimes 
       case s"Timer-$_" if allowTimers => false
       case _ => true
     }
+
     // pprint.log(read)
     // pprint.log(expected)
     assert(filtered == expected)
@@ -70,7 +74,7 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
             "mill.scalalib.JvmWorkerModule#worker cl" -> 2,
             "mill.scalalib.worker.JvmWorkerImpl#getCachedClassLoader cl" -> 2
           )
-          checkThreads(tester, allowTimers = true)(
+          checkThreads(tester)(
             "HandleRunThread",
             "MillServerActionRunner",
             "MillSocketTimeoutInterruptThread",
@@ -95,7 +99,7 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
             "mill.scalalib.JvmWorkerModule#worker cl" -> 2,
             "mill.scalalib.worker.JvmWorkerImpl#getCachedClassLoader cl" -> 2
           )
-          checkThreads(tester, allowTimers = true)(
+          checkThreads(tester)(
             "HandleRunThread",
             "MillServerActionRunner",
             "MillSocketTimeoutInterruptThread",
@@ -117,7 +121,7 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
           "mill.daemon.MillBuildBootstrap#processRunClasspath classLoader cl" -> 1,
           "mill.scalalib.JvmWorkerModule#worker cl" -> 1
         )
-        checkThreads(tester)(
+        checkThreads(tester, allowTimers = false)(
           "HandleRunThread",
           "MillServerActionRunner",
           "MillSocketTimeoutInterruptThread",
@@ -140,7 +144,7 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
             "mill.scalalib.JvmWorkerModule#worker cl" -> 2,
             "mill.scalalib.worker.JvmWorkerImpl#getCachedClassLoader cl" -> 1
           )
-          checkThreads(tester, allowTimers = true)(
+          checkThreads(tester)(
             "HandleRunThread",
             "MillServerActionRunner",
             "MillSocketTimeoutInterruptThread",
@@ -165,7 +169,7 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
             "mill.scalalib.JvmWorkerModule#worker cl" -> 2,
             "mill.scalalib.worker.JvmWorkerImpl#getCachedClassLoader cl" -> 1
           )
-          checkThreads(tester, allowTimers = true)(
+          checkThreads(tester)(
             "HandleRunThread",
             "MillServerActionRunner",
             "MillSocketTimeoutInterruptThread",
@@ -192,7 +196,7 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
             "mill.scalalib.JvmWorkerModule#worker cl" -> 2,
             "mill.scalalib.worker.JvmWorkerImpl#getCachedClassLoader cl" -> 1
           )
-          checkThreads(tester, allowTimers = true)(
+          checkThreads(tester)(
             "HandleRunThread",
             "MillServerActionRunner",
             "MillSocketTimeoutInterruptThread",
@@ -216,7 +220,7 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
           "mill.scalalib.JvmWorkerModule#worker cl" -> 2,
           "mill.scalalib.worker.JvmWorkerImpl#getCachedClassLoader cl" -> 1
         )
-        checkThreads(tester, allowTimers = true)(
+        checkThreads(tester)(
           "HandleRunThread",
           "MillServerActionRunner",
           "MillSocketTimeoutInterruptThread",

--- a/integration/feature/leak-hygiene/src/LeakHygieneTests.scala
+++ b/integration/feature/leak-hygiene/src/LeakHygieneTests.scala
@@ -23,12 +23,13 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
     assert(read == expected)
   }
 
-  def checkThreads(tester: IntegrationTester)(expected: String*) = {
+  def checkThreads(tester: IntegrationTester, allowTimers: Boolean = false)(expected: String*) = {
     val out = tester.eval(("show", "countThreads")).out
     val read = upickle.default.read[Seq[String]](out)
     val filtered = read.filter {
       case s"coursier-pool-$_" => false
       case s"scala-execution-context-$_" => false
+      case s"Timer-$_" if allowTimers => false
       case _ => true
     }
     // pprint.log(read)
@@ -69,7 +70,7 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
             "mill.scalalib.JvmWorkerModule#worker cl" -> 2,
             "mill.scalalib.worker.JvmWorkerImpl#getCachedClassLoader cl" -> 2
           )
-          checkThreads(tester)(
+          checkThreads(tester, allowTimers = true)(
             "HandleRunThread",
             "MillServerActionRunner",
             "MillSocketTimeoutInterruptThread",
@@ -94,7 +95,7 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
             "mill.scalalib.JvmWorkerModule#worker cl" -> 2,
             "mill.scalalib.worker.JvmWorkerImpl#getCachedClassLoader cl" -> 2
           )
-          checkThreads(tester)(
+          checkThreads(tester, allowTimers = true)(
             "HandleRunThread",
             "MillServerActionRunner",
             "MillSocketTimeoutInterruptThread",
@@ -139,7 +140,7 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
             "mill.scalalib.JvmWorkerModule#worker cl" -> 2,
             "mill.scalalib.worker.JvmWorkerImpl#getCachedClassLoader cl" -> 1
           )
-          checkThreads(tester)(
+          checkThreads(tester, allowTimers = true)(
             "HandleRunThread",
             "MillServerActionRunner",
             "MillSocketTimeoutInterruptThread",
@@ -164,7 +165,7 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
             "mill.scalalib.JvmWorkerModule#worker cl" -> 2,
             "mill.scalalib.worker.JvmWorkerImpl#getCachedClassLoader cl" -> 1
           )
-          checkThreads(tester)(
+          checkThreads(tester, allowTimers = true)(
             "HandleRunThread",
             "MillServerActionRunner",
             "MillSocketTimeoutInterruptThread",
@@ -191,7 +192,7 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
             "mill.scalalib.JvmWorkerModule#worker cl" -> 2,
             "mill.scalalib.worker.JvmWorkerImpl#getCachedClassLoader cl" -> 1
           )
-          checkThreads(tester)(
+          checkThreads(tester, allowTimers = true)(
             "HandleRunThread",
             "MillServerActionRunner",
             "MillSocketTimeoutInterruptThread",
@@ -215,7 +216,7 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
           "mill.scalalib.JvmWorkerModule#worker cl" -> 2,
           "mill.scalalib.worker.JvmWorkerImpl#getCachedClassLoader cl" -> 1
         )
-        checkThreads(tester)(
+        checkThreads(tester, allowTimers = true)(
           "HandleRunThread",
           "MillServerActionRunner",
           "MillSocketTimeoutInterruptThread",

--- a/libs/scalalib/worker/src/mill/scalalib/worker/JvmWorkerImpl.scala
+++ b/libs/scalalib/worker/src/mill/scalalib/worker/JvmWorkerImpl.scala
@@ -115,8 +115,6 @@ class JvmWorkerImpl(
       import key._
       classloaderCache.updateWith(compilersSig) {
         case Some((cl, 1)) =>
-          // We try to find the timer created by scala.tools.nsc.classpath.FileBasedCache
-          // and cancel it, so that it shuts down its thread.
           cl.close()
           None
         case Some((cl, n)) if n > 1 => Some((cl, n - 1))

--- a/libs/scalalib/worker/src/mill/scalalib/worker/JvmWorkerImpl.scala
+++ b/libs/scalalib/worker/src/mill/scalalib/worker/JvmWorkerImpl.scala
@@ -115,6 +115,32 @@ class JvmWorkerImpl(
       import key._
       classloaderCache.updateWith(compilersSig) {
         case Some((cl, 1)) =>
+          // We try to find the timer created by scala.tools.nsc.classpath.FileBasedCache
+          // and cancel it, so that it shuts down its thread.
+          for {
+            cls <- {
+              try Some(cl.loadClass("scala.tools.nsc.classpath.FileBasedCache$"))
+              catch { case _: ClassNotFoundException => None }
+            }
+            moduleField <- {
+              try Some(cls.getField("MODULE$"))
+              catch { case _: NoSuchFieldException => None }
+            }
+            module = moduleField.get(null)
+            timerField <- {
+              try Some(cls.getDeclaredField("scala$tools$nsc$classpath$FileBasedCache$$timer"))
+              catch { case _: NoSuchFieldException => None }
+            }
+            _ = timerField.setAccessible(true)
+            timerOpt0 = timerField.get(module)
+            getOrElseMethod <- timerOpt0.getClass.getMethods.find(_.getName == "getOrElse")
+            timer <-
+              Option(getOrElseMethod.invoke(timerOpt0, null).asInstanceOf[java.util.Timer])
+          } {
+
+            timer.cancel()
+          }
+
           cl.close()
           None
         case Some((cl, n)) if n > 1 => Some((cl, n - 1))
@@ -657,13 +683,9 @@ class JvmWorkerImpl(
   }
 
   override def close(): Unit = {
-    val urlClassLoaders = classloaderCache
-      .map(_._2._1)
-      .collect { case v: AutoCloseable => v }
-
-    // pprint.log(classloaderCache.map(_._2._1))
-    // pprint.log(urlClassLoaders.map(_.getURLs))
-    urlClassLoaders.foreach(_.close())
+    scalaCompilerCache.close()
+    javaOnlyCompilerCache.close()
+    classloaderCache.foreach(_._2._1.close())
 
     classloaderCache.clear()
     close0()

--- a/libs/scalalib/worker/src/mill/scalalib/worker/JvmWorkerImpl.scala
+++ b/libs/scalalib/worker/src/mill/scalalib/worker/JvmWorkerImpl.scala
@@ -117,29 +117,6 @@ class JvmWorkerImpl(
         case Some((cl, 1)) =>
           // We try to find the timer created by scala.tools.nsc.classpath.FileBasedCache
           // and cancel it, so that it shuts down its thread.
-          for {
-            cls <- {
-              try Some(cl.loadClass("scala.tools.nsc.classpath.FileBasedCache$"))
-              catch { case _: ClassNotFoundException => None }
-            }
-            moduleField <- {
-              try Some(cls.getField("MODULE$"))
-              catch { case _: NoSuchFieldException => None }
-            }
-            module = moduleField.get(null)
-            timerField <- {
-              try Some(cls.getDeclaredField("scala$tools$nsc$classpath$FileBasedCache$$timer"))
-              catch { case _: NoSuchFieldException => None }
-            }
-            _ = timerField.setAccessible(true)
-            timerOpt0 = timerField.get(module)
-            getOrElseMethod <- timerOpt0.getClass.getMethods.find(_.getName == "getOrElse")
-            timer <-
-              Option(getOrElseMethod.invoke(timerOpt0, null).asInstanceOf[java.util.Timer])
-          } {
-            timer.cancel()
-          }
-
           cl.close()
           None
         case Some((cl, n)) if n > 1 => Some((cl, n - 1))

--- a/libs/scalalib/worker/src/mill/scalalib/worker/JvmWorkerImpl.scala
+++ b/libs/scalalib/worker/src/mill/scalalib/worker/JvmWorkerImpl.scala
@@ -1,6 +1,5 @@
 package mill.scalalib.worker
 
-import coursier.version.Version
 import mill.util.CachedFactory
 import mill.api._
 import mill.api.internal.internal
@@ -45,9 +44,8 @@ import java.io.File
 import java.net.URLClassLoader
 import java.util.Optional
 import scala.collection.mutable
-import scala.jdk.CollectionConverters.{ListHasAsScala, MapHasAsScala}
+import scala.jdk.CollectionConverters.ListHasAsScala
 import scala.util.Properties.isWin
-import scala.util.{Failure, Success, Try}
 
 @internal
 class JvmWorkerImpl(
@@ -90,7 +88,7 @@ class JvmWorkerImpl(
         scalaOrganization,
         compilerClasspath
       )
-      val loader = getCachedClassLoader(key.scalaVersion, compilersSig, combinedCompilerJars)
+      val loader = getCachedClassLoader(compilersSig, combinedCompilerJars)
       val scalaInstance = new ScalaInstance(
         version = key.scalaVersion,
         loader = loader,
@@ -116,68 +114,51 @@ class JvmWorkerImpl(
     override def teardown(key: CompileCacheKey, value: (URLClassLoader, Compilers)): Unit = {
       import key._
       classloaderCache.updateWith(compilersSig) {
-        case Some((cl, groupOpt, 1)) =>
-          for (group <- groupOpt) {
-            // Trying to find the timer created by scala.tools.nsc.classpath.FileBasedCache
-            // and its thread. We cancel the timer and interrupt the thread, so that
-            // the thread cleanly exits, and doesn't keep hanging around.
-
-            val threadOpt = Thread.getAllStackTraces()
-              .asScala
-              .keysIterator
-              .find { t =>
-                t.getClass.getName == "java.util.TimerThread" &&
-                t.getThreadGroup == group
-              }
-
-            for (thread <- threadOpt) {
-              val timerOpt = for {
-                cls <- {
-                  try Some(cl.loadClass("scala.tools.nsc.classpath.FileBasedCache$"))
-                  catch { case _: ClassNotFoundException => None }
-                }
-                moduleField <- {
-                  try Some(cls.getField("MODULE$"))
-                  catch { case _: NoSuchFieldException => None }
-                }
-                module = moduleField.get(null)
-                timerField <- {
-                  try Some(cls.getDeclaredField("scala$tools$nsc$classpath$FileBasedCache$$timer"))
-                  catch { case _: NoSuchFieldException => None }
-                }
-                _ = timerField.setAccessible(true)
-                timerOpt0 = timerField.get(module)
-                getOrElseMethod <- timerOpt0.getClass.getMethods.find(_.getName == "getOrElse")
-                timer <-
-                  Option(getOrElseMethod.invoke(timerOpt0, null).asInstanceOf[java.util.Timer])
-              } yield timer
-              // interrupt effectively exits the thread only if the timer has been cancelled
-              for (timer <- timerOpt)
-                timer.cancel()
-              thread.interrupt()
+        case Some((cl, 1)) =>
+          // We try to find the timer created by scala.tools.nsc.classpath.FileBasedCache
+          // and cancel it, so that it shuts down its thread.
+          for {
+            cls <- {
+              try Some(cl.loadClass("scala.tools.nsc.classpath.FileBasedCache$"))
+              catch { case _: ClassNotFoundException => None }
             }
+            moduleField <- {
+              try Some(cls.getField("MODULE$"))
+              catch { case _: NoSuchFieldException => None }
+            }
+            module = moduleField.get(null)
+            timerField <- {
+              try Some(cls.getDeclaredField("scala$tools$nsc$classpath$FileBasedCache$$timer"))
+              catch { case _: NoSuchFieldException => None }
+            }
+            _ = timerField.setAccessible(true)
+            timerOpt0 = timerField.get(module)
+            getOrElseMethod <- timerOpt0.getClass.getMethods.find(_.getName == "getOrElse")
+            timer <-
+              Option(getOrElseMethod.invoke(timerOpt0, null).asInstanceOf[java.util.Timer])
+          } {
+            timer.cancel()
           }
 
           cl.close()
           None
-        case Some((cl, groupOpt, n)) if n > 1 => Some((cl, groupOpt, n - 1))
+        case Some((cl, n)) if n > 1 => Some((cl, n - 1))
         case _ => ??? // No other cases; n should never be zero or negative
       }
     }
   }
 
   private val classloaderCache =
-    collection.mutable.LinkedHashMap.empty[Long, (URLClassLoader, Option[ThreadGroup], Int)]
+    collection.mutable.LinkedHashMap.empty[Long, (URLClassLoader, Int)]
 
   def getCachedClassLoader(
-      scalaVersion: String,
       compilersSig: Long,
       combinedCompilerJars: Array[java.io.File]
   ): URLClassLoader = {
     classloaderCache.synchronized {
       classloaderCache.get(compilersSig) match {
-        case Some((cl, groupOpt, i)) =>
-          classloaderCache(compilersSig) = (cl, groupOpt, i + 1)
+        case Some((cl, i)) =>
+          classloaderCache(compilersSig) = (cl, i + 1)
           cl
         case _ =>
           // the Scala compiler must load the `xsbti.*` classes from the same loader as `JvmWorkerImpl`
@@ -187,40 +168,7 @@ class JvmWorkerImpl(
             sharedLoader = getClass.getClassLoader,
             sharedPrefixes = Seq("xsbti")
           )
-          val groupOpt = Option.when(
-            scalaVersion.startsWith("2.") && Version(scalaVersion) >= Version("2.12.9")
-          ) {
-            val group = new ThreadGroup("mill-jvm-worker-impl")
-            var result: Try[Boolean] = null
-
-            // Making sure scala.tools.nsc.classpath.FileBasedCache is initialized from
-            // a thread with a specific thread group, so that the java.util.Timer it creates
-            // starts its thread in this thread group, and we can find it back and interrupt it
-            // later on.
-            val tmpThread = new Thread(group, "mill-jvm-worker-impl") {
-              setDaemon(true)
-              override def run(): Unit = {
-                result =
-                  try {
-                    val cls = cl.loadClass("scala.tools.nsc.classpath.FileBasedCache$")
-                    val fld = cls.getField("MODULE$")
-                    fld.get(null)
-                    Success(true)
-                  } catch {
-                    case _: ClassNotFoundException =>
-                      Success(false)
-                    case _: NoSuchFieldError =>
-                      Success(false)
-                    case err: Throwable =>
-                      Failure(err)
-                  }
-              }
-            }
-            tmpThread.start()
-            tmpThread.join()
-            Option.when(result.get)(group)
-          }.flatten
-          classloaderCache.update(compilersSig, (cl, groupOpt, 1))
+          classloaderCache.update(compilersSig, (cl, 1))
           cl
       }
     }

--- a/runner/launcher/src/mill/launcher/MillProcessLauncher.java
+++ b/runner/launcher/src/mill/launcher/MillProcessLauncher.java
@@ -219,8 +219,6 @@ public class MillProcessLauncher {
 
     String serverTimeout = millServerTimeout();
     if (serverTimeout != null) vmOptions.add("-Dmill.server_timeout=" + serverTimeout);
-    // https://github.com/com-lihaoyi/mill/issues/5083
-    vmOptions.add("-Dscalac.filebasedcache.defer.close.ms=0");
 
     // extra opts
     vmOptions.addAll(millJvmOpts());


### PR DESCRIPTION
IIUC, in order to cache opened zip files, scalac delays the closing of those with [a timer](https://github.com/scala/scala/blob/6d0b1346d645ea79ad6aaedba90a098b4af5b01f/src/compiler/scala/tools/nsc/classpath/ZipAndJarFileLookupFactory.scala#L326C15-L326C20). The thread created by this timer keeps hanging around, making Mill leak threads. So https://github.com/com-lihaoyi/mill/pull/5082 disabled that timer. It seems disabling that timer creates new issues: https://github.com/com-lihaoyi/mill/issues/5159 (which look like scalac bugs to me).

So that PR handles those timers another way: it uses reflection to get the timers created by scalac, and stops them manually, when we dispose of the scala compiler.