### PR TITLE
Android: Example with versions from boms (with compose-bom)

### DIFF
--- a/libs/androidlib/src/mill/androidlib/AndroidModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidModule.scala
@@ -158,7 +158,7 @@ trait AndroidModule extends JavaModule {
           VariantMatcher.Equals("androidJvm"),
           VariantMatcher.Equals("jvm")
         ))
-    ).withForceDepMgmtVersions(Some(true))
+    )
   }
 
   /**


### PR DESCRIPTION
Example with versions to be resolved via Boms for android architecture samples. E.g. our build.mill for architecture samples can now declare the dependencies in the [compose-bom without a version](https://github.com/android/architecture-samples/blob/main/gradle/libs.versions.toml#L83) .

This is just an improvement on `build.mill` for the architecture-sample thirdparty example , getting it closer to the gradle configuration (no versions on the androidx.compose)