### PR TITLE
Rebootstrap

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1,4 +1,4 @@
-//| mill-version: 1.0.1-22-3ffc87
+//| mill-version: 1.0.1-25-ee7483
 //| mill-jvm-opts: ["-XX:NonProfiledCodeHeapSize=250m", "-XX:ReservedCodeCacheSize=500m"]
 //| mill-opts: ["--jobs=0.5C"]
 

--- a/integration/package.mill
+++ b/integration/package.mill
@@ -82,17 +82,6 @@ object `package` extends mill.Module {
       def mode: String = moduleSegments.parts.last
       def scalaVersion = Deps.scalaVersion
 
-      /** Extracts the values of the provided keys from the environment. */
-      private def extractFromEnv(keys: String*): Task[Map[String, String]] = Task.Anon {
-        val env = Task.env
-        keys.foldLeft(Map.empty[String, String]) { (map, key) =>
-          env.get(key) match {
-            case Some(value) => map.updated(key, value)
-            case None => map
-          }
-        }
-      }
-
       def forkEnv = Task {
         super.forkEnv() ++
           IntegrationTestModule.this.forkEnv() ++
@@ -103,13 +92,6 @@ object `package` extends mill.Module {
             "MILL_LAUNCHER_BAT" -> build.dist.bootstrapLauncherBat().path.toString,
             "MILL_INTEGRATION_LAUNCHER" -> millIntegrationLauncher().path.toString
           ) ++
-          extractFromEnv(
-            "MILL_TESTS_BSP_UPDATE_SNAPSHOTS",
-            "MILL_TESTS_PUBLISH_ORG",
-            "MILL_TESTS_PUBLISH_DRY_RUN",
-            SonatypeHelpers.USERNAME_ENV_VARIABLE_NAME,
-            SonatypeHelpers.PASSWORD_ENV_VARIABLE_NAME
-          )() ++
           (if (millIntegrationIsPackagedLauncher()) Map() else build.dist.localTestOverridesEnv())
       }
 


### PR DESCRIPTION
Pulls in https://github.com/com-lihaoyi/mill/pull/5617, which means we shouldn't need to manually propagate environment variables from our build.mill into our integration tests