### PR TITLE
Ignore `Operation not supported` when closing watch logs

### DIFF
--- a/runner/daemon/src/mill/daemon/Watching.scala
+++ b/runner/daemon/src/mill/daemon/Watching.scala
@@ -217,7 +217,13 @@ object Watching {
           if (alreadyStale) None
           else doWatch(notifiablesChanged = () => pathChangesDetected)
         }
-      }
+      }(closable =>
+        try closable.close()
+        catch{ case e: java.io.IOException =>
+          // Not sure why this happens, but if it does happen it probably means the
+          // file handle has already been closed, so just continue on without crashing
+        }
+      )
     }
 
     if (watchArgs.useNotify) doWatchFsNotify()


### PR DESCRIPTION
Works around https://github.com/com-lihaoyi/mill/issues/5375

I still don't know why it happens, but it's happened multiple times, and in any case it should be fine to ignore the error