### PR TITLE
Android compose samples: JetNews

### DIFF
--- a/example/thirdparty/android-compose-samples/build.mill
+++ b/example/thirdparty/android-compose-samples/build.mill
@@ -267,7 +267,7 @@ object JetNews extends mill.api.Module {
   }
 }
 
-/** Usage
+/** Usage JetLagged
 
 > ./mill JetLagged.app.androidApk
 
@@ -308,3 +308,45 @@ object JetNews extends mill.api.Module {
 > ./mill show JetLagged.app.deleteAndroidVirtualDevice
 
 */
+
+/** Usage JetNews
+
+ > ./mill JetNews.app.androidApk
+
+ > ./mill show JetNews.app.createAndroidVirtualDevice
+ ...Name: test, DeviceId: medium_phone...
+
+ > ./mill show JetNews.app.startAndroidEmulator
+
+ > ./mill show JetNews.app.androidInstall
+ ...All files should be loaded. Notifying the device...
+
+ > ./mill show JetNews.app.androidRun --activity com.example.jetnews.ui.MainActivity
+ [
+ "Starting: Intent { cmp=com.example.jetnews/.ui.MainActivity }",
+ "Status: ok",
+ "LaunchState: COLD",
+ "Activity: com.example.jetnews/.ui.MainActivity",
+ "TotalTime: ...",
+ "WaitTime: ...",
+ "Complete"
+ ]
+
+ > ./mill show JetNews.app.androidTest
+ {
+ "msg": "",
+ "results": [
+ {
+ "fullyQualifiedName": "com.example.jetnews.JetnewsTests.app_launches",
+ selector": "com.example.jetnews.JetnewsTests.app_launches",
+ "duration": ...,
+ "status": "Success"
+ }
+ ]
+ }
+
+ > ./mill show JetNews.app.stopAndroidEmulator
+
+ > ./mill show JetNews.app.deleteAndroidVirtualDevice
+
+ */

--- a/example/thirdparty/android-compose-samples/build.mill
+++ b/example/thirdparty/android-compose-samples/build.mill
@@ -272,7 +272,7 @@ object JetNews extends mill.api.Module {
 
 /** Usage
 
-> ./mill -j1 JetNews.app.androidApk
+> ./mill JetNews.app.androidApk
 
 > ./mill show JetLagged.app.createAndroidVirtualDevice
 ...Name: test, DeviceId: medium_phone...

--- a/example/thirdparty/android-compose-samples/build.mill
+++ b/example/thirdparty/android-compose-samples/build.mill
@@ -311,42 +311,42 @@ object JetNews extends mill.api.Module {
 
 /** Usage JetNews
 
- > ./mill JetNews.app.androidApk
+> ./mill JetNews.app.androidApk
 
- > ./mill show JetNews.app.createAndroidVirtualDevice
- ...Name: test, DeviceId: medium_phone...
+> ./mill show JetNews.app.createAndroidVirtualDevice
+...Name: test, DeviceId: medium_phone...
 
- > ./mill show JetNews.app.startAndroidEmulator
+> ./mill show JetNews.app.startAndroidEmulator
 
- > ./mill show JetNews.app.androidInstall
- ...All files should be loaded. Notifying the device...
+> ./mill show JetNews.app.androidInstall
+...All files should be loaded. Notifying the device...
 
- > ./mill show JetNews.app.androidRun --activity com.example.jetnews.ui.MainActivity
- [
- "Starting: Intent { cmp=com.example.jetnews/.ui.MainActivity }",
- "Status: ok",
- "LaunchState: COLD",
- "Activity: com.example.jetnews/.ui.MainActivity",
- "TotalTime: ...",
- "WaitTime: ...",
- "Complete"
- ]
+> ./mill show JetNews.app.androidRun --activity com.example.jetnews.ui.MainActivity
+[
+  "Starting: Intent { cmp=com.example.jetnews/.ui.MainActivity }",
+  "Status: ok",
+  "LaunchState: COLD",
+  "Activity: com.example.jetnews/.ui.MainActivity",
+  "TotalTime: ...",
+  "WaitTime: ...",
+  "Complete"
+]
 
- > ./mill show JetNews.app.androidTest
- {
- "msg": "",
- "results": [
- {
- "fullyQualifiedName": "com.example.jetnews.JetnewsTests.app_launches",
- selector": "com.example.jetnews.JetnewsTests.app_launches",
- "duration": ...,
- "status": "Success"
- }
- ]
- }
+> ./mill show JetNews.app.androidTest
+{
+  "msg": "",
+  "results": [
+    {
+      "fullyQualifiedName": "com.example.jetnews.JetnewsTests.app_launches",
+      selector": "com.example.jetnews.JetnewsTests.app_launches",
+      "duration": ...,
+      "status": "Success"
+    }
+  ]
+}
 
- > ./mill show JetNews.app.stopAndroidEmulator
+> ./mill show JetNews.app.stopAndroidEmulator
 
- > ./mill show JetNews.app.deleteAndroidVirtualDevice
+> ./mill show JetNews.app.deleteAndroidVirtualDevice
 
- */
+*/

--- a/example/thirdparty/android-compose-samples/build.mill
+++ b/example/thirdparty/android-compose-samples/build.mill
@@ -274,7 +274,7 @@ object JetNews extends mill.api.Module {
 
 /** Usage
 
-> ./mill JetLagged.app.androidApk
+> ./mill -j1 JetLagged.app.androidApk
 
 > ./mill show JetLagged.app.createAndroidVirtualDevice
 ...Name: test, DeviceId: medium_phone...
@@ -314,7 +314,7 @@ object JetNews extends mill.api.Module {
 
 /** Usage
 
-> ./mill JetNews.app.androidApk
+> ./mill -j1 JetNews.app.androidApk
 
 > ./mill show JetNews.app.androidInstall
 ...All files should be loaded. Notifying the device...

--- a/example/thirdparty/android-compose-samples/build.mill
+++ b/example/thirdparty/android-compose-samples/build.mill
@@ -139,6 +139,134 @@ object JetLagged extends mill.api.Module {
   }
 }
 
+object JetNews extends mill.api.Module {
+  object app extends AndroidAppKotlinModule, AndroidR8AppModule {
+    def kotlinVersion = Versions.kotlinVersion
+
+    def kotlinLanguageVersion = Versions.kotlinLanguageVersion
+
+    def androidIsDebug = true
+
+    // FIXME: ideally R8 should compile without erroring, but the app seems to be working
+    // without some reportedly missing classes.
+    override def androidR8Args = Seq("--map-diagnostics", "error", "warning")
+
+    override def androidDebugSettings: T[AndroidBuildTypeSettings] = Task {
+      AndroidBuildTypeSettings(
+        isMinifyEnabled = false,
+        isShrinkEnabled = false
+      ).withDefaultProguardFile("proguard-android-optimize.txt")
+        .withProguardLocalFiles(
+          Seq(
+            moduleDir / "proguard-rules.pro"
+          )
+        )
+    }
+
+    override def androidApplicationNamespace = "com.example.jetnews"
+
+    override def androidApplicationId = "com.example.jetnews"
+
+    override def kotlincOptions = super.kotlincOptions() ++ Seq(
+      "-jvm-target",
+      "17"
+    )
+
+    def bomMvnDeps = super.mvnDeps() ++ Seq(
+      mvn"androidx.compose:compose-bom:2025.05.00"
+    )
+
+    def mvnDeps = super.mvnDeps() ++ Seq(
+      mvn"com.google.accompanist:accompanist-adaptive:0.37.3",
+      mvn"androidx.appcompat:appcompat:1.7.0",
+      mvn"org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2",
+      mvn"androidx.concurrent:concurrent-futures:1.1.0",
+      mvn"androidx.core:core-ktx:1.16.0",
+      mvn"androidx.activity:activity-compose:1.10.1",
+      mvn"androidx.lifecycle:lifecycle-common:2.9.0",
+      mvn"androidx.lifecycle:lifecycle-process:2.9.0",
+      mvn"androidx.lifecycle:lifecycle-runtime-compose:2.9.0",
+      mvn"androidx.lifecycle:lifecycle-viewmodel-compose:2.9.0",
+      mvn"androidx.lifecycle:lifecycle-viewmodel-ktx:2.9.0",
+      mvn"androidx.navigation:navigation-compose:2.9.0",
+      mvn"androidx.emoji2:emoji2:1.5.0",
+      mvn"androidx.emoji2:emoji2-views:1.5.0",
+      mvn"androidx.emoji2:emoji2-bundled:1.5.0",
+      mvn"androidx.window:window:1.4.0",
+      mvn"androidx.window.extensions.core:core:1.0.0",
+      mvn"androidx.constraintlayout:constraintlayout-compose:1.1.1",
+      mvn"io.coil-kt:coil-compose:2.7.0",
+      mvn"androidx.customview:customview-poolingcontainer:1.0.0",
+      mvn"androidx.tracing:tracing:1.2.0",
+      mvn"org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.1",
+      mvn"androidx.glance:glance-appwidget:1.2.0-alpha01",
+      mvn"androidx.glance:glance-material3:1.2.0-alpha01",
+
+      // version is resolved from compose-bom
+      mvn"androidx.compose.runtime:runtime",
+      mvn"androidx.compose.foundation:foundation",
+      mvn"androidx.compose.foundation:foundation-layout",
+      mvn"androidx.compose.ui:ui-util",
+      mvn"androidx.compose.material3:material3",
+      mvn"androidx.compose.animation:animation",
+      mvn"androidx.compose.animation:animation-tooling-internal",
+      mvn"androidx.compose.material:material-icons-extended",
+      mvn"androidx.compose.material:material",
+      mvn"androidx.compose.material3:material3-window-size-class",
+      mvn"androidx.compose.ui:ui-text-google-fonts",
+      mvn"androidx.compose.ui:ui-tooling-preview",
+      mvn"androidx.compose.ui:ui-unit",
+      mvn"androidx.compose.ui:ui-text",
+      mvn"androidx.compose.ui:ui-graphics",
+
+      // debug dependencies
+      mvn"androidx.compose.ui:ui-tooling",
+      mvn"androidx.compose.ui:ui-test-manifest"
+    )
+
+    def androidEnableCompose = true
+    override def kotlinUseEmbeddableCompiler: Task[Boolean] = Task { true }
+
+    def androidSdkModule = mill.api.ModuleRef(androidSdkModule0)
+
+    def androidCompileSdk = Versions.androidCompileSdk
+
+    def androidMinSdk = Versions.androidMinSdk
+
+    object androidTest extends AndroidAppKotlinInstrumentedTests, AndroidR8AppModule,
+    AndroidTestModule.AndroidJUnit {
+
+      def bomMvnDeps = super.mvnDeps() ++ Seq(
+        mvn"androidx.compose:compose-bom:2025.05.00"
+      )
+
+      // TODO consider defaulting this to the parent app value
+      override def androidEnableCompose = true
+
+      // TODO consider defaulting this to the parent app value
+      override def kotlinUseEmbeddableCompiler: Task[Boolean] = Task {
+        true
+      }
+
+      // FIXME: ideally R8 should compile without erroring, but the app seems to be working
+      // without some reportedly missing classes.
+      override def androidR8Args = Seq("--map-diagnostics", "error", "warning")
+
+      def mvnDeps = super.mvnDeps() ++ Seq(
+        mvn"junit:junit:4.13.2",
+        mvn"androidx.test:core:1.6.1",
+        mvn"androidx.test:runner:1.6.1",
+        mvn"androidx.test.espresso:espresso-core:3.6.1",
+        mvn"androidx.test:rules:1.6.1",
+        mvn"androidx.test.ext:junit:1.2.1",
+        mvn"org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2",
+        mvn"androidx.compose.ui:ui-test",
+        mvn"androidx.compose.ui:ui-test-junit4"
+      )
+    }
+  }
+}
+
 /** Usage
 
 > ./mill JetLagged.app.androidApk

--- a/example/thirdparty/android-compose-samples/build.mill
+++ b/example/thirdparty/android-compose-samples/build.mill
@@ -267,6 +267,11 @@ object JetNews extends mill.api.Module {
   }
 }
 
+// The compose samples repository, contains many sample apps!
+// Let's say we are building 2 apps with a shared android emulator!
+
+// First we build, run and test JetLagged
+
 /** Usage
 
 > ./mill JetLagged.app.androidApk
@@ -303,20 +308,13 @@ object JetNews extends mill.api.Module {
   ]
 }
 
-> ./mill show JetLagged.app.stopAndroidEmulator
-
-> ./mill show JetLagged.app.deleteAndroidVirtualDevice
-
 */
 
-/** Usage
+// Then on the same emulator we build, run and test JetNews too
+
+/** Usage JetNews
 
 > ./mill JetNews.app.androidApk
-
-> ./mill show JetNews.app.createAndroidVirtualDevice
-...Name: test, DeviceId: medium_phone...
-
-> ./mill show JetNews.app.startAndroidEmulator
 
 > ./mill show JetNews.app.androidInstall
 ...All files should be loaded. Notifying the device...
@@ -339,32 +337,32 @@ object JetNews extends mill.api.Module {
     {
       "fullyQualifiedName": "com.example.jetnews.HomeScreenTests.postsContainError_snackbarShown",
       "selector": "com.example.jetnews.HomeScreenTests.postsContainError_snackbarShown",
-      "duration": 2,
+      "duration": ...,
       "status": "Success"
     },
     {
       "fullyQualifiedName": "com.example.jetnews.JetnewsTests.app_opensArticle",
       "selector": "com.example.jetnews.JetnewsTests.app_opensArticle",
-      "duration": 1,
+      "duration": ...,
       "status": "Success"
     },
     {
       "fullyQualifiedName": "com.example.jetnews.JetnewsTests.app_launches",
       "selector": "com.example.jetnews.JetnewsTests.app_launches",
-      "duration": 1,
+      "duration": ...,
       "status": "Success"
     },
     {
       "fullyQualifiedName": "com.example.jetnews.JetnewsTests.app_opensInterests",
       "selector": "com.example.jetnews.JetnewsTests.app_opensInterests",
-      "duration": 1,
+      "duration": ...,
       "status": "Success"
     }
   ]
 }
 
-> ./mill show JetNews.app.stopAndroidEmulator
+> ./mill show JetLagged.app.stopAndroidEmulator
 
-> ./mill show JetNews.app.deleteAndroidVirtualDevice
+> ./mill show JetLagged.app.deleteAndroidVirtualDevice
 
 */

--- a/example/thirdparty/android-compose-samples/build.mill
+++ b/example/thirdparty/android-compose-samples/build.mill
@@ -267,7 +267,7 @@ object JetNews extends mill.api.Module {
   }
 }
 
-/** Usage JetLagged
+/** Usage
 
 > ./mill JetLagged.app.androidApk
 
@@ -309,7 +309,7 @@ object JetNews extends mill.api.Module {
 
 */
 
-/** Usage JetNews
+/** Usage
 
 > ./mill JetNews.app.androidApk
 
@@ -337,9 +337,27 @@ object JetNews extends mill.api.Module {
   "msg": "",
   "results": [
     {
+      "fullyQualifiedName": "com.example.jetnews.HomeScreenTests.postsContainError_snackbarShown",
+      "selector": "com.example.jetnews.HomeScreenTests.postsContainError_snackbarShown",
+      "duration": 2,
+      "status": "Success"
+    },
+    {
+      "fullyQualifiedName": "com.example.jetnews.JetnewsTests.app_opensArticle",
+      "selector": "com.example.jetnews.JetnewsTests.app_opensArticle",
+      "duration": 1,
+      "status": "Success"
+    },
+    {
       "fullyQualifiedName": "com.example.jetnews.JetnewsTests.app_launches",
-      selector": "com.example.jetnews.JetnewsTests.app_launches",
-      "duration": ...,
+      "selector": "com.example.jetnews.JetnewsTests.app_launches",
+      "duration": 1,
+      "status": "Success"
+    },
+    {
+      "fullyQualifiedName": "com.example.jetnews.JetnewsTests.app_opensInterests",
+      "selector": "com.example.jetnews.JetnewsTests.app_opensInterests",
+      "duration": 1,
       "status": "Success"
     }
   ]

--- a/example/thirdparty/android-compose-samples/build.mill
+++ b/example/thirdparty/android-compose-samples/build.mill
@@ -312,7 +312,7 @@ object JetNews extends mill.api.Module {
 
 // Then on the same emulator we build, run and test JetNews too
 
-/** Usage JetNews
+/** Usage
 
 > ./mill JetNews.app.androidApk
 

--- a/example/thirdparty/android-compose-samples/build.mill
+++ b/example/thirdparty/android-compose-samples/build.mill
@@ -234,7 +234,7 @@ object JetNews extends mill.api.Module {
     def androidMinSdk = Versions.androidMinSdk
 
     object androidTest extends AndroidAppKotlinInstrumentedTests, AndroidR8AppModule,
-    AndroidTestModule.AndroidJUnit {
+          AndroidTestModule.AndroidJUnit {
 
       def bomMvnDeps = super.mvnDeps() ++ Seq(
         mvn"androidx.compose:compose-bom:2025.05.00"

--- a/example/thirdparty/android-compose-samples/build.mill
+++ b/example/thirdparty/android-compose-samples/build.mill
@@ -268,53 +268,16 @@ object JetNews extends mill.api.Module {
 }
 
 // The compose samples repository, contains many sample apps!
-// Let's say we are building 2 apps with a shared android emulator!
-
-// First we build, run and test JetLagged
+// The following example is for building, testing and running JetNews.
 
 /** Usage
 
-> ./mill -j1 JetLagged.app.androidApk
+> ./mill -j1 JetNews.app.androidApk
 
 > ./mill show JetLagged.app.createAndroidVirtualDevice
 ...Name: test, DeviceId: medium_phone...
 
 > ./mill show JetLagged.app.startAndroidEmulator
-
-> ./mill show JetLagged.app.androidInstall
-...All files should be loaded. Notifying the device...
-
-> ./mill show JetLagged.app.androidRun --activity com.example.jetlagged.MainActivity
-[
-  "Starting: Intent { cmp=com.example.jetlagged/.MainActivity }",
-  "Status: ok",
-  "LaunchState: COLD",
-  "Activity: com.example.jetlagged/.MainActivity",
-  "TotalTime: ...",
-  "WaitTime: ...",
-  "Complete"
-]
-
-> ./mill show JetLagged.app.androidTest
-{
-  "msg": "",
-  "results": [
-    {
-      "fullyQualifiedName": "com.example.jetlagged.AppTest.app_launches",
-      "selector": "com.example.jetlagged.AppTest.app_launches",
-      "duration": ...,
-      "status": "Success"
-    }
-  ]
-}
-
-*/
-
-// Then on the same emulator we build, run and test JetNews too
-
-/** Usage
-
-> ./mill -j1 JetNews.app.androidApk
 
 > ./mill show JetNews.app.androidInstall
 ...All files should be loaded. Notifying the device...
@@ -361,8 +324,8 @@ object JetNews extends mill.api.Module {
   ]
 }
 
-> ./mill show JetLagged.app.stopAndroidEmulator
+> ./mill show JetNews.app.stopAndroidEmulator
 
-> ./mill show JetLagged.app.deleteAndroidVirtualDevice
+> ./mill show JetNews.app.deleteAndroidVirtualDevice
 
 */

--- a/website/docs/modules/ROOT/nav.adoc
+++ b/website/docs/modules/ROOT/nav.adoc
@@ -36,6 +36,7 @@
 *** xref:android/kotlin.adoc[]
 *** xref:android/android-linting.adoc[]
 *** xref:android/compose-samples.adoc[]
+*** xref:android/hilt-sample.adoc[]
 ** xref:pythonlib/intro.adoc[]
 *** xref:pythonlib/module-config.adoc[]
 *** xref:pythonlib/dependencies.adoc[]

--- a/website/docs/modules/ROOT/nav.adoc
+++ b/website/docs/modules/ROOT/nav.adoc
@@ -35,6 +35,7 @@
 *** xref:android/java.adoc[]
 *** xref:android/kotlin.adoc[]
 *** xref:android/android-linting.adoc[]
+*** xref:android/compose-samples.adoc[]
 ** xref:pythonlib/intro.adoc[]
 *** xref:pythonlib/module-config.adoc[]
 *** xref:pythonlib/dependencies.adoc[]

--- a/website/docs/modules/ROOT/pages/android/compose-samples.adoc
+++ b/website/docs/modules/ROOT/pages/android/compose-samples.adoc
@@ -3,12 +3,12 @@
 
 
 This page provides an example of using Mill as a build tool against more real like examples, using the
-official [compose samples](https://github.com/android/compose-samples)
+official https://github.com/android/compose-samples[compose samples]
 
 *Example Apps*
 
-- [JetLagged](https://github.com/android/compose-samples/tree/main/JetLagged)
-- [JetNews](https://github.com/android/compose-samples/tree/main/JetNews)
+- https://github.com/android/compose-samples/tree/main/JetLagged[JetLagged]
+- https://github.com/android/compose-samples/tree/main/JetNews[JetNews]
 
 == Android Mill Setup for building JetLagged and JetNews
 

--- a/website/docs/modules/ROOT/pages/android/compose-samples.adoc
+++ b/website/docs/modules/ROOT/pages/android/compose-samples.adoc
@@ -1,0 +1,18 @@
+= Android Jetpack Compose
+:page-aliases: android_jetpack_compose.adoc
+
+
+This page provides an example of using Mill as a build tool against more real like examples, using the
+official [compose samples](https://github.com/android/compose-samples)
+
+*Example Apps*
+
+- [JetLagged](https://github.com/android/compose-samples/tree/main/JetLagged)
+- [JetNews](https://github.com/android/compose-samples/tree/main/JetNews)
+
+== Android Mill Setup for building JetLagged and JetNews
+
+include::partial$example/thirdparty/android-compose-samples.adoc[]
+
+This example demonstrates how to build multiple Android Apps from the same project, translating
+their Gradle configuration to Mill and using R8 to optimise the App in a similar configuration as the original Gradle setup.

--- a/website/docs/modules/ROOT/pages/android/hilt-sample.adoc
+++ b/website/docs/modules/ROOT/pages/android/hilt-sample.adoc
@@ -1,0 +1,13 @@
+= Android Hilt Sample
+:page-aliases: android_hilt_sample.adoc
+
+This page provides an example of using Mill to build an Android application
+that utilizes Hilt for dependency injection, based on the official
+https://github.com/android/architecture-samples[TODO app].
+
+== Android Mill Setup for building the TODO App
+
+include::partial$example/thirdparty/androidtodo.adoc[]
+
+This example demonstrates how to build an Android app that uses Hilt for dependency injection,
+translating the original Gradle configuration to Mill.


### PR DESCRIPTION
Added [JetNews](https://github.com/android/compose-samples/tree/main/JetNews) to the compose samples.
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/dab31d7f-6604-44c9-bf52-0e498ee1699c" />

The object structure is similar to the JetLagged sample. R8 still currently throws some errors but converting them to warnings allows the app to function and the tests to pass successfully. 
This expands the test coverage and will be useful for detecting regressions in the future

