### PR TITLE
Fix BSP compilation progress message

### DIFF
--- a/core/api/daemon/src/mill/api/daemon/internal/CompileProblemReporter.scala
+++ b/core/api/daemon/src/mill/api/daemon/internal/CompileProblemReporter.scala
@@ -14,7 +14,7 @@ trait CompileProblemReporter {
   def fileVisited(file: java.nio.file.Path): Unit
   def printSummary(): Unit
   def finish(): Unit
-  def notifyProgress(percentage: Long, total: Long): Unit
+  def notifyProgress(progress: Long, total: Long): Unit
 
   def maxErrors: Int = CompileProblemReporter.defaultMaxErrors
 }

--- a/integration/ide/bsp-server/src/BspServerTests.scala
+++ b/integration/ide/bsp-server/src/BspServerTests.scala
@@ -376,7 +376,7 @@ object BspServerTests extends UtestIntegrationTestSuite {
       )
 
       var messages = Seq.empty[b.ShowMessageParams]
-      val client: b.BuildClient = new DummyBuildClient {
+      val client: TestBuildClient = new DummyBuildClient {
         override def onBuildShowMessage(params: b.ShowMessageParams): Unit = {
           messages = messages :+ params
         }
@@ -477,7 +477,7 @@ object BspServerTests extends UtestIntegrationTestSuite {
       def runTest(): Unit = {
         var messages = Seq.empty[b.ShowMessageParams]
         val diagnostics = new mutable.ListBuffer[b.PublishDiagnosticsParams]
-        val client: b.BuildClient = new DummyBuildClient {
+        val client: TestBuildClient = new DummyBuildClient {
           override def onBuildPublishDiagnostics(params: b.PublishDiagnosticsParams): Unit = {
             // Not looking at diagnostics for generated sources of the build
             val keep =

--- a/libs/javalib/src/mill/javalib/internal/RpcCompileProblemReporterMessage.scala
+++ b/libs/javalib/src/mill/javalib/internal/RpcCompileProblemReporterMessage.scala
@@ -11,5 +11,5 @@ object RpcCompileProblemReporterMessage {
   case class FileVisited(file: os.Path) extends RpcCompileProblemReporterMessage
   case object PrintSummary extends RpcCompileProblemReporterMessage
   case object Finish extends RpcCompileProblemReporterMessage
-  case class NotifyProgress(percentage: Long, total: Long) extends RpcCompileProblemReporterMessage
+  case class NotifyProgress(progress: Long, total: Long) extends RpcCompileProblemReporterMessage
 }

--- a/libs/javalib/worker/src/mill/javalib/worker/JvmWorkerImpl.scala
+++ b/libs/javalib/worker/src/mill/javalib/worker/JvmWorkerImpl.scala
@@ -462,8 +462,8 @@ class JvmWorkerImpl(args: JvmWorkerArgs) extends JvmWorkerApi with AutoCloseable
               reporter.fileVisited(file.toNIO)
             case RpcCompileProblemReporterMessage.PrintSummary => reporter.printSummary()
             case RpcCompileProblemReporterMessage.Finish => reporter.finish()
-            case RpcCompileProblemReporterMessage.NotifyProgress(percentage, total) =>
-              reporter.notifyProgress(percentage = percentage, total = total)
+            case RpcCompileProblemReporterMessage.NotifyProgress(progress, total) =>
+              reporter.notifyProgress(progress = progress, total = total)
           }
 
         case None =>

--- a/libs/javalib/worker/src/mill/javalib/zinc/RpcCompileProblemReporter.scala
+++ b/libs/javalib/worker/src/mill/javalib/zinc/RpcCompileProblemReporter.scala
@@ -28,6 +28,6 @@ class RpcCompileProblemReporter(
 
   override def finish(): Unit = send(RpcCompileProblemReporterMessage.Finish)
 
-  override def notifyProgress(percentage: Long, total: Long): Unit =
-    send(RpcCompileProblemReporterMessage.NotifyProgress(percentage, total))
+  override def notifyProgress(progress: Long, total: Long): Unit =
+    send(RpcCompileProblemReporterMessage.NotifyProgress(progress, total))
 }

--- a/libs/javalib/worker/src/mill/javalib/zinc/ZincWorker.scala
+++ b/libs/javalib/worker/src/mill/javalib/zinc/ZincWorker.scala
@@ -437,8 +437,7 @@ class ZincWorker(
             prevPhase: String,
             nextPhase: String
         ): Boolean = {
-          val percentage = current * 100 / total
-          reporter.notifyProgress(percentage = percentage, total = total)
+          reporter.notifyProgress(progress = current, total = total)
           true
         }
       }

--- a/runner/bsp/worker/src/mill/bsp/worker/BspCompileProblemReporter.scala
+++ b/runner/bsp/worker/src/mill/bsp/worker/BspCompileProblemReporter.scala
@@ -185,13 +185,15 @@ private class BspCompileProblemReporter(
     client.onBuildTaskStart(taskStartParams)
   }
 
-  override def notifyProgress(percentage: Long, total: Long): Unit = {
+  override def notifyProgress(progress: Long, total: Long): Unit = {
     val params = new TaskProgressParams(taskId).tap { it =>
       it.setEventTime(System.currentTimeMillis())
       it.setData(new CompileTask(targetId))
       it.setDataKind("compile-progress")
-      it.setMessage(s"Compiling target ${targetDisplayName} ($percentage%)")
-      it.setProgress(percentage)
+      it.setMessage(s"Compiling target ${targetDisplayName} (${progress * 100 / total}%)")
+      // Not a percentage, but the # of units done,
+      // see https://github.com/build-server-protocol/build-server-protocol/blob/bc6835d240b0810bcebe1738e7b71caa49b24f29/spec/src/main/resources/META-INF/smithy/bsp/bsp.smithy#L1150
+      it.setProgress(progress)
       it.setTotal(total)
     }
     client.onBuildTaskProgress(params)


### PR DESCRIPTION
This fixes the `onBuildTaskProgress` notification that Mill reports via BSP. This notification has a `progress` parameter, that should be the [number of "units" compiled](https://github.com/build-server-protocol/build-server-protocol/blob/bc6835d240b0810bcebe1738e7b71caa49b24f29/spec/src/main/resources/META-INF/smithy/bsp/bsp.smithy#L1150), alongside a `total` parameter, corresponding the total number of "units" to compile. Mill used to treat `progress` as a percentage, which messes with BSP clients' progress calculations if they rely on this parameter.