### PR TITLE
Android: Fix androidtodo and replace compose samples in ci with it

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -156,7 +156,7 @@ jobs:
             setup-android: true
 
           - java-version: 17
-            millargs: "'example.thirdparty[android-compose-samples].packaged.daemon'"
+            millargs: "'example.thirdparty[androidtodo].packaged.daemon'"
             setup-android: true
 
           - java-version: 24

--- a/example/thirdparty/androidtodo/build.mill
+++ b/example/thirdparty/androidtodo/build.mill
@@ -109,7 +109,7 @@ object app extends AndroidAppKotlinModule, AndroidR8AppModule, AndroidBuildConfi
     mvn"com.google.dagger:hilt-android-compiler:2.56"
   )
 
-  object test extends Ksp2Tests, AndroidHiltSupport, TestModule.Junit4 {
+  object test extends Ksp2Tests, AndroidAppKotlinTests, AndroidHiltSupport, TestModule.Junit4 {
 
     def moduleDeps = super.moduleDeps ++ Seq(`shared-test`)
 


### PR DESCRIPTION
This was broken accidentally since [the ksp 2 work](https://github.com/com-lihaoyi/mill/pull/5727) , I didn't realise it wasn't running in the CI.


I'd prefer to have androidtodo over jetnews, as jetnews doesn't use Hilt, and androidtodo uses both compose and hilt (and KSP), so if I may choose one I prefer androidtodo.