### PR TITLE
Run examples with local repo under out/ rather than ~/.ivy2/local

### DIFF
--- a/dist/package.mill
+++ b/dist/package.mill
@@ -9,6 +9,9 @@ import mill.util.Jvm
 import millbuild.*
 import mill.api.BuildCtx
 import scala.util.Using
+import scala.util.Properties
+import java.nio.file.Files
+import java.nio.file.attribute.PosixFilePermission
 
 trait DistModule extends Module {
   // All modules that we want to aggregate as part of this `dev` assembly.
@@ -19,9 +22,49 @@ trait DistModule extends Module {
 
   def executableRaw: T[PathRef]
 
+  def localRepo: T[PathRef] = Task {
+    val dest = Task.dest
+    val repos = Task.traverse(allPublishModules)(m => m.publishLocalTestRepo)().map(_.path)
+    for (repo <- repos; elem <- os.list(repo))
+      os.copy.into(elem, dest, mergeFolders = true)
+    PathRef(dest)
+  }
+
   def executable = Task {
-    Task.traverse(allPublishModules)(m => m.publishLocal(doc = false))()
-    executableRaw()
+    val rawExecutable = executableRaw()
+    if (Properties.isWin) {
+      val launcher = Task.dest / "mill.bat"
+      val launcherContent =
+        s"""@echo off
+           |set "NEW_COURSIER_REPOSITORIES=${localRepo().path.toNIO.toUri.toASCIIString}|ivy2Local|central"
+           |if defined COURSIER_REPOSITORIES (
+           |  set "NEW_COURSIER_REPOSITORIES=%NEW_COURSIER_REPOSITORIES%|%COURSIER_REPOSITORIES%"
+           |) else (
+           |  set "NEW_COURSIER_REPOSITORIES=%NEW_COURSIER_REPOSITORIES%|ivy2Local|central"
+           |)
+           |set "COURSIER_REPOSITORIES=%NEW_COURSIER_REPOSITORIES%"
+           |set NEW_COURSIER_REPOSITORIES=
+           |"${rawExecutable.path.toString.replace("\"", "\\\"")}" %*
+           |if errorlevel 1 exit /b %errorlevel%
+           |""".stripMargin
+      os.write(launcher, launcherContent)
+      PathRef(launcher)
+    } else {
+      val launcher = Task.dest / "mill"
+      val launcherContent =
+        s"""#!/usr/bin/env bash
+           |set -e
+           |export COURSIER_REPOSITORIES="${localRepo().path.toNIO.toUri.toASCIIString}|$${COURSIER_REPOSITORIES:-ivy2Local|central}"
+           |exec '${rawExecutable.path.toString.replace("'", "\\'")}' "$$@"
+           |""".stripMargin
+      os.write(launcher, launcherContent)
+      val perms = Files.getPosixFilePermissions(launcher.toNIO)
+      perms.add(PosixFilePermission.OWNER_EXECUTE)
+      perms.add(PosixFilePermission.GROUP_EXECUTE)
+      perms.add(PosixFilePermission.OTHERS_EXECUTE)
+      Files.setPosixFilePermissions(launcher.toNIO, perms)
+      PathRef(launcher)
+    }
   }
 
   def localBinName: String
@@ -32,11 +75,10 @@ trait DistModule extends Module {
    * Build and install Mill locally.
    *
    * @param binFile The location where the Mill binary should be installed
-   * @param ivyRepo The local Ivy repository where Mill modules should be published to
    */
-  def installLocal(binFile: String = localBinName, ivyRepo: String = null) =
+  def installLocal(binFile: String = localBinName) =
     Task.Command {
-      PathRef(installLocalTask(Task.Anon(binFile), ivyRepo)())
+      PathRef(installLocalTask(Task.Anon(binFile), globalInstall = true)())
     }
 
   val batExt = if (scala.util.Properties.isWin) ".bat" else ""
@@ -53,16 +95,30 @@ trait DistModule extends Module {
     PathRef(path)
   }
 
-  def installLocalTask(binFile: Task[String], ivyRepo: String = null): Task[os.Path] = Task.Anon {
-    val targetFile = os.Path(binFile(), BuildCtx.workspaceRoot)
-    if (os.exists(targetFile))
-      Task.log.info(s"Overwriting existing local Mill binary at ${targetFile}")
-    os.copy.over(executable().path, targetFile, createFolders = true)
-    Task.log.info(
-      s"Published ${build.dist.allPublishModules.size} modules and installed ${targetFile}"
-    )
-    targetFile
-  }
+  def installLocalTask(binFile: Task[String], globalInstall: Boolean = false): Task[os.Path] =
+    if (globalInstall)
+      Task.Anon {
+        val targetFile = os.Path(binFile(), BuildCtx.workspaceRoot)
+        if (os.exists(targetFile))
+          Task.log.info(s"Overwriting existing local Mill binary at ${targetFile}")
+        Task.traverse(allPublishModules)(m => m.publishLocal(doc = false))()
+        os.copy.over(executableRaw().path, targetFile, createFolders = true)
+        Task.log.info(
+          s"Published ${build.dist.allPublishModules.size} modules globally and installed ${targetFile}"
+        )
+        targetFile
+      }
+    else
+      Task.Anon {
+        val targetFile = os.Path(binFile(), BuildCtx.workspaceRoot)
+        if (os.exists(targetFile))
+          Task.log.info(s"Overwriting existing local Mill binary at ${targetFile}")
+        os.copy.over(executable().path, targetFile, createFolders = true)
+        Task.log.info(
+          s"Published ${build.dist.allPublishModules.size} modules under local repo and installed ${targetFile}"
+        )
+        targetFile
+      }
 
   def artifactName: T[String]
   def artifact = Task { Artifact(Settings.pomOrg, artifactName(), build.millVersion()) }

--- a/integration/ide/bsp-server/resources/snapshots/build-targets-jvm-test-environments.json
+++ b/integration/ide/bsp-server/resources/snapshots/build-targets-jvm-test-environments.json
@@ -18,7 +18,7 @@
         "file:///workspace/app/test/compile-resources",
         "file:///workspace/app/test/resources",
         "file:///workspace/out/mill-bsp-out/app/test/compile.dest/classes",
-        "file:///user-home/.ivy2/local/com.lihaoyi/mill-libs-javalib-testrunner-entrypoint/SNAPSHOT/jars/mill-libs-javalib-testrunner-entrypoint.jar",
+        "file:///mill-workspace/out/dist/localRepo.dest/com/lihaoyi/mill-libs-javalib-testrunner-entrypoint/SNAPSHOT/mill-libs-javalib-testrunner-entrypoint-SNAPSHOT.jar",
         "file:///coursier-cache/https/repo1.maven.org/maven2/org/scala-sbt/test-interface/1.0/test-interface-1.0.jar"
       ],
       "jvmOptions": [],
@@ -52,7 +52,7 @@
         "file:///workspace/hello-java/test/compile-resources",
         "file:///workspace/hello-java/test/resources",
         "file:///workspace/out/mill-bsp-out/hello-java/test/compile.dest/classes",
-        "file:///user-home/.ivy2/local/com.lihaoyi/mill-libs-javalib-testrunner-entrypoint/SNAPSHOT/jars/mill-libs-javalib-testrunner-entrypoint.jar",
+        "file:///mill-workspace/out/dist/localRepo.dest/com/lihaoyi/mill-libs-javalib-testrunner-entrypoint/SNAPSHOT/mill-libs-javalib-testrunner-entrypoint-SNAPSHOT.jar",
         "file:///coursier-cache/https/repo1.maven.org/maven2/org/scala-sbt/test-interface/1.0/test-interface-1.0.jar"
       ],
       "jvmOptions": [],
@@ -87,7 +87,7 @@
         "file:///workspace/hello-scala/test/compile-resources",
         "file:///workspace/hello-scala/test/resources",
         "file:///workspace/out/mill-bsp-out/hello-scala/test/compile.dest/classes",
-        "file:///user-home/.ivy2/local/com.lihaoyi/mill-libs-javalib-testrunner-entrypoint/SNAPSHOT/jars/mill-libs-javalib-testrunner-entrypoint.jar",
+        "file:///mill-workspace/out/dist/localRepo.dest/com/lihaoyi/mill-libs-javalib-testrunner-entrypoint/SNAPSHOT/mill-libs-javalib-testrunner-entrypoint-SNAPSHOT.jar",
         "file:///coursier-cache/https/repo1.maven.org/maven2/org/scala-sbt/test-interface/1.0/test-interface-1.0.jar"
       ],
       "jvmOptions": [],

--- a/integration/ide/build-classpath-contents/src/BuildClasspathContentsTests.scala
+++ b/integration/ide/build-classpath-contents/src/BuildClasspathContentsTests.scala
@@ -18,36 +18,37 @@ object BuildClasspathContentsTests extends UtestIntegrationTestSuite {
         .filter(_.startsWith(BuildCtx.workspaceRoot))
         .map(_.subRelativeTo(BuildCtx.workspaceRoot))
         .filter(!_.startsWith("out/integration"))
+        .filter(!_.startsWith("out/dist/localRepo.dest"))
         .map(_.toString)
         .sorted
       if (sys.env("MILL_INTEGRATION_IS_PACKAGED_LAUNCHER") == "true") {
         assertGoldenLiteral(
           millPublishedJars,
           List(
-            "mill-core-api-daemon_3.jar",
-            "mill-core-api_3.jar",
-            "mill-core-constants.jar",
-            "mill-libs-androidlib-databinding_3.jar",
-            "mill-libs-androidlib_3.jar",
-            "mill-libs-daemon-client.jar",
-            "mill-libs-daemon-server_3.jar",
-            "mill-libs-javalib-api_3.jar",
-            "mill-libs-javalib-testrunner-entrypoint.jar",
-            "mill-libs-javalib-testrunner_3.jar",
-            "mill-libs-javalib_3.jar",
-            "mill-libs-javascriptlib_3.jar",
-            "mill-libs-kotlinlib-api_3.jar",
-            "mill-libs-kotlinlib-ksp2-api_3.jar",
-            "mill-libs-kotlinlib_3.jar",
-            "mill-libs-pythonlib_3.jar",
-            "mill-libs-rpc_3.jar",
-            "mill-libs-scalajslib-api_3.jar",
-            "mill-libs-scalajslib_3.jar",
-            "mill-libs-scalalib_3.jar",
-            "mill-libs-scalanativelib-api_3.jar",
-            "mill-libs-scalanativelib_3.jar",
-            "mill-libs-util_3.jar",
-            "mill-libs_3.jar",
+            "mill-core-api-daemon_3-SNAPSHOT.jar",
+            "mill-core-api_3-SNAPSHOT.jar",
+            "mill-core-constants-SNAPSHOT.jar",
+            "mill-libs-androidlib-databinding_3-SNAPSHOT.jar",
+            "mill-libs-androidlib_3-SNAPSHOT.jar",
+            "mill-libs-daemon-client-SNAPSHOT.jar",
+            "mill-libs-daemon-server_3-SNAPSHOT.jar",
+            "mill-libs-javalib-api_3-SNAPSHOT.jar",
+            "mill-libs-javalib-testrunner-entrypoint-SNAPSHOT.jar",
+            "mill-libs-javalib-testrunner_3-SNAPSHOT.jar",
+            "mill-libs-javalib_3-SNAPSHOT.jar",
+            "mill-libs-javascriptlib_3-SNAPSHOT.jar",
+            "mill-libs-kotlinlib-api_3-SNAPSHOT.jar",
+            "mill-libs-kotlinlib-ksp2-api_3-SNAPSHOT.jar",
+            "mill-libs-kotlinlib_3-SNAPSHOT.jar",
+            "mill-libs-pythonlib_3-SNAPSHOT.jar",
+            "mill-libs-rpc_3-SNAPSHOT.jar",
+            "mill-libs-scalajslib-api_3-SNAPSHOT.jar",
+            "mill-libs-scalajslib_3-SNAPSHOT.jar",
+            "mill-libs-scalalib_3-SNAPSHOT.jar",
+            "mill-libs-scalanativelib-api_3-SNAPSHOT.jar",
+            "mill-libs-scalanativelib_3-SNAPSHOT.jar",
+            "mill-libs-util_3-SNAPSHOT.jar",
+            "mill-libs_3-SNAPSHOT.jar",
             "mill-moduledefs_3-0.11.10.jar"
           )
         )

--- a/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.iml
+++ b/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.iml
@@ -53,37 +53,37 @@
         <orderEntry type="library" scope="RUNTIME" name="logback-classic-1.5.18.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="logback-core-1.5.18.jar" level="project"/>
         <orderEntry type="library" name="mainargs_3-0.7.6.jar" level="project"/>
-        <orderEntry type="library" name="mill-core-api-daemon_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-core-api_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-core-constants.jar" level="project"/>
-        <orderEntry type="library" scope="RUNTIME" name="mill-core-eval_3.jar" level="project"/>
-        <orderEntry type="library" scope="RUNTIME" name="mill-core-exec_3.jar" level="project"/>
-        <orderEntry type="library" scope="RUNTIME" name="mill-core-internal-cli_3.jar" level="project"/>
-        <orderEntry type="library" scope="RUNTIME" name="mill-core-internal_3.jar" level="project"/>
-        <orderEntry type="library" scope="RUNTIME" name="mill-core-resolve_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-androidlib-databinding_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-androidlib_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-daemon-client.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-daemon-server_3.jar" level="project"/>
-        <orderEntry type="library" scope="RUNTIME" name="mill-libs-init_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-javalib-api_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-javalib-testrunner-entrypoint.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-javalib-testrunner_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-javalib_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-javascriptlib_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-kotlinlib-api_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-kotlinlib-ksp2-api_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-kotlinlib_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-pythonlib_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-rpc_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-scalajslib-api_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-scalajslib_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-scalalib_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-scalanativelib-api_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-scalanativelib_3.jar" level="project"/>
-        <orderEntry type="library" scope="RUNTIME" name="mill-libs-tabcomplete_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-util_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-core-api-daemon_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-core-api_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-core-constants-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-core-eval_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-core-exec_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-core-internal-cli_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-core-internal_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-core-resolve_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-androidlib-databinding_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-androidlib_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-daemon-client-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-daemon-server_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-libs-init_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-javalib-api_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-javalib-testrunner-entrypoint-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-javalib-testrunner_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-javalib_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-javascriptlib_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-kotlinlib-api_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-kotlinlib-ksp2-api_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-kotlinlib_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-pythonlib_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-rpc_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-scalajslib-api_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-scalajslib_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-scalalib_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-scalanativelib-api_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-scalanativelib_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-libs-tabcomplete_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-util_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs_3-SNAPSHOT.jar" level="project"/>
         <orderEntry type="library" name="mill-moduledefs_3-0.11.10.jar" level="project"/>
         <orderEntry type="library" name="munit_3-0.7.29.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="native-terminal-no-ffm-0.0.9.1.jar" level="project"/>

--- a/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.mill-build.iml
+++ b/integration/ide/gen-idea/resources/extended/idea/mill_modules/mill-build.mill-build.iml
@@ -54,40 +54,40 @@
         <orderEntry type="library" scope="RUNTIME" name="logback-classic-1.5.18.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="logback-core-1.5.18.jar" level="project"/>
         <orderEntry type="library" name="mainargs_3-0.7.6.jar" level="project"/>
-        <orderEntry type="library" name="mill-core-api-daemon_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-core-api_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-core-constants.jar" level="project"/>
-        <orderEntry type="library" scope="RUNTIME" name="mill-core-eval_3.jar" level="project"/>
-        <orderEntry type="library" scope="RUNTIME" name="mill-core-exec_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-core-internal-cli_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-core-internal_3.jar" level="project"/>
-        <orderEntry type="library" scope="RUNTIME" name="mill-core-resolve_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-androidlib-databinding_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-androidlib_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-daemon-client.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-daemon-server_3.jar" level="project"/>
-        <orderEntry type="library" scope="RUNTIME" name="mill-libs-init_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-javalib-api_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-javalib-testrunner-entrypoint.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-javalib-testrunner_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-javalib_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-javascriptlib_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-kotlinlib-api_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-kotlinlib-ksp2-api_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-kotlinlib_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-pythonlib_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-rpc_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-scalajslib-api_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-scalajslib_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-scalalib_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-scalanativelib-api_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-scalanativelib_3.jar" level="project"/>
-        <orderEntry type="library" scope="RUNTIME" name="mill-libs-tabcomplete_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-util_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-core-api-daemon_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-core-api_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-core-constants-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-core-eval_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-core-exec_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-core-internal-cli_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-core-internal_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-core-resolve_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-androidlib-databinding_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-androidlib_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-daemon-client-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-daemon-server_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-libs-init_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-javalib-api_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-javalib-testrunner-entrypoint-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-javalib-testrunner_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-javalib_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-javascriptlib_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-kotlinlib-api_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-kotlinlib-ksp2-api_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-kotlinlib_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-pythonlib_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-rpc_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-scalajslib-api_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-scalajslib_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-scalalib_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-scalanativelib-api_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-scalanativelib_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-libs-tabcomplete_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-util_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs_3-SNAPSHOT.jar" level="project"/>
         <orderEntry type="library" name="mill-moduledefs_3-0.11.10.jar" level="project"/>
-        <orderEntry type="library" name="mill-runner-codesig_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-runner-meta_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-runner-codesig_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-runner-meta_3-SNAPSHOT.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="native-terminal-no-ffm-0.0.9.1.jar" level="project"/>
         <orderEntry type="library" name="os-lib_3-0.11.5.jar" level="project"/>
         <orderEntry type="library" name="os-zip-0.11.5.jar" level="project"/>

--- a/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/mill-build.iml
+++ b/integration/ide/gen-idea/resources/hello-idea/idea/mill_modules/mill-build.iml
@@ -50,37 +50,37 @@
         <orderEntry type="library" scope="RUNTIME" name="logback-classic-1.5.18.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="logback-core-1.5.18.jar" level="project"/>
         <orderEntry type="library" name="mainargs_3-0.7.6.jar" level="project"/>
-        <orderEntry type="library" name="mill-core-api-daemon_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-core-api_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-core-constants.jar" level="project"/>
-        <orderEntry type="library" scope="RUNTIME" name="mill-core-eval_3.jar" level="project"/>
-        <orderEntry type="library" scope="RUNTIME" name="mill-core-exec_3.jar" level="project"/>
-        <orderEntry type="library" scope="RUNTIME" name="mill-core-internal-cli_3.jar" level="project"/>
-        <orderEntry type="library" scope="RUNTIME" name="mill-core-internal_3.jar" level="project"/>
-        <orderEntry type="library" scope="RUNTIME" name="mill-core-resolve_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-androidlib-databinding_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-androidlib_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-daemon-client.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-daemon-server_3.jar" level="project"/>
-        <orderEntry type="library" scope="RUNTIME" name="mill-libs-init_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-javalib-api_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-javalib-testrunner-entrypoint.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-javalib-testrunner_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-javalib_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-javascriptlib_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-kotlinlib-api_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-kotlinlib-ksp2-api_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-kotlinlib_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-pythonlib_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-rpc_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-scalajslib-api_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-scalajslib_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-scalalib_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-scalanativelib-api_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-scalanativelib_3.jar" level="project"/>
-        <orderEntry type="library" scope="RUNTIME" name="mill-libs-tabcomplete_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs-util_3.jar" level="project"/>
-        <orderEntry type="library" name="mill-libs_3.jar" level="project"/>
+        <orderEntry type="library" name="mill-core-api-daemon_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-core-api_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-core-constants-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-core-eval_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-core-exec_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-core-internal-cli_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-core-internal_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-core-resolve_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-androidlib-databinding_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-androidlib_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-daemon-client-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-daemon-server_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-libs-init_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-javalib-api_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-javalib-testrunner-entrypoint-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-javalib-testrunner_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-javalib_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-javascriptlib_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-kotlinlib-api_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-kotlinlib-ksp2-api_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-kotlinlib_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-pythonlib_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-rpc_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-scalajslib-api_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-scalajslib_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-scalalib_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-scalanativelib-api_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-scalanativelib_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-libs-tabcomplete_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-util_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs_3-SNAPSHOT.jar" level="project"/>
         <orderEntry type="library" name="mill-moduledefs_3-0.11.10.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="native-terminal-no-ffm-0.0.9.1.jar" level="project"/>
         <orderEntry type="library" name="os-lib_3-0.11.5.jar" level="project"/>

--- a/integration/package.mill
+++ b/integration/package.mill
@@ -168,7 +168,10 @@ object `package` extends mill.Module {
   def testMill: T[PathRef] = {
     val name = if (scala.util.Properties.isWin) "mill.bat" else "mill"
     Task {
-      PathRef(build.dist.installLocalTask(binFile = Task.Anon((Task.dest / name).toString()))())
+      val executable = build.dist.executable().path
+      val dest = Task.dest / name
+      os.copy.over(executable, dest)
+      PathRef(dest)
     }
   }
 


### PR DESCRIPTION
This changes how Mill is run in integration tests and examples. This makes it stop publishing things under `~/.ivy2/local`, and use something like `out/dist/localRepo.dest` instead, which is the `Task.dest` of the new `dist.localRepo` task. That new repository is a local Maven repositiory rather than an Ivy one, which has a slightly different file structure, the same as Maven Central.

For that new repository to be taken into account, the Mill launcher used in examples and ITs is now a script (bat under Windows, bash everywhere else) that sets the `COURSIER_REPOSITORIES` env var, so that the new local repo is added to it, and gets automatically used when running examples and ITs.

The second commit of this PR mainly updates the file names of the locally published Mill artifacts, because of the switch from an Ivy repository to a Maven one.