### PR TITLE
Android: Improve CI performance

### DIFF
--- a/example/androidlib/java/5-R8/build.mill
+++ b/example/androidlib/java/5-R8/build.mill
@@ -87,6 +87,8 @@ object app extends AndroidR8AppModule { // <2>
 
 > ./mill show app.androidApk
 
+> ./mill show app.it.androidTestApk
+
 > ./mill show app.createAndroidVirtualDevice
 ...Name: java-test, DeviceId: medium_phone...
 

--- a/example/androidlib/java/6-native-libs/build.mill
+++ b/example/androidlib/java/6-native-libs/build.mill
@@ -68,6 +68,8 @@ object app extends AndroidNativeAppModule { // <1>
 > ./mill show app.androidApk
 ".../out/app/androidApk.dest/app.apk"
 
+> ./mill show app.it.androidTestApk
+
 > ./mill show app.createAndroidVirtualDevice
 ...Name: java-test, DeviceId: medium_phone...
 

--- a/example/androidlib/kotlin/1-hello-kotlin/build.mill
+++ b/example/androidlib/kotlin/1-hello-kotlin/build.mill
@@ -74,6 +74,8 @@ object app extends AndroidAppKotlinModule {
 > ./mill show app.androidApk
 ".../out/app/androidApk.dest/app.apk"
 
+> ./mill app.it.androidTestApk
+
 */
 
 // This command triggers the build process, which installs the Android Setup, compiles the kotlin

--- a/example/thirdparty/android-compose-samples/build.mill
+++ b/example/thirdparty/android-compose-samples/build.mill
@@ -334,6 +334,8 @@ object Jetchat extends mill.api.Module {
 
 > ./mill JetNews.app.androidApk
 
+> ./mill JetNews.app.androidTest.androidTestApk
+
 > ./mill show JetNews.app.createAndroidVirtualDevice
 ...Name: test, DeviceId: medium_phone...
 

--- a/example/thirdparty/androidtodo/build.mill
+++ b/example/thirdparty/androidtodo/build.mill
@@ -248,6 +248,8 @@ object `shared-test` extends AndroidKotlinModule, AndroidHiltSupport {
 
 > ./mill app.androidApk
 
+> ./mill app.androidTest.androidTestApk
+
 > ./mill app.test
 
 > cat out/app/test/testForked.dest/test-report.xml


### PR DESCRIPTION
References #6276

Run the `test.androidTestApk ` task before running the emulator to improve the performance.

This results to roughly 10 minutes less execution time for the `androidlib.__` tests. 

Old: https://github.com/com-lihaoyi/mill/actions/runs/20304955988/job/58320335231
<img width="470" height="58" alt="image" src="https://github.com/user-attachments/assets/8fed7500-12c0-42f1-8bd4-c57f6fc688a1" />

This: https://github.com/com-lihaoyi/mill/actions/runs/20307780659/job/58330783010?pr=6406
<img width="470" height="58" alt="image" src="https://github.com/user-attachments/assets/d59914fc-6020-42a6-acc9-2fd33dc09c54" />

