### PR TITLE
Fix selective testing by consistently setting `COURSIER_ARCHIVE_CACHE`

### DIFF
--- a/.github/actions/post-build-selective/action.yml
+++ b/.github/actions/post-build-selective/action.yml
@@ -8,10 +8,6 @@ inputs:
     required: true
     type: string
 
-  coursierarchive:
-    default: ''
-    type: string
-
 runs:
   using: "composite"
   steps:
@@ -48,8 +44,6 @@ runs:
     #  shell: ${{ inputs.shell }}
 
     - run: ./mill -i -k selective.run ${{ inputs.millargs }}
-      env:
-        COURSIER_ARCHIVE_CACHE: ${{ inputs.coursierarchive }}
       shell: ${{ inputs.shell }}
 
     - name: Clean-up Test Reports

--- a/.github/workflows/post-build-selective.yml
+++ b/.github/workflows/post-build-selective.yml
@@ -33,6 +33,9 @@ on:
         default: false
         type: boolean
 
+env:
+  COURSIER_ARCHIVE_CACHE: ${{ inputs.coursierarchive }}
+
 jobs:
   run:
     runs-on: ${{ inputs.os }}
@@ -67,5 +70,4 @@ jobs:
 
         with:
           millargs: ${{ inputs.millargs }}
-          coursierarchive: ${{ inputs.coursierarchive }}
           shell: ${{ inputs.shell }}

--- a/.github/workflows/post-build-selective.yml
+++ b/.github/workflows/post-build-selective.yml
@@ -10,6 +10,10 @@ on:
         required: true
         type: string
 
+      coursierarchive:
+        default: "/tmp"
+        required: false
+        type: string
       java-version:
         required: true
         type: string
@@ -28,6 +32,9 @@ on:
       install-xvfb:
         default: false
         type: boolean
+
+env:
+  COURSIER_ARCHIVE_CACHE: ${{ inputs.coursierarchive }}
 
 jobs:
   run:

--- a/.github/workflows/post-build-selective.yml
+++ b/.github/workflows/post-build-selective.yml
@@ -10,10 +10,6 @@ on:
         required: true
         type: string
 
-      coursierarchive:
-        default: "/tmp"
-        required: false
-        type: string
       java-version:
         required: true
         type: string
@@ -32,9 +28,6 @@ on:
       install-xvfb:
         default: false
         type: boolean
-
-env:
-  COURSIER_ARCHIVE_CACHE: ${{ inputs.coursierarchive }}
 
 jobs:
   run:

--- a/.github/workflows/pre-build.yml
+++ b/.github/workflows/pre-build.yml
@@ -20,6 +20,14 @@ on:
         required: true
         type: string
 
+      coursierarchive:
+        default: "/tmp"
+        required: false
+        type: string
+
+env:
+  COURSIER_ARCHIVE_CACHE: ${{ inputs.coursierarchive }}
+
 jobs:
   run:
     runs-on: ${{ inputs.os }}

--- a/.github/workflows/publish-bridges.yaml
+++ b/.github/workflows/publish-bridges.yaml
@@ -26,7 +26,6 @@ jobs:
       LANG: "en_US.UTF-8"
       LC_MESSAGES: "en_US.UTF-8"
       LC_ALL: "en_US.UTF-8"
-      COURSIER_ARCHIVE_CACHE: ${{ matrix.coursierarchive }}
       REPO_ACCESS_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
       MILL_COMPILER_BRIDGE_VERSIONS: ${{ inputs.bridge_versions }}
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -71,6 +71,7 @@ jobs:
     with:
       os: windows-latest
       shell: powershell
+      coursierarchive: "C:/coursier-arc"
 
   test-docs:
     if: (github.event.action == 'ready_for_review') || (github.event.pull_request.draft == false)
@@ -224,10 +225,9 @@ jobs:
       java-version: ${{ matrix.java-version }}
       millargs: ${{ matrix.millargs }}
       shell: powershell
-    env:
       # Provide a shorter coursier archive folder to avoid hitting path-length bugs when
       # running the graal native image binary on windows
-      COURSIER_ARCHIVE_CACHE: "C:/coursier-arc"
+      coursierarchive: "C:/coursier-arc"
 
   itest:
     needs: build-linux

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -119,8 +119,6 @@ jobs:
         with:
           millargs: ${{ matrix.millargs }}
           shell: bash
-        env:
-          COURSIER_ARCHIVE_CACHE: "/tmp"
 
   linux:
     needs: build-linux

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -118,8 +118,9 @@ jobs:
       - uses: ./.github/actions/post-build-selective
         with:
           millargs: ${{ matrix.millargs }}
-          coursierarchive: "/tmp"
           shell: bash
+        env:
+          COURSIER_ARCHIVE_CACHE: "/tmp"
 
   linux:
     needs: build-linux
@@ -224,10 +225,11 @@ jobs:
       os: windows-latest
       java-version: ${{ matrix.java-version }}
       millargs: ${{ matrix.millargs }}
+      shell: powershell
+    env:
       # Provide a shorter coursier archive folder to avoid hitting path-length bugs when
       # running the graal native image binary on windows
-      coursierarchive: "C:/coursier-arc"
-      shell: powershell
+      COURSIER_ARCHIVE_CACHE: "C:/coursier-arc"
 
   itest:
     needs: build-linux


### PR DESCRIPTION
Should fix https://github.com/com-lihaoyi/mill/issues/5910, if https://github.com/com-lihaoyi/mill/pull/5916 doesn't work

This moves the `COURSIER_ARCHIVE_CACHE` configuration to coarse-grained job-level config rather than step-level config, ensuring it is applied consistently across all actions and steps, and preventing it from flipping back and forth and spuriously triggering selective testing