### PR TITLE
Fix version sources in CrossSbtTests

### DIFF
--- a/libs/scalalib/src/mill/scalalib/CrossSbtModule.scala
+++ b/libs/scalalib/src/mill/scalalib/CrossSbtModule.scala
@@ -16,7 +16,7 @@ trait CrossSbtModule extends SbtModule with CrossModuleBase { outer =>
   trait CrossSbtTests extends SbtTests {
     override def moduleDir = outer.moduleDir
 
-    def versionSourcesPaths = scalaVersionDirectoryNames.map(s => os.sub / "src/main" / s"scala-$s")
+    def versionSourcesPaths = scalaVersionDirectoryNames.map(s => os.sub / "src/test" / s"scala-$s")
     def versionSources = Task.Sources(versionSourcesPaths*)
     override def sources = Task { super.sources() ++ versionSources() }
   }


### PR DESCRIPTION
They were pointing to src/main instead of src/test.

I was about to file an issue but the fix is easy enough. Of course this probably needs a test.
