### PR TITLE
Improve selective testing for `dist.scripts` and  use current version as default

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -29,10 +29,6 @@ import mill.androidlib.AndroidSdkModule
 def millVersionIsStable0(implicit ctx: mill.api.TaskCtx) = ctx.env.contains("MILL_STABLE_VERSION")
 def millVersionIsStable: T[Boolean] = Task.Input { millVersionIsStable0 }
 
-def millVersionTruth: T[VcsVersion.State] = Task.Input {
-  VcsVersion.calcVcsState(Task.log)
-}
-
 def millVersion: T[String] = Task.Input {
   if (millVersionIsStable0) {
     val vcsState = VcsVersion.calcVcsState(Task.log)

--- a/dist/scripts/package.mill
+++ b/dist/scripts/package.mill
@@ -15,10 +15,9 @@ object `package` extends mill.Module { scripts =>
     def templateFile: T[PathRef]
     def finalName: T[String]
     def substitutions: T[Map[String, String]] = Map(
-      "mill-version" -> build.millVersionTruth().format(),
+      "mill-version" -> build.millVersion(),
       "mill-repo-url" -> Settings.projectUrl,
       "mill-maven-url" -> Settings.mavenRepoUrl,
-      "mill-best-version" -> "0.12.10", // TODO: build.millVersionTruth()
       "mill-download-cache-unix" -> "~/.cache/mill/download",
       "mill-download-cache-win" -> "%USERPROFILE%\\\\.mill\\\\download",
       "template-file" -> templateFile().path.relativeTo(BuildCtx.workspaceRoot).toString

--- a/dist/scripts/src/mill.bat
+++ b/dist/scripts/src/mill.bat
@@ -34,7 +34,7 @@ rem setlocal seems to be unavailable on Windows 95/98/ME
 rem but I don't think we need to support them in 2019
 setlocal enabledelayedexpansion
 
-if [!DEFAULT_MILL_VERSION!]==[] ( set "DEFAULT_MILL_VERSION={{{ mill-best-version }}}" )
+if [!DEFAULT_MILL_VERSION!]==[] ( set "DEFAULT_MILL_VERSION={{{ mill-version }}}" )
 
 if [!MILL_GITHUB_RELEASE_CDN!]==[] ( set "MILL_GITHUB_RELEASE_CDN=" )
 

--- a/dist/scripts/src/mill.sh
+++ b/dist/scripts/src/mill.sh
@@ -33,7 +33,7 @@
 set -e
 
 if [ -z "${DEFAULT_MILL_VERSION}" ] ; then
-  DEFAULT_MILL_VERSION="{{{ mill-best-version }}}"
+  DEFAULT_MILL_VERSION="{{{ mill-version }}}"
 fi
 
 


### PR DESCRIPTION
* We shouldn't use `millVersionTruth` because that causes selective testing invalidation regardless of code changes, instead we should use `millVersion`

* We don't need separate `mill-version` and `mill-best-version` substitute, just have a single `mill-version`