### PR TITLE
Install to both native and non-native paths in `installLocalCache`

### DIFF
--- a/dist/package.mill
+++ b/dist/package.mill
@@ -41,12 +41,14 @@ trait DistModule extends Module {
 
   val batExt = if (scala.util.Properties.isWin) ".bat" else ""
 
+  def installLocalCachePath(suffixTask: Task[String]) = Task.Anon {
+    (os.home / ".cache/mill/download" / (build.millVersion() + suffixTask() + batExt)).toString()
+  }
+
   def installLocalCache() = Task.Command {
-    val path = installLocalTask(
-      Task.Anon(
-        (os.home / ".cache/mill/download" / (build.millVersion() + cacheBinarySuffix() + batExt)).toString()
-      )
-    )()
+    val path = installLocalTask(installLocalCachePath(build.dist.cacheBinarySuffix))()
+    val path2 = installLocalTask(installLocalCachePath(build.dist.native.cacheBinarySuffix))()
+
     Task.log.streams.out.println(path.toString())
     PathRef(path)
   }


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/5262, and avoids the developer needing to tediously add a `-jvm` suffix when using their locally published version. In general people know what they last `installLocalCache`d, and there's no need to be pedantic to ask that they specify the exact correct suffix (`-jvm` or `-native` or neither) 