### PR TITLE
Rename `optional` in `BuildGenUtil` to `renderIfArgsNonEmpty` to make it more consistent with the other function names

### DIFF
--- a/libs/init/buildgen/src/mill/main/buildgen/BuildGenUtil.scala
+++ b/libs/init/buildgen/src/mill/main/buildgen/BuildGenUtil.scala
@@ -360,7 +360,12 @@ object BuildGenUtil {
   def renderIfArgsNonEmpty(construct: String, args: IterableOnce[String]): String =
     renderIfArgsNonEmpty(construct + "(", args, ",", ")")
 
-  def renderIfArgsNonEmpty(start: String, args: IterableOnce[String], sep: String, end: String): String = {
+  def renderIfArgsNonEmpty(
+      start: String,
+      args: IterableOnce[String],
+      sep: String,
+      end: String
+  ): String = {
     val itr = args.iterator
     if (itr.isEmpty) ""
     else itr.mkString(start, sep, end)


### PR DESCRIPTION
A follow-up of #4586.

Also see the "more alternative names" TODO comment and remove it before merging.