### PR TITLE
Ensure `must be defs defined in a Module class/trait/object body` error happens for commands

### DIFF
--- a/core/api/test/src/mill/api/MacroErrorTests.scala
+++ b/core/api/test/src/mill/api/MacroErrorTests.scala
@@ -233,11 +233,11 @@ object MacroErrorTests extends TestSuite {
             lazy val millDiscover = Discover[this.type]
           }
           """
-          )
+        )
 
-          assert(error.msg.contains(
-            "Task{} members must be defs defined in a Module class/trait/object body"
-          ))
+        assert(error.msg.contains(
+          "Task{} members must be defs defined in a Module class/trait/object body"
+        ))
       }
       test("command") {
         val error = utest.assertCompileError(
@@ -250,11 +250,11 @@ object MacroErrorTests extends TestSuite {
             lazy val millDiscover = Discover[this.type]
           }
           """
-          )
+        )
 
-          assert(error.msg.contains(
-            "Task{} members must be defs defined in a Module class/trait/object body"
-          ))
+        assert(error.msg.contains(
+          "Task{} members must be defs defined in a Module class/trait/object body"
+        ))
       }
     }
 


### PR DESCRIPTION
The basic issue is that we did this check in `Cacher`, but since `Command`s are not cached this check did not take effect. The solution is to move the check into `Task.scala`'s `assertTaskShapeOwner` so it happens for all named tasks

covered by unit tests