### PR TITLE
Add support for Scala 3.8+

### DIFF
--- a/libs/javalib/api/src/mill/javalib/api/JvmWorkerUtil.scala
+++ b/libs/javalib/api/src/mill/javalib/api/JvmWorkerUtil.scala
@@ -112,6 +112,15 @@ object JvmWorkerUtil {
     }
 
   /**
+   * @return true if scala-library contains both Scala 2 and 3 libraries, as opposed to
+   * having both scala3-library and scala2-library.
+   */
+  def isUnifiedLibraryAvailable(scalaVersion: String): Boolean =
+    scalaVersion match {
+      case Scala3Version(minor, _) => minor.toInt >= 8 // 3.8 or later
+    }
+
+  /**
    * Given a version string using a semantic versioning scheme (like x.y.z) it
    * returns all the sub-versions in it (major, minor, patch, etc.).
    * For example, matchingVersions("2.0.0") returns "2.0.0", "2.0" and "2"

--- a/libs/javalib/worker/src/mill/javalib/zinc/ZincWorker.scala
+++ b/libs/javalib/worker/src/mill/javalib/zinc/ZincWorker.scala
@@ -106,9 +106,16 @@ class ZincWorker(
           loaderLibraryOnly = ClasspathUtil.rootLoader,
           libraryJars = Array(libraryJarNameGrep(
             compilerClasspath,
-            // we don't support too outdated dotty versions
-            // and because there will be no scala 2.14, so hardcode "2.13." here is acceptable
-            if (JvmWorkerUtil.isDottyOrScala3(key.scalaVersion)) "2.13." else key.scalaVersion
+            if (
+              JvmWorkerUtil.isDottyOrScala3(
+                key.scalaVersion
+              ) && !JvmWorkerUtil.isUnifiedLibraryAvailable(key.scalaVersion)
+            )
+              // we don't support too outdated dotty versions
+              // and because there will be no scala 2.14, so hardcode "2.13." here is acceptable.
+              // Since 3.8, we can just use the unified library.
+              "2.13."
+            else key.scalaVersion
           ).path.toIO),
           compilerJars = combinedCompilerJars,
           allJars = combinedCompilerJars,

--- a/libs/javalib/worker/src/mill/javalib/zinc/ZincWorker.scala
+++ b/libs/javalib/worker/src/mill/javalib/zinc/ZincWorker.scala
@@ -107,15 +107,14 @@ class ZincWorker(
           libraryJars = Array(libraryJarNameGrep(
             compilerClasspath,
             if (
-              JvmWorkerUtil.isDottyOrScala3(
-                key.scalaVersion
-              ) && !JvmWorkerUtil.isUnifiedLibraryAvailable(key.scalaVersion)
+              JvmWorkerUtil.isDottyOrScala3(key.scalaVersion) && 
+              !JvmWorkerUtil.isUnifiedLibraryAvailable(key.scalaVersion)
             )
-              // we don't support too outdated dotty versions
-              // and because there will be no scala 2.14, so hardcode "2.13." here is acceptable.
-              // Since 3.8, we can just use the unified library.
+              // All stable Scala 3 versions before 3.8 use the Scala 2.13 library
               "2.13."
-            else key.scalaVersion
+            else
+              // Since Scala 3.8, we can just use the unified library
+              key.scalaVersion
           ).path.toIO),
           compilerJars = combinedCompilerJars,
           allJars = combinedCompilerJars,

--- a/libs/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/libs/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -259,6 +259,13 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase
     super.mandatoryMvnDeps() ++ scalaLibraryMvnDeps()
   }
 
+  override private[mill] def repositoriesTask0 = Task.Anon {
+    super.repositoriesTask0() ++ Seq(
+      // Scala 3 compiler nightlies
+      coursier.maven.MavenRepository("https://repo.scala-lang.org/artifactory/maven-nightlies")
+    )
+  }
+
   /**
    * Classpath of the Scala Compiler & any compiler plugins
    */


### PR DESCRIPTION
Should resolve #5739

- Use unified scala-library for Scala 3.8 and later
- Add Scala 3 compiler nightly repository to default ScalaModule's repositories list

