### PR TITLE
Clean up daemon/server launching code to try and stabilize it

### DIFF
--- a/libs/daemon/client/src/mill/client/ServerLaunchResult.java
+++ b/libs/daemon/client/src/mill/client/ServerLaunchResult.java
@@ -1,13 +1,7 @@
 package mill.client;
 
-import java.util.function.Function;
 
 public abstract class ServerLaunchResult {
-  public abstract <R> R fold(
-      Function<Success, R> onSuccess,
-      Function<AlreadyRunning, R> onAlreadyRunning,
-      Function<ServerDied, R> onProcessDied);
-
   /// The server process was not running, so it was started and is now running.
   public static class Success extends ServerLaunchResult {
     /// The server process.
@@ -15,14 +9,6 @@ public abstract class ServerLaunchResult {
 
     public Success(LaunchedServer server) {
       this.server = server;
-    }
-
-    @Override
-    public <R> R fold(
-        Function<Success, R> onSuccess,
-        Function<AlreadyRunning, R> onAlreadyRunning,
-        Function<ServerDied, R> onProcessDied) {
-      return onSuccess.apply(this);
     }
   }
 
@@ -35,13 +21,6 @@ public abstract class ServerLaunchResult {
       this.server = server;
     }
 
-    @Override
-    public <R> R fold(
-        Function<Success, R> onSuccess,
-        Function<AlreadyRunning, R> onAlreadyRunning,
-        Function<ServerDied, R> onProcessDied) {
-      return onAlreadyRunning.apply(this);
-    }
   }
 
   /// We tried to start the server, the process has started but has died unexpectedly.
@@ -60,14 +39,6 @@ public abstract class ServerLaunchResult {
     @Override
     public String toString() {
       return "ProcessDied{" + "server=" + server + ", outputs=" + outputs + '}';
-    }
-
-    @Override
-    public <R> R fold(
-        Function<Success, R> onSuccess,
-        Function<AlreadyRunning, R> onAlreadyRunning,
-        Function<ServerDied, R> onProcessDied) {
-      return onProcessDied.apply(this);
     }
   }
 }

--- a/libs/daemon/client/src/mill/client/ServerLaunchResult.java
+++ b/libs/daemon/client/src/mill/client/ServerLaunchResult.java
@@ -1,6 +1,5 @@
 package mill.client;
 
-
 public abstract class ServerLaunchResult {
   /// The server process was not running, so it was started and is now running.
   public static class Success extends ServerLaunchResult {
@@ -20,7 +19,6 @@ public abstract class ServerLaunchResult {
     public AlreadyRunning(LaunchedServer server) {
       this.server = server;
     }
-
   }
 
   /// We tried to start the server, the process has started but has died unexpectedly.

--- a/libs/daemon/client/src/mill/client/ServerLauncher.java
+++ b/libs/daemon/client/src/mill/client/ServerLauncher.java
@@ -105,6 +105,17 @@ public abstract class ServerLauncher {
     return result;
   }
 
+  public static class Launched implements AutoCloseable{
+    public int port;
+    public Socket socket;
+    public LaunchedServer launchedServer;
+
+    @Override
+    public void close() throws Exception {
+      socket.close();
+      launchedServer.kill();
+    }
+  }
   /**
    * Establishes a connection to the Mill server by acquiring necessary locks and potentially
    * starting a new server process if one is not already running.
@@ -114,7 +125,7 @@ public abstract class ServerLauncher {
    * @return a Socket connected to the Mill server
    * @throws Exception if the server fails to start or a connection cannot be established
    */
-  public static Socket launchOrConnectToServer(
+  public static Launched launchOrConnectToServer(
       Locks locks,
       Path daemonDir,
       String debugName,
@@ -123,48 +134,47 @@ public abstract class ServerLauncher {
       Consumer<ServerLaunchResult.ServerDied> onFailure,
       Consumer<String> log)
       throws Exception {
-    var result = ensureServerIsRunning(locks, daemonDir, initServer, log);
-    return result.fold(
-        success -> {
-          try {
-            return onServerRunning(daemonDir, debugName, serverInitWaitMillis, log);
-          } catch (Exception e) {
-            throw new RuntimeException(e);
-          }
-        },
-        alreadyRunning -> {
-          try {
-            return onServerRunning(daemonDir, debugName, serverInitWaitMillis, log);
-          } catch (Exception e) {
-            throw new RuntimeException(e);
-          }
-        },
-        processDied -> {
-          onFailure.accept(processDied);
-          throw new IllegalStateException(processDied.toString());
-        });
-  }
-
-  /// Invoked when {@link ServerLauncher#ensureServerIsRunning} succeeds.
-  public static Socket onServerRunning(
-      Path daemonDir, String debugName, int serverInitWaitMillis, Consumer<String> log)
-      throws Exception {
-    var startTime = System.nanoTime();
-    log.accept("Reading server port: " + daemonDir.toAbsolutePath());
-    var port = readServerPort(daemonDir, startTime, serverInitWaitMillis);
-    log.accept("Read server port, connecting: " + port);
-    return connectToServer(
-        startTime,
+    log.accept("Acquiring the launcher lock: " + locks.launcherLock);
+    try (var ignored = locks.launcherLock.lock()) {
+      return withTimeout(
         serverInitWaitMillis,
-        port,
-        debugName + ". Daemon directory: " + daemonDir.toAbsolutePath());
+        "server launch failed",
+        () -> {
+          try {
+            var result = ensureServerIsRunning(locks, daemonDir, initServer, 10 * 1000, log);
+            if (result instanceof ServerLaunchResult.Success || result instanceof ServerLaunchResult.AlreadyRunning) {
+              log.accept("Reading server port: " + daemonDir.toAbsolutePath());
+              var port = readServerPort(daemonDir, serverInitWaitMillis);
+              log.accept("Read server port, connecting: " + port);
+              var connected = connectToServer(
+                serverInitWaitMillis,
+                port,
+                debugName + ". Daemon directory: " + daemonDir.toAbsolutePath());
+              var launched = new Launched();
+              launched.port = port;
+              launched.socket = connected;
+              if (result instanceof ServerLaunchResult.Success) {
+                launched.launchedServer = ((ServerLaunchResult.Success)result).server;
+              } else if (result instanceof ServerLaunchResult.AlreadyRunning) {
+                launched.launchedServer = ((ServerLaunchResult.AlreadyRunning)result).server;
+              }
+              return Optional.of(launched);
+            } else {
+              var processDied = (ServerLaunchResult.ServerDied) result;
+              onFailure.accept(processDied);
+              throw new IllegalStateException(processDied.toString());
+            }
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        }
+      );
+    }
   }
 
-  public static Integer readServerPort(
-      Path daemonDir, long startTimeMonotonicNanos, long serverInitWaitMillis) throws Exception {
+  public static Integer readServerPort(Path daemonDir, long serverInitWaitMillis) throws Exception {
     var portFile = daemonDir.resolve(DaemonFiles.socketPort);
     return withTimeout(
-        startTimeMonotonicNanos,
         serverInitWaitMillis,
         "Failed to read server port from " + portFile.toAbsolutePath(),
         () -> {
@@ -179,11 +189,9 @@ public abstract class ServerLauncher {
   /// Connects to the Mill server at the given port.
   ///
   /// @return a socket that should then be used with [#runWithConnection]
-  public static Socket connectToServer(
-      long startTimeMonotonicNanos, long serverInitWaitMillis, int port, String errorMessage)
+  public static Socket connectToServer(long serverInitWaitMillis, int port, String errorMessage)
       throws Exception {
     return withTimeout(
-        startTimeMonotonicNanos,
         serverInitWaitMillis,
         "Failed to connect to server within " + serverInitWaitMillis + "ms on port " + port + ". "
             + errorMessage,
@@ -197,11 +205,11 @@ public abstract class ServerLauncher {
   }
 
   public static <A> A withTimeout(
-      long startTimeMonotonicNanos,
       long timeoutMillis,
       String errorMessage,
       Supplier<Optional<A>> supplier)
       throws Exception {
+    var startTimeMonotonicNanos = System.nanoTime();
     var current = Optional.<A>empty();
     Throwable throwable = null;
     var timeoutNanos = timeoutMillis * 1000 * 1000;
@@ -230,81 +238,78 @@ public abstract class ServerLauncher {
   /// @param daemonDir  the directory where the server will write its port
   /// @param initServer the function to use to start the server
   public static ServerLaunchResult ensureServerIsRunning(
-      Locks locks, Path daemonDir, InitServer initServer, Consumer<String> log) throws Exception {
+      Locks locks, Path daemonDir, InitServer initServer, long timeoutMillis, Consumer<String> log) throws Exception {
     Files.createDirectories(daemonDir);
 
-    log.accept("Acquiring the launcher lock: " + locks.launcherLock);
-    try (var ignored = locks.launcherLock.lock()) {
-      // See if the server is already running.
-      log.accept("Checking if the daemon lock is available: " + locks.daemonLock);
-      var startTime = System.nanoTime();
-      return withTimeout(startTime, 10 * 1000, "Failed to determine server status", () -> {
-        try {
-          if (locks.daemonLock.probe()) {
-            log.accept("The daemon lock is available, starting the server.");
-            try {
-              var launchedServer = initServer.init();
+    // See if the server is already running.
+    log.accept("Checking if the daemon lock is available: " + locks.daemonLock);
+    return withTimeout(timeoutMillis, "Failed to determine server status", () -> {
+      try {
+        if (locks.daemonLock.probe()) {
+          log.accept("The daemon lock is available, starting the server.");
+          try {
+            var launchedServer = initServer.init();
 
-              log.accept("The server has started: " + launchedServer);
+            log.accept("The server has started: " + launchedServer);
 
-              log.accept("Waiting for the server to take the daemon lock: " + locks.daemonLock);
-              var maybeLaunchFailed =
-                  waitUntilDaemonTakesTheLock(locks.daemonLock, daemonDir, launchedServer);
-              if (maybeLaunchFailed.isPresent()) {
-                var outputs = maybeLaunchFailed.get();
-                log.accept("The server " + launchedServer + " failed to start: " + outputs);
+            log.accept("Waiting for the server to take the daemon lock: " + locks.daemonLock);
+            var maybeLaunchFailed =
+                waitUntilDaemonTakesTheLock(locks.daemonLock, daemonDir, launchedServer);
+            if (maybeLaunchFailed.isPresent()) {
+              var outputs = maybeLaunchFailed.get();
+              log.accept("The server " + launchedServer + " failed to start: " + outputs);
 
-                return Optional.of(new ServerLaunchResult.ServerDied(launchedServer, outputs));
-              } else {
-                log.accept("The server " + launchedServer + " has taken the daemon lock: "
-                    + locks.daemonLock);
-                return Optional.of(new ServerLaunchResult.Success(launchedServer));
-              }
-            } catch (Exception e) {
-              throw new RuntimeException(e);
+              return Optional.of(new ServerLaunchResult.ServerDied(launchedServer, outputs));
+            } else {
+              log.accept("The server " + launchedServer + " has taken the daemon lock: "
+                  + locks.daemonLock);
+              return Optional.of(new ServerLaunchResult.Success(launchedServer));
             }
-          } else {
-            log.accept("The daemon lock is not available, there is already a server running.");
-            var pidFile = daemonDir.resolve(DaemonFiles.processId);
-            log.accept("Trying to read the process ID of a running daemon from "
-                + pidFile.toAbsolutePath());
-            try {
-              // We need to read the contents of the file and then parse them in a loop because of
-              // a race
-              // condition where an empty file is created first and only then the process ID is
-              // written to it,
-              // and thus we can read an empty string from the file otherwise.
-              var contents = Files.readString(pidFile);
-              var pid = Long.parseLong(contents);
-              log.accept("Read PID: " + pid);
-
-              var launchedServer =
-                  // PID < 0 is only used in tests.
-                  pid >= 0
-                      ? new LaunchedServer.OsProcess(ProcessHandle.of(pid)
-                          .orElseThrow(
-                              () -> new IllegalStateException("No process found for PID " + pid)))
-                      : new LaunchedServer() {
-                        @Override
-                        public boolean isAlive() {
-                          throw new RuntimeException("not implemented, this should never happen");
-                        }
-
-                        @Override
-                        public void kill() {
-                          throw new RuntimeException("not implemented, this should never happen");
-                        }
-                      };
-              return Optional.of(new ServerLaunchResult.AlreadyRunning(launchedServer));
-            } catch (IOException | NumberFormatException e) {
-              return Optional.empty();
-            }
+          } catch (Exception e) {
+            throw new RuntimeException(e);
           }
-        } catch (Exception e) {
-          return Optional.empty();
+        } else {
+          log.accept("The daemon lock is not available, there is already a server running.");
+          var pidFile = daemonDir.resolve(DaemonFiles.processId);
+          log.accept("Trying to read the process ID of a running daemon from "
+              + pidFile.toAbsolutePath());
+          try {
+            // We need to read the contents of the file and then parse them in a loop because of
+            // a race
+            // condition where an empty file is created first and only then the process ID is
+            // written to it,
+            // and thus we can read an empty string from the file otherwise.
+            var contents = Files.readString(pidFile);
+            var pid = Long.parseLong(contents);
+            log.accept("Read PID: " + pid);
+
+            var launchedServer =
+                // PID < 0 is only used in tests.
+                pid >= 0
+                    ? new LaunchedServer.OsProcess(ProcessHandle.of(pid)
+                        .orElseThrow(
+                            () -> new IllegalStateException("No process found for PID " + pid)))
+                    : new LaunchedServer() {
+                      @Override
+                      public boolean isAlive() {
+                        throw new RuntimeException("not implemented, this should never happen");
+                      }
+
+                      @Override
+                      public void kill() {
+                        throw new RuntimeException("not implemented, this should never happen");
+                      }
+                    };
+            return Optional.of(new ServerLaunchResult.AlreadyRunning(launchedServer));
+          } catch (IOException | NumberFormatException e) {
+            return Optional.empty();
+          }
         }
-      });
-    }
+      } catch (Exception e) {
+        return Optional.empty();
+      }
+    });
+
   }
 
   /// Busy-spins until the server process is running and has taken the `daemonLock`, returning an

--- a/runner/client/src/mill/client/MillServerLauncher.java
+++ b/runner/client/src/mill/client/MillServerLauncher.java
@@ -62,7 +62,7 @@ public abstract class MillServerLauncher extends ServerLauncher {
     }
     log.accept("launchOrConnectToServer: " + locks);
 
-    try (var connection = launchOrConnectToServer(
+    try (var launched = launchOrConnectToServer(
         locks,
         daemonDir,
         "From MillServerLauncher",
@@ -74,11 +74,11 @@ public abstract class MillServerLauncher extends ServerLauncher {
           System.exit(1);
         },
         log)) {
-      log.accept("runWithConnection: " + connection);
+      log.accept("runWithConnection: " + launched);
       var result = runWithConnection(
-          "MillServerLauncher[" + connection.getLocalSocketAddress() + " -> "
-              + connection.getRemoteSocketAddress() + "]",
-          connection,
+          "MillServerLauncher[" + launched.socket.getLocalSocketAddress() + " -> "
+              + launched.socket.getRemoteSocketAddress() + "]",
+        launched.socket,
           streams,
           false,
           rawServerStdin -> {

--- a/runner/client/src/mill/client/MillServerLauncher.java
+++ b/runner/client/src/mill/client/MillServerLauncher.java
@@ -65,7 +65,6 @@ public abstract class MillServerLauncher extends ServerLauncher {
     try (var launched = launchOrConnectToServer(
         locks,
         daemonDir,
-        "From MillServerLauncher",
         serverInitWaitMillis,
         () -> initServer(daemonDir, locks),
         serverDied -> {
@@ -78,7 +77,7 @@ public abstract class MillServerLauncher extends ServerLauncher {
       var result = runWithConnection(
           "MillServerLauncher[" + launched.socket.getLocalSocketAddress() + " -> "
               + launched.socket.getRemoteSocketAddress() + "]",
-        launched.socket,
+          launched.socket,
           streams,
           false,
           rawServerStdin -> {


### PR DESCRIPTION
Previously the retries of each step (1) ensure server alive (2) read port (3) connect to socket, happened sequentially with no opportunity for backtracking, which could cause problems if the server was in a bad state, e.g. if the server was alive but shutting down: 

- (1) may succeed but (2) may never become possible
- (1) may succeed and (2) may succeed but (3) may then never work

This PR changes the logic such that the retries for (1) and (2, 3) are nested: we retry the server-alive check, if that succeeds we try to read the port and connect to it, but if either of those fails we go back to retry the server alive check again. This ensures that in the server shutting down scenario, we get a chance to launch a new server if port reading or socket connection fails