### PR TITLE
Add Task.Command#makeExclusive

### DIFF
--- a/core/api/src/mill/api/Task.scala
+++ b/core/api/src/mill/api/Task.scala
@@ -542,7 +542,7 @@ object Task {
      *
      * Changing it to true ensures this command doesn't run concurrently with other commands.
      */
-    def withExclusive(value: Boolean)(implicit ctx: ModuleCtx): Command[T] =
+    def makeExclusive(value: Boolean)(implicit ctx: ModuleCtx): Command[T] =
       if (exclusive == value) this
       else
         new Command[T](

--- a/core/api/src/mill/api/Task.scala
+++ b/core/api/src/mill/api/Task.scala
@@ -536,6 +536,25 @@ object Task {
     override def asCommand: Some[Command[T]] = Some(this)
     // FIXME: deprecated return type: Change to Option
     override def writerOpt: Some[Writer[?]] = Some(writer)
+
+    /**
+     * Change the "exclusive" flag of this command
+     *
+     * Changing it to true ensures this command doesn't run concurrently with other commands.
+     */
+    def withExclusive(value: Boolean)(implicit ctx: ModuleCtx): Command[T] =
+      if (exclusive == value) this
+      else
+        new Command[T](
+          inputs,
+          evaluate0,
+          ctx,
+          writer,
+          isPrivate,
+          exclusive = value,
+          persistent,
+          selectiveInputs0
+        )
   }
   class Worker[T](
       val inputs: Seq[Task[Any]],

--- a/core/exec/test/src/mill/exec/ExecutionTests.scala
+++ b/core/exec/test/src/mill/exec/ExecutionTests.scala
@@ -76,11 +76,17 @@ object ExecutionTests extends TestSuite {
     def cleanClientRight() = Task.Command(exclusive = true) {
       "cleanClientRight done"
     }
+    // not actually used below, but we check that this compiles fine here
+    def cleanClientRightMadeExclusive() =
+      cleanClientRight().withExclusive(true)
 
     def cleanClientDownstream() = Task.Command() {
       cleanClientRight()()
       "cleanClientDownstream done"
     }
+
+    def nonExclusiveCommand() = Task.Command() { "nonExclusive done" }
+    def nonExclusiveCommandMadeExclusive() = nonExclusiveCommand().withExclusive(true)
 
     lazy val millDiscover = Discover[this.type]
   }
@@ -634,6 +640,44 @@ object ExecutionTests extends TestSuite {
           assert(result.isRight)
           val Right(UnitTester.Result(value, _)) = result.runtimeChecked
           assert(value == "cleanClientDownstream done")
+        }
+      }
+    }
+
+    test("withExclusive") {
+      test("nonExclusiveBecomesExclusive") {
+        // withExclusive on a non-exclusive command returns a new Command with exclusive = true
+        val cmd = exclusiveCommands.nonExclusiveCommand()
+        assert(!cmd.exclusive)
+        val exclusive = exclusiveCommands.nonExclusiveCommandMadeExclusive()
+        assert(exclusive.exclusive)
+      }
+
+      test("alreadyExclusiveReturnsSelf") {
+        // withExclusive(true) on an already-exclusive command returns the same instance
+        val cmd = exclusiveCommands.cleanClientRight()
+        val cmd0 = cmd.withExclusive(true)(using null)
+        assert(cmd.exclusive)
+        assert(cmd0 eq cmd)
+      }
+
+      test("makeExclusivePreservesProperties") {
+        // withExclusive(true) preserves inputs, isPrivate, persistent, and selectiveInputs0
+        val cmd = exclusiveCommands.nonExclusiveCommand()
+        val exclusive = exclusiveCommands.nonExclusiveCommandMadeExclusive()
+        assert(exclusive.inputs == cmd.inputs)
+        assert(exclusive.isPrivate == cmd.isPrivate)
+        assert(exclusive.persistent == cmd.persistent)
+        assert(exclusive.selectiveInputs0 == cmd.selectiveInputs0)
+      }
+
+      test("makeExclusiveCommandWorks") {
+        // A command turned exclusive via withExclusive(true) executes successfully
+        UnitTester(exclusiveCommands, null).scoped { tester =>
+          val result = tester.apply(exclusiveCommands.nonExclusiveCommandMadeExclusive())
+          assert(result.isRight)
+          val Right(UnitTester.Result(value, _)) = result.runtimeChecked
+          assert(value == "nonExclusive done")
         }
       }
     }

--- a/core/exec/test/src/mill/exec/ExecutionTests.scala
+++ b/core/exec/test/src/mill/exec/ExecutionTests.scala
@@ -78,7 +78,7 @@ object ExecutionTests extends TestSuite {
     }
     // not actually used below, but we check that this compiles fine here
     def cleanClientRightMadeExclusive() =
-      cleanClientRight().withExclusive(true)
+      cleanClientRight().makeExclusive(true)
 
     def cleanClientDownstream() = Task.Command() {
       cleanClientRight()()
@@ -86,7 +86,7 @@ object ExecutionTests extends TestSuite {
     }
 
     def nonExclusiveCommand() = Task.Command() { "nonExclusive done" }
-    def nonExclusiveCommandMadeExclusive() = nonExclusiveCommand().withExclusive(true)
+    def nonExclusiveCommandMadeExclusive() = nonExclusiveCommand().makeExclusive(true)
 
     lazy val millDiscover = Discover[this.type]
   }
@@ -644,9 +644,9 @@ object ExecutionTests extends TestSuite {
       }
     }
 
-    test("withExclusive") {
+    test("makeExclusive") {
       test("nonExclusiveBecomesExclusive") {
-        // withExclusive on a non-exclusive command returns a new Command with exclusive = true
+        // makeExclusive on a non-exclusive command returns a new Command with exclusive = true
         val cmd = exclusiveCommands.nonExclusiveCommand()
         assert(!cmd.exclusive)
         val exclusive = exclusiveCommands.nonExclusiveCommandMadeExclusive()
@@ -654,15 +654,15 @@ object ExecutionTests extends TestSuite {
       }
 
       test("alreadyExclusiveReturnsSelf") {
-        // withExclusive(true) on an already-exclusive command returns the same instance
+        // makeExclusive(true) on an already-exclusive command returns the same instance
         val cmd = exclusiveCommands.cleanClientRight()
-        val cmd0 = cmd.withExclusive(true)(using null)
+        val cmd0 = cmd.makeExclusive(true)(using null)
         assert(cmd.exclusive)
         assert(cmd0 eq cmd)
       }
 
       test("makeExclusivePreservesProperties") {
-        // withExclusive(true) preserves inputs, isPrivate, persistent, and selectiveInputs0
+        // makeExclusive(true) preserves inputs, isPrivate, persistent, and selectiveInputs0
         val cmd = exclusiveCommands.nonExclusiveCommand()
         val exclusive = exclusiveCommands.nonExclusiveCommandMadeExclusive()
         assert(exclusive.inputs == cmd.inputs)
@@ -672,7 +672,7 @@ object ExecutionTests extends TestSuite {
       }
 
       test("makeExclusiveCommandWorks") {
-        // A command turned exclusive via withExclusive(true) executes successfully
+        // A command turned exclusive via makeExclusive(true) executes successfully
         UnitTester(exclusiveCommands, null).scoped { tester =>
           val result = tester.apply(exclusiveCommands.nonExclusiveCommandMadeExclusive())
           assert(result.isRight)


### PR DESCRIPTION
New attempt at https://github.com/com-lihaoyi/mill/pull/6928

This adds a `makeExclusive` helper on `Task.Command`, that can be used to make a copy of the command with `exclusive` set to true.

This can be helpful if users want to make existing Mill commands exclusive, like
```scala
def testForked(args: String*) =
  super.testForked(args*).makeExclusive(true)
def publishLocal(localIvyRepo: String = null, sources: Boolean = true, doc: Boolean = true, transitive: Boolean = false) =
  super.publishLocal(localIvyRepo, sources, doc, transitive).makeExclusive(true)
```

This can be useful in some contexts, like if the tests do fancy terminal stuff and cannot run in parallel because of that, or when publishing locally many modules at a time while passing `--transitive=true` (if several command runs try to publish a given transitive dependency at the same time, they sometimes clash, with one writing files that the other doesn't expect to exist already).