### PR TITLE
init: copy `.jvmopts` to `.mill-jvm-opts` when converting a sbt project

### DIFF
--- a/integration/migrating/init/src/MillInitSbtTests.scala
+++ b/integration/migrating/init/src/MillInitSbtTests.scala
@@ -56,7 +56,7 @@ object MillInitScala3ExampleProjectWithJvmOptsTests extends BuildGenTestSuite {
       "https://github.com/scala/scala3-example-project/archive/853808c50601e88edaa7272bcfb887b96be0e22a.zip"
 
     test - integrationTest(url)(it =>
-      os.write(it.workspacePath / ".jvmopts", "-Ddummy=prop")
+      os.write(it.workspacePath / ".jvmopts", "-Ddummy=prop -Ddummy2=prop2")
       testMillInit(
         it,
         expectedAllSourceFileNums = Map("allSourceFiles" -> 13, "test.allSourceFiles" -> 1),
@@ -68,7 +68,7 @@ object MillInitScala3ExampleProjectWithJvmOptsTests extends BuildGenTestSuite {
           Some(SplitTaskResults(successful = SortedSet("test"), failed = SortedSet.empty))
       )
       assert(os.exists(it.workspacePath / ".mill-jvm-opts"))
-      assert(os.read(it.workspacePath / ".mill-jvm-opts") == "-Ddummy=prop")
+      assert(os.read(it.workspacePath / ".mill-jvm-opts") == "-Ddummy=prop -Ddummy2=prop2")
     )
   }
 }

--- a/libs/init/sbt/src/mill/main/sbt/SbtBuildGenMain.scala
+++ b/libs/init/sbt/src/mill/main/sbt/SbtBuildGenMain.scala
@@ -169,6 +169,17 @@ object SbtBuildGenMain
           println(s"creating backup ${backup.last}")
           os.move.over(jvmOptsMill, backup)
         }
+        var reportOnce = true
+        // Since .jvmopts may contain multiple args per line, we warn the user
+        // as Mill wants each arg on a separate line
+        os.read.lines(jvmOptsSbt).collectFirst {
+          // Warn the user once when we find spaces, but ignore comments
+          case x if reportOnce && !x.trim().startsWith("#") && x.trim().contains(" ") =>
+            reportOnce = false
+            println(
+              s"${jvmOptsMill.last}: Please check that each arguments is on a separate line!"
+            )
+        }
         os.copy(jvmOptsSbt, jvmOptsMill)
       }
     }


### PR DESCRIPTION
Fix https://github.com/com-lihaoyi/mill/issues/5335

