### PR TITLE
[config.artifactory] Read credential configs for publish

### DIFF
--- a/contrib/artifactory/src/mill/contrib/artifactory/ArtifactoryPublishModule.scala
+++ b/contrib/artifactory/src/mill/contrib/artifactory/ArtifactoryPublishModule.scala
@@ -83,11 +83,7 @@ object ArtifactoryPublishModule extends ExternalModule {
         password <- Task.env.get("ARTIFACTORY_PASSWORD")
       } yield {
         s"$username:$password"
-      }).getOrElse(
-        Task.fail(
-          "Consider using ARTIFACTORY_USERNAME/ARTIFACTORY_PASSWORD environment variables or passing `credentials` argument"
-        )
-      )
+      }).getOrElse("")
     } else {
       credentials
     }

--- a/libs/util/src/mill/exports.scala
+++ b/libs/util/src/mill/exports.scala
@@ -11,4 +11,5 @@ export mill.api.Task.Worker
 export mill.api.DefaultTaskModule
 export mill.api.JsonFormatters.*
 export mill.util.TokenReaders.*
+export mill.util.CoursierConfig
 export upickle.implicits.namedTuples.default.given


### PR DESCRIPTION
Currently, the `publishArtifactory` task requires credentials to be supplied via environment variables or command-line arguments. If these are not provided, the system will fall back to searching for credentials in the Coursier configuration files.
