### PR TITLE
Fixed mappings for ErrorProneModule in auto-migration

### DIFF
--- a/integration/migrating/init/resources/golden/gradle/fast-csv
+++ b/integration/migrating/init/resources/golden/gradle/fast-csv
@@ -55,14 +55,18 @@ Module dependencies of lib.test:
     "--release",
     "17",
     "-Xlint:all",
-    "-Werror"
+    "-Werror",
+    "-XDshould-stop.ifError=FLOW",
+    "-XDshouldStopPolicyIfError=FLOW"
   ],
   "lib.test.javacOptions": [
     "-source",
     "25",
     "-target",
     "25",
-    "-parameters"
+    "-parameters",
+    "-XDshould-stop.ifError=FLOW",
+    "-XDshouldStopPolicyIfError=FLOW"
   ]
 }
 null

--- a/libs/init/buildgen/api/src/mill/main/buildgen/ModuleSpec.scala
+++ b/libs/init/buildgen/api/src/mill/main/buildgen/ModuleSpec.scala
@@ -76,21 +76,18 @@ case class ModuleSpec(
 
   def tree: Seq[ModuleSpec] = this +: children.flatMap(_.tree)
 
-  def withErrorProneModule(errorProneMvnDeps: Seq[MvnDep]): ModuleSpec = {
-    javacOptions.base.find(_.group.head.startsWith("-Xplugin:ErrorProne")).fold(this) { epOption =>
-      val epOptions = epOption.group.head.split("\\s").toSeq.tail
-      val (epJavacOptions, javacOptions0) = javacOptions.base
-        .diff(Seq(epOption, Opt("-XDcompilePolicy=simple")))
-        .partition(_.group.head.startsWith("-XD"))
-      this.copy(
-        imports = "mill.javalib.errorprone.ErrorProneModule" +: imports,
-        supertypes = supertypes :+ "ErrorProneModule",
-        errorProneDeps = errorProneMvnDeps,
-        errorProneOptions = epOptions,
-        errorProneJavacEnableOptions = epJavacOptions,
-        javacOptions = javacOptions0
-      )
-    }
+  def withErrorProneModule(
+      errorProneMvnDeps: Values[MvnDep] = Values(),
+      errorProneOptions: Values[String] = Values(),
+      errorProneJavacEnableOptions: Values[Opt] = Values()
+  ): ModuleSpec = {
+    this.copy(
+      imports = "mill.javalib.errorprone.ErrorProneModule" +: imports,
+      supertypes = supertypes :+ "ErrorProneModule",
+      errorProneDeps = errorProneMvnDeps,
+      errorProneOptions = errorProneOptions,
+      errorProneJavacEnableOptions = errorProneJavacEnableOptions
+    )
   }
 
   def withSpringBootModule(springBootVersion: Value[String]): ModuleSpec =
@@ -298,4 +295,6 @@ object ModuleSpec {
       }
     }
   }
+
+  def isManagedJavacOption(arg: String): Boolean = arg == "-XDcompilePolicy=simple"
 }

--- a/libs/init/gradle/exportplugin/src/mill/main/gradle/BuildModelBuilder.scala
+++ b/libs/init/gradle/exportplugin/src/mill/main/gradle/BuildModelBuilder.scala
@@ -78,6 +78,7 @@ class BuildModelBuilder(ctx: GradleBuildCtx, objectFactory: ObjectFactory, works
         case _ => None
       }
       val buildDir = os.Path(getLayout.getBuildDirectory.get().getAsFile)
+      val mainJavaCompile = task[JavaCompile]("compileJava")
       mainModule = mainModule.copy(
         imports = "mill.javalib.*" +: mainModule.imports,
         supertypes = "MavenModule" +: mainModule.supertypes,
@@ -86,12 +87,19 @@ class BuildModelBuilder(ctx: GradleBuildCtx, objectFactory: ObjectFactory, works
         runMvnDeps = mvnDeps("runtimeOnly"),
         bomMvnDeps = mainBomDeps.collect(toMvnDep),
         depManagement = mainConstraints.collect(toMvnDep),
-        javacOptions = task[JavaCompile]("compileJava").fold(Nil)(javacOptions),
+        javacOptions = mainJavaCompile.fold(Nil)(javacOptions),
         moduleDeps = moduleDeps("implementation", "api"),
         compileModuleDeps = moduleDeps("compileOnly", "compileOnlyApi"),
         runModuleDeps = moduleDeps("runtimeOnly"),
         bomModuleDeps = mainBomDeps.collect(toModuleDep)
-      ).withErrorProneModule(mvnDeps("errorprone"))
+      )
+      val hasErrorPronePlugin = getPluginManager.hasPlugin("net.ltgt.errorprone")
+      if (hasErrorPronePlugin) {
+        mainModule = mainModule.withErrorProneModule(
+          errorProneMvnDeps = mvnDeps("errorprone"),
+          errorProneOptions = mainJavaCompile.fold(Nil)(errorProneOptions)
+        )
+      }
       if (isSpringBoot) {
         val pluginVersion = detectPluginVersion(project0, SpringBootPluginId)
         mainModule = mainModule.withSpringBootModule(pluginVersion)
@@ -102,6 +110,7 @@ class BuildModelBuilder(ctx: GradleBuildCtx, objectFactory: ObjectFactory, works
           .fold(Nil)(_.getAllDependencies.asScala.toSeq.collect(toMvnDep)))
         val testBomDeps = testConfigs.flatMap(_.getDependencies.asScala).filter(isBom)
         val testConstraints = testConfigs.flatMap(_.getDependencyConstraints.asScala)
+        val testJavaCompile = task[JavaCompile]("compileTestJava")
         var testModule = ModuleSpec(
           name = "test",
           supertypes = "MavenTests" +: testMixin.toSeq,
@@ -116,7 +125,7 @@ class BuildModelBuilder(ctx: GradleBuildCtx, objectFactory: ObjectFactory, works
           runMvnDeps = mvnDeps("testRuntimeOnly"),
           bomMvnDeps = testBomDeps.collect(toMvnDep),
           depManagement = testConstraints.collect(toMvnDep),
-          javacOptions = task[JavaCompile]("compileTestJava").fold(Nil)(javacOptions),
+          javacOptions = testJavaCompile.fold(Nil)(javacOptions),
           moduleDeps = Values(
             moduleDeps("testImplementation")
               .diff(Seq(ModuleDep(moduleDir.subRelativeTo(workspace).segments))),
@@ -128,7 +137,13 @@ class BuildModelBuilder(ctx: GradleBuildCtx, objectFactory: ObjectFactory, works
           testParallelism = Some(false),
           testSandboxWorkingDir = Some(false),
           testFramework = Option.when(testMixin.isEmpty)("")
-        ).withErrorProneModule(mainModule.errorProneDeps.base)
+        )
+        if (hasErrorPronePlugin) {
+          testModule = testModule.withErrorProneModule(
+            errorProneMvnDeps = mainModule.errorProneDeps,
+            errorProneOptions = testJavaCompile.fold(Nil)(errorProneOptions)
+          )
+        }
         if (isSpringBoot) {
           testModule = testModule.withSpringBootTestsModule()
         }
@@ -253,8 +268,19 @@ class BuildModelBuilder(ctx: GradleBuildCtx, objectFactory: ObjectFactory, works
       Option(task.getTargetCompatibility).map(Opt("-target", _))
     ).flatten)(n => Seq(Opt("--release", n.toString))) ++
       Option(task.getOptions.getEncoding).map(Opt("-encoding", _)) ++
-      Opt.groups(task.getOptions.getAllCompilerArgs.asScala.toSeq)
+      Opt.groups(
+        task.getOptions.getAllCompilerArgs.asScala.toSeq
+          .filterNot(arg => isManagedJavacOption(arg) || isErrorProneOption(arg))
+      )
   }
+
+  private def isErrorProneOption(arg: String): Boolean = arg.startsWith("-Xplugin:ErrorProne")
+
+  private def errorProneOptions(task: JavaCompile): Seq[String] =
+    task.getOptions.getAllCompilerArgs.asScala.toSeq
+      .collectFirst {
+        case arg if isErrorProneOption(arg) => arg.split("\\s+").toSeq.tail
+      }.getOrElse(Nil)
 
   private def toPomPackagingType(pom: MavenPom): Option[String] =
     Try(pom.getPackaging).filter(_ != "jar").toOption

--- a/libs/init/gradle/src/mill/main/gradle/MillGradleBuildGenMain.scala
+++ b/libs/init/gradle/src/mill/main/gradle/MillGradleBuildGenMain.scala
@@ -81,7 +81,7 @@ object MillGradleBuildGenMain {
       val file = gradleWorkspace / "gradle/wrapper/gradle-wrapper.properties"
       if (os.isFile(file)) Using.resource(os.read.inputStream(file))(properties.load)
       val prop = properties.getProperty("org.gradle.jvmargs")
-      if (prop == null) Nil else prop.trim.split("\\s").toSeq
+      if (prop == null) Nil else prop.trim.split("\\s+").toSeq
     }
     buildGen.writeBuildFiles(
       baseDir = millWorkspace,

--- a/libs/init/gradle/test/resources/expected-scala/gradle-8-0/list/package.mill
+++ b/libs/init/gradle/test/resources/expected-scala/gradle-8-0/list/package.mill
@@ -7,19 +7,19 @@ import millbuild.*
 
 object `package` extends ProjectBaseModule, ErrorProneModule {
 
-  def errorProneDeps = Seq(mvn"com.google.errorprone:error_prone_core:2.28.0")
-
-  def errorProneJavacEnableOptions =
+  def javacOptions = super.javacOptions() ++
     Seq("-XDshould-stop.ifError=FLOW", "-XDshouldStopPolicyIfError=FLOW")
 
+  def errorProneDeps = Seq(mvn"com.google.errorprone:error_prone_core:2.28.0")
+
   object test extends ProjectBaseTests, ErrorProneModule {
+
+    def javacOptions = super.javacOptions() ++
+      Seq("-XDshould-stop.ifError=FLOW", "-XDshouldStopPolicyIfError=FLOW")
 
     def errorProneDeps = Seq(mvn"com.google.errorprone:error_prone_core:2.28.0")
 
     def errorProneOptions = Seq("-XepCompilingTestOnlyCode")
-
-    def errorProneJavacEnableOptions =
-      Seq("-XDshould-stop.ifError=FLOW", "-XDshouldStopPolicyIfError=FLOW")
 
   }
 

--- a/libs/init/gradle/test/resources/expected-scala/gradle-8-0/utilities/package.mill
+++ b/libs/init/gradle/test/resources/expected-scala/gradle-8-0/utilities/package.mill
@@ -9,9 +9,9 @@ object `package` extends ProjectBaseModule, ErrorProneModule {
 
   def moduleDeps = Seq(build.list)
 
-  def errorProneDeps = Seq(mvn"com.google.errorprone:error_prone_core:2.28.0")
-
-  def errorProneJavacEnableOptions =
+  def javacOptions = super.javacOptions() ++
     Seq("-XDshould-stop.ifError=FLOW", "-XDshouldStopPolicyIfError=FLOW")
+
+  def errorProneDeps = Seq(mvn"com.google.errorprone:error_prone_core:2.28.0")
 
 }

--- a/libs/init/gradle/test/resources/expected-scala/with-args/gradle-8-0/build.mill
+++ b/libs/init/gradle/test/resources/expected-scala/with-args/gradle-8-0/build.mill
@@ -42,12 +42,16 @@ object `package` extends Module {
 
     def depManagement = Seq(mvn"org.apache.commons:commons-text:1.9")
 
-    def javacOptions = Seq("-source", "17", "-target", "17")
+    def javacOptions = Seq(
+      "-source",
+      "17",
+      "-target",
+      "17",
+      "-XDshould-stop.ifError=FLOW",
+      "-XDshouldStopPolicyIfError=FLOW"
+    )
 
     def errorProneDeps = Seq(mvn"com.google.errorprone:error_prone_core:2.28.0")
-
-    def errorProneJavacEnableOptions =
-      Seq("-XDshould-stop.ifError=FLOW", "-XDshouldStopPolicyIfError=FLOW")
 
     object test extends MavenTests, TestModule.Junit5, ErrorProneModule {
 
@@ -57,7 +61,14 @@ object `package` extends Module {
 
       def bomMvnDeps = Seq(mvn"org.junit:junit-bom:5.9.1")
 
-      def javacOptions = Seq("-source", "17", "-target", "17")
+      def javacOptions = Seq(
+        "-source",
+        "17",
+        "-target",
+        "17",
+        "-XDshould-stop.ifError=FLOW",
+        "-XDshouldStopPolicyIfError=FLOW"
+      )
 
       def forkWorkingDir = moduleDir
 
@@ -65,9 +76,6 @@ object `package` extends Module {
         Seq(mvn"com.google.errorprone:error_prone_core:2.28.0")
 
       def errorProneOptions = Seq("-XepCompilingTestOnlyCode")
-
-      def errorProneJavacEnableOptions =
-        Seq("-XDshould-stop.ifError=FLOW", "-XDshouldStopPolicyIfError=FLOW")
 
       def testParallelism = false
 
@@ -83,12 +91,16 @@ object `package` extends Module {
 
     def depManagement = Seq(mvn"org.apache.commons:commons-text:1.9")
 
-    def javacOptions = Seq("-source", "17", "-target", "17")
+    def javacOptions = Seq(
+      "-source",
+      "17",
+      "-target",
+      "17",
+      "-XDshould-stop.ifError=FLOW",
+      "-XDshouldStopPolicyIfError=FLOW"
+    )
 
     def errorProneDeps = Seq(mvn"com.google.errorprone:error_prone_core:2.28.0")
-
-    def errorProneJavacEnableOptions =
-      Seq("-XDshould-stop.ifError=FLOW", "-XDshouldStopPolicyIfError=FLOW")
 
   }
 

--- a/libs/init/gradle/test/resources/expected/gradle-8-0/list/package.mill.yaml
+++ b/libs/init/gradle/test/resources/expected/gradle-8-0/list/package.mill.yaml
@@ -1,11 +1,11 @@
 extends: [millbuild.ProjectBaseModule, mill.javalib.errorprone.ErrorProneModule]
+javacOptions: !append [-XDshould-stop.ifError=FLOW, -XDshouldStopPolicyIfError=FLOW]
 errorProneDeps:
 - com.google.errorprone:error_prone_core:2.28.0
-errorProneJavacEnableOptions: [-XDshould-stop.ifError=FLOW, -XDshouldStopPolicyIfError=FLOW]
 
 object test:
   extends: [ProjectBaseTests, mill.javalib.errorprone.ErrorProneModule]
+  javacOptions: !append [-XDshould-stop.ifError=FLOW, -XDshouldStopPolicyIfError=FLOW]
   errorProneDeps:
   - com.google.errorprone:error_prone_core:2.28.0
   errorProneOptions: [-XepCompilingTestOnlyCode]
-  errorProneJavacEnableOptions: [-XDshould-stop.ifError=FLOW, -XDshouldStopPolicyIfError=FLOW]

--- a/libs/init/gradle/test/resources/expected/gradle-8-0/utilities/package.mill.yaml
+++ b/libs/init/gradle/test/resources/expected/gradle-8-0/utilities/package.mill.yaml
@@ -1,5 +1,5 @@
 extends: [millbuild.ProjectBaseModule, mill.javalib.errorprone.ErrorProneModule]
 moduleDeps: [list]
+javacOptions: !append [-XDshould-stop.ifError=FLOW, -XDshouldStopPolicyIfError=FLOW]
 errorProneDeps:
 - com.google.errorprone:error_prone_core:2.28.0
-errorProneJavacEnableOptions: [-XDshould-stop.ifError=FLOW, -XDshouldStopPolicyIfError=FLOW]

--- a/libs/init/gradle/test/resources/expected/with-args/gradle-8-0/build.mill.yaml
+++ b/libs/init/gradle/test/resources/expected/with-args/gradle-8-0/build.mill.yaml
@@ -27,10 +27,9 @@ object list:
   extends: [MavenModule, mill.javalib.errorprone.ErrorProneModule]
   depManagement:
   - org.apache.commons:commons-text:1.9
-  javacOptions: [-source, 17, -target, 17]
+  javacOptions: [-source, 17, -target, 17, -XDshould-stop.ifError=FLOW, -XDshouldStopPolicyIfError=FLOW]
   errorProneDeps:
   - com.google.errorprone:error_prone_core:2.28.0
-  errorProneJavacEnableOptions: [-XDshould-stop.ifError=FLOW, -XDshouldStopPolicyIfError=FLOW]
   
   object test:
     extends: [MavenTests, TestModule.Junit5, mill.javalib.errorprone.ErrorProneModule]
@@ -40,11 +39,10 @@ object list:
     - org.junit.platform:junit-platform-launcher
     bomMvnDeps:
     - org.junit:junit-bom:5.9.1
-    javacOptions: [-source, 17, -target, 17]
+    javacOptions: [-source, 17, -target, 17, -XDshould-stop.ifError=FLOW, -XDshouldStopPolicyIfError=FLOW]
     errorProneDeps:
     - com.google.errorprone:error_prone_core:2.28.0
     errorProneOptions: [-XepCompilingTestOnlyCode]
-    errorProneJavacEnableOptions: [-XDshould-stop.ifError=FLOW, -XDshouldStopPolicyIfError=FLOW]
     testParallelism: false
     testSandboxWorkingDir: false
 
@@ -53,7 +51,6 @@ object utilities:
   moduleDeps: [list]
   depManagement:
   - org.apache.commons:commons-text:1.9
-  javacOptions: [-source, 17, -target, 17]
+  javacOptions: [-source, 17, -target, 17, -XDshould-stop.ifError=FLOW, -XDshouldStopPolicyIfError=FLOW]
   errorProneDeps:
   - com.google.errorprone:error_prone_core:2.28.0
-  errorProneJavacEnableOptions: [-XDshould-stop.ifError=FLOW, -XDshouldStopPolicyIfError=FLOW]

--- a/libs/init/maven/src/mill/main/maven/MillMavenBuildGenMain.scala
+++ b/libs/init/maven/src/mill/main/maven/MillMavenBuildGenMain.scala
@@ -114,7 +114,8 @@ object MillMavenBuildGenMain {
             runModuleDeps = moduleDeps("runtime"),
             bomModuleDeps = bomModuleDeps,
             artifactName = Option(model.getArtifactId)
-          ).withErrorProneModule(plugins.errorProneMvnDeps)
+          )
+          mainModule = plugins.withErrorProneModule(mainModule).getOrElse(mainModule)
           if (isSpringParentProject) {
             mainModule = mainModule.withSpringBootModule(springBootVersion)
           }

--- a/libs/init/maven/src/mill/main/maven/Plugins.scala
+++ b/libs/init/maven/src/mill/main/maven/Plugins.scala
@@ -1,6 +1,7 @@
 package mill.main.maven
 
-import mill.main.buildgen.ModuleSpec.{MvnDep, Opt}
+import mill.main.buildgen.ModuleSpec
+import mill.main.buildgen.ModuleSpec.*
 import org.apache.maven.model.{ConfigurationContainer, Model}
 import org.codehaus.plexus.util.xml.Xpp3Dom
 
@@ -12,28 +13,49 @@ class Plugins(model: Model) {
     def opt(name: String, prefix: String = "-") = value(dom, name).map(Opt(prefix + name, _))
     opt("release", "--").fold(Seq(opt("source"), opt("target")).flatten)(Seq(_)) ++
       opt("encoding") ++
-      child(dom, "compilerArgs").fold(Nil)(dom => Opt.groups(values(dom, "arg")))
+      child(dom, "compilerArgs").fold(Nil)(dom =>
+        Opt.groups(
+          values(dom, "arg").filterNot(arg => isManagedJavacOption(arg) || isErrorProneOption(arg))
+        )
+      )
   }
 
-  def errorProneMvnDeps: Seq[MvnDep] = plugin("maven-compiler-plugin").flatMap(config)
-    .filter(child(_, "compilerArgs").exists(
-      values(_, "arg").exists(_.startsWith("-Xplugin:ErrorProne"))
-    ))
-    .flatMap(child(_, "annotationProcessorPaths"))
-    .fold(Nil)(children(_, "path"))
-    .flatMap { dom =>
-      for {
-        organization <- value(dom, "groupId")
-        name <- value(dom, "artifactId")
-        version = value(dom, "version").getOrElse("")
-        excludes = children(dom, "exclusions").flatMap { dom =>
+  private def isErrorProneOption(arg: String): Boolean = arg.startsWith("-Xplugin:ErrorProne")
+
+  def withErrorProneModule(spec: ModuleSpec): Option[ModuleSpec] =
+    for {
+      dom <- plugin("maven-compiler-plugin").flatMap(config)
+      epArg <- child(dom, "compilerArgs").flatMap(values(_, "arg").find(isErrorProneOption))
+      epArgs = epArg.split("\\s+").toSeq.tail
+      // https://errorprone.info/docs/flags#maven
+      epOptions = epArgs.collectFirst {
+        case arg if arg.head == '@' =>
+          os.read(os.Path(arg.tail)).split("\\s+").toSeq
+      }.getOrElse(epArgs)
+      epMvnDeps = child(dom, "annotationProcessorPaths").fold(Nil)(children(_, "path"))
+        .flatMap { dom =>
           for {
-            groupId <- value(dom, "groupId")
-            artifactId <- value(dom, "artifactId")
-          } yield (groupId, artifactId)
+            organization <- value(dom, "groupId")
+            name <- value(dom, "artifactId")
+            version = value(dom, "version").getOrElse("")
+            classifier = value(dom, "classifier")
+            _type = value(dom, "type")
+            excludes = children(dom, "exclusions").flatMap { dom =>
+              for {
+                groupId <- value(dom, "groupId")
+                artifactId <- value(dom, "artifactId")
+              } yield (groupId, artifactId)
+            }
+          } yield MvnDep(
+            organization = organization,
+            name = name,
+            version = version,
+            classifier = classifier,
+            `type` = _type,
+            excludes = excludes
+          )
         }
-      } yield MvnDep(organization, name, version, excludes = excludes)
-    }
+    } yield spec.withErrorProneModule(errorProneMvnDeps = epMvnDeps, errorProneOptions = epOptions)
 
   def skipDeploy: Boolean = plugin("maven-deploy-plugin").flatMap(config)
     .flatMap(value(_, "skip")).fold(false)(_.toBoolean)

--- a/libs/init/maven/test/resources/expected-scala/quickstart/build.mill
+++ b/libs/init/maven/test/resources/expected-scala/quickstart/build.mill
@@ -11,11 +11,10 @@ object `package` extends MavenModule, ErrorProneModule, PublishModule {
 
   def bomMvnDeps = Seq(mvn"org.junit:junit-bom:5.11.0")
 
-  def javacOptions = Seq("-source", "8", "-target", "8")
+  def javacOptions =
+    Seq("-source", "8", "-target", "8", "-XDshould-stop=ifError=FLOW")
 
   def errorProneDeps = Seq(mvn"com.google.errorprone:error_prone_core:2.28.0")
-
-  def errorProneJavacEnableOptions = Seq("-XDshould-stop=ifError=FLOW")
 
   def artifactName = "maven-3-9-11"
 

--- a/libs/init/maven/test/resources/expected-scala/with-args/quickstart/build.mill
+++ b/libs/init/maven/test/resources/expected-scala/with-args/quickstart/build.mill
@@ -11,11 +11,10 @@ object `package` extends MavenModule, ErrorProneModule, PublishModule {
 
   def bomMvnDeps = Seq(mvn"org.junit:junit-bom:5.11.0")
 
-  def javacOptions = Seq("-source", "8", "-target", "8")
+  def javacOptions =
+    Seq("-source", "8", "-target", "8", "-XDshould-stop=ifError=FLOW")
 
   def errorProneDeps = Seq(mvn"com.google.errorprone:error_prone_core:2.28.0")
-
-  def errorProneJavacEnableOptions = Seq("-XDshould-stop=ifError=FLOW")
 
   def artifactName = "maven-3-9-11"
 

--- a/libs/init/maven/test/resources/expected/quickstart/build.mill.yaml
+++ b/libs/init/maven/test/resources/expected/quickstart/build.mill.yaml
@@ -3,10 +3,9 @@ mill-jvm-version: system
 extends: [MavenModule, mill.javalib.errorprone.ErrorProneModule, PublishModule]
 bomMvnDeps:
 - org.junit:junit-bom:5.11.0
-javacOptions: [-source, 8, -target, 8]
+javacOptions: [-source, 8, -target, 8, -XDshould-stop=ifError=FLOW]
 errorProneDeps:
 - com.google.errorprone:error_prone_core:2.28.0
-errorProneJavacEnableOptions: [-XDshould-stop=ifError=FLOW]
 artifactName: maven-3-9-11
 pomSettings:
   organization: com.mycompany.app

--- a/libs/init/maven/test/resources/expected/with-args/quickstart/build.mill.yaml
+++ b/libs/init/maven/test/resources/expected/with-args/quickstart/build.mill.yaml
@@ -3,10 +3,9 @@ mill-jvm-version: system
 extends: [MavenModule, mill.javalib.errorprone.ErrorProneModule, PublishModule]
 bomMvnDeps:
 - org.junit:junit-bom:5.11.0
-javacOptions: [-source, 8, -target, 8]
+javacOptions: [-source, 8, -target, 8, -XDshould-stop=ifError=FLOW]
 errorProneDeps:
 - com.google.errorprone:error_prone_core:2.28.0
-errorProneJavacEnableOptions: [-XDshould-stop=ifError=FLOW]
 artifactName: maven-3-9-11
 pomSettings:
   organization: com.mycompany.app

--- a/libs/init/sbt/src/mill/main/sbt/MillSbtBuildGenMain.scala
+++ b/libs/init/sbt/src/mill/main/sbt/MillSbtBuildGenMain.scala
@@ -123,7 +123,7 @@ object MillSbtBuildGenMain {
       if (os.isFile(file)) os.read.lines(file)
         .map(_.trim)
         .filter(s => s.nonEmpty && !s.startsWith("#"))
-        .flatMap(_.split("\\s"))
+        .flatMap(_.split("\\s+"))
       else Nil
     }
     val metaMvnDeps =


### PR DESCRIPTION
- Revised mappings to include unmanaged [back door compiler options](https://github.com/openjdk/jdk/blob/ef0851d8adbb834e1cd5aff5b3b973b953e57e2d/src/jdk.compiler/share/classes/com/sun/tools/javac/main/Option.java#L653) in `javacOptions` instead of `errorProneEnableJavacOptions`.
- Handle consecutive delimiters when parsing whitespace delimited values. This change was applied in other places where this pattern appears.
- For Maven projects,
  - Added support for loading [errorProneOptions from file](https://errorprone.info/docs/flags#maven).
  - Added mappings for `classifier` and `type` attributes for `errorProneMvnDeps`.

Resolves #6827
