### PR TITLE
Android: remove `ui-tooling` from updaetable deps

### DIFF
--- a/libs/androidlib/package.mill
+++ b/libs/androidlib/package.mill
@@ -42,8 +42,11 @@ object `package` extends MillPublishScalaModule with BuildInfo {
       "Version of ComposePreviewRenderer"
     ),
     BuildInfo.Value("uiToolingVersion", Deps.AndroidDeps.uiTooling.version, "Version of uiTooling"),
-    BuildInfo.Value("screenshotValidationJunitEngineVersion", Deps.AndroidDeps.screenshotValidationJunitEngine.version, "Version of screenshotValidationJunitEngine"),
-
+    BuildInfo.Value(
+      "screenshotValidationJunitEngineVersion",
+      Deps.AndroidDeps.screenshotValidationJunitEngine.version,
+      "Version of screenshotValidationJunitEngine"
+    )
   )
 
   trait MillAndroidModule extends MillPublishScalaModule {

--- a/libs/androidlib/package.mill
+++ b/libs/androidlib/package.mill
@@ -41,7 +41,9 @@ object `package` extends MillPublishScalaModule with BuildInfo {
       Deps.AndroidDeps.composePreviewRenderer.version,
       "Version of ComposePreviewRenderer"
     ),
-    BuildInfo.Value("uiToolingVersion", Deps.AndroidDeps.uiTooling.version, "Version of uiTooling")
+    BuildInfo.Value("uiToolingVersion", Deps.AndroidDeps.uiTooling.version, "Version of uiTooling"),
+    BuildInfo.Value("screenshotValidationJunitEngineVersion", Deps.AndroidDeps.screenshotValidationJunitEngine.version, "Version of screenshotValidationJunitEngine"),
+
   )
 
   trait MillAndroidModule extends MillPublishScalaModule {

--- a/libs/androidlib/src/mill/androidlib/AndroidAppKotlinModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppKotlinModule.scala
@@ -83,6 +83,10 @@ trait AndroidAppKotlinModule extends AndroidKotlinModule with AndroidAppModule {
       Versions.composePreviewRendererVersion
     }
 
+    def screenshotValidationJunitEngineVersion: T[String] = Task {
+      Versions.screenshotValidationJunitEngineVersion
+    }
+
     override def moduleDeps: Seq[JavaModule] = Seq(outer)
 
     override final def kotlinVersion = outer.kotlinVersion()
@@ -302,7 +306,7 @@ trait AndroidAppKotlinModule extends AndroidKotlinModule with AndroidAppModule {
     def androidPreviewScreenshotTestEngineClasspath: T[Seq[PathRef]] = Task {
       defaultResolver().classpath(
         Seq(
-          mvn"com.android.tools.screenshot:screenshot-validation-junit-engine:0.0.1-alpha09"
+          mvn"com.android.tools.screenshot:screenshot-validation-junit-engine:${screenshotValidationJunitEngineVersion()}"
         )
       )
     }

--- a/mill-build/src/millbuild/Deps.scala
+++ b/mill-build/src/millbuild/Deps.scala
@@ -294,14 +294,18 @@ object Deps {
     val composePreviewRenderer =
       mvn"com.android.tools.compose:compose-preview-renderer-model:0.0.1-alpha09"
     val uiTooling = mvn"androidx.compose.ui:ui:1.7.6"
+    val screenshotValidationJunitEngine = mvn"com.android.tools.screenshot:screenshot-validation-junit-engine:0.0.1-alpha09"
 
+    // TODO: uiTooling is needed for screenshot tests
+    // so we handle it diferrently.
+    // Removed it from updaetable for now
     def updateable = Seq(
       manifestMerger,
       bundleTool,
       layoutLibRenderer,
       layoutLibRuntime,
       composePreviewRenderer,
-      uiTooling
+      screenshotValidationJunitEngine
     )
 
   }

--- a/mill-build/src/millbuild/Deps.scala
+++ b/mill-build/src/millbuild/Deps.scala
@@ -294,7 +294,8 @@ object Deps {
     val composePreviewRenderer =
       mvn"com.android.tools.compose:compose-preview-renderer-model:0.0.1-alpha09"
     val uiTooling = mvn"androidx.compose.ui:ui:1.7.6"
-    val screenshotValidationJunitEngine = mvn"com.android.tools.screenshot:screenshot-validation-junit-engine:0.0.1-alpha09"
+    val screenshotValidationJunitEngine =
+      mvn"com.android.tools.screenshot:screenshot-validation-junit-engine:0.0.1-alpha09"
 
     // TODO: uiTooling is needed for screenshot tests
     // so we handle it diferrently.


### PR DESCRIPTION
Should resolve https://github.com/com-lihaoyi/mill/issues/5426 where ui-tooling was having dependancy conflicts.
Ui-tooling is a special case and will be handled differently, so we remove it from the `updaetable` packages sequence.
In addition, we extracted `screenshotValidationJunitEngine`s hardcoded value that remained in androidlib.