### PR TITLE
`millBinPlatform` should be `1` for `1.1.0-RCx`

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -69,7 +69,7 @@ def millDownloadUrlCurrent = Task {
 def millBinPlatform: T[String] = Task {
   val tag = millLastTag()
   tag match {
-    case s"$_-M$_" | s"$_-RC$_" => tag
+    case s"$_.0.0-M$_" | s"$_.0.0-RC$_" => tag
     case tag => tag.split('.').head
   }
 }


### PR DESCRIPTION
Only RCs and Ms of 1.0.0 should have the whole version as binary version
since minor versions are binary compatible with the previous minor.

Pull Request: https://github.com/com-lihaoyi/mill/pull/6134