### PR TITLE
Fix slowness in `showMvnDepsTree`

### DIFF
--- a/libs/javalib/src/mill/javalib/JavaModule.scala
+++ b/libs/javalib/src/mill/javalib/JavaModule.scala
@@ -1418,7 +1418,7 @@ trait JavaModule
     val treeTask = mvnDepsTree(args)
     Task.Command(exclusive = true) {
       val rendered = treeTask()
-      Task.log.streams.out.println(rendered)
+      Task.log.unprefixedStreams.out.println(rendered)
       rendered
     }
   }


### PR DESCRIPTION
Vibe coded

> Implemented a fix for issue [#6823](https://github.com/com-lihaoyi/mill/issues/6823) by changing `showMvnDepsTree` to print via the unprefixed logger stream:
> 
> - Changed `/Users/lihaoyi/Github/mill/libs/javalib/src/mill/javalib/JavaModule.scala:1421`
>   - from `Task.log.streams.out.println(rendered)`
>   - to `Task.log.unprefixedStreams.out.println(rendered)`
> 
> Why this fixes it:
> - `jstack` sampling during the hang showed `main` blocked in `PromptLogger.awaitPumperEmpty` while printing `showMvnDepsTree` output, i.e. output path throttling for massive trees.
> - Using `unprefixedStreams` bypasses that per-line prompt/prefix path for this large blob output.
> 
> Validation:
> - Ran `./mill -i libs.scalalib.test.testOnly mill.scalalib.CrossVersionTests`
> - Result: all 7 tests passed.
> 
> I also reproduced the slow spark case and confirmed it gets stuck in logger output handling; the patch targets exactly that bottleneck.