### PR TITLE
Fix outdated doc comment

### DIFF
--- a/core/api/src/mill/api/ExternalModule.scala
+++ b/core/api/src/mill/api/ExternalModule.scala
@@ -8,7 +8,7 @@ import mill.api.internal.RootModule0
  *
  * Implementors should make sure, the final override of [[millDiscover]] happens in the final object.
  * {{{
- *    override protected def millDiscover: Discover = Discover[this.type]
+ *    override def millDiscover: Discover = Discover[this.type]
  * }}}
  */
 abstract class ExternalModule(using


### PR DESCRIPTION
`protected` is misplaced here:
<img width="940" height="246" alt="image" src="https://github.com/user-attachments/assets/52d1d687-40fa-4d66-a2b3-3c0cbd5aabb2" />

Immediately marking the PR as ready as there are no code changes.