### PR TITLE
Make `OwaspDependencyCheckModule` worker configurable

### DIFF
--- a/contrib/owaspdependencycheck/src/mill/contrib/owaspdependencycheck/OwaspDependencyCheckJavaModule.scala
+++ b/contrib/owaspdependencycheck/src/mill/contrib/owaspdependencycheck/OwaspDependencyCheckJavaModule.scala
@@ -1,0 +1,14 @@
+package mill.contrib.owaspdependencycheck
+
+import mill.api.Task.Simple as T
+import mill.api.{PathRef, Task}
+import mill.javalib.JavaModule
+
+/**
+ * Java Dependency Check, that adds the resolvedRunMvnDeps path to be scanned in the dependency check.
+ */
+trait OwaspDependencyCheckJavaModule extends JavaModule, OwaspDependencyCheckModule {
+  override def owaspDependencyCheckFiles: T[Seq[PathRef]] = Task {
+    super.resolvedRunMvnDeps()
+  }
+}

--- a/contrib/owaspdependencycheck/src/mill/contrib/owaspdependencycheck/OwaspDependencyCheckModule.scala
+++ b/contrib/owaspdependencycheck/src/mill/contrib/owaspdependencycheck/OwaspDependencyCheckModule.scala
@@ -26,7 +26,7 @@ trait OwaspDependencyCheckModule extends Module, OfflineSupportModule {
     Seq("--nvdDatafeed", "https://dependency-check.github.io/DependencyCheck_Builder/nvd_cache/")
 
   /**
-   * The worker is version specific, so is another version is required, it can be customized here.
+   * The worker is version specific. If another version is required it can be customized here.
    */
   val owaspDependencyCheckWorker: ModuleRef[OwaspDependencyCheckWorker] =
     ModuleRef(OwaspDependencyCheckWorker)
@@ -73,62 +73,4 @@ trait OwaspDependencyCheckModule extends Module, OfflineSupportModule {
         DependencyCheckResult(Seq.empty, 0)
       }
     }
-}
-
-/**
- * Java Dependency Check, that adds the resolvedRunMvnDeps path to be scanned in the dependency check.
- */
-trait OwaspDependencyCheckJavaModule extends JavaModule, OwaspDependencyCheckModule {
-  override def owaspDependencyCheckFiles: T[Seq[PathRef]] = Task {
-    super.resolvedRunMvnDeps()
-  }
-}
-
-trait OwaspDependencyCheckWorker extends CoursierModule, OfflineSupportModule {
-
-  def dependencyCheckVersion: T[String]
-
-  def dependencyCheckClasspath: T[Seq[PathRef]] = Task {
-    defaultResolver().classpath(
-      Seq(mvn"org.owasp:dependency-check-cli:${dependencyCheckVersion()}")
-    )
-  }
-
-  def worker: Worker[DependencyCheckInstance] = Task.Worker {
-    new DependencyCheckInstance(dependencyCheckClasspath().map(_.path))
-  }
-
-  private[owaspdependencycheck] class DependencyCheckInstance(
-      dependencyCheckClasspath: Seq[os.Path]
-  ) extends AutoCloseable {
-    val classLoader = mill.util.Jvm.createClassLoader(dependencyCheckClasspath)
-    val depencencyCheckCli = classLoader.loadClass("org.owasp.dependencycheck.App")
-    val appConstructor = depencencyCheckCli.getConstructor()
-    val mainMethod = depencencyCheckCli.getMethod("run", classOf[Array[String]])
-
-    def runScan(args: Seq[String]): Int = {
-      val ctxLoader = Thread.currentThread().getContextClassLoader
-      try {
-        Thread.currentThread().setContextClassLoader(classLoader)
-        val app = appConstructor.newInstance()
-        mainMethod.invoke(app, args.to(Array)).asInstanceOf[Int]
-      } finally {
-        Thread.currentThread().setContextClassLoader(ctxLoader)
-      }
-    }
-
-    def close() = {
-      classLoader.close()
-    }
-  }
-
-  override def prepareOffline(all: Flag): Command[Seq[PathRef]] = Task.Command {
-    (super.prepareOffline(all)() ++ dependencyCheckClasspath()).distinct
-  }
-}
-
-object OwaspDependencyCheckWorker extends ExternalModule, OwaspDependencyCheckWorker {
-  def dependencyCheckVersion: T[String] = "12.2.0" // FIXME: source from build
-
-  override lazy val millDiscover = Discover[this.type]
 }

--- a/contrib/owaspdependencycheck/src/mill/contrib/owaspdependencycheck/OwaspDependencyCheckModule.scala
+++ b/contrib/owaspdependencycheck/src/mill/contrib/owaspdependencycheck/OwaspDependencyCheckModule.scala
@@ -5,7 +5,7 @@ import mill.*
 import mill.api.*
 import mill.javalib.*
 
-trait OwaspDependencyCheckModule extends Module with OfflineSupportModule {
+trait OwaspDependencyCheckModule extends Module, OfflineSupportModule {
 
   /**
    * The files to be scanned by the Dependency Check.
@@ -19,28 +19,36 @@ trait OwaspDependencyCheckModule extends Module with OfflineSupportModule {
    * The --scan flags are appended based on the files in [[owaspDependencyCheckFiles]]
    *
    * The --out dir is set by the [[owaspDependencyCheck]].
+   *
    * @return
    */
   def owaspDependencyCheckConfigArgs: T[Seq[String]] =
     Seq("--nvdDatafeed", "https://dependency-check.github.io/DependencyCheck_Builder/nvd_cache/")
 
   /**
+   * The worker is version specific, so is another version is required, it can be customized here.
+   */
+  val owaspDependencyCheckWorker: ModuleRef[OwaspDependencyCheckWorker] = ModuleRef(OwaspDependencyCheckWorker)
+
+  /**
    * Be default true, then [[owaspDependencyCheck()]] will fail if the dependency scan fails (eg. --failOnCVSS).
+   *
    * @return
    */
   def owaspDependencyCheckFailTask: Boolean = true
 
   case class DependencyCheckResult(reportFiles: Seq[PathRef], exitCode: Int)
-      derives upickle.ReadWriter {
+    derives upickle.ReadWriter {
     def success: Boolean = exitCode == 0
   }
 
   override def prepareOffline(all: Flag): Command[Seq[PathRef]] = Task.Command {
-    super.prepareOffline(all)() ++ OwaspDependencyCheckWorker.dependencyCheckClasspath()
+    (super.prepareOffline(all)() ++ owaspDependencyCheckWorker().prepareOffline(all)()).distinct
   }
 
   /**
    * Run the dependency check
+   *
    * @return
    */
   final def owaspDependencyCheck(): Task.Command[DependencyCheckResult] =
@@ -53,7 +61,7 @@ trait OwaspDependencyCheckModule extends Module with OfflineSupportModule {
 
         val arguments = args ++ scanDirectives ++ Seq("--out", Task.dest.toString)
         println(s"Final scan arguments to Dependency Check CLI: ${arguments.mkString(" ")}")
-        val exitCode = OwaspDependencyCheckWorker.worker().runScan(arguments)
+        val exitCode = owaspDependencyCheckWorker().worker().runScan(arguments)
         val result = DependencyCheckResult(os.list(Task.dest).map(PathRef(_)), exitCode)
         if (owaspDependencyCheckFailTask && !result.success) {
           throw new Exception(s"Dependency Check failed with status code $exitCode")
@@ -69,37 +77,37 @@ trait OwaspDependencyCheckModule extends Module with OfflineSupportModule {
 /**
  * Java Dependency Check, that adds the resolvedRunMvnDeps path to be scanned in the dependency check.
  */
-trait OwaspDependencyCheckJavaModule extends JavaModule with OwaspDependencyCheckModule {
+trait OwaspDependencyCheckJavaModule extends JavaModule, OwaspDependencyCheckModule {
   override def owaspDependencyCheckFiles: T[Seq[PathRef]] = Task {
     super.resolvedRunMvnDeps()
   }
 }
 
-object OwaspDependencyCheckWorker extends ExternalModule with CoursierModule {
-  lazy val millDiscover = Discover[this.type]
+trait OwaspDependencyCheckWorker extends CoursierModule, OfflineSupportModule {
+
+  def dependencyCheckVersion: T[String]
+
   def dependencyCheckClasspath: T[Seq[PathRef]] = Task {
     defaultResolver().classpath(
-      Seq(mvn"org.owasp:dependency-check-cli:12.2.0")
+      Seq(mvn"org.owasp:dependency-check-cli:${dependencyCheckVersion()}")
     )
   }
 
-  def dependencyCheckClassLoader: Worker[java.net.URLClassLoader] = Task.Worker {
-    mill.util.Jvm.createClassLoader(dependencyCheckClasspath().map(_.path))
+  def worker: Worker[DependencyCheckInstance] = Task.Worker {
+    new DependencyCheckInstance(dependencyCheckClasspath().map(_.path))
   }
 
-  def worker: Worker[DependencyCheckInstance] =
-    Task.Worker { new DependencyCheckInstance(dependencyCheckClassLoader()) }
-
-  private[owaspdependencycheck] class DependencyCheckInstance(cl: ClassLoader)
-      extends AutoCloseable {
-    val depencencyCheckCli = cl.loadClass("org.owasp.dependencycheck.App")
+  private[owaspdependencycheck] class DependencyCheckInstance(dependencyCheckClasspath: Seq[os.Path])
+    extends AutoCloseable {
+    val classLoader = mill.util.Jvm.createClassLoader(dependencyCheckClasspath)
+    val depencencyCheckCli = classLoader.loadClass("org.owasp.dependencycheck.App")
     val appConstructor = depencencyCheckCli.getConstructor()
     val mainMethod = depencencyCheckCli.getMethod("run", classOf[Array[String]])
 
     def runScan(args: Seq[String]): Int = {
       val ctxLoader = Thread.currentThread().getContextClassLoader
       try {
-        Thread.currentThread().setContextClassLoader(cl)
+        Thread.currentThread().setContextClassLoader(classLoader)
         val app = appConstructor.newInstance()
         mainMethod.invoke(app, args.to(Array)).asInstanceOf[Int]
       } finally {
@@ -108,7 +116,17 @@ object OwaspDependencyCheckWorker extends ExternalModule with CoursierModule {
     }
 
     def close() = {
-      // No-op
+      classLoader.close()
     }
   }
+
+  override def prepareOffline(all: Flag): Command[Seq[PathRef]] = Task.Command {
+    (super.prepareOffline(all)() ++ dependencyCheckClasspath()).distinct
+  }
+}
+
+object OwaspDependencyCheckWorker extends ExternalModule, OwaspDependencyCheckWorker {
+  def dependencyCheckVersion: T[String] = "12.2.0" // FIXME: source from build
+
+  override lazy val millDiscover = Discover[this.type]
 }

--- a/contrib/owaspdependencycheck/src/mill/contrib/owaspdependencycheck/OwaspDependencyCheckModule.scala
+++ b/contrib/owaspdependencycheck/src/mill/contrib/owaspdependencycheck/OwaspDependencyCheckModule.scala
@@ -28,7 +28,8 @@ trait OwaspDependencyCheckModule extends Module, OfflineSupportModule {
   /**
    * The worker is version specific, so is another version is required, it can be customized here.
    */
-  val owaspDependencyCheckWorker: ModuleRef[OwaspDependencyCheckWorker] = ModuleRef(OwaspDependencyCheckWorker)
+  val owaspDependencyCheckWorker: ModuleRef[OwaspDependencyCheckWorker] =
+    ModuleRef(OwaspDependencyCheckWorker)
 
   /**
    * Be default true, then [[owaspDependencyCheck()]] will fail if the dependency scan fails (eg. --failOnCVSS).
@@ -38,7 +39,7 @@ trait OwaspDependencyCheckModule extends Module, OfflineSupportModule {
   def owaspDependencyCheckFailTask: Boolean = true
 
   case class DependencyCheckResult(reportFiles: Seq[PathRef], exitCode: Int)
-    derives upickle.ReadWriter {
+      derives upickle.ReadWriter {
     def success: Boolean = exitCode == 0
   }
 
@@ -97,8 +98,9 @@ trait OwaspDependencyCheckWorker extends CoursierModule, OfflineSupportModule {
     new DependencyCheckInstance(dependencyCheckClasspath().map(_.path))
   }
 
-  private[owaspdependencycheck] class DependencyCheckInstance(dependencyCheckClasspath: Seq[os.Path])
-    extends AutoCloseable {
+  private[owaspdependencycheck] class DependencyCheckInstance(
+      dependencyCheckClasspath: Seq[os.Path]
+  ) extends AutoCloseable {
     val classLoader = mill.util.Jvm.createClassLoader(dependencyCheckClasspath)
     val depencencyCheckCli = classLoader.loadClass("org.owasp.dependencycheck.App")
     val appConstructor = depencencyCheckCli.getConstructor()

--- a/contrib/owaspdependencycheck/src/mill/contrib/owaspdependencycheck/OwaspDependencyCheckWorker.scala
+++ b/contrib/owaspdependencycheck/src/mill/contrib/owaspdependencycheck/OwaspDependencyCheckWorker.scala
@@ -50,7 +50,7 @@ trait OwaspDependencyCheckWorker extends CoursierModule, OfflineSupportModule {
 }
 
 object OwaspDependencyCheckWorker extends ExternalModule, OwaspDependencyCheckWorker {
-  def dependencyCheckVersion: T[String] = "12.2.0" // FIXME: source from build
+  def dependencyCheckVersion: T[String] = BuildInfo.owaspDependencyCheckVersion
 
   override lazy val millDiscover = Discover[this.type]
 }

--- a/contrib/owaspdependencycheck/src/mill/contrib/owaspdependencycheck/OwaspDependencyCheckWorker.scala
+++ b/contrib/owaspdependencycheck/src/mill/contrib/owaspdependencycheck/OwaspDependencyCheckWorker.scala
@@ -1,0 +1,56 @@
+package mill.contrib.owaspdependencycheck
+
+import mainargs.Flag
+import mill.api.Task.{Command, Simple as T}
+import mill.api.Task.{Worker, Simple as T}
+import mill.api.{Discover, ExternalModule, PathRef, Task}
+import mill.javalib.{CoursierModule, DepSyntax, OfflineSupportModule}
+
+trait OwaspDependencyCheckWorker extends CoursierModule, OfflineSupportModule {
+
+  def dependencyCheckVersion: T[String]
+
+  def dependencyCheckClasspath: T[Seq[PathRef]] = Task {
+    defaultResolver().classpath(
+      Seq(mvn"org.owasp:dependency-check-cli:${dependencyCheckVersion()}")
+    )
+  }
+
+  def worker: Worker[DependencyCheckInstance] = Task.Worker {
+    new DependencyCheckInstance(dependencyCheckClasspath().map(_.path))
+  }
+
+  private[owaspdependencycheck] class DependencyCheckInstance(
+      dependencyCheckClasspath: Seq[os.Path]
+  ) extends AutoCloseable {
+    val classLoader = mill.util.Jvm.createClassLoader(dependencyCheckClasspath)
+    val depencencyCheckCli = classLoader.loadClass("org.owasp.dependencycheck.App")
+    val appConstructor = depencencyCheckCli.getConstructor()
+    val mainMethod = depencencyCheckCli.getMethod("run", classOf[Array[String]])
+
+    def runScan(args: Seq[String]): Int = {
+      val ctxLoader = Thread.currentThread().getContextClassLoader
+      try {
+        Thread.currentThread().setContextClassLoader(classLoader)
+        val app = appConstructor.newInstance()
+        mainMethod.invoke(app, args.to(Array)).asInstanceOf[Int]
+      } finally {
+        Thread.currentThread().setContextClassLoader(ctxLoader)
+      }
+    }
+
+    def close() = {
+      classLoader.close()
+    }
+  }
+
+  override def prepareOffline(all: Flag): Command[Seq[PathRef]] = Task.Command {
+    (super.prepareOffline(all)() ++ dependencyCheckClasspath()).distinct
+  }
+}
+
+object OwaspDependencyCheckWorker extends ExternalModule, OwaspDependencyCheckWorker {
+  def dependencyCheckVersion: T[String] = "12.2.0" // FIXME: source from build
+
+  override lazy val millDiscover = Discover[this.type]
+}

--- a/contrib/owaspdependencycheck/src/mill/contrib/owaspdependencycheck/OwaspDependencyCheckWorker.scala
+++ b/contrib/owaspdependencycheck/src/mill/contrib/owaspdependencycheck/OwaspDependencyCheckWorker.scala
@@ -1,7 +1,7 @@
 package mill.contrib.owaspdependencycheck
 
 import mainargs.Flag
-import mill.api.Task.{Command, Simple as T}
+import mill.api.Task.Command
 import mill.api.Task.{Worker, Simple as T}
 import mill.api.{Discover, ExternalModule, PathRef, Task}
 import mill.javalib.{CoursierModule, DepSyntax, OfflineSupportModule}

--- a/contrib/owaspdependencycheck/test/src/mill/contrib/owaspdependencycheck/OwaspDependencyCheckModuleTests.scala
+++ b/contrib/owaspdependencycheck/test/src/mill/contrib/owaspdependencycheck/OwaspDependencyCheckModuleTests.scala
@@ -1,9 +1,5 @@
 package mill.contrib.owaspdependencycheck
 
-import mill.contrib.owaspdependencycheck.{
-  OwaspDependencyCheckJavaModule,
-  OwaspDependencyCheckModule
-}
 import mill.testkit.{TestRootModule, UnitTester}
 import utest.{TestSuite, Tests, test}
 import mill.api.{Discover, PathRef, Task}

--- a/contrib/package.mill
+++ b/contrib/package.mill
@@ -247,7 +247,10 @@ object `package` extends mill.Module {
     def testModuleDeps = super.testModuleDeps ++ Seq(build.libs.scalalib)
     override def buildInfoPackageName: String = "mill.contrib.owaspdependencycheck"
     override def buildInfoMembers: T[Seq[BuildInfo.Value]] = Seq(
-      BuildInfo.Value("owaspDependencyCheckVersion", Deps.RuntimeDeps.owaspDependencyCheckCli_runtime.version)
+      BuildInfo.Value(
+        "owaspDependencyCheckVersion",
+        Deps.RuntimeDeps.owaspDependencyCheckCli_runtime.version
+      )
     )
   }
 }

--- a/contrib/package.mill
+++ b/contrib/package.mill
@@ -242,8 +242,12 @@ object `package` extends mill.Module {
     def testModuleDeps: Seq[JavaModule] = super.testModuleDeps ++ Seq(build.libs.scalalib)
   }
 
-  object owaspdependencycheck extends ContribModule {
+  object owaspdependencycheck extends ContribModule, BuildInfo {
     def compileModuleDeps = Seq(build.libs.javalib)
     def testModuleDeps = super.testModuleDeps ++ Seq(build.libs.scalalib)
+    override def buildInfoPackageName: String = "mill.contrib.owaspdependencycheck"
+    override def buildInfoMembers: T[Seq[BuildInfo.Value]] = Seq(
+      BuildInfo.Value("owaspDependencyCheckVersion", Deps.RuntimeDeps.owaspDependencyCheckCli_runtime.version)
+    )
   }
 }

--- a/mill-build/src/millbuild/Deps.scala
+++ b/mill-build/src/millbuild/Deps.scala
@@ -319,7 +319,7 @@ object Deps {
       pmdDist_runtime,
       proguard_runtime,
       revApi_runtime,
-      sbtTestInterface,
+      sbtTestInterface
     )
   }
 

--- a/mill-build/src/millbuild/Deps.scala
+++ b/mill-build/src/millbuild/Deps.scala
@@ -291,7 +291,7 @@ object Deps {
     val koverJvmAgent_runtime = mvn"org.jetbrains.kotlinx:kover-jvm-agent:$koverVersion_runtime"
     val ktfmt_runtime = mvn"com.facebook:ktfmt:0.58"
     val ktlint_runtime = mvn"com.pinterest.ktlint:ktlint-core:0.49.1"
-    val owaspDependencyCheckCli_runtime = mvn"org.owasp:dependency-check-cli:12.2.0"
+    val owaspDependencyCheckCli_runtime = mvn"org.owasp:dependency-check-cli:12.2.1"
     val palantirFormat_runtime = mvn"com.palantir.javaformat:palantir-java-format:2.74.0"
     val pmdDist_runtime = mvn"net.sourceforge.pmd:pmd-dist:7.15.0"
     val proguard_runtime = mvn"com.guardsquare:proguard-base:7.7.0"

--- a/mill-build/src/millbuild/Deps.scala
+++ b/mill-build/src/millbuild/Deps.scala
@@ -291,11 +291,12 @@ object Deps {
     val koverJvmAgent_runtime = mvn"org.jetbrains.kotlinx:kover-jvm-agent:$koverVersion_runtime"
     val ktfmt_runtime = mvn"com.facebook:ktfmt:0.58"
     val ktlint_runtime = mvn"com.pinterest.ktlint:ktlint-core:0.49.1"
+    val owaspDependencyCheckCli_runtime = mvn"org.owasp:dependency-check-cli:12.2.0"
     val palantirFormat_runtime = mvn"com.palantir.javaformat:palantir-java-format:2.74.0"
+    val pmdDist_runtime = mvn"net.sourceforge.pmd:pmd-dist:7.15.0"
     val proguard_runtime = mvn"com.guardsquare:proguard-base:7.7.0"
     val revApi_runtime = mvn"org.revapi:revapi-standalone:0.12.0"
     val sbtTestInterface = mvn"com.github.sbt:junit-interface:0.13.2"
-    val pmdDist_runtime = mvn"net.sourceforge.pmd:pmd-dist:7.15.0"
 
     def updateable = Seq(
       detektCli_runtime,
@@ -313,11 +314,12 @@ object Deps {
       koverJvmAgent_runtime,
       ktfmt_runtime,
       ktlint_runtime,
+      owaspDependencyCheckCli_runtime,
       palantirFormat_runtime,
+      pmdDist_runtime,
       proguard_runtime,
       revApi_runtime,
       sbtTestInterface,
-      pmdDist_runtime
     )
   }
 


### PR DESCRIPTION
Since the worker is bound to a specific version, it should not be hardcoded but user configurable.

The default version of the `org.owasp.dependency-check-cli` artifact is now sourced from the main build and can be scanned for updates (like all other tool versions used by Mill).
