### PR TITLE
Fix prompt when server restarts

### DIFF
--- a/runner/client/src/mill/client/MillServerLauncher.java
+++ b/runner/client/src/mill/client/MillServerLauncher.java
@@ -43,12 +43,8 @@ public abstract class MillServerLauncher extends ServerLauncher {
    */
   public abstract LaunchedServer initServer(Path daemonDir, Locks locks) throws Exception;
 
-  public abstract void prepareDaemonDir(Path daemonDir) throws Exception;
-
   public Result run(Path daemonDir, String javaHome, Consumer<String> log) throws Exception {
     Files.createDirectories(daemonDir);
-    log.accept("Preparing Mill daemon directory: " + daemonDir.toAbsolutePath());
-    prepareDaemonDir(daemonDir);
 
     var initData = new ClientInitData(
         /* interactive */ Util.hasConsole(),
@@ -73,7 +69,7 @@ public abstract class MillServerLauncher extends ServerLauncher {
         serverInitWaitMillis,
         () -> initServer(daemonDir, locks),
         serverDied -> {
-          System.err.println("Server died during startup:");
+              System.err.println("Server died during startup:");
           System.err.println(serverDied.toString());
           System.exit(1);
         },

--- a/runner/client/src/mill/client/MillServerLauncher.java
+++ b/runner/client/src/mill/client/MillServerLauncher.java
@@ -69,7 +69,7 @@ public abstract class MillServerLauncher extends ServerLauncher {
         serverInitWaitMillis,
         () -> initServer(daemonDir, locks),
         serverDied -> {
-              System.err.println("Server died during startup:");
+          System.err.println("Server died during startup:");
           System.err.println(serverDied.toString());
           System.exit(1);
         },

--- a/runner/launcher/src/mill/launcher/MillLauncherMain.java
+++ b/runner/launcher/src/mill/launcher/MillLauncherMain.java
@@ -83,10 +83,6 @@ public class MillLauncherMain {
                 return new LaunchedServer.OsProcess(
                     MillProcessLauncher.launchMillDaemon(daemonDir, outMode).toHandle());
               }
-
-              public void prepareDaemonDir(Path daemonDir) throws Exception {
-                MillProcessLauncher.prepareMillRunFolder(daemonDir);
-              }
             };
 
         var daemonDir0 = Paths.get(outDir, OutFiles.millDaemon);

--- a/runner/launcher/src/mill/launcher/MillProcessLauncher.java
+++ b/runner/launcher/src/mill/launcher/MillProcessLauncher.java
@@ -329,6 +329,7 @@ public class MillProcessLauncher {
   static void writeTerminalDims(boolean tputExists, Path daemonDir) throws Exception {
     String str;
 
+    mill.constants.DebugLog.println("tputExists " + tputExists);
     try {
       if (!mill.constants.Util.hasConsole()) str = "0 0";
       else {
@@ -358,7 +359,11 @@ public class MillProcessLauncher {
     // The cause is currently unknown, but this fixes the symptoms at least.
     //
     String oldValue = memoizedTerminalDims.getAndSet(str);
+    mill.constants.DebugLog.println("(oldValue == null) " + (oldValue == null));
+    if (oldValue != null)
+      mill.constants.DebugLog.println("!oldValue.equals(str) " + !oldValue.equals(str));
     if ((oldValue == null) || !oldValue.equals(str)) {
+      mill.constants.DebugLog.println("Files.write " + daemonDir.resolve(DaemonFiles.terminfo));
       Files.write(daemonDir.resolve(DaemonFiles.terminfo), str.getBytes());
     }
   }
@@ -376,6 +381,7 @@ public class MillProcessLauncher {
   public static void prepareMillRunFolder(Path daemonDir) throws Exception {
     // Clear out run-related files from the server folder to make sure we
     // never hit issues where we are reading the files from a previous run
+    mill.constants.DebugLog.println("Files.deleteIfExists " + daemonDir.resolve(DaemonFiles.terminfo));
     Files.deleteIfExists(daemonDir.resolve(DaemonFiles.terminfo));
 
     Path sandbox = daemonDir.resolve(DaemonFiles.sandbox);

--- a/runner/launcher/src/mill/launcher/MillProcessLauncher.java
+++ b/runner/launcher/src/mill/launcher/MillProcessLauncher.java
@@ -329,7 +329,6 @@ public class MillProcessLauncher {
   static void writeTerminalDims(boolean tputExists, Path daemonDir) throws Exception {
     String str;
 
-    mill.constants.DebugLog.println("tputExists " + tputExists);
     try {
       if (!mill.constants.Util.hasConsole()) str = "0 0";
       else {
@@ -359,11 +358,7 @@ public class MillProcessLauncher {
     // The cause is currently unknown, but this fixes the symptoms at least.
     //
     String oldValue = memoizedTerminalDims.getAndSet(str);
-    mill.constants.DebugLog.println("(oldValue == null) " + (oldValue == null));
-    if (oldValue != null)
-      mill.constants.DebugLog.println("!oldValue.equals(str) " + !oldValue.equals(str));
     if ((oldValue == null) || !oldValue.equals(str)) {
-      mill.constants.DebugLog.println("Files.write " + daemonDir.resolve(DaemonFiles.terminfo));
       Files.write(daemonDir.resolve(DaemonFiles.terminfo), str.getBytes());
     }
   }
@@ -381,7 +376,6 @@ public class MillProcessLauncher {
   public static void prepareMillRunFolder(Path daemonDir) throws Exception {
     // Clear out run-related files from the server folder to make sure we
     // never hit issues where we are reading the files from a previous run
-    mill.constants.DebugLog.println("Files.deleteIfExists " + daemonDir.resolve(DaemonFiles.terminfo));
     Files.deleteIfExists(daemonDir.resolve(DaemonFiles.terminfo));
 
     Path sandbox = daemonDir.resolve(DaemonFiles.sandbox);

--- a/runner/launcher/src/mill/launcher/MillProcessLauncher.java
+++ b/runner/launcher/src/mill/launcher/MillProcessLauncher.java
@@ -39,7 +39,6 @@ public class MillProcessLauncher {
     boolean interrupted = false;
 
     try {
-      MillProcessLauncher.prepareMillRunFolder(processDir);
       Process p = configureRunMillProcess(builder, processDir);
       return p.waitFor();
 
@@ -75,6 +74,7 @@ public class MillProcessLauncher {
 
     Path sandbox = daemonDir.resolve(DaemonFiles.sandbox);
     Files.createDirectories(sandbox);
+    MillProcessLauncher.prepareMillRunFolder(daemonDir);
     builder.environment().put(EnvVars.MILL_WORKSPACE_ROOT, new File("").getCanonicalPath());
     if (System.getenv(EnvVars.MILL_EXECUTABLE_PATH) == null)
       builder.environment().put(EnvVars.MILL_EXECUTABLE_PATH, getExecutablePath());

--- a/runner/server/test/src/mill/server/ClientServerTests.scala
+++ b/runner/server/test/src/mill/server/ClientServerTests.scala
@@ -106,8 +106,6 @@ object ClientServerTests extends TestSuite {
         Optional.of(memoryLock),
         forceFailureForTestingMillisDelay
       ) {
-        def prepareDaemonDir(daemonDir: Path) = { /*do nothing*/ }
-
         def initServer(daemonDir: Path, locks: Locks) = {
           nextServerId += 1
           // Use a negative process ID to indicate we're not a real process.


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/5637

The basic problem was that `prepareMillRunFolder` gets called via `MillServerLauncher#run` and `prepareDaemonDir`, which can end up calling it twice when the daemon restarts since we call `.run` twice in `MillLauncherMain`. But `memoizedTerminalDims` gets set the first time and not cleared, and so the second time `prepareMillRunFolder` gets run it deletes the old `terminfo` file but thinks the dimensions are unchanged (v.s. the `memoizedTerminalDims`) and so does not write a new one

The fix is to move `prepareMillRunFolder` into `configureRunMillProcess`, so it only gets called when we actually spawn the Mill daemon process, which should only happen once per launcher. This also lets us remove `prepareDaemonDir` and simplify things overall