### PR TITLE
Contrib: Document how to Owasp Dependency Check Version

### DIFF
--- a/contrib/owaspdependencycheck/readme.adoc
+++ b/contrib/owaspdependencycheck/readme.adoc
@@ -78,3 +78,19 @@ This will make the `owaspDependencyCheck` fail if any vulnerability with a CVSS 
 If you do not want to fail the task, for example to use the result in a downstream task,
 then set `owaspDependencyCheckFailTask = false`.
 
+== Override the Dependency Check Version
+To override the version used, use your own Owasp Dependency Check worker:
+
+[source,scala]
+----
+import mill.contrib.owaspdependencycheck.{OwaspDependencyCheckWorker,OwaspDependencyCheckModule}
+object MyBuildsOwaspDependencyCheckWorker extends OwaspDependencyCheckWorker {
+  // A version from https://github.com/dependency-check/DependencyCheck
+  override def dependencyCheckVersion: T[String] = "<version>"
+}
+// Then override the worker:
+object myModule extends OwaspDependencyCheckModule {
+  override def owaspDependencyCheckWorker: mill.api.ModuleRef[OwaspDependencyCheckWorker] =
+    mill.api.ModuleRef(MyBuildsOwaspDependencyCheckWorker)
+}
+----

--- a/contrib/owaspdependencycheck/src/mill/contrib/owaspdependencycheck/OwaspDependencyCheckModule.scala
+++ b/contrib/owaspdependencycheck/src/mill/contrib/owaspdependencycheck/OwaspDependencyCheckModule.scala
@@ -28,7 +28,7 @@ trait OwaspDependencyCheckModule extends Module, OfflineSupportModule {
   /**
    * The worker is version specific. If another version is required it can be customized here.
    */
-  val owaspDependencyCheckWorker: ModuleRef[OwaspDependencyCheckWorker] =
+  def owaspDependencyCheckWorker: ModuleRef[OwaspDependencyCheckWorker] =
     ModuleRef(OwaspDependencyCheckWorker)
 
   /**


### PR DESCRIPTION
- Document how to override the version, by creating your own worker
- Turn val -> def to avoid any initialization weirdness