### PR TITLE
Move internal task into dedicated `GenIDeaModuleInternal` module

### DIFF
--- a/core/api/src/mill/api/internal/JavaModuleApi.scala
+++ b/core/api/src/mill/api/internal/JavaModuleApi.scala
@@ -1,10 +1,10 @@
 package mill.api.internal
 
 import mill.api.internal.bsp.BspJavaModuleApi
-import mill.api.internal.idea.ResolvedModule
+import mill.api.internal.idea.{GenIdeaModuleApi, GenIdeaModuleInternalApi}
 import mill.api.internal.{EvaluatorApi, ModuleApi, TaskApi, UnresolvedPathApi}
 
-trait JavaModuleApi extends ModuleApi {
+trait JavaModuleApi extends ModuleApi with GenIdeaModuleApi {
 
   def recursiveModuleDeps: Seq[JavaModuleApi]
 
@@ -14,20 +14,6 @@ trait JavaModuleApi extends ModuleApi {
 
   def javacOptions: TaskApi[Seq[String]]
   def mandatoryJavacOptions: TaskApi[Seq[String]]
-
-  // IDEA tasks
-
-  def skipIdea: Boolean
-
-  // FIXME: Move to internal trait like we do for BSP tasks
-  private[mill] def genIdeaMetadata(
-      ideaConfigVersion: Int,
-      evaluator: EvaluatorApi,
-      path: mill.api.Segments
-  ): TaskApi[ResolvedModule]
-
-  // FIXME: Move to internal trait like we do for BSP tasks
-  private[mill] def intellijModulePathJava: java.nio.file.Path
 
   // BSP Tasks that sometimes need to be customized
 
@@ -46,6 +32,12 @@ trait JavaModuleApi extends ModuleApi {
    * Internal access to some BSP helper tasks
    */
   private[mill] def bspJavaModule: () => BspJavaModuleApi
+
+  /**
+   * Internal access to some GenIdea helper tasks
+   */
+  private[mill] def genIdeaModuleInternal: () => GenIdeaModuleInternalApi
+
 }
 
 object JavaModuleApi

--- a/core/api/src/mill/api/internal/idea/GenIdeaModuleApi.scala
+++ b/core/api/src/mill/api/internal/idea/GenIdeaModuleApi.scala
@@ -1,0 +1,11 @@
+package mill.api.internal.idea
+
+trait GenIdeaModuleApi {
+
+  def skipIdea: Boolean
+
+  private[mill] def intellijModulePathJava: java.nio.file.Path
+
+}
+
+

--- a/core/api/src/mill/api/internal/idea/GenIdeaModuleInternalApi.scala
+++ b/core/api/src/mill/api/internal/idea/GenIdeaModuleInternalApi.scala
@@ -1,0 +1,15 @@
+package mill.api.internal.idea
+
+import mill.api.internal.{EvaluatorApi, PathRefApi, TaskApi}
+
+trait GenIdeaModuleInternalApi {
+
+  private[mill] def genIdeaMetadata(
+      ideaConfigVersion: Int,
+      evaluator: EvaluatorApi,
+      path: mill.api.Segments
+  ): TaskApi[ResolvedModule]
+
+  private[mill] def ideaCompileOutput: TaskApi[PathRefApi]
+
+}

--- a/core/api/src/mill/api/internal/idea/IdeaConfigFile.scala
+++ b/core/api/src/mill/api/internal/idea/IdeaConfigFile.scala
@@ -15,7 +15,7 @@ final case class IdeaConfigFile(
     config: Seq[Element]
 ) {
   // An empty component name meas we contribute a whole file
-  // If we have a fill file, we only accept a single root xml node.
+  // If we have a full file, we only accept a single root xml node.
   require(
     component.forall(_.nonEmpty) && (component.nonEmpty || config.size == 1),
     "Files contributions must have exactly one root element."

--- a/integration/ide/gen-idea/resources/extended/idea/mill_modules/helloworld.iml
+++ b/integration/ide/gen-idea/resources/extended/idea/mill_modules/helloworld.iml
@@ -1,6 +1,6 @@
 <module type="JAVA_MODULE" version="4">
     <component name="NewModuleRootManager">
-        <output url="file://$MODULE_DIR$/../../out/HelloWorld/ideaCompileOutput.dest/classes"/>
+        <output url="file://$MODULE_DIR$/../../out/HelloWorld/internalGenIdeaModule/ideaCompileOutput.dest/classes"/>
         <exclude-output/>
         <content url="file://$MODULE_DIR$/../../out/HelloWorld/generatedSources.dest/classes">
             <sourceFolder url="file://$MODULE_DIR$/../../out/HelloWorld/generatedSources.dest/classes" isTestSource="false" generated="true"/>

--- a/integration/ide/gen-idea/resources/extended/idea/mill_modules/helloworld.subscala3.iml
+++ b/integration/ide/gen-idea/resources/extended/idea/mill_modules/helloworld.subscala3.iml
@@ -1,6 +1,6 @@
 <module type="JAVA_MODULE" version="4">
     <component name="NewModuleRootManager">
-        <output url="file://$MODULE_DIR$/../../out/HelloWorld/subScala3/ideaCompileOutput.dest/classes"/>
+        <output url="file://$MODULE_DIR$/../../out/HelloWorld/subScala3/internalGenIdeaModule/ideaCompileOutput.dest/classes"/>
         <exclude-output/>
         <content url="file://$MODULE_DIR$/../../HelloWorld/subScala3">
             <sourceFolder url="file://$MODULE_DIR$/../../HelloWorld/subScala3/src" isTestSource="false"/>

--- a/integration/ide/gen-idea/resources/extended/idea/mill_modules/helloworld.test.iml
+++ b/integration/ide/gen-idea/resources/extended/idea/mill_modules/helloworld.test.iml
@@ -1,6 +1,6 @@
 <module type="JAVA_MODULE" version="4">
     <component name="NewModuleRootManager">
-        <output-test url="file://$MODULE_DIR$/../../out/HelloWorld/test/ideaCompileOutput.dest/classes"/>
+        <output-test url="file://$MODULE_DIR$/../../out/HelloWorld/test/internalGenIdeaModule/ideaCompileOutput.dest/classes"/>
         <exclude-output/>
         <content url="file://$MODULE_DIR$/../../HelloWorld/test">
             <sourceFolder url="file://$MODULE_DIR$/../../HelloWorld/test/src" isTestSource="true"/>

--- a/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.iml
+++ b/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.iml
@@ -1,6 +1,6 @@
 <module type="JAVA_MODULE" version="4">
     <component name="NewModuleRootManager">
-        <output url="file://$MODULE_DIR$/../../out/mill-build/ideaCompileOutput.dest/classes"/>
+        <output url="file://$MODULE_DIR$/../../out/mill-build/internalGenIdeaModule/ideaCompileOutput.dest/classes"/>
         <exclude-output/>
         <content url="file://$MODULE_DIR$/../..">
             <sourceFolder url="file://$MODULE_DIR$/../../out/mill-build/generatedScriptSources.dest/support" isTestSource="false" generated="true"/>

--- a/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.mill-build.iml
+++ b/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.mill-build.iml
@@ -1,6 +1,6 @@
 <module type="JAVA_MODULE" version="4">
     <component name="NewModuleRootManager">
-        <output url="file://$MODULE_DIR$/../../out/mill-build/mill-build/ideaCompileOutput.dest/classes"/>
+        <output url="file://$MODULE_DIR$/../../out/mill-build/mill-build/internalGenIdeaModule/ideaCompileOutput.dest/classes"/>
         <exclude-output/>
         <content url="file://$MODULE_DIR$/../../out/mill-build/mill-build/generatedScriptSources.dest/support">
             <sourceFolder url="file://$MODULE_DIR$/../../out/mill-build/mill-build/generatedScriptSources.dest/support" isTestSource="false" generated="true"/>

--- a/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/helloidea.iml
+++ b/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/helloidea.iml
@@ -1,6 +1,6 @@
 <module type="JAVA_MODULE" version="4">
     <component name="NewModuleRootManager">
-        <output url="file://$MODULE_DIR$/../../out/HelloIdea/ideaCompileOutput.dest/classes"/>
+        <output url="file://$MODULE_DIR$/../../out/HelloIdea/internalGenIdeaModule/ideaCompileOutput.dest/classes"/>
         <exclude-output/>
         <content url="file://$MODULE_DIR$/../../HelloIdea">
             <sourceFolder url="file://$MODULE_DIR$/../../HelloIdea/src" isTestSource="false"/>

--- a/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/helloidea.scala3.iml
+++ b/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/helloidea.scala3.iml
@@ -1,6 +1,6 @@
 <module type="JAVA_MODULE" version="4">
     <component name="NewModuleRootManager">
-        <output url="file://$MODULE_DIR$/../../out/HelloIdea/scala3/ideaCompileOutput.dest/classes"/>
+        <output url="file://$MODULE_DIR$/../../out/HelloIdea/scala3/internalGenIdeaModule/ideaCompileOutput.dest/classes"/>
         <exclude-output/>
         <content url="file://$MODULE_DIR$/../../HelloIdea/scala3">
             <sourceFolder url="file://$MODULE_DIR$/../../HelloIdea/scala3/src" isTestSource="false"/>

--- a/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/helloidea.scala3.test.iml
+++ b/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/helloidea.scala3.test.iml
@@ -1,6 +1,6 @@
 <module type="JAVA_MODULE" version="4">
     <component name="NewModuleRootManager">
-        <output-test url="file://$MODULE_DIR$/../../out/HelloIdea/scala3/test/ideaCompileOutput.dest/classes"/>
+        <output-test url="file://$MODULE_DIR$/../../out/HelloIdea/scala3/test/internalGenIdeaModule/ideaCompileOutput.dest/classes"/>
         <exclude-output/>
         <content url="file://$MODULE_DIR$/../../HelloIdea/scala3/test">
             <sourceFolder url="file://$MODULE_DIR$/../../HelloIdea/scala3/test/src" isTestSource="true"/>

--- a/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/helloidea.test.iml
+++ b/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/helloidea.test.iml
@@ -1,6 +1,6 @@
 <module type="JAVA_MODULE" version="4">
     <component name="NewModuleRootManager">
-        <output-test url="file://$MODULE_DIR$/../../out/HelloIdea/test/ideaCompileOutput.dest/classes"/>
+        <output-test url="file://$MODULE_DIR$/../../out/HelloIdea/test/internalGenIdeaModule/ideaCompileOutput.dest/classes"/>
         <exclude-output/>
         <content url="file://$MODULE_DIR$/../../HelloIdea/test">
             <sourceFolder url="file://$MODULE_DIR$/../../HelloIdea/test/src" isTestSource="true"/>

--- a/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/helloideajs.iml
+++ b/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/helloideajs.iml
@@ -1,6 +1,6 @@
 <module type="JAVA_MODULE" version="4">
     <component name="NewModuleRootManager">
-        <output url="file://$MODULE_DIR$/../../out/HelloIdeaJs/ideaCompileOutput.dest/classes"/>
+        <output url="file://$MODULE_DIR$/../../out/HelloIdeaJs/internalGenIdeaModule/ideaCompileOutput.dest/classes"/>
         <exclude-output/>
         <content url="file://$MODULE_DIR$/../../HelloIdeaJs">
             <sourceFolder url="file://$MODULE_DIR$/../../HelloIdeaJs/src" isTestSource="false"/>

--- a/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/helloideajs.test.iml
+++ b/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/helloideajs.test.iml
@@ -1,6 +1,6 @@
 <module type="JAVA_MODULE" version="4">
     <component name="NewModuleRootManager">
-        <output-test url="file://$MODULE_DIR$/../../out/HelloIdeaJs/test/ideaCompileOutput.dest/classes"/>
+        <output-test url="file://$MODULE_DIR$/../../out/HelloIdeaJs/test/internalGenIdeaModule/ideaCompileOutput.dest/classes"/>
         <exclude-output/>
         <content url="file://$MODULE_DIR$/../../HelloIdeaJs/test">
             <sourceFolder url="file://$MODULE_DIR$/../../HelloIdeaJs/test/src" isTestSource="true"/>

--- a/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/mill-build.iml
+++ b/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/mill-build.iml
@@ -1,6 +1,6 @@
 <module type="JAVA_MODULE" version="4">
     <component name="NewModuleRootManager">
-        <output url="file://$MODULE_DIR$/../../out/mill-build/ideaCompileOutput.dest/classes"/>
+        <output url="file://$MODULE_DIR$/../../out/mill-build/internalGenIdeaModule/ideaCompileOutput.dest/classes"/>
         <exclude-output/>
         <content url="file://$MODULE_DIR$/../..">
             <sourceFolder url="file://$MODULE_DIR$/../../out/mill-build/generatedScriptSources.dest/support" isTestSource="false" generated="true"/>

--- a/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/modulea.iml
+++ b/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/modulea.iml
@@ -1,6 +1,6 @@
 <module type="JAVA_MODULE" version="4">
     <component name="NewModuleRootManager">
-        <output url="file://$MODULE_DIR$/../../out/moduleA/ideaCompileOutput.dest/classes"/>
+        <output url="file://$MODULE_DIR$/../../out/moduleA/internalGenIdeaModule/ideaCompileOutput.dest/classes"/>
         <exclude-output/>
         <content url="file://$MODULE_DIR$/../../moduleA">
             <sourceFolder url="file://$MODULE_DIR$/../../moduleA/src" isTestSource="false"/>

--- a/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/moduleb.iml
+++ b/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/moduleb.iml
@@ -1,6 +1,6 @@
 <module type="JAVA_MODULE" version="4">
     <component name="NewModuleRootManager">
-        <output url="file://$MODULE_DIR$/../../out/moduleB/ideaCompileOutput.dest/classes"/>
+        <output url="file://$MODULE_DIR$/../../out/moduleB/internalGenIdeaModule/ideaCompileOutput.dest/classes"/>
         <exclude-output/>
         <content url="file://$MODULE_DIR$/../../moduleB">
             <sourceFolder url="file://$MODULE_DIR$/../../moduleB/src" isTestSource="false"/>

--- a/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/modulec.iml
+++ b/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/modulec.iml
@@ -1,6 +1,6 @@
 <module type="JAVA_MODULE" version="4">
     <component name="NewModuleRootManager">
-        <output url="file://$MODULE_DIR$/../../out/moduleC/ideaCompileOutput.dest/classes"/>
+        <output url="file://$MODULE_DIR$/../../out/moduleC/internalGenIdeaModule/ideaCompileOutput.dest/classes"/>
         <exclude-output/>
         <content url="file://$MODULE_DIR$/../../moduleC">
             <sourceFolder url="file://$MODULE_DIR$/../../moduleC/src" isTestSource="false"/>

--- a/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/moduled.iml
+++ b/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/moduled.iml
@@ -1,6 +1,6 @@
 <module type="JAVA_MODULE" version="4">
     <component name="NewModuleRootManager">
-        <output url="file://$MODULE_DIR$/../../out/moduleD/ideaCompileOutput.dest/classes"/>
+        <output url="file://$MODULE_DIR$/../../out/moduleD/internalGenIdeaModule/ideaCompileOutput.dest/classes"/>
         <exclude-output/>
         <content url="file://$MODULE_DIR$/../../moduleD">
             <sourceFolder url="file://$MODULE_DIR$/../../moduleD/src" isTestSource="false"/>

--- a/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/modulee.iml
+++ b/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/modulee.iml
@@ -1,6 +1,6 @@
 <module type="JAVA_MODULE" version="4">
     <component name="NewModuleRootManager">
-        <output url="file://$MODULE_DIR$/../../out/moduleE/ideaCompileOutput.dest/classes"/>
+        <output url="file://$MODULE_DIR$/../../out/moduleE/internalGenIdeaModule/ideaCompileOutput.dest/classes"/>
         <exclude-output/>
         <content url="file://$MODULE_DIR$/../../moduleE">
             <sourceFolder url="file://$MODULE_DIR$/../../moduleE/src" isTestSource="false"/>

--- a/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/modulef.iml
+++ b/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/modulef.iml
@@ -1,6 +1,6 @@
 <module type="JAVA_MODULE" version="4">
     <component name="NewModuleRootManager">
-        <output url="file://$MODULE_DIR$/../../out/moduleF/ideaCompileOutput.dest/classes"/>
+        <output url="file://$MODULE_DIR$/../../out/moduleF/internalGenIdeaModule/ideaCompileOutput.dest/classes"/>
         <exclude-output/>
         <content url="file://$MODULE_DIR$/../../moduleF">
             <sourceFolder url="file://$MODULE_DIR$/../../moduleF/src" isTestSource="false"/>

--- a/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/moduleg-2.12.5.iml
+++ b/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/moduleg-2.12.5.iml
@@ -1,6 +1,6 @@
 <module type="JAVA_MODULE" version="4">
     <component name="NewModuleRootManager">
-        <output url="file://$MODULE_DIR$/../../out/moduleG/2.12.5/ideaCompileOutput.dest/classes"/>
+        <output url="file://$MODULE_DIR$/../../out/moduleG/2.12.5/internalGenIdeaModule/ideaCompileOutput.dest/classes"/>
         <exclude-output/>
         <content url="file://$MODULE_DIR$/../../moduleG">
             <sourceFolder url="file://$MODULE_DIR$/../../moduleG/src" isTestSource="false"/>

--- a/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/moduleg-2.13.6.iml
+++ b/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/moduleg-2.13.6.iml
@@ -1,6 +1,6 @@
 <module type="JAVA_MODULE" version="4">
     <component name="NewModuleRootManager">
-        <output url="file://$MODULE_DIR$/../../out/moduleG/2.13.6/ideaCompileOutput.dest/classes"/>
+        <output url="file://$MODULE_DIR$/../../out/moduleG/2.13.6/internalGenIdeaModule/ideaCompileOutput.dest/classes"/>
         <exclude-output/>
         <content url="file://$MODULE_DIR$/../../moduleG">
             <sourceFolder url="file://$MODULE_DIR$/../../moduleG/src" isTestSource="false"/>

--- a/libs/kotlinlib/src/mill/kotlinlib/KotlinMavenModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/KotlinMavenModule.scala
@@ -1,5 +1,7 @@
 package mill.kotlinlib
 
+import java.nio.file.Path
+
 import mill.Task
 import mill.javalib.MavenModule
 
@@ -11,7 +13,7 @@ trait KotlinMavenModule extends KotlinModule with MavenModule {
   override def sources = super.sources() ++ sources0()
 
   trait KotlinMavenTests extends KotlinTests with MavenTests {
-    override def intellijModulePath: os.Path = moduleDir / "src/test"
+    override def intellijModulePathJava: Path = (moduleDir / "src/test").toNIO
 
     private def sources0 = Task.Sources("src/test/kotlin")
     override def sources = super.sources() ++ sources0()

--- a/libs/kotlinlib/src/mill/kotlinlib/KotlinWorkerManager.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/KotlinWorkerManager.scala
@@ -10,7 +10,6 @@ import mill.define.{Discover, ExternalModule, TaskCtx}
 import mill.kotlinlib.worker.api.KotlinWorker
 import mill.util.ClassLoaderCachedFactory
 
-import java.net.URLClassLoader
 class KotlinWorkerFactory()(implicit ctx: TaskCtx)
     extends ClassLoaderCachedFactory[KotlinWorker](ctx.jobs) {
 

--- a/libs/scalalib/src/mill/scalalib/GenIdeaModule.scala
+++ b/libs/scalalib/src/mill/scalalib/GenIdeaModule.scala
@@ -1,21 +1,24 @@
 package mill.scalalib
 
-import mill.define.Task
+import mill.define.{ModuleRef, Task}
 import mill.{Module, PathRef, T}
-import mill.api.internal.idea.{IdeaConfigFile, JavaFacet}
+import mill.api.internal.idea.{
+  GenIdeaModuleApi,
+  IdeaConfigFile,
+  JavaFacet
+}
 
 /**
  * Module specific configuration of the Idea project file generator.
  */
-trait GenIdeaModule extends Module {
+trait GenIdeaModule extends Module with GenIdeaModuleApi {
 
-  def intellijModulePath: os.Path = moduleDir
-  def intellijModulePathJava: java.nio.file.Path = intellijModulePath.toNIO
+  override def intellijModulePathJava: java.nio.file.Path = moduleDir.toNIO
 
   /**
    * Skip Idea project file generation.
    */
-  def skipIdea: Boolean = false
+  override def skipIdea: Boolean = false
 
   /**
    * Contribute facets to the Java module configuration.
@@ -30,9 +33,5 @@ trait GenIdeaModule extends Module {
    */
   def ideaConfigFiles(ideaConfigVersion: Int): Task[Seq[IdeaConfigFile]] =
     Task.Anon { Seq[IdeaConfigFile]() }
-
-  def ideaCompileOutput: T[PathRef] = Task(persistent = true) {
-    PathRef(Task.dest / "classes")
-  }
 
 }

--- a/libs/scalalib/src/mill/scalalib/MavenModule.scala
+++ b/libs/scalalib/src/mill/scalalib/MavenModule.scala
@@ -1,5 +1,7 @@
 package mill.scalalib
 
+import java.nio.file.Path
+
 import mill.Task
 
 /**
@@ -14,7 +16,7 @@ trait MavenModule extends JavaModule { outer =>
 
   trait MavenTests extends JavaTests {
     override def moduleDir = outer.moduleDir
-    override def intellijModulePath: os.Path = outer.moduleDir / "src/test"
+    override def intellijModulePathJava: Path = (outer.moduleDir / "src/test").toNIO
 
     override def sources = Task.Sources("src/test/java")
     override def resources = Task.Sources("src/test/resources")

--- a/libs/scalalib/src/mill/scalalib/idea/GenIdeaModuleInternal.scala
+++ b/libs/scalalib/src/mill/scalalib/idea/GenIdeaModuleInternal.scala
@@ -1,0 +1,156 @@
+package mill.scalalib.idea
+
+import mill.Task
+import mill.api.Segments
+import mill.api.internal.idea.{
+  GenIdeaModuleInternalApi,
+  IdeaConfigFile,
+  JavaFacet,
+  ResolvedModule,
+  Scoped
+}
+import mill.api.internal.{EvaluatorApi, internal}
+import mill.define.{Discover, ExternalModule, ModuleCtx, PathRef}
+import mill.scalalib.{BoundDep, Dep, JavaModule, ScalaModule}
+
+@internal
+private[mill] object GenIdeaModuleInternal extends ExternalModule {
+
+  // Requirement of ExternalModule's
+  override protected def millDiscover: Discover = Discover[this.type]
+
+  // Hack-ish way to have some BSP state in the module context
+  @internal
+  implicit class EmbeddableGenIdeaModuleInternal(javaModule: JavaModule)
+      extends mill.define.Module {
+    // We act in the context of the module
+    override def moduleCtx: ModuleCtx = javaModule.moduleCtx
+
+    private val emptyPathRefs = Task.Anon(Seq.empty[PathRef])
+
+    // We keep all BSP-related tasks/state in this sub-module
+    @internal
+    object internalGenIdeaModule extends mill.define.Module with GenIdeaModuleInternalApi {
+
+      private[mill] override def genIdeaMetadata(
+          ideaConfigVersion: Int,
+          evaluator: EvaluatorApi,
+          path: Segments
+      ): Task[ResolvedModule] = {
+        val mod = javaModule
+        val jm = javaModule
+
+        // same as input of resolvedMvnDeps
+        val allMvnDeps =
+          Task.Anon {
+            Seq(
+              mod.coursierDependency,
+              mod.coursierDependency.withConfiguration(coursier.core.Configuration.provided)
+            ).map(BoundDep(_, force = false))
+          }
+
+        val scalaCompilerClasspath = mod match {
+          case sm: ScalaModule => Task.Anon(sm.scalaCompilerClasspath())
+          case _ => emptyPathRefs
+        }
+
+        val externalLibraryDependencies = Task.Anon {
+          jm.defaultResolver().classpath(jm.mandatoryMvnDeps())
+        }
+
+        val externalDependencies = Task.Anon {
+          jm.resolvedMvnDeps() ++
+            Task.traverse(jm.transitiveModuleDeps)(_.unmanagedClasspath)().flatten
+        }
+
+        val extCompileMvnDeps = Task.Anon {
+          jm.defaultResolver().classpath(jm.compileMvnDeps())
+        }
+
+        val extRunMvnDeps = Task.Anon {
+          jm.resolvedRunMvnDeps()
+        }
+
+        val externalSources = Task.Anon {
+          jm.millResolver().classpath(allMvnDeps(), sources = true)
+        }
+
+        val (scalacPluginsMvnDeps, allScalacOptions, scalaVersion) = mod match {
+          case mod: ScalaModule => (
+              Task.Anon(mod.scalacPluginMvnDeps()),
+              Task.Anon(mod.allScalacOptions()),
+              Task.Anon {
+                Some(mod.scalaVersion())
+              }
+            )
+          case _ => (
+              Task.Anon(Seq[Dep]()),
+              Task.Anon(Seq[String]()),
+              Task.Anon(None)
+            )
+        }
+
+        val scalacPluginDependencies = Task.Anon {
+          jm.defaultResolver().classpath(scalacPluginsMvnDeps())
+        }
+
+        val facets = Task.Anon { jm.ideaJavaModuleFacets(ideaConfigVersion)() }
+
+        val configFileContributions = Task.Anon {
+          mod.ideaConfigFiles(ideaConfigVersion)()
+        }
+
+        val resources = Task.Anon { jm.resources() }
+        val generatedSources = Task.Anon { jm.generatedSources() }
+        val allSources = Task.Anon { jm.allSources() }
+
+        Task.Anon {
+          val resolvedCp: Seq[Scoped[os.Path]] =
+            externalDependencies().map(_.path).map(Scoped(_, None)) ++
+              extCompileMvnDeps()
+                .map(_.path)
+                .map(Scoped(_, Some("PROVIDED"))) ++
+              extRunMvnDeps().map(_.path).map(Scoped(_, Some("RUNTIME")))
+
+          // unused, but we want to trigger sources, to have them available (automatically)
+          // TODO: make this a separate eval to handle resolve errors
+          externalSources()
+
+          val resolvedSp: Seq[PathRef] = scalacPluginDependencies()
+          val resolvedCompilerCp: Seq[PathRef] = scalaCompilerClasspath()
+          val resolvedLibraryCp: Seq[PathRef] = externalLibraryDependencies()
+          val scalacOpts: Seq[String] = allScalacOptions()
+          val resolvedFacets: Seq[JavaFacet] = facets()
+          val resolvedConfigFileContributions: Seq[IdeaConfigFile] = configFileContributions()
+          val resolvedCompilerOutput = ideaCompileOutput()
+          val resolvedScalaVersion = scalaVersion()
+
+          ResolvedModule(
+            path = path,
+            classpath = resolvedCp
+              .filter(_.value.ext == "jar")
+              .map(s => Scoped(s.value.toNIO, s.scope)),
+            module = mod,
+            pluginClasspath = resolvedSp.map(_.path).filter(_.ext == "jar").map(_.toNIO),
+            scalaOptions = scalacOpts,
+            scalaCompilerClasspath = resolvedCompilerCp.map(_.path.toNIO),
+            libraryClasspath = resolvedLibraryCp.map(_.path.toNIO),
+            facets = resolvedFacets,
+            configFileContributions = resolvedConfigFileContributions,
+            compilerOutput = resolvedCompilerOutput.path.toNIO,
+            scalaVersion = resolvedScalaVersion,
+            resources = resources().map(_.path.toNIO),
+            generatedSources = generatedSources().map(_.path.toNIO),
+            allSources = allSources().map(_.path.toNIO)
+          )
+        }
+
+      }
+
+      private[mill] override def ideaCompileOutput: Task.Simple[PathRef] = Task(persistent = true) {
+        PathRef(Task.dest / "classes")
+      }
+
+    }
+  }
+}

--- a/runner/idea/src/mill/idea/GenIdeaImpl.scala
+++ b/runner/idea/src/mill/idea/GenIdeaImpl.scala
@@ -128,7 +128,7 @@ class GenIdeaImpl(
         : Map[EvaluatorApi, Seq[TaskApi[ResolvedModule]]] =
       modulesByEvaluator.map { case (evaluator, m) =>
         evaluator -> m.map {
-          case (path, mod) => mod.genIdeaMetadata(ideaConfigVersion, evaluator, path)
+          case (path, mod) => mod.genIdeaModuleInternal().genIdeaMetadata(ideaConfigVersion, evaluator, path)
 
         }
       }

--- a/runner/meta/src/mill/meta/MillBuildRootModule.scala
+++ b/runner/meta/src/mill/meta/MillBuildRootModule.scala
@@ -1,17 +1,18 @@
 package mill.meta
 
+import java.nio.file.Path
+
 import mill.*
 import mill.api.Result
 import mill.api.internal.internal
 import mill.constants.CodeGenConstants.buildFileExtensions
 import mill.constants.OutFiles.*
-import mill.define.{PathRef, Discover, RootModule0, Task}
+import mill.define.{Discover, PathRef, RootModule0, Task}
 import mill.scalalib.{Dep, DepSyntax, Lib, ScalaModule}
 import mill.scalalib.api.{CompilationResult, Versions}
 import mill.util.BuildInfo
 import mill.api.internal.MillScalaParser
 import mill.define.JsonFormatters.given
-
 import scala.jdk.CollectionConverters.ListHasAsScala
 
 /**
@@ -33,7 +34,7 @@ trait MillBuildRootModule()(implicit
     .mkString("/")
 
   override def moduleDir: os.Path = rootModuleInfo.projectRoot / os.up / millBuild
-  override def intellijModulePath: os.Path = moduleDir / os.up
+  override def intellijModulePathJava: Path = (moduleDir / os.up).toNIO
 
   override def scalaVersion: T[String] = BuildInfo.scalaVersion
 


### PR DESCRIPTION
This uses the same technique of an implicitly attached sub-module to avoid adding private and likely changing internals to public stable modules. this follows the previous BSP refactorings.

This is just the refactoring. There are likely more improvement that can be applied, now that we are able to cache in the context of a module.

Removed the `GenIdeaModule.intellijModulePath` in favor to the redundant `intellijModulePathJava`. This should reduce confusion  about what to override. But it needs a deprecation in Mill 0.12 which I'll add in a separate PR.

