### PR TITLE
Android: mill.idea/

### DIFF
--- a/libs/androidlib/src/mill/androidlib/AndroidModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidModule.scala
@@ -21,6 +21,10 @@ trait AndroidModule extends JavaModule { outer =>
     ModuleRef(new BspAndroidModule.Wrap(this) {}.internalBspJavaModule)
   }
 
+  private[mill] override lazy val genIdeaInternalExt = {
+    ModuleRef(new mill.androidlib.idea.GenIdeaModule.Wrap(this) {}.internalGenIdea)
+  }
+
   // https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:build-system/gradle-core/src/main/java/com/android/build/gradle/internal/tasks/D8BundleMainDexListTask.kt;l=210-223;drc=66ab6bccb85ce3ed7b371535929a69f494d807f0
   val mainDexPlatformRules = Seq(
     "-keep public class * extends android.app.Instrumentation {\n" +
@@ -396,11 +400,6 @@ trait AndroidModule extends JavaModule { outer =>
   def androidResolvedMvnDeps: T[Seq[PathRef]] = Task {
     val transformedAars = androidUnpackedAarMvnDeps().flatMap(_.classesJar)
     androidJarMvnDeps() ++ transformedAars
-  }
-
-  override private[mill] def alternativeResolvedMvnDeps = Task {
-    val aarDeps = androidUnpackedAarMvnDeps()
-    aarDeps.flatMap(_.classesJar)
   }
 
   def androidAarMvnDeps: T[Seq[PathRef]] = Task {

--- a/libs/androidlib/src/mill/androidlib/idea/GenIdeaModule.scala
+++ b/libs/androidlib/src/mill/androidlib/idea/GenIdeaModule.scala
@@ -1,0 +1,29 @@
+package mill.androidlib.idea
+
+import mill.androidlib.AndroidModule
+import mill.api.daemon.experimental
+import mill.api.daemon.internal.internal
+import mill.api.{ModuleCtx, Task}
+
+@experimental
+trait GenIdeaModule extends mill.javalib.idea.GenIdeaModule {
+
+  override private[mill] def extDependencies = Task {
+    super.extDependencies() ++ javaModuleRef().androidUnpackedAarMvnDeps().flatMap(_.classesJar)
+  }
+
+  def javaModuleRef: mill.api.ModuleRef[AndroidModule]
+
+}
+
+@internal
+object GenIdeaModule {
+  trait Wrap(javaModule0: AndroidModule) extends mill.api.Module {
+    override def moduleCtx: ModuleCtx = javaModule0.moduleCtx
+
+    @internal
+    object internalGenIdea extends GenIdeaModule {
+      def javaModuleRef = mill.api.ModuleRef(javaModule0)
+    }
+  }
+}

--- a/libs/javalib/src/mill/javalib/JavaModule.scala
+++ b/libs/javalib/src/mill/javalib/JavaModule.scala
@@ -1187,18 +1187,6 @@ trait JavaModule
   }
 
   /**
-   * This method can be used by downstream JavaModule subsclasses to pass
-   * non jar dependencies. The use case for this can be for example,
-   * an AAR (Android) that the AndroidModule is transforming into classes.jar
-   * and sources.jar . Callers of this method can get these jars from this method
-   * as [[resolvedMvnDeps]] will contain AARs which may not be compatible with an
-   * IDE integration (such as the [[GenIdeaModule]]
-   */
-  private[mill] def alternativeResolvedMvnDeps: T[Seq[PathRef]] = Task {
-    Seq.empty[PathRef]
-  }
-
-  /**
    * Resolved dependency sources, unpacked into a single directory. Useful to quickly
    * look up the sources of the dependencies on your classpath so you can find the
    * exact source code you are compiling and running against.

--- a/libs/javalib/src/mill/javalib/idea/GenIdeaModule.scala
+++ b/libs/javalib/src/mill/javalib/idea/GenIdeaModule.scala
@@ -30,7 +30,7 @@ trait GenIdeaModule extends mill.api.Module with GenIdeaInternalApi {
   }
 
   private[mill] def extDependencies = Task {
-    javaModule.resolvedMvnDeps() ++ javaModule.alternativeResolvedMvnDeps() ++
+    javaModule.resolvedMvnDeps() ++
       Task.traverse(javaModule.transitiveModuleDeps)(_.unmanagedClasspath)().flatten
   }
 


### PR DESCRIPTION
## Context

Part of https://github.com/com-lihaoyi/mill/issues/6624

This is part of improving the IDE integration (and for this PR in particular intelliJ) with the Android support in mill.

After a long and hard look at BSP , I think it may be a better way to at least tackle first direct idea support. This PR does not resolve the whole issue but makes a small step in that direction.

## Provided in the PR

The PR fixes the missing dependencies from the .idea/ configuration files which were ignored because, the GenIdea uses the resolvedMvnDeps which have the AARs which are filtered out. 

## Results

This sets up the AARs properly with sources

<img width="1919" height="447" alt="image" src="https://github.com/user-attachments/assets/f2cdf8cd-8eae-4964-a6e3-3ca29d860ea0" />


## Limitations

- Still , this does not support mixing mill's Android support with Scala (related to https://github.com/com-lihaoyi/mill/issues/6908 ) , we'll need to cover a lot of missing features for that since the androidlib has not got any scala context .
- It does not fix the wider IDE highlighting issue but it makes a small step towards that direction, for the `mill.idea/` approach