### PR TITLE
Fix `Task.Sources` override in `./mill init`

### DIFF
--- a/libs/init/buildgen/src/mill/main/buildgen/BuildGenUtil.scala
+++ b/libs/init/buildgen/src/mill/main/buildgen/BuildGenUtil.scala
@@ -460,10 +460,11 @@ object BuildGenUtil {
 
   def renderResources(args: IterableOnce[os.SubPath]): String =
     optional(
-      "def resources = Task.Sources { super.resources() ++ Seq(",
-      args.iterator.map(sub => s"PathRef(moduleDir / ${escape(sub.toString())})"),
+      """def resources = Task { super.resources() ++ customResources() }
+        |def customResources = Task.Sources(""".stripMargin,
+      args.iterator.map(sub => escape(sub.toString())),
       ", ",
-      ") }"
+      ")"
     )
 
   def renderPomPackaging(packaging: String): String =

--- a/libs/init/maven/test/resources/expected/misc/build.mill
+++ b/libs/init/maven/test/resources/expected/misc/build.mill
@@ -34,8 +34,8 @@ object `package` extends PublishModule with MavenModule {
 
   def publishVersion = "1.0-SNAPSHOT"
 
-  def resources = Task
-    .Sources { super.resources() ++ Seq(PathRef(moduleDir / "resources")) }
+  def resources = Task { super.resources() ++ customResources() }
+  def customResources = Task.Sources("resources")
 
   object test extends MavenTests with TestModule.Junit4 {
 
@@ -46,12 +46,8 @@ object `package` extends PublishModule with MavenModule {
       mvn"org.mockito:mockito-core:1.8.5"
     )
 
-    def resources = Task.Sources {
-      super.resources() ++ Seq(
-        PathRef(moduleDir / "test/resources"),
-        PathRef(moduleDir / "src/test/secrets")
-      )
-    }
+    def resources = Task { super.resources() ++ customResources() }
+    def customResources = Task.Sources("test/resources", "src/test/secrets")
 
     def testSandboxWorkingDir = false
     def testParallelism = false


### PR DESCRIPTION
We no longer allow calling upstream tasks in `Task.Sources`, and thus have to split it into a standalone `Task.Sources` and a normal `Task` that aggregates the `Task.Sources` with the `super`