### PR TITLE
Fixes incorrect parsing of `PublishInfo` from string when artifact id or version contains regex-sensitive characters

### DIFF
--- a/libs/javalib/package.mill
+++ b/libs/javalib/package.mill
@@ -50,7 +50,8 @@ object `package` extends MillStableScalaModule {
     super.mimaBinaryIssueFilters() ++ Seq(
       // This was `private[mill]`, package private doesn't have the JVM bytecode equivalent, so mima can't check it.
       ProblemFilter.exclude[Problem]("mill.javalib.PublishModule.checkSonatypeCreds"),
-      ProblemFilter.exclude[Problem]("mill.javalib.publish.SonatypeHelpers.getArtifactMappings")
+      ProblemFilter.exclude[Problem]("mill.javalib.publish.SonatypeHelpers.getArtifactMappings"),
+      ProblemFilter.exclude[Problem]("mill.javalib.publish.PublishInfo.parseFromFile")
     )
 
   object backgroundwrapper extends MillPublishJavaModule with MillJavaModule {

--- a/libs/javalib/src/mill/javalib/MavenWorkerSupport.scala
+++ b/libs/javalib/src/mill/javalib/MavenWorkerSupport.scala
@@ -56,12 +56,11 @@ object MavenWorkerSupport {
         publishDatas: Map[os.SubPath, PathRef]
     ): List[M2Artifact.Default] =
       publishDatas.iterator.map { case (name, pathRef) =>
-        val publishInfo = PublishInfo.parseFromFile(
-          pathRef,
+        val publishInfo = PublishInfo.IvyMetadata.parseFromFile(
           fileName = name.toString,
           artifactId = artifact.id,
           artifactVersion = artifact.version
-        )
+        ).toPublishInfo(pathRef)
         M2Artifact.Default(publishInfo, artifact): M2Artifact.Default
       }.toList
 

--- a/libs/javalib/test/src/mill/javalib/publish/PublishInfoTests.scala
+++ b/libs/javalib/test/src/mill/javalib/publish/PublishInfoTests.scala
@@ -1,0 +1,67 @@
+package mill.javalib.publish
+
+import utest.*
+
+object PublishInfoTests extends TestSuite {
+  override def tests: Tests = Tests {
+    test("IvyMetadata") {
+      test("parseFromFile") {
+        test("testProject") {
+          def parse(name: String) = PublishInfo.IvyMetadata.parseFromFile(
+            fileName = name,
+            artifactId = "testProject_3.3.4",
+            artifactVersion = "0.0.1-SNAPSHOT"
+          )
+
+          test("pom") {
+            val actual = parse("testProject_3.3.4-0.0.1-SNAPSHOT.pom")
+            assert(actual == PublishInfo.IvyMetadata.Pom)
+          }
+
+          test("jar") {
+            val actual = parse("testProject_3.3.4-0.0.1-SNAPSHOT.jar")
+            assert(actual == PublishInfo.IvyMetadata.Jar)
+          }
+
+          test("sources") {
+            val actual = parse("testProject_3.3.4-0.0.1-SNAPSHOT-sources.jar")
+            assert(actual == PublishInfo.IvyMetadata.SourcesJar)
+          }
+
+          test("docs") {
+            val actual = parse("testProject_3.3.4-0.0.1-SNAPSHOT-javadoc.jar")
+            assert(actual == PublishInfo.IvyMetadata.DocJar)
+          }
+        }
+
+        test("chisel-plugin") {
+          def parse(name: String) = PublishInfo.IvyMetadata.parseFromFile(
+            fileName = name,
+            artifactId = "chisel-plugin_3.3.4",
+            artifactVersion = "7.0.0-RC3+5-c4ca27e5-SNAPSHOT"
+          )
+
+          test("pom") {
+            val actual = parse("chisel-plugin_3.3.4-7.0.0-RC3+5-c4ca27e5-SNAPSHOT.pom")
+            assert(actual == PublishInfo.IvyMetadata.Pom)
+          }
+
+          test("jar") {
+            val actual = parse("chisel-plugin_3.3.4-7.0.0-RC3+5-c4ca27e5-SNAPSHOT.jar")
+            assert(actual == PublishInfo.IvyMetadata.Jar)
+          }
+
+          test("sources") {
+            val actual = parse("chisel-plugin_3.3.4-7.0.0-RC3+5-c4ca27e5-SNAPSHOT-sources.jar")
+            assert(actual == PublishInfo.IvyMetadata.SourcesJar)
+          }
+
+          test("docs") {
+            val actual = parse("chisel-plugin_3.3.4-7.0.0-RC3+5-c4ca27e5-SNAPSHOT-javadoc.jar")
+            assert(actual == PublishInfo.IvyMetadata.DocJar)
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR fixes parsing of strings like "chisel-plugin_3.3.4-7.0.0-RC3+5-c4ca27e5-SNAPSHOT.pom". Previously `chisel-plugin_2.13.14-7.0.0-RC3+4-4815de48-SNAPSHOT` would be identified as a `classifier`.

This happened because when constructing a regular expression we did not escape the id/version parts and thus symbols like + were interpreted as regex instructions instead of literals, which made the regex never match.

Additionally, a small refactoring has been done where `PublishInfo.parseFromFile` is now `PublishInfo.IvyMetadata.parseFromFile`, as it's actually the metadata we are parsing.