### PR TITLE
Fix line numbers of files with yaml predefs

### DIFF
--- a/core/api/src/mill/api/internal/MillScalaParser.scala
+++ b/core/api/src/mill/api/internal/MillScalaParser.scala
@@ -3,7 +3,10 @@ package mill.api.internal
 import scala.util.DynamicVariable
 
 trait MillScalaParser {
-  def splitScript(rawCode: String, fileName: String): Either[String, (Seq[String], Seq[String])]
+  def splitScript(
+      rawCode: String,
+      fileName: String
+  ): Either[String, (String, Seq[String], Seq[String])]
 
   /* not sure if this is the right way, in case needs change, or if we should accept some
    * "generic" visitor over some "generic" trees?

--- a/integration/failure/compile-error/resources/build.mill
+++ b/integration/failure/compile-error/resources/build.mill
@@ -1,3 +1,6 @@
+//| # make sure line numbers are correctly
+//| # offset in the presence of a yaml header
+//| dummy-key: dummy-value
 package build
 import mill._
 import mill.scalalib._

--- a/integration/failure/compile-error/src/CompileErrorTests.scala
+++ b/integration/failure/compile-error/src/CompileErrorTests.scala
@@ -25,7 +25,7 @@ object CompileErrorTests extends UtestIntegrationTestSuite {
       }
 
       locally {
-        assert(res.err.contains("""build.mill:8:5"""))
+        assert(res.err.contains("""build.mill:11:5"""))
         assert(res.err.contains("""foo.noSuchMethod"""))
         assert(res.err.contains("""value noSuchMethod is not a member"""))
       }

--- a/integration/feature/leak-hygiene/src/LeakHygieneTests.scala
+++ b/integration/feature/leak-hygiene/src/LeakHygieneTests.scala
@@ -173,7 +173,7 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
 
         // Exercise modifying build.mill
         for (i <- Range(0, 2)) {
-          tester.modifyFile(tester.workspacePath / "build.mill", "\n" + _)
+          tester.modifyFile(tester.workspacePath / "build.mill", _ + "\n")
 
           tester.eval(("show", "__.compile"))
           checkClassloaders(tester)(

--- a/runner/daemon/src/mill/daemon/MillScalaParserImpl.scala
+++ b/runner/daemon/src/mill/daemon/MillScalaParserImpl.scala
@@ -49,7 +49,10 @@ object MillScalaParserImpl extends MillScalaParser {
       trees <- liftErrors(MillParsers.outlineCompilationUnit(source))
       (pkgs, stmts) <- liftErrors(splitTrees(trees))
     yield {
-      val prefix = new String(source.file.toByteArray).take(trees.head.startPos.start)
+      val prefix =
+        if (!trees.head.startPos.exists) ""
+        else new String(source.file.toByteArray).take(trees.head.startPos.start)
+
       (prefix, pkgs, stmts)
     }
   }

--- a/runner/launcher/src/mill/launcher/CoursierClient.scala
+++ b/runner/launcher/src/mill/launcher/CoursierClient.scala
@@ -3,7 +3,18 @@ package mill.launcher
 import coursier.cache.{ArchiveCache, FileCache}
 import coursier.jvm.{JavaHome, JvmCache, JvmChannel, JvmIndex}
 import coursier.util.Task
-import coursier.{Artifacts, Classifier, Dependency, ModuleName, Organization, Repository, Resolution, Resolve, Type, VersionConstraint}
+import coursier.{
+  Artifacts,
+  Classifier,
+  Dependency,
+  ModuleName,
+  Organization,
+  Repository,
+  Resolution,
+  Resolve,
+  Type,
+  VersionConstraint
+}
 import coursier.cache.{ArchiveCache, CachePolicy, FileCache}
 import coursier.core.{BomDependency, Module}
 import coursier.error.FetchError.DownloadingArtifacts

--- a/runner/meta/src/mill/meta/FileImportGraph.scala
+++ b/runner/meta/src/mill/meta/FileImportGraph.scala
@@ -92,6 +92,7 @@ object FileImportGraph {
       } catch {
         case ex: Throwable =>
           seenScripts(s) = ""
+          pprint.log(ex.getStackTrace.mkString("\n"))
           errors.append(ex.getClass.getName + " " + ex.getMessage)
       }
 

--- a/runner/meta/src/mill/meta/FileImportGraph.scala
+++ b/runner/meta/src/mill/meta/FileImportGraph.scala
@@ -61,8 +61,9 @@ object FileImportGraph {
         yamlHeaderError.flatMap(_ =>
           MillScalaParser.current.value.splitScript(content, fileName)
         ) match {
-          case Right(splitted) =>
-            val (pkgs, stmts) = splitted
+          case Right((prefix, pkgs, stmts)) =>
+            mill.constants.DebugLog.println("pkgs" + pprint.apply(pkgs).toString)
+            mill.constants.DebugLog.println("stmts " + pprint.apply(stmts).toString)
             val importSegments = pkgs.mkString(".")
 
             val expectedImportSegments0 =
@@ -83,7 +84,7 @@ object FileImportGraph {
                   s"folder structure. Expected: $expectedImport"
               )
             }
-            seenScripts(s) = stmts.mkString
+            seenScripts(s) = prefix + stmts.mkString
           case Left(error) =>
             seenScripts(s) = ""
             errors.append(error)


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/5223

Previously the script parser would look for the `package build` line and then discard anything before it. Now, we explicitly keep the `prefix: String` of any code before the `package`, which can basically only be line comments or block comments, and prepend it back onto the script code before passing it further down the pipeline to keep the line numbers the same as they were before