### PR TITLE
Attempt to fix inactive annotation processor detection

### DIFF
--- a/libs/javalib/worker/src/mill/javalib/zinc/IncrementalAnnotationProcessing.scala
+++ b/libs/javalib/worker/src/mill/javalib/zinc/IncrementalAnnotationProcessing.scala
@@ -129,9 +129,8 @@ private[mill] object IncrementalAnnotationProcessing {
       log: Logger.Actions
   ): Mode = {
     val javaSources = sources.filter(_.ext == "java")
-    if (
-      !incrementalCompilation || javacOptions.contains("-proc:none") || javaSources.isEmpty
-    ) Mode.None
+    if (!incrementalCompilation || javacOptions.contains("-proc:none") || javaSources.isEmpty)
+      Mode.None
     else {
       val processorPath = parsePathOption(javacOptions, "-processorpath", "--processor-path")
         .map(_.map(os.Path(_, os.pwd)))

--- a/libs/javalib/worker/src/mill/javalib/zinc/IncrementalAnnotationProcessing.scala
+++ b/libs/javalib/worker/src/mill/javalib/zinc/IncrementalAnnotationProcessing.scala
@@ -128,10 +128,9 @@ private[mill] object IncrementalAnnotationProcessing {
       incrementalCompilation: Boolean,
       log: Logger.Actions
   ): Mode = {
+    val javaSources = sources.filter(_.ext == "java")
     if (
-      !incrementalCompilation || javacOptions.contains("-proc:none") || !sources.exists(
-        _.ext == "java"
-      )
+      !incrementalCompilation || javacOptions.contains("-proc:none") || javaSources.isEmpty
     ) Mode.None
     else {
       val processorPath = parsePathOption(javacOptions, "-processorpath", "--processor-path")
@@ -154,10 +153,12 @@ private[mill] object IncrementalAnnotationProcessing {
               if (activeKinds.exists(_ == TrackingMode.Aggregating)) TrackingMode.Aggregating
               else TrackingMode.Isolating
 
-            val sourceStamps = snapshotSources(sources)
+            val sourceStamps = snapshotSources(javaSources)
             val classesDir = workDir / "classes"
             val previous = decodeSnapshot(readSnapshot(snapshotPath(workDir)), workDir, classesDir)
-            val previousStamps = previous.sourceStamps
+            val previousStamps = previous.sourceStamps.filter { case (path, _) =>
+              path.ext == "java"
+            }
             val changedSources = changedSourcesSince(previousStamps, sourceStamps)
             val staleProducts = staleProductsFor(previous.products, previousStamps, sourceStamps)
             val removedSources = previousStamps.keySet -- sourceStamps.keySet
@@ -180,7 +181,7 @@ private[mill] object IncrementalAnnotationProcessing {
                 lookupData = Option.when(!requiresFullRecompile) {
                   lookupData(staleProducts, changedSources, removedSources, sourceStamps.keySet)
                 },
-                tracker = new CompileTracker(trackingMode, sources.toSet, classesDir)
+                tracker = new CompileTracker(trackingMode, javaSources.toSet, classesDir)
               )
             )
         }

--- a/libs/javalib/worker/src/mill/javalib/zinc/IncrementalAnnotationProcessing.scala
+++ b/libs/javalib/worker/src/mill/javalib/zinc/IncrementalAnnotationProcessing.scala
@@ -129,7 +129,11 @@ private[mill] object IncrementalAnnotationProcessing {
       incrementalCompilation: Boolean,
       log: Logger.Actions
   ): Mode = {
-    if (!incrementalCompilation || javacOptions.contains("-proc:none")) Mode.None
+    if (
+      !incrementalCompilation || javacOptions.contains("-proc:none") || !sources.exists(
+        _.ext == "java"
+      )
+    ) Mode.None
     else {
       val processorPath = parsePathOption(javacOptions, "-processorpath", "--processor-path")
         .map(_.map(os.Path(_, os.pwd)))
@@ -710,14 +714,17 @@ private[mill] object IncrementalAnnotationProcessing {
   }
 
   object SourceAnnotationIndex {
-    def fromSources(sources: Seq[os.Path]): Option[SourceAnnotationIndex] =
+    def fromSources(sources: Seq[os.Path]): Option[SourceAnnotationIndex] = {
+      val javaSources = sources.filter(_.ext == "java")
+
       Option(ToolProvider.getSystemJavaCompiler).flatMap { compiler =>
         def standardFileManager: StandardJavaFileManager =
           compiler.getStandardFileManager(null, null, null)
 
         scala.util.Try {
           Using.resource(standardFileManager) { fileManager =>
-            val javaFiles = fileManager.getJavaFileObjectsFromPaths(sources.map(_.toNIO).asJava)
+            val javaFiles =
+              fileManager.getJavaFileObjectsFromPaths(javaSources.map(_.toNIO).asJava)
             val task = compiler
               .getTask(null, fileManager, null, Nil.asJava, null, javaFiles)
               .asInstanceOf[JavacTask]
@@ -733,6 +740,7 @@ private[mill] object IncrementalAnnotationProcessing {
           }
         }.toOption
       }
+    }
 
     private def addAnnotationsFromUnit(
         unit: CompilationUnitTree,

--- a/libs/javalib/worker/src/mill/javalib/zinc/IncrementalAnnotationProcessing.scala
+++ b/libs/javalib/worker/src/mill/javalib/zinc/IncrementalAnnotationProcessing.scala
@@ -45,7 +45,6 @@ private[mill] object IncrementalAnnotationProcessing {
 
   enum Mode {
     case None
-    case Disabled
     case Enabled(plan: CompilePlan)
   }
 
@@ -149,7 +148,7 @@ private[mill] object IncrementalAnnotationProcessing {
         val kinds =
           resolveTrackingModes(activeProcessors.toSet, metadata, processorPath, compileClasspath)
         kinds match {
-          case None => Mode.Disabled
+          case None => Mode.None
           case Some(activeKinds) =>
             val trackingMode =
               if (activeKinds.exists(_ == TrackingMode.Aggregating)) TrackingMode.Aggregating

--- a/libs/javalib/worker/src/mill/javalib/zinc/ZincWorker.scala
+++ b/libs/javalib/worker/src/mill/javalib/zinc/ZincWorker.scala
@@ -349,17 +349,6 @@ class ZincWorker(jobs: Int, useFileLocks: Boolean = false) extends AutoCloseable
       )
 
     val effectiveIncrementalCompilation = incrementalAnnotationProcessing match {
-      case IncrementalAnnotationProcessing.Mode.Disabled =>
-        processConfig.log.warn(
-          s"""Disabling zinc incremental compilation because annotation processors do not declare supported
-             |incremental metadata.
-             |Mill only reads incremental annotation processor metadata from the active processor path
-             |and the compile classpath.
-             |To enable incremental annotation processing, use processors that publish
-             |`META-INF/gradle/incremental.annotation.processors`, or add a patched jar/directory or
-             |compile-time classpath entry with that metadata.""".stripMargin
-        )
-        false
       case IncrementalAnnotationProcessing.Mode.Enabled(plan) if plan.requiresFullRecompile =>
         false
       case _ => incrementalCompilation
@@ -379,7 +368,6 @@ class ZincWorker(jobs: Int, useFileLocks: Boolean = false) extends AutoCloseable
       case IncrementalAnnotationProcessing.Mode.None =>
         IncrementalAnnotationProcessing.previousExtraProducts(workDir).foreach(os.remove.all(_))
         os.remove.all(IncrementalAnnotationProcessing.snapshotPath(workDir))
-      case IncrementalAnnotationProcessing.Mode.Disabled =>
     }
 
     if (localConfig.logDebugEnabled) {

--- a/libs/javalib/worker/test/src/mill/javalib/zinc/IncrementalAnnotationProcessingDetectionTests.scala
+++ b/libs/javalib/worker/test/src/mill/javalib/zinc/IncrementalAnnotationProcessingDetectionTests.scala
@@ -136,7 +136,7 @@ object IncrementalAnnotationProcessingDetectionTests extends TestSuite {
       } finally os.remove.all(workDir)
     }
 
-    test("detectDisablesForRelevantProcessorWithoutMetadata") {
+    test("detectDoesNotDisableForRelevantProcessorWithoutMetadata") {
       val workDir = os.temp.dir()
       try {
         val relevantProcessor = compileProcessor(
@@ -166,7 +166,7 @@ object IncrementalAnnotationProcessingDetectionTests extends TestSuite {
           log = Logger.Actions.noOp
         )
 
-        assert(mode == IncrementalAnnotationProcessing.Mode.Disabled)
+        assert(mode == IncrementalAnnotationProcessing.Mode.None)
       } finally os.remove.all(workDir)
     }
 

--- a/libs/javalib/worker/test/src/mill/javalib/zinc/IncrementalAnnotationProcessingDetectionTests.scala
+++ b/libs/javalib/worker/test/src/mill/javalib/zinc/IncrementalAnnotationProcessingDetectionTests.scala
@@ -90,6 +90,11 @@ object IncrementalAnnotationProcessingDetectionTests extends TestSuite {
     path
   }
 
+  private def sourceStamp(path: os.Path): IncrementalAnnotationProcessing.SourceStamp = {
+    val stat = os.stat(path)
+    IncrementalAnnotationProcessing.SourceStamp(stat.mtime.toMillis, stat.size)
+  }
+
   val tests: Tests = Tests {
     test("detectIgnoresInactiveServiceProviders") {
       val workDir = os.temp.dir()
@@ -208,6 +213,70 @@ object IncrementalAnnotationProcessingDetectionTests extends TestSuite {
         )
 
         assert(mode == IncrementalAnnotationProcessing.Mode.None)
+      } finally os.remove.all(workDir)
+    }
+
+    test("detectDoesNotRequireFullRecompileWhenOnlyScalaSourceChanges") {
+      val workDir = os.temp.dir()
+      try {
+        val aggregatingProcessor = compileProcessor(
+          workDir,
+          ProcessorSpec(
+            className = "example.AggregatingProcessor",
+            supportedAnnotationTypes = Seq("*"),
+            metadataKind = Some("aggregating")
+          )
+        )
+        val javaSrc = source(
+          workDir,
+          "src/example/Plain.java",
+          """package example;
+            |
+            |class Plain {}
+            |""".stripMargin
+        )
+        val scalaSrc = source(
+          workDir,
+          "src/example/PlainScala.scala",
+          """package example
+            |
+            |class PlainScala
+            |""".stripMargin
+        )
+        val classesDir = workDir / "classes"
+        val unknownProduct = classesDir / os.RelPath("META-INF/services/example.Service")
+        writeSource(unknownProduct, "example.ServiceImpl\n")
+
+        IncrementalAnnotationProcessing.writeSnapshot(
+          IncrementalAnnotationProcessing.snapshotPath(workDir),
+          IncrementalAnnotationProcessing.Snapshot(
+            sourceStamps = Map(
+              javaSrc.relativeTo(workDir).toString -> sourceStamp(javaSrc),
+              scalaSrc.relativeTo(workDir).toString ->
+                IncrementalAnnotationProcessing.SourceStamp(0L, 0L)
+            ),
+            products = Map(
+              unknownProduct.relativeTo(classesDir).toString ->
+                IncrementalAnnotationProcessing.PersistedOwnership.Unknown
+            )
+          )
+        )
+
+        val mode = IncrementalAnnotationProcessing.detect(
+          javacOptions = Nil,
+          compileClasspath = Seq(aggregatingProcessor),
+          sources = Seq(javaSrc, scalaSrc),
+          workDir = workDir,
+          incrementalCompilation = true,
+          log = Logger.Actions.noOp
+        )
+
+        mode match {
+          case IncrementalAnnotationProcessing.Mode.Enabled(plan) =>
+            assert(!plan.requiresFullRecompile)
+            assert(plan.staleProducts.isEmpty)
+          case _ => assert(false)
+        }
       } finally os.remove.all(workDir)
     }
 

--- a/libs/javalib/worker/test/src/mill/javalib/zinc/IncrementalAnnotationProcessingDetectionTests.scala
+++ b/libs/javalib/worker/test/src/mill/javalib/zinc/IncrementalAnnotationProcessingDetectionTests.scala
@@ -170,6 +170,80 @@ object IncrementalAnnotationProcessingDetectionTests extends TestSuite {
       } finally os.remove.all(workDir)
     }
 
+    test("detectIgnoresInactiveServiceProvidersOnCompileClasspathWithScalaSources") {
+      val workDir = os.temp.dir()
+      try {
+        val unrelatedProcessor = compileProcessor(
+          workDir,
+          ProcessorSpec(
+            className = "example.UnrelatedProcessor",
+            supportedAnnotationTypes = Seq("unrelated.Other"),
+            metadataKind = None
+          )
+        )
+        val javaSrc = source(
+          workDir,
+          "src/example/Plain.java",
+          """package example;
+            |
+            |class Plain {}
+            |""".stripMargin
+        )
+        val scalaSrc = source(
+          workDir,
+          "src/example/PlainScala.scala",
+          """package example
+            |
+            |class PlainScala
+            |""".stripMargin
+        )
+
+        val mode = IncrementalAnnotationProcessing.detect(
+          javacOptions = Nil,
+          compileClasspath = Seq(unrelatedProcessor),
+          sources = Seq(javaSrc, scalaSrc),
+          workDir = workDir,
+          incrementalCompilation = true,
+          log = Logger.Actions.noOp
+        )
+
+        assert(mode == IncrementalAnnotationProcessing.Mode.None)
+      } finally os.remove.all(workDir)
+    }
+
+    test("detectIgnoresServiceProvidersWithoutJavaSources") {
+      val workDir = os.temp.dir()
+      try {
+        val processor = compileProcessor(
+          workDir,
+          ProcessorSpec(
+            className = "example.Processor",
+            supportedAnnotationTypes = Seq("*"),
+            metadataKind = None
+          )
+        )
+        val scalaSrc = source(
+          workDir,
+          "src/example/PlainScala.scala",
+          """package example
+            |
+            |class PlainScala
+            |""".stripMargin
+        )
+
+        val mode = IncrementalAnnotationProcessing.detect(
+          javacOptions = Nil,
+          compileClasspath = Seq(processor),
+          sources = Seq(scalaSrc),
+          workDir = workDir,
+          incrementalCompilation = true,
+          log = Logger.Actions.noOp
+        )
+
+        assert(mode == IncrementalAnnotationProcessing.Mode.None)
+      } finally os.remove.all(workDir)
+    }
+
     test("trackingProcessorWrappingIsDisabledWithoutTracker") {
       val workDir = os.temp.dir()
       try {


### PR DESCRIPTION
Fixes #7058.
Fixes #7063.

This PR keeps normal Zinc incremental compilation enabled when javac annotation processors are present but unsupported by Mill's AP tracker.

Changes:

- Missing javac AP incremental metadata disables only Mill AP tracking, not Zinc incremental compilation.
- Inactive processor detection and javac AP tracking consider Java sources only.

#7063:

- Scala-only edits in mixed Scala/Java modules should not invalidate javac AP outputs or force full-module recompiles.

Validation:

```bash
./mill libs.javalib.worker.test.testOnly mill.javalib.zinc.IncrementalAnnotationProcessingDetectionTests
```
