### PR TITLE
Fix #7015: 2nd attempt — ignore -color:* in Zinc MiniSetup equivalence

### DIFF
--- a/integration/feature/zinc-incremental-scala3-color/resources/app/src/App.scala
+++ b/integration/feature/zinc-incremental-scala3-color/resources/app/src/App.scala
@@ -1,0 +1,7 @@
+package app
+
+object App {
+  def main(args: Array[String]): Unit = {
+    println(models.Foo("hello").greet)
+  }
+}

--- a/integration/feature/zinc-incremental-scala3-color/resources/app/src/models/Foo.scala
+++ b/integration/feature/zinc-incremental-scala3-color/resources/app/src/models/Foo.scala
@@ -1,0 +1,5 @@
+package models
+
+case class Foo(name: String) {
+  def greet: String = s"hello, $name"
+}

--- a/integration/feature/zinc-incremental-scala3-color/resources/build.mill
+++ b/integration/feature/zinc-incremental-scala3-color/resources/build.mill
@@ -1,0 +1,9 @@
+package build
+// Issue https://github.com/com-lihaoyi/mill/issues/7015
+import mill.*
+import mill.scalalib.*
+
+object app extends ScalaModule {
+  def scalaVersion = "3.8.3"
+  def zincIncrementalCompilation = true
+}

--- a/integration/feature/zinc-incremental-scala3-color/src/ZincIncrementalScala3ColorTests.scala
+++ b/integration/feature/zinc-incremental-scala3-color/src/ZincIncrementalScala3ColorTests.scala
@@ -1,0 +1,64 @@
+package mill.integration
+
+import mill.testkit.UtestIntegrationTestSuite
+
+import utest.*
+
+// Regression test for issue https://github.com/com-lihaoyi/mill/issues/7015
+//
+// On Scala 3, ZincWorker conditionally prepends `-color:never` to scalacOptions
+// based on the current client's `colored` flag. That option is baked into
+// Zinc's MiniSetup, so alternating clients with different TTY state (e.g. a
+// non-TTY CI run followed by an interactive shell) makes the MiniSetup
+// comparison fail on the next edit and cold-rebuilds every source in the
+// module. Here we simulate the two clients with `--color=false` / `--color=true`
+// and assert that sources which were NOT edited are not recompiled.
+object ZincIncrementalScala3ColorTests extends UtestIntegrationTestSuite {
+  val tests: Tests = Tests {
+    test("colorFlagPreservesIncremental") - integrationTest { tester =>
+      import tester.*
+
+      val appSrc = workspacePath / "app/src/App.scala"
+      val classes = workspacePath / "out/app/compile.dest/classes"
+      val appClass = classes / "app/App.class"
+      val fooClass = classes / "models/Foo.class"
+
+      // Client B (non-TTY): cold compile with colored=false.
+      // MiniSetup gets baked with `-color:never` in scalacOptions.
+      val firstRun = tester.eval(("--color=false", "app.compile"))
+      assert(firstRun.isSuccess)
+      assert(Seq(classes, appClass, fooClass, appSrc).forall(os.exists))
+
+      val appClassInfo1 = os.stat(appClass)
+      val fooClassInfo1 = os.stat(fooClass)
+
+      // Edit only App.scala. Foo.scala is untouched.
+      os.write.append(appSrc, "\n ")
+
+      // Client T (TTY): compile with colored=true.
+      // Worker builds scalacOptions WITHOUT `-color:never`, hands them to
+      // Zinc. Zinc compares against stored MiniSetup (with `-color:never`),
+      // declares a mismatch, and cold-recompiles every source — including
+      // Foo.scala, which was not edited.
+      val secondRun = tester.eval(("--color=true", "app.compile"))
+      assert(secondRun.isSuccess)
+
+      val appClassInfo2 = os.stat(appClass)
+      val fooClassInfo2 = os.stat(fooClass)
+
+      // App.scala was edited, so its .class is expected to be rewritten.
+      // We use mtime instead of ctime because Scala 3 compile is fast enough
+      // that both runs can land inside the same wall-clock second, and
+      // os-lib's ctime formatter is second-granularity; mtime has nanosecond
+      // precision.
+      assert(appClassInfo1.mtime != appClassInfo2.mtime)
+
+      // Foo.scala was NOT edited. With a correct incremental compile this
+      // .class should be untouched. This assertion reproduces issue #7015 —
+      // pre-fix, Zinc cold-rebuilds Foo.class because of the MiniSetup
+      // mismatch caused by the `-color:never` injection being tied to
+      // per-client TTY state.
+      assert(fooClassInfo1.mtime == fooClassInfo2.mtime)
+    }
+  }
+}

--- a/libs/javalib/worker/src/mill/javalib/zinc/ZincWorker.scala
+++ b/libs/javalib/worker/src/mill/javalib/zinc/ZincWorker.scala
@@ -452,7 +452,12 @@ class ZincWorker(jobs: Int, useFileLocks: Boolean = false) extends AutoCloseable
     val incOptions0 = IncOptions.of().withAuxiliaryClassFiles(
       auxiliaryClassFileExtensions.map(new AuxiliaryClassFileExtension(_)).toArray
     ).withExternalHooks(externalHooks)
-    val incOptions = incOptions0
+    // Exclude `-color:*` from Zinc's MiniSetup equivalence check. The option
+    // is injected per-client below based on TTY state, so without this,
+    // alternating TTY and non-TTY clients against the same daemon would
+    // invalidate the stored analysis and cold-rebuild the whole module on
+    // every edit. See https://github.com/com-lihaoyi/mill/issues/7015
+    val incOptions = incOptions0.withIgnoredScalacOptions(Array("-color:.*"))
     val compileProgress = reporter.map { reporter =>
       new CompileProgress {
         override def advance(


### PR DESCRIPTION
Fixes #7015. **2nd attempt** — previous PR #7022 was closed because unconditionally injecting `-color:never` regressed `integration.dedicated.full-run-logs` (stripped ANSI from Scala 3 diagnostics even when `--color=true`).

## Approach

Use Zinc's built-in `IncOptions.withIgnoredScalacOptions(Array("-color:.*"))` to exclude `-color:*` from the `MiniSetup` equivalence check. This is the exact hook Zinc provides for options that should not trigger invalidation (see `IncrementalCompilerImpl.prevAnalysis` → `equivScalacOptions(incOptions.ignoredScalacOptions)`).

Per-client `-color:never` injection in `ZincWorker.compileInternal` is left **unchanged** — color rendering stays correct for both TTY and non-TTY callers; only the stored analysis comparison ignores the difference.

## Commits

1. Regression test `integration.feature.zinc-incremental-scala3-color` — compile `--color=false`, edit one file, recompile `--color=true`, assert unedited `Foo.class` is not rewritten. Fails on `main`.
2. Fix: add `.withIgnoredScalacOptions(Array("-color:.*"))` on `IncOptions` in `libs/javalib/worker/src/mill/javalib/zinc/ZincWorker.scala`.

Test was verified locally: ❌ red on commit 1, ✅ green on commit 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)