### PR TITLE
Fix internal names mangling in `mvnDepsTree`

### DIFF
--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -1,26 +1,23 @@
 package mill
 package scalalib
 
-import coursier.{core => cs}
 import coursier.core.{BomDependency, Configuration, DependencyManagement, Resolution}
 import coursier.params.ResolutionParams
-import coursier.parse.JavaOrScalaModule
-import coursier.parse.ModuleParser
+import coursier.parse.{JavaOrScalaModule, ModuleParser}
 import coursier.util.{EitherT, ModuleMatcher, Monad}
-import coursier.{Repository, Type}
+import coursier.{Repository, Type, core as cs}
 import mainargs.{Flag, arg}
 import mill.Agg
 import mill.api.{Ctx, MillException, PathRef, Result, internal}
 import mill.define.{Command, ModuleRef, Segment, Task, TaskModule}
-import mill.scalalib.internal.ModuleUtils
 import mill.scalalib.api.CompilationResult
 import mill.scalalib.bsp.{BspBuildTarget, BspModule, BspUri, JvmBuildTarget}
+import mill.scalalib.internal.ModuleUtils
 import mill.scalalib.publish.Artifact
 import mill.util.{JarManifest, Jvm}
 
-import os.{Path, ProcessOutput}
-
 import scala.annotation.nowarn
+import scala.util.matching.Regex
 
 /**
  * Core configuration required to compile a single Java compilation target
@@ -1267,9 +1264,8 @@ trait JavaModule
       // Filter the output, so that the special organization and version used for Mill's own modules
       // don't appear in the output. This only leaves the modules' name built from millModuleSegments.
       val processedTree = tree
-        .replace(" mill-internal:", " ")
-        .replace(":0+mill-internal ", " ")
-        .replace(":0+mill-internal" + System.lineSeparator(), System.lineSeparator())
+        .replace(" " + JavaModule.internalOrg + ":", " ")
+        .replaceAll(":" + Regex.quote(JavaModule.internalVersion) + "(\\w*$|\\n)", "$1")
 
       println(processedTree)
 
@@ -1355,15 +1351,15 @@ trait JavaModule
 
   @deprecated("Binary compat shim, use `.runner().run(..., background=true)`", "Mill 0.12.0")
   override protected def doRunBackground(
-      taskDest: Path,
+      taskDest: os.Path,
       runClasspath: Seq[PathRef],
       zwBackgroundWrapperClasspath: Agg[PathRef],
       forkArgs: Seq[String],
       forkEnv: Map[String, String],
       finalMainClass: String,
-      forkWorkingDir: Path,
+      forkWorkingDir: os.Path,
       runUseArgsFile: Boolean,
-      backgroundOutputs: Option[Tuple2[ProcessOutput, ProcessOutput]]
+      backgroundOutputs: Option[Tuple2[os.ProcessOutput, os.ProcessOutput]]
   )(args: String*): Ctx => Result[Unit] = {
     // overridden here for binary compatibility (0.11.x)
     super.doRunBackground(
@@ -1451,7 +1447,7 @@ trait JavaModule
    */
   def artifactSuffix: T[String] = platformSuffix()
 
-  override def forkWorkingDir: T[Path] = Task {
+  override def forkWorkingDir: T[os.Path] = Task {
     // overridden here for binary compatibility (0.11.x)
     super.forkWorkingDir()
   }

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -5,7 +5,7 @@ import coursier.core.{BomDependency, Configuration, DependencyManagement, Resolu
 import coursier.params.ResolutionParams
 import coursier.parse.{JavaOrScalaModule, ModuleParser}
 import coursier.util.{EitherT, ModuleMatcher, Monad}
-import coursier.{Repository, Type, core as cs}
+import coursier.{Repository, Type, core => cs}
 import mainargs.{Flag, arg}
 import mill.Agg
 import mill.api.{Ctx, MillException, PathRef, Result, internal}

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -1264,7 +1264,7 @@ trait JavaModule
       // Filter the output, so that the special organization and version used for Mill's own modules
       // don't appear in the output. This only leaves the modules' name built from millModuleSegments.
       val processedTree = tree
-        .replace(" " + JavaModule.internalOrg + ":", " ")
+        .replace(s" ${JavaModule.internalOrg.value}:", " ")
         .replaceAll(":" + Regex.quote(JavaModule.internalVersion) + "(\\w*$|\\n)", "$1")
 
       println(processedTree)

--- a/scalalib/test/src/mill/scalalib/CrossVersionTests.scala
+++ b/scalalib/test/src/mill/scalalib/CrossVersionTests.scala
@@ -164,7 +164,6 @@ object CrossVersionTests extends TestSuite {
       expected.drop(actual.length).map(y => s"'$y' is expected but missing")
   }
 
-
   def tests: Tests = Tests {
 
     test("StandaloneScala213") {


### PR DESCRIPTION
Before, some `:0+mill-internal` were not properly removed, e.g. when on the last line of the rendered tree.

