### PR TITLE
Remove `--add-default` parameter from `testForked` due to breaking semantic compatibility

### DIFF
--- a/libs/javalib/src/mill/javalib/TestModule.scala
+++ b/libs/javalib/src/mill/javalib/TestModule.scala
@@ -95,9 +95,6 @@ trait TestModule
     }
   }
 
-  def testForked(args: String*): Task.Command[(msg: String, results: Seq[TestResult])] =
-    testForked(addDefault = true, args*)
-
   def getTestEnvironmentVars(args: String*): Task.Command[(
       mainClass: String,
       testRunnerClasspathArg: String,
@@ -166,9 +163,6 @@ trait TestModule
       testTask(argsTask, Task.Anon { selector })()
     }
   }
-
-  private[mill] def testOnly(args: String*): Task.Command[(msg: String, results: Seq[TestResult])] =
-    testOnly(addDefault = true, args*)
 
   /**
    * Controls whether the TestRunner should receive its arguments via an args-file instead of a long parameter list.


### PR DESCRIPTION
This is causing problems rebootstrapping due to the `override def testForked` in `integration/package.mill` no longer working due to the change in signature.

It seems that for non-final tasks, adding parameters cannot be done safely in a binary/semantic-compatible way. That is the same limitation we hit in https://docs.scala-lang.org/sips/unroll-default-arguments.html, and I guess is just something we'll have to live with