### PR TITLE
Use existing Path constructor in error reporting.

### DIFF
--- a/libs/javalib/worker/src/mill/javalib/zinc/TransformingReporter.scala
+++ b/libs/javalib/worker/src/mill/javalib/zinc/TransformingReporter.scala
@@ -82,12 +82,8 @@ private object TransformingReporter {
     InterfaceUtil.jo2o(pos.sourcePath()) match {
       case None => message
       case Some(path) =>
-        val absPath = os.FilePath(path) match {
-          case abs: os.Path => abs
-          // Assume relative paths are relative to the current workspaceRoot
-          case rel: os.RelPath => workspaceRoot / rel
-          case sub: os.SubPath => workspaceRoot / sub
-        }
+        // Assume relative paths are relative to the current workspaceRoot
+        val absPath = os.Path(path, workspaceRoot)
         // Render paths within the current workspaceRoot as relative paths to cut down on verbosity
         val displayPath =
           if absPath.startsWith(workspaceRoot) then absPath.subRelativeTo(workspaceRoot).toString


### PR DESCRIPTION
As per https://github.com/com-lihaoyi/mill/pull/6851#discussion_r2834819115