### PR TITLE
Disable automatic heap dump on OOM

### DIFF
--- a/runner/launcher/src/mill/launcher/MillProcessLauncher.java
+++ b/runner/launcher/src/mill/launcher/MillProcessLauncher.java
@@ -234,7 +234,6 @@ public class MillProcessLauncher {
     // extra opts
     vmOptions.addAll(millJvmOpts(outMode));
 
-    vmOptions.add("-XX:+HeapDumpOnOutOfMemoryError");
     vmOptions.add("-cp");
 
     vmOptions.add(String.join(File.pathSeparator, runnerClasspath));


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/5968

Can be re-enabled via `mill-jvm-opts` for any user that wants this back