### PR TITLE
Split up `docJar` into javadoc/scaladoc generation and jar creation

### DIFF
--- a/libs/javalib/src/mill/javalib/JavaModule.scala
+++ b/libs/javalib/src/mill/javalib/JavaModule.scala
@@ -17,7 +17,7 @@ import mill.javalib.api.CompilationResult
 import mill.javalib.bsp.{BspJavaModule, BspModule}
 import mill.javalib.internal.ModuleUtils
 import mill.javalib.publish.Artifact
-import mill.util.{JarManifest, Jvm, Jvm as Seq}
+import mill.util.{JarManifest, Jvm}
 import os.Path
 
 import scala.util.chaining.scalaUtilChainingOps
@@ -1131,9 +1131,8 @@ trait JavaModule
         stdin = os.Inherit,
         stdout = os.Inherit
       )
-
-      PathRef(javadocDir)
     }
+    PathRef(javadocDir)
   }
 
   /**

--- a/libs/javalib/src/mill/javalib/JavaModule.scala
+++ b/libs/javalib/src/mill/javalib/JavaModule.scala
@@ -9,7 +9,13 @@ import coursier.util.{EitherT, ModuleMatcher, Monad}
 import mainargs.Flag
 import mill.api.{MillException, Result}
 import mill.api.daemon.internal.{EvaluatorApi, JavaModuleApi, internal}
-import mill.api.daemon.internal.bsp.{BspBuildTarget, BspJavaModuleApi, BspModuleApi, BspUri, JvmBuildTarget}
+import mill.api.daemon.internal.bsp.{
+  BspBuildTarget,
+  BspJavaModuleApi,
+  BspModuleApi,
+  BspUri,
+  JvmBuildTarget
+}
 import mill.javalib.*
 import mill.api.daemon.internal.idea.GenIdeaInternalApi
 import mill.api.{DefaultTaskModule, ModuleRef, PathRef, Segment, Task, TaskCtx}

--- a/libs/javalib/src/mill/javalib/JavaModule.scala
+++ b/libs/javalib/src/mill/javalib/JavaModule.scala
@@ -9,22 +9,17 @@ import coursier.util.{EitherT, ModuleMatcher, Monad}
 import mainargs.Flag
 import mill.api.{MillException, Result}
 import mill.api.daemon.internal.{EvaluatorApi, JavaModuleApi, internal}
-import mill.api.daemon.internal.bsp.{
-  BspBuildTarget,
-  BspJavaModuleApi,
-  BspModuleApi,
-  BspUri,
-  JvmBuildTarget
-}
+import mill.api.daemon.internal.bsp.{BspBuildTarget, BspJavaModuleApi, BspModuleApi, BspUri, JvmBuildTarget}
 import mill.javalib.*
 import mill.api.daemon.internal.idea.GenIdeaInternalApi
-import mill.api.{ModuleRef, PathRef, Segment, Task, TaskCtx, DefaultTaskModule}
+import mill.api.{DefaultTaskModule, ModuleRef, PathRef, Segment, Task, TaskCtx}
 import mill.javalib.api.CompilationResult
 import mill.javalib.bsp.{BspJavaModule, BspModule}
 import mill.javalib.internal.ModuleUtils
 import mill.javalib.publish.Artifact
-import mill.util.{JarManifest, Jvm}
+import mill.util.{JarManifest, Jvm, Jvm as Seq}
 import os.Path
+
 import scala.util.chaining.scalaUtilChainingOps
 import scala.util.matching.Regex
 
@@ -1085,11 +1080,7 @@ trait JavaModule
    */
   def docJarUseArgsFile: T[Boolean] = Task { scala.util.Properties.isWin }
 
-  /**
-   * The documentation jar, containing all the Javadoc/Scaladoc HTML files, for
-   * publishing to Maven Central
-   */
-  def docJar: T[PathRef] = Task[PathRef] {
+  def generatedJavadoc: T[PathRef] = Task[PathRef] {
     val outDir = Task.dest
 
     val javadocDir = outDir / "javadoc"
@@ -1140,9 +1131,17 @@ trait JavaModule
         stdin = os.Inherit,
         stdout = os.Inherit
       )
-    }
 
-    PathRef(Jvm.createJar(Task.dest / "out.jar", Seq(javadocDir)))
+      PathRef(javadocDir)
+    }
+  }
+
+  /**
+   * The documentation jar, containing all the Javadoc/Scaladoc HTML files, for
+   * publishing to Maven Central
+   */
+  def docJar: T[PathRef] = Task[PathRef] {
+    PathRef(Jvm.createJar(Task.dest / "out.jar", Seq(generatedJavadoc().path)))
   }
 
   /**

--- a/libs/javalib/src/mill/javalib/JavaModule.scala
+++ b/libs/javalib/src/mill/javalib/JavaModule.scala
@@ -1086,7 +1086,7 @@ trait JavaModule
    */
   def docJarUseArgsFile: T[Boolean] = Task { scala.util.Properties.isWin }
 
-  def generatedJavadoc: T[PathRef] = Task[PathRef] {
+  def javadocGenerated: T[PathRef] = Task[PathRef] {
     val outDir = Task.dest
 
     val javadocDir = outDir / "javadoc"
@@ -1146,7 +1146,7 @@ trait JavaModule
    * publishing to Maven Central
    */
   def docJar: T[PathRef] = Task[PathRef] {
-    PathRef(Jvm.createJar(Task.dest / "out.jar", Seq(generatedJavadoc().path)))
+    PathRef(Jvm.createJar(Task.dest / "out.jar", Seq(javadocGenerated().path)))
   }
 
   /**

--- a/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -239,7 +239,7 @@ trait KotlinModule extends JavaModule { outer =>
    * and option by using [[dokkaOptions]].
    */
   override def docJar: T[PathRef] = Task[PathRef] {
-    PathRef(Jvm.createJar(Task.dest / "out.jar", Seq(dokkaGenerated())))
+    PathRef(Jvm.createJar(Task.dest / "out.jar", Seq(dokkaGenerated().path)))
   }
 
   /**

--- a/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -181,14 +181,12 @@ trait KotlinModule extends JavaModule { outer =>
   }
 
   /**
-   * The documentation jar, containing all the Dokka HTML files, for
+   * The generated documentation, containing all the Dokka HTML files, for
    * publishing to Maven Central. You can control Dokka version by using [[dokkaVersion]]
    * and option by using [[dokkaOptions]].
    */
-  override def docJar: T[PathRef] = Task[PathRef] {
-    val outDir = Task.dest
-
-    val dokkaDir = outDir / "dokka"
+  def dokkaGenerated: T[PathRef] = Task[PathRef] {
+    val dokkaDir = Task.dest / "dokka"
     os.makeDir.all(dokkaDir)
 
     val files = Lib.findSourceFiles(docSources(), Seq("java", "kt"))
@@ -232,7 +230,16 @@ trait KotlinModule extends JavaModule { outer =>
       )
     }
 
-    PathRef(Jvm.createJar(outDir / "out.jar", Seq(dokkaDir)))
+    PathRef(dokkaDir)
+  }
+
+  /**
+   * The documentation jar, containing all the Dokka HTML files, for
+   * publishing to Maven Central. You can control Dokka version by using [[dokkaVersion]]
+   * and option by using [[dokkaOptions]].
+   */
+  override def docJar: T[PathRef] = Task[PathRef] {
+    PathRef(Jvm.createJar(Task.dest / "out.jar", Seq(dokkaGenerated())))
   }
 
   /**

--- a/libs/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/libs/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -302,7 +302,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase
     else allSources()
   }
 
-  def generatedScaladoc: T[PathRef] = Task {
+  def scalaDocGenerated: T[PathRef] = Task {
     val compileCp = Seq(
       "-classpath",
       compileClasspath()
@@ -411,7 +411,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase
   }
 
   override def docJar: T[PathRef] = Task {
-    PathRef(Jvm.createJar(Task.dest / "out.jar", Seq(generatedScaladoc().path)))
+    PathRef(Jvm.createJar(Task.dest / "out.jar", Seq(scalaDocGenerated().path)))
   }
 
   /**

--- a/libs/scalalib/test/src/mill/scalalib/DottyDocTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/DottyDocTests.scala
@@ -40,35 +40,39 @@ object DottyDocTests extends TestSuite {
   def tests: Tests = Tests {
     test("static") - UnitTester(StaticDocsModule, resourcePath).scoped { eval =>
       val Right(_) = eval.apply(StaticDocsModule.static.docJar): @unchecked
-      val dest = eval.outPath / "static/docJar.dest"
+      val scaladoc = eval.outPath / "static/scalaDocGenerated.dest"
+      val docJar = eval.outPath / "static/docJar.dest"
       assert(
-        os.exists(dest / "out.jar"), // final jar should exist
         // check if extra markdown files have been included and translated to html
-        os.exists(dest / "javadoc/_site/index.html"),
-        os.exists(dest / "javadoc/_site/nested/extra.html"),
+        os.exists(scaladoc / "javadoc/_site/index.html"),
+        os.exists(scaladoc / "javadoc/_site/nested/extra.html"),
         // also check that API docs have been generated
-        os.exists(dest / "javadoc/_site/api/pkg/SomeClass.html")
+        os.exists(scaladoc / "javadoc/_site/api/pkg/SomeClass.html"),
+        // final jar should exist
+        os.exists(docJar / "out.jar")
       )
     }
     test("empty") - UnitTester(EmptyDocsModule, resourcePath).scoped { eval =>
       val Right(_) = eval.apply(EmptyDocsModule.empty.docJar): @unchecked
-      val dest = eval.outPath / "empty/docJar.dest"
+      val scaladoc = eval.outPath / "empty/scalaDocGenerated.dest"
+      val docJar = eval.outPath / "empty/docJar.dest"
       assert(
-        os.exists(dest / "out.jar"),
-        os.exists(dest / "javadoc/_site/api/pkg/SomeClass.html")
+        os.exists(scaladoc / "javadoc/_site/api/pkg/SomeClass.html"),
+        os.exists(docJar / "out.jar")
       )
     }
     test("multiple") - UnitTester(MultiDocsModule, resourcePath).scoped { eval =>
       val Right(_) = eval.apply(MultiDocsModule.multidocs.docJar): @unchecked
-      val dest = eval.outPath / "multidocs/docJar.dest"
+      val scaladoc = eval.outPath / "multidocs/scalaDocGenerated.dest"
+      val docJar = eval.outPath / "multidocs/docJar.dest"
       assert(
-        os.exists(dest / "out.jar"), // final jar should exist
-        os.exists(dest / "javadoc/_site/api/pkg/SomeClass.html"),
-        os.exists(dest / "javadoc/_site/index.html"),
-        os.exists(dest / "javadoc/_site/nested/original.html"),
-        os.exists(dest / "javadoc/_site/nested/extra.html"),
+        os.exists(docJar / "out.jar"), // final jar should exist
+        os.exists(scaladoc / "javadoc/_site/api/pkg/SomeClass.html"),
+        os.exists(scaladoc / "javadoc/_site/index.html"),
+        os.exists(scaladoc / "javadoc/_site/nested/original.html"),
+        os.exists(scaladoc / "javadoc/_site/nested/extra.html"),
         // check that later doc sources overwrite earlier ones
-        os.read(dest / "javadoc/_site/index.html").contains("overwritten")
+        os.read(scaladoc / "javadoc/_site/index.html").contains("overwritten")
       )
     }
   }

--- a/libs/scalalib/test/src/mill/scalalib/ScalaDoc3Tests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/ScalaDoc3Tests.scala
@@ -41,35 +41,38 @@ object ScalaDoc3Tests extends TestSuite {
   def tests: Tests = Tests {
     test("static") - UnitTester(StaticDocsModule, resourcePath).scoped { eval =>
       val Right(_) = eval.apply(StaticDocsModule.static.docJar): @unchecked
-      val dest = eval.outPath / "static/docJar.dest"
+      val docjar = eval.outPath / "static/docJar.dest"
+      val scaladoc = eval.outPath / "static/scalaDocGenerated.dest"
       assert(
-        os.exists(dest / "out.jar"), // final jar should exist
+        os.exists(docjar / "out.jar"), // final jar should exist
         // check if extra markdown files have been included and translated to html
-        os.exists(dest / "javadoc/index.html"),
-        os.exists(dest / "javadoc/nested/extra.html"),
+        os.exists(scaladoc / "javadoc/index.html"),
+        os.exists(scaladoc / "javadoc/nested/extra.html"),
         // also check that API docs have been generated
-        os.exists(dest / "javadoc/api/pkg/SomeClass.html")
+        os.exists(scaladoc / "javadoc/api/pkg/SomeClass.html")
       )
     }
     test("empty") - UnitTester(EmptyDocsModule, resourcePath).scoped { eval =>
       val Right(_) = eval.apply(EmptyDocsModule.empty.docJar): @unchecked
-      val dest = eval.outPath / "empty/docJar.dest"
+      val scaladoc = eval.outPath / "empty/scalaDocGenerated.dest"
+      val docJar = eval.outPath / "empty/docJar.dest"
       assert(
-        os.exists(dest / "out.jar"),
-        os.exists(dest / "javadoc/api/pkg/SomeClass.html")
+        os.exists(docJar / "out.jar"),
+        os.exists(scaladoc / "javadoc/api/pkg/SomeClass.html")
       )
     }
     test("multiple") - UnitTester(MultiDocsModule, resourcePath).scoped { eval =>
       val Right(_) = eval.apply(MultiDocsModule.multidocs.docJar): @unchecked
-      val dest = eval.outPath / "multidocs/docJar.dest"
+      val docJar = eval.outPath / "multidocs/docJar.dest"
+      val scaladoc = eval.outPath / "multidocs/scalaDocGenerated.dest"
       assert(
-        os.exists(dest / "out.jar"), // final jar should exist
-        os.exists(dest / "javadoc/api/pkg/SomeClass.html"),
-        os.exists(dest / "javadoc/index.html"),
-        os.exists(dest / "javadoc/docs/nested/original.html"),
-        os.exists(dest / "javadoc/docs/nested/extra.html"),
+        os.exists(docJar / "out.jar"), // final jar should exist
+        os.exists(scaladoc / "javadoc/api/pkg/SomeClass.html"),
+        os.exists(scaladoc / "javadoc/index.html"),
+        os.exists(scaladoc / "javadoc/docs/nested/original.html"),
+        os.exists(scaladoc / "javadoc/docs/nested/extra.html"),
         // check that later doc sources overwrite earlier ones
-        os.read(dest / "javadoc/index.html").contains("overwritten")
+        os.read(scaladoc / "javadoc/index.html").contains("overwritten")
       )
     }
   }

--- a/libs/scalalib/test/src/mill/scalalib/ScalaScaladocTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/ScalaScaladocTests.scala
@@ -67,7 +67,7 @@ object ScalaScaladocTests extends TestSuite {
         val Right(result) = eval.apply(HelloWorldDocTitle.core.docJar): @unchecked
         assert(
           result.evalCount > 0,
-          os.read(eval.outPath / "core/docJar.dest/javadoc/index.html").contains(
+          os.read(eval.outPath / "core/scalaDocGenerated.dest/javadoc/index.html").contains(
             "<span id=\"doc-title\">Hello World"
           )
         )


### PR DESCRIPTION
`JavaModule`, `ScalaModule` and `KoltinModule` currently implement the `docJar` task to produce an Javadoc-compatible JAR ready for publishing and consumption by IDEs. Unfortunately, this JAR is rather unsuited for direct consumption by a browser, e.g. to read the API documentation directly. It either needs to be extracted (Mill doesn't provide any convenience task for that) or users can use the implementation detail like the `javadoc` directory in the `javaDoc.dest`  directory, which is not documented and can change at any time.

This PR splits the generation of the API documentation from the `docJar` packaging. As a result, users can use the result of `javadocGenerated`, `scalaDocGenerated` and `dokkaGenerated` tasks to directly access the exploded API documentation. The names were choosed to have the same prefix as the tools and other already existing configuration tasks, like `javadocOptions`, `scalaDocOptions` and `dokkaOptions`.

As a neat side effect, in Kotlin or Scala modules, users can generate the pure Java API part with `javadocGenerated`.

Since some documentation processors support advanced features like static site generation, the `scalaDocGenerated` task can later split up further, to improve the incremental build speed.