### PR TITLE
Blog: Remove link not referenced in stable

### DIFF
--- a/website/blog/modules/ROOT/pages/15-android-build-flow.adoc
+++ b/website/blog/modules/ROOT/pages/15-android-build-flow.adoc
@@ -179,7 +179,7 @@ The diagram above still doesn’t tell the whole story! It shows a typical build
 - Instrumented tests (separate APK, own resources, manifests, dependencies)
 - Native code (NDK builds, CMake integration)
 
-We cover a lot of these architecture styles in various Android examples, based on xref:mill::android/java.adoc[Java], xref:mill::android/kotlin.adoc[Kotlin] and third party integration examples covering xref:mill::android/compose-samples.adoc[Android Compose], xref:mill::android/android-native-example.adoc[Android Native] and xref:mill::android/hilt-sample.adoc[Dependency Injection with Hilt].
+We cover a lot of these architecture styles in various Android examples, based on xref:mill::android/java.adoc[Java], xref:mill::android/kotlin.adoc[Kotlin] and third party integration examples covering xref:mill::android/compose-samples.adoc[Android Compose] and xref:mill::android/hilt-sample.adoc[Dependency Injection with Hilt].
 
 Endless tunnel sample app
 image:AndroidEndlessTunnelExample.png[An Android app built with Mill using native code, showing a 3D tunnel effect.]


### PR DESCRIPTION
Fixes publish docs by removing the link reference to the android native docs that was introduced on the same PR