### PR TITLE
Cut down the number of Mill file suffixes to just `.mill`

### DIFF
--- a/core/constants/src/mill/constants/CodeGenConstants.java
+++ b/core/constants/src/mill/constants/CodeGenConstants.java
@@ -22,14 +22,12 @@ public class CodeGenConstants {
   /**
    * The name of the root build file
    */
-  public static final List<String> rootBuildFileNames =
-      List.of("build.mill");
+  public static final List<String> rootBuildFileNames = List.of("build.mill");
 
   /**
    * The name of any sub-folder build files
    */
-  public static final List<String> nestedBuildFileNames =
-      List.of("package.mill");
+  public static final List<String> nestedBuildFileNames = List.of("package.mill");
 
   /**
    * The extensions used by build files

--- a/core/constants/src/mill/constants/CodeGenConstants.java
+++ b/core/constants/src/mill/constants/CodeGenConstants.java
@@ -23,18 +23,18 @@ public class CodeGenConstants {
    * The name of the root build file
    */
   public static final List<String> rootBuildFileNames =
-      List.of("build.mill", "build.mill.scala", "build.sc");
+      List.of("build.mill");
 
   /**
    * The name of any sub-folder build files
    */
   public static final List<String> nestedBuildFileNames =
-      List.of("package.mill", "package.mill.scala", "package.sc");
+      List.of("package.mill");
 
   /**
    * The extensions used by build files
    */
-  public static final List<String> buildFileExtensions = List.of("mill", "mill.scala", "sc");
+  public static final List<String> buildFileExtensions = List.of("mill");
 
   /**
    * The user-facing name for the root of the module tree.

--- a/dist/scripts/src/mill.sh
+++ b/dist/scripts/src/mill.sh
@@ -57,10 +57,6 @@ MILL_BUILD_SCRIPT=""
 
 if [ -f "build.mill" ] ; then
   MILL_BUILD_SCRIPT="build.mill"
-elif [ -f "build.mill.scala" ] ; then
-  MILL_BUILD_SCRIPT="build.mill.scala"
-elif [ -f "build.sc" ] ; then
-  MILL_BUILD_SCRIPT="build.sc"
 fi
 
 # Please note, that if a MILL_VERSION is already set in the environment,

--- a/example/package.mill
+++ b/example/package.mill
@@ -146,7 +146,7 @@ object `package` extends Module {
 
     def testRepoRoot = Task {
       os.copy(super.testRepoRoot().path, Task.dest, mergeFolders = true)
-      for (suffix <- Seq("build.sc", "build.mill", "build.mill.scala")) {
+      for (suffix <- Seq("build.mill")) {
         for (lines <- buildScLines() if os.exists(Task.dest / suffix)) {
           os.write.over(Task.dest / suffix, lines.mkString("\n"))
         }
@@ -159,7 +159,7 @@ object `package` extends Module {
       case Some(upstream) => Task {
           os.copy.over(super.testRepoRoot().path, Task.dest)
           val upstreamRoot = upstream.testRepoRoot().path
-          val suffix = Seq("build.sc", "build.mill").find(s => os.exists(upstreamRoot / s)).head
+          val suffix = Seq("build.mill").find(s => os.exists(upstreamRoot / s)).head
           for (lines <- buildScLines()) {
             os.write.over(Task.dest / suffix, lines.mkString("\n"))
           }
@@ -171,7 +171,7 @@ object `package` extends Module {
       case Some(upstream) => Task {
           Some {
             val upstreamRoot = upstream.testRepoRoot().path
-            val suffix = Seq("build.sc", "build.mill").find(s => os.exists(upstreamRoot / s)).head
+            val suffix = Seq("build.mill").find(s => os.exists(upstreamRoot / s)).head
             val upstreamLines = os.read.lines(upstream.testRepoRoot().path / suffix)
             val lines = os.read.lines(super.testRepoRoot().path / suffix)
 
@@ -345,7 +345,6 @@ $txt
       )
       os.remove.all(Task.dest / ".mill-version")
 
-      os.remove.all(Task.dest / "build.sc")
       PathRef(Task.dest)
     }
   }

--- a/integration/failure/missing-build-file/src/MissingBuildFileTests.scala
+++ b/integration/failure/missing-build-file/src/MissingBuildFileTests.scala
@@ -9,7 +9,7 @@ object MissingBuildFileTests extends UtestIntegrationTestSuite {
       val res = tester.eval(("resolve", "_"))
       assert(!res.isSuccess)
 
-      val s"${prefix}No build file (build.mill, build.mill.scala, build.sc) found in $msg. Are you in a Mill project directory?" =
+      val s"${prefix}No build file (build.mill) found in $msg. Are you in a Mill project directory?" =
         res.err: @unchecked
       // Silence unused variable warning
       val _ = prefix

--- a/mill
+++ b/mill
@@ -63,10 +63,6 @@ MILL_BUILD_SCRIPT=""
 
 if [ -f "build.mill" ] ; then
   MILL_BUILD_SCRIPT="build.mill"
-elif [ -f "build.mill.scala" ] ; then
-  MILL_BUILD_SCRIPT="build.mill.scala"
-elif [ -f "build.sc" ] ; then
-  MILL_BUILD_SCRIPT="build.sc"
 fi
 
 # Please note, that if a MILL_VERSION is already set in the environment,

--- a/mill-build/src-testkit/mill/testkit/ExampleParser.scala
+++ b/mill-build/src-testkit/mill/testkit/ExampleParser.scala
@@ -6,7 +6,7 @@ object ExampleParser {
     val states = collection.mutable.Buffer("yaml")
     val chunks = collection.mutable.Buffer(collection.mutable.Buffer.empty[String])
 
-    val rootBuildFileNames = Seq("build.sc", "build.mill", "build.mill.scala")
+    val rootBuildFileNames = Seq("build.mill")
     val buildFile = rootBuildFileNames.map(testRepoRoot / _)
       .find(os.exists)
       .getOrElse(

--- a/mill.bat
+++ b/mill.bat
@@ -46,16 +46,6 @@ SET MILL_BUILD_SCRIPT=
 
 if exist "build.mill" (
   set MILL_BUILD_SCRIPT=build.mill
-) else (
-    if exist "build.mill.scala" (
-      set MILL_BUILD_SCRIPT=build.mill.scala
-    ) else (
-        if exist "build.sc" (
-          set MILL_BUILD_SCRIPT=build.sc
-        ) else (
-            rem no-op
-        )
-    )
 )
 
 if [!MILL_VERSION!]==[] (

--- a/runner/daemon/test/src/mill/daemon/MillMainTests.scala
+++ b/runner/daemon/test/src/mill/daemon/MillMainTests.scala
@@ -98,10 +98,8 @@ object MillMainTests extends TestSuite {
         val file1 = (dir / ".mill-version").tap { os.write(_, "1") }
         val file2 =
           (dir / ".config" / "mill-version").tap { os.write(_, "2", createFolders = true) }
-        val file3 = (dir / "build.mill").tap { os.write(_, "//| mill-version: 3") }
+        val file3 = (dir / "build.mill").tap { os.write(_, "//|    mill-version:    3") }
         // Added content spaces to test parsing
-        val file4 = (dir / "build.mill.scala").tap { os.write(_, "//| mill-version:    4") }
-        val file5 = (dir / "build.sc").tap { os.write(_, "//|     mill-version: 5") }
         test(".mill-version") {
           val read = MillMain0.readBestMillVersion(dir)
           assert(read == Some(file1, "1"))
@@ -116,21 +114,6 @@ object MillMainTests extends TestSuite {
           os.remove(file2)
           val read = MillMain0.readBestMillVersion(dir)
           assert(read == Some(file3, "3"))
-        }
-        test("build.mill.scala") {
-          os.remove(file1)
-          os.remove(file2)
-          os.remove(file3)
-          val read = MillMain0.readBestMillVersion(dir)
-          assert(read == Some(file4, "4"))
-        }
-        test("build.sc") {
-          os.remove(file1)
-          os.remove(file2)
-          os.remove(file3)
-          os.remove(file4)
-          val read = MillMain0.readBestMillVersion(dir)
-          assert(read == Some(file5, "5"))
         }
       }
     }

--- a/runner/meta/src/mill/meta/FileImportGraph.scala
+++ b/runner/meta/src/mill/meta/FileImportGraph.scala
@@ -35,7 +35,7 @@ object FileImportGraph {
   implicit val readWriter: upickle.ReadWriter[FileImportGraph] = upickle.macroRW
 
   /**
-   * We perform a depth-first traversal of the import graph of `.sc` files,
+   * We perform a depth-first traversal of the import graph of `.mill` files,
    * starting from `build.mill`, collecting the information necessary to
    * instantiate the [[MillRootModule]]
    */

--- a/runner/meta/src/mill/meta/MillBuildRootModule.scala
+++ b/runner/meta/src/mill/meta/MillBuildRootModule.scala
@@ -100,7 +100,7 @@ trait MillBuildRootModule()(implicit
 
   /**
    * Additional script files, we generate, since not all Mill source
-   * files (e.g. `.sc` and `.mill`) can be fed to the compiler as-is.
+   * files (`*.mill` can be fed to the compiler as-is.
    *
    * The `wrapped` files aren't supposed to appear under [[generatedSources]] and [[allSources]],
    * since they are derived from [[sources]] and would confuse any further tooling like IDEs.


### PR DESCRIPTION
`.sc` was fine as a migration bridge and `.mill.scala` was a good stopgap measure when `.mill` file support in tools wasn't there, but IntelliJ/VSCode/ScalaFmt now have support for `.mill` files so we can consider standardizing on it.

This is a breaking change for local builds but not plugins, so would go into 1.1.0