### PR TITLE
Silence noisy logback error

### DIFF
--- a/dist/package.mill
+++ b/dist/package.mill
@@ -517,9 +517,12 @@ object `package` extends MillJavaModule with Proguard with DistModule {
       "-Dfile.encoding=UTF-8",
       "-Dsun.stdout.encoding=UTF-8",
       "-Dsun.stderr.encoding=UTF-8",
-      // Skip logback version check to avoid NPE in native image during manifest reading
+      // Include logback version properties files (added in logback 1.5.26, see https://logback.qos.ch/news.html)
+      // to avoid NPE in VersionUtil.checkForVersionEquality during logback initialization in native image
+      // https://www.graalvm.org/latest/reference-manual/native-image/guides/include-resources/
       // https://github.com/com-lihaoyi/mill/issues/6777
-      "-Dlogback.skipVersionCheck=true",
+      """-H:IncludeResources=ch/qos/logback/.*/logback-.*-version\.properties""",
+      """-H:-ReduceImplicitExceptionStackTraceInformation""",
       // Prevent Native Image runtime from consuming runtime options like -D<key>=<value>
       // https://github.com/com-lihaoyi/mill/issues/6770
       "-H:-ParseRuntimeOptions"


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/6777

Tested manually by building the native image locally and forcing coursier to download stuff:

```console
> ./mill dist.native.installLocal 
> rm -rf ~/Library/Caches/Coursier 
> ./mill-native version  
```

Without this PR we get the spurious error, with this PR we do not