### PR TITLE
More tweaks to tab-completion logic

### DIFF
--- a/libs/tabcomplete/src/mill/tabcomplete/TabCompleteModule.scala
+++ b/libs/tabcomplete/src/mill/tabcomplete/TabCompleteModule.scala
@@ -62,7 +62,8 @@ private[this] object TabCompleteModule extends ExternalModule {
                   .resolveEntrypoint(t.ctx.enclosingCls, t.ctx.segments.last.value)
               }
               for (ep <- entryPoints.headOption) {
-                val taskArgs = v.remaining.drop(index - 1)
+                val taskArgs = v.remaining.drop(1)
+                val taskArgsIndex = index - parsedArgCount - 1
 
                 val grouped2 = mainargs.TokenGrouping.groupArgs(
                   taskArgs,
@@ -75,8 +76,8 @@ private[this] object TabCompleteModule extends ExternalModule {
 
                 def handleRemaining(remaining: Seq[String]) = {
                   val commandParsedArgCount = v.remaining.length - remaining.length - 1
-                  if (index - parsedArgCount - 1 == commandParsedArgCount) {
-                    findMatchingArgs(remaining.headOption, ep.flattenedArgSigs.map(_._1))
+                  if (taskArgsIndex == commandParsedArgCount) {
+                    findMatchingArgs(remaining.lift(taskArgsIndex), ep.flattenedArgSigs.map(_._1))
                       .getOrElse(delegateToBash(args, index))
                   } else delegateToBash(args, index)
                 }

--- a/libs/tabcomplete/src/mill/tabcomplete/TabCompleteModule.scala
+++ b/libs/tabcomplete/src/mill/tabcomplete/TabCompleteModule.scala
@@ -22,9 +22,11 @@ private[this] object TabCompleteModule extends ExternalModule {
       @arg(positional = true) index: Int,
       args: mainargs.Leftover[String]
   ) = Task.Command(exclusive = true)[Unit] {
-    def group(tokens: Seq[String],
-              flattenedArgSigs: Seq[(ArgSig, TokensReader.Terminal[_])],
-              allowLeftover: Boolean) = {
+    def group(
+        tokens: Seq[String],
+        flattenedArgSigs: Seq[(ArgSig, TokensReader.Terminal[_])],
+        allowLeftover: Boolean
+    ) = {
       mainargs.TokenGrouping.groupArgs(
         tokens,
         flattenedArgSigs,

--- a/libs/tabcomplete/test/src/mill/tabcomplete/TabCompleteTests.scala
+++ b/libs/tabcomplete/test/src/mill/tabcomplete/TabCompleteTests.scala
@@ -16,7 +16,10 @@ object TabCompleteTests extends TestSuite {
     object foo extends Module
     object bar extends Module {
       def task2(argA3: String, argB4: Int) = Task.Command { 456 }
-      def taskPositional(@mainargs.arg(positional = true) argA3: String, @mainargs.arg(positional = true) argB4: Int) = Task.Command { 456 }
+      def taskPositional(
+          @mainargs.arg(positional = true) argA3: String,
+          @mainargs.arg(positional = true) argB4: Int
+      ) = Task.Command { 456 }
 
     }
     object qux extends Cross[QuxModule](12, 34, 56)


### PR DESCRIPTION
- Skip positional params
- Consolidate `Success` and `MismatchedArguments` logic when handling command parameters
- When handling failed parses of command params, use the index location when determining autocomplete, not the token at which the parse failed

Tested via additional unit tests