### PR TITLE
Add tests to sonatype snapshot publishing (0.12.x)

### DIFF
--- a/integration/feature/publish-sonatype-central-snapshots/src/PublishSonatypeCentralSnapshotTests.scala
+++ b/integration/feature/publish-sonatype-central-snapshots/src/PublishSonatypeCentralSnapshotTests.scala
@@ -1,17 +1,17 @@
-import mill.javalib.publish.SonatypeHelpers
+import mill.javalib.publish.SonatypeHelpers.{PASSWORD_ENV_VARIABLE_NAME, USERNAME_ENV_VARIABLE_NAME}
 import mill.testkit.UtestIntegrationTestSuite
-import utest._
-import SonatypeHelpers.{USERNAME_ENV_VARIABLE_NAME, PASSWORD_ENV_VARIABLE_NAME}
+import utest.*
 
 object PublishSonatypeCentralSnapshotTests extends UtestIntegrationTestSuite {
+  private val ENV_VAR_PUBLISH_ORG = "MILL_TESTS_PUBLISH_ORG"
+  private val ENV_VAR_DRY_RUN = "MILL_TESTS_PUBLISH_DRY_RUN"
+
   val tests: Tests = Tests {
-    test("publish") - integrationTest { tester =>
+    test("actual") - integrationTest { tester =>
       import tester.*
 
-      val PUBLISH_ORG_ENV_VARIABLE_NAME = "MILL_TESTS_PUBLISH_ORG"
-
       val env = sys.env
-      val maybePublishOrg = env.get(PUBLISH_ORG_ENV_VARIABLE_NAME)
+      val maybePublishOrg = env.get(ENV_VAR_PUBLISH_ORG)
       val maybePublishUsername = env.get(USERNAME_ENV_VARIABLE_NAME)
       val maybePublishPassword = env.get(PASSWORD_ENV_VARIABLE_NAME)
 
@@ -20,21 +20,12 @@ object PublishSonatypeCentralSnapshotTests extends UtestIntegrationTestSuite {
           val res = eval(
             "testProject.publishSonatypeCentral",
             env = Map(
-              PUBLISH_ORG_ENV_VARIABLE_NAME -> publishOrg,
+              ENV_VAR_PUBLISH_ORG -> publishOrg,
               USERNAME_ENV_VARIABLE_NAME -> publishUsername,
               PASSWORD_ENV_VARIABLE_NAME -> publishPassword
             )
           )
-          println(
-            s"""Success: ${res.isSuccess}
-               |
-               |stdout:
-               |${res.out}
-               |
-               |stderr:
-               |${res.err}
-               |""".stripMargin
-          )
+          println(res.debugString)
           // Extract the values so that `assert` macro would print them out nicely if the test fails
           // instead of printing `res` twice.
           val isSuccess = res.isSuccess
@@ -45,7 +36,7 @@ object PublishSonatypeCentralSnapshotTests extends UtestIntegrationTestSuite {
           case class WithName[A](name: String, description: String, value: A)
           val missingEnvVars = Vector(
             WithName(
-              PUBLISH_ORG_ENV_VARIABLE_NAME,
+              ENV_VAR_PUBLISH_ORG,
               "The organization to publish to",
               maybePublishOrg
             ),
@@ -54,10 +45,75 @@ object PublishSonatypeCentralSnapshotTests extends UtestIntegrationTestSuite {
           ).filter(_.value.isEmpty).map(v => s"${v.name} (${v.description})")
 
           println(
-            s"""Test is disabled because the following environment variables are not set:
+            s"""Test is disabled by default (due to the potential flakyness and slowness of Sonatype Central).
+               |
+               |To enable this test, set the following environment variables:
                |${missingEnvVars.mkString("\n")}""".stripMargin
           )
       }
+    }
+
+    test("dryRun") - integrationTest { tester =>
+      import tester.*
+
+      val res = eval(
+        "testProject.publishSonatypeCentral",
+        env = Map(
+          ENV_VAR_PUBLISH_ORG -> "io.github.mill_tests",
+          USERNAME_ENV_VARIABLE_NAME -> "mill-tests-username",
+          PASSWORD_ENV_VARIABLE_NAME -> "mill-tests-password",
+          ENV_VAR_DRY_RUN -> "1"
+        )
+      )
+      println(res.debugString)
+      // Extract the values so that `assert` macro would print them out nicely if the test fails
+      // instead of printing `res` twice.
+      val isSuccess = res.isSuccess
+      val err = res.err
+      assert(isSuccess && err.contains("finished with result:"))
+
+      val publishedDir =
+        workspacePath / "out" / "testProject" / "publishSonatypeCentral.dest" / "repository" / "io" / "github" /
+          "mill_tests" / "testProject_3"
+
+      val rootMetadataFile = publishedDir / "maven-metadata.xml"
+      assert(os.exists(rootMetadataFile))
+
+      val rootMetadataContents = os.read(rootMetadataFile)
+      assert(rootMetadataContents.contains("<version>0.0.1-SNAPSHOT</version>"))
+
+      val publishedVersionDir = publishedDir / "0.0.1-SNAPSHOT"
+
+      val metadataFile = publishedVersionDir / "maven-metadata.xml"
+      assert(os.exists(metadataFile))
+
+      val metadataContents: String = os.read(metadataFile)
+      assert(metadataContents.contains("<version>0.0.1-SNAPSHOT</version>"))
+
+      val timestampRegex = """<timestamp>(\d{8}\.\d{6})</timestamp>""".r
+      val timestamp = timestampRegex.findFirstMatchIn(metadataContents).map(_.group(1)).getOrElse {
+        throw new Exception(
+          s"No timestamp found via $timestampRegex in $metadataFile:\n$metadataContents"
+        )
+      }
+
+      val expectedFiles = Vector(
+        rootMetadataFile,
+        publishedDir / "maven-metadata.xml.md5",
+        publishedDir / "maven-metadata.xml.sha1",
+        metadataFile,
+        publishedVersionDir / "maven-metadata.xml.md5",
+        publishedVersionDir / "maven-metadata.xml.sha1",
+        publishedVersionDir / s"testProject_3-0.0.1-$timestamp-1.jar",
+        publishedVersionDir / s"testProject_3-0.0.1-$timestamp-1.jar.md5",
+        publishedVersionDir / s"testProject_3-0.0.1-$timestamp-1.jar.sha1",
+        publishedVersionDir / s"testProject_3-0.0.1-$timestamp-1.pom",
+        publishedVersionDir / s"testProject_3-0.0.1-$timestamp-1.pom.md5",
+        publishedVersionDir / s"testProject_3-0.0.1-$timestamp-1.pom.sha1"
+      )
+      val actualFiles = os.walk(publishedDir).toVector
+      val missingFiles = expectedFiles.filterNot(actualFiles.contains)
+      assert(missingFiles.isEmpty)
     }
   }
 }

--- a/integration/feature/publish-sonatype-central/resources/build.mill
+++ b/integration/feature/publish-sonatype-central/resources/build.mill
@@ -1,0 +1,19 @@
+package build
+
+import mill._, scalalib._, publish._
+
+object testProject extends ScalaModule with SonatypeCentralPublishModule {
+  def scalaVersion = "3.3.6"
+  def publishVersion = "0.0.1"
+
+  def pomSettings = Task {
+    PomSettings(
+      description = "Hello",
+      organization = "io.github.lihaoyi",
+      url = "https://github.com/lihaoyi/example",
+      licenses = Seq(License.MIT),
+      versionControl = VersionControl.github("lihaoyi", "example"),
+      developers = Seq(Developer("lihaoyi", "Li Haoyi", "https://github.com/lihaoyi"))
+    )
+  }
+}

--- a/integration/feature/publish-sonatype-central/resources/testProject/src/Foo.scala
+++ b/integration/feature/publish-sonatype-central/resources/testProject/src/Foo.scala
@@ -1,0 +1,7 @@
+package foo
+
+object Foo {
+  def main(args: Array[String]): Unit = {
+    println("Hello World")
+  }
+}

--- a/integration/feature/publish-sonatype-central/src/PublishSonatypeCentralTests.scala
+++ b/integration/feature/publish-sonatype-central/src/PublishSonatypeCentralTests.scala
@@ -1,0 +1,62 @@
+import mill.javalib.publish.SonatypeHelpers.{PASSWORD_ENV_VARIABLE_NAME, USERNAME_ENV_VARIABLE_NAME}
+import mill.testkit.UtestIntegrationTestSuite
+import utest.*
+
+object PublishSonatypeCentralTests extends UtestIntegrationTestSuite {
+  private val ENV_VAR_DRY_RUN = "MILL_TESTS_PUBLISH_DRY_RUN"
+
+  val tests: Tests = Tests {
+    test("dryRun") - integrationTest { tester =>
+      import tester.*
+
+      val res = eval(
+        "testProject.publishSonatypeCentral",
+        env = Map(
+          USERNAME_ENV_VARIABLE_NAME -> "mill-tests-username",
+          PASSWORD_ENV_VARIABLE_NAME -> "mill-tests-password",
+          ENV_VAR_DRY_RUN -> "1",
+          "MILL_PGP_SECRET_BASE64" -> "LS0tLS1CRUdJTiBQR1AgUFJJVkFURSBLRVkgQkxPQ0stLS0tLQoKeFZnRWFHekhpeFlKS3dZQkJBSGFSdzhCQVFkQWxQamhsaGo5MUtZUnhDQXFtaUZNMjR1UEVDL0kxemR0CnlWS2dRR1lENHZZQUFQOW9jK0ZFQzQ2dkt6b0tNWVE3M1Jvemh4UDE3WWhUZnZwRFBwYk1CZHNZQ2c2RQp6VEpwYnk1bmFYUm9kV0l1WVhKMGRYSmhlaTUwWlhOMFVISnZhbVZqZENCaWIzUWdQR0Z6UUdGeWRIVnkKWVhvdWJtVjBQc0tNQkJBV0NnQWRCUUpvYk1lTEJBc0pCd2dERlFnS0JCWUFBZ0VDR1FFQ0d3TUNIZ0VBCklRa1FBMkRDK3lxemF1RVdJUVRnUmJWQ05LcVpxRTFkdDB3RFlNTDdLck5xNFR1L0FQNHRDYzZpYWNUdQpZVEJBa2Q3UDZOM1E1VTZjbGdnSElVQ2lRL3lIbmFvVHZ3RUExbU92M2MydEVORGtrdnF5Ujl2YVhWNHEKZlBEckNDRmRTUTR0anpMY3hnVEhYUVJvYk1lTEVnb3JCZ0VFQVpkVkFRVUJBUWRBUHpzMjV5RERLSC80Cm1KNmtMU1dLSExITXJEWUZMWGVHOTNWRTluSVY0Q0FEQVFnSEFBRC9aQ1hVMDhqMkZTU2VYQWdZaFZzNwp2akVDQjQweTA2TjdaM0pqaitCSko3Z08xc0o0QkJnV0NBQUpCUUpvYk1lTEFoc01BQ0VKRUFOZ3d2c3EKczJyaEZpRUU0RVcxUWpTcW1haE5YYmRNQTJEQyt5cXphdUgrY2dEL1QxRUVkVDl1WnR6L255bGk1OHR0CjYxaWNLcndyU3kzSTBBRDNYWWErcm40QS9qWEZlZXNsNVBZZWtpU0ZzNVZGNUczRVNpWmY0amJxZXlOWQpLd09ENVIwSwo9WDhSdQotLS0tLUVORCBQR1AgUFJJVkFURSBLRVkgQkxPQ0stLS0tLQo="
+        )
+      )
+      println(res.debugString)
+      // Extract the values so that `assert` macro would print them out nicely if the test fails
+      // instead of printing `res` twice.
+      val isSuccess = res.isSuccess
+      assert(isSuccess)
+
+      val dir =
+        workspacePath / "out" / "testProject" / "publishSonatypeCentral.dest" / "repository" /
+          "io.github.lihaoyi.testProject_3-0.0.1"
+
+      val expectedFiles = Vector(
+        dir / "io/github/lihaoyi/testProject_3/0.0.1/testProject_3-0.0.1-javadoc.jar",
+        dir / "io/github/lihaoyi/testProject_3/0.0.1/testProject_3-0.0.1-javadoc.jar.asc",
+        dir / "io/github/lihaoyi/testProject_3/0.0.1/testProject_3-0.0.1-javadoc.jar.asc.md5",
+        dir / "io/github/lihaoyi/testProject_3/0.0.1/testProject_3-0.0.1-javadoc.jar.asc.sha1",
+        dir / "io/github/lihaoyi/testProject_3/0.0.1/testProject_3-0.0.1-javadoc.jar.md5",
+        dir / "io/github/lihaoyi/testProject_3/0.0.1/testProject_3-0.0.1-javadoc.jar.sha1",
+        dir / "io/github/lihaoyi/testProject_3/0.0.1/testProject_3-0.0.1-sources.jar",
+        dir / "io/github/lihaoyi/testProject_3/0.0.1/testProject_3-0.0.1-sources.jar.asc",
+        dir / "io/github/lihaoyi/testProject_3/0.0.1/testProject_3-0.0.1-sources.jar.asc.md5",
+        dir / "io/github/lihaoyi/testProject_3/0.0.1/testProject_3-0.0.1-sources.jar.asc.sha1",
+        dir / "io/github/lihaoyi/testProject_3/0.0.1/testProject_3-0.0.1-sources.jar.md5",
+        dir / "io/github/lihaoyi/testProject_3/0.0.1/testProject_3-0.0.1-sources.jar.sha1",
+        dir / "io/github/lihaoyi/testProject_3/0.0.1/testProject_3-0.0.1.jar",
+        dir / "io/github/lihaoyi/testProject_3/0.0.1/testProject_3-0.0.1.jar.asc",
+        dir / "io/github/lihaoyi/testProject_3/0.0.1/testProject_3-0.0.1.jar.asc.md5",
+        dir / "io/github/lihaoyi/testProject_3/0.0.1/testProject_3-0.0.1.jar.asc.sha1",
+        dir / "io/github/lihaoyi/testProject_3/0.0.1/testProject_3-0.0.1.jar.md5",
+        dir / "io/github/lihaoyi/testProject_3/0.0.1/testProject_3-0.0.1.jar.sha1",
+        dir / "io/github/lihaoyi/testProject_3/0.0.1/testProject_3-0.0.1.pom",
+        dir / "io/github/lihaoyi/testProject_3/0.0.1/testProject_3-0.0.1.pom.asc",
+        dir / "io/github/lihaoyi/testProject_3/0.0.1/testProject_3-0.0.1.pom.asc.md5",
+        dir / "io/github/lihaoyi/testProject_3/0.0.1/testProject_3-0.0.1.pom.asc.sha1",
+        dir / "io/github/lihaoyi/testProject_3/0.0.1/testProject_3-0.0.1.pom.md5",
+        dir / "io/github/lihaoyi/testProject_3/0.0.1/testProject_3-0.0.1.pom.sha1"
+      )
+      val actualFiles = os.walk(dir).toVector
+      val missingFiles = expectedFiles.filterNot(actualFiles.contains)
+      assert(missingFiles.isEmpty)
+    }
+  }
+}

--- a/scalalib/maven-worker/src/mill/scalalib/maven/worker/impl/WorkerImpl.scala
+++ b/scalalib/maven-worker/src/mill/scalalib/maven/worker/impl/WorkerImpl.scala
@@ -32,9 +32,9 @@ class WorkerImpl extends internal.MavenWorkerSupport.Api {
   }
 
   override def publishToLocal(
-    publishTo: Path,
-    workspace: Path,
-    artifacts: IterableOnce[RemoteM2Publisher.M2Artifact]
+      publishTo: Path,
+      workspace: Path,
+      artifacts: IterableOnce[RemoteM2Publisher.M2Artifact]
   ): RemoteM2Publisher.DeployResult = {
     val deployResult = WorkerRemoteM2Publisher.publishLocal(
       publishTo = publishTo,
@@ -64,7 +64,7 @@ class WorkerImpl extends internal.MavenWorkerSupport.Api {
 }
 object WorkerImpl {
   def deployResultFromMaven(deployResult: org.eclipse.aether.deployment.DeployResult)
-  : RemoteM2Publisher.DeployResult =
+      : RemoteM2Publisher.DeployResult =
     RemoteM2Publisher.DeployResult(
       artifacts = deployResult.getArtifacts.iterator().asScala.map(_.toString).toVector,
       metadatas = deployResult.getMetadata.iterator().asScala.map(_.toString).toVector

--- a/scalalib/maven-worker/src/mill/scalalib/maven/worker/impl/WorkerImpl.scala
+++ b/scalalib/maven-worker/src/mill/scalalib/maven/worker/impl/WorkerImpl.scala
@@ -1,15 +1,16 @@
 package mill.scalalib.maven.worker.impl
 
 import ch.qos.logback.classic.{Level, Logger}
-import mill.scalalib.MavenWorkerSupport
+import mill.scalalib.internal
 import mill.scalalib.MavenWorkerSupport.RemoteM2Publisher
 import org.slf4j.LoggerFactory
+import os.Path
 
 import scala.jdk.CollectionConverters.*
 
 //noinspection ScalaUnusedSymbol - invoked dynamically as a worker.
-class WorkerImpl extends MavenWorkerSupport.Api {
-  def publishToRemote(
+class WorkerImpl extends internal.MavenWorkerSupport.Api {
+  override def publishToRemote(
       uri: String,
       workspace: os.Path,
       username: String,
@@ -27,10 +28,21 @@ class WorkerImpl extends MavenWorkerSupport.Api {
       )
     }
 
-    RemoteM2Publisher.DeployResult(
-      artifacts = deployResult.getArtifacts.iterator().asScala.map(_.toString).toVector,
-      metadatas = deployResult.getMetadata.iterator().asScala.map(_.toString).toVector
+    WorkerImpl.deployResultFromMaven(deployResult)
+  }
+
+  override def publishToLocal(
+    publishTo: Path,
+    workspace: Path,
+    artifacts: IterableOnce[RemoteM2Publisher.M2Artifact]
+  ): RemoteM2Publisher.DeployResult = {
+    val deployResult = WorkerRemoteM2Publisher.publishLocal(
+      publishTo = publishTo,
+      workspace = workspace,
+      artifacts = artifacts.iterator.map(WorkerRemoteM2Publisher.asM2Artifact)
     )
+
+    WorkerImpl.deployResultFromMaven(deployResult)
   }
 
   private def withQuietLogging[T](
@@ -49,4 +61,12 @@ class WorkerImpl extends MavenWorkerSupport.Api {
       originalLevels.foreach(t => t._1.setLevel(t._2))
     }
   }
+}
+object WorkerImpl {
+  def deployResultFromMaven(deployResult: org.eclipse.aether.deployment.DeployResult)
+  : RemoteM2Publisher.DeployResult =
+    RemoteM2Publisher.DeployResult(
+      artifacts = deployResult.getArtifacts.iterator().asScala.map(_.toString).toVector,
+      metadatas = deployResult.getMetadata.iterator().asScala.map(_.toString).toVector
+    )
 }

--- a/scalalib/src/mill/scalalib/MavenWorkerSupport.scala
+++ b/scalalib/src/mill/scalalib/MavenWorkerSupport.scala
@@ -16,9 +16,9 @@ private[mill] trait MavenWorkerSupport extends CoursierModule {
     Jvm.createClassLoader(classPath = classPath.indexed, parent = getClass.getClassLoader)
   }
 
-  protected def mavenWorker: Worker[MavenWorkerSupport.Api] = Task.Worker {
+  protected def mavenWorker: Worker[internal.MavenWorkerSupport.Api] = Task.Worker {
     mavenWorkerClassloader().loadClass("mill.scalalib.maven.worker.impl.WorkerImpl")
-      .getConstructor().newInstance().asInstanceOf[MavenWorkerSupport.Api]
+      .getConstructor().newInstance().asInstanceOf[internal.MavenWorkerSupport.Api]
   }
 }
 object MavenWorkerSupport {

--- a/scalalib/src/mill/scalalib/SonatypeCentralPublishModule.scala
+++ b/scalalib/src/mill/scalalib/SonatypeCentralPublishModule.scala
@@ -43,6 +43,7 @@ trait SonatypeCentralPublishModule extends PublishModule with MavenWorkerSupport
       val publishData = publishArtifacts()
       val artifact = publishData.meta
       val finalCredentials = getSonatypeCredentials(username, password)()
+      val dryRun = Task.env.get("MILL_TESTS_PUBLISH_DRY_RUN").contains("1")
 
       def publishSnapshot(): Unit = {
         val uri = sonatypeSnapshotUri
@@ -56,14 +57,24 @@ trait SonatypeCentralPublishModule extends PublishModule with MavenWorkerSupport
           s"Detected a 'SNAPSHOT' version, publishing to Sonatype Central Snapshots at '$uri'"
         )
         val worker = mavenWorker()
-        val result = worker.publishToRemote(
-          uri = uri,
-          workspace = Task.dest / "maven",
-          username = finalCredentials.username,
-          password = finalCredentials.password,
-          artifacts
-        )
-        Task.log.info(s"Deployment to '$uri' finished with result: $result")
+        if (dryRun) {
+          val publishTo = Task.dest / "repository"
+          val result = worker.publishToLocal(
+            publishTo = publishTo,
+            workspace = Task.dest / "maven",
+            artifacts
+          )
+          Task.log.info(s"Dry-run publishing to '$publishTo' finished with result: $result")
+        } else {
+          val result = worker.publishToRemote(
+            uri = uri,
+            workspace = Task.dest / "maven",
+            username = finalCredentials.username,
+            password = finalCredentials.password,
+            artifacts
+          )
+          Task.log.info(s"Publishing to '$uri' finished with result: $result")
+        }
       }
 
       def publishRelease(): Unit = {
@@ -79,11 +90,23 @@ trait SonatypeCentralPublishModule extends PublishModule with MavenWorkerSupport
           env = Task.env,
           awaitTimeout = sonatypeCentralAwaitTimeout()
         )
-        publisher.publish(
-          fileMapping,
-          artifact,
-          getPublishingTypeFromReleaseFlag(sonatypeCentralShouldRelease())
-        )
+
+        if (dryRun) {
+          val publishTo = Task.dest / "repository"
+          publisher.publishAllToLocal(
+            publishTo,
+            singleBundleName = None,
+            (fileMapping, artifact)
+          )
+          Task.log.info(s"Dry-run publishing to '$publishTo' finished.")
+        } else {
+          publisher.publish(
+            fileMapping,
+            artifact,
+            getPublishingTypeFromReleaseFlag(sonatypeCentralShouldRelease())
+          )
+          Task.log.info("Publishing finished.")
+        }
       }
 
       // The snapshot publishing does not use the same API as release publishing.

--- a/scalalib/src/mill/scalalib/SonatypeCentralPublisher.scala
+++ b/scalalib/src/mill/scalalib/SonatypeCentralPublisher.scala
@@ -1,6 +1,10 @@
 package mill.scalalib
 
-import com.lumidion.sonatype.central.client.core.{DeploymentName, PublishingType, SonatypeCredentials}
+import com.lumidion.sonatype.central.client.core.{
+  DeploymentName,
+  PublishingType,
+  SonatypeCredentials
+}
 import com.lumidion.sonatype.central.client.requests.SyncSonatypeClient
 import mill.api.Logger
 import mill.scalalib.publish.Artifact
@@ -37,7 +41,7 @@ class SonatypeCentralPublisher(
       singleBundleName: Option[String],
       artifacts: (Seq[(os.Path, String)], Artifact)*
   ): Unit = {
-    val prepared = prepareToPublishAll(singleBundleName, artifacts*)
+    val prepared = prepareToPublishAll(singleBundleName, artifacts *)
     log.info(prepared.mappingsString)
 
     prepared.deployments.foreach { case (zipFile, deploymentName) =>
@@ -46,11 +50,11 @@ class SonatypeCentralPublisher(
   }
 
   private[mill] def publishAllToLocal(
-    publishTo: os.Path,
-    singleBundleName: Option[String],
-    artifacts: (Seq[(os.Path, String)], Artifact)*
+      publishTo: os.Path,
+      singleBundleName: Option[String],
+      artifacts: (Seq[(os.Path, String)], Artifact)*
   ): Unit = {
-    val prepared = prepareToPublishAll(singleBundleName, artifacts*)
+    val prepared = prepareToPublishAll(singleBundleName, artifacts *)
     log.info(prepared.mappingsString)
 
     prepared.deployments.foreach { case (zipFile, deploymentName) =>
@@ -62,20 +66,20 @@ class SonatypeCentralPublisher(
   }
 
   private case class PreparedArtifacts(
-    mappings: Seq[(Artifact, Seq[(String, Array[Byte])])],
-    deployments: Vector[(File, DeploymentName)]
+      mappings: Seq[(Artifact, Seq[(String, Array[Byte])])],
+      deployments: Vector[(File, DeploymentName)]
   ) {
     def mappingsString: String = s"mappings ${pprint.apply(
-      mappings.map { case (a, fileSetContents) =>
-        (a, fileSetContents.sortBy(_._1).map(_._1))
-      }
-    )}"
+        mappings.map { case (a, fileSetContents) =>
+          (a, fileSetContents.sortBy(_._1).map(_._1))
+        }
+      )}"
   }
 
   /** Prepare artifacts for publishing. */
   private def prepareToPublishAll(
-    singleBundleName: Option[String],
-    artifacts: (Seq[(os.Path, String)], Artifact)*
+      singleBundleName: Option[String],
+      artifacts: (Seq[(os.Path, String)], Artifact)*
   ): PreparedArtifacts = {
     val releases = getArtifactMappings(isSigned = true, gpgArgs, workspace, env, artifacts)
 

--- a/scalalib/src/mill/scalalib/internal/MavenWorkerSupport.scala
+++ b/scalalib/src/mill/scalalib/internal/MavenWorkerSupport.scala
@@ -1,0 +1,17 @@
+package mill.scalalib.internal
+
+import mill.api.internal
+import mill.scalalib.MavenWorkerSupport.RemoteM2Publisher
+
+@internal
+object MavenWorkerSupport {
+  trait Api extends mill.scalalib.MavenWorkerSupport.Api {
+
+    /** Publishes artifacts to a local Maven repository. */
+    def publishToLocal(
+        publishTo: os.Path,
+        workspace: os.Path,
+        artifacts: IterableOnce[RemoteM2Publisher.M2Artifact]
+    ): RemoteM2Publisher.DeployResult
+  }
+}

--- a/testkit/src/mill/testkit/IntegrationTester.scala
+++ b/testkit/src/mill/testkit/IntegrationTester.scala
@@ -41,7 +41,18 @@ object IntegrationTester {
    * A very simplified version of `os.CommandResult` meant for easily
    * performing assertions against.
    */
-  case class EvalResult(isSuccess: Boolean, out: String, err: String)
+  case class EvalResult(isSuccess: Boolean, out: String, err: String) {
+    def debugString: String = {
+      s"""Success: $isSuccess
+         |
+         |stdout:
+         |$out
+         |
+         |stderr:
+         |$err
+         |""".stripMargin
+    }
+  }
 
   trait Impl extends AutoCloseable with IntegrationTesterBase {
 


### PR DESCRIPTION
Adds tests that run in CI that publish to a local directory for sonatype central release and snapshot publishing.

Backport of https://github.com/com-lihaoyi/mill/pull/5525
