### PR TITLE
Make annotation processors not inherit zinc classpath

### DIFF
--- a/libs/javalib/test/resources/incremental-annotation-processing/classloaderIsolation/src/example/Helper.java
+++ b/libs/javalib/test/resources/incremental-annotation-processing/classloaderIsolation/src/example/Helper.java
@@ -1,0 +1,7 @@
+package example;
+
+public class Helper {
+    public static String value() {
+        return "helper";
+    }
+}

--- a/libs/javalib/test/resources/incremental-annotation-processing/classloaderIsolation/src/example/Probed.java
+++ b/libs/javalib/test/resources/incremental-annotation-processing/classloaderIsolation/src/example/Probed.java
@@ -1,0 +1,8 @@
+package example;
+
+@Probe
+public class Probed {
+    public static String value() {
+        return "probed";
+    }
+}

--- a/libs/javalib/test/resources/incremental-annotation-processing/classloaderIsolationProcessor/compile-resources/META-INF/gradle/incremental.annotation.processors
+++ b/libs/javalib/test/resources/incremental-annotation-processing/classloaderIsolationProcessor/compile-resources/META-INF/gradle/incremental.annotation.processors
@@ -1,0 +1,1 @@
+example.ClassloaderProbeProcessor,isolating

--- a/libs/javalib/test/resources/incremental-annotation-processing/classloaderIsolationProcessor/src/example/ClassloaderProbeProcessor.java
+++ b/libs/javalib/test/resources/incremental-annotation-processing/classloaderIsolationProcessor/src/example/ClassloaderProbeProcessor.java
@@ -1,0 +1,47 @@
+package example;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Set;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.TypeElement;
+import javax.tools.FileObject;
+import javax.tools.StandardLocation;
+
+@SupportedAnnotationTypes("example.Probe")
+@SupportedSourceVersion(SourceVersion.RELEASE_8)
+public class ClassloaderProbeProcessor extends AbstractProcessor {
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        if (roundEnv.processingOver()) return false;
+
+        ClassLoader cl = getClass().getClassLoader();
+        ClassLoader parent = cl.getParent();
+        StringBuilder sb = new StringBuilder();
+        sb.append("self=").append(cl.getClass().getName()).append('\n');
+        sb.append("parent=").append(parent == null ? "<bootstrap>" : parent.getClass().getName())
+            .append('\n');
+        sb.append("parent-is-platform=")
+            .append(parent == ClassLoader.getPlatformClassLoader())
+            .append('\n');
+
+        try {
+            FileObject file = processingEnv.getFiler().createResource(
+                StandardLocation.CLASS_OUTPUT,
+                "",
+                "META-INF/probe/result.txt"
+            );
+            try (Writer writer = file.openWriter()) {
+                writer.write(sb.toString());
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        return false;
+    }
+}

--- a/libs/javalib/test/resources/incremental-annotation-processing/classloaderIsolationProcessor/src/example/ClassloaderProbeProcessor.java
+++ b/libs/javalib/test/resources/incremental-annotation-processing/classloaderIsolationProcessor/src/example/ClassloaderProbeProcessor.java
@@ -2,6 +2,8 @@ package example;
 
 import java.io.IOException;
 import java.io.Writer;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.Set;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.RoundEnvironment;
@@ -19,15 +21,16 @@ public class ClassloaderProbeProcessor extends AbstractProcessor {
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
         if (roundEnv.processingOver()) return false;
 
-        ClassLoader cl = getClass().getClassLoader();
-        ClassLoader parent = cl.getParent();
         StringBuilder sb = new StringBuilder();
-        sb.append("self=").append(cl.getClass().getName()).append('\n');
-        sb.append("parent=").append(parent == null ? "<bootstrap>" : parent.getClass().getName())
-            .append('\n');
-        sb.append("parent-is-platform=")
-            .append(parent == ClassLoader.getPlatformClassLoader())
-            .append('\n');
+        ClassLoader cur = getClass().getClassLoader();
+        while (cur != null) {
+            if (cur instanceof URLClassLoader) {
+                for (URL url : ((URLClassLoader) cur).getURLs()) {
+                    sb.append(url).append('\n');
+                }
+            }
+            cur = cur.getParent();
+        }
 
         try {
             FileObject file = processingEnv.getFiler().createResource(

--- a/libs/javalib/test/resources/incremental-annotation-processing/classloaderIsolationProcessor/src/example/Probe.java
+++ b/libs/javalib/test/resources/incremental-annotation-processing/classloaderIsolationProcessor/src/example/Probe.java
@@ -1,0 +1,10 @@
+package example;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.TYPE)
+public @interface Probe {}

--- a/libs/javalib/test/src/mill/javalib/IncrementalAnnotationProcessingTests.scala
+++ b/libs/javalib/test/src/mill/javalib/IncrementalAnnotationProcessingTests.scala
@@ -83,6 +83,21 @@ object IncrementalAnnotationProcessingTests extends TestSuite {
       }
     }
 
+    object classloaderIsolationProcessor extends JavaModule
+
+    object classloaderIsolation extends JavaModule {
+      def moduleDeps = Seq(classloaderIsolationProcessor)
+
+      override def javacOptions: T[Seq[String]] = Task {
+        super.javacOptions() ++ Seq(
+          "-processorpath",
+          classloaderIsolationProcessor.compile().classes.path.toString,
+          "-processor",
+          "example.ClassloaderProbeProcessor"
+        )
+      }
+    }
+
     lazy val millDiscover = Discover[this.type]
   }
 
@@ -402,6 +417,38 @@ object IncrementalAnnotationProcessingTests extends TestSuite {
       assert(!os.exists(generatedComponent))
       assert(os.exists(helperClass))
       assert(os.stat(helperClass).ctime == helperStatBefore.ctime)
+    }
+
+    test("classloaderIsolation") - testEval().scoped { eval =>
+      val probeFile =
+        eval.outPath / "classloaderIsolation/compile.dest/classes/META-INF/probe/result.txt"
+
+      val Right(first) = eval(Modules.classloaderIsolation.compile).runtimeChecked
+      assert(first.evalCount > 0, os.exists(probeFile))
+
+      // Mill's tracking processor classloader is only created on incremental
+      // recompiles, so trigger a second compile by modifying the source.
+      os.write.over(
+        Modules.classloaderIsolation.moduleDir / "src/example/Probed.java",
+        """package example;
+          |
+          |@Probe
+          |public class Probed {
+          |    public static String value() {
+          |        return "probed-changed";
+          |    }
+          |}
+          |""".stripMargin
+      )
+
+      val Right(second) = eval(Modules.classloaderIsolation.compile).runtimeChecked
+      assert(second.evalCount > 0, os.exists(probeFile))
+
+      // Annotation processors should be loaded into a URLClassLoader whose parent is
+      // the JDK platform classloader, so they cannot see Zinc / Mill worker / Scala
+      // stdlib classes from the enclosing worker classpath.
+      val content = os.read(probeFile)
+      assert(content.contains("parent-is-platform=true"))
     }
 
     test("dynamic") - testEval().scoped { eval =>

--- a/libs/javalib/test/src/mill/javalib/IncrementalAnnotationProcessingTests.scala
+++ b/libs/javalib/test/src/mill/javalib/IncrementalAnnotationProcessingTests.scala
@@ -444,11 +444,14 @@ object IncrementalAnnotationProcessingTests extends TestSuite {
       val Right(second) = eval(Modules.classloaderIsolation.compile).runtimeChecked
       assert(second.evalCount > 0, os.exists(probeFile))
 
-      // Annotation processors should be loaded into a URLClassLoader whose parent is
-      // the JDK platform classloader, so they cannot see Zinc / Mill worker / Scala
-      // stdlib classes from the enclosing worker classpath.
-      val content = os.read(probeFile)
-      assert(content.contains("parent-is-platform=true"))
+      // The processor's classloader chain must contain exactly the processor's own
+      // compile output and nothing else. Any extra entries (e.g. Mill / Zinc worker
+      // jars from MillURLClassLoader) indicate a classloader-isolation regression.
+      val urls = os.read(probeFile).linesIterator.filter(_.nonEmpty).toSet
+      val expectedUrl =
+        (eval.outPath / "classloaderIsolationProcessor/compile.dest/classes")
+          .toIO.toURI.toURL.toString
+      assert(urls == Set(expectedUrl))
     }
 
     test("dynamic") - testEval().scoped { eval =>

--- a/libs/javalib/worker/src/mill/javalib/zinc/IncrementalAnnotationProcessing.scala
+++ b/libs/javalib/worker/src/mill/javalib/zinc/IncrementalAnnotationProcessing.scala
@@ -522,7 +522,7 @@ private[mill] object IncrementalAnnotationProcessing {
       classpath: Seq[os.Path]
   ): Option[TrackingMode] = {
     val urls = classpath.iterator.map(_.toIO.toURI.toURL).toArray
-    Using.resource(new java.net.URLClassLoader(urls, getClass.getClassLoader)) { loader =>
+    Using.resource(new java.net.URLClassLoader(urls, ClassLoader.getPlatformClassLoader)) { loader =>
       scala.util
         .Try {
           val cls = loader.loadClass(processorClassName)
@@ -543,7 +543,7 @@ private[mill] object IncrementalAnnotationProcessing {
       annotationIndex: SourceAnnotationIndex
   ): Boolean = {
     val urls = classpath.iterator.map(_.toIO.toURI.toURL).toArray
-    Using.resource(new java.net.URLClassLoader(urls, getClass.getClassLoader)) { loader =>
+    Using.resource(new java.net.URLClassLoader(urls, ClassLoader.getPlatformClassLoader)) { loader =>
       scala.util
         .Try {
           val cls = loader.loadClass(processorClassName)

--- a/libs/javalib/worker/src/mill/javalib/zinc/IncrementalAnnotationProcessing.scala
+++ b/libs/javalib/worker/src/mill/javalib/zinc/IncrementalAnnotationProcessing.scala
@@ -522,18 +522,19 @@ private[mill] object IncrementalAnnotationProcessing {
       classpath: Seq[os.Path]
   ): Option[TrackingMode] = {
     val urls = classpath.iterator.map(_.toIO.toURI.toURL).toArray
-    Using.resource(new java.net.URLClassLoader(urls, ClassLoader.getPlatformClassLoader)) { loader =>
-      scala.util
-        .Try {
-          val cls = loader.loadClass(processorClassName)
-          val processor = cls.getDeclaredConstructor().newInstance().asInstanceOf[Processor]
-          val options = processor.getSupportedOptions.asScala
-          if (options.contains(DynamicAggregatingOption)) TrackingMode.Aggregating
-          else if (options.contains(DynamicIsolatingOption)) TrackingMode.Isolating
-          else null
-        }
-        .toOption
-        .filter(_ != null)
+    Using.resource(new java.net.URLClassLoader(urls, ClassLoader.getPlatformClassLoader)) {
+      loader =>
+        scala.util
+          .Try {
+            val cls = loader.loadClass(processorClassName)
+            val processor = cls.getDeclaredConstructor().newInstance().asInstanceOf[Processor]
+            val options = processor.getSupportedOptions.asScala
+            if (options.contains(DynamicAggregatingOption)) TrackingMode.Aggregating
+            else if (options.contains(DynamicIsolatingOption)) TrackingMode.Isolating
+            else null
+          }
+          .toOption
+          .filter(_ != null)
     }
   }
 
@@ -543,15 +544,16 @@ private[mill] object IncrementalAnnotationProcessing {
       annotationIndex: SourceAnnotationIndex
   ): Boolean = {
     val urls = classpath.iterator.map(_.toIO.toURI.toURL).toArray
-    Using.resource(new java.net.URLClassLoader(urls, ClassLoader.getPlatformClassLoader)) { loader =>
-      scala.util
-        .Try {
-          val cls = loader.loadClass(processorClassName)
-          val processor = cls.getDeclaredConstructor().newInstance().asInstanceOf[Processor]
-          val supported = processor.getSupportedAnnotationTypes.asScala.toSet
-          supported.isEmpty || supported.exists(annotationIndex.matches)
-        }
-        .getOrElse(true)
+    Using.resource(new java.net.URLClassLoader(urls, ClassLoader.getPlatformClassLoader)) {
+      loader =>
+        scala.util
+          .Try {
+            val cls = loader.loadClass(processorClassName)
+            val processor = cls.getDeclaredConstructor().newInstance().asInstanceOf[Processor]
+            val supported = processor.getSupportedAnnotationTypes.asScala.toSet
+            supported.isEmpty || supported.exists(annotationIndex.matches)
+          }
+          .getOrElse(true)
     }
   }
 

--- a/libs/javalib/worker/src/mill/javalib/zinc/IncrementalTrackingJavaCompiler.scala
+++ b/libs/javalib/worker/src/mill/javalib/zinc/IncrementalTrackingJavaCompiler.scala
@@ -52,7 +52,7 @@ private[mill] object IncrementalTrackingJavaCompiler {
       if (names.isEmpty) None
       else {
         val urls = processorPath.iterator.map(_.toIO.toURI.toURL).toArray
-        val loader = new java.net.URLClassLoader(urls, getClass.getClassLoader)
+        val loader = new java.net.URLClassLoader(urls, ClassLoader.getPlatformClassLoader)
         val processors = names.map { name =>
           val delegate =
             loader.loadClass(name).getDeclaredConstructor().newInstance().asInstanceOf[Processor]


### PR DESCRIPTION
This should avoid conflicts between the annotation processor classpath and the zinc classpath, which may have different versions of common libraries from maven central

Covered by a unit test