### PR TITLE
Add -H:-ParseRuntimeOptions to native image options

### DIFF
--- a/dist/package.mill
+++ b/dist/package.mill
@@ -516,7 +516,10 @@ object `package` extends MillJavaModule with Proguard with DistModule {
       // Set UTF-8 encoding to fix Unicode character display issues on Windows
       "-Dfile.encoding=UTF-8",
       "-Dsun.stdout.encoding=UTF-8",
-      "-Dsun.stderr.encoding=UTF-8"
+      "-Dsun.stderr.encoding=UTF-8",
+      // Prevent Native Image runtime from consuming runtime options like -D<key>=<value>
+      // https://github.com/com-lihaoyi/mill/issues/6770
+      "-H:-ParseRuntimeOptions"
       // Enable JVisualVM support
       // https://www.graalvm.org/latest/tools/visualvm/#using-visualvm-with-graalvm-native-executables
       // "--enable-monitoring=jvmstat,heapdump"


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/6770

I tested this on my M2 Pro Macbook Pro and confirmed it fixes the issue with propagating `-D<key>=<foo>` arguments to Scalatest.