### PR TITLE
Android: Create Scheduled CI Workflow

### DIFF
--- a/.github/actions/pre-build-setup/action.yml
+++ b/.github/actions/pre-build-setup/action.yml
@@ -53,7 +53,7 @@ runs:
       shell: bash
 
     - run: ./mill -k selective.prepare ${{ inputs.prepareargs }}
-      if: ${{ (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-all-tests')) || github.repository != 'com-lihaoyi/mill' || github.event_name == 'schedule' }}
+      if: ${{ (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-all-tests')) || github.repository != 'com-lihaoyi/mill' }}
       shell: ${{ inputs.shell }}
 
     - uses: actions/upload-artifact@v4.6.0

--- a/.github/actions/pre-build-setup/action.yml
+++ b/.github/actions/pre-build-setup/action.yml
@@ -53,7 +53,7 @@ runs:
       shell: bash
 
     - run: ./mill -k selective.prepare ${{ inputs.prepareargs }}
-      if: ${{ (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-all-tests')) || github.repository != 'com-lihaoyi/mill' }}
+      if: ${{ (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-all-tests')) || github.repository != 'com-lihaoyi/mill' || github.event_name == 'schedule' }}
       shell: ${{ inputs.shell }}
 
     - uses: actions/upload-artifact@v4.6.0

--- a/.github/actions/pre-build-setup/action.yml
+++ b/.github/actions/pre-build-setup/action.yml
@@ -53,7 +53,7 @@ runs:
       shell: bash
 
     - run: ./mill -k selective.prepare ${{ inputs.prepareargs }}
-      if: ${{ (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-all-tests')) || github.repository != 'com-lihaoyi/mill' }}
+      if: ${{ ((github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-all-tests')) || github.repository != 'com-lihaoyi/mill') && github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
       shell: ${{ inputs.shell }}
 
     - uses: actions/upload-artifact@v4.6.0

--- a/.github/workflows/scheduled-android-tests.yml
+++ b/.github/workflows/scheduled-android-tests.yml
@@ -14,8 +14,15 @@ env:
   FORCE_COLOR: '1'
 
 jobs:
+  build-linux:
+    uses: ./.github/workflows/pre-build.yml
+    with:
+      java-version: 21
+      os: ubuntu-latest
+      shell: bash
+
   android:
-    runs-on: ubuntu-latest
+    needs: build-linux
     strategy:
       fail-fast: false
       matrix:
@@ -27,24 +34,9 @@ jobs:
             millargs: example.thirdparty.android-endless-tunnel.packaged.daemon
             setup-android: true
     name: Android / ${{ matrix.name }}
-    steps:
-      - uses: actions/checkout@v5
-        with: { fetch-depth: 1 }
-      - uses: actions/setup-java@v5
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-      - uses: ./.github/actions/setup-android
-      - uses: coursier/cache-action@v8
-      - name: Run example
-        run: ./mill show ${{ matrix.millargs }}
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v5
-        if: always() # always run even if the previous step fails
-        with:
-          fail_on_failure: false
-          include_passed: false
-          detailed_summary: true
-          annotate_only: true
-          require_tests: false
-          report_paths: 'out/**/test-report.xml'
+    uses: ./.github/workflows/post-build-selective.yml
+    with:
+      setup-android: ${{ matrix.setup-android }}
+      java-version: 21
+      millargs: ${{ matrix.millargs }}
+      shell: bash

--- a/.github/workflows/scheduled-android-tests.yml
+++ b/.github/workflows/scheduled-android-tests.yml
@@ -28,7 +28,8 @@ jobs:
             setup-android: true
     name: Android / ${{ matrix.name }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
+        with: { fetch-depth: 1 }
       - uses: actions/setup-java@v5
         with:
           java-version: '21'

--- a/.github/workflows/scheduled-android-tests.yml
+++ b/.github/workflows/scheduled-android-tests.yml
@@ -14,23 +14,8 @@ env:
   FORCE_COLOR: '1'
 
 jobs:
-  build-linux:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/pre-build-setup
-        with:
-          os: ubuntu-latest
-          java-version: 21
-          shell: bash
-          prepareargs: 'example.thirdparty.{androidtodo,android-endless-tunnel}.packaged.daemon'
-      - uses: actions/upload-artifact@v6.0.0
-        with:
-          path: .
-          name: ubuntu-latest-artifact
-          include-hidden-files: true
   android:
-    needs: build-linux
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -42,9 +27,13 @@ jobs:
             millargs: example.thirdparty.android-endless-tunnel.packaged.daemon
             setup-android: true
     name: Android / ${{ matrix.name }}
-    uses: ./.github/workflows/post-build-selective.yml
-    with:
-      setup-android: ${{ matrix.setup-android }}
-      java-version: 21
-      millargs: ${{ matrix.millargs }}
-      shell: bash
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+      - uses: ./.github/actions/setup-android
+      - uses: coursier/cache-action@v8
+      - name: Run example
+        run: ./mill show ${{ matrix.millargs }}

--- a/.github/workflows/scheduled-android-tests.yml
+++ b/.github/workflows/scheduled-android-tests.yml
@@ -17,6 +17,7 @@ jobs:
   build-linux:
     uses: ./.github/workflows/pre-build.yml
     with:
+      compileargs: 'dist.executable + core.api.test.compile + testkit.compile + libs.androidlib.compile'
       java-version: 21
       os: ubuntu-latest
       shell: bash

--- a/.github/workflows/scheduled-android-tests.yml
+++ b/.github/workflows/scheduled-android-tests.yml
@@ -24,7 +24,11 @@ jobs:
           java-version: 21
           shell: bash
           prepareargs: 'example.thirdparty.{androidtodo,android-endless-tunnel}.packaged.daemon'
-      - run: ./mill -k ${{ inputs.compileargs }}
+      - uses: actions/upload-artifact@v6.0.0
+        with:
+          path: .
+          name: ubuntu-latest-artifact
+          include-hidden-files: true
   android:
     needs: build-linux
     strategy:

--- a/.github/workflows/scheduled-android-tests.yml
+++ b/.github/workflows/scheduled-android-tests.yml
@@ -15,12 +15,16 @@ env:
 
 jobs:
   build-linux:
-    uses: ./.github/workflows/pre-build.yml
-    with:
-      java-version: 21
-      os: ubuntu-latest
-      shell: bash
-
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/pre-build-setup
+        with:
+          os: ubuntu-latest
+          java-version: 21
+          shell: bash
+          prepareargs: 'example.thirdparty.{androidtodo,android-endless-tunnel}.packaged.daemon'
+      - run: ./mill -k ${{ inputs.compileargs }}
   android:
     needs: build-linux
     strategy:

--- a/.github/workflows/scheduled-android-tests.yml
+++ b/.github/workflows/scheduled-android-tests.yml
@@ -30,6 +30,9 @@ jobs:
           - name: androidtodo
             millargs: example.thirdparty.androidtodo.packaged.daemon
             setup-android: true
+          - name: android-endless-tunnel
+            millargs: example.thirdparty.android-endless-tunnel.packaged.daemon
+            setup-android: true
     name: Android / ${{ matrix.name }}
     uses: ./.github/workflows/post-build-selective.yml
     with:

--- a/.github/workflows/scheduled-android-tests.yml
+++ b/.github/workflows/scheduled-android-tests.yml
@@ -1,0 +1,39 @@
+name: Scheduled Android Tests
+
+on:
+  schedule:
+    # 03:00 every Sunday
+    - cron: '0 3 * * 0'
+  workflow_dispatch:
+
+concurrency:
+  group: scheduled-android-tests
+  cancel-in-progress: true
+
+env:
+  FORCE_COLOR: '1'
+
+jobs:
+  build-linux:
+    uses: ./.github/workflows/pre-build.yml
+    with:
+      java-version: 21
+      os: ubuntu-latest
+      shell: bash
+
+  android:
+    needs: build-linux
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: androidtodo
+            millargs: example.thirdparty.androidtodo.packaged.daemon
+            setup-android: true
+    name: Android / ${{ matrix.name }}
+    uses: ./.github/workflows/post-build-selective.yml
+    with:
+      setup-android: ${{ matrix.setup-android }}
+      java-version: 21
+      millargs: ${{ matrix.millargs }}
+      shell: bash

--- a/.github/workflows/scheduled-android-tests.yml
+++ b/.github/workflows/scheduled-android-tests.yml
@@ -38,3 +38,13 @@ jobs:
       - uses: coursier/cache-action@v8
       - name: Run example
         run: ./mill show ${{ matrix.millargs }}
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v5
+        if: always() # always run even if the previous step fails
+        with:
+          fail_on_failure: false
+          include_passed: false
+          detailed_summary: true
+          annotate_only: true
+          require_tests: false
+          report_paths: 'out/**/test-report.xml'

--- a/example/thirdparty/androidtodo/build.mill
+++ b/example/thirdparty/androidtodo/build.mill
@@ -278,7 +278,11 @@ object `shared-test` extends AndroidKotlinModule, AndroidHiltSupport {
   "Complete"
 ]
 
-> ./mill app.androidTest
+*/
+
+// (Exclude TasksScreenTest test class since it is flaky on CI)
+/** Usage
+> ./mill app.androidTest -e notClass com.example.android.architecture.blueprints.todoapp.tasks.TasksScreenTest
 
 > cat out/app/androidTest/testForked.dest/test-report.xml
 <?xml version='1.0' encoding='UTF-8'?>

--- a/example/thirdparty/androidtodo/build.mill
+++ b/example/thirdparty/androidtodo/build.mill
@@ -286,7 +286,7 @@ object `shared-test` extends AndroidKotlinModule, AndroidHiltSupport {
 
 > cat out/app/androidTest/testForked.dest/test-report.xml
 <?xml version='1.0' encoding='UTF-8'?>
-<testsuites tests="38" failures="0" errors="0" skipped="0" time="...">
+<testsuites tests="26" failures="0" errors="0" skipped="0" time="...">
 ...
 
 > ./mill show app.stopAndroidEmulator


### PR DESCRIPTION
### Adds 
- A `Scheduled Android Tests` workflow that will run periodically (every week?), in order to avoid testing certain examples on each merge/PR. 
For now this includes `androidtodo` and `android-endless-tunnel` (native example)

### Tweaks
- Makes `selective.prepare` not run when `event_name` is `scheduled` or `workflow_dispatch`
- Exclude a flaky instrumented test class of `androidtodo` from running on CI. Will look into it later on

Closes #6845
