### PR TITLE
Fix `ClassCastException with testLocal when using BouncyCastle`

### DIFF
--- a/libs/javalib/test/resources/test-local-security-provider/test/src/secprov/SecurityProviderTest.java
+++ b/libs/javalib/test/resources/test-local-security-provider/test/src/secprov/SecurityProviderTest.java
@@ -1,0 +1,33 @@
+package secprov;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+import java.security.Provider;
+import java.security.Security;
+
+public class SecurityProviderTest {
+
+  /**
+   * A minimal security provider for testing classloader isolation.
+   */
+  public static class TestProvider extends Provider {
+    public TestProvider() {
+      super("MillTestProvider", "1.0", "Test security provider for classloader isolation testing");
+    }
+  }
+
+  @Test
+  public void testSecurityProviderIsolation() {
+    // If withClassLoader properly cleans up security providers, there should be
+    // no stale provider from a previous classloader when this test runs again.
+    Provider existing = Security.getProvider("MillTestProvider");
+    assertNull(
+        "Stale security provider found from a previous classloader; "
+            + "withClassLoader should clean up providers registered in isolated classloaders",
+        existing
+    );
+    // Register our provider (will be cleaned up by withClassLoader after the test)
+    Security.addProvider(new TestProvider());
+    assertNotNull(Security.getProvider("MillTestProvider"));
+  }
+}

--- a/libs/javalib/test/src/mill/javalib/TestLocalSecurityProviderTests.scala
+++ b/libs/javalib/test/src/mill/javalib/TestLocalSecurityProviderTests.scala
@@ -1,0 +1,33 @@
+package mill.javalib
+
+import mill.api.Discover
+import mill.testkit.{TestRootModule, UnitTester}
+import utest.*
+import mill.util.TokenReaders.*
+
+object TestLocalSecurityProviderTests extends TestSuite {
+
+  object module extends TestRootModule with JavaModule {
+    object test extends JavaTests with TestModule.Junit4
+    lazy val millDiscover = Discover[this.type]
+  }
+
+  val testModuleSourcesPath =
+    os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "test-local-security-provider"
+
+  def tests = Tests {
+    test("securityProviderCleanup") {
+      // Run testLocal twice to verify that security providers registered during
+      // the first run are cleaned up and don't leak into the second run.
+      // Without the fix, the second run would find a stale provider from the
+      // first run's (now-closed) classloader, causing ClassCastExceptions
+      // for libraries like BouncyCastle (see https://github.com/com-lihaoyi/mill/issues/6995)
+      UnitTester(module, testModuleSourcesPath).scoped { eval =>
+        val res1 = eval(module.test.testLocal())
+        assert(res1.isRight)
+        val res2 = eval(module.test.testLocal())
+        assert(res2.isRight)
+      }
+    }
+  }
+}

--- a/libs/util/java11/src/mill/util/Jvm.scala
+++ b/libs/util/java11/src/mill/util/Jvm.scala
@@ -365,6 +365,10 @@ object Jvm {
       sharedLoader = sharedLoader,
       sharedPrefixes = sharedPrefixes
     )
+    // Snapshot security providers before running, so we can clean up any
+    // providers registered by code in the isolated classloader. Providers
+    // from a closed classloader would cause ClassCastExceptions on reuse.
+    val providersBefore = java.security.Security.getProviders.map(_.getName).toSet
     Thread.currentThread().setContextClassLoader(newClassloader)
     try {
       f(newClassloader)
@@ -374,6 +378,14 @@ object Jvm {
     } finally {
       Thread.currentThread().setContextClassLoader(oldClassloader)
       newClassloader.close()
+      // Remove any security providers that were added by code in the
+      // now-closed classloader, to prevent ClassCastExceptions when a
+      // subsequent classloader loads the same provider classes
+      for (p <- java.security.Security.getProviders) {
+        if (!providersBefore.contains(p.getName)) {
+          java.security.Security.removeProvider(p.getName)
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/6995, Vibe Coded

> Root Cause                                                                                                              
>  
> When testLocal runs tests in-process, Jvm.withClassLoader creates an isolated MillURLClassLoader for the test classpath.
>  If test code (e.g. BouncyCastle) registers a JCE security provider via java.security.Security.addProvider(), that
> provider persists globally in the JVM even after the classloader is closed. On a subsequent testLocal run, a new        
> classloader is created, but the old provider (loaded by the now-closed classloader) still exists. When code in the new
> classloader tries to use the provider, it gets objects whose classes were loaded by the old classloader, causing
> ClassCastException because the same class loaded by two different classloaders are incompatible types.
> 
> Fix
> 
> libs/util/java11/src/mill/util/Jvm.scala: In withClassLoader, snapshot the registered security providers before         
> executing the function, and after closing the classloader, remove any providers that were added during execution. This
> prevents stale providers from leaking across classloader boundaries.                                                    
>                                                                 
> Test
> 
> libs/javalib/test/src/mill/javalib/TestLocalSecurityProviderTests.scala +                                               
> libs/javalib/test/resources/test-local-security-provider/test/src/secprov/SecurityProviderTest.java: A JUnit4 test that
> registers a custom security provider, paired with a Mill test that runs testLocal twice. The Java test asserts that no  
> stale provider from a previous classloader exists when the test starts. Without the fix, the second testLocal invocation
>  finds the stale provider and fails.
> 
> 
