### PR TITLE
Add option `-L` as short alternative to `--meta-level`

### DIFF
--- a/core/internal/cli/src/mill/internal/MillCliConfig.scala
+++ b/core/internal/cli/src/mill/internal/MillCliConfig.scala
@@ -78,6 +78,7 @@ case class MillCliConfig(
     )
     color: Option[Boolean] = None,
     @arg(
+      short = 'L',
       doc =
         """Select a meta-level to run the given tasks. Level 0 is the main project in `build.mill`,
            level 1 the first meta-build in `mill-build/build.mill`, etc.

--- a/libs/tabcomplete/test/src/mill/tabcomplete/TabCompleteTests.scala
+++ b/libs/tabcomplete/test/src/mill/tabcomplete/TabCompleteTests.scala
@@ -311,11 +311,12 @@ object TabCompleteTests extends TestSuite {
           evalComplete("1", "./mill", "-"),
           Set(
             "-i  Alias for now `--no-daemon`. No longer needed for interactive commands since Mill 1.1.0",
-            "-b  Ring the bell once if the run completes successfully, twice if it fails.",
             "-k  Continue build, even after build failures.",
             "-w  Watch and re-run the given tasks when their inputs change.",
             "-D  <k=v> Define (or overwrite) a system property.",
             "-d  Show debug output on STDOUT",
+            "-L  <int> Select a meta-level to run the given tasks. Level 0 is the main project in `build.mill`, level 1 the first meta-build in `mill-build/build.mill`, etc. If negative, -1 means the deepest meta-build (bootstrap build), -2 the second deepest meta-build, etc.",
+            "-b  Ring the bell once if the run completes successfully, twice if it fails.",
             "-v  Show mill version information and exit.",
             "-j  <str> The number of parallel threads. It can be an integer e.g. `5` meaning 5 threads, an expression e.g. `0.5C` meaning half as many threads as available cores, or `C-2` meaning 2 threads less than the number of cores. `1` disables parallelism and `0` (the default) uses 1 thread per core."
           )

--- a/website/docs/modules/ROOT/pages/cli/flags.adoc
+++ b/website/docs/modules/ROOT/pages/cli/flags.adoc
@@ -30,7 +30,7 @@ To see a cheat sheet of all the command line flags that Mill supports, you can u
 .Output of `mill --help`
 [,console]
 ----
-Mill Build Tool, version 1.1.0-28-6e5003
+Mill Build Tool, version 1.1.6-36-5da273-DIRTYab7bf63d
 Usage: mill [options] task [task-options] [+ task ...]
 
 Task cheat sheet:
@@ -53,7 +53,7 @@ Task cheat sheet:
   ./mill foo.test + bar.test       # run tests in the `foo` module and `bar` module
   ./mill '{foo,bar,qux}.test'      # run tests in the `foo` module, `bar` module, and `qux` module
 
-  ./mill __.resolvedMvnSources     # resolve all third-party dependencies' source code for browsing
+  ./mill foo.resolvedMvnSources    # resolve `foo`'s third-party dependencies' source code for browsing
 
   ./mill foo.assembly              # generate an executable assembly of the module `foo`
   ./mill show foo.assembly         # print the output path of the assembly of module `foo`
@@ -66,27 +66,28 @@ Task cheat sheet:
   ./mill visualize __.compile      # show how the `compile` tasks in each module depend on one another
 
 Options:
-  -D --define <k=v>   Define (or overwrite) a system property.
-  --color <bool>      Toggle colored output; by default enabled only if the console is interactive
-                      or FORCE_COLOR environment variable is set, and NO_COLOR is not set
-  --help              Print this help message and exit.
-  --help-advanced     Print a internal or advanced command flags not intended for common usage
-  --import <str>      Additional ivy dependencies to load into mill, e.g. plugins.
-  -j --jobs <str>     The number of parallel threads. It can be an integer e.g. `5` meaning 5
-                      threads, an expression e.g. `0.5C` meaning half as many threads as available
-                      cores, or `C-2` meaning 2 threads less than the number of cores. `1` disables
-                      parallelism and `0` (the default) uses 1 thread per core.
-  -k --keep-going     Continue build, even after build failures.
-  --meta-level <int>  Select a meta-level to run the given tasks. Level 0 is the main project in
-                      `build.mill`, level 1 the first meta-build in `mill-build/build.mill`, etc. If
-                      negative, -1 means the deepest meta-build (bootstrap build), -2 the second
-                      deepest meta-build, etc.
-  --no-daemon         Run without a long-lived background daemon.
-  --ticker <bool>     Enable or disable the ticker log, which provides information on running tasks
-                      and where each log line came from
-  -v --version        Show mill version information and exit.
-  -w --watch          Watch and re-run the given tasks when their inputs change.
-  task <str>...       The name or a query of the tasks(s) you want to build.
+  -D --define <k=v>      Define (or overwrite) a system property.
+  -L --meta-level <int>  Select a meta-level to run the given tasks. Level 0 is the main project in
+                         `build.mill`, level 1 the first meta-build in `mill-build/build.mill`, etc.
+                         If negative, -1 means the deepest meta-build (bootstrap build), -2 the
+                         second deepest meta-build, etc.
+  --color <bool>         Toggle colored output; by default enabled only if the console is
+                         interactive or FORCE_COLOR environment variable is set, and NO_COLOR is not
+                         set
+  --help                 Print this help message and exit.
+  --help-advanced        Print a internal or advanced command flags not intended for common usage
+  --import <str>         Additional ivy dependencies to load into mill, e.g. plugins.
+  -j --jobs <str>        The number of parallel threads. It can be an integer e.g. `5` meaning 5
+                         threads, an expression e.g. `0.5C` meaning half as many threads as
+                         available cores, or `C-2` meaning 2 threads less than the number of cores.
+                         `1` disables parallelism and `0` (the default) uses 1 thread per core.
+  -k --keep-going        Continue build, even after build failures.
+  --no-daemon            Run without a long-lived background daemon.
+  --ticker <bool>        Enable or disable the ticker log, which provides information on running
+                         tasks and where each log line came from
+  -v --version           Show mill version information and exit.
+  -w --watch             Watch and re-run the given tasks when their inputs change.
+  task <str>...          The name or a query of the tasks(s) you want to build.
 
 See documentation at https://mill-build.org for more details
 ----


### PR DESCRIPTION
Make the `--meta-level` option more convenient.
