### PR TITLE
Optimize `precomputeMethodNamesPerClass` to speed up large mostly-cached builds

### DIFF
--- a/core/exec/src/mill/exec/CodeSigUtils.scala
+++ b/core/exec/src/mill/exec/CodeSigUtils.scala
@@ -9,23 +9,18 @@ import java.lang.reflect.Method
 private[mill] object CodeSigUtils {
   def precomputeMethodNamesPerClass(transitiveNamed: Seq[Task.Named[?]])
       : (Map[Class[?], IndexedSeq[Class[?]]], Map[Class[?], Map[String, Method]]) = {
-    def resolveTransitiveParents(c: Class[?]): Set[Class[?]] = {
-      val seen = collection.mutable.Set.empty[Class[?]]
+    def resolveTransitiveParents(c: Class[?]): Iterable[Class[?]] = {
+      val seen = collection.mutable.Set(c)
       val queue = collection.mutable.Queue(c)
       while (queue.nonEmpty) {
         val current = queue.dequeue()
-        for (next <- Option(current.getSuperclass) if !seen.contains(next)) {
-          seen.add(next)
-          queue.enqueue(next)
-        }
-
-        for (next <- current.getInterfaces if !seen.contains(next)) {
+        for (next <- Option(current.getSuperclass) ++ current.getInterfaces if !seen.contains(next)) {
           seen.add(next)
           queue.enqueue(next)
         }
       }
 
-      seen.toSet
+      seen
     }
 
     val classToTransitiveClasses: Map[Class[?], IndexedSeq[Class[?]]] = transitiveNamed

--- a/core/exec/src/mill/exec/CodeSigUtils.scala
+++ b/core/exec/src/mill/exec/CodeSigUtils.scala
@@ -9,12 +9,15 @@ import java.lang.reflect.Method
 private[mill] object CodeSigUtils {
   def precomputeMethodNamesPerClass(transitiveNamed: Seq[Task.Named[?]])
       : (Map[Class[?], IndexedSeq[Class[?]]], Map[Class[?], Map[String, Method]]) = {
+
     def resolveTransitiveParents(c: Class[?]): Iterable[Class[?]] = {
-      val seen = collection.mutable.Set(c)
+      val seen = collection.mutable.LinkedHashSet(c) // Maintain first-seen ordering
       val queue = collection.mutable.Queue(c)
       while (queue.nonEmpty) {
         val current = queue.dequeue()
-        for (next <- Option(current.getSuperclass) ++ current.getInterfaces if !seen.contains(next)) {
+        for (
+          next <- Option(current.getSuperclass) ++ current.getInterfaces if !seen.contains(next)
+        ) {
           seen.add(next)
           queue.enqueue(next)
         }

--- a/core/exec/src/mill/exec/CodeSigUtils.scala
+++ b/core/exec/src/mill/exec/CodeSigUtils.scala
@@ -12,10 +12,14 @@ private[mill] object CodeSigUtils {
     def resolveTransitiveParents(c: Class[?]): Set[Class[?]] = {
       val seen = collection.mutable.Set.empty[Class[?]]
       val queue = collection.mutable.Queue(c)
-      while(queue.nonEmpty){
+      while (queue.nonEmpty) {
         val current = queue.dequeue()
-        val nextList = Seq(current.getSuperclass) ++ current.getInterfaces
-        for(next <- nextList if !seen.contains(next)) {
+        for (next <- Option(current.getSuperclass) if !seen.contains(next)) {
+          seen.add(next)
+          queue.enqueue(next)
+        }
+
+        for (next <- current.getInterfaces if !seen.contains(next)) {
           seen.add(next)
           queue.enqueue(next)
         }


### PR DESCRIPTION
- Make `resolveTransitiveParents` an imperative breadth-first-search with seen-set, rather than the clever lazy-recursive iterator that would need to be de-duplicated later
- Call `.distinct` on the `enclosingCls`s before running `resolveTransitiveParents`, to avoid doing it more than once on each class

Seems to speed up `while true; do time ./mill-assembly.jar __.compile; done` from ~4.5s to ~2.5s per iteration, and makes this particular method drop off the JProfiler report