### PR TITLE
Allow `init` to be run interactively

### DIFF
--- a/libs/init/src/mill/init/Giter8Module.scala
+++ b/libs/init/src/mill/init/Giter8Module.scala
@@ -37,7 +37,7 @@ trait Giter8Module extends CoursierModule {
       mainClass = "giter8.Giter8",
       classPath = giter8Dependencies.map(_.path).toVector,
       mainArgs = args,
-      cwd = BuildCtx.workspaceRoot,
+      cwd = BuildCtx.workspaceRoot
     )
   }
 }

--- a/testkit/src/mill/testkit/UnitTester.scala
+++ b/testkit/src/mill/testkit/UnitTester.scala
@@ -230,9 +230,8 @@ class UnitTester(
   def scoped[T](tester: UnitTester => T): T = {
     try {
       BuildCtx.workspaceRoot0.withValue(module.moduleDir) {
-        mill.api.daemon.LauncherSubprocess.withValue(
-          config =>
-            DaemonRpc.defaultRunSubprocess(DaemonRpc.ServerToClient.RunSubprocess(config)).exitCode
+        mill.api.daemon.LauncherSubprocess.withValue(config =>
+          DaemonRpc.defaultRunSubprocess(DaemonRpc.ServerToClient.RunSubprocess(config)).exitCode
         ) {
           tester(this)
         }


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/4596

Tested manually

```
lihaoyi test$  /Users/lihaoyi/Github/mill/mill-proguard.jar init com-lihaoyi/mill-scala-hello.g8
1] init
4] mill.init.Giter8Module/init Creating a new project...
3/4] mill init com-lihaoyi/mill-scala-hello.g8
4] mill.init.Giter8Module/init
2026-01-24 20:58:05 WARN  FS_POSIX:158 - 
A minimal Scala project built with Mill 

name [Scala Hello World]: test
package [example]: omg

1/1, SUCCESS] mill init com-lihaoyi/mill-scala-hello.g8 5s
lihaoyi test$ find .
.
./test
./test/build.sc
./test/test
./test/test/test
./test/test/test/src
./test/test/test/src/omg
./test/test/test/src/omg/HelloTest.scala
./test/test/src
./test/test/src/omg
./test/test/src/omg/Hello.scala
./test/.mill-version
```