### PR TITLE
Try to fix spurious circular task errors

### DIFF
--- a/core/api/src/mill/api/internal/Cacher.scala
+++ b/core/api/src/mill/api/internal/Cacher.scala
@@ -1,6 +1,5 @@
 package mill.api.internal
 
-import collection.mutable.LinkedHashSet
 import scala.collection.immutable.VectorMap
 import scala.collection.mutable
 import scala.util.DynamicVariable
@@ -26,7 +25,7 @@ trait Cacher extends mill.moduledefs.Cacher {
       )
     }
 
-    Cacher.taskEvaluationStack.withValue(Cacher.taskEvaluationStack.value ++ Seq((c, this) -> ())){
+    Cacher.taskEvaluationStack.withValue(Cacher.taskEvaluationStack.value ++ Seq((c, this) -> ())) {
       cacherLazyMap.getOrElseUpdate(c, t).asInstanceOf[T]
     }
   }


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/6060

My guess is that the problem is the `LinkedHashSet` in `Cacher.taskEvaluationStack` is actually a mutable collection shared between different threads. That could potentially cause all sorts of problems, so this replaces it with a immutable `VectorMap` to preserve ordering and provide lookups in an immutable fashion