### PR TITLE
Handle proxy settings upon startup

### DIFF
--- a/dist/package.mill
+++ b/dist/package.mill
@@ -281,7 +281,9 @@ object `package` extends MillJavaModule with DistModule {
     def nativeImageOptions = Seq(
       "--no-fallback",
       "--enable-url-protocols=https",
-      "-Os"
+      "-Os",
+      // Allow users to use authenticated proxies
+      "-Djdk.http.auth.tunneling.disabledSchemes="
       // Enable JVisualVM support
       // https://www.graalvm.org/latest/tools/visualvm/#using-visualvm-with-graalvm-native-executables
       // "--enable-monitoring=jvmstat,heapdump"

--- a/runner/daemon/src/mill/daemon/MillDaemonMain.scala
+++ b/runner/daemon/src/mill/daemon/MillDaemonMain.scala
@@ -44,6 +44,9 @@ object MillDaemonMain {
       // UnsatisfiedLinkError: Native Library C:\Windows\System32\ole32.dll already loaded in another classloader
       sys.props("coursier.windows.disable-ffm") = "true"
 
+    // Take into account proxy-related Java properties
+    coursier.Resolve.proxySetup()
+
     mill.api.SystemStreamsUtils.withTopLevelSystemStreamProxy {
       Server.overrideSigIntHandling()
 

--- a/runner/daemon/src/mill/daemon/MillNoDaemonMain.scala
+++ b/runner/daemon/src/mill/daemon/MillNoDaemonMain.scala
@@ -21,6 +21,9 @@ object MillNoDaemonMain {
       // UnsatisfiedLinkError: Native Library C:\Windows\System32\ole32.dll already loaded in another classloader
       sys.props("coursier.windows.disable-ffm") = "true"
 
+    // Take into account proxy-related Java properties
+    coursier.Resolve.proxySetup()
+
     val args = MillDaemonMain.Args(getClass.getName, args0)
       .fold(err => throw IllegalArgumentException(err), identity)
 

--- a/runner/launcher/src/mill/launcher/MillLauncherMain.java
+++ b/runner/launcher/src/mill/launcher/MillLauncherMain.java
@@ -72,6 +72,8 @@ public class MillLauncherMain {
                   + " make it less responsive.");
     }
 
+    coursier.Resolve.proxySetup();
+
     String[] runnerClasspath = MillProcessLauncher.cachedComputedValue0(
         outMode,
         "resolve-runner",


### PR DESCRIPTION
This calls `coursier.Resolve.proxySetup()` upon startup in the various Mill main classes. This method sets some Java properties that make the JDK HTTP stuff be fine with proxy authentication, but also reads proxy settings from `~/.m2/settings.xml` and from the Scala CLI config files. See its [documentation page](https://scala-cli.virtuslab.org/docs/guides/power/proxy/) in the Scala CLI documentation.

coursier and Scala CLI both rely on it to handle proxy and proxy authentication. Seems people stopped complaining about proxies in these two projects since.

Note that this is cumbersome to test, both manually and in integration tests. As a consequence, I didn't add a section about this in the Mill documentation in this PR, waiting for user feedback to be sure that it works.

Documentation and an integration test should be added in a later PR.