### PR TITLE
Disable `scoverage` sub-module for BSP clients by default

### DIFF
--- a/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
+++ b/contrib/scoverage/src/mill/contrib/scoverage/ScoverageModule.scala
@@ -218,7 +218,10 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
       }
     }
 
-    override def skipIdea = true
+    // Disable this module in BSP clients by default
+    override def enableBsp: Boolean = false
+    // Skip this module in IntelliJ IDEA by default
+    override def skipIdea: Boolean = true
   }
 
   trait ScoverageTests extends ScalaTests {


### PR DESCRIPTION
Not excluding `scoverage` sub-modules in BSP means, the IDE forces each `ScoverageModule` to compile twice, once normal and once with the Scoverage-plugin enabled, which is totally waste of resources.

If tests need the compiled scoverage-enhanced classes, Mill already builds them on demand.

Fix https://github.com/com-lihaoyi/mill/issues/6911

Pull request: https://github.com/com-lihaoyi/mill/pull/6912