### PR TITLE
Add `Result.traverse`

### DIFF
--- a/core/api/daemon/src/mill/api/daemon/Result.scala
+++ b/core/api/daemon/src/mill/api/daemon/Result.scala
@@ -1,6 +1,6 @@
 package mill.api.daemon
 
-import scala.collection.{BuildFrom, Factory, mutable}
+import scala.collection.Factory
 import scala.util.boundary
 
 /**

--- a/core/api/daemon/src/mill/api/daemon/Result.scala
+++ b/core/api/daemon/src/mill/api/daemon/Result.scala
@@ -1,6 +1,7 @@
 package mill.api.daemon
 
-import scala.collection.{BuildFrom, mutable}
+import scala.collection.{BuildFrom, Factory, mutable}
+import scala.util.boundary
 
 /**
  * Represents a computation that either succeeds with a value [[T]] or
@@ -47,16 +48,42 @@ object Result {
     case Right(value) => Result.Success(value)
   }
 
-  // implementation similar to scala.concurrent.Future#sequence
-  def sequence[B, M[X] <: IterableOnce[X]](in: M[Result[B]])(
-      implicit cbf: BuildFrom[M[Result[B]], B, M[B]]
-  ): Result[M[B]] = {
-    in.iterator
-      .foldLeft[Result[mutable.Builder[B, M[B]]]](Success(cbf.newBuilder(in))) {
-        case (acc, el) =>
-          for (a <- acc; e <- el) yield a += e
+  extension [A](rr: Result[Result[A]]) {
+    def flatten: Result[A] = rr.flatMap(identity)
+  }
+
+  /**
+   * Converts a `Collection[Result[T]]` into a `Result[Collection[T]]`
+   */
+  def sequence[B, M[X] <: IterableOnce[X]](in: M[Result[B]])(using factory: Factory[B, M[B]]): Result[M[B]] = {
+    boundary {
+      val builder = factory.newBuilder
+      builder.sizeHint(in)
+      in.iterator.foreach {
+        case Success(b) => builder += b
+        case Failure(error) => boundary.break(Failure(error))
       }
-      .map(_.result())
+
+      builder.result()
+    }
+  }
+
+  /**
+   * Converts a `Collection[T]` into a `Result[Collection[V]]` using the given `f: T => Result[V]`
+   */
+  def traverse[A, B, Collection[x] <: IterableOnce[x]](collection: Collection[Result[A]])(
+    f: A => Result[B]
+  )(using factory: Factory[B, Collection[B]]): Result[Collection[B]] = {
+    boundary {
+      val builder = factory.newBuilder
+      builder.sizeHint(collection)
+      collection.iterator.map(_.flatMap(f)).foreach {
+        case Success(b) => builder += b
+        case Failure(error) => boundary.break(Failure(error))
+      }
+
+      builder.result()
+    }
   }
 
   final class Exception(val error: String) extends java.lang.Exception(error)

--- a/core/api/test/src/mill/api/daemon/ResultTests.scala
+++ b/core/api/test/src/mill/api/daemon/ResultTests.scala
@@ -1,0 +1,50 @@
+package mill.api.daemon
+
+import utest.*
+
+object ResultTests extends TestSuite {
+  val tests = Tests {
+    test("sequence") {
+      test("empty") {
+        val actual = Result.sequence(Seq.empty)
+        assert(actual == Result.Success(Seq.empty))
+      }
+
+      test("success") {
+        val actual = Result.sequence(Seq(Result.Success(1), Result.Success(2)))
+        assert(actual == Result.Success(Seq(1, 2)))
+      }
+
+      test("failure") {
+        val actual = Result.sequence(Seq(Result.Success(1), Result.Failure("fail"), Result.Success(2)))
+        assert(actual == Result.Failure("fail"))
+      }
+    }
+
+    test("traverse") {
+      test("empty") {
+        test("success") {
+          val actual = Result.traverse(Seq.empty)(Result.Success(_))
+          assert(actual == Result.Success(Seq.empty))
+        }
+
+        test("failure") {
+          val actual = Result.traverse(Seq.empty)(_ => Result.Failure("fail"))
+          assert(actual == Result.Success(Seq.empty))
+        }
+      }
+
+      test("success") {
+        val actual = Result.traverse(Seq(1, 2))(Result.Success(_))
+        assert(actual == Result.Success(Seq(1, 2)))
+      }
+
+      test("failure") {
+        val actual = Result.traverse(Seq(1, 2, 3)) { x =>
+          if (x % 2 == 0) Result.Failure(s"fail $x") else Result.Success(x)
+        }
+        assert(actual == Result.Failure("fail 2"))
+      }
+    }
+  }
+}

--- a/core/resolve/src/mill/resolve/ParseArgs.scala
+++ b/core/resolve/src/mill/resolve/ParseArgs.scala
@@ -61,7 +61,7 @@ private[mill] object ParseArgs {
         .sequence(selectors.map(ExpandBraces.expandBraces))
         .map(_.flatten)
       selectors <- Result.sequence(expandedSelectors.map(extractSegments))
-    } yield (selectors.toList, args)
+    } yield (selectors.iterator.toList, args)
   }
 
   def extractSelsAndArgs(

--- a/core/resolve/src/mill/resolve/Resolve.scala
+++ b/core/resolve/src/mill/resolve/Resolve.scala
@@ -316,10 +316,7 @@ private[mill] trait Resolve[T] {
           }
         }
 
-        Result
-          .sequence(selected)
-          .flatMap(Result.sequence(_))
-          .map(_.flatten)
+        Result.sequence(selected.map(_.flatten)).map(_.flatten)
       }
 
       Result.sequence(resolved)


### PR DESCRIPTION
From the issue:

> Currently we use `Result.sequence` everywhere, but many of the call sites could be replaced by `Result.traverse` for better conciseness and clarity.

Added `Result.traverse`, optimized `Result.sequence` as well, and covered them with tests. I did not actually find any usages where `traverse` would be useful though.

Fixes https://github.com/com-lihaoyi/mill/issues/5241.