### PR TITLE
Ensure the coursier cache logger is properly initialized / stopped

### DIFF
--- a/core/util/src/mill/util/Jvm.scala
+++ b/core/util/src/mill/util/Jvm.scala
@@ -563,7 +563,8 @@ object Jvm {
       coursierCacheCustomizer: Option[FileCache[Task] => FileCache[Task]] = None
   ): JvmIndex = {
     val coursierCache0 = coursierCache(ctx, coursierCacheCustomizer)
-    jvmIndex0(ctx, coursierCacheCustomizer).unsafeRun()(coursierCache0.ec)
+    coursierCache0.logger.use(jvmIndex0(ctx, coursierCacheCustomizer))
+      .unsafeRun()(using coursierCache0.ec)
   }
 
   def jvmIndex0(
@@ -622,7 +623,8 @@ object Jvm {
       // when given a version like "17", always pick highest version in the index
       // rather than the highest already on disk
       .withUpdate(true)
-    val file = javaHome.get(id).unsafeRun()(coursierCache0.ec)
+    val file = coursierCache0.logger.use(javaHome.get(id))
+      .unsafeRun()(using coursierCache0.ec)
     Result.Success(os.Path(file))
 
   }

--- a/integration/bootstrap/no-java-bootstrap/src/NoJavaBootstrapTests.scala
+++ b/integration/bootstrap/no-java-bootstrap/src/NoJavaBootstrapTests.scala
@@ -27,7 +27,8 @@ object NoJavaBootstrapTests extends UtestIntegrationTestSuite {
     )
     val jvmCache = JvmCache().withIndex(index)
 
-    val entry = jvmCache.entries(mill.client.BuildInfo.defaultJvmId).unsafeRun()(using cache.ec)
+    val entry = cache.logger.use(jvmCache.entries(mill.client.BuildInfo.defaultJvmId))
+      .unsafeRun()(using cache.ec)
       .left.map(err => sys.error(err))
       .merge
       .last

--- a/libs/androidlib/src/mill/androidlib/AndroidSdkModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidSdkModule.scala
@@ -83,7 +83,7 @@ trait AndroidSdkModule extends Module {
       .pipe { cache =>
         if (Task.offline) cache.withCachePolicies(Seq(LocalOnly)) else cache
       }
-    cache.file(Artifact(url)).run.unsafeRun()(using cache.ec) match {
+    cache.logger.use(cache.file(Artifact(url)).run).unsafeRun()(using cache.ec) match {
       case Right(file) =>
         PathRef(os.Path(file)).withRevalidateOnce
       case Left(_) if Task.offline =>

--- a/libs/scalalib/src/mill/scalalib/dependency/metadata/MavenMetadataLoader.scala
+++ b/libs/scalalib/src/mill/scalalib/dependency/metadata/MavenMetadataLoader.scala
@@ -24,8 +24,8 @@ private[dependency] final case class MavenMetadataLoader(
 
   override def getVersions(module: coursier.Module): List[Version] = {
     // TODO fallback to 'versionsFromListing' if 'versions' doesn't work? (needs to be made public in coursier first)
-    val allVersions =
-      mavenRepo.versions(module, cache.fetch).run.unsafeRun()(cache.ec)
+    val allVersions = cache.logger.use(mavenRepo.versions(module, cache.fetch).run)
+      .unsafeRun()(using cache.ec)
     allVersions
       .map(_._1.available.map(Version(_)))
       .getOrElse(List.empty)

--- a/runner/launcher/src/mill/launcher/CoursierClient.scala
+++ b/runner/launcher/src/mill/launcher/CoursierClient.scala
@@ -61,6 +61,6 @@ object CoursierClient {
       // rather than the highest already on disk
       .withUpdate(true)
 
-    javaHome.get(id).unsafeRun()(using coursierCache0.ec)
+    coursierCache0.logger.using(javaHome.get(id)).unsafeRun()(using coursierCache0.ec)
   }
 }


### PR DESCRIPTION
This fixes https://github.com/com-lihaoyi/mill/issues/5358 by ensuring the coursier cache logger is initialized and then stopped around calls that might download things.

Fixes https://github.com/com-lihaoyi/mill/issues/5358