### PR TITLE
Add explicit dependency on gson not to depend on an interval

### DIFF
--- a/mill-build/src/millbuild/Deps.scala
+++ b/mill-build/src/millbuild/Deps.scala
@@ -175,6 +175,7 @@ object Deps {
   val zinc = mvn"org.scala-sbt::zinc:1.10.8".withDottyCompat(scalaVersion)
   // keep in sync with doc/antora/antory.yml
   val bsp4j = mvn"ch.epfl.scala:bsp4j:2.2.0-M2"
+  val gson = mvn"com.google.code.gson:gson:2.10.1"
   val fansi = mvn"com.lihaoyi::fansi:0.5.0"
   val jarjarabrams =
     mvn"com.eed3si9n.jarjarabrams::jarjar-abrams-core:1.14.1".withDottyCompat(scalaVersion)
@@ -254,7 +255,7 @@ object Deps {
   lazy val transitiveDeps = Seq(
     mvn"org.apache.ant:ant:1.10.15",
     Deps.commonsIo,
-    mvn"com.google.code.gson:gson:2.11.0",
+    Deps.gson,
     mvn"com.google.protobuf:protobuf-java:4.29.3",
     mvn"com.google.guava:guava:33.4.0-jre",
     mvn"org.yaml:snakeyaml:2.3",

--- a/runner/bsp/package.mill
+++ b/runner/bsp/package.mill
@@ -43,6 +43,10 @@ object `package` extends MillPublishScalaModule with BuildInfo {
     ) ++ build.libs.scalalib.compileModuleDeps
     def mvnDeps = Seq(
       Deps.bsp4j,
+      // Pulled transitively by bsp4j, that only depends on an interval for it, [2.9.1,2.11)
+      // Adding it as a dependency here in order to depend on a constant version rather than an interval
+      // If needed, that version can be bumped in the future to accomodate any conflict that might arise
+      Deps.gson,
       Deps.sbtTestInterface,
       Deps.osLib
     )


### PR DESCRIPTION
`ch.epfl.scala:bsp4j:2.2.0-M2` depends on `org.eclipse.lsp4j:org.eclipse.lsp4j.jsonrpc:0.20.1`, that itself depends on `com.google.code.gson:gson:[2.9.1,2.11)`

In order not to depend on a version interval and make the resolution reproducible, we add an explicit dependency on a gson version in this interval.

Depending on version intervals makes resolution check for new versions by pulling version listing repeatedly, even when all artifacts are in cache. Depending on a fixed version changes that, and makes resolution not attempt to download anything if all artifacts are in cache.


Fixes https://github.com/com-lihaoyi/mill/issues/5222