### PR TITLE
Run JMH benchmarks in exclusive mode

### DIFF
--- a/contrib/jmh/src/mill/contrib/jmh/JmhModule.scala
+++ b/contrib/jmh/src/mill/contrib/jmh/JmhModule.scala
@@ -37,7 +37,7 @@ trait JmhModule extends JavaModule {
   def mvnDeps = super.mvnDeps() ++ Seq(mvn"org.openjdk.jmh:jmh-core:${jmhCoreVersion()}")
 
   def runJmh(args: String*) =
-    Task.Command {
+    Task.Command(exclusive = true) {
       val (_, resources) = generateBenchmarkSources()
       Jvm.callProcess(
         mainClass = "org.openjdk.jmh.Main",


### PR DESCRIPTION
## Summary
- Marks `runJmh` as `exclusive = true` so JMH benchmarks run without other tasks executing concurrently
- JMH requires stable system resources to produce accurate measurements, so concurrent task execution can skew benchmark results

## Test plan
- [ ] Existing `contrib.jmh` tests should pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)