### PR TITLE
Close ExternalSummary class loaders right after use

### DIFF
--- a/integration/feature/leak-hygiene/src/LeakHygieneTests.scala
+++ b/integration/feature/leak-hygiene/src/LeakHygieneTests.scala
@@ -66,7 +66,6 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
         mill.constants.DebugLog("\nstart")
         checkClassloaders(tester)(
           "mill.daemon.MillBuildBootstrap#processRunClasspath classLoader cl" -> 1,
-          "mill.codesig.ExternalSummary.apply upstreamClassloader" -> 1,
           "mill.javalib.JvmWorkerModule#worker cl" -> 1,
           "mill.javalib.worker.JvmWorkerImpl#scalaCompilerCache.setup loader" -> 1
         )
@@ -87,7 +86,6 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
           tester.eval(("show", "clean"))
           tester.eval(("show", "__.compile"))
           checkClassloaders(tester)(
-            "mill.codesig.ExternalSummary.apply upstreamClassloader" -> 1,
             "mill.daemon.MillBuildBootstrap#processRunClasspath classLoader cl" -> 1,
             "mill.kotlinlib.KotlinWorkerManager" -> 1,
             "mill.javalib.JvmWorkerModule#worker cl" -> 2,
@@ -112,7 +110,6 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
         for (i <- Range(0, 2)) {
           tester.eval(("show", "__.compile"))
           checkClassloaders(tester)(
-            "mill.codesig.ExternalSummary.apply upstreamClassloader" -> 1,
             "mill.daemon.MillBuildBootstrap#processRunClasspath classLoader cl" -> 1,
             "mill.kotlinlib.KotlinWorkerManager" -> 1,
             "mill.javalib.JvmWorkerModule#worker cl" -> 2,

--- a/runner/codesig/src/mill/codesig/ExternalSummary.scala
+++ b/runner/codesig/src/mill/codesig/ExternalSummary.scala
@@ -6,6 +6,8 @@ import org.objectweb.asm.{ClassReader, ClassVisitor, MethodVisitor, Opcodes}
 
 import java.net.URLClassLoader
 
+import scala.util.Using
+
 case class ExternalSummary(
     directMethods: Map[JCls, Map[MethodSig, Boolean]],
     directAncestors: Map[JCls, Set[JCls]],
@@ -27,46 +29,48 @@ object ExternalSummary {
       localSummary: LocalSummary,
       upstreamClasspath: Seq[os.Path]
   )(implicit st: SymbolTable): ExternalSummary = {
-    val upstreamClassloader = mill.util.Jvm.createClassLoader(
+    def createUpstreamClassloader() = mill.util.Jvm.createClassLoader(
       upstreamClasspath,
       getClass.getClassLoader
     )
-
-    val allDirectAncestors = localSummary.mapValuesOnly(_.directAncestors).flatten
-
-    val allMethodCallParamClasses = localSummary
-      .mapValuesOnly(_.methods.values)
-      .flatten
-      .flatMap(_.calls)
-      .flatMap(call => Seq(call.cls) ++ call.desc.args)
-      .collect { case c: JType.Cls => c }
 
     val methodsPerCls = collection.mutable.Map.empty[JCls, Map[MethodSig, Boolean]]
     val ancestorsPerCls = collection.mutable.Map.empty[JCls, Set[JCls]]
     val directSuperclasses = collection.mutable.Map.empty[JCls, JCls]
 
-    def load(cls: JCls): Unit = methodsPerCls.getOrElse(cls, load0(cls))
+    Using.resource(createUpstreamClassloader()) { upstreamClassloader =>
+      val allDirectAncestors = localSummary.mapValuesOnly(_.directAncestors).flatten
 
-    def load0(cls: JCls): Unit = {
-      val visitor = new MyClassVisitor()
-      val resourcePath =
-        os.resource(upstreamClassloader) / os.SubPath(cls.name.replace('.', '/') + ".class")
+      val allMethodCallParamClasses = localSummary
+        .mapValuesOnly(_.methods.values)
+        .flatten
+        .flatMap(_.calls)
+        .flatMap(call => Seq(call.cls) ++ call.desc.args)
+        .collect { case c: JType.Cls => c }
 
-      new ClassReader(os.read.inputStream(resourcePath)).accept(
-        visitor,
-        ClassReader.SKIP_CODE | ClassReader.SKIP_FRAMES | ClassReader.SKIP_DEBUG
-      )
+      def load(cls: JCls): Unit = methodsPerCls.getOrElse(cls, load0(cls))
 
-      directSuperclasses(cls) = visitor.superclass
-      methodsPerCls(cls) = visitor.methods
-      ancestorsPerCls(cls) = visitor.ancestors
-      ancestorsPerCls(cls).foreach(load)
+      def load0(cls: JCls): Unit = {
+        val visitor = new MyClassVisitor()
+        val resourcePath =
+          os.resource(upstreamClassloader) / os.SubPath(cls.name.replace('.', '/') + ".class")
+
+        new ClassReader(os.read.inputStream(resourcePath)).accept(
+          visitor,
+          ClassReader.SKIP_CODE | ClassReader.SKIP_FRAMES | ClassReader.SKIP_DEBUG
+        )
+
+        directSuperclasses(cls) = visitor.superclass
+        methodsPerCls(cls) = visitor.methods
+        ancestorsPerCls(cls) = visitor.ancestors
+        ancestorsPerCls(cls).foreach(load)
+      }
+
+      (allDirectAncestors ++ allMethodCallParamClasses)
+        .filter(!localSummary.contains(_))
+        .toSet
+        .foreach(load)
     }
-
-    (allDirectAncestors ++ allMethodCallParamClasses)
-      .filter(!localSummary.contains(_))
-      .toSet
-      .foreach(load)
 
     ExternalSummary(methodsPerCls.toMap, ancestorsPerCls.toMap, directSuperclasses.toMap)
   }


### PR DESCRIPTION
It seems the class loaders used by ExternalSummary are only used right after having been created, and aren't needed anymore after that. So the changes here make sure we do close them right after.