### PR TITLE
Fix `./mill init` example download in 0.12.x

### DIFF
--- a/dist/package.mill
+++ b/dist/package.mill
@@ -271,14 +271,15 @@ object `package` extends RootModule with InstallModule {
     prepareBootstrapLauncher(millBootstrapBat().path, Task.dest, build.millVersion(), "mill.bat")
   }
 
-  def examplePathsWithArtifactName: Task[Seq[(PathRef, String)]] = Task.Anon {
-    for {
-      exampleMod <- build.example.exampleModules
-      path = exampleMod.millSourcePath
-    } yield {
-      val example = path.subRelativeTo(Task.workspace)
+  def examplePathsWithArtifactName0: Task[Seq[PathRef]] = Task.Input {
+    for (exampleMod <- build.example.exampleModules) yield PathRef(exampleMod.moduleDir)
+  }
+
+  def examplePathsWithArtifactName = Task {
+    for (pr <- examplePathsWithArtifactName0()) yield {
+      val example = pr.path.subRelativeTo(Task.workspace)
       val artifactName = example.segments.mkString("-")
-      (PathRef(path), artifactName)
+      (pr, s"${build.dist.artifactFileNamePrefix()}-$artifactName")
     }
   }
 

--- a/main/init/package.mill
+++ b/main/init/package.mill
@@ -16,8 +16,7 @@ object `package` extends RootModule with build.MillPublishScalaModule {
   def exampleList: T[PathRef] = Task {
     val data: Seq[(os.SubPath, String)] =
       build.dist.examplePathsWithArtifactName().map { case (pathRef, str) =>
-        val downloadUrl =
-          s"${build.millDownloadUrl()}/${build.dist.artifactFileNamePrefix()}-$str.zip"
+        val downloadUrl = s"${build.millDownloadUrl()}/$str.zip"
         val subPath = pathRef.path.subRelativeTo(Task.workspace / "example")
         (subPath, downloadUrl)
       }

--- a/main/init/package.mill
+++ b/main/init/package.mill
@@ -17,7 +17,7 @@ object `package` extends RootModule with build.MillPublishScalaModule {
     val data: Seq[(os.SubPath, String)] =
       build.dist.examplePathsWithArtifactName().map { case (pathRef, str) =>
         val downloadUrl =
-          s"${build.millDownloadUrl()}/mill-dist-${build.dist.artifactFileNamePrefix()}-$str.zip"
+          s"${build.millDownloadUrl()}/${build.dist.artifactFileNamePrefix()}-$str.zip"
         val subPath = pathRef.path.subRelativeTo(Task.workspace / "example")
         (subPath, downloadUrl)
       }


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/5238

Backport of https://github.com/com-lihaoyi/mill/commit/0d8285e215951fb7b0869d2af8ec3c423e72dace