### PR TITLE
Use Kotlin build-tools-api to compile Kotlin code

### DIFF
--- a/example/kotlinlib/basic/7-dependency-injection/build.mill
+++ b/example/kotlinlib/basic/7-dependency-injection/build.mill
@@ -7,14 +7,13 @@ import kotlinlib.ksp.KspModule
 object dagger extends KspModule {
 
   def kotlinVersion = "2.2.0"
-
   def kspVersion = "2.0.2"
-
   def kspJvmTarget = "17"
 
   def mainClass = Some("com.example.dagger.MainKt")
 
   def kotlincOptions = super.kotlincOptions() ++ Seq("-no-reflect", "-verbose")
+  override def kotlincUseBtApi = false
 
   def mvnDeps = super.mvnDeps() ++ Seq(
     mvn"com.google.dagger:dagger:2.57"
@@ -36,7 +35,6 @@ object dagger extends KspModule {
     def kotlinSymbolProcessors = Seq(
       mvn"com.google.dagger:dagger-compiler:2.57"
     )
-
   }
 }
 

--- a/example/kotlinlib/basic/7-dependency-injection/build.mill
+++ b/example/kotlinlib/basic/7-dependency-injection/build.mill
@@ -13,7 +13,8 @@ object dagger extends KspModule {
   def mainClass = Some("com.example.dagger.MainKt")
 
   def kotlincOptions = super.kotlincOptions() ++ Seq("-no-reflect", "-verbose")
-  override def kotlincUseBtApi = false
+
+//  override def kotlincUseBtApi = false
 
   def mvnDeps = super.mvnDeps() ++ Seq(
     mvn"com.google.dagger:dagger:2.57"
@@ -44,12 +45,20 @@ object dagger extends KspModule {
 
 /** Usage
 
-> ./mill dagger.compile
+> ./mill show dagger.generatedSources
+[
+  "ref:v0:.../out/dagger/generatedSourcesWithKsp2.dest/generated/java",
+  "ref:v0:.../out/dagger/generatedSourcesWithKsp2.dest/generated/kotlin"
+]
 
 > ls out/dagger/generatedSourcesWithKsp2.dest/generated/java/com/example/dagger/
 DaggerNumberApp.java
 NumberService_Factory.java
 RandomNumberGenerator_Factory.java
+
+> ./mill dagger.compile
+Compiling 6 Kotlin sources and reading 3 Java sources to .../out/dagger/compile.dest/classes ...
+Compiling 3 Java sources to .../out/dagger/compile.dest/classes ...
 
 > ./mill dagger.run
 Random number: ...

--- a/example/thirdparty/arrow/build.mill
+++ b/example/thirdparty/arrow/build.mill
@@ -131,6 +131,7 @@ object `package` extends Module {
       def kotlinLanguageVersion = majorVersion(kotlinVersion())
       def kotlinApiVersion = majorVersion(kotlinVersion())
       def kotlinExplicitApi = ArrowMultiplatformModule.this.kotlinExplicitApi
+      def kotlincUseBtApi = false
 
       override def sources: T[Seq[PathRef]] = Task.Sources({
         val sourcesRootPath = moduleDir / "src"

--- a/libs/javalib/src/mill/javalib/JavaHomeModule.scala
+++ b/libs/javalib/src/mill/javalib/JavaHomeModule.scala
@@ -7,6 +7,7 @@ import mill.api.{PathRef, Task}
  * Common trait for modules that use either a custom or a globally shared [[JvmWorkerModule]].
  */
 trait JavaHomeModule extends CoursierModule {
+
   def jvmId: T[String] = ""
 
   def jvmIndexVersion: T[String] = mill.javalib.api.Versions.coursierJvmIndexVersion

--- a/libs/javalib/src/mill/javalib/JavaModule.scala
+++ b/libs/javalib/src/mill/javalib/JavaModule.scala
@@ -68,6 +68,7 @@ trait JavaModule
     () => genIdeaInternalExt()
 
   override def jvmWorker: ModuleRef[JvmWorkerModule] = super.jvmWorker
+
   trait JavaTests extends JavaModule with TestModule {
     // Run some consistence checks
     hierarchyChecks()

--- a/libs/javalib/src/mill/javalib/SemanticDbJavaModule.scala
+++ b/libs/javalib/src/mill/javalib/SemanticDbJavaModule.scala
@@ -16,7 +16,7 @@ import mill.javalib.api.internal.{JavaCompilerOptions, ZincCompileJava}
 @experimental
 trait SemanticDbJavaModule extends CoursierModule with SemanticDbJavaModuleApi
     with WithJvmWorkerModule {
-  
+
   def jvmWorker: ModuleRef[JvmWorkerModule]
 
   def upstreamSemanticDbDatas: Task[Seq[SemanticDbJavaModule.SemanticDbData]] =

--- a/libs/javalib/src/mill/javalib/SemanticDbJavaModule.scala
+++ b/libs/javalib/src/mill/javalib/SemanticDbJavaModule.scala
@@ -16,6 +16,7 @@ import mill.javalib.api.internal.{JavaCompilerOptions, ZincCompileJava}
 @experimental
 trait SemanticDbJavaModule extends CoursierModule with SemanticDbJavaModuleApi
     with WithJvmWorkerModule {
+  
   def jvmWorker: ModuleRef[JvmWorkerModule]
 
   def upstreamSemanticDbDatas: Task[Seq[SemanticDbJavaModule.SemanticDbData]] =

--- a/libs/kotlinlib/api/src/mill/kotlinlib/worker/api/KotlinWorker.scala
+++ b/libs/kotlinlib/api/src/mill/kotlinlib/worker/api/KotlinWorker.scala
@@ -10,8 +10,10 @@ import mill.api.Result
 
 trait KotlinWorker {
 
-  def compile(target: KotlinWorkerTarget, args: Seq[String], sources: Seq[os.Path])(implicit
-      ctx: TaskCtx
-  ): Result[Unit]
+  def compile(
+      target: KotlinWorkerTarget,
+      args: Seq[String],
+      sources: Seq[os.Path]
+  )(implicit ctx: TaskCtx): Result[Unit]
 
 }

--- a/libs/kotlinlib/api/src/mill/kotlinlib/worker/api/KotlinWorker.scala
+++ b/libs/kotlinlib/api/src/mill/kotlinlib/worker/api/KotlinWorker.scala
@@ -5,17 +5,14 @@
  */
 package mill.kotlinlib.worker.api
 
-import mill.api.{TaskCtx}
-import mill.api.{Result}
+import mill.api.TaskCtx
+import mill.api.Result
 
 trait KotlinWorker {
 
-  def compile(target: KotlinWorkerTarget, args: Seq[String])(implicit ctx: TaskCtx): Result[Unit]
-  val x = 1
+  def compile(target: KotlinWorkerTarget, args: Seq[String], sources: Seq[os.Path])(implicit ctx: TaskCtx): Result[Unit]
+
 }
 
-sealed trait KotlinWorkerTarget
-object KotlinWorkerTarget {
-  case object Jvm extends KotlinWorkerTarget
-  case object Js extends KotlinWorkerTarget
-}
+
+

--- a/libs/kotlinlib/api/src/mill/kotlinlib/worker/api/KotlinWorker.scala
+++ b/libs/kotlinlib/api/src/mill/kotlinlib/worker/api/KotlinWorker.scala
@@ -11,8 +11,8 @@ import mill.api.Result
 trait KotlinWorker {
 
   def compile(
-      kotlinVersion: String,
       target: KotlinWorkerTarget,
+      useBtApi: Boolean,
       args: Seq[String],
       sources: Seq[os.Path]
   )(implicit ctx: TaskCtx): Result[Unit]

--- a/libs/kotlinlib/api/src/mill/kotlinlib/worker/api/KotlinWorker.scala
+++ b/libs/kotlinlib/api/src/mill/kotlinlib/worker/api/KotlinWorker.scala
@@ -7,7 +7,6 @@ package mill.kotlinlib.worker.api
 
 import mill.api.TaskCtx
 import mill.api.Result
-import mill.util.Version
 
 trait KotlinWorker {
 

--- a/libs/kotlinlib/api/src/mill/kotlinlib/worker/api/KotlinWorker.scala
+++ b/libs/kotlinlib/api/src/mill/kotlinlib/worker/api/KotlinWorker.scala
@@ -7,10 +7,12 @@ package mill.kotlinlib.worker.api
 
 import mill.api.TaskCtx
 import mill.api.Result
+import mill.util.Version
 
 trait KotlinWorker {
 
   def compile(
+      kotlinVersion: String,
       target: KotlinWorkerTarget,
       args: Seq[String],
       sources: Seq[os.Path]

--- a/libs/kotlinlib/api/src/mill/kotlinlib/worker/api/KotlinWorker.scala
+++ b/libs/kotlinlib/api/src/mill/kotlinlib/worker/api/KotlinWorker.scala
@@ -10,9 +10,8 @@ import mill.api.Result
 
 trait KotlinWorker {
 
-  def compile(target: KotlinWorkerTarget, args: Seq[String], sources: Seq[os.Path])(implicit ctx: TaskCtx): Result[Unit]
+  def compile(target: KotlinWorkerTarget, args: Seq[String], sources: Seq[os.Path])(implicit
+      ctx: TaskCtx
+  ): Result[Unit]
 
 }
-
-
-

--- a/libs/kotlinlib/api/src/mill/kotlinlib/worker/api/KotlinWorkerTarget.scala
+++ b/libs/kotlinlib/api/src/mill/kotlinlib/worker/api/KotlinWorkerTarget.scala
@@ -1,0 +1,8 @@
+package mill.kotlinlib.worker.api
+
+sealed trait KotlinWorkerTarget
+
+object KotlinWorkerTarget {
+  case object Jvm extends KotlinWorkerTarget
+  case object Js extends KotlinWorkerTarget
+}

--- a/libs/kotlinlib/package.mill
+++ b/libs/kotlinlib/package.mill
@@ -39,15 +39,9 @@ object `package` extends MillStableScalaModule with BuildInfo {
     )
   )
 
-  trait MillKotlinModule extends MillPublishScalaModule {
-    override def javacOptions = super.javacOptions() ++ {
-      val release =
-        if (scala.util.Properties.isJavaAtLeast(11)) Seq("-release", "8")
-        else Seq("-source", "1.8", "-target", "1.8")
-      release ++ Seq("-encoding", "UTF-8", "-deprecation")
-    }
-  }
+  trait MillKotlinModule extends MillPublishScalaModule
 
+  // shared between kotlinlib and kotlinlib.worker
   object api extends MillKotlinModule {
     def moduleDeps = Seq(build.libs.javalib.testrunner)
 
@@ -64,7 +58,8 @@ object `package` extends MillStableScalaModule with BuildInfo {
     override def compileMvnDeps: T[Seq[Dep]] =
       super.mandatoryMvnDeps() ++ Seq(
         Deps.osLib,
-        Deps.kotlinCompiler
+        Deps.kotlinCompiler,
+        Deps.kotlinBuildToolsApi
       )
   }
 

--- a/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -334,7 +334,7 @@ trait KotlinModule extends JavaModule with KotlinModuleApi { outer =>
       }
 
       if (isMixed || isKotlin) {
-        val extra = if(isJava) s"and ${javaSourceFiles.size} Java sources " else ""
+        val extra = if(isJava) s"and reading ${javaSourceFiles.size} Java sources " else ""
         ctx.log.info(
           s"Compiling ${kotlinSourceFiles.size} Kotlin sources ${extra}to ${classes} ..."
         )

--- a/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -334,8 +334,9 @@ trait KotlinModule extends JavaModule with KotlinModuleApi { outer =>
       }
 
       if (isMixed || isKotlin) {
+        val extra = if(isJava) s"and ${javaSourceFiles.size} Java sources " else ""
         ctx.log.info(
-          s"Compiling ${kotlinSourceFiles.size} Kotlin sources to ${classes} ..."
+          s"Compiling ${kotlinSourceFiles.size} Kotlin sources ${extra}to ${classes} ..."
         )
 
         val compilerArgs: Seq[String] = Seq(

--- a/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -490,6 +490,7 @@ trait KotlinModule extends JavaModule with KotlinModuleApi { outer =>
     }
     override def kotlinUseEmbeddableCompiler: Task[Boolean] =
       Task.Anon { outer.kotlinUseEmbeddableCompiler() }
+    override def kotlincUseBtApi: Task.Simple[Boolean] = Task { outer.kotlincUseBtApi() }
   }
 
 }

--- a/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -334,7 +334,7 @@ trait KotlinModule extends JavaModule with KotlinModuleApi { outer =>
       }
 
       if (isMixed || isKotlin) {
-        val extra = if(isJava) s"and reading ${javaSourceFiles.size} Java sources " else ""
+        val extra = if (isJava) s"and reading ${javaSourceFiles.size} Java sources " else ""
         ctx.log.info(
           s"Compiling ${kotlinSourceFiles.size} Kotlin sources ${extra}to ${classes} ..."
         )

--- a/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -359,9 +359,10 @@ trait KotlinModule extends JavaModule with KotlinModuleApi { outer =>
         val workerResult =
           KotlinWorkerManager.kotlinWorker().withValue(kotlinCompilerClasspath()) {
             _.compile(
-              KotlinWorkerTarget.Jvm,
-              compilerArgs,
-              kotlinSourceFiles ++ javaSourceFiles
+              kotlinVersion = kotlinVersion(),
+              target = KotlinWorkerTarget.Jvm,
+              args = compilerArgs,
+              sources = kotlinSourceFiles ++ javaSourceFiles
             )
           }
 

--- a/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -12,11 +12,11 @@ import mill.api.Result
 import mill.api.ModuleRef
 import mill.kotlinlib.worker.api.KotlinWorkerTarget
 import mill.javalib.api.CompilationResult
-import mill.javalib.api.{JvmWorkerApi => PublicJvmWorkerApi}
+import mill.javalib.api.JvmWorkerApi as PublicJvmWorkerApi
 import mill.javalib.api.internal.JvmWorkerApi
 import mill.api.daemon.internal.{CompileProblemReporter, KotlinModuleApi, internal}
 import mill.javalib.{JavaModule, JvmWorkerModule, Lib}
-import mill.util.Jvm
+import mill.util.{Jvm, Version}
 import mill.*
 
 import java.io.File
@@ -359,8 +359,8 @@ trait KotlinModule extends JavaModule with KotlinModuleApi { outer =>
         val workerResult =
           KotlinWorkerManager.kotlinWorker().withValue(kotlinCompilerClasspath()) {
             _.compile(
-              kotlinVersion = kotlinVersion(),
               target = KotlinWorkerTarget.Jvm,
+              useBtApi = kotlincUseBtApi(),
               args = compilerArgs,
               sources = kotlinSourceFiles ++ javaSourceFiles
             )
@@ -391,6 +391,15 @@ trait KotlinModule extends JavaModule with KotlinModuleApi { outer =>
    * Additional Kotlin compiler options to be used by [[compile]].
    */
   def kotlincOptions: T[Seq[String]] = Task { Seq.empty[String] }
+
+  /**
+   * Enable use of new Kotlin Build API (Beta).
+   * Enabled by default for Kotlin 2.x targetting the JVM.
+   */
+  def kotlincUseBtApi: T[Boolean] = Task {
+    Version.parse(kotlinVersion())
+      .isNewerThan(Version.parse("2.0.0"))(Version.IgnoreQualifierOrdering)
+  }
 
   /**
    * Mandatory command-line options to pass to the Kotlin compiler

--- a/libs/kotlinlib/src/mill/kotlinlib/js/KotlinJsModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/js/KotlinJsModule.scala
@@ -415,7 +415,12 @@ trait KotlinJsModule extends KotlinModule { outer =>
     } else {
       Task.log.info(s"Linking IR to $compileDestination")
     }
-    val workerResult = worker.compile(KotlinWorkerTarget.Js, compilerArgs, inputFiles)
+    val workerResult = worker.compile(
+      kotlinVersion = kotlinVersion(),
+      target = KotlinWorkerTarget.Js,
+      args = compilerArgs,
+      sources = inputFiles
+    )
 
     val analysisFile = Task.dest / "kotlin.analysis.dummy"
     if (!os.exists(analysisFile)) {

--- a/libs/kotlinlib/src/mill/kotlinlib/js/KotlinJsModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/js/KotlinJsModule.scala
@@ -416,7 +416,7 @@ trait KotlinJsModule extends KotlinModule { outer =>
       Task.log.info(s"Linking IR to $compileDestination")
     }
     val workerResult = worker.compile(
-      kotlinVersion = kotlinVersion(),
+      kotlinVersion = kotlinVersion,
       target = KotlinWorkerTarget.Js,
       args = compilerArgs,
       sources = inputFiles

--- a/libs/kotlinlib/src/mill/kotlinlib/ksp/KspModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/ksp/KspModule.scala
@@ -239,12 +239,12 @@ trait KspModule extends KotlinModule { outer =>
       compileCp.iterator.mkString(File.pathSeparator)
     )
 
-    val compilerArgs: Seq[String] = classpath ++ kspCompilerArgs ++ sourceFiles.map(_.toString)
+    val compilerArgs: Seq[String] = classpath ++ kspCompilerArgs
 
     Task.log.info(s"KSP arguments: ${compilerArgs.mkString(" ")}")
 
     KotlinWorkerManager.kotlinWorker().withValue(kotlinCompilerClasspath()) {
-      _.compile(KotlinWorkerTarget.Jvm, compilerArgs)
+      _.compile(KotlinWorkerTarget.Jvm, compilerArgs, sourceFiles)
     }
 
     GeneratedKspSources(PathRef(java), PathRef(kotlin), PathRef(resources), PathRef(classes))

--- a/libs/kotlinlib/src/mill/kotlinlib/ksp/KspModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/ksp/KspModule.scala
@@ -244,7 +244,12 @@ trait KspModule extends KotlinModule { outer =>
     Task.log.info(s"KSP arguments: ${compilerArgs.mkString(" ")}")
 
     KotlinWorkerManager.kotlinWorker().withValue(kotlinCompilerClasspath()) {
-      _.compile(KotlinWorkerTarget.Jvm, compilerArgs, sourceFiles)
+      _.compile(
+        kotlinVersion = kotlinVersion(),
+        target = KotlinWorkerTarget.Jvm,
+        args = compilerArgs,
+        sources = sourceFiles
+      )
     }
 
     GeneratedKspSources(PathRef(java), PathRef(kotlin), PathRef(resources), PathRef(classes))

--- a/libs/kotlinlib/src/mill/kotlinlib/ksp/KspModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/ksp/KspModule.scala
@@ -260,8 +260,8 @@ trait KspModule extends KotlinModule { outer =>
 
     KotlinWorkerManager.kotlinWorker().withValue(kotlinCompilerClasspath()) {
       _.compile(
-        kotlinVersion = kotlinVersion(),
         target = KotlinWorkerTarget.Jvm,
+        useBtApi = kotlincUseBtApi(),
         args = compilerArgs,
         sources = sourceFiles
       )

--- a/libs/kotlinlib/test/src/mill/kotlinlib/HelloKotlinTests.scala
+++ b/libs/kotlinlib/test/src/mill/kotlinlib/HelloKotlinTests.scala
@@ -10,7 +10,7 @@ import utest.*
 object HelloKotlinTests extends TestSuite {
 
   val crossMatrix = for {
-    kotlinVersion <- Seq("1.9.24", "2.0.20", "2.1.0")
+    kotlinVersion <- Seq("1.9.24", "2.0.20", "2.1.20", Versions.kotlinVersion).distinct
     embeddable <- Seq(false, true)
   } yield (kotlinVersion, embeddable)
 

--- a/libs/kotlinlib/test/src/mill/kotlinlib/js/KotlinJsKotlinVersionsTests.scala
+++ b/libs/kotlinlib/test/src/mill/kotlinlib/js/KotlinJsKotlinVersionsTests.scala
@@ -48,7 +48,6 @@ object KotlinJsKotlinVersionsTests extends TestSuite {
   def tests: Tests = Tests {
     test("compile with lowest Kotlin version") {
       testEval().scoped { eval =>
-
         val Right(_) = eval.apply(module.foo(kotlinLowestVersion).compile): @unchecked
       }
     }

--- a/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/Compiler.scala
+++ b/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/Compiler.scala
@@ -1,0 +1,13 @@
+package mill.kotlinlib.worker.impl
+
+import mill.api.TaskCtx
+
+trait Compiler {
+  def compile(
+      args: Seq[String],
+      sources: Seq[os.Path]
+  )(implicit
+      ctx: TaskCtx
+  ): (Int, String)
+
+}

--- a/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JsCompileImpl.scala
+++ b/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JsCompileImpl.scala
@@ -1,0 +1,25 @@
+package mill.kotlinlib.worker.impl
+
+import mill.api.TaskCtx
+import org.jetbrains.kotlin.cli.js.K2JSCompiler
+
+
+class JsCompileImpl() {
+
+  def compile(
+      args: Seq[String],
+      sources: Seq[os.Path]
+  )(implicit
+      ctx: TaskCtx
+  ): (Int, String) = {
+
+    val compiler = new K2JSCompiler()
+    val allArgs = args ++ sources.map(_.toString)
+
+    val exitCode = compiler.exec(ctx.log.streams.err, allArgs*)
+
+    (exitCode.getCode(), exitCode.name())
+
+  }
+
+}

--- a/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JsCompileImpl.scala
+++ b/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JsCompileImpl.scala
@@ -3,7 +3,7 @@ package mill.kotlinlib.worker.impl
 import mill.api.TaskCtx
 import org.jetbrains.kotlin.cli.js.K2JSCompiler
 
-class JsCompileImpl() {
+class JsCompileImpl extends Compiler() {
 
   def compile(
       args: Seq[String],

--- a/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JsCompileImpl.scala
+++ b/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JsCompileImpl.scala
@@ -3,7 +3,6 @@ package mill.kotlinlib.worker.impl
 import mill.api.TaskCtx
 import org.jetbrains.kotlin.cli.js.K2JSCompiler
 
-
 class JsCompileImpl() {
 
   def compile(

--- a/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JvmCompileBtApiImpl.scala
+++ b/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JvmCompileBtApiImpl.scala
@@ -1,11 +1,7 @@
 package mill.kotlinlib.worker.impl
 
 import mill.api.TaskCtx
-import org.jetbrains.kotlin.buildtools.api.{
-  CompilationResult,
-  CompilationService,
-  ProjectId
-}
+import org.jetbrains.kotlin.buildtools.api.{CompilationResult, CompilationService, ProjectId}
 import org.jetbrains.kotlin.cli.common.ExitCode
 
 import java.util.UUID

--- a/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JvmCompileBtApiImpl.scala
+++ b/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JvmCompileBtApiImpl.scala
@@ -19,7 +19,7 @@ class JvmCompileBtApiImpl() extends Compiler {
     val incrementalCompilerStatePath = ctx.dest / "inc-state"
 
     val service = CompilationService.loadImplementation(getClass().getClassLoader())
-    val executionConfig = service.makeCompilerExecutionStrategyConfiguration()
+    val strategyConfig = service.makeCompilerExecutionStrategyConfiguration()
     val compilationConfig = service.makeJvmCompilationConfiguration().tap { conf =>
       val incrementalConfig =
         conf.makeClasspathSnapshotBasedIncrementalCompilationConfiguration()
@@ -30,7 +30,7 @@ class JvmCompileBtApiImpl() extends Compiler {
     val projectId = new ProjectId.ProjectUUID(UUID.randomUUID())
     val compilationResult = service.compileJvm(
       projectId,
-      executionConfig,
+      strategyConfig,
       compilationConfig,
       KotlinInterop.toKotlinList(sources.map(_.toIO).toArray),
       KotlinInterop.toKotlinList(args.toArray)

--- a/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JvmCompileBtApiImpl.scala
+++ b/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JvmCompileBtApiImpl.scala
@@ -1,0 +1,55 @@
+package mill.kotlinlib.worker.impl
+
+import mill.api.TaskCtx
+import org.jetbrains.kotlin.buildtools.api.{CompilationResult, CompilationService, ProjectId}
+import org.jetbrains.kotlin.cli.common.ExitCode
+
+import java.util.UUID
+import scala.util.chaining.scalaUtilChainingOps
+
+class JvmCompileBtApiImpl() {
+
+  def compile(
+      args: Seq[String],
+      sources: Seq[os.Path]
+  )(implicit
+      ctx: TaskCtx
+  ): (Int, String) = {
+
+    val incrementalCompilerStatePath = ctx.dest / "inc-state"
+
+    val service = CompilationService.loadImplementation(getClass().getClassLoader())
+    val executionConfig = service.makeCompilerExecutionStrategyConfiguration()
+    val compilationConfig = service.makeJvmCompilationConfiguration().tap { conf =>
+      val incrementalConfig =
+        conf.makeClasspathSnapshotBasedIncrementalCompilationConfiguration()
+      incrementalConfig.setRootProjectDir(ctx.workspace.toIO)
+      incrementalConfig.usePreciseJavaTracking(true)
+      incrementalConfig.setBuildDir(incrementalCompilerStatePath.toIO)
+    }
+    val projectId = new ProjectId.ProjectUUID(UUID.randomUUID())
+    val compilationResult = service.compileJvm(
+      projectId,
+      executionConfig,
+      compilationConfig,
+      KotlinInterop.toKotlinList(sources.map(_.toIO).toArray),
+      KotlinInterop.toKotlinList(args.toArray)
+    )
+
+    val exitCode = compilationResult match {
+      case CompilationResult.COMPILATION_SUCCESS => ExitCode.OK
+      case CompilationResult.COMPILATION_ERROR => ExitCode.COMPILATION_ERROR
+      case CompilationResult.COMPILATION_OOM_ERROR => ExitCode.OOM_ERROR
+      case CompilationResult.COMPILER_INTERNAL_ERROR => ExitCode.INTERNAL_ERROR
+    }
+
+    // Do we really need to call this (after each compilation)?
+    service.finishProjectCompilation(projectId)
+
+    //        val compiler = new K2JVMCompiler()
+    //        compiler.exec(ctx.log.streams.err, args*)
+
+    (exitCode.getCode(), exitCode.name())
+  }
+
+}

--- a/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JvmCompileBtApiImpl.scala
+++ b/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JvmCompileBtApiImpl.scala
@@ -7,7 +7,7 @@ import org.jetbrains.kotlin.cli.common.ExitCode
 import java.util.UUID
 import scala.util.chaining.scalaUtilChainingOps
 
-class JvmCompileBtApiImpl() {
+class JvmCompileBtApiImpl() extends Compiler {
 
   def compile(
       args: Seq[String],

--- a/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JvmCompileBtApiImpl.scala
+++ b/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JvmCompileBtApiImpl.scala
@@ -1,7 +1,11 @@
 package mill.kotlinlib.worker.impl
 
 import mill.api.TaskCtx
-import org.jetbrains.kotlin.buildtools.api.{CompilationResult, CompilationService, KotlinLogger, ProjectId}
+import org.jetbrains.kotlin.buildtools.api.{
+  CompilationResult,
+  CompilationService,
+  ProjectId
+}
 import org.jetbrains.kotlin.cli.common.ExitCode
 
 import java.util.UUID

--- a/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JvmCompileImpl.scala
+++ b/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JvmCompileImpl.scala
@@ -1,11 +1,7 @@
 package mill.kotlinlib.worker.impl
 
 import mill.api.TaskCtx
-import org.jetbrains.kotlin.buildtools.api.{CompilationResult, CompilationService, ProjectId}
-import org.jetbrains.kotlin.cli.common.ExitCode
-
-import java.util.UUID
-import scala.util.chaining.scalaUtilChainingOps
+import org.jetbrains.kotlin.cli.jvm.K2JVMCompiler
 
 class JvmCompileImpl() {
 
@@ -16,38 +12,10 @@ class JvmCompileImpl() {
       ctx: TaskCtx
   ): (Int, String) = {
 
-    val incrementalCompilerStatePath = ctx.dest / "inc-state"
+    val allArgs = args ++ sources.map(_.toString)
 
-    val service = CompilationService.loadImplementation(getClass().getClassLoader())
-    val executionConfig = service.makeCompilerExecutionStrategyConfiguration()
-    val compilationConfig = service.makeJvmCompilationConfiguration().tap { conf =>
-      val incrementalConfig =
-        conf.makeClasspathSnapshotBasedIncrementalCompilationConfiguration()
-      incrementalConfig.setRootProjectDir(ctx.workspace.toIO)
-      incrementalConfig.usePreciseJavaTracking(true)
-      incrementalConfig.setBuildDir(incrementalCompilerStatePath.toIO)
-    }
-    val projectId = new ProjectId.ProjectUUID(UUID.randomUUID())
-    val compilationResult = service.compileJvm(
-      projectId,
-      executionConfig,
-      compilationConfig,
-      KotlinInterop.toKotlinList(sources.map(_.toIO).toArray),
-      KotlinInterop.toKotlinList(args.toArray)
-    )
-
-    val exitCode = compilationResult match {
-      case CompilationResult.COMPILATION_SUCCESS => ExitCode.OK
-      case CompilationResult.COMPILATION_ERROR => ExitCode.COMPILATION_ERROR
-      case CompilationResult.COMPILATION_OOM_ERROR => ExitCode.OOM_ERROR
-      case CompilationResult.COMPILER_INTERNAL_ERROR => ExitCode.INTERNAL_ERROR
-    }
-
-    // Do we really need to call this (after each compilation)?
-    service.finishProjectCompilation(projectId)
-
-    //        val compiler = new K2JVMCompiler()
-    //        compiler.exec(ctx.log.streams.err, args*)
+    val compiler = new K2JVMCompiler()
+    val exitCode = compiler.exec(ctx.log.streams.err, allArgs*)
 
     (exitCode.getCode(), exitCode.name())
   }

--- a/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JvmCompileImpl.scala
+++ b/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JvmCompileImpl.scala
@@ -1,0 +1,54 @@
+package mill.kotlinlib.worker.impl
+
+import mill.api.TaskCtx
+import org.jetbrains.kotlin.buildtools.api.{CompilationResult, CompilationService, ProjectId}
+import org.jetbrains.kotlin.cli.common.ExitCode
+
+import java.util.UUID
+import scala.util.chaining.scalaUtilChainingOps
+
+
+class JvmCompileImpl() {
+
+  def compile(
+      args: Seq[String],
+      sources: Seq[os.Path]
+  )(implicit
+      ctx: TaskCtx
+  ): (Int, String) = {
+
+    val incrementalCompilerStatePath = ctx.dest / "inc-state"
+
+    val service = CompilationService.loadImplementation(getClass().getClassLoader())
+    val executionConfig = service.makeCompilerExecutionStrategyConfiguration()
+    val compilationConfig = service.makeJvmCompilationConfiguration().tap { conf =>
+      val incrementalConfig =
+        conf.makeClasspathSnapshotBasedIncrementalCompilationConfiguration()
+      incrementalConfig.setRootProjectDir(ctx.workspace.toIO)
+      incrementalConfig.usePreciseJavaTracking(true)
+      incrementalConfig.setBuildDir(incrementalCompilerStatePath.toIO)
+    }
+    val projectId = new ProjectId.ProjectUUID(UUID.randomUUID())
+    val compilationResult = service.compileJvm(
+      projectId,
+      executionConfig,
+      compilationConfig,
+      KotlinInterop.toKotlinList(sources.map(_.toIO).toArray),
+      KotlinInterop.toKotlinList(args.toArray)
+    )
+
+    val exitCode = compilationResult match {
+      case CompilationResult.COMPILATION_SUCCESS => ExitCode.OK
+      case CompilationResult.COMPILATION_ERROR => ExitCode.COMPILATION_ERROR
+      case CompilationResult.COMPILATION_OOM_ERROR => ExitCode.OOM_ERROR
+      case CompilationResult.COMPILER_INTERNAL_ERROR => ExitCode.INTERNAL_ERROR
+    }
+
+    //        val compiler = new K2JVMCompiler()
+    //        compiler.exec(ctx.log.streams.err, args*)
+
+
+    (exitCode.getCode(), exitCode.name())
+  }
+
+}

--- a/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JvmCompileImpl.scala
+++ b/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JvmCompileImpl.scala
@@ -43,6 +43,9 @@ class JvmCompileImpl() {
       case CompilationResult.COMPILER_INTERNAL_ERROR => ExitCode.INTERNAL_ERROR
     }
 
+    // Do we really need to call this (after each compilation)?
+    service.finishProjectCompilation(projectId)
+
     //        val compiler = new K2JVMCompiler()
     //        compiler.exec(ctx.log.streams.err, args*)
 

--- a/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JvmCompileImpl.scala
+++ b/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JvmCompileImpl.scala
@@ -3,7 +3,7 @@ package mill.kotlinlib.worker.impl
 import mill.api.TaskCtx
 import org.jetbrains.kotlin.cli.jvm.K2JVMCompiler
 
-class JvmCompileImpl() {
+class JvmCompileImpl() extends Compiler {
 
   def compile(
       args: Seq[String],

--- a/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JvmCompileImpl.scala
+++ b/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JvmCompileImpl.scala
@@ -7,7 +7,6 @@ import org.jetbrains.kotlin.cli.common.ExitCode
 import java.util.UUID
 import scala.util.chaining.scalaUtilChainingOps
 
-
 class JvmCompileImpl() {
 
   def compile(
@@ -46,7 +45,6 @@ class JvmCompileImpl() {
 
     //        val compiler = new K2JVMCompiler()
     //        compiler.exec(ctx.log.streams.err, args*)
-
 
     (exitCode.getCode(), exitCode.name())
   }

--- a/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/KotlinInterop.java
+++ b/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/KotlinInterop.java
@@ -6,5 +6,4 @@ public class KotlinInterop {
   public static <T> List<T> toKotlinList(T[] args) {
     return kotlin.collections.CollectionsKt.listOf(args);
   }
-
 }

--- a/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/KotlinInterop.java
+++ b/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/KotlinInterop.java
@@ -1,0 +1,10 @@
+package mill.kotlinlib.worker.impl;
+
+import java.util.List;
+
+public class KotlinInterop {
+  public static <T> List<T> toKotlinList(T[] args) {
+    return kotlin.collections.CollectionsKt.listOf(args);
+  }
+
+}

--- a/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/KotlinWorkerImpl.scala
+++ b/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/KotlinWorkerImpl.scala
@@ -30,7 +30,7 @@ class KotlinWorkerImpl extends KotlinWorker {
       case (target = KotlinWorkerTarget.Js) => JsCompileImpl()
     }
 
-    ctx.log.info(s"Using compiler backend: ${compiler.getClass().getSimpleName()}")
+    ctx.log.debug(s"Using compiler backend: ${compiler.getClass().getSimpleName()}")
 
     val (exitCode, exitCodeName) = compiler.compile(args, sources)
 

--- a/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/KotlinWorkerImpl.scala
+++ b/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/KotlinWorkerImpl.scala
@@ -19,9 +19,8 @@ class KotlinWorkerImpl extends KotlinWorker {
   )(implicit
       ctx: TaskCtx
   ): Result[Unit] = {
-    ctx.log.debug(s"Using Kotlin ${kotlinVersion} compiler arguments: " + args.map(v =>
-      s"'${v}'"
-    ).mkString(" "))
+    ctx.log.debug(s"Using Kotlin ${kotlinVersion} compiler arguments: " +
+      args.map(v => s"'${v}'").mkString(" "))
 
     val kv = Version.parse(kotlinVersion)
 

--- a/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/KotlinWorkerImpl.scala
+++ b/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/KotlinWorkerImpl.scala
@@ -19,13 +19,16 @@ class KotlinWorkerImpl extends KotlinWorker {
   )(implicit
       ctx: TaskCtx
   ): Result[Unit] = {
-    ctx.log.debug(s"Using Kotlin ${kotlinVersion} compiler arguments: " + args.map(v => s"'${v}'").mkString(" "))
+    ctx.log.debug(s"Using Kotlin ${kotlinVersion} compiler arguments: " + args.map(v =>
+      s"'${v}'"
+    ).mkString(" "))
 
     val kv = Version.parse(kotlinVersion)
 
     val (exitCode, exitCodeName) = target match {
 
-      case KotlinWorkerTarget.Jvm if kv.isNewerThan(Version.parse("2.0.0"))(Version.IgnoreQualifierOrdering) =>
+      case KotlinWorkerTarget.Jvm
+          if kv.isNewerThan(Version.parse("2.0.0"))(Version.IgnoreQualifierOrdering) =>
         // Use dedicated class to load classes lazily
         JvmCompileBtApiImpl().compile(args, sources)
 

--- a/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/KotlinWorkerImpl.scala
+++ b/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/KotlinWorkerImpl.scala
@@ -21,6 +21,8 @@ class KotlinWorkerImpl extends KotlinWorker {
     ctx.log.debug(s"Using Kotlin compiler arguments: " +
       args.map(v => s"'${v}'").mkString(" "))
 
+    ctx.log.debug(s"Using source files: ${sources.map(v => s"'${v}'").mkString(" ")}")
+
     // Use dedicated class to load implementation classes lazily
     val compiler = (target = target, useBtApi = useBtApi) match {
       case (KotlinWorkerTarget.Jvm, true) => JvmCompileBtApiImpl()

--- a/libs/scalalib/test/src/mill/scalalib/ScalaValidatedPathRefTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/ScalaValidatedPathRefTests.scala
@@ -6,6 +6,7 @@ import mill.testkit.UnitTester
 import mill.testkit.TestRootModule
 import utest.*
 
+// TODO: Move into Java module or even further up
 object ScalaValidatedPathRefTests extends TestSuite {
 
   object ValidatedTarget extends TestRootModule {

--- a/mill-build/src/millbuild/Deps.scala
+++ b/mill-build/src/millbuild/Deps.scala
@@ -191,6 +191,8 @@ object Deps {
   val sonatypeCentralClient = mvn"com.lumidion::sonatype-central-client-requests:0.5.0"
   val kotlinVersion = "2.1.20"
   val kotlinCompiler = mvn"org.jetbrains.kotlin:kotlin-compiler:$kotlinVersion"
+  val kotlinBuildToolsApi = mvn"org.jetbrains.kotlin:kotlin-build-tools-api:$kotlinVersion"
+  val kotlinBuildToolsImpl = mvn"org.jetbrains.kotlin:kotlin-build-tools-impl:$kotlinVersion"
 
   /** Used for the `mill init` from a Maven project. */
   object MavenInit {

--- a/mill-build/src/millbuild/MillPublishJavaModule.scala
+++ b/mill-build/src/millbuild/MillPublishJavaModule.scala
@@ -3,12 +3,7 @@ package millbuild
 import build_.package_ as build
 import mill.Task
 import mill.scalalib.PublishModule
-import mill.scalalib.publish.{
-  Developer,
-  License,
-  PomSettings,
-  VersionControl
-}
+import mill.scalalib.publish.{Developer, License, PomSettings, VersionControl}
 
 trait MillPublishJavaModule extends MillJavaModule with PublishModule {
 

--- a/mill-build/src/millbuild/MillPublishJavaModule.scala
+++ b/mill-build/src/millbuild/MillPublishJavaModule.scala
@@ -1,19 +1,12 @@
 package millbuild
 
 import build_.package_ as build
-import coursier.MavenRepository
-import mill.PathRef
-import mill.T
 import mill.Task
-import mill.scalalib.Dep
-import mill.scalalib.JavaModule
 import mill.scalalib.PublishModule
 import mill.scalalib.publish.{
   Developer,
   License,
-  LocalM2Publisher,
   PomSettings,
-  PublishInfo,
   VersionControl
 }
 
@@ -26,7 +19,7 @@ trait MillPublishJavaModule extends MillJavaModule with PublishModule {
   )
   def pomSettings = MillPublishJavaModule.commonPomSettings(artifactName())
   def javacOptions =
-    super.javacOptions() ++ Seq("-source", "11", "-target", "11", "-encoding", "UTF-8")
+    super.javacOptions() ++ Seq("--release", "11", "-encoding", "UTF-8", "-deprecation")
 }
 
 object MillPublishJavaModule {


### PR DESCRIPTION
With Kotlin 2.2, there is a new beta build tools api (BT API) which should be used by build tools to integrate the Kotlin compiler. This PR adds support for this API and uses it by default if the module is using Kotlin 2.0+ for JVM.

Related to https://github.com/com-lihaoyi/mill/issues/5788