### PR TITLE
Update coursier to 2.1.25-M13 (0.12.x)

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -119,7 +119,7 @@ object Deps {
   val bloopConfig = ivy"ch.epfl.scala::bloop-config:1.5.5"
 
   val classgraph = ivy"io.github.classgraph:classgraph:4.8.179"
-  val coursierVersion = "2.1.25-M2"
+  val coursierVersion = "2.1.25-M13"
   val coursier = ivy"io.get-coursier::coursier:$coursierVersion"
   val coursierInterface = ivy"io.get-coursier:interface:1.0.29-M1"
   val coursierJvm = ivy"io.get-coursier::coursier-jvm:$coursierVersion"

--- a/scalalib/src/mill/scalalib/JsonFormatters.scala
+++ b/scalalib/src/mill/scalalib/JsonFormatters.scala
@@ -19,6 +19,15 @@ trait JsonFormatters {
       _.asString,
       coursier.version.Version(_)
     )
+  implicit lazy val variantMatcherFormat: RW[coursier.core.VariantSelector.VariantMatcher] =
+    RW.merge(
+      upickle.default.macroRW[coursier.core.VariantSelector.VariantMatcher.Api.type],
+      upickle.default.macroRW[coursier.core.VariantSelector.VariantMatcher.Runtime.type],
+      upickle.default.macroRW[coursier.core.VariantSelector.VariantMatcher.Equals],
+      upickle.default.macroRW[coursier.core.VariantSelector.VariantMatcher.MinimumVersion],
+      upickle.default.macroRW[coursier.core.VariantSelector.VariantMatcher.AnyOf],
+      upickle.default.macroRW[coursier.core.VariantSelector.VariantMatcher.EndsWith]
+    )
   implicit lazy val variantSelectorFormat: RW[coursier.core.VariantSelector] =
     RW.merge(
       upickle.default.macroRW[coursier.core.VariantSelector.ConfigurationBased],


### PR DESCRIPTION
Same version as the one used in `main`