### PR TITLE
Android: Use java 21 in examples

### DIFF
--- a/example/thirdparty/android-endless-tunnel/build.mill
+++ b/example/thirdparty/android-endless-tunnel/build.mill
@@ -1,3 +1,4 @@
+//| mill-jvm-version: zulu:21
 // This is how endless-tunnel from android ndk-sample can be built with mill.
 // The original code is in https://github.com/android/ndk-samples/tree/main/endless-tunnel
 

--- a/example/thirdparty/androidtodo/build.mill
+++ b/example/thirdparty/androidtodo/build.mill
@@ -1,3 +1,4 @@
+//| mill-jvm-version: zulu:21
 package build
 
 import mill.*, androidlib.*, kotlinlib.*


### PR DESCRIPTION
#7076 which bumped to Java 25, correctly updated the Android examples to use Java21 except these two. 
I noticed that their [weekly scheduled CI run](https://github.com/com-lihaoyi/mill/actions/runs/26351968056) failed.