### PR TITLE
Fix: macOS Intel (x64) native image publishing

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -34,7 +34,7 @@ jobs:
           publishartifacts: dist.native.publishArtifacts
           uploadgithub: false
 
-        - os: macos-14
+        - os: macos-15-intel
           publishartifacts: dist.native.publishArtifacts
           uploadgithub: false
 


### PR DESCRIPTION
## Problem

PR #6398 changed `macos-13` to `macos-14` to fix publishing issues, but this inadvertently broke Intel (x64) native image publishing.

**Root cause:** `macos-14` is an ARM64 (Apple Silicon) runner, not Intel. This caused both macOS jobs to build for `aarch64`, with no job building for `amd64` (Intel).

## Timeline of GitHub Actions macOS Runner Changes

1. **January 2024**: GitHub introduced `macos-14` as their first M1 (ARM64) runner
   - https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/

2. **September 2025**: GitHub announced `macos-13` deprecation
   - https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

3. **December 4, 2025**: `macos-13` was fully retired
