### PR TITLE
Repro uTest Line Number Bug

### DIFF
--- a/libs/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
@@ -212,7 +212,7 @@ object HelloWorldTests extends TestSuite {
         // Make sure we *do* end up compiling the compiler bridge, since it's
         // *not* using a pre-compiled bridge value
         assert(os.exists(
-          eval.outPath / "mill/scalalib/JvmWorkerModule/worker.dest" / s"zinc-${zincVersion}"
+          eval.outPath / "mill/scallib/JvmWorkerModule/worker.dest" / s"zinc-${zincVersion}"
         ))
       }
 

--- a/mill-build/src/millbuild/Deps.scala
+++ b/mill-build/src/millbuild/Deps.scala
@@ -272,7 +272,7 @@ object Deps {
     // tests framework (test)
     val scalaCheck = mvn"org.scalacheck::scalacheck:1.18.1"
     val scalaTest = mvn"org.scalatest::scalatest:3.2.19"
-    val utest = mvn"com.lihaoyi::utest:0.8.5"
+    val utest = mvn"com.lihaoyi::utest:0.8.7"
     val zioTest = mvn"dev.zio::zio-test:2.1.14"
   }
 


### PR DESCRIPTION
@pawelsadlo I'm still seeing https://github.com/com-lihaoyi/utest/issues/354 in the Mill repo in this case, even after pulling in  https://github.com/com-lihaoyi/utest/pull/380 which contains your fix. Could you help take a look and see whether we missed a case?

The problem can be reproduced on this PR with

```
> ./mill -w libs.scalalib.test mill.scalalib.HelloWorldTests.compile.nonPreCompiledBridge
[1199] X mill.scalalib.HelloWorldTests.compile.nonPreCompiledBridge 8395ms 
[1199]   utest.AssertionError: os.exists(
[1199]             eval.outPath / "mill/scallib/JvmWorkerModule/worker.dest" / s"zinc-${zincVersion}"
[1199]           )
[1199]   eval: mill.testkit.UnitTester = mill.testkit.UnitTester@5f432f8b
[1199]   mill.scalalib.HelloWorldTests.zincVersion: String = 1.10.8
[1199]     utest.asserts.Asserts$.assertImpl(Asserts.scala:30)
[1199]     mill.scalalib.HelloWorldTests$.tests$$anonfun$1$$anonfun$3$$anonfun$2$$anonfun$1(HelloWorldTests.scala:120)
[1199]     mill.testkit.UnitTester.scoped$$anonfun$1(UnitTester.scala:227)
[1199]     scala.util.DynamicVariable.withValue(DynamicVariable.scala:59)
[1199]     mill.testkit.UnitTester.scoped(UnitTester.scala:228)
[1199]     mill.scalalib.HelloWorldTests$.tests$$anonfun$1$$anonfun$3$$anonfun$2(HelloWorldTests.scala:191)
```

Where the `HelloWorldTests.scala:120` should be `HelloWorldTests.scala:215` given the position of the failure