### PR TITLE
Android: Revert androidNonTransitiveRClasses

### DIFF
--- a/libs/androidlib/src/mill/androidlib/AndroidModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidModule.scala
@@ -208,7 +208,7 @@ trait AndroidModule extends JavaModule { outer =>
    * @return a sequence of PathRef to the compiled resources
    */
   def androidTransitiveCompiledResources: T[Seq[PathRef]] = Task {
-    Task.traverse(androidTransitiveModuleDeps) {
+    Task.traverse(transitiveModuleRunModuleDeps) {
       case m: AndroidModule =>
         m.androidCompiledModuleResources
       case _ =>


### PR DESCRIPTION
I've decided to revert the whole androidNonTransitiveRClasses because it was the wrong implementation after all (see linked issue). 

To achieve the same optimisation as in gradle we need to do more work with Symbol based R generation that is not immediately available from the tools we have.

```
# Enables namespacing of each library's R class so that its R class includes only the
# resources declared in the library itself and none from the library's dependencies,
# thereby reducing the size of the R class for that library
android.nonTransitiveRClass=true
```

Related to: https://github.com/com-lihaoyi/mill/issues/6232