### PR TITLE
Make selective execution trigger when Mill version or JVM version is changed

### DIFF
--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -485,7 +485,7 @@ trait GroupExecution {
   }
 
   def getValueHash(v: Val, task: Task[?], inputsHash: Int): Int = {
-    (if (task.isInstanceOf[Task.Worker[?]]) inputsHash else v.##) + invalidateAllHashes
+    if (task.isInstanceOf[Task.Worker[?]]) inputsHash else v.## + invalidateAllHashes
   }
   private def loadUpToDateWorker(
       logger: Logger,


### PR DESCRIPTION
We do this by including `classloaderSigHash`/`javaHomeHash` in Mill task value hash. Since selective execution triggers based on the value hashes of input tasks, this causes all input tasks to trigger when selective execution is used

Fixes https://github.com/com-lihaoyi/mill/issues/5943