### PR TITLE
Fix import of module-info-stripped jars in the Scala REPL

### DIFF
--- a/libs/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/libs/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -454,6 +454,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase
   /** Use `repl` instead */
   def console(@com.lihaoyi.unroll args: mill.api.Args = mill.api.Args()): Command[Unit] =
     repl(args.value*)
+
   /**
    * The classpath used to run the Scala console with [[console]].
    */


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/6730

It seems like the Scala REPL needs the jar entries on the classpath to end with `.jar`, whereas the module-info stripping logic generated a file ending with `-jar` instead which confused it.

Tested manually, this now passes where it previously failed

```scala
lihaoyi test$ ~/Github/mill/mill-assembly.jar  --import "org.commonmark:commonmark:0.26.0" repl
40] console
Welcome to Scala 3.8.1 (21.0.9, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                          
scala> import org.commonmark
                                                                                                                          
scala> 
```