### PR TITLE
Minor fixes for project importer

### DIFF
--- a/libs/init/buildgen/src/mill/main/buildgen/BuildGenUtil.scala
+++ b/libs/init/buildgen/src/mill/main/buildgen/BuildGenUtil.scala
@@ -533,7 +533,7 @@ object BuildGenUtil {
     val name = backtickWrap(testModule)
     testModuleExtraType match {
       case Some(supertype) => s"object $name extends $testModuleMainType with $supertype"
-      case None => s"trait $name extends $testModuleMainType"
+      case None => s"object $name extends $testModuleMainType with TestModule.Junit4"
     }
   }
 

--- a/runner/meta/src/mill/meta/CodeGen.scala
+++ b/runner/meta/src/mill/meta/CodeGen.scala
@@ -69,7 +69,9 @@ object CodeGen {
           // resolve logic to traverse, cannot actually be evaluated and used
           val lhs = backtickWrap(c)
           val rhs = s"${pkgSelector2(Some(c))}.package_"
-          s"final lazy val $lhs: $rhs.type = $rhs // subfolder module reference"
+          // Leave a space between `lhs` and `:` in case `lhs` ends with a `_`, since
+          // without the space they would be parsed as one token and fail compilation
+          s"final lazy val $lhs : $rhs.type = $rhs // subfolder module reference"
         }
         .mkString("\n")
 


### PR DESCRIPTION
- If no test framework can be identified, default to `TestModule.Junit4` to allow the build to at least compile
- Add a space between the `lazy val $lhs` and the following `:` to avoid parsing errors when `lhs` ends with a `_`

Noticed these while trying to get MIMA imports working