### PR TITLE
Simplify readwrite lock blocking message 

### DIFF
--- a/core/api/daemon/src/mill/api/daemon/Logger.scala
+++ b/core/api/daemon/src/mill/api/daemon/Logger.scala
@@ -202,6 +202,13 @@ object Logger {
 
     private[mill] def enableTicker: Boolean
 
+    /**
+     * True for sinks where the lock label can't be inferred from the
+     * surrounding prompt-line prefix (e.g. BSP, where wait messages are
+     * emitted to stderr without that prefix).
+     */
+    private[mill] def waitMessageNeedsLabel: Boolean = false
+
     def infoColor(s: String): String
     def warnColor(s: String): String
     def errorColor(s: String): String

--- a/core/api/daemon/src/mill/api/daemon/Logger.scala
+++ b/core/api/daemon/src/mill/api/daemon/Logger.scala
@@ -202,11 +202,7 @@ object Logger {
 
     private[mill] def enableTicker: Boolean
 
-    /**
-     * True for sinks (e.g. `BspLogger`) whose surrounding prompt-line
-     * prefix doesn't reliably name the lock, so the wait message must
-     * carry the label itself.
-     */
+    /** True for sinks (e.g. `BspLogger`) whose prompt-line prefix doesn't name the lock. */
     private[mill] def waitMessageNeedsLabel: Boolean = false
 
     def infoColor(s: String): String

--- a/core/api/daemon/src/mill/api/daemon/Logger.scala
+++ b/core/api/daemon/src/mill/api/daemon/Logger.scala
@@ -203,9 +203,9 @@ object Logger {
     private[mill] def enableTicker: Boolean
 
     /**
-     * True for sinks where the lock label can't be inferred from the
-     * surrounding prompt-line prefix (e.g. BSP, where wait messages are
-     * emitted to stderr without that prefix).
+     * True for sinks (e.g. `BspLogger`) whose surrounding prompt-line
+     * prefix doesn't reliably name the lock, so the wait message must
+     * carry the label itself.
      */
     private[mill] def waitMessageNeedsLabel: Boolean = false
 

--- a/core/api/daemon/src/mill/api/daemon/internal/LauncherLocking.scala
+++ b/core/api/daemon/src/mill/api/daemon/internal/LauncherLocking.scala
@@ -165,7 +165,7 @@ private[mill] object LauncherLocking {
         kind: LockKind,
         waitReporter: WaitReporter
     ): Lease = NoopLease
-    override def tryMetaBuildWriteLock(depth: Int): Either[String, Lease] = Right(NoopLease)
+    override def tryMetaBuildWriteLock(depth: Int): Either[Contention, Lease] = Right(NoopLease)
     override def awaitMetaBuildStateChange(depth: Int, timeoutMs: Long): Unit = ()
     override def taskLock(
         path: Path,

--- a/core/api/daemon/src/mill/api/daemon/internal/LauncherLocking.scala
+++ b/core/api/daemon/src/mill/api/daemon/internal/LauncherLocking.scala
@@ -104,11 +104,7 @@ private[mill] object LauncherLocking {
     def downgradeToRead(): Unit = ()
   }
 
-  /**
-   * Why a non-blocking Write attempt failed. Carries the values
-   * [[WaitReporter.reportWait]] needs so callers don't have to thread
-   * `label` and `syntheticPrefix` through alongside the lock.
-   */
+  /** Failure carrier for [[WaitReporter.reportWait]] arguments. */
   case class Contention(message: String, label: String, syntheticPrefix: Seq[String])
 
   /**

--- a/core/api/daemon/src/mill/api/daemon/internal/LauncherLocking.scala
+++ b/core/api/daemon/src/mill/api/daemon/internal/LauncherLocking.scala
@@ -112,16 +112,21 @@ private[mill] object LauncherLocking {
    *
    * Implementations may also respond to holder changes by re-calling
    * `reportWait` — each call replaces the previous wait status.
+   *
+   * `syntheticPrefix`, when nonempty, supplies a stable prompt-line key for
+   * implementations that synthesise a fresh prompt line for the wait (i.e.
+   * when the caller's logger has no preexisting prompt line). It is ignored
+   * when the wait can be attached as a detail to an existing line.
    */
   trait WaitReporter {
-    def reportWait(message: String): AutoCloseable
+    def reportWait(message: String, syntheticPrefix: Seq[String] = Nil): AutoCloseable
   }
 
   object WaitReporter {
     private val NoopToken: AutoCloseable = () => ()
 
     /** Discards wait events. Useful for tests and noBuildLock. */
-    val Noop: WaitReporter = (_: String) => NoopToken
+    val Noop: WaitReporter = (_: String, _: Seq[String]) => NoopToken
 
     /**
      * Prints the wait message once on `reportWait` and does nothing on close.
@@ -129,7 +134,7 @@ private[mill] object LauncherLocking {
      * the user's terminal history. Used when no live prompt is available
      * (early bootstrap, no-daemon, BSP, `--ticker false`, etc.).
      */
-    def stderr(stream: PrintStream): WaitReporter = (msg: String) => {
+    def stderr(stream: PrintStream): WaitReporter = (msg: String, _: Seq[String]) => {
       stream.println(msg)
       NoopToken
     }

--- a/core/api/daemon/src/mill/api/daemon/internal/LauncherLocking.scala
+++ b/core/api/daemon/src/mill/api/daemon/internal/LauncherLocking.scala
@@ -112,11 +112,6 @@ private[mill] object LauncherLocking {
    *
    * Implementations may also respond to holder changes by re-calling
    * `reportWait` — each call replaces the previous wait status.
-   *
-   * `syntheticPrefix`, when nonempty, supplies a stable prompt-line key for
-   * implementations that synthesise a fresh prompt line for the wait (i.e.
-   * when the caller's logger has no preexisting prompt line). It is ignored
-   * when the wait can be attached as a detail to an existing line.
    */
   trait WaitReporter {
     def reportWait(message: String, syntheticPrefix: Seq[String] = Nil): AutoCloseable

--- a/core/api/daemon/src/mill/api/daemon/internal/LauncherLocking.scala
+++ b/core/api/daemon/src/mill/api/daemon/internal/LauncherLocking.scala
@@ -30,7 +30,7 @@ private[mill] trait LauncherLocking extends AutoCloseable {
    * read-then-write pattern in [[mill.internal.LockUpgrade.readThenWrite]]
    * work without poisoning the caller's own re-probe.
    */
-  def tryMetaBuildWriteLock(depth: Int): Either[String, LauncherLocking.Lease]
+  def tryMetaBuildWriteLock(depth: Int): Either[LauncherLocking.Contention, LauncherLocking.Lease]
 
   /**
    * Block on the meta-build lock at `depth` for up to `timeoutMs`,
@@ -60,7 +60,7 @@ private[mill] trait LauncherLocking extends AutoCloseable {
   def tryTaskWriteLock(
       path: Path,
       displayLabel: String
-  ): Either[String, LauncherLocking.Lease]
+  ): Either[LauncherLocking.Contention, LauncherLocking.Lease]
 
   /**
    * Bounded await on per-task lock state changes; counterpart of
@@ -105,6 +105,14 @@ private[mill] object LauncherLocking {
   }
 
   /**
+   * Description of why a non-blocking Write attempt failed: the
+   * human-readable wait message, the lock's bare label, and the
+   * synthetic prompt-line prefix the lock would like its `WaitReporter`
+   * to use when no preexisting prompt-line is available.
+   */
+  case class Contention(message: String, label: String, syntheticPrefix: Seq[String])
+
+  /**
    * Surface a "blocked on lock" status to the user when a lock acquisition has
    * to wait. Implementations should display the message in a way that doesn't
    * disturb the active console UI (e.g. via the multi-line prompt's detail
@@ -114,14 +122,18 @@ private[mill] object LauncherLocking {
    * `reportWait` — each call replaces the previous wait status.
    */
   trait WaitReporter {
-    def reportWait(message: String, syntheticPrefix: Seq[String] = Nil): AutoCloseable
+    def reportWait(
+        message: String,
+        label: String,
+        syntheticPrefix: Seq[String] = Nil
+    ): AutoCloseable
   }
 
   object WaitReporter {
     private val NoopToken: AutoCloseable = () => ()
 
     /** Discards wait events. Useful for tests and noBuildLock. */
-    val Noop: WaitReporter = (_: String, _: Seq[String]) => NoopToken
+    val Noop: WaitReporter = (_: String, _: String, _: Seq[String]) => NoopToken
 
     /**
      * Prints the wait message once on `reportWait` and does nothing on close.
@@ -129,10 +141,19 @@ private[mill] object LauncherLocking {
      * the user's terminal history. Used when no live prompt is available
      * (early bootstrap, no-daemon, BSP, `--ticker false`, etc.).
      */
-    def stderr(stream: PrintStream): WaitReporter = (msg: String, _: Seq[String]) => {
-      stream.println(msg)
-      NoopToken
-    }
+    def stderr(stream: PrintStream): WaitReporter =
+      (msg: String, label: String, _: Seq[String]) => {
+        stream.println(ensureLabel(msg, label))
+        NoopToken
+      }
+
+    /** Inject `'$label'` into `message` if not already present. */
+    def ensureLabel(message: String, label: String): String =
+      if (label.isEmpty || message.contains(s"'$label'")) message
+      else message.replaceFirst(
+        raw"^blocked on (read|write) lock",
+        s"blocked on $$1 lock '$label'"
+      )
   }
 
   object Noop extends LauncherLocking {

--- a/core/api/daemon/src/mill/api/daemon/internal/LauncherLocking.scala
+++ b/core/api/daemon/src/mill/api/daemon/internal/LauncherLocking.scala
@@ -105,10 +105,9 @@ private[mill] object LauncherLocking {
   }
 
   /**
-   * Description of why a non-blocking Write attempt failed: the
-   * human-readable wait message, the lock's bare label, and the
-   * synthetic prompt-line prefix the lock would like its `WaitReporter`
-   * to use when no preexisting prompt-line is available.
+   * Why a non-blocking Write attempt failed. Carries the values
+   * [[WaitReporter.reportWait]] needs so callers don't have to thread
+   * `label` and `syntheticPrefix` through alongside the lock.
    */
   case class Contention(message: String, label: String, syntheticPrefix: Seq[String])
 

--- a/core/api/daemon/src/mill/api/daemon/internal/LauncherLocking.scala
+++ b/core/api/daemon/src/mill/api/daemon/internal/LauncherLocking.scala
@@ -173,7 +173,7 @@ private[mill] object LauncherLocking {
         kind: LockKind,
         waitReporter: WaitReporter
     ): Lease = NoopLease
-    override def tryTaskWriteLock(path: Path, displayLabel: String): Either[String, Lease] =
+    override def tryTaskWriteLock(path: Path, displayLabel: String): Either[Contention, Lease] =
       Right(NoopLease)
     override def awaitTaskStateChange(path: Path, displayLabel: String, timeoutMs: Long): Unit = ()
     override def exclusiveLock(kind: LockKind, waitReporter: WaitReporter): Lease = NoopLease

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -298,7 +298,7 @@ trait GroupExecution {
 
         // Try-Write + bounded await for `LockUpgrade.readThenWrite`'s
         // retryable loop; mirrors `acquireTaskLock`'s input-task skip.
-        def tryWriteTaskLock(): Either[String, LauncherLocking.Lease] =
+        def tryWriteTaskLock(): Either[LauncherLocking.Contention, LauncherLocking.Lease] =
           if (labelled.isInputTask)
             LauncherLocking.Noop.tryTaskWriteLock(
               paths.dest.toNIO,
@@ -448,8 +448,7 @@ trait GroupExecution {
           acquireRead = acquireTaskLock(LauncherLocking.LockKind.Read),
           tryAcquireWrite = () => tryWriteTaskLock(),
           awaitStateChange = awaitTaskLockChange,
-          waitReporter = taskWaitReporter,
-          lockLabel = labelled.ctx.segments.render
+          waitReporter = taskWaitReporter
         )(_ => LockUpgrade.Decision.Escalate) { scope =>
           val (execRes, serializedPaths) =
             if (os.Path(labelled.ctx.fileName).endsWith("mill-build/build.mill")) {

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -362,8 +362,7 @@ trait GroupExecution {
             acquireRead = acquireTaskLock(LauncherLocking.LockKind.Read),
             tryAcquireWrite = () => tryWriteTaskLock(),
             awaitStateChange = awaitTaskLockChange,
-            waitReporter = taskWaitReporter,
-            lockLabel = labelled.ctx.segments.render
+            waitReporter = taskWaitReporter
           ) { scope =>
             loadCachedOrWorker(
               loadCachedJson(logger, inputsHash, labelled, paths),

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -362,7 +362,8 @@ trait GroupExecution {
             acquireRead = acquireTaskLock(LauncherLocking.LockKind.Read),
             tryAcquireWrite = () => tryWriteTaskLock(),
             awaitStateChange = awaitTaskLockChange,
-            waitReporter = taskWaitReporter
+            waitReporter = taskWaitReporter,
+            lockLabel = labelled.ctx.segments.render
           ) { scope =>
             loadCachedOrWorker(
               loadCachedJson(logger, inputsHash, labelled, paths),
@@ -448,7 +449,8 @@ trait GroupExecution {
           acquireRead = acquireTaskLock(LauncherLocking.LockKind.Read),
           tryAcquireWrite = () => tryWriteTaskLock(),
           awaitStateChange = awaitTaskLockChange,
-          waitReporter = taskWaitReporter
+          waitReporter = taskWaitReporter,
+          lockLabel = labelled.ctx.segments.render
         )(_ => LockUpgrade.Decision.Escalate) { scope =>
           val (execRes, serializedPaths) =
             if (os.Path(labelled.ctx.fileName).endsWith("mill-build/build.mill")) {

--- a/core/internal/src/mill/internal/BspLogger.scala
+++ b/core/internal/src/mill/internal/BspLogger.scala
@@ -34,6 +34,10 @@ class BspLogger(
     }
     override def enableTicker = true
 
+    // BSP stderr lines aren't prefixed with the lock-owning task's name, so
+    // PromptWaitReporter must keep the label in the wait message.
+    override def waitMessageNeedsLabel = true
+
     // Surface only the lock-wait subset of prompt-line/detail updates into
     // BSP-server stderr — `PromptWaitReporter` routes its "blocked on …"
     // messages through the prompt API even though BSP has no live prompt UI,

--- a/core/internal/src/mill/internal/BspLogger.scala
+++ b/core/internal/src/mill/internal/BspLogger.scala
@@ -35,7 +35,7 @@ class BspLogger(
     override def enableTicker = true
 
     // BSP stderr lines aren't prefixed with the lock-owning task's name, so
-    // PromptWaitReporter must keep the label in the wait message.
+    // `PromptWaitReporter` must keep the label in the wait message.
     override def waitMessageNeedsLabel = true
 
     // Surface only the lock-wait subset of prompt-line/detail updates into

--- a/core/internal/src/mill/internal/CrossThreadRwLock.scala
+++ b/core/internal/src/mill/internal/CrossThreadRwLock.scala
@@ -59,9 +59,7 @@ class CrossThreadRwLock(
         // Surface as MillException so MillMain0.handleMillException renders a
         // clean user-facing message instead of a stack trace; this is an
         // expected condition when --no-wait collides with another launcher.
-        // Force the label into the message: this exception bubbles up
-        // standalone, with no surrounding prompt-line prefix to identify
-        // the lock.
+        // Force the label inline — error has no prompt context.
         val msg = WaitReporter.ensureLabel(waitingMessage(currentBlocker(), kind), label)
         throw new MillException(s"$msg and --no-wait was set, failing")
       } else {

--- a/core/internal/src/mill/internal/CrossThreadRwLock.scala
+++ b/core/internal/src/mill/internal/CrossThreadRwLock.scala
@@ -59,9 +59,11 @@ class CrossThreadRwLock(
         // Surface as MillException so MillMain0.handleMillException renders a
         // clean user-facing message instead of a stack trace; this is an
         // expected condition when --no-wait collides with another launcher.
-        throw new MillException(
-          s"${waitingMessage(currentBlocker(), kind)} and --no-wait was set, failing"
-        )
+        // Force the label into the message: this exception bubbles up
+        // standalone, with no surrounding prompt-line prefix to identify
+        // the lock.
+        val msg = WaitReporter.ensureLabel(waitingMessage(currentBlocker(), kind), label)
+        throw new MillException(s"$msg and --no-wait was set, failing")
       } else {
         if (isWrite) waitingWriters += 1
         None

--- a/core/internal/src/mill/internal/CrossThreadRwLock.scala
+++ b/core/internal/src/mill/internal/CrossThreadRwLock.scala
@@ -35,7 +35,7 @@ class CrossThreadRwLock(
     val labelToken = if (showLabelInMessage) s" '$label'" else ""
     blocker match {
       case Some(h) =>
-        s"blocked on $kindStr lock$labelToken command '${h.command}' PID ${h.pid}"
+        s"blocked on $kindStr lock$labelToken PID ${h.pid} '${h.command}'"
       case None => s"blocked on $kindStr lock$labelToken"
     }
   }

--- a/core/internal/src/mill/internal/CrossThreadRwLock.scala
+++ b/core/internal/src/mill/internal/CrossThreadRwLock.scala
@@ -8,8 +8,23 @@ import mill.api.daemon.internal.LauncherLocking.{Lease, LockKind, WaitReporter}
  * and released on separate threads. `label` is the human-readable name used in
  * waiting/blocking messages; uniqueness across locks is the registry's
  * responsibility (e.g. [[LauncherLockRegistry]]'s map key), not the lock's.
+ *
+ * `showLabelInMessage` keeps the `'$label'` token in the "blocked on …" string
+ * for locks whose identity isn't already obvious from the surrounding prompt
+ * context (e.g. the daemon-wide `exclusive` lock); set it `false` for per-task
+ * and per-meta-build locks whose label would just duplicate the prompt-line
+ * prefix the user is already seeing.
+ *
+ * `syntheticPrefix` is forwarded to [[LauncherLocking.WaitReporter.reportWait]]
+ * so a wait that has to fabricate its own prompt line (no preexisting line to
+ * attach to) can use a meaningful prefix like `mill-build/build.mill` instead
+ * of an opaque `wait-N`.
  */
-class CrossThreadRwLock(label: String) {
+class CrossThreadRwLock(
+    label: String,
+    showLabelInMessage: Boolean = true,
+    syntheticPrefix: Seq[String] = Nil
+) {
   import CrossThreadRwLock.HolderInfo
 
   private val monitor = new Object
@@ -28,10 +43,11 @@ class CrossThreadRwLock(label: String) {
 
   private def waitingMessage(blocker: Option[HolderInfo], kind: LockKind): String = {
     val kindStr = kind match { case LockKind.Read => "read"; case LockKind.Write => "write" }
+    val labelToken = if (showLabelInMessage) s" '$label'" else ""
     blocker match {
       case Some(h) =>
-        s"blocked on $kindStr lock '$label' command '${h.command}' PID ${h.pid}"
-      case None => s"blocked on $kindStr lock '$label'"
+        s"blocked on $kindStr lock$labelToken command '${h.command}' PID ${h.pid}"
+      case None => s"blocked on $kindStr lock$labelToken"
     }
   }
 
@@ -65,7 +81,8 @@ class CrossThreadRwLock(label: String) {
 
     leaseOpt.getOrElse {
       val blocker = monitor.synchronized(currentBlocker())
-      val waitToken = waitReporter.reportWait(waitingMessage(blocker, kind))
+      val waitToken =
+        waitReporter.reportWait(waitingMessage(blocker, kind), syntheticPrefix)
 
       try {
         monitor.synchronized {

--- a/core/internal/src/mill/internal/CrossThreadRwLock.scala
+++ b/core/internal/src/mill/internal/CrossThreadRwLock.scala
@@ -8,17 +8,6 @@ import mill.api.daemon.internal.LauncherLocking.{Lease, LockKind, WaitReporter}
  * and released on separate threads. `label` is the human-readable name used in
  * waiting/blocking messages; uniqueness across locks is the registry's
  * responsibility (e.g. [[LauncherLockRegistry]]'s map key), not the lock's.
- *
- * `showLabelInMessage` keeps the `'$label'` token in the "blocked on …" string
- * for locks whose identity isn't already obvious from the surrounding prompt
- * context (e.g. the daemon-wide `exclusive` lock); set it `false` for per-task
- * and per-meta-build locks whose label would just duplicate the prompt-line
- * prefix the user is already seeing.
- *
- * `syntheticPrefix` is forwarded to [[LauncherLocking.WaitReporter.reportWait]]
- * so a wait that has to fabricate its own prompt line (no preexisting line to
- * attach to) can use a meaningful prefix like `mill-build/build.mill` instead
- * of an opaque `wait-N`.
  */
 class CrossThreadRwLock(
     label: String,

--- a/core/internal/src/mill/internal/CrossThreadRwLock.scala
+++ b/core/internal/src/mill/internal/CrossThreadRwLock.scala
@@ -1,7 +1,7 @@
 package mill.internal
 
 import mill.api.MillException
-import mill.api.daemon.internal.LauncherLocking.{Lease, LockKind, WaitReporter}
+import mill.api.daemon.internal.LauncherLocking.{Contention, Lease, LockKind, WaitReporter}
 
 /**
  * A version of [[java.util.concurrent.locks.ReadWriteLock]] that can be acquired
@@ -71,7 +71,7 @@ class CrossThreadRwLock(
     leaseOpt.getOrElse {
       val blocker = monitor.synchronized(currentBlocker())
       val waitToken =
-        waitReporter.reportWait(waitingMessage(blocker, kind), syntheticPrefix)
+        waitReporter.reportWait(waitingMessage(blocker, kind), label, syntheticPrefix)
 
       try {
         monitor.synchronized {
@@ -115,13 +115,17 @@ class CrossThreadRwLock(
    * fall back to Read, and re-probe shared state without poisoning its
    * own next Read attempt.
    */
-  def tryAcquireWrite(acquirer: HolderInfo): Either[String, Lease] = monitor.synchronized {
+  def tryAcquireWrite(acquirer: HolderInfo): Either[Contention, Lease] = monitor.synchronized {
     if (canAcquireWrite) {
       writerActive = true
       val lease = newLease(initiallyWrite = true)
       holders.put(lease, acquirer)
       Right(lease)
-    } else Left(waitingMessage(currentBlocker(), LockKind.Write))
+    } else Left(Contention(
+      waitingMessage(currentBlocker(), LockKind.Write),
+      label,
+      syntheticPrefix
+    ))
   }
 
   /**

--- a/core/internal/src/mill/internal/LauncherLockRegistry.scala
+++ b/core/internal/src/mill/internal/LauncherLockRegistry.scala
@@ -16,8 +16,7 @@ private[mill] class LauncherLockRegistry {
   // are taken by every normal task batch (and by plain `exclusive` commands) so they share
   // freely; write leases are taken by globally-exclusive command batches
   // (`Task.Command(globalExclusive = true)`, e.g. `clean`) so they run alone across all
-  // launchers. `'exclusive'` is kept in wait messages because this lock applies to any
-  // task, so the surrounding prompt context can't identify it on its own.
+  // launchers.
   val exclusiveLock: CrossThreadRwLock =
     new CrossThreadRwLock(label = "exclusive", showLabelInMessage = true)
 
@@ -27,8 +26,6 @@ private[mill] class LauncherLockRegistry {
       LauncherLockRegistry.makeMetaBuildLock
     )
 
-  // The display label is the task name, which is already shown as the prompt-line
-  // prefix immediately above the wait detail; suppressing it avoids duplication.
   def taskLockFor(
       normalizedAbsolutePath: String,
       displayLabel: String
@@ -40,6 +37,16 @@ private[mill] class LauncherLockRegistry {
 }
 
 private[mill] object LauncherLockRegistry {
+
+  private val makeMetaBuildLock: java.util.function.Function[Int, CrossThreadRwLock] =
+    (depth: Int) => {
+      val label = metaBuildLabel(depth)
+      new CrossThreadRwLock(
+        label = label,
+        showLabelInMessage = false,
+        syntheticPrefix = Seq(label)
+      )
+    }
 
   /**
    * Mirror the meta-build prompt-line prefix used by `MillBuildBootstrap`'s
@@ -54,16 +61,6 @@ private[mill] object LauncherLockRegistry {
    * `build.mill` here keeps the lock label readable without needing to
    * thread the actual filename through the lock registry.
    */
-  // The label is promoted to the synthetic prompt-line prefix, so it would only
-  // duplicate if also embedded in the wait message itself.
-  private val makeMetaBuildLock: java.util.function.Function[Int, CrossThreadRwLock] =
-    (depth: Int) => {
-      val label =
-        (Seq.fill(depth)(OutFiles.millBuild) :+ "build.mill").mkString("/")
-      new CrossThreadRwLock(
-        label = label,
-        showLabelInMessage = false,
-        syntheticPrefix = Seq(label)
-      )
-    }
+  def metaBuildLabel(depth: Int): String =
+    (Seq.fill(depth)(OutFiles.millBuild) :+ "build.mill").mkString("/")
 }

--- a/core/internal/src/mill/internal/LauncherLockRegistry.scala
+++ b/core/internal/src/mill/internal/LauncherLockRegistry.scala
@@ -39,35 +39,33 @@ private[mill] class LauncherLockRegistry {
 private[mill] object LauncherLockRegistry {
 
   private val makeMetaBuildLock: java.util.function.Function[Int, CrossThreadRwLock] =
-    (depth: Int) =>
+    (depth: Int) => {
+      val prefix = metaBuildPromptPrefix(depth)
       new CrossThreadRwLock(
-        label = metaBuildLabel(depth),
+        label = prefix.headOption.getOrElse(""),
         showLabelInMessage = false,
-        syntheticPrefix = metaBuildPromptPrefix(depth)
+        syntheticPrefix = prefix
       )
+    }
 
   /**
-   * Build-file path relative to the project root, used as the lock's
-   * human-readable label in `--no-wait` errors and BSP wait messages:
-   *   - depth 0: `build.mill`               (the user-level project)
-   *   - depth 1: `mill-build/build.mill`
-   *   - depth N: `mill-build/.../mill-build/build.mill` (N segments)
+   * Mirror `MillBuildBootstrap.bootLogPrefix(depth)` so wait messages and
+   * synthetic prompt lines reference each meta-build by the same name the
+   * user already sees in the multi-line prompt:
+   *   - depth 0: `Nil`                            (user-level project, no prefix)
+   *   - depth 1: `Seq("build.mill")`
+   *   - depth 2: `Seq("mill-build/build.mill")`
+   *   - depth N: one element with `(N-1)` `mill-build` segments + `build.mill`
+   *
+   * Used for both the lock's `syntheticPrefix` (prompt-line key) and as
+   * the source of its bare `label` (via `headOption`). The `Nil` case
+   * yields an empty label, which `WaitReporter.ensureLabel` short-circuits
+   * cleanly — depth 0 has no `mill-build/` chain to identify it anyway.
    *
    * The exact build-file name (`build.mill` vs `build.mill.yaml`) varies
    * per project but is fixed for one daemon — using the canonical
    * `build.mill` here keeps the label readable without needing to thread
    * the actual filename through the lock registry.
-   */
-  def metaBuildLabel(depth: Int): String =
-    (Seq.fill(depth)(OutFiles.millBuild) :+ "build.mill").mkString("/")
-
-  /**
-   * Mirror `MillBuildBootstrap.bootLogPrefix(depth)` exactly so a synthetic
-   * wait line at this depth reuses the same prompt-line prefix the active
-   * launcher's tasks at the same depth are already showing:
-   *   - depth 0: `Nil`                     (user-level tasks have no prefix)
-   *   - depth 1: `Seq("build.mill")`
-   *   - depth 2: `Seq("mill-build/build.mill")` (one fewer mill-build segment than [[metaBuildLabel]])
    */
   def metaBuildPromptPrefix(depth: Int): Seq[String] =
     if (depth == 0) Nil

--- a/core/internal/src/mill/internal/LauncherLockRegistry.scala
+++ b/core/internal/src/mill/internal/LauncherLockRegistry.scala
@@ -16,8 +16,10 @@ private[mill] class LauncherLockRegistry {
   // are taken by every normal task batch (and by plain `exclusive` commands) so they share
   // freely; write leases are taken by globally-exclusive command batches
   // (`Task.Command(globalExclusive = true)`, e.g. `clean`) so they run alone across all
-  // launchers.
-  val exclusiveLock: CrossThreadRwLock = new CrossThreadRwLock(label = "exclusive")
+  // launchers. `'exclusive'` is kept in wait messages because this lock applies to any
+  // task, so the surrounding prompt context can't identify it on its own.
+  val exclusiveLock: CrossThreadRwLock =
+    new CrossThreadRwLock(label = "exclusive", showLabelInMessage = true)
 
   def metaBuildLockFor(depth: Int): CrossThreadRwLock =
     metaBuildLocks.computeIfAbsent(
@@ -25,13 +27,15 @@ private[mill] class LauncherLockRegistry {
       LauncherLockRegistry.makeMetaBuildLock
     )
 
+  // The display label is the task name, which is already shown as the prompt-line
+  // prefix immediately above the wait detail; suppressing it avoids duplication.
   def taskLockFor(
       normalizedAbsolutePath: String,
       displayLabel: String
   ): CrossThreadRwLock =
     taskLocks.computeIfAbsent(
       normalizedAbsolutePath,
-      _ => new CrossThreadRwLock(label = displayLabel)
+      _ => new CrossThreadRwLock(label = displayLabel, showLabelInMessage = false)
     )
 }
 
@@ -50,10 +54,16 @@ private[mill] object LauncherLockRegistry {
    * `build.mill` here keeps the lock label readable without needing to
    * thread the actual filename through the lock registry.
    */
+  // The label is promoted to the synthetic prompt-line prefix, so it would only
+  // duplicate if also embedded in the wait message itself.
   private val makeMetaBuildLock: java.util.function.Function[Int, CrossThreadRwLock] =
     (depth: Int) => {
       val label =
         (Seq.fill(depth)(OutFiles.millBuild) :+ "build.mill").mkString("/")
-      new CrossThreadRwLock(label = label)
+      new CrossThreadRwLock(
+        label = label,
+        showLabelInMessage = false,
+        syntheticPrefix = Seq(label)
+      )
     }
 }

--- a/core/internal/src/mill/internal/LauncherLockRegistry.scala
+++ b/core/internal/src/mill/internal/LauncherLockRegistry.scala
@@ -39,28 +39,37 @@ private[mill] class LauncherLockRegistry {
 private[mill] object LauncherLockRegistry {
 
   private val makeMetaBuildLock: java.util.function.Function[Int, CrossThreadRwLock] =
-    (depth: Int) => {
-      val label = metaBuildLabel(depth)
+    (depth: Int) =>
       new CrossThreadRwLock(
-        label = label,
+        label = metaBuildLabel(depth),
         showLabelInMessage = false,
-        syntheticPrefix = Seq(label)
+        syntheticPrefix = metaBuildPromptPrefix(depth)
       )
-    }
 
   /**
-   * Mirror the meta-build prompt-line prefix used by `MillBuildBootstrap`'s
-   * `bootLogPrefix`, so wait messages reference the build file by the same
-   * name the user already sees in the multi-line prompt:
-   *   - depth 0: `build.mill`         (the user-level project)
+   * Build-file path relative to the project root, used as the lock's
+   * human-readable label in `--no-wait` errors and BSP wait messages:
+   *   - depth 0: `build.mill`               (the user-level project)
    *   - depth 1: `mill-build/build.mill`
    *   - depth N: `mill-build/.../mill-build/build.mill` (N segments)
    *
    * The exact build-file name (`build.mill` vs `build.mill.yaml`) varies
    * per project but is fixed for one daemon — using the canonical
-   * `build.mill` here keeps the lock label readable without needing to
-   * thread the actual filename through the lock registry.
+   * `build.mill` here keeps the label readable without needing to thread
+   * the actual filename through the lock registry.
    */
   def metaBuildLabel(depth: Int): String =
     (Seq.fill(depth)(OutFiles.millBuild) :+ "build.mill").mkString("/")
+
+  /**
+   * Mirror `MillBuildBootstrap.bootLogPrefix(depth)` exactly so a synthetic
+   * wait line at this depth reuses the same prompt-line prefix the active
+   * launcher's tasks at the same depth are already showing:
+   *   - depth 0: `Nil`                     (user-level tasks have no prefix)
+   *   - depth 1: `Seq("build.mill")`
+   *   - depth 2: `Seq("mill-build/build.mill")` (one fewer mill-build segment than [[metaBuildLabel]])
+   */
+  def metaBuildPromptPrefix(depth: Int): Seq[String] =
+    if (depth == 0) Nil
+    else Seq((Seq.fill(depth - 1)(OutFiles.millBuild) :+ "build.mill").mkString("/"))
 }

--- a/core/internal/src/mill/internal/LauncherLockRegistry.scala
+++ b/core/internal/src/mill/internal/LauncherLockRegistry.scala
@@ -18,7 +18,11 @@ private[mill] class LauncherLockRegistry {
   // (`Task.Command(globalExclusive = true)`, e.g. `clean`) so they run alone across all
   // launchers.
   val exclusiveLock: CrossThreadRwLock =
-    new CrossThreadRwLock(label = "exclusive", showLabelInMessage = true)
+    new CrossThreadRwLock(
+      label = "exclusive",
+      showLabelInMessage = true,
+      syntheticPrefix = Seq("exclusive-lock")
+    )
 
   def metaBuildLockFor(depth: Int): CrossThreadRwLock =
     metaBuildLocks.computeIfAbsent(

--- a/core/internal/src/mill/internal/LauncherLockRegistry.scala
+++ b/core/internal/src/mill/internal/LauncherLockRegistry.scala
@@ -49,18 +49,13 @@ private[mill] object LauncherLockRegistry {
     }
 
   /**
-   * Mirror `MillBuildBootstrap.bootLogPrefix(depth)` so wait messages and
-   * synthetic prompt lines reference each meta-build by the same name the
+   * Mirrors `MillBuildBootstrap.bootLogPrefix(depth)` so wait messages and
+   * synthetic prompt-line keys reference each meta-build by the name the
    * user already sees in the multi-line prompt:
-   *   - depth 0: `Nil`                            (user-level project, no prefix)
+   *   - depth 0: `Nil`                         (user-level project, no prefix)
    *   - depth 1: `Seq("build.mill")`
    *   - depth 2: `Seq("mill-build/build.mill")`
-   *   - depth N: one element with `(N-1)` `mill-build` segments + `build.mill`
-   *
-   * Used for both the lock's `syntheticPrefix` (prompt-line key) and as
-   * the source of its bare `label` (via `headOption`). The `Nil` case
-   * yields an empty label, which `WaitReporter.ensureLabel` short-circuits
-   * cleanly — depth 0 has no `mill-build/` chain to identify it anyway.
+   *   - depth N: `(N-1)` `mill-build` segments + `build.mill`
    *
    * The exact build-file name (`build.mill` vs `build.mill.yaml`) varies
    * per project but is fixed for one daemon — using the canonical

--- a/core/internal/src/mill/internal/LauncherLockingImpl.scala
+++ b/core/internal/src/mill/internal/LauncherLockingImpl.scala
@@ -50,7 +50,8 @@ private[mill] class LauncherLockingImpl(
     ))
   }
 
-  override def tryMetaBuildWriteLock(depth: Int): Either[String, LauncherLocking.Lease] = {
+  override def tryMetaBuildWriteLock(depth: Int)
+      : Either[LauncherLocking.Contention, LauncherLocking.Lease] = {
     ensureOpen()
     if (noBuildLock) LauncherLocking.Noop.tryMetaBuildWriteLock(depth)
     else lockRegistry.metaBuildLockFor(depth).tryAcquireWrite(holder).map(acquireManagedLease)
@@ -82,7 +83,7 @@ private[mill] class LauncherLockingImpl(
   override def tryTaskWriteLock(
       path: java.nio.file.Path,
       displayLabel: String
-  ): Either[String, LauncherLocking.Lease] = {
+  ): Either[LauncherLocking.Contention, LauncherLocking.Lease] = {
     ensureOpen()
     if (noBuildLock || exclusiveWriteCount.get() > 0)
       LauncherLocking.Noop.tryTaskWriteLock(path, displayLabel)

--- a/core/internal/src/mill/internal/LockUpgrade.scala
+++ b/core/internal/src/mill/internal/LockUpgrade.scala
@@ -60,13 +60,18 @@ object LockUpgrade {
    * (i.e., must not increment any waiter counter that gates Read
    * acquisition); otherwise the caller's own next Read attempt would
    * trip writer-priority and the retry loop would stall.
+   *
+   * `syntheticPrefix` is forwarded to `waitReporter.reportWait` so a session-
+   * level wait (no preexisting prompt line to attach to) can fabricate one
+   * with a meaningful prefix instead of a `wait-N` placeholder.
    */
   def readThenWrite[T](
       acquireRead: => LauncherLocking.Lease,
       tryAcquireWrite: () => Either[String, LauncherLocking.Lease],
       awaitStateChange: Long => Unit,
       waitReporter: LauncherLocking.WaitReporter,
-      awaitTimeoutMs: Long = 1000L
+      awaitTimeoutMs: Long = 1000L,
+      syntheticPrefix: Seq[String] = Nil
   )(
       readBody: Scope => Decision[T]
   )(
@@ -124,7 +129,8 @@ object LockUpgrade {
                     throw t
                 }
               case Left(blockMsg) =>
-                if (waitToken == null) waitToken = waitReporter.reportWait(blockMsg)
+                if (waitToken == null)
+                  waitToken = waitReporter.reportWait(blockMsg, syntheticPrefix)
                 awaitStateChange(awaitTimeoutMs)
                 loop()
             }

--- a/core/internal/src/mill/internal/LockUpgrade.scala
+++ b/core/internal/src/mill/internal/LockUpgrade.scala
@@ -123,9 +123,9 @@ object LockUpgrade {
                     writeScope.closeAlways()
                     throw t
                 }
-              case Left(c) =>
+              case Left(LauncherLocking.Contention(message, label, syntheticPrefix)) =>
                 if (waitToken == null)
-                  waitToken = waitReporter.reportWait(c.message, c.label, c.syntheticPrefix)
+                  waitToken = waitReporter.reportWait(message, label, syntheticPrefix)
                 awaitStateChange(awaitTimeoutMs)
                 loop()
             }

--- a/core/internal/src/mill/internal/LockUpgrade.scala
+++ b/core/internal/src/mill/internal/LockUpgrade.scala
@@ -70,6 +70,7 @@ object LockUpgrade {
       tryAcquireWrite: () => Either[String, LauncherLocking.Lease],
       awaitStateChange: Long => Unit,
       waitReporter: LauncherLocking.WaitReporter,
+      lockLabel: String,
       awaitTimeoutMs: Long = 1000L,
       syntheticPrefix: Seq[String] = Nil
   )(
@@ -130,7 +131,7 @@ object LockUpgrade {
                 }
               case Left(blockMsg) =>
                 if (waitToken == null)
-                  waitToken = waitReporter.reportWait(blockMsg, syntheticPrefix)
+                  waitToken = waitReporter.reportWait(blockMsg, lockLabel, syntheticPrefix)
                 awaitStateChange(awaitTimeoutMs)
                 loop()
             }

--- a/core/internal/src/mill/internal/LockUpgrade.scala
+++ b/core/internal/src/mill/internal/LockUpgrade.scala
@@ -60,19 +60,13 @@ object LockUpgrade {
    * (i.e., must not increment any waiter counter that gates Read
    * acquisition); otherwise the caller's own next Read attempt would
    * trip writer-priority and the retry loop would stall.
-   *
-   * `syntheticPrefix` is forwarded to `waitReporter.reportWait` so a session-
-   * level wait (no preexisting prompt line to attach to) can fabricate one
-   * with a meaningful prefix instead of a `wait-N` placeholder.
    */
   def readThenWrite[T](
       acquireRead: => LauncherLocking.Lease,
-      tryAcquireWrite: () => Either[String, LauncherLocking.Lease],
+      tryAcquireWrite: () => Either[LauncherLocking.Contention, LauncherLocking.Lease],
       awaitStateChange: Long => Unit,
       waitReporter: LauncherLocking.WaitReporter,
-      lockLabel: String,
-      awaitTimeoutMs: Long = 1000L,
-      syntheticPrefix: Seq[String] = Nil
+      awaitTimeoutMs: Long = 1000L
   )(
       readBody: Scope => Decision[T]
   )(
@@ -129,9 +123,9 @@ object LockUpgrade {
                     writeScope.closeAlways()
                     throw t
                 }
-              case Left(blockMsg) =>
+              case Left(c) =>
                 if (waitToken == null)
-                  waitToken = waitReporter.reportWait(blockMsg, lockLabel, syntheticPrefix)
+                  waitToken = waitReporter.reportWait(c.message, c.label, c.syntheticPrefix)
                 awaitStateChange(awaitTimeoutMs)
                 loop()
             }

--- a/core/internal/src/mill/internal/PromptWaitReporter.scala
+++ b/core/internal/src/mill/internal/PromptWaitReporter.scala
@@ -59,5 +59,4 @@ object PromptWaitReporter {
         }
       }
     }
-
 }

--- a/core/internal/src/mill/internal/PromptWaitReporter.scala
+++ b/core/internal/src/mill/internal/PromptWaitReporter.scala
@@ -45,10 +45,7 @@ object PromptWaitReporter {
           () => prompt.setPromptDetail(baseKey, "")
         } else {
           // Session logger has no prompt-line — synthesise one or the
-          // wait detail has nothing to attach to. Prefer a lock-supplied
-          // prefix (e.g. `mill-build/build.mill`) over an opaque `wait-N`
-          // so the user can read what they're blocked on without the
-          // message also having to repeat the lock identity.
+          // wait detail has nothing to attach to.
           val syntheticKey =
             if (syntheticPrefix.nonEmpty) syntheticPrefix
             else Seq("wait-" + syntheticCounter.incrementAndGet())
@@ -56,5 +53,26 @@ object PromptWaitReporter {
           () => prompt.removePromptLine(syntheticKey, msg)
         }
       }
+    }
+
+  /**
+   * BSP-side wait reporter: BSP has no live prompt UI, so route every wait to
+   * stderr as a single line that names the lock label even when the lock is
+   * configured to suppress it for prompt usage. The prompt-line task-name
+   * prefix that ordinarily makes the label redundant doesn't exist here.
+   */
+  def stderrWithLabel(stream: PrintStream, label: String): WaitReporter =
+    (msg: String, _: Seq[String]) => {
+      stream.println(injectLabel(msg, label))
+      () => ()
+    }
+
+  private val lockMsgWithoutLabel =
+    raw"^(blocked on (?:read|write) lock)( command .*| ?$$)".r
+
+  private def injectLabel(msg: String, label: String): String =
+    lockMsgWithoutLabel.findFirstMatchIn(msg) match {
+      case Some(m) => s"${m.group(1)} '$label'${m.group(2)}"
+      case None => msg
     }
 }

--- a/core/internal/src/mill/internal/PromptWaitReporter.scala
+++ b/core/internal/src/mill/internal/PromptWaitReporter.scala
@@ -40,9 +40,7 @@ object PromptWaitReporter {
       val prompt = logger.prompt
       val baseKey = logger.logKey
       (msg: String, label: String, syntheticPrefix: Seq[String]) => {
-        // The label can be omitted from the message when some surrounding
-        // prompt context (the existing line's prefix or a synthetic-line
-        // prefix) already names the lock; otherwise inject it.
+        // Avoid duplicating the label when the surrounding prefix already shows it.
         val prefixCarriesLabel = baseKey.nonEmpty || syntheticPrefix.nonEmpty
         val displayMsg =
           if (prefixCarriesLabel && !prompt.waitMessageNeedsLabel) msg
@@ -51,6 +49,8 @@ object PromptWaitReporter {
           prompt.setPromptDetail(baseKey, displayMsg)
           () => prompt.setPromptDetail(baseKey, "")
         } else {
+          // Session logger has no prompt-line — synthesise one or the
+          // wait detail has nothing to attach to.
           val syntheticKey =
             if (syntheticPrefix.nonEmpty) syntheticPrefix
             else Seq("wait-" + syntheticCounter.incrementAndGet())

--- a/core/internal/src/mill/internal/PromptWaitReporter.scala
+++ b/core/internal/src/mill/internal/PromptWaitReporter.scala
@@ -39,40 +39,25 @@ object PromptWaitReporter {
     else {
       val prompt = logger.prompt
       val baseKey = logger.logKey
-      (msg: String, syntheticPrefix: Seq[String]) => {
+      (msg: String, label: String, syntheticPrefix: Seq[String]) => {
+        // The label can be omitted from the message when some surrounding
+        // prompt context (the existing line's prefix or a synthetic-line
+        // prefix) already names the lock; otherwise inject it.
+        val prefixCarriesLabel = baseKey.nonEmpty || syntheticPrefix.nonEmpty
+        val displayMsg =
+          if (prefixCarriesLabel && !prompt.waitMessageNeedsLabel) msg
+          else WaitReporter.ensureLabel(msg, label)
         if (baseKey.nonEmpty) {
-          prompt.setPromptDetail(baseKey, msg)
+          prompt.setPromptDetail(baseKey, displayMsg)
           () => prompt.setPromptDetail(baseKey, "")
         } else {
-          // Session logger has no prompt-line — synthesise one or the
-          // wait detail has nothing to attach to.
           val syntheticKey =
             if (syntheticPrefix.nonEmpty) syntheticPrefix
             else Seq("wait-" + syntheticCounter.incrementAndGet())
-          prompt.setPromptLine(syntheticKey, "", msg)
-          () => prompt.removePromptLine(syntheticKey, msg)
+          prompt.setPromptLine(syntheticKey, "", displayMsg)
+          () => prompt.removePromptLine(syntheticKey, displayMsg)
         }
       }
     }
 
-  /**
-   * BSP-side wait reporter: BSP has no live prompt UI, so route every wait to
-   * stderr as a single line that names the lock label even when the lock is
-   * configured to suppress it for prompt usage. The prompt-line task-name
-   * prefix that ordinarily makes the label redundant doesn't exist here.
-   */
-  def stderrWithLabel(stream: PrintStream, label: String): WaitReporter =
-    (msg: String, _: Seq[String]) => {
-      stream.println(injectLabel(msg, label))
-      () => ()
-    }
-
-  private val lockMsgWithoutLabel =
-    raw"^(blocked on (?:read|write) lock)( command .*| ?$$)".r
-
-  private def injectLabel(msg: String, label: String): String =
-    lockMsgWithoutLabel.findFirstMatchIn(msg) match {
-      case Some(m) => s"${m.group(1)} '$label'${m.group(2)}"
-      case None => msg
-    }
 }

--- a/core/internal/src/mill/internal/PromptWaitReporter.scala
+++ b/core/internal/src/mill/internal/PromptWaitReporter.scala
@@ -39,14 +39,19 @@ object PromptWaitReporter {
     else {
       val prompt = logger.prompt
       val baseKey = logger.logKey
-      (msg: String) => {
+      (msg: String, syntheticPrefix: Seq[String]) => {
         if (baseKey.nonEmpty) {
           prompt.setPromptDetail(baseKey, msg)
           () => prompt.setPromptDetail(baseKey, "")
         } else {
           // Session logger has no prompt-line — synthesise one or the
-          // wait detail has nothing to attach to.
-          val syntheticKey = Seq("wait-" + syntheticCounter.incrementAndGet())
+          // wait detail has nothing to attach to. Prefer a lock-supplied
+          // prefix (e.g. `mill-build/build.mill`) over an opaque `wait-N`
+          // so the user can read what they're blocked on without the
+          // message also having to repeat the lock identity.
+          val syntheticKey =
+            if (syntheticPrefix.nonEmpty) syntheticPrefix
+            else Seq("wait-" + syntheticCounter.incrementAndGet())
           prompt.setPromptLine(syntheticKey, "", msg)
           () => prompt.removePromptLine(syntheticKey, msg)
         }

--- a/core/internal/test/src/mill/internal/CrossThreadRwLockTests.scala
+++ b/core/internal/test/src/mill/internal/CrossThreadRwLockTests.scala
@@ -387,9 +387,7 @@ object CrossThreadRwLockTests extends TestSuite {
 
       assertEventually(waitingBytes.size() > 0)
       val msg = waitingBytes.toString
-      assert(msg.contains("PID 9876 'blockerTask'"))
-      assert(msg.contains("'holder-naming'"))
-      assert(msg.contains("blocked on write lock"))
+      assert(msg.contains("blocked on write lock 'holder-naming' PID 9876 'blockerTask'"))
 
       firstLease.close()
       assert(secondAcquired.await(5, TimeUnit.SECONDS))
@@ -471,9 +469,9 @@ object CrossThreadRwLockTests extends TestSuite {
         } catch {
           case e: Exception => e
         }
-      assert(ex.getMessage.contains("PID 7777 'blockerCmd'"))
-      assert(ex.getMessage.contains("'no-wait'"))
-      assert(ex.getMessage.contains("--no-wait"))
+      assert(ex.getMessage.contains(
+        "blocked on write lock 'no-wait' PID 7777 'blockerCmd' and --no-wait was set, failing"
+      ))
 
       first.close()
     }
@@ -516,10 +514,8 @@ object CrossThreadRwLockTests extends TestSuite {
 
       assertEventually(waitingBytes.size() > 0)
       val msg = waitingBytes.toString
-      assert(msg.contains("command 'stillHoldingCmd'"))
-      assert(msg.contains("'stale-last-holder'"))
-      assert(msg.contains("PID 1111"))
-      assert(!msg.contains("command 'alreadyReleasedCmd'"))
+      assert(msg.contains("blocked on write lock 'stale-last-holder' PID 1111 'stillHoldingCmd'"))
+      assert(!msg.contains("'alreadyReleasedCmd'"))
       assert(!msg.contains("PID 2222"))
 
       firstReader.close()

--- a/core/internal/test/src/mill/internal/CrossThreadRwLockTests.scala
+++ b/core/internal/test/src/mill/internal/CrossThreadRwLockTests.scala
@@ -387,9 +387,8 @@ object CrossThreadRwLockTests extends TestSuite {
 
       assertEventually(waitingBytes.size() > 0)
       val msg = waitingBytes.toString
-      assert(msg.contains("command 'blockerTask'"))
+      assert(msg.contains("PID 9876 'blockerTask'"))
       assert(msg.contains("'holder-naming'"))
-      assert(msg.contains("PID 9876"))
       assert(msg.contains("blocked on write lock"))
 
       firstLease.close()
@@ -472,9 +471,8 @@ object CrossThreadRwLockTests extends TestSuite {
         } catch {
           case e: Exception => e
         }
-      assert(ex.getMessage.contains("command 'blockerCmd'"))
+      assert(ex.getMessage.contains("PID 7777 'blockerCmd'"))
       assert(ex.getMessage.contains("'no-wait'"))
-      assert(ex.getMessage.contains("PID 7777"))
       assert(ex.getMessage.contains("--no-wait"))
 
       first.close()

--- a/integration/dedicated/bsp-concurrency/src/BspConcurrencyTests.scala
+++ b/integration/dedicated/bsp-concurrency/src/BspConcurrencyTests.scala
@@ -128,8 +128,8 @@ object BspConcurrencyTests extends UtestIntegrationTestSuite {
           cliLauncherOpt = Some(cliLauncher)
           assertEventually {
             val errText = cliLauncher.err.text()
-            (errText.contains("blocked on read lock 'gated.sources' command 'BSP:") ||
-              errText.contains("blocked on write lock 'gated.sources' command 'BSP:")) &&
+            (errText.contains("blocked on read lock command 'BSP:") ||
+              errText.contains("blocked on write lock command 'BSP:")) &&
             errText.contains(s"PID $bspPid")
           }
           assert(cliLauncher.process.isAlive())

--- a/integration/dedicated/bsp-concurrency/src/BspConcurrencyTests.scala
+++ b/integration/dedicated/bsp-concurrency/src/BspConcurrencyTests.scala
@@ -18,9 +18,9 @@ import scala.jdk.CollectionConverters.*
  * shared output directory. They assert on the *fine-grained* lock messages
  * that surface to whichever side is waiting:
  *
- *   - CLI side: "blocked on <kind> lock '<task>' command 'BSP:<endpoint>' PID <bspPid>"
+ *   - CLI side: "blocked on <kind> lock '<task>' PID <bspPid> 'BSP:<endpoint>'"
  *     appears in the launcher's stderr when BSP holds a task lock.
- *   - BSP side: the same shape with `command '<cliCommand>' PID <cliPid>`
+ *   - BSP side: the same shape with `PID <cliPid> '<cliCommand>'`
  *     appears in the daemon-side BSP server stderr when CLI holds a task lock.
  *
  * The tests rely on `gated.compile` parking on a workspace-relative gate file
@@ -128,9 +128,8 @@ object BspConcurrencyTests extends UtestIntegrationTestSuite {
           cliLauncherOpt = Some(cliLauncher)
           assertEventually {
             val errText = cliLauncher.err.text()
-            (errText.contains("blocked on read lock 'gated.sources' command 'BSP:") ||
-              errText.contains("blocked on write lock 'gated.sources' command 'BSP:")) &&
-            errText.contains(s"PID $bspPid")
+            (errText.contains(s"blocked on read lock 'gated.sources' PID $bspPid 'BSP:") ||
+            errText.contains(s"blocked on write lock 'gated.sources' PID $bspPid 'BSP:"))
           }
           assert(cliLauncher.process.isAlive())
 
@@ -185,11 +184,8 @@ object BspConcurrencyTests extends UtestIntegrationTestSuite {
 
           assertEventually {
             val text = bspStderr.toString
-            (text.contains("blocked on read lock 'exclusive' command 'runGatedExclusive'") ||
-              text.contains(
-                "blocked on write lock 'exclusive' command 'runGatedExclusive'"
-              )) &&
-            text.contains(s"PID $cliPid")
+            text.contains(s"blocked on read lock 'exclusive' PID $cliPid 'runGatedExclusive'") ||
+            text.contains(s"blocked on write lock 'exclusive' PID $cliPid 'runGatedExclusive'")
           }
           // The BSP RPC future must not have resolved yet — still parked on the lock.
           assert(!workspaceTargetsFuture.isDone)

--- a/integration/dedicated/bsp-concurrency/src/BspConcurrencyTests.scala
+++ b/integration/dedicated/bsp-concurrency/src/BspConcurrencyTests.scala
@@ -128,8 +128,8 @@ object BspConcurrencyTests extends UtestIntegrationTestSuite {
           cliLauncherOpt = Some(cliLauncher)
           assertEventually {
             val errText = cliLauncher.err.text()
-            (errText.contains("blocked on read lock command 'BSP:") ||
-              errText.contains("blocked on write lock command 'BSP:")) &&
+            (errText.contains("blocked on read lock 'gated.sources' command 'BSP:") ||
+              errText.contains("blocked on write lock 'gated.sources' command 'BSP:")) &&
             errText.contains(s"PID $bspPid")
           }
           assert(cliLauncher.process.isAlive())

--- a/integration/dedicated/concurrency/src/ConcurrencyTests.scala
+++ b/integration/dedicated/concurrency/src/ConcurrencyTests.scala
@@ -218,7 +218,7 @@ object ConcurrencyTests extends UtestIntegrationTestSuite {
         launcher2,
         "runHoldMetaBuildRead",
         blockerPid,
-        "mill-build/build.mill"
+        "build.mill"
       ))
       assert(launcher2.process.isAlive())
       assert(!launcher2.containsLines("shared-value"))
@@ -235,7 +235,7 @@ object ConcurrencyTests extends UtestIntegrationTestSuite {
       assertContention(launcher1, Set.empty)
       assertContention(
         launcher2,
-        Set(blockedLine("runHoldMetaBuildRead", blockerPid, "mill-build/build.mill", "write"))
+        Set(blockedLine("runHoldMetaBuildRead", blockerPid, "build.mill", "write"))
       )
     }
 

--- a/integration/dedicated/concurrency/src/ConcurrencyTests.scala
+++ b/integration/dedicated/concurrency/src/ConcurrencyTests.scala
@@ -31,7 +31,7 @@ object ConcurrencyTests extends UtestIntegrationTestSuite {
       launcher.containsLines(blockedLine(command, pid, taskName, "read"))
 
   private def blockedLine(command: String, pid: Long, taskName: String, kind: String): String =
-    s"blocked on $kind lock '$taskName' command '$command' PID $pid"
+    s"blocked on $kind lock '$taskName' PID $pid '$command'"
 
   /**
    * Exact set of "blocked on ... lock ..." lines this launcher emitted.

--- a/integration/dedicated/concurrent-interrupt-shutdown/src/ConcurrentInterruptShutdownTests.scala
+++ b/integration/dedicated/concurrent-interrupt-shutdown/src/ConcurrentInterruptShutdownTests.scala
@@ -10,7 +10,7 @@ object ConcurrentInterruptShutdownTests extends UtestIntegrationTestSuite {
   implicit val retryInterval: RetryInterval = RetryInterval(50.millis)
 
   private def blockedBy(command: String, taskName: String, stderrText: String): Boolean =
-    stderrText.contains(s"blocked on read lock '$taskName' command '$command' PID ")
+    stderrText.contains(s"blocked on read lock command '$command' PID ")
 
   val tests: Tests = Tests {
     test("interrupt-blocked") - integrationTest { tester =>

--- a/integration/dedicated/concurrent-interrupt-shutdown/src/ConcurrentInterruptShutdownTests.scala
+++ b/integration/dedicated/concurrent-interrupt-shutdown/src/ConcurrentInterruptShutdownTests.scala
@@ -10,7 +10,7 @@ object ConcurrentInterruptShutdownTests extends UtestIntegrationTestSuite {
   implicit val retryInterval: RetryInterval = RetryInterval(50.millis)
 
   private def blockedBy(command: String, taskName: String, stderrText: String): Boolean =
-    stderrText.contains(s"blocked on read lock command '$command' PID ")
+    stderrText.contains(s"blocked on read lock '$taskName' command '$command' PID ")
 
   val tests: Tests = Tests {
     test("interrupt-blocked") - integrationTest { tester =>

--- a/integration/dedicated/concurrent-interrupt-shutdown/src/ConcurrentInterruptShutdownTests.scala
+++ b/integration/dedicated/concurrent-interrupt-shutdown/src/ConcurrentInterruptShutdownTests.scala
@@ -31,7 +31,7 @@ object ConcurrentInterruptShutdownTests extends UtestIntegrationTestSuite {
       assertEventually(blockedBy(
         "waitForExists --fileName file1.txt",
         "waitForExists",
-        launcher1.process.pid(),
+        launcher1.process.wrapped.pid(),
         launcher2.err.text()
       ))
       launcher2.process.destroy(recursive = false)
@@ -54,7 +54,7 @@ object ConcurrentInterruptShutdownTests extends UtestIntegrationTestSuite {
       assertEventually(blockedBy(
         "waitForExists --fileName file1.txt",
         "waitForExists",
-        launcher1.process.pid(),
+        launcher1.process.wrapped.pid(),
         launcher2.err.text()
       ))
       launcher1.process.destroy(recursive = false)

--- a/integration/dedicated/concurrent-interrupt-shutdown/src/ConcurrentInterruptShutdownTests.scala
+++ b/integration/dedicated/concurrent-interrupt-shutdown/src/ConcurrentInterruptShutdownTests.scala
@@ -10,7 +10,8 @@ object ConcurrentInterruptShutdownTests extends UtestIntegrationTestSuite {
   implicit val retryInterval: RetryInterval = RetryInterval(50.millis)
 
   private def blockedBy(command: String, taskName: String, stderrText: String): Boolean =
-    stderrText.contains(s"blocked on read lock '$taskName' command '$command' PID ")
+    stderrText.contains(s"blocked on read lock '$taskName' PID ") &&
+      stderrText.contains(s"'$command'")
 
   val tests: Tests = Tests {
     test("interrupt-blocked") - integrationTest { tester =>

--- a/integration/dedicated/concurrent-interrupt-shutdown/src/ConcurrentInterruptShutdownTests.scala
+++ b/integration/dedicated/concurrent-interrupt-shutdown/src/ConcurrentInterruptShutdownTests.scala
@@ -9,9 +9,13 @@ object ConcurrentInterruptShutdownTests extends UtestIntegrationTestSuite {
   implicit val retryMax: RetryMax = RetryMax((if (sys.env.contains("CI")) 120000 else 15000).millis)
   implicit val retryInterval: RetryInterval = RetryInterval(50.millis)
 
-  private def blockedBy(command: String, taskName: String, stderrText: String): Boolean =
-    stderrText.contains(s"blocked on read lock '$taskName' PID ") &&
-      stderrText.contains(s"'$command'")
+  private def blockedBy(
+      command: String,
+      taskName: String,
+      pid: Long,
+      stderrText: String
+  ): Boolean =
+    stderrText.contains(s"blocked on read lock '$taskName' PID $pid '$command'")
 
   val tests: Tests = Tests {
     test("interrupt-blocked") - integrationTest { tester =>
@@ -27,6 +31,7 @@ object ConcurrentInterruptShutdownTests extends UtestIntegrationTestSuite {
       assertEventually(blockedBy(
         "waitForExists --fileName file1.txt",
         "waitForExists",
+        launcher1.process.pid(),
         launcher2.err.text()
       ))
       launcher2.process.destroy(recursive = false)
@@ -49,6 +54,7 @@ object ConcurrentInterruptShutdownTests extends UtestIntegrationTestSuite {
       assertEventually(blockedBy(
         "waitForExists --fileName file1.txt",
         "waitForExists",
+        launcher1.process.pid(),
         launcher2.err.text()
       ))
       launcher1.process.destroy(recursive = false)

--- a/integration/dedicated/output-directory/src/OutputDirectoryLockTests.scala
+++ b/integration/dedicated/output-directory/src/OutputDirectoryLockTests.scala
@@ -40,7 +40,7 @@ object OutputDirectoryLockTests extends UtestIntegrationTestSuite {
   }
 
   private def blockedLine(command: String, pid: Long, taskName: String): String =
-    s"blocked on read lock command '$command' PID $pid"
+    s"blocked on read lock '$taskName' command '$command' PID $pid"
 
   def tests: Tests = Tests {
     test("taskLocks") - integrationTest { tester =>

--- a/integration/dedicated/output-directory/src/OutputDirectoryLockTests.scala
+++ b/integration/dedicated/output-directory/src/OutputDirectoryLockTests.scala
@@ -40,7 +40,7 @@ object OutputDirectoryLockTests extends UtestIntegrationTestSuite {
   }
 
   private def blockedLine(command: String, pid: Long, taskName: String): String =
-    s"blocked on read lock '$taskName' command '$command' PID $pid"
+    s"blocked on read lock '$taskName' PID $pid '$command'"
 
   def tests: Tests = Tests {
     test("taskLocks") - integrationTest { tester =>

--- a/integration/dedicated/output-directory/src/OutputDirectoryLockTests.scala
+++ b/integration/dedicated/output-directory/src/OutputDirectoryLockTests.scala
@@ -40,7 +40,7 @@ object OutputDirectoryLockTests extends UtestIntegrationTestSuite {
   }
 
   private def blockedLine(command: String, pid: Long, taskName: String): String =
-    s"blocked on read lock '$taskName' command '$command' PID $pid"
+    s"blocked on read lock command '$command' PID $pid"
 
   def tests: Tests = Tests {
     test("taskLocks") - integrationTest { tester =>

--- a/runner/daemon/src/mill/daemon/MetaBuildAccess.scala
+++ b/runner/daemon/src/mill/daemon/MetaBuildAccess.scala
@@ -1,8 +1,7 @@
 package mill.daemon
 
 import mill.api.daemon.internal.LauncherLocking
-import mill.constants.OutFiles
-import mill.internal.LockUpgrade
+import mill.internal.{LauncherLockRegistry, LockUpgrade}
 
 import java.util.concurrent.atomic.AtomicReference
 
@@ -58,11 +57,6 @@ private[daemon] class MetaBuildAccess(
   )(
       evaluate: MetaBuildAccess.WriteScope => T
   ): T = {
-    // Mirror [[mill.internal.LauncherLockRegistry.makeMetaBuildLock]] and
-    // `MillBuildBootstrap.bootLogPrefix` so the synthetic prompt-line key here
-    // matches the prefix the user already sees for the same meta-build depth.
-    val syntheticPrefix =
-      Seq((Seq.fill(depth)(OutFiles.millBuild) :+ "build.mill").mkString("/"))
     LockUpgrade.readThenWrite(
       acquireRead =
         workspaceLocking.metaBuildLock(depth, LauncherLocking.LockKind.Read, waitReporter),
@@ -70,7 +64,7 @@ private[daemon] class MetaBuildAccess(
       awaitStateChange =
         timeoutMs => workspaceLocking.awaitMetaBuildStateChange(depth, timeoutMs),
       waitReporter = waitReporter,
-      syntheticPrefix = syntheticPrefix
+      syntheticPrefix = Seq(LauncherLockRegistry.metaBuildLabel(depth))
     )(scope => probe(ref.get(), scope)) { scope =>
       evaluate(new MetaBuildAccess.WriteScope(ref, scope))
     }

--- a/runner/daemon/src/mill/daemon/MetaBuildAccess.scala
+++ b/runner/daemon/src/mill/daemon/MetaBuildAccess.scala
@@ -57,6 +57,7 @@ private[daemon] class MetaBuildAccess(
   )(
       evaluate: MetaBuildAccess.WriteScope => T
   ): T = {
+    val label = LauncherLockRegistry.metaBuildLabel(depth)
     LockUpgrade.readThenWrite(
       acquireRead =
         workspaceLocking.metaBuildLock(depth, LauncherLocking.LockKind.Read, waitReporter),
@@ -64,7 +65,8 @@ private[daemon] class MetaBuildAccess(
       awaitStateChange =
         timeoutMs => workspaceLocking.awaitMetaBuildStateChange(depth, timeoutMs),
       waitReporter = waitReporter,
-      syntheticPrefix = Seq(LauncherLockRegistry.metaBuildLabel(depth))
+      lockLabel = label,
+      syntheticPrefix = Seq(label)
     )(scope => probe(ref.get(), scope)) { scope =>
       evaluate(new MetaBuildAccess.WriteScope(ref, scope))
     }

--- a/runner/daemon/src/mill/daemon/MetaBuildAccess.scala
+++ b/runner/daemon/src/mill/daemon/MetaBuildAccess.scala
@@ -1,6 +1,7 @@
 package mill.daemon
 
 import mill.api.daemon.internal.LauncherLocking
+import mill.constants.OutFiles
 import mill.internal.LockUpgrade
 
 import java.util.concurrent.atomic.AtomicReference
@@ -57,13 +58,19 @@ private[daemon] class MetaBuildAccess(
   )(
       evaluate: MetaBuildAccess.WriteScope => T
   ): T = {
+    // Mirror [[mill.internal.LauncherLockRegistry.makeMetaBuildLock]] and
+    // `MillBuildBootstrap.bootLogPrefix` so the synthetic prompt-line key here
+    // matches the prefix the user already sees for the same meta-build depth.
+    val syntheticPrefix =
+      Seq((Seq.fill(depth)(OutFiles.millBuild) :+ "build.mill").mkString("/"))
     LockUpgrade.readThenWrite(
       acquireRead =
         workspaceLocking.metaBuildLock(depth, LauncherLocking.LockKind.Read, waitReporter),
       tryAcquireWrite = () => workspaceLocking.tryMetaBuildWriteLock(depth),
       awaitStateChange =
         timeoutMs => workspaceLocking.awaitMetaBuildStateChange(depth, timeoutMs),
-      waitReporter = waitReporter
+      waitReporter = waitReporter,
+      syntheticPrefix = syntheticPrefix
     )(scope => probe(ref.get(), scope)) { scope =>
       evaluate(new MetaBuildAccess.WriteScope(ref, scope))
     }

--- a/runner/daemon/src/mill/daemon/MetaBuildAccess.scala
+++ b/runner/daemon/src/mill/daemon/MetaBuildAccess.scala
@@ -1,7 +1,7 @@
 package mill.daemon
 
 import mill.api.daemon.internal.LauncherLocking
-import mill.internal.{LauncherLockRegistry, LockUpgrade}
+import mill.internal.LockUpgrade
 
 import java.util.concurrent.atomic.AtomicReference
 
@@ -57,16 +57,13 @@ private[daemon] class MetaBuildAccess(
   )(
       evaluate: MetaBuildAccess.WriteScope => T
   ): T = {
-    val label = LauncherLockRegistry.metaBuildLabel(depth)
     LockUpgrade.readThenWrite(
       acquireRead =
         workspaceLocking.metaBuildLock(depth, LauncherLocking.LockKind.Read, waitReporter),
       tryAcquireWrite = () => workspaceLocking.tryMetaBuildWriteLock(depth),
       awaitStateChange =
         timeoutMs => workspaceLocking.awaitMetaBuildStateChange(depth, timeoutMs),
-      waitReporter = waitReporter,
-      lockLabel = label,
-      syntheticPrefix = Seq(label)
+      waitReporter = waitReporter
     )(scope => probe(ref.get(), scope)) { scope =>
       evaluate(new MetaBuildAccess.WriteScope(ref, scope))
     }


### PR DESCRIPTION
No need for it to contain the task name in the multi-line prompt, since it appears on the prompt line which already includes the task name. Other scenarios like the BSP logs or when `--ticker false` (e.g. in integration tests) we continue to show the task name