### PR TITLE
Add serialCommandExec parameter to evaluate API

### DIFF
--- a/core/api/daemon/src/mill/api/daemon/internal/EvaluatorApi.scala
+++ b/core/api/daemon/src/mill/api/daemon/internal/EvaluatorApi.scala
@@ -10,7 +10,8 @@ trait EvaluatorApi extends AutoCloseable {
       scriptArgs: Seq[String],
       selectMode: SelectMode,
       reporter: Int => Option[CompileProblemReporter] = _ => None,
-      selectiveExecution: Boolean = false
+      selectiveExecution: Boolean = false,
+      serialCommandExec: Boolean = false
   ): Result[EvaluatorApi.Result[Any]]
 
   private[mill] def executeApi[T](

--- a/core/api/src/mill/api/Evaluator.scala
+++ b/core/api/src/mill/api/Evaluator.scala
@@ -108,7 +108,8 @@ trait Evaluator extends AutoCloseable with EvaluatorApi {
       scriptArgs: Seq[String],
       selectMode: SelectMode = SelectMode.Separated,
       reporter: Int => Option[CompileProblemReporter] = _ => None,
-      selectiveExecution: Boolean = false
+      selectiveExecution: Boolean = false,
+      serialCommandExec: Boolean = false
   ): mill.api.Result[Evaluator.Result[Any]]
 
   private[mill] def executeApi[T](

--- a/core/api/src/mill/api/EvaluatorProxy.scala
+++ b/core/api/src/mill/api/EvaluatorProxy.scala
@@ -110,9 +110,10 @@ final class EvaluatorProxy(var delegate0: () => Evaluator) extends Evaluator {
       scriptArgs: Seq[String],
       selectMode: SelectMode,
       reporter: Int => Option[CompileProblemReporter] = _ => None,
-      selectiveExecution: Boolean = false
+      selectiveExecution: Boolean = false,
+      serialCommandExec: Boolean = false
   ): mill.api.Result[Evaluator.Result[Any]] = {
-    delegate.evaluate(scriptArgs, selectMode, reporter, selectiveExecution)
+    delegate.evaluate(scriptArgs, selectMode, reporter, selectiveExecution, serialCommandExec)
   }
   def close = delegate0 = null
 

--- a/core/eval/src/mill/eval/EvaluatorImpl.scala
+++ b/core/eval/src/mill/eval/EvaluatorImpl.scala
@@ -401,7 +401,8 @@ final class EvaluatorImpl(
       scriptArgs: Seq[String],
       selectMode: SelectMode,
       reporter: Int => Option[CompileProblemReporter] = _ => None,
-      selectiveExecution: Boolean = false
+      selectiveExecution: Boolean = false,
+      serialCommandExec: Boolean = false
   ): mill.api.Result[Evaluator.Result[Any]] = {
     val promptLineLogger = new PrefixLogger(
       logger0 = baseLogger,
@@ -416,6 +417,7 @@ final class EvaluatorImpl(
       yield execute(
         tasks.asInstanceOf[Seq[Task[Any]]],
         reporter = reporter,
+        serialCommandExec = serialCommandExec,
         selectiveExecution = selectiveExecution
       )
   }


### PR DESCRIPTION
## Summary
- Adds a `serialCommandExec: Boolean = false` parameter to the `evaluate` method across `EvaluatorApi`, `Evaluator`, `EvaluatorProxy`, and `EvaluatorImpl`
- Forwards the parameter to the existing `execute` call, allowing callers of `evaluate` to force serial task execution without needing to call `execute` directly

## Test plan
- [x] Verified all modules compile successfully (`./mill __.compile` — 30195 modules)
- [ ] Existing tests should pass unchanged since the new parameter defaults to `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)