### PR TITLE
Ensure deprecation versions always contain the project name

### DIFF
--- a/core/api/daemon/src/mill/api/daemon/internal/SemanticDbJavaModuleApi.scala
+++ b/core/api/daemon/src/mill/api/daemon/internal/SemanticDbJavaModuleApi.scala
@@ -3,9 +3,9 @@ package mill.api.daemon.internal
 import mill.api.daemon.BuildInfo
 
 trait SemanticDbJavaModuleApi {
-  @deprecated("Move to BSP context")
+  @deprecated("Move to BSP context", "Mill 1.0.0-RC2")
   private[mill] def bspBuildTargetCompileSemanticDb: TaskApi[java.nio.file.Path]
-  @deprecated("Move to BSP context")
+  @deprecated("Move to BSP context", "Mill 1.0.0-RC2")
   private[mill] def bspCompiledClassesAndSemanticDbFiles: TaskApi[UnresolvedPathApi[?]]
 }
 object SemanticDbJavaModuleApi {

--- a/libs/javalib/src/mill/javalib/JvmWorkerModule.scala
+++ b/libs/javalib/src/mill/javalib/JvmWorkerModule.scala
@@ -132,7 +132,7 @@ trait JvmWorkerModule extends OfflineSupportModule with CoursierModule {
     } else ZincCompilerBridgeProvider.AcquireResult.Compiled(bridgeJar)
   }
 
-  @deprecated("This is an internal API that has been accidentally exposed.", "1.0.2")
+  @deprecated("This is an internal API that has been accidentally exposed.", "Mill 1.0.2")
   def scalaCompilerBridgeJar(
       scalaVersion: String,
       scalaOrganization: String,

--- a/libs/javalib/src/mill/javalib/MavenWorkerSupport.scala
+++ b/libs/javalib/src/mill/javalib/MavenWorkerSupport.scala
@@ -40,7 +40,7 @@ object MavenWorkerSupport {
   }
 
   object RemoteM2Publisher {
-    @deprecated("This should have been an internal API.", "1.0.1")
+    @deprecated("This should have been an internal API.", "Mill 1.0.1")
     def asM2Artifacts(
         pom: os.Path,
         artifact: Artifact,

--- a/libs/javalib/src/mill/javalib/PublishModule.scala
+++ b/libs/javalib/src/mill/javalib/PublishModule.scala
@@ -292,7 +292,7 @@ trait PublishModule extends JavaModule { outer =>
     Artifact(pomSettings().organization, artifactId(), publishVersion())
   }
 
-  @deprecated("Use `defaultPublishInfos` that takes parameters instead.", "1.0.1")
+  @deprecated("Use `defaultPublishInfos` that takes parameters instead.", "Mill 1.0.1")
   def defaultPublishInfos: T[Seq[PublishInfo]] =
     Task { defaultPublishInfos(sources = true, docs = true)() }
 
@@ -493,7 +493,7 @@ trait PublishModule extends JavaModule { outer =>
 
   @deprecated(
     "Do not override this task, override `artifactMetadata`, `publishArtifactsDefaultPayload` or `extraPublish` instead.",
-    "1.0.1"
+    "Mill 1.0.1"
   )
   def publishArtifacts: T[PublishModule.PublishData] = Task {
     PublishModule.PublishData(artifactMetadata(), publishArtifactsPayload()())
@@ -645,11 +645,11 @@ object PublishModule extends ExternalModule with DefaultTaskModule {
 
   val defaultGpgArgs: Seq[String] = internal.PublishModule.defaultGpgArgs
 
-  @deprecated("This API should have been internal and is not guaranteed to stay.", "1.0.1")
+  @deprecated("This API should have been internal and is not guaranteed to stay.", "Mill 1.0.1")
   def pgpImportSecretIfProvided(env: Map[String, String]): Unit =
     internal.PublishModule.pgpImportSecretIfProvidedOrThrow(env)
 
-  @deprecated("This API should have been internal and is not guaranteed to stay.", "1.0.1")
+  @deprecated("This API should have been internal and is not guaranteed to stay.", "Mill 1.0.1")
   def defaultGpgArgsForPassphrase(passphrase: Option[String]): Seq[String] =
     internal.PublishModule.defaultGpgArgsForPassphrase(passphrase).map(Secret.unpack)
 

--- a/libs/javalib/src/mill/javalib/SonatypeCentralPublishModule.scala
+++ b/libs/javalib/src/mill/javalib/SonatypeCentralPublishModule.scala
@@ -24,7 +24,8 @@ import mill.javalib.PublishModule.PublishData
 import mill.javalib.internal.PublishModule.GpgArgs
 
 trait SonatypeCentralPublishModule extends PublishModule, MavenWorkerSupport {
-  @deprecated("Use `sonatypeCentralGpgArgsForKey` instead.", "1.0.1")
+
+  @deprecated("Use `sonatypeCentralGpgArgsForKey` instead.", "Mill 1.0.1")
   def sonatypeCentralGpgArgs: T[String] =
     Task { SonatypeCentralPublishModule.sonatypeCentralGpgArgsSentinelValue }
 

--- a/libs/javalib/src/mill/javalib/SonatypeCentralPublisher.scala
+++ b/libs/javalib/src/mill/javalib/SonatypeCentralPublisher.scala
@@ -56,7 +56,7 @@ class SonatypeCentralPublisher(
     new SyncSonatypeClient(credentials, readTimeout = readTimeout, connectTimeout = connectTimeout)
 
   // binary compatibility forwarder
-  @deprecated("Use `publish` where `fileMapping: Map[os.SubPath, os.Path]` instead.", "1.0.1")
+  @deprecated("Use `publish` where `fileMapping: Map[os.SubPath, os.Path]` instead.", "Mill 1.0.1")
   def publish(
       fileMapping: Seq[(os.Path, String)],
       artifact: Artifact,

--- a/libs/javalib/src/mill/javalib/publish/SonatypePublisher.scala
+++ b/libs/javalib/src/mill/javalib/publish/SonatypePublisher.scala
@@ -13,7 +13,7 @@ import scala.annotation.targetName
  *
  * @see https://central.sonatype.org/pages/ossrh-eol/
  */
-@deprecated("Use `mill.javalib.SonatypeCentralPublisher` instead", "1.0.0")
+@deprecated("Use `mill.javalib.SonatypeCentralPublisher` instead", "Mill 1.0.0")
 class SonatypePublisher(
     uri: String,
     snapshotUri: String,


### PR DESCRIPTION
This greatly improves compiler warning readability and is best practice.

