### PR TITLE
Fix re-use of out folder in shared tests

### DIFF
--- a/integration/package.mill
+++ b/integration/package.mill
@@ -52,9 +52,10 @@ object `package` extends mill.Module {
     def forkArgs: T[Seq[String]]
     def testExclusive = false
     def testClasspath: T[Seq[PathRef]]
+
     trait ModeModule extends MillBaseTestsModule {
       override def testClasspath: T[Seq[PathRef]] = IntegrationTestModule.this.testClasspath()
-      def useSharedOut = false
+      def useSharedOut: Boolean
       override def enableBsp = false
       override def testForked(args: String*) = Task.Command(exclusive = testExclusive) {
 
@@ -123,7 +124,7 @@ object `package` extends mill.Module {
       }
 
     object shared extends IntegrationLauncherModule {
-      def useSharedOut = true
+      override def useSharedOut = true
       def millIntegrationLauncher = build.dist.launcher()
       def millIntegrationIsPackagedLauncher = Task(false)
     }
@@ -136,14 +137,17 @@ object `package` extends mill.Module {
       def millIntegrationIsPackagedLauncher = Task(true)
     }
     trait IntegrationLauncherModule extends Module {
+      def useSharedOut = false
       def millIntegrationLauncher: T[PathRef]
       def millIntegrationIsPackagedLauncher: Task[Boolean]
       object nodaemon extends ModeModule {
+        override def useSharedOut = IntegrationLauncherModule.this.useSharedOut
         def millIntegrationLauncher = IntegrationLauncherModule.this.millIntegrationLauncher
         def millIntegrationIsPackagedLauncher =
           IntegrationLauncherModule.this.millIntegrationIsPackagedLauncher
       }
       object daemon extends ModeModule {
+        override def useSharedOut = IntegrationLauncherModule.this.useSharedOut
         def millIntegrationLauncher = IntegrationLauncherModule.this.millIntegrationLauncher
         def millIntegrationIsPackagedLauncher =
           IntegrationLauncherModule.this.millIntegrationIsPackagedLauncher

--- a/testkit/src/mill/testkit/IntegrationTesterBase.scala
+++ b/testkit/src/mill/testkit/IntegrationTesterBase.scala
@@ -48,6 +48,7 @@ trait IntegrationTesterBase {
     println(s"Preparing integration test in $workspacePath")
     os.makeDir.all(workspacePath)
     if (!sys.env.contains("MILL_TEST_SHARED_OUTPUT_DIR")) {
+      println("Clearing out folder")
       Retry(logger = Retry.printStreamLogger(System.err)) {
         val tmp = os.temp.dir()
         val outDir = os.Path(out, workspacePath)
@@ -56,6 +57,7 @@ trait IntegrationTesterBase {
       }
       for (p <- os.list(workspacePath)) os.remove.all(p)
     } else {
+      println("Re-using out folder")
       // if `MILL_TEST_SHARED_OUTPUT_DIR` is provided, keep `out/` intact
       // to re-use the daemon
       for (p <- os.list(workspacePath) if p.last != "out") os.remove.all(p)


### PR DESCRIPTION
This regressed in https://github.com/com-lihaoyi/mill/pull/6283 and has been slowing down our CI considerably