### PR TITLE
Prepare for rebootstrapping mill

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -9,10 +9,10 @@ import millbuild.*
 //import com.github.lolgab.mill.mima.Mima
 import coursier.maven.MavenRepository
 import coursier.VersionConstraint
-import mill.main.VcsVersion
+import mill.vcs.VcsVersion
 //import com.goyeau.mill.scalafix.ScalafixModule
 import mill._
-import mill.main.Tasks
+import mill.util.Tasks
 import mill.scalalib._
 import mill.scalalib.api.JvmWorkerUtil
 import mill.scalalib.publish._

--- a/contrib/package.mill
+++ b/contrib/package.mill
@@ -3,7 +3,7 @@ package build.contrib
 import scala.util.chaining._
 import coursier.maven.MavenRepository
 import mill._
-import mill.main.Tasks
+import mill.util.Tasks
 import mill.scalalib._
 import mill.scalalib.api.JvmWorkerUtil
 import mill.scalalib.publish._

--- a/example/package.mill
+++ b/example/package.mill
@@ -3,7 +3,7 @@ package build.example
 import scala.util.chaining._
 import coursier.maven.MavenRepository
 import mill._
-import mill.main.Tasks
+import mill.util.Tasks
 import mill.scalalib._
 import mill.scalalib.api.JvmWorkerUtil
 import mill.scalalib.publish._

--- a/integration/package.mill
+++ b/integration/package.mill
@@ -3,7 +3,7 @@ package build.integration
 import scala.util.chaining._
 import coursier.maven.MavenRepository
 import mill._
-import mill.main.Tasks
+import mill.util.Tasks
 import mill.scalalib._
 import mill.scalalib.api.JvmWorkerUtil
 import mill.scalalib.publish._

--- a/libs/scalalib/package.mill
+++ b/libs/scalalib/package.mill
@@ -4,7 +4,7 @@ import scala.util.chaining._
 
 import coursier.maven.MavenRepository
 import mill._
-import mill.main.Tasks
+import mill.util.Tasks
 import mill.scalalib._
 import mill.scalalib.api.JvmWorkerUtil
 import mill.scalalib.publish._


### PR DESCRIPTION
Reboostrapping is needed to fix API doc generation (https://github.com/com-lihaoyi/mill/issues/5355).

This fixes some imports to the types that were moved in `main` branch.