### PR TITLE
Native: minor fix on image options when no matching repository data

### DIFF
--- a/libs/javalib/src/mill/javalib/NativeImageModule.scala
+++ b/libs/javalib/src/mill/javalib/NativeImageModule.scala
@@ -105,7 +105,7 @@ trait NativeImageModule extends WithJvmWorkerModule, OfflineSupportModule {
    * Additional options for the `native-image` Tool.
    */
   def nativeImageOptions: T[Seq[String]] = Task {
-    nativeMvnDepsMetadata().toSeq.flatMap(md =>
+    nativeMvnDepsMetadata().filter(pr => os.exists(pr.path)).toSeq.flatMap(md =>
       Seq("--configurations-path", (md.path / "META-INF").toString)
     )
   }


### PR DESCRIPTION
Fixes no such file or directory exception if no dependencies or no matches for graalvm metadata