### PR TITLE
Fix mill server timeout back to 30min

### DIFF
--- a/runner/daemon/src/mill/daemon/MillDaemonMain.scala
+++ b/runner/daemon/src/mill/daemon/MillDaemonMain.scala
@@ -37,7 +37,7 @@ object MillDaemonMain {
       )
 
       val acceptTimeoutMillis =
-        Try(System.getProperty("mill.server_timeout").toInt).getOrElse(30 * 1000) // 30 minutes
+        Try(System.getProperty("mill.server_timeout").toInt).getOrElse(30 * 60 * 1000) // 30 minutes
 
       new MillDaemonMain(
         daemonDir = os.Path(args0(0)),


### PR DESCRIPTION
Previously it was changed to 30s for debugging and accidentally committed, this just changes it back