### PR TITLE
Various cleanups

### DIFF
--- a/contrib/playlib/worker/src-shared/mill/playlib/worker/RouteCompilerWorkerBase.scala
+++ b/contrib/playlib/worker/src-shared/mill/playlib/worker/RouteCompilerWorkerBase.scala
@@ -67,8 +67,8 @@ protected[playlib] class RouteCompilerWorkerBase extends RouteCompilerWorkerApi 
       )
     ).foldLeft(seed) {
       case (Right(accFiles), Right(files)) => Right(accFiles ++ files)
-      case (Right(accFiles), Left(errors)) => Left(errors)
-      case (left @ Left(errors), _) => left
+      case (Right(_), Left(errors)) => Left(errors)
+      case (left @ Left(_), _) => left
     }
   }
 

--- a/contrib/versionfile/src/mill/contrib/versionfile/Version.scala
+++ b/contrib/versionfile/src/mill/contrib/versionfile/Version.scala
@@ -34,8 +34,8 @@ sealed trait Version {
     }
 
     this match {
-      case release: Release => Release.apply.tupled(segments)
-      case snapshot: Snapshot => Snapshot.apply.tupled(segments)
+      case _: Release => Release.apply.tupled(segments)
+      case _: Snapshot => Snapshot.apply.tupled(segments)
     }
   }
 }

--- a/core/api/src/mill/api/internal/EvaluatorApi.scala
+++ b/core/api/src/mill/api/internal/EvaluatorApi.scala
@@ -2,7 +2,6 @@ package mill.api.internal
 
 import mill.api.*
 import scala.collection.mutable
-import scala.util.DynamicVariable
 
 trait EvaluatorApi extends AutoCloseable {
   def evaluate(

--- a/core/api/src/mill/api/internal/bsp/BspJavaModuleApi.scala
+++ b/core/api/src/mill/api/internal/bsp/BspJavaModuleApi.scala
@@ -2,7 +2,7 @@ package mill.api.internal.bsp
 
 import java.nio.file.Path
 
-import mill.api.internal.{EvaluatorApi, JavaModuleApi, ModuleApi, TaskApi}
+import mill.api.internal.{EvaluatorApi, ModuleApi, TaskApi}
 
 trait BspJavaModuleApi extends ModuleApi {
 

--- a/core/api/src/mill/api/internal/idea/GenIdeaInternalApi.scala
+++ b/core/api/src/mill/api/internal/idea/GenIdeaInternalApi.scala
@@ -1,6 +1,6 @@
 package mill.api.internal.idea
 
-import mill.api.internal.{EvaluatorApi, PathRefApi, TaskApi}
+import mill.api.internal.{PathRefApi, TaskApi}
 
 trait GenIdeaInternalApi {
 

--- a/core/coursierutil/src/mill/coursierutil/TestOverridesRepo.scala
+++ b/core/coursierutil/src/mill/coursierutil/TestOverridesRepo.scala
@@ -4,8 +4,6 @@ import coursier.core.{ArtifactSource, Extension, Info, Module, Project, Publicat
 import coursier.util.{Artifact, EitherT, Monad}
 import coursier.{Classifier, Dependency, Repository, Type}
 
-import java.util.concurrent.ConcurrentHashMap
-
 /**
  * A `coursier.Repository` that exposes modules with hard-coded artifact list
  *

--- a/core/define/src/mill/define/BaseModule.scala
+++ b/core/define/src/mill/define/BaseModule.scala
@@ -14,7 +14,7 @@ abstract class BaseModule(
     millModuleEnclosing0: sourcecode.Enclosing,
     millModuleLine0: sourcecode.Line,
     millFile0: sourcecode.File
-) extends Module.BaseClass()(
+) extends Module.BaseClass(using
       mill.define.ModuleCtx.makeRoot(
         implicitly,
         implicitly,

--- a/core/define/src/mill/define/Module.scala
+++ b/core/define/src/mill/define/Module.scala
@@ -1,6 +1,5 @@
 package mill.define
 
-import mill.api
 import mill.api.internal.{ModuleApi, internal}
 import mill.define.internal.{OverrideMapping, Reflect}
 import mill.define.Task.Simple
@@ -95,7 +94,7 @@ object Module {
         filter,
         Reflect.getMethods(_, scala.reflect.NameTransformer.decode)
       )
-        .map { case (name, cls, getter) => getter(outer) }
+        .map { case (getter = getter) => getter(outer) }
         .toSeq
     }
   }

--- a/core/define/src/mill/define/internal/Reflect.scala
+++ b/core/define/src/mill/define/internal/Reflect.scala
@@ -125,7 +125,7 @@ private[mill] object Reflect {
       outerCls: Class[?],
       filter: String => Boolean = Function.const(true),
       getMethods: Class[?] => Array[(java.lang.reflect.Method, String)]
-  ): Array[(String, Class[?], Any => T)] = {
+  ): Array[(name: String, `class`: Class[?], getter: Any => T)] = {
     reflectNestedObjects0[T](outerCls, filter, getMethods).map {
       case (name, m: java.lang.reflect.Method) =>
         (name, m.getReturnType, (outer: Any) => m.invoke(outer).asInstanceOf[T])

--- a/core/exec/src/mill/exec/Execution.scala
+++ b/core/exec/src/mill/exec/Execution.scala
@@ -275,7 +275,7 @@ private[mill] case class Execution(
     }
 
     val tasks0 = terminals0.filter {
-      case c: Task.Command[_] => false
+      case _: Task.Command[_] => false
       case _ => true
     }
 

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -149,7 +149,7 @@ private trait GroupExecution {
 
               val cachedValueAndHash =
                 upToDateWorker.map(w => (w -> Nil, inputsHash))
-                  .orElse(cached.flatMap { case (inputHash, valOpt, valueHash) =>
+                  .orElse(cached.flatMap { case (_, valOpt, valueHash) =>
                     valOpt.map((_, valueHash))
                   })
 
@@ -218,7 +218,7 @@ private trait GroupExecution {
                   )
               }
           }
-        case task =>
+        case _ =>
           val (newResults, newEvaluated) = executeGroup(
             group = group,
             results = results,
@@ -383,7 +383,7 @@ private trait GroupExecution {
     def normalJson(w: upickle.default.Writer[_]) = PathRef.withSerializedPaths {
       upickle.default.writeJs(v.value)(using w.asInstanceOf[upickle.default.Writer[Any]])
     }
-    lazy val workerJson = labelled.asWorker.map { w =>
+    lazy val workerJson = labelled.asWorker.map { _ =>
       ujson.Obj(
         "worker" -> ujson.Str(labelled.toString),
         "toString" -> ujson.Str(v.value.toString),

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -46,7 +46,7 @@ private trait GroupExecution {
       "MILL_BIN_PLATFORM" -> mill.constants.BuildInfo.millBinPlatform
     )
     def rec(x: Any): ujson.Value = {
-      import collection.JavaConverters._
+      import scala.jdk.CollectionConverters._
       x match {
         case d: java.util.Date => ujson.Str(d.toString)
         case s: String => ujson.Str(mill.constants.Util.interpolateEnvVars(s, envWithPwd.asJava))
@@ -57,11 +57,9 @@ private trait GroupExecution {
         case false => ujson.False
         case null => ujson.Null
         case m: java.util.Map[Object, Object] =>
-          import collection.JavaConverters._
           val scalaMap = m.asScala
           ujson.Obj.from(scalaMap.map { case (k, v) => (k.toString, rec(v)) })
         case l: java.util.List[Object] =>
-          import collection.JavaConverters._
           val scalaList: collection.Seq[Object] = l.asScala
           ujson.Arr.from(scalaList.map(rec))
       }

--- a/core/exec/test/src/mill/exec/ExecutionTests.scala
+++ b/core/exec/test/src/mill/exec/ExecutionTests.scala
@@ -238,13 +238,13 @@ object ExecutionTests extends TestSuite {
       }
 
       UnitTester(build, null).scoped { tester =>
-        val Right(UnitTester.Result(worker1, _)) = tester.apply(build.worker)
-        val Right(UnitTester.Result(worker2, _)) = tester.apply(build.worker)
+        val Right(UnitTester.Result(worker1, _)) = tester.apply(build.worker): @unchecked
+        val Right(UnitTester.Result(worker2, _)) = tester.apply(build.worker): @unchecked
         assert(worker1 == worker2)
         assert(worker1.n == 10)
         assert(!worker1.closed)
         x = 11
-        val Right(UnitTester.Result(worker3, _)) = tester.apply(build.worker)
+        val Right(UnitTester.Result(worker3, _)) = tester.apply(build.worker): @unchecked
         assert(worker3 != worker2)
         assert(worker3.n == 11)
         assert(!worker3.closed)

--- a/core/internal/src/mill/internal/PipeStreams.scala
+++ b/core/internal/src/mill/internal/PipeStreams.scala
@@ -82,7 +82,7 @@ private[mill] class PipeStreams(val bufferSize: Int = 1024) { pipe =>
       notifyAll()
       try wait(1000)
       catch {
-        case ex: InterruptedException =>
+        case _: InterruptedException =>
           throw new java.io.InterruptedIOException
       }
     }

--- a/core/internal/src/mill/internal/PromptLogger.scala
+++ b/core/internal/src/mill/internal/PromptLogger.scala
@@ -70,7 +70,7 @@ private[mill] class PromptLogger(
       while (!runningState.stopped) {
         try Thread.sleep(promptUpdateIntervalMillis)
         catch {
-          case e: InterruptedException => /*do nothing*/
+          case _: InterruptedException => /*do nothing*/
         }
 
         readTerminalDims(terminfoPath).foreach(termDimensions = _)
@@ -359,7 +359,7 @@ private[mill] object PromptLogger {
       infoColor: fansi.Attrs
   ) {
     private val statuses = collection.mutable.SortedMap
-      .empty[Seq[String], Status](PromptLoggerUtil.seqStringOrdering)
+      .empty[Seq[String], Status](using PromptLoggerUtil.seqStringOrdering)
 
     private var headerPrefix = ""
     // Pre-compute the prelude and current prompt as byte arrays so that
@@ -418,7 +418,7 @@ private[mill] object PromptLogger {
       val sOptEntry = sOpt.map(StatusEntry(_, now, ""))
       statuses.updateWith(key) {
         case None =>
-          statuses.find { case (k, v) => v.next.isEmpty } match {
+          statuses.find { case (_, v) => v.next.isEmpty } match {
             case Some((reusableKey, reusableValue)) =>
               statuses.remove(reusableKey)
               Some(reusableValue.copy(next = sOptEntry))

--- a/core/internal/src/mill/internal/PromptLoggerUtil.scala
+++ b/core/internal/src/mill/internal/PromptLoggerUtil.scala
@@ -76,7 +76,7 @@ private object PromptLoggerUtil {
           }
         )
       )
-    } catch { case e => None }
+    } catch { case _ => None }
   }
 
   def renderPrompt(
@@ -100,7 +100,7 @@ private object PromptLoggerUtil {
 
     val body0 = statuses
       .flatMap {
-        case (threadId, status) =>
+        case (_, status) =>
           // For statuses that have completed transitioning from Some to None, continue
           // rendering them as an empty line for `statusRemovalRemoveDelayMillis` to try
           // and maintain prompt height and stop it from bouncing up and down

--- a/core/internal/src/mill/internal/Util.scala
+++ b/core/internal/src/mill/internal/Util.scala
@@ -53,7 +53,7 @@ private[mill] object Util {
   )
 
   def backtickWrap(s: String): String = s match {
-    case s"`$v`" => s
+    case s"`$_`" => s
     case _ => if (encode(s) == s && !alphaKeywords.contains(s)) s
       else "`" + s + "`"
   }

--- a/core/internal/src/mill/internal/Util.scala
+++ b/core/internal/src/mill/internal/Util.scala
@@ -74,11 +74,11 @@ private[mill] object Util {
         case false => ujson.False
         case null => ujson.Null
         case m: java.util.Map[Object, Object] =>
-          import collection.JavaConverters._
+          import scala.jdk.CollectionConverters._
           val scalaMap = m.asScala
           ujson.Obj.from(scalaMap.map { case (k, v) => (k.toString, rec(v)) })
         case l: java.util.List[Object] =>
-          import collection.JavaConverters._
+          import scala.jdk.CollectionConverters._
           val scalaList: collection.Seq[Object] = l.asScala
           ujson.Arr.from(scalaList.map(rec))
       }

--- a/core/internal/test/src/mill/internal/PipeStreamsTests.scala
+++ b/core/internal/test/src/mill/internal/PipeStreamsTests.scala
@@ -47,7 +47,7 @@ object PipeStreamsTests extends TestSuite {
       Thread.sleep(100) // Give it time for pipe to fill up
 
       val reader = Future {
-        for (i <- Range(0, chunkCount)) yield {
+        for (_ <- Range(0, chunkCount)) yield {
           pipe.input.readNBytes(chunkSize).toSeq
         }
       }
@@ -65,7 +65,7 @@ object PipeStreamsTests extends TestSuite {
       val writeFutures =
         for (i <- Range(0, chunkCount)) yield Future {
           pipe.output.write(Array.fill(chunkSize)(i.toByte))
-        }(writerPool)
+        }(using writerPool)
 
       Await.ready(Future.sequence(writeFutures), Inf)
 
@@ -89,7 +89,7 @@ object PipeStreamsTests extends TestSuite {
       val writerPool = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(40))
       for (i <- Range(0, chunkCount)) yield Future {
         pipe.output.write(Array.fill(chunkSize)(i.toByte))
-      }(writerPool)
+      }(using writerPool)
 
       val out = pipe.input.readNBytes(chunkSize * chunkCount)
 

--- a/core/resolve/src/mill/resolve/Resolve.scala
+++ b/core/resolve/src/mill/resolve/Resolve.scala
@@ -395,12 +395,12 @@ private[mill] trait Resolve[T] {
           moduleCls <-
             try Result.Success(rootModule.getClass.getClassLoader.loadClass(scoping.render + "$"))
             catch {
-              case e: ClassNotFoundException =>
+              case _: ClassNotFoundException =>
                 try Result.Success(rootModule.getClass.getClassLoader.loadClass(
                     scoping.render + ".package$"
                   ))
                 catch {
-                  case e: ClassNotFoundException =>
+                  case _: ClassNotFoundException =>
                     Result.Failure("Cannot resolve external module " + scoping.render)
                 }
             }

--- a/core/resolve/src/mill/resolve/ResolveCore.scala
+++ b/core/resolve/src/mill/resolve/ResolveCore.scala
@@ -442,7 +442,7 @@ private object ResolveCore {
                     Segments.labels(c.moduleSegments.last.value),
                     c.getClass
                   ),
-                  Some((x: Module) => mill.api.Result.Success(c))
+                  Some((_: Module) => mill.api.Result.Success(c))
                 )
               )
         }

--- a/core/resolve/test/src/mill/resolve/ModuleTests.scala
+++ b/core/resolve/test/src/mill/resolve/ModuleTests.scala
@@ -4,9 +4,8 @@ import mill.api.Result
 import mill.define.{Discover, ModuleRef, Task, TaskModule}
 import mill.testkit.TestRootModule
 import mill.define.DynamicModule
-import mill.util.TestGraphs
 import mill.util.TestGraphs.*
-import mill.{Cross, Module, Task}
+import mill.{Cross, Module}
 import utest.*
 
 object ModuleTests extends TestSuite {

--- a/core/util/test/src/mill/util/RetryTests.scala
+++ b/core/util/test/src/mill/util/RetryTests.scala
@@ -32,7 +32,7 @@ object RetryTests extends TestSuite {
         Retry(
           logger = Retry.printStreamLogger(System.err),
           filter = {
-            case (i, ex: RuntimeException) => true
+            case (_, _: RuntimeException) => true
             case _ => false
           }
         ) {

--- a/core/util/test/src/mill/util/VersionTests.scala
+++ b/core/util/test/src/mill/util/VersionTests.scala
@@ -22,7 +22,7 @@ object VersionTests extends TestSuite {
       test("ignoreQualifier") {
         val ordering = Version.IgnoreQualifierOrdering
         val input =
-          versions.map(Version.parse).sorted(ordering).map(_.toString())
+          versions.map(Version.parse).sorted(using ordering).map(_.toString())
         val expected = Seq(
           "0.10.0",
           "0.10.0-M2",
@@ -40,7 +40,7 @@ object VersionTests extends TestSuite {
       }
       test("maven") {
         val ordering = Version.MavenOrdering
-        val input = versions.map(Version.parse).sorted(ordering).map(_.toString())
+        val input = versions.map(Version.parse).sorted(using ordering).map(_.toString())
         val expected = Seq(
           "0.10.0-M2",
           "0.10.0",
@@ -58,7 +58,7 @@ object VersionTests extends TestSuite {
       }
       test("osgi") {
         val ordering = Version.OsgiOrdering
-        val input = versions.map(Version.parse).sorted(ordering).map(_.toString())
+        val input = versions.map(Version.parse).sorted(using ordering).map(_.toString())
         val expected = Seq(
           "0.10.0",
           "0.10.0-M2",
@@ -77,7 +77,7 @@ object VersionTests extends TestSuite {
     }
     test("Version.isAtLeast(String, String)") {
       test("ignoreQualifier") {
-        implicit val ordering = Version.IgnoreQualifierOrdering
+        given Ordering[Version] = Version.IgnoreQualifierOrdering
         assert(
           Version.isAtLeast("0.8.9", "0.7.10") == true,
           Version.isAtLeast("0.8.9", "0.8.10") == false,

--- a/integration/feature/mill-jvm-property/src/MillJvmPropertyTests.scala
+++ b/integration/feature/mill-jvm-property/src/MillJvmPropertyTests.scala
@@ -1,6 +1,5 @@
 package mill.integration
 
-import mill.constants.Util
 import mill.testkit.UtestIntegrationTestSuite
 import utest._
 

--- a/libs/androidlib/src/mill/androidlib/AndroidAppKotlinModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppKotlinModule.scala
@@ -1,7 +1,5 @@
 package mill.androidlib
 
-import coursier.core.VariantSelector.VariantMatcher
-import coursier.params.ResolutionParams
 import mill.define.{ModuleRef, PathRef, Task}
 import mill.kotlinlib.{Dep, DepSyntax}
 import mill.scalalib.TestModule.Junit5

--- a/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
@@ -78,12 +78,6 @@ trait AndroidAppModule extends AndroidModule { outer =>
    */
   def androidApplicationId: String
 
-  private def androidManifestUsesSdkSection: Task[Elem] = Task.Anon {
-    val minSdkVersion = androidMinSdk().toString
-    val targetSdkVersion = androidTargetSdk().toString
-    <uses-sdk android:minSdkVersion={minSdkVersion} android:targetSdkVersion={targetSdkVersion}/>
-  }
-
   def androidDebugManifestLocation: T[PathRef] = Task.Source {
     "src/debug/AndroidManifest.xml"
   }

--- a/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
@@ -7,7 +7,6 @@ import mill.api.internal.{internal, *}
 import mill.define.{ModuleRef, PathRef, Task}
 import mill.scalalib.*
 import mill.testrunner.TestResult
-import mill.util.Jvm
 import os.{Path, RelPath, zip}
 import upickle.default.*
 import scala.jdk.OptionConverters.RichOptional

--- a/libs/androidlib/src/mill/androidlib/AndroidModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidModule.scala
@@ -7,7 +7,6 @@ import mill.T
 import mill.androidlib.manifestmerger.AndroidManifestMerger
 import mill.define.{ModuleRef, PathRef, Task}
 import mill.scalalib.*
-import mill.util.Jvm
 import mill.define.JsonFormatters.given
 
 import scala.collection.immutable

--- a/libs/androidlib/src/mill/androidlib/AndroidSdkModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidSdkModule.scala
@@ -83,10 +83,10 @@ trait AndroidSdkModule extends Module {
       .pipe { cache =>
         if (Task.offline) cache.withCachePolicies(Seq(LocalOnly)) else cache
       }
-    cache.file(Artifact(url)).run.unsafeRun()(cache.ec) match {
+    cache.file(Artifact(url)).run.unsafeRun()(using cache.ec) match {
       case Right(file) =>
         PathRef(os.Path(file)).withRevalidateOnce
-      case Left(ex) if Task.offline =>
+      case Left(_) if Task.offline =>
         Task.fail(s"Can't fetch bundle tools (from ${url}) while in offline mode.")
       case Left(ex) =>
         Task.fail(ex.getMessage())

--- a/libs/javascriptlib/test/src/mill/javascriptlib/HelloWorldTests.scala
+++ b/libs/javascriptlib/test/src/mill/javascriptlib/HelloWorldTests.scala
@@ -32,7 +32,7 @@ object HelloWorldTests extends TestSuite {
       UnitTester(HelloWorldJavascript, resourcePath, outStream = new PrintStream(baos)).scoped {
         eval =>
 
-          val Right(result) = eval.apply(HelloWorldJavascript.qux.run(Args("James"))): @unchecked
+          val Right(_) = eval.apply(HelloWorldJavascript.qux.run(Args("James"))): @unchecked
 
           assert(baos.toString() == "Hello James Qux\n")
       }

--- a/libs/main/src/mill/main/SubfolderModule.scala
+++ b/libs/main/src/mill/main/SubfolderModule.scala
@@ -12,7 +12,7 @@ abstract class SubfolderModule(millDiscover: Discover)(implicit
     millModuleLine0: sourcecode.Line,
     millFile0: sourcecode.File,
     subFolderInfo: SubfolderModule.Info
-) extends mill.define.Module.BaseClass()(
+) extends mill.define.Module.BaseClass(using
       ModuleCtx.makeRoot(
         millModuleEnclosing0 = subFolderInfo.segments.mkString("."),
         millModuleLine0 = millModuleLine0,

--- a/libs/scalajslib/worker/1/src/mill/scalajslib/worker/ScalaJSWorkerImpl.scala
+++ b/libs/scalajslib/worker/1/src/mill/scalajslib/worker/ScalaJSWorkerImpl.scala
@@ -27,8 +27,6 @@ import scala.ref.SoftReference
 import com.armanbilge.sjsimportmap.ImportMappedIRFile
 import mill.constants.InputPumper
 
-import scala.annotation.nowarn
-
 class ScalaJSWorkerImpl extends ScalaJSWorkerApi {
   private case class LinkerInput(
       isFullLinkJS: Boolean,
@@ -257,17 +255,16 @@ class ScalaJSWorkerImpl extends ScalaJSWorkerApi {
               .withSourceMap(PathOutputFile(sourceMapFile))
               .withSourceMapURI(java.net.URI.create(sourceMapFile.getFileName.toString))
           }
-          linker.link(irFiles, moduleInitializers, linkerOutput, logger).map {
-            file =>
-              Report(
-                publicModules = Seq(Report.Module(
-                  moduleID = "main",
-                  jsFileName = jsFileName,
-                  sourceMapName = sourceMapNameOpt,
-                  moduleKind = moduleKind
-                )),
-                dest = dest
-              )
+          linker.link(irFiles, moduleInitializers, linkerOutput, logger).map { _ =>
+            Report(
+              publicModules = Seq(Report.Module(
+                moduleID = "main",
+                jsFileName = jsFileName,
+                sourceMapName = sourceMapNameOpt,
+                moduleKind = moduleKind
+              )),
+              dest = dest
+            )
           }
         } else {
           val linkerOutput = PathOutputDirectory(dest.toPath())

--- a/libs/scalajslib/worker/1/src/mill/scalajslib/worker/jsenv/Selenium.scala
+++ b/libs/scalajslib/worker/1/src/mill/scalajslib/worker/jsenv/Selenium.scala
@@ -1,22 +1,23 @@
 package mill.scalajslib.worker.jsenv
 
 import mill.scalajslib.worker.api._
+import scala.util.chaining.given
 
 object Selenium {
   def apply(config: JsEnvConfig.Selenium) =
     new org.scalajs.jsenv.selenium.SeleniumJSEnv(
       capabilities = config.capabilities match {
+
         case options: JsEnvConfig.Selenium.ChromeOptions =>
-          val result = new org.openqa.selenium.chrome.ChromeOptions()
-          result.setHeadless(options.headless)
-          result
+          new org.openqa.selenium.chrome.ChromeOptions()
+            .tap(_.setHeadless(options.headless))
+
         case options: JsEnvConfig.Selenium.FirefoxOptions =>
-          val result = new org.openqa.selenium.firefox.FirefoxOptions()
-          result.setHeadless(options.headless)
-          result
-        case options: JsEnvConfig.Selenium.SafariOptions =>
-          val result = new org.openqa.selenium.safari.SafariOptions()
-          result
+          new org.openqa.selenium.firefox.FirefoxOptions()
+            .tap(_.setHeadless(options.headless))
+
+        case _: JsEnvConfig.Selenium.SafariOptions =>
+          new org.openqa.selenium.safari.SafariOptions()
       }
     )
 }

--- a/libs/scalalib/api/src/mill/javalib/spring/boot/worker/SpringBootTools.scala
+++ b/libs/scalalib/api/src/mill/javalib/spring/boot/worker/SpringBootTools.scala
@@ -10,7 +10,7 @@ trait SpringBootTools {
       mainClass: String,
       libs: Seq[os.Path],
       assemblyScript: Option[String]
-  )(implicit ctx: TaskCtx): Unit
+  )(using ctx: TaskCtx): Unit
 
   /**
    * Find a SpringBootApplication entry point.

--- a/libs/scalalib/api/src/mill/scalalib/api/JvmWorkerApi.scala
+++ b/libs/scalalib/api/src/mill/scalalib/api/JvmWorkerApi.scala
@@ -17,7 +17,7 @@ trait JvmWorkerApi {
       reporter: Option[CompileProblemReporter],
       reportCachedProblems: Boolean,
       incrementalCompilation: Boolean
-  )(implicit ctx: JvmWorkerApi.Ctx): mill.api.Result[CompilationResult]
+  )(using ctx: JvmWorkerApi.Ctx): mill.api.Result[CompilationResult]
 
   /** Compile a mixed Scala/Java or Scala-only project */
   def compileMixed(
@@ -34,7 +34,7 @@ trait JvmWorkerApi {
       reportCachedProblems: Boolean,
       incrementalCompilation: Boolean,
       auxiliaryClassFileExtensions: Seq[String]
-  )(implicit ctx: JvmWorkerApi.Ctx): mill.api.Result[CompilationResult]
+  )(using ctx: JvmWorkerApi.Ctx): mill.api.Result[CompilationResult]
 
   def docJar(
       scalaVersion: String,
@@ -42,6 +42,6 @@ trait JvmWorkerApi {
       compilerClasspath: Seq[PathRef],
       scalacPluginClasspath: Seq[PathRef],
       args: Seq[String]
-  )(implicit ctx: JvmWorkerApi.Ctx): Boolean
+  )(using ctx: JvmWorkerApi.Ctx): Boolean
 
 }

--- a/libs/scalalib/spring-boot-worker/src/mill/javalib/spring/boot/worker/impl/SpringBootToolsImpl.scala
+++ b/libs/scalalib/spring-boot-worker/src/mill/javalib/spring/boot/worker/impl/SpringBootToolsImpl.scala
@@ -41,7 +41,7 @@ class SpringBootToolsImpl() extends SpringBootTools {
       mainClass: String,
       libs: Seq[Path],
       launchScript: Option[String]
-  )(implicit ctx: TaskCtx): Unit = {
+  )(using ctx: TaskCtx): Unit = {
     val repack = new Repackager(base.toIO)
     repack.setMainClass(mainClass)
 

--- a/libs/scalalib/test/src/mill/scalalib/JavaHomeTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/JavaHomeTests.scala
@@ -132,7 +132,7 @@ object JavaHomeTests extends TestSuite {
       test("test11") {
         UnitTester(HelloJavaJavaHome11Override, resourcePath).scoped { eval =>
 
-          val Left(ExecResult.Failure(ref1)) =
+          val Left(ExecResult.Failure(_)) =
             eval.apply(HelloJavaJavaHome11Override.core.test.testForked()): @unchecked
 
           //        assert(
@@ -146,7 +146,7 @@ object JavaHomeTests extends TestSuite {
       test("test17") {
         UnitTester(HelloJavaJavaHome17Override, resourcePath).scoped { eval =>
 
-          val Left(ExecResult.Failure(ref1)) =
+          val Left(ExecResult.Failure(_)) =
             eval.apply(HelloJavaJavaHome17Override.core.test.testForked()): @unchecked
 
           //        assert(
@@ -168,7 +168,7 @@ object JavaHomeTests extends TestSuite {
           resourcePathCompile,
           errStream = new PrintStream(baos)
         ).scoped { eval =>
-          val Left(result) = eval.apply(JavaJdk11DoesntCompile.javamodule.compile): @unchecked
+          val Left(_) = eval.apply(JavaJdk11DoesntCompile.javamodule.compile): @unchecked
           assert(baos.toString.contains("cannot find symbol"))
           assert(baos.toString.contains("method indent"))
         }
@@ -176,7 +176,7 @@ object JavaHomeTests extends TestSuite {
 
       test("jdk17java") {
         UnitTester(JavaJdk17Compiles, resourcePathCompile).scoped { eval =>
-          val Right(result) = eval.apply(JavaJdk17Compiles.javamodule.compile): @unchecked
+          val Right(_) = eval.apply(JavaJdk17Compiles.javamodule.compile): @unchecked
         }
       }
 
@@ -190,7 +190,7 @@ object JavaHomeTests extends TestSuite {
 
       test("jdk17scala") {
         UnitTester(JavaJdk17Compiles, resourcePathCompile).scoped { eval =>
-          val Right(result) = eval.apply(JavaJdk17Compiles.scalamodule.compile): @unchecked
+          val Right(_) = eval.apply(JavaJdk17Compiles.scalamodule.compile): @unchecked
         }
       }
     }

--- a/libs/scalalib/test/src/mill/scalalib/PublishModuleTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/PublishModuleTests.scala
@@ -361,7 +361,7 @@ object PublishModuleTests extends TestSuite {
       def clearRepo(): Unit =
         os.remove.all(ivy2Repo)
 
-      eval(compileAndRuntimeStuff.main.publishLocal(ivy2Repo.toString)).right.get
+      eval(compileAndRuntimeStuff.main.publishLocal(ivy2Repo.toString)).get
       assert(repoHasIvyXml())
       assert(repoHasJar())
       assert(repoHasSourcesJar())
@@ -369,7 +369,7 @@ object PublishModuleTests extends TestSuite {
 
       clearRepo()
 
-      eval(compileAndRuntimeStuff.main.publishLocal(ivy2Repo.toString, doc = false)).right.get
+      eval(compileAndRuntimeStuff.main.publishLocal(ivy2Repo.toString, doc = false)).get
       assert(repoHasIvyXml())
       assert(repoHasJar())
       assert(repoHasSourcesJar())
@@ -406,7 +406,7 @@ object PublishModuleTests extends TestSuite {
       def clearRepo(): Unit =
         os.remove.all(ivy2Repo)
 
-      eval(compileAndRuntimeStuff.transitive.publishLocal(ivy2Repo.toString)).right.get
+      eval(compileAndRuntimeStuff.transitive.publishLocal(ivy2Repo.toString)).get
       assert(!repoHasIvyXml(mainModuleName))
       assert(!repoHasJar(mainModuleName))
       assert(!repoHasSourcesJar(mainModuleName))
@@ -421,7 +421,7 @@ object PublishModuleTests extends TestSuite {
       eval(compileAndRuntimeStuff.transitive.publishLocal(
         ivy2Repo.toString,
         transitive = true
-      )).right.get
+      )).get
       assert(repoHasIvyXml(mainModuleName))
       assert(repoHasJar(mainModuleName))
       assert(repoHasSourcesJar(mainModuleName))
@@ -433,7 +433,7 @@ object PublishModuleTests extends TestSuite {
 
       clearRepo()
 
-      eval(compileAndRuntimeStuff.transitive.publishLocal(ivy2Repo.toString, doc = false)).right.get
+      eval(compileAndRuntimeStuff.transitive.publishLocal(ivy2Repo.toString, doc = false)).get
       assert(!repoHasIvyXml(mainModuleName))
       assert(!repoHasJar(mainModuleName))
       assert(!repoHasSourcesJar(mainModuleName))
@@ -461,7 +461,7 @@ object PublishModuleTests extends TestSuite {
 
       clearRepo()
 
-      eval(compileAndRuntimeStuff.runtimeTransitive.publishLocal(ivy2Repo.toString)).right.get
+      eval(compileAndRuntimeStuff.runtimeTransitive.publishLocal(ivy2Repo.toString)).get
       assert(!repoHasIvyXml(mainModuleName))
       assert(!repoHasJar(mainModuleName))
       assert(!repoHasSourcesJar(mainModuleName))
@@ -476,7 +476,7 @@ object PublishModuleTests extends TestSuite {
       eval(compileAndRuntimeStuff.runtimeTransitive.publishLocal(
         ivy2Repo.toString,
         transitive = true
-      )).right.get
+      )).get
       assert(repoHasIvyXml(mainModuleName))
       assert(repoHasJar(mainModuleName))
       assert(repoHasSourcesJar(mainModuleName))

--- a/libs/scalalib/test/src/mill/scalalib/PublishModuleTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/PublishModuleTests.scala
@@ -16,7 +16,6 @@ import mill.testkit.UnitTester
 import mill.testkit.TestRootModule
 import utest.*
 import mill.util.TokenReaders._
-import java.io.PrintStream
 import scala.jdk.CollectionConverters.*
 import scala.xml.NodeSeq
 
@@ -233,19 +232,19 @@ object PublishModuleTests extends TestSuite {
     test("pom-packaging-type") - {
       test("pom") - UnitTester(PomOnly, resourcePath).scoped { eval =>
         val Right(result) = eval.apply(PomOnly.core.pom): @unchecked
-//
-//        assert(
-//          os.exists(result.path),
-//          evalCount > 0
-//        )
-//
-//        val pomXml = scala.xml.XML.loadFile(result.path.toString)
-//        val scalaLibrary = pomXml \ "dependencies" \ "dependency"
-//        assert(
-//          (pomXml \ "packaging").text == PackagingType.Pom,
-//          (scalaLibrary \ "artifactId").text == "slf4j-api",
-//          (scalaLibrary \ "groupId").text == "org.slf4j"
-//        )
+
+        assert(
+          os.exists(result.value.path),
+          result.evalCount > 0
+        )
+
+        val pomXml = scala.xml.XML.loadFile(result.value.path.toString)
+        val scalaLibrary = pomXml \ "dependencies" \ "dependency"
+        assert(
+          (pomXml \ "packaging").text == PackagingType.Pom,
+          (scalaLibrary \ "artifactId").text == "slf4j-api",
+          (scalaLibrary \ "groupId").text == "org.slf4j"
+        )
       }
     }
 

--- a/libs/scalalib/worker/src/mill/scalalib/worker/JvmWorkerImpl.scala
+++ b/libs/scalalib/worker/src/mill/scalalib/worker/JvmWorkerImpl.scala
@@ -230,7 +230,7 @@ class JvmWorkerImpl(
       compilerClasspath: Seq[PathRef],
       scalacPluginClasspath: Seq[PathRef],
       args: Seq[String]
-  )(implicit ctx: JvmWorkerApi.Ctx): Boolean = {
+  )(using ctx: JvmWorkerApi.Ctx): Boolean = {
     withCompilers(
       scalaVersion,
       scalaOrganization,
@@ -474,7 +474,7 @@ class JvmWorkerImpl(
         scalaOrganization,
         javacRuntimeOptions
       )
-    ) { case (loader, compilers) =>
+    ) { case (_, compilers) =>
       f(compilers)
     }
   }
@@ -658,7 +658,7 @@ class JvmWorkerImpl(
       reporter.foreach(_.finish())
       previousScalaColor match {
         case null => sys.props.remove(scalaColorProp)
-        case v => sys.props(scalaColorProp) = previousScalaColor
+        case _ => sys.props(scalaColorProp) = previousScalaColor
       }
     }
   }

--- a/libs/scalalib/worker/src/mill/scalalib/worker/ZincProblemPosition.scala
+++ b/libs/scalalib/worker/src/mill/scalalib/worker/ZincProblemPosition.scala
@@ -2,8 +2,7 @@ package mill.scalalib.worker
 
 import java.io.File
 import java.util.Optional
-import mill.api._
-import mill.api.internal._
+import mill.api.internal.ProblemPosition
 import mill.api.internal.internal
 
 import scala.jdk.OptionConverters.RichOptional

--- a/libs/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
+++ b/libs/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
@@ -2,6 +2,7 @@ package mill
 package scalanativelib
 
 import mainargs.Flag
+import mill.{api => _, *}
 import mill.api.Result
 import mill.api.internal.bsp.ScalaBuildTarget
 import mill.scalalib.api.JvmWorkerUtil
@@ -14,9 +15,6 @@ import mill.scalanativelib.worker.{
   ScalaNativeWorkerExternalModule,
   api as workerApi
 }
-import mill.{api => _, *}
-
-import mill.constants.EnvVars
 import mill.scalanativelib.worker.api.ScalaNativeWorkerApi
 
 trait ScalaNativeModule extends ScalaModule with ScalaNativeModuleApi { outer =>

--- a/libs/scalanativelib/src/mill/scalanativelib/worker/ScalaNativeWorker.scala
+++ b/libs/scalanativelib/src/mill/scalanativelib/worker/ScalaNativeWorker.scala
@@ -1,13 +1,10 @@
 package mill.scalanativelib.worker
 
 import mill.define.{Discover}
-import mill.{PathRef, Task, Worker}
+import mill.{Task, Worker}
 import mill.scalanativelib.worker.{api => workerApi}
-import mill.util.CachedFactory
 
 import mill.util.ClassLoaderCachedFactory
-
-import java.net.URLClassLoader
 
 private[scalanativelib] class ScalaNativeWorker(jobs: Int)
     extends ClassLoaderCachedFactory[workerApi.ScalaNativeWorkerApi](jobs) {

--- a/libs/scalanativelib/test/src/mill/scalanativelib/CompileRunTests.scala
+++ b/libs/scalanativelib/test/src/mill/scalanativelib/CompileRunTests.scala
@@ -92,7 +92,7 @@ object CompileRunTests extends TestSuite {
 
         val outPath = result.value.classes.path
         val outputFiles = os.walk(outPath).filter(os.isFile).map(_.last).toSet
-        val expectedClassfiles = compileClassfiles(scalaVersion, scalaNativeVersion)
+        val expectedClassfiles = compileClassfiles(scalaVersion)
         assert(
           outputFiles == expectedClassfiles,
           result.evalCount > 0
@@ -147,7 +147,7 @@ object CompileRunTests extends TestSuite {
 
   }
 
-  def compileClassfiles(scalaVersion: String, scalaNativeVersion: String) = {
+  def compileClassfiles(scalaVersion: String) = {
     val common = Set(
       "ArgsParser$.class",
       "ArgsParser$.nir",

--- a/libs/scalanativelib/worker/0.5/src/mill/scalanativelib/worker/ScalaNativeWorkerImpl.scala
+++ b/libs/scalanativelib/worker/0.5/src/mill/scalanativelib/worker/ScalaNativeWorkerImpl.scala
@@ -1,7 +1,6 @@
 package mill.scalanativelib.worker
 
 import java.io.File
-import java.lang.System.err
 
 import mill.scalanativelib.worker.api._
 import scala.scalanative.util.Scope
@@ -28,11 +27,16 @@ class ScalaNativeWorkerImpl extends mill.scalanativelib.worker.api.ScalaNativeWo
 
   def logger(level: NativeLogLevel): Logger =
     Logger(
-      traceFn = msg => if (level.value >= NativeLogLevel.Trace.value) err.println(s"[trace] $msg"),
-      debugFn = msg => if (level.value >= NativeLogLevel.Debug.value) err.println(s"[debug] $msg"),
-      infoFn = msg => if (level.value >= NativeLogLevel.Info.value) err.println(s"[info] $msg"),
-      warnFn = msg => if (level.value >= NativeLogLevel.Warn.value) err.println(s"[warn] $msg"),
-      errorFn = msg => if (level.value >= NativeLogLevel.Error.value) err.println(s"[error] $msg")
+      traceFn =
+        msg => if (level.value >= NativeLogLevel.Trace.value) System.err.println(s"[trace] $msg"),
+      debugFn =
+        msg => if (level.value >= NativeLogLevel.Debug.value) System.err.println(s"[debug] $msg"),
+      infoFn =
+        msg => if (level.value >= NativeLogLevel.Info.value) System.err.println(s"[info] $msg"),
+      warnFn =
+        msg => if (level.value >= NativeLogLevel.Warn.value) System.err.println(s"[warn] $msg"),
+      errorFn =
+        msg => if (level.value >= NativeLogLevel.Error.value) System.err.println(s"[error] $msg")
     )
 
   def discoverClang(): File = Discover.clang().toFile

--- a/runner/codesig/src/mill/codesig/JvmModel.scala
+++ b/runner/codesig/src/mill/codesig/JvmModel.scala
@@ -50,7 +50,7 @@ object JvmModel {
     }
 
     object Desc extends Table[String, Desc] {
-      def create: String => Desc = s => JvmModel.this.Desc.read(s)(SymbolTable.this)
+      def create: String => Desc = s => JvmModel.this.Desc.read(s)(using SymbolTable.this)
       def read(name: String): Desc = get(name)
     }
   }

--- a/runner/codesig/src/mill/codesig/LocalSummary.scala
+++ b/runner/codesig/src/mill/codesig/LocalSummary.scala
@@ -41,7 +41,7 @@ object LocalSummary {
       isAbstract: Boolean
   )
   object MethodInfo {
-    implicit def rw(implicit st: SymbolTable): ReadWriter[MethodInfo] = macroRW
+    given rw(using SymbolTable): ReadWriter[MethodInfo] = macroRW
   }
 
   implicit def rw(implicit st: SymbolTable): ReadWriter[LocalSummary] = macroRW

--- a/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
+++ b/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
@@ -1,6 +1,6 @@
 package mill.daemon
 
-import mill.api.internal.{BuildFileApi, EvaluatorApi, PathRefApi, RootModuleApi, internal}
+import mill.api.internal.{BuildFileApi, EvaluatorApi, MillScalaParser, PathRefApi, RootModuleApi, internal}
 import mill.api.{Logger, Result, SystemStreams, Val}
 import mill.constants.CodeGenConstants.*
 import mill.constants.OutFiles.{millBuild, millRunnerState}
@@ -10,10 +10,10 @@ import mill.internal.PrefixLogger
 import mill.meta.{FileImportGraph, MillBuildRootModule}
 import mill.meta.CliImports
 import mill.util.BuildInfo
-
 import java.io.File
 import java.net.URLClassLoader
 import java.util.concurrent.ThreadPoolExecutor
+
 import scala.jdk.CollectionConverters.ListHasAsScala
 import scala.util.Using
 import scala.collection.mutable.Buffer
@@ -111,7 +111,7 @@ class MillBuildBootstrap(
         }
       } else {
         val parsedScriptFiles = FileImportGraph
-          .parseBuildFiles(projectRoot, currentRoot / os.up, output)
+          .parseBuildFiles(projectRoot, currentRoot / os.up, output, MillScalaParser.current.value)
 
         val state =
           if (os.exists(currentRoot)) evaluateRec(depth + 1)

--- a/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
+++ b/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
@@ -1,6 +1,13 @@
 package mill.daemon
 
-import mill.api.internal.{BuildFileApi, EvaluatorApi, MillScalaParser, PathRefApi, RootModuleApi, internal}
+import mill.api.internal.{
+  BuildFileApi,
+  EvaluatorApi,
+  MillScalaParser,
+  PathRefApi,
+  RootModuleApi,
+  internal
+}
 import mill.api.{Logger, Result, SystemStreams, Val}
 import mill.constants.CodeGenConstants.*
 import mill.constants.OutFiles.{millBuild, millRunnerState}

--- a/runner/daemon/src/mill/daemon/MillDaemonMain.scala
+++ b/runner/daemon/src/mill/daemon/MillDaemonMain.scala
@@ -3,9 +3,8 @@ package mill.daemon
 import mill.api.SystemStreams
 import mill.client.ClientUtil
 import mill.client.lock.{DoubleLock, Lock, Locks}
-import mill.constants.{OutFiles, DaemonFiles}
+import mill.constants.OutFiles
 import sun.misc.{Signal, SignalHandler}
-import scala.jdk.CollectionConverters.*
 
 import scala.util.Try
 

--- a/runner/daemon/src/mill/daemon/MillMain0.scala
+++ b/runner/daemon/src/mill/daemon/MillMain0.scala
@@ -180,7 +180,7 @@ object MillMain0 {
                         )
                         defaultJobCount
                       }
-                    case other =>
+                    case _ =>
                       streams.err.println(
                         s"Warning: ignoring leftover arguments passed to ${config.leftoverArgs.value.head}"
                       )

--- a/runner/daemon/src/mill/daemon/MillMain0.scala
+++ b/runner/daemon/src/mill/daemon/MillMain0.scala
@@ -3,24 +3,21 @@ package mill.daemon
 import mill.api.internal.internal
 import mill.api.{Logger, MillException, Result, SystemStreams}
 import mill.bsp.BSP
-import mill.client.lock.{DoubleLock, Lock}
-import mill.constants.{DaemonFiles, OutFiles, Util}
+import mill.client.lock.Lock
+import mill.constants.{DaemonFiles, OutFiles}
 import mill.define.BuildCtx
 import mill.internal.{Colors, MultiStream, PrefixLogger, PromptLogger, SimpleLogger}
 import mill.server.Server
 import mill.util.BuildInfo
 import mill.{api, define}
+import mill.api.internal.bsp.BspServerResult
 
 import java.io.{InputStream, PipedInputStream, PrintStream, PrintWriter, StringWriter}
 import java.lang.reflect.InvocationTargetException
 import java.util.Locale
 import java.util.concurrent.{ThreadPoolExecutor, TimeUnit}
-import java.util.concurrent.locks.ReentrantLock
-import scala.collection.immutable
 import scala.jdk.CollectionConverters.*
-import scala.util.control.NonFatal
-import scala.util.{Properties, Using}
-import mill.api.internal.bsp.BspServerResult
+import scala.util.Using
 
 @internal
 object MillMain0 {

--- a/runner/daemon/src/mill/daemon/MillScalaParserImpl.scala
+++ b/runner/daemon/src/mill/daemon/MillScalaParserImpl.scala
@@ -5,7 +5,6 @@ import dotty.tools.dotc.Driver
 import dotty.tools.dotc.ast.Positioned
 import dotty.tools.dotc.ast.Trees
 import dotty.tools.dotc.ast.untpd
-import dotty.tools.dotc.ast.untpd.ImportSelector
 import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.core.Contexts.ctx
 import dotty.tools.dotc.core.Contexts.inContext
@@ -27,7 +26,7 @@ import dotty.tools.dotc.util.SourceFile
 import dotty.tools.dotc.util.Spans.Span
 import dotty.tools.dotc.util.SourcePosition
 
-import mill.api.internal.{MillScalaParser}
+import mill.api.internal.MillScalaParser
 import mill.api.internal.MillScalaParser.{ObjectData, Snip}
 
 object MillScalaParserImpl extends MillScalaParser {

--- a/runner/daemon/src/mill/daemon/RunnerState.scala
+++ b/runner/daemon/src/mill/daemon/RunnerState.scala
@@ -3,7 +3,7 @@ package mill.daemon
 import mill.api.Val
 import mill.define.JsonFormatters._
 import mill.api.internal.{EvaluatorApi, internal, PathRefApi}
-import mill.define.{PathRef, RootModule0}
+import mill.define.RootModule0
 import mill.define.internal.Watchable
 import mill.api.MillURLClassLoader
 import upickle.default.{ReadWriter, macroRW}
@@ -63,10 +63,10 @@ object RunnerState {
         workerCache.map { case (k, (i, v)) =>
           (k, Frame.WorkerInfo(System.identityHashCode(v), i))
         },
-        evalWatched.collect { case Watchable.Path(p, quick, sig) =>
+        evalWatched.collect { case Watchable.Path(p, _, _) =>
           os.Path(p)
         },
-        moduleWatched.collect { case Watchable.Path(p, quick, sig) =>
+        moduleWatched.collect { case Watchable.Path(p, _, _) =>
           os.Path(p)
         },
         classLoaderOpt.map(_.identity),

--- a/runner/daemon/src/mill/daemon/Watching.scala
+++ b/runner/daemon/src/mill/daemon/Watching.scala
@@ -62,7 +62,7 @@ object Watching {
 
     watch match {
       case None =>
-        val Result(watchables, errorOpt, result) =
+        val Result(_, errorOpt, result) =
           evaluate(enterKeyPressed = false, previousState = None)
         handleError(errorOpt)
         (errorOpt.isEmpty, result)
@@ -262,12 +262,12 @@ object Watching {
   def poll(w: Watchable): Long = w match {
     case Watchable.Path(p, quick, sig) =>
       new PathRef(os.Path(p), quick, sig, PathRef.Revalidate.Once).recomputeSig()
-    case Watchable.Value(f, sig, pretty) => f()
+    case Watchable.Value(f, _, _) => f()
   }
 
   def signature(w: Watchable): Long = w match {
     case Watchable.Path(p, quick, sig) =>
       new PathRef(os.Path(p), quick, sig, PathRef.Revalidate.Once).sig
-    case Watchable.Value(f, sig, pretty) => sig
+    case Watchable.Value(f, sig, _) => sig
   }
 }

--- a/runner/launcher/src/mill/launcher/CoursierClient.scala
+++ b/runner/launcher/src/mill/launcher/CoursierClient.scala
@@ -1,38 +1,16 @@
 package mill.launcher
 
+import coursier.{Artifacts, Dependency, ModuleName, Organization, Resolve, VersionConstraint}
 import coursier.cache.{ArchiveCache, FileCache}
 import coursier.jvm.{JavaHome, JvmCache, JvmChannel, JvmIndex}
 import coursier.util.Task
-import coursier.{
-  Artifacts,
-  Classifier,
-  Dependency,
-  ModuleName,
-  Organization,
-  Repository,
-  Resolution,
-  Resolve,
-  Type,
-  VersionConstraint
-}
-import coursier.cache.{ArchiveCache, CachePolicy, FileCache}
-import coursier.core.{BomDependency, Module}
-import coursier.error.FetchError.DownloadingArtifacts
-import coursier.error.ResolutionError.CantDownloadModule
-import coursier.jvm.{JavaHome, JvmCache, JvmChannel, JvmIndex}
-import coursier.params.ResolutionParams
-import coursier.parse.RepositoryParser
-import coursier.util.Task
+import coursier.core.Module
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
-import coursier.core.{ArtifactSource, Extension, Info, Module, Project, Publication}
-import coursier.util.{Artifact, EitherT, Monad}
-import coursier.{Classifier, Dependency, Repository, Type}
 import mill.coursierutil.TestOverridesRepo
 
-import java.util.concurrent.ConcurrentHashMap
 object CoursierClient {
   def resolveMillDaemon() = {
     val repositories = Await.result(Resolve().finalRepositories.future(), Duration.Inf)
@@ -83,6 +61,6 @@ object CoursierClient {
       // rather than the highest already on disk
       .withUpdate(true)
 
-    javaHome.get(id).unsafeRun()(coursierCache0.ec)
+    javaHome.get(id).unsafeRun()(using coursierCache0.ec)
   }
 }

--- a/runner/meta/src/mill/meta/FileImportGraph.scala
+++ b/runner/meta/src/mill/meta/FileImportGraph.scala
@@ -42,7 +42,8 @@ object FileImportGraph {
   def parseBuildFiles(
       topLevelProjectRoot: os.Path,
       projectRoot: os.Path,
-      output: os.Path
+      output: os.Path,
+      parser: MillScalaParser = MillScalaParser.current.value
   ): FileImportGraph = {
     val seenScripts = mutable.Map.empty[os.Path, String]
     val errors = mutable.Buffer.empty[String]
@@ -59,7 +60,7 @@ object FileImportGraph {
             catch { case e: RuntimeException => Left(e.getMessage) }
 
         yamlHeaderError.flatMap(_ =>
-          MillScalaParser.current.value.splitScript(content, fileName)
+          parser.splitScript(content, fileName)
         ) match {
           case Right((prefix, pkgs, stmts)) =>
             val importSegments = pkgs.mkString(".")

--- a/runner/meta/src/mill/meta/MillBuildRootModule.scala
+++ b/runner/meta/src/mill/meta/MillBuildRootModule.scala
@@ -316,7 +316,8 @@ object MillBuildRootModule {
     FileImportGraph.parseBuildFiles(
       millBuildRootModuleInfo.topLevelProjectRoot,
       millBuildRootModuleInfo.projectRoot / os.up,
-      millBuildRootModuleInfo.output
+      millBuildRootModuleInfo.output,
+      parser
     )
   }
 }

--- a/runner/server/src/mill/server/Server.scala
+++ b/runner/server/src/mill/server/Server.scala
@@ -2,17 +2,17 @@ package mill.server
 
 import mill.api.SystemStreams
 import mill.constants.ProxyStream.Output
-import mill.client.lock.{DoubleLock, Lock, Locks}
+import mill.client.lock.{Lock, Locks}
 import mill.client.*
 import mill.constants.{DaemonFiles, InputPumper}
+import mill.constants.OutFiles
 import mill.constants.ProxyStream
 
 import java.io.*
-import java.net.{InetAddress, Socket, ServerSocket}
+import java.net.{InetAddress, Socket}
 import scala.jdk.CollectionConverters.*
 import scala.util.Try
 import scala.util.Using
-import mill.constants.OutFiles
 
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -180,7 +180,7 @@ abstract class Server[T](
         ProxyStream.sendHeartbeat(currentOutErr)
         true
       } catch {
-        case e: Throwable =>
+        case _: Throwable =>
           clientDisappeared = true
           false
       }
@@ -285,7 +285,7 @@ abstract class Server[T](
       Thread.sleep(5)
       try t.stop()
       catch {
-        case e: UnsupportedOperationException =>
+        case _: UnsupportedOperationException =>
         // nothing we can do about, removed in Java 20
         case e: java.lang.Error if e.getMessage.contains("Cleaner terminated abnormally") =>
         // ignore this error and do nothing; seems benign
@@ -325,7 +325,7 @@ object Server {
   }
   def checkProcessIdFile(processIdFile: os.Path, processId: String): Option[String] = {
     Try(os.read(processIdFile)) match {
-      case scala.util.Failure(e) => Some(s"processId file missing")
+      case scala.util.Failure(_) => Some(s"processId file missing")
 
       case scala.util.Success(s) =>
         Option.when(s != processId) {
@@ -383,7 +383,7 @@ object Server {
       def activeTaskString =
         try os.read(out / OutFiles.millActiveCommand)
         catch {
-          case e => "<unknown>"
+          case _ => "<unknown>"
         }
 
       def activeTaskPrefix = s"Another Mill process is running '$activeTaskString',"


### PR DESCRIPTION
* use `using` keyword
* remove unused vars
* cleanup imports 
* silence partial matches in tests
* use named tuples
* avoid deprecated converters
* removed unused code