### PR TITLE
Bump coursier index version

### DIFF
--- a/mill-build/src/millbuild/Deps.scala
+++ b/mill-build/src/millbuild/Deps.scala
@@ -209,7 +209,7 @@ object Deps {
       mvn"org.apache.maven.resolver:maven-resolver-transport-wagon:$mavenResolverVersion"
   }
 
-  val coursierJvmIndexVersion = "0.0.4-111-eb6e08"
+  val coursierJvmIndexVersion = "0.0.4-116-9b244a"
   val gradleApi = mvn"dev.gradleplugins:gradle-api:8.11.1"
 
   val androidTools = mvn"com.android.tools.build:gradle:8.9.1"


### PR DESCRIPTION
Now that https://github.com/com-lihaoyi/mill/issues/5706 is fixed, we can start depending on the updated JVM index with newer JVM versions available