### PR TITLE
Add optional deps to the class path of their modules

### DIFF
--- a/libs/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/libs/scalalib/src/mill/scalalib/JavaModule.scala
@@ -1554,6 +1554,11 @@ object JavaModule {
   final case class InternalRepo(projects: Seq[cs.Project])
       extends cs.Repository {
 
+    // Reversing the sequence before calling toMap, so that earlier elements have precedence
+    // over later one, in case they have the same module / version.
+    // That's useful for the handling of optional dependencies, where the main project, with
+    // initially optional dependencies marked as non-optional, is put upfront, but might still
+    // be pulled transitively, in that case without the special handling of optional dependencies.
     private lazy val map = projects.reverseIterator.map(proj => proj.moduleVersion -> proj).toMap
 
     override def toString(): String =

--- a/libs/scalalib/test/src/mill/scalalib/ResolveDepsTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/ResolveDepsTests.scala
@@ -201,29 +201,30 @@ object ResolveDepsTests extends TestSuite {
         val dependsOnOptionalRunCp = eval(TestCase.optional.dependsOnOptional.runClasspath)
           .fold(_.get, _.value).map(_.path)
 
-        // optional dependencies in mvnDeps should be added to the current module class path,
-        // but not to the class path of its dependees
+        // optional dependencies in mvnDeps should be added to the current module class path
         assert(optionalCompileCp.exists(_.last == "interface-1.0.29-M1.jar"))
         assert(optionalRuntimeCp.exists(_.last == "interface-1.0.29-M1.jar"))
         assert(optionalRunCp.exists(_.last == "interface-1.0.29-M1.jar"))
-        assert(!dependsOnOptionalCompileCp.exists(_.last == "interface-1.0.29-M1.jar"))
-        assert(!dependsOnOptionalRuntimeCp.exists(_.last == "interface-1.0.29-M1.jar"))
-        assert(!dependsOnOptionalRunCp.exists(_.last == "interface-1.0.29-M1.jar"))
 
         // optional dependencies in compileMvnDeps should be added to the current module compile class path,
-        // but not to the runtime class path or to the class path of its dependees
+        // but not to the runtime class path
         assert(optionalCompileCp.exists(_.last == "sourcecode_3-0.4.3-M5.jar"))
         assert(!optionalRuntimeCp.exists(_.last == "sourcecode_3-0.4.3-M5.jar"))
         assert(!optionalRunCp.exists(_.last == "sourcecode_3-0.4.3-M5.jar"))
-        assert(!dependsOnOptionalCompileCp.exists(_.last == "sourcecode_3-0.4.3-M5.jar"))
-        assert(!dependsOnOptionalRuntimeCp.exists(_.last == "sourcecode_3-0.4.3-M5.jar"))
-        assert(!dependsOnOptionalRunCp.exists(_.last == "sourcecode_3-0.4.3-M5.jar"))
 
         // optional dependencies in runMvnDeps should be added to the current module run class path,
-        // but not to the compile class path or to the class path of its dependees
+        // but not to the compile class path
         assert(!optionalCompileCp.exists(_.last == "logback-core-1.5.18.jar"))
         assert(optionalRuntimeCp.exists(_.last == "logback-core-1.5.18.jar"))
         assert(optionalRunCp.exists(_.last == "logback-core-1.5.18.jar"))
+
+        // in transitive modules, optional dependencies are always ignored
+        assert(!dependsOnOptionalCompileCp.exists(_.last == "interface-1.0.29-M1.jar"))
+        assert(!dependsOnOptionalRuntimeCp.exists(_.last == "interface-1.0.29-M1.jar"))
+        assert(!dependsOnOptionalRunCp.exists(_.last == "interface-1.0.29-M1.jar"))
+        assert(!dependsOnOptionalCompileCp.exists(_.last == "sourcecode_3-0.4.3-M5.jar"))
+        assert(!dependsOnOptionalRuntimeCp.exists(_.last == "sourcecode_3-0.4.3-M5.jar"))
+        assert(!dependsOnOptionalRunCp.exists(_.last == "sourcecode_3-0.4.3-M5.jar"))
         assert(!dependsOnOptionalCompileCp.exists(_.last == "logback-core-1.5.18.jar"))
         assert(!dependsOnOptionalRuntimeCp.exists(_.last == "logback-core-1.5.18.jar"))
         assert(!dependsOnOptionalRunCp.exists(_.last == "logback-core-1.5.18.jar"))


### PR DESCRIPTION
Optional dependencies are marked as optional for consumers of a module.

They should still be added to the class path of the module that has them as optional dependencies, as Maven does, as mentioned by @lefou in https://github.com/com-lihaoyi/mill/issues/5095

Fixes https://github.com/com-lihaoyi/mill/issues/5095