### PR TITLE
Convert `.mill-jvm-version` from a symlink to a normal file

### DIFF
--- a/.mill-jvm-version
+++ b/.mill-jvm-version
@@ -1,1 +1,1 @@
-default-mill-jvm-version
+zulu:17.0.14


### PR DESCRIPTION
Windows doesn't properly support symlinks, so loading the Mill repo fails on windows

```
PS C:\work\mill-main> ./mill libs.scalalib.test.testForked mill.scalalib.UnidocTest
Mill client failed with unknown exception
coursier.jvm.JvmCache$JvmNotFoundInIndex: JVM default-mill-jvm-version not found in index: JVM default-mill-jvm-version not found
        at coursier.jvm.JvmCache.$anonfun$get$3(JvmCache.scala:112)
        at coursier.jvm.JvmCache.$anonfun$get$3$adapted(JvmCache.scala:111)
        at coursier.util.Task$.$anonfun$flatMap$extension$1(Task.scala:14)
        at coursier.util.Task$.$anonfun$flatMap$extension$1$adapted(Task.scala:14)
        at coursier.util.Task$.wrap(Task.scala:82)
        at coursier.util.Task$.$anonfun$flatMap$2(Task.scala:14)
        at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:470)
        at java.base@23.0.1/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
        at java.base@23.0.1/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
        at java.base@23.0.1/java.lang.Thread.runWith(Thread.java:1588)
        at java.base@23.0.1/java.lang.Thread.run(Thread.java:1575)
        at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:832)
        at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:808)
```