### PR TITLE
Documentation Tweaks

### DIFF
--- a/example/javalib/basic/1-simple/build.mill
+++ b/example/javalib/basic/1-simple/build.mill
@@ -58,6 +58,13 @@ Test foo.FooTest.testEscaping finished...
 //// SNIPPET:END
 //// SNIPPET:REPL
 //
+// You can start a JShell REPL attached to your `foo` module via:
+//
+// [source,console]
+// ----
+// > ./mill -i foo.jshell
+// ----
+//
 // You can also start a standalone JShell console
 // via `./mill --jshell`. This is useful if you just need a JShell console to experiment
 // with at the command line without being attached to a particular project or module.

--- a/example/scalalib/basic/1-simple/build.mill
+++ b/example/scalalib/basic/1-simple/build.mill
@@ -9,6 +9,21 @@
 // argument parsing, Scalatags for HTML generation - and uses them to wrap a
 // given input string in HTML templates with proper escaping.
 //
+//// SNIPPET:END
+// You can download this example project using the *download* link above
+// if you want to try out the commands below yourself, or browse the full sources
+// of the example (including supporting files) via the *browse* link. the `./mill` script
+// (`./mill.bat` on windows) takes care of downloading and caching any further dependencies,
+// including downloading a JVM if you do not already have one. All examples
+// in this documentation site are executable and are continually exercised as
+// part of Mill's CI workflows, and they range from the simple hello-world
+// projects on this page to more sophisticated
+// xref:{language-small}lib/web-examples.adoc[web build examples] or
+// xref:{language-small}lib/build-examples.adoc[example
+// builds for real-world projects]
+//
+// === Basic Folder Layout
+//
 // The source code for this module lives in the `src/` folder.
 // Output for this module (compiled files, resolved dependency lists, ...)
 // lives in `out/`. A typical filesystem layout is shown below:
@@ -41,6 +56,8 @@
 // xref:#_sbt_compatible_modules[`sbt`-Compatible Modules]
 //
 //// SNIPPET:END
+//
+// === Typical Usage
 //
 // Typical usage from the command line is shown below:
 //
@@ -104,21 +121,6 @@ compiling 1 Scala source to...
 
 */
 
-//
-//
-// You can download this example project using the *download* link above
-// if you want to try out the commands below yourself, or browse the full sources
-// of the example (including supporting files) via the *browse* link. the `./mill` script
-// (`./mill.bat` on windows) takes care of downloading and caching any further dependencies,
-// including downloading a JVM if you do not already have one. All examples
-// in this documentation site are executable and are continually exercised as
-// part of Mill's CI workflows, and they range from the simple hello-world
-// projects on this page to more sophisticated
-// xref:{language-small}lib/web-examples.adoc[web build examples] or
-// xref:{language-small}lib/build-examples.adoc[example
-// builds for real-world projects]
-//
-
 // The output of every Mill task is stored in the `out/` folder under a name
 // corresponding to the task that created it. e.g. The `assembly` task puts its
 // metadata output in `out/assembly.json`, and its output files in
@@ -132,22 +134,27 @@ compiling 1 Scala source to...
 // ----
 // > ./mill resolve __ # recursively list all tasks and modules that are available
 //
-// > ./mill runBackground # run the main method in the background
+// > ./mill foo.runBackground # run the main method in the background
 //
 // > ./mill clean <task>  # delete the cached output of a task, terminate any runBackground
 //
-// > ./mill launcher      # prepares a out/launcher.dest/run you can run later
+// > ./mill foo.launcher      # prepares a out/launcher.dest/run you can run later
 //
-// > ./mill jar           # bundle the classfiles into a jar suitable for publishing
+// > ./mill foo.jar           # bundle the classfiles into a jar suitable for publishing
 //
-// > ./mill -i console    # start a Scala console within your project
-//
-// > ./mill -i repl       # start an Ammonite Scala REPL within your project
-//
-// > ./mill -w compile    # watch input files and re-compile whenever a file changes
+// > ./mill -w foo.compile    # watch input files and re-compile whenever a file changes
 // ----
 //
 //// SNIPPET:REPL
+//
+// You can start a Scala REPL attached to your `foo` module via
+//
+// [source,console]
+// ----
+// > ./mill -i foo.console    # start a Scala console within your project
+//
+// > ./mill -i foo.repl       # start an Ammonite Scala REPL within your project
+// ----
 //
 // You can also start a standalone Scala REPL with the
 // xref:fundamentals/bundled-libraries.adoc[Bundled Libraries]

--- a/example/scalalib/basic/2-module-deps/build.mill
+++ b/example/scalalib/basic/2-module-deps/build.mill
@@ -9,7 +9,9 @@
 // Inter-module dependencies are defined by the `moduleDeps` key, and modules
 // can also be nested within each other, as `bar.test` is nested
 // within `bar`.
-
+//
+// === Multi-Module Folder Layout
+//
 // The above builds expect the following project layout:
 //
 //// SNIPPET:TREE
@@ -68,7 +70,9 @@ bar.run
 // The unique path on disk that Mill automatically assigns each task also ensures
 // you do not need to worry about choosing a path on disk to cache outputs, or
 // filesystem collisions if multiple tasks write to the same path.
-
+//
+// === Task Query Syntax
+//
 // You can use wildcards and brace-expansion to select
 // multiple tasks at once or to shorten the path to deeply nested tasks. If
 // you provide optional task arguments and your wildcard or brace-expansion is


### PR DESCRIPTION
- Make `.repl`/`.console` docs only apply to Scala intro, and add `.jshell` docs for Java intro
- Add some sub-headings for the intro page
- Move `You can download this example project` to nearer the top of the page