### PR TITLE
Added check for first character of a segment in `Util.backtickWrap`

### DIFF
--- a/core/internal/src/mill/internal/Util.scala
+++ b/core/internal/src/mill/internal/Util.scala
@@ -61,7 +61,11 @@ object Util {
 
   def backtickWrap(s: String): String = s match {
     case s"`$_`" => s
-    case _ => if (encode(s) == s && !alphaKeywords.contains(s)) s
+    case _ =>
+      if (
+        encode(s) == s && !alphaKeywords.contains(s) &&
+        (s.isEmpty || Character.isJavaIdentifierStart(s.charAt(0)))
+      ) s
       else "`" + s + "`"
   }
 

--- a/core/internal/src/mill/internal/Util.scala
+++ b/core/internal/src/mill/internal/Util.scala
@@ -62,10 +62,7 @@ object Util {
   def backtickWrap(s: String): String = s match {
     case s"`$_`" => s
     case _ =>
-      if (
-        encode(s) == s && !alphaKeywords.contains(s) &&
-        (s.isEmpty || Character.isJavaIdentifierStart(s.charAt(0)))
-      ) s
+      if (encode(s) == s && !alphaKeywords.contains(s) && Character.isJavaIdentifierStart(s.head)) s
       else "`" + s + "`"
   }
 


### PR DESCRIPTION
Segments made of numeric characters were causing a crash for an example listed in #6075.
```
Caused by: .../ghidra/Ghidra/Test/IntegrationTest/package.mill:10: error: [dialect scala3] `)` expected but `double constant` found
  def moduleDeps = Seq(build.Ghidra.Processors.68000, build.Ghidra.Processors.8051, build.Ghidra.Processors.AARCH64, ...
```
This fix wraps such values in backticks to produce a legal identifier.