### PR TITLE
Fix "Scala Native linking crash when setting `SourceLevelDebuggingConfig.Enabled`"

### DIFF
--- a/libs/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
+++ b/libs/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
@@ -53,10 +53,16 @@ trait ScalaNativeModule extends ScalaModule with ScalaNativeModuleApi { outer =>
       case v @ ("0.4.0" | "0.4.1") =>
         Result.Failure(s"Scala Native $v is not supported. Please update to 0.4.2+")
       case version =>
+        // Workaround for https://github.com/com-lihaoyi/mill/issues/6780:
+        // Scala Native `tools_3` 0.5.10 can crash during linking when
+        // `SourceLevelDebuggingConfig` is enabled.
+        //
+        // Using the Scala 2.13 published toolchain artifacts avoids the issue and is
+        // compatible with Mill's Scala 3 runtime (Scala 3 uses the 2.13 standard library).
         Result.Success(
           Seq(
-            mvn"org.scala-native::tools:$version",
-            mvn"org.scala-native::test-runner:$version"
+            mvn"org.scala-native:tools_2.13:$version",
+            mvn"org.scala-native:test-runner_2.13:$version"
           )
         )
 

--- a/libs/scalanativelib/test/src/mill/scalanativelib/SourceLevelDebuggingTests.scala
+++ b/libs/scalanativelib/test/src/mill/scalanativelib/SourceLevelDebuggingTests.scala
@@ -1,0 +1,39 @@
+package mill.scalanativelib
+
+import mill.given
+import mill.api.Discover
+import mill.scalanativelib.api.SourceLevelDebuggingConfig
+import mill.testkit.UnitTester
+import mill.testkit.TestRootModule
+import utest.*
+
+object SourceLevelDebuggingTests extends TestSuite {
+
+  object SourceLevelDebuggingDisabled extends TestRootModule with ScalaNativeModule {
+    def scalaNativeVersion = "0.5.10"
+    def scalaVersion = "3.3.7"
+    def nativeSourceLevelDebuggingConfig = SourceLevelDebuggingConfig.Disabled
+    override lazy val millDiscover = Discover[this.type]
+  }
+
+  object SourceLevelDebuggingEnabled extends TestRootModule with ScalaNativeModule {
+    def scalaNativeVersion = "0.5.10"
+    def scalaVersion = "3.3.7"
+    def nativeSourceLevelDebuggingConfig = SourceLevelDebuggingConfig.Enabled()
+    override lazy val millDiscover = Discover[this.type]
+  }
+
+  val millSourcePath = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "features"
+
+  val tests: Tests = Tests {
+    test("nativeLink works with source-level debugging disabled") -
+      UnitTester(SourceLevelDebuggingDisabled, millSourcePath).scoped { eval =>
+        val Right(_) = eval(SourceLevelDebuggingDisabled.nativeLink).runtimeChecked
+      }
+
+    test("nativeLink works with source-level debugging enabled") -
+      UnitTester(SourceLevelDebuggingEnabled, millSourcePath).scoped { eval =>
+        val Right(_) = eval(SourceLevelDebuggingEnabled.nativeLink).runtimeChecked
+      }
+  }
+}

--- a/mill-build/src/millbuild/Deps.scala
+++ b/mill-build/src/millbuild/Deps.scala
@@ -44,10 +44,12 @@ object Deps {
 
   object Scalanative_0_5 {
     val scalanativeVersion = "0.5.10"
-    val scalanativeTools = mvn"org.scala-native::tools:${scalanativeVersion}"
-    val scalanativeUtil = mvn"org.scala-native::util:${scalanativeVersion}"
-    val scalanativeNir = mvn"org.scala-native::nir:${scalanativeVersion}"
-    val scalanativeTestRunner = mvn"org.scala-native::test-runner:${scalanativeVersion}"
+    // Workaround for https://github.com/com-lihaoyi/mill/issues/6780:
+    // prefer Scala 2.13 published toolchain artifacts.
+    val scalanativeTools = mvn"org.scala-native:tools_2.13:${scalanativeVersion}"
+    val scalanativeUtil = mvn"org.scala-native:util_2.13:${scalanativeVersion}"
+    val scalanativeNir = mvn"org.scala-native:nir_2.13:${scalanativeVersion}"
+    val scalanativeTestRunner = mvn"org.scala-native:test-runner_2.13:${scalanativeVersion}"
   }
 
   trait Play {


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/6780. Vibe coded, I have no idea why using the `_2.13` jars is necessary, and neither does codex it seems. But it does make the stack trace and hang go away