### PR TITLE
Compile directly to jar by default rather than to loose class files

### DIFF
--- a/libs/androidlib/src/mill/androidlib/AndroidModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidModule.scala
@@ -639,6 +639,7 @@ trait AndroidModule extends JavaModule { outer =>
         compileClasspath = Seq.empty,
         javacOptions = jOpts.compiler,
         incrementalCompilation = true,
+        compileToJar = false,
         workDir = Task.dest
       ),
       javaHome = javaHome().map(_.path),
@@ -905,6 +906,7 @@ trait AndroidModule extends JavaModule { outer =>
           compileClasspath = androidTransitiveLibRClasspath().map(_.path),
           javacOptions = jOpts.compiler,
           incrementalCompilation = zincIncrementalCompilation(),
+          compileToJar = false,
           workDir = Task.dest
         ),
         javaHome = javaHome().map(_.path),

--- a/libs/groovylib/src/mill/groovylib/GroovyModule.scala
+++ b/libs/groovylib/src/mill/groovylib/GroovyModule.scala
@@ -265,6 +265,7 @@ trait GroovyModule extends JavaModule with GroovyModuleApi { outer =>
         compileClasspath = compileCp,
         javacOptions = jOpts.compiler,
         incrementalCompilation = true,
+        compileToJar = false,
         workDir = ctx.dest
       ),
       javaHome = javaHome,

--- a/libs/javalib/api/src/mill/javalib/api/internal/InternalJvmWorkerApi.scala
+++ b/libs/javalib/api/src/mill/javalib/api/internal/InternalJvmWorkerApi.scala
@@ -40,6 +40,7 @@ trait InternalJvmWorkerApi extends PublicJvmWorkerApi, AutoCloseable {
         compileClasspath = compileClasspath,
         javacOptions = jOpts.compiler,
         incrementalCompilation = incrementalCompilation,
+        compileToJar = false,
         workDir = workDir
       ),
       javaHome = javaHome,
@@ -83,6 +84,7 @@ trait InternalJvmWorkerApi extends PublicJvmWorkerApi, AutoCloseable {
         compilerBridgeOpt = compilerBridgeOpt,
         incrementalCompilation = incrementalCompilation,
         auxiliaryClassFileExtensions = auxiliaryClassFileExtensions,
+        compileToJar = false,
         workDir = workDir
       ),
       javaHome = javaHome,

--- a/libs/javalib/api/src/mill/javalib/api/internal/ZincOp.scala
+++ b/libs/javalib/api/src/mill/javalib/api/internal/ZincOp.scala
@@ -16,8 +16,8 @@ object ZincOp {
       javacOptions: Seq[String],
       incrementalCompilation: Boolean,
       workDir: os.Path,
-      @com.lihaoyi.unroll compileToJar: Boolean = true,
-    ) extends ZincOp {
+      @com.lihaoyi.unroll compileToJar: Boolean = true
+  ) extends ZincOp {
     type Response = Result[CompilationResult]
   }
 
@@ -36,8 +36,8 @@ object ZincOp {
       incrementalCompilation: Boolean,
       auxiliaryClassFileExtensions: Seq[String],
       workDir: os.Path,
-      @com.lihaoyi.unroll compileToJar: Boolean = true,
-    ) extends ZincOp {
+      @com.lihaoyi.unroll compileToJar: Boolean = true
+  ) extends ZincOp {
     type Response = Result[CompilationResult]
   }
 

--- a/libs/javalib/api/src/mill/javalib/api/internal/ZincOp.scala
+++ b/libs/javalib/api/src/mill/javalib/api/internal/ZincOp.scala
@@ -15,8 +15,9 @@ object ZincOp {
       compileClasspath: Seq[os.Path],
       javacOptions: Seq[String],
       incrementalCompilation: Boolean,
-      workDir: os.Path
-  ) extends ZincOp {
+      workDir: os.Path,
+      @com.lihaoyi.unroll compileToJar: Boolean = true,
+    ) extends ZincOp {
     type Response = Result[CompilationResult]
   }
 
@@ -34,8 +35,9 @@ object ZincOp {
       compilerBridgeOpt: Option[PathRef],
       incrementalCompilation: Boolean,
       auxiliaryClassFileExtensions: Seq[String],
-      workDir: os.Path
-  ) extends ZincOp {
+      workDir: os.Path,
+      @com.lihaoyi.unroll compileToJar: Boolean = true,
+    ) extends ZincOp {
     type Response = Result[CompilationResult]
   }
 

--- a/libs/javalib/src/mill/javalib/JavaModule.scala
+++ b/libs/javalib/src/mill/javalib/JavaModule.scala
@@ -959,6 +959,13 @@ trait JavaModule
   def zincIncrementalCompilation: T[Boolean] = Task { allSourceFiles().length > 1 }
 
   /**
+   * Whether to compile directly to a jar file instead of to a directory of classfiles.
+   * This can be faster on some filesystems by avoiding the overhead of creating many
+   * individual class files.
+   */
+  def compileToJar: T[Boolean] = Task { true }
+
+  /**
    * Compiles the current module to generate compiled classfiles/bytecode.
    *
    * When you override this, you probably also want/need to override [[bspCompileClassesPath]],
@@ -995,6 +1002,7 @@ trait JavaModule
         compileClasspath = compileClasspath().map(_.path),
         javacOptions = javacCompilerOptions,
         incrementalCompilation = zincIncrementalCompilation(),
+        compileToJar = compileToJar(),
         workDir = Task.dest
       ),
       javaHome = javaHome().map(_.path),
@@ -1015,7 +1023,7 @@ trait JavaModule
   /** The path where the compiled classes produced by [[compile]] are stored. */
   @internal
   private[mill] def compileClassesPath: UnresolvedPath.DestPath =
-    resolveRelativeToOut(compile, _ / "classes")
+    resolveRelativeToOut(compile, _ / "classes.jar")
 
   /**
    * The path to the compiled classes by [[compile]] without forcing to actually run the compilation.

--- a/libs/javalib/src/mill/javalib/JavaModule.scala
+++ b/libs/javalib/src/mill/javalib/JavaModule.scala
@@ -1275,7 +1275,11 @@ trait JavaModule
    */
   def jar: T[PathRef] = Task {
     val jar = Task.dest / "out.jar"
-    Jvm.createJar(jar, localClasspath().map(_.path).filter(os.exists), manifest())
+    val classesPath = compile().classes.path
+    val base = if (os.isFile(classesPath) && classesPath.ext == "jar") Some(classesPath) else None
+    val inputs = localClasspath().map(_.path).filter(os.exists)
+    val filteredInputs = inputs.filter(!base.contains(_))
+    Jvm.createJar(jar, filteredInputs, manifest(), base = base)
     PathRef(jar)
   }
 

--- a/libs/javalib/src/mill/javalib/SemanticDbJavaModule.scala
+++ b/libs/javalib/src/mill/javalib/SemanticDbJavaModule.scala
@@ -147,6 +147,7 @@ trait SemanticDbJavaModule extends CoursierModule with SemanticDbJavaModuleApi
           ),
         javacOptions = javacCompilerOptions,
         incrementalCompilation = zincIncrementalCompilation(),
+        compileToJar = false,
         workDir = Task.dest
       ),
       javaHome = javaHome().map(_.path),

--- a/libs/javalib/src/mill/javalib/TestModule.scala
+++ b/libs/javalib/src/mill/javalib/TestModule.scala
@@ -477,11 +477,13 @@ object TestModule {
 
     protected lazy val classesDir: Task[Option[os.Path]] = this match {
       case withCompileTask: JavaModule => Task.Anon {
-          Some(withCompileTask.compile().classes.path)
+          val p = withCompileTask.compile().classes.path
+          Option.when(os.isDir(p))(p)
         }
       case m => Task.Anon {
           m.testClasspath().map(_.path).find { path =>
-            os.exists(path) && os.walk.stream(path).exists(p => os.isFile(p) && p.ext == "class")
+            os.exists(path) && os.isDir(path) &&
+            os.walk.stream(path).exists(p => os.isFile(p) && p.ext == "class")
           }
         }
     }

--- a/libs/javalib/test/src/mill/javalib/HelloJavaTests.scala
+++ b/libs/javalib/test/src/mill/javalib/HelloJavaTests.scala
@@ -9,6 +9,11 @@ import mill.api.Discover
 
 object HelloJavaTests extends TestSuite {
 
+  private def classesContain(classesPath: os.Path, fileName: String): Boolean = {
+    if (os.isDir(classesPath)) os.walk(classesPath).exists(_.last == fileName)
+    else os.proc("jar", "tf", classesPath).call().out.lines().exists(_.endsWith(fileName))
+  }
+
   object HelloJava extends TestRootModule {
     object core extends JavaModule {
       override def docJarUseArgsFile = false
@@ -43,10 +48,10 @@ object HelloJavaTests extends TestSuite {
           result2.evalCount == 0,
           result3.evalCount != 0,
           result3.evalCount != 0,
-          os.walk(result1.value.classes.path).exists(_.last == "Core.class"),
-          !os.walk(result1.value.classes.path).exists(_.last == "Main.class"),
-          os.walk(result3.value.classes.path).exists(_.last == "Main.class"),
-          !os.walk(result3.value.classes.path).exists(_.last == "Core.class")
+          classesContain(result1.value.classes.path, "Core.class"),
+          !classesContain(result1.value.classes.path, "Main.class"),
+          classesContain(result3.value.classes.path, "Main.class"),
+          !classesContain(result3.value.classes.path, "Core.class")
         )
       }
     }

--- a/libs/javalib/test/src/mill/javalib/JavaCompileErrorFormattingTests.scala
+++ b/libs/javalib/test/src/mill/javalib/JavaCompileErrorFormattingTests.scala
@@ -39,7 +39,7 @@ object JavaCompileErrorFormattingTests extends TestSuite {
       assertGoldenLiteral(
         checkLines("java-type-unchecked"),
         List(
-          "compiling 1 Java source to out/core/compile.dest/classes ...",
+          "compiling 1 Java source to out/core/compile.dest/classes.jar ...",
           "[warn] core/src/Foo.java:6:22",
           "        return (T[]) obj;",
           "                     ^^^",
@@ -61,7 +61,7 @@ object JavaCompileErrorFormattingTests extends TestSuite {
       assertGoldenLiteral(
         checkLines("java-type-mismatch"),
         List(
-          "compiling 1 Java source to out/core/compile.dest/classes ...",
+          "compiling 1 Java source to out/core/compile.dest/classes.jar ...",
           "[error] core/src/Foo.java:5:17",
           "        int x = \"hello\";",
           "                ^^^^^^^",
@@ -76,7 +76,7 @@ object JavaCompileErrorFormattingTests extends TestSuite {
       assertGoldenLiteral(
         checkLines("java-type-method"),
         List(
-          "compiling 1 Java source to out/core/compile.dest/classes ...",
+          "compiling 1 Java source to out/core/compile.dest/classes.jar ...",
           "[error] core/src/Foo.java:6:10",
           "        s.nonExistentMethod();",
           "         ^^^^^^^^^^^^^^^^^^",
@@ -93,7 +93,7 @@ object JavaCompileErrorFormattingTests extends TestSuite {
       assertGoldenLiteral(
         checkLines("java-type-variable"),
         List(
-          "compiling 1 Java source to out/core/compile.dest/classes ...",
+          "compiling 1 Java source to out/core/compile.dest/classes.jar ...",
           "[error] core/src/Foo.java:5:17",
           "        int x = undefinedVariable + 1;",
           "                ^^^^^^^^^^^^^^^^^",
@@ -110,7 +110,7 @@ object JavaCompileErrorFormattingTests extends TestSuite {
       assertGoldenLiteral(
         checkLines("java-parse-semicolon"),
         List(
-          "compiling 1 Java source to out/core/compile.dest/classes ...",
+          "compiling 1 Java source to out/core/compile.dest/classes.jar ...",
           "[error] core/src/Foo.java:5:18",
           "        int x = 1",
           "                 ^",
@@ -125,7 +125,7 @@ object JavaCompileErrorFormattingTests extends TestSuite {
       assertGoldenLiteral(
         checkLines("java-parse-string"),
         List(
-          "compiling 1 Java source to out/core/compile.dest/classes ...",
+          "compiling 1 Java source to out/core/compile.dest/classes.jar ...",
           "[error] core/src/Foo.java:5:20",
           "        String s = \"hello world",
           "                   ^",
@@ -140,7 +140,7 @@ object JavaCompileErrorFormattingTests extends TestSuite {
       assertGoldenLiteral(
         checkLines("java-parse-toplevel"),
         List(
-          "compiling 1 Java source to out/core/compile.dest/classes ...",
+          "compiling 1 Java source to out/core/compile.dest/classes.jar ...",
           "[error] core/src/Foo.java:3:1",
           "int x = 1;",
           "^",

--- a/libs/javalib/test/src/mill/javalib/JavaHomeTests.scala
+++ b/libs/javalib/test/src/mill/javalib/JavaHomeTests.scala
@@ -11,6 +11,23 @@ object JavaHome17Tests extends JavaHomeTests("temurin:17.0.9", "17.", Seq[Byte](
 trait JavaHomeTests(jvmVersion0: String, expectedPrefix: String, expectedBytes: Seq[Byte])
     extends TestSuite {
 
+  private def findClassBytes(classesPath: os.Path, className: String): Option[Array[Byte]] = {
+    if (os.isDir(classesPath)) {
+      os.walk(classesPath).find(_.last == className).map(os.read.bytes(_))
+    } else {
+      val zip = new java.util.zip.ZipFile(classesPath.toIO)
+      try {
+        val entries = zip.entries()
+        var result: Option[Array[Byte]] = None
+        while (entries.hasMoreElements && result.isEmpty) {
+          val e = entries.nextElement()
+          if (e.getName.endsWith(className)) result = Some(zip.getInputStream(e).readAllBytes())
+        }
+        result
+      } finally zip.close()
+    }
+  }
+
   object HelloJavaJavaHome11Override extends TestRootModule {
     object core extends JavaModule {
       def jvmVersion = jvmVersion0
@@ -29,14 +46,14 @@ trait JavaHomeTests(jvmVersion0: String, expectedPrefix: String, expectedBytes: 
 
         val Right(result) = eval.apply(HelloJavaJavaHome11Override.core.compile).runtimeChecked
 
-        val coreClassFile = os.walk(result.value.classes.path).find(_.last == "Core.class")
+        val coreClassBytes = findClassBytes(result.value.classes.path, "Core.class")
 
         assert(
-          coreClassFile.isDefined,
+          coreClassBytes.isDefined,
 
           // The first eight bytes are magic numbers followed by two bytes for major version and two bytes for minor version
           // We are overriding to java 11 which corresponds to class file version 55
-          os.read.bytes(coreClassFile.get, 4, 4).toSeq == expectedBytes
+          coreClassBytes.get.slice(4, 8).toSeq == expectedBytes
         )
 
         val path = eval.evaluator.workspace / "java.version"

--- a/libs/javalib/test/src/mill/javalib/JavaTabsErrorFormattingTests.scala
+++ b/libs/javalib/test/src/mill/javalib/JavaTabsErrorFormattingTests.scala
@@ -34,7 +34,7 @@ object JavaTabsErrorFormattingTests extends TestSuite {
         assertGoldenLiteral(
           errLines,
           List(
-            "compiling 1 Java source to out/core/compile.dest/classes ...",
+            "compiling 1 Java source to out/core/compile.dest/classes.jar ...",
             "[error] core/src/Core.java:5:11",
             "\t\tint i = 12345.6;",
             "\t\t        ^^^^^^^",

--- a/libs/javalib/worker/src/mill/javalib/zinc/ZincWorker.scala
+++ b/libs/javalib/worker/src/mill/javalib/zinc/ZincWorker.scala
@@ -190,6 +190,7 @@ class ZincWorker(jobs: Int, useFileLocks: Boolean = false) extends AutoCloseable
         reportCachedProblems = reportCachedProblems,
         incrementalCompilation = op.incrementalCompilation,
         auxiliaryClassFileExtensions = Seq.empty,
+        compileToJar = op.compileToJar,
         localConfig = localConfig,
         processConfig = processConfig,
         workDir = op.workDir
@@ -224,6 +225,7 @@ class ZincWorker(jobs: Int, useFileLocks: Boolean = false) extends AutoCloseable
         reportCachedProblems = reportCachedProblems,
         incrementalCompilation = op.incrementalCompilation,
         auxiliaryClassFileExtensions = op.auxiliaryClassFileExtensions,
+        compileToJar = op.compileToJar,
         localConfig = localConfig,
         processConfig = processConfig,
         workDir = op.workDir
@@ -329,6 +331,7 @@ class ZincWorker(jobs: Int, useFileLocks: Boolean = false) extends AutoCloseable
       reportCachedProblems: Boolean,
       incrementalCompilation: Boolean,
       auxiliaryClassFileExtensions: Seq[String],
+      compileToJar: Boolean,
       zincCache: os.SubPath = os.sub / "zinc",
       localConfig: ZincWorker.LocalConfig,
       processConfig: ZincWorker.ProcessConfig,
@@ -337,7 +340,9 @@ class ZincWorker(jobs: Int, useFileLocks: Boolean = false) extends AutoCloseable
 
     os.makeDir.all(workDir)
 
-    val classesDir = workDir / "classes"
+    val classesDir =
+      if (compileToJar) workDir / "classes.jar"
+      else workDir / "classes"
 
     if (localConfig.logDebugEnabled) {
       processConfig.log.debug(

--- a/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -467,6 +467,7 @@ trait KotlinModule extends JavaModule with KotlinModuleApi { outer =>
         compileClasspath = compileCp,
         javacOptions = jOpts.compiler,
         incrementalCompilation = true,
+        compileToJar = false,
         workDir = workDir
       ),
       javaHome = javaHome,

--- a/libs/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/libs/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -356,6 +356,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase
         compilerBridgeOpt = scalaCompilerBridge(),
         incrementalCompilation = zincIncrementalCompilation(),
         auxiliaryClassFileExtensions = zincAuxiliaryClassFileExtensions(),
+        compileToJar = compileToJar(),
         workDir = Task.dest
       ),
       javaHome = javaHome().map(_.path),
@@ -713,6 +714,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase
           compilerBridgeOpt = scalaCompilerBridge(),
           incrementalCompilation = zincIncrementalCompilation(),
           auxiliaryClassFileExtensions = zincAuxiliaryClassFileExtensions(),
+          compileToJar = false,
           workDir = Task.dest
         ),
         javaHome = javaHome().map(_.path),

--- a/libs/util/java11/src/mill/util/Jvm.scala
+++ b/libs/util/java11/src/mill/util/Jvm.scala
@@ -463,20 +463,52 @@ object Jvm {
       }
 
       // Note: we only sort each input path, but not the whole archive
-      for {
-        p <- inputPaths
-        (file, mapping) <-
-          if (os.isFile(p)) Seq((p, os.sub / p.last))
-          else os.walk(p).map(sub => (sub, sub.subRelativeTo(p))).sorted
-        if (includeDirs || os.isFile(file)) && !seen(mapping) && fileFilter(p, mapping)
-      } {
-        val _ = seen.add(mapping)
-        val name = mapping.toString() + (if (os.isDir(file)) "/" else "")
-        val entry = new JarEntry(name)
-        entry.setTime(mTime(file))
-        jarStream.putNextEntry(entry)
-        if (os.isFile(file)) jarStream.write(os.read.bytes(file))
-        jarStream.closeEntry()
+      for (p <- inputPaths) {
+        if (os.isFile(p) && p.ext == "jar") {
+          // Extract jar contents into the output jar rather than nesting it
+          val jis = new java.util.jar.JarInputStream(
+            new java.io.BufferedInputStream(Files.newInputStream(p.toNIO))
+          )
+          try {
+            var jarEntry = jis.getNextJarEntry
+            while (jarEntry != null) {
+              val name = jarEntry.getName.stripSuffix("/")
+              if (name.nonEmpty) {
+                val mapping = os.sub / os.SubPath(name)
+                if (!seen(mapping)) {
+                  val isDir = jarEntry.isDirectory
+                  if (includeDirs || !isDir) {
+                    val _ = seen.add(mapping)
+                    val entry = new JarEntry(jarEntry.getName)
+                    entry.setTime(if (jarEntry.getTime != -1) jarEntry.getTime else curTime)
+                    jarStream.putNextEntry(entry)
+                    if (!isDir) jarStream.write(jis.readAllBytes())
+                    jarStream.closeEntry()
+                  }
+                }
+              }
+              jarEntry = jis.getNextJarEntry
+            }
+          } finally {
+            jis.close()
+          }
+        } else {
+          val entries =
+            if (os.isFile(p)) Seq((p, os.sub / p.last))
+            else os.walk(p).map(sub => (sub, sub.subRelativeTo(p))).sorted
+          for {
+            (file, mapping) <- entries
+            if (includeDirs || os.isFile(file)) && !seen(mapping) && fileFilter(p, mapping)
+          } {
+            val _ = seen.add(mapping)
+            val name = mapping.toString() + (if (os.isDir(file)) "/" else "")
+            val entry = new JarEntry(name)
+            entry.setTime(mTime(file))
+            jarStream.putNextEntry(entry)
+            if (os.isFile(file)) jarStream.write(os.read.bytes(file))
+            jarStream.closeEntry()
+          }
+        }
       }
       jar
     } finally {

--- a/libs/util/java11/src/mill/util/Jvm.scala
+++ b/libs/util/java11/src/mill/util/Jvm.scala
@@ -405,7 +405,8 @@ object Jvm {
       manifest: JarManifest = JarManifest.Empty,
       fileFilter: (os.Path, os.RelPath) => Boolean = (_, _) => true,
       includeDirs: Boolean = true,
-      timestamp: Option[Long] = None
+      timestamp: Option[Long] = None,
+      base: Option[os.Path] = None
   ): os.Path = {
 
     val curTime = timestamp.getOrElse(System.currentTimeMillis())
@@ -432,6 +433,33 @@ object Jvm {
         entry.setTime(curTime)
         jarStream.putNextEntry(entry)
         jarStream.closeEntry()
+      }
+
+      // If a base jar is provided, copy its entries into the output jar
+      base.foreach { baseJar =>
+        val jis = new java.util.jar.JarInputStream(
+          new java.io.BufferedInputStream(Files.newInputStream(baseJar.toNIO))
+        )
+        try {
+          var jarEntry = jis.getNextJarEntry
+          while (jarEntry != null) {
+            val name = jarEntry.getName.stripSuffix("/")
+            if (name.nonEmpty) {
+              val mapping = os.sub / os.SubPath(name)
+              if (!seen(mapping)) {
+                val _ = seen.add(mapping)
+                val entry = new JarEntry(jarEntry.getName)
+                entry.setTime(if (jarEntry.getTime != -1) jarEntry.getTime else curTime)
+                jarStream.putNextEntry(entry)
+                if (!jarEntry.isDirectory) jarStream.write(jis.readAllBytes())
+                jarStream.closeEntry()
+              }
+            }
+            jarEntry = jis.getNextJarEntry
+          }
+        } finally {
+          jis.close()
+        }
       }
 
       // Note: we only sort each input path, but not the whole archive

--- a/runner/meta/src/mill/meta/MillBuildRootModule.scala
+++ b/runner/meta/src/mill/meta/MillBuildRootModule.scala
@@ -310,7 +310,8 @@ trait MillBuildRootModule()(using rootModuleInfo: RootModule.Info) extends Boots
           compilerBridgeOpt = scalaCompilerBridge(),
           incrementalCompilation = zincIncrementalCompilation(),
           auxiliaryClassFileExtensions = zincAuxiliaryClassFileExtensions(),
-          compileToJar = compileToJar(),
+          // hardcode false for now since we need to mangle the class files after
+          compileToJar = false,
           workDir = Task.dest
         ),
         javaHome = javaHome().map(_.path),

--- a/runner/meta/src/mill/meta/MillBuildRootModule.scala
+++ b/runner/meta/src/mill/meta/MillBuildRootModule.scala
@@ -310,7 +310,7 @@ trait MillBuildRootModule()(using rootModuleInfo: RootModule.Info) extends Boots
           compilerBridgeOpt = scalaCompilerBridge(),
           incrementalCompilation = zincIncrementalCompilation(),
           auxiliaryClassFileExtensions = zincAuxiliaryClassFileExtensions(),
-          compileToJar = false,
+          compileToJar = compileToJar(),
           workDir = Task.dest
         ),
         javaHome = javaHome().map(_.path),

--- a/runner/meta/src/mill/meta/MillBuildRootModule.scala
+++ b/runner/meta/src/mill/meta/MillBuildRootModule.scala
@@ -310,6 +310,7 @@ trait MillBuildRootModule()(using rootModuleInfo: RootModule.Info) extends Boots
           compilerBridgeOpt = scalaCompilerBridge(),
           incrementalCompilation = zincIncrementalCompilation(),
           auxiliaryClassFileExtensions = zincAuxiliaryClassFileExtensions(),
+          compileToJar = false,
           workDir = Task.dest
         ),
         javaHome = javaHome().map(_.path),


### PR DESCRIPTION
This can improve filesystem performance in scenarios where reading and writing hundreds or thousands of smal lfiles can be expensive