### PR TITLE
Make most example projects Scala 3.7.1 by default

### DIFF
--- a/example/scalalib/basic/1-simple/build.mill
+++ b/example/scalalib/basic/1-simple/build.mill
@@ -7,7 +7,7 @@ object foo extends ScalaModule {
   def scalaVersion = "3.7.1"
   def mvnDeps = Seq(
     mvn"com.lihaoyi::scalatags:0.13.1",
-    mvn"com.lihaoyi::mainargs:0.6.2"
+    mvn"com.lihaoyi::mainargs:0.7.6"
   )
 
   object test extends ScalaTests {

--- a/example/scalalib/basic/1-simple/build.mill
+++ b/example/scalalib/basic/1-simple/build.mill
@@ -4,7 +4,7 @@ package build
 import mill._, scalalib._
 
 object foo extends ScalaModule {
-  def scalaVersion = "2.13.11"
+  def scalaVersion = "3.7.1"
   def mvnDeps = Seq(
     mvn"com.lihaoyi::scalatags:0.13.1",
     mvn"com.lihaoyi::mainargs:0.6.2"

--- a/example/scalalib/basic/1-simple/build.mill
+++ b/example/scalalib/basic/1-simple/build.mill
@@ -11,7 +11,7 @@ object foo extends ScalaModule {
   )
 
   object test extends ScalaTests {
-    def mvnDeps = Seq(mvn"com.lihaoyi::utest:0.8.5")
+    def mvnDeps = Seq(mvn"com.lihaoyi::utest:0.8.7")
     def testFramework = "utest.runner.Framework"
   }
 }

--- a/example/scalalib/basic/2-custom-build-logic/build.mill
+++ b/example/scalalib/basic/2-custom-build-logic/build.mill
@@ -9,7 +9,7 @@ package build
 import mill._, scalalib._
 
 object foo extends ScalaModule {
-  def scalaVersion = "2.13.11"
+  def scalaVersion = "3.7.1"
 
   /** Total number of lines in module source files */
   def lineCount = Task {

--- a/example/scalalib/basic/3-multi-module/build.mill
+++ b/example/scalalib/basic/3-multi-module/build.mill
@@ -12,11 +12,11 @@ trait MyModule extends ScalaModule {
 
 object foo extends MyModule {
   def moduleDeps = Seq(bar)
-  def mvnDeps = Seq(mvn"com.lihaoyi::mainargs:0.4.0")
+  def mvnDeps = Seq(mvn"com.lihaoyi::mainargs:0.7.6")
 }
 
 object bar extends MyModule {
-  def mvnDeps = Seq(mvn"com.lihaoyi::scalatags:0.12.0")
+  def mvnDeps = Seq(mvn"com.lihaoyi::scalatags:0.13.1")
 }
 //// SNIPPET:END
 

--- a/example/scalalib/basic/3-multi-module/build.mill
+++ b/example/scalalib/basic/3-multi-module/build.mill
@@ -3,7 +3,7 @@ package build
 import mill._, scalalib._
 
 trait MyModule extends ScalaModule {
-  def scalaVersion = "2.13.11"
+  def scalaVersion = "3.7.1"
   object test extends ScalaTests {
     def mvnDeps = Seq(mvn"com.lihaoyi::utest:0.8.5")
     def testFramework = "utest.runner.Framework"
@@ -16,7 +16,7 @@ object foo extends MyModule {
 }
 
 object bar extends MyModule {
-  def mvnDeps = Seq(mvn"com.lihaoyi::scalatags:0.8.2")
+  def mvnDeps = Seq(mvn"com.lihaoyi::scalatags:0.12.0")
 }
 //// SNIPPET:END
 

--- a/example/scalalib/basic/3-multi-module/build.mill
+++ b/example/scalalib/basic/3-multi-module/build.mill
@@ -5,7 +5,7 @@ import mill._, scalalib._
 trait MyModule extends ScalaModule {
   def scalaVersion = "3.7.1"
   object test extends ScalaTests {
-    def mvnDeps = Seq(mvn"com.lihaoyi::utest:0.8.5")
+    def mvnDeps = Seq(mvn"com.lihaoyi::utest:0.8.7")
     def testFramework = "utest.runner.Framework"
   }
 }

--- a/example/scalalib/basic/4-compat-modules/build.mill
+++ b/example/scalalib/basic/4-compat-modules/build.mill
@@ -9,7 +9,7 @@ package build
 import mill._, scalalib._
 
 object foo extends SbtModule {
-  def scalaVersion = "2.13.16"
+  def scalaVersion = "3.7.1"
   object test extends SbtTests {
     def mvnDeps = Seq(mvn"com.lihaoyi::utest:0.8.5")
     def testFramework = "utest.runner.Framework"

--- a/example/scalalib/basic/4-compat-modules/build.mill
+++ b/example/scalalib/basic/4-compat-modules/build.mill
@@ -11,7 +11,7 @@ import mill._, scalalib._
 object foo extends SbtModule {
   def scalaVersion = "3.7.1"
   object test extends SbtTests {
-    def mvnDeps = Seq(mvn"com.lihaoyi::utest:0.8.5")
+    def mvnDeps = Seq(mvn"com.lihaoyi::utest:0.8.7")
     def testFramework = "utest.runner.Framework"
   }
 }
@@ -19,7 +19,7 @@ object foo extends SbtModule {
 object bar extends Cross[BarModule]("2.12.17", "2.13.16")
 trait BarModule extends CrossSbtModule {
   object test extends CrossSbtTests {
-    def mvnDeps = Seq(mvn"com.lihaoyi::utest:0.8.5")
+    def mvnDeps = Seq(mvn"com.lihaoyi::utest:0.8.7")
     def testFramework = "utest.runner.Framework"
   }
 }

--- a/example/scalalib/basic/6-realistic/build.mill
+++ b/example/scalalib/basic/6-realistic/build.mill
@@ -23,7 +23,7 @@ trait MyModule extends PublishModule {
 trait MyScalaModule extends MyModule with CrossScalaModule {
   def mvnDeps = Seq(mvn"com.lihaoyi::scalatags:0.13.1")
   object test extends ScalaTests {
-    def mvnDeps = Seq(mvn"com.lihaoyi::utest:0.8.5")
+    def mvnDeps = Seq(mvn"com.lihaoyi::utest:0.8.7")
     def testFramework = "utest.runner.Framework"
   }
 }

--- a/example/scalalib/dependencies/1-mvn-deps/build.mill
+++ b/example/scalalib/dependencies/1-mvn-deps/build.mill
@@ -5,8 +5,8 @@ import mill._, scalalib._
 object `package` extends ScalaModule {
   def scalaVersion = "2.12.17"
   def mvnDeps = Seq(
-    mvn"com.lihaoyi::upickle:3.1.0",
-    mvn"com.lihaoyi::pprint:0.8.1",
+    mvn"com.lihaoyi::upickle:4.1.0",
+    mvn"com.lihaoyi::pprint:0.9.0",
     mvn"${scalaOrganization()}:scala-reflect:${scalaVersion()}"
   )
 }

--- a/example/scalalib/dependencies/2-run-compile-deps/build.mill
+++ b/example/scalalib/dependencies/2-run-compile-deps/build.mill
@@ -8,7 +8,7 @@ package build
 import mill._, scalalib._
 
 object foo extends ScalaModule {
-  def scalaVersion = "2.13.16"
+  def scalaVersion = "3.7.1"
   def moduleDeps = Seq(bar)
   def runMvnDeps = Seq(
     mvn"javax.servlet:servlet-api:2.5",
@@ -34,7 +34,7 @@ object foo extends ScalaModule {
 //// SNIPPET:BUILD2
 
 object bar extends ScalaModule {
-  def scalaVersion = "2.13.16"
+  def scalaVersion = "3.7.1"
   def compileMvnDeps = Seq(
     mvn"javax.servlet:servlet-api:2.5",
     mvn"org.eclipse.jetty:jetty-server:9.4.42.v20210604",

--- a/example/scalalib/dependencies/3-unmanaged-jars/build.mill
+++ b/example/scalalib/dependencies/3-unmanaged-jars/build.mill
@@ -11,7 +11,7 @@ package build
 import mill._, scalalib._
 
 object `package` extends ScalaModule {
-  def scalaVersion = "2.13.16"
+  def scalaVersion = "3.7.1"
   def lib = Task.Source("lib")
   def unmanagedClasspath = Task {
     if (!os.exists(lib().path)) Seq()

--- a/example/scalalib/dependencies/4-downloading-unmanaged-jars/build.mill
+++ b/example/scalalib/dependencies/4-downloading-unmanaged-jars/build.mill
@@ -8,7 +8,7 @@ package build
 import mill._, scalalib._
 
 object `package` extends ScalaModule {
-  def scalaVersion = "2.13.16"
+  def scalaVersion = "3.7.1"
   def unmanagedClasspath = Task {
     if (Task.offline) Task.fail("Cannot download classpath when in offline-mode") // <1>
     else {

--- a/example/scalalib/dependencies/5-repository-config/build.mill
+++ b/example/scalalib/dependencies/5-repository-config/build.mill
@@ -8,7 +8,7 @@ import mill._, scalalib._
 import mill.define.ModuleRef
 
 object foo extends ScalaModule {
-  def scalaVersion = "2.13.16"
+  def scalaVersion = "3.7.1"
 
   def mvnDeps = Seq(
     mvn"com.lihaoyi::scalatags:0.13.1",
@@ -59,7 +59,7 @@ object CustomJvmWorkerModule extends JvmWorkerModule with CoursierModule {
 }
 
 object bar extends ScalaModule {
-  def scalaVersion = "2.13.16"
+  def scalaVersion = "3.7.1"
   def jvmWorker = ModuleRef(CustomJvmWorkerModule)
   // ... rest of your build definitions
 

--- a/example/scalalib/dependencies/5-repository-config/build.mill
+++ b/example/scalalib/dependencies/5-repository-config/build.mill
@@ -12,7 +12,7 @@ object foo extends ScalaModule {
 
   def mvnDeps = Seq(
     mvn"com.lihaoyi::scalatags:0.13.1",
-    mvn"com.lihaoyi::mainargs:0.6.2"
+    mvn"com.lihaoyi::mainargs:0.7.6"
   )
 
   def repositories = Seq("https://oss.sonatype.org/content/repositories/releases")

--- a/example/scalalib/linting/1-scalafmt/build.mill
+++ b/example/scalalib/linting/1-scalafmt/build.mill
@@ -2,7 +2,7 @@ package build
 import mill._, scalalib._
 
 object `package` extends ScalaModule {
-  def scalaVersion = "2.13.11"
+  def scalaVersion = "3.7.1"
 }
 
 /** See Also: .scalafmt.conf */

--- a/example/scalalib/linting/2-contrib-scoverage/build.mill
+++ b/example/scalalib/linting/2-contrib-scoverage/build.mill
@@ -11,7 +11,7 @@ object `package` extends ScoverageModule {
   def scalaVersion = "3.7.1"
   def mvnDeps = Seq(
     mvn"com.lihaoyi::scalatags:0.13.1",
-    mvn"com.lihaoyi::mainargs:0.0.7.6"
+    mvn"com.lihaoyi::mainargs:0.7.6"
   )
 
   object test extends ScoverageTests /*with TestModule.Utest */ {

--- a/example/scalalib/linting/2-contrib-scoverage/build.mill
+++ b/example/scalalib/linting/2-contrib-scoverage/build.mill
@@ -8,7 +8,7 @@ import mill.contrib.scoverage._
 
 object `package` extends ScoverageModule {
   def scoverageVersion = "2.1.0"
-  def scalaVersion = "2.13.11"
+  def scalaVersion = "3.7.1"
   def mvnDeps = Seq(
     mvn"com.lihaoyi::scalatags:0.13.1",
     mvn"com.lihaoyi::mainargs:0.6.2"
@@ -53,6 +53,6 @@ scoverage.xmlReport
 
 > ./mill scoverage.consoleReport
 ...
-Statement coverage.: 16.67%
+Statement coverage.: 10.53%
 Branch coverage....: 100.00%
 */

--- a/example/scalalib/linting/2-contrib-scoverage/build.mill
+++ b/example/scalalib/linting/2-contrib-scoverage/build.mill
@@ -11,7 +11,7 @@ object `package` extends ScoverageModule {
   def scalaVersion = "3.7.1"
   def mvnDeps = Seq(
     mvn"com.lihaoyi::scalatags:0.13.1",
-    mvn"com.lihaoyi::mainargs:0.6.2"
+    mvn"com.lihaoyi::mainargs:0.0.7.6"
   )
 
   object test extends ScoverageTests /*with TestModule.Utest */ {

--- a/example/scalalib/linting/2-contrib-scoverage/build.mill
+++ b/example/scalalib/linting/2-contrib-scoverage/build.mill
@@ -15,7 +15,7 @@ object `package` extends ScoverageModule {
   )
 
   object test extends ScoverageTests /*with TestModule.Utest */ {
-    def mvnDeps = Seq(mvn"com.lihaoyi::utest:0.8.5")
+    def mvnDeps = Seq(mvn"com.lihaoyi::utest:0.8.7")
     def testFramework = "utest.runner.Framework"
   }
 }

--- a/example/scalalib/module/1-common-config/build.mill
+++ b/example/scalalib/module/1-common-config/build.mill
@@ -14,7 +14,7 @@ object `package` extends ScalaModule {
 
   // You can have arbitrary numbers of third-party dependencies
   def mvnDeps = Seq(
-    mvn"com.lihaoyi::scalatags:0.8.2",
+    mvn"com.lihaoyi::scalatags:0.12.0",
     mvn"com.lihaoyi::os-lib:0.10.7"
   )
 

--- a/example/scalalib/module/1-common-config/build.mill
+++ b/example/scalalib/module/1-common-config/build.mill
@@ -15,7 +15,7 @@ object `package` extends ScalaModule {
   // You can have arbitrary numbers of third-party dependencies
   def mvnDeps = Seq(
     mvn"com.lihaoyi::scalatags:0.13.1",
-    mvn"com.lihaoyi::os-lib:0.11.5"
+    mvn"com.lihaoyi::os-lib:0.11.4"
   )
 
   // Choose a main class to use for `.run` if there are multiple present

--- a/example/scalalib/module/1-common-config/build.mill
+++ b/example/scalalib/module/1-common-config/build.mill
@@ -14,8 +14,8 @@ object `package` extends ScalaModule {
 
   // You can have arbitrary numbers of third-party dependencies
   def mvnDeps = Seq(
-    mvn"com.lihaoyi::scalatags:0.12.0",
-    mvn"com.lihaoyi::os-lib:0.10.7"
+    mvn"com.lihaoyi::scalatags:0.13.1",
+    mvn"com.lihaoyi::os-lib:0.11.5"
   )
 
   // Choose a main class to use for `.run` if there are multiple present

--- a/example/scalalib/module/11-main-class/build.mill
+++ b/example/scalalib/module/11-main-class/build.mill
@@ -3,7 +3,7 @@ package build
 import mill._, scalalib._
 
 object `package` extends ScalaModule {
-  def scalaVersion = "2.13.16"
+  def scalaVersion = "3.7.1"
   def mainClass = Some("foo.Qux")
 }
 

--- a/example/scalalib/module/15-unidoc/build.mill
+++ b/example/scalalib/module/15-unidoc/build.mill
@@ -2,15 +2,15 @@ package build
 import mill._, scalalib._
 
 object foo extends ScalaModule with UnidocModule {
-  def scalaVersion = "2.13.16"
+  def scalaVersion = "3.7.1"
   def moduleDeps = Seq(bar, qux)
 
   object bar extends ScalaModule {
-    def scalaVersion = "2.13.16"
+    def scalaVersion = "3.7.1"
   }
 
   object qux extends ScalaModule {
-    def scalaVersion = "2.13.16"
+    def scalaVersion = "3.7.1"
     def moduleDeps = Seq(bar)
   }
 

--- a/example/scalalib/module/2-custom-tasks/build.mill
+++ b/example/scalalib/module/2-custom-tasks/build.mill
@@ -14,7 +14,7 @@ import mill._, scalalib._
 
 object `package` extends ScalaModule {
   def scalaVersion = "3.7.1"
-  def mvnDeps = Seq(mvn"com.lihaoyi::mainargs:0.4.0")
+  def mvnDeps = Seq(mvn"com.lihaoyi::mainargs:0.7.6")
 
   def generatedSources: T[Seq[PathRef]] = Task {
     val prettyMvnDeps = for (ivyDep <- mvnDeps()) yield {
@@ -97,7 +97,7 @@ object `package` extends ScalaModule {
 
 > ./mill run --text hello
 text: hello
-MyDeps.value: List((com.lihaoyi,mainargs,0.4.0))
+MyDeps.value: List((com.lihaoyi,mainargs,0.7.6))
 my.line.count: 14
 
 > ./mill show lineCount

--- a/example/scalalib/module/2-custom-tasks/build.mill
+++ b/example/scalalib/module/2-custom-tasks/build.mill
@@ -13,7 +13,7 @@ package build
 import mill._, scalalib._
 
 object `package` extends ScalaModule {
-  def scalaVersion = "2.13.16"
+  def scalaVersion = "3.7.1"
   def mvnDeps = Seq(mvn"com.lihaoyi::mainargs:0.4.0")
 
   def generatedSources: T[Seq[PathRef]] = Task {

--- a/example/scalalib/module/3-generated-sources/build.mill
+++ b/example/scalalib/module/3-generated-sources/build.mill
@@ -3,7 +3,7 @@ package build
 import mill._, scalalib._
 
 object foo extends ScalaModule {
-  def scalaVersion = "2.13.16"
+  def scalaVersion = "3.7.1"
 
   def generatedSources = Task {
     os.write(

--- a/example/scalalib/module/4-compilation-execution-flags/build.mill
+++ b/example/scalalib/module/4-compilation-execution-flags/build.mill
@@ -3,7 +3,7 @@ package build
 import mill._, scalalib._
 
 object `package` extends ScalaModule {
-  def scalaVersion = "2.13.16"
+  def scalaVersion = "3.7.1"
   def scalacOptions = Seq("-Ydelambdafy:inline")
   def forkArgs = Seq("-Xmx4g", "-Dmy.jvm.property=hello")
   def forkEnv = Map("MY_ENV_VAR" -> "WORLD")

--- a/example/scalalib/module/7-resources/build.mill
+++ b/example/scalalib/module/7-resources/build.mill
@@ -9,7 +9,7 @@ object foo extends ScalaModule {
   )
 
   object test extends ScalaTests {
-    def mvnDeps = Seq(mvn"com.lihaoyi::utest:0.8.5")
+    def mvnDeps = Seq(mvn"com.lihaoyi::utest:0.8.7")
     def testFramework = "utest.runner.Framework"
 
     def otherFiles = Task.Source("other-files")

--- a/example/scalalib/module/7-resources/build.mill
+++ b/example/scalalib/module/7-resources/build.mill
@@ -5,7 +5,7 @@ import mill._, scalalib._
 object foo extends ScalaModule {
   def scalaVersion = "3.7.1"
   def mvnDeps = Seq(
-    mvn"com.lihaoyi::os-lib:0.10.7"
+    mvn"com.lihaoyi::os-lib:0.11.5"
   )
 
   object test extends ScalaTests {

--- a/example/scalalib/module/7-resources/build.mill
+++ b/example/scalalib/module/7-resources/build.mill
@@ -5,7 +5,7 @@ import mill._, scalalib._
 object foo extends ScalaModule {
   def scalaVersion = "3.7.1"
   def mvnDeps = Seq(
-    mvn"com.lihaoyi::os-lib:0.11.5"
+    mvn"com.lihaoyi::os-lib:0.11.4"
   )
 
   object test extends ScalaTests {

--- a/example/scalalib/module/7-resources/build.mill
+++ b/example/scalalib/module/7-resources/build.mill
@@ -3,7 +3,7 @@ package build
 import mill._, scalalib._
 
 object foo extends ScalaModule {
-  def scalaVersion = "2.13.16"
+  def scalaVersion = "3.7.1"
   def mvnDeps = Seq(
     mvn"com.lihaoyi::os-lib:0.10.7"
   )

--- a/example/scalalib/native/1-simple/build.mill
+++ b/example/scalalib/native/1-simple/build.mill
@@ -11,7 +11,7 @@ object `package` extends ScalaNativeModule {
   )
 
   object test extends ScalaNativeTests with TestModule.Utest {
-    def mvnDeps = Seq(mvn"com.lihaoyi::utest::0.8.5")
+    def mvnDeps = Seq(mvn"com.lihaoyi::utest::0.8.7")
     def testFramework = "utest.runner.Framework"
   }
 }

--- a/example/scalalib/native/1-simple/build.mill
+++ b/example/scalalib/native/1-simple/build.mill
@@ -3,7 +3,7 @@ import mill._, scalalib._, scalanativelib._
 
 object `package` extends ScalaNativeModule {
   def scalaVersion = "3.3.4"
-  def scalaNativeVersion = "0.5.5"
+  def scalaNativeVersion = "0.5.8"
 
   // You can have arbitrary numbers of third-party dependencies
   def mvnDeps = Seq(

--- a/example/scalalib/native/2-interop/build.mill
+++ b/example/scalalib/native/2-interop/build.mill
@@ -6,7 +6,7 @@ object `package` extends ScalaNativeModule {
   def scalaNativeVersion = "0.5.8"
 
   object test extends ScalaNativeTests {
-    def mvnDeps = Seq(mvn"com.lihaoyi::utest::0.8.5")
+    def mvnDeps = Seq(mvn"com.lihaoyi::utest::0.8.7")
     def testFramework = "utest.runner.Framework"
   }
 

--- a/example/scalalib/native/2-interop/build.mill
+++ b/example/scalalib/native/2-interop/build.mill
@@ -3,7 +3,7 @@ import mill._, scalalib._, scalanativelib._
 
 object `package` extends ScalaNativeModule {
   def scalaVersion = "3.3.4"
-  def scalaNativeVersion = "0.5.5"
+  def scalaNativeVersion = "0.5.8"
 
   object test extends ScalaNativeTests {
     def mvnDeps = Seq(mvn"com.lihaoyi::utest::0.8.5")

--- a/example/scalalib/native/3-multi-module/build.mill
+++ b/example/scalalib/native/3-multi-module/build.mill
@@ -3,7 +3,7 @@ import mill._, scalalib._, scalanativelib._
 
 trait MyModule extends ScalaNativeModule {
   def scalaVersion = "3.3.4"
-  def scalaNativeVersion = "0.5.5"
+  def scalaNativeVersion = "0.5.8"
 
   object test extends ScalaNativeTests {
     def mvnDeps = Seq(mvn"com.lihaoyi::utest::0.8.5")

--- a/example/scalalib/native/3-multi-module/build.mill
+++ b/example/scalalib/native/3-multi-module/build.mill
@@ -6,7 +6,7 @@ trait MyModule extends ScalaNativeModule {
   def scalaNativeVersion = "0.5.8"
 
   object test extends ScalaNativeTests {
-    def mvnDeps = Seq(mvn"com.lihaoyi::utest::0.8.5")
+    def mvnDeps = Seq(mvn"com.lihaoyi::utest::0.8.7")
     def testFramework = "utest.runner.Framework"
   }
 }

--- a/example/scalalib/native/4-common-config/build.mill
+++ b/example/scalalib/native/4-common-config/build.mill
@@ -3,7 +3,7 @@ import mill._, scalalib._, scalanativelib._, scalanativelib.api._
 
 object `package` extends ScalaNativeModule {
   def scalaVersion = "3.3.4"
-  def scalaNativeVersion = "0.5.5"
+  def scalaNativeVersion = "0.5.8"
 
   // You can have arbitrary numbers of third-party dependencies
   // Scala Native uses double colon `::` between organization and the dependency names

--- a/example/scalalib/publishing/1-assembly-config/build.mill
+++ b/example/scalalib/publishing/1-assembly-config/build.mill
@@ -8,7 +8,7 @@ import mill.scalalib.Assembly._
 
 object foo extends ScalaModule {
   def moduleDeps = Seq(bar)
-  def scalaVersion = "2.13.16"
+  def scalaVersion = "3.7.1"
   def mvnDeps = Seq(mvn"com.lihaoyi::os-lib:0.10.7")
   def assemblyRules = Seq(
     // all application.conf files will be concatenated into single file
@@ -26,7 +26,7 @@ object foo extends ScalaModule {
 }
 
 object bar extends ScalaModule {
-  def scalaVersion = "2.13.16"
+  def scalaVersion = "3.7.1"
 }
 //// SNIPPET:END
 

--- a/example/scalalib/publishing/1-assembly-config/build.mill
+++ b/example/scalalib/publishing/1-assembly-config/build.mill
@@ -9,7 +9,7 @@ import mill.scalalib.Assembly._
 object foo extends ScalaModule {
   def moduleDeps = Seq(bar)
   def scalaVersion = "3.7.1"
-  def mvnDeps = Seq(mvn"com.lihaoyi::os-lib:0.11.5")
+  def mvnDeps = Seq(mvn"com.lihaoyi::os-lib:0.11.4")
   def assemblyRules = Seq(
     // all application.conf files will be concatenated into single file
     Rule.Append("application.conf"),

--- a/example/scalalib/publishing/1-assembly-config/build.mill
+++ b/example/scalalib/publishing/1-assembly-config/build.mill
@@ -9,7 +9,7 @@ import mill.scalalib.Assembly._
 object foo extends ScalaModule {
   def moduleDeps = Seq(bar)
   def scalaVersion = "3.7.1"
-  def mvnDeps = Seq(mvn"com.lihaoyi::os-lib:0.10.7")
+  def mvnDeps = Seq(mvn"com.lihaoyi::os-lib:0.11.5")
   def assemblyRules = Seq(
     // all application.conf files will be concatenated into single file
     Rule.Append("application.conf"),

--- a/example/scalalib/publishing/2-publish-module/build.mill
+++ b/example/scalalib/publishing/2-publish-module/build.mill
@@ -3,7 +3,7 @@ package build
 import mill._, scalalib._, publish._
 
 object foo extends ScalaModule with PublishModule {
-  def scalaVersion = "2.13.16"
+  def scalaVersion = "3.7.1"
   def publishVersion = "0.0.1"
 
   def pomSettings = PomSettings(
@@ -27,7 +27,7 @@ object foo extends ScalaModule with PublishModule {
 > ./mill foo.publishLocal # publish specific modules
 
 > ./mill __.publishLocal # publish every eligible module
-Publishing Artifact(com.lihaoyi,foo_2.13,0.0.1) to ivy repo...
+Publishing Artifact(com.lihaoyi,foo_3,0.0.1) to ivy repo...
 
 */
 

--- a/example/scalalib/publishing/3-publish-module-sonatype/build.mill
+++ b/example/scalalib/publishing/3-publish-module-sonatype/build.mill
@@ -3,7 +3,7 @@ package build
 import mill._, scalalib._, publish._
 
 object foo extends ScalaModule with SonatypeCentralPublishModule {
-  def scalaVersion = "2.13.16"
+  def scalaVersion = "3.7.1"
   def publishVersion = "0.0.1"
 
   def pomSettings = PomSettings(

--- a/example/scalalib/publishing/7-native-image/build.mill
+++ b/example/scalalib/publishing/7-native-image/build.mill
@@ -4,7 +4,7 @@ import mill._, scalalib._
 import mill.define.ModuleRef
 
 object foo extends ScalaModule with NativeImageModule {
-  def scalaVersion = "2.13.11"
+  def scalaVersion = "3.7.1"
 
   def jvmId = "graalvm-community:17.0.7"
 

--- a/example/scalalib/publishing/8-native-image-libs/build.mill
+++ b/example/scalalib/publishing/8-native-image-libs/build.mill
@@ -10,7 +10,7 @@ object foo extends ScalaModule with NativeImageModule {
 
   def mvnDeps = Seq(
     mvn"com.lihaoyi::scalatags:0.13.1",
-    mvn"com.lihaoyi::mainargs:0.6.2"
+    mvn"com.lihaoyi::mainargs:0.7.6"
   )
 
   def jvmId = "graalvm-community:23.0.1"

--- a/example/scalalib/publishing/8-native-image-libs/build.mill
+++ b/example/scalalib/publishing/8-native-image-libs/build.mill
@@ -4,7 +4,7 @@ import mill._, scalalib._
 import mill.define.ModuleRef
 
 object foo extends ScalaModule with NativeImageModule {
-  def scalaVersion = "2.13.11"
+  def scalaVersion = "3.7.1"
 
   def nativeImageOptions = Seq("--no-fallback", "-Os")
 

--- a/example/scalalib/spark/1-hello-spark/build.mill
+++ b/example/scalalib/spark/1-hello-spark/build.mill
@@ -11,7 +11,7 @@ object foo extends ScalaModule {
   def forkArgs = Seq("--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED")
 
   object test extends ScalaTests {
-    def mvnDeps = Seq(mvn"com.lihaoyi::utest:0.8.5")
+    def mvnDeps = Seq(mvn"com.lihaoyi::utest:0.8.7")
     def testFramework = "utest.runner.Framework"
 
     def forkArgs = Seq("--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED")

--- a/example/scalalib/spark/3-semi-realistic/build.mill
+++ b/example/scalalib/spark/3-semi-realistic/build.mill
@@ -13,7 +13,7 @@ object `package` extends ScalaModule {
   def prependShellScript = ""
 
   object test extends ScalaTests {
-    def mvnDeps = Seq(mvn"com.lihaoyi::utest:0.8.5")
+    def mvnDeps = Seq(mvn"com.lihaoyi::utest:0.8.7")
     def testFramework = "utest.runner.Framework"
 
     def forkArgs = Seq("--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED")

--- a/example/scalalib/testing/1-test-suite/build.mill
+++ b/example/scalalib/testing/1-test-suite/build.mill
@@ -3,7 +3,7 @@ package build
 import mill._, scalalib._
 
 object foo extends ScalaModule {
-  def scalaVersion = "2.13.15"
+  def scalaVersion = "3.7.1"
   object test extends ScalaTests {
     def mvnDeps = Seq(mvn"com.lihaoyi::utest:0.8.5")
     def testFramework = "utest.runner.Framework"
@@ -64,7 +64,7 @@ compiling 2 ... source...
 //
 //// SNIPPET:BUILD2
 object bar extends ScalaModule {
-  def scalaVersion = "2.13.15"
+  def scalaVersion = "3.7.1"
 
   object test extends ScalaTests with TestModule.Utest {
     def utestVersion = "0.8.5"

--- a/example/scalalib/testing/1-test-suite/build.mill
+++ b/example/scalalib/testing/1-test-suite/build.mill
@@ -5,7 +5,7 @@ import mill._, scalalib._
 object foo extends ScalaModule {
   def scalaVersion = "3.7.1"
   object test extends ScalaTests {
-    def mvnDeps = Seq(mvn"com.lihaoyi::utest:0.8.5")
+    def mvnDeps = Seq(mvn"com.lihaoyi::utest:0.8.7")
     def testFramework = "utest.runner.Framework"
   }
 }
@@ -67,7 +67,7 @@ object bar extends ScalaModule {
   def scalaVersion = "3.7.1"
 
   object test extends ScalaTests with TestModule.Utest {
-    def utestVersion = "0.8.5"
+    def utestVersion = "0.8.7"
   }
 }
 

--- a/example/scalalib/testing/2-test-deps/build.mill
+++ b/example/scalalib/testing/2-test-deps/build.mill
@@ -14,7 +14,7 @@ package build
 import mill._, scalalib._
 
 object qux extends ScalaModule {
-  def scalaVersion = "2.13.16"
+  def scalaVersion = "3.7.1"
   def moduleDeps = Seq(baz)
 
   object test extends ScalaTests with TestModule.Utest {
@@ -24,7 +24,7 @@ object qux extends ScalaModule {
 }
 
 object baz extends ScalaModule {
-  def scalaVersion = "2.13.16"
+  def scalaVersion = "3.7.1"
 
   object test extends ScalaTests with TestModule.Utest {
     def utestVersion = "0.8.5"

--- a/example/scalalib/testing/2-test-deps/build.mill
+++ b/example/scalalib/testing/2-test-deps/build.mill
@@ -18,7 +18,7 @@ object qux extends ScalaModule {
   def moduleDeps = Seq(baz)
 
   object test extends ScalaTests with TestModule.Utest {
-    def utestVersion = "0.8.5"
+    def utestVersion = "0.8.7"
     def moduleDeps = super.moduleDeps ++ Seq(baz.test)
   }
 }
@@ -27,7 +27,7 @@ object baz extends ScalaModule {
   def scalaVersion = "3.7.1"
 
   object test extends ScalaTests with TestModule.Utest {
-    def utestVersion = "0.8.5"
+    def utestVersion = "0.8.7"
   }
 }
 

--- a/example/scalalib/testing/3-integration-suite/build.mill
+++ b/example/scalalib/testing/3-integration-suite/build.mill
@@ -10,10 +10,10 @@ object qux extends ScalaModule {
   def scalaVersion = "3.7.1"
 
   object test extends ScalaTests with TestModule.Utest {
-    def utestVersion = "0.8.5"
+    def utestVersion = "0.8.7"
   }
   object integration extends ScalaTests with TestModule.Utest {
-    def utestVersion = "0.8.5"
+    def utestVersion = "0.8.7"
   }
 }
 //// SNIPPET:END

--- a/example/scalalib/testing/3-integration-suite/build.mill
+++ b/example/scalalib/testing/3-integration-suite/build.mill
@@ -7,7 +7,7 @@ package build
 import mill._, scalalib._
 
 object qux extends ScalaModule {
-  def scalaVersion = "2.13.16"
+  def scalaVersion = "3.7.1"
 
   object test extends ScalaTests with TestModule.Utest {
     def utestVersion = "0.8.5"

--- a/example/scalalib/testing/4-test-parallel/build.mill
+++ b/example/scalalib/testing/4-test-parallel/build.mill
@@ -7,7 +7,7 @@ package build
 import mill._, scalalib._
 
 object foo extends ScalaModule {
-  def scalaVersion = "2.13.16"
+  def scalaVersion = "3.7.1"
   object test extends ScalaTests with TestModule.Utest {
     def utestVersion = "0.8.5"
 

--- a/example/scalalib/testing/4-test-parallel/build.mill
+++ b/example/scalalib/testing/4-test-parallel/build.mill
@@ -9,7 +9,7 @@ import mill._, scalalib._
 object foo extends ScalaModule {
   def scalaVersion = "3.7.1"
   object test extends ScalaTests with TestModule.Utest {
-    def utestVersion = "0.8.5"
+    def utestVersion = "0.8.7"
 
     def testParallelism = true
   }

--- a/example/scalalib/testing/5-test-grouping/build.mill
+++ b/example/scalalib/testing/5-test-grouping/build.mill
@@ -8,7 +8,7 @@ package build
 import mill._, scalalib._
 
 object foo extends ScalaModule {
-  def scalaVersion = "2.13.16"
+  def scalaVersion = "3.7.1"
   object test extends ScalaTests with TestModule.Utest {
     def utestVersion = "0.8.5"
 

--- a/example/scalalib/testing/5-test-grouping/build.mill
+++ b/example/scalalib/testing/5-test-grouping/build.mill
@@ -10,7 +10,7 @@ import mill._, scalalib._
 object foo extends ScalaModule {
   def scalaVersion = "3.7.1"
   object test extends ScalaTests with TestModule.Utest {
-    def utestVersion = "0.8.5"
+    def utestVersion = "0.8.7"
 
     def testForkGrouping = discoveredTestClasses().grouped(1).toSeq
     def testParallelism = false

--- a/example/scalalib/testing/6-test-group-parallel/build.mill
+++ b/example/scalalib/testing/6-test-group-parallel/build.mill
@@ -7,7 +7,7 @@ import mill._, scalalib._
 object foo extends ScalaModule {
   def scalaVersion = "3.7.1"
   object test extends ScalaTests with TestModule.Utest {
-    def utestVersion = "0.8.5"
+    def utestVersion = "0.8.7"
 
     // Group tests by GroupX and GroupY
     def testForkGrouping =

--- a/example/scalalib/testing/6-test-group-parallel/build.mill
+++ b/example/scalalib/testing/6-test-group-parallel/build.mill
@@ -5,7 +5,7 @@ package build
 import mill._, scalalib._
 
 object foo extends ScalaModule {
-  def scalaVersion = "2.13.16"
+  def scalaVersion = "3.7.1"
   object test extends ScalaTests with TestModule.Utest {
     def utestVersion = "0.8.5"
 

--- a/example/scalalib/web/1-todo-webapp/build.mill
+++ b/example/scalalib/web/1-todo-webapp/build.mill
@@ -2,7 +2,7 @@ package build
 import mill._, scalalib._
 
 object `package` extends ScalaModule {
-  def scalaVersion = "2.13.16"
+  def scalaVersion = "3.7.1"
   def mvnDeps = Seq(
     mvn"com.lihaoyi::cask:0.9.1",
     mvn"com.lihaoyi::scalatags:0.13.1"

--- a/example/scalalib/web/1-todo-webapp/build.mill
+++ b/example/scalalib/web/1-todo-webapp/build.mill
@@ -10,7 +10,7 @@ object `package` extends ScalaModule {
 
   object test extends ScalaTests with TestModule.Utest {
     def mvnDeps = Seq(
-      mvn"com.lihaoyi::utest::0.8.5",
+      mvn"com.lihaoyi::utest::0.8.7",
       mvn"com.lihaoyi::requests::0.6.9"
     )
   }

--- a/example/scalalib/web/2-webapp-cache-busting/build.mill
+++ b/example/scalalib/web/2-webapp-cache-busting/build.mill
@@ -27,7 +27,7 @@ object `package` extends ScalaModule {
 
   object test extends ScalaTests with TestModule.Utest {
     def mvnDeps = Seq(
-      mvn"com.lihaoyi::utest::0.8.5",
+      mvn"com.lihaoyi::utest::0.8.7",
       mvn"com.lihaoyi::requests::0.6.9"
     )
   }

--- a/example/scalalib/web/2-webapp-cache-busting/build.mill
+++ b/example/scalalib/web/2-webapp-cache-busting/build.mill
@@ -7,7 +7,7 @@ object `package` extends ScalaModule {
   def mvnDeps = Seq(
     mvn"com.lihaoyi::cask:0.9.1",
     mvn"com.lihaoyi::scalatags:0.13.1",
-    mvn"com.lihaoyi::os-lib:0.10.7"
+    mvn"com.lihaoyi::os-lib:0.11.5"
   )
 
   def resources = Task {

--- a/example/scalalib/web/2-webapp-cache-busting/build.mill
+++ b/example/scalalib/web/2-webapp-cache-busting/build.mill
@@ -7,7 +7,7 @@ object `package` extends ScalaModule {
   def mvnDeps = Seq(
     mvn"com.lihaoyi::cask:0.9.1",
     mvn"com.lihaoyi::scalatags:0.13.1",
-    mvn"com.lihaoyi::os-lib:0.11.5"
+    mvn"com.lihaoyi::os-lib:0.11.4"
   )
 
   def resources = Task {

--- a/example/scalalib/web/2-webapp-cache-busting/build.mill
+++ b/example/scalalib/web/2-webapp-cache-busting/build.mill
@@ -3,7 +3,7 @@ import mill._, scalalib._
 import java.util.Arrays
 
 object `package` extends ScalaModule {
-  def scalaVersion = "2.13.16"
+  def scalaVersion = "3.7.1"
   def mvnDeps = Seq(
     mvn"com.lihaoyi::cask:0.9.1",
     mvn"com.lihaoyi::scalatags:0.13.1",

--- a/example/scalalib/web/3-todo-http4s/build.mill
+++ b/example/scalalib/web/3-todo-http4s/build.mill
@@ -12,7 +12,7 @@ object `package` extends ScalaModule {
 
   object test extends ScalaTests with TestModule.Utest {
     def mvnDeps = Seq(
-      mvn"com.lihaoyi::utest::0.8.5",
+      mvn"com.lihaoyi::utest::0.8.7",
       mvn"org.typelevel::cats-effect-testing-utest::1.6.0",
       mvn"org.http4s::http4s-client::0.23.30"
     )

--- a/example/scalalib/web/3-todo-http4s/build.mill
+++ b/example/scalalib/web/3-todo-http4s/build.mill
@@ -2,7 +2,7 @@ package build
 import mill._, scalalib._
 
 object `package` extends ScalaModule {
-  def scalaVersion = "2.13.16"
+  def scalaVersion = "3.7.1"
   def mvnDeps = Seq(
     mvn"org.http4s::http4s-ember-server::0.23.30",
     mvn"org.http4s::http4s-dsl::0.23.30",

--- a/example/scalalib/web/4-scalajs-module/build.mill
+++ b/example/scalalib/web/4-scalajs-module/build.mill
@@ -6,7 +6,7 @@ object foo extends ScalaJSModule {
   def scalaJSVersion = "1.19.0"
   def mvnDeps = Seq(mvn"com.lihaoyi::scalatags::0.13.1")
   object test extends ScalaJSTests with TestModule.Utest {
-    def utestVersion = "0.8.5"
+    def utestVersion = "0.8.7"
   }
 }
 

--- a/example/scalalib/web/4-scalajs-module/build.mill
+++ b/example/scalalib/web/4-scalajs-module/build.mill
@@ -2,8 +2,8 @@ package build
 import mill._, scalalib._, scalajslib._
 
 object foo extends ScalaJSModule {
-  def scalaVersion = "2.13.14"
-  def scalaJSVersion = "1.16.0"
+  def scalaVersion = "3.7.1"
+  def scalaJSVersion = "1.19.0"
   def mvnDeps = Seq(mvn"com.lihaoyi::scalatags::0.13.1")
   object test extends ScalaJSTests with TestModule.Utest {
     def utestVersion = "0.8.5"

--- a/example/scalalib/web/5-webapp-scalajs/build.mill
+++ b/example/scalalib/web/5-webapp-scalajs/build.mill
@@ -3,7 +3,7 @@ import mill._, scalalib._, scalajslib._
 
 object `package` extends ScalaModule {
 
-  def scalaVersion = "2.13.14"
+  def scalaVersion = "3.7.1"
   def mvnDeps = Seq(
     mvn"com.lihaoyi::cask:0.9.1",
     mvn"com.lihaoyi::scalatags:0.13.1"
@@ -27,8 +27,8 @@ object `package` extends ScalaModule {
   }
 
   object client extends ScalaJSModule {
-    def scalaVersion = "2.13.14"
-    def scalaJSVersion = "1.16.0"
+    def scalaVersion = "3.7.1"
+    def scalaJSVersion = "1.19.0"
     def mvnDeps = Seq(mvn"org.scala-js::scalajs-dom::2.2.0")
   }
 }

--- a/example/scalalib/web/5-webapp-scalajs/build.mill
+++ b/example/scalalib/web/5-webapp-scalajs/build.mill
@@ -20,7 +20,7 @@ object `package` extends ScalaModule {
   }
 
   object test extends ScalaTests with TestModule.Utest {
-    def utestVersion = "0.8.5"
+    def utestVersion = "0.8.7"
     def mvnDeps = Seq(
       mvn"com.lihaoyi::requests::0.6.9"
     )

--- a/example/scalalib/web/6-webapp-scalajs-shared/build.mill
+++ b/example/scalalib/web/6-webapp-scalajs-shared/build.mill
@@ -6,7 +6,7 @@ trait AppScalaModule extends ScalaModule {
 }
 
 trait AppScalaJSModule extends AppScalaModule with ScalaJSModule {
-  def scalaJSVersion = "1.16.0"
+  def scalaJSVersion = "1.19.0"
 }
 
 object `package` extends AppScalaModule {

--- a/example/scalalib/web/6-webapp-scalajs-shared/build.mill
+++ b/example/scalalib/web/6-webapp-scalajs-shared/build.mill
@@ -32,7 +32,7 @@ object `package` extends AppScalaModule {
     trait SharedModule extends AppScalaModule with PlatformScalaModule {
       def mvnDeps = Seq(
         mvn"com.lihaoyi::scalatags::0.13.1",
-        mvn"com.lihaoyi::upickle::3.0.0"
+        mvn"com.lihaoyi::upickle::4.1.0"
       )
     }
 

--- a/example/scalalib/web/6-webapp-scalajs-shared/build.mill
+++ b/example/scalalib/web/6-webapp-scalajs-shared/build.mill
@@ -22,7 +22,7 @@ object `package` extends AppScalaModule {
   }
 
   object test extends ScalaTests with TestModule.Utest {
-    def utestVersion = "0.8.5"
+    def utestVersion = "0.8.7"
     def mvnDeps = Seq(
       mvn"com.lihaoyi::requests::0.6.9"
     )

--- a/example/scalalib/web/7-cross-version-platform-publishing/build.mill
+++ b/example/scalalib/web/7-cross-version-platform-publishing/build.mill
@@ -24,7 +24,7 @@ trait FooModule extends Cross.Module[String] {
   }
 
   trait SharedJS extends Shared with ScalaJSModule {
-    def scalaJSVersion = "1.16.0"
+    def scalaJSVersion = "1.19.0"
   }
 
   object bar extends Module {

--- a/example/scalalib/web/7-cross-version-platform-publishing/build.mill
+++ b/example/scalalib/web/7-cross-version-platform-publishing/build.mill
@@ -39,7 +39,7 @@ trait FooModule extends Cross.Module[String] {
   object qux extends Module {
     object jvm extends Shared {
       def moduleDeps = Seq(bar.jvm)
-      def mvnDeps = super.mvnDeps() ++ Seq(mvn"com.lihaoyi::upickle::3.0.0")
+      def mvnDeps = super.mvnDeps() ++ Seq(mvn"com.lihaoyi::upickle::4.1.0")
 
       object test extends ScalaTests with FooTestModule
     }

--- a/example/scalalib/web/7-cross-version-platform-publishing/build.mill
+++ b/example/scalalib/web/7-cross-version-platform-publishing/build.mill
@@ -20,7 +20,7 @@ trait FooModule extends Cross.Module[String] {
   }
 
   trait FooTestModule extends TestModule.Utest {
-    def utestVersion = "0.8.5"
+    def utestVersion = "0.8.7"
   }
 
   trait SharedJS extends Shared with ScalaJSModule {

--- a/example/scalalib/web/8-cross-platform-version-publishing/build.mill
+++ b/example/scalalib/web/8-cross-platform-version-publishing/build.mill
@@ -42,7 +42,7 @@ object qux extends Module {
   object jvm extends Cross[JvmModule](scalaVersions)
   trait JvmModule extends Shared {
     def moduleDeps = Seq(bar.jvm())
-    def mvnDeps = super.mvnDeps() ++ Seq(mvn"com.lihaoyi::upickle::3.0.0")
+    def mvnDeps = super.mvnDeps() ++ Seq(mvn"com.lihaoyi::upickle::4.1.0")
 
     object test extends ScalaTests with SharedTestModule
   }

--- a/example/scalalib/web/8-cross-platform-version-publishing/build.mill
+++ b/example/scalalib/web/8-cross-platform-version-publishing/build.mill
@@ -17,7 +17,7 @@ trait Shared extends CrossScalaModule with PlatformScalaModule with PublishModul
 }
 
 trait SharedTestModule extends TestModule.Utest {
-  def utestVersion = "0.8.5"
+  def utestVersion = "0.8.7"
 }
 
 trait SharedJS extends Shared with ScalaJSModule {

--- a/example/scalalib/web/8-cross-platform-version-publishing/build.mill
+++ b/example/scalalib/web/8-cross-platform-version-publishing/build.mill
@@ -21,7 +21,7 @@ trait SharedTestModule extends TestModule.Utest {
 }
 
 trait SharedJS extends Shared with ScalaJSModule {
-  def scalaJSVersion = "1.16.0"
+  def scalaJSVersion = "1.19.0"
 }
 
 val scalaVersions = Seq("2.13.14", "3.3.3")

--- a/example/scalalib/web/9-wasm/build.mill
+++ b/example/scalalib/web/9-wasm/build.mill
@@ -3,7 +3,7 @@ import mill._, scalalib._, scalajslib._
 import mill.scalajslib.api._
 
 object wasm extends ScalaJSModule {
-  override def scalaVersion = "2.13.14"
+  override def scalaVersion = "3.7.1"
 
   override def scalaJSVersion = "1.17.0"
 

--- a/example/scalalib/web/9-wasm/build.mill
+++ b/example/scalalib/web/9-wasm/build.mill
@@ -5,7 +5,7 @@ import mill.scalajslib.api._
 object wasm extends ScalaJSModule {
   override def scalaVersion = "3.7.1"
 
-  override def scalaJSVersion = "1.17.0"
+  override def scalaJSVersion = "1.19.0"
 
   override def moduleKind = ModuleKind.ESModule
 


### PR DESCRIPTION
Since Mill is on Scala 3, it's time for the examples to be Scala 3 as well. Also bumped library versions in the examples

Left a few on Scala 2 where the upgrade was a bit fiddly (e.g. dealing with fatal warnings, compiler plugins, etc.)