### PR TITLE
Separate android manifest merger to avoid classpath conflicts

### DIFF
--- a/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
@@ -280,54 +280,30 @@ trait AndroidAppModule extends AndroidModule { outer =>
     PathRef(unsignedApk)
   }
 
-  /**
-   * Creates a merged manifest from application and dependencies manifests.
-   *
-   * See [[https://developer.android.com/build/manage-manifests]] for more details.
-   */
-  def androidMergedManifest: T[PathRef] = Task {
-    val debugManifest = Seq(androidDebugManifestLocation().path).filter(os.exists)
-    val libManifests = androidUnpackArchives().flatMap(_.manifest.map(_.path))
-    val allManifests = debugManifest ++ libManifests
-    val mergedManifestPath = Task.dest / "AndroidManifest.xml"
-    // TODO put it to the dedicated worker if cost of classloading is too high
-    Jvm.callProcess(
-      mainClass = "com.android.manifmerger.Merger",
-      mainArgs = Seq(
-        "--main",
-        androidManifest().path.toString(),
-        "--remove-tools-declarations",
-        "--property",
-        s"min_sdk_version=${androidMinSdk()}",
-        "--property",
-        s"target_sdk_version=${androidTargetSdk()}",
-        "--property",
-        s"version_code=${androidVersionCode()}",
-        "--property",
-        s"version_name=${androidVersionName()}",
-        "--property",
-        s"package=${androidApplicationId}",
-        "--manifest-placeholders",
-        s"applicationId=${androidApplicationId}",
-        "--out",
-        mergedManifestPath.toString()
-      ) ++ allManifests.flatMap(m => Seq("--libs", m.toString)),
-      classPath = manifestMergerClasspath().map(_.path).toVector,
-      stdin = os.Inherit,
-      stdout = os.Inherit
-    )
-    PathRef(mergedManifestPath)
+  override def androidMergeableManifests: Task[Seq[PathRef]] = Task {
+    val debugManifest = Seq(androidDebugManifestLocation()).filter(pr => os.exists(pr.path))
+    val libManifests = androidUnpackArchives().flatMap(_.manifest)
+    debugManifest ++ libManifests
   }
 
-  /**
-   * Classpath for the manifest merger run.
-   */
-  def manifestMergerClasspath: T[Seq[PathRef]] = Task {
-    defaultResolver().classpath(
-      Seq(
-        mvn"com.android.tools.build:manifest-merger:${androidSdkModule().manifestMergerVersion()}"
-      )
-    )
+  override def androidMergedManifestArgs: Task[Seq[String]] = Task {
+    Seq(
+      "--main",
+      androidManifest().path.toString(),
+      "--remove-tools-declarations",
+      "--property",
+      s"min_sdk_version=${androidMinSdk()}",
+      "--property",
+      s"target_sdk_version=${androidTargetSdk()}",
+      "--property",
+      s"version_code=${androidVersionCode()}",
+      "--property",
+      s"version_name=${androidVersionName()}",
+      "--property",
+      s"package=${androidApplicationId}",
+      "--manifest-placeholders",
+      s"applicationId=${androidApplicationId}"
+    ) ++ androidMergeableManifests().flatMap(m => Seq("--libs", m.path.toString))
   }
 
   /**
@@ -974,39 +950,33 @@ trait AndroidAppModule extends AndroidModule { outer =>
       }.map(PathRef(_))
     }
 
+    override def androidMergeableManifests: Task[Seq[PathRef]] = Task {
+      Seq(outer.androidDebugManifestLocation()).filter(pr =>
+        os.exists(pr.path)
+      ) ++ androidxTestManifests()
+    }
+
     /**
-     * Creates a merged manifest for instrumented tests.
+     * Args for the manifest merger, to create a merged manifest for instrumented tests via [[androidMergedManifest]].
      *
      * See [[https://developer.android.com/build/manage-manifests]] for more details.
      */
-    def androidMergedManifest: T[PathRef] = Task {
-      val debugManifest = Seq(outer.androidDebugManifestLocation().path).filter(os.exists)
-      val androidxManifests = androidxTestManifests().map(_.path)
-      val libManifests = (debugManifest ++ androidxManifests)
-      val mergedManifestPath = Task.dest / "AndroidManifest.xml"
-      // TODO put it to the dedicated worker if cost of classloading is too high
-      Jvm.callProcess(
-        mainClass = "com.android.manifmerger.Merger",
-        mainArgs = Seq(
-          "--main",
-          androidManifest().path.toString(),
-          "--remove-tools-declarations",
-          "--property",
-          s"min_sdk_version=${androidMinSdk()}",
-          "--property",
-          s"target_sdk_version=${androidTargetSdk()}",
-          "--property",
-          s"version_code=${androidVersionCode()}",
-          "--property",
-          s"target_package=${outer.androidApplicationId}",
-          "--property",
-          s"version_name=${androidVersionName()}",
-          "--out",
-          mergedManifestPath.toString()
-        ) ++ libManifests.flatMap(m => Seq("--libs", m.toString())),
-        classPath = manifestMergerClasspath().map(_.path)
-      )
-      PathRef(mergedManifestPath)
+    override def androidMergedManifestArgs: Task[Seq[String]] = Task {
+      Seq(
+        "--main",
+        androidManifest().path.toString(),
+        "--remove-tools-declarations",
+        "--property",
+        s"min_sdk_version=${androidMinSdk()}",
+        "--property",
+        s"target_sdk_version=${androidTargetSdk()}",
+        "--property",
+        s"version_code=${androidVersionCode()}",
+        "--property",
+        s"target_package=${outer.androidApplicationId}",
+        "--property",
+        s"version_name=${androidVersionName()}"
+      ) ++ androidMergeableManifests().flatMap(m => Seq("--libs", m.path.toString))
     }
 
     override def androidVirtualDeviceIdentifier: String = outer.androidVirtualDeviceIdentifier

--- a/libs/androidlib/src/mill/androidlib/AndroidModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidModule.scala
@@ -4,6 +4,7 @@ import coursier.Repository
 import coursier.core.VariantSelector.VariantMatcher
 import coursier.params.ResolutionParams
 import mill.T
+import mill.androidlib.manifestmerger.AndroidManifestMerger
 import mill.define.{ModuleRef, PathRef, Task}
 import mill.scalalib.*
 import mill.util.Jvm
@@ -247,17 +248,6 @@ trait AndroidModule extends JavaModule {
   }
 
   /**
-   * Classpath for the manifest merger run.
-   */
-  def manifestMergerClasspath: T[Seq[PathRef]] = Task {
-    defaultResolver().classpath(
-      Seq(
-        mvn"com.android.tools.build:manifest-merger:${androidSdkModule().manifestMergerVersion()}"
-      )
-    )
-  }
-
-  /**
    * Extracts JAR files and resources from AAR dependencies.
    */
   def androidUnpackArchives: T[Seq[UnpackedDep]] = Task {
@@ -314,35 +304,47 @@ trait AndroidModule extends JavaModule {
     })
   }
 
+  def androidManifestMergerModuleRef: ModuleRef[AndroidManifestMerger] =
+    ModuleRef(AndroidManifestMerger)
+
+  def androidMergeableManifests: Task[Seq[PathRef]] = Task {
+    androidUnpackArchives().flatMap(_.manifest)
+  }
+
+  def androidMergedManifestArgs: Task[Seq[String]] = Task {
+    Seq(
+      "--main",
+      androidManifest().path.toString(),
+      "--remove-tools-declarations",
+      "--property",
+      s"min_sdk_version=${androidMinSdk()}",
+      "--property",
+      s"target_sdk_version=${androidTargetSdk()}",
+      "--property",
+      s"version_code=${androidVersionCode()}",
+      "--property",
+      s"version_name=${androidVersionName()}"
+    ) ++ androidMergeableManifests().flatMap(m => Seq("--libs", m.path.toString()))
+  }
+
   /**
-   * Creates a merged manifest from application and dependencies manifests.
+   * Creates a merged manifest from application and dependencies manifests using.
+   * Merged manifests are given via [[androidMergeableManifests]] and merger args via
+   * [[androidMergedManifestArgs]]
    *
    * See [[https://developer.android.com/build/manage-manifests]] for more details.
    */
   def androidMergedManifest: T[PathRef] = Task {
-    val libManifests = androidUnpackArchives().map(_.manifest.get)
-    val mergedManifestPath = Task.dest / "AndroidManifest.xml"
-    // TODO put it to the dedicated worker if cost of classloading is too high
-    Jvm.callProcess(
-      mainClass = "com.android.manifmerger.Merger",
-      mainArgs = Seq(
-        "--main",
-        androidManifest().path.toString(),
-        "--remove-tools-declarations",
-        "--property",
-        s"min_sdk_version=${androidMinSdk()}",
-        "--property",
-        s"target_sdk_version=${androidTargetSdk()}",
-        "--property",
-        s"version_code=${androidVersionCode()}",
-        "--property",
-        s"version_name=${androidVersionName()}",
-        "--out",
-        mergedManifestPath.toString()
-      ) ++ libManifests.flatMap(m => Seq("--libs", m.path.toString())),
-      classPath = manifestMergerClasspath().map(_.path)
-    )
-    PathRef(mergedManifestPath)
+
+    val mergedAndroidManifestLocation = androidManifestMergerModuleRef().androidMergedManifest(
+      args = Task.Anon(androidMergedManifestArgs())
+    )()
+
+    val mergedAndroidManifestDest = Task.dest / "AndroidManifest.xml"
+
+    os.move(mergedAndroidManifestLocation, mergedAndroidManifestDest)
+
+    PathRef(mergedAndroidManifestDest)
   }
 
   def androidLibsRClasses: T[Seq[PathRef]] = Task {

--- a/libs/androidlib/src/mill/androidlib/AndroidModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidModule.scala
@@ -237,15 +237,16 @@ trait AndroidModule extends JavaModule {
       transformedAarFilesToJar ++ jarFiles
     }
 
-  def androidTransformAarFiles(resolvedDeps: Task[Seq[PathRef]]): Task[Seq[UnpackedDep]] = Task.Anon {
-    val transformDest = Task.dest / "transform"
-    val aarFiles = resolvedDeps()
-      .map(_.path)
-      .filter(_.ext == "aar")
-      .distinct
+  def androidTransformAarFiles(resolvedDeps: Task[Seq[PathRef]]): Task[Seq[UnpackedDep]] =
+    Task.Anon {
+      val transformDest = Task.dest / "transform"
+      val aarFiles = resolvedDeps()
+        .map(_.path)
+        .filter(_.ext == "aar")
+        .distinct
 
-    extractAarFiles(aarFiles, transformDest)
-  }
+      extractAarFiles(aarFiles, transformDest)
+    }
 
   /**
    * Extracts JAR files and resources from AAR dependencies.

--- a/libs/androidlib/src/mill/androidlib/AndroidModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidModule.scala
@@ -237,7 +237,7 @@ trait AndroidModule extends JavaModule {
       transformedAarFilesToJar ++ jarFiles
     }
 
-  def androidTransformAarFiles(resolvedDeps: Task[Seq[PathRef]]): Task[Seq[UnpackedDep]] = Task {
+  def androidTransformAarFiles(resolvedDeps: Task[Seq[PathRef]]): Task[Seq[UnpackedDep]] = Task.Anon {
     val transformDest = Task.dest / "transform"
     val aarFiles = resolvedDeps()
       .map(_.path)

--- a/libs/androidlib/src/mill/androidlib/manifestmerger/AndroidManifestMerger.scala
+++ b/libs/androidlib/src/mill/androidlib/manifestmerger/AndroidManifestMerger.scala
@@ -1,0 +1,55 @@
+package mill.androidlib.manifestmerger
+
+import coursier.Repository
+import mill.*
+import mill.androidlib.AndroidSdkModule
+import mill.define.{Discover, ExternalModule}
+import mill.scalalib.*
+import mill.util.Jvm
+
+@mill.api.experimental
+trait AndroidManifestMerger extends ExternalModule with JvmWorkerModule {
+
+  override def repositoriesTask: Task[Seq[Repository]] = Task.Anon {
+    super.repositoriesTask() :+ AndroidSdkModule.mavenGoogle
+  }
+
+  // TODO: dont have them hardcoded
+  /**
+   * Specifies the version of the Manifest Merger.
+   */
+  def manifestMergerVersion: T[String] = "31.10.0"
+  
+  /**
+   * Classpath for the manifest merger run.
+   */
+  def manifestMergerClasspath: T[Seq[PathRef]] = Task {
+    defaultResolver().classpath(
+      Seq(
+        mvn"com.android.tools.build:manifest-merger:${manifestMergerVersion()}"
+      )
+    )
+  }
+  
+  /**
+   * Creates a merged manifest from application and dependencies manifests.
+   *
+   * See [[https://developer.android.com/build/manage-manifests]] for more details.
+   */
+  def androidMergedManifest(
+                             args: Task[Seq[String]],
+                           ): Task[os.Path] = Task.Anon {
+
+    val outFile = os.temp()
+    Jvm.callProcess(
+      mainClass = "com.android.manifmerger.Merger",
+      mainArgs = args() ++ Seq("--out", outFile.toString()),
+      classPath = manifestMergerClasspath().map(_.path)
+    )
+    outFile
+  }
+  
+  lazy val millDiscover: Discover = Discover.apply[this.type]
+}
+
+object AndroidManifestMerger extends AndroidManifestMerger

--- a/libs/androidlib/src/mill/androidlib/manifestmerger/AndroidManifestMerger.scala
+++ b/libs/androidlib/src/mill/androidlib/manifestmerger/AndroidManifestMerger.scala
@@ -19,7 +19,7 @@ trait AndroidManifestMerger extends ExternalModule with JvmWorkerModule {
    * Specifies the version of the Manifest Merger.
    */
   def manifestMergerVersion: T[String] = "31.10.0"
-  
+
   /**
    * Classpath for the manifest merger run.
    */
@@ -30,15 +30,15 @@ trait AndroidManifestMerger extends ExternalModule with JvmWorkerModule {
       )
     )
   }
-  
+
   /**
    * Creates a merged manifest from application and dependencies manifests.
    *
    * See [[https://developer.android.com/build/manage-manifests]] for more details.
    */
   def androidMergedManifest(
-                             args: Task[Seq[String]],
-                           ): Task[os.Path] = Task.Anon {
+      args: Task[Seq[String]]
+  ): Task[os.Path] = Task.Anon {
 
     val outFile = os.temp()
     Jvm.callProcess(
@@ -48,7 +48,7 @@ trait AndroidManifestMerger extends ExternalModule with JvmWorkerModule {
     )
     outFile
   }
-  
+
   lazy val millDiscover: Discover = Discover.apply[this.type]
 }
 


### PR DESCRIPTION
## Motivation

During testing more android samples (compose-sample) it became apparent that the merger can conflict in 2 situations:
1. Dependency resolution: AndroidAppModule uses a separate strategy for resolving android dependencies (e.g. environment android etc) while the merger is a jvm app, running on the host machine.
2. Classpath conflicts, picking up wrong classes from the shared classloader.

## Proposed solution

I've separated the merger into its own external module, which allows it to have an independent dependency resolution strategy.

Classpath issues are also resolved with this approach.

## Bug fixes

I've noticed while experimenting for compose-samples that runClasspath is not properly evaluated (due to caching) as I've missed to make it Task.Anon, fixed in this PR