### PR TITLE
Use `DoubleLock` for mutex on compiler bridge creation to avoid races between `MillDaemonMain` and `ZincWorkerMain` processes

### DIFF
--- a/libs/javalib/worker/src/mill/javalib/zinc/ZincWorker.scala
+++ b/libs/javalib/worker/src/mill/javalib/zinc/ZincWorker.scala
@@ -554,6 +554,9 @@ class ZincWorker(
     )
     val compiledDest = workingDir / "compiled"
     val doneFile = compiledDest / "DONE"
+    // Use a double-lock here because we need mutex both between threads within this
+    // process, as well as between different processes since sometimes we are initializing
+    // the compiler bridge inside a separate `ZincWorkerMain` subprocess
     val doubleLock = new DoubleLock(
       memoryLock,
       new FileLock((compilerBridge.workspace / "compiler-bridge-locks" / scalaVersion).toString)


### PR DESCRIPTION
Hopefully fixes https://github.com/com-lihaoyi/mill/issues/5743. Will need to rebootstrap on this to stop the failures in our CI

The previous in-memory lock is no longer sufficient for mutex in this code path, because now both the main Mill process and any `ZincWorkerMain` subprocess could both be trying to initialize compiler bridges in the same `compilerBridge.workspace` folder

