### PR TITLE
Remove custom class loader for docJar

### DIFF
--- a/libs/javalib/worker/src/mill/javalib/worker/JvmWorkerImpl.scala
+++ b/libs/javalib/worker/src/mill/javalib/worker/JvmWorkerImpl.scala
@@ -257,10 +257,6 @@ class JvmWorkerImpl(
           val hasErrorsMethod = reporter.getClass().getMethod("hasErrors")
           !hasErrorsMethod.invoke(reporter).asInstanceOf[Boolean]
         } else if (JvmWorkerUtil.isScala3(scalaVersion)) {
-          // DottyDoc makes use of `com.fasterxml.jackson.databind.Module` which
-          // requires the ContextClassLoader to be set appropriately
-          mill.api.ClassLoader.withContextClassLoader(getClass.getClassLoader) {
-
             val scaladocClass =
               compilers.scalac().scalaInstance().loader().loadClass("dotty.tools.scaladoc.Main")
 
@@ -269,7 +265,6 @@ class JvmWorkerImpl(
               scaladocMethod.invoke(scaladocClass.getConstructor().newInstance(), args.toArray)
             val hasErrorsMethod = reporter.getClass().getMethod("hasErrors")
             !hasErrorsMethod.invoke(reporter).asInstanceOf[Boolean]
-          }
         } else {
           val scaladocClass =
             compilers.scalac().scalaInstance().loader().loadClass("scala.tools.nsc.ScalaDoc")


### PR DESCRIPTION
This is causing errors like:
```
java.lang.reflect.InvocationTargetException
    java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
    java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    java.base/java.lang.reflect.Method.invoke(Method.java:569)
    mill.javalib.worker.JvmWorkerImpl.docJar$$anonfun$1$$anonfun$1(JvmWorkerImpl.scala:252)
    mill.api.daemon.ClassLoader$.withContextClassLoader(ClassLoader.scala:14)
    mill.javalib.worker.JvmWorkerImpl.docJar$$anonfun$1(JvmWorkerImpl.scala:255)
    mill.javalib.worker.JvmWorkerImpl.withCompilers$$anonfun$1(JvmWorkerImpl.scala:475)
    mill.util.CachedFactory.withValue(CachedFactory.scala:39)
    mill.javalib.worker.JvmWorkerImpl.withCompilers(JvmWorkerImpl.scala:474)
    mill.javalib.worker.JvmWorkerImpl.docJar(JvmWorkerImpl.scala:226)
    build_.common.package_.generateWithZinc$1(package.mill:18)
    build_.common.package_.scalaDocGeneratedd$$anonfun$1$$anonfun$1(package.mill:90)
    mill.api.Task$Named.evaluate(Task.scala:338)
    mill.api.Task$Named.evaluate$(Task.scala:323)
    mill.api.Task$Computed.evaluate(Task.scala:349)
java.util.ServiceConfigurationError: com.fasterxml.jackson.databind.Module: com.fasterxml.jackson.datatype.jsr310.JavaTimeModule not a subtype
    java.base/java.util.ServiceLoader.fail(ServiceLoader.java:593)
    java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNextService(ServiceLoader.java:1244)
    java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNext(ServiceLoader.java:1273)
    java.base/java.util.ServiceLoader$2.hasNext(ServiceLoader.java:1309)
    java.base/java.util.ServiceLoader$3.hasNext(ServiceLoader.java:1393)
    com.fasterxml.jackson.databind.ObjectMapper.findModules(ObjectMapper.java:1131)
    com.fasterxml.jackson.databind.ObjectMapper.findModules(ObjectMapper.java:1115)
    com.fasterxml.jackson.databind.ObjectMapper.findAndRegisterModules(ObjectMapper.java:1165)
    dotty.tools.scaladoc.site.BlogParser$.readYml(BlogParser.scala:19)
    dotty.tools.scaladoc.site.StaticSiteLoader.loadBlog(StaticSiteLoader.scala:118)
    dotty.tools.scaladoc.site.StaticSiteLoader.loadBasedOnFileSystem(StaticSiteLoader.scala:111)
    dotty.tools.scaladoc.site.StaticSiteLoader.load$$anonfun$3(StaticSiteLoader.scala:22)
    scala.Option.fold(Option.scala:263)
    dotty.tools.scaladoc.site.StaticSiteLoader.load(StaticSiteLoader.scala:22)
    dotty.tools.scaladoc.site.StaticSiteContext.staticSiteRoot$lzyINIT1(StaticSiteContext.scala:43)
    dotty.tools.scaladoc.site.StaticSiteContext.staticSiteRoot(StaticSiteContext.scala:43)
    dotty.tools.scaladoc.renderers.Renderer.<init>(Renderer.scala:36)
    dotty.tools.scaladoc.renderers.HtmlRenderer.<init>(HtmlRenderer.scala:10)
    dotty.tools.scaladoc.Scaladoc$.run(Scaladoc.scala:241)
    dotty.tools.scaladoc.Scaladoc$.run$$anonfun$1(Scaladoc.scala:70)
    scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
    scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
    scala.Option.map(Option.scala:242)
    dotty.tools.scaladoc.Scaladoc$.run(Scaladoc.scala:55)
    dotty.tools.scaladoc.Main.run(Main.scala:8)
    java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
    java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    java.base/java.lang.reflect.Method.invoke(Method.java:569)
    mill.javalib.worker.JvmWorkerImpl.docJar$$anonfun$1$$anonfun$1(JvmWorkerImpl.scala:252)
    mill.api.daemon.ClassLoader$.withContextClassLoader(ClassLoader.scala:14)
    mill.javalib.worker.JvmWorkerImpl.docJar$$anonfun$1(JvmWorkerImpl.scala:255)
    mill.javalib.worker.JvmWorkerImpl.withCompilers$$anonfun$1(JvmWorkerImpl.scala:475)
    mill.util.CachedFactory.withValue(CachedFactory.scala:39)
    mill.javalib.worker.JvmWorkerImpl.withCompilers(JvmWorkerImpl.scala:474)
    mill.javalib.worker.JvmWorkerImpl.docJar(JvmWorkerImpl.scala:226)
    build_.common.package_.generateWithZinc$1(package.mill:18)
    build_.common.package_.scalaDocGeneratedd$$anonfun$1$$anonfun$1(package.mill:90)
    mill.api.Task$Named.evaluate(Task.scala:338)
    mill.api.Task$Named.evaluate$(Task.scala:323)
    mill.api.Task$Computed.evaluate(Task.scala:349)
  ```

Please open all PRs as drafts and ensure that your fork of Mill has 
`settings/actions` / `Allow all actions and reusable workflows` enabled to run CI on
your own fork of the Mill repo. Only once CI passes mark the PR as `Ready for review`
and CI will run on the main Mill repo before we merge it.
