### PR TITLE
Fix Spotless RelPathRef decoding

### DIFF
--- a/libs/javalib/src/mill/javalib/spotless/Format.scala
+++ b/libs/javalib/src/mill/javalib/spotless/Format.scala
@@ -293,7 +293,7 @@ object Format {
         def write0[V](out: Visitor[?, V], v: RelPathRef) =
           summon[ReadWriter[PathRef]].write0(out, v.ref)
         def mapNonNullsFunction(t: String) =
-          if t.startsWith("ref:") then RelPathRef(upickle.read[PathRef](t))
+          if t.startsWith("ref:") then RelPathRef(upickle.read[PathRef](ujson.Str(t)))
           else t
       }
   }

--- a/libs/javalib/src/mill/javalib/spotless/SpotlessModule.scala
+++ b/libs/javalib/src/mill/javalib/spotless/SpotlessModule.scala
@@ -60,13 +60,19 @@ trait SpotlessModule extends CoursierModule, OfflineSupportModule {
    *  - resolve any [[Format.RelPathRef relative references]]
    *  - relativize a file path for applying path matchers
    */
+  private def spotlessFormatsJson = Task.Input {
+    val file = moduleDir / ".spotless-formats.json"
+    if os.exists(file) then Some(PathRef(file))
+    else None
+  }
+
   def spotlessFormats: Task[Seq[Format]] = Task {
     BuildCtx.withFilesystemCheckerDisabled {
       import Format.*
       RelPathRef.withDynamicRoot(moduleDir) {
-        val file = moduleDir / ".spotless-formats.json"
-        if os.exists(file) then upickle.read[Seq[Format]](file.toNIO)
-        else Seq(defaultJava, defaultKotlin, defaultScala)
+        spotlessFormatsJson() match
+          case Some(ref) => upickle.read[Seq[Format]](ref.path.toNIO)
+          case None => Seq(defaultJava, defaultKotlin, defaultScala)
       }
     }
   }

--- a/libs/scalalib/test/src/mill/scalalib/spotless/FormatTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/spotless/FormatTests.scala
@@ -1,0 +1,15 @@
+package mill.scalalib.spotless
+
+import mill.javalib.spotless.Format
+import utest.*
+
+object FormatTests extends TestSuite {
+  def tests = Tests {
+    test("relPathRefRoundTrip") {
+      val value = Format.RelPathRef("path.conf")
+      val json = upickle.write(value)
+      val decoded = upickle.read[Format.RelPathRef](json)
+      assert(decoded == value)
+    }
+  }
+}

--- a/libs/scalalib/test/src/mill/scalalib/spotless/SpotlessTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/spotless/SpotlessTests.scala
@@ -128,7 +128,7 @@ object SpotlessTests extends TestSuite {
         val legacyRef0 = PathRef(legacy)
 
         call("git", "init", "-b", "ratchet")
-        call("git", "config", "set", "--local", "commit.gpgsign", "false")
+        call("git", "config", "--local", "commit.gpgsign", "false")
         call("git", "add", ".gitignore", legacy)
         call("git", "commit", "-m", "0") // minimum 1 commit required
 


### PR DESCRIPTION
Fix Spotless RelPathRef decoding

Spotless RelPathRef writes by delegating to PathRef, producing values like
`ref:v0:...:/path/to/config`. The corresponding reader receives this decoded
string and passes it to `upickle.read[PathRef](t)`, which treats `t` as raw JSON text.

That fails because `ref:v0:...:/path/to/config` without quotes is not valid JSON.
The fix is to replace `t` with `ujson.Str(t)`, so `t` is read as a JSON string value
rather than as raw JSON text.

This fixes Spotless task cache misses for options such as a non-default
`ScalaFmt.configFile`, where Mill wrote `out/spotlessFormats.json` but could not
read it back on the next run.

