### PR TITLE
Deprecate CoursierModule#mapDependencies (0.12.x)

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -397,22 +397,12 @@ trait MillJavaModule extends JavaModule {
       Seq(MavenRepository("https://oss.sonatype.org/content/repositories/releases"))
   }
 
-  def mapDependencies: Task[coursier.Dependency => coursier.Dependency] = Task.Anon {
-    super.mapDependencies().andThen { dep =>
-      forcedVersions.find(f =>
-        f.dep.module.organization.value == dep.module.organization.value &&
-          f.dep.module.name.value == dep.module.name.value
-      ).map { forced =>
-        val newDep = dep.withVersion(forced.dep.version)
-        Task.log.debug(s"Forcing version of ${dep.module} from ${dep.version} to ${newDep.version}")
-        newDep
-      }.getOrElse(dep)
-    }
+  def resolutionParams: Task[coursier.params.ResolutionParams] = Task.Anon {
+    super.resolutionParams().addForceVersion0(
+      Deps.jline.dep.module -> Deps.jline.dep.versionConstraint,
+      Deps.jna.dep.module -> Deps.jna.dep.versionConstraint
+    )
   }
-  val forcedVersions: Seq[Dep] = Deps.transitiveDeps ++ Seq(
-    Deps.jline,
-    Deps.jna
-  )
 
   def javadocOptions = super.javadocOptions() ++ Seq(
     // Disable warnings for missing documentation comments or tags (for example,

--- a/build.mill
+++ b/build.mill
@@ -119,7 +119,7 @@ object Deps {
   val bloopConfig = ivy"ch.epfl.scala::bloop-config:1.5.5"
 
   val classgraph = ivy"io.github.classgraph:classgraph:4.8.179"
-  val coursierVersion = "2.1.25-M2"
+  val coursierVersion = "2.1.25-M13"
   val coursier = ivy"io.get-coursier::coursier:$coursierVersion"
   val coursierInterface = ivy"io.get-coursier:interface:1.0.29-M1"
   val coursierJvm = ivy"io.get-coursier::coursier-jvm:$coursierVersion"

--- a/build.mill
+++ b/build.mill
@@ -523,6 +523,10 @@ trait MillStableScalaModule extends MillPublishScalaModule with Mima {
     ProblemFilter.exclude[Problem]("mill.eval.Tarjans*"),
     ProblemFilter.exclude[Problem]("mill.define.Ctx#Impl*"),
     ProblemFilter.exclude[Problem]("mill.resolve.ResolveNotFoundHandler*"),
+    // added an override in ScalaModule
+    ProblemFilter.exclude[ReversedMissingMethodProblem](
+      "mill.scalalib.ScalaModule.mill$scalalib$ScalaModule$$super$resolutionParams"
+    ),
     // (4x) See https://github.com/com-lihaoyi/mill/pull/2739
     ProblemFilter.exclude[ReversedMissingMethodProblem](
       "mill.scalajslib.ScalaJSModule.mill$scalajslib$ScalaJSModule$$super$scalaLibraryIvyDeps"

--- a/example/android/kotlinlib/2-compose/build.mill
+++ b/example/android/kotlinlib/2-compose/build.mill
@@ -39,20 +39,27 @@ object app extends AndroidAppKotlinModule {
   )
 
   // This is a temporary fix
-  def mapDependencies: Task[coursier.Dependency => coursier.Dependency] = Task.Anon {
-    super.mapDependencies().andThen { (d: coursier.Dependency) =>
-      // otherwise there are some resolution problems (version conflicts), because Coursier is using pom files only,
-      // but Gradle is working with .module files if available
-      if (d.module.organization.value == "androidx.collection") {
-        d.withVersion("1.4.4")
-      } else if (d.module.organization.value == "androidx.lifecycle") {
-        d.withVersion("2.8.3")
-      } else if (d.module.organization.value == "androidx.compose.runtime") {
-        d.withVersion("1.7.5")
-      } else {
-        d
-      }
-    }
+  def resolutionParams: Task[coursier.params.ResolutionParams] = Task.Anon {
+    super.resolutionParams().addForceVersion0(
+      coursier.Module(
+        coursier.Organization("androidx.collection"),
+        coursier.ModuleName("*"),
+        Map.empty
+      ) ->
+        coursier.version.VersionConstraint("1.4.4"),
+      coursier.Module(
+        coursier.Organization("androidx.lifecycle"),
+        coursier.ModuleName("*"),
+        Map.empty
+      ) ->
+        coursier.version.VersionConstraint("2.8.3"),
+      coursier.Module(
+        coursier.Organization("androidx.compose.runtime"),
+        coursier.ModuleName("*"),
+        Map.empty
+      ) ->
+        coursier.version.VersionConstraint("1.7.5")
+    )
   }
 }
 

--- a/example/android/kotlinlib/3-compose-screenshot-tests/build.mill
+++ b/example/android/kotlinlib/3-compose-screenshot-tests/build.mill
@@ -39,20 +39,27 @@ object app extends AndroidAppKotlinModule {
   )
 
   // This is a temporary fix
-  def mapDependencies: Task[coursier.Dependency => coursier.Dependency] = Task.Anon {
-    super.mapDependencies().andThen { (d: coursier.Dependency) =>
-      // otherwise there are some resolution problems (version conflicts), because Coursier is using pom files only,
-      // but Gradle is working with .module files if available
-      if (d.module.organization.value == "androidx.collection") {
-        d.withVersion("1.4.4")
-      } else if (d.module.organization.value == "androidx.lifecycle") {
-        d.withVersion("2.8.3")
-      } else if (d.module.organization.value == "androidx.compose.runtime") {
-        d.withVersion("1.7.5")
-      } else {
-        d
-      }
-    }
+  def resolutionParams: Task[coursier.params.ResolutionParams] = Task.Anon {
+    super.resolutionParams().addForceVersion0(
+      coursier.Module(
+        coursier.Organization("androidx.collection"),
+        coursier.ModuleName("*"),
+        Map.empty
+      ) ->
+        coursier.version.VersionConstraint("1.4.4"),
+      coursier.Module(
+        coursier.Organization("androidx.lifecycle"),
+        coursier.ModuleName("*"),
+        Map.empty
+      ) ->
+        coursier.version.VersionConstraint("2.8.3"),
+      coursier.Module(
+        coursier.Organization("androidx.compose.runtime"),
+        coursier.ModuleName("*"),
+        Map.empty
+      ) ->
+        coursier.version.VersionConstraint("1.7.5")
+    )
   }
 
   object screenshotTest extends AndroidAppKotlinScreenshotTests {

--- a/kotlinlib/src/mill/kotlinlib/android/AndroidAppKotlinModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/android/AndroidAppKotlinModule.scala
@@ -77,9 +77,6 @@ trait AndroidAppKotlinModule extends AndroidAppModule with KotlinModule { outer 
     /* There are no testclasses for screenshot tests, just the engine running a diff over the images */
     override def discoveredTestClasses: T[Seq[String]] = Task { Seq.empty[String] }
 
-    override def mapDependencies: Task[Dependency => Dependency] =
-      Task.Anon(outer.mapDependencies())
-
     override def androidCompileSdk: T[Int] = outer.androidCompileSdk()
 
     override def androidMergedManifest: T[PathRef] = outer.androidMergedManifest()

--- a/kotlinlib/src/mill/kotlinlib/android/AndroidAppKotlinModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/android/AndroidAppKotlinModule.scala
@@ -1,6 +1,5 @@
 package mill.kotlinlib.android
 
-import coursier.Dependency
 import coursier.core.Reconciliation
 import coursier.params.ResolutionParams
 import coursier.util.ModuleMatchers

--- a/main/util/src/mill/util/CoursierSupport.scala
+++ b/main/util/src/mill/util/CoursierSupport.scala
@@ -129,7 +129,11 @@ trait CoursierSupport {
       deps: IterableOnce[Dependency],
       force: IterableOnce[Dependency] = Nil,
       sources: Boolean = false,
-      mapDependencies: Option[Dependency => Dependency] = None,
+      @deprecated(
+        "This parameter is now ignored, use resolutionParams to adjust how resolution behaves",
+        "Mill 0.12.15"
+      )
+      deprecatedMapDependencies: Option[Dependency => Dependency] = None,
       customizer: Option[Resolution => Resolution] = None,
       ctx: Option[mill.api.Ctx.Log] = None,
       coursierCacheCustomizer: Option[FileCache[Task] => FileCache[Task]] = None,
@@ -140,7 +144,7 @@ trait CoursierSupport {
       repositories,
       deps,
       force,
-      mapDependencies,
+      deprecatedMapDependencies,
       customizer,
       ctx,
       coursierCacheCustomizer,
@@ -192,7 +196,11 @@ trait CoursierSupport {
       deps: IterableOnce[Dependency],
       force: IterableOnce[Dependency],
       sources: Boolean = false,
-      mapDependencies: Option[Dependency => Dependency] = None,
+      @deprecated(
+        "This parameter is now ignored, use resolutionParams to adjust how resolution behaves",
+        "Mill 0.12.15"
+      )
+      deprecatedMapDependencies: Option[Dependency => Dependency] = None,
       customizer: Option[Resolution => Resolution] = None,
       ctx: Option[mill.api.Ctx.Log] = None,
       coursierCacheCustomizer: Option[FileCache[Task] => FileCache[Task]] = None,
@@ -209,7 +217,7 @@ trait CoursierSupport {
       deps,
       force,
       sources,
-      mapDependencies,
+      deprecatedMapDependencies,
       customizer,
       ctx,
       coursierCacheCustomizer,
@@ -230,7 +238,11 @@ trait CoursierSupport {
       deps: IterableOnce[Dependency],
       force: IterableOnce[Dependency],
       sources: Boolean,
-      mapDependencies: Option[Dependency => Dependency],
+      @deprecated(
+        "This parameter is now ignored, use resolutionParams to adjust how resolution behaves",
+        "Mill 0.12.15"
+      )
+      deprecatedMapDependencies: Option[Dependency => Dependency],
       customizer: Option[Resolution => Resolution],
       ctx: Option[mill.api.Ctx.Log],
       coursierCacheCustomizer: Option[FileCache[Task] => FileCache[Task]],
@@ -246,7 +258,7 @@ trait CoursierSupport {
       deps,
       force,
       sources,
-      mapDependencies,
+      deprecatedMapDependencies,
       customizer,
       ctx,
       coursierCacheCustomizer,
@@ -261,7 +273,11 @@ trait CoursierSupport {
       deps: IterableOnce[Dependency],
       force: IterableOnce[Dependency],
       sources: Boolean,
-      mapDependencies: Option[Dependency => Dependency],
+      @deprecated(
+        "This parameter is now ignored, use resolutionParams to adjust how resolution behaves",
+        "Mill 0.12.15"
+      )
+      deprecatedMapDependencies: Option[Dependency => Dependency],
       customizer: Option[Resolution => Resolution],
       ctx: Option[mill.api.Ctx.Log],
       coursierCacheCustomizer: Option[FileCache[Task] => FileCache[Task]],
@@ -276,7 +292,7 @@ trait CoursierSupport {
       deps,
       force,
       sources,
-      mapDependencies,
+      deprecatedMapDependencies,
       customizer,
       ctx,
       coursierCacheCustomizer,
@@ -291,7 +307,11 @@ trait CoursierSupport {
       repositories: Seq[Repository],
       deps: IterableOnce[Dependency],
       force: IterableOnce[Dependency],
-      mapDependencies: Option[Dependency => Dependency] = None,
+      @deprecated(
+        "This parameter is now ignored, use resolutionParams to adjust how resolution behaves",
+        "Mill 0.12.15"
+      )
+      deprecatedMapDependencies: Option[Dependency => Dependency] = None,
       customizer: Option[Resolution => Resolution] = None,
       ctx: Option[mill.api.Ctx.Log] = None,
       coursierCacheCustomizer: Option[FileCache[Task] => FileCache[Task]] = None
@@ -301,7 +321,7 @@ trait CoursierSupport {
       repositories,
       deps0,
       force,
-      mapDependencies,
+      deprecatedMapDependencies,
       customizer,
       ctx,
       coursierCacheCustomizer,
@@ -365,7 +385,11 @@ trait CoursierSupport {
       repositories: Seq[Repository],
       deps: IterableOnce[Dependency],
       force: IterableOnce[Dependency],
-      mapDependencies: Option[Dependency => Dependency] = None,
+      @deprecated(
+        "This parameter is now ignored, use resolutionParams to adjust how resolution behaves",
+        "Mill 0.12.15"
+      )
+      deprecatedMapDependencies: Option[Dependency => Dependency] = None,
       customizer: Option[Resolution => Resolution] = None,
       ctx: Option[mill.api.Ctx.Log] = None,
       coursierCacheCustomizer: Option[FileCache[Task] => FileCache[Task]] = None,
@@ -374,11 +398,11 @@ trait CoursierSupport {
   ): Result[Resolution] = {
 
     val rootDeps = deps.iterator
-      .map(d => mapDependencies.fold(d)(_.apply(d)))
+      .map(d => deprecatedMapDependencies.fold(d)(_.apply(d)))
       .toSeq
 
     val forceVersions = force.iterator
-      .map(mapDependencies.getOrElse(identity[Dependency](_)))
+      .map(deprecatedMapDependencies.getOrElse(identity[Dependency](_)))
       .map { d => d.module -> d.version }
       .toMap
 
@@ -395,7 +419,7 @@ trait CoursierSupport {
       .withDependencies(rootDeps)
       .withRepositories(testOverridesRepo +: repositories)
       .withResolutionParams(resolutionParams0)
-      .withMapDependenciesOpt(mapDependencies)
+      .withMapDependenciesOpt(deprecatedMapDependencies)
       .withBoms(boms.toSeq)
 
     resolve.either() match {
@@ -438,7 +462,11 @@ trait CoursierSupport {
       repositories: Seq[Repository],
       deps: IterableOnce[Dependency],
       force: IterableOnce[Dependency],
-      mapDependencies: Option[Dependency => Dependency],
+      @deprecated(
+        "This parameter is now ignored, use resolutionParams to adjust how resolution behaves",
+        "Mill 0.12.15"
+      )
+      deprecatedMapDependencies: Option[Dependency => Dependency],
       customizer: Option[Resolution => Resolution],
       ctx: Option[mill.api.Ctx.Log],
       coursierCacheCustomizer: Option[FileCache[Task] => FileCache[Task]],
@@ -448,7 +476,7 @@ trait CoursierSupport {
       repositories,
       deps,
       force,
-      mapDependencies,
+      deprecatedMapDependencies,
       customizer,
       ctx,
       coursierCacheCustomizer,
@@ -461,7 +489,11 @@ trait CoursierSupport {
       repositories: Seq[Repository],
       deps: IterableOnce[Dependency],
       force: IterableOnce[Dependency],
-      mapDependencies: Option[Dependency => Dependency],
+      @deprecated(
+        "This parameter is now ignored, use resolutionParams to adjust how resolution behaves",
+        "Mill 0.12.15"
+      )
+      deprecatedMapDependencies: Option[Dependency => Dependency],
       customizer: Option[Resolution => Resolution],
       ctx: Option[mill.api.Ctx.Log],
       coursierCacheCustomizer: Option[FileCache[Task] => FileCache[Task]]
@@ -470,7 +502,7 @@ trait CoursierSupport {
       repositories,
       deps,
       force,
-      mapDependencies,
+      deprecatedMapDependencies,
       customizer,
       ctx,
       coursierCacheCustomizer,

--- a/scalalib/src/mill/scalalib/CoursierModule.scala
+++ b/scalalib/src/mill/scalalib/CoursierModule.scala
@@ -46,7 +46,7 @@ trait CoursierModule extends mill.Module {
     new CoursierModule.Resolver(
       repositories = allRepositories(),
       bind = bindDependency(),
-      mapDependencies = Some(mapDependencies()),
+      deprecatedMapDependencies = Some(mapDependencies()),
       customizer = resolutionCustomizer(),
       coursierCacheCustomizer = coursierCacheCustomizer(),
       ctx = Some(implicitly[mill.api.Ctx.Log]),
@@ -66,7 +66,7 @@ trait CoursierModule extends mill.Module {
     new CoursierModule.Resolver(
       repositories = repositoriesTask(),
       bind = bindDependency(),
-      mapDependencies = Some(mapDependencies()),
+      deprecatedMapDependencies = Some(mapDependencies()),
       customizer = resolutionCustomizer(),
       coursierCacheCustomizer = coursierCacheCustomizer(),
       ctx = Some(implicitly[mill.api.Ctx.Log]),
@@ -97,7 +97,7 @@ trait CoursierModule extends mill.Module {
         deps = deps(),
         sources = sources,
         artifactTypes = artifactTypes,
-        mapDependencies = Some(mapDependencies()),
+        deprecatedMapDependencies = Some(mapDependencies()),
         customizer = resolutionCustomizer(),
         coursierCacheCustomizer = coursierCacheCustomizer(),
         ctx = Some(implicitly[mill.api.Ctx.Log])
@@ -239,7 +239,11 @@ object CoursierModule {
   class Resolver(
       repositories: Seq[Repository],
       bind: Dep => BoundDep,
-      mapDependencies: Option[Dependency => Dependency] = None,
+      @deprecated(
+        "This parameter is now ignored, use resolutionParams to adjust how resolution behaves",
+        "Mill 0.12.15"
+      )
+      deprecatedMapDependencies: Option[Dependency => Dependency] = None,
       customizer: Option[coursier.core.Resolution => coursier.core.Resolution] = None,
       ctx: Option[mill.api.Ctx.Log] = None,
       coursierCacheCustomizer: Option[
@@ -252,7 +256,11 @@ object CoursierModule {
     def this(
         repositories: Seq[Repository],
         bind: Dep => BoundDep,
-        mapDependencies: Option[Dependency => Dependency],
+        @deprecated(
+          "This parameter is now ignored, use resolutionParams to adjust how resolution behaves",
+          "Mill 0.12.15"
+        )
+        deprecatedMapDependencies: Option[Dependency => Dependency],
         customizer: Option[coursier.core.Resolution => coursier.core.Resolution],
         ctx: Option[mill.api.Ctx.Log],
         coursierCacheCustomizer: Option[
@@ -264,7 +272,7 @@ object CoursierModule {
       this(
         repositories,
         bind,
-        mapDependencies,
+        deprecatedMapDependencies,
         customizer,
         ctx,
         coursierCacheCustomizer,
@@ -282,14 +290,18 @@ object CoursierModule {
         sources: Boolean = false,
         artifactTypes: Option[Set[coursier.Type]] = None,
         resolutionParamsMapOpt: Option[ResolutionParams => ResolutionParams] = None,
-        mapDependencies: Option[Dependency => Dependency] = null
+        @deprecated(
+          "This parameter is now ignored, use resolutionParams to adjust how resolution behaves",
+          "Mill 0.12.15"
+        )
+        deprecatedMapDependencies: Option[Dependency => Dependency] = null
     )(implicit ctx: mill.api.Ctx.Log): Agg[PathRef] =
       resolveDepsSafe(
         deps,
         sources,
         artifactTypes,
         resolutionParamsMapOpt,
-        mapDependencies
+        deprecatedMapDependencies
       ).getOrThrow
 
     @deprecated("Use classpath instead", "Mill 0.12.10")
@@ -298,9 +310,13 @@ object CoursierModule {
         sources: Boolean = false,
         artifactTypes: Option[Set[coursier.Type]] = None,
         resolutionParamsMapOpt: Option[ResolutionParams => ResolutionParams] = None,
-        mapDependencies: Option[Dependency => Dependency] = null
+        @deprecated(
+          "This parameter is now ignored, use resolutionParams to adjust how resolution behaves",
+          "Mill 0.12.15"
+        )
+        deprecatedMapDependencies: Option[Dependency => Dependency] = null
     )(implicit ctx: mill.api.Ctx.Log): Agg[PathRef] =
-      classpath(deps, sources, artifactTypes, resolutionParamsMapOpt, mapDependencies)
+      classpath(deps, sources, artifactTypes, resolutionParamsMapOpt, deprecatedMapDependencies)
 
     @deprecated("Use classpath instead", "Mill 0.12.10")
     def resolveDeps[T: CoursierModule.Resolvable](
@@ -324,14 +340,19 @@ object CoursierModule {
         sources: Boolean = false,
         artifactTypes: Option[Set[coursier.Type]] = None,
         resolutionParamsMapOpt: Option[ResolutionParams => ResolutionParams] = None,
-        mapDependencies: Option[Dependency => Dependency] = null
+        @deprecated(
+          "This parameter is now ignored, use resolutionParams to adjust how resolution behaves",
+          "Mill 0.12.15"
+        )
+        deprecatedMapDependencies: Option[Dependency => Dependency] = null
     )(implicit ctx: mill.api.Ctx.Log): Result[Agg[PathRef]] =
       Lib.resolveDependencies(
         repositories = repositories,
         deps = deps.map(implicitly[CoursierModule.Resolvable[T]].bind(_, bind)),
         sources = sources,
         artifactTypes = artifactTypes,
-        mapDependencies = Option(mapDependencies).getOrElse(this.mapDependencies),
+        deprecatedMapDependencies =
+          Option(deprecatedMapDependencies).getOrElse(this.deprecatedMapDependencies),
         customizer = customizer,
         coursierCacheCustomizer = coursierCacheCustomizer,
         ctx = Option(ctx),
@@ -384,7 +405,7 @@ object CoursierModule {
       val res = Lib.resolveDependenciesMetadataSafe(
         repositories = repositories,
         deps = deps0,
-        mapDependencies = mapDependencies,
+        deprecatedMapDependencies = deprecatedMapDependencies,
         customizer = customizer,
         coursierCacheCustomizer = coursierCacheCustomizer,
         ctx = ctx,
@@ -424,7 +445,7 @@ object CoursierModule {
       Lib.resolveDependenciesMetadataSafe(
         repositories = repositories,
         deps = deps0,
-        mapDependencies = mapDependencies,
+        deprecatedMapDependencies = deprecatedMapDependencies,
         customizer = customizer,
         coursierCacheCustomizer = coursierCacheCustomizer,
         ctx = Option(ctx),

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -1229,7 +1229,6 @@ trait JavaModule
       val resolution: Resolution = Lib.resolveDependenciesMetadataSafe(
         allRepositories(),
         dependencies,
-        Some(mapDependencies()),
         customizer = resolutionCustomizer(),
         coursierCacheCustomizer = coursierCacheCustomizer(),
         resolutionParams = resolutionParams()

--- a/scalalib/src/mill/scalalib/JsonFormatters.scala
+++ b/scalalib/src/mill/scalalib/JsonFormatters.scala
@@ -19,6 +19,15 @@ trait JsonFormatters {
       _.asString,
       coursier.version.Version(_)
     )
+  implicit lazy val variantMatcherFormat: RW[coursier.core.VariantSelector.VariantMatcher] =
+    RW.merge(
+      upickle.default.macroRW[coursier.core.VariantSelector.VariantMatcher.Api.type],
+      upickle.default.macroRW[coursier.core.VariantSelector.VariantMatcher.Runtime.type],
+      upickle.default.macroRW[coursier.core.VariantSelector.VariantMatcher.Equals],
+      upickle.default.macroRW[coursier.core.VariantSelector.VariantMatcher.MinimumVersion],
+      upickle.default.macroRW[coursier.core.VariantSelector.VariantMatcher.AnyOf],
+      upickle.default.macroRW[coursier.core.VariantSelector.VariantMatcher.EndsWith]
+    )
   implicit lazy val variantSelectorFormat: RW[coursier.core.VariantSelector] =
     RW.merge(
       upickle.default.macroRW[coursier.core.VariantSelector.ConfigurationBased],

--- a/scalalib/src/mill/scalalib/Lib.scala
+++ b/scalalib/src/mill/scalalib/Lib.scala
@@ -182,6 +182,31 @@ object Lib {
     res.map(_.map(_.withRevalidateOnce))
   }
 
+  // bin-compat shim
+  def resolveDependencies(
+      repositories: Seq[Repository],
+      deps: IterableOnce[BoundDep],
+      sources: Boolean,
+      mapDependencies: Option[Dependency => Dependency],
+      customizer: Option[coursier.core.Resolution => coursier.core.Resolution],
+      ctx: Option[Ctx.Log],
+      coursierCacheCustomizer: Option[
+        coursier.cache.FileCache[Task] => coursier.cache.FileCache[Task]
+      ],
+      artifactTypes: Option[Set[Type]]
+  ): Result[Agg[PathRef]] =
+    resolveDependencies(
+      repositories,
+      deps,
+      sources,
+      mapDependencies,
+      customizer,
+      ctx,
+      coursierCacheCustomizer,
+      artifactTypes,
+      ResolutionParams()
+    )
+
   @deprecated("Use the override accepting artifactTypes", "Mill after 0.12.0-RC3")
   def resolveDependencies(
       repositories: Seq[Repository],

--- a/scalalib/src/mill/scalalib/Lib.scala
+++ b/scalalib/src/mill/scalalib/Lib.scala
@@ -34,7 +34,11 @@ object Lib {
   def resolveDependenciesMetadata(
       repositories: Seq[Repository],
       deps: IterableOnce[BoundDep],
-      mapDependencies: Option[Dependency => Dependency] = None,
+      @deprecated(
+        "This parameter is now ignored, use resolutionParams to adjust how resolution behaves",
+        "Mill 0.12.15"
+      )
+      deprecatedMapDependencies: Option[Dependency => Dependency] = None,
       customizer: Option[coursier.core.Resolution => coursier.core.Resolution] = None,
       ctx: Option[Ctx.Log] = None,
       coursierCacheCustomizer: Option[
@@ -45,7 +49,7 @@ object Lib {
     val res = resolveDependenciesMetadataSafe(
       repositories,
       deps0,
-      mapDependencies,
+      deprecatedMapDependencies,
       customizer,
       ctx,
       coursierCacheCustomizer
@@ -56,7 +60,11 @@ object Lib {
   def resolveDependenciesMetadataSafe(
       repositories: Seq[Repository],
       deps: IterableOnce[BoundDep],
-      mapDependencies: Option[Dependency => Dependency] = None,
+      @deprecated(
+        "This parameter is now ignored, use resolutionParams to adjust how resolution behaves",
+        "Mill 0.12.15"
+      )
+      deprecatedMapDependencies: Option[Dependency => Dependency] = None,
       customizer: Option[coursier.core.Resolution => coursier.core.Resolution] = None,
       ctx: Option[Ctx.Log] = None,
       coursierCacheCustomizer: Option[
@@ -70,7 +78,7 @@ object Lib {
       repositories = repositories,
       deps = depSeq.map(_.dep),
       force = depSeq.filter(_.force).map(_.dep),
-      mapDependencies = mapDependencies,
+      deprecatedMapDependencies = None,
       customizer = customizer,
       ctx = ctx,
       coursierCacheCustomizer = coursierCacheCustomizer,
@@ -83,7 +91,11 @@ object Lib {
   def resolveDependenciesMetadataSafe(
       repositories: Seq[Repository],
       deps: IterableOnce[BoundDep],
-      mapDependencies: Option[Dependency => Dependency],
+      @deprecated(
+        "This parameter is now ignored, use resolutionParams to adjust how resolution behaves",
+        "Mill 0.12.15"
+      )
+      deprecatedMapDependencies: Option[Dependency => Dependency],
       customizer: Option[coursier.core.Resolution => coursier.core.Resolution],
       ctx: Option[Ctx.Log],
       coursierCacheCustomizer: Option[
@@ -94,7 +106,7 @@ object Lib {
     resolveDependenciesMetadataSafe(
       repositories,
       deps,
-      mapDependencies,
+      deprecatedMapDependencies,
       customizer,
       ctx,
       coursierCacheCustomizer,
@@ -106,7 +118,11 @@ object Lib {
   def resolveDependenciesMetadataSafe(
       repositories: Seq[Repository],
       deps: IterableOnce[BoundDep],
-      mapDependencies: Option[Dependency => Dependency],
+      @deprecated(
+        "This parameter is now ignored, use resolutionParams to adjust how resolution behaves",
+        "Mill 0.12.15"
+      )
+      deprecatedMapDependencies: Option[Dependency => Dependency],
       customizer: Option[coursier.core.Resolution => coursier.core.Resolution],
       ctx: Option[Ctx.Log],
       coursierCacheCustomizer: Option[
@@ -116,7 +132,7 @@ object Lib {
     resolveDependenciesMetadataSafe(
       repositories,
       deps,
-      mapDependencies,
+      deprecatedMapDependencies,
       customizer,
       ctx,
       coursierCacheCustomizer,
@@ -135,7 +151,11 @@ object Lib {
       repositories: Seq[Repository],
       deps: IterableOnce[BoundDep],
       sources: Boolean = false,
-      mapDependencies: Option[Dependency => Dependency] = None,
+      @deprecated(
+        "This parameter is now ignored, use resolutionParams to adjust how resolution behaves",
+        "Mill 0.12.15"
+      )
+      deprecatedMapDependencies: Option[Dependency => Dependency] = None,
       customizer: Option[coursier.core.Resolution => coursier.core.Resolution] = None,
       ctx: Option[Ctx.Log] = None,
       coursierCacheCustomizer: Option[
@@ -151,7 +171,7 @@ object Lib {
       force = depSeq.filter(_.force).map(_.dep),
       sources = sources,
       artifactTypes = artifactTypes,
-      mapDependencies = mapDependencies,
+      deprecatedMapDependencies = deprecatedMapDependencies,
       customizer = customizer,
       ctx = ctx,
       coursierCacheCustomizer = coursierCacheCustomizer,
@@ -162,37 +182,16 @@ object Lib {
     res.map(_.map(_.withRevalidateOnce))
   }
 
-  // bin-compat shim
-  def resolveDependencies(
-      repositories: Seq[Repository],
-      deps: IterableOnce[BoundDep],
-      sources: Boolean,
-      mapDependencies: Option[Dependency => Dependency],
-      customizer: Option[coursier.core.Resolution => coursier.core.Resolution],
-      ctx: Option[Ctx.Log],
-      coursierCacheCustomizer: Option[
-        coursier.cache.FileCache[Task] => coursier.cache.FileCache[Task]
-      ],
-      artifactTypes: Option[Set[Type]]
-  ): Result[Agg[PathRef]] =
-    resolveDependencies(
-      repositories,
-      deps,
-      sources,
-      mapDependencies,
-      customizer,
-      ctx,
-      coursierCacheCustomizer,
-      artifactTypes,
-      ResolutionParams()
-    )
-
   @deprecated("Use the override accepting artifactTypes", "Mill after 0.12.0-RC3")
   def resolveDependencies(
       repositories: Seq[Repository],
       deps: IterableOnce[BoundDep],
       sources: Boolean,
-      mapDependencies: Option[Dependency => Dependency],
+      @deprecated(
+        "This parameter is now ignored, use resolutionParams to adjust how resolution behaves",
+        "Mill 0.12.15"
+      )
+      deprecatedMapDependencies: Option[Dependency => Dependency],
       customizer: Option[coursier.core.Resolution => coursier.core.Resolution],
       ctx: Option[Ctx.Log],
       coursierCacheCustomizer: Option[
@@ -203,7 +202,7 @@ object Lib {
       repositories,
       deps,
       sources,
-      mapDependencies,
+      deprecatedMapDependencies,
       customizer,
       ctx,
       coursierCacheCustomizer,
@@ -293,7 +292,7 @@ object Lib {
             BoundDep(coursier.Dependency(distModule, BuildInfo.millVersion), force = false)
           ),
           sources = useSources,
-          mapDependencies = None,
+          deprecatedMapDependencies = None,
           customizer = None,
           coursierCacheCustomizer = None,
           ctx = ctx

--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -58,24 +58,27 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
    */
   def scalaVersion: T[String]
 
-  override def mapDependencies: Task[coursier.Dependency => coursier.Dependency] = Task.Anon {
-    super.mapDependencies().andThen { (d: coursier.Dependency) =>
-      val artifacts =
-        if (JvmWorkerUtil.isDotty(scalaVersion()))
-          Set("dotty-library", "dotty-compiler")
-        else if (JvmWorkerUtil.isScala3(scalaVersion()))
-          Set("scala3-library", "scala3-compiler")
-        else
-          Set("scala-library", "scala-compiler", "scala-reflect")
-      if (!artifacts(d.module.name.value)) d
+  override def resolutionParams: Task[coursier.params.ResolutionParams] = Task.Anon {
+    val isTypelevelScala = scalaOrganization() == "org.typelevel"
+    val scalaModuleNames =
+      if (JvmWorkerUtil.isDotty(scalaVersion()))
+        Seq("dotty-library", "dotty-compiler")
+      else if (JvmWorkerUtil.isScala3(scalaVersion()))
+        Seq("scala3-library", "scala3-compiler")
       else
-        d.withModule(
-          d.module.withOrganization(
-            coursier.Organization(scalaOrganization())
-          )
-        )
-          .withVersion(scalaVersion())
+        Seq("scala-library", "scala-compiler", "scala-reflect")
+    val constraint = coursier.version.VersionConstraint(scalaVersion())
+    val forced = scalaModuleNames.map { name =>
+      val mod = coursier.core.Module(
+        coursier.core.Organization(scalaOrganization()),
+        coursier.core.ModuleName(name),
+        Map.empty
+      )
+      (mod, constraint)
     }
+    super.resolutionParams()
+      .withTypelevel(isTypelevelScala)
+      .addForceVersion0(forced *)
   }
 
   override def resolveCoursierDependency: Task[Dep => coursier.Dependency] =

--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -78,7 +78,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
     }
     super.resolutionParams()
       .withTypelevel(isTypelevelScala)
-      .addForceVersion0(forced *)
+      .addForceVersion0(forced: _*)
   }
 
   override def resolveCoursierDependency: Task[Dep => coursier.Dependency] =

--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -58,6 +58,9 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase { outer =>
    */
   def scalaVersion: T[String]
 
+  override def mapDependencies: Task[coursier.Dependency => coursier.Dependency] =
+    super.mapDependencies
+
   override def resolutionParams: Task[coursier.params.ResolutionParams] = Task.Anon {
     val isTypelevelScala = scalaOrganization() == "org.typelevel"
     val scalaModuleNames =

--- a/scalalib/src/mill/scalalib/ZincWorkerModule.scala
+++ b/scalalib/src/mill/scalalib/ZincWorkerModule.scala
@@ -148,10 +148,15 @@ trait ZincWorkerModule extends mill.Module with OfflineSupportModule with Coursi
     val useSources = !isBinaryBridgeAvailable(scalaVersion)
 
     val bridgeJar = resolveDependencies(
-      repositories,
-      Seq(bridgeDep.bindDep("", "", "")),
+      repositories = repositories,
+      deps = Seq(bridgeDep.bindDep("", "", "")),
       sources = useSources,
-      mapDependencies = Some(overrideScalaLibrary(scalaVersion, scalaOrganization))
+      deprecatedMapDependencies = Some(overrideScalaLibrary(scalaVersion, scalaOrganization)),
+      customizer = None,
+      ctx = None,
+      coursierCacheCustomizer = None,
+      artifactTypes = None,
+      resolutionParams = coursier.params.ResolutionParams()
     ).map(deps =>
       ZincWorkerUtil.grepJar(deps, bridgeName, bridgeVersion, useSources)
     )
@@ -204,7 +209,7 @@ trait ZincWorkerModule extends mill.Module with OfflineSupportModule with Coursi
     val deps = resolver.classpath(
       Seq(bridgeDep.bindDep("", "", "")),
       sources = useSources,
-      mapDependencies = Some(overrideScalaLibrary(scalaVersion, scalaOrganization))
+      deprecatedMapDependencies = Some(overrideScalaLibrary(scalaVersion, scalaOrganization))
     )
 
     val bridgeJar = ZincWorkerUtil.grepJar(deps, bridgeName, bridgeVersion, useSources)
@@ -226,7 +231,13 @@ trait ZincWorkerModule extends mill.Module with OfflineSupportModule with Coursi
       deps = Seq(ivy"org.scala-sbt:compiler-interface:${Versions.zinc}".bindDep("", "", "")),
       // Since Zinc 1.4.0, the compiler-interface depends on the Scala library
       // We need to override it with the scalaVersion and scalaOrganization of the module
-      mapDependencies = Some(overrideScalaLibrary(scalaVersion, scalaOrganization))
+      sources = false,
+      deprecatedMapDependencies = Some(overrideScalaLibrary(scalaVersion, scalaOrganization)),
+      customizer = None,
+      ctx = None,
+      coursierCacheCustomizer = None,
+      artifactTypes = None,
+      resolutionParams = coursier.params.ResolutionParams()
     )
   }
 
@@ -239,7 +250,7 @@ trait ZincWorkerModule extends mill.Module with OfflineSupportModule with Coursi
       deps = Seq(ivy"org.scala-sbt:compiler-interface:${Versions.zinc}".bindDep("", "", "")),
       // Since Zinc 1.4.0, the compiler-interface depends on the Scala library
       // We need to override it with the scalaVersion and scalaOrganization of the module
-      mapDependencies = Some(overrideScalaLibrary(scalaVersion, scalaOrganization))
+      deprecatedMapDependencies = Some(overrideScalaLibrary(scalaVersion, scalaOrganization))
     )
   }
 

--- a/scalalib/src/mill/scalalib/dependency/versions/VersionsFinder.scala
+++ b/scalalib/src/mill/scalalib/dependency/versions/VersionsFinder.scala
@@ -71,7 +71,7 @@ private[dependency] object VersionsFinder {
       val x = Lib.resolveDependenciesMetadataSafe(
         repositories = repos,
         deps = dependencies: IterableOnce[BoundDep],
-        mapDependencies = Option(mapDeps),
+        deprecatedMapDependencies = Option(mapDeps),
         customizer = custom,
         ctx = Option(Task.log),
         coursierCacheCustomizer = cacheCustom,


### PR DESCRIPTION
Backport of https://github.com/com-lihaoyi/mill/pull/5070, deprecating rather than removing stuff