### PR TITLE
Flesh out `os.Checker` error messages to make them more actionable

### DIFF
--- a/core/api/src/mill/api/internal/ResolveChecker.scala
+++ b/core/api/src/mill/api/internal/ResolveChecker.scala
@@ -6,7 +6,7 @@ private[mill] class ResolveChecker(workspace: os.Path) extends os.Checker {
       case path: os.Path if mill.api.FilesystemCheckerEnabled.value =>
         sys.error(
           s"Reading from ${path.relativeTo(workspace)} not allowed during resolution phase.\n" +
-          "You may only read from files during resolution within a `BuildCtx.watchValue block."
+            "You may only read from files during resolution within a `BuildCtx.watchValue block."
         )
       case _ =>
     }

--- a/core/api/src/mill/api/internal/ResolveChecker.scala
+++ b/core/api/src/mill/api/internal/ResolveChecker.scala
@@ -4,7 +4,10 @@ private[mill] class ResolveChecker(workspace: os.Path) extends os.Checker {
   def onRead(path: os.ReadablePath): Unit = {
     path match {
       case path: os.Path if mill.api.FilesystemCheckerEnabled.value =>
-        sys.error(s"Reading from ${path.relativeTo(workspace)} not allowed during resolution phase")
+        sys.error(
+          s"Reading from ${path.relativeTo(workspace)} not allowed during resolution phase.\n" +
+          "You may only read from files during resolution within a `BuildCtx.watchValue block."
+        )
       case _ =>
     }
   }

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -539,7 +539,7 @@ private object GroupExecution {
             if (path.startsWith(workspace) && !validReadDests.exists(path.startsWith(_))) {
               sys.error(
                 s"Reading from ${path.relativeTo(workspace)} not allowed during execution of `$terminal`.\n" +
-                "You can only read files referenced by `Task.Source` or `Task.Sources`, or within a `Task.Input"
+                  "You can only read files referenced by `Task.Source` or `Task.Sources`, or within a `Task.Input"
               )
             }
           }
@@ -551,7 +551,7 @@ private object GroupExecution {
           if (path.startsWith(workspace) && !validWriteDests.exists(path.startsWith(_))) {
             sys.error(
               s"Writing to ${path.relativeTo(workspace)} not allowed during execution of `$terminal`.\n" +
-              "You can only write to files within your `Task.dest`, or to other files from a `Task.Command"
+                "You can only write to files within your `Task.dest`, or to other files from a `Task.Command"
             )
           }
         }

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -538,7 +538,8 @@ private object GroupExecution {
           if (!isCommand && !isInput && mill.api.FilesystemCheckerEnabled.value) {
             if (path.startsWith(workspace) && !validReadDests.exists(path.startsWith(_))) {
               sys.error(
-                s"Reading from ${path.relativeTo(workspace)} not allowed during execution of `$terminal`"
+                s"Reading from ${path.relativeTo(workspace)} not allowed during execution of `$terminal`.\n" +
+                "You can only read files referenced by `Task.Source` or `Task.Sources`, or within a `Task.Input"
               )
             }
           }
@@ -549,7 +550,8 @@ private object GroupExecution {
         if (!isCommand && mill.api.FilesystemCheckerEnabled.value) {
           if (path.startsWith(workspace) && !validWriteDests.exists(path.startsWith(_))) {
             sys.error(
-              s"Writing to ${path.relativeTo(workspace)} not allowed during execution of `$terminal`"
+              s"Writing to ${path.relativeTo(workspace)} not allowed during execution of `$terminal`.\n" +
+              "You can only write to files within your `Task.dest`, or to other files from a `Task.Command"
             )
           }
         }

--- a/example/depth/sandbox/1-task/build.mill
+++ b/example/depth/sandbox/1-task/build.mill
@@ -32,7 +32,7 @@ def bannedWriteTask = Task {
 
 /** Usage
 > ./mill bannedWriteTask
-error: ...Writing to banned-path not allowed during execution of `bannedWriteTask`
+error: ...Writing to banned-path not allowed during execution of `bannedWriteTask`.
 */
 
 def bannedReadTask = Task {
@@ -41,7 +41,7 @@ def bannedReadTask = Task {
 
 /** Usage
 > ./mill bannedReadTask
-error: ...Reading from build.mill not allowed during execution of `bannedReadTask`
+error: ...Reading from build.mill not allowed during execution of `bannedReadTask`.
 */
 
 def bannedReadTask2 = Task {
@@ -50,7 +50,7 @@ def bannedReadTask2 = Task {
 
 /** Usage
 > ./mill bannedReadTask2
-error: ...Reading from out/foo/tDestTask.json not allowed during execution of `bannedReadTask2`
+error: ...Reading from out/foo/tDestTask.json not allowed during execution of `bannedReadTask2`.
 */
 
 // Furthermore, code _outside_ of a task that runs during module initialization can only


### PR DESCRIPTION
Rather than just saying what is not allowed, we should suggest what the user does instead