### PR TITLE
Generalize `AllEvaluators` logic

### DIFF
--- a/.github/actions/post-build-selective/action.yml
+++ b/.github/actions/post-build-selective/action.yml
@@ -57,3 +57,11 @@ runs:
         annotate_only: true
         require_tests: false
         report_paths: 'out/**/test-report.xml'
+
+    - name: Upload Chrome Profile
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: mill-chrome-profile-${{ runner.os }}-${{ github.job }}
+        path: out/mill-chrome-profile.json
+        if-no-files-found: ignore

--- a/.github/actions/post-build-selective/action.yml
+++ b/.github/actions/post-build-selective/action.yml
@@ -57,11 +57,3 @@ runs:
         annotate_only: true
         require_tests: false
         report_paths: 'out/**/test-report.xml'
-
-    - name: Upload Chrome Profile
-      uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: mill-chrome-profile-${{ runner.os }}-${{ github.job }}
-        path: out/mill-chrome-profile.json
-        if-no-files-found: ignore

--- a/core/api/daemon/src/mill/api/daemon/internal/AllEvaluators.scala
+++ b/core/api/daemon/src/mill/api/daemon/internal/AllEvaluators.scala
@@ -1,0 +1,9 @@
+package mill.api.daemon.internal
+
+import scala.util.DynamicVariable
+
+/**
+ * Hold all evaluators from the bootstrap process.
+ * Used by @allEvaluatorsCommand tasks to access evaluators from all bootstrap levels.
+ */
+private[mill] object AllEvaluators extends DynamicVariable[Seq[EvaluatorApi]](Seq.empty)

--- a/core/api/daemon/src/mill/api/daemon/internal/EvaluatorApi.scala
+++ b/core/api/daemon/src/mill/api/daemon/internal/EvaluatorApi.scala
@@ -40,6 +40,17 @@ trait EvaluatorApi extends AutoCloseable {
   ): Result[Boolean] = Result.Success(false)
 
   /**
+   * Resolves tasks from script arguments and checks if all resolved tasks are marked
+   * with @allEvaluatorsCommand annotation. Returns Success(true) if all tasks are
+   * allEvaluatorsCommand, Success(false) if any task is not, or Failure if resolution fails.
+   */
+  private[mill] def areAllEvaluatorsCommand(
+      scriptArgs: Seq[String],
+      selectMode: SelectMode,
+      allowPositionalCommandArgs: Boolean = false
+  ): Result[Boolean] = Result.Success(false)
+
+  /**
    * Returns a copy of this evaluator with the isFinalDepth flag set to the given value.
    * Used to defer the decision of whether this is the final depth until after
    * determining if we should short-circuit for @nonBootstrapped tasks.

--- a/core/api/src/mill/api/Discover.scala
+++ b/core/api/src/mill/api/Discover.scala
@@ -196,7 +196,13 @@ object Discover {
               ${ Expr.ofList(entryPoints.toList) },
               ${
                 Expr.ofList(names.map { case (name, nonBootstrapped, allEvaluatorsCommand) =>
-                  '{ new TaskInfo(${ Expr(name) }, ${ Expr(nonBootstrapped) }, ${ Expr(allEvaluatorsCommand) }) }
+                  '{
+                    new TaskInfo(
+                      ${ Expr(name) },
+                      ${ Expr(nonBootstrapped) },
+                      ${ Expr(allEvaluatorsCommand) }
+                    )
+                  }
                 })
               }
             )

--- a/core/api/src/mill/api/Discover.scala
+++ b/core/api/src/mill/api/Discover.scala
@@ -140,7 +140,7 @@ object Discover {
       // changing unnecessarily
       val mapping: Seq[(
           TypeRepr,
-          (Seq[scala.quoted.Expr[mainargs.MainData[?, ?]]], Seq[(String, Boolean)])
+          (Seq[scala.quoted.Expr[mainargs.MainData[?, ?]]], Seq[(String, Boolean, Boolean)])
       )] =
         for (curCls <- seen.toSeq.sortBy(_.typeSymbol.fullName)) yield {
           val declMethods = filterDefs(curCls.typeSymbol.declaredMethods)

--- a/core/api/src/mill/api/Discover.scala
+++ b/core/api/src/mill/api/Discover.scala
@@ -28,6 +28,16 @@ final class Discover(val classInfo: Map[Class[?], Discover.ClassInfo]) {
     }
   }
 
+  /**
+   * Check if the given task name is marked as allEvaluatorsCommand for the given class.
+   * Looks up the class hierarchy to find if any parent class has this task marked as allEvaluatorsCommand.
+   */
+  private[mill] def isAllEvaluatorsCommand(cls: Class[?], name: String): Boolean = {
+    resolveClassInfos(cls).exists { case (_, info) =>
+      info.allEvaluatorsCommandTaskNames.contains(name)
+    }
+  }
+
   private[mill] def resolveEntrypoint(cls: Class[?], name: String) = {
     val res = for {
       (cls2, node) <- resolveClassInfos(cls)
@@ -56,8 +66,14 @@ object Discover {
   ) {
     lazy val declaredTaskNameSet = declaredTasks.map(_.name).toSet
     lazy val nonBootstrappedTaskNames = declaredTasks.filter(_.nonBootstrapped).map(_.name).toSet
+    lazy val allEvaluatorsCommandTaskNames =
+      declaredTasks.filter(_.allEvaluatorsCommand).map(_.name).toSet
   }
-  final class TaskInfo(val name: String, @com.lihaoyi.unroll val nonBootstrapped: Boolean = false)
+  final class TaskInfo(
+      val name: String,
+      @com.lihaoyi.unroll val nonBootstrapped: Boolean = false,
+      @com.lihaoyi.unroll val allEvaluatorsCommand: Boolean = false
+  )
 
   inline def apply[T]: Discover = ${ Router.applyImpl[T] }
 
@@ -138,7 +154,9 @@ object Discover {
           val names = taskMethods.map { m =>
             val hasNonBootstrapped =
               m.annotations.exists(_.tpe =:= TypeRepr.of[mill.api.nonBootstrapped])
-            (m.name, hasNonBootstrapped)
+            val hasAllEvaluatorsCommand =
+              m.annotations.exists(_.tpe =:= TypeRepr.of[mill.api.allEvaluatorsCommand])
+            (m.name, hasNonBootstrapped, hasAllEvaluatorsCommand)
           }
           val entryPoints = for {
             m <- sortedMethods(curCls, sub = TypeRepr.of[Task.Command[?]], declMethods)
@@ -177,8 +195,8 @@ object Discover {
             def func() = new ClassInfo(
               ${ Expr.ofList(entryPoints.toList) },
               ${
-                Expr.ofList(names.map { case (name, nonBootstrapped) =>
-                  '{ new TaskInfo(${ Expr(name) }, ${ Expr(nonBootstrapped) }) }
+                Expr.ofList(names.map { case (name, nonBootstrapped, allEvaluatorsCommand) =>
+                  '{ new TaskInfo(${ Expr(name) }, ${ Expr(nonBootstrapped) }, ${ Expr(allEvaluatorsCommand) }) }
                 })
               }
             )

--- a/core/api/src/mill/api/annotations.scala
+++ b/core/api/src/mill/api/annotations.scala
@@ -20,3 +20,27 @@ import scala.annotation.StaticAnnotation
  * }}}
  */
 final class nonBootstrapped extends StaticAnnotation
+
+/**
+ * Annotation to mark a command that needs access to all evaluators from the bootstrap process.
+ *
+ * Commands marked with this annotation will:
+ * 1. Allow the bootstrap process to complete (success or failure)
+ * 2. Receive the full list of evaluators from all bootstrap levels
+ * 3. Execute after bootstrapping with access to all evaluators
+ *
+ * The command must accept a `Seq[EvaluatorApi]` parameter containing evaluators
+ * from all bootstrap depths.
+ *
+ * This is useful for IDE integration commands like `GenIdea` and `GenEclipse` that
+ * need to analyze modules across all build levels.
+ *
+ * Usage:
+ * {{{
+ * @allEvaluatorsCommand
+ * def idea(evaluators: Seq[EvaluatorApi]): Command[Unit] = Task.Command(exclusive = true) {
+ *   new GenIdeaImpl(evaluators).run()
+ * }
+ * }}}
+ */
+final class allEvaluatorsCommand extends StaticAnnotation

--- a/integration/feature/gen-idea/resources/extended/idea/mill_modules/mill-build.iml
+++ b/integration/feature/gen-idea/resources/extended/idea/mill_modules/mill-build.iml
@@ -12,6 +12,7 @@
         <orderEntry type="inheritedJdk"/>
         <orderEntry type="sourceFolder" forTests="false"/>
         <orderEntry type="library" name="scala-SDK-<version>" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="JavaEWAH-1.2.3.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="aircompressor-0.27.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="cache-util-COURSIER_VERSION.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="commons-codec-1.19.0.jar" level="project"/>
@@ -67,8 +68,10 @@
         <orderEntry type="library" name="mill-libs-androidlib_3-SNAPSHOT.jar" level="project"/>
         <orderEntry type="library" name="mill-libs-daemon-client_3-SNAPSHOT.jar" level="project"/>
         <orderEntry type="library" name="mill-libs-daemon-server_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-libs-eclipse_3-SNAPSHOT.jar" level="project"/>
         <orderEntry type="library" name="mill-libs-groovylib-api_3-SNAPSHOT.jar" level="project"/>
         <orderEntry type="library" name="mill-libs-groovylib_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-libs-idea_3-SNAPSHOT.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="mill-libs-init_3-SNAPSHOT.jar" level="project"/>
         <orderEntry type="library" name="mill-libs-javalib-api_3-SNAPSHOT.jar" level="project"/>
         <orderEntry type="library" name="mill-libs-javalib-testrunner-entrypoint-SNAPSHOT.jar" level="project"/>
@@ -92,8 +95,11 @@
         <orderEntry type="library" name="mill-libs_3-SNAPSHOT.jar" level="project"/>
         <orderEntry type="library" name="mill-moduledefs_3-<version>.jar" level="project"/>
         <orderEntry type="library" name="mill-runner-autooverride-api_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-runner-eclipse_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-runner-idea_3-SNAPSHOT.jar" level="project"/>
         <orderEntry type="library" name="munit_3-<version>.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="native-terminal-no-ffm-0.0.9.1.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="org.eclipse.jgit-6.10.1.202505221210-r.jar" level="project"/>
         <orderEntry type="library" name="os-lib_3-<version>.jar" level="project"/>
         <orderEntry type="library" name="os-zip-0.11.6.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="plexus-archiver-4.10.1.jar" level="project"/>

--- a/integration/feature/gen-idea/resources/extended/idea/mill_modules/mill-build.mill-build.iml
+++ b/integration/feature/gen-idea/resources/extended/idea/mill_modules/mill-build.mill-build.iml
@@ -16,6 +16,7 @@
         <orderEntry type="inheritedJdk"/>
         <orderEntry type="sourceFolder" forTests="false"/>
         <orderEntry type="library" name="scala-SDK-<version>" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="JavaEWAH-1.2.3.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="aircompressor-0.27.jar" level="project"/>
         <orderEntry type="library" name="asm-9.9.1.jar" level="project"/>
         <orderEntry type="library" name="asm-tree-9.9.1.jar" level="project"/>
@@ -70,8 +71,10 @@
         <orderEntry type="library" name="mill-libs-androidlib_3-SNAPSHOT.jar" level="project"/>
         <orderEntry type="library" name="mill-libs-daemon-client_3-SNAPSHOT.jar" level="project"/>
         <orderEntry type="library" name="mill-libs-daemon-server_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-libs-eclipse_3-SNAPSHOT.jar" level="project"/>
         <orderEntry type="library" name="mill-libs-groovylib-api_3-SNAPSHOT.jar" level="project"/>
         <orderEntry type="library" name="mill-libs-groovylib_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-libs-idea_3-SNAPSHOT.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="mill-libs-init_3-SNAPSHOT.jar" level="project"/>
         <orderEntry type="library" name="mill-libs-javalib-api_3-SNAPSHOT.jar" level="project"/>
         <orderEntry type="library" name="mill-libs-javalib-testrunner-entrypoint-SNAPSHOT.jar" level="project"/>
@@ -96,8 +99,11 @@
         <orderEntry type="library" name="mill-moduledefs_3-<version>.jar" level="project"/>
         <orderEntry type="library" name="mill-runner-autooverride-api_3-SNAPSHOT.jar" level="project"/>
         <orderEntry type="library" name="mill-runner-codesig_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-runner-eclipse_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-runner-idea_3-SNAPSHOT.jar" level="project"/>
         <orderEntry type="library" name="mill-runner-meta_3-SNAPSHOT.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="native-terminal-no-ffm-0.0.9.1.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="org.eclipse.jgit-6.10.1.202505221210-r.jar" level="project"/>
         <orderEntry type="library" name="os-lib_3-<version>.jar" level="project"/>
         <orderEntry type="library" name="os-zip-0.11.6.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="plexus-archiver-4.10.1.jar" level="project"/>

--- a/integration/feature/gen-idea/resources/hello-idea/idea/mill_modules/mill-build.iml
+++ b/integration/feature/gen-idea/resources/hello-idea/idea/mill_modules/mill-build.iml
@@ -12,6 +12,7 @@
         <orderEntry type="inheritedJdk"/>
         <orderEntry type="sourceFolder" forTests="false"/>
         <orderEntry type="library" name="scala-SDK-<version>" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="JavaEWAH-1.2.3.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="aircompressor-0.27.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="cache-util-COURSIER_VERSION.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="commons-codec-1.19.0.jar" level="project"/>
@@ -64,8 +65,10 @@
         <orderEntry type="library" name="mill-libs-androidlib_3-SNAPSHOT.jar" level="project"/>
         <orderEntry type="library" name="mill-libs-daemon-client_3-SNAPSHOT.jar" level="project"/>
         <orderEntry type="library" name="mill-libs-daemon-server_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-libs-eclipse_3-SNAPSHOT.jar" level="project"/>
         <orderEntry type="library" name="mill-libs-groovylib-api_3-SNAPSHOT.jar" level="project"/>
         <orderEntry type="library" name="mill-libs-groovylib_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-libs-idea_3-SNAPSHOT.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="mill-libs-init_3-SNAPSHOT.jar" level="project"/>
         <orderEntry type="library" name="mill-libs-javalib-api_3-SNAPSHOT.jar" level="project"/>
         <orderEntry type="library" name="mill-libs-javalib-testrunner-entrypoint-SNAPSHOT.jar" level="project"/>
@@ -89,7 +92,10 @@
         <orderEntry type="library" name="mill-libs_3-SNAPSHOT.jar" level="project"/>
         <orderEntry type="library" name="mill-moduledefs_3-<version>.jar" level="project"/>
         <orderEntry type="library" name="mill-runner-autooverride-api_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-runner-eclipse_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-runner-idea_3-SNAPSHOT.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="native-terminal-no-ffm-0.0.9.1.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="org.eclipse.jgit-6.10.1.202505221210-r.jar" level="project"/>
         <orderEntry type="library" name="os-lib_3-<version>.jar" level="project"/>
         <orderEntry type="library" name="os-zip-0.11.6.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="plexus-archiver-4.10.1.jar" level="project"/>

--- a/libs/eclipse/package.mill
+++ b/libs/eclipse/package.mill
@@ -1,0 +1,13 @@
+package build.libs.eclipse
+
+import mill.*
+import millbuild.*
+
+/**
+ * Module for Eclipse project file generation.
+ * Contains the GenEclipse ExternalModule that loads the implementation reflectively.
+ */
+object `package` extends MillStableScalaModule {
+  def moduleDeps = Seq(build.core.api, build.libs.javalib)
+  def runModuleDeps = Seq(build.runner.eclipse)
+}

--- a/libs/eclipse/src/mill/eclipse/GenEclipse.scala
+++ b/libs/eclipse/src/mill/eclipse/GenEclipse.scala
@@ -1,0 +1,75 @@
+package mill.eclipse
+
+import mill.*
+import mill.api.{DefaultTaskModule, Discover, ExternalModule, PathRef, allEvaluatorsCommand}
+import mill.api.daemon.internal.{AllEvaluators, EvaluatorApi}
+import mill.javalib.{CoursierModule, Dep}
+
+/**
+ * Alias for mill.eclipse.GenEclipse to support `./mill mill.eclipse/` syntax.
+ */
+object `package` extends ExternalModule.Alias(GenEclipse)
+
+/**
+ * External module for generating Eclipse project files.
+ *
+ * This module uses the @allEvaluatorsCommand annotation to access evaluators
+ * from all bootstrap levels, enabling it to analyze modules across the entire
+ * build hierarchy.
+ *
+ * Usage:
+ * {{{
+ * ./mill mill.eclipse.GenEclipse/eclipse
+ * ./mill mill.eclipse.GenEclipse/
+ * ./mill mill.eclipse/
+ * }}}
+ */
+object GenEclipse extends ExternalModule with CoursierModule with DefaultTaskModule {
+
+  def defaultTask() = "eclipse"
+
+  /**
+   * Classpath for the GenEclipse worker implementation.
+   */
+  def workerClasspath: T[Seq[PathRef]] = Task {
+    defaultResolver().classpath(Seq(
+      Dep.millProjectModule("mill-runner-eclipse")
+    ))
+  }
+
+  /**
+   * Creates a classloader for the GenEclipse worker.
+   */
+  def workerClassLoader: Worker[ClassLoader & AutoCloseable] = Task.Worker {
+    mill.util.Jvm.createClassLoader(workerClasspath().map(_.path), getClass.getClassLoader)
+  }
+
+  /**
+   * Generates Eclipse project files for the current Mill build.
+   *
+   * This command analyzes all Java modules in the build and generates
+   * Eclipse project configuration including:
+   * - .project files
+   * - .classpath files
+   * - .settings directory with JDT preferences
+   */
+  @allEvaluatorsCommand
+  def eclipse(): Command[Unit] = Task.Command(exclusive = true) {
+    val evaluators = AllEvaluators.value
+    if (evaluators.isEmpty) {
+      throw new Exception(
+        "No evaluators available. The eclipse command requires access to build evaluators."
+      )
+    }
+
+    val cl = workerClassLoader()
+    val implClass = cl.loadClass("mill.eclipse.GenEclipseImpl")
+    val impl = implClass
+      .getConstructor(classOf[Seq[EvaluatorApi]])
+      .newInstance(evaluators)
+
+    implClass.getMethod("run").invoke(impl)
+  }
+
+  lazy val millDiscover: Discover = Discover[this.type]
+}

--- a/libs/idea/package.mill
+++ b/libs/idea/package.mill
@@ -1,0 +1,13 @@
+package build.libs.idea
+
+import mill.*
+import millbuild.*
+
+/**
+ * Module for IntelliJ IDEA project file generation.
+ * Contains the GenIdea ExternalModule that loads the implementation reflectively.
+ */
+object `package` extends MillStableScalaModule {
+  def moduleDeps = Seq(build.core.api, build.libs.javalib)
+  def runModuleDeps = Seq(build.runner.idea)
+}

--- a/libs/idea/src/mill/idea/GenIdea.scala
+++ b/libs/idea/src/mill/idea/GenIdea.scala
@@ -1,0 +1,76 @@
+package mill.idea
+
+import mill.*
+import mill.api.{DefaultTaskModule, Discover, ExternalModule, PathRef, allEvaluatorsCommand}
+import mill.api.daemon.internal.{AllEvaluators, EvaluatorApi}
+import mill.javalib.{CoursierModule, Dep}
+
+/**
+ * Alias for mill.idea.GenIdea to support `./mill mill.idea/` syntax.
+ */
+object `package` extends ExternalModule.Alias(GenIdea)
+
+/**
+ * External module for generating IntelliJ IDEA project files.
+ *
+ * This module uses the @allEvaluatorsCommand annotation to access evaluators
+ * from all bootstrap levels, enabling it to analyze modules across the entire
+ * build hierarchy.
+ *
+ * Usage:
+ * {{{
+ * ./mill mill.idea.GenIdea/idea
+ * ./mill mill.idea.GenIdea/
+ * ./mill mill.idea/
+ * }}}
+ */
+object GenIdea extends ExternalModule with CoursierModule with DefaultTaskModule {
+
+  def defaultTask() = "idea"
+
+  /**
+   * Classpath for the GenIdea worker implementation.
+   */
+  def workerClasspath: T[Seq[PathRef]] = Task {
+    defaultResolver().classpath(Seq(
+      Dep.millProjectModule("mill-runner-idea")
+    ))
+  }
+
+  /**
+   * Creates a classloader for the GenIdea worker.
+   */
+  def workerClassLoader: Worker[ClassLoader & AutoCloseable] = Task.Worker {
+    mill.util.Jvm.createClassLoader(workerClasspath().map(_.path), getClass.getClassLoader)
+  }
+
+  /**
+   * Generates IntelliJ IDEA project files for the current Mill build.
+   *
+   * This command analyzes all modules in the build (including meta-builds)
+   * and generates the appropriate .idea directory structure with:
+   * - Module files (.iml)
+   * - Library definitions
+   * - Compiler settings
+   * - Project settings
+   */
+  @allEvaluatorsCommand
+  def idea(): Command[Unit] = Task.Command(exclusive = true) {
+    val evaluators = AllEvaluators.value
+    if (evaluators.isEmpty) {
+      throw new Exception(
+        "No evaluators available. The idea command requires access to build evaluators."
+      )
+    }
+
+    val cl = workerClassLoader()
+    val implClass = cl.loadClass("mill.idea.GenIdeaImpl")
+    val impl = implClass
+      .getConstructor(classOf[Seq[EvaluatorApi]])
+      .newInstance(evaluators)
+
+    implClass.getMethod("run").invoke(impl)
+  }
+
+  lazy val millDiscover: Discover = Discover[this.type]
+}

--- a/libs/package.mill
+++ b/libs/package.mill
@@ -22,6 +22,8 @@ object `package` extends MillStableScalaModule {
 
   def runModuleDeps = Seq(
     build.libs.init,
-    build.libs.tabcomplete
+    build.libs.tabcomplete,
+    build.libs.idea,
+    build.libs.eclipse
   )
 }

--- a/runner/daemon/src/mill/daemon/MillMain0.scala
+++ b/runner/daemon/src/mill/daemon/MillMain0.scala
@@ -326,9 +326,8 @@ object MillMain0 {
                         val bootstrapped = runMillBootstrap(
                           skipSelectiveExecution = false,
                           Some(stateCache),
-                          Seq(
-                            "mill.tabcomplete.TabCompleteModule/complete"
-                          ) ++ config.leftoverArgs.value,
+                          Seq("mill.tabcomplete.TabCompleteModule/complete") ++
+                            config.leftoverArgs.value,
                           streams,
                           "tab-completion"
                         )

--- a/runner/daemon/src/mill/daemon/MillMain0.scala
+++ b/runner/daemon/src/mill/daemon/MillMain0.scala
@@ -441,38 +441,6 @@ object MillMain0 {
                         streams.err.println("Exiting BSP runner loop")
 
                         (!errored, RunnerState(None, Nil, None))
-                      } else if (
-                        config.leftoverArgs.value == Seq("mill.idea.GenIdea/idea") ||
-                        config.leftoverArgs.value == Seq("mill.idea.GenIdea/") ||
-                        config.leftoverArgs.value == Seq("mill.idea/")
-                      ) {
-                        val runnerState =
-                          runMillBootstrap(
-                            false,
-                            None,
-                            Seq("resolve", "_"),
-                            streams,
-                            "BSP:initialize"
-                          )
-                        new mill.idea.GenIdeaImpl(runnerState.frames.flatMap(_.evaluator))
-                          .run()
-                        (true, RunnerState(None, Nil, None))
-                      } else if (
-                        config.leftoverArgs.value == Seq("mill.eclipse.GenEclipse/eclipse") ||
-                        config.leftoverArgs.value == Seq("mill.eclipse.GenEclipse/") ||
-                        config.leftoverArgs.value == Seq("mill.eclipse/")
-                      ) {
-                        val runnerState =
-                          runMillBootstrap(
-                            false,
-                            None,
-                            Seq("resolve", "_"),
-                            streams,
-                            "BSP:initialize"
-                          )
-                        new mill.eclipse.GenEclipseImpl(runnerState.frames.flatMap(_.evaluator))
-                          .run()
-                        (true, RunnerState(None, Nil, None))
                       } else {
                         Watching.watchLoop(
                           ringBell = config.ringBell.value,


### PR DESCRIPTION
This PR is an extension of https://github.com/com-lihaoyi/mill/pull/6593, allowing the hardcoded `mill.idea/` and `mill.eclipse/` support to be removed from `MillMain0` and instead replaced by commands annotated with `@allEvaluatorsCommand`