### PR TITLE
Escape colon when naming BSP modules

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1,4 +1,4 @@
-//| mill-version: 1.1.5-20-b7b75c
+//| mill-version: 1.1.5-14-3574a3
 //| mill-jvm-opts: ["-XX:NonProfiledCodeHeapSize=250m", "-XX:ReservedCodeCacheSize=500m"]
 //| mill-opts: ["--jobs=0.5C", "-DMILL_ENABLE_STATIC_CHECKS=true"]
 

--- a/build.mill
+++ b/build.mill
@@ -1,4 +1,4 @@
-//| mill-version: 1.1.5-14-3574a3
+//| mill-version: 1.1.5-20-b7b75c
 //| mill-jvm-opts: ["-XX:NonProfiledCodeHeapSize=250m", "-XX:ReservedCodeCacheSize=500m"]
 //| mill-opts: ["--jobs=0.5C", "-DMILL_ENABLE_STATIC_CHECKS=true"]
 

--- a/integration/dedicated/bsp-server/resources/snapshots/workspace-build-targets.json
+++ b/integration/dedicated/bsp-server/resources/snapshots/workspace-build-targets.json
@@ -587,7 +587,7 @@
       "id": {
         "uri": "file:///workspace/scripts/folder1/script.scala"
       },
-      "displayName": "scripts/folder1/script.scala:",
+      "displayName": "scripts/folder1/script.scala-",
       "baseDirectory": "file:///workspace/scripts/folder1/script.scala",
       "tags": [
         "library",
@@ -630,7 +630,7 @@
       "id": {
         "uri": "file:///workspace/scripts/folder2/Foo.java"
       },
-      "displayName": "scripts/folder2/Foo.java:",
+      "displayName": "scripts/folder2/Foo.java-",
       "baseDirectory": "file:///workspace/scripts/folder2/Foo.java",
       "tags": [
         "library",
@@ -656,7 +656,7 @@
       "id": {
         "uri": "file:///workspace/scripts/folder2/FooTest.java"
       },
-      "displayName": "scripts/folder2/FooTest.java:",
+      "displayName": "scripts/folder2/FooTest.java-",
       "baseDirectory": "file:///workspace/scripts/folder2/FooTest.java",
       "tags": [
         "test"
@@ -685,7 +685,7 @@
       "id": {
         "uri": "file:///workspace/scripts/foldershared/Foo.java"
       },
-      "displayName": "scripts/foldershared/Foo.java:",
+      "displayName": "scripts/foldershared/Foo.java-",
       "baseDirectory": "file:///workspace/scripts/foldershared/Foo.java",
       "tags": [
         "library",
@@ -711,7 +711,7 @@
       "id": {
         "uri": "file:///workspace/scripts/foldershared/script.scala"
       },
-      "displayName": "scripts/foldershared/script.scala:",
+      "displayName": "scripts/foldershared/script.scala-",
       "baseDirectory": "file:///workspace/scripts/foldershared/script.scala",
       "tags": [
         "library",
@@ -754,7 +754,7 @@
       "id": {
         "uri": "file:///workspace/scripts/ignored-folder-2/negated-not-ignored.java"
       },
-      "displayName": "scripts/ignored-folder-2/negated-not-ignored.java:",
+      "displayName": "scripts/ignored-folder-2/negated-not-ignored.java-",
       "baseDirectory": "file:///workspace/scripts/ignored-folder-2/negated-not-ignored.java",
       "tags": [
         "library",

--- a/libs/javalib/src/mill/javalib/bsp/BspModule.scala
+++ b/libs/javalib/src/mill/javalib/bsp/BspModule.scala
@@ -8,7 +8,9 @@ import mill.api.daemon.internal.internal
 
 trait BspModule extends mill.api.Module with BspModuleApi {
 
-  private[mill] def bspDisplayName0: String = this.moduleSegments.render
+  // Sanitize `:` because although it is fine for Mill, IntelliJ writes this string as the
+  // name of the `.iml` file on disk that ends up exploding on windows since `:` is reserved
+  private[mill] def bspDisplayName0: String = this.moduleSegments.render.replace(':', '-')
 
   private[mill] def bspDisplayName: String = bspDisplayName0 match {
     case "" => "root-module"


### PR DESCRIPTION
Fixes the issue reported in https://github.com/com-lihaoyi/mill/discussions/7000#discussioncomment-16538693, where IntelliJ writes the BSP name as the name of the `.iml` file, causing failures on windows where `:` is dis-allowed. To mitigate this, we just replace `:` with `-` when naming BSP modules

