### PR TITLE
Fix doc publishing

### DIFF
--- a/website/package.mill
+++ b/website/package.mill
@@ -299,7 +299,7 @@ object `package` extends mill.Module {
     }.dropRight(1) ++
       // Set the latest stable branch as the "master" docs that people default to
       Seq(
-        (Settings.docTags.last, Settings.docTags.last, Settings.docTags.last, "master", false),
+        (Settings.docTags.last, Settings.docTags.last, Settings.docTags.last, "master", true),
         ("dev", "dev", "dev", "dev", true)
       )
 


### PR DESCRIPTION
This was broken since releasing 1.0.0.

- Publishing code should gracefully handle case where no unstable release is present
- The new `master` docs use `newWebsiteTask = true` rather than `false`, since they are on `1.0.0` which has the new `website.*` module layout