### PR TITLE
Prefix logging for BSP

### DIFF
--- a/core/api/src/mill/api/SystemStreams.scala
+++ b/core/api/src/mill/api/SystemStreams.scala
@@ -3,6 +3,8 @@ package mill.api
 import java.io.InputStream
 import java.io.PrintStream
 
+import scala.util.DynamicVariable
+
 /**
  * Represents a set of streams that look similar to those provided by the
  * operating system. These may internally be proxied/redirected/processed, but
@@ -14,3 +16,8 @@ class SystemStreams(
     val err: PrintStream,
     val in: InputStream
 )
+
+object SystemStreams {
+  val original = new SystemStreams(System.out, System.err, System.in)
+  val current = new DynamicVariable(original)
+}

--- a/core/api/src/mill/api/internal/api.scala
+++ b/core/api/src/mill/api/internal/api.scala
@@ -32,6 +32,8 @@ trait JavaModuleApi extends ModuleApi {
 
   private[mill] def bspBuildTargetCompile: TaskApi[java.nio.file.Path]
 
+  private[mill] def bspLoggingTest: TaskApi[Unit]
+
   private[mill] def bspBuildTargetJavacOptions(clientWantsSemanticDb: Boolean)
       : TaskApi[EvaluatorApi => (java.nio.file.Path, Seq[String], Seq[String])]
 

--- a/core/internal/src/mill/internal/PrefixLogger.scala
+++ b/core/internal/src/mill/internal/PrefixLogger.scala
@@ -56,25 +56,30 @@ private[mill] class PrefixLogger(
     logger0.unprefixedStreams.in
   )
 
+  private def addPrefix(prefix: String, s: String): String =
+    s.linesWithSeparators.map(prefix + _).mkString
+
   override def info(s: String): Unit = {
     prompt.reportKey(logKey)
-    logger0.info("" + prompt.infoColor(linePrefix) + s)
+    unprefixedStreams.err.println(addPrefix(prompt.infoColor(linePrefix), s))
   }
   override def warn(s: String): Unit = {
     prompt.reportKey(logKey)
-    logger0.warn("" + prompt.warnColor(linePrefix) + s)
+    unprefixedStreams.err.println(addPrefix(prompt.warnColor(linePrefix), s))
   }
   override def error(s: String): Unit = {
     prompt.reportKey(logKey)
-    logger0.error("" + prompt.infoColor(linePrefix) + s)
+    unprefixedStreams.err.println(addPrefix(prompt.errorColor(linePrefix), s))
   }
   override def ticker(s: String): Unit = prompt.setPromptDetail(logKey, s)
 
   def prompt = logger0.prompt
 
   override def debug(s: String): Unit = {
-    if (prompt.debugEnabled) prompt.reportKey(logKey)
-    logger0.debug("" + prompt.infoColor(linePrefix) + s)
+    if (debugEnabled) {
+      if (prompt.debugEnabled) prompt.reportKey(logKey)
+      unprefixedStreams.err.println(addPrefix(prompt.infoColor(linePrefix), s))
+    }
   }
   override def withOutStream(outStream: PrintStream): Logger = new ProxyLogger(this) with Logger {
     override lazy val unprefixedStreams = new SystemStreams(

--- a/core/internal/src/mill/internal/SimpleLogger.scala
+++ b/core/internal/src/mill/internal/SimpleLogger.scala
@@ -1,0 +1,50 @@
+package mill.internal
+
+import mill.api.{SystemStreams, Logger}
+
+import java.io.PrintStream
+
+private[mill] class SimpleLogger(
+    override val unprefixedStreams: SystemStreams,
+    override val logKey: Seq[String],
+    debugEnabled: Boolean
+) extends Logger {
+  override def toString: String = s"SimpleLogger($unprefixedStreams, $debugEnabled)"
+
+  private val linePrefix: String =
+    if (logKey.isEmpty) ""
+    else s"[${logKey.mkString("-")}] "
+  private def prefixPrintStream(stream: java.io.OutputStream) = {
+    new PrintStream(new LinePrefixOutputStream(
+      linePrefix,
+      stream,
+      () => ()
+    ))
+  }
+
+  val streams = new SystemStreams(
+    out = prefixPrintStream(unprefixedStreams.out),
+    err = prefixPrintStream(unprefixedStreams.err),
+    unprefixedStreams.in
+  )
+
+  def isInteractive() = false
+
+  def info(s: String): Unit =
+    unprefixedStreams.err.println(s)
+
+  def warn(s: String): Unit =
+    unprefixedStreams.err.println(s)
+
+  def error(s: String): Unit =
+    unprefixedStreams.err.println(s)
+
+  val prompt = new Logger.Prompt.NoOp {
+    override def enableTicker = true
+  }
+  def ticker(s: String): Unit = ()
+
+  def debug(s: String): Unit =
+    if (debugEnabled)
+      unprefixedStreams.err.println(s)
+}

--- a/integration/ide/bsp-server/resources/project/build.mill
+++ b/integration/ide/bsp-server/resources/project/build.mill
@@ -37,3 +37,13 @@ object app extends scalalib.JavaModule {
     mvn"com.mysql:mysql-connector-j:9.1.0"
   )
 }
+
+object errored extends scalalib.ScalaModule {
+  def scalaVersion = Option(System.getenv("TEST_SCALA_2_13_VERSION")).getOrElse(???)
+
+  def compile = Task {
+    val res = super.compile()
+    sys.error("nope")
+    res
+  }
+}

--- a/integration/ide/bsp-server/resources/snapshots/logging
+++ b/integration/ide/bsp-server/resources/snapshots/logging
@@ -1,0 +1,37 @@
+[bsp] Trying to load BSP server...
+[bsp] BSP server started
+[1-buildInitialize] Entered buildInitialize
+[1-buildInitialize] buildInitialize took * msec
+[2-workspaceBuildTargets] Entered workspaceBuildTargets
+[bsp-init-build.mill-61] [info] compiling * Scala sources to * ...
+[bsp-init-build.mill-61] [info] done compiling
+[bsp-init] SNAPSHOT
+[2-workspaceBuildTargets] Evaluating * tasks
+[2-workspaceBuildTargets] Done
+[2-workspaceBuildTargets] Evaluating 1 task
+[2-workspaceBuildTargets] Done
+[2-workspaceBuildTargets] workspaceBuildTargets took * msec
+[3-loggingTest] Entered loggingTest
+[3-loggingTest] Evaluating 1 task
+[3-loggingTest-1] bspLoggingTest from System.out
+[3-loggingTest-1] bspLoggingTest from System.err
+[3-loggingTest-1] bspLoggingTest from Console.out
+[3-loggingTest-1] bspLoggingTest from Console.err
+[3-loggingTest-1] bspLoggingTest from Task.log.info
+[3-loggingTest] Done
+[3-loggingTest] loggingTest took * msec
+[4-compile] Entered buildTargetCompile
+[4-compile] Evaluating 1 task
+[4-compile] * tasks failed
+[4-compile] errored.compile java.lang.RuntimeException: nope
+[4-compile]     scala.sys.package$.error(package.scala:*)
+[4-compile]     build_.package_.build_$package_$errored$$$_$compile$$anonfun$1$$anonfun$1(build.mill:*)
+[4-compile]     mill.define.Task$Named.evaluate(Task.scala:*)
+[4-compile]     mill.define.Task$Named.evaluate$(Task.scala:*)
+[4-compile]     mill.define.Task$Computed.evaluate(Task.scala:*)
+[4-compile] Failed
+[4-compile] buildTargetCompile took * msec
+[5-buildShutdown] Entered buildShutdown
+[6-onBuildExit] Entered onBuildExit
+[bsp] BSP session returned with mill.api.internal.BspServerResult$Shutdown$@*
+[bsp] Exiting BSP runner loop. Stopping BSP server. Last result: Success(mill.api.internal.BspServerResult$Shutdown$@*)

--- a/integration/ide/bsp-server/resources/snapshots/workspace-build-targets.json
+++ b/integration/ide/bsp-server/resources/snapshots/workspace-build-targets.json
@@ -32,6 +32,46 @@
     },
     {
       "id": {
+        "uri": "file:///workspace/errored"
+      },
+      "displayName": "errored",
+      "baseDirectory": "file:///workspace/errored",
+      "tags": [
+        "library",
+        "application"
+      ],
+      "languageIds": [
+        "java",
+        "scala"
+      ],
+      "dependencies": [],
+      "capabilities": {
+        "canCompile": true,
+        "canTest": false,
+        "canRun": true,
+        "canDebug": false
+      },
+      "dataKind": "scala",
+      "data": {
+        "scalaOrganization": "org.scala-lang",
+        "scalaVersion": "<scala-version>",
+        "scalaBinaryVersion": "2.13",
+        "platform": 1,
+        "jars": [
+          "file:///coursier-cache/https/repo1.maven.org/maven2/org/scala-lang/scala-compiler/<scala-version>/scala-compiler-<scala-version>.jar",
+          "file:///coursier-cache/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/<scala-version>/scala-reflect-<scala-version>.jar",
+          "file:///coursier-cache/https/repo1.maven.org/maven2/org/scala-lang/scala-library/<scala-version>/scala-library-<scala-version>.jar",
+          "file:///coursier-cache/https/repo1.maven.org/maven2/io/github/java-diff-utils/java-diff-utils/<java-diff-utils-version>/java-diff-utils-<java-diff-utils-version>.jar",
+          "file:///coursier-cache/https/repo1.maven.org/maven2/org/jline/jline/<jline-version>/jline-<jline-version>-jdk8.jar"
+        ],
+        "jvmBuildTarget": {
+          "javaHome": "java-home",
+          "javaVersion": "<java-version>"
+        }
+      }
+    },
+    {
+      "id": {
         "uri": "file:///workspace/hello-java"
       },
       "displayName": "hello-java",

--- a/integration/ide/bsp-server/src/BspServerTests.scala
+++ b/integration/ide/bsp-server/src/BspServerTests.scala
@@ -250,7 +250,7 @@ object BspServerTests extends UtestIntegrationTestSuite {
         (message.getType, message.getMessage)
       }
       val expectedMessages = Seq(
-        (b.MessageType.ERROR, "buildTargetCompile failed, see Mill logs for more details")
+        (b.MessageType.ERROR, "Compiling errored failed, see Mill logs for more details")
       )
       assert(expectedMessages == messages0)
     }

--- a/integration/ide/bsp-server/src/BspServerTests.scala
+++ b/integration/ide/bsp-server/src/BspServerTests.scala
@@ -250,7 +250,7 @@ object BspServerTests extends UtestIntegrationTestSuite {
         (message.getType, message.getMessage)
       }
       val expectedMessages = Seq(
-        (b.MessageType.ERROR, "result failed, see Mill logs for more details")
+        (b.MessageType.ERROR, "buildTargetCompile failed, see Mill logs for more details")
       )
       assert(expectedMessages == messages0)
     }

--- a/integration/ide/bsp-server/src/BspServerTests.scala
+++ b/integration/ide/bsp-server/src/BspServerTests.scala
@@ -5,13 +5,18 @@ import mill.api.BuildInfo
 import mill.bsp.Constants
 import mill.integration.BspServerTestUtil._
 import mill.testkit.UtestIntegrationTestSuite
+import mill.testrunner.TestRunnerUtils
 import utest._
+
+import java.io.ByteArrayOutputStream
 
 import scala.jdk.CollectionConverters._
 
 object BspServerTests extends UtestIntegrationTestSuite {
   def snapshotsPath: os.Path =
     super.workspaceSourcePath / "snapshots"
+  def logsPath: os.Path =
+    super.workspaceSourcePath / "logs"
   override protected def workspaceSourcePath: os.Path =
     super.workspaceSourcePath / "project"
 
@@ -105,7 +110,8 @@ object BspServerTests extends UtestIntegrationTestSuite {
           normalizedLocalValues = normalizedLocalValues
         )
 
-        val targetIds = buildTargets.getTargets.asScala.map(_.getId).asJava
+        val targetIds =
+          buildTargets.getTargets.asScala.filter(_.getDisplayName != "errored").map(_.getId).asJava
         val metaBuildTargetId = new b.BuildTargetIdentifier(
           (workspacePath / "mill-build").toNIO.toUri.toASCIIString.stripSuffix("/")
         )
@@ -192,6 +198,61 @@ object BspServerTests extends UtestIntegrationTestSuite {
           normalizedLocalValues = normalizedLocalValues
         )
       }
+    }
+
+    test("logging") - integrationTest { tester =>
+      import tester._
+      eval(
+        "--bsp-install",
+        stdout = os.Inherit,
+        stderr = os.Inherit,
+        check = true,
+        env = Map("MILL_EXECUTABLE_PATH" -> tester.millExecutable.toString)
+      )
+
+      var messages = Seq.empty[b.ShowMessageParams]
+      val client: b.BuildClient = new DummyBuildClient {
+        override def onBuildShowMessage(params: b.ShowMessageParams): Unit = {
+          messages = messages :+ params
+        }
+      }
+
+      val stderr = new ByteArrayOutputStream
+      withBspServer(
+        workspacePath,
+        millTestSuiteEnv,
+        bspLog = Some((bytes, len) => stderr.write(bytes, 0, len)),
+        client = client
+      ) { (buildServer, _) =>
+        val targets = buildServer.workspaceBuildTargets().get().getTargets.asScala
+        buildServer.loggingTest().get()
+
+        buildServer.buildTargetCompile(
+          new b.CompileParams(
+            targets.filter(_.getDisplayName == "errored").map(_.getId).asJava
+          )
+        ).get()
+      }
+
+      val logs = stderr.toString
+        .linesWithSeparators
+        .filter(_.startsWith("["))
+        .mkString
+
+      compareLogWithSnapshot(
+        logs,
+        snapshotsPath / "logging",
+        // ignoring compilation warnings that might go away in the future
+        ignoreLine = TestRunnerUtils.matchesGlob("[bsp-init-build.mill-*] [warn] *")
+      )
+
+      val messages0 = messages.map { message =>
+        (message.getType, message.getMessage)
+      }
+      val expectedMessages = Seq(
+        (b.MessageType.ERROR, "result failed, see Mill logs for more details")
+      )
+      assert(expectedMessages == messages0)
     }
   }
 }

--- a/libs/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/libs/scalalib/src/mill/scalalib/JavaModule.scala
@@ -1454,6 +1454,14 @@ trait JavaModule
 
   private[mill] def bspBuildTargetCompile = Task.Anon { compile().classes.path.toNIO }
 
+  private[mill] def bspLoggingTest = Task.Anon {
+    System.out.println("bspLoggingTest from System.out")
+    System.err.println("bspLoggingTest from System.err")
+    Console.out.println("bspLoggingTest from Console.out")
+    Console.err.println("bspLoggingTest from Console.err")
+    Task.log.info("bspLoggingTest from Task.log.info")
+  }
+
   private[mill] def genIdeaMetadata(
       ideaConfigVersion: Int,
       evaluator: EvaluatorApi,

--- a/runner/bsp/package.mill
+++ b/runner/bsp/package.mill
@@ -38,7 +38,8 @@ object `package` extends MillPublishScalaModule with BuildInfo {
     def compileModuleDeps = Seq(
       build.runner.bsp,
       build.runner.client,
-      build.core.api
+      build.core.api,
+      build.core.internal
     ) ++ build.libs.scalalib.compileModuleDeps
     def mvnDeps = Seq(
       Deps.bsp4j,

--- a/runner/bsp/worker/src/mill/bsp/worker/BspWorkerImpl.scala
+++ b/runner/bsp/worker/src/mill/bsp/worker/BspWorkerImpl.scala
@@ -4,7 +4,7 @@ import ch.epfl.scala.bsp4j.BuildClient
 import mill.bsp.BuildInfo
 import mill.api.internal.{BspServerHandle, BspServerResult, EvaluatorApi}
 import mill.bsp.Constants
-import mill.api.{Result, SystemStreams}
+import mill.api.{Logger, Result, SystemStreams}
 import mill.client.lock.Lock
 import org.eclipse.lsp4j.jsonrpc.Launcher
 
@@ -19,7 +19,8 @@ object BspWorkerImpl {
       streams: SystemStreams,
       logDir: os.Path,
       canReload: Boolean,
-      outLock: Lock
+      outLock: Lock,
+      baseLogger: Logger
   ): mill.api.Result[BspServerHandle] = {
 
     try {
@@ -36,7 +37,8 @@ object BspWorkerImpl {
           canReload = canReload,
           debugMessages = Option(System.getenv("MILL_BSP_DEBUG")).contains("true"),
           onShutdown = () => listening.cancel(true),
-          outLock = outLock
+          outLock = outLock,
+          baseLogger = baseLogger
         ) with MillJvmBuildServer with MillJavaBuildServer with MillScalaBuildServer
 
       lazy val launcher = new Launcher.Builder[BuildClient]()

--- a/runner/bsp/worker/src/mill/bsp/worker/MillBspLogger.scala
+++ b/runner/bsp/worker/src/mill/bsp/worker/MillBspLogger.scala
@@ -37,22 +37,4 @@ private class MillBspLogger(client: BuildClient, taskId: Int, logger: Logger)
       case e: Exception => // noop
     }
   }
-
-  override def error(s: String): Unit = {
-    super.error(s)
-    client.onBuildShowMessage(new ShowMessageParams(MessageType.ERROR, s))
-  }
-
-  override def info(s: String): Unit = {
-    super.info(s)
-    client.onBuildShowMessage(new ShowMessageParams(MessageType.INFO, s))
-  }
-
-  override def debug(s: String): Unit = {
-    super.debug(s)
-    if (debugEnabled) {
-      client.onBuildLogMessage(new LogMessageParams(MessageType.LOG, s))
-    }
-  }
-
 }

--- a/runner/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/runner/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -361,7 +361,7 @@ private class MillBuildServer(
             logger,
             Utils.getBspLoggedReporterPool(p.getOriginId, state.bspIdByModule, client),
             TestReporter.DummyTestReporter
-          )
+          )(using sourcecode.Name("buildTargetCompile"))
         }
         .toSeq
       val compileResult = new CompileResult(Utils.getStatusCode(result))
@@ -410,7 +410,7 @@ private class MillBuildServer(
         Seq(runTask),
         logger,
         Utils.getBspLoggedReporterPool(runParams.getOriginId, state.bspIdByModule, client)
-      )
+      )(using sourcecode.Name("buildTargetRun"))
       val response = runResult.transitiveResultsApi(runTask) match {
         case r if r.asSuccess.isDefined => new RunResult(StatusCode.OK)
         case _ => new RunResult(StatusCode.ERROR)
@@ -480,7 +480,7 @@ private class MillBuildServer(
                   client
                 ),
                 testReporter
-              )
+              )(using sourcecode.Name("buildTargetTest"))
               val statusCode = Utils.getStatusCode(Seq(results))
 
               // Notifying the client that the testing of this build target ended
@@ -534,7 +534,7 @@ private class MillBuildServer(
               ev,
               Seq(cleanTask),
               logger = logger
-            )
+            )(using sourcecode.Name("buildTargetCleanCache"))
             val cleanedPaths =
               cleanResult.results.head.get.value.asInstanceOf[Seq[java.nio.file.Path]]
             if (cleanResult.transitiveFailingApi.size > 0) (
@@ -806,7 +806,7 @@ private class MillBuildServer(
             ev,
             ts.map(_._2),
             logger
-          )
+          )(using sourcecode.Name("loggingTest"))
         }
         .toSeq
       null

--- a/runner/bsp/worker/src/mill/bsp/worker/MillJavaBuildServer.scala
+++ b/runner/bsp/worker/src/mill/bsp/worker/MillJavaBuildServer.scala
@@ -20,7 +20,8 @@ private trait MillJavaBuildServer extends JavaBuildServer { this: MillBuildServe
       targetIds = _ => javacOptionsParams.getTargets.asScala,
       tasks = { case m: JavaModuleApi =>
         m.bspBuildTargetJavacOptions(sessionInfo.clientWantsSemanticDb)
-      }
+      },
+      requestDescription = "Getting javac options of {}"
     ) {
       // We ignore all non-JavaModule
       case (ev, state, id, m: JavaModuleApi, f) =>

--- a/runner/bsp/worker/src/mill/bsp/worker/MillJvmBuildServer.scala
+++ b/runner/bsp/worker/src/mill/bsp/worker/MillJvmBuildServer.scala
@@ -43,7 +43,8 @@ private trait MillJvmBuildServer extends JvmBuildServer { this: MillBuildServer 
   )(implicit name: sourcecode.Name): CompletableFuture[V] = {
     handlerTasks(
       targetIds = _ => targetIds,
-      tasks = { case m: RunModuleApi => m.bspJvmRunTestEnvironment }
+      tasks = { case m: RunModuleApi => m.bspJvmRunTestEnvironment },
+      requestDescription = "Getting JVM test environment of {}"
     ) {
       case (
             ev,
@@ -108,7 +109,8 @@ private trait MillJvmBuildServer extends JvmBuildServer { this: MillBuildServer 
       targetIds = _ => params.getTargets.asScala,
       tasks = {
         case m: JavaModuleApi => m.bspCompileClasspath
-      }
+      },
+      requestDescription = "Getting JVM compile class path of {}"
     ) {
       case (ev, _, id, _: JavaModuleApi, compileClasspath) =>
         new JvmCompileClasspathItem(id, compileClasspath(ev).asJava)

--- a/runner/bsp/worker/src/mill/bsp/worker/MillScalaBuildServer.scala
+++ b/runner/bsp/worker/src/mill/bsp/worker/MillScalaBuildServer.scala
@@ -31,7 +31,8 @@ private trait MillScalaBuildServer extends ScalaBuildServer { this: MillBuildSer
             sessionInfo.enableJvmCompileClasspathProvider,
             sessionInfo.clientWantsSemanticDb
           )
-      }
+      },
+      requestDescription = "Getting scalac options of {}"
     ) {
       // We ignore all non-JavaModule
       case (
@@ -56,7 +57,8 @@ private trait MillScalaBuildServer extends ScalaBuildServer { this: MillBuildSer
       : CompletableFuture[ScalaMainClassesResult] =
     handlerTasks(
       targetIds = _ => p.getTargets.asScala.toSeq,
-      tasks = { case m: JavaModuleApi => m.bspBuildTargetScalaMainClasses }
+      tasks = { case m: JavaModuleApi => m.bspBuildTargetScalaMainClasses },
+      requestDescription = "Getting main classes of {}"
     ) {
       case (ev, state, id, m: JavaModuleApi, (classes, forkArgs, forkEnv)) =>
         // We find all main classes, although we could also find only the configured one
@@ -81,7 +83,8 @@ private trait MillScalaBuildServer extends ScalaBuildServer { this: MillBuildSer
       targetIds = _ => p.getTargets.asScala.toSeq,
       tasks = {
         case m: TestModuleApi => m.bspBuildTargetScalaTestClasses
-      }
+      },
+      requestDescription = "Getting test classes of {}"
     ) {
       case (ev, state, id, m: TestModuleApi, (frameworkName, classes)) =>
         val item = new ScalaTestClassesItem(id, classes.asJava)

--- a/runner/daemon/src/mill/daemon/RunnerState.scala
+++ b/runner/daemon/src/mill/daemon/RunnerState.scala
@@ -97,7 +97,7 @@ object RunnerState {
     )
     implicit val loggedRw: ReadWriter[Logged] = macroRW
 
-    def empty: Frame = Frame(Map.empty, Nil, Nil, Map.empty, None, Nil, None, null)
+    def empty: Frame = Frame(Map.empty, Nil, Nil, Map.empty, None, Nil, None, None)
   }
 
 }

--- a/runner/launcher/src/mill/launcher/MillProcessLauncher.java
+++ b/runner/launcher/src/mill/launcher/MillProcessLauncher.java
@@ -75,7 +75,8 @@ public class MillProcessLauncher {
     Path sandbox = daemonDir.resolve(DaemonFiles.sandbox);
     Files.createDirectories(sandbox);
     builder.environment().put(EnvVars.MILL_WORKSPACE_ROOT, new File("").getCanonicalPath());
-    builder.environment().put(EnvVars.MILL_EXECUTABLE_PATH, getExecutablePath());
+    if (System.getenv(EnvVars.MILL_EXECUTABLE_PATH) == null)
+      builder.environment().put(EnvVars.MILL_EXECUTABLE_PATH, getExecutablePath());
 
     String jdkJavaOptions = System.getenv("JDK_JAVA_OPTIONS");
     if (jdkJavaOptions == null) jdkJavaOptions = "";


### PR DESCRIPTION
Same as https://github.com/com-lihaoyi/mill/pull/5154, with a cleaner git history to ease review

---

When Mill runs as a BSP server, this makes it log in a similar way as when running Mill from the command-line, with `[…] ` prefixes.

For example, the small BSP session run in the test added in this PR logs the following to stderr:
```text
[bsp] Trying to load BSP server...
[bsp] BSP server started
[1-buildInitialize] Entered buildInitialize
[1-buildInitialize] buildInitialize took 2 msec
[2-workspaceBuildTargets] Entered workspaceBuildTargets
[bsp-init-build.mill-61] [info] compiling 3 Scala sources to /Users/alexandre/projects/mill/mill-class-loading/out/integration/ide/bsp-server/local/daemon/testForked.dest/sandbox/run-1/out/mill-build/compile.dest/classes ...
[bsp-init-build.mill-61] [warn] package scala contains object and package with same name: caps.
[bsp-init-build.mill-61] [warn] This indicates that there are several versions of the Scala standard library on the classpath.
[bsp-init-build.mill-61] [warn] The build should be reconfigured so that only one version of the standard library is on the classpath.
[bsp-init-build.mill-61] [warn] one warning found
[bsp-init-build.mill-61] [info] done compiling
[bsp-init] SNAPSHOT
[2-workspaceBuildTargets] Evaluating 5 tasks
[2-workspaceBuildTargets] Done
[2-workspaceBuildTargets] Evaluating 1 task
[2-workspaceBuildTargets] Done
[2-workspaceBuildTargets] workspaceBuildTargets took 4197 msec
[3-loggingTest] Entered loggingTest
[3-loggingTest] Evaluating 1 task
[3-loggingTest-1] bspLoggingTest from System.out
[3-loggingTest-1] bspLoggingTest from System.err
[3-loggingTest-1] bspLoggingTest from Console.out
[3-loggingTest-1] bspLoggingTest from Console.err
[3-loggingTest-1] bspLoggingTest from Task.log.info
[3-loggingTest] Done
[3-loggingTest] loggingTest took 11 msec
[4-buildShutdown] Entered buildShutdown
[5-onBuildExit] Entered onBuildExit
Reload finished, result: mill.api.internal.BspServerResult$Shutdown$@6726cc69
Shutting down executor
[bsp] BSP session returned with mill.api.internal.BspServerResult$Shutdown$@6726cc69
Stopping server via handle...
[bsp] Exiting BSP runner loop. Stopping BSP server. Last result: Success(mill.api.internal.BspServerResult$Shutdown$@6726cc69)
```

This helps make sense of what's going on when working on BSP-releated features, but could also help Mill BSP users in case anything goes wrong.