### PR TITLE
Disable `--scie` in Python example extensions

### DIFF
--- a/example/extending/python/4-python-libs-bundle/build.mill
+++ b/example/extending/python/4-python-libs-bundle/build.mill
@@ -74,9 +74,7 @@ trait PythonModule extends Module {
         "-c",
         sources().path / mainFileName(),
         "-o",
-        pexFile,
-        "--scie",
-        "eager"
+        pexFile
       ),
       env = Map("PYTHONPATH" -> Task.dest.toString),
       stdout = os.Inherit


### PR DESCRIPTION
Follow up of https://github.com/com-lihaoyi/mill/pull/5561, seems like that PR missed a spot