### PR TITLE
Optmize performance for cylic check

### DIFF
--- a/libs/javalib/src/mill/javalib/internal/ModuleUtils.scala
+++ b/libs/javalib/src/mill/javalib/internal/ModuleUtils.scala
@@ -21,14 +21,15 @@ object ModuleUtils {
   def recursive[T](name: String, start: T, deps: T => Seq[T]): Seq[T] = {
 
     @tailrec def rec(
-        seenModules: List[T],
+        seenModules: Set[T],
+        result: List[T],
         toAnalyze: List[(List[T], List[T])]
     ): List[T] = {
       toAnalyze match {
-        case Nil => seenModules
+        case Nil => result
         case traces :: rest =>
           traces match {
-            case (_, Nil) => rec(seenModules, rest)
+            case (_, Nil) => rec(seenModules, result, rest)
             case (trace, cand :: remaining) =>
               if (trace.contains(cand)) {
                 // cycle!
@@ -38,9 +39,10 @@ object ModuleUtils {
                 println(msg)
                 throw new mill.api.MillException(msg)
               }
+              val alreadySeen = seenModules.contains(cand)
               rec(
-                if (seenModules.contains(cand)) seenModules
-                else { seenModules ++ Seq(cand) },
+                if (alreadySeen) seenModules else seenModules + cand,
+                if (alreadySeen) result else cand :: result,
                 toAnalyze = ((cand :: trace, deps(cand).toList)) :: (trace, remaining) :: rest
               )
           }
@@ -48,8 +50,9 @@ object ModuleUtils {
     }
 
     rec(
-      seenModules = List(),
+      seenModules = Set.empty,
+      result = Nil,
       toAnalyze = List((List(start), deps(start).toList))
-    ).reverse
+    )
   }
 }


### PR DESCRIPTION
List.contains is slow on large number of modules
```
benchmark                  (depCount)  Mode  Cnt        Score        Error  Units
ModuleUtilsJmh.newSetList          10  avgt   20      809.918 ±    164.825  ns/op
ModuleUtilsJmh.newSetList         100  avgt   20     8839.895 ±    852.083  ns/op
ModuleUtilsJmh.newSetList        1000  avgt   20   113960.451 ±  14368.900  ns/op
ModuleUtilsJmh.oldList             10  avgt   20      530.315 ±     44.856  ns/op
ModuleUtilsJmh.oldList            100  avgt   20    33012.497 ±   2543.791  ns/op
ModuleUtilsJmh.oldList           1000  avgt   20  3065535.100 ± 230869.212  ns/op
```
https://gist.github.com/jilen/b9dce075d3c0ce9f2fb4a16838fc4e40