### PR TITLE
Readd the `mill-version` to `build.mill`

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1,3 +1,4 @@
+//| mill-version: 1.1.0-RC4-18-0577b3
 //| mill-jvm-opts: ["-XX:NonProfiledCodeHeapSize=250m", "-XX:ReservedCodeCacheSize=500m"]
 //| mill-opts: ["--jobs=0.5C", "-DMILL_ENABLE_STATIC_CHECKS=true"]
 


### PR DESCRIPTION
1. Configuring the version should be the default for each build, especially Mill itself, to be a good example. Even patch-releases of Mill bring new features, so having a minimal expected Mill version for each project is necessary.

2. The fact that we have a repo-local bootstrap script should not dictate every user to use it. There is no indicator that the `DEFAULT_MILL_VERSION` is meant to be the best version, since it is only a fallback mechanism and deeply buried in the bootstrap script logic. The purpose of the `./mill` script is to provide convenience in CI and for occasional users that don't have an installed version on  their system.

3. Users who have the `DEFAULT_MILL_VERSION` variable pre-set in their environment (which is a good way to define a reasonable fallback), might end up using the wrong Mill version to build Mill, even if they are using the local `./mill` script. Note that these users aren't doing anything wrong. It's the original purpose of that variable.

4. Many users, including me, prefer to use programs they explicitly installed to their system over some random local scripts. Without a configured version (either via `mill-version` header or config file), they have no idea what the best Mill version is.

5. It is in general not adviced, to mix executable script code (which needs to be updated and checked regularly) with project-specific configuration data. Re-using the `DEFAULT_MILL_VERSION` fallback initialization sends the signal, that this script should be edited by users in case they want to change the version, which is not recommended.
   Once edited, the script is no longer identical to any official downloadable artifact and fingerprinting no longer works. Maintenance isn't  possible then, as the `./mill` script has no helpful header comment indicating it's own version.

Pull request: https://github.com/com-lihaoyi/mill/pull/6618