### PR TITLE
Run at most one BSP server per build client

### DIFF
--- a/core/constants/src/mill/constants/OutFiles.java
+++ b/core/constants/src/mill/constants/OutFiles.java
@@ -128,9 +128,23 @@ public class OutFiles {
     public final String millOutLock = "mill-out-lock";
 
     /**
+     * Lock file used for exclusively running the Mill BSP server for that lock id
+     */
+    public final String millBspLock(String lockId) {
+      return "mill-bsp-" + lockId + "-lock";
+    }
+
+    /**
      * JSON file containing info about the active Mill process (command and process directory)
      */
     public final String millActive = "mill-active.json";
+
+    /**
+     * JSON file containing info about the active Mill BSP process for that lock id (process directory and PID)
+     */
+    public final String millActiveBsp(String lockId) {
+      return "mill-active-bsp-" + lockId + ".json";
+    }
 
     /**
      * File used to store metadata related to selective execution, mostly

--- a/core/internal/cli/src/mill/internal/MillCliConfig.scala
+++ b/core/internal/cli/src/mill/internal/MillCliConfig.scala
@@ -108,6 +108,18 @@ case class MillCliConfig(
     @arg(
       hidden = true,
       doc =
+        """Do not wait for an exclusive BSP server lock to run BSP server, just exit with an error if the BSP server lock is hold by another process"""
+    )
+    noWaitForBspLock: Flag = Flag(),
+    @arg(
+      hidden = true,
+      doc =
+        """If the BSP lock is hold by another process, wait for it to release the lock"""
+    )
+    bspNoKillOther: Flag = Flag(),
+    @arg(
+      hidden = true,
+      doc =
         """Evaluate tasks / commands without acquiring an exclusive lock on the Mill output directory"""
     )
     noBuildLock: Flag = Flag(),

--- a/integration/bsp-util/src/BspServerTestUtil.scala
+++ b/integration/bsp-util/src/BspServerTestUtil.scala
@@ -8,7 +8,7 @@ import mill.bsp.Constants
 import org.eclipse.lsp4j as l
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest
 
-import java.io.ByteArrayOutputStream
+import java.io.{ByteArrayOutputStream, InputStream, OutputStream}
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.{CompletableFuture, ExecutorService, Executors, ThreadFactory}
 import scala.build.bsp.ScalaScriptBuildServer
@@ -140,14 +140,13 @@ object BspServerTestUtil {
     def loggingTest(): CompletableFuture[Object]
   }
 
-  def withBspServer[T](
-      workspacePath: os.Path,
-      millTestSuiteEnv: Map[String, String],
-      bspLog: Option[(Array[Byte], Int) => Unit] = None,
-      client: TestBuildClient = new DummyBuildClient {}
-  )(f: (MillBuildServer, b.InitializeBuildResult) => T): T = {
+  private val isCI = System.getenv("CI") != null
 
-    val outputOnErrorOnly = System.getenv("CI") != null
+  def startBspServer[T](
+      workspacePath: os.Path,
+      env: Map[String, String],
+      bspLog: Option[(Array[Byte], Int) => Unit]
+  ): os.SubProcess = {
 
     val bspCommand = {
       val bspMetadataFile = workspacePath / Constants.bspDir / s"${Constants.serverName}.json"
@@ -161,60 +160,98 @@ object BspServerTestUtil {
       contentsJson("argv").arr.map(_.str)
     }
 
-    val stderr = new ByteArrayOutputStream
-    val proc = os.proc(bspCommand).spawn(
+    os.proc(bspCommand).spawn(
       cwd = workspacePath,
       stderr =
-        if (bspLog.isDefined || outputOnErrorOnly)
+        if (bspLog.isDefined || !isCI)
           os.ProcessOutput { (bytes, len) =>
-            if (outputOnErrorOnly)
-              stderr.write(bytes, 0, len)
-            else
+            if (!isCI)
               System.err.write(bytes, 0, len)
             for (f <- bspLog)
               f(bytes, len)
           }
         else os.Inherit,
-      env = millTestSuiteEnv
+      env = env
+    )
+  }
+
+  def bspBuildServer(
+      input: InputStream,
+      output: OutputStream,
+      workspacePath: os.Path,
+      client: TestBuildClient = new DummyBuildClient {}
+  ): (MillBuildServer, b.InitializeBuildResult) = {
+
+    val launcher = new l.jsonrpc.Launcher.Builder[MillBuildServer]
+      .setExecutorService(bspJsonrpcPool)
+      .setInput(input)
+      .setOutput(output)
+      .setRemoteInterface(classOf[MillBuildServer])
+      .setLocalService(client)
+      .setExceptionHandler { t =>
+        System.err.println(s"Error during LSP processing: $t")
+        t.printStackTrace(System.err)
+        l.jsonrpc.RemoteEndpoint.DEFAULT_EXCEPTION_HANDLER.apply(t)
+      }
+      .create()
+
+    launcher.startListening()
+
+    val buildServer = launcher.getRemoteProxy()
+
+    val initParams = new b.InitializeBuildParams(
+      "Mill Integration",
+      BuildInfo.millVersion,
+      b.Bsp4j.PROTOCOL_VERSION,
+      workspacePath.toURI.toASCIIString,
+      new b.BuildClientCapabilities(List("java", "scala", "kotlin").asJava)
+    )
+    // Tell Mill BSP we want semanticdbs
+    initParams.setData(
+      InitData(
+        mill.api.daemon.BuildInfo.semanticDBVersion,
+        mill.api.daemon.BuildInfo.semanticDbJavaVersion
+      )
+    )
+    // This seems to be unused by Mill BSP for now, setting it just in case
+    initParams.setDataKind("scala")
+
+    val initRes = buildServer.buildInitialize(initParams).get()
+
+    (buildServer, initRes)
+  }
+
+  def withBspServer[T](
+      workspacePath: os.Path,
+      millTestSuiteEnv: Map[String, String],
+      bspLog: Option[(Array[Byte], Int) => Unit] = None,
+      client: TestBuildClient = new DummyBuildClient {}
+  )(f: (MillBuildServer, b.InitializeBuildResult) => T): T = {
+
+    val stderr = new ByteArrayOutputStream
+    val proc = startBspServer(
+      workspacePath,
+      millTestSuiteEnv,
+      bspLog =
+        if (isCI)
+          Some {
+            (b, len) =>
+              stderr.write(b, 0, len)
+              for (f <- bspLog)
+                f(b, len)
+          }
+        else
+          bspLog
     )
 
     var success = false
     try {
-      val launcher = new l.jsonrpc.Launcher.Builder[MillBuildServer]
-        .setExecutorService(bspJsonrpcPool)
-        .setInput(proc.stdout.wrapped)
-        .setOutput(proc.stdin.wrapped)
-        .setRemoteInterface(classOf[MillBuildServer])
-        .setLocalService(client)
-        .setExceptionHandler { t =>
-          System.err.println(s"Error during LSP processing: $t")
-          t.printStackTrace(System.err)
-          l.jsonrpc.RemoteEndpoint.DEFAULT_EXCEPTION_HANDLER.apply(t)
-        }
-        .create()
-
-      launcher.startListening()
-
-      val buildServer = launcher.getRemoteProxy()
-
-      val initParams = new b.InitializeBuildParams(
-        "Mill Integration",
-        BuildInfo.millVersion,
-        b.Bsp4j.PROTOCOL_VERSION,
-        workspacePath.toURI.toASCIIString,
-        new b.BuildClientCapabilities(List("java", "scala", "kotlin").asJava)
+      val (buildServer, initRes) = bspBuildServer(
+        proc.stdout.wrapped,
+        proc.stdin.wrapped,
+        workspacePath,
+        client
       )
-      // Tell Mill BSP we want semanticdbs
-      initParams.setData(
-        InitData(
-          mill.api.daemon.BuildInfo.semanticDBVersion,
-          mill.api.daemon.BuildInfo.semanticDbJavaVersion
-        )
-      )
-      // This seems to be unused by Mill BSP for now, setting it just in case
-      initParams.setDataKind("scala")
-
-      val initRes = buildServer.buildInitialize(initParams).get()
 
       val value =
         try f(buildServer, initRes)
@@ -235,7 +272,7 @@ object BspServerTestUtil {
 
         proc.join(30000L)
       } finally {
-        if (!success && outputOnErrorOnly) {
+        if (!success && isCI) {
           System.err.println(" == BSP server output ==")
           System.err.write(stderr.toByteArray)
           System.err.println(" == end of BSP server output ==")

--- a/integration/dedicated/bsp-server-error/src/BspServerErrorTests.scala
+++ b/integration/dedicated/bsp-server-error/src/BspServerErrorTests.scala
@@ -22,12 +22,36 @@ object BspServerErrorTests extends UtestIntegrationTestSuite {
         env = Map("MILL_EXECUTABLE_PATH" -> tester.millExecutable.toString)
       )
 
+      val firstServerStderr = new ByteArrayOutputStream
+      val firstServerProc = startBspServer(
+        workspacePath,
+        millTestSuiteEnv,
+        bspLog = Some((bytes, len) => firstServerStderr.write(bytes, 0, len))
+      )
+
+      // wait for server instance to be ready to ensure the first BSP server started well
+      bspBuildServer(
+        firstServerProc.stdout.wrapped,
+        firstServerProc.stdin.wrapped,
+        workspacePath
+      )
+
+      assert(firstServerProc.isAlive())
+
       val stderr = new ByteArrayOutputStream
       withBspServer(
         workspacePath,
         millTestSuiteEnv,
         bspLog = Some((bytes, len) => stderr.write(bytes, 0, len))
       ) { (buildServer, initRes) =>
+
+        assert(!firstServerProc.isAlive())
+
+        val firstServerStderrStr = new String(firstServerStderr.toByteArray)
+        assert(firstServerStderrStr.contains("Received SIGTERM, exiting"))
+
+        val currentStderrStr = new String(stderr.toByteArray)
+        assert(currentStderrStr.contains("Sent SIGTERM to process"))
 
         assert(initRes.getCapabilities.getInverseSourcesProvider == true)
 

--- a/libs/tabcomplete/test/src/mill/tabcomplete/TabCompleteTests.scala
+++ b/libs/tabcomplete/test/src/mill/tabcomplete/TabCompleteTests.scala
@@ -362,6 +362,7 @@ object TabCompleteTests extends TestSuite {
             "--import                  <str> Additional ivy dependencies to load into mill, e.g. plugins.",
             "--bsp-install             Create mill-bsp.json with Mill details under .bsp/",
             "--allow-positional        Allows command args to be passed positionally without `--arg` by default",
+            "--bsp-no-kill-other       If the BSP lock is hold by another process, wait for it to release the lock",
             "--meta-level              <int> Select a meta-level to run the given tasks. Level 0 is the main project in `build.mill`, level 1 the first meta-build in `mill-build/build.mill`, etc. If negative, -1 means the deepest meta-build (bootstrap build), -2 the second deepest meta-build, etc.",
             "--bsp                     Enable BSP server mode. Typically used by a BSP client when starting the Mill BSP server.",
             "--help-advanced           Print a internal or advanced command flags not intended for common usage",
@@ -380,6 +381,7 @@ object TabCompleteTests extends TestSuite {
             "--color                   <bool> Toggle colored output; by default enabled only if the console is interactive or FORCE_COLOR environment variable is set, and NO_COLOR is not set",
             "--no-daemon               Run without a long-lived background daemon.",
             "--no-wait-for-build-lock  Do not wait for an exclusive lock on the Mill output directory to evaluate tasks / commands.",
+            "--no-wait-for-bsp-lock    Do not wait for an exclusive BSP server lock to run BSP server, just exit with an error if the BSP server lock is hold by another process",
             "--version                 Show mill version information and exit.",
             "--task                    <str> The name or a query of the tasks(s) you want to build."
           )

--- a/runner/bsp/worker/src/mill/bsp/worker/BspWorkerImpl.scala
+++ b/runner/bsp/worker/src/mill/bsp/worker/BspWorkerImpl.scala
@@ -25,7 +25,9 @@ object BspWorkerImpl {
       outLock: Lock,
       baseLogger: Logger,
       out: os.Path,
-      daemonDir: os.Path
+      daemonDir: os.Path,
+      noWaitForBspLock: Boolean,
+      killOther: Boolean
   ): mill.api.Result[(BspServerHandle, BuildClient)] = {
 
     try {
@@ -45,7 +47,9 @@ object BspWorkerImpl {
           outLock = outLock,
           baseLogger = baseLogger,
           out = out,
-          daemonDir = daemonDir
+          daemonDir = daemonDir,
+          noWaitForBspLock = noWaitForBspLock,
+          killOther = killOther
         ) with EndpointsJvm
           with EndpointsJava
           with EndpointsScala

--- a/runner/bsp/worker/src/mill/bsp/worker/Endpoints.scala
+++ b/runner/bsp/worker/src/mill/bsp/worker/Endpoints.scala
@@ -100,10 +100,13 @@ trait MillBspEndpoints extends BuildServer with EndpointsApi {
 
       sessionInfo = new MillBspEndpoints.SessionInfo(
         clientType,
+        request.getDisplayName,
         clientWantsSemanticDb = clientWantsSemanticDb,
         enableJvmCompileClasspathProvider = enableJvmCompileClasspathProvider
       )
-      new InitializeBuildResult(serverName, serverVersion, bspVersion, capabilities)
+      val res = new InitializeBuildResult(serverName, serverVersion, bspVersion, capabilities)
+      doneInitializingBuild()
+      res
     }
 
   override def onBuildInitialized(): Unit = {
@@ -571,6 +574,7 @@ trait MillBspEndpoints extends BuildServer with EndpointsApi {
 object MillBspEndpoints {
   class SessionInfo(
       val clientType: ClientType,
+      val clientDisplayName: String,
       val clientWantsSemanticDb: Boolean,
       /** `true` when client and server support the `JvmCompileClasspathProvider` request. */
       val enableJvmCompileClasspathProvider: Boolean

--- a/runner/bsp/worker/src/mill/bsp/worker/EndpointsApi.scala
+++ b/runner/bsp/worker/src/mill/bsp/worker/EndpointsApi.scala
@@ -41,6 +41,8 @@ trait EndpointsApi {
   protected[worker] def sessionResult: scala.concurrent.Promise[BspServerResult]
   protected[worker] def sessionResult_=(p: scala.concurrent.Promise[BspServerResult]): Unit
 
+  protected def doneInitializingBuild(): Unit
+
   protected def handlerRaw[V](block: Logger => V)(using
       name: sourcecode.Name,
       enclosing: sourcecode.Enclosing

--- a/runner/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
+++ b/runner/bsp/worker/src/mill/bsp/worker/MillBuildServer.scala
@@ -18,6 +18,7 @@ import scala.util.{Failure, Success}
 import mill.api.daemon.internal.NonFatal
 import mill.api.daemon.internal.bsp.{BspModuleApi, BspServerResult}
 import mill.api.daemon.internal.*
+import mill.constants.OutFiles.OutFiles
 
 import scala.annotation.unused
 
@@ -37,7 +38,9 @@ private abstract class MillBuildServer(
     outLock: Lock,
     protected val baseLogger: Logger,
     out: os.Path,
-    daemonDir: os.Path
+    daemonDir: os.Path,
+    noWaitForBspLock: Boolean,
+    killOther: Boolean
 ) extends EndpointsApi with AutoCloseable {
 
   import MillBuildServer.*
@@ -58,6 +61,83 @@ private abstract class MillBuildServer(
   private val requestCount = new AtomicInteger
 
   def initialized = sessionInfo != null
+
+  private var bspLock: Lock = scala.compiletime.uninitialized
+
+  private def initLock(bspLockId: String): Unit = {
+    assert(bspLock == null)
+    bspLock = Lock.file((out / OutFiles.millBspLock(bspLockId)).toString)
+    val activeBspFile = out / OutFiles.millActiveBsp(bspLockId)
+    def readActiveInfo(): (Option[os.Path], Option[Long]) =
+      try {
+        val json = os.read(activeBspFile)
+        // Simple JSON parsing for {"processDir":"...","pid":...}
+        val processDirPattern = """"processDir"\s*:\s*"([^"]*)"""".r
+        val pidPattern = """"pid"\s*:\s*([0-9]+)""".r
+        val processDir = processDirPattern.findFirstMatchIn(json).map(m => os.Path(m.group(1)))
+        val pid = pidPattern.findFirstMatchIn(json).flatMap(m => m.group(1).toLongOption)
+        (processDir, pid)
+      } catch {
+        case NonFatal(_) => (None, None)
+      }
+
+    val tryLocked = bspLock.tryLock()
+    if (tryLocked.isLocked)
+      tryLocked
+    else if (noWaitForBspLock)
+      throw new Exception("Another Mill BSP process is running, failing")
+    else {
+      val (_, pidOpt) = readActiveInfo()
+      if (killOther)
+        pidOpt match {
+          case Some(pid) =>
+            val handle = ProcessHandle.of(pid).orElseThrow()
+            if (handle.isAlive()) {
+              if (handle.destroy())
+                baseLogger.info(s"Sent SIGTERM to process $pid")
+              else
+                baseLogger.warn(s"Could not send SIGTERM to process $pid")
+              var i = 200
+              while (i > 0 && handle.isAlive()) {
+                Thread.sleep(10L)
+                i -= 1
+              }
+              if (handle.isAlive())
+                if (handle.destroyForcibly())
+                  baseLogger.info(s"Sent SIGKILL to process $pid")
+                else
+                  baseLogger.warn(s"Could not send SIGKILL to process $pid")
+            } else
+              baseLogger.info(s"Other Mill process with PID $pid exited")
+          case None =>
+            baseLogger.warn(
+              s"PID of other Mill process not found in $activeBspFile, could not terminate it"
+            )
+        }
+      else
+        baseLogger.info(
+          s"Another Mill BSP server is running with PID ${pidOpt.fold("<unknown>")(_.toString)} waiting for it to be done..."
+        )
+      bspLock.lock()
+    }
+
+    val pid = ProcessHandle.current().pid()
+    val json = s"""{"processDir":"$daemonDir","pid":$pid}"""
+    os.write.over(activeBspFile, json)
+  }
+
+  protected def doneInitializingBuild(): Unit = {
+    assert(initialized, "Expected Mill BSP server to be initialized")
+    if (bspLock == null) {
+      val bspLockId = sessionInfo.clientDisplayName
+        // just in case
+        .replace(" ", "_")
+        .replace("/", "_")
+        .replace("\\", "_")
+      initLock(bspLockId)
+    } else
+      baseLogger.warn("Mill BSP server initialized more than once")
+  }
 
   // ==========================================================================
   // Lifecycle Management

--- a/runner/daemon/src/mill/daemon/IdeWorkerSupport.scala
+++ b/runner/daemon/src/mill/daemon/IdeWorkerSupport.scala
@@ -92,7 +92,9 @@ private object IdeWorkerSupport {
       classOf[Lock],
       classOf[Logger],
       classOf[os.Path],
-      classOf[os.Path]
+      classOf[os.Path],
+      classOf[Boolean],
+      classOf[Boolean]
     )
 
     val bspEvaluatorsClass = classLoader.loadClass("mill.bsp.worker.BspEvaluators")
@@ -134,7 +136,9 @@ private object IdeWorkerSupport {
       outLock: Lock,
       baseLogger: Logger,
       out: os.Path,
-      daemonDir: os.Path
+      daemonDir: os.Path,
+      noWaitForBspLock: Boolean,
+      killOther: Boolean
   ): (BspServerHandle, BspBuildClient) = {
     val handles = bspHandles
     val result = mill.api.daemon.ClassLoader.withContextClassLoader(handles.classLoader) {
@@ -147,7 +151,9 @@ private object IdeWorkerSupport {
         outLock,
         baseLogger,
         out,
-        daemonDir
+        daemonDir,
+        noWaitForBspLock,
+        killOther
       )).asInstanceOf[Result[(Any, Any)]]
     }
 

--- a/runner/daemon/src/mill/daemon/MillMain0.scala
+++ b/runner/daemon/src/mill/daemon/MillMain0.scala
@@ -26,6 +26,7 @@ import mill.api.daemon.internal.NonFatal
 import java.io.{InputStream, PrintStream, PrintWriter, StringWriter}
 import java.lang.reflect.InvocationTargetException
 import java.util.concurrent.{ThreadPoolExecutor, TimeUnit}
+import sun.misc.Signal
 import scala.jdk.CollectionConverters.*
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
@@ -336,10 +337,24 @@ object MillMain0 {
 
                         (true, bootstrapped)
                       } else if (bspMode) {
+                        // Can happen if a concurrent BSP server starts and shuts us down.
+                        // We log in the console what happened just in case, so that users know why we exit.
+                        // This is also used in the tests.
+                        Signal.handle(
+                          new Signal("TERM"),
+                          _ => SystemStreams.originalErr.println("Received SIGTERM, exiting")
+                        )
+
                         val bspLogger = getBspLogger(streams, config)
                         var prevRunnerStateOpt = Option.empty[RunnerState]
-                        val (bspServerHandle, buildClient) =
-                          startBspServer(streams0, outLock, bspLogger, daemonDir)
+                        val (bspServerHandle, buildClient) = startBspServer(
+                          streams0,
+                          outLock,
+                          bspLogger,
+                          daemonDir,
+                          noWaitForBspLock = config.noWaitForBspLock.value,
+                          killOther = !config.bspNoKillOther.value
+                        )
                         var keepGoing = true
                         var errored = false
                         val initCommandLogger = new PrefixLogger(bspLogger, Seq("init"))
@@ -521,7 +536,9 @@ object MillMain0 {
       bspStreams: SystemStreams,
       outLock: Lock,
       bspLogger: Logger,
-      daemonDir: os.Path
+      daemonDir: os.Path,
+      noWaitForBspLock: Boolean,
+      killOther: Boolean
   ): (BspServerHandle, IdeWorkerSupport.BspBuildClient) = {
     bspLogger.info("Trying to load BSP server...")
 
@@ -539,7 +556,9 @@ object MillMain0 {
         outLock = outLock,
         baseLogger = bspLogger,
         out = outFolder,
-        daemonDir = daemonDir
+        daemonDir = daemonDir,
+        noWaitForBspLock = noWaitForBspLock,
+        killOther = killOther
       )
 
     bspLogger.info("BSP server started")


### PR DESCRIPTION
This makes Mill run at most one BSP server per build client type in a given project. This identifies build clients with their "display name" in the build initialize request, and ensures only one build server for this display name runs at a time.

If two build servers run at a time for build clients with the same display name, it is likely the first one is a zombie that's not needed anymore. Yet, it keeps watching the build sources, and tries to re-compile the build every time its sources change. Build servers hinder each other in such a scenario, so this PR makes this more unlikely, by having the second build server kill the first one upon startup.

Knowing if a build server already runs is handled the same way as locking when running tasks, except we also put the display name in the lock file name and its accompanying "active" info file name, and we default to killing the other Mill process here, rather than waiting for it to release the lock.

The build client display name is taken into account here, so that users can still have a Mill BSP server running for IntelliJ and another one running for VSCode.