### PR TITLE
Exclude coursier dependencies from compile time classpath by default

### DIFF
--- a/core/util/package.mill
+++ b/core/util/package.mill
@@ -12,6 +12,10 @@ import millbuild.*
 object `package` extends MillStableScalaModule with BuildInfo {
   def moduleDeps = Seq(build.core.api, build.core.constants, build.core.define)
 
+  // Exclude most coursier transitive dependencies from the compile classpath so users
+  // can't compile against them, but include them at runtime as they are necessary.
+  // This keeps the compile classpath clean and anyone who wants to use those dependencies
+  // can include them explicitly in their YAML header or meta-build
   def mvnDeps = Seq(
     Deps.coursier.exclude("*" -> "*"),
     Deps.coursierCore.exclude("*" -> "*"),
@@ -23,6 +27,7 @@ object `package` extends MillStableScalaModule with BuildInfo {
     Deps.mainargs,
     Deps.requests
   )
+
   def runMvnDeps = Seq(Deps.coursierJvm)
 
   def buildInfoPackageName = "mill.util"

--- a/core/util/package.mill
+++ b/core/util/package.mill
@@ -13,12 +13,17 @@ object `package` extends MillStableScalaModule with BuildInfo {
   def moduleDeps = Seq(build.core.api, build.core.constants, build.core.define)
 
   def mvnDeps = Seq(
-    Deps.coursier,
-    Deps.coursierJvm,
+    Deps.coursier.exclude("*" -> "*"),
+    Deps.coursierCore.exclude("*" -> "*"),
+    Deps.coursierCache.exclude("*" -> "*"),
+    Deps.coursierUtil.exclude("*" -> "*"),
+    Deps.coursierVersions.exclude("*" -> "*"),
+    Deps.coursierJvm.exclude("*" -> "*"),
     Deps.jline,
     Deps.mainargs,
     Deps.requests
   )
+  def runMvnDeps = Seq(Deps.coursierJvm)
 
   def buildInfoPackageName = "mill.util"
 

--- a/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.iml
+++ b/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.iml
@@ -31,25 +31,25 @@
         <orderEntry type="library" name="fansi_3-0.5.0.jar" level="project"/>
         <orderEntry type="library" name="fastparse_3-3.1.1.jar" level="project"/>
         <orderEntry type="library" name="geny_3-1.1.1.jar" level="project"/>
-        <orderEntry type="library" name="graphviz-java-0.18.1.jar" level="project"/>
-        <orderEntry type="library" name="graphviz-java-min-deps-0.18.1.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="graphviz-java-0.18.1.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="graphviz-java-min-deps-0.18.1.jar" level="project"/>
         <orderEntry type="library" name="hamcrest-core-1.3.jar" level="project"/>
-        <orderEntry type="library" name="is-terminal-0.1.2.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="is-terminal-0.1.2.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="jansi-2.4.1.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="javax.inject-1.jar" level="project"/>
-        <orderEntry type="library" name="jcl-over-slf4j-1.7.30.jar" level="project"/>
-        <orderEntry type="library" name="jgrapht-core-1.4.0.jar" level="project"/>
-        <orderEntry type="library" name="jheaps-0.11.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="jcl-over-slf4j-1.7.30.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="jgrapht-core-1.4.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="jheaps-0.11.jar" level="project"/>
         <orderEntry type="library" name="jline-3.28.0.jar" level="project"/>
-        <orderEntry type="library" name="jline-native-3.29.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="jline-native-3.29.0.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="jna-5.17.0.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="jsoniter-scala-core_2.13-2.13.39.jar" level="project"/>
-        <orderEntry type="library" name="jsr305-3.0.2.jar" level="project"/>
-        <orderEntry type="library" name="jul-to-slf4j-1.7.30.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="jsr305-3.0.2.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="jul-to-slf4j-1.7.30.jar" level="project"/>
         <orderEntry type="library" name="junit-4.13.2.jar" level="project"/>
         <orderEntry type="library" name="junit-interface-0.7.29.jar" level="project"/>
-        <orderEntry type="library" name="logback-classic-1.5.17.jar" level="project"/>
-        <orderEntry type="library" name="logback-core-1.5.17.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="logback-classic-1.5.17.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="logback-core-1.5.17.jar" level="project"/>
         <orderEntry type="library" name="mainargs_3-0.7.6.jar" level="project"/>
         <orderEntry type="library" name="mill-core-api_3.jar" level="project"/>
         <orderEntry type="library" name="mill-core-constants.jar" level="project"/>
@@ -77,7 +77,7 @@
         <orderEntry type="library" name="mill-libs_3.jar" level="project"/>
         <orderEntry type="library" name="mill-moduledefs_3-0.11.4.jar" level="project"/>
         <orderEntry type="library" name="munit_3-0.7.29.jar" level="project"/>
-        <orderEntry type="library" name="native-terminal-no-ffm-0.0.9.1.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="native-terminal-no-ffm-0.0.9.1.jar" level="project"/>
         <orderEntry type="library" name="os-lib_3-0.11.5-M9.jar" level="project"/>
         <orderEntry type="library" name="os-zip-0.11.5-M9.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="plexus-archiver-4.10.0.jar" level="project"/>
@@ -96,7 +96,7 @@
         <orderEntry type="library" name="scala-xml_3-2.3.0.jar" level="project"/>
         <orderEntry type="library" scope="PROVIDED" name="scala3-library_3-3.3.3.jar" level="project"/>
         <orderEntry type="library" name="scala3-library_3-3.7.0.jar" level="project"/>
-        <orderEntry type="library" name="slf4j-api-2.0.17.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="slf4j-api-2.0.17.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="snakeyaml-engine-2.9.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="sonatype-central-client-core_3-0.3.0.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="sonatype-central-client-requests_3-0.3.0.jar" level="project"/>

--- a/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.iml
+++ b/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.iml
@@ -11,40 +11,39 @@
         <orderEntry type="inheritedJdk"/>
         <orderEntry type="sourceFolder" forTests="false"/>
         <orderEntry type="library" name="scala-SDK-3.7.0" level="project"/>
-        <orderEntry type="library" name="aircompressor-0.27.jar" level="project"/>
-        <orderEntry type="library" name="cache-util-2.1.25-M13.jar" level="project"/>
-        <orderEntry type="library" name="commons-codec-1.17.0.jar" level="project"/>
-        <orderEntry type="library" name="commons-compress-1.26.2.jar" level="project"/>
-        <orderEntry type="library" name="commons-io-2.18.0.jar" level="project"/>
-        <orderEntry type="library" name="commons-lang3-3.14.0.jar" level="project"/>
-        <orderEntry type="library" name="concurrent-reference-hash-map-1.1.0.jar" level="project"/>
-        <orderEntry type="library" name="config_2.13-1.1.3.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="aircompressor-0.27.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="cache-util-2.1.25-M13.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="commons-codec-1.17.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="commons-compress-1.26.2.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="commons-io-2.18.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="commons-lang3-3.14.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="concurrent-reference-hash-map-1.1.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="config_2.13-1.1.3.jar" level="project"/>
         <orderEntry type="library" name="coursier-cache_2.13-2.1.25-M13.jar" level="project"/>
         <orderEntry type="library" name="coursier-core_2.13-2.1.25-M13.jar" level="project"/>
-        <orderEntry type="library" name="coursier-env_2.13-2.1.25-M13.jar" level="project"/>
-        <orderEntry type="library" name="coursier-exec-2.1.25-M13.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="coursier-env_2.13-2.1.25-M13.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="coursier-exec-2.1.25-M13.jar" level="project"/>
         <orderEntry type="library" name="coursier-jvm_2.13-2.1.25-M13.jar" level="project"/>
-        <orderEntry type="library" name="coursier-proxy-setup-2.1.25-M13.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="coursier-proxy-setup-2.1.25-M13.jar" level="project"/>
         <orderEntry type="library" name="coursier-util_2.13-2.1.25-M13.jar" level="project"/>
         <orderEntry type="library" name="coursier_2.13-2.1.25-M13.jar" level="project"/>
-        <orderEntry type="library" name="dependency_2.13-0.3.2.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="dependency_2.13-0.3.2.jar" level="project"/>
         <orderEntry type="library" name="fansi_3-0.5.0.jar" level="project"/>
         <orderEntry type="library" name="fastparse_3-3.1.1.jar" level="project"/>
         <orderEntry type="library" name="geny_3-1.1.1.jar" level="project"/>
         <orderEntry type="library" name="graphviz-java-0.18.1.jar" level="project"/>
         <orderEntry type="library" name="graphviz-java-min-deps-0.18.1.jar" level="project"/>
         <orderEntry type="library" name="hamcrest-core-1.3.jar" level="project"/>
-        <orderEntry type="library" name="interface-1.0.29-M1.jar" level="project"/>
         <orderEntry type="library" name="is-terminal-0.1.2.jar" level="project"/>
-        <orderEntry type="library" name="jansi-2.4.1.jar" level="project"/>
-        <orderEntry type="library" name="javax.inject-1.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="jansi-2.4.1.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="javax.inject-1.jar" level="project"/>
         <orderEntry type="library" name="jcl-over-slf4j-1.7.30.jar" level="project"/>
         <orderEntry type="library" name="jgrapht-core-1.4.0.jar" level="project"/>
         <orderEntry type="library" name="jheaps-0.11.jar" level="project"/>
         <orderEntry type="library" name="jline-3.28.0.jar" level="project"/>
         <orderEntry type="library" name="jline-native-3.29.0.jar" level="project"/>
-        <orderEntry type="library" name="jna-5.17.0.jar" level="project"/>
-        <orderEntry type="library" name="jsoniter-scala-core_2.13-2.13.39.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="jna-5.17.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="jsoniter-scala-core_2.13-2.13.39.jar" level="project"/>
         <orderEntry type="library" name="jsr305-3.0.2.jar" level="project"/>
         <orderEntry type="library" name="jul-to-slf4j-1.7.30.jar" level="project"/>
         <orderEntry type="library" name="junit-4.13.2.jar" level="project"/>
@@ -81,19 +80,19 @@
         <orderEntry type="library" name="native-terminal-no-ffm-0.0.9.1.jar" level="project"/>
         <orderEntry type="library" name="os-lib_3-0.11.5-M9.jar" level="project"/>
         <orderEntry type="library" name="os-zip-0.11.5-M9.jar" level="project"/>
-        <orderEntry type="library" name="plexus-archiver-4.10.0.jar" level="project"/>
-        <orderEntry type="library" name="plexus-classworlds-2.6.0.jar" level="project"/>
-        <orderEntry type="library" name="plexus-container-default-2.1.1.jar" level="project"/>
-        <orderEntry type="library" name="plexus-io-3.5.0.jar" level="project"/>
-        <orderEntry type="library" name="plexus-utils-4.0.1.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="plexus-archiver-4.10.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="plexus-classworlds-2.6.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="plexus-container-default-2.1.1.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="plexus-io-3.5.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="plexus-utils-4.0.1.jar" level="project"/>
         <orderEntry type="library" name="pprint_3-0.9.0.jar" level="project"/>
         <orderEntry type="library" name="requests_3-0.9.0.jar" level="project"/>
-        <orderEntry type="library" name="scala-collection-compat_2.13-2.13.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="scala-collection-compat_2.13-2.13.0.jar" level="project"/>
         <orderEntry type="library" name="scala-collection-compat_3-2.12.0.jar" level="project"/>
         <orderEntry type="library" scope="PROVIDED" name="scala-library-2.13.12.jar" level="project"/>
         <orderEntry type="library" name="scala-library-2.13.16.jar" level="project"/>
         <orderEntry type="library" name="scala-reflect-2.13.15.jar" level="project"/>
-        <orderEntry type="library" name="scala-xml_2.13-2.3.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="scala-xml_2.13-2.3.0.jar" level="project"/>
         <orderEntry type="library" name="scala-xml_3-2.3.0.jar" level="project"/>
         <orderEntry type="library" scope="PROVIDED" name="scala3-library_3-3.3.3.jar" level="project"/>
         <orderEntry type="library" name="scala3-library_3-3.7.0.jar" level="project"/>
@@ -103,9 +102,9 @@
         <orderEntry type="library" name="sonatype-central-client-requests_3-0.3.0.jar" level="project"/>
         <orderEntry type="library" name="sonatype-central-client-upickle_3-0.3.0.jar" level="project"/>
         <orderEntry type="library" name="sourcecode_3-0.4.3-M5.jar" level="project"/>
-        <orderEntry type="library" name="specification-level_2.13-1.1.3.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="specification-level_2.13-1.1.3.jar" level="project"/>
         <orderEntry type="library" name="test-interface-1.0.jar" level="project"/>
-        <orderEntry type="library" name="tika-core-3.1.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="tika-core-3.1.0.jar" level="project"/>
         <orderEntry type="library" name="ujson_3-4.2.1.jar" level="project"/>
         <orderEntry type="library" name="upack_3-4.2.1.jar" level="project"/>
         <orderEntry type="library" name="upickle-core_3-4.2.1.jar" level="project"/>
@@ -113,10 +112,10 @@
         <orderEntry type="library" name="upickle-implicits_3-4.2.1.jar" level="project"/>
         <orderEntry type="library" name="upickle_3-4.2.1.jar" level="project"/>
         <orderEntry type="library" name="versions_2.13-0.5.1.jar" level="project"/>
-        <orderEntry type="library" name="windows-ansi-0.0.6.jar" level="project"/>
-        <orderEntry type="library" name="windows-jni-utils-0.3.3.jar" level="project"/>
-        <orderEntry type="library" name="xbean-reflect-3.7.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="windows-ansi-0.0.6.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="windows-jni-utils-0.3.3.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="xbean-reflect-3.7.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="xz-1.9.jar" level="project"/>
-        <orderEntry type="library" name="zstd-jni-1.5.7-3.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="zstd-jni-1.5.7-3.jar" level="project"/>
     </component>
 </module>

--- a/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.iml
+++ b/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.iml
@@ -98,9 +98,9 @@
         <orderEntry type="library" name="scala3-library_3-3.7.0.jar" level="project"/>
         <orderEntry type="library" name="slf4j-api-2.0.17.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="snakeyaml-engine-2.9.jar" level="project"/>
-        <orderEntry type="library" name="sonatype-central-client-core_3-0.3.0.jar" level="project"/>
-        <orderEntry type="library" name="sonatype-central-client-requests_3-0.3.0.jar" level="project"/>
-        <orderEntry type="library" name="sonatype-central-client-upickle_3-0.3.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="sonatype-central-client-core_3-0.3.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="sonatype-central-client-requests_3-0.3.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="sonatype-central-client-upickle_3-0.3.0.jar" level="project"/>
         <orderEntry type="library" name="sourcecode_3-0.4.3-M5.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="specification-level_2.13-1.1.3.jar" level="project"/>
         <orderEntry type="library" name="test-interface-1.0.jar" level="project"/>

--- a/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.mill-build.iml
+++ b/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.mill-build.iml
@@ -100,9 +100,9 @@
         <orderEntry type="library" name="scala3-library_3-3.7.0.jar" level="project"/>
         <orderEntry type="library" name="slf4j-api-2.0.17.jar" level="project"/>
         <orderEntry type="library" name="snakeyaml-engine-2.9.jar" level="project"/>
-        <orderEntry type="library" name="sonatype-central-client-core_3-0.3.0.jar" level="project"/>
-        <orderEntry type="library" name="sonatype-central-client-requests_3-0.3.0.jar" level="project"/>
-        <orderEntry type="library" name="sonatype-central-client-upickle_3-0.3.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="sonatype-central-client-core_3-0.3.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="sonatype-central-client-requests_3-0.3.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="sonatype-central-client-upickle_3-0.3.0.jar" level="project"/>
         <orderEntry type="library" name="sourcecode_3-0.4.3-M5.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="specification-level_2.13-1.1.3.jar" level="project"/>
         <orderEntry type="library" name="test-interface-1.0.jar" level="project"/>

--- a/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.mill-build.iml
+++ b/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.mill-build.iml
@@ -13,41 +13,40 @@
         <orderEntry type="inheritedJdk"/>
         <orderEntry type="sourceFolder" forTests="false"/>
         <orderEntry type="library" name="scala-SDK-3.7.0" level="project"/>
-        <orderEntry type="library" name="aircompressor-0.27.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="aircompressor-0.27.jar" level="project"/>
         <orderEntry type="library" name="asm-9.8.jar" level="project"/>
         <orderEntry type="library" name="asm-tree-9.8.jar" level="project"/>
-        <orderEntry type="library" name="cache-util-2.1.25-M13.jar" level="project"/>
-        <orderEntry type="library" name="commons-codec-1.17.0.jar" level="project"/>
-        <orderEntry type="library" name="commons-compress-1.26.2.jar" level="project"/>
-        <orderEntry type="library" name="commons-io-2.18.0.jar" level="project"/>
-        <orderEntry type="library" name="commons-lang3-3.14.0.jar" level="project"/>
-        <orderEntry type="library" name="concurrent-reference-hash-map-1.1.0.jar" level="project"/>
-        <orderEntry type="library" name="config_2.13-1.1.3.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="cache-util-2.1.25-M13.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="commons-codec-1.17.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="commons-compress-1.26.2.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="commons-io-2.18.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="commons-lang3-3.14.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="concurrent-reference-hash-map-1.1.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="config_2.13-1.1.3.jar" level="project"/>
         <orderEntry type="library" name="coursier-cache_2.13-2.1.25-M13.jar" level="project"/>
         <orderEntry type="library" name="coursier-core_2.13-2.1.25-M13.jar" level="project"/>
-        <orderEntry type="library" name="coursier-env_2.13-2.1.25-M13.jar" level="project"/>
-        <orderEntry type="library" name="coursier-exec-2.1.25-M13.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="coursier-env_2.13-2.1.25-M13.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="coursier-exec-2.1.25-M13.jar" level="project"/>
         <orderEntry type="library" name="coursier-jvm_2.13-2.1.25-M13.jar" level="project"/>
-        <orderEntry type="library" name="coursier-proxy-setup-2.1.25-M13.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="coursier-proxy-setup-2.1.25-M13.jar" level="project"/>
         <orderEntry type="library" name="coursier-util_2.13-2.1.25-M13.jar" level="project"/>
         <orderEntry type="library" name="coursier_2.13-2.1.25-M13.jar" level="project"/>
-        <orderEntry type="library" name="dependency_2.13-0.3.2.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="dependency_2.13-0.3.2.jar" level="project"/>
         <orderEntry type="library" name="fansi_3-0.5.0.jar" level="project"/>
         <orderEntry type="library" name="fastparse_3-3.1.1.jar" level="project"/>
         <orderEntry type="library" name="geny_3-1.1.1.jar" level="project"/>
         <orderEntry type="library" name="graphviz-java-0.18.1.jar" level="project"/>
         <orderEntry type="library" name="graphviz-java-min-deps-0.18.1.jar" level="project"/>
-        <orderEntry type="library" name="interface-1.0.29-M1.jar" level="project"/>
         <orderEntry type="library" name="is-terminal-0.1.2.jar" level="project"/>
-        <orderEntry type="library" name="jansi-2.4.1.jar" level="project"/>
-        <orderEntry type="library" name="javax.inject-1.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="jansi-2.4.1.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="javax.inject-1.jar" level="project"/>
         <orderEntry type="library" name="jcl-over-slf4j-1.7.30.jar" level="project"/>
         <orderEntry type="library" name="jgrapht-core-1.4.0.jar" level="project"/>
         <orderEntry type="library" name="jheaps-0.11.jar" level="project"/>
         <orderEntry type="library" name="jline-3.28.0.jar" level="project"/>
         <orderEntry type="library" name="jline-native-3.29.0.jar" level="project"/>
-        <orderEntry type="library" name="jna-5.17.0.jar" level="project"/>
-        <orderEntry type="library" name="jsoniter-scala-core_2.13-2.13.39.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="jna-5.17.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="jsoniter-scala-core_2.13-2.13.39.jar" level="project"/>
         <orderEntry type="library" name="jsr305-3.0.2.jar" level="project"/>
         <orderEntry type="library" name="jul-to-slf4j-1.7.30.jar" level="project"/>
         <orderEntry type="library" name="logback-classic-1.5.17.jar" level="project"/>
@@ -83,19 +82,19 @@
         <orderEntry type="library" name="native-terminal-no-ffm-0.0.9.1.jar" level="project"/>
         <orderEntry type="library" name="os-lib_3-0.11.5-M9.jar" level="project"/>
         <orderEntry type="library" name="os-zip-0.11.5-M9.jar" level="project"/>
-        <orderEntry type="library" name="plexus-archiver-4.10.0.jar" level="project"/>
-        <orderEntry type="library" name="plexus-classworlds-2.6.0.jar" level="project"/>
-        <orderEntry type="library" name="plexus-container-default-2.1.1.jar" level="project"/>
-        <orderEntry type="library" name="plexus-io-3.5.0.jar" level="project"/>
-        <orderEntry type="library" name="plexus-utils-4.0.1.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="plexus-archiver-4.10.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="plexus-classworlds-2.6.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="plexus-container-default-2.1.1.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="plexus-io-3.5.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="plexus-utils-4.0.1.jar" level="project"/>
         <orderEntry type="library" name="pprint_3-0.9.0.jar" level="project"/>
         <orderEntry type="library" name="requests_3-0.9.0.jar" level="project"/>
-        <orderEntry type="library" name="scala-collection-compat_2.13-2.13.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="scala-collection-compat_2.13-2.13.0.jar" level="project"/>
         <orderEntry type="library" name="scala-collection-compat_3-2.12.0.jar" level="project"/>
         <orderEntry type="library" scope="PROVIDED" name="scala-library-2.13.12.jar" level="project"/>
         <orderEntry type="library" name="scala-library-2.13.16.jar" level="project"/>
         <orderEntry type="library" name="scala-reflect-2.13.15.jar" level="project"/>
-        <orderEntry type="library" name="scala-xml_2.13-2.3.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="scala-xml_2.13-2.3.0.jar" level="project"/>
         <orderEntry type="library" name="scala-xml_3-2.3.0.jar" level="project"/>
         <orderEntry type="library" scope="PROVIDED" name="scala3-library_3-3.3.3.jar" level="project"/>
         <orderEntry type="library" name="scala3-library_3-3.7.0.jar" level="project"/>
@@ -105,9 +104,9 @@
         <orderEntry type="library" name="sonatype-central-client-requests_3-0.3.0.jar" level="project"/>
         <orderEntry type="library" name="sonatype-central-client-upickle_3-0.3.0.jar" level="project"/>
         <orderEntry type="library" name="sourcecode_3-0.4.3-M5.jar" level="project"/>
-        <orderEntry type="library" name="specification-level_2.13-1.1.3.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="specification-level_2.13-1.1.3.jar" level="project"/>
         <orderEntry type="library" name="test-interface-1.0.jar" level="project"/>
-        <orderEntry type="library" name="tika-core-3.1.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="tika-core-3.1.0.jar" level="project"/>
         <orderEntry type="library" name="ujson_3-4.2.1.jar" level="project"/>
         <orderEntry type="library" name="upack_3-4.2.1.jar" level="project"/>
         <orderEntry type="library" name="upickle-core_3-4.2.1.jar" level="project"/>
@@ -115,10 +114,10 @@
         <orderEntry type="library" name="upickle-implicits_3-4.2.1.jar" level="project"/>
         <orderEntry type="library" name="upickle_3-4.2.1.jar" level="project"/>
         <orderEntry type="library" name="versions_2.13-0.5.1.jar" level="project"/>
-        <orderEntry type="library" name="windows-ansi-0.0.6.jar" level="project"/>
-        <orderEntry type="library" name="windows-jni-utils-0.3.3.jar" level="project"/>
-        <orderEntry type="library" name="xbean-reflect-3.7.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="windows-ansi-0.0.6.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="windows-jni-utils-0.3.3.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="xbean-reflect-3.7.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="xz-1.9.jar" level="project"/>
-        <orderEntry type="library" name="zstd-jni-1.5.7-3.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="zstd-jni-1.5.7-3.jar" level="project"/>
     </component>
 </module>

--- a/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.mill-build.iml
+++ b/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.mill-build.iml
@@ -35,22 +35,22 @@
         <orderEntry type="library" name="fansi_3-0.5.0.jar" level="project"/>
         <orderEntry type="library" name="fastparse_3-3.1.1.jar" level="project"/>
         <orderEntry type="library" name="geny_3-1.1.1.jar" level="project"/>
-        <orderEntry type="library" name="graphviz-java-0.18.1.jar" level="project"/>
-        <orderEntry type="library" name="graphviz-java-min-deps-0.18.1.jar" level="project"/>
-        <orderEntry type="library" name="is-terminal-0.1.2.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="graphviz-java-0.18.1.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="graphviz-java-min-deps-0.18.1.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="is-terminal-0.1.2.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="jansi-2.4.1.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="javax.inject-1.jar" level="project"/>
-        <orderEntry type="library" name="jcl-over-slf4j-1.7.30.jar" level="project"/>
-        <orderEntry type="library" name="jgrapht-core-1.4.0.jar" level="project"/>
-        <orderEntry type="library" name="jheaps-0.11.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="jcl-over-slf4j-1.7.30.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="jgrapht-core-1.4.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="jheaps-0.11.jar" level="project"/>
         <orderEntry type="library" name="jline-3.28.0.jar" level="project"/>
-        <orderEntry type="library" name="jline-native-3.29.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="jline-native-3.29.0.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="jna-5.17.0.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="jsoniter-scala-core_2.13-2.13.39.jar" level="project"/>
-        <orderEntry type="library" name="jsr305-3.0.2.jar" level="project"/>
-        <orderEntry type="library" name="jul-to-slf4j-1.7.30.jar" level="project"/>
-        <orderEntry type="library" name="logback-classic-1.5.17.jar" level="project"/>
-        <orderEntry type="library" name="logback-core-1.5.17.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="jsr305-3.0.2.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="jul-to-slf4j-1.7.30.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="logback-classic-1.5.17.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="logback-core-1.5.17.jar" level="project"/>
         <orderEntry type="library" name="mainargs_3-0.7.6.jar" level="project"/>
         <orderEntry type="library" name="mill-core-api_3.jar" level="project"/>
         <orderEntry type="library" name="mill-core-constants.jar" level="project"/>
@@ -79,7 +79,7 @@
         <orderEntry type="library" name="mill-moduledefs_3-0.11.4.jar" level="project"/>
         <orderEntry type="library" name="mill-runner-codesig_3.jar" level="project"/>
         <orderEntry type="library" name="mill-runner-meta_3.jar" level="project"/>
-        <orderEntry type="library" name="native-terminal-no-ffm-0.0.9.1.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="native-terminal-no-ffm-0.0.9.1.jar" level="project"/>
         <orderEntry type="library" name="os-lib_3-0.11.5-M9.jar" level="project"/>
         <orderEntry type="library" name="os-zip-0.11.5-M9.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="plexus-archiver-4.10.0.jar" level="project"/>
@@ -98,7 +98,7 @@
         <orderEntry type="library" name="scala-xml_3-2.3.0.jar" level="project"/>
         <orderEntry type="library" scope="PROVIDED" name="scala3-library_3-3.3.3.jar" level="project"/>
         <orderEntry type="library" name="scala3-library_3-3.7.0.jar" level="project"/>
-        <orderEntry type="library" name="slf4j-api-2.0.17.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="slf4j-api-2.0.17.jar" level="project"/>
         <orderEntry type="library" name="snakeyaml-engine-2.9.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="sonatype-central-client-core_3-0.3.0.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="sonatype-central-client-requests_3-0.3.0.jar" level="project"/>

--- a/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/mill-build.iml
+++ b/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/mill-build.iml
@@ -94,9 +94,9 @@
         <orderEntry type="library" name="scala3-library_3-3.7.0.jar" level="project"/>
         <orderEntry type="library" name="slf4j-api-2.0.17.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="snakeyaml-engine-2.9.jar" level="project"/>
-        <orderEntry type="library" name="sonatype-central-client-core_3-0.3.0.jar" level="project"/>
-        <orderEntry type="library" name="sonatype-central-client-requests_3-0.3.0.jar" level="project"/>
-        <orderEntry type="library" name="sonatype-central-client-upickle_3-0.3.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="sonatype-central-client-core_3-0.3.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="sonatype-central-client-requests_3-0.3.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="sonatype-central-client-upickle_3-0.3.0.jar" level="project"/>
         <orderEntry type="library" name="sourcecode_3-0.4.3-M5.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="specification-level_2.13-1.1.3.jar" level="project"/>
         <orderEntry type="library" name="test-interface-1.0.jar" level="project"/>

--- a/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/mill-build.iml
+++ b/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/mill-build.iml
@@ -11,39 +11,38 @@
         <orderEntry type="inheritedJdk"/>
         <orderEntry type="sourceFolder" forTests="false"/>
         <orderEntry type="library" name="scala-SDK-3.7.0" level="project"/>
-        <orderEntry type="library" name="aircompressor-0.27.jar" level="project"/>
-        <orderEntry type="library" name="cache-util-2.1.25-M13.jar" level="project"/>
-        <orderEntry type="library" name="commons-codec-1.17.0.jar" level="project"/>
-        <orderEntry type="library" name="commons-compress-1.26.2.jar" level="project"/>
-        <orderEntry type="library" name="commons-io-2.18.0.jar" level="project"/>
-        <orderEntry type="library" name="commons-lang3-3.14.0.jar" level="project"/>
-        <orderEntry type="library" name="concurrent-reference-hash-map-1.1.0.jar" level="project"/>
-        <orderEntry type="library" name="config_2.13-1.1.3.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="aircompressor-0.27.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="cache-util-2.1.25-M13.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="commons-codec-1.17.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="commons-compress-1.26.2.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="commons-io-2.18.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="commons-lang3-3.14.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="concurrent-reference-hash-map-1.1.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="config_2.13-1.1.3.jar" level="project"/>
         <orderEntry type="library" name="coursier-cache_2.13-2.1.25-M13.jar" level="project"/>
         <orderEntry type="library" name="coursier-core_2.13-2.1.25-M13.jar" level="project"/>
-        <orderEntry type="library" name="coursier-env_2.13-2.1.25-M13.jar" level="project"/>
-        <orderEntry type="library" name="coursier-exec-2.1.25-M13.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="coursier-env_2.13-2.1.25-M13.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="coursier-exec-2.1.25-M13.jar" level="project"/>
         <orderEntry type="library" name="coursier-jvm_2.13-2.1.25-M13.jar" level="project"/>
-        <orderEntry type="library" name="coursier-proxy-setup-2.1.25-M13.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="coursier-proxy-setup-2.1.25-M13.jar" level="project"/>
         <orderEntry type="library" name="coursier-util_2.13-2.1.25-M13.jar" level="project"/>
         <orderEntry type="library" name="coursier_2.13-2.1.25-M13.jar" level="project"/>
-        <orderEntry type="library" name="dependency_2.13-0.3.2.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="dependency_2.13-0.3.2.jar" level="project"/>
         <orderEntry type="library" name="fansi_3-0.5.0.jar" level="project"/>
         <orderEntry type="library" name="fastparse_3-3.1.1.jar" level="project"/>
         <orderEntry type="library" name="geny_3-1.1.1.jar" level="project"/>
         <orderEntry type="library" name="graphviz-java-0.18.1.jar" level="project"/>
         <orderEntry type="library" name="graphviz-java-min-deps-0.18.1.jar" level="project"/>
-        <orderEntry type="library" name="interface-1.0.29-M1.jar" level="project"/>
         <orderEntry type="library" name="is-terminal-0.1.2.jar" level="project"/>
-        <orderEntry type="library" name="jansi-2.4.1.jar" level="project"/>
-        <orderEntry type="library" name="javax.inject-1.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="jansi-2.4.1.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="javax.inject-1.jar" level="project"/>
         <orderEntry type="library" name="jcl-over-slf4j-1.7.30.jar" level="project"/>
         <orderEntry type="library" name="jgrapht-core-1.4.0.jar" level="project"/>
         <orderEntry type="library" name="jheaps-0.11.jar" level="project"/>
         <orderEntry type="library" name="jline-3.28.0.jar" level="project"/>
         <orderEntry type="library" name="jline-native-3.29.0.jar" level="project"/>
-        <orderEntry type="library" name="jna-5.17.0.jar" level="project"/>
-        <orderEntry type="library" name="jsoniter-scala-core_2.13-2.13.39.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="jna-5.17.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="jsoniter-scala-core_2.13-2.13.39.jar" level="project"/>
         <orderEntry type="library" name="jsr305-3.0.2.jar" level="project"/>
         <orderEntry type="library" name="jul-to-slf4j-1.7.30.jar" level="project"/>
         <orderEntry type="library" name="logback-classic-1.5.17.jar" level="project"/>
@@ -77,19 +76,19 @@
         <orderEntry type="library" name="native-terminal-no-ffm-0.0.9.1.jar" level="project"/>
         <orderEntry type="library" name="os-lib_3-0.11.5-M9.jar" level="project"/>
         <orderEntry type="library" name="os-zip-0.11.5-M9.jar" level="project"/>
-        <orderEntry type="library" name="plexus-archiver-4.10.0.jar" level="project"/>
-        <orderEntry type="library" name="plexus-classworlds-2.6.0.jar" level="project"/>
-        <orderEntry type="library" name="plexus-container-default-2.1.1.jar" level="project"/>
-        <orderEntry type="library" name="plexus-io-3.5.0.jar" level="project"/>
-        <orderEntry type="library" name="plexus-utils-4.0.1.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="plexus-archiver-4.10.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="plexus-classworlds-2.6.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="plexus-container-default-2.1.1.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="plexus-io-3.5.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="plexus-utils-4.0.1.jar" level="project"/>
         <orderEntry type="library" name="pprint_3-0.9.0.jar" level="project"/>
         <orderEntry type="library" name="requests_3-0.9.0.jar" level="project"/>
-        <orderEntry type="library" name="scala-collection-compat_2.13-2.13.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="scala-collection-compat_2.13-2.13.0.jar" level="project"/>
         <orderEntry type="library" name="scala-collection-compat_3-2.12.0.jar" level="project"/>
         <orderEntry type="library" scope="PROVIDED" name="scala-library-2.13.12.jar" level="project"/>
         <orderEntry type="library" name="scala-library-2.13.16.jar" level="project"/>
         <orderEntry type="library" name="scala-reflect-2.13.15.jar" level="project"/>
-        <orderEntry type="library" name="scala-xml_2.13-2.3.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="scala-xml_2.13-2.3.0.jar" level="project"/>
         <orderEntry type="library" name="scala-xml_3-2.3.0.jar" level="project"/>
         <orderEntry type="library" scope="PROVIDED" name="scala3-library_3-3.3.3.jar" level="project"/>
         <orderEntry type="library" name="scala3-library_3-3.7.0.jar" level="project"/>
@@ -99,9 +98,9 @@
         <orderEntry type="library" name="sonatype-central-client-requests_3-0.3.0.jar" level="project"/>
         <orderEntry type="library" name="sonatype-central-client-upickle_3-0.3.0.jar" level="project"/>
         <orderEntry type="library" name="sourcecode_3-0.4.3-M5.jar" level="project"/>
-        <orderEntry type="library" name="specification-level_2.13-1.1.3.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="specification-level_2.13-1.1.3.jar" level="project"/>
         <orderEntry type="library" name="test-interface-1.0.jar" level="project"/>
-        <orderEntry type="library" name="tika-core-3.1.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="tika-core-3.1.0.jar" level="project"/>
         <orderEntry type="library" name="ujson_3-4.2.1.jar" level="project"/>
         <orderEntry type="library" name="upack_3-4.2.1.jar" level="project"/>
         <orderEntry type="library" name="upickle-core_3-4.2.1.jar" level="project"/>
@@ -109,10 +108,10 @@
         <orderEntry type="library" name="upickle-implicits_3-4.2.1.jar" level="project"/>
         <orderEntry type="library" name="upickle_3-4.2.1.jar" level="project"/>
         <orderEntry type="library" name="versions_2.13-0.5.1.jar" level="project"/>
-        <orderEntry type="library" name="windows-ansi-0.0.6.jar" level="project"/>
-        <orderEntry type="library" name="windows-jni-utils-0.3.3.jar" level="project"/>
-        <orderEntry type="library" name="xbean-reflect-3.7.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="windows-ansi-0.0.6.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="windows-jni-utils-0.3.3.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="xbean-reflect-3.7.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="xz-1.9.jar" level="project"/>
-        <orderEntry type="library" name="zstd-jni-1.5.7-3.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="zstd-jni-1.5.7-3.jar" level="project"/>
     </component>
 </module>

--- a/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/mill-build.iml
+++ b/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/mill-build.iml
@@ -31,22 +31,22 @@
         <orderEntry type="library" name="fansi_3-0.5.0.jar" level="project"/>
         <orderEntry type="library" name="fastparse_3-3.1.1.jar" level="project"/>
         <orderEntry type="library" name="geny_3-1.1.1.jar" level="project"/>
-        <orderEntry type="library" name="graphviz-java-0.18.1.jar" level="project"/>
-        <orderEntry type="library" name="graphviz-java-min-deps-0.18.1.jar" level="project"/>
-        <orderEntry type="library" name="is-terminal-0.1.2.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="graphviz-java-0.18.1.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="graphviz-java-min-deps-0.18.1.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="is-terminal-0.1.2.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="jansi-2.4.1.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="javax.inject-1.jar" level="project"/>
-        <orderEntry type="library" name="jcl-over-slf4j-1.7.30.jar" level="project"/>
-        <orderEntry type="library" name="jgrapht-core-1.4.0.jar" level="project"/>
-        <orderEntry type="library" name="jheaps-0.11.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="jcl-over-slf4j-1.7.30.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="jgrapht-core-1.4.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="jheaps-0.11.jar" level="project"/>
         <orderEntry type="library" name="jline-3.28.0.jar" level="project"/>
-        <orderEntry type="library" name="jline-native-3.29.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="jline-native-3.29.0.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="jna-5.17.0.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="jsoniter-scala-core_2.13-2.13.39.jar" level="project"/>
-        <orderEntry type="library" name="jsr305-3.0.2.jar" level="project"/>
-        <orderEntry type="library" name="jul-to-slf4j-1.7.30.jar" level="project"/>
-        <orderEntry type="library" name="logback-classic-1.5.17.jar" level="project"/>
-        <orderEntry type="library" name="logback-core-1.5.17.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="jsr305-3.0.2.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="jul-to-slf4j-1.7.30.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="logback-classic-1.5.17.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="logback-core-1.5.17.jar" level="project"/>
         <orderEntry type="library" name="mainargs_3-0.7.6.jar" level="project"/>
         <orderEntry type="library" name="mill-core-api_3.jar" level="project"/>
         <orderEntry type="library" name="mill-core-constants.jar" level="project"/>
@@ -73,7 +73,7 @@
         <orderEntry type="library" name="mill-libs-testrunner_3.jar" level="project"/>
         <orderEntry type="library" name="mill-libs_3.jar" level="project"/>
         <orderEntry type="library" name="mill-moduledefs_3-0.11.4.jar" level="project"/>
-        <orderEntry type="library" name="native-terminal-no-ffm-0.0.9.1.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="native-terminal-no-ffm-0.0.9.1.jar" level="project"/>
         <orderEntry type="library" name="os-lib_3-0.11.5-M9.jar" level="project"/>
         <orderEntry type="library" name="os-zip-0.11.5-M9.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="plexus-archiver-4.10.0.jar" level="project"/>
@@ -92,7 +92,7 @@
         <orderEntry type="library" name="scala-xml_3-2.3.0.jar" level="project"/>
         <orderEntry type="library" scope="PROVIDED" name="scala3-library_3-3.3.3.jar" level="project"/>
         <orderEntry type="library" name="scala3-library_3-3.7.0.jar" level="project"/>
-        <orderEntry type="library" name="slf4j-api-2.0.17.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="slf4j-api-2.0.17.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="snakeyaml-engine-2.9.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="sonatype-central-client-core_3-0.3.0.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="sonatype-central-client-requests_3-0.3.0.jar" level="project"/>

--- a/libs/main/package.mill
+++ b/libs/main/package.mill
@@ -23,7 +23,6 @@ object `package` extends MillStableScalaModule {
   )
   def mvnDeps = Seq(
     Deps.nativeTerminal,
-    Deps.coursierInterface,
     Deps.logback,
     Deps.jgraphtCore,
     Deps.millModuledefs,
@@ -42,4 +41,5 @@ object `package` extends MillStableScalaModule {
   }
 
   def testModuleDeps = super.testModuleDeps ++ Seq(build.testkit)
+  def testMvnDeps = Seq(Deps.coursierInterface)
 }

--- a/libs/main/package.mill
+++ b/libs/main/package.mill
@@ -22,23 +22,20 @@ object `package` extends MillStableScalaModule {
     build.libs.init
   )
   def mvnDeps = Seq(
-    Deps.nativeTerminal,
-    Deps.logback,
-    Deps.jgraphtCore,
     Deps.millModuledefs,
-    mvn"guru.nidi:graphviz-java-min-deps:0.18.1"
-      // We only need the in-memory library for some stuff, and don't
-      // need the heavyweight v8 binary that comes bundled with it
-      .exclude(
-        "guru.nidi.com.eclipsesource.j2v8" -> "j2v8_macosx_x86_64",
-        "guru.nidi.com.eclipsesource.j2v8" -> "j2v8_linux_x86_64"
-      )
   )
 
-  def compileMvnDeps = Task {
-    if (JvmWorkerUtil.isScala3(scalaVersion())) Seq.empty
-    else Seq(Deps.scalaReflect(scalaVersion()))
-  }
+  def compileMvnDeps = Seq(
+    Deps.nativeTerminal,
+    Deps.jgraphtCore,
+    Deps.graphvizWithExcludes,
+  )
+  def runMvnDeps = Seq(
+    Deps.logback,
+    Deps.nativeTerminal,
+    Deps.jgraphtCore,
+    Deps.graphvizWithExcludes,
+  )
 
   def testModuleDeps = super.testModuleDeps ++ Seq(build.testkit)
   def testMvnDeps = Seq(Deps.coursierInterface)

--- a/libs/main/package.mill
+++ b/libs/main/package.mill
@@ -22,19 +22,19 @@ object `package` extends MillStableScalaModule {
     build.libs.init
   )
   def mvnDeps = Seq(
-    Deps.millModuledefs,
+    Deps.millModuledefs
   )
 
   def compileMvnDeps = Seq(
     Deps.nativeTerminal,
     Deps.jgraphtCore,
-    Deps.graphvizWithExcludes,
+    Deps.graphvizWithExcludes
   )
   def runMvnDeps = Seq(
     Deps.logback,
     Deps.nativeTerminal,
     Deps.jgraphtCore,
-    Deps.graphvizWithExcludes,
+    Deps.graphvizWithExcludes
   )
 
   def testModuleDeps = super.testModuleDeps ++ Seq(build.testkit)

--- a/libs/scalalib/package.mill
+++ b/libs/scalalib/package.mill
@@ -18,16 +18,18 @@ import millbuild.*
 object `package` extends MillStableScalaModule {
 
   def moduleDeps = Seq(build.core.util, build.libs.scalalib.api, build.libs.testrunner)
-  def mvnDeps = {
-    Seq(Deps.scalaXml) ++ {
+  def mvnDeps =
+    Seq(Deps.scalaXml) ++
       // despite compiling with Scala 3, we need to include scala-reflect
       // for the scala.reflect.internal.util.ScalaClassLoader
       // used in ScalaModule.scalacHelp,
       // (also transitively included by com.eed3si9n.jarjarabrams:jarjar-abrams-core)
       // perhaps the class can be copied here?
-      Seq(Deps.scalaReflect(scalaVersion())) ++ Seq(Deps.sonatypeCentralClient)
-    }
-  }
+      Seq(Deps.scalaReflect(scalaVersion()))
+
+  def compileMvnDeps = Seq(Deps.sonatypeCentralClient)
+  def runMvnDeps = Seq(Deps.sonatypeCentralClient)
+
   def testMvnDeps = super.testMvnDeps() ++ Seq(Deps.TestDeps.scalaCheck)
   def transitiveLocalTestOverrides =
     super.transitiveLocalTestOverrides() ++ Seq(

--- a/mill-build/src/millbuild/Deps.scala
+++ b/mill-build/src/millbuild/Deps.scala
@@ -107,6 +107,13 @@ object Deps {
     mvn"org.webjars.npm:viz.js-graphviz-java:2.1.3",
     mvn"org.apache.xmlgraphics:batik-rasterizer:1.18"
   )
+  val graphvizWithExcludes = mvn"guru.nidi:graphviz-java-min-deps:0.18.1"
+    // We only need the in-memory library for some stuff, and don't
+    // need the heavyweight v8 binary that comes bundled with it
+    .exclude(
+      "guru.nidi.com.eclipsesource.j2v8" -> "j2v8_macosx_x86_64",
+      "guru.nidi.com.eclipsesource.j2v8" -> "j2v8_linux_x86_64"
+    )
 
   val jgraphtCore = mvn"org.jgrapht:jgrapht-core:1.4.0" // 1.5.0+ dont support JDK8
   val javet = Seq(

--- a/mill-build/src/millbuild/Deps.scala
+++ b/mill-build/src/millbuild/Deps.scala
@@ -87,6 +87,10 @@ object Deps {
   val classgraph = mvn"io.github.classgraph:classgraph:4.8.179"
   val coursierVersion = "2.1.25-M13"
   val coursier = mvn"io.get-coursier::coursier:$coursierVersion".withDottyCompat(scalaVersion)
+  val coursierCore = mvn"io.get-coursier::coursier-core:$coursierVersion".withDottyCompat(scalaVersion)
+  val coursierCache = mvn"io.get-coursier::coursier-cache:$coursierVersion".withDottyCompat(scalaVersion)
+  val coursierUtil = mvn"io.get-coursier::coursier-util:$coursierVersion".withDottyCompat(scalaVersion)
+  val coursierVersions = mvn"io.get-coursier::versions:0.5.1".withDottyCompat(scalaVersion)
   val coursierInterface = mvn"io.get-coursier:interface:1.0.29-M1"
   val coursierJvm =
     mvn"io.get-coursier::coursier-jvm:$coursierVersion".withDottyCompat(scalaVersion)
@@ -147,7 +151,7 @@ object Deps {
     mvn"org.scoverage::scalac-scoverage-serializer:${scoverage2Version}"
   val scalaparse = mvn"com.lihaoyi::scalaparse:${fastparse.version}"
   val scalatags = mvn"com.lihaoyi::scalatags:0.13.1".withDottyCompat(scalaVersion)
-  def scalaXml = mvn"org.scala-lang.modules::scala-xml:2.3.0"
+  val scalaXml = mvn"org.scala-lang.modules::scala-xml:2.3.0"
   // keep in sync with doc/antora/antory.yml
   val semanticDBscala = mvn"org.scalameta:::semanticdb-scalac:4.13.4"
   val semanticDbJava = mvn"com.sourcegraph:semanticdb-java:0.10.3"

--- a/mill-build/src/millbuild/Deps.scala
+++ b/mill-build/src/millbuild/Deps.scala
@@ -87,9 +87,12 @@ object Deps {
   val classgraph = mvn"io.github.classgraph:classgraph:4.8.179"
   val coursierVersion = "2.1.25-M13"
   val coursier = mvn"io.get-coursier::coursier:$coursierVersion".withDottyCompat(scalaVersion)
-  val coursierCore = mvn"io.get-coursier::coursier-core:$coursierVersion".withDottyCompat(scalaVersion)
-  val coursierCache = mvn"io.get-coursier::coursier-cache:$coursierVersion".withDottyCompat(scalaVersion)
-  val coursierUtil = mvn"io.get-coursier::coursier-util:$coursierVersion".withDottyCompat(scalaVersion)
+  val coursierCore =
+    mvn"io.get-coursier::coursier-core:$coursierVersion".withDottyCompat(scalaVersion)
+  val coursierCache =
+    mvn"io.get-coursier::coursier-cache:$coursierVersion".withDottyCompat(scalaVersion)
+  val coursierUtil =
+    mvn"io.get-coursier::coursier-util:$coursierVersion".withDottyCompat(scalaVersion)
   val coursierVersions = mvn"io.get-coursier::versions:0.5.1".withDottyCompat(scalaVersion)
   val coursierInterface = mvn"io.get-coursier:interface:1.0.29-M1"
   val coursierJvm =

--- a/runner/idea/package.mill
+++ b/runner/idea/package.mill
@@ -5,4 +5,5 @@ import millbuild.*
 
 object `package` extends MillPublishScalaModule {
   def moduleDeps = Seq(build.core.util)
+  def mvnDeps = Seq(Deps.scalaXml)
 }

--- a/runner/launcher/package.mill
+++ b/runner/launcher/package.mill
@@ -15,8 +15,6 @@ object `package` extends MillPublishScalaModule with BuildInfo {
 
   def mvnDeps = Seq(
     Deps.nativeTerminal,
-    Deps.coursier,
-    Deps.coursierInterface,
     Deps.coursierJvm,
     Deps.logback,
     Deps.snakeyamlEngine,


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/5183. Also moved `sonatype-central-client`, `graphviz-java`, and `jgrapht` off the compile classpath. All in all removes ~91 jars from the compile classpath, cleaning it up considerably

It might be worth defining a new `def privateMvnDeps` task to automate the tedious work of duplicating the same deps in `runMvnDeps` and `compileMvnDeps`

CC @alexarchambault 