### PR TITLE
Avoid configuring `scie` when building PEX files

### DIFF
--- a/libs/pythonlib/src/mill/pythonlib/PythonModule.scala
+++ b/libs/pythonlib/src/mill/pythonlib/PythonModule.scala
@@ -120,7 +120,7 @@ trait PythonModule extends PipModule with DefaultTaskModule with JavaHomeModule 
   /**
    * Command-line options to pass as bundle configuration defined by the user.
    */
-  def bundleOptions: T[Seq[String]] = Task { Seq("--scie", "eager") }
+  def bundleOptions: T[Seq[String]] = Task { Seq.empty[String] }
 
   // TODO: right now, any task that calls this helper will have its own python
   // cache. This is slow. Look into sharing the cache between tasks.


### PR DESCRIPTION
Hopefully this will fix the flakiness we've been seeing where the `scie` step in PEX gets rate limited by github

```
[6546] pex: Zipping PEX file.
[6546] pex: Zipping PEX file.: 347.5ms
[6546] pex: Building scie(s)
[6546] pex: Building scie(s): 3358.7ms
[6546] Traceback (most recent call last):
[6546]   File "/home/runner/work/mill/mill/out/integration/localOutFolder.dest/local-0/out/out/foo/pythonExe.dest/venv/lib/python3.12/site-packages/pex/result.py", line 105, in catch
[6546]     return func(*args, **kwargs)
[6546]            ^^^^^^^^^^^^^^^^^^^^^
[6546]   File "/home/runner/work/mill/mill/out/integration/localOutFolder.dest/local-0/out/out/foo/pythonExe.dest/venv/lib/python3.12/site-packages/pex/bin/pex.py", line 1379, in do_main
[6546]     for scie_info in scie.build(
[6546]   File "/home/runner/work/mill/mill/out/integration/localOutFolder.dest/local-0/out/out/foo/pythonExe.dest/venv/lib/python3.12/site-packages/pex/scie/science.py", line 503, in build
[6546]     raise ScienceError(
[6546] pex.scie.science.ScienceError: Failed to build 1 scie:
[6546] 
[6546] 1. For CPython 3.12 on linux-x86_64: Command `/home/runner/.cache/pex/scies/0/science/0.8.0/bin/science --cache-dir /home/runner/.cache/pex/scies/0/science/0.8.0/cache -v lift --file pex=/home/runner/work/mill/mill/out/integration/localOutFolder.dest/local-0/out/out/foo/bundle.dest/bundle.pex --file configure-binding.py=/home/runner/work/mill/mill/out/integration/localOutFolder.dest/local-0/out/out/foo/pythonExe.dest/venv/lib/python3.12/site-packages/pex/scie/configure-binding.py build --dest-dir /home/runner/work/mill/mill/out/integration/localOutFolder.dest/local-0/out/out/foo/bundle.dest bundle-lift-linux-x86_64.toml` failed with exit code 1 (saved lift manifest to bundle-lift-linux-x86_64.toml for inspection):
[6546] HTTP Request: GET https://api.github.com/repos/indygreg/python-build-standalone/releases/latest "HTTP/1.1 403 rate limit exceeded"
[6546]   File "<frozen runpy>", line 198, in _run_module_as_main
[6546]   File "<frozen runpy>", line 88, in _run_code
[6546]   File "/home/runner/.cache/nce/a3cbb39820d0908147a1b448838de1fefca95c8b177fb484471c758200ca3f3e/science.pyz/__main__.py", line 3, in <module>
[6546]     _bootstrap.bootstrap()
[6546]   File "/home/runner/.cache/nce/a3cbb39820d0908147a1b448838de1fefca95c8b177fb484471c758200ca3f3e/science.pyz/_bootstrap/__init__.py", line 253, in bootstrap
[6546]     run(import_string(env.entry_point))
[6546]   File "/home/runner/.cache/nce/a3cbb39820d0908147a1b448838de1fefca95c8b177fb484471c758200ca3f3e/science.pyz/_bootstrap/__init__.py", line 38, in run
[6546]     sys.exit(module())
[6546]              ^^^^^^^^
[6546]   File "/home/runner/.cache/nce/ba7257887eb1da08c71c410700e65849b7716ee6237f3e86558d33802728b3ec/bindings/shiv_root/science.pyz_ee33d73d113bc985a5864e6f8cba0864a510cb1e41b1ee0166167c2dc244968c/site-packages/science/exe.py", line 749, in main
[6546]     _main(prog_name=SCIE_ARGV0)
[6546]   File "/home/runner/.cache/nce/ba7257887eb1da08c71c410700e65849b7716ee6237f3e86558d33802728b3ec/bindings/shiv_root/science.pyz_ee33d73d113bc985a5864e6f8cba0864a510cb1e41b1ee0166167c2dc244968c/site-packages/click/core.py", line 1157, in __call__
[6546]     return self.main(*args, **kwargs)
[6546]            ^^^^^^^^^^^^^^^^^^^^^^^^^^
[6546]   File "/home/runner/.cache/nce/ba7257887eb1da08c71c410700e65849b7716ee6237f3e86558d33802728b3ec/bindings/shiv_root/science.pyz_ee33d73d113bc985a5864e6f8cba0864a510cb1e41b1ee0166167c2dc244968c/site-packages/click/core.py", line 1078, in main
[6546]     rv = self.invoke(ctx)
[6546]          ^^^^^^^^^^^^^^^^
[6546]   File "/home/runner/.cache/nce/ba7257887eb1da08c71c410700e65849b7716ee6237f3e86558d33802728b3ec/bindings/shiv_root/science.pyz_ee33d73d113bc985a5864e6f8cba0864a510cb1e41b1ee0166167c2dc244968c/site-packages/click/core.py", line 1688, in invoke
[6546]     return _process_result(sub_ctx.command.invoke(sub_ctx))
[6546]                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[6546]   File "/home/runner/.cache/nce/ba7257887eb1da08c71c410700e65849b7716ee6237f3e86558d33802728b3ec/bindings/shiv_root/science.pyz_ee33d73d113bc985a5864e6f8cba0864a510cb1e41b1ee0166167c2dc244968c/site-packages/click/core.py", line 1688, in invoke
[6546]     return _process_result(sub_ctx.command.invoke(sub_ctx))
[6546]                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[6546]   File "/home/runner/.cache/nce/ba7257887eb1da08c71c410700e65849b7716ee6237f3e86558d33802728b3ec/bindings/shiv_root/science.pyz_ee33d73d113bc985a5864e6f8cba0864a510cb1e41b1ee0166167c2dc244968c/site-packages/click/core.py", line 1434, in invoke
[6546]     return ctx.invoke(self.callback, **ctx.params)
[6546]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[6546]   File "/home/runner/.cache/nce/ba7257887eb1da08c71c410700e65849b7716ee6237f3e86558d33802728b3ec/bindings/shiv_root/science.pyz_ee33d73d113bc985a5864e6f8cba0864a510cb1e41b1ee0166167c2dc244968c/site-packages/click/core.py", line 783, in invoke
[6546]     return __callback(*args, **kwargs)
[6546]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
[6546]   File "/home/runner/.cache/nce/ba7257887eb1da08c71c410700e65849b7716ee6237f3e86558d33802728b3ec/bindings/shiv_root/science.pyz_ee33d73d113bc985a5864e6f8cba0864a510cb1e41b1ee0166167c2dc244968c/site-packages/click/decorators.py", line 92, in new_func
[6546]     return ctx.invoke(f, obj, *args, **kwargs)
[6546]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[6546]   File "/home/runner/.cache/nce/ba7257887eb1da08c71c410700e65849b7716ee6237f3e86558d33802728b3ec/bindings/shiv_root/science.pyz_ee33d73d113bc985a5864e6f8cba0864a510cb1e41b1ee0166167c2dc244968c/site-packages/click/core.py", line 783, in invoke
[6546]     return __callback(*args, **kwargs)
[6546]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
[6546]   File "/home/runner/.cache/nce/ba7257887eb1da08c71c410700e65849b7716ee6237f3e86558d33802728b3ec/bindings/shiv_root/science.pyz_ee33d73d113bc985a5864e6f8cba0864a510cb1e41b1ee0166167c2dc244968c/site-packages/science/exe.py", line 690, in _build
[6546]     application = parse_application(lift_config, config)
[6546]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[6546]   File "/home/runner/.cache/nce/ba7257887eb1da08c71c410700e65849b7716ee6237f3e86558d33802728b3ec/bindings/shiv_root/science.pyz_ee33d73d113bc985a5864e6f8cba0864a510cb1e41b1ee0166167c2dc244968c/site-packages/science/exe.py", line 572, in parse_application
[6546]     application = parse_config(config, source=config.name)
[6546]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[6546]   File "/home/runner/.cache/nce/ba7257887eb1da08c71c410700e65849b7716ee6237f3e86558d33802728b3ec/bindings/shiv_root/science.pyz_ee33d73d113bc985a5864e6f8cba0864a510cb1e41b1ee0166167c2dc244968c/site-packages/science/config.py", line 41, in parse_config
[6546]     return parse_config_data(Data(provenance=provenance, data=data))
[6546]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[6546]   File "/home/runner/.cache/nce/ba7257887eb1da08c71c410700e65849b7716ee6237f3e86558d33802728b3ec/bindings/shiv_root/science.pyz_ee33d73d113bc985a5864e6f8cba0864a510cb1e41b1ee0166167c2dc244968c/site-packages/science/config.py", line 143, in parse_config_data
[6546]     interp := parse_dataclass(
[6546]               ^^^^^^^^^^^^^^^^
[6546]   File "/home/runner/.cache/nce/ba7257887eb1da08c71c410700e65849b7716ee6237f3e86558d33802728b3ec/bindings/shiv_root/science.pyz_ee33d73d113bc985a5864e6f8cba0864a510cb1e41b1ee0166167c2dc244968c/site-packages/science/dataclass/deserializer.py", line 177, in parse
[6546]     kwargs[field.name] = parser(data)
[6546]                          ^^^^^^^^^^^^
[6546]   File "/home/runner/.cache/nce/ba7257887eb1da08c71c410700e65849b7716ee6237f3e86558d33802728b3ec/bindings/shiv_root/science.pyz_ee33d73d113bc985a5864e6f8cba0864a510cb1e41b1ee0166167c2dc244968c/site-packages/science/config.py", line 72, in parse_provider
[6546]     return provider_type.create(identifier=fields.id, lazy=fields.lazy, config=config)
[6546]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[6546]   File "/home/runner/.cache/nce/ba7257887eb1da08c71c410700e65849b7716ee6237f3e86558d33802728b3ec/bindings/shiv_root/science.pyz_ee33d73d113bc985a5864e6f8cba0864a510cb1e41b1ee0166167c2dc244968c/site-packages/science/providers/python_build_standalone.py", line 204, in create
[6546]     release = release_data["name"]
[6546]               ~~~~~~~~~~~~^^^^^^^^
[6546] builtins.KeyError: 'name'
[6546] Failed to build 1 scie:
```