### PR TITLE
Dep API refinements, add `force` attribute

### DIFF
--- a/libs/javalib/src/mill/javalib/Dep.scala
+++ b/libs/javalib/src/mill/javalib/Dep.scala
@@ -238,7 +238,7 @@ object Dep {
   }
 
   /**
-   * In the presence of an non-empty `platformSuffix`, validate all given `deps` and return the warning, if any.
+   * In the presence of a non-empty `platformSuffix`, validate all given `deps` and return the warning, if any.
    * @param platformSuffix The platformSuffix, may also be empty (`""`).
    * @param deps The dependencies to analyze
    * @return An empty `Seq` when there are no warning, otherwise s `Seq[String]` with all validation warnings.

--- a/libs/javalib/src/mill/javalib/Dep.scala
+++ b/libs/javalib/src/mill/javalib/Dep.scala
@@ -4,7 +4,9 @@ import upickle.{macroRW, ReadWriter as RW}
 import mill.api.CrossVersion.*
 import mill.api.CrossVersion
 import coursier.core.{Configuration, Dependency, MinimizedExclusions}
-import mill.javalib.api.{Versions, JvmWorkerUtil}
+import coursier.version.VersionConstraint
+import mill.javalib.api.{JvmWorkerUtil, Versions}
+
 import scala.annotation.unused
 
 /**
@@ -215,7 +217,7 @@ object Dep {
     apply(
       coursier.Dependency(
         coursier.Module(coursier.Organization(org), coursier.ModuleName(name)),
-        version
+        VersionConstraint(version)
       ),
       cross,
       force

--- a/libs/javalib/src/mill/javalib/Dep.scala
+++ b/libs/javalib/src/mill/javalib/Dep.scala
@@ -118,11 +118,14 @@ object Dep {
     val parts = signature.split(';')
     val module = parts.head
     var exclusions = Seq.empty[(String, String)]
+    var force = false
     val attributes = parts.tail.foldLeft(coursier.Attributes()) { (as, s) =>
       s.split('=') match {
         case Array("classifier", v) => as.withClassifier(coursier.Classifier(v))
         case Array("type", v) => as.withType(coursier.Type(v))
         case Array("exclude", s"${org}:${name}") => exclusions ++= Seq((org, name)); as
+        case Array("force") | Array("force", "true" | "yes") => force = true; as
+        case Array("force", "false" | "no") => force = false; as
         case Array(_, _) => throw Exception(s"Unrecognized attribute: [$s]")
         case _ => throw Exception(s"Unable to parse attribute specifier: [$s]")
       }
@@ -139,6 +142,7 @@ object Dep {
       case Array(a, "", "", b, "", c) => Dep(a, b, c, cross = Full(platformed = true))
       case _ => throw Exception(s"Unable to parse signature: [$signature]")
     })
+      .forceVersion(force)
       .exclude(exclusions.sorted*)
       .configure(attributes = attributes)
   }
@@ -160,12 +164,17 @@ object Dep {
       case s => s";type=$s"
     }
 
+    val forceAttr = dep.force match {
+      case false => ""
+      case true => ";force"
+    }
+
     val excludeAttr =
       dep.dep.minimizedExclusions.toSeq().sorted.map(e =>
         s";exclude=${e._1.value}:${e._2.value}"
       ).mkString
 
-    val attrs = classifierAttr + typeAttr + excludeAttr
+    val attrs = classifierAttr + typeAttr + forceAttr + excludeAttr
 
     val prospective = dep.cross match {
       case CrossVersion.Constant("", false) => Some(s"$org:$mod:$ver$attrs")

--- a/libs/javalib/src/mill/javalib/Dep.scala
+++ b/libs/javalib/src/mill/javalib/Dep.scala
@@ -26,6 +26,7 @@ case class Dep(dep: coursier.Dependency, cross: CrossVersion, force: Boolean) {
   }
   def configure(attributes: coursier.Attributes): Dep = copy(dep = dep.withAttributes(attributes))
   def forceVersion(): Dep = copy(force = true)
+  def forceVersion(force: Boolean): Dep = copy(force = force)
   def exclude(exclusions: (String, String)*): Dep = copy(
     dep = dep.withMinimizedExclusions(
       dep.minimizedExclusions.join(

--- a/libs/javalib/src/mill/javalib/Dep.scala
+++ b/libs/javalib/src/mill/javalib/Dep.scala
@@ -27,9 +27,12 @@ case class Dep(dep: coursier.Dependency, cross: CrossVersion, force: Boolean) {
   def configure(attributes: coursier.Attributes): Dep = copy(dep = dep.withAttributes(attributes))
   def forceVersion(): Dep = copy(force = true)
   def exclude(exclusions: (String, String)*): Dep = copy(
-    dep = dep.withExclusions(
-      dep.exclusions() ++
-        exclusions.map { case (k, v) => (coursier.Organization(k), coursier.ModuleName(v)) }
+    dep = dep.withMinimizedExclusions(
+      dep.minimizedExclusions.join(
+        MinimizedExclusions(
+          exclusions.map { case (k, v) => (coursier.Organization(k), coursier.ModuleName(v)) }.toSet
+        )
+      )
     )
   )
   def excludeOrg(organizations: String*): Dep = exclude(organizations.map(_ -> "*")*)
@@ -157,7 +160,9 @@ object Dep {
     }
 
     val excludeAttr =
-      dep.dep.exclusions().toSeq.sorted.map(e => s";exclude=${e._1.value}:${e._2.value}").mkString
+      dep.dep.minimizedExclusions.toSeq().sorted.map(e =>
+        s";exclude=${e._1.value}:${e._2.value}"
+      ).mkString
 
     val attrs = classifierAttr + typeAttr + excludeAttr
 

--- a/libs/javalib/test/src/mill/javalib/DepTests.scala
+++ b/libs/javalib/test/src/mill/javalib/DepTests.scala
@@ -101,10 +101,14 @@ class DepTests extends TestSuite {
       test("simple") { check("com.example:example-core:1.2.3") }
       test("force") {
         check("com.example:example-core:1.2.3;force")
-        check("com.example:example-core:1.2.3;force=true",
-          normalized = "com.example:example-core:1.2.3;force")
-        check("com.example:example-core:1.2.3;force=false",
-          normalized = "com.example:example-core:1.2.3")
+        check(
+          "com.example:example-core:1.2.3;force=true",
+          normalized = "com.example:example-core:1.2.3;force"
+        )
+        check(
+          "com.example:example-core:1.2.3;force=false",
+          normalized = "com.example:example-core:1.2.3"
+        )
       }
     }
   }

--- a/libs/javalib/test/src/mill/javalib/DepTests.scala
+++ b/libs/javalib/test/src/mill/javalib/DepTests.scala
@@ -88,5 +88,24 @@ class DepTests extends TestSuite {
         msg
       }
     }
+
+    test("parse-unparse") {
+      def check(dep: String, test: Dep => Boolean = _ => true, normalized: String = null): Unit = {
+        val parsed = Dep.parse(dep)
+        assert(test(parsed))
+        val unparsed = Dep.unparse(parsed)
+        assert(unparsed.isDefined)
+        if (normalized == null) assert(Some(dep) == unparsed)
+        else assert(Some(normalized) == unparsed)
+      }
+      test("simple") { check("com.example:example-core:1.2.3") }
+      test("force") {
+        check("com.example:example-core:1.2.3;force")
+        check("com.example:example-core:1.2.3;force=true",
+          normalized = "com.example:example-core:1.2.3;force")
+        check("com.example:example-core:1.2.3;force=false",
+          normalized = "com.example:example-core:1.2.3")
+      }
+    }
   }
 }

--- a/libs/javalib/test/src/mill/javalib/ResolveDepsTests.scala
+++ b/libs/javalib/test/src/mill/javalib/ResolveDepsTests.scala
@@ -95,7 +95,7 @@ object ResolveDepsTests extends TestSuite {
     object forceVersion extends JavaModule {
       def mvnDeps = Seq(
         mvn"org.apache.lucene:lucene-analyzers-common:4.6.1",
-        mvn"org.apache.lucene:lucene-core:4.6.0".forceVersion()
+        mvn"org.apache.lucene:lucene-core:4.6.0;force"
       )
 
       object dependee extends JavaModule {


### PR DESCRIPTION
Encode the existing `forceVersion` API also via the string representation and its parser, making it representable in JSON and configurable via YAML.

Also replace some use of deprecated coursier API.
