### PR TITLE
Replace Yoda conditions

### DIFF
--- a/libs/init/buildgen/src/mill/main/buildgen/BuildGenUtil.scala
+++ b/libs/init/buildgen/src/mill/main/buildgen/BuildGenUtil.scala
@@ -219,7 +219,7 @@ object BuildGenUtil {
 
       childCompanions.foreach { case entry @ (objectName, childConstants) =>
         val parentConstants = mergedParentCompanions.getOrElse(objectName, null)
-        if (null == parentConstants) mergedParentCompanions += entry
+        if (parentConstants == null) mergedParentCompanions += entry
         else {
           if (childConstants.exists { case (k, v) => v != parentConstants.getOrElse(k, v) })
             boundary.break(null)
@@ -237,7 +237,7 @@ object BuildGenUtil {
       children.iterator.foreach {
         case child @ Tree(Node(_ :+ dir, nested), Seq()) if nested.outer.isEmpty =>
           val mergedCompanions = merge(module.companions, nested.companions)
-          if (null == mergedCompanions) unmerged += child
+          if (mergedCompanions == null) unmerged += child
           else {
             val mergedImports = module.imports ++ nested.imports
             val mergedInner = {
@@ -271,7 +271,7 @@ object BuildGenUtil {
     pprint.Util.literalize(if (value == null) "" else value)
 
   def escapeOption(value: String): String =
-    if (null == value) "None" else s"Some(\"$value\")"
+    if (value == null) "None" else s"Some(\"$value\")"
 
   def renderMvnString(
       group: String,
@@ -291,7 +291,7 @@ object BuildGenUtil {
         }
     }
     val sepVersion =
-      if (null == version) {
+      if (version == null) {
         println(
           s"assuming $group:$artifact is a BOM dependency; if not, please specify version in the generated build file"
         )
@@ -319,7 +319,7 @@ object BuildGenUtil {
     groupArtifactVersion._2.endsWith("-bom")
 
   def isNullOrEmpty(value: String | Null): Boolean =
-    null == value || value.isEmpty
+    value == null || value.isEmpty
 
   val linebreak: String =
     """

--- a/libs/init/buildgen/src/mill/main/buildgen/BuildGenUtil.scala
+++ b/libs/init/buildgen/src/mill/main/buildgen/BuildGenUtil.scala
@@ -464,9 +464,9 @@ object BuildGenUtil {
     )
 
   def renderPomPackaging(packaging: String): String =
-    if (isNullOrEmpty(packaging) || "jar" == packaging) "" // skip default
+    if (isNullOrEmpty(packaging) || packaging == "jar") "" // skip default
     else {
-      val pkg = if ("pom" == packaging) "PackagingType.Pom" else escape(packaging)
+      val pkg = if (packaging == "pom") "PackagingType.Pom" else escape(packaging)
       s"def pomPackagingType = $pkg"
     }
 

--- a/libs/init/gradle/src/mill/main/gradle/GradleBuildGenMain.scala
+++ b/libs/init/gradle/src/mill/main/gradle/GradleBuildGenMain.scala
@@ -118,7 +118,7 @@ object GradleBuildGenMain extends BuildGenBase.MavenAndGradle[ProjectModel, Dep]
       val projects = input.nodes(Tree.Traversal.BreadthFirst).map(_.value).toSeq
       cfg.baseProject
         .flatMap(name => projects.collectFirst { case m if name == m.name => m })
-        .orElse(projects.collectFirst { case m if null != m.maven().pom() => m })
+        .orElse(projects.collectFirst { case m if m != null.maven().pom() => m })
         .orElse(projects.collectFirst { case m if !m.maven().repositories().isEmpty => m })
         .getOrElse(input.node.value)
     }
@@ -127,7 +127,7 @@ object GradleBuildGenMain extends BuildGenBase.MavenAndGradle[ProjectModel, Dep]
     }
     val supertypes =
       Seq("MavenModule") ++
-        Option.when(null != project.maven().pom()) { "PublishModule" }
+        Option.when(project != null.maven().pom()) { "PublishModule" }
 
     val javacOptions = getJavacOptions(project)
     val scalaVersion = None
@@ -204,7 +204,7 @@ object GradleBuildGenMain extends BuildGenBase.MavenAndGradle[ProjectModel, Dep]
       baseInfo: IrBaseInfo,
       build: Node[ProjectModel]
   ): Seq[String] =
-    Option.when(null != build.value.maven().pom() && {
+    Option.when(build != null.value.maven().pom() && {
       val baseTrait = baseInfo.moduleTypedef
       baseTrait == null || !baseTrait.moduleSupertypes.contains("PublishModule")
     }) { "PublishModule" }.toSeq ++
@@ -226,13 +226,13 @@ object GradleBuildGenMain extends BuildGenBase.MavenAndGradle[ProjectModel, Dep]
 
   def getPomPackaging(project: ProjectModel): String = {
     val pom = project.maven().pom()
-    if (null == pom) null else pom.packaging()
+    if (pom == null) null else pom.packaging()
   }
 
   def getPublishProperties(project: ProjectModel, cfg: BuildGenUtil.Config): Seq[(String, String)] =
     if (cfg.publishProperties.value) {
       val pom = project.maven().pom()
-      if (null == pom) Seq.empty
+      if (pom == null) Seq.empty
       else pom.properties().iterator().asScala
         .map(prop => (prop.key(), prop.value()))
         .toSeq
@@ -250,7 +250,7 @@ object GradleBuildGenMain extends BuildGenBase.MavenAndGradle[ProjectModel, Dep]
 
   def extractPomSettings(project: ProjectModel): IrPom | Null = {
     val pom = project.maven.pom()
-    if (null == pom) null
+    if (pom == null) null
     else {
       IrPom(
         pom.description(),

--- a/libs/init/gradle/src/mill/main/gradle/GradleBuildGenMain.scala
+++ b/libs/init/gradle/src/mill/main/gradle/GradleBuildGenMain.scala
@@ -217,7 +217,7 @@ object GradleBuildGenMain extends BuildGenBase.MavenAndGradle[ProjectModel, Dep]
 
   def getJavacOptions(project: ProjectModel): Seq[String] = {
     val _java = project._java()
-    if (null == _java) Seq.empty
+    if (_java == null) Seq.empty
     else _java.javacOptions().asScala.toSeq
   }
 
@@ -278,7 +278,7 @@ object GradleBuildGenMain extends BuildGenBase.MavenAndGradle[ProjectModel, Dep]
     var sd = IrScopedDeps()
     val hasTest = os.exists(os.Path(project.directory()) / "src/test")
     val _java = project._java()
-    if (null != _java) {
+    if (_java != null) {
       val mvnDep: ExternalDep => String =
         cfg.shared.basicConfig.depsObject.fold(interpMvn(_)) { objName => dep =>
           val depName = s"`${dep.group()}:${dep.name()}`"

--- a/libs/init/gradle/src/mill/main/gradle/GradleBuildGenMain.scala
+++ b/libs/init/gradle/src/mill/main/gradle/GradleBuildGenMain.scala
@@ -118,7 +118,7 @@ object GradleBuildGenMain extends BuildGenBase.MavenAndGradle[ProjectModel, Dep]
       val projects = input.nodes(Tree.Traversal.BreadthFirst).map(_.value).toSeq
       cfg.baseProject
         .flatMap(name => projects.collectFirst { case m if name == m.name => m })
-        .orElse(projects.collectFirst { case m if m != null.maven().pom() => m })
+        .orElse(projects.collectFirst { case m if m.maven().pom() != null => m })
         .orElse(projects.collectFirst { case m if !m.maven().repositories().isEmpty => m })
         .getOrElse(input.node.value)
     }
@@ -127,7 +127,7 @@ object GradleBuildGenMain extends BuildGenBase.MavenAndGradle[ProjectModel, Dep]
     }
     val supertypes =
       Seq("MavenModule") ++
-        Option.when(project != null.maven().pom()) { "PublishModule" }
+        Option.when(project.maven().pom() != null) { "PublishModule" }
 
     val javacOptions = getJavacOptions(project)
     val scalaVersion = None
@@ -204,7 +204,7 @@ object GradleBuildGenMain extends BuildGenBase.MavenAndGradle[ProjectModel, Dep]
       baseInfo: IrBaseInfo,
       build: Node[ProjectModel]
   ): Seq[String] =
-    Option.when(build != null.value.maven().pom() && {
+    Option.when(build.value.maven().pom() != null && {
       val baseTrait = baseInfo.moduleTypedef
       baseTrait == null || !baseTrait.moduleSupertypes.contains("PublishModule")
     }) { "PublishModule" }.toSeq ++

--- a/libs/init/gradle/src/mill/main/gradle/MavenModel.java
+++ b/libs/init/gradle/src/mill/main/gradle/MavenModel.java
@@ -338,7 +338,7 @@ public interface MavenModel extends Serializable {
     }
 
     static Scm from(MavenPomScm scm) {
-      return null == scm
+      return scm == null
           ? null
           : new Impl(
               scm.getUrl().getOrNull(),

--- a/libs/init/maven/src/mill/main/maven/MavenBuildGenMain.scala
+++ b/libs/init/maven/src/mill/main/maven/MavenBuildGenMain.scala
@@ -185,7 +185,7 @@ object MavenBuildGenMain extends BuildGenBase.MavenAndGradle[Model, Dependency] 
     )
 
   def mkPomParent(parent: Parent): IrArtifact =
-    if (null == parent) null
+    if (parent == null) null
     else IrArtifact(parent.getGroupId, parent.getArtifactId, parent.getVersion)
 
   def extractPomSettings(model: Model): IrPom = {

--- a/libs/init/maven/src/mill/main/maven/Plugins.scala
+++ b/libs/init/maven/src/mill/main/maven/Plugins.scala
@@ -34,7 +34,7 @@ object Plugins {
         // javac throws exception if release is specified with source/target, and
         // plugin configuration returns default values for source/target when not specified
         val release = dom.child("release")
-        if (null == release) {
+        if (release == null) {
           dom.child("source").foreachValue(options += "-source" += _)
           dom.child("target").foreachValue(options += "-target" += _)
         } else {
@@ -51,12 +51,12 @@ object Plugins {
   private implicit class NullableDomOps(val self: Xpp3Dom) extends AnyVal {
 
     def child(name: String): Xpp3Dom =
-      if (null == self) self else self.getChild(name)
+      if (self == null) self else self.getChild(name)
 
     def foreachValue(f: String => Unit): Unit =
-      if (null != self) f(self.getValue)
+      if (self != null) f(self.getValue)
 
     def foreachChildValue(f: String => Unit): Unit =
-      if (null != self) self.getChildren.iterator.foreach(dom => f(dom.getValue))
+      if (self != null) self.getChildren.iterator.foreach(dom => f(dom.getValue))
   }
 }

--- a/libs/javalib/spotless-worker/src/mill/javalib/spotless/converters.scala
+++ b/libs/javalib/spotless-worker/src/mill/javalib/spotless/converters.scala
@@ -21,7 +21,7 @@ class ToFormatterStep(charset: Charset, provisioner: Provisioner)
     extends (Step => FormatterStep):
 
   def path(sub: RelPathRef): Option[Path] =
-    Option.when(null != sub && os.exists(sub.ref.path))(sub.ref.path)
+    Option.when(sub != null && os.exists(sub.ref.path))(sub.ref.path)
 
   def read(cof: ContentOrFile): String =
     Option(cof.content)
@@ -174,9 +174,9 @@ class ToFormatterStep(charset: Charset, provisioner: Provisioner)
 def toLintSuppression(suppress: Suppress) = {
   import suppress.*
   val ls = LintSuppression()
-  if (null != path) ls.setPath(path)
-  if (null != step) ls.setStep(step)
-  if (null != shortCode) ls.setShortCode(shortCode)
+  if (path != null) ls.setPath(path)
+  if (step != null) ls.setStep(step)
+  if (shortCode != null) ls.setShortCode(shortCode)
   ls
 }
 

--- a/libs/javalib/src/mill/javalib/dependency/versions/Version.scala
+++ b/libs/javalib/src/mill/javalib/dependency/versions/Version.scala
@@ -161,7 +161,7 @@ private[dependency] object VersionOrdering extends Ordering[Version] {
         case (Left(_), Right(_)) => -1
         case (Right(_), Left(_)) => 1
         case (Right(x), Right(y)) => x `compareTo` y
-      } find (0 != _) orElse Some(a `compareTo` b)
+      } find (_ != 0) orElse Some(a `compareTo` b)
   }
 
   private def compareNumericParts(a: List[Long], b: List[Long]): Option[Int] =


### PR DESCRIPTION
A follow-up of #4586. Replaces #5851.

Yoda conditions are unnecessary and seem unidiomatic in Scala. Replacing them might slightly improve readability.