### PR TITLE
Read coursier env vars and Java properties via input tasks

### DIFF
--- a/integration/bootstrap/no-java-bootstrap/src/NoJavaBootstrapTests.scala
+++ b/integration/bootstrap/no-java-bootstrap/src/NoJavaBootstrapTests.scala
@@ -19,7 +19,7 @@ object NoJavaBootstrapTests extends UtestIntegrationTestSuite {
     val cache = FileCache()
     val index = JvmIndex.load(
       cache = cache,
-      repositories = Resolve().repositories,
+      repositories = Resolve.defaultRepositories,
       indexChannel = JvmChannel.module(
         JvmChannel.centralModule(),
         version = mill.api.BuildInfo.coursierJvmIndexVersion

--- a/integration/feature/cs-env-vars/resources/build.mill
+++ b/integration/feature/cs-env-vars/resources/build.mill
@@ -1,0 +1,12 @@
+package build
+import mill._, javalib._
+import java.io.File
+
+object `package` extends JavaModule {
+  def mvnDeps = Seq(
+    mvn"org.slf4j:slf4j-simple:2.0.9"
+  )
+  def printRunClasspath = Task {
+    println(runClasspath().map(_.path.toString).mkString(File.pathSeparator))
+  }
+}

--- a/integration/feature/cs-env-vars/resources/build.mill
+++ b/integration/feature/cs-env-vars/resources/build.mill
@@ -1,12 +1,13 @@
 package build
-import mill._, javalib._
+import mill._, scalalib._
 import java.io.File
 
-object `package` extends JavaModule {
+object `package` extends ScalaModule {
+  def scalaVersion = "2.13.16"
   def mvnDeps = Seq(
     mvn"org.slf4j:slf4j-simple:2.0.9"
   )
-  def printRunClasspath = Task {
+  def printRunClasspath() = Task.Command {
     println(runClasspath().map(_.path.toString).mkString(File.pathSeparator))
   }
 }

--- a/integration/feature/cs-env-vars/src/CsEnvVarsTests.scala
+++ b/integration/feature/cs-env-vars/src/CsEnvVarsTests.scala
@@ -1,5 +1,6 @@
 package mill.integration
 
+import coursier.cache.FileCache
 import mill.testkit.UtestIntegrationTestSuite
 import utest._
 
@@ -7,24 +8,67 @@ import java.io.File
 
 object CsEnvVarsTests extends UtestIntegrationTestSuite {
   val tests: Tests = Tests {
-    test("env vars") - integrationTest { tester =>
+    test("cache") - integrationTest { tester =>
       import tester._
 
-      def check(cache: os.Path): Unit = {
+      def check(cacheOpt: Option[os.Path]): Unit = {
+        val env = cacheOpt.toSeq.map { cache =>
+          "COURSIER_CACHE" -> cache.toString
+        }
         val res = eval(
           ("printRunClasspath"),
-          env = Map("COURSIER_CACHE" -> cache.toString)
+          env = env.toMap
         )
         assert(res.exitCode == 0)
 
-        pprint.err.log(res.out)
-        val cp = res.out.split(File.pathSeparator).map(os.Path(_))
-        assert(cp.exists(p => p.startsWith(cache) && p.last.startsWith("slf4j-api-")))
+        val cp = res.out.split(File.pathSeparator).filter(_.nonEmpty).map(os.Path(_))
+
+        val actualCache = cacheOpt.getOrElse(os.Path(FileCache().location))
+        assert(cp.exists(p => p.startsWith(actualCache) && p.last.startsWith("slf4j-api-")))
       }
 
-      check(workspacePath / "cache-0")
-      check(workspacePath / "cache-1")
-      check(workspacePath / "cache-2")
+      check(None)
+      check(Some(workspacePath / "cache-0"))
+      check(Some(workspacePath / "cache-1"))
+    }
+
+    test("mirrors") - integrationTest { tester =>
+      import tester._
+
+      def check(mirrorFileOpt: Option[os.Path]): Unit = {
+        val env = mirrorFileOpt.toSeq.map { file =>
+          "COURSIER_MIRRORS" -> file.toString
+        }
+        val res = eval(
+          ("printRunClasspath"),
+          env = env.toMap
+        )
+        assert(res.exitCode == 0)
+
+        val cacheRoot = os.Path(FileCache().location)
+        val cp = res.out.split(File.pathSeparator)
+          .filter(_.nonEmpty)
+          .map(os.Path(_))
+          .filter(_.startsWith(cacheRoot))
+          .map(_.relativeTo(cacheRoot).asSubPath)
+
+        val centralReplaced = cp.forall { f =>
+          f.startsWith(os.sub / "https/repo.maven.apache.org/maven2")
+        }
+        assert(cp.exists(f => f.last.startsWith("scala-library-") && f.last.endsWith(".jar")))
+        assert(mirrorFileOpt.nonEmpty == centralReplaced)
+      }
+
+      check(None)
+
+      val mirrorFile = workspacePath / "mirror.properties"
+      os.write(
+        mirrorFile,
+        """central.from=https://repo1.maven.org/maven2
+          |central.to=https://repo.maven.apache.org/maven2/
+          |""".stripMargin
+      )
+      check(Some(mirrorFile))
     }
   }
 }

--- a/integration/feature/cs-env-vars/src/CsEnvVarsTests.scala
+++ b/integration/feature/cs-env-vars/src/CsEnvVarsTests.scala
@@ -1,0 +1,30 @@
+package mill.integration
+
+import mill.testkit.UtestIntegrationTestSuite
+import utest._
+
+import java.io.File
+
+object CsEnvVarsTests extends UtestIntegrationTestSuite {
+  val tests: Tests = Tests {
+    test("env vars") - integrationTest { tester =>
+      import tester._
+
+      def check(cache: os.Path): Unit = {
+        val res = eval(
+          ("printRunClasspath"),
+          env = Map("COURSIER_CACHE" -> cache.toString)
+        )
+        assert(res.exitCode == 0)
+
+        pprint.err.log(res.out)
+        val cp = res.out.split(File.pathSeparator).map(os.Path(_))
+        assert(cp.exists(p => p.startsWith(cache) && p.last.startsWith("slf4j-api-")))
+      }
+
+      check(workspacePath / "cache-0")
+      check(workspacePath / "cache-1")
+      check(workspacePath / "cache-2")
+    }
+  }
+}

--- a/integration/ide/bsp-server/resources/snapshots/logging
+++ b/integration/ide/bsp-server/resources/snapshots/logging
@@ -3,10 +3,10 @@
 [1-buildInitialize] Entered buildInitialize
 [1-buildInitialize] Got client semanticdbVersion: * Enabling SemanticDB support.
 [1-buildInitialize] buildInitialize took * msec
-[bsp-init-mill-build/build.mill-58] [info] compiling * Scala sources to * ...
-[bsp-init-mill-build/build.mill-58] [info] done compiling
-[bsp-init-build.mill-58] [info] compiling * Scala sources to * ...
-[bsp-init-build.mill-58] [info] done compiling
+[bsp-init-mill-build/build.mill-59] [info] compiling * Scala sources to * ...
+[bsp-init-mill-build/build.mill-59] [info] done compiling
+[bsp-init-build.mill-59] [info] compiling * Scala sources to * ...
+[bsp-init-build.mill-59] [info] done compiling
 [bsp-init] SNAPSHOT
 [2-workspaceBuildTargets] Entered workspaceBuildTargets
 [2-workspaceBuildTargets] Evaluating * tasks
@@ -31,12 +31,12 @@
 [4-compile] buildTargetCompile took * msec
 [5-compile] Entered buildTargetCompile
 [5-compile] Evaluating 1 task
-[5-compile-54] [info] compiling * Scala source to * ...
-[5-compile-54] [error] *:2:3: not found: value nope
-[5-compile-54] [error]   nope
-[5-compile-54] [error]   ^
-[5-compile-54] [error] one error found
-[5-compile-54] errored.compilation-error.semanticDbDataDetailed failed
+[5-compile-55] [info] compiling * Scala source to * ...
+[5-compile-55] [error] *:2:3: not found: value nope
+[5-compile-55] [error]   nope
+[5-compile-55] [error]   ^
+[5-compile-55] [error] one error found
+[5-compile-55] errored.compilation-error.semanticDbDataDetailed failed
 [5-compile] Done
 [5-compile] buildTargetCompile took * msec
 [6-compile] Entered buildTargetCompile

--- a/libs/init/gradle/src/mill/main/gradle/GradleBuildGenMain.scala
+++ b/libs/init/gradle/src/mill/main/gradle/GradleBuildGenMain.scala
@@ -5,7 +5,7 @@ import mill.api.daemon.internal.internal
 import mill.main.buildgen.*
 import mill.main.buildgen.BuildGenUtil.*
 import mill.main.gradle.JavaModel.{Dep, ExternalDep}
-import mill.util.Jvm
+import mill.util.{CoursierConfig, Jvm}
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.tooling.GradleConnector
 import os.Path
@@ -59,7 +59,10 @@ object GradleBuildGenMain extends BuildGenBase.MavenAndGradle[ProjectModel, Dep]
     val args =
       cfg.shared.basicConfig.jvmId.map { id =>
         println(s"resolving Java home for jvmId $id")
-        val home = Jvm.resolveJavaHome(id).get
+        val home = Jvm.resolveJavaHome(
+          id,
+          config = CoursierConfig.default()
+        ).get
         s"-Dorg.gradle.java.home=$home"
       } ++ Seq("--init-script", writeGradleInitScript.toString())
 

--- a/libs/javalib/src/mill/javalib/CoursierConfigModule.scala
+++ b/libs/javalib/src/mill/javalib/CoursierConfigModule.scala
@@ -1,0 +1,180 @@
+package mill.javalib
+
+import coursier.CoursierEnv
+import coursier.cache.{CacheEnv, CachePolicy}
+import coursier.core.Repository
+import coursier.credentials.Credentials
+import coursier.params.Mirror
+import coursier.util.{EnvEntry, EnvValues}
+import mill.api.*
+import mill.{T, Task}
+
+import scala.concurrent.duration.Duration
+
+/**
+ * Reads coursier environment variables and Java properties
+ *
+ * This module reads environment variables and Java properties, and uses
+ * them to get default values for a number of coursier parameters, such as:
+ *
+ * * the coursier cache location, read from `COURSIER_CACHE` in the environment
+ *   and `coursier.cache` in Java properties. It is recommended to use an
+ *   absolute path rather than a relative one.
+ *
+ * * the coursier archive cache location, read from `COURSIER_ARCHIVE_CACHE` in
+ *   the environment and in `coursier.archive.cache` in Java properties.
+ *
+ * * credentials, read from `COURSIER_CREDENTIALS` in the environment, and
+ *   `coursier.credentials` in Java properties. Its format is documented
+ *   here: https://github.com/coursier/coursier/blob/701e93664855709db38e443cb7a19e36ddc49b78/doc/docs/other-credentials.md
+ *
+ * * TTL for snapshot artifacts / version listings / etc., read from
+ *   `COURSIER_TTL` in the environment and `coursier.ttl` in Java properties.
+ *   This value is parsed with `scala.concurrent.duration.Duration`, and accepts
+ *   formats like "5 hours", "1 day", etc. or just "0".
+ *
+ * * default repositories, read from `COURSIER_REPOSITORIES` in the environment
+ *   and `coursier.repositories` in Java properties. It can be set to values like
+ *   "ivy2Local|central|https://maven.google.com". Its format is documented here:
+ *   https://github.com/coursier/coursier/blob/701e93664855709db38e443cb7a19e36ddc49b78/doc/docs/other-repositories.md
+ *
+ * * mirror repository files, read from `COURSIER_MIRRORS` and `coursier.mirrors`,
+ *   whose file they point to should contains things like
+ *
+ *       google.from=https://repo1.maven.org/maven2
+ *       google.to=https://maven.google.com
+ *
+ * Environment variables always have precedence over Java properties.
+ */
+object CoursierConfigModule extends ExternalModule with CoursierConfigModule {
+  lazy val millDiscover = Discover[this.type]
+}
+
+trait CoursierConfigModule extends Module {
+
+  // All environment / Java properties "entries" that we're going to read.
+  // These are read all at once via coursierEnv.
+  private val entries = Seq(
+    CacheEnv.cache,
+    CacheEnv.credentials,
+    CacheEnv.ttl,
+    CacheEnv.cachePolicy,
+    CacheEnv.archiveCache,
+    CoursierEnv.mirrors,
+    CoursierEnv.mirrorsExtra,
+    CoursierEnv.repositories,
+    CoursierEnv.scalaCliConfig,
+    CoursierEnv.configDir
+  )
+
+  private val envVars = entries.map(_.envName).toSet
+  private val propNames = entries.map(_.propName).toSet
+
+  extension (entry: EnvEntry)
+    private def readFrom(env: Map[String, String], props: Map[String, String]): EnvValues =
+      EnvValues(env.get(entry.envName), props.get(entry.propName))
+
+  /**
+   * Environment variables and Java properties, and their values, used by coursier
+   */
+  def coursierEnv: T[(env: Map[String, String], props: Map[String, String])] = Task.Input {
+    val env = Task.env.filterKeys(envVars).toMap
+    val props =
+      propNames.iterator.flatMap(name => sys.props.get(name).iterator.map(name -> _)).toMap
+    (env, props)
+  }
+
+  /** Default repositories for dependency resolution */
+  def defaultRepositories: Task[Seq[Repository]] = Task.Anon {
+    val (env, props) = coursierEnv()
+    CoursierEnv.defaultRepositories(
+      CoursierEnv.repositories.readFrom(env, props),
+      CoursierEnv.scalaCliConfig.readFrom(env, props)
+    )
+  }
+
+  /** Default JSON configuration files to be used by coursier */
+  def defaultConfFiles: Task[Seq[PathRef]] = Task.Anon {
+    val (env, props) = coursierEnv()
+    CacheEnv.defaultConfFiles(CacheEnv.scalaCliConfig.readFrom(env, props))
+      .map(os.Path(_, BuildCtx.workspaceRoot))
+      .map(PathRef(_))
+  }
+
+  /** Default mirrors to be used by coursier */
+  def defaultMirrors: Task[Seq[Mirror]] = Task.Anon {
+    val (env, props) = coursierEnv()
+    CoursierEnv.defaultMirrors(
+      CoursierEnv.mirrors.readFrom(env, props),
+      CoursierEnv.mirrorsExtra.readFrom(env, props),
+      CoursierEnv.scalaCliConfig.readFrom(env, props),
+      CoursierEnv.configDir.readFrom(env, props)
+    )
+  }
+
+  /** Default cache location to be used by coursier */
+  def defaultCacheLocation: Task[String] = Task.Anon {
+    val (env, props) = coursierEnv()
+    val path: java.nio.file.Path = CacheEnv.defaultCacheLocation(
+      CacheEnv.cache.readFrom(env, props)
+    )
+    path.toString
+  }
+
+  /**
+   * Default archive cache location to be used by coursier
+   *
+   * This is the directory under which archives are unpacked
+   * by `coursier.cache.ArchiveCache`. This includes JVMs
+   * managed by coursier, which Mill relies on by default.
+   */
+  def defaultArchiveCacheLocation: Task[String] = Task.Anon {
+    val (env, props) = coursierEnv()
+    val path: java.nio.file.Path = CacheEnv.defaultArchiveCacheLocation(
+      CacheEnv.archiveCache.readFrom(env, props)
+    )
+    path.toString
+  }
+
+  /** Default repository credentials to be used by coursier */
+  def defaultCredentials: Task[Seq[Credentials]] = Task.Anon {
+    val (env, props) = coursierEnv()
+    CacheEnv.defaultCredentials(
+      CacheEnv.credentials.readFrom(env, props),
+      CacheEnv.scalaCliConfig.readFrom(env, props),
+      CacheEnv.configDir.readFrom(env, props)
+    )
+  }
+
+  /** Default TTL used by coursier when downloading changing artifacts such as snapshots */
+  def defaultTtl: Task[Option[Duration]] = Task.Anon {
+    val (env, props) = coursierEnv()
+    CacheEnv.defaultTtl(
+      CacheEnv.ttl.readFrom(env, props)
+    )
+  }
+
+  /** Default cache policies used by coursier when downloading artifacts */
+  def defaultCachePolicies: Task[Seq[CachePolicy]] = Task.Anon {
+    val (env, props) = coursierEnv()
+    CacheEnv.defaultCachePolicies(
+      CacheEnv.cachePolicy.readFrom(env, props)
+    )
+  }
+
+  /**
+   * Aggregates coursier parameters read from the environment
+   */
+  def coursierConfig: Task[mill.util.CoursierConfig] = Task.Anon {
+    mill.util.CoursierConfig(
+      defaultRepositories(),
+      defaultConfFiles().map(_.path),
+      defaultMirrors(),
+      defaultCacheLocation(),
+      defaultArchiveCacheLocation(),
+      defaultCredentials(),
+      defaultTtl(),
+      defaultCachePolicies()
+    )
+  }
+}

--- a/libs/javalib/src/mill/javalib/CoursierModule.scala
+++ b/libs/javalib/src/mill/javalib/CoursierModule.scala
@@ -1,5 +1,6 @@
 package mill.javalib
 
+import com.lihaoyi.unroll
 import coursier.cache.FileCache
 import coursier.core.Resolution
 import coursier.core.VariantSelector.VariantMatcher
@@ -235,35 +236,8 @@ object CoursierModule {
       // Introduced in https://github.com/com-lihaoyi/mill/commit/451df6846861a9c7d265bffec0c5fcf07133b320
       @unused offline: Boolean,
       checkGradleModules: Boolean,
-      config: mill.util.CoursierConfig
+      @unroll config: mill.util.CoursierConfig = mill.util.CoursierConfig.default()
   ) {
-
-    // bin-compat shim
-    def this(
-        repositories: Seq[Repository],
-        bind: Dep => BoundDep,
-        mapDependencies: Option[Dependency => Dependency],
-        customizer: Option[coursier.core.Resolution => coursier.core.Resolution],
-        coursierCacheCustomizer: Option[
-          coursier.cache.FileCache[coursier.util.Task] => coursier.cache.FileCache[
-            coursier.util.Task
-          ]
-        ],
-        resolutionParams: ResolutionParams,
-        offline: Boolean,
-        checkGradleModules: Boolean
-    ) =
-      this(
-        repositories,
-        bind,
-        mapDependencies,
-        customizer,
-        coursierCacheCustomizer,
-        resolutionParams,
-        offline,
-        checkGradleModules,
-        mill.util.CoursierConfig.default()
-      )
 
     /**
      * Class path of the passed dependencies

--- a/libs/javalib/src/mill/javalib/CoursierModule.scala
+++ b/libs/javalib/src/mill/javalib/CoursierModule.scala
@@ -12,8 +12,6 @@ import mill.util.Jvm
 import mill.T
 
 import scala.annotation.unused
-import scala.concurrent.Await
-import scala.concurrent.duration.Duration
 
 /**
  * This module provides the capability to resolve (transitive) dependencies from (remote) repositories.
@@ -104,11 +102,7 @@ trait CoursierModule extends mill.api.Module {
 
   // Bincompat stub
   private[mill] def repositoriesTask0 = Task.Anon {
-    val resolve = Resolve()
-    val repos = Await.result(
-      resolve.finalRepositories.future()(using resolve.cache.ec),
-      Duration.Inf
-    )
+    val repos = Resolve.defaultRepositories
     Jvm.reposFromStrings(repositories()).map(_ ++ repos)
   }
 

--- a/libs/javalib/src/mill/javalib/Dependency.scala
+++ b/libs/javalib/src/mill/javalib/Dependency.scala
@@ -23,7 +23,8 @@ object Dependency extends ExternalModule {
         ev,
         Task.ctx(),
         ev.rootModule,
-        allowPreRelease
+        allowPreRelease,
+        CoursierConfigModule
       )
     }
 

--- a/libs/javalib/src/mill/javalib/JavaHomeModule.scala
+++ b/libs/javalib/src/mill/javalib/JavaHomeModule.scala
@@ -27,7 +27,8 @@ trait JavaHomeModule extends CoursierModule {
         coursierCacheCustomizer = coursierCacheCustomizer(),
         ctx = Some(Task.ctx()),
         jvmIndexVersion = jvmIndexVersion(),
-        useShortPaths = useShortJvmPath(id)
+        useShortPaths = useShortJvmPath(id),
+        config = coursierConfigModule().coursierConfig()
       ).get
       // Java home is externally managed, better revalidate it at least once
       PathRef(path, quick = true).withRevalidateOnce

--- a/libs/javalib/src/mill/javalib/JavaModule.scala
+++ b/libs/javalib/src/mill/javalib/JavaModule.scala
@@ -1236,7 +1236,8 @@ trait JavaModule
         customizer = resolutionCustomizer(),
         coursierCacheCustomizer = coursierCacheCustomizer(),
         resolutionParams = resolutionParams(),
-        checkGradleModules = checkGradleModules()
+        checkGradleModules = checkGradleModules(),
+        config = coursierConfigModule().coursierConfig()
       ).get
 
       val roots = whatDependsOn match {

--- a/libs/javalib/src/mill/javalib/Lib.scala
+++ b/libs/javalib/src/mill/javalib/Lib.scala
@@ -39,7 +39,8 @@ object Lib {
       ] = None,
       resolutionParams: ResolutionParams = ResolutionParams(),
       boms: IterableOnce[BomDependency] = Nil,
-      checkGradleModules: Boolean = false
+      checkGradleModules: Boolean = false,
+      config: mill.util.CoursierConfig
   ): Result[Resolution] = {
     val depSeq = deps.iterator.toSeq
     mill.util.Jvm.resolveDependenciesMetadataSafe(
@@ -52,9 +53,37 @@ object Lib {
       coursierCacheCustomizer = coursierCacheCustomizer,
       resolutionParams = resolutionParams,
       boms = boms,
-      checkGradleModules = checkGradleModules
+      checkGradleModules = checkGradleModules,
+      config = config
     )
   }
+
+  // bin-compat shim
+  def resolveDependenciesMetadataSafe(
+      repositories: Seq[Repository],
+      deps: IterableOnce[BoundDep],
+      mapDependencies: Option[Dependency => Dependency],
+      customizer: Option[coursier.core.Resolution => coursier.core.Resolution],
+      ctx: Option[TaskCtx],
+      coursierCacheCustomizer: Option[
+        coursier.cache.FileCache[Task] => coursier.cache.FileCache[Task]
+      ],
+      resolutionParams: ResolutionParams,
+      boms: IterableOnce[BomDependency],
+      checkGradleModules: Boolean
+  ): Result[Resolution] =
+    resolveDependenciesMetadataSafe(
+      repositories,
+      deps,
+      mapDependencies,
+      customizer,
+      ctx,
+      coursierCacheCustomizer,
+      resolutionParams,
+      boms,
+      checkGradleModules,
+      mill.util.CoursierConfig.default()
+    )
 
   /**
    * Resolve dependencies using Coursier.
@@ -75,7 +104,8 @@ object Lib {
       ] = None,
       artifactTypes: Option[Set[Type]] = None,
       resolutionParams: ResolutionParams = ResolutionParams(),
-      checkGradleModules: Boolean = false
+      checkGradleModules: Boolean = false,
+      config: mill.util.CoursierConfig
   ): Result[Seq[PathRef]] = {
     val depSeq = deps.iterator.toSeq
     val res = mill.util.Jvm.resolveDependencies(
@@ -89,11 +119,41 @@ object Lib {
       ctx = ctx,
       coursierCacheCustomizer = coursierCacheCustomizer,
       resolutionParams = resolutionParams,
-      checkGradleModules = checkGradleModules
+      checkGradleModules = checkGradleModules,
+      config = config
     )
 
     res.map(_.map(_.withRevalidateOnce))
   }
+
+  // bin-compat shim
+  def resolveDependencies(
+      repositories: Seq[Repository],
+      deps: IterableOnce[BoundDep],
+      sources: Boolean,
+      mapDependencies: Option[Dependency => Dependency],
+      customizer: Option[coursier.core.Resolution => coursier.core.Resolution],
+      ctx: Option[TaskCtx],
+      coursierCacheCustomizer: Option[
+        coursier.cache.FileCache[Task] => coursier.cache.FileCache[Task]
+      ],
+      artifactTypes: Option[Set[Type]],
+      resolutionParams: ResolutionParams,
+      checkGradleModules: Boolean
+  ): Result[Seq[PathRef]] =
+    resolveDependencies(
+      repositories,
+      deps,
+      sources,
+      mapDependencies,
+      customizer,
+      ctx,
+      coursierCacheCustomizer,
+      artifactTypes,
+      resolutionParams,
+      checkGradleModules,
+      mill.util.CoursierConfig.default()
+    )
 
   def scalaCompilerMvnDeps(scalaOrganization: String, scalaVersion: String): Seq[Dep] =
     if (JvmWorkerUtil.isDotty(scalaVersion))

--- a/libs/javalib/src/mill/javalib/Lib.scala
+++ b/libs/javalib/src/mill/javalib/Lib.scala
@@ -1,6 +1,7 @@
 package mill
 package javalib
 
+import com.lihaoyi.unroll
 import coursier.core.BomDependency
 import coursier.params.ResolutionParams
 import coursier.util.Task
@@ -40,7 +41,7 @@ object Lib {
       resolutionParams: ResolutionParams = ResolutionParams(),
       boms: IterableOnce[BomDependency] = Nil,
       checkGradleModules: Boolean = false,
-      config: mill.util.CoursierConfig
+      @unroll config: mill.util.CoursierConfig = mill.util.CoursierConfig.default()
   ): Result[Resolution] = {
     val depSeq = deps.iterator.toSeq
     mill.util.Jvm.resolveDependenciesMetadataSafe(
@@ -57,33 +58,6 @@ object Lib {
       config = config
     )
   }
-
-  // bin-compat shim
-  def resolveDependenciesMetadataSafe(
-      repositories: Seq[Repository],
-      deps: IterableOnce[BoundDep],
-      mapDependencies: Option[Dependency => Dependency],
-      customizer: Option[coursier.core.Resolution => coursier.core.Resolution],
-      ctx: Option[TaskCtx],
-      coursierCacheCustomizer: Option[
-        coursier.cache.FileCache[Task] => coursier.cache.FileCache[Task]
-      ],
-      resolutionParams: ResolutionParams,
-      boms: IterableOnce[BomDependency],
-      checkGradleModules: Boolean
-  ): Result[Resolution] =
-    resolveDependenciesMetadataSafe(
-      repositories,
-      deps,
-      mapDependencies,
-      customizer,
-      ctx,
-      coursierCacheCustomizer,
-      resolutionParams,
-      boms,
-      checkGradleModules,
-      mill.util.CoursierConfig.default()
-    )
 
   /**
    * Resolve dependencies using Coursier.
@@ -105,7 +79,7 @@ object Lib {
       artifactTypes: Option[Set[Type]] = None,
       resolutionParams: ResolutionParams = ResolutionParams(),
       checkGradleModules: Boolean = false,
-      config: mill.util.CoursierConfig
+      @unroll config: mill.util.CoursierConfig = mill.util.CoursierConfig.default()
   ): Result[Seq[PathRef]] = {
     val depSeq = deps.iterator.toSeq
     val res = mill.util.Jvm.resolveDependencies(
@@ -125,35 +99,6 @@ object Lib {
 
     res.map(_.map(_.withRevalidateOnce))
   }
-
-  // bin-compat shim
-  def resolveDependencies(
-      repositories: Seq[Repository],
-      deps: IterableOnce[BoundDep],
-      sources: Boolean,
-      mapDependencies: Option[Dependency => Dependency],
-      customizer: Option[coursier.core.Resolution => coursier.core.Resolution],
-      ctx: Option[TaskCtx],
-      coursierCacheCustomizer: Option[
-        coursier.cache.FileCache[Task] => coursier.cache.FileCache[Task]
-      ],
-      artifactTypes: Option[Set[Type]],
-      resolutionParams: ResolutionParams,
-      checkGradleModules: Boolean
-  ): Result[Seq[PathRef]] =
-    resolveDependencies(
-      repositories,
-      deps,
-      sources,
-      mapDependencies,
-      customizer,
-      ctx,
-      coursierCacheCustomizer,
-      artifactTypes,
-      resolutionParams,
-      checkGradleModules,
-      mill.util.CoursierConfig.default()
-    )
 
   def scalaCompilerMvnDeps(scalaOrganization: String, scalaVersion: String): Seq[Dep] =
     if (JvmWorkerUtil.isDotty(scalaVersion))

--- a/libs/javalib/src/mill/javalib/dependency/DependencyUpdatesImpl.scala
+++ b/libs/javalib/src/mill/javalib/dependency/DependencyUpdatesImpl.scala
@@ -2,6 +2,7 @@ package mill.javalib.dependency
 
 import mill.api.*
 import mill.api.internal.RootModule0
+import mill.javalib.CoursierConfigModule
 import mill.javalib.dependency.updates.{DependencyUpdates, ModuleDependenciesUpdates, UpdatesFinder}
 import mill.javalib.dependency.versions.{ModuleDependenciesVersions, VersionsFinder}
 
@@ -11,11 +12,12 @@ object DependencyUpdatesImpl {
       evaluator: Evaluator,
       ctx: TaskCtx,
       rootModule: RootModule0,
-      allowPreRelease: Boolean
+      allowPreRelease: Boolean,
+      coursierConfigModule: CoursierConfigModule
   ): Seq[ModuleDependenciesUpdates] = {
     // 1. Find all available versions for each dependency
     val allDependencyVersions: Seq[ModuleDependenciesVersions] =
-      VersionsFinder.findVersions(evaluator, ctx, rootModule)
+      VersionsFinder.findVersions(evaluator, ctx, rootModule, coursierConfigModule)
 
     // 2. Extract updated versions from all available versions
     val allUpdates = allDependencyVersions.map { dependencyVersions =>
@@ -37,6 +39,21 @@ object DependencyUpdatesImpl {
     val _ = discover // unused but part of public API
     apply(evaluator, ctx, rootModule, allowPreRelease)
   }
+
+  @deprecated("Use the override accepting a CoursierConfigModule instead", "Mill after 1.0.0-RC3")
+  def apply(
+      evaluator: Evaluator,
+      ctx: TaskCtx,
+      rootModule: RootModule0,
+      allowPreRelease: Boolean
+  ): Seq[ModuleDependenciesUpdates] =
+    apply(
+      evaluator,
+      ctx,
+      rootModule,
+      allowPreRelease,
+      CoursierConfigModule
+    )
 
   def showAllUpdates(
       updates: Seq[ModuleDependenciesUpdates],

--- a/libs/javalib/src/mill/javalib/dependency/DependencyUpdatesImpl.scala
+++ b/libs/javalib/src/mill/javalib/dependency/DependencyUpdatesImpl.scala
@@ -1,5 +1,6 @@
 package mill.javalib.dependency
 
+import com.lihaoyi.unroll
 import mill.api.*
 import mill.api.internal.RootModule0
 import mill.javalib.CoursierConfigModule
@@ -13,7 +14,7 @@ object DependencyUpdatesImpl {
       ctx: TaskCtx,
       rootModule: RootModule0,
       allowPreRelease: Boolean,
-      coursierConfigModule: CoursierConfigModule
+      @unroll coursierConfigModule: CoursierConfigModule = CoursierConfigModule
   ): Seq[ModuleDependenciesUpdates] = {
     // 1. Find all available versions for each dependency
     val allDependencyVersions: Seq[ModuleDependenciesVersions] =
@@ -39,21 +40,6 @@ object DependencyUpdatesImpl {
     val _ = discover // unused but part of public API
     apply(evaluator, ctx, rootModule, allowPreRelease)
   }
-
-  @deprecated("Use the override accepting a CoursierConfigModule instead", "Mill after 1.0.0-RC3")
-  def apply(
-      evaluator: Evaluator,
-      ctx: TaskCtx,
-      rootModule: RootModule0,
-      allowPreRelease: Boolean
-  ): Seq[ModuleDependenciesUpdates] =
-    apply(
-      evaluator,
-      ctx,
-      rootModule,
-      allowPreRelease,
-      CoursierConfigModule
-    )
 
   def showAllUpdates(
       updates: Seq[ModuleDependenciesUpdates],

--- a/libs/javalib/src/mill/javalib/internal/ZincCompilerBridgeProvider.scala
+++ b/libs/javalib/src/mill/javalib/internal/ZincCompilerBridgeProvider.scala
@@ -122,9 +122,11 @@ object ZincCompilerBridgeProvider {
           if (JvmWorkerUtil.isDottyOrScala3(scalaVersion)) "dotty.tools.dotc.Main"
           else "scala.tools.nsc.Main"
         )
-        compilerMain
-          .getMethod("process", classOf[Array[String]])
-          .invoke(null, argsArray ++ Array("-nowarn"))
+        mill.api.ClassLoader.withContextClassLoader(classloader) {
+          compilerMain
+            .getMethod("process", classOf[Array[String]])
+            .invoke(null, argsArray ++ Array("-nowarn"))
+        }
       } else {
         throw new IllegalArgumentException("Currently not implemented case.")
       }

--- a/libs/javalib/src/mill/javalib/internal/ZincCompilerBridgeProvider.scala
+++ b/libs/javalib/src/mill/javalib/internal/ZincCompilerBridgeProvider.scala
@@ -122,11 +122,9 @@ object ZincCompilerBridgeProvider {
           if (JvmWorkerUtil.isDottyOrScala3(scalaVersion)) "dotty.tools.dotc.Main"
           else "scala.tools.nsc.Main"
         )
-        mill.api.ClassLoader.withContextClassLoader(classloader) {
-          compilerMain
-            .getMethod("process", classOf[Array[String]])
-            .invoke(null, argsArray ++ Array("-nowarn"))
-        }
+        compilerMain
+          .getMethod("process", classOf[Array[String]])
+          .invoke(null, argsArray ++ Array("-nowarn"))
       } else {
         throw new IllegalArgumentException("Currently not implemented case.")
       }

--- a/libs/javalib/test/src/mill/javalib/ResolveDepsTests.scala
+++ b/libs/javalib/test/src/mill/javalib/ResolveDepsTests.scala
@@ -10,6 +10,7 @@ import mill.api.{Result}
 import mill.api.{Discover, Task}
 import mill.testkit.{TestRootModule, UnitTester}
 import utest.*
+import mill.util.CoursierConfig
 import mill.util.TokenReaders._
 object ResolveDepsTests extends TestSuite {
   val scala212Version = sys.props.getOrElse("TEST_SCALA_2_12_VERSION", ???)
@@ -18,7 +19,8 @@ object ResolveDepsTests extends TestSuite {
 
   def evalDeps(deps: Seq[Dep]): Result[Seq[PathRef]] = Lib.resolveDependencies(
     repos,
-    deps.map(Lib.depToBoundDep(_, scala212Version, ""))
+    deps.map(Lib.depToBoundDep(_, scala212Version, "")),
+    config = CoursierConfig.default()
   )
 
   def assertRoundTrip(deps: Seq[Dep], simplified: Boolean) = {

--- a/libs/scalalib/test/src/mill/scalalib/CoursierMirrorTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/CoursierMirrorTests.scala
@@ -1,6 +1,6 @@
 package mill.scalalib
 
-// import coursier.cache.FileCache
+import coursier.cache.FileCache
 import mill.api.Discover
 import mill.testkit.{TestRootModule, UnitTester}
 import mill.util.TokenReaders.*
@@ -18,22 +18,40 @@ object CoursierMirrorTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
+  def withJavaProp[T](name: String, value: String)(thunk: => T): T = {
+    // might not be fine with concurrent uses / changes of the same property,
+    // but doing that is better than setting the value and forgetting about it
+    val formerValueOpt = sys.props.get(name)
+    try {
+      sys.props(name) = value
+      thunk
+    } finally {
+      formerValueOpt match {
+        case None =>
+          sys.props.remove(name)
+        case Some(formerValue) =>
+          sys.props(name) = formerValue
+      }
+    }
+  }
+
   def tests: Tests = Tests {
-    sys.props("coursier.mirrors") = (resourcePath / "mirror.properties").toString
-    test("readMirror") - UnitTester(CoursierTest, resourcePath).scoped { /*eval*/ _ =>
-      // Doesn't pass when other tests are running before/after in the same JVM
-      //      val Right(result) = eval.apply(CoursierTest.core.compileClasspath): @unchecked
-      //      val cacheRoot = os.Path(FileCache().location)
-      //      val cp = result.value
-      //        .map(_.path)
-      //        .filter(_.startsWith(cacheRoot))
-      //        .map(_.relativeTo(cacheRoot).asSubPath)
-      //      assert(cp.exists(f => f.last.startsWith("scala-library-") && f.last.endsWith(".jar")))
-      //      pprint.log(cp)
-      //      val centralReplaced = cp.forall { f =>
-      //        f.startsWith(os.sub / "https/repo.maven.apache.org/maven2")
-      //      }
-      //      assert(centralReplaced)
+    test("readMirror") {
+      withJavaProp("coursier.mirrors", (resourcePath / "mirror.properties").toString) {
+        UnitTester(CoursierTest, resourcePath).scoped { eval =>
+          val Right(result) = eval.apply(CoursierTest.core.compileClasspath): @unchecked
+          val cacheRoot = os.Path(FileCache().location)
+          val cp = result.value
+            .map(_.path)
+            .filter(_.startsWith(cacheRoot))
+            .map(_.relativeTo(cacheRoot).asSubPath)
+          assert(cp.exists(f => f.last.startsWith("scala-library-") && f.last.endsWith(".jar")))
+          val centralReplaced = cp.forall { f =>
+            f.startsWith(os.sub / "https/repo.maven.apache.org/maven2")
+          }
+          assert(centralReplaced)
+        }
+      }
     }
   }
 }

--- a/libs/scalalib/test/src/mill/scalalib/CoursierMirrorTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/CoursierMirrorTests.scala
@@ -1,7 +1,7 @@
 package mill.scalalib
 
-import coursier.cache.FileCache
 import mill.api.Discover
+import mill.javalib.CoursierConfigModule
 import mill.testkit.{TestRootModule, UnitTester}
 import mill.util.TokenReaders.*
 import utest.*
@@ -40,7 +40,8 @@ object CoursierMirrorTests extends TestSuite {
       withJavaProp("coursier.mirrors", (resourcePath / "mirror.properties").toString) {
         UnitTester(CoursierTest, resourcePath).scoped { eval =>
           val Right(result) = eval.apply(CoursierTest.core.compileClasspath): @unchecked
-          val cacheRoot = os.Path(FileCache().location)
+          val Right(cacheResult) = eval.apply(CoursierConfigModule.defaultCacheLocation): @unchecked
+          val cacheRoot = os.Path(cacheResult.value)
           val cp = result.value
             .map(_.path)
             .filter(_.startsWith(cacheRoot))

--- a/libs/util/src/mill/util/CoursierConfig.scala
+++ b/libs/util/src/mill/util/CoursierConfig.scala
@@ -1,0 +1,53 @@
+package mill.util
+
+import coursier.CoursierEnv
+import coursier.cache.{CacheEnv, CachePolicy}
+import coursier.core.Repository
+import coursier.credentials.Credentials
+import coursier.params.Mirror
+
+import scala.concurrent.duration.Duration
+
+final case class CoursierConfig(
+    repositories: Seq[Repository],
+    confFiles: Seq[os.Path],
+    mirrors: Seq[Mirror],
+    cacheLocation: String,
+    archiveCacheLocation: String,
+    credentials: Seq[Credentials],
+    ttl: Option[Duration],
+    cachePolicies: Seq[CachePolicy]
+)
+
+object CoursierConfig {
+  // as much as possible, prefer using CoursierConfigModule.coursierConfig(),
+  // that reads up-to-date values from the environment and from Java properties
+  private[mill] def default(): CoursierConfig =
+    CoursierConfig(
+      CoursierEnv.defaultRepositories(
+        CoursierEnv.repositories.read(),
+        CoursierEnv.scalaCliConfig.read()
+      ),
+      CacheEnv.defaultConfFiles(CacheEnv.scalaCliConfig.read())
+        .map(os.Path(_)),
+      CoursierEnv.defaultMirrors(
+        CoursierEnv.mirrors.read(),
+        CoursierEnv.mirrorsExtra.read(),
+        CoursierEnv.scalaCliConfig.read(),
+        CoursierEnv.configDir.read()
+      ),
+      CacheEnv.defaultCacheLocation(CacheEnv.cache.read()).toString,
+      CacheEnv.defaultArchiveCacheLocation(CacheEnv.archiveCache.read()).toString,
+      CacheEnv.defaultCredentials(
+        CacheEnv.credentials.read(),
+        CacheEnv.scalaCliConfig.read(),
+        CacheEnv.configDir.read()
+      ),
+      CacheEnv.defaultTtl(
+        CacheEnv.ttl.read()
+      ),
+      CacheEnv.defaultCachePolicies(
+        CacheEnv.cachePolicy.read()
+      )
+    )
+}

--- a/libs/util/src/mill/util/Jvm.scala
+++ b/libs/util/src/mill/util/Jvm.scala
@@ -1,5 +1,6 @@
 package mill.util
 
+import com.lihaoyi.unroll
 import coursier.cache.{ArchiveCache, CachePolicy, FileCache}
 import coursier.core.{BomDependency, VariantSelector}
 import coursier.error.FetchError.DownloadingArtifacts
@@ -477,7 +478,7 @@ object Jvm {
       artifactTypes: Option[Set[Type]] = None,
       resolutionParams: ResolutionParams = ResolutionParams(),
       checkGradleModules: Boolean = false,
-      config: CoursierConfig
+      @unroll config: CoursierConfig = CoursierConfig.default()
   ): Result[coursier.Artifacts.Result] = {
     val resolutionRes = resolveDependenciesMetadataSafe(
       repositories,
@@ -523,35 +524,6 @@ object Jvm {
     }
   }
 
-  // bin-compat shim
-  def getArtifacts(
-      repositories: Seq[Repository],
-      deps: IterableOnce[Dependency],
-      force: IterableOnce[Dependency],
-      sources: Boolean,
-      mapDependencies: Option[Dependency => Dependency],
-      customizer: Option[Resolution => Resolution],
-      ctx: Option[mill.api.TaskCtx],
-      coursierCacheCustomizer: Option[FileCache[Task] => FileCache[Task]],
-      artifactTypes: Option[Set[Type]],
-      resolutionParams: ResolutionParams,
-      checkGradleModules: Boolean
-  ): Result[coursier.Artifacts.Result] =
-    getArtifacts(
-      repositories,
-      deps,
-      force,
-      sources,
-      mapDependencies,
-      customizer,
-      ctx,
-      coursierCacheCustomizer,
-      artifactTypes,
-      resolutionParams,
-      checkGradleModules,
-      CoursierConfig.default()
-    )
-
   /**
    * Resolve dependencies using Coursier.
    *
@@ -571,7 +543,7 @@ object Jvm {
       artifactTypes: Option[Set[Type]] = None,
       resolutionParams: ResolutionParams = ResolutionParams(),
       checkGradleModules: Boolean = false,
-      config: CoursierConfig = CoursierConfig.default()
+      @unroll config: CoursierConfig = CoursierConfig.default()
   ): Result[Seq[PathRef]] =
     getArtifacts(
       repositories,
@@ -594,61 +566,21 @@ object Jvm {
       }
     }
 
-  // bin-compat shim
-  def resolveDependencies(
-      repositories: Seq[Repository],
-      deps: IterableOnce[Dependency],
-      force: IterableOnce[Dependency],
-      sources: Boolean,
-      mapDependencies: Option[Dependency => Dependency],
-      customizer: Option[Resolution => Resolution],
-      ctx: Option[mill.api.TaskCtx],
-      coursierCacheCustomizer: Option[FileCache[Task] => FileCache[Task]],
-      artifactTypes: Option[Set[Type]],
-      resolutionParams: ResolutionParams,
-      checkGradleModules: Boolean
-  ): Result[Seq[PathRef]] =
-    resolveDependencies(
-      repositories,
-      deps,
-      force,
-      sources,
-      mapDependencies,
-      customizer,
-      ctx,
-      coursierCacheCustomizer,
-      artifactTypes,
-      resolutionParams,
-      checkGradleModules,
-      CoursierConfig.default()
-    )
-
   def jvmIndex(
       ctx: Option[mill.api.TaskCtx] = None,
       coursierCacheCustomizer: Option[FileCache[Task] => FileCache[Task]] = None,
-      config: CoursierConfig
+      @unroll config: CoursierConfig = CoursierConfig.default()
   ): JvmIndex = {
     val coursierCache0 = coursierCache(ctx, coursierCacheCustomizer, config)
     coursierCache0.logger.use(jvmIndex0(ctx, coursierCacheCustomizer, config = config))
       .unsafeRun()(using coursierCache0.ec)
   }
 
-  // bin-compat shim
-  def jvmIndex(
-      ctx: Option[mill.api.TaskCtx],
-      coursierCacheCustomizer: Option[FileCache[Task] => FileCache[Task]]
-  ): JvmIndex =
-    jvmIndex(
-      ctx,
-      coursierCacheCustomizer,
-      CoursierConfig.default()
-    )
-
   def jvmIndex0(
       ctx: Option[mill.api.TaskCtx] = None,
       coursierCacheCustomizer: Option[FileCache[Task] => FileCache[Task]] = None,
       jvmIndexVersion: String = "latest.release",
-      config: CoursierConfig
+      @unroll config: CoursierConfig = CoursierConfig.default()
   ): Task[JvmIndex] = {
     val coursierCache0 = coursierCache(ctx, coursierCacheCustomizer, config)
     JvmIndex.load(
@@ -661,19 +593,6 @@ object Jvm {
     )
   }
 
-  // bin-compat shim
-  def jvmIndex0(
-      ctx: Option[mill.api.TaskCtx],
-      coursierCacheCustomizer: Option[FileCache[Task] => FileCache[Task]],
-      jvmIndexVersion: String
-  ): Task[JvmIndex] =
-    jvmIndex0(
-      ctx,
-      coursierCacheCustomizer,
-      jvmIndexVersion,
-      CoursierConfig.default()
-    )
-
   /**
    * Resolve java home using Coursier.
    *
@@ -685,7 +604,7 @@ object Jvm {
       coursierCacheCustomizer: Option[FileCache[Task] => FileCache[Task]] = None,
       jvmIndexVersion: String = mill.api.BuildInfo.coursierJvmIndexVersion,
       useShortPaths: Boolean = false,
-      config: CoursierConfig
+      @unroll config: CoursierConfig = CoursierConfig.default()
   ): Result[os.Path] = {
     val coursierCache0 = coursierCache(ctx, coursierCacheCustomizer, config)
     val shortPathDirOpt = Option.when(useShortPaths) {
@@ -727,23 +646,6 @@ object Jvm {
 
   }
 
-  // bin-compat shim
-  def resolveJavaHome(
-      id: String,
-      ctx: Option[mill.api.TaskCtx],
-      coursierCacheCustomizer: Option[FileCache[Task] => FileCache[Task]],
-      jvmIndexVersion: String,
-      useShortPaths: Boolean
-  ): Result[os.Path] =
-    resolveJavaHome(
-      id,
-      ctx,
-      coursierCacheCustomizer,
-      jvmIndexVersion,
-      useShortPaths,
-      CoursierConfig.default()
-    )
-
   def resolveDependenciesMetadataSafe(
       repositories: Seq[Repository],
       deps: IterableOnce[Dependency],
@@ -755,7 +657,7 @@ object Jvm {
       resolutionParams: ResolutionParams = ResolutionParams(),
       boms: IterableOnce[BomDependency] = Nil,
       checkGradleModules: Boolean = false,
-      config: CoursierConfig
+      @unroll config: CoursierConfig = CoursierConfig.default()
   ): Result[Resolution] = {
 
     val rootDeps = deps.iterator
@@ -853,33 +755,6 @@ object Jvm {
         Result.Success(resolution)
     }
   }
-
-  // bin-compat shim
-  def resolveDependenciesMetadataSafe(
-      repositories: Seq[Repository],
-      deps: IterableOnce[Dependency],
-      force: IterableOnce[Dependency],
-      mapDependencies: Option[Dependency => Dependency],
-      customizer: Option[Resolution => Resolution],
-      ctx: Option[mill.api.TaskCtx],
-      coursierCacheCustomizer: Option[FileCache[Task] => FileCache[Task]],
-      resolutionParams: ResolutionParams,
-      boms: IterableOnce[BomDependency],
-      checkGradleModules: Boolean
-  ): Result[Resolution] =
-    resolveDependenciesMetadataSafe(
-      repositories,
-      deps,
-      force,
-      mapDependencies,
-      customizer,
-      ctx,
-      coursierCacheCustomizer,
-      resolutionParams,
-      boms,
-      checkGradleModules,
-      CoursierConfig.default()
-    )
 
   // Parse a list of repositories from their string representation
   private[mill] def reposFromStrings(repoList: Seq[String]): Result[Seq[Repository]] = {

--- a/libs/util/src/mill/util/Jvm.scala
+++ b/libs/util/src/mill/util/Jvm.scala
@@ -574,7 +574,7 @@ object Jvm {
     val coursierCache0 = coursierCache(ctx, coursierCacheCustomizer)
     JvmIndex.load(
       cache = coursierCache0, // the coursier.cache.Cache instance to use
-      repositories = Resolve().repositories, // repositories to use
+      repositories = Resolve.defaultRepositories, // repositories to use
       indexChannel = JvmChannel.module(
         JvmChannel.centralModule(),
         version = jvmIndexVersion

--- a/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
+++ b/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
@@ -525,15 +525,12 @@ object MillBuildBootstrap {
   ): (Result[Seq[Any]], Seq[Watchable], Seq[Watchable]) = {
     import buildFileApi._
     evalWatchedValues.clear()
-    val evalTaskResult =
-      mill.api.ClassLoader.withContextClassLoader(rootModule.getClass.getClassLoader) {
-        evaluator.evaluate(
-          tasksAndParams,
-          SelectMode.Separated,
-          reporter = reporter,
-          selectiveExecution = selectiveExecution
-        )
-      }
+    val evalTaskResult = evaluator.evaluate(
+      tasksAndParams,
+      SelectMode.Separated,
+      reporter = reporter,
+      selectiveExecution = selectiveExecution
+    )
 
     evalTaskResult match {
       case Result.Failure(msg) => (Result.Failure(msg), Nil, moduleWatchedValues)

--- a/runner/launcher/src/mill/launcher/CoursierClient.scala
+++ b/runner/launcher/src/mill/launcher/CoursierClient.scala
@@ -9,13 +9,10 @@ import coursier.core.Module
 
 import java.io.File
 
-import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration.Duration
 
 object CoursierClient {
   def resolveMillDaemon() = {
-    val repositories = Await.result(Resolve().finalRepositories.future(), Duration.Inf)
     val coursierCache0 = FileCache[Task]()
       .withLogger(coursier.cache.loggers.RefreshLogger.create())
 
@@ -34,7 +31,7 @@ object CoursierClient {
           Module(Organization("com.lihaoyi"), ModuleName("mill-runner-daemon_3"), Map()),
           VersionConstraint(mill.client.BuildInfo.millVersion)
         )))
-        .withRepositories(testOverridesRepos ++ repositories)
+        .withRepositories(testOverridesRepos ++ Resolve.defaultRepositories)
 
       val result = resolve.either().flatMap { v =>
         Artifacts(coursierCache0)
@@ -58,7 +55,7 @@ object CoursierClient {
       .withIndex(
         JvmIndex.load(
           cache = coursierCache0,
-          repositories = Resolve().repositories,
+          repositories = Resolve.defaultRepositories,
           indexChannel = JvmChannel.module(
             JvmChannel.centralModule(),
             version = mill.client.Versions.coursierJvmIndexVersion

--- a/website/docs/modules/ROOT/pages/cli/installation-ide.adoc
+++ b/website/docs/modules/ROOT/pages/cli/installation-ide.adoc
@@ -404,9 +404,6 @@ The below command should pass the environment variable to the `mill` command.
 > COURSIER_REPOSITORIES=https://packages.corp.com/artifactory/maven/ mill resolve _
 ----
 
-NOTE: Currently, you may need to `./mill shutdown` before calling Mill with the environment variable to make sure it gets properly propagated to Mill's background daemon.
-There is an https://github.com/com-lihaoyi/mill/issues/5134[open issue] to let Mill  detect these changes automatically.
-
 If you are using bootstrap script, a more permanent solution could be to set the environment variable
 at the top of the bootstrap script, or as a user environment variable.
 


### PR DESCRIPTION
This is a new attempt at fixing https://github.com/com-lihaoyi/mill/issues/5134. Turns out setting the context class loader when evaluating user code addresses the issue while not running into https://github.com/com-lihaoyi/mill/issues/5398 again.

---

Description from https://github.com/com-lihaoyi/mill/pull/5350 that still applies:

This makes Mill read all environment variables and Java properties used by coursier via a `Task.Input`.

In more detail, this adds a `CoursierConfigModule` external module in scalalib. It contains a single `Task.Input`, that reads all environment variables used by coursier via `Task.env` and all Java properties used by coursier via `sys.props`.

Helper tasks compute default values for various parameters (repositories, cache location, etc.). `CoursierConfigModule.coursierConfig` returns most of these parameters in a case class defined in Mill, `CoursierConfig`. For convenience, down-the-line, we pass `CoursierConfig` instances around.

Fixes https://github.com/com-lihaoyi/mill/issues/5134 (by managing coursier env vars / Java properties via `Task.Input`)