### PR TITLE
Use `_mill1.0.0-RCx` as mill suffix for release candidates

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -71,10 +71,9 @@ def millDownloadUrl = Task {
 
 def millBinPlatform: T[String] = Task {
   val tag = millLastTag()
-  if (tag.contains("-M")) tag
-  else {
-    val pos = if (tag.startsWith("0.")) 2 else 1
-    tag.split("[.]", pos + 1).take(pos).mkString(".")
+  tag match {
+    case s"$_-M$_" | s"$_-RC$_" => tag
+    case tag => tag.split('.').head
   }
 }
 


### PR DESCRIPTION
This allows to safely perform binary breakages between release candidates without breaking the ecosystem.

Pull Request: https://github.com/com-lihaoyi/mill/pull/5299