### PR TITLE
fix(kotlinlib): remove stale Kotlin CLI class files

### DIFF
--- a/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -340,7 +340,16 @@ trait KotlinModule extends JavaModule with KotlinModuleApi { outer =>
           s"Compiling ${kotlinSourceFiles.size} Kotlin sources ${extra}to ${classes.relativeTo(BuildCtx.workspaceRoot)} ..."
         )
 
-        val compilerArgs: Seq[String] = Seq(
+        val supportsCliOutputTracking =
+          Version.parse(kotlinVersion())
+            .isAtLeast(Version.parse("1.1.3"))(using Version.IgnoreQualifierOrdering)
+
+        val useBtApi =
+          kotlincUseBtApi() && kotlinUseEmbeddableCompiler()
+
+        val useCliOutputTracking = !useBtApi && supportsCliOutputTracking
+
+        val compilerArgs0: Seq[String] = Seq(
           // destdir
           Seq("-d", classes.toString()),
           // apply multi-platform support (expect/actual)
@@ -355,14 +364,25 @@ trait KotlinModule extends JavaModule with KotlinModuleApi { outer =>
           extraKotlinArgs
         ).flatten
 
-        val useBtApi =
-          kotlincUseBtApi() && kotlinUseEmbeddableCompiler()
-
         if (kotlincUseBtApi() && !kotlinUseEmbeddableCompiler()) {
           ctx.log.warn(
             "Kotlin Build Tools API requires kotlinUseEmbeddableCompiler=true; " +
               "falling back to CLI compiler backend."
           )
+        }
+
+        val compilerArgs =
+          if (useCliOutputTracking && !compilerArgs0.contains("-Xreport-output-files")) {
+            compilerArgs0 :+ "-Xreport-output-files"
+          } else {
+            compilerArgs0
+          }
+
+        if (!useBtApi && !useCliOutputTracking) {
+          // Older Kotlin CLI versions cannot report output mappings, so fall back to a
+          // clean classes directory to avoid stale class files from deleted sources.
+          os.remove.all(classes)
+          os.makeDir.all(classes)
         }
 
         val workerResult =

--- a/libs/kotlinlib/test/src/mill/kotlinlib/HelloKotlinTests.scala
+++ b/libs/kotlinlib/test/src/mill/kotlinlib/HelloKotlinTests.scala
@@ -264,5 +264,45 @@ object HelloKotlinTests extends TestSuite {
         os.remove(anotherFile)
       }
     }
+
+    test("deletedTestSourceRemovesClassFileWithCliCompiler") {
+      testEval().scoped { eval =>
+        val cliModule = HelloKotlin.main.crossModules.find(m =>
+          m.crossValue == "2.3.0" && !m.crossValue2
+        ).get
+
+        val srcDir = eval.evaluator.workspace / "main/test/src"
+        val extraFile = srcDir / "DeletedKotlinSourceTest.kt"
+        os.write(
+          extraFile,
+          """package hello.tests
+            |
+            |import org.junit.Test
+            |
+            |class DeletedKotlinSourceTest {
+            |    @Test fun deletedTestMustNotRun() = Unit
+            |}
+            |""".stripMargin,
+          createFolders = true
+        )
+
+        val Right(result1) = eval.apply(cliModule.test.compile).runtimeChecked
+        val deletedClass = result1.value.classes.path / "hello/tests/DeletedKotlinSourceTest.class"
+        assert(os.exists(deletedClass))
+
+        os.remove(extraFile)
+
+        val Right(result2) = eval.apply(cliModule.test.compile).runtimeChecked
+        val Right(discovered) = eval.apply(cliModule.test.discoveredTestClasses).runtimeChecked
+
+        assert(
+          result2.evalCount > 0,
+          !os.exists(deletedClass),
+          os.exists(result2.value.classes.path / "hello/tests/HelloTest.class"),
+          discovered.value.contains("hello.tests.HelloTest"),
+          !discovered.value.contains("hello.tests.DeletedKotlinSourceTest")
+        )
+      }
+    }
   }
 }

--- a/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JvmCompileImpl.scala
+++ b/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JvmCompileImpl.scala
@@ -1,9 +1,114 @@
 package mill.kotlinlib.worker.impl
 
 import mill.api.TaskCtx
+import org.jetbrains.kotlin.cli.common.messages.{
+  CompilerMessageSeverity,
+  CompilerMessageSourceLocation,
+  MessageCollector,
+  MessageRenderer,
+  OutputMessageUtil,
+  PrintingMessageCollector
+}
 import org.jetbrains.kotlin.cli.jvm.K2JVMCompiler
+import org.jetbrains.kotlin.config.Services
+
+import java.io.{FileInputStream, FileOutputStream}
+import java.util.Properties
+import scala.collection.mutable
+import scala.util.Try
 
 class JvmCompileImpl() extends Compiler {
+
+  private def destinationDirectoryFromArgs(args: Seq[String])(using ctx: TaskCtx): os.Path = {
+    args.sliding(2)
+      .collectFirst {
+        case Seq("-d", dir) => os.Path(dir, ctx.workspace)
+      }
+      .getOrElse(ctx.dest / "classes")
+  }
+
+  private def trackedOutputsFile(using ctx: TaskCtx): os.Path =
+    ctx.dest / "kotlin-cli-output-files.properties"
+
+  private def isInDirectory(path: os.Path, dir: os.Path): Boolean =
+    path.toNIO.normalize().startsWith(dir.toNIO.normalize())
+
+  private def loadTrackedOutputs(file: os.Path)(using ctx: TaskCtx): Option[Seq[os.Path]] = {
+    if (!os.exists(file)) None
+    else {
+      Try {
+        val props = new Properties()
+        val input = new FileInputStream(file.toIO)
+        try {
+          props.load(input)
+        } finally {
+          input.close()
+        }
+
+        val count = Try(props.getProperty("count").toInt).getOrElse(0)
+        (0 until count).flatMap { i =>
+          Option(props.getProperty(s"output.$i")).flatMap { path =>
+            Try(os.Path(path, ctx.workspace)).toOption
+          }
+        }
+      }.toOption
+    }
+  }
+
+  private def storeTrackedOutputs(file: os.Path, outputs: Seq[os.Path]): Unit = {
+    os.makeDir.all(file / os.up)
+
+    val props = new Properties()
+    val distinctOutputs = outputs.distinct.sortBy(_.toString)
+    props.setProperty("count", distinctOutputs.size.toString)
+    distinctOutputs.zipWithIndex.foreach { case (output, index) =>
+      props.setProperty(s"output.$index", output.toString)
+    }
+
+    val out = new FileOutputStream(file.toIO)
+    try {
+      props.store(out, "Kotlin CLI output files")
+    } finally {
+      out.close()
+    }
+  }
+
+  private def removePreviousOutputs(destinationDirectory: os.Path)(using ctx: TaskCtx): Unit = {
+    loadTrackedOutputs(trackedOutputsFile) match {
+      case Some(outputs) =>
+        outputs.filter(isInDirectory(_, destinationDirectory)).foreach(os.remove.all(_))
+      case None =>
+        os.remove.all(destinationDirectory)
+        os.makeDir.all(destinationDirectory)
+    }
+  }
+
+  private def trackingMessageCollector(
+      delegate: MessageCollector,
+      destinationDirectory: os.Path,
+      outputFiles: mutable.LinkedHashSet[os.Path]
+  ): MessageCollector = new MessageCollector {
+    override def clear(): Unit = delegate.clear()
+
+    override def hasErrors(): Boolean = delegate.hasErrors()
+
+    override def report(
+        severity: CompilerMessageSeverity,
+        message: String,
+        location: CompilerMessageSourceLocation
+    ): Unit = {
+      if (severity == CompilerMessageSeverity.OUTPUT) {
+        val outputFile = Option(OutputMessageUtil.parseOutputMessage(message))
+          .flatMap(output => Option(output.outputFile))
+          .map(file => os.Path(file.toPath))
+          .filter(isInDirectory(_, destinationDirectory))
+
+        outputFile.foreach(outputFiles.add)
+      } else {
+        delegate.report(severity, message, location)
+      }
+    }
+  }
 
   def compile(
       args: Seq[String],
@@ -12,10 +117,35 @@ class JvmCompileImpl() extends Compiler {
       ctx: TaskCtx
   ): (Int, String) = {
 
+    val shouldTrackOutputs = args.contains("-Xreport-output-files")
     val allArgs = args ++ sources.map(_.toString)
 
     val compiler = K2JVMCompiler()
-    val exitCode = compiler.exec(ctx.log.streams.err, allArgs*)
+    val exitCode =
+      if (shouldTrackOutputs) {
+        val destinationDirectory = destinationDirectoryFromArgs(args)
+        removePreviousOutputs(destinationDirectory)
+
+        val arguments = compiler.createArguments()
+        compiler.parseArguments(allArgs.toArray, arguments)
+
+        val outputFiles = mutable.LinkedHashSet.empty[os.Path]
+        val printer = new PrintingMessageCollector(
+          ctx.log.streams.err,
+          MessageRenderer.PLAIN_RELATIVE_PATHS,
+          false
+        )
+        val collector = trackingMessageCollector(printer, destinationDirectory, outputFiles)
+        val result = compiler.exec(collector, Services.EMPTY, arguments)
+
+        if (result.getCode() == 0) {
+          storeTrackedOutputs(trackedOutputsFile, outputFiles.toSeq)
+        }
+
+        result
+      } else {
+        compiler.exec(ctx.log.streams.err, allArgs*)
+      }
 
     (exitCode.getCode(), exitCode.name())
   }


### PR DESCRIPTION
TLDR: Track Kotlin CLI output files and remove the previous Kotlin outputs before recompiling, so deleted Kotlin sources cannot leave stale `.class` files that still get discovered as tests.

This uses `-Xreport-output-files` for Kotlin CLI versions that support it. Kotlin documents compiler option metadata via the [compiler-options schema](https://kotlinlang.org/docs/compiler-reference.html#schema-for-compiler-options); the `kotlin-compiler-arguments-description` schema lists `Xreport-output-files` as reporting source-to-output mappings, introduced in Kotlin 1.1.3. Older CLI versions fall back to a clean classes dir.

The Kotlin Build Tools API path is unchanged because Kotlin IC already handles stale output cleanup.

Closes #7126

Validation:
- `./mill --no-server libs.kotlinlib.test mill.kotlinlib.HelloKotlinTests`
- `./mill --no-server libs.kotlinlib.test 'mill.kotlinlib.MixedHelloWorldTests.failures'`
- Re-ran the external stale-test MRE with locally built Mill
