### PR TITLE
Snapshot handling in `SonatypeCentralPublishModule/publishAll`

### DIFF
--- a/libs/javalib/src/mill/javalib/SonatypeCentralPublishModule.scala
+++ b/libs/javalib/src/mill/javalib/SonatypeCentralPublishModule.scala
@@ -60,7 +60,7 @@ trait SonatypeCentralPublishModule extends PublishModule with MavenWorkerSupport
       val artifacts = MavenWorkerSupport.RemoteM2Publisher.asM2Artifacts(
         pom().path,
         artifact,
-        defaultPublishInfos(sources = sources, docs = docs)
+        defaultPublishInfos(sources = sources, docs = docs)()
       )
 
       Task.log.info(
@@ -141,7 +141,7 @@ object SonatypeCentralPublishModule extends ExternalModule with DefaultTaskModul
       bundleName: String = ""
   ): Command[Unit] = Task.Command {
     val artifacts = Task.sequence(publishArtifacts.value)().map(_.withConcretePath)
-    val (snapshotArtifacts, releaseArtifacts) = artifacts.partition(_.artifact.isSnapshot)
+    val (snapshotArtifacts, releaseArtifacts) = artifacts.partition(_._2.isSnapshot)
     val log = Task.log
 
     if (snapshotArtifacts.nonEmpty) {

--- a/libs/javalib/src/mill/javalib/publish/model.scala
+++ b/libs/javalib/src/mill/javalib/publish/model.scala
@@ -10,6 +10,7 @@ case class Artifact(group: String, id: String, version: String) derives RW {
       !version.contains("/"),
     "Artifact coordinates must not contain `/`s"
   )
+
   def isSnapshot: Boolean = version.endsWith("-SNAPSHOT")
 }
 


### PR DESCRIPTION
Currently, there are two ways to publish artifacts to Sonatype Central:
- `./mill __.publishSonatypeCentral`
- `./mill SonatypeCentralPublishModule/publishAll`

Unfortunately, they have different code paths, and when adding snapshot support, I only added it to `publishSonatypeCentral`, which resulted in people being confused about why things do not work when they use `SonatypeCentralPublishModule/publishAll`.

I looked at whether snapshot support can be added to `publishAll`, but it seems it can't, as the `publishArtifacts: mill.util.Tasks[PublishModule.PublishData] = Tasks.resolveMainDefault("__:PublishModule.publishArtifacts")` value does not have enough metadata for snapshot publishing (we require `PublishInfo`, but by the time we get `PublishData` it is already gone).

The current solution is to:
- abort the task if you're only trying to publish snapshots.
- warn the user and skip the snapshots if you are mixing snapshots and releases.

The solution isn't great, but the whole publishing pipeline needs improvements, as mentioned in https://github.com/com-lihaoyi/mill/issues/5538.