### PR TITLE
Add retry around github zip downloads

### DIFF
--- a/example/package.mill
+++ b/example/package.mill
@@ -431,7 +431,7 @@ $frontMatter
     def repoSlug = repoPath.split("/").last
 
     def downloadTestRepo(label: String, commit: String, dest: os.Path) = {
-      mill.util.Retry(){
+      mill.util.Retry() {
         os.unzip.stream(requests.get.stream(s"https://github.com/$label/archive/$commit.zip"), dest)
       }
       dest


### PR DESCRIPTION
Attempts to paper over the flakiness we're seeing e.g. https://github.com/com-lihaoyi/mill/actions/runs/23427774683/job/68146487062?pr=6953
```
requests.TimeoutException: Request to https://github.com/apache/commons-io/archive/b91a48074231ef813bc9b91a815d77f6343ff8f0.zip timed out. (readTimeout: 10000, connectTimout: 10000)
  requests.Requester$$anon$2$$anon$3.applyOrElse(Requester.scala:370)
  requests.Requester$$anon$2$$anon$3.applyOrElse(Requester.scala:367)
  scala.PartialFunction$Lifted.apply(PartialFunction.scala:354)
  scala.PartialFunction$Lifted.apply(PartialFunction.scala:353)
  requests.Requester$$anon$2.readBytesThrough(Requester.scala:381)
  os.unzip$$anon$2.generate(ZipOps.scala:444)
  geny.Generator$Filtered.generate(Generator.scala:281)
  geny.Generator.foreach(Generator.scala:51)
  geny.Generator.foreach$(Generator.scala:33)
  geny.Generator$Filtered.foreach(Generator.scala:279)
  os.unzip$.stream(ZipOps.scala:419)
  build_.example.package_$ThirdPartyModule.downloadTestRepo(package.mill:434)
  build_.example.package_$ThirdPartyModule.downloadTestRepo$(package.mill:429)
  build_.example.package_$ThirdPartyModule_impl$1.downloadTestRepo(package.mill:200)
  build_.example.package_$ThirdPartyModule.downloadedRepo$$anonfun$1$$anonfun$1(package.mill:438)
  mill.api.Task$Named.evaluate(Task.scala:443)
  mill.api.Task$Named.evaluate$(Task.scala:428)
  mill.api.Task$Computed.evaluate(Task.scala:454)
0009] [error] example.thirdparty.jimfs.downloadedRepo
requests.TimeoutException: Request to https://github.com/google/jimfs/archive/5b60a42eb9d3cd7a2073d549bd0cb833f5a7e7e9.zip timed out. (readTimeout: 10000, connectTimout: 10000)
  requests.Requester$$anon$2$$anon$3.applyOrElse(Requester.scala:370)
  requests.Requester$$anon$2$$anon$3.applyOrElse(Requester.scala:367)
  scala.PartialFunction$Lifted.apply(PartialFunction.scala:354)
  scala.PartialFunction$Lifted.apply(PartialFunction.scala:353)
  requests.Requester$$anon$2.readBytesThrough(Requester.scala:381)
  os.unzip$$anon$2.generate(ZipOps.scala:444)
  geny.Generator$Filtered.generate(Generator.scala:281)
  geny.Generator.foreach(Generator.scala:51)
  geny.Generator.foreach$(Generator.scala:33)
  geny.Generator$Filtered.foreach(Generator.scala:279)
  os.unzip$.stream(ZipOps.scala:419)
  build_.example.package_$ThirdPartyModule.downloadTestRepo(package.mill:434)
  build_.example.package_$ThirdPartyModule.downloadTestRepo$(package.mill:429)
  build_.example.package_$ThirdPartyModule_impl$1.downloadTestRepo(package.mill:200)
  build_.example.package_$ThirdPartyModule.downloadedRepo$$anonfun$1$$anonfun$1(package.mill:438)
  mill.api.Task$Named.evaluate(Task.scala:443)
  mill.api.Task$Named.evaluate$(Task.scala:428)
  mill.api.Task$Computed.evaluate(Task.scala:454)
1] [error] selective.run
```