### PR TITLE
Android: ManifestMerger bugfixes

### DIFF
--- a/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
@@ -87,24 +87,6 @@ trait AndroidAppModule extends AndroidModule { outer =>
   }
 
   /**
-   * Provides os.Path to an XML file containing configuration and metadata about your android application.
-   * TODO dynamically add android:debuggable
-   */
-  override def androidManifest: T[PathRef] = Task {
-    val manifestFromSourcePath = androidManifestLocation().path
-
-    val manifestElem = XML.loadFile(manifestFromSourcePath.toString())
-    // add the application package
-    val manifestWithPackage =
-      manifestElem % Attribute(None, "package", Text(androidNamespace), Null)
-
-    val generatedManifestPath = Task.dest / "AndroidManifest.xml"
-    os.write(generatedManifestPath, manifestWithPackage.mkString)
-
-    PathRef(generatedManifestPath)
-  }
-
-  /**
    * Specifies the file format(s) of the lint report. Available file formats are defined in AndroidLintReportFormat,
    * such as [[AndroidLintReportFormat.Html]], [[AndroidLintReportFormat.Xml]], [[AndroidLintReportFormat.Txt]],
    * and [[AndroidLintReportFormat.Sarif]].

--- a/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
@@ -275,7 +275,7 @@ trait AndroidAppModule extends AndroidModule { outer =>
     debugManifest ++ libManifests
   }
 
-  override def androidMergedManifestArgs: Task[Seq[String]] = Task {
+  override def androidMergedManifestArgs: Task[Seq[String]] = Task.Anon {
     Seq(
       "--main",
       androidManifest().path.toString(),
@@ -982,7 +982,7 @@ trait AndroidAppModule extends AndroidModule { outer =>
      *
      * See [[https://developer.android.com/build/manage-manifests]] for more details.
      */
-    override def androidMergedManifestArgs: Task[Seq[String]] = Task {
+    override def androidMergedManifestArgs: Task[Seq[String]] = Task.Anon {
       Seq(
         "--main",
         androidManifest().path.toString(),

--- a/libs/androidlib/src/mill/androidlib/AndroidModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidModule.scala
@@ -344,7 +344,7 @@ trait AndroidModule extends JavaModule {
     androidUnpackArchives().flatMap(_.manifest)
   }
 
-  def androidMergedManifestArgs: Task[Seq[String]] = Task {
+  def androidMergedManifestArgs: Task[Seq[String]] = Task.Anon {
     Seq(
       "--main",
       androidManifest().path.toString(),

--- a/libs/androidlib/src/mill/androidlib/AndroidModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidModule.scala
@@ -55,8 +55,19 @@ trait AndroidModule extends JavaModule {
   def androidManifest: T[PathRef] = Task {
     val manifestFromSourcePath = androidManifestLocation().path
 
-    val manifestElem = XML.loadFile(manifestFromSourcePath.toString()) %
-      Attribute(None, "xmlns:android", Text("http://schemas.android.com/apk/res/android"), Null)
+    val original = XML.loadFile(manifestFromSourcePath.toString())
+
+    val manifestElem = Option(original.scope.getURI("android")) match {
+      case Some(_) =>
+        original
+      case None =>
+        original % Attribute(
+          None,
+          "xmlns:android",
+          Text("http://schemas.android.com/apk/res/android"),
+          Null
+        )
+    }
     // add the application package
     val manifestWithPackage =
       manifestElem % Attribute(None, "package", Text(androidNamespace), Null)


### PR DESCRIPTION
Fixes some issues of ManifestMerger as mentioned in https://github.com/com-lihaoyi/mill/issues/5654.

> - Android manifest merge cache does not seem to be invalidated when the manifest file changes
> - Android manifest merge fails if `xmlns:android="http://schemas.android.com/apk/res/android"` property already exists
> 