### PR TITLE
Hook individual test class timings into Mill Chrome Profiler

### DIFF
--- a/core/api/daemon/src/mill/api/daemon/Logger.scala
+++ b/core/api/daemon/src/mill/api/daemon/Logger.scala
@@ -161,6 +161,10 @@ object Logger {
 
     private[mill] def beginChromeProfileEntry(text: String): Unit
     private[mill] def endChromeProfileEntry(): Unit
+
+    private[mill] def logBeginChromeProfileEntry(message: String, timestamp: Long) = ()
+    private[mill] def logEndChromeProfileEntry(timestamp: Long) = ()
+
     def debugEnabled: Boolean
 
     private[mill] def enableTicker: Boolean

--- a/core/api/daemon/src/mill/api/daemon/Logger.scala
+++ b/core/api/daemon/src/mill/api/daemon/Logger.scala
@@ -72,7 +72,7 @@ trait Logger {
   private[mill] final def withPromptLine[T](t: => T): T = {
     prompt.setPromptLine(logKey, keySuffix, message)
     try t
-    finally prompt.removePromptLine(logKey)
+    finally prompt.removePromptLine(logKey, message)
   }
 
   /**
@@ -155,7 +155,7 @@ object Logger {
     private[mill] def setPromptLine(key: Seq[String], keySuffix: String, message: String): Unit
     private[mill] def setPromptHeaderPrefix(s: String): Unit
     private[mill] def clearPromptStatuses(): Unit
-    private[mill] def removePromptLine(key: Seq[String]): Unit
+    private[mill] def removePromptLine(key: Seq[String], message: String): Unit
     private[mill] def withPromptPaused[T](t: => T): T
     private[mill] def withPromptUnpaused[T](t: => T): T
 
@@ -182,7 +182,7 @@ object Logger {
         ()
       private[mill] def setPromptHeaderPrefix(s: String): Unit = ()
       private[mill] def clearPromptStatuses(): Unit = ()
-      private[mill] def removePromptLine(key: Seq[String]): Unit = ()
+      private[mill] def removePromptLine(key: Seq[String], message: String): Unit = ()
       private[mill] def withPromptPaused[T](t: => T): T = t
       private[mill] def withPromptUnpaused[T](t: => T): T = t
 

--- a/core/internal/src/mill/internal/MultiLogger.scala
+++ b/core/internal/src/mill/internal/MultiLogger.scala
@@ -65,9 +65,9 @@ private[mill] class MultiLogger(
       logger2.prompt.clearPromptStatuses()
     }
 
-    private[mill] override def removePromptLine(key: Seq[String]): Unit = {
-      logger1.prompt.removePromptLine(key)
-      logger2.prompt.removePromptLine(key)
+    private[mill] override def removePromptLine(key: Seq[String], message: String): Unit = {
+      logger1.prompt.removePromptLine(key, message)
+      logger2.prompt.removePromptLine(key, message)
     }
 
     private[mill] override def setPromptHeaderPrefix(s: String): Unit = {

--- a/core/internal/src/mill/internal/MultiLogger.scala
+++ b/core/internal/src/mill/internal/MultiLogger.scala
@@ -104,6 +104,16 @@ private[mill] class MultiLogger(
       logger1.prompt.endChromeProfileEntry()
       logger2.prompt.endChromeProfileEntry()
     }
+
+    override private[mill] def logBeginChromeProfileEntry(message: String, nanoTime: Long) = {
+      logger1.prompt.logBeginChromeProfileEntry(message, nanoTime)
+      logger2.prompt.logBeginChromeProfileEntry(message, nanoTime)
+    }
+
+    override private[mill] def logEndChromeProfileEntry(nanoTime: Long) = {
+      logger1.prompt.logEndChromeProfileEntry(nanoTime)
+      logger2.prompt.logEndChromeProfileEntry(nanoTime)
+    }
   }
   def debug(s: String): Unit = {
     logger1.debug(s)

--- a/core/internal/src/mill/internal/PromptLogger.scala
+++ b/core/internal/src/mill/internal/PromptLogger.scala
@@ -123,6 +123,22 @@ private[mill] class PromptLogger(
       )
     }
 
+    override private[mill] def logBeginChromeProfileEntry(message: String, nanoTime: Long) = {
+      chromeProfileLogger.logBegin(
+        message,
+        "job",
+        nanoTime / 1000,
+        threadNumberer.getThreadId(Thread.currentThread())
+      )
+    }
+
+    override private[mill] def logEndChromeProfileEntry(nanoTime: Long) = {
+      chromeProfileLogger.logEnd(
+        nanoTime / 1000,
+        threadNumberer.getThreadId(Thread.currentThread())
+      )
+    }
+
     val threadNumberer = new ThreadNumberer()
     override def setPromptHeaderPrefix(s: String): Unit = PromptLogger.this.synchronized {
       promptLineState.setHeaderPrefix(s)

--- a/core/internal/src/mill/internal/PromptLogger.scala
+++ b/core/internal/src/mill/internal/PromptLogger.scala
@@ -148,9 +148,9 @@ private[mill] class PromptLogger(
       promptLineState.clearStatuses()
     }
 
-    override def removePromptLine(key: Seq[String]): Unit = PromptLogger.this.synchronized {
+    override def removePromptLine(key: Seq[String], message: String): Unit = PromptLogger.this.synchronized {
       promptLineState.setCurrent(key, None)
-      endChromeProfileEntry()
+      if (message != "") endChromeProfileEntry()
     }
 
     override def setPromptDetail(key: Seq[String], s: String): Unit =
@@ -178,7 +178,7 @@ private[mill] class PromptLogger(
 
     override def setPromptLine(key: Seq[String], keySuffix: String, message: String): Unit =
       PromptLogger.this.synchronized {
-        beginChromeProfileEntry(message)
+        if (message != "") beginChromeProfileEntry(message)
         promptLineState.setCurrent(key, Some(s"[${key.mkString("-")}]${spaceNonEmpty(message)}"))
         seenIdentifiers(key) = (keySuffix, message)
       }

--- a/libs/javalib/src/mill/javalib/TestModuleUtil.scala
+++ b/libs/javalib/src/mill/javalib/TestModuleUtil.scala
@@ -343,7 +343,7 @@ final class TestModuleUtil(
               lines.drop(seenLines).collect{
                 case s"CLAIM $currentTestClass $nanoTime" =>
                   logger.prompt.logBeginChromeProfileEntry(currentTestClass, nanoTime.toLong)
-                case s"COMPLETE $nanoTime" =>
+                case s"COMPLETED $nanoTime" =>
                   logger.prompt.logEndChromeProfileEntry(nanoTime.toLong)
               }
               seenLines = lines.length

--- a/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunnerUtils.scala
+++ b/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunnerUtils.scala
@@ -311,13 +311,22 @@ import scala.math.Ordering.Implicits.*
       os.write.over(resultPath, upickle.default.write((successCounter, failureCounter)))
     }
 
+    def logClaim[T](testClass: String)(t: => T): T = {
+      val claimLog = claimFolder / os.up / "claim.log"
+      os.write.append(claimLog, s"CLAIM $testClass ${System.nanoTime()}\n")
+      try t
+      finally {
+        os.write.append(claimLog, s"COMPLETED ${System.nanoTime()}\n")
+      }
+    }
     startingTestClass.foreach { testClass =>
-      os.write.append(claimFolder / os.up / s"${claimFolder.last}.log", s"$testClass\n")
-      runClaimedTestClass(testClass)
+      logClaim(testClass){ runClaimedTestClass(testClass) }
     }
 
     for (file <- os.list(testClassQueueFolder)) {
-      for (claimedTestClass <- claimFile(file, claimFolder)) runClaimedTestClass(claimedTestClass)
+      for (claimedTestClass <- claimFile(file, claimFolder)) {
+        logClaim(claimedTestClass) { runClaimedTestClass(claimedTestClass) }
+      }
     }
 
     handleRunnerDone(runner, events)
@@ -328,10 +337,7 @@ import scala.math.Ordering.Implicits.*
       os.exists(file) &&
         scala.util.Try(os.move(file, claimFolder / file.last, atomicMove = true)).isSuccess
     ) {
-      // append only log, used to communicate with parent about what test is being claimed
-      // so that the parent can log the claimed test's name to its logger
-      val claimLog = claimFolder / os.up / s"${claimFolder.last}.log"
-      os.write.append(claimLog, s"${file.last}\n")
+
       file.last
     }
   }


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/5558


<img width="1227" height="283" alt="Screenshot 2025-08-01 at 8 55 22 AM" src="https://github.com/user-attachments/assets/1d7b52e0-d127-4152-b8f1-b137b49638ad" />

- Update `TestRunnerUtils.scala`'s writing to `claim.log` to contain both `CLAIM` and `COMPLETED` entries for each test class, along with the `System.nanoTime` for each one

- Update `TestModuleUtil.scala` to read the `CLAIM` and `COMPLETED` entries, ignore ones that have been seen before, and pass them to new `logBeginChromeProfileEntry` and `logEndChromeProfileEntry` entries on `PromptLogger`

- `logBeginChromeProfileEntry` and `logEndChromeProfileEntry` are basically the same as `beginChromeProfileEntry` and `endChromeProfileEntry`, except they take an explicit `nanoTime` so they can precisely log profile entries from earlier (e.g. things written to `claim.log` but only read from `claim.log` a few milliseconds later)