### PR TITLE
Android: Generate test_config.properties

### DIFF
--- a/libs/androidlib/src/mill/androidlib/AndroidModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidModule.scala
@@ -945,19 +945,26 @@ trait AndroidModule extends JavaModule { outer =>
     }
 
     /**
-     * Generates a Java properties file required when [[androidIncludeAndroidResources]] is true,
-     * containing necessary information for the Android resource processing in unit tests.
-     *
-     * Properties and expected name on the classpath are defined at
-     * [[https://developer.android.com/reference/tools/gradle-api/8.3/null/com/android/build/api/dsl/UnitTestOptions#getIsIncludeAndroidResources()]]
+     * The properties of the generated test configuration file for Android unit tests.
      */
-    def androidGeneratedTestConfigSources: T[Seq[PathRef]] = Task {
-      val properties: Map[String, String] = Map(
+    def androidTestConfigProperties: T[Map[String, String]] = Task {
+      Map(
         "android_custom_package" -> outer.androidNamespace,
         "android_merged_manifest" -> outer.androidMergedManifest().path.toString,
         "android_resource_apk" -> (outer.androidLinkedResources().path / "apk" / "res.apk").toString,
         "android_merged_assets" -> outer.androidTransitiveMergedAssets().path.toString
       )
+    }
+
+    /**
+     * Generates a Java properties file required when [[androidIncludeAndroidResources]] is true,
+     * containing necessary information for the Android resource processing in unit tests.
+     *
+     * Expected name on the classpath and properties are defined at
+     * [[https://developer.android.com/reference/tools/gradle-api/8.3/null/com/android/build/api/dsl/UnitTestOptions#getIsIncludeAndroidResources()]]
+     */
+    def androidGeneratedTestConfigSources: T[Seq[PathRef]] = Task {
+      val properties = androidTestConfigProperties()
 
       val content = properties.map { case (key, value) =>
         s"$key=$value"


### PR DESCRIPTION
Closes #6620 

This adds to the support for the `isIncludeAndroidResources` that was introduced in https://github.com/com-lihaoyi/mill/pull/6638, by generating the `com/android/tools/test_config.properties` file as described [here (agp docs)](https://developer.android.com/reference/tools/gradle-api/8.3/null/com/android/build/api/dsl/UnitTestOptions#getIsIncludeAndroidResources()).

This also makes roboelectric unit tests work (Ref: [jetcaster.wear](https://github.com/vaslabs-ltd/compose-samples-with-mill/blob/main/Jetcaster/package.mill#L442) and the [koin example](https://github.com/com-lihaoyi/mill/pull/6833))