### PR TITLE
Kotlin fix incremental compilation for generated sources

### DIFF
--- a/example/kotlinlib/module/10-dependency-injection/build.mill
+++ b/example/kotlinlib/module/10-dependency-injection/build.mill
@@ -14,9 +14,6 @@ object dagger extends KspModule {
 
   def kotlincOptions = super.kotlincOptions() ++ Seq("-no-reflect", "-verbose")
 
-  // dagger doesn't play well with BtApi's incremental compilation
-  override def kotlincUseBtApi = false
-
   def mvnDeps = Seq(
     mvn"com.google.dagger:dagger:2.57"
   )

--- a/libs/androidlib/src/mill/androidlib/hilt/AndroidHiltSupport.scala
+++ b/libs/androidlib/src/mill/androidlib/hilt/AndroidHiltSupport.scala
@@ -24,11 +24,6 @@ import mill.{T, Task}
 @mill.api.experimental
 trait AndroidHiltSupport extends KspModule, AndroidKotlinModule {
 
-  // Dagger does not work with the bt api
-  override def kotlincUseBtApi: T[Boolean] = Task {
-    false
-  }
-
   override def kspProcessorOptions: T[Map[String, String]] = Task {
     super.kspProcessorOptions() ++ Map(
       "dagger.fastInit" -> "enabled",

--- a/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JvmCompileBtApiImpl.scala
+++ b/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JvmCompileBtApiImpl.scala
@@ -62,7 +62,7 @@ class JvmCompileBtApiImpl() extends Compiler {
       strategyConfig,
       compilationConfig,
       KotlinInterop.toKotlinList(sourceFiles),
-      KotlinInterop.toKotlinList(args.toArray)
+      KotlinInterop.toKotlinList(sourceFiles.map(_.toString) ++ args.toArray)
     )
 
     val exitCode = compilationResult match {


### PR DESCRIPTION
Fix for https://github.com/com-lihaoyi/mill/issues/6379

It seems that in order to get the compilation to take mixed sources (Java + Kotlin) we should pass all the files as [compiler arguments](https://github.com/JetBrains/kotlin/blob/677deda4b2f29d931161cd6d234fafbf023e5f81/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/compilerRunner/btapi/BuildToolsApiCompilationWork.kt#L111-L117)

as found by @lefou (see [this comment](https://github.com/com-lihaoyi/mill/pull/5785#issuecomment-3273752670))

This was evident in ksp setups because both hilt and dagger generate java files. But the problem is not necessarily on KSP / dependency injection frameworks, but in mixed sources in general.

 
 
