### PR TITLE
Fix forced versions

### DIFF
--- a/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBModule.scala
+++ b/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBModule.scala
@@ -91,8 +91,8 @@ trait ScalaPBModule extends ScalaModule {
   def scalaPBProtoClasspath: T[Seq[PathRef]] = Task {
     millResolver().classpath(
       Seq(
-        coursierDependency.withConfiguration(coursier.core.Configuration.provided),
-        coursierDependency
+        coursierDependencyTask().withConfiguration(coursier.core.Configuration.provided),
+        coursierDependencyTask()
       )
     )
   }

--- a/integration/feature/inspect/src/InspectTests.scala
+++ b/integration/feature/inspect/src/InspectTests.scala
@@ -91,8 +91,8 @@ object InspectTests extends UtestIntegrationTestSuite {
           |                             tree.
           |
           |Inputs:
-          |    core.mandatoryMvnDeps
           |    core.mvnDeps
+          |    core.mandatoryMvnDeps
           |    core.compileMvnDeps
           |    core.runMvnDeps
           |    core.bomMvnDeps

--- a/libs/javalib/src/mill/javalib/CoursierModule.scala
+++ b/libs/javalib/src/mill/javalib/CoursierModule.scala
@@ -40,7 +40,7 @@ trait CoursierModule extends mill.api.Module {
    * A [[CoursierModule.Resolver]] to resolve dependencies.
    *
    * Unlike [[defaultResolver]], this resolver can resolve Mill modules too
-   * (obtained via [[JavaModule.coursierDependency]]).
+   * (obtained via [[JavaModule.coursierDependencyTask]]).
    *
    * @return `CoursierModule.Resolver` instance
    */
@@ -141,7 +141,7 @@ trait CoursierModule extends mill.api.Module {
    *
    * Unlike [[repositoriesTask]], this includes the Mill internal repositories,
    * which allow to resolve Mill internal modules (usually brought in via
-   * `JavaModule#coursierDependency`).
+   * `JavaModule#coursierDependencyTask`).
    *
    * Beware that this needs to evaluate `JavaModule#coursierProject` of all
    * module dependencies of the current module, which itself evaluates `JavaModule#mvnDeps`

--- a/libs/javalib/src/mill/javalib/JavaModule.scala
+++ b/libs/javalib/src/mill/javalib/JavaModule.scala
@@ -478,9 +478,11 @@ trait JavaModule
   /**
    * The `coursier.Dependency` to use to refer to this module
    */
+  @deprecated("Use coursierDependencyTask instead", "Mill > 1.0.4")
   def coursierDependency: cs.Dependency =
-    // this is a simple def, and not a Task, as this is simple enough and needed in places
-    // where eval'ing a Task would be impractical or not allowed
+    coursierDependency0
+
+  private def coursierDependency0: cs.Dependency =
     cs.Dependency(
       cs.Module(
         JavaModule.internalOrg,
@@ -489,6 +491,10 @@ trait JavaModule
       ),
       JavaModule.internalVersion
     ).withConfiguration(cs.Configuration.compile)
+
+  def coursierDependencyTask: Task[cs.Dependency] = Task.Anon {
+    coursierDependency0
+  }
 
   /**
    * The `coursier.Project` corresponding to this `JavaModule`.
@@ -502,151 +508,159 @@ trait JavaModule
     coursierProject0()
   }
 
-  private[mill] def coursierProject0: Task[cs.Project] = Task.Anon {
+  private[mill] def coursierProject0: Task[cs.Project] = {
 
-    // Tells coursier that if something depends on a given scope of ours, we should also
-    // pull other scopes of our own dependencies.
-    //
-    // E.g. scopes(runtime) contains compile, so depending on us as a runtime dependency
-    // will not only pull our runtime dependencies, but also our compile ones.
-    //
-    // This is the default scope mapping used in coursier for Maven dependencies, but for
-    // one scope: provided. By default in Maven, depending on a dependency as provided
-    // doesn't pull anything. Here, by explicitly adding provided to the values,
-    // we make coursier pull our own provided dependencies.
-    //
-    // Note that this is kind of a hack: by default, pulling a dependency in scope A
-    // pulls its scope A dependencies. But this is withheld for provided, unless it's
-    // added back explicitly like we do here.
-    val scopes = Map(
-      cs.Configuration.compile -> Seq.empty,
-      cs.Configuration.runtime -> Seq(cs.Configuration.compile),
-      cs.Configuration.default -> Seq(cs.Configuration.runtime),
-      cs.Configuration.test -> Seq(cs.Configuration.runtime),
-      // hack, so that depending on `coursierDependency.withConfiguration(Configuration.provided)`
-      // pulls our provided dependencies (rather than nothing)
-      cs.Configuration.provided -> Seq(cs.Configuration.provided)
-    )
+    val moduleDepsChecked0 = Task.sequence(moduleDepsChecked.map(_.coursierDependencyTask))
+    val compileModuleDepsChecked0 =
+      Task.sequence(compileModuleDepsChecked.map(_.coursierDependencyTask))
+    val runModuleDepsChecked0 = Task.sequence(runModuleDepsChecked.map(_.coursierDependencyTask))
 
-    val internalDependencies =
-      bomModuleDepsChecked.map { modDep =>
-        val dep = coursier.core.Dependency(
-          coursier.core.Module(
-            coursier.core.Organization("mill-internal"),
-            coursier.core.ModuleName(modDep.moduleSegments.parts.mkString("-")),
-            Map.empty
-          ),
-          "0+mill-internal"
-        )
-        (coursier.core.Configuration.`import`, dep)
-      } ++
-        moduleDepsChecked.flatMap { modDep =>
-          // Standard dependencies
-          // We pull their compile scope when our compile scope is asked,
-          // and pull their runtime scope when our runtime scope is asked.
-          Seq(
-            (
-              cs.Configuration.compile,
-              modDep.coursierDependency.withConfiguration(cs.Configuration.compile)
+    Task.Anon {
+
+      // Tells coursier that if something depends on a given scope of ours, we should also
+      // pull other scopes of our own dependencies.
+      //
+      // E.g. scopes(runtime) contains compile, so depending on us as a runtime dependency
+      // will not only pull our runtime dependencies, but also our compile ones.
+      //
+      // This is the default scope mapping used in coursier for Maven dependencies, but for
+      // one scope: provided. By default in Maven, depending on a dependency as provided
+      // doesn't pull anything. Here, by explicitly adding provided to the values,
+      // we make coursier pull our own provided dependencies.
+      //
+      // Note that this is kind of a hack: by default, pulling a dependency in scope A
+      // pulls its scope A dependencies. But this is withheld for provided, unless it's
+      // added back explicitly like we do here.
+      val scopes = Map(
+        cs.Configuration.compile -> Seq.empty,
+        cs.Configuration.runtime -> Seq(cs.Configuration.compile),
+        cs.Configuration.default -> Seq(cs.Configuration.runtime),
+        cs.Configuration.test -> Seq(cs.Configuration.runtime),
+        // hack, so that depending on `coursierDependencyTask.withConfiguration(Configuration.provided)`
+        // pulls our provided dependencies (rather than nothing)
+        cs.Configuration.provided -> Seq(cs.Configuration.provided)
+      )
+
+      val internalDependencies =
+        bomModuleDepsChecked.map { modDep =>
+          val dep = coursier.core.Dependency(
+            coursier.core.Module(
+              coursier.core.Organization("mill-internal"),
+              coursier.core.ModuleName(modDep.moduleSegments.parts.mkString("-")),
+              Map.empty
             ),
+            "0+mill-internal"
+          )
+          (coursier.core.Configuration.`import`, dep)
+        } ++
+          moduleDepsChecked0().flatMap { modDep =>
+            // Standard dependencies
+            // We pull their compile scope when our compile scope is asked,
+            // and pull their runtime scope when our runtime scope is asked.
+            Seq(
+              (
+                cs.Configuration.compile,
+                modDep.withConfiguration(cs.Configuration.compile)
+              ),
+              (
+                cs.Configuration.runtime,
+                modDep.withConfiguration(cs.Configuration.runtime)
+              )
+            )
+          } ++
+          compileModuleDepsChecked0().map { modDep =>
+            // Compile-only (aka provided) dependencies
+            // We pull their compile scope when our provided scope is asked (see scopes above)
+            (
+              cs.Configuration.provided,
+              modDep.withConfiguration(cs.Configuration.compile)
+            )
+          } ++
+          runModuleDepsChecked0().map { modDep =>
+            // Runtime dependencies
+            // We pull their runtime scope when our runtime scope is pulled
             (
               cs.Configuration.runtime,
-              modDep.coursierDependency.withConfiguration(cs.Configuration.runtime)
+              modDep.withConfiguration(cs.Configuration.runtime)
             )
-          )
+          }
+
+      val dependencies =
+        (mandatoryMvnDeps() ++ mvnDeps()).map(bindDependency()).map(_.dep).iterator.toSeq.flatMap {
+          dep =>
+            // Standard dependencies, like above
+            // We pull their compile scope when our compile scope is asked,
+            // and pull their runtime scope when our runtime scope is asked.
+            if (dep.isVariantAttributesBased)
+              Seq(
+                (cs.Configuration.compile, dep),
+                (cs.Configuration.runtime, dep)
+              )
+            else
+              Seq(
+                (cs.Configuration.compile, dep.withConfiguration(cs.Configuration.compile)),
+                (cs.Configuration.runtime, dep.withConfiguration(cs.Configuration.runtime))
+              )
         } ++
-        compileModuleDepsChecked.map { modDep =>
-          // Compile-only (aka provided) dependencies
-          // We pull their compile scope when our provided scope is asked (see scopes above)
-          (
-            cs.Configuration.provided,
-            modDep.coursierDependency.withConfiguration(cs.Configuration.compile)
-          )
-        } ++
-        runModuleDepsChecked.map { modDep =>
-          // Runtime dependencies
-          // We pull their runtime scope when our runtime scope is pulled
-          (
-            cs.Configuration.runtime,
-            modDep.coursierDependency.withConfiguration(cs.Configuration.runtime)
-          )
+          compileMvnDeps().map(bindDependency()).map(_.dep).map { dep =>
+            // Compile-only (aka provided) dependencies, like above
+            // We pull their compile scope when our provided scope is asked (see scopes above)
+            if (dep.isVariantAttributesBased)
+              (cs.Configuration.provided, dep)
+            else
+              (cs.Configuration.provided, dep.withConfiguration(cs.Configuration.compile))
+          } ++
+          runMvnDeps().map(bindDependency()).map(_.dep).map { dep =>
+            // Runtime dependencies, like above
+            // We pull their runtime scope when our runtime scope is pulled
+            if (dep.isVariantAttributesBased)
+              (
+                cs.Configuration.runtime,
+                dep
+              )
+            else
+              (
+                cs.Configuration.runtime,
+                dep.withConfiguration(cs.Configuration.runtime)
+              )
+          } ++
+          allBomDeps().map { bomDep =>
+            // BOM dependencies
+            // Maven has a special scope for those: "import"
+            val dep =
+              cs.Dependency(bomDep.module, bomDep.version).withConfiguration(bomDep.config)
+            (cs.Configuration.`import`, dep)
+          }
+
+      val depMgmt =
+        processedDependencyManagement(
+          depManagement().iterator.toSeq.map(bindDependency()).map(_.dep)
+        ).map {
+          case (key, values) =>
+            val config0 =
+              if (values.config.isEmpty) cs.Configuration.compile
+              else values.config
+            (config0, values.fakeDependency(key))
         }
 
-    val dependencies =
-      (mandatoryMvnDeps() ++ mvnDeps()).map(bindDependency()).map(_.dep).iterator.toSeq.flatMap {
-        dep =>
-          // Standard dependencies, like above
-          // We pull their compile scope when our compile scope is asked,
-          // and pull their runtime scope when our runtime scope is asked.
-          if (dep.isVariantAttributesBased)
-            Seq(
-              (cs.Configuration.compile, dep),
-              (cs.Configuration.runtime, dep)
-            )
-          else
-            Seq(
-              (cs.Configuration.compile, dep.withConfiguration(cs.Configuration.compile)),
-              (cs.Configuration.runtime, dep.withConfiguration(cs.Configuration.runtime))
-            )
-      } ++
-        compileMvnDeps().map(bindDependency()).map(_.dep).map { dep =>
-          // Compile-only (aka provided) dependencies, like above
-          // We pull their compile scope when our provided scope is asked (see scopes above)
-          if (dep.isVariantAttributesBased)
-            (cs.Configuration.provided, dep)
-          else
-            (cs.Configuration.provided, dep.withConfiguration(cs.Configuration.compile))
-        } ++
-        runMvnDeps().map(bindDependency()).map(_.dep).map { dep =>
-          // Runtime dependencies, like above
-          // We pull their runtime scope when our runtime scope is pulled
-          if (dep.isVariantAttributesBased)
-            (
-              cs.Configuration.runtime,
-              dep
-            )
-          else
-            (
-              cs.Configuration.runtime,
-              dep.withConfiguration(cs.Configuration.runtime)
-            )
-        } ++
-        allBomDeps().map { bomDep =>
-          // BOM dependencies
-          // Maven has a special scope for those: "import"
-          val dep =
-            cs.Dependency(bomDep.module, bomDep.version).withConfiguration(bomDep.config)
-          (cs.Configuration.`import`, dep)
-        }
-
-    val depMgmt =
-      processedDependencyManagement(
-        depManagement().iterator.toSeq.map(bindDependency()).map(_.dep)
-      ).map {
-        case (key, values) =>
-          val config0 =
-            if (values.config.isEmpty) cs.Configuration.compile
-            else values.config
-          (config0, values.fakeDependency(key))
-      }
-
-    cs.Project(
-      module = coursierDependency.module,
-      version = coursierDependency.version,
-      dependencies = internalDependencies ++ dependencies,
-      configurations = scopes,
-      parent = None,
-      dependencyManagement = depMgmt,
-      properties = Nil,
-      profiles = Nil,
-      versions = None,
-      snapshotVersioning = None,
-      packagingOpt = None,
-      relocated = false,
-      actualVersionOpt = None,
-      publications = Nil,
-      info = coursier.core.Info.empty
-    )
+      cs.Project(
+        module = coursierDependencyTask().module,
+        version = coursierDependencyTask().version,
+        dependencies = internalDependencies ++ dependencies,
+        configurations = scopes,
+        parent = None,
+        dependencyManagement = depMgmt,
+        properties = Nil,
+        profiles = Nil,
+        versions = None,
+        snapshotVersioning = None,
+        packagingOpt = None,
+        relocated = false,
+        actualVersionOpt = None,
+        publications = Nil,
+        info = coursier.core.Info.empty
+      )
+    }
   }
 
   /**
@@ -675,8 +689,8 @@ trait JavaModule
     //
     // Dependencies, both external ones (like mvnDeps, bomMvnDeps, etc.) and internal ones
     // (like moduleDeps) are put in coursier.Project#dependencies. The coursier.Dependency
-    // used to represent each module is built by JavaModule#coursierDependency. So we put
-    // JavaModule#coursierDependency in the dependencies field of other modules'
+    // used to represent each module is built by JavaModule#coursierDependencyTask. So we put
+    // JavaModule#coursierDependencyTask in the dependencies field of other modules'
     // JavaModule#coursierProject to represent links between them.
     //
     // coursier.Project#dependencies accepts (coursier.Configuration, coursier.Dependency) tuples.
@@ -1021,10 +1035,10 @@ trait JavaModule
     millResolver().classpath(
       Seq(
         BoundDep(
-          coursierDependency.withConfiguration(cs.Configuration.provided),
+          coursierDependencyTask().withConfiguration(cs.Configuration.provided),
           force = false
         ),
-        BoundDep(coursierDependency, force = false)
+        BoundDep(coursierDependencyTask(), force = false)
       ),
       artifactTypes = Some(artifactTypes()),
       resolutionParamsMapOpt =
@@ -1061,7 +1075,7 @@ trait JavaModule
     millResolver().classpath(
       Seq(
         BoundDep(
-          coursierDependency.withConfiguration(cs.Configuration.runtime),
+          coursierDependencyTask().withConfiguration(cs.Configuration.runtime),
           force = false
         )
       ),
@@ -1227,11 +1241,10 @@ trait JavaModule
       whatDependsOn: List[JavaOrScalaModule]
   ): Task[String] =
     Task.Anon {
-      val dependencies =
-        (additionalDeps() ++ Seq(BoundDep(coursierDependency, force = false))).iterator.to(Seq)
+      val dependencies = additionalDeps() ++ Seq(BoundDep(coursierDependencyTask(), force = false))
       val resolution: Resolution = Lib.resolveDependenciesMetadataSafe(
         allRepositories(),
-        dependencies,
+        dependencies.iterator.to(Seq),
         Some(mapDependencies()),
         customizer = resolutionCustomizer(),
         coursierCacheCustomizer = coursierCacheCustomizer(),
@@ -1244,7 +1257,7 @@ trait JavaModule
         case List() =>
           val mandatoryModules =
             mandatoryMvnDeps().map(bindDependency()).iterator.map(_.dep.module).toSet
-          val (mandatory, main) = resolution.dependenciesOf0(coursierDependency).toTry.get
+          val (mandatory, main) = resolution.dependenciesOf0(coursierDependencyTask()).toTry.get
             .partition(dep => mandatoryModules.contains(dep.module))
           additionalDeps().iterator.toSeq.map(_.dep) ++ main ++ mandatory
         case _ =>
@@ -1306,8 +1319,8 @@ trait JavaModule
             args.inverse.value,
             Task.Anon {
               Seq(
-                coursierDependency.withConfiguration(cs.Configuration.provided),
-                coursierDependency.withConfiguration(cs.Configuration.runtime)
+                coursierDependencyTask().withConfiguration(cs.Configuration.provided),
+                coursierDependencyTask().withConfiguration(cs.Configuration.runtime)
               ).map(BoundDep(_, force = false))
             },
             modules
@@ -1317,7 +1330,7 @@ trait JavaModule
             args.inverse.value,
             Task.Anon {
               Seq(BoundDep(
-                coursierDependency.withConfiguration(cs.Configuration.provided),
+                coursierDependencyTask().withConfiguration(cs.Configuration.provided),
                 force = false
               ))
             },
@@ -1328,7 +1341,7 @@ trait JavaModule
             args.inverse.value,
             Task.Anon {
               Seq(BoundDep(
-                coursierDependency.withConfiguration(cs.Configuration.runtime),
+                coursierDependencyTask().withConfiguration(cs.Configuration.runtime),
                 force = false
               ))
             },
@@ -1384,8 +1397,8 @@ trait JavaModule
         Task.Anon {
           millResolver().classpath(
             Seq(
-              coursierDependency.withConfiguration(cs.Configuration.provided),
-              coursierDependency
+              coursierDependencyTask().withConfiguration(cs.Configuration.provided),
+              coursierDependencyTask()
             ),
             sources = true,
             resolutionParamsMapOpt =
@@ -1396,7 +1409,7 @@ trait JavaModule
         },
         Task.Anon {
           millResolver().classpath(
-            Seq(coursierDependency.withConfiguration(cs.Configuration.runtime)),
+            Seq(coursierDependencyTask().withConfiguration(cs.Configuration.runtime)),
             sources = true
           )
         }

--- a/libs/javalib/src/mill/javalib/JavaModule.scala
+++ b/libs/javalib/src/mill/javalib/JavaModule.scala
@@ -493,7 +493,12 @@ trait JavaModule
     ).withConfiguration(cs.Configuration.compile)
 
   def coursierDependencyTask: Task[cs.Dependency] = Task.Anon {
-    coursierDependency0
+    val bindDependency0 = bindDependency()
+    val forceVersions = mvnDeps().filter(_.force).map(bindDependency0(_).dep).map { dep =>
+      DependencyManagement.Key.from(dep) ->
+        DependencyManagement.Values.from(Configuration.empty, dep)
+    }
+    coursierDependency0.addOverrides(cs.Overrides(forceVersions.toMap))
   }
 
   /**

--- a/libs/javalib/src/mill/javalib/JavaModule.scala
+++ b/libs/javalib/src/mill/javalib/JavaModule.scala
@@ -478,7 +478,7 @@ trait JavaModule
   /**
    * The `coursier.Dependency` to use to refer to this module
    */
-  @deprecated("Use coursierDependencyTask instead", "Mill > 1.0.4")
+  @deprecated("Use coursierDependencyTask instead", "Mill 1.1.0")
   def coursierDependency: cs.Dependency =
     coursierDependency0
 

--- a/libs/javalib/src/mill/javalib/PublishModule.scala
+++ b/libs/javalib/src/mill/javalib/PublishModule.scala
@@ -211,7 +211,7 @@ trait PublishModule extends JavaModule { outer =>
    * @return
    */
   private def ivy(hasJar: Boolean): Task[String] = Task.Anon {
-    val dep = coursierDependency.withConfiguration(Configuration.runtime)
+    val dep = coursierDependencyTask().withConfiguration(Configuration.runtime)
     val resolution = millResolver().resolution(Seq(BoundDep(dep, force = false)))
 
     val (results, bomDepMgmt) =

--- a/libs/javalib/src/mill/javalib/bsp/BspJavaModule.scala
+++ b/libs/javalib/src/mill/javalib/bsp/BspJavaModule.scala
@@ -54,8 +54,8 @@ trait BspJavaModule extends mill.api.Module with BspJavaModuleApi {
     (
       resolvedDepsSources = jm.millResolver().classpath(
         Seq(
-          jm.coursierDependency.withConfiguration(coursier.core.Configuration.provided),
-          jm.coursierDependency
+          jm.coursierDependencyTask().withConfiguration(coursier.core.Configuration.provided),
+          jm.coursierDependencyTask()
         ),
         sources = true
       ).map(_.path.toNIO),
@@ -73,8 +73,8 @@ trait BspJavaModule extends mill.api.Module with BspJavaModuleApi {
       jm.millResolver()
         .resolution(
           Seq(
-            jm.coursierDependency.withConfiguration(coursier.core.Configuration.provided),
-            jm.coursierDependency
+            jm.coursierDependencyTask().withConfiguration(coursier.core.Configuration.provided),
+            jm.coursierDependencyTask()
           )
         )
         .orderedDependencies

--- a/libs/javalib/src/mill/javalib/eclipse/GenEclipseModule.scala
+++ b/libs/javalib/src/mill/javalib/eclipse/GenEclipseModule.scala
@@ -17,8 +17,8 @@ trait GenEclipseModule extends mill.api.Module with GenEclipseInternalApi {
   // download their sources as well.
   private[mill] def allCoursierDependencies = Task {
     Seq(
-      javaModule.coursierDependency,
-      javaModule.coursierDependency.withConfiguration(coursier.core.Configuration.provided)
+      javaModule.coursierDependencyTask(),
+      javaModule.coursierDependencyTask().withConfiguration(coursier.core.Configuration.provided)
     ).map(BoundDep(_, force = false))
   }
 

--- a/libs/javalib/src/mill/javalib/idea/GenIdeaModule.scala
+++ b/libs/javalib/src/mill/javalib/idea/GenIdeaModule.scala
@@ -18,8 +18,8 @@ trait GenIdeaModule extends mill.api.Module with GenIdeaInternalApi {
   private lazy val javaModule = javaModuleRef()
   private[mill] def allMvnDeps = Task {
     Seq(
-      javaModule.coursierDependency,
-      javaModule.coursierDependency.withConfiguration(coursier.core.Configuration.provided)
+      javaModule.coursierDependencyTask(),
+      javaModule.coursierDependencyTask().withConfiguration(coursier.core.Configuration.provided)
     ).map(BoundDep(_, force = false))
   }
 

--- a/libs/javalib/src/mill/javalib/revapi/RevapiModule.scala
+++ b/libs/javalib/src/mill/javalib/revapi/RevapiModule.scala
@@ -84,7 +84,7 @@ trait RevapiModule extends PublishModule {
     Seq(jar()) ++
       Task.traverse(recursiveModuleDeps)(_.jar)() ++
       millResolver().classpath(
-        Seq(coursierDependency),
+        Seq(coursierDependencyTask()),
         artifactTypes = Some(revapiArtifactTypes())
       )
   }

--- a/libs/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/libs/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -464,7 +464,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase
       }
       val bind = bindDependency()
       Seq(BoundDep(
-        coursierDependency.withConfiguration(coursier.core.Configuration.runtime),
+        coursierDependencyTask().withConfiguration(coursier.core.Configuration.runtime),
         force = false
       )) ++
         Seq(mvn"com.lihaoyi:::ammonite:${ammVersion}").map(bind)


### PR DESCRIPTION
This fixes https://github.com/com-lihaoyi/mill/issues/5796 (forced versions not enforced) by taking them into account in `JavaModule#coursierDependency`, so that they're being enforced during dependency resolution, and are taken into account in other modules if needed.

In order to get forced versions from `mvnDeps`, `JavaModule#coursierDependency` needs to be a task. So in more detail, the current `coursierDependency` is deprecated, and a new `coursierDependencyTask` is used instead.