### PR TITLE
Fix VcsVersion short hash collision in Mill website publishing

### DIFF
--- a/libs/vcs/src/mill/vcs/VcsVersion.scala
+++ b/libs/vcs/src/mill/vcs/VcsVersion.scala
@@ -60,7 +60,8 @@ object VcsVersion extends ExternalModule with VcsVersion {
         val actualRevHashDigits =
           if (revHashDigits != -1) currentRevision.take(revHashDigits)
           else {
-            os.call(("git", "rev-parse", "--short", currentRevision),
+            os.call(
+              ("git", "rev-parse", "--short", currentRevision),
               cwd = vcsBasePath,
               stderr = os.Pipe
             ).out.trim()

--- a/libs/vcs/src/mill/vcs/VcsVersion.scala
+++ b/libs/vcs/src/mill/vcs/VcsVersion.scala
@@ -37,7 +37,7 @@ object VcsVersion extends ExternalModule with VcsVersion {
         countSep: String = "-",
         commitCountPad: Byte = 0,
         revSep: String = "-",
-        revHashDigits: Int = 6,
+        revHashDigits: Int = -1,
         dirtySep: String = "-DIRTY",
         dirtyHashDigits: Int = 8,
         tagModifier: String => String = stripV,
@@ -57,7 +57,16 @@ object VcsVersion extends ExternalModule with VcsVersion {
       } else ""
 
       val revisionPart = if (isUntagged) {
-        s"$revSep${currentRevision.take(revHashDigits)}"
+        val actualRevHashDigits =
+          if (revHashDigits != -1) currentRevision.take(revHashDigits)
+          else {
+            os.call(("git", "rev-parse", "--short", currentRevision),
+              cwd = vcsBasePath,
+              stderr = os.Pipe
+            ).out.trim()
+          }
+
+        s"$revSep$actualRevHashDigits"
       } else ""
 
       val dirtyPart = dirtyHash match {

--- a/website/package.mill
+++ b/website/package.mill
@@ -318,7 +318,13 @@ object `package` extends mill.Module {
         else crossValue
 
       val gitVersion =
-        if (crossValue2 == "dev") build.latestUnstableVersion().split('-').last
+        if (crossValue2 == "dev") {
+          val prefix = build.latestUnstableVersion().split('-').last
+          // In case of conflict, pick the latest commit matching the prefix,
+          // which is probably the correct one
+          val logged = os.call(("git", "log", "--pretty=format:%H")).out.lines()
+          logged.find(_.startsWith(prefix)).get
+        }
         else crossValue2
 
       val displayVersion =


### PR DESCRIPTION
1. Workaround the problem by picking the latest commit matching the VcsVersion short hash, to avoid an ambiguous hash error on checkout
2. Update VcsVersion to use `git rev-parse --short` rather than hardcoding `6`, which should make it less susceptible to hash collisions