### PR TITLE
Fix link to coursier JVM Index in Doc

### DIFF
--- a/example/fundamentals/javahome/2-custom-jvm-yaml/build.mill
+++ b/example/fundamentals/javahome/2-custom-jvm-yaml/build.mill
@@ -1,3 +1,5 @@
+// :link-jvm-indices: https://github.com/coursier/jvm-index/blob/master/indices/linux-arm64.json
+//
 // Mill's JVM can be configured via the
 // xref:cli/build-header.adoc#_mill_jvm_version[mill-jvm-version] key in your
 // declarative `build.mill.yaml` file:

--- a/example/fundamentals/javahome/4-custom-module-jvm/build.mill
+++ b/example/fundamentals/javahome/4-custom-module-jvm/build.mill
@@ -1,5 +1,3 @@
-// :link-jvm-indices: https://github.com/coursier/jvm-index/blob/master/indices/linux-arm64.json
-//
 // Configuring custom JVMs is done by setting the `jvmVersion`
 // of any `JavaModule`, `ScalaModule`, or `KotlinModule`. This can be done
 // declaratively via `package.mill.yaml` files:


### PR DESCRIPTION
Fixes broken link in https://mill-build.org/mill/fundamentals/configuring-jvm-versions.html

Removed the `:link-jvm-indices` in the JavaModule JVM section, as it seems unused there.
Most likely it got moved.