### PR TITLE
Update Contrib OWASP Dependency Check to 12.2.2

### DIFF
--- a/mill-build/src/millbuild/Deps.scala
+++ b/mill-build/src/millbuild/Deps.scala
@@ -300,7 +300,7 @@ object Deps {
     val koverJvmAgent_runtime = mvn"org.jetbrains.kotlinx:kover-jvm-agent:$koverVersion_runtime"
     val ktfmt_runtime = mvn"com.facebook:ktfmt:0.58"
     val ktlint_runtime = mvn"com.pinterest.ktlint:ktlint-core:0.49.1"
-    val owaspDependencyCheckCli_runtime = mvn"org.owasp:dependency-check-cli:12.2.1"
+    val owaspDependencyCheckCli_runtime = mvn"org.owasp:dependency-check-cli:12.2.2"
     val palantirFormat_runtime = mvn"com.palantir.javaformat:palantir-java-format:2.90.0"
     val pmdDist_runtime = mvn"net.sourceforge.pmd:pmd-dist:7.15.0"
     val proguard_runtime = mvn"com.guardsquare:proguard-base:7.9.1"


### PR DESCRIPTION
OWASP Dependency Check version 12.2.2 fixes
a cache database schema issue,
where caching vulnerability info failed.

