### PR TITLE
Avoid `String.stripMargin` in code generator templates

### DIFF
--- a/libs/init/buildgen/test/src/mill/main/buildgen/BuildGenChecker.scala
+++ b/libs/init/buildgen/test/src/mill/main/buildgen/BuildGenChecker.scala
@@ -17,7 +17,10 @@ class BuildGenChecker(mainAssembly: os.Path, sourceRoot: os.Path, scalafmtConfig
       sourceRel: os.SubPath,
       expectedRel: os.SubPath,
       initArgs: Seq[String] = Nil,
-      updateSnapshots: Boolean = false // pass true to update test data on disk
+      // pass true to update test data on disk
+      updateSnapshots: Boolean = sys.env
+        .getOrElse("UTEST_UPDATE_GOLDEN_TESTS", "0")
+        .equals("1")
   )(using tp: TestPath): Boolean = {
     val testRoot = os.pwd / tp.value
     os.copy.over(sourceRoot / sourceRel, testRoot, createFolders = true, replaceExisting = true)

--- a/libs/init/gradle/test/resources/expected/gradle-6-0/build.mill
+++ b/libs/init/gradle/test/resources/expected/gradle-6-0/build.mill
@@ -1,9 +1,11 @@
 //| mill-version: SNAPSHOT
 //| mill-jvm-version: system
 package build
+
 import mill.*
 import mill.javalib.*
 import millbuild.*
+
 object `package` extends MavenModule {
 
   def mvnDeps = Seq(Deps.guava)
@@ -25,4 +27,5 @@ object `package` extends MavenModule {
     def testSandboxWorkingDir = false
 
   }
+
 }

--- a/libs/init/gradle/test/resources/expected/gradle-6-0/mill-build/src/Deps.scala
+++ b/libs/init/gradle/test/resources/expected/gradle-6-0/mill-build/src/Deps.scala
@@ -1,7 +1,8 @@
 package millbuild
-import mill.javalib.*
-object Deps {
 
+import mill.javalib.*
+
+object Deps {
   val guava = mvn"com.google.guava:guava:28.0-jre"
   val testng = mvn"org.testng:testng:6.14.3"
 }

--- a/libs/init/gradle/test/resources/expected/gradle-7-0/app/package.mill
+++ b/libs/init/gradle/test/resources/expected/gradle-7-0/app/package.mill
@@ -1,7 +1,9 @@
 package build.app
+
 import mill.*
 import mill.javalib.*
 import millbuild.*
+
 object `package` extends ProjectBaseModule {
 
   def moduleDeps = Seq(build.utilities)
@@ -9,4 +11,5 @@ object `package` extends ProjectBaseModule {
   def mvnDeps = Seq(mvn"org.apache.commons:commons-text")
 
   object test extends Tests {}
+
 }

--- a/libs/init/gradle/test/resources/expected/gradle-7-0/build.mill
+++ b/libs/init/gradle/test/resources/expected/gradle-7-0/build.mill
@@ -1,6 +1,8 @@
 //| mill-version: SNAPSHOT
 //| mill-jvm-version: system
 package build
+
 import mill.*
 import millbuild.*
+
 object `package` extends Module {}

--- a/libs/init/gradle/test/resources/expected/gradle-7-0/list/package.mill
+++ b/libs/init/gradle/test/resources/expected/gradle-7-0/list/package.mill
@@ -1,8 +1,11 @@
 package build.list
+
 import mill.*
 import mill.javalib.*
 import millbuild.*
+
 object `package` extends ProjectBaseModule {
 
   object test extends Tests {}
+
 }

--- a/libs/init/gradle/test/resources/expected/gradle-7-0/mill-build/src/Deps.scala
+++ b/libs/init/gradle/test/resources/expected/gradle-7-0/mill-build/src/Deps.scala
@@ -1,7 +1,8 @@
 package millbuild
-import mill.javalib.*
-object Deps {
 
+import mill.javalib.*
+
+object Deps {
   val commonsText = mvn"org.apache.commons:commons-text:1.9"
   val junitBom = mvn"org.junit:junit-bom:5.7.1"
   val junitJupiterApi = mvn"org.junit.jupiter:junit-jupiter-api:5.7.1"

--- a/libs/init/gradle/test/resources/expected/gradle-7-0/mill-build/src/ProjectBaseModule.scala
+++ b/libs/init/gradle/test/resources/expected/gradle-7-0/mill-build/src/ProjectBaseModule.scala
@@ -1,6 +1,8 @@
 package millbuild
+
 import mill.*
 import mill.javalib.*
+
 trait ProjectBaseModule extends MavenModule {
 
   def depManagement = Seq(Deps.commonsText)
@@ -30,4 +32,5 @@ trait ProjectBaseModule extends MavenModule {
     def testSandboxWorkingDir = false
 
   }
+
 }

--- a/libs/init/gradle/test/resources/expected/gradle-7-0/utilities/package.mill
+++ b/libs/init/gradle/test/resources/expected/gradle-7-0/utilities/package.mill
@@ -1,7 +1,9 @@
 package build.utilities
+
 import mill.*
 import mill.javalib.*
 import millbuild.*
+
 object `package` extends ProjectBaseModule {
 
   def moduleDeps = Seq(build.list)

--- a/libs/init/gradle/test/resources/expected/gradle-8-0/app/package.mill
+++ b/libs/init/gradle/test/resources/expected/gradle-8-0/app/package.mill
@@ -1,7 +1,9 @@
 package build.app
+
 import mill.*
 import mill.javalib.*
 import millbuild.*
+
 object `package` extends ProjectBaseModule {
 
   def moduleDeps = Seq(build.utilities)
@@ -9,4 +11,5 @@ object `package` extends ProjectBaseModule {
   def mvnDeps = Seq(mvn"org.apache.commons:commons-text")
 
   object test extends Tests, TestModule.Junit5 {}
+
 }

--- a/libs/init/gradle/test/resources/expected/gradle-8-0/build.mill
+++ b/libs/init/gradle/test/resources/expected/gradle-8-0/build.mill
@@ -1,6 +1,8 @@
 //| mill-version: SNAPSHOT
 //| mill-jvm-version: system
 package build
+
 import mill.*
 import millbuild.*
+
 object `package` extends Module {}

--- a/libs/init/gradle/test/resources/expected/gradle-8-0/list/package.mill
+++ b/libs/init/gradle/test/resources/expected/gradle-8-0/list/package.mill
@@ -1,8 +1,10 @@
 package build.list
+
 import mill.*
 import mill.javalib.*
 import mill.javalib.errorprone.ErrorProneModule
 import millbuild.*
+
 object `package` extends ProjectBaseModule, ErrorProneModule {
 
   def errorProneDeps = Seq(Deps.error_prone_core)
@@ -20,4 +22,5 @@ object `package` extends ProjectBaseModule, ErrorProneModule {
       Seq("-XDshould-stop.ifError=FLOW", "-XDshouldStopPolicyIfError=FLOW")
 
   }
+
 }

--- a/libs/init/gradle/test/resources/expected/gradle-8-0/mill-build/src/Deps.scala
+++ b/libs/init/gradle/test/resources/expected/gradle-8-0/mill-build/src/Deps.scala
@@ -1,7 +1,8 @@
 package millbuild
-import mill.javalib.*
-object Deps {
 
+import mill.javalib.*
+
+object Deps {
   val commonsText = mvn"org.apache.commons:commons-text:1.9"
   val error_prone_core = mvn"com.google.errorprone:error_prone_core:2.28.0"
   val junitBom = mvn"org.junit:junit-bom:5.9.1"

--- a/libs/init/gradle/test/resources/expected/gradle-8-0/mill-build/src/ProjectBaseModule.scala
+++ b/libs/init/gradle/test/resources/expected/gradle-8-0/mill-build/src/ProjectBaseModule.scala
@@ -1,7 +1,9 @@
 package millbuild
+
 import mill.*
 import mill.javalib.*
 import mill.javalib.errorprone.ErrorProneModule
+
 trait ProjectBaseModule extends MavenModule {
 
   def depManagement = Seq(Deps.commonsText)
@@ -25,4 +27,5 @@ trait ProjectBaseModule extends MavenModule {
     def testSandboxWorkingDir = false
 
   }
+
 }

--- a/libs/init/gradle/test/resources/expected/gradle-8-0/utilities/package.mill
+++ b/libs/init/gradle/test/resources/expected/gradle-8-0/utilities/package.mill
@@ -1,8 +1,10 @@
 package build.utilities
+
 import mill.*
 import mill.javalib.*
 import mill.javalib.errorprone.ErrorProneModule
 import millbuild.*
+
 object `package` extends ProjectBaseModule, ErrorProneModule {
 
   def moduleDeps = Seq(build.list)

--- a/libs/init/gradle/test/resources/expected/gradle-9-0-0/app/package.mill
+++ b/libs/init/gradle/test/resources/expected/gradle-9-0-0/app/package.mill
@@ -1,7 +1,9 @@
 package build.app
+
 import mill.*
 import mill.javalib.*
 import millbuild.*
+
 object `package` extends ProjectBaseModule {
 
   def moduleDeps = Seq(build.utilities)
@@ -9,4 +11,5 @@ object `package` extends ProjectBaseModule {
   def mvnDeps = Seq(mvn"org.apache.commons:commons-text")
 
   object test extends Tests {}
+
 }

--- a/libs/init/gradle/test/resources/expected/gradle-9-0-0/build.mill
+++ b/libs/init/gradle/test/resources/expected/gradle-9-0-0/build.mill
@@ -2,6 +2,8 @@
 //| mill-jvm-version: system
 //| mill-jvm-opts: ["-Xmx2g", "-XX:MaxMetaspaceSize=512m"]
 package build
+
 import mill.*
 import millbuild.*
+
 object `package` extends Module {}

--- a/libs/init/gradle/test/resources/expected/gradle-9-0-0/list/package.mill
+++ b/libs/init/gradle/test/resources/expected/gradle-9-0-0/list/package.mill
@@ -1,8 +1,10 @@
 package build.list
+
 import mill.*
 import mill.javalib.*
 import mill.javalib.publish.*
 import millbuild.*
+
 object `package` extends ProjectBaseModule, PublishModule {
 
   def artifactName = "list"
@@ -31,4 +33,5 @@ object `package` extends ProjectBaseModule, PublishModule {
   def publishVersion = "unspecified"
 
   object test extends Tests {}
+
 }

--- a/libs/init/gradle/test/resources/expected/gradle-9-0-0/mill-build/src/Deps.scala
+++ b/libs/init/gradle/test/resources/expected/gradle-9-0-0/mill-build/src/Deps.scala
@@ -1,7 +1,8 @@
 package millbuild
-import mill.javalib.*
-object Deps {
 
+import mill.javalib.*
+
+object Deps {
   val commonsText = mvn"org.apache.commons:commons-text:1.13.0"
   val junitBom = mvn"org.junit:junit-bom:5.12.1"
   val junitJupiter = mvn"org.junit.jupiter:junit-jupiter:5.12.1"

--- a/libs/init/gradle/test/resources/expected/gradle-9-0-0/mill-build/src/ProjectBaseModule.scala
+++ b/libs/init/gradle/test/resources/expected/gradle-9-0-0/mill-build/src/ProjectBaseModule.scala
@@ -1,7 +1,9 @@
 package millbuild
+
 import mill.*
 import mill.javalib.*
 import mill.javalib.publish.*
+
 trait ProjectBaseModule extends MavenModule {
 
   def depManagement = Seq(Deps.commonsText)
@@ -25,4 +27,5 @@ trait ProjectBaseModule extends MavenModule {
     def testSandboxWorkingDir = false
 
   }
+
 }

--- a/libs/init/gradle/test/resources/expected/gradle-9-0-0/utilities/package.mill
+++ b/libs/init/gradle/test/resources/expected/gradle-9-0-0/utilities/package.mill
@@ -1,8 +1,10 @@
 package build.utilities
+
 import mill.*
 import mill.javalib.*
 import mill.javalib.publish.*
 import millbuild.*
+
 object `package` extends ProjectBaseModule, PublishModule {
 
   def moduleDeps = Seq(build.list)

--- a/libs/init/gradle/test/resources/expected/with-args/gradle-8-0/build.mill
+++ b/libs/init/gradle/test/resources/expected/with-args/gradle-8-0/build.mill
@@ -1,9 +1,11 @@
 //| mill-version: SNAPSHOT
 //| mill-jvm-version: system
 package build
+
 import mill.*
 import mill.javalib.*
 import mill.javalib.errorprone.ErrorProneModule
+
 object `package` extends Module {
 
   object app extends MavenModule {
@@ -33,6 +35,7 @@ object `package` extends Module {
       def testSandboxWorkingDir = false
 
     }
+
   }
 
   object list extends MavenModule, ErrorProneModule {
@@ -71,6 +74,7 @@ object `package` extends Module {
       def testSandboxWorkingDir = false
 
     }
+
   }
 
   object utilities extends MavenModule, ErrorProneModule {
@@ -87,4 +91,5 @@ object `package` extends Module {
       Seq("-XDshould-stop.ifError=FLOW", "-XDshouldStopPolicyIfError=FLOW")
 
   }
+
 }

--- a/libs/init/maven/test/resources/expected/maven-samples/build.mill
+++ b/libs/init/maven/test/resources/expected/maven-samples/build.mill
@@ -1,10 +1,12 @@
 //| mill-version: SNAPSHOT
 //| mill-jvm-version: system
 package build
+
 import mill.*
 import mill.javalib.*
 import mill.javalib.publish.*
 import millbuild.*
+
 object `package` extends PublishModule {
 
   def pomPackagingType = "pom"

--- a/libs/init/maven/test/resources/expected/maven-samples/mill-build/src/Deps.scala
+++ b/libs/init/maven/test/resources/expected/maven-samples/mill-build/src/Deps.scala
@@ -1,7 +1,8 @@
 package millbuild
-import mill.javalib.*
-object Deps {
 
+import mill.javalib.*
+
+object Deps {
   val hamcrestCore = mvn"org.hamcrest:hamcrest-core:1.2.1"
   val hamcrestLibrary = mvn"org.hamcrest:hamcrest-library:1.2.1"
   val jspApi = mvn"javax.servlet.jsp:jsp-api:2.2"

--- a/libs/init/maven/test/resources/expected/maven-samples/mill-build/src/ProjectBaseModule.scala
+++ b/libs/init/maven/test/resources/expected/maven-samples/mill-build/src/ProjectBaseModule.scala
@@ -1,7 +1,9 @@
 package millbuild
+
 import mill.*
 import mill.javalib.*
 import mill.javalib.publish.*
+
 trait ProjectBaseModule extends MavenModule, PublishModule {
 
   def javacOptions = Seq("-source", "1.6", "-target", "1.6")
@@ -24,4 +26,5 @@ trait ProjectBaseModule extends MavenModule, PublishModule {
     def testSandboxWorkingDir = false
 
   }
+
 }

--- a/libs/init/maven/test/resources/expected/maven-samples/multi-module/package.mill
+++ b/libs/init/maven/test/resources/expected/maven-samples/multi-module/package.mill
@@ -1,8 +1,10 @@
 package build.`multi-module`
+
 import mill.*
 import mill.javalib.*
 import mill.javalib.publish.*
 import millbuild.*
+
 object `package` extends JavaModule, BomModule, PublishModule {
 
   def depManagement = Seq(

--- a/libs/init/maven/test/resources/expected/maven-samples/multi-module/server/package.mill
+++ b/libs/init/maven/test/resources/expected/maven-samples/multi-module/server/package.mill
@@ -1,8 +1,10 @@
 package build.`multi-module`.server
+
 import mill.*
 import mill.javalib.*
 import mill.javalib.publish.*
 import millbuild.*
+
 object `package` extends ProjectBaseModule {
 
   def depManagement = Seq(
@@ -30,4 +32,5 @@ object `package` extends ProjectBaseModule {
   )
 
   object test extends Tests {}
+
 }

--- a/libs/init/maven/test/resources/expected/maven-samples/multi-module/webapp/package.mill
+++ b/libs/init/maven/test/resources/expected/maven-samples/multi-module/webapp/package.mill
@@ -1,8 +1,10 @@
 package build.`multi-module`.webapp
+
 import mill.*
 import mill.javalib.*
 import mill.javalib.publish.*
 import millbuild.*
+
 object `package` extends ProjectBaseModule {
 
   def moduleDeps = Seq(build.`multi-module`.server)

--- a/libs/init/maven/test/resources/expected/maven-samples/single-module/package.mill
+++ b/libs/init/maven/test/resources/expected/maven-samples/single-module/package.mill
@@ -1,8 +1,10 @@
 package build.`single-module`
+
 import mill.*
 import mill.javalib.*
 import mill.javalib.publish.*
 import millbuild.*
+
 object `package` extends ProjectBaseModule {
 
   def mvnDeps = Seq(Deps.servletApi, Deps.jspApi)
@@ -24,4 +26,5 @@ object `package` extends ProjectBaseModule {
   )
 
   object test extends Tests {}
+
 }

--- a/libs/init/maven/test/resources/expected/quickstart/build.mill
+++ b/libs/init/maven/test/resources/expected/quickstart/build.mill
@@ -1,11 +1,13 @@
 //| mill-version: SNAPSHOT
 //| mill-jvm-version: system
 package build
+
 import mill.*
 import mill.javalib.*
 import mill.javalib.errorprone.ErrorProneModule
 import mill.javalib.publish.*
 import millbuild.*
+
 object `package` extends MavenModule, ErrorProneModule, PublishModule {
 
   def bomMvnDeps = Seq(Deps.junitBom)
@@ -44,4 +46,5 @@ object `package` extends MavenModule, ErrorProneModule, PublishModule {
     def testSandboxWorkingDir = false
 
   }
+
 }

--- a/libs/init/maven/test/resources/expected/quickstart/mill-build/src/Deps.scala
+++ b/libs/init/maven/test/resources/expected/quickstart/mill-build/src/Deps.scala
@@ -1,7 +1,8 @@
 package millbuild
-import mill.javalib.*
-object Deps {
 
+import mill.javalib.*
+
+object Deps {
   val error_prone_core = mvn"com.google.errorprone:error_prone_core:2.28.0"
   val junitBom = mvn"org.junit:junit-bom:5.11.0"
   val junitJupiterApi = mvn"org.junit.jupiter:junit-jupiter-api:5.11.0"

--- a/libs/init/maven/test/resources/expected/spring-start/build.mill
+++ b/libs/init/maven/test/resources/expected/spring-start/build.mill
@@ -1,10 +1,12 @@
 //| mill-version: SNAPSHOT
 //| mill-jvm-version: system
 package build
+
 import mill.*
 import mill.javalib.*
 import mill.javalib.publish.*
 import millbuild.*
+
 object `package` extends MavenModule, PublishModule {
 
   def mvnDeps = Seq(Deps.springBootStarterDataJdbc)
@@ -451,4 +453,5 @@ object `package` extends MavenModule, PublishModule {
     def testFramework = sys.error("no test framework")
 
   }
+
 }

--- a/libs/init/maven/test/resources/expected/spring-start/mill-build/src/Deps.scala
+++ b/libs/init/maven/test/resources/expected/spring-start/mill-build/src/Deps.scala
@@ -1,7 +1,8 @@
 package millbuild
-import mill.javalib.*
-object Deps {
 
+import mill.javalib.*
+
+object Deps {
   val HikariCP = mvn"com.zaxxer:HikariCP:6.3.3"
   val `ehcache#0` = mvn"org.ehcache:ehcache:3.10.9"
   val `ehcache#1` = mvn"org.ehcache:ehcache:3.10.9;classifier=jakarta"

--- a/libs/init/maven/test/resources/expected/with-args/maven-samples/build.mill
+++ b/libs/init/maven/test/resources/expected/with-args/maven-samples/build.mill
@@ -1,9 +1,11 @@
 //| mill-version: SNAPSHOT
 //| mill-jvm-version: system
 package build
+
 import mill.*
 import mill.javalib.*
 import mill.javalib.publish.*
+
 object `package` extends PublishModule {
 
   def pomPackagingType = "pom"
@@ -106,6 +108,7 @@ object `package` extends PublishModule {
         def testSandboxWorkingDir = false
 
       }
+
     }
 
     object webapp extends MavenModule, PublishModule {
@@ -155,6 +158,7 @@ object `package` extends PublishModule {
       )
 
     }
+
   }
 
   object `single-module` extends MavenModule, PublishModule {
@@ -205,5 +209,7 @@ object `package` extends PublishModule {
       def testSandboxWorkingDir = false
 
     }
+
   }
+
 }

--- a/libs/init/maven/test/resources/expected/with-args/quickstart/build.mill
+++ b/libs/init/maven/test/resources/expected/with-args/quickstart/build.mill
@@ -1,10 +1,12 @@
 //| mill-version: SNAPSHOT
 //| mill-jvm-version: system
 package build
+
 import mill.*
 import mill.javalib.*
 import mill.javalib.errorprone.ErrorProneModule
 import mill.javalib.publish.*
+
 object `package` extends MavenModule, ErrorProneModule, PublishModule {
 
   def bomMvnDeps = Seq(mvn"org.junit:junit-bom:5.11.0")
@@ -51,4 +53,5 @@ object `package` extends MavenModule, ErrorProneModule, PublishModule {
     def testSandboxWorkingDir = false
 
   }
+
 }

--- a/libs/init/sbt/test/resources/expected/cross-version/build.mill
+++ b/libs/init/sbt/test/resources/expected/cross-version/build.mill
@@ -2,11 +2,13 @@
 //| mill-jvm-version: system
 //| mill-jvm-opts: ["-Xms2g", "-Xmx2g"]
 package build
+
 import mill.*
 import mill.javalib.PublishModule
 import mill.javalib.publish.*
 import mill.scalalib.*
 import millbuild.*
+
 object `package`
     extends Cross[CrossVersionModule]("2.12.18", "2.13.12", "3.3.1")
 trait CrossVersionModule extends PublishModule, CrossSbtModule {
@@ -35,4 +37,5 @@ trait CrossVersionModule extends PublishModule, CrossSbtModule {
     def testSandboxWorkingDir = false
 
   }
+
 }

--- a/libs/init/sbt/test/resources/expected/cross-version/mill-build/src/Deps.scala
+++ b/libs/init/sbt/test/resources/expected/cross-version/mill-build/src/Deps.scala
@@ -1,6 +1,7 @@
 package millbuild
-import mill.javalib.*
-object Deps {
 
+import mill.javalib.*
+
+object Deps {
   val scalatest = mvn"org.scalatest::scalatest:3.2.18"
 }

--- a/libs/init/sbt/test/resources/expected/crossproject-cross-version/build.mill
+++ b/libs/init/sbt/test/resources/expected/crossproject-cross-version/build.mill
@@ -1,5 +1,7 @@
 //| mill-version: SNAPSHOT
 //| mill-jvm-version: system
 package build
+
 import mill.*
+
 object `package` extends Module {}

--- a/libs/init/sbt/test/resources/expected/crossproject-cross-version/dummy/package.mill
+++ b/libs/init/sbt/test/resources/expected/crossproject-cross-version/dummy/package.mill
@@ -1,4 +1,5 @@
 package build.dummy
+
 import mill.*
 import mill.javalib.PublishModule
 import mill.javalib.publish.*
@@ -8,6 +9,7 @@ import mill.scalalib.*
 import mill.scalanativelib.ScalaNativeModule
 import mill.scalanativelib.api.*
 import millbuild.*
+
 object `package` extends Module {
 
   object js extends Cross[JsModule]("2.12.20", "2.13.14", "3.7.1")
@@ -63,4 +65,5 @@ object `package` extends Module {
     )
 
   }
+
 }

--- a/libs/init/sbt/test/resources/expected/crossproject-cross-version/full/package.mill
+++ b/libs/init/sbt/test/resources/expected/crossproject-cross-version/full/package.mill
@@ -1,4 +1,5 @@
 package build.full
+
 import mill.*
 import mill.javalib.PublishModule
 import mill.javalib.publish.*
@@ -8,6 +9,7 @@ import mill.scalalib.*
 import mill.scalanativelib.ScalaNativeModule
 import mill.scalanativelib.api.*
 import millbuild.*
+
 object `package` extends Module {
 
   object js extends Cross[JsModule]("2.12.20", "2.13.14", "3.7.1")
@@ -65,4 +67,5 @@ object `package` extends Module {
     )
 
   }
+
 }

--- a/libs/init/sbt/test/resources/expected/crossproject-cross-version/jvm-util/package.mill
+++ b/libs/init/sbt/test/resources/expected/crossproject-cross-version/jvm-util/package.mill
@@ -1,9 +1,11 @@
 package build.`jvm-util`
+
 import mill.*
 import mill.javalib.PublishModule
 import mill.javalib.publish.*
 import mill.scalalib.*
 import millbuild.*
+
 object `package` extends Cross[JvmUtilModule]("2.12.20", "2.13.14", "3.7.1")
 trait JvmUtilModule extends PublishModule, CrossSbtModule {
 

--- a/libs/init/sbt/test/resources/expected/crossproject-cross-version/mill-build/src/Deps.scala
+++ b/libs/init/sbt/test/resources/expected/crossproject-cross-version/mill-build/src/Deps.scala
@@ -1,6 +1,7 @@
 package millbuild
-import mill.javalib.*
-object Deps {
 
+import mill.javalib.*
+
+object Deps {
   val upickle = mvn"com.lihaoyi::upickle::4.3.0"
 }

--- a/libs/init/sbt/test/resources/expected/crossproject-cross-version/mill-build/src/ProjectBaseModule.scala
+++ b/libs/init/sbt/test/resources/expected/crossproject-cross-version/mill-build/src/ProjectBaseModule.scala
@@ -1,4 +1,5 @@
 package millbuild
+
 import mill.*
 import mill.javalib.PublishModule
 import mill.javalib.publish.*
@@ -7,6 +8,7 @@ import mill.scalajslib.api.*
 import mill.scalalib.*
 import mill.scalanativelib.ScalaNativeModule
 import mill.scalanativelib.api.*
+
 trait ProjectBaseModule extends PublishModule, CrossSbtPlatformModule {
 
   def mvnDeps = Seq(Deps.upickle)
@@ -34,4 +36,5 @@ trait ProjectBaseModule extends PublishModule, CrossSbtPlatformModule {
     def testFramework = sys.error("no test framework")
 
   }
+
 }

--- a/libs/init/sbt/test/resources/expected/crossproject-cross-version/pure/package.mill
+++ b/libs/init/sbt/test/resources/expected/crossproject-cross-version/pure/package.mill
@@ -1,4 +1,5 @@
 package build.pure
+
 import mill.*
 import mill.javalib.PublishModule
 import mill.javalib.publish.*
@@ -8,6 +9,7 @@ import mill.scalalib.*
 import mill.scalanativelib.ScalaNativeModule
 import mill.scalanativelib.api.*
 import millbuild.*
+
 object `package` extends Module {
 
   object js extends Cross[JsModule]("2.12.20", "2.13.14", "3.7.1")
@@ -29,6 +31,7 @@ object `package` extends Module {
     )
 
     object test extends Tests, ScalaJSTests {}
+
   }
 
   object jvm extends Cross[JvmModule]("2.12.20", "2.13.14", "3.7.1")
@@ -46,6 +49,7 @@ object `package` extends Module {
     )
 
     object test extends Tests {}
+
   }
 
   object native extends Cross[NativeModule]("2.12.20", "2.13.14", "3.7.1")
@@ -65,5 +69,7 @@ object `package` extends Module {
     )
 
     object test extends Tests, ScalaNativeTests {}
+
   }
+
 }

--- a/libs/init/sbt/test/resources/expected/crossproject/build.mill
+++ b/libs/init/sbt/test/resources/expected/crossproject/build.mill
@@ -1,5 +1,7 @@
 //| mill-version: SNAPSHOT
 //| mill-jvm-version: system
 package build
+
 import mill.*
+
 object `package` extends Module {}

--- a/libs/init/sbt/test/resources/expected/crossproject/dummy/package.mill
+++ b/libs/init/sbt/test/resources/expected/crossproject/dummy/package.mill
@@ -1,4 +1,5 @@
 package build.dummy
+
 import mill.*
 import mill.javalib.PublishModule
 import mill.javalib.publish.*
@@ -8,6 +9,7 @@ import mill.scalalib.*
 import mill.scalanativelib.ScalaNativeModule
 import mill.scalanativelib.api.*
 import millbuild.*
+
 object `package` extends Module {
 
   object js extends ProjectBaseModule, ScalaJSModule {
@@ -60,4 +62,5 @@ object `package` extends Module {
     )
 
   }
+
 }

--- a/libs/init/sbt/test/resources/expected/crossproject/full/package.mill
+++ b/libs/init/sbt/test/resources/expected/crossproject/full/package.mill
@@ -1,4 +1,5 @@
 package build.full
+
 import mill.*
 import mill.javalib.PublishModule
 import mill.javalib.publish.*
@@ -8,6 +9,7 @@ import mill.scalalib.*
 import mill.scalanativelib.ScalaNativeModule
 import mill.scalanativelib.api.*
 import millbuild.*
+
 object `package` extends Module {
 
   object js extends ProjectBaseModule, ScalaJSModule {
@@ -32,6 +34,7 @@ object `package` extends Module {
     )
 
     object test extends Tests, ScalaJSTests, TestModule.Utest {}
+
   }
 
   object jvm extends ProjectBaseModule {
@@ -52,6 +55,7 @@ object `package` extends Module {
     )
 
     object test extends Tests, TestModule.Utest {}
+
   }
 
   object native extends ProjectBaseModule, ScalaNativeModule {
@@ -74,5 +78,7 @@ object `package` extends Module {
     )
 
     object test extends Tests, ScalaNativeTests, TestModule.Utest {}
+
   }
+
 }

--- a/libs/init/sbt/test/resources/expected/crossproject/mill-build/src/Deps.scala
+++ b/libs/init/sbt/test/resources/expected/crossproject/mill-build/src/Deps.scala
@@ -1,7 +1,8 @@
 package millbuild
-import mill.javalib.*
-object Deps {
 
+import mill.javalib.*
+
+object Deps {
   val osLib = mvn"com.lihaoyi::os-lib:0.11.5"
   val upickle = mvn"com.lihaoyi::upickle::4.3.0"
   val utest = mvn"com.lihaoyi::utest::0.9.1"

--- a/libs/init/sbt/test/resources/expected/crossproject/mill-build/src/ProjectBaseModule.scala
+++ b/libs/init/sbt/test/resources/expected/crossproject/mill-build/src/ProjectBaseModule.scala
@@ -1,4 +1,5 @@
 package millbuild
+
 import mill.*
 import mill.javalib.PublishModule
 import mill.javalib.publish.*
@@ -7,6 +8,7 @@ import mill.scalajslib.api.*
 import mill.scalalib.*
 import mill.scalanativelib.ScalaNativeModule
 import mill.scalanativelib.api.*
+
 trait ProjectBaseModule extends PublishModule, SbtPlatformModule {
 
   def mvnDeps = Seq(Deps.upickle)
@@ -24,4 +26,5 @@ trait ProjectBaseModule extends PublishModule, SbtPlatformModule {
     def testSandboxWorkingDir = false
 
   }
+
 }

--- a/libs/init/sbt/test/resources/expected/crossproject/pure/package.mill
+++ b/libs/init/sbt/test/resources/expected/crossproject/pure/package.mill
@@ -1,4 +1,5 @@
 package build.pure
+
 import mill.*
 import mill.javalib.PublishModule
 import mill.javalib.publish.*
@@ -8,6 +9,7 @@ import mill.scalalib.*
 import mill.scalanativelib.ScalaNativeModule
 import mill.scalanativelib.api.*
 import millbuild.*
+
 object `package` extends Module {
 
   object js extends ProjectBaseModule, ScalaJSModule {
@@ -62,4 +64,5 @@ object `package` extends Module {
     )
 
   }
+
 }

--- a/libs/init/sbt/test/resources/expected/sbt-multi-project-example/build.mill
+++ b/libs/init/sbt/test/resources/expected/sbt-multi-project-example/build.mill
@@ -1,5 +1,7 @@
 //| mill-version: SNAPSHOT
 //| mill-jvm-version: system
 package build
+
 import mill.*
+
 object `package` extends Module {}

--- a/libs/init/sbt/test/resources/expected/sbt-multi-project-example/common/package.mill
+++ b/libs/init/sbt/test/resources/expected/sbt-multi-project-example/common/package.mill
@@ -1,9 +1,11 @@
 package build.common
+
 import mill.*
 import mill.javalib.PublishModule
 import mill.javalib.publish.*
 import mill.scalalib.*
 import millbuild.*
+
 object `package` extends ProjectBaseModule {
 
   def mvnDeps = Seq(
@@ -41,4 +43,5 @@ object `package` extends ProjectBaseModule {
   )
 
   object test extends Tests {}
+
 }

--- a/libs/init/sbt/test/resources/expected/sbt-multi-project-example/mill-build/src/Deps.scala
+++ b/libs/init/sbt/test/resources/expected/sbt-multi-project-example/mill-build/src/Deps.scala
@@ -1,7 +1,8 @@
 package millbuild
-import mill.javalib.*
-object Deps {
 
+import mill.javalib.*
+
+object Deps {
   val akkaStream = mvn"com.typesafe.akka::akka-stream:2.5.6"
   val config = mvn"com.typesafe:config:1.3.1"
   val jclOverSlf4j = mvn"org.slf4j:jcl-over-slf4j:1.7.25"

--- a/libs/init/sbt/test/resources/expected/sbt-multi-project-example/mill-build/src/ProjectBaseModule.scala
+++ b/libs/init/sbt/test/resources/expected/sbt-multi-project-example/mill-build/src/ProjectBaseModule.scala
@@ -1,8 +1,10 @@
 package millbuild
+
 import mill.*
 import mill.javalib.PublishModule
 import mill.javalib.publish.*
 import mill.scalalib.*
+
 trait ProjectBaseModule extends PublishModule, SbtModule {
 
   def scalaVersion = "2.12.3"
@@ -35,4 +37,5 @@ trait ProjectBaseModule extends PublishModule, SbtModule {
     def testSandboxWorkingDir = false
 
   }
+
 }

--- a/libs/init/sbt/test/resources/expected/sbt-multi-project-example/multi1/package.mill
+++ b/libs/init/sbt/test/resources/expected/sbt-multi-project-example/multi1/package.mill
@@ -1,9 +1,11 @@
 package build.multi1
+
 import mill.*
 import mill.javalib.PublishModule
 import mill.javalib.publish.*
 import mill.scalalib.*
 import millbuild.*
+
 object `package` extends ProjectBaseModule {
 
   def moduleDeps = Seq(build.common)
@@ -45,4 +47,5 @@ object `package` extends ProjectBaseModule {
   )
 
   object test extends Tests {}
+
 }

--- a/libs/init/sbt/test/resources/expected/sbt-multi-project-example/multi2/package.mill
+++ b/libs/init/sbt/test/resources/expected/sbt-multi-project-example/multi2/package.mill
@@ -1,9 +1,11 @@
 package build.multi2
+
 import mill.*
 import mill.javalib.PublishModule
 import mill.javalib.publish.*
 import mill.scalalib.*
 import millbuild.*
+
 object `package` extends ProjectBaseModule {
 
   def moduleDeps = Seq(build.common)
@@ -42,4 +44,5 @@ object `package` extends ProjectBaseModule {
   )
 
   object test extends Tests {}
+
 }

--- a/libs/init/sbt/test/resources/expected/sbt-multi-project-example/nested/nested/package.mill
+++ b/libs/init/sbt/test/resources/expected/sbt-multi-project-example/nested/nested/package.mill
@@ -1,9 +1,11 @@
 package build.nested.nested
+
 import mill.*
 import mill.javalib.PublishModule
 import mill.javalib.publish.*
 import mill.scalalib.*
 import millbuild.*
+
 object `package` extends ProjectBaseModule {
 
   def mvnDeps = Seq(Deps.nettyTransportNativeEpoll)

--- a/libs/init/sbt/test/resources/expected/sbt-multi-project-example/nested/package.mill
+++ b/libs/init/sbt/test/resources/expected/sbt-multi-project-example/nested/package.mill
@@ -1,3 +1,5 @@
 package build.nested
+
 import mill.*
+
 object `package` extends Module {}

--- a/libs/init/sbt/test/resources/expected/scala-seed-project/build.mill
+++ b/libs/init/sbt/test/resources/expected/scala-seed-project/build.mill
@@ -1,11 +1,13 @@
 //| mill-version: SNAPSHOT
 //| mill-jvm-version: system
 package build
+
 import mill.*
 import mill.javalib.PublishModule
 import mill.javalib.publish.*
 import mill.scalalib.*
 import millbuild.*
+
 object `package` extends PublishModule, SbtModule {
 
   def scalaVersion = "2.13.12"
@@ -32,4 +34,5 @@ object `package` extends PublishModule, SbtModule {
     def testSandboxWorkingDir = false
 
   }
+
 }

--- a/libs/init/sbt/test/resources/expected/scala-seed-project/mill-build/src/Deps.scala
+++ b/libs/init/sbt/test/resources/expected/scala-seed-project/mill-build/src/Deps.scala
@@ -1,6 +1,7 @@
 package millbuild
-import mill.javalib.*
-object Deps {
 
+import mill.javalib.*
+
+object Deps {
   val munit = mvn"org.scalameta::munit:0.7.29"
 }

--- a/libs/init/sbt/test/resources/expected/with-args/crossproject-cross-version/build.mill
+++ b/libs/init/sbt/test/resources/expected/with-args/crossproject-cross-version/build.mill
@@ -1,6 +1,7 @@
 //| mill-version: SNAPSHOT
 //| mill-jvm-version: system
 package build
+
 import mill.*
 import mill.javalib.PublishModule
 import mill.javalib.publish.*
@@ -9,6 +10,7 @@ import mill.scalajslib.api.*
 import mill.scalalib.*
 import mill.scalanativelib.ScalaNativeModule
 import mill.scalanativelib.api.*
+
 object `package` extends Module {
 
   object dummy extends Module {
@@ -119,6 +121,7 @@ object `package` extends Module {
       def publishVersion = "0.1.0-SNAPSHOT"
 
     }
+
   }
 
   object full extends Module {
@@ -231,6 +234,7 @@ object `package` extends Module {
       def publishVersion = "0.1.0-SNAPSHOT"
 
     }
+
   }
 
   object `jvm-util` extends Cross[JvmUtilModule]("2.12.20", "2.13.14", "3.7.1")
@@ -312,6 +316,7 @@ object `package` extends Module {
         def testFramework = sys.error("no test framework")
 
       }
+
     }
 
     object jvm extends Cross[JvmModule]("2.12.20", "2.13.14", "3.7.1")
@@ -354,6 +359,7 @@ object `package` extends Module {
         def testFramework = sys.error("no test framework")
 
       }
+
     }
 
     object native extends Cross[NativeModule]("2.12.20", "2.13.14", "3.7.1")
@@ -399,6 +405,9 @@ object `package` extends Module {
         def testFramework = sys.error("no test framework")
 
       }
+
     }
+
   }
+
 }

--- a/libs/init/sbt/test/resources/expected/with-args/sbt-multi-project-example/build.mill
+++ b/libs/init/sbt/test/resources/expected/with-args/sbt-multi-project-example/build.mill
@@ -1,10 +1,12 @@
 //| mill-version: SNAPSHOT
 //| mill-jvm-version: system
 package build
+
 import mill.*
 import mill.javalib.PublishModule
 import mill.javalib.publish.*
 import mill.scalalib.*
+
 object `package` extends Module {
 
   object common extends PublishModule, SbtModule {
@@ -78,6 +80,7 @@ object `package` extends Module {
       def testSandboxWorkingDir = false
 
     }
+
   }
 
   object multi1 extends PublishModule, SbtModule {
@@ -156,6 +159,7 @@ object `package` extends Module {
       def testSandboxWorkingDir = false
 
     }
+
   }
 
   object multi2 extends PublishModule, SbtModule {
@@ -230,6 +234,7 @@ object `package` extends Module {
       def testSandboxWorkingDir = false
 
     }
+
   }
 
   object nested extends Module {
@@ -293,5 +298,7 @@ object `package` extends Module {
       )
 
     }
+
   }
+
 }


### PR DESCRIPTION
Generated code may purposefully contain the symbol used as margin `|` , resulting in ill-formatted and wrongly generated code.
