### PR TITLE
Allow un-prefixed dependencies in `--import`

### DIFF
--- a/runner/meta/src/mill/meta/MillBuildRootModule.scala
+++ b/runner/meta/src/mill/meta/MillBuildRootModule.scala
@@ -108,10 +108,11 @@ trait MillBuildRootModule()(using
 
   override def runMvnDeps = Task {
     val imports = cliImports()
-    val ivyImports = imports.collect {
+    val ivyImports = imports.map {
       // compat with older Mill-versions
       case s"ivy:$rest" => rest
       case s"mvn:$rest" => rest
+      case rest => rest
     }
     MillIvy.processMillMvnDepsignature(ivyImports).map(mill.scalalib.Dep.parse) ++
       // Needed at runtime to instantiate a `mill.eval.EvaluatorImpl` in the `build.mill`,


### PR DESCRIPTION
The `ivy:` and `mvn:` prefixes don't really do anything, so might as well just allow bare dependency strings as well