### PR TITLE
feat: support Playwright testing for Scala-JS

### DIFF
--- a/libs/scalajslib/api/src/mill/scalajslib/worker/api/JsEnvConfig.scala
+++ b/libs/scalajslib/api/src/mill/scalajslib/worker/api/JsEnvConfig.scala
@@ -38,4 +38,15 @@ private[scalajslib] object JsEnvConfig {
     case class FirefoxOptions(headless: Boolean) extends Capabilities
     case class SafariOptions() extends Capabilities
   }
+
+  final case class Playwright(
+      browserName: String = "chromium",
+      headless: Boolean = true,
+      showLogs: Boolean = false,
+      debug: Boolean = false,
+      //   pwConfig: Config = Config(),
+      runConfigEnv: Map[String, String] = Map.empty,
+      launchOptions: List[String] = Nil,
+      additionalLaunchOptions: List[String] = Nil
+  ) extends JsEnvConfig
 }

--- a/libs/scalajslib/package.mill
+++ b/libs/scalajslib/package.mill
@@ -35,6 +35,7 @@ object `package` extends MillStableScalaModule with BuildInfo {
       ),
       BuildInfo.Value("scalajsEnvPhantomJs", formatDep(Deps.Scalajs_1.scalajsEnvPhantomjs)),
       BuildInfo.Value("scalajsEnvSelenium", formatDep(Deps.Scalajs_1.scalajsEnvSelenium)),
+      BuildInfo.Value("scalajsEnvPlaywright", formatDep(Deps.Scalajs_1.scalajsEnvPlaywright)),
       BuildInfo.Value("scalajsImportMap", formatDep(Deps.Scalajs_1.scalajsImportMap))
     )
   }
@@ -60,6 +61,7 @@ object `package` extends MillStableScalaModule with BuildInfo {
       Deps.Scalajs_1.scalajsEnvExoegoJsdomNodejs,
       Deps.Scalajs_1.scalajsEnvPhantomjs,
       Deps.Scalajs_1.scalajsEnvSelenium,
+      Deps.Scalajs_1.scalajsEnvPlaywright,
       Deps.Scalajs_1.scalajsImportMap
     )
   }

--- a/libs/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/libs/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -68,6 +68,8 @@ trait ScalaJSModule extends scalalib.ScalaModule with ScalaJSModuleApi { outer =
         mvn"${ScalaJSBuildInfo.scalajsEnvPhantomJs}"
       case _: JsEnvConfig.Selenium =>
         mvn"${ScalaJSBuildInfo.scalajsEnvSelenium}"
+      case _: JsEnvConfig.Playwright =>
+        mvn"${ScalaJSBuildInfo.scalajsEnvPlaywright}"
     }
 
     Seq(dep)

--- a/libs/scalajslib/src/mill/scalajslib/api/JsEnvConfig.scala
+++ b/libs/scalajslib/src/mill/scalajslib/api/JsEnvConfig.scala
@@ -11,6 +11,7 @@ object JsEnvConfig {
   implicit def rwExoegoJsDomNodeJs: RW[ExoegoJsDomNodeJs] = macroRW
   implicit def rwPhantom: RW[Phantom] = macroRW
   implicit def rwSelenium: RW[Selenium] = macroRW
+  implicit def rwPlaywright: RW[Playwright] = macroRW
   implicit def rw: RW[JsEnvConfig] = macroRW
 
   private given Root_JsEnvConfig: Mirrors.Root[JsEnvConfig] =
@@ -116,4 +117,15 @@ object JsEnvConfig {
         new SafariOptions()
     }
   }
+
+  final case class Playwright(
+      browserName: String = "chromium",
+      headless: Boolean = true,
+      showLogs: Boolean = false,
+      debug: Boolean = false,
+      //   pwConfig: Config = Config(),
+      runConfigEnv: Map[String, String] = Map.empty,
+      launchOptions: List[String] = Nil,
+      additionalLaunchOptions: List[String] = Nil
+  ) extends JsEnvConfig
 }

--- a/libs/scalajslib/src/mill/scalajslib/worker/ScalaJSWorker.scala
+++ b/libs/scalajslib/src/mill/scalajslib/worker/ScalaJSWorker.scala
@@ -109,6 +109,17 @@ private[scalajslib] class ScalaJSWorker(jobs: Int)
               workerApi.JsEnvConfig.Selenium.SafariOptions()
           }
         )
+      case config: api.JsEnvConfig.Playwright =>
+        workerApi.JsEnvConfig.Playwright(
+          browserName = config.browserName,
+          headless = config.headless,
+          showLogs = config.showLogs,
+          debug = config.debug,
+          // pwConfig = config.pwConfig,
+          runConfigEnv = config.runConfigEnv,
+          launchOptions = config.launchOptions,
+          additionalLaunchOptions = config.additionalLaunchOptions
+        )
     }
   }
 

--- a/libs/scalajslib/worker/1/src/mill/scalajslib/worker/ScalaJSWorkerImpl.scala
+++ b/libs/scalajslib/worker/1/src/mill/scalajslib/worker/ScalaJSWorkerImpl.scala
@@ -367,6 +367,8 @@ class ScalaJSWorkerImpl extends ScalaJSWorkerApi {
       Phantom(config)
     case config: JsEnvConfig.Selenium =>
       Selenium(config)
+    case config: JsEnvConfig.Playwright =>
+      Playwright(config)
   }
 
   def jsEnvInput(report: Report): Seq[Input] = {

--- a/libs/scalajslib/worker/1/src/mill/scalajslib/worker/jsenv/Playwright.scala
+++ b/libs/scalajslib/worker/1/src/mill/scalajslib/worker/jsenv/Playwright.scala
@@ -1,0 +1,18 @@
+package mill.scalajslib.worker.jsenv
+
+import mill.scalajslib.worker.api._
+import scala.util.chaining.given
+
+object Playwright {
+  def apply(config: JsEnvConfig.Playwright) =
+    new io.github.thijsbroersen.jsenv.playwright.PWEnv(
+      browserName = config.browserName,
+      headless = config.headless,
+      showLogs = config.showLogs,
+      debug = config.debug,
+      // pwConfig = config.pwConfig,
+      runConfigEnv = config.runConfigEnv,
+      launchOptions = config.launchOptions,
+      additionalLaunchOptions = config.additionalLaunchOptions
+    )
+}

--- a/mill-build/src/millbuild/Deps.scala
+++ b/mill-build/src/millbuild/Deps.scala
@@ -32,6 +32,8 @@ object Deps {
       mvn"org.scala-js::scalajs-env-phantomjs:1.0.0".withDottyCompat(scalaVersion)
     val scalajsEnvSelenium =
       mvn"org.scala-js::scalajs-env-selenium:1.1.1".withDottyCompat(scalaVersion)
+    val scalajsEnvPlaywright =
+      mvn"io.github.thijsbroersen::scala-js-env-playwright:0.1.21-SNAPSHOT"
     val scalajsSbtTestAdapter =
       mvn"org.scala-js::scalajs-sbt-test-adapter:${scalaJsVersion}".withDottyCompat(scalaVersion)
     val scalajsLinker =


### PR DESCRIPTION
I could not find any existing JSEnv which allows me to properly test against some browser features and am using [scala-js-env-playwright](https://github.com/ThijsBroersen/scala-js-env-playwright) for a while now. The current version is still a snapshot so this PR is not ready to be merged, but I would love some feedback on what is required to get this feature as part of Mill. Currently I am using a custom build mill-assembly for my projects.

Here a draft of Playwright support for Scala-js testing. 

I was also wondering why isn't Mill supporting just a raw JSEnv? Any custom JSEnv implemention now first requires Mill to include it..