### PR TITLE
Fix deadlock in logging infrastructure caused by locking on wrong stream.

### DIFF
--- a/core/internal/src/mill/internal/PromptLogger.scala
+++ b/core/internal/src/mill/internal/PromptLogger.scala
@@ -246,7 +246,7 @@ class PromptLogger(
             } else lines.foreach(printPrefixed(infoColor(prefix), _))
           }
         }
-      } else streamManager.pipe.output.synchronized { logMsg.writeTo(logStream) }
+      } else logStream.synchronized { logMsg.writeTo(logStream) }
 
       streamManager.awaitPumperEmpty()
     }


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/6224, caused by the following deadlock
```
Found one Java-level deadlock:
=============================
"HandleRunThread-Socket[addr=/127.0.0.1,port=64003,localport=64002]":
  waiting to lock monitor 0x0000600004a61fb0 (object 0x000000060010d078, a mill.api.SystemStreamsUtils$ThreadLocalStreams$Out$),
  which is held by "execution-contexts-threadpool-1-thread-12"

"execution-contexts-threadpool-1-thread-12":
  waiting to lock monitor 0x0000600004a64ea0 (object 0x0000000600802f28, a mill.internal.PipeStreams$Output$),
  which is held by "/Users/lihaoyi/Library/Caches/Coursier/arc/https/cdn.azul.com/zulu/bin/zulu21.46.19-ca-jdk21.0.9-macosx_aarch64.tar.gz/zulu21.46.19-ca-jdk21.0.9-macosx_aarch64/zulu-21.jdk/Contents/Home/bin/java -Xss100m -cp /Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.17/scala-library-2.13.17.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/utest_2.13/0.9.1/utest_2.13-0.9.1.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/fastparse_2.13/3.1.1/fastparse_2.13-3.1.1.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/pprint_2.13/0.9.3/pprint_2.13-0.9.3.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/ujson_2.13/4.4.0/ujson_2.13-4.4.0.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/scalatags_2.13/0.13.1/scalatags_2.13-0.13.1.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-collection-compat_2.13/2.13.0/scala-collection-compat_2.13-2.13.0.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/os-lib_2.13/0.11.4/os-lib_2.13-0.11.4.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/mainargs_2.13/0.7.6/mainargs_2.13-0.7.6.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/tukaani/xz/1.10/xz-1.10.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/lz4/lz4-java/1.8.0/lz4-java-1.8.0.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/yaml/snakeyaml/2.4/snakeyaml-2.4.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/google/re2j/re2j/1.8/re2j-1.8.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/sourcecode_2.13/0.4.3-M5/sourcecode_2.13-0.4.3-M5.jar:/Users/lihaoy

"/Users/lihaoyi/Library/Caches/Coursier/arc/https/cdn.azul.com/zulu/bin/zulu21.46.19-ca-jdk21.0.9-macosx_aarch64.tar.gz/zulu21.46.19-ca-jdk21.0.9-macosx_aarch64/zulu-21.jdk/Contents/Home/bin/java -Xss100m -cp /Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.17/scala-library-2.13.17.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/utest_2.13/0.9.1/utest_2.13-0.9.1.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/fastparse_2.13/3.1.1/fastparse_2.13-3.1.1.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/pprint_2.13/0.9.3/pprint_2.13-0.9.3.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/ujson_2.13/4.4.0/ujson_2.13-4.4.0.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/scalatags_2.13/0.13.1/scalatags_2.13-0.13.1.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-collection-compat_2.13/2.13.0/scala-collection-compat_2.13-2.13.0.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/os-lib_2.13/0.11.4/os-lib_2.13-0.11.4.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/mainargs_2.13/0.7.6/mainargs_2.13-0.7.6.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/tukaani/xz/1.10/xz-1.10.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/lz4/lz4-java/1.8.0/lz4-java-1.8.0.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/yaml/snakeyaml/2.4/snakeyaml-2.4.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/google/re2j/re2j/1.8/re2j-1.8.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/sourcecode_2.13/0.4.3-M5/sourcecode_2.13-0.4.3-M5.jar:/Users/lihaoyi/Library/Caches/Cour
  waiting for ownable synchronizer 0x00000006008033a8, (a java.util.concurrent.locks.ReentrantLock$NonfairSync),
  which is held by "FileToStreamTailerThread"

"FileToStreamTailerThread":
  waiting to lock monitor 0x0000600004a64ea0 (object 0x0000000600802f28, a mill.internal.PipeStreams$Output$),
  which is held by "/Users/lihaoyi/Library/Caches/Coursier/arc/https/cdn.azul.com/zulu/bin/zulu21.46.19-ca-jdk21.0.9-macosx_aarch64.tar.gz/zulu21.46.19-ca-jdk21.0.9-macosx_aarch64/zulu-21.jdk/Contents/Home/bin/java -Xss100m -cp /Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.17/scala-library-2.13.17.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/utest_2.13/0.9.1/utest_2.13-0.9.1.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/fastparse_2.13/3.1.1/fastparse_2.13-3.1.1.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/pprint_2.13/0.9.3/pprint_2.13-0.9.3.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/ujson_2.13/4.4.0/ujson_2.13-4.4.0.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/scalatags_2.13/0.13.1/scalatags_2.13-0.13.1.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-collection-compat_2.13/2.13.0/scala-collection-compat_2.13-2.13.0.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/os-lib_2.13/0.11.4/os-lib_2.13-0.11.4.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/mainargs_2.13/0.7.6/mainargs_2.13-0.7.6.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/tukaani/xz/1.10/xz-1.10.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/lz4/lz4-java/1.8.0/lz4-java-1.8.0.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/yaml/snakeyaml/2.4/snakeyaml-2.4.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/google/re2j/re2j/1.8/re2j-1.8.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/sourcecode_2.13/0.4.3-M5/sourcecode_2.13-0.4.3-M5.jar:/Users/lihaoy

Java stack information for the threads listed above:
===================================================
"HandleRunThread-Socket[addr=/127.0.0.1,port=64003,localport=64002]":
	at java.io.PrintStream.flush(java.base@21.0.9/PrintStream.java:455)
	- waiting to lock <0x000000060010d078> (a mill.api.SystemStreamsUtils$ThreadLocalStreams$Out$)
	at mill.server.MillDaemonServer.endConnection(MillDaemonServer.scala:157)
	at mill.server.Server.runSocketHandler(Server.scala:261)
	at mill.server.Server.runLocked$$anonfun$5$$anonfun$1(Server.scala:155)
	at mill.server.Server.runLocked$$anonfun$5$$anonfun$adapted$1(Server.scala:163)
	at mill.server.Server$$Lambda/0x0000007001135428.apply(Unknown Source)
	at mill.api.daemon.StartThread$.$anonfun$1(SpawnThread.scala:5)
	at mill.api.daemon.StartThread$$$Lambda/0x000000700112b730.run(Unknown Source)
	at java.lang.Thread.runWith(java.base@21.0.9/Thread.java:1596)
	at java.lang.Thread.run(java.base@21.0.9/Thread.java:1583)
"execution-contexts-threadpool-1-thread-12":
	at mill.internal.PromptLogger$prompt$.logPrefixedLine(PromptLogger.scala:208)
	- waiting to lock <0x0000000600802f28> (a mill.internal.PipeStreams$Output$)
	at mill.internal.PrefixLogger.prefixPrintStream$$anonfun$1(PrefixLogger.scala:49)
	at mill.internal.PrefixLogger$$Lambda/0x0000007001f05e38.applyVoid(Unknown Source)
	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
	at mill.internal.LineBufferingOutputStream.writeOutBuffer(LineBufferingOutputStream.scala:22)
	at mill.internal.LineBufferingOutputStream.write(LineBufferingOutputStream.scala:36)
	- locked <0x00000006a48000c0> (a mill.internal.LineBufferingOutputStream)
	at java.io.PrintStream.implWrite(java.base@21.0.9/PrintStream.java:643)
	at java.io.PrintStream.write(java.base@21.0.9/PrintStream.java:623)
	at mill.internal.MultiStream$$anon$1.write(MultiStream.scala:14)
	at java.io.PrintStream.implWrite(java.base@21.0.9/PrintStream.java:643)
	at java.io.PrintStream.write(java.base@21.0.9/PrintStream.java:629)
	- locked <0x00000006a4800120> (a mill.internal.MultiStream)
	at mill.api.SystemStreamsUtils$ThreadLocalStreams$ProxyOutputStream.write(SystemStreamsUtils.scala:107)
	at java.io.PrintStream.implWrite(java.base@21.0.9/PrintStream.java:643)
	at java.io.PrintStream.write(java.base@21.0.9/PrintStream.java:629)
	- locked <0x000000060010d078> (a mill.api.SystemStreamsUtils$ThreadLocalStreams$Out$)
	at sun.nio.cs.StreamEncoder.writeBytes(java.base@21.0.9/StreamEncoder.java:309)
	at sun.nio.cs.StreamEncoder.implFlushBuffer(java.base@21.0.9/StreamEncoder.java:405)
	at sun.nio.cs.StreamEncoder.lockedFlushBuffer(java.base@21.0.9/StreamEncoder.java:123)
	at sun.nio.cs.StreamEncoder.flushBuffer(java.base@21.0.9/StreamEncoder.java:110)
	at java.io.OutputStreamWriter.flushBuffer(java.base@21.0.9/OutputStreamWriter.java:192)
	at java.io.PrintStream.implNewLine(java.base@21.0.9/PrintStream.java:881)
	at java.io.PrintStream.newLine(java.base@21.0.9/PrintStream.java:865)
	- locked <0x000000060010d078> (a mill.api.SystemStreamsUtils$ThreadLocalStreams$Out$)
	at java.io.PrintStream.println(java.base@21.0.9/PrintStream.java:1172)
	- locked <0x000000060010d078> (a mill.api.SystemStreamsUtils$ThreadLocalStreams$Out$)
	at mill.javalib.testrunner.TestRunnerUtils$.$anonfun$11(TestRunnerUtils.scala:254)
	at mill.javalib.testrunner.TestRunnerUtils$$$Lambda/0x000000700523aac8.apply$mcV$sp(Unknown Source)
	at mill.javalib.testrunner.TestRunnerUtils$.runTasks$$anonfun$1(TestRunnerUtils.scala:261)
	at mill.javalib.testrunner.TestRunnerUtils$$$Lambda/0x000000700523adb8.applyVoid(Unknown Source)
	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
	at scala.collection.immutable.List.foreach(List.scala:327)
	at mill.javalib.testrunner.TestRunnerUtils$.runTasks(TestRunnerUtils.scala:258)
	at mill.javalib.testrunner.TestRunnerUtils$.runTestFramework0(TestRunnerUtils.scala:282)
	at mill.javalib.testrunner.TestRunner$.runTestFramework$$anonfun$1(TestRunner.scala:20)
	at mill.javalib.testrunner.TestRunner$$$Lambda/0x000000700523a310.apply(Unknown Source)
	at mill.util.Jvm$.withClassLoader(Jvm.scala:259)
	at mill.javalib.testrunner.TestRunner$.runTestFramework(TestRunner.scala:19)
	at mill.scalanativelib.TestScalaNativeModule.testTask$$anonfun$1(ScalaNativeModule.scala:474)
	at mill.scalanativelib.TestScalaNativeModule$$Lambda/0x0000007002050890.apply(Unknown Source)
	at mill.api.Task$Anon.evaluate(Task.scala:436)
	at mill.exec.GroupExecution.$anonfun$14(GroupExecution.scala:349)
	at mill.exec.GroupExecution$$Lambda/0x00000070020d2fb8.apply(Unknown Source)
	at mill.exec.GroupExecution$.wrap$$anonfun$1$$anonfun$1$$anonfun$1$$anonfun$1$$anonfun$1(GroupExecution.scala:661)
	at mill.exec.GroupExecution$$$Lambda/0x00000070020df548.apply(Unknown Source)
	at mill.api.daemon.ClassLoader$.withContextClassLoader(ClassLoader.scala:14)
	at mill.exec.GroupExecution$.wrap$$anonfun$1$$anonfun$1$$anonfun$1$$anonfun$1(GroupExecution.scala:671)
	at mill.exec.GroupExecution$$$Lambda/0x00000070020dd928.apply(Unknown Source)
	at mill.api.Evaluator$.withCurrentEvaluator$$anonfun$2$$anonfun$1(Evaluator.scala:146)
	at mill.api.Evaluator$$$Lambda/0x0000007001f077f8.apply(Unknown Source)
	at scala.util.DynamicVariable.withValue(DynamicVariable.scala:60)
	at mill.api.Evaluator$.withCurrentEvaluator$$anonfun$2(Evaluator.scala:147)
	at mill.api.Evaluator$$$Lambda/0x0000007001f07418.apply(Unknown Source)
	at scala.util.Using$.resource(Using.scala:298)
	at mill.api.Evaluator$.withCurrentEvaluator(Evaluator.scala:148)
	at mill.exec.GroupExecution$.wrap$$anonfun$1$$anonfun$1$$anonfun$1(GroupExecution.scala:672)
	at mill.exec.GroupExecution$$$Lambda/0x00000070020dc2c0.apply(Unknown Source)
	at mill.api.SystemStreamsUtils$.withStreams$$anonfun$1$$anonfun$1$$anonfun$1$$anonfun$1$$anonfun$1$$anonfun$1$$anonfun$1(SystemStreamsUtils.scala:49)
	at mill.api.SystemStreamsUtils$$$Lambda/0x00000070020837c8.apply(Unknown Source)
	at scala.util.DynamicVariable.withValue(DynamicVariable.scala:60)
	at mill.api.SystemStreamsUtils$.withStreams$$anonfun$1$$anonfun$1$$anonfun$1$$anonfun$1$$anonfun$1$$anonfun$1(SystemStreamsUtils.scala:50)
	at mill.api.SystemStreamsUtils$$$Lambda/0x00000070020818d8.apply(Unknown Source)
	at scala.util.DynamicVariable.withValue(DynamicVariable.scala:60)
	at mill.api.SystemStreamsUtils$.withStreams$$anonfun$1$$anonfun$1$$anonfun$1$$anonfun$1$$anonfun$1(SystemStreamsUtils.scala:51)
	at mill.api.SystemStreamsUtils$$$Lambda/0x00000070020807f8.apply(Unknown Source)
	at scala.util.DynamicVariable.withValue(DynamicVariable.scala:60)
	at mill.api.SystemStreamsUtils$.withStreams$$anonfun$1$$anonfun$1$$anonfun$1$$anonfun$1(SystemStreamsUtils.scala:52)
	at mill.api.SystemStreamsUtils$$$Lambda/0x000000700207e7a8.apply(Unknown Source)
	at scala.util.DynamicVariable.withValue(DynamicVariable.scala:60)
	at scala.Console$.withErr(Console.scala:195)
	at mill.api.SystemStreamsUtils$.withStreams$$anonfun$1$$anonfun$1$$anonfun$1(SystemStreamsUtils.scala:53)
	at mill.api.SystemStreamsUtils$$$Lambda/0x000000700207d6c8.apply(Unknown Source)
	at scala.util.DynamicVariable.withValue(DynamicVariable.scala:60)
	at scala.Console$.withOut(Console.scala:166)
	at mill.api.SystemStreamsUtils$.withStreams$$anonfun$1$$anonfun$1(SystemStreamsUtils.scala:54)
	at mill.api.SystemStreamsUtils$$$Lambda/0x000000700207c048.apply(Unknown Source)
	at scala.util.DynamicVariable.withValue(DynamicVariable.scala:60)
	at scala.Console$.withIn(Console.scala:229)
	at scala.Console$.withIn(Console.scala:242)
	at mill.api.SystemStreamsUtils$.withStreams$$anonfun$1(SystemStreamsUtils.scala:55)
	at mill.api.SystemStreamsUtils$$$Lambda/0x000000700207a158.apply(Unknown Source)
	at scala.util.DynamicVariable.withValue(DynamicVariable.scala:60)
	at mill.api.SystemStreamsUtils$.withStreams(SystemStreamsUtils.scala:56)
	at mill.exec.GroupExecution$.wrap$$anonfun$1$$anonfun$1(GroupExecution.scala:673)
	at mill.exec.GroupExecution$$$Lambda/0x00000070020db1e0.apply(Unknown Source)
	at scala.util.DynamicVariable.withValue(DynamicVariable.scala:60)
	at mill.exec.GroupExecution$.wrap$$anonfun$1(GroupExecution.scala:674)
	at mill.exec.GroupExecution$$$Lambda/0x00000070020d95c0.apply(Unknown Source)
	at scala.util.DynamicVariable.withValue(DynamicVariable.scala:60)
	at mill.exec.GroupExecution$.wrap(GroupExecution.scala:675)
	at mill.exec.GroupExecution.executeGroup$$anonfun$1(GroupExecution.scala:362)
	at mill.exec.GroupExecution$$Lambda/0x00000070020cbfd8.applyVoid(Unknown Source)
	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
	at scala.collection.immutable.VectorStatics$.foreachRec(Vector.scala:2128)
	at scala.collection.immutable.Vector.foreach(Vector.scala:307)
	at mill.exec.GroupExecution.executeGroup(GroupExecution.scala:309)
	at mill.exec.GroupExecution.executeGroupCached(GroupExecution.scala:225)
	at mill.exec.GroupExecution.executeGroupCached$(GroupExecution.scala:21)
	at mill.exec.Execution.executeGroupCached(Execution.scala:16)
	at mill.exec.Execution.evaluateTerminals$1$$anonfun$1$$anonfun$1$$anonfun$1(Execution.scala:246)
	at mill.exec.Execution$$Lambda/0x0000007002084d90.apply(Unknown Source)
	at mill.api.daemon.Logger.withPromptLine(Logger.scala:40)
	at mill.api.daemon.Logger.withPromptLine$(Logger.scala:12)
	at mill.internal.PrefixLogger.withPromptLine(PrefixLogger.scala:21)
	at mill.exec.Execution.evaluateTerminals$1$$anonfun$1$$anonfun$1(Execution.scala:278)
	at mill.exec.Execution$$Lambda/0x0000007002070f00.apply(Unknown Source)
	at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:503)
	at mill.exec.ExecutionContexts$.execute$$anonfun$1$$anonfun$1$$anonfun$1$$anonfun$1(ExecutionContexts.scala:67)
	at mill.exec.ExecutionContexts$.execute$$anonfun$1$$anonfun$1$$anonfun$1$$anonfun$adapted$1(ExecutionContexts.scala:68)
	at mill.exec.ExecutionContexts$$$Lambda/0x00000070020749d8.apply(Unknown Source)
	at mill.api.SystemStreamsUtils$.withStreams$$anonfun$1$$anonfun$1$$anonfun$1$$anonfun$1$$anonfun$1$$anonfun$1$$anonfun$1(SystemStreamsUtils.scala:49)
	at mill.api.SystemStreamsUtils$$$Lambda/0x00000070020837c8.apply(Unknown Source)
	at scala.util.DynamicVariable.withValue(DynamicVariable.scala:60)
	at mill.api.SystemStreamsUtils$.withStreams$$anonfun$1$$anonfun$1$$anonfun$1$$anonfun$1$$anonfun$1$$anonfun$1(SystemStreamsUtils.scala:50)
	at mill.api.SystemStreamsUtils$$$Lambda/0x00000070020818d8.apply(Unknown Source)
	at scala.util.DynamicVariable.withValue(DynamicVariable.scala:60)
	at mill.api.SystemStreamsUtils$.withStreams$$anonfun$1$$anonfun$1$$anonfun$1$$anonfun$1$$anonfun$1(SystemStreamsUtils.scala:51)
	at mill.api.SystemStreamsUtils$$$Lambda/0x00000070020807f8.apply(Unknown Source)
	at scala.util.DynamicVariable.withValue(DynamicVariable.scala:60)
	at mill.api.SystemStreamsUtils$.withStreams$$anonfun$1$$anonfun$1$$anonfun$1$$anonfun$1(SystemStreamsUtils.scala:52)
	at mill.api.SystemStreamsUtils$$$Lambda/0x000000700207e7a8.apply(Unknown Source)
	at scala.util.DynamicVariable.withValue(DynamicVariable.scala:60)
	at scala.Console$.withErr(Console.scala:195)
	at mill.api.SystemStreamsUtils$.withStreams$$anonfun$1$$anonfun$1$$anonfun$1(SystemStreamsUtils.scala:53)
	at mill.api.SystemStreamsUtils$$$Lambda/0x000000700207d6c8.apply(Unknown Source)
	at scala.util.DynamicVariable.withValue(DynamicVariable.scala:60)
	at scala.Console$.withOut(Console.scala:166)
	at mill.api.SystemStreamsUtils$.withStreams$$anonfun$1$$anonfun$1(SystemStreamsUtils.scala:54)
	at mill.api.SystemStreamsUtils$$$Lambda/0x000000700207c048.apply(Unknown Source)
	at scala.util.DynamicVariable.withValue(DynamicVariable.scala:60)
	at scala.Console$.withIn(Console.scala:229)
	at scala.Console$.withIn(Console.scala:242)
	at mill.api.SystemStreamsUtils$.withStreams$$anonfun$1(SystemStreamsUtils.scala:55)
	at mill.api.SystemStreamsUtils$$$Lambda/0x000000700207a158.apply(Unknown Source)
	at scala.util.DynamicVariable.withValue(DynamicVariable.scala:60)
	at mill.api.SystemStreamsUtils$.withStreams(SystemStreamsUtils.scala:56)
	at mill.exec.ExecutionContexts$.execute$$anonfun$1$$anonfun$1$$anonfun$1(ExecutionContexts.scala:68)
	at mill.exec.ExecutionContexts$.execute$$anonfun$1$$anonfun$1$$anonfun$adapted$1(ExecutionContexts.scala:69)
	at mill.exec.ExecutionContexts$$$Lambda/0x00000070020722d0.apply(Unknown Source)
	at scala.util.DynamicVariable.withValue(DynamicVariable.scala:60)
	at mill.exec.ExecutionContexts$.execute$$anonfun$1$$anonfun$1(ExecutionContexts.scala:69)
	at mill.exec.ExecutionContexts$.execute$$anonfun$1$$anonfun$adapted$1(ExecutionContexts.scala:70)
	at mill.exec.ExecutionContexts$$$Lambda/0x0000007002071a60.apply(Unknown Source)
	at scala.util.DynamicVariable.withValue(DynamicVariable.scala:60)
	at mill.exec.ExecutionContexts$.mill$exec$ExecutionContexts$ThreadPool$$_$execute$$anonfun$1(ExecutionContexts.scala:70)
	at mill.exec.ExecutionContexts$ThreadPool$$Lambda/0x0000007002071770.apply$mcV$sp(Unknown Source)
	at mill.exec.ExecutionContexts$ThreadPool$PriorityRunnable.run(ExecutionContexts.scala:89)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@21.0.9/ThreadPoolExecutor.java:1144)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@21.0.9/ThreadPoolExecutor.java:642)
	at java.lang.Thread.runWith(java.base@21.0.9/Thread.java:1596)
	at java.lang.Thread.run(java.base@21.0.9/Thread.java:1583)
"/Users/lihaoyi/Library/Caches/Coursier/arc/https/cdn.azul.com/zulu/bin/zulu21.46.19-ca-jdk21.0.9-macosx_aarch64.tar.gz/zulu21.46.19-ca-jdk21.0.9-macosx_aarch64/zulu-21.jdk/Contents/Home/bin/java -Xss100m -cp /Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.17/scala-library-2.13.17.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/utest_2.13/0.9.1/utest_2.13-0.9.1.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/fastparse_2.13/3.1.1/fastparse_2.13-3.1.1.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/pprint_2.13/0.9.3/pprint_2.13-0.9.3.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/ujson_2.13/4.4.0/ujson_2.13-4.4.0.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/scalatags_2.13/0.13.1/scalatags_2.13-0.13.1.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-collection-compat_2.13/2.13.0/scala-collection-compat_2.13-2.13.0.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/os-lib_2.13/0.11.4/os-lib_2.13-0.11.4.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/mainargs_2.13/0.7.6/mainargs_2.13-0.7.6.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/tukaani/xz/1.10/xz-1.10.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/lz4/lz4-java/1.8.0/lz4-java-1.8.0.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/yaml/snakeyaml/2.4/snakeyaml-2.4.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/google/re2j/re2j/1.8/re2j-1.8.jar:/Users/lihaoyi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/sourcecode_2.13/0.4.3-M5/sourcecode_2.13-0.4.3-M5.jar:/Users/lihaoyi/Library/Caches/Cour
	at jdk.internal.misc.Unsafe.park(java.base@21.0.9/Native Method)
	- parking to wait for  <0x00000006008033a8> (a java.util.concurrent.locks.ReentrantLock$NonfairSync)
	at java.util.concurrent.locks.LockSupport.park(java.base@21.0.9/LockSupport.java:221)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(java.base@21.0.9/AbstractQueuedSynchronizer.java:788)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(java.base@21.0.9/AbstractQueuedSynchronizer.java:1024)
	at java.util.concurrent.locks.ReentrantLock$Sync.lock(java.base@21.0.9/ReentrantLock.java:153)
	at java.util.concurrent.locks.ReentrantLock.lock(java.base@21.0.9/ReentrantLock.java:322)
	at jdk.internal.misc.InternalLock.lock(java.base@21.0.9/InternalLock.java:74)
	at java.io.PrintStream.write(java.base@21.0.9/PrintStream.java:788)
	at java.io.PrintStream.print(java.base@21.0.9/PrintStream.java:1002)
	at mill.internal.PromptLogger$prompt$.printPrefixed$1(PromptLogger.scala:215)
	at mill.internal.PromptLogger$prompt$.logPrefixedLine$$anonfun$1$$anonfun$2(PromptLogger.scala:246)
	at mill.internal.PromptLogger$prompt$$$Lambda/0x0000007001cb5538.applyVoid(Unknown Source)
	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
	at scala.collection.immutable.List.foreach(List.scala:327)
	at mill.internal.PromptLogger$prompt$.logPrefixedLine$$anonfun$1(PromptLogger.scala:246)
	at mill.internal.PromptLogger$prompt$$$Lambda/0x000000700180f408.applyVoid(Unknown Source)
	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
	at scala.Option.foreach(Option.scala:439)
	at mill.internal.PromptLogger$prompt$.logPrefixedLine(PromptLogger.scala:209)
	- locked <0x0000000600802f28> (a mill.internal.PipeStreams$Output$)
	at mill.internal.MultiLogger$$anon$1.logPrefixedLine(MultiLogger.scala:63)
	at mill.internal.PrefixLogger.prefixPrintStream$$anonfun$1(PrefixLogger.scala:49)
	at mill.internal.PrefixLogger$$Lambda/0x0000007001f05e38.applyVoid(Unknown Source)
	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
	at mill.internal.LineBufferingOutputStream.writeOutBuffer(LineBufferingOutputStream.scala:22)
	at mill.internal.LineBufferingOutputStream.write(LineBufferingOutputStream.scala:36)
	- locked <0x000000065960c968> (a mill.internal.LineBufferingOutputStream)
	at java.io.PrintStream.implWrite(java.base@21.0.9/PrintStream.java:643)
	at java.io.PrintStream.write(java.base@21.0.9/PrintStream.java:623)
	at mill.internal.MultiStream$$anon$1.write(MultiStream.scala:14)
	at java.io.PrintStream.implWrite(java.base@21.0.9/PrintStream.java:643)
	at java.io.PrintStream.write(java.base@21.0.9/PrintStream.java:629)
	- locked <0x0000000657171f10> (a mill.internal.MultiStream)
	at mill.constants.InputPumper.run(InputPumper.java:53)
	at java.lang.Thread.runWith(java.base@21.0.9/Thread.java:1596)
	at java.lang.Thread.run(java.base@21.0.9/Thread.java:1583)
"FileToStreamTailerThread":
	at mill.constants.ProxyStream$Output.write(ProxyStream.java:96)
	- waiting to lock <0x0000000600802f28> (a mill.internal.PipeStreams$Output$)
	at java.io.PrintStream.implWrite(java.base@21.0.9/PrintStream.java:643)
	at java.io.PrintStream.write(java.base@21.0.9/PrintStream.java:623)
	at mill.api.SystemStreamsUtils$ThreadLocalStreams$ProxyOutputStream.write(SystemStreamsUtils.scala:107)
	at java.io.PrintStream.implWrite(java.base@21.0.9/PrintStream.java:643)
	at java.io.PrintStream.write(java.base@21.0.9/PrintStream.java:623)
	at sun.nio.cs.StreamEncoder.writeBytes(java.base@21.0.9/StreamEncoder.java:309)
	at sun.nio.cs.StreamEncoder.implFlushBuffer(java.base@21.0.9/StreamEncoder.java:405)
	at sun.nio.cs.StreamEncoder.lockedFlushBuffer(java.base@21.0.9/StreamEncoder.java:123)
	at sun.nio.cs.StreamEncoder.flushBuffer(java.base@21.0.9/StreamEncoder.java:110)
	at java.io.OutputStreamWriter.flushBuffer(java.base@21.0.9/OutputStreamWriter.java:192)
	at java.io.PrintStream.implWriteln(java.base@21.0.9/PrintStream.java:849)
	at java.io.PrintStream.writeln(java.base@21.0.9/PrintStream.java:826)
	at java.io.PrintStream.println(java.base@21.0.9/PrintStream.java:1168)
	at mill.client.FileToStreamTailer.lambda$run$0(FileToStreamTailer.java:55)
	at mill.client.FileToStreamTailer$$Lambda/0x00000070011a7560.accept(Unknown Source)
	at java.util.Optional.ifPresent(java.base@21.0.9/Optional.java:178)
	at mill.client.FileToStreamTailer.run(FileToStreamTailer.java:49)

Found 1 deadlock.
```

We previously locked on `streamManager.pipe.output`, when we really should be locking on the specific `logStream` to follow the convention used by most `java.io.{Print,Input,Output}Stream`s which lock on the thing they are printing to.

Tested manually by `__.test` on the Sjsonnet codebase, deadlocks before this PR and passes after