### PR TITLE
Bisect Bootstrap

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1,4 +1,4 @@
-//| mill-version: 1.1.0-RC2-40-0576e4
+//| mill-version: 1.1.0-RC2-61-ddb191
 //| mill-jvm-opts: ["-XX:NonProfiledCodeHeapSize=250m", "-XX:ReservedCodeCacheSize=500m"]
 //| mill-opts: ["--jobs=0.5C", "-DMILL_ENABLE_STATIC_CHECKS=true"]
 


### PR DESCRIPTION
`build-windows` hangs rebootstrapping on latest `main`, seemingly reliably (both `com-lihaoyi/mill` and `lihaoyi/mill-1` CI runs exhibited this)

```
BAD 2e15c7486c02f81ebda86ea49702d1091bf18ec1 (upstream/main, main, bisect-rebootstrap) Make selective execution work via `Task`s rather than `String`s (#6291)

e3ba14737800e8ff84642e49fe17a20dad94189e Bump scala-steward-org/scala-steward-action from 2.75.0 to 2.78.0 (#6285)
3033a461582a307866926f4bcdffacb580e0269b Fix codesig detection for overriden tasks (#6290)

BAD 7152ed8628a4c878fcf6bc4996e4713c3bb2d7fb Add MILL_BSP_OUTPUT_DIR env var and rework defaults (#6262)

c5e504c71f19d725d33b5a5859b29c01ef4d7c4c make integration tests run packaged by default
b954b325cf0c9f597ea6140b6de4ad358489aaf5 Fix re-use of out folder in shared tests (#6288)

BAD cb0dbac3eb1795589e389400e44295f36e973022 Add `Result#zip`, rename `Failure.combine` to `Failure.join` (#6284)


BAD 0852de943cd3a6acffdbe163258f1a0b6094efea Validate connections to ZincWorker before using cached processees (#6287)

GOOD GOOD d318f9a9231dc7d657a10ef9b8fe19d1fd8de55b try to fix example tests

6287f4cc0ff50dd97a2f2e17241627b8bbdd5c80 Clean up integration test setup (#6283)
647a9ce0f8d6177927a50988b7abbf36a20e2e17 Disable arrow JS tests (#6282)
6ff59dd551eedf467c062993da6b7218e69ca237 `OutFiles`: use singleton instance instead of static fields (#6266)
12e7f625639498dbad56ce50864a4e309d749e3a Model exceptions in `Result.Failure` (#6279)
f63298c1afde67c1702271b18ed44f0b1c9c33d0 Add a `example.javalib.basic[3-simple]` alias for integration and example tests (#6280)
28b8ac2204a25a92ca617772abf11f9957e1e12d Convert `Result.Failure` into a more structured representation (#6278)

GOOD ddb191caedb652dc441d8d76762d22a91316f358 (HEAD -> debug, upstream/debug) Fix tests (#6277)

8090811f5a7682ab0d7d6a27d17152bfb1697e4e More improvement to YAML line number error reporting (#6275)
94465911bfa091fcc45f92a3571a10ec19e7110f Update GroupExecution.scala
1a3ab3bf6b3bb336d15e95a5b34f0d63f6cf8bca WIP use `upickle.core.BufferedValue` rather than `ujson.Value` to preserve char offsets and improve error reporting (#6273)
80a6d61b2fb79803ff83f7e7ca1075ed3c77fd52 Add  `nativeSourceLevelDebuggingConfig` and `nativeBaseName` (#6274)
8cc1887e19d39e5f5a100663688c9aa0742f5409 Report error if build header comment conflicts with task defined in `mill-build/build.mill` (#6271)
dceb479a79b5af944577ce6bf853329463c25f55 Allow `console`/`--repl` to take arguments from the command line (#6269)
ad645ae14de40ab1b7c47413bae0e3066ed6ea56 Scala 3.8.0-RC2 (#6268)
308937f3b5d7f237c49e9d3e09e77802b01c49c4 Make unsuccessful tasks always run the subsequent time when `--watch` is active (#6263)
15dd9fbf97361e6dd356c52523db8ce99d087c0f Try to fix pyspark example test by bumping pyspark version (#6267)
90de0756943b17fb92d50ca55cc0c6814ca98143 Fix warning about workers not implementing AutoCloseable (#6259)
b90560011f9692bc20e82acd97f2315cd78bc626 Revert "Bump actions/checkout from 5 to 6 (#6240)"
a5bc9add27cd9914bc8281745387b91d5415466f Update pyspark example (#6264)
ef68019c7bfa5213e2bbb62a06868de35583d745 Fix API leakage in Sonatype publisher (#6256)
5d3d9cf877da5d63c3894b2d054f4e57f9c49a46 Fix deadlock in logging infrastructure caused by locking on wrong stream. (#6255)
cc39f07316b12915a7854d8dc5c1d418cf4ecb30 Bump actions/checkout from 5 to 6 (#6240)
9593582a335ff9d713dbaff723c31eb55fd9e8b6 Improvements to examples and integration tests (#6254)
8dbcf480b6ec67995b39b03e95421c0d848ce07a Fix dependency update finder for bom and diverse resolution params (#6247)
b5f0cd6fbfbd242826809ec715110543cb69276a (more-scala38) Rebootstrap on Scala 3.8/JDK17 changes (#6253)
d869ed852a3b1c763a6918848c25b61aac55a26c Add TestModule#testArgsDefault (#6252)
91b085b4670bf0d5c4cc4f4ee61de28c917e8ce5 Allow users to provide their own compiler bridge (#6250)
0576e43a86577f886f8f70e49e519074a17af1f5 more gh actions tweaks
15e094dc0a1b1681d319dfeee724e1c24b2ee4b3 Bump java version in publish-docs job to try and fix it
6075022286821ac44748f873c3963dee3210277f Polish for YAML config error reporting (#6248)
2d202d3634d2e589758a2c69c6f3c1e22195b481 Split plugin/user-facing code to Scala3.7/Java11 to allow rest of codebase to upgrade to Scala3.8/Java17 (#6242)
ad6eb37dff81ae718a818c6b88f35aabdeeee723 Generation Software Bill of Materials (SBOM) (#4757)
91ae3340157762bc7d1f5e2306e01e8d54bd5fc6 Rebootstrap (#6244)```