### PR TITLE
Rename `Config` to `MavenAndGradleCommonConfig` in `BuildGenUtil` to make it clearer

### DIFF
--- a/libs/init/buildgen/src/mill/main/buildgen/BuildGenUtil.scala
+++ b/libs/init/buildgen/src/mill/main/buildgen/BuildGenUtil.scala
@@ -557,15 +557,16 @@ object BuildGenUtil {
   object BasicConfig {
     implicit def parser: mainargs.ParserForClass[BasicConfig] = mainargs.ParserForClass[BasicConfig]
   }
-  // TODO alternative names: `MavenAndGradleConfig`, `MavenAndGradleSharedConfig`
+
+  // TODO other alternative names to consider: `MavenAndGradleConfig`, `MavenAndGradleSharedConfig`
   @mainargs.main
-  case class Config(
+  case class MavenAndGradleCommonConfig(
       basicConfig: BasicConfig,
       @arg(doc = "capture Maven publish properties", short = 'p')
       publishProperties: Flag = Flag()
   )
-
-  object Config {
-    implicit def configParser: mainargs.ParserForClass[Config] = mainargs.ParserForClass[Config]
+  object MavenAndGradleCommonConfig {
+    implicit def configParser: mainargs.ParserForClass[MavenAndGradleCommonConfig] =
+      mainargs.ParserForClass[MavenAndGradleCommonConfig]
   }
 }

--- a/libs/init/gradle/src/mill/main/gradle/GradleBuildGenMain.scala
+++ b/libs/init/gradle/src/mill/main/gradle/GradleBuildGenMain.scala
@@ -229,7 +229,10 @@ object GradleBuildGenMain extends BuildGenBase.MavenAndGradle[ProjectModel, Dep]
     if (null == pom) null else pom.packaging()
   }
 
-  def getPublishProperties(project: ProjectModel, cfg: BuildGenUtil.Config): Seq[(String, String)] =
+  def getPublishProperties(
+      project: ProjectModel,
+      cfg: BuildGenUtil.MavenAndGradleCommonConfig
+  ): Seq[(String, String)] =
     if (cfg.publishProperties.value) {
       val pom = project.maven().pom()
       if (null == pom) Seq.empty
@@ -369,8 +372,8 @@ object GradleBuildGenMain extends BuildGenBase.MavenAndGradle[ProjectModel, Dep]
   @main
   @internal
   case class Config(
-      shared: BuildGenUtil.Config,
-      @arg(doc = "name of Gradle project to extract settings for --base-module", short = 'g')
+                     shared: BuildGenUtil.MavenAndGradleCommonConfig,
+                     @arg(doc = "name of Gradle project to extract settings for --base-module", short = 'g')
       baseProject: Option[String] = None
   )
 

--- a/libs/init/gradle/src/mill/main/gradle/GradleBuildGenMain.scala
+++ b/libs/init/gradle/src/mill/main/gradle/GradleBuildGenMain.scala
@@ -372,8 +372,8 @@ object GradleBuildGenMain extends BuildGenBase.MavenAndGradle[ProjectModel, Dep]
   @main
   @internal
   case class Config(
-                     shared: BuildGenUtil.MavenAndGradleCommonConfig,
-                     @arg(doc = "name of Gradle project to extract settings for --base-module", short = 'g')
+      shared: BuildGenUtil.MavenAndGradleCommonConfig,
+      @arg(doc = "name of Gradle project to extract settings for --base-module", short = 'g')
       baseProject: Option[String] = None
   )
 

--- a/libs/init/maven/src/mill/main/maven/MavenBuildGenMain.scala
+++ b/libs/init/maven/src/mill/main/maven/MavenBuildGenMain.scala
@@ -293,10 +293,10 @@ object MavenBuildGenMain extends BuildGenBase.MavenAndGradle[Model, Dependency] 
   @main
   @internal
   case class Config(
-                     shared: BuildGenUtil.MavenAndGradleCommonConfig,
-                     @arg(doc = "use cache for Maven repository system")
+      shared: BuildGenUtil.MavenAndGradleCommonConfig,
+      @arg(doc = "use cache for Maven repository system")
       cacheRepository: Flag = Flag(),
-                     @arg(doc = "process Maven plugin executions and configurations")
+      @arg(doc = "process Maven plugin executions and configurations")
       processPlugins: Flag = Flag()
   ) extends ModelerConfig
 

--- a/libs/init/maven/src/mill/main/maven/MavenBuildGenMain.scala
+++ b/libs/init/maven/src/mill/main/maven/MavenBuildGenMain.scala
@@ -164,7 +164,10 @@ object MavenBuildGenMain extends BuildGenBase.MavenAndGradle[Model, Dependency] 
       .toSeq
       .sorted
 
-  def getPublishProperties(model: Model, cfg: BuildGenUtil.Config): Seq[(String, String)] =
+  def getPublishProperties(
+      model: Model,
+      cfg: BuildGenUtil.MavenAndGradleCommonConfig
+  ): Seq[(String, String)] =
     if (cfg.publishProperties.value) {
       val props = model.getProperties
       props.stringPropertyNames().iterator().asScala
@@ -290,10 +293,10 @@ object MavenBuildGenMain extends BuildGenBase.MavenAndGradle[Model, Dependency] 
   @main
   @internal
   case class Config(
-      shared: BuildGenUtil.Config,
-      @arg(doc = "use cache for Maven repository system")
+                     shared: BuildGenUtil.MavenAndGradleCommonConfig,
+                     @arg(doc = "use cache for Maven repository system")
       cacheRepository: Flag = Flag(),
-      @arg(doc = "process Maven plugin executions and configurations")
+                     @arg(doc = "process Maven plugin executions and configurations")
       processPlugins: Flag = Flag()
   ) extends ModelerConfig
 


### PR DESCRIPTION
A follow-up of #4586.

Also see the "other alternative names to consider" TODO comment and remove it before merging.