### PR TITLE
Add Task.Command#makeExclusive

### DIFF
--- a/core/api/src/mill/api/Task.scala
+++ b/core/api/src/mill/api/Task.scala
@@ -536,6 +536,25 @@ object Task {
     override def asCommand: Some[Command[T]] = Some(this)
     // FIXME: deprecated return type: Change to Option
     override def writerOpt: Some[Writer[?]] = Some(writer)
+
+    /**
+     * Make this command exclusive
+     *
+     * This ensures this command doesn't run concurrently with other commands.
+     */
+    def makeExclusive: Command[T] =
+      if (exclusive) this
+      else
+        new Command[T](
+          inputs,
+          evaluate0,
+          ctx0,
+          writer,
+          isPrivate,
+          exclusive = true,
+          persistent,
+          selectiveInputs0
+        )
   }
   class Worker[T](
       val inputs: Seq[Task[Any]],

--- a/core/exec/test/src/mill/exec/ExecutionTests.scala
+++ b/core/exec/test/src/mill/exec/ExecutionTests.scala
@@ -82,6 +82,8 @@ object ExecutionTests extends TestSuite {
       "cleanClientDownstream done"
     }
 
+    def nonExclusiveCommand() = Task.Command() { "nonExclusive done" }
+
     lazy val millDiscover = Discover[this.type]
   }
 
@@ -634,6 +636,43 @@ object ExecutionTests extends TestSuite {
           assert(result.isRight)
           val Right(UnitTester.Result(value, _)) = result.runtimeChecked
           assert(value == "cleanClientDownstream done")
+        }
+      }
+    }
+
+    test("makeExclusive") {
+      test("nonExclusiveBecomesExclusive") {
+        // makeExclusive on a non-exclusive command returns a new Command with exclusive = true
+        val cmd = exclusiveCommands.nonExclusiveCommand()
+        assert(!cmd.exclusive)
+        val exclusive = cmd.makeExclusive
+        assert(exclusive.exclusive)
+      }
+
+      test("alreadyExclusiveReturnsSelf") {
+        // makeExclusive on an already-exclusive command returns the same instance
+        val cmd = exclusiveCommands.cleanClientRight()
+        assert(cmd.exclusive)
+        assert(cmd.makeExclusive eq cmd)
+      }
+
+      test("makeExclusivePreservesProperties") {
+        // makeExclusive preserves inputs, isPrivate, persistent, and selectiveInputs0
+        val cmd = exclusiveCommands.nonExclusiveCommand()
+        val exclusive = cmd.makeExclusive
+        assert(exclusive.inputs == cmd.inputs)
+        assert(exclusive.isPrivate == cmd.isPrivate)
+        assert(exclusive.persistent == cmd.persistent)
+        assert(exclusive.selectiveInputs0 == cmd.selectiveInputs0)
+      }
+
+      test("makeExclusiveCommandWorks") {
+        // A command turned exclusive via makeExclusive executes successfully
+        UnitTester(exclusiveCommands, null).scoped { tester =>
+          val result = tester.apply(exclusiveCommands.nonExclusiveCommand().makeExclusive)
+          assert(result.isRight)
+          val Right(UnitTester.Result(value, _)) = result.runtimeChecked
+          assert(value == "nonExclusive done")
         }
       }
     }


### PR DESCRIPTION
This adds a `makeExclusive` helper on `Task.Command`, that returns a copy of the command with `exclusive` set to true.

This can be helpful if users want to make existing Mill commands exclusive, like
```scala
def testForked(args: String*) =
  super.testForked(args*).makeExclusive
def publishLocal(localIvyRepo: String = null, sources: Boolean = true, doc: Boolean = true, transitive: Boolean = false) =
  super.publishLocal(localIvyRepo, sources, doc, transitive).makeExclusive
```

This can be useful in some contexts, like if the tests do fancy termnal stuff, or when publishing locally many modules at a time while passing `--transitive=true` (if several command runs try to publish a given transitive dependency at the same time, they sometimes clash, with one writing files that the other doesn't expect to exist).