### PR TITLE
Added mappings for SBT plugins in `./mill init`

### DIFF
--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
@@ -165,6 +165,7 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
       PathRef(Task.dest)
     }
 
+    override def platformSuffix = Task { outer.platformSuffix() }
     override def compileResources: T[Seq[PathRef]] = outer.compileResources
     override def generatedSources: T[Seq[PathRef]] = Task { outer.generatedSources() }
     override def allSources: T[Seq[PathRef]] = Task { outer.allSources() }

--- a/integration/manual/migrating/src/InitSbtAirstreamTests.scala
+++ b/integration/manual/migrating/src/InitSbtAirstreamTests.scala
@@ -1,0 +1,27 @@
+package mill.integration
+import utest.*
+object InitSbtAirstreamTests extends InitTestSuite(
+      "https://github.com/raquo/Airstream",
+      "v17.2.1",
+      Seq("--mill-jvm-id", "17")
+    ) {
+  def tests = Tests {
+    test("compile") - assert(
+      eval("__.compile").isSuccess
+    )
+    test("publishLocal") - assert(
+      eval(("_.publishLocal", "--local-ivy-repo", ".ivy2local")).isSuccess
+    )
+    test("mima") - assert(
+      eval("_.mimaReportBinaryIssues").isSuccess
+    )
+    test("issues") {
+      test("requires support for jsEnv") - assert(
+        !eval(("_.test.testOnly", "com.raquo.airstream.web.WebStorageVarSpec")).isSuccess
+      )
+      test("scalafmtConfig file does not specify the scalafmt version to use") - assert(
+        !eval("_.checkFormat").isSuccess
+      )
+    }
+  }
+}

--- a/integration/manual/migrating/src/InitSbtFs2Tests.scala
+++ b/integration/manual/migrating/src/InitSbtFs2Tests.scala
@@ -1,0 +1,37 @@
+package mill.integration
+import utest.*
+object InitSbtFs2Tests extends InitTestSuite(
+      "https://github.com/typelevel/fs2",
+      "v3.12.2",
+      Seq("--mill-jvm-id", "17")
+    ) {
+  def tests = Tests {
+    test("compile") - assert(
+      eval("(__:PublishModule).__.compile").isSuccess
+    )
+    test("test") - assert(
+      eval("core.js._.test").isSuccess,
+      eval("core.jvm._.test").isSuccess
+    )
+    test("publishLocal") - assert(
+      eval(("core.__.publishLocal", "--local-ivy-repo", ".ivy2local")).isSuccess
+    )
+    test("mima") - assert(
+      eval(("show", "core.__.mimaBinaryIssueFilters")).isSuccess
+    )
+    test("scalafmt") - assert(
+      eval("core.__.checkFormat").isSuccess
+    )
+    test("issues") {
+      test("ScalaNative version not supported") - assert(
+        !eval("core.native.2_13_16.test.scalaNativeWorkerClasspath").isSuccess
+      )
+      test("ScalaJS resources not found at runtime") - assert(
+        !eval(("io.js.2_13_16.test.testOnly", "fs2.io.net.tls.TLSSocketSuite")).isSuccess
+      )
+      test("Java 9+ API not available with scalacOptions --release 8") - assert(
+        !eval("benchmark.2_13_16.compile").isSuccess
+      )
+    }
+  }
+}

--- a/integration/manual/migrating/src/InitSbtGatlingTests.scala
+++ b/integration/manual/migrating/src/InitSbtGatlingTests.scala
@@ -1,0 +1,39 @@
+package mill.integration
+import utest.*
+object InitSbtGatlingTests extends InitTestSuite(
+      "https://github.com/gatling/gatling",
+      "v3.14.9",
+      Seq("--mill-jvm-id", "17")
+    ) {
+  def tests = Tests {
+    test("compile") - assert(
+      eval("__.compile").isSuccess
+    )
+    test("test") - assert(
+      eval("gatling-core.test").isSuccess
+    )
+    test("publishLocal") - assert(
+      eval(("gatling-core.publishLocal", "--local-ivy-repo", ".ivy2local")).isSuccess
+    )
+    test("jmh") - assert(
+      eval(("gatling-benchmarks.runJmh", "-l")).isSuccess
+    )
+    test("scalafix") - assert(
+      eval(("gatling-core.fix", "--rules", "NoAutoTupling")).isSuccess
+    )
+    test("issues") {
+      test("missing generated resources") - assert(
+        !eval((
+          "gatling-charts.test.testOnly",
+          "io.gatling.charts.result.reader.LogFileReaderSpec"
+        )).isSuccess
+      )
+      test("Scaladoc generation fails for module with Java only sources") - assert(
+        !eval("gatling-netty-util.scalaDocGenerated").isSuccess
+      )
+      test("ScalafmtModule requires config file") - assert(
+        !eval("gatling-core.checkFormat").isSuccess
+      )
+    }
+  }
+}

--- a/integration/manual/migrating/src/InitSbtScala3Tests.scala
+++ b/integration/manual/migrating/src/InitSbtScala3Tests.scala
@@ -1,0 +1,20 @@
+package mill.integration
+import utest.*
+object InitSbtScala3Tests extends InitTestSuite(
+      "https://github.com/scala/scala3",
+      "3.7.4",
+      Seq("--mill-jvm-id", "17")
+    ) {
+  def tests = Tests {
+    test("shared base directory") {
+      val pkgLines = os.read.lines(tester.workspacePath / "compiler/package.mill")
+      assert(pkgLines.count(_.trim == "def moduleDir = outer.moduleDir") == 4)
+    }
+    test("mimaBackwardIssueFilters") - assert(
+      eval(("show", "library.scala3-library-bootstrapped.mimaBackwardIssueFilters")).isSuccess
+    )
+    test("mimaForwardIssueFilters") - assert(
+      eval(("show", "tasty.tasty-core-bootstrapped.mimaForwardIssueFilters")).isSuccess
+    )
+  }
+}

--- a/integration/manual/migrating/src/InitSbtZioHttpTests.scala
+++ b/integration/manual/migrating/src/InitSbtZioHttpTests.scala
@@ -1,0 +1,45 @@
+package mill.integration
+import utest.*
+object InitSbtZioHttpTests extends InitTestSuite(
+      "https://github.com/zio/zio-http",
+      "v3.7.4",
+      Seq("--mill-jvm-id", "17")
+    ) {
+  def tests = Tests {
+    test("compile") - assert(
+      eval("(__:PublishModule).__.compile").isSuccess
+    )
+    // Commented because the tasks hang after completion
+//    test("test") - assert(
+//      eval("zio-http.jvm.2_12_20.test").isSuccess,
+//      eval("zio-http.jvm.2_13_16.test").isSuccess,
+//      eval("zio-http.jvm.3_3_5.test").isSuccess
+//    )
+    test("publishLocal") - assert(
+      eval(("zio-http.__.publishLocal", "--local-ivy-repo", ".ivy2local")).isSuccess
+    )
+    test("jmh") - assert(
+      eval(("zio-http-benchmarks._.runJmh", "-l")).isSuccess
+    )
+    test("mima") - assert(
+      eval(("show", "zio-http.jvm._.mimaBinaryIssueFilters")).isSuccess
+    )
+    test("scoverage") - assert(
+      eval("zio-http.jvm._.scoverage.consoleReport").isSuccess
+    )
+    test("scalafix") - assert(
+      eval(("zio-http.__.fix", "--rules", "NoAutoTupling")).isSuccess
+    )
+    test("scalafmt") - assert(
+      eval("zio-http.__.reformat").isSuccess
+    )
+    test("issues") {
+      test("fastLinkJSTest linking errors") - assert(
+        !eval("zio-http.js.2_12_20.test").isSuccess
+      )
+      test("requires mapping for sbt-protoc plugin") - assert(
+        !eval("sbt-zio-http-grpc-tests.2_12_20.test.compile").isSuccess
+      )
+    }
+  }
+}

--- a/integration/manual/migrating/src/InitTestSuite.scala
+++ b/integration/manual/migrating/src/InitTestSuite.scala
@@ -1,0 +1,26 @@
+package mill.integration
+import mill.testkit.{IntegrationTester, UtestIntegrationTestSuite}
+abstract class InitTestSuite(gitUrl: String, gitBranch: String, initArgs: Seq[String])
+    extends UtestIntegrationTestSuite {
+
+  lazy val tester = new IntegrationTester(
+    daemonMode,
+    workspaceSourcePath,
+    millExecutable,
+    debugLog,
+    cleanupProcessIdFile = cleanupProcessIdFile
+  ) {
+    override def initWorkspace() = {
+      os.makeDir(workspacePath)
+      os.proc("git", "clone", gitUrl, "--depth", "1", "--branch", gitBranch, workspacePath).call()
+      this.eval("init" +: initArgs, stdout = os.Inherit, stderr = os.Inherit)
+      this.eval(("--meta-level", 1, "__.compile"), stdout = os.Inherit, stderr = os.Inherit)
+      os.symlink(workspacePath / millExecutable.last, millExecutable)
+    }
+  }
+
+  override def utestAfterAll() = tester.close()
+
+  def eval(cmd: os.Shellable): IntegrationTester.EvalResult =
+    tester.eval(cmd, stdout = os.Inherit, stderr = os.Inherit)
+}

--- a/integration/migrating/init/resources/golden/sbt/fs2
+++ b/integration/migrating/init/resources/golden/sbt/fs2
@@ -1143,7 +1143,6 @@ Module dependencies of unidocs.3_3_5:
     "org.openjdk.jmh:jmh-generator-reflection:1.37"
   ],
   "core.js.2_12_20.mvnDeps": [
-    "org.scodec::scodec-core::1.11.10",
     "org.scodec::scodec-bits::1.1.38",
     "org.typelevel::cats-core::2.11.0",
     "org.typelevel::cats-effect::3.6.0"
@@ -1157,7 +1156,6 @@ Module dependencies of unidocs.3_3_5:
     "org.typelevel::scalacheck-effect-munit::2.0.0-M2"
   ],
   "core.js.2_13_16.mvnDeps": [
-    "org.scodec::scodec-core::1.11.10",
     "org.scodec::scodec-bits::1.1.38",
     "org.typelevel::cats-core::2.11.0",
     "org.typelevel::cats-effect::3.6.0"
@@ -1171,7 +1169,6 @@ Module dependencies of unidocs.3_3_5:
     "org.typelevel::scalacheck-effect-munit::2.0.0-M2"
   ],
   "core.js.3_3_5.mvnDeps": [
-    "org.scodec::scodec-core::2.2.1",
     "org.scodec::scodec-bits::1.1.38",
     "org.typelevel::cats-core::2.11.0",
     "org.typelevel::cats-effect::3.6.0"
@@ -1185,7 +1182,6 @@ Module dependencies of unidocs.3_3_5:
     "org.typelevel::scalacheck-effect-munit::2.0.0-M2"
   ],
   "core.jvm.2_12_20.mvnDeps": [
-    "org.scodec::scodec-core::1.11.10",
     "org.scodec::scodec-bits::1.1.38",
     "org.typelevel::cats-core::2.11.0",
     "org.typelevel::cats-effect::3.6.0"
@@ -1201,7 +1197,6 @@ Module dependencies of unidocs.3_3_5:
     "org.scalatestplus::testng-7-5:3.2.14.0"
   ],
   "core.jvm.2_13_16.mvnDeps": [
-    "org.scodec::scodec-core::1.11.10",
     "org.scodec::scodec-bits::1.1.38",
     "org.typelevel::cats-core::2.11.0",
     "org.typelevel::cats-effect::3.6.0"
@@ -1217,7 +1212,6 @@ Module dependencies of unidocs.3_3_5:
     "org.scalatestplus::testng-7-5:3.2.14.0"
   ],
   "core.jvm.3_3_5.mvnDeps": [
-    "org.scodec::scodec-core::2.2.1",
     "org.scodec::scodec-bits::1.1.38",
     "org.typelevel::cats-core::2.11.0",
     "org.typelevel::cats-effect::3.6.0"
@@ -1233,7 +1227,6 @@ Module dependencies of unidocs.3_3_5:
     "org.scalatestplus::testng-7-5:3.2.14.0"
   ],
   "core.native.2_12_20.mvnDeps": [
-    "org.scodec::scodec-core::1.11.10",
     "org.scodec::scodec-bits::1.1.38",
     "org.typelevel::cats-core::2.11.0",
     "org.typelevel::cats-effect::3.6.0"
@@ -1248,7 +1241,6 @@ Module dependencies of unidocs.3_3_5:
     "org.typelevel::scalacheck-effect-munit::2.0.0-M2"
   ],
   "core.native.2_13_16.mvnDeps": [
-    "org.scodec::scodec-core::1.11.10",
     "org.scodec::scodec-bits::1.1.38",
     "org.typelevel::cats-core::2.11.0",
     "org.typelevel::cats-effect::3.6.0"
@@ -1263,7 +1255,6 @@ Module dependencies of unidocs.3_3_5:
     "org.typelevel::scalacheck-effect-munit::2.0.0-M2"
   ],
   "core.native.3_3_5.mvnDeps": [
-    "org.scodec::scodec-core::2.2.1",
     "org.scodec::scodec-bits::1.1.38",
     "org.typelevel::cats-core::2.11.0",
     "org.typelevel::cats-effect::3.6.0"
@@ -1290,57 +1281,48 @@ Module dependencies of unidocs.3_3_5:
     "org.typelevel::munit-cats-effect::2.0.0"
   ],
   "io.js.2_12_20.mvnDeps": [
-    "org.scodec::scodec-core::1.11.10",
     "com.comcast::ip4s-core::3.6.0"
   ],
   "io.js.2_12_20.test.mvnDeps": [],
   "io.js.2_13_16.mvnDeps": [
-    "org.scodec::scodec-core::1.11.10",
     "com.comcast::ip4s-core::3.6.0"
   ],
   "io.js.2_13_16.test.mvnDeps": [],
   "io.js.3_3_5.mvnDeps": [
-    "org.scodec::scodec-core::2.2.1",
     "com.comcast::ip4s-core::3.6.0"
   ],
   "io.js.3_3_5.test.mvnDeps": [],
   "io.jvm.2_12_20.mvnDeps": [
-    "org.scodec::scodec-core::1.11.10",
     "com.comcast::ip4s-core::3.6.0"
   ],
   "io.jvm.2_12_20.test.mvnDeps": [
     "com.google.jimfs:jimfs:1.3.0"
   ],
   "io.jvm.2_13_16.mvnDeps": [
-    "org.scodec::scodec-core::1.11.10",
     "com.comcast::ip4s-core::3.6.0"
   ],
   "io.jvm.2_13_16.test.mvnDeps": [
     "com.google.jimfs:jimfs:1.3.0"
   ],
   "io.jvm.3_3_5.mvnDeps": [
-    "org.scodec::scodec-core::2.2.1",
     "com.comcast::ip4s-core::3.6.0"
   ],
   "io.jvm.3_3_5.test.mvnDeps": [
     "com.google.jimfs:jimfs:1.3.0"
   ],
   "io.native.2_12_20.mvnDeps": [
-    "org.scodec::scodec-core::1.11.10",
     "com.comcast::ip4s-core::3.6.0"
   ],
   "io.native.2_12_20.test.mvnDeps": [
     "org.scala-native::test-interface::0.4.17"
   ],
   "io.native.2_13_16.mvnDeps": [
-    "org.scodec::scodec-core::1.11.10",
     "com.comcast::ip4s-core::3.6.0"
   ],
   "io.native.2_13_16.test.mvnDeps": [
     "org.scala-native::test-interface::0.4.17"
   ],
   "io.native.3_3_5.mvnDeps": [
-    "org.scodec::scodec-core::2.2.1",
     "com.comcast::ip4s-core::3.6.0"
   ],
   "io.native.3_3_5.test.mvnDeps": [
@@ -1355,45 +1337,27 @@ Module dependencies of unidocs.3_3_5:
   "mdoc.3_3_5.mvnDeps": [
     "org.scalameta::mdoc:2.6.2"
   ],
-  "protocols.js.2_12_20.mvnDeps": [
-    "org.scodec::scodec-core::1.11.10"
-  ],
+  "protocols.js.2_12_20.mvnDeps": [],
   "protocols.js.2_12_20.test.mvnDeps": [],
-  "protocols.js.2_13_16.mvnDeps": [
-    "org.scodec::scodec-core::1.11.10"
-  ],
+  "protocols.js.2_13_16.mvnDeps": [],
   "protocols.js.2_13_16.test.mvnDeps": [],
-  "protocols.js.3_3_5.mvnDeps": [
-    "org.scodec::scodec-core::2.2.1"
-  ],
+  "protocols.js.3_3_5.mvnDeps": [],
   "protocols.js.3_3_5.test.mvnDeps": [],
-  "protocols.jvm.2_12_20.mvnDeps": [
-    "org.scodec::scodec-core::1.11.10"
-  ],
+  "protocols.jvm.2_12_20.mvnDeps": [],
   "protocols.jvm.2_12_20.test.mvnDeps": [],
-  "protocols.jvm.2_13_16.mvnDeps": [
-    "org.scodec::scodec-core::1.11.10"
-  ],
+  "protocols.jvm.2_13_16.mvnDeps": [],
   "protocols.jvm.2_13_16.test.mvnDeps": [],
-  "protocols.jvm.3_3_5.mvnDeps": [
-    "org.scodec::scodec-core::2.2.1"
-  ],
+  "protocols.jvm.3_3_5.mvnDeps": [],
   "protocols.jvm.3_3_5.test.mvnDeps": [],
-  "protocols.native.2_12_20.mvnDeps": [
-    "org.scodec::scodec-core::1.11.10"
-  ],
+  "protocols.native.2_12_20.mvnDeps": [],
   "protocols.native.2_12_20.test.mvnDeps": [
     "org.scala-native::test-interface::0.4.17"
   ],
-  "protocols.native.2_13_16.mvnDeps": [
-    "org.scodec::scodec-core::1.11.10"
-  ],
+  "protocols.native.2_13_16.mvnDeps": [],
   "protocols.native.2_13_16.test.mvnDeps": [
     "org.scala-native::test-interface::0.4.17"
   ],
-  "protocols.native.3_3_5.mvnDeps": [
-    "org.scodec::scodec-core::2.2.1"
-  ],
+  "protocols.native.3_3_5.mvnDeps": [],
   "protocols.native.3_3_5.test.mvnDeps": [
     "org.scala-native::test-interface::0.4.17"
   ],
@@ -6077,7 +6041,7 @@ Module dependencies of unidocs.3_3_5:
     "-Ywarn-dead-code",
     "-Ypartial-unification",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3",
     "-release",
@@ -6098,7 +6062,7 @@ Module dependencies of unidocs.3_3_5:
     "-Xlint:_,-implicit-recursion,-recurse-with-default,-unused,-byname-implicit",
     "-Wconf:cat=scala3-migration:s",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3",
     "-release",
@@ -6134,7 +6098,7 @@ Module dependencies of unidocs.3_3_5:
     "-Ywarn-dead-code",
     "-Ypartial-unification",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3"
   ],
@@ -6150,7 +6114,7 @@ Module dependencies of unidocs.3_3_5:
     "-Ywarn-dead-code",
     "-Ypartial-unification",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3"
   ],
@@ -6168,7 +6132,7 @@ Module dependencies of unidocs.3_3_5:
     "-Xlint:_,-implicit-recursion,-recurse-with-default,-unused,-byname-implicit",
     "-Wconf:cat=scala3-migration:s",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3"
   ],
@@ -6186,7 +6150,7 @@ Module dependencies of unidocs.3_3_5:
     "-Xlint:_,-implicit-recursion,-recurse-with-default,-unused,-byname-implicit",
     "-Wconf:cat=scala3-migration:s",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3"
   ],
@@ -6234,7 +6198,7 @@ Module dependencies of unidocs.3_3_5:
     "-Ywarn-dead-code",
     "-Ypartial-unification",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3"
   ],
@@ -6250,7 +6214,7 @@ Module dependencies of unidocs.3_3_5:
     "-Ywarn-dead-code",
     "-Ypartial-unification",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3"
   ],
@@ -6268,7 +6232,7 @@ Module dependencies of unidocs.3_3_5:
     "-Xlint:_,-implicit-recursion,-recurse-with-default,-unused,-byname-implicit",
     "-Wconf:cat=scala3-migration:s",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3"
   ],
@@ -6286,7 +6250,7 @@ Module dependencies of unidocs.3_3_5:
     "-Xlint:_,-implicit-recursion,-recurse-with-default,-unused,-byname-implicit",
     "-Wconf:cat=scala3-migration:s",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3"
   ],
@@ -6334,7 +6298,7 @@ Module dependencies of unidocs.3_3_5:
     "-Ywarn-dead-code",
     "-Ypartial-unification",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3"
   ],
@@ -6350,7 +6314,7 @@ Module dependencies of unidocs.3_3_5:
     "-Ywarn-dead-code",
     "-Ypartial-unification",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3"
   ],
@@ -6368,7 +6332,7 @@ Module dependencies of unidocs.3_3_5:
     "-Xlint:_,-implicit-recursion,-recurse-with-default,-unused,-byname-implicit",
     "-Wconf:cat=scala3-migration:s",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3"
   ],
@@ -6386,7 +6350,7 @@ Module dependencies of unidocs.3_3_5:
     "-Xlint:_,-implicit-recursion,-recurse-with-default,-unused,-byname-implicit",
     "-Wconf:cat=scala3-migration:s",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3"
   ],
@@ -6434,7 +6398,7 @@ Module dependencies of unidocs.3_3_5:
     "-Ywarn-dead-code",
     "-Ypartial-unification",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3",
     "-release",
@@ -6453,7 +6417,7 @@ Module dependencies of unidocs.3_3_5:
     "-Ywarn-dead-code",
     "-Ypartial-unification",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3",
     "-release",
@@ -6474,7 +6438,7 @@ Module dependencies of unidocs.3_3_5:
     "-Xlint:_,-implicit-recursion,-recurse-with-default,-unused,-byname-implicit",
     "-Wconf:cat=scala3-migration:s",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3",
     "-release",
@@ -6494,7 +6458,7 @@ Module dependencies of unidocs.3_3_5:
     "-Xlint:_,-implicit-recursion,-recurse-with-default,-unused,-byname-implicit",
     "-Wconf:cat=scala3-migration:s",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3",
     "-release",
@@ -6548,7 +6512,7 @@ Module dependencies of unidocs.3_3_5:
     "-Ywarn-dead-code",
     "-Ypartial-unification",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3"
   ],
@@ -6564,7 +6528,7 @@ Module dependencies of unidocs.3_3_5:
     "-Ywarn-dead-code",
     "-Ypartial-unification",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3"
   ],
@@ -6582,7 +6546,7 @@ Module dependencies of unidocs.3_3_5:
     "-Xlint:_,-implicit-recursion,-recurse-with-default,-unused,-byname-implicit",
     "-Wconf:cat=scala3-migration:s",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3"
   ],
@@ -6600,7 +6564,7 @@ Module dependencies of unidocs.3_3_5:
     "-Xlint:_,-implicit-recursion,-recurse-with-default,-unused,-byname-implicit",
     "-Wconf:cat=scala3-migration:s",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3"
   ],
@@ -6648,7 +6612,7 @@ Module dependencies of unidocs.3_3_5:
     "-Ywarn-dead-code",
     "-Ypartial-unification",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3"
   ],
@@ -6664,7 +6628,7 @@ Module dependencies of unidocs.3_3_5:
     "-Ywarn-dead-code",
     "-Ypartial-unification",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3"
   ],
@@ -6682,7 +6646,7 @@ Module dependencies of unidocs.3_3_5:
     "-Xlint:_,-implicit-recursion,-recurse-with-default,-unused,-byname-implicit",
     "-Wconf:cat=scala3-migration:s",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3"
   ],
@@ -6700,7 +6664,7 @@ Module dependencies of unidocs.3_3_5:
     "-Xlint:_,-implicit-recursion,-recurse-with-default,-unused,-byname-implicit",
     "-Wconf:cat=scala3-migration:s",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3"
   ],
@@ -6748,7 +6712,7 @@ Module dependencies of unidocs.3_3_5:
     "-Ywarn-dead-code",
     "-Ypartial-unification",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3"
   ],
@@ -6764,7 +6728,7 @@ Module dependencies of unidocs.3_3_5:
     "-Ywarn-dead-code",
     "-Ypartial-unification",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3"
   ],
@@ -6782,7 +6746,7 @@ Module dependencies of unidocs.3_3_5:
     "-Xlint:_,-implicit-recursion,-recurse-with-default,-unused,-byname-implicit",
     "-Wconf:cat=scala3-migration:s",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3"
   ],
@@ -6800,7 +6764,7 @@ Module dependencies of unidocs.3_3_5:
     "-Xlint:_,-implicit-recursion,-recurse-with-default,-unused,-byname-implicit",
     "-Wconf:cat=scala3-migration:s",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3"
   ],
@@ -6848,7 +6812,7 @@ Module dependencies of unidocs.3_3_5:
     "-Ywarn-dead-code",
     "-Ypartial-unification",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3"
   ],
@@ -6866,7 +6830,7 @@ Module dependencies of unidocs.3_3_5:
     "-Xlint:_,-implicit-recursion,-recurse-with-default,-unused,-byname-implicit",
     "-Wconf:cat=scala3-migration:s",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3"
   ],
@@ -6898,7 +6862,7 @@ Module dependencies of unidocs.3_3_5:
     "-Ywarn-dead-code",
     "-Ypartial-unification",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3",
     "-release",
@@ -6917,7 +6881,7 @@ Module dependencies of unidocs.3_3_5:
     "-Ywarn-dead-code",
     "-Ypartial-unification",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3",
     "-release",
@@ -6938,7 +6902,7 @@ Module dependencies of unidocs.3_3_5:
     "-Xlint:_,-implicit-recursion,-recurse-with-default,-unused,-byname-implicit",
     "-Wconf:cat=scala3-migration:s",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3",
     "-release",
@@ -6958,7 +6922,7 @@ Module dependencies of unidocs.3_3_5:
     "-Xlint:_,-implicit-recursion,-recurse-with-default,-unused,-byname-implicit",
     "-Wconf:cat=scala3-migration:s",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3",
     "-release",
@@ -7012,7 +6976,7 @@ Module dependencies of unidocs.3_3_5:
     "-Ywarn-dead-code",
     "-Ypartial-unification",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3",
     "-release",
@@ -7031,7 +6995,7 @@ Module dependencies of unidocs.3_3_5:
     "-Ywarn-dead-code",
     "-Ypartial-unification",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3",
     "-release",
@@ -7052,7 +7016,7 @@ Module dependencies of unidocs.3_3_5:
     "-Xlint:_,-implicit-recursion,-recurse-with-default,-unused,-byname-implicit",
     "-Wconf:cat=scala3-migration:s",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3",
     "-release",
@@ -7072,7 +7036,7 @@ Module dependencies of unidocs.3_3_5:
     "-Xlint:_,-implicit-recursion,-recurse-with-default,-unused,-byname-implicit",
     "-Wconf:cat=scala3-migration:s",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3",
     "-release",
@@ -7126,7 +7090,7 @@ Module dependencies of unidocs.3_3_5:
     "-Ywarn-dead-code",
     "-Ypartial-unification",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3",
     "-release",
@@ -7145,7 +7109,7 @@ Module dependencies of unidocs.3_3_5:
     "-Ywarn-dead-code",
     "-Ypartial-unification",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3",
     "-release",
@@ -7166,7 +7130,7 @@ Module dependencies of unidocs.3_3_5:
     "-Xlint:_,-implicit-recursion,-recurse-with-default,-unused,-byname-implicit",
     "-Wconf:cat=scala3-migration:s",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3",
     "-release",
@@ -7186,7 +7150,7 @@ Module dependencies of unidocs.3_3_5:
     "-Xlint:_,-implicit-recursion,-recurse-with-default,-unused,-byname-implicit",
     "-Wconf:cat=scala3-migration:s",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3",
     "-release",
@@ -7240,7 +7204,7 @@ Module dependencies of unidocs.3_3_5:
     "-Ywarn-dead-code",
     "-Ypartial-unification",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3",
     "-release",
@@ -7259,7 +7223,7 @@ Module dependencies of unidocs.3_3_5:
     "-Ywarn-dead-code",
     "-Ypartial-unification",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3",
     "-release",
@@ -7280,7 +7244,7 @@ Module dependencies of unidocs.3_3_5:
     "-Xlint:_,-implicit-recursion,-recurse-with-default,-unused,-byname-implicit",
     "-Wconf:cat=scala3-migration:s",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3",
     "-release",
@@ -7300,7 +7264,7 @@ Module dependencies of unidocs.3_3_5:
     "-Xlint:_,-implicit-recursion,-recurse-with-default,-unused,-byname-implicit",
     "-Wconf:cat=scala3-migration:s",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3",
     "-release",
@@ -7354,7 +7318,7 @@ Module dependencies of unidocs.3_3_5:
     "-Ywarn-dead-code",
     "-Ypartial-unification",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3",
     "-release",
@@ -7373,7 +7337,7 @@ Module dependencies of unidocs.3_3_5:
     "-Ywarn-dead-code",
     "-Ypartial-unification",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3",
     "-release",
@@ -7394,7 +7358,7 @@ Module dependencies of unidocs.3_3_5:
     "-Xlint:_,-implicit-recursion,-recurse-with-default,-unused,-byname-implicit",
     "-Wconf:cat=scala3-migration:s",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3",
     "-release",
@@ -7414,7 +7378,7 @@ Module dependencies of unidocs.3_3_5:
     "-Xlint:_,-implicit-recursion,-recurse-with-default,-unused,-byname-implicit",
     "-Wconf:cat=scala3-migration:s",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3",
     "-release",
@@ -7468,7 +7432,7 @@ Module dependencies of unidocs.3_3_5:
     "-Ywarn-dead-code",
     "-Ypartial-unification",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3",
     "-release",
@@ -7487,7 +7451,7 @@ Module dependencies of unidocs.3_3_5:
     "-Ywarn-dead-code",
     "-Ypartial-unification",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3",
     "-release",
@@ -7508,7 +7472,7 @@ Module dependencies of unidocs.3_3_5:
     "-Xlint:_,-implicit-recursion,-recurse-with-default,-unused,-byname-implicit",
     "-Wconf:cat=scala3-migration:s",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3",
     "-release",
@@ -7528,7 +7492,7 @@ Module dependencies of unidocs.3_3_5:
     "-Xlint:_,-implicit-recursion,-recurse-with-default,-unused,-byname-implicit",
     "-Wconf:cat=scala3-migration:s",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3",
     "-release",
@@ -7582,7 +7546,7 @@ Module dependencies of unidocs.3_3_5:
     "-Ywarn-dead-code",
     "-Ypartial-unification",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3",
     "-release",
@@ -7601,7 +7565,7 @@ Module dependencies of unidocs.3_3_5:
     "-Ywarn-dead-code",
     "-Ypartial-unification",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3",
     "-release",
@@ -7622,7 +7586,7 @@ Module dependencies of unidocs.3_3_5:
     "-Xlint:_,-implicit-recursion,-recurse-with-default,-unused,-byname-implicit",
     "-Wconf:cat=scala3-migration:s",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3",
     "-release",
@@ -7642,7 +7606,7 @@ Module dependencies of unidocs.3_3_5:
     "-Xlint:_,-implicit-recursion,-recurse-with-default,-unused,-byname-implicit",
     "-Wconf:cat=scala3-migration:s",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3",
     "-release",
@@ -7696,7 +7660,7 @@ Module dependencies of unidocs.3_3_5:
     "-Ywarn-dead-code",
     "-Ypartial-unification",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3"
   ],
@@ -7714,7 +7678,7 @@ Module dependencies of unidocs.3_3_5:
     "-Xlint:_,-implicit-recursion,-recurse-with-default,-unused,-byname-implicit",
     "-Wconf:cat=scala3-migration:s",
     "-Ybackend-parallelism",
-    "10",
+    "16",
     "-language:_",
     "-Xsource:3"
   ],

--- a/integration/package.mill
+++ b/integration/package.mill
@@ -223,6 +223,7 @@ object `package` extends mill.Module {
   object multimode extends Cross[IntegrationCrossModule](build.listCross)
   object bootstrap extends Cross[IntegrationCrossModule](build.listCross)
   object migrating extends Cross[MigrationIntegrationCrossModule](build.listCross)
+  object manual extends Cross[IntegrationCrossModule](build.listCross)
   trait MigrationIntegrationCrossModule extends IntegrationCrossModule {
     def forkEnv = super.forkEnv() ++ initRepos.all().map { case (name, path) =>
       s"MILL_INIT_REPO_$name" -> path

--- a/libs/init/buildgen/src/mill/main/buildgen/BuildGenScala.scala
+++ b/libs/init/buildgen/src/mill/main/buildgen/BuildGenScala.scala
@@ -3,7 +3,6 @@ package mill.main.buildgen
 import mill.constants.CodeGenConstants.rootModuleAlias
 import mill.constants.OutFiles.OutFiles.millBuild
 import mill.internal.Util.backtickWrap
-import mill.main.buildgen.BuildInfo.millVersion
 import mill.main.buildgen.BuildGenUtil.*
 import mill.main.buildgen.ModuleSpec.*
 import pprint.Util.literalize
@@ -26,7 +25,8 @@ object BuildGenScala extends BuildGen {
         bomMvnDeps,
         depManagement,
         errorProneDeps,
-        scalacPluginMvnDeps
+        scalacPluginMvnDeps,
+        scalafixIvyDeps
       )
     }.flatMap { values =>
       values.base ++ values.cross.flatMap(_._2)
@@ -50,14 +50,15 @@ object BuildGenScala extends BuildGen {
       pkg.copy(module = pkg.module.recMap { module =>
         import module.*
         module.copy(
-          imports = "import millbuild.*" +: imports,
+          imports = "millbuild.*" +: imports,
           mvnDeps = withRefs(mvnDeps),
           compileMvnDeps = withRefs(compileMvnDeps),
           runMvnDeps = withRefs(runMvnDeps),
           bomMvnDeps = withRefs(bomMvnDeps),
           depManagement = withRefs(depManagement),
           errorProneDeps = withRefs(errorProneDeps),
-          scalacPluginMvnDeps = withRefs(scalacPluginMvnDeps)
+          scalacPluginMvnDeps = withRefs(scalacPluginMvnDeps),
+          scalafixIvyDeps = withRefs(scalafixIvyDeps)
         )
       })
     )
@@ -71,7 +72,8 @@ object BuildGenScala extends BuildGen {
       baseModule: Option[ModuleSpec] = None,
       millJvmVersion: Option[String] = None,
       millJvmOpts: Seq[String] = Nil,
-      depNames: Seq[(MvnDep, String)] = Nil
+      depNames: Seq[(MvnDep, String)] = Nil,
+      metaMvnDeps: Seq[String] = Nil
   ): Seq[os.Path] = {
     var packages0 = fillPackages(packages).sortBy(_.dir)
     packages0 = if (merge) Seq(mergePackages(packages0.head, packages0.tail)) else packages0
@@ -97,18 +99,24 @@ object BuildGenScala extends BuildGen {
       file
     }
     val rootPackage +: nestedPackages = packages0: @unchecked
-    val millJvmVersion0 = resolveMillJvmVersion(millJvmVersion)
-    val millJvmOptsLine = if (millJvmOpts.isEmpty) ""
-    else millJvmOpts.mkString("//| mill-jvm-opts: [\"", "\", \"", s"\"]")
+    var buildHeader = Seq(
+      s"//| mill-version: $resolveMillVersion",
+      s"//| mill-jvm-version: ${resolveMillJvmVersion(millJvmVersion)}"
+    )
+    if (millJvmOpts.nonEmpty) {
+      buildHeader :+= "//| mill-jvm-opts:"
+      buildHeader ++= millJvmOpts.map("//|   - " + _)
+    }
+    if (metaMvnDeps.nonEmpty) {
+      buildHeader :+= "//| mvnDeps:"
+      buildHeader ++= metaMvnDeps.map("//|   - " + _)
+    }
     println("writing build.mill")
     os.write(
       baseDir / "build.mill",
-      Seq(
-        s"//| mill-version: $millVersion",
-        s"//| mill-jvm-version: $millJvmVersion0",
-        millJvmOptsLine,
-        renderPackage(rootPackage)
-      ).filter(_.nonEmpty).mkString(lineSep)
+      s"""${buildHeader.mkString(lineSep)}
+         |${renderPackage(rootPackage)}
+         |""".stripMargin
     )
     val subFiles = for (pkg <- nestedPackages) yield {
       val file = os.sub / pkg.dir / "package.mill"
@@ -134,7 +142,7 @@ object BuildGenScala extends BuildGen {
   private def renderBaseModule(module: ModuleSpec): String = {
     import module.*
     Seq(
-      s"trait $name ${renderExtendsClause(supertypes ++ mixins)} {",
+      s"trait $name ${renderExtendsClause(supertypes)} {",
       "  " + renderModuleBody(module),
       "  " + children.sortBy(_.name).map(renderBaseModule).mkString(lineSep * 2),
       "}"
@@ -143,48 +151,100 @@ object BuildGenScala extends BuildGen {
 
   private def renderModuleBody(module: ModuleSpec) = {
     import module.*
-    val renderModuleDir = if (useOuterModuleDir) "def moduleDir = outer.moduleDir" else ""
-    Seq(
-      renderModuleDir,
-      render("moduleDeps", moduleDeps, encodeModuleDep, isTask = false),
-      render("compileModuleDeps", compileModuleDeps, encodeModuleDep, isTask = false),
-      render("runModuleDeps", runModuleDeps, encodeModuleDep, isTask = false),
-      render("bomModuleDeps", bomModuleDeps, encodeModuleDep, isTask = false),
-      render("mandatoryMvnDeps", mandatoryMvnDeps, encodeMvnDep),
-      render("mvnDeps", mvnDeps, encodeMvnDep),
-      render("compileMvnDeps", compileMvnDeps, encodeMvnDep),
-      render("runMvnDeps", runMvnDeps, encodeMvnDep),
-      render("bomMvnDeps", bomMvnDeps, encodeMvnDep),
-      render("depManagement", depManagement, encodeMvnDep),
-      render("scalaJSVersion", scalaJSVersion, encodeString),
-      render("moduleKind", moduleKind, identity[String]),
-      render("scalaNativeVersion", scalaNativeVersion, encodeString),
-      render("scalaVersion", scalaVersion, encodeString),
-      render("scalacOptions", scalacOptions, encodeLiteralOpt),
-      render("scalacPluginMvnDeps", scalacPluginMvnDeps, encodeMvnDep),
-      render("javacOptions", javacOptions, encodeOpt),
-      render("sourcesRootFolders", sourcesRootFolders, encodeString, isTask = false),
-      render("sourcesFolders", sourcesFolders, encodeString, isTask = false),
-      renderSources("sources", sources),
-      renderSources("resources", resources),
-      render("forkArgs", forkArgs, encodeOpt),
-      render("forkWorkingDir", forkWorkingDir, encodeRelPath("moduleDir", _)),
-      render("errorProneDeps", errorProneDeps, encodeMvnDep),
-      render("errorProneOptions", errorProneOptions, encodeString),
-      render("errorProneJavacEnableOptions", errorProneJavacEnableOptions, encodeOpt),
-      render("artifactName", artifactName, encodeString),
-      render("pomPackagingType", pomPackagingType, encodeString),
-      render("pomParentProject", pomParentProject, a => s"Some(${encodeArtifact(a)})"),
-      render("pomSettings", pomSettings, encodePomSettings),
-      render("publishVersion", publishVersion, encodeString),
-      render("versionScheme", versionScheme, a => s"Some($a)"),
-      render("publishProperties", publishProperties, encodeProperty, collection = "Map"),
-      render("testParallelism", testParallelism, _.toString),
-      render("testSandboxWorkingDir", testSandboxWorkingDir, _.toString),
-      render("testFramework", testFramework, encodeTestFramework),
-      render("repositories", repositories, encodeString)
-    ).mkString(lineSep * 2)
+    val lines = Seq.newBuilder[String]
+    for (a <- alias) lines += s"$a =>"
+    lines += renderDefValue("moduleDir", moduleDir, identity[String])
+    lines += renderDefValues("moduleDeps", moduleDeps, encodeModuleDep, isTask = false)
+    lines += renderDefValues(
+      "compileModuleDeps",
+      compileModuleDeps,
+      encodeModuleDep,
+      isTask = false
+    )
+    lines += renderDefValues("runModuleDeps", runModuleDeps, encodeModuleDep, isTask = false)
+    lines += renderDefValues("bomModuleDeps", bomModuleDeps, encodeModuleDep, isTask = false)
+    lines += renderDefValues("mandatoryMvnDeps", mandatoryMvnDeps, encodeMvnDep)
+    lines += renderDefValues("mvnDeps", mvnDeps, encodeMvnDep)
+    lines += renderDefValues("compileMvnDeps", compileMvnDeps, encodeMvnDep)
+    lines += renderDefValues("runMvnDeps", runMvnDeps, encodeMvnDep)
+    lines += renderDefValues("bomMvnDeps", bomMvnDeps, encodeMvnDep)
+    lines += renderDefValues("depManagement", depManagement, encodeMvnDep)
+    lines += renderDefValue("scalaJSVersion", scalaJSVersion, encodeString)
+    lines += renderDefValue("moduleKind", moduleKind, identity[String])
+    lines += renderDefValue("scalaNativeVersion", scalaNativeVersion, encodeString)
+    lines += renderDefValue("scalaVersion", scalaVersion, encodeString)
+    lines += renderDefValues("scalacOptions", scalacOptions, encodeLiteralOpt)
+    lines += renderDefValues("scalacPluginMvnDeps", scalacPluginMvnDeps, encodeMvnDep)
+    lines += renderDefValues("javacOptions", javacOptions, encodeOpt)
+    lines += renderDefValues(
+      "sourcesRootFolders",
+      sourcesRootFolders,
+      encodeString,
+      isTask = false
+    )
+    if (isBomModule) {
+      lines += "def sources = Nil"
+      lines += "def resources = Nil"
+    } else {
+      lines += renderDefValues("sourcesFolders", sourcesFolders, encodeString, isTask = false)
+      lines += renderDefSources("sources", sources)
+      lines += renderDefSources("resources", resources)
+    }
+    lines += renderDefValues("forkArgs", forkArgs, encodeOpt)
+    lines += renderDefValue("forkWorkingDir", forkWorkingDir, identity[String])
+    lines += renderDefValues("errorProneDeps", errorProneDeps, encodeMvnDep)
+    lines += renderDefValues("errorProneOptions", errorProneOptions, encodeString)
+    lines += renderDefValues(
+      "errorProneJavacEnableOptions",
+      errorProneJavacEnableOptions,
+      encodeOpt
+    )
+    lines += renderDefValue("jmhCoreVersion", jmhCoreVersion, encodeString)
+    lines += renderDefValue("scalafixConfig", scalafixConfig, encodeSome)
+    lines += renderDefValues("scalafixIvyDeps", scalafixIvyDeps, encodeMvnDep)
+    lines += renderDefValue("scoverageVersion", scoverageVersion, encodeString)
+    lines += renderDefValue("branchCoverageMin", branchCoverageMin, encodeSome)
+    lines += renderDefValue("statementCoverageMin", statementCoverageMin, encodeSome)
+    lines += renderDefValues("mimaPreviousVersions", mimaPreviousVersions, encodeString)
+    lines += renderDefValues("mimaPreviousArtifacts", mimaPreviousArtifacts, encodeMvnDep)
+    lines += renderDefValue("mimaCheckDirection", mimaCheckDirection, identity[String])
+    lines += renderDefValues("mimaBinaryIssueFilters", mimaBinaryIssueFilters, identity[String])
+    lines += renderDefValues(
+      "mimaBackwardIssueFilters",
+      mimaBackwardIssueFilters,
+      encodeIssueFiltersTuple,
+      collection = "Map"
+    )
+    lines += renderDefValues(
+      "mimaForwardIssueFilters",
+      mimaForwardIssueFilters,
+      encodeIssueFiltersTuple,
+      collection = "Map"
+    )
+    lines += renderDefValues("mimaExcludeAnnotations", mimaExcludeAnnotations, encodeString)
+    lines += renderDefValue("mimaReportSignatureProblems", mimaReportSignatureProblems, _.toString)
+    lines += renderDefValue("artifactName", artifactName, encodeString)
+    lines += renderDefValue("pomPackagingType", pomPackagingType, encodeString)
+    lines += renderDefValue(
+      "pomParentProject",
+      pomParentProject,
+      a => s"Some(${encodeArtifact(a)})"
+    )
+    lines += renderDefValue("pomSettings", pomSettings, encodePomSettings)
+    lines += renderDefValue("publishVersion", publishVersion, encodeString)
+    lines += renderDefValue("versionScheme", versionScheme, encodeSome)
+    lines += renderDefValues(
+      "publishProperties",
+      publishProperties,
+      encodeProperty,
+      collection = "Map"
+    )
+    lines += renderDefValue("testParallelism", testParallelism, _.toString)
+    lines += renderDefValue("testSandboxWorkingDir", testSandboxWorkingDir, _.toString)
+    lines += renderDefValue("testFramework", testFramework, encodeTestFramework)
+    lines += renderDefValues("repositories", repositories, encodeString)
 
+    lines.result().filter(_.nonEmpty).mkString(lineSep * 2)
   }
 
   private def renderPackage(pkg: PackageSpec) = {
@@ -200,7 +260,7 @@ object BuildGenScala extends BuildGen {
   private def renderModule(module: ModuleSpec, isPackageRoot: Boolean = false): String = {
     import module.*
     val name0 = if (isPackageRoot) "`package`" else backtickWrap(name)
-    val extendsClause = renderExtendsClause(supertypes ++ mixins)
+    val extendsClause = renderExtendsClause(supertypes)
     val typeDeclaration = if (crossKeys.isEmpty) s"object $name0 $extendsClause"
     else {
       val crossTraitName = backtickWrap(name.split("\\W") match {
@@ -211,22 +271,21 @@ object BuildGenScala extends BuildGen {
         crossKeys.sorted.mkString(s"extends Cross[$crossTraitName](\"", "\", \"", "\")")
       s"object $name0 $crossExtendsClause\ntrait $crossTraitName $extendsClause"
     }
-    val aliasDeclaration = if (children.exists(_.useOuterModuleDir)) " outer => " else ""
 
     Seq(
-      s"""$typeDeclaration {$aliasDeclaration""",
+      s"""$typeDeclaration {""",
       renderModuleBody(module),
       children.sortBy(_.name).map(renderModule(_)).mkString(lineSep * 2),
       "}"
     ).mkString(lineSep * 2)
   }
 
-  private def render[A](member: String, value: Value[A], encode: A => String): String = {
+  private def renderDefValue[A](member: String, value: Value[A], encode: A => String) = {
     import value.*
     if (cross.isEmpty) base.fold("")(a => s"def $member = ${encode(a)}")
     else renderCrossMatch(s"def $member = ", cross, base, encode, "")
   }
-  private def render[A](
+  private def renderDefValues[A](
       member: String,
       values: Values[A],
       encode: A => String,
@@ -235,8 +294,7 @@ object BuildGenScala extends BuildGen {
   ): String = {
     def encodeAll(as: Seq[A]) = as.map(encode).mkString(s"$collection(", ", ", ")")
     import values.*
-    if (empty) s"def $member = $collection()"
-    else if (base.isEmpty && cross.isEmpty && appendRefs.isEmpty) ""
+    if (base.isEmpty && cross.isEmpty) ""
     else {
       val stmt = StringBuilder(s"def $member = ")
       var append = false
@@ -244,10 +302,6 @@ object BuildGenScala extends BuildGen {
       if (appendSuper) {
         append = true
         stmt ++= s"super.$member$invoke"
-      }
-      if (appendRefs.nonEmpty) {
-        if (append) stmt ++= " ++ " else append = true
-        stmt ++= appendRefs.map(encodeModuleDep(_) ++ s".$member$invoke").mkString(" ++ ")
       }
       if (base.nonEmpty) {
         if (append) stmt ++= " ++ " else append = true
@@ -263,16 +317,15 @@ object BuildGenScala extends BuildGen {
       }
     }
   }
-  private def renderSources(member: String, values: Values[os.RelPath]) = {
+  private def renderDefSources(member: String, values: Values[os.RelPath]) = {
     def encodeSources(rels: Seq[os.RelPath]) = rels.map(rel =>
       if (rel.ups == 0) encodeString(rel.toString) else encodeRelPath("os.rel", rel)
     ).mkString("Task.Sources(", ", ", ")")
     def encodeSeq(rels: Seq[os.RelPath]) =
       rels.map(encodeRelPath("os.rel", _)).mkString("Seq(", ", ", ")")
     import values.*
-    if (empty) s"def $member = Task.Sources()"
-    else if (base.isEmpty && cross.isEmpty && appendRefs.isEmpty) ""
-    else if (cross.isEmpty && !appendSuper && appendRefs.isEmpty) {
+    if (base.isEmpty && cross.isEmpty) ""
+    else if (cross.isEmpty && !appendSuper) {
       s"def $member = ${encodeSources(base)}"
     } else {
       val stmt = StringBuilder(s"def $member = ")
@@ -280,10 +333,6 @@ object BuildGenScala extends BuildGen {
       if (appendSuper) {
         append = true
         stmt ++= s"super.$member()"
-      }
-      if (appendRefs.nonEmpty) {
-        if (append) stmt ++= " ++ " else append = true
-        stmt ++= appendRefs.map(encodeModuleDep(_) ++ s".$member()").mkString(" ++ ")
       }
       if (base.nonEmpty) {
         val customTask = s"custom${member.capitalize}"
@@ -382,4 +431,7 @@ object BuildGenScala extends BuildGen {
   }
   private def encodeTestFramework(s: String) =
     if (s.isEmpty) "sys.error(\"no test framework\")" else encodeString(s)
+  private def encodeSome(a: Any) = s"Some($a)"
+  private def encodeIssueFiltersTuple(k: String, v: Seq[String]) =
+    s"""("$k", ${if (v.isEmpty) "Seq.empty[ProblemFilter]" else v.mkString("Seq(", ", ", ")")})"""
 }

--- a/libs/init/buildgen/src/mill/main/buildgen/BuildGenUtil.scala
+++ b/libs/init/buildgen/src/mill/main/buildgen/BuildGenUtil.scala
@@ -1,6 +1,7 @@
 package mill.main.buildgen
 
 import mill.init.Util
+import mill.main.buildgen.BuildInfo.millVersion
 
 /**
  * Shared utilities for build file generation (both Scala and YAML formats).
@@ -36,12 +37,16 @@ object BuildGenUtil {
 
   def renderImports(module: ModuleSpec): String = {
     val imports = module.tree.flatMap(_.imports)
-    ("import mill.*" +: imports).distinct.sorted.mkString(lineSep)
+    ("mill.*" +: imports).distinct.sorted.map("import " + _).mkString(lineSep)
   }
 
   def renderExtendsClause(supertypes: Seq[String]): String = {
     if (supertypes.isEmpty) "extends Module"
     else supertypes.mkString("extends ", ", ", "")
+  }
+
+  def resolveMillVersion: String = {
+    if (sys.env.contains("MILL_UNSTABLE_VERSION")) "SNAPSHOT" else millVersion
   }
 
   def resolveMillJvmVersion(millJvmVersion: Option[String]): String = {

--- a/libs/init/buildgen/src/mill/main/buildgen/BuildGenYaml.scala
+++ b/libs/init/buildgen/src/mill/main/buildgen/BuildGenYaml.scala
@@ -2,7 +2,6 @@ package mill.main.buildgen
 
 import mill.constants.CodeGenConstants.rootModuleAlias
 import mill.internal.Util.backtickWrap
-import mill.main.buildgen.BuildInfo.millVersion
 import mill.main.buildgen.BuildGenUtil.*
 import mill.main.buildgen.ModuleSpec.*
 import pprint.Util.literalize
@@ -23,7 +22,8 @@ object BuildGenYaml extends BuildGen {
       baseModule: Option[ModuleSpec] = None,
       millJvmVersion: Option[String] = None,
       millJvmOpts: Seq[String] = Nil,
-      depNames: Seq[(MvnDep, String)] = Nil
+      depNames: Seq[(MvnDep, String)] = Nil,
+      metaMvnDeps: Seq[String] = Nil
   ): Seq[os.Path] = {
     var packages0 = fillPackages(packages).sortBy(_.dir)
     packages0 = if (merge) Seq(mergePackages(packages0.head, packages0.tail)) else packages0
@@ -46,6 +46,7 @@ object BuildGenYaml extends BuildGen {
     }
 
     val rootPackage +: nestedPackages = packages0: @unchecked
+    val millVersion = resolveMillVersion
     val millJvmVersion0 = resolveMillJvmVersion(millJvmVersion)
 
     println("writing build.mill.yaml")
@@ -66,7 +67,7 @@ object BuildGenYaml extends BuildGen {
   private def renderBaseModule(module: ModuleSpec): String = {
     import module.*
     Seq(
-      s"trait $name ${renderExtendsClause(supertypes ++ mixins)} {",
+      s"trait $name ${renderExtendsClause(supertypes)} {",
       "  " + renderScalaModuleBody(module),
       "  " + children.sortBy(_.name).map(renderBaseModule).mkString(lineSep * 2),
       "}"
@@ -80,7 +81,7 @@ object BuildGenYaml extends BuildGen {
     renderScalaStringValues("def repositories", repositories).foreach(lines += _)
     renderScalaModuleDepValues("def bomModuleDeps", bomModuleDeps).foreach(lines += _)
     renderScalaOptValues("def forkArgs", forkArgs).foreach(lines += _)
-    forkWorkingDir.base.foreach(_ => lines += "def forkWorkingDir = moduleDir")
+    forkWorkingDir.base.foreach(dir => lines += s"def forkWorkingDir = $dir")
     renderScalaMvnDepValues("def mandatoryMvnDeps", mandatoryMvnDeps).foreach(lines += _)
     renderScalaMvnDepValues("def mvnDeps", mvnDeps).foreach(lines += _)
     renderScalaMvnDepValues("def compileMvnDeps", compileMvnDeps).foreach(lines += _)
@@ -214,9 +215,8 @@ object BuildGenYaml extends BuildGen {
     val lines = Seq.newBuilder[String]
 
     // extends - add Module as base if there are children but no explicit supertypes
-    val allSupertypes = supertypes ++ mixins
     val effectiveSupertypes =
-      if (allSupertypes.isEmpty && children.nonEmpty) Seq("Module") else allSupertypes
+      if (supertypes.isEmpty && children.nonEmpty) Seq("Module") else supertypes
     if (effectiveSupertypes.nonEmpty) {
       lines += renderYamlExtends(effectiveSupertypes)
     }

--- a/libs/init/gradle/exportplugin/src/mill/main/gradle/BuildModelBuilder.scala
+++ b/libs/init/gradle/exportplugin/src/mill/main/gradle/BuildModelBuilder.scala
@@ -54,7 +54,7 @@ class BuildModelBuilder(ctx: GradleBuildCtx, objectFactory: ObjectFactory, works
       val deps = configs.flatMap(_.getDependencies.asScala)
       val constraints = configs.flatMap(_.getDependencyConstraints.asScala)
       mainModule = mainModule.copy(
-        imports = "import mill.javalib.*" +: mainModule.imports,
+        imports = "mill.javalib.*" +: mainModule.imports,
         supertypes = "JavaModule" +: "BomModule" +: mainModule.supertypes,
         bomMvnDeps = deps.filter(isBom).collect(toMvnDep),
         depManagement = constraints.collect(toMvnDep),
@@ -78,7 +78,7 @@ class BuildModelBuilder(ctx: GradleBuildCtx, objectFactory: ObjectFactory, works
       }
       val buildDir = os.Path(getLayout.getBuildDirectory.get().getAsFile)
       mainModule = mainModule.copy(
-        imports = "import mill.javalib.*" +: mainModule.imports,
+        imports = "mill.javalib.*" +: mainModule.imports,
         supertypes = "MavenModule" +: mainModule.supertypes,
         mvnDeps = mvnDeps("implementation", "api"),
         compileMvnDeps = mvnDeps("compileOnly", "compileOnlyApi"),
@@ -99,14 +99,13 @@ class BuildModelBuilder(ctx: GradleBuildCtx, objectFactory: ObjectFactory, works
         val testConstraints = testConfigs.flatMap(_.getDependencyConstraints.asScala)
         var testModule = ModuleSpec(
           name = "test",
-          supertypes = Seq("MavenTests"),
-          mixins = testMixin.toSeq,
+          supertypes = "MavenTests" +: testMixin.toSeq,
           forkArgs = task[Test]("test").fold(Nil) { task =>
             task.getSystemProperties.asScala.map {
               case (k, v) => Opt(s"-D$k=$v")
             }.toSeq ++ Opt.groups(task.getJvmArgs.asScala.toSeq)
           },
-          forkWorkingDir = Some(os.rel),
+          forkWorkingDir = Some("moduleDir"),
           mvnDeps = mvnDeps("testImplementation"),
           compileMvnDeps = mvnDeps("testCompileOnly"),
           runMvnDeps = mvnDeps("testRuntimeOnly"),
@@ -158,7 +157,7 @@ class BuildModelBuilder(ctx: GradleBuildCtx, objectFactory: ObjectFactory, works
       pom = Option(pub.getPom)
     } do {
       mainModule = mainModule.copy(
-        imports = "import mill.javalib.*" +: "import mill.javalib.publish.*" +: mainModule.imports,
+        imports = "mill.javalib.*" +: "mill.javalib.publish.*" +: mainModule.imports,
         supertypes = mainModule.supertypes :+ "PublishModule",
         artifactName = Option(pub.getArtifactId),
         pomPackagingType = pom.flatMap(toPomPackagingType),

--- a/libs/init/gradle/test/resources/expected-scala/gradle-8-0/app/package.mill
+++ b/libs/init/gradle/test/resources/expected-scala/gradle-8-0/app/package.mill
@@ -10,6 +10,6 @@ object `package` extends ProjectBaseModule {
 
   def mvnDeps = Seq(mvn"org.apache.commons:commons-text")
 
-  object test extends ProjectBaseTests, TestModule.Junit5 {}
+  object test extends ProjectBaseTests {}
 
 }

--- a/libs/init/gradle/test/resources/expected-scala/gradle-8-0/list/package.mill
+++ b/libs/init/gradle/test/resources/expected-scala/gradle-8-0/list/package.mill
@@ -12,7 +12,7 @@ object `package` extends ProjectBaseModule, ErrorProneModule {
   def errorProneJavacEnableOptions =
     Seq("-XDshould-stop.ifError=FLOW", "-XDshouldStopPolicyIfError=FLOW")
 
-  object test extends ProjectBaseTests, ErrorProneModule, TestModule.Junit5 {
+  object test extends ProjectBaseTests, ErrorProneModule {
 
     def errorProneDeps = Seq(mvn"com.google.errorprone:error_prone_core:2.28.0")
 

--- a/libs/init/gradle/test/resources/expected-scala/gradle-8-0/mill-build/src/ProjectBaseModule.scala
+++ b/libs/init/gradle/test/resources/expected-scala/gradle-8-0/mill-build/src/ProjectBaseModule.scala
@@ -10,7 +10,7 @@ trait ProjectBaseModule extends MavenModule {
 
   def javacOptions = Seq("-source", "11", "-target", "11")
 
-  trait ProjectBaseTests extends MavenTests {
+  trait ProjectBaseTests extends MavenTests, TestModule.Junit5 {
 
     def mvnDeps = Seq(mvn"org.junit.jupiter:junit-jupiter:5.9.1")
 

--- a/libs/init/gradle/test/resources/expected-scala/gradle-9-0-0/build.mill
+++ b/libs/init/gradle/test/resources/expected-scala/gradle-9-0-0/build.mill
@@ -1,6 +1,8 @@
 //| mill-version: SNAPSHOT
 //| mill-jvm-version: system
-//| mill-jvm-opts: ["-Xmx2g", "-XX:MaxMetaspaceSize=512m"]
+//| mill-jvm-opts:
+//|   - -Xmx2g
+//|   - -XX:MaxMetaspaceSize=512m
 package build
 
 import mill.*

--- a/libs/init/gradle/test/resources/expected-scala/with-args/gradle-8-0/build.mill
+++ b/libs/init/gradle/test/resources/expected-scala/with-args/gradle-8-0/build.mill
@@ -49,7 +49,7 @@ object `package` extends Module {
     def errorProneJavacEnableOptions =
       Seq("-XDshould-stop.ifError=FLOW", "-XDshouldStopPolicyIfError=FLOW")
 
-    object test extends MavenTests, ErrorProneModule, TestModule.Junit5 {
+    object test extends MavenTests, TestModule.Junit5, ErrorProneModule {
 
       def mvnDeps = Seq(mvn"org.junit.jupiter:junit-jupiter:5.9.1")
 

--- a/libs/init/gradle/test/resources/expected/gradle-8-0/app/package.mill.yaml
+++ b/libs/init/gradle/test/resources/expected/gradle-8-0/app/package.mill.yaml
@@ -4,4 +4,4 @@ mvnDeps:
 - org.apache.commons:commons-text
 
 object test:
-  extends: [ProjectBaseTests, TestModule.Junit5]
+  extends: ProjectBaseTests

--- a/libs/init/gradle/test/resources/expected/gradle-8-0/list/package.mill.yaml
+++ b/libs/init/gradle/test/resources/expected/gradle-8-0/list/package.mill.yaml
@@ -4,7 +4,7 @@ errorProneDeps:
 errorProneJavacEnableOptions: [-XDshould-stop.ifError=FLOW, -XDshouldStopPolicyIfError=FLOW]
 
 object test:
-  extends: [ProjectBaseTests, mill.javalib.errorprone.ErrorProneModule, TestModule.Junit5]
+  extends: [ProjectBaseTests, mill.javalib.errorprone.ErrorProneModule]
   errorProneDeps:
   - com.google.errorprone:error_prone_core:2.28.0
   errorProneOptions: [-XepCompilingTestOnlyCode]

--- a/libs/init/gradle/test/resources/expected/gradle-8-0/mill-build/src/ProjectBaseModule.scala
+++ b/libs/init/gradle/test/resources/expected/gradle-8-0/mill-build/src/ProjectBaseModule.scala
@@ -9,7 +9,7 @@ trait ProjectBaseModule extends MavenModule {
   def depManagement = Seq(mvn"org.apache.commons:commons-text:1.9")
   def javacOptions = Seq("-source", "11", "-target", "11")
 
-  trait ProjectBaseTests extends MavenTests {
+  trait ProjectBaseTests extends MavenTests, TestModule.Junit5 {
 
     def forkWorkingDir = moduleDir
     def mvnDeps = Seq(mvn"org.junit.jupiter:junit-jupiter:5.9.1")

--- a/libs/init/gradle/test/resources/expected/with-args/gradle-8-0/build.mill.yaml
+++ b/libs/init/gradle/test/resources/expected/with-args/gradle-8-0/build.mill.yaml
@@ -33,7 +33,7 @@ object list:
   errorProneJavacEnableOptions: [-XDshould-stop.ifError=FLOW, -XDshouldStopPolicyIfError=FLOW]
   
   object test:
-    extends: [MavenTests, mill.javalib.errorprone.ErrorProneModule, TestModule.Junit5]
+    extends: [MavenTests, TestModule.Junit5, mill.javalib.errorprone.ErrorProneModule]
     mvnDeps:
     - org.junit.jupiter:junit-jupiter:5.9.1
     runMvnDeps:

--- a/libs/init/maven/src/mill/main/maven/Modeler.scala
+++ b/libs/init/maven/src/mill/main/maven/Modeler.scala
@@ -82,7 +82,7 @@ object Modeler {
     val props = new Properties()
     System.getenv().forEach((k, v) => props.put(s"env.$k", v))
     System.getProperties.forEach((k, v) => props.put(k, v))
-    props.put("maven.multiModuleProjectDirectory", os.pwd.toString)
+    props.put("maven.multiModuleProjectDirectory", mvnWorkspace.toString)
     props
   }
 }

--- a/libs/init/maven/test/resources/expected-scala/maven-samples/multi-module/package.mill
+++ b/libs/init/maven/test/resources/expected-scala/maven-samples/multi-module/package.mill
@@ -15,6 +15,10 @@ object `package` extends JavaModule, BomModule, PublishModule {
     mvn"org.mockito:mockito-core:1.8.5"
   )
 
+  def sources = Nil
+
+  def resources = Nil
+
   def pomPackagingType = "pom"
 
   def pomSettings = PomSettings(

--- a/libs/init/maven/test/resources/expected-scala/with-args/maven-samples/build.mill
+++ b/libs/init/maven/test/resources/expected-scala/with-args/maven-samples/build.mill
@@ -32,6 +32,10 @@ object `package` extends PublishModule {
       mvn"org.mockito:mockito-core:1.8.5"
     )
 
+    def sources = Nil
+
+    def resources = Nil
+
     def pomPackagingType = "pom"
 
     def pomSettings = PomSettings(

--- a/libs/init/package.mill
+++ b/libs/init/package.mill
@@ -1,12 +1,10 @@
 package build.libs.init
 
 import mill.*
-import mill.api.{BuildCtx, Cross, TaskCtx}
+import mill.api.{BuildCtx, Cross}
 import mill.contrib.buildinfo.BuildInfo
 import mill.scalalib.Assembly.Rule
 import mill.scalalib.ScalaModule
-import mill.scalalib.scalafmt.ScalafmtModule
-import mill.util.Jvm
 import millbuild.*
 
 object `package` extends MillPublishScalaModule {
@@ -96,59 +94,10 @@ object `package` extends MillPublishScalaModule {
       def mvnDeps = Seq(Deps.mainargs)
       def testModuleDeps = super.testModuleDeps ++ Seq(buildgen.test)
       def prependShellScript = ""
-      def testForkEnv = super.testForkEnv() ++ Map("TEST_MAIN_ASSEMBLY" -> assembly().path.toString)
-      def scalafmtConfigFile = Task {
-        val file = Task.dest / ".scalafmt.conf"
-        os.write(
-          file,
-          s"""version = "${Deps.scalafmtDynamic.version}"
-             |runner.dialect = scala3
-             |newlines.source=fold
-             |project.includePaths = [
-             |  "glob:**/build.mill"
-             |  "glob:**/package.mill"
-             |  "glob:**/mill-build/**.scala"
-             |]
-             |""".stripMargin
-        )
-        PathRef(file)
-      }
-      def millExecutable: T[PathRef] = build.dist.raw.executableRaw()
-      def mocks: Map[String, Mock]
-      def runMock(mock: Mock) = Task.Command(persistent = true) {
-        import mock.*
-        val cacheDir = Task.dest
-        val repoName = gitUrl.split("/").last.stripSuffix(".git")
-        val repoDir = cacheDir / repoName
-        if (os.exists(repoDir)) {
-          os.proc("git", "clean", "-fdx").call(repoDir)
-        } else {
-          os.proc("git", "clone", gitUrl, repoDir).call(cacheDir)
-        }
-        os.proc("git", "checkout", gitRev).call(repoDir, stdout = os.Inherit)
-        Jvm.callProcess(
-          mainClass = finalMainClass(),
-          mainArgs = initArgs,
-          classPath = runClasspath().map(_.path),
-          cwd = repoDir,
-          stdout = os.Inherit
-        )
-        Jvm.callProcess(
-          mainClass = "org.scalafmt.cli.Cli",
-          mainArgs = Seq("-c", scalafmtConfigFile().path.toString, repoDir.toString),
-          classPath = ScalafmtModule.scalafmtClasspath().map(_.path),
-          cwd = repoDir,
-          stdout = os.Inherit
-        )
-        val millExe = millExecutable().path
-        for (task <- checkTasks) do
-          os.proc(millExe, "--no-daemon", task).call(repoDir, stdout = os.Inherit, check = false)
-      }
-      def runMocks(ids: String*) = {
-        val task = Task.traverse(if (ids.isEmpty) mocks.values.toSeq else ids.map(mocks))(runMock)
-        Task.Command { task() }
-      }
-      def defaultTask() = "runMocks"
+      def testForkEnv = super.testForkEnv() ++ Map(
+        "MILL_UNSTABLE_VERSION" -> "1",
+        "TEST_MAIN_ASSEMBLY" -> assembly().path.toString
+      )
     }
   }
 
@@ -164,48 +113,9 @@ object `package` extends MillPublishScalaModule {
       os.copy(exportplugin.assembly().path, Task.dest / "exportplugin-assembly.jar")
       PathRef(Task.dest)
     }
-    def resources = Task { super.resources() ++ Seq(exportpluginAssemblyResource()) }
-    def mocks = Map(
-      "ehcache3" -> Mock(
-        "https://github.com/ehcache/ehcache3.git",
-        "v3.10.8",
-        Seq("--gradle-jvm-id", "11", "--mill-jvm-id", "17"),
-        "__.compile"
-      ),
-      "fastcsv" -> Mock(
-        "https://github.com/osiegmar/FastCSV.git",
-        "v4.1.0",
-        Seq("--gradle-jvm-id", "25", "--mill-jvm-id", "25")
-      ),
-      "jcommander" -> Mock(
-        "https://github.com/cbeust/jcommander.git",
-        "3.0",
-        Seq("--gradle-jvm-id", "21", "--mill-jvm-id", "21"),
-        "__.compile"
-      ),
-      "microconfig" -> Mock(
-        "https://github.com/microconfig/microconfig.git",
-        "v4.9.5",
-        Seq("--gradle-jvm-id", "17", "--mill-jvm-id", "17"),
-        "__.test"
-      ),
-      "mockito" -> Mock(
-        "https://github.com/mockito/mockito.git",
-        "v5.20.0",
-        Seq("--gradle-jvm-id", "17", "--mill-jvm-id", "21")
-      ),
-      "spotbugs" -> Mock(
-        "https://github.com/spotbugs/spotbugs.git",
-        "4.9.8",
-        Seq("--gradle-jvm-id", "17", "--mill-jvm-id", "25"),
-        "__.compile"
-      ),
-      "spring-framework" -> Mock(
-        "https://github.com/spring-projects/spring-framework.git",
-        "v6.2.12",
-        Seq("--gradle-jvm-id", "24", "--mill-jvm-id", "24")
-      )
-    )
+    def resources = Task {
+      super.resources() ++ Seq(exportpluginAssemblyResource())
+    }
 
     object api extends MillPublishJavaModule {
       def jvmId = "11"
@@ -229,73 +139,6 @@ object `package` extends MillPublishScalaModule {
       Deps.MavenInit.mavenResolverTransportWagon
     )
     def testModuleDeps = super.testModuleDeps ++ Seq(buildgen.test)
-    def mocks = Map(
-      "aws-sdk-java-v2" -> Mock(
-        "https://github.com/aws/aws-sdk-java-v2.git",
-        "2.40.4",
-        Seq("--mill-jvm-id", "21")
-      ),
-      "byte-buddy" -> Mock(
-        "https://github.com/raphw/byte-buddy.git",
-        "byte-buddy-1.17.8",
-        Seq("--mill-jvm-id", "25"),
-        "__.compile"
-      ),
-      "checkstyle" -> Mock(
-        "https://github.com/checkstyle/checkstyle.git",
-        "checkstyle-12.1.1",
-        Seq("--mill-jvm-id", "21"),
-        "__.compile"
-      ),
-      "error-prone" -> Mock(
-        "https://github.com/google/error-prone.git",
-        "v2.43.0",
-        Seq("--mill-jvm-id", "21"),
-        "__.compile"
-      ),
-      "fastjson2" -> Mock(
-        "https://github.com/alibaba/fastjson2.git",
-        "2.0.60",
-        Seq("--mill-jvm-id", "21"),
-        "__.compile"
-      ),
-      "hikaricp" -> Mock(
-        "https://github.com/brettwooldridge/HikariCP.git",
-        "HikariCP-7.0.2",
-        Seq("--mill-jvm-id", "17"),
-        "__.compile"
-      ),
-      "jansi" -> Mock(
-        "https://github.com/fusesource/jansi.git",
-        "jansi-2.4.2",
-        Seq("--mill-jvm-id", "17"),
-        "__.test"
-      ),
-      "java-design-patterns" -> Mock(
-        "https://github.com/iluwatar/java-design-patterns",
-        "ede37bd05568b1b8b814d8e9a1d2bbd71d9d615d",
-        Seq("--mill-jvm-id", "21"),
-        "__.compile"
-      ),
-      "netty" -> Mock(
-        "https://github.com/netty/netty.git",
-        "netty-4.2.7.Final",
-        Seq("--mill-jvm-id", "17"),
-        "__.compile"
-      ),
-      "spring-ai" -> Mock(
-        "https://github.com/spring-projects/spring-ai.git",
-        "v1.0.3",
-        Seq("--mill-jvm-id", "17"),
-        "__.compile"
-      ),
-      "thealgorithms" -> Mock(
-        "https://github.com/TheAlgorithms/Java.git",
-        "2707da25e35f6973ceacdf4aa7dde9ecf7d4d34c",
-        Seq("--mill-jvm-id", "21"),
-        "__.test"
-      )
-    )
   }
 
   object sbt extends buildgen.MainModule with BuildInfo {
@@ -304,105 +147,29 @@ object `package` extends MillPublishScalaModule {
       os.copy(exportplugin.assembly().path, Task.dest / "exportplugin-assembly.jar")
       PathRef(Task.dest)
     }
-    def resources = Task { super.resources() ++ Seq(sbtPluginJarResource()) }
+    def resources = Task {
+      super.resources() ++ Seq(sbtPluginJarResource())
+    }
     def testModuleDeps = super.testModuleDeps ++ Seq(buildgen.test)
     def buildInfoPackageName = "mill.main.sbt"
     def buildInfoMembers = Seq(
       BuildInfo.Value("exportpluginAssemblyResource", "/exportplugin-assembly.jar"),
-      BuildInfo.Value("sbtVersion", Deps.sbt.version)
-    )
-    def mocks = Map(
-      "airstream" -> Mock(
-        "https://github.com/raquo/Airstream.git",
-        "v17.2.1",
-        Seq("--mill-jvm-id", "17"),
-        "__.test"
-      ),
-      "cats" -> Mock(
-        "https://github.com/typelevel/cats.git",
-        "v2.13.0",
-        Seq("--mill-jvm-id", "17")
-      ),
-      "enumeratum" -> Mock(
-        "https://github.com/lloydmeta/enumeratum.git",
-        "enumeratum-1.9.0",
-        Seq("--mill-jvm-id", "17", "-Denumeratum.useLocalVersion=true"),
-        "__[3.3.5].compile"
-      ),
-      "fs2" -> Mock(
-        "https://github.com/typelevel/fs2.git",
-        "v3.12.2",
-        Seq("--mill-jvm-id", "17"),
-        "__.compile"
-      ),
-      "gatling" -> Mock(
-        "https://github.com/gatling/gatling.git",
-        "v3.14.7",
-        Seq("--mill-jvm-id", "24"),
-        "__.test"
-      ),
-      "lila" -> Mock(
-        "https://github.com/lichess-org/lila.git",
-        "master",
-        Seq("--mill-jvm-id", "21")
-      ),
-      "nscala-time" -> Mock(
-        "https://github.com/nscala-time/nscala-time.git",
-        "releases/3.0.0",
-        Seq("--mill-jvm-id", "21"),
-        "__.test"
-      ),
-      "refined" -> Mock(
-        "https://github.com/fthomas/refined.git",
-        "v0.11.3",
-        Seq("--mill-jvm-id", "17")
-      ),
-      "scala3" -> Mock(
-        "https://github.com/scala/scala3.git",
-        "3.7.3",
-        Seq("--mill-jvm-id", "17")
-      ),
-      "scala-logging" -> Mock(
-        "https://github.com/lightbend-labs/scala-logging.git",
-        "v3.9.6",
-        Seq("--mill-jvm-id", "17"),
-        "__.test"
-      ),
-      "scopt" -> Mock(
-        "https://github.com/scopt/scopt.git",
-        "v4.1.0",
-        Seq("--mill-jvm-id", "17"),
-        "__.test"
-      ),
-      "scrypto" -> Mock(
-        "https://github.com/input-output-hk/scrypto.git",
-        "v3.1.0",
-        Seq("--mill-jvm-id", "17"),
-        "__.test"
-      )
+      BuildInfo.Value("sbtVersion", Deps.sbt.version),
+      BuildInfo.Value("millScalafixDep", "com.goyeau::mill-scalafix_mill1:0.6.0"),
+      BuildInfo.Value("millMimaDep", "com.github.lolgab::mill-mima_mill1:0.2.0")
     )
 
     object api extends Cross[ApiModule](Deps.sbtScalaVersion212, Deps.scalaVersion)
     trait ApiModule extends MillPublishCrossScalaModule {
       def moduleDeps = Seq(buildgen.api())
     }
+
     object exportplugin extends ScalaModule {
       def jvmId = "11"
       def scalaVersion = Deps.sbtScalaVersion212
       def moduleDeps = Seq(api(Deps.sbtScalaVersion212))
-      def compileMvnDeps = Seq(Deps.sbt)
+      def compileMvnDeps = Seq(Deps.sbt, Deps.mimaCore)
       def assemblyRules = Seq(Rule.ExcludePattern("scala\\.*"))
     }
   }
-}
-
-@mainargs.main
-private case class Mock(
-    @mainargs.arg(positional = true) gitUrl: String,
-    @mainargs.arg(positional = true) gitRev: String,
-    @mainargs.arg(short = 'i') initArgs: Seq[String],
-    checkTasks: String*
-) derives upickle.default.ReadWriter
-private object Mock {
-  given mainargs.TokensReader[Mock] = mainargs.Parser[Mock]
 }

--- a/libs/init/sbt/api/src/mill/main/sbt/SbtModuleSpec.scala
+++ b/libs/init/sbt/api/src/mill/main/sbt/SbtModuleSpec.scala
@@ -1,9 +1,9 @@
 package mill.main.sbt
 
-import mill.main.buildgen.ModuleSpec
+import mill.main.buildgen._
 import upickle.default.{ReadWriter, macroRW, readwriter}
 
-case class SbtModuleSpec(sharedBaseDir: Either[os.SubPath, os.SubPath], module: ModuleSpec)
+case class SbtModuleSpec(root: Either[os.SubPath, PackageSpec], module: ModuleSpec)
 object SbtModuleSpec {
   implicit val rwSubPath: ReadWriter[os.SubPath] =
     readwriter[String].bimap(_.toString, os.SubPath(_))

--- a/libs/init/sbt/exportplugin/src/mill/main/sbt/ExportBuildPlugin.scala
+++ b/libs/init/sbt/exportplugin/src/mill/main/sbt/ExportBuildPlugin.scala
@@ -1,7 +1,9 @@
 package mill.main.sbt
 
 import _root_.sbt.{Value => _, _}
-import mill.main.buildgen.ModuleSpec
+import _root_.sbt.dsl.LinterLevel.Ignore
+import com.typesafe.tools.mima.core.ProblemFilter
+import mill.main.buildgen._
 import mill.main.buildgen.ModuleSpec._
 
 import scala.language.implicitConversions
@@ -17,10 +19,19 @@ object ExportBuildPlugin extends AutoPlugin {
 
   val millInitExportDir = settingKey[os.Path]("")
   val millInitExportProject = taskKey[Unit]("")
-  // Proxies for third-party plugin settings that are resolved using reflection.
+  // Copies/proxies for third-party plugin settings/tasks
   val millScalaJSModuleKind = settingKey[Option[String]]("")
-  // Copies of third-party plugin settings that are resolved directly.
   val crossProjectBaseDirectory = settingKey[File]("")
+  val mimaPreviousArtifacts = settingKey[Set[ModuleID]]("")
+  val mimaCheckDirection = settingKey[String]("")
+  val millMimaBinaryIssueFilters = taskKey[Seq[String]]("")
+  val millMimaBackwardIssueFilters = taskKey[Seq[(String, Seq[String])]]("")
+  val millMimaForwardIssueFilters = taskKey[Seq[(String, Seq[String])]]("")
+  val mimaExcludeAnnotations = settingKey[Seq[String]]("")
+  val mimaReportSignatureProblems = settingKey[Boolean]("")
+  val coverageMinimumStmtTotal = settingKey[Double]("")
+  val coverageMinimumBranchTotal = settingKey[Double]("")
+  val scalafixDependencies = settingKey[Seq[ModuleID]]("")
 
   import autoImport._
   override def globalSettings = Seq(
@@ -29,20 +40,11 @@ object ExportBuildPlugin extends AutoPlugin {
   )
   override def projectSettings = Seq(
     millScalaJSModuleKind := scalaJSModuleKind.value,
+    millMimaBinaryIssueFilters := mimaBinaryIssueFilters.value,
+    millMimaBackwardIssueFilters := mimaBackwardIssueFilters.value,
+    millMimaForwardIssueFilters := mimaForwardIssueFilters.value,
     millInitExportProject := exportProject.value
   )
-
-  // This is required to export projects that are not aggregated by the root project.
-  private def exportBuild = Def.taskDyn {
-    val structure = Project.structure(Keys.state.value)
-    Def.task {
-      val _ = std.TaskExtra.joinTasks(structure.allProjectPairs.flatMap {
-        case (project, ref) =>
-          if (project.aggregate.isEmpty) (ref / millInitExportProject).get(structure.data)
-          else None
-      }).join.value
-    }
-  }
 
   private def proxyForSetting(id: String, rt: Class[_]) = {
     val manifest = new Manifest[AnyRef] { def runtimeClass = rt }
@@ -63,6 +65,59 @@ object ExportBuildPlugin extends AutoPlugin {
     }
   }
 
+  private def toMillProblemFilter(pf: ProblemFilter) = {
+    "ProblemFilter.exclude" + pf.toString.stripPrefix("ExcludeByName")
+  }
+
+  private def mimaBinaryIssueFilters = Def.taskDyn[Seq[String]] {
+    try {
+      val mimaBinaryIssueFilters = taskKey[Seq[ProblemFilter]]("")
+      Def.task {
+        mimaBinaryIssueFilters.?.value.toSeq.flatten.map(toMillProblemFilter)
+      }
+    } catch {
+      case _: NoClassDefFoundError => Def.task(Nil)
+    }
+  }
+
+  private def mimaBackwardIssueFilters = Def.taskDyn[Seq[(String, Seq[String])]] {
+    try {
+      val mimaBackwardIssueFilters = taskKey[Map[String, Seq[ProblemFilter]]]("")
+      Def.task {
+        mimaBackwardIssueFilters.?.value.toSeq.flatten.map {
+          case (k, v) => (k, v.map(toMillProblemFilter))
+        }
+      }
+    } catch {
+      case _: NoClassDefFoundError => Def.task(Nil)
+    }
+  }
+
+  private def mimaForwardIssueFilters = Def.taskDyn[Seq[(String, Seq[String])]] {
+    try {
+      val mimaForwardIssueFilters = taskKey[Map[String, Seq[ProblemFilter]]]("")
+      Def.task {
+        mimaForwardIssueFilters.?.value.toSeq.flatten.map {
+          case (k, v) => (k, v.map(toMillProblemFilter))
+        }
+      }
+    } catch {
+      case _: NoClassDefFoundError => Def.task(Nil)
+    }
+  }
+
+  // This is required to export projects that are not aggregated by the root project.
+  private def exportBuild = Def.taskDyn {
+    val structure = Project.structure(Keys.state.value)
+    Def.task {
+      val _ = std.TaskExtra.joinTasks(structure.allProjectPairs.flatMap {
+        case (project, ref) =>
+          if (project.aggregate.isEmpty) (ref / millInitExportProject).get(structure.data)
+          else None
+      }).join.value
+    }
+  }
+
   private def exportProject = Def.taskDyn {
     val project = Keys.thisProject.value
     val scalaVersion = Keys.scalaVersion.value
@@ -71,12 +126,9 @@ object ExportBuildPlugin extends AutoPlugin {
     // Ignore duplicate invocations triggered by cross-build execution.
     Def.task(if (!os.exists(outFile)) {
       def hasAutoPlugin(label: String) = project.autoPlugins.exists(_.label == label)
-      val hasScalaJSPlugin = hasAutoPlugin("org.scalajs.sbtplugin.ScalaJSPlugin")
-      val hasScalaNativePlugin = hasAutoPlugin("scala.scalanative.sbtplugin.ScalaNativePlugin")
       val structure = Project.structure(Keys.state.value)
-      def isBaseDirShared(baseDir: File) =
-        structure.allProjects.count(p => p.aggregate.isEmpty && p.base == baseDir) > 1
-      val useOuterModuleDir = isBaseDirShared(project.base)
+      def isBaseDirShared(projectId: String, baseDir: File) =
+        structure.allProjects.exists(p => p.id != projectId && p.base == baseDir)
       val baseDir = os.Path(project.base)
       val crossProjectBaseDir = crossProjectBaseDirectory.?.value.map(os.Path(_)).orElse(
         if (baseDir.last.matches("""^[.]?(js|jvm|native)$""")) Some(baseDir / os.up) else None
@@ -95,54 +147,75 @@ object ExportBuildPlugin extends AutoPlugin {
         base = base,
         cross = if (isCrossVersion && base.nonEmpty) Seq(scalaVersion -> base) else Nil
       )
-      var mainModule = ModuleSpec(
-        name = if (useOuterModuleDir) project.id else toModuleName(baseDir.last),
-        imports = Seq("import mill.scalalib.*"),
-        supertypes = Seq((isCrossPlatform, isCrossVersion) match {
+      val (mainName, mainModuleDir, mainRoot) = {
+        val moduleDir = toModuleDir(crossProjectBaseDir.getOrElse(baseDir))
+        if (isBaseDirShared(project.id, project.base))
+          (
+            project.id,
+            Some("outer.moduleDir"),
+            Right(PackageSpec(moduleDir, ModuleSpec(baseDir.last, alias = Some("outer"))))
+          )
+        else if (isCrossPlatform)
+          (toModuleName(baseDir.last), None, Right(PackageSpec.root(moduleDir)))
+        else (baseDir.last, None, Left(moduleDir))
+      }
+      val mainSupertypes =
+        ((isCrossPlatform, isCrossVersion) match {
           case (true, true) => "CrossSbtPlatformModule"
           case (true, _) => "SbtPlatformModule"
           case (_, true) => "CrossSbtModule"
           case _ => "SbtModule"
-        }),
-        mixins =
-          if (
-            (Compile / Keys.unmanagedSourceDirectories).value.exists(_.name.last match {
-              case '+' | '-' => true
-              case _ => false
-            })
-          ) Seq("CrossScalaVersionRanges")
-          else Nil,
-        useOuterModuleDir = useOuterModuleDir,
-        crossKeys = if (isCrossVersion) Seq(scalaVersion) else Nil,
-        repositories = Keys.resolvers.value
-          .diff(Seq(Resolver.mavenCentral, Resolver.mavenLocal))
-          .collect {
-            case r: MavenRepository => r.root
-          }
+        }) +: (Compile / Keys.unmanagedSourceDirectories).value.collectFirst {
+          case dir if Seq('+', '-').contains(dir.name.last) => "CrossScalaVersionRanges"
+        }.toSeq
+      var mainModule = ModuleSpec(
+        name = mainName,
+        imports = Seq("mill.scalalib.*"),
+        supertypes = mainSupertypes,
+        moduleDir = mainModuleDir,
+        crossKeys = if (isCrossVersion) Seq(scalaVersion) else Nil
       )
 
-      def skipDep(dep: ModuleID) = {
-        import dep.{name, organization => org}
-        ((name.startsWith("scala-library") ||
-          name.startsWith("scala3-library")) && org == "org.scala-lang") ||
-        (name.startsWith("dotty") && org == "ch.epfl.lamp") ||
-        (hasScalaJSPlugin && !name.startsWith("scalajs-dom") && org == "org.scala-js") ||
-        (hasScalaNativePlugin && org == "org.scala-native")
-      }
       val configDeps = Keys.libraryDependencies.value.collect {
         case dep if !skipDep(dep) => (dep, dep.configurations.getOrElse("compile").split(';').toSeq)
       }
+      def toMvnDep(dep: ModuleID) = {
+        import ModuleSpec.{CrossVersion => CV}
+        import dep._
+        import librarymanagement.{For2_13Use3, For3Use2_13, Patch}
+        val artifact = explicitArtifacts.find(_.name == name)
+        MvnDep(
+          organization = organization,
+          name = name,
+          version = revision,
+          classifier = artifact.flatMap(_.classifier),
+          `type` = artifact.map(_.`type`),
+          excludes = exclusions.map(x => (x.organization, x.name)),
+          cross = crossVersion match {
+            case v: Binary => CV.Binary(platformed = v.prefix.nonEmpty)
+            case v: Full => CV.Full(platformed = v.prefix.nonEmpty)
+            case _: Patch => CV.Full(platformed = false)
+            case v: For2_13Use3 => if (scalaVersion.startsWith("2.13."))
+                CV.Constant("_3", platformed = v.prefix.nonEmpty)
+              else CV.Binary(platformed = v.prefix.nonEmpty)
+            case v: For3Use2_13 => if (scalaVersion.startsWith("3."))
+                CV.Constant("_2.13", platformed = v.prefix.nonEmpty)
+              else CV.Binary(platformed = v.prefix.nonEmpty)
+            case _ => CV.Constant("", platformed = false)
+          }
+        )
+      }
       def mvnDeps(configs: String*) = configDeps.collect {
-        case (dep, configs0) if configs.exists(configs0.contains) => toMvnDep(dep)
+        case (dep, depConfigs) if configs.exists(depConfigs.contains) => toMvnDep(dep)
       }
       val configProjectDeps = project.dependencies
         .map(dep => dep -> dep.configuration.getOrElse("compile").split(";").toSeq)
       def moduleDeps(p: String => Boolean, childSegment: Option[String] = None): Seq[ModuleDep] =
         configProjectDeps.flatMap {
-          case (dep, configs) if configs.exists(p) =>
+          case (dep, depConfigs) if depConfigs.exists(p) =>
             (dep.project / Keys.baseDirectory).get(structure.data).flatMap { depBaseDir =>
               var depModuleDir = toModuleDir(os.Path(depBaseDir))
-              if (isBaseDirShared(depBaseDir))
+              if (isBaseDirShared(dep.project.project, depBaseDir))
                 depModuleDir = depModuleDir / os.RelPath(dep.project.project)
               val depCrossScalaVersions =
                 (dep.project / Keys.crossScalaVersions).get(structure.data).getOrElse(Nil)
@@ -155,6 +228,11 @@ object ExportBuildPlugin extends AutoPlugin {
           case _ => None
         }
       mainModule = mainModule.copy(
+        repositories = Keys.resolvers.value
+          .diff(Seq(Resolver.mavenCentral, Resolver.mavenLocal))
+          .collect {
+            case r: MavenRepository => r.root
+          },
         mvnDeps = mvnDeps("compile"),
         compileMvnDeps = mvnDeps("provided", "optional"),
         runMvnDeps = mvnDeps("runtime"),
@@ -175,12 +253,64 @@ object ExportBuildPlugin extends AutoPlugin {
         ).copy(appendSuper = true)
       )
 
+      if (hasAutoPlugin("org.scalajs.sbtplugin.ScalaJSPlugin")) {
+        Keys.libraryDependencies.value.collectFirst {
+          case dep
+              if dep.organization == "org.scala-js" && dep.name.startsWith("scalajs-library") =>
+            mainModule = mainModule.copy(
+              imports =
+                "mill.scalajslib.ScalaJSModule" +: "mill.scalajslib.api.*" +: mainModule.imports,
+              supertypes = mainModule.supertypes :+ "ScalaJSModule",
+              scalaJSVersion = Some(dep.revision),
+              moduleKind = millScalaJSModuleKind.value
+            )
+        }
+      }
+      if (hasAutoPlugin("scala.scalanative.sbtplugin.ScalaNativePlugin")) {
+        Keys.libraryDependencies.value.collectFirst {
+          case dep
+              if dep.organization == "org.scala-native" &&
+                dep.configurations.contains("plugin->default(compile)") =>
+            mainModule = mainModule.copy(
+              imports =
+                "mill.scalanativelib.ScalaNativeModule" +: "mill.scalanativelib.api.*" +: mainModule.imports,
+              supertypes = mainModule.supertypes :+ "ScalaNativeModule",
+              scalaNativeVersion = Some(dep.revision)
+            )
+        }
+      }
       if (!(Keys.publish / Keys.skip).value && Keys.publishArtifact.value) {
         mainModule = mainModule.copy(
-          imports =
-            "import mill.javalib.PublishModule" +: "import mill.javalib.publish.*" +: mainModule.imports,
-          supertypes = "PublishModule" +: mainModule.supertypes,
-          pomSettings = Some(toPomSettings(Keys.projectInfo.value, Keys.organization.value)),
+          imports = "mill.javalib.PublishModule" +: "mill.javalib.publish.*" +: mainModule.imports,
+          supertypes = mainModule.supertypes :+ "PublishModule",
+          pomSettings = {
+            val projectInfo = Keys.projectInfo.value
+            import projectInfo._
+            Some(PomSettings(
+              description = description,
+              organization = Keys.organization.value,
+              url = homepage.fold("")(_.toExternalForm),
+              licenses = licenses.map {
+                case (name, url) => ModuleSpec.License(
+                    name = name,
+                    url = url.toExternalForm,
+                    distribution = "repo" // hardcoded by sbt
+                  )
+              },
+              versionControl = scmInfo.fold(VersionControl()) { scmInfo =>
+                import scmInfo._
+                VersionControl(
+                  Some(browseUrl.toExternalForm),
+                  Some(connection),
+                  devConnection
+                )
+              },
+              developers = developers.map { developer =>
+                import developer._
+                ModuleSpec.Developer(id, name, url.toExternalForm)
+              }
+            ))
+          },
           publishVersion = Some(Keys.version.value),
           versionScheme = Keys.versionScheme.value.collect {
             case "early-semver" => "VersionScheme.EarlySemVer"
@@ -190,48 +320,84 @@ object ExportBuildPlugin extends AutoPlugin {
           }
         )
       }
+      if (hasAutoPlugin("pl.project13.scala.sbt.JmhPlugin")) {
+        Keys.libraryDependencies.value.collectFirst {
+          case dep if dep.organization == "org.openjdk.jmh" =>
+            mainModule = mainModule.withJmhModule(value(Some(dep.revision)))
+        }
+      }
+      if (hasAutoPlugin("com.typesafe.tools.mima.plugin.MimaPlugin")) {
+        val org = Keys.organization.value
+        val name = Keys.moduleName.value
+        val (versionedArtifacts, artifacts) =
+          mimaPreviousArtifacts.?.value.toSeq.flatten.partition {
+            dep => dep.organization == org && dep.name == name
+          }
+        mainModule = mainModule.copy(
+          imports = "com.github.lolgab.mill.mima.*" +: mainModule.imports,
+          supertypes = mainModule.supertypes :+ "Mima",
+          mimaPreviousVersions = versionedArtifacts.map(_.revision),
+          mimaPreviousArtifacts =
+            values(artifacts.map(toMvnDep)).copy(appendSuper = versionedArtifacts.nonEmpty),
+          mimaCheckDirection = mimaCheckDirection.?.value.collect {
+            case "both" => "CheckDirection.Both"
+            case "forward" => "CheckDirection.Forward"
+          },
+          mimaBinaryIssueFilters = millMimaBinaryIssueFilters.value,
+          mimaBackwardIssueFilters = millMimaBackwardIssueFilters.value,
+          mimaForwardIssueFilters = millMimaForwardIssueFilters.value,
+          mimaExcludeAnnotations = mimaExcludeAnnotations.?.value.getOrElse[Seq[String]](Nil),
+          mimaReportSignatureProblems = mimaReportSignatureProblems.?.value.filter(identity)
+        )
+      }
+      if (hasAutoPlugin("scoverage.ScoverageSbtPlugin")) {
+        val moduleIDAttrKey = AttributeKey[ModuleID]("moduleID")
+        structure.units.get(Keys.thisProjectRef.value.build).iterator
+          .flatMap(_.unit.plugins.pluginData.dependencyClasspath)
+          .flatMap(_.get(moduleIDAttrKey))
+          .collectFirst {
+            case dep if
+                  dep.name.startsWith("scalac-scoverage") &&
+                    dep.organization == "org.scoverage" =>
+              mainModule = mainModule.copy(
+                imports = "mill.contrib.scoverage.ScoverageModule" +: mainModule.imports,
+                supertypes = mainModule.supertypes :+ "ScoverageModule",
+                scoverageVersion = Some(dep.revision),
+                branchCoverageMin = coverageMinimumBranchTotal.?.value.filter(_ != 0.0),
+                statementCoverageMin = coverageMinimumStmtTotal.?.value.filter(_ != 0.0)
+              )
+          }
+      }
+      val hasScalafixPlugin = hasAutoPlugin("scalafix.sbt.ScalafixPlugin")
+      if (hasScalafixPlugin) {
+        mainModule = withScalafixModule(
+          mainModule,
+          (Compile / scalafixDependencies).?.value.getOrElse(Nil).distinct.map(toMvnDep)
+        )
+      }
+      val hasScalafmtPlugin = hasAutoPlugin("org.scalafmt.sbt.ScalafmtPlugin")
+      if (hasScalafmtPlugin) {
+        mainModule = withScalafmtModule(mainModule)
+      }
 
-      if (hasScalaJSPlugin) {
-        Keys.libraryDependencies.value.collectFirst {
-          case dep
-              if dep.organization == "org.scala-js" && dep.name.startsWith("scalajs-library") =>
-            mainModule = mainModule.copy(
-              imports =
-                "import mill.scalajslib.ScalaJSModule" +: "import mill.scalajslib.api.*" +: mainModule.imports,
-              supertypes = "ScalaJSModule" +: mainModule.supertypes,
-              scalaJSVersion = Some(dep.revision),
-              moduleKind = millScalaJSModuleKind.value
-            )
-        }
-      }
-      if (hasScalaNativePlugin) {
-        Keys.libraryDependencies.value.collectFirst {
-          case dep
-              if dep.organization == "org.scala-native" &&
-                dep.configurations.contains("plugin->default(compile)") =>
-            mainModule = mainModule.copy(
-              imports =
-                "import mill.scalanativelib.ScalaNativeModule" +: "import mill.scalanativelib.api.*" +: mainModule.imports,
-              supertypes = "ScalaNativeModule" +: mainModule.supertypes,
-              scalaNativeVersion = Some(dep.revision)
-            )
-        }
-      }
-      if ((Test / Keys.sourceDirectories).value.exists(_.exists)) {
+      if ((Test / Keys.unmanagedSourceDirectories).value.exists(_.exists)) {
         val testMvnDeps = mvnDeps("test")
         val testMixin = ModuleSpec.testModuleMixin(testMvnDeps)
-        val testModule = ModuleSpec(
+        val testSupertypes = mainModule.supertypes.collect {
+          case "CrossSbtPlatformModule" => "CrossSbtPlatformTests"
+          case "SbtPlatformModule" => "SbtPlatformTests"
+          case "CrossSbtModule" => "CrossSbtTests"
+          case "SbtModule" => "SbtTests"
+          case "ScalaJSModule" => "ScalaJSTests"
+          case "ScalaNativeModule" => "ScalaNativeTests"
+          case "ScoverageModule" => "ScoverageTests"
+        } ++ testMixin.toSeq
+        var testModule = ModuleSpec(
           name = "test",
-          supertypes = mainModule.supertypes.collect {
-            case "ScalaJSModule" => "ScalaJSTests"
-            case "ScalaNativeModule" => "ScalaNativeTests"
-            case "CrossSbtPlatformModule" => "CrossSbtPlatformTests"
-            case "SbtPlatformModule" => "SbtPlatformTests"
-            case "CrossSbtModule" => "CrossSbtTests"
-            case "SbtModule" => "SbtTests"
-          },
-          mixins = testMixin.toSeq,
-          mvnDeps = values(testMvnDeps).copy(appendSuper = hasScalaNativePlugin),
+          supertypes = testSupertypes,
+          forkWorkingDir = if ((Test / Keys.fork).value) Some("this.moduleDir") else None,
+          mvnDeps =
+            values(testMvnDeps).copy(appendSuper = testSupertypes.contains("ScalaNativeTests")),
           compileMvnDeps = mainModule.compileMvnDeps,
           runMvnDeps = mainModule.compileMvnDeps.base ++ mainModule.runMvnDeps.base,
           moduleDeps = values(
@@ -243,28 +409,40 @@ object ExportBuildPlugin extends AutoPlugin {
           testParallelism = Some(false),
           testSandboxWorkingDir = Some(false),
           testFramework =
-            if (testMixin.isEmpty) testFramework(testMvnDeps).orElse(Some("")) else None
+            if (testMixin.isEmpty) testMvnDeps.collectFirst {
+              case dep if dep.organization == "com.eed3si9n.verify" => "verify.runner.Framework"
+            }.orElse(Some(""))
+            else None
         )
+        if (hasScalafixPlugin) {
+          testModule = withScalafixModule(
+            testModule,
+            (Test / scalafixDependencies).?.value.getOrElse(Nil).distinct.map(toMvnDep)
+          )
+        }
+        if (hasScalafmtPlugin) {
+          testModule = withScalafmtModule(testModule)
+        }
         mainModule = mainModule.copy(children = Seq(testModule))
       }
 
-      val moduleDir = toModuleDir(crossProjectBaseDir.getOrElse(baseDir))
-      val exportedData = SbtModuleSpec(
-        Either.cond(isCrossPlatform || useOuterModuleDir, moduleDir, moduleDir),
-        mainModule
-      )
       Using.resource(os.write.outputStream(outFile))(
-        upickle.default.writeToOutputStream(exportedData, _)
+        upickle.default.writeToOutputStream(SbtModuleSpec(mainRoot, mainModule), _)
       )
     })
   }
 
+  private def skipDep(dep: ModuleID) = {
+    import dep.{name, organization => org}
+    ((name.startsWith("scala-library") ||
+      name.startsWith("scala3-library")) && org == "org.scala-lang") ||
+    (name.startsWith("dotty") && org == "ch.epfl.lamp") ||
+    (!name.startsWith("scalajs-dom") && org == "org.scala-js") ||
+    (org == "org.scala-native")
+  }
+
   private def skipScalacOption(s: String) =
     s.startsWith("-P") || s.startsWith("-Xplugin") || s.startsWith("-scalajs")
-
-  private def testFramework(deps: Seq[MvnDep]) = deps.collectFirst {
-    case dep if dep.organization == "com.eed3si9n.verify" => "verify.runner.Framework"
-  }
 
   // Cleanup `CrossType.Pure` module names.
   private def toModuleName(dirName: String) = dirName.stripPrefix(".")
@@ -274,62 +452,20 @@ object ExportBuildPlugin extends AutoPlugin {
     case init :+ last => os.sub / os.SubPath(init :+ toModuleName(last))
   }
 
-  private def toMvnDep(dep: ModuleID) = {
-    import ModuleSpec.{CrossVersion => CV}
-    import dep._
-    import librarymanagement.{For2_13Use3, For3Use2_13, Patch}
-    val artifact = explicitArtifacts.find(_.name == name)
-    MvnDep(
-      organization = organization,
-      name = name,
-      version = revision,
-      classifier = artifact.flatMap(_.classifier),
-      `type` = artifact.map(_.`type`),
-      excludes = exclusions.map(x => (x.organization, x.name)),
-      cross = crossVersion match {
-        case v: Binary => CV.Binary(platformed = v.prefix.nonEmpty)
-        case v: Full => CV.Full(platformed = v.prefix.nonEmpty)
-        case _: Patch => CV.Full(platformed = false)
-        case v: For2_13Use3 => CV.Constant("_3", platformed = v.prefix.nonEmpty)
-        case v: For3Use2_13 => CV.Constant("_2.13", platformed = v.prefix.nonEmpty)
-        case _ => CV.Constant("", platformed = false)
-      }
+  private def withScalafixModule(module: ModuleSpec, scalafixIvyDeps: Values[MvnDep]) = {
+    module.copy(
+      imports = "com.goyeau.mill.scalafix.ScalafixModule" +: "mill.api.BuildCtx" +: module.imports,
+      supertypes = module.supertypes :+ "ScalafixModule",
+      scalafixConfig = if (!os.exists(os.pwd / ".scalafix.conf")) None
+      else Some("""BuildCtx.workspaceRoot / ".scalafix.conf""""),
+      scalafixIvyDeps = scalafixIvyDeps
     )
   }
 
-  private def toPomSettings(moduleInfo: ModuleInfo, groupId: String) = {
-    import moduleInfo._
-    PomSettings(
-      description = description,
-      organization = groupId,
-      url = homepage.fold("")(_.toExternalForm),
-      licenses = licenses.map(toLicense),
-      versionControl = toVersionControl(scmInfo),
-      developers = developers.map(toDeveloper)
+  private def withScalafmtModule(module: ModuleSpec) = {
+    module.copy(
+      imports = "mill.scalalib.scalafmt.ScalafmtModule" +: module.imports,
+      supertypes = module.supertypes :+ "ScalafmtModule"
     )
-  }
-
-  private def toLicense(license: (String, URL)) = {
-    val (name, url) = license
-    ModuleSpec.License(
-      name = name,
-      url = url.toExternalForm,
-      distribution = "repo" // hardcoded by sbt
-    )
-  }
-
-  private def toVersionControl(scmInfo: Option[ScmInfo]) =
-    scmInfo.fold(VersionControl()) { scmInfo =>
-      import scmInfo._
-      VersionControl(
-        Some(browseUrl.toExternalForm),
-        Some(connection),
-        devConnection
-      )
-    }
-
-  private def toDeveloper(developer: librarymanagement.Developer) = {
-    import developer._
-    ModuleSpec.Developer(id, name, url.toExternalForm)
   }
 }

--- a/libs/init/sbt/test/resources/expected/cross-version/build.mill
+++ b/libs/init/sbt/test/resources/expected/cross-version/build.mill
@@ -1,6 +1,8 @@
 //| mill-version: SNAPSHOT
 //| mill-jvm-version: system
-//| mill-jvm-opts: ["-Xms2g", "-Xmx2g"]
+//| mill-jvm-opts:
+//|   - -Xms2g
+//|   - -Xmx2g
 package build
 
 import mill.*
@@ -11,7 +13,7 @@ import millbuild.*
 
 object `package`
     extends Cross[CrossVersionModule]("2.12.18", "2.13.12", "3.3.1")
-trait CrossVersionModule extends PublishModule, CrossSbtModule {
+trait CrossVersionModule extends CrossSbtModule, PublishModule {
 
   def javacOptions = Seq("--release", "8")
 

--- a/libs/init/sbt/test/resources/expected/crossproject-cross-version/dummy/package.mill
+++ b/libs/init/sbt/test/resources/expected/crossproject-cross-version/dummy/package.mill
@@ -13,7 +13,8 @@ import millbuild.*
 object `package` extends Module {
 
   object js extends Cross[JsModule]("2.12.21", "2.13.18", "3.7.1")
-  trait JsModule extends ProjectBaseModule, ScalaJSModule {
+  trait JsModule
+      extends ProjectBaseModule, CrossSbtPlatformModule, ScalaJSModule {
 
     def scalaJSVersion = "1.16.0"
 
@@ -33,7 +34,7 @@ object `package` extends Module {
   }
 
   object jvm extends Cross[JvmModule]("2.12.21", "2.13.18", "3.7.1")
-  trait JvmModule extends ProjectBaseModule {
+  trait JvmModule extends ProjectBaseModule, CrossSbtPlatformModule {
 
     def artifactName = "dummy"
 
@@ -49,7 +50,8 @@ object `package` extends Module {
   }
 
   object native extends Cross[NativeModule]("2.12.21", "2.13.18", "3.7.1")
-  trait NativeModule extends ProjectBaseModule, ScalaNativeModule {
+  trait NativeModule
+      extends ProjectBaseModule, CrossSbtPlatformModule, ScalaNativeModule {
 
     def scalaNativeVersion = "0.5.7"
 

--- a/libs/init/sbt/test/resources/expected/crossproject-cross-version/full/package.mill
+++ b/libs/init/sbt/test/resources/expected/crossproject-cross-version/full/package.mill
@@ -13,7 +13,8 @@ import millbuild.*
 object `package` extends Module {
 
   object js extends Cross[JsModule]("2.12.21", "2.13.18", "3.7.1")
-  trait JsModule extends ProjectBaseModule, ScalaJSModule {
+  trait JsModule
+      extends ProjectBaseModule, CrossSbtPlatformModule, ScalaJSModule {
 
     def scalaJSVersion = "1.16.0"
 
@@ -33,7 +34,7 @@ object `package` extends Module {
   }
 
   object jvm extends Cross[JvmModule]("2.12.21", "2.13.18", "3.7.1")
-  trait JvmModule extends ProjectBaseModule {
+  trait JvmModule extends ProjectBaseModule, CrossSbtPlatformModule {
 
     def moduleDeps = Seq(build.`jvm-util`())
 
@@ -51,7 +52,8 @@ object `package` extends Module {
   }
 
   object native extends Cross[NativeModule]("2.12.21", "2.13.18", "3.7.1")
-  trait NativeModule extends ProjectBaseModule, ScalaNativeModule {
+  trait NativeModule
+      extends ProjectBaseModule, CrossSbtPlatformModule, ScalaNativeModule {
 
     def scalaNativeVersion = "0.5.7"
 

--- a/libs/init/sbt/test/resources/expected/crossproject-cross-version/jvm-util/package.mill
+++ b/libs/init/sbt/test/resources/expected/crossproject-cross-version/jvm-util/package.mill
@@ -7,21 +7,7 @@ import mill.scalalib.*
 import millbuild.*
 
 object `package` extends Cross[JvmUtilModule]("2.12.21", "2.13.18", "3.7.1")
-trait JvmUtilModule extends PublishModule, CrossSbtModule {
-
-  def mvnDeps = Seq(Deps.upickle)
-
-  def scalacOptions = Seq("-deprecation") ++
-    (crossScalaVersion match {
-      case "2.12.21" => Seq(
-          "-Xlint:_,-unused",
-          "-Ywarn-numeric-widen",
-          "-Ywarn-unused:_,-nowarn,-privates"
-        )
-      case "2.13.18" => Seq("-Xlint:_,-unused", "-Wnumeric-widen", "-Wunused")
-      case "3.7.1"   => Seq("-Wunused")
-      case _         => Seq()
-    })
+trait JvmUtilModule extends ProjectBaseModule {
 
   def artifactName = "jvmutil"
 
@@ -33,7 +19,5 @@ trait JvmUtilModule extends PublishModule, CrossSbtModule {
     VersionControl(None, None, None, None),
     Seq()
   )
-
-  def publishVersion = "0.1.0-SNAPSHOT"
 
 }

--- a/libs/init/sbt/test/resources/expected/crossproject-cross-version/mill-build/src/ProjectBaseModule.scala
+++ b/libs/init/sbt/test/resources/expected/crossproject-cross-version/mill-build/src/ProjectBaseModule.scala
@@ -9,7 +9,7 @@ import mill.scalalib.*
 import mill.scalanativelib.ScalaNativeModule
 import mill.scalanativelib.api.*
 
-trait ProjectBaseModule extends PublishModule, CrossSbtPlatformModule {
+trait ProjectBaseModule extends CrossSbtModule, PublishModule {
 
   def mvnDeps = Seq(Deps.upickle)
 
@@ -27,7 +27,7 @@ trait ProjectBaseModule extends PublishModule, CrossSbtPlatformModule {
 
   def publishVersion = "0.1.0-SNAPSHOT"
 
-  trait ProjectBaseTests extends CrossSbtPlatformTests {
+  trait ProjectBaseTests extends CrossSbtTests {
 
     def testParallelism = false
 

--- a/libs/init/sbt/test/resources/expected/crossproject-cross-version/pure/package.mill
+++ b/libs/init/sbt/test/resources/expected/crossproject-cross-version/pure/package.mill
@@ -13,7 +13,8 @@ import millbuild.*
 object `package` extends Module {
 
   object js extends Cross[JsModule]("2.12.21", "2.13.18", "3.7.1")
-  trait JsModule extends ProjectBaseModule, ScalaJSModule {
+  trait JsModule
+      extends ProjectBaseModule, CrossSbtPlatformModule, ScalaJSModule {
 
     def scalaJSVersion = "1.16.0"
 
@@ -30,12 +31,12 @@ object `package` extends Module {
       Seq()
     )
 
-    object test extends ProjectBaseTests, ScalaJSTests {}
+    object test extends ProjectBaseTests, CrossSbtPlatformTests, ScalaJSTests {}
 
   }
 
   object jvm extends Cross[JvmModule]("2.12.21", "2.13.18", "3.7.1")
-  trait JvmModule extends ProjectBaseModule {
+  trait JvmModule extends ProjectBaseModule, CrossSbtPlatformModule {
 
     def artifactName = "pure"
 
@@ -48,12 +49,13 @@ object `package` extends Module {
       Seq()
     )
 
-    object test extends ProjectBaseTests {}
+    object test extends ProjectBaseTests, CrossSbtPlatformTests {}
 
   }
 
   object native extends Cross[NativeModule]("2.12.21", "2.13.18", "3.7.1")
-  trait NativeModule extends ProjectBaseModule, ScalaNativeModule {
+  trait NativeModule
+      extends ProjectBaseModule, CrossSbtPlatformModule, ScalaNativeModule {
 
     def scalaNativeVersion = "0.5.7"
 
@@ -68,7 +70,8 @@ object `package` extends Module {
       Seq()
     )
 
-    object test extends ProjectBaseTests, ScalaNativeTests {}
+    object test
+        extends ProjectBaseTests, CrossSbtPlatformTests, ScalaNativeTests {}
 
   }
 

--- a/libs/init/sbt/test/resources/expected/crossproject/full/package.mill
+++ b/libs/init/sbt/test/resources/expected/crossproject/full/package.mill
@@ -33,7 +33,7 @@ object `package` extends Module {
       Seq()
     )
 
-    object test extends ProjectBaseTests, ScalaJSTests, TestModule.Utest {}
+    object test extends ProjectBaseTests, ScalaJSTests {}
 
   }
 
@@ -54,7 +54,7 @@ object `package` extends Module {
       Seq()
     )
 
-    object test extends ProjectBaseTests, TestModule.Utest {}
+    object test extends ProjectBaseTests {}
 
   }
 
@@ -77,7 +77,7 @@ object `package` extends Module {
       Seq()
     )
 
-    object test extends ProjectBaseTests, ScalaNativeTests, TestModule.Utest {}
+    object test extends ProjectBaseTests, ScalaNativeTests {}
 
   }
 

--- a/libs/init/sbt/test/resources/expected/crossproject/mill-build/src/ProjectBaseModule.scala
+++ b/libs/init/sbt/test/resources/expected/crossproject/mill-build/src/ProjectBaseModule.scala
@@ -9,7 +9,7 @@ import mill.scalalib.*
 import mill.scalanativelib.ScalaNativeModule
 import mill.scalanativelib.api.*
 
-trait ProjectBaseModule extends PublishModule, SbtPlatformModule {
+trait ProjectBaseModule extends SbtPlatformModule, PublishModule {
 
   def mvnDeps = Seq(Deps.upickle)
 
@@ -17,9 +17,9 @@ trait ProjectBaseModule extends PublishModule, SbtPlatformModule {
 
   def publishVersion = "0.1.0-SNAPSHOT"
 
-  trait ProjectBaseTests extends SbtPlatformTests {
+  trait ProjectBaseTests extends SbtPlatformTests, TestModule.Utest {
 
-    def mvnDeps = Seq(Deps.utest)
+    def mvnDeps = super.mvnDeps() ++ Seq(Deps.utest)
 
     def testParallelism = false
 

--- a/libs/init/sbt/test/resources/expected/sbt-multi-project-example/mill-build/src/ProjectBaseModule.scala
+++ b/libs/init/sbt/test/resources/expected/sbt-multi-project-example/mill-build/src/ProjectBaseModule.scala
@@ -5,7 +5,7 @@ import mill.javalib.PublishModule
 import mill.javalib.publish.*
 import mill.scalalib.*
 
-trait ProjectBaseModule extends PublishModule, SbtModule {
+trait ProjectBaseModule extends SbtModule, PublishModule {
 
   def scalaVersion = "2.12.3"
 

--- a/libs/init/sbt/test/resources/expected/scala-seed-project/build.mill
+++ b/libs/init/sbt/test/resources/expected/scala-seed-project/build.mill
@@ -8,7 +8,7 @@ import mill.javalib.publish.*
 import mill.scalalib.*
 import millbuild.*
 
-object `package` extends PublishModule, SbtModule {
+object `package` extends SbtModule, PublishModule {
 
   def scalaVersion = "2.13.12"
 

--- a/libs/init/sbt/test/resources/expected/with-args/crossproject-cross-version/build.mill
+++ b/libs/init/sbt/test/resources/expected/with-args/crossproject-cross-version/build.mill
@@ -17,7 +17,7 @@ object `package` extends Module {
 
     object js extends Cross[JsModule]("2.12.21", "2.13.18", "3.7.1")
     trait JsModule
-        extends ScalaJSModule, PublishModule, CrossSbtPlatformModule {
+        extends CrossSbtPlatformModule, ScalaJSModule, PublishModule {
 
       def mvnDeps = Seq(mvn"com.lihaoyi::upickle::4.3.0")
 
@@ -54,7 +54,7 @@ object `package` extends Module {
     }
 
     object jvm extends Cross[JvmModule]("2.12.21", "2.13.18", "3.7.1")
-    trait JvmModule extends PublishModule, CrossSbtPlatformModule {
+    trait JvmModule extends CrossSbtPlatformModule, PublishModule {
 
       def mvnDeps = Seq(mvn"com.lihaoyi::upickle::4.3.0")
 
@@ -88,7 +88,7 @@ object `package` extends Module {
 
     object native extends Cross[NativeModule]("2.12.21", "2.13.18", "3.7.1")
     trait NativeModule
-        extends ScalaNativeModule, PublishModule, CrossSbtPlatformModule {
+        extends CrossSbtPlatformModule, ScalaNativeModule, PublishModule {
 
       def mvnDeps = Seq(mvn"com.lihaoyi::upickle::4.3.0")
 
@@ -128,7 +128,7 @@ object `package` extends Module {
 
     object js extends Cross[JsModule]("2.12.21", "2.13.18", "3.7.1")
     trait JsModule
-        extends ScalaJSModule, PublishModule, CrossSbtPlatformModule {
+        extends CrossSbtPlatformModule, ScalaJSModule, PublishModule {
 
       def mvnDeps = Seq(mvn"com.lihaoyi::upickle::4.3.0")
 
@@ -165,7 +165,7 @@ object `package` extends Module {
     }
 
     object jvm extends Cross[JvmModule]("2.12.21", "2.13.18", "3.7.1")
-    trait JvmModule extends PublishModule, CrossSbtPlatformModule {
+    trait JvmModule extends CrossSbtPlatformModule, PublishModule {
 
       def moduleDeps = Seq(build.`jvm-util`())
 
@@ -201,7 +201,7 @@ object `package` extends Module {
 
     object native extends Cross[NativeModule]("2.12.21", "2.13.18", "3.7.1")
     trait NativeModule
-        extends ScalaNativeModule, PublishModule, CrossSbtPlatformModule {
+        extends CrossSbtPlatformModule, ScalaNativeModule, PublishModule {
 
       def mvnDeps = Seq(mvn"com.lihaoyi::upickle::4.3.0")
 
@@ -238,7 +238,7 @@ object `package` extends Module {
   }
 
   object `jvm-util` extends Cross[JvmUtilModule]("2.12.21", "2.13.18", "3.7.1")
-  trait JvmUtilModule extends PublishModule, CrossSbtModule {
+  trait JvmUtilModule extends CrossSbtModule, PublishModule {
 
     def mvnDeps = Seq(mvn"com.lihaoyi::upickle::4.3.0")
 
@@ -273,7 +273,7 @@ object `package` extends Module {
 
     object js extends Cross[JsModule]("2.12.21", "2.13.18", "3.7.1")
     trait JsModule
-        extends ScalaJSModule, PublishModule, CrossSbtPlatformModule {
+        extends CrossSbtPlatformModule, ScalaJSModule, PublishModule {
 
       def mvnDeps = Seq(mvn"com.lihaoyi::upickle::4.3.0")
 
@@ -307,7 +307,7 @@ object `package` extends Module {
 
       def publishVersion = "0.1.0-SNAPSHOT"
 
-      object test extends ScalaJSTests, CrossSbtPlatformTests {
+      object test extends CrossSbtPlatformTests, ScalaJSTests {
 
         def testParallelism = false
 
@@ -320,7 +320,7 @@ object `package` extends Module {
     }
 
     object jvm extends Cross[JvmModule]("2.12.21", "2.13.18", "3.7.1")
-    trait JvmModule extends PublishModule, CrossSbtPlatformModule {
+    trait JvmModule extends CrossSbtPlatformModule, PublishModule {
 
       def mvnDeps = Seq(mvn"com.lihaoyi::upickle::4.3.0")
 
@@ -364,7 +364,7 @@ object `package` extends Module {
 
     object native extends Cross[NativeModule]("2.12.21", "2.13.18", "3.7.1")
     trait NativeModule
-        extends ScalaNativeModule, PublishModule, CrossSbtPlatformModule {
+        extends CrossSbtPlatformModule, ScalaNativeModule, PublishModule {
 
       def mvnDeps = Seq(mvn"com.lihaoyi::upickle::4.3.0")
 
@@ -396,7 +396,7 @@ object `package` extends Module {
 
       def publishVersion = "0.1.0-SNAPSHOT"
 
-      object test extends ScalaNativeTests, CrossSbtPlatformTests {
+      object test extends CrossSbtPlatformTests, ScalaNativeTests {
 
         def testParallelism = false
 

--- a/libs/init/sbt/test/resources/expected/with-args/sbt-multi-project-example/build.mill
+++ b/libs/init/sbt/test/resources/expected/with-args/sbt-multi-project-example/build.mill
@@ -9,7 +9,7 @@ import mill.scalalib.*
 
 object `package` extends Module {
 
-  object common extends PublishModule, SbtModule {
+  object common extends SbtModule, PublishModule {
 
     def mvnDeps = Seq(
       mvn"ch.qos.logback:logback-classic:1.2.3",
@@ -83,7 +83,7 @@ object `package` extends Module {
 
   }
 
-  object multi1 extends PublishModule, SbtModule {
+  object multi1 extends SbtModule, PublishModule {
 
     def moduleDeps = Seq(build.common)
 
@@ -162,7 +162,7 @@ object `package` extends Module {
 
   }
 
-  object multi2 extends PublishModule, SbtModule {
+  object multi2 extends SbtModule, PublishModule {
 
     def moduleDeps = Seq(build.common)
 
@@ -239,7 +239,7 @@ object `package` extends Module {
 
   object nested extends Module {
 
-    object nested extends PublishModule, SbtModule {
+    object nested extends SbtModule, PublishModule {
 
       def mvnDeps = Seq(
         mvn"io.netty:netty-transport-native-epoll:4.1.118.Final;classifier=linux-x86_64;type=pom;exclude=io.netty:netty-transport-native-epoll"

--- a/libs/scalalib/src/mill/scalalib/SbtPlatformModule.scala
+++ b/libs/scalalib/src/mill/scalalib/SbtPlatformModule.scala
@@ -1,6 +1,6 @@
 package mill.scalalib
 
-import mill.api.PathRef
+import mill.api.Task
 
 /**
  * A cross-platform module that can share sources with other cross members.
@@ -32,15 +32,15 @@ trait SbtPlatformModule extends PlatformScalaModule with SbtModule { outer =>
   override def sourcesFolders =
     sourcesRootFolders.flatMap(root => super.sourcesFolders.map(root / _))
   override def resources =
-    sourcesRootFolders.map(root => PathRef(moduleDir / root / "src/main/resources"))
+    Task.Sources(sourcesRootFolders.map(root => root / "src/main/resources")*)
 
   trait SbtPlatformTests extends SbtTests {
 
     override def sourcesFolders = outer.sourcesRootFolders.flatMap(root =>
       super.sourcesFolders.map(root / _)
     )
-    override def resources = outer.sourcesRootFolders.map(root =>
-      PathRef(moduleDir / root / "src" / testModuleName / "resources")
-    )
+    override def resources = Task.Sources(outer.sourcesRootFolders.map(root =>
+      root / "src" / testModuleName / "resources"
+    )*)
   }
 }

--- a/mill-build/src/millbuild/Deps.scala
+++ b/mill-build/src/millbuild/Deps.scala
@@ -241,6 +241,7 @@ object Deps {
   val hiltGradlePlugin = mvn"com.google.dagger:hilt-android-gradle-plugin:2.56"
 
   val sbt = mvn"org.scala-sbt:sbt:1.10.10"
+  val mimaCore = mvn"com.typesafe::mima-core:1.1.4"
   val snakeyamlEngine = mvn"org.snakeyaml:snakeyaml-engine:3.0.1"
   val spotlessLibExtra = mvn"com.diffplug.spotless:spotless-lib-extra:3.2.0"
   // JGit 6.x series, used by spotlessLibExtra, works on Java 11


### PR DESCRIPTION
Added mappings in SBT migration that target the following Mill plugins:
- `com.github.lolgab.mill.mima.Mima`
- `com.goyeau.mill.scalafix.ScalafixModule`
- `mill.contrib.jmh.JmhModule`
- `mill.scalalib.scalafmt.ScalafmtModule`
- `mill.contrib.scoverage.ScoverageModule`

Other enhancements and fixes:
- Added tests for build functionality in `integration.manual[migrating]`
- Removed references to managed `bomModuleDeps` and added `bomMvnDeps` and `depManagement` values instead
- Merged `ModuleSpec.mixin` into `ModuleSpec.supertypes`
- Replaced `ModuleSpec.useOuterModuleDir` with `alias` and `moduleDir`
- Added mapping for `ModuleSpec.forkWorkingDir` when SBT `Test / fork` is set
- Removed import keyword from `ModuleSpec.imports` values
- Fixed bug in `BuildGen.withBaseModule.parentValues` that was causing cross values to leak through
- Fixed mapping for SBT `CrossVersion` subtypes `For2_13Use3` and `For3Use2_13`
- Wrapped `SbtPlatformModule.resources` in `Task.Sources` to prevent access errors