### PR TITLE
Simplify `launchOrConnectToServer` to eliminate nested retries

### DIFF
--- a/integration/failure/invalid-build-header-no-space/src/InvalidBuildHeaderNoSpaceTests.scala
+++ b/integration/failure/invalid-build-header-no-space/src/InvalidBuildHeaderNoSpaceTests.scala
@@ -5,6 +5,7 @@ import mill.testkit.UtestIntegrationTestSuite
 import utest._
 
 object InvalidBuildHeaderNoSpaceTests extends UtestIntegrationTestSuite {
+  override def cleanupProcessIdFile = false // process never launches due to yaml header syntax error
   val tests: Tests = Tests {
     test - integrationTest { tester =>
       import tester._

--- a/integration/failure/invalid-build-header-no-space/src/InvalidBuildHeaderNoSpaceTests.scala
+++ b/integration/failure/invalid-build-header-no-space/src/InvalidBuildHeaderNoSpaceTests.scala
@@ -5,7 +5,8 @@ import mill.testkit.UtestIntegrationTestSuite
 import utest._
 
 object InvalidBuildHeaderNoSpaceTests extends UtestIntegrationTestSuite {
-  override def cleanupProcessIdFile = false // process never launches due to yaml header syntax error
+  override def cleanupProcessIdFile =
+    false // process never launches due to yaml header syntax error
   val tests: Tests = Tests {
     test - integrationTest { tester =>
       import tester._

--- a/integration/failure/invalid-build-header/src/InvalidBuildHeaderTests.scala
+++ b/integration/failure/invalid-build-header/src/InvalidBuildHeaderTests.scala
@@ -5,6 +5,7 @@ import mill.testkit.UtestIntegrationTestSuite
 import utest._
 
 object InvalidBuildHeaderTests extends UtestIntegrationTestSuite {
+  override def cleanupProcessIdFile = false // process never launches due to yaml header syntax error
   val tests: Tests = Tests {
     test - integrationTest { tester =>
       import tester._

--- a/integration/failure/invalid-build-header/src/InvalidBuildHeaderTests.scala
+++ b/integration/failure/invalid-build-header/src/InvalidBuildHeaderTests.scala
@@ -5,7 +5,8 @@ import mill.testkit.UtestIntegrationTestSuite
 import utest._
 
 object InvalidBuildHeaderTests extends UtestIntegrationTestSuite {
-  override def cleanupProcessIdFile = false // process never launches due to yaml header syntax error
+  override def cleanupProcessIdFile =
+    false // process never launches due to yaml header syntax error
   val tests: Tests = Tests {
     test - integrationTest { tester =>
       import tester._

--- a/libs/daemon/client/src/mill/client/ServerLauncher.java
+++ b/libs/daemon/client/src/mill/client/ServerLauncher.java
@@ -147,7 +147,9 @@ public abstract class ServerLauncher {
           if (result instanceof ServerLaunchResult.Success
               || result instanceof ServerLaunchResult.AlreadyRunning) {
             log.accept("Reading server port: " + daemonDir.toAbsolutePath());
-            var port = Integer.parseInt(Files.readString(daemonDir.resolve(DaemonFiles.socketPort)));
+            var port =
+              Integer.parseInt(Files.readString(daemonDir.resolve(DaemonFiles.socketPort)));
+
             var launched = new Launched();
             launched.port = port;
             log.accept("Read server port, connecting: " + port);
@@ -269,6 +271,7 @@ public abstract class ServerLauncher {
                     };
             return Optional.of(new ServerLaunchResult.AlreadyRunning(launchedServer));
           } catch (IOException | NumberFormatException e) {
+            log.accept("Read PID exception: " + e);
             return Optional.empty();
           }
         }

--- a/libs/daemon/client/src/mill/client/ServerLauncher.java
+++ b/libs/daemon/client/src/mill/client/ServerLauncher.java
@@ -147,14 +147,7 @@ public abstract class ServerLauncher {
           if (result instanceof ServerLaunchResult.Success
               || result instanceof ServerLaunchResult.AlreadyRunning) {
             log.accept("Reading server port: " + daemonDir.toAbsolutePath());
-            var port = retryWithTimeout(serverInitWaitMillis / 10, "Reading server port", () -> {
-              try {
-                return Optional.of(
-                    Integer.parseInt(Files.readString(daemonDir.resolve(DaemonFiles.socketPort))));
-              } catch (IOException e) {
-                throw new RuntimeException(e);
-              }
-            });
+            var port = Integer.parseInt(Files.readString(daemonDir.resolve(DaemonFiles.socketPort)));
             var launched = new Launched();
             launched.port = port;
             log.accept("Read server port, connecting: " + port);

--- a/libs/daemon/client/src/mill/client/ServerLauncher.java
+++ b/libs/daemon/client/src/mill/client/ServerLauncher.java
@@ -142,6 +142,8 @@ public abstract class ServerLauncher {
     try (var ignored = locks.launcherLock.lock()) {
       return retryWithTimeout(serverInitWaitMillis, "server launch failed", () -> {
         try {
+          log.accept("launchOrConnectToServer try");
+
           var result =
               ensureServerIsRunning(locks, daemonDir, initServer, serverInitWaitMillis / 3, log);
           if (result instanceof ServerLaunchResult.Success

--- a/libs/daemon/client/src/mill/client/ServerLauncher.java
+++ b/libs/daemon/client/src/mill/client/ServerLauncher.java
@@ -142,7 +142,7 @@ public abstract class ServerLauncher {
     try (var ignored = locks.launcherLock.lock()) {
       return retryWithTimeout(serverInitWaitMillis, "server launch failed", () -> {
         try {
-          log.accept("launchOrConnectToServer try");
+          log.accept("launchOrConnectToServer attempt");
 
           var result =
               ensureServerIsRunning(locks, daemonDir, initServer, serverInitWaitMillis / 3, log);
@@ -154,8 +154,9 @@ public abstract class ServerLauncher {
 
             var launched = new Launched();
             launched.port = port;
-            log.accept("Read server port, connecting: " + port);
+            log.accept("Read server port");
             if (openSocket) {
+              log.accept("Connecting: " + port);
               var connected = new Socket(InetAddress.getLoopbackAddress(), port);
               launched.socket = connected;
             }

--- a/libs/daemon/client/src/mill/client/ServerLauncher.java
+++ b/libs/daemon/client/src/mill/client/ServerLauncher.java
@@ -148,7 +148,7 @@ public abstract class ServerLauncher {
               || result instanceof ServerLaunchResult.AlreadyRunning) {
             log.accept("Reading server port: " + daemonDir.toAbsolutePath());
             var port =
-              Integer.parseInt(Files.readString(daemonDir.resolve(DaemonFiles.socketPort)));
+                Integer.parseInt(Files.readString(daemonDir.resolve(DaemonFiles.socketPort)));
 
             var launched = new Launched();
             launched.port = port;

--- a/runner/launcher/src/mill/launcher/MillLauncherMain.java
+++ b/runner/launcher/src/mill/launcher/MillLauncherMain.java
@@ -79,7 +79,7 @@ public class MillLauncherMain {
         // start in client-server mode
         var optsArgs = new java.util.ArrayList<>(MillProcessLauncher.millOpts(outMode));
         Collections.addAll(optsArgs, args);
-
+        Consumer<String> log = (s) -> logs.add(java.time.Instant.now() + " " + s);
         MillServerLauncher launcher =
             new MillServerLauncher(
                 new MillServerLauncher.Streams(System.in, System.out, System.err),
@@ -88,14 +88,17 @@ public class MillLauncherMain {
                 Optional.empty(),
                 -1) {
               public LaunchedServer initServer(Path daemonDir, Locks locks) throws Exception {
-                return new LaunchedServer.OsProcess(
+                log.accept("initServer START");
+                var res = new LaunchedServer.OsProcess(
                     MillProcessLauncher.launchMillDaemon(daemonDir, outMode).toHandle());
+                log.accept("initServer END");
+                return res;
               }
             };
 
         var daemonDir0 = Paths.get(outDir, OutFiles.millDaemon);
         String javaHome = MillProcessLauncher.javaHome(outMode);
-        Consumer<String> log = (s) -> logs.add(java.time.Instant.now() + " " + s);
+
         var exitCode = launcher.run(daemonDir0, javaHome, log).exitCode;
         if (exitCode == ClientUtil.ExitServerCodeWhenVersionMismatch()) {
           exitCode = launcher.run(daemonDir0, javaHome, log).exitCode;

--- a/runner/launcher/src/mill/launcher/MillLauncherMain.java
+++ b/runner/launcher/src/mill/launcher/MillLauncherMain.java
@@ -4,6 +4,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
@@ -95,7 +96,8 @@ public class MillLauncherMain {
         // start in client-server mode
         var optsArgs = new java.util.ArrayList<>(MillProcessLauncher.millOpts(outMode));
         Collections.addAll(optsArgs, args);
-        var formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'").withZone(ZoneId.of("UTC"));
+        var formatter =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'").withZone(ZoneId.of("UTC"));
         Consumer<String> log = (s) -> logs.add(formatter.format(Instant.now()) + " " + s);
         MillServerLauncher launcher =
             new MillServerLauncher(

--- a/runner/launcher/src/mill/launcher/MillLauncherMain.java
+++ b/runner/launcher/src/mill/launcher/MillLauncherMain.java
@@ -95,7 +95,7 @@ public class MillLauncherMain {
         // start in client-server mode
         var optsArgs = new java.util.ArrayList<>(MillProcessLauncher.millOpts(outMode));
         Collections.addAll(optsArgs, args);
-        var formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        var formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'").withZone(ZoneId.of("UTC"));
         Consumer<String> log = (s) -> logs.add(formatter.format(Instant.now()) + " " + s);
         MillServerLauncher launcher =
             new MillServerLauncher(

--- a/runner/launcher/src/mill/launcher/MillLauncherMain.java
+++ b/runner/launcher/src/mill/launcher/MillLauncherMain.java
@@ -107,9 +107,9 @@ public class MillLauncherMain {
                 Optional.empty(),
                 -1) {
               public LaunchedServer initServer(Path daemonDir, Locks locks) throws Exception {
-                var launched =
-                    MillProcessLauncher.launchMillDaemon(daemonDir, outMode, runnerClasspath);
-                return new LaunchedServer.OsProcess(launched.toHandle());
+                return new LaunchedServer.OsProcess(
+                    MillProcessLauncher.launchMillDaemon(daemonDir, outMode, runnerClasspath)
+                        .toHandle());
               }
             };
 

--- a/runner/launcher/src/mill/launcher/MillLauncherMain.java
+++ b/runner/launcher/src/mill/launcher/MillLauncherMain.java
@@ -95,7 +95,7 @@ public class MillLauncherMain {
 
         var daemonDir0 = Paths.get(outDir, OutFiles.millDaemon);
         String javaHome = MillProcessLauncher.javaHome(outMode);
-        Consumer<String> log = logs::add;
+        Consumer<String> log = (s) -> logs.add(java.time.Instant.now() + " " + s);
         var exitCode = launcher.run(daemonDir0, javaHome, log).exitCode;
         if (exitCode == ClientUtil.ExitServerCodeWhenVersionMismatch()) {
           exitCode = launcher.run(daemonDir0, javaHome, log).exitCode;

--- a/runner/launcher/src/mill/launcher/MillLauncherMain.java
+++ b/runner/launcher/src/mill/launcher/MillLauncherMain.java
@@ -89,8 +89,9 @@ public class MillLauncherMain {
                 -1) {
               public LaunchedServer initServer(Path daemonDir, Locks locks) throws Exception {
                 log.accept("initServer START");
-                var res = new LaunchedServer.OsProcess(
-                    MillProcessLauncher.launchMillDaemon(daemonDir, outMode).toHandle());
+                var launched = MillProcessLauncher.launchMillDaemon(daemonDir, outMode, log);
+                log.accept("initServer launched");
+                var res = new LaunchedServer.OsProcess(launched.toHandle());
                 log.accept("initServer END");
                 return res;
               }

--- a/runner/launcher/src/mill/launcher/MillProcessLauncher.java
+++ b/runner/launcher/src/mill/launcher/MillProcessLauncher.java
@@ -42,6 +42,7 @@ public class MillProcessLauncher {
     try {
       Process p = configureRunMillProcess(builder, processDir);
       return p.waitFor();
+
     } catch (InterruptedException e) {
       interrupted = true;
       throw e;
@@ -62,10 +63,12 @@ public class MillProcessLauncher {
     l.add("mill.daemon.MillDaemonMain");
     l.add(daemonDir.toFile().getCanonicalPath());
     l.add(outMode.asString());
+
     ProcessBuilder builder = new ProcessBuilder()
         .command(l)
         .redirectOutput(daemonDir.resolve(DaemonFiles.stdout).toFile())
         .redirectError(daemonDir.resolve(DaemonFiles.stderr).toFile());
+
     return configureRunMillProcess(builder, daemonDir);
   }
 
@@ -74,9 +77,8 @@ public class MillProcessLauncher {
     Files.createDirectories(sandbox);
     MillProcessLauncher.prepareMillRunFolder(daemonDir);
     builder.environment().put(EnvVars.MILL_WORKSPACE_ROOT, new File("").getCanonicalPath());
-    if (System.getenv(EnvVars.MILL_EXECUTABLE_PATH) == null) {
+    if (System.getenv(EnvVars.MILL_EXECUTABLE_PATH) == null)
       builder.environment().put(EnvVars.MILL_EXECUTABLE_PATH, getExecutablePath());
-    }
 
     String jdkJavaOptions = System.getenv("JDK_JAVA_OPTIONS");
     if (jdkJavaOptions == null) jdkJavaOptions = "";

--- a/runner/launcher/src/mill/launcher/MillProcessLauncher.java
+++ b/runner/launcher/src/mill/launcher/MillProcessLauncher.java
@@ -73,6 +73,7 @@ public class MillProcessLauncher {
   }
 
   static Process configureRunMillProcess(ProcessBuilder builder, Path daemonDir) throws Exception {
+
     Path sandbox = daemonDir.resolve(DaemonFiles.sandbox);
     Files.createDirectories(sandbox);
     MillProcessLauncher.prepareMillRunFolder(daemonDir);

--- a/testkit/src/mill/testkit/ExampleTester.scala
+++ b/testkit/src/mill/testkit/ExampleTester.scala
@@ -76,7 +76,8 @@ class ExampleTester(
     millExecutable: os.Path,
     bashExecutable: String = ExampleTester.defaultBashExecutable(),
     val baseWorkspacePath: os.Path,
-    val propagateJavaHome: Boolean = true
+    val propagateJavaHome: Boolean = true,
+    val cleanupProcessIdFile: Boolean = true,
 ) extends IntegrationTesterBase {
 
   def processCommandBlock(commandBlock: String): Unit = {

--- a/testkit/src/mill/testkit/ExampleTester.scala
+++ b/testkit/src/mill/testkit/ExampleTester.scala
@@ -77,7 +77,7 @@ class ExampleTester(
     bashExecutable: String = ExampleTester.defaultBashExecutable(),
     val baseWorkspacePath: os.Path,
     val propagateJavaHome: Boolean = true,
-    val cleanupProcessIdFile: Boolean = true,
+    val cleanupProcessIdFile: Boolean = true
 ) extends IntegrationTesterBase {
 
   def processCommandBlock(commandBlock: String): Unit = {

--- a/testkit/src/mill/testkit/IntegrationTestSuite.scala
+++ b/testkit/src/mill/testkit/IntegrationTestSuite.scala
@@ -35,6 +35,7 @@ trait IntegrationTestSuite {
    */
   protected def propagateJavaHome: Boolean = true
 
+  protected def cleanupProcessIdFile: Boolean = true
   def debugLog: Boolean = false
 
   /**
@@ -53,7 +54,8 @@ trait IntegrationTestSuite {
         millExecutable,
         debugLog,
         baseWorkspacePath = os.pwd,
-        propagateJavaHome = propagateJavaHome
+        propagateJavaHome = propagateJavaHome,
+        cleanupProcessIdFile = cleanupProcessIdFile
       )
       try block(tester)
       finally tester.close()

--- a/testkit/src/mill/testkit/IntegrationTester.scala
+++ b/testkit/src/mill/testkit/IntegrationTester.scala
@@ -26,7 +26,8 @@ class IntegrationTester(
     val millExecutable: os.Path,
     override val debugLog: Boolean = false,
     val baseWorkspacePath: os.Path = os.pwd,
-    val propagateJavaHome: Boolean = true
+    val propagateJavaHome: Boolean = true,
+    val cleanupProcessIdFile: Boolean = true
 ) extends IntegrationTester.Impl {
   initWorkspace()
 }

--- a/testkit/src/mill/testkit/IntegrationTesterBase.scala
+++ b/testkit/src/mill/testkit/IntegrationTesterBase.scala
@@ -6,6 +6,7 @@ import mill.util.Retry
 trait IntegrationTesterBase {
   def workspaceSourcePath: os.Path
   def daemonMode: Boolean
+  def cleanupProcessIdFile: Boolean
 
   def propagateJavaHome: Boolean
 
@@ -75,7 +76,7 @@ trait IntegrationTesterBase {
   def removeProcessIdFile(): Unit = {
     if (!sys.env.contains("MILL_TEST_SHARED_OUTPUT_DIR")) {
       val outDir = os.Path(out, workspacePath)
-      if (os.exists(outDir)) {
+      if (os.exists(outDir) && cleanupProcessIdFile) {
         if (daemonMode) {
           val serverPath = outDir / millDaemon
           os.remove(serverPath / processId)


### PR DESCRIPTION
Previously we needed a `retryWithTimeout` around the reading of the port because the initial process launch could take >10s, which would make the outer `retryWithTimeout` not take effect. This is because we were performing the coursier runner classpath resolution as part of that launch, which can take arbitrarily long, overshooting the retry timeout.

This PR fixes it by moving the coursier runner classpath resolution out of the retry loop, so the retry loop only contains the logic around launching the process. This should help keep the time of each attempt to a more reasonable amount, allowing the outer retries to work and avoiding the need for nested retries around the individual steps of the process launch workflow