### PR TITLE
Refactor publishing tasks into more granular blocks

### DIFF
--- a/libs/androidlib/src/mill/androidlib/AndroidLibModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidLibModule.scala
@@ -48,22 +48,22 @@ trait AndroidLibModule extends AndroidModule with PublishModule {
    * [[PackagingType.Aar]].
    */
   override def publishArtifactsDefaultPayload(
-    sources: Boolean = true,
-    docs: Boolean = true
+      sources: Boolean = true,
+      docs: Boolean = true
   ): Task[Map[os.SubPath, PathRef]] =
     (pomPackagingType, this) match {
       case (PackagingType.Aar, androidLib: AndroidLibModule) => Task.Anon {
-        val baseName = publishArtifactsBaseName()
-        val baseContent = Map(
-          os.SubPath(s"$baseName.pom") -> pom(),
-          os.SubPath(s"$baseName.aar") -> androidLib.androidAar()
-        )
-        val sourcesOpt =
-          if (sources) Map(os.SubPath(s"$baseName-sources.jar") -> sourceJar()) else Map.empty
-        val docsOpt =
-          if (docs) Map(os.SubPath(s"$baseName-javadoc.jar") -> docJar()) else Map.empty
-        baseContent ++ sourcesOpt ++ docsOpt
-      }
+          val baseName = publishArtifactsBaseName()
+          val baseContent = Map(
+            os.SubPath(s"$baseName.pom") -> pom(),
+            os.SubPath(s"$baseName.aar") -> androidLib.androidAar()
+          )
+          val sourcesOpt =
+            if (sources) Map(os.SubPath(s"$baseName-sources.jar") -> sourceJar()) else Map.empty
+          val docsOpt =
+            if (docs) Map(os.SubPath(s"$baseName-javadoc.jar") -> docJar()) else Map.empty
+          baseContent ++ sourcesOpt ++ docsOpt
+        }
 
       case (otherPackagingType, otherModuleType) =>
         throw new IllegalArgumentException(

--- a/libs/androidlib/src/mill/androidlib/AndroidLibModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidLibModule.scala
@@ -5,7 +5,6 @@ import mill.api.{PathRef, Task}
 import mill.javalib.*
 import mill.javalib.publish.{PackagingType, PublishInfo}
 import mill.util.Jvm
-import upickle.default.*
 import scala.xml.*
 
 @mill.api.experimental
@@ -46,50 +45,36 @@ trait AndroidLibModule extends AndroidModule with PublishModule {
 
   /**
    * Tailored to publish an AAR artifact. Throws an error if the packaging type is not
-   * Aar
-   * @return
+   * [[PackagingType.Aar]].
    */
-  override def publishArtifacts: T[PublishModule.PublishData] = {
-    val baseNameTask: Task[String] = Task.Anon { s"${artifactId()}-${publishVersion()}" }
-    val defaultPayloadTask = (pomPackagingType, this) match {
+  override def publishArtifactsDefaultPayload(
+    sources: Boolean = true,
+    docs: Boolean = true
+  ): Task[Map[os.SubPath, PathRef]] =
+    (pomPackagingType, this) match {
       case (PackagingType.Aar, androidLib: AndroidLibModule) => Task.Anon {
-          val baseName = baseNameTask()
-          Map(
-            os.SubPath(s"$baseName.aar") -> androidLib.androidAar(),
-            os.SubPath(s"$baseName-sources.jar") -> sourceJar(),
-            os.SubPath(s"$baseName-javadoc.jar") -> docJar(),
-            os.SubPath(s"$baseName.pom") -> pom()
-          )
-        }
+        val baseName = publishArtifactsBaseName()
+        val baseContent = Map(
+          os.SubPath(s"$baseName.pom") -> pom(),
+          os.SubPath(s"$baseName.aar") -> androidLib.androidAar()
+        )
+        val sourcesOpt =
+          if (sources) Map(os.SubPath(s"$baseName-sources.jar") -> sourceJar()) else Map.empty
+        val docsOpt =
+          if (docs) Map(os.SubPath(s"$baseName-javadoc.jar") -> docJar()) else Map.empty
+        baseContent ++ sourcesOpt ++ docsOpt
+      }
+
       case (otherPackagingType, otherModuleType) =>
         throw new IllegalArgumentException(
           s"Packaging type $otherPackagingType not supported with $otherModuleType"
         )
     }
-    Task {
-      val baseName = baseNameTask()
-      PublishModule.PublishData(
-        meta = artifactMetadata(),
-        payload = defaultPayloadTask() ++ extraPublish().map(p =>
-          os.SubPath(s"$baseName${p.classifierPart}.${p.ext}") -> p.file
-        )
-      )
-    }
-  }
 
-  override def defaultPublishInfos: T[Seq[PublishInfo]] = {
-    def defaultPublishJars: Task[Seq[(PathRef, PathRef => PublishInfo)]] = {
-      pomPackagingType match {
-        case PackagingType.Pom => Task.Anon(Seq())
-        case _ => Task.Anon(Seq(
-            (androidAar(), PublishInfo.aar),
-            (sourceJar(), PublishInfo.sourcesJar),
-            (docJar(), PublishInfo.docJar)
-          ))
-      }
-    }
-    Task {
-      defaultPublishJars().map { case (jar, info) => info(jar) }
+  override def defaultMainPublishInfos: Task[Seq[PublishInfo]] = {
+    pomPackagingType match {
+      case PackagingType.Pom => Task.Anon(Seq.empty)
+      case _ => Task.Anon(Seq(PublishInfo.aar(androidAar())))
     }
   }
 

--- a/libs/javalib/src/mill/javalib/PublishModule.scala
+++ b/libs/javalib/src/mill/javalib/PublishModule.scala
@@ -5,8 +5,7 @@ import coursier.core.{Configuration, DependencyManagement}
 import mill.api.{DefaultTaskModule, ExternalModule, Task}
 import mill.api.PathRef
 import mill.api.Result
-import mill.util.{JarManifest, PossiblySecret, Secret, Tasks}
-import mill.javalib.publish.SonatypeHelpers.{PASSWORD_ENV_VARIABLE_NAME, USERNAME_ENV_VARIABLE_NAME}
+import mill.util.{JarManifest, Secret, Tasks, FileSetContents}
 import mill.javalib.publish.{Artifact, SonatypePublisher}
 import os.Path
 import mill.api.BuildCtx
@@ -295,17 +294,28 @@ trait PublishModule extends JavaModule { outer =>
     Artifact(pomSettings().organization, artifactId(), publishVersion())
   }
 
-  def defaultPublishInfos: T[Seq[PublishInfo]] = {
-    def defaultPublishJars: Task[Seq[(PathRef, PathRef => PublishInfo)]] = {
-      pomPackagingType match {
-        case PackagingType.Pom => Task.Anon(Seq())
-        case _ => Task.Anon(Seq(
-            (jar(), PublishInfo.jar)
-          ))
-      }
-    }
-    Task {
-      defaultPublishJars().map { case (jar, info) => info(jar) }
+  @deprecated("Use `defaultPublishInfos` that takes parameters instead.", "1.0.1")
+  def defaultPublishInfos: T[Seq[PublishInfo]] =
+    Task { defaultPublishInfos(sources = true, docs = true)() }
+
+  /** The [[PublishInfo]] of the [[defaultMainPublishInfos]] and optionally the [[sourcesJar]] and [[docJar]]. */
+  def defaultPublishInfos(sources: Boolean, docs: Boolean): Task[Seq[PublishInfo]] = {
+    val sourcesJarOpt =
+      if (sources) Task.Anon(Some(PublishInfo.sourcesJar(sourceJar())))
+      else Task.Anon(None)
+
+    val docJarOpt =
+      if (docs) Task.Anon(Some(PublishInfo.docJar(docJar())))
+      else Task.Anon(None)
+
+    Task.Anon(defaultMainPublishInfos() ++ sourcesJarOpt() ++ docJarOpt())
+  }
+
+  /** The [[PublishInfo]] of the main artifact, which can have multiple files. */
+  def defaultMainPublishInfos: Task[Seq[PublishInfo]] = {
+    pomPackagingType match {
+      case PackagingType.Pom => Task.Anon(Seq.empty)
+      case _ => Task.Anon(Seq(PublishInfo.jar(jar())))
     }
   }
 
@@ -367,7 +377,7 @@ trait PublishModule extends JavaModule { outer =>
       sources: Boolean,
       doc: Boolean,
       transitive: Boolean
-  ): Task[Seq[Path]] =
+  ): Task[Seq[Path]] = {
     if (transitive) {
       val publishTransitiveModuleDeps = (transitiveModuleDeps ++ transitiveRunModuleDeps).collect {
         case p: PublishModule => p
@@ -376,39 +386,58 @@ trait PublishModule extends JavaModule { outer =>
         publishMod.publishLocalTask(localIvyRepo, sources, doc, transitive = false)
       }.map(_.flatten)
     } else {
-      val sourcesJarOpt =
-        if (sources) Task.Anon(Some(PublishInfo.sourcesJar(sourceJar())))
-        else Task.Anon(None)
-      val docJarOpt =
-        if (doc) Task.Anon(Some(PublishInfo.docJar(docJar())))
-        else Task.Anon(None)
-
       Task.Anon {
+        val contents = publishLocalContentsTask(sources = sources, doc = doc)()
         val publisher = localIvyRepo() match {
           case None => LocalIvyPublisher
           case Some(path) => new LocalIvyPublisher(path)
         }
-        val publishInfos =
-          defaultPublishInfos() ++ sourcesJarOpt().toSeq ++ docJarOpt().toSeq ++ extraPublish()
-        publisher.publishLocal(
-          pom = pom().path,
-          ivy = Right(ivy().path),
-          artifact = artifactMetadata(),
-          publishInfos = publishInfos
-        )
+        publisher.publishLocal(contents.artifact, contents.contents)
       }
     }
+  }
+
+  /** Produce the contents for the ivy publishing. */
+  private def publishLocalContentsTask(
+    sources: Boolean,
+    doc: Boolean
+  ): Task[(artifact: Artifact, contents: Map[os.SubPath, FileSetContents.Writable])] = {
+    Task.Anon {
+      val publishInfos = defaultPublishInfos(sources = sources, docs = doc)() ++ extraPublish()
+      val artifact = artifactMetadata()
+      val contents = LocalIvyPublisher.createFileSetContents(
+        artifact = artifact,
+        pom = pom().path,
+        ivy = ivy().path,
+        publishInfos = publishInfos
+      )
+      (artifact, contents)
+    }
+  }
 
   /**
    * Publish artifacts to a local Maven repository.
+   *
    * @param m2RepoPath The path to the local repository  as string (default: `$HOME/.m2/repository`).
    *                   If not set, falls back to `maven.repo.local` system property or `~/.m2/repository`
    * @return [[PathRef]]s to published files.
    */
   def publishM2Local(m2RepoPath: String = null): Task.Command[Seq[PathRef]] = m2RepoPath match {
-    case null => Task.Command { publishM2LocalTask(Task.Anon { publishM2LocalRepoPath() })() }
+    case null => Task.Command {
+      publishM2LocalTask(
+        Task.Anon { publishM2LocalRepoPath() },
+        sources = true,
+        docs = true
+      )()
+    }
     case p =>
-      Task.Command { publishM2LocalTask(Task.Anon { os.Path(p, BuildCtx.workspaceRoot) })() }
+      Task.Command {
+        publishM2LocalTask(
+          Task.Anon { os.Path(p, BuildCtx.workspaceRoot) },
+          sources = true,
+          docs = true
+        )()
+      }
   }
 
   /**
@@ -416,7 +445,7 @@ trait PublishModule extends JavaModule { outer =>
    * @return [[PathRef]]s to published files.
    */
   def publishM2LocalCached: T[Seq[PathRef]] = Task {
-    publishM2LocalTask(publishM2LocalRepoPath)()
+    publishM2LocalTask(publishM2LocalRepoPath, sources = true, docs = true)()
   }
 
   /**
@@ -429,18 +458,26 @@ trait PublishModule extends JavaModule { outer =>
       .getOrElse(os.Path(os.home / ".m2", BuildCtx.workspaceRoot)) / "repository"
   }
 
-  private def publishM2LocalTask(m2RepoPath: Task[os.Path]): Task[Seq[PathRef]] = Task.Anon {
+  private def publishM2LocalTask(
+    m2RepoPath: Task[os.Path], sources: Boolean, docs: Boolean
+  ): Task[Seq[PathRef]] = Task.Anon {
     val path = m2RepoPath()
-    val publishInfos = defaultPublishInfos() ++
-      Seq(
-        PublishInfo.sourcesJar(sourceJar()),
-        PublishInfo.docJar(docJar())
-      ) ++
-      extraPublish()
+    val contents = publishM2LocalContentsTask(sources = sources, docs = docs)()
 
     new LocalM2Publisher(path)
-      .publish(pom().path, artifactMetadata(), publishInfos)
+      .publish(contents.artifact, contents.contents)
       .map(PathRef(_).withRevalidateOnce)
+  }
+
+  /** Produce the contents for the maven publishing. */
+  private def publishM2LocalContentsTask(sources: Boolean, docs: Boolean)
+      : Task[(artifact: Artifact, contents: Map[os.SubPath, os.Path])] = Task.Anon {
+    val publishInfos = defaultPublishInfos(sources = sources, docs = docs)() ++ extraPublish()
+    val artifact = artifactMetadata()
+    val contents =
+      LocalM2Publisher.createFileSetContents(pom = pom().path, artifact = artifact, publishInfos)
+
+    (artifact, contents)
   }
 
   /** @see [[PublishModule.sonatypeLegacyOssrhUri]] */
@@ -449,33 +486,57 @@ trait PublishModule extends JavaModule { outer =>
   /** @see [[PublishModule.sonatypeCentralSnapshotUri]] */
   def sonatypeCentralSnapshotUri: String = PublishModule.sonatypeCentralSnapshotUri
 
-  def publishArtifacts: T[PublishModule.PublishData] = {
-    val baseNameTask: Task[String] = Task.Anon { s"${artifactId()}-${publishVersion()}" }
-    val defaultPayloadTask = (pomPackagingType, this) match {
-      case (PackagingType.Pom, _) => Task.Anon {
-          val baseName = baseNameTask()
-          Map(
-            os.SubPath(s"$baseName.pom") -> pom()
-          )
-        }
-      case (PackagingType.Jar, _) | _ => Task.Anon {
-          val baseName = baseNameTask()
-          Map(
-            os.SubPath(s"$baseName.jar") -> jar(),
-            os.SubPath(s"$baseName-sources.jar") -> sourceJar(),
-            os.SubPath(s"$baseName-javadoc.jar") -> docJar(),
-            os.SubPath(s"$baseName.pom") -> pom()
-          )
-        }
-    }
-    Task {
-      val baseName = baseNameTask()
-      PublishModule.PublishData(
-        meta = artifactMetadata(),
-        payload = defaultPayloadTask() ++ extraPublish().map(p =>
-          os.SubPath(s"$baseName${p.classifierPart}.${p.ext}") -> p.file
+  def publishArtifacts: T[PublishModule.PublishData] = Task {
+    PublishModule.PublishData(artifactMetadata(), publishArtifactsPayload()())
+  }
+
+  /** [[publishArtifactsDefaultPayload]] with [[extraPublish]]. */
+  def publishArtifactsPayload(
+    sources: Boolean = true,
+    docs: Boolean = true
+  ): Task[Map[os.SubPath, PathRef]] = Task {
+    val defaultPayload = publishArtifactsDefaultPayload(sources = sources, docs = docs)()
+    val baseName = publishArtifactsBaseName()
+    val extraPayload =
+      extraPublish().iterator.map(p =>
+        os.SubPath(s"$baseName${p.classifierPart}.${p.ext}") -> p.file
+      ).toMap
+    defaultPayload ++ extraPayload
+  }
+
+  /** The base name for the published artifacts. */
+  def publishArtifactsBaseName: T[String] =
+    Task { s"${artifactId()}-${publishVersion()}" }
+
+  /**
+   * The default payload for the published artifacts.
+   *
+   * @param sources whether to include sources JAR when [[pomPackagingType]] is [[PackagingType.Jar]]
+   * @param docs whether to include javadoc JAR when [[pomPackagingType]] is [[PackagingType.Jar]]
+   */
+  def publishArtifactsDefaultPayload(
+    sources: Boolean = true,
+    docs: Boolean = true
+  ): Task[Map[os.SubPath, PathRef]] = {
+    pomPackagingType match {
+      case PackagingType.Pom => Task.Anon {
+        val baseName = publishArtifactsBaseName()
+        Map(
+          os.SubPath(s"$baseName.pom") -> pom()
         )
-      )
+      }
+
+      case _ => Task.Anon {
+        val baseName = publishArtifactsBaseName()
+        val baseContent = Map(
+          os.SubPath(s"$baseName.pom") -> pom(),
+          os.SubPath(s"$baseName.jar") -> jar()
+        )
+        val sourcesOpt =
+          if (sources) Map(os.SubPath(s"$baseName-sources.jar") -> sourceJar()) else Map.empty
+        val docsOpt = if (docs) Map(os.SubPath(s"$baseName-javadoc.jar") -> docJar()) else Map.empty
+        baseContent ++ sourcesOpt ++ docsOpt
+      }
     }
   }
 

--- a/libs/javalib/src/mill/javalib/PublishModule.scala
+++ b/libs/javalib/src/mill/javalib/PublishModule.scala
@@ -399,8 +399,8 @@ trait PublishModule extends JavaModule { outer =>
 
   /** Produce the contents for the ivy publishing. */
   private def publishLocalContentsTask(
-    sources: Boolean,
-    doc: Boolean
+      sources: Boolean,
+      doc: Boolean
   ): Task[(artifact: Artifact, contents: Map[os.SubPath, FileSetContents.Writable])] = {
     Task.Anon {
       val publishInfos = defaultPublishInfos(sources = sources, docs = doc)() ++ extraPublish()
@@ -424,12 +424,12 @@ trait PublishModule extends JavaModule { outer =>
    */
   def publishM2Local(m2RepoPath: String = null): Task.Command[Seq[PathRef]] = m2RepoPath match {
     case null => Task.Command {
-      publishM2LocalTask(
-        Task.Anon { publishM2LocalRepoPath() },
-        sources = true,
-        docs = true
-      )()
-    }
+        publishM2LocalTask(
+          Task.Anon { publishM2LocalRepoPath() },
+          sources = true,
+          docs = true
+        )()
+      }
     case p =>
       Task.Command {
         publishM2LocalTask(
@@ -459,7 +459,9 @@ trait PublishModule extends JavaModule { outer =>
   }
 
   private def publishM2LocalTask(
-    m2RepoPath: Task[os.Path], sources: Boolean, docs: Boolean
+      m2RepoPath: Task[os.Path],
+      sources: Boolean,
+      docs: Boolean
   ): Task[Seq[PathRef]] = Task.Anon {
     val path = m2RepoPath()
     val contents = publishM2LocalContentsTask(sources = sources, docs = docs)()
@@ -492,8 +494,8 @@ trait PublishModule extends JavaModule { outer =>
 
   /** [[publishArtifactsDefaultPayload]] with [[extraPublish]]. */
   def publishArtifactsPayload(
-    sources: Boolean = true,
-    docs: Boolean = true
+      sources: Boolean = true,
+      docs: Boolean = true
   ): Task[Map[os.SubPath, PathRef]] = Task {
     val defaultPayload = publishArtifactsDefaultPayload(sources = sources, docs = docs)()
     val baseName = publishArtifactsBaseName()
@@ -515,28 +517,29 @@ trait PublishModule extends JavaModule { outer =>
    * @param docs whether to include javadoc JAR when [[pomPackagingType]] is [[PackagingType.Jar]]
    */
   def publishArtifactsDefaultPayload(
-    sources: Boolean = true,
-    docs: Boolean = true
+      sources: Boolean = true,
+      docs: Boolean = true
   ): Task[Map[os.SubPath, PathRef]] = {
     pomPackagingType match {
       case PackagingType.Pom => Task.Anon {
-        val baseName = publishArtifactsBaseName()
-        Map(
-          os.SubPath(s"$baseName.pom") -> pom()
-        )
-      }
+          val baseName = publishArtifactsBaseName()
+          Map(
+            os.SubPath(s"$baseName.pom") -> pom()
+          )
+        }
 
       case _ => Task.Anon {
-        val baseName = publishArtifactsBaseName()
-        val baseContent = Map(
-          os.SubPath(s"$baseName.pom") -> pom(),
-          os.SubPath(s"$baseName.jar") -> jar()
-        )
-        val sourcesOpt =
-          if (sources) Map(os.SubPath(s"$baseName-sources.jar") -> sourceJar()) else Map.empty
-        val docsOpt = if (docs) Map(os.SubPath(s"$baseName-javadoc.jar") -> docJar()) else Map.empty
-        baseContent ++ sourcesOpt ++ docsOpt
-      }
+          val baseName = publishArtifactsBaseName()
+          val baseContent = Map(
+            os.SubPath(s"$baseName.pom") -> pom(),
+            os.SubPath(s"$baseName.jar") -> jar()
+          )
+          val sourcesOpt =
+            if (sources) Map(os.SubPath(s"$baseName-sources.jar") -> sourceJar()) else Map.empty
+          val docsOpt =
+            if (docs) Map(os.SubPath(s"$baseName-javadoc.jar") -> docJar()) else Map.empty
+          baseContent ++ sourcesOpt ++ docsOpt
+        }
     }
   }
 


### PR DESCRIPTION
While working on sonatype central snapshot publishing I noticed that `AndroidLibModule` is overriding `publishArtifacts` Task while copying a lot of code from the parent's `PublishModule.publishArtifacts` task.

For example, if you compare these two:
https://github.com/com-lihaoyi/mill/blob/8d6bbf562cbda3f5e730433d7d0e94f484681288/libs/javalib/src/mill/javalib/PublishModule.scala#L452-L480
https://github.com/com-lihaoyi/mill/blob/8d6bbf562cbda3f5e730433d7d0e94f484681288/libs/androidlib/src/mill/androidlib/AndroidLibModule.scala#L52-L78

<img width="1788" height="654" alt="image" src="https://github.com/user-attachments/assets/21651aef-be6a-49b9-93e8-c2047ab4ff4c" />

You can see that most of the code is copy-pasted and only a few bits differ.

This leads to two problems:

1. If `PublishModule.publishArtifacts` logic is changed, people can forget to update the `AndroidLibModule.publishArtifacts`.
2. When changing either of those you have to play "find the differences" game while grokking the intent of the code.

Similar problem is witnessed in `defaultPublishInfos`:
https://github.com/com-lihaoyi/mill/blob/8d6bbf562cbda3f5e730433d7d0e94f484681288/libs/javalib/src/mill/javalib/PublishModule.scala#L298-L310
https://github.com/com-lihaoyi/mill/blob/8d6bbf562cbda3f5e730433d7d0e94f484681288/libs/androidlib/src/mill/androidlib/AndroidLibModule.scala#L80-L94
<img width="1682" height="350" alt="image" src="https://github.com/user-attachments/assets/59c609ec-b967-440e-94c5-fe3730d8432f" />

This PR splits out the logic into smaller blocks which `AndroidLibModule` can then override (specifically it overrides `publishArtifactsDefaultPayload` and `defaultMainPublishInfos`).

---

Part of https://github.com/com-lihaoyi/mill/pull/5425.