### PR TITLE
Integrate Jib Docker builder into contrib/docker

### DIFF
--- a/contrib/docker/readme.adoc
+++ b/contrib/docker/readme.adoc
@@ -3,7 +3,9 @@
 
 Automatically build docker images from your mill project.
 
-Requires the docker CLI to be installed.
+By default, images are built using https://github.com/GoogleContainerTools/jib[Jib],
+which does not require a Docker daemon or CLI. To use the classic Dockerfile-based
+approach, extend `ClassicDockerConfig` instead of `DockerConfig`.
 
 In the simplest configuration just extend `DockerModule` and declare a `DockerConfig` object.
 
@@ -32,7 +34,9 @@ $ docker run foo
 
 == Configuration
 
-Configure the image by overriding tasks in the `DockerConfig` object
+Configure the image by overriding tasks in the `DockerConfig` object.
+
+=== Shared options (both Jib and Dockerfile modes)
 
 [source,scala]
 ----
@@ -42,33 +46,68 @@ object docker extends DockerConfig {
 
   def baseImage = "openjdk:11"
 
-  // Configure whether the docker build should check the remote registry for a new version of the base image before building.
-  // By default this is true if the base image is using a latest tag
-  def pullBaseImage = true
-  // Add container metadata via the LABEL instruction
+  // Add container metadata via labels
   def labels = Map("version" -> "1.0")
   // TCP ports the container will listen to
   def exposedPorts = Seq(8080, 443)
   // UDP ports the container will listen to
   def exposedUdpPorts = Seq(80)
-  // The names of mount points, these will be translated to VOLUME instructions
-  def volumes = Seq("/v1", "/v2")
-  // Environment variables to be set in the container (ENV instructions)
+  // Environment variables to be set in the container
   def envVars = Map("foo" -> "bar", "foobar" -> "barfoo")
   // JVM runtime options such as heap size settings
   def jvmOptions = Seq("-Xmx1024M", "-XX:+HeapDumpOnOutOfMemoryError")
-  // Add RUN instructions
+  // User to use when running the image
+  def user = "new-user"
+  // Target platform (e.g. "linux/amd64"); used by both Jib and buildx
+  def platform = "linux/arm64"
+}
+----
+
+=== Jib-specific options
+
+Jib is the default backend (`DockerConfig`). It builds images without requiring a Docker daemon.
+
+[source,scala]
+----
+object docker extends DockerConfig {
+  // Source image (defaults to RegistryImage from baseImage)
+  def jibSourceImage = JibImage.RegistryImage("openjdk:17")
+  // Target image (defaults to DockerDaemonImage from first tag)
+  def jibTargetImage = JibImage.RegistryImage("myregistry.com/myapp")
+  // Image format: JibImageFormat.Docker (default) or JibImageFormat.OCI
+  def jibImageFormat = JibImageFormat.OCI
+  // Custom entrypoint (overrides Jib's default Java entrypoint)
+  def entrypoint = Seq("/bin/sh", "-c", "java -jar /app.jar")
+  // Program arguments passed to the main class
+  def jibProgramArgs = Seq("--server.port=8080")
+  // Allow insecure registries
+  def allowInsecureRegistries = true
+}
+----
+
+The `getJavaBuilder` and `getJibBuilder` tasks can be overridden for advanced
+customization of the Jib container builder.
+
+=== Dockerfile-based builds (ClassicDockerConfig)
+
+Extend `ClassicDockerConfig` instead of `DockerConfig` to use the classic
+Dockerfile-based approach. This requires a Docker CLI to be installed.
+
+[source,scala]
+----
+object docker extends ClassicDockerConfig {
+  // Configure whether the docker build should check the remote registry for a new version
+  // of the base image before building. By default true if the base image uses a latest tag.
+  def pullBaseImage = true
+  // The names of mount points (not supported by Jib)
+  def volumes = Seq("/v1", "/v2")
+  // Add RUN instructions (not supported by Jib)
   def run = Seq(
     "/bin/bash -c 'echo Hello World!'",
     "useradd -ms /bin/bash new-user"
   )
-  // User to use when running the image
-  def user = "new-user"
-  // Optionally override the docker executable to use something else
+  // Optionally override the docker executable
   def executable = "podman"
-  // If the executable is docker (which is also the default), you can optionally also pass a platform parameter
-  // docker buildx is then used to build multi-platform images
-  def platform = "linux/arm64"
 }
 ----
 

--- a/contrib/docker/src/mill/contrib/docker/JibBuild.scala
+++ b/contrib/docker/src/mill/contrib/docker/JibBuild.scala
@@ -1,0 +1,184 @@
+package mill
+package contrib.docker
+
+import com.google.cloud.tools.jib.api.*
+import com.google.cloud.tools.jib.api.buildplan.{ImageFormat, Port}
+
+import scala.jdk.CollectionConverters.*
+import scala.jdk.OptionConverters.*
+
+object JibBuild {
+
+  private val toolName = "mill-contrib-docker-jib"
+
+  def javaBuild(
+      sourceImage: JibSourceImage,
+      dependencies: Seq[mill.api.PathRef],
+      snapshotDependencies: Seq[mill.api.PathRef],
+      classes: Seq[mill.api.PathRef],
+      jvmOptions: Seq[String],
+      mainClass: Option[String],
+      mainClassSearchPaths: Seq[mill.api.PathRef],
+      logger: mill.api.Logger
+  ): JavaContainerBuilder = {
+
+    val javaBuilder = sourceImage match {
+      case JibImage.RegistryImage(qualifiedName, credentialsEnvironment) =>
+        val image = com.google.cloud.tools.jib.api.RegistryImage.named(
+          ImageReference.parse(qualifiedName)
+        )
+        credentialsEnvironment.foreach { case (username, password) =>
+          image.addCredentialRetriever(retrieveEnvCredentials(username, password))
+        }
+        JavaContainerBuilder.from(image)
+      case JibImage.DockerDaemonImage(qualifiedName, _) =>
+        JavaContainerBuilder.from(
+          DockerDaemonImage.named(ImageReference.parse(qualifiedName))
+        )
+      case JibImage.SourceTarFile(path) =>
+        JavaContainerBuilder.from(TarImage.at(path.path.wrapped))
+    }
+
+    javaBuilder.addDependencies(dependencies.map(_.path.wrapped).asJava)
+    javaBuilder.addSnapshotDependencies(snapshotDependencies.map(_.path.wrapped).asJava)
+
+    classes
+      .filter(p => os.isDir(p.path))
+      .map(_.path.wrapped)
+      .toSet
+      .foreach(javaBuilder.addClasses)
+    javaBuilder.addSnapshotDependencies(
+      classes.filter(p => os.isFile(p.path)).map(_.path.wrapped).asJava
+    )
+
+    javaBuilder.addJvmFlags(jvmOptions.asJava)
+
+    setMainClass(mainClass, mainClassSearchPaths, javaBuilder, logger)
+
+    javaBuilder
+  }
+
+  def setContainerParams(
+      labels: Map[String, String],
+      envVars: Map[String, String],
+      exposedPorts: Seq[Int],
+      exposedUdpPorts: Seq[Int],
+      user: String,
+      platforms: Set[JibPlatform],
+      imageFormat: JibImageFormat,
+      entrypoint: Seq[String],
+      programArgs: Seq[String],
+      containerBuilder: JibContainerBuilder
+  ): JibContainerBuilder = {
+
+    containerBuilder.setEnvironment(envVars.asJava)
+    if (platforms.nonEmpty) {
+      containerBuilder.setPlatforms(
+        platforms
+          .map(p => new com.google.cloud.tools.jib.api.buildplan.Platform(p.architecture, p.os))
+          .asJava
+      )
+    }
+    containerBuilder.setLabels(labels.asJava)
+    containerBuilder.setUser(if (user.isEmpty) null else user)
+    containerBuilder.setProgramArguments(programArgs.asJava)
+    containerBuilder.setFormat(imageFormat match {
+      case JibImageFormat.Docker => ImageFormat.Docker
+      case JibImageFormat.OCI => ImageFormat.OCI
+    })
+
+    val ports: Set[Port] =
+      exposedPorts.map(Port.tcp).toSet ++ exposedUdpPorts.map(Port.udp).toSet
+    containerBuilder.setExposedPorts(ports.asJava)
+    containerBuilder.setCreationTime(java.time.Instant.now())
+
+    if (entrypoint.nonEmpty) {
+      containerBuilder.setEntrypoint(entrypoint.asJava)
+    }
+
+    containerBuilder
+  }
+
+  def containerize(
+      jibBuilder: JibContainerBuilder,
+      targetImage: JibTargetImage,
+      tags: Seq[String],
+      allowInsecureRegistries: Boolean,
+      logger: mill.api.Logger,
+      dest: os.Path
+  ): JibContainer = {
+    val containerizer = targetImage match {
+      case JibImage.DockerDaemonImage(qualifiedName, _) =>
+        Containerizer.to(DockerDaemonImage.named(qualifiedName))
+      case JibImage.RegistryImage(qualifiedName, credentialsEnvironment) =>
+        val image = com.google.cloud.tools.jib.api.RegistryImage.named(
+          ImageReference.parse(qualifiedName)
+        )
+        credentialsEnvironment.foreach { case (username, password) =>
+          image.addCredentialRetriever(retrieveEnvCredentials(username, password))
+        }
+        Containerizer.to(image)
+      case JibImage.TargetTarFile(qualifiedName, filename) =>
+        Containerizer.to(TarImage.at((dest / filename).wrapped).named(qualifiedName))
+    }
+
+    val containerizerWithLogs = containerizer.addEventHandler(JibLogging.logger(logger))
+
+    tags.foreach(containerizerWithLogs.withAdditionalTag)
+    containerizerWithLogs
+      .setAllowInsecureRegistries(allowInsecureRegistries)
+      .setToolName(toolName)
+
+    jibBuilder.containerize(containerizerWithLogs)
+  }
+
+  private def isSnapshotDependency(pathRef: mill.api.PathRef): Boolean =
+    pathRef.path.last.endsWith("-SNAPSHOT.jar")
+
+  private def retrieveEnvCredentials(
+      usernameEnv: String,
+      passwordEnv: String
+  ): CredentialRetriever =
+    new CredentialRetriever {
+      def retrieve(): java.util.Optional[Credential] = {
+        val option = for {
+          username <- sys.env.get(usernameEnv)
+          password <- sys.env.get(passwordEnv)
+        } yield Credential.from(username, password)
+        option.asJava
+      }
+    }
+
+  private def setMainClass(
+      mainClass: Option[String],
+      mainClassSearchPaths: Seq[mill.api.PathRef],
+      javaBuilder: JavaContainerBuilder,
+      logger: mill.api.Logger
+  ): Unit =
+    if (mainClass.isDefined) {
+      javaBuilder.setMainClass(mainClass.get)
+    } else {
+      val classfiles = mainClassSearchPaths
+        .flatMap(pathRef => os.walk(pathRef.path))
+        .collect { case p if os.isFile(p) => p.wrapped }
+        .asJava
+      val result = MainClassFinder.find(classfiles, JibLogging.eventLogger(logger))
+      result.getType match {
+        case MainClassFinder.Result.Type.MAIN_CLASS_FOUND =>
+          logger.info(s"Main class found: ${result.getFoundMainClass}")
+          javaBuilder.setMainClass(result.getFoundMainClass)
+        case MainClassFinder.Result.Type.MAIN_CLASS_NOT_FOUND =>
+          logger.error("No main class found")
+        case MainClassFinder.Result.Type.MULTIPLE_MAIN_CLASSES =>
+          logger.info(s"Multiple main classes found, using: ${result.getFoundMainClasses.get(0)}")
+          javaBuilder.setMainClass(result.getFoundMainClasses.get(0))
+      }
+    }
+
+  def partitionDependencies(
+      resolvedRunMvnDeps: Seq[mill.api.PathRef]
+  ): (Seq[mill.api.PathRef], Seq[mill.api.PathRef]) =
+    resolvedRunMvnDeps
+      .filter(pathRef => os.exists(pathRef.path))
+      .partition(isSnapshotDependency)
+}

--- a/contrib/docker/src/mill/contrib/docker/JibLogging.scala
+++ b/contrib/docker/src/mill/contrib/docker/JibLogging.scala
@@ -1,0 +1,31 @@
+package mill
+package contrib.docker
+
+import com.google.cloud.tools.jib.event.events.ProgressEvent
+import com.google.cloud.tools.jib.event.events.TimerEvent
+import com.google.cloud.tools.jib.api.LogEvent
+import com.google.cloud.tools.jib.api.JibEvent
+
+object JibLogging {
+
+  def eventLogger(log: mill.api.Logger): java.util.function.Consumer[LogEvent] =
+    new java.util.function.Consumer[LogEvent] {
+      def accept(e: LogEvent): Unit = log.info(s"LogEvent: ${e.getMessage}")
+    }
+
+  def logger(log: mill.api.Logger): java.util.function.Consumer[JibEvent] =
+    new java.util.function.Consumer[JibEvent] {
+      def accept(e: JibEvent): Unit = e match {
+        case m: LogEvent =>
+          log.info(s"LogEvent: ${m.getMessage}")
+        case p: ProgressEvent =>
+          log.ticker(
+            s"ProgressEvent: ${p.getAllocation.getFractionOfRoot * p.getUnits} ${p.getAllocation.getDescription}"
+          )
+        case t: TimerEvent =>
+          log.ticker(s"TimerEvent: ${t.getDescription} ${t.getElapsed}")
+        case _ =>
+          log.info(s"JibEvent: $e")
+      }
+    }
+}

--- a/contrib/docker/src/mill/contrib/docker/JibTypes.scala
+++ b/contrib/docker/src/mill/contrib/docker/JibTypes.scala
@@ -1,0 +1,44 @@
+package mill
+package contrib.docker
+
+import upickle.default.*
+
+enum JibImageFormat derives ReadWriter {
+  case Docker, OCI
+}
+
+sealed trait JibSourceImage
+sealed trait JibTargetImage {
+  def qualifiedName: String
+}
+
+object JibImage {
+  case class SourceTarFile(path: mill.api.PathRef) extends JibSourceImage
+  case class TargetTarFile(
+      qualifiedName: String,
+      filename: String = "out.tar"
+  ) extends JibTargetImage
+  case class DockerDaemonImage(
+      qualifiedName: String,
+      credentialsEnvironment: Option[(String, String)] = None
+  ) extends JibTargetImage
+      with JibSourceImage
+  case class RegistryImage(
+      qualifiedName: String,
+      credentialsEnvironment: Option[(String, String)] = None
+  ) extends JibTargetImage
+      with JibSourceImage
+
+  given ReadWriter[SourceTarFile] = macroRW
+  given ReadWriter[TargetTarFile] = macroRW
+  given ReadWriter[RegistryImage] = macroRW
+  given ReadWriter[DockerDaemonImage] = macroRW
+  given ReadWriter[JibTargetImage] = macroRW
+  given ReadWriter[JibSourceImage] = macroRW
+}
+
+final case class JibPlatform(os: String, architecture: String)
+
+object JibPlatform {
+  given ReadWriter[JibPlatform] = macroRW
+}

--- a/contrib/package.mill
+++ b/contrib/package.mill
@@ -190,6 +190,7 @@ object `package` extends mill.Module {
 
   object docker extends ContribModule {
     def compileModuleDeps = Seq(build.libs.javalib)
+    def mvnDeps = Seq(Deps.jibCore)
     def testModuleDeps = super.testModuleDeps ++ Seq(build.libs.javalib)
   }
 

--- a/mill-build/src/millbuild/Deps.scala
+++ b/mill-build/src/millbuild/Deps.scala
@@ -110,6 +110,7 @@ object Deps {
   val castor = mvn"com.lihaoyi::castor:0.3.0"
   val fastparse = mvn"com.lihaoyi::fastparse:3.1.1"
   val flywayCore = mvn"org.flywaydb:flyway-core:11.8.2"
+  val jibCore = mvn"com.google.cloud.tools:jib-core:0.27.2"
   val graphvizJava = Seq(
     mvn"guru.nidi:graphviz-java-min-deps:0.18.1",
     mvn"org.webjars.npm:viz.js-graphviz-java:2.1.3",


### PR DESCRIPTION
Add Jib (Google's container image builder) as the default Docker image build backend in contrib/docker. Jib builds images without requiring a Docker daemon or CLI, producing optimized layered images directly.

DockerConfig now uses Jib by default. The existing Dockerfile-based approach is available via ClassicDockerConfig for users who need Dockerfile features like RUN instructions and VOLUME mounts.

New files:
- JibTypes.scala: Type definitions (JibImageFormat, JibSourceImage, etc.)
- JibLogging.scala: Bridges Mill logger to Jib's event system
- JibBuild.scala: Core Jib build logic (layers, container params, main class detection)


