### PR TITLE
Tab complete nested modules and tasks when token is exact match for module

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1,4 +1,4 @@
-//| mill-version: 1.0.0-RC2-1-6b33e1-DIRTY28d5f247
+//| mill-version: 1.0.0-RC2
 //| mill-jvm-opts: ["-XX:NonProfiledCodeHeapSize=250m", "-XX:ReservedCodeCacheSize=500m"]
 //| mill-opts: ["--jobs=0.5C"]
 

--- a/build.mill
+++ b/build.mill
@@ -1,4 +1,4 @@
-//| mill-version: 1.0.0-RC1-53-8781d1
+//| mill-version: 1.0.0-RC2-1-6b33e1-DIRTY28d5f247
 //| mill-jvm-opts: ["-XX:NonProfiledCodeHeapSize=250m", "-XX:ReservedCodeCacheSize=500m"]
 //| mill-opts: ["--jobs=0.5C"]
 

--- a/libs/tabcomplete/src/mill/tabcomplete/TabCompleteModule.scala
+++ b/libs/tabcomplete/src/mill/tabcomplete/TabCompleteModule.scala
@@ -23,7 +23,7 @@ object TabCompleteModule extends ExternalModule {
       args: mainargs.Leftover[String]
   ) = Task.Command(exclusive = true) {
 
-    val (query, unescapedOpt) = args.value.lift(index) match {
+    val (query, unescaped) = args.value.lift(index) match {
       // Zsh has the index pointing off the end of the args list, while
       // Bash has the index pointing at an empty string arg
       case None | Some("") => ("_", None)
@@ -44,10 +44,12 @@ object TabCompleteModule extends ExternalModule {
         (query, Some(unescaped))
     }
 
+    def normalizeSeps(s: String) = s.replace('[', '.')
+
     ev.resolveSegments(Seq(query), SelectMode.Multi).map { res =>
-      val unescapedStr = unescapedOpt.getOrElse("")
-      val filtered = res.map(_.render).filter(_.startsWith(unescapedStr))
-      val moreFiltered = unescapedOpt match {
+      val normalizedUnescaped = normalizeSeps(unescaped.getOrElse(""))
+      val filtered = res.map(_.render).filter(normalizeSeps(_).startsWith(normalizedUnescaped))
+      val moreFiltered = unescaped match {
         case Some(u) if filtered.contains(u) =>
           ev.resolveSegments(Seq(u + "._"), SelectMode.Multi) match {
             case Result.Success(v) => v.map(_.render)

--- a/libs/tabcomplete/src/mill/tabcomplete/TabCompleteModule.scala
+++ b/libs/tabcomplete/src/mill/tabcomplete/TabCompleteModule.scala
@@ -1,7 +1,7 @@
 package mill.tabcomplete
 
 import mill.*
-import mill.api.SelectMode
+import mill.api.{SelectMode, Result}
 import mill.define.{Discover, Evaluator, ExternalModule}
 
 import mainargs.arg
@@ -23,27 +23,43 @@ object TabCompleteModule extends ExternalModule {
       args: mainargs.Leftover[String]
   ) = Task.Command(exclusive = true) {
 
-    val query = args.value.lift(index) match{
-      // Zsh has the index pointing off the end of the args list,
-      // so use "" as the last arg if out of bounds
-      case None | Some("") => "_"
+    val (query, unescaped) = args.value.lift(index) match{
+      // Zsh has the index pointing off the end of the args list, while
+      // Bash has the index pointing at an empty string arg
+      case None | Some("") => ("_", None)
 
       case Some(currentToken) =>
-        val deSlashed = currentToken.replace("\\", "").replace("\"", "").replace("\'", "")
-        val trimmed = deSlashed.take(
-          deSlashed.lastIndexWhere(c => !c.isLetterOrDigit && !"-_,".contains(c)) + 1
-        )
-        trimmed.lastOption match {
-          case None => "."
+        val unescaped = currentToken.replace("\\", "").replace("\"", "").replace("\'", "")
+        val trimmed = unescaped
+          .take(unescaped.lastIndexWhere(c => !c.isLetterOrDigit && !"-_,".contains(c)) + 1)
+
+        val query = trimmed.lastOption match {
+          case None => "_"
           case Some('.') => trimmed + "_"
           case Some('[') => trimmed + "__]"
           case Some(',') => trimmed + "__]"
           case Some(']') => trimmed + "._"
         }
+
+        (query, Some(unescaped))
     }
 
+    def normalizeSeps(s: String) = s.replace('[', '.')
+
     ev.resolveSegments(Seq(query), SelectMode.Multi).map { res =>
-      res.map(_.render).filter(_.replace('[', '.').startsWith(deSlashed.replace('[', '.'))).foreach(println)
+      val normalizedUnescaped = normalizeSeps(unescaped.getOrElse(""))
+      val filtered = res.map(_.render).filter(normalizeSeps(_).startsWith(normalizedUnescaped))
+      val moreFiltered = unescaped match{
+        case Some(u) if filtered.contains(u) =>
+            ev.resolveSegments(Seq(u + "._"), SelectMode.Multi) match{
+              case Result.Success(v) => v.map(_.render)
+              case Result.Failure(error) => Nil
+            }
+
+        case _ => Nil
+      }
+
+      (filtered ++ moreFiltered).foreach(println)
     }
   }
 

--- a/libs/tabcomplete/src/mill/tabcomplete/TabCompleteModule.scala
+++ b/libs/tabcomplete/src/mill/tabcomplete/TabCompleteModule.scala
@@ -23,7 +23,7 @@ object TabCompleteModule extends ExternalModule {
       args: mainargs.Leftover[String]
   ) = Task.Command(exclusive = true) {
 
-    val (query, unescaped) = args.value.lift(index) match {
+    val (query, unescapedOpt) = args.value.lift(index) match {
       // Zsh has the index pointing off the end of the args list, while
       // Bash has the index pointing at an empty string arg
       case None | Some("") => ("_", None)
@@ -44,12 +44,10 @@ object TabCompleteModule extends ExternalModule {
         (query, Some(unescaped))
     }
 
-    def normalizeSeps(s: String) = s.replace('[', '.')
-
     ev.resolveSegments(Seq(query), SelectMode.Multi).map { res =>
-      val normalizedUnescaped = normalizeSeps(unescaped.getOrElse(""))
-      val filtered = res.map(_.render).filter(normalizeSeps(_).startsWith(normalizedUnescaped))
-      val moreFiltered = unescaped match {
+      val unescapedStr = unescapedOpt.getOrElse("")
+      val filtered = res.map(_.render).filter(_.startsWith(unescapedStr))
+      val moreFiltered = unescapedOpt match {
         case Some(u) if filtered.contains(u) =>
           ev.resolveSegments(Seq(u + "._"), SelectMode.Multi) match {
             case Result.Success(v) => v.map(_.render)

--- a/libs/tabcomplete/test/src/mill/tabcomplete/TabCompleteTests.scala
+++ b/libs/tabcomplete/test/src/mill/tabcomplete/TabCompleteTests.scala
@@ -91,6 +91,15 @@ object TabCompleteTests extends TestSuite {
       assert(out == expected)
     }
 
+    test("exactModule") - {
+      val out = evalComplete("1", "./mill", "bar")
+      val expected =
+        """bar
+          |bar.task2
+          |""".stripMargin
+      assert(out == expected)
+    }
+
     test("nested") - {
       val out = evalComplete("1", "./mill", "bar.")
       val expected =

--- a/libs/tabcomplete/test/src/mill/tabcomplete/TabCompleteTests.scala
+++ b/libs/tabcomplete/test/src/mill/tabcomplete/TabCompleteTests.scala
@@ -129,16 +129,6 @@ object TabCompleteTests extends TestSuite {
       assert(out == expected)
     }
 
-    test("cross3") - {
-      val out = evalComplete("1", "./mill", "qux.")
-      val expected =
-        """qux[12]
-          |qux[34]
-          |qux[56]
-          |""".stripMargin
-      assert(out == expected)
-    }
-
     test("crossPartial") - {
       val out = evalComplete("1", "./mill", "qux[1")
       val expected =

--- a/libs/tabcomplete/test/src/mill/tabcomplete/TabCompleteTests.scala
+++ b/libs/tabcomplete/test/src/mill/tabcomplete/TabCompleteTests.scala
@@ -118,6 +118,17 @@ object TabCompleteTests extends TestSuite {
       assert(out == expected)
     }
 
+    test("cross2") - {
+      val out = evalComplete("1", "./mill", "qux")
+      val expected =
+        """qux
+          |qux[12]
+          |qux[34]
+          |qux[56]
+          |""".stripMargin
+      assert(out == expected)
+    }
+
     test("crossPartial") - {
       val out = evalComplete("1", "./mill", "qux[1")
       val expected =

--- a/libs/tabcomplete/test/src/mill/tabcomplete/TabCompleteTests.scala
+++ b/libs/tabcomplete/test/src/mill/tabcomplete/TabCompleteTests.scala
@@ -129,6 +129,16 @@ object TabCompleteTests extends TestSuite {
       assert(out == expected)
     }
 
+    test("cross3") - {
+      val out = evalComplete("1", "./mill", "qux.")
+      val expected =
+        """qux[12]
+          |qux[34]
+          |qux[56]
+          |""".stripMargin
+      assert(out == expected)
+    }
+
     test("crossPartial") - {
       val out = evalComplete("1", "./mill", "qux[1")
       val expected =


### PR DESCRIPTION
```
> ./mill bar<TAB>
bar
bar.task2

> ./mill qux<TAB>
qux
qux[12]
qux[34]
qux[56]
```

Implementing this involved looking for the case where the first `resolve` returns an exact match for the current token, and if so perform a second `resolve` with `._` appended to the current token.


Tested manually in Zsh on Mac, also updated the unit tests to consider these cases

