### PR TITLE
Print concurrent Mill process PID when waiting for lock

### DIFF
--- a/integration/dedicated/bsp-server/src/BspServerTests.scala
+++ b/integration/dedicated/bsp-server/src/BspServerTests.scala
@@ -455,7 +455,8 @@ object BspServerTests extends UtestIntegrationTestSuite {
           // ignore watcher logs
           val watchGlob = TestRunnerUtils.matchesGlob("bsp-watch] *")
           // ignoring compilation warnings that might go away in the future
-          val waitingGlob = TestRunnerUtils.matchesGlob("*] Another Mill process is running *")
+          val waitingGlob =
+            TestRunnerUtils.matchesGlob("*] Another Mill process with PID * is running *")
           s =>
             watchGlob(s) || waitingGlob(s) ||
               // These can happen in different orders due to filesystem ordering, not stable to

--- a/integration/dedicated/concurrent-interrupt-shutdown/src/ConcurrentInterruptShutdownTests.scala
+++ b/integration/dedicated/concurrent-interrupt-shutdown/src/ConcurrentInterruptShutdownTests.scala
@@ -20,7 +20,12 @@ object ConcurrentInterruptShutdownTests extends UtestIntegrationTestSuite {
 
       assertEventually(
         launcher2.err.text().contains(
-          "Another Mill process is running 'waitForExists --fileName file1.txt', waiting for it to be done..."
+          "Another Mill process with PID "
+        )
+      )
+      assertEventually(
+        launcher2.err.text().contains(
+          " is running 'waitForExists --fileName file1.txt', waiting for it to be done..."
         )
       )
       launcher2.process.destroy(recursive = false)
@@ -40,7 +45,12 @@ object ConcurrentInterruptShutdownTests extends UtestIntegrationTestSuite {
 
       assertEventually(
         launcher2.err.text().contains(
-          "Another Mill process is running 'waitForExists --fileName file1.txt', waiting for it to be done..."
+          "Another Mill process with PID "
+        )
+      )
+      assertEventually(
+        launcher2.err.text().contains(
+          " is running 'waitForExists --fileName file1.txt', waiting for it to be done..."
         )
       )
       launcher1.process.destroy(recursive = false)

--- a/integration/dedicated/output-directory/src/OutputDirectoryLockTests.scala
+++ b/integration/dedicated/output-directory/src/OutputDirectoryLockTests.scala
@@ -35,7 +35,14 @@ object OutputDirectoryLockTests extends UtestIntegrationTestSuite {
         noWaitRes
           .err
           .contains(
-            s"Another Mill process is running 'show blockWhileExists --path $signalFile', failing"
+            s"Another Mill process with PID "
+          )
+      )
+      assert(
+        noWaitRes
+          .err
+          .contains(
+            s" is running 'show blockWhileExists --path $signalFile', failing"
           )
       )
 
@@ -49,7 +56,10 @@ object OutputDirectoryLockTests extends UtestIntegrationTestSuite {
       assertEventually {
         val stderrText = spawnedWaitingRes.err.text()
         stderrText.contains(
-          s"Another Mill process is running 'show blockWhileExists --path $signalFile', waiting for it to be done..."
+          s"Another Mill process with PID "
+        ) &&
+        stderrText.contains(
+          s" is running 'show blockWhileExists --path $signalFile', waiting for it to be done..."
         ) &&
         stderrText.contains("tail -F out/mill-console-tail to see its progress")
       }

--- a/libs/daemon/server/src/mill/server/Server.scala
+++ b/libs/daemon/server/src/mill/server/Server.scala
@@ -471,34 +471,37 @@ object Server {
   )(t: => T): T = {
     if (noBuildLock) t
     else {
-      def readActiveInfo(): (String, Option[os.Path]) = {
+      def readActiveInfo(): (command: String, processDir: Option[os.Path], pid: Option[Long]) = {
         try {
           val json = os.read(out / OutFiles.millActive)
           // Simple JSON parsing for {"command":"...","processDir":"..."}
           val commandPattern = """"command"\s*:\s*"([^"]*)"""".r
           val processDirPattern = """"processDir"\s*:\s*"([^"]*)"""".r
+          val pidPattern = """"pid"\s*:\s*([0-9]+)""".r
           val command = commandPattern.findFirstMatchIn(json).map(_.group(1)).getOrElse("<unknown>")
           val processDir = processDirPattern.findFirstMatchIn(json).map(m => os.Path(m.group(1)))
-          (command, processDir)
+          val pid = pidPattern.findFirstMatchIn(json).flatMap(m => m.group(1).toLongOption)
+          (command, processDir, pid)
         } catch {
-          case NonFatal(_) => ("<unknown>", None)
+          case NonFatal(_) => ("<unknown>", None, None)
         }
       }
 
-      def activeTaskPrefix(command: String) = s"Another Mill process is running '$command',"
+      def activeTaskPrefix(command: String, pidOpt: Option[Long]) =
+        s"Another Mill process with PID ${pidOpt.fold("<unknown>")(_.toString)} is running '$command',"
 
       setIdle(true)
       Using.resource {
         val tryLocked = outLock.tryLock()
         if (tryLocked.isLocked) tryLocked
         else if (noWaitForBuildLock) {
-          val (command, _) = readActiveInfo()
-          throw new Exception(s"${activeTaskPrefix(command)} failing")
+          val (command, _, pidOpt) = readActiveInfo()
+          throw new Exception(s"${activeTaskPrefix(command, pidOpt)} failing")
         } else {
-          val (command, _) = readActiveInfo()
+          val (command, _, pidOpt) = readActiveInfo()
           val consoleLogPath = out / DaemonFiles.millConsoleTail
           streams.err.println(
-            s"${activeTaskPrefix(command)} waiting for it to be done... " +
+            s"${activeTaskPrefix(command, pidOpt)} waiting for it to be done... " +
               s"(tail -F ${consoleLogPath.relativeTo(mill.api.BuildCtx.workspaceRoot)} to see its progress)"
           )
           outLock.lock()
@@ -506,7 +509,9 @@ object Server {
       } { _ =>
         setIdle(false)
         if (Thread.interrupted()) throw new InterruptedException()
-        val json = s"""{"command":"$millActiveCommandMessage","processDir":"$daemonDir"}"""
+        val pid = ProcessHandle.current().pid()
+        val json =
+          s"""{"command":"$millActiveCommandMessage","processDir":"$daemonDir","pid":$pid}"""
         os.write.over(out / OutFiles.millActive, json)
         try t
         finally os.remove.all(out / OutFiles.millActive)


### PR DESCRIPTION
This makes Mill print the PID of the other Mill process, when the current one is waiting for another Mill process to be done.

Instead of printing
```text
Another Mill process is running _some task_, waiting for it to be done...
```
we print
```text
Another Mill process with PID XXX is running _some task_, waiting for it to be done...
```

This allows users to kill the other process if they don't expect another Mill process to be running. Printing the PID is handy in that case.