### PR TITLE
Fix spurious version mismatch error when using `-jvm` launcher

### DIFF
--- a/runner/daemon/src/mill/daemon/MillMain0.scala
+++ b/runner/daemon/src/mill/daemon/MillMain0.scala
@@ -600,7 +600,7 @@ object MillMain0 {
 
   def checkMillVersionFromFile(projectDir: os.Path, stderr: PrintStream): Unit = {
     readBestMillVersion(projectDir).foreach { case (file, version) =>
-      if (BuildInfo.millVersion != version.stripSuffix("-native")) {
+      if (BuildInfo.millVersion != version.stripSuffix("-native").stripSuffix("-jvm")) {
         val msg =
           s"""Mill version ${BuildInfo.millVersion} is different than configured for this directory!
              |Configured version is ${version} (${file})""".stripMargin


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/pull/5510

The version mismatch checker should strip trailing `-jvm` suffixes, just like it already strips trailing `-native`