### PR TITLE
Clean up compilation warnings

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -7,6 +7,8 @@ package build
 import coursier.{MavenRepository, Repository}
 import millbuild.*
 
+import scala.language.reflectiveCalls
+
 //import com.github.lolgab.mill.mima.Mima
 import coursier.maven.MavenRepository
 import coursier.VersionConstraint

--- a/contrib/codeartifact/src/mill/contrib/codeartifact/CodeartifactPublishModule.scala
+++ b/contrib/codeartifact/src/mill/contrib/codeartifact/CodeartifactPublishModule.scala
@@ -18,6 +18,11 @@ trait CodeartifactPublishModule extends PublishModule {
       connectTimeout: Int = 5000
   ): Command[Unit] =
     Task.Command {
+      if (!publish) throw Exception(
+        "`publish` is set to false, but the parameter never did anything, so we're throwing an exception to at " +
+          "least get your attention."
+      )
+
       val (artifacts, artifactInfo) = publishArtifacts().withConcretePath
 
       new CodeartifactPublisher(

--- a/contrib/gitlab/src/mill/contrib/gitlab/GitlabTokenLookup.scala
+++ b/contrib/gitlab/src/mill/contrib/gitlab/GitlabTokenLookup.scala
@@ -39,7 +39,7 @@ trait GitlabTokenLookup {
     val token = LazyList
       .from(tokenSearchOrder)
       .map(token => buildHeaders(token, env, prop, workspace))
-      .find(_.isInstanceOf[Result.Success[_]])
+      .find(_.isInstanceOf[Result.Success[?]])
       .flatMap(_.toOption)
 
     token match {

--- a/contrib/jmh/test/src/mill/contrib/jmh/JmhModuleTest.scala
+++ b/contrib/jmh/test/src/mill/contrib/jmh/JmhModuleTest.scala
@@ -25,7 +25,7 @@ object JmhModuleTest extends TestSuite {
       test("listJmhBenchmarks") - UnitTester(jmh, testModuleSourcesPath).scoped { eval =>
         val paths = ExecutionPaths.resolve(eval.outPath, jmh.listJmhBenchmarks())
         val outFile = paths.dest / "benchmarks.out"
-        val Right(result) = eval(jmh.listJmhBenchmarks("-o", outFile.toString)): @unchecked
+        val Right(_) = eval(jmh.listJmhBenchmarks("-o", outFile.toString)): @unchecked
         val expected =
           """Benchmarks:
             |mill.contrib.jmh.Bench2.log

--- a/contrib/playlib/test/src/mill/playlib/PlaySingleModuleTests.scala
+++ b/contrib/playlib/test/src/mill/playlib/PlaySingleModuleTests.scala
@@ -75,7 +75,7 @@ object PlaySingleModuleTests extends TestSuite with PlayTestSuite {
       )
 
       // don't recompile if nothing changed
-      val Right(result2) = eval.apply(playsingle.compile): @unchecked
+      val Right(_) = eval.apply(playsingle.compile): @unchecked
       // assert(unchangedEvalCount == 0)
     }
   }

--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageReportWorker.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageReportWorker.scala
@@ -12,7 +12,7 @@ import ScoverageReportWorkerApi2.{Ctx => ApiCtx}
 
 class ScoverageReportWorker {
 
-  def bridge(classpath: Seq[PathRef])(implicit ctx: TaskCtx): ScoverageReportWorkerApiBridge = {
+  def bridge(classpath: Seq[PathRef]): ScoverageReportWorkerApiBridge = {
     def ctx0(implicit ctx: TaskCtx): ApiCtx = {
       val logger = new ApiLogger {
         def error(msg: String): Unit = ctx.log.error(msg)

--- a/contrib/testng/src/mill/testng/TestNGFingerprint.java
+++ b/contrib/testng/src/mill/testng/TestNGFingerprint.java
@@ -1,0 +1,16 @@
+package mill.testng;
+
+import sbt.testing.AnnotatedFingerprint;
+
+public class TestNGFingerprint implements AnnotatedFingerprint {
+
+  public static final TestNGFingerprint instance = new TestNGFingerprint();
+
+  public String annotationName() {
+    return "org.testng.annotations.Test";
+  }
+
+  public boolean isModule() {
+    return false;
+  }
+}

--- a/contrib/testng/src/mill/testng/TestNGFramework.java
+++ b/contrib/testng/src/mill/testng/TestNGFramework.java
@@ -1,6 +1,5 @@
 package mill.testng;
 
-import sbt.testing.AnnotatedFingerprint;
 import sbt.testing.Fingerprint;
 import sbt.testing.Framework;
 import sbt.testing.Runner;
@@ -18,18 +17,5 @@ public class TestNGFramework implements Framework {
   @Override
   public Runner runner(String[] args, String[] remoteArgs, ClassLoader classLoader) {
     return new TestNGRunner(args, remoteArgs, classLoader);
-  }
-}
-
-class TestNGFingerprint implements AnnotatedFingerprint {
-
-  public static final TestNGFingerprint instance = new TestNGFingerprint();
-
-  public String annotationName() {
-    return "org.testng.annotations.Test";
-  }
-
-  public boolean isModule() {
-    return false;
   }
 }

--- a/core/api/daemon/src/mill/api/daemon/MillURLClassLoader.scala
+++ b/core/api/daemon/src/mill/api/daemon/MillURLClassLoader.scala
@@ -59,6 +59,7 @@ object MillURLClassLoader {
       openClassloaders.updateWith(label) {
         case Some(1) => None
         case Some(n) => Some(n - 1)
+        case None => throw Exception(s"removeOpenClassLoader $label not found")
       }
     }
 

--- a/core/api/src/mill/api/Cross.scala
+++ b/core/api/src/mill/api/Cross.scala
@@ -1,7 +1,6 @@
 package mill.api
 
 import scala.collection.mutable
-import scala.reflect.ClassTag
 
 import scala.quoted.*
 
@@ -119,7 +118,7 @@ object Cross {
     )
   }
 
-  class Factory[T: ClassTag](
+  class Factory[T](
       val makeList: Seq[(Class[?], mill.api.ModuleCtx => T)],
       val crossValuesListLists: Seq[Seq[Any]],
       val crossSegmentsList: Seq[Seq[String]],

--- a/core/api/src/mill/api/Evaluator.scala
+++ b/core/api/src/mill/api/Evaluator.scala
@@ -47,7 +47,15 @@ trait Evaluator extends AutoCloseable with EvaluatorApi {
       selectMode: SelectMode,
       allowPositionalCommandArgs: Boolean = false,
       resolveToModuleTasks: Boolean = false
-  ): mill.api.Result[List[Resolved]] = mill.api.Result.Success(Nil)
+  ): mill.api.Result[List[Resolved]] = {
+    // These are used in the overrides.
+    val _ = scriptArgs
+    val _ = selectMode
+    val _ = allowPositionalCommandArgs
+    val _ = resolveToModuleTasks
+
+    mill.api.Result.Success(Nil)
+  }
 
   def resolveTasks(
       scriptArgs: Seq[String],

--- a/core/api/src/mill/api/ExternalModule.scala
+++ b/core/api/src/mill/api/ExternalModule.scala
@@ -16,7 +16,7 @@ abstract class ExternalModule(implicit
     millModuleLine0: sourcecode.Line,
     millFile0: sourcecode.File
 ) extends RootModule0(BuildCtx.workspaceRoot, external0 = true)(
-      millModuleEnclosing0,
+      using millModuleEnclosing0,
       millModuleLine0,
       millFile0
     ) {

--- a/core/api/src/mill/api/PathRef.scala
+++ b/core/api/src/mill/api/PathRef.scala
@@ -32,7 +32,7 @@ case class PathRef private[mill] (
       path: os.Path = path,
       quick: Boolean = quick,
       sig: Int = sig,
-      revalidate: PathRef.Revalidate = revalidate
+      revalidate: PathRef.Revalidate
   ): PathRef = PathRef(path, quick, sig, revalidate)
 
   def withRevalidate(revalidate: PathRef.Revalidate): PathRef = copy(revalidate = revalidate)

--- a/core/api/src/mill/api/Task.scala
+++ b/core/api/src/mill/api/Task.scala
@@ -397,7 +397,7 @@ object Task {
   }
 
   class Anon[T](
-      val inputs: Seq[Task[_]],
+      val inputs: Seq[Task[?]],
       evaluate0: (Seq[Any], mill.api.TaskCtx) => Result[T],
       enclosing: sourcecode.Enclosing
   ) extends Task[T] {

--- a/core/api/src/mill/api/Task.scala
+++ b/core/api/src/mill/api/Task.scala
@@ -9,7 +9,7 @@ import mill.api.internal.{Applicative, Cacher, NamedParameterOnlyDummy}
 import upickle.default.ReadWriter
 import upickle.default.Writer
 
-import scala.annotation.targetName
+import scala.annotation.{targetName, unused}
 import scala.language.implicitConversions
 import scala.quoted.*
 
@@ -149,7 +149,7 @@ object Task {
       inline ctx: mill.api.ModuleCtx
   ): os.Path = value match {
     // TODO: support "."
-    case str: String => ctx.millSourcePath / os.up / os.PathChunk.segmentsFromString(str)
+//    case str: String => ctx.millSourcePath / os.up / os.PathChunk.segmentsFromString(str)
     case sub: os.SubPath => ctx.millSourcePath / os.up / os.PathChunk.SubPathChunk(sub)
     case rel: os.RelPath => ctx.millSourcePath / os.up / os.PathChunk.RelPathChunk(rel)
     case p: os.Path => p
@@ -210,7 +210,7 @@ object Task {
    *                   runs.
    */
   def Command(
-      t: NamedParameterOnlyDummy = new NamedParameterOnlyDummy,
+      @unused t: NamedParameterOnlyDummy = new NamedParameterOnlyDummy,
       exclusive: Boolean = false,
       persistent: Boolean = false
   ): CommandFactory = new CommandFactory(exclusive = exclusive, persistent = persistent)
@@ -279,7 +279,7 @@ object Task {
    * Violating that invariant can result in confusing mis-behaviors
    */
   def apply(
-      t: NamedParameterOnlyDummy = new NamedParameterOnlyDummy,
+      @unused t: NamedParameterOnlyDummy = new NamedParameterOnlyDummy,
       persistent: Boolean = false
   ): ApplyFactory = new ApplyFactory(persistent)
   class ApplyFactory private[mill] (val persistent: Boolean) {
@@ -517,7 +517,7 @@ object Task {
         ctx: Expr[mill.api.ModuleCtx]
     ): Expr[Simple[Seq[PathRef]]] = {
       val expr = appImpl[Simple, Seq[PathRef]](
-        (in, ev) => '{ new Sources($ev, $ctx, ${ taskIsPrivate() }) },
+        ( /*in*/ _, ev) => '{ new Sources($ev, $ctx, ${ taskIsPrivate() }) },
         values,
         allowTaskReferences = false
       )
@@ -531,7 +531,7 @@ object Task {
     ): Expr[Simple[PathRef]] = {
 
       val expr = appImpl[Simple, PathRef](
-        (in, ev) => '{ new Source($ev, $ctx, ${ taskIsPrivate() }) },
+        ( /*in*/ _, ev) => '{ new Source($ev, $ctx, ${ taskIsPrivate() }) },
         value,
         allowTaskReferences = false
       )
@@ -547,7 +547,7 @@ object Task {
     ): Expr[Simple[T]] = {
 
       val expr = appImpl[Simple, T](
-        (in, ev) => '{ new Input[T]($ev, $ctx, $w, ${ taskIsPrivate() }) },
+        ( /*in*/ _, ev) => '{ new Input[T]($ev, $ctx, $w, ${ taskIsPrivate() }) },
         value,
         allowTaskReferences = false
       )

--- a/core/api/src/mill/api/internal/Applicative.scala
+++ b/core/api/src/mill/api/internal/Applicative.scala
@@ -40,7 +40,7 @@ object Applicative {
     import quotes.reflect.*
 
     def checkForNestedTasks() = {
-      val taskType = TypeRepr.of[Task[_]]
+      val taskType = TypeRepr.of[Task[?]]
 
       def isTask(tpr: TypeRepr): Boolean =
         // We use `typeSymbol` for a robust check.

--- a/core/api/src/mill/api/internal/Cacher.scala
+++ b/core/api/src/mill/api/internal/Cacher.scala
@@ -16,7 +16,7 @@ private[mill] object Cacher {
     import quotes.reflect.*
     // In Scala 3, the top level splice of a macro is owned by a symbol called "macro" with the macro flag set,
     // but not the method flag.
-    def isMacroOwner(sym: Symbol)(using Quotes): Boolean =
+    def isMacroOwner(sym: Symbol): Boolean =
       sym.name == "macro" && sym.flags.is(Flags.Macro | Flags.Synthetic) && !sym.flags.is(
         Flags.Method
       )

--- a/core/api/src/mill/api/internal/Mirrors.scala
+++ b/core/api/src/mill/api/internal/Mirrors.scala
@@ -43,7 +43,7 @@ private[mill] object Mirrors {
     ${ Internal.autoMirrorImpl[R, T]('h, 'p) }
 
   /** Try to synthesize a proof that `T` has a synthetic Mirror inside of `Root[R]`. */
-  transparent inline given autoPath[R, T <: R](using inline h: Root[R]): Path[R, T] =
+  transparent inline given autoPath[R, T <: R]: Path[R, T] =
     ${ Internal.autoPathImpl[R, T] }
 
   def makeRoot[T](ms: Map[String, Mirror]): Root[T] = new Internal.Rooted(ms)
@@ -302,6 +302,7 @@ private[mill] object Mirrors {
                 '[
                 type ts <: Tuple; `ts`]
               ) => TypeRepr.of[t *: ts]
+          case other => throw Exception(s"unexpected: $other")
       )
     }
 
@@ -350,6 +351,8 @@ private[mill] object Mirrors {
               }
             ]
           }
+
+        case other => throw Exception(s"unexpected: $other")
       }
     }
 
@@ -369,6 +372,8 @@ private[mill] object Mirrors {
               type MirroredElemLabels = names
             }]
           }
+
+        case other => throw Exception(s"unexpected: $other")
       }
     }
 
@@ -424,6 +429,8 @@ private[mill] object Mirrors {
               '[
               type types <: Tuple; `types`]
             ) => '{ AutoSum[T, label, names, types]((arg: T) => ${ ordinalBody('arg) }) }
+
+        case other => throw Exception(s"unexpected: $other")
       }
 
       innerMirrors + (structure.clsName -> sumMirror)
@@ -439,6 +446,8 @@ private[mill] object Mirrors {
           tpe.asType match
             case '[t] =>
               '{ $arg.productElement(${ Expr(i) }).asInstanceOf[t] }.asTerm
+
+            case other => throw Exception(s"unexpected: $other")
         )
         Ref(structure.companion)
           .select(structure.applyMethod)
@@ -455,6 +464,7 @@ private[mill] object Mirrors {
               '[
               type types <: Tuple; `types`]
             ) => '{ AutoProduct[T, label, names, types](p => ${ applyCall('p) }) }
+        case other => throw Exception(s"unexpected: $other")
       }
       structure.clsName -> mirror
     }

--- a/core/api/src/mill/api/internal/Reflect.scala
+++ b/core/api/src/mill/api/internal/Reflect.scala
@@ -37,8 +37,9 @@ private[mill] object Reflect {
     } yield (m, n)
 
   private val classSeqOrdering =
-    Ordering.Implicits.seqOrdering[Seq, Class[?]](using (c1, c2) =>
-      if (c1 == c2) 0 else if (c1.isAssignableFrom(c2)) 1 else -1
+    Ordering.Implicits.seqOrdering[Seq, Class[?]](using
+      (c1, c2) =>
+        if (c1 == c2) 0 else if (c1.isAssignableFrom(c2)) 1 else -1
     )
 
   def reflect(
@@ -132,6 +133,7 @@ private[mill] object Reflect {
         (name, m.getReturnType, (outer: Any) => m.invoke(outer).asInstanceOf[T])
       case (name, m: java.lang.reflect.Field) =>
         (name, m.getType, (outer: Any) => m.get(outer).asInstanceOf[T])
+      case other => throw new IllegalArgumentException(s"Unexpected member: $other")
     }
   }
 

--- a/core/api/src/mill/api/internal/Reflect.scala
+++ b/core/api/src/mill/api/internal/Reflect.scala
@@ -37,7 +37,7 @@ private[mill] object Reflect {
     } yield (m, n)
 
   private val classSeqOrdering =
-    Ordering.Implicits.seqOrdering[Seq, Class[?]]((c1, c2) =>
+    Ordering.Implicits.seqOrdering[Seq, Class[?]](using (c1, c2) =>
       if (c1 == c2) 0 else if (c1.isAssignableFrom(c2)) 1 else -1
     )
 

--- a/core/api/src/mill/api/internal/Util.scala
+++ b/core/api/src/mill/api/internal/Util.scala
@@ -6,7 +6,7 @@ object Util {
     char.toString * (targetLength - s.length) + s
   }
 
-  def renderSecondsSuffix(millis: Long, @com.lihaoyi.unroll dummy: Int = 0) =
+  def renderSecondsSuffix(millis: Long) =
     (millis / 1000).toInt match {
       case 0 => ""
       case n => s" ${n}s"

--- a/core/api/test/src/mill/api/CacherTests.scala
+++ b/core/api/test/src/mill/api/CacherTests.scala
@@ -5,7 +5,6 @@ import mill.testkit.TestRootModule
 import mill.Task
 import mill.api.Result.Success
 import utest._
-import utest.framework.TestPath
 
 object CacherTests extends TestSuite {
   object Base extends Base {
@@ -30,7 +29,7 @@ object CacherTests extends TestSuite {
   }
 
   val tests = Tests {
-    def eval[T <: mill.testkit.TestRootModule, V](mapping: T, v: Task[V])(implicit tp: TestPath) = {
+    def eval[T <: mill.testkit.TestRootModule, V](mapping: T, v: Task[V]) = {
       UnitTester(mapping, null).scoped { evaluator =>
         evaluator(v).toOption.get.value
       }

--- a/core/api/test/src/mill/api/MacroErrorTests.scala
+++ b/core/api/test/src/mill/api/MacroErrorTests.scala
@@ -1,7 +1,9 @@
 package mill.api
 
-import utest._
+import utest.*
 import mill.testkit.TestRootModule
+
+import scala.annotation.unused
 
 object MacroErrorTests extends TestSuite {
 
@@ -89,7 +91,7 @@ object MacroErrorTests extends TestSuite {
       // come from inside the Task{...} block
       test("pos") {
         // This should compile
-        object foo extends TestRootModule {
+        @unused object foo extends TestRootModule {
           def a = Task { 1 }
           val arr = Array(a)
           def b = {

--- a/core/eval/src/mill/eval/SelectiveExecutionImpl.scala
+++ b/core/eval/src/mill/eval/SelectiveExecutionImpl.scala
@@ -160,7 +160,7 @@ private[mill] class SelectiveExecutionImpl(evaluator: Evaluator)
         interGroupDeps.toSeq.sortBy(_._1.toString) // sort to ensure determinism
       )
 
-      val (vertexToIndex, edgeIndices) =
+      val ( /*vertexToIndex*/ _, edgeIndices) =
         SpanningForest.graphMapToIndices(indexToTerminal, reverseInterGroupDeps)
 
       val json = SpanningForest.writeJson(
@@ -216,7 +216,7 @@ object SelectiveExecutionImpl {
             reporter = _ => None,
             testReporter = TestReporter.DummyTestReporter,
             workspace = evaluator.workspace,
-            systemExit = n => ???,
+            systemExit = _ => ???,
             fork = null,
             jobs = evaluator.effectiveThreadCount,
             offline = evaluator.offline

--- a/core/exec/src/mill/exec/Execution.scala
+++ b/core/exec/src/mill/exec/Execution.scala
@@ -98,8 +98,10 @@ private[mill] case class Execution(
   private def execute0(
       goals: Seq[Task[?]],
       logger: Logger,
-      reporter: Int => Option[CompileProblemReporter] = _ => Option.empty[CompileProblemReporter],
-      testReporter: TestReporter = TestReporter.DummyTestReporter,
+      reporter: Int => Option[
+        CompileProblemReporter
+      ] /* = _ => Option.empty[CompileProblemReporter]*/,
+      testReporter: TestReporter /* = TestReporter.DummyTestReporter*/,
       serialCommandExec: Boolean
   ): Execution.Results = {
     os.makeDir.all(outPath)

--- a/core/exec/src/mill/exec/Execution.scala
+++ b/core/exec/src/mill/exec/Execution.scala
@@ -302,7 +302,7 @@ private[mill] case class Execution(
                 t,
                 (Seq(t) ++ plan.sortedGroups.lookupKey(t))
                   .flatMap { t0 => res.newResults.get(t0) }
-                  .sortBy(!_.isInstanceOf[ExecResult.Failing[_]])
+                  .sortBy(!_.isInstanceOf[ExecResult.Failing[?]])
                   .head
               )
 

--- a/core/exec/src/mill/exec/ExecutionLogs.scala
+++ b/core/exec/src/mill/exec/ExecutionLogs.scala
@@ -13,7 +13,7 @@ private object ExecutionLogs {
       indexToTerminal: Array[Task[?]],
       outPath: os.Path
   ): Unit = {
-    val (vertexToIndex, edgeIndices) =
+    val ( /*vertexToIndex*/ _, edgeIndices) =
       SpanningForest.graphMapToIndices(indexToTerminal, interGroupDeps)
 
     SpanningForest.writeJsonFile(

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -377,7 +377,7 @@ private trait GroupExecution {
         workerCache.update(w.ctx.segments.render, (workerCacheHash(inputsHash), v))
       }
 
-    def normalJson(w: upickle.default.Writer[_]) = PathRef.withSerializedPaths {
+    def normalJson(w: upickle.default.Writer[?]) = PathRef.withSerializedPaths {
       upickle.default.writeJs(v.value)(using w.asInstanceOf[upickle.default.Writer[Any]])
     }
     lazy val workerJson = labelled.asWorker.map { _ =>

--- a/core/exec/test/src/mill/exec/JavaCompileJarTests.scala
+++ b/core/exec/test/src/mill/exec/JavaCompileJarTests.scala
@@ -56,7 +56,7 @@ object JavaCompileJarTests extends TestSuite {
             Task.dest / "out.jar",
             Seq(classFiles().path, readme().path) ++ resourceRoot().map(_.path),
             JarManifest.MillDefault,
-            (p: os.Path, r: os.RelPath) => noFoos(r.last)
+            (_: os.Path, r: os.RelPath) => noFoos(r.last)
           )
           PathRef(jar)
         }
@@ -170,7 +170,7 @@ object JavaCompileJarTests extends TestSuite {
       ).call(evaluator.outPath).out.text()
       assert(executed == s"${31337 + 271828}${System.lineSeparator}")
 
-      for (i <- 0 until 3) {
+      for (_ <- 0 until 3) {
         // Build.run is not cached, so every time we eval it, it has to
         // re-evaluate
         val Right(result) = eval(Build.run("test.Foo")): @unchecked

--- a/core/resolve/test/src/mill/resolve/ParseArgsTests.scala
+++ b/core/resolve/test/src/mill/resolve/ParseArgsTests.scala
@@ -101,6 +101,7 @@ object ParseArgsTests extends TestSuite {
         val selectors = selectors0.map {
           case (Some(v1), Some(v2)) => (Some(v1.value), v2.value)
           case (None, Some(v2)) => (None, v2.value)
+          case other @ (_, None) => throw Exception(s"Unexpected: $other")
         }
         assert(
           selectors == expectedSelectors,
@@ -240,6 +241,7 @@ object ParseArgsTests extends TestSuite {
             val selectors = selectors0.map {
               case (Some(v1), Some(v2)) => (Some(v1.value), v2.value)
               case (None, Some(v2)) => (None, v2.value)
+              case other @ (_, None) => throw Exception(s"Unexpected: $other")
             }
             (selectors, args)
         }

--- a/example/package.mill
+++ b/example/package.mill
@@ -291,6 +291,8 @@ $txt
 ----
 $txt
 ----"""
+            case (kind, txt) =>
+              throw Exception(s"Unknown kind: $kind\n\nText: $txt")
           }
           .mkString("\n")
       )

--- a/integration/failure/missing-build-file/src/MissingBuildFileTests.scala
+++ b/integration/failure/missing-build-file/src/MissingBuildFileTests.scala
@@ -1,16 +1,19 @@
 package mill.integration
 
 import mill.testkit.UtestIntegrationTestSuite
-
-import utest._
+import utest.*
 
 object MissingBuildFileTests extends UtestIntegrationTestSuite {
   val tests: Tests = Tests {
     test - integrationTest { tester =>
       val res = tester.eval(("resolve", "_"))
       assert(!res.isSuccess)
+
       val s"${prefix}No build file (build.mill, build.mill.scala, build.sc) found in $msg. Are you in a Mill project directory?" =
         res.err: @unchecked
+      // Silence unused variable warning
+      val _ = prefix
+      val _ = msg
     }
   }
 }

--- a/integration/feature/leak-hygiene/src/LeakHygieneTests.scala
+++ b/integration/feature/leak-hygiene/src/LeakHygieneTests.scala
@@ -83,7 +83,7 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
         )
 
         // Exercise clean compile all
-        for (i <- Range(0, 2)) {
+        for (_ <- Range(0, 2)) {
           tester.eval(("show", "clean"))
           tester.eval(("show", "__.compile"))
           checkClassloaders(tester)(
@@ -114,7 +114,7 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
         }
 
         // Exercise no-op compile all
-        for (i <- Range(0, 2)) {
+        for (_ <- Range(0, 2)) {
           tester.eval(("show", "__.compile"))
           checkClassloaders(tester)(
             Map(
@@ -168,7 +168,7 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
         )
 
         // Exercise clean compile all post-shutdown
-        for (i <- Range(0, 2)) {
+        for (_ <- Range(0, 2)) {
           tester.eval(("show", "clean"))
           tester.eval(("show", "__.compile"))
           checkClassloaders(tester)(
@@ -198,7 +198,7 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
         }
 
         // Exercise modifying build.mill
-        for (i <- Range(0, 2)) {
+        for (_ <- Range(0, 2)) {
           tester.modifyFile(tester.workspacePath / "build.mill", _ + "\n")
 
           tester.eval(("show", "__.compile"))
@@ -229,7 +229,7 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
 
         }
         // Exercise modifying Foo.java, Foo.kt, Foo.scala
-        for (i <- Range(0, 2)) {
+        for (_ <- Range(0, 2)) {
           tester.modifyFile(tester.workspacePath / "hello-java/src/Foo.java", "//hello\n" + _)
           tester.modifyFile(tester.workspacePath / "hello-kotlin/src/Foo.kt", "//hello\n" + _)
           tester.modifyFile(tester.workspacePath / "hello-scala/src/Foo.scala", "//hello\n" + _)

--- a/integration/ide/bsp-server-reload/src/BspServerReloadTests.scala
+++ b/integration/ide/bsp-server-reload/src/BspServerReloadTests.scala
@@ -33,7 +33,7 @@ object BspServerReloadTests extends UtestIntegrationTestSuite {
         env = Map("MILL_EXECUTABLE_PATH" -> tester.millExecutable.toString)
       )
 
-      var didChangePromise = Promise[b.DidChangeBuildTarget]()
+      val didChangePromise = Promise[b.DidChangeBuildTarget]()
 
       val client = new DummyBuildClient {
         override def onBuildTargetDidChange(params: b.DidChangeBuildTarget): Unit =

--- a/integration/invalidation/multi-level-editing/src/MultiLevelBuildTests.scala
+++ b/integration/invalidation/multi-level-editing/src/MultiLevelBuildTests.scala
@@ -1,9 +1,9 @@
 package mill.integration
 
 import mill.testkit.{IntegrationTester, UtestIntegrationTestSuite}
-import mill.constants.OutFiles._
+import mill.constants.OutFiles.*
 import mill.daemon.RunnerState
-import utest._
+import utest.*
 
 import scala.util.matching.Regex
 
@@ -58,7 +58,9 @@ trait MultiLevelBuildTests extends UtestIntegrationTestSuite {
    * appropriate files to get watched
    */
   def checkWatchedFiles(tester: IntegrationTester, expected0: Seq[os.Path]*): Unit = {
-    for ((expectedWatched0, (frame, path)) <- expected0.zip(loadFrames(tester, expected0.length))) {
+    for (
+      (expectedWatched0, (frame, /*path*/ _)) <- expected0.zip(loadFrames(tester, expected0.length))
+    ) {
       val frameWatched = frame
         .evalWatched
         .filter(_.startsWith(tester.workspacePath))
@@ -111,7 +113,7 @@ trait MultiLevelBuildTests extends UtestIntegrationTestSuite {
     }
 
     val currentClassLoaderIds =
-      for ((frame, path) <- loadFrames(tester, expectedChanged0.length))
+      for ((frame, /*path*/ _) <- loadFrames(tester, expectedChanged0.length))
         yield frame.classLoaderIdentity
 
     val changed = currentClassLoaderIds

--- a/libs/androidlib/package.mill
+++ b/libs/androidlib/package.mill
@@ -52,7 +52,7 @@ object `package` extends MillPublishScalaModule with BuildInfo {
   )
 
   trait MillAndroidModule extends MillPublishScalaModule {
-    override def javacOptions = {
+    override def javacOptions = super.javacOptions() ++ {
       val release = Seq("-source", "1.8", "-target", "1.8")
       release ++ Seq("-encoding", "UTF-8", "-deprecation")
     }

--- a/libs/init/buildgen/src/mill/main/buildgen/BuildGenBase.scala
+++ b/libs/init/buildgen/src/mill/main/buildgen/BuildGenBase.scala
@@ -64,7 +64,6 @@ trait BuildGenBase[M, D, I] {
               BuildGenUtil.renderImports(
                 shared.baseModule,
                 isNested,
-                moduleNodes.size,
                 extraImports
               ),
             companions =

--- a/libs/init/buildgen/src/mill/main/buildgen/BuildGenUtil.scala
+++ b/libs/init/buildgen/src/mill/main/buildgen/BuildGenUtil.scala
@@ -148,7 +148,6 @@ object BuildGenUtil {
   def renderImports(
       baseModule: Option[String],
       isNested: Boolean,
-      packagesSize: Int,
       extraImports: Seq[String]
   ): SortedSet[String] = {
     scala.collection.immutable.SortedSet(
@@ -475,9 +474,13 @@ object BuildGenUtil {
     if (isNullOrEmpty(artifact)) ""
     else s"def pomParentProject = Some($artifact)"
 
-  def renderPomSettings(arg: String | Null, superArg: String | Null = null): String =
+  // TODO review: should there be `if (arg != superArg)` check or `superArg` isn't needed?
+  def renderPomSettings(arg: String | Null, superArg: String | Null = null): String = {
+    val _ = superArg
+
     if (isNullOrEmpty(arg)) ""
     else s"def pomSettings = $arg"
+  }
 
   def renderPublishVersion(arg: String | Null, superArg: String | Null = null): String =
     if (arg != superArg)
@@ -486,8 +489,7 @@ object BuildGenUtil {
     else ""
 
   def renderPublishProperties(
-      args: Seq[(String, String)],
-      superArgs: Seq[(String, String)] = Seq.empty
+      args: Seq[(String, String)]
   ): String = {
     val tuples = args.iterator.map { case (k, v) => s"(${escape(k)}, ${escape(v)})" }
     optional("def publishProperties = super.publishProperties() ++ Map", tuples)

--- a/libs/init/gradle/src/mill/main/gradle/GradleBuildGenMain.scala
+++ b/libs/init/gradle/src/mill/main/gradle/GradleBuildGenMain.scala
@@ -318,14 +318,14 @@ object GradleBuildGenMain extends BuildGenBase.MavenAndGradle[ProjectModel, Dep]
             appendMvnDepPackage(
               config.deps.asScala,
               onPackage = v => sd.copy(mainCompileModuleDeps = sd.mainCompileModuleDeps + v),
-              onMvn = (v, id) => sd.copy(mainCompileMvnDeps = sd.mainCompileMvnDeps + v)
+              onMvn = (v, /*id*/ _) => sd.copy(mainCompileMvnDeps = sd.mainCompileMvnDeps + v)
             )
 
           case RUNTIME_ONLY_CONFIGURATION_NAME =>
             appendMvnDepPackage(
               config.deps.asScala,
               onPackage = v => sd.copy(mainRunModuleDeps = sd.mainRunModuleDeps + v),
-              onMvn = (v, id) => sd.copy(mainRunMvnDeps = sd.mainRunMvnDeps + v)
+              onMvn = (v, /*id*/ _) => sd.copy(mainRunMvnDeps = sd.mainRunMvnDeps + v)
             )
 
           case TEST_IMPLEMENTATION_CONFIGURATION_NAME =>
@@ -346,7 +346,7 @@ object GradleBuildGenMain extends BuildGenBase.MavenAndGradle[ProjectModel, Dep]
             appendMvnDepPackage(
               config.deps.asScala,
               onPackage = v => sd.copy(testCompileModuleDeps = sd.testCompileModuleDeps + v),
-              onMvn = (v, id) => sd.copy(testCompileMvnDeps = sd.testCompileMvnDeps + v)
+              onMvn = (v, /*id*/ _) => sd.copy(testCompileMvnDeps = sd.testCompileMvnDeps + v)
             )
 
           case name =>

--- a/libs/init/gradle/src/mill/main/gradle/JavaModel.java
+++ b/libs/init/gradle/src/mill/main/gradle/JavaModel.java
@@ -170,11 +170,12 @@ public interface JavaModel extends Serializable {
     }
 
     static ProjectDep from(ProjectDependency dep, VersionNumber gradleVersionNumber) {
-      //noinspection deprecation
-      return new Impl(
-          gradleVersionNumber.compareTo(VersionNumber.parse("8.11")) >= 0
-              ? dep.getPath()
-              : dep.getDependencyProject().getPath());
+      @SuppressWarnings("deprecation")
+      var path = gradleVersionNumber.compareTo(VersionNumber.parse("8.11")) >= 0
+        ? dep.getPath()
+        : dep.getDependencyProject().getPath();
+
+      return new Impl(path);
     }
   }
 

--- a/libs/init/maven/src/mill/main/maven/MavenBuildGenMain.scala
+++ b/libs/init/maven/src/mill/main/maven/MavenBuildGenMain.scala
@@ -78,7 +78,7 @@ object MavenBuildGenMain extends BuildGenBase.MavenAndGradle[Model, Dependency] 
     val typedef = IrTrait(
       cfg.shared.basicConfig.jvmId,
       baseModule,
-      getModuleSupertypes(cfg),
+      getModuleSupertypes,
       javacOptions,
       scalaVersion,
       scalacOptions,
@@ -134,7 +134,7 @@ object MavenBuildGenMain extends BuildGenBase.MavenAndGradle[Model, Dependency] 
     )
   }
 
-  def getModuleSupertypes(cfg: Config): Seq[String] = Seq("PublishModule", "MavenModule")
+  def getModuleSupertypes: Seq[String] = Seq("PublishModule", "MavenModule")
 
   def getProjectGav(model: Model): (String, String, String) =
     (model.getGroupId, model.getArtifactId, model.getVersion)
@@ -144,7 +144,7 @@ object MavenBuildGenMain extends BuildGenBase.MavenAndGradle[Model, Dependency] 
   def getMillSourcePath(model: Model): Path = os.Path(model.getProjectDirectory)
 
   override def getSupertypes(cfg: Config, baseInfo: IrBaseInfo, build: Node[Model]): Seq[String] =
-    cfg.shared.basicConfig.baseModule.fold(getModuleSupertypes(cfg))(Seq(_))
+    cfg.shared.basicConfig.baseModule.fold(getModuleSupertypes)(Seq(_))
 
   def processResources(
       input: java.util.List[org.apache.maven.model.Resource],

--- a/libs/javalib/src/mill/javalib/CoursierModule.scala
+++ b/libs/javalib/src/mill/javalib/CoursierModule.scala
@@ -6,11 +6,12 @@ import coursier.core.VariantSelector.VariantMatcher
 import coursier.params.ResolutionParams
 import coursier.{Dependency, Repository, Resolve}
 import mill.api.Task
-import mill.api.{PathRef}
-import mill.api.{Result}
+import mill.api.PathRef
+import mill.api.Result
 import mill.util.Jvm
 import mill.T
 
+import scala.annotation.unused
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
@@ -233,7 +234,9 @@ object CoursierModule {
         coursier.cache.FileCache[coursier.util.Task] => coursier.cache.FileCache[coursier.util.Task]
       ] = None,
       resolutionParams: ResolutionParams = ResolutionParams(),
-      offline: Boolean,
+      // TODO review: this does nothing? :/
+      // Introduced in https://github.com/com-lihaoyi/mill/commit/451df6846861a9c7d265bffec0c5fcf07133b320
+      @unused offline: Boolean,
       checkGradleModules: Boolean
   ) {
 

--- a/libs/javalib/src/mill/javalib/Dependency.scala
+++ b/libs/javalib/src/mill/javalib/Dependency.scala
@@ -23,7 +23,6 @@ object Dependency extends ExternalModule {
         ev,
         Task.ctx(),
         ev.rootModule,
-        ev.rootModule.moduleCtx.discover,
         allowPreRelease
       )
     }

--- a/libs/javalib/src/mill/javalib/GenIdeaModule.scala
+++ b/libs/javalib/src/mill/javalib/GenIdeaModule.scala
@@ -24,13 +24,17 @@ trait GenIdeaModule extends Module with GenIdeaModuleApi {
    * @param ideaConfigVersion The IDEA configuration version in use. Probably `4`.
    * @return
    */
-  def ideaJavaModuleFacets(ideaConfigVersion: Int): Task[Seq[JavaFacet]] =
+  def ideaJavaModuleFacets(ideaConfigVersion: Int): Task[Seq[JavaFacet]] = {
+    val _ = ideaConfigVersion // silence unused, this is part of API
     Task.Anon { Seq[JavaFacet]() }
+  }
 
   /**
    * Contribute components to idea config files.
    */
-  def ideaConfigFiles(ideaConfigVersion: Int): Task[Seq[IdeaConfigFile]] =
+  def ideaConfigFiles(ideaConfigVersion: Int): Task[Seq[IdeaConfigFile]] = {
+    val _ = ideaConfigVersion // silence unused, this is part of API
     Task.Anon { Seq[IdeaConfigFile]() }
+  }
 
 }

--- a/libs/javalib/src/mill/javalib/OfflineSupportModule.scala
+++ b/libs/javalib/src/mill/javalib/OfflineSupportModule.scala
@@ -11,6 +11,8 @@ trait OfflineSupportModule extends mill.api.Module {
    * @param all If `true`, it also fetches resources not always needed.
    */
   def prepareOffline(all: Flag): Task.Command[Seq[PathRef]] = {
+    val _ = all // silence unused, this is used in the overrides
+
     val check = Task.Anon {
       if (Task.offline) {
         Task.log.warn("Running prepareOffline while in --offline mode is likely not what you want")

--- a/libs/javalib/src/mill/javalib/PublishModule.scala
+++ b/libs/javalib/src/mill/javalib/PublishModule.scala
@@ -629,7 +629,7 @@ trait PublishModule extends JavaModule { outer =>
       pom = pom().path,
       artifact = artifactMetadata(),
       publishInfos = publishInfos
-    )(new TaskCtx.Log {
+    )(using new TaskCtx.Log {
       // Silence logging for publishLocalTestRepo since it's very spammy during
       // development, and since it's all local we can just see the files on disk
       override def log: Logger = mill.api.Logger.DummyLogger

--- a/libs/javalib/src/mill/javalib/RunModule.scala
+++ b/libs/javalib/src/mill/javalib/RunModule.scala
@@ -1,7 +1,6 @@
 package mill.javalib
 
 import java.lang.reflect.Modifier
-
 import scala.util.control.NonFatal
 import mill.api.BuildCtx
 import mainargs.arg
@@ -313,6 +312,8 @@ object RunModule {
         runBackgroundLogToConsole: Boolean = false,
         propagateEnv: java.lang.Boolean = null
     )(implicit ctx: TaskCtx): Unit = {
+      val _ = propagateEnv // silence unused, this is used in the override
+
       run(
         args,
         mainClass,

--- a/libs/javalib/src/mill/javalib/SemanticDbJavaModule.scala
+++ b/libs/javalib/src/mill/javalib/SemanticDbJavaModule.scala
@@ -32,7 +32,7 @@ trait SemanticDbJavaModule extends CoursierModule with SemanticDbJavaModuleApi
       "SEMANTICDB_VERSION",
       SemanticDbJavaModuleApi.contextSemanticDbVersion.get().getOrElse(builtin)
     )
-    Version.chooseNewest(requested, builtin)(Version.IgnoreQualifierOrdering)
+    Version.chooseNewest(requested, builtin)(using Version.IgnoreQualifierOrdering)
   }
 
   def semanticDbJavaVersion: T[String] = Task.Input {
@@ -41,7 +41,7 @@ trait SemanticDbJavaModule extends CoursierModule with SemanticDbJavaModuleApi
       "JAVASEMANTICDB_VERSION",
       SemanticDbJavaModuleApi.contextJavaSemanticDbVersion.get().getOrElse(builtin)
     )
-    Version.chooseNewest(requested, builtin)(Version.IgnoreQualifierOrdering)
+    Version.chooseNewest(requested, builtin)(using Version.IgnoreQualifierOrdering)
   }
 
   def semanticDbScalaVersion: T[String] = BuildInfo.scalaVersion
@@ -206,7 +206,7 @@ object SemanticDbJavaModule extends ExternalModule with CoursierModule {
       else List.empty
 
     val isNewEnough =
-      Version.isAtLeast(semanticDbJavaVersion, "0.8.10")(Version.IgnoreQualifierOrdering)
+      Version.isAtLeast(semanticDbJavaVersion, "0.8.10")(using Version.IgnoreQualifierOrdering)
     val buildTool = s" -build-tool:${if (isNewEnough) "mill" else "sbt"}"
     val verbose = if (ctx.log.debugEnabled) " -verbose" else ""
     javacOptions ++ Seq(

--- a/libs/javalib/src/mill/javalib/TestModule.scala
+++ b/libs/javalib/src/mill/javalib/TestModule.scala
@@ -251,7 +251,6 @@ trait TestModule
         forkArgs(),
         globSelectors(),
         jvmWorker().scalalibClasspath(),
-        resources(),
         testFramework(),
         runClasspath(),
         testClasspath(),

--- a/libs/javalib/src/mill/javalib/TestModuleUtil.scala
+++ b/libs/javalib/src/mill/javalib/TestModuleUtil.scala
@@ -31,7 +31,6 @@ final class TestModuleUtil(
     forkArgs: Seq[String],
     selectors: Seq[String],
     scalalibClasspath: Seq[PathRef],
-    resources: Seq[PathRef],
     testFramework: String,
     runClasspath: Seq[PathRef],
     testClasspath: Seq[PathRef],

--- a/libs/javalib/src/mill/javalib/dependency/DependencyUpdatesImpl.scala
+++ b/libs/javalib/src/mill/javalib/dependency/DependencyUpdatesImpl.scala
@@ -11,7 +11,6 @@ object DependencyUpdatesImpl {
       evaluator: Evaluator,
       ctx: TaskCtx,
       rootModule: RootModule0,
-      discover: Discover,
       allowPreRelease: Boolean
   ): Seq[ModuleDependenciesUpdates] = {
 

--- a/libs/javalib/src/mill/javalib/spotless/Format.scala
+++ b/libs/javalib/src/mill/javalib/spotless/Format.scala
@@ -290,7 +290,7 @@ object Format {
     given ReadWriter[RelPathRef] =
       new Visitor.MapReader[Any, String, RelPathRef](readwriter[String])
         with ReadWriter[RelPathRef] {
-        def write0[V](out: Visitor[_, V], v: RelPathRef) =
+        def write0[V](out: Visitor[?, V], v: RelPathRef) =
           summon[ReadWriter[PathRef]].write0(out, v.ref)
         def mapNonNullsFunction(t: String) =
           if t.startsWith("ref:") then RelPathRef(upickle.default.read[PathRef](t))

--- a/libs/javalib/test/src/mill/javalib/HelloJavaTests.scala
+++ b/libs/javalib/test/src/mill/javalib/HelloJavaTests.scala
@@ -174,7 +174,7 @@ object HelloJavaTests extends TestSuite {
     test("test") - {
       testEval().scoped { eval =>
 
-        val Left(ExecResult.Failure(ref1)) =
+        val Left(ExecResult.Failure(_)) =
           eval.apply(HelloJava.core.test.testForked()): @unchecked
 
         //      assert(

--- a/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunner.scala
+++ b/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunner.scala
@@ -1,6 +1,5 @@
 package mill.javalib.testrunner
 
-import mill.api.TaskCtx
 import mill.api.daemon.internal.{TestReporter, internal}
 import mill.util.Jvm
 
@@ -13,7 +12,7 @@ import mill.util.Jvm
       args: Seq[String],
       testReporter: TestReporter,
       classFilter: Class[?] => Boolean = _ => true
-  )(implicit ctx: TaskCtx.Log): (String, Seq[TestResult]) = {
+  ): (String, Seq[TestResult]) = {
     Jvm.withClassLoader(
       classPath = entireClasspath.toVector,
       sharedPrefixes = Seq("sbt.testing.", "mill.api.daemon.internal.TestReporter")

--- a/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunnerUtils.scala
+++ b/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunnerUtils.scala
@@ -381,7 +381,8 @@ import scala.math.Ordering.Implicits.*
       cl: ClassLoader
   ): Array[String] = {
     val framework = frameworkInstances(cl)
-    val (runner, tasksArr) = getTestTasks(framework, args, classFilter, cl, testClassfilePath)
+    val ( /*runner*/ _, tasksArr) =
+      getTestTasks(framework, args, classFilter, cl, testClassfilePath)
     tasksArr.flatten.map(_.taskDef().fullyQualifiedName())
   }
 

--- a/libs/javalib/worker/src/mill/javalib/worker/JvmWorkerImpl.scala
+++ b/libs/javalib/worker/src/mill/javalib/worker/JvmWorkerImpl.scala
@@ -516,6 +516,7 @@ class JvmWorkerImpl(
       auxiliaryClassFileExtensions: Seq[String],
       zincCache: os.SubPath = os.sub / "zinc"
   )(implicit ctx: JvmWorkerApi.Ctx): Result[CompilationResult] = {
+    val _ = javaHome // unused for now
     import JvmWorkerImpl.{ForwardingReporter, TransformingReporter, PositionMapper}
 
     val requireReporter = ctx.env.get("MILL_JVM_WORKER_REQUIRE_REPORTER").contains("true")

--- a/libs/javascriptlib/src/mill/javascriptlib/TestModule.scala
+++ b/libs/javascriptlib/src/mill/javascriptlib/TestModule.scala
@@ -32,7 +32,10 @@ object TestModule {
 
     private[TestModule] def runCoverage: T[TestResult]
 
-    protected def coverageTask(args: Task[Seq[String]]): Task[TestResult] = Task { runCoverage() }
+    protected def coverageTask(args: Task[Seq[String]]): Task[TestResult] = Task {
+      val _ = args // silence unused parameter warning
+      runCoverage()
+    }
 
     def coverage(args: String*): Command[TestResult] =
       Task.Command {

--- a/libs/javascriptlib/src/mill/javascriptlib/TsLintModule.scala
+++ b/libs/javascriptlib/src/mill/javascriptlib/TsLintModule.scala
@@ -65,6 +65,8 @@ trait TsLintModule extends Module {
 
   // eslint
   def checkFormatEslint(args: mill.api.Args): Command[Unit] = Task.Command {
+    val _ = args // silence unused parameter warning
+
     resolvedFmtConfig() match {
       case Eslint =>
         val cwd = BuildCtx.workspaceRoot
@@ -109,6 +111,8 @@ trait TsLintModule extends Module {
   }
 
   def reformatEslint(args: mill.api.Args): Command[Unit] = Task.Command {
+    val _ = args // silence unused parameter warning, part of API
+
     resolvedFmtConfig() match {
       case Eslint =>
         val cwd = BuildCtx.workspaceRoot

--- a/libs/javascriptlib/src/mill/javascriptlib/TypeScriptModule.scala
+++ b/libs/javascriptlib/src/mill/javascriptlib/TypeScriptModule.scala
@@ -571,7 +571,6 @@ trait TypeScriptModule extends Module { outer =>
         .map {
           case (key, "") => Some(s"--$key")
           case (key, value) => Some(s"--$key=$value")
-          case _ => None
         }.toSeq ++ Seq(if (enableEsm()) Some("--loader") else None)).flatten
 
     val runnable: Shellable = (

--- a/libs/kotlinlib/package.mill
+++ b/libs/kotlinlib/package.mill
@@ -40,7 +40,7 @@ object `package` extends MillStableScalaModule with BuildInfo {
   )
 
   trait MillKotlinModule extends MillPublishScalaModule {
-    override def javacOptions = {
+    override def javacOptions = super.javacOptions() ++ {
       val release =
         if (scala.util.Properties.isJavaAtLeast(11)) Seq("-release", "8")
         else Seq("-source", "1.8", "-target", "1.8")

--- a/libs/pythonlib/test/src/mill/pythonlib/HelloWorldTests.scala
+++ b/libs/pythonlib/test/src/mill/pythonlib/HelloWorldTests.scala
@@ -30,7 +30,7 @@ object HelloWorldTests extends TestSuite {
       val baos = new ByteArrayOutputStream()
       UnitTester(HelloWorldPython, resourcePath, outStream = new PrintStream(baos)).scoped { eval =>
 
-        val Right(result) = eval.apply(HelloWorldPython.qux.run(Args())): @unchecked
+        val Right(_) = eval.apply(HelloWorldPython.qux.run(Args())): @unchecked
 
         assert(baos.toString().contains("Hello,  Qux!\n"))
       }

--- a/libs/pythonlib/test/src/mill/pythonlib/RunBackgroundTests.scala
+++ b/libs/pythonlib/test/src/mill/pythonlib/RunBackgroundTests.scala
@@ -21,7 +21,7 @@ object RunBackgroundTests extends TestSuite {
       UnitTester(HelloWorldPython, resourcePath).scoped { eval =>
 
         val lockedFile = os.temp()
-        val Right(result) =
+        val Right(_) =
           eval.apply(HelloWorldPython.foo.runBackground(Args(lockedFile))): @unchecked
         val maxSleep = 20000
         val now1 = System.currentTimeMillis()

--- a/libs/scalajslib/src/mill/scalajslib/api/JsEnvConfig.scala
+++ b/libs/scalajslib/src/mill/scalajslib/api/JsEnvConfig.scala
@@ -80,7 +80,7 @@ object JsEnvConfig {
     class ChromeOptions private (val headless: Boolean) extends Capabilities {
       def withHeadless(value: Boolean): Unit = copy(headless = value)
       private def copy(
-          headless: Boolean = this.headless
+          headless: Boolean
       ): ChromeOptions = new ChromeOptions(
         headless = headless
       )
@@ -94,7 +94,7 @@ object JsEnvConfig {
     class FirefoxOptions private (val headless: Boolean) extends Capabilities {
       def withHeadless(value: Boolean): Unit = copy(headless = value)
       private def copy(
-          headless: Boolean = this.headless
+          headless: Boolean
       ): FirefoxOptions = new FirefoxOptions(
         headless = headless
       )

--- a/libs/scalajslib/src/mill/scalajslib/worker/ScalaJSWorker.scala
+++ b/libs/scalajslib/src/mill/scalajslib/worker/ScalaJSWorker.scala
@@ -66,8 +66,8 @@ private[scalajslib] class ScalaJSWorker(jobs: Int)
     moduleSplitStyle match {
       case api.ModuleSplitStyle.FewestModules => workerApi.ModuleSplitStyle.FewestModules
       case api.ModuleSplitStyle.SmallestModules => workerApi.ModuleSplitStyle.SmallestModules
-      case api.ModuleSplitStyle.SmallModulesFor(packages) =>
-        workerApi.ModuleSplitStyle.SmallModulesFor(packages)
+      case api.ModuleSplitStyle.SmallModulesFor(packages*) =>
+        workerApi.ModuleSplitStyle.SmallModulesFor(packages*)
     }
 
   private def toWorkerApi(jsEnvConfig: api.JsEnvConfig): workerApi.JsEnvConfig = {

--- a/libs/scalalib/test/src/mill/scalalib/CoursierMirrorTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/CoursierMirrorTests.scala
@@ -21,7 +21,7 @@ object CoursierMirrorTests extends TestSuite {
 
   def tests: Tests = Tests {
     sys.props("coursier.mirrors") = (resourcePath / "mirror.properties").toString
-    test("readMirror") - UnitTester(CoursierTest, resourcePath).scoped { eval =>
+    test("readMirror") - UnitTester(CoursierTest, resourcePath).scoped { /*eval*/ _ =>
       // Doesn't pass when other tests are running before/after in the same JVM
       //      val Right(result) = eval.apply(CoursierTest.core.compileClasspath): @unchecked
       //      val cacheRoot = os.Path(FileCache().location)

--- a/libs/scalalib/test/src/mill/scalalib/CrossVersionTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/CrossVersionTests.scala
@@ -5,7 +5,6 @@ import mill.util.TokenReaders.*
 import mill.testkit.UnitTester
 import mill.testkit.TestRootModule
 import utest.*
-import utest.framework.TestPath
 
 object CrossVersionTests extends TestSuite {
 
@@ -132,12 +131,13 @@ object CrossVersionTests extends TestSuite {
 
   def check(
       mod: JavaModule,
+      // TODO review: unused, removed in https://github.com/com-lihaoyi/mill/commit/1d12ccb6a56b9840a926f6cba642e0098cafe5db#diff-497c3d3724a2d2e3daa4ec3b6965cd82799711327d26f609dee4cceb786b4805L151
       expectedDeps: Seq[String],
       expectedLibs: Seq[String],
       expectedMvnDepsTree: Option[String] = None
-  )(using
-      testPath: TestPath
   ) = {
+    val _ = expectedDeps
+
     init().scoped { eval =>
       val Right(result) = eval.apply(mod.showMvnDepsTree(MvnDepsTreeArgs())): @unchecked
 

--- a/libs/scalalib/test/src/mill/scalalib/TestRunnerParallelismTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/TestRunnerParallelismTests.scala
@@ -23,7 +23,7 @@ object TestRunnerParallelismTests extends TestSuite {
       os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "utestSingleTest"
     ).scoped { eval =>
       val Right(result) = eval.apply(utestSingleTest.testForked()): @unchecked
-      val (doneMsg @ _, results) = result.value
+      val (/*doneMsg*/ _, results) = result.value
       // Only one test should have been run
       assert(results.size == 1)
       // If we are actually running in serial mode (because there was only 1 group and 1 test case, so we disabled

--- a/libs/scalalib/test/src/mill/scalalib/spotless/SpotlessTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/spotless/SpotlessTests.scala
@@ -42,11 +42,11 @@ object SpotlessTests extends TestSuite {
         import module.moduleDir
 
         val numDirty = os.walk.stream(moduleDir / "src").filter(os.isFile).count()
-        val Left(_) = eval("spotless", "--check")
+        val Left(_) = eval("spotless", "--check"): @unchecked
         val log = logStream.toString()
         assert(log.contains(s"format errors in $numDirty files"))
 
-        val Right(_) = eval("spotless")
+        val Right(_) = eval("spotless"): @unchecked
         assert(diff(resources / "clean", moduleDir / "src") == 0)
       }
     }
@@ -58,7 +58,7 @@ object SpotlessTests extends TestSuite {
       UnitTester(module, resources / "suppress", errStream = errStream).scoped { eval =>
         import module.moduleDir
 
-        val Left(_) = eval("spotless")
+        val Left(_) = eval("spotless"): @unchecked
         var log = logStream.toString
         val lints = Seq(
           "Diktat.kt:L12 diktat(diktat-ruleset:debug-print) [DEBUG_PRINT] use a dedicated logging library: found println()",
@@ -71,7 +71,7 @@ object SpotlessTests extends TestSuite {
           _.map(_.copy(suppressions = Seq(Format.Suppress(step = "ktlint"))))
         )
         logStream.reset()
-        val Left(_) = eval("spotless")
+        val Left(_) = eval("spotless"): @unchecked
         log = logStream.toString
         for lint <- lints.take(2) do assert(log.contains(lint))
         assert(
@@ -83,7 +83,7 @@ object SpotlessTests extends TestSuite {
         updateFormats(moduleDir)(
           _.map(_.copy(suppressions = Seq(Format.Suppress()))) // suppress all
         )
-        val Right(_) = eval("spotless")
+        val Right(_) = eval("spotless"): @unchecked
       }
     }
 
@@ -94,7 +94,7 @@ object SpotlessTests extends TestSuite {
       UnitTester(module, resources / "invalidation", errStream = errStream).scoped { eval =>
         import module.moduleDir
 
-        val Right(_) = eval("spotless")
+        val Right(_) = eval("spotless"): @unchecked
         var log = logStream.toString
         var header = os.read.lines.stream(moduleDir / "src/LicenseHeader").head
         assert(
@@ -131,7 +131,7 @@ object SpotlessTests extends TestSuite {
         call("git", "add", ".gitignore", legacy)
         call("git", "commit", "-m", "0") // minimum 1 commit required
 
-        val Right(_) = eval("ratchet")
+        val Right(_) = eval("ratchet"): @unchecked
         var log = logStream.toString
         assert(log.contains("ratchet found no changes"))
 
@@ -144,7 +144,7 @@ object SpotlessTests extends TestSuite {
 
         call("git", "add", "--all")
         logStream.reset()
-        val Right(_) = eval("ratchet", "--staged")
+        val Right(_) = eval("ratchet", "--staged"): @unchecked
         log = logStream.toString
         assert(
           log.contains(s"ratchet found changes in ${patch.length} files"),
@@ -159,7 +159,7 @@ object SpotlessTests extends TestSuite {
         call("git", "add", "--all") // re-stage formatted files
         call("git", "commit", "-m", "1")
         logStream.reset()
-        val Right(_) = eval("ratchet", "HEAD^", "HEAD")
+        val Right(_) = eval("ratchet", "HEAD^", "HEAD"): @unchecked
         log = logStream.toString
         assert(
           log.contains(s"ratchet found changes in ${patch.length} files"),
@@ -173,7 +173,7 @@ object SpotlessTests extends TestSuite {
         os.move(patch(2), pkg / patch(2).last) // ChangeType.RENAME
         os.copy(patch(3), pkg / patch(3).last) // ChangeType.COPY
         logStream.reset()
-        val Right(_) = eval("ratchet")
+        val Right(_) = eval("ratchet"): @unchecked
         log = logStream.toString
         assert(
           log.contains("ratchet found changes in 3 files"), // DELETE is ignored
@@ -190,7 +190,7 @@ object SpotlessTests extends TestSuite {
       val logStream = ByteArrayOutputStream()
       val errStream = PrintStream(logStream, true)
       UnitTester(rootModule, resources / "multiModule", errStream = errStream).scoped { eval =>
-        val Left(_) = eval("spotless", "--check")
+        val Left(_) = eval("spotless", "--check"): @unchecked
         var log = logStream.toString
         assert(
           log.contains("format errors in bar/src/bar/Bar.scala"),
@@ -199,7 +199,7 @@ object SpotlessTests extends TestSuite {
         )
 
         logStream.reset()
-        val Right(_) = eval("spotless")
+        val Right(_) = eval("spotless"): @unchecked
         log = logStream.toString
         assert(
           log.contains("formatting bar/src/bar/Bar.scala"),
@@ -213,7 +213,7 @@ object SpotlessTests extends TestSuite {
       val logStream = ByteArrayOutputStream()
       val errStream = PrintStream(logStream, true)
       UnitTester(nestedModule, resources / "multiModule", errStream = errStream).scoped { eval =>
-        val Left(_) = eval("bar.spotless", "--check")
+        val Left(_) = eval("bar.spotless", "--check"): @unchecked
         var log = logStream.toString
         assert(
           log.contains("format errors in src/bar/Bar.scala"),
@@ -221,7 +221,7 @@ object SpotlessTests extends TestSuite {
         )
 
         logStream.reset()
-        val Left(_) = eval("foo.spotless", "--check")
+        val Left(_) = eval("foo.spotless", "--check"): @unchecked
         log = logStream.toString
         assert(
           log.contains("format errors in src/foo/Foo.java"),
@@ -229,7 +229,7 @@ object SpotlessTests extends TestSuite {
         )
 
         logStream.reset()
-        val Right(_) = eval("__.spotless")
+        val Right(_) = eval("__.spotless"): @unchecked
         log = logStream.toString
         assert(
           log.contains("formatting src/bar/Bar.scala"),

--- a/libs/scalalib/test/src/mill/scalalib/spotless/SpotlessTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/spotless/SpotlessTests.scala
@@ -95,8 +95,8 @@ object SpotlessTests extends TestSuite {
         import module.moduleDir
 
         val Right(_) = eval("spotless"): @unchecked
-        var log = logStream.toString
-        var header = os.read.lines.stream(moduleDir / "src/LicenseHeader").head
+        val log = logStream.toString
+        val header = os.read.lines.stream(moduleDir / "src/LicenseHeader").head
         assert(
           log.contains("formatting src/LicenseHeader"),
           header == "// GPL"

--- a/libs/tabcomplete/src/mill/tabcomplete/TabCompleteModule.scala
+++ b/libs/tabcomplete/src/mill/tabcomplete/TabCompleteModule.scala
@@ -75,6 +75,7 @@ private object TabCompleteModule extends ExternalModule {
               val remaining = group(taskArgs, ep.flattenedArgSigs, false) match {
                 case mainargs.Result.Success(grouping) => grouping.remaining
                 case r: mainargs.Result.Failure.MismatchedArguments => r.unknown
+                case other => throw Exception(s"Unexpected result: $other")
               }
 
               val commandParsedArgCount = v.remaining.length - remaining.length - 1
@@ -221,6 +222,7 @@ private object TabCompleteModule extends ExternalModule {
           case Some('[') => trimmed + "__]"
           case Some(',') => trimmed + "__]"
           case Some(']') => trimmed + "._"
+          case Some(other) => throw Exception(s"Unexpected char: $other")
         }
 
         (query, Some(unescaped))

--- a/libs/tabcomplete/src/mill/tabcomplete/TabCompleteModule.scala
+++ b/libs/tabcomplete/src/mill/tabcomplete/TabCompleteModule.scala
@@ -11,7 +11,7 @@ import mill.api.internal.Resolved
  * Handles Bash and Zsh tab completions, which provide an array of tokens in the current
  * shell and the index of the token currently being completed.
  */
-private[this] object TabCompleteModule extends ExternalModule {
+private object TabCompleteModule extends ExternalModule {
 
   lazy val millDiscover = Discover[this.type]
 
@@ -26,7 +26,7 @@ private[this] object TabCompleteModule extends ExternalModule {
     val args = args0.value
     def group(
         tokens: Seq[String],
-        flattenedArgSigs: Seq[(ArgSig, TokensReader.Terminal[_])],
+        flattenedArgSigs: Seq[(ArgSig, TokensReader.Terminal[?])],
         allowLeftover: Boolean
     ) = {
       mainargs.TokenGrouping.groupArgs(
@@ -56,7 +56,7 @@ private[this] object TabCompleteModule extends ExternalModule {
             val entrypointOpt = resolved match {
               case _: Result.Failure => None
               case Result.Success(ts) =>
-                val entryPoints: Seq[mainargs.MainData[_, _]] = ts.flatMap { t =>
+                val entryPoints: Seq[mainargs.MainData[?, ?]] = ts.flatMap { t =>
                   ev
                     .rootModule
                     .moduleCtx
@@ -134,7 +134,7 @@ private[this] object TabCompleteModule extends ExternalModule {
     res.foreach(println)
   }
 
-  def flattenSigs(ep: mainargs.MainData[_, _]) = ep.flattenedArgSigs.map(_._1)
+  def flattenSigs(ep: mainargs.MainData[?, ?]) = ep.flattenedArgSigs.map(_._1)
 
   def findMatchingArgs(
       stringOpt: Option[String],

--- a/libs/tabcomplete/test/src/mill/tabcomplete/TabCompleteTests.scala
+++ b/libs/tabcomplete/test/src/mill/tabcomplete/TabCompleteTests.scala
@@ -7,20 +7,21 @@ import mill.testkit.TestRootModule
 import utest.*
 
 import java.io.{ByteArrayOutputStream, PrintStream}
+import scala.annotation.unused
 
 object TabCompleteTests extends TestSuite {
   object mainModule extends TestRootModule {
     lazy val millDiscover = Discover[this.type]
-    def task1(argA: String = "", argB2: Int = 0) = Task.Command { 123 }
+    def task1(@unused argA: String = "", @unused argB2: Int = 0) = Task.Command { 123 }
     object foo extends Module
     object bar extends Module {
       def task2(
-          @mainargs.arg(doc = "arg a 3 docs") argA3: String,
-          @mainargs.arg(doc = "arg b 4 docs") argB4: Int
+          @mainargs.arg(doc = "arg a 3 docs") @unused argA3: String,
+          @mainargs.arg(doc = "arg b 4 docs") @unused argB4: Int
       ) = Task.Command { 456 }
       def taskPositional(
-          @mainargs.arg(positional = true) argA3: String,
-          @mainargs.arg(positional = true) argB4: Int
+          @mainargs.arg(positional = true) @unused argA3: String,
+          @mainargs.arg(positional = true) @unused argB4: Int
       ) = Task.Command { 456 }
 
     }

--- a/libs/util/src/mill/util/RefCountedClassLoaderCache.scala
+++ b/libs/util/src/mill/util/RefCountedClassLoaderCache.scala
@@ -49,7 +49,7 @@ class RefCountedClassLoaderCache(
           parent = parent,
           sharedLoader = sharedLoader,
           sharedPrefixes = sharedPrefixes
-        )(e)
+        )(using e)
         cache.update(compilersSig, (cl, 1))
         cl
     }

--- a/libs/util/src/mill/util/Retry.scala
+++ b/libs/util/src/mill/util/Retry.scala
@@ -35,7 +35,7 @@ case class Retry(
 ) {
 
   def apply[T](t: => T): T = {
-    indexed(i => t)
+    indexed(_ => t)
   }
 
   def indexed[T](t: Int => T): T = {

--- a/libs/util/src/mill/util/Secret.scala
+++ b/libs/util/src/mill/util/Secret.scala
@@ -8,7 +8,7 @@ package mill.util
 class Secret[+A](val value: A) {
   override def toString: String = "<REDACTED>"
 
-  private def canEqual(other: Any): Boolean = other.isInstanceOf[Secret[_]]
+  private def canEqual(other: Any): Boolean = other.isInstanceOf[Secret[?]]
 
   override def equals(other: Any): Boolean = other match {
     case that: Secret[_] => that.canEqual(this) && value == that.value

--- a/libs/util/src/mill/util/Version.scala
+++ b/libs/util/src/mill/util/Version.scala
@@ -35,16 +35,16 @@ class Version private (
 
 final class MavenVersion(val underlying: Version) extends AnyVal {
   def isNewerThan(other: MavenVersion): Boolean = {
-    underlying.isNewerThan(other.underlying)(Version.MavenOrdering)
+    underlying.isNewerThan(other.underlying)(using Version.MavenOrdering)
   }
 }
 final class OsgiVersion(val underlying: Version) extends AnyVal {
   def isNewerThan(other: OsgiVersion): Boolean =
-    underlying.isNewerThan(other.underlying)(Version.OsgiOrdering)
+    underlying.isNewerThan(other.underlying)(using Version.OsgiOrdering)
 }
 final class IgnoreQualifierVersion(val underlying: Version) extends AnyVal {
   def isNewerThan(other: IgnoreQualifierVersion): Boolean =
-    underlying.isNewerThan(other.underlying)(Version.IgnoreQualifierOrdering)
+    underlying.isNewerThan(other.underlying)(using Version.IgnoreQualifierOrdering)
 }
 
 @experimental

--- a/mill-build/src/millbuild/MillJavaModule.scala
+++ b/mill-build/src/millbuild/MillJavaModule.scala
@@ -93,6 +93,13 @@ trait MillJavaModule extends JavaModule {
     Deps.jna
   )
 
+  override def javacOptions = super.javacOptions() ++ Seq(
+    "-Werror",
+    "-Xlint",
+    "-Xlint:-serial", // we don't care about java serialization
+    "-Xlint:-try" // TODO: a bunch of code needs reviewing with this lint
+  )
+
   def javadocOptions = super.javadocOptions() ++ Seq(
     // Disable warnings for missing documentation comments or tags (for example,
     // a missing comment or class, or a missing @return tag or similar tag on a method).

--- a/mill-build/src/millbuild/MillPublishJavaModule.scala
+++ b/mill-build/src/millbuild/MillPublishJavaModule.scala
@@ -25,7 +25,7 @@ trait MillPublishJavaModule extends MillJavaModule with PublishModule {
     "info.releaseNotesURL" -> Settings.changelogUrl
   )
   def pomSettings = MillPublishJavaModule.commonPomSettings(artifactName())
-  def javacOptions = Seq("-source", "11", "-target", "11", "-encoding", "UTF-8")
+  def javacOptions = super.javacOptions() ++ Seq("-source", "11", "-target", "11", "-encoding", "UTF-8")
 }
 
 object MillPublishJavaModule {

--- a/mill-build/src/millbuild/MillScalaModule.scala
+++ b/mill-build/src/millbuild/MillScalaModule.scala
@@ -28,7 +28,7 @@ trait MillScalaModule extends ScalaModule with MillJavaModule with ScalafixModul
       "-feature"
     ) ++ (
       if (JvmWorkerUtil.isScala3(scalaVersion())) Seq(
-        // "-Werror",
+        "-Werror",
         "-Wunused:all",
         // "-Xfatal-warnings",
         "-Wconf:msg=An existential type that came from a Scala-2 classfile:silent",
@@ -47,7 +47,7 @@ trait MillScalaModule extends ScalaModule with MillJavaModule with ScalafixModul
       )
       else Seq(
         "-P:acyclic:force",
-        // "-Xfatal-warnings",
+        "-Xfatal-warnings",
         "-Xlint:unused",
         "-Xlint:adapted-args",
         "-Xsource:3",

--- a/mill-build/src/millbuild/MillScalaModule.scala
+++ b/mill-build/src/millbuild/MillScalaModule.scala
@@ -43,7 +43,7 @@ trait MillScalaModule extends ScalaModule with MillJavaModule with ScalafixModul
         // "-Wsafe-init",
         // "-Wnonunit-statement",
         // "-Wimplausible-patterns",
-        // "-rewrite", "-source", "3.6-migration"
+        // "-rewrite", "-source", "3.7-migration"
       )
       else Seq(
         "-P:acyclic:force",

--- a/runner/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/runner/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -12,9 +12,9 @@ import mill.api.internal.WatchSig
 import mill.internal.PrefixLogger
 import mill.server.Server
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest
+
 import java.util.concurrent.{CompletableFuture, ConcurrentHashMap, LinkedBlockingQueue, TimeUnit}
 import java.util.concurrent.atomic.AtomicInteger
-
 import scala.collection.mutable
 import scala.concurrent.{Await, Promise}
 import scala.concurrent.duration.Duration
@@ -22,7 +22,6 @@ import scala.jdk.CollectionConverters.*
 import scala.util.chaining.scalaUtilChainingOps
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
-
 import mill.api.daemon.internal.bsp.{
   BspModuleApi,
   BspServerResult,
@@ -30,6 +29,8 @@ import mill.api.daemon.internal.bsp.{
   ScalaBuildTarget
 }
 import mill.api.daemon.internal.*
+
+import scala.annotation.unused
 
 private class MillBuildServer(
     topLevelProjectRoot: os.Path,
@@ -989,12 +990,12 @@ private class MillBuildServer(
 
   private def evaluate(
       evaluator: EvaluatorApi,
-      requestDescription: String,
+      @unused requestDescription: String,
       goals: Seq[TaskApi[?]],
       logger: Logger,
       reporter: Int => Option[CompileProblemReporter],
       testReporter: TestReporter = TestReporter.DummyTestReporter,
-      errorOpt: EvaluatorApi.Result[Any] => Option[String] = evaluatorErrorOpt(_)
+      errorOpt: EvaluatorApi.Result[Any] => Option[String] = evaluatorErrorOpt
   ): ExecutionResultsApi = {
     val goalCount = goals.length
     logger.info(s"Evaluating $goalCount ${if (goalCount > 1) "tasks" else "task"}")

--- a/runner/client/src/mill/client/FileToStreamTailer.java
+++ b/runner/client/src/mill/client/FileToStreamTailer.java
@@ -97,7 +97,7 @@ public class FileToStreamTailer extends Thread implements AutoCloseable {
   }
 
   @Override
-  public void close() throws Exception {
+  public void close() {
     flush();
     interrupt();
   }

--- a/runner/codesig/src/mill/codesig/ExternalSummary.scala
+++ b/runner/codesig/src/mill/codesig/ExternalSummary.scala
@@ -51,7 +51,7 @@ object ExternalSummary {
       def load0(cls: JCls): Unit = {
         val visitor = new MyClassVisitor()
         val resourcePath =
-          os.resource(upstreamClassloader) / os.SubPath(cls.name.replace('.', '/') + ".class")
+          os.resource(using upstreamClassloader) / os.SubPath(cls.name.replace('.', '/') + ".class")
 
         new ClassReader(os.read.inputStream(resourcePath)).accept(
           visitor,

--- a/runner/codesig/src/mill/codesig/LocalSummary.scala
+++ b/runner/codesig/src/mill/codesig/LocalSummary.scala
@@ -41,7 +41,7 @@ object LocalSummary {
       isAbstract: Boolean
   )
   object MethodInfo {
-    given rw(using SymbolTable): ReadWriter[MethodInfo] = macroRW
+    given rw: ReadWriter[MethodInfo] = macroRW
   }
 
   implicit def rw(implicit st: SymbolTable): ReadWriter[LocalSummary] = macroRW

--- a/runner/codesig/test/cases/callgraph/complicated/13-iterator-inherit-external-filter-scala/src/Hello.scala
+++ b/runner/codesig/test/cases/callgraph/complicated/13-iterator-inherit-external-filter-scala/src/Hello.scala
@@ -22,8 +22,8 @@ object Hello {
 
   class FilterBigTestIterator[A](parent: BigTestIterator[A], pred: A => Boolean)
       extends BigTestIterator[A] {
-    private[this] var hd: A = _
-    private[this] var hdDefined: Boolean = false
+    private var hd: A = compiletime.uninitialized
+    private var hdDefined: Boolean = false
 
     def hasNext: Boolean = hdDefined || {
       while ({

--- a/runner/codesig/test/cases/callgraph/realistic/3-par-merge-sort/src/Hello.scala
+++ b/runner/codesig/test/cases/callgraph/realistic/3-par-merge-sort/src/Hello.scala
@@ -41,6 +41,7 @@ object Main {
         case (true, false) => true
         case (false, true) => false
         case (true, true) => Ordering[T].lt(sortedLeft(leftIdx), sortedRight(rightIdx))
+        case (false, false) => throw Exception("impossible")
       }
       if (takeLeft) {
         output += sortedLeft(leftIdx)

--- a/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
+++ b/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
@@ -132,7 +132,7 @@ class MillBuildBootstrap(
             else {
               val bootstrapModule =
                 new MillBuildRootModule.BootstrapModule()(
-                  new RootModule.Info(currentRoot, output, projectRoot)
+                  using new RootModule.Info(currentRoot, output, projectRoot)
                 )
               RunnerState(Some(bootstrapModule), Nil, None, Some(parsedScriptFiles.buildFile))
             }

--- a/runner/daemon/src/mill/daemon/MillScalaParserImpl.scala
+++ b/runner/daemon/src/mill/daemon/MillScalaParserImpl.scala
@@ -318,7 +318,7 @@ object MillScalaParserImpl extends MillScalaParser {
     buf.result()
   }
 
-  private def validSpan(sourcePos: SourcePosition)(using Context): Boolean =
+  private def validSpan(sourcePos: SourcePosition): Boolean =
     sourcePos.span.exists && !sourcePos.span.isSynthetic
 
   private def slice(start: Int, end: Int)(using Context): String =

--- a/runner/daemon/src/mill/daemon/Watching.scala
+++ b/runner/daemon/src/mill/daemon/Watching.scala
@@ -214,13 +214,14 @@ object Watching {
           if (alreadyStale) None
           else doWatch(notifiablesChanged = () => pathChangesDetected)
         }
-      }(using closable =>
-        try closable.close()
-        catch {
-          case e: java.io.IOException =>
-          // Not sure why this happens, but if it does happen it probably means the
-          // file handle has already been closed, so just continue on without crashing
-        }
+      }(using
+        closable =>
+          try closable.close()
+          catch {
+            case _: java.io.IOException =>
+            // Not sure why this happens, but if it does happen it probably means the
+            // file handle has already been closed, so just continue on without crashing
+          }
       )
     }
 

--- a/runner/daemon/src/mill/daemon/Watching.scala
+++ b/runner/daemon/src/mill/daemon/Watching.scala
@@ -214,7 +214,7 @@ object Watching {
           if (alreadyStale) None
           else doWatch(notifiablesChanged = () => pathChangesDetected)
         }
-      }(closable =>
+      }(using closable =>
         try closable.close()
         catch {
           case e: java.io.IOException =>

--- a/runner/idea/src/mill/idea/GenIdeaImpl.scala
+++ b/runner/idea/src/mill/idea/GenIdeaImpl.scala
@@ -631,6 +631,8 @@ class GenIdeaImpl(
       compilerBridgeJar: Option[os.Path],
       scaladocExtraClasspath: Seq[os.Path]
   ): Elem = {
+    val _ = scaladocExtraClasspath // unused for now
+
     <component name="libraryTable">
       <library name={name} type="Scala">
         <properties>

--- a/runner/launcher/src/mill/launcher/JLineNativeLoader.java
+++ b/runner/launcher/src/mill/launcher/JLineNativeLoader.java
@@ -137,7 +137,7 @@ final class JLineNativeLoader {
 
     System.load(loader.millJLineNativeLibLocation.toString());
 
-    Class cls = org.jline.nativ.JLineNativeLoader.class;
+    var cls = org.jline.nativ.JLineNativeLoader.class;
     java.lang.reflect.Field fld;
     try {
       fld = cls.getDeclaredField("loaded");

--- a/runner/launcher/src/mill/launcher/MillProcessLauncher.java
+++ b/runner/launcher/src/mill/launcher/MillProcessLauncher.java
@@ -122,11 +122,11 @@ public class MillProcessLauncher {
                 Object conf = mill.launcher.ConfigReader.readYaml(
                     buildFile, buildFile.getFileName().toString());
                 if (!(conf instanceof Map)) return new String[] {};
-                Map<String, Object> conf2 = (Map<String, Object>) conf;
+                @SuppressWarnings("unchecked") var conf2 = (Map<String, Object>) conf;
 
                 if (!conf2.containsKey(key)) return new String[] {};
                 if (conf2.get(key) instanceof List) {
-                  List<String> list = (List<String>) conf2.get(key);
+                  @SuppressWarnings("unchecked") var list = (List<String>) conf2.get(key);
                   String[] arr = new String[list.size()];
                   for (int i = 0; i < arr.length; i++) {
                     arr[i] = mill.constants.Util.interpolateEnvVars(list.get(i), env);
@@ -299,7 +299,7 @@ public class MillProcessLauncher {
     return Integer.parseInt(new String(proc.getInputStream().readAllBytes()).trim());
   }
 
-  private static AtomicReference<String> memoizedTerminalDims = new AtomicReference();
+  private static final AtomicReference<String> memoizedTerminalDims = new AtomicReference<>();
 
   private static final boolean canUseNativeTerminal;
 

--- a/runner/meta/src/mill/meta/FileImportGraph.scala
+++ b/runner/meta/src/mill/meta/FileImportGraph.scala
@@ -130,13 +130,13 @@ object FileImportGraph {
         (false, multiple.head)
     }
 
-    (dummy, foundRootBuildFileName)
+    (dummy = dummy, foundRootBuildFileName = foundRootBuildFileName)
   }
 
   def walkBuildFiles(projectRoot: os.Path, output: os.Path): Seq[os.Path] = {
     if (!os.exists(projectRoot)) Nil
     else {
-      val (dummy, foundRootBuildFileName) = findRootBuildFiles(projectRoot)
+      val foundRootBuildFileName = findRootBuildFiles(projectRoot).foundRootBuildFileName
 
       val buildFileExtension =
         buildFileExtensions.asScala.find(ex => foundRootBuildFileName.endsWith(s".$ex")).get

--- a/testkit/src/mill/testkit/TestBaseModule.scala
+++ b/testkit/src/mill/testkit/TestBaseModule.scala
@@ -12,7 +12,7 @@ abstract class TestRootModule(
     millModuleLine0: sourcecode.Line,
     millModuleFile0: sourcecode.File
 ) extends RootModule0(millSourcePath0 = baseModuleSourcePath)(
-      millModuleEnclosing0,
+      using millModuleEnclosing0,
       millModuleLine0,
       millModuleFile0
     ) {

--- a/testkit/src/mill/testkit/UnitTester.scala
+++ b/testkit/src/mill/testkit/UnitTester.scala
@@ -17,6 +17,7 @@ import mill.resolve.Resolve
 import java.io.InputStream
 import java.io.PrintStream
 import java.util.concurrent.ThreadPoolExecutor
+import scala.annotation.targetName
 
 object UnitTester {
   case class Result[T](value: T, evalCount: Int)
@@ -165,9 +166,9 @@ class UnitTester(
     }
   }
 
+  @targetName("applyTasks")
   def apply(
-      tasks: Seq[Task[?]],
-      dummy: DummyImplicit = null
+      tasks: Seq[Task[?]]
   ): Either[ExecResult.Failing[?], UnitTester.Result[Seq[?]]] = {
 
     val evaluated = evaluator.execute(tasks).executionResults


### PR DESCRIPTION
Goes through the codebase and fixes it so that there wouldn't be any compilation warnings.

Enables `javac` linting.

Makes warnings fatal when building in CI.

Note: we should review `TODO review` comments and decide what should be done with them.