### PR TITLE
Bump uPickle to 4.3.0

### DIFF
--- a/contrib/buildinfo/src/mill/contrib/buildinfo/BuildInfo.scala
+++ b/contrib/buildinfo/src/mill/contrib/buildinfo/BuildInfo.scala
@@ -108,7 +108,7 @@ object BuildInfo {
 
   case class Value(key: String, value: String, comment: String = "")
   object Value {
-    implicit val rw: upickle.default.ReadWriter[Value] = upickle.default.macroRW
+    implicit val rw: upickle.ReadWriter[Value] = upickle.macroRW
   }
   def staticCompiledCodegen(
       buildInfoMembers: Seq[Value],

--- a/contrib/flyway/src/mill/contrib/flyway/FlywayModule.scala
+++ b/contrib/flyway/src/mill/contrib/flyway/FlywayModule.scala
@@ -88,8 +88,8 @@ object FlywayModule {
     }
   }
 
-  implicit def migrateOutputWriter: upickle.default.Writer[MigrateOutput] =
-    upickle.default.writer[ujson.Obj].comap(r =>
+  implicit def migrateOutputWriter: upickle.Writer[MigrateOutput] =
+    upickle.writer[ujson.Obj].comap(r =>
       ujson.Obj(
         "category" -> r.category.jsonify,
         "version" -> r.version.jsonify,
@@ -99,8 +99,8 @@ object FlywayModule {
       )
     )
 
-  implicit def cleanResultWriter: upickle.default.Writer[CleanResult] =
-    upickle.default.writer[ujson.Obj].comap(r =>
+  implicit def cleanResultWriter: upickle.Writer[CleanResult] =
+    upickle.writer[ujson.Obj].comap(r =>
       ujson.Obj(
         "flywayVersion" -> r.flywayVersion.jsonify,
         "database" -> r.database.jsonify,
@@ -110,8 +110,8 @@ object FlywayModule {
         "schemasDropped" -> ujson.Arr.from(r.schemasDropped.asScala.toSeq.map(_.jsonify))
       )
     )
-  implicit def migrateResultWriter: upickle.default.Writer[MigrateResult] =
-    upickle.default.writer[ujson.Obj].comap(r =>
+  implicit def migrateResultWriter: upickle.Writer[MigrateResult] =
+    upickle.writer[ujson.Obj].comap(r =>
       ujson.Obj(
         "flywayVersion" -> r.flywayVersion.jsonify,
         "database" -> r.database.jsonify,
@@ -120,12 +120,12 @@ object FlywayModule {
         "initialSchemaVersion" -> r.initialSchemaVersion.jsonify,
         "targetSchemaVersion" -> r.targetSchemaVersion.jsonify,
         "schemaName" -> r.schemaName.jsonify,
-        "migrations" -> ujson.Arr.from(r.migrations.asScala.toSeq.map(upickle.default.write(_))),
+        "migrations" -> ujson.Arr.from(r.migrations.asScala.toSeq.map(upickle.write(_))),
         "migrationsExecuted" -> ujson.Num(r.migrationsExecuted)
       )
     )
-  implicit def baselineResultWriter: upickle.default.Writer[BaselineResult] =
-    upickle.default.writer[ujson.Obj].comap(r =>
+  implicit def baselineResultWriter: upickle.Writer[BaselineResult] =
+    upickle.writer[ujson.Obj].comap(r =>
       ujson.Obj(
         "flywayVersion" -> r.flywayVersion.jsonify,
         "database" -> r.database.jsonify,

--- a/contrib/versionfile/src/mill/contrib/versionfile/Version.scala
+++ b/contrib/versionfile/src/mill/contrib/versionfile/Version.scala
@@ -64,7 +64,7 @@ object Version {
   val ReleaseVersion: Regex = raw"""(\d+)\.(\d+)\.(\d+)""".r
   val MinorSnapshotVersion: Regex = raw"""(\d+)\.(\d+)\.(\d+)-SNAPSHOT""".r
 
-  import upickle.default._
+  import upickle._
 
   implicit val readWriter: ReadWriter[Version] =
     readwriter[String].bimap(_.toString, Version.of)

--- a/contrib/versionfile/src/mill/contrib/versionfile/VersionFileModule.scala
+++ b/contrib/versionfile/src/mill/contrib/versionfile/VersionFileModule.scala
@@ -65,7 +65,7 @@ trait VersionFileModule extends Module {
       case _: Version.Snapshot => s"Setting next version to $version"
     }
 
-  import upickle.default._
+  import upickle._
 
   implicit val shellableReadWriter: ReadWriter[os.Shellable] =
     readwriter[Seq[String]].bimap(

--- a/contrib/versionfile/test/src/mill/contrib/versionfile/VersionTests.scala
+++ b/contrib/versionfile/test/src/mill/contrib/versionfile/VersionTests.scala
@@ -44,7 +44,7 @@ object VersionTests extends TestSuite {
       test("upickle") {
         val in = Version.of("1.2.3")
         val out = Version.readWriter.visitString(
-          Version.readWriter.write(upickle.default.StringReader, in),
+          Version.readWriter.write(upickle.StringReader, in),
           0
         )
         assert(in == out)

--- a/core/api/src/mill/api/Cached.scala
+++ b/core/api/src/mill/api/Cached.scala
@@ -3,5 +3,5 @@ package mill.api
 private[mill] case class Cached(value: ujson.Value, valueHash: Int, inputsHash: Int)
 
 private[mill] object Cached {
-  implicit val rw: upickle.default.ReadWriter[Cached] = upickle.default.macroRW
+  implicit val rw: upickle.ReadWriter[Cached] = upickle.macroRW
 }

--- a/core/api/src/mill/api/CrossVersion.scala
+++ b/core/api/src/mill/api/CrossVersion.scala
@@ -3,7 +3,7 @@ package mill.api
 /**
  * Models the different kinds of cross-versions supported by Mill for Scala dependencies.
  */
-enum CrossVersion derives upickle.default.ReadWriter {
+enum CrossVersion derives upickle.ReadWriter {
   import CrossVersion.*
 
   /** If true, the cross-version suffix should start with a platform suffix if it exists */

--- a/core/api/src/mill/api/JsonFormatters.scala
+++ b/core/api/src/mill/api/JsonFormatters.scala
@@ -2,7 +2,7 @@ package mill.api
 
 import mill.api.daemon.internal.Severity
 import os.Path
-import upickle.default.{ReadWriter as RW, Reader, Writer}
+import upickle.{ReadWriter as RW, Reader, Writer}
 
 import scala.reflect.ClassTag
 import scala.util.matching.Regex
@@ -21,13 +21,13 @@ trait JsonFormatters {
       Right(os.Path(strs.last, BuildCtx.workspaceRoot))
   }
 
-  implicit val pathReadWrite: RW[os.Path] = upickle.default.readwriter[String]
+  implicit val pathReadWrite: RW[os.Path] = upickle.readwriter[String]
     .bimap[os.Path](
       _.toString,
       os.Path(_)
     )
 
-  implicit val relPathRW: RW[os.RelPath] = upickle.default.readwriter[String]
+  implicit val relPathRW: RW[os.RelPath] = upickle.readwriter[String]
     .bimap[os.RelPath](_.toString, os.RelPath(_))
 
   implicit def subPathRW: RW[os.SubPath] = JsonFormatters.Default.subPathRW
@@ -38,28 +38,28 @@ trait JsonFormatters {
 
   implicit def resultRW[A: { Reader, Writer }]: RW[Result[A]] = JsonFormatters.Default.resultRW
 
-  implicit val nioPathRW: RW[java.nio.file.Path] = upickle.default.readwriter[String]
+  implicit val nioPathRW: RW[java.nio.file.Path] = upickle.readwriter[String]
     .bimap[java.nio.file.Path](
       _.toUri().toString(),
       s => java.nio.file.Path.of(new java.net.URI(s))
     )
 
-  implicit val regexReadWrite: RW[Regex] = upickle.default.readwriter[String]
+  implicit val regexReadWrite: RW[Regex] = upickle.readwriter[String]
     .bimap[Regex](
       _.pattern.toString,
       _.r
     )
 
-  implicit val bytesReadWrite: RW[geny.Bytes] = upickle.default.readwriter[String]
+  implicit val bytesReadWrite: RW[geny.Bytes] = upickle.readwriter[String]
     .bimap(
       o => java.util.Base64.getEncoder.encodeToString(o.array),
       str => new geny.Bytes(java.util.Base64.getDecoder.decode(str))
     )
 
-  implicit val crFormat: RW[os.CommandResult] = upickle.default.macroRW
+  implicit val crFormat: RW[os.CommandResult] = upickle.macroRW
 
   implicit val stackTraceRW: RW[StackTraceElement] =
-    upickle.default.readwriter[ujson.Obj].bimap[StackTraceElement](
+    upickle.readwriter[ujson.Obj].bimap[StackTraceElement](
       ste =>
         ujson.Obj(
           "declaringClass" -> ujson.Str(ste.getClassName),
@@ -77,7 +77,7 @@ trait JsonFormatters {
     )
 
   implicit def enumFormat[T <: java.lang.Enum[?]: ClassTag]: RW[T] =
-    upickle.default.readwriter[String].bimap(
+    upickle.readwriter[String].bimap(
       _.name(),
       (s: String) =>
         implicitly[ClassTag[T]]
@@ -93,12 +93,12 @@ trait JsonFormatters {
 object JsonFormatters extends JsonFormatters {
   object Default {
     val subPathRW: RW[os.SubPath] =
-      upickle.default.readwriter[String].bimap[os.SubPath](_.toString, os.SubPath(_))
+      upickle.readwriter[String].bimap[os.SubPath](_.toString, os.SubPath(_))
 
     val fileRW: RW[java.io.File] =
-      upickle.default.readwriter[String].bimap[java.io.File](_.toString, java.io.File(_))
+      upickle.readwriter[String].bimap[java.io.File](_.toString, java.io.File(_))
 
-    val severityRW: RW[Severity] = upickle.default.readwriter[String].bimap[Severity](
+    val severityRW: RW[Severity] = upickle.readwriter[String].bimap[Severity](
       {
         case mill.api.daemon.internal.Error => "error"
         case mill.api.daemon.internal.Warn => "warn"

--- a/core/api/src/mill/api/PathRef.scala
+++ b/core/api/src/mill/api/PathRef.scala
@@ -2,7 +2,7 @@ package mill.api
 
 import mill.api.DummyOutputStream
 import mill.api.daemon.internal.PathRefApi
-import upickle.default.ReadWriter as RW
+import upickle.ReadWriter as RW
 
 import java.nio.file as jnio
 import java.security.{DigestOutputStream, MessageDigest}
@@ -192,7 +192,7 @@ object PathRef {
   /**
    * Default JSON formatter for [[PathRef]].
    */
-  implicit def jsonFormatter: RW[PathRef] = upickle.default.readwriter[String].bimap[PathRef](
+  implicit def jsonFormatter: RW[PathRef] = upickle.readwriter[String].bimap[PathRef](
     p => {
       storeSerializedPaths(p)
       p.toString()

--- a/core/api/src/mill/api/SelectiveExecution.scala
+++ b/core/api/src/mill/api/SelectiveExecution.scala
@@ -44,7 +44,7 @@ object SelectiveExecution {
     )
   }
 
-  implicit val rw: upickle.default.ReadWriter[Metadata] = upickle.default.macroRW
+  implicit val rw: upickle.ReadWriter[Metadata] = upickle.macroRW
 
   case class ChangedTasks(
       resolved: Seq[Task.Named[?]],

--- a/core/api/src/mill/api/Task.scala
+++ b/core/api/src/mill/api/Task.scala
@@ -6,8 +6,8 @@ import mill.api.daemon.internal.CompileProblemReporter
 import mill.api.daemon.internal.{NamedTaskApi, TaskApi, TestReporter}
 import mill.api.internal.Applicative.Applyable
 import mill.api.internal.{Applicative, Cacher, NamedParameterOnlyDummy}
-import upickle.default.ReadWriter
-import upickle.default.Writer
+import upickle.ReadWriter
+import upickle.Writer
 
 import scala.annotation.{targetName, unused}
 import scala.language.implicitConversions
@@ -341,9 +341,9 @@ object Task {
 
     val ctx: ModuleCtx = ctx0
 
-    def readWriterOpt: Option[upickle.default.ReadWriter[?]] = None
+    def readWriterOpt: Option[upickle.ReadWriter[?]] = None
 
-    def writerOpt: Option[upickle.default.Writer[?]] = readWriterOpt.orElse(None)
+    def writerOpt: Option[upickle.Writer[?]] = readWriterOpt.orElse(None)
   }
 
   class Computed[+T](
@@ -435,7 +435,7 @@ object Task {
   class Input[T](
       val evaluate0: (Seq[Any], mill.api.TaskCtx) => Result[T],
       val ctx0: mill.api.ModuleCtx,
-      val writer: upickle.default.Writer[?],
+      val writer: upickle.Writer[?],
       val isPrivate: Option[Boolean]
   ) extends Simple[T] {
     val inputs = Nil
@@ -451,7 +451,7 @@ object Task {
   ) extends Input[Seq[PathRef]](
         evaluate0,
         ctx0,
-        upickle.default.readwriter[Seq[PathRef]],
+        upickle.readwriter[Seq[PathRef]],
         isPrivate
       ) {}
 
@@ -462,7 +462,7 @@ object Task {
   ) extends Input[PathRef](
         evaluate0,
         ctx0,
-        upickle.default.readwriter[PathRef],
+        upickle.readwriter[PathRef],
         isPrivate
       ) {}
 
@@ -563,7 +563,7 @@ object Task {
     def inputImpl[T: Type](using
         Quotes
     )(value: Expr[Result[T]])(
-        w: Expr[upickle.default.Writer[T]],
+        w: Expr[upickle.Writer[T]],
         ctx: Expr[mill.api.ModuleCtx]
     ): Expr[Simple[T]] = {
       assertTaskShapeOwner("Task.Input", 0)

--- a/core/api/test/src/mill/api/PathRefTests.scala
+++ b/core/api/test/src/mill/api/PathRefTests.scala
@@ -86,7 +86,7 @@ object PathRefTests extends TestSuite {
         os.write(file, "hello")
         val pr = PathRef(file, quick)
         val prFile = pr.path.toString().replace("\\", "\\\\")
-        val json = upickle.default.write(pr)
+        val json = upickle.write(pr)
         if (quick) {
           assert(json.startsWith(""""qref:v0:"""))
           assert(json.endsWith(s""":${prFile}""""))
@@ -95,7 +95,7 @@ object PathRefTests extends TestSuite {
           val expected = s""""ref:v0:${hash}:${prFile}""""
           assert(json == expected)
         }
-        val pr1 = upickle.default.read[PathRef](json)
+        val pr1 = upickle.read[PathRef](json)
         assert(pr == pr1)
       }
 

--- a/core/eval/src/mill/eval/SelectiveExecutionImpl.scala
+++ b/core/eval/src/mill/eval/SelectiveExecutionImpl.scala
@@ -76,7 +76,7 @@ private[mill] class SelectiveExecutionImpl(evaluator: Evaluator)
   def saveMetadata(metadata: SelectiveExecution.Metadata): Unit = {
     os.write.over(
       evaluator.outPath / OutFiles.millSelectiveExecution,
-      upickle.default.write(metadata, indent = 2)
+      upickle.write(metadata, indent = 2)
     )
   }
 
@@ -111,7 +111,7 @@ private[mill] class SelectiveExecutionImpl(evaluator: Evaluator)
     if (oldMetadataTxt == "") None
     else Some {
       val transitiveNamed = PlanImpl.transitiveNamed(tasks)
-      val oldMetadata = upickle.default.read[SelectiveExecution.Metadata](oldMetadataTxt)
+      val oldMetadata = upickle.read[SelectiveExecution.Metadata](oldMetadataTxt)
       val (changedRootTasks, downstreamTasks) =
         evaluator.selective.computeDownstream(
           transitiveNamed,

--- a/core/internal/src/mill/internal/JsonArrayLogger.scala
+++ b/core/internal/src/mill/internal/JsonArrayLogger.scala
@@ -4,7 +4,7 @@ import java.io.{BufferedOutputStream, PrintStream}
 import java.nio.file.{Files, StandardOpenOption}
 import java.util.concurrent.ArrayBlockingQueue
 
-private[mill] class JsonArrayLogger[T: upickle.default.Writer](outPath: os.Path, indent: Int) {
+private[mill] class JsonArrayLogger[T: upickle.Writer](outPath: os.Path, indent: Int) {
   private var used = false
 
   @volatile var closed = false
@@ -33,7 +33,7 @@ private[mill] class JsonArrayLogger[T: upickle.default.Writer](outPath: os.Path,
               if (used) traceStream.println(",")
               else traceStream.println("[")
               used = true
-              val indented = upickle.default.write(v, indent = indent)
+              val indented = upickle.write(v, indent = indent)
                 .linesIterator
                 .map(indentStr + _)
                 .mkString("\n")
@@ -106,7 +106,7 @@ private[mill] object JsonArrayLogger {
     )
 
     object Timing {
-      implicit val readWrite: upickle.default.ReadWriter[Timing] = upickle.default.macroRW
+      implicit val readWrite: upickle.ReadWriter[Timing] = upickle.macroRW
     }
   }
 
@@ -151,7 +151,7 @@ private[mill] object JsonArrayLogger {
      * See https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/
      */
     @upickle.implicits.key("ph")
-    enum TraceEvent derives upickle.default.ReadWriter {
+    enum TraceEvent derives upickle.ReadWriter {
       @upickle.implicits.key("B") case Begin(
           name: String,
           cat: String,

--- a/example/fundamentals/tasks/2-primary-tasks/build.mill
+++ b/example/fundamentals/tasks/2-primary-tasks/build.mill
@@ -236,10 +236,10 @@ Finding Largest File
 // returned and automatically serialized/de-serialized as necessary. One
 // notable exception is ``case class``es: if you want return your own
 // `case class`, you must mark it JSON-serializable by adding
-// `derives upickle.default.ReadWriter`:
+// `derives upickle.ReadWriter`:
 
 case class ClassFileData(totalFileSize: Long, largestFile: String)
-    derives upickle.default.ReadWriter
+    derives upickle.ReadWriter
 
 def summarizeClassFileStats = Task {
   val files = os.walk(classFiles().path)

--- a/example/scalalib/dependencies/1-mvn-deps/build.mill
+++ b/example/scalalib/dependencies/1-mvn-deps/build.mill
@@ -5,7 +5,7 @@ import mill.*, scalalib.*
 object `package` extends ScalaModule {
   def scalaVersion = "2.12.20"
   def mvnDeps = Seq(
-    mvn"com.lihaoyi::upickle:4.1.0",
+    mvn"com.lihaoyi::upickle:4.3.0",
     mvn"com.lihaoyi::pprint:0.9.0",
     mvn"${scalaOrganization()}:scala-reflect:${scalaVersion()}"
   )

--- a/example/scalalib/dependencies/1-mvn-deps/src/Foo.scala
+++ b/example/scalalib/dependencies/1-mvn-deps/src/Foo.scala
@@ -3,6 +3,6 @@ package foo
 object Foo {
   def main(args: Array[String]): Unit = {
     println("pretty-printed using PPrint: " + pprint.PPrinter.BlackWhite.apply(args))
-    println("serialized using uPickle: " + upickle.write(args))
+    println("serialized using uPickle: " + upickle.default.write(args))
   }
 }

--- a/example/scalalib/dependencies/1-mvn-deps/src/Foo.scala
+++ b/example/scalalib/dependencies/1-mvn-deps/src/Foo.scala
@@ -3,6 +3,6 @@ package foo
 object Foo {
   def main(args: Array[String]): Unit = {
     println("pretty-printed using PPrint: " + pprint.PPrinter.BlackWhite.apply(args))
-    println("serialized using uPickle: " + upickle.default.write(args))
+    println("serialized using uPickle: " + upickle.write(args))
   }
 }

--- a/example/scalalib/web/1-todo-webapp/build.mill
+++ b/example/scalalib/web/1-todo-webapp/build.mill
@@ -5,6 +5,7 @@ object `package` extends ScalaModule {
   def scalaVersion = "3.7.1"
   def mvnDeps = Seq(
     mvn"com.lihaoyi::cask:0.9.1",
+    mvn"com.lihaoyi::upickle:4.3.0",
     mvn"com.lihaoyi::scalatags:0.13.1"
   )
 

--- a/example/scalalib/web/1-todo-webapp/src/WebApp.scala
+++ b/example/scalalib/web/1-todo-webapp/src/WebApp.scala
@@ -6,7 +6,7 @@ object WebApp extends cask.MainRoutes {
   case class Todo(checked: Boolean, text: String)
 
   object Todo {
-    implicit def todoRW: upickle.default.ReadWriter[Todo] = upickle.default.macroRW[Todo]
+    implicit def todoRW: upickle.ReadWriter[Todo] = upickle.macroRW[Todo]
   }
 
   var todos = Seq(

--- a/example/scalalib/web/2-webapp-cache-busting/build.mill
+++ b/example/scalalib/web/2-webapp-cache-busting/build.mill
@@ -19,7 +19,7 @@ object `package` extends ScalaModule {
 
     os.write(
       Task.dest / "hashed-resource-mapping.json",
-      upickle.default.write(hashMapping.toMap, indent = 4)
+      upickle.write(hashMapping.toMap, indent = 4)
     )
 
     Seq(PathRef(Task.dest))

--- a/example/scalalib/web/2-webapp-cache-busting/build.mill
+++ b/example/scalalib/web/2-webapp-cache-busting/build.mill
@@ -6,6 +6,7 @@ object `package` extends ScalaModule {
   def scalaVersion = "3.7.1"
   def mvnDeps = Seq(
     mvn"com.lihaoyi::cask:0.9.1",
+    mvn"com.lihaoyi::upickle:4.3.0",
     mvn"com.lihaoyi::scalatags:0.13.1",
     mvn"com.lihaoyi::os-lib:0.11.4"
   )

--- a/example/scalalib/web/2-webapp-cache-busting/src/WebApp.scala
+++ b/example/scalalib/web/2-webapp-cache-busting/src/WebApp.scala
@@ -7,10 +7,10 @@ object WebApp extends cask.MainRoutes {
   case class Todo(checked: Boolean, text: String)
 
   object Todo {
-    implicit def todoRW: upickle.default.ReadWriter[Todo] = upickle.default.macroRW[Todo]
+    implicit def todoRW: upickle.ReadWriter[Todo] = upickle.macroRW[Todo]
   }
 
-  val hashedResourceMapping = upickle.default.read[Map[String, String]](
+  val hashedResourceMapping = upickle.read[Map[String, String]](
     os.read(os.resource / "hashed-resource-mapping.json")
   )
   def hashedResource(s: String) = s match {

--- a/example/scalalib/web/5-webapp-scalajs/build.mill
+++ b/example/scalalib/web/5-webapp-scalajs/build.mill
@@ -6,6 +6,7 @@ object `package` extends ScalaModule {
   def scalaVersion = "3.7.1"
   def mvnDeps = Seq(
     mvn"com.lihaoyi::cask:0.9.1",
+    mvn"com.lihaoyi::upickle:4.3.0",
     mvn"com.lihaoyi::scalatags:0.13.1"
   )
 

--- a/example/scalalib/web/5-webapp-scalajs/src/WebApp.scala
+++ b/example/scalalib/web/5-webapp-scalajs/src/WebApp.scala
@@ -7,7 +7,7 @@ object WebApp extends cask.MainRoutes {
   case class Todo(checked: Boolean, text: String)
 
   object Todo {
-    implicit def todoRW: upickle.default.ReadWriter[Todo] = upickle.default.macroRW[Todo]
+    implicit def todoRW: upickle.ReadWriter[Todo] = upickle.macroRW[Todo]
   }
 
   var todos = Seq(

--- a/example/scalalib/web/6-webapp-scalajs-shared/build.mill
+++ b/example/scalalib/web/6-webapp-scalajs-shared/build.mill
@@ -32,7 +32,7 @@ object `package` extends AppScalaModule {
     trait SharedModule extends AppScalaModule, PlatformScalaModule {
       def mvnDeps = Seq(
         mvn"com.lihaoyi::scalatags::0.13.1",
-        mvn"com.lihaoyi::upickle::4.1.0"
+        mvn"com.lihaoyi::upickle::4.3.0"
       )
     }
 

--- a/example/scalalib/web/6-webapp-scalajs-shared/client/src/ClientApp.scala
+++ b/example/scalalib/web/6-webapp-scalajs-shared/client/src/ClientApp.scala
@@ -14,7 +14,7 @@ object ClientApp {
     ).`then`[String](response => response.text())
       .`then`[Unit] { text =>
         todoApp.innerHTML = Shared
-          .renderBody(upickle.default.read[Seq[Todo]](text), state)
+          .renderBody(upickle.read[Seq[Todo]](text), state)
           .render
 
         initListeners()
@@ -66,7 +66,7 @@ object ClientApp {
               newTodoInput.value = ""
 
               todoApp.innerHTML = Shared
-                .renderBody(upickle.default.read[Seq[Todo]](text), state)
+                .renderBody(upickle.read[Seq[Todo]](text), state)
                 .render
 
               initListeners()

--- a/example/scalalib/web/6-webapp-scalajs-shared/shared/src/Shared.scala
+++ b/example/scalalib/web/6-webapp-scalajs-shared/shared/src/Shared.scala
@@ -5,7 +5,7 @@ import scalatags.Text.tags2
 case class Todo(checked: Boolean, text: String)
 
 object Todo {
-  implicit def todoRW: upickle.default.ReadWriter[Todo] = upickle.default.macroRW[Todo]
+  implicit def todoRW: upickle.ReadWriter[Todo] = upickle.macroRW[Todo]
 }
 
 object Shared {

--- a/example/scalalib/web/6-webapp-scalajs-shared/src/WebApp.scala
+++ b/example/scalalib/web/6-webapp-scalajs-shared/src/WebApp.scala
@@ -11,37 +11,37 @@ object WebApp extends cask.MainRoutes {
   )
 
   @cask.post("/list/:state")
-  def list(state: String) = upickle.default.write(todos)
+  def list(state: String) = upickle.write(todos)
 
   @cask.post("/add/:state")
   def add(state: String, request: cask.Request) = {
     todos = Seq(Todo(false, request.text())) ++ todos
-    upickle.default.write(todos)
+    upickle.write(todos)
   }
 
   @cask.post("/delete/:state/:index")
   def delete(state: String, index: Int) = {
     todos = todos.patch(index, Nil, 1)
-    upickle.default.write(todos)
+    upickle.write(todos)
   }
 
   @cask.post("/toggle/:state/:index")
   def toggle(state: String, index: Int) = {
     todos = todos.updated(index, todos(index).copy(checked = !todos(index).checked))
-    upickle.default.write(todos)
+    upickle.write(todos)
   }
 
   @cask.post("/clear-completed/:state")
   def clearCompleted(state: String) = {
     todos = todos.filter(!_.checked)
-    upickle.default.write(todos)
+    upickle.write(todos)
   }
 
   @cask.post("/toggle-all/:state")
   def toggleAll(state: String) = {
     val next = todos.filter(_.checked).size != 0
     todos = todos.map(_.copy(checked = next))
-    upickle.default.write(todos)
+    upickle.write(todos)
   }
 
   @cask.get("/")

--- a/example/scalalib/web/7-cross-version-platform-publishing/build.mill
+++ b/example/scalalib/web/7-cross-version-platform-publishing/build.mill
@@ -38,7 +38,7 @@ trait FooModule extends Cross.Module[String] {
   object qux extends Module {
     object jvm extends Shared {
       def moduleDeps = Seq(bar.jvm)
-      def mvnDeps = super.mvnDeps() ++ Seq(mvn"com.lihaoyi::upickle::4.1.0")
+      def mvnDeps = super.mvnDeps() ++ Seq(mvn"com.lihaoyi::upickle::4.3.0")
 
       object test extends ScalaTests, FooTestModule
     }

--- a/example/scalalib/web/8-cross-platform-version-publishing/build.mill
+++ b/example/scalalib/web/8-cross-platform-version-publishing/build.mill
@@ -42,7 +42,7 @@ object qux extends Module {
   object jvm extends Cross[JvmModule](scalaVersions)
   trait JvmModule extends Shared {
     def moduleDeps = Seq(bar.jvm())
-    def mvnDeps = super.mvnDeps() ++ Seq(mvn"com.lihaoyi::upickle::4.1.0")
+    def mvnDeps = super.mvnDeps() ++ Seq(mvn"com.lihaoyi::upickle::4.3.0")
 
     object test extends ScalaTests, SharedTestModule
   }

--- a/integration/feature/leak-hygiene/src/LeakHygieneTests.scala
+++ b/integration/feature/leak-hygiene/src/LeakHygieneTests.scala
@@ -18,7 +18,7 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
   ]]) = {
     val res = tester.eval(("show", "countClassLoaders"), check = true)
 
-    val read = upickle.default.read[Map[String, Int]](res.out).toSeq.sorted
+    val read = upickle.read[Map[String, Int]](res.out).toSeq.sorted
 
     assertGoldenLiteral(read, expected)
   }
@@ -27,7 +27,7 @@ object LeakHygieneTests extends UtestIntegrationTestSuite {
       expected: utest.framework.GoldenFix.Span[Seq[String]]
   ) = {
     val out = tester.eval(("show", "countThreads")).out
-    val read = upickle.default.read[Seq[String]](out)
+    val read = upickle.read[Seq[String]](out)
     // Filter out threads from the thread pool that runs tasks
     // 'countThreads' marks the thread that runs it with a '!' prefix
     val taskPoolPrefixOpt = read

--- a/integration/ide/build-classpath-contents/src/BuildClasspathContentsTests.scala
+++ b/integration/ide/build-classpath-contents/src/BuildClasspathContentsTests.scala
@@ -8,7 +8,7 @@ object BuildClasspathContentsTests extends UtestIntegrationTestSuite {
     test("test") - integrationTest { tester =>
       val result1 =
         tester.eval(("--meta-level", "1", "show", "compileClasspath"), stderr = os.Inherit)
-      val deserialized = upickle.default.read[Seq[mill.api.PathRef]](result1.out)
+      val deserialized = upickle.read[Seq[mill.api.PathRef]](result1.out)
       val millPublishedJars = deserialized
         .map(_.path.last)
         .filter(_.startsWith("mill-"))

--- a/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.iml
+++ b/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.iml
@@ -112,13 +112,13 @@
         <orderEntry type="library" scope="RUNTIME" name="specification-level_3-1.8.5.jar" level="project"/>
         <orderEntry type="library" name="test-interface-1.0.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="tika-core-3.2.2.jar" level="project"/>
-        <orderEntry type="library" name="ujson_3-4.2.1.jar" level="project"/>
+        <orderEntry type="library" name="ujson_3-4.3.0.jar" level="project"/>
         <orderEntry type="library" name="unroll-annotation_3-0.2.0.jar" level="project"/>
-        <orderEntry type="library" name="upack_3-4.2.1.jar" level="project"/>
-        <orderEntry type="library" name="upickle-core_3-4.2.1.jar" level="project"/>
-        <orderEntry type="library" name="upickle-implicits-named-tuples_3-4.2.1.jar" level="project"/>
-        <orderEntry type="library" name="upickle-implicits_3-4.2.1.jar" level="project"/>
-        <orderEntry type="library" name="upickle_3-4.2.1.jar" level="project"/>
+        <orderEntry type="library" name="upack_3-4.3.0.jar" level="project"/>
+        <orderEntry type="library" name="upickle-core_3-4.3.0.jar" level="project"/>
+        <orderEntry type="library" name="upickle-implicits-named-tuples_3-4.3.0.jar" level="project"/>
+        <orderEntry type="library" name="upickle-implicits_3-4.3.0.jar" level="project"/>
+        <orderEntry type="library" name="upickle_3-4.3.0.jar" level="project"/>
         <orderEntry type="library" name="versions_2.13-0.5.1.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="windows-ansi-0.0.6.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="windows-jni-utils-0.3.3.jar" level="project"/>

--- a/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.mill-build.iml
+++ b/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.mill-build.iml
@@ -114,13 +114,13 @@
         <orderEntry type="library" scope="RUNTIME" name="specification-level_3-1.8.5.jar" level="project"/>
         <orderEntry type="library" name="test-interface-1.0.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="tika-core-3.2.2.jar" level="project"/>
-        <orderEntry type="library" name="ujson_3-4.2.1.jar" level="project"/>
+        <orderEntry type="library" name="ujson_3-4.3.0.jar" level="project"/>
         <orderEntry type="library" name="unroll-annotation_3-0.2.0.jar" level="project"/>
-        <orderEntry type="library" name="upack_3-4.2.1.jar" level="project"/>
-        <orderEntry type="library" name="upickle-core_3-4.2.1.jar" level="project"/>
-        <orderEntry type="library" name="upickle-implicits-named-tuples_3-4.2.1.jar" level="project"/>
-        <orderEntry type="library" name="upickle-implicits_3-4.2.1.jar" level="project"/>
-        <orderEntry type="library" name="upickle_3-4.2.1.jar" level="project"/>
+        <orderEntry type="library" name="upack_3-4.3.0.jar" level="project"/>
+        <orderEntry type="library" name="upickle-core_3-4.3.0.jar" level="project"/>
+        <orderEntry type="library" name="upickle-implicits-named-tuples_3-4.3.0.jar" level="project"/>
+        <orderEntry type="library" name="upickle-implicits_3-4.3.0.jar" level="project"/>
+        <orderEntry type="library" name="upickle_3-4.3.0.jar" level="project"/>
         <orderEntry type="library" name="versions_2.13-0.5.1.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="windows-ansi-0.0.6.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="windows-jni-utils-0.3.3.jar" level="project"/>

--- a/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/mill-build.iml
+++ b/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/mill-build.iml
@@ -108,13 +108,13 @@
         <orderEntry type="library" scope="RUNTIME" name="specification-level_3-1.8.5.jar" level="project"/>
         <orderEntry type="library" name="test-interface-1.0.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="tika-core-3.2.2.jar" level="project"/>
-        <orderEntry type="library" name="ujson_3-4.2.1.jar" level="project"/>
+        <orderEntry type="library" name="ujson_3-4.3.0.jar" level="project"/>
         <orderEntry type="library" name="unroll-annotation_3-0.2.0.jar" level="project"/>
-        <orderEntry type="library" name="upack_3-4.2.1.jar" level="project"/>
-        <orderEntry type="library" name="upickle-core_3-4.2.1.jar" level="project"/>
-        <orderEntry type="library" name="upickle-implicits-named-tuples_3-4.2.1.jar" level="project"/>
-        <orderEntry type="library" name="upickle-implicits_3-4.2.1.jar" level="project"/>
-        <orderEntry type="library" name="upickle_3-4.2.1.jar" level="project"/>
+        <orderEntry type="library" name="upack_3-4.3.0.jar" level="project"/>
+        <orderEntry type="library" name="upickle-core_3-4.3.0.jar" level="project"/>
+        <orderEntry type="library" name="upickle-implicits-named-tuples_3-4.3.0.jar" level="project"/>
+        <orderEntry type="library" name="upickle-implicits_3-4.3.0.jar" level="project"/>
+        <orderEntry type="library" name="upickle_3-4.3.0.jar" level="project"/>
         <orderEntry type="library" name="versions_2.13-0.5.1.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="windows-ansi-0.0.6.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="windows-jni-utils-0.3.3.jar" level="project"/>

--- a/integration/invalidation/multi-level-editing/src/MultiLevelBuildTests.scala
+++ b/integration/invalidation/multi-level-editing/src/MultiLevelBuildTests.scala
@@ -48,7 +48,7 @@ trait MultiLevelBuildTests extends UtestIntegrationTestSuite {
       yield {
         val path =
           tester.workspacePath / "out" / Seq.fill(depth)(millBuild) / millRunnerState
-        if (os.exists(path)) upickle.default.read[RunnerState.Frame.Logged](os.read(path)) -> path
+        if (os.exists(path)) upickle.read[RunnerState.Frame.Logged](os.read(path)) -> path
         else RunnerState.Frame.Logged(Map(), Seq(), Seq(), None, Seq(), 0) -> path
       }
   }

--- a/libs/androidlib/src/mill/androidlib/AndroidAppKotlinModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppKotlinModule.scala
@@ -203,7 +203,7 @@ trait AndroidAppKotlinModule extends AndroidKotlinModule, AndroidAppModule { out
         resourceApkPath = resourceApkPath().path.toString(),
         resultsFilePath = resultsFilePath.toString()
       )
-      os.write(cliArgsFile, upickle.default.write(cliArgs))
+      os.write(cliArgsFile, upickle.write(cliArgs))
 
       PathRef(cliArgsFile)
 
@@ -279,7 +279,7 @@ trait AndroidAppKotlinModule extends AndroidKotlinModule, AndroidAppModule { out
       )
       os.write(
         androidDiscoveredPreviewsPath,
-        upickle.default.write(Map("screenshots" -> screenshotConfigurations))
+        upickle.write(Map("screenshots" -> screenshotConfigurations))
       )
 
       (

--- a/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
@@ -11,7 +11,7 @@ import mill.api.{ModuleRef, PathRef, Task}
 import mill.javalib.*
 import os.{Path, RelPath, zip}
 import os.RelPath.stringRelPathValidated
-import upickle.default.*
+import upickle.*
 import scala.concurrent.duration.*
 
 import scala.jdk.OptionConverters.RichOptional

--- a/libs/androidlib/src/mill/androidlib/AndroidBuildTypeSettings.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidBuildTypeSettings.scala
@@ -15,6 +15,6 @@ case class AndroidBuildTypeSettings(
 )
 
 object AndroidBuildTypeSettings {
-  implicit val resultRW: upickle.default.ReadWriter[AndroidBuildTypeSettings] =
-    upickle.default.macroRW
+  implicit val resultRW: upickle.ReadWriter[AndroidBuildTypeSettings] =
+    upickle.macroRW
 }

--- a/libs/androidlib/src/mill/androidlib/AndroidModuleGeneratedDexVariants.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidModuleGeneratedDexVariants.scala
@@ -9,6 +9,6 @@ case class AndroidModuleGeneratedDexVariants(
 )
 
 object AndroidModuleGeneratedDexVariants {
-  implicit def resultRW: upickle.default.ReadWriter[AndroidModuleGeneratedDexVariants] =
-    upickle.default.macroRW
+  implicit def resultRW: upickle.ReadWriter[AndroidModuleGeneratedDexVariants] =
+    upickle.macroRW
 }

--- a/libs/androidlib/src/mill/androidlib/AndroidPackageableExtraFile.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidPackageableExtraFile.scala
@@ -6,6 +6,6 @@ import mill.api.PathRef
 case class AndroidPackageableExtraFile(source: PathRef, destination: os.RelPath)
 
 object AndroidPackageableExtraFile {
-  implicit val resultRW: upickle.default.ReadWriter[AndroidPackageableExtraFile] =
-    upickle.default.macroRW
+  implicit val resultRW: upickle.ReadWriter[AndroidPackageableExtraFile] =
+    upickle.macroRW
 }

--- a/libs/androidlib/src/mill/androidlib/AndroidSdkModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidSdkModule.scala
@@ -8,7 +8,7 @@ import mill.*
 import mill.api.{Result, TaskCtx}
 import mill.androidlib.Versions
 import scala.util.Properties.{isLinux, isMac, isWin}
-import upickle.default.ReadWriter
+import upickle.ReadWriter
 
 import java.math.BigInteger
 import java.nio.charset.StandardCharsets

--- a/libs/androidlib/src/mill/androidlib/ComposeRenderer.scala
+++ b/libs/androidlib/src/mill/androidlib/ComposeRenderer.scala
@@ -22,7 +22,7 @@ private[androidlib] object ComposeRenderer {
   )
 
   object Args {
-    implicit def resultRW: upickle.default.ReadWriter[Args] = upickle.default.macroRW
+    implicit def resultRW: upickle.ReadWriter[Args] = upickle.macroRW
   }
 
   case class Screenshot(
@@ -33,7 +33,7 @@ private[androidlib] object ComposeRenderer {
   )
 
   object Screenshot {
-    implicit def resultRW: upickle.default.ReadWriter[Screenshot] = upickle.default.macroRW
+    implicit def resultRW: upickle.ReadWriter[Screenshot] = upickle.macroRW
   }
 
   case class PreviewParams(
@@ -43,7 +43,7 @@ private[androidlib] object ComposeRenderer {
   )
 
   object PreviewParams {
-    implicit def resultRW: upickle.default.ReadWriter[PreviewParams] = upickle.default.macroRW
+    implicit def resultRW: upickle.ReadWriter[PreviewParams] = upickle.macroRW
   }
 
   object Tests {

--- a/libs/init/sbt/src/mill/main/sbt/SbtBuildGenMain.scala
+++ b/libs/init/sbt/src/mill/main/sbt/SbtBuildGenMain.scala
@@ -139,7 +139,7 @@ object SbtBuildGenMain
     val buildExportPickled = os.read(workspace / "target" / "mill-init-build-export.json")
     // TODO This is mainly for debugging purposes. Comment out or uncomment this line as needed.
     // println("sbt build export retrieved: " + buildExportPickled)
-    import upickle.default.*
+    import upickle.*
     val buildExport = read[BuildExport](buildExportPickled)
 
     import scala.math.Ordering.Implicits.*

--- a/libs/init/src/mill/init/InitModule.scala
+++ b/libs/init/src/mill/init/InitModule.scala
@@ -102,9 +102,9 @@ trait InitModule extends Module {
     }
   private def usingExamples[T](fun: Seq[(ExampleId, ExampleUrl)] => T): Try[T] =
     Using(getClass.getClassLoader.getResourceAsStream("exampleList.txt")) { exampleList =>
-      val reader = upickle.default.reader[Seq[(ExampleId, ExampleUrl)]]
+      val reader = upickle.reader[Seq[(ExampleId, ExampleUrl)]]
       val exampleNames: Seq[(ExampleId, ExampleUrl)] =
-        upickle.default.read(exampleList)(using reader)
+        upickle.read(exampleList)(using reader)
       fun(exampleNames)
     }
 }

--- a/libs/javalib/api/src/mill/javalib/api/CompilationResult.scala
+++ b/libs/javalib/api/src/mill/javalib/api/CompilationResult.scala
@@ -7,6 +7,6 @@ import mill.api.JsonFormatters._
 case class CompilationResult(analysisFile: os.Path, classes: PathRef)
 
 object CompilationResult {
-  implicit val jsonFormatter: upickle.default.ReadWriter[CompilationResult] =
-    upickle.default.macroRW
+  implicit val jsonFormatter: upickle.ReadWriter[CompilationResult] =
+    upickle.macroRW
 }

--- a/libs/javalib/api/src/mill/javalib/api/internal/JavaCompilerOptions.scala
+++ b/libs/javalib/api/src/mill/javalib/api/internal/JavaCompilerOptions.scala
@@ -10,8 +10,8 @@ case class JavaCompilerOptions private (options: Seq[String]) {
   }
 }
 object JavaCompilerOptions {
-  given rw: upickle.default.ReadWriter[JavaCompilerOptions] =
-    summon[upickle.default.ReadWriter[Seq[String]]]
+  given rw: upickle.ReadWriter[JavaCompilerOptions] =
+    summon[upickle.ReadWriter[Seq[String]]]
       .bimap(_.options, new JavaCompilerOptions(_))
 
   def empty: JavaCompilerOptions = new JavaCompilerOptions(Seq.empty)

--- a/libs/javalib/api/src/mill/javalib/api/internal/zinc_operations.scala
+++ b/libs/javalib/api/src/mill/javalib/api/internal/zinc_operations.scala
@@ -11,7 +11,7 @@ case class ZincCompileJava(
     compileClasspath: Seq[os.Path],
     javacOptions: JavaCompilerOptions,
     incrementalCompilation: Boolean
-) derives upickle.default.ReadWriter
+) derives upickle.ReadWriter
 
 /** Compiles Java and Scala sources. */
 case class ZincCompileMixed(
@@ -26,7 +26,7 @@ case class ZincCompileMixed(
     scalacPluginClasspath: Seq[PathRef],
     incrementalCompilation: Boolean,
     auxiliaryClassFileExtensions: Seq[String]
-) derives upickle.default.ReadWriter
+) derives upickle.ReadWriter
 
 /** Creates a Scaladoc jar. */
 case class ZincScaladocJar(
@@ -35,4 +35,4 @@ case class ZincScaladocJar(
     compilerClasspath: Seq[PathRef],
     scalacPluginClasspath: Seq[PathRef],
     args: Seq[String]
-) derives upickle.default.ReadWriter
+) derives upickle.ReadWriter

--- a/libs/javalib/src/mill/javalib/Assembly.scala
+++ b/libs/javalib/src/mill/javalib/Assembly.scala
@@ -20,7 +20,7 @@ case class Assembly(pathRef: PathRef, entries: Int)
  */
 object Assembly {
 
-  implicit val assemblyJsonRW: upickle.default.ReadWriter[Assembly] = upickle.default.macroRW
+  implicit val assemblyJsonRW: upickle.ReadWriter[Assembly] = upickle.macroRW
 
   val defaultRules: Seq[Rule] = Seq(
     Rule.Append("reference.conf", separator = "\n"),

--- a/libs/javalib/src/mill/javalib/Dep.scala
+++ b/libs/javalib/src/mill/javalib/Dep.scala
@@ -1,6 +1,6 @@
 package mill.javalib
 
-import upickle.default.{macroRW, ReadWriter as RW}
+import upickle.{macroRW, ReadWriter as RW}
 import mill.api.CrossVersion.*
 import mill.api.CrossVersion
 import coursier.core.{Configuration, Dependency, MinimizedExclusions}
@@ -175,15 +175,15 @@ object Dep {
 
   // Use literal JSON strings for common cases so that files
   // containing serialized dependencies can be easier to skim
-  implicit val rw: RW[Dep] = upickle.default.readwriter[ujson.Value].bimap[Dep](
+  implicit val rw: RW[Dep] = upickle.readwriter[ujson.Value].bimap[Dep](
     (dep: Dep) =>
       unparse(dep) match {
         case Some(s) => ujson.Str(s)
-        case None => upickle.default.writeJs[Dep](dep)(using rw0)
+        case None => upickle.writeJs[Dep](dep)(using rw0)
       },
     {
       case s: ujson.Str => parse(s.value)
-      case v: ujson.Value => upickle.default.read[Dep](v)(using rw0)
+      case v: ujson.Value => upickle.read[Dep](v)(using rw0)
     }
   )
 
@@ -243,18 +243,18 @@ case class BoundDep(
 
 object BoundDep {
   @unused private implicit val depFormat: RW[Dependency] = mill.javalib.JsonFormatters.depFormat
-  private val jsonify0: upickle.default.ReadWriter[BoundDep] = upickle.default.macroRW
+  private val jsonify0: upickle.ReadWriter[BoundDep] = upickle.macroRW
 
   // Use literal JSON strings for common cases so that files
   // containing serialized dependencies can be easier to skim
   //
   // `BoundDep` is basically a `Dep` with `cross=CrossVersion.Constant("", false)`,
   // so we can re-use most of `Dep`'s serialization logic
-  implicit val jsonify: upickle.default.ReadWriter[BoundDep] =
-    upickle.default.readwriter[ujson.Value].bimap[BoundDep](
+  implicit val jsonify: upickle.ReadWriter[BoundDep] =
+    upickle.readwriter[ujson.Value].bimap[BoundDep](
       bdep => {
         Dep.unparse(Dep(bdep.dep, CrossVersion.Constant("", false), bdep.force)) match {
-          case None => upickle.default.writeJs(bdep)(using jsonify0)
+          case None => upickle.writeJs(bdep)(using jsonify0)
           case Some(s) => ujson.Str(s)
         }
       },
@@ -262,7 +262,7 @@ object BoundDep {
         case ujson.Str(s) =>
           val dep = Dep.parse(s)
           BoundDep(dep.dep, dep.force)
-        case v => upickle.default.read[BoundDep](v)(using jsonify0)
+        case v => upickle.read[BoundDep](v)(using jsonify0)
       }
     )
 }

--- a/libs/javalib/src/mill/javalib/JsonFormatters.scala
+++ b/libs/javalib/src/mill/javalib/JsonFormatters.scala
@@ -1,6 +1,6 @@
 package mill.javalib
 
-import upickle.default.{ReadWriter => RW}
+import upickle.{ReadWriter => RW}
 import mill.api.internal.Mirrors.autoMirror
 import mill.api.daemon.internal.TestReporter
 import mill.api.internal.Mirrors
@@ -8,17 +8,17 @@ import mill.api.internal.Mirrors
 trait JsonFormatters {
   import JsonFormatters.mirrors.given
 
-  implicit lazy val publicationFormat: RW[coursier.core.Publication] = upickle.default.macroRW
-  implicit lazy val extensionFormat: RW[coursier.core.Extension] = upickle.default.macroRW
+  implicit lazy val publicationFormat: RW[coursier.core.Publication] = upickle.macroRW
+  implicit lazy val extensionFormat: RW[coursier.core.Extension] = upickle.macroRW
 
-  implicit lazy val modFormat: RW[coursier.Module] = upickle.default.macroRW
+  implicit lazy val modFormat: RW[coursier.Module] = upickle.macroRW
   implicit lazy val versionConstraintFormat: RW[coursier.version.VersionConstraint] =
     implicitly[RW[String]].bimap(
       _.asString,
       coursier.version.VersionConstraint(_)
     )
   implicit lazy val versionIntervalFormat0: RW[coursier.version.VersionInterval] =
-    upickle.default.macroRW
+    upickle.macroRW
   implicit lazy val versionFormat0: RW[coursier.version.Version] =
     implicitly[RW[String]].bimap(
       _.asString,
@@ -26,99 +26,99 @@ trait JsonFormatters {
     )
   implicit lazy val variantMatcherFormat: RW[coursier.core.VariantSelector.VariantMatcher] =
     RW.merge(
-      upickle.default.macroRW[coursier.core.VariantSelector.VariantMatcher.Api.type],
-      upickle.default.macroRW[coursier.core.VariantSelector.VariantMatcher.Runtime.type],
-      upickle.default.macroRW[coursier.core.VariantSelector.VariantMatcher.Equals],
-      upickle.default.macroRW[coursier.core.VariantSelector.VariantMatcher.MinimumVersion],
-      upickle.default.macroRW[coursier.core.VariantSelector.VariantMatcher.AnyOf],
-      upickle.default.macroRW[coursier.core.VariantSelector.VariantMatcher.EndsWith]
+      upickle.macroRW[coursier.core.VariantSelector.VariantMatcher.Api.type],
+      upickle.macroRW[coursier.core.VariantSelector.VariantMatcher.Runtime.type],
+      upickle.macroRW[coursier.core.VariantSelector.VariantMatcher.Equals],
+      upickle.macroRW[coursier.core.VariantSelector.VariantMatcher.MinimumVersion],
+      upickle.macroRW[coursier.core.VariantSelector.VariantMatcher.AnyOf],
+      upickle.macroRW[coursier.core.VariantSelector.VariantMatcher.EndsWith]
     )
   implicit lazy val variantSelectorFormat: RW[coursier.core.VariantSelector] =
     RW.merge(
-      upickle.default.macroRW[coursier.core.VariantSelector.ConfigurationBased],
-      upickle.default.macroRW[coursier.core.VariantSelector.AttributesBased]
+      upickle.macroRW[coursier.core.VariantSelector.ConfigurationBased],
+      upickle.macroRW[coursier.core.VariantSelector.AttributesBased]
     )
   private implicit lazy val variantAttributesFormat: RW[coursier.core.Variant.Attributes] =
-    upickle.default.macroRW
+    upickle.macroRW
   implicit lazy val variantFormat: RW[coursier.core.Variant] =
     RW.merge(
-      upickle.default.macroRW[coursier.core.Variant.Configuration],
+      upickle.macroRW[coursier.core.Variant.Configuration],
       variantAttributesFormat
     )
-  implicit lazy val bomDepFormat: RW[coursier.core.BomDependency] = upickle.default.macroRW
+  implicit lazy val bomDepFormat: RW[coursier.core.BomDependency] = upickle.macroRW
   implicit lazy val overridesFormat: RW[coursier.core.Overrides] =
     implicitly[RW[coursier.core.DependencyManagement.Map]].bimap(
       _.flatten.toMap,
       coursier.core.Overrides(_)
     )
-  implicit lazy val depFormat: RW[coursier.core.Dependency] = upickle.default.macroRW
+  implicit lazy val depFormat: RW[coursier.core.Dependency] = upickle.macroRW
   implicit lazy val minimizedExclusionsFormat: RW[coursier.core.MinimizedExclusions] =
-    upickle.default.macroRW
+    upickle.macroRW
   implicit lazy val exclusionDataFormat: RW[coursier.core.MinimizedExclusions.ExclusionData] =
     RW.merge(
-      upickle.default.macroRW[coursier.core.MinimizedExclusions.ExcludeNone.type],
-      upickle.default.macroRW[coursier.core.MinimizedExclusions.ExcludeAll.type],
-      upickle.default.macroRW[coursier.core.MinimizedExclusions.ExcludeSpecific]
+      upickle.macroRW[coursier.core.MinimizedExclusions.ExcludeNone.type],
+      upickle.macroRW[coursier.core.MinimizedExclusions.ExcludeAll.type],
+      upickle.macroRW[coursier.core.MinimizedExclusions.ExcludeSpecific]
     )
-  implicit lazy val attrFormat: RW[coursier.Attributes] = upickle.default.macroRW
-  implicit lazy val orgFormat: RW[coursier.Organization] = upickle.default.macroRW
-  implicit lazy val modNameFormat: RW[coursier.ModuleName] = upickle.default.macroRW
-  implicit lazy val configurationFormat: RW[coursier.core.Configuration] = upickle.default.macroRW
-  implicit lazy val typeFormat: RW[coursier.core.Type] = upickle.default.macroRW
-  implicit lazy val classifierFormat: RW[coursier.core.Classifier] = upickle.default.macroRW
+  implicit lazy val attrFormat: RW[coursier.Attributes] = upickle.macroRW
+  implicit lazy val orgFormat: RW[coursier.Organization] = upickle.macroRW
+  implicit lazy val modNameFormat: RW[coursier.ModuleName] = upickle.macroRW
+  implicit lazy val configurationFormat: RW[coursier.core.Configuration] = upickle.macroRW
+  implicit lazy val typeFormat: RW[coursier.core.Type] = upickle.macroRW
+  implicit lazy val classifierFormat: RW[coursier.core.Classifier] = upickle.macroRW
   implicit lazy val depMgmtKeyFormat: RW[coursier.core.DependencyManagement.Key] =
-    upickle.default.macroRW
+    upickle.macroRW
   implicit lazy val depMgmtValuesFormat: RW[coursier.core.DependencyManagement.Values] =
-    upickle.default.macroRW
-  implicit lazy val activationOsFormat: RW[coursier.core.Activation.Os] = upickle.default.macroRW
-  implicit lazy val infoDeveloperFormat: RW[coursier.core.Info.Developer] = upickle.default.macroRW
-  implicit lazy val infoScmFormat: RW[coursier.core.Info.Scm] = upickle.default.macroRW
-  implicit lazy val infoLicenseFormat: RW[coursier.core.Info.License] = upickle.default.macroRW
-  implicit lazy val infoFormat: RW[coursier.core.Info] = upickle.default.macroRW
+    upickle.macroRW
+  implicit lazy val activationOsFormat: RW[coursier.core.Activation.Os] = upickle.macroRW
+  implicit lazy val infoDeveloperFormat: RW[coursier.core.Info.Developer] = upickle.macroRW
+  implicit lazy val infoScmFormat: RW[coursier.core.Info.Scm] = upickle.macroRW
+  implicit lazy val infoLicenseFormat: RW[coursier.core.Info.License] = upickle.macroRW
+  implicit lazy val infoFormat: RW[coursier.core.Info] = upickle.macroRW
   implicit lazy val snapshotVersionFormat: RW[coursier.core.SnapshotVersion] =
-    upickle.default.macroRW
+    upickle.macroRW
   implicit lazy val versionInternalFormat: RW[coursier.core.VersionInterval] =
-    upickle.default.macroRW
+    upickle.macroRW
   implicit lazy val versionFormat: RW[coursier.core.Version] =
     implicitly[RW[String]].bimap(
       _.repr,
       coursier.core.Version(_)
     )
   implicit lazy val snapshotVersioningFormat: RW[coursier.core.SnapshotVersioning] =
-    upickle.default.macroRW
+    upickle.macroRW
   implicit lazy val versionsFormat: RW[coursier.core.Versions] =
-    upickle.default.readwriter[ujson.Value].bimap[coursier.core.Versions](
+    upickle.readwriter[ujson.Value].bimap[coursier.core.Versions](
       versions =>
         ujson.Obj(
           "latest" -> versions.latest,
           "release" -> versions.release,
           "available" -> versions.available,
-          "lastUpdated" -> upickle.default.writeJs(versions.lastUpdated)
+          "lastUpdated" -> upickle.writeJs(versions.lastUpdated)
         ),
       json =>
         coursier.core.Versions(
           latest = json("latest").str,
           release = json("release").str,
-          available = upickle.default.read(json("available")): List[String],
+          available = upickle.read(json("available")): List[String],
           lastUpdated =
-            upickle.default.read(json("lastUpdated")): Option[coursier.core.Versions.DateTime]
+            upickle.read(json("lastUpdated")): Option[coursier.core.Versions.DateTime]
         )
     )
   implicit lazy val versionsDateTimeFormat: RW[coursier.core.Versions.DateTime] =
-    upickle.default.macroRW
-  implicit lazy val activationFormat: RW[coursier.core.Activation] = upickle.default.macroRW
-  implicit lazy val profileFormat: RW[coursier.core.Profile] = upickle.default.macroRW
+    upickle.macroRW
+  implicit lazy val activationFormat: RW[coursier.core.Activation] = upickle.macroRW
+  implicit lazy val profileFormat: RW[coursier.core.Profile] = upickle.macroRW
   private implicit lazy val variantPublicationFormat: RW[coursier.core.VariantPublication] =
-    upickle.default.macroRW
+    upickle.macroRW
   private implicit def attributesMapFormat[T: RW]: RW[Map[coursier.core.Variant.Attributes, T]] =
     implicitly[RW[Map[String, T]]].bimap(
       attrMap => attrMap.map { case (k, v) => k.variantName -> v },
       strMap => strMap.map { case (k, v) => coursier.core.Variant.Attributes(k) -> v }
     )
-  implicit lazy val projectFormat: RW[coursier.core.Project] = upickle.default.macroRW
+  implicit lazy val projectFormat: RW[coursier.core.Project] = upickle.macroRW
 
-  implicit lazy val logLevelRW: upickle.default.ReadWriter[TestReporter.LogLevel] =
-    implicitly[upickle.default.ReadWriter[String]].bimap(
+  implicit lazy val logLevelRW: upickle.ReadWriter[TestReporter.LogLevel] =
+    implicitly[upickle.ReadWriter[String]].bimap(
       _.asString,
       TestReporter.LogLevel.fromString(_)
     )

--- a/libs/javalib/src/mill/javalib/PublishModule.scala
+++ b/libs/javalib/src/mill/javalib/PublishModule.scala
@@ -684,9 +684,9 @@ object PublishModule extends ExternalModule with DefaultTaskModule {
       (PublishData.withConcretePath(payloadAsMap), meta)
   }
   object PublishData {
-    implicit def jsonify: upickle.default.ReadWriter[PublishData] = {
+    implicit def jsonify: upickle.ReadWriter[PublishData] = {
       import mill.javalib.publish.JsonFormatters.artifactFormat
-      upickle.default.macroRW
+      upickle.macroRW
     }
 
     def apply(meta: Artifact, payload: Map[os.SubPath, PathRef]): PublishData =

--- a/libs/javalib/src/mill/javalib/SemanticDbJavaModule.scala
+++ b/libs/javalib/src/mill/javalib/SemanticDbJavaModule.scala
@@ -216,7 +216,7 @@ object SemanticDbJavaModule extends ExternalModule with CoursierModule {
   case class SemanticDbData(
       compilationResult: CompilationResult,
       semanticDbFiles: PathRef
-  ) derives upickle.default.ReadWriter
+  ) derives upickle.ReadWriter
 
   private[mill] def workerClasspath: T[Seq[PathRef]] = Task {
     defaultResolver().classpath(Seq(

--- a/libs/javalib/src/mill/javalib/TestModule.scala
+++ b/libs/javalib/src/mill/javalib/TestModule.scala
@@ -211,7 +211,7 @@ trait TestModule
       )
 
       val argsFile = Task.dest / "testargs"
-      os.write(argsFile, upickle.default.write(testArgs))
+      os.write(argsFile, upickle.write(testArgs))
 
       val testRunnerClasspathArg =
         jvmWorker().scalalibClasspath()

--- a/libs/javalib/src/mill/javalib/TestModuleUtil.scala
+++ b/libs/javalib/src/mill/javalib/TestModuleUtil.scala
@@ -15,12 +15,10 @@ import scala.xml.Elem
 import scala.collection.mutable
 import mill.api.Logger
 
-import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
 import mill.api.BuildCtx
 import mill.javalib.testrunner.{GetTestTasksMain, TestArgs, TestResult, TestRunnerUtils}
-import os.Path
 
-import scala.annotation.unused
 import scala.concurrent.Future
 
 /**
@@ -32,7 +30,7 @@ final class TestModuleUtil(
     forkArgs: Seq[String],
     selectors: Seq[String],
     scalalibClasspath: Seq[PathRef],
-    @unused resources: Seq[PathRef],
+    resources: Seq[PathRef],
     testFramework: String,
     runClasspath: Seq[PathRef],
     testClasspath: Seq[PathRef],
@@ -49,10 +47,11 @@ final class TestModuleUtil(
     propagateEnv: Boolean = true
 )(implicit ctx: mill.api.TaskCtx) {
 
-  private val (jvmArgs, props) = TestModuleUtil.loadArgsAndProps(useArgsFile, forkArgs)
+  private val (jvmArgs, props: Map[String, String]) =
+    TestModuleUtil.loadArgsAndProps(useArgsFile, forkArgs)
 
   private val testRunnerClasspathArg = scalalibClasspath
-    .map(_.path.toURL)
+    .map(_.path.toNIO.toUri.toURL)
     .mkString(",")
 
   def runTests(): Result[(msg: String, results: Seq[TestResult])] = {
@@ -122,7 +121,7 @@ final class TestModuleUtil(
     }
   }
 
-  def callTestRunnerSubprocess(
+  private def callTestRunnerSubprocess(
       baseFolder: os.Path,
       resultPath: os.Path,
       // either:
@@ -130,8 +129,7 @@ final class TestModuleUtil(
       //     - list of glob selectors to feed to the test runner directly.
       // - Right((startingTestClass, testClassQueueFolder, claimFolder)):
       //     - first test class to run, folder containing test classes for test runner to claim from, and the worker's base folder.
-      selector: Either[Seq[String], (Option[String], os.Path, os.Path)],
-      poll: () => Unit
+      selector: Either[Seq[String], (Option[String], os.Path, os.Path)]
   )(implicit ctx: mill.api.TaskCtx) = {
     if (!os.exists(baseFolder)) os.makeDir.all(baseFolder)
 
@@ -152,12 +150,12 @@ final class TestModuleUtil(
 
     val argsFile = baseFolder / "testargs"
     val sandbox = baseFolder / "sandbox"
-    os.write(argsFile, upickle.write(testArgs), createFolders = true)
+    os.write(argsFile, upickle.default.write(testArgs), createFolders = true)
 
     os.makeDir.all(sandbox)
 
-    val proc = BuildCtx.withFilesystemCheckerDisabled {
-      Jvm.spawnProcess(
+    BuildCtx.withFilesystemCheckerDisabled {
+      Jvm.callProcess(
         mainClass = "mill.javalib.testrunner.entrypoint.TestRunnerMain",
         classPath = (runClasspath ++ testrunnerEntrypointClasspath).map(_.path),
         jvmArgs = jvmArgs,
@@ -173,39 +171,28 @@ final class TestModuleUtil(
         propagateEnv = false
       )
     }
-    while (proc.isAlive()) {
-      Thread.sleep(10)
-      poll()
-    }
 
     if (!os.exists(outputPath))
       Result.Failure(s"Test reporting Failed: ${outputPath} does not exist")
     else
-      Result.Success(upickle.read[(String, Seq[TestResult])](ujson.read(outputPath.toIO)))
+      Result.Success(upickle.default.read[(String, Seq[TestResult])](ujson.read(outputPath.toIO)))
   }
 
-  def prepareTestClassesFolder(selectors2: Seq[String], base: os.Path): os.Path = {
-    // test-classes folder is used to store the test classes for the children test runners to claim from
-    val testClassQueueFolder = base / "test-classes"
-    os.makeDir.all(testClassQueueFolder)
-    selectors2.zipWithIndex.foreach { case (s, _) =>
-      os.write.over(testClassQueueFolder / s, Array.empty[Byte])
-    }
-    testClassQueueFolder
-  }
-
-  def jobsProcessLength(numTests: Int) = {
-    val cappedJobs = Math.max(Math.min(Task.ctx().jobs, numTests), 1)
-    (cappedJobs, cappedJobs.toString.length)
-  }
-
-  def runTestQueueScheduler(
+  private def runTestQueueScheduler(
       filteredClassLists: Seq[Seq[String]]
   )(implicit ctx: mill.api.TaskCtx) = {
 
-    val filteredClassCount: Int = filteredClassLists.map(_.size).sum
+    val filteredClassCount = filteredClassLists.map(_.size).sum
 
-    val groupFolderData: Seq[(Path, Path, Int)] = prepareTestGroups(filteredClassLists)
+    def prepareTestClassesFolder(selectors2: Seq[String], base: os.Path): os.Path = {
+      // test-classes folder is used to store the test classes for the children test runners to claim from
+      val testClassQueueFolder = base / "test-classes"
+      os.makeDir.all(testClassQueueFolder)
+      selectors2.zipWithIndex.foreach { case (s, _) =>
+        os.write.over(testClassQueueFolder / s, Array.empty[Byte])
+      }
+      testClassQueueFolder
+    }
 
     def runTestRunnerSubprocess(
         base: os.Path,
@@ -244,30 +231,20 @@ final class TestModuleUtil(
           resultPath,
           Right((startingTestClass, testClassQueueFolder, claimFolder))
         )
-        processIndex <- 0 until Math.max(Math.min(jobs, numTests), 1)
-      } yield runTestFuture(
-        filteredClassCount,
-        groupFolderData,
-        groupFolder,
-        testClassQueueFolder,
-        groupFolder.last,
-        maxProcessLength,
-        paddedGroupIndex,
-        processIndex
-      )
 
-      Task.fork.blocking {
-        TestModuleUtil.waitForFutures(ctx, filteredClassCount, subprocessFutures)
+        workerStatusMap.remove(claimLog)
+        Some(result)
+      } else {
+        None
       }
-
-      subprocessFutures.flatMap(_._2.value).map(_.get)
     }
 
-    TestModuleUtil.processTestResults(outputs)
-  }
+    def jobsProcessLength(numTests: Int) = {
+      val cappedJobs = Math.max(Math.min(Task.ctx().jobs, numTests), 1)
+      (cappedJobs, cappedJobs.toString.length)
+    }
 
-  private def prepareTestGroups(filteredClassLists: Seq[Seq[String]]) = {
-    filteredClassLists match {
+    val groupFolderData = filteredClassLists match {
       case Nil => Seq((Task.dest, prepareTestClassesFolder(Nil, Task.dest), 0))
       case Seq(singleTestClassList) =>
         Seq((
@@ -292,116 +269,167 @@ final class TestModuleUtil(
           )
         }
     }
-  }
 
-  def runTestFuture(
-      filteredClassCount: Int,
-      groupFolderData: Seq[(Path, Path, Int)],
-      groupFolder: Path,
-      testClassQueueFolder: Path,
-      groupName: String,
-      maxProcessLength: Int,
-      paddedGroupIndex: String,
-      processIndex: Int
-  ) = {
-    val paddedProcessIndex =
-      mill.api.internal.Util.leftPad(processIndex.toString, maxProcessLength, '0')
+    val groupLength = groupFolderData.length
+    val maxGroupLength = groupLength.toString.length
 
-    val workerLabel = s"worker-$paddedProcessIndex"
-    val processFolder =
-      if (testParallelism && filteredClassCount != 1) groupFolder / workerLabel
-      else groupFolder
+    val outputs = TestModuleUtil.withTestProgressTickerThread(filteredClassCount) {
+      (workerStatusMap, workerResultSet) =>
+        // We got "--jobs" threads, and "groupLength" test groups, so we will spawn at most jobs * groupLength runners here
+        // In most case, this is more than necessary, and runner creation is expensive,
+        // but we have a check for non-empty test-classes folder before really spawning a new runner, so in practice the overhead is low
+        val subprocessFutures = for {
+          ((groupFolder, testClassQueueFolder, numTests), groupIndex) <-
+            groupFolderData.zipWithIndex
+          // Don't have re-calculate for every processes
+          groupName = groupFolder.last
+          (jobs, maxProcessLength) = jobsProcessLength(numTests)
+          paddedGroupIndex =
+            mill.api.internal.Util.leftPad(groupIndex.toString, maxGroupLength, '0')
+          processIndex <- 0 until Math.max(Math.min(jobs, numTests), 1)
+        } yield {
 
-    val resultPath = processFolder / s"result.log"
-    os.write.over(resultPath, upickle.write((0L, 0L)), createFolders = true)
-    val label =
-      if (groupFolderData.size == 1) paddedProcessIndex
-      else s"$paddedGroupIndex-$paddedProcessIndex"
+          val paddedProcessIndex =
+            mill.api.internal.Util.leftPad(processIndex.toString, maxProcessLength, '0')
 
-    def fork[T](block: Logger => T): Future[T] = {
-      if (testParallelism && filteredClassCount != 1) {
-        Task.fork.async(
-          processFolder,
-          label,
-          "",
-          // With the test queue scheduler, prioritize the *first* test subprocess
-          // over other Mill tasks via `priority = -1`, but de-prioritize the others
-          // increasingly according to their processIndex. This should help Mill
-          // use fewer longer-lived test subprocesses, minimizing JVM startup overhead
-          priority = if (processIndex == 0) -1 else processIndex
-        ) {
-          block
-        }
-      } else Future.successful(block(ctx.log))
-    }
+          val workerLabel = s"worker-$paddedProcessIndex"
+          val processFolder =
+            if (testParallelism && filteredClassCount != 1) groupFolder / workerLabel
+            else groupFolder
 
-    processFolder -> fork {
-      logger =>
-        val testClassTimeMap = new ConcurrentHashMap[String, Long]()
+          val label =
+            if (groupFolderData.size == 1) paddedProcessIndex
+            else s"$paddedGroupIndex-$paddedProcessIndex"
 
-        val claimFolder = processFolder / "claim"
-        os.makeDir.all(claimFolder)
-
-        // Make sure we can claim at least one test class to start before we spawn the
-        // subprocess, because creating JVM subprocesses are expensive and we don't want
-        // to spawn one if there is nothing for it to do
-        val startingTestClass = os
-          .list
-          .stream(testClassQueueFolder)
-          .map(TestRunnerUtils.claimFile(_, claimFolder))
-          .collectFirst { case Some(name) => name }
-
-        // force run when processIndex == 0 (first subprocess), even if there are no tests to run
-        // to force the process to go through the test framework setup/teardown logic
-        val result = Option.when(processIndex == 0 || startingTestClass.nonEmpty) {
-          startingTestClass.foreach(logger.ticker(_))
-          // queue.log file will be appended by the runner with the stolen test class's name
-          // it can be used to check the order of test classes of the runner
-          val claimLog = processFolder / "claim.log"
-          os.write.over(claimLog, Array.empty[Byte])
-
-          var currentTestClassNanoTime = Option.empty[(String, Long)]
-          var seenLines = 0
-          callTestRunnerSubprocess(
-            processFolder,
-            processFolder / "result.log",
-            Right((startingTestClass, testClassQueueFolder, claimFolder)),
-            () => {
-              val lines = os.read.lines(claimLog)
-              lines.drop(seenLines).collect {
-                case s"CLAIM $currentTestClass $nanoTime0" =>
-                  val nanoTime = nanoTime0.toLong
-                  logger.prompt.logBeginChromeProfileEntry(currentTestClass, nanoTime)
-                  testClassTimeMap.putIfAbsent(currentTestClass, nanoTime)
-                  currentTestClassNanoTime = Some(currentTestClass -> nanoTime)
-                case s"COMPLETED $nanoTime" =>
-                  logger.prompt.logEndChromeProfileEntry(nanoTime.toLong)
-                  None
+          def fork[T](block: Logger => T): Future[T] = {
+            if (testParallelism && filteredClassCount != 1) {
+              Task.fork.async(
+                processFolder,
+                label,
+                workerLabel,
+                // With the test queue scheduler, prioritize the *first* test subprocess
+                // over other Mill tasks via `priority = -1`, but de-prioritize the others
+                // increasingly according to their processIndex. This should help Mill
+                // use fewer longer-lived test subprocesses, minimizing JVM startup overhead
+                priority = if (processIndex == 0) -1 else processIndex
+              ) {
+                block
               }
-              seenLines = lines.length
-              for ((currentTestClass, nanoTime) <- currentTestClassNanoTime) {
-                val now = System.nanoTime()
-                logger.ticker(
-                  s"$currentTestClass${Util.renderSecondsSuffix((now - nanoTime) / 1000000)}"
-                )
-              }
-            }
-          )
+            } else Future.successful(block(ctx.log))
+          }
+          fork {
+            logger =>
+              val result = runTestRunnerSubprocess(
+                processFolder,
+                testClassQueueFolder,
+                // force run when processIndex == 0 (first subprocess), even if there are no tests to run
+                // to force the process to go through the test framework setup/teardown logic
+                force = processIndex == 0,
+                logger,
+                workerStatusMap,
+                workerResultSet
+              )
+
+              val claimedClasses =
+                if (os.exists(processFolder / "claim")) os.list(processFolder / "claim").size else 0
+
+              (claimedClasses, groupName, result)
+          }
         }
 
-        val claimedClasses = if (os.exists(claimFolder)) os.list(claimFolder).size else 0
+        Task.fork.blocking {
+          // We special-case this to avoid
+          while ({
+            val claimedCounts = subprocessFutures.flatMap(_.value).flatMap(_.toOption).map(_._1)
+            !(
+              (claimedCounts.sum == filteredClassCount && subprocessFutures.head.isCompleted) ||
+                subprocessFutures.forall(_.isCompleted)
+            )
+          }) Thread.sleep(1)
+        }
 
-        (claimedClasses, groupName, result)
+        subprocessFutures.flatMap(_.value).map(_.get)
     }
+
+    val subprocessResult = {
+      val failMap = mutable.Map.empty[String, String]
+      val successMap = mutable.Map.empty[String, (String, Seq[TestResult])]
+
+      outputs.foreach {
+        case (_, name, Some(Result.Failure(v))) => failMap.updateWith(name) {
+            case Some(old) => Some(old + " " + v)
+            case None => Some(v)
+          }
+        case (_, name, Some(Result.Success((msg, results)))) => successMap.updateWith(name) {
+            case Some((oldMsg, oldResults)) => Some((oldMsg + " " + msg, oldResults ++ results))
+            case None => Some((msg, results))
+          }
+        case _ => ()
+      }
+
+      if (failMap.nonEmpty) {
+        Result.Failure(failMap.values.mkString("\n"))
+      } else {
+        Result.Success((
+          successMap.values.map(_._1).mkString("\n"),
+          successMap.values.flatMap(_._2).toSeq
+        ))
+      }
+    }
+
+    subprocessResult
   }
+
 }
 
 private[mill] object TestModuleUtil {
 
-  def loadArgsAndProps(
-      useArgsFile: Boolean,
-      forkArgs: Seq[String]
-  ): (Seq[String], Map[String, String]) = {
+  private def withTestProgressTickerThread[T](totalClassCount: Long)(
+      body: (
+          java.util.concurrent.ConcurrentMap[os.Path, String => Unit],
+          java.util.concurrent.ConcurrentMap[os.Path, Unit]
+      ) => T
+  )(implicit ctx: mill.api.TaskCtx): T = {
+    val workerStatusMap = new java.util.concurrent.ConcurrentHashMap[os.Path, String => Unit]()
+    val workerResultSet = new java.util.concurrent.ConcurrentHashMap[os.Path, Unit]()
+
+    val testClassTimeMap = new java.util.concurrent.ConcurrentHashMap[String, Long]()
+
+    val executor = Executors.newScheduledThreadPool(1)
+    try {
+      // Periodically check the result log file and tick the relevant infos
+      executor.scheduleWithFixedDelay(
+        () => {
+          // reuse to reduce syscall, may not be as accurate as running `System.currentTimeMillis()` inside each entry
+          val now = System.currentTimeMillis()
+          workerStatusMap.forEach { (claimLog, callback) =>
+            // the last one is always the latest
+            os.read.lines(claimLog).lastOption.foreach { currentTestClass =>
+              testClassTimeMap.putIfAbsent(currentTestClass, now)
+              val last = testClassTimeMap.get(currentTestClass)
+              callback(s"$currentTestClass${Util.renderSecondsSuffix(now - last)}")
+            }
+          }
+          var totalSuccess = 0L
+          var totalFailure = 0L
+          workerResultSet.forEach { (resultLog, _) =>
+            val (success, failure) = upickle.default.read[(Long, Long)](os.read.stream(resultLog))
+            totalSuccess += success
+            totalFailure += failure
+          }
+          ctx.log.ticker(s"${totalSuccess + totalFailure}/${totalClassCount} completed${
+              if totalFailure > 0 then s", ${totalFailure} failures." else "."
+            }")
+        },
+        0,
+        20,
+        java.util.concurrent.TimeUnit.MILLISECONDS
+      )
+      body(workerStatusMap, workerResultSet)
+    } finally executor.shutdown()
+  }
+
+  private def loadArgsAndProps(useArgsFile: Boolean, forkArgs: Seq[String]) = {
     if (useArgsFile) {
       val (props, jvmArgs) = forkArgs.partition(_.startsWith("-D"))
       val sysProps =
@@ -523,7 +551,7 @@ private[mill] object TestModuleUtil {
     if (results0.nonEmpty) Some(xml) else None
   }
 
-  def formatTimestamp(timestamp: Instant): String = {
+  private def formatTimestamp(timestamp: Instant): String = {
     DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(
       LocalDateTime.ofInstant(
         timestamp.truncatedTo(ChronoUnit.SECONDS),
@@ -532,7 +560,7 @@ private[mill] object TestModuleUtil {
     )
   }
 
-  def testCaseStatus(e: TestResult): Option[Elem] = {
+  private def testCaseStatus(e: TestResult): Option[Elem] = {
     val trace: String = e.exceptionTrace.map(stackTraceTrace =>
       stackTraceTrace.map(t =>
         s"${t.getClassName}.${t.getMethodName}(${t.getFileName}:${t.getLineNumber})"
@@ -574,79 +602,6 @@ private[mill] object TestModuleUtil {
           .zipWithIndex
           .map { case (s, i) => if (prevSegments.lift(i).contains(s)) s.head else s }
           .mkString(".")
-    }
-  }
-
-  def processTestResults(outputs: Vector[(
-      Int,
-      String,
-      Option[Result[(String, Seq[TestResult])]]
-  )]) = {
-    val failMap = mutable.Map.empty[String, String]
-    val successMap = mutable.Map.empty[String, (String, Seq[TestResult])]
-    val subprocessResult = {
-
-      outputs.foreach {
-        case (_, name, Some(Result.Failure(v))) =>
-          failMap.updateWith(name) {
-            case Some(old) => Some(old + " " + v)
-            case None => Some(v)
-          }
-        case (_, name, Some(Result.Success((msg, results)))) =>
-          successMap.updateWith(name) {
-            case Some((oldMsg, oldResults)) => Some((oldMsg + " " + msg, oldResults ++ results))
-            case None => Some((msg, results))
-          }
-        case _ => ()
-      }
-
-      if (failMap.nonEmpty) {
-        Result.Failure(failMap.values.mkString("\n"))
-      } else {
-        Result.Success((
-          successMap.values.map(_._1).mkString("\n"),
-          successMap.values.flatMap(_._2).toSeq
-        ))
-      }
-    }
-
-    subprocessResult
-  }
-
-  private def waitForFutures(
-      ctx: TaskCtx,
-      filteredClassCount: Int,
-      subprocessFutures: Vector[(
-          Path,
-          Future[(Int, String, Option[Result[(String, Seq[TestResult])]])]
-      )]
-  ): Unit = {
-    while ({
-      val claimedCounts = subprocessFutures.flatMap(_._2.value).flatMap(_.toOption).map(_._1)
-      !(
-        (claimedCounts.sum == filteredClassCount && subprocessFutures.head._2.isCompleted) ||
-          subprocessFutures.forall(_._2.isCompleted)
-      )
-    }) {
-      val allResultsOpt =
-        // Don't crash if a result.log file is malformed, just try again
-        // since that might happen transiently during a write
-        try {
-          Some(subprocessFutures.map(_._1 / "result.log").map(p =>
-            upickle.read[(Long, Long)](os.read.stream(p))
-          ))
-        } catch {
-          case _: Exception => None
-        }
-
-      for (allResults <- allResultsOpt) {
-        val totalSuccess = allResults.map(_._1).sum
-        val totalFailure = allResults.map(_._2).sum
-        val totalClassCount = filteredClassCount
-        val failureSuffix = if totalFailure > 0 then s", $totalFailure failures" else ""
-        ctx.log.ticker(s"${totalSuccess + totalFailure}/$totalClassCount completed$failureSuffix.")
-      }
-      Thread.sleep(10)
     }
   }
 }

--- a/libs/javalib/src/mill/javalib/TestModuleUtil.scala
+++ b/libs/javalib/src/mill/javalib/TestModuleUtil.scala
@@ -152,7 +152,7 @@ final class TestModuleUtil(
 
     val argsFile = baseFolder / "testargs"
     val sandbox = baseFolder / "sandbox"
-    os.write(argsFile, upickle.default.write(testArgs), createFolders = true)
+    os.write(argsFile, upickle.write(testArgs), createFolders = true)
 
     os.makeDir.all(sandbox)
 
@@ -181,7 +181,7 @@ final class TestModuleUtil(
     if (!os.exists(outputPath))
       Result.Failure(s"Test reporting Failed: ${outputPath} does not exist")
     else
-      Result.Success(upickle.default.read[(String, Seq[TestResult])](ujson.read(outputPath.toIO)))
+      Result.Success(upickle.read[(String, Seq[TestResult])](ujson.read(outputPath.toIO)))
   }
 
   def prepareTestClassesFolder(selectors2: Seq[String], base: os.Path): os.Path = {
@@ -289,7 +289,7 @@ final class TestModuleUtil(
       else groupFolder
 
     val resultPath = processFolder / s"result.log"
-    os.write.over(resultPath, upickle.default.write((0L, 0L)), createFolders = true)
+    os.write.over(resultPath, upickle.write((0L, 0L)), createFolders = true)
     val label =
       if (groupFolderData.size == 1) paddedProcessIndex
       else s"$paddedGroupIndex-$paddedProcessIndex"
@@ -609,7 +609,7 @@ private[mill] object TestModuleUtil {
         // since that might happen transiently during a write
         try {
           Some(subprocessFutures.map(_._1 / "result.log").map(p =>
-            upickle.default.read[(Long, Long)](os.read.stream(p))
+            upickle.read[(Long, Long)](os.read.stream(p))
           ))
         } catch {
           case _: Exception => None

--- a/libs/javalib/src/mill/javalib/UnresolvedPath.scala
+++ b/libs/javalib/src/mill/javalib/UnresolvedPath.scala
@@ -2,7 +2,7 @@ package mill.javalib
 
 import mill.api.daemon.internal.UnresolvedPathApi
 import mill.api.{ExecutionPaths, Segment, Segments}
-import upickle.default.{ReadWriter, macroRW}
+import upickle.{ReadWriter, macroRW}
 
 /**
  * An unresolved path is relative to some unspecified destination

--- a/libs/javalib/src/mill/javalib/checkstyle/CheckstyleXsltReport.scala
+++ b/libs/javalib/src/mill/javalib/checkstyle/CheckstyleXsltReport.scala
@@ -11,7 +11,7 @@ import mill.api.PathRef
 case class CheckstyleXsltReport(xslt: PathRef, output: PathRef)
 object CheckstyleXsltReport {
 
-  import upickle.default._
+  import upickle._
 
   implicit val RW: ReadWriter[CheckstyleXsltReport] = macroRW[CheckstyleXsltReport]
 }

--- a/libs/javalib/src/mill/javalib/dependency/updates/DependencyUpdates.scala
+++ b/libs/javalib/src/mill/javalib/dependency/updates/DependencyUpdates.scala
@@ -13,6 +13,6 @@ final case class DependencyUpdates(
 object DependencyUpdates {
   import mill.javalib.JsonFormatters.depFormat
 
-  implicit val rw: upickle.default.ReadWriter[DependencyUpdates] =
-    upickle.default.macroRW
+  implicit val rw: upickle.ReadWriter[DependencyUpdates] =
+    upickle.macroRW
 }

--- a/libs/javalib/src/mill/javalib/dependency/updates/ModuleDependenciesUpdates.scala
+++ b/libs/javalib/src/mill/javalib/dependency/updates/ModuleDependenciesUpdates.scala
@@ -6,6 +6,6 @@ final case class ModuleDependenciesUpdates(
 )
 
 object ModuleDependenciesUpdates {
-  implicit val rw: upickle.default.ReadWriter[ModuleDependenciesUpdates] =
-    upickle.default.macroRW
+  implicit val rw: upickle.ReadWriter[ModuleDependenciesUpdates] =
+    upickle.macroRW
 }

--- a/libs/javalib/src/mill/javalib/dependency/versions/Version.scala
+++ b/libs/javalib/src/mill/javalib/dependency/versions/Version.scala
@@ -54,8 +54,8 @@ case class ValidVersion(
   override def toString: String = text
 }
 object ValidVersion {
-  implicit val rw: upickle.default.ReadWriter[ValidVersion] =
-    upickle.default.macroRW
+  implicit val rw: upickle.ReadWriter[ValidVersion] =
+    upickle.macroRW
 }
 
 case class InvalidVersion(text: String) extends Version {
@@ -66,8 +66,8 @@ case class InvalidVersion(text: String) extends Version {
   def patch: Long = -1
 }
 object InvalidVersion {
-  implicit val rw: upickle.default.ReadWriter[InvalidVersion] =
-    upickle.default.macroRW
+  implicit val rw: upickle.ReadWriter[InvalidVersion] =
+    upickle.macroRW
 }
 
 private[dependency] object ReleaseVersion {
@@ -128,8 +128,8 @@ object Version {
   }
 
   implicit def versionOrdering: Ordering[Version] = VersionOrdering
-  implicit val rw: upickle.default.ReadWriter[Version] =
-    upickle.default.macroRW
+  implicit val rw: upickle.ReadWriter[Version] =
+    upickle.macroRW
 }
 
 private[dependency] object VersionOrdering extends Ordering[Version] {

--- a/libs/javalib/src/mill/javalib/internal/RpcCompileProblemReporterMessage.scala
+++ b/libs/javalib/src/mill/javalib/internal/RpcCompileProblemReporterMessage.scala
@@ -2,7 +2,7 @@ package mill.javalib.internal
 
 import mill.api.JsonFormatters.*
 
-sealed trait RpcCompileProblemReporterMessage derives upickle.default.ReadWriter
+sealed trait RpcCompileProblemReporterMessage derives upickle.ReadWriter
 object RpcCompileProblemReporterMessage {
   case object Start extends RpcCompileProblemReporterMessage
   case class LogError(problem: RpcProblem) extends RpcCompileProblemReporterMessage

--- a/libs/javalib/src/mill/javalib/internal/RpcDiagnosticCode.scala
+++ b/libs/javalib/src/mill/javalib/internal/RpcDiagnosticCode.scala
@@ -6,7 +6,7 @@ import mill.api.daemon.internal.DiagnosticCode
 case class RpcDiagnosticCode(
     code: String,
     explanation: Option[String]
-) extends DiagnosticCode derives upickle.default.ReadWriter
+) extends DiagnosticCode derives upickle.ReadWriter
 object RpcDiagnosticCode {
   def apply(d: DiagnosticCode): RpcDiagnosticCode = apply(
     code = d.code,

--- a/libs/javalib/src/mill/javalib/internal/RpcProblem.scala
+++ b/libs/javalib/src/mill/javalib/internal/RpcProblem.scala
@@ -10,7 +10,7 @@ case class RpcProblem(
     message: String,
     position: RpcProblemPosition,
     diagnosticCode: Option[RpcDiagnosticCode]
-) extends Problem derives upickle.default.ReadWriter
+) extends Problem derives upickle.ReadWriter
 object RpcProblem {
   def apply(p: Problem): RpcProblem = apply(
     category = p.category,

--- a/libs/javalib/src/mill/javalib/internal/RpcProblemPosition.scala
+++ b/libs/javalib/src/mill/javalib/internal/RpcProblemPosition.scala
@@ -20,7 +20,7 @@ case class RpcProblemPosition(
     startColumn: Option[Int],
     endLine: Option[Int],
     endColumn: Option[Int]
-) extends ProblemPosition derives upickle.default.ReadWriter
+) extends ProblemPosition derives upickle.ReadWriter
 object RpcProblemPosition {
   def apply(p: ProblemPosition): RpcProblemPosition = apply(
     line = p.line,

--- a/libs/javalib/src/mill/javalib/internal/ZincCompilerBridgeProvider.scala
+++ b/libs/javalib/src/mill/javalib/internal/ZincCompilerBridgeProvider.scala
@@ -2,7 +2,7 @@ package mill.javalib.internal
 
 import mill.api.daemon.internal.internal
 import mill.javalib.api.JvmWorkerUtil
-import upickle.default.ReadWriter
+import upickle.ReadWriter
 
 import java.io.File
 import scala.util.Properties.isWin

--- a/libs/javalib/src/mill/javalib/publish/JsonFormatters.scala
+++ b/libs/javalib/src/mill/javalib/publish/JsonFormatters.scala
@@ -1,12 +1,12 @@
 package mill.javalib.publish
 
-import upickle.default.{ReadWriter => RW}
+import upickle.{ReadWriter => RW}
 
 trait JsonFormatters {
-  implicit lazy val artifactFormat: RW[Artifact] = upickle.default.macroRW
-  implicit lazy val developerFormat: RW[Developer] = upickle.default.macroRW
-  implicit lazy val licenseFormat: RW[License] = upickle.default.macroRW
-  implicit lazy val versionControlFormat: RW[VersionControl] = upickle.default.macroRW
-  implicit lazy val pomSettingsFormat: RW[PomSettings] = upickle.default.macroRW
+  implicit lazy val artifactFormat: RW[Artifact] = upickle.macroRW
+  implicit lazy val developerFormat: RW[Developer] = upickle.macroRW
+  implicit lazy val licenseFormat: RW[License] = upickle.macroRW
+  implicit lazy val versionControlFormat: RW[VersionControl] = upickle.macroRW
+  implicit lazy val pomSettingsFormat: RW[PomSettings] = upickle.macroRW
 }
 object JsonFormatters extends JsonFormatters

--- a/libs/javalib/src/mill/javalib/publish/PublishInfo.scala
+++ b/libs/javalib/src/mill/javalib/publish/PublishInfo.scala
@@ -31,7 +31,7 @@ case class PublishInfo(
 }
 
 object PublishInfo {
-  implicit def jsonify: upickle.default.ReadWriter[PublishInfo] = upickle.default.macroRW
+  implicit def jsonify: upickle.ReadWriter[PublishInfo] = upickle.macroRW
 
   /**
    * See https://ant.apache.org/ivy/history/latest-milestone/ivyfile/artifact.html for Ivy XML descriptions.

--- a/libs/javalib/src/mill/javalib/publish/VersionScheme.scala
+++ b/libs/javalib/src/mill/javalib/publish/VersionScheme.scala
@@ -1,5 +1,5 @@
 package mill.javalib.publish
-import upickle.default.{macroRW, ReadWriter}
+import upickle.{macroRW, ReadWriter}
 sealed abstract class VersionScheme(val value: String) {
   def toProperty: (String, String) = "info.versionScheme" -> value
 }

--- a/libs/javalib/src/mill/javalib/publish/model.scala
+++ b/libs/javalib/src/mill/javalib/publish/model.scala
@@ -1,7 +1,7 @@
 package mill.javalib.publish
 
 import mill.javalib.Dep
-import upickle.default.ReadWriter as RW
+import upickle.ReadWriter as RW
 import JsonFormatters._
 case class Artifact(group: String, id: String, version: String) derives RW {
   require(

--- a/libs/javalib/src/mill/javalib/spotless/Format.scala
+++ b/libs/javalib/src/mill/javalib/spotless/Format.scala
@@ -2,7 +2,7 @@ package mill.javalib.spotless
 
 import mill.api.{BuildCtx, PathRef}
 import upickle.core.Visitor
-import upickle.default.*
+import upickle.*
 
 import scala.util.DynamicVariable
 
@@ -293,7 +293,7 @@ object Format {
         def write0[V](out: Visitor[?, V], v: RelPathRef) =
           summon[ReadWriter[PathRef]].write0(out, v.ref)
         def mapNonNullsFunction(t: String) =
-          if t.startsWith("ref:") then RelPathRef(upickle.default.read[PathRef](t))
+          if t.startsWith("ref:") then RelPathRef(upickle.read[PathRef](t))
           else t
       }
   }

--- a/libs/javalib/src/mill/javalib/spotless/SpotlessModule.scala
+++ b/libs/javalib/src/mill/javalib/spotless/SpotlessModule.scala
@@ -65,7 +65,7 @@ trait SpotlessModule extends CoursierModule, OfflineSupportModule {
       import Format.*
       RelPathRef.withDynamicRoot(moduleDir) {
         val file = moduleDir / ".spotless-formats.json"
-        if os.exists(file) then upickle.default.read[Seq[Format]](file.toNIO)
+        if os.exists(file) then upickle.read[Seq[Format]](file.toNIO)
         else Seq(defaultJava, defaultKotlin, defaultScala)
       }
     }

--- a/libs/javalib/test/src/mill/javalib/ResolveDepsTests.scala
+++ b/libs/javalib/test/src/mill/javalib/ResolveDepsTests.scala
@@ -30,7 +30,7 @@ object ResolveDepsTests extends TestSuite {
       } else {
         assert(unparsed.isEmpty)
       }
-      assert(upickle.default.read[Dep](upickle.default.write(dep)) == dep)
+      assert(upickle.read[Dep](upickle.write(dep)) == dep)
     }
   }
 

--- a/libs/javalib/testrunner/src/mill/javalib/testrunner/Model.scala
+++ b/libs/javalib/testrunner/src/mill/javalib/testrunner/Model.scala
@@ -22,12 +22,12 @@ import mill.api.daemon.internal.{TestReporter, internal}
 )
 
 @internal object TestArgs {
-  implicit lazy val logLevelRW: upickle.default.ReadWriter[TestReporter.LogLevel] =
-    implicitly[upickle.default.ReadWriter[String]].bimap(
+  implicit lazy val logLevelRW: upickle.ReadWriter[TestReporter.LogLevel] =
+    implicitly[upickle.ReadWriter[String]].bimap(
       _.asString,
       TestReporter.LogLevel.fromString(_)
     )
-  implicit def resultRW: upickle.default.ReadWriter[TestArgs] = upickle.default.macroRW
+  implicit def resultRW: upickle.ReadWriter[TestArgs] = upickle.macroRW
 }
 
 @internal case class TestResult(
@@ -41,5 +41,5 @@ import mill.api.daemon.internal.{TestReporter, internal}
 )
 
 @internal object TestResult {
-  implicit def resultRW: upickle.default.ReadWriter[TestResult] = upickle.default.macroRW
+  implicit def resultRW: upickle.ReadWriter[TestResult] = upickle.macroRW
 }

--- a/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunnerMain0.scala
+++ b/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunnerMain0.scala
@@ -5,7 +5,7 @@ import mill.api.daemon.internal.{TestReporter, internal}
 @internal object TestRunnerMain0 {
   def main0(args: Array[String], classLoader: ClassLoader): Unit = {
     try {
-      val testArgs = upickle.default.read[TestArgs](os.read(os.Path(args(1))))
+      val testArgs = upickle.read[TestArgs](os.read(os.Path(args(1))))
       testArgs.sysProps.foreach { case (k, v) => System.setProperty(k, v) }
 
       val result = testArgs.globSelectors match {
@@ -38,7 +38,7 @@ import mill.api.daemon.internal.{TestReporter, internal}
       // dirtied the thread-interrupted flag and forgot to clean up. Otherwise,
       // that flag causes writing the results to disk to fail
       Thread.interrupted()
-      os.write(testArgs.outputPath, upickle.default.stream(result))
+      os.write(testArgs.outputPath, upickle.stream(result))
     } catch {
       case e: Throwable =>
         println(e)

--- a/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunnerUtils.scala
+++ b/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunnerUtils.scala
@@ -249,7 +249,7 @@ import scala.math.Ordering.Implicits.*
 
     val resultLog: () => Unit = resultPathOpt match {
       case Some(resultPath) =>
-        () => os.write.over(resultPath, upickle.default.write((successCounter, failureCounter)))
+        () => os.write.over(resultPath, upickle.write((successCounter, failureCounter)))
       case None => () =>
           systemOut.println(s"Test result: ${successCounter + failureCounter} completed${
               if failureCounter > 0 then s", ${failureCounter} failures." else "."
@@ -318,7 +318,7 @@ import scala.math.Ordering.Implicits.*
       val tasks = runner.tasks(taskDefs.toArray)
       val taskResult = executeTasks(tasks, testReporter, events, systemOut)
       if taskResult then successCounter += 1 else failureCounter += 1
-      os.write.over(resultPath, upickle.default.write((successCounter, failureCounter)))
+      os.write.over(resultPath, upickle.write((successCounter, failureCounter)))
     }
 
     def logClaim[T](testClass: String)(t: => T): T = {

--- a/libs/javalib/worker/src/mill/javalib/zinc/ZincWorker.scala
+++ b/libs/javalib/worker/src/mill/javalib/zinc/ZincWorker.scala
@@ -609,7 +609,7 @@ object ZincWorker {
       logDebugEnabled: Boolean,
       logPromptColored: Boolean,
       zincLogDebug: Boolean
-  ) derives upickle.default.ReadWriter
+  ) derives upickle.ReadWriter
 
   private case class ScalaCompilerCacheKey(
       scalaVersion: String,

--- a/libs/javalib/worker/src/mill/javalib/zinc/ZincWorkerRpcServer.scala
+++ b/libs/javalib/worker/src/mill/javalib/zinc/ZincWorkerRpcServer.scala
@@ -11,7 +11,7 @@ import mill.server.Server
 import mill.util.Timed
 import org.apache.logging.log4j.core.util.NullOutputStream
 import sbt.internal.util.ConsoleOut
-import upickle.default.ReadWriter
+import upickle.ReadWriter
 
 import java.io.PrintStream
 

--- a/libs/javascriptlib/src/mill/javascriptlib/TypeScriptModule.scala
+++ b/libs/javascriptlib/src/mill/javascriptlib/TypeScriptModule.scala
@@ -903,7 +903,7 @@ object TypeScriptModule {
   }
 
   object PackageJson {
-    implicit val rw: upickle.default.ReadWriter[PackageJson] = upickle.default.macroRW
+    implicit val rw: upickle.ReadWriter[PackageJson] = upickle.macroRW
   }
 
   private def removeEmptyValues(json: ujson.Value): ujson.Value = {

--- a/libs/kotlinlib/src/mill/kotlinlib/js/BinaryKind.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/js/BinaryKind.scala
@@ -1,6 +1,6 @@
 package mill.kotlinlib.js
 
-import upickle.default.ReadWriter
+import upickle.ReadWriter
 
 enum BinaryKind derives ReadWriter {
   case Library

--- a/libs/kotlinlib/src/mill/kotlinlib/js/ModuleKind.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/js/ModuleKind.scala
@@ -1,6 +1,6 @@
 package mill.kotlinlib.js
 
-import upickle.default.ReadWriter
+import upickle.ReadWriter
 
 enum ModuleKind(val extension: String) derives ReadWriter {
   case NoModule extends ModuleKind("js")

--- a/libs/kotlinlib/src/mill/kotlinlib/js/OutputMode.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/js/OutputMode.scala
@@ -1,6 +1,6 @@
 package mill.kotlinlib.js
 
-import upickle.default.ReadWriter
+import upickle.ReadWriter
 
 private[kotlinlib] enum OutputMode derives ReadWriter {
   case Js

--- a/libs/kotlinlib/src/mill/kotlinlib/js/RunTarget.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/js/RunTarget.scala
@@ -1,6 +1,6 @@
 package mill.kotlinlib.js
 
-import upickle.default.ReadWriter
+import upickle.ReadWriter
 
 enum RunTarget derives ReadWriter {
   // TODO rely on the node version installed in the env or fetch a specific one?

--- a/libs/kotlinlib/src/mill/kotlinlib/js/SourceMapEmbedSourcesKind.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/js/SourceMapEmbedSourcesKind.scala
@@ -1,6 +1,6 @@
 package mill.kotlinlib.js
 
-import upickle.default.ReadWriter
+import upickle.ReadWriter
 
 enum SourceMapEmbedSourcesKind derives ReadWriter {
   case Always

--- a/libs/kotlinlib/src/mill/kotlinlib/js/SourceMapNamesPolicy.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/js/SourceMapNamesPolicy.scala
@@ -1,6 +1,6 @@
 package mill.kotlinlib.js
 
-import upickle.default.ReadWriter
+import upickle.ReadWriter
 
 enum SourceMapNamesPolicy derives ReadWriter {
   case SimpleNames

--- a/libs/kotlinlib/src/mill/kotlinlib/ksp/GeneratedKspSources.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/ksp/GeneratedKspSources.scala
@@ -1,7 +1,7 @@
 package mill.kotlinlib.ksp
 
 import mill.api.PathRef
-import upickle.default.ReadWriter
+import upickle.ReadWriter
 
 @mill.api.experimental
 case class GeneratedKspSources(

--- a/libs/pythonlib/src/mill/pythonlib/PipModule.scala
+++ b/libs/pythonlib/src/mill/pythonlib/PipModule.scala
@@ -143,7 +143,7 @@ object PipModule {
       sig: Int
   )
   object InstallArgs {
-    implicit val rw: upickle.default.ReadWriter[InstallArgs] = upickle.default.macroRW
+    implicit val rw: upickle.ReadWriter[InstallArgs] = upickle.macroRW
     def apply(
         args: Seq[String],
         paths: Seq[PathRef]

--- a/libs/pythonlib/src/mill/pythonlib/PublishModule.scala
+++ b/libs/pythonlib/src/mill/pythonlib/PublishModule.scala
@@ -241,8 +241,8 @@ trait PublishModule extends PythonModule {
 }
 
 object PublishModule {
-  private implicit lazy val licenseFormat: upickle.default.ReadWriter[License] =
-    upickle.default.macroRW
+  private implicit lazy val licenseFormat: upickle.ReadWriter[License] =
+    upickle.macroRW
 
   /**
    * Static metadata about a project.
@@ -261,7 +261,7 @@ object PublishModule {
       urls: Map[String, String] = Map()
   )
   object PublishMeta {
-    implicit val rw: upickle.default.ReadWriter[PublishMeta] = upickle.default.macroRW
+    implicit val rw: upickle.ReadWriter[PublishMeta] = upickle.macroRW
   }
 
   case class Developer(
@@ -269,7 +269,7 @@ object PublishModule {
       email: String
   )
   object Developer {
-    implicit val rw: upickle.default.ReadWriter[Developer] = upickle.default.macroRW
+    implicit val rw: upickle.ReadWriter[Developer] = upickle.macroRW
   }
 
 }

--- a/libs/rpc/src/mill/rpc/MillRpcClient.scala
+++ b/libs/rpc/src/mill/rpc/MillRpcClient.scala
@@ -2,7 +2,7 @@ package mill.rpc
 
 import mill.api.daemon.Logger
 import pprint.TPrint
-import upickle.default.{Reader, Writer}
+import upickle.{Reader, Writer}
 
 import scala.util.Try
 
@@ -60,14 +60,14 @@ object MillRpcClient {
               s"RPC wire has broken (${wireTransport.name}). The server probably crashed."
             )
           case Some(MillRpcServerToClient.Ask(id, dataJson)) =>
-            val data = upickle.default.read[ServerToClient](dataJson)
+            val data = upickle.read[ServerToClient](dataJson)
             handleServerMessage(id, data)
           case Some(MillRpcServerToClient.Response(`requestId`, either)) =>
             either match {
               case Left(err) =>
                 throw err
               case Right(responseJson) =>
-                val response = upickle.default.read[A](responseJson)
+                val response = upickle.read[A](responseJson)
                 responseReceived = Some(response)
             }
           case Some(MillRpcServerToClient.Response(reqId, either)) =>

--- a/libs/rpc/src/mill/rpc/MillRpcClientToServer.scala
+++ b/libs/rpc/src/mill/rpc/MillRpcClientToServer.scala
@@ -1,6 +1,6 @@
 package mill.rpc
 
-import upickle.default.{Reader, Writer}
+import upickle.{Reader, Writer}
 
 /** Protocol messages that are sent from client to the server. */
 enum MillRpcClientToServer[+Data] derives Reader, Writer {

--- a/libs/rpc/src/mill/rpc/MillRpcMessage.scala
+++ b/libs/rpc/src/mill/rpc/MillRpcMessage.scala
@@ -1,7 +1,7 @@
 package mill.rpc
 
 import pprint.TPrint
-import upickle.default.ReadWriter
+import upickle.ReadWriter
 
 trait MillRpcMessage {
   type Response

--- a/libs/rpc/src/mill/rpc/MillRpcRequestId.scala
+++ b/libs/rpc/src/mill/rpc/MillRpcRequestId.scala
@@ -47,8 +47,8 @@ object MillRpcRequestId {
     else Right(MillRpcRequestId(parts.flatten))
   }
 
-  given rw: upickle.default.ReadWriter[MillRpcRequestId] =
-    upickle.default.readwriter[String].bimap(
+  given rw: upickle.ReadWriter[MillRpcRequestId] =
+    upickle.readwriter[String].bimap(
       _.toString,
       fromString(_).fold(err => throw IllegalArgumentException(err), identity)
     )

--- a/libs/rpc/src/mill/rpc/MillRpcServer.scala
+++ b/libs/rpc/src/mill/rpc/MillRpcServer.scala
@@ -2,7 +2,7 @@ package mill.rpc
 
 import mill.api.daemon.Logger
 import pprint.TPrint
-import upickle.default.{Reader, Writer}
+import upickle.{Reader, Writer}
 
 import scala.util.control.NonFatal
 

--- a/libs/rpc/src/mill/rpc/MillRpcServerToClient.scala
+++ b/libs/rpc/src/mill/rpc/MillRpcServerToClient.scala
@@ -1,6 +1,6 @@
 package mill.rpc
 
-import upickle.default.{Reader, Writer}
+import upickle.{Reader, Writer}
 
 /** Protocol messages that are sent from server to the client. */
 enum MillRpcServerToClient[+Data] derives Reader, Writer {

--- a/libs/rpc/src/mill/rpc/MillRpcWireTransport.scala
+++ b/libs/rpc/src/mill/rpc/MillRpcWireTransport.scala
@@ -1,7 +1,7 @@
 package mill.rpc
 
 import pprint.{TPrint, TPrintColors}
-import upickle.default.{Reader, Writer}
+import upickle.{Reader, Writer}
 
 import java.io.{BufferedReader, PrintStream}
 import java.util.concurrent.BlockingQueue
@@ -39,7 +39,7 @@ trait MillRpcWireTransport extends AutoCloseable {
 
       case Some(line) =>
         log(s"Received, will try to parse as $typeName: $line")
-        val parsed = upickle.default.read(line)
+        val parsed = upickle.read(line)
         log(s"Parsed: ${pprint.apply(parsed)}")
         Some(parsed)
     }
@@ -51,7 +51,7 @@ trait MillRpcWireTransport extends AutoCloseable {
   /** Helper that writes a message to the wire, logging along the way. */
   def writeSerialized[A: Writer](message: A, log: String => Unit): Unit = {
     log(s"Serializing message to be sent: ${pprint.apply(message)}")
-    val serialized = upickle.default.write(message)
+    val serialized = upickle.write(message)
     log(s"Sending: $serialized")
     write(serialized)
     log(s"Sent: $serialized")

--- a/libs/rpc/src/mill/rpc/RpcConsole.scala
+++ b/libs/rpc/src/mill/rpc/RpcConsole.scala
@@ -18,7 +18,7 @@ trait RpcConsole { self =>
   }
 }
 object RpcConsole {
-  enum Message derives upickle.default.ReadWriter {
+  enum Message derives upickle.ReadWriter {
     case Print(s: String)
     case Flush
   }

--- a/libs/rpc/src/mill/rpc/RpcLogger.scala
+++ b/libs/rpc/src/mill/rpc/RpcLogger.scala
@@ -4,7 +4,7 @@ import mill.api.daemon.Logger
 
 /** Logs messages by sending them from the server to the client via an RPC. */
 object RpcLogger {
-  enum Message derives upickle.default.ReadWriter {
+  enum Message derives upickle.ReadWriter {
     case Info(s: String)
     case Debug(s: String)
     case Warn(s: String)

--- a/libs/rpc/src/mill/rpc/RpcThrowable.scala
+++ b/libs/rpc/src/mill/rpc/RpcThrowable.scala
@@ -9,7 +9,7 @@ case class RpcThrowable(
     stacktrace: Vector[RpcStackTraceElement],
     cause: Option[RpcThrowable]
 ) extends RuntimeException(message.orNull, cause.orNull) with NoStackTrace
-    derives upickle.default.ReadWriter {
+    derives upickle.ReadWriter {
   setStackTrace(stacktrace.iterator.map(_.toStackTraceElement).toArray)
 
   override def toString: String = {
@@ -37,7 +37,7 @@ case class RpcStackTraceElement(
     methodName: String,
     fileName: String,
     lineNumber: Int
-) derives upickle.default.ReadWriter {
+) derives upickle.ReadWriter {
   def toStackTraceElement: StackTraceElement =
     StackTraceElement(
       classLoaderName,

--- a/libs/rpc/test/src/mill/rpc/MillRpcTests.scala
+++ b/libs/rpc/test/src/mill/rpc/MillRpcTests.scala
@@ -1,7 +1,7 @@
 package mill.rpc
 
 import mill.api.daemon.Logger
-import upickle.default.ReadWriter
+import upickle.ReadWriter
 import utest.*
 
 import java.util.concurrent.ArrayBlockingQueue

--- a/libs/scalajslib/src/mill/scalajslib/api/ESFeatures.scala
+++ b/libs/scalajslib/src/mill/scalajslib/api/ESFeatures.scala
@@ -1,6 +1,6 @@
 package mill.scalajslib.api
 
-import upickle.default.ReadWriter
+import upickle.ReadWriter
 
 case class ESFeatures private (
     allowBigIntsForLongs: Boolean,

--- a/libs/scalajslib/src/mill/scalajslib/api/ESModuleImportMapping.scala
+++ b/libs/scalajslib/src/mill/scalajslib/api/ESModuleImportMapping.scala
@@ -1,6 +1,6 @@
 package mill.scalajslib.api
 
-import upickle.default.ReadWriter
+import upickle.ReadWriter
 
 enum ESModuleImportMapping derives ReadWriter {
   case Prefix(prefix: String, replacement: String)

--- a/libs/scalajslib/src/mill/scalajslib/api/ESVersion.scala
+++ b/libs/scalajslib/src/mill/scalajslib/api/ESVersion.scala
@@ -1,6 +1,6 @@
 package mill.scalajslib.api
 
-import upickle.default.ReadWriter
+import upickle.ReadWriter
 
 enum ESVersion derives ReadWriter {
   case ES2015

--- a/libs/scalajslib/src/mill/scalajslib/api/JsEnvConfig.scala
+++ b/libs/scalajslib/src/mill/scalajslib/api/JsEnvConfig.scala
@@ -1,6 +1,6 @@
 package mill.scalajslib.api
 
-import upickle.default.{ReadWriter => RW, macroRW}
+import upickle.{ReadWriter => RW, macroRW}
 import mill.api.internal.Mirrors.autoMirror
 import mill.api.internal.Mirrors
 

--- a/libs/scalajslib/src/mill/scalajslib/api/ModuleKind.scala
+++ b/libs/scalajslib/src/mill/scalajslib/api/ModuleKind.scala
@@ -1,6 +1,6 @@
 package mill.scalajslib.api
 
-import upickle.default.ReadWriter
+import upickle.ReadWriter
 
 enum ModuleKind derives ReadWriter {
   case NoModule

--- a/libs/scalajslib/src/mill/scalajslib/api/ModuleSplitStyle.scala
+++ b/libs/scalajslib/src/mill/scalajslib/api/ModuleSplitStyle.scala
@@ -1,6 +1,6 @@
 package mill.scalajslib.api
 
-import upickle.default.ReadWriter
+import upickle.ReadWriter
 
 enum ModuleSplitStyle derives ReadWriter {
   case FewestModules

--- a/libs/scalajslib/src/mill/scalajslib/api/OutputPatterns.scala
+++ b/libs/scalajslib/src/mill/scalajslib/api/OutputPatterns.scala
@@ -1,7 +1,7 @@
 package mill.scalajslib.api
 
 import mill.api.internal.Mirrors
-import upickle.default.{ReadWriter => RW, macroRW}
+import upickle.{ReadWriter => RW, macroRW}
 import mill.api.internal.Mirrors.autoMirror
 
 class OutputPatterns private (

--- a/libs/scalajslib/src/mill/scalajslib/api/Report.scala
+++ b/libs/scalajslib/src/mill/scalajslib/api/Report.scala
@@ -1,7 +1,7 @@
 package mill.scalajslib.api
 
 import mill.api.internal.Mirrors
-import upickle.default.{ReadWriter => RW, macroRW}
+import upickle.{ReadWriter => RW, macroRW}
 import Mirrors.autoMirror
 
 final class Report private (val publicModules: Iterable[Report.Module], val dest: mill.PathRef) {

--- a/libs/scalalib/test/src/mill/scalalib/spotless/SpotlessTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/spotless/SpotlessTests.scala
@@ -252,5 +252,5 @@ private def updateFormats(cwd: os.Path)(f: Seq[Format] => Seq[Format]) =
   val file = cwd / ".spotless-formats.json"
   os.write.over(
     file,
-    upickle.default.write(f(upickle.default.read[Seq[Format]](file.toNIO)))
+    upickle.write(f(upickle.read[Seq[Format]](file.toNIO)))
   )

--- a/libs/scalanativelib/src/mill/scalanativelib/api/ScalaNativeApi.scala
+++ b/libs/scalanativelib/src/mill/scalanativelib/api/ScalaNativeApi.scala
@@ -1,6 +1,6 @@
 package mill.scalanativelib.api
 
-import upickle.default._
+import upickle._
 
 sealed abstract class LTO(val value: String)
 object LTO {

--- a/libs/util/src/mill/util/JarManifest.scala
+++ b/libs/util/src/mill/util/JarManifest.scala
@@ -4,7 +4,7 @@ import mill.api.BuildInfo
 import mill.api.internal.Mirrors
 import mill.api.internal.Mirrors.autoMirror
 import mill.util.JarManifest
-import upickle.default.ReadWriter
+import upickle.ReadWriter
 
 import java.util.jar.{Attributes, Manifest}
 
@@ -67,6 +67,6 @@ object JarManifest {
 
   private given Root_JarManifest: Mirrors.Root[JarManifest] = Mirrors.autoRoot[JarManifest]
 
-  implicit val jarManifestRW: ReadWriter[JarManifest] = upickle.default.macroRW
+  implicit val jarManifestRW: ReadWriter[JarManifest] = upickle.macroRW
 
 }

--- a/libs/util/src/mill/util/MainModule.scala
+++ b/libs/util/src/mill/util/MainModule.scala
@@ -354,7 +354,7 @@ object MainModule {
             t match {
               case t: mill.api.Task.Named[_] =>
                 val jsonFile = ExecutionPaths.resolve(evaluator.outPath, t).meta
-                val metadata = upickle.default.read[Cached](ujson.read(jsonFile.toIO))
+                val metadata = upickle.read[Cached](ujson.read(jsonFile.toIO))
                 Some((t.toString, metadata.value))
               case _ => None
             }

--- a/libs/util/src/mill/util/VcsVersion.scala
+++ b/libs/util/src/mill/util/VcsVersion.scala
@@ -21,7 +21,7 @@ object VcsVersion extends ExternalModule with VcsVersion {
   case class Vcs(val name: String)
   def git = Vcs("git")
 
-  implicit val jsonify: upickle.default.ReadWriter[Vcs] = upickle.default.macroRW
+  implicit val jsonify: upickle.ReadWriter[Vcs] = upickle.macroRW
 
   case class State(
       currentRevision: String,
@@ -84,7 +84,7 @@ object VcsVersion extends ExternalModule with VcsVersion {
   }
 
   object State {
-    implicit val jsonify: upickle.default.ReadWriter[State] = upickle.default.macroRW
+    implicit val jsonify: upickle.ReadWriter[State] = upickle.macroRW
   }
 
   lazy val millDiscover = Discover[this.type]

--- a/libs/util/src/mill/util/VisualizeModule.scala
+++ b/libs/util/src/mill/util/VisualizeModule.scala
@@ -48,7 +48,7 @@ object VisualizeModule extends ExternalModule {
       in.put((tasks, transitiveTasks, sortedGroups, plan, ctx.dest))
       val res = out.take()
       res.map { v =>
-        println(upickle.default.write(v.map(_.path.toString()), indent = 2))
+        println(upickle.write(v.map(_.path.toString()), indent = 2))
         v
       }
     }

--- a/mill-build/src/millbuild/Deps.scala
+++ b/mill-build/src/millbuild/Deps.scala
@@ -175,7 +175,7 @@ object Deps {
   val sourcecode = mvn"com.lihaoyi::sourcecode:0.4.3-M5"
   val springBootTools = mvn"org.springframework.boot:spring-boot-loader-tools:3.5.5"
   val upickle = mvn"com.lihaoyi::upickle:4.3.0"
-  val upickleNamedTuples = mvn"com.lihaoyi::upickle-implicits-named-tuples:4.2.1"
+  val upickleNamedTuples = mvn"com.lihaoyi::upickle-implicits-named-tuples:4.3.0"
   // Using "native-terminal-no-ffm" rather than just "native-terminal", as the GraalVM releases currently
   // lacks support for FFM on Mac ARM. That should be fixed soon, see oracle/graal#8113.
   val nativeTerminal = mvn"io.github.alexarchambault.native-terminal:native-terminal-no-ffm:0.0.9.1"

--- a/mill-build/src/millbuild/Deps.scala
+++ b/mill-build/src/millbuild/Deps.scala
@@ -174,7 +174,7 @@ object Deps {
   val semanticDbShared = mvn"org.scalameta:semanticdb-shared_2.13:${semanticDBscala.version}"
   val sourcecode = mvn"com.lihaoyi::sourcecode:0.4.3-M5"
   val springBootTools = mvn"org.springframework.boot:spring-boot-loader-tools:3.5.5"
-  val upickle = mvn"com.lihaoyi::upickle:4.2.1"
+  val upickle = mvn"com.lihaoyi::upickle:4.3.0"
   val upickleNamedTuples = mvn"com.lihaoyi::upickle-implicits-named-tuples:4.2.1"
   // Using "native-terminal-no-ffm" rather than just "native-terminal", as the GraalVM releases currently
   // lacks support for FFM on Mac ARM. That should be fixed soon, see oracle/graal#8113.

--- a/runner/bsp/src/mill/bsp/BSP.scala
+++ b/runner/bsp/src/mill/bsp/BSP.scala
@@ -37,7 +37,7 @@ private[mill] object BSP {
     val millPath = sys.env.get("MILL_EXECUTABLE_PATH")
       .getOrElse(throw new IllegalStateException("Env 'MILL_EXECUTABLE_PATH' not set"))
 
-    upickle.default.write(
+    upickle.write(
       BspConfigJson(
         name = "mill-bsp",
         argv = Seq(

--- a/runner/bsp/src/mill/bsp/BspConfigJson.scala
+++ b/runner/bsp/src/mill/bsp/BspConfigJson.scala
@@ -1,6 +1,6 @@
 package mill.bsp
 
-import upickle.default._
+import upickle._
 
 private case class BspConfigJson(
     name: String,

--- a/runner/codesig/src/mill/codesig/ExternalSummary.scala
+++ b/runner/codesig/src/mill/codesig/ExternalSummary.scala
@@ -20,8 +20,8 @@ case class ExternalSummary(
  */
 object ExternalSummary {
 
-  implicit def rw(implicit st: SymbolTable): upickle.default.ReadWriter[ExternalSummary] =
-    upickle.default.macroRW
+  implicit def rw(implicit st: SymbolTable): upickle.ReadWriter[ExternalSummary] =
+    upickle.macroRW
 
   def apply(
       localSummary: LocalSummary,

--- a/runner/codesig/src/mill/codesig/JvmModel.scala
+++ b/runner/codesig/src/mill/codesig/JvmModel.scala
@@ -1,6 +1,6 @@
 package mill.codesig
 
-import upickle.default.{ReadWriter, readwriter, stringKeyRW}
+import upickle.{ReadWriter, readwriter, stringKeyRW}
 
 import scala.annotation.switch
 import scala.collection.immutable.ArraySeq

--- a/runner/codesig/src/mill/codesig/LocalSummary.scala
+++ b/runner/codesig/src/mill/codesig/LocalSummary.scala
@@ -4,7 +4,7 @@ import mill.codesig.JvmModel.*
 import mill.codesig.JvmModel.JType.Cls as JCls
 import mill.codesig.LocalSummary.ClassInfo
 import org.objectweb.asm.*
-import upickle.default.{ReadWriter, macroRW}
+import upickle.{ReadWriter, macroRW}
 
 import scala.collection.mutable
 

--- a/runner/codesig/src/mill/codesig/Logger.scala
+++ b/runner/codesig/src/mill/codesig/Logger.scala
@@ -5,22 +5,22 @@ class Logger(mandatoryLogFolder: os.Path, logFolder: Option[os.Path]) {
   os.remove.all(mandatoryLogFolder)
   private var count = 1
 
-  def log0[T: upickle.default.Writer](
+  def log0[T: upickle.Writer](
       p: os.Path,
       res: sourcecode.Text[T],
       prefix: String = ""
   ): Unit = {
     os.write(
       p / s"$prefix${res.source}.json",
-      upickle.default.stream(res.value, indent = 2),
+      upickle.stream(res.value, indent = 2),
       createFolders = true
     )
     count += 1
   }
-  def log[T: upickle.default.Writer](t: => sourcecode.Text[T], prefix: String = ""): Unit = {
+  def log[T: upickle.Writer](t: => sourcecode.Text[T], prefix: String = ""): Unit = {
     logFolder.foreach(log0(_, t, s"$count-$prefix"))
   }
-  def mandatoryLog[T: upickle.default.Writer](
+  def mandatoryLog[T: upickle.Writer](
       t: => sourcecode.Text[T],
       prefix: String = ""
   ): Unit = {

--- a/runner/codesig/src/mill/codesig/ReachabilityAnalysis.scala
+++ b/runner/codesig/src/mill/codesig/ReachabilityAnalysis.scala
@@ -3,7 +3,7 @@ package mill.codesig
 import mill.codesig.JvmModel.*
 import mill.internal.{SpanningForest, Tarjans}
 import ujson.Obj
-import upickle.default.{Writer, writer}
+import upickle.{Writer, writer}
 
 import scala.collection.immutable.SortedMap
 
@@ -271,7 +271,7 @@ object CallGraphAnalysis {
    */
   sealed trait Node
 
-  implicit def nodeRw: Writer[Node] = upickle.default.stringKeyW(
+  implicit def nodeRw: Writer[Node] = upickle.stringKeyW(
     writer[String].comap[Node](_.toString)
   )
 

--- a/runner/codesig/src/mill/codesig/ResolvedCalls.scala
+++ b/runner/codesig/src/mill/codesig/ResolvedCalls.scala
@@ -4,7 +4,7 @@ import mill.codesig.JvmModel.*
 import mill.codesig.JvmModel.JType.Cls as JCls
 import mill.internal.SpanningForest
 import mill.internal.SpanningForest.breadthFirst
-import upickle.default.{ReadWriter, macroRW}
+import upickle.{ReadWriter, macroRW}
 
 case class ResolvedCalls(
     localCalls: Map[MethodCall, ResolvedCalls.MethodCallInfo],

--- a/runner/codesig/test/src/CallGraphTests.scala
+++ b/runner/codesig/test/src/CallGraphTests.scala
@@ -2,7 +2,7 @@ package mill.codesig
 
 import os.Path
 import utest._
-import upickle.default.{read, write}
+import upickle.{read, write}
 import scala.collection.immutable.{SortedMap, SortedSet}
 
 /**
@@ -139,7 +139,7 @@ object CallGraphTests extends TestSuite {
       parseJson(testCaseSourceFilesRoot, "expected-transitive-call-graph")
 
     val transitiveGraph0 = codeSig.transitiveCallGraphValues[SortedSet[String]](
-      codeSig.indexToNodes.map(x => SortedSet(upickle.default.writeJs(x).str)),
+      codeSig.indexToNodes.map(x => SortedSet(upickle.writeJs(x).str)),
       _ | _,
       SortedSet.empty[String]
     )
@@ -156,8 +156,8 @@ object CallGraphTests extends TestSuite {
       .to(SortedMap)
 
     for (expectedTransitiveGraph <- expectedTransitiveGraphOpt) {
-      val expectedTransitiveGraphJson = upickle.default.write(expectedTransitiveGraph, indent = 2)
-      val transitiveGraphJson = upickle.default.write(transitiveGraph, indent = 2)
+      val expectedTransitiveGraphJson = upickle.write(expectedTransitiveGraph, indent = 2)
+      val transitiveGraphJson = upickle.write(transitiveGraph, indent = 2)
       assert(expectedTransitiveGraphJson == transitiveGraphJson)
     }
   }

--- a/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
+++ b/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
@@ -72,7 +72,7 @@ class MillBuildBootstrap(
     for ((frame, depth) <- runnerState.frames.zipWithIndex) {
       os.write.over(
         recOut(output, depth) / millRunnerState,
-        upickle.default.write(frame.loggedData, indent = 4),
+        upickle.write(frame.loggedData, indent = 4),
         createFolders = true
       )
     }

--- a/runner/daemon/src/mill/daemon/RunnerState.scala
+++ b/runner/daemon/src/mill/daemon/RunnerState.scala
@@ -6,7 +6,7 @@ import mill.api.daemon.internal.{EvaluatorApi, internal, PathRefApi}
 import mill.api.internal.RootModule
 import mill.api.daemon.Watchable
 import mill.api.MillURLClassLoader
-import upickle.default.{ReadWriter, macroRW}
+import upickle.{ReadWriter, macroRW}
 
 /**
  * This contains a list of frames each representing cached data from a single

--- a/runner/meta/src/mill/meta/FileImportGraph.scala
+++ b/runner/meta/src/mill/meta/FileImportGraph.scala
@@ -32,7 +32,7 @@ case class FileImportGraph(
 object FileImportGraph {
 
   import mill.api.JsonFormatters.pathReadWrite
-  implicit val readWriter: upickle.default.ReadWriter[FileImportGraph] = upickle.default.macroRW
+  implicit val readWriter: upickle.ReadWriter[FileImportGraph] = upickle.macroRW
 
   /**
    * We perform a depth-first traversal of the import graph of `.sc` files,

--- a/runner/meta/src/mill/meta/MillBuildRootModule.scala
+++ b/runner/meta/src/mill/meta/MillBuildRootModule.scala
@@ -207,7 +207,7 @@ trait MillBuildRootModule()(implicit
         ),
         prevTransitiveCallGraphHashesOpt = () =>
           Option.when(os.exists(Task.dest / "previous/transitiveCallGraphHashes0.json"))(
-            upickle.default.read[Map[String, Int]](
+            upickle.read[Map[String, Int]](
               os.read.stream(Task.dest / "previous/transitiveCallGraphHashes0.json")
             )
           )

--- a/runner/server/src/mill/server/MillDaemonServer.scala
+++ b/runner/server/src/mill/server/MillDaemonServer.scala
@@ -60,9 +60,9 @@ abstract class MillDaemonServer[State](
     serverLog(s"read client init data: $initData")
     import initData.*
 
-    serverLog("args " + upickle.default.write(args))
-    serverLog("env " + upickle.default.write(env.asScala))
-    serverLog("props " + upickle.default.write(userSpecifiedProperties.asScala))
+    serverLog("args " + upickle.write(args))
+    serverLog("env " + upickle.write(env.asScala))
+    serverLog("props " + upickle.write(userSpecifiedProperties.asScala))
 
     val millVersionChanged = lastMillVersion.exists(_ != clientMillVersion)
     val javaVersionChanged = lastJavaVersion.exists(_ != clientJavaVersion)

--- a/testkit/src/mill/testkit/IntegrationTester.scala
+++ b/testkit/src/mill/testkit/IntegrationTester.scala
@@ -205,7 +205,7 @@ object IntegrationTester {
        * Returns the `.json` metadata file contents parsed into a [[Evaluator.Cached]]
        * object, containing both the value as JSON and the associated metadata (e.g. hashes)
        */
-      def cached: Cached = upickle.default.read[Cached](text)
+      def cached: Cached = upickle.read[Cached](text)
 
       /**
        * Returns the value as JSON
@@ -215,7 +215,7 @@ object IntegrationTester {
       /**
        * Returns the value parsed from JSON into a value of type [[T]]
        */
-      def value[T: upickle.default.Reader]: T = upickle.default.read[T](cached.value)
+      def value[T: upickle.Reader]: T = upickle.read[T](cached.value)
     }
 
     /**

--- a/website/package.mill
+++ b/website/package.mill
@@ -565,7 +565,7 @@ object `package` extends mill.Module {
     // This is flaky due to rate limits so ignore it for now
 
     // if (brokenRemoteLinks().nonEmpty){
-    //   throw new Exception("Broken Remote Links: " + upickle.default.write(brokenRemoteLinks(), indent = 2))
+    //   throw new Exception("Broken Remote Links: " + upickle.write(brokenRemoteLinks(), indent = 2))
     // }
   }
 


### PR DESCRIPTION
Also updates code to use the new `upickle.*` APIs available on Scala3, rather than `upickle.default.*` that we were using before