### PR TITLE
Try to fix flakiness in `externalModuleTargetsAreNamespacedByModulePackagePath`

### DIFF
--- a/core/exec/test/src/mill/exec/ModuleTests.scala
+++ b/core/exec/test/src/mill/exec/ModuleTests.scala
@@ -50,7 +50,6 @@ object ModuleTests extends TestSuite {
     }
     test("externalModuleTargetsAreNamespacedByModulePackagePath") {
       UnitTester(Build, null).scoped { check =>
-        os.remove.all(check.outPath)
         val zresult = check.apply(Build.z)
         assert(
           zresult == Right(Result(30, 1)),


### PR DESCRIPTION
Not sure why that `os.remove.all` is failing, but also not sure why it is necessary. So just trying to remove it

Fixes  https://github.com/com-lihaoyi/mill/issues/5680