### PR TITLE
Update scalafmt to 3.11.0 and introduce a `scalafmt-worker` module

### DIFF
--- a/libs/scalalib/package.mill
+++ b/libs/scalalib/package.mill
@@ -28,9 +28,18 @@ object `package` extends MillStableScalaModule {
   def compileMvnDeps = Seq(Deps.sonatypeCentralClient)
   def runMvnDeps = Seq(Deps.sonatypeCentralClient)
   def testModuleDeps = super.testModuleDeps ++ Seq(build.testkit.internal)
+  def localTestExtraModules =
+    super.localTestExtraModules ++ Seq(
+      `scalafmt-worker`
+    )
 
   def testForkEnv = {
     val locale = if (Properties.isMac) "en_US.UTF-8" else "C.utf8"
     super.testForkEnv() ++ Map("LC_ALL" -> locale)
+  }
+
+  object `scalafmt-worker` extends MillPublishScalaModule {
+    def moduleDeps = Seq(build.libs.scalalib)
+    def mvnDeps = Seq(Deps.scalafmtDynamic)
   }
 }

--- a/libs/scalalib/scalafmt-worker/src/ScalafmtWorkerImpl.scala
+++ b/libs/scalalib/scalafmt-worker/src/ScalafmtWorkerImpl.scala
@@ -1,0 +1,116 @@
+package mill.scalalib.scalafmt.worker
+
+import mill.scalalib.scalafmt.ScalafmtWorker
+import mill.api.daemon.*
+import mill.api.*
+import org.scalafmt.interfaces.*
+import org.scalafmt.dynamic.coursier.CoursierDependencyDownloader
+import scala.collection.mutable
+
+private[scalafmt] class ScalafmtWorkerImpl() extends ScalafmtWorker {
+
+  private val lock = new Object
+  private val reformatted: mutable.Map[os.Path, Int] = mutable.Map.empty
+  private var configSig: Int = 0
+
+  private val scalafmt = Scalafmt
+    .create(getClass().getClassLoader())
+    .withRepositoryPackageDownloader(
+      new RepositoryPackageDownloaderFactory {
+        override def create(reporter: ScalafmtReporter, props: RepositoryProperties) =
+          CoursierDependencyDownloader(Seq.empty)
+      }
+    )
+
+//  val scalafmt = cl.loadClass("org.scalafmt.interfaces.Scalafmt")
+//    .getMethod("create", classOf[java.lang.ClassLoader])
+//    .invoke(null, cl)
+
+  override def reformat(input: Seq[PathRef], scalafmtConfig: PathRef)(using ctx: TaskCtx): Unit = {
+    reformatAction(input, scalafmtConfig, dryRun = false)
+  }
+
+  override def checkFormat(input: Seq[PathRef], scalafmtConfig: PathRef)(using
+      ctx: TaskCtx
+  ): Result[Unit] = {
+
+    val misformatted = reformatAction(input, scalafmtConfig, dryRun = true)
+    if (misformatted.isEmpty) {
+      Result.Success(())
+    } else {
+      val out = ctx.log.streams.out
+      for (u <- misformatted) {
+        out.println(u.path.toString)
+      }
+      Result.Failure(s"Found ${misformatted.length} misformatted files")
+    }
+  }
+
+  // run scalafmt over input files and return any files that changed
+  // (only save changes to files if dryRun is false)
+  private def reformatAction(
+      input: Seq[PathRef],
+      scalafmtConfig: PathRef,
+      dryRun: Boolean
+  )(using ctx: TaskCtx): Seq[PathRef] = lock.synchronized {
+
+    // only consider files that have changed since last reformat
+    val toConsider =
+      if (scalafmtConfig.sig != configSig) input
+      else input.filterNot(ref => reformatted.get(ref.path).contains(ref.sig))
+
+    if (toConsider.nonEmpty) {
+
+      if (dryRun) {
+        ctx.log.info(s"Checking format of ${toConsider.size} Scala sources")
+      } else {
+        ctx.log.info(s"Formatting ${toConsider.size} Scala sources")
+      }
+
+      val configPath = scalafmtConfig.path.toNIO
+
+      // keeps track of files that are misformatted
+      val misformatted = mutable.ListBuffer.empty[PathRef]
+
+      def markFormatted(path: PathRef) = {
+        val updRef = PathRef(path.path)
+        reformatted += updRef.path -> updRef.sig
+      }
+
+      toConsider.foreach { pathToFormat =>
+        val code = os.read(pathToFormat.path)
+        val formattedCode = scalafmt
+          .getClass
+          .getMethods
+          .filter(_.getName == "format")
+          .head
+          .invoke(scalafmt, configPath, pathToFormat.path.toNIO, code)
+          .asInstanceOf[String]
+
+        if (code != formattedCode) {
+          misformatted += pathToFormat
+          if (!dryRun) {
+            os.write.over(pathToFormat.path, formattedCode)
+            markFormatted(pathToFormat)
+          }
+        } else {
+          markFormatted(pathToFormat)
+        }
+
+      }
+
+      configSig = scalafmtConfig.sig
+      misformatted.toList
+    } else {
+      ctx.log.info(s"Everything is formatted already")
+      Nil
+    }
+  }
+
+  override def close(): Unit = lock.synchronized {
+    scalafmt.clear()
+    reformatted.clear()
+    configSig = 0
+  }
+
+}

--- a/libs/scalalib/scalafmt-worker/src/ScalafmtWorkerImpl.scala
+++ b/libs/scalalib/scalafmt-worker/src/ScalafmtWorkerImpl.scala
@@ -1,10 +1,16 @@
 package mill.scalalib.scalafmt.worker
 
 import mill.scalalib.scalafmt.ScalafmtWorker
-import mill.api.daemon.*
-import mill.api.*
-import org.scalafmt.interfaces.*
+import mill.api.daemon.Result
+import mill.api.{PathRef, TaskCtx}
 import org.scalafmt.dynamic.coursier.CoursierDependencyDownloader
+import org.scalafmt.interfaces.{
+  RepositoryPackageDownloaderFactory,
+  RepositoryProperties,
+  Scalafmt,
+  ScalafmtReporter
+}
+
 import scala.collection.mutable
 
 private[scalafmt] class ScalafmtWorkerImpl() extends ScalafmtWorker {
@@ -21,10 +27,6 @@ private[scalafmt] class ScalafmtWorkerImpl() extends ScalafmtWorker {
           CoursierDependencyDownloader(Seq.empty)
       }
     )
-
-//  val scalafmt = cl.loadClass("org.scalafmt.interfaces.Scalafmt")
-//    .getMethod("create", classOf[java.lang.ClassLoader])
-//    .invoke(null, cl)
 
   override def reformat(input: Seq[PathRef], scalafmtConfig: PathRef)(using ctx: TaskCtx): Unit = {
     reformatAction(input, scalafmtConfig, dryRun = false)

--- a/libs/scalalib/src/mill/scalalib/scalafmt/ScalafmtWorker.scala
+++ b/libs/scalalib/src/mill/scalalib/scalafmt/ScalafmtWorker.scala
@@ -1,131 +1,19 @@
 package mill.scalalib.scalafmt
 
-import mill.*
-import mill.api.{Discover, ExternalModule, PathRef, TaskCtx}
-import mill.scalalib.*
+import mill.api.daemon.Result
+import mill.api.{PathRef, TaskCtx}
 
-import scala.collection.mutable
-import mill.api.Result
+private[scalafmt] trait ScalafmtWorker extends AutoCloseable {
 
-object ScalafmtWorkerModule extends ExternalModule with JavaModule {
-
-  /**
-   * Classpath for running Scalafmt
-   */
-  def scalafmtClasspath: T[Seq[PathRef]] = Task {
-    defaultResolver().classpath(
-      Seq(mvn"org.scalameta:scalafmt-dynamic_2.13:${mill.javalib.api.Versions.scalafmtVersion}")
-    )
-  }
-
-  def scalafmtClassLoader: Worker[java.net.URLClassLoader] = Task.Worker {
-    mill.util.Jvm.createClassLoader(scalafmtClasspath().map(_.path))
-  }
-
-  def worker: Worker[ScalafmtWorker] = Task.Worker { ScalafmtWorker(scalafmtClassLoader()) }
-
-  lazy val millDiscover = Discover[this.type]
-}
-
-private[scalafmt] class ScalafmtWorker(cl: ClassLoader) extends AutoCloseable {
-  private val lock = new Object
-  private val reformatted: mutable.Map[os.Path, Int] = mutable.Map.empty
-  private var configSig: Int = 0
-
-  val scalafmt = cl.loadClass("org.scalafmt.interfaces.Scalafmt")
-    .getMethod("create", classOf[java.lang.ClassLoader])
-    .invoke(null, cl)
-
-  def reformat(input: Seq[PathRef], scalafmtConfig: PathRef)(using ctx: TaskCtx): Unit = {
-    reformatAction(input, scalafmtConfig, dryRun = false)
-  }
-
-  def checkFormat(input: Seq[PathRef], scalafmtConfig: PathRef)(using
-      ctx: TaskCtx
-  ): Result[Unit] = {
-
-    val misformatted = reformatAction(input, scalafmtConfig, dryRun = true)
-    if (misformatted.isEmpty) {
-      Result.Success(())
-    } else {
-      val out = ctx.log.streams.out
-      for (u <- misformatted) {
-        out.println(u.path.toString)
-      }
-      Result.Failure(s"Found ${misformatted.length} misformatted files")
-    }
-  }
-
-  // run scalafmt over input files and return any files that changed
-  // (only save changes to files if dryRun is false)
-  private def reformatAction(
+  def reformat(
       input: Seq[PathRef],
-      scalafmtConfig: PathRef,
-      dryRun: Boolean
-  )(using ctx: TaskCtx): Seq[PathRef] = lock.synchronized {
+      scalafmtConfig: PathRef
+  )(using ctx: TaskCtx): Unit
 
-    // only consider files that have changed since last reformat
-    val toConsider =
-      if (scalafmtConfig.sig != configSig) input
-      else input.filterNot(ref => reformatted.get(ref.path).contains(ref.sig))
-
-    if (toConsider.nonEmpty) {
-
-      if (dryRun) {
-        ctx.log.info(s"Checking format of ${toConsider.size} Scala sources")
-      } else {
-        ctx.log.info(s"Formatting ${toConsider.size} Scala sources")
-      }
-
-      val configPath = scalafmtConfig.path.toNIO
-
-      // keeps track of files that are misformatted
-      val misformatted = mutable.ListBuffer.empty[PathRef]
-
-      def markFormatted(path: PathRef) = {
-        val updRef = PathRef(path.path)
-        reformatted += updRef.path -> updRef.sig
-      }
-
-      toConsider.foreach { pathToFormat =>
-        val code = os.read(pathToFormat.path)
-        val formattedCode = scalafmt
-          .getClass
-          .getMethods
-          .filter(_.getName == "format")
-          .head
-          .invoke(scalafmt, configPath, pathToFormat.path.toNIO, code)
-          .asInstanceOf[String]
-
-        if (code != formattedCode) {
-          misformatted += pathToFormat
-          if (!dryRun) {
-            os.write.over(pathToFormat.path, formattedCode)
-            markFormatted(pathToFormat)
-          }
-        } else {
-          markFormatted(pathToFormat)
-        }
-
-      }
-
-      configSig = scalafmtConfig.sig
-      misformatted.toList
-    } else {
-      ctx.log.info(s"Everything is formatted already")
-      Nil
-    }
-  }
-
-  override def close(): Unit = lock.synchronized {
-    scalafmt
-      .getClass
-      .getMethods
-      .filter(_.getName == "clear")
-      .head
-      .invoke(scalafmt)
-
-    reformatted.clear()
-    configSig = 0
-  }
+  def checkFormat(
+      input: Seq[PathRef],
+      scalafmtConfig: PathRef
+  )(using
+      ctx: TaskCtx
+  ): Result[Unit]
 }

--- a/libs/scalalib/src/mill/scalalib/scalafmt/ScalafmtWorkerModule.scala
+++ b/libs/scalalib/src/mill/scalalib/scalafmt/ScalafmtWorkerModule.scala
@@ -1,0 +1,47 @@
+package mill.scalalib.scalafmt
+
+import mill.*
+import mill.api.{PathRef, Task, *}
+import mill.scalalib.*
+import mill.util.Jvm
+
+object ScalafmtWorkerModule extends ExternalModule with JavaModule {
+
+  /**
+   * Classpath for running Scalafmt
+   */
+  @deprecated("Unused", "Mill after 1.1.6")
+  def scalafmtClasspath: T[Seq[PathRef]] = Task {
+    defaultResolver().classpath(
+      Seq(mvn"org.scalameta:scalafmt-dynamic_2.13:${mill.javalib.api.Versions.scalafmtVersion}")
+    )
+  }
+
+  @deprecated("Unused", "Mill after 1.1.6")
+  def scalafmtClassLoader: Worker[java.net.URLClassLoader] = Task.Worker {
+    mill.util.Jvm.createClassLoader(scalafmtClasspath().map(_.path))
+  }
+
+  /**
+   * CLasspath used to load the scalafmt worker, which itself depends on scalafmt-dynamic
+   */
+  def scalafmtWorkerClasspath: T[Seq[PathRef]] = Task {
+    defaultResolver().classpath(Seq(Dep.millProjectModule("mill-libs-scalalib-scalafmt-worker")))
+  }
+
+  private def scalafmtWorkerClassLoader: Worker[ClassLoader & AutoCloseable] = Task.Worker {
+    Jvm.createClassLoader(
+      classPath = scalafmtWorkerClasspath().map(_.path),
+      parent = getClass().getClassLoader()
+    )
+  }
+
+  def worker: Worker[ScalafmtWorker] = Task.Worker {
+    val cls = scalafmtWorkerClassLoader().loadClass(
+      getClass().getPackageName + ".worker.ScalafmtWorkerImpl"
+    )
+    cls.getConstructor().newInstance().asInstanceOf[ScalafmtWorker]
+  }
+
+  lazy val millDiscover = Discover[this.type]
+}

--- a/mill-build/src/millbuild/Deps.scala
+++ b/mill-build/src/millbuild/Deps.scala
@@ -191,7 +191,7 @@ object Deps {
     .exclude("org.scala-sbt" -> "compiler-interface")
 
   def scalaCompilerInterface = mvn"org.scala-sbt:compiler-interface:${zinc.version}"
-  val scalafmtDynamic = mvn"org.scalameta::scalafmt-dynamic:3.10.3".withDottyCompat(scalaVersion)
+  val scalafmtDynamic = mvn"org.scalameta::scalafmt-dynamic:3.11.0".withDottyCompat(scalaVersion)
   def scalaReflect(scalaVersion: String) =
     if (JvmWorkerUtil.isScala3(scalaVersion))
       mvn"org.scala-lang:scala-reflect:${Deps.scala2Version}"


### PR DESCRIPTION
Introduce `scalafmt-worker` module to address non-trivial API changes.

The previous Java Reflection based approach is to in-ergonomic and error-prone since creating a `Scalafmt` instance now involves more API use that before.

Now, we directly depend on `scalafmt-dynamic` from the new worker module.

The previous `ScalafmtWorker` class is now a trait, but keeps the same methods.