### PR TITLE
Fixed compilation error in BomModule example

### DIFF
--- a/example/fundamentals/dependencies/2-managed/build.mill
+++ b/example/fundamentals/dependencies/2-managed/build.mill
@@ -55,7 +55,7 @@ object baz extends JavaModule {
 
 // One can manage and publish Bill of Material (BOM) modules from Mill, by using `BomModule`:
 
-object myBom extends BomModule {
+object myBom extends JavaModule, BomModule {
   // Importing external BOMs from our BOM module with bomMvnDeps
   def bomMvnDeps = Seq(
     mvn"com.google.protobuf:protobuf-bom:4.28.1"


### PR DESCRIPTION
The fix resolves the following compile error:
```console
[build.mill-59] [error] 6 │object myBom extends BomModule {
[build.mill-59] [error]   │       ^
[build.mill-59] [error]   │object creation impossible, since def compile: mill.api.Task.Simple[mill.javalib.api.CompilationResult] in trait SemanticDbJavaModule in package mill.javalib is not defined 
[build.mill-59] [error]   │(The class implements abstract override def compile:
[build.mill-59] [error]   │  mill.api.Task.Simple[mill.javalib.api.CompilationResult] in trait BomModule in package mill.javalib but that definition still needs an implementation)
```
