### PR TITLE
Fix android install

### DIFF
--- a/libs/androidlib/src/mill/androidlib/AndroidAppKotlinModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppKotlinModule.scala
@@ -27,7 +27,7 @@ trait AndroidAppKotlinModule extends AndroidKotlinModule with AndroidAppModule {
 
   private def kotlinSources = Task.Sources("src/main/kotlin")
   override def sources: T[Seq[PathRef]] =
-    super.sources() ++ kotlinSources()
+    super[AndroidAppModule].sources() ++ kotlinSources()
 
   trait AndroidAppKotlinTests extends AndroidAppKotlinModule with AndroidAppTests {
     override def kotlinVersion: T[String] = outer.kotlinVersion

--- a/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
@@ -816,7 +816,7 @@ trait AndroidAppModule extends AndroidModule { outer =>
 
     Task.log.debug("Building dex with command: " + dex.dexCliArgs.mkString(" "))
 
-    Task.log.info(os.call(dex.dexCliArgs).err.text())
+    os.call(dex.dexCliArgs)
 
     PathRef(dex.outPath.path)
 


### PR DESCRIPTION
Fixes caches not being invalidated for androidDex when source code changes

ref: https://github.com/com-lihaoyi/mill/issues/5616

## Explanation

- androidD8Dex was just returning the cli arguments with the paths as strings, thus while it was executed, androidDex was not, because the result from `androidD8Dex` was identical even after source changes. After adding the list of PathRef of the compiled classes the androidDex was executed on altering source files as in turn, compiled files were changed and detection is propagated by path ref hashing.
- androidDex was forwarding the PathRef of `androidD8Dex` which was being created on an empty directory, thus the PathRef signature was identical. Recreating it gives a fresh hash.

## Fix demo

https://github.com/user-attachments/assets/76a85669-c62b-43a7-85e4-5931f2f53b6d




