### PR TITLE
Rebootstrap for real

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1,4 +1,3 @@
-//| mill-version: 1.1.0-RC4
 //| mill-jvm-opts: ["-XX:NonProfiledCodeHeapSize=250m", "-XX:ReservedCodeCacheSize=500m"]
 //| mill-opts: ["--jobs=0.5C", "-DMILL_ENABLE_STATIC_CHECKS=true"]
 


### PR DESCRIPTION
Follow up to https://github.com/com-lihaoyi/mill/pull/6609, attempting to follow the newer convention of relying on the bootstrap scripts to define the mill version