### PR TITLE
Fix `-D` property passing with graal native launcher

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -277,7 +277,7 @@ jobs:
             install-sbt: true
 
           - java-version: 17
-            millargs: "'integration.{feature,failure}.__.packaged.nodaemon'"
+            millargs: "'integration.{feature,failure}.__.native.nodaemon'"
             install-sbt: false
 
           - java-version: 24 # Run this with Mill native launcher as a smoketest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -222,7 +222,7 @@ jobs:
             install-sbt: false
 
           - java-version: 11
-            millargs: "'integration.{failure,feature,ide}.__.packaged.daemon'"
+            millargs: "'integration.{failure,feature,ide}.__.native.daemon'"
             install-android-sdk: false
             install-sbt: false
 

--- a/runner/client/src/mill/client/ClientUtil.java
+++ b/runner/client/src/mill/client/ClientUtil.java
@@ -22,6 +22,27 @@ public class ClientUtil {
 
   private static Charset utf8 = Charset.forName("UTF-8");
 
+  /**
+   * When using Graal Native Image, the launcher receives any `-D` properties
+   * as system properties rather than command-line flags. Thus we try to identify
+   * any system properties that are set by the user so we can propagate them to
+   * the Mill daemon process appropriately
+   */
+  public static Map<String, String> getUserSetProperties() {
+    java.util.Set<String> bannedPrefixes = java.util.Set.of(
+      "path", "line", "native", "sun", "os", "java", "file", "jdk", "user"
+    );
+
+    java.util.Properties props = System.getProperties();
+    Map<String, String> propsMap = new java.util.HashMap<>();
+    for (String key : props.stringPropertyNames()) {
+      if (!bannedPrefixes.contains(key.split("\\.")[0])) {
+        propsMap.put(key, props.getProperty(key));
+      }
+    }
+    return propsMap;
+  }
+
   public static String[] parseArgs(InputStream argStream) throws IOException {
     int argsLength = readInt(argStream);
     String[] args = new String[argsLength];

--- a/runner/client/src/mill/client/ClientUtil.java
+++ b/runner/client/src/mill/client/ClientUtil.java
@@ -29,9 +29,8 @@ public class ClientUtil {
    * the Mill daemon process appropriately
    */
   public static Map<String, String> getUserSetProperties() {
-    java.util.Set<String> bannedPrefixes = java.util.Set.of(
-      "path", "line", "native", "sun", "os", "java", "file", "jdk", "user"
-    );
+    java.util.Set<String> bannedPrefixes =
+        java.util.Set.of("path", "line", "native", "sun", "os", "java", "file", "jdk", "user");
 
     java.util.Properties props = System.getProperties();
     Map<String, String> propsMap = new java.util.HashMap<>();

--- a/runner/client/src/mill/client/ServerLauncher.java
+++ b/runner/client/src/mill/client/ServerLauncher.java
@@ -187,6 +187,7 @@ public abstract class ServerLauncher {
     ClientUtil.writeString(in, javaHome);
     ClientUtil.writeArgs(args, in);
     ClientUtil.writeMap(env, in);
+    ClientUtil.writeMap(ClientUtil.getUserSetProperties(), in);
     ProxyStream.Pumper outPumper = new ProxyStream.Pumper(outErr, stdout, stderr);
     InputPumper inPump = new InputPumper(() -> stdin, () -> in, true);
     PumperThread outPumperThread = new PumperThread(outPumper, "outPump");

--- a/runner/launcher/src/mill/launcher/MillLauncherMain.java
+++ b/runner/launcher/src/mill/launcher/MillLauncherMain.java
@@ -33,7 +33,7 @@ public class MillLauncherMain {
 
     if (runNoServer) {
       // start in no-server mode
-      System.exit(MillProcessLauncher.launchMillNoServer(args));
+      System.exit(MillProcessLauncher.launchMillNoDaemon(args));
     } else
       try {
         // start in client-server mode
@@ -51,7 +51,7 @@ public class MillLauncherMain {
                 null,
                 -1) {
               public Process initServer(Path daemonDir, Locks locks) throws Exception {
-                return MillProcessLauncher.launchMillServer(daemonDir);
+                return MillProcessLauncher.launchMillDaemon(daemonDir);
               }
 
               public void preparedaemonDir(Path daemonDir) throws Exception {

--- a/runner/launcher/src/mill/launcher/MillProcessLauncher.java
+++ b/runner/launcher/src/mill/launcher/MillProcessLauncher.java
@@ -22,12 +22,14 @@ import mill.constants.EnvVars;
 
 public class MillProcessLauncher {
 
-  static int launchMillNoServer(String[] args) throws Exception {
+  static int launchMillNoDaemon(String[] args) throws Exception {
     final String sig = String.format("%08x", UUID.randomUUID().hashCode());
     final Path processDir = Paths.get(".").resolve(out).resolve(millNoDaemon).resolve(sig);
 
     final List<String> l = new ArrayList<>();
     l.addAll(millLaunchJvmCommand());
+    Map<String, String> propsMap = ClientUtil.getUserSetProperties();
+    for(String key: propsMap.keySet()) l.add("-D" + key + "=" + propsMap.get(key));
     l.add("mill.daemon.MillNoDaemonMain");
     l.add(processDir.toAbsolutePath().toString());
     l.addAll(millOpts());
@@ -56,7 +58,7 @@ public class MillProcessLauncher {
     }
   }
 
-  static Process launchMillServer(Path daemonDir) throws Exception {
+  static Process launchMillDaemon(Path daemonDir) throws Exception {
     List<String> l = new ArrayList<>();
     l.addAll(millLaunchJvmCommand());
     l.add("mill.daemon.MillDaemonMain");

--- a/runner/launcher/src/mill/launcher/MillProcessLauncher.java
+++ b/runner/launcher/src/mill/launcher/MillProcessLauncher.java
@@ -29,7 +29,7 @@ public class MillProcessLauncher {
     final List<String> l = new ArrayList<>();
     l.addAll(millLaunchJvmCommand());
     Map<String, String> propsMap = ClientUtil.getUserSetProperties();
-    for(String key: propsMap.keySet()) l.add("-D" + key + "=" + propsMap.get(key));
+    for (String key : propsMap.keySet()) l.add("-D" + key + "=" + propsMap.get(key));
     l.add("mill.daemon.MillNoDaemonMain");
     l.add(processDir.toAbsolutePath().toString());
     l.addAll(millOpts());

--- a/runner/server/src/mill/server/Server.scala
+++ b/runner/server/src/mill/server/Server.scala
@@ -217,7 +217,8 @@ abstract class Server[T](
       val env = ClientUtil.parseMap(socketIn)
       serverLog("args " + upickle.default.write(args))
       serverLog("env " + upickle.default.write(env.asScala))
-//      val userSpecifiedProperties = ClientUtil.parseMap(socketIn)
+      val userSpecifiedProperties = ClientUtil.parseMap(socketIn)
+      serverLog("props " + upickle.default.write(userSpecifiedProperties.asScala))
       // Proxy the input stream through a pair of Piped**putStream via a pumper,
       // as the `UnixDomainSocketInputStream` we get directly from the socket does
       // not properly implement `available(): Int` and thus messes up polling logic
@@ -269,7 +270,7 @@ abstract class Server[T](
               new SystemStreams(stdout, stderr, proxiedSocketInput),
               env.asScala.toMap,
               idle = _,
-              Map(),
+              userSpecifiedProperties.asScala.toMap,
               initialSystemProperties,
               systemExit = exitCode => {
                 writeExitCode(exitCode)

--- a/runner/server/test/src/mill/server/ClientServerTests.scala
+++ b/runner/server/test/src/mill/server/ClientServerTests.scala
@@ -64,9 +64,6 @@ object ClientServerTests extends TestSuite {
         env.toSeq.sortBy(_._1).foreach {
           case (key, value) => streams.out.println(s"$key=$value")
         }
-        // systemProperties.toSeq.sortBy(_._1).foreach {
-        //   case (key, value) => streams.out.println(s"$key=$value")
-        // }
         if (args.nonEmpty) {
           streams.err.println(str.toUpperCase + args(0))
         }

--- a/runner/server/test/src/mill/server/ClientServerTests.scala
+++ b/runner/server/test/src/mill/server/ClientServerTests.scala
@@ -64,9 +64,9 @@ object ClientServerTests extends TestSuite {
         env.toSeq.sortBy(_._1).foreach {
           case (key, value) => streams.out.println(s"$key=$value")
         }
-        systemProperties.toSeq.sortBy(_._1).foreach {
-          case (key, value) => streams.out.println(s"$key=$value")
-        }
+        // systemProperties.toSeq.sortBy(_._1).foreach {
+        //   case (key, value) => streams.out.println(s"$key=$value")
+        // }
         if (args.nonEmpty) {
           streams.err.println(str.toUpperCase + args(0))
         }


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/5209

When using Graal Native Image, the launcher receives any `-D` properties as system properties rather than command-line flags. Thus we try to identify any system properties that are set by the user so we can propagate them to the Mill daemon process appropriately.

Testing this in CI is kind of annoying because there are 3 different dataflows that properties can go through: 

1. JVM launcher: the properties get passed through application-level flags and handled by mainargs
2. Native launcher daemon: the properties get picked up as system-props in the launcher, and passed over the socket at the start of a new connection
3. Native launcher nodaemon: the properties get picked up as system-props in the launcher, and passed as `-D` JVM flags to the background process


So:

- I just manually ran `./mill -j1 'integration.feature[mill-jvm-property].__.testForked'` to exercise all three code paths now. These pass on this PR, but the `native.{daemon,nodaemon}` versions fail on `main`
- `example.fundamentals.tasks[4-inputs]` runs in `.local.daemon` mode in Linux CI, exercising code path (1)
- I tweaked the `'integration.{failure,feature,ide}.__.packaged.daemon'` in our Linux CI to `'integration.{failure,feature,ide}.__.native.daemon'`, to exercise code path (2)
- I tweaked the `integration.{feature,failure}.__.packaged.nodaemon` in our Windows CI to `'integration.{feature,failure}.__.native.nodaemon'` exercise code path (3)