### PR TITLE
Fix androidtodo

### DIFF
--- a/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
@@ -1039,8 +1039,6 @@ trait AndroidAppModule extends AndroidModule { outer =>
       ) ++ androidMergeableManifests().flatMap(m => Seq("--libs", m.path.toString))
     }
 
-    override def androidTransitiveCompiledResources: T[Seq[PathRef]] = Seq.empty[PathRef]
-
     override def androidVirtualDeviceIdentifier: String = outer.androidVirtualDeviceIdentifier
     override def androidEmulatorArchitecture: String = outer.androidEmulatorArchitecture
 

--- a/libs/androidlib/src/mill/androidlib/AndroidModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidModule.scala
@@ -192,23 +192,12 @@ trait AndroidModule extends JavaModule { outer =>
   }
 
   /**
-   * The transitive module dependencies of this module.
-   * This does not include direct dependencies, meaning
-   * these are only the dependencies of the dependencies.
-   */
-  def androidTransitiveModuleDeps: Seq[JavaModule] = {
-    val moduleDepsCheckedSet = moduleDepsChecked.toSet
-    val isDirectDependency = (m: JavaModule) => moduleDepsCheckedSet.contains(m)
-    transitiveModuleRunModuleDeps.filterNot(isDirectDependency)
-  }
-
-  /**
    * Gets all the transitive compiled Android resources (typically in res/ directory)
    * from the [[androidTransitiveModuleDeps]]
    * @return a sequence of PathRef to the compiled resources
    */
   def androidTransitiveCompiledResources: T[Seq[PathRef]] = Task {
-    Task.traverse(transitiveModuleRunModuleDeps) {
+    Task.traverse(moduleDepsChecked) {
       case m: AndroidModule =>
         m.androidCompiledModuleResources
       case _ =>


### PR DESCRIPTION
Fixes the issue of instrumented tests pulling resources from the main app: https://github.com/com-lihaoyi/mill/issues/6355

Issue was after non transitive R class revert, we've left the androidTransitiveModuleDeps resulting in missing resources