### PR TITLE
fix(javalib): add batch task mode for forked tests

### DIFF
--- a/integration/feature/test-task-batch/resources/app/test/src/com/example/BatchFramework.scala
+++ b/integration/feature/test-task-batch/resources/app/test/src/com/example/BatchFramework.scala
@@ -1,0 +1,118 @@
+package com.example
+
+import sbt.testing.Event
+import sbt.testing.EventHandler
+import sbt.testing.Fingerprint
+import sbt.testing.Framework
+import sbt.testing.Logger
+import sbt.testing.OptionalThrowable
+import sbt.testing.Runner
+import sbt.testing.Selector
+import sbt.testing.Status
+import sbt.testing.SubclassFingerprint
+import sbt.testing.SuiteSelector
+import sbt.testing.Task
+import sbt.testing.TaskDef
+
+trait BatchSuite
+trait BatchResource
+
+object SharedResource extends BatchResource
+object BatchSuiteTest extends BatchSuite
+
+class BatchFramework extends Framework {
+  def name(): String = "batch-framework"
+
+  def fingerprints(): Array[Fingerprint] = Array(
+    BatchFramework.ResourceFingerprint,
+    BatchFramework.SuiteFingerprint
+  )
+
+  def runner(
+      args: Array[String],
+      remoteArgs: Array[String],
+      testClassLoader: ClassLoader
+  ): Runner = new BatchRunner(args, remoteArgs)
+
+  def slaveRunner(
+      args: Array[String],
+      remoteArgs: Array[String],
+      testClassLoader: ClassLoader,
+      send: String => Unit
+  ): Runner = new BatchRunner(args, remoteArgs)
+}
+
+object BatchFramework {
+  object SuiteFingerprint extends SubclassFingerprint {
+    def isModule(): Boolean = true
+    def requireNoArgConstructor(): Boolean = true
+    def superclassName(): String = "com.example.BatchSuite"
+  }
+
+  object ResourceFingerprint extends SubclassFingerprint {
+    def isModule(): Boolean = true
+    def requireNoArgConstructor(): Boolean = true
+    def superclassName(): String = "com.example.BatchResource"
+  }
+}
+
+final class BatchRunner(
+    runnerArgs: Array[String],
+    runnerRemoteArgs: Array[String]
+) extends Runner {
+
+  def args(): Array[String] = runnerArgs
+  def remoteArgs(): Array[String] = runnerRemoteArgs
+
+  def tasks(taskDefs: Array[TaskDef]): Array[Task] = {
+    val names = taskDefs.map(_.fullyQualifiedName()).toSet
+    if (
+      names.contains("com.example.SharedResource") &&
+      sys.env.get("MY_ENV") != Some("MY_ENV_VALUE")
+    ) {
+      throw new RuntimeException("Missing MY_ENV while materializing tasks")
+    }
+
+    if (
+      names.contains("com.example.BatchSuiteTest") &&
+      !names.contains("com.example.SharedResource")
+    ) {
+      throw new RuntimeException("BatchSuiteTest was split from SharedResource")
+    }
+
+    taskDefs
+      .filter(_.fullyQualifiedName() == "com.example.BatchSuiteTest")
+      .map(new BatchTask(_))
+  }
+
+  def done(): String = ""
+}
+
+final class BatchTask(td: TaskDef) extends Task {
+  def taskDef(): TaskDef = td
+  def tags(): Array[String] = Array.empty
+
+  def execute(
+      eventHandler: EventHandler,
+      loggers: Array[Logger]
+  ): Array[Task] = {
+    loggers.foreach(_.info("batch task ran with MY_ENV_VALUE"))
+    eventHandler.handle(new Event {
+      def fullyQualifiedName(): String = td.fullyQualifiedName()
+      def fingerprint(): Fingerprint = td.fingerprint()
+      def selector(): Selector = new SuiteSelector
+      def status(): Status = Status.Success
+      def throwable(): OptionalThrowable = new OptionalThrowable()
+      def duration(): Long = 0L
+    })
+    Array.empty
+  }
+
+  def execute(
+      eventHandler: EventHandler,
+      loggers: Array[Logger],
+      continuation: Array[Task] => Unit
+  ): Unit = {
+    continuation(execute(eventHandler, loggers))
+  }
+}

--- a/integration/feature/test-task-batch/resources/build.mill
+++ b/integration/feature/test-task-batch/resources/build.mill
@@ -1,0 +1,17 @@
+package build
+
+import mill.*
+import mill.scalalib.*
+
+object app extends ScalaModule {
+  def scalaVersion = "3.8.2"
+
+  object test extends ScalaTests {
+    def mvnDeps = Seq(mvn"org.scala-sbt:test-interface:1.0")
+    def testFramework = "com.example.BatchFramework"
+    def testBatchFrameworkTasks = true
+    override def forkEnv = {
+      super.forkEnv() ++ Map("MY_ENV" -> "MY_ENV_VALUE")
+    }
+  }
+}

--- a/integration/feature/test-task-batch/src/TestTaskBatchTests.scala
+++ b/integration/feature/test-task-batch/src/TestTaskBatchTests.scala
@@ -1,0 +1,22 @@
+package mill.integration
+
+import mill.testkit.UtestIntegrationTestSuite
+import utest.*
+
+object TestTaskBatchTests extends UtestIntegrationTestSuite {
+  val tests: Tests = Tests {
+    test("forkedBatch") - integrationTest { tester =>
+      val res = tester.eval("app.test")
+      assert(res.isSuccess)
+      assert(res.out.contains("batch task ran with MY_ENV_VALUE"))
+
+      val selected = tester.eval((
+        "app.test.testOnly",
+        "com.example.SharedResource",
+        "com.example.BatchSuiteTest"
+      ))
+      assert(selected.isSuccess)
+      assert(selected.out.contains("batch task ran with MY_ENV_VALUE"))
+    }
+  }
+}

--- a/libs/javalib/src/mill/javalib/TestModule.scala
+++ b/libs/javalib/src/mill/javalib/TestModule.scala
@@ -212,6 +212,22 @@ trait TestModule
   def testParallelism: T[Boolean] = Task { true }
 
   /**
+   * Whether Mill should pass each fork group's full selected `TaskDef` batch to
+   * `Runner.tasks` inside one forked test JVM.
+   *
+   * Some sbt-testing frameworks use `Runner.tasks` to wire relationships between related
+   * `TaskDef`s. For example, Weaver's `GlobalResource` setup is connected to suites from
+   * the full `TaskDef` batch. Set this to true for such frameworks.
+   *
+   * Setting this to true disables intra-group queue parallelism: all classes in a
+   * `testForkGrouping` group run in one subprocess. Separate fork groups can still run
+   * independently.
+   *
+   * See also: https://github.com/com-lihaoyi/mill/issues/7113
+   */
+  def testBatchFrameworkTasks: T[Boolean] = Task { false }
+
+  /**
    * Discovers and runs the module's tests in a subprocess, reporting the
    * results to the console.
    * Arguments before "--" will be used as wildcard selector to select
@@ -335,7 +351,8 @@ trait TestModule
         testLogLevel(),
         propagateEnv(),
         jvmWorker().internalWorker(),
-        discoveredClassesOpt = aheadOfTimeDiscoveredTestClassesIfNeeded()
+        discoveredClassesOpt = aheadOfTimeDiscoveredTestClassesIfNeeded(),
+        testBatchFrameworkTasks = testBatchFrameworkTasks()
       )
       testModuleUtil.runTests()
     }

--- a/libs/javalib/src/mill/javalib/TestModuleUtil.scala
+++ b/libs/javalib/src/mill/javalib/TestModuleUtil.scala
@@ -50,7 +50,9 @@ final class TestModuleUtil(
     propagateEnv: Boolean = true,
     jvmWorker: mill.javalib.api.internal.InternalJvmWorkerApi,
     @com.lihaoyi.unroll
-    discoveredClassesOpt: Option[Seq[(String, Int)]] = None
+    discoveredClassesOpt: Option[Seq[(String, Int)]] = None,
+    @com.lihaoyi.unroll
+    testBatchFrameworkTasks: Boolean = false
 )(using ctx: mill.api.TaskCtx) {
 
   private val (jvmArgs, props) = TestModuleUtil.loadArgsAndProps(useArgsFile, forkArgs)
@@ -70,33 +72,39 @@ final class TestModuleUtil(
     /** This is filtered by mill. */
     val filteredClassLists0 = testClassLists.map(_.filter(globFilter)).filter(_.nonEmpty)
 
-    /** This is filtered by the test framework. */
+    /** This is filtered by the test framework when using queue scheduling. */
     val filteredClassLists = {
-      // If test grouping is enabled and multiple test groups are detected, we need to
-      // run test discovery via the test framework's own argument parsing and filtering
-      // logic once before we potentially fork off multiple test groups that will
-      // each do the same thing and then run tests. This duplication is necessary so we can
-      // skip test groups that we know will be empty, which is important because even an empty
-      // test group requires spawning a JVM which can take 1+ seconds to realize there are no
-      // tests to run and shut down
-      val discoveredTests = jvmWorker.apply(
-        ZincOp.GetTestTasks(
-          (runClasspath ++ testrunnerEntrypointClasspath).map(_.path),
-          testClasspath.map(_.path),
-          testFramework,
-          selectors,
-          args,
-          discoveredClassesOpt
-        ),
-        javaHome = javaHome
-      ).toSet
+      if (testBatchFrameworkTasks) {
+        filteredClassLists0
+      } else {
+        // If test grouping is enabled and multiple test groups are detected, we need to
+        // run test discovery via the test framework's own argument parsing and filtering
+        // logic once before we potentially fork off multiple test groups that will
+        // each do the same thing and then run tests. This duplication is necessary so we can
+        // skip test groups that we know will be empty, which is important because even an empty
+        // test group requires spawning a JVM which can take 1+ seconds to realize there are no
+        // tests to run and shut down
+        val discoveredTests = jvmWorker.apply(
+          ZincOp.GetTestTasks(
+            (runClasspath ++ testrunnerEntrypointClasspath).map(_.path),
+            testClasspath.map(_.path),
+            testFramework,
+            selectors,
+            args,
+            discoveredClassesOpt
+          ),
+          javaHome = javaHome
+        ).toSet
 
-      filteredClassLists0.map(_.filter(discoveredTests)).filter(_.nonEmpty)
+        filteredClassLists0.map(_.filter(discoveredTests)).filter(_.nonEmpty)
+      }
     }
 
     if (selectors.nonEmpty && filteredClassLists.isEmpty) throw doesNotMatchError
 
-    val result = runTestQueueScheduler(filteredClassLists)
+    val result =
+      if (testBatchFrameworkTasks) runTestBatchScheduler(filteredClassLists)
+      else runTestQueueScheduler(filteredClassLists)
 
     result match {
       case f: Result.Failure => f
@@ -206,7 +214,7 @@ final class TestModuleUtil(
 
     val filteredClassCount: Int = filteredClassLists.map(_.size).sum
 
-    val groupFolderData: Seq[(Path, Path, Int)] = prepareTestGroups(filteredClassLists)
+    val groupFolderData: Seq[(TestGroup, Path)] = prepareTestGroups(filteredClassLists)
 
     val outputs = {
       // In parallel mode, we spawn up to "--jobs" runners per group. This is more than
@@ -214,23 +222,19 @@ final class TestModuleUtil(
       // In non-parallel mode, each group uses a single shared folder, so only spawn one
       // runner per group.
       val subprocessFutures = for {
-        ((groupFolder, testClassQueueFolder, numTests), groupIndex) <-
-          groupFolderData.zipWithIndex.toVector
+        ((group, testClassQueueFolder), _) <- groupFolderData.zipWithIndex.toVector
+        groupFolder = group.folder
+        numTests = group.testClasses.length
         (processCount, maxProcessLength) = jobsProcessLength(filteredClassCount, numTests)
-        paddedGroupIndex = Util.leftPad(
-          groupIndex.toString,
-          groupFolderData.length.toString.length,
-          '0'
-        )
         processIndex <- 0 until processCount
       } yield runTestFuture(
         filteredClassCount,
-        groupFolderData,
+        groupFolderData.length,
         groupFolder,
         testClassQueueFolder,
         groupFolder.last,
         maxProcessLength,
-        paddedGroupIndex,
+        group.label,
         processIndex
       )
 
@@ -244,37 +248,95 @@ final class TestModuleUtil(
     TestModuleUtil.processTestResults(outputs)
   }
 
-  private def prepareTestGroups(filteredClassLists: Seq[Seq[String]]) = {
+  private def runTestBatchScheduler(
+      filteredClassLists: Seq[Seq[String]]
+  )(using ctx: mill.api.TaskCtx) = {
+
+    val filteredClassCount: Int = filteredClassLists.map(_.size).sum
+    val groups = testGroups(filteredClassLists)
+
+    val subprocessFutures = groups.toVector.map { group =>
+      val groupFolder = group.folder
+      val testClassList = group.testClasses
+      val resultPath = groupFolder / "result.log"
+      os.write.over(resultPath, upickle.write((0L, 0L)), createFolders = true)
+
+      val selector: Either[Seq[String], (Option[String], os.Path, os.Path)] =
+        if (testClassList.isEmpty) {
+          // Use an empty queue so framework setup/done still runs without selecting all tests.
+          val testClassQueueFolder = prepareTestClassesFolder(Nil, groupFolder)
+          val claimFolder = groupFolder / "claim"
+          os.makeDir.all(claimFolder)
+          Right((None, testClassQueueFolder, claimFolder))
+        } else {
+          Left(testClassList)
+        }
+
+      def run() = {
+        val result = callTestRunnerSubprocess(
+          groupFolder,
+          resultPath,
+          selector,
+          () => ()
+        )
+
+        (testClassList.size, groupFolder.last, Some(result))
+      }
+
+      val future =
+        if (groups.size > 1) {
+          Task.fork.async(
+            groupFolder,
+            group.label,
+            "",
+            priority = -1
+          ) { _ =>
+            run()
+          }
+        } else {
+          Future.successful(run())
+        }
+
+      groupFolder -> future
+    }
+
+    Task.fork.blocking {
+      TestModuleUtil.waitForFutures(ctx, filteredClassCount, subprocessFutures)
+    }
+
+    TestModuleUtil.processTestResults(
+      subprocessFutures.flatMap(_._2.value).map(_.get)
+    )
+  }
+
+  private case class TestGroup(folder: Path, testClasses: Seq[String], label: String)
+
+  private def testGroups(filteredClassLists: Seq[Seq[String]]): Seq[TestGroup] = {
     filteredClassLists match {
-      case Nil => Seq((Task.dest, prepareTestClassesFolder(Nil, Task.dest), 0))
-      case Seq(singleTestClassList) =>
-        Seq((
-          Task.dest,
-          prepareTestClassesFolder(singleTestClassList, Task.dest),
-          singleTestClassList.length
-        ))
+      case Nil => Seq(TestGroup(Task.dest, Nil, "0"))
+      case Seq(singleTestClassList) => Seq(TestGroup(Task.dest, singleTestClassList, "0"))
       case multipleTestClassLists =>
         val maxLength = multipleTestClassLists.length.toString.length
         multipleTestClassLists.zipWithIndex.map { case (testClassList, i) =>
-          val paddedIndex = mill.api.internal.Util.leftPad(i.toString, maxLength, '0')
+          val paddedIndex = Util.leftPad(i.toString, maxLength, '0')
           val folderName = testClassList match {
             case Seq(single) => single
-            case multiple =>
-              s"group-$paddedIndex-${multiple.head}"
+            case multiple => s"group-$paddedIndex-${multiple.head}"
           }
 
-          (
-            Task.dest / folderName,
-            prepareTestClassesFolder(testClassList, Task.dest / folderName),
-            testClassList.length
-          )
+          TestGroup(Task.dest / folderName, testClassList, paddedIndex)
         }
     }
   }
 
+  private def prepareTestGroups(filteredClassLists: Seq[Seq[String]]) =
+    testGroups(filteredClassLists).map { group =>
+      (group, prepareTestClassesFolder(group.testClasses, group.folder))
+    }
+
   def runTestFuture(
       filteredClassCount: Int,
-      groupFolderData: Seq[(Path, Path, Int)],
+      groupCount: Int,
       groupFolder: Path,
       testClassQueueFolder: Path,
       groupName: String,
@@ -293,7 +355,7 @@ final class TestModuleUtil(
     val resultPath = processFolder / s"result.log"
     os.write.over(resultPath, upickle.write((0L, 0L)), createFolders = true)
     val label =
-      if (groupFolderData.size == 1) paddedProcessIndex
+      if (groupCount == 1) paddedProcessIndex
       else s"$paddedGroupIndex-$paddedProcessIndex"
 
     def fork[T](block: Logger => T): Future[T] = {


### PR DESCRIPTION
## TLDR

Add opt-in `testBatchFrameworkTasks` for sbt-testing frameworks that need the full selected `TaskDef` batch in one `Runner.tasks(...)` call.

Fixes #7113.

## Why

Mill's queue scheduler calls `Runner.tasks(...)` per claimed class.

That is fine for most frameworks, but not for frameworks that wire related `TaskDef`s together during `Runner.tasks(...)`.

Example: Weaver `GlobalResource` needs to see the resource `TaskDef` and suite `TaskDef`s together, inside the forked JVM where `forkEnv` is available.

## What Changed

- Add `def testBatchFrameworkTasks: T[Boolean] = false`
- When true:
  - skip queue pre-filtering outside the forked test JVM
  - run each fork group as one batch inside the forked JVM
  - pass the full selected `TaskDef` batch to `Runner.tasks(...)`
- Keep default behavior unchanged for all frameworks

## Tradeoff

`testBatchFrameworkTasks = true` disables intra-group queue parallelism.

`testForkGrouping` still works: separate groups can still run separately.

## Safety

Default is `false`, so existing queue behavior remains unchanged.

The batch path reuses the same fork group folder naming as the queue path. Empty batches use an empty queue so framework setup/done still runs without selecting all tests.

## Tests

- `./mill libs.javalib.compile`
- `./mill integration.feature.test-task-batch`
- `./mill libs.javalib.test mill.javalib.TestModuleUtilTests`

Regression fixture:
- fake sbt-testing framework fails if `forkEnv` is missing in `Runner.tasks(...)`
- fails if resource and suite `TaskDef`s are split
- opts in with `testBatchFrameworkTasks = true`
