### PR TITLE
Allow users to discover tests classes via zinc

### DIFF
--- a/libs/javalib/api/src/mill/javalib/api/internal/ZincOp.scala
+++ b/libs/javalib/api/src/mill/javalib/api/internal/ZincOp.scala
@@ -61,9 +61,18 @@ object ZincOp {
       testCp: Seq[os.Path],
       framework: String,
       selectors: Seq[String],
-      args: Seq[String]
+      args: Seq[String],
+      discoveredClassesOpt: Option[Seq[(String, Int)]]
   ) extends ZincOp {
     type Response = Seq[String]
+  }
+
+  case class DiscoverTestsZinc(
+      runCp: Seq[os.Path],
+      analysisFile: os.Path,
+      framework: String
+  ) extends ZincOp {
+    type Response = Seq[(String, Int)]
   }
 
   case class DiscoverJunit5Tests(

--- a/libs/javalib/src/mill/javalib/JavaModule.scala
+++ b/libs/javalib/src/mill/javalib/JavaModule.scala
@@ -135,6 +135,8 @@ trait JavaModule
      * @throws MillException
      */
     protected def hierarchyChecks(): Unit = JavaModule.hierarchyChecks(outer, this)
+
+    protected def zincAnalysisFile = Task.Anon(Some(compile().analysisFile))
   }
 
   def defaultTask(): String = "run"

--- a/libs/javalib/src/mill/javalib/TestModule.scala
+++ b/libs/javalib/src/mill/javalib/TestModule.scala
@@ -69,22 +69,79 @@ trait TestModule
   }
 
   /**
+   * Enables test class discovery using Zinc analysis file
+   *
+   * Set this to true to have Mill find test classes reading the Zinc analysis file
+   * rather than by reading class files. This is required when using junit4 from Scala.js
+   * tests, by using Scala.js junit compatibility library, for example.
+   */
+  protected def discoverTestsWithZinc: Boolean = false
+
+  /**
+   * Path to the Zinc analysis file
+   *
+   * Only used when `discoverTestsWithZinc` is true. See `discoverTestsWithZinc` for more details.
+   */
+  protected def zincAnalysisFile: Task[Option[os.Path]] = Task.Anon(None)
+
+  /**
    * Test classes (often called test suites) discovered by the configured [[testFramework]].
    */
-  def discoveredTestClasses: T[Seq[String]] = Task {
-    val worker = jvmWorker().internalWorker()
-    val discoveredTests = worker.apply(
-      ZincOp.DiscoverTests(
-        runClasspath().map(_.path),
-        testClasspath().map(_.path),
-        testFramework()
-      ),
-      javaHome().map(_.path),
-      javaRuntimeOptions = testDiscoverRuntimeOptions()
-    )
+  def discoveredTestClasses: T[Seq[String]] =
+    if (discoverTestsWithZinc)
+      Task {
+        zincAnalysisFileDiscoveredTestClasses().map(_._1)
+      }
+    else
+      Task {
+        val worker = jvmWorker().internalWorker()
+        val discoveredTests = worker.apply(
+          ZincOp.DiscoverTests(
+            runClasspath().map(_.path),
+            testClasspath().map(_.path),
+            testFramework()
+          ),
+          javaHome().map(_.path),
+          javaRuntimeOptions = testDiscoverRuntimeOptions()
+        )
 
-    discoveredTests.sorted
-  }
+        discoveredTests.sorted
+      }
+
+  /**
+   * Test classes discovered by reading the Zinc analysis file
+   */
+  protected def zincAnalysisFileDiscoveredTestClasses: T[Seq[(String, Int)]] =
+    Task {
+      val worker = jvmWorker().internalWorker()
+      worker.apply(
+        ZincOp.DiscoverTestsZinc(
+          runClasspath().map(_.path),
+          zincAnalysisFile().getOrElse {
+            Task.fail(
+              "No zinc analysis file available. discoverTestsWithZinc can only be set to true on JavaTests and its sub-classes."
+            )
+          },
+          testFramework()
+        ),
+        javaHome().map(_.path),
+        javaRuntimeOptions = testDiscoverRuntimeOptions()
+      )
+    }
+
+  /**
+   * When running tests, do not let the Mill test runner re-discover test classes, but use those instead
+   *
+   * For now, this is only used when test class discovery using the Zinc analysis file is enabled,
+   * see `discoverTestsWithZinc`.
+   */
+  protected def aheadOfTimeDiscoveredTestClassesIfNeeded: Task[Option[Seq[(String, Int)]]] =
+    if (discoverTestsWithZinc)
+      Task.Anon {
+        Some(zincAnalysisFileDiscoveredTestClasses())
+      }
+    else
+      Task.Anon(None)
 
   /**
    * Default arguments to be passed to `testForked`, `testOnly`, and `testCached`
@@ -217,7 +274,8 @@ trait TestModule
         colored = Task.log.prompt.colored,
         testCp = testClasspath().map(_.path),
         globSelectors = Left(selectors),
-        logLevel = testLogLevel()
+        logLevel = testLogLevel(),
+        discoveredTestClasses = aheadOfTimeDiscoveredTestClassesIfNeeded()
       )
 
       val argsFile = Task.dest / "testargs"
@@ -276,7 +334,8 @@ trait TestModule
         testParallelism(),
         testLogLevel(),
         propagateEnv(),
-        jvmWorker().internalWorker()
+        jvmWorker().internalWorker(),
+        discoveredClassesOpt = aheadOfTimeDiscoveredTestClassesIfNeeded()
       )
       testModuleUtil.runTests()
     }
@@ -292,7 +351,8 @@ trait TestModule
         runClasspath().map(_.path),
         Seq.from(testClasspath().map(_.path)),
         args,
-        Task.testReporter
+        Task.testReporter,
+        discoveredTestClasses = aheadOfTimeDiscoveredTestClassesIfNeeded()
       )
       TestModule.handleResults(doneMsg, results, Task.ctx(), testReportXml())
     }
@@ -316,7 +376,7 @@ trait TestModule
       ) { classLoader =>
         val framework = Framework.framework(testFramework())(classLoader)
         framework.name() -> TestRunnerUtils
-          .discoverTests(classLoader, framework, testClasspath().map(_.path))
+          .discoverTests(classLoader, framework, testClasspath().map(_.path), None)
       }
     val classes = classFingerprint.map(classF => classF._1.getName.stripSuffix("$"))
     (frameworkName = frameworkName, classes = classes)

--- a/libs/javalib/src/mill/javalib/TestModuleUtil.scala
+++ b/libs/javalib/src/mill/javalib/TestModuleUtil.scala
@@ -48,7 +48,9 @@ final class TestModuleUtil(
     testParallelism: Boolean,
     testLogLevel: TestReporter.LogLevel,
     propagateEnv: Boolean = true,
-    jvmWorker: mill.javalib.api.internal.InternalJvmWorkerApi
+    jvmWorker: mill.javalib.api.internal.InternalJvmWorkerApi,
+    @com.lihaoyi.unroll
+    discoveredClassesOpt: Option[Seq[(String, Int)]] = None
 )(using ctx: mill.api.TaskCtx) {
 
   private val (jvmArgs, props) = TestModuleUtil.loadArgsAndProps(useArgsFile, forkArgs)
@@ -83,7 +85,8 @@ final class TestModuleUtil(
           testClasspath.map(_.path),
           testFramework,
           selectors,
-          args
+          args,
+          discoveredClassesOpt
         ),
         javaHome = javaHome
       ).toSet
@@ -131,7 +134,8 @@ final class TestModuleUtil(
       colored = Task.log.prompt.colored,
       testCp = testClasspath.map(_.path),
       globSelectors = selector,
-      logLevel = testLogLevel
+      logLevel = testLogLevel,
+      discoveredTestClasses = discoveredClassesOpt
     )
 
     val argsFile = baseFolder / "testargs"

--- a/libs/javalib/testrunner/src/mill/javalib/testrunner/DiscoverTests.scala
+++ b/libs/javalib/testrunner/src/mill/javalib/testrunner/DiscoverTests.scala
@@ -10,7 +10,7 @@ import mill.api.daemon.internal.internal
       sharedPrefixes = Seq("sbt.testing.")
     ) { classLoader =>
       TestRunnerUtils
-        .discoverTests(classLoader, Framework.framework(framework)(classLoader), testCp)
+        .discoverTests(classLoader, Framework.framework(framework)(classLoader), testCp, None)
         .toSeq
         .map(_._1.getName())
         .map {

--- a/libs/javalib/testrunner/src/mill/javalib/testrunner/GetTestTasks.scala
+++ b/libs/javalib/testrunner/src/mill/javalib/testrunner/GetTestTasks.scala
@@ -17,7 +17,8 @@ import mill.api.daemon.internal.internal
           Seq.from(testCp),
           args,
           cls => globFilter(cls.getName),
-          classLoader
+          classLoader,
+          discoveredClassesOpt
         )
         .toSeq
     }

--- a/libs/javalib/testrunner/src/mill/javalib/testrunner/Model.scala
+++ b/libs/javalib/testrunner/src/mill/javalib/testrunner/Model.scala
@@ -18,7 +18,8 @@ import mill.api.daemon.internal.{TestReporter, internal}
     // - Right((selectorFolder: os.Path, baseFolder: os.Path)): - a pair of paths, testrunner will try to claim test glob from selectorFolder
     // and move it actomatically in to baseFolder and run it from there.
     globSelectors: Either[Seq[String], (Option[String], os.Path, os.Path)],
-    logLevel: TestReporter.LogLevel
+    logLevel: TestReporter.LogLevel,
+    discoveredTestClasses: Option[Seq[(String, Int)]]
 )
 
 @internal object TestArgs {

--- a/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunner.scala
+++ b/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunner.scala
@@ -11,6 +11,7 @@ import mill.util.Jvm
       testClassfilePath: Seq[os.Path],
       args: Seq[String],
       testReporter: TestReporter,
+      discoveredTestClasses: Option[Seq[(String, Int)]],
       classFilter: Class[?] => Boolean = _ => true
   ): (String, Seq[TestResult]) = {
     Jvm.withClassLoader(
@@ -23,7 +24,8 @@ import mill.util.Jvm
         args,
         classFilter,
         classLoader,
-        testReporter
+        testReporter,
+        discoveredTestClasses
       )
     }
   }

--- a/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunnerMain0.scala
+++ b/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunnerMain0.scala
@@ -18,6 +18,7 @@ import mill.api.daemon.internal.{TestReporter, internal}
             classFilter = cls => filter(cls.getName),
             cl = classLoader,
             testReporter = TestReporter(testArgs.logLevel),
+            discoveredTestClasses = testArgs.discoveredTestClasses,
             resultPathOpt = Some(testArgs.resultPath)
           )
         case Right((startingTestClass, testClassQueueFolder, claimFolder)) =>
@@ -30,6 +31,7 @@ import mill.api.daemon.internal.{TestReporter, internal}
             claimFolder = claimFolder,
             cl = classLoader,
             testReporter = TestReporter(testArgs.logLevel),
+            discoveredTestClasses = testArgs.discoveredTestClasses,
             resultPath = testArgs.resultPath
           )
       }

--- a/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunnerUtils.scala
+++ b/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunnerUtils.scala
@@ -41,12 +41,13 @@ import scala.math.Ordering.Implicits.*
   def discoverTests(
       cl: ClassLoader,
       framework: Framework,
-      classpath: Seq[os.Path]
+      classpath: Seq[os.Path],
+      discoveredTestClasses: Option[Seq[(String, Int)]]
   ): Seq[ClassWithFingerprint] = {
 
     val fingerprints = framework.fingerprints()
 
-    val testClasses = classpath
+    def foundTestClasses = classpath
       // Don't blow up if there are no classfiles representing
       // the tests to run Instead just don't run anything
       .filter(os.exists(_))
@@ -83,7 +84,16 @@ import scala.math.Ordering.Implicits.*
       // https://stackoverflow.com/a/17468590
       .filter { case (c, _) => !c.isMemberClass && !c.isAnonymousClass }
 
-    testClasses
+    discoveredTestClasses match {
+      case Some(discoveredTestClasses0) =>
+        discoveredTestClasses0.map {
+          case (clsName, fingerprintIdx) =>
+            val cls = cl.loadClass(clsName)
+            (cls, fingerprints(fingerprintIdx))
+        }
+      case None =>
+        foundTestClasses
+    }
   }
 
   def matchFingerprints(
@@ -116,11 +126,12 @@ import scala.math.Ordering.Implicits.*
       args: Seq[String],
       classFilter: Class[?] => Boolean,
       cl: ClassLoader,
-      testClassfilePath: Seq[Path]
+      testClassfilePath: Seq[Path],
+      discoveredTestClasses: Option[Seq[(String, Int)]]
   ): (Runner, Array[Array[Task]]) = {
 
     val runner = framework.runner(args.toArray, Array[String](), cl)
-    val testClasses = discoverTests(cl, framework, testClassfilePath)
+    val testClasses = discoverTests(cl, framework, testClassfilePath, discoveredTestClasses)
 
     val tasks = runner.tasks(
       for ((cls, fingerprint) <- testClasses.iterator.toArray if classFilter(cls))
@@ -271,12 +282,14 @@ import scala.math.Ordering.Implicits.*
       classFilter: Class[?] => Boolean,
       cl: ClassLoader,
       testReporter: TestReporter,
+      discoveredTestClasses: Option[Seq[(String, Int)]],
       resultPathOpt: Option[os.Path] = None
   ): (String, Seq[TestResult]) = {
 
     val framework = frameworkInstances(cl)
 
-    val (runner, tasksArr) = getTestTasks(framework, args, classFilter, cl, testClassfilePath)
+    val (runner, tasksArr) =
+      getTestTasks(framework, args, classFilter, cl, testClassfilePath, discoveredTestClasses)
 
     val (doneMessage, results) =
       runTasks(tasksArr.view.map(_.toSeq).toSeq, testReporter, runner, resultPathOpt)
@@ -360,14 +373,15 @@ import scala.math.Ordering.Implicits.*
       claimFolder: os.Path,
       cl: ClassLoader,
       testReporter: TestReporter,
-      resultPath: os.Path
+      resultPath: os.Path,
+      discoveredTestClasses: Option[Seq[(String, Int)]]
   ): (String, Seq[TestResult]) = {
 
     val framework = frameworkInstances(cl)
 
     val runner = framework.runner(args.toArray, Array[String](), cl)
 
-    val testClasses = discoverTests(cl, framework, testClassfilePath)
+    val testClasses = discoverTests(cl, framework, testClassfilePath, discoveredTestClasses)
 
     val (doneMessage, results) = runTasksFromQueue(
       startingTestClass,
@@ -387,11 +401,12 @@ import scala.math.Ordering.Implicits.*
       testClassfilePath: Seq[Path],
       args: Seq[String],
       classFilter: Class[?] => Boolean,
-      cl: ClassLoader
+      cl: ClassLoader,
+      discoveredTestClasses: Option[Seq[(String, Int)]]
   ): Array[String] = {
     val framework = frameworkInstances(cl)
     val ( /*runner*/ _, tasksArr) =
-      getTestTasks(framework, args, classFilter, cl, testClassfilePath)
+      getTestTasks(framework, args, classFilter, cl, testClassfilePath, discoveredTestClasses)
     tasksArr.flatten.map(_.taskDef()).filter(_ != null).map(_.fullyQualifiedName())
   }
 

--- a/libs/javalib/worker/src/mill/javalib/zinc/TestDiscovery.scala
+++ b/libs/javalib/worker/src/mill/javalib/zinc/TestDiscovery.scala
@@ -1,0 +1,91 @@
+package mill.javalib.zinc
+
+import mill.javalib.api.internal.ZincOp
+import xsbt.api.Discovery
+import mill.javalib.testrunner.Framework
+import sbt.testing.SubclassFingerprint
+import sbt.testing.AnnotatedFingerprint
+import sbt.internal.inc.FileAnalysisStore
+import sbt.internal.inc.Analysis
+import xsbti.api.Definition
+import mill.api.daemon.internal.NonFatal
+import sbt.testing.Fingerprint
+import xsbt.api.Discovered
+import xsbti.api.ClassLike
+
+object TestDiscovery {
+  def apply(op: ZincOp.DiscoverTestsZinc): Seq[(String, Int)] = {
+    import op.*
+    mill.util.Jvm.withClassLoader(
+      classPath = runCp,
+      sharedPrefixes = Seq("sbt.testing.")
+    ) { classLoader =>
+      val frameworkInstance = Framework.framework(framework)(classLoader)
+      val fingerprints = frameworkInstance.fingerprints()
+
+      val analysis = FileAnalysisStore.binary(analysisFile.toIO)
+        .get()
+        .get()
+        .getAnalysis
+        .asInstanceOf[Analysis]
+
+      discover(fingerprints, allDefs(analysis))
+    }
+  }
+
+  // Initially adapted from https://github.com/sbt/sbt/blob/f64b5288ca0711c84a0345276441671d6f3b240e/main-actions/src/main/scala/sbt/Tests.scala#L547-L586
+  private def discover(
+      fingerprints: Seq[Fingerprint],
+      definitions: Seq[Definition]
+  ): Seq[(String, Int)] = {
+    val subclasses = fingerprints
+      .collect {
+        case sub: SubclassFingerprint =>
+          sub.superclassName
+      }
+      .toSet
+    val annotations = fingerprints
+      .collect {
+        case ann: AnnotatedFingerprint =>
+          ann.annotationName
+      }
+      .toSet
+
+    def toFingerprintIndices(d: Discovered): Seq[Int] =
+      fingerprints.zipWithIndex.collect {
+        case (sub: SubclassFingerprint, idx)
+            if sub.isModule == d.isModule && d.baseClasses.contains(sub.superclassName) =>
+          idx
+        case (ann: AnnotatedFingerprint, idx)
+            if ann.isModule == d.isModule && d.annotations.contains(ann.annotationName) =>
+          idx
+      }
+
+    val discovered = Discovery(subclasses, annotations)(
+      definitions.filter {
+        case c: ClassLike =>
+          c.topLevel
+        case _ => false
+      }
+    )
+
+    for {
+      (df, di) <- discovered
+      fingerprintIdx <- toFingerprintIndices(di)
+    } yield (df.name, fingerprintIdx)
+  }
+
+  // Copied and adapted from https://github.com/sbt/sbt/blob/f64b5288ca0711c84a0345276441671d6f3b240e/main-actions/src/main/scala/sbt/Tests.scala#L528-L546
+  private def allDefs(analysis: Analysis): Seq[Definition] =
+    analysis.apis.internal.values.toVector.flatMap { ac =>
+      try
+        Seq(ac.api.classApi, ac.api.objectApi) ++
+          ac.api.classApi.structure.declared.toSeq ++
+          ac.api.classApi.structure.inherited.toSeq ++
+          ac.api.objectApi.structure.declared.toSeq ++
+          ac.api.objectApi.structure.inherited.toSeq
+      catch
+        case NonFatal(e) if e.getMessage.startsWith("No companions") =>
+          Nil
+    }
+}

--- a/libs/javalib/worker/src/mill/javalib/zinc/ZincWorker.scala
+++ b/libs/javalib/worker/src/mill/javalib/zinc/ZincWorker.scala
@@ -593,6 +593,9 @@ class ZincWorker(jobs: Int, useFileLocks: Boolean = false) extends AutoCloseable
       case msg: ZincOp.DiscoverTests =>
         mill.javalib.testrunner.DiscoverTests(msg).asInstanceOf[op.Response]
 
+      case msg: ZincOp.DiscoverTestsZinc =>
+        TestDiscovery(msg).asInstanceOf[op.Response]
+
       case msg: ZincOp.GetTestTasks =>
         mill.javalib.testrunner.GetTestTasks(msg).asInstanceOf[op.Response]
 

--- a/libs/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/libs/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -418,6 +418,7 @@ trait TestScalaJSModule extends ScalaJSModule with TestModule {
       Seq(compile().classes.path),
       args(),
       Task.testReporter,
+      aheadOfTimeDiscoveredTestClassesIfNeeded(),
       cls => TestRunnerUtils.globFilter(globSelectors())(cls.getName)
     )
     val res = TestModule.handleResults(doneMsg, results, Task.ctx(), testReportXml())
@@ -427,6 +428,38 @@ trait TestScalaJSModule extends ScalaJSModule with TestModule {
     Thread.sleep(100)
     close()
     res
+  }
+
+}
+
+object TestScalaJSModule {
+
+  /**
+   * TestModule that uses Scala.js' JUnit 4 compatibility library to run tests
+   */
+  trait Junit4ScalaJs extends TestScalaJSModule {
+
+    // Seems to be mandatory - the junit4 @Test annotations are no where to be found
+    // in test class files
+    override protected def discoverTestsWithZinc = true
+
+    override def testFramework: T[String] = "com.novocode.junit.JUnitFramework"
+    override def mandatoryMvnDeps: T[Seq[Dep]] = Task {
+      super.mandatoryMvnDeps() ++
+        Seq(
+          mvn"org.scala-js::scalajs-junit-test-runtime:${scalaJSVersion()}"
+            .withDottyCompat(scalaVersion())
+        )
+    }
+
+    override def scalacPluginMvnDeps: T[Seq[Dep]] = Task {
+      val extra =
+        if (scalaVersion().startsWith("2."))
+          Seq(mvn"org.scala-js:::scalajs-junit-test-plugin:${scalaJSVersion()}")
+        else
+          Nil
+      super.scalacPluginMvnDeps() ++ extra
+    }
   }
 
 }

--- a/libs/scalajslib/test/resources/hello-js-world/build/test-junit4/src/junit4/ArgsParserTests.scala
+++ b/libs/scalajslib/test/resources/hello-js-world/build/test-junit4/src/junit4/ArgsParserTests.scala
@@ -1,0 +1,19 @@
+import org.junit._
+
+class ArgsParserTests {
+
+  @Test def one(): Unit = {
+    val result = ArgsParser.parse("hello:world")
+    assert(
+      result.length == 2,
+      result == Seq("hello", "world")
+    )
+  }
+  @Test def two(): Unit = { // we fail this test to check testing in scala.js
+    val result = ArgsParser.parse("hello:world")
+    assert(
+      result.length == 80
+    )
+  }
+
+}

--- a/libs/scalajslib/test/resources/hello-js-world/build/test-junit4/src/junit4/MainTests.scala
+++ b/libs/scalajslib/test/resources/hello-js-world/build/test-junit4/src/junit4/MainTests.scala
@@ -1,0 +1,17 @@
+import org.junit._
+
+class MainTests {
+
+  @Test def vmNameContainsJs(): Unit = {
+    assert(
+      Main.vmName.contains("js")
+    )
+  }
+
+  @Test def vmNameContainsScala(): Unit = {
+    assert(
+      Main.vmName.contains("Scala")
+    )
+  }
+
+}

--- a/libs/scalajslib/test/src/mill/scalajslib/CompileLinkTests.scala
+++ b/libs/scalajslib/test/src/mill/scalajslib/CompileLinkTests.scala
@@ -49,6 +49,10 @@ object CompileLinkTests extends TestSuite {
         )
       }
 
+      object `test-junit4` extends ScalaJSTests with TestScalaJSModule.Junit4ScalaJs {
+        override def sources = Task.Sources("src/junit4")
+      }
+
     }
     object inherited extends ScalaJSModule {
       val (scala, scalaJS) = matrix.head

--- a/libs/scalajslib/test/src/mill/scalajslib/Junit4Tests.scala
+++ b/libs/scalajslib/test/src/mill/scalajslib/Junit4Tests.scala
@@ -1,0 +1,20 @@
+package mill.scalajslib
+
+import mill.javalib.api.JvmWorkerUtil
+import utest.*
+
+object Junit4Tests extends TestSuite {
+  import CompileLinkTests.*
+  import UtestTests.*
+  def tests: Tests = Tests {
+
+    test("junit4") {
+      testAllMatrix((scala, scalaJS) => checkJunit4(scala, scalaJS, cached = false))
+    }
+
+    test("junit4Cached") {
+      testAllMatrix((scala, scalaJS) => checkJunit4(scala, scalaJS, cached = true))
+    }
+
+  }
+}

--- a/libs/scalajslib/test/src/mill/scalajslib/UtestTests.scala
+++ b/libs/scalajslib/test/src/mill/scalajslib/UtestTests.scala
@@ -58,6 +58,13 @@ object UtestTests extends TestSuite {
 //      argParserSpec("parse should two").status == "Failure"
 //    )
   }
+
+  def checkJunit4(scalaVersion: String, scalaJSVersion: String, cached: Boolean) = {
+    runTests(
+      if (!cached) HelloJSWorld.build(scalaVersion, scalaJSVersion).`test-junit4`.testForked()
+      else HelloJSWorld.build(scalaVersion, scalaJSVersion).`test-junit4`.testCached
+    )
+  }
   def tests: Tests = Tests {
 
     test("utest") {

--- a/libs/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
+++ b/libs/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
@@ -507,6 +507,7 @@ trait TestScalaNativeModule extends ScalaNativeModule with TestModule {
       Seq(compile().classes.path),
       args(),
       Task.testReporter,
+      aheadOfTimeDiscoveredTestClassesIfNeeded(),
       cls => TestRunnerUtils.globFilter(globSelectors())(cls.getName)
     )
     val res = TestModule.handleResults(doneMsg, results, Task.ctx(), testReportXml())


### PR DESCRIPTION
This allows users to enable test class discovery using the zinc analysis file, rather than by inspecting test class files.

This is useful when using [Scala.js' junit4 compatibility library](https://github.com/scala-js/scala-js/tree/55e86dbcccbfcf3341b046310da25dc41815787a/junit-runtime). Tests are annotated with `@Test`, but these annotations are nowhere to be found in the resulting class files, so that Mill's current test class discovery misses those. sbt finds those on the other hand, as [it finds test classes using the zinc analysis file](https://github.com/sbt/sbt/blob/f64b5288ca0711c84a0345276441671d6f3b240e/main-actions/src/main/scala/sbt/Tests.scala#L528-L546).

This PR allows users to do the same from Mill, by setting `discoverTestsWithZinc` to true in Scala test modules. This allows Mill to run Scala.js junit4 test suites, as shown in the tests added in this PR.

This is not enabled by default, as this is only useful in a very specific case (use of junit4 in Scala.js tests), and the current test discovery mechanism seems to work fine aside from that very specific case.