### PR TITLE
Sort resolve output with modules first, then commands, then other tasks

### DIFF
--- a/core/resolve/src/mill/resolve/Resolve.scala
+++ b/core/resolve/src/mill/resolve/Resolve.scala
@@ -366,19 +366,19 @@ private[mill] trait Resolve[T] {
         case ResolveCore.Error(value) => Result.Failure(value)
       }
 
-    resolved
-      .flatMap(r =>
-        handleResolved(
-          rootModule,
-          r.sortBy(_.segments),
-          args,
-          sel,
-          nullCommandDefaults,
-          allowPositionalCommandArgs,
-          resolveToModuleTasks,
-          cache = cache
-        )
+    resolved.flatMap { r =>
+      val sorted = r.sorted
+      handleResolved(
+        rootModule,
+        sorted,
+        args,
+        sel,
+        nullCommandDefaults,
+        allowPositionalCommandArgs,
+        resolveToModuleTasks,
+        cache = cache
       )
+    }
   }
 
   private[mill] def deduplicate(items: List[T]): List[T] = items

--- a/core/resolve/src/mill/resolve/ResolveCore.scala
+++ b/core/resolve/src/mill/resolve/ResolveCore.scala
@@ -27,9 +27,24 @@ private object ResolveCore {
   }
 
   object Resolved {
+    implicit object resolvedOrder extends Ordering[Resolved] {
+      def orderingKey(r: Resolved) = r match {
+        case _: Module => 1
+        case _: Command => 2
+        case _: NamedTask => 3
+      }
+
+      override def compare(x: Resolved, y: Resolved): Int = {
+        val keyX = orderingKey(x)
+        val keyY = orderingKey(y)
+        if (keyX == keyY) Segments.ordering.compare(x.segments, y.segments)
+        else Ordering.Int.compare(keyX, keyY)
+      }
+    }
+
     case class Module(segments: Segments, cls: Class[?]) extends Resolved
-    case class NamedTask(segments: Segments) extends Resolved
     case class Command(segments: Segments) extends Resolved
+    case class NamedTask(segments: Segments) extends Resolved
   }
 
   sealed trait Result

--- a/core/resolve/test/src/mill/resolve/ErrorTests.scala
+++ b/core/resolve/test/src/mill/resolve/ErrorTests.scala
@@ -375,12 +375,12 @@ object ErrorTests extends TestSuite {
               "",
               "myCross",
               "myCross[1]",
-              "myCross[1].foo",
               "myCross[2]",
-              "myCross[2].foo",
               "myCross[3]",
-              "myCross[3].foo",
               "myCross[4]",
+              "myCross[1].foo",
+              "myCross[2].foo",
+              "myCross[3].foo",
               "myCross[4].foo"
             ))
           )

--- a/libs/main/src/mill/main/MainModule.scala
+++ b/libs/main/src/mill/main/MainModule.scala
@@ -42,7 +42,7 @@ trait MainModule extends BaseModule with MainModuleApi {
 
       resolved.map { resolvedSegmentsList =>
         val resolvedStrings = resolvedSegmentsList.map(_.render)
-        resolvedStrings.sorted.foreach(println)
+        resolvedStrings.foreach(println)
         resolvedStrings
       }
     }


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/5280

We can improve the pretty-printing out `resolve` output later, but this at least gives some kind of meaningful ordering so e.g. `resolve _` shows the stuff you probably care most about at the top