### PR TITLE
Use relative script imports in `1-script/` examples

### DIFF
--- a/example/javalib/basic/1-script/FooTest.java
+++ b/example/javalib/basic/1-script/FooTest.java
@@ -1,5 +1,5 @@
 //| extends: [mill.script.JavaModule.Junit4]
-//| moduleDeps: [Foo.java]
+//| moduleDeps: [./Foo.java]
 //| mvnDeps:
 //| - "com.google.guava:guava:33.3.0-jre"
 

--- a/example/kotlinlib/basic/1-script/FooTest.kt
+++ b/example/kotlinlib/basic/1-script/FooTest.kt
@@ -1,5 +1,5 @@
 //| extends: [mill.script.KotlinModule.Junit5]
-//| moduleDeps: [Foo.kt]
+//| moduleDeps: [./Foo.kt]
 //| mvnDeps:
 //| - "io.kotest:kotest-runner-junit5:5.9.1"
 //| - "com.github.sbt.junit:jupiter-interface:0.11.2"

--- a/example/scalalib/basic/1-script/FooTests.scala
+++ b/example/scalalib/basic/1-script/FooTests.scala
@@ -1,5 +1,5 @@
 //| extends: [mill.script.ScalaModule.Utest]
-//| moduleDeps: [Foo.scala]
+//| moduleDeps: [./Foo.scala]
 //| mvnDeps:
 //| - "com.lihaoyi::utest:0.9.1"
 


### PR DESCRIPTION
This should ensure that the imports work even if the scripts gets downloaded or copy-pasted somewhere else