### PR TITLE
Move `TestGraphs` from `libs.main` to `core.define` modules

### DIFF
--- a/core/define/package.mill
+++ b/core/define/package.mill
@@ -30,4 +30,7 @@ object `package` extends MillStableScalaModule {
     Deps.mainargs,
     Deps.fastparse
   )
+
+  def testModuleDeps = super.testModuleDeps ++ Seq(build.testkit)
+  def testMvnDeps = Seq(Deps.coursierInterface)
 }

--- a/core/define/test/src/mill/define/BasePathTests.scala
+++ b/core/define/test/src/mill/define/BasePathTests.scala
@@ -1,6 +1,6 @@
 package mill.define
 
-import mill.util.TestGraphs
+import mill.define.TestGraphs
 import mill.testkit.TestRootModule
 import utest._
 

--- a/core/define/test/src/mill/define/DiscoverTests.scala
+++ b/core/define/test/src/mill/define/DiscoverTests.scala
@@ -1,6 +1,6 @@
 package mill.define
 
-import mill.util.TestGraphs
+import mill.define.TestGraphs
 import Task.Simple
 import utest._
 

--- a/core/define/test/src/mill/define/ModuleTests.scala
+++ b/core/define/test/src/mill/define/ModuleTests.scala
@@ -1,6 +1,6 @@
 package mill.define
 
-import mill.util.TestGraphs
+import mill.define.TestGraphs
 import utest.*
 
 /**

--- a/core/define/test/src/mill/define/TestGraphs.scala
+++ b/core/define/test/src/mill/define/TestGraphs.scala
@@ -1,8 +1,9 @@
-package mill.util
+package mill.define
+
 import mainargs.arg
-import mill.testkit.TestRootModule
-import mill.define.{Cross, Discover, TaskModule}
 import mill.*
+import mill.define.{Cross, Discover, TaskModule}
+import mill.testkit.TestRootModule
 
 /**
  * Example dependency graphs for us to use in our test suite.
@@ -134,7 +135,7 @@ object TestGraphs {
 
   trait TraitWithModule extends Module { outer =>
     object TraitModule extends Module {
-      def testFrameworks = Task { Seq("mill.UTestFramework") }
+      def testFrameworks = Task { Seq("mill.define.UTestFramework") }
       def test() = Task.Command { () /*do nothing*/ }
     }
   }

--- a/core/define/test/src/mill/define/UTestFramework.scala
+++ b/core/define/test/src/mill/define/UTestFramework.scala
@@ -1,4 +1,4 @@
-package mill
+package mill.define
 
 class UTestFramework extends utest.runner.Framework {
   override def exceptionStackFrameHighlighter(s: StackTraceElement): Boolean = {

--- a/core/exec/test/src/mill/exec/CrossTests.scala
+++ b/core/exec/test/src/mill/exec/CrossTests.scala
@@ -4,8 +4,14 @@ import mill.define.Discover
 import mill.{Cross, Task}
 import mill.testkit.{TestRootModule, UnitTester}
 import mill.testkit.UnitTester.Result
-import mill.util.TestGraphs
-import mill.util.TestGraphs.{crossResolved, doubleCross, nestedCrosses, nonStringCross, singleCross}
+import mill.define.TestGraphs
+import mill.define.TestGraphs.{
+  crossResolved,
+  doubleCross,
+  nestedCrosses,
+  nonStringCross,
+  singleCross
+}
 import utest.*
 
 object CrossTests extends TestSuite {

--- a/core/exec/test/src/mill/exec/ExecutionTests.scala
+++ b/core/exec/test/src/mill/exec/ExecutionTests.scala
@@ -1,7 +1,7 @@
 package mill.exec
 
 import mill.define.{Discover, Task}
-import mill.util.TestGraphs
+import mill.define.TestGraphs
 import mill.testkit.{TestRootModule, UnitTester}
 import mill.{PathRef, exec}
 import utest.*

--- a/core/exec/test/src/mill/exec/PlanTests.scala
+++ b/core/exec/test/src/mill/exec/PlanTests.scala
@@ -2,7 +2,7 @@ package mill.exec
 
 import mill.define.Task
 import mill.define.Task.Simple
-import mill.util.TestGraphs
+import mill.define.TestGraphs
 import utest.*
 
 import scala.collection.mutable

--- a/core/resolve/test/src/mill/resolve/ModuleTests.scala
+++ b/core/resolve/test/src/mill/resolve/ModuleTests.scala
@@ -4,7 +4,7 @@ import mill.api.Result
 import mill.define.{Discover, ModuleRef, Task, TaskModule}
 import mill.testkit.TestRootModule
 import mill.define.DynamicModule
-import mill.util.TestGraphs.*
+import mill.define.TestGraphs.*
 import mill.{Cross, Module}
 import utest.*
 

--- a/core/resolve/test/src/mill/resolve/ResolveTests.scala
+++ b/core/resolve/test/src/mill/resolve/ResolveTests.scala
@@ -2,8 +2,8 @@ package mill.resolve
 
 import mill.api.Result
 import mill.define.Discover
-import mill.util.TestGraphs
-import mill.util.TestGraphs.*
+import mill.define.TestGraphs
+import mill.define.TestGraphs.*
 import mill.testkit.TestRootModule
 import mill.{Module, Task}
 import utest.*

--- a/libs/main/package.mill
+++ b/libs/main/package.mill
@@ -36,7 +36,4 @@ object `package` extends MillStableScalaModule {
     Deps.jgraphtCore,
     Deps.graphvizWithExcludes
   )
-
-  def testModuleDeps = super.testModuleDeps ++ Seq(build.testkit)
-  def testMvnDeps = Seq(Deps.coursierInterface)
 }

--- a/libs/main/test/src/mill/TestMain.scala
+++ b/libs/main/test/src/mill/TestMain.scala
@@ -1,5 +1,0 @@
-package mill
-
-object TestMain {
-  def main(args: Array[String]): Unit = {}
-}

--- a/mill-build/src/millbuild/MillBaseTestsModule.scala
+++ b/mill-build/src/millbuild/MillBaseTestsModule.scala
@@ -28,6 +28,6 @@ trait MillBaseTestsModule extends TestModule {
     )
   }
 
-  def testFramework = "mill.UTestFramework"
+  def testFramework = "mill.define.UTestFramework"
   def testParallelism = true
 }

--- a/mill-build/src/millbuild/MillJavaModule.scala
+++ b/mill-build/src/millbuild/MillJavaModule.scala
@@ -42,8 +42,8 @@ trait MillJavaModule extends JavaModule {
   def testMvnDeps: T[Seq[Dep]] = Seq(Deps.TestDeps.utest)
   def testForkEnv: T[Map[String, String]] = forkEnv() ++ localTestOverridesEnv()
   def testModuleDeps: Seq[JavaModule] =
-    if (this == build.libs.main) Seq(build.libs.main, build.core.util)
-    else Seq(this, build.libs.main.test)
+    if (this == build.core.define) Seq(build.core.define)
+    else Seq(this, build.core.define.test)
 
   def localTestOverridesEnv = Task {
     transitiveLocalTestOverrides()


### PR DESCRIPTION
It only really requires stuff in `core` anyway, so no sense pulling in stuff in `main`

After this PR, ` ./mill plan core.define.test | grep main.` no longer returns any results