### PR TITLE
Android: Package jnis provided by dependencies

### DIFF
--- a/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
@@ -10,6 +10,7 @@ import mill.api.JsonFormatters.given
 import mill.api.{ModuleRef, PathRef, Task}
 import mill.javalib.*
 import os.{Path, RelPath, zip}
+import os.RelPath.stringRelPathValidated
 import upickle.default.*
 import scala.concurrent.duration.*
 
@@ -205,6 +206,19 @@ trait AndroidAppModule extends AndroidModule { outer =>
   }
 
   /**
+   * Picks all jni deps from the resolved dependencies to be packaged into the APK.
+   * @return
+   */
+  def androidPackageableNativeLibs: T[Seq[AndroidPackageableExtraFile]] = Task {
+    androidTransformAarFiles(resolvedRunMvnDeps)().flatMap {
+      unpackedDep =>
+        unpackedDep.nativeLibs.toList.flatMap(lib => os.list(lib.path))
+    }.map(nativeLibDir =>
+      AndroidPackageableExtraFile(PathRef(nativeLibDir), "lib" / nativeLibDir.last)
+    )
+  }
+
+  /**
    * Packages DEX files and Android resources into an unsigned APK.
    *
    * @return A `PathRef` to the generated unsigned APK file (`app.unsigned.apk`).
@@ -217,14 +231,17 @@ trait AndroidAppModule extends AndroidModule { outer =>
       .filter(_.ext == "dex")
       .map(os.zip.ZipSource.fromPath)
 
-    val metaInf = androidPackageMetaInfoFiles().map(extraFile =>
-      os.zip.ZipSource.fromPathTuple((extraFile.source.path, extraFile.destination.asSubPath))
-    )
+    def asZipSource(androidPackageableExtraFile: AndroidPackageableExtraFile): os.zip.ZipSource =
+      os.zip.ZipSource.fromPathTuple(
+        (androidPackageableExtraFile.source.path, androidPackageableExtraFile.destination.asSubPath)
+      )
+
+    val metaInf = androidPackageMetaInfoFiles().map(asZipSource)
+
+    val nativeLibs = androidPackageableNativeLibs().map(asZipSource)
 
     // add all the extra files to the APK
-    val extraFiles: Seq[zip.ZipSource] = androidPackageableExtraFiles().map(extraFile =>
-      os.zip.ZipSource.fromPathTuple((extraFile.source.path, extraFile.destination.asSubPath))
-    )
+    val extraFiles: Seq[zip.ZipSource] = androidPackageableExtraFiles().map(asZipSource)
 
     // TODO generate aar-metadata.properties (for lib distribution, not in this module) or
     //  app-metadata.properties (for app distribution).
@@ -240,6 +257,7 @@ trait AndroidAppModule extends AndroidModule { outer =>
     // androidGradlePluginVersion=8.7.2
     os.zip(unsignedApk, dexFiles)
     os.zip(unsignedApk, metaInf)
+    os.zip(unsignedApk, nativeLibs)
     os.zip(unsignedApk, extraFiles)
 
     PathRef(unsignedApk)

--- a/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
@@ -207,7 +207,6 @@ trait AndroidAppModule extends AndroidModule { outer =>
 
   /**
    * Picks all jni deps from the resolved dependencies to be packaged into the APK.
-   * @return
    */
   def androidPackageableNativeDeps: T[Seq[AndroidPackageableExtraFile]] = Task {
     androidTransformAarFiles(resolvedRunMvnDeps)().flatMap {

--- a/libs/kotlinlib/src/mill/kotlinlib/ksp/Ksp2Module.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/ksp/Ksp2Module.scala
@@ -44,7 +44,7 @@ trait Ksp2Module extends KspBaseModule { outer =>
    * For finding the right versions, also see [[https://github.com/google/ksp/releases]]
    * For more info go to [[https://github.com/google/ksp/blob/main/docs/ksp2cmdline.md]]
    */
-  def kspDeps: T[Seq[Dep]] = Task {
+  def kspToolsDeps: T[Seq[Dep]] = Task {
     Seq(
       mvn"com.google.devtools.ksp:symbol-processing-aa-embeddable:${kotlinVersion()}-${kspVersion()}",
       mvn"com.google.devtools.ksp:symbol-processing-api:${kotlinVersion()}-${kspVersion()}",
@@ -53,8 +53,11 @@ trait Ksp2Module extends KspBaseModule { outer =>
     )
   }
 
-  def kspDepsResolved: T[Seq[PathRef]] = Task {
-    defaultResolver().classpath(kspDeps(), resolutionParamsMapOpt = Some(addJvmVariantAttributes))
+  def kspToolsDepsClasspath: T[Seq[PathRef]] = Task {
+    defaultResolver().classpath(
+      kspToolsDeps(),
+      resolutionParamsMapOpt = Some(addJvmVariantAttributes)
+    )
   }
 
   /**
@@ -113,7 +116,7 @@ trait Ksp2Module extends KspBaseModule { outer =>
       s"-map-annotation-arguments-in-java=false"
     ) ++ kspArgs() :+ processorClasspath
 
-    val kspJvmMainClasspath = kspDepsResolved().map(_.path)
+    val kspJvmMainClasspath = kspToolsDepsClasspath().map(_.path)
     val mainClass = "com.google.devtools.ksp.cmdline.KSPJvmMain"
     Task.log.debug(
       s"Running Kotlin Symbol Processing with java -cp ${kspJvmMainClasspath.mkString(File.pathSeparator)} ${mainClass} ${args.mkString(" ")}"

--- a/libs/kotlinlib/src/mill/kotlinlib/ksp/KspModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/ksp/KspModule.scala
@@ -40,7 +40,6 @@ trait KspModule extends KspBaseModule { outer =>
    * Mandatory plugins that are needed for KSP to work.
    * For more info go to [[https://kotlinlang.org/docs/ksp-command-line.html]]
    *
-   * @return
    */
   def kspPlugins: T[Seq[Dep]] = Task {
     Seq(

--- a/libs/kotlinlib/src/mill/kotlinlib/ksp/KspModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/ksp/KspModule.scala
@@ -39,7 +39,6 @@ trait KspModule extends KspBaseModule { outer =>
   /**
    * Mandatory plugins that are needed for KSP to work.
    * For more info go to [[https://kotlinlang.org/docs/ksp-command-line.html]]
-   *
    */
   def kspPlugins: T[Seq[Dep]] = Task {
     Seq(

--- a/libs/kotlinlib/src/mill/kotlinlib/ksp/KspModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/ksp/KspModule.scala
@@ -40,8 +40,6 @@ trait KspModule extends KspBaseModule { outer =>
    * Mandatory plugins that are needed for KSP to work.
    * For more info go to [[https://kotlinlang.org/docs/ksp-command-line.html]]
    *
-   * @deprecated Use `kspDeps` instead
-   *
    * @return
    */
   def kspPlugins: T[Seq[Dep]] = Task {


### PR DESCRIPTION
This PR resolves an issue found [during integration](https://github.com/com-lihaoyi/mill/issues/5758) where we were missing the functionality to include in the apk, native deps provided by dependencies 

<img width="1448" height="637" alt="image" src="https://github.com/user-attachments/assets/8101b58f-5006-4cac-9fc8-8b277b3007ab" />


I have also renamed the kspDeps as suggested from https://github.com/com-lihaoyi/mill/pull/5727
