### PR TITLE
Android compose samples: Jet Lagged

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -187,6 +187,11 @@ jobs:
             install-sbt: false
 
           - java-version: 17
+            millargs: "'example.thirdparty[android-compose-samples].local.daemon'"
+            install-android-sdk: true
+            install-sbt: false
+
+          - java-version: 17
             millargs: "'{example,integration}.migrating.__.local.daemon'"
             install-android-sdk: false
             install-sbt: true

--- a/example/androidlib/kotlin/2-compose/build.mill
+++ b/example/androidlib/kotlin/2-compose/build.mill
@@ -35,6 +35,8 @@ object app extends AndroidAppKotlinModule {
 
   def mvnDeps: T[Seq[Dep]] = Seq(
     mvn"androidx.core:core-ktx:1.15.0",
+    mvn"androidx.collection:collection-jvm:1.4.4",
+    mvn"androidx.collection:collection-ktx:1.4.4",
     mvn"androidx.appcompat:appcompat:1.7.0",
     mvn"androidx.annotation:annotation:1.9.1",
     mvn"androidx.activity:activity-compose:1.10.0",

--- a/example/package.mill
+++ b/example/package.mill
@@ -319,7 +319,11 @@ $txt
     "arrow" -> ("arrow-kt/arrow", "bc9bf92cc98e01c21bdd2bf8640cf7db0f97204a"),
     "ollama-js" -> ("ollama/ollama-js", "99293abe2c7c27ce7e76e8b4a98cae948f00058d"),
     "androidtodo" -> ("android/architecture-samples", "b3437ab428f6fd91804b28801650d590ff52971c"),
-    "android-endless-tunnel" -> ("android/ndk-samples", "46ac919196faf1efcfe8018a0dcc79d4f8fbeca7")
+    "android-endless-tunnel" -> ("android/ndk-samples", "46ac919196faf1efcfe8018a0dcc79d4f8fbeca7"),
+    "android-compose-samples" -> (
+      "android/compose-samples",
+      "e4e6f0f96618f1ba04aa88d64ca19a166a662424"
+    )
   )
   object thirdparty extends Cross[ThirdPartyModule](build.listIn(moduleDir / "thirdparty"))
   trait ThirdPartyModule extends ExampleCrossModule {

--- a/example/thirdparty/android-compose-samples/build.mill
+++ b/example/thirdparty/android-compose-samples/build.mill
@@ -7,8 +7,6 @@ object Versions {
 
   val androidCompileSdk = 33
   val androidMinSdk = 21
-  val androidLifecycleCompose = "2.9.0"
-  val androidXNavigation = "2.9.0"
 }
 
 // Create and configure an Android SDK module to manage Android SDK paths and tools.

--- a/example/thirdparty/android-compose-samples/build.mill
+++ b/example/thirdparty/android-compose-samples/build.mill
@@ -1,0 +1,116 @@
+import mill._, androidlib._, kotlinlib._
+import hilt.AndroidHiltSupport
+
+object Versions {
+  val kotlinVersion = "2.1.20"
+  val kotlinLanguageVersion = "1.9"
+
+  val androidCompileSdk = 33
+  val androidMinSdk = 21
+  val androidLifecycleCompose = "2.9.0"
+  val androidXNavigation = "2.9.0"
+}
+
+// Create and configure an Android SDK module to manage Android SDK paths and tools.
+object androidSdkModule0 extends AndroidSdkModule {
+  def buildToolsVersion = "35.0.0"
+}
+
+object JetLagged extends mill.define.Module {
+  object app extends AndroidAppKotlinModule with AndroidR8AppModule {
+    def kotlinVersion = Versions.kotlinVersion
+
+    def kotlinLanguageVersion = Versions.kotlinLanguageVersion
+
+    def androidIsDebug = true
+
+    override def androidR8Args = Seq("--map-diagnostics", "error", "warning")
+
+    override def androidDesugaringLibrary = Task {
+      Some(
+        mvn"com.android.tools:desugar_jdk_libs:2.1.5"
+      )
+    }
+
+    override def androidDebugSettings: T[AndroidBuildTypeSettings] = Task {
+      AndroidBuildTypeSettings(
+        isMinifyEnabled = false,
+        isShrinkEnabled = false
+      )
+        .withProguardLocalFiles(
+          Seq(
+            moduleDir / "proguard-rules.pro"
+          )
+        )
+    }
+
+    override def androidApplicationNamespace = "com.example.jetlagged"
+
+    override def androidApplicationId = "com.example.jetlagged"
+
+    override def kotlincOptions = super.kotlincOptions() ++ Seq(
+      "-jvm-target",
+      "17"
+    )
+
+    def bomMvnDeps = super.mvnDeps() ++ Seq(
+      mvn"androidx.compose:compose-bom:2025.05.00"
+    )
+
+    def mvnDeps = super.mvnDeps() ++ Seq(
+      mvn"com.google.accompanist:accompanist-adaptive:0.37.3",
+      mvn"androidx.appcompat:appcompat:1.7.0",
+      mvn"org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2",
+      mvn"androidx.concurrent:concurrent-futures:1.1.0",
+      mvn"androidx.core:core-ktx:1.16.0",
+      mvn"androidx.activity:activity-compose:1.10.1",
+      mvn"androidx.lifecycle:lifecycle-common:2.9.0",
+      mvn"androidx.lifecycle:lifecycle-process:2.9.0",
+      mvn"androidx.lifecycle:lifecycle-runtime-compose:2.9.0",
+      mvn"androidx.lifecycle:lifecycle-viewmodel-compose:2.9.0",
+      mvn"androidx.lifecycle:lifecycle-viewmodel-ktx:2.9.0",
+      mvn"androidx.navigation:navigation-compose:2.9.0",
+      mvn"androidx.emoji2:emoji2:1.5.0",
+      mvn"androidx.emoji2:emoji2-views:1.5.0",
+      mvn"androidx.emoji2:emoji2-bundled:1.5.0",
+      mvn"androidx.window:window:1.4.0",
+      mvn"androidx.window.extensions.core:core:1.0.0",
+      mvn"androidx.constraintlayout:constraintlayout-compose:1.1.1",
+      mvn"io.coil-kt:coil-compose:2.7.0",
+      mvn"androidx.customview:customview-poolingcontainer:1.0.0",
+      mvn"androidx.tracing:tracing:1.2.0",
+      mvn"org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.1",
+
+      // version is resolved from compose-bom
+      mvn"androidx.compose.runtime:runtime",
+      mvn"androidx.compose.foundation:foundation",
+      mvn"androidx.compose.foundation:foundation-layout",
+      mvn"androidx.compose.ui:ui-util",
+      mvn"androidx.compose.material3:material3",
+      mvn"androidx.compose.animation:animation",
+      mvn"androidx.compose.animation:animation-tooling-internal",
+      mvn"androidx.compose.material:material-icons-extended",
+      mvn"androidx.compose.material:material",
+      mvn"androidx.compose.material3:material3-window-size-class",
+      mvn"androidx.compose.ui:ui-text-google-fonts",
+      mvn"androidx.compose.ui:ui-tooling-preview",
+      mvn"androidx.compose.ui:ui-unit",
+      mvn"androidx.compose.ui:ui-text",
+      mvn"androidx.compose.ui:ui-graphics",
+
+      // debug dependencies
+      mvn"androidx.compose.ui:ui-tooling",
+      mvn"androidx.compose.ui:ui-test-manifest"
+    )
+
+    def androidEnableCompose = true
+    override def kotlinUseEmbeddableCompiler: Task[Boolean] = Task { true }
+
+    def androidSdkModule = mill.define.ModuleRef(androidSdkModule0)
+
+    def androidCompileSdk = Versions.androidCompileSdk
+
+    def androidMinSdk = Versions.androidMinSdk
+
+  }
+}

--- a/example/thirdparty/android-compose-samples/build.mill
+++ b/example/thirdparty/android-compose-samples/build.mill
@@ -26,12 +26,6 @@ object JetLagged extends mill.define.Module {
 
     override def androidR8Args = Seq("--map-diagnostics", "error", "warning")
 
-    override def androidDesugaringLibrary = Task {
-      Some(
-        mvn"com.android.tools:desugar_jdk_libs:2.1.5"
-      )
-    }
-
     override def androidDebugSettings: T[AndroidBuildTypeSettings] = Task {
       AndroidBuildTypeSettings(
         isMinifyEnabled = false,

--- a/example/thirdparty/android-compose-samples/build.mill
+++ b/example/thirdparty/android-compose-samples/build.mill
@@ -30,7 +30,7 @@ object JetLagged extends mill.define.Module {
       AndroidBuildTypeSettings(
         isMinifyEnabled = false,
         isShrinkEnabled = false
-      )
+      ).withDefaultProguardFile("proguard-android-optimize.txt")
         .withProguardLocalFiles(
           Seq(
             moduleDir / "proguard-rules.pro"
@@ -108,3 +108,32 @@ object JetLagged extends mill.define.Module {
 
   }
 }
+
+/** Usage
+
+> ./mill JetLagged.app.androidApk
+
+> ./mill show JetLagged.app.createAndroidVirtualDevice
+...Name: test, DeviceId: medium_phone...
+
+> ./mill show JetLagged.app.startAndroidEmulator
+
+> ./mill show JetLagged.app.androidInstall
+...All files should be loaded. Notifying the device...
+
+> ./mill show JetLagged.app.androidRun --activity com.example.jetlagged.MainActivity
+[
+  "Starting: Intent { cmp=com.example.jetlagged/.MainActivity }",
+  "Status: ok",
+  "LaunchState: COLD",
+  "Activity: com.example.jetlagged/.MainActivity",
+  "TotalTime: ...",
+  "WaitTime: ...",
+  "Complete"
+]
+
+> ./mill show JetLagged.app.stopAndroidEmulator
+
+> ./mill show JetLagged.app.deleteAndroidVirtualDevice
+
+*/

--- a/example/thirdparty/android-compose-samples/build.mill
+++ b/example/thirdparty/android-compose-samples/build.mill
@@ -22,6 +22,8 @@ object JetLagged extends mill.define.Module {
 
     def androidIsDebug = true
 
+    // FIXME: ideally R8 should compile without erroring, but the app seems to be working
+    // without some reportedly missing classes.
     override def androidR8Args = Seq("--map-diagnostics", "error", "warning")
 
     override def androidDebugSettings: T[AndroidBuildTypeSettings] = Task {

--- a/example/thirdparty/androidtodo/build.mill
+++ b/example/thirdparty/androidtodo/build.mill
@@ -60,25 +60,7 @@ object app extends AndroidAppKotlinModule with AndroidR8AppModule with AndroidBu
     mvn"androidx.compose:compose-bom:2024.12.01"
   )
 
-  // versions are resolved with compose-bom
-  def composeDeps = Seq(
-    mvn"androidx.compose.foundation:foundation",
-    mvn"androidx.compose.foundation:foundation-layout",
-    mvn"androidx.compose.animation:animation",
-    mvn"androidx.compose.material3:material3",
-    mvn"androidx.compose.material:material",
-    mvn"androidx.compose.material:material-icons-extended",
-    mvn"androidx.compose.ui:ui-tooling-preview",
-    mvn"androidx.compose.ui:ui",
-    mvn"androidx.compose.ui:ui-unit",
-    mvn"androidx.compose.ui:ui-text",
-    mvn"androidx.compose.ui:ui-graphics",
-    // debug
-    mvn"androidx.compose.ui:ui-tooling",
-    mvn"androidx.compose.ui:ui-test-manifest"
-  )
-
-  def mvnDeps: T[Seq[Dep]] = super.mvnDeps() ++ composeDeps ++ Seq(
+  def mvnDeps: T[Seq[Dep]] = super.mvnDeps() ++ Seq(
     mvn"androidx.core:core-ktx:1.15.0",
     mvn"androidx.appcompat:appcompat:1.7.0",
     mvn"androidx.annotation:annotation:1.9.1",
@@ -100,7 +82,23 @@ object app extends AndroidAppKotlinModule with AndroidR8AppModule with AndroidBu
     mvn"androidx.hilt:hilt-navigation-compose:1.2.0",
     mvn"com.google.accompanist:accompanist-swiperefresh:0.36.0",
     mvn"androidx.customview:customview-poolingcontainer:1.0.0",
-    mvn"androidx.tracing:tracing:1.2.0"
+    mvn"androidx.tracing:tracing:1.2.0",
+
+    // versions are resolved with compose-bom
+    mvn"androidx.compose.foundation:foundation",
+    mvn"androidx.compose.foundation:foundation-layout",
+    mvn"androidx.compose.animation:animation",
+    mvn"androidx.compose.material3:material3",
+    mvn"androidx.compose.material:material",
+    mvn"androidx.compose.material:material-icons-extended",
+    mvn"androidx.compose.ui:ui-tooling-preview",
+    mvn"androidx.compose.ui:ui",
+    mvn"androidx.compose.ui:ui-unit",
+    mvn"androidx.compose.ui:ui-text",
+    mvn"androidx.compose.ui:ui-graphics",
+    // debug
+    mvn"androidx.compose.ui:ui-tooling",
+    mvn"androidx.compose.ui:ui-test-manifest"
   )
 
   def kotlinSymbolProcessors: T[Seq[Dep]] = Seq(

--- a/libs/androidlib/src/mill/androidlib/AndroidAppBundle.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppBundle.scala
@@ -28,7 +28,7 @@ trait AndroidAppBundle extends AndroidAppModule with JavaModule {
    */
   def androidBundleZip: T[PathRef] = Task {
     val dexFile = androidDex().path
-    val resFile = androidCompiledResources().resApkFile.path
+    val resFile = androidLinkedResources().path / "apk/res.apk"
     val baseDir = Task.dest / "base"
     val appDir = Task.dest / "app"
 

--- a/libs/androidlib/src/mill/androidlib/AndroidAppKotlinModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppKotlinModule.scala
@@ -208,7 +208,7 @@ trait AndroidAppKotlinModule extends AndroidKotlinModule with AndroidAppModule {
     }
 
     private def resourceApkPath: Task[PathRef] = Task {
-      outer.androidCompiledResources().resApkFile
+      PathRef(outer.androidLinkedResources().path / "apk/res.apk")
     }
 
     // TODO previews must be source controlled to be used as a base

--- a/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
@@ -232,7 +232,7 @@ trait AndroidAppModule extends AndroidModule { outer =>
   def androidUnsignedApk: T[PathRef] = Task {
     val unsignedApk = Task.dest / "app.unsigned.apk"
 
-    os.copy(androidCompiledResources().resApkFile.path, unsignedApk)
+    os.copy(androidLinkedResources().path / "apk/res.apk", unsignedApk)
     val dexFiles = os.walk(androidDex().path)
       .filter(_.ext == "dex")
       .map(os.zip.ZipSource.fromPath)
@@ -806,7 +806,7 @@ trait AndroidAppModule extends AndroidModule { outer =>
       .flatMap(_.proguardRules)
       .map(p => os.read(p.path))
       .appendedAll(mainDexPlatformRules)
-      .appended(os.read(androidCompiledResources().mainDexRulesProFile.path))
+      .appended(os.read(androidLinkedResources().path / "proguard/main-dex-rules.pro"))
       .mkString("\n")
     os.write(proguardFile, knownProguardRules)
 
@@ -1090,6 +1090,7 @@ trait AndroidAppModule extends AndroidModule { outer =>
 case class UnpackedDep(
     name: String,
     classesJar: Option[PathRef],
+    repackagedJars: Seq[PathRef],
     proguardRules: Option[PathRef],
     androidResources: Option[PathRef],
     manifest: Option[PathRef],

--- a/libs/androidlib/src/mill/androidlib/AndroidModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidModule.scala
@@ -120,7 +120,15 @@ trait AndroidModule extends JavaModule {
    * Specifies AAPT options for Android resource compilation.
    */
   def androidAaptOptions: T[Seq[String]] = Task {
-    Seq("--auto-add-overlay")
+    if (androidIsDebug()) {
+      Seq(
+        "--proguard-minimal-keep-rules",
+        "--debug-mode",
+        "--auto-add-overlay"
+      )
+    } else {
+      Seq("--auto-add-overlay")
+    }
   }
 
   /**
@@ -527,12 +535,8 @@ trait AndroidModule extends JavaModule {
       androidVersionName(),
       "--proguard-main-dex",
       mainDexRulesProFile.toString,
-      "--proguard-conditional-keep-rules",
-      // Todo change on debug
-      "--proguard-minimal-keep-rules",
-      "--debug-mode",
-      "--strict-visibility",
-      "--auto-add-overlay",
+      "--proguard-conditional-keep-rules"
+    ) ++ androidAaptOptions() ++ Seq(
       "-o",
       resApkFile.toString
     ) ++ filesToLink.flatMap(flat => Seq("-R", flat.toString()))

--- a/libs/androidlib/src/mill/androidlib/AndroidModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidModule.scala
@@ -255,6 +255,12 @@ trait AndroidModule extends JavaModule {
       extractAarFiles(aarFiles, transformDest)
     }
 
+  /**
+   * Runtime deps collected from repackaged content
+   * from (usually) AAR files. Can usually be found in
+   * libs/repackaged.jar.
+   * @return
+   */
   def androidRepackagedDeps: T[Seq[PathRef]] = Task {
     androidTransformAarFiles(Task.Anon(resolvedRunMvnDeps()))()
       .flatMap(_.repackagedJars)
@@ -445,6 +451,12 @@ trait AndroidModule extends JavaModule {
    */
   def androidNamespace: String
 
+  /**
+   * Gets the extracted android resources from the dependencies using [[androidLibraryResources]]
+   * and compiles them into flata files using aapt2. This allows for the resources to be linked
+   * using overlay.
+   * @return
+   */
   def androidCompiledLibResources: T[PathRef] = Task {
     val libAndroidResources: Seq[Path] = androidLibraryResources().map(_.path)
 
@@ -468,6 +480,11 @@ trait AndroidModule extends JavaModule {
     PathRef(Task.dest)
   }
 
+  /**
+   * Gets all the android resources from this module and its
+   * module dependencies and compiles them into flata files.
+   * @return
+   */
   def androidCompiledModuleResources = Task {
 
     val moduleResources =
@@ -495,6 +512,12 @@ trait AndroidModule extends JavaModule {
 
   }
 
+  /**
+   * Links all the resources coming from [[androidCompiledLibResources]] and
+   * [[androidCompiledModuleResources]] using auto overlay to resolve conflicts.
+   * For more information see [[https://developer.android.com/tools/aapt2#link]]
+   * @return a directory which contains the apk, proguard and generated R sources.
+   */
   def androidLinkedResources: T[PathRef] = Task {
     val compiledLibResDir = androidCompiledLibResources().path
     val moduleResDir = androidCompiledModuleResources().path

--- a/libs/androidlib/src/mill/androidlib/AndroidR8AppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidR8AppModule.scala
@@ -29,16 +29,6 @@ trait AndroidR8AppModule extends AndroidAppModule {
 
   }
 
-  def androidDesugaringLibrary: T[Option[Dep]] = Task {
-    None
-  }
-
-  def androidDesugaringLibraryClasspath: T[Seq[PathRef]] = Task {
-    defaultResolver().classpath(
-      androidDesugaringLibrary().toSeq
-    )
-  }
-
   /**
    * Selects the meta info and metadata files to package. These are being extracted
    * and output by R8 from the dependency jars.

--- a/libs/androidlib/src/mill/androidlib/AndroidR8AppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidR8AppModule.scala
@@ -3,6 +3,7 @@ package mill.androidlib
 import mill.*
 import mill.define.{PathRef, Task}
 import mill.define.BuildCtx
+import mill.scalalib.{Dep, DepSyntax}
 
 @mill.api.experimental
 trait AndroidR8AppModule extends AndroidAppModule {
@@ -26,6 +27,16 @@ trait AndroidR8AppModule extends AndroidAppModule {
 
     dex.outPath
 
+  }
+
+  def androidDesugaringLibrary: T[Option[Dep]] = Task {
+    None
+  }
+
+  def androidDesugaringLibraryClasspath: T[Seq[PathRef]] = Task {
+    defaultResolver().classpath(
+      androidDesugaringLibrary().toSeq
+    )
   }
 
   /**
@@ -104,6 +115,10 @@ trait AndroidR8AppModule extends AndroidAppModule {
     )
   }
 
+  def androidR8Args: T[Seq[String]] = Task {
+    Seq.empty[String]
+  }
+
   def androidDebugSettings: T[AndroidBuildTypeSettings] = Task {
     AndroidBuildTypeSettings()
   }
@@ -125,7 +140,7 @@ trait AndroidR8AppModule extends AndroidAppModule {
    * Prepares the R8 cli command to build this android app!
    * @return
    */
-  def androidR8Dex: Task[(outPath: PathRef, dexCliArgs: Seq[String])] = Task {
+  def androidR8Dex: T[(outPath: PathRef, dexCliArgs: Seq[String])] = Task {
     val destDir = Task.dest / "minify"
     os.makeDir.all(destDir)
 
@@ -213,6 +228,8 @@ trait AndroidR8AppModule extends AndroidAppModule {
     val pgArgs = Seq("--pg-conf", androidProguard().path.toString)
 
     r8ArgsBuilder ++= pgArgs
+
+    r8ArgsBuilder ++= androidR8Args()
 
     r8ArgsBuilder ++= allClassFiles
 


### PR DESCRIPTION
## Summary

This PR builds on top of https://github.com/com-lihaoyi/mill/pull/5285 and https://github.com/com-lihaoyi/mill/pull/5285 , and extends the work by creating a new linking android resources method that triggers the merging algorithm (with flat files instead of zips and auto overlay, with -R to add each library resource)

![Screenshot From 2025-06-16 18-24-28](https://github.com/user-attachments/assets/24f4c67e-95c0-464d-acd6-0f02cc6e10f8)

## Android Dependency Resolution changes

- New configuration parameters were needed to include "common" dependencies otherwise some of them were failing to be resolved for android

##  Android Resources

This is the major change that allows for [JetLagged](https://github.com/android/compose-samples/tree/main/JetLagged) from compose samples to work (only to run the App for now). The key change was to overlay the flat files of the libraries (with `-R` parameter) instead of linking them together as command inputs (without -R)

This allows for any conflicts of values that are the same to be resolved and it took some trial and error (I have a few versions of compose sample branches with a lot of failing attempts).

Another change is to use the android resources from resolved run maven deps although I have a suspicion we'll come back to that later on, I don't think the dependency resolution and packaging work is finished.
 

