### PR TITLE
Enable mima for Mill 1.0.0 series

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -325,11 +325,11 @@ jobs:
       buildcmd: |
         set -eux
         ./mill -i mill.scalalib.scalafmt.ScalafmtModule/scalafmt --check + __.fix --check + mill.javalib.palantirformat.PalantirFormatModule/ --check + mill.kotlinlib.ktlint.KtlintModule/checkFormatAll
-#  mima:
-#    needs: build-linux
-#    uses: ./.github/workflows/post-build-raw.yml
-#    with:
-#      java-version: '17'
-#      buildcmd: |
-#        set -eux
-#        ./mill -i __.mimaReportBinaryIssues
+  mima:
+    needs: build-linux
+    uses: ./.github/workflows/post-build-raw.yml
+    with:
+      java-version: '17'
+      buildcmd: |
+        set -eux
+        ./mill -i __.mimaReportBinaryIssues

--- a/core/constants/package.mill
+++ b/core/constants/package.mill
@@ -9,7 +9,7 @@ import millbuild.*
  * This module contains basic constants and helpers shared between the client,
  * server, and the rest of the Mill codebase.
  */
-object `package` extends MillPublishJavaModule with BuildInfo {
+object `package` extends MillStableJavaModule with BuildInfo {
   def buildInfoPackageName = "mill.constants"
   def buildInfoMembers = Seq(
     BuildInfo.Value("millVersion", build.millVersion(), "Mill version."),

--- a/libs/javalib/src/mill/javalib/pmd/PmdArgs.scala
+++ b/libs/javalib/src/mill/javalib/pmd/PmdArgs.scala
@@ -1,7 +1,7 @@
 package mill.javalib.pmd
 
 import mainargs.{Leftover, ParserForClass, arg, main}
-import mill.api.daemon.experimental
+import mill.api.experimental
 
 @main(doc = "Arguments for PmdModule")
 @experimental

--- a/mill-build/build.mill
+++ b/mill-build/build.mill
@@ -10,7 +10,7 @@ object `package` extends MillBuildRootModule {
   override def mvnDeps = Seq(
     // Hardcode MIMA version so test-mill-bootstrap.sh works with
     // the locally-built `SNAPSHOT` version
-//    mvn"com.github.lolgab::mill-mima_mill1.0.0-RC3:0.2.0-M4",
+    mvn"com.github.lolgab::mill-mima_mill1:0.2.0",
     mvn"net.sourceforge.htmlcleaner:htmlcleaner:2.29",
     // TODO: implement empty version for ivy deps as we do in import parser
     mvn"com.lihaoyi::mill-contrib-buildinfo:${mill.api.BuildInfo.millVersion}",

--- a/mill-build/src/millbuild/MillStableJavaModule.scala
+++ b/mill-build/src/millbuild/MillStableJavaModule.scala
@@ -10,5 +10,5 @@ trait MillStableJavaModule extends MillPublishJavaModule with Mima {
 
   def mimaPreviousVersions: T[Seq[String]] = Settings.mimaBaseVersions
 
-  def mimaExcludeAnnotations = Seq("mill.api.internal.internal", "mill.api.experimental")
+  def mimaExcludeAnnotations = Seq("mill.api.daemon.experimental")
 }

--- a/mill-build/src/millbuild/MillStableJavaModule.scala
+++ b/mill-build/src/millbuild/MillStableJavaModule.scala
@@ -1,0 +1,14 @@
+package millbuild
+
+import com.github.lolgab.mill.mima.*
+import mill.*
+
+/** Publishable module which contains strictly handled API. */
+trait MillStableJavaModule extends MillPublishJavaModule with Mima {
+
+  override def mimaBinaryIssueFilters: T[Seq[ProblemFilter]] = Seq.empty[ProblemFilter]
+
+  def mimaPreviousVersions: T[Seq[String]] = Settings.mimaBaseVersions
+
+  def mimaExcludeAnnotations = Seq("mill.api.internal.internal", "mill.api.experimental")
+}

--- a/mill-build/src/millbuild/MillStableScalaModule.scala
+++ b/mill-build/src/millbuild/MillStableScalaModule.scala
@@ -1,34 +1,5 @@
 package millbuild
-//import com.github.lolgab.mill.mima._
 import mill._, scalalib._
 
 /** Publishable module which contains strictly handled API. */
-trait MillStableScalaModule extends MillPublishScalaModule /*with Mima*/ {
-
-//  override def mimaBinaryIssueFilters: T[Seq[ProblemFilter]] = Seq.empty[ProblemFilter]
-//
-//  def mimaPreviousVersions: T[Seq[String]] = Settings.mimaBaseVersions
-//
-//  def mimaPreviousArtifacts: T[Seq[Dep]] = Task {
-//    Settings.mimaBaseVersions
-//      .map({ version =>
-//        val patchedSuffix = {
-//          val base = artifactSuffix()
-//          version match {
-//            case s"0.$minor.$_" if minor.toIntOption.exists(_ < 12) =>
-//              base match {
-//                case "_3" => "_2.13"
-//                case s"_3_$suffix" => s"_2.13_$suffix"
-//                case _ => base
-//              }
-//            case _ => base
-//          }
-//        }
-//        val patchedId = artifactName() + patchedSuffix
-//        mvn"${pomSettings().organization}:${patchedId}:${version}"
-//      })
-//    Seq.empty[Dep]
-//  }
-//
-//  def mimaExcludeAnnotations = Seq("mill.api.internal.internal", "mill.api.experimental")
-}
+trait MillStableScalaModule extends MillPublishScalaModule with MillStableJavaModule

--- a/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
+++ b/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
@@ -42,7 +42,6 @@ import scala.collection.mutable.Buffer
  * re-evaluation. This should be transparent, improving performance without
  * affecting behavior.
  */
-@internal
 class MillBuildBootstrap(
     projectRoot: os.Path,
     output: os.Path,
@@ -357,7 +356,6 @@ class MillBuildBootstrap(
 
 }
 
-@internal
 object MillBuildBootstrap {
   // Keep this outside of `case class MillBuildBootstrap` because otherwise the lambdas
   // tend to capture the entire enclosing instance, causing memory leaks

--- a/runner/daemon/src/mill/daemon/MillMain0.scala
+++ b/runner/daemon/src/mill/daemon/MillMain0.scala
@@ -24,7 +24,6 @@ import scala.concurrent.duration.Duration
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Using}
 
-@internal
 object MillMain0 {
 
   def handleMillException[T](

--- a/runner/daemon/src/mill/daemon/Watching.scala
+++ b/runner/daemon/src/mill/daemon/Watching.scala
@@ -16,7 +16,6 @@ import scala.util.{Try, Using}
  * Logic around the "watch and wait" functionality in Mill: re-run on change,
  * re-run when the user presses Enter, printing status messages, etc.
  */
-@internal
 object Watching {
   case class Result[T](watched: Seq[Watchable], error: Option[String], result: T)
 


### PR DESCRIPTION
Turns on MIMA for `mill.constants` as well

Tested manually by breaking bincompat in `core.constants` and `libs.javalib` and making sure `__.mimaReportBinaryIssues` fails
