### PR TITLE
Improve error message for discover parens checks

### DIFF
--- a/core/define/src/mill/define/Discover.scala
+++ b/core/define/src/mill/define/Discover.scala
@@ -90,8 +90,9 @@ object Discover {
               returnType <:< tt && !(returnType <:< TypeRepr.of[Nothing])
             }
             .foreach { case (tt, n, label) =>
+
               if (m.paramSymss.length != n) report.errorAndAbort(
-                s"$label definitions must have $n parameter list" + (if (n == 1) "" else "s"),
+                s"$label definition `$m` must have $n parameter list" + (if (n == 1) "" else "s"),
                 m.pos.getOrElse(Position.ofMacroExpansion)
               )
             }
@@ -128,7 +129,7 @@ object Discover {
             curCls,
             declMethods,
             (TypeRepr.of[Task.Command[?]], 1, "`Task.Command`"),
-            (TypeRepr.of[Task.Simple[?]], 0, "Target")
+            (TypeRepr.of[Task.Simple[?]], 0, "Task")
           )
 
           val names =

--- a/core/define/src/mill/define/TaskCtx.scala
+++ b/core/define/src/mill/define/TaskCtx.scala
@@ -55,7 +55,7 @@ object TaskCtx {
   }
 
   @compileTimeOnly(
-    "Task.ctx() / Task.* APIs can only be used with a Task{...} block"
+    "Task.ctx() / Task.* APIs can only be used within a Task{...} block"
   )
   @ImplicitStub
   implicit def taskCtx: TaskCtx = ???

--- a/core/define/src/mill/define/internal/Applicative.scala
+++ b/core/define/src/mill/define/internal/Applicative.scala
@@ -18,7 +18,7 @@ import scala.quoted.*
 object Applicative {
 
   trait Applyable[M[+_], +T] { this: M[T] =>
-    @compileTimeOnly("Target#apply() can only be used with a Task{...} block")
+    @compileTimeOnly("Task#apply() can only be used within a Task{...} block")
     def apply(): T = ???
   }
 
@@ -76,7 +76,7 @@ object Applicative {
               val sym = x.symbol
               if (sym != Symbol.noSymbol && defs(sym) && !localDefs(sym)) {
                 macroError(
-                  "Target#apply() call cannot use `" + x.symbol + "` defined within the Task{...} block",
+                  "Task#apply() call cannot use `" + x.symbol + "` defined within the Task{...} block",
                   x.pos
                 )
               }

--- a/core/define/test/src/mill/define/ApplicativeTests.scala
+++ b/core/define/test/src/mill/define/ApplicativeTests.scala
@@ -15,7 +15,7 @@ object ApplicativeTests extends TestSuite {
       value
     }
   }
-  @compileTimeOnly("Task.ctx() can only be used with a Task{...} block")
+  @compileTimeOnly("Task.ctx() can only be used within a Task{...} block")
   @ImplicitStub
   implicit def taskCtx: String = ???
 

--- a/core/define/test/src/mill/define/MacroErrorTests.scala
+++ b/core/define/test/src/mill/define/MacroErrorTests.scala
@@ -24,12 +24,12 @@ object MacroErrorTests extends TestSuite {
           mill.define.Discover[foo.type]
         """)
         assert(
-          e.msg.contains("`Task.Command` definitions must have 1 parameter list"),
+          e.msg.contains("`Task.Command` definition `method w` must have 1 parameter list"),
           e.pos.contains("def w = ")
         )
       }
 
-      test("target") {
+      test("task") {
         val e = compileError("""
           object foo extends TestRootModule{
             def x() = Task {1}
@@ -38,7 +38,7 @@ object MacroErrorTests extends TestSuite {
           mill.define.Discover[foo.type]
         """)
         assert(
-          e.msg.contains("Target definitions must have 0 parameter lists"),
+          e.msg.contains("Task definition `method x` must have 0 parameter lists"),
           e.pos.contains("def x() = ")
         )
       }
@@ -51,7 +51,7 @@ object MacroErrorTests extends TestSuite {
           mill.define.Discover[foo.type]
         """)
         assert(
-          e.msg.contains("Target definitions must have 0 parameter lists"),
+          e.msg.contains("Task definition `method y` must have 0 parameter lists"),
           e.pos.contains("def y() = ")
         )
       }
@@ -64,7 +64,7 @@ object MacroErrorTests extends TestSuite {
           mill.define.Discover[foo.type]
         """)
         assert(
-          e.msg.contains("Target definitions must have 0 parameter lists"),
+          e.msg.contains("Task definition `method z` must have 0 parameter lists"),
           e.pos.contains("def z() = ")
         )
       }
@@ -77,14 +77,14 @@ object MacroErrorTests extends TestSuite {
           mill.define.Discover[foo.type]
         """)
         assert(
-          e.msg.contains("Target definitions must have 0 parameter lists"),
+          e.msg.contains("Task definition `method a` must have 0 parameter lists"),
           e.pos.contains("def a() = ")
         )
       }
     }
     test("badTmacro") {
       // Make sure we can reference values from outside the Task{...} block as part
-      // of our `Target#apply()` calls, but we cannot reference any values that
+      // of our `Task#apply()` calls, but we cannot reference any values that
       // come from inside the Task{...} block
       test("pos") {
         // This should compile
@@ -116,7 +116,7 @@ object MacroErrorTests extends TestSuite {
       test("neg3") {
 
         val expectedMsg =
-          "Target#apply() call cannot use `val n` defined within the Task{...} block"
+          "Task#apply() call cannot use `val n` defined within the Task{...} block"
         val err = compileError("""
           object foo extends TestRootModule{
             def a = Task { 1 }
@@ -135,7 +135,7 @@ object MacroErrorTests extends TestSuite {
       test("neg4") {
 
         val expectedMsg =
-          "Target#apply() call cannot use `val x` defined within the Task{...} block"
+          "Task#apply() call cannot use `val x` defined within the Task{...} block"
         val err = compileError("""
           object foo extends TestRootModule{
             def a = Task { 1 }


### PR DESCRIPTION
Print the name of the task method which is at fault, so it's easier for the user to figure out which method is being problematic