### PR TITLE
Update autofix-ci/action to 1.3.4

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -13,4 +13,4 @@ jobs:
       - run: |
           ./mill __.fix + mill.javalib.palantirformat.PalantirFormatModule/ + mill.scalalib.scalafmt.ScalafmtModule/scalafmt + mill.kotlinlib.ktlint.KtlintModule/
 
-      - uses: autofix-ci/action@551dded8c6cc8a1054039c8bc0b8b48c51dfc6ef
+      - uses: autofix-ci/action@v1.3.4


### PR DESCRIPTION
Switch from cryptic commit hash-based to release tag-based version.
