### PR TITLE
ErrorProne annotation processor deps and boms (#6639)

### DIFF
--- a/libs/javalib/src/mill/javalib/errorprone/ErrorProneModule.scala
+++ b/libs/javalib/src/mill/javalib/errorprone/ErrorProneModule.scala
@@ -32,7 +32,15 @@ trait ErrorProneModule extends JavaModule {
    * The classpath of the `error-prone` compiler plugin.
    */
   def errorProneClasspath: T[Seq[PathRef]] = Task {
-    defaultResolver().classpath(errorProneDeps())
+    defaultResolver().classpath(
+      errorProneDeps() ++ annotationProcessorsMvnDeps(),
+      boms = allBomDeps()
+    )
+  }
+
+  // Avoid duplicate -processorpath
+  override def annotationProcessorsJavacOptions: T[Seq[String]] = Task {
+    Seq.empty
   }
 
   /**


### PR DESCRIPTION
Fixes #6639

- In `ErrorProneModule`, make `annotationProcessorsJavacOptions` empty so processor deps are not emitted as a separate `-processorpath` from `JavaModule`.

- Make `ErrorProneModule` use bom and `annotationProcessorsMvnDeps` so we don't have to repeat it