### PR TITLE
Park cursor after the multiline prompt rather than at the start

### DIFF
--- a/core/internal/src/mill/internal/PromptLogger.scala
+++ b/core/internal/src/mill/internal/PromptLogger.scala
@@ -277,14 +277,15 @@ private[mill] object PromptLogger {
     }
 
     def moveUp() = {
+      mill.constants.DebugLog.println("lastPromptHeight " + lastPromptHeight)
       if (lastPromptHeight != 0) {
         systemStreams0.err.write((AnsiNav.left(9999) + AnsiNav.up(lastPromptHeight)).getBytes)
       }
     }
 
     def refreshPrompt(): Unit = synchronizer.synchronized {
-      moveUp()
-      writeCurrentPrompt()
+//      moveUp()
+//      writeCurrentPrompt()
     }
 
     object pumper extends ProxyStream.Pumper(
@@ -318,6 +319,7 @@ private[mill] object PromptLogger {
         ) {
           synchronizer.synchronized {
             writeCurrentPrompt()
+            systemStreams0.err.flush()
           }
         }
       }
@@ -327,6 +329,7 @@ private[mill] object PromptLogger {
           lastCharWritten = buf(end - 1).toChar
           synchronizer.synchronized {
             moveUp()
+            systemStreams0.err.flush()
             lastPromptHeight = 0
           }
           // Clear each line as they are drawn, rather than relying on clearing
@@ -338,6 +341,7 @@ private[mill] object PromptLogger {
               .replaceAll("(\r\n|\n|\t)", AnsiNav.clearLine(0) + "$1")
               .getBytes
           )
+          dest.write(AnsiNav.clearScreen(0).getBytes)
         } else {
           dest.write(buf, 0, end)
         }

--- a/core/internal/src/mill/internal/PromptLogger.scala
+++ b/core/internal/src/mill/internal/PromptLogger.scala
@@ -321,7 +321,6 @@ private[mill] object PromptLogger {
         }
       }
 
-
       override def write(dest: OutputStream, buf: Array[Byte], end: Int): Unit = {
         lastCharWritten = buf(end - 1).toChar
         val clearLines = enableTicker && interactive()
@@ -330,7 +329,6 @@ private[mill] object PromptLogger {
           moveUp()
           lastPromptHeight = 0
         }
-
 
         if (clearLines) {
           // Clear each line as they are drawn, rather than relying on clearing

--- a/core/internal/src/mill/internal/PromptLogger.scala
+++ b/core/internal/src/mill/internal/PromptLogger.scala
@@ -277,15 +277,14 @@ private[mill] object PromptLogger {
     }
 
     def moveUp() = {
-      mill.constants.DebugLog.println("lastPromptHeight " + lastPromptHeight)
       if (lastPromptHeight != 0) {
         systemStreams0.err.write((AnsiNav.left(9999) + AnsiNav.up(lastPromptHeight)).getBytes)
       }
     }
 
     def refreshPrompt(): Unit = synchronizer.synchronized {
-//      moveUp()
-//      writeCurrentPrompt()
+      moveUp()
+      writeCurrentPrompt()
     }
 
     object pumper extends ProxyStream.Pumper(
@@ -318,7 +317,7 @@ private[mill] object PromptLogger {
           lastCharWritten == '\n'
         ) {
           synchronizer.synchronized {
-            writeCurrentPrompt()
+            refreshPrompt()
             systemStreams0.err.flush()
           }
         }
@@ -329,7 +328,6 @@ private[mill] object PromptLogger {
           lastCharWritten = buf(end - 1).toChar
           synchronizer.synchronized {
             moveUp()
-            systemStreams0.err.flush()
             lastPromptHeight = 0
           }
           // Clear each line as they are drawn, rather than relying on clearing
@@ -341,7 +339,6 @@ private[mill] object PromptLogger {
               .replaceAll("(\r\n|\n|\t)", AnsiNav.clearLine(0) + "$1")
               .getBytes
           )
-          dest.write(AnsiNav.clearScreen(0).getBytes)
         } else {
           dest.write(buf, 0, end)
         }

--- a/core/internal/src/mill/internal/PromptLogger.scala
+++ b/core/internal/src/mill/internal/PromptLogger.scala
@@ -317,7 +317,9 @@ private[mill] object PromptLogger {
           lastCharWritten == '\n'
         ) {
           synchronizer.synchronized {
-            refreshPrompt()
+            // `preRead` may be run more than once per `write` call, and so we
+            // only write out the current prompt if it has not already been written
+            if (lastPromptHeight == 0) writeCurrentPrompt()
             systemStreams0.err.flush()
           }
         }

--- a/core/internal/src/mill/internal/PromptLoggerUtil.scala
+++ b/core/internal/src/mill/internal/PromptLoggerUtil.scala
@@ -148,7 +148,7 @@ private object PromptLoggerUtil {
   // according to whether it is interactive or ending
   def renderPromptWrapped(
       currentPromptLines: Seq[String],
-      interactive: Boolean,
+      interactive: Boolean
   ): String = {
     if (!interactive) currentPromptLines.mkString("\n") + "\n"
     else currentPromptLines.map(_ + AnsiNav.clearLine(0)).mkString("\n") + "\n"

--- a/core/internal/src/mill/internal/PromptLoggerUtil.scala
+++ b/core/internal/src/mill/internal/PromptLoggerUtil.scala
@@ -149,21 +149,9 @@ private object PromptLoggerUtil {
   def renderPromptWrapped(
       currentPromptLines: Seq[String],
       interactive: Boolean,
-      ending: Boolean
   ): String = {
     if (!interactive) currentPromptLines.mkString("\n") + "\n"
-    else {
-      // For the ending prompt, leave the cursor at the bottom on a new line rather than
-      // scrolling back left/up. We do not want further output to overwrite the header as
-      // it will no longer re-render
-      val backUp =
-        if (ending) "\n"
-        else AnsiNav.left(9999) + AnsiNav.up(currentPromptLines.length - 1)
-
-      currentPromptLines.map(_ + AnsiNav.clearLine(0)).mkString("\n") +
-        AnsiNav.clearScreen(0) +
-        backUp
-    }
+    else currentPromptLines.map(_ + AnsiNav.clearLine(0)).mkString("\n") + "\n"
   }
 
   def renderHeader(

--- a/core/internal/test/src/mill/internal/PromptLoggerTests.scala
+++ b/core/internal/test/src/mill/internal/PromptLoggerTests.scala
@@ -108,7 +108,8 @@ object PromptLoggerTests extends TestSuite {
       promptLogger.prompt.setPromptHeaderPrefix("123/456")
       promptLogger.refreshPrompt()
       check(promptLogger, baos)(
-        "[123/456] ============================== TITLE =============================="
+        "[123/456] ============================== TITLE ==============================",
+        ""
       )
       promptLogger.prompt.setPromptLine(Seq("1"), "/456", "my-task")
 
@@ -123,7 +124,8 @@ object PromptLoggerTests extends TestSuite {
         "[1/456] my-task",
         "[1] HELLO",
         "[123/456] ============================= TITLE ============================= 10s",
-        "[1] my-task 10s"
+        "[1] my-task 10s",
+        ""
       )
 
       prefixLogger.streams.out.println("WORLD")
@@ -135,7 +137,8 @@ object PromptLoggerTests extends TestSuite {
         "[1] HELLO",
         "[1] WORLD",
         "[123/456] ============================= TITLE ============================= 10s",
-        "[1] my-task 10s"
+        "[1] my-task 10s",
+        ""
       )
 
       // Adding new ticker entries doesn't appear immediately,
@@ -166,7 +169,8 @@ object PromptLoggerTests extends TestSuite {
         "[3] hello short lived",
         "[3] goodbye short lived",
         "[123/456] ============================= TITLE ============================= 10s",
-        "[1] my-task 10s"
+        "[1] my-task 10s",
+        ""
       )
 
       newPrefixLogger3.prompt.removePromptLine(Seq("3"))
@@ -187,7 +191,8 @@ object PromptLoggerTests extends TestSuite {
         "[3] goodbye short lived",
         "[123/456] ============================= TITLE ============================= 11s",
         "[1] my-task 11s",
-        "[2] my-task-new 1s"
+        "[2] my-task-new 1s",
+        ""
       )
 
       promptLogger.prompt.removePromptLine(Seq("1"))
@@ -208,7 +213,8 @@ object PromptLoggerTests extends TestSuite {
         "[3] goodbye short lived",
         "[123/456] ============================= TITLE ============================= 11s",
         "[1] my-task 11s",
-        "[2] my-task-new 1s"
+        "[2] my-task-new 1s",
+        ""
       )
 
       now += 1000
@@ -228,6 +234,7 @@ object PromptLoggerTests extends TestSuite {
         "[3] goodbye short lived",
         "[123/456] ============================= TITLE ============================= 12s",
         "[2] my-task-new 2s",
+        "",
         ""
       )
 
@@ -246,7 +253,8 @@ object PromptLoggerTests extends TestSuite {
         "[3] hello short lived",
         "[3] goodbye short lived",
         "[123/456] ============================= TITLE ============================= 22s",
-        "[2] my-task-new 12s"
+        "[2] my-task-new 12s",
+        ""
       )
       now += 10000
       promptLogger.close()
@@ -282,19 +290,22 @@ object PromptLoggerTests extends TestSuite {
       promptLogger.refreshPrompt()
       check(promptLogger, baos)(
         "[123/456] ============================== TITLE ============================= 1s",
-        "[1] my-task 1s detail"
+        "[1] my-task 1s detail",
+        ""
       )
       prefixLogger.ticker("detail-too-long-gets-truncated-abcdefghijklmnopqrstuvwxyz1234567890")
       promptLogger.refreshPrompt()
       check(promptLogger, baos)(
         "[123/456] ============================== TITLE ============================= 1s",
-        "[1] my-task 1s detail-too-long-gets-truncated...fghijklmnopqrstuvwxyz1234567890"
+        "[1] my-task 1s detail-too-long-gets-truncated...fghijklmnopqrstuvwxyz1234567890",
+        ""
       )
       promptLogger.prompt.removePromptLine(Seq("1"))
       now += 10000
       promptLogger.refreshPrompt()
       check(promptLogger, baos)(
-        "[123/456] ============================= TITLE ============================= 11s"
+        "[123/456] ============================= TITLE ============================= 11s",
+        ""
       )
     }
   }


### PR DESCRIPTION
This would allow the prompt to continue to be shown after using `Ctrl-C` to interrupt a command, and avoid messing up the prompt in terminals like Windows Terminal which do not clear the screen after `Ctrl-C`

Instead of bundling the `up` codes immediately after every prompt and of the same height, we instead print the `up` codes before each prompt equal to the height of the _previously rendered_ prompt, which we track in a `lastPromptHeight` variable. This leaves the cursor after the prompt in between prints, so on interruption the prompt remains visible above.

Updated the unit tests to account for the cursor being on a new blank line, and manually tested it using `rm -rf out && ./mill-assembly.jar -i __.compile` on the Mill repo