### PR TITLE
Make `bspClean` work

### DIFF
--- a/libs/util/src/mill/util/bsp/BspMainModule.scala
+++ b/libs/util/src/mill/util/bsp/BspMainModule.scala
@@ -5,6 +5,7 @@ import mill.api.daemon.internal.{EvaluatorApi, TaskApi, internal}
 import mill.api.{Discover, Evaluator, ExternalModule, ModuleCtx}
 import mill.util.MainModule
 import mill.Task
+import mill.nioPathRW
 
 @internal
 private[mill] object BspMainModule extends ExternalModule {
@@ -26,7 +27,7 @@ private[mill] object BspMainModule extends ExternalModule {
       private[mill] def bspClean(
           evaluator: EvaluatorApi,
           tasks: String*
-      ): TaskApi[Seq[java.nio.file.Path]] = Task.Anon {
+      ): TaskApi[Seq[java.nio.file.Path]] = Task.Command {
         mainModule.cleanTask(evaluator.asInstanceOf[Evaluator], tasks*)().map(_.path.toNIO)
       }
 


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/6425 by making `def bspClean` a `Task.Command` rather than a `Task.Anon`, so it runs with the filesystem checker disabled

Tested manually in VSCode, `Clean compile` crashes on 1.1.0-RC3 and passes on publishLocalCache from this PR