### PR TITLE
Update lazy val bytecode signature heuristics to work with Scala 3 lazy vals

### DIFF
--- a/integration/invalidation/codesig-hello/resources/build.mill
+++ b/integration/invalidation/codesig-hello/resources/build.mill
@@ -3,5 +3,6 @@ import mill._
 
 val valueFoo = 0
 val valueFooUsedInBar = 0
-def helperFoo = { println("running helperFoo"); 1 + valueFoo }
-def foo = Task { println("running foo"); helperFoo }
+lazy val lazyValue = 0
+def helperFoo = { println("running helperFoo"); 1 + valueFoo + lazyValue }
+def foo = Task { println("running foo"); helperFoo + lazyValue }

--- a/integration/invalidation/codesig-hello/src/CodeSigHelloTests.scala
+++ b/integration/invalidation/codesig-hello/src/CodeSigHelloTests.scala
@@ -53,6 +53,17 @@ object CodeSigHelloTests extends UtestIntegrationTestSuite {
 
       val cached3 = eval("foo")
       assert(cached3.out == "")
+
+      // Changing the body of a `lazy val` invalidates the usages
+      modifyFile(
+        workspacePath / "build.mill",
+        _.replace("lazy val lazyValue = 0", "lazy val lazyValue = 1")
+      )
+      val mangledLazyVal = eval("foo")
+      assert(mangledLazyVal.out.linesIterator.toSeq == Seq(
+        "running foo2",
+        "running helperFoo2"
+      ))
     }
   }
 }

--- a/runner/codesig/src/mill/codesig/LocalSummary.scala
+++ b/runner/codesig/src/mill/codesig/LocalSummary.scala
@@ -192,11 +192,19 @@ object LocalSummary {
         descriptor: String
     ): Unit = {
       val lazyValBodyStart = (owner, name, descriptor) match {
-        case ("scala/runtime/LazyVals$Evaluating$", "MODULE$", "Lscala/runtime/LazyVals$Evaluating$;") => true
+        case (
+              "scala/runtime/LazyVals$Evaluating$",
+              "MODULE$",
+              "Lscala/runtime/LazyVals$Evaluating$;"
+            ) => true
         case _ => false
       }
       val lazyValBodyEnd = (owner, name, descriptor) match {
-        case ("scala/runtime/LazyVals$NullValue$", "MODULE$", "Lscala/runtime/LazyVals$NullValue$;") => true
+        case (
+              "scala/runtime/LazyVals$NullValue$",
+              "MODULE$",
+              "Lscala/runtime/LazyVals$NullValue$;"
+            ) => true
         case _ => false
       }
       val isLazyValsGet = (owner, name, descriptor) match {


### PR DESCRIPTION
Should fix https://github.com/com-lihaoyi/mill/issues/5356

The previous heuristics worked for Scala 2, but weren't covered by tests, and so bitrotted in Scala 3. This PR updates the heuristics to the bytecode I can see being emitted by the Scala 3 compiler, and adds an integration test assertion to make sure that if it regresses again we can notice.