### PR TITLE
Android: Jetchat example, update databinding apis

### DIFF
--- a/example/thirdparty/android-compose-samples/build.mill
+++ b/example/thirdparty/android-compose-samples/build.mill
@@ -298,6 +298,12 @@ object Jetchat extends mill.api.Module {
 
     def androidMinSdk = Versions.androidMinSdk
 
+    /*
+     * FIXME Currently broken with
+     * Message 2) profileScreen_back_conversationScreen(com.example.compose.jetchat.NavigationTest)
+     * android.content.res.Resources$NotFoundException: String resource ID #0x7f0c002b
+     * Message android.content.res.Resources$NotFoundException: String resource ID #0x7f0c002b
+     */
     object androidTest extends AndroidAppKotlinInstrumentedTests, AndroidR8AppModule {
       override def bomMvnDeps = super.mvnDeps() ++ Seq(
         mvn"androidx.compose:compose-bom:2025.08.00"
@@ -325,7 +331,9 @@ object Jetchat extends mill.api.Module {
         mvn"androidx.compose.ui:ui-test",
         mvn"androidx.compose.ui:ui-test-junit4",
         mvn"androidx.collection:collection-ktx:1.5.0",
-        mvn"androidx.savedstate:savedstate-ktx:1.3.0"
+        mvn"androidx.savedstate:savedstate-ktx:1.3.0",
+        mvn"androidx.appcompat:appcompat:1.7.0",
+        mvn"androidx.lifecycle:lifecycle-viewmodel-compose:2.9.0"
       )
 
     }


### PR DESCRIPTION
This PR updates the Jetchat databinding api after the latest databinding changes.

<img width="1920" height="1080" alt="Screenshot From 2025-10-30 18-06-22" src="https://github.com/user-attachments/assets/5c37f740-c92c-4b87-b61f-c9036e0d11cd" />


Still android tests are not passing for it, but I'll create an issue for that