### PR TITLE
Make `--bsp` Mill process launch from `MillBspMain` class

### DIFF
--- a/runner/daemon/src/mill/daemon/MillBspMain.scala
+++ b/runner/daemon/src/mill/daemon/MillBspMain.scala
@@ -1,0 +1,5 @@
+package mill.daemon
+
+object MillBspMain {
+  def main(args0: Array[String]): Unit = MillNoDaemonMain.main(args0)
+}

--- a/runner/launcher/src/mill/launcher/MillLauncherMain.java
+++ b/runner/launcher/src/mill/launcher/MillLauncherMain.java
@@ -90,7 +90,8 @@ public class MillLauncherMain {
     if (runNoDaemon) {
       String mainClass = bspMode ? "mill.daemon.MillBspMain" : "mill.daemon.MillNoDaemonMain";
       // start in no-server mode
-      int exitCode = MillProcessLauncher.launchMillNoDaemon(args, outMode, runnerClasspath, mainClass);
+      int exitCode =
+          MillProcessLauncher.launchMillNoDaemon(args, outMode, runnerClasspath, mainClass);
       System.exit(exitCode);
     } else {
       var logs = new java.util.ArrayList<String>();

--- a/runner/launcher/src/mill/launcher/MillLauncherMain.java
+++ b/runner/launcher/src/mill/launcher/MillLauncherMain.java
@@ -88,8 +88,10 @@ public class MillLauncherMain {
         });
 
     if (runNoDaemon) {
+      String mainClass = bspMode ? "mill.daemon.MillBspMain" : "mill.daemon.MillNoDaemonMain";
       // start in no-server mode
-      System.exit(MillProcessLauncher.launchMillNoDaemon(args, outMode, runnerClasspath));
+      int exitCode = MillProcessLauncher.launchMillNoDaemon(args, outMode, runnerClasspath, mainClass);
+      System.exit(exitCode);
     } else {
       var logs = new java.util.ArrayList<String>();
       try {

--- a/runner/launcher/src/mill/launcher/MillProcessLauncher.java
+++ b/runner/launcher/src/mill/launcher/MillProcessLauncher.java
@@ -19,7 +19,8 @@ import mill.constants.*;
 
 public class MillProcessLauncher {
 
-  static int launchMillNoDaemon(String[] args, OutFolderMode outMode, String[] runnerClasspath, String mainClass)
+  static int launchMillNoDaemon(
+      String[] args, OutFolderMode outMode, String[] runnerClasspath, String mainClass)
       throws Exception {
     final String sig = String.format("%08x", UUID.randomUUID().hashCode());
     final Path processDir =

--- a/runner/launcher/src/mill/launcher/MillProcessLauncher.java
+++ b/runner/launcher/src/mill/launcher/MillProcessLauncher.java
@@ -19,7 +19,7 @@ import mill.constants.*;
 
 public class MillProcessLauncher {
 
-  static int launchMillNoDaemon(String[] args, OutFolderMode outMode, String[] runnerClasspath)
+  static int launchMillNoDaemon(String[] args, OutFolderMode outMode, String[] runnerClasspath, String mainClass)
       throws Exception {
     final String sig = String.format("%08x", UUID.randomUUID().hashCode());
     final Path processDir =
@@ -29,7 +29,7 @@ public class MillProcessLauncher {
     l.addAll(millLaunchJvmCommand(outMode, runnerClasspath));
     Map<String, String> propsMap = ClientUtil.getUserSetProperties();
     for (String key : propsMap.keySet()) l.add("-D" + key + "=" + propsMap.get(key));
-    l.add("mill.daemon.MillNoDaemonMain");
+    l.add(mainClass);
     l.add(processDir.toAbsolutePath().toString());
     l.add(outMode.asString());
     l.addAll(millOpts(outMode));


### PR DESCRIPTION
This should make the `MillBspMain` processes easier to distinguish from the command line from the `MillDaemonMain` or `MillNoDaemonMain` processes launched by users when you run `jps`.

Tested manually via `./mill dist.installLocalCache` and using the new version in a Mill project I load into Intellij. `jps` then shows the `MillBspMain` clearly separate from the other user-created Mill processes:

```console
$ jps
4930 MillNoDaemonMain
1717 
7063 MillLauncherMain
7080 Jps
5835 MillDaemonMain
749 Main
7070 MillBspMain
4927 NailgunRunner
```