### PR TITLE
WIP make `mill-jvm-version` config required, avoid using system `java` unless explicitly specified 

### DIFF
--- a/runner/launcher/src/mill/launcher/MillProcessLauncher.java
+++ b/runner/launcher/src/mill/launcher/MillProcessLauncher.java
@@ -156,7 +156,15 @@ public class MillProcessLauncher {
 
   static String millJvmVersion() throws Exception {
     List<String> res = loadMillConfig("mill-jvm-version");
-    if (res.isEmpty()) return null;
+    if (res.isEmpty()) {
+      throw new Exception(
+        "mill-jvm-version not set. Please set this in" +
+          "your build header to specify the version of the JVM this project " +
+          "should use, e.g. `//| mill-jvm-version: 17`, " +
+          "`//| mill-jvm-version: temurin:17`, or `//| mill-jvm-version: system` " +
+          "if you want to use the globally-installed JVM on your machine"
+      );
+    }
     else return res.get(0);
   }
 


### PR DESCRIPTION
This will make Mill builds more reproducible, and avoid the JVM-version confusion that e.g. @makingthematrix encountered recently in the discord channel.

