### PR TITLE
Added defaults for members of PomSettings

### DIFF
--- a/libs/init/buildgen/src/mill/main/buildgen/BuildGen.scala
+++ b/libs/init/buildgen/src/mill/main/buildgen/BuildGen.scala
@@ -45,7 +45,7 @@ trait BuildGen {
         imports = (a.imports ++ b.imports).distinct.filter(!_.startsWith("millbuild.")),
         supertypes = a.supertypes.intersect(b.supertypes) match {
           case Nil => hierarchy.take(1)
-          case seq if hierarchy.contains(seq.head) => seq
+          case seq if seq.exists(hierarchy.contains) => seq
           case seq => hierarchy.head +: seq
         },
         repositories = parentValues(a.repositories, b.repositories),

--- a/libs/javalib/src/mill/javalib/publish/model.scala
+++ b/libs/javalib/src/mill/javalib/publish/model.scala
@@ -71,12 +71,12 @@ case class Developer(
 ) derives RW
 
 case class PomSettings(
-    description: String,
-    organization: String,
-    url: String,
-    licenses: Seq[License],
-    versionControl: VersionControl,
-    developers: Seq[Developer],
+    description: String = "",
+    organization: String = "",
+    url: String = "",
+    licenses: Seq[License] = Nil,
+    versionControl: VersionControl = VersionControl(),
+    developers: Seq[Developer] = Nil,
     @deprecated("Value will be ignored. Use PublishModule.pomPackagingType instead", "Mill 0.11.8")
     packaging: String = PackagingType.Jar
 ) derives RW


### PR DESCRIPTION
Resolves #6865. The fix was verified manually for the example project:
```
$ ./mill show pomSettings
{
  "organization": "org.springframework"
}
```

Also revised heuristic for computing `supertypes` of a base module to resolve compilation errors in the imported build for the example project:
```
build.mill.yaml-68] [error] mill-build/src/ProjectBaseModule.scala:9:44
build.mill.yaml-68]     extends MavenModule, SpringBootModule, MavenModule, PublishModule {
build.mill.yaml-68]                                            ^^^^^^^^^^^
build.mill.yaml-68] trait MavenModule is extended twice
build.mill.yaml-68] [error] mill-build/src/ProjectBaseModule.scala:24:50
build.mill.yaml-68]       extends MavenTests, SpringBootTestsModule, MavenTests, TestModule.Junit5 {
build.mill.yaml-68]                                                  ^^^^^^^^^^
build.mill.yaml-68] trait MavenTests is extended twice
```
