### PR TITLE
Catch uncaught errors in test frameworks and ignore them

### DIFF
--- a/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunnerUtils.scala
+++ b/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunnerUtils.scala
@@ -180,7 +180,7 @@ import scala.math.Ordering.Implicits.*
             })
           )
         catch {
-          case e: Throwable =>
+          case _: Throwable =>
             // Sometimes test suites fail really early during instantiation, which might not
             // get properly caught by the test framework which expects failures during execution.
             // When that happens, just treat this task as having no children, and don't blow up


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/5718

Tested manually, task still fails but it doesn't have the ugly internal infrastructure error


```
lihaoyi gatling$ ./mill -k gatling-charts.test.testForked
...
[507/507] gatling-charts.test.testForked
[507] Running Test Class io.gatling.charts.util.HtmlHelperSpec
[507] HtmlHelperSpec:
[507] htmlEscape
[507] - should escape with entity chars
[507] Running Test Class io.gatling.charts.FileNamingConventionsSpec
[507] FileNamingConventionsSpec:
[507] toRequestFileName
[507] - should generate non clashing names
[507] Running Test Class io.gatling.charts.result.reader.LogFileReaderSpec
[507] LogFileReaderSpec:
[507] io.gatling.charts.result.reader.LogFileReaderSpec *** ABORTED ***
[507]   java.lang.ExceptionInInitializerError:
[507]   at io.gatling.charts.result.reader.LogFileReaderSpec.$anonfun$resultsDirectory$1(LogFileReaderSpec.scala:54)
[507]   at io.gatling.charts.result.reader.LogFileReaderSpec.$anonfun$resultsDirectory$1$adapted(LogFileReaderSpec.scala:50)
[507]   at scala.util.Using$.resource(Using.scala:296)
[507]   at io.gatling.charts.result.reader.LogFileReaderSpec.<init>(LogFileReaderSpec.scala:50)
[507]   at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)
[507]   at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)
[507]   at java.base/java.lang.reflect.ReflectAccess.newInstance(ReflectAccess.java:128)
[507]   at java.base/jdk.internal.reflect.ReflectionFactory.newInstance(ReflectionFactory.java:304)
[507]   at java.base/java.lang.Class.newInstance(Class.java:725)
[507]   at org.scalatest.tools.Framework$ScalaTestTask.execute(Framework.scala:454)
[507]   ...
[507]   Cause: java.util.MissingResourceException: Can't find bundle for base name gatling-version, locale en_SG
[507]   at java.base/java.util.ResourceBundle.throwMissingResourceException(ResourceBundle.java:2059)
[507]   at java.base/java.util.ResourceBundle.getBundleImpl(ResourceBundle.java:1697)
[507]   at java.base/java.util.ResourceBundle.getBundleImpl(ResourceBundle.java:1600)
[507]   at java.base/java.util.ResourceBundle.getBundleImpl(ResourceBundle.java:1555)
[507]   at java.base/java.util.ResourceBundle.getBundle(ResourceBundle.java:861)
[507]   at io.gatling.commons.util.GatlingVersion$.<clinit>(GatlingVersion.scala:35)
[507]   at io.gatling.charts.result.reader.LogFileReaderSpec.$anonfun$resultsDirectory$1(LogFileReaderSpec.scala:54)
[507]   at io.gatling.charts.result.reader.LogFileReaderSpec.$anonfun$resultsDirectory$1$adapted(LogFileReaderSpec.scala:50)
[507]   at scala.util.Using$.resource(Using.scala:296)
[507]   at io.gatling.charts.result.reader.LogFileReaderSpec.<init>(LogFileReaderSpec.scala:50)
[507]   ...
[507] Running Test Class io.gatling.charts.template.ConsoleTemplateSpec
[507] ConsoleTemplateSpec:
[507] console template
[507] - should format the request counters properly
[507] - should format the grouped counts properly
[507] Run completed in 204 milliseconds.
[507] Total number of tests run: 4
[507] Suites: completed 3, aborted 1
[507] Tests: succeeded 4, failed 0, canceled 0, ignored 0, pending 0
[507] *** 1 SUITE ABORTED ***
[507] gatling-charts.test.testForked failed
[507/507, 1 failed] ============================== gatling-charts.test.testForked ============================== 23s
1 tasks failed
gatling-charts.test.testForked 1 tests failed: 
  io.gatling.charts.result.reader.LogFileReaderSpec SuiteSelector
```