### PR TITLE
Make `MavenTests`/`SbtTests`/`KotlinMavenTests` modules take their folder path from their module name

### DIFF
--- a/example/javalib/basic/4-compat-modules/bar/src/main/java/bar/Bar.java
+++ b/example/javalib/basic/4-compat-modules/bar/src/main/java/bar/Bar.java
@@ -1,7 +1,0 @@
-package bar;
-
-public class Bar {
-  public static void main(String[] args) {
-    System.out.println("Bar.value: " + Bar.value);
-  }
-}

--- a/example/javalib/basic/4-compat-modules/build.mill
+++ b/example/javalib/basic/4-compat-modules/build.mill
@@ -10,6 +10,7 @@ import mill.*, javalib.*
 
 object foo extends MavenModule {
   object test extends MavenTests, TestModule.Junit4
+  object integration extends MavenTests, TestModule.Junit4
 }
 
 // `MavenModule` is a variant of `JavaModule`
@@ -40,6 +41,9 @@ compiling 1 Java source...
 
 > ./mill foo.test
 ...foo.FooTests.hello ...
+
+> ./mill foo.integration
+...foo.FooIntegrationTests.hello ...
 
 */
 

--- a/example/javalib/basic/4-compat-modules/foo/src/integration/java/foo/FooIntegrationTests.java
+++ b/example/javalib/basic/4-compat-modules/foo/src/integration/java/foo/FooIntegrationTests.java
@@ -1,0 +1,14 @@
+package foo;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class FooIntegrationTests {
+
+  @Test
+  public void hello() {
+    String result = Foo.hello();
+    assertEquals("Hello World", result);
+  }
+}

--- a/example/kotlinlib/basic/4-compat-modules/build.mill
+++ b/example/kotlinlib/basic/4-compat-modules/build.mill
@@ -13,9 +13,10 @@ object foo extends KotlinModule, KotlinMavenModule {
   def kotlinVersion = "1.9.24"
 
   object test extends KotlinMavenTests, TestModule.Junit5 {
-    def mvnDeps = super.mvnDeps() ++ Seq(
-      mvn"io.kotest:kotest-runner-junit5:5.9.1"
-    )
+    def mvnDeps = Seq(mvn"io.kotest:kotest-runner-junit5:5.9.1")
+  }
+  object integration extends KotlinMavenTests, TestModule.Junit5 {
+    def mvnDeps = Seq(mvn"io.kotest:kotest-runner-junit5:5.9.1")
   }
 }
 
@@ -26,6 +27,8 @@ object foo extends KotlinModule, KotlinMavenModule {
 // - `foo/src/main/kotlin`
 // - `foo/src/test/java`
 // - `foo/src/test/kotlin`
+// - `foo/src/integration/java`
+// - `foo/src/integration/kotlin`
 //
 // Rather than Mill's
 //
@@ -49,6 +52,9 @@ Compiling 1 Kotlin source...
 
 > ./mill foo.test
 ...foo.FooTests hello ...
+
+> ./mill foo.integration
+...foo.FooIntegrationTests hello ...
 
 */
 

--- a/example/kotlinlib/basic/4-compat-modules/foo/src/integration/java/foo/FooIntegrationTests.kt
+++ b/example/kotlinlib/basic/4-compat-modules/foo/src/integration/java/foo/FooIntegrationTests.kt
@@ -1,0 +1,12 @@
+package foo
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class FooIntegrationTests :
+    FunSpec({
+        test("hello") {
+            val result = hello()
+            result shouldBe "Hello World, Earth"
+        }
+    })

--- a/example/scalalib/basic/4-compat-modules/build.mill
+++ b/example/scalalib/basic/4-compat-modules/build.mill
@@ -14,6 +14,10 @@ object foo extends SbtModule {
     def mvnDeps = Seq(mvn"com.lihaoyi::utest:0.8.9")
     def testFramework = "utest.runner.Framework"
   }
+  object integration extends SbtTests {
+    def mvnDeps = Seq(mvn"com.lihaoyi::utest:0.8.9")
+    def testFramework = "utest.runner.Framework"
+  }
 }
 
 object bar extends Cross[BarModule]("2.12.17", "2.13.16")
@@ -31,6 +35,7 @@ trait BarModule extends CrossSbtModule {
 // - `foo/src/main/scala-2.12`
 // - `foo/src/main/scala-2.13`
 // - `foo/src/test/scala`
+// - `foo/src/integration/scala`
 //
 // Rather than Mill's
 //
@@ -56,6 +61,9 @@ compiling 1 Scala source...
 
 > ./mill foo.test
 + foo.FooTests.hello ...
+
+> ./mill foo.integration
++ foo.FooIntegrationTests.hello ...
 
 > ./mill bar[2.13.16].run
 Bar.value: Hello World Scala library version 2.13.16...

--- a/example/scalalib/basic/4-compat-modules/foo/src/integration/scala/FooIntegrationTests.scala
+++ b/example/scalalib/basic/4-compat-modules/foo/src/integration/scala/FooIntegrationTests.scala
@@ -1,0 +1,11 @@
+package foo
+import utest.*
+object FooIntegrationTests extends TestSuite {
+  def tests = Tests {
+    test("hello") {
+      val result = Foo.hello()
+      assert(result == "Hello World")
+      result
+    }
+  }
+}

--- a/libs/javalib/src/mill/javalib/MavenModule.scala
+++ b/libs/javalib/src/mill/javalib/MavenModule.scala
@@ -17,7 +17,13 @@ trait MavenModule extends JavaModule { outer =>
 
   trait MavenTests extends JavaTests {
     override def moduleDir = outer.moduleDir
+
+    /**
+     * The name of this module's folder within `src/`: e.g. `src/test/`, `src/integration/`,
+     * etc. Defaults to the name of the module object, but can be overridden by users
+     */
     def testModuleName = moduleCtx.segments.last.value
+
     private[mill] override def intellijModulePathJava: Path =
       (outer.moduleDir / "src" / testModuleName).toNIO
 

--- a/libs/javalib/src/mill/javalib/MavenModule.scala
+++ b/libs/javalib/src/mill/javalib/MavenModule.scala
@@ -17,9 +17,11 @@ trait MavenModule extends JavaModule { outer =>
 
   trait MavenTests extends JavaTests {
     override def moduleDir = outer.moduleDir
-    private[mill] override def intellijModulePathJava: Path = (outer.moduleDir / "src/test").toNIO
+    def testModuleName = moduleCtx.segments.last.value
+    private[mill] override def intellijModulePathJava: Path =
+      (outer.moduleDir / "src" / testModuleName).toNIO
 
-    override def sources = Task.Sources("src/test/java")
-    override def resources = Task.Sources("src/test/resources")
+    override def sources = Task.Sources(moduleDir / "src" / testModuleName / "java")
+    override def resources = Task.Sources(moduleDir / "src" / testModuleName / "resources")
   }
 }

--- a/libs/kotlinlib/src/mill/kotlinlib/KotlinMavenModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/KotlinMavenModule.scala
@@ -12,7 +12,9 @@ trait KotlinMavenModule extends KotlinModule with MavenModule {
   override def sources = super.sources() ++ sources0()
 
   trait KotlinMavenTests extends KotlinTests with MavenTests {
-    private def sources0 = Task.Sources(moduleDir / "src" / testModuleName / "kotlin")
-    override def sources = super.sources() ++ sources0()
+    override def sources = Task.Sources(
+      moduleDir / "src" / testModuleName / "java",
+      moduleDir / "src" / testModuleName / "kotlin"
+    )
   }
 }

--- a/libs/kotlinlib/src/mill/kotlinlib/KotlinMavenModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/KotlinMavenModule.scala
@@ -1,7 +1,5 @@
 package mill.kotlinlib
 
-import java.nio.file.Path
-
 import mill.Task
 import mill.javalib.MavenModule
 
@@ -14,9 +12,7 @@ trait KotlinMavenModule extends KotlinModule with MavenModule {
   override def sources = super.sources() ++ sources0()
 
   trait KotlinMavenTests extends KotlinTests with MavenTests {
-    private[mill] override def intellijModulePathJava: Path = (moduleDir / "src/test").toNIO
-
-    private def sources0 = Task.Sources("src/test/kotlin")
+    private def sources0 = Task.Sources(moduleDir / "src" / testModuleName / "kotlin")
     override def sources = super.sources() ++ sources0()
   }
 }

--- a/libs/scalalib/src/mill/scalalib/SbtModule.scala
+++ b/libs/scalalib/src/mill/scalalib/SbtModule.scala
@@ -10,7 +10,9 @@ trait SbtModule extends ScalaModule with MavenModule {
   override def sources = Task.Sources("src/main/scala", "src/main/java")
 
   trait SbtTests extends ScalaTests with MavenTests {
-    private def sources0 = Task.Sources(moduleDir / "src" / testModuleName / "scala")
-    override def sources = super.sources() ++ sources0()
+    override def sources = Task.Sources(
+      moduleDir / "src" / testModuleName / "java",
+      moduleDir / "src" / testModuleName / "scala"
+    )
   }
 }

--- a/libs/scalalib/src/mill/scalalib/SbtModule.scala
+++ b/libs/scalalib/src/mill/scalalib/SbtModule.scala
@@ -10,6 +10,7 @@ trait SbtModule extends ScalaModule with MavenModule {
   override def sources = Task.Sources("src/main/scala", "src/main/java")
 
   trait SbtTests extends ScalaTests with MavenTests {
-    override def sources = Task.Sources("src/test/scala", "src/test/java")
+    private def sources0 = Task.Sources(moduleDir / "src" / testModuleName / "scala")
+    override def sources = super.sources() ++ sources0()
   }
 }


### PR DESCRIPTION
So an `object integration` automatically gets `src/integration/java/` as their sources, and `src/integration/` as their `intellijModulePathJava`, without the user needing to specifically configure it.

Update the three `4-compat-modules` example tests to exercise and document this