### PR TITLE
Remove `private[mill]` annotations from non-public submodule

### DIFF
--- a/core/eval/src/mill/eval/EvaluatorImpl.scala
+++ b/core/eval/src/mill/eval/EvaluatorImpl.scala
@@ -21,11 +21,11 @@ import mill.resolve.{ParseArgs, Resolve}
  * As well as [[evaluate]] which does all of these phases one after another
  */
 
-final class EvaluatorImpl private[mill] (
-    private[mill] val allowPositionalCommandArgs: Boolean,
-    private[mill] val selectiveExecution: Boolean,
+final class EvaluatorImpl(
+    val allowPositionalCommandArgs: Boolean,
+    val selectiveExecution: Boolean,
     private val execution: Execution,
-    private[mill] override val scriptModuleInit: (
+    override val scriptModuleInit: (
         String,
         Evaluator
     ) => Seq[Result[ExternalModule]]
@@ -40,15 +40,15 @@ final class EvaluatorImpl private[mill] (
     )
   override val staticBuildOverrides = execution.staticBuildOverrides
 
-  private[mill] def workspace = execution.workspace
-  private[mill] def baseLogger = execution.baseLogger
-  private[mill] def outPath = execution.outPath
-  private[mill] def codeSignatures = execution.codeSignatures
-  private[mill] def rootModule = execution.rootModule.asInstanceOf[RootModule0]
-  private[mill] def workerCache = execution.workerCache
-  private[mill] def env = execution.env
-  private[mill] def effectiveThreadCount = execution.effectiveThreadCount
-  override private[mill] def offline: Boolean = execution.offline
+  def workspace = execution.workspace
+  def baseLogger = execution.baseLogger
+  def outPath = execution.outPath
+  def codeSignatures = execution.codeSignatures
+  def rootModule = execution.rootModule.asInstanceOf[RootModule0]
+  def workerCache = execution.workerCache
+  def env = execution.env
+  def effectiveThreadCount = execution.effectiveThreadCount
+  override def offline: Boolean = execution.offline
 
   def withBaseLogger(newBaseLogger: Logger): Evaluator = new EvaluatorImpl(
     allowPositionalCommandArgs,

--- a/core/eval/src/mill/eval/SelectiveExecutionImpl.scala
+++ b/core/eval/src/mill/eval/SelectiveExecutionImpl.scala
@@ -9,7 +9,7 @@ import mill.exec.{CodeSigUtils, Execution, PlanImpl}
 import mill.internal.SpanningForest
 import mill.internal.SpanningForest.breadthFirst
 
-private[mill] class SelectiveExecutionImpl(evaluator: Evaluator)
+class SelectiveExecutionImpl(evaluator: Evaluator)
     extends mill.api.SelectiveExecution {
 
   def computeHashCodeSignatures(

--- a/core/exec/src/mill/exec/CodeSigUtils.scala
+++ b/core/exec/src/mill/exec/CodeSigUtils.scala
@@ -6,7 +6,7 @@ import mill.api.{Task, Segment}
 import scala.reflect.NameTransformer.encode
 import java.lang.reflect.Method
 
-private[mill] object CodeSigUtils {
+object CodeSigUtils {
   def precomputeMethodNamesPerClass(transitiveNamed: Seq[Task.Named[?]])
       : (Map[Class[?], IndexedSeq[Class[?]]], Map[Class[?], Map[String, Method]]) = {
 

--- a/core/exec/src/mill/exec/Execution.scala
+++ b/core/exec/src/mill/exec/Execution.scala
@@ -13,7 +13,7 @@ import scala.concurrent.*
 /**
  * Core logic of evaluating tasks, without any user-facing helper methods
  */
-private[mill] case class Execution(
+case class Execution(
     baseLogger: Logger,
     profileLogger: JsonArrayLogger.Profile,
     workspace: os.Path,
@@ -347,7 +347,7 @@ private[mill] case class Execution(
   }
 }
 
-private[mill] object Execution {
+object Execution {
 
   /**
    * Format a failed count as a string to be used in status messages.

--- a/core/exec/src/mill/exec/PlanImpl.scala
+++ b/core/exec/src/mill/exec/PlanImpl.scala
@@ -4,7 +4,7 @@ import mill.api.{Plan, Task}
 import mill.api.MultiBiMap
 import mill.api.TopoSorted
 
-private[mill] object PlanImpl {
+object PlanImpl {
   def plan(goals: Seq[Task[?]]): Plan = {
     val transitive = PlanImpl.transitiveTasks(goals.toIndexedSeq)
     val goalSet = goals.toSet

--- a/core/internal/src/mill/internal/AnsiNav.scala
+++ b/core/internal/src/mill/internal/AnsiNav.scala
@@ -3,7 +3,7 @@ package mill.internal
 import java.io.Writer
 
 // Reference https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797
-private[mill] class AnsiNav(output: Writer) {
+class AnsiNav(output: Writer) {
   def control(n: Int, c: Char): Unit = output.write(AnsiNav.control(n, c))
 
   /**
@@ -45,7 +45,7 @@ private[mill] class AnsiNav(output: Writer) {
   def clearLine(n: Int): Unit = output.write(AnsiNav.clearLine(n))
 }
 
-private[mill] object AnsiNav {
+object AnsiNav {
   def control(n: Int, c: Char): String = "\u001b[" + n + c
   def up(n: Int): String = if (n != 0) control(n, 'A') else ""
   def down(n: Int): String = if (n != 0) control(n, 'B') else ""

--- a/core/internal/src/mill/internal/Colors.scala
+++ b/core/internal/src/mill/internal/Colors.scala
@@ -1,7 +1,7 @@
 package mill.internal
 
-private[mill] case class Colors(info: fansi.Attrs, warn: fansi.Attrs, error: fansi.Attrs)
-private[mill] object Colors {
+case class Colors(info: fansi.Attrs, warn: fansi.Attrs, error: fansi.Attrs)
+object Colors {
   object Default extends Colors(fansi.Color.Blue, fansi.Color.Yellow, fansi.Color.Red)
   object BlackWhite extends Colors(fansi.Attrs.Empty, fansi.Attrs.Empty, fansi.Attrs.Empty)
 }

--- a/core/internal/src/mill/internal/FileLogger.scala
+++ b/core/internal/src/mill/internal/FileLogger.scala
@@ -5,7 +5,7 @@ import mill.api.BuildCtx
 import java.io.{OutputStream, PrintStream}
 import java.nio.file.{Files, StandardOpenOption}
 
-private[mill] class FileLogger(
+class FileLogger(
     file: os.Path,
     append: Boolean = false
 ) extends Logger with AutoCloseable {

--- a/core/internal/src/mill/internal/JsonArrayLogger.scala
+++ b/core/internal/src/mill/internal/JsonArrayLogger.scala
@@ -4,7 +4,7 @@ import java.io.{BufferedOutputStream, PrintStream}
 import java.nio.file.{Files, StandardOpenOption}
 import java.util.concurrent.ArrayBlockingQueue
 
-private[mill] class JsonArrayLogger[T: upickle.Writer](outPath: os.Path, indent: Int) {
+class JsonArrayLogger[T: upickle.Writer](outPath: os.Path, indent: Int) {
   private var used = false
 
   @volatile var closed = false
@@ -64,9 +64,9 @@ private[mill] class JsonArrayLogger[T: upickle.Writer](outPath: os.Path, indent:
   }
 }
 
-private[mill] object JsonArrayLogger {
+object JsonArrayLogger {
 
-  private[mill] class Profile(outPath: os.Path)
+  class Profile(outPath: os.Path)
       extends JsonArrayLogger[Profile.Timing](outPath, indent = 2) {
     def log(
         terminal: String,
@@ -107,7 +107,7 @@ private[mill] object JsonArrayLogger {
     }
   }
 
-  private[mill] class ChromeProfile(outPath: os.Path)
+  class ChromeProfile(outPath: os.Path)
       extends JsonArrayLogger[ChromeProfile.TraceEvent](outPath, indent = -1) {
 
     def logBegin(

--- a/core/internal/src/mill/internal/LineBufferingOutputStream.scala
+++ b/core/internal/src/mill/internal/LineBufferingOutputStream.scala
@@ -10,7 +10,7 @@ import java.io.{ByteArrayOutputStream, OutputStream}
  * @param linePrefix The function to provide the prefix.
  * @param out The underlying output stream.
  */
-private[mill] class LineBufferingOutputStream(onLineComplete: ByteArrayOutputStream => Unit)
+class LineBufferingOutputStream(onLineComplete: ByteArrayOutputStream => Unit)
     extends OutputStream {
 
   val buffer = new ByteArrayOutputStream()

--- a/core/internal/src/mill/internal/MultiLogger.scala
+++ b/core/internal/src/mill/internal/MultiLogger.scala
@@ -4,7 +4,7 @@ import mill.api.{Logger, SystemStreams}
 
 import java.io.{InputStream, PrintStream, ByteArrayOutputStream}
 
-private[mill] class MultiLogger(
+class MultiLogger(
     val logger1: Logger,
     val logger2: Logger,
     val inStream0: InputStream
@@ -16,7 +16,7 @@ private[mill] class MultiLogger(
     inStream0
   )
 
-  private[mill] override lazy val unprefixedStreams: SystemStreams = new SystemStreams(
+  override lazy val unprefixedStreams: SystemStreams = new SystemStreams(
     new MultiStream(logger1.unprefixedStreams.out, logger2.unprefixedStreams.out),
     new MultiStream(logger1.unprefixedStreams.err, logger2.unprefixedStreams.err),
     inStream0
@@ -46,7 +46,7 @@ private[mill] class MultiLogger(
       logger2.prompt.setPromptDetail(key, s)
     }
 
-    private[mill] override def setPromptLine(
+    override def setPromptLine(
         key: Seq[String],
         keySuffix: String,
         message: String
@@ -55,7 +55,7 @@ private[mill] class MultiLogger(
       logger2.prompt.setPromptLine(key, keySuffix, message)
     }
 
-    private[mill] override def logPrefixedLine(
+    override def logPrefixedLine(
         key: Seq[String],
         logMsg: ByteArrayOutputStream,
         logToOut: Boolean
@@ -64,26 +64,26 @@ private[mill] class MultiLogger(
       logger2.prompt.logPrefixedLine(key, logMsg, logToOut)
     }
 
-    private[mill] override def clearPromptStatuses(): Unit = {
+    override def clearPromptStatuses(): Unit = {
       logger1.prompt.clearPromptStatuses()
       logger2.prompt.clearPromptStatuses()
     }
 
-    private[mill] override def removePromptLine(key: Seq[String], message: String): Unit = {
+    override def removePromptLine(key: Seq[String], message: String): Unit = {
       logger1.prompt.removePromptLine(key, message)
       logger2.prompt.removePromptLine(key, message)
     }
 
-    private[mill] override def setPromptHeaderPrefix(s: String): Unit = {
+    override def setPromptHeaderPrefix(s: String): Unit = {
       logger1.prompt.setPromptHeaderPrefix(s)
       logger2.prompt.setPromptHeaderPrefix(s)
     }
 
-    private[mill] override def withPromptPaused[T](t: => T): T = {
+    override def withPromptPaused[T](t: => T): T = {
       logger1.prompt.withPromptPaused(logger2.prompt.withPromptPaused(t))
     }
 
-    private[mill] override def withPromptUnpaused[T](t: => T): T = {
+    override def withPromptUnpaused[T](t: => T): T = {
       logger1.prompt.withPromptUnpaused(logger2.prompt.withPromptUnpaused(t))
     }
 
@@ -99,22 +99,22 @@ private[mill] class MultiLogger(
       logger1.prompt.errorColor(logger2.prompt.errorColor(s))
     override def colored: Boolean = logger1.prompt.colored || logger2.prompt.colored
 
-    override private[mill] def beginChromeProfileEntry(text: String): Unit = {
+    override def beginChromeProfileEntry(text: String): Unit = {
       logger1.prompt.beginChromeProfileEntry(text)
       logger2.prompt.beginChromeProfileEntry(text)
     }
 
-    override private[mill] def endChromeProfileEntry(): Unit = {
+    override def endChromeProfileEntry(): Unit = {
       logger1.prompt.endChromeProfileEntry()
       logger2.prompt.endChromeProfileEntry()
     }
 
-    override private[mill] def logBeginChromeProfileEntry(message: String, nanoTime: Long) = {
+    override def logBeginChromeProfileEntry(message: String, nanoTime: Long) = {
       logger1.prompt.logBeginChromeProfileEntry(message, nanoTime)
       logger2.prompt.logBeginChromeProfileEntry(message, nanoTime)
     }
 
-    override private[mill] def logEndChromeProfileEntry(nanoTime: Long) = {
+    override def logEndChromeProfileEntry(nanoTime: Long) = {
       logger1.prompt.logEndChromeProfileEntry(nanoTime)
       logger2.prompt.logEndChromeProfileEntry(nanoTime)
     }
@@ -124,11 +124,11 @@ private[mill] class MultiLogger(
     logger2.debug(s)
   }
 
-  private[mill] override def logKey = logger1.logKey ++ logger2.logKey
+  override def logKey = logger1.logKey ++ logger2.logKey
 
-  private[mill] override def message = logger1.message ++ logger2.message
+  override def message = logger1.message ++ logger2.message
 
-  private[mill] override def keySuffix = logger1.keySuffix ++ logger2.keySuffix
+  override def keySuffix = logger1.keySuffix ++ logger2.keySuffix
 
   override def redirectOutToErr: Boolean = logger1.redirectOutToErr || logger1.redirectOutToErr
   override def withRedirectOutToErr() = new MultiLogger(

--- a/core/internal/src/mill/internal/MultiStream.scala
+++ b/core/internal/src/mill/internal/MultiStream.scala
@@ -1,6 +1,6 @@
 package mill.internal
 import java.io.{OutputStream, PrintStream}
-private[mill] class MultiStream(stream1: OutputStream, stream2: OutputStream)
+class MultiStream(stream1: OutputStream, stream2: OutputStream)
     extends PrintStream(new OutputStream {
       def write(b: Int): Unit = {
         stream1.write(b)

--- a/core/internal/src/mill/internal/PipeStreams.scala
+++ b/core/internal/src/mill/internal/PipeStreams.scala
@@ -9,7 +9,7 @@ import java.io.{IOException, InputStream, OutputStream}
  * somewhat cleaned up as a single object rather than two loose objects you have
  * to connect together.
  */
-private[mill] class PipeStreams(val bufferSize: Int = 1024) { pipe =>
+class PipeStreams(val bufferSize: Int = 1024) { pipe =>
 
   private var closedByWriter = false
   @volatile private var closedByReader = false

--- a/core/internal/src/mill/internal/PrefixLogger.scala
+++ b/core/internal/src/mill/internal/PrefixLogger.scala
@@ -18,7 +18,7 @@ import java.io.PrintStream
  *
  * [$parentKeys-$key0] $message
  */
-private[mill] case class PrefixLogger(
+case class PrefixLogger(
     logger0: Logger,
     key0: Seq[String],
     override val keySuffix: String = "",
@@ -34,7 +34,7 @@ private[mill] case class PrefixLogger(
     case None => logger0.redirectOutToErr
     case Some(b) => b
   }
-  private[mill] override val logKey = logger0.logKey ++ key0
+  override val logKey = logger0.logKey ++ key0
 
   assert(key0.forall(_.nonEmpty))
   val linePrefix: String = Logger.formatPrefix(
@@ -55,7 +55,7 @@ private[mill] case class PrefixLogger(
     logger0.streams.in
   )
 
-  private[mill] override val unprefixedStreams = new SystemStreams(
+  override val unprefixedStreams = new SystemStreams(
     if (redirectOutToErr) logger0.unprefixedStreams.err else logger0.unprefixedStreams.out,
     logger0.unprefixedStreams.err,
     logger0.unprefixedStreams.in

--- a/core/internal/src/mill/internal/PromptLogger.scala
+++ b/core/internal/src/mill/internal/PromptLogger.scala
@@ -16,7 +16,7 @@ import java.io.*
  * [[streams]] are *not* synchronized, and instead goes into a [[PipeStreams]]
  * buffer to be read out and handled asynchronously.
  */
-private[mill] class PromptLogger(
+class PromptLogger(
     colored: Boolean,
     enableTicker: Boolean,
     infoColor: fansi.Attrs,
@@ -104,15 +104,15 @@ private[mill] class PromptLogger(
 
   object prompt extends Logger.Prompt {
 
-    private[mill] def beginChromeProfileEntry(text: String): Unit = {
+    def beginChromeProfileEntry(text: String): Unit = {
       logBeginChromeProfileEntry(text, System.nanoTime())
     }
 
-    private[mill] def endChromeProfileEntry(): Unit = {
+    def endChromeProfileEntry(): Unit = {
       logEndChromeProfileEntry(System.nanoTime())
     }
 
-    override private[mill] def logBeginChromeProfileEntry(message: String, nanoTime: Long) = {
+    override def logBeginChromeProfileEntry(message: String, nanoTime: Long) = {
       chromeProfileLogger.logBegin(
         message,
         "job",
@@ -121,7 +121,7 @@ private[mill] class PromptLogger(
       )
     }
 
-    override private[mill] def logEndChromeProfileEntry(nanoTime: Long) = {
+    override def logEndChromeProfileEntry(nanoTime: Long) = {
       chromeProfileLogger.logEnd(
         nanoTime / 1000,
         threadNumberer.getThreadId(Thread.currentThread())
@@ -259,10 +259,10 @@ private[mill] class PromptLogger(
         seenIdentifiers(key) = (keySuffix, message)
       }
 
-    private[mill] override def withPromptPaused[T](t: => T): T =
+    override def withPromptPaused[T](t: => T): T =
       runningState.withPromptPaused0(true, t)
 
-    private[mill] override def withPromptUnpaused[T](t: => T): T =
+    override def withPromptUnpaused[T](t: => T): T =
       runningState.withPromptPaused0(false, t)
 
     def enableTicker = PromptLogger.this.enableTicker
@@ -303,7 +303,7 @@ private[mill] class PromptLogger(
   def streams = streamManager.proxySystemStreams
 }
 
-private[mill] object PromptLogger {
+object PromptLogger {
 
   /**
    * Manages the paused/unpaused/stopped state of the prompt logger. Encapsulate in a separate

--- a/core/internal/src/mill/internal/PromptLoggerUtil.scala
+++ b/core/internal/src/mill/internal/PromptLoggerUtil.scala
@@ -5,15 +5,15 @@ import scala.annotation.switch
 
 private object PromptLoggerUtil {
 
-  private[mill] val defaultTermWidth = 99
-  private[mill] val defaultTermHeight = 25
+  val defaultTermWidth = 99
+  val defaultTermHeight = 25
 
   /**
    * How often to update the multiline status prompt on the terminal.
    * Too frequent is bad because it causes a lot of visual noise,
    * but too infrequent results in latency. 10 times per second seems reasonable
    */
-  private[mill] val promptUpdateIntervalMillis = 100
+  val promptUpdateIntervalMillis = 100
 
   /**
    * How often to update the multiline status prompt in non-interactive scenarios,
@@ -23,7 +23,7 @@ private object PromptLoggerUtil {
    * the logs, but we still want to print it occasionally so people can debug stuck
    * background or CI jobs and see what tasks it is running when stuck
    */
-  private[mill] val nonInteractivePromptUpdateIntervalMillis = 60000
+  val nonInteractivePromptUpdateIntervalMillis = 60000
 
   /**
    * Add some extra latency delay to the process of removing an entry from the status
@@ -41,14 +41,14 @@ private object PromptLoggerUtil {
    */
   val statusRemovalRemoveDelayMillis = 2000
 
-  private[mill] case class StatusEntry(text: String, startTimeMillis: Long, detail: String = "")
+  case class StatusEntry(text: String, startTimeMillis: Long, detail: String = "")
 
   /**
    * Represents a line in the prompt. Stores up to two separate [[StatusEntry]]s, because
    * we want to buffer up status transitions to debounce them. Which status entry is currently
    * shown depends on the [[beginTransitionTime]] and other heuristics
    */
-  private[mill] case class Status(
+  case class Status(
       next: Option[StatusEntry],
       beginTransitionTime: Long,
       prev: Option[StatusEntry]
@@ -59,7 +59,7 @@ private object PromptLoggerUtil {
    * and down via `\n` to have a "fresh" line. This only should get called to clear the prompt, so
    * the cursor is already at the left-most column, which '\n' will not change.
    */
-  private[mill] val clearScreenToEndBytes: Array[Byte] =
+  val clearScreenToEndBytes: Array[Byte] =
     (AnsiNav.clearScreen(0) + AnsiNav.up(1) + "\n").getBytes
 
   def spaceNonEmpty(s: String) = if (s.isEmpty) "" else s" $s"
@@ -207,7 +207,7 @@ private object PromptLoggerUtil {
     ???
   }
 
-  private[mill] val seqStringOrdering = new Ordering[Seq[String]] {
+  val seqStringOrdering = new Ordering[Seq[String]] {
     def compare(xs: Seq[String], ys: Seq[String]): Int = {
       val iter = xs.iterator.zip(ys)
       while (iter.nonEmpty) {

--- a/core/internal/src/mill/internal/ProxyLogger.scala
+++ b/core/internal/src/mill/internal/ProxyLogger.scala
@@ -6,7 +6,7 @@ import mill.api.{Logger, SystemStreams}
  * A Logger that forwards all logging to another Logger.  Intended to be
  * used as a base class for wrappers that modify logging behavior.
  */
-private[mill] class ProxyLogger(logger: Logger) extends Logger {
+class ProxyLogger(logger: Logger) extends Logger {
   override def toString: String = s"ProxyLogger($logger)"
 
   lazy val streams = logger.streams
@@ -19,8 +19,8 @@ private[mill] class ProxyLogger(logger: Logger) extends Logger {
 
   def prompt = logger.prompt
 
-  private[mill] override def logKey: Seq[String] = logger.logKey
-  private[mill] override def unprefixedStreams: SystemStreams = logger.unprefixedStreams
+  override def logKey: Seq[String] = logger.logKey
+  override def unprefixedStreams: SystemStreams = logger.unprefixedStreams
 
   override def redirectOutToErr: Boolean = logger.redirectOutToErr
 

--- a/core/internal/src/mill/internal/SimpleLogger.scala
+++ b/core/internal/src/mill/internal/SimpleLogger.scala
@@ -4,7 +4,7 @@ import mill.api.{SystemStreams, Logger}
 
 import java.io.PrintStream
 
-private[mill] class SimpleLogger(
+class SimpleLogger(
     override val unprefixedStreams: SystemStreams,
     override val logKey: Seq[String],
     debugEnabled: Boolean

--- a/core/internal/src/mill/internal/SpanningForest.scala
+++ b/core/internal/src/mill/internal/SpanningForest.scala
@@ -12,7 +12,7 @@ import scala.collection.mutable
  * Returns the forest as a [[Node]] structure with the top-level node containing
  * the roots of the forest
  */
-private[mill] object SpanningForest {
+object SpanningForest {
 
   def graphMapToIndices[T](
       vertices: Iterable[T],

--- a/core/internal/src/mill/internal/Tarjans.scala
+++ b/core/internal/src/mill/internal/Tarjans.scala
@@ -4,7 +4,7 @@ import scala.collection.mutable
 
 // Adapted from
 // https://github.com/indy256/codelibrary/blob/c52247216258e84aac442a23273b7d8306ef757b/java/src/SCCTarjan.java
-private[mill] object Tarjans {
+object Tarjans {
   def apply(graph: IndexedSeq[Array[Int]]): Array[Array[Int]] = {
     val n = graph.length
     val visited = new Array[Boolean](n)

--- a/core/internal/src/mill/internal/Util.scala
+++ b/core/internal/src/mill/internal/Util.scala
@@ -4,7 +4,7 @@ import scala.reflect.NameTransformer.encode
 import mill.api.Result
 import mill.api.ModuleCtx.HeaderData
 
-private[mill] object Util {
+object Util {
 
   val alphaKeywords: Set[String] = Set(
     "abstract",
@@ -60,7 +60,7 @@ private[mill] object Util {
       else "`" + s + "`"
   }
 
-  private[mill] def parseHeaderData(scriptFile: os.Path): Result[HeaderData] = {
+  def parseHeaderData(scriptFile: os.Path): Result[HeaderData] = {
     val headerDataOpt = mill.api.BuildCtx.withFilesystemCheckerDisabled {
       // If the module file got deleted, handle that gracefully
       if (!os.exists(scriptFile)) Result.Success("")

--- a/core/resolve/src/mill/resolve/ParseArgs.scala
+++ b/core/resolve/src/mill/resolve/ParseArgs.scala
@@ -7,7 +7,7 @@ import mill.api.{Segment, Segments, SelectMode}
 
 import scala.annotation.tailrec
 
-private[mill] object ParseArgs {
+object ParseArgs {
 
   type TasksWithParams = (Seq[(Option[Segments], Option[Segments])], Seq[String])
 

--- a/core/resolve/src/mill/resolve/Resolve.scala
+++ b/core/resolve/src/mill/resolve/Resolve.scala
@@ -15,9 +15,9 @@ import mill.api.{
 }
 import mill.resolve.ResolveCore.makeResultException
 
-private[mill] object Resolve {
+object Resolve {
   object Segments extends Resolve[Segments] {
-    private[mill] def handleResolved(
+    def handleResolved(
         rootModule: RootModule0,
         resolved: Seq[Resolved],
         args: Seq[String],
@@ -30,11 +30,11 @@ private[mill] object Resolve {
       Result.Success(resolved.map(_.fullSegments))
     }
 
-    private[mill] override def deduplicate(items: List[Segments]): List[Segments] = items.distinct
+    override def deduplicate(items: List[Segments]): List[Segments] = items.distinct
   }
 
   object Raw extends Resolve[Resolved] {
-    private[mill] def handleResolved(
+    def handleResolved(
         rootModule: RootModule0,
         resolved: Seq[Resolved],
         args: Seq[String],
@@ -47,11 +47,11 @@ private[mill] object Resolve {
       Result.Success(resolved)
     }
 
-    private[mill] override def deduplicate(items: List[Resolved]): List[Resolved] = items.distinct
+    override def deduplicate(items: List[Resolved]): List[Resolved] = items.distinct
   }
 
   object Inspect extends Resolve[Either[Module, Task.Named[Any]]] {
-    private[mill] def handleResolved(
+    def handleResolved(
         rootModule: RootModule0,
         resolved: Seq[Resolved],
         args: Seq[String],
@@ -146,7 +146,7 @@ private[mill] object Resolve {
         }
 
     }
-    private[mill] def handleResolved(
+    def handleResolved(
         rootModule: RootModule0,
         resolved: Seq[Resolved],
         args: Seq[String],
@@ -174,7 +174,7 @@ private[mill] object Resolve {
       )
     }
 
-    private[mill] override def deduplicate(items: List[Task.Named[Any]]): List[Task.Named[Any]] =
+    override def deduplicate(items: List[Task.Named[Any]]): List[Task.Named[Any]] =
       items.distinctBy(_.ctx.segments)
   }
 
@@ -292,8 +292,8 @@ private[mill] object Resolve {
   }
 }
 
-private[mill] trait Resolve[T] {
-  private[mill] def handleResolved(
+trait Resolve[T] {
+  def handleResolved(
       rootModule: RootModule0,
       resolved: Seq[Resolved],
       args: Seq[String],
@@ -304,7 +304,7 @@ private[mill] trait Resolve[T] {
       cache: ResolveCore.Cache
   ): Result[Seq[T]]
 
-  private[mill] def resolve(
+  def resolve(
       rootModule: RootModule0,
       scriptArgs: Seq[String],
       selectMode: SelectMode,
@@ -375,7 +375,7 @@ private[mill] trait Resolve[T] {
     Result.sequence(resolvedGroups).map(_.flatten.toList).map(deduplicate)
   }
 
-  private[mill] def resolveNonEmptyAndHandle(
+  def resolveNonEmptyAndHandle(
       args: Seq[String],
       rootModule: RootModule0,
       sel: Segments,
@@ -395,7 +395,7 @@ private[mill] trait Resolve[T] {
       resolveNonEmptyAndHandle1(rootModule, sel, cache)
     )
   }
-  private[mill] def resolveNonEmptyAndHandle1(
+  def resolveNonEmptyAndHandle1(
       rootModule: RootModule0,
       sel: Segments,
       cache: ResolveCore.Cache
@@ -411,7 +411,7 @@ private[mill] trait Resolve[T] {
     )
   }
 
-  private[mill] def resolveNonEmptyAndHandle2(
+  def resolveNonEmptyAndHandle2(
       rootModule: RootModule0,
       args: Seq[String],
       sel: Segments,
@@ -459,9 +459,9 @@ private[mill] trait Resolve[T] {
     }
   }
 
-  private[mill] def deduplicate(items: List[T]): List[T] = items
+  def deduplicate(items: List[T]): List[T] = items
 
-  private[mill] def resolveRootModule(
+  def resolveRootModule(
       rootModule: RootModule0,
       scopedSel: Option[Segments]
   ): Result[RootModule0] = {

--- a/integration/bsp-util/src/BspServerTestUtil.scala
+++ b/integration/bsp-util/src/BspServerTestUtil.scala
@@ -16,7 +16,7 @@ import scala.reflect.ClassTag
 
 object BspServerTestUtil {
 
-  private[mill] def bsp4jVersion: String = sys.props.getOrElse("BSP4J_VERSION", ???)
+  def bsp4jVersion: String = sys.props.getOrElse("BSP4J_VERSION", ???)
 
   trait TestBuildClient extends b.BuildClient {
     // Whether to check the validity of some messages

--- a/runner/bsp/src/mill/bsp/BSP.scala
+++ b/runner/bsp/src/mill/bsp/BSP.scala
@@ -5,7 +5,7 @@ import mill.api.BuildCtx
 
 import java.io.PrintStream
 
-private[mill] object BSP {
+object BSP {
 
   /**
    * Installs the mill-bsp server. It creates a json file

--- a/runner/bsp/src/mill/bsp/Constants.scala
+++ b/runner/bsp/src/mill/bsp/Constants.scala
@@ -1,7 +1,7 @@
 package mill.bsp
 
 import os.SubPath
-private[mill] object Constants {
+object Constants {
   val bspDir: SubPath = os.sub / ".bsp"
   val bspProtocolVersion = BuildInfo.bsp4jVersion
   val bspWorkerImplClass = "mill.bsp.worker.BspWorkerImpl"

--- a/runner/bsp/worker/src/mill/bsp/worker/BspClientType.scala
+++ b/runner/bsp/worker/src/mill/bsp/worker/BspClientType.scala
@@ -1,7 +1,7 @@
 package mill.bsp.worker
 
 /** Used to handle edge cases for specific BSP clients. */
-private[mill] enum BspClientType {
+enum BspClientType {
 
   /** Intellij IDEA */
   case IntellijBSP

--- a/runner/bsp/worker/src/mill/bsp/worker/BspEvaluators.scala
+++ b/runner/bsp/worker/src/mill/bsp/worker/BspEvaluators.scala
@@ -17,7 +17,7 @@ import java.nio.file.Path
 import java.util.concurrent.ConcurrentHashMap
 import scala.jdk.CollectionConverters._
 
-private[mill] class BspEvaluators(
+class BspEvaluators(
     workspaceDir: os.Path,
     val evaluators: Seq[EvaluatorApi],
     debug: (() => String) => Unit,

--- a/runner/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/runner/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -982,7 +982,7 @@ private class MillBuildServer(
       requestCount0,
       new PrefixLogger(
         new ProxyLogger(baseLogger) {
-          override private[mill] def logKey: Seq[String] = {
+          override def logKey: Seq[String] = {
             val logKey0 = super.logKey
             if (logKey0.startsWith(Seq("bsp"))) logKey0.drop(1)
             else logKey0
@@ -1089,7 +1089,7 @@ private object MillBuildServer {
       d.javaVersion.foreach(jv => it.setJavaVersion(jv))
     }
 
-  private[mill] def enclosingRequestName(using enclosing: sourcecode.Enclosing): String = {
+  def enclosingRequestName(using enclosing: sourcecode.Enclosing): String = {
     // enclosing.value typically looks like "mill.bsp.worker.MillBuildServer#buildTargetCompile logger"
     // First, try to isolate the part with the BSP request name
     var name0 = enclosing.value.split(" ") match {

--- a/runner/bsp/worker/src/mill/bsp/worker/Utils.scala
+++ b/runner/bsp/worker/src/mill/bsp/worker/Utils.scala
@@ -17,7 +17,7 @@ import scala.jdk.CollectionConverters.*
 import scala.util.chaining.scalaUtilChainingOps
 import mill.api.daemon.internal.bsp.{BspBuildTarget, BspModuleApi}
 
-private[mill] object Utils {
+object Utils {
 
   def sanitizeUri(uri: String): String =
     if (uri.endsWith("/")) sanitizeUri(uri.substring(0, uri.length - 1)) else uri

--- a/runner/daemon/src/mill/daemon/MillMain0.scala
+++ b/runner/daemon/src/mill/daemon/MillMain0.scala
@@ -553,7 +553,7 @@ object MillMain0 {
     bspServerHandleRes
   }
 
-  private[mill] def parseThreadCount(
+  def parseThreadCount(
       threadCountRaw: Option[String],
       availableCores: Int
   ): Result[Int] = {

--- a/runner/meta/src/mill/meta/CliImports.scala
+++ b/runner/meta/src/mill/meta/CliImports.scala
@@ -5,4 +5,4 @@ import scala.util.DynamicVariable
 /**
  * Hold additional runtime dependencies given via the `--import` cli option.
  */
-private[mill] object CliImports extends DynamicVariable[Seq[String]](Seq.empty)
+object CliImports extends DynamicVariable[Seq[String]](Seq.empty)

--- a/runner/meta/src/mill/meta/MillBuildRootModule.scala
+++ b/runner/meta/src/mill/meta/MillBuildRootModule.scala
@@ -55,7 +55,7 @@ trait MillBuildRootModule()(using
     .mkString("/")
 
   override def moduleDir: os.Path = rootModuleInfo.projectRoot / os.up / millBuild
-  private[mill] override def intellijModulePathJava: Path = (moduleDir / os.up).toNIO
+  override def intellijModulePathJava: Path = (moduleDir / os.up).toNIO
 
   override def scalaVersion: T[String] = BuildInfo.scalaVersion
 


### PR DESCRIPTION
This submodules are already not part of the Mill public API, so `private[mill]` is unnecessary