### PR TITLE
Simplify newline processes in `PromptLogger`

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1,4 +1,4 @@
-//| mill-version: 1.0.0-RC3-26-c3ea9b
+//| mill-version: 1.0.0-RC3-28-3ea414
 //| mill-jvm-opts: ["-XX:NonProfiledCodeHeapSize=250m", "-XX:ReservedCodeCacheSize=500m"]
 //| mill-opts: ["--jobs=0.5C"]
 
@@ -24,6 +24,51 @@ import scala.util.Properties
 import mill.api.BuildCtx
 import mill.androidlib.AndroidSdkModule
 
+def run() = Task.Command(exclusive = true){
+  println("abc")
+  println("123")
+  println("xyz")
+}
+def run2() = Task.Command(exclusive = true){
+  println("abc")
+  println("123")
+  println("xyz")
+}
+def run3() = Task.Command(exclusive = true){
+  println("abc")
+  println("123")
+  println("xyz")
+}
+def run4() = Task.Command(exclusive = true){
+  println("abc")
+  println("123")
+  println("xyz")
+}
+def run5() = Task.Command(exclusive = true){
+  println("abc")
+  println("123")
+  println("xyz")
+}
+def run6() = Task.Command(exclusive = true){
+  println("abc")
+  println("123")
+  println("xyz")
+}
+def run7() = Task.Command(exclusive = true){
+  println("abc")
+  println("123")
+  println("xyz")
+}
+def run8() = Task.Command(exclusive = true){
+  println("abc")
+  println("123")
+  println("xyz")
+}
+def run9() = Task.Command(exclusive = true){
+  println("abc")
+  println("123")
+  println("xyz")
+}
 def millVersionIsStable: T[Boolean] = Task.Input {
   Task.env.contains("MILL_STABLE_VERSION")
 }

--- a/build.mill
+++ b/build.mill
@@ -24,51 +24,6 @@ import scala.util.Properties
 import mill.api.BuildCtx
 import mill.androidlib.AndroidSdkModule
 
-def run() = Task.Command(exclusive = true){
-  println("abc")
-  println("123")
-  println("xyz")
-}
-def run2() = Task.Command(exclusive = true){
-  println("abc")
-  println("123")
-  println("xyz")
-}
-def run3() = Task.Command(exclusive = true){
-  println("abc")
-  println("123")
-  println("xyz")
-}
-def run4() = Task.Command(exclusive = true){
-  println("abc")
-  println("123")
-  println("xyz")
-}
-def run5() = Task.Command(exclusive = true){
-  println("abc")
-  println("123")
-  println("xyz")
-}
-def run6() = Task.Command(exclusive = true){
-  println("abc")
-  println("123")
-  println("xyz")
-}
-def run7() = Task.Command(exclusive = true){
-  println("abc")
-  println("123")
-  println("xyz")
-}
-def run8() = Task.Command(exclusive = true){
-  println("abc")
-  println("123")
-  println("xyz")
-}
-def run9() = Task.Command(exclusive = true){
-  println("abc")
-  println("123")
-  println("xyz")
-}
 def millVersionIsStable: T[Boolean] = Task.Input {
   Task.env.contains("MILL_STABLE_VERSION")
 }

--- a/core/internal/src/mill/internal/PromptLogger.scala
+++ b/core/internal/src/mill/internal/PromptLogger.scala
@@ -337,7 +337,6 @@ private[mill] object PromptLogger {
           // the entire screen before each batch of writes, to try and reduce the
           // amount of terminal flickering in slow terminals (e.g. windows)
           // https://stackoverflow.com/questions/71452837/how-to-reduce-flicker-in-terminal-re-drawing
-          pprint.log(new String(buf, 0, end))
           PromptLoggerUtil.streamToPrependNewlines(dest, buf, end, AnsiNav.clearLine(0).getBytes)
         } else {
           dest.write(buf, 0, end)

--- a/core/internal/src/mill/internal/PromptLogger.scala
+++ b/core/internal/src/mill/internal/PromptLogger.scala
@@ -337,11 +337,8 @@ private[mill] object PromptLogger {
           // the entire screen before each batch of writes, to try and reduce the
           // amount of terminal flickering in slow terminals (e.g. windows)
           // https://stackoverflow.com/questions/71452837/how-to-reduce-flicker-in-terminal-re-drawing
-          dest.write(
-            new String(buf, 0, end)
-              .replaceAll("(\r\n|\n|\t)", AnsiNav.clearLine(0) + "$1")
-              .getBytes
-          )
+          pprint.log(new String(buf, 0, end))
+          PromptLoggerUtil.streamToPrependNewlines(dest, buf, end, AnsiNav.clearLine(0).getBytes)
         } else {
           dest.write(buf, 0, end)
         }

--- a/core/internal/src/mill/internal/PromptLoggerUtil.scala
+++ b/core/internal/src/mill/internal/PromptLoggerUtil.scala
@@ -220,18 +220,23 @@ private object PromptLoggerUtil {
     }
   }
 
-  def streamToPrependNewlines(dest: OutputStream, buf: Array[Byte], end: Int, prepended: Array[Byte]) = {
+  def streamToPrependNewlines(
+      dest: OutputStream,
+      buf: Array[Byte],
+      end: Int,
+      prepended: Array[Byte]
+  ) = {
     var last = 0
     var i = 0
     while (i < end) {
       (buf(i): @switch) match {
         case '\r' =>
-          if (i + 1 < buf.length && buf(i + 1) == '\n') {
+          if (i + 1 < end && buf(i + 1) == '\n') {
             dest.write(buf, last, i - last)
             dest.write(prepended)
             last = i
             i += 2
-          }else {
+          } else {
             i += 1
           }
         case '\n' | '\t' =>
@@ -242,6 +247,6 @@ private object PromptLoggerUtil {
         case _ => i += 1
       }
     }
-    dest.write(buf, last, buf.length - last)
+    dest.write(buf, last, end - last)
   }
 }

--- a/core/internal/src/mill/internal/PromptLoggerUtil.scala
+++ b/core/internal/src/mill/internal/PromptLoggerUtil.scala
@@ -1,5 +1,8 @@
 package mill.internal
 
+import java.io.OutputStream
+import scala.annotation.switch
+
 private object PromptLoggerUtil {
 
   private[mill] val defaultTermWidth = 99
@@ -215,5 +218,30 @@ private object PromptLoggerUtil {
 
       return xs.lengthCompare(ys)
     }
+  }
+
+  def streamToPrependNewlines(dest: OutputStream, buf: Array[Byte], end: Int, prepended: Array[Byte]) = {
+    var last = 0
+    var i = 0
+    while (i < end) {
+      (buf(i): @switch) match {
+        case '\r' =>
+          if (i + 1 < buf.length && buf(i + 1) == '\n') {
+            dest.write(buf, last, i - last)
+            dest.write(prepended)
+            last = i
+            i += 2
+          }else {
+            i += 1
+          }
+        case '\n' | '\t' =>
+          dest.write(buf, last, i - last)
+          dest.write(prepended)
+          last = i
+          i += 1
+        case _ => i += 1
+      }
+    }
+    dest.write(buf, last, buf.length - last)
   }
 }

--- a/core/internal/test/src/mill/internal/PromptLoggerUtilTests.scala
+++ b/core/internal/test/src/mill/internal/PromptLoggerUtilTests.scala
@@ -461,12 +461,10 @@ object PromptLoggerUtilTests extends TestSuite {
         assert(rendered == expected)
       }
     }
-    test("streamToPrependNewlines"){
+    test("streamToPrependNewlines") {
       val baos = new ByteArrayOutputStream()
       val input = "Hello\nworld\r\nI\tam\tcow\n".getBytes
       PromptLoggerUtil.streamToPrependNewlines(baos, input, input.length, "!!!".getBytes)
-      pprint.log(baos.toString.toCharArray)
-      pprint.log("Hello!!!\nworld!!!\r\nI!!!\tam!!!\tcow!!!\n".toCharArray)
       baos.toByteArray ==> "Hello!!!\nworld!!!\r\nI!!!\tam!!!\tcow!!!\n".getBytes
     }
   }

--- a/core/internal/test/src/mill/internal/PromptLoggerUtilTests.scala
+++ b/core/internal/test/src/mill/internal/PromptLoggerUtilTests.scala
@@ -3,6 +3,7 @@ package mill.internal
 import PromptLoggerUtil.*
 import utest.*
 
+import java.io.ByteArrayOutputStream
 import scala.collection.immutable.SortedMap
 object PromptLoggerUtilTests extends TestSuite {
 
@@ -459,6 +460,14 @@ object PromptLoggerUtilTests extends TestSuite {
         )
         assert(rendered == expected)
       }
+    }
+    test("streamToPrependNewlines"){
+      val baos = new ByteArrayOutputStream()
+      val input = "Hello\nworld\r\nI\tam\tcow\n".getBytes
+      PromptLoggerUtil.streamToPrependNewlines(baos, input, input.length, "!!!".getBytes)
+      pprint.log(baos.toString.toCharArray)
+      pprint.log("Hello!!!\nworld!!!\r\nI!!!\tam!!!\tcow!!!\n".toCharArray)
+      baos.toByteArray ==> "Hello!!!\nworld!!!\r\nI!!!\tam!!!\tcow!!!\n".getBytes
     }
   }
 }


### PR DESCRIPTION
This removes the `Array[Byte] => String => Regex => String => Array[Byte]` data copies and conversions, and instead just does the processing of newlines directly on the `Array[Byte]` as it is streamed