### PR TITLE
Automate more of Sonatype setup

### DIFF
--- a/integration/feature/init-gpg-publish/src/InitGpgPublishTests.scala
+++ b/integration/feature/init-gpg-publish/src/InitGpgPublishTests.scala
@@ -5,48 +5,109 @@ import mill.testkit.UtestIntegrationTestSuite
 import mill.testkit.internal.SonatypeCentralTestUtils
 import utest.*
 
+import com.sun.net.httpserver.{HttpExchange, HttpHandler, HttpServer}
+import java.net.InetSocketAddress
+
 object InitGpgPublishTests extends UtestIntegrationTestSuite {
-  private def extractExportValue(output: String, name: String): String =
-    (s"(?m)^export ${java.util.regex.Pattern.quote(name)}=(.*)$$").r
-      .findFirstMatchIn(output)
-      .map(_.group(1).trim)
-      .getOrElse("")
+
+  private def withMockKeyserver[T](f: String => T): T = {
+    val server = HttpServer.create(new InetSocketAddress(0), 0)
+    var uploadedKey: Option[String] = None
+
+    server.createContext(
+      "/pks/add",
+      new HttpHandler {
+        def handle(exchange: HttpExchange): Unit = {
+          val reqBody = exchange.getRequestBody
+          val body =
+            try new String(reqBody.readAllBytes(), "UTF-8")
+            finally reqBody.close()
+          uploadedKey = Some(body)
+          exchange.sendResponseHeaders(200, 0)
+          exchange.getResponseBody.close()
+        }
+      }
+    )
+
+    server.createContext(
+      "/pks/lookup",
+      new HttpHandler {
+        def handle(exchange: HttpExchange): Unit = {
+          val response = uploadedKey match {
+            case Some(key) if key.contains("keytext=") =>
+              val decoded = java.net.URLDecoder.decode(
+                key.split("keytext=")(1),
+                "UTF-8"
+              )
+              decoded
+            case _ =>
+              "Not Found"
+          }
+          val responseBytes = response.getBytes("UTF-8")
+          exchange.sendResponseHeaders(200, responseBytes.length)
+          exchange.getResponseBody.write(responseBytes)
+          exchange.getResponseBody.close()
+        }
+      }
+    )
+
+    server.start()
+    val port = server.getAddress.getPort
+    try f(s"http://localhost:$port")
+    finally server.stop(0)
+  }
 
   private def initGpgKeysSmokeTest(): Unit = integrationTest { tester =>
     import tester.*
 
-    val res = eval(
-      "mill.javalib.SonatypeCentralPublishModule/initGpgKeys",
-      stdin = Seq(
-        "Mill Test User\n",
-        "mill-test-user@example.com\n",
-        "mill-test-passphrase\n"
-      ).mkString,
-      mergeErrIntoOut = true
-    )
-    println(res.debugString)
-    assert(res.isSuccess)
+    withMockKeyserver { keyserverUrl =>
+      val res = eval(
+        Seq(
+          "mill.javalib.SonatypeCentralPublishModule/initGpgKeys",
+          "--keyserverUrl",
+          keyserverUrl
+        ),
+        stdin = Seq(
+          "Mill Test User\n",
+          "mill-test-user@example.com\n",
+          "mill-test-passphrase\n"
+        ).mkString,
+        mergeErrIntoOut = true
+      )
+      println(res.debugString)
+      assert(res.isSuccess)
 
-    val output = res.out
-    assert(output.contains("PGP Key Setup for Sonatype Central Publishing"))
-    assert(output.contains("PGP key generated successfully"))
-    assert(output.contains("Key verified on keyserver!"))
-    val secretBase64 = extractExportValue(output, "MILL_PGP_SECRET_BASE64")
-    val passphrase = extractExportValue(output, "MILL_PGP_PASSPHRASE")
-    assert(secretBase64.nonEmpty)
-    assert(passphrase == "mill-test-passphrase")
+      val output = res.out
+      assert(output.contains("PGP Key Setup for Sonatype Central Publishing"))
+      assert(output.contains("PGP key generated successfully"))
+      assert(output.contains("Key verified on keyserver!"))
+      assert(output.contains("Local Shell Configuration"))
+      assert(output.contains("GitHub Actions"))
+      assert(output.contains("MILL_PGP_SECRET_BASE64"))
+      assert(output.contains("MILL_SONATYPE_USERNAME"))
 
-    dryRunWithKey(
-      tester,
-      Seq(
-        "mill.javalib.SonatypeCentralPublishModule/publishAll",
-        "--publishArtifacts",
-        "testProject.publishArtifacts"
-      ),
-      "mill.javalib.SonatypeCentralPublishModule/publishAll.dest",
-      secretBase64,
-      Some(passphrase)
-    )
+      val armoredKey = os.read(
+        workspacePath / "out" / "mill.javalib.SonatypeCentralPublishModule" /
+          "initGpgKeys.dest" / "pgp-private-key.asc"
+      ).trim
+      assert(armoredKey.contains("BEGIN PGP PRIVATE KEY BLOCK"))
+
+      val secretBase64 =
+        java.util.Base64.getEncoder.encodeToString(armoredKey.getBytes("UTF-8"))
+      val passphrase = "mill-test-passphrase"
+
+      dryRunWithKey(
+        tester,
+        Seq(
+          "mill.javalib.SonatypeCentralPublishModule/publishAll",
+          "--publishArtifacts",
+          "testProject.publishArtifacts"
+        ),
+        "mill.javalib.SonatypeCentralPublishModule/publishAll.dest",
+        secretBase64,
+        Some(passphrase)
+      )
+    }
   }
 
   val tests: Tests = Tests {

--- a/libs/javalib/package.mill
+++ b/libs/javalib/package.mill
@@ -55,7 +55,8 @@ object `package` extends MillStableScalaModule {
       // This was `private[mill]`, package private doesn't have the JVM bytecode equivalent, so mima can't check it.
       ProblemFilter.exclude[Problem]("mill.javalib.PublishModule.checkSonatypeCreds"),
       ProblemFilter.exclude[Problem]("mill.javalib.publish.SonatypeHelpers.getArtifactMappings"),
-      ProblemFilter.exclude[Problem]("mill.javalib.publish.PublishInfo.parseFromFile")
+      ProblemFilter.exclude[Problem]("mill.javalib.publish.PublishInfo.parseFromFile"),
+      ProblemFilter.exclude[Problem]("mill.javalib.SonatypeCentralPublishModule.initGpgKeys")
     )
 
   object backgroundwrapper extends MillPublishJavaModule with MillJavaModule {
@@ -150,7 +151,7 @@ object `package` extends MillStableScalaModule {
   }
 
   object `pgp-worker` extends MillPublishScalaModule with MillJava11ScalaModule {
-    def moduleDeps = Seq(api)
+    def moduleDeps = Seq(api, build.libs.util.java11)
     def mvnDeps = Seq(
       Deps.bouncyCastleProv,
       Deps.bouncyCastlePgp,

--- a/libs/javalib/pgp-worker/src/mill/javalib/pgp/worker/MillInitGpgKeysMain.scala
+++ b/libs/javalib/pgp-worker/src/mill/javalib/pgp/worker/MillInitGpgKeysMain.scala
@@ -1,13 +1,35 @@
 package mill.javalib.pgp.worker
 
 import mill.javalib.api.PgpKeyMaterial
+import mill.util.ShellConfiguration
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path, Paths, StandardOpenOption}
 
 object MillInitGpgKeysMain {
+
+  class UserAbortException extends RuntimeException("User aborted")
+
+  private val DefaultKeyserverUrl = "https://keyserver.ubuntu.com"
+
   def main(args: Array[String]): Unit = {
     val outputSecretPath = extractArg(args, "--output-secret")
+    val detectedName = extractArg(args, "--name")
+    val detectedEmail = extractArg(args, "--email")
+    val detectedUrl = extractArg(args, "--url")
+    val keyserverUrl = extractArg(args, "--keyserver-url").getOrElse(DefaultKeyserverUrl)
+
+    try run(outputSecretPath, detectedName, detectedEmail, detectedUrl, keyserverUrl)
+    catch { case _: UserAbortException => println("\nAborted.") }
+  }
+
+  private def run(
+      outputSecretPath: Option[String],
+      detectedName: Option[String],
+      detectedEmail: Option[String],
+      detectedUrl: Option[String],
+      keyserverUrl: String
+  ): Unit = {
     println("=== PGP Key Setup for Sonatype Central Publishing ===")
     println("")
     println("This will create a new PGP key pair for signing your artifacts.")
@@ -15,25 +37,28 @@ object MillInitGpgKeysMain {
     println("  - Your real name")
     println("  - Your email address")
     println("  - A passphrase to protect your key")
+    println("(Type \"q\" at any prompt to abort)")
     println("")
     println("Step 1: Generating PGP key pair...")
-    def prompt(label: String): String = {
-      print(label)
+    def prompt(label: String, hint: Option[String]): String = {
+      val promptText = hint match {
+        case Some(h) => s"$label[$h]: "
+        case None => label
+      }
+      print(promptText)
       System.out.flush()
-      scala.io.StdIn.readLine()
+      val input = readLineOrAbort()
+      if (input.trim.isEmpty) hint.getOrElse("") else input.trim
     }
 
-    val name = prompt("Enter your name: ")
-    val email = prompt("Enter your email: ")
+    val name = prompt("Enter your name: ", detectedName)
+    val email = prompt("Enter your email: ", detectedEmail)
 
     print("Enter passphrase (leave empty for no passphrase): ")
     System.out.flush()
-    val passphrase = System.console() match {
-      case null => scala.io.StdIn.readLine()
-      case console => new String(console.readPassword())
-    }
+    val passphrase = readPasswordOrEmpty()
 
-    if (passphrase == null || passphrase.isEmpty) {
+    if (passphrase.isEmpty) {
       System.err.println("Warning: Empty passphrase provided")
     }
 
@@ -51,11 +76,91 @@ object MillInitGpgKeysMain {
     println(s"Generated key ID: $keyId")
     println("")
 
-    // Step 2: Upload public key to keyserver
-    println("Step 2: Uploading public key to keyserver.ubuntu.com...")
+    println(s"Step 2: Uploading public key to $keyserverUrl...")
+    uploadAndVerifyKey(generated, keyId, keyserverUrl)
+    println("")
+
+    val secretKeyBase64 =
+      java.util.Base64.getEncoder.encodeToString(generated.secretKeyArmored.getBytes("UTF-8"))
+
+    outputSecretPath.foreach { pathString =>
+      val secretPath = Paths.get(pathString)
+      writeString(secretPath, generated.secretKeyArmored)
+      println(s"The generated PGP secret key has been saved to:")
+      println(s"  ${secretPath.toAbsolutePath}")
+      println("")
+    }
+
+    println("")
+    println("=== Setup Complete! ===")
+    println("")
+
+    printLocalShellInstructions(secretKeyBase64)
+
+    val sonatypeCredentials = promptSonatypeCredentials()
+
+    offerShellConfigSetup(secretKeyBase64, passphrase, sonatypeCredentials)
+
+    val remoteUrl = detectRemoteUrl(detectedUrl)
+    val repoSlug = remoteUrl.flatMap(parseGitHubSlug)
+    val isGitHub = remoteUrl.forall(url =>
+      url.contains("github.com") || parseGitHubSlug(url).isDefined
+    )
+
+    if (isGitHub) {
+      printGitHubActionsInstructions()
+      offerGitHubSecretUpload(repoSlug, secretKeyBase64, passphrase, sonatypeCredentials)
+      printWorkflowYaml(passphrase)
+    }
+  }
+
+  private def readLineOrEmpty(): String = {
+    val line = scala.io.StdIn.readLine()
+    if (line == null) "" else line
+  }
+
+  private def readLineOrAbort(): String = {
+    val line = readLineOrEmpty()
+    if (line.trim.toLowerCase == "q" || line.trim.toLowerCase == "quit")
+      throw new UserAbortException
+    line
+  }
+
+  private def readPasswordOrEmpty(): String = {
+    System.console() match {
+      case null => readLineOrEmpty()
+      case console =>
+        val chars = console.readPassword()
+        if (chars == null) "" else new String(chars)
+    }
+  }
+
+  private def promptSonatypeCredentials(): Option[(String, String)] = {
+    print(
+      "Enter Sonatype username (from https://central.sonatype.com/usertoken, or press Enter to skip): "
+    )
+    System.out.flush()
+    readLineOrAbort().trim match {
+      case "" => None
+      case username =>
+        print("Enter Sonatype password: ")
+        System.out.flush()
+        val password = readPasswordOrEmpty()
+        if (password.isEmpty) None
+        else Some((username, password))
+    }
+  }
+
+  private val MaxKeyserverRetries = 10
+
+  private def uploadAndVerifyKey(
+      generated: PgpKeyMaterial,
+      keyId: String,
+      keyserverUrl: String
+  ): Unit = {
     try {
       val uploadResult = requests.post(
-        url = "https://keyserver.ubuntu.com/pks/add",
+        url = s"$keyserverUrl/pks/add",
         data = Map("keytext" -> generated.publicKeyArmored)
       )
 
@@ -63,24 +168,26 @@ object MillInitGpgKeysMain {
       else {
         System.err.println(
           s"Warning: Failed to upload key to keyserver (status ${uploadResult.statusCode}).\n" +
-            "You may need to upload manually via https://keyserver.ubuntu.com/pks/add"
+            s"You may need to upload manually via $keyserverUrl/pks/add"
         )
       }
     } catch {
-      case e: Exception =>
+      case e: java.io.IOException =>
+        System.err.println(s"Warning: Failed to upload key to keyserver: ${e.getMessage}")
+      case e: requests.RequestFailedException =>
         System.err.println(s"Warning: Failed to upload key to keyserver: ${e.getMessage}")
     }
     println("")
 
-    // Step 3: Verify key was uploaded
     println("Step 3: Verifying key upload...")
-    val deadline = System.currentTimeMillis() + 60000
     var verified = false
     var lastError: Option[String] = None
-    while (!verified && System.currentTimeMillis() < deadline) {
+    var attempt = 0
+    while (!verified && attempt < MaxKeyserverRetries) {
+      attempt += 1
       try {
         val verifyResult = requests.get(
-          url = "https://keyserver.ubuntu.com/pks/lookup",
+          url = s"$keyserverUrl/pks/lookup",
           params = Map("op" -> "get", "search" -> s"0x$keyId")
         )
 
@@ -88,14 +195,15 @@ object MillInitGpgKeysMain {
           verified = true
         else {
           lastError = Some(
-            s"Request to https://keyserver.ubuntu.com/pks/lookup failed with status code ${verifyResult.statusCode}"
+            s"Request to $keyserverUrl/pks/lookup failed with status code ${verifyResult.statusCode}"
           )
         }
       } catch {
-        case e: Exception => lastError = Some(e.getMessage)
+        case e: java.io.IOException => lastError = Some(e.getMessage)
+        case e: requests.RequestFailedException => lastError = Some(e.getMessage)
       }
 
-      if (!verified) Thread.sleep(2000)
+      if (!verified && attempt < MaxKeyserverRetries) Thread.sleep(2000)
     }
 
     if (verified) println("Key verified on keyserver!")
@@ -106,50 +214,191 @@ object MillInitGpgKeysMain {
         "This may be due to keyserver propagation delay. Try again later with:"
       )
       System.err.println(
-        s"  https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x$keyId"
+        s"  $keyserverUrl/pks/lookup?op=get&search=0x$keyId"
       )
     }
+  }
+
+  private def printLocalShellInstructions(secretKeyBase64: String): Unit = {
+    println("--- Local Shell Configuration ---")
+    println("To publish from your shell, set these environment variables:")
+    println("  export MILL_PGP_SECRET_BASE64=<base64 encoded key>")
+    println("  export MILL_PGP_PASSPHRASE=<passphrase>")
+    println("  export MILL_SONATYPE_USERNAME=<from https://central.sonatype.com/usertoken>")
+    println("  export MILL_SONATYPE_PASSWORD=<from https://central.sonatype.com/usertoken>")
     println("")
+    println(
+      s"Note: MILL_PGP_SECRET_BASE64 is ${secretKeyBase64.length} characters when base64 encoded."
+    )
+    println("Some shells may have issues with very long values in config files.")
+    println("")
+  }
 
-    // Base64 encode the key (without newlines for environment variable)
-    val secretKeyBase64 =
-      java.util.Base64.getEncoder.encodeToString(generated.secretKeyArmored.getBytes("UTF-8"))
+  private def offerShellConfigSetup(
+      secretKeyBase64: String,
+      passphrase: String,
+      sonatypeCredentials: Option[(String, String)]
+  ): Unit = {
+    val shells = ShellConfiguration.installed
+    if (shells.isEmpty) return
 
-    outputSecretPath.foreach { pathString =>
-      val secretPath = Paths.get(pathString)
-      writeString(secretPath, generated.secretKeyArmored)
-      println("")
-      println(s"Saved secret key to: ${secretPath.toAbsolutePath}")
-      println("To store it in your home directory for manual use, you can import it into GnuPG:")
-      println(s"  gpg --import ${secretPath.toAbsolutePath}")
+    val envVars: Seq[(String, String, String)] = Seq(
+      ("MILL_PGP_SECRET_BASE64", secretKeyBase64, "<generated key>"),
+      ("MILL_PGP_PASSPHRASE", passphrase, "<passphrase>")
+    ) ++ sonatypeCredentials.map { case (u, _) =>
+      ("MILL_SONATYPE_USERNAME", u, "<sonatype username>")
+    }.toSeq ++ sonatypeCredentials.map { case (_, p) =>
+      ("MILL_SONATYPE_PASSWORD", p, "<sonatype password>")
+    }.toSeq
+
+    println("")
+    println("The following shell configurations were detected:")
+    println("")
+    shells.zipWithIndex.foreach { case (shell, idx) =>
+      println(s"  [${idx + 1}] ${shell.configPath}")
+      envVars.foreach { case (envName, _, placeholder) =>
+        println(s"      ${shell.formatEnvVar(envName, placeholder)}")
+      }
       println("")
     }
 
+    print("Enter numbers to update (e.g. \"1 2\"), or press Enter to skip: ")
+    System.out.flush()
+    val input = readLineOrAbort()
+    if (input.trim.nonEmpty) {
+      val indices = input.trim.split("\\s+").flatMap(s => scala.util.Try(s.toInt - 1).toOption)
+      val envPairs = envVars.map { case (envName, value, _) => (envName, value) }
+      for (idx <- indices if idx >= 0 && idx < shells.length) {
+        val shell = shells(idx)
+        val diff = shell.previewUpsert(envPairs)
+        if (diff.nonEmpty) {
+          println(s"Changes to ${shell.configPath}:")
+          println(diff)
+        }
+      }
+      print("Apply these changes? [y/N]: ")
+      System.out.flush()
+      val confirm = readLineOrAbort()
+      if (confirm.trim.toLowerCase.startsWith("y")) {
+        for (idx <- indices if idx >= 0 && idx < shells.length) {
+          val shell = shells(idx)
+          envVars.foreach { case (envName, value, _) =>
+            shell.upsertEnvVar(envName, value)
+          }
+          println(s"  Updated ${shell.configPath}")
+        }
+      }
+      println("")
+    }
+  }
+
+  private def detectRemoteUrl(detectedRepoUrl: Option[String]): Option[String] = {
+    detectRemoteUrlFromGit().orElse(detectedRepoUrl)
+  }
+
+  private def detectRemoteUrlFromGit(): Option[String] = {
+    try {
+      val result = os.proc("git", "remote", "get-url", "origin")
+        .call(mergeErrIntoOut = true, check = false)
+      if (result.exitCode == 0) Some(result.out.text().trim).filter(_.nonEmpty)
+      else None
+    } catch {
+      case _: java.io.IOException => None
+    }
+  }
+
+  private def parseGitHubSlug(url: String): Option[String] = {
+    val httpsPattern = """https?://github\.com/([^/]+/[^/]+?)(?:\.git)?/?$""".r
+    val sshPattern = """git@github\.com:([^/]+/[^/]+?)(?:\.git)?$""".r
+    url match {
+      case httpsPattern(slug) => Some(slug)
+      case sshPattern(slug) => Some(slug)
+      case _ => None
+    }
+  }
+
+  private def printGitHubActionsInstructions(): Unit = {
+    println("--- GitHub Actions ---")
+    println("To publish from GitHub Actions, add these repository secrets:")
+    println("  MILL_PGP_SECRET_BASE64 = <base64 key>")
+    println("  MILL_PGP_PASSPHRASE = <passphrase>")
+    println("  MILL_SONATYPE_USERNAME = <from https://central.sonatype.com/usertoken>")
+    println("  MILL_SONATYPE_PASSWORD = <from https://central.sonatype.com/usertoken>")
     println("")
-    println("=== Setup Complete! ===")
+  }
+
+  private def offerGitHubSecretUpload(
+      repoSlug: Option[String],
+      secretKeyBase64: String,
+      passphrase: String,
+      sonatypeCredentials: Option[(String, String)]
+  ): Unit = {
+    if (!ShellConfiguration.findOnPath("gh")) return
+
+    val ghAuthenticated =
+      try {
+        os.proc("gh", "auth", "status").call(mergeErrIntoOut = true, check = false).exitCode == 0
+      } catch {
+        case _: java.io.IOException => false
+      }
+    if (!ghAuthenticated) return
+
+    val repo = repoSlug match {
+      case Some(slug) => slug
+      case None =>
+        print("Enter GitHub repo (org/repo): ")
+        System.out.flush()
+        val input = readLineOrAbort().trim
+        if (input.isEmpty) return
+        input
+    }
+
+    println(s"The following secrets will be uploaded to $repo:")
+    println("  MILL_PGP_SECRET_BASE64 = <generated key>")
+    if (passphrase.nonEmpty) println("  MILL_PGP_PASSPHRASE = <passphrase>")
+    sonatypeCredentials.foreach { _ =>
+      println("  MILL_SONATYPE_USERNAME = <provided>")
+      println("  MILL_SONATYPE_PASSWORD = <provided>")
+    }
+    if (sonatypeCredentials.isEmpty) {
+      println("  MILL_SONATYPE_USERNAME = <not provided, skipping>")
+      println("  MILL_SONATYPE_PASSWORD = <not provided, skipping>")
+    }
+    print(s"Upload these secrets to GitHub ($repo) now? [y/N]: ")
+    System.out.flush()
+    val confirm = readLineOrAbort()
+    if (!confirm.trim.toLowerCase.startsWith("y")) return
+
+    ghSecretSet(repo, "MILL_PGP_SECRET_BASE64", secretKeyBase64)
+    if (passphrase.nonEmpty) ghSecretSet(repo, "MILL_PGP_PASSPHRASE", passphrase)
+
+    sonatypeCredentials.foreach { case (username, password) =>
+      ghSecretSet(repo, "MILL_SONATYPE_USERNAME", username)
+      ghSecretSet(repo, "MILL_SONATYPE_PASSWORD", password)
+    }
     println("")
-    println("To publish to Maven Central from your shell, export the following credentials.")
-    println(
-      "MILL_SONATYPE_PASSWORD and MILL_SONATYPE_USERNAME can be generated at https://central.sonatype.com/usertoken"
-    )
-    println("")
-    println("-" * 72)
-    println(s"export MILL_PGP_SECRET_BASE64=$secretKeyBase64")
-    println(s"export MILL_PGP_PASSPHRASE=$passphrase")
-    println(s"export MILL_SONATYPE_PASSWORD=...")
-    println(s"export MILL_SONATYPE_USERNAME=...")
-    println("-" * 72)
-    println("")
-    println("To publish from GitHub Actions, add the credentials above as repository secrets at")
-    println("")
-    println("- https://github.com/<org>/<repo>/settings/secrets/actions/new")
-    println("")
-    println("and then include them in your .github/workflows/publish-artifacts.yml as:")
-    println("")
+  }
+
+  private def ghSecretSet(repo: String, name: String, value: String): Unit = {
+    try {
+      val result = os.proc("gh", "secret", "set", name, "-R", repo)
+        .call(stdin = value, mergeErrIntoOut = true, check = false)
+      if (result.exitCode == 0) println(s"  Uploaded $name")
+      else System.err.println(s"  Warning: Failed to upload $name: ${result.out.text().trim}")
+    } catch {
+      case e: java.io.IOException =>
+        System.err.println(s"  Warning: Failed to upload $name: ${e.getMessage}")
+    }
+  }
+
+  private def printWorkflowYaml(passphrase: String): Unit = {
+    println("Then include them in .github/workflows/publish-artifacts.yml:")
     println("-" * 72)
     println("env:")
     println("  MILL_PGP_SECRET_BASE64: ${{ secrets.MILL_PGP_SECRET_BASE64 }}")
-    println("  MILL_PGP_PASSPHRASE: ${{ secrets.MILL_PGP_PASSPHRASE }}")
+    if (passphrase.nonEmpty) {
+      println("  MILL_PGP_PASSPHRASE: ${{ secrets.MILL_PGP_PASSPHRASE }}")
+    }
     println("  MILL_SONATYPE_USERNAME: ${{ secrets.MILL_SONATYPE_USERNAME }}")
     println("  MILL_SONATYPE_PASSWORD: ${{ secrets.MILL_SONATYPE_PASSWORD }}")
     println("-" * 72)

--- a/libs/javalib/src/mill/javalib/SonatypeCentralPublishModule.scala
+++ b/libs/javalib/src/mill/javalib/SonatypeCentralPublishModule.scala
@@ -261,12 +261,28 @@ object SonatypeCentralPublishModule extends ExternalModule, DefaultTaskModule, M
    *
    * See https://central.sonatype.org/publish/requirements/gpg/ for more details.
    */
-  def initGpgKeys(): Task.Command[Unit] = Task.Command {
+  def initGpgKeys(
+      pomSettings: mill.util.Tasks[publish.PomSettings] =
+        Tasks.resolveMainDefault("__:PublishModule.pomSettings"),
+      keyserverUrl: String = "https://keyserver.ubuntu.com"
+  ): Task.Command[Unit] = Task.Command {
     val secretPath = Task.dest / "pgp-private-key.asc"
+
+    val pomArgs = Task.sequence(pomSettings.value)().headOption match {
+      case Some(pom) =>
+        val devArgs = pom.developers.headOption.toSeq.flatMap { dev =>
+          Seq("--name", dev.name) ++ (if (dev.email.nonEmpty) Seq("--email", dev.email) else Nil)
+        }
+        val urlArgs = if (pom.url.nonEmpty) Seq("--url", pom.url) else Nil
+        devArgs ++ urlArgs
+      case None => Nil
+    }
+
     val exitCode = Jvm.callInteractiveProcess(
       mainClass = "mill.javalib.pgp.worker.MillInitGpgKeysMain",
       classPath = pgpWorkerClasspath().map(_.path),
-      mainArgs = Seq("--output-secret", secretPath.toString),
+      mainArgs = Seq("--output-secret", secretPath.toString, "--keyserver-url", keyserverUrl) ++
+        pomArgs,
       env = Task.env,
       cwd = BuildCtx.workspaceRoot
     )

--- a/libs/util/java11/src/mill/util/ShellConfiguration.scala
+++ b/libs/util/java11/src/mill/util/ShellConfiguration.scala
@@ -1,0 +1,195 @@
+package mill.util
+
+sealed trait ShellConfiguration {
+  def name: String
+  def configPath: os.Path
+  def formatEnvVar(name: String, value: String): String
+  def envVarPattern(name: String): scala.util.matching.Regex
+
+  def formatComment(text: String): String = s"# $text"
+
+  def upsertEnvVar(name: String, value: String): Unit = {
+    val content = os.read(configPath)
+    val pattern = envVarPattern(name)
+    val newLine = formatEnvVar(name, value)
+    val newContent = pattern.findFirstMatchIn(content) match {
+      case Some(_) =>
+        pattern.replaceFirstIn(content, scala.util.matching.Regex.quoteReplacement(newLine))
+      case None =>
+        if (content.endsWith("\n")) content + newLine + "\n"
+        else content + "\n" + newLine + "\n"
+    }
+    val tmp = os.temp(newContent, dir = configPath / os.up)
+    try os.move(tmp, configPath, replaceExisting = true, atomicMove = true)
+    catch {
+      case _: java.nio.file.AtomicMoveNotSupportedException =>
+        os.move(tmp, configPath, replaceExisting = true)
+    }
+  }
+
+  def previewUpsert(envVars: Seq[(String, String)]): String = {
+    val tmpCopy =
+      os.temp(os.read(configPath), dir = configPath / os.up, prefix = ".mill-preview-")
+    try {
+      envVars.foreach { case (envName, value) =>
+        withConfigPath(tmpCopy).upsertEnvVar(envName, value)
+      }
+      if (!ShellConfiguration.findOnPath("git")) return "(diff preview unavailable — git not found)"
+      val result = os.proc("git", "diff", "--no-index", "--", configPath, tmpCopy)
+        .call(mergeErrIntoOut = true, check = false)
+      result.out.text()
+    } finally os.remove(tmpCopy)
+  }
+
+  def withConfigPath(newPath: os.Path): ShellConfiguration
+}
+
+object ShellConfiguration {
+
+  def findOnPath(binaryName: String): Boolean = {
+    Option(System.getenv("PATH")).exists { path =>
+      val dirs = path.split(java.io.File.pathSeparatorChar)
+      val extensions = if (isWindows) Seq("", ".exe", ".cmd", ".bat") else Seq("")
+      dirs.exists(dir =>
+        extensions.exists(ext =>
+          java.nio.file.Files.isExecutable(java.nio.file.Paths.get(dir, binaryName + ext))
+        )
+      )
+    }
+  }
+
+  val isMac: Boolean = System.getProperty("os.name").toLowerCase.contains("mac")
+  val isWindows: Boolean = System.getProperty("os.name").toLowerCase.contains("win")
+
+  def installed: Seq[ShellConfiguration] = detectors.flatMap(_.detect)
+
+  private val detectors: Seq[ShellDetector] =
+    Seq(BashDetector, ZshDetector, FishDetector, NushellDetector, PowerShellDetector)
+
+  private def escapeForPosix(value: String): String =
+    value
+      .replace("\\", "\\\\")
+      .replace("\"", "\\\"")
+      .replace("$", "\\$")
+      .replace("`", "\\`")
+      .replace("!", "\\!")
+      .replace("\n", "\\n")
+
+  // Matches the content between quotes, allowing escaped characters (e.g. \")
+  private val quotedContent = """(?:[^"\n\\]|\\.)*"""
+
+  case class Bash(configPath: os.Path) extends ShellConfiguration {
+    val name = "Bash"
+    def formatEnvVar(name: String, value: String): String =
+      s"""export $name="${escapeForPosix(value)}""""
+    def envVarPattern(name: String): scala.util.matching.Regex =
+      s"""(?m)^export ${java.util.regex.Pattern.quote(name)}="$quotedContent"$$""".r
+    def withConfigPath(newPath: os.Path): Bash = copy(configPath = newPath)
+  }
+
+  case class Zsh(configPath: os.Path) extends ShellConfiguration {
+    val name = "Zsh"
+    def formatEnvVar(name: String, value: String): String =
+      s"""export $name="${escapeForPosix(value)}""""
+    def envVarPattern(name: String): scala.util.matching.Regex =
+      s"""(?m)^export ${java.util.regex.Pattern.quote(name)}="$quotedContent"$$""".r
+    def withConfigPath(newPath: os.Path): Zsh = copy(configPath = newPath)
+  }
+
+  case class Fish(configPath: os.Path) extends ShellConfiguration {
+    val name = "Fish"
+    def formatEnvVar(name: String, value: String): String =
+      s"""set -gx $name "${escapeForPosix(value)}""""
+    def envVarPattern(name: String): scala.util.matching.Regex =
+      s"""(?m)^set -gx ${java.util.regex.Pattern.quote(name)} "$quotedContent"$$""".r
+    def withConfigPath(newPath: os.Path): Fish = copy(configPath = newPath)
+  }
+
+  case class Nushell(configPath: os.Path) extends ShellConfiguration {
+    val name = "Nushell"
+    private def escapeValue(value: String): String =
+      value
+        .replace("\\", "\\\\")
+        .replace("\"", "\\\"")
+        .replace("'", "\\'")
+        .replace("\n", "\\n")
+    def formatEnvVar(name: String, value: String): String =
+      s"""$$env.${name} = "${escapeValue(value)}""""
+    def envVarPattern(name: String): scala.util.matching.Regex =
+      s"""(?m)^\\$$env\\.${java.util.regex.Pattern.quote(name)} = "$quotedContent"$$""".r
+    def withConfigPath(newPath: os.Path): Nushell = copy(configPath = newPath)
+  }
+
+  case class PowerShell(configPath: os.Path) extends ShellConfiguration {
+    val name = "PowerShell"
+    override def formatComment(text: String): String = s"# $text"
+    private def escapeValue(value: String): String =
+      value
+        .replace("`", "``")
+        .replace("\"", "`\"")
+        .replace("\n", "`n")
+    def formatEnvVar(name: String, value: String): String =
+      s"""$$env:${name} = "${escapeValue(value)}""""
+    def envVarPattern(name: String): scala.util.matching.Regex =
+      s"""(?m)^\\$$env:${java.util.regex.Pattern.quote(name)} = "$quotedContent"$$""".r
+    def withConfigPath(newPath: os.Path): PowerShell = copy(configPath = newPath)
+  }
+
+  // --- Detection logic (private) ---
+
+  private sealed trait ShellDetector {
+    def detect: Option[ShellConfiguration]
+  }
+
+  private object BashDetector extends ShellDetector {
+    def detect: Option[ShellConfiguration] = {
+      if (isMac) return None
+      if (!findOnPath("bash")) return None
+      val bashrc = os.home / ".bashrc"
+      if (os.exists(bashrc)) Some(Bash(bashrc)) else None
+    }
+  }
+
+  private object ZshDetector extends ShellDetector {
+    def detect: Option[ShellConfiguration] = {
+      if (!findOnPath("zsh")) return None
+      runConfigDetection("zsh", Seq("-c", """echo "${ZDOTDIR:-$HOME}/.zshrc"""")).map(Zsh(_))
+    }
+  }
+
+  private object FishDetector extends ShellDetector {
+    def detect: Option[ShellConfiguration] = {
+      if (!findOnPath("fish")) return None
+      runConfigDetection("fish", Seq("-c", "echo $__fish_config_dir/config.fish")).map(Fish(_))
+    }
+  }
+
+  private object NushellDetector extends ShellDetector {
+    def detect: Option[ShellConfiguration] = {
+      if (!findOnPath("nu")) return None
+      runConfigDetection("nu", Seq("-c", "echo $nu.config-path")).map(Nushell(_))
+    }
+  }
+
+  private object PowerShellDetector extends ShellDetector {
+    val binaryNames = Seq("pwsh", "powershell")
+
+    def detect: Option[ShellConfiguration] = {
+      binaryNames.view.flatMap { bin =>
+        if (!findOnPath(bin)) None
+        else runConfigDetection(bin, Seq("-c", "echo $PROFILE")).map(PowerShell(_))
+      }.headOption
+    }
+  }
+
+  private def runConfigDetection(binary: String, args: Seq[String]): Option[os.Path] = {
+    scala.util.Try {
+      os.proc(binary +: args).call(mergeErrIntoOut = true, check = false)
+    }.toOption
+      .filter(_.exitCode == 0)
+      .map(_.out.text().trim)
+      .filter(_.nonEmpty)
+      .map(os.Path(_))
+      .filter(os.exists(_))
+  }
+}

--- a/libs/util/test/src/mill/util/ShellConfigurationTests.scala
+++ b/libs/util/test/src/mill/util/ShellConfigurationTests.scala
@@ -1,0 +1,121 @@
+package mill.util
+
+import utest.*
+
+object ShellConfigurationTests extends TestSuite {
+
+  private val dummyPath = os.pwd / "dummy"
+
+  val tests: Tests = Tests {
+    test("formatEnvVar") {
+      test("bash escapes special characters") {
+        val result =
+          ShellConfiguration.Bash(dummyPath)
+            .formatEnvVar("FOO", """hello "world" $HOME `cmd`!hist\n""")
+        assert(result == """export FOO="hello \"world\" \$HOME \`cmd\`\!hist\\n"""")
+      }
+      test("zsh escapes special characters") {
+        val result =
+          ShellConfiguration.Zsh(dummyPath).formatEnvVar("FOO", """a"b$c`d!e\f""")
+        assert(result == """export FOO="a\"b\$c\`d\!e\\f"""")
+      }
+      test("fish escapes special characters") {
+        val result =
+          ShellConfiguration.Fish(dummyPath).formatEnvVar("FOO", """a"b$c!d\e""")
+        assert(result == """set -gx FOO "a\"b\$c\!d\\e"""")
+      }
+      test("nushell escapes special characters") {
+        val result =
+          ShellConfiguration.Nushell(dummyPath).formatEnvVar("FOO", """a"b'c\d""")
+        assert(result == """$env.FOO = "a\"b\'c\\d"""")
+      }
+      test("powershell escapes special characters") {
+        val result =
+          ShellConfiguration.PowerShell(dummyPath).formatEnvVar("FOO", """a"b`c""")
+        assert(result == """$env:FOO = "a`"b``c"""")
+      }
+      test("newlines are escaped") {
+        val result =
+          ShellConfiguration.Bash(dummyPath).formatEnvVar("FOO", "line1\nline2")
+        assert(result == """export FOO="line1\nline2"""")
+      }
+      test("powershell newlines use backtick-n") {
+        val result =
+          ShellConfiguration.PowerShell(dummyPath).formatEnvVar("FOO", "line1\nline2")
+        assert(result == """$env:FOO = "line1`nline2"""")
+      }
+    }
+
+    test("envVarPattern") {
+      test("bash matches quoted export line") {
+        val pattern = ShellConfiguration.Bash(dummyPath).envVarPattern("MY_VAR")
+        assert(pattern.findFirstIn("""export MY_VAR="hello"""").isDefined)
+        assert(pattern.findFirstIn("""export OTHER_VAR="hello"""").isEmpty)
+      }
+      test("bash does not match unquoted values") {
+        val pattern = ShellConfiguration.Bash(dummyPath).envVarPattern("MY_VAR")
+        assert(pattern.findFirstIn("""export MY_VAR=hello""").isEmpty)
+      }
+      test("regex injection is prevented") {
+        val pattern = ShellConfiguration.Bash(dummyPath).envVarPattern("FOO.*BAR")
+        assert(pattern.findFirstIn("""export FOO.*BAR="val"""").isDefined)
+        assert(pattern.findFirstIn("""export FOOXXBAR="val"""").isEmpty)
+      }
+      test("fish matches set line") {
+        val pattern = ShellConfiguration.Fish(dummyPath).envVarPattern("MY_VAR")
+        assert(pattern.findFirstIn("""set -gx MY_VAR "hello"""").isDefined)
+        assert(pattern.findFirstIn("""set -gx OTHER "hello"""").isEmpty)
+      }
+      test("nushell matches env line") {
+        val pattern = ShellConfiguration.Nushell(dummyPath).envVarPattern("MY_VAR")
+        assert(pattern.findFirstIn("""$env.MY_VAR = "hello"""").isDefined)
+      }
+      test("nushell does not match across lines") {
+        val pattern = ShellConfiguration.Nushell(dummyPath).envVarPattern("MY_VAR")
+        val multiline = "$env.MY_VAR = \"hello\nworld\""
+        assert(pattern.findFirstIn(multiline).isEmpty)
+      }
+      test("powershell matches env line") {
+        val pattern = ShellConfiguration.PowerShell(dummyPath).envVarPattern("MY_VAR")
+        assert(pattern.findFirstIn("""$env:MY_VAR = "hello"""").isDefined)
+      }
+      test("bash matches values with escaped quotes") {
+        val pattern = ShellConfiguration.Bash(dummyPath).envVarPattern("MY_VAR")
+        assert(pattern.findFirstIn("""export MY_VAR="hello \"world\""""").isDefined)
+      }
+    }
+
+    test("upsertEnvVar") {
+      test("inserts new variable") {
+        val tmp = os.temp("# existing config\n")
+        ShellConfiguration.Bash(tmp).upsertEnvVar("NEW_VAR", "new_value")
+        val content = os.read(tmp)
+        assert(content.contains("""export NEW_VAR="new_value""""))
+        assert(content.startsWith("# existing config\n"))
+      }
+      test("updates existing variable") {
+        val tmp = os.temp("# config\nexport MY_VAR=\"old\"\n# end\n")
+        ShellConfiguration.Bash(tmp).upsertEnvVar("MY_VAR", "new")
+        val content = os.read(tmp)
+        assert(content.contains("""export MY_VAR="new""""))
+        assert(!content.contains("old"))
+        assert(content.contains("# end"))
+      }
+      test("updates variable with escaped quotes in existing value") {
+        val tmp = os.temp("# config\nexport MY_VAR=\"hello \\\"world\\\"\"\n# end\n")
+        ShellConfiguration.Bash(tmp).upsertEnvVar("MY_VAR", "new")
+        val content = os.read(tmp)
+        assert(content.contains("""export MY_VAR="new""""))
+        assert(!content.contains("world"))
+        assert(content.contains("# end"))
+      }
+      test("handles file without trailing newline") {
+        val tmp = os.temp("# config")
+        ShellConfiguration.Bash(tmp).upsertEnvVar("VAR", "val")
+        val content = os.read(tmp)
+        assert(content.contains("""export VAR="val""""))
+        assert(content.startsWith("# config\n"))
+      }
+    }
+  }
+}


### PR DESCRIPTION
Following up on your [How To Publish to Maven Central Easily with Mill](https://mill-build.org/blog/18-how-to-publish-to-maven-central-easily-with-mill.html) blog post, I'd like to propose a few additional automations:

- initGpgKeys now auto-detects developer name, email, and URL from pomSettings and pre-fills the prompts, so users can just press Enter to accept defaults
- After key generation, the command offers to write credentials directly into detected shell config files (bash, zsh, fish, nushell, powershell) with a diff preview before applying
- If `gh` CLI is authenticated, offers to upload secrets directly to the GitHub repository
- Prompts for Sonatype credentials during the same flow instead of requiring users to set them separately
- Users can type "q" at any prompt to abort cleanly
- Keyserver URL is now configurable via --keyserverUrl parameter, allowing tests to use a mock server instead of hitting the real keyserver

## Technical details

- New ShellConfiguration utility in libs/util/java11 handles cross-platform shell config detection and atomic env var upsert with proper escaping per shell
- Integration test uses an in-process HTTP mock keyserver instead of relying on keyserver.ubuntu.com
- Keyserver verification uses a bounded retry count (3 attempts) instead of a 60-second deadline loop

## Usage of AI
1. Claude Opus 4.6 created the initial plan.
2. I did multiple rounds of manual plan reviews and refinements.
3. Claude generated the implementation.
4. I did multiple rounds of manual and automated code reviews until I was happy with the result.