### PR TITLE
Make selective execution work via `Task`s rather than `String`s

### DIFF
--- a/core/api/src/mill/api/SelectiveExecution.scala
+++ b/core/api/src/mill/api/SelectiveExecution.scala
@@ -27,7 +27,7 @@ private[mill] trait SelectiveExecution {
 
   def resolve0(tasks: Seq[String]): Result[Array[String]]
 
-  def resolveTasks0(tasks: Seq[String]): Result[(Seq[Task.Named[?]], Seq[Task.Named[?]])]
+  def resolveTasks0(tasks: Seq[String]): Result[Array[Task.Named[?]]]
 
   def resolveChanged(tasks: Seq[String]): Result[Seq[String]]
 

--- a/core/eval/src/mill/eval/SelectiveExecutionImpl.scala
+++ b/core/eval/src/mill/eval/SelectiveExecutionImpl.scala
@@ -133,17 +133,19 @@ class SelectiveExecutionImpl(evaluator: Evaluator)
   }
 
   def resolve0(tasks: Seq[String]): Result[Array[String]] = {
-    for ((resolvedSet0, downstreamSet0) <- resolveTasks0(tasks)) yield {
-      val resolvedSet = resolvedSet0.map(_.ctx.segments.render).toSet
-      val downstreamSet = downstreamSet0.map(_.ctx.segments.render).toSet
-      resolvedSet.intersect(downstreamSet).toArray.sorted
-    }
+    resolveTasks0(tasks).map(_.map(_.ctx.segments.render))
   }
-  def resolveTasks0(tasks: Seq[String]): Result[(Seq[Task.Named[?]], Seq[Task.Named[?]])] = {
+  def resolveTasks0(tasks: Seq[String]): Result[Array[Task.Named[?]]] = {
     for {
       (resolved, changedTasks) <-
         evaluator.resolveTasks(tasks, SelectMode.Separated).zip(this.computeChangedTasks(tasks))
-    } yield (resolved, changedTasks.downstreamTasks)
+    } yield {
+      val downstreamTasksRendered = changedTasks.downstreamTasks.map(_.ctx.segments.render).toSet
+
+      resolved
+        .filter(t => downstreamTasksRendered.contains(t.ctx.segments.render))
+        .toArray
+    }
   }
 
   def resolveChanged(tasks: Seq[String]): Result[Seq[String]] = {

--- a/example/thirdparty/mockito/build.mill
+++ b/example/thirdparty/mockito/build.mill
@@ -301,9 +301,3 @@ Test org.mockitousage.session.MockitoSessionTest.allows_updating_strictness fini
 ...
 
 */
-
-
-
-
-
-

--- a/libs/util/src/mill/util/SelectiveExecutionModule.scala
+++ b/libs/util/src/mill/util/SelectiveExecutionModule.scala
@@ -79,11 +79,9 @@ trait SelectiveExecutionModule extends mill.api.Module {
       if (!os.exists(evaluator.outPath / OutFiles.millSelectiveExecution)) {
         Result.Failure("`selective.run` can only be run after `selective.prepare`")
       } else {
-        evaluator.selective.resolveTasks0(tasks).flatMap { (resolvedTasks, downstreamTasks) =>
-          val downstreamTasksRendered = downstreamTasks.map(_.ctx.segments.render).toSet
-          val resolved = resolvedTasks.filter(t => downstreamTasksRendered.contains(t.ctx.segments.render))
-          if (resolved.isEmpty) Result.Success(())
-          else evaluator.execute(resolved) match {
+        evaluator.selective.resolveTasks0(tasks).flatMap { resolvedTasks =>
+          if (resolvedTasks.isEmpty) Result.Success(())
+          else evaluator.execute(resolvedTasks) match {
             case Evaluator.Result(_, f: Result.Failure, _, _) => f
             case Evaluator.Result(_, Result.Success(_), _, _) =>
           }


### PR DESCRIPTION
This works around https://github.com/com-lihaoyi/mill/issues/4119 in selective execution, which was causing problems in bootstrapping in https://github.com/com-lihaoyi/mill/pull/6289. Instead of serializing strings that we parse again (which fails if they contain `.super`), we just pass the tasks directly preserving all the information intact

Tested manually