### PR TITLE
Impore `Task.{Source,Sources}` API

### DIFF
--- a/core/define/src/mill/define/Task.scala
+++ b/core/define/src/mill/define/Task.scala
@@ -148,34 +148,31 @@ object Task {
    * signature for you source files/folders and decides whether or not downstream
    * [[Task.Computed]]s need to be invalidated and re-computed.
    */
-  inline def Sources(inline values: Result[os.Path]*)(implicit
+  inline def Sources(inline values: (os.Path | os.SubPath | os.RelPath | String)*)(implicit
       inline ctx: mill.define.ModuleCtx
   ): Simple[Seq[PathRef]] = ${
-    Macros.sourcesImpl('{ Result.sequence(values.map(_.map(PathRef(_)))) })('ctx)
+    Macros.sourcesImpl('{ values.map(p => PathRef(mapToPath(p))) })('ctx)
   }
 
-  inline def Sources(inline values: os.SubPath*)(implicit
-      inline ctx: mill.define.ModuleCtx,
-      dummy: Boolean = true
-  ): Simple[Seq[PathRef]] = ${
-    Macros.sourcesImpl(
-      '{ values.map(sub => PathRef(ctx.millSourcePath / os.up / os.PathChunk.SubPathChunk(sub))) }
-    )('ctx)
+  inline private def mapToPath(value: os.Path | os.SubPath | os.RelPath | String)(implicit
+      inline ctx: mill.define.ModuleCtx
+  ): os.Path = value match {
+    // TODO: support "."
+    case "." => ctx.millSourcePath / os.up
+    case str: String => ctx.millSourcePath / os.up / os.PathChunk.segmentsFromString(str)
+    case sub: os.SubPath => ctx.millSourcePath / os.up / os.PathChunk.SubPathChunk(sub)
+    case rel: os.RelPath => ctx.millSourcePath / os.up / os.PathChunk.RelPathChunk(rel)
+    case p: os.Path => p
   }
 
   /**
    * Similar to [[Sources]], but only for a single source file or folder. Defined
    * using `Task.Source`.
    */
-  inline def Source(inline value: Result[os.Path])(implicit
+  inline def Source(inline value: os.Path | os.SubPath | os.RelPath | String)(implicit
       inline ctx: mill.define.ModuleCtx
   ): Simple[PathRef] =
-    ${ Macros.sourceImpl('{ value.map(PathRef(_)) })('ctx) }
-
-  inline def Source(inline value: os.SubPath)(implicit
-      inline ctx: mill.define.ModuleCtx
-  ): Simple[PathRef] =
-    ${ Macros.sourceImpl('{ PathRef(ctx.millSourcePath / os.up / value) })('ctx) }
+    ${ Macros.sourceImpl('{ PathRef(mapToPath(value)) })('ctx) }
 
   /**
    * [[Input]]s, normally defined using `Task.Input`, are [[Task.Named]]s that

--- a/libs/scalalib/test/src/mill/javalib/revapi/RevapiModuleTests.scala
+++ b/libs/scalalib/test/src/mill/javalib/revapi/RevapiModuleTests.scala
@@ -73,7 +73,7 @@ object RevapiModuleTests extends TestSuite {
     object module2 extends module with RevapiModule {
       override def revapiConfigFiles: T[Seq[PathRef]] =
         Task.Sources(
-          os.list(conf).iterator.filter(_.ext == "json").toSeq.map(mill.api.Result.Success(_))*
+          os.list(conf).iterator.filter(_.ext == "json").toSeq*
         )
       override def revapiClasspath: T[Seq[PathRef]] = Task {
         super.revapiClasspath() ++ Seq(PathRef(conf))
@@ -113,7 +113,7 @@ object RevapiModuleTests extends TestSuite {
       }
       override def revapiConfigFiles: T[Seq[PathRef]] =
         Task.Sources(
-          os.list(conf).iterator.filter(_.ext == "json").toSeq.map(mill.api.Result.Success(_))*
+          os.list(conf).iterator.filter(_.ext == "json").toSeq*
         )
       override def revapiClasspath: T[Seq[PathRef]] = Task {
         super.revapiClasspath() ++ Seq(PathRef(conf))

--- a/runner/meta/src/mill/meta/MillBuildRootModule.scala
+++ b/runner/meta/src/mill/meta/MillBuildRootModule.scala
@@ -48,7 +48,7 @@ trait MillBuildRootModule()(implicit
    * @see [[generatedSources]]
    */
   def scriptSources: T[Seq[PathRef]] = Task.Sources(
-    scriptSourcesPaths.map(Result.Success(_))* // Ensure ordering is deterministic
+    scriptSourcesPaths* // Ensure ordering is deterministic
   )
 
   def parseBuildFiles: T[FileImportGraph] = Task {


### PR DESCRIPTION
Accept the following tpye:
* `os.SubPath` - an sub-path resolved against `moduleDir`
* `os.RelPath` - an relative path resolved against `moduleDir`
* `os.Path` - an absolute path
* `String` - a sub-path relative to `moduleDir`; the special string `"."` is treated as the `moduleDir`.

