### PR TITLE
Don't return synthetic root results when not asked to in buildTargetSources

### DIFF
--- a/integration/dedicated/bsp-server/resources/snapshots/build-targets-output-paths-synthetic-root.json
+++ b/integration/dedicated/bsp-server/resources/snapshots/build-targets-output-paths-synthetic-root.json
@@ -1,0 +1,39 @@
+{
+  "items": [
+    {
+      "target": {
+        "uri": "file:///workspace/mill-synthetic-root-target"
+      },
+      "outputPaths": [
+        {
+          "uri": "file:///workspace/.idea/",
+          "kind": 2
+        },
+        {
+          "uri": "file:///workspace/out/",
+          "kind": 2
+        },
+        {
+          "uri": "file:///workspace/.bsp/",
+          "kind": 2
+        },
+        {
+          "uri": "file:///workspace/.bloop/",
+          "kind": 2
+        },
+        {
+          "uri": "file:///workspace/.project/",
+          "kind": 2
+        },
+        {
+          "uri": "file:///workspace/.classpath/",
+          "kind": 2
+        },
+        {
+          "uri": "file:///workspace/.settings/",
+          "kind": 2
+        }
+      ]
+    }
+  ]
+}

--- a/integration/dedicated/bsp-server/resources/snapshots/build-targets-output-paths.json
+++ b/integration/dedicated/bsp-server/resources/snapshots/build-targets-output-paths.json
@@ -92,41 +92,6 @@
     },
     {
       "target": {
-        "uri": "file:///workspace/mill-synthetic-root-target"
-      },
-      "outputPaths": [
-        {
-          "uri": "file:///workspace/.idea/",
-          "kind": 2
-        },
-        {
-          "uri": "file:///workspace/out/",
-          "kind": 2
-        },
-        {
-          "uri": "file:///workspace/.bsp/",
-          "kind": 2
-        },
-        {
-          "uri": "file:///workspace/.bloop/",
-          "kind": 2
-        },
-        {
-          "uri": "file:///workspace/.project/",
-          "kind": 2
-        },
-        {
-          "uri": "file:///workspace/.classpath/",
-          "kind": 2
-        },
-        {
-          "uri": "file:///workspace/.settings/",
-          "kind": 2
-        }
-      ]
-    },
-    {
-      "target": {
         "uri": "file:///workspace/scripts"
       },
       "outputPaths": []

--- a/integration/dedicated/bsp-server/resources/snapshots/build-targets-sources-synthetic-root.json
+++ b/integration/dedicated/bsp-server/resources/snapshots/build-targets-sources-synthetic-root.json
@@ -1,0 +1,16 @@
+{
+  "items": [
+    {
+      "target": {
+        "uri": "file:///workspace/mill-synthetic-root-target"
+      },
+      "sources": [
+        {
+          "uri": "file:///workspace/src",
+          "kind": 2,
+          "generated": false
+        }
+      ]
+    }
+  ]
+}

--- a/integration/dedicated/bsp-server/resources/snapshots/build-targets-sources.json
+++ b/integration/dedicated/bsp-server/resources/snapshots/build-targets-sources.json
@@ -277,18 +277,6 @@
     },
     {
       "target": {
-        "uri": "file:///workspace/mill-synthetic-root-target"
-      },
-      "sources": [
-        {
-          "uri": "file:///workspace/src",
-          "kind": 2,
-          "generated": false
-        }
-      ]
-    },
-    {
-      "target": {
         "uri": "file:///workspace/scripts"
       },
       "sources": [

--- a/integration/dedicated/bsp-server/src/BspServerTests.scala
+++ b/integration/dedicated/bsp-server/src/BspServerTests.scala
@@ -70,7 +70,20 @@ object BspServerTests extends UtestIntegrationTestSuite {
           normalizedLocalValues = normalizedLocalValues
         )
 
-        val targetIds = buildTargets.getTargets.asScala.map(_.getId).asJava
+        val targetIds = buildTargets.getTargets.asScala
+          .map(_.getId)
+          .asJava
+        // Making some queries without the synthetic root module,
+        // to ensure that its results are not mistakenly added in
+        // the responses when they're not requested
+        val targetIdsWithoutSyntheticRoot = buildTargets.getTargets.asScala
+          .filter(_.getDisplayName != "mill-synthetic-root")
+          .map(_.getId)
+          .asJava
+        val syntheticRootOnlyTargetIds = buildTargets.getTargets.asScala
+          .filter(_.getDisplayName == "mill-synthetic-root")
+          .map(_.getId)
+          .asJava
         val metaBuildTargetId = new b.BuildTargetIdentifier(
           (workspacePath / "mill-build").toURI.toASCIIString.stripSuffix("/")
         )
@@ -119,9 +132,17 @@ object BspServerTests extends UtestIntegrationTestSuite {
 
         compareWithGsonSnapshot(
           buildServer
-            .buildTargetSources(new b.SourcesParams(targetIds))
+            .buildTargetSources(new b.SourcesParams(targetIdsWithoutSyntheticRoot))
             .get(),
           snapshotsPath / "build-targets-sources.json",
+          normalizedLocalValues = normalizedLocalValues
+        )
+
+        compareWithGsonSnapshot(
+          buildServer
+            .buildTargetSources(new b.SourcesParams(syntheticRootOnlyTargetIds))
+            .get(),
+          snapshotsPath / "build-targets-sources-synthetic-root.json",
           normalizedLocalValues = normalizedLocalValues
         )
 
@@ -175,9 +196,17 @@ object BspServerTests extends UtestIntegrationTestSuite {
 
         compareWithGsonSnapshot(
           buildServer
-            .buildTargetOutputPaths(new b.OutputPathsParams(targetIds))
+            .buildTargetOutputPaths(new b.OutputPathsParams(targetIdsWithoutSyntheticRoot))
             .get(),
           snapshotsPath / "build-targets-output-paths.json",
+          normalizedLocalValues = normalizedLocalValues
+        )
+
+        compareWithGsonSnapshot(
+          buildServer
+            .buildTargetOutputPaths(new b.OutputPathsParams(syntheticRootOnlyTargetIds))
+            .get(),
+          snapshotsPath / "build-targets-output-paths-synthetic-root.json",
           normalizedLocalValues = normalizedLocalValues
         )
 

--- a/runner/bsp/worker/src/mill/bsp/worker/Endpoints.scala
+++ b/runner/bsp/worker/src/mill/bsp/worker/Endpoints.scala
@@ -212,8 +212,11 @@ trait MillBspEndpoints extends BuildServer with EndpointsApi {
         ).asJava
       )
     } { (sourceItems, state, _) =>
+      val fromSyntheticRootTarget = state.syntheticRootBspBuildTarget
+        .filter(data => sourcesParams.getTargets.asScala.contains(data.id))
+        .map(_.synthSources)
       new SourcesResult(
-        (sourceItems.asScala ++ state.syntheticRootBspBuildTarget.map(_.synthSources))
+        (sourceItems.asScala ++ fromSyntheticRootTarget)
           .sortBy(_.getTarget.getUri)
           .asJava
       )


### PR DESCRIPTION
This fixes a bug in the BSP server, in `buildTargetSources`, where it as returning results for the "synthetic root module" even these were not requested.