### PR TITLE
Avoid List.contains in inputHash

### DIFF
--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -246,10 +246,11 @@ trait GroupExecution {
   ): GroupExecution.Results = {
 
     val inputsHash = {
+      val groupSet = group.toSet
       // The order of tasks within a is unstable, so use `unorderedHash` to
       // make sure we get a stable hash out of it
       val externalInputsHash = MurmurHash3.unorderedHash(
-        group.iterator.flatMap(effectiveInputs).filterNot(group.contains)
+        group.iterator.flatMap(effectiveInputs).filterNot(groupSet.contains)
           .flatMap(results(_).asSuccess.map(_.value._2))
       )
       val sideHashes = MurmurHash3.unorderedHash(group.iterator.map(_.sideHash))


### PR DESCRIPTION
For a noop(already cached) compile task of large codebase,

Before:
```
Executed in   18.96 secs    fish           external
   usr time  124.78 secs    0.00 micros  124.78 secs
   sys time    3.66 secs  789.00 micros    3.66 secs
```
After:
```
Executed in   13.07 secs    fish           external
   usr time   63.67 secs  747.00 micros   63.67 secs
   sys time    4.24 secs   77.00 micros    4.24 secs
```