### PR TITLE
Migrate `GenIdeaModule.intellijModulePath` to `intellijModulePathJava`

### DIFF
--- a/kotlinlib/src/mill/kotlinlib/KotlinMavenModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/KotlinMavenModule.scala
@@ -3,6 +3,8 @@ package mill.kotlinlib
 import mill.Task
 import mill.javalib.MavenModule
 
+import java.nio.file.Path
+
 /**
  * A [[KotlinModule]] with a Maven compatible directory layout.
  */
@@ -11,7 +13,7 @@ trait KotlinMavenModule extends KotlinModule with MavenModule {
   override def sources = super.sources() ++ sources0()
 
   trait KotlinMavenTests extends KotlinTests with MavenTests {
-    override def intellijModulePath: os.Path = moduleDir / "src/test"
+    override def intellijModulePathJava: Path = (moduleDir / "src/test").toNIO
 
     private def sources0 = Task.Sources("src/test/kotlin")
     override def sources = super.sources() ++ sources0()

--- a/runner/src/mill/runner/MillBuildRootModule.scala
+++ b/runner/src/mill/runner/MillBuildRootModule.scala
@@ -1,17 +1,18 @@
 package mill.runner
 
 import coursier.Repository
-import mill._
+import mill.*
 import mill.api.{PathRef, Result, internal}
 import mill.define.{Discover, Task}
 import mill.scalalib.{BoundDep, Dep, DepSyntax, Lib, ScalaModule}
 import mill.util.CoursierSupport
 import mill.util.Util.millProjectModule
-import mill.scalalib.api.{CompilationResult, Versions, JvmWorkerUtil}
-import mill.main.client.OutFiles._
+import mill.scalalib.api.{CompilationResult, JvmWorkerUtil, Versions}
+import mill.main.client.OutFiles.*
 import mill.main.client.CodeGenConstants.buildFileExtensions
 import mill.main.{BuildInfo, RootModule}
 
+import java.nio.file.Path
 import scala.util.Try
 
 /**
@@ -33,7 +34,7 @@ abstract class MillBuildRootModule()(implicit
     .mkString("/")
 
   override def millSourcePath: os.Path = rootModuleInfo.projectRoot / os.up / millBuild
-  override def intellijModulePath: os.Path = moduleDir / os.up
+  override def intellijModulePathJava: Path = (moduleDir / os.up).toNIO
 
   override def scalaVersion: T[String] = BuildInfo.scalaVersion
 

--- a/scalalib/src/mill/scalalib/GenIdeaModule.scala
+++ b/scalalib/src/mill/scalalib/GenIdeaModule.scala
@@ -1,8 +1,11 @@
 package mill.scalalib
 
+import mill.api.WorkspaceRoot
 import mill.define.Task
 import mill.{Module, PathRef, T}
 import os.SubPath
+
+import java.nio.file.Path
 
 /**
  * Module specific configuration of the Idea project file generator.
@@ -10,7 +13,12 @@ import os.SubPath
 trait GenIdeaModule extends Module {
   import GenIdeaModule._
 
-  def intellijModulePath: os.Path = moduleDir
+  /**
+   * The path denoting the module directory in generated IntelliJ projects. Defaults to [[moduleDir]].
+   */
+  def intellijModulePathJava: Path = moduleDir.toNIO
+  @deprecated("Use and override intellijModulePathJava instead", "Mill 0.12.15")
+  def intellijModulePath: os.Path = os.Path(intellijModulePathJava, WorkspaceRoot.workspaceRoot)
 
   /**
    * Skip Idea project file generation.

--- a/scalalib/src/mill/scalalib/MavenModule.scala
+++ b/scalalib/src/mill/scalalib/MavenModule.scala
@@ -2,6 +2,7 @@ package mill.scalalib
 
 import mill.Task
 
+import java.nio.file.Path
 import scala.annotation.nowarn
 
 /**
@@ -19,7 +20,7 @@ trait MavenModule extends JavaModule { outer =>
   @deprecated("Use MavenTests instead", since = "Mill 0.11.10")
   trait MavenModuleTests extends JavaTests {
     override def millSourcePath = outer.millSourcePath
-    override def intellijModulePath: os.Path = outer.moduleDir / "src/test"
+    override def intellijModulePathJava: Path = (outer.moduleDir / "src/test").toNIO
 
     override def sources = Task.Sources("src/test/java")
     override def resources = Task.Sources("src/test/resources")


### PR DESCRIPTION
This change enhances forward compatibility with Mill 1.

Deprecated `intellijModulePath`.

