### PR TITLE
Fix docs for `dokkaOptions`

### DIFF
--- a/example/scalalib/module/9-docjar/build.mill
+++ b/example/scalalib/module/9-docjar/build.mill
@@ -1,5 +1,5 @@
 // To generate API documentation you can use the `docJar` task on the module you'd
-// like to create the docs for, configured via `{language-small}DocOptions`:
+// like to create the docs for, configured via `{language-doc}Options`:
 
 //// SNIPPET:BUILD
 package build

--- a/website/docs/modules/ROOT/pages/javalib/module-config.adoc
+++ b/website/docs/modules/ROOT/pages/javalib/module-config.adoc
@@ -2,6 +2,7 @@
 :page-aliases: Java_Module_Config.adoc
 :language: Java
 :language-small: java
+:language-doc: javadoc
 
 This page goes into more detail about the various configuration options
 for `JavaModule`.

--- a/website/docs/modules/ROOT/pages/kotlinlib/module-config.adoc
+++ b/website/docs/modules/ROOT/pages/kotlinlib/module-config.adoc
@@ -2,6 +2,7 @@
 :page-aliases: Kotlin_Module_Config.adoc
 :language: Kotlin
 :language-small: kotlin
+:language-doc: dokka
 
 This page goes into more detail about the various configuration options
 for `KotlinModule`.

--- a/website/docs/modules/ROOT/pages/scalalib/module-config.adoc
+++ b/website/docs/modules/ROOT/pages/scalalib/module-config.adoc
@@ -2,6 +2,7 @@
 :page-aliases: Configuring_Mill.adoc, Scala_Module_Config.adoc
 :language: Scala
 :language-small: scala
+:language-doc: scaladoc
 
 This page goes into more detail about the various configuration options
 for `ScalaModule`.


### PR DESCRIPTION
Unlike `scaladocOptions` and `javadocOptions`, `dokkaOptions` does not follow the `{language-small}docOptions` pattern, so we needed to add a new `{language-doc}` configuration for our docsite 