### PR TITLE
OWASP Dependency Check Improvements

### DIFF
--- a/contrib/owaspdependencycheck/src/mill/contrib/owaspdependencycheck/OwaspDependencyCheckModule.scala
+++ b/contrib/owaspdependencycheck/src/mill/contrib/owaspdependencycheck/OwaspDependencyCheckModule.scala
@@ -70,8 +70,7 @@ trait OwaspDependencyCheckJavaModule extends JavaModule with OwaspDependencyChec
   }
 }
 
-object OwaspDependencyCheckWorker extends ExternalModule with CoursierModule
-    with OfflineSupportModule {
+object OwaspDependencyCheckWorker extends ExternalModule with CoursierModule {
   lazy val millDiscover = Discover[this.type]
   def dependencyCheckClasspath: T[Seq[PathRef]] = Task {
     defaultResolver().classpath(

--- a/contrib/owaspdependencycheck/src/mill/contrib/owaspdependencycheck/OwaspDependencyCheckModule.scala
+++ b/contrib/owaspdependencycheck/src/mill/contrib/owaspdependencycheck/OwaspDependencyCheckModule.scala
@@ -62,11 +62,11 @@ trait OwaspDependencyCheckModule extends Module {
 }
 
 /**
- * Java Dependency Check, that adds the runtime class path to be scanned in the dependency check.
+ * Java Dependency Check, that adds the resolvedRunMvnDeps path to be scanned in the dependency check.
  */
 trait OwaspDependencyCheckJavaModule extends JavaModule with OwaspDependencyCheckModule {
   override def owaspDependencyCheckFiles: T[Seq[PathRef]] = Task {
-    super.runClasspath().filter(p => p.path.last.endsWith(".jar"))
+    super.resolvedRunMvnDeps()
   }
 }
 

--- a/contrib/owaspdependencycheck/test/src/mill/contrib/owaspdependencycheck/OwaspDependencyCheckModuleTests.scala
+++ b/contrib/owaspdependencycheck/test/src/mill/contrib/owaspdependencycheck/OwaspDependencyCheckModuleTests.scala
@@ -29,10 +29,29 @@ object TestModule extends TestRootModule {
     override def owaspDependencyCheckFiles: T[Seq[PathRef]] = Seq.empty
   }
   object javaExample extends OwaspDependencyCheckJavaModule {
-    override def mvnDeps: T[Seq[Dep]] = Seq(mvn"ch.qos.logback:logback-classic:1.5.12")
+    override def mvnDeps: T[Seq[Dep]] = Seq(mvn"ch.qos.logback:logback-classic:1.5.32")
   }
   object failingJavaExample extends OwaspDependencyCheckJavaModule {
     override def mvnDeps: T[Seq[Dep]] = Seq(mvn"org.json:json:20230618")
+
+    override def owaspDependencyCheckConfigArgs: T[Seq[String]] = Task {
+      super.owaspDependencyCheckConfigArgs() ++ ossScanCredentials() ++ Seq("--failOnCVSS", "4")
+    }
+  }
+  object failingTransitiveDeps extends OwaspDependencyCheckJavaModule {
+    override def moduleDeps = Seq(failingJavaExample)
+    override def mvnDeps: T[Seq[Dep]] = Seq(mvn"ch.qos.logback:logback-classic:1.5.32")
+
+    override def owaspDependencyCheckConfigArgs: T[Seq[String]] = Task {
+      super.owaspDependencyCheckConfigArgs() ++ ossScanCredentials() ++ Seq("--failOnCVSS", "4")
+    }
+  }
+  object avoidCompile extends OwaspDependencyCheckJavaModule {
+    override def mvnDeps: T[Seq[Dep]] = Seq(mvn"ch.qos.logback:logback-classic:1.5.32")
+    override def compile: T[mill.javalib.api.CompilationResult] = Task {
+      super.compile()
+      throw new AssertionError("should not be invoked")
+    }
 
     override def owaspDependencyCheckConfigArgs: T[Seq[String]] = Task {
       super.owaspDependencyCheckConfigArgs() ++ ossScanCredentials() ++ Seq("--failOnCVSS", "4")
@@ -95,6 +114,9 @@ class OwaspDependencyCheckModuleTests extends TestSuite {
         val Right(resultPackageJsonExample) =
           eval.apply(TestModule.examplePackageJson.owaspDependencyCheck()).runtimeChecked
         assert(resultPackageJsonExample.value.success)
+        val Right(resultNoCompile) =
+          eval.apply(TestModule.avoidCompile.owaspDependencyCheck()).runtimeChecked
+        assert(resultNoCompile.value.success)
       }
     }
     test("Run failing dependency scans") - UnitTester(
@@ -104,6 +126,8 @@ class OwaspDependencyCheckModuleTests extends TestSuite {
       runIfOssIsEnabled(eval) {
         val Left(error) =
           eval.apply(TestModule.failingJavaExample.owaspDependencyCheck()).runtimeChecked
+        val Left(errorTransitive) =
+          eval.apply(TestModule.failingTransitiveDeps.owaspDependencyCheck()).runtimeChecked
         val Right(suppressedFailure) =
           eval.apply(TestModule.failingJavaExampleNoTaskFail.owaspDependencyCheck()).runtimeChecked
         assert(!suppressedFailure.value.success)


### PR DESCRIPTION
Improvements for the OWASP Dependency check:

- Removing OfflineModule trait: Its untested and barely makes sense.
- Avoid triggering compling the JavaModule, by only scanning the mvnDeps true instead of the runClasspath