### PR TITLE
Android: Auto-Download CmdlineTools

### DIFF
--- a/.github/actions/setup-android/action.yml
+++ b/.github/actions/setup-android/action.yml
@@ -7,12 +7,6 @@ runs:
       run: echo "ANDROID_SDK_ROOT=$HOME/.android/sdk" >> $GITHUB_ENV
       shell: bash
 
-    - uses: android-actions/setup-android@v3
-      with:
-        log-accepted-android-sdk-licenses: false
-        cmdline-tools-version: 11076708
-        packages: cmdline-tools;latest platform-tools emulator system-images;android-35;google_apis_playstore;x86_64
-
     - name: Enable KVM group perms
       run: |
         echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules

--- a/libs/androidlib/package.mill
+++ b/libs/androidlib/package.mill
@@ -43,6 +43,11 @@ object `package` extends MillPublishScalaModule with BuildInfo {
       "screenshotValidationJunitEngineVersion",
       Deps.AndroidDeps.screenshotValidationJunitEngine.version,
       "Version of screenshotValidationJunitEngine"
+    ),
+    BuildInfo.Value(
+      "cmdlineToolsVersion",
+      Deps.AndroidDeps.cmdlineToolsVersion,
+      "Version of CommandLineTools"
     )
   )
 

--- a/libs/androidlib/src/mill/androidlib/AndroidSdkModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidSdkModule.scala
@@ -322,7 +322,7 @@ trait AndroidSdkModule extends Module {
     // Accept Licenses
     // TODO: Prompt the user to accept licenses interactively
     if (isCI)
-      os.proc("echo", "y").pipeTo(os.proc(sdkManagerExe.toString, "--licenses")).call()
+      os.proc("echo", "y\n" * 10).pipeTo(os.proc(sdkManagerExe.toString, "--licenses")).call()
     sdkManagerExe
   }
 

--- a/mill-build/src/millbuild/Deps.scala
+++ b/mill-build/src/millbuild/Deps.scala
@@ -308,6 +308,7 @@ object Deps {
     val screenshotValidationJunitEngine =
       mvn"com.android.tools.screenshot:screenshot-validation-junit-engine:0.0.1-alpha09"
 
+    val cmdlineToolsVersion = "19.0"
     // TODO: uiTooling is needed for screenshot tests
     // so we handle it diferrently.
     // Removed it from updaetable for now


### PR DESCRIPTION
## Motivation  
Previously, `cmdline-tools` had to be downloaded manually (either via Android Studio or from the official website). In CI, a plugin was used to handle this step. This PR automates the process entirely, removing the need for manual setup.  
This should also resolve https://github.com/com-lihaoyi/mill/issues/5600

## What this changes  
- Adds automatic downloading of `cmdline-tools` if not found.  
- The version to be downloaded is hardcoded, with the option for users to override it by providing their own.  

## TBC
- Update the documentation.  
- Add interactive license acceptance prompting for users.
