### PR TITLE
Fix caching of module instantiations in resolver

### DIFF
--- a/core/resolve/src/mill/resolve/ResolveCore.scala
+++ b/core/resolve/src/mill/resolve/ResolveCore.scala
@@ -50,7 +50,10 @@ private object ResolveCore {
    * same module
    */
   class Cache(
-      val instantiatedModules: collection.mutable.Map[(RootModule0, Segments), mill.api.Result[Module]] =
+      val instantiatedModules: collection.mutable.Map[
+        (RootModule0, Segments),
+        mill.api.Result[Module]
+      ] =
         collection.mutable.Map(),
       decodedNames: collection.mutable.Map[String, String] = collection.mutable.Map(),
       methods: collection.mutable.Map[(Class[?], Boolean, Class[?]), Array[(


### PR DESCRIPTION
Should unblock rebootstrapping by fixing the failure we saw in https://github.com/com-lihaoyi/mill/pull/6009

Previously the cache was keyed on `Segments`, which isn't correct because different root modules can have the same segments pointing at different tasks.

Tested manually 
