### PR TITLE
fix: catch NoClassDefFoundError during test discovery

### DIFF
--- a/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunnerUtils.scala
+++ b/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunnerUtils.scala
@@ -63,7 +63,9 @@ import scala.math.Ordering.Implicits.*
                 // sbt-jupiter-interface ignores fingerprinting since JUnit5 has its own resolving mechanism
                 Some((cls, fingerprints.head))
               } else if (
-                Modifier.isAbstract(cls.getModifiers) || cls.isInterface || publicConstructorCount > 1
+                Modifier.isAbstract(
+                  cls.getModifiers
+                ) || cls.isInterface || publicConstructorCount > 1
               ) {
                 None
               } else {

--- a/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunnerUtils.scala
+++ b/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunnerUtils.scala
@@ -77,10 +77,14 @@ import scala.math.Ordering.Implicits.*
               }
             } catch {
               // Scala 3 inline methods can generate synthetic type references in method
-              // signatures that don't have corresponding class files (e.g. package namespace
-              // types). When the JVM reflects on such classes via getDeclaredMethods/getMethods,
-              // it throws NoClassDefFoundError. Skip these classes during test discovery.
-              case _: NoClassDefFoundError | _: LinkageError => None
+              // signatures that don't have corresponding class files. When the JVM tries
+              // to reflect on these methods, it throws NoClassDefFoundError. We gracefully
+              // skip these classes as they are not valid test classes.
+              case e: (NoClassDefFoundError | LinkageError) =>
+                System.err.println(
+                  s"Skipping class during test discovery: ${path.stripSuffix(".class").replace('/', '.')} (${e.getClass.getSimpleName}: ${e.getMessage})"
+                )
+                None
             }
           }
             .toSeq
@@ -131,9 +135,13 @@ import scala.math.Ordering.Implicits.*
 
       }.map { f => (cls, f) }
     } catch {
-      // Scala 3 inline methods can reference synthetic types (e.g. package namespace classes)
-      // that don't exist as class files. JVM reflection on such methods throws NoClassDefFoundError.
-      case _: NoClassDefFoundError | _: LinkageError => None
+      // Reflection operations like getDeclaredMethods/getMethods can fail when classes
+      // reference synthetic types (e.g. from Scala 3 inline methods) that lack class files.
+      case e: (NoClassDefFoundError | LinkageError) =>
+        System.err.println(
+          s"Skipping class during fingerprint matching: ${cls.getName} (${e.getClass.getSimpleName}: ${e.getMessage})"
+        )
+        None
     }
   }
 

--- a/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunnerUtils.scala
+++ b/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunnerUtils.scala
@@ -54,23 +54,31 @@ import scala.math.Ordering.Implicits.*
       .flatMap { base =>
         Seq.from[ClassWithFingerprint](
           listClassFiles(base).map { path =>
-            val cls = cl.loadClass(path.stripSuffix(".class").replace('/', '.'))
-            val publicConstructorCount =
-              cls.getConstructors.count(c => Modifier.isPublic(c.getModifiers))
+            try {
+              val cls = cl.loadClass(path.stripSuffix(".class").replace('/', '.'))
+              val publicConstructorCount =
+                cls.getConstructors.count(c => Modifier.isPublic(c.getModifiers))
 
-            if (framework.name() == "Jupiter") {
-              // sbt-jupiter-interface ignores fingerprinting since JUnit5 has its own resolving mechanism
-              Some((cls, fingerprints.head))
-            } else if (
-              Modifier.isAbstract(cls.getModifiers) || cls.isInterface || publicConstructorCount > 1
-            ) {
-              None
-            } else {
-              (cls.getName.endsWith("$"), publicConstructorCount == 0) match {
-                case (true, true) => matchFingerprints(cl, cls, fingerprints, isModule = true)
-                case (false, false) => matchFingerprints(cl, cls, fingerprints, isModule = false)
-                case _ => None
+              if (framework.name() == "Jupiter") {
+                // sbt-jupiter-interface ignores fingerprinting since JUnit5 has its own resolving mechanism
+                Some((cls, fingerprints.head))
+              } else if (
+                Modifier.isAbstract(cls.getModifiers) || cls.isInterface || publicConstructorCount > 1
+              ) {
+                None
+              } else {
+                (cls.getName.endsWith("$"), publicConstructorCount == 0) match {
+                  case (true, true) => matchFingerprints(cl, cls, fingerprints, isModule = true)
+                  case (false, false) => matchFingerprints(cl, cls, fingerprints, isModule = false)
+                  case _ => None
+                }
               }
+            } catch {
+              // Scala 3 inline methods can generate synthetic type references in method
+              // signatures that don't have corresponding class files (e.g. package namespace
+              // types). When the JVM reflects on such classes via getDeclaredMethods/getMethods,
+              // it throws NoClassDefFoundError. Skip these classes during test discovery.
+              case _: NoClassDefFoundError | _: LinkageError => None
             }
           }
             .toSeq
@@ -102,23 +110,29 @@ import scala.math.Ordering.Implicits.*
       fingerprints: Array[Fingerprint],
       isModule: Boolean
   ): Option[ClassWithFingerprint] = {
-    fingerprints.find {
-      case f: SubclassFingerprint =>
-        f.isModule == isModule &&
-        cl.loadClass(f.superclassName()).isAssignableFrom(cls)
+    try {
+      fingerprints.find {
+        case f: SubclassFingerprint =>
+          f.isModule == isModule &&
+          cl.loadClass(f.superclassName()).isAssignableFrom(cls)
 
-      case f: AnnotatedFingerprint =>
-        val annotationCls = cl.loadClass(f.annotationName()).asInstanceOf[Class[Annotation]]
-        f.isModule == isModule &&
-        (
-          cls.isAnnotationPresent(annotationCls) ||
-            cls.getDeclaredMethods.exists(_.isAnnotationPresent(annotationCls)) ||
-            cls.getMethods.exists(m =>
-              m.isAnnotationPresent(annotationCls) && Modifier.isPublic(m.getModifiers())
-            )
-        )
+        case f: AnnotatedFingerprint =>
+          val annotationCls = cl.loadClass(f.annotationName()).asInstanceOf[Class[Annotation]]
+          f.isModule == isModule &&
+          (
+            cls.isAnnotationPresent(annotationCls) ||
+              cls.getDeclaredMethods.exists(_.isAnnotationPresent(annotationCls)) ||
+              cls.getMethods.exists(m =>
+                m.isAnnotationPresent(annotationCls) && Modifier.isPublic(m.getModifiers())
+              )
+          )
 
-    }.map { f => (cls, f) }
+      }.map { f => (cls, f) }
+    } catch {
+      // Scala 3 inline methods can reference synthetic types (e.g. package namespace classes)
+      // that don't exist as class files. JVM reflection on such methods throws NoClassDefFoundError.
+      case _: NoClassDefFoundError | _: LinkageError => None
+    }
   }
 
   def getTestTasks(

--- a/libs/javalib/testrunner/test/src/mill/javalib/testrunner/TestRunnerUtilsTests.scala
+++ b/libs/javalib/testrunner/test/src/mill/javalib/testrunner/TestRunnerUtilsTests.scala
@@ -6,7 +6,8 @@ import utest.*
 object TestRunnerUtilsTests extends TestSuite {
 
   class BrokenReflectionClassLoader(parent: ClassLoader) extends ClassLoader(parent) {
-    private val syntheticTypes = Set("non.existent.SyntheticType", "non.existent.SyntheticAnnotation")
+    private val syntheticTypes =
+      Set("non.existent.SyntheticType", "non.existent.SyntheticAnnotation")
 
     override def loadClass(name: String): Class[?] = {
       if (syntheticTypes.contains(name)) {

--- a/libs/javalib/testrunner/test/src/mill/javalib/testrunner/TestRunnerUtilsTests.scala
+++ b/libs/javalib/testrunner/test/src/mill/javalib/testrunner/TestRunnerUtilsTests.scala
@@ -1,0 +1,110 @@
+package mill.javalib.testrunner
+
+import sbt.testing.*
+import utest.*
+
+object TestRunnerUtilsTests extends TestSuite {
+
+  class BrokenReflectionClassLoader(parent: ClassLoader) extends ClassLoader(parent) {
+    private val syntheticTypes = Set("non.existent.SyntheticType", "non.existent.SyntheticAnnotation")
+
+    override def loadClass(name: String): Class[?] = {
+      if (syntheticTypes.contains(name)) {
+        throw new NoClassDefFoundError(name.replace('.', '/'))
+      } else {
+        super.loadClass(name)
+      }
+    }
+  }
+
+  class BrokenClass
+
+  class ErrorTriggeringFramework extends Framework {
+    def fingerprints(): Array[Fingerprint] = Array(
+      new SubclassFingerprint {
+        def isModule: Boolean = false
+        def superclassName(): String = "non.existent.SyntheticType"
+        def requireNoArgConstructor(): Boolean = true
+      }
+    )
+    def name(): String = "ErrorTriggeringFramework"
+    def runner(
+        args: Array[String],
+        remoteArgs: Array[String],
+        testClassLoader: ClassLoader
+    ): Runner = null
+  }
+
+  class AnnotationErrorFramework extends Framework {
+    def fingerprints(): Array[Fingerprint] = Array(
+      new AnnotatedFingerprint {
+        def isModule: Boolean = false
+        def annotationName(): String = "non.existent.SyntheticAnnotation"
+      }
+    )
+    def name(): String = "AnnotationErrorFramework"
+    def runner(
+        args: Array[String],
+        remoteArgs: Array[String],
+        testClassLoader: ClassLoader
+    ): Runner = null
+  }
+
+  def tests = Tests {
+    test("discoverTests gracefully skips classes that trigger NoClassDefFoundError") {
+      val cl = new BrokenReflectionClassLoader(getClass.getClassLoader)
+      val framework = new ErrorTriggeringFramework()
+
+      val tmpDir = os.temp.dir()
+      val classFile = tmpDir / "mill" / "javalib" / "testrunner" /
+        "TestRunnerUtilsTests$BrokenClass.class"
+      os.makeDir.all(classFile / os.up)
+      val realClassFile = os.Path(
+        classOf[BrokenClass]
+          .getProtectionDomain
+          .getCodeSource
+          .getLocation
+          .toURI
+      )
+      if (os.isDir(realClassFile)) {
+        val src = realClassFile / "mill" / "javalib" / "testrunner" /
+          "TestRunnerUtilsTests$BrokenClass.class"
+        if (os.exists(src)) os.copy(src, classFile)
+      }
+
+      val result = TestRunnerUtils.discoverTests(
+        cl,
+        framework,
+        classpath = Seq(tmpDir),
+        discoveredTestClasses = None
+      )
+      assert(result.isEmpty)
+    }
+
+    test("matchFingerprints returns None on NoClassDefFoundError") {
+      val cl = new BrokenReflectionClassLoader(getClass.getClassLoader)
+      val fingerprints = new ErrorTriggeringFramework().fingerprints()
+
+      val result = TestRunnerUtils.matchFingerprints(
+        cl,
+        classOf[BrokenClass],
+        fingerprints,
+        isModule = false
+      )
+      assert(result.isEmpty)
+    }
+
+    test("matchFingerprints returns None on NoClassDefFoundError for annotations") {
+      val cl = new BrokenReflectionClassLoader(getClass.getClassLoader)
+      val fingerprints = new AnnotationErrorFramework().fingerprints()
+
+      val result = TestRunnerUtils.matchFingerprints(
+        cl,
+        classOf[BrokenClass],
+        fingerprints,
+        isModule = false
+      )
+      assert(result.isEmpty)
+    }
+  }
+}


### PR DESCRIPTION
## Problem

Mill's test discovery crashes with `NoClassDefFoundError` when the test classpath contains libraries that use Scala 3 inline methods with synthetic type references.

Scala 3 inline methods can generate synthetic type references in method signatures that don't have corresponding class files — e.g. package namespace types like `io.bullet.borer.internal`. When `TestRunnerUtils.matchFingerprints` calls `cls.getDeclaredMethods()` / `cls.getMethods()`, the JVM tries to resolve these types and throws `NoClassDefFoundError`.

## Reproducer

Using the [tresql](https://github.com/mrumkovskis/tresql) project (`mill-build` branch):

```bash
git clone -b mill-build https://github.com/mrumkovskis/tresql.git && cd tresql
./mill _.test  # Scala 3.3.7 tests fail during discovery
```

Error:
```
NoClassDefFoundError: io/bullet/borer/internal
  at java.lang.Class.getDeclaredMethods0(Class.java:-2)
  at mill.javalib.testrunner.TestRunnerUtils$.matchFingerprints
```

The `io.bullet.borer.internal` type is a Scala 3 compiler synthetic for the `internal` package namespace, generated in `Encoder`/`Decoder` inline method stubs. No such class file exists in the borer JAR.

sbt handles this gracefully because its test discovery uses zinc analysis rather than JVM reflection.

## Fix

Wrap class loading and fingerprint matching in `TestRunnerUtils` with try/catch for `NoClassDefFoundError` and `LinkageError`, skipping classes that can't be fully resolved during reflection.

## Test plan
- [x] Verified fix resolves the tresql reproducer — all 3 Scala versions pass
- [ ] Existing Mill test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)