### PR TITLE
Add `copilot-setup-steps.yml`

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -24,3 +24,5 @@ jobs:
 
       - name: Run Mill compile
         run: ./mill __.compile
+
+      - uses: sbt/setup-sbt@v1


### PR DESCRIPTION
This helps preinstall tools and dependencies for the GitHub Copilot coding agent in case any developer wants to delegate a task to the coding agent. See https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/customize-the-agent-environment for more details. I am not familiar with all the workflow scripts in this project so I just added some basic stuff, and it is tested to work in https://github.com/ShreckYe/mill/pull/1. Please add more missing setups if needed. Also feel free to close this if this is unnecessary at the moment.