### PR TITLE
Refine test class fingerprinting - exclude local classes

### DIFF
--- a/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunnerUtils.scala
+++ b/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunnerUtils.scala
@@ -56,13 +56,24 @@ import scala.math.Ordering.Implicits.*
           listClassFiles(base).map { path =>
             val cls = cl.loadClass(path.stripSuffix(".class").replace('/', '.'))
             val publicConstructorCount =
-              cls.getConstructors.count(c => Modifier.isPublic(c.getModifiers))
+              cls.getConstructors.count(c => Modifier.isPublic(c.getModifiers()))
 
             if (framework.name() == "Jupiter") {
               // sbt-jupiter-interface ignores fingerprinting since JUnit5 has its own resolving mechanism
               Some((cls, fingerprints.head))
             } else if (
-              Modifier.isAbstract(cls.getModifiers) || cls.isInterface || publicConstructorCount > 1
+              // abstract classes
+              Modifier.isAbstract(cls.getModifiers())
+              // interfaces
+              || cls.isInterface()
+              // classes, that can't be constructed publicly
+              || publicConstructorCount > 1
+              // non-static inner classes
+              || (cls.isMemberClass() && !Modifier.isStatic(cls.getModifiers()))
+              // local classes (declared inside a method)
+              || cls.isLocalClass()
+              // anonymous inner classes
+              || cls.isAnonymousClass()
             ) {
               None
             } else {
@@ -77,12 +88,6 @@ import scala.math.Ordering.Implicits.*
             .flatten
         )
       }
-      // I think this is a bug in sbt-junit-interface. AFAICT, JUnit is not
-      // meant to pick up non-static inner classes as test suites, and doing
-      // so makes the jimfs test suite fail
-      //
-      // https://stackoverflow.com/a/17468590
-      .filter { case (c, _) => !c.isMemberClass && !c.isAnonymousClass }
 
     discoveredTestClasses match {
       case Some(discoveredTestClasses0) =>

--- a/libs/scalalib/test/resources/testrunner/scalatest/src/OuterTests.scala
+++ b/libs/scalalib/test/resources/testrunner/scalatest/src/OuterTests.scala
@@ -1,0 +1,16 @@
+// Issue https://github.com/com-lihaoyi/mill/issues/7094
+package mill.scalalib
+
+import org.scalatest.Args
+import org.scalatest.funsuite.AnyFunSuite
+
+class OuterTests extends AnyFunSuite {
+  test("the test") {
+    class InnerTests extends AnyFunSuite {
+      test("inner test")(assert(2 + 2 == 5))
+    }
+
+    val suite = new InnerTests()
+    assert(!suite.run(None, Args(_ => ())).succeeds())
+  }
+}

--- a/libs/scalalib/test/src/mill/scalalib/TestRunnerScalatestTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/TestRunnerScalatestTests.scala
@@ -87,9 +87,8 @@ object TestRunnerScalatestTests extends TestSuite {
               "testargs"
             ),
             testrunnerGrouping.scalatest -> Set(
-              "group-1-mill.scalalib.ScalaTestSpec",
-              "mill.scalalib.OuterTests",
-              "mill.scalalib.ScalaTestSpec3",
+              "group-0-mill.scalalib.OuterTests",
+              "group-1-mill.scalalib.ScalaTestSpec2",
               "test-report.xml"
             ),
             testrunnerWorkStealing.scalatest -> Set("worker-0", "test-classes", "test-report.xml")
@@ -134,9 +133,8 @@ object TestRunnerScalatestTests extends TestSuite {
               "testargs"
             ),
             testrunnerGrouping.scalatest -> Set(
-              "group-1-mill.scalalib.ScalaTestSpec",
-              "mill.scalalib.OuterTests",
-              "mill.scalalib.ScalaTestSpec3",
+              "group-0-mill.scalalib.OuterTests",
+              "group-1-mill.scalalib.ScalaTestSpec2",
               "test-report.xml"
             ),
             testrunnerWorkStealing.scalatest -> Set("worker-0", "test-classes", "test-report.xml")

--- a/libs/scalalib/test/src/mill/scalalib/TestRunnerScalatestTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/TestRunnerScalatestTests.scala
@@ -4,29 +4,46 @@ import mill.api.ExecResult
 import mill.testkit.UnitTester
 import sbt.testing.Status
 import utest.*
+import TestRunnerTestUtils.*
 
 object TestRunnerScalatestTests extends TestSuite {
-  import TestRunnerTestUtils.*
+
   override def tests: Tests = Tests {
+
     test("test") - UnitTester(testrunner, resourcePath).scoped { eval =>
       val Right(result) = eval(testrunner.scalatest.testForked()).runtimeChecked
-      assert(result.value.results.size == 9)
-      junitReportIn(eval.outPath, "scalatest").shouldHave(9 -> Status.Success)
+      assert(result.value.results.size == 10)
+      junitReportIn(eval.outPath, "scalatest").shouldHave(10 -> Status.Success)
     }
+
     test("discoveredTestClasses") - UnitTester(testrunner, resourcePath).scoped { eval =>
-      val Right(result) = eval.apply(testrunner.scalatest.discoveredTestClasses).runtimeChecked
-      val expected = Seq(
+      val Right(result) = eval.apply(testrunner.scalatestZinc.discoveredTestClasses).runtimeChecked
+      val expected = Set(
+        "mill.scalalib.OuterTests",
         "mill.scalalib.ScalaTestSpec",
         "mill.scalalib.ScalaTestSpec2",
         "mill.scalalib.ScalaTestSpec3"
       )
-      assert(result.value == expected)
+      assert(result.value.toSet == expected)
+      expected
+    }
+
+    test("discoveredTestClassesWithZinc") - UnitTester(testrunner, resourcePath).scoped { eval =>
+      val Right(result) = eval.apply(testrunner.scalatestZinc.discoveredTestClasses).runtimeChecked
+      val expected = Set(
+        "mill.scalalib.OuterTests",
+        "mill.scalalib.ScalaTestSpec",
+        "mill.scalalib.ScalaTestSpec2",
+        "mill.scalalib.ScalaTestSpec3"
+      )
+      assert(result.value.toSet == expected)
       expected
     }
 
     test("testOnly") - {
       scala.util.Using.resource(TestOnlyTester(_.scalatest)) { tester =>
 
+        println("Case 1:")
         // Run all tests re-using the same `tester` object for performance reasons
         // singleClass
         tester.testOnly(
@@ -53,10 +70,11 @@ object TestRunnerScalatestTests extends TestSuite {
           }
         )
 
+        println("Case 2:")
         // Runs three test classes with 3 test cases each, and trigger test grouping
         tester.testOnly(
           Seq("*"),
-          9,
+          10,
           Map(
             testrunner.scalatest -> Set(
               "claim",
@@ -69,26 +87,35 @@ object TestRunnerScalatestTests extends TestSuite {
               "testargs"
             ),
             testrunnerGrouping.scalatest -> Set(
-              "group-0-mill.scalalib.ScalaTestSpec",
+              "group-1-mill.scalalib.ScalaTestSpec",
+              "mill.scalalib.OuterTests",
               "mill.scalalib.ScalaTestSpec3",
               "test-report.xml"
             ),
             testrunnerWorkStealing.scalatest -> Set("worker-0", "test-classes", "test-report.xml")
           )
         )
+
+        println("Case 3:")
         // include flag -n
         tester.testOnly(Seq("mill.scalalib.ScalaTestSpec", "--", "-n", "tagged"), 1)
+
+        println("Case 4:")
         // exclude flag -l
         tester.testOnly(Seq("mill.scalalib.ScalaTestSpec", "--", "-l", "tagged"), 2)
+
+        println("Case 5:")
         // Specific test flag -z
         tester.testOnly(
           Seq("mill.scalalib.ScalaTestSpec", "--", "-z", "should have size 0"),
           1
         )
 
+        println("Case 6:")
         // Specific test flag -z with multiple suites
         tester.testOnly(Seq("*", "--", "-z", "should have size 0"), 3)
 
+        println("Case 7:")
         // Scalatest runs all test suites even when `-z` only finds matching tests
         // in one of them. This is just how Scalatest works, and you are expected to
         // sue `testOnly` with a selector before the `--` to select the class you want
@@ -107,7 +134,8 @@ object TestRunnerScalatestTests extends TestSuite {
               "testargs"
             ),
             testrunnerGrouping.scalatest -> Set(
-              "group-0-mill.scalalib.ScalaTestSpec",
+              "group-1-mill.scalalib.ScalaTestSpec",
+              "mill.scalalib.OuterTests",
               "mill.scalalib.ScalaTestSpec3",
               "test-report.xml"
             ),
@@ -115,6 +143,7 @@ object TestRunnerScalatestTests extends TestSuite {
           )
         )
 
+        println("Case 8:")
         // includeAndExclude
         tester.testOnly0 { (eval, mod) =>
           val Left(ExecResult.Failure(msg = msg)) =

--- a/libs/scalalib/test/src/mill/scalalib/TestRunnerTestUtils.scala
+++ b/libs/scalalib/test/src/mill/scalalib/TestRunnerTestUtils.scala
@@ -11,6 +11,7 @@ import utest.*
 import scala.xml.{Elem, NodeSeq, XML}
 
 object TestRunnerTestUtils {
+
   object testrunner extends TestRunnerTestModule {
     def computeTestForkGrouping(x: Seq[String]) = Seq(x)
     def enableParallelism = false
@@ -43,7 +44,7 @@ object TestRunnerTestUtils {
       override def testParallelism = enableParallelism
     }
 
-    object scalatest extends ScalaTests with TestModule.ScalaTest {
+    trait ScalaTest extends ScalaTests with TestModule.ScalaTest {
       override def testForkGrouping = computeTestForkGrouping(discoveredTestClasses())
       override def testParallelism = enableParallelism
       override def mvnDeps = Task {
@@ -51,6 +52,11 @@ object TestRunnerTestUtils {
           mvn"org.scalatest::scalatest:${sys.props.getOrElse("TEST_SCALATEST_VERSION", ???)}"
         )
       }
+    }
+    object scalatest extends ScalaTest
+    object scalatestZinc extends ScalaTest {
+      override def moduleDir = scalatest.moduleDir
+      override def discoverTestsWithZinc = true
     }
 
     trait DoneMessage extends ScalaTests {


### PR DESCRIPTION
Added a new test case adapted from issue comment https://github.com/com-lihaoyi/mill/issues/7094#issuecomment-508575575, reproducing the issue with false detection of a local class.

Refined test class fingerprinting. Especially detect local classes, which are defined inside other methods. Those should not be counted as tests.

Fix https://github.com/com-lihaoyi/mill/issues/7094
