### PR TITLE
Fixes incorrect parsing of `PublishInfo` from string when artifact id or version contains regex-sensitive characters (0.12.x)

### DIFF
--- a/scalalib/src/mill/scalalib/MavenWorkerSupport.scala
+++ b/scalalib/src/mill/scalalib/MavenWorkerSupport.scala
@@ -51,12 +51,11 @@ object MavenWorkerSupport {
         publishDatas: Seq[(PathRef, String)]
     ): List[M2Artifact.Default] =
       publishDatas.iterator.map { case (pathRef, name) =>
-        val publishInfo = PublishInfo.parseFromFile(
-          pathRef,
+        val publishInfo = PublishInfo.IvyMetadata.parseFromFile(
           fileName = name,
           artifactId = artifact.id,
           artifactVersion = artifact.version
-        )
+        ).toPublishInfo(pathRef)
         M2Artifact.Default(publishInfo, artifact): M2Artifact.Default
       }.toList
 

--- a/scalalib/src/mill/scalalib/publish/PublishInfo.scala
+++ b/scalalib/src/mill/scalalib/publish/PublishInfo.scala
@@ -2,6 +2,8 @@ package mill.scalalib.publish
 
 import mill.PathRef
 
+import java.util.regex.Pattern
+
 /**
  * An extra resource artifact to publish.
  *
@@ -74,6 +76,40 @@ object PublishInfo {
     def tryToMatch(extension: String, classifier: Option[String]): Option[IvyMetadata] = {
       Known.find(meta => meta.extension == extension && meta.classifier == classifier)
     }
+
+
+    /**
+     * Tries to parse the data from a filename.
+     *
+     * Take note that this is not perfect. After smushing the data into a string there's no way to tell what is the
+     * classifier and what is the extension, as both of them can contain dots ('.'). The heuristic that we take is that
+     * extensions are without the dot, so things like ".tar.gz" aren't supported, but they do not seem to be used in Maven
+     * ecosystem, so that works out for most of the cases.
+     *
+     * This should eventually be rehauled, see https://github.com/com-lihaoyi/mill/issues/5538 for more information.
+     *
+     * @param fileName name of the file to use. Can be different from the actual filename of the `file`.
+     * @param artifactId for example, "mill"
+     * @param artifactVersion version of the artifact, for example "1.0.0-RC3"
+     */
+    def parseFromFile(
+      fileName: String,
+      artifactId: String,
+      artifactVersion: String
+    ): IvyMetadata = {
+      val regex = s"^${Pattern.quote(artifactId)}-${Pattern.quote(artifactVersion)}-?"
+      val withoutArtifactIdAndVersion = fileName.replaceFirst(regex, "")
+      val extension = withoutArtifactIdAndVersion.split('.').lastOption.getOrElse("")
+      val classifier = withoutArtifactIdAndVersion.replaceFirst(s"\\.$extension$$", "") match {
+        case "" => None
+        case other => Some(other)
+      }
+
+      tryToMatch(extension = extension, classifier = classifier).getOrElse {
+        // If nothing specific matched, assume it's a generic jar.
+        Jar.copy(extension = extension, classifier = classifier)
+      }
+    }
   }
 
   private[mill] def fromMetadata(file: PathRef, metadata: IvyMetadata): PublishInfo =
@@ -84,47 +120,4 @@ object PublishInfo {
   private[mill] def sourcesJar(sourcesJar: PathRef): PublishInfo =
     fromMetadata(sourcesJar, IvyMetadata.SourcesJar)
   private[mill] def docJar(docJar: PathRef): PublishInfo = fromMetadata(docJar, IvyMetadata.DocJar)
-
-  /**
-   * Tries to parse the data from a filename.
-   *
-   * Take note that this is not perfect. After smushing the data into a string there's no way to tell what is the
-   * classifier and what is the extension, as both of them can contain dots ('.'). The heuristic that we take is that
-   * extensions are without the dot, so things like ".tar.gz" aren't supported, but they do not seem to be used in Maven
-   * ecosystem, so that works out for most of the cases.
-   *
-   * This should eventually be rehauled, see https://github.com/com-lihaoyi/mill/issues/5538 for more information.
-   *
-   * @param file reference to the file.
-   * @param fileName name of the file to use. Can be different from the actual filename of the `file`.
-   * @param artifactId for example, "mill"
-   * @param artifactVersion version of the artifact, for example "1.0.0-RC3"
-   */
-  private[mill] def parseFromFile(
-      file: PathRef,
-      fileName: String,
-      artifactId: String,
-      artifactVersion: String
-  ): PublishInfo = {
-    val withoutArtifactIdAndVersion = fileName.replaceFirst(s"^$artifactId-$artifactVersion-?", "")
-    val extension = withoutArtifactIdAndVersion.split('.').lastOption.getOrElse("")
-    val classifier = withoutArtifactIdAndVersion.replaceFirst(s"\\.$extension$$", "") match {
-      case "" => None
-      case other => Some(other)
-    }
-
-    IvyMetadata.tryToMatch(extension = extension, classifier = classifier) match {
-      case Some(meta) => meta.toPublishInfo(file)
-      case None =>
-        // If nothing specific matched, assume it's a generic jar.
-        val jar = IvyMetadata.Jar
-        apply(
-          file,
-          classifier = classifier,
-          ext = extension,
-          ivyConfig = jar.config,
-          ivyType = jar.`type`
-        )
-    }
-  }
 }

--- a/scalalib/test/src/mill/scalalib/publish/PublishInfoTests.scala
+++ b/scalalib/test/src/mill/scalalib/publish/PublishInfoTests.scala
@@ -1,0 +1,67 @@
+package mill.scalalib.publish
+
+import utest.*
+
+object PublishInfoTests extends TestSuite {
+  override def tests: Tests = Tests {
+    test("IvyMetadata") {
+      test("parseFromFile") {
+        test("testProject") {
+          def parse(name: String) = PublishInfo.IvyMetadata.parseFromFile(
+            fileName = name,
+            artifactId = "testProject_3.3.4",
+            artifactVersion = "0.0.1-SNAPSHOT"
+          )
+
+          test("pom") {
+            val actual = parse("testProject_3.3.4-0.0.1-SNAPSHOT.pom")
+            assert(actual == PublishInfo.IvyMetadata.Pom)
+          }
+
+          test("jar") {
+            val actual = parse("testProject_3.3.4-0.0.1-SNAPSHOT.jar")
+            assert(actual == PublishInfo.IvyMetadata.Jar)
+          }
+
+          test("sources") {
+            val actual = parse("testProject_3.3.4-0.0.1-SNAPSHOT-sources.jar")
+            assert(actual == PublishInfo.IvyMetadata.SourcesJar)
+          }
+
+          test("docs") {
+            val actual = parse("testProject_3.3.4-0.0.1-SNAPSHOT-javadoc.jar")
+            assert(actual == PublishInfo.IvyMetadata.DocJar)
+          }
+        }
+
+        test("chisel-plugin") {
+          def parse(name: String) = PublishInfo.IvyMetadata.parseFromFile(
+            fileName = name,
+            artifactId = "chisel-plugin_3.3.4",
+            artifactVersion = "7.0.0-RC3+5-c4ca27e5-SNAPSHOT"
+          )
+
+          test("pom") {
+            val actual = parse("chisel-plugin_3.3.4-7.0.0-RC3+5-c4ca27e5-SNAPSHOT.pom")
+            assert(actual == PublishInfo.IvyMetadata.Pom)
+          }
+
+          test("jar") {
+            val actual = parse("chisel-plugin_3.3.4-7.0.0-RC3+5-c4ca27e5-SNAPSHOT.jar")
+            assert(actual == PublishInfo.IvyMetadata.Jar)
+          }
+
+          test("sources") {
+            val actual = parse("chisel-plugin_3.3.4-7.0.0-RC3+5-c4ca27e5-SNAPSHOT-sources.jar")
+            assert(actual == PublishInfo.IvyMetadata.SourcesJar)
+          }
+
+          test("docs") {
+            val actual = parse("chisel-plugin_3.3.4-7.0.0-RC3+5-c4ca27e5-SNAPSHOT-javadoc.jar")
+            assert(actual == PublishInfo.IvyMetadata.DocJar)
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR fixes parsing of strings like "chisel-plugin_3.3.4-7.0.0-RC3+5-c4ca27e5-SNAPSHOT.pom". Previously `chisel-plugin_2.13.14-7.0.0-RC3+4-4815de48-SNAPSHOT` would be identified as a `classifier`.

This happened because when constructing a regular expression we did not escape the id/version parts and thus symbols like + were interpreted as regex instructions instead of literals, which made the regex never match.

Additionally, a small refactoring has been done where `PublishInfo.parseFromFile` is now `PublishInfo.IvyMetadata.parseFromFile`, as it's actually the metadata we are parsing.

---

Backport of https://github.com/com-lihaoyi/mill/pull/5589.