### PR TITLE
Remove leftover Kotlin multiplatform suffixes

### DIFF
--- a/example/kotlinlib/basic/1-simple/build.mill
+++ b/example/kotlinlib/basic/1-simple/build.mill
@@ -7,13 +7,13 @@ object foo extends KotlinModule {
   def kotlinVersion = "1.9.24"
 
   def mvnDeps = Seq(
-    mvn"com.github.ajalt.clikt:clikt-jvm:4.4.0",
-    mvn"org.jetbrains.kotlinx:kotlinx-html-jvm:0.11.0"
+    mvn"com.github.ajalt.clikt:clikt:4.4.0",
+    mvn"org.jetbrains.kotlinx:kotlinx-html:0.11.0"
   )
 
   object test extends KotlinTests with TestModule.Junit5 {
     def mvnDeps = Seq(
-      mvn"io.kotest:kotest-runner-junit5-jvm:5.9.1"
+      mvn"io.kotest:kotest-runner-junit5:5.9.1"
     )
   }
 }

--- a/example/kotlinlib/basic/2-custom-build-logic/build.mill
+++ b/example/kotlinlib/basic/2-custom-build-logic/build.mill
@@ -21,7 +21,7 @@ object foo extends KotlinModule {
 
   object test extends KotlinTests with TestModule.Junit5 {
     def mvnDeps = super.mvnDeps() ++ Seq(
-      mvn"io.kotest:kotest-runner-junit5-jvm:5.9.1"
+      mvn"io.kotest:kotest-runner-junit5:5.9.1"
     )
   }
 }

--- a/example/kotlinlib/basic/3-multi-module/build.mill
+++ b/example/kotlinlib/basic/3-multi-module/build.mill
@@ -7,7 +7,7 @@ trait MyModule extends KotlinModule {
 
   object test extends KotlinTests with TestModule.Junit5 {
     def mvnDeps = super.mvnDeps() ++ Seq(
-      mvn"io.kotest:kotest-runner-junit5-jvm:5.9.1"
+      mvn"io.kotest:kotest-runner-junit5:5.9.1"
     )
   }
 }
@@ -15,14 +15,14 @@ trait MyModule extends KotlinModule {
 object foo extends MyModule {
   def moduleDeps = Seq(bar)
   def mvnDeps = Seq(
-    mvn"com.github.ajalt.clikt:clikt-jvm:4.4.0"
+    mvn"com.github.ajalt.clikt:clikt:4.4.0"
   )
 }
 
 object bar extends MyModule {
   def mainClass = Some("bar.BarKt")
   def mvnDeps = Seq(
-    mvn"org.jetbrains.kotlinx:kotlinx-html-jvm:0.11.0"
+    mvn"org.jetbrains.kotlinx:kotlinx-html:0.11.0"
   )
 }
 

--- a/example/kotlinlib/basic/4-compat-modules/build.mill
+++ b/example/kotlinlib/basic/4-compat-modules/build.mill
@@ -14,7 +14,7 @@ object foo extends KotlinModule with KotlinMavenModule {
 
   object test extends KotlinMavenTests with TestModule.Junit5 {
     def mvnDeps = super.mvnDeps() ++ Seq(
-      mvn"io.kotest:kotest-runner-junit5-jvm:5.9.1"
+      mvn"io.kotest:kotest-runner-junit5:5.9.1"
     )
   }
 }

--- a/example/kotlinlib/basic/6-realistic/build.mill
+++ b/example/kotlinlib/basic/6-realistic/build.mill
@@ -16,11 +16,11 @@ trait MyModule extends KotlinModule with PublishModule {
 
   def kotlinVersion = "1.9.24"
 
-  def mvnDeps = Seq(mvn"org.jetbrains.kotlinx:kotlinx-html-jvm:0.11.0")
+  def mvnDeps = Seq(mvn"org.jetbrains.kotlinx:kotlinx-html:0.11.0")
 
   object test extends KotlinTests with TestModule.Junit5 {
     def mvnDeps = super.mvnDeps() ++ Seq(
-      mvn"io.kotest:kotest-runner-junit5-jvm:5.9.1"
+      mvn"io.kotest:kotest-runner-junit5:5.9.1"
     )
   }
 }

--- a/example/kotlinlib/basic/7-dependency-injection/build.mill
+++ b/example/kotlinlib/basic/7-dependency-injection/build.mill
@@ -30,7 +30,7 @@ object dagger extends KspModule {
 
     def mvnDeps = super.mvnDeps() ++ Seq(
       mvn"com.google.dagger:dagger-compiler:2.55",
-      mvn"io.kotest:kotest-runner-junit5-jvm:5.9.1"
+      mvn"io.kotest:kotest-runner-junit5:5.9.1"
     )
 
     def kotlinSymbolProcessors = Seq(

--- a/example/kotlinlib/dependencies/5-repository-config/build.mill
+++ b/example/kotlinlib/dependencies/5-repository-config/build.mill
@@ -9,8 +9,8 @@ object foo extends KotlinModule {
   def kotlinVersion = "1.9.24"
 
   def mvnDeps = Seq(
-    mvn"com.github.ajalt.clikt:clikt-jvm:4.4.0",
-    mvn"org.jetbrains.kotlinx:kotlinx-html-jvm:0.11.0"
+    mvn"com.github.ajalt.clikt:clikt:4.4.0",
+    mvn"org.jetbrains.kotlinx:kotlinx-html:0.11.0"
   )
 
   def repositories = Seq("https://oss.sonatype.org/content/repositories/releases")

--- a/example/kotlinlib/linting/4-kover/build.mill
+++ b/example/kotlinlib/linting/4-kover/build.mill
@@ -11,7 +11,7 @@ object `package` extends KotlinModule with KoverModule {
 
     }
     override def mvnDeps = super.mvnDeps() ++ Seq(
-      mvn"io.kotest:kotest-runner-junit5-jvm:5.9.1"
+      mvn"io.kotest:kotest-runner-junit5:5.9.1"
     )
   }
 

--- a/example/kotlinlib/module/1-common-config/build.mill
+++ b/example/kotlinlib/module/1-common-config/build.mill
@@ -5,7 +5,7 @@ import mill._, kotlinlib._
 object `package` extends KotlinModule {
   // You can have arbitrary numbers of third-party dependencies
   def mvnDeps = Seq(
-    mvn"org.jetbrains.kotlinx:kotlinx-html-jvm:0.11.0"
+    mvn"org.jetbrains.kotlinx:kotlinx-html:0.11.0"
   )
 
   def kotlinVersion = "1.9.24"

--- a/example/kotlinlib/module/15-jni/build.mill
+++ b/example/kotlinlib/module/15-jni/build.mill
@@ -34,7 +34,7 @@ object `package` extends KotlinModule {
 
   object test extends KotlinTests with TestModule.Junit5 {
     def mvnDeps = super.mvnDeps() ++ Seq(
-      mvn"io.kotest:kotest-runner-junit5-jvm:5.9.1"
+      mvn"io.kotest:kotest-runner-junit5:5.9.1"
     )
     def forkEnv = Map("HELLO_WORLD_BINARY" -> nativeCompiled().path.toString)
   }

--- a/example/kotlinlib/module/2-custom-tasks/build.mill
+++ b/example/kotlinlib/module/2-custom-tasks/build.mill
@@ -6,7 +6,7 @@ object `package` extends KotlinModule {
 
   def kotlinVersion = "1.9.24"
 
-  def mvnDeps = Seq(mvn"com.github.ajalt.clikt:clikt-jvm:4.4.0")
+  def mvnDeps = Seq(mvn"com.github.ajalt.clikt:clikt:4.4.0")
 
   def generatedSources: T[Seq[PathRef]] = Task {
     val prettyMvnDeps = for (ivyDep <- mvnDeps()) yield {
@@ -49,7 +49,7 @@ object `package` extends KotlinModule {
 
 > ./mill run --text hello
 text: hello
-MyDeps.value: com.github.ajalt.clikt:clikt-jvm:4.4.0
+MyDeps.value: com.github.ajalt.clikt:clikt:4.4.0
 my.line.count: 17
 
 > ./mill show lineCount

--- a/example/kotlinlib/module/7-resources/build.mill
+++ b/example/kotlinlib/module/7-resources/build.mill
@@ -14,7 +14,7 @@ object foo extends KotlinModule {
     )
 
     def mvnDeps = super.mvnDeps() ++ Seq(
-      mvn"io.kotest:kotest-runner-junit5-jvm:5.9.1"
+      mvn"io.kotest:kotest-runner-junit5:5.9.1"
     )
   }
 }

--- a/example/kotlinlib/module/8-kotlin-compiler-plugins/build.mill
+++ b/example/kotlinlib/module/8-kotlin-compiler-plugins/build.mill
@@ -29,7 +29,7 @@ object foo extends KotlinModule {
 
   object test extends KotlinTests with TestModule.Junit5 {
     def mvnDeps = super.mvnDeps() ++ Seq(
-      mvn"io.kotest:kotest-runner-junit5-jvm:5.9.1"
+      mvn"io.kotest:kotest-runner-junit5:5.9.1"
     )
   }
 }

--- a/example/kotlinlib/publishing/8-native-image-libs/build.mill
+++ b/example/kotlinlib/publishing/8-native-image-libs/build.mill
@@ -13,8 +13,8 @@ object foo extends KotlinModule with NativeImageModule {
   )
 
   def mvnDeps = Seq(
-    mvn"com.github.ajalt.clikt:clikt-jvm:4.4.0",
-    mvn"org.jetbrains.kotlinx:kotlinx-html-jvm:0.11.0"
+    mvn"com.github.ajalt.clikt:clikt:4.4.0",
+    mvn"org.jetbrains.kotlinx:kotlinx-html:0.11.0"
   )
 
   def jvmId = "graalvm-community:23.0.2"

--- a/example/kotlinlib/testing/1-test-suite/build.mill
+++ b/example/kotlinlib/testing/1-test-suite/build.mill
@@ -10,7 +10,7 @@ object foo extends KotlinModule {
     def testFramework = "com.github.sbt.junit.jupiter.api.JupiterFramework"
     def mvnDeps = Seq(
       mvn"com.github.sbt.junit:jupiter-interface:0.11.4",
-      mvn"io.kotest:kotest-runner-junit5-jvm:5.9.1",
+      mvn"io.kotest:kotest-runner-junit5:5.9.1",
       mvn"org.mockito.kotlin:mockito-kotlin:5.4.0"
     )
 
@@ -35,7 +35,7 @@ object bar extends KotlinModule {
 
   object test extends KotlinTests with TestModule.Junit5 {
     def mvnDeps = super.mvnDeps() ++ Seq(
-      mvn"io.kotest:kotest-runner-junit5-jvm:5.9.1",
+      mvn"io.kotest:kotest-runner-junit5:5.9.1",
       mvn"org.mockito.kotlin:mockito-kotlin:5.4.0"
     )
 

--- a/example/kotlinlib/testing/2-test-deps/build.mill
+++ b/example/kotlinlib/testing/2-test-deps/build.mill
@@ -11,7 +11,7 @@ object qux extends KotlinModule {
   object test extends KotlinTests with TestModule.Junit5 {
     def moduleDeps = super.moduleDeps ++ Seq(baz.test)
     def mvnDeps = super.mvnDeps() ++ Seq(
-      mvn"io.kotest:kotest-runner-junit5-jvm:5.9.1",
+      mvn"io.kotest:kotest-runner-junit5:5.9.1",
       mvn"com.google.guava:guava:33.3.0-jre"
     )
   }
@@ -23,7 +23,7 @@ object baz extends KotlinModule {
 
   object test extends KotlinTests with TestModule.Junit5 {
     def mvnDeps = super.mvnDeps() ++ Seq(
-      mvn"io.kotest:kotest-runner-junit5-jvm:5.9.1",
+      mvn"io.kotest:kotest-runner-junit5:5.9.1",
       mvn"com.google.guava:guava:33.3.0-jre"
     )
   }

--- a/example/kotlinlib/testing/3-integration-suite/build.mill
+++ b/example/kotlinlib/testing/3-integration-suite/build.mill
@@ -7,12 +7,12 @@ object qux extends KotlinModule {
 
   object test extends KotlinTests with TestModule.Junit5 {
     def mvnDeps = super.mvnDeps() ++ Seq(
-      mvn"io.kotest:kotest-runner-junit5-jvm:5.9.1"
+      mvn"io.kotest:kotest-runner-junit5:5.9.1"
     )
   }
   object integration extends KotlinTests with TestModule.Junit5 {
     def mvnDeps = super.mvnDeps() ++ Seq(
-      mvn"io.kotest:kotest-runner-junit5-jvm:5.9.1"
+      mvn"io.kotest:kotest-runner-junit5:5.9.1"
     )
   }
 }

--- a/example/kotlinlib/testing/4-test-parallel/build.mill
+++ b/example/kotlinlib/testing/4-test-parallel/build.mill
@@ -10,7 +10,7 @@ object foo extends KotlinModule {
     def testFramework = "com.github.sbt.junit.jupiter.api.JupiterFramework"
     def mvnDeps = Seq(
       mvn"com.github.sbt.junit:jupiter-interface:0.11.4",
-      mvn"io.kotest:kotest-runner-junit5-jvm:5.9.1",
+      mvn"io.kotest:kotest-runner-junit5:5.9.1",
       mvn"org.mockito.kotlin:mockito-kotlin:5.4.0"
     )
 

--- a/example/kotlinlib/testing/5-test-grouping/build.mill
+++ b/example/kotlinlib/testing/5-test-grouping/build.mill
@@ -10,7 +10,7 @@ object foo extends KotlinModule {
     def testFramework = "com.github.sbt.junit.jupiter.api.JupiterFramework"
     def mvnDeps = Seq(
       mvn"com.github.sbt.junit:jupiter-interface:0.11.4",
-      mvn"io.kotest:kotest-runner-junit5-jvm:5.9.1",
+      mvn"io.kotest:kotest-runner-junit5:5.9.1",
       mvn"org.mockito.kotlin:mockito-kotlin:5.4.0"
     )
 

--- a/example/kotlinlib/testing/6-test-group-parallel/build.mill
+++ b/example/kotlinlib/testing/6-test-group-parallel/build.mill
@@ -10,7 +10,7 @@ object foo extends KotlinModule {
     def testFramework = "com.github.sbt.junit.jupiter.api.JupiterFramework"
     def mvnDeps = Seq(
       mvn"com.github.sbt.junit:jupiter-interface:0.11.4",
-      mvn"io.kotest:kotest-runner-junit5-jvm:5.9.1",
+      mvn"io.kotest:kotest-runner-junit5:5.9.1",
       mvn"org.mockito.kotlin:mockito-kotlin:5.4.0"
     )
 

--- a/example/kotlinlib/web/1-hello-ktor/build.mill
+++ b/example/kotlinlib/web/1-hello-ktor/build.mill
@@ -9,14 +9,14 @@ object `package` extends KotlinModule {
   def mainClass = Some("com.example.HelloKtorKt")
 
   def mvnDeps = Seq(
-    mvn"io.ktor:ktor-server-core-jvm:2.3.12",
-    mvn"io.ktor:ktor-server-netty-jvm:2.3.12"
+    mvn"io.ktor:ktor-server-core:2.3.12",
+    mvn"io.ktor:ktor-server-netty:2.3.12"
   )
 
   object test extends KotlinTests with TestModule.Junit5 {
     def mvnDeps = super.mvnDeps() ++ Seq(
-      mvn"io.kotest:kotest-runner-junit5-jvm:5.9.1",
-      mvn"io.ktor:ktor-server-test-host-jvm:2.3.12"
+      mvn"io.kotest:kotest-runner-junit5:5.9.1",
+      mvn"io.ktor:ktor-server-test-host:2.3.12"
     )
   }
 }

--- a/example/kotlinlib/web/2-todo-ktor/build.mill
+++ b/example/kotlinlib/web/2-todo-ktor/build.mill
@@ -14,14 +14,14 @@ object `package` extends KotlinModule {
   val exposedVersion = "0.53.0"
 
   def mvnDeps = Seq(
-    mvn"io.ktor:ktor-server-core-jvm:$ktorVersion",
-    mvn"io.ktor:ktor-server-netty-jvm:$ktorVersion",
+    mvn"io.ktor:ktor-server-core:$ktorVersion",
+    mvn"io.ktor:ktor-server-netty:$ktorVersion",
     mvn"org.jetbrains.exposed:exposed-core:$exposedVersion",
     mvn"org.jetbrains.exposed:exposed-jdbc:$exposedVersion",
     mvn"com.h2database:h2:2.2.224",
-    mvn"io.ktor:ktor-server-webjars-jvm:$ktorVersion",
+    mvn"io.ktor:ktor-server-webjars:$ktorVersion",
     mvn"org.webjars:jquery:3.2.1",
-    mvn"io.ktor:ktor-server-thymeleaf-jvm:$ktorVersion",
+    mvn"io.ktor:ktor-server-thymeleaf:$ktorVersion",
     mvn"org.webjars:webjars-locator:0.41",
     mvn"org.webjars.npm:todomvc-common:1.0.5",
     mvn"org.webjars.npm:todomvc-app-css:2.4.1",
@@ -30,8 +30,8 @@ object `package` extends KotlinModule {
 
   object test extends KotlinTests with TestModule.Junit5 {
     def mvnDeps = super.mvnDeps() ++ Seq(
-      mvn"io.kotest:kotest-runner-junit5-jvm:5.9.1",
-      mvn"io.ktor:ktor-server-test-host-jvm:2.3.12"
+      mvn"io.kotest:kotest-runner-junit5:5.9.1",
+      mvn"io.ktor:ktor-server-test-host:2.3.12"
     )
   }
 }

--- a/example/kotlinlib/web/3-hello-kotlinjs/build.mill
+++ b/example/kotlinlib/web/3-hello-kotlinjs/build.mill
@@ -15,7 +15,7 @@ object `package` extends KotlinJsModule {
   override def kotlinVersion = "1.9.25"
   override def kotlinJsRunTarget = Some(RunTarget.Node)
   override def mvnDeps = Seq(
-    mvn"org.jetbrains.kotlinx:kotlinx-html-js:0.11.0"
+    mvn"org.jetbrains.kotlinx:kotlinx-html:0.11.0"
   )
   object test extends KotlinJsModule with KotestTests {
     override def kotestVersion = "5.9.1"

--- a/example/kotlinlib/web/4-webapp-kotlinjs/build.mill
+++ b/example/kotlinlib/web/4-webapp-kotlinjs/build.mill
@@ -16,9 +16,9 @@ object `package` extends KotlinModule {
   override def mainClass = Some("webapp.WebApp")
 
   override def mvnDeps = Seq(
-    mvn"io.ktor:ktor-server-core-jvm:$ktorVersion",
-    mvn"io.ktor:ktor-server-netty-jvm:$ktorVersion",
-    mvn"io.ktor:ktor-server-html-builder-jvm:$ktorVersion"
+    mvn"io.ktor:ktor-server-core:$ktorVersion",
+    mvn"io.ktor:ktor-server-netty:$ktorVersion",
+    mvn"io.ktor:ktor-server-html-builder:$ktorVersion"
   )
 
   override def resources = Task {
@@ -33,8 +33,8 @@ object `package` extends KotlinModule {
 
   object test extends KotlinTests with TestModule.Junit5 {
     override def mvnDeps = super.mvnDeps() ++ Seq(
-      mvn"io.kotest:kotest-runner-junit5-jvm:5.9.1",
-      mvn"io.ktor:ktor-server-test-host-jvm:$ktorVersion"
+      mvn"io.kotest:kotest-runner-junit5:5.9.1",
+      mvn"io.ktor:ktor-server-test-host:$ktorVersion"
     )
   }
 
@@ -44,7 +44,7 @@ object `package` extends KotlinModule {
     override def kotlinJsSplitPerModule = false
 
     override def mvnDeps = Seq(
-      mvn"org.jetbrains.kotlinx:kotlinx-html-js:$kotlinHtmlVersion"
+      mvn"org.jetbrains.kotlinx:kotlinx-html:$kotlinHtmlVersion"
     )
   }
 }

--- a/example/kotlinlib/web/5-webapp-kotlinjs-shared/build.mill
+++ b/example/kotlinlib/web/5-webapp-kotlinjs-shared/build.mill
@@ -24,11 +24,11 @@ object `package` extends AppKotlinModule {
   override def moduleDeps = Seq(shared.jvm)
 
   override def mvnDeps = Seq(
-    mvn"io.ktor:ktor-server-core-jvm:$ktorVersion",
-    mvn"io.ktor:ktor-server-netty-jvm:$ktorVersion",
-    mvn"io.ktor:ktor-server-html-builder-jvm:$ktorVersion",
-    mvn"io.ktor:ktor-server-content-negotiation-jvm:$ktorVersion",
-    mvn"io.ktor:ktor-serialization-kotlinx-json-jvm:$ktorVersion",
+    mvn"io.ktor:ktor-server-core:$ktorVersion",
+    mvn"io.ktor:ktor-server-netty:$ktorVersion",
+    mvn"io.ktor:ktor-server-html-builder:$ktorVersion",
+    mvn"io.ktor:ktor-server-content-negotiation:$ktorVersion",
+    mvn"io.ktor:ktor-serialization-kotlinx-json:$ktorVersion",
     mvn"ch.qos.logback:logback-classic:1.5.8"
   )
 
@@ -42,8 +42,8 @@ object `package` extends AppKotlinModule {
 
   object test extends KotlinTests with TestModule.Junit5 {
     override def mvnDeps = super.mvnDeps() ++ Seq(
-      mvn"io.kotest:kotest-runner-junit5-jvm:5.9.1",
-      mvn"io.ktor:ktor-server-test-host-jvm:$ktorVersion"
+      mvn"io.kotest:kotest-runner-junit5:5.9.1",
+      mvn"io.ktor:ktor-server-test-host:$ktorVersion"
     )
   }
 
@@ -57,14 +57,14 @@ object `package` extends AppKotlinModule {
 
     object jvm extends SharedModule {
       override def mvnDeps = super.mvnDeps() ++ Seq(
-        mvn"org.jetbrains.kotlinx:kotlinx-html-jvm:$kotlinHtmlVersion",
-        mvn"org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:$kotlinxSerializationVersion"
+        mvn"org.jetbrains.kotlinx:kotlinx-html:$kotlinHtmlVersion",
+        mvn"org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion"
       )
     }
     object js extends SharedModule with AppKotlinJsModule {
       override def mvnDeps = super.mvnDeps() ++ Seq(
-        mvn"org.jetbrains.kotlinx:kotlinx-html-js:$kotlinHtmlVersion",
-        mvn"org.jetbrains.kotlinx:kotlinx-serialization-json-js:$kotlinxSerializationVersion"
+        mvn"org.jetbrains.kotlinx:kotlinx-html:$kotlinHtmlVersion",
+        mvn"org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion"
       )
     }
   }
@@ -73,8 +73,8 @@ object `package` extends AppKotlinModule {
     override def kotlinJsSplitPerModule = false
     override def moduleDeps = Seq(shared.js)
     override def mvnDeps = Seq(
-      mvn"org.jetbrains.kotlinx:kotlinx-html-js:$kotlinHtmlVersion",
-      mvn"org.jetbrains.kotlinx:kotlinx-serialization-json-js:$kotlinxSerializationVersion"
+      mvn"org.jetbrains.kotlinx:kotlinx-html:$kotlinHtmlVersion",
+      mvn"org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion"
     )
   }
 }

--- a/example/thirdparty/arrow/build.mill
+++ b/example/thirdparty/arrow/build.mill
@@ -31,29 +31,29 @@ object libraries {
 
   // libraries
   val coroutinesCoreJvm =
-    mvn"org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:${versions.coroutines}"
+    mvn"org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.coroutines}"
   val coroutinesCoreJs =
-    mvn"org.jetbrains.kotlinx:kotlinx-coroutines-core-js:${versions.coroutines}"
+    mvn"org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.coroutines}"
   val coroutinesTestJvm =
-    mvn"org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm:${versions.coroutines}"
+    mvn"org.jetbrains.kotlinx:kotlinx-coroutines-test:${versions.coroutines}"
   val coroutinesTestJs =
-    mvn"org.jetbrains.kotlinx:kotlinx-coroutines-test-js:${versions.coroutines}"
-  val kotestAssertionsCoreJvm = mvn"io.kotest:kotest-assertions-core-jvm:${versions.kotest}"
-  val kotestAssertionsCoreJs = mvn"io.kotest:kotest-assertions-core-js:${versions.kotest}"
-  val kotestPropertyJvm = mvn"io.kotest:kotest-property-jvm:${versions.kotest}"
-  val kotestPropertyJs = mvn"io.kotest:kotest-property-js:${versions.kotest}"
+    mvn"org.jetbrains.kotlinx:kotlinx-coroutines-test:${versions.coroutines}"
+  val kotestAssertionsCoreJvm = mvn"io.kotest:kotest-assertions-core:${versions.kotest}"
+  val kotestAssertionsCoreJs = mvn"io.kotest:kotest-assertions-core:${versions.kotest}"
+  val kotestPropertyJvm = mvn"io.kotest:kotest-property:${versions.kotest}"
+  val kotestPropertyJs = mvn"io.kotest:kotest-property:${versions.kotest}"
   val kotlinReflect = mvn"org.jetbrains.kotlin:kotlin-reflect:${versions.kotlin}"
   val kotlinStdlib = mvn"org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"
   val kotlinTestJunit5 = mvn"org.jetbrains.kotlin:kotlin-test-junit5:${versions.kotlin}"
-  val kotlinTestJs = mvn"org.jetbrains.kotlin:kotlin-test-js:${versions.kotlin}"
+  val kotlinTestJs = mvn"org.jetbrains.kotlin:kotlin-test:${versions.kotlin}"
   val kotlinxSerializationCoreJvm =
-    mvn"org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:${versions.kotlinxSerialization}"
+    mvn"org.jetbrains.kotlinx:kotlinx-serialization-core:${versions.kotlinxSerialization}"
   val kotlinxSerializationCoreJs =
-    mvn"org.jetbrains.kotlinx:kotlinx-serialization-core-js:${versions.kotlinxSerialization}"
+    mvn"org.jetbrains.kotlinx:kotlinx-serialization-core:${versions.kotlinxSerialization}"
   val kotlinxSerializationJson =
     mvn"org.jetbrains.kotlinx:kotlinx-serialization-json:${versions.kotlinxSerialization}"
   val kotlinxSerializationJsonJs =
-    mvn"org.jetbrains.kotlinx:kotlinx-serialization-json-js:${versions.kotlinxSerialization}"
+    mvn"org.jetbrains.kotlinx:kotlinx-serialization-json:${versions.kotlinxSerialization}"
   val squareupOkhttpMockWebServer =
     mvn"com.squareup.okhttp3:mockwebserver:${versions.mockWebServer}"
   val squareupRetrofitLib = mvn"com.squareup.retrofit2:retrofit:${versions.retrofit}"
@@ -71,8 +71,8 @@ object libraries {
   val composeRuntime = mvn"androidx.compose.runtime:runtime:${versions.compose}"
   val kotlinCompileTesting = mvn"dev.zacsweers.kctfork:core:${versions.kotlinCompileTesting}"
   val kotlinCompileTestingKsp = mvn"dev.zacsweers.kctfork:ksp:${versions.kotlinCompileTesting}"
-  val cache4kJs = mvn"io.github.reactivecircus.cache4k:cache4k-js:${versions.cache4k}"
-  val cache4kJvm = mvn"io.github.reactivecircus.cache4k:cache4k-jvm:${versions.cache4k}"
+  val cache4kJs = mvn"io.github.reactivecircus.cache4k:cache4k:${versions.cache4k}"
+  val cache4kJvm = mvn"io.github.reactivecircus.cache4k:cache4k:${versions.cache4k}"
 
   // plugins
   val kotlinxSerializationPlugin =

--- a/libs/kotlinlib/src/mill/kotlinlib/js/KotlinJsModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/js/KotlinJsModule.scala
@@ -73,7 +73,7 @@ trait KotlinJsModule extends KotlinModule { outer =>
       // Filter out the non-js kotlin-stdlib
       .filterNot(d => d.organization == "org.jetbrains.kotlin" && d.name == "kotlin-stdlib") ++
       Seq(
-        mvn"org.jetbrains.kotlin:kotlin-stdlib-js:${kotlinVersion()}"
+        mvn"org.jetbrains.kotlin:kotlin-stdlib:${kotlinVersion()}"
       )
   }
 
@@ -698,7 +698,7 @@ trait KotlinJsModule extends KotlinModule { outer =>
    */
   trait KotlinTestPackageTests extends KotlinJsTests {
     override def mandatoryMvnDeps: T[Seq[Dep]] = super.mandatoryMvnDeps() ++ Seq(
-      mvn"org.jetbrains.kotlin:kotlin-test-js:${kotlinVersion()}"
+      mvn"org.jetbrains.kotlin:kotlin-test:${kotlinVersion()}"
     )
   }
 
@@ -714,15 +714,15 @@ trait KotlinJsModule extends KotlinModule { outer =>
     def kotestVersion: T[String]
 
     override def kotlincPluginMvnDeps: T[Seq[Dep]] = super.kotlincPluginMvnDeps() ++ Seq(
-      mvn"io.kotest:kotest-framework-multiplatform-plugin-embeddable-compiler-jvm:${kotestVersion()}"
+      mvn"io.kotest:kotest-framework-multiplatform-plugin-embeddable-compiler:${kotestVersion()}"
     )
 
     override def mandatoryMvnDeps: T[Seq[Dep]] = super.mandatoryMvnDeps() ++ Seq(
-      mvn"io.kotest:kotest-framework-engine-js:${kotestVersion()}"
+      mvn"io.kotest:kotest-framework-engine:${kotestVersion()}"
         // buggy JVM dependency of a kotlin-js dependency?
         // seems that exclusion can be dropped for kotest-framework-engine-js >= 6.0.0.M2
         .exclude(("org.jetbrains.kotlinx", "kotlinx-coroutines-debug")),
-      mvn"io.kotest:kotest-assertions-core-js:${kotestVersion()}"
+      mvn"io.kotest:kotest-assertions-core:${kotestVersion()}"
     )
   }
 

--- a/libs/kotlinlib/test/src/mill/kotlinlib/HelloKotlinTests.scala
+++ b/libs/kotlinlib/test/src/mill/kotlinlib/HelloKotlinTests.scala
@@ -33,7 +33,7 @@ object HelloKotlinTests extends TestSuite {
       }
       object kotest extends KotlinTests with TestModule.Junit5 {
         override def mvnDeps = super.mvnDeps() ++ Seq(
-          mvn"io.kotest:kotest-runner-junit5-jvm:${junit5Version}"
+          mvn"io.kotest:kotest-runner-junit5:${junit5Version}"
         )
       }
     }

--- a/libs/kotlinlib/test/src/mill/kotlinlib/contrib/kover/KoverModuleTests.scala
+++ b/libs/kotlinlib/test/src/mill/kotlinlib/contrib/kover/KoverModuleTests.scala
@@ -24,7 +24,7 @@ object KoverModuleTests extends TestSuite {
 
       }
       override def mvnDeps = super.mvnDeps() ++ Seq(
-        mvn"io.kotest:kotest-runner-junit5-jvm:5.9.1"
+        mvn"io.kotest:kotest-runner-junit5:5.9.1"
       )
     }
 

--- a/libs/kotlinlib/test/src/mill/kotlinlib/js/KotlinJsKotlinVersionsTests.scala
+++ b/libs/kotlinlib/test/src/mill/kotlinlib/js/KotlinJsKotlinVersionsTests.scala
@@ -30,7 +30,7 @@ object KotlinJsKotlinVersionsTests extends TestSuite {
         case _ => "0.11.0"
       }
       super.mvnDeps() ++ Seq(
-        mvn"org.jetbrains.kotlinx:kotlinx-html-js:$kotlinxHtmlVersion"
+        mvn"org.jetbrains.kotlinx:kotlinx-html:$kotlinxHtmlVersion"
       )
     }
   }

--- a/mill-build/src/millbuild/Deps.scala
+++ b/mill-build/src/millbuild/Deps.scala
@@ -220,8 +220,8 @@ object Deps {
     val freemarker = mvn"org.freemarker:freemarker:2.3.34"
     val jupiterInterface = mvn"com.github.sbt.junit:jupiter-interface:0.13.3"
     val kotestJvm =
-      mvn"io.kotest:kotest-framework-multiplatform-plugin-embeddable-compiler-jvm:5.9.1"
-    val kotlinxHtmlJvm = mvn"org.jetbrains.kotlinx:kotlinx-html-jvm:0.11.0"
+      mvn"io.kotest:kotest-framework-multiplatform-plugin-embeddable-compiler:5.9.1"
+    val kotlinxHtmlJvm = mvn"org.jetbrains.kotlinx:kotlinx-html:0.11.0"
     val koverCli = mvn"org.jetbrains.kotlinx:kover-cli:$koverVersion"
     val koverJvmAgent = mvn"org.jetbrains.kotlinx:kover-jvm-agent:$koverVersion"
     val ktfmt = mvn"com.facebook:ktfmt:0.53"


### PR DESCRIPTION
Now that Coursier can understand KMP artifact metadata and resolution natively, we no longer need to manually specify the platform-specific version of each artifact
