### PR TITLE
Update limitations of the SBOM plugin

### DIFF
--- a/contrib/sbom/readme.adoc
+++ b/contrib/sbom/readme.adoc
@@ -5,7 +5,6 @@ This plugin creates Software Bill of Materials (SBOM)
 
 This module has some limitations at the moment:
 
-- Minimal SBOM, various properties of libraries are missing. e.g. the license.
 - Only JVM ecosystem libraries are reported.
 - Only the CycloneDX JSON format is supported
 


### PR DESCRIPTION
I just tested this on 1.1.0-RC4 and the SBOM includes the licenses of JVM libraries, so this note appears to be out-of-date.

