### PR TITLE
Fix some trapped output

### DIFF
--- a/core/internal/src/mill/internal/PromptLogger.scala
+++ b/core/internal/src/mill/internal/PromptLogger.scala
@@ -180,7 +180,7 @@ class PromptLogger(
             if (reportedIdentifiers(key) && lines0.isEmpty) None
             else {
               reportedIdentifiers.add(key)
-              seenIdentifiers.get(key)
+              seenIdentifiers.get(key).orElse(Some(("", "")))
             }
 
           val lines = for (line <- lines0) yield {


### PR DESCRIPTION
Consider this change with caution. I'm opening this more as an issue than as a PR (although if you think the change is fine, let's merge it).

When printing things to stderr right after [this line](https://github.com/com-lihaoyi/mill/blob/1c0cf1a4e05da1f4b44a5defcf21cd268dc0c1a7/runner/daemon/src/mill/daemon/MillMain0.scala#L277), without this change, the printed stuff gets trapped. Diving into this with Claude AI, I ended up finding that this change fixes that problem. It also doesn't break the CI.

I don't understand much about all the proxy stream / prompt logger and all logic, so I'm not sure what other implications this change could have.