### PR TITLE
Correct error message suggesting `jvmId` instead of `jvmVersion`

### DIFF
--- a/integration/failure/jvm-version/src/JvmVersionTests.scala
+++ b/integration/failure/jvm-version/src/JvmVersionTests.scala
@@ -13,7 +13,7 @@ object JvmVersionTests extends UtestIntegrationTestSuite {
       assert(
         res.err.contains(
           """Invalid java.version 11.0.29. Mill requires Java 17 and above to run the build tool itself. """ +
-            """Individual `JavaModule` can be set to lower Java versions via `def jvmId = "11"`"""
+            """Individual `JavaModule` can be set to lower Java versions via `def jvmVersion = "11"`"""
         )
       )
     }


### PR DESCRIPTION
Correct error message for JVM