### PR TITLE
Remove unnecessary `rm build.mill` from migration docs

### DIFF
--- a/example/migrating/javalib/1-maven-complete/build.mill
+++ b/example/migrating/javalib/1-maven-complete/build.mill
@@ -1,7 +1,5 @@
 /** Usage
 
-> rm build.mill # remove any existing build file
-
 > git init .
 > git remote add -f origin https://github.com/davidmoten/geo.git
 > git checkout 0.8.1 # example multi-module Java project using JUnit4

--- a/example/migrating/javalib/2-maven-incomplete/build.mill
+++ b/example/migrating/javalib/2-maven-incomplete/build.mill
@@ -1,7 +1,5 @@
 /** Usage
 
-> rm build.mill # remove any existing build file
-
 > git init .
 > git remote add -f origin https://github.com/dhatim/fastexcel.git
 > git checkout 0.18.4

--- a/example/migrating/javalib/3-maven-complete-large/build.mill
+++ b/example/migrating/javalib/3-maven-complete-large/build.mill
@@ -1,7 +1,5 @@
 /** Usage
 
-> rm build.mill # remove any existing build file
-
 > git init .
 > git remote add -f origin https://github.com/iluwatar/java-design-patterns
 > git checkout ede37bd05568b1b8b814d8e9a1d2bbd71d9d615d

--- a/example/migrating/javalib/4-gradle-complete/build.mill
+++ b/example/migrating/javalib/4-gradle-complete/build.mill
@@ -1,7 +1,5 @@
 /** Usage
 
-> rm build.mill # remove any existing build file
-
 > git init .
 > git remote add -f origin https://github.com/komamitsu/fluency.git
 > git checkout 2.7.3 # multi-module Java project that requires Java 16+

--- a/example/migrating/javalib/5-gradle-incomplete/build.mill
+++ b/example/migrating/javalib/5-gradle-incomplete/build.mill
@@ -1,7 +1,5 @@
 /** Usage
 
-> rm build.mill # remove any existing build file
-
 > git init .
 > git remote add -f origin https://github.com/mockito/mockito.git
 > git checkout v5.19.0 # multi-module Java project

--- a/example/migrating/scalalib/1-sbt-complete/build.mill
+++ b/example/migrating/scalalib/1-sbt-complete/build.mill
@@ -1,7 +1,5 @@
 /** Usage
 
-> rm build.mill # remove any existing build file
-
 > git init .
 > git remote add -f origin https://github.com/scala/scala3-example-project.git
 > git checkout 853808c50601e88edaa7272bcfb887b96be0e22a

--- a/example/migrating/scalalib/2-sbt-incomplete/build.mill
+++ b/example/migrating/scalalib/2-sbt-incomplete/build.mill
@@ -1,7 +1,5 @@
 /** Usage
 
-> rm build.mill # remove any existing build file
-
 > git init .
 > git remote add -f origin https://github.com/fthomas/refined.git
 > git checkout v0.11.3


### PR DESCRIPTION
This should no longer be needed since https://github.com/com-lihaoyi/mill/pull/6122 where the dummy `build.mill`s get translated into `readme.adoc`s instead