### PR TITLE
Add flywayExtraConfig hook to FlywayModule for custom Flyway properties

### DIFF
--- a/contrib/flyway/src/mill/contrib/flyway/FlywayModule.scala
+++ b/contrib/flyway/src/mill/contrib/flyway/FlywayModule.scala
@@ -36,11 +36,12 @@ trait FlywayModule extends JavaModule {
     Map.empty[String, String]
   }
 
-  /** Extra Flyway configuration properties beyond URL/user/password.
-    * Override this to add properties like SCHEMAS, OUT_OF_ORDER, CLEAN_DISABLED, etc.
-    * Keys should be Flyway configuration property names (e.g. "flyway.schemas").
-    * These are merged into the config map passed to Flyway.configure().
-    */
+  /**
+   * Extra Flyway configuration properties beyond URL/user/password.
+   * Override this to add properties like SCHEMAS, OUT_OF_ORDER, CLEAN_DISABLED, etc.
+   * Keys should be Flyway configuration property names (e.g. "flyway.schemas").
+   * These are merged into the config map passed to Flyway.configure().
+   */
   def flywayExtraConfig: T[Map[String, String]] = Task { Map.empty[String, String] }
 
   def flywayDriverDeps: T[Seq[Dep]]

--- a/contrib/flyway/src/mill/contrib/flyway/FlywayModule.scala
+++ b/contrib/flyway/src/mill/contrib/flyway/FlywayModule.scala
@@ -236,7 +236,7 @@ trait FlywayModule extends JavaModule {
       password: String,
       fileLocations: Seq[PathRef],
       placeholders: Map[String, String],
-      extraConfig: Map[String, String] = Map.empty
+      extraConfig: Map[String, String]
   )(
       f: (AnyRef, MillURLClassLoader, String) => T
   ): T = {

--- a/contrib/flyway/src/mill/contrib/flyway/FlywayModule.scala
+++ b/contrib/flyway/src/mill/contrib/flyway/FlywayModule.scala
@@ -36,6 +36,13 @@ trait FlywayModule extends JavaModule {
     Map.empty[String, String]
   }
 
+  /** Extra Flyway configuration properties beyond URL/user/password.
+    * Override this to add properties like SCHEMAS, OUT_OF_ORDER, CLEAN_DISABLED, etc.
+    * Keys should be Flyway configuration property names (e.g. "flyway.schemas").
+    * These are merged into the config map passed to Flyway.configure().
+    */
+  def flywayExtraConfig: T[Map[String, String]] = Task { Map.empty[String, String] }
+
   def flywayDriverDeps: T[Seq[Dep]]
   def flywayPluginDeps: T[Seq[Dep]] = Task {
     Seq.empty
@@ -92,7 +99,8 @@ trait FlywayModule extends JavaModule {
 
     val configProps = Map(flyway.URL -> flywayUrl()) ++
       strToOptPair(flyway.USER, flywayUser()) ++
-      strToOptPair(flyway.PASSWORD, flywayPassword())
+      strToOptPair(flyway.PASSWORD, flywayPassword()) ++
+      flywayExtraConfig()
 
     LogFactory.setLogCreator(new ConsoleLogCreator(Level.INFO))
 
@@ -114,7 +122,8 @@ trait FlywayModule extends JavaModule {
       flywayUser(),
       flywayPassword(),
       flywayFileLocations(),
-      flywayPlaceholders()
+      flywayPlaceholders(),
+      flywayExtraConfig()
     ) {
       (flyway, _, _) => toMigrateResult(callNoArg(flyway, "migrate"))
     }
@@ -129,7 +138,8 @@ trait FlywayModule extends JavaModule {
       flywayUser(),
       flywayPassword(),
       flywayFileLocations(),
-      flywayPlaceholders()
+      flywayPlaceholders(),
+      flywayExtraConfig()
     ) {
       (flyway, _, _) => toCleanResult(callNoArg(flyway, "clean"))
     }
@@ -144,7 +154,8 @@ trait FlywayModule extends JavaModule {
       flywayUser(),
       flywayPassword(),
       flywayFileLocations(),
-      flywayPlaceholders()
+      flywayPlaceholders(),
+      flywayExtraConfig()
     ) {
       (flyway, _, _) => toBaselineResult(callNoArg(flyway, "baseline"))
     }
@@ -159,7 +170,8 @@ trait FlywayModule extends JavaModule {
       flywayUser(),
       flywayPassword(),
       flywayFileLocations(),
-      flywayPlaceholders()
+      flywayPlaceholders(),
+      flywayExtraConfig()
     ) {
       (flyway, isolatedLoader, _) =>
         val info = callNoArg(flyway, "info")
@@ -191,7 +203,8 @@ trait FlywayModule extends JavaModule {
       flywayUser(),
       flywayPassword(),
       flywayFileLocations(),
-      flywayPlaceholders()
+      flywayPlaceholders(),
+      flywayExtraConfig()
     ) {
       (flyway, flywayLoader, currentUrl) =>
         val conf = callNoArg(flyway, "getConfiguration")
@@ -221,7 +234,8 @@ trait FlywayModule extends JavaModule {
       user: String,
       password: String,
       fileLocations: Seq[PathRef],
-      placeholders: Map[String, String]
+      placeholders: Map[String, String],
+      extraConfig: Map[String, String] = Map.empty
   )(
       f: (AnyRef, MillURLClassLoader, String) => T
   ): T = {
@@ -229,7 +243,7 @@ trait FlywayModule extends JavaModule {
       loader,
       fileLocations.map(pr => s"filesystem:${pr.path}"),
       placeholders,
-      configProps(url, user, password)
+      configProps(url, user, password) ++ extraConfig
     )
     f(flyway, loader, url)
   }

--- a/contrib/flyway/test/src/mill/contrib/flyway/BuildTest.scala
+++ b/contrib/flyway/test/src/mill/contrib/flyway/BuildTest.scala
@@ -40,6 +40,22 @@ object BuildTest extends TestSuite {
       def flywayDriverDeps = Seq(h2)
     }
 
+    object extraConfigBuild extends FlywayModule {
+      override def resources = Task.Sources(resourceFolder)
+
+      def h2 = mvn"com.h2database:h2:2.1.214"
+
+      def flywayUrl = "jdbc:h2:mem:extra_config_db;DB_CLOSE_DELAY=-1"
+      def flywayDriverDeps = Seq(h2)
+
+      override def flywayExtraConfig = Task {
+        Map(
+          "flyway.outOfOrder" -> "true",
+          "flyway.schemas" -> "PUBLIC"
+        )
+      }
+    }
+
     object pgBuild extends FlywayModule {
       override def resources = Task.Sources(resourceFolder)
       def flywayUrl = "jdbc:postgresql://127.0.0.1:1/flywaydb"
@@ -97,6 +113,24 @@ object BuildTest extends TestSuite {
 
     test("info") - UnitTester(Build, null).scoped { eval =>
       val Right(result) = eval(Build.build.flywayInfo()).runtimeChecked
+      assert(result.evalCount > 0)
+    }
+
+    test("extraConfig_migrate") - UnitTester(Build, null).scoped { eval =>
+      val Right(result) = eval(Build.extraConfigBuild.flywayMigrate()).runtimeChecked
+      assert(
+        result.evalCount > 0,
+        result.value.migrationsExecuted == 1
+      )
+    }
+
+    test("extraConfig_clean") - UnitTester(Build, null).scoped { eval =>
+      val Right(result) = eval(Build.extraConfigBuild.flywayClean()).runtimeChecked
+      assert(result.evalCount > 0)
+    }
+
+    test("extraConfig_info") - UnitTester(Build, null).scoped { eval =>
+      val Right(result) = eval(Build.extraConfigBuild.flywayInfo()).runtimeChecked
       assert(result.evalCount > 0)
     }
 


### PR DESCRIPTION
## Summary

- Adds public overridable `flywayExtraConfig: T[Map[String, String]]` task (defaults to empty map)
- Merges extra config into the legacy `flywayInstance` worker
- Threads extra config through `withIsolatedFlyway` to all command methods (`flywayMigrate`, `flywayClean`, `flywayBaseline`, `flywayInfo`, `flywayDetectedDatabaseType`)

## Problem

`FlywayModule` only passes URL/USER/PASSWORD to Flyway. The internal methods (`configProps`, `withIsolatedFlyway`, `createIsolatedFlyway`) are all private, so users who need extra config like SCHEMAS or OUT_OF_ORDER must copy-paste ~30 lines of reflection code.

Users can now simply write:

```scala
override def flywayExtraConfig = Task {
  Map(
    "flyway.schemas" -> "my_schema",
    "flyway.outOfOrder" -> "true"
  )
}
```

Fixes #7008

## Test plan

- Added `extraConfigBuild` test module with custom `flywayExtraConfig`
- Tests for `flywayMigrate`, `flywayClean`, and `flywayInfo` with extra config using H2
- `./mill contrib.flyway.test`