### PR TITLE
fix: guard empty directChildren in defaultTask resolution

### DIFF
--- a/core/resolve/src/mill/resolve/Resolve.scala
+++ b/core/resolve/src/mill/resolve/Resolve.scala
@@ -150,7 +150,13 @@ object Resolve {
             )
 
             directChildrenOrErr.flatMap(directChildren =>
-              directChildren.head match {
+              if (directChildren.isEmpty) {
+                Result.Failure(
+                  s"Cannot resolve default task '${value.defaultTask()}' " +
+                    s"in module '${value.moduleSegments.render}'. " +
+                    s"Check that the task name is spelled correctly."
+                )
+              } else directChildren.head match {
                 case r: Resolved.NamedTask => instantiateNamedTask(r, value, cache).map(Some(_))
                 case r: Resolved.Command =>
                   instantiateCommand(


### PR DESCRIPTION
Fixes #7013

When `defaultTask` contains a typo or invalid reference, Mill crashes with:
```
java.util.NoSuchElementException: head of empty ArraySeq
```

This adds an `isEmpty` check before the `.head` call and returns a clear error:
```
Cannot resolve default task 'myTaskTypo' in module 'app'. Check that the task name is spelled correctly.
```

Reproduced and verified the fix locally with the test case from the issue.