### PR TITLE
Android: Generate MinifyKeepRules for Proguard 

### DIFF
--- a/example/thirdparty/android-compose-samples/build.mill
+++ b/example/thirdparty/android-compose-samples/build.mill
@@ -20,8 +20,7 @@ object JetLagged extends mill.api.Module {
 
     override def androidDebugSettings: T[AndroidBuildTypeSettings] = Task {
       AndroidBuildTypeSettings(
-        isMinifyEnabled = false,
-        isShrinkEnabled = false
+        isMinifyEnabled = false
       )
     }
 
@@ -129,8 +128,7 @@ object JetNews extends mill.api.Module {
 
     override def androidDebugSettings: T[AndroidBuildTypeSettings] = Task {
       AndroidBuildTypeSettings(
-        isMinifyEnabled = false,
-        isShrinkEnabled = false
+        isMinifyEnabled = false
       )
     }
     def androidProjectProguardFiles = Task.Sources(

--- a/example/thirdparty/androidtodo/build.mill
+++ b/example/thirdparty/androidtodo/build.mill
@@ -31,8 +31,7 @@ object app
 
   override def androidDebugSettings: T[AndroidBuildTypeSettings] = Task {
     AndroidBuildTypeSettings(
-      isMinifyEnabled = false,
-      isShrinkEnabled = false
+      isMinifyEnabled = false
     )
   }
 
@@ -161,8 +160,7 @@ object app
 
     override def androidDebugSettings: T[AndroidBuildTypeSettings] = Task {
       AndroidBuildTypeSettings(
-        isMinifyEnabled = false,
-        isShrinkEnabled = false
+        isMinifyEnabled = false
       )
     }
 

--- a/libs/androidlib/src/mill/androidlib/AndroidBuildTypeSettings.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidBuildTypeSettings.scala
@@ -10,7 +10,6 @@ package mill.androidlib
  */
 case class AndroidBuildTypeSettings(
     isMinifyEnabled: Boolean = false,
-    isShrinkEnabled: Boolean = false,
     enableDesugaring: Boolean = true
 )
 

--- a/libs/androidlib/src/mill/androidlib/AndroidR8AppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidR8AppModule.scala
@@ -267,7 +267,8 @@ trait AndroidR8AppModule extends AndroidAppModule {
   /**
    * Generates ProGuard/R8 keep rules to keep classes that are referenced in the AndroidManifest.xml
    * and in the layout XML files (for custom views).
-   * https://android.googlesource.com/platform/tools/base/+/studio-master-dev/build-system/gradle-core/src/main/java/com/android/build/gradle/internal/tasks/GenerateLibraryProguardRulesTask.kt
+   *
+   * [[https://android.googlesource.com/platform/tools/base/+/refs/tags/studio-2025.1.3/sdk-common/src/main/java/com/android/ide/common/symbols/SymbolUtils.kt#235]]
    */
   def generatedMinifyKeepRules: T[Seq[String]] = Task {
     val keepClasses = extractKeepClassesFromManifest() ++ extractKeepClassesFromResources()
@@ -282,6 +283,13 @@ trait AndroidR8AppModule extends AndroidAppModule {
     }
   }
 
+
+  /**
+   * Extracts the classes to keep from the Manifest file.
+   *
+   * See `mManifestData.mKeepClasses` in
+   * [[https://android.googlesource.com/platform/tools/base/+/refs/tags/studio-2025.1.3/sdk-common/src/main/java/com/android/ide/common/xml/AndroidManifestParser.java]]
+   */
   def extractKeepClassesFromManifest: T[Seq[String]] = Task {
     val manifestPath: os.Path = androidMergedManifest().path
     val manifest = XML.loadFile(manifestPath.toIO)

--- a/libs/androidlib/src/mill/androidlib/AndroidR8AppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidR8AppModule.scala
@@ -267,7 +267,6 @@ trait AndroidR8AppModule extends AndroidAppModule {
     (PathRef(outputPath), r8Args, allClassFilesPathRefs)
   }
 
-
   /**
    * Generates ProGuard/R8 keep rules to keep classes that are referenced in the AndroidManifest.xml
    * and in the layout XML files (for custom views).

--- a/libs/androidlib/src/mill/androidlib/AndroidR8AppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidR8AppModule.scala
@@ -166,7 +166,7 @@ trait AndroidR8AppModule extends AndroidAppModule {
         s"-printseeds $seedsOut",
         s"-printusage $usageOut"
       ) ++
-        (if (androidBuildSettings().isMinifyEnabled) then generatedMinifyKeepRules()
+        (if (androidBuildSettings().isMinifyEnabled) then androidGeneratedMinifyKeepRules()
          else Seq())
     // Create an extra ProGuard config file
     val extraRulesFile = destDir / "extra-rules.pro"
@@ -270,7 +270,7 @@ trait AndroidR8AppModule extends AndroidAppModule {
    *
    * [[https://android.googlesource.com/platform/tools/base/+/refs/tags/studio-2025.1.3/sdk-common/src/main/java/com/android/ide/common/symbols/SymbolUtils.kt#235]]
    */
-  def generatedMinifyKeepRules: T[Seq[String]] = Task {
+  def androidGeneratedMinifyKeepRules: T[Seq[String]] = Task {
     val keepClasses = extractKeepClassesFromManifest() ++ extractKeepClassesFromResources()
     keepClasses.map(c => s"-keep class $c { *; }")
   }
@@ -290,7 +290,7 @@ trait AndroidR8AppModule extends AndroidAppModule {
    * See `mManifestData.mKeepClasses` in
    * [[https://android.googlesource.com/platform/tools/base/+/refs/tags/studio-2025.1.3/sdk-common/src/main/java/com/android/ide/common/xml/AndroidManifestParser.java]]
    */
-  def extractKeepClassesFromManifest: T[Seq[String]] = Task {
+  private def extractKeepClassesFromManifest: T[Seq[String]] = Task {
     val manifestPath: os.Path = androidMergedManifest().path
     val manifest = XML.loadFile(manifestPath.toIO)
     val packageName: String = (manifest \ "@package").text
@@ -315,7 +315,7 @@ trait AndroidR8AppModule extends AndroidAppModule {
     nodes.flatMap(collectClasses).distinct
   }
 
-  def extractKeepClassesFromResources: T[Seq[String]] = Task {
+  private def extractKeepClassesFromResources: T[Seq[String]] = Task {
     val resDirs: Seq[os.Path] = androidResources().map(_.path)
 
     val layoutXmls: Seq[os.Path] = resDirs.flatMap { resDir =>

--- a/libs/androidlib/src/mill/androidlib/AndroidR8AppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidR8AppModule.scala
@@ -94,8 +94,7 @@ trait AndroidR8AppModule extends AndroidAppModule {
    */
   def androidReleaseSettings: T[AndroidBuildTypeSettings] = Task {
     AndroidBuildTypeSettings(
-      isMinifyEnabled = true,
-      isShrinkEnabled = true
+      isMinifyEnabled = true
     )
   }
 
@@ -210,11 +209,7 @@ trait AndroidR8AppModule extends AndroidAppModule {
     }
 
     if (!androidBuildSettings().isMinifyEnabled) {
-      r8ArgsBuilder += "--no-minification"
-    }
-
-    if (!androidBuildSettings().isShrinkEnabled) {
-      r8ArgsBuilder += "--no-tree-shaking"
+      r8ArgsBuilder ++= Seq("--no-minification", "--no-tree-shaking")
     }
 
     r8ArgsBuilder ++= Seq(
@@ -281,8 +276,8 @@ trait AndroidR8AppModule extends AndroidAppModule {
 
   private def combinePackageAndClassName(packageName: String, className: String): String = {
     className match {
-      case c if c.startsWith(".") => packageName + c
-      case c if !c.contains(".") => packageName + "." + c
+      case c if c.startsWith(".") => s"$packageName$c"
+      case c if !c.contains(".") => s"$packageName.$c"
       case c => c
     }
   }

--- a/libs/androidlib/src/mill/androidlib/AndroidR8AppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidR8AppModule.scala
@@ -161,12 +161,14 @@ trait AndroidR8AppModule extends AndroidAppModule {
     destDir / "res"
 
     // Extra ProGuard rules
-    val extraRules = generatedMinifyKeepRules() ++
+    val extraRules =
       Seq(
         // Instruct R8 to print seeds and usage.
         s"-printseeds $seedsOut",
         s"-printusage $usageOut"
-      )
+      ) ++
+        (if (androidBuildSettings().isMinifyEnabled) then generatedMinifyKeepRules()
+         else Seq())
     // Create an extra ProGuard config file
     val extraRulesFile = destDir / "extra-rules.pro"
     val extraRulesContent = extraRules.mkString("\n")

--- a/libs/androidlib/src/mill/androidlib/AndroidR8AppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidR8AppModule.scala
@@ -283,7 +283,6 @@ trait AndroidR8AppModule extends AndroidAppModule {
     }
   }
 
-
   /**
    * Extracts the classes to keep from the Manifest file.
    *


### PR DESCRIPTION
Generate keep rules for user defined classes in order to improve the minification. Relevant Issue: https://github.com/com-lihaoyi/mill/issues/5893

Implementation is the same as Gradle's: ([Task](https://android.googlesource.com/platform/tools/base/+/studio-master-dev/build-system/gradle-core/src/main/java/com/android/build/gradle/internal/tasks/GenerateLibraryProguardRulesTask.kt), [Impl](https://android.googlesource.com/platform/tools/base/+/refs/tags/studio-2025.1.3/sdk-common/src/main/java/com/android/ide/common/symbols/SymbolUtils.kt#235)):
- Extract `name` tags from the merged Manifest
- Extract tags from `res/layout*.xml` files


<img width="1173" height="323" alt="image" src="https://github.com/user-attachments/assets/6ad479c7-d1f8-46a7-9329-55c0bb57b7ce" />


### APK Comparison
Release APK with Mill:
<img width="1394" height="331" alt="image" src="https://github.com/user-attachments/assets/6b874e8c-95ae-4787-a819-3e00e3b83447" />

Release APK with Gradle:
<img width="1395" height="430" alt="image" src="https://github.com/user-attachments/assets/cb55eb81-bce6-4933-8610-9b8a9c7ac0ce" />

