### PR TITLE
Android: make `AndroidModule` a CrossModule

### DIFF
--- a/example/androidlib/java/1-hello-world/build.mill
+++ b/example/androidlib/java/1-hello-world/build.mill
@@ -17,7 +17,7 @@ object androidSdkModule0 extends AndroidSdkModule {
 }
 
 // Actual android application
-object app extends AndroidAppModule {
+trait App extends AndroidAppModule {
   def androidSdkModule = mill.api.ModuleRef(androidSdkModule0)
   def androidMinSdk = 19
   def androidCompileSdk = 35
@@ -37,11 +37,11 @@ object app extends AndroidAppModule {
 
   override def androidVirtualDeviceIdentifier: String = "java-test"
 
-  object test extends AndroidAppTests, TestModule.Junit4 {
+  trait Test extends AndroidAppTests, TestModule.Junit4 {
     def junit4Version = "4.13.2"
   }
 
-  object it extends AndroidAppInstrumentedTests {
+  trait It extends AndroidAppInstrumentedTests {
 
     def androidSdkModule = mill.api.ModuleRef(androidSdkModule0)
 
@@ -57,14 +57,18 @@ object app extends AndroidAppModule {
     )
   }
 
+  object test extends Cross[Test](AndroidBuildVariant.Debug)
+  object it extends Cross[It](AndroidBuildVariant.Debug)
+
 }
+object app extends Cross[App](AndroidBuildVariant.Debug, AndroidBuildVariant.Release)
 
 ////SNIPPET:END
 
 /** Usage
 
-> ./mill show app.androidApk
-".../out/app/androidApk.dest/app.apk"
+> ./mill show app[debug].androidApk
+".../out/app/debug/androidApk.dest/app.apk"
 
 */
 
@@ -98,10 +102,10 @@ object app extends AndroidAppModule {
 
 /** Usage
 
-> ./mill show app.test
+> ./mill show app[debug].test[debug]
 ...compiling 1 Java source...
 
-> cat out/app/test/testForked.dest/out.json
+> cat out/app/debug/test/debug/testForked.dest/out.json
 ["",[{"fullyQualifiedName":"com.helloworld.ExampleUnitTest.textSize_isCorrect","selector":"com.helloworld.ExampleUnitTest.textSize_isCorrect","duration":...,"status":"Success"}]]
 
 */
@@ -110,15 +114,15 @@ object app extends AndroidAppModule {
 
 /** Usage
 
-> ./mill show app.createAndroidVirtualDevice
+> ./mill show app[debug].createAndroidVirtualDevice
 ...Name: java-test, DeviceId: medium_phone...
 
-> ./mill show app.startAndroidEmulator
+> ./mill show app[debug].startAndroidEmulator
 
-> ./mill show app.adbDevices
+> ./mill show app[debug].adbDevices
 ...emulator-5554...device...
 
-> ./mill show app.it
+> ./mill show app[debug].it[debug]
 ...
 {
   "msg": "",
@@ -133,7 +137,7 @@ object app extends AndroidAppModule {
 }
 ...
 
-> cat out/app/it/testForked.dest/test-report.xml
+> cat out/app/debug/it/debug/testForked.dest/test-report.xml
 ...
 <?xml version='1.0' encoding='UTF-8'?>
 <testsuites tests="1" failures="0" errors="0" skipped="0" time="...">
@@ -146,9 +150,9 @@ object app extends AndroidAppModule {
       </testsuites>
 ...
 
-> ./mill show app.stopAndroidEmulator
+> ./mill show app[debug].stopAndroidEmulator
 
-> ./mill show app.deleteAndroidVirtualDevice
+> ./mill show app[debug].deleteAndroidVirtualDevice
 
 */
 

--- a/libs/androidlib/src/mill/androidlib/AndroidBuildVariant.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidBuildVariant.scala
@@ -1,0 +1,29 @@
+package mill.androidlib
+
+import mill.*
+import mill.api.Cross
+
+/**
+ * Represents an Android build variant, such as "debug" or "release".
+ */
+@mill.api.experimental
+sealed trait AndroidBuildVariant {
+  def name: String
+
+}
+object AndroidBuildVariant {
+  case object Debug extends AndroidBuildVariant {
+    def name = "debug"
+  }
+
+  case object Release extends AndroidBuildVariant {
+    def name = "release"
+  }
+
+  def variants: Seq[AndroidBuildVariant] =
+    Seq(Debug, Release)
+
+  implicit object VariantToSegments extends Cross.ToSegments[AndroidBuildVariant](v =>
+        List(v.name)
+      )
+}

--- a/libs/androidlib/src/mill/androidlib/AndroidModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidModule.scala
@@ -6,7 +6,7 @@ import coursier.params.ResolutionParams
 import mill.T
 import mill.androidlib.manifestmerger.AndroidManifestMerger
 import mill.api.daemon.internal.bsp.BspBuildTarget
-import mill.api.{ModuleRef, PathRef, Task}
+import mill.api.{ModuleRef, PathRef, Task, Cross}
 import mill.javalib.*
 import mill.javalib.api.CompilationResult
 import mill.javalib.api.internal.{JavaCompilerOptions, ZincCompileJava}
@@ -14,7 +14,8 @@ import mill.javalib.api.internal.{JavaCompilerOptions, ZincCompileJava}
 import scala.collection.immutable
 import scala.xml.*
 
-trait AndroidModule extends JavaModule { outer =>
+trait AndroidModule extends JavaModule, Cross.Module[AndroidBuildVariant] { outer =>
+  def buildVariant: AndroidBuildVariant = crossValue
 
   // https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:build-system/gradle-core/src/main/java/com/android/build/gradle/internal/tasks/D8BundleMainDexListTask.kt;l=210-223;drc=66ab6bccb85ce3ed7b371535929a69f494d807f0
   val mainDexPlatformRules = Seq(
@@ -84,8 +85,8 @@ trait AndroidModule extends JavaModule { outer =>
    *
    * This option will probably go away in the future once build variants are supported.
    */
-  def androidIsDebug: T[Boolean] = {
-    true
+  def androidIsDebug: T[Boolean] = Task {
+    buildVariant == AndroidBuildVariant.Debug
   }
 
   /**


### PR DESCRIPTION
This an experiment on making `AndroidModule` a CrossModule, in order to have `debug` and `release` variants. [Ref](https://github.com/com-lihaoyi/mill/pull/5957?notification_referrer_id=NT_kwDOBJuLtbQxOTQyNzE5NzU3Mzo3NzMwMjcwOQ#issuecomment-3418814797)
### Thoughts
- Build.mill is a bit more complex for the user this way
- Since this is just for experimentation, `androidIsDebug` remains and returns true/false according to `crossValue`

### Example:
<img width="1393" height="216" alt="image" src="https://github.com/user-attachments/assets/0b2e1a4a-eec0-4d27-ae8d-94827854572e" />
