### PR TITLE
Improve error reporting for OS checker errors

### DIFF
--- a/core/exec/src/mill/exec/Execution.scala
+++ b/core/exec/src/mill/exec/Execution.scala
@@ -219,7 +219,6 @@ private[mill] case class Execution(
                   allTransitiveClassMethods,
                   forkExecutionContext,
                   exclusive,
-                  offline,
                   upstreamPathRefs
                 )
 

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -34,6 +34,7 @@ private trait GroupExecution {
   def exclusiveSystemStreams: SystemStreams
   def getEvaluator: () => EvaluatorApi
   def headerData: String
+  def offline: Boolean
   lazy val parsedHeaderData: Map[String, ujson.Value] = {
     import org.snakeyaml.engine.v2.api.{Load, LoadSettings}
     val loaded = new Load(LoadSettings.builder().build()).loadFromString(headerData)
@@ -89,7 +90,6 @@ private trait GroupExecution {
       allTransitiveClassMethods: Map[Class[?], Map[String, Method]],
       executionContext: mill.define.TaskCtx.Fork.Api,
       exclusive: Boolean,
-      offline: Boolean,
       upstreamPathRefs: Seq[PathRef]
   ): GroupExecution.Results = {
     logger.withPromptLine {
@@ -186,11 +186,9 @@ private trait GroupExecution {
                       logger = logger,
                       executionContext = executionContext,
                       exclusive = exclusive,
-                      isCommand = labelled.isInstanceOf[Task.Command[?]],
-                      isInput = labelled.isInstanceOf[Task.Input[?]],
                       deps = deps,
-                      offline = offline,
-                      upstreamPathRefs = upstreamPathRefs
+                      upstreamPathRefs = upstreamPathRefs,
+                      terminal = labelled
                     )
 
                   val (valueHash, serializedPaths) = newResults(labelled) match {
@@ -233,11 +231,9 @@ private trait GroupExecution {
             logger = logger,
             executionContext = executionContext,
             exclusive = exclusive,
-            isCommand = task.isInstanceOf[Task.Command[?]],
-            isInput = task.isInstanceOf[Task.Input[?]],
             deps = deps,
-            offline = offline,
-            upstreamPathRefs = upstreamPathRefs
+            upstreamPathRefs = upstreamPathRefs,
+            terminal = terminal
           )
           GroupExecution.Results(
             newResults,
@@ -265,13 +261,10 @@ private trait GroupExecution {
       logger: mill.api.Logger,
       executionContext: mill.define.TaskCtx.Fork.Api,
       exclusive: Boolean,
-      isCommand: Boolean,
-      isInput: Boolean,
       deps: Seq[Task[?]],
-      offline: Boolean,
-      upstreamPathRefs: Seq[PathRef]
+      upstreamPathRefs: Seq[PathRef],
+      terminal: Task[?]
   ): (Map[Task[?], ExecResult[(Val, Int)]], mutable.Buffer[Task[?]]) = {
-
     val newEvaluated = mutable.Buffer.empty[Task[?]]
     val newResults = mutable.Map.empty[Task[?], ExecResult[(Val, Int)]]
 
@@ -318,15 +311,14 @@ private trait GroupExecution {
             workspace,
             validWriteDests,
             validReadDests,
-            isCommand,
-            isInput,
             exclusive,
             multiLogger,
             logger,
             exclusiveSystemStreams,
             counterMsg,
             destCreator,
-            getEvaluator().asInstanceOf[Evaluator]
+            getEvaluator().asInstanceOf[Evaluator],
+            terminal
           ) {
             try {
               task.evaluate(args) match {
@@ -532,23 +524,24 @@ private object GroupExecution {
       workspace: os.Path,
       validWriteDests: Seq[os.Path],
       validReadDests: Seq[os.Path],
-      isCommand: Boolean,
-      isInput: Boolean,
       exclusive: Boolean,
       multiLogger: Logger,
       logger: Logger,
       exclusiveSystemStreams: SystemStreams,
       counterMsg: String,
       destCreator: DestCreator,
-      evaluator: Evaluator
+      evaluator: Evaluator,
+      terminal: Task[?]
   )(t: => T): T = {
+    val isCommand = terminal.isInstanceOf[Task.Command[?]]
+    val isInput = terminal.isInstanceOf[Task.Input[?]]
     val executionChecker = new os.Checker {
       def onRead(path: os.ReadablePath): Unit = path match {
         case path: os.Path =>
           if (!isCommand && !isInput) {
             if (path.startsWith(workspace) && !validReadDests.exists(path.startsWith(_))) {
               sys.error(
-                s"Reading from ${path.relativeTo(workspace)} not allowed during execution phase"
+                s"Reading from ${path.relativeTo(workspace)} not allowed during execution of `$terminal`"
               )
             }
           }
@@ -559,7 +552,7 @@ private object GroupExecution {
         if (!isCommand) {
           if (path.startsWith(workspace) && !validWriteDests.exists(path.startsWith(_))) {
             sys.error(
-              s"Writing to ${path.relativeTo(workspace)} not allowed during execution phase"
+              s"Writing to ${path.relativeTo(workspace)} not allowed during execution of `$terminal`"
             )
           }
         }

--- a/example/depth/sandbox/1-task/build.mill
+++ b/example/depth/sandbox/1-task/build.mill
@@ -29,7 +29,7 @@ def bannedWriteTask = Task {
 
 /** Usage
 > ./mill bannedWriteTask
-error: ...Writing to banned-path not allowed during execution phase
+error: ...Writing to banned-path not allowed during execution of `bannedWriteTask`
 */
 
 def bannedReadTask = Task {
@@ -38,7 +38,7 @@ def bannedReadTask = Task {
 
 /** Usage
 > ./mill bannedReadTask
-error: ...Reading from build.mill not allowed during execution phase
+error: ...Reading from build.mill not allowed during execution of `bannedReadTask`
 */
 
 def bannedReadTask2 = Task {
@@ -47,7 +47,7 @@ def bannedReadTask2 = Task {
 
 /** Usage
 > ./mill bannedReadTask2
-error: ...Reading from out/foo/tDestTask.json not allowed during execution phase
+error: ...Reading from out/foo/tDestTask.json not allowed during execution of `bannedReadTask2`
 */
 
 // === Task `os.pwd` redirection

--- a/integration/failure/os-checker/src/OsCheckerTests.scala
+++ b/integration/failure/os-checker/src/OsCheckerTests.scala
@@ -19,7 +19,7 @@ object OsCheckerTests extends UtestIntegrationTestSuite {
 
       assert(res2.isSuccess == false)
       assert(res2.err.contains(
-        s"Writing to file.txt not allowed during execution phase"
+        s"Writing to file.txt not allowed during execution of `qux`"
       ))
 
       tester.modifyFile(workspacePath / "build.mill", _.replace("if (false)", "if (true)"))


### PR DESCRIPTION
Prints the name of the task in the error message, so it's more clear what the problem is.

Noticed when investigating https://github.com/com-lihaoyi/mill/issues/5248