### PR TITLE
Add JPMS Support

### DIFF
--- a/example/package.mill
+++ b/example/package.mill
@@ -416,6 +416,7 @@ $frontMatter
     "mockito" -> ("mockito/mockito", "97f3574cc07fdf36f1f76ba7332ac57675e140b1"),
     "gatling" -> ("gatling/gatling", "3870fda86e6bca005fbd53108c60a65db36279b6"),
     "arrow" -> ("arrow-kt/arrow", "bc9bf92cc98e01c21bdd2bf8640cf7db0f97204a"),
+    "jdata" -> ("asarkar/jdata", "89faaa7d433c37ad0271e801d66e177aac6605a4"),
     "ollama-js" -> ("ollama/ollama-js", "99293abe2c7c27ce7e76e8b4a98cae948f00058d"),
     "androidtodo" -> ("android/architecture-samples", "b3437ab428f6fd91804b28801650d590ff52971c"),
     "android-endless-tunnel" -> ("android/ndk-samples", "46ac919196faf1efcfe8018a0dcc79d4f8fbeca7"),

--- a/libs/javalib/src/mill/javalib/JavaModule.scala
+++ b/libs/javalib/src/mill/javalib/JavaModule.scala
@@ -1063,12 +1063,12 @@ trait JavaModule
    * All classfiles and resources from upstream modules and dependencies
    * necessary to compile this module.
    */
-  private lazy val compileClasspathTaskRegular: Task[Seq[PathRef]] = Task.Anon {
+  private def compileClasspathTaskRegular: T[Seq[PathRef]] = Task {
     resolvedMvnDeps() ++
       transitiveCompileClasspathTask(CompileFor.Regular)() ++
       localCompileClasspath()
   }
-  private lazy val compileClasspathTaskSemanticDb: Task[Seq[PathRef]] = Task.Anon {
+  private def compileClasspathTaskSemanticDb: T[Seq[PathRef]] = Task {
     resolvedMvnDeps() ++
       transitiveCompileClasspathTask(CompileFor.SemanticDb)() ++
       localCompileClasspath()

--- a/libs/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/libs/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -323,7 +323,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase
         |For details, see: https://github.com/sbt/zinc/issues/1010""".stripMargin
     )
 
-    val jOpts = JavaCompilerOptions.split(javacOptions() ++ mandatoryJavacOptions())
+    val jOpts = JavaCompilerOptions.split(javacOptions() ++ jpmsJavacOptions() ++ mandatoryJavacOptions())
 
     val worker = jvmWorker().internalWorker()
 
@@ -673,7 +673,10 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase
       )
         .filterNot(_ == "-Xfatal-warnings")
 
-      val javacOpts = SemanticDbJavaModule.javacOptionsTask(javacOptions(), semanticDbJavaVersion())
+      val javacOpts = SemanticDbJavaModule.javacOptionsTask(
+        javacOptions() ++ jpmsJavacOptionsFor(CompileFor.SemanticDb)() ++ mandatoryJavacOptions(),
+        semanticDbJavaVersion()
+      )
 
       Task.log.debug(s"effective scalac options: ${scalacOptions}")
       Task.log.debug(s"effective javac options: ${javacOpts}")

--- a/libs/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/libs/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -323,7 +323,8 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase
         |For details, see: https://github.com/sbt/zinc/issues/1010""".stripMargin
     )
 
-    val jOpts = JavaCompilerOptions.split(javacOptions() ++ jpmsJavacOptions() ++ mandatoryJavacOptions())
+    val jOpts =
+      JavaCompilerOptions.split(javacOptions() ++ jpmsJavacOptions() ++ mandatoryJavacOptions())
 
     val worker = jvmWorker().internalWorker()
 


### PR DESCRIPTION
  - JPMS compile support: if module-info.java exists, infer javac --module-path from the module’s compile classpath (unless user already set --module-path/-p), and apply it to
    normal + SemanticDB compilation.
  - Thirdparty suite repo list: add jdata entry in example/package.mill.
