### PR TITLE
Add explicit `sys.exit` to `ZincWorkerMain` to ensure process terminates

### DIFF
--- a/libs/javalib/worker/src/mill/javalib/zinc/ZincWorkerMain.scala
+++ b/libs/javalib/worker/src/mill/javalib/zinc/ZincWorkerMain.scala
@@ -18,6 +18,9 @@ object ZincWorkerMain {
       case Array(daemonDir, jobsStr) =>
         val server = ZincWorkerTcpServer(os.Path(daemonDir), jobsStr.toInt)
         server.run()
+        // Make sure we explicitly exit, so that even if there are some leaked threads
+        // hanging around the process properly terminates rather than hanging
+        sys.exit(0)
 
       case other =>
         Console.err.println(


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/6347

Tested manually