### PR TITLE
Add some logs & error reporting for (unsupported) publishing snapshots to Sonatype Central (backport #5367)

### DIFF
--- a/contrib/sonatypecentral/src/mill/contrib/sonatypecentral/SonatypeCentralPublishModule.scala
+++ b/contrib/sonatypecentral/src/mill/contrib/sonatypecentral/SonatypeCentralPublishModule.scala
@@ -1,72 +1,20 @@
 package mill.contrib.sonatypecentral
 
-import com.lumidion.sonatype.central.client.core.{PublishingType, SonatypeCredentials}
-import mill._
-import scalalib._
-import define.{ExternalModule, Task}
-import mill.api.Result
-import mill.contrib.sonatypecentral.SonatypeCentralPublishModule.{
-  defaultAwaitTimeout,
-  defaultConnectTimeout,
-  defaultCredentials,
-  defaultReadTimeout,
-  getPublishingTypeFromReleaseFlag,
-  getSonatypeCredentials
-}
-import mill.scalalib.publish.Artifact
-import mill.scalalib.publish.SonatypeHelpers.{
-  PASSWORD_ENV_VARIABLE_NAME,
-  USERNAME_ENV_VARIABLE_NAME
-}
+import mill.*
+import scalalib.*
+import define.{ExternalModule, ModuleRef}
 
-trait SonatypeCentralPublishModule extends PublishModule {
-  def sonatypeCentralGpgArgs: T[String] = Task {
-    PublishModule.defaultGpgArgsForPassphrase(Task.env.get("MILL_PGP_PASSPHRASE")).mkString(",")
-  }
-
-  def sonatypeCentralConnectTimeout: T[Int] = Task { defaultConnectTimeout }
-
-  def sonatypeCentralReadTimeout: T[Int] = Task { defaultReadTimeout }
-
-  def sonatypeCentralAwaitTimeout: T[Int] = Task { defaultAwaitTimeout }
-
-  def sonatypeCentralShouldRelease: T[Boolean] = Task { true }
-
-  def publishSonatypeCentral(
-      username: String = defaultCredentials,
-      password: String = defaultCredentials
-  ): define.Command[Unit] =
-    Task.Command {
-      val publishData = publishArtifacts()
-      val fileMapping = publishData.withConcretePath._1
-      val artifact = publishData.meta
-      val finalCredentials = getSonatypeCredentials(username, password)()
-      PublishModule.pgpImportSecretIfProvided(Task.env)
-      val publisher = new SonatypeCentralPublisher(
-        credentials = finalCredentials,
-        gpgArgs = sonatypeCentralGpgArgs().split(",").toIndexedSeq,
-        connectTimeout = sonatypeCentralConnectTimeout(),
-        readTimeout = sonatypeCentralReadTimeout(),
-        log = Task.log,
-        workspace = Task.workspace,
-        env = Task.env,
-        awaitTimeout = sonatypeCentralAwaitTimeout()
-      )
-      publisher.publish(
-        fileMapping,
-        artifact,
-        getPublishingTypeFromReleaseFlag(sonatypeCentralShouldRelease())
-      )
-    }
-}
+trait SonatypeCentralPublishModule extends mill.scalalib.SonatypeCentralPublishModule
 
 object SonatypeCentralPublishModule extends ExternalModule {
 
-  val defaultCredentials: String = ""
-  val defaultReadTimeout: Int = 60000
-  val defaultConnectTimeout: Int = 5000
-  val defaultAwaitTimeout: Int = 120 * 1000
-  val defaultShouldRelease: Boolean = true
+  private lazy val other = ModuleRef(mill.scalalib.SonatypeCentralPublishModule)
+
+  val defaultCredentials: String = other().defaultCredentials
+  val defaultReadTimeout: Int = other().defaultReadTimeout
+  val defaultConnectTimeout: Int = other().defaultConnectTimeout
+  val defaultAwaitTimeout: Int = other().defaultConnectTimeout
+  val defaultShouldRelease: Boolean = other().defaultShouldRelease
 
   def publishAll(
       publishArtifacts: mill.main.Tasks[PublishModule.PublishData],
@@ -78,74 +26,17 @@ object SonatypeCentralPublishModule extends ExternalModule {
       connectTimeout: Int = defaultConnectTimeout,
       awaitTimeout: Int = defaultAwaitTimeout,
       bundleName: String = ""
-  ): Command[Unit] = Task.Command {
-
-    val artifacts: Seq[(Seq[(os.Path, String)], Artifact)] =
-      Task.sequence(publishArtifacts.value)().map {
-        case data @ PublishModule.PublishData(_, _) => data.withConcretePath
-      }
-
-    val finalBundleName = if (bundleName.isEmpty) None else Some(bundleName)
-    val finalCredentials = getSonatypeCredentials(username, password)()
-    PublishModule.pgpImportSecretIfProvided(Task.env)
-    val publisher = new SonatypeCentralPublisher(
-      credentials = finalCredentials,
-      gpgArgs = gpgArgs match {
-        case "" => PublishModule.defaultGpgArgsForPassphrase(Task.env.get("MILL_PGP_PASSPHRASE"))
-        case gpgArgs => gpgArgs.split(",").toIndexedSeq
-      },
-      connectTimeout = connectTimeout,
-      readTimeout = readTimeout,
-      log = Task.log,
-      workspace = Task.workspace,
-      env = Task.env,
-      awaitTimeout = awaitTimeout
-    )
-    publisher.publishAll(
-      getPublishingTypeFromReleaseFlag(shouldRelease),
-      finalBundleName,
-      artifacts: _*
-    )
-  }
-
-  private def getPublishingTypeFromReleaseFlag(shouldRelease: Boolean): PublishingType = {
-    if (shouldRelease) {
-      PublishingType.AUTOMATIC
-    } else {
-      PublishingType.USER_MANAGED
-    }
-  }
-
-  private def getSonatypeCredential(
-      credentialParameterValue: String,
-      credentialName: String,
-      envVariableName: String
-  ): Task[String] = Task.Anon {
-    if (credentialParameterValue.nonEmpty) {
-      Result.Success(credentialParameterValue)
-    } else {
-      (for {
-        credential <- Task.env.get(envVariableName)
-      } yield {
-        Result.Success(credential)
-      }).getOrElse(
-        Result.Failure(
-          s"No $credentialName set. Consider using the $envVariableName environment variable or passing `$credentialName` argument"
-        )
-      )
-    }
-  }
-
-  private def getSonatypeCredentials(
-      usernameParameterValue: String,
-      passwordParameterValue: String
-  ): Task[SonatypeCredentials] = Task.Anon {
-    val username =
-      getSonatypeCredential(usernameParameterValue, "username", USERNAME_ENV_VARIABLE_NAME)()
-    val password =
-      getSonatypeCredential(passwordParameterValue, "password", PASSWORD_ENV_VARIABLE_NAME)()
-    Result.Success(SonatypeCredentials(username, password))
-  }
+  ): Command[Unit] = other().publishAll(
+    publishArtifacts = publishArtifacts,
+    username = username,
+    password = password,
+    shouldRelease = shouldRelease,
+    gpgArgs = gpgArgs,
+    readTimeout = readTimeout,
+    connectTimeout = connectTimeout,
+    awaitTimeout = awaitTimeout,
+    bundleName = bundleName
+  )
 
   lazy val millDiscover: mill.define.Discover = mill.define.Discover[this.type]
 }

--- a/contrib/sonatypecentral/src/mill/contrib/sonatypecentral/SonatypeCentralPublisher.scala
+++ b/contrib/sonatypecentral/src/mill/contrib/sonatypecentral/SonatypeCentralPublisher.scala
@@ -1,18 +1,7 @@
 package mill.contrib.sonatypecentral
 
-import com.lumidion.sonatype.central.client.core.{
-  DeploymentName,
-  PublishingType,
-  SonatypeCredentials
-}
-import com.lumidion.sonatype.central.client.requests.SyncSonatypeClient
+import com.lumidion.sonatype.central.client.core.SonatypeCredentials
 import mill.api.Logger
-import mill.scalalib.publish.Artifact
-import mill.scalalib.publish.SonatypeHelpers.getArtifactMappings
-
-import java.nio.file.Files
-import java.util.jar.JarOutputStream
-import java.util.zip.ZipEntry
 
 class SonatypeCentralPublisher(
     credentials: SonatypeCredentials,
@@ -23,120 +12,13 @@ class SonatypeCentralPublisher(
     workspace: os.Path,
     env: Map[String, String],
     awaitTimeout: Int
-) {
-  private val sonatypeCentralClient =
-    new SyncSonatypeClient(credentials, readTimeout = readTimeout, connectTimeout = connectTimeout)
-
-  def publish(
-      fileMapping: Seq[(os.Path, String)],
-      artifact: Artifact,
-      publishingType: PublishingType
-  ): Unit = {
-    publishAll(publishingType, None, fileMapping -> artifact)
-  }
-
-  def publishAll(
-      publishingType: PublishingType,
-      singleBundleName: Option[String],
-      artifacts: (Seq[(os.Path, String)], Artifact)*
-  ): Unit = {
-    val mappings = getArtifactMappings(isSigned = true, gpgArgs, workspace, env, artifacts)
-
-    val (_, releases) = mappings.partition(_._1.isSnapshot)
-
-    val releaseGroups = releases.groupBy(_._1.group)
-    val wd = os.pwd / "out/publish-central"
-    os.makeDir.all(wd)
-
-    singleBundleName.fold {
-      for ((_, groupReleases) <- releaseGroups) {
-        groupReleases.foreach { case (artifact, data) =>
-          val fileNameWithoutExtension = s"${artifact.group}-${artifact.id}-${artifact.version}"
-          val zipFile = streamToFile(fileNameWithoutExtension, wd) { outputStream =>
-            zipFilesToJar(data, outputStream)
-          }
-
-          val deploymentName = DeploymentName.fromArtifact(
-            artifact.group,
-            artifact.id,
-            artifact.version
-          )
-
-          publishFile(zipFile, deploymentName, publishingType)
-        }
-      }
-
-    } { singleBundleName =>
-      val zipFile = streamToFile(singleBundleName, wd) { outputStream =>
-        for ((_, groupReleases) <- releaseGroups) {
-          groupReleases.foreach { case (_, data) =>
-            zipFilesToJar(data, outputStream)
-          }
-        }
-      }
-
-      val deploymentName = DeploymentName(singleBundleName)
-
-      publishFile(zipFile, deploymentName, publishingType)
-    }
-  }
-
-  private def publishFile(
-      zipFile: java.io.File,
-      deploymentName: DeploymentName,
-      publishingType: PublishingType
-  ): Unit = {
-    try {
-      mill.api.Retry(
-        count = 5,
-        backoffMillis = 1000,
-        filter = (_, ex) => ex.getMessage.contains("Read end dead")
-      ) {
-        sonatypeCentralClient.uploadBundleFromFile(
-          zipFile,
-          deploymentName,
-          Some(publishingType),
-          timeout = awaitTimeout
-        )
-      }
-    } catch {
-      case ex: Throwable => {
-        throw new RuntimeException(
-          s"Failed to publish ${deploymentName.unapply} to Sonatype Central",
-          ex
-        )
-      }
-
-    }
-
-    log.info(s"Successfully published ${deploymentName.unapply} to Sonatype Central")
-  }
-
-  private def streamToFile(
-      fileNameWithoutExtension: String,
-      wd: os.Path
-  )(func: JarOutputStream => Unit): java.io.File = {
-    val zipFile =
-      (wd / s"$fileNameWithoutExtension.zip")
-    val fileOutputStream = Files.newOutputStream(zipFile.toNIO)
-    val jarOutputStream = new JarOutputStream(fileOutputStream)
-    try {
-      func(jarOutputStream)
-    } finally {
-      jarOutputStream.close()
-    }
-    zipFile.toIO
-  }
-
-  private def zipFilesToJar(
-      files: Seq[(String, Array[Byte])],
-      jarOutputStream: JarOutputStream
-  ): Unit = {
-    files.foreach { case (filename, fileAsBytes) =>
-      val zipEntry = new ZipEntry(filename)
-      jarOutputStream.putNextEntry(zipEntry)
-      jarOutputStream.write(fileAsBytes)
-      jarOutputStream.closeEntry()
-    }
-  }
-}
+) extends mill.scalalib.SonatypeCentralPublisher(
+      credentials = credentials,
+      gpgArgs = gpgArgs,
+      readTimeout = readTimeout,
+      connectTimeout = connectTimeout,
+      log = log,
+      workspace = workspace,
+      env = env,
+      awaitTimeout = awaitTimeout
+    )

--- a/scalalib/src/mill/scalalib/SonatypeCentralPublisher.scala
+++ b/scalalib/src/mill/scalalib/SonatypeCentralPublisher.scala
@@ -6,7 +6,7 @@ import com.lumidion.sonatype.central.client.core.{
   SonatypeCredentials
 }
 import com.lumidion.sonatype.central.client.requests.SyncSonatypeClient
-import mill.api.Logger
+import mill.api.{Logger, Result}
 import mill.scalalib.publish.Artifact
 import mill.scalalib.publish.SonatypeHelpers.getArtifactMappings
 
@@ -41,8 +41,27 @@ class SonatypeCentralPublisher(
       artifacts: (Seq[(os.Path, String)], Artifact)*
   ): Unit = {
     val mappings = getArtifactMappings(isSigned = true, gpgArgs, workspace, env, artifacts)
-
-    val (_, releases) = mappings.partition(_._1.isSnapshot)
+    log.info(s"mappings ${pprint.apply(mappings.map { case (a, kvs) => (a, kvs.map(_._1)) })}")
+    val (snapshots, releases) = mappings.partition(_._1.isSnapshot)
+    if (snapshots.nonEmpty) {
+      val snapshotNames = snapshots.map(_._1)
+        .map { case Artifact(group, id, version) => s"$group:$id:$version" }
+      throw new Result.Exception(
+        s"""Publishing snapshots to Sonatype Central Portal is currently not supported by Mill.
+           |This is tracked under https://github.com/com-lihaoyi/mill/issues/4421
+           |The following snapshots will not be published:
+           |  ${snapshotNames.mkString("\n  ")}""".stripMargin
+      )
+    }
+    if (releases.isEmpty) {
+      log.error("No releases to publish to Sonatype Central.")
+      val errorMessage =
+        "No releases to publish to Sonatype Central." +
+          (if (snapshots.nonEmpty)
+             "It seems there were only snapshots to publish, which is not supported by Mill, currently."
+           else "Please check your build configuration.")
+      throw new Result.Exception(errorMessage)
+    }
 
     val releaseGroups = releases.groupBy(_._1.group)
     val wd = os.pwd / "out/publish-central"


### PR DESCRIPTION
Some much missed logs and error handling for:
- https://github.com/com-lihaoyi/mill/pull/3130

Also relevant to:
- https://github.com/com-lihaoyi/mill/issues/4421
- https://github.com/com-lihaoyi/mill/issues/5357
- https://github.com/VirtusLab/scala-cli/issues/3742

With this, we should:
- not have a green CI, when trying to publish snapshots only 🙃
- not upload empty bundles/silently not upload anything, when publishing
in such a case
- have any logs to follow up on

Backport of pull request: https://github.com/com-lihaoyi/mill/pull/5367

