### PR TITLE
Add completion descriptions to bash tab completion

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1,4 +1,4 @@
-//| mill-version: 1.0.2-28-601f8c
+//| mill-version: 1.0.2-19-fe3d72
 //| mill-jvm-opts: ["-XX:NonProfiledCodeHeapSize=250m", "-XX:ReservedCodeCacheSize=500m"]
 //| mill-opts: ["--jobs=0.5C"]
 

--- a/build.mill
+++ b/build.mill
@@ -1,4 +1,4 @@
-//| mill-version: 1.0.2-19-fe3d72
+//| mill-version: 1.0.2-28-601f8c
 //| mill-jvm-opts: ["-XX:NonProfiledCodeHeapSize=250m", "-XX:ReservedCodeCacheSize=500m"]
 //| mill-opts: ["--jobs=0.5C"]
 

--- a/libs/tabcomplete/resources/mill/tabcomplete/complete.sh
+++ b/libs/tabcomplete/resources/mill/tabcomplete/complete.sh
@@ -1,31 +1,43 @@
+_mill_trim_line() {
+  local line="$1"
+  local ellipsis="..."
+
+  if (( ${#line} > COLUMNS )); then
+    echo "${line:0:$(( COLUMNS - ${#ellipsis} ))}${ellipsis}"
+  else
+    echo "$line"
+  fi
+}
+
 _mill_bash() {
-  # compopt makes bash not insert a newline after each completion, which
-  # is what we want for modules. Only works for bash 4+
   compopt -o nospace 2>/dev/null
-  COMPREPLY=( $(${COMP_WORDS[0]} --tab-complete "$COMP_CWORD" "${COMP_WORDS[@]}") )
+  local IFS=$'\n'
+
+  # in bash, keep $COLUMNS up-to-date; in zsh it’s automatic
+  shopt -s checkwinsize 2>/dev/null
+
+  # grab raw, newline-split completions
+  local raw=( $("${COMP_WORDS[0]}" --tab-complete "$COMP_CWORD" "${COMP_WORDS[@]}") )
+  local trimmed=()
+
+  # trim each one
+  for line in "${raw[@]}"; do
+    trimmed+=( "$(_mill_trim_line "$line")" )
+  done
+
+  COMPREPLY=( "${trimmed[@]}" )
 }
 
 _mill_zsh() {
-  # `-S` to avoid the trailing space after a completion, since it is
-  # common that the user will want to put a `.` and continue typing
-  #
-  # zsh $CURRENT is 1-indexed while bash $COMP_CWORD is 0-indexed, so
-  # subtract 1 from zsh's variable so Mill gets a consistent index
-  local -a descs opts expl
-  descs=("${(f)$($words[1] --tab-complete "$((CURRENT - 1))" --is-zsh $words)}")
-  for d in $descs; do
-    opts+=("${d%% *}")      # before the space
-    if (( ${#d} > COLUMNS )); then
-      # leave room for “…” (3 chars)
-      expl+=("${d:0:$((COLUMNS-3))}...")
-    else
-      expl+=("$d")
-    fi
+  local -a raw opts trimmed
+  raw=("${(f)$($words[1] --tab-complete "$((CURRENT - 1))" $words)}")
 
+  for d in $raw; do
+    opts+=( "${d%% *}" )             # value
+    trimmed+=( "$(_mill_trim_line "$d")" )  # trimmed “value description…”
   done
 
-  # -S '' = no suffix; -d expl = descriptions array
-  compadd -S '' -d expl -- $opts
+  compadd -S '' -d trimmed -- $opts
 }
 
 if [ -n "${ZSH_VERSION:-}" ]; then

--- a/libs/tabcomplete/src/mill/tabcomplete/TabCompleteModule.scala
+++ b/libs/tabcomplete/src/mill/tabcomplete/TabCompleteModule.scala
@@ -120,7 +120,7 @@ private[this] object TabCompleteModule extends ExternalModule {
         // inserting the description at the point of completion
         //
         // https://stackoverflow.com/a/10130007/871202
-        if (outputs.length == 1) prefix
+        if (outputs.length == 1 || suffix.isEmpty) prefix
         else s"$prefix${" " * (offset - prefix.length)}$suffix"
 
       case s => s

--- a/libs/tabcomplete/src/mill/tabcomplete/TabCompleteModule.scala
+++ b/libs/tabcomplete/src/mill/tabcomplete/TabCompleteModule.scala
@@ -136,9 +136,12 @@ private[this] object TabCompleteModule extends ExternalModule {
 
   def findMatchingArgs(
       stringOpt: Option[String],
-      argSigs: Seq[mainargs.ArgSig],
+      argSigs: Seq[mainargs.ArgSig]
   ): Option[Seq[(String, String)]] = {
-    def findMatchArgs0(prefix: String, nameField: ArgSig => Option[String]): Option[Seq[(String, String)]] = {
+    def findMatchArgs0(
+        prefix: String,
+        nameField: ArgSig => Option[String]
+    ): Option[Seq[(String, String)]] = {
       val res = for (arg <- argSigs if !arg.positional) yield {
         if (
           stringOpt.exists(_.startsWith(prefix)) &&

--- a/libs/tabcomplete/src/mill/tabcomplete/TabCompleteModule.scala
+++ b/libs/tabcomplete/src/mill/tabcomplete/TabCompleteModule.scala
@@ -115,7 +115,7 @@ private[this] object TabCompleteModule extends ExternalModule {
     val prefixes = outputs.map(_._1)
     val offset = prefixes.map(_.length).maxOption.getOrElse(0) + 2
 
-    val res = outputs match{
+    val res = outputs match {
       // When there is only one output and it has a description, trim off the description
       // and include it as a second output. This ensures that shells like Bash won't
       // insert the description at the prompt, since Bash doesn't have the ability to trim
@@ -125,7 +125,7 @@ private[this] object TabCompleteModule extends ExternalModule {
       // https://stackoverflow.com/a/10130007/871202
       case Seq((prefix, suffix)) if suffix.nonEmpty => Seq(prefix, prefix + ",  " + suffix)
       case _ =>
-        for((prefix, suffix) <- outputs) yield{
+        for ((prefix, suffix) <- outputs) yield {
           if (suffix.isEmpty) prefix
           else s"$prefix${" " * (offset - prefix.length)}$suffix"
         }

--- a/libs/tabcomplete/src/mill/tabcomplete/TabCompleteModule.scala
+++ b/libs/tabcomplete/src/mill/tabcomplete/TabCompleteModule.scala
@@ -115,6 +115,11 @@ private[this] object TabCompleteModule extends ExternalModule {
 
     val res = outputs.map {
       case s"$prefix:$suffix" =>
+        // When there is only one output, trim off the description, since Bash doesn't
+        // have the ability to trim them off automatically and we need to stop it from
+        // inserting the description at the point of completion
+        //
+        // https://stackoverflow.com/a/10130007/871202
         if (outputs.length == 1) prefix
         else s"$prefix${" " * (offset - prefix.length)}$suffix"
 

--- a/libs/tabcomplete/test/src/mill/tabcomplete/TabCompleteTests.scala
+++ b/libs/tabcomplete/test/src/mill/tabcomplete/TabCompleteTests.scala
@@ -244,19 +244,28 @@ object TabCompleteTests extends TestSuite {
       test("longFlagBrokenEarlier") {
         assertGoldenLiteral(
           evalComplete("1", "./mill", "--jo", "1", "task1"),
-          Set("--jobs", "--jobs,  <str> The number of parallel threads. It can be an integer e.g. `5`")
+          Set(
+            "--jobs",
+            "--jobs,  <str> The number of parallel threads. It can be an integer e.g. `5`"
+          )
         )
       }
       test("longFlagCompleteEarlier") {
         assertGoldenLiteral(
           evalComplete("1", "./mill", "--jobs", "1", "task1"),
-          Set("--jobs", "--jobs,  <str> The number of parallel threads. It can be an integer e.g. `5`")
+          Set(
+            "--jobs",
+            "--jobs,  <str> The number of parallel threads. It can be an integer e.g. `5`"
+          )
         )
       }
       test("longFlagIncomplete") {
         assertGoldenLiteral(
           evalComplete("1", "./mill", "--jobs"),
-          Set("--jobs", "--jobs,  <str> The number of parallel threads. It can be an integer e.g. `5`")
+          Set(
+            "--jobs",
+            "--jobs,  <str> The number of parallel threads. It can be an integer e.g. `5`"
+          )
         )
       }
     }

--- a/libs/tabcomplete/test/src/mill/tabcomplete/TabCompleteTests.scala
+++ b/libs/tabcomplete/test/src/mill/tabcomplete/TabCompleteTests.scala
@@ -97,7 +97,7 @@ object TabCompleteTests extends TestSuite {
       test("exactModule") {
         assertGoldenLiteral(
           evalComplete("1", "./mill", "bar"),
-          Set("bar")
+          Set("bar", "bar.task2", "bar.taskPositional")
         )
       }
 
@@ -118,7 +118,7 @@ object TabCompleteTests extends TestSuite {
       test("cross2") {
         assertGoldenLiteral(
           evalComplete("1", "./mill", "qux"),
-          Set("qux")
+          Set("qux", "qux[12]", "qux[34]", "qux[56]")
         )
       }
 

--- a/libs/tabcomplete/test/src/mill/tabcomplete/TabCompleteTests.scala
+++ b/libs/tabcomplete/test/src/mill/tabcomplete/TabCompleteTests.scala
@@ -244,7 +244,19 @@ object TabCompleteTests extends TestSuite {
       test("longFlagBrokenEarlier") {
         assertGoldenLiteral(
           evalComplete("1", "./mill", "--jo", "1", "task1"),
-          Set("--jobs")
+          Set("--jobs", "--jobs,  <str> The number of parallel threads. It can be an integer e.g. `5`")
+        )
+      }
+      test("longFlagCompleteEarlier") {
+        assertGoldenLiteral(
+          evalComplete("1", "./mill", "--jobs", "1", "task1"),
+          Set("--jobs", "--jobs,  <str> The number of parallel threads. It can be an integer e.g. `5`")
+        )
+      }
+      test("longFlagIncomplete") {
+        assertGoldenLiteral(
+          evalComplete("1", "./mill", "--jobs"),
+          Set("--jobs", "--jobs,  <str> The number of parallel threads. It can be an integer e.g. `5`")
         )
       }
     }
@@ -259,7 +271,7 @@ object TabCompleteTests extends TestSuite {
         test {
           assertGoldenLiteral(
             evalComplete("2", "./mill", "task1", "--arg-b"),
-            Set("--arg-b-2")
+            Set("--arg-b-2", "--arg-b-2,  <int> ")
           )
         }
       }
@@ -287,7 +299,7 @@ object TabCompleteTests extends TestSuite {
         test {
           assertGoldenLiteral(
             evalComplete("2", "./mill", "bar.task2", "--arg-b"),
-            Set("--arg-b-4")
+            Set("--arg-b-4", "--arg-b-4,  <int> arg b 4 docs")
           )
         }
 

--- a/libs/tabcomplete/test/src/mill/tabcomplete/TabCompleteTests.scala
+++ b/libs/tabcomplete/test/src/mill/tabcomplete/TabCompleteTests.scala
@@ -97,7 +97,7 @@ object TabCompleteTests extends TestSuite {
       test("exactModule") {
         assertGoldenLiteral(
           evalComplete("1", "./mill", "bar"),
-          Set("bar", "bar.task2", "bar.taskPositional")
+          Set("bar")
         )
       }
 
@@ -118,7 +118,7 @@ object TabCompleteTests extends TestSuite {
       test("cross2") {
         assertGoldenLiteral(
           evalComplete("1", "./mill", "qux"),
-          Set("qux", "qux[12]", "qux[34]", "qux[56]")
+          Set("qux")
         )
       }
 
@@ -167,7 +167,16 @@ object TabCompleteTests extends TestSuite {
       test("short") {
         assertGoldenLiteral(
           evalComplete("1", "./mill", "-"),
-          Set("-j", "-w", "-k", "-b", "-v", "-d", "-i", "-D")
+          Set(
+            "-b  Ring the bell once if the run completes successfully, twice if it fails.",
+            "-w  Watch and re-run the given tasks when when their inputs change.",
+            "-i  Run Mill in interactive mode, suitable for opening REPLs and taking user input.",
+            "-v  Show mill version information and exit.",
+            "-k  Continue build, even after build failures.",
+            "-D  <k=v> Define (or overwrite) a system property.",
+            "-d  Show debug output on STDOUT",
+            "-j  <str> The number of parallel threads. It can be an integer e.g. `5`"
+          )
         )
       }
       test("emptyAfterFlag") {
@@ -194,39 +203,42 @@ object TabCompleteTests extends TestSuite {
         assertGoldenLiteral(
           evalComplete("1", "./mill", "--"),
           Set(
-            "--jobs",
-            "--no-filesystem-checker",
-            "--keep-going",
-            "--watch",
-            "--no-build-lock",
-            "--interactive",
-            "--no-wait-for-build-lock",
-            "--help",
-            "--color",
-            "--help-advanced",
-            "--tab-complete",
-            "--offline",
-            "--allow-positional",
-            "--ticker",
-            "--bsp",
-            "--meta-level",
-            "--version",
-            "--no-daemon",
-            "--import",
-            "--bsp-install",
-            "--task",
-            "--notify-watch",
-            "--bsp-watch",
-            "--define",
-            "--bell",
-            "--debug"
+            "--bsp                     Enable BSP server mode.",
+            "--debug                   Show debug output on STDOUT",
+            "--bell                    Ring the bell once if the run completes successfully, twice if it fails.",
+            "--color                   <bool> Toggle colored output; by default enabled only if the console is interactive",
+            "--no-build-lock           Evaluate tasks / commands without acquiring an exclusive lock on the Mill output directory",
+            "--import                  <str> Additional ivy dependencies to load into mill, e.g. plugins.",
+            "--jobs                    <str> The number of parallel threads. It can be an integer e.g. `5`",
+            "--bsp-install             Create mill-bsp.json with Mill details under .bsp/",
+            "--no-daemon               Run without a long-lived background daemon. Must be the first argument.",
+            "--help                    Print this help message and exit.",
+            "--allow-positional        Allows command args to be passed positionally without `--arg` by default",
+            "--watch                   Watch and re-run the given tasks when when their inputs change.",
+            "--interactive             Run Mill in interactive mode, suitable for opening REPLs and taking user input.",
+            "--no-wait-for-build-lock  Do not wait for an exclusive lock on the Mill output directory to evaluate tasks / commands.",
+            "--help-advanced           Print a internal or advanced command flags not intended for common usage",
+            "--ticker                  <bool> Enable or disable the ticker log, which provides information on running",
+            "--tab-complete            Runs Mill in tab-completion mode",
+            "--meta-level              <int> Select a meta-level to run the given tasks. Level 0 is the main project in `build.mill`,",
+            "--keep-going              Continue build, even after build failures.",
+            "--define                  <k=v> Define (or overwrite) a system property.",
+            "--notify-watch            <bool> Use filesystem based file watching instead of polling based one (defaults to true).",
+            "--bsp-watch               <bool> Automatically reload the build when its sources change when running the BSP server (defaults to true).",
+            "--offline                 Try to work offline.",
+            "--no-filesystem-checker   Globally disables the checks that prevent you from reading and writing to disallowed ",
+            "--version                 Show mill version information and exit.",
+            "--task                    <str> The name or a query of the tasks(s) you want to build."
           )
         )
       }
       test("longflagsfiltered") {
         assertGoldenLiteral(
           evalComplete("1", "./mill", "--h"),
-          Set("--help", "--help-advanced")
+          Set(
+            "--help           Print this help message and exit.",
+            "--help-advanced  Print a internal or advanced command flags not intended for common usage"
+          )
         )
       }
       test("longFlagBrokenEarlier") {
@@ -241,7 +253,7 @@ object TabCompleteTests extends TestSuite {
         test {
           assertGoldenLiteral(
             evalComplete("2", "./mill", "task1", "--a"),
-            Set("--arg-a", "--arg-b-2")
+            Set("--arg-a    <str> ", "--arg-b-2  <int> ")
           )
         }
         test {
@@ -269,7 +281,7 @@ object TabCompleteTests extends TestSuite {
         test {
           assertGoldenLiteral(
             evalComplete("2", "./mill", "bar.task2", "--a"),
-            Set("--arg-a-3", "--arg-b-4")
+            Set("--arg-a-3  <str> arg a 3 docs", "--arg-b-4  <int> arg b 4 docs")
           )
         }
         test {
@@ -303,23 +315,6 @@ object TabCompleteTests extends TestSuite {
             Set("file2.txt", "file1.txt", "out")
           )
         }
-      }
-    }
-    test("docs") {
-      test {
-        assertGoldenLiteral(
-          evalComplete("2", "--is-zsh", "./mill", "bar.task2", "--"),
-          Set("--arg-a-3  <str> arg a 3 docs", "--arg-b-4  <int> arg b 4 docs")
-        )
-      }
-      test {
-        assertGoldenLiteral(
-          evalComplete("1", "--is-zsh", "./mill", "--h"),
-          Set(
-            "--help           Print this help message and exit.",
-            "--help-advanced  Print a internal or advanced command flags not intended for common usage"
-          )
-        )
       }
     }
   }


### PR DESCRIPTION
* Uses the hack described at https://stackoverflow.com/a/10130007/871202, where we place the descriptions in-line in the completion tokens but trim them off when there's only one token to prevent them from being inserted

* Refactored `complete.sh` to share the line-truncation-ellipses-insertion logic between bash and zsh completers