### PR TITLE
Improve error message for command instantiation failure

### DIFF
--- a/core/resolve/src/mill/resolve/Resolve.scala
+++ b/core/resolve/src/mill/resolve/Resolve.scala
@@ -199,7 +199,7 @@ private[mill] object Resolve {
         allowPositionalCommandArgs
       )
 
-      invoked.head
+      invoked
     }.flatMap(x => x)
   }
 
@@ -210,9 +210,13 @@ private[mill] object Resolve {
       rest: Seq[String],
       nullCommandDefaults: Boolean,
       allowPositionalCommandArgs: Boolean
-  ): Option[Result[Task.Command[?]]] = for {
-    ep <- discover.resolveEntrypoint(target.getClass, name)
-  } yield {
+  ): Result[Task.Command[?]] = {
+    val ep = discover.resolveEntrypoint(target.getClass, name)
+      .getOrElse(
+        sys.error(
+          s"Unable to resolve command $name on module $target of class ${target.getClass}"
+        )
+      )
     def withNullDefault(a: mainargs.ArgSig): mainargs.ArgSig = {
       if (a.default.nonEmpty) a
       else if (nullCommandDefaults) {


### PR DESCRIPTION
Hopefully this will make failures easier to debug than the status quo error:
```
java.util.NoSuchElementException: head of empty list
scala.collection.immutable.Nil$.head(List.scala:663)
scala.collection.immutable.Nil$.head(List.scala:662)
mill.resolve.Resolve$.instantiateCommand$$anonfun$1)Resolve.scala:202)
```