### PR TITLE
Fix Proguard sandbox checker failures for Coursier-managed JDKs

### DIFF
--- a/contrib/proguard/src/mill/contrib/proguard/Proguard.scala
+++ b/contrib/proguard/src/mill/contrib/proguard/Proguard.scala
@@ -47,8 +47,15 @@ trait Proguard extends JavaModule {
    * Defaults to the `java.home` system property.
    * Keep in sync with [[java9RtJar]]-
    */
-  def finalJavaHome: T[PathRef] =
-    javaHome().getOrElse(PathRef(Path(sys.props("java.home")), quick = true))
+  def finalJavaHome: T[PathRef] = Task {
+    javaHome().getOrElse {
+      // java.home may point to a Coursier-managed JDK inside the workspace (common on CI).
+      // That path isn't in the sandbox allow-list, so disable the checker for this PathRef.
+      mill.api.BuildCtx.withFilesystemCheckerDisabled {
+        PathRef(Path(sys.props("java.home")), quick = true)
+      }
+    }
+  }
 
   /** Specifies the input jar to proguard. Defaults to the output of the `assembly` task. */
   def inJar: T[PathRef] = Task { assembly() }
@@ -67,12 +74,14 @@ trait Proguard extends JavaModule {
    * Defaults the jars under `javaHome`.
    */
   def libraryJars: T[Seq[PathRef]] = Task {
-    val javaJars =
+    // finalJavaHome may point to a Coursier-managed JDK inside the workspace,
+    // so listing and wrapping its jars also needs the checker disabled.
+    mill.api.BuildCtx.withFilesystemCheckerDisabled {
       os.list(
         finalJavaHome().path / "lib",
         sort = false
       ).filter(_.ext == "jar").toSeq.map(PathRef(_))
-    javaJars
+    }
   }
 
   /**

--- a/contrib/proguard/test/src/mill/contrib/proguard/ProguardTests.scala
+++ b/contrib/proguard/test/src/mill/contrib/proguard/ProguardTests.scala
@@ -26,6 +26,17 @@ object ProguardTests extends TestSuite {
 
   def tests: Tests = Tests {
     test("Proguard module") {
+      test("finalJavaHome should resolve inside task context") - UnitTester(
+        proguard,
+        testModuleSourcesPath
+      ).scoped { eval =>
+        val Right(result) = eval.apply(proguard.finalJavaHome).runtimeChecked
+        assert(
+          os.exists(result.value.path),
+          result.value.path.toString().nonEmpty
+        )
+      }
+
       test("should download proguard jars") - UnitTester(proguard, testModuleSourcesPath).scoped {
         eval =>
           val Right(result) = eval.apply(proguard.proguardClasspath).runtimeChecked


### PR DESCRIPTION
## Summary

- Wraps `finalJavaHome` in `Task { }` and uses `BuildCtx.withFilesystemCheckerDisabled` for the `PathRef` construction
- Applies the same fix to `libraryJars`, which reads from the same JDK path

## Problem

When using Mill with a Coursier-managed JDK (`.mill-jvm-version` set to e.g. `17`), `sys.props("java.home")` points into the Coursier cache. If that cache is inside the workspace (common on CI), the sandbox `ExecutionChecker` rejects the read.

Fixes #7007

## Test plan

- Added test that evaluates `finalJavaHome` through `UnitTester` in sandboxed context
- `./mill contrib.proguard.test`