### PR TITLE
Remove the "filter out Gradle projects without the `java` plugin" TODO

### DIFF
--- a/libs/init/buildgen/src/mill/main/buildgen/BuildGenBase.scala
+++ b/libs/init/buildgen/src/mill/main/buildgen/BuildGenBase.scala
@@ -105,7 +105,6 @@ trait BuildGenBase[M, D, I] {
 object BuildGenBase {
   trait MavenAndGradle[M, D] extends BuildGenBase[M, D, Tree[Node[M]]] {
     override def getModuleTree(input: Tree[Node[M]]): Tree[Node[Option[M]]] =
-      // TODO consider filtering out projects without the `java` plugin applied in Gradle too
       input.map(node => node.copy(value = Some(node.value)))
     override def extraImports: Seq[String] = Seq()
   }


### PR DESCRIPTION
A follow-up of #4586.

This TODO seems incorrect or hard to implement. It seems the root projects of Ehcache 3 and FastCSV can't be filtered out because they contain needed metadata as the default base modules though they don't have the `java` plugin applied. And if we change the default base module selection strategy it looks like some extra work and also introduces breaking changes. See commit 8323a7d540fad585f4f7f7230434a0acff41afc1 for more details.