### PR TITLE
Fix slow scala compilation when ZincWorker subprocess is used

### DIFF
--- a/libs/daemon/server/src/mill/server/Server.scala
+++ b/libs/daemon/server/src/mill/server/Server.scala
@@ -36,7 +36,8 @@ abstract class Server(args: Server.Args) {
     }
   }
 
-  def serverLog(s: String): Unit = serverLog0(s"pid:$processId ${timestampStr()} $s")
+  def serverLog(s: String): Unit =
+    serverLog0(s"pid:$processId ${timestampStr()} [t${Thread.currentThread().getId}] $s")
 
   protected type PreHandleConnectionData
 

--- a/libs/javalib/src/mill/javalib/JvmWorkerModule.scala
+++ b/libs/javalib/src/mill/javalib/JvmWorkerModule.scala
@@ -45,6 +45,7 @@ trait JvmWorkerModule extends OfflineSupportModule with CoursierModule {
     ))
   }
 
+  /** Whether Zinc debug logging is enabled. */
   def zincLogDebug: T[Boolean] = Task.Input(Task.ctx().log.debugEnabled)
 
   def worker: Worker[JvmWorkerApi] = internalWorker

--- a/libs/javalib/src/mill/javalib/JvmWorkerModule.scala
+++ b/libs/javalib/src/mill/javalib/JvmWorkerModule.scala
@@ -63,10 +63,10 @@ trait JvmWorkerModule extends OfflineSupportModule with CoursierModule {
         .asInstanceOf[JvmWorkerFactoryApi]
 
     val ctx = Task.ctx()
-    val zincCompilerBridge = ZincCompilerBridgeProvider[Unit](
+    val zincCompilerBridge = ZincCompilerBridgeProvider(
       workspace = ctx.dest,
       logInfo = ctx.log.info,
-      acquire = (scalaVersion, scalaOrganization, _) =>
+      acquire = (scalaVersion, scalaOrganization) =>
         scalaCompilerBridgeJarV2(
           scalaVersion = scalaVersion,
           scalaOrganization = scalaOrganization,

--- a/libs/javalib/src/mill/javalib/JvmWorkerModule.scala
+++ b/libs/javalib/src/mill/javalib/JvmWorkerModule.scala
@@ -76,7 +76,6 @@ trait JvmWorkerModule extends OfflineSupportModule with CoursierModule {
       zincCompilerBridge,
       classPath = classpath().map(_.path),
       jobs = jobs,
-      compileToJar = false,
       zincLogDebug = zincLogDebug(),
       close0 = () => cl.close()
     )

--- a/libs/javalib/src/mill/javalib/internal/JvmWorkerFactoryApi.scala
+++ b/libs/javalib/src/mill/javalib/internal/JvmWorkerFactoryApi.scala
@@ -13,7 +13,6 @@ case class JvmWorkerArgs[CompilerBridgeData](
     compilerBridge: ZincCompilerBridgeProvider[CompilerBridgeData],
     classPath: Seq[os.Path],
     jobs: Int,
-    compileToJar: Boolean,
     zincLogDebug: Boolean,
     close0: () => Unit
 )

--- a/libs/javalib/src/mill/javalib/internal/JvmWorkerFactoryApi.scala
+++ b/libs/javalib/src/mill/javalib/internal/JvmWorkerFactoryApi.scala
@@ -9,8 +9,8 @@ import mill.javalib.api.internal.JvmWorkerApi
  *
  * @param classPath The classpath of the worker.
  */
-case class JvmWorkerArgs[CompilerBridgeData](
-    compilerBridge: ZincCompilerBridgeProvider[CompilerBridgeData],
+case class JvmWorkerArgs(
+    compilerBridge: ZincCompilerBridgeProvider,
     classPath: Seq[os.Path],
     jobs: Int,
     zincLogDebug: Boolean,
@@ -19,5 +19,5 @@ case class JvmWorkerArgs[CompilerBridgeData](
 
 @internal
 trait JvmWorkerFactoryApi {
-  def make(args: JvmWorkerArgs[Unit]): JvmWorkerApi
+  def make(args: JvmWorkerArgs): JvmWorkerApi
 }

--- a/libs/javalib/src/mill/javalib/internal/ZincCompilerBridgeProvider.scala
+++ b/libs/javalib/src/mill/javalib/internal/ZincCompilerBridgeProvider.scala
@@ -14,21 +14,17 @@ import scala.util.Properties.isWin
  * @param logInfo  logs a message at INFO level.
  */
 @internal
-case class ZincCompilerBridgeProvider[-AcquireData](
+case class ZincCompilerBridgeProvider(
     workspace: os.Path,
     logInfo: String => Unit,
-    acquire: ZincCompilerBridgeProvider.Acquire[AcquireData]
+    acquire: ZincCompilerBridgeProvider.Acquire
 )
 @internal
 object ZincCompilerBridgeProvider {
 
-  /**
-   * Provides the compiler bridge.
-   *
-   * @tparam Data extra data to pass to the acquire function.
-   */
-  trait Acquire[-Data] {
-    def apply(scalaVersion: String, scalaOrganization: String, data: Data): AcquireResult[os.Path]
+  /** Provides the compiler bridge. */
+  trait Acquire {
+    def apply(scalaVersion: String, scalaOrganization: String): AcquireResult[os.Path]
   }
 
   enum AcquireResult[+Path] derives ReadWriter {

--- a/libs/javalib/worker/src/mill/javalib/worker/JvmWorkerFactory.scala
+++ b/libs/javalib/worker/src/mill/javalib/worker/JvmWorkerFactory.scala
@@ -5,5 +5,5 @@ import mill.javalib.internal.{JvmWorkerArgs, JvmWorkerFactoryApi}
 
 //noinspection ScalaUnusedSymbol - used dynamically by classloading via a FQCN
 class JvmWorkerFactory extends JvmWorkerFactoryApi {
-  override def make(args: JvmWorkerArgs[Unit]): JvmWorkerApi = JvmWorkerImpl(args)
+  override def make(args: JvmWorkerArgs): JvmWorkerApi = JvmWorkerImpl(args)
 }

--- a/libs/javalib/worker/src/mill/javalib/worker/JvmWorkerImpl.scala
+++ b/libs/javalib/worker/src/mill/javalib/worker/JvmWorkerImpl.scala
@@ -232,7 +232,7 @@ class JvmWorkerImpl(args: JvmWorkerArgs) extends JvmWorkerApi with AutoCloseable
           fileAndDebugLog(log, s"Starting JVM subprocess for $mainClass for $key")
           val process = Timed(Jvm.spawnProcess(
             mainClass = mainClass,
-            mainArgs = Seq(daemonDir.toString),
+            mainArgs = Seq(daemonDir.toString, jobs.toString),
             javaHome = key.javaHome,
             jvmArgs = key.runtimeOptions.options,
             classPath = classPath
@@ -374,10 +374,8 @@ class JvmWorkerImpl(args: JvmWorkerArgs) extends JvmWorkerApi with AutoCloseable
                   writeSynchronizer = clientToServer
                 )
 
-              val init = ZincWorkerRpcServer.Initialize(
-                compilerBridgeWorkspace = compilerBridge.workspace,
-                jobs = jobs
-              )
+              val init =
+                ZincWorkerRpcServer.Initialize(compilerBridgeWorkspace = compilerBridge.workspace)
               fileAndDebugLog(
                 log,
                 s"Connected to $daemonDir on port $port, sending init: ${pprint(init)}"

--- a/libs/javalib/worker/src/mill/javalib/worker/JvmWorkerImpl.scala
+++ b/libs/javalib/worker/src/mill/javalib/worker/JvmWorkerImpl.scala
@@ -44,7 +44,6 @@ class JvmWorkerImpl(args: JvmWorkerArgs[Unit]) extends JvmWorkerApi with AutoClo
     ZincWorker(
       compilerBridge,
       jobs = jobs,
-      compileToJar = compileToJar,
       zincLogDebug = zincLogDebug
     )
 
@@ -381,7 +380,6 @@ class JvmWorkerImpl(args: JvmWorkerArgs[Unit]) extends JvmWorkerApi with AutoClo
               val init = ZincWorkerRpcServer.Initialize(
                 compilerBridgeWorkspace = compilerBridge.workspace,
                 jobs = jobs,
-                compileToJar = compileToJar,
                 zincLogDebug = zincLogDebug
               )
               fileAndDebugLog(

--- a/libs/javalib/worker/src/mill/javalib/worker/JvmWorkerImpl.scala
+++ b/libs/javalib/worker/src/mill/javalib/worker/JvmWorkerImpl.scala
@@ -43,8 +43,7 @@ class JvmWorkerImpl(args: JvmWorkerArgs[Unit]) extends JvmWorkerApi with AutoClo
   private val zincLocalWorker =
     ZincWorker(
       compilerBridge,
-      jobs = jobs,
-      zincLogDebug = zincLogDebug
+      jobs = jobs
     )
 
   override def compileJava(
@@ -113,7 +112,8 @@ class JvmWorkerImpl(args: JvmWorkerArgs[Unit]) extends JvmWorkerApi with AutoClo
       env = ctx.env,
       dest = ctx.dest,
       logDebugEnabled = log.debugEnabled,
-      logPromptColored = log.prompt.colored
+      logPromptColored = log.prompt.colored,
+      zincLogDebug = zincLogDebug
     )
 
     if (javaRuntimeOptions.options.isEmpty && javaHome.isEmpty) {
@@ -379,8 +379,7 @@ class JvmWorkerImpl(args: JvmWorkerArgs[Unit]) extends JvmWorkerApi with AutoClo
 
               val init = ZincWorkerRpcServer.Initialize(
                 compilerBridgeWorkspace = compilerBridge.workspace,
-                jobs = jobs,
-                zincLogDebug = zincLogDebug
+                jobs = jobs
               )
               fileAndDebugLog(
                 log,

--- a/libs/javalib/worker/src/mill/javalib/zinc/ZincWorker.scala
+++ b/libs/javalib/worker/src/mill/javalib/zinc/ZincWorker.scala
@@ -33,12 +33,10 @@ import scala.collection.mutable
 
 class ZincWorker[CompilerBridgeData](
     compilerBridge: ZincCompilerBridgeProvider[CompilerBridgeData],
-    jobs: Int,
-    zincLogDebug: Boolean
+    jobs: Int
 ) extends AutoCloseable { self =>
   private val incrementalCompiler = new sbt.internal.inc.IncrementalCompilerImpl()
   private val compilerBridgeLocks: mutable.Map[String, Object] = mutable.Map.empty[String, Object]
-  private val zincLogLevel = if (zincLogDebug) sbt.util.Level.Debug else sbt.util.Level.Info
 
   private val classloaderCache = new RefCountedClassLoaderCache(
     sharedLoader = getClass.getClassLoader,
@@ -384,6 +382,7 @@ class ZincWorker[CompilerBridgeData](
       suppressedMessage = _ => None
     )
     val loggerId = Thread.currentThread().getId.toString
+    val zincLogLevel = if (ctx.zincLogDebug) sbt.util.Level.Debug else sbt.util.Level.Info
     val logger = SbtLoggerUtils.createLogger(loggerId, consoleAppender, zincLogLevel)
 
     val maxErrors = reporter.map(_.maxErrors).getOrElse(CompileProblemReporter.defaultMaxErrors)
@@ -595,7 +594,8 @@ object ZincWorker {
       env: Map[String, String],
       dest: os.Path,
       logDebugEnabled: Boolean,
-      logPromptColored: Boolean
+      logPromptColored: Boolean,
+      zincLogDebug: Boolean
   ) derives upickle.default.ReadWriter
 
   private case class ScalaCompilerCacheKey(

--- a/libs/javalib/worker/src/mill/javalib/zinc/ZincWorker.scala
+++ b/libs/javalib/worker/src/mill/javalib/zinc/ZincWorker.scala
@@ -31,6 +31,7 @@ import java.net.URLClassLoader
 import java.util.Optional
 import scala.collection.mutable
 
+/** @param jobs number of parallel jobs */
 class ZincWorker(
     jobs: Int
 ) extends AutoCloseable { self =>

--- a/libs/javalib/worker/src/mill/javalib/zinc/ZincWorker.scala
+++ b/libs/javalib/worker/src/mill/javalib/zinc/ZincWorker.scala
@@ -34,7 +34,6 @@ import scala.collection.mutable
 class ZincWorker[CompilerBridgeData](
     compilerBridge: ZincCompilerBridgeProvider[CompilerBridgeData],
     jobs: Int,
-    compileToJar: Boolean,
     zincLogDebug: Boolean
 ) extends AutoCloseable { self =>
   private val incrementalCompiler = new sbt.internal.inc.IncrementalCompilerImpl()
@@ -361,9 +360,7 @@ class ZincWorker[CompilerBridgeData](
 
     os.makeDir.all(ctx.dest)
 
-    val classesDir =
-      if (compileToJar) ctx.dest / "classes.jar"
-      else ctx.dest / "classes"
+    val classesDir = ctx.dest / "classes"
 
     if (ctx.logDebugEnabled) {
       deps.log.debug(

--- a/libs/javalib/worker/src/mill/javalib/zinc/ZincWorkerRpcServer.scala
+++ b/libs/javalib/worker/src/mill/javalib/zinc/ZincWorkerRpcServer.scala
@@ -50,7 +50,6 @@ class ZincWorkerRpcServer(
       val worker = ZincWorker(
         zincCompilerBridge,
         jobs = initialize.jobs,
-        compileToJar = initialize.compileToJar,
         zincLogDebug = initialize.zincLogDebug
       )
 
@@ -149,7 +148,6 @@ object ZincWorkerRpcServer {
   case class Initialize(
       compilerBridgeWorkspace: os.Path,
       jobs: Int,
-      compileToJar: Boolean,
       zincLogDebug: Boolean
   ) derives ReadWriter
 

--- a/libs/javalib/worker/src/mill/javalib/zinc/ZincWorkerRpcServer.scala
+++ b/libs/javalib/worker/src/mill/javalib/zinc/ZincWorkerRpcServer.scala
@@ -16,6 +16,7 @@ import upickle.default.ReadWriter
 import java.io.PrintStream
 
 class ZincWorkerRpcServer(
+    worker: ZincWorker,
     serverName: String,
     transport: MillRpcWireTransport,
     setIdle: Server.SetIdle,
@@ -35,9 +36,7 @@ class ZincWorkerRpcServer(
       serverToClient: MillRpcChannel[ServerToClient]
   ): MillRpcChannel[ClientToServer] = setIdle.doWork {
     val result = Timed {
-      val worker = ZincWorker(jobs = initialize.jobs)
-
-      // This is an ugly hack. `ConsoleOut` is sealed but we need to provide a way to send these logs to the Mill server
+      // This is an ugly hack. `ConsoleOut` is sealed, but we need to provide a way to send these logs to the Mill server
       // over RPC, so we hijack `PrintStream` by overriding the methods that `ConsoleOut` uses.
       //
       // This is obviously extra fragile, but I couldn't find a better way to do it.
@@ -146,8 +145,7 @@ object ZincWorkerRpcServer {
    * @param compilerBridgeWorkspace The workspace to use for the compiler bridge.
    */
   case class Initialize(
-      compilerBridgeWorkspace: os.Path,
-      jobs: Int
+      compilerBridgeWorkspace: os.Path
   ) derives ReadWriter
 
   sealed trait ReporterMode derives ReadWriter {

--- a/libs/javalib/worker/src/mill/javalib/zinc/ZincWorkerRpcServer.scala
+++ b/libs/javalib/worker/src/mill/javalib/zinc/ZincWorkerRpcServer.scala
@@ -49,8 +49,7 @@ class ZincWorkerRpcServer(
       )
       val worker = ZincWorker(
         zincCompilerBridge,
-        jobs = initialize.jobs,
-        zincLogDebug = initialize.zincLogDebug
+        jobs = initialize.jobs
       )
 
       val deps = {
@@ -147,8 +146,7 @@ object ZincWorkerRpcServer {
    */
   case class Initialize(
       compilerBridgeWorkspace: os.Path,
-      jobs: Int,
-      zincLogDebug: Boolean
+      jobs: Int
   ) derives ReadWriter
 
   sealed trait ReporterMode derives ReadWriter {

--- a/libs/util/src/mill/util/request_ids.scala
+++ b/libs/util/src/mill/util/request_ids.scala
@@ -1,0 +1,20 @@
+package mill.util
+
+import java.util.concurrent.atomic.AtomicLong
+
+/** A sequential request id. */
+private[mill] case class RequestId(value: Long) extends AnyVal {
+  override def toString: String = s"req#$value"
+}
+
+/** A thread-safe factory for request ids. */
+private[mill] class RequestIdFactory {
+  private val counter = AtomicLong(0)
+
+  def next(): RequestId = {
+    val value = counter.getAndIncrement()
+    RequestId(value)
+  }
+
+  override def toString: String = s"RequestIdFactory(current=${counter.get()})"
+}


### PR DESCRIPTION
Previously a new `ZincWorker` instance was created for each connection to the `ZincWorkerRpcServer`, which was very unfortunate, as `ZincWorker` contains the classloader caches needed to actually make scalac fast. And because a new `ZincWorker` was used for each compilation, scalac never actually got JITed.

This PR refactors code so that a shared `ZincWorker` instance is created in `ZincWorkerMain`.

Tested manually with gatling codebase:
```
time ./mill __.semanticDbData (before): real    1m25,658s
time ./mill __.semanticDbData (after ): real    0m47,254s
```

---

Related to https://github.com/com-lihaoyi/mill/pull/5713