### PR TITLE
Enabled Kotlin BT API only for modules using Kotlin 2.1+

### DIFF
--- a/example/thirdparty/arrow/build.mill
+++ b/example/thirdparty/arrow/build.mill
@@ -131,7 +131,6 @@ object `package` extends Module {
       def kotlinLanguageVersion = majorVersion(kotlinVersion())
       def kotlinApiVersion = majorVersion(kotlinVersion())
       def kotlinExplicitApi = ArrowMultiplatformModule.this.kotlinExplicitApi
-      def kotlincUseBtApi = false
 
       override def sources: T[Seq[PathRef]] = Task.Sources({
         val sourcesRootPath = moduleDir / "src"

--- a/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -395,11 +395,11 @@ trait KotlinModule extends JavaModule with KotlinModuleApi { outer =>
 
   /**
    * Enable use of new Kotlin Build API (Beta).
-   * Enabled by default for Kotlin 2.x targetting the JVM.
+   * Enabled by default for Kotlin 2.1+ for JVM.
    */
   def kotlincUseBtApi: T[Boolean] = Task {
     Version.parse(kotlinVersion())
-      .isNewerThan(Version.parse("2.0.0"))(using Version.IgnoreQualifierOrdering)
+      .isNewerThan(Version.parse("2.1.0"))(using Version.IgnoreQualifierOrdering)
   }
 
   /**


### PR DESCRIPTION
Follow up on #5785 to fix the failing `arrow` test.