### PR TITLE
Fix prompt resizing when connecting to existing daemon

### DIFF
--- a/libs/daemon/client/src/mill/client/LaunchedServer.java
+++ b/libs/daemon/client/src/mill/client/LaunchedServer.java
@@ -20,7 +20,6 @@ public abstract class LaunchedServer {
     public boolean isAlive() {
       return process.isAlive();
     }
-
   }
 
   /// Code running in the same process.
@@ -42,6 +41,5 @@ public abstract class LaunchedServer {
     public boolean isAlive() {
       return thread.isAlive();
     }
-
   }
 }

--- a/libs/daemon/client/src/mill/client/LaunchedServer.java
+++ b/libs/daemon/client/src/mill/client/LaunchedServer.java
@@ -3,8 +3,6 @@ package mill.client;
 public abstract class LaunchedServer {
   public abstract boolean isAlive();
 
-  public abstract void kill();
-
   /// An operating system process was launched.
   public static class OsProcess extends LaunchedServer {
     public final ProcessHandle process;
@@ -23,12 +21,6 @@ public abstract class LaunchedServer {
       return process.isAlive();
     }
 
-    @Override
-    public void kill() {
-      if (!process.destroy())
-        throw new IllegalStateException(
-            "Asked " + process + " to terminate, but the termination request failed.");
-    }
   }
 
   /// Code running in the same process.
@@ -51,9 +43,5 @@ public abstract class LaunchedServer {
       return thread.isAlive();
     }
 
-    @Override
-    public void kill() {
-      _kill.run();
-    }
   }
 }

--- a/libs/daemon/client/src/mill/client/ServerLauncher.java
+++ b/libs/daemon/client/src/mill/client/ServerLauncher.java
@@ -37,32 +37,21 @@ import mill.constants.ProxyStream;
 ///   - Wait for `ProxyStream.END` packet or `clientSocket.close()`,
 ///     indicating server has finished execution and all data has been received
 public abstract class ServerLauncher {
-  public static class RunWithConnectionResult<A> {
-    public final A result;
-
-    public final int exitCode;
-
-    public RunWithConnectionResult(A result, int exitCode) {
-      this.result = result;
-      this.exitCode = exitCode;
-    }
-  }
 
   /// Run a client logic with a connection established to a Mill server (via [#connectToServer]).
   ///
   /// @param connection     the socket connected to the server
   /// @param streams        streams to use for the client logic
-  /// @param closeConnectionAfterClientLogic whether to close the connection after running the
-  // client logic
+  /// @param closeConnectionAfterClientLogic whether to close the connection after running the client logic
   /// @param runClientLogic the client logic to run
   /// @return the exit code that the server sent back
-  public static <A> RunWithConnectionResult<A> runWithConnection(
-      String debugName,
+  public static int runWithConnection(
       Socket connection,
       Streams streams,
       boolean closeConnectionAfterClientLogic,
       Consumer<OutputStream> sendInitData,
-      RunClientLogic<A> runClientLogic)
+      Runnable runClientLogic,
+      String debugName)
       throws Exception {
     // According to
     // https://pzemtsov.github.io/2015/01/19/on-the-benefits-of-stream-buffering-in-Java.html it
@@ -76,21 +65,19 @@ public abstract class ServerLauncher {
     socketOutputStream.flush();
     var pumperThread =
         startStreamPumpers(socketInputStream, socketOutputStream, streams, debugName);
-    var result = runClientLogic.run();
+    runClientLogic.run();
     if (closeConnectionAfterClientLogic) socketInputStream.close();
     pumperThread.join();
-    return new RunWithConnectionResult<>(result, pumperThread.exitCode());
+    return pumperThread.exitCode();
   }
 
   /// Run a client logic with a connection established to a Mill server (via [#connectToServer]).
   ///
   /// @param connection     the socket connected to the server
-  /// @param closeConnectionAfterClientLogic whether to close the connection after running the
-  // client logic
+  /// @param closeConnectionAfterClientLogic whether to close the connection after running the client logic
   /// @param runClientLogic the client logic to run
   /// @return the exit code that the server sent back
   public static <A> A runWithConnection(
-      String debugName,
       Socket connection,
       boolean closeConnectionAfterClientLogic,
       Consumer<OutputStream> sendInitData,
@@ -353,24 +340,9 @@ public abstract class ServerLauncher {
     LaunchedServer init() throws Exception;
   }
 
-  public interface RunClientLogic<A> {
-    /// Runs the client logic.
-    A run() throws Exception;
-  }
-
   public interface RunClientLogicWithStreams<A> {
     /// Runs the client logic.
     A run(BufferedInputStream inStream, BufferedOutputStream outStream) throws Exception;
-  }
-
-  public static class Result {
-    public final int exitCode;
-    public final Path daemonDir;
-
-    public Result(int exitCode, Path daemonDir) {
-      this.exitCode = exitCode;
-      this.daemonDir = daemonDir;
-    }
   }
 
   public static class Streams {

--- a/libs/daemon/client/src/mill/client/ServerLauncher.java
+++ b/libs/daemon/client/src/mill/client/ServerLauncher.java
@@ -42,7 +42,8 @@ public abstract class ServerLauncher {
   ///
   /// @param connection     the socket connected to the server
   /// @param streams        streams to use for the client logic
-  /// @param closeConnectionAfterClientLogic whether to close the connection after running the client logic
+  /// @param closeConnectionAfterClientLogic whether to close the connection after running the
+  // client logic
   /// @param runClientLogic the client logic to run
   /// @return the exit code that the server sent back
   public static int runWithConnection(
@@ -74,7 +75,8 @@ public abstract class ServerLauncher {
   /// Run a client logic with a connection established to a Mill server (via [#connectToServer]).
   ///
   /// @param connection     the socket connected to the server
-  /// @param closeConnectionAfterClientLogic whether to close the connection after running the client logic
+  /// @param closeConnectionAfterClientLogic whether to close the connection after running the
+  // client logic
   /// @param runClientLogic the client logic to run
   /// @return the exit code that the server sent back
   public static <A> A runWithConnection(
@@ -253,7 +255,6 @@ public abstract class ServerLauncher {
                       public boolean isAlive() {
                         throw new RuntimeException("not implemented, this should never happen");
                       }
-
                     };
             return Optional.of(new ServerLaunchResult.AlreadyRunning(launchedServer));
           } catch (IOException | NumberFormatException e) {

--- a/libs/daemon/client/src/mill/client/ServerLauncher.java
+++ b/libs/daemon/client/src/mill/client/ServerLauncher.java
@@ -254,10 +254,6 @@ public abstract class ServerLauncher {
                         throw new RuntimeException("not implemented, this should never happen");
                       }
 
-                      @Override
-                      public void kill() {
-                        throw new RuntimeException("not implemented, this should never happen");
-                      }
                     };
             return Optional.of(new ServerLaunchResult.AlreadyRunning(launchedServer));
           } catch (IOException | NumberFormatException e) {

--- a/libs/javalib/worker/src/mill/javalib/worker/JvmWorkerImpl.scala
+++ b/libs/javalib/worker/src/mill/javalib/worker/JvmWorkerImpl.scala
@@ -340,7 +340,6 @@ class JvmWorkerImpl(args: JvmWorkerArgs) extends JvmWorkerApi with AutoCloseable
           val debugName =
             s"ZincWorker,TCP ${socket.getRemoteSocketAddress} -> ${socket.getLocalSocketAddress}"
           ServerLauncher.runWithConnection(
-            debugName,
             socket,
             /* closeConnectionAfterCommand */ true,
             /* sendInitData */ _ => {},

--- a/runner/client/src/mill/client/MillServerLauncher.java
+++ b/runner/client/src/mill/client/MillServerLauncher.java
@@ -92,14 +92,14 @@ public abstract class MillServerLauncher extends ServerLauncher {
             log.accept("running client logic");
             forceTestFailure(daemonDir, log);
           },
-        "MillServerLauncher[" + launched.socket.getLocalSocketAddress() + " -> "
-          + launched.socket.getRemoteSocketAddress() + "]");
+          "MillServerLauncher[" + launched.socket.getLocalSocketAddress() + " -> "
+              + launched.socket.getRemoteSocketAddress() + "]");
       log.accept("runWithConnection exit code: " + result);
       return result;
     }
   }
 
-  private void forceTestFailure(Path daemonDir, Consumer<String> log)  {
+  private void forceTestFailure(Path daemonDir, Consumer<String> log) {
     if (forceFailureForTestingMillisDelay > 0) {
       log.accept(
           "Force failure for testing in " + forceFailureForTestingMillisDelay + "ms: " + daemonDir);

--- a/runner/client/src/mill/client/MillServerLauncher.java
+++ b/runner/client/src/mill/client/MillServerLauncher.java
@@ -43,7 +43,7 @@ public abstract class MillServerLauncher extends ServerLauncher {
    */
   public abstract LaunchedServer initServer(Path daemonDir, Locks locks) throws Exception;
 
-  public Result run(Path daemonDir, String javaHome, Consumer<String> log) throws Exception {
+  public int run(Path daemonDir, String javaHome, Consumer<String> log) throws Exception {
     Files.createDirectories(daemonDir);
 
     var initData = new ClientInitData(
@@ -76,8 +76,6 @@ public abstract class MillServerLauncher extends ServerLauncher {
         true /*openSocket*/)) {
       log.accept("runWithConnection: " + launched);
       var result = runWithConnection(
-          "MillServerLauncher[" + launched.socket.getLocalSocketAddress() + " -> "
-              + launched.socket.getRemoteSocketAddress() + "]",
           launched.socket,
           streams,
           false,
@@ -93,19 +91,24 @@ public abstract class MillServerLauncher extends ServerLauncher {
           () -> {
             log.accept("running client logic");
             forceTestFailure(daemonDir, log);
-            return 0;
-          });
-      log.accept("runWithConnection exit code: " + result.exitCode);
-      return new Result(result.exitCode, daemonDir);
+          },
+        "MillServerLauncher[" + launched.socket.getLocalSocketAddress() + " -> "
+          + launched.socket.getRemoteSocketAddress() + "]");
+      log.accept("runWithConnection exit code: " + result);
+      return result;
     }
   }
 
-  private void forceTestFailure(Path daemonDir, Consumer<String> log) throws Exception {
+  private void forceTestFailure(Path daemonDir, Consumer<String> log)  {
     if (forceFailureForTestingMillisDelay > 0) {
       log.accept(
           "Force failure for testing in " + forceFailureForTestingMillisDelay + "ms: " + daemonDir);
-      Thread.sleep(forceFailureForTestingMillisDelay);
-      throw new Exception("Force failure for testing: " + daemonDir);
+      try {
+        Thread.sleep(forceFailureForTestingMillisDelay);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+      throw new RuntimeException("Force failure for testing: " + daemonDir);
     } else {
       log.accept("No force failure for testing: " + daemonDir);
     }

--- a/runner/launcher/src/mill/launcher/MillLauncherMain.java
+++ b/runner/launcher/src/mill/launcher/MillLauncherMain.java
@@ -116,12 +116,13 @@ public class MillLauncherMain {
               }
             };
 
-        var daemonDir0 = Paths.get(outDir, OutFiles.millDaemon);
+        var daemonDir = Paths.get(outDir, OutFiles.millDaemon);
         String javaHome = MillProcessLauncher.javaHome(outMode);
 
-        var exitCode = launcher.run(daemonDir0, javaHome, log).exitCode;
+        MillProcessLauncher.prepareMillRunFolder(daemonDir);
+        var exitCode = launcher.run(daemonDir, javaHome, log).exitCode;
         if (exitCode == ClientUtil.ExitServerCodeWhenVersionMismatch()) {
-          exitCode = launcher.run(daemonDir0, javaHome, log).exitCode;
+          exitCode = launcher.run(daemonDir, javaHome, log).exitCode;
         }
         System.exit(exitCode);
       } catch (Exception e) {

--- a/runner/launcher/src/mill/launcher/MillLauncherMain.java
+++ b/runner/launcher/src/mill/launcher/MillLauncherMain.java
@@ -117,9 +117,9 @@ public class MillLauncherMain {
         String javaHome = MillProcessLauncher.javaHome(outMode);
 
         MillProcessLauncher.prepareMillRunFolder(daemonDir);
-        var exitCode = launcher.run(daemonDir, javaHome, log).exitCode;
+        var exitCode = launcher.run(daemonDir, javaHome, log);
         if (exitCode == ClientUtil.ExitServerCodeWhenVersionMismatch()) {
-          exitCode = launcher.run(daemonDir, javaHome, log).exitCode;
+          exitCode = launcher.run(daemonDir, javaHome, log);
         }
         System.exit(exitCode);
       } catch (Exception e) {

--- a/runner/launcher/src/mill/launcher/MillLauncherMain.java
+++ b/runner/launcher/src/mill/launcher/MillLauncherMain.java
@@ -48,12 +48,9 @@ public class MillLauncherMain {
     // Ensure that if we're running in BSP mode we don't start a daemon.
     //
     // This is needed because when Metals/Idea closes, they only kill the BSP client and the BSP
-    // server lurks around
-    // waiting for the next client to connect.
-    //
+    // server lurks around waiting for the next client to connect.
     // This is unintuitive from the user's perspective and wastes resources, as most people expect
-    // everything related
-    // to the BSP server to be killed when closing the editor.
+    // everything related to the BSP server to be killed when closing the editor.
     if (bspMode) runNoDaemon = true;
 
     var outMode = bspMode ? OutFolderMode.BSP : OutFolderMode.REGULAR;

--- a/runner/launcher/src/mill/launcher/MillProcessLauncher.java
+++ b/runner/launcher/src/mill/launcher/MillProcessLauncher.java
@@ -26,6 +26,8 @@ public class MillProcessLauncher {
     final Path processDir =
         Paths.get(".").resolve(outFor(outMode)).resolve(millNoDaemon).resolve(sig);
 
+    MillProcessLauncher.prepareMillRunFolder(processDir);
+
     final List<String> l = new ArrayList<>();
     l.addAll(millLaunchJvmCommand(outMode, runnerClasspath));
     Map<String, String> propsMap = ClientUtil.getUserSetProperties();
@@ -77,7 +79,7 @@ public class MillProcessLauncher {
 
     Path sandbox = daemonDir.resolve(DaemonFiles.sandbox);
     Files.createDirectories(sandbox);
-    MillProcessLauncher.prepareMillRunFolder(daemonDir);
+
     builder.environment().put(EnvVars.MILL_WORKSPACE_ROOT, new File("").getCanonicalPath());
     if (System.getenv(EnvVars.MILL_EXECUTABLE_PATH) == null)
       builder.environment().put(EnvVars.MILL_EXECUTABLE_PATH, getExecutablePath());

--- a/runner/server/test/src/mill/server/ClientServerTests.scala
+++ b/runner/server/test/src/mill/server/ClientServerTests.scala
@@ -99,6 +99,7 @@ object ClientServerTests extends TestSuite {
       val in = new ByteArrayInputStream(s"hello$ENDL".getBytes())
       val out = new ByteArrayOutputStream()
       val err = new ByteArrayOutputStream()
+      val daemonDir = outDir / "server-0"
       val result = new MillServerLauncher(
         ServerLauncher.Streams(in, out, err),
         env.asJava,
@@ -121,14 +122,14 @@ object ClientServerTests extends TestSuite {
           LaunchedServer.NewThread(t, () => { /* do nothing */ })
         }
       }.run(
-        (outDir / "server-0").relativeTo(os.pwd).toNIO,
+        daemonDir.relativeTo(os.pwd).toNIO,
         "",
         msg => println(s"MillServerLauncher: $msg")
       )
 
       ClientResult(
-        result.exitCode,
-        os.Path(result.daemonDir, os.pwd),
+        result,
+        daemonDir,
         outDir,
         out.toString,
         err.toString


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/5919

This regressed in https://github.com/com-lihaoyi/mill/pull/5832, which made us only start the `terminfo` writing thread when spawning a new server, which neglects the case where we are connecting to an existing server. Thus when you ran `./mill clean && ./mill __.compile`, the `__.compile` runs with a launcher connected to the existing server, and thus doesn't update when the terminal size changes

This PR makes us start the `terminfo` thread regardless of whether we are spawning a new server or not. Tested manually

Also did some cleanup of `libs/daemon/client` to remove dead code. 

