### PR TITLE
Stableize various modules

### DIFF
--- a/libs/kotlinlib/package.mill
+++ b/libs/kotlinlib/package.mill
@@ -8,7 +8,7 @@ import millbuild.*
 
 // TODO change MillPublishScalaModule to MillStableScalaModule after mill version with kotlinlib is released,
 //  because currently there is no previous artifact version
-object `package` extends MillPublishScalaModule with BuildInfo {
+object `package` extends MillStableScalaModule with BuildInfo {
 
   def moduleDeps = Seq(build.libs.scalalib, build.libs.testrunner, api)
   def transitiveLocalTestOverrides =

--- a/libs/scalajslib/package.mill
+++ b/libs/scalajslib/package.mill
@@ -39,7 +39,7 @@ object `package` extends MillStableScalaModule with BuildInfo {
     )
   }
 
-  object api extends MillPublishScalaModule {
+  object api extends MillStableScalaModule {
     def mvnDeps = Seq(Deps.sbtTestInterface)
   }
 

--- a/libs/scalanativelib/package.mill
+++ b/libs/scalanativelib/package.mill
@@ -10,7 +10,7 @@ object `package` extends MillStableScalaModule {
   def transitiveLocalTestOverrides =
     super.transitiveLocalTestOverrides() ++ Seq(worker("0.5").localTestOverride())
 
-  object api extends MillPublishScalaModule {
+  object api extends MillStableScalaModule {
     def mvnDeps = Seq(Deps.sbtTestInterface)
   }
 

--- a/libs/tabcomplete/package.mill
+++ b/libs/tabcomplete/package.mill
@@ -7,6 +7,6 @@ import millbuild.*
  * Scala logic for tab-completion in Bash and Zsh, delegated to by the `complete.sh`
  * script that runs in both shells
  */
-object `package` extends MillStableScalaModule {
+object `package` extends MillPublishScalaModule {
   def moduleDeps = Seq(build.core.define, build.libs.main)
 }

--- a/libs/vcs/package.mill
+++ b/libs/vcs/package.mill
@@ -2,6 +2,6 @@ package build.libs.vcs
 import mill._
 import millbuild.*
 
-object `package` extends MillPublishScalaModule {
+object `package` extends MillStableScalaModule {
   def moduleDeps = Seq(build.core.define)
 }


### PR DESCRIPTION
- `mill.vcs` needs to be stable
- `mill.tabcomplete` does not need to be stable
- `mill.scalanativelib`, `mill.scalajslib`, `mill.kotlinlib` can probably be stable by now
