### PR TITLE
scalajslib: fix LinkerInput equality so the linker cache hits

### DIFF
--- a/libs/scalajslib/worker/1/src/mill/scalajslib/worker/ScalaJSWorkerImpl.scala
+++ b/libs/scalajslib/worker/1/src/mill/scalajslib/worker/ScalaJSWorkerImpl.scala
@@ -38,8 +38,8 @@ class ScalaJSWorkerImpl(jobs: Int) extends ScalaJSWorkerApi with ScalaJSConfigWo
     override def equals(other: Any): Boolean = other match {
       case that: LinkerInput =>
         dest == that.dest &&
-          sjs.StandardConfig.fingerprint(config) ==
-            sjs.StandardConfig.fingerprint(that.config)
+        sjs.StandardConfig.fingerprint(config) ==
+          sjs.StandardConfig.fingerprint(that.config)
       case _ => false
     }
     override def hashCode(): Int =

--- a/libs/scalajslib/worker/1/src/mill/scalajslib/worker/ScalaJSWorkerImpl.scala
+++ b/libs/scalajslib/worker/1/src/mill/scalajslib/worker/ScalaJSWorkerImpl.scala
@@ -28,7 +28,23 @@ class ScalaJSWorkerImpl(jobs: Int) extends ScalaJSWorkerApi with ScalaJSConfigWo
   private case class LinkerInput(
       dest: Either[File, sjs.OutputDirectory],
       config: sjs.StandardConfig
-  )
+  ) {
+    // sjs.StandardConfig is a `final class` with reference equality, so the
+    // auto-generated case-class equals would never match across fastLinkJS
+    // invocations (each invocation builds a fresh StandardConfig via
+    // ScalaJSConfig.config(...)). That made the ScalaJSLinker CachedFactory
+    // miss every time, discarding the optimizer/emitter incremental state.
+    // Use StandardConfig.fingerprint for a structural comparison instead.
+    override def equals(other: Any): Boolean = other match {
+      case that: LinkerInput =>
+        dest == that.dest &&
+          sjs.StandardConfig.fingerprint(config) ==
+            sjs.StandardConfig.fingerprint(that.config)
+      case _ => false
+    }
+    override def hashCode(): Int =
+      (dest, sjs.StandardConfig.fingerprint(config)).hashCode
+  }
   private def minorIsGreaterThanOrEqual(number: Int) = ScalaJSVersions.current match {
     case s"1.$n.$_" if n.toIntOption.exists(_ < number) => false
     case _ => true

--- a/libs/scalajslib/worker/1/src/mill/scalajslib/worker/ScalaJSWorkerImpl.scala
+++ b/libs/scalajslib/worker/1/src/mill/scalajslib/worker/ScalaJSWorkerImpl.scala
@@ -35,15 +35,15 @@ class ScalaJSWorkerImpl(jobs: Int) extends ScalaJSWorkerApi with ScalaJSConfigWo
     // ScalaJSConfig.config(...)). That made the ScalaJSLinker CachedFactory
     // miss every time, discarding the optimizer/emitter incremental state.
     // Use StandardConfig.fingerprint for a structural comparison instead.
+    // The fingerprint is cached so CachedFactory lookups (hashCode + equals
+    // on each candidate) don't rebuild the string repeatedly.
+    private lazy val configFingerprint: String = sjs.StandardConfig.fingerprint(config)
     override def equals(other: Any): Boolean = other match {
       case that: LinkerInput =>
-        dest == that.dest &&
-        sjs.StandardConfig.fingerprint(config) ==
-          sjs.StandardConfig.fingerprint(that.config)
+        dest == that.dest && configFingerprint == that.configFingerprint
       case _ => false
     }
-    override def hashCode(): Int =
-      (dest, sjs.StandardConfig.fingerprint(config)).hashCode
+    override def hashCode(): Int = (dest, configFingerprint).hashCode
   }
   private def minorIsGreaterThanOrEqual(number: Int) = ScalaJSVersions.current match {
     case s"1.$n.$_" if n.toIntOption.exists(_ < number) => false


### PR DESCRIPTION
Fixed https://github.com/com-lihaoyi/mill/issues/7016

## How was this tested

I tested it manually with this minimal repro. `reused`, and `invalidated` show if the cache hit.

<details>
<summary><b>Minimal reproduction</b></summary>

`build.mill`:
```scala
package build
import mill.*, scalalib.*, scalajslib.*

object app extends ScalaJSModule {
  def scalaVersion = "3.3.4"
  def scalaJSVersion = "1.19.0"
}
```

`app/src/Main.scala`:
```scala
object Main {
  def main(args: Array[String]): Unit = {
    val xs = (1 to 100).toList
    val mapped = xs.map(_ * 2).filter(_ % 3 == 0)
    val grouped = mapped.groupBy(_ % 5).view.mapValues(_.sum).toMap
    println(s"sum = ${mapped.sum}, groups = $grouped")
  }
}
```

Run `fastLinkJS` three times, mutating the source between runs so the outer Mill task cache doesn't short-circuit and hide the inner-cache bug:

```bash
./mill clean app
./mill app.fastLinkJS 2>&1 | grep -E "Batch mode|cache stats|Optimizing"
printf '\n// bump 1\n' >> app/src/Main.scala
./mill app.fastLinkJS 2>&1 | grep -E "Batch mode|cache stats|Optimizing"
printf '\n// bump 2\n' >> app/src/Main.scala
./mill app.fastLinkJS 2>&1 | grep -E "Batch mode|cache stats|Optimizing"
```


**Actual** — three byte-identical runs:
```
Optimizer: Batch mode: true
Optimizer: Optimizing 2933 methods.
Emitter: Class tree cache stats: reused: 0 -- invalidated: 283
Emitter: Method tree cache stats: reused: 0 -- invalidated: 907
```

**Expected** — runs 2 and 3 should show `reused: 282 -- invalidated: 1` (only the one class whose source changed).

</details>

## ❌ Mill 1.1.5

<img width="1736" height="961" alt="Screenshot 2026-04-16 at 06 49 58" src="https://github.com/user-attachments/assets/0660e14f-fcfc-42a9-bcdd-bb2600cc94ec" />

## ✅ Mill 1.1.2

<img width="1743" height="841" alt="Screenshot 2026-04-16 at 06 51 53" src="https://github.com/user-attachments/assets/f34ff266-341f-430d-a412-188873510c93" />

## ✅ Mill 1.1.5 with the fix

<img width="1794" height="1123" alt="Screenshot 2026-04-16 at 07 12 44" src="https://github.com/user-attachments/assets/426a39ab-b237-4464-a20e-a8c2843393e8" />


