### PR TITLE
Give effect to useCpPassingJar settings in RunModule

### DIFF
--- a/libs/javalib/src/mill/javalib/RunModule.scala
+++ b/libs/javalib/src/mill/javalib/RunModule.scala
@@ -306,11 +306,17 @@ object RunModule {
       val mainArgs = args.value
       val classPath = runClasspath ++ extraRunClasspath
       val jvmArgs = Option(forkArgs).getOrElse(forkArgs0)
-      Option(useCpPassingJar) match {
+      val useCpPassingJar1 = Option(useCpPassingJar) match {
         case Some(b) => b: Boolean
         case None => useCpPassingJar0
       }
       val env = Option(forkEnv).getOrElse(forkEnv0)
+
+      val cpPassingJarPath =
+        if useCpPassingJar1 then
+          Some(os.temp(prefix = "run-", suffix = ".jar", deleteOnExit = false))
+        else
+          None
 
       BuildCtx.withFilesystemCheckerDisabled {
         if (background) {
@@ -336,8 +342,7 @@ object RunModule {
             stdin = "",
             stdout = stdout,
             stderr = stderr,
-            cpPassingJarPath =
-              Some(os.temp(prefix = "run-", suffix = ".jar", deleteOnExit = false)),
+            cpPassingJarPath = cpPassingJarPath,
             javaHome = javaHome,
             destroyOnExit = false
           )
@@ -352,8 +357,7 @@ object RunModule {
             stdin = os.Inherit,
             stdout = os.Inherit,
             stderr = os.Inherit,
-            cpPassingJarPath =
-              Some(os.temp(prefix = "run-", suffix = ".jar", deleteOnExit = false)),
+            cpPassingJarPath = cpPassingJarPath,
             javaHome = javaHome
           )
         }


### PR DESCRIPTION
I think the existing logic in RunModule accidentally fails to give effect to user settings for `useCpPassingJar`, whether provided directly when running or via overriding `runUseArgsFile`. Currently, a temporary CLASSPATH-passing jar file will be created unconditionally, on any platform, if `runClasspath` is nonempty. 

This PR attempts to complete logic I think left accidentally not-quite-complete in RunModule.