### PR TITLE
Print logs to console if an exception happens during mill launcher initialization

### DIFF
--- a/runner/launcher/src/mill/launcher/MillLauncherMain.java
+++ b/runner/launcher/src/mill/launcher/MillLauncherMain.java
@@ -68,21 +68,21 @@ public class MillLauncherMain {
         Collections.addAll(optsArgs, args);
 
         MillServerLauncher launcher =
-          new MillServerLauncher(
-            new MillServerLauncher.Streams(System.in, System.out, System.err),
-            System.getenv(),
-            optsArgs.toArray(new String[0]),
-            Optional.empty(),
-            -1) {
-            public LaunchedServer initServer(Path daemonDir, Locks locks) throws Exception {
-              return new LaunchedServer.OsProcess(
-                MillProcessLauncher.launchMillDaemon(daemonDir, outMode).toHandle());
-            }
+            new MillServerLauncher(
+                new MillServerLauncher.Streams(System.in, System.out, System.err),
+                System.getenv(),
+                optsArgs.toArray(new String[0]),
+                Optional.empty(),
+                -1) {
+              public LaunchedServer initServer(Path daemonDir, Locks locks) throws Exception {
+                return new LaunchedServer.OsProcess(
+                    MillProcessLauncher.launchMillDaemon(daemonDir, outMode).toHandle());
+              }
 
-            public void prepareDaemonDir(Path daemonDir) throws Exception {
-              MillProcessLauncher.prepareMillRunFolder(daemonDir);
-            }
-          };
+              public void prepareDaemonDir(Path daemonDir) throws Exception {
+                MillProcessLauncher.prepareMillRunFolder(daemonDir);
+              }
+            };
 
         var daemonDir0 = Paths.get(outDir, OutFiles.millDaemon);
         String javaHome = MillProcessLauncher.javaHome(outMode);


### PR DESCRIPTION
Currently if an exception like https://github.com/com-lihaoyi/mill/issues/5734 happens while launching the mill daemon there is no logs to look to. This PR adds in-memory logging and outputs that in case of failure.
