### PR TITLE
Skip docjars and sourcejars when using `publishLocalTestRepo`

### DIFF
--- a/libs/javalib/src/mill/javalib/PublishModule.scala
+++ b/libs/javalib/src/mill/javalib/PublishModule.scala
@@ -624,7 +624,7 @@ trait PublishModule extends JavaModule { outer =>
    */
   def publishLocalTestRepo: Task[PathRef] = Task {
     val publisher = new LocalM2Publisher(Task.dest)
-    val publishInfos = defaultPublishInfos() ++
+    val publishInfos = defaultPublishInfos(sources = false, docs = false)() ++
       Seq(PublishInfo.sourcesJar(sourceJar())) ++
       extraPublish()
     publisher.publish(


### PR DESCRIPTION
This was causing `docjar` to run every time tests were run locally, which likely surfaced the misbehavior mentioned in https://github.com/com-lihaoyi/mill/pull/5580 (though it's not the root cause) and also greatly slows down iterative development on this repo