### PR TITLE
tab-complete flags like `-j` or `--jobs`, and forward non-task tab completion to bash

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -136,7 +136,7 @@ jobs:
             millargs: "'{contrib,core,testkit,runner,dist}.__.test'"
 
           - java-version: 17
-            millargs: "'libs.{scalalib,init}.__.test'"
+            millargs: "'libs.{scalalib,init,tabcomplete}.__.test'"
             install-sbt: true
 
           - java-version: 11
@@ -208,7 +208,7 @@ jobs:
             millargs: '"example.migrating.javalib.__.packaged.daemon"'
 
           - java-version: 11
-            millargs: '"libs.{util,javalib,androidlib,graphviz,tabcomplete}.__.test"'
+            millargs: '"libs.{util,javalib,androidlib,graphviz}.__.test"'
 
           - java-version: 17
             millargs: '"example.scalalib.{basic,publishing}.__.packaged.daemon"'

--- a/build.mill
+++ b/build.mill
@@ -1,4 +1,4 @@
-//| mill-version: 1.0.2
+//| mill-version: 1.0.2-21-dd0b03
 //| mill-jvm-opts: ["-XX:NonProfiledCodeHeapSize=250m", "-XX:ReservedCodeCacheSize=500m"]
 //| mill-opts: ["--jobs=0.5C"]
 

--- a/build.mill
+++ b/build.mill
@@ -1,4 +1,4 @@
-//| mill-version: 1.0.2-21-dd0b03
+//| mill-version: 1.0.2
 //| mill-jvm-opts: ["-XX:NonProfiledCodeHeapSize=250m", "-XX:ReservedCodeCacheSize=500m"]
 //| mill-opts: ["--jobs=0.5C"]
 

--- a/core/internal/src/mill/internal/MillCliConfig.scala
+++ b/core/internal/src/mill/internal/MillCliConfig.scala
@@ -1,4 +1,4 @@
-package mill.daemon
+package mill.internal
 
 import mainargs.{Flag, Leftover, arg}
 
@@ -189,9 +189,7 @@ task cheat sheet:
 options:
 """
 
-  import mill.api.JsonFormatters.*
-
-  private lazy val parser: ParserForClass[MillCliConfig] = mainargs.ParserForClass[MillCliConfig]
+  lazy val parser: ParserForClass[MillCliConfig] = mainargs.ParserForClass[MillCliConfig]
 
   private lazy val helpAdvancedParser: ParserForClass[MillCliConfig] = new ParserForClass(
     parser.main.copy(argSigs0 = parser.main.argSigs0.collect {

--- a/core/internal/src/mill/internal/MillCliConfig.scala
+++ b/core/internal/src/mill/internal/MillCliConfig.scala
@@ -1,6 +1,7 @@
 package mill.internal
 
 import mainargs.{Flag, Leftover, arg}
+import mill.api.JsonFormatters.*
 
 case class MillCliConfig(
     // ==================== NORMAL CLI FLAGS ====================

--- a/libs/tabcomplete/package.mill
+++ b/libs/tabcomplete/package.mill
@@ -8,5 +8,5 @@ import millbuild.*
  * script that runs in both shells
  */
 object `package` extends MillPublishScalaModule {
-  def moduleDeps = Seq(build.core.api, build.libs.util)
+  def moduleDeps = Seq(build.core.api, build.libs.util, build.core.internal)
 }

--- a/libs/tabcomplete/src/mill/tabcomplete/TabCompleteModule.scala
+++ b/libs/tabcomplete/src/mill/tabcomplete/TabCompleteModule.scala
@@ -54,7 +54,7 @@ private[this] object TabCompleteModule extends ExternalModule {
             // Complete long flags by looking at prefixes
             case Some(s"--$flag") =>
               MillCliConfig.parser.main.argSigs0
-                .flatMap(_.mappedName(mainargs.Util.kebabCaseNameMapper))
+                .flatMap(_.longName(mainargs.Util.kebabCaseNameMapper))
                 .filter(_.startsWith(flag))
                 .map("--" + _)
                 .foreach(println)
@@ -75,17 +75,13 @@ private[this] object TabCompleteModule extends ExternalModule {
   }
 
   def delegateToBash(args: mainargs.Leftover[String], index: Int) = {
-    mill.constants.DebugLog.println("delegateToBash " + os.pwd)
     val res = os.call((
         "bash",
         "-c",
         "compgen -f -- " + args.value.lift(index).map(pprint.Util.literalize(_)).getOrElse("\"\"")
       ), check = false)
 
-
-    mill.constants.DebugLog.println("delegateToBash " + pprint.apply(res))
-    res.out
-      .lines().foreach(println)
+    res.out.lines().foreach(println)
   }
 
 

--- a/libs/tabcomplete/src/mill/tabcomplete/TabCompleteModule.scala
+++ b/libs/tabcomplete/src/mill/tabcomplete/TabCompleteModule.scala
@@ -142,7 +142,7 @@ private[this] object TabCompleteModule extends ExternalModule {
         val homeDest = ".cache/mill/download/mill-completion.sh"
 
         writeLoudly(os.home / os.SubPath(homeDest), script)
-        for (fileName <- Seq(".bash_profile", ".zshrc")) {
+        for (fileName <- Seq(".bash_profile", ".zshrc", ".bashrc")) {
           val file = os.home / fileName
           // We use the marker comment to help remove any previous `source` line before
           // adding a new line, so that running `install` over and over doesn't build up

--- a/libs/tabcomplete/src/mill/tabcomplete/TabCompleteModule.scala
+++ b/libs/tabcomplete/src/mill/tabcomplete/TabCompleteModule.scala
@@ -14,7 +14,6 @@ private[this] object TabCompleteModule extends ExternalModule {
 
   lazy val millDiscover = Discover[this.type]
 
-
   /**
    * The main entrypoint for Mill's Bash and Zsh tab-completion logic
    */
@@ -30,7 +29,7 @@ private[this] object TabCompleteModule extends ExternalModule {
       // - `missing` should be empty since all Mill flags have defaults
       // - `duplicate` should be empty since we use `allowRepeats = true`
       // - `unknown` should be empty since unknown tokens end up in `leftoverArgs`
-      case mainargs.Result.Failure.MismatchedArguments(Nil, unknown, Nil, Some(incomplete)) =>
+      case mainargs.Result.Failure.MismatchedArguments(Nil, unknown, Nil, Some(_)) =>
         // In this case, we cannot really identify any tokens in the argument list
         // which are task selectors, since the last flag is incomplete and prior
         // flags are all completed. So just delegate to bash completion
@@ -50,7 +49,7 @@ private[this] object TabCompleteModule extends ExternalModule {
         else if (index < parsedArgCount) delegateToBash(args, index)
         // This is the task I need to autocomplete, or the next incomplete flag
         else if (index == parsedArgCount) {
-          args.value.lift(index) match{
+          args.value.lift(index) match {
             // Complete long flags by looking at prefixes
             case Some(s"--$flag") =>
               MillCliConfig.parser.main.argSigs0
@@ -71,19 +70,20 @@ private[this] object TabCompleteModule extends ExternalModule {
         } else ???
     }
 
-
   }
 
   def delegateToBash(args: mainargs.Leftover[String], index: Int) = {
-    val res = os.call((
+    val res = os.call(
+      (
         "bash",
         "-c",
         "compgen -f -- " + args.value.lift(index).map(pprint.Util.literalize(_)).getOrElse("\"\"")
-      ), check = false)
+      ),
+      check = false
+    )
 
     res.out.lines().foreach(println)
   }
-
 
   def completeTasks(ev: Evaluator, index: Int, args: Seq[String]) = {
 

--- a/libs/tabcomplete/test/src/mill/tabcomplete/TabCompleteTests.scala
+++ b/libs/tabcomplete/test/src/mill/tabcomplete/TabCompleteTests.scala
@@ -39,189 +39,198 @@ object TabCompleteTests extends TestSuite {
         os.write(tester.evaluator.workspace / "file2.txt", "")
         tester.evaluator.evaluate(Seq("mill.tabcomplete.TabCompleteModule/complete") ++ s).get
       }
-      outStream.toString.linesIterator.toSeq
+      outStream.toString.linesIterator.toSet
     }
 
     test("empty-bash") {
       assertGoldenLiteral(
         evalComplete("1", "./mill", ""),
-        List("bar", "foo", "qux", "task1")
+        Set("bar", "foo", "qux", "task1")
       )
     }
     test("empty-zsh") {
       assertGoldenLiteral(
         evalComplete("1", "./mill"),
-        List("bar", "foo", "qux", "task1")
+        Set("bar", "foo", "qux", "task1")
       )
     }
     test("task") {
       assertGoldenLiteral(
         evalComplete("1", "./mill", "t"),
-        List("task1")
+        Set("task1")
       )
     }
     test("firstTask") {
       assertGoldenLiteral(
         evalComplete("1", "./mill", "t", "bar.task2"),
-        List("task1")
+        Set("task1")
       )
     }
 
     test("secondNonTask") {
       assertGoldenLiteral(
         evalComplete("2", "./mill", "bar.task2", "f"),
-        List("file2.txt", "file1.txt")
+        Set("file2.txt", "file1.txt")
       )
     }
     test("secondNonTaskEmpty") {
       assertGoldenLiteral(
         evalComplete("2", "./mill", "bar.task2", ""),
-        List("file2.txt", "file1.txt", "out")
+        Set("file2.txt", "file1.txt", "out")
       )
     }
 
     test("module") {
       assertGoldenLiteral(
         evalComplete("1", "./mill", "fo"),
-        List("foo")
+        Set("foo")
       )
     }
 
     test("exactModule") {
       assertGoldenLiteral(
         evalComplete("1", "./mill", "bar"),
-        List("bar", "bar.task2")
+        Set("bar", "bar.task2")
       )
     }
 
     test("nested") {
       assertGoldenLiteral(
         evalComplete("1", "./mill", "bar."),
-        List("bar.task2")
+        Set("bar.task2")
       )
     }
 
     test("cross") {
       assertGoldenLiteral(
         evalComplete("1", "./mill", "qux["),
-        List("qux[12]", "qux[34]", "qux[56]")
+        Set("qux[12]", "qux[34]", "qux[56]")
       )
     }
 
     test("cross2") {
       assertGoldenLiteral(
         evalComplete("1", "./mill", "qux"),
-        List("qux", "qux[12]", "qux[34]", "qux[56]")
+        Set("qux", "qux[12]", "qux[34]", "qux[56]")
       )
     }
 
     test("crossPartial") {
       assertGoldenLiteral(
         evalComplete("1", "./mill", "qux[1"),
-        List("qux[12]")
+        Set("qux[12]")
       )
     }
 
     test("crossNested") {
       assertGoldenLiteral(
         evalComplete("1", "./mill", "qux[12]"),
-        List("qux[12].task3")
+        Set("qux[12].task3")
       )
     }
 
     test("crossNestedSlashed") {
       assertGoldenLiteral(
         evalComplete("1", "./mill", "qux\\[12\\]"),
-        List("qux[12].task3")
+        Set("qux[12].task3")
       )
     }
     test("crossNestedSingleQuoted") {
       assertGoldenLiteral(
         evalComplete("1", "./mill", "'qux[12]"),
-        List("qux[12].task3")
+        Set("qux[12].task3")
       )
     }
     test("crossNestedDoubleQuoted") {
       assertGoldenLiteral(
         evalComplete("1", "./mill", "\"qux[12]"),
-        List("qux[12].task3")
+        Set("qux[12].task3")
       )
     }
 
     test("crossComplete") {
       assertGoldenLiteral(
         evalComplete("1", "./mill", "qux[12].task3"),
-        List("qux[12].task3")
+        Set("qux[12].task3")
       )
 
     }
     test("shortflags") {
       assertGoldenLiteral(
         evalComplete("1", "./mill", "-"),
-        List("-v", "-b", "-d", "-k", "-D", "-j", "-i", "-w", "-h", "-s")
+        Set("-v", "-b", "-d", "-k", "-D", "-j", "-i", "-w", "-h", "-s")
       )
     }
     test("emptyAfterFlag") {
       assertGoldenLiteral(
         evalComplete("2", "./mill", "-v"),
-        List("bar", "foo", "qux", "task1")
+        Set("bar", "foo", "qux", "task1")
       )
 
     }
     test("filterAfterFlag") {
       assertGoldenLiteral(
         evalComplete("2", "./mill", "-v", "f"),
-        List("foo")
+        Set("foo")
       )
     }
     test("filterAfterFlagAfterTask") {
       assertGoldenLiteral(
         evalComplete("3", "./mill", "-v", "task1", "f"),
-        Seq("file2.txt", "file1.txt")
+        Set("file2.txt", "file1.txt")
       )
     }
     test("longflags") {
       assertGoldenLiteral(
         evalComplete("1", "./mill", "--"),
-        List(
-          "--no-daemon",
-          "--ticker",
-          "--keep-going",
-          "--interactive",
-          "--help",
-          "--help-advanced",
+        Set(
+          "--jobs",
           "--watch",
-          "--color",
-          "--meta-level",
-          "--allow-positional",
-          "--bsp",
-          "--bsp-install",
-          "--bsp-watch",
           "--no-build-lock",
-          "--no-wait-for-build-lock",
-          "--offline",
-          "--no-filesystem-checker",
-          "--tab-complete",
-          "--home",
+          "--interactive",
           "--repl",
-          "--no-server",
-          "--silent",
+          "--home",
+          "--no-wait-for-build-lock",
+          "--help",
+          "--color",
+          "--help-advanced",
+          "--tab-complete",
+          "--disable-ticker",
+          "--offline",
+          "--allow-positional",
+          "--ticker",
           "--disable-prompt",
+          "--no-server",
           "--enable-ticker",
-          "--disable-ticker"
+          "--no-filesystem-checker",
+          "--disable-callgraph",
+          "--keep-going",
+          "--bsp",
+          "--meta-level",
+          "--version",
+          "--no-daemon",
+          "--import",
+          "--bsp-install",
+          "--task",
+          "--notify-watch",
+          "--bsp-watch",
+          "--define",
+          "--bell",
+          "--silent",
+          "--debug"
         )
       )
     }
     test("longflagsfiltered") {
       assertGoldenLiteral(
         evalComplete("1", "./mill", "--h"),
-        List("--help", "--help-advanced", "--home")
+        Set("--help", "--help-advanced", "--home")
       )
     }
     test("longFlagBrokenEarlier") {
       assertGoldenLiteral(
         evalComplete("1", "./mill", "--jo", "1", "task1"),
-        List("--jobs")
+        Set("--jobs")
       )
     }
   }

--- a/libs/tabcomplete/test/src/mill/tabcomplete/TabCompleteTests.scala
+++ b/libs/tabcomplete/test/src/mill/tabcomplete/TabCompleteTests.scala
@@ -2,7 +2,6 @@ package mill.tabcomplete
 
 import mill.Task
 import mill.api.{Cross, Discover, Module}
-import mill.internal.MillCliConfig
 import mill.testkit.UnitTester
 import mill.testkit.TestRootModule
 import utest.*
@@ -43,145 +42,145 @@ object TabCompleteTests extends TestSuite {
       outStream.toString.linesIterator.toSeq
     }
 
-    test("empty-bash") - {
+    test("empty-bash") {
       assertGoldenLiteral(
         evalComplete("1", "./mill", ""),
         List("bar", "foo", "qux", "task1")
       )
     }
-    test("empty-zsh") - {
+    test("empty-zsh") {
       assertGoldenLiteral(
         evalComplete("1", "./mill"),
         List("bar", "foo", "qux", "task1")
       )
     }
-    test("task") - {
+    test("task") {
       assertGoldenLiteral(
         evalComplete("1", "./mill", "t"),
         List("task1")
       )
     }
-    test("firstTask") - {
+    test("firstTask") {
       assertGoldenLiteral(
         evalComplete("1", "./mill", "t", "bar.task2"),
         List("task1")
       )
     }
 
-    test("secondNonTask") - {
+    test("secondNonTask") {
       assertGoldenLiteral(
         evalComplete("2", "./mill", "bar.task2", "f"),
         List("file2.txt", "file1.txt")
       )
     }
-    test("secondNonTaskEmpty") - {
+    test("secondNonTaskEmpty") {
       assertGoldenLiteral(
         evalComplete("2", "./mill", "bar.task2", ""),
         List("file2.txt", "file1.txt", "out")
       )
     }
 
-    test("module") - {
+    test("module") {
       assertGoldenLiteral(
         evalComplete("1", "./mill", "fo"),
         List("foo")
       )
     }
 
-    test("exactModule") - {
+    test("exactModule") {
       assertGoldenLiteral(
         evalComplete("1", "./mill", "bar"),
         List("bar", "bar.task2")
       )
     }
 
-    test("nested") - {
+    test("nested") {
       assertGoldenLiteral(
         evalComplete("1", "./mill", "bar."),
         List("bar.task2")
       )
     }
 
-    test("cross") - {
+    test("cross") {
       assertGoldenLiteral(
         evalComplete("1", "./mill", "qux["),
         List("qux[12]", "qux[34]", "qux[56]")
       )
     }
 
-    test("cross2") - {
+    test("cross2") {
       assertGoldenLiteral(
         evalComplete("1", "./mill", "qux"),
         List("qux", "qux[12]", "qux[34]", "qux[56]")
       )
     }
 
-    test("crossPartial") - {
+    test("crossPartial") {
       assertGoldenLiteral(
         evalComplete("1", "./mill", "qux[1"),
         List("qux[12]")
       )
     }
 
-    test("crossNested") - {
+    test("crossNested") {
       assertGoldenLiteral(
         evalComplete("1", "./mill", "qux[12]"),
         List("qux[12].task3")
       )
     }
 
-    test("crossNestedSlashed") - {
+    test("crossNestedSlashed") {
       assertGoldenLiteral(
         evalComplete("1", "./mill", "qux\\[12\\]"),
         List("qux[12].task3")
       )
     }
-    test("crossNestedSingleQuoted") - {
+    test("crossNestedSingleQuoted") {
       assertGoldenLiteral(
         evalComplete("1", "./mill", "'qux[12]"),
         List("qux[12].task3")
       )
     }
-    test("crossNestedDoubleQuoted") - {
+    test("crossNestedDoubleQuoted") {
       assertGoldenLiteral(
         evalComplete("1", "./mill", "\"qux[12]"),
         List("qux[12].task3")
       )
     }
 
-    test("crossComplete") - {
+    test("crossComplete") {
       assertGoldenLiteral(
         evalComplete("1", "./mill", "qux[12].task3"),
         List("qux[12].task3")
       )
 
     }
-    test("shortflags") - {
+    test("shortflags") {
       assertGoldenLiteral(
         evalComplete("1", "./mill", "-"),
         List("-v", "-b", "-d", "-k", "-D", "-j", "-i", "-w", "-h", "-s")
       )
     }
-    test("emptyAfterFlag") - {
+    test("emptyAfterFlag") {
       assertGoldenLiteral(
         evalComplete("2", "./mill", "-v"),
         List("bar", "foo", "qux", "task1")
       )
 
     }
-    test("filterAfterFlag") - {
+    test("filterAfterFlag") {
       assertGoldenLiteral(
         evalComplete("2", "./mill", "-v", "f"),
         List("foo")
       )
     }
-    test("filterAfterFlagAfterTask") - {
+    test("filterAfterFlagAfterTask") {
       assertGoldenLiteral(
         evalComplete("3", "./mill", "-v", "task1", "f"),
         Seq("file2.txt", "file1.txt")
       )
     }
-    test("longflags") - {
+    test("longflags") {
       assertGoldenLiteral(
         evalComplete("1", "./mill", "--"),
         List(
@@ -213,10 +212,16 @@ object TabCompleteTests extends TestSuite {
         )
       )
     }
-    test("longflagsfiltered") - {
+    test("longflagsfiltered") {
       assertGoldenLiteral(
         evalComplete("1", "./mill", "--h"),
         List("--help", "--help-advanced", "--home")
+      )
+    }
+    test("longFlagBrokenEarlier") {
+      assertGoldenLiteral(
+        evalComplete("1", "./mill", "--jo", "1", "task1"),
+        List("--jobs")
       )
     }
   }

--- a/runner/daemon/src/mill/daemon/MillMain0.scala
+++ b/runner/daemon/src/mill/daemon/MillMain0.scala
@@ -14,7 +14,8 @@ import mill.internal.{
   MultiStream,
   PrefixLogger,
   PromptLogger,
-  SimpleLogger
+  SimpleLogger,
+  MillCliConfig
 }
 import mill.server.Server
 import mill.util.BuildInfo


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/5300

- Only use `resolve` to tab-complete the task selector being run - the first token in `leftoverArgs` - and not tokens before or after
- If the first token in `leftoverArgs` begins with `-` or `--`, it's actually a not-yet-fully-typed flag so autocomplete using the list of short or long flags
- If the autocomplete is on anything else, it's probably not a task or a flag, so delegate to the default bash completion list using `bash -c "compgen -f -- "`. This should work in both bash and zsh since we're just using bash to give us a list to print

Moved `mill.daemon.MillCliConfig` to `mill.internal` so `mill.tabcomplete` can use it. It's all still private so it shouldn't affect anything

Covered with additional unit tests, also tested locally using `dist.installLocalCache` in zsh and bash