### PR TITLE
Convert scalalib alias `val`/`type`s to `export`s

### DIFF
--- a/libs/scalalib/src/mill/scalalib/exports.scala
+++ b/libs/scalalib/src/mill/scalalib/exports.scala
@@ -1,80 +1,60 @@
 package mill.scalalib
 
-lazy val Assembly = mill.javalib.Assembly
-type Assembly = mill.javalib.Assembly
+export mill.javalib.Assembly
 
-lazy val AssemblyModule = mill.javalib.AssemblyModule
-type AssemblyModule = mill.javalib.AssemblyModule
+export mill.javalib.AssemblyModule
 
-type BomModule = mill.javalib.BomModule
+export mill.javalib.BomModule
 
-lazy val BoundDep = mill.javalib.BoundDep
-type BoundDep = mill.javalib.BoundDep
+export mill.javalib.BoundDep
 
-lazy val CoursierModule = mill.javalib.CoursierModule
-type CoursierModule = mill.javalib.CoursierModule
+export mill.javalib.CoursierModule
 
-lazy val Dep = mill.javalib.Dep
-type Dep = mill.javalib.Dep
+export mill.javalib.Dep
 
 object Dependency extends mill.api.ExternalModule.Alias(mill.javalib.Dependency)
 
-// lazy val GenIdeaModule = mill.javalib.GenIdeaModule
-type GenIdeaModule = mill.javalib.GenIdeaModule
+export mill.javalib.GenIdeaModule
 
-// lazy val JavaHomeModule = mill.javalib.JavaHomeModule
-type JavaHomeModule = mill.javalib.JavaHomeModule
+export mill.javalib.JavaHomeModule
 
-lazy val JavaModule = mill.javalib.JavaModule
-type JavaModule = mill.javalib.JavaModule
+export mill.javalib.JavaModule
 
-// lazy val JlinkModule = mill.javalib.JlinkModule
-type JlinkModule = mill.javalib.JlinkModule
+export mill.javalib.JlinkModule
 
-// lazy val JpackageModule = mill.javalib.JpackageModule
-type JpackageModule = mill.javalib.JpackageModule
+export mill.javalib.JpackageModule
 
-lazy val JsonFormatters = mill.javalib.JsonFormatters
-type JsonFormatters = mill.javalib.JsonFormatters
+export mill.javalib.JsonFormatters
 
-lazy val JvmWorkerModule = mill.javalib.JvmWorkerModule
-type JvmWorkerModule = mill.javalib.JvmWorkerModule
+export mill.javalib.JvmWorkerModule
 
-lazy val Lib = mill.javalib.Lib
-// type Lib = mill.javalib.Lib
+export mill.javalib.Lib
 
-// lazy val MavenModule = mill.javalib.MavenModule
-type MavenModule = mill.javalib.MavenModule
+export mill.javalib.MavenModule
 
-lazy val MvnDepsTreeArgs = mill.javalib.MvnDepsTreeArgs
-type MvnDepsTreeArgs = mill.javalib.MvnDepsTreeArgs
+export mill.javalib.MvnDepsTreeArgs
 
-// lazy val NativeImageModule = mill.javalib.NativeImageModule
-type NativeImageModule = mill.javalib.NativeImageModule
+export mill.javalib.NativeImageModule
 
-lazy val OfflineSupport = mill.javalib.OfflineSupport
-// type OfflineSupport = mill.javalib.OfflineSupport
+export mill.javalib.OfflineSupport
 
-// lazy val OfflineSupportModule = mill.javalib.OfflineSupportModule
-type OfflineSupportModule = mill.javalib.OfflineSupportModule
+export mill.javalib.OfflineSupportModule
 
-lazy val PublishModule = mill.javalib.PublishModule
-type PublishModule = mill.javalib.PublishModule
+export mill.javalib.PublishModule
 
-lazy val RunModule = mill.javalib.RunModule
-type RunModule = mill.javalib.RunModule
+export mill.javalib.RunModule
 
-// lazy val SonatypeCentralPublisher = mill.javalib.SonatypeCentralPublisher.self
-type SonatypeCentralPublisher = mill.javalib.SonatypeCentralPublisher
+export mill.javalib.SonatypeCentralPublisher
 
 object SonatypeCentralPublishModule
     extends mill.api.ExternalModule.Alias(mill.javalib.SonatypeCentralPublishModule)
 
-lazy val TestModule = mill.javalib.TestModule
-type TestModule = mill.javalib.TestModule
+export mill.javalib.TestModule
 
-lazy val TestModuleUtil = mill.javalib.TestModuleUtil
-// type TestModuleUtil = mill.javalib.TestModuleUtil
+export mill.javalib.TestModuleUtil
 
-// lazy val WithJvmWorkerModule = mill.javalib.WithJvmWorkerModule
-type WithJvmWorkerModule = mill.javalib.WithJvmWorkerModule
+export mill.javalib.WithJvmWorkerModule
+
+export mill.javalib.JsonFormatters.*
+
+export mill.javalib.DepSyntax

--- a/libs/scalalib/src/mill/scalalib/package.scala
+++ b/libs/scalalib/src/mill/scalalib/package.scala
@@ -5,13 +5,6 @@ package mill
  * Scala projects on the JVM. Scala.js and Scala-Native toolchains are in `mill.scalajslib`
  * and `mill.scalanativelib` respectively.
  */
-package object scalalib extends mill.scalalib.JsonFormatters {
+package object scalalib
 
-  implicit class DepSyntax(ctx: StringContext) extends AnyVal {
-    def mvn(args: Any*): Dep = mill.javalib.DepSyntax(ctx).mvn(args*)
 
-    @deprecated("Use `mvn` string interpolator instead.", "Mill 0.12.11")
-    def ivy(args: Any*): Dep = mill.javalib.DepSyntax(ctx).mvn(args*)
-  }
-
-}


### PR DESCRIPTION
Taking advantage of new Scala 3 syntax