### PR TITLE
Don't send onBuildShowMessage upon simple compilation errors

### DIFF
--- a/integration/ide/bsp-server/resources/project/build.mill
+++ b/integration/ide/bsp-server/resources/project/build.mill
@@ -38,13 +38,20 @@ object app extends scalalib.JavaModule {
   )
 }
 
-object errored extends scalalib.ScalaModule {
-  def scalaVersion = Option(System.getenv("TEST_SCALA_2_13_VERSION")).getOrElse(???)
+object errored extends Module {
 
-  def compile = Task {
-    val res = super.compile()
-    sys.error("nope")
-    res
+  object exception extends scalalib.ScalaModule {
+    def scalaVersion = Option(System.getenv("TEST_SCALA_2_13_VERSION")).getOrElse(???)
+
+    def compile = Task {
+      val res = super.compile()
+      sys.error("nope")
+      res
+    }
+  }
+
+  object `compilation-error` extends scalalib.ScalaModule {
+    def scalaVersion = Option(System.getenv("TEST_SCALA_2_13_VERSION")).getOrElse(???)
   }
 }
 

--- a/integration/ide/bsp-server/resources/project/errored/compilation-error/src/Thing.scala
+++ b/integration/ide/bsp-server/resources/project/errored/compilation-error/src/Thing.scala
@@ -1,0 +1,3 @@
+object Thing {
+  nope
+}

--- a/integration/ide/bsp-server/resources/snapshots/logging
+++ b/integration/ide/bsp-server/resources/snapshots/logging
@@ -23,9 +23,9 @@
 [4-compile] Entered buildTargetCompile
 [4-compile] Evaluating 1 task
 [4-compile] * tasks failed
-[4-compile] errored.compile java.lang.RuntimeException: nope
+[4-compile] errored.exception.compile java.lang.RuntimeException: nope
 [4-compile]     scala.sys.package$.error(package.scala:*)
-[4-compile]     build_.package_.build_$package_$errored$$$_$compile$$anonfun$1$$anonfun$1(build.mill:*)
+[4-compile]     build_.package_.build_*(build.mill:*)
 [4-compile]     mill.define.Task$Named.evaluate(Task.scala:*)
 [4-compile]     mill.define.Task$Named.evaluate$(Task.scala:*)
 [4-compile]     mill.define.Task$Computed.evaluate(Task.scala:*)
@@ -33,9 +33,18 @@
 [4-compile] buildTargetCompile took * msec
 [5-compile] Entered buildTargetCompile
 [5-compile] Evaluating 1 task
+[5-compile-*] [info] compiling 1 Scala source to * ...
+[5-compile-*] [error] */errored/compilation-error/src/Thing.scala:2:3: not found: value nope
+[5-compile-*] [error]   nope
+[5-compile-*] [error]   ^
+[5-compile-*] [error] one error found
 [5-compile] Done
 [5-compile] buildTargetCompile took * msec
-[7-buildShutdown] Entered buildShutdown
-[8-onBuildExit] Entered onBuildExit
+[6-compile] Entered buildTargetCompile
+[6-compile] Evaluating 1 task
+[6-compile] Done
+[6-compile] buildTargetCompile took * msec
+[8-buildShutdown] Entered buildShutdown
+[9-onBuildExit] Entered onBuildExit
 [bsp] BSP session returned with mill.api.internal.bsp.BspServerResult$Shutdown$@*
 [bsp] Exiting BSP runner loop. Stopping BSP server. Last result: Success(mill.api.internal.bsp.BspServerResult$Shutdown$@*)

--- a/integration/ide/bsp-server/resources/snapshots/workspace-build-targets.json
+++ b/integration/ide/bsp-server/resources/snapshots/workspace-build-targets.json
@@ -72,10 +72,50 @@
     },
     {
       "id": {
-        "uri": "file:///workspace/errored"
+        "uri": "file:///workspace/errored/compilation-error"
       },
-      "displayName": "errored",
-      "baseDirectory": "file:///workspace/errored",
+      "displayName": "errored.compilation-error",
+      "baseDirectory": "file:///workspace/errored/compilation-error",
+      "tags": [
+        "library",
+        "application"
+      ],
+      "languageIds": [
+        "java",
+        "scala"
+      ],
+      "dependencies": [],
+      "capabilities": {
+        "canCompile": true,
+        "canTest": false,
+        "canRun": true,
+        "canDebug": false
+      },
+      "dataKind": "scala",
+      "data": {
+        "scalaOrganization": "org.scala-lang",
+        "scalaVersion": "<scala-version>",
+        "scalaBinaryVersion": "2.13",
+        "platform": 1,
+        "jars": [
+          "file:///coursier-cache/https/repo1.maven.org/maven2/org/scala-lang/scala-compiler/<scala-version>/scala-compiler-<scala-version>.jar",
+          "file:///coursier-cache/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/<scala-version>/scala-reflect-<scala-version>.jar",
+          "file:///coursier-cache/https/repo1.maven.org/maven2/org/scala-lang/scala-library/<scala-version>/scala-library-<scala-version>.jar",
+          "file:///coursier-cache/https/repo1.maven.org/maven2/io/github/java-diff-utils/java-diff-utils/<java-diff-utils-version>/java-diff-utils-<java-diff-utils-version>.jar",
+          "file:///coursier-cache/https/repo1.maven.org/maven2/org/jline/jline/<jline-version>/jline-<jline-version>-jdk8.jar"
+        ],
+        "jvmBuildTarget": {
+          "javaHome": "java-home",
+          "javaVersion": "<java-version>"
+        }
+      }
+    },
+    {
+      "id": {
+        "uri": "file:///workspace/errored/exception"
+      },
+      "displayName": "errored.exception",
+      "baseDirectory": "file:///workspace/errored/exception",
       "tags": [
         "library",
         "application"

--- a/integration/ide/bsp-server/src/BspServerTests.scala
+++ b/integration/ide/bsp-server/src/BspServerTests.scala
@@ -114,7 +114,8 @@ object BspServerTests extends UtestIntegrationTestSuite {
         val targetIds = buildTargets
           .getTargets
           .asScala
-          .filter(_.getDisplayName != "errored")
+          .filter(_.getDisplayName != "errored.exception")
+          .filter(_.getDisplayName != "errored.compilation-error")
           .filter(_.getDisplayName != "delayed")
           .map(_.getId)
           .asJava
@@ -296,7 +297,13 @@ object BspServerTests extends UtestIntegrationTestSuite {
 
         buildServer.buildTargetCompile(
           new b.CompileParams(
-            targets.filter(_.getDisplayName == "errored").map(_.getId).asJava
+            targets.filter(_.getDisplayName == "errored.exception").map(_.getId).asJava
+          )
+        ).get()
+
+        buildServer.buildTargetCompile(
+          new b.CompileParams(
+            targets.filter(_.getDisplayName == "errored.compilation-error").map(_.getId).asJava
           )
         ).get()
 
@@ -311,7 +318,7 @@ object BspServerTests extends UtestIntegrationTestSuite {
         )
         val erroredCompileFuture = buildServer.buildTargetCompile(
           new b.CompileParams(
-            targets.filter(_.getDisplayName == "errored").map(_.getId).asJava
+            targets.filter(_.getDisplayName == "errored.exception").map(_.getId).asJava
           )
         )
         erroredCompileFuture.cancel(true)
@@ -323,7 +330,7 @@ object BspServerTests extends UtestIntegrationTestSuite {
         .filter(_.startsWith("["))
         .mkString
 
-      val expectedCancelledLine = "[6-compile] buildTargetCompile was cancelled"
+      val expectedCancelledLine = "[7-compile] buildTargetCompile was cancelled"
 
       assert(logs.linesIterator.contains(expectedCancelledLine))
 
@@ -347,7 +354,8 @@ object BspServerTests extends UtestIntegrationTestSuite {
         (message.getType, message.getMessage)
       }
       val expectedMessages = Seq(
-        (b.MessageType.ERROR, "Compiling errored failed, see Mill logs for more details")
+        // no message for errored.compilation-error, compilation diagnostics are enough
+        (b.MessageType.ERROR, "Compiling errored.exception failed, see Mill logs for more details")
       )
       assert(expectedMessages == messages0)
     }

--- a/runner/bsp/worker/src/mill/bsp/worker/BspCompileProblemReporter.scala
+++ b/runner/bsp/worker/src/mill/bsp/worker/BspCompileProblemReporter.scala
@@ -32,6 +32,8 @@ private class BspCompileProblemReporter(
   private var errors = 0
   private var warnings = 0
 
+  def hasErrors: Boolean = errors > 0
+
   object diagnostics {
     private val map = mutable.Map.empty[TextDocumentIdentifier, java.util.List[Diagnostic]]
     def add(textDocument: TextDocumentIdentifier, diagnostic: Diagnostic): Unit =

--- a/runner/bsp/worker/src/mill/bsp/worker/Utils.scala
+++ b/runner/bsp/worker/src/mill/bsp/worker/Utils.scala
@@ -30,7 +30,7 @@ private object Utils {
       originId: String,
       bspIdsByModule: Map[BspModuleApi, BuildTargetIdentifier],
       client: BuildClient
-  ): Int => Option[CompileProblemReporter] = { (moduleHashCode: Int) =>
+  ): Int => Option[BspCompileProblemReporter] = { (moduleHashCode: Int) =>
     bspIdsByModule.find(_._1.hashCode == moduleHashCode).map {
       case (module: JavaModuleApi, targetId) =>
         val buildTarget = module.bspBuildTarget


### PR DESCRIPTION
This fixes a regression from #5200. Since #5200, if the code base doesn't compile, an error notification was shown to users via `onBuildShowMessage` (dismiss-able notification in the lower right corner of the window in VSCode). This PR makes Mill stop doing that, but keeps showing such a notification if the compile request goes wrong for another reason (like a failing intermediate task - behavior introduced in #5200).