### PR TITLE
Android: Standardize the use of application id and namespace

### DIFF
--- a/example/thirdparty/androidtodo/build.mill
+++ b/example/thirdparty/androidtodo/build.mill
@@ -26,7 +26,7 @@ object app extends AndroidAppKotlinModule with AndroidBuildConfig with AndroidHi
 
   def androidApplicationNamespace = "com.example.android.architecture.blueprints.todoapp"
   // TODO change this to com.example.android.architecture.blueprints.main when mill supports build variants
-  def androidApplicationId = "com.example.android.architecture.blueprints.todoapp"
+  def androidApplicationId = "com.example.android.architecture.blueprints.main"
 
   def androidSdkModule = mill.define.ModuleRef(androidSdkModule0)
 
@@ -177,10 +177,10 @@ object `shared-test` extends AndroidKotlinModule with AndroidHiltSupport {
 
 > ./mill show app.androidRun --activity com.example.android.architecture.blueprints.todoapp.TodoActivity
 [
-  "Starting: Intent { cmp=com.example.android.architecture.blueprints.todoapp/.TodoActivity }",
+  "Starting: Intent { cmp=com.example.android.architecture.blueprints.main/com.example.android.architecture.blueprints.todoapp.TodoActivity }",
   "Status: ok",
   "LaunchState: COLD",
-  "Activity: com.example.android.architecture.blueprints.todoapp/.TodoActivity",
+  "Activity: com.example.android.architecture.blueprints.main/com.example.android.architecture.blueprints.todoapp.TodoActivity",
   "TotalTime: ...",
   "WaitTime: ...",
   "Complete"

--- a/libs/androidlib/src/mill/androidlib/AndroidSdkModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidSdkModule.scala
@@ -40,7 +40,7 @@ trait AndroidSdkModule extends Module {
   /**
    * Specifies the version of the Manifest Merger.
    */
-  def manifestMergerVersion: T[String] = "31.7.3"
+  def manifestMergerVersion: T[String] = "31.10.0"
 
   /**
    * Specifies the version of the Android build tools to be used.


### PR DESCRIPTION
This PR standardises the use of application id and namespace. It is also one of the pre-requisites of making hilt instrumented tests to work.

The application id is a unique id for every android app , so the android manifest package depends on it.

The android manifest package is also used whenever there's a relative path for Applications and activities so

```xml
<manifest package="com.foo">
    <application android:name=".TodoApplication"/>
</manifest>
```

Becomes 

```xml
<manifest package="com.foo">
    <application android:name="com.foo.TodoApplication"/>
</manifest>
```

During manifest merging. Because this happens when the manifest is loaded (before everything is merged) we start with the manifest package being the android namespace. We then pass the package property to the merger to be the application id (the package for each up is unique). This is what appears to be happening in AGP as well. (It is also the reason why I was confused when reverse engineering the AGP behaviour and was alternating between namespace and application id)


I've also cleaned up some of the xml manual modifications that are not needed anymore as are handled by the merger tool