### PR TITLE
Fix selective testing invalidation of declarative config

### DIFF
--- a/core/eval/src/mill/eval/SelectiveExecutionImpl.scala
+++ b/core/eval/src/mill/eval/SelectiveExecutionImpl.scala
@@ -60,10 +60,9 @@ class SelectiveExecutionImpl(evaluator: Evaluator)
       oldHashes: SelectiveExecution.Metadata,
       newHashes: SelectiveExecution.Metadata
   ): DownstreamResult = {
-    val millVersionChanged =
-      oldHashes.millVersion.nonEmpty && oldHashes.millVersion != newHashes.millVersion
-    val jvmVersionChanged =
-      oldHashes.millJvmVersion.nonEmpty && oldHashes.millJvmVersion != newHashes.millJvmVersion
+    // Treat any version difference as a change, including when old metadata is missing version info
+    val millVersionChanged = oldHashes.millVersion != newHashes.millVersion
+    val jvmVersionChanged = oldHashes.millJvmVersion != newHashes.millJvmVersion
 
     // If either version changed, treat all tasks as changed
     if (millVersionChanged || jvmVersionChanged) {


### PR DESCRIPTION
Previously we were incorrectly hashing the `Task[?]` object which caused the hash to not change while the process was running, but always change when the process shuts down. Now we properly hash the `upickle.core.BufferedValue` associated with the task, which contains the actual value we care about

Also make it such that upgrading from an earlier version where `millVersion` and `millJvmVersion` were missing from the `out/mill-selective-execution.json` would properly invalidate everything, rather than nothing