### PR TITLE
Fix for `SerializedException.partialFrom` in the case of interleaved classloader and non-classloader exceptions

### DIFF
--- a/core/api/daemon/src/mill/api/daemon/Result.scala
+++ b/core/api/daemon/src/mill/api/daemon/Result.scala
@@ -175,8 +175,9 @@ object Result {
         val transformedCause = if (cause0 == null) null else transform(cause0)
 
         val result =
-          if (current.getClass.getClassLoader ne classLoader) current
-          else {
+          if ((current.getClass.getClassLoader ne classLoader) && (transformedCause eq cause0)) {
+            current
+          } else {
             new SerializedException(
               Result.Failure.ExceptionInfo(
                 current.getClass.getName,


### PR DESCRIPTION
> The current implementation only uses the transformed cause when it also replaces the current
> exception. If the current exception’s classloader is not the target, it returns the original exception object as-is and
> drops the transformed cause.
>
> In Result.SerializedException.partialFrom, the key line is:
>
> val result =
>   if (current.getClass.getClassLoader ne classLoader) current
>   else new SerializedException(..., transformedCause)
>
> So for a wrapper exception from a different classloader (e.g. InvocationTargetException from the bootstrap loader) that
> wraps a classloader-defined exception, you transform the child, but then return the original wrapper with its original
> (unsanitized) cause. The sanitized child is computed but never attached.
>
> Example chain:
>
> - InvocationTargetException (bootstrap loader)
>     - cause: FooException (from the short-lived classloader)
>
> FooException gets replaced, but InvocationTargetException is returned unchanged, so its cause still points at the
> original FooException, which can still blow up after the classloader closes.
>