### PR TITLE
Run Mill with `-Dfile.encoding=UTF-8` by default to try and fix windows unicode issues

### DIFF
--- a/runner/launcher/src/mill/launcher/MillProcessLauncher.java
+++ b/runner/launcher/src/mill/launcher/MillProcessLauncher.java
@@ -252,6 +252,9 @@ public class MillProcessLauncher {
     String serverTimeout = millServerTimeout();
     if (serverTimeout != null) vmOptions.add("-Dmill.server_timeout=" + serverTimeout);
 
+    // Set UTF-8 encoding to fix Unicode character display issues on Windows
+    vmOptions.add("-Dfile.encoding=UTF-8");
+
     // extra opts
     vmOptions.addAll(millJvmOpts(outMode));
 


### PR DESCRIPTION
Attempts to fix https://github.com/com-lihaoyi/mill/issues/6118 and fix https://github.com/com-lihaoyi/mill/issues/4894
