### PR TITLE
Add warning header if looking at old or unstable versions of docs

### DIFF
--- a/website/docs/supplemental-ui/partials/header-content.hbs
+++ b/website/docs/supplemental-ui/partials/header-content.hbs
@@ -132,7 +132,7 @@
       <strong>
         WARNING: this page contains documentation for an old/unstable version of Mill
         ({{page.componentVersion.displayVersion}}). The latest stable Mill version is
-        {{site.keys.latest_stable_mill_version}} and its documentation can be found at
+        {{page.component.latest.displayVersion}} and its documentation can be found at
         <a href="{{{or site.url (or siteRootUrl siteRootPath)}}}">{{{or site.url (or siteRootUrl siteRootPath)}}}</a>
       </strong>
     </div>

--- a/website/package.mill
+++ b/website/package.mill
@@ -262,7 +262,6 @@ object `package` extends mill.Module {
        |  start_page: mill::index.adoc
        |  keys:
        |    google_analytics: 'G-1C582ZJR85'
-       |    latest_stable_mill_version: '${Settings.docTags.last}'
        |
        |content:
        |  sources:


### PR DESCRIPTION
This should make it clearer to humans/search-engines/AI-agents what the current version of the docs are, hopefully avoiding confusion from learning out of date patterns or APIs