### PR TITLE
Fix `mill.tabcomplete/install` without a build file

### DIFF
--- a/runner/daemon/package.mill
+++ b/runner/daemon/package.mill
@@ -35,9 +35,15 @@ object `package` extends MillPublishScalaModule {
     build.core.eval,
     build.runner.server,
     build.runner.launcher,
-    build.runner.meta,
-    build.libs.script,
-    build.libs.init
+    build.runner.meta
+  )
+
+  def runModuleDeps = Seq(
+    // We don't use these, but they need to be on the classpath so we can access their classes
+    // and external modules at runtime even in the absence of a build.mill file or meta-build
+    build.libs.init,
+    build.libs.tabcomplete,
+    build.libs.script
   )
 
 }


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/6736

In the absence of a `build.mill` file, the `BootstrapRootModule` runs in the same classpath as the main daemon. This does not have `mill-libs` on the classpath, since the daemon doesn't need it, but previously we had already added `mill-libs-init` and `mill-libs-script` to give access to those classes. 

This PR additionally adds `mill-libs-tabcomplete`, and moves them to `runModuleDeps` since they're purely for use via runtime reflection and we don't need to compile against them. We already have `mill-libs-javalib` and `mill-libs-scalalib` on the classpath since we need to compile against them statically. We might need to add more stuff in future if other external modules turn out to be useful to run without a `build.mill` present.