### PR TITLE
Improve documentation for Sonatype Central snapshot publishing

### DIFF
--- a/website/docs/modules/ROOT/partials/Publishing_Footer.adoc
+++ b/website/docs/modules/ROOT/partials/Publishing_Footer.adoc
@@ -76,6 +76,54 @@ You can also specify individual modules you want to publish in two ways:
 > mill mill.javalib.SonatypeCentralPublishModule/ --publishArtifacts foo.publishArtifacts
 ----
 
+=== SNAPSHOT versions
+
+To publish SNAPSHOT versions (that is any version that ends with `-SNAPSHOT`), you need to enable support for them in
+your Sonatype Central namespace. To do that, go to the
+https://central.sonatype.com/publishing/namespaces[Sonatype Central portal], click on the "three dots" next to the
+namespace name, and click on "Enable SNAPSHOTs".
+
+SNAPSHOT versions do not have same semantics as regular versions: they are not signed and are not kept forever in the
+repository.
+
+See https://central.sonatype.org/publish/publish-portal-snapshots/[Sonatype Central documentation] for more information.
+
+You build file should look like:
+[source,scala]
+----
+object mymodule extends JavaModule {
+  def publishVersion = "0.0.1-SNAPSHOT"
+}
+----
+
+Running any of the publishing tasks will now publish SNAPSHOT versions. When running them you should see a note from
+Mill that is has detected a SNAPSHOT version.
+
+To consume SNAPSHOT versions in your project, make sure to add the snapshot repository to your build file:
+
+[source,scala]
+----
+object myModule extends JavaModule {
+  def repositories = Seq("https://central.sonatype.com/repository/maven-snapshots")
+
+  def mvnDeps = Seq(mvn"com.example:mymodule:1.0.0-SNAPSHOT")
+}
+----
+
+Note that if you have downstream modules that depend on this module, they will need to add the snapshot repository
+to their definition as well, at least until https://github.com/com-lihaoyi/mill/issues/5573[this issue] is fixed.
+
+[source,scala]
+----
+
+object myDownstreamModule extends JavaModule {
+  def moduleDeps = Seq(myModule)
+
+  // This is also needed.
+  def repositories = Seq("https://central.sonatype.com/repository/maven-snapshots")
+}
+----
+
 === Publishing Using Github Actions
 
 


### PR DESCRIPTION
This adds documentation on how to publish snapshots to Sonatype Central and how to consume these published snapshots.