### PR TITLE
Slight format fixes for latest blog post and other pages

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -30,8 +30,9 @@ _2025-08-05_
    Mill also now displays the description for flags and tasks that get tab completed
    ({link-pr}/5648[#5648], {link-pr}/5650[#5650]). Note that these improvements require
    you to re-run `./mill mill.tabcomplete/install` to activate
-
-```
++
+[,console]
+----
 $ ./mill -<tab>
 -D  <k=v> Define (or overwrite) a system property.
 -b  Ring the bell once if the run completes successfully, twice if it fails.
@@ -49,8 +50,7 @@ core.eval       This folder contains the core evaluator logic for the Mill build
 core.exec       This module contains code related to planning and execution of the Mill
 core.internal   This package contains internal helpers and utilities used throughout
 core.resolve    This module contains logic around resolving Mill command line
-```
-
+----
 
 
 * Add a generator for Eclipse JDT project files ({link-pr}/5614[#5614]). This can be run
@@ -201,16 +201,20 @@ script in order to work, due to changes in the Sonatype Central package registry
 forced a change in the download URLs for new releases going forward. To update your
 bootstrap script, you can use:
 +
-```
-# linux
-curl -L https://repo1.maven.org/maven2/com/lihaoyi/mill-dist/1.0.0/mill-dist-1.0.0-mill.sh -o mill
-chmod +x mill
-echo 1.0.0 > .mill-version
-
-# windows
-curl -L https://repo1.maven.org/maven2/com/lihaoyi/mill-dist/1.0.0/mill-dist-1.0.0-mill.bat -o mill.bat
-echo 1.0.0 > .mill-version
-```
+.Linux
+[,console]
+----
+> curl -L https://repo1.maven.org/maven2/com/lihaoyi/mill-dist/1.0.0/mill-dist-1.0.0-mill.sh -o mill
+> chmod +x mill
+> echo 1.0.0 > .mill-version
+----
++
+.Windows
+[,console]
+----
+> curl -L https://repo1.maven.org/maven2/com/lihaoyi/mill-dist/1.0.0/mill-dist-1.0.0-mill.bat -o mill.bat
+> echo 1.0.0 > .mill-version
+----
 
 ==== Major Breaking Changes
 
@@ -220,7 +224,8 @@ echo 1.0.0 > .mill-version
   use Scala 3 language features such as https://docs.scala-lang.org/scala3/reference/other-new-features/indentation.html[Optional Braces]
   in your `.mill` files
 +
-```scala
+[,scala]
+----
 package build
 import mill.*, javalib.*
 
@@ -234,7 +239,7 @@ object foo extends JavaModule:
     def mvnDeps = Seq(
       mvn"com.google.guava:guava:33.3.0-jre"
     )
-```
+----
 
 
 * Mill now supports a YAML front-matter syntax (YAML version 1.2) in your root `build.mill`
@@ -242,7 +247,8 @@ object foo extends JavaModule:
   the `import $ivy...` syntax and allows external configuration files like `.mill-version`,
   `.mill-jvm-version`, etc. to be configured together e.g.
 +
-```scala
+[,scala]
+----
 //| mill-version: 1.0.0
 //| mill-jvm-version: 17
 //| repositories: [$PWD_URI/custom-repo]
@@ -252,7 +258,7 @@ object foo extends JavaModule:
 
 package build
 ...
-```
+----
 
 * The YAML front-matter allows you to configure arbitrary tasks in the meta-build.
   Above we show how to configure the `def repositories` and `def mvnDeps` tasks for the
@@ -268,23 +274,25 @@ package build
 * The `Agg()`/`Agg[T]` collection types have been removed and replaced by `Seq()`/`Seq[T]`
   ({link-pr}/4525[#4525]):
 +
-```diff
+[,diff]
+----
 -def ivyDeps = Agg(
 +def mvnDeps = Seq(
    mvn"org.scalameta::munit::0.7.29"
 )
-```
+----
 
 * `import $file` has been removed and replaced by direct references to the
   definitions ({link-pr}/4462[#4462]), e.g. if you have a `package build.foo.bar`
   containing `def qux` you can refer to the definition via `build.foo.bar.qux`
   or `import build.foo.bar.qux` without needing the `import $file`
 +
-```diff
+[,diff]
+----
 -import $file.foo.bar.Qux
 +import build.foo.bar.Qux
 ...Qux...
-```
+----
 
 * `import $packages` and `import $meta` are no longer necessary and have been removed
 
@@ -307,14 +315,15 @@ package build
 
 * The `T.*` methods have been removed. These were replaced by `Task.*` equivalents in 0.12.x.
 +
-```diff
+[,diff]
+----
 - def foo = T {
 -   ...T.dest...
 - }
 + def foo = Task{
 +   ...Task.dest...
 + }
-```
+----
 
 * `def zincWorker`, `ZincWorkerModule`, and `ZincWorkerUtil` have been renamed to
   `jvmWorker`, `JvmWorkerModule`, and `JvmWorkerUtil` {link-pr}/4834[#4834])
@@ -377,12 +386,13 @@ package build
   superclass, as they can be identified unambiguously by the `object package` name, so
   setting up the appropriate superclass is now taken care of by Mill automatically ({link-pr}/5008[#5008])
 +
-```diff
+[,diff]
+----
 -object `package` extends RootModule with JavaModule {
 +object `package` extends JavaModule {
    ...
  }
-```
+----
 
 * `Jvm.*` methods to spawn subprocesses and classloaders have been consolidated from 20+ helpers
   into 4 main functions ({link-pr}/4456[#4456]): `Jvm.createClassLoader`, `Jvm.withClassLoader`,
@@ -399,11 +409,12 @@ package build
   tasks ({link-pr}/4524[#4524]). Most cases where a `Task.Sources` was receiving an upstream
   task can be replaced by a separate `Task.Sources` and `Task{}`
 +
-```diff
+[,diff]
+----
 - def sources = Task.Sources{ super.sources() ++ Seq(PathRef(...)) }
 + def customSources =  Task.Sources(...)
 + def sources = Task { super.sources() ++ customSources() }
-```
+----
 
 * Mill's plugin infrastructure has changed with the release of Mill 1.0.0: plugins now need
   to use Scala 3.7.0, should now depend on `mill-libs` rather than `mill-dist`, and integration
@@ -449,11 +460,12 @@ package build
 
 * `Cross` can now be applied to root modules ({link-pr}/4593[#4593])
 +
-```scala
+[,scala]
+----
 object `package` extends Cross[FooModule]("3.6.2", "2.13.16") {
   ...
 }
-```
+----
 
 * Mill now supports a `--offline` option to run in offline mode.
   Custom tasks that need to download remote resources should respect that mode via
@@ -476,12 +488,13 @@ object `package` extends Cross[FooModule]("3.6.2", "2.13.16") {
 * Scala 3.7 https://docs.scala-lang.org/sips/named-tuples.html[Scala 3.7.0 Named Tuples]
   can be used as task return values:
 +
-```scala
+[,scala]
+----
 import upickle.implicits.namedTuples.default.given
 def namedTupleTask = Task {
   (hello = "world", i = Seq("am", "cow"))
 }
-```
+----
 
 * `def repositories: T[Seq[String]]` is now provided as a simpler alternative to
   `def repositoriesTask`, making it easier to add the most common URL/file-based repositories
@@ -553,10 +566,11 @@ _2025-05-18_
   Central that forced a change in the download URLs for new releases going forward. To update your 
   bootstrap script, you can use
 +
-```
-curl -L https://repo1.maven.org/maven2/com/lihaoyi/mill-dist/0.12.13/mill-dist-0.12.13-mill.sh -o mill
-chmod +x mill
-```
+[,console]
+----
+> curl -L https://repo1.maven.org/maven2/com/lihaoyi/mill-dist/0.12.13/mill-dist-0.12.13-mill.sh -o mill
+> chmod +x mill
+----
 
 * Backport `mill.scalalib.SonatypeCentralPublishModule/` from `main` ({link-pr}/5107[#5107]). With
 the https://central.sonatype.org/news/20250326_ossrh_sunset/[Sunset of `oss.sonatype.org`],
@@ -1116,8 +1130,8 @@ parallel builds {link-pr}/3577[#3577]
 ** Mill now shows all active tasks and their duration at the bottom of your terminal
 ** Stream task logs are now prefixed with the task index on the left and the task
 name above, so you can attribute each line of logs to the task that generated it
-
-```
++
+----
 ...
 [3861/4712] main.client.publishLocalCached
 [3861] Publishing Artifact(com.lihaoyi,mill-libs-client,0.12.0-RC2-67-a566d8-DIRTY875bcbb1) to ivy repo /Users/lihaoyi/.ivy2/local
@@ -1129,7 +1143,7 @@ name above, so you can attribute each line of logs to the task that generated it
 [3706] contrib.playlib.worker[2.9].docJar 1s
 [3707] contrib.playlib.worker[2.6].docJar 1s
 ... and 3 more threads
-```
+----
 
 * Add API for tasks to spawn concurrent and parallel futures via `Task.fork.{async,await}` {link-pr}/3478[#3478]
 
@@ -1139,8 +1153,9 @@ by overriding `def testForkGrouping` {link-pr}/3478[#3478]
 * Use coursier thread pool to run coursier-related tasks to avoid deadlocks {link-pr}/3614[#3614]
 
 * `inspect` now shows useful information when used on modules, not just tasks {link-pr}/3532[#3532]
-
-```
++
+[,console]
+----
 $ ./mill inspect dist0
 dist0(build.mill:745)
     Version of [[dist]] meant for local integration testing within the Mill
@@ -1154,7 +1169,7 @@ Module Dependencies: runner, idea
 Default Task: dist0.run
 
 Tasks: dist0.fix, dist0.testTransitiveDeps
-```
+----
 
 * `mill init` now supports creating a project based on examples from Mill's documentation {link-pr}/3583[#3583],
 and unpacks the example into the current folder rather than a subfolder {link-pr}/3626[#3626]

--- a/website/blog/modules/ROOT/pages/12-direct-style-build-tool.adoc
+++ b/website/blog/modules/ROOT/pages/12-direct-style-build-tool.adoc
@@ -41,7 +41,7 @@ At a glance, Mill looks similar to other build tools you may be familiar with, w
 `build.mill` file in the root of a project defining the dependencies and testing
 setup for a module:
 
-[source,scala]
+[,scala]
 ----
 package build
 import mill._, javalib._
@@ -61,7 +61,7 @@ what this build means: a `JavaModule` with two ivy dependencies `argparse4j` and
 and a `test` submodule supporting `Junit4`.
 This build can then be compiled, tested, run, or packaged into an assembly from the command line:
 
-[source,console]
+[,console]
 ----
 > /mill foo.compile
 compiling 1 Java source...
@@ -181,7 +181,7 @@ but if we remove these built in classes we can see how Mill works under the hood
 the following Mill tasks that define some source files, use the `javac` executable to compile
 them into classfiles, and then the `jar` executable to package them together into an assembly:
 
-[source,scala]
+[,scala]
 ----
 def mainClass: T[Option[String]] = Some("foo.Foo")
 

--- a/website/blog/modules/ROOT/pages/13-mill-build-tool-v1-0-0.adoc
+++ b/website/blog/modules/ROOT/pages/13-mill-build-tool-v1-0-0.adoc
@@ -30,13 +30,14 @@ Mill 1.0.0 defaults to using a https://www.graalvm.org/latest/reference-manual/n
 launchers by default. This shaves significant overhead off of Mill command line invocations,
 meaning running `./mill` commands in the terminal can often complete in as little as 100ms:
 
-```bash
+[,console]
+----
 $  time ./mill foo.compile
 [35/35] foo.compile
 [35] [info] compiling 1 Java source...
 [35] [info] done compiling
 ./mill foo.compile  0.01s user 0.01s system 20% cpu 0.109 total
-```
+----
 
 Slow startups and long warmup times have always been a pain point working in the
 JVM ecosystem, and this has always applied to JVM command-line tooling as well. Mill had
@@ -59,7 +60,8 @@ no longer needs a JVM pre-installed in order to run. The launcher binary is self
 and is able to download and cache any JVM it needs in order to start itself or other Java
 processes.
 
-```bash
+[,console]
+----
 $ echo temurin:23 > .mill-jvm-version
 
 $ ./mill foo.test
@@ -70,7 +72,7 @@ https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.2%2B7/
 [build.mill-60] [info] done compiling
 [81/95] foo.compile
 [81] [info] compiling 1 Java source...
-```
+----
 
 This means that Mill is able to manage your JVM installations completely on your behalf,
 without you needing to first install a JVM ahead of time, external tools like
@@ -96,16 +98,18 @@ Mill 1.0.0 comes with built-in support for
 xref:mill::cli/installation-ide.adoc#_bashzsh_tab_completion[Bash and Zsh tab-completion].
 This can be installed via
 
-```bash
+[,console]
+----
 $ ./mill mill.tabcomplete/install
 Writing to /Users/lihaoyi/.cache/mill/download/mill-completion.sh
 Writing to /Users/lihaoyi/.bash_profile
 Writing to /Users/lihaoyi/.zshrc
-```
+----
 
 Once set up, you can then use `<TAB>` to auto-complete Mill modules and tasks from the command-line:
 
-```bash
+[,console]
+----
 $ ./mill f<TAB>
 $ ./mill foo
 
@@ -115,7 +119,7 @@ foo.runBackground      foo.runLocal           foo.runMainBackground  foo.runMvnD
 
 $ ./mill foo.runB<TAB>
 $ ./mill foo.runBackground
-```
+----
 
 While this is not rocket science, we expect that this will be a significant quality-of-life
 improvement to everyone using Mill. Nobody memorizes the names of every module and task within
@@ -133,8 +137,8 @@ although Mill relies on the assumption that tasks would only write to their dest
 folder (available as `Task.dest` within any task body), and that module initialization
 did not write to the filesystem, there was never enforcement of these expectations:
 
-
-```scala
+[,scala]
+----
 object foo extends Module {
   def bannedWriteTask = Task {
     os.write(BuildCtx.workspaceRoot / "banned-path", "hello")  // bad!
@@ -142,7 +146,7 @@ object foo extends Module {
 
   os.write(moduleDir / "banned-write.txt", "hello") // bad!
 }
-```
+----
 
 This meant it was possible to write code that violated Mill's internal expectations,
 which could cause all sorts of things to go wrong: cache invalidation issues, race
@@ -154,10 +158,11 @@ In Mill 1.0.0, most common filesystem read/write APIs have been instrumented to 
 that they are not misused. That means code that violates Mill's conventions raises an
 immediate error:
 
-```bash
+[,console]
+----
 $ ./mill foo.bannedWriteTask
 error: ...Writing to banned-path not allowed during execution of `foo.bannedWriteTask`
-```
+----
 
 These sandboxes are not intended to be fully hermetic: there are escape hatches
 (e.g. `BuildCtx.withFilesystemCheckerDisabled{ ... }`), not all APIs are instrumented
@@ -178,8 +183,9 @@ contains configuration like the `mill-version`, `mill-jvm-version`, the `build.m
 This is reminiscent of https://jekyllrb.com/docs/front-matter/[Jekyll FrontMatter] or Python's
 https://peps.python.org/pep-0723/[PEP723 Inline script metadata]:
 
-_build.mill_
-```scala
+.`build.mill`
+[,scala]
+----
 //| mill-version: 1.0.0
 //| mill-jvm-version: 17
 //| repositories: [$PWD_URI/custom-repo]
@@ -189,7 +195,7 @@ _build.mill_
 
 package build
 ...
-```
+----
 
 Previously, Mill had a wide variety of ways these things were configured:
 

--- a/website/blog/modules/ROOT/pages/14-bash-zsh-completion.adoc
+++ b/website/blog/modules/ROOT/pages/14-bash-zsh-completion.adoc
@@ -44,7 +44,8 @@ user's cursor is currently over. From this information, the completion function 
 a list of strings that are possible completions for the word at that index, and
 return it to the shell. At a glance, this looks something like:
 
-```bash
+[,bash]
+----
 _generate_foo_completions() {
   local idx=$1; shift
   local words=( "$@" )
@@ -74,7 +75,7 @@ if [ -n "${ZSH_VERSION:-}" ]; then
 elif [ -n "${BASH_VERSION:-}" ]; then
   complete -F _complete_foo_bash foo
 fi
-```
+----
 
 - `_generate_foo_completions` is a dummy function used
   for demonstration purposes that prints out a hardcoded set of completions,
@@ -97,7 +98,8 @@ For example, the Mill build tool provides a `./mill mill.tabcomplete/install`
 builtin that automatically updates these files and instructs the user to
 restart the shell or `source` the relevant script to begin using completions:
 
-```bash
+[,console]
+----
 $ ./mill mill.tabcomplete/install
 [1/1] mill.tabcomplete.TabCompleteModule.install
 Writing to /Users/lihaoyi/.cache/mill/download/mill-completion.sh
@@ -105,7 +107,7 @@ Writing to /Users/lihaoyi/.bash_profile
 Writing to /Users/lihaoyi/.zshrc
 Writing to /Users/lihaoyi/.bashrc
 Please restart your shell or `source ~/.cache/mill/download/mill-completion.sh` to enable completions
-```
+----
 
 Although the Shell syntax can be very finnicky, e.g. passing arrays to as
 function arguments via `"${words[@]}"`, the actual underlying logic here isn't
@@ -118,13 +120,14 @@ You can try this out live by pasting it into your Bash or Zsh shell and
 typing `foo <TAB>` or `foo a<TAB>`. Note that you don't
 actually need a `foo` command installed:
 
-```bash
+[,console]
+----
 $ foo <TAB>
 apple    apricot  banana   cherry   durian
 
 $ foo a<TAB>
 apple    apricot
-```
+----
 
 That's all you need to get a basic tab-completer working. In real usage"
 
@@ -145,10 +148,11 @@ to commands like `./foo` as well. This is handy for programs like Mill, Maven, o
 which typically use a `./mill` xref:mill::cli/installation-ide.adoc#_bootstrap_scripts[Bootstrap Script]
 to run:
 
-```bash
+[,console]
+----
 $ ./foo a<TAB>
 apple    apricot
-```
+----
 
 == Zsh Completion Descriptions
 
@@ -164,7 +168,8 @@ completion descriptions by default so we trim off the description,
 but in Zsh we pass both the `trimmed` completion-words as well as the `raw` words and
 descriptions to `compadd -d raw -- $trimmed` as two parallel arrays.
 
-```bash
+[,bash]
+----
 _generate_foo_completions() {
   local idx=$1; shift
   local words=( "$@" )
@@ -207,13 +212,14 @@ if [ -n "${ZSH_VERSION:-}" ]; then
 elif [ -n "${BASH_VERSION:-}" ]; then
   complete -F _complete_foo_bash foo
 fi
-```
+----
 
 Zsh would then display the `raw` lines including both the completion-word as well
 as the descriptions when displaying the completion options, but use the `trimmed`
 lines which only contain the completion-words when completing the line
 
-```bash
+[,console]
+----
 $ foo a<TAB>
 $ foo ap
 
@@ -222,7 +228,7 @@ apple: a common fruit                          apricot: sour fruit with a large 
 
 $ foo app<TAB>
 $ foo apple
-```
+----
 
 However in this scenario the descriptions are entirely ignored by Bash. Because Bash
 does not have a concept of tab-complete descriptions, in Bash we only pass the `trimmed`
@@ -235,10 +241,11 @@ that the completions are generated dynamically every time we call
 `_generate_foo_completions`, and Bash and Zsh only inserts text
 that is a common prefix to all completion options
 
-```bash
+[,console]
+----
 $ foo a<TAB>
 $ foo ap
-```
+----
 
 Therefore, if we have multiple differing word-completions, we can actually append
 whatever we want to the right of those words in `_generate_foo_completions`!
@@ -250,7 +257,8 @@ The code below implements this: if there is only one completion we trim off the 
 following the `:` off as normal, but if there's more than one completion we leave the
 description intact for the user to see
 
-```bash
+[source,bash]
+----
 _complete_foo_bash() {
   local IFS=$'\n'
   local raw=($(_generate_foo_completions "$COMP_CWORD" "${COMP_WORDS[@]}"))
@@ -263,13 +271,14 @@ _complete_foo_bash() {
 
   COMPREPLY=( "${trimmed[@]}" )
 }
-```
+----
 
 Now when I use autocomplete in Bash, I can see the descriptions for each item, but when
 the tab-completion actually completes the token it only completes the word itself and
 does not include the description!
 
-```bash
+[,console]
+----
 $ foo <TAB>
 apple: a common fruit                     cherry: small and sweet with a large pit
 apricot: sour fruit with a large stone    durian: stinky spiky fruit
@@ -284,7 +293,7 @@ apple: a common fruit                   apricot: sour fruit with a large stone
 
 $ foo app<TAB>
 $ foo apple
-```
+----
 
 In this section, we only needed to make changes to the `_complete_foo_bash` function,
 as the Zsh completion logic in `_complete_foo_zsh` is completely unchanged.
@@ -294,9 +303,10 @@ as the Zsh completion logic in `_complete_foo_zsh` is completely unchanged.
 The last quality of life feature we will add is the ability to show completion
 descriptions when tabbing on a complete word:
 
-```bash
+[,console]
+----
 $ foo apple<TAB>
-```
+----
 
 For example, the Mill build tool does this so if you're not sure what a flag or command
 does, you can press `<TAB>` on it to see more details:
@@ -327,7 +337,8 @@ and descriptions for the user to see.
 
 Doing this in `_complete_foo_bash` looks like the following:
 
-```bash
+[,bash]
+----
 _complete_foo_bash() {
   local IFS=$'\n'
   local raw=($(_generate_foo_completions "$COMP_CWORD" "${COMP_WORDS[@]}"))
@@ -340,7 +351,7 @@ _complete_foo_bash() {
 
   COMPREPLY=( "${trimmed[@]}" )
 }
-```
+----
 
 Instead of checking the length of `raw` to decide whether we add a trimmed
 and non-trimmed lines to `trimmed`, we now instead _always_ add the non-trimmed lines
@@ -355,7 +366,8 @@ inserted into the user's command
 
 In Zsh, this can be similarly done via:
 
-```bash
+[,bash]
+----
 _complete_foo_zsh() {
   local -a raw trimmed
   local IFS=$'\n'
@@ -369,7 +381,7 @@ _complete_foo_zsh() {
 
   compadd -d raw -- $trimmed
 }
-```
+----
 
 The change here is similar to the Bash snippet above: when the number of completions is 1,
 we add an additional completion to make it ambiguous so Zsh prints the description. But
@@ -378,10 +390,11 @@ our `if` block needs to append items to both `trimmed` and `raw`.
 
 Using this, it now looks like
 
-```bash
+[,console]
+----
 $ foo apple<TAB>
 apple                  apple: a common fruit
-```
+----
 
 Although the UI is not quite perfect - the word `apple` gets duplicated twice -
 this nevertheless achieves the original goal of letting users `<TAB>` on an
@@ -392,7 +405,8 @@ already-completed flag or command to see the description or documentation for th
 
 At this point, our final code looks like this:
 
-```bash
+[,bash]
+----
 _generate_foo_completions() {
   local idx=$1; shift
   local words=( "$@" )
@@ -444,7 +458,7 @@ if [ -n "${ZSH_VERSION:-}" ]; then
 elif [ -n "${BASH_VERSION:-}" ]; then
   complete -F _complete_foo_bash foo
 fi
-```
+----
 
 And can be used in both Bash or Zsh to provide an identical user experience:
 
@@ -453,7 +467,8 @@ And can be used in both Bash or Zsh to provide an identical user experience:
 * Performing partial or entire-word completions
 * Showing the description or documentation when ``<TAB>``ing on an already-completed word
 
-```bash
+[,console]
+----
 $ foo <TAB>
 apple: a common fruit                     banana: starchy and high in potassium     durian: stinky spiky fruit
 apricot: sour fruit with a large stone    cherry: small and sweet with a large pit
@@ -469,7 +484,7 @@ $ foo apple
 
 $ foo apple<TAB>
 apple                  apple: a common fruit
-```
+----
 
 The actual docs for each shell's tab-completion system contains a lot more detail (e.g.
 https://zsh.sourceforge.io/Doc/Release/Completion-System.html[72 pages] for Zsh!), and

--- a/website/blog/modules/ROOT/pages/5-executable-jars.adoc
+++ b/website/blog/modules/ROOT/pages/5-executable-jars.adoc
@@ -225,9 +225,9 @@ digraph G {
 
 If you use `less out.jar` to look at what's inside the Jar file, it looks like this:
 
-[source,bash]
+[,console]
 ----
-exec java $JAVA_OPTS -cp "$0" 'foo.Foo' "$@"
+> exec java $JAVA_OPTS -cp "$0" 'foo.Foo' "$@"
 PK^C^D^T^@^H^H^H^@<B5>`"Z^@^@^@^@^@^@^@^@^@^@^@^@^T^@^Q^@META-INF/MANIFEST.MFUT^M^@^G<97>^Pvg<97>^Pvg<97>^Pvgeɱ
 <80> ^P^@<D0><FD><C0>^?<B8>^_81s<C9>1<A1><CD>-<DA>^OR^P<C4>^Cu<E9><EF>ESC^Z{<EB><8B><DC>JNcҕ<FA>(<D2><.<DA>=<F1>L7<ED><8F><C7>XjE<A3>^W<AB>^]ٕl<CE>n<B3>
 N<91><FA>%<FD>3ri^T*<8F><E1>1<8B><E8>CD<81><82>^WPK^G^HB?^Xo[^@^@^@n^@^@^@PK^C^D
@@ -257,9 +257,9 @@ To fix this, we can replace our shell script zip prefix with a "universal" scrip
 is both a valid `.sh` program as well as valid `.bat` program, the latter being the
 standard windows command line language. Thus, instead of:
 
-[source,bash]
+[,console]
 ----
-exec java  $JAVA_OPTS -cp "$0" 'foo.Foo' "$@"
+> exec java  $JAVA_OPTS -cp "$0" 'foo.Foo' "$@"
 ----
 
 We can instead use:

--- a/website/docs/modules/ROOT/pages/android/android-initial-setup.adoc
+++ b/website/docs/modules/ROOT/pages/android/android-initial-setup.adoc
@@ -15,12 +15,14 @@ Ensure the `$ANDROID_HOME` environment variable is set (typically to `~/Android/
 
 Mill will automatically install and use the `19.0` version.
 To use a different version, override `cmdlineToolsVersion` in your `build.mill`.
+
 [NOTE]
 ====
 The SDK package licenses must be accepted before installing new packages.
 If not accepted, Mill will throw an error with instructions.
 You can also configure Mill to automatically accept the licenses by overriding `autoAcceptLicenses`.
 ====
+
 [source,scala]
 ----
 object androidSdkModule0 extends AndroidSdkModule {
@@ -32,6 +34,7 @@ object androidSdkModule0 extends AndroidSdkModule {
   override def autoAcceptLicenses = true
 }
 ----
+
 [NOTE]
 ====
 This feature is still experimental.
@@ -58,6 +61,7 @@ image::basic/AndroidStudio.png[AndroidStudio.png]
 
 == 5. Release the project
 By default, mill projects are considered in debug mode, so if your project is ready for release, you should add the following to your app object in the `build.mill` file:
+
 [source,scala]
 ----
 override def androidIsDebug = Task { false }
@@ -66,13 +70,15 @@ def androidReleaseKeyAlias: T[Option[String]] = Task { Some("releaseKey") }
 def androidReleaseKeyPass: T[Option[String]] = Task { Some("MillBuildTool") }
 def androidReleaseKeyStorePass: T[Option[String]] = Task { Some("MillBuildTool") }
 ----
+
 Make sure to replace the values with your actual keystore information.
 If you don't have a keystore yet, you can create one using the `keytool` command:
-[source,bash]
+
+[,console]
 ----
-keytool -genkey -v -keystore releaseKey.jks \
-        -storepass <PASS> -keyalg RSA \
-        -keysize 2048 -validity 10000 \
-        -alias releaseKey -keypass <PASS>
+> keytool -genkey -v -keystore releaseKey.jks \
+          -storepass <PASS> -keyalg RSA \
+          -keysize 2048 -validity 10000 \
+          -alias releaseKey -keypass <PASS>
 ----
 

--- a/website/docs/modules/ROOT/pages/cli/installation-ide.adoc
+++ b/website/docs/modules/ROOT/pages/cli/installation-ide.adoc
@@ -127,9 +127,10 @@ Github doesn't yet have built-in support for syntax highlighting `.mill` files a
 but you can set this up in your own projects by creating a `.gitattributes` file in the root
 of your Github repository
 
-```
+[,console]
+----
 > echo '*.mill linguist-language=Scala' > .gitattributes
-```
+----
 
 [#_ide_support]
 == IDE Support

--- a/website/docs/modules/ROOT/pages/comparisons/why-mill.adoc
+++ b/website/docs/modules/ROOT/pages/comparisons/why-mill.adoc
@@ -389,7 +389,8 @@ and invalidation.
 It's worth contrasting the Mill config above with e.g. the equivalent Gradle configuration
 for setting up a line-count resource file:
 
-```kotlin
+[,kotlin]
+----
 import java.io.File
 
 tasks.register("generateLineCount") {
@@ -420,7 +421,7 @@ tasks.named("processResources") {
     dependsOn("generateLineCount")
     from(layout.buildDirectory.dir("generated-resources"))
 }
-```
+----
 
 While the Gradle config is a bit more verbose than Mill's, that is not where the problem
 lies. The problem lies in the fact that the Gradle "config as code" doesn't _actually_

--- a/website/docs/modules/ROOT/pages/extending/thirdparty-plugins.adoc
+++ b/website/docs/modules/ROOT/pages/extending/thirdparty-plugins.adoc
@@ -41,15 +41,17 @@ object MyAliases extends Aliases {
 
 To show all the defined aliases:
 
-```sh
-./mill Alias/list
-```
+[,console]
+----
+> ./mill Alias/list
+----
 
 Run an alias:
 
-```sh
-./mill Alias/run testall
-```
+[,console]
+----
+> ./mill Alias/run testall
+----
 
 When run, each aliased task is checked if valid.
 

--- a/website/docs/modules/ROOT/partials/Publishing_Footer.adoc
+++ b/website/docs/modules/ROOT/partials/Publishing_Footer.adoc
@@ -19,7 +19,7 @@ Mill uses the following environment variables as a way to pass the necessary sec
 for publishing:
 
 
-[source,sh]
+[,sh]
 ----
 # Sonatype Central Portal needs your public key to be uploaded so it can use for verification of artifacts from their end.
 #
@@ -59,7 +59,7 @@ export MILL_PGP_PASSPHRASE=...
 You can publish all eligible modules in your Mill project using 
 `mill.javalib.SonatypeCentralPublishModule/`:
 
-[source,console]
+[,console]
 ----
 > mill mill.javalib.SonatypeCentralPublishModule/
 ----
@@ -71,7 +71,7 @@ You can also specify individual modules you want to publish in two ways:
 > mill foo.publishSonatypeCentral
 ----
 
-[source.console]
+[,console]
 ----
 > mill mill.javalib.SonatypeCentralPublishModule/ --publishArtifacts foo.publishArtifacts
 ----
@@ -89,6 +89,7 @@ repository.
 See https://central.sonatype.org/publish/publish-portal-snapshots/[Sonatype Central documentation] for more information.
 
 You build file should look like:
+
 [source,scala]
 ----
 object mymodule extends JavaModule {
@@ -129,7 +130,8 @@ object myDownstreamModule extends JavaModule {
 
 To publish on Github Actions, you can use something like this:
 
-```yaml
+[,yaml]
+----
 # .github/workflows/publish-artifacts.yml
 name: Publish Artifacts
 on:
@@ -152,7 +154,7 @@ jobs:
           MILL_PGP_SECRET_BASE64: ${{ secrets.MILL_PGP_SECRET_BASE64 }}
           MILL_SONATYPE_PASSWORD: ${{ secrets.MILL_SONATYPE_PASSWORD }}
           MILL_SONATYPE_USERNAME: ${{ secrets.MILL_SONATYPE_USERNAME }}
-```
+----
 
 Where `MILL_PGP_PASSPHRASE`, `MILL_PGP_SECRET_BASE64`, `MILL_SONATYPE_PASSWORD`, and
 `MILL_SONATYPE_USERNAME` configured for the repository's or organization's Github Actions
@@ -224,7 +226,8 @@ Typically
 
 To publish on Github Actions, you can use something like this:
 
-```yaml
+[,yaml]
+----
 # .github/workflows/publish-artifacts.yml
 name: Publish Artifacts
 on:
@@ -247,7 +250,7 @@ jobs:
           MILL_PGP_SECRET_BASE64: ${{ secrets.MILL_PGP_SECRET_BASE64 }}
           MILL_SONATYPE_PASSWORD: ${{ secrets.MILL_SONATYPE_PASSWORD }}
           MILL_SONATYPE_USERNAME: ${{ secrets.MILL_SONATYPE_USERNAME }}
-```
+----
 
 Where `MILL_PGP_PASSPHRASE`, `MILL_PGP_SECRET_BASE64`, `MILL_SONATYPE_PASSWORD`, and
 `MILL_SONATYPE_USERNAME` configured for the repository's or organization's Github Actions
@@ -325,6 +328,7 @@ The `./mill mill.javalib.SonatypeCentralPublishModule/publishAll` takes the foll
 
 ==== Example command
 
+[,console]
 ----
 $ mill -i \
 mill.javalib.SonatypeCentralPublishModule/publishAll \


### PR DESCRIPTION
Most notably, mark console snippets as `console`, not `bash`.

