### PR TITLE
support placeholders for flyway

### DIFF
--- a/contrib/flyway/readme.adoc
+++ b/contrib/flyway/readme.adoc
@@ -23,6 +23,11 @@ object foo extends ScalaModule with FlywayModule {
   def flywayUrl = "jdbc:postgresql:myDb" // required
   def flywayDriverDeps = Seq(mvn"org.postgresql:postgresql:42.2.5") // required
   def flywayUser = "postgres" // optional
+  def flywayPlaceholders = Task {
+    Map(
+      "org" -> "mill"
+    )
+  } // optional
   // def flywayPassword = "" // optional
   //endregion
 }

--- a/contrib/flyway/src/mill/contrib/flyway/FlywayModule.scala
+++ b/contrib/flyway/src/mill/contrib/flyway/FlywayModule.scala
@@ -25,6 +25,9 @@ trait FlywayModule extends JavaModule {
   def flywayFileLocations: T[Seq[PathRef]] = Task {
     resources().map(pr => PathRef(pr.path / "db/migration", pr.quick))
   }
+  def flywayPlaceholders: T[Map[String, String]] = Task {
+    Map.empty[String, String]
+  }
 
   def flywayDriverDeps: T[Seq[Dep]]
 
@@ -54,6 +57,7 @@ trait FlywayModule extends JavaModule {
     Flyway
       .configure(jdbcClassloader)
       .locations(flywayFileLocations().map("filesystem:" + _.path)*)
+      .placeholders(flywayPlaceholders().asJava)
       .configuration(configProps.asJava)
       .cleanDisabled(false)
       .load


### PR DESCRIPTION
Flyway can support placeholders so you don't repeat yourself, e.g.

`CREATE TABLE mill_table; CREATE TABLE mill_table2;` becomes `CREATE TABLE ${org}_table; CREATE TABLE ${org}_table2`.