### PR TITLE
Fix some `Task`s not returning `Task.Simple`

### DIFF
--- a/example/thirdparty/android-compose-samples/build.mill
+++ b/example/thirdparty/android-compose-samples/build.mill
@@ -83,7 +83,7 @@ object JetLagged extends mill.api.Module {
     )
 
     def androidEnableCompose = true
-    override def kotlinUseEmbeddableCompiler: Task[Boolean] = Task { true }
+    override def kotlinUseEmbeddableCompiler: T[Boolean] = Task { true }
 
     def androidSdkModule = mill.api.ModuleRef(androidSdkModule0)
 
@@ -101,7 +101,7 @@ object JetLagged extends mill.api.Module {
       override def androidEnableCompose = true
 
       // TODO consider defaulting this to the parent app value
-      override def kotlinUseEmbeddableCompiler: Task[Boolean] = Task {
+      override def kotlinUseEmbeddableCompiler: T[Boolean] = Task {
         true
       }
 
@@ -193,7 +193,7 @@ object JetNews extends mill.api.Module {
     )
 
     def androidEnableCompose = true
-    override def kotlinUseEmbeddableCompiler: Task[Boolean] = Task { true }
+    override def kotlinUseEmbeddableCompiler: T[Boolean] = Task { true }
 
     def androidSdkModule = mill.api.ModuleRef(androidSdkModule0)
 
@@ -212,7 +212,7 @@ object JetNews extends mill.api.Module {
       override def androidEnableCompose = true
 
       // TODO consider defaulting this to the parent app value
-      override def kotlinUseEmbeddableCompiler: Task[Boolean] = Task {
+      override def kotlinUseEmbeddableCompiler: T[Boolean] = Task {
         true
       }
 
@@ -263,7 +263,7 @@ object Jetchat extends mill.api.Module {
 
     override def androidDataBindingCompilerVersion = "8.13.0"
 
-    override def kotlinUseEmbeddableCompiler: Task[Boolean] = Task {
+    override def kotlinUseEmbeddableCompiler: T[Boolean] = Task {
       true
     }
 
@@ -307,7 +307,7 @@ object Jetchat extends mill.api.Module {
       override def androidEnableCompose = true
 
       // TODO consider defaulting this to the parent app value
-      override def kotlinUseEmbeddableCompiler: Task[Boolean] = Task {
+      override def kotlinUseEmbeddableCompiler: T[Boolean] = Task {
         true
       }
 

--- a/example/thirdparty/android-compose-samples/build.mill
+++ b/example/thirdparty/android-compose-samples/build.mill
@@ -83,7 +83,7 @@ object JetLagged extends mill.api.Module {
     )
 
     def androidEnableCompose = true
-    override def kotlinUseEmbeddableCompiler: T[Boolean] = Task { true }
+    override def kotlinUseEmbeddableCompiler: Task[Boolean] = Task.Anon { true }
 
     def androidSdkModule = mill.api.ModuleRef(androidSdkModule0)
 
@@ -101,7 +101,7 @@ object JetLagged extends mill.api.Module {
       override def androidEnableCompose = true
 
       // TODO consider defaulting this to the parent app value
-      override def kotlinUseEmbeddableCompiler: T[Boolean] = Task {
+      override def kotlinUseEmbeddableCompiler: Task[Boolean] = Task.Anon {
         true
       }
 
@@ -193,7 +193,7 @@ object JetNews extends mill.api.Module {
     )
 
     def androidEnableCompose = true
-    override def kotlinUseEmbeddableCompiler: T[Boolean] = Task { true }
+    override def kotlinUseEmbeddableCompiler: Task[Boolean] = Task.Anon { true }
 
     def androidSdkModule = mill.api.ModuleRef(androidSdkModule0)
 
@@ -212,7 +212,7 @@ object JetNews extends mill.api.Module {
       override def androidEnableCompose = true
 
       // TODO consider defaulting this to the parent app value
-      override def kotlinUseEmbeddableCompiler: T[Boolean] = Task {
+      override def kotlinUseEmbeddableCompiler: Task[Boolean] = Task.Anon {
         true
       }
 
@@ -263,7 +263,7 @@ object Jetchat extends mill.api.Module {
 
     override def androidDataBindingCompilerVersion = "8.13.0"
 
-    override def kotlinUseEmbeddableCompiler: T[Boolean] = Task {
+    override def kotlinUseEmbeddableCompiler: Task[Boolean] = Task.Anon {
       true
     }
 
@@ -307,7 +307,7 @@ object Jetchat extends mill.api.Module {
       override def androidEnableCompose = true
 
       // TODO consider defaulting this to the parent app value
-      override def kotlinUseEmbeddableCompiler: T[Boolean] = Task {
+      override def kotlinUseEmbeddableCompiler: Task[Boolean] = Task.Anon {
         true
       }
 

--- a/libs/androidlib/src/mill/androidlib/AndroidAppKotlinModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppKotlinModule.scala
@@ -163,7 +163,7 @@ trait AndroidAppKotlinModule extends AndroidKotlinModule, AndroidAppModule { out
       PathRef(Task.dest / "results.json")
     }
 
-    private def screenshotResults: Task[PathRef] = Task {
+    private def screenshotResults: T[PathRef] = Task {
       val dir = Task.dest / "generated-screenshots"
       os.makeDir(dir)
       PathRef(dir)
@@ -205,7 +205,7 @@ trait AndroidAppKotlinModule extends AndroidKotlinModule, AndroidAppModule { out
 
     }
 
-    private def resourceApkPath: Task[PathRef] = Task {
+    private def resourceApkPath: T[PathRef] = Task {
       PathRef(outer.androidLinkedResources().path / "apk/res.apk")
     }
 
@@ -284,7 +284,7 @@ trait AndroidAppKotlinModule extends AndroidKotlinModule, AndroidAppModule { out
       )
     }
 
-    private def diffImageDirPath: Task[PathRef] = Task {
+    private def diffImageDirPath: T[PathRef] = Task {
       val diffImageDir = Task.dest / "diff-images"
       PathRef(diffImageDir)
     }

--- a/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidAppModule.scala
@@ -302,7 +302,7 @@ trait AndroidAppModule extends AndroidModule { outer =>
   override def androidPackagedDeps: T[Seq[PathRef]] =
     super.androidPackagedDeps() ++ Seq(androidProcessedResources())
 
-  override def androidMergeableManifests: Task[Seq[PathRef]] = Task {
+  override def androidMergeableManifests: T[Seq[PathRef]] = Task {
     val debugManifest = Seq(androidDebugManifestLocation()).filter(pr => os.exists(pr.path))
     super.androidMergeableManifests() ++ debugManifest
   }
@@ -976,47 +976,48 @@ trait AndroidAppModule extends AndroidModule { outer =>
 
   // uses the d8 tool to generate the dex file, when minification is disabled
   private def androidD8Dex
-      : Task[(outPath: PathRef, dexCliArgs: Seq[String], appCompiledFiles: Seq[PathRef])] = Task {
+      : Task[(outPath: PathRef, dexCliArgs: Seq[String], appCompiledFiles: Seq[PathRef])] =
+    Task.Anon {
 
-    val outPath = Task.dest / "dex-output"
-    os.makeDir.all(outPath)
+      val outPath = Task.dest / "dex-output"
+      os.makeDir.all(outPath)
 
-    val appCompiledPathRefs = androidPackagedCompiledClasses() ++ androidPackagedClassfiles()
+      val appCompiledPathRefs = androidPackagedCompiledClasses() ++ androidPackagedClassfiles()
 
-    val appCompiledFiles = appCompiledPathRefs.map(_.path.toString())
+      val appCompiledFiles = appCompiledPathRefs.map(_.path.toString())
 
-    val libsJarPathRefs = androidPackagedDeps()
-      .filter(_ != androidSdkModule().androidJarPath())
+      val libsJarPathRefs = androidPackagedDeps()
+        .filter(_ != androidSdkModule().androidJarPath())
 
-    val libsJarFiles = libsJarPathRefs.map(_.path.toString())
+      val libsJarFiles = libsJarPathRefs.map(_.path.toString())
 
-    val filenamesFile = Task.dest / "all-files.txt"
-    os.write.over(filenamesFile, (appCompiledFiles ++ libsJarFiles).mkString("\n"))
+      val filenamesFile = Task.dest / "all-files.txt"
+      os.write.over(filenamesFile, (appCompiledFiles ++ libsJarFiles).mkString("\n"))
 
-    val proguardFile = androidProguard().path
+      val proguardFile = androidProguard().path
 
-    val d8Args = Seq(
-      androidSdkModule().d8Exe().path.toString,
-      if (androidIsDebug()) "--debug" else "--release",
-      // TODO explore --incremental flag for incremental builds
-      "--output",
-      outPath.toString(),
-      "--lib",
-      androidSdkModule().androidJarPath().path.toString(),
-      "--min-api",
-      androidMinSdk().toString,
-      "--main-dex-rules",
-      proguardFile.toString()
-    ) :+ s"@$filenamesFile"
+      val d8Args = Seq(
+        androidSdkModule().d8Exe().path.toString,
+        if (androidIsDebug()) "--debug" else "--release",
+        // TODO explore --incremental flag for incremental builds
+        "--output",
+        outPath.toString(),
+        "--lib",
+        androidSdkModule().androidJarPath().path.toString(),
+        "--min-api",
+        androidMinSdk().toString,
+        "--main-dex-rules",
+        proguardFile.toString()
+      ) :+ s"@$filenamesFile"
 
-    Task.log.info(s"Running d8 with the command: ${d8Args.mkString(" ")}")
+      Task.log.info(s"Running d8 with the command: ${d8Args.mkString(" ")}")
 
-    (
-      outPath = PathRef(outPath),
-      dexCliArgs = d8Args,
-      appCompiledFiles = appCompiledPathRefs ++ libsJarPathRefs
-    )
-  }
+      (
+        outPath = PathRef(outPath),
+        dexCliArgs = d8Args,
+        appCompiledFiles = appCompiledPathRefs ++ libsJarPathRefs
+      )
+    }
 
   trait AndroidAppTests extends AndroidTestModule, AndroidAppModule {
     override def androidApplicationId: String = s"${outer.androidApplicationId}.test"
@@ -1091,7 +1092,7 @@ trait AndroidAppModule extends AndroidModule { outer =>
       PathRef(destManifest)
     }
 
-    private def androidxTestManifests: Task[Seq[PathRef]] = Task {
+    private def androidxTestManifests: T[Seq[PathRef]] = Task {
       androidUnpackRunArchives().flatMap {
         unpackedArchive =>
           unpackedArchive.manifest.map(_.path)
@@ -1103,7 +1104,7 @@ trait AndroidAppModule extends AndroidModule { outer =>
       }.map(PathRef(_))
     }
 
-    override def androidMergeableManifests: Task[Seq[PathRef]] = Task {
+    override def androidMergeableManifests: T[Seq[PathRef]] = Task {
       Seq(outer.androidDebugManifestLocation()).filter(pr =>
         os.exists(pr.path)
       ) ++ androidxTestManifests()

--- a/libs/androidlib/src/mill/androidlib/AndroidModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidModule.scala
@@ -554,7 +554,7 @@ trait AndroidModule extends JavaModule { outer =>
   def androidManifestMergerModuleRef: ModuleRef[AndroidManifestMerger] =
     ModuleRef(AndroidManifestMerger)
 
-  def androidMergeableManifests: Task[Seq[PathRef]] = Task {
+  def androidMergeableManifests: T[Seq[PathRef]] = Task {
     androidUnpackRunArchives().flatMap(_.manifest) ++ androidDirectModuleDepsManifests()
   }
 

--- a/libs/androidlib/src/mill/androidlib/AndroidR8AppModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidR8AppModule.scala
@@ -58,7 +58,7 @@ trait AndroidR8AppModule extends AndroidAppModule { outer =>
     )
   }
 
-  def androidLibraryProguardConfigs: Task[Seq[PathRef]] = Task {
+  def androidLibraryProguardConfigs: T[Seq[PathRef]] = Task {
     androidUnpackRunArchives()
       // TODO need also collect rules from other modules,
       // but Android lib module doesn't yet exist

--- a/libs/androidlib/src/mill/androidlib/AndroidSdkManagerModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidSdkManagerModule.scala
@@ -3,6 +3,7 @@ package mill.androidlib
 import mill.api.*
 import mill.api.JsonFormatters.pathReadWrite
 import mill.client.lock.{Lock, TryLocked}
+import mill.T
 import os.CommandResult
 import upickle.ReadWriter
 
@@ -32,7 +33,7 @@ trait AndroidSdkManagerModule extends ExternalModule {
 
   def androidSdkManagerLockFile: os.Path = androidMillHomeDir() / ".sdkmanager.lock"
 
-  def androidSdkManagerWorkerMaxWaitAttempts: Task[Int] = Task {
+  def androidSdkManagerWorkerMaxWaitAttempts: T[Int] = Task {
     25
   }
 

--- a/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -120,7 +120,7 @@ trait KotlinModule extends JavaModule with KotlinModuleApi { outer =>
    *
    * See also https://discuss.kotlinlang.org/t/kotlin-compiler-embeddable-vs-kotlin-compiler/3196
    */
-  def kotlinUseEmbeddableCompiler: Task[Boolean] = Task { false }
+  def kotlinUseEmbeddableCompiler: T[Boolean] = Task { false }
 
   /**
    * The Ivy/Coursier dependencies resembling the Kotlin compiler.
@@ -515,9 +515,9 @@ trait KotlinModule extends JavaModule with KotlinModuleApi { outer =>
       outer.kotlincOptions().filterNot(_.startsWith("-Xcommon-sources")) ++
         Seq(s"-Xfriend-paths=${outer.compile().classes.path.toString()}")
     }
-    override def kotlinUseEmbeddableCompiler: Task[Boolean] =
-      Task.Anon { outer.kotlinUseEmbeddableCompiler() }
-    override def kotlincUseBtApi: Task.Simple[Boolean] = Task { outer.kotlincUseBtApi() }
+    override def kotlinUseEmbeddableCompiler: T[Boolean] =
+      Task { outer.kotlinUseEmbeddableCompiler() }
+    override def kotlincUseBtApi: T[Boolean] = Task { outer.kotlincUseBtApi() }
   }
 
 }
@@ -537,9 +537,9 @@ object KotlinModule {
       outer.kotlincOptions().filterNot(_.startsWith("-Xcommon-sources")) ++
         Seq(s"-Xfriend-paths=${outer.compile().classes.path.toString()}")
     }
-    override def kotlinUseEmbeddableCompiler: Task[Boolean] =
-      Task.Anon { outer.kotlinUseEmbeddableCompiler() }
-    override def kotlincUseBtApi: Task.Simple[Boolean] = Task { outer.kotlincUseBtApi() }
+    override def kotlinUseEmbeddableCompiler: T[Boolean] =
+      Task { outer.kotlinUseEmbeddableCompiler() }
+    override def kotlincUseBtApi: T[Boolean] = Task { outer.kotlincUseBtApi() }
   }
   private[mill] def addJvmVariantAttributes: ResolutionParams => ResolutionParams = { params =>
     params.addVariantAttributes(

--- a/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -120,7 +120,9 @@ trait KotlinModule extends JavaModule with KotlinModuleApi { outer =>
    *
    * See also https://discuss.kotlinlang.org/t/kotlin-compiler-embeddable-vs-kotlin-compiler/3196
    */
-  def kotlinUseEmbeddableCompiler: T[Boolean] = Task { false }
+  // TODO: Keeping this as `Task.Anon` since changing the return type from `Task` would cause binary incompatibility.
+  // If/when binary compatibility can be broken, consider switching this to `Task` that returns`T`
+  def kotlinUseEmbeddableCompiler: Task[Boolean] = Task.Anon { false }
 
   /**
    * The Ivy/Coursier dependencies resembling the Kotlin compiler.
@@ -515,8 +517,8 @@ trait KotlinModule extends JavaModule with KotlinModuleApi { outer =>
       outer.kotlincOptions().filterNot(_.startsWith("-Xcommon-sources")) ++
         Seq(s"-Xfriend-paths=${outer.compile().classes.path.toString()}")
     }
-    override def kotlinUseEmbeddableCompiler: T[Boolean] =
-      Task { outer.kotlinUseEmbeddableCompiler() }
+    override def kotlinUseEmbeddableCompiler: Task[Boolean] =
+      Task.Anon { outer.kotlinUseEmbeddableCompiler() }
     override def kotlincUseBtApi: T[Boolean] = Task { outer.kotlincUseBtApi() }
   }
 
@@ -537,9 +539,9 @@ object KotlinModule {
       outer.kotlincOptions().filterNot(_.startsWith("-Xcommon-sources")) ++
         Seq(s"-Xfriend-paths=${outer.compile().classes.path.toString()}")
     }
-    override def kotlinUseEmbeddableCompiler: T[Boolean] =
-      Task { outer.kotlinUseEmbeddableCompiler() }
-    override def kotlincUseBtApi: T[Boolean] = Task { outer.kotlincUseBtApi() }
+    override def kotlinUseEmbeddableCompiler: Task[Boolean] =
+      Task.Anon { outer.kotlinUseEmbeddableCompiler() }
+    override def kotlincUseBtApi: Task.Simple[Boolean] = Task { outer.kotlincUseBtApi() }
   }
   private[mill] def addJvmVariantAttributes: ResolutionParams => ResolutionParams = { params =>
     params.addVariantAttributes(

--- a/libs/kotlinlib/src/mill/kotlinlib/kapt/KaptModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/kapt/KaptModule.scala
@@ -65,7 +65,7 @@ trait KaptModule extends KotlinModule { outer =>
   def kaptCorrectErrorTypes: T[Boolean] = Task { true }
   def kaptMapDiagnosticLocations: T[Boolean] = Task { true }
 
-  override def kotlinUseEmbeddableCompiler: T[Boolean] = Task { true }
+  override def kotlinUseEmbeddableCompiler: Task[Boolean] = Task.Anon { true }
 
   override def kotlincPluginMvnDeps: T[Seq[Dep]] = Task {
     super.kotlincPluginMvnDeps() ++ kaptPluginMvnDeps()

--- a/libs/kotlinlib/src/mill/kotlinlib/kapt/KaptModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/kapt/KaptModule.scala
@@ -65,7 +65,7 @@ trait KaptModule extends KotlinModule { outer =>
   def kaptCorrectErrorTypes: T[Boolean] = Task { true }
   def kaptMapDiagnosticLocations: T[Boolean] = Task { true }
 
-  override def kotlinUseEmbeddableCompiler: Task[Boolean] = Task { true }
+  override def kotlinUseEmbeddableCompiler: T[Boolean] = Task { true }
 
   override def kotlincPluginMvnDeps: T[Seq[Dep]] = Task {
     super.kotlincPluginMvnDeps() ++ kaptPluginMvnDeps()

--- a/libs/kotlinlib/src/mill/kotlinlib/ksp/KspModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/ksp/KspModule.scala
@@ -122,9 +122,10 @@ trait KspModule extends KotlinModule { outer =>
     sources()
   }
 
-  override def kotlinUseEmbeddableCompiler: T[Boolean] = kspModuleMode match {
-    case KspModuleMode.Ksp1 => Task { true }
-    case KspModuleMode.Ksp2Cli | KspModuleMode.Ksp2 => Task { super.kotlinUseEmbeddableCompiler() }
+  override def kotlinUseEmbeddableCompiler: Task[Boolean] = kspModuleMode match {
+    case KspModuleMode.Ksp1 => Task.Anon { true }
+    case KspModuleMode.Ksp2Cli | KspModuleMode.Ksp2 =>
+      Task.Anon { super.kotlinUseEmbeddableCompiler() }
   }
 
   /**

--- a/libs/kotlinlib/src/mill/kotlinlib/ksp/KspModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/ksp/KspModule.scala
@@ -122,7 +122,7 @@ trait KspModule extends KotlinModule { outer =>
     sources()
   }
 
-  override def kotlinUseEmbeddableCompiler: Task[Boolean] = kspModuleMode match {
+  override def kotlinUseEmbeddableCompiler: T[Boolean] = kspModuleMode match {
     case KspModuleMode.Ksp1 => Task { true }
     case KspModuleMode.Ksp2Cli | KspModuleMode.Ksp2 => Task { super.kotlinUseEmbeddableCompiler() }
   }

--- a/libs/kotlinlib/test/src/mill/kotlinlib/HelloKotlinTests.scala
+++ b/libs/kotlinlib/test/src/mill/kotlinlib/HelloKotlinTests.scala
@@ -22,7 +22,7 @@ object HelloKotlinTests extends TestSuite {
     trait KotlinVersionCross extends KotlinModule with Cross.Module2[String, Boolean] {
       def kotlinVersion = crossValue
 
-      override def kotlinUseEmbeddableCompiler: T[Boolean] = Task { crossValue2 }
+      override def kotlinUseEmbeddableCompiler: Task[Boolean] = Task.Anon { crossValue2 }
 
       override def mainClass = Some("hello.HelloKt")
 

--- a/libs/kotlinlib/test/src/mill/kotlinlib/HelloKotlinTests.scala
+++ b/libs/kotlinlib/test/src/mill/kotlinlib/HelloKotlinTests.scala
@@ -22,7 +22,7 @@ object HelloKotlinTests extends TestSuite {
     trait KotlinVersionCross extends KotlinModule with Cross.Module2[String, Boolean] {
       def kotlinVersion = crossValue
 
-      override def kotlinUseEmbeddableCompiler: Task[Boolean] = Task { crossValue2 }
+      override def kotlinUseEmbeddableCompiler: T[Boolean] = Task { crossValue2 }
 
       override def mainClass = Some("hello.HelloKt")
 


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/6979#

Some `Task`s were accidentally returning `Task` instead of `Task.Simple`, which caused the following:
- Can't be called by cli
- Broke `visualizePlan` for such tasks that depended on their `super`s (see: https://github.com/com-lihaoyi/mill/issues/6979#issuecomment-4312458654)