### PR TITLE
Fixes for `./mill init` download URLs

### DIFF
--- a/libs/init/src/mill/init/InitModule.scala
+++ b/libs/init/src/mill/init/InitModule.scala
@@ -40,9 +40,14 @@ trait InitModule extends Module {
               msg + "\n\n" + exampleIds.mkString("\n") + "\n\n" + msg
             if (showAll.value) (exampleIds, fullMessage(exampleIds))
             else {
-              val toShow = List("basic", "builds", "web")
+              val categoriesToShow = List("basic", "builds", "web")
+              val libsToHide = List("groovylib", "javascriptlib", "pythonlib")
               val filteredIds = exampleIds
-                .filter(_.split('/').lift.apply(1).exists(toShow.contains))
+                .filter { id =>
+                  val segments = id.split('/').lift
+                  segments(1).exists(categoriesToShow.contains) &&
+                  !segments(0).exists(libsToHide.contains)
+                }
 
               (filteredIds, fullMessage(filteredIds))
             }

--- a/mill-build/src/millbuild/MillPublishJavaModule.scala
+++ b/mill-build/src/millbuild/MillPublishJavaModule.scala
@@ -161,7 +161,12 @@ object MillPublishJavaModule {
             os.read(path).replace("millVersion=SNAPSHOT", s"millVersion=$millVersion")
           )
         } else if (path.last == "exampleList.txt") {
-          os.write.over(path, os.read(path).replace("/SNAPSHOT/", s"/$millVersion/"))
+          os.write.over(
+            path,
+            os.read(path)
+              .replace("/SNAPSHOT/", s"/$millVersion/")
+              .replace("-SNAPSHOT-", s"-$millVersion-")
+          )
         }
       }
     }


### PR DESCRIPTION
- Fix mangling of `-SNAPSHOT-` in the `exampleList.txt` resource file
- Skip Python/JS/Groovy in default example list since they are experimental, limit list to Java/Scala/Kotlin