### PR TITLE
Skip autoformatting in code files containing build headers

### DIFF
--- a/libs/javalib/src/mill/javalib/palantirformat/PalantirFormatModule.scala
+++ b/libs/javalib/src/mill/javalib/palantirformat/PalantirFormatModule.scala
@@ -87,7 +87,9 @@ object PalantirFormatModule extends ExternalModule with PalantirFormatBaseModule
       .filter(os.exists(_))
       .flatMap(os.walk(_, includeTarget = true))
       .filter(os.isFile)
+      // skip formatting single-file projects since Palantir Format messes up the header block
       .filter(_.ext == "java")
+      .filter(!os.read(_).startsWith("//|")) 
       .toSeq
 
     if (check) {

--- a/libs/kotlinlib/src/mill/kotlinlib/ktlint/KtlintModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/ktlint/KtlintModule.scala
@@ -121,7 +121,9 @@ object KtlintModule extends ExternalModule with KtlintModule with DefaultTaskMod
     args ++= configArgument
     args ++= formatArgument
     args ++= filesToFormat.map(_.path)
+      // skip formatting single-file projects since Palantir Format messes up the header block
       .filter(f => os.exists(f) && (f.ext == "kt" || f.ext == "kts"))
+      .filter(!os.read(_).startsWith("//|"))
       .map(_.toString())
 
     val exitCode = BuildCtx.withFilesystemCheckerDisabled {


### PR DESCRIPTION
Preparation for https://github.com/com-lihaoyi/mill/pull/5820, so we can include single `.java` or `.kt` files in our codebase without their `//|` build headers being mangled by the autoformatter