### PR TITLE
Android: pass compileMvnDeps as classpaths to R8

### DIFF
--- a/libs/androidlib/src/mill/androidlib/AndroidModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidModule.scala
@@ -302,6 +302,10 @@ trait AndroidModule extends JavaModule { outer =>
     transformedAndroidDeps(Task.Anon(resolvedMvnDeps()))()
   }
 
+  def androidResolvedCompileMvnDeps: T[Seq[PathRef]] = Task {
+    defaultResolver().classpath(compileMvnDeps())
+  }
+
   protected def transformedAndroidDeps(resolvedDeps: Task[Seq[PathRef]]): Task[Seq[PathRef]] =
     Task.Anon {
       val transformedAarFilesToJar: Seq[PathRef] =

--- a/libs/androidlib/src/mill/androidlib/AndroidR8AppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidR8AppModule.scala
@@ -182,6 +182,12 @@ trait AndroidR8AppModule extends AndroidAppModule {
     val allClassFilesFile = Task.dest / "all-classes.txt"
     os.write.over(allClassFilesFile, allClassFiles.mkString("\n"))
 
+    val compiledMvnDepsFile = Task.dest / "compiled-mvndeps.txt"
+    os.write.over(
+      compiledMvnDepsFile,
+      androidResolvedCompileMvnDeps().map(_.path.toString()).mkString("\n")
+    )
+
     val r8ArgsBuilder = Seq.newBuilder[String]
 
     r8ArgsBuilder += androidSdkModule().r8Exe().path.toString
@@ -241,6 +247,11 @@ trait AndroidR8AppModule extends AndroidAppModule {
       ) ++ androidCommonProguardFiles().flatMap(pgf => Seq("--pg-conf", pgf.path.toString))
 
     r8ArgsBuilder ++= pgArgs
+
+    r8ArgsBuilder ++= Seq(
+      "--classpath",
+      "@" + compiledMvnDepsFile.toString
+    )
 
     r8ArgsBuilder ++= androidR8Args()
 

--- a/libs/androidlib/src/mill/androidlib/AndroidR8AppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidR8AppModule.scala
@@ -182,12 +182,6 @@ trait AndroidR8AppModule extends AndroidAppModule {
     val allClassFilesFile = Task.dest / "all-classes.txt"
     os.write.over(allClassFilesFile, allClassFiles.mkString("\n"))
 
-    val compiledMvnDepsFile = Task.dest / "compiled-mvndeps.txt"
-    os.write.over(
-      compiledMvnDepsFile,
-      androidResolvedCompileMvnDeps().map(_.path.toString()).mkString("\n")
-    )
-
     val r8ArgsBuilder = Seq.newBuilder[String]
 
     r8ArgsBuilder += androidSdkModule().r8Exe().path.toString
@@ -248,10 +242,18 @@ trait AndroidR8AppModule extends AndroidAppModule {
 
     r8ArgsBuilder ++= pgArgs
 
-    r8ArgsBuilder ++= Seq(
-      "--classpath",
-      "@" + compiledMvnDepsFile.toString
-    )
+    val resolvedCompileMvnDeps = androidResolvedCompileMvnDeps()
+    if (!resolvedCompileMvnDeps.isEmpty) {
+      val compiledMvnDepsFile = Task.dest / "compiled-mvndeps.txt"
+      os.write.over(
+        compiledMvnDepsFile,
+        androidResolvedCompileMvnDeps().map(_.path.toString()).mkString("\n")
+      )
+      r8ArgsBuilder ++= Seq(
+        "--classpath",
+        "@" + compiledMvnDepsFile.toString
+      )
+    }
 
     r8ArgsBuilder ++= androidR8Args()
 


### PR DESCRIPTION
Resolves https://github.com/com-lihaoyi/mill/issues/5875
Now no errors are thrown when using R8 for XR applications, thus `override def androidR8Args = Seq("--map-diagnostics", "error", "warning")` is not needed anymore.