### PR TITLE
Consolidate old `TestModuleUtil#runTestDefault` code path into `runTestQueueScheduler`

### DIFF
--- a/example/scalalib/testing/5-test-grouping/build.mill
+++ b/example/scalalib/testing/5-test-grouping/build.mill
@@ -34,9 +34,7 @@ object foo extends ScalaModule {
 
 > find out/foo/test/testForked.dest
 ...
-out/foo/test/testForked.dest/foo.HelloTests.log
 out/foo/test/testForked.dest/foo.HelloTests/sandbox
-out/foo/test/testForked.dest/foo.WorldTests.log
 out/foo/test/testForked.dest/foo.WorldTests/sandbox
 out/foo/test/testForked.dest/test-report.xml
 

--- a/libs/javalib/src/mill/javalib/TestModuleUtil.scala
+++ b/libs/javalib/src/mill/javalib/TestModuleUtil.scala
@@ -320,7 +320,7 @@ final class TestModuleUtil(
               ) {
                 block
               }
-            }else Future.successful(block(ctx.log))
+            } else Future.successful(block(ctx.log))
           }
           fork {
             logger =>

--- a/libs/javalib/src/mill/javalib/TestModuleUtil.scala
+++ b/libs/javalib/src/mill/javalib/TestModuleUtil.scala
@@ -108,9 +108,6 @@ final class TestModuleUtil(
       }
     if (selectors.nonEmpty && filteredClassLists.isEmpty) throw doesNotMatchError
 
-    /** If we only have a single group with one test there is no point in running things in parallel. */
-    val parallelismIsUseless =
-      filteredClassLists.sizeIs == 1 && filteredClassLists.forall(_.sizeIs == 1)
     val result = runTestQueueScheduler(filteredClassLists)
 
     result match {

--- a/libs/javalib/src/mill/javalib/TestModuleUtil.scala
+++ b/libs/javalib/src/mill/javalib/TestModuleUtil.scala
@@ -109,11 +109,7 @@ final class TestModuleUtil(
     /** If we only have a single group with one test there is no point in running things in parallel. */
     val parallelismIsUseless =
       filteredClassLists.sizeIs == 1 && filteredClassLists.forall(_.sizeIs == 1)
-    val result = if (testParallelism && !parallelismIsUseless) {
-      runTestQueueScheduler(filteredClassLists)
-    } else {
-      runTestDefault(filteredClassLists)
-    }
+    val result = runTestQueueScheduler(filteredClassLists)
 
     result match {
       case Result.Failure(errMsg) => Result.Failure(errMsg)
@@ -181,86 +177,6 @@ final class TestModuleUtil(
       Result.Failure(s"Test reporting Failed: ${outputPath} does not exist")
     else
       Result.Success(upickle.default.read[(String, Seq[TestResult])](ujson.read(outputPath.toIO)))
-  }
-
-  private def runTestDefault(
-      filteredClassLists: Seq[Seq[String]]
-  )(implicit ctx: mill.api.TaskCtx) = {
-
-    def runTestRunnerSubprocess(
-        base: os.Path,
-        testClassList: Seq[String],
-        workerResultSet: java.util.concurrent.ConcurrentMap[os.Path, Unit]
-    ) = {
-      os.makeDir.all(base)
-
-      // test runner will log success/failure test class counter here while running
-      val resultPath = base / s"result.log"
-      os.write.over(resultPath, upickle.default.write((0L, 0L)))
-      workerResultSet.put(resultPath, ())
-
-      callTestRunnerSubprocess(
-        base,
-        resultPath,
-        Left(testClassList)
-      )
-    }
-
-    TestModuleUtil.withTestProgressTickerThread(filteredClassLists.map(_.size).sum) {
-      (_, workerResultSet) =>
-        filteredClassLists match {
-          // When no tests at all are discovered, run at least one test JVM
-          // process to go through the test framework setup/teardown logic
-          case Nil => runTestRunnerSubprocess(Task.dest, Nil, workerResultSet)
-          case Seq(singleTestClassList) =>
-            runTestRunnerSubprocess(Task.dest, singleTestClassList, workerResultSet)
-          case multipleTestClassLists =>
-            val maxLength = multipleTestClassLists.length.toString.length
-            val futures = multipleTestClassLists.zipWithIndex.map { case (testClassList, i) =>
-              val groupPromptMessage = testClassList match {
-                case Seq(single) => single
-                case multiple =>
-                  TestModuleUtil.collapseTestClassNames(
-                    multiple
-                  ).mkString(", ") + s", ${multiple.length} suites"
-              }
-
-              val paddedIndex = mill.api.internal.Util.leftPad(i.toString, maxLength, '0')
-              val folderName = testClassList match {
-                case Seq(single) => single
-                case multiple =>
-                  s"group-$paddedIndex-${multiple.head}"
-              }
-
-              // set priority = -1 to always prioritize test subprocesses over normal Mill
-              // tasks. This minimizes the number of blocked tasks since Mill tasks can be
-              // blocked on test subprocesses, but not vice versa, so better to schedule
-              // the test subprocesses first
-              Task.fork.async(
-                Task.dest / folderName,
-                paddedIndex,
-                groupPromptMessage,
-                priority = -1
-              ) {
-                _ =>
-                  (
-                    folderName,
-                    runTestRunnerSubprocess(Task.dest / folderName, testClassList, workerResultSet)
-                  )
-              }
-            }
-
-            val outputs = Task.fork.awaitAll(futures)
-
-            val (lefts, rights) = outputs.partitionMap {
-              case (name, Result.Failure(v)) => Left(name + " " + v)
-              case (name, Result.Success((msg, results))) => Right((name + " " + msg, results))
-            }
-
-            if (lefts.nonEmpty) Result.Failure(lefts.mkString("\n"))
-            else Result.Success((rights.map(_._1).mkString("\n"), rights.flatMap(_._2)))
-        }
-    }
   }
 
   private def runTestQueueScheduler(

--- a/libs/scalalib/test/src/mill/scalalib/TestRunnerScalatestTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/TestRunnerScalatestTests.scala
@@ -33,9 +33,12 @@ object TestRunnerScalatestTests extends TestSuite {
           Seq("mill.scalalib.ScalaTestSpec"),
           3, {
             val results = Set(
+              "claim",
+              "claim.log",
               "out.json",
               "result.log",
               "sandbox",
+              "test-classes",
               "test-report.xml",
               "testargs"
             )
@@ -56,9 +59,12 @@ object TestRunnerScalatestTests extends TestSuite {
           9,
           Map(
             testrunner.scalatest -> Set(
+              "claim",
+              "claim.log",
               "out.json",
               "result.log",
               "sandbox",
+              "test-classes",
               "test-report.xml",
               "testargs"
             ),
@@ -91,9 +97,12 @@ object TestRunnerScalatestTests extends TestSuite {
           3,
           Map(
             testrunner.scalatest -> Set(
+              "claim",
+              "claim.log",
               "out.json",
               "result.log",
               "sandbox",
+              "test-classes",
               "test-report.xml",
               "testargs"
             ),

--- a/libs/scalalib/test/src/mill/scalalib/TestRunnerUtestTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/TestRunnerUtestTests.scala
@@ -38,9 +38,12 @@ object TestRunnerUtestTests extends TestSuite {
           Seq("mill.scalalib.FooTests"),
           1, {
             val results = Set(
+              "claim",
+              "claim.log",
               "out.json",
               "result.log",
               "sandbox",
+              "test-classes",
               "test-report.xml",
               "testargs"
             )
@@ -59,9 +62,12 @@ object TestRunnerUtestTests extends TestSuite {
           2,
           Map(
             testrunner.utest -> Set(
+              "claim",
+              "claim.log",
               "out.json",
               "result.log",
               "sandbox",
+              "test-classes",
               "test-report.xml",
               "testargs"
             ),
@@ -81,9 +87,12 @@ object TestRunnerUtestTests extends TestSuite {
           3,
           Map(
             testrunner.utest -> Set(
+              "claim",
+              "claim.log",
               "out.json",
               "result.log",
               "sandbox",
+              "test-classes",
               "test-report.xml",
               "testargs"
             ),


### PR DESCRIPTION
We can consolidate the desired behavior into `runTestQueueScheduler` (e.g. avoiding parallelizing via `async`, avoiding the extra `worker-$n/` folder) to avoid duplication and make it easier to maintain and extend with new features (e.g. https://github.com/com-lihaoyi/mill/issues/5558). There's some minor overhead in maintaining the `claim`/`claim.log`/`test-classes` folders, but overall it's probably negligible