### PR TITLE
Overhaul chrome profile management

### DIFF
--- a/core/api/daemon/src/mill/api/daemon/Logger.scala
+++ b/core/api/daemon/src/mill/api/daemon/Logger.scala
@@ -76,6 +76,16 @@ trait Logger {
   }
 
   /**
+   * Helper method to enable this logger as a line item in the global prompt
+   * while the given code block is running
+   */
+  private[mill] final def withChromeProfile[T](text: String)(t: => T): T = {
+    prompt.beginChromeProfileEntry(text)
+    try t
+    finally prompt.endChromeProfileEntry()
+  }
+
+  /**
    * A short dash-separated prefix that is printed before every log line. Used to
    * uniquely identify log lines belonging to this logger from log lines belonging
    * to others, which is especially necessary in the presence of concurrency and
@@ -119,7 +129,6 @@ object Logger {
    * to logger unchanged without any customization.
    */
   private[mill] trait Prompt {
-
     private[mill] def setPromptDetail(key: Seq[String], s: String): Unit
     private[mill] def reportKey(key: Seq[String]): Unit
     private[mill] def setPromptLine(key: Seq[String], keySuffix: String, message: String): Unit
@@ -129,6 +138,8 @@ object Logger {
     private[mill] def withPromptPaused[T](t: => T): T
     private[mill] def withPromptUnpaused[T](t: => T): T
 
+    private[mill] def beginChromeProfileEntry(text: String): Unit
+    private[mill] def endChromeProfileEntry(): Unit
     def debugEnabled: Boolean
 
     private[mill] def enableTicker: Boolean
@@ -149,6 +160,10 @@ object Logger {
       private[mill] def removePromptLine(key: Seq[String]): Unit = ()
       private[mill] def withPromptPaused[T](t: => T): T = t
       private[mill] def withPromptUnpaused[T](t: => T): T = t
+
+      private[mill] def beginChromeProfileEntry(text: String): Unit = ()
+
+      private[mill] def endChromeProfileEntry(): Unit = ()
 
       def debugEnabled: Boolean = false
 

--- a/core/api/src/mill/api/MultiBiMap.scala
+++ b/core/api/src/mill/api/MultiBiMap.scala
@@ -19,6 +19,7 @@ private[mill] trait MultiBiMap[K, V] {
   def items(): Iterator[(K, collection.Seq[V])]
   def values(): Iterator[collection.Seq[V]]
   def keyCount: Int
+  def foreach(f: (K, collection.Seq[V]) => Unit): Unit
 }
 
 private[mill] object MultiBiMap {
@@ -51,5 +52,7 @@ private[mill] object MultiBiMap {
     def items(): Iterator[(K, collection.Seq[V])] = keyToValues.iterator
 
     def keyCount: Int = keyToValues.size
+
+    def foreach(f: (K, collection.Seq[V]) => Unit): Unit = keyToValues.foreach(f(_, _))
   }
 }

--- a/core/api/src/mill/api/TopoSorted.scala
+++ b/core/api/src/mill/api/TopoSorted.scala
@@ -2,5 +2,10 @@ package mill.api
 
 /**
  * Represents the topologically sorted set of tasks
+ *
+ * `values`is guaranteed to be topological sorted and cycle free.
+ * That's why the constructor is package private.
+ *
+ * @see [[PlanImpl.topoSorted]]
  */
 final class TopoSorted private[mill] (val values: IndexedSeq[mill.api.Task[?]])

--- a/core/api/src/mill/api/internal/Reflect.scala
+++ b/core/api/src/mill/api/internal/Reflect.scala
@@ -78,7 +78,6 @@ private[mill] object Reflect {
     arr.distinctBy(_.getName)
   }
 
-
   def reflectNestedObjects0[T: ClassTag](
       outerCls: Class[?],
       filter: String => Boolean = Function.const(true),

--- a/core/eval/src/mill/eval/EvaluatorImpl.scala
+++ b/core/eval/src/mill/eval/EvaluatorImpl.scala
@@ -6,7 +6,7 @@ import mill.constants.OutFiles.*
 import mill.api.{PathRef, *}
 import mill.api.internal.{ResolveChecker, RootModule0}
 import mill.api.daemon.Watchable
-import mill.exec.{Execution, PlanImpl}
+import mill.exec.{Execution, ExecutionLogs, PlanImpl}
 import mill.internal.PrefixLogger
 import mill.resolve.Resolve
 

--- a/core/eval/src/mill/eval/EvaluatorImpl.scala
+++ b/core/eval/src/mill/eval/EvaluatorImpl.scala
@@ -249,8 +249,7 @@ final class EvaluatorImpl private[mill] (
     val promptLineLogger = new PrefixLogger(
       logger0 = baseLogger,
       key0 = Seq("resolve"),
-      keySuffix = "",
-      noPrefix = false
+      message = scriptArgs.mkString(" ")
     )
     val resolved = promptLineLogger.withPromptLine {
       os.checker.withValue(ResolveChecker(workspace)) {

--- a/core/eval/src/mill/eval/EvaluatorImpl.scala
+++ b/core/eval/src/mill/eval/EvaluatorImpl.scala
@@ -4,9 +4,10 @@ import mill.api.daemon.internal.{CompileProblemReporter, ExecutionResultsApi, Te
 import mill.constants.OutFiles
 import mill.constants.OutFiles.*
 import mill.api.{PathRef, *}
-import mill.api.internal.{RootModule0, ResolveChecker}
+import mill.api.internal.{ResolveChecker, RootModule0}
 import mill.api.daemon.Watchable
 import mill.exec.{Execution, PlanImpl}
+import mill.internal.PrefixLogger
 import mill.resolve.Resolve
 
 /**
@@ -245,19 +246,26 @@ final class EvaluatorImpl private[mill] (
       reporter: Int => Option[CompileProblemReporter] = _ => None,
       selectiveExecution: Boolean = false
   ): mill.api.Result[Evaluator.Result[Any]] = {
-    val resolved = os.checker.withValue(ResolveChecker(workspace)) {
-      Evaluator.withCurrentEvaluator(this) {
-        Resolve.Tasks.resolve(
-          rootModule,
-          scriptArgs,
-          selectMode,
-          allowPositionalCommandArgs
-        )
+    val promptLineLogger = new PrefixLogger(
+      logger0 = baseLogger,
+      key0 = Seq("resolve"),
+      keySuffix = "",
+      noPrefix = false
+    )
+    val resolved = promptLineLogger.withPromptLine {
+      os.checker.withValue(ResolveChecker(workspace)) {
+        Evaluator.withCurrentEvaluator(this) {
+          Resolve.Tasks.resolve(
+            rootModule,
+            scriptArgs,
+            selectMode,
+            allowPositionalCommandArgs
+          )
+        }
       }
     }
-
-    for (task <- resolved)
-      yield execute(Seq.from(task), reporter = reporter, selectiveExecution = selectiveExecution)
+    for (tasks <- resolved)
+      yield execute(Seq.from(tasks), reporter = reporter, selectiveExecution = selectiveExecution)
   }
 
   def close(): Unit = execution.close()

--- a/core/eval/src/mill/eval/EvaluatorImpl.scala
+++ b/core/eval/src/mill/eval/EvaluatorImpl.scala
@@ -6,7 +6,7 @@ import mill.constants.OutFiles.*
 import mill.api.{PathRef, *}
 import mill.api.internal.{ResolveChecker, RootModule0}
 import mill.api.daemon.Watchable
-import mill.exec.{Execution, ExecutionLogs, PlanImpl}
+import mill.exec.{Execution, PlanImpl}
 import mill.internal.PrefixLogger
 import mill.resolve.Resolve
 

--- a/core/eval/src/mill/eval/EvaluatorImpl.scala
+++ b/core/eval/src/mill/eval/EvaluatorImpl.scala
@@ -249,7 +249,7 @@ final class EvaluatorImpl private[mill] (
     val promptLineLogger = new PrefixLogger(
       logger0 = baseLogger,
       key0 = Seq("resolve"),
-      message = scriptArgs.mkString(" ")
+      message = "resolve " + scriptArgs.mkString(" ")
     )
     val resolved = promptLineLogger.withPromptLine {
       os.checker.withValue(ResolveChecker(workspace)) {

--- a/core/exec/src/mill/exec/Execution.scala
+++ b/core/exec/src/mill/exec/Execution.scala
@@ -182,9 +182,9 @@ private[mill] case class Execution(
 
                 val contextLogger = new PrefixLogger(
                   logger0 = logger,
-                  key0 = if (!logger.prompt.enableTicker) Nil else Seq(countMsg),
+                  key0 = Seq(countMsg),
                   keySuffix = keySuffix,
-                  message = if (logger.prompt.enableTicker) terminal.toString else "",
+                  message = terminal.toString,
                   noPrefix = exclusive
                 )
 

--- a/core/exec/src/mill/exec/Execution.scala
+++ b/core/exec/src/mill/exec/Execution.scala
@@ -163,7 +163,8 @@ private[mill] case class Execution(
           futures(terminal) = Future.sequence(deps.map(futures)).map { upstreamValues =>
             try {
               val countMsg = mill.api.internal.Util.leftPad(
-                count.getAndIncrement().toString, terminals.length.toString.length,
+                count.getAndIncrement().toString,
+                terminals.length.toString.length,
                 '0'
               )
 

--- a/core/exec/src/mill/exec/Execution.scala
+++ b/core/exec/src/mill/exec/Execution.scala
@@ -1,7 +1,7 @@
 package mill.exec
 
 import mill.api.daemon.internal.*
-import mill.constants.OutFiles.{millChromeProfile, millProfile}
+import mill.constants.OutFiles.millProfile
 import mill.api.*
 import mill.internal.{JsonArrayLogger, PrefixLogger}
 

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -90,160 +90,159 @@ private trait GroupExecution {
       exclusive: Boolean,
       upstreamPathRefs: Seq[PathRef]
   ): GroupExecution.Results = {
-    logger.withPromptLine {
-      val externalInputsHash = MurmurHash3.orderedHash(
-        group.flatMap(_.inputs).filter(!group.contains(_))
-          .flatMap(results(_).asSuccess.map(_.value._2))
-      )
 
-      val sideHashes = MurmurHash3.orderedHash(group.iterator.map(_.sideHash))
+    val externalInputsHash = MurmurHash3.orderedHash(
+      group.flatMap(_.inputs).filter(!group.contains(_))
+        .flatMap(results(_).asSuccess.map(_.value._2))
+    )
 
-      val scriptsHash = MurmurHash3.orderedHash(
-        group
-          .iterator
-          .collect { case namedTask: Task.Named[_] =>
-            CodeSigUtils.codeSigForTask(
-              namedTask,
-              classToTransitiveClasses,
-              allTransitiveClassMethods,
-              codeSignatures,
-              constructorHashSignatures
-            )
-          }
-          .flatten
-      )
+    val sideHashes = MurmurHash3.orderedHash(group.iterator.map(_.sideHash))
 
-      val javaHomeHash = sys.props("java.home").hashCode
-      val inputsHash =
-        externalInputsHash + sideHashes + classLoaderSigHash + scriptsHash + javaHomeHash
+    val scriptsHash = MurmurHash3.orderedHash(
+      group
+        .iterator
+        .collect { case namedTask: Task.Named[_] =>
+          CodeSigUtils.codeSigForTask(
+            namedTask,
+            classToTransitiveClasses,
+            allTransitiveClassMethods,
+            codeSignatures,
+            constructorHashSignatures
+          )
+        }
+        .flatten
+    )
 
-      terminal match {
+    val javaHomeHash = sys.props("java.home").hashCode
+    val inputsHash =
+      externalInputsHash + sideHashes + classLoaderSigHash + scriptsHash + javaHomeHash
 
-        case labelled: Task.Named[_] =>
-          labelled.ctx.segments.value match {
-            case Seq(Segment.Label(single)) if parsedHeaderData.contains(single) =>
-              val jsonData = parsedHeaderData(single)
-              val (resultData, serializedPaths) = PathRef.withSerializedPaths {
-                upickle.default.read[Any](jsonData)(
-                  using labelled.readWriterOpt.get.asInstanceOf[upickle.default.Reader[Any]]
-                )
-              }
-              GroupExecution.Results(
-                Map(labelled -> ExecResult.Success(Val(resultData), resultData.##)),
-                Nil,
-                cached = true,
-                inputsHash,
-                -1,
-                false,
-                serializedPaths
+    terminal match {
+
+      case labelled: Task.Named[_] =>
+        labelled.ctx.segments.value match {
+          case Seq(Segment.Label(single)) if parsedHeaderData.contains(single) =>
+            val jsonData = parsedHeaderData(single)
+            val (resultData, serializedPaths) = PathRef.withSerializedPaths {
+              upickle.default.read[Any](jsonData)(
+                using labelled.readWriterOpt.get.asInstanceOf[upickle.default.Reader[Any]]
               )
-            case _ =>
-              val out = if (!labelled.ctx.external) outPath else externalOutPath
-              val paths = ExecutionPaths.resolve(out, labelled.ctx.segments)
-              val cached = loadCachedJson(logger, inputsHash, labelled, paths)
+            }
+            GroupExecution.Results(
+              Map(labelled -> ExecResult.Success(Val(resultData), resultData.##)),
+              Nil,
+              cached = true,
+              inputsHash,
+              -1,
+              false,
+              serializedPaths
+            )
+          case _ =>
+            val out = if (!labelled.ctx.external) outPath else externalOutPath
+            val paths = ExecutionPaths.resolve(out, labelled.ctx.segments)
+            val cached = loadCachedJson(logger, inputsHash, labelled, paths)
 
-              // `cached.isEmpty` means worker metadata file removed by user so recompute the worker
-              val upToDateWorker = loadUpToDateWorker(logger, inputsHash, labelled, cached.isEmpty)
+            // `cached.isEmpty` means worker metadata file removed by user so recompute the worker
+            val upToDateWorker = loadUpToDateWorker(logger, inputsHash, labelled, cached.isEmpty)
 
-              val cachedValueAndHash =
-                upToDateWorker.map(w => (w -> Nil, inputsHash))
-                  .orElse(cached.flatMap { case (_, valOpt, valueHash) =>
-                    valOpt.map((_, valueHash))
-                  })
+            val cachedValueAndHash =
+              upToDateWorker.map(w => (w -> Nil, inputsHash))
+                .orElse(cached.flatMap { case (_, valOpt, valueHash) =>
+                  valOpt.map((_, valueHash))
+                })
 
-              cachedValueAndHash match {
-                case Some(((v, serializedPaths), hashCode)) =>
-                  val res = ExecResult.Success((v, hashCode))
-                  val newResults: Map[Task[?], ExecResult[(Val, Int)]] =
-                    Map(labelled -> res)
+            cachedValueAndHash match {
+              case Some(((v, serializedPaths), hashCode)) =>
+                val res = ExecResult.Success((v, hashCode))
+                val newResults: Map[Task[?], ExecResult[(Val, Int)]] =
+                  Map(labelled -> res)
 
-                  GroupExecution.Results(
-                    newResults,
-                    Nil,
-                    cached = true,
-                    inputsHash,
-                    -1,
-                    valueHashChanged = false,
-                    serializedPaths
+                GroupExecution.Results(
+                  newResults,
+                  Nil,
+                  cached = true,
+                  inputsHash,
+                  -1,
+                  valueHashChanged = false,
+                  serializedPaths
+                )
+
+              case _ =>
+                // uncached
+                if (!labelled.persistent) os.remove.all(paths.dest)
+
+                val (newResults, newEvaluated) =
+                  executeGroup(
+                    group = group,
+                    results = results,
+                    inputsHash = inputsHash,
+                    paths = Some(paths),
+                    taskLabelOpt = Some(terminal.toString),
+                    counterMsg = countMsg,
+                    reporter = zincProblemReporter,
+                    testReporter = testReporter,
+                    logger = logger,
+                    executionContext = executionContext,
+                    exclusive = exclusive,
+                    deps = deps,
+                    upstreamPathRefs = upstreamPathRefs,
+                    terminal = labelled
                   )
 
-                case _ =>
-                  // uncached
-                  if (!labelled.persistent) os.remove.all(paths.dest)
+                val (valueHash, serializedPaths) = newResults(labelled) match {
+                  case ExecResult.Success((v, _)) =>
+                    val valueHash = getValueHash(v, terminal, inputsHash)
+                    val serializedPaths =
+                      handleTaskResult(v, valueHash, paths.meta, inputsHash, labelled)
+                    (valueHash, serializedPaths)
 
-                  val (newResults, newEvaluated) =
-                    executeGroup(
-                      group = group,
-                      results = results,
-                      inputsHash = inputsHash,
-                      paths = Some(paths),
-                      taskLabelOpt = Some(terminal.toString),
-                      counterMsg = countMsg,
-                      reporter = zincProblemReporter,
-                      testReporter = testReporter,
-                      logger = logger,
-                      executionContext = executionContext,
-                      exclusive = exclusive,
-                      deps = deps,
-                      upstreamPathRefs = upstreamPathRefs,
-                      terminal = labelled
-                    )
+                  case _ =>
+                    // Wipe out any cached meta.json file that exists, so
+                    // a following run won't look at the cached metadata file and
+                    // assume it's associated with the possibly-borked state of the
+                    // destPath after an evaluation failure.
+                    os.remove.all(paths.meta)
+                    (0, Nil)
+                }
 
-                  val (valueHash, serializedPaths) = newResults(labelled) match {
-                    case ExecResult.Success((v, _)) =>
-                      val valueHash = getValueHash(v, terminal, inputsHash)
-                      val serializedPaths =
-                        handleTaskResult(v, valueHash, paths.meta, inputsHash, labelled)
-                      (valueHash, serializedPaths)
+                GroupExecution.Results(
+                  newResults,
+                  newEvaluated.toSeq,
+                  cached = if (labelled.isInstanceOf[Task.Input[?]]) null else false,
+                  inputsHash,
+                  cached.map(_._1).getOrElse(-1),
+                  !cached.map(_._3).contains(valueHash),
+                  serializedPaths
+                )
+            }
+        }
+      case _ =>
+        val (newResults, newEvaluated) = executeGroup(
+          group = group,
+          results = results,
+          inputsHash = inputsHash,
+          paths = None,
+          taskLabelOpt = None,
+          counterMsg = countMsg,
+          reporter = zincProblemReporter,
+          testReporter = testReporter,
+          logger = logger,
+          executionContext = executionContext,
+          exclusive = exclusive,
+          deps = deps,
+          upstreamPathRefs = upstreamPathRefs,
+          terminal = terminal
+        )
+        GroupExecution.Results(
+          newResults,
+          newEvaluated.toSeq,
+          null,
+          inputsHash,
+          -1,
+          valueHashChanged = false,
+          serializedPaths = Nil
+        )
 
-                    case _ =>
-                      // Wipe out any cached meta.json file that exists, so
-                      // a following run won't look at the cached metadata file and
-                      // assume it's associated with the possibly-borked state of the
-                      // destPath after an evaluation failure.
-                      os.remove.all(paths.meta)
-                      (0, Nil)
-                  }
-
-                  GroupExecution.Results(
-                    newResults,
-                    newEvaluated.toSeq,
-                    cached = if (labelled.isInstanceOf[Task.Input[?]]) null else false,
-                    inputsHash,
-                    cached.map(_._1).getOrElse(-1),
-                    !cached.map(_._3).contains(valueHash),
-                    serializedPaths
-                  )
-              }
-          }
-        case _ =>
-          val (newResults, newEvaluated) = executeGroup(
-            group = group,
-            results = results,
-            inputsHash = inputsHash,
-            paths = None,
-            taskLabelOpt = None,
-            counterMsg = countMsg,
-            reporter = zincProblemReporter,
-            testReporter = testReporter,
-            logger = logger,
-            executionContext = executionContext,
-            exclusive = exclusive,
-            deps = deps,
-            upstreamPathRefs = upstreamPathRefs,
-            terminal = terminal
-          )
-          GroupExecution.Results(
-            newResults,
-            newEvaluated.toSeq,
-            null,
-            inputsHash,
-            -1,
-            valueHashChanged = false,
-            serializedPaths = Nil
-          )
-
-      }
     }
   }
 

--- a/core/exec/src/mill/exec/PlanImpl.scala
+++ b/core/exec/src/mill/exec/PlanImpl.scala
@@ -34,8 +34,8 @@ private[mill] object PlanImpl {
 
     val output = new MultiBiMap.Mutable[T, Task[?]]()
     val topoSortedIndices = topoSortedTasks.values.zipWithIndex.toMap
-    for(task <- topoSortedTasks.values){
-      for(t <- important.lift(task)){
+    for (task <- topoSortedTasks.values) {
+      for (t <- important.lift(task)) {
 
         val transitiveTasks = collection.mutable.LinkedHashSet[Task[?]]()
 

--- a/core/exec/src/mill/exec/PlanImpl.scala
+++ b/core/exec/src/mill/exec/PlanImpl.scala
@@ -33,20 +33,26 @@ private[mill] object PlanImpl {
   ]): MultiBiMap[T, Task[?]] = {
 
     val output = new MultiBiMap.Mutable[T, Task[?]]()
-    for ((task, t) <- topoSortedTasks.values.flatMap(t => important.lift(t).map((t, _))).iterator) {
+    val topoSortedIndices = topoSortedTasks.values.zipWithIndex.toMap
+    for(task <- topoSortedTasks.values){
+      for(t <- important.lift(task)){
 
-      val transitiveTasks = collection.mutable.LinkedHashSet[Task[?]]()
-      def rec(t: Task[?]): Unit = {
-        if (transitiveTasks.contains(t)) () // do nothing
-        else if (important.isDefinedAt(t) && t != task) () // do nothing
-        else {
-          transitiveTasks.add(t)
-          t.inputs.foreach(rec)
+        val transitiveTasks = collection.mutable.LinkedHashSet[Task[?]]()
+
+        def rec(t: Task[?]): Unit = {
+          if (transitiveTasks.contains(t)) () // do nothing
+          else if (important.isDefinedAt(t) && t != task) () // do nothing
+          else {
+            transitiveTasks.add(t)
+            t.inputs.foreach(rec)
+          }
         }
+
+        rec(task)
+        output.addAll(t, transitiveTasks.toArray.sortBy(topoSortedIndices))
       }
-      rec(task)
-      output.addAll(t, topoSorted(transitiveTasks.toIndexedSeq).values)
     }
+
     output
   }
 
@@ -88,13 +94,10 @@ private[mill] object PlanImpl {
     val indexed = transitiveTasks
     val taskIndices = indexed.zipWithIndex.toMap
 
-    val numberedEdges =
-      for (t <- transitiveTasks)
-        yield t.inputs.collect(taskIndices).toArray
+    val numberedEdges = transitiveTasks.map(_.inputs.collect(taskIndices).toArray)
 
-    val sortedClusters = mill.internal.Tarjans(numberedEdges.toArray)
-    val nonTrivialClusters = sortedClusters.filter(_.length > 1)
-    assert(nonTrivialClusters.isEmpty, nonTrivialClusters)
-    new TopoSorted(IndexedSeq.from(sortedClusters.flatten.map(indexed)))
+    val sortedClusters = mill.internal.Tarjans(numberedEdges)
+    assert(sortedClusters.count(_.length > 1) == 0, sortedClusters.filter(_.length > 1))
+    new TopoSorted(sortedClusters.flatten.map(indexed))
   }
 }

--- a/core/internal/src/mill/internal/JsonArrayLogger.scala
+++ b/core/internal/src/mill/internal/JsonArrayLogger.scala
@@ -1,4 +1,4 @@
-package mill.exec
+package mill.internal
 
 import java.io.PrintStream
 import java.nio.file.{Files, StandardOpenOption}
@@ -84,8 +84,8 @@ private[mill] object JsonArrayLogger {
     def log(
         terminal: String,
         cat: String,
+        ph: String,
         startTime: Long,
-        duration: Long,
         threadId: Int,
         cached: Boolean
     ): Unit = {
@@ -93,9 +93,8 @@ private[mill] object JsonArrayLogger {
       val event = ChromeProfile.TraceEvent(
         name = terminal,
         cat = cat,
-        ph = "X",
+        ph = ph,
         ts = startTime,
-        dur = duration,
         pid = 1,
         tid = threadId,
         args = if (cached) Seq("cached") else Seq()
@@ -115,7 +114,6 @@ private[mill] object JsonArrayLogger {
         cat: String,
         ph: String,
         ts: Long,
-        dur: Long,
         pid: Int,
         tid: Int,
         args: Seq[String]

--- a/core/internal/src/mill/internal/JsonArrayLogger.scala
+++ b/core/internal/src/mill/internal/JsonArrayLogger.scala
@@ -26,7 +26,7 @@ private[mill] class JsonArrayLogger[T: upickle.default.Writer](outPath: os.Path,
       while ({
         val value =
           try Some(buffer.take())
-          catch { case e: InterruptedException => None }
+          catch { case _: InterruptedException => None }
 
         value match {
           case Some(v) =>

--- a/core/internal/src/mill/internal/JsonArrayLogger.scala
+++ b/core/internal/src/mill/internal/JsonArrayLogger.scala
@@ -122,6 +122,7 @@ private[mill] object JsonArrayLogger {
         pid = 1,
         tid = threadId
       )
+
       log(event)
     }
     def logEnd(
@@ -146,8 +147,7 @@ private[mill] object JsonArrayLogger {
      */
     @upickle.implicits.key("ph")
     enum TraceEvent derives upickle.default.ReadWriter {
-      @upickle.implicits.key("B")
-      case Begin(
+      @upickle.implicits.key("B") case Begin(
           name: String,
           cat: String,
           ts: Long,
@@ -155,8 +155,7 @@ private[mill] object JsonArrayLogger {
           tid: Int
       )
 
-      @upickle.implicits.key("E")
-      case End(
+      @upickle.implicits.key("E") case End(
           ts: Long,
           pid: Int,
           tid: Int

--- a/core/internal/src/mill/internal/JsonArrayLogger.scala
+++ b/core/internal/src/mill/internal/JsonArrayLogger.scala
@@ -81,46 +81,65 @@ private[mill] object JsonArrayLogger {
   private[mill] class ChromeProfile(outPath: os.Path)
       extends JsonArrayLogger[ChromeProfile.TraceEvent](outPath, indent = -1) {
 
-    def log(
+    def logBegin(
         terminal: String,
         cat: String,
         ph: String,
         startTime: Long,
         threadId: Int,
-        cached: Boolean
     ): Unit = {
 
-      val event = ChromeProfile.TraceEvent(
+      val event = ChromeProfile.TraceEvent.Begin(
         name = terminal,
         cat = cat,
         ph = ph,
         ts = startTime,
         pid = 1,
         tid = threadId,
-        args = if (cached) Seq("cached") else Seq()
+      )
+      log(event)
+    }
+    def logEnd(
+        ph: String,
+        endTime: Long,
+        threadId: Int,
+    ): Unit = {
+
+      val event = ChromeProfile.TraceEvent.End(
+        ph = ph,
+        ts = endTime,
+        pid = 1,
+        tid = threadId,
       )
       log(event)
     }
   }
 
   private object ChromeProfile {
-
     /**
      * Trace Event Format, that can be loaded with Google Chrome via chrome://tracing
      * See https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/
      */
-    case class TraceEvent(
-        name: String,
-        cat: String,
-        ph: String,
-        ts: Long,
-        pid: Int,
-        tid: Int,
-        args: Seq[String]
-    )
+    enum TraceEvent derives upickle.default.ReadWriter {
+      case Begin(
+                       name: String,
+                       cat: String,
+                       ph: String,
+                       ts: Long,
+                       pid: Int,
+                       tid: Int,
+                     )
 
-    object TraceEvent {
-      implicit val readWrite: upickle.default.ReadWriter[TraceEvent] = upickle.default.macroRW
+      case End(
+                            ph: String,
+                            ts: Long,
+                            pid: Int,
+                            tid: Int,
+                          )
     }
+
+
+
+
   }
 }

--- a/core/internal/src/mill/internal/MultiLogger.scala
+++ b/core/internal/src/mill/internal/MultiLogger.scala
@@ -94,6 +94,16 @@ private[mill] class MultiLogger(
     override def errorColor(s: String): String =
       logger1.prompt.errorColor(logger2.prompt.errorColor(s))
     override def colored: Boolean = logger1.prompt.colored || logger2.prompt.colored
+
+    override private[mill] def beginChromeProfileEntry(text: String): Unit = {
+      logger1.prompt.beginChromeProfileEntry(text)
+      logger2.prompt.beginChromeProfileEntry(text)
+    }
+
+    override private[mill] def endChromeProfileEntry(): Unit = {
+      logger1.prompt.endChromeProfileEntry()
+      logger2.prompt.endChromeProfileEntry()
+    }
   }
   def debug(s: String): Unit = {
     logger1.debug(s)

--- a/core/internal/src/mill/internal/PromptLogger.scala
+++ b/core/internal/src/mill/internal/PromptLogger.scala
@@ -111,7 +111,6 @@ private[mill] class PromptLogger(
       chromeProfileLogger.logBegin(
         text,
         "job",
-        "B",
         System.nanoTime() / 1000,
         threadNumberer.getThreadId(Thread.currentThread())
       )
@@ -119,7 +118,6 @@ private[mill] class PromptLogger(
 
     private[mill] def endChromeProfileEntry(): Unit = {
       chromeProfileLogger.logEnd(
-        "E",
         System.nanoTime() / 1000,
         threadNumberer.getThreadId(Thread.currentThread())
       )
@@ -135,9 +133,8 @@ private[mill] class PromptLogger(
     }
 
     override def removePromptLine(key: Seq[String]): Unit = PromptLogger.this.synchronized {
-      val threadId = threadNumberer.getThreadId(Thread.currentThread())
       promptLineState.setCurrent(key, None)
-      chromeProfileLogger.logEnd("E", System.nanoTime() / 1000, threadId)
+      endChromeProfileEntry()
     }
 
     override def setPromptDetail(key: Seq[String], s: String): Unit =
@@ -165,8 +162,7 @@ private[mill] class PromptLogger(
 
     override def setPromptLine(key: Seq[String], keySuffix: String, message: String): Unit =
       PromptLogger.this.synchronized {
-        val threadId = threadNumberer.getThreadId(Thread.currentThread())
-        chromeProfileLogger.logBegin(message, "job", "B", System.nanoTime() / 1000, threadId)
+        beginChromeProfileEntry(message)
         promptLineState.setCurrent(key, Some(s"[${key.mkString("-")}]${spaceNonEmpty(message)}"))
         seenIdentifiers(key) = (keySuffix, message)
       }

--- a/core/internal/src/mill/internal/PromptLogger.scala
+++ b/core/internal/src/mill/internal/PromptLogger.scala
@@ -34,7 +34,6 @@ private[mill] class PromptLogger(
   override def toString: String = s"PromptLogger(${literalize(titleText)})"
   import PromptLogger.*
 
-
   private var termDimensions: (Option[Int], Option[Int]) = (None, None)
 
   readTerminalDims(terminfoPath).foreach(termDimensions = _)

--- a/core/internal/src/mill/internal/PromptLogger.scala
+++ b/core/internal/src/mill/internal/PromptLogger.scala
@@ -108,11 +108,21 @@ private[mill] class PromptLogger(
   object prompt extends Logger.Prompt {
 
     private[mill] def beginChromeProfileEntry(text: String): Unit = {
-      chromeProfileLogger.logBegin(text, "job", "B", System.nanoTime() / 1000, 0)
+      chromeProfileLogger.logBegin(
+        text,
+        "job",
+        "B",
+        System.nanoTime() / 1000,
+        threadNumberer.getThreadId(Thread.currentThread())
+      )
     }
 
     private[mill] def endChromeProfileEntry(): Unit = {
-      chromeProfileLogger.logEnd("E", System.nanoTime() / 1000, 0)
+      chromeProfileLogger.logEnd(
+        "E",
+        System.nanoTime() / 1000,
+        threadNumberer.getThreadId(Thread.currentThread())
+      )
     }
 
     val threadNumberer = new ThreadNumberer()

--- a/core/internal/src/mill/internal/Tarjans.scala
+++ b/core/internal/src/mill/internal/Tarjans.scala
@@ -5,7 +5,7 @@ import scala.collection.mutable
 // Adapted from
 // https://github.com/indy256/codelibrary/blob/c52247216258e84aac442a23273b7d8306ef757b/java/src/SCCTarjan.java
 private[mill] object Tarjans {
-  def apply(graph: Array[Array[Int]]): Array[Array[Int]] = {
+  def apply(graph: IndexedSeq[Array[Int]]): Array[Array[Int]] = {
     val n = graph.length
     val visited = new Array[Boolean](n)
     val stack = mutable.ArrayBuffer.empty[Integer]

--- a/core/internal/src/mill/internal/ThreadNumberer.scala
+++ b/core/internal/src/mill/internal/ThreadNumberer.scala
@@ -1,4 +1,4 @@
-package mill.exec
+package mill.internal
 
 /**
  * Small class to take named threads and assign them stable integer IDs

--- a/core/internal/test/src/mill/internal/PromptLoggerTests.scala
+++ b/core/internal/test/src/mill/internal/PromptLoggerTests.scala
@@ -22,7 +22,8 @@ object PromptLoggerTests extends TestSuite {
       titleText = "TITLE",
       terminfoPath = terminfoPath,
       currentTimeMillis = now,
-      autoUpdate = false
+      autoUpdate = false,
+      chromeProfileLogger = new JsonArrayLogger.ChromeProfile(os.temp())
     ) {
       // For testing purposes, wait till the system is quiescent before re-printing
       // the prompt, to try and keep the test executions deterministic

--- a/integration/feature/full-run-logs/src/FullRunLogsTests.scala
+++ b/integration/feature/full-run-logs/src/FullRunLogsTests.scala
@@ -97,13 +97,13 @@ object FullRunLogsTests extends UtestIntegrationTestSuite {
       assert(millProfile.exists(_.obj("label").str == "compileClasspath"))
       assert(millProfile.exists(_.obj("label").str == "mvnDeps"))
       assert(millProfile.exists(_.obj("label").str == "javacOptions"))
-      assert(millChromeProfile.exists(_.obj.get("name") == ujson.Str("compile")))
-      assert(millChromeProfile.exists(_.obj.get("name") == ujson.Str("compileClasspath")))
-      assert(millChromeProfile.exists(_.obj.get("name") == ujson.Str("mvnDeps")))
-      assert(millChromeProfile.exists(_.obj.get("name") == ujson.Str("javacOptions")))
+      assert(millChromeProfile.exists(_.obj.get("name") == Some(ujson.Str("compile"))))
+      assert(millChromeProfile.exists(_.obj.get("name") == Some(ujson.Str("compileClasspath"))))
+      assert(millChromeProfile.exists(_.obj.get("name") == Some(ujson.Str("mvnDeps"))))
+      assert(millChromeProfile.exists(_.obj.get("name") == Some(ujson.Str("javacOptions"))))
       // Profile logs for show itself
       assert(millProfile.exists(_.obj("label").str == "show"))
-      assert(millChromeProfile.exists(_.obj.get("name") == ujson.Str("show")))
+      assert(millChromeProfile.exists(_.obj.get("name") == Some(ujson.Str("show"))))
     }
   }
 }

--- a/integration/feature/full-run-logs/src/FullRunLogsTests.scala
+++ b/integration/feature/full-run-logs/src/FullRunLogsTests.scala
@@ -97,13 +97,13 @@ object FullRunLogsTests extends UtestIntegrationTestSuite {
       assert(millProfile.exists(_.obj("label").str == "compileClasspath"))
       assert(millProfile.exists(_.obj("label").str == "mvnDeps"))
       assert(millProfile.exists(_.obj("label").str == "javacOptions"))
-      assert(millChromeProfile.exists(_.obj("name").str == "compile"))
-      assert(millChromeProfile.exists(_.obj("name").str == "compileClasspath"))
-      assert(millChromeProfile.exists(_.obj("name").str == "mvnDeps"))
-      assert(millChromeProfile.exists(_.obj("name").str == "javacOptions"))
+      assert(millChromeProfile.exists(_.obj.get("name") == ujson.Str("compile")))
+      assert(millChromeProfile.exists(_.obj.get("name") == ujson.Str("compileClasspath")))
+      assert(millChromeProfile.exists(_.obj.get("name") == ujson.Str("mvnDeps")))
+      assert(millChromeProfile.exists(_.obj.get("name") == ujson.Str("javacOptions")))
       // Profile logs for show itself
       assert(millProfile.exists(_.obj("label").str == "show"))
-      assert(millChromeProfile.exists(_.obj("name").str == "show"))
+      assert(millChromeProfile.exists(_.obj.get("name") == ujson.Str("show")))
     }
   }
 }

--- a/integration/feature/leak-hygiene/src/LeakHygieneTests.scala
+++ b/integration/feature/leak-hygiene/src/LeakHygieneTests.scala
@@ -70,6 +70,8 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
         )
         checkThreads(tester)(
           "HandleRunThread",
+          "JsonArrayLogger mill-chrome-profile.json",
+          "JsonArrayLogger mill-profile.json",
           "MillServerActionRunner",
           "MillServerTimeoutThread",
           "Process ID Checker Thread",
@@ -92,6 +94,8 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
           )
           checkThreads(tester)(
             "HandleRunThread",
+            "JsonArrayLogger mill-chrome-profile.json",
+            "JsonArrayLogger mill-profile.json",
             "MillServerActionRunner",
             "MillServerTimeoutThread",
             "Process ID Checker Thread",
@@ -116,6 +120,8 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
           )
           checkThreads(tester)(
             "HandleRunThread",
+            "JsonArrayLogger mill-chrome-profile.json",
+            "JsonArrayLogger mill-profile.json",
             "MillServerActionRunner",
             "MillServerTimeoutThread",
             "Process ID Checker Thread",
@@ -138,6 +144,8 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
         )
         checkThreads(tester)(
           "HandleRunThread",
+          "JsonArrayLogger mill-chrome-profile.json",
+          "JsonArrayLogger mill-profile.json",
           "MillServerActionRunner",
           "MillServerTimeoutThread",
           "Process ID Checker Thread",
@@ -160,6 +168,8 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
           )
           checkThreads(tester)(
             "HandleRunThread",
+            "JsonArrayLogger mill-chrome-profile.json",
+            "JsonArrayLogger mill-profile.json",
             "MillServerActionRunner",
             "MillServerTimeoutThread",
             "Process ID Checker Thread",
@@ -185,6 +195,8 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
           )
           checkThreads(tester)(
             "HandleRunThread",
+            "JsonArrayLogger mill-chrome-profile.json",
+            "JsonArrayLogger mill-profile.json",
             "MillServerActionRunner",
             "MillServerTimeoutThread",
             "Process ID Checker Thread",
@@ -212,6 +224,8 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
           )
           checkThreads(tester)(
             "HandleRunThread",
+            "JsonArrayLogger mill-chrome-profile.json",
+            "JsonArrayLogger mill-profile.json",
             "MillServerActionRunner",
             "MillServerTimeoutThread",
             "Process ID Checker Thread",
@@ -236,6 +250,8 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
         )
         checkThreads(tester)(
           "HandleRunThread",
+          "JsonArrayLogger mill-chrome-profile.json",
+          "JsonArrayLogger mill-profile.json",
           "MillServerActionRunner",
           "MillServerTimeoutThread",
           "Process ID Checker Thread",

--- a/libs/javalib/src/mill/javalib/JavaModule.scala
+++ b/libs/javalib/src/mill/javalib/JavaModule.scala
@@ -645,7 +645,7 @@ trait JavaModule
    *
    * Doesn't include the coursier project of the current module, see [[coursierProject]] for that.
    */
-  def transitiveCoursierProjects: T[Seq[cs.Project]] = {
+  def transitiveCoursierProjects: Task[Seq[cs.Project]] = {
     val allModuleDeps =
       (compileModuleDepsChecked ++ moduleDepsChecked ++ runModuleDepsChecked ++ bomModuleDepsChecked).distinct
     Task {

--- a/libs/javalib/src/mill/javalib/JavaModule.scala
+++ b/libs/javalib/src/mill/javalib/JavaModule.scala
@@ -645,7 +645,7 @@ trait JavaModule
    *
    * Doesn't include the coursier project of the current module, see [[coursierProject]] for that.
    */
-  def transitiveCoursierProjects: Task[Seq[cs.Project]] = {
+  def transitiveCoursierProjects: T[Seq[cs.Project]] = {
     val allModuleDeps =
       (compileModuleDepsChecked ++ moduleDepsChecked ++ runModuleDepsChecked ++ bomModuleDepsChecked).distinct
     Task {

--- a/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
+++ b/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
@@ -84,145 +84,147 @@ class MillBuildBootstrap(
   }
 
   def evaluateRec(depth: Int): RunnerState = {
-    // println(s"+evaluateRec($depth) " + recRoot(projectRoot, depth))
-    val currentRoot = recRoot(projectRoot, depth)
-    val prevFrameOpt = prevRunnerState.frames.lift(depth)
-    val prevOuterFrameOpt = prevRunnerState.frames.lift(depth - 1)
+    logger.withChromeProfile(s"meta-level $depth") {
+      // println(s"+evaluateRec($depth) " + recRoot(projectRoot, depth))
+      val currentRoot = recRoot(projectRoot, depth)
+      val prevFrameOpt = prevRunnerState.frames.lift(depth)
+      val prevOuterFrameOpt = prevRunnerState.frames.lift(depth - 1)
 
-    val requestedDepth = requestedMetaLevel.filter(_ >= 0).getOrElse(0)
+      val requestedDepth = requestedMetaLevel.filter(_ >= 0).getOrElse(0)
 
-    val (nestedState, headerDataOpt) =
-      if (depth == 0) {
-        // On this level we typically want to assume a Mill project, which means we want to require an existing `build.mill`.
-        // Unfortunately, some tasks also make sense without a `build.mill`, e.g. the `init` command.
-        // Hence, we only report a missing `build.mill` as a problem if the command itself does not succeed.
-        lazy val state = evaluateRec(depth + 1)
-        if (
-          rootBuildFileNames.asScala.exists(rootBuildFileName =>
-            os.exists(currentRoot / rootBuildFileName)
-          )
-        ) (state, None)
-        else {
-          val msg =
-            s"No build file (${rootBuildFileNames.asScala.mkString(", ")}) found in $projectRoot. Are you in a Mill project directory?"
-          val res =
-            if (needBuildFile) RunnerState(None, Nil, Some(msg), None)
-            else {
-              state match {
-                case RunnerState(bootstrapModuleOpt, frames, Some(error), None) =>
-                  // Add a potential clue (missing build.mill) to the underlying error message
-                  RunnerState(bootstrapModuleOpt, frames, Some(msg + "\n" + error))
-                case state => state
-              }
-            }
-          (res, None)
-        }
-      } else {
-        val parsedScriptFiles = FileImportGraph
-          .parseBuildFiles(projectRoot, currentRoot / os.up, output, MillScalaParser.current.value)
-
-        val state =
-          if (os.exists(currentRoot)) evaluateRec(depth + 1)
+      val (nestedState, headerDataOpt) =
+        if (depth == 0) {
+          // On this level we typically want to assume a Mill project, which means we want to require an existing `build.mill`.
+          // Unfortunately, some tasks also make sense without a `build.mill`, e.g. the `init` command.
+          // Hence, we only report a missing `build.mill` as a problem if the command itself does not succeed.
+          lazy val state = evaluateRec(depth + 1)
+          if (
+            rootBuildFileNames.asScala.exists(rootBuildFileName =>
+              os.exists(currentRoot / rootBuildFileName)
+            )
+          ) (state, None)
           else {
-            val bootstrapModule =
-              new MillBuildRootModule.BootstrapModule()(
-                new RootModule.Info(currentRoot, output, projectRoot)
-              )
-            RunnerState(Some(bootstrapModule), Nil, None, Some(parsedScriptFiles.buildFile))
+            val msg =
+              s"No build file (${rootBuildFileNames.asScala.mkString(", ")}) found in $projectRoot. Are you in a Mill project directory?"
+            val res =
+              if (needBuildFile) RunnerState(None, Nil, Some(msg), None)
+              else {
+                state match {
+                  case RunnerState(bootstrapModuleOpt, frames, Some(error), None) =>
+                    // Add a potential clue (missing build.mill) to the underlying error message
+                    RunnerState(bootstrapModuleOpt, frames, Some(msg + "\n" + error))
+                  case state => state
+                }
+              }
+            (res, None)
+          }
+        } else {
+          val parsedScriptFiles = FileImportGraph
+            .parseBuildFiles(projectRoot, currentRoot / os.up, output, MillScalaParser.current.value)
+
+          val state =
+            if (os.exists(currentRoot)) evaluateRec(depth + 1)
+            else {
+              val bootstrapModule =
+                new MillBuildRootModule.BootstrapModule()(
+                  new RootModule.Info(currentRoot, output, projectRoot)
+                )
+              RunnerState(Some(bootstrapModule), Nil, None, Some(parsedScriptFiles.buildFile))
+            }
+
+          (state, Some(parsedScriptFiles.headerData))
+        }
+
+      val res =
+        if (nestedState.errorOpt.isDefined) nestedState.add(errorOpt = nestedState.errorOpt)
+        else if (depth == 0 && requestedDepth > nestedState.frames.size) {
+          // User has requested a frame depth, we actually don't have
+          nestedState.add(errorOpt =
+            Some(
+              s"Invalid selected meta-level ${requestedDepth}. Valid range: 0 .. ${nestedState.frames.size}"
+            )
+          )
+        } else if (depth < requestedDepth) {
+          // We already evaluated on a deeper level, hence we just need to make sure,
+          // we return a proper structure with all already existing watch data
+          val evalState = RunnerState.Frame(
+            prevFrameOpt.map(_.workerCache).getOrElse(Map.empty),
+            Seq.empty,
+            Seq.empty,
+            Map.empty,
+            None,
+            Nil,
+            // We don't want to evaluate anything in this depth (and above), so we just skip creating an evaluator,
+            // mainly because we didn't even construct (compile) its classpath
+            None,
+            None
+          )
+          nestedState.add(frame = evalState, errorOpt = None)
+        } else {
+          val rootModuleRes = nestedState.frames.headOption match {
+            case None =>
+              Result.Success(BuildFileApi.Bootstrap(nestedState.bootstrapModuleOpt.get))
+            case Some(nestedFrame) => getRootModule(nestedFrame.classLoaderOpt.get)
           }
 
-        (state, Some(parsedScriptFiles.headerData))
-      }
+          rootModuleRes match {
+            case Result.Failure(err) => nestedState.add(errorOpt = Some(err))
+            case Result.Success((buildFileApi)) =>
 
-    val res =
-      if (nestedState.errorOpt.isDefined) nestedState.add(errorOpt = nestedState.errorOpt)
-      else if (depth == 0 && requestedDepth > nestedState.frames.size) {
-        // User has requested a frame depth, we actually don't have
-        nestedState.add(errorOpt =
-          Some(
-            s"Invalid selected meta-level ${requestedDepth}. Valid range: 0 .. ${nestedState.frames.size}"
-          )
-        )
-      } else if (depth < requestedDepth) {
-        // We already evaluated on a deeper level, hence we just need to make sure,
-        // we return a proper structure with all already existing watch data
-        val evalState = RunnerState.Frame(
-          prevFrameOpt.map(_.workerCache).getOrElse(Map.empty),
-          Seq.empty,
-          Seq.empty,
-          Map.empty,
-          None,
-          Nil,
-          // We don't want to evaluate anything in this depth (and above), so we just skip creating an evaluator,
-          // mainly because we didn't even construct (compile) its classpath
-          None,
-          None
-        )
-        nestedState.add(frame = evalState, errorOpt = None)
-      } else {
-        val rootModuleRes = nestedState.frames.headOption match {
-          case None =>
-            Result.Success(BuildFileApi.Bootstrap(nestedState.bootstrapModuleOpt.get))
-          case Some(nestedFrame) => getRootModule(nestedFrame.classLoaderOpt.get)
-        }
-
-        rootModuleRes match {
-          case Result.Failure(err) => nestedState.add(errorOpt = Some(err))
-          case Result.Success((buildFileApi)) =>
-
-            Using.resource(makeEvaluator(
-              projectRoot,
-              output,
-              keepGoing,
-              env,
-              logger,
-              ec,
-              allowPositionalCommandArgs,
-              systemExit,
-              streams0,
-              selectiveExecution,
-              offline,
-              prevFrameOpt.map(_.workerCache).getOrElse(Map.empty),
-              nestedState.frames.headOption.map(_.codeSignatures).getOrElse(Map.empty),
-              buildFileApi.rootModule,
-              // We want to use the grandparent buildHash, rather than the parent
-              // buildHash, because the parent build changes are instead detected
-              // by analyzing the scriptImportGraph in a more fine-grained manner.
-              nestedState
-                .frames
-                .dropRight(1)
-                .headOption
-                .map(_.runClasspath)
-                .getOrElse(millBootClasspathPathRefs)
-                .map(p => (os.Path(p.javaPath), p.sig))
-                .hashCode(),
-              nestedState
-                .frames
-                .headOption
-                .flatMap(_.classLoaderOpt)
-                .map(_.hashCode())
-                .getOrElse(0),
-              depth,
-              actualBuildFileName = nestedState.buildFile,
-              headerData = headerDataOpt.getOrElse("")
-            )) { evaluator =>
-              if (depth == requestedDepth) {
-                processFinalTasks(nestedState, buildFileApi, evaluator)
-              } else if (depth <= requestedDepth) nestedState
-              else {
-                processRunClasspath(
-                  nestedState,
-                  buildFileApi,
-                  evaluator,
-                  prevFrameOpt,
-                  prevOuterFrameOpt
-                )
+              Using.resource(makeEvaluator(
+                projectRoot,
+                output,
+                keepGoing,
+                env,
+                logger,
+                ec,
+                allowPositionalCommandArgs,
+                systemExit,
+                streams0,
+                selectiveExecution,
+                offline,
+                prevFrameOpt.map(_.workerCache).getOrElse(Map.empty),
+                nestedState.frames.headOption.map(_.codeSignatures).getOrElse(Map.empty),
+                buildFileApi.rootModule,
+                // We want to use the grandparent buildHash, rather than the parent
+                // buildHash, because the parent build changes are instead detected
+                // by analyzing the scriptImportGraph in a more fine-grained manner.
+                nestedState
+                  .frames
+                  .dropRight(1)
+                  .headOption
+                  .map(_.runClasspath)
+                  .getOrElse(millBootClasspathPathRefs)
+                  .map(p => (os.Path(p.javaPath), p.sig))
+                  .hashCode(),
+                nestedState
+                  .frames
+                  .headOption
+                  .flatMap(_.classLoaderOpt)
+                  .map(_.hashCode())
+                  .getOrElse(0),
+                depth,
+                actualBuildFileName = nestedState.buildFile,
+                headerData = headerDataOpt.getOrElse("")
+              )) { evaluator =>
+                if (depth == requestedDepth) {
+                  processFinalTasks(nestedState, buildFileApi, evaluator)
+                } else if (depth <= requestedDepth) nestedState
+                else {
+                  processRunClasspath(
+                    nestedState,
+                    buildFileApi,
+                    evaluator,
+                    prevFrameOpt,
+                    prevOuterFrameOpt
+                  )
+                }
               }
-            }
+          }
         }
-      }
 
-    res
+      res
+    }
   }
 
   /**

--- a/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
+++ b/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
@@ -120,7 +120,12 @@ class MillBuildBootstrap(
           }
         } else {
           val parsedScriptFiles = FileImportGraph
-            .parseBuildFiles(projectRoot, currentRoot / os.up, output, MillScalaParser.current.value)
+            .parseBuildFiles(
+              projectRoot,
+              currentRoot / os.up,
+              output,
+              MillScalaParser.current.value
+            )
 
           val state =
             if (os.exists(currentRoot)) evaluateRec(depth + 1)

--- a/runner/daemon/src/mill/daemon/MillMain0.scala
+++ b/runner/daemon/src/mill/daemon/MillMain0.scala
@@ -8,7 +8,14 @@ import mill.bsp.BSP
 import mill.client.lock.Lock
 import mill.constants.{DaemonFiles, OutFiles}
 import mill.api.BuildCtx
-import mill.internal.{Colors, JsonArrayLogger, MultiStream, PrefixLogger, PromptLogger, SimpleLogger}
+import mill.internal.{
+  Colors,
+  JsonArrayLogger,
+  MultiStream,
+  PrefixLogger,
+  PromptLogger,
+  SimpleLogger
+}
 import mill.server.Server
 import mill.util.BuildInfo
 import mill.api

--- a/runner/daemon/src/mill/daemon/MillMain0.scala
+++ b/runner/daemon/src/mill/daemon/MillMain0.scala
@@ -8,7 +8,7 @@ import mill.bsp.BSP
 import mill.client.lock.Lock
 import mill.constants.{DaemonFiles, OutFiles}
 import mill.api.BuildCtx
-import mill.internal.{Colors, MultiStream, PrefixLogger, PromptLogger, SimpleLogger}
+import mill.internal.{Colors, JsonArrayLogger, MultiStream, PrefixLogger, PromptLogger, SimpleLogger}
 import mill.server.Server
 import mill.util.BuildInfo
 import mill.api
@@ -292,7 +292,8 @@ object MillMain0 {
                               .orElse(Option.when(config.disableTicker.value)(false)),
                             daemonDir,
                             colored = colored,
-                            colors = colors
+                            colors = colors,
+                            out = out
                           )) { logger =>
                             proceed(logger)
                           }
@@ -521,7 +522,8 @@ object MillMain0 {
       enableTicker: Option[Boolean],
       daemonDir: os.Path,
       colored: Boolean,
-      colors: Colors
+      colors: Colors,
+      out: os.Path
   ): Logger & AutoCloseable = {
     new PromptLogger(
       colored = colored,
@@ -533,7 +535,8 @@ object MillMain0 {
       debugEnabled = config.debugLog.value,
       titleText = config.leftoverArgs.value.mkString(" "),
       terminfoPath = daemonDir / DaemonFiles.terminfo,
-      currentTimeMillis = () => System.currentTimeMillis()
+      currentTimeMillis = () => System.currentTimeMillis(),
+      chromeProfileLogger = new JsonArrayLogger.ChromeProfile(out / OutFiles.millChromeProfile)
     )
   }
 

--- a/runner/daemon/src/mill/daemon/MillMain0.scala
+++ b/runner/daemon/src/mill/daemon/MillMain0.scala
@@ -252,7 +252,6 @@ object MillMain0 {
                             !config.noFilesystemChecker.value
                           ) {
                             tailManager.withOutErr(logger.streams.out, logger.streams.err) {
-
                               new MillBuildBootstrap(
                                 projectRoot = BuildCtx.workspaceRoot,
                                 output = out,

--- a/testkit/src/mill/testkit/UnitTester.scala
+++ b/testkit/src/mill/testkit/UnitTester.scala
@@ -100,7 +100,7 @@ class UnitTester(
         titleText = "",
         terminfoPath = os.temp(),
         currentTimeMillis = () => System.currentTimeMillis(),
-        chromeProfileLogger = new JsonArrayLogger.ChromeProfile(outPath / millChromeProfile),
+        chromeProfileLogger = new JsonArrayLogger.ChromeProfile(outPath / millChromeProfile)
       ) {
     val prefix: String = {
       val idx = fullName.value.lastIndexOf(".")

--- a/testkit/src/mill/testkit/UnitTester.scala
+++ b/testkit/src/mill/testkit/UnitTester.scala
@@ -11,7 +11,7 @@ import mill.constants.OutFiles.millChromeProfile
 import mill.constants.OutFiles.millProfile
 import mill.api.Evaluator
 import mill.api.SelectMode
-import mill.exec.JsonArrayLogger
+import mill.internal.JsonArrayLogger
 import mill.resolve.Resolve
 
 import java.io.InputStream
@@ -99,7 +99,8 @@ class UnitTester(
         debugEnabled = debugEnabled,
         titleText = "",
         terminfoPath = os.temp(),
-        currentTimeMillis = () => System.currentTimeMillis()
+        currentTimeMillis = () => System.currentTimeMillis(),
+        chromeProfileLogger = new JsonArrayLogger.ChromeProfile(outPath / millChromeProfile),
       ) {
     val prefix: String = {
       val idx = fullName.value.lastIndexOf(".")
@@ -121,8 +122,7 @@ class UnitTester(
 
   val execution = new mill.exec.Execution(
     baseLogger = logger,
-    chromeProfileLogger = new JsonArrayLogger.ChromeProfile(outPath / millChromeProfile),
-    profileLogger = new JsonArrayLogger.Profile(outPath / millProfile),
+    profileLogger = new mill.internal.JsonArrayLogger.Profile(outPath / millProfile),
     workspace = module.moduleDir,
     outPath = outPath,
     externalOutPath = outPath,


### PR DESCRIPTION
- Move chrome profile handling from `Execution` into `PromptLogger`, so it can be used outside of the execution phase
- Consolidate chrome-profiling handling into `withPromptLine` to keep it consistent with the terminal UI
- Make chrome-profile logging use separate `begin` and `end` events, so that in-progress tasks can be properly displayed on the profile
- Move chrome-profile logging onto a separate thread to avoid blocking the main execution codepaths
- Add some ad-hoc profile logging for Mill lifecycle phases, to give an approximate view of where non-execution-related time is going. 

<img width="1840" height="652" alt="Screenshot 2025-07-25 at 12 21 54 PM" src="https://github.com/user-attachments/assets/7acaca10-387e-4467-8077-8cd76b82e991" />

- This also makes `[resolve]` and `[planning]` visible in the terminal UI giving the user some indication of what is happening

<img width="976" height="659" alt="Screenshot 2025-07-25 at 12 27 20 PM" src="https://github.com/user-attachments/assets/37441490-9c30-4231-b496-054d668ffbc6" />


- Added some minor micro-optimizations to hot code paths surfaced by this additional profiling, seems to cut down `./mill-assembly.jar __.compile` times on the Mill repo from ~2.5s to ~2.0s