### PR TITLE
Fix "`Anothing Mill process is running` message when using a single launcher with a single daemon"

### DIFF
--- a/libs/daemon/server/src/mill/server/Server.scala
+++ b/libs/daemon/server/src/mill/server/Server.scala
@@ -246,7 +246,7 @@ abstract class Server[Prepared, Handled](args: Server.Args) {
       @volatile var done = false
       @volatile var idle = false
 
-      val runThread = StartThread(connectionHandlerThreadName(clientSocket)) {
+      StartThread(connectionHandlerThreadName(clientSocket)) {
         try {
           val connResult =
             handleConnection(connectionData, closeServer(_, _, Some(data)), idle = _, data)


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/6684. The key fix is the `runThread.interrupt()` removal, which seems to result in complicated edge cases as the interrupt flag gets get and set by various random `java.io` and `java.nio` APIs that are impossible to keep track of. Instead, we just let the thread continue to run: 

- If the thread was not idle the process gets killed anyway, so interruption is unnecessary
- If the thread was idle, the watching logic reading from `RpcStdinInputStream` ends up failing and terminating the thread anyway

Tested by:

1. Publishing a local version with `./mill dist.native.installLocalCache`
2. Using it in `build.mill`
3. Running `while true; do ./mill version; done;` on one terminal
4. Starting `./mill -w core.api.compile` on a second terminal and stopping it with `Ctrl-C` repeatedly

Without this PR, sometimes when stopping the second terminal command the first terminal would briefly go into `Anothing Mill process is running` state. With this PR, only when *starting* the second terminal command does the first terminal go into `Anothing Mill process is running`, which is correct and what it should do