### PR TITLE
Reproduce logging issue on latest `main`

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1,4 +1,4 @@
-//| mill-version: 1.1.0-RC1
+//| mill-version: 1.1.0-RC1-129-023375
 //| mill-jvm-opts: ["-XX:NonProfiledCodeHeapSize=250m", "-XX:ReservedCodeCacheSize=500m"]
 //| mill-opts: ["--jobs=0.5C", "-DMILL_ENABLE_STATIC_CHECKS=true"]
 

--- a/integration/failure/yaml-config-misc/resources/mispelledextends/package.mill.yaml
+++ b/integration/failure/yaml-config-misc/resources/mispelledextends/package.mill.yaml
@@ -1,1 +1,1 @@
-extends: [mill.javalib.JavaModuleTypod]
+//| hello: world

--- a/integration/package.mill
+++ b/integration/package.mill
@@ -75,7 +75,8 @@ object `package` extends mill.Module {
             testReportXml(),
             javaHome().map(_.path),
             testParallelism(),
-            testLogLevel()
+            testLogLevel(),
+            jvmWorker = jvmWorker().internalWorker()
           )
           testModuleUtil.runTests()
         }


### PR DESCRIPTION
Seems like some lines get cut in half and shifted to the next line

```
lihaoyi mill$ ./mill 'integration.failure[yaml-config-misc].packaged.nodaemon'                             
8164] integration.failure[yaml-config-misc].packaged.nodaemon.testForked
8164] Running Test Class mill.integration.YamlConfigMiscTests
8164] -------------------------------- Running Tests --------------------------------
8164] Preparing integration test in /Users/lihaoyi/Github/mill/out/integration/failure/yaml-config-misc/packaged/nodaemon/testForked.dest/sandbox/run-1
8164] X mill.integration.YamlConfigMiscTests 4575ms 
8164]   utest.AssertionError: res.err.replace('\\', '/').contains("mispelledextends/package.mill.yaml")
8164]   res: EvalResult = EvalResult(
8164]     CommandResult(
8164]       command = ArraySeq(
8164]         "/Users/lihaoyi/Github/mill/out/dist/executable.dest/mill",
8164]         "--no-daemon",
8164]         "--ticker",
8164]         "false",
8164]         "version"
8164]       ),
8164]       exitCode = 1,
8164]       chunks = Vector(
8164]         Right(
8164]           1 tasks failed
8164]   generatedScriptSources scala.MatchError: [Ljava.lang.String;@486ad537 (of class [Ljava.lang.String;)
8164]       mill.meta.CodeGen$.processDataRest$1$$anonfun$2(CodeGen.scala:106)
8164]       scala.collection.Iterator$$anon$9.next(Iterator.scala:584)
8164]       scala.collection.immutable.List.prependedAll(List.scala:153)
8164]       scala.collection.immutable.List$.from(List.scala:685)
8164]       scala.collection.immuta
8164] ble.List$.from(List.scala:682)
8164]       scala.collection.IterableOps$WithFilter.map(Iterable.scala:900)
8164]       mill.meta.CodeGen$.processDataRest$1(CodeGen.scala:103)
8164]       mill.meta.CodeGen$.writeBuildOverrides$1(CodeGen.scala:116)
8164]       mill.meta.CodeGen$.generateWrappedAndSupportSources$$anonfun$1(CodeGen.scala:121)
8164]       scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
8164]       scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
8164]       scala.collection.immutable.List.foreach(List.scala:334)
8164]       mill.meta.CodeGen$.generateWrappedAndSupportSources(CodeGen.scala:35)
8164]       mill.meta.MillBuildRootModule.generatedScriptSources$$anonfun$1$$anonfun$1(MillBuildRootModule.scala:133)
8164]       mill.api.Task$Named.evaluate(Task.scala:370)
8164]       mill.api.Task$Named.evaluate$(Task.scala:355)
8164]       mill.api.Task$Computed.evaluate(Task.scala:381)
8164]   
8164]       )
8164]       )
8164]     )
8164]   )
8164]     utest.asserts.Asserts$.assertImpl(Asserts.scala:30)
8164]     mill.integration.YamlConfig
8164] MiscTests$.$init$$$anonfun$1$$anonfun$1(YamlConfigMiscTests.scala:13)
8164]     scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
8164]     scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
8164]     mill.testkit.IntegrationTestSuite.integrationTest$$anonfun$1(IntegrationTestSuite.scala:60)
8164]     mill.util.Retry.apply$$anonfun$1(Retry.scala:38)
8164]     mill.util.Retry.apply$$anonfun$adapted$1(Retry.scala:38)
8164]     mill.util.Retry.rec$1$$anonfun$1$$anonfun$1(Retry.scala:48)
8164]     scala.util.Try$.apply(Try.scala:217)
8164]     mill.util.Retry.rec$1$$anonfun$1(Retry.scala:48)
8164]     mill.api.daemon.StartThread$.$anonfun$1(SpawnThread.scala:5)
8164]     java.la
8164] ng.Thread.run(Thread.java:1583)
8164] Tests: 1, Passed: 0, Failed: 1
8164/8164, 1 failed] ==================== integration.failure[yaml-config-misc].packaged.nodaemon ==================== 6s
1 tasks failed
8164] integration.failure[yaml-config-misc].packaged.nodaemon.testForked 1 tests failed: 
  mill.integration.YamlConfigMiscTests mill.integration.YamlConfigMiscTests.
lihaoyi mill$ 

```