### PR TITLE
Factor thread pool used to run tasks

### DIFF
--- a/core/exec/src/mill/exec/Execution.scala
+++ b/core/exec/src/mill/exec/Execution.scala
@@ -6,7 +6,7 @@ import mill.constants.OutFiles.{millChromeProfile, millProfile}
 import mill.define._
 import mill.internal.PrefixLogger
 
-import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.{ConcurrentHashMap, ThreadPoolExecutor}
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 import scala.collection.mutable
 import scala.concurrent._
@@ -27,7 +27,7 @@ private[mill] case class Execution(
     workerCache: mutable.Map[String, (Int, Val)],
     env: Map[String, String],
     failFast: Boolean,
-    threadCount: Option[Int],
+    ec: Option[ThreadPoolExecutor],
     codeSignatures: Map[String, Int],
     systemExit: Int => Nothing,
     exclusiveSystemStreams: SystemStreams,
@@ -48,7 +48,7 @@ private[mill] case class Execution(
       workerCache: mutable.Map[String, (Int, Val)],
       env: Map[String, String],
       failFast: Boolean,
-      threadCount: Option[Int],
+      ec: Option[ThreadPoolExecutor],
       codeSignatures: Map[String, Int],
       systemExit: Int => Nothing,
       exclusiveSystemStreams: SystemStreams,
@@ -68,7 +68,7 @@ private[mill] case class Execution(
     workerCache,
     env,
     failFast,
-    threadCount,
+    ec,
     codeSignatures,
     systemExit,
     exclusiveSystemStreams,
@@ -94,12 +94,7 @@ private[mill] case class Execution(
     os.makeDir.all(outPath)
 
     PathRef.validatedPaths.withValue(new PathRef.ValidatedPaths()) {
-      val ec =
-        if (effectiveThreadCount == 1) ExecutionContexts.RunNow
-        else new ExecutionContexts.ThreadPool(effectiveThreadCount)
-
-      try execute0(goals, logger, reporter, testReporter, ec, serialCommandExec)
-      finally ec.close()
+      execute0(goals, logger, reporter, testReporter, serialCommandExec)
     }
   }
 
@@ -108,7 +103,6 @@ private[mill] case class Execution(
       logger: Logger,
       reporter: Int => Option[CompileProblemReporter] = _ => Option.empty[CompileProblemReporter],
       testReporter: TestReporter = TestReporter.DummyTestReporter,
-      ec: mill.define.TaskCtx.Fork.Impl,
       serialCommandExec: Boolean
   ): Execution.Results = {
     os.makeDir.all(outPath)
@@ -140,9 +134,10 @@ private[mill] case class Execution(
 
     def evaluateTerminals(
         terminals: Seq[Task[?]],
-        forkExecutionContext: mill.define.TaskCtx.Fork.Impl,
         exclusive: Boolean
     ) = {
+      val forkExecutionContext =
+        ec.fold(ExecutionContexts.RunNow)(new ExecutionContexts.ThreadPool(_))
       implicit val taskExecutionContext =
         if (exclusive) ExecutionContexts.RunNow else forkExecutionContext
       // We walk the task graph in topological order and schedule the futures
@@ -293,9 +288,9 @@ private[mill] case class Execution(
 
     // Run all non-command tasks according to the threads
     // given but run the commands in linear order
-    val nonExclusiveResults = evaluateTerminals(tasks, ec, exclusive = false)
+    val nonExclusiveResults = evaluateTerminals(tasks, exclusive = false)
 
-    val exclusiveResults = evaluateTerminals(leafExclusiveCommands, ec, exclusive = true)
+    val exclusiveResults = evaluateTerminals(leafExclusiveCommands, exclusive = true)
 
     logger.prompt.clearPromptStatuses()
 

--- a/integration/feature/leak-hygiene/resources/build.mill
+++ b/integration/feature/leak-hygiene/resources/build.mill
@@ -49,7 +49,12 @@ def countThreads() = Task.Command {
     .keySet
     .asScala
     .toSeq
-    .collect { case t if t.getThreadGroup.getName == "main" => t.getName }
+    .collect {
+      case t if t.getThreadGroup.getName == "main" =>
+        // Mark the current thread with a '!' prefix
+        val prefix = if (t == Thread.currentThread()) "!" else ""
+        prefix + t.getName
+    }
     .sorted
 }
 

--- a/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
+++ b/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
@@ -13,6 +13,7 @@ import mill.util.BuildInfo
 
 import java.io.File
 import java.net.URLClassLoader
+import java.util.concurrent.ThreadPoolExecutor
 import scala.jdk.CollectionConverters.ListHasAsScala
 import scala.util.Using
 import scala.collection.mutable.Buffer
@@ -39,7 +40,7 @@ class MillBuildBootstrap(
     keepGoing: Boolean,
     imports: Seq[String],
     env: Map[String, String],
-    threadCount: Option[Int],
+    ec: Option[ThreadPoolExecutor],
     targetsAndParams: Seq[String],
     prevRunnerState: RunnerState,
     logger: Logger,
@@ -167,7 +168,7 @@ class MillBuildBootstrap(
               keepGoing,
               env,
               logger,
-              threadCount,
+              ec,
               allowPositionalCommandArgs,
               systemExit,
               streams0,
@@ -354,7 +355,7 @@ object MillBuildBootstrap {
       keepGoing: Boolean,
       env: Map[String, String],
       logger: Logger,
-      threadCount: Option[Int],
+      ec: Option[ThreadPoolExecutor],
       allowPositionalCommandArgs: Boolean,
       systemExit: Int => Nothing,
       streams0: SystemStreams,
@@ -398,7 +399,7 @@ object MillBuildBootstrap {
         workerCache.to(collection.mutable.Map),
         env,
         !keepGoing,
-        threadCount,
+        ec,
         codeSignatures,
         systemExit,
         streams0,

--- a/runner/daemon/src/mill/daemon/MillMain0.scala
+++ b/runner/daemon/src/mill/daemon/MillMain0.scala
@@ -14,6 +14,7 @@ import mill.{api, define}
 import java.io.{InputStream, PipedInputStream, PrintStream}
 import java.lang.reflect.InvocationTargetException
 import java.util.Locale
+import java.util.concurrent.{ThreadPoolExecutor, TimeUnit}
 import java.util.concurrent.locks.ReentrantLock
 import scala.collection.immutable
 import scala.jdk.CollectionConverters.*
@@ -257,10 +258,14 @@ object MillMain0 {
                   val userSpecifiedProperties =
                     userSpecifiedProperties0 ++ config.extraSystemProperties
 
-                  val threadCount = Some(maybeThreadCount.toOption.get)
+                  val threadCount = maybeThreadCount.toOption.get
+
+                  def createEc(): Option[ThreadPoolExecutor] =
+                    if (threadCount == 1) None
+                    else Some(mill.exec.ExecutionContexts.createExecutor(threadCount))
 
                   val out = os.Path(OutFiles.out, BuildCtx.workspaceRoot)
-                  Using.resource(new TailManager(daemonDir)) { tailManager =>
+                  Using.resources(new TailManager(daemonDir), createEc()) { (tailManager, ec) =>
                     def runMillBootstrap(
                         enterKeyPressed: Boolean,
                         prevState: Option[RunnerState],
@@ -289,7 +294,7 @@ object MillMain0 {
                               keepGoing = config.keepGoing.value,
                               imports = config.imports,
                               env = env,
-                              threadCount = threadCount,
+                              ec = ec,
                               targetsAndParams = targetsAndParams,
                               prevRunnerState = prevState.getOrElse(stateCache),
                               logger = logger,
@@ -589,4 +594,14 @@ object MillMain0 {
     for (k <- systemPropertiesToUnset) System.clearProperty(k)
     for ((k, v) <- desiredProps) System.setProperty(k, v)
   }
+
+  private implicit lazy val threadPoolExecutorOptionReleasable
+      : Using.Releasable[Option[ThreadPoolExecutor]] =
+    new Using.Releasable[Option[ThreadPoolExecutor]] {
+      def release(resource: Option[ThreadPoolExecutor]): Unit =
+        for (t <- resource) {
+          t.shutdown()
+          t.awaitTermination(Long.MaxValue, TimeUnit.SECONDS)
+        }
+    }
 }


### PR DESCRIPTION
This makes `mill.exec.Execution` accept a thread pool in its constructor, rather than creating one every time tasks need to be run. In BSP and in watch mode, this should save the thread pool creation across task runs. I don't have numbers to back the impact of this change, but factoring the thread pool was part of [a bunch of optimizations](https://github.com/coursier/sbt-coursier/pull/256) in the coursier integration in sbt a few years ago. Plus given we follow more of a single-execution-at-a-time model, there's no reason not to re-use the thread pool across executions.