### PR TITLE
Repro uTest line number problem

### DIFF
--- a/libs/jvmlib/test/src/mill/scalalib/spotless/SpotlessTests.scala
+++ b/libs/jvmlib/test/src/mill/scalalib/spotless/SpotlessTests.scala
@@ -98,7 +98,7 @@ object SpotlessTests extends TestSuite {
         var header = os.read.lines.stream(moduleDir / "src/LicenseHeader").head
         assert(
           log.contains("formatting src/LicenseHeader"),
-          header == "// GPL"
+          header == "// GPL "
         )
 
         os.write.over(moduleDir / "LICENSE", "// MIT")


### PR DESCRIPTION
On this PR, ` ./mill libs.jvmlib.test.testForked mill.scalalib.spotless.SpotlessTests.invalidation` gives the wrong line number in the stack trace: 35, when it should be 101

CC @pawelsadlo if you could take a look