### PR TITLE
Make Mill work with `mill-build/src/` folder even if `mill-build/build.mill` does not exist

### DIFF
--- a/example/extending/metabuild/5-meta-shared-sources/build.mill
+++ b/example/extending/metabuild/5-meta-shared-sources/build.mill
@@ -9,7 +9,6 @@ object `package` extends ScalaModule {
   def sources = Task { super.sources() ++ customSources() }
 }
 
-/** See Also: mill-build/build.mill */
 /** See Also: mill-build/src/ScalaVersion.scala */
 /** See Also: src/Foo.scala */
 

--- a/example/extending/metabuild/5-meta-shared-sources/mill-build/build.mill
+++ b/example/extending/metabuild/5-meta-shared-sources/mill-build/build.mill
@@ -1,6 +1,0 @@
-package build
-
-import mill.*
-import mill.meta.MillBuildRootModule
-
-object `package` extends MillBuildRootModule

--- a/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
+++ b/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
@@ -96,6 +96,7 @@ class MillBuildBootstrap(
       val currentRootContainsBuildFile = rootBuildFileNames.asScala.exists(rootBuildFileName =>
         os.exists(currentRoot / rootBuildFileName)
       )
+
       val (nestedState, headerDataOpt) =
         if (depth == 0) {
           // On this level we typically want to assume a Mill project, which means we want to require an existing `build.mill`.


### PR DESCRIPTION
Fixes part of https://github.com/com-lihaoyi/mill/issues/5780, at least the Mill handling of the `mill-build/` folder

Adjusted the `example/extending/metabuild/5-meta-shared-sources/` test to work. Previously this would fail, now it passes