### PR TITLE
Properly propagate incomplete UTF-8 bytes separately to avoid corruption during string construction

### DIFF
--- a/libs/rpc/src/mill/rpc/RpcConsole.scala
+++ b/libs/rpc/src/mill/rpc/RpcConsole.scala
@@ -9,13 +9,7 @@ trait RpcConsole { self =>
   def println(s: String): Unit = print(s + "\n")
   def flush(): Unit
 
-  def asStream: OutputStream = new {
-    override def write(b: Int): Unit = self.print(b.toChar.toString)
-    override def write(b: Array[Byte]): Unit = self.print(String(b, StandardCharsets.UTF_8))
-    override def write(b: Array[Byte], off: Int, len: Int): Unit =
-      self.print(String(b, off, len, StandardCharsets.UTF_8))
-    override def flush(): Unit = self.flush()
-  }
+  def asStream: OutputStream = new RpcConsole.Utf8OutputStream(self)
 }
 object RpcConsole {
   enum Message derives upickle.ReadWriter {
@@ -34,5 +28,88 @@ object RpcConsole {
   def printStreamHandler(printStream: PrintStream, msg: Message): Unit = msg match {
     case Message.Print(s) => printStream.print(s)
     case Message.Flush => printStream.flush()
+  }
+
+  /**
+   * An OutputStream that buffers incomplete UTF-8 byte sequences across writes,
+   * forwarding only complete characters as strings to the underlying [[RpcConsole]].
+   *
+   * This is needed because upstream byte sources (e.g. [[mill.constants.ProxyStream]])
+   * may split writes at arbitrary byte boundaries, potentially in the middle of
+   * multi-byte UTF-8 characters. Without buffering, such partial sequences would be
+   * converted to the Unicode replacement character (U+FFFD).
+   */
+  class Utf8OutputStream(console: RpcConsole) extends OutputStream {
+    // Pending bytes from an incomplete UTF-8 sequence at the end of the last write
+    private var pending: Array[Byte] = Array.emptyByteArray
+
+    override def write(b: Int): Unit = write(Array(b.toByte), 0, 1)
+
+    override def write(b: Array[Byte]): Unit = write(b, 0, b.length)
+
+    override def write(b: Array[Byte], off: Int, len: Int): Unit = {
+      if (len == 0) return
+
+      // Combine any pending bytes with the new data
+      val data =
+        if (pending.isEmpty) java.util.Arrays.copyOfRange(b, off, off + len)
+        else {
+          val combined = new Array[Byte](pending.length + len)
+          System.arraycopy(pending, 0, combined, 0, pending.length)
+          System.arraycopy(b, off, combined, pending.length, len)
+          combined
+        }
+
+      // Find the boundary after the last complete UTF-8 character
+      val boundary = lastCompleteUtf8Boundary(data)
+
+      if (boundary > 0) {
+        console.print(new String(data, 0, boundary, StandardCharsets.UTF_8))
+      }
+
+      pending =
+        if (boundary < data.length) java.util.Arrays.copyOfRange(data, boundary, data.length)
+        else Array.emptyByteArray
+    }
+
+    override def flush(): Unit = {
+      // Flush any pending bytes (they are likely malformed; let String handle them)
+      if (pending.nonEmpty) {
+        console.print(new String(pending, StandardCharsets.UTF_8))
+        pending = Array.emptyByteArray
+      }
+      console.flush()
+    }
+
+    override def close(): Unit = flush()
+  }
+
+  /**
+   * Returns the index in `data` after the last complete UTF-8 character.
+   * Any trailing incomplete multi-byte sequence is excluded so it can be
+   * buffered for the next write.
+   */
+  private[rpc] def lastCompleteUtf8Boundary(data: Array[Byte]): Int = {
+    val len = data.length
+    if (len == 0) return 0
+
+    // Walk backwards past continuation bytes (10xxxxxx)
+    var i = len - 1
+    while (i >= 0 && (data(i) & 0xc0) == 0x80) i -= 1
+
+    // If we didn't find a leading byte, all bytes are continuations (malformed)
+    if (i < 0) return len
+
+    val leadByte = data(i) & 0xff
+    val expectedLen =
+      if ((leadByte & 0x80) == 0) 1 // 0xxxxxxx  — ASCII
+      else if ((leadByte & 0xe0) == 0xc0) 2 // 110xxxxx — 2-byte
+      else if ((leadByte & 0xf0) == 0xe0) 3 // 1110xxxx — 3-byte
+      else if ((leadByte & 0xf8) == 0xf0) 4 // 11110xxx — 4-byte
+      else 1 // Invalid leading byte; treat as single byte
+
+    val actualLen = len - i
+    if (actualLen >= expectedLen) len // last sequence is complete
+    else i // last sequence is incomplete — exclude it
   }
 }


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/6891, Vibe Coded

⏺ Problem                                                                                                                 
                                                                                                                        
  In daemon mode, all output from the Mill daemon is forwarded to the launcher client via RPC. The RPC protocol serializes
   output as JSON strings, so bytes must be converted to String at the boundary. This happened in RpcConsole.asStream   
  (libs/rpc/src/mill/rpc/RpcConsole.scala), which wrapped an OutputStream that called new String(bytes, UTF_8) on every   
  write call.                                                                                                           

  Upstream byte sources split writes at arbitrary boundaries — ProxyStream.Output splits into 126-byte packets,
  InputPumper reads in 1024-byte chunks. When a multi-byte UTF-8 character (e.g., the 3-byte box-drawing character ─)
  straddled one of these boundaries, the bytes were split across two independent write calls. Each call converted its
  partial byte sequence to a String, producing U+FFFD replacement characters instead of the intended character.

  mill -i avoided the issue because -i is an alias for --no-daemon, which bypasses the RPC path entirely.

  Fix

  Replaced the naive inline asStream implementation with RpcConsole.Utf8OutputStream, which buffers trailing incomplete
  UTF-8 byte sequences across write calls. On each write it finds the last complete UTF-8 character boundary, converts
  only the complete bytes to a String, and holds back any trailing partial sequence until the next write supplies the
  remaining bytes. On flush/close, any remaining pending bytes are emitted as-is.