### PR TITLE
Disable git gpg signing in automated tests

### DIFF
--- a/libs/scalalib/test/src/mill/scalalib/spotless/SpotlessTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/spotless/SpotlessTests.scala
@@ -129,7 +129,7 @@ object SpotlessTests extends TestSuite {
 
         call("git", "init", "-b", "ratchet")
         call("git", "add", ".gitignore", legacy)
-        call("git", "commit", "-m", "0") // minimum 1 commit required
+        call("git", "commit", "-c", "commit.gpgsign=false", "-m", "0") // minimum 1 commit required
 
         val Right(_) = eval("ratchet")
         var log = logStream.toString
@@ -157,7 +157,7 @@ object SpotlessTests extends TestSuite {
         )
 
         call("git", "add", "--all") // re-stage formatted files
-        call("git", "commit", "-m", "1")
+        call("git", "commit", "-c", "commit.gpgsign=false", "-m", "1")
         logStream.reset()
         val Right(_) = eval("ratchet", "HEAD^", "HEAD")
         log = logStream.toString

--- a/libs/scalalib/test/src/mill/scalalib/spotless/SpotlessTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/spotless/SpotlessTests.scala
@@ -128,8 +128,9 @@ object SpotlessTests extends TestSuite {
         val legacyRef0 = PathRef(legacy)
 
         call("git", "init", "-b", "ratchet")
+        call("git", "config", "set", "--local", "commit.gpgsign", "false")
         call("git", "add", ".gitignore", legacy)
-        call("git", "commit", "-c", "commit.gpgsign=false", "-m", "0") // minimum 1 commit required
+        call("git", "commit", "-m", "0") // minimum 1 commit required
 
         val Right(_) = eval("ratchet")
         var log = logStream.toString
@@ -157,7 +158,7 @@ object SpotlessTests extends TestSuite {
         )
 
         call("git", "add", "--all") // re-stage formatted files
-        call("git", "commit", "-c", "commit.gpgsign=false", "-m", "1")
+        call("git", "commit", "-m", "1")
         logStream.reset()
         val Right(_) = eval("ratchet", "HEAD^", "HEAD")
         log = logStream.toString


### PR DESCRIPTION
This fixes the local issue on my machine that some tests hang if the gpg agent has currently no unlocked key to use.

