### PR TITLE
fix(javalib): avoid duplicate non-parallel test runners

### DIFF
--- a/libs/javalib/src/mill/javalib/TestModuleUtil.scala
+++ b/libs/javalib/src/mill/javalib/TestModuleUtil.scala
@@ -190,9 +190,14 @@ final class TestModuleUtil(
     testClassQueueFolder
   }
 
-  def jobsProcessLength(numTests: Int) = {
-    val cappedJobs = Math.max(Math.min(Task.ctx().jobs, numTests), 1)
-    (cappedJobs, cappedJobs.toString.length)
+  def jobsProcessLength(filteredClassCount: Int, numTests: Int) = {
+    val processCount = TestModuleUtil.testSubprocessCount(
+      testParallelism = testParallelism,
+      filteredClassCount = filteredClassCount,
+      jobs = Task.ctx().jobs,
+      numTests = numTests
+    )
+    (processCount, processCount.toString.length)
   }
 
   def runTestQueueScheduler(
@@ -204,19 +209,20 @@ final class TestModuleUtil(
     val groupFolderData: Seq[(Path, Path, Int)] = prepareTestGroups(filteredClassLists)
 
     val outputs = {
-      // We got "--jobs" threads, and "groupLength" test groups, so we will spawn at most jobs * groupLength runners here
-      // In most case, this is more than necessary, and runner creation is expensive,
-      // but we have a check for non-empty test-classes folder before really spawning a new runner, so in practice the overhead is low
+      // In parallel mode, we spawn up to "--jobs" runners per group. This is more than
+      // necessary in most cases, but the non-empty test-classes check keeps overhead low.
+      // In non-parallel mode, each group uses a single shared folder, so only spawn one
+      // runner per group.
       val subprocessFutures = for {
         ((groupFolder, testClassQueueFolder, numTests), groupIndex) <-
           groupFolderData.zipWithIndex.toVector
-        (jobs, maxProcessLength) = jobsProcessLength(numTests)
+        (processCount, maxProcessLength) = jobsProcessLength(filteredClassCount, numTests)
         paddedGroupIndex = Util.leftPad(
           groupIndex.toString,
           groupFolderData.length.toString.length,
           '0'
         )
-        processIndex <- 0 until Math.max(Math.min(jobs, numTests), 1)
+        processIndex <- 0 until processCount
       } yield runTestFuture(
         filteredClassCount,
         groupFolderData,
@@ -370,6 +376,16 @@ final class TestModuleUtil(
 }
 
 private[mill] object TestModuleUtil {
+
+  private[mill] def testSubprocessCount(
+      testParallelism: Boolean,
+      filteredClassCount: Int,
+      jobs: Int,
+      numTests: Int
+  ): Int = {
+    if (testParallelism && filteredClassCount != 1) Math.max(Math.min(jobs, numTests), 1)
+    else 1
+  }
 
   def loadArgsAndProps(
       useArgsFile: Boolean,

--- a/libs/javalib/test/src/mill/javalib/TestModuleUtilTests.scala
+++ b/libs/javalib/test/src/mill/javalib/TestModuleUtilTests.scala
@@ -295,6 +295,40 @@ object TestModuleUtilTests extends TestSuite {
     }
 
     // format: on
+    test("testSubprocessCount") {
+      assert(
+        TestModuleUtil.testSubprocessCount(
+          testParallelism = false,
+          filteredClassCount = 2,
+          jobs = 8,
+          numTests = 2
+        ) == 1
+      )
+      assert(
+        TestModuleUtil.testSubprocessCount(
+          testParallelism = true,
+          filteredClassCount = 2,
+          jobs = 8,
+          numTests = 2
+        ) == 2
+      )
+      assert(
+        TestModuleUtil.testSubprocessCount(
+          testParallelism = true,
+          filteredClassCount = 1,
+          jobs = 8,
+          numTests = 1
+        ) == 1
+      )
+      assert(
+        TestModuleUtil.testSubprocessCount(
+          testParallelism = true,
+          filteredClassCount = 0,
+          jobs = 8,
+          numTests = 0
+        ) == 1
+      )
+    }
     test("collapseTestClassNames") {
       val res = TestModuleUtil.collapseTestClassNames(
         Seq(

--- a/libs/scalalib/test/resources/testrunner/queueDrift/src/QueueDriftFramework.scala
+++ b/libs/scalalib/test/resources/testrunner/queueDrift/src/QueueDriftFramework.scala
@@ -1,0 +1,62 @@
+package mill.scalalib
+
+import sbt.testing._
+
+import java.nio.file.{Files, Paths}
+
+trait QueueDriftBase
+class QueueDriftStart extends QueueDriftBase
+class QueueDriftFiller extends QueueDriftBase
+class QueueDriftExtra extends QueueDriftBase
+
+class QueueDriftFramework extends Framework {
+  override def fingerprints(): Array[Fingerprint] = Array(new SubclassFingerprint {
+    override def isModule(): Boolean = false
+    override def superclassName(): String = "mill.scalalib.QueueDriftBase"
+    override def requireNoArgConstructor(): Boolean = true
+  })
+  override def name(): String = "QueueDriftFramework"
+  override def runner(
+      runnerArgs: Array[String],
+      runnerRemoteArgs: Array[String],
+      testClassLoader: ClassLoader
+  ): Runner = new Runner {
+    override def args(): Array[String] = runnerArgs
+    override def remoteArgs(): Array[String] = runnerRemoteArgs
+    override def done(): String = {
+      QueueDriftFramework.queueExtraClass()
+      ""
+    }
+    override def tasks(taskDefs: Array[TaskDef]): Array[Task] = {
+      taskDefs.map(QueueDriftTask(_))
+    }
+  }
+}
+
+object QueueDriftFramework {
+  def queueExtraClass(): Unit = {
+    val queueFolder = Paths.get("").toAbsolutePath.getParent.resolve("test-classes")
+    Files.createDirectories(queueFolder)
+    Files.write(queueFolder.resolve("mill.scalalib.QueueDriftExtra"), Array.emptyByteArray)
+    ()
+  }
+}
+
+case class QueueDriftTask(taskDef0: TaskDef) extends Task {
+  override def taskDef(): TaskDef = taskDef0
+  override def tags(): Array[String] = Array.empty
+  override def execute(
+      eventHandler: EventHandler,
+      loggers: Array[Logger]
+  ): Array[Task] = {
+    eventHandler.handle(new Event {
+      override def fullyQualifiedName(): String = taskDef0.fullyQualifiedName()
+      override def fingerprint(): Fingerprint = taskDef0.fingerprint()
+      override def selector(): Selector = new SuiteSelector()
+      override def status(): Status = Status.Success
+      override def throwable(): OptionalThrowable = new OptionalThrowable()
+      override def duration(): Long = 0L
+    })
+    Array.empty
+  }
+}

--- a/libs/scalalib/test/src/mill/scalalib/TestRunnerSchedulerTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/TestRunnerSchedulerTests.scala
@@ -1,0 +1,29 @@
+package mill.scalalib
+
+import mill.testkit.UnitTester
+import utest.*
+
+object TestRunnerSchedulerTests extends TestSuite {
+  import TestRunnerTestUtils.*
+
+  override def tests: Tests = Tests {
+    test("non-parallel queue scheduler uses one runner per group") - {
+      UnitTester(testrunner, resourcePath, threads = Some(2)).scoped { eval =>
+        val Right(result) = eval.apply(testrunner.queueDrift.testForked()).runtimeChecked
+
+        assert(
+          result.value.results.map(_.fullyQualifiedName).toSet == Set(
+            "mill.scalalib.QueueDriftStart",
+            "mill.scalalib.QueueDriftFiller"
+          )
+        )
+        assert(
+          os.exists(
+            eval.outPath / "queueDrift" / "testForked.dest" / "test-classes" /
+              "mill.scalalib.QueueDriftExtra"
+          )
+        )
+      }
+    }
+  }
+}

--- a/libs/scalalib/test/src/mill/scalalib/TestRunnerTestUtils.scala
+++ b/libs/scalalib/test/src/mill/scalalib/TestRunnerTestUtils.scala
@@ -77,6 +77,19 @@ object TestRunnerTestUtils {
       override def testParallelism = enableParallelism
       override def zioTestVersion: T[String] = sys.props.getOrElse("TEST_ZIOTEST_VERSION", ???)
     }
+
+    object queueDrift extends ScalaTests {
+      override def testFramework = "mill.scalalib.QueueDriftFramework"
+      override def mvnDeps = Task {
+        super.mvnDeps() ++ Seq(
+          mvn"org.scala-sbt:test-interface:${sys.props.getOrElse("TEST_TEST_INTERFACE_VERSION", ???)}"
+        )
+      }
+      override def testForkGrouping = Task {
+        Seq(Seq("mill.scalalib.QueueDriftStart", "mill.scalalib.QueueDriftFiller"))
+      }
+      override def testParallelism = false
+    }
   }
 
   val resourcePath = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "testrunner"


### PR DESCRIPTION
Fixes #7106.

Commit structure:

1. Add failing regression for non-parallel queue scheduler reusing `testForked.dest`.
2. Cap non-parallel scheduler to one runner per group.

Validation:

- Commit 1 fails with `FileAlreadyExistsException: .../testForked.dest/testargs`.
- Final branch passes focused scheduler tests and existing UTest/ScalaTest runner tests.

Regression setup:

- Test module sets `testParallelism = false`.
- It has one test group with two classes.
- `UnitTester(..., threads = Some(2))` lets the old scheduler create two runner futures.
- A tiny fake test framework writes one extra class marker into `test-classes` during `Runner.done()`.

Old behavior:

```text
runner 0 -> testForked.dest/testargs
runner 0 drains tests, then leaves one marker
runner 1 sees marker, reuses testForked.dest
runner 1 writes testargs again -> FileAlreadyExistsException
```

Fixed behavior: non-parallel mode creates one runner per group, so no second runner reuses the same dest.
