### PR TITLE
Update Scala.js environment lib `scala-js-env-jsdom-nodejs` version to 1.1.1

### DIFF
--- a/mill-build/src/millbuild/Deps.scala
+++ b/mill-build/src/millbuild/Deps.scala
@@ -24,7 +24,7 @@ object Deps {
   object Scalajs_1 {
     val scalaJsVersion = "1.19.0"
     val scalajsEnvJsdomNodejs =
-      mvn"org.scala-js::scalajs-env-jsdom-nodejs:1.1.0".withDottyCompat(scalaVersion)
+      mvn"org.scala-js::scalajs-env-jsdom-nodejs:1.1.1".withDottyCompat(scalaVersion)
     val scalajsEnvExoegoJsdomNodejs =
       mvn"net.exoego::scalajs-env-jsdom-nodejs:2.1.0".withDottyCompat(scalaVersion)
     val scalajsEnvNodejs = mvn"org.scala-js::scalajs-env-nodejs:1.4.0".withDottyCompat(scalaVersion)


### PR DESCRIPTION
Bump `scala-js-env-jsdom-nodejs` library which now supports jsdom 27. 
Ref. https://github.com/scala-js/scala-js-env-jsdom-nodejs/releases/tag/v1.1.1

Pull Request: https://github.com/com-lihaoyi/mill/pull/5964