### PR TITLE
Refactor publishing code to use a more appropriate data structure to represent the publishing data

### DIFF
--- a/contrib/artifactory/src/mill/contrib/artifactory/ArtifactoryPublisher.scala
+++ b/contrib/artifactory/src/mill/contrib/artifactory/ArtifactoryPublisher.scala
@@ -14,42 +14,42 @@ class ArtifactoryPublisher(
   private val api =
     new ArtifactoryHttpApi(credentials, readTimeout = readTimeout, connectTimeout = connectTimeout)
 
-  def publish(fileMapping: Seq[(os.Path, String)], artifact: Artifact): Unit = {
+  def publish(fileMapping: Map[os.SubPath, os.Path], artifact: Artifact): Unit = {
     publishAll(fileMapping -> artifact)
   }
 
-  def publishAll(artifacts: (Seq[(os.Path, String)], Artifact)*): Unit = {
+  def publishAll(artifacts: (Map[os.SubPath, os.Path], Artifact)*): Unit = {
     log.info("arts: " + artifacts)
     val mappings = for ((fileMapping0, artifact) <- artifacts) yield {
-      val publishPath = Seq(
+      val publishPath = os.SubPath(Seq(
         artifact.group.replace(".", "/"),
         artifact.id,
         artifact.version
-      ).mkString("/")
-      val fileMapping = fileMapping0.map { case (file, name) => (file, publishPath + "/" + name) }
-
-      artifact -> fileMapping.map {
-        case (file, name) => name -> os.read.bytes(file)
+      ).mkString("/"))
+      val fileMapping = fileMapping0.map { case (name, contents) =>
+        publishPath / name -> os.read.bytes(contents)
       }
+
+      artifact -> fileMapping
     }
 
     val (snapshots, releases) = mappings.partition(_._1.isSnapshot)
 
-    if (snapshots.nonEmpty) publishToRepo(snapshotUri, snapshots.flatMap(_._2), snapshots.map(_._1))
-    if (releases.nonEmpty) publishToRepo(releaseUri, releases.flatMap(_._2), releases.map(_._1))
+    if (snapshots.nonEmpty) publishToRepo(snapshotUri, snapshots.iterator.flatMap(_._2).toMap, snapshots.map(_._1))
+    if (releases.nonEmpty) publishToRepo(releaseUri, releases.iterator.flatMap(_._2).toMap, releases.map(_._1))
   }
 
   private def publishToRepo(
       repoUri: String,
-      payloads: Seq[(String, Array[Byte])],
+      payloads: Map[os.SubPath, Array[Byte]],
       artifacts: Seq[Artifact]
   ): Unit = {
-    val publishResults = payloads.map {
+    val publishResults = payloads.iterator.map {
       case (fileName, data) =>
         log.info(s"Uploading $fileName")
         val resp = api.upload(s"$repoUri/$fileName", data)
         resp
-    }
+    }.toVector
     reportPublishResults(publishResults, artifacts)
   }
 

--- a/contrib/codeartifact/src/mill/contrib/codeartifact/CodeArtifactPublisher.scala
+++ b/contrib/codeartifact/src/mill/contrib/codeartifact/CodeArtifactPublisher.scala
@@ -21,15 +21,15 @@ class CodeartifactPublisher(
   )
 
   private def basePublishPath(artifact: Artifact) =
-    Seq(
+    os.SubPath(Vector(
       artifact.group.replace(".", "/"),
       artifact.id
-    ).mkString("/")
+    ))
 
   private def versionPublishPath(artifact: Artifact) =
-    s"${basePublishPath(artifact)}/${artifact.version}"
+    basePublishPath(artifact) / artifact.version
 
-  def publish(fileMapping: Seq[(os.Path, String)], artifact: Artifact): Unit = {
+  def publish(fileMapping: Map[os.SubPath, os.Path], artifact: Artifact): Unit = {
     publishAll(fileMapping -> artifact)
   }
 
@@ -53,23 +53,21 @@ class CodeartifactPublisher(
       </versioning>
     </metadata>
 
-  def publishAll(artifacts: (Seq[(os.Path, String)], Artifact)*): Unit = {
+  def publishAll(artifacts: (Map[os.SubPath, os.Path], Artifact)*): Unit = {
     log.info("arts: " + artifacts)
     val mappings = for ((fileMapping0, artifact) <- artifacts) yield {
       val publishPath = versionPublishPath(artifact)
-      val fileMapping = fileMapping0.map {
-        case (file, name) => (file, publishPath + "/" + name)
+      val fileMapping = fileMapping0.map { case (name, contents) =>
+        publishPath / name -> os.read.bytes(contents)
       }
 
-      artifact -> fileMapping.map {
-        case (file, name) => name -> os.read.bytes(file)
-      }
+      artifact -> fileMapping
     }
 
     val (snapshots, releases) = mappings.partition(_._1.isSnapshot)
 
     if (snapshots.nonEmpty) {
-      publishToRepo(snapshotUri, snapshots.flatMap(_._2), snapshots.map(_._1))
+      publishToRepo(snapshotUri, snapshots.iterator.flatMap(_._2).toMap, snapshots.map(_._1))
 
       val artifact = snapshots.head._1
       api.upload(
@@ -78,7 +76,7 @@ class CodeartifactPublisher(
       )
     }
     if (releases.nonEmpty) {
-      publishToRepo(releaseUri, releases.flatMap(_._2), releases.map(_._1))
+      publishToRepo(releaseUri, releases.iterator.flatMap(_._2).toMap, releases.map(_._1))
 
       val artifact = releases.head._1
       api.upload(
@@ -90,15 +88,15 @@ class CodeartifactPublisher(
 
   private def publishToRepo(
       repoUri: String,
-      payloads: Seq[(String, Array[Byte])],
+      payloads: Map[os.SubPath, Array[Byte]],
       artifacts: Seq[Artifact]
   ): Unit = {
-    val publishResults = payloads.map {
+    val publishResults = payloads.iterator.map {
       case (fileName, data) =>
         log.info(s"Uploading $fileName")
         val resp = api.upload(s"$repoUri/$fileName", data)
         resp
-    }
+    }.toVector
     reportPublishResults(publishResults, artifacts)
   }
 

--- a/contrib/gitlab/test/src/mill/contrib/gitlab/GitlabTokenTests.scala
+++ b/contrib/gitlab/test/src/mill/contrib/gitlab/GitlabTokenTests.scala
@@ -141,7 +141,10 @@ object GitlabTokenTests extends TestSuite {
 
       val artifact = Artifact("test.group", "id", "0.0.0")
 
-      publisher.publish(Seq(fakeFile -> "data.file"), artifact)
+      publisher.publish(
+        Map(os.SubPath("data.file") -> fakeFile),
+        artifact
+      )
 
       os.remove(fakeFile)
 

--- a/core/api/src/mill/api/JsonFormatters.scala
+++ b/core/api/src/mill/api/JsonFormatters.scala
@@ -29,6 +29,8 @@ trait JsonFormatters {
   implicit val relPathRW: RW[os.RelPath] = upickle.default.readwriter[String]
     .bimap[os.RelPath](_.toString, os.RelPath(_))
 
+  implicit def subPathRW: RW[os.SubPath] = JsonFormatters.Default.subPathRW
+
   implicit val nioPathRW: RW[java.nio.file.Path] = upickle.default.readwriter[String]
     .bimap[java.nio.file.Path](
       _.toUri().toString(),
@@ -81,4 +83,8 @@ trait JsonFormatters {
   export upickle.implicits.namedTuples.default.given
 }
 
-object JsonFormatters extends JsonFormatters
+object JsonFormatters extends JsonFormatters {
+  object Default {
+    val subPathRW: RW[os.SubPath] = upickle.default.readwriter[String].bimap[os.SubPath](_.toString, os.SubPath(_))
+  }
+}

--- a/example/androidlib/java/4-sum-lib-java/build.mill
+++ b/example/androidlib/java/4-sum-lib-java/build.mill
@@ -129,8 +129,8 @@ Publish ... to /home/.../.m2/repository/...
   },
   "payload": [
     [
-      ".../out/lib/androidAar.dest/library.aar",
-      "lib-0.0.1.aar"
+      "lib-0.0.1.aar",
+      ".../out/lib/androidAar.dest/library.aar"
     ],
 ...
 

--- a/example/androidlib/kotlin/4-sum-lib-kotlin/build.mill
+++ b/example/androidlib/kotlin/4-sum-lib-kotlin/build.mill
@@ -131,8 +131,8 @@ Publish ... to /home/.../.m2/repository/...
   },
   "payload": [
     [
-      ".../out/lib/androidAar.dest/library.aar",
-      "lib-0.0.1.aar"
+      "lib-0.0.1.aar",
+      ".../out/lib/androidAar.dest/library.aar"
     ],
 ...
 

--- a/libs/androidlib/src/mill/androidlib/AndroidLibModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidLibModule.scala
@@ -51,14 +51,14 @@ trait AndroidLibModule extends AndroidModule with PublishModule {
    */
   override def publishArtifacts: T[PublishModule.PublishData] = {
     val baseNameTask: Task[String] = Task.Anon { s"${artifactId()}-${publishVersion()}" }
-    val defaultPayloadTask: Task[Seq[(PathRef, String)]] = (pomPackagingType, this) match {
+    val defaultPayloadTask = (pomPackagingType, this) match {
       case (PackagingType.Aar, androidLib: AndroidLibModule) => Task.Anon {
           val baseName = baseNameTask()
-          Seq(
-            androidLib.androidAar() -> s"$baseName.aar",
-            sourceJar() -> s"$baseName-sources.jar",
-            docJar() -> s"$baseName-javadoc.jar",
-            pom() -> s"$baseName.pom"
+          Map(
+            os.SubPath(s"$baseName.aar") -> androidLib.androidAar(),
+            os.SubPath(s"$baseName-sources.jar") -> sourceJar(),
+            os.SubPath(s"$baseName-javadoc.jar") -> docJar(),
+            os.SubPath(s"$baseName.pom") -> pom()
           )
         }
       case (otherPackagingType, otherModuleType) =>
@@ -71,7 +71,7 @@ trait AndroidLibModule extends AndroidModule with PublishModule {
       PublishModule.PublishData(
         meta = artifactMetadata(),
         payload = defaultPayloadTask() ++ extraPublish().map(p =>
-          (p.file, s"$baseName${p.classifierPart}.${p.ext}")
+          os.SubPath(s"$baseName${p.classifierPart}.${p.ext}") -> p.file
         )
       )
     }

--- a/libs/javalib/src/mill/javalib/PublishModule.scala
+++ b/libs/javalib/src/mill/javalib/PublishModule.scala
@@ -592,10 +592,10 @@ object PublishModule extends ExternalModule with DefaultTaskModule {
     def apply(meta: Artifact, payload: Map[os.SubPath, PathRef]): PublishData =
       apply(meta, mapToSeq(payload))
 
-    private[mill] def seqToMap(payload: Seq[(PathRef, String)]): Map[os.SubPath, PathRef] =
+    private def seqToMap(payload: Seq[(PathRef, String)]): Map[os.SubPath, PathRef] =
       payload.iterator.map { case (pathRef, name) => os.SubPath(name) -> pathRef }.toMap
 
-    private[mill] def mapToSeq(payload: Map[os.SubPath, PathRef]): Seq[(PathRef, String)] =
+    private def mapToSeq(payload: Map[os.SubPath, PathRef]): Seq[(PathRef, String)] =
       payload.iterator.map { case (name, pathRef) => pathRef -> name.toString }.toSeq
   }
 

--- a/libs/javalib/src/mill/javalib/SonatypeCentralPublisher.scala
+++ b/libs/javalib/src/mill/javalib/SonatypeCentralPublisher.scala
@@ -1,10 +1,6 @@
 package mill.javalib
 
-import com.lumidion.sonatype.central.client.core.{
-  DeploymentName,
-  PublishingType,
-  SonatypeCredentials
-}
+import com.lumidion.sonatype.central.client.core.{DeploymentName, PublishingType, SonatypeCredentials}
 import com.lumidion.sonatype.central.client.requests.SyncSonatypeClient
 import mill.api.Logger
 import mill.javalib.internal.PublishModule.GpgArgs
@@ -15,6 +11,7 @@ import mill.javalib.publish.SonatypeHelpers.getArtifactMappings
 import java.nio.file.Files
 import java.util.jar.JarOutputStream
 import java.util.zip.ZipEntry
+import scala.annotation.targetName
 
 /**
  * Publishing logic for the standard Sonatype Central repository `central.sonatype.org`
@@ -53,23 +50,47 @@ class SonatypeCentralPublisher(
   private val sonatypeCentralClient =
     new SyncSonatypeClient(credentials, readTimeout = readTimeout, connectTimeout = connectTimeout)
 
+  // binary compatibility forwarder
   def publish(
       fileMapping: Seq[(os.Path, String)],
       artifact: Artifact,
       publishingType: PublishingType
-  ): Unit = {
+  ): Unit =
+    publish(fileMapping.iterator.map { case (path, name) => os.SubPath(name) -> path }.toMap, artifact, publishingType)
+
+  def publish(
+      fileMapping: Map[os.SubPath, os.Path],
+      artifact: Artifact,
+      publishingType: PublishingType
+  ): Unit =
     publishAll(publishingType, None, fileMapping -> artifact)
-  }
 
   def publishAll(
       publishingType: PublishingType,
       singleBundleName: Option[String],
       artifacts: (Seq[(os.Path, String)], Artifact)*
   ): Unit = {
-    val releases = getArtifactMappings(isSigned = true, gpgArgs, workspace, env, artifacts)
-    log.info(s"mappings ${pprint.apply(releases.map { case (a, kvs) => (a, kvs.map(_._1)) })}")
+    val mappedArtifacts = artifacts.iterator.map { case (fileMapping, artifact) =>
+      val mapping = fileMapping.iterator.map { case (path, name) => os.SubPath(name) -> path }.toMap
+      mapping -> artifact
+    }.toArray
+    publishAll(publishingType, singleBundleName, mappedArtifacts*)
+  }
 
-    val releaseGroups = releases.groupBy(_._1.group)
+  @targetName("publishAllByMap")
+  def publishAll(
+      publishingType: PublishingType,
+      singleBundleName: Option[String],
+      artifacts: (Map[os.SubPath, os.Path], Artifact)*
+  ): Unit = {
+    val releases = getArtifactMappings(isSigned = true, gpgArgs, workspace, env, artifacts)
+    log.info(s"mappings ${pprint.apply(
+      releases.map { case (a, fileSetContents) =>
+        (a, fileSetContents.keys.toVector.sorted.map(_.toString))
+      }
+    )}")
+
+    val releaseGroups = releases.groupBy(_.artifact.group)
     val wd = os.pwd / "out/publish-central"
     os.makeDir.all(wd)
 
@@ -78,7 +99,9 @@ class SonatypeCentralPublisher(
         groupReleases.foreach { case (artifact, data) =>
           val fileNameWithoutExtension = s"${artifact.group}-${artifact.id}-${artifact.version}"
           val zipFile = streamToFile(fileNameWithoutExtension, wd) { outputStream =>
-            log.info(s"bundle $fileNameWithoutExtension with ${pprint.apply(data.map(_._1))}")
+            log.info(
+              s"bundle $fileNameWithoutExtension with ${pprint.apply(data.keys.toVector.sorted.map(_.toString))}"
+            )
             zipFilesToJar(data, outputStream)
           }
 
@@ -153,11 +176,11 @@ class SonatypeCentralPublisher(
   }
 
   private def zipFilesToJar(
-      files: Seq[(String, Array[Byte])],
+      files: Map[os.SubPath, Array[Byte]],
       jarOutputStream: JarOutputStream
   ): Unit = {
     files.foreach { case (filename, fileAsBytes) =>
-      val zipEntry = new ZipEntry(filename)
+      val zipEntry = new ZipEntry(filename.toString)
       jarOutputStream.putNextEntry(zipEntry)
       jarOutputStream.write(fileAsBytes)
       jarOutputStream.closeEntry()

--- a/libs/javalib/src/mill/javalib/publish/LocalIvyPublisher.scala
+++ b/libs/javalib/src/mill/javalib/publish/LocalIvyPublisher.scala
@@ -1,6 +1,7 @@
 package mill.javalib.publish
 
 import mill.api.TaskCtx
+import mill.util.FileSetContents
 
 /**
  * Logic to publish modules to your `~/.ivy2/local` repository
@@ -14,7 +15,6 @@ class LocalIvyPublisher(localIvyRepo: os.Path) {
    * @param ivy If right, the path to the ivy.xml file of this module; if left, its content as a String
    * @param artifact Coordinates of this module
    * @param publishInfos Files to publish in this module
-   * @param ctx
    * @return The files created or written to when publishing locally this module
    */
   def publishLocal(
@@ -22,31 +22,26 @@ class LocalIvyPublisher(localIvyRepo: os.Path) {
       ivy: Either[String, os.Path],
       artifact: Artifact,
       publishInfos: Seq[PublishInfo]
-  )(implicit ctx: TaskCtx.Log): Seq[os.Path] = {
+  )(implicit ctx: TaskCtx.Log): Seq[os.Path] =
+    publishLocal(
+      artifact = artifact,
+      contents = LocalIvyPublisher.createFileSetContents(pom, ivy.merge, artifact, publishInfos)
+    )
 
+  /**
+   * Publishes a module locally
+   *
+   * @param artifact Coordinates of this module
+   * @param contents Files to publish, create with [[LocalIvyPublisher.createFileSetContents]].
+   * @return The files created or written to when publishing locally this module
+   */
+  def publishLocal(
+      artifact: Artifact,
+      contents: Map[os.SubPath, FileSetContents.Writable]
+  )(implicit ctx: TaskCtx.Log): Seq[os.Path] = {
     ctx.log.info(s"Publishing ${artifact} to ivy repo ${localIvyRepo}")
     val releaseDir = localIvyRepo / artifact.group / artifact.id / artifact.version
-
-    val toCopy: Seq[(Either[String, os.Path], os.Path)] =
-      Seq(
-        Right(pom) -> releaseDir / "poms" / s"${artifact.id}.pom",
-        ivy -> releaseDir / "ivys/ivy.xml"
-      ) ++
-        publishInfos.map { entry =>
-          (
-            Right(entry.file.path),
-            releaseDir / s"${entry.ivyType}s" / s"${artifact.id}${entry.classifierPart}.${entry.ext}"
-          )
-        }
-
-    toCopy.map {
-      case (from, to) =>
-        from match {
-          case Left(content) => os.write.over(to, content, createFolders = true)
-          case Right(path) => os.copy.over(path, to, createFolders = true)
-        }
-        to
-    }
+    FileSetContents.writeTo(releaseDir, contents)
   }
 
 }
@@ -56,4 +51,25 @@ object LocalIvyPublisher
       sys.props.get("ivy.home")
         .map(os.Path(_))
         .getOrElse(os.home / ".ivy2") / "local"
-    )
+    ) {
+  /**
+   * @param pom          The POM of this module
+   * @param ivy          If right, the path to the ivy.xml file of this module; if left, its content as a String
+   * @param artifact     Coordinates of this module
+   * @param publishInfos Files to publish in this module
+   */
+  def createFileSetContents(
+    pom: os.Path,
+    ivy: FileSetContents.Writable,
+    artifact: Artifact,
+    publishInfos: Seq[PublishInfo]
+  ): Map[os.SubPath, FileSetContents.Writable] = {
+    Map(
+      os.SubPath("poms") / s"${artifact.id}.pom" -> pom,
+      os.SubPath("ivys") / "ivy.xml" -> ivy
+    ) ++ publishInfos.iterator.map { entry =>
+      os.SubPath(s"${entry.ivyType}s") / s"${artifact.id}${entry.classifierPart}.${entry.ext}" ->
+        entry.file.path
+    }
+  }
+}

--- a/libs/javalib/src/mill/javalib/publish/LocalM2Publisher.scala
+++ b/libs/javalib/src/mill/javalib/publish/LocalM2Publisher.scala
@@ -1,6 +1,7 @@
 package mill.javalib.publish
 
 import mill.api.TaskCtx
+import mill.util.FileSetContents
 
 /**
  * Logic to publish modules to your `~/.m2` repository
@@ -13,28 +14,53 @@ class LocalM2Publisher(m2Repo: os.Path) {
    * @param pom The POM of this module
    * @param artifact Coordinates of this module
    * @param publishInfos Files to publish in this module
-   * @param ctx
    * @return
    */
   def publish(
       pom: os.Path,
       artifact: Artifact,
       publishInfos: Seq[PublishInfo]
+  )(implicit ctx: TaskCtx.Log): Seq[os.Path] =
+    publish(artifact, LocalM2Publisher.createFileSetContents(pom, artifact, publishInfos))
+  
+  /**
+   * Publishes a module in the local Maven repository
+   *
+   * @param artifact Coordinates of this module
+   * @param contents Files to publish, create with [[LocalM2Publisher.createFileSetContents]].
+   */
+  def publish(
+      artifact: Artifact,
+      contents: Map[os.SubPath, FileSetContents.Writable]
   )(implicit ctx: TaskCtx.Log): Seq[os.Path] = {
 
     val releaseDir = m2Repo / artifact.group.split("[.]") / artifact.id / artifact.version
-    ctx.log.info(s"Publish ${artifact.id}-${artifact.version} to ${releaseDir}")
-
-    val toCopy: Seq[(os.Path, os.Path)] =
-      Seq(pom -> releaseDir / s"${artifact.id}-${artifact.version}.pom") ++
-        publishInfos.map { e =>
-          e.file.path -> releaseDir / s"${artifact.id}-${artifact.version}${e.classifierPart}.${e.ext}"
-        }
-    toCopy.map {
-      case (from, to) =>
-        os.copy.over(from, to, createFolders = true)
-        to
-    }
+    ctx.log.info(
+      s"Publish ${artifact.id}-${artifact.version} to $releaseDir. " +
+        s"File list: [${contents.keys.toVector.sorted.mkString(", ")}]"
+    )
+    FileSetContents.writeTo(m2Repo, contents)
   }
+}
+object LocalM2Publisher {
 
+  /**
+   * @param pom The POM of this module
+   * @param artifact Coordinates of this module
+   * @param publishInfos Files to publish in this module
+   */
+  def createFileSetContents(
+    pom: os.Path,
+    artifact: Artifact,
+    publishInfos: Seq[PublishInfo]
+  ): Map[os.SubPath, os.Path] = {
+    val releaseDir =
+      (os.RelPath(".") / artifact.group.split("[.]") / artifact.id / artifact.version).asSubPath
+    val artifactStr = s"${artifact.id}-${artifact.version}"
+
+    Map(releaseDir / s"$artifactStr.pom" -> pom) ++
+      publishInfos.iterator.map { e =>
+        releaseDir / s"$artifactStr${e.classifierPart}.${e.ext}" -> e.file.path
+      }.toMap
+  }
 }

--- a/libs/javalib/src/mill/javalib/publish/SonatypeHelpers.scala
+++ b/libs/javalib/src/mill/javalib/publish/SonatypeHelpers.scala
@@ -1,6 +1,5 @@
 package mill.javalib.publish
 
-import mill.javalib.PublishModule
 import mill.javalib.internal.PublishModule.GpgArgs
 
 import java.math.BigInteger
@@ -17,36 +16,41 @@ object SonatypeHelpers {
       gpgArgs: GpgArgs,
       workspace: os.Path,
       env: Map[String, String],
-      artifacts: Seq[(Seq[(os.Path, String)], Artifact)]
-  ): Seq[(Artifact, Seq[(String, Array[Byte])])] = {
+      artifacts: Seq[(Map[os.SubPath, os.Path], Artifact)]
+  ): Seq[(artifact: Artifact, contents: Map[os.SubPath, Array[Byte]])] = {
     for ((fileMapping0, artifact) <- artifacts) yield {
-      val publishPath = Seq(
-        artifact.group.replace(".", "/"),
-        artifact.id,
-        artifact.version
-      ).mkString("/")
-      val fileMapping = fileMapping0.map { case (file, name) => (file, publishPath + "/" + name) }
+      val publishPath =
+        os.SubPath(artifact.group.replace(".", "/")) / artifact.id / artifact.version
+      val fileMapping = fileMapping0.map { case (name, contents) => publishPath / name -> contents }
 
       val signedArtifacts =
         if (isSigned) fileMapping.map {
-          case (file, name) =>
-            gpgSigned(file = file, args = gpgArgs, workspace = workspace, env = env) -> s"$name.asc"
+          case (name, file) =>
+            val signatureFile =
+              gpgSigned(file = file, args = gpgArgs, workspace = workspace, env = env)
+            os.SubPath(s"$name.asc") -> signatureFile
         }
-        else Seq()
+        else Map.empty
 
-      artifact -> (fileMapping ++ signedArtifacts).flatMap {
-        case (file, name) =>
-          val content = os.read.bytes(file)
+      val allFiles = (fileMapping ++ signedArtifacts).flatMap { case (name, file) =>
+        val content = os.read.bytes(file)
 
-          Seq(
-            name -> content,
-            (name + ".md5") -> md5hex(content),
-            (name + ".sha1") -> sha1hex(content)
-          )
+        Map(
+          name -> content,
+          os.SubPath(s"$name.md5") -> md5hex(content),
+          os.SubPath(s"$name.sha1") -> sha1hex(content)
+        )
       }
+
+      artifact -> allFiles
     }
   }
 
+  /**
+   * Signs a file with GPG.
+   *
+   * @return The path of the signature file.
+   */
   private def gpgSigned(
       file: os.Path,
       args: GpgArgs,

--- a/libs/javalib/src/mill/javalib/publish/SonatypePublisher.scala
+++ b/libs/javalib/src/mill/javalib/publish/SonatypePublisher.scala
@@ -1,9 +1,10 @@
 package mill.javalib.publish
 
 import mill.api.Logger
-import mill.javalib.PublishModule
 import mill.javalib.internal.PublishModule.GpgArgs
 import mill.javalib.publish.SonatypeHelpers.getArtifactMappings
+
+import scala.annotation.targetName
 
 /**
  * The publisher for the end-of-life OSSRH Sonatype publishing.
@@ -63,53 +64,65 @@ class SonatypePublisher(
     connectTimeout = connectTimeout
   )
 
-  def publish(fileMapping: Seq[(os.Path, String)], artifact: Artifact, release: Boolean): Unit = {
+  // binary compatibility forwarder
+  def publish(fileMapping: Seq[(os.Path, String)], artifact: Artifact, release: Boolean): Unit =
+    publishAll(release, fileMapping.iterator.map { case (path, name) => os.SubPath(name) -> path }.toMap -> artifact)
+
+  def publish(fileMapping: Map[os.SubPath, os.Path], artifact: Artifact, release: Boolean): Unit =
     publishAll(release, fileMapping -> artifact)
+
+  // binary compatibility forwarder
+  def publishAll(release: Boolean, artifacts: (Seq[(os.Path, String)], Artifact)*): Unit = {
+    val mappedArtifacts = artifacts.iterator.map { case (fileMapping, artifact) =>
+      val mapping = fileMapping.iterator.map { case (path, name) => os.SubPath(name) -> path }.toMap
+      mapping -> artifact
+    }.toArray
+    publishAll(release, mappedArtifacts*)
   }
 
-  def publishAll(release: Boolean, artifacts: (Seq[(os.Path, String)], Artifact)*): Unit = {
+  @targetName("publishAllByMap")
+  def publishAll(release: Boolean, artifacts: (Map[os.SubPath, os.Path], Artifact)*): Unit = {
     val mappings = getArtifactMappings(signed, gpgArgs, workspace, env, artifacts)
 
-    val (snapshots, releases) = mappings.partition(_._1.isSnapshot)
+    val (snapshots, releases) = mappings.partition(_.artifact.isSnapshot)
     if (snapshots.nonEmpty) {
-      publishSnapshot(snapshots.flatMap(_._2), snapshots.map(_._1))
+      publishSnapshot(
+        snapshots.iterator.flatMap(_.contents).toMap,
+        snapshots.map(_.artifact)
+      )
     }
-    val releaseGroups = releases.groupBy(_._1.group)
+    val releaseGroups = releases.groupBy(_.artifact.group)
     for ((group, groupReleases) <- releaseGroups) {
-      if (stagingRelease) {
-        publishRelease(
-          release,
-          groupReleases.flatMap(_._2),
-          group,
-          releases.map(_._1),
-          awaitTimeout
-        )
-      } else publishReleaseNonstaging(groupReleases.flatMap(_._2), releases.map(_._1))
+      val groupArtifacts = groupReleases.map(_.artifact)
+      val groupContents = groupReleases.iterator.flatMap(_.contents).toMap
+      if (stagingRelease)
+        publishRelease(release, groupContents, group, groupArtifacts, awaitTimeout)
+      else publishReleaseNonstaging(groupContents, groupArtifacts)
     }
   }
 
   private def publishSnapshot(
-      payloads: Seq[(String, Array[Byte])],
+      payloads: Map[os.SubPath, Array[Byte]],
       artifacts: Seq[Artifact]
   ): Unit = {
     publishToUri(payloads, artifacts, snapshotUri)
   }
 
   private def publishToUri(
-      payloads: Seq[(String, Array[Byte])],
+      payloads: Map[os.SubPath, Array[Byte]],
       artifacts: Seq[Artifact],
       uri: String
   ): Unit = {
-    val publishResults = payloads.map {
+    val publishResults = payloads.iterator.map {
       case (fileName, data) =>
         log.info(s"Uploading $fileName")
         api.upload(s"$uri/$fileName", data)
-    }
+    }.toVector
     reportPublishResults(publishResults, artifacts)
   }
 
   private def publishReleaseNonstaging(
-      payloads: Seq[(String, Array[Byte])],
+      payloads: Map[os.SubPath, Array[Byte]],
       artifacts: Seq[Artifact]
   ): Unit = {
     publishToUri(payloads, artifacts, uri)
@@ -117,7 +130,7 @@ class SonatypePublisher(
 
   private def publishRelease(
       release: Boolean,
-      payloads: Seq[(String, Array[Byte])],
+      payloads: Map[os.SubPath, Array[Byte]],
       stagingProfile: String,
       artifacts: Seq[Artifact],
       awaitTimeout: Int

--- a/libs/util/src/mill/util/FileSetContents.scala
+++ b/libs/util/src/mill/util/FileSetContents.scala
@@ -1,0 +1,29 @@
+package mill.util
+
+import os.{Path, SubPath}
+
+object FileSetContents {
+  type Writable = String | Path | Array[Byte]
+
+  /**
+   * Writes the contents to the given directory.
+   *
+   * @return The paths to the written files.
+   */
+  def writeTo(dir: Path, contents: Map[SubPath, Writable]): Vector[Path] = {
+    contents.iterator.map { case (to, content) =>
+      val destination = to.resolveFrom(dir)
+
+      content match {
+        case from: Path =>
+          os.copy.over(from, destination, createFolders = true)
+        case content: String =>
+          os.write.over(destination, content, createFolders = true)
+        case bytes: Array[Byte] @unchecked =>
+          os.write.over(destination, bytes, createFolders = true)
+      }
+
+      destination
+    }.toVector
+  }
+}

--- a/mill-build/src/millbuild/MillStableJavaModule.scala
+++ b/mill-build/src/millbuild/MillStableJavaModule.scala
@@ -11,4 +11,6 @@ trait MillStableJavaModule extends MillPublishJavaModule with Mima {
   def mimaPreviousVersions: T[Seq[String]] = Settings.mimaBaseVersions
 
   def mimaExcludeAnnotations = Seq("mill.api.daemon.experimental")
+
+  override def mimaReportSignatureProblems = true
 }


### PR DESCRIPTION
A part of https://github.com/com-lihaoyi/mill/pull/5425 extracted from it.

The API has been changed from `Seq[(Contents, String)]` to `Map[os.SubPath, Contents]`.

- `String` is replaced with `os.SubPath` to make sure the paths are relative without any `..` components.
- `Seq` is replaced with `Map` to ensure multiple contents cannot be written to the same file path.

Additionally, this turns on mima signature checking which ensures that generics are also checked. This has caught an issue in `defaultGpgArgs`, which has been fixed by this PR as well.