### PR TITLE
Attempt to fix `publishDocs` job and android tests

### DIFF
--- a/example/androidlib/kotlin/1-hello-kotlin/build.mill
+++ b/example/androidlib/kotlin/1-hello-kotlin/build.mill
@@ -22,7 +22,7 @@ object androidSdkModule0 extends AndroidSdkModule {
 // Actual android application
 object app extends AndroidAppKotlinModule {
 
-  def kotlinVersion = "2.2.20"
+  def kotlinVersion = "2.0.20"
   def androidSdkModule = mill.api.ModuleRef(androidSdkModule0)
   def androidMinSdk = 19
   def androidCompileSdk = 35

--- a/example/androidlib/kotlin/2-compose/build.mill
+++ b/example/androidlib/kotlin/2-compose/build.mill
@@ -23,7 +23,7 @@ object androidSdkModule0 extends AndroidSdkModule {
 // Actual android application
 object app extends AndroidAppKotlinModule {
 
-  def kotlinVersion = "2.2.20"
+  def kotlinVersion = "2.0.21"
   def androidSdkModule = mill.api.ModuleRef(androidSdkModule0)
   def androidCompileSdk = 35
   def androidMinSdk = 26

--- a/example/androidlib/kotlin/3-compose-screenshot-tests/build.mill
+++ b/example/androidlib/kotlin/3-compose-screenshot-tests/build.mill
@@ -24,7 +24,7 @@ object androidSdkModule0 extends AndroidSdkModule {
 // Actual android application
 object app extends AndroidAppKotlinModule {
 
-  def kotlinVersion = "2.2.20"
+  def kotlinVersion = "2.0.21"
   def androidSdkModule = mill.api.ModuleRef(androidSdkModule0)
   def androidApplicationId = "com.example.screenshottest"
   def androidApplicationNamespace = "com.example.screenshottest"

--- a/example/androidlib/kotlin/4-sum-lib-kotlin/build.mill
+++ b/example/androidlib/kotlin/4-sum-lib-kotlin/build.mill
@@ -22,7 +22,7 @@ object lib extends AndroidKotlinModule, AndroidLibModule {
   def androidSdkModule = mill.api.ModuleRef(androidSdkModule0)
   def androidMinSdk = 19
   def androidCompileSdk = 35
-  def kotlinVersion = "2.2.20"
+  def kotlinVersion = "2.0.20"
 
   def androidLibPackage = "com.example"
 
@@ -44,7 +44,7 @@ object lib extends AndroidKotlinModule, AndroidLibModule {
 
 object app extends AndroidAppKotlinModule {
 
-  def kotlinVersion = "2.2.20"
+  def kotlinVersion = "2.0.20"
   def androidSdkModule = mill.api.ModuleRef(androidSdkModule0)
   def androidMinSdk = 19
   def androidCompileSdk = 35

--- a/libs/javalib/worker/src/mill/javalib/zinc/ZincWorker.scala
+++ b/libs/javalib/worker/src/mill/javalib/zinc/ZincWorker.scala
@@ -251,6 +251,10 @@ class ZincWorker(jobs: Int, useFileLocks: Boolean = false) extends AutoCloseable
         failWithFirstError = true,
         logger = msg => processConfig.log.debug(msg)
       ) {
+        // Make retries idempotent: scaladoc rejects `-d` if the dir is missing,
+        // and a failed first attempt can leave it in a state the second
+        // rejects, masking the real error from the first run.
+        os.makeDir.all(op.workDir)
         if (
           JvmWorkerUtil.isDotty(op.scalaVersion) || JvmWorkerUtil.isScala3Milestone(op.scalaVersion)
         ) {

--- a/website/package.mill
+++ b/website/package.mill
@@ -16,6 +16,9 @@ object `package` extends mill.Module {
    * API documentation generated with ScalaDoc.
    */
   object apidocs extends UnidocModule {
+    // Scala 3.8.2 scaladoc trips on Java 25's restrictions on `sun.misc.Unsafe`
+    // (used by `LazyVals$`); pin the worker JVM to 21 until upstream catches up.
+    def jvmVersion = "temurin:21"
     def dummy = Task { PathRef(Task.dest) }
     def unidocDocumentTitle = Task { "Mill" }
 

--- a/website/package.mill
+++ b/website/package.mill
@@ -18,7 +18,7 @@ object `package` extends mill.Module {
   object apidocs extends UnidocModule {
     // Scala 3.8.2 scaladoc trips on Java 25's restrictions on `sun.misc.Unsafe`
     // (used by `LazyVals$`); pin the worker JVM to 21 until upstream catches up.
-    def jvmVersion = "temurin:21"
+    override def jvmVersion = Task { "temurin:21" }
     def dummy = Task { PathRef(Task.dest) }
     def unidocDocumentTitle = Task { "Mill" }
 


### PR DESCRIPTION
* Revert `apidocs` compilation back to Java 21 for now
* Revert `example.androidlib` tests back to older version of kotlin, since they were earlier already reverted back to Java 21