### PR TITLE
Fix lombok failure with incremental annotation processing.

### DIFF
--- a/libs/javalib/test/resources/incremental-annotation-processing/lombok/lombok.config
+++ b/libs/javalib/test/resources/incremental-annotation-processing/lombok/lombok.config
@@ -1,0 +1,1 @@
+lombok.log.fieldName = LOGGER

--- a/libs/javalib/test/resources/incremental-annotation-processing/lombok/src/example/App.java
+++ b/libs/javalib/test/resources/incremental-annotation-processing/lombok/src/example/App.java
@@ -1,0 +1,10 @@
+package example;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class App {
+    public static void main(String[] args) {
+        LOGGER.info("hello");
+    }
+}

--- a/libs/javalib/test/src/mill/javalib/IncrementalAnnotationProcessingTests.scala
+++ b/libs/javalib/test/src/mill/javalib/IncrementalAnnotationProcessingTests.scala
@@ -42,6 +42,17 @@ object IncrementalAnnotationProcessingTests extends TestSuite {
       }
     }
 
+    object lombok extends JavaModule {
+      def mvnDeps = Seq(
+        mvn"org.projectlombok:lombok:1.18.38",
+        mvn"org.slf4j:slf4j-api:2.0.17"
+      )
+
+      override def annotationProcessorsMvnDeps: T[Seq[Dep]] = Task {
+        Seq(mvn"org.projectlombok:lombok:1.18.38")
+      }
+    }
+
     object localMetadataConfigProcessor extends JavaModule
 
     object localMetadataConfig extends JavaModule {
@@ -286,6 +297,33 @@ object IncrementalAnnotationProcessingTests extends TestSuite {
       val Right(second) = eval(Modules.autoservice.compile).runtimeChecked
       assert(second.evalCount > 0)
       assert(!os.exists(serviceFile))
+    }
+
+    test("lombok") - testEval().scoped { eval =>
+      val appClass = eval.outPath / "lombok/compile.dest/classes/example/App.class"
+
+      val Right(first) = eval(Modules.lombok.compile).runtimeChecked
+      assert(first.evalCount > 0, os.exists(appClass))
+
+      val before = mtimeMillis(appClass)
+      os.write.over(
+        Modules.lombok.moduleDir / "src/example/App.java",
+        """package example;
+          |
+          |import lombok.extern.slf4j.Slf4j;
+          |
+          |@Slf4j
+          |public class App {
+          |    public static void main(String[] args) {
+          |        LOGGER.info("hello again");
+          |    }
+          |}
+          |""".stripMargin
+      )
+
+      val Right(second) = eval(Modules.lombok.compile).runtimeChecked
+      assert(second.evalCount > 0)
+      assertUpdated(appClass, before)
     }
 
     test("localMetadataConfig") - testEval().scoped { eval =>

--- a/libs/javalib/worker/src/mill/javalib/zinc/IncrementalAnnotationProcessing.scala
+++ b/libs/javalib/worker/src/mill/javalib/zinc/IncrementalAnnotationProcessing.scala
@@ -358,9 +358,12 @@ private[mill] object IncrementalAnnotationProcessing {
     fileObject match {
       case tracked: TrackingOutputObject => tracked.path
       case _ =>
-        reflectedUnderlyingVirtualFile(fileObject)
+        explicitUnderlyingVirtualFile(fileObject)
+          .orElse(reflectedUnderlyingVirtualFile(fileObject))
           .collect { case pathBased: PathBasedFile => pathBased.toPath.toAbsolutePath.normalize() }
+          .orElse(explicitPath(fileObject))
           .orElse(reflectedPath(fileObject))
+          .orElse(explicitNestedFileObject(fileObject).flatMap(fileObjectPath))
           .orElse(reflectedNestedFileObject(fileObject).flatMap(fileObjectPath))
           .orElse {
             Option(fileObject.toUri)
@@ -449,10 +452,18 @@ private[mill] object IncrementalAnnotationProcessing {
   private def reflectedUnderlyingVirtualFile(fileObject: FileObject): Option[VirtualFile] =
     reflectedValues(fileObject).collectFirst { case virtual: VirtualFile => virtual }
 
+  private def explicitUnderlyingVirtualFile(fileObject: FileObject): Option[VirtualFile] =
+    namedFieldValues(fileObject, "underlying", "delegate", "clientFileObject")
+      .collectFirst { case virtual: VirtualFile => virtual }
+
   private def reflectedNestedFileObject(fileObject: FileObject): Option[FileObject] =
     reflectedValues(fileObject).collectFirst {
       case nested: FileObject if nested ne fileObject => nested
     }
+
+  private def explicitNestedFileObject(fileObject: FileObject): Option[FileObject] =
+    namedFieldValues(fileObject, "underlying", "delegate", "fileObject", "clientFileObject")
+      .collectFirst { case nested: FileObject if nested ne fileObject => nested }
 
   private def reflectedPath(fileObject: FileObject): Option[Path] =
     Option.when(fileObject.getClass.getName.startsWith("com.sun.tools.javac.file.")) {
@@ -460,6 +471,10 @@ private[mill] object IncrementalAnnotationProcessing {
         path.toAbsolutePath.normalize()
       }
     }.flatten
+
+  private def explicitPath(fileObject: FileObject): Option[Path] =
+    namedFieldValues(fileObject, "path", "file", "entry")
+      .collectFirst { case path: Path => path.toAbsolutePath.normalize() }
 
   private def reflectedValues(value: AnyRef): Iterator[AnyRef] =
     reflectedFieldCache
@@ -470,6 +485,19 @@ private[mill] object IncrementalAnnotationProcessing {
           field.get(value)
         }.toOption.collect { case ref: AnyRef => ref }
       }
+
+  private def namedFieldValues(value: AnyRef, names: String*): Iterator[AnyRef] = {
+    val nameSet = names.toSet
+    reflectedFieldCache
+      .get(value.getClass)
+      .iterator
+      .filter(field => nameSet(field.getName))
+      .flatMap { field =>
+        scala.util.Try {
+          field.get(value)
+        }.toOption.collect { case ref: AnyRef => ref }
+      }
+  }
 
   private def changedSourcesSince(
       previousStamps: Map[os.Path, SourceStamp],

--- a/libs/javalib/worker/src/mill/javalib/zinc/IncrementalTrackingJavaCompiler.scala
+++ b/libs/javalib/worker/src/mill/javalib/zinc/IncrementalTrackingJavaCompiler.scala
@@ -7,7 +7,7 @@ import xsbti.compile.{IncToolOptions, JavaCompiler as XJavaCompiler, Output}
 import java.io.{OutputStream, PrintWriter, Writer}
 import java.net.URI
 import java.nio.charset.Charset
-import java.nio.file.{Files, InvalidPathException, Path, Paths}
+import java.nio.file.{Files, Path, Paths}
 import javax.annotation.processing.{Completion, Filer, Messager, Processor, ProcessingEnvironment}
 import javax.lang.model.SourceVersion
 import javax.lang.model.element.{AnnotationMirror, Element, ExecutableElement, TypeElement}
@@ -24,6 +24,7 @@ import javax.tools.{
   StandardJavaFileManager
 }
 import scala.jdk.CollectionConverters.*
+import xsbti.PathBasedFile
 
 private[mill] object IncrementalTrackingJavaCompiler {
   private[mill] final case class LoadedProcessors(
@@ -219,10 +220,9 @@ private final case class TrackingVirtualJavaFileObject(underlying: VirtualFile)
 
 private object TrackingVirtualJavaFileObject {
   def uriFor(underlying: VirtualFile): URI =
-    try Paths.get(underlying.id).toUri
-    catch {
-      case _: InvalidPathException =>
-        new URI("vf", "tmp", s"/${underlying.id}", null)
+    underlying match {
+      case pathBased: PathBasedFile => pathBased.toPath.toUri
+      case _ => new URI("vf", "tmp", s"/${underlying.id}", null)
     }
 }
 

--- a/libs/javalib/worker/src/mill/javalib/zinc/IncrementalTrackingJavaCompiler.scala
+++ b/libs/javalib/worker/src/mill/javalib/zinc/IncrementalTrackingJavaCompiler.scala
@@ -269,13 +269,14 @@ private final class TrackingJavaFileObject(
   }
 
   private def onOpen[T](result: => T): T = {
+    val opened = result
     classFileManager.foreach(
       _.generated(
         Array[VirtualFile](sbt.internal.inc.PlainVirtualFile(path.getOrElse(Paths.get(toUri))))
       )
     )
     tracker.foreach(_.recordSiblingGenerated(path, siblingPath))
-    result
+    opened
   }
 }
 
@@ -296,8 +297,9 @@ private final class TrackingFilerJavaFileObject(
   }
 
   private def onOpen[T](result: => T): T = {
+    val opened = result
     tracker.foreach(_.recordOwnedGenerated(path, owners))
-    result
+    opened
   }
 }
 
@@ -318,8 +320,9 @@ private final class TrackingFilerFileObject(
   }
 
   private def onOpen[T](result: => T): T = {
+    val opened = result
     tracker.foreach(_.recordOwnedGenerated(path, owners))
-    result
+    opened
   }
 }
 

--- a/libs/javalib/worker/src/mill/javalib/zinc/IncrementalTrackingJavaCompiler.scala
+++ b/libs/javalib/worker/src/mill/javalib/zinc/IncrementalTrackingJavaCompiler.scala
@@ -59,20 +59,12 @@ private[mill] object IncrementalTrackingJavaCompiler {
         val processors = names.map { name =>
           val delegate =
             loader.loadClass(name).getDeclaredConstructor().newInstance().asInstanceOf[Processor]
-          if (needsRawProcessingEnvironment(delegate)) delegate
-          else new TrackingProcessor(delegate)
+          new TrackingProcessor(delegate)
         }
         Some(LoadedProcessors(loader, processors))
       }
     }
   }
-
-  // Lombok's processor stack expects the original javac ProcessingEnvironment rather than our
-  // TrackingProcessingEnvironment wrapper. See:
-  // - https://github.com/projectlombok/lombok/blob/v1.18.38/src/core/lombok/launch/AnnotationProcessor.java
-  // - https://github.com/projectlombok/lombok/blob/v1.18.38/src/core/lombok/javac/apt/Processor.java
-  private def needsRawProcessingEnvironment(processor: Processor): Boolean =
-    processor.getClass.getName.startsWith("lombok.")
 }
 
 private[mill] final class IncrementalTrackingJavaCompiler(compiler: javax.tools.JavaCompiler)

--- a/libs/javalib/worker/src/mill/javalib/zinc/IncrementalTrackingJavaCompiler.scala
+++ b/libs/javalib/worker/src/mill/javalib/zinc/IncrementalTrackingJavaCompiler.scala
@@ -1,5 +1,4 @@
 package mill.javalib.zinc
-
 import sbt.internal.inc.javac.{DirectToJarFileManager, SameFileFixFileManager}
 import sbt.util.{Level, Logger}
 import xsbti.{Reporter, VirtualFile}
@@ -8,7 +7,7 @@ import xsbti.compile.{IncToolOptions, JavaCompiler as XJavaCompiler, Output}
 import java.io.{OutputStream, PrintWriter, Writer}
 import java.net.URI
 import java.nio.charset.Charset
-import java.nio.file.{Files, Path, Paths}
+import java.nio.file.{Files, InvalidPathException, Path, Paths}
 import javax.annotation.processing.{Completion, Filer, Messager, Processor, ProcessingEnvironment}
 import javax.lang.model.SourceVersion
 import javax.lang.model.element.{AnnotationMirror, Element, ExecutableElement, TypeElement}
@@ -59,12 +58,16 @@ private[mill] object IncrementalTrackingJavaCompiler {
         val processors = names.map { name =>
           val delegate =
             loader.loadClass(name).getDeclaredConstructor().newInstance().asInstanceOf[Processor]
-          new TrackingProcessor(delegate)
+          if (needsRawProcessingEnvironment(delegate)) delegate
+          else new TrackingProcessor(delegate)
         }
         Some(LoadedProcessors(loader, processors))
       }
     }
   }
+
+  private def needsRawProcessingEnvironment(processor: Processor): Boolean =
+    processor.getClass.getName.startsWith("lombok.")
 }
 
 private[mill] final class IncrementalTrackingJavaCompiler(compiler: javax.tools.JavaCompiler)
@@ -201,7 +204,7 @@ private sealed trait TrackingOutputObject {
 
 private final case class TrackingVirtualJavaFileObject(underlying: VirtualFile)
     extends javax.tools.SimpleJavaFileObject(
-      new URI("vf", "tmp", s"/${underlying.id}", null),
+      TrackingVirtualJavaFileObject.uriFor(underlying),
       Kind.SOURCE
     ) {
   override def openInputStream = underlying.input
@@ -212,6 +215,15 @@ private final case class TrackingVirtualJavaFileObject(underlying: VirtualFile)
     try sbt.io.IO.readStream(in)
     finally in.close()
   }
+}
+
+private object TrackingVirtualJavaFileObject {
+  def uriFor(underlying: VirtualFile): URI =
+    try Paths.get(underlying.id).toUri
+    catch {
+      case _: InvalidPathException =>
+        new URI("vf", "tmp", s"/${underlying.id}", null)
+    }
 }
 
 private final class TrackingFileManager(

--- a/libs/javalib/worker/src/mill/javalib/zinc/IncrementalTrackingJavaCompiler.scala
+++ b/libs/javalib/worker/src/mill/javalib/zinc/IncrementalTrackingJavaCompiler.scala
@@ -67,6 +67,10 @@ private[mill] object IncrementalTrackingJavaCompiler {
     }
   }
 
+  // Lombok's processor stack expects the original javac ProcessingEnvironment rather than our
+  // TrackingProcessingEnvironment wrapper. See:
+  // - https://github.com/projectlombok/lombok/blob/v1.18.38/src/core/lombok/launch/AnnotationProcessor.java
+  // - https://github.com/projectlombok/lombok/blob/v1.18.38/src/core/lombok/javac/apt/Processor.java
   private def needsRawProcessingEnvironment(processor: Processor): Boolean =
     processor.getClass.getName.startsWith("lombok.")
 }

--- a/libs/javalib/worker/test/src/mill/javalib/zinc/IncrementalAnnotationProcessingTrackerTests.scala
+++ b/libs/javalib/worker/test/src/mill/javalib/zinc/IncrementalAnnotationProcessingTrackerTests.scala
@@ -6,7 +6,10 @@ import javax.tools.{FileObject, JavaFileObject, SimpleJavaFileObject}
 
 object IncrementalAnnotationProcessingTrackerTests extends TestSuite {
 
-  private def fileObject(path: os.Path, kind: JavaFileObject.Kind): FileObject =
+  private final class DelegateFileObject(val delegate: JavaFileObject)
+      extends SimpleJavaFileObject(delegate.toUri, delegate.getKind) {}
+
+  private def fileObject(path: os.Path, kind: JavaFileObject.Kind): JavaFileObject =
     new SimpleJavaFileObject(path.toNIO.toUri, kind) {}
 
   val tests: Tests = Tests {
@@ -79,6 +82,21 @@ object IncrementalAnnotationProcessingTrackerTests extends TestSuite {
         assert(
           tracker.snapshot.products == Map(
             generatedClass -> IncrementalAnnotationProcessing.ProductOwnership.Isolating(source)
+          )
+        )
+      } finally os.remove.all(workDir)
+    }
+
+    test("fileObjectPathPrefersKnownDelegateFields") {
+      val workDir = os.temp.dir()
+      try {
+        val source = workDir / "generated/example/MapperImpl.java"
+        val delegate = fileObject(source, JavaFileObject.Kind.SOURCE)
+        val wrapped = new DelegateFileObject(delegate)
+
+        assert(
+          IncrementalAnnotationProcessing.fileObjectPath(wrapped).contains(
+            source.toNIO.toAbsolutePath.normalize()
           )
         )
       } finally os.remove.all(workDir)


### PR DESCRIPTION
Fixes a bug caused by https://github.com/com-lihaoyi/mill/pull/6999 that caused some of the init/migration tests using lombok to fail. Apparently Lombok doesn't like `vf://` file URIs, so this PR uses raw file URIs where possible