### PR TITLE
Android: added `tools` sdk package to install automatically

### DIFF
--- a/.github/actions/setup-android/action.yml
+++ b/.github/actions/setup-android/action.yml
@@ -11,7 +11,7 @@ runs:
       with:
         log-accepted-android-sdk-licenses: false
         cmdline-tools-version: 11076708
-        packages: tools cmdline-tools;latest platform-tools emulator system-images;android-35;google_apis_playstore;x86_64
+        packages: cmdline-tools;latest platform-tools emulator system-images;android-35;google_apis_playstore;x86_64
 
     - name: Enable KVM group perms
       run: |

--- a/example/androidlib/java/5-R8/build.mill
+++ b/example/androidlib/java/5-R8/build.mill
@@ -22,11 +22,6 @@ import mill.*, androidlib.*, scalalib.*
 
 object androidSdkModule0 extends AndroidSdkModule { // <1>
   def buildToolsVersion = "35.0.0"
-  override def sdkPackages = Task {
-    super.sdkPackages() ++ Seq(
-      "tools"
-    )
-  }
 }
 
 object app extends AndroidR8AppModule { // <2>

--- a/example/androidlib/java/5-R8/build.mill
+++ b/example/androidlib/java/5-R8/build.mill
@@ -22,6 +22,11 @@ import mill.*, androidlib.*, scalalib.*
 
 object androidSdkModule0 extends AndroidSdkModule { // <1>
   def buildToolsVersion = "35.0.0"
+  override def sdkPackages = Task {
+    super.sdkPackages() ++ Seq(
+      "tools"
+    )
+  }
 }
 
 object app extends AndroidR8AppModule { // <2>

--- a/libs/androidlib/src/mill/androidlib/AndroidSdkModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidSdkModule.scala
@@ -285,7 +285,7 @@ trait AndroidSdkModule extends Module {
       s"build-tools;${buildToolsVersion()}",
       s"platforms;${platformsVersion()}",
       "cmdline-tools;latest",
-      "tools;latest"
+      "tools"
     )
     // sdkmanager executable and state of the installed package is a shared resource, which can be accessed
     // from the different Android SDK modules.

--- a/libs/androidlib/src/mill/androidlib/AndroidSdkModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidSdkModule.scala
@@ -284,7 +284,8 @@ trait AndroidSdkModule extends Module {
       "platform-tools",
       s"build-tools;${buildToolsVersion()}",
       s"platforms;${platformsVersion()}",
-      "cmdline-tools;latest"
+      "cmdline-tools;latest",
+      "tools;latest"
     )
     // sdkmanager executable and state of the installed package is a shared resource, which can be accessed
     // from the different Android SDK modules.

--- a/libs/androidlib/src/mill/androidlib/AndroidSdkModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidSdkModule.scala
@@ -269,15 +269,6 @@ trait AndroidSdkModule extends Module {
    * For more details on the `sdkmanager` tool, refer to:
    * [[https://developer.android.com/tools/sdkmanager sdkmanager Documentation]]
    */
-  protected def sdkPackages = Task {
-    Seq(
-      "platform-tools",
-      s"build-tools;${buildToolsVersion()}",
-      s"platforms;${platformsVersion()}",
-      "cmdline-tools;latest"
-    )
-  }
-
   def installAndroidSdkComponents: T[Unit] = Task {
     val sdkPath0 = sdkPath()
     val sdkManagerPath = findLatestSdkManager(sdkPath0.path) match {
@@ -288,10 +279,17 @@ trait AndroidSdkModule extends Module {
             " for more details."
         )
     }
+
+    val packages = Seq(
+      "platform-tools",
+      s"build-tools;${buildToolsVersion()}",
+      s"platforms;${platformsVersion()}",
+      "cmdline-tools;latest"
+    )
     // sdkmanager executable and state of the installed package is a shared resource, which can be accessed
     // from the different Android SDK modules.
     AndroidSdkLock.synchronized {
-      val missingPackages = sdkPackages().filter(p => !isPackageInstalled(sdkPath0.path, p))
+      val missingPackages = packages.filter(p => !isPackageInstalled(sdkPath0.path, p))
       val packagesWithoutLicense = missingPackages
         .map(p => (p, isLicenseAccepted(sdkPath0.path, remoteReposInfo()().path, p)))
         .filter(!_._2)

--- a/libs/androidlib/src/mill/androidlib/AndroidSdkModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidSdkModule.scala
@@ -269,6 +269,15 @@ trait AndroidSdkModule extends Module {
    * For more details on the `sdkmanager` tool, refer to:
    * [[https://developer.android.com/tools/sdkmanager sdkmanager Documentation]]
    */
+  protected def sdkPackages = Task {
+    Seq(
+      "platform-tools",
+      s"build-tools;${buildToolsVersion()}",
+      s"platforms;${platformsVersion()}",
+      "cmdline-tools;latest"
+    )
+  }
+
   def installAndroidSdkComponents: T[Unit] = Task {
     val sdkPath0 = sdkPath()
     val sdkManagerPath = findLatestSdkManager(sdkPath0.path) match {
@@ -279,17 +288,10 @@ trait AndroidSdkModule extends Module {
             " for more details."
         )
     }
-
-    val packages = Seq(
-      "platform-tools",
-      s"build-tools;${buildToolsVersion()}",
-      s"platforms;${platformsVersion()}",
-      "cmdline-tools;latest"
-    )
     // sdkmanager executable and state of the installed package is a shared resource, which can be accessed
     // from the different Android SDK modules.
     AndroidSdkLock.synchronized {
-      val missingPackages = packages.filter(p => !isPackageInstalled(sdkPath0.path, p))
+      val missingPackages = sdkPackages().filter(p => !isPackageInstalled(sdkPath0.path, p))
       val packagesWithoutLicense = missingPackages
         .map(p => (p, isLicenseAccepted(sdkPath0.path, remoteReposInfo()().path, p)))
         .filter(!_._2)


### PR DESCRIPTION
### Motivation
Running the android tests on a vanilla setup lead to the error of not having `proguard` and provided `proguard` default configurations which the `r8` third party examples rely on.

### Solution
Added `tools` to the sdk packages that get installed automatically and removed it from the setup android action

### Thoughts for the Future
I think the future goal could be for mill to setup everything (with automatic license accept on CI) and we can slowly remove the setup android steps on the CI.
For example `cmdline-tools`'s manual installation seems necessary for now since sdkmanager comes with it. 