### PR TITLE
Fix Scala.js link logs in server-client mode

### DIFF
--- a/libs/scalajslib/worker/1/src/mill/scalajslib/worker/ScalaJSWorkerImpl.scala
+++ b/libs/scalajslib/worker/1/src/mill/scalajslib/worker/ScalaJSWorkerImpl.scala
@@ -181,7 +181,7 @@ class ScalaJSWorkerImpl extends ScalaJSWorkerApi {
 
     def awaitFutureWhilePrinting[T](future: Future[T]): T = {
       while ({
-        val message = queue.poll(10, java.util.concurrent.TimeUnit.MILLISECONDS)
+        val message = queue.poll(1, java.util.concurrent.TimeUnit.MILLISECONDS)
         if (message == null) {
           !future.isCompleted
         } else {


### PR DESCRIPTION
The Scala.js toolchain calls the logger functions in a separate thread, which breaks the streams swapping Mill does.
This PR, instead of printing directly to `stderr`, adds the lines to a queue and drains them later from the main thread while waiting for the linking future to complete by polling.
