### PR TITLE
Use `import foo.*` rather than `foo._` in examples and docs

### DIFF
--- a/example/androidlib/java/1-hello-world/build.mill
+++ b/example/androidlib/java/1-hello-world/build.mill
@@ -9,7 +9,7 @@
 //// SNIPPET:BUILD
 package build
 
-import mill._, androidlib._, scalalib._
+import mill.*, androidlib.*, scalalib.*
 
 // Create and configure an Android SDK module to manage Android SDK paths and tools.
 object androidSdkModule0 extends AndroidSdkModule {

--- a/example/androidlib/java/2-app-bundle/build.mill
+++ b/example/androidlib/java/2-app-bundle/build.mill
@@ -7,7 +7,7 @@
 //// SNIPPET:BUILD
 package build
 
-import mill._, androidlib._
+import mill.*, androidlib.*
 
 object androidSdkModule0 extends AndroidSdkModule {
   def buildToolsVersion = "35.0.0"

--- a/example/androidlib/java/3-linting/build.mill
+++ b/example/androidlib/java/3-linting/build.mill
@@ -10,7 +10,7 @@
 //// SNIPPET:BUILD
 package build
 
-import mill._, androidlib._
+import mill.*, androidlib.*
 
 // Create and configure an Android SDK module to manage Android SDK paths and tools.
 object androidSdkModule0 extends AndroidSdkModule {

--- a/example/androidlib/java/4-sum-lib-java/build.mill
+++ b/example/androidlib/java/4-sum-lib-java/build.mill
@@ -11,11 +11,11 @@
 //// SNIPPET:BUILD
 package build
 
-import mill._, androidlib._, scalalib._
+import mill.*, androidlib.*, scalalib.*
 
 import coursier.maven.MavenRepository
 
-import publish._
+import publish.*
 
 // Create and configure an Android SDK module to manage Android SDK paths and tools.
 object androidSdkModule0 extends AndroidSdkModule {

--- a/example/androidlib/java/5-R8/build.mill
+++ b/example/androidlib/java/5-R8/build.mill
@@ -18,7 +18,7 @@
 // https://www.guardsquare.com/manual/configuration/usage
 package build
 
-import mill._, androidlib._, scalalib._
+import mill.*, androidlib.*, scalalib.*
 
 object androidSdkModule0 extends AndroidSdkModule { // <1>
   def buildToolsVersion = "35.0.0"

--- a/example/androidlib/java/6-native-libs/build.mill
+++ b/example/androidlib/java/6-native-libs/build.mill
@@ -10,7 +10,7 @@
 
 package build
 
-import mill._, androidlib._, scalalib._
+import mill.*, androidlib.*, scalalib.*
 import mill.api.BuildCtx
 
 object androidSdkModule0 extends AndroidSdkModule {

--- a/example/androidlib/kotlin/1-hello-kotlin/build.mill
+++ b/example/androidlib/kotlin/1-hello-kotlin/build.mill
@@ -9,7 +9,7 @@
 //// SNIPPET:BUILD
 package build
 
-import mill._, androidlib._, kotlinlib._, scalalib._
+import mill.*, androidlib.*, kotlinlib.*, scalalib.*
 
 import coursier.maven.MavenRepository
 

--- a/example/androidlib/kotlin/2-compose/build.mill
+++ b/example/androidlib/kotlin/2-compose/build.mill
@@ -9,7 +9,7 @@
 //// SNIPPET:BUILD
 package build
 
-import mill._, androidlib._, kotlinlib._
+import mill.*, androidlib.*, kotlinlib.*
 
 import coursier.core.{MinimizedExclusions, ModuleName, Organization}
 import coursier.params.ResolutionParams

--- a/example/androidlib/kotlin/3-compose-screenshot-tests/build.mill
+++ b/example/androidlib/kotlin/3-compose-screenshot-tests/build.mill
@@ -9,7 +9,7 @@
 //// SNIPPET:BUILD
 package build
 
-import mill._, androidlib._, kotlinlib._
+import mill.*, androidlib.*, kotlinlib.*
 
 import coursier.core.{MinimizedExclusions, ModuleName, Organization}
 import coursier.params.ResolutionParams

--- a/example/androidlib/kotlin/4-sum-lib-kotlin/build.mill
+++ b/example/androidlib/kotlin/4-sum-lib-kotlin/build.mill
@@ -11,10 +11,10 @@
 //// SNIPPET:BUILD
 package build
 
-import mill._, androidlib._, kotlinlib._
+import mill.*, androidlib.*, kotlinlib.*
 
 import coursier.maven.MavenRepository
-import publish._
+import publish.*
 
 // Create and configure an Android SDK module to manage Android SDK paths and tools.
 object androidSdkModule0 extends AndroidSdkModule {

--- a/example/cli/builtins/1-builtin-commands/build.mill
+++ b/example/cli/builtins/1-builtin-commands/build.mill
@@ -10,7 +10,7 @@
 // The following examples will be assuming the `build.mill` file given below:
 
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 trait MyModule extends JavaModule {
   object test extends JavaTests with TestModule.Junit4

--- a/example/depth/javahome/1-custom-jvms/build.mill
+++ b/example/depth/javahome/1-custom-jvms/build.mill
@@ -12,7 +12,7 @@
 //
 // To see what Jvms are available for download look at the index for your os
 // and architecture {link-jvm-indices}[here].
-import mill._, javalib._
+import mill.*, javalib.*
 import mill.api.ModuleRef
 
 object foo extends JavaModule {
@@ -51,7 +51,7 @@ Test foo.FooTest.testSimple finished...
 // although that might mean the JVM version is no longer stable and might change over
 // time as new releases are published:
 
-import scalalib._
+import scalalib.*
 
 object bar extends ScalaModule {
   def scalaVersion = "2.13.12"
@@ -74,7 +74,7 @@ Bar running on Java 23.0.1
 // Linux/X64, but you may have additional cases if you need to support Windows or other
 // OS/CPU combinations
 
-import kotlinlib._
+import kotlinlib.*
 
 object qux extends KotlinModule {
   def kotlinVersion = "2.0.20"

--- a/example/depth/sandbox/1-task/build.mill
+++ b/example/depth/sandbox/1-task/build.mill
@@ -12,7 +12,7 @@
 // each task is lazily initialized when `Task.dest` is referenced and used:
 
 package build
-import mill._
+import mill.*
 import mill.api.BuildCtx
 
 object foo extends Module {

--- a/example/depth/sandbox/2-test/build.mill
+++ b/example/depth/sandbox/2-test/build.mill
@@ -3,7 +3,7 @@
 // `foo.test` and `bar.test`:
 
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 trait MyModule extends JavaModule {
   object test extends JavaTests with TestModule.Junit4

--- a/example/extending/imports/1-mvn-deps/build.mill
+++ b/example/extending/imports/1-mvn-deps/build.mill
@@ -5,7 +5,7 @@
 // in your resource path for your application to use.
 
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 import org.thymeleaf.TemplateEngine
 import org.thymeleaf.context.Context
 

--- a/example/extending/imports/2-mvn-deps-scala/build.mill
+++ b/example/extending/imports/2-mvn-deps-scala/build.mill
@@ -5,8 +5,8 @@
 // a HTML generation library that does the string concatenation/construction internally
 // and also escapes the input strings on your behalf:
 
-import mill._, scalalib._
-import scalatags.Text.all._
+import mill.*, scalalib.*
+import scalatags.Text.all.*
 
 object bar extends ScalaModule {
   def scalaVersion = "2.13.16"

--- a/example/extending/imports/3-contrib-dep/build.mill
+++ b/example/extending/imports/3-contrib-dep/build.mill
@@ -1,7 +1,7 @@
 //| mvnDeps: ["com.lihaoyi::mill-contrib-buildinfo:$MILL_VERSION"]
 
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 import mill.contrib.buildinfo.BuildInfo
 
 object foo extends ScalaModule with BuildInfo {

--- a/example/extending/jvmcode/1-subprocess/build.mill
+++ b/example/extending/jvmcode/1-subprocess/build.mill
@@ -14,7 +14,7 @@
 // idiosyncracies (e.g. classpaths) that Mill provides helper methods specifically for them.
 
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 import mill.util.Jvm
 
 object foo extends JavaModule {

--- a/example/extending/jvmcode/2-classloader/build.mill
+++ b/example/extending/jvmcode/2-classloader/build.mill
@@ -6,7 +6,7 @@
 // * `loadClass`/`getMethod`/`invoke` to call methods on those classes using Java reflection
 
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 import mill.util.Jvm
 
 object foo extends JavaModule {

--- a/example/extending/jvmcode/3-worker/build.mill
+++ b/example/extending/jvmcode/3-worker/build.mill
@@ -10,7 +10,7 @@
 // load the Groovy interpreter classpath files:
 
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 import mill.util.Jvm
 
 object coursierModule extends CoursierModule

--- a/example/extending/jvmcode/4-module-classloader/build.mill
+++ b/example/extending/jvmcode/4-module-classloader/build.mill
@@ -4,7 +4,7 @@
 // serves as a code-generated to generated the `sources` of the `foo` module:
 
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 import mill.util.Jvm
 
 object foo extends JavaModule {

--- a/example/extending/jvmcode/5-module-run-task/build.mill
+++ b/example/extending/jvmcode/5-module-run-task/build.mill
@@ -3,7 +3,7 @@
 // within the `bar` module as `bar/src/Bar.scala`.
 
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 import mill.util.Jvm
 
 object foo extends ScalaModule {

--- a/example/extending/jvmcode/6-module-cached-classloader/build.mill
+++ b/example/extending/jvmcode/6-module-cached-classloader/build.mill
@@ -13,7 +13,7 @@
 // cached/re-used where possible, and torn down properly when no longer necessary.
 
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 import mill.util.Jvm
 import mill.util.CachedFactory
 import java.net.{URL, URLClassLoader}

--- a/example/extending/metabuild/3-autoformatting/build.mill
+++ b/example/extending/metabuild/3-autoformatting/build.mill
@@ -3,7 +3,7 @@
 // You only need a `.scalafmt.conf` config file which at least needs configure the Scalafmt version.
 
 package build
-import mill._
+import mill.*
 
 object foo extends Module { def task = Task { "2.13.4" } }
 

--- a/example/extending/metabuild/4-meta-build/build.mill
+++ b/example/extending/metabuild/4-meta-build/build.mill
@@ -1,7 +1,7 @@
 package build
 
-import mill._, scalalib._
-import scalatags.Text.all._
+import mill.*, scalalib.*
+import scalatags.Text.all.*
 
 object `package` extends ScalaModule {
   def scalaVersion = "2.13.4"
@@ -21,7 +21,7 @@ object `package` extends ScalaModule {
 // file and it's `import $file` and `$ivy` are a shorthand syntax for defining
 // a Mill `ScalaModule`, with sources and `mvnDeps` and so on, which is
 // compiled and executed to perform your build. This "meta-build" module lives in
-// `mill-build/`, and can be enabled via the `import $meta._` statement above.
+// `mill-build/`, and can be enabled via the `import $meta.*` statement above.
 
 /** See Also: mill-build/build.mill */
 /** See Also: src/Foo.scala */
@@ -59,7 +59,7 @@ Run-time HTML snippet: <p>world</p>
 // This example is trivial, but in larger builds there may be much more scenarios
 // where you may want to keep the libraries used in your `build.mill` and the libraries
 // used in your application code consistent. With the `mill-build/build.mill` configuration
-// enabled by `import $meta._`, this becomes possible.
+// enabled by `import $meta.*`, this becomes possible.
 //
 // You can customize the `mill-build/` module with more flexibility than is
 // provided by `//| mvnDeps` or `import $file`, overriding any tasks that are

--- a/example/extending/metabuild/4-meta-build/mill-build/build.mill
+++ b/example/extending/metabuild/4-meta-build/mill-build/build.mill
@@ -1,6 +1,6 @@
 package build
 
-import mill._, scalalib._
+import mill.*, scalalib.*
 import mill.meta.MillBuildRootModule
 
 object `package` extends MillBuildRootModule {

--- a/example/extending/metabuild/4-meta-build/src/Foo.scala
+++ b/example/extending/metabuild/4-meta-build/src/Foo.scala
@@ -1,5 +1,5 @@
 package foo
-import scalatags.Text.all._
+import scalatags.Text.all.*
 object Foo {
   def main(args: Array[String]): Unit = {
     println("Build-time HTML snippet: " + os.read(os.resource / "snippet.txt"))

--- a/example/extending/metabuild/5-meta-shared-sources/build.mill
+++ b/example/extending/metabuild/5-meta-shared-sources/build.mill
@@ -1,6 +1,6 @@
 package build
 
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 object `package` extends ScalaModule {
   def scalaVersion = millbuild.ScalaVersion.myScalaVersion

--- a/example/extending/metabuild/5-meta-shared-sources/mill-build/build.mill
+++ b/example/extending/metabuild/5-meta-shared-sources/mill-build/build.mill
@@ -1,6 +1,6 @@
 package build
 
-import mill._
+import mill.*
 import mill.meta.MillBuildRootModule
 
 object `package` extends MillBuildRootModule

--- a/example/extending/plugins/7-writing-mill-plugins/build.mill
+++ b/example/extending/plugins/7-writing-mill-plugins/build.mill
@@ -4,7 +4,7 @@
 
 // == Project Configuration
 package build
-import mill._, scalalib._, publish._
+import mill.*, scalalib.*, publish.*
 import mill.util.BuildInfo.{millVersion, millBinPlatform}
 
 object myplugin extends ScalaModule with PublishModule {

--- a/example/extending/plugins/7-writing-mill-plugins/myplugin/integration/resources/example-test-project/build.mill
+++ b/example/extending/plugins/7-writing-mill-plugins/myplugin/integration/resources/example-test-project/build.mill
@@ -2,7 +2,7 @@
 //| - com.lihaoyi::myplugin::0.0.1
 package build
 
-import mill._, myplugin._
+import mill.*, myplugin.*
 
 object `package` extends LineCountJavaModule {
   def lineCountResourceFileName = "line-count.txt"

--- a/example/extending/plugins/7-writing-mill-plugins/myplugin/integration/resources/integration-test-project/build.mill
+++ b/example/extending/plugins/7-writing-mill-plugins/myplugin/integration/resources/integration-test-project/build.mill
@@ -2,7 +2,7 @@
 //| - com.lihaoyi::myplugin::0.0.1
 package build
 
-import mill._, myplugin._
+import mill.*, myplugin.*
 
 object `package` extends LineCountJavaModule {
   def lineCountResourceFileName = "line-count.txt"

--- a/example/extending/plugins/7-writing-mill-plugins/myplugin/integration/src/mill/testkit/ExampleTests.scala
+++ b/example/extending/plugins/7-writing-mill-plugins/myplugin/integration/src/mill/testkit/ExampleTests.scala
@@ -1,6 +1,6 @@
 package myplugin
 import mill.testkit.ExampleTester
-import utest._
+import utest.*
 
 object ExampleTests extends TestSuite {
 

--- a/example/extending/plugins/7-writing-mill-plugins/myplugin/integration/src/mill/testkit/IntegrationTests.scala
+++ b/example/extending/plugins/7-writing-mill-plugins/myplugin/integration/src/mill/testkit/IntegrationTests.scala
@@ -1,6 +1,6 @@
 package myplugin
 import mill.testkit.IntegrationTester
-import utest._
+import utest.*
 
 object IntegrationTests extends TestSuite {
 

--- a/example/extending/plugins/7-writing-mill-plugins/myplugin/src/LineCountJavaModule.scala
+++ b/example/extending/plugins/7-writing-mill-plugins/myplugin/src/LineCountJavaModule.scala
@@ -1,5 +1,5 @@
 package myplugin
-import mill._
+import mill.*
 
 /**
  * Example Mill plugin trait that adds a `line-count.txt`

--- a/example/extending/plugins/7-writing-mill-plugins/myplugin/test/src/mill/testkit/UnitTests.scala
+++ b/example/extending/plugins/7-writing-mill-plugins/myplugin/test/src/mill/testkit/UnitTests.scala
@@ -3,8 +3,8 @@ package myplugin
 import mill.testkit.{TestRootModule, UnitTester}
 import mill.api.Discover
 import mill.PathRef
-import mill.util.TokenReaders._
-import utest._
+import mill.util.TokenReaders.*
+import utest.*
 
 object UnitTests extends TestSuite {
   def tests: Tests = Tests {

--- a/example/extending/python/1-hello-python/build.mill
+++ b/example/extending/python/1-hello-python/build.mill
@@ -4,7 +4,7 @@
 // type hints, helping to catch errors in development.
 
 package build
-import mill._
+import mill.*
 
 def pythonExe: T[PathRef] = Task {
 

--- a/example/extending/python/2-python-modules/build.mill
+++ b/example/extending/python/2-python-modules/build.mill
@@ -4,7 +4,7 @@
 // that can be re-used.
 
 package build
-import mill._
+import mill.*
 
 trait PythonModule extends Module {
 

--- a/example/extending/python/3-python-module-deps/build.mill
+++ b/example/extending/python/3-python-module-deps/build.mill
@@ -6,7 +6,7 @@
 // make them available during `typeCheck` and `run`:
 
 package build
-import mill._
+import mill.*
 
 trait PythonModule extends Module {
 

--- a/example/extending/python/4-python-libs-bundle/build.mill
+++ b/example/extending/python/4-python-libs-bundle/build.mill
@@ -6,7 +6,7 @@
 //   making deployment easier.
 
 package build
-import mill._
+import mill.*
 import mill.api.BuildCtx
 
 trait PythonModule extends Module {

--- a/example/extending/typescript/1-hello-typescript/build.mill
+++ b/example/extending/typescript/1-hello-typescript/build.mill
@@ -10,7 +10,7 @@
 // library necessary for accessing Node.js APIs:
 
 package build
-import mill._
+import mill.*
 
 def npmInstall = Task {
   os.call(("npm", "install", "--save-dev", "typescript@5.6.3", "@types/node@22.7.8"))

--- a/example/extending/typescript/2-typescript-modules/build.mill
+++ b/example/extending/typescript/2-typescript-modules/build.mill
@@ -5,7 +5,7 @@
 // `trait TypeScriptModule extends Module` wrapper:
 
 package build
-import mill._
+import mill.*
 
 trait TypeScriptModule extends Module {
   def npmInstall = Task {

--- a/example/extending/typescript/3-module-deps/build.mill
+++ b/example/extending/typescript/3-module-deps/build.mill
@@ -12,7 +12,7 @@
 //    use in `compile`, and `compiledJavascript` for use in `run`
 
 package build
-import mill._
+import mill.*
 
 trait TypeScriptModule extends Module {
   def moduleDeps: Seq[TypeScriptModule] = Nil

--- a/example/extending/typescript/4-npm-deps-bundle/build.mill
+++ b/example/extending/typescript/4-npm-deps-bundle/build.mill
@@ -15,7 +15,7 @@
 //    into a `def prepareRun` task.
 
 package build
-import mill._
+import mill.*
 
 trait TypeScriptModule extends Module {
   def moduleDeps: Seq[TypeScriptModule] = Nil

--- a/example/fundamentals/cross/1-simple/build.mill
+++ b/example/fundamentals/cross/1-simple/build.mill
@@ -1,6 +1,6 @@
 // Mill handles cross-building of all sorts via the `Cross[T]` module.
 package build
-import mill._
+import mill.*
 
 object foo extends Cross[FooModule]("2.10", "2.11", "2.12")
 trait FooModule extends Cross.Module[String] {

--- a/example/fundamentals/cross/10-static-blog/build.mill
+++ b/example/fundamentals/cross/10-static-blog/build.mill
@@ -8,7 +8,7 @@
 // HTML generation respectively:
 package build
 
-import scalatags.Text.all._
+import scalatags.Text.all.*
 import org.commonmark.parser.Parser
 import org.commonmark.renderer.html.HtmlRenderer
 import mill.api.BuildCtx
@@ -19,7 +19,7 @@ import mill.api.BuildCtx
 // and a `render` task that parses the file's markdown and generates a HTML
 // output file
 
-import mill._
+import mill.*
 
 def mdNameToHtml(s: String) = s.toLowerCase.replace(".md", ".html")
 def mdNameToTitle(s: String) =

--- a/example/fundamentals/cross/11-default-cross-module/build.mill
+++ b/example/fundamentals/cross/11-default-cross-module/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._
+import mill.*
 
 object foo extends Cross[FooModule]("2.10", "2.11", "2.12")
 

--- a/example/fundamentals/cross/2-cross-source-path/build.mill
+++ b/example/fundamentals/cross/2-cross-source-path/build.mill
@@ -1,7 +1,7 @@
 // If you want to have dedicated ``moduleDir``s, you can add the cross
 // parameters to it as follows:
 package build
-import mill._
+import mill.*
 
 object foo extends Cross[FooModule]("2.10", "2.11", "2.12")
 trait FooModule extends Cross.Module[String] {

--- a/example/fundamentals/cross/3-outside-dependency/build.mill
+++ b/example/fundamentals/cross/3-outside-dependency/build.mill
@@ -2,7 +2,7 @@
 // as given below:
 
 package build
-import mill._
+import mill.*
 
 object foo extends Cross[FooModule]("2.10", "2.11", "2.12")
 trait FooModule extends Cross.Module[String] {

--- a/example/fundamentals/cross/4-cross-dependencies/build.mill
+++ b/example/fundamentals/cross/4-cross-dependencies/build.mill
@@ -1,7 +1,7 @@
 // Tasks in cross-modules can use one another the same way they are used from
 // external tasks:
 package build
-import mill._
+import mill.*
 
 object foo extends mill.Cross[FooModule]("2.10", "2.11", "2.12")
 trait FooModule extends Cross.Module[String] {

--- a/example/fundamentals/cross/5-multiple-cross-axes/build.mill
+++ b/example/fundamentals/cross/5-multiple-cross-axes/build.mill
@@ -1,7 +1,7 @@
 // You can have a cross-module with multiple inputs using the `Cross.Module2`
 // trait:
 package build
-import mill._
+import mill.*
 
 val crossMatrix = for {
   crossVersion <- Seq("2.10", "2.11", "2.12")

--- a/example/fundamentals/cross/6-axes-extension/build.mill
+++ b/example/fundamentals/cross/6-axes-extension/build.mill
@@ -1,7 +1,7 @@
 // You can also take an existing cross module and extend it with additional cross
 // axes as shown:
 package build
-import mill._
+import mill.*
 
 object foo extends Cross[FooModule]("a", "b")
 trait FooModule extends Cross.Module[String] {

--- a/example/fundamentals/cross/7-inner-cross-module/build.mill
+++ b/example/fundamentals/cross/7-inner-cross-module/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._
+import mill.*
 
 trait MyModule extends Module {
   def crossValue: String

--- a/example/fundamentals/cross/8-resolvers/build.mill
+++ b/example/fundamentals/cross/8-resolvers/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._
+import mill.*
 
 trait MyModule extends Cross.Module[String] {
   implicit object resolver extends mill.api.Cross.Resolver[MyModule] {

--- a/example/fundamentals/cross/9-dynamic-cross-modules/build.mill
+++ b/example/fundamentals/cross/9-dynamic-cross-modules/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 import mill.api.BuildCtx
 
 val moduleNames = BuildCtx.watchValue(os.list(moduleDir / "modules").map(_.last))

--- a/example/fundamentals/dependencies/1-external-bom/build.mill
+++ b/example/fundamentals/dependencies/1-external-bom/build.mill
@@ -2,7 +2,7 @@
 
 //// SNIPPET:BUILD1
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 object foo extends JavaModule {
   def bomMvnDeps = Seq(

--- a/example/fundamentals/dependencies/2-managed/build.mill
+++ b/example/fundamentals/dependencies/2-managed/build.mill
@@ -2,7 +2,7 @@
 
 //// SNIPPET:BUILD1
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 object foo extends JavaModule {
   def depManagement = Seq(

--- a/example/fundamentals/dependencies/3-search-updates/build.mill
+++ b/example/fundamentals/dependencies/3-search-updates/build.mill
@@ -5,7 +5,7 @@
 // build:
 
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 trait MyModule extends ScalaModule {
   def scalaVersion = "2.13.11"

--- a/example/fundamentals/libraries/1-oslib/build.mill
+++ b/example/fundamentals/libraries/1-oslib/build.mill
@@ -7,7 +7,7 @@
 // as part of its xref:depth/sandboxing.adoc[] efforts to prevent accidental
 // interference between tasks:
 
-import mill._
+import mill.*
 
 def task1 = Task {
   os.write(os.pwd / "file.txt", "hello")

--- a/example/fundamentals/libraries/2-upickle/build.mill
+++ b/example/fundamentals/libraries/2-upickle/build.mill
@@ -17,7 +17,7 @@
 // Most Scala primitive types (``String``s, ``Int``s, ``Boolean``s, etc.) and
 // collections types (``Seq``s, ``List``s, ``Tuple``s, etc.) are serializable by default.
 
-import mill._
+import mill.*
 
 def taskInt = Task { 123 }
 def taskBoolean = Task { true }

--- a/example/fundamentals/libraries/3-requests/build.mill
+++ b/example/fundamentals/libraries/3-requests/build.mill
@@ -13,7 +13,7 @@
 // https://github.com/bazelbuild/bazel[Bazel Build Tool] binary, and use Bazel to
 // compile the Remote APIs source code as part of our build:
 
-import mill._
+import mill.*
 
 def remoteApisZip = Task {
   println("downloading bazel-remote-apis sources...")

--- a/example/fundamentals/libraries/4-mainargs/build.mill
+++ b/example/fundamentals/libraries/4-mainargs/build.mill
@@ -1,6 +1,6 @@
 // Mill uses MainArgs to handle argument parsing for ``Task.Command``s that
 // are run from the command line.
-import mill._
+import mill.*
 
 def commandSimple(str: String, i: Int, bool: Boolean = true) = Task.Command {
   println(s"$str $i $bool")

--- a/example/fundamentals/modules/10-external-module-aliases/build.mill
+++ b/example/fundamentals/modules/10-external-module-aliases/build.mill
@@ -3,7 +3,7 @@
 // `mill.javalib.palantirformat.PalantirFormatModule` below:
 
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 object foo extends JavaModule
 

--- a/example/fundamentals/modules/11-abstract-module-ref/build.mill
+++ b/example/fundamentals/modules/11-abstract-module-ref/build.mill
@@ -6,7 +6,7 @@
 // not participate in task query resolution:
 
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 import mill.api.ModuleRef
 
 object foo extends JavaModule

--- a/example/fundamentals/modules/12-default-tasks/build.mill
+++ b/example/fundamentals/modules/12-default-tasks/build.mill
@@ -2,7 +2,7 @@
 // allows them to be run directly without needing the task name provided explicitly:
 
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 import mill.api.TaskModule
 
 object foo extends TaskModule {

--- a/example/fundamentals/modules/6-modules/build.mill
+++ b/example/fundamentals/modules/6-modules/build.mill
@@ -4,7 +4,7 @@
 // path you would use to run tasks within that module from the command line. e.g.
 // for the following `build.mill`:
 package build
-import mill._
+import mill.*
 
 object foo extends Module {
   def bar = Task { "hello" }

--- a/example/fundamentals/modules/7-root-module/build.mill
+++ b/example/fundamentals/modules/7-root-module/build.mill
@@ -2,7 +2,7 @@
 // as the root module of the file:
 
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 object `package` extends JavaModule {
   def mvnDeps = Seq(

--- a/example/fundamentals/modules/8-diy-java-modules/build.mill
+++ b/example/fundamentals/modules/8-diy-java-modules/build.mill
@@ -2,7 +2,7 @@
 // so far into a worked example: implementing our own minimal version of
 // `mill.scalalib.JavaModule` from first principles.
 package build
-import mill._
+import mill.*
 
 trait DiyJavaModule extends Module {
   def moduleDeps: Seq[DiyJavaModule] = Nil

--- a/example/fundamentals/modules/9-backticked-names/build.mill
+++ b/example/fundamentals/modules/9-backticked-names/build.mill
@@ -1,6 +1,6 @@
 package build
-import mill._
-import mill.scalalib._
+import mill.*
+import mill.scalalib.*
 
 object `hyphenated-module` extends Module {
   def `hyphenated-task` = Task {

--- a/example/fundamentals/out-dir/1-out-files/build.mill
+++ b/example/fundamentals/out-dir/1-out-files/build.mill
@@ -8,7 +8,7 @@
 // For the purposes of this page, we will be using the following minimal Mill build
 
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 object foo extends JavaModule {}
 

--- a/example/fundamentals/out-dir/2-custom-out/build.mill
+++ b/example/fundamentals/out-dir/2-custom-out/build.mill
@@ -5,7 +5,7 @@
 
 package build
 
-import mill._
+import mill.*
 
 object foo extends Module {
   def printDest = Task {

--- a/example/fundamentals/tasks/1-task-graph/build.mill
+++ b/example/fundamentals/tasks/1-task-graph/build.mill
@@ -2,7 +2,7 @@
 // making use of the most common `Task.Source`, `Task`, and `Task.Command` types
 // to define a simple build graph with some input source files and intermediate build steps:
 package build
-import mill._
+import mill.*
 
 def mainClass: T[Option[String]] = Some("foo.Foo")
 

--- a/example/fundamentals/tasks/3-anonymous-tasks/build.mill
+++ b/example/fundamentals/tasks/3-anonymous-tasks/build.mill
@@ -3,7 +3,7 @@
 // find yourself repeating in ``Task``s and ``Command``s.
 
 package build
-import mill._
+import mill.*
 
 def data = Task.Source("data")
 

--- a/example/fundamentals/tasks/4-inputs/build.mill
+++ b/example/fundamentals/tasks/4-inputs/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._
+import mill.*
 import mill.api.BuildCtx
 
 def myInput = Task.Input {

--- a/example/fundamentals/tasks/5-persistent-tasks/build.mill
+++ b/example/fundamentals/tasks/5-persistent-tasks/build.mill
@@ -12,7 +12,7 @@
 // and re-use previously-compressed files if a file in the
 // input folder did not change:
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 import java.util.Arrays
 import java.io.ByteArrayOutputStream
 import java.util.zip.GZIPOutputStream

--- a/example/fundamentals/tasks/6-workers/build.mill
+++ b/example/fundamentals/tasks/6-workers/build.mill
@@ -20,7 +20,7 @@
 // without having to recompute them:
 
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 import java.util.Arrays
 import java.io.ByteArrayOutputStream
 import java.util.zip.GZIPOutputStream
@@ -140,7 +140,7 @@ Cached from disk: world.txt
 // To implement resource cleanup, your worker can implement `java.lang.AutoCloseable`.
 // Once the worker is no longer needed, Mill will call the `close()` method on it before any newer version of this worker is created.
 
-import mill._
+import mill.*
 import java.lang.AutoCloseable
 
 class MyWorker() extends AutoCloseable {
@@ -171,7 +171,7 @@ def myWorker = Task.Worker { new MyWorker() }
 // version of `CompressWorker` we saw earlier, but using `CacheFactory` to cache, reset, and
 // re-use the `ByteArrayOutputStream` between calls to `cachedCompressWorker().compress`:
 //
-import mill._
+import mill.*
 import java.lang.AutoCloseable
 import mill.util.CachedFactory
 import java.io.ByteArrayOutputStream

--- a/example/fundamentals/tasks/7-forking-futures/build.mill
+++ b/example/fundamentals/tasks/7-forking-futures/build.mill
@@ -5,7 +5,7 @@
 
 package build
 
-import mill._
+import mill.*
 
 def taskSpawningFutures = Task {
   val f1 = Task.fork.async(dest = Task.dest / "future-1", key = "1", message = "First Future") {

--- a/example/javalib/basic/1-simple/build.mill
+++ b/example/javalib/basic/1-simple/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 object foo extends JavaModule {
   def mvnDeps = Seq(

--- a/example/javalib/basic/2-custom-build-logic/build.mill
+++ b/example/javalib/basic/2-custom-build-logic/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 object foo extends JavaModule {
 

--- a/example/javalib/basic/3-multi-module/build.mill
+++ b/example/javalib/basic/3-multi-module/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 trait MyModule extends JavaModule {
   object test extends JavaTests with TestModule.Junit4

--- a/example/javalib/basic/4-compat-modules/build.mill
+++ b/example/javalib/basic/4-compat-modules/build.mill
@@ -6,7 +6,7 @@
 // Maven or Gradle build:
 
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 object foo extends MavenModule {
   object test extends MavenTests with TestModule.Junit4

--- a/example/javalib/basic/6-realistic/build.mill
+++ b/example/javalib/basic/6-realistic/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:ALL
 package build
-import mill._, javalib._, publish._
+import mill.*, javalib.*, publish.*
 
 trait MyModule extends JavaModule with PublishModule {
   def publishVersion = "0.0.1"

--- a/example/javalib/dependencies/1-mvn-deps/build.mill
+++ b/example/javalib/dependencies/1-mvn-deps/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 object `package` extends JavaModule {
   def mvnDeps = Seq(

--- a/example/javalib/dependencies/2-run-compile-deps/build.mill
+++ b/example/javalib/dependencies/2-run-compile-deps/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD1
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 object foo extends JavaModule {
   def moduleDeps = Seq(bar)

--- a/example/javalib/dependencies/3-unmanaged-jars/build.mill
+++ b/example/javalib/dependencies/3-unmanaged-jars/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 object `package` extends JavaModule {
   def lib = Task.Source("lib")

--- a/example/javalib/dependencies/4-downloading-unmanaged-jars/build.mill
+++ b/example/javalib/dependencies/4-downloading-unmanaged-jars/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 object `package` extends JavaModule {
   def unmanagedClasspath = Task {

--- a/example/javalib/dependencies/5-repository-config/build.mill
+++ b/example/javalib/dependencies/5-repository-config/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD1
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 import mill.api.ModuleRef
 
 object foo extends JavaModule {

--- a/example/javalib/linting/1-error-prone/build.mill
+++ b/example/javalib/linting/1-error-prone/build.mill
@@ -6,7 +6,7 @@
 
 package build
 
-import mill._, javalib._, errorprone._
+import mill.*, javalib.*, errorprone.*
 
 object `package` extends JavaModule with ErrorProneModule {
   def errorProneOptions = Seq("-XepAllErrorsAsWarnings")

--- a/example/javalib/linting/2-checkstyle/build.mill
+++ b/example/javalib/linting/2-checkstyle/build.mill
@@ -2,7 +2,7 @@
 // https://checkstyle.org[Checkstyle] and generates reports from these checks.
 
 package build
-import mill._, javalib._, checkstyle._
+import mill.*, javalib.*, checkstyle.*
 
 object `package` extends CheckstyleModule {
   def checkstyleVersion = "9.3"
@@ -81,9 +81,9 @@ Audit done.
 // To share `checkstyle-config.xml` across modules, adapt the following example.
 // [source,scala]
 // ----
-// import mill._
+// import mill.*
 // import mill.contrib.checkstyle.CheckstyleModule
-// import mill.scalalib._
+// import mill.scalalib.*
 //
 // object foo extends Module {
 //
@@ -138,11 +138,11 @@ Audit done.
 // For a custom setup, adapt the following example.
 // [source,scala]
 // ----
-// import mill._
+// import mill.*
 // import mill.api.PathRef
 // import mill.contrib.checkstyle.CheckstyleXsltModule
 // import mill.contrib.checkstyle.CheckstyleXsltReport
-// import mill.scalalib._
+// import mill.scalalib.*
 //
 // object foo extends JavaModule with CheckstyleXsltModule {
 //

--- a/example/javalib/linting/3-palantirformat/build.mill
+++ b/example/javalib/linting/3-palantirformat/build.mill
@@ -2,8 +2,8 @@
 // https://github.com/palantir/palantir-java-format[Palantir Java Format] project.
 package build
 
-import mill._
-import mill.javalib.palantirformat._
+import mill.*
+import mill.javalib.palantirformat.*
 
 object `package` extends PalantirFormatModule
 

--- a/example/javalib/module/1-common-config/build.mill
+++ b/example/javalib/module/1-common-config/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 object `package` extends JavaModule {
   // You can have arbitrary numbers of third-party dependencies

--- a/example/javalib/module/11-main-class/build.mill
+++ b/example/javalib/module/11-main-class/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 object `package` extends JavaModule {
   def mainClass = Some("foo.Qux")

--- a/example/javalib/module/15-jni/build.mill
+++ b/example/javalib/module/15-jni/build.mill
@@ -2,7 +2,7 @@
 // code using JNI.
 
 package build
-import mill._, javalib._, util.Jvm
+import mill.*, javalib.*, util.Jvm
 
 object `package` extends JavaModule {
   // Additional source folder to put C sources

--- a/example/javalib/module/2-custom-tasks/build.mill
+++ b/example/javalib/module/2-custom-tasks/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 object `package` extends JavaModule {
   def mvnDeps = Seq(mvn"net.sourceforge.argparse4j:argparse4j:0.9.0")

--- a/example/javalib/module/3-generated-sources/build.mill
+++ b/example/javalib/module/3-generated-sources/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD1
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 object foo extends JavaModule {
 

--- a/example/javalib/module/4-compilation-execution-flags/build.mill
+++ b/example/javalib/module/4-compilation-execution-flags/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 object `package` extends JavaModule {
   def forkArgs = Seq("-Xmx4g", "-Dmy.jvm.property=hello")

--- a/example/javalib/module/7-resources/build.mill
+++ b/example/javalib/module/7-resources/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 object foo extends JavaModule {
   object test extends JavaTests with TestModule.Junit4 {

--- a/example/javalib/module/8-annotation-processors/build.mill
+++ b/example/javalib/module/8-annotation-processors/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 import java.io.File
 
 object foo extends JavaModule {

--- a/example/javalib/module/9-docjar/build.mill
+++ b/example/javalib/module/9-docjar/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 object foo extends JavaModule {
   def javadocOptions = Seq("-quiet")

--- a/example/javalib/publishing/1-assembly-config/build.mill
+++ b/example/javalib/publishing/1-assembly-config/build.mill
@@ -1,7 +1,7 @@
 //// SNIPPET:BUILD
 package build
-import mill._, javalib._
-import mill.javalib.Assembly._
+import mill.*, javalib.*
+import mill.javalib.Assembly.*
 
 object foo extends JavaModule {
   def moduleDeps = Seq(bar)

--- a/example/javalib/publishing/2-publish-module/build.mill
+++ b/example/javalib/publishing/2-publish-module/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, javalib._, publish._
+import mill.*, javalib.*, publish.*
 
 object foo extends JavaModule with PublishModule {
   def publishVersion = "0.0.1"

--- a/example/javalib/publishing/3-revapi/build.mill
+++ b/example/javalib/publishing/3-revapi/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, javalib._, publish._, revapi._
+import mill.*, javalib.*, publish.*, revapi.*
 
 object bar extends JavaModule with RevapiModule {
   def publishVersion = "0.0.1"

--- a/example/javalib/publishing/5-jlink/build.mill
+++ b/example/javalib/publishing/5-jlink/build.mill
@@ -2,8 +2,8 @@
 // Starting with JDK 9, `jlink` bundles Java app code with a stripped-down version of the JVM.
 
 package build
-import mill._, javalib._
-import mill.javalib.Assembly._
+import mill.*, javalib.*
+import mill.javalib.Assembly.*
 import mill.scalalib.JlinkModule
 
 object foo extends JavaModule with JlinkModule {

--- a/example/javalib/publishing/6-jpackage/build.mill
+++ b/example/javalib/publishing/6-jpackage/build.mill
@@ -2,8 +2,8 @@
 // using the `jpackage` tool.
 
 package build
-import mill._, javalib._
-import mill.javalib.Assembly._
+import mill.*, javalib.*
+import mill.javalib.Assembly.*
 import mill.scalalib.JpackageModule
 
 object foo extends JavaModule with JpackageModule {

--- a/example/javalib/publishing/7-native-image/build.mill
+++ b/example/javalib/publishing/7-native-image/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 import mill.api.ModuleRef
 
 object foo extends JavaModule with NativeImageModule {

--- a/example/javalib/publishing/8-native-image-libs/build.mill
+++ b/example/javalib/publishing/8-native-image-libs/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 import mill.api.ModuleRef
 
 object foo extends JavaModule with NativeImageModule {

--- a/example/javalib/publishing/9-publish-module-sonatype/build.mill
+++ b/example/javalib/publishing/9-publish-module-sonatype/build.mill
@@ -1,7 +1,7 @@
 //// SNIPPET:BUILD
 package build
 
-import mill._, javalib._, publish._
+import mill.*, javalib.*, publish.*
 
 import mill.scalalib.SonatypeCentralPublishModule
 

--- a/example/javalib/publishing/9-repackage-config/build.mill
+++ b/example/javalib/publishing/9-repackage-config/build.mill
@@ -4,7 +4,7 @@
 
 package build
 
-import mill._, javalib._, publish._
+import mill.*, javalib.*, publish.*
 import mill.javalib.repackage.RepackageModule
 
 trait MyModule extends JavaModule with PublishModule {

--- a/example/javalib/testing/1-test-suite/build.mill
+++ b/example/javalib/testing/1-test-suite/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD1
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 object foo extends JavaModule {
   object test extends JavaTests {

--- a/example/javalib/testing/2-test-deps/build.mill
+++ b/example/javalib/testing/2-test-deps/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 object qux extends JavaModule {
   def moduleDeps = Seq(baz)

--- a/example/javalib/testing/3-integration-suite/build.mill
+++ b/example/javalib/testing/3-integration-suite/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD3
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 object qux extends JavaModule {
   object test extends JavaTests with TestModule.Junit5
   object integration extends JavaTests with TestModule.Junit5

--- a/example/javalib/testing/4-test-parallel/build.mill
+++ b/example/javalib/testing/4-test-parallel/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD1
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 object foo extends JavaModule {
   object test extends JavaTests {

--- a/example/javalib/testing/5-test-grouping/build.mill
+++ b/example/javalib/testing/5-test-grouping/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD1
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 object foo extends JavaModule {
   object test extends JavaTests {

--- a/example/javalib/testing/6-test-group-parallel/build.mill
+++ b/example/javalib/testing/6-test-group-parallel/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD1
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 object foo extends JavaModule {
   object test extends JavaTests {

--- a/example/javalib/web/1-hello-jetty/build.mill
+++ b/example/javalib/web/1-hello-jetty/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 object `package` extends JavaModule {
   def mvnDeps = Seq(

--- a/example/javalib/web/2-hello-spring-boot/build.mill
+++ b/example/javalib/web/2-hello-spring-boot/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 object `package` extends JavaModule {
   def mvnDeps = Seq(

--- a/example/javalib/web/3-todo-spring-boot/build.mill
+++ b/example/javalib/web/3-todo-spring-boot/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 object `package` extends JavaModule {
   def mvnDeps = Seq(

--- a/example/javalib/web/4-hello-micronaut/build.mill
+++ b/example/javalib/web/4-hello-micronaut/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 object `package` extends MicronautModule {
   def micronautVersion = "4.5.3"

--- a/example/javalib/web/5-todo-micronaut/build.mill
+++ b/example/javalib/web/5-todo-micronaut/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 object `package` extends MicronautModule {
   def micronautVersion = "4.4.3"

--- a/example/javascriptlib/basic/1-simple/build.mill
+++ b/example/javascriptlib/basic/1-simple/build.mill
@@ -1,6 +1,6 @@
 package build
 
-import mill._, javascriptlib._
+import mill.*, javascriptlib.*
 
 object foo extends TypeScriptModule {
   def npmDeps = Seq("immutable@4.3.7")

--- a/example/javascriptlib/basic/2-react/build.mill
+++ b/example/javascriptlib/basic/2-react/build.mill
@@ -1,6 +1,6 @@
 package build
 
-import mill._, javascriptlib._
+import mill.*, javascriptlib.*
 
 object foo extends RsWithServeModule {
   override def forkEnv = super.forkEnv() + ("PORT" -> "3000")

--- a/example/javascriptlib/basic/3-custom-build-logic/build.mill
+++ b/example/javascriptlib/basic/3-custom-build-logic/build.mill
@@ -1,6 +1,6 @@
 package build
 
-import mill._, javascriptlib._
+import mill.*, javascriptlib.*
 
 object foo extends TypeScriptModule {
 

--- a/example/javascriptlib/basic/4-multi-modules/build.mill
+++ b/example/javascriptlib/basic/4-multi-modules/build.mill
@@ -1,6 +1,6 @@
 package build
 
-import mill._, javascriptlib._
+import mill.*, javascriptlib.*
 
 object foo extends TypeScriptModule {
   object bar extends TypeScriptModule {

--- a/example/javascriptlib/basic/5-client-server-hello/build.mill
+++ b/example/javascriptlib/basic/5-client-server-hello/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, javascriptlib._
+import mill.*, javascriptlib.*
 
 object client extends ReactScriptsModule
 

--- a/example/javascriptlib/basic/6-client-server-realistic/build.mill
+++ b/example/javascriptlib/basic/6-client-server-realistic/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, javascriptlib._
+import mill.*, javascriptlib.*
 
 object client extends ReactScriptsModule
 

--- a/example/javascriptlib/dependencies/1-npm-deps/build.mill
+++ b/example/javascriptlib/dependencies/1-npm-deps/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, javascriptlib._
+import mill.*, javascriptlib.*
 
 object foo extends TypeScriptModule {
   def npmDeps = Seq("lodash@4.17.21")

--- a/example/javascriptlib/dependencies/2-unmanaged-packages/build.mill
+++ b/example/javascriptlib/dependencies/2-unmanaged-packages/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, javascriptlib._
+import mill.*, javascriptlib.*
 
 object foo extends TypeScriptModule {
   def unmanagedDepsFolder = Task.Source("lib")

--- a/example/javascriptlib/dependencies/3-downloading-unmanaged-packages/build.mill
+++ b/example/javascriptlib/dependencies/3-downloading-unmanaged-packages/build.mill
@@ -4,7 +4,7 @@
 // library, one of Mill's xref:fundamentals/bundled-libraries.adoc[Bundled Libraries].
 //
 package build
-import mill._, javascriptlib._
+import mill.*, javascriptlib.*
 
 object foo extends TypeScriptModule {
   def unmanagedDeps = Task {

--- a/example/javascriptlib/dependencies/4-repository-config/build.mill
+++ b/example/javascriptlib/dependencies/4-repository-config/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, javascriptlib._
+import mill.*, javascriptlib.*
 
 object foo extends TypeScriptModule {
   def npmDeps = Seq("lodash@4.17.21")

--- a/example/javascriptlib/linting/1-linting/build.mill
+++ b/example/javascriptlib/linting/1-linting/build.mill
@@ -1,6 +1,6 @@
 package build
 
-import mill._, javascriptlib._
+import mill.*, javascriptlib.*
 
 object foo extends TypeScriptModule with TsLintModule
 

--- a/example/javascriptlib/linting/2-autoformatting/build.mill
+++ b/example/javascriptlib/linting/2-autoformatting/build.mill
@@ -1,6 +1,6 @@
 package build
 
-import mill._, javascriptlib._
+import mill.*, javascriptlib.*
 
 object foo extends TypeScriptModule with TsLintModule
 

--- a/example/javascriptlib/linting/3-code-coverage/build.mill
+++ b/example/javascriptlib/linting/3-code-coverage/build.mill
@@ -1,6 +1,6 @@
 package build
 
-import mill._, javascriptlib._
+import mill.*, javascriptlib.*
 
 object foo extends TypeScriptModule {
   object test extends TypeScriptTests with TestModule.Jest

--- a/example/javascriptlib/module/1-common-config/build.mill
+++ b/example/javascriptlib/module/1-common-config/build.mill
@@ -1,7 +1,7 @@
 package build
 
-import mill._
-import mill.javascriptlib._
+import mill.*
+import mill.javascriptlib.*
 
 object foo extends TypeScriptModule {
 

--- a/example/javascriptlib/module/2-custom-tasks/build.mill
+++ b/example/javascriptlib/module/2-custom-tasks/build.mill
@@ -1,6 +1,6 @@
 package build
 
-import mill._, javascriptlib._
+import mill.*, javascriptlib.*
 
 object foo extends TypeScriptModule {
 

--- a/example/javascriptlib/module/3-override-tasks/build.mill
+++ b/example/javascriptlib/module/3-override-tasks/build.mill
@@ -1,7 +1,7 @@
 package build
 
-import mill._
-import mill.javascriptlib._
+import mill.*
+import mill.javascriptlib.*
 
 object `package` extends TypeScriptModule {
   def moduleName = "foo"

--- a/example/javascriptlib/module/4-compilation-execution-flags/build.mill
+++ b/example/javascriptlib/module/4-compilation-execution-flags/build.mill
@@ -1,7 +1,7 @@
 package build
 
-import mill._
-import mill.javascriptlib._
+import mill.*
+import mill.javascriptlib.*
 
 object foo extends TypeScriptModule {
   def compilerOptions =

--- a/example/javascriptlib/module/5-resources/build.mill
+++ b/example/javascriptlib/module/5-resources/build.mill
@@ -1,7 +1,7 @@
 package build
 
-import mill._, javascriptlib._
-import ujson._
+import mill.*, javascriptlib.*
+import ujson.*
 
 object foo extends TypeScriptModule {
   object test extends TypeScriptTests with TestModule.Jest {

--- a/example/javascriptlib/module/6-executable-config/build.mill
+++ b/example/javascriptlib/module/6-executable-config/build.mill
@@ -1,7 +1,7 @@
 package build
 
-import mill._
-import mill.javascriptlib._
+import mill.*
+import mill.javascriptlib.*
 
 object foo extends TypeScriptModule {
   def bundleFlags =

--- a/example/javascriptlib/module/7-root-module/build.mill
+++ b/example/javascriptlib/module/7-root-module/build.mill
@@ -3,7 +3,7 @@
 
 package build
 
-import mill._, javascriptlib._
+import mill.*, javascriptlib.*
 
 object `package` extends TypeScriptModule {
   def moduleName = "foo"

--- a/example/javascriptlib/publishing/1-publish/build.mill
+++ b/example/javascriptlib/publishing/1-publish/build.mill
@@ -1,7 +1,7 @@
 package build
 
-import mill._, javascriptlib._
-import ujson._
+import mill.*, javascriptlib.*
+import ujson.*
 
 object foo extends PublishModule {
   def pubBundledOut = "dist"

--- a/example/javascriptlib/publishing/2-realistic/build.mill
+++ b/example/javascriptlib/publishing/2-realistic/build.mill
@@ -1,7 +1,7 @@
 package build
 
-import mill._, javascriptlib._
-import ujson._
+import mill.*, javascriptlib.*
+import ujson.*
 
 object foo extends TypeScriptModule {
   object bar extends TypeScriptModule {

--- a/example/javascriptlib/testing/1-test-suite/build.mill
+++ b/example/javascriptlib/testing/1-test-suite/build.mill
@@ -1,6 +1,6 @@
 package build
 
-import mill._, javascriptlib._
+import mill.*, javascriptlib.*
 
 object bar extends TypeScriptModule {
   object test extends TypeScriptTests with TestModule.Jest

--- a/example/javascriptlib/testing/2-test-deps/build.mill
+++ b/example/javascriptlib/testing/2-test-deps/build.mill
@@ -1,6 +1,6 @@
 package build
 
-import mill._, javascriptlib._
+import mill.*, javascriptlib.*
 
 object bar extends TypeScriptModule {
   def npmDeps = Seq("immutable@4.3.7")

--- a/example/javascriptlib/testing/3-integration-suite-cypress/build.mill
+++ b/example/javascriptlib/testing/3-integration-suite-cypress/build.mill
@@ -1,6 +1,6 @@
 package build
 
-import mill._, javascriptlib._
+import mill.*, javascriptlib.*
 
 object client extends ReactScriptsModule
 

--- a/example/javascriptlib/testing/3-integration-suite-playwright/build.mill
+++ b/example/javascriptlib/testing/3-integration-suite-playwright/build.mill
@@ -1,6 +1,6 @@
 package build
 
-import mill._, javascriptlib._
+import mill.*, javascriptlib.*
 
 object client extends ReactScriptsModule
 

--- a/example/kotlinlib/basic/1-simple/build.mill
+++ b/example/kotlinlib/basic/1-simple/build.mill
@@ -1,7 +1,7 @@
 //// SNIPPET:BUILD
 
 package build
-import mill._, kotlinlib._
+import mill.*, kotlinlib.*
 
 object foo extends KotlinModule {
   def kotlinVersion = "1.9.24"

--- a/example/kotlinlib/basic/2-custom-build-logic/build.mill
+++ b/example/kotlinlib/basic/2-custom-build-logic/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, kotlinlib._
+import mill.*, kotlinlib.*
 
 object foo extends KotlinModule {
 

--- a/example/kotlinlib/basic/3-multi-module/build.mill
+++ b/example/kotlinlib/basic/3-multi-module/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, kotlinlib._
+import mill.*, kotlinlib.*
 
 trait MyModule extends KotlinModule {
   def kotlinVersion = "1.9.24"

--- a/example/kotlinlib/basic/4-compat-modules/build.mill
+++ b/example/kotlinlib/basic/4-compat-modules/build.mill
@@ -6,7 +6,7 @@
 // Maven or Gradle build:
 
 package build
-import mill._, kotlinlib._
+import mill.*, kotlinlib.*
 
 object foo extends KotlinModule with KotlinMavenModule {
 

--- a/example/kotlinlib/basic/6-realistic/build.mill
+++ b/example/kotlinlib/basic/6-realistic/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:ALL
 package build
-import mill._, kotlinlib._, publish._
+import mill.*, kotlinlib.*, publish.*
 
 trait MyModule extends KotlinModule with PublishModule {
   def publishVersion = "0.0.1"

--- a/example/kotlinlib/basic/7-dependency-injection/build.mill
+++ b/example/kotlinlib/basic/7-dependency-injection/build.mill
@@ -1,7 +1,7 @@
 //// SNIPPET:BUILD
 
 package build
-import mill._, kotlinlib._
+import mill.*, kotlinlib.*
 import kotlinlib.ksp.KspModule
 
 object dagger extends KspModule {

--- a/example/kotlinlib/dependencies/1-mvn-deps/build.mill
+++ b/example/kotlinlib/dependencies/1-mvn-deps/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, kotlinlib._
+import mill.*, kotlinlib.*
 
 object `package` extends KotlinModule {
 

--- a/example/kotlinlib/dependencies/2-run-compile-deps/build.mill
+++ b/example/kotlinlib/dependencies/2-run-compile-deps/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD1
 package build
-import mill._, kotlinlib._
+import mill.*, kotlinlib.*
 
 object foo extends KotlinModule {
 

--- a/example/kotlinlib/dependencies/3-unmanaged-jars/build.mill
+++ b/example/kotlinlib/dependencies/3-unmanaged-jars/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, kotlinlib._
+import mill.*, kotlinlib.*
 
 object `package` extends KotlinModule {
 

--- a/example/kotlinlib/dependencies/4-downloading-unmanaged-jars/build.mill
+++ b/example/kotlinlib/dependencies/4-downloading-unmanaged-jars/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, kotlinlib._
+import mill.*, kotlinlib.*
 
 object `package` extends KotlinModule {
 

--- a/example/kotlinlib/dependencies/5-repository-config/build.mill
+++ b/example/kotlinlib/dependencies/5-repository-config/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD1
 package build
-import mill._, kotlinlib._
+import mill.*, kotlinlib.*
 import mill.javalib.{JvmWorkerModule, CoursierModule}
 import mill.api.ModuleRef
 

--- a/example/kotlinlib/linting/1-detekt/build.mill
+++ b/example/kotlinlib/linting/1-detekt/build.mill
@@ -1,6 +1,6 @@
 package build
 
-import mill._
+import mill.*
 import kotlinlib.KotlinModule
 import kotlinlib.detekt.DetektModule
 

--- a/example/kotlinlib/linting/2-ktlint/build.mill
+++ b/example/kotlinlib/linting/2-ktlint/build.mill
@@ -1,6 +1,6 @@
 package build
 
-import mill._
+import mill.*
 import mill.util.Jvm
 
 import kotlinlib.KotlinModule

--- a/example/kotlinlib/linting/3-ktfmt/build.mill
+++ b/example/kotlinlib/linting/3-ktfmt/build.mill
@@ -1,6 +1,6 @@
 package build
 
-import mill._
+import mill.*
 import mill.util.Jvm
 
 import kotlinlib.KotlinModule

--- a/example/kotlinlib/linting/4-kover/build.mill
+++ b/example/kotlinlib/linting/4-kover/build.mill
@@ -1,6 +1,6 @@
 package build
 
-import mill._, kotlinlib._
+import mill.*, kotlinlib.*
 import kotlinlib.kover.KoverModule
 
 object `package` extends KotlinModule with KoverModule {

--- a/example/kotlinlib/module/1-common-config/build.mill
+++ b/example/kotlinlib/module/1-common-config/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, kotlinlib._
+import mill.*, kotlinlib.*
 
 object `package` extends KotlinModule {
   // You can have arbitrary numbers of third-party dependencies

--- a/example/kotlinlib/module/11-main-class/build.mill
+++ b/example/kotlinlib/module/11-main-class/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, kotlinlib._
+import mill.*, kotlinlib.*
 
 object `package` extends KotlinModule {
 

--- a/example/kotlinlib/module/15-jni/build.mill
+++ b/example/kotlinlib/module/15-jni/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, kotlinlib._, util.Jvm
+import mill.*, kotlinlib.*, util.Jvm
 
 object `package` extends KotlinModule {
 

--- a/example/kotlinlib/module/2-custom-tasks/build.mill
+++ b/example/kotlinlib/module/2-custom-tasks/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, kotlinlib._
+import mill.*, kotlinlib.*
 
 object `package` extends KotlinModule {
 

--- a/example/kotlinlib/module/3-generated-sources/build.mill
+++ b/example/kotlinlib/module/3-generated-sources/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD1
 package build
-import mill._, kotlinlib._
+import mill.*, kotlinlib.*
 
 object foo extends KotlinModule {
 

--- a/example/kotlinlib/module/4-compilation-execution-flags/build.mill
+++ b/example/kotlinlib/module/4-compilation-execution-flags/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, kotlinlib._
+import mill.*, kotlinlib.*
 
 object `package` extends KotlinModule {
 

--- a/example/kotlinlib/module/7-resources/build.mill
+++ b/example/kotlinlib/module/7-resources/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, kotlinlib._
+import mill.*, kotlinlib.*
 
 object foo extends KotlinModule {
 

--- a/example/kotlinlib/module/8-kotlin-compiler-plugins/build.mill
+++ b/example/kotlinlib/module/8-kotlin-compiler-plugins/build.mill
@@ -4,7 +4,7 @@
 
 package build
 
-import mill._, kotlinlib._
+import mill.*, kotlinlib.*
 import java.io.File
 
 object foo extends KotlinModule {

--- a/example/kotlinlib/module/9-docjar/build.mill
+++ b/example/kotlinlib/module/9-docjar/build.mill
@@ -3,7 +3,7 @@
 
 //// SNIPPET:BUILD
 package build
-import mill._, kotlinlib._
+import mill.*, kotlinlib.*
 
 object foo extends KotlinModule {
 

--- a/example/kotlinlib/publishing/1-assembly-config/build.mill
+++ b/example/kotlinlib/publishing/1-assembly-config/build.mill
@@ -1,7 +1,7 @@
 //// SNIPPET:BUILD
 package build
-import mill._, kotlinlib._
-import mill.javalib.Assembly._
+import mill.*, kotlinlib.*
+import mill.javalib.Assembly.*
 
 object foo extends KotlinModule {
 

--- a/example/kotlinlib/publishing/2-publish-module/build.mill
+++ b/example/kotlinlib/publishing/2-publish-module/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, kotlinlib._, publish._
+import mill.*, kotlinlib.*, publish.*
 
 object foo extends KotlinModule with PublishModule {
 

--- a/example/kotlinlib/publishing/3-publish-module-sonatype/build.mill
+++ b/example/kotlinlib/publishing/3-publish-module-sonatype/build.mill
@@ -1,7 +1,7 @@
 //// SNIPPET:BUILD
 package build
 
-import mill._, kotlinlib._, publish._
+import mill.*, kotlinlib.*, publish.*
 
 import mill.scalalib.SonatypeCentralPublishModule
 

--- a/example/kotlinlib/publishing/7-native-image/build.mill
+++ b/example/kotlinlib/publishing/7-native-image/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, kotlinlib._
+import mill.*, kotlinlib.*
 import mill.api.ModuleRef
 
 object foo extends KotlinModule with NativeImageModule {

--- a/example/kotlinlib/publishing/8-native-image-libs/build.mill
+++ b/example/kotlinlib/publishing/8-native-image-libs/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, kotlinlib._
+import mill.*, kotlinlib.*
 import mill.api.ModuleRef
 
 object foo extends KotlinModule with NativeImageModule {

--- a/example/kotlinlib/testing/1-test-suite/build.mill
+++ b/example/kotlinlib/testing/1-test-suite/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD1
 package build
-import mill._, kotlinlib._
+import mill.*, kotlinlib.*
 
 object foo extends KotlinModule {
 

--- a/example/kotlinlib/testing/2-test-deps/build.mill
+++ b/example/kotlinlib/testing/2-test-deps/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, kotlinlib._
+import mill.*, kotlinlib.*
 
 object qux extends KotlinModule {
 

--- a/example/kotlinlib/testing/3-integration-suite/build.mill
+++ b/example/kotlinlib/testing/3-integration-suite/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD3
 package build
-import mill._, kotlinlib._
+import mill.*, kotlinlib.*
 object qux extends KotlinModule {
 
   def kotlinVersion = "1.9.24"

--- a/example/kotlinlib/testing/4-test-parallel/build.mill
+++ b/example/kotlinlib/testing/4-test-parallel/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD1
 package build
-import mill._, kotlinlib._
+import mill.*, kotlinlib.*
 
 object foo extends KotlinModule {
 

--- a/example/kotlinlib/testing/5-test-grouping/build.mill
+++ b/example/kotlinlib/testing/5-test-grouping/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD1
 package build
-import mill._, kotlinlib._
+import mill.*, kotlinlib.*
 
 object foo extends KotlinModule {
 

--- a/example/kotlinlib/testing/6-test-group-parallel/build.mill
+++ b/example/kotlinlib/testing/6-test-group-parallel/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD1
 package build
-import mill._, kotlinlib._
+import mill.*, kotlinlib.*
 
 object foo extends KotlinModule {
 

--- a/example/kotlinlib/web/1-hello-ktor/build.mill
+++ b/example/kotlinlib/web/1-hello-ktor/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, kotlinlib._
+import mill.*, kotlinlib.*
 
 object `package` extends KotlinModule {
 

--- a/example/kotlinlib/web/2-todo-ktor/build.mill
+++ b/example/kotlinlib/web/2-todo-ktor/build.mill
@@ -2,7 +2,7 @@
 // https://todomvc.com/[TodoMVC] example app using Kotlin and Ktor.
 
 package build
-import mill._, kotlinlib._
+import mill.*, kotlinlib.*
 
 object `package` extends KotlinModule {
 

--- a/example/kotlinlib/web/3-hello-kotlinjs/build.mill
+++ b/example/kotlinlib/web/3-hello-kotlinjs/build.mill
@@ -8,7 +8,7 @@
 // * https://github.com/com-lihaoyi/mill/issues/3611
 
 package build
-import mill._, kotlinlib._, kotlinlib.js._
+import mill.*, kotlinlib.*, kotlinlib.js.*
 
 object `package` extends KotlinJsModule {
   override def kotlinJsModuleKind = ModuleKind.ESModule

--- a/example/kotlinlib/web/4-webapp-kotlinjs/build.mill
+++ b/example/kotlinlib/web/4-webapp-kotlinjs/build.mill
@@ -5,7 +5,7 @@
 
 package build
 
-import mill._, kotlinlib._, kotlinlib.js._
+import mill.*, kotlinlib.*, kotlinlib.js.*
 
 object `package` extends KotlinModule {
 

--- a/example/kotlinlib/web/5-webapp-kotlinjs-shared/build.mill
+++ b/example/kotlinlib/web/5-webapp-kotlinjs-shared/build.mill
@@ -5,7 +5,7 @@
 // which is then rendered into HTML on the client.
 
 package build
-import mill._, kotlinlib._, kotlinlib.js._
+import mill.*, kotlinlib.*, kotlinlib.js.*
 
 trait AppKotlinModule extends KotlinModule {
   def kotlinVersion = "1.9.25"

--- a/example/kotlinlib/web/6-hello-spring-boot/build.mill
+++ b/example/kotlinlib/web/6-hello-spring-boot/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, kotlinlib._
+import mill.*, kotlinlib.*
 
 object `package` extends KotlinModule {
 

--- a/example/kotlinlib/web/7-todo-spring-boot/build.mill
+++ b/example/kotlinlib/web/7-todo-spring-boot/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, kotlinlib._
+import mill.*, kotlinlib.*
 
 object `package` extends KotlinModule {
   def kotlinVersion = "1.9.24"

--- a/example/large/multifile/10-multi-file-builds/bar/qux/mymodule/src/BarQux.scala
+++ b/example/large/multifile/10-multi-file-builds/bar/qux/mymodule/src/BarQux.scala
@@ -1,5 +1,5 @@
 package bar.qux
-import scalatags.Text.all._
+import scalatags.Text.all.*
 object BarQux {
   def printText(text: String): Unit = {
     val value = p("world")

--- a/example/large/multifile/10-multi-file-builds/bar/qux/package.mill
+++ b/example/large/multifile/10-multi-file-builds/bar/qux/package.mill
@@ -1,5 +1,5 @@
 package build.bar.qux
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 object mymodule extends build.MyModule {
   def mvnDeps = Seq(mvn"com.lihaoyi::scalatags:0.8.2")

--- a/example/large/multifile/10-multi-file-builds/build.mill
+++ b/example/large/multifile/10-multi-file-builds/build.mill
@@ -31,7 +31,7 @@
 //
 package build
 
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 trait MyModule extends ScalaModule {
   def scalaVersion = "2.13.11"

--- a/example/large/multifile/10-multi-file-builds/foo/package.mill
+++ b/example/large/multifile/10-multi-file-builds/foo/package.mill
@@ -1,5 +1,5 @@
 package build.foo
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 object `package` extends build.MyModule {
   def moduleDeps = Seq(build.bar.qux.mymodule)

--- a/example/large/multifile/11-helper-files/build.mill
+++ b/example/large/multifile/11-helper-files/build.mill
@@ -3,7 +3,7 @@
 // as your `build.mill` or a `package.mill`.
 
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 object `package` extends MyModule {
   def forkEnv = Map(

--- a/example/large/multifile/11-helper-files/foo/package.mill
+++ b/example/large/multifile/11-helper-files/foo/package.mill
@@ -1,5 +1,5 @@
 package build.foo
-import mill._, scalalib._
+import mill.*, scalalib.*
 object `package` extends build.MyModule {
   def forkEnv = Map(
     "MY_SCALA_VERSION" -> build.myScalaVersion,

--- a/example/large/multifile/11-helper-files/util.mill
+++ b/example/large/multifile/11-helper-files/util.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 def myScalaVersion = "2.13.14"
 

--- a/example/large/multilang/14-multi-language/build.mill
+++ b/example/large/multilang/14-multi-language/build.mill
@@ -3,7 +3,7 @@
 // through the web-server api.
 
 package build
-import mill._, javascriptlib._, pythonlib._, javalib._
+import mill.*, javascriptlib.*, pythonlib.*, javalib.*
 
 object client extends ReactScriptsModule
 

--- a/example/large/selective/9-selective-execution/build.mill
+++ b/example/large/selective/9-selective-execution/build.mill
@@ -34,7 +34,7 @@
 // where `bar` depends on `foo` but `qux` is standalone:
 
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 trait MyModule extends JavaModule {
   object test extends JavaTests with TestModule.Junit4

--- a/example/package.mill
+++ b/example/package.mill
@@ -1,12 +1,12 @@
 package build.example
 // imports
-import scala.util.chaining._
+import scala.util.chaining.*
 import coursier.maven.MavenRepository
-import mill._
+import mill.*
 import mill.util.Tasks
-import mill.scalalib._
+import mill.scalalib.*
 import mill.scalalib.api.JvmWorkerUtil
-import mill.scalalib.publish._
+import mill.scalalib.publish.*
 import mill.util.Jvm
 import mill.define.SelectMode
 import mill.contrib.buildinfo.BuildInfo

--- a/example/pythonlib/basic/1-simple/build.mill
+++ b/example/pythonlib/basic/1-simple/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, pythonlib._
+import mill.*, pythonlib.*
 
 object foo extends PythonModule {
 

--- a/example/pythonlib/basic/2-custom-build-logic/build.mill
+++ b/example/pythonlib/basic/2-custom-build-logic/build.mill
@@ -4,7 +4,7 @@
 // line count of all the source files in that module
 
 package build
-import mill._, pythonlib._
+import mill.*, pythonlib.*
 
 object foo extends PythonModule {
 

--- a/example/pythonlib/basic/3-multi-module/build.mill
+++ b/example/pythonlib/basic/3-multi-module/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, pythonlib._
+import mill.*, pythonlib.*
 
 trait MyModule extends PythonModule {
   def resources = super.resources() ++ Seq(PathRef(moduleDir / "res"))

--- a/example/pythonlib/dependencies/1-pip-deps/build.mill
+++ b/example/pythonlib/dependencies/1-pip-deps/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, pythonlib._
+import mill.*, pythonlib.*
 
 object `package` extends PythonModule {
   def pythonDeps = Seq(

--- a/example/pythonlib/dependencies/2-pip-requirements/build.mill
+++ b/example/pythonlib/dependencies/2-pip-requirements/build.mill
@@ -2,7 +2,7 @@
 // useful if you're migrating an existing project to mill.
 
 package build
-import mill._, pythonlib._
+import mill.*, pythonlib.*
 
 object `package` extends PythonModule {
   def pythonRequirementFiles = Task.Sources {

--- a/example/pythonlib/dependencies/3-unmanaged-wheels/build.mill
+++ b/example/pythonlib/dependencies/3-unmanaged-wheels/build.mill
@@ -4,7 +4,7 @@
 // include it in your project, `unmanagedWheels` is the way to do it.
 
 package build
-import mill._, pythonlib._
+import mill.*, pythonlib.*
 
 object `package` extends PythonModule {
   def unmanagedWheels: T[Seq[PathRef]] = Task.Input {

--- a/example/pythonlib/dependencies/4-downloading-unmanaged-wheels/build.mill
+++ b/example/pythonlib/dependencies/4-downloading-unmanaged-wheels/build.mill
@@ -4,7 +4,7 @@
 // library, one of Mill's xref:fundamentals/bundled-libraries.adoc[Bundled Libraries].
 //
 package build
-import mill._, pythonlib._
+import mill.*, pythonlib.*
 
 object `package` extends PythonModule {
   def unmanagedWheels = Task {

--- a/example/pythonlib/dependencies/5-repository-config/build.mill
+++ b/example/pythonlib/dependencies/5-repository-config/build.mill
@@ -4,7 +4,7 @@
 // the module:
 
 package build
-import mill._, pythonlib._
+import mill.*, pythonlib.*
 
 object foo extends PythonModule {
 

--- a/example/pythonlib/dependencies/6-debugging/build.mill
+++ b/example/pythonlib/dependencies/6-debugging/build.mill
@@ -3,7 +3,7 @@
 // `pipInstallArgs` task.
 
 package build
-import mill._, pythonlib._
+import mill.*, pythonlib.*
 
 object `package` extends PythonModule {
   def pythonDeps = Seq(

--- a/example/pythonlib/linting/1-ruff-format/build.mill
+++ b/example/pythonlib/linting/1-ruff-format/build.mill
@@ -1,7 +1,7 @@
 // First, make your module extend `pythonlib.RuffModule`.
 
 package build
-import mill._, pythonlib._
+import mill.*, pythonlib.*
 
 object `package` extends PythonModule with RuffModule
 

--- a/example/pythonlib/linting/2-ruff-check/build.mill
+++ b/example/pythonlib/linting/2-ruff-check/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, pythonlib._
+import mill.*, pythonlib.*
 
 object `package` extends PythonModule with RuffModule {}
 

--- a/example/pythonlib/linting/3-coverage/build.mill
+++ b/example/pythonlib/linting/3-coverage/build.mill
@@ -3,7 +3,7 @@
 //
 // You can use it by extending `CoverageTests` in your test module.
 
-import mill._, pythonlib._
+import mill.*, pythonlib.*
 
 object `package` extends PythonModule {
 

--- a/example/pythonlib/module/1-common-config/build.mill
+++ b/example/pythonlib/module/1-common-config/build.mill
@@ -5,7 +5,7 @@
 // add variables for environment and options for python respectively.
 
 package build
-import mill._, pythonlib._
+import mill.*, pythonlib.*
 
 object foo extends PythonModule {
   // You can have arbitrary numbers of third-party libraries

--- a/example/pythonlib/module/2-custom-tasks/build.mill
+++ b/example/pythonlib/module/2-custom-tasks/build.mill
@@ -9,7 +9,7 @@
 //    env variable defined in `forkEnv` and print it when the program runs
 //
 package build
-import mill._, pythonlib._
+import mill.*, pythonlib.*
 
 object foo extends PythonModule {
 

--- a/example/pythonlib/module/3-override-tasks/build.mill
+++ b/example/pythonlib/module/3-override-tasks/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, pythonlib._
+import mill.*, pythonlib.*
 
 object foo extends PythonModule {
   def sources = Task {

--- a/example/pythonlib/module/4-compilation-execution-flags/build.mill
+++ b/example/pythonlib/module/4-compilation-execution-flags/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, pythonlib._
+import mill.*, pythonlib.*
 
 object `package` extends PythonModule {
   def mainScript = Task.Source { "src/foo.py" }

--- a/example/pythonlib/module/5-resources/build.mill
+++ b/example/pythonlib/module/5-resources/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, pythonlib._
+import mill.*, pythonlib.*
 
 object foo extends PythonModule {
   def mainScript = Task.Source { "src/foo.py" }

--- a/example/pythonlib/module/6-pex-config/build.mill
+++ b/example/pythonlib/module/6-pex-config/build.mill
@@ -3,7 +3,7 @@
 // options for Python compilation, and bundle creation settings.
 
 package build
-import mill._, pythonlib._
+import mill.*, pythonlib.*
 
 object foo extends PythonModule {
   // This Script will be the entry point for the bundle

--- a/example/pythonlib/publishing/1-publish-module/build.mill
+++ b/example/pythonlib/publishing/1-publish-module/build.mill
@@ -1,7 +1,7 @@
 // All packaging and publishing functionality is defined in `PublishModule`.
 // Start by extending it.
 
-import mill._, pythonlib._
+import mill.*, pythonlib.*
 
 object `package` extends PythonModule with PublishModule {
 

--- a/example/pythonlib/publishing/2-publish-module-advanced/build.mill
+++ b/example/pythonlib/publishing/2-publish-module-advanced/build.mill
@@ -24,7 +24,7 @@
 // The following example shows how to override the packaging process by providing a
 // custom `setup.py` file.
 
-import mill._, pythonlib._
+import mill.*, pythonlib.*
 
 object `package` extends PythonModule with PublishModule {
 

--- a/example/pythonlib/testing/1-test-suite/build.mill
+++ b/example/pythonlib/testing/1-test-suite/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, pythonlib._
+import mill.*, pythonlib.*
 
 object foo extends PythonModule {
   def mainScript = Task.Source { "src/foo.py" }

--- a/example/pythonlib/testing/2-test-deps/build.mill
+++ b/example/pythonlib/testing/2-test-deps/build.mill
@@ -2,7 +2,7 @@
 // and test modules can use their `moduleDeps` to also depend on each other
 
 package build
-import mill._, pythonlib._
+import mill.*, pythonlib.*
 
 object foo extends PythonModule {
 

--- a/example/pythonlib/testing/3-integration-suite/build.mill
+++ b/example/pythonlib/testing/3-integration-suite/build.mill
@@ -3,7 +3,7 @@
 // to that named `test`.
 
 package build
-import mill._, pythonlib._
+import mill.*, pythonlib.*
 
 object foo extends PythonModule {
 

--- a/example/pythonlib/web/1-hello-flask/build.mill
+++ b/example/pythonlib/web/1-hello-flask/build.mill
@@ -2,7 +2,7 @@
 // at the root URL (`/`), with Flask installed as a dependency
 // and tests enabled using `unittest`.
 package build
-import mill._, pythonlib._
+import mill.*, pythonlib.*
 
 object foo extends PythonModule {
 

--- a/example/pythonlib/web/2-todo-flask/build.mill
+++ b/example/pythonlib/web/2-todo-flask/build.mill
@@ -3,7 +3,7 @@
 // Tasks can be filtered as `all`, `active`, or `completed` based on their state.
 // The application demonstrates dynamic rendering using Flask's routing and templating features.
 package build
-import mill._, pythonlib._
+import mill.*, pythonlib.*
 
 object todo extends PythonModule {
 

--- a/example/pythonlib/web/3-hello-django/build.mill
+++ b/example/pythonlib/web/3-hello-django/build.mill
@@ -2,7 +2,7 @@
 // It features a simple view that returns `<h1>Hello, Mill!</h1>` and
 // includes `Django's` core functionality for `testing` and `running` a development server.
 package build
-import mill._, pythonlib._
+import mill.*, pythonlib.*
 
 object foo extends PythonModule {
 

--- a/example/pythonlib/web/4-todo-django/build.mill
+++ b/example/pythonlib/web/4-todo-django/build.mill
@@ -2,7 +2,7 @@
 // It features dynamic `HTML` rendering with `Django's` template engine, `CRUD` operations with
 // Django `ORM`, and efficient form handling for managing tasks.
 package build
-import mill._, pythonlib._
+import mill.*, pythonlib.*
 
 object todo extends PythonModule {
 

--- a/example/scalalib/basic/1-simple/build.mill
+++ b/example/scalalib/basic/1-simple/build.mill
@@ -1,7 +1,7 @@
 //// SNIPPET:BUILD
 
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 object foo extends ScalaModule {
   def scalaVersion = "3.7.1"

--- a/example/scalalib/basic/1-simple/foo/src/Foo.scala
+++ b/example/scalalib/basic/1-simple/foo/src/Foo.scala
@@ -1,5 +1,5 @@
 package foo
-import scalatags.Text.all._
+import scalatags.Text.all.*
 import mainargs.{main, ParserForMethods}
 
 object Foo {

--- a/example/scalalib/basic/1-simple/foo/test/src/FooTests.scala
+++ b/example/scalalib/basic/1-simple/foo/test/src/FooTests.scala
@@ -1,6 +1,6 @@
 package foo
 
-import utest._
+import utest.*
 
 object FooTests extends TestSuite {
   def tests = Tests {

--- a/example/scalalib/basic/2-custom-build-logic/build.mill
+++ b/example/scalalib/basic/2-custom-build-logic/build.mill
@@ -6,7 +6,7 @@
 
 //// SNIPPET:BUILD
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 object foo extends ScalaModule {
   def scalaVersion = "3.7.1"

--- a/example/scalalib/basic/3-multi-module/bar/src/Bar.scala
+++ b/example/scalalib/basic/3-multi-module/bar/src/Bar.scala
@@ -1,5 +1,5 @@
 package bar
-import scalatags.Text.all._
+import scalatags.Text.all.*
 object Bar {
   def generateHtml(text: String) = {
     val value = h1(text)

--- a/example/scalalib/basic/3-multi-module/bar/test/src/BarTests.scala
+++ b/example/scalalib/basic/3-multi-module/bar/test/src/BarTests.scala
@@ -1,5 +1,5 @@
 package bar
-import utest._
+import utest.*
 object BarTests extends TestSuite {
   def tests = Tests {
     test("simple") {

--- a/example/scalalib/basic/3-multi-module/build.mill
+++ b/example/scalalib/basic/3-multi-module/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 trait MyModule extends ScalaModule {
   def scalaVersion = "3.7.1"

--- a/example/scalalib/basic/4-compat-modules/build.mill
+++ b/example/scalalib/basic/4-compat-modules/build.mill
@@ -6,7 +6,7 @@
 // `sbt` build:
 
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 object foo extends SbtModule {
   def scalaVersion = "3.7.1"

--- a/example/scalalib/basic/4-compat-modules/foo/src/test/scala/FooTests.scala
+++ b/example/scalalib/basic/4-compat-modules/foo/src/test/scala/FooTests.scala
@@ -1,5 +1,5 @@
 package foo
-import utest._
+import utest.*
 object FooTests extends TestSuite {
   def tests = Tests {
     test("hello") {

--- a/example/scalalib/basic/6-realistic/bar/src/Bar.scala
+++ b/example/scalalib/basic/6-realistic/bar/src/Bar.scala
@@ -1,5 +1,5 @@
 package bar
-import scalatags.Text.all._
+import scalatags.Text.all.*
 object Bar {
   val value = p("world", " ", BarVersionSpecific.text())
 }

--- a/example/scalalib/basic/6-realistic/bar/test/src-2/BarVersionSpecificTests.scala
+++ b/example/scalalib/basic/6-realistic/bar/test/src-2/BarVersionSpecificTests.scala
@@ -1,5 +1,5 @@
 package bar
-import utest._
+import utest.*
 object BarVersionSpecificTests extends TestSuite {
   def tests = Tests {
     test("test") {

--- a/example/scalalib/basic/6-realistic/bar/test/src-3/BarVersionSpecificTests.scala
+++ b/example/scalalib/basic/6-realistic/bar/test/src-3/BarVersionSpecificTests.scala
@@ -1,5 +1,5 @@
 package bar
-import utest._
+import utest.*
 object BarVersionSpecificTests extends TestSuite {
   def tests = Tests {
     test("test") {

--- a/example/scalalib/basic/6-realistic/bar/test/src/BarTests.scala
+++ b/example/scalalib/basic/6-realistic/bar/test/src/BarTests.scala
@@ -1,5 +1,5 @@
 package bar
-import utest._
+import utest.*
 object BarTests extends TestSuite {
   def tests = Tests {
     test("test") {

--- a/example/scalalib/basic/6-realistic/build.mill
+++ b/example/scalalib/basic/6-realistic/build.mill
@@ -5,7 +5,7 @@
 //
 //// SNIPPET:ALL
 package build
-import mill._, scalalib._, publish._
+import mill.*, scalalib.*, publish.*
 
 trait MyModule extends PublishModule {
   def publishVersion = "0.0.1"

--- a/example/scalalib/basic/6-realistic/foo/src/Foo.scala
+++ b/example/scalalib/basic/6-realistic/foo/src/Foo.scala
@@ -1,5 +1,5 @@
 package foo
-import scalatags.Text.all._
+import scalatags.Text.all.*
 object Foo {
   val value = h1("hello")
   def main(args: Array[String]): Unit = {

--- a/example/scalalib/basic/6-realistic/foo/test/src/FooTests.scala
+++ b/example/scalalib/basic/6-realistic/foo/test/src/FooTests.scala
@@ -1,5 +1,5 @@
 package foo
-import utest._
+import utest.*
 object FooTests extends TestSuite {
   def tests = Tests {
     test("test") {

--- a/example/scalalib/dependencies/1-mvn-deps/build.mill
+++ b/example/scalalib/dependencies/1-mvn-deps/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 object `package` extends ScalaModule {
   def scalaVersion = "2.12.17"

--- a/example/scalalib/dependencies/2-run-compile-deps/build.mill
+++ b/example/scalalib/dependencies/2-run-compile-deps/build.mill
@@ -5,7 +5,7 @@
 
 //// SNIPPET:BUILD1
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 object foo extends ScalaModule {
   def scalaVersion = "3.7.1"

--- a/example/scalalib/dependencies/3-unmanaged-jars/build.mill
+++ b/example/scalalib/dependencies/3-unmanaged-jars/build.mill
@@ -8,7 +8,7 @@
 
 //// SNIPPET:BUILD
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 object `package` extends ScalaModule {
   def scalaVersion = "3.7.1"

--- a/example/scalalib/dependencies/3-unmanaged-jars/src/Foo.scala
+++ b/example/scalalib/dependencies/3-unmanaged-jars/src/Foo.scala
@@ -2,7 +2,7 @@ package foo
 
 import com.grack.nanojson.JsonParser
 import com.grack.nanojson.JsonObject
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 object Foo {
 
   def main(args: Array[String]): Unit = {

--- a/example/scalalib/dependencies/4-downloading-unmanaged-jars/build.mill
+++ b/example/scalalib/dependencies/4-downloading-unmanaged-jars/build.mill
@@ -5,7 +5,7 @@
 //
 //// SNIPPET:BUILD
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 object `package` extends ScalaModule {
   def scalaVersion = "3.7.1"

--- a/example/scalalib/dependencies/5-repository-config/build.mill
+++ b/example/scalalib/dependencies/5-repository-config/build.mill
@@ -4,7 +4,7 @@
 
 //// SNIPPET:BUILD1
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 import mill.api.ModuleRef
 
 object foo extends ScalaModule {

--- a/example/scalalib/dependencies/5-repository-config/foo/src/Foo.scala
+++ b/example/scalalib/dependencies/5-repository-config/foo/src/Foo.scala
@@ -1,5 +1,5 @@
 package foo
-import scalatags.Text.all._
+import scalatags.Text.all.*
 import mainargs.{main, ParserForMethods}
 object Foo {
   @main

--- a/example/scalalib/linting/1-scalafmt/build.mill
+++ b/example/scalalib/linting/1-scalafmt/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 object `package` extends ScalaModule {
   def scalaVersion = "3.7.1"

--- a/example/scalalib/linting/2-contrib-scoverage/build.mill
+++ b/example/scalalib/linting/2-contrib-scoverage/build.mill
@@ -2,9 +2,9 @@
 //| - com.lihaoyi::mill-contrib-scoverage:$MILL_VERSION
 package build
 
-import mill._, scalalib._
+import mill.*, scalalib.*
 
-import mill.contrib.scoverage._
+import mill.contrib.scoverage.*
 
 object `package` extends ScoverageModule {
   def scoverageVersion = "2.1.0"

--- a/example/scalalib/linting/2-contrib-scoverage/src/Foo.scala
+++ b/example/scalalib/linting/2-contrib-scoverage/src/Foo.scala
@@ -1,5 +1,5 @@
 package foo
-import scalatags.Text.all._
+import scalatags.Text.all.*
 import mainargs.{main, ParserForMethods}
 
 object Foo {

--- a/example/scalalib/linting/2-contrib-scoverage/test/src/FooTests.scala
+++ b/example/scalalib/linting/2-contrib-scoverage/test/src/FooTests.scala
@@ -1,5 +1,5 @@
 package foo
-import utest._
+import utest.*
 
 object FooTests extends TestSuite {
   def tests = Tests {

--- a/example/scalalib/linting/3-acyclic/build.mill
+++ b/example/scalalib/linting/3-acyclic/build.mill
@@ -15,7 +15,7 @@
 // shown below:
 
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 object `package` extends ScalaModule {
   def scalaVersion = "2.13.11"

--- a/example/scalalib/module/1-common-config/build.mill
+++ b/example/scalalib/module/1-common-config/build.mill
@@ -7,7 +7,7 @@
 
 //// SNIPPET:BUILD
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 object `package` extends ScalaModule {
   def scalaVersion = "2.13.16"

--- a/example/scalalib/module/1-common-config/custom-src/Foo2.scala
+++ b/example/scalalib/module/1-common-config/custom-src/Foo2.scala
@@ -1,5 +1,5 @@
 package foo
-import scalatags.Text.all._
+import scalatags.Text.all.*
 object Foo2 {
   val value = h1("hello2")
   def main(args: Array[String]): Unit = {

--- a/example/scalalib/module/1-common-config/src/Foo.scala
+++ b/example/scalalib/module/1-common-config/src/Foo.scala
@@ -1,5 +1,5 @@
 package foo
-import scalatags.Text.all._
+import scalatags.Text.all.*
 object Foo {
   val value = h1("hello")
   def main(args: Array[String]): Unit = {

--- a/example/scalalib/module/11-main-class/build.mill
+++ b/example/scalalib/module/11-main-class/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 object `package` extends ScalaModule {
   def scalaVersion = "3.7.1"

--- a/example/scalalib/module/14-cross-scala-version/build.mill
+++ b/example/scalalib/module/14-cross-scala-version/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 val scalaVersions = Seq("2.12.17", "2.13.16")
 

--- a/example/scalalib/module/15-unidoc/build.mill
+++ b/example/scalalib/module/15-unidoc/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 object foo extends ScalaModule with UnidocModule {
   def scalaVersion = "3.7.1"

--- a/example/scalalib/module/2-custom-tasks/build.mill
+++ b/example/scalalib/module/2-custom-tasks/build.mill
@@ -10,7 +10,7 @@
 
 //// SNIPPET:BUILD
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 object `package` extends ScalaModule {
   def scalaVersion = "3.7.1"

--- a/example/scalalib/module/3-generated-sources/build.mill
+++ b/example/scalalib/module/3-generated-sources/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD1
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 object foo extends ScalaModule {
   def scalaVersion = "3.7.1"

--- a/example/scalalib/module/4-compilation-execution-flags/build.mill
+++ b/example/scalalib/module/4-compilation-execution-flags/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 object `package` extends ScalaModule {
   def scalaVersion = "3.7.1"

--- a/example/scalalib/module/7-resources/build.mill
+++ b/example/scalalib/module/7-resources/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 object foo extends ScalaModule {
   def scalaVersion = "3.7.1"

--- a/example/scalalib/module/7-resources/foo/test/src/FooTests.scala
+++ b/example/scalalib/module/7-resources/foo/test/src/FooTests.scala
@@ -1,5 +1,5 @@
 package foo
-import utest._
+import utest.*
 object FooTests extends TestSuite {
   def tests = Tests {
     test("simple") {

--- a/example/scalalib/module/8-scala-compiler-plugins/build.mill
+++ b/example/scalalib/module/8-scala-compiler-plugins/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 object `package` extends ScalaModule {
   def scalaVersion = "2.13.16"

--- a/example/scalalib/module/9-docjar/build.mill
+++ b/example/scalalib/module/9-docjar/build.mill
@@ -3,7 +3,7 @@
 
 //// SNIPPET:BUILD
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 object foo extends ScalaModule {
   def scalaVersion = "3.1.3"

--- a/example/scalalib/native/1-simple/build.mill
+++ b/example/scalalib/native/1-simple/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, scalalib._, scalanativelib._
+import mill.*, scalalib.*, scalanativelib.*
 
 object `package` extends ScalaNativeModule {
   def scalaVersion = "3.3.4"

--- a/example/scalalib/native/1-simple/src/Foo.scala
+++ b/example/scalalib/native/1-simple/src/Foo.scala
@@ -1,7 +1,7 @@
 package foo
 
-import scala.scalanative.libc._
-import scala.scalanative.unsafe._
+import scala.scalanative.libc.*
+import scala.scalanative.unsafe.*
 import mainargs.{main, ParserForMethods}
 
 object Foo {

--- a/example/scalalib/native/1-simple/test/src/FooTests.scala
+++ b/example/scalalib/native/1-simple/test/src/FooTests.scala
@@ -1,7 +1,7 @@
 package foo
 
-import scala.scalanative.unsafe._
-import utest._
+import scala.scalanative.unsafe.*
+import utest.*
 
 object FooTests extends TestSuite {
   def tests = Tests {

--- a/example/scalalib/native/2-interop/build.mill
+++ b/example/scalalib/native/2-interop/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, scalalib._, scalanativelib._
+import mill.*, scalalib.*, scalanativelib.*
 
 object `package` extends ScalaNativeModule {
   def scalaVersion = "3.3.4"

--- a/example/scalalib/native/2-interop/src/foo/HelloWorld.scala
+++ b/example/scalalib/native/2-interop/src/foo/HelloWorld.scala
@@ -1,8 +1,8 @@
 package foo
 
-import scala.scalanative.libc._
-import scala.scalanative.unsafe._
-import scala.scalanative.unsigned._
+import scala.scalanative.libc.*
+import scala.scalanative.unsafe.*
+import scala.scalanative.unsigned.*
 
 object Main {
   def main(args: Array[String]): Unit = {

--- a/example/scalalib/native/2-interop/test/src/HelloWorldTests.scala
+++ b/example/scalalib/native/2-interop/test/src/HelloWorldTests.scala
@@ -1,7 +1,7 @@
 package foo
 
-import utest._
-import scala.scalanative.unsafe._
+import utest.*
+import scala.scalanative.unsafe.*
 import scala.scalanative.libc.stdlib
 
 object HelloWorldTest extends TestSuite {

--- a/example/scalalib/native/3-multi-module/bar/src/Bar.scala
+++ b/example/scalalib/native/3-multi-module/bar/src/Bar.scala
@@ -1,7 +1,7 @@
 package bar
 
-import scala.scalanative.libc._
-import scala.scalanative.unsafe._
+import scala.scalanative.libc.*
+import scala.scalanative.unsafe.*
 
 object Bar {
   def main(args: Array[String]): Unit = Zone {

--- a/example/scalalib/native/3-multi-module/bar/test/src/BarTests.scala
+++ b/example/scalalib/native/3-multi-module/bar/test/src/BarTests.scala
@@ -1,7 +1,7 @@
 package bar
 
-import utest._
-import scala.scalanative.unsafe._
+import utest.*
+import scala.scalanative.unsafe.*
 
 object BarTests extends TestSuite {
   def tests = Tests {

--- a/example/scalalib/native/3-multi-module/build.mill
+++ b/example/scalalib/native/3-multi-module/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, scalalib._, scalanativelib._
+import mill.*, scalalib.*, scalanativelib.*
 
 trait MyModule extends ScalaNativeModule {
   def scalaVersion = "3.3.4"

--- a/example/scalalib/native/3-multi-module/foo/src/Foo.scala
+++ b/example/scalalib/native/3-multi-module/foo/src/Foo.scala
@@ -1,7 +1,7 @@
 package foo
 
-import scala.scalanative.libc._
-import scala.scalanative.unsafe._
+import scala.scalanative.libc.*
+import scala.scalanative.unsafe.*
 import mainargs.{main, ParserForMethods, arg}
 
 object Foo {

--- a/example/scalalib/native/4-common-config/build.mill
+++ b/example/scalalib/native/4-common-config/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, scalalib._, scalanativelib._, scalanativelib.api._
+import mill.*, scalalib.*, scalanativelib.*, scalanativelib.api.*
 
 object `package` extends ScalaNativeModule {
   def scalaVersion = "3.3.4"

--- a/example/scalalib/native/4-common-config/src/Foo.scala
+++ b/example/scalalib/native/4-common-config/src/Foo.scala
@@ -1,8 +1,8 @@
 package foo
 
-import scala.scalanative.libc._
-import scala.scalanative.unsafe._
-import fansi._
+import scala.scalanative.libc.*
+import scala.scalanative.unsafe.*
+import fansi.*
 
 object Foo {
 

--- a/example/scalalib/publishing/1-assembly-config/build.mill
+++ b/example/scalalib/publishing/1-assembly-config/build.mill
@@ -3,8 +3,8 @@
 
 //// SNIPPET:BUILD
 package build
-import mill._, scalalib._
-import mill.scalalib.Assembly._
+import mill.*, scalalib.*
+import mill.scalalib.Assembly.*
 
 object foo extends ScalaModule {
   def moduleDeps = Seq(bar)

--- a/example/scalalib/publishing/2-publish-module/build.mill
+++ b/example/scalalib/publishing/2-publish-module/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, scalalib._, publish._
+import mill.*, scalalib.*, publish.*
 
 object foo extends ScalaModule with PublishModule {
   def scalaVersion = "3.7.1"

--- a/example/scalalib/publishing/3-publish-module-sonatype/build.mill
+++ b/example/scalalib/publishing/3-publish-module-sonatype/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, scalalib._, publish._
+import mill.*, scalalib.*, publish.*
 
 object foo extends ScalaModule with SonatypeCentralPublishModule {
   def scalaVersion = "3.7.1"

--- a/example/scalalib/publishing/7-native-image/build.mill
+++ b/example/scalalib/publishing/7-native-image/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 import mill.api.ModuleRef
 
 object foo extends ScalaModule with NativeImageModule {

--- a/example/scalalib/publishing/8-native-image-libs/build.mill
+++ b/example/scalalib/publishing/8-native-image-libs/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 import mill.api.ModuleRef
 
 object foo extends ScalaModule with NativeImageModule {

--- a/example/scalalib/publishing/8-native-image-libs/foo/src/Foo.scala
+++ b/example/scalalib/publishing/8-native-image-libs/foo/src/Foo.scala
@@ -1,5 +1,5 @@
 package foo
-import scalatags.Text.all._
+import scalatags.Text.all.*
 import mainargs.{main, ParserForMethods}
 
 object Foo {

--- a/example/scalalib/spark/1-hello-spark/build.mill
+++ b/example/scalalib/spark/1-hello-spark/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 object foo extends ScalaModule {
   def scalaVersion = "2.12.15"

--- a/example/scalalib/spark/1-hello-spark/foo/test/src/FooTests.scala
+++ b/example/scalalib/spark/1-hello-spark/foo/test/src/FooTests.scala
@@ -1,7 +1,7 @@
 package foo
 
 import org.apache.spark.sql.SparkSession
-import utest._
+import utest.*
 
 object FooTests extends TestSuite {
   def tests = Tests {

--- a/example/scalalib/spark/2-hello-pyspark/build.mill
+++ b/example/scalalib/spark/2-hello-pyspark/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, pythonlib._
+import mill.*, pythonlib.*
 
 object foo extends PythonModule {
 

--- a/example/scalalib/spark/3-semi-realistic/build.mill
+++ b/example/scalalib/spark/3-semi-realistic/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 object `package` extends ScalaModule {
   def scalaVersion = "2.12.15"

--- a/example/scalalib/spark/3-semi-realistic/src/foo/Foo.scala
+++ b/example/scalalib/spark/3-semi-realistic/src/foo/Foo.scala
@@ -1,7 +1,7 @@
 package foo
 
 import org.apache.spark.sql.{SparkSession, Dataset, DataFrame}
-import org.apache.spark.sql.functions._
+import org.apache.spark.sql.functions.*
 
 object Foo {
 
@@ -30,7 +30,7 @@ object Foo {
         "transactions.csv not provided as argument and not found in resources"
       ))
 
-    import spark.implicits._
+    import spark.implicits.*
 
     val df = spark.read
       .option("header", "true")

--- a/example/scalalib/spark/3-semi-realistic/test/src/FooTests.scala
+++ b/example/scalalib/spark/3-semi-realistic/test/src/FooTests.scala
@@ -1,7 +1,7 @@
 package foo
 
 import org.apache.spark.sql.SparkSession
-import utest._
+import utest.*
 
 object FooTests extends TestSuite {
   val spark = SparkSession.builder()
@@ -9,7 +9,7 @@ object FooTests extends TestSuite {
     .master("local[*]")
     .getOrCreate()
 
-  import spark.implicits._
+  import spark.implicits.*
 
   def tests = Tests {
     test("computeSummary should compute correct summary statistics") {

--- a/example/scalalib/testing/1-test-suite/bar/test/src/BarTests.scala
+++ b/example/scalalib/testing/1-test-suite/bar/test/src/BarTests.scala
@@ -1,5 +1,5 @@
 package bar
-import utest._
+import utest.*
 object BarTests extends TestSuite {
   def tests = Tests {
     test("hello") {

--- a/example/scalalib/testing/1-test-suite/build.mill
+++ b/example/scalalib/testing/1-test-suite/build.mill
@@ -1,6 +1,6 @@
 //// SNIPPET:BUILD1
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 object foo extends ScalaModule {
   def scalaVersion = "3.7.1"

--- a/example/scalalib/testing/1-test-suite/foo/test/src/FooMoreTests.scala
+++ b/example/scalalib/testing/1-test-suite/foo/test/src/FooMoreTests.scala
@@ -1,5 +1,5 @@
 package foo
-import utest._
+import utest.*
 object FooMoreTests extends TestSuite {
   def tests = Tests {
     test("hello") {

--- a/example/scalalib/testing/1-test-suite/foo/test/src/FooTests.scala
+++ b/example/scalalib/testing/1-test-suite/foo/test/src/FooTests.scala
@@ -1,5 +1,5 @@
 package foo
-import utest._
+import utest.*
 object FooTests extends TestSuite {
   def tests = Tests {
     test("hello") {

--- a/example/scalalib/testing/2-test-deps/baz/test/src/BazTests.scala
+++ b/example/scalalib/testing/2-test-deps/baz/test/src/BazTests.scala
@@ -1,5 +1,5 @@
 package baz
-import utest._
+import utest.*
 object BazTests extends TestSuite {
   def tests = Tests {
     test("simple") {

--- a/example/scalalib/testing/2-test-deps/build.mill
+++ b/example/scalalib/testing/2-test-deps/build.mill
@@ -11,7 +11,7 @@
 
 //// SNIPPET:BUILD
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 object qux extends ScalaModule {
   def scalaVersion = "3.7.1"

--- a/example/scalalib/testing/2-test-deps/qux/test/src/QuxTests.scala
+++ b/example/scalalib/testing/2-test-deps/qux/test/src/QuxTests.scala
@@ -1,5 +1,5 @@
 package qux
-import utest._
+import utest.*
 object QuxTests extends TestSuite {
   def tests = Tests {
     test("simple") {

--- a/example/scalalib/testing/3-integration-suite/build.mill
+++ b/example/scalalib/testing/3-integration-suite/build.mill
@@ -4,7 +4,7 @@
 
 //// SNIPPET:BUILD3
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 object qux extends ScalaModule {
   def scalaVersion = "3.7.1"

--- a/example/scalalib/testing/3-integration-suite/qux/integration/src/QuxTests.scala
+++ b/example/scalalib/testing/3-integration-suite/qux/integration/src/QuxTests.scala
@@ -1,5 +1,5 @@
 package qux
-import utest._
+import utest.*
 object QuxIntegrationTests extends TestSuite {
   def tests = Tests {
     test("helloworld") {

--- a/example/scalalib/testing/3-integration-suite/qux/test/src/QuxTests.scala
+++ b/example/scalalib/testing/3-integration-suite/qux/test/src/QuxTests.scala
@@ -1,5 +1,5 @@
 package qux
-import utest._
+import utest.*
 object QuxTests extends TestSuite {
   def tests = Tests {
     test("hello") {

--- a/example/scalalib/testing/4-test-parallel/build.mill
+++ b/example/scalalib/testing/4-test-parallel/build.mill
@@ -4,7 +4,7 @@
 //
 //// SNIPPET:BUILD1
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 object foo extends ScalaModule {
   def scalaVersion = "3.7.1"

--- a/example/scalalib/testing/4-test-parallel/foo/test/src/RandomTestsA.scala
+++ b/example/scalalib/testing/4-test-parallel/foo/test/src/RandomTestsA.scala
@@ -1,5 +1,5 @@
 package foo
-import utest._
+import utest.*
 object RandomTestsA extends RandomTestsUtils {
   def tests = Tests {
     test("test1") { testGreeting("Storm", 380) }

--- a/example/scalalib/testing/4-test-parallel/foo/test/src/RandomTestsB.scala
+++ b/example/scalalib/testing/4-test-parallel/foo/test/src/RandomTestsB.scala
@@ -1,5 +1,5 @@
 package foo
-import utest._
+import utest.*
 object RandomTestsB extends RandomTestsUtils {
   def tests = Tests {
     test("test1") { testGreeting("Dakota", 180) }

--- a/example/scalalib/testing/4-test-parallel/foo/test/src/RandomTestsC.scala
+++ b/example/scalalib/testing/4-test-parallel/foo/test/src/RandomTestsC.scala
@@ -1,5 +1,5 @@
 package foo
-import utest._
+import utest.*
 object RandomTestsC extends RandomTestsUtils {
   def tests = Tests {
     test("test1") { testGreeting("Jordan", 950) }

--- a/example/scalalib/testing/4-test-parallel/foo/test/src/RandomTestsD.scala
+++ b/example/scalalib/testing/4-test-parallel/foo/test/src/RandomTestsD.scala
@@ -1,5 +1,5 @@
 package foo
-import utest._
+import utest.*
 object RandomTestsD extends RandomTestsUtils {
   def tests = Tests {
     test("test1") { testGreeting("Kai", 140) }

--- a/example/scalalib/testing/4-test-parallel/foo/test/src/RandomTestsE.scala
+++ b/example/scalalib/testing/4-test-parallel/foo/test/src/RandomTestsE.scala
@@ -1,5 +1,5 @@
 package foo
-import utest._
+import utest.*
 object RandomTestsE extends RandomTestsUtils {
   def tests = Tests {
     test("test1") { testGreeting("Sage", 280) }

--- a/example/scalalib/testing/4-test-parallel/foo/test/src/RandomTestsUtils.scala
+++ b/example/scalalib/testing/4-test-parallel/foo/test/src/RandomTestsUtils.scala
@@ -1,5 +1,5 @@
 package foo
-import utest._
+import utest.*
 
 abstract class RandomTestsUtils extends TestSuite {
 

--- a/example/scalalib/testing/5-test-grouping/build.mill
+++ b/example/scalalib/testing/5-test-grouping/build.mill
@@ -5,7 +5,7 @@
 
 //// SNIPPET:BUILD1
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 object foo extends ScalaModule {
   def scalaVersion = "3.7.1"

--- a/example/scalalib/testing/5-test-grouping/foo/test/src/HelloTests.scala
+++ b/example/scalalib/testing/5-test-grouping/foo/test/src/HelloTests.scala
@@ -1,5 +1,5 @@
 package foo
-import utest._
+import utest.*
 object HelloTests extends TestSuite {
   def tests = Tests {
     test("hello") {

--- a/example/scalalib/testing/5-test-grouping/foo/test/src/WorldTests.scala
+++ b/example/scalalib/testing/5-test-grouping/foo/test/src/WorldTests.scala
@@ -1,5 +1,5 @@
 package foo
-import utest._
+import utest.*
 object WorldTests extends TestSuite {
   def tests = Tests {
     test("world") {

--- a/example/scalalib/testing/6-test-group-parallel/build.mill
+++ b/example/scalalib/testing/6-test-group-parallel/build.mill
@@ -2,7 +2,7 @@
 
 //// SNIPPET:BUILD1
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 object foo extends ScalaModule {
   def scalaVersion = "3.7.1"

--- a/example/scalalib/testing/6-test-group-parallel/foo/test/src/GroupX1.scala
+++ b/example/scalalib/testing/6-test-group-parallel/foo/test/src/GroupX1.scala
@@ -1,5 +1,5 @@
 package foo
-import utest._
+import utest.*
 object GroupX1 extends RandomTestsUtils {
   def tests = Tests {
     test("test1") { testGreeting("Aether", 550) }

--- a/example/scalalib/testing/6-test-group-parallel/foo/test/src/GroupX2.scala
+++ b/example/scalalib/testing/6-test-group-parallel/foo/test/src/GroupX2.scala
@@ -1,5 +1,5 @@
 package foo
-import utest._
+import utest.*
 object GroupX2 extends RandomTestsUtils {
   def tests = Tests {
     test("test1") { testGreeting("Chronos", 350) }

--- a/example/scalalib/testing/6-test-group-parallel/foo/test/src/GroupX3.scala
+++ b/example/scalalib/testing/6-test-group-parallel/foo/test/src/GroupX3.scala
@@ -1,5 +1,5 @@
 package foo
-import utest._
+import utest.*
 object GroupX3 extends RandomTestsUtils {
   def tests = Tests {
     test("test1") { testGreeting("Fortuna", 250) }

--- a/example/scalalib/testing/6-test-group-parallel/foo/test/src/GroupX4.scala
+++ b/example/scalalib/testing/6-test-group-parallel/foo/test/src/GroupX4.scala
@@ -1,5 +1,5 @@
 package foo
-import utest._
+import utest.*
 object GroupX4 extends RandomTestsUtils {
   def tests = Tests {
     test("test1") { testGreeting("Janus", 210) }

--- a/example/scalalib/testing/6-test-group-parallel/foo/test/src/GroupX5.scala
+++ b/example/scalalib/testing/6-test-group-parallel/foo/test/src/GroupX5.scala
@@ -1,5 +1,5 @@
 package foo
-import utest._
+import utest.*
 object GroupX5 extends RandomTestsUtils {
   def tests = Tests {
     test("test1") { testGreeting("Orion", 950) }

--- a/example/scalalib/testing/6-test-group-parallel/foo/test/src/GroupY1.scala
+++ b/example/scalalib/testing/6-test-group-parallel/foo/test/src/GroupY1.scala
@@ -1,5 +1,5 @@
 package foo
-import utest._
+import utest.*
 object GroupY1 extends RandomTestsUtils {
   def tests = Tests {
     test("test1") { testGreeting("Hades", 150) }

--- a/example/scalalib/testing/6-test-group-parallel/foo/test/src/GroupY2.scala
+++ b/example/scalalib/testing/6-test-group-parallel/foo/test/src/GroupY2.scala
@@ -1,5 +1,5 @@
 package foo
-import utest._
+import utest.*
 object GroupY2 extends RandomTestsUtils {
   def tests = Tests {
     test("test1") { testGreeting("Odin", 340) }

--- a/example/scalalib/testing/6-test-group-parallel/foo/test/src/GroupY3.scala
+++ b/example/scalalib/testing/6-test-group-parallel/foo/test/src/GroupY3.scala
@@ -1,5 +1,5 @@
 package foo
-import utest._
+import utest.*
 object GroupY3 extends RandomTestsUtils {
   def tests = Tests {
     test("test1") { testGreeting("Ra", 210) }

--- a/example/scalalib/testing/6-test-group-parallel/foo/test/src/GroupY4.scala
+++ b/example/scalalib/testing/6-test-group-parallel/foo/test/src/GroupY4.scala
@@ -1,5 +1,5 @@
 package foo
-import utest._
+import utest.*
 object GroupY4 extends RandomTestsUtils {
   def tests = Tests {
     test("test1") { testGreeting("Wotan", 950) }

--- a/example/scalalib/testing/6-test-group-parallel/foo/test/src/GroupY5.scala
+++ b/example/scalalib/testing/6-test-group-parallel/foo/test/src/GroupY5.scala
@@ -1,5 +1,5 @@
 package foo
-import utest._
+import utest.*
 object GroupY5 extends RandomTestsUtils {
   def tests = Tests {
     test("test1") { testGreeting("Xiuhtecuhtli", 260) }

--- a/example/scalalib/testing/6-test-group-parallel/foo/test/src/RandomTestsUtils.scala
+++ b/example/scalalib/testing/6-test-group-parallel/foo/test/src/RandomTestsUtils.scala
@@ -1,5 +1,5 @@
 package foo
-import utest._
+import utest.*
 
 abstract class RandomTestsUtils extends TestSuite {
   // sleepTime try to mimics real-life test time,

--- a/example/scalalib/web/1-todo-webapp/build.mill
+++ b/example/scalalib/web/1-todo-webapp/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 object `package` extends ScalaModule {
   def scalaVersion = "3.7.1"

--- a/example/scalalib/web/1-todo-webapp/src/WebApp.scala
+++ b/example/scalalib/web/1-todo-webapp/src/WebApp.scala
@@ -1,5 +1,5 @@
 package webapp
-import scalatags.Text.all._
+import scalatags.Text.all.*
 import scalatags.Text.tags2
 
 object WebApp extends cask.MainRoutes {

--- a/example/scalalib/web/1-todo-webapp/test/src/WebAppTests.scala
+++ b/example/scalalib/web/1-todo-webapp/test/src/WebAppTests.scala
@@ -1,6 +1,6 @@
 package webapp
 
-import utest._
+import utest.*
 
 object WebAppTests extends TestSuite {
   def withServer[T](example: cask.main.Main)(f: String => T): T = {

--- a/example/scalalib/web/2-webapp-cache-busting/build.mill
+++ b/example/scalalib/web/2-webapp-cache-busting/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 import java.util.Arrays
 
 object `package` extends ScalaModule {

--- a/example/scalalib/web/2-webapp-cache-busting/src/WebApp.scala
+++ b/example/scalalib/web/2-webapp-cache-busting/src/WebApp.scala
@@ -1,5 +1,5 @@
 package webapp
-import scalatags.Text.all._
+import scalatags.Text.all.*
 import scalatags.Text.tags2
 
 object WebApp extends cask.MainRoutes {

--- a/example/scalalib/web/2-webapp-cache-busting/test/src/WebAppTests.scala
+++ b/example/scalalib/web/2-webapp-cache-busting/test/src/WebAppTests.scala
@@ -1,6 +1,6 @@
 package webapp
 
-import utest._
+import utest.*
 
 object WebAppTests extends TestSuite {
   def withServer[T](example: cask.main.Main)(f: String => T): T = {

--- a/example/scalalib/web/3-todo-http4s/build.mill
+++ b/example/scalalib/web/3-todo-http4s/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 object `package` extends ScalaModule {
   def scalaVersion = "3.7.1"

--- a/example/scalalib/web/3-todo-http4s/src/WebApp.scala
+++ b/example/scalalib/web/3-todo-http4s/src/WebApp.scala
@@ -1,18 +1,18 @@
 package webapp
 
 import scala.concurrent.duration.Duration
-import scalatags.Text.all._
+import scalatags.Text.all.*
 import scalatags.Text.tags2
-import cats.effect._
-import cats.syntax.all._
-import com.comcast.ip4s._
-import org.http4s._
-import org.http4s.dsl.io._
-import org.http4s.ember.server._
-import org.http4s.scalatags._
-import org.http4s.server.staticcontent._
-import io.circe._
-import io.circe.generic.semiauto._
+import cats.effect.*
+import cats.syntax.all.*
+import com.comcast.ip4s.*
+import org.http4s.*
+import org.http4s.dsl.io.*
+import org.http4s.ember.server.*
+import org.http4s.scalatags.*
+import org.http4s.server.staticcontent.*
+import io.circe.*
+import io.circe.generic.semiauto.*
 
 object WebApp extends IOApp.Simple {
   case class Todo(checked: Boolean, text: String)

--- a/example/scalalib/web/3-todo-http4s/test/src/WebAppTests.scala
+++ b/example/scalalib/web/3-todo-http4s/test/src/WebAppTests.scala
@@ -1,9 +1,9 @@
 package webapp
 
-import utest._
-import cats.effect._
+import utest.*
+import cats.effect.*
 import cats.effect.testing.utest.EffectTestSuite
-import org.http4s.client._
+import org.http4s.client.*
 
 object WebAppTests extends EffectTestSuite[IO] {
 

--- a/example/scalalib/web/4-scalajs-module/build.mill
+++ b/example/scalalib/web/4-scalajs-module/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, scalalib._, scalajslib._
+import mill.*, scalalib.*, scalajslib.*
 
 object foo extends ScalaJSModule {
   def scalaVersion = "3.7.1"

--- a/example/scalalib/web/4-scalajs-module/foo/src/Foo.scala
+++ b/example/scalalib/web/4-scalajs-module/foo/src/Foo.scala
@@ -1,5 +1,5 @@
 package foo
-import scalatags.Text.all._
+import scalatags.Text.all.*
 import scala.scalajs.js
 object Foo {
   def main(args: Array[String]): Unit = {

--- a/example/scalalib/web/4-scalajs-module/foo/test/src/FooTests.scala
+++ b/example/scalalib/web/4-scalajs-module/foo/test/src/FooTests.scala
@@ -1,5 +1,5 @@
 package foo
-import utest._
+import utest.*
 object FooTests extends TestSuite {
   def tests = Tests {
     test("hello") {

--- a/example/scalalib/web/5-webapp-scalajs/build.mill
+++ b/example/scalalib/web/5-webapp-scalajs/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, scalalib._, scalajslib._
+import mill.*, scalalib.*, scalajslib.*
 
 object `package` extends ScalaModule {
 

--- a/example/scalalib/web/5-webapp-scalajs/src/WebApp.scala
+++ b/example/scalalib/web/5-webapp-scalajs/src/WebApp.scala
@@ -1,5 +1,5 @@
 package webapp
-import scalatags.Text.all._
+import scalatags.Text.all.*
 import scalatags.Text.tags2
 
 object WebApp extends cask.MainRoutes {

--- a/example/scalalib/web/5-webapp-scalajs/test/src/WebAppTests.scala
+++ b/example/scalalib/web/5-webapp-scalajs/test/src/WebAppTests.scala
@@ -1,6 +1,6 @@
 package webapp
 
-import utest._
+import utest.*
 
 object WebAppTests extends TestSuite {
   def withServer[T](example: cask.main.Main)(f: String => T): T = {

--- a/example/scalalib/web/6-webapp-scalajs-shared/build.mill
+++ b/example/scalalib/web/6-webapp-scalajs-shared/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, scalalib._, scalajslib._
+import mill.*, scalalib.*, scalajslib.*
 
 trait AppScalaModule extends ScalaModule {
   def scalaVersion = "3.3.3"

--- a/example/scalalib/web/6-webapp-scalajs-shared/shared/src/Shared.scala
+++ b/example/scalalib/web/6-webapp-scalajs-shared/shared/src/Shared.scala
@@ -1,5 +1,5 @@
 package shared
-import scalatags.Text.all._
+import scalatags.Text.all.*
 import scalatags.Text.tags2
 
 case class Todo(checked: Boolean, text: String)

--- a/example/scalalib/web/6-webapp-scalajs-shared/src/WebApp.scala
+++ b/example/scalalib/web/6-webapp-scalajs-shared/src/WebApp.scala
@@ -1,5 +1,5 @@
 package webapp
-import scalatags.Text.all._
+import scalatags.Text.all.*
 import scalatags.Text.tags2
 import shared.{Shared, Todo}
 

--- a/example/scalalib/web/6-webapp-scalajs-shared/test/src/WebAppTests.scala
+++ b/example/scalalib/web/6-webapp-scalajs-shared/test/src/WebAppTests.scala
@@ -1,6 +1,6 @@
 package webapp
 
-import utest._
+import utest.*
 
 object WebAppTests extends TestSuite {
   def withServer[T](example: cask.main.Main)(f: String => T): T = {

--- a/example/scalalib/web/7-cross-version-platform-publishing/build.mill
+++ b/example/scalalib/web/7-cross-version-platform-publishing/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, scalalib._, scalajslib._, publish._
+import mill.*, scalalib.*, scalajslib.*, publish.*
 
 object foo extends Cross[FooModule]("2.13.14", "3.3.3")
 trait FooModule extends Cross.Module[String] {

--- a/example/scalalib/web/7-cross-version-platform-publishing/foo/bar/src/Bar.scala
+++ b/example/scalalib/web/7-cross-version-platform-publishing/foo/bar/src/Bar.scala
@@ -1,5 +1,5 @@
 package bar
-import scalatags.Text.all._
+import scalatags.Text.all.*
 object Bar {
   val value = p("world", " ", BarVersionSpecific.text())
 }

--- a/example/scalalib/web/7-cross-version-platform-publishing/foo/bar/test/src/BarTests.scala
+++ b/example/scalalib/web/7-cross-version-platform-publishing/foo/bar/test/src/BarTests.scala
@@ -1,5 +1,5 @@
 package bar
-import utest._
+import utest.*
 object BarTests extends TestSuite {
   def tests = Tests {
     test("test") {

--- a/example/scalalib/web/7-cross-version-platform-publishing/foo/qux/src/Qux.scala
+++ b/example/scalalib/web/7-cross-version-platform-publishing/foo/qux/src/Qux.scala
@@ -1,5 +1,5 @@
 package qux
-import scalatags.Text.all._
+import scalatags.Text.all.*
 object Qux {
   def main(args: Array[String]): Unit = {
     println("Bar.value: " + bar.Bar.value)

--- a/example/scalalib/web/7-cross-version-platform-publishing/foo/qux/test/src/QuxTests.scala
+++ b/example/scalalib/web/7-cross-version-platform-publishing/foo/qux/test/src/QuxTests.scala
@@ -1,5 +1,5 @@
 package qux
-import utest._
+import utest.*
 object QuxTests extends TestSuite {
   def tests = Tests {
     test("parseJsonGetKeys") {

--- a/example/scalalib/web/8-cross-platform-version-publishing/bar/src/Bar.scala
+++ b/example/scalalib/web/8-cross-platform-version-publishing/bar/src/Bar.scala
@@ -1,5 +1,5 @@
 package bar
-import scalatags.Text.all._
+import scalatags.Text.all.*
 object Bar {
   val value = p("world", " ", BarVersionSpecific.text())
 }

--- a/example/scalalib/web/8-cross-platform-version-publishing/bar/test/src/BarTests.scala
+++ b/example/scalalib/web/8-cross-platform-version-publishing/bar/test/src/BarTests.scala
@@ -1,5 +1,5 @@
 package bar
-import utest._
+import utest.*
 object BarTests extends TestSuite {
   def tests = Tests {
     test("test") {

--- a/example/scalalib/web/8-cross-platform-version-publishing/build.mill
+++ b/example/scalalib/web/8-cross-platform-version-publishing/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, scalalib._, scalajslib._, publish._
+import mill.*, scalalib.*, scalajslib.*, publish.*
 
 trait Shared extends CrossScalaModule with PlatformScalaModule with PublishModule {
   def publishVersion = "0.0.1"

--- a/example/scalalib/web/8-cross-platform-version-publishing/qux/src/Qux.scala
+++ b/example/scalalib/web/8-cross-platform-version-publishing/qux/src/Qux.scala
@@ -1,5 +1,5 @@
 package qux
-import scalatags.Text.all._
+import scalatags.Text.all.*
 object Qux {
   def main(args: Array[String]): Unit = {
     println("Bar.value: " + bar.Bar.value)

--- a/example/scalalib/web/8-cross-platform-version-publishing/qux/test/src/QuxTests.scala
+++ b/example/scalalib/web/8-cross-platform-version-publishing/qux/test/src/QuxTests.scala
@@ -1,5 +1,5 @@
 package qux
-import utest._
+import utest.*
 object QuxTests extends TestSuite {
   def tests = Tests {
     test("parseJsonGetKeys") {

--- a/example/scalalib/web/9-wasm/build.mill
+++ b/example/scalalib/web/9-wasm/build.mill
@@ -1,6 +1,6 @@
 package build
-import mill._, scalalib._, scalajslib._
-import mill.scalajslib.api._
+import mill.*, scalalib.*, scalajslib.*
+import mill.scalajslib.api.*
 
 object wasm extends ScalaJSModule {
   override def scalaVersion = "3.7.1"

--- a/example/thirdparty/acyclic/build.mill
+++ b/example/thirdparty/acyclic/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, scalalib._, publish._
+import mill.*, scalalib.*, publish.*
 import mill.api.BuildCtx
 
 // acyclic test suite assumes files are on disk at specific paths relative to `os.pwd`.

--- a/example/thirdparty/android-compose-samples/build.mill
+++ b/example/thirdparty/android-compose-samples/build.mill
@@ -1,4 +1,4 @@
-import mill._, androidlib._, kotlinlib._
+import mill.*, androidlib.*, kotlinlib.*
 
 object Versions {
   val kotlinVersion = "2.1.20"

--- a/example/thirdparty/android-endless-tunnel/build.mill
+++ b/example/thirdparty/android-endless-tunnel/build.mill
@@ -3,7 +3,7 @@
 
 package build
 
-import mill._, androidlib._, scalalib._
+import mill.*, androidlib.*, scalalib.*
 
 object androidSdkModule0 extends AndroidSdkModule {
   def buildToolsVersion = "35.0.0"

--- a/example/thirdparty/androidtodo/build.mill
+++ b/example/thirdparty/androidtodo/build.mill
@@ -1,6 +1,6 @@
 package build
 
-import mill._, androidlib._, kotlinlib._
+import mill.*, androidlib.*, kotlinlib.*
 import hilt.AndroidHiltSupport
 
 object Versions {

--- a/example/thirdparty/arrow/build.mill
+++ b/example/thirdparty/arrow/build.mill
@@ -1,6 +1,6 @@
 package build
 
-import mill._, kotlinlib._, kotlinlib.js._
+import mill.*, kotlinlib.*, kotlinlib.js.*
 import mill.scalalib.CoursierModule
 import mill.api.Result
 import mill.testrunner.TestResult

--- a/example/thirdparty/commons-io/build.mill
+++ b/example/thirdparty/commons-io/build.mill
@@ -2,7 +2,7 @@
 //| - com.lihaoyi::mill-contrib-jmh:$MILL_VERSION
 package build
 
-import mill._, javalib._, publish._
+import mill.*, javalib.*, publish.*
 import mill.api.ModuleRef
 import contrib.jmh.JmhModule
 

--- a/example/thirdparty/fansi/build.mill
+++ b/example/thirdparty/fansi/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, scalalib._, scalajslib._, scalanativelib._, publish._
+import mill.*, scalalib.*, scalajslib.*, scalanativelib.*, publish.*
 
 val dottyCommunityBuildVersion = sys.props.get("dottyVersion").toList
 

--- a/example/thirdparty/gatling/build.mill
+++ b/example/thirdparty/gatling/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 object Dependencies {
   // Compile dependencies

--- a/example/thirdparty/jimfs/build.mill
+++ b/example/thirdparty/jimfs/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, javalib._, publish._
+import mill.*, javalib.*, publish.*
 
 def sharedCompileMvnDeps = Task {
   Seq(

--- a/example/thirdparty/mockito/build.mill
+++ b/example/thirdparty/mockito/build.mill
@@ -1,5 +1,5 @@
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 import mill.api.ModuleRef
 
 object libraries {

--- a/example/thirdparty/netty/build.mill
+++ b/example/thirdparty/netty/build.mill
@@ -4,7 +4,7 @@
 //| - ant:ant-optional:1.5.3-1
 package build
 
-import mill._, javalib._
+import mill.*, javalib.*
 import mill.api.BuildCtx
 
 // TODO:

--- a/example/thirdparty/ollama-js/build.mill
+++ b/example/thirdparty/ollama-js/build.mill
@@ -22,9 +22,9 @@
 
 package build
 
-import mill._, javascriptlib._
-import os._
-import ujson._
+import mill.*, javascriptlib.*
+import os.*
+import ujson.*
 
 trait OllamaModule extends TypeScriptModule {
   def moduleName = "ollama"

--- a/website/docs/logo.sc
+++ b/website/docs/logo.sc
@@ -2,7 +2,7 @@ import $ivy.`com.lihaoyi::scalatags:0.6.7`
 import scalatags.Text.implicits._
 import scalatags.Text.svgTags._
 import scalatags.Text.svgAttrs._
-import os._
+import os.*
 
 val svgWidth = 24
 val svgHeight = 24

--- a/website/docs/modules/ROOT/pages/comparisons/why-mill.adoc
+++ b/website/docs/modules/ROOT/pages/comparisons/why-mill.adoc
@@ -33,7 +33,7 @@ dependencies, you can compile, run, or test your project:
 ----
 // build.mill
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 object foo extends JavaModule {
   def mvnDeps = Seq(
@@ -197,7 +197,7 @@ assembly configuration, default compiler flags, and so on.
 [source,scala]
 ----
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 object foo extends JavaModule {
 }
@@ -216,7 +216,7 @@ can depend on other tasks such as `allSourceFiles()` below:
 [source,scala]
 ----
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 object foo extends JavaModule {
   /** Total number of lines in module source files */
@@ -253,7 +253,7 @@ to its existing value `super.resources()`:
 [source,scala]
 ----
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 object foo extends JavaModule {
   /** Total number of lines in module source files */
@@ -304,7 +304,7 @@ Thymeleaf classes available for you to import and use in your build as below:
 //| mvnDeps: ["org.thymeleaf:thymeleaf:3.1.1.RELEASE"]
 package build
 
-import mill._, javalib._
+import mill.*, javalib.*
 import org.thymeleaf.TemplateEngine
 import org.thymeleaf.context.Context
 
@@ -586,7 +586,7 @@ Thus, when you see a Mill build configured as such, with an `object` extending a
 [source,scala]
 ----
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 object foo extends JavaModule {
 }
@@ -620,7 +620,7 @@ and call `super`:
 [source,scala]
 ----
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 object foo extends JavaModule {
   /** Total number of lines in module source files */
@@ -670,7 +670,7 @@ by `object foo` and `object bar` to share the configuration:
 [source,scala]
 ----
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 object foo extends MyJavaModule
 object bar extends MyJavaModule

--- a/website/docs/modules/ROOT/pages/depth/evaluation-model.adoc
+++ b/website/docs/modules/ROOT/pages/depth/evaluation-model.adoc
@@ -15,7 +15,7 @@ as the basis for discussion:
 ----
 // build.mill
 package build
-import mill._, javalib._
+import mill.*, javalib.*
 
 object foo extends JavaModule {}
 

--- a/website/docs/modules/ROOT/pages/extending/thirdparty-plugins.adoc
+++ b/website/docs/modules/ROOT/pages/extending/thirdparty-plugins.adoc
@@ -25,7 +25,7 @@ Project home: https://github.com/carlosedp/mill-aliases
 ----
 //| mvnDeps: ["com.carlosedp::mill-aliases::0.2.1"]
 
-import mill._, scalalib._
+import mill.*, scalalib.*
 import com.carlosedp.aliases._
 
 object foo extends ScalaModule {
@@ -84,7 +84,7 @@ Project home: https://github.com/lefou/mill-aspectj
 ----
 //| mvnDeps: ["de.tototec::de.tobiasroeser.mill.aspectj_mill0.9:0.3.1-12-89db01"]
 
-import mill._
+import mill.*
 import mill.scalalib._
 import mill.api._
 
@@ -243,7 +243,7 @@ parameters for your application using the `DockerNativeConfig` trait in the
 ----
 //| mvnDeps: ["com.carlosedp::mill-docker-nativeimage::0.6.0"]
 
-import mill._, mill.scalalib._, mill.scalalib.scalafmt._
+import mill.*, mill.scalalib._, mill.scalalib.scalafmt._
 import com.carlosedp.milldockernative.DockerNative
 
 object hello extends ScalaModule with DockerNative {
@@ -482,7 +482,7 @@ We assume, you have a mill plugin named `mill-demo`
 .`build.mill`
 [source,scala]
 ----
-import mill._, mill.scalalib._
+import mill.*, mill.scalalib._
 
 object demo extends ScalaModule with PublishModule {
   // ...
@@ -562,7 +562,7 @@ JBake home: https://jbake.org
 ----
 //| mvnDeps: ["de.tototec::de.tobiasroeser.mill.jbake:0.1.0"]
 
-import mill._
+import mill.*
 import de.tobiasroeser.mill.jbake._
 
 object site extends JBakeModule {
@@ -684,7 +684,7 @@ And set the previous artifacts you want to check binary compatibility.
 ----
 //| mvnDeps: ["com.github.lolgab::mill-mima_mill0.9:0.0.2"]
 
-import mill._, scalalib._
+import mill.*, scalalib.*
 import com.github.lolgab.mill.mima._
 
 object main extends ScalaModule with Mima {
@@ -794,7 +794,7 @@ Project home: https://github.com/lefou/mill-osgi
 ----
 //| mvnDeps: ["de.tototec::de.tobiasroeser.mill.osgi:0.0.5"]
 
-import mill._, mill.scalalib._
+import mill.*, mill.scalalib._
 import de.tobiasroeser.mill.osgi._
 
 object project extends ScalaModule with OsgiBundleModule {
@@ -849,7 +849,7 @@ set-up a `package.json` file with your TypeScript dependencies.
 ----
 //| mvnDeps: ["com.github.lolgab::mill-scalablytyped::0.0.2"]
 
-import mill._, scalalib._
+import mill.*, scalalib.*
 import com.github.lolgab.mill.scalablytyped._
 
 object main extends ScalaJSModule with ScalablyTyped {
@@ -993,7 +993,7 @@ Project home: https://github.com/lefou/mill-spring-boot
 
 [source,scala,subs="attributes,verbatim"]
 ----
-import mill._
+import mill.*
 import mill.scalalib._
 import de.tobiasroeser.mill.spring.boot.SpringBootModule
 
@@ -1019,7 +1019,7 @@ Project home: https://github.com/sake92/squery
 ----
 //| mvnDeps: ["ba.sake::mill-squery-generator_mill0.11:0.6.2"]
 
-import mill._
+import mill.*
 import mill.scalalib._
 import ba.sake.squery.generator._
 import ba.sake.squery.generator.mill.SqueryGeneratorModule
@@ -1080,7 +1080,7 @@ When used with its defaults, the outcome is identical to the version scheme that
 ----
 //| mvnDeps: ["de.tototec::de.tobiasroeser.mill.vcs.version::0.1.2"]
 
-import mill._
+import mill.*
 import mill.scalalib._
 import de.tobiasroeser.mill.vcs.version.VcsVersion
 

--- a/website/docs/modules/ROOT/pages/fundamentals/modules.adoc
+++ b/website/docs/modules/ROOT/pages/fundamentals/modules.adoc
@@ -40,7 +40,7 @@ shared between all builds which use that library:
 [source,scala]
 ----
 package foo
-import mill._
+import mill.*
 
 object Bar extends mill.api.ExternalModule {
   def baz = Task { 1 }

--- a/website/docs/modules/ROOT/pages/scalalib/module-config.adoc
+++ b/website/docs/modules/ROOT/pages/scalalib/module-config.adoc
@@ -65,7 +65,7 @@ For example, you may want to inherit all of your regular `scalacOptions` but dis
 .Example: Using `consoleScalacOptions` to disable fatal warnings
 [source,scala,subs="attributes,verbatim"]
 ----
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 object foo extends ScalaModule {
   def consoleScalacOptions = scalacOptions().filterNot(o => o == "-Xfatal-warnings")
@@ -80,7 +80,7 @@ In order to start the repl, you may have to specify a different available Ammoni
 .Example: Overriding `ammoniteVersion` to select a release compatible to the `scalaVersion`
 [source,scala,subs="attributes,verbatim"]
 ----
-import mill._. scalalib._
+import mill.*. scalalib._
 
 object foo extends ScalaModule {
   def scalaVersion = "2.12.6"
@@ -111,7 +111,7 @@ If for any reason you want to disable incremental compilation for a module, you 
 .`build.mill`
 [source,scala,subs="attributes,verbatim"]
 ----
-import mill._, scalalib._
+import mill.*, scalalib.*
 
 object foo extends ScalaModule {
   def zincIncrementalCompilation = false


### PR DESCRIPTION
This is the newer Scala 3 syntax and would look more familiar to people coming from other languages