### PR TITLE
Move `VcsVersion` and `SubfolderModule` out of `mill.main` into its own module, re-enable forgotten tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -212,7 +212,7 @@ jobs:
             install-sbt: false
 
           - java-version: 11
-            millargs: "'example.{cli,fundamentals,depth,extending}.__.local.daemon'"
+            millargs: "'example.{cli,fundamentals,depth,extending,large}.__.local.daemon'"
             install-android-sdk: false
             install-sbt: false
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -139,7 +139,7 @@ jobs:
             install-sbt: true
 
           - java-version: 17
-            millargs: "'libs.{main,scalalib,testrunner}.__.test'"
+            millargs: "'libs.{main,scalalib,testrunner,vcs,androidlib,graphviz,init,tabcomplete}.__.test'"
             install-android-sdk: false
             install-sbt: true
 

--- a/ci/mill-bootstrap.patch
+++ b/ci/mill-bootstrap.patch
@@ -1,0 +1,13 @@
+diff --git a/build.mill b/build.mill
+index 7a17b99362a..67ebbcd2434 100644
+--- a/build.mill
++++ b/build.mill
+@@ -9,7 +9,7 @@ import millbuild.*
+ //import com.github.lolgab.mill.mima.Mima
+ import coursier.maven.MavenRepository
+ import coursier.VersionConstraint
+-import mill.main.VcsVersion
++import mill.vcs.VcsVersion
+ //import com.goyeau.mill.scalafix.ScalafixModule
+ import mill._
+ import mill.main.Tasks

--- a/core/define/src/mill/define/SubfolderModule.scala
+++ b/core/define/src/mill/define/SubfolderModule.scala
@@ -1,6 +1,7 @@
-package mill.main;
+package mill.define
+
+import mill.define.{Discover, ModuleCtx, Segments}
 import mill.*
-import mill.define.{ModuleCtx, Discover, Segments}
 
 object SubfolderModule {
   class Info(val millSourcePath0: os.Path, val segments: Seq[String]) {

--- a/integration/failure/root-module-compile-error/src/RootModuleCompileErrorTests.scala
+++ b/integration/failure/root-module-compile-error/src/RootModuleCompileErrorTests.scala
@@ -29,7 +29,7 @@ object RootModuleCompileErrorTests extends UtestIntegrationTestSuite {
         assert(res.err.replace('\\', '/').contains("""foo/package.mill:6:92"""))
         assert(res.err.contains("""Not found: type UnknownFooModule"""))
         assert(res.err.contains(
-          """abstract class package_  extends _root_.mill.main.SubfolderModule(build.millDiscover) with UnknownFooModule {"""
+          """abstract class package_  extends _root_.mill.define.SubfolderModule(build.millDiscover) with UnknownFooModule {"""
         ))
         assert(res.err.contains(
           """                                                                                           ^^^^^^^^^^^^^^^^"""

--- a/integration/failure/root-module-compile-error/src/RootModuleCompileErrorTests.scala
+++ b/integration/failure/root-module-compile-error/src/RootModuleCompileErrorTests.scala
@@ -26,7 +26,7 @@ object RootModuleCompileErrorTests extends UtestIntegrationTestSuite {
 
       locally {
         // For now these error messages still show generated/mangled code; not ideal, but it'll do
-        assert(res.err.replace('\\', '/').contains("""foo/package.mill:6:92"""))
+        assert(res.err.replace('\\', '/').contains("""foo/package.mill:6:94"""))
         assert(res.err.contains("""Not found: type UnknownFooModule"""))
         assert(res.err.contains(
           """abstract class package_  extends _root_.mill.define.SubfolderModule(build.millDiscover) with UnknownFooModule {"""

--- a/integration/ide/build-classpath-contents/src/BuildClasspathContentsTests.scala
+++ b/integration/ide/build-classpath-contents/src/BuildClasspathContentsTests.scala
@@ -44,6 +44,7 @@ object BuildClasspathContentsTests extends UtestIntegrationTestSuite {
           "mill-libs-tabcomplete_3.jar",
           "mill-libs-testrunner-entrypoint.jar",
           "mill-libs-testrunner_3.jar",
+          "mill-libs-vcs_3.jar",
           "mill-libs_3.jar",
           "mill-moduledefs_3-0.11.4.jar"
         )

--- a/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.iml
+++ b/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.iml
@@ -76,6 +76,7 @@
         <orderEntry type="library" name="mill-libs-tabcomplete_3.jar" level="project"/>
         <orderEntry type="library" name="mill-libs-testrunner-entrypoint.jar" level="project"/>
         <orderEntry type="library" name="mill-libs-testrunner_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-vcs_3.jar" level="project"/>
         <orderEntry type="library" name="mill-libs_3.jar" level="project"/>
         <orderEntry type="library" name="mill-moduledefs_3-0.11.4.jar" level="project"/>
         <orderEntry type="library" name="munit_3-0.7.29.jar" level="project"/>

--- a/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.mill-build.iml
+++ b/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.mill-build.iml
@@ -77,6 +77,7 @@
         <orderEntry type="library" name="mill-libs-tabcomplete_3.jar" level="project"/>
         <orderEntry type="library" name="mill-libs-testrunner-entrypoint.jar" level="project"/>
         <orderEntry type="library" name="mill-libs-testrunner_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-vcs_3.jar" level="project"/>
         <orderEntry type="library" name="mill-libs_3.jar" level="project"/>
         <orderEntry type="library" name="mill-moduledefs_3-0.11.4.jar" level="project"/>
         <orderEntry type="library" name="mill-runner-codesig_3.jar" level="project"/>

--- a/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/mill-build.iml
+++ b/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/mill-build.iml
@@ -73,6 +73,7 @@
         <orderEntry type="library" name="mill-libs-tabcomplete_3.jar" level="project"/>
         <orderEntry type="library" name="mill-libs-testrunner-entrypoint.jar" level="project"/>
         <orderEntry type="library" name="mill-libs-testrunner_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-vcs_3.jar" level="project"/>
         <orderEntry type="library" name="mill-libs_3.jar" level="project"/>
         <orderEntry type="library" name="mill-moduledefs_3-0.11.4.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="native-terminal-no-ffm-0.0.9.1.jar" level="project"/>

--- a/libs/init/buildgen/src/mill/main/buildgen/BuildGenUtil.scala
+++ b/libs/init/buildgen/src/mill/main/buildgen/BuildGenUtil.scala
@@ -343,9 +343,8 @@ object BuildGenUtil {
   }
 
   def renderExtends(supertypes: Seq[String]): String = supertypes match {
-    case Seq() => ""
-    case Seq(head) => s"extends $head"
-    case head +: tail => tail.mkString(s"extends $head with ", " with ", "")
+    case Seq() => "extends mill.Module"
+    case items => s"extends ${items.mkString(" with ")}"
   }
 
   def renderLicense(

--- a/libs/init/gradle/src/mill/main/gradle/GradleBuildGenMain.scala
+++ b/libs/init/gradle/src/mill/main/gradle/GradleBuildGenMain.scala
@@ -202,7 +202,7 @@ object GradleBuildGenMain extends BuildGenBase.MavenAndGradle[ProjectModel, Dep]
       Option.when(null != build.value.maven().pom() && {
         val baseTrait = baseInfo.moduleTypedef
         baseTrait == null || !baseTrait.moduleSupertypes.contains("PublishModule")
-      }) { "PublishModule" } ++
+      }) { "PublishModule" }.toSeq ++
       Option.when(build.dirs.nonEmpty || os.exists(getMillSourcePath(build.value) / "src")) {
         getModuleSupertypes(cfg)
       }.toSeq.flatten

--- a/libs/init/gradle/src/mill/main/gradle/GradleBuildGenMain.scala
+++ b/libs/init/gradle/src/mill/main/gradle/GradleBuildGenMain.scala
@@ -199,7 +199,6 @@ object GradleBuildGenMain extends BuildGenBase.MavenAndGradle[ProjectModel, Dep]
       baseInfo: IrBaseInfo,
       build: Node[ProjectModel]
   ): Seq[String] =
-    Seq("mill.Module") ++
       Option.when(null != build.value.maven().pom() && {
         val baseTrait = baseInfo.moduleTypedef
         baseTrait == null || !baseTrait.moduleSupertypes.contains("PublishModule")

--- a/libs/init/gradle/src/mill/main/gradle/GradleBuildGenMain.scala
+++ b/libs/init/gradle/src/mill/main/gradle/GradleBuildGenMain.scala
@@ -199,10 +199,10 @@ object GradleBuildGenMain extends BuildGenBase.MavenAndGradle[ProjectModel, Dep]
       baseInfo: IrBaseInfo,
       build: Node[ProjectModel]
   ): Seq[String] =
-      Option.when(null != build.value.maven().pom() && {
-        val baseTrait = baseInfo.moduleTypedef
-        baseTrait == null || !baseTrait.moduleSupertypes.contains("PublishModule")
-      }) { "PublishModule" }.toSeq ++
+    Option.when(null != build.value.maven().pom() && {
+      val baseTrait = baseInfo.moduleTypedef
+      baseTrait == null || !baseTrait.moduleSupertypes.contains("PublishModule")
+    }) { "PublishModule" }.toSeq ++
       Option.when(build.dirs.nonEmpty || os.exists(getMillSourcePath(build.value) / "src")) {
         getModuleSupertypes(cfg)
       }.toSeq.flatten

--- a/libs/init/maven/src/mill/main/maven/MavenBuildGenMain.scala
+++ b/libs/init/maven/src/mill/main/maven/MavenBuildGenMain.scala
@@ -140,7 +140,7 @@ object MavenBuildGenMain extends BuildGenBase.MavenAndGradle[Model, Dependency] 
   def getMillSourcePath(model: Model): Path = os.Path(model.getProjectDirectory)
 
   override def getSupertypes(cfg: Config, baseInfo: IrBaseInfo, build: Node[Model]): Seq[String] =
-      cfg.shared.basicConfig.baseModule.fold(getModuleSupertypes(cfg))(Seq(_))
+    cfg.shared.basicConfig.baseModule.fold(getModuleSupertypes(cfg))(Seq(_))
 
   def processResources(
       input: java.util.List[org.apache.maven.model.Resource],

--- a/libs/init/maven/src/mill/main/maven/MavenBuildGenMain.scala
+++ b/libs/init/maven/src/mill/main/maven/MavenBuildGenMain.scala
@@ -140,7 +140,6 @@ object MavenBuildGenMain extends BuildGenBase.MavenAndGradle[Model, Dependency] 
   def getMillSourcePath(model: Model): Path = os.Path(model.getProjectDirectory)
 
   override def getSupertypes(cfg: Config, baseInfo: IrBaseInfo, build: Node[Model]): Seq[String] =
-    Seq("mill.Module") ++
       cfg.shared.basicConfig.baseModule.fold(getModuleSupertypes(cfg))(Seq(_))
 
   def processResources(

--- a/libs/init/sbt/src/mill/main/sbt/SbtBuildGenMain.scala
+++ b/libs/init/sbt/src/mill/main/sbt/SbtBuildGenMain.scala
@@ -286,7 +286,7 @@ object SbtBuildGenMain
   def getMillSourcePath(project: Project): Path = os.Path(project.projectDirectory)
 
   override def getSupertypes(cfg: Config, baseInfo: IrBaseInfo, build: Node[Project]): Seq[String] =
-    Seq("mill.Module") ++ getModuleSupertypes(cfg)
+    getModuleSupertypes(cfg)
 
   def getJavacOptions(buildInfo: BuildInfo): Seq[String] =
     buildInfo.javacOptions.getOrElse(Seq.empty)

--- a/libs/main/package.mill
+++ b/libs/main/package.mill
@@ -10,9 +10,8 @@ import mill.scalalib.api.JvmWorkerUtil
 import millbuild.*
 
 /**
- * This package encapsulates the entire classpath that is available within the `build.mill`
- * file, for use by build authors or plugin authors. All the various language `*lib` modules,
- * the available `core.*` modules, and builtin tasks defined on the top-level `build` object.
+ * This package contains all the default tasks available in a Mill build: `show`, `path`,
+ * `resolve`, etc. along with their respective modules
  */
 object `package` extends MillStableScalaModule {
 

--- a/libs/package.mill
+++ b/libs/package.mill
@@ -17,6 +17,7 @@ object `package` extends MillStableScalaModule {
     build.libs.pythonlib,
     build.libs.init,
     build.libs.main,
-    build.libs.tabcomplete
+    build.libs.tabcomplete,
+    build.libs.vcs,
   )
 }

--- a/libs/package.mill
+++ b/libs/package.mill
@@ -18,6 +18,6 @@ object `package` extends MillStableScalaModule {
     build.libs.init,
     build.libs.main,
     build.libs.tabcomplete,
-    build.libs.vcs,
+    build.libs.vcs
   )
 }

--- a/libs/vcs/package.mill
+++ b/libs/vcs/package.mill
@@ -1,0 +1,7 @@
+package build.libs.vcs
+import mill._
+import millbuild.*
+
+object `package` extends MillPublishScalaModule {
+  def moduleDeps = Seq(build.core.define)
+}

--- a/libs/vcs/src/mill/vcs/VcsVersion.scala
+++ b/libs/vcs/src/mill/vcs/VcsVersion.scala
@@ -1,9 +1,8 @@
-package mill.main
-
+package mill.vcs
 import scala.util.Try
-import mill.define.Task
+import mill.define.{Task, Module}
+import mill.define.Task.{Simple => T}
 import mill.api.Logger
-import mill.*
 import mill.define.{Discover, ExternalModule}
 import os.SubprocessException
 
@@ -92,7 +91,7 @@ object VcsVersion extends ExternalModule with VcsVersion {
   lazy val millDiscover = Discover[this.type]
 }
 
-trait VcsVersion extends mill.Module {
+trait VcsVersion extends Module {
 
   def vcsBasePath: os.Path = moduleDir
 

--- a/libs/vcs/test/src/mill/vcs/VcsVersionTests.scala
+++ b/libs/vcs/test/src/mill/vcs/VcsVersionTests.scala
@@ -1,4 +1,4 @@
-package mill.main
+package mill.vcs
 
 import utest.*
 object VcsVersionTests extends TestSuite {

--- a/runner/meta/src/mill/meta/CodeGen.scala
+++ b/runner/meta/src/mill/meta/CodeGen.scala
@@ -233,7 +233,7 @@ object CodeGen {
 
     val newParent =
       if (segments.isEmpty) "_root_.mill.main.MainRootModule"
-      else "_root_.mill.main.SubfolderModule(build.millDiscover)"
+      else "_root_.mill.define.SubfolderModule(build.millDiscover)"
 
     objectData.find(o => o.name.text == "`package`") match {
       case Some(objectData) =>
@@ -290,7 +290,7 @@ object CodeGen {
       segments: Seq[String]
   ): String = {
     s"""|object MillMiscInfo
-        |    extends mill.main.SubfolderModule.Info(
+        |    extends mill.define.SubfolderModule.Info(
         |  millSourcePath0 = os.Path(${literalize(scriptFolderPath.toString)}),
         |  segments = _root_.scala.Seq(${segments.map(pprint.Util.literalize(_)).mkString(", ")})
         |)


### PR DESCRIPTION
This makes the purpose of each module much cleaner and easier to document and understand

Also re-enabled some module test suites we forgot to enable before in CI