### PR TITLE
Turn on incremental compilation for `semanticDbData` task

### DIFF
--- a/libs/javalib/src/mill/javalib/SemanticDbJavaModule.scala
+++ b/libs/javalib/src/mill/javalib/SemanticDbJavaModule.scala
@@ -298,13 +298,18 @@ object SemanticDbJavaModule extends ExternalModule with CoursierModule {
         import os./
         dest match {
           case folder / s"$prefix.semanticdb"
-            if !existingSources.contains((folder / prefix).subRelativeTo(targetDir / semanticPath)) =>
+              if !existingSources.contains(
+                (folder / prefix).subRelativeTo(targetDir / semanticPath)
+              ) =>
             os.remove(dest)
           case _ =>
         }
 
         for (
-          (data, dest) <- postProcessed(source, sourceroot, classesDir / semanticPath, workerClasspath)
+          (
+            data,
+            dest
+          ) <- postProcessed(source, sourceroot, classesDir / semanticPath, workerClasspath)
         ) {
           os.write.over(targetDir / semanticPath / dest, data, createFolders = true)
         }

--- a/libs/javalib/src/mill/javalib/SemanticDbJavaModule.scala
+++ b/libs/javalib/src/mill/javalib/SemanticDbJavaModule.scala
@@ -305,14 +305,10 @@ object SemanticDbJavaModule extends ExternalModule with CoursierModule {
           case _ =>
         }
 
-        for (
-          (
-            data,
-            dest
-          ) <- postProcessed(source, sourceroot, classesDir / semanticPath, workerClasspath)
-        ) {
-          os.write.over(targetDir / semanticPath / dest, data, createFolders = true)
-        }
+        postProcessed(source, sourceroot, classesDir / semanticPath, workerClasspath)
+          .foreach { case (data, dest) =>
+            os.write.over(targetDir / semanticPath / dest, data, createFolders = true)
+          }
       }
     }
 

--- a/libs/javalib/src/mill/javalib/SemanticDbJavaModule.scala
+++ b/libs/javalib/src/mill/javalib/SemanticDbJavaModule.scala
@@ -107,10 +107,6 @@ trait SemanticDbJavaModule extends CoursierModule with SemanticDbJavaModuleApi
       semanticDbJavaVersion()
     )
 
-    // we currently assume, we don't do incremental java compilation
-    os.remove.all(Task.dest / "classes")
-    os.remove.all(Task.dest / "zinc")
-
     Task.log.debug(s"effective javac options: ${javacOpts}")
 
     jvmWorker().worker()
@@ -131,7 +127,8 @@ trait SemanticDbJavaModule extends CoursierModule with SemanticDbJavaModuleApi
             r.classes.path,
             BuildCtx.workspaceRoot,
             Task.dest / "data",
-            SemanticDbJavaModule.workerClasspath().map(_.path)
+            SemanticDbJavaModule.workerClasspath().map(_.path),
+            allSourceFiles().map(_.path)
           )
         }
       }
@@ -272,7 +269,8 @@ object SemanticDbJavaModule extends ExternalModule with CoursierModule {
       classesDir: os.Path,
       sourceroot: os.Path,
       targetDir: os.Path,
-      workerClasspath: Seq[os.Path]
+      workerClasspath: Seq[os.Path],
+      sources: Seq[os.Path]
   ): PathRef = {
     assert(classesDir != targetDir)
     os.remove.all(targetDir)
@@ -281,18 +279,32 @@ object SemanticDbJavaModule extends ExternalModule with CoursierModule {
     val semanticPath = os.rel / "META-INF/semanticdb"
     val toClean = classesDir / semanticPath / sourceroot.segments.toSeq
 
+    val existingSources = sources.map(_.subRelativeTo(sourceroot)).toSet
+
     // copy over all found semanticdb-files into the target directory
     // but with corrected directory layout
     if (os.exists(classesDir)) {
-      for (p <- os.walk(classesDir, preOrder = true) if os.isFile(p)) {
-        val target =
-          if (p.startsWith(toClean)) targetDir / semanticPath / p.relativeTo(toClean)
-          else targetDir / p.relativeTo(classesDir)
+      for (source <- os.walk(classesDir, preOrder = true) if os.isFile(source)) {
+        val dest =
+          if (source.startsWith(toClean)) targetDir / semanticPath / source.relativeTo(toClean)
+          else targetDir / source.relativeTo(classesDir)
 
-        os.copy(p, target, createFolders = true)
+        os.copy(source, dest, createFolders = true)
+
+        // SemanticDB plugin doesn't delete old `.semanticdb` files during incremental compilation.
+        // So we need to do it ourselves, using the fact that the `.semanticdb` files have the same
+        // name and path as the `.java` or `.scala` files they are created from, just with `.semanticdb`
+        // appended on the end
+        import os./
+        dest match {
+          case folder / s"$prefix.semanticdb"
+            if !existingSources.contains((folder / prefix).subRelativeTo(targetDir / semanticPath)) =>
+            os.remove(dest)
+          case _ =>
+        }
 
         for (
-          (data, dest) <- postProcessed(p, sourceroot, classesDir / semanticPath, workerClasspath)
+          (data, dest) <- postProcessed(source, sourceroot, classesDir / semanticPath, workerClasspath)
         ) {
           os.write.over(targetDir / semanticPath / dest, data, createFolders = true)
         }

--- a/libs/javalib/test/src/mill/javalib/HelloJavaTests.scala
+++ b/libs/javalib/test/src/mill/javalib/HelloJavaTests.scala
@@ -146,7 +146,6 @@ object HelloJavaTests extends TestSuite {
               expectedFile1,
               expectedFile3,
               os.rel / "hello/Core.class",
-              os.rel / "hello/Second.class", // not sure why this isn't deleted???
               os.rel / "hello/Third.class"
             ),
             result2.evalCount > 0

--- a/libs/javalib/test/src/mill/javalib/HelloJavaTests.scala
+++ b/libs/javalib/test/src/mill/javalib/HelloJavaTests.scala
@@ -29,7 +29,7 @@ object HelloJavaTests extends TestSuite {
 
   val resourcePath = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "hello-java"
 
-  def testEval() = UnitTester(HelloJava, resourcePath)
+  def testEval() = UnitTester(HelloJava, resourcePath, debugEnabled = true)
   def tests: Tests = Tests {
     test("compile") {
       testEval().scoped { eval =>
@@ -146,6 +146,7 @@ object HelloJavaTests extends TestSuite {
               expectedFile1,
               expectedFile3,
               os.rel / "hello/Core.class",
+              os.rel / "hello/Second.class", // not sure why this isn't deleted???
               os.rel / "hello/Third.class"
             ),
             result2.evalCount > 0

--- a/libs/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/libs/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -613,8 +613,6 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase
     Task.log.debug(s"effective scalac options: ${scalacOptions}")
     Task.log.debug(s"effective javac options: ${javacOpts}")
 
-    // Disable incremental compilation because semanticDb plugin doesn't work well incrementally
-    os.remove.all(Task.dest / "classes")
     jvmWorker().worker()
       .compileMixed(
         upstreamCompileOutput = upstreamCompileOutput(),
@@ -639,7 +637,8 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase
             compileRes.classes.path,
             BuildCtx.workspaceRoot,
             Task.dest / "data",
-            SemanticDbJavaModule.workerClasspath().map(_.path)
+            SemanticDbJavaModule.workerClasspath().map(_.path),
+            allSourceFiles().map(_.path)
           )
         }
       }

--- a/runner/daemon/src/mill/daemon/MillDaemonMain.scala
+++ b/runner/daemon/src/mill/daemon/MillDaemonMain.scala
@@ -10,7 +10,6 @@ import scala.util.{Properties, Try}
 
 object MillDaemonMain {
   def main(args0: Array[String]): Unit = {
-    mill.constants.DebugLog.println("MillDaemonMain.main")
 
     // Set by an integration test
     if (System.getenv("MILL_DAEMON_CRASH") == "true")


### PR DESCRIPTION
- Remove the code the cleans out the `classes/` folder or `zinc` file in between runs
- Add some custom code to remove old `.semanticdb` files when their originating `.java` or `.scala` files are not present

Tested by the existing unit tests, which seem pretty rigorous at failing if I didn't get the implementation quite right