### PR TITLE
Use C1 for no-server (faster cold start)

### DIFF
--- a/runner/launcher/src/mill/launcher/MillProcessLauncher.scala
+++ b/runner/launcher/src/mill/launcher/MillProcessLauncher.scala
@@ -29,7 +29,13 @@ object MillProcessLauncher {
 
     val userPropsSeq = ClientUtil.getUserSetProperties().map { case (k, v) => s"-D$k=$v" }.toSeq
 
-    val cmd = millLaunchJvmCommand(runnerClasspath, outMode, workDir, millRepositories) ++
+    val cmd = millLaunchJvmCommand(
+      runnerClasspath,
+      outMode,
+      workDir,
+      millRepositories,
+      extraJvmOpts = Seq("-XX:TieredStopAtLevel=1")
+    ) ++
       userPropsSeq ++
       Seq(mainClass, processDir.toString, outMode.asString, useFileLocks.toString) ++
       loadMillConfig(ConfigConstants.millOpts, workDir) ++
@@ -192,7 +198,8 @@ object MillProcessLauncher {
       runnerClasspath: Seq[os.Path],
       outMode: OutFolderMode,
       workDir: os.Path,
-      millRepositories: Seq[String]
+      millRepositories: Seq[String],
+      extraJvmOpts: Seq[String] = Seq.empty
   ): Seq[String] = {
     val millProps = sys.props.toSeq
       .filter(_._1.startsWith("MILL_"))
@@ -211,6 +218,7 @@ object MillProcessLauncher {
       millProps ++
       serverTimeoutOpt ++
       encodingOpts ++
+      extraJvmOpts ++
       loadMillConfig(ConfigConstants.millJvmOpts, workDir) ++
       Seq("-cp", runnerClasspath.mkString(File.pathSeparator))
   }


### PR DESCRIPTION
This change is only for "--no-server".

Since this is a single-run mode the startup time to analyze and compile C2 takes longer than the run itself.

On a project like Ammonite the cold start before is 29s and after is 24s (tested locally). Pretty big savings.

On a Spring hello world example before is 7.5s and after is 5.9s.

Big savings, pretty useful for cases like CI or other single use cases.