### PR TITLE
Make `run` interactive by default.

### DIFF
--- a/libs/javalib/src/mill/javalib/RunModule.scala
+++ b/libs/javalib/src/mill/javalib/RunModule.scala
@@ -407,20 +407,21 @@ object RunModule {
             propagateEnv = false
           )
         } else {
-          Jvm.callProcess(
+          val exitCode = Jvm.callInteractiveProcess(
             mainClass = mainClass1,
             classPath = classPath,
             jvmArgs = jvmArgs,
             env = (if (propEnv) ctx.env else Map()) ++ env,
             mainArgs = mainArgs,
             cwd = cwd,
-            stdin = os.Inherit,
-            stdout = os.Inherit,
-            stderr = os.Inherit,
             cpPassingJarPath = cpPassingJarPath,
             javaHome = javaHome,
+            // We explicitly pass in the full env map above; don't double-propagate.
             propagateEnv = false
           )
+
+          // Keep legacy semantics: non-zero exit is treated as task failure.
+          if (exitCode != 0) throw new RuntimeException("Subprocess failed")
         }
       }
     }

--- a/libs/javalib/test/src/mill/javalib/RunTests.scala
+++ b/libs/javalib/test/src/mill/javalib/RunTests.scala
@@ -2,6 +2,7 @@ package mill.javalib
 
 import mill.*
 import mill.api.ExecResult
+import mill.api.daemon.LauncherSubprocess
 import mill.testkit.{TestRootModule, UnitTester}
 import utest.*
 import mill.api.Discover
@@ -80,6 +81,19 @@ object RunTests extends TestSuite {
         ).runtimeChecked
 
         assert(result.evalCount > 0)
+      }
+
+      test("runUsesInteractiveSubprocess") - UnitTester(HelloJavaWithMain, resourcePath).scoped {
+        eval =>
+          var seen: Option[LauncherSubprocess.Config] = None
+
+          LauncherSubprocess.withValue(config => { seen = Some(config); 0 }) {
+            val Right(result) =
+              eval.apply(HelloJavaWithMain.app.run(Task.Anon(Args("testArg")))).runtimeChecked
+            assert(result.evalCount > 0)
+          }
+
+          assert(seen.nonEmpty)
       }
       test("notRunWithoutMainClass") - UnitTester(
         HelloJavaWithoutMain,


### PR DESCRIPTION
We already made the task exclusive in https://github.com/com-lihaoyi/mill/pull/6220, so might as well make the subprocess interactive so things like using `.run` on terminal applications works without fiddling.

Tested manually