### PR TITLE
Fix `./mill init` example download paths

### DIFF
--- a/dist/package.mill
+++ b/dist/package.mill
@@ -235,13 +235,13 @@ object `package` extends MillJavaModule with DistModule {
     for (path <- examplePaths()) yield {
       val example = path.subRelativeTo(BuildCtx.workspaceRoot)
       val artifactName = example.segments.mkString("-")
-      (path, s"${build.dist.artifactFileNamePrefix()}-$artifactName")
+      s"${build.dist.artifactFileNamePrefix()}-$artifactName"
     }
   }
 
   def exampleZips: T[Seq[PathRef]] = Task {
     examplePathRefs().zip(exampleArtifactNames()).map {
-      case (pr, (examplePath, exampleStr)) =>
+      case (pr, exampleStr) =>
         os.copy(pr.path, Task.dest / exampleStr, createFolders = true)
         val ignoreErrorsOnCI = Task.dest / exampleStr / "ignoreErrorsOnCI"
         if (os.exists(ignoreErrorsOnCI)) os.remove(ignoreErrorsOnCI)

--- a/libs/init/test/src/mill/init/ExampleListTests.scala
+++ b/libs/init/test/src/mill/init/ExampleListTests.scala
@@ -1,0 +1,17 @@
+package mill.init
+
+import utest.*
+
+object ExampleListTests extends TestSuite {
+  override def tests: Tests = Tests {
+    test("init") {
+      val deserialized = upickle.default.read[Seq[(String, String)]](os.read(os.resource / "exampleList.txt"))
+
+      val expected = (
+        "scalalib/basic/1-simple",
+        "https://repo1.maven.org/maven2/com/lihaoyi/mill-dist/SNAPSHOT/mill-dist-SNAPSHOT-example-scalalib-basic-1-simple.zip"
+      )
+      assert(deserialized.contains(expected))
+    }
+  }
+}


### PR DESCRIPTION
Also add a simple smoketests to make sure the paths aren't malformed