### PR TITLE
Make `kotlinSources` task private

### DIFF
--- a/core/define/src/mill/define/Task.scala
+++ b/core/define/src/mill/define/Task.scala
@@ -471,9 +471,9 @@ object Task {
             Expr[(Seq[Any], mill.define.TaskCtx) => Result[T]]
         ) => Expr[M[T]],
         t: Expr[Result[T]],
-        allowTaskReferences: Boolean = true
+        allowedTaskReferences: Applicative.TaskReferences = Applicative.TaskReferences.All
     ): Expr[M[T]] =
-      Applicative.impl[M, Task, Result, T, mill.define.TaskCtx](traverseCtx, t, allowTaskReferences)
+      Applicative.impl[M, Task, Result, T, mill.define.TaskCtx](traverseCtx, t, allowedTaskReferences)
 
     private def taskIsPrivate()(using Quotes): Expr[Option[Boolean]] =
       Cacher.withMacroOwner {
@@ -515,7 +515,7 @@ object Task {
       val expr = appImpl[Simple, Seq[PathRef]](
         (in, ev) => '{ new Sources($ev, $ctx, ${ taskIsPrivate() }) },
         values,
-        allowTaskReferences = false
+        allowedTaskReferences = Applicative.TaskReferences.Sources
       )
       Cacher.impl0(expr)
     }
@@ -529,7 +529,7 @@ object Task {
       val expr = appImpl[Simple, PathRef](
         (in, ev) => '{ new Source($ev, $ctx, ${ taskIsPrivate() }) },
         value,
-        allowTaskReferences = false
+        allowedTaskReferences = Applicative.TaskReferences.Source
       )
       Cacher.impl0(expr)
 
@@ -545,7 +545,7 @@ object Task {
       val expr = appImpl[Simple, T](
         (in, ev) => '{ new Input[T]($ev, $ctx, $w, ${ taskIsPrivate() }) },
         value,
-        allowTaskReferences = false
+        allowedTaskReferences = Applicative.TaskReferences.None
       )
       Cacher.impl0(expr)
     }

--- a/libs/androidlib/src/mill/androidlib/AndroidAppKotlinModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppKotlinModule.scala
@@ -26,14 +26,14 @@ import upickle.implicits.namedTuples.default.given
 @mill.api.experimental
 trait AndroidAppKotlinModule extends AndroidKotlinModule with AndroidAppModule { outer =>
 
-  def kotlinSources = Task.Sources("src/main/kotlin")
+  private def kotlinSources0 = Task.Sources("src/main/kotlin")
   override def sources: T[Seq[PathRef]] =
-    super[AndroidAppModule].sources() ++ kotlinSources()
+    super[AndroidAppModule].sources() ++ kotlinSources0()
 
   trait AndroidAppKotlinTests extends KotlinTests with AndroidAppTests {
-    def kotlinSources = Task.Sources("src/test/kotlin")
+    private def kotlinSources0 = Task.Sources("src/test/kotlin")
     override def sources: T[Seq[PathRef]] =
-      super[AndroidAppTests].sources() ++ kotlinSources()
+      super[AndroidAppTests].sources() ++ kotlinSources0()
   }
 
   trait AndroidAppKotlinInstrumentedTests extends AndroidAppKotlinModule
@@ -42,9 +42,9 @@ trait AndroidAppKotlinModule extends AndroidKotlinModule with AndroidAppModule {
     override final def kotlinVersion = outer.kotlinVersion
     override final def androidSdkModule = outer.androidSdkModule
 
-    def kotlinSources = Task.Sources("src/androidTest/kotlin")
+    private def kotlinSources0 = Task.Sources("src/androidTest/kotlin")
     override def sources: T[Seq[PathRef]] =
-      super[AndroidAppInstrumentedTests].sources() ++ kotlinSources()
+      super[AndroidAppInstrumentedTests].sources() ++ kotlinSources0()
   }
 
   trait AndroidAppKotlinScreenshotTests extends AndroidAppKotlinModule with TestModule with Junit5 {

--- a/libs/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/libs/scalalib/src/mill/scalalib/JavaModule.scala
@@ -741,6 +741,7 @@ trait JavaModule
    */
   def assemblyRules: Seq[Assembly.Rule] = Assembly.defaultRules
 
+  @deprecated("FOR REMOVAL")
   def sourcesFolders: Seq[os.SubPath] = Seq("src")
 
   /**


### PR DESCRIPTION
Also renamed them to `kotlinSources0` to make their temporary character more obvious.

