### PR TITLE
Refactor PythonModule's venv tasks to expose venv/bin

### DIFF
--- a/libs/pythonlib/src/mill/pythonlib/PythonModule.scala
+++ b/libs/pythonlib/src/mill/pythonlib/PythonModule.scala
@@ -45,7 +45,10 @@ trait PythonModule extends PipModule with DefaultTaskModule with JavaHomeModule 
   def venv: T[PathRef] = Task {
     val venv = Task.dest / "venv"
     os.call((hostPythonCommand(), "-m", "venv", venv))
-    os.call((venv / "bin/python3", "-m", "pip", "install", pipInstallArgs().args), stdout = os.Inherit)
+    os.call(
+      (venv / "bin/python3", "-m", "pip", "install", pipInstallArgs().args),
+      stdout = os.Inherit
+    )
     PathRef(venv)
   }
 

--- a/libs/pythonlib/src/mill/pythonlib/PythonModule.scala
+++ b/libs/pythonlib/src/mill/pythonlib/PythonModule.scala
@@ -43,9 +43,10 @@ trait PythonModule extends PipModule with DefaultTaskModule with JavaHomeModule 
    * needed by this module and its dependencies.
    */
   def venv: T[PathRef] = Task {
-    os.call((hostPythonCommand(), "-m", "venv", Task.dest / "venv"))
-    os.call((Task.dest / "bin/python", "-m", "pip", "install", pipInstallArgs().args), stdout = os.Inherit)
-    PathRef(Task.dest / "venv")
+    val venv = Task.dest / "venv"
+    os.call((hostPythonCommand(), "-m", "venv", venv))
+    os.call((venv / "bin/python3", "-m", "pip", "install", pipInstallArgs().args), stdout = os.Inherit)
+    PathRef(venv)
   }
 
   /*

--- a/libs/pythonlib/src/mill/pythonlib/PythonModule.scala
+++ b/libs/pythonlib/src/mill/pythonlib/PythonModule.scala
@@ -38,15 +38,32 @@ trait PythonModule extends PipModule with DefaultTaskModule with JavaHomeModule 
    */
   def hostPythonCommand: T[String] = Task { "python3" }
 
+  /*
+   * Initalize a virtual environment for this module, and install all libraries and tools
+   * needed by this module and its dependencies.
+   */
+  def venv: T[PathRef] = Task {
+    os.call((hostPythonCommand(), "-m", "venv", Task.dest / "venv"))
+    os.call((Task.dest / "bin/python", "-m", "pip", "install", pipInstallArgs().args), stdout = os.Inherit)
+    PathRef(Task.dest / "venv")
+  }
+
+  /*
+   * The path to the binary directory of the virtual environment which has been
+   * initialized to contain all libraries and tools needed by this module and its
+   * dependencies.
+   */
+  def venvBin: T[PathRef] = Task {
+    PathRef(venv().path / "bin")
+  }
+
   /**
    * An executable python interpreter. This interpreter is set up to run in a
    * virtual environment which has been initialized to contain all libraries and
    * tools needed by this module and its dependencies.
    */
   def pythonExe: T[PathRef] = Task {
-    os.call((hostPythonCommand(), "-m", "venv", Task.dest / "venv"))
-    val python = Task.dest / "venv/bin/python3"
-    os.call((python, "-m", "pip", "install", pipInstallArgs().args), stdout = os.Inherit)
+    val python = venvBin().path / "python3"
     PathRef(python)
   }
 


### PR DESCRIPTION
Hi,

We use a few Python tools in our Mill-based project. Right now, our build just assumes those tools are available, but we would love to have those managed by Mill instead, and `PythonModule` has most of what we need.
The only issue is, one of those tools (`lit`) is not properly exposed as a module, so is not usable as `python -m lit`, only as `lit` with the venv's binary directory on the PATH; and I am assuming being more compatible with this scenario is a net win for Mill?
This PR offers an easy compromise for now, to just expose the venv's binary directory as a task, so that we can easily refer to it in our `PythonModule`'s commands/tasks, and use said tool fully managed by Mill.

Ideally, we could just weave this directory in the PATH and have subprocesses honor it, but after an attempt, it sounds like this would require more changes in `os-lib` itself to get to work.

Hopefully this light change is not controversial?