### PR TITLE
Android: Minor cleanup and dexing/shrinking fixes

### DIFF
--- a/example/thirdparty/androidtodo/build.mill
+++ b/example/thirdparty/androidtodo/build.mill
@@ -107,7 +107,7 @@ object app
     mvn"com.google.dagger:hilt-android-compiler:2.56"
   )
 
-  object test extends KspTests, AndroidAppKotlinTests, AndroidHiltSupport, TestModule.Junit4,
+  object test extends KspTests, AndroidHiltSupport, AndroidAppKotlinTests, TestModule.Junit4,
         KotlinIdeaModule {
 
     def moduleDeps = super.moduleDeps ++ Seq(`shared-test`)

--- a/libs/androidlib/src/mill/androidlib/AndroidAppBundle.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppBundle.scala
@@ -28,7 +28,7 @@ trait AndroidAppBundle extends AndroidAppModule with JavaModule {
    */
   def androidBundleZip: T[PathRef] = Task {
     val dexFile = androidDex().path
-    val resFile = androidLinkedResources().path / "apk/res.apk"
+    val resFile = androidLinkedResources().apk.path
     val baseDir = Task.dest / "base"
     val appDir = Task.dest / "app"
 

--- a/libs/androidlib/src/mill/androidlib/AndroidAppKotlinModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppKotlinModule.scala
@@ -196,17 +196,13 @@ trait AndroidAppKotlinModule extends AndroidKotlinModule, AndroidAppModule { out
         ),
         screenshots = androidDiscoveredPreviews().screenshotConfigs,
         namespace = androidApplicationNamespace,
-        resourceApkPath = resourceApkPath().path.toString(),
+        resourceApkPath = androidLinkedResources().apk.path.toString(),
         resultsFilePath = resultsFilePath.toString()
       )
       os.write(cliArgsFile, upickle.write(cliArgs))
 
       PathRef(cliArgsFile)
 
-    }
-
-    private def resourceApkPath: Task[PathRef] = Task {
-      PathRef(outer.androidLinkedResources().path / "apk/res.apk")
     }
 
     // TODO previews must be source controlled to be used as a base

--- a/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
@@ -256,7 +256,7 @@ trait AndroidAppModule extends AndroidModule { outer =>
   def androidUnsignedApk: T[PathRef] = Task {
     val unsignedApk = Task.dest / "app.unsigned.apk"
 
-    os.copy(androidLinkedResources().path / "apk/res.apk", unsignedApk)
+    os.copy(androidLinkedResources().apk.path, unsignedApk)
 
     val androidDexPath = androidDex().path
     os.zip(
@@ -888,9 +888,14 @@ trait AndroidAppModule extends AndroidModule { outer =>
     androidUnpackArchives()
       .flatMap(_.proguardRules)
       .map(p => os.read(p.path))
-      .appendedAll(mainDexPlatformRules)
-      .appended(os.read(androidLinkedResources().path / "proguard/main-dex-rules.pro"))
+      .appended(os.read(androidLinkedResources().proguardRulesFile.path))
       .mkString("\n")
+  }
+
+  def androidKnownProguardRulesFile: T[PathRef] = Task {
+    val filePath = Task.dest / "known_rules.pro"
+    os.write(filePath, androidKnownProguardRules())
+    PathRef(filePath)
   }
 
   /**

--- a/libs/androidlib/src/mill/androidlib/AndroidModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidModule.scala
@@ -26,22 +26,6 @@ trait AndroidModule extends JavaModule { outer =>
     ModuleRef(new GenIdeaAndroidModule.Wrap(this) {}.internalGenIdea)
   }
 
-  // https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:build-system/gradle-core/src/main/java/com/android/build/gradle/internal/tasks/D8BundleMainDexListTask.kt;l=210-223;drc=66ab6bccb85ce3ed7b371535929a69f494d807f0
-  val mainDexPlatformRules = Seq(
-    "-keep public class * extends android.app.Instrumentation {\n" +
-      "  <init>(); \n" +
-      "  void onCreate(...);\n" +
-      "  android.app.Application newApplication(...);\n" +
-      "  void callApplicationOnCreate(android.app.Application);\n" +
-      "}",
-    "-keep public class * extends android.app.Application { " +
-      "  <init>();\n" +
-      "  void attachBaseContext(android.content.Context);\n" +
-      "}",
-    "-keep public class * extends android.app.backup.BackupAgent { <init>(); }",
-    "-keep public class * extends android.test.InstrumentationTestCase { <init>(); }"
-  )
-
   /**
    * Adds "aar" to the handled artifact types.
    */
@@ -600,7 +584,7 @@ trait AndroidModule extends JavaModule { outer =>
     // But we also need to have R.java classes for libraries. The process below is quite hacky and inefficient, because:
     // * it will generate R.java for the library even library has no resources declared
     // * R.java will have not only resource ID from this library, but from other libraries as well. They should be stripped.
-    val rClassDir = androidLinkedResources().path / "generatedSources/java"
+    val rClassDir = androidLinkedResources().generatedSourcesDir.path
     val rSources = os.walk(rClassDir).filter(p => os.isFile(p) && p.ext == "java")
     val mainRClassPath = rSources
       .find(_.last == "R.java")
@@ -812,7 +796,8 @@ trait AndroidModule extends JavaModule { outer =>
    * For more information see [[https://developer.android.com/tools/aapt2#link]]
    * @return a directory which contains the apk, proguard and generated R sources.
    */
-  def androidLinkedResources: T[PathRef] = Task {
+  def androidLinkedResources: T[AndroidLinkedResources] = Task {
+
     val compiledLibResDir = androidCompiledLibResources().path
     val moduleResDirs = (androidCompiledModuleResources() ++ androidTransitiveCompiledResources())
       .map(_.path)
@@ -833,10 +818,7 @@ trait AndroidModule extends JavaModule { outer =>
     os.makeDir(apkDir)
 
     val resApkFile = apkDir / "res.apk"
-
-    val mainDexRulesProFile = proguard / "main-dex-rules.pro"
-
-    val aapt2Link = Seq(androidSdkModule().aapt2Exe().path.toString(), "link")
+    val proguardRulesFile = proguard / "proguard-rules.pro"
 
     val linkArgs = Seq(
       "-I",
@@ -855,9 +837,8 @@ trait AndroidModule extends JavaModule { outer =>
       androidVersionCode().toString,
       "--version-name",
       androidVersionName(),
-      "--proguard-main-dex",
-      mainDexRulesProFile.toString,
-      "--proguard-conditional-keep-rules"
+      "--proguard",
+      proguardRulesFile.toString
     ) ++ androidAaptOptions() ++ Seq(
       "-o",
       resApkFile.toString,
@@ -867,11 +848,17 @@ trait AndroidModule extends JavaModule { outer =>
       transitiveMergedAssetsDir.toString
     )
 
+    val aapt2Link = Seq(androidSdkModule().aapt2Exe().path.toString(), "link")
+
     Task.log.info((aapt2Link ++ linkArgs).mkString(" "))
 
     os.call(aapt2Link ++ linkArgs)
 
-    PathRef(Task.dest)
+    AndroidLinkedResources(
+      apk = PathRef(resApkFile),
+      generatedSourcesDir = PathRef(javaRClassDir),
+      proguardRulesFile = PathRef(proguardRulesFile)
+    )
   }
 
   /**
@@ -992,7 +979,7 @@ trait AndroidModule extends JavaModule { outer =>
       Map(
         "android_custom_package" -> outer.androidNamespace,
         "android_merged_manifest" -> outer.androidMergedManifest().path.toString,
-        "android_resource_apk" -> (outer.androidLinkedResources().path / "apk" / "res.apk").toString,
+        "android_resource_apk" -> outer.androidLinkedResources().apk.path.toString,
         "android_merged_assets" -> outer.androidTransitiveMergedAssets().path.toString
       )
     }
@@ -1034,3 +1021,9 @@ trait AndroidModule extends JavaModule { outer =>
   }
 
 }
+
+case class AndroidLinkedResources(
+    apk: PathRef,
+    generatedSourcesDir: PathRef,
+    proguardRulesFile: PathRef
+) derives upickle.default.ReadWriter

--- a/libs/androidlib/src/mill/androidlib/AndroidR8AppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidR8AppModule.scala
@@ -143,6 +143,10 @@ trait AndroidR8AppModule extends AndroidAppModule { outer =>
     Seq.empty[String]
   }
 
+  def androidR8ExtraRules: T[Seq[String]] = Task {
+    Seq.empty[String]
+  }
+
   def androidDebugSettings: T[AndroidBuildTypeSettings] = Task {
     AndroidBuildTypeSettings()
   }
@@ -230,14 +234,14 @@ trait AndroidR8AppModule extends AndroidAppModule { outer =>
       val baselineOutOpt = diagnosticsDir / "baseline-profile-rewritten.txt"
 
       // Extra ProGuard rules
-      val extraRules =
+      val extraRules = androidR8ExtraRules() ++
         Seq(
           // Instruct R8 to print seeds and usage.
           s"-printseeds $seedsOut",
           s"-printusage $usageOut"
         ) ++
-          (if (androidBuildSettings().isMinifyEnabled) then androidGeneratedMinifyKeepRules()
-           else Seq())
+        (if (androidBuildSettings().isMinifyEnabled) then androidGeneratedMinifyKeepRules()
+         else Seq())
       // Create an extra ProGuard config file
       val extraRulesFile = Task.dest / "extra-rules.pro"
       val extraRulesContent = extraRules.mkString("\n")
@@ -319,6 +323,8 @@ trait AndroidR8AppModule extends AndroidAppModule { outer =>
         Seq(
           "--pg-conf",
           androidProguard().path.toString,
+          "--pg-conf",
+          androidKnownProguardRulesFile().path.toString,
           "--pg-conf",
           extraRulesFile.toString
         ) ++ androidCommonProguardFiles().flatMap(pgf => Seq("--pg-conf", pgf.path.toString))

--- a/libs/androidlib/src/mill/androidlib/AndroidR8AppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidR8AppModule.scala
@@ -82,8 +82,11 @@ trait AndroidR8AppModule extends AndroidAppModule { outer =>
    * Useful for dependencies that are provided in devices and compile only module deps
    * such as for avoiding to package main sources in the androidTest apk.
    */
-  def androidR8CompileOnlyClasspath: T[Seq[PathRef]] =
-    androidResolvedCompileMvnDeps() ++ androidTransitiveCompileOnlyClasspath() ++ androidTransitiveModuleRClasspath()
+  def androidR8CompileOnlyClasspath: T[Seq[PathRef]] = Task {
+    val cp =
+      androidResolvedCompileMvnDeps() ++ androidTransitiveCompileOnlyClasspath() ++ androidTransitiveModuleRClasspath()
+    cp.filter(_.path.ext == "jar")
+  }
 
   /**
    * Creates a file of [[androidR8CompileOnlyClasspath]] for CLI compatibility reasons (e.g. windows arg limit)
@@ -331,14 +334,14 @@ trait AndroidR8AppModule extends AndroidAppModule { outer =>
 
       r8ArgsBuilder ++= pgArgs
 
-      val compileOnlyClasspath = androidR8CompileOnlyClasspath()
+      val compileOnlyClasspathFileOpt = androidR8CompileOnlyClasspathFile()
 
-      r8ArgsBuilder ++= compileOnlyClasspath.filter(_.path.ext == "jar").flatMap(compiledMvnDeps =>
-        Seq(
+      compileOnlyClasspathFileOpt.foreach { cpFile =>
+        r8ArgsBuilder ++= Seq(
           "--classpath",
-          compiledMvnDeps.path.toString
+          s"@${cpFile.path.toString}"
         )
-      )
+      }
 
       r8ArgsBuilder ++= androidR8Args()
 

--- a/libs/androidlib/src/mill/androidlib/idea/GenIdeaAndroidModule.scala
+++ b/libs/androidlib/src/mill/androidlib/idea/GenIdeaAndroidModule.scala
@@ -22,7 +22,7 @@ trait GenIdeaAndroidModule extends mill.javalib.idea.GenIdeaModule {
   override private[mill] def moduleGeneratedSources = Task {
     val superSources = super.moduleGeneratedSources()
     val rSourcesDirs =
-      Seq(javaModuleRef().androidLinkedResources().path / "generatedSources").map(PathRef(_))
+      Seq(javaModuleRef().androidLinkedResources().generatedSourcesDir)
 
     superSources ++ rSourcesDirs
   }


### PR DESCRIPTION
## Changes

Make `androidLinkedResources` return a structure instead of just its `Task.dest`
```scala
case class AndroidLinkedResources(
  apk: PathRef,
  generatedSourcesDir: PathRef,
  proguardRulesFile: PathRef
)
```
so downstream tasks can safely use these fields.

**Legacy code cleanup:**
- Proguard rules that are meant for d8 ([main-dex-rules](https://github.com/com-lihaoyi/mill/blob/main/libs/androidlib/src/mill/androidlib/AndroidModule.scala#L858)  and [mainDexPlatformRules](https://github.com/com-lihaoyi/mill/blob/main/libs/androidlib/src/mill/androidlib/AndroidModule.scala#L30)) were needed for api <21 which we can ignore as no modern builds require it

**R8 fixes:**
- Generate proguard keep rules for R8 with AAPT2 (`--proguard` flag), pick them up and pass them to R8 
- Add `androidR8ExtraRules` task to be able to configure R8 with more ease from `build.mill`
- The logic of passing the classpath with `--classpath @<filename_with_cp_entries>` was accidentally ignored, so this adds this back. (This is helpful because it makes the cli command more compact)


## Future work
Gradle seems to use D8 by default for faster (debug) builds and only uses R8 when minification or optimization is enabled (release builds). ([Ref](https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:build-system/gradle-core/src/main/java/com/android/build/gradle/internal/TaskManager.kt;l=1723?q=maybeCreateJavaCodeShrinkerTask&ss=android-studio%2Fplatform%2Ftools%2Fbase))
In the current implementation, mixing in `AndroidR8AppModule` always enables R8, regardless of build type.
We could do the same as gradle, determine which tool to use based on the build settings, and even completely drop the R8 trait

Additionally, if we do keep the trait, some Proguard-related tasks currently reside in `AndroidModule` and `AndroidAppModule` but are only relevant to R8 and could be moved into `AndroidR8AppModule`