### PR TITLE
Avoid use .right.get.

### DIFF
--- a/runner/launcher/src/mill/launcher/CoursierClient.scala
+++ b/runner/launcher/src/mill/launcher/CoursierClient.scala
@@ -27,13 +27,14 @@ object CoursierClient {
         )))
         .withRepositories(Seq(TestOverridesRepo) ++ repositories)
 
-      resolve.either() match {
-        case Left(err) => sys.error(err.toString)
-        case Right(v) =>
-          Artifacts(coursierCache0)
-            .withResolution(v)
-            .eitherResult()
-            .right.get
+      val result = resolve.either().flatMap { v =>
+        Artifacts(coursierCache0)
+          .withResolution(v)
+          .eitherResult()
+      }
+      result match {
+        case Left(e) => sys.error(e.toString())
+        case Right(v) => v
       }
     }
 


### PR DESCRIPTION
This can avoid useless error message like 
```
 Either.right.get on Left
```