### PR TITLE
Test selectiveInputs

### DIFF
--- a/libs/javascriptlib/src/mill/javascriptlib/TestModule.scala
+++ b/libs/javascriptlib/src/mill/javascriptlib/TestModule.scala
@@ -4,7 +4,7 @@ import mill.*
 import mill.api.BuildCtx
 
 trait TestModule extends DefaultTaskModule {
-
+  val y = 123
   import TestModule.TestResult
 
   def testForked(args: String*): Command[TestResult] =

--- a/libs/javascriptlib/src/mill/javascriptlib/TestModule.scala
+++ b/libs/javascriptlib/src/mill/javascriptlib/TestModule.scala
@@ -4,6 +4,7 @@ import mill.*
 import mill.api.BuildCtx
 
 trait TestModule extends DefaultTaskModule {
+
   import TestModule.TestResult
 
   def testForked(args: String*): Command[TestResult] =

--- a/runner/launcher/src/mill/launcher/MillLauncherMain.scala
+++ b/runner/launcher/src/mill/launcher/MillLauncherMain.scala
@@ -14,6 +14,7 @@ import java.time.{Instant, ZoneId}
  * Mill launcher main entry point.
  */
 object MillLauncherMain {
+
   def main(args: Array[String]): Unit = {
     System.exit(main0(args, None, sys.env, os.pwd))
   }

--- a/runner/launcher/src/mill/launcher/MillLauncherMain.scala
+++ b/runner/launcher/src/mill/launcher/MillLauncherMain.scala
@@ -14,7 +14,7 @@ import java.time.{Instant, ZoneId}
  * Mill launcher main entry point.
  */
 object MillLauncherMain {
-
+  val x = 123
   def main(args: Array[String]): Unit = {
     System.exit(main0(args, None, sys.env, os.pwd))
   }


### PR DESCRIPTION
- This PR should not run the Kotlin tests, despite touching `MillLauncherMain.scala`, because of `selectiveInputs`

- This PR should run the Javascript tests, because we touched `javascriptlib` source files directly