### PR TITLE
Update BSP test snapshots via MILL_TESTS_BSP_UPDATE_SNAPSHOTS env var

### DIFF
--- a/integration/ide/bsp-server/src/BspServerTestUtil.scala
+++ b/integration/ide/bsp-server/src/BspServerTestUtil.scala
@@ -21,13 +21,14 @@ object BspServerTestUtil {
   /** Allows to update the snapshots on the disk when running tests. */
   lazy val updateSnapshots: Boolean = {
     val varName = "MILL_TESTS_BSP_UPDATE_SNAPSHOTS"
-    val value = sys.env.get(varName)
-    if (value.isEmpty) println(
-      s"Using current BSP snapshots. You can update them by setting the $varName=1 environment variable."
-    )
-    val doUpdate = value.contains("1")
-    if (doUpdate) println(s"Updating BSP snapshots for tests.")
-    doUpdate
+    sys.env.get(varName) match {
+      case Some("1") =>
+        println(s"Updating BSP snapshots for tests.")
+        true
+      case _ =>
+        println(s"Using current BSP snapshots. Update with env var $varName=1")
+        false
+    }
   }
 
   private[mill] def bsp4jVersion: String = sys.props.getOrElse("BSP4J_VERSION", ???)

--- a/integration/ide/bsp-server/src/BspServerTestUtil.scala
+++ b/integration/ide/bsp-server/src/BspServerTestUtil.scala
@@ -18,11 +18,17 @@ import scala.reflect.ClassTag
 
 object BspServerTestUtil {
 
-  /**
-   * Set to true when running tests to update the snapshots on the disk. Do not forget to set it back to
-   * false after that.
-   */
-  val updateSnapshots = false
+  /** Allows to update the snapshots on the disk when running tests. */
+  lazy val updateSnapshots: Boolean = {
+    val varName = "MILL_TESTS_BSP_UPDATE_SNAPSHOTS"
+    val value = sys.env.get(varName)
+    if (value.isEmpty) println(
+      s"Using current BSP snapshots. You can update them by setting the $varName=1 environment variable."
+    )
+    val doUpdate = value.contains("1")
+    if (doUpdate) println(s"Updating BSP snapshots for tests.")
+    doUpdate
+  }
 
   private[mill] def bsp4jVersion: String = sys.props.getOrElse("BSP4J_VERSION", ???)
 

--- a/integration/ide/bsp-server/src/BspServerTestUtil.scala
+++ b/integration/ide/bsp-server/src/BspServerTestUtil.scala
@@ -124,7 +124,7 @@ object BspServerTestUtil {
           snapshotLines.iterator
             .zip(logLines.iterator)
             .zipWithIndex
-            .map {
+            .forall {
               case ((snapshotLine, logLine), lineIdx) =>
                 val cmp = TestRunnerUtils.matchesGlob(snapshotLine)
                 cmp(logLine) || {
@@ -134,7 +134,6 @@ object BspServerTestUtil {
                   false
                 }
             }
-            .foldLeft(true)(_ && _)
         else {
           System.err.println(s"Expected ${snapshotLines.length} lines, got ${logLines.length}")
           false

--- a/integration/ide/bsp-server/src/BspServerTests.scala
+++ b/integration/ide/bsp-server/src/BspServerTests.scala
@@ -14,7 +14,7 @@ import mill.testrunner.TestRunnerUtils
 import utest.*
 
 object BspServerTests extends UtestIntegrationTestSuite {
-  def snapshotsPath: os.Path =
+  protected def snapshotsPath: os.Path =
     super.workspaceSourcePath / "snapshots"
   def logsPath: os.Path =
     super.workspaceSourcePath / "logs"

--- a/integration/package.mill
+++ b/integration/package.mill
@@ -39,7 +39,14 @@ object `package` extends mill.Module {
       def mode: String = moduleSegments.parts.last
       def scalaVersion = Deps.scalaVersion
 
-      def forkEnv =
+      def forkEnv = {
+        def exportFromEnv(key: String) = {
+          sys.env.get(key) match {
+            case Some(value) => Map(key -> value)
+            case None => Map.empty
+          }
+        }
+
         super.forkEnv() ++
           IntegrationTestModule.this.forkEnv() ++
           Map(
@@ -49,7 +56,9 @@ object `package` extends mill.Module {
             "MILL_LAUNCHER_BAT" -> build.dist.bootstrapLauncherBat().path.toString,
             "MILL_INTEGRATION_LAUNCHER" -> millIntegrationLauncher().path.toString
           ) ++
+          exportFromEnv("MILL_TESTS_BSP_UPDATE_SNAPSHOTS") ++
           (if (millIntegrationIsPackagedLauncher()) Map() else build.dist.localTestOverridesEnv())
+      }
 
       def millIntegrationLauncher: T[PathRef]
 

--- a/integration/package.mill
+++ b/integration/package.mill
@@ -39,14 +39,15 @@ object `package` extends mill.Module {
       def mode: String = moduleSegments.parts.last
       def scalaVersion = Deps.scalaVersion
 
-      def forkEnv = {
-        def exportFromEnv(key: String) = {
-          sys.env.get(key) match {
-            case Some(value) => Map(key -> value)
-            case None => Map.empty
-          }
+      private def envUpdateSnapshots: Task.Simple[Map[String, String]] = Task.Input {
+        val key = "MILL_TESTS_BSP_UPDATE_SNAPSHOTS"
+        Task.env.get(key) match {
+          case Some(value) => Map(key -> value)
+          case None => Map.empty
         }
+      }
 
+      def forkEnv = Task {
         super.forkEnv() ++
           IntegrationTestModule.this.forkEnv() ++
           Map(
@@ -56,7 +57,7 @@ object `package` extends mill.Module {
             "MILL_LAUNCHER_BAT" -> build.dist.bootstrapLauncherBat().path.toString,
             "MILL_INTEGRATION_LAUNCHER" -> millIntegrationLauncher().path.toString
           ) ++
-          exportFromEnv("MILL_TESTS_BSP_UPDATE_SNAPSHOTS") ++
+          envUpdateSnapshots() ++
           (if (millIntegrationIsPackagedLauncher()) Map() else build.dist.localTestOverridesEnv())
       }
 


### PR DESCRIPTION
The current way of changing the code and then changing it back is error prone, as witnessed in https://github.com/com-lihaoyi/mill/pull/5265#discussion_r2140429333 .

I changed it to use an environment variable, which has no chance of being committed to the codebase.