### PR TITLE
Implement support for Scala 3.8 (backport of #5751)

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -635,7 +635,11 @@ trait MillStableScalaModule extends MillPublishScalaModule with Mima {
     ProblemFilter.exclude[Problem]("mill.util.PromptLogger#*"),
     ProblemFilter.exclude[Problem]("mill.util.PromptLoggerUtil.*"),
     ProblemFilter.exclude[Problem]("mill.main.SelectiveExecution*"),
-    ProblemFilter.exclude[Problem]("mill.eval.ExecutionContexts*")
+    ProblemFilter.exclude[Problem]("mill.eval.ExecutionContexts*"),
+    // https://github.com/com-lihaoyi/mill/pull/5797 private nested class inside trait, maybe false-positive problem
+    ProblemFilter.exclude[ReversedMissingMethodProblem](
+      "mill.scalalib.api.ZincWorkerUtil.mill$scalalib$api$ZincWorkerUtil$$MinorMajorVersion"
+    )
   )
   def mimaPreviousVersions: T[Seq[String]] = Settings.mimaBaseVersions
 

--- a/scalalib/api/src/mill/scalalib/api/ZincWorkerUtil.scala
+++ b/scalalib/api/src/mill/scalalib/api/ZincWorkerUtil.scala
@@ -65,7 +65,7 @@ trait ZincWorkerUtil {
     case _ => scalaVersion
   }
 
-  private def majorMinorVersion(version: String): ( /*major: */ Int, /*minor:*/ Int) = version match {
+  private def partialVersion(version: String): ( /*major: */ Int, /*minor:*/ Int) = version match {
     case PartialVersion(major, minor) => (major.toInt, minor.toInt)
   }
 
@@ -175,7 +175,7 @@ trait ZincWorkerUtil {
    * @return `true` if the scala-library version should be enforced to be a `2.13.`
    */
   def enforceScala213Library(scalaVersion: String): Boolean = {
-    val (major, minor) = majorMinorVersion(scalaVersion)
+    val (major, minor) = partial(scalaVersion)
     // Some Dotty versions and all Scala 3 versions before 3.8
     major == 0 || (major == 3 && minor < 8)
   }

--- a/scalalib/api/src/mill/scalalib/api/ZincWorkerUtil.scala
+++ b/scalalib/api/src/mill/scalalib/api/ZincWorkerUtil.scala
@@ -65,7 +65,7 @@ trait ZincWorkerUtil {
     case _ => scalaVersion
   }
 
-  private def binaryVersion(version: String): ( /*major: */ Int, /*minor:*/ Int) = version match {
+  private def majorMinorVersion(version: String): ( /*major: */ Int, /*minor:*/ Int) = version match {
     case PartialVersion(major, minor) => (major.toInt, minor.toInt)
   }
 
@@ -175,7 +175,7 @@ trait ZincWorkerUtil {
    * @return `true` if the scala-library version should be enforced to be a `2.13.`
    */
   def enforceScala213Library(scalaVersion: String): Boolean = {
-    val (major, minor) = binaryVersion(scalaVersion)
+    val (major, minor) = majorMinorVersion(scalaVersion)
     // Some Dotty versions and all Scala 3 versions before 3.8
     major == 0 || (major == 3 && minor < 8)
   }

--- a/scalalib/api/src/mill/scalalib/api/ZincWorkerUtil.scala
+++ b/scalalib/api/src/mill/scalalib/api/ZincWorkerUtil.scala
@@ -64,7 +64,7 @@ trait ZincWorkerUtil {
     case TypelevelVersion(major, minor, _) => s"$major.$minor"
     case _ => scalaVersion
   }
-  
+
   private case class Version(major: Int, minor: Int)
   private def minorMajorVersion(version: String): Version = version match {
     case PartialVersion(major, minor) => Version(major = major.toInt, minor = minor.toInt)

--- a/scalalib/api/src/mill/scalalib/api/ZincWorkerUtil.scala
+++ b/scalalib/api/src/mill/scalalib/api/ZincWorkerUtil.scala
@@ -65,9 +65,8 @@ trait ZincWorkerUtil {
     case _ => scalaVersion
   }
 
-  private case class Version(major: Int, minor: Int)
-  private def minorMajorVersion(version: String): Version = version match {
-    case PartialVersion(major, minor) => Version(major = major.toInt, minor = minor.toInt)
+  private def binaryVersion(version: String): ( /*major: */ Int, /*minor:*/ Int) = version match {
+    case PartialVersion(major, minor) => (major.toInt, minor.toInt)
   }
 
   private val ScalaJSFullVersion = """^([0-9]+)\.([0-9]+)\.([0-9]+)(-.*)?$""".r
@@ -176,9 +175,9 @@ trait ZincWorkerUtil {
    * @return `true` if the scala-library version should be enforced to be a `2.13.`
    */
   def enforceScala213Library(scalaVersion: String): Boolean = {
-    val sv = minorMajorVersion(scalaVersion)
+    val (major, minor) = binaryVersion(scalaVersion)
     // Some Dotty versions and all Scala 3 versions before 3.8
-    sv.major == 0 || (sv.major == 3 && sv.minor < 8)
+    major == 0 || (major == 3 && minor < 8)
   }
 }
 

--- a/scalalib/api/src/mill/scalalib/api/ZincWorkerUtil.scala
+++ b/scalalib/api/src/mill/scalalib/api/ZincWorkerUtil.scala
@@ -65,8 +65,9 @@ trait ZincWorkerUtil {
     case _ => scalaVersion
   }
 
-  private def partialVersion(version: String): ( /*major: */ Int, /*minor:*/ Int) = version match {
-    case PartialVersion(major, minor) => (major.toInt, minor.toInt)
+  private[this] case class MinorMajorVersion(major: Int, minor: Int)
+  private def minorMajorVersion(version: String): MinorMajorVersion = version match {
+    case PartialVersion(major, minor) => MinorMajorVersion(major = major.toInt, minor = minor.toInt)
   }
 
   private val ScalaJSFullVersion = """^([0-9]+)\.([0-9]+)\.([0-9]+)(-.*)?$""".r
@@ -175,9 +176,9 @@ trait ZincWorkerUtil {
    * @return `true` if the scala-library version should be enforced to be a `2.13.`
    */
   def enforceScala213Library(scalaVersion: String): Boolean = {
-    val (major, minor) = partialVersion(scalaVersion)
+    val sv = minorMajorVersion(scalaVersion)
     // Some Dotty versions and all Scala 3 versions before 3.8
-    major == 0 || (major == 3 && minor < 8)
+    sv.major == 0 || (sv.major == 3 && sv.minor < 8)
   }
 }
 

--- a/scalalib/api/src/mill/scalalib/api/ZincWorkerUtil.scala
+++ b/scalalib/api/src/mill/scalalib/api/ZincWorkerUtil.scala
@@ -175,7 +175,7 @@ trait ZincWorkerUtil {
    * @return `true` if the scala-library version should be enforced to be a `2.13.`
    */
   def enforceScala213Library(scalaVersion: String): Boolean = {
-    val (major, minor) = partial(scalaVersion)
+    val (major, minor) = partialVersion(scalaVersion)
     // Some Dotty versions and all Scala 3 versions before 3.8
     major == 0 || (major == 3 && minor < 8)
   }

--- a/scalalib/test/src/mill/scalalib/Scala38NightlyTests.scala
+++ b/scalalib/test/src/mill/scalalib/Scala38NightlyTests.scala
@@ -8,17 +8,18 @@ import utest.*
 // TODO: Once Scala 3.8.0 is out, we can change this test to use 3.8.0 and remove the extra repo
 object Scala38NightlyTests extends TestSuite {
 
-  val repo = coursier.maven.MavenRepository("https://repo.scala-lang.org/artifactory/maven-nightlies")
+  val repo =
+    coursier.maven.MavenRepository("https://repo.scala-lang.org/artifactory/maven-nightlies")
 
   object Scala38Nightly extends TestBaseModule {
     object JvmWorker extends JvmWorkerModule {
-      override def repositoriesTask = Task.Anon { 
+      override def repositoriesTask = Task.Anon {
         super.repositoriesTask() ++ Seq(repo)
       }
     }
     object foo extends ScalaModule {
       override def zincWorker: ModuleRef[JvmWorkerModule] = ModuleRef(JvmWorker)
-      override def repositoriesTask = Task.Anon { 
+      override def repositoriesTask = Task.Anon {
         super.repositoriesTask() ++ Seq(repo)
       }
       override def scalaVersion = "3.8.0-RC1-bin-20250825-ee2f641-NIGHTLY"

--- a/scalalib/test/src/mill/scalalib/Scala38NightlyTests.scala
+++ b/scalalib/test/src/mill/scalalib/Scala38NightlyTests.scala
@@ -13,6 +13,8 @@ object Scala38NightlyTests extends TestSuite {
 
   object Scala38Nightly extends TestBaseModule {
     object JvmWorker extends JvmWorkerModule {
+      // Scala 3.8 requires at least JDK 17
+      override def jvmId = "temurin:17"
       override def repositoriesTask = Task.Anon {
         super.repositoriesTask() ++ Seq(repo)
       }

--- a/scalalib/test/src/mill/scalalib/Scala38NightlyTests.scala
+++ b/scalalib/test/src/mill/scalalib/Scala38NightlyTests.scala
@@ -13,8 +13,6 @@ object Scala38NightlyTests extends TestSuite {
 
   object Scala38Nightly extends TestBaseModule {
     object JvmWorker extends JvmWorkerModule {
-      // Scala 3.8 requires at least JDK 17
-      override def jvmId = "temurin:17"
       override def repositoriesTask = Task.Anon {
         super.repositoriesTask() ++ Seq(repo)
       }
@@ -39,8 +37,15 @@ object Scala38NightlyTests extends TestSuite {
       Scala38Nightly,
       sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "dotty213"
     ).scoped { eval =>
-      val Right(result) = eval.apply(Scala38Nightly.foo.run()): @unchecked
-      assert(result.evalCount > 0)
+      // Scala 3.8 requires at least JDK 17
+      if (sys.props("java.vm.specification.version").toInt < 17)
+        System.err.println(
+          s"Skipped ${Scala38NightlyTests.getClass().getName}.scala38nightly test: requires JDK 17"
+        )
+      else {
+        val Right(result) = eval.apply(Scala38Nightly.foo.run()): @unchecked
+        assert(result.evalCount > 0)
+      }
     }
 
   }

--- a/scalalib/test/src/mill/scalalib/Scala38NightlyTests.scala
+++ b/scalalib/test/src/mill/scalalib/Scala38NightlyTests.scala
@@ -1,0 +1,44 @@
+package mill.scalalib
+
+import mill.*
+import mill.define.{Discover, ModuleRef}
+import mill.testkit.{TestBaseModule, UnitTester}
+import utest.*
+
+// TODO: Once Scala 3.8.0 is out, we can change this test to use 3.8.0 and remove the extra repo
+object Scala38NightlyTests extends TestSuite {
+
+  val repo = coursier.maven.MavenRepository("https://repo.scala-lang.org/artifactory/maven-nightlies")
+
+  object Scala38Nightly extends TestBaseModule {
+    object JvmWorker extends JvmWorkerModule {
+      override def repositoriesTask = Task.Anon { 
+        super.repositoriesTask() ++ Seq(repo)
+      }
+    }
+    object foo extends ScalaModule {
+      override def zincWorker: ModuleRef[JvmWorkerModule] = ModuleRef(JvmWorker)
+      override def repositoriesTask = Task.Anon { 
+        super.repositoriesTask() ++ Seq(repo)
+      }
+      override def scalaVersion = "3.8.0-RC1-bin-20250825-ee2f641-NIGHTLY"
+      override def ivyDeps = Agg(
+        ivy"org.scala-lang.modules::scala-xml:2.4.0"
+      )
+    }
+
+    override lazy val millDiscover = Discover[this.type]
+  }
+
+  def tests: Tests = Tests {
+
+    test("scala38nightly") - UnitTester(
+      Scala38Nightly,
+      sourceRoot = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "dotty213"
+    ).scoped { eval =>
+      val Right(result) = eval.apply(Scala38Nightly.foo.run()): @unchecked
+      assert(result.evalCount > 0)
+    }
+
+  }
+}

--- a/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
+++ b/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
@@ -91,9 +91,10 @@ class ZincWorkerImpl(
         loaderLibraryOnly = ClasspathUtil.rootLoader,
         libraryJars = Array(libraryJarNameGrep(
           compilerClasspath,
-          // we don't support too outdated dotty versions
-          // and because there will be no scala 2.14, so hardcode "2.13." here is acceptable
-          if (JvmWorkerUtil.isDottyOrScala3(key.scalaVersion)) "2.13." else key.scalaVersion
+            // if Dotty or Scala 3.0 - 3.7, use the 2.13 version of the standard library
+            if (JvmWorkerUtil.enforceScala213Library(key.scalaVersion)) "2.13."
+            // otherwise use the library matching the Scala version
+            else key.scalaVersion
         ).path.toIO),
         compilerJars = combinedCompilerJars,
         allJars = combinedCompilerJars,

--- a/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
+++ b/scalalib/worker/src/mill/scalalib/worker/ZincWorkerImpl.scala
@@ -91,10 +91,10 @@ class ZincWorkerImpl(
         loaderLibraryOnly = ClasspathUtil.rootLoader,
         libraryJars = Array(libraryJarNameGrep(
           compilerClasspath,
-            // if Dotty or Scala 3.0 - 3.7, use the 2.13 version of the standard library
-            if (JvmWorkerUtil.enforceScala213Library(key.scalaVersion)) "2.13."
-            // otherwise use the library matching the Scala version
-            else key.scalaVersion
+          // if Dotty or Scala 3.0 - 3.7, use the 2.13 version of the standard library
+          if (JvmWorkerUtil.enforceScala213Library(key.scalaVersion)) "2.13."
+          // otherwise use the library matching the Scala version
+          else key.scalaVersion
         ).path.toIO),
         compilerJars = combinedCompilerJars,
         allJars = combinedCompilerJars,


### PR DESCRIPTION
Backports https://github.com/com-lihaoyi/mill/pull/5751 to 0.12.x branch