### PR TITLE
Support command overloading in a binary compatible fashion

### DIFF
--- a/core/define/src/mill/define/Discover.scala
+++ b/core/define/src/mill/define/Discover.scala
@@ -23,7 +23,7 @@ class Discover(val classInfo: Map[Class[?], Discover.ClassInfo]) {
       if ep.mainName.getOrElse(ep.defaultName) == name
     } yield ep
 
-    res.headOption
+    res.maxByOption(_.argSigs0.length)
   }
 }
 

--- a/core/define/src/mill/define/Discover.scala
+++ b/core/define/src/mill/define/Discover.scala
@@ -23,6 +23,10 @@ class Discover(val classInfo: Map[Class[?], Discover.ClassInfo]) {
       if ep.mainName.getOrElse(ep.defaultName) == name
     } yield ep
 
+    // When there are multiple entrypoints matching the class and name,
+    // return the one with the longest argument lists, since users may
+    // add additional arguments to a command (with default values) to 
+    // preserve binary compatibility while evolving the method signature
     res.maxByOption(_.argSigs0.length)
   }
 }

--- a/core/define/src/mill/define/Discover.scala
+++ b/core/define/src/mill/define/Discover.scala
@@ -25,7 +25,7 @@ class Discover(val classInfo: Map[Class[?], Discover.ClassInfo]) {
 
     // When there are multiple entrypoints matching the class and name,
     // return the one with the longest argument lists, since users may
-    // add additional arguments to a command (with default values) to 
+    // add additional arguments to a command (with default values) to
     // preserve binary compatibility while evolving the method signature
     res.maxByOption(_.argSigs0.length)
   }


### PR DESCRIPTION
Fixes  https://github.com/com-lihaoyi/mill/issues/5281

The previous code already collected all command overloads in the `Discover` data structure, but it returned one arbitrarily when queried. This PR makes it return the one with the longer argument list, which supports `@unroll`-style signature evolution of adding parameters with default values to the right side of a parameter list.

Added a unit test that fails on main, passes on this PR 