### PR TITLE
Add integration test ensuring `-D` property passing works (backport #5212)

### DIFF
--- a/integration/feature/mill-jvm-property/resources/build.mill
+++ b/integration/feature/mill-jvm-property/resources/build.mill
@@ -1,0 +1,6 @@
+package build
+import mill._
+
+def printSysProp(propName: String) = Task.Command {
+  println(sys.props(propName))
+}

--- a/integration/feature/mill-jvm-property/src/MillJvmPropertyTests.scala
+++ b/integration/feature/mill-jvm-property/src/MillJvmPropertyTests.scala
@@ -1,0 +1,28 @@
+package mill.integration
+
+import mill.constants.Util
+import mill.testkit.UtestIntegrationTestSuite
+import utest._
+
+object MillJvmPropertyTests extends UtestIntegrationTestSuite {
+  val tests: Tests = Tests {
+    test("simple") - integrationTest { tester =>
+      import tester._
+      // Property not set
+      val res1 = eval(("printSysProp", "--propName", "foo-property"))
+      assert(res1.out == "null")
+
+      // Property newly set
+      val res2 = eval(("-Dfoo-property=hello-world", "printSysProp", "--propName", "foo-property"))
+      assert(res2.out == "hello-world")
+
+      // Existing property modified
+      val res3 = eval(("-Dfoo-property=i-am-cow", "printSysProp", "--propName", "foo-property"))
+      assert(res3.out == "i-am-cow")
+
+      // Existing property removed
+      val res4 = eval(("printSysProp", "--propName", "foo-property"))
+      assert(res4.out == "null")
+    }
+  }
+}

--- a/integration/feature/mill-jvm-property/src/MillJvmPropertyTests.scala
+++ b/integration/feature/mill-jvm-property/src/MillJvmPropertyTests.scala
@@ -1,6 +1,5 @@
 package mill.integration
 
-import mill.constants.Util
 import mill.testkit.UtestIntegrationTestSuite
 import utest._
 


### PR DESCRIPTION
Integration test to reproduce https://github.com/com-lihaoyi/mill/issues/5416

Backport of https://github.com/com-lihaoyi/mill/pull/5212

It shows, that current `0.12.x` branch is not passing the test for `native` builds.

```console
> mill -j1 integration.feature[mill-jvm-property].native.__.test
...
[5956/5974] integration.feature[mill-jvm-property].native.fork.test
[5956] -------------------------------- Running Tests --------------------------------
[5956] Copying integration test sources from /home/lefou/work/opensource/mill-0.12/integration/feature/mill-jvm-property/resources to /home/lefou/work/opensource/mill-0.12/out/integration/feature/mill-jvm-property/native/fork/test.dest/sandbox/run-1
[5956] X mill.integration.MillJvmPropertyTests.simple 12660ms 
[5956]   utest.AssertionError: assert(res2.out == "hello-world")
[5956]   res2: mill.testkit.IntegrationTester.EvalResult = EvalResult(true,null,)
[5956]     utest.asserts.Asserts$.assertImpl(Asserts.scala:30)
[5956]     mill.integration.MillJvmPropertyTests$.$anonfun$tests$3(MillJvmPropertyTests.scala:16)
[5956]     mill.integration.MillJvmPropertyTests$.$anonfun$tests$3$adapted(MillJvmPropertyTests.scala:8)
[5956]     mill.testkit.IntegrationTestSuite.integrationTest(IntegrationTestSuite.scala:20)
[5956]     mill.testkit.IntegrationTestSuite.integrationTest$(IntegrationTestSuite.scala:12)
[5956]     mill.testkit.UtestIntegrationTestSuite.integrationTest(UtestIntegrationTestSuite.scala:7)
[5956]     mill.integration.MillJvmPropertyTests$.$anonfun$tests$2(MillJvmPropertyTests.scala:8)
[5956] Tests: 1, Passed: 0, Failed: 1

```
