### PR TITLE
Improve `does not override` error message to include superclass names 

### DIFF
--- a/core/eval/src/mill/eval/EvaluatorImpl.scala
+++ b/core/eval/src/mill/eval/EvaluatorImpl.scala
@@ -220,7 +220,14 @@ final class EvaluatorImpl(
 
       invalidBuildOverrides.map { case (k, v) =>
         java.nio.file.Files.readString(v.path.toNIO)
-        val doesNotOverridePrefix = s"key ${literalize(k)} does not override any task"
+        val extendsInfo = mill.internal.Util.parseHeaderData(v.path) match {
+          case mill.api.Result.Success(headerData) =>
+            val extendsValues = headerData.`extends`.value.value.map(_.value)
+            if (extendsValues.nonEmpty) s" on ${extendsValues.mkString(", ")}"
+            else ""
+          case _ => ""
+        }
+        val doesNotOverridePrefix = s"key ${literalize(k)} does not override any task$extendsInfo"
         val message = mill.resolve.ResolveNotFoundHandler.findMostSimilar(k, validKeys) match {
           case None =>
             if (millKeys.contains(k))

--- a/integration/failure/yaml-config-tasks/src/YamlConfigTasksTests.scala
+++ b/integration/failure/yaml-config-tasks/src/YamlConfigTasksTests.scala
@@ -17,7 +17,7 @@ object YamlConfigTasksTests extends UtestIntegrationTestSuite {
         "^"
       )
       assert(res.err.contains(
-        "key \"scalaVersionn\" does not override any task, did you mean \"scalaVersion\"?"
+        "key \"scalaVersionn\" does not override any task on ScalaModule, did you mean \"scalaVersion\"?"
       ))
       res.assertContainsLines(
         "[error] test/package.mill.yaml:2:1",


### PR DESCRIPTION
Apart from helping users, this should help us debug the flakiness we're seeing in CI such as https://github.com/lihaoyi/mill-1/actions/runs/21103955013/job/60692540005 by telling us what the integration test thinks the actual super-class is