### PR TITLE
Protect `moduleNestedCtx` to prevent it from being imported by `import build._`

### DIFF
--- a/core/define/src/mill/define/Module.scala
+++ b/core/define/src/mill/define/Module.scala
@@ -16,7 +16,7 @@ import scala.reflect.ClassTag
  * the concrete instance.
  */
 trait Module extends Module.BaseClass with ModuleCtx.Wrapper with ModuleApi {
-  implicit def moduleNestedCtx: ModuleCtx.Nested = moduleCtx
+  protected implicit def moduleNestedCtx: ModuleCtx.Nested = moduleCtx
     .withMillSourcePath(moduleDir)
     .withSegments(moduleSegments)
     .withEnclosingModule(this)


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/5345

The basic problem was that `import build._` pulled in the `build.moduleNestedCtx` implicit, which depending on scoping could over-ride the lexical `moduleNestedCtx`. This fix makes `moduleNestedCtx` `protected`, so it is available in the nested scope but cannot be imported

Tested manually, seems to fix the reported problem