### PR TITLE
Fix cross-request deadlocks from retained per-task read locks

### DIFF
--- a/core/api/daemon/src/mill/api/daemon/internal/LauncherLocking.scala
+++ b/core/api/daemon/src/mill/api/daemon/internal/LauncherLocking.scala
@@ -54,6 +54,16 @@ private[mill] trait LauncherLocking extends AutoCloseable {
   ): LauncherLocking.Lease
 
   /**
+   * Non-blocking, non-queued Read counterpart of [[taskLock]].
+   * This lets callers preserve normal optimistic parallelism while still
+   * avoiding ordered wait cycles when the lock is actually contended.
+   */
+  def tryTaskReadLock(
+      path: Path,
+      displayLabel: String
+  ): Either[LauncherLocking.Contention, LauncherLocking.Lease]
+
+  /**
    * Non-blocking, non-queued Write counterpart of [[taskLock]].
    * See [[tryMetaBuildWriteLock]] for semantics.
    */
@@ -67,6 +77,17 @@ private[mill] trait LauncherLocking extends AutoCloseable {
    * [[awaitMetaBuildStateChange]].
    */
   def awaitTaskStateChange(path: Path, displayLabel: String, timeoutMs: Long): Unit
+
+  /**
+   * Monotonic version for a task output lock. Incremented after a successful
+   * task publish under the corresponding Write lock, and used by evaluations
+   * that temporarily drop retained Reads to detect whether their in-memory
+   * result became stale.
+   */
+  def taskVersion(path: Path): Long
+
+  /** Mark the given task output as rewritten and return its new version. */
+  def markTaskWritten(path: Path): Long
 
   /**
    * Daemon-wide lock taken by each task batch. Normal batches take Read so
@@ -168,9 +189,13 @@ private[mill] object LauncherLocking {
         kind: LockKind,
         waitReporter: WaitReporter
     ): Lease = NoopLease
+    override def tryTaskReadLock(path: Path, displayLabel: String): Either[Contention, Lease] =
+      Right(NoopLease)
     override def tryTaskWriteLock(path: Path, displayLabel: String): Either[Contention, Lease] =
       Right(NoopLease)
     override def awaitTaskStateChange(path: Path, displayLabel: String, timeoutMs: Long): Unit = ()
+    override def taskVersion(path: Path): Long = 0L
+    override def markTaskWritten(path: Path): Long = 0L
     override def exclusiveLock(kind: LockKind, waitReporter: WaitReporter): Lease = NoopLease
     override def withReleasedExclusive[T](waitReporter: WaitReporter)(body: => T): T = body
     override def close(): Unit = ()

--- a/core/exec/src/mill/exec/Execution.scala
+++ b/core/exec/src/mill/exec/Execution.scala
@@ -155,6 +155,25 @@ case class Execution(
       testReporter: TestReporter /* = TestReporter.DummyTestReporter*/,
       serialCommandExec: Boolean
   ): Execution.Results = {
+    while (true) {
+      try return execute0Once(goals, logger, reporter, testReporter, serialCommandExec)
+      catch {
+        case e: Execution.RetryDueToDroppedTaskLock =>
+          logger.debug(s"Retrying evaluation after concurrent rewrite of ${e.label}")
+      }
+    }
+    throw new AssertionError("unreachable")
+  }
+
+  private def execute0Once(
+      goals: Seq[Task[?]],
+      logger: Logger,
+      reporter: Int => Option[
+        CompileProblemReporter
+      ] /* = _ => Option.empty[CompileProblemReporter]*/,
+      testReporter: TestReporter /* = TestReporter.DummyTestReporter*/,
+      serialCommandExec: Boolean
+  ): Execution.Results = {
     os.makeDir.all(outPath)
     val failed = AtomicBoolean(false)
     val count = AtomicInteger(1)
@@ -492,6 +511,7 @@ case class Execution(
 }
 
 object Execution {
+  class RetryDueToDroppedTaskLock(val label: String) extends RuntimeException(label)
 
   /**
    * Tracks per-task read leases on the workspace lock and releases them once
@@ -507,13 +527,34 @@ object Execution {
       indexToTerminal: Array[Task[?]],
       interGroupDeps: Map[Task[?], Seq[Task[?]]]
   ) {
+    class Retained(
+        val path: java.nio.file.Path,
+        val label: String,
+        val key: String,
+        var lease: LauncherLocking.Lease,
+        var observedVersion: Long
+    ) {
+      var dropped: Boolean = false
+    }
+
     class State(initialPending: Int) {
       val pending = AtomicInteger(initialPending)
       val completed = AtomicBoolean(false)
-      val leases = new java.util.concurrent.ConcurrentLinkedQueue[LauncherLocking.Lease]()
+      val activeConsumers = AtomicInteger(0)
+      var retained: Retained = null
     }
 
     val states = new ConcurrentHashMap[Task[?], State]()
+    private val transitiveUpstreams: Map[Task[?], Seq[Task[?]]] = {
+      val memo = mutable.Map.empty[Task[?], Seq[Task[?]]]
+      def rec(task: Task[?]): Seq[Task[?]] = memo.getOrElseUpdate(
+        task, {
+          val direct = interGroupDeps.getOrElse(task, Nil)
+          (direct ++ direct.flatMap(rec)).distinct
+        }
+      )
+      indexToTerminal.iterator.map(t => t -> rec(t)).toMap
+    }
 
     locally {
       val pendingCounts = mutable.Map.empty[Task[?], Int].withDefaultValue(0)
@@ -526,11 +567,12 @@ object Execution {
       try lease.close()
       catch { case _: Throwable => () }
 
-    private def drainLeases(s: State): Unit = {
-      var lease = s.leases.poll()
-      while (lease != null) {
-        closeQuietly(lease)
-        lease = s.leases.poll()
+    private def drainLeases(s: State): Unit = s.synchronized {
+      val retained = s.retained
+      s.retained = null
+      if (retained != null && retained.lease != null) {
+        closeQuietly(retained.lease)
+        retained.lease = null
       }
     }
 
@@ -539,7 +581,13 @@ object Execution {
       while (queue.nonEmpty) {
         val task = queue.dequeue()
         val s = states.get(task)
-        if (s != null && s.completed.get() && s.pending.get() == 0 && states.remove(task, s)) {
+        if (
+          s != null &&
+          s.completed.get() &&
+          s.pending.get() == 0 &&
+          s.activeConsumers.get() == 0 &&
+          states.remove(task, s)
+        ) {
           drainLeases(s)
           for (upstream <- interGroupDeps.getOrElse(task, Nil)) {
             val upstreamState = states.get(upstream)
@@ -552,10 +600,96 @@ object Execution {
       }
     }
 
-    def retain(task: Task[?], lease: LauncherLocking.Lease): Unit = {
+    def retain(
+        task: Task[?],
+        path: java.nio.file.Path,
+        label: String,
+        lease: LauncherLocking.Lease,
+        observedVersion: Long
+    ): Unit = {
       val s = states.get(task)
-      if (s != null) s.leases.add(lease)
+      if (s != null) s.synchronized {
+        if (s.retained != null && s.retained.lease != null) closeQuietly(s.retained.lease)
+        s.retained = Retained(
+          path = path,
+          label = label,
+          key = path.toAbsolutePath.normalize().toString,
+          lease = lease,
+          observedVersion = observedVersion
+        )
+      }
       else closeQuietly(lease)
+    }
+
+    def retain(task: Task[?], lease: LauncherLocking.Lease): Unit =
+      retain(task, java.nio.file.Paths.get(task.toString), task.toString, lease, 0L)
+
+    def releaseHigherThan(key: String): Unit = {
+      import scala.jdk.CollectionConverters.*
+      for (s <- states.values().asScala) s.synchronized {
+        val retained = s.retained
+        if (
+          retained != null &&
+          retained.lease != null &&
+          retained.key > key &&
+          s.activeConsumers.get() == 0
+        ) {
+          closeQuietly(retained.lease)
+          retained.lease = null
+          retained.dropped = true
+        }
+      }
+    }
+
+    def reacquireDropped(
+        workspaceLocking: LauncherLocking,
+        waitReporter: LauncherLocking.WaitReporter
+    ): Unit = {
+      import scala.jdk.CollectionConverters.*
+      val dropped = states.values().asScala.toSeq.flatMap { s =>
+        s.synchronized {
+          val retained = s.retained
+          Option.when(retained != null && retained.dropped && retained.lease == null)(s -> retained)
+        }
+      }.sortBy(_._2.key)
+
+      for ((s, retained) <- dropped) {
+        val lease = workspaceLocking.taskLock(
+          retained.path,
+          retained.label,
+          LauncherLocking.LockKind.Read,
+          waitReporter
+        )
+        val currentVersion = workspaceLocking.taskVersion(retained.path)
+        if (currentVersion != retained.observedVersion) {
+          closeQuietly(lease)
+          throw RetryDueToDroppedTaskLock(retained.label)
+        }
+        s.synchronized {
+          if (s.retained eq retained) {
+            retained.lease = lease
+            retained.dropped = false
+          } else closeQuietly(lease)
+        }
+      }
+    }
+
+    def withActiveConsumers[T](terminal: Task[?])(body: => T): T = {
+      val upstreams = transitiveUpstreams.getOrElse(terminal, Nil)
+      upstreams.foreach { task =>
+        val s = states.get(task)
+        if (s != null) s.activeConsumers.incrementAndGet()
+      }
+      try body
+      finally {
+        upstreams.foreach { task =>
+          val s = states.get(task)
+          if (s != null) {
+            s.activeConsumers.decrementAndGet()
+            releaseIfDrained(task)
+          }
+        }
+      }
     }
 
     def onCompleted(terminal: Task[?]): Unit = {

--- a/core/exec/src/mill/exec/Execution.scala
+++ b/core/exec/src/mill/exec/Execution.scala
@@ -621,9 +621,6 @@ object Execution {
       else closeQuietly(lease)
     }
 
-    def retain(task: Task[?], lease: LauncherLocking.Lease): Unit =
-      retain(task, java.nio.file.Paths.get(task.toString), task.toString, lease, 0L)
-
     def releaseHigherThan(key: String): Unit = {
       import scala.jdk.CollectionConverters.*
       for (s <- states.values().asScala) s.synchronized {
@@ -643,7 +640,8 @@ object Execution {
 
     def reacquireDropped(
         workspaceLocking: LauncherLocking,
-        waitReporter: LauncherLocking.WaitReporter
+        waitReporter: LauncherLocking.WaitReporter,
+        block: Boolean = true
     ): Unit = {
       import scala.jdk.CollectionConverters.*
       val dropped = states.values().asScala.toSeq.flatMap { s =>
@@ -654,19 +652,27 @@ object Execution {
       }.sortBy(_._2.key)
 
       for ((s, retained) <- dropped) {
-        val lease = workspaceLocking.taskLock(
-          retained.path,
-          retained.label,
-          LauncherLocking.LockKind.Read,
-          waitReporter
-        )
+        val lease =
+          if (block) {
+            workspaceLocking.taskLock(
+              retained.path,
+              retained.label,
+              LauncherLocking.LockKind.Read,
+              waitReporter
+            )
+          } else {
+            workspaceLocking.tryTaskReadLock(retained.path, retained.label) match {
+              case Right(lease) => lease
+              case Left(_) => throw RetryDueToDroppedTaskLock(retained.label)
+            }
+          }
         val currentVersion = workspaceLocking.taskVersion(retained.path)
         if (currentVersion != retained.observedVersion) {
           closeQuietly(lease)
           throw RetryDueToDroppedTaskLock(retained.label)
         }
         s.synchronized {
-          if (s.retained eq retained) {
+          if ((s.retained eq retained) && retained.dropped && retained.lease == null) {
             retained.lease = lease
             retained.dropped = false
           } else closeQuietly(lease)

--- a/core/exec/src/mill/exec/Execution.scala
+++ b/core/exec/src/mill/exec/Execution.scala
@@ -546,13 +546,17 @@ object Execution {
 
     val states = new ConcurrentHashMap[Task[?], State]()
     private val transitiveUpstreams: Map[Task[?], Seq[Task[?]]] = {
-      val memo = mutable.Map.empty[Task[?], Seq[Task[?]]]
-      def rec(task: Task[?]): Seq[Task[?]] = memo.getOrElseUpdate(
-        task, {
-          val direct = interGroupDeps.getOrElse(task, Nil)
-          (direct ++ direct.flatMap(rec)).distinct
+      def rec(task: Task[?]): Seq[Task[?]] = {
+        val seen = mutable.LinkedHashSet.empty[Task[?]]
+        val stack = mutable.Stack.from(interGroupDeps.getOrElse(task, Nil).reverse)
+        while (stack.nonEmpty) {
+          val upstream = stack.pop()
+          if (seen.add(upstream)) {
+            stack.pushAll(interGroupDeps.getOrElse(upstream, Nil).reverse)
+          }
         }
-      )
+        seen.toSeq
+      }
       indexToTerminal.iterator.map(t => t -> rec(t)).toMap
     }
 
@@ -641,6 +645,12 @@ object Execution {
     def reacquireDropped(
         workspaceLocking: LauncherLocking,
         waitReporter: LauncherLocking.WaitReporter,
+        // `block = false` is mandatory while holding any task Write lease.
+        // Blocking Read reacquisition can wait for a peer writer, and allowing
+        // a writer to block on another task lock can recreate the exact
+        // cross-task wait cycle that ordered dropping is meant to avoid.
+        // Blocking reacquisition is only safe from read/cache-probe paths and
+        // non-Named groups, where this evaluation does not hold a task Write.
         block: Boolean = true
     ): Unit = {
       import scala.jdk.CollectionConverters.*

--- a/core/exec/src/mill/exec/Execution.scala
+++ b/core/exec/src/mill/exec/Execution.scala
@@ -680,14 +680,32 @@ object Execution {
       }
     }
 
-    def withActiveConsumers[T](terminal: Task[?])(body: => T): T = {
+    /**
+     * Mark every transitive upstream of `terminal` as having an active consumer
+     * for the duration of `body`, so [[releaseHigherThan]] will not drop their
+     * retained reads while `body` may still read those outputs.
+     *
+     * Incrementing alone is not sufficient: a sibling future may already have
+     * dropped (or be concurrently dropping) one of those reads in the window
+     * before we incremented, and the increment never re-takes a lease that is
+     * already gone. So *after* marking the upstreams active — which blocks any
+     * further drops, since [[releaseHigherThan]] skips tasks whose
+     * `activeConsumers` is non-zero — we `reacquire()` to re-take and
+     * re-validate anything dropped beforehand, before `body` (user code or
+     * worker cleanup) can observe an unprotected upstream `dest/`. `reacquire`
+     * may throw [[RetryDueToDroppedTaskLock]] if an upstream was rewritten by a
+     * peer while it was dropped, forcing a from-scratch retry.
+     */
+    def withActiveConsumers[T](terminal: Task[?], reacquire: () => Unit)(body: => T): T = {
       val upstreams = transitiveUpstreams.getOrElse(terminal, Nil)
       upstreams.foreach { task =>
         val s = states.get(task)
         if (s != null) s.activeConsumers.incrementAndGet()
       }
-      try body
-      finally {
+      try {
+        reacquire()
+        body
+      } finally {
         upstreams.foreach { task =>
           val s = states.get(task)
           if (s != null) {

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -304,6 +304,11 @@ trait GroupExecution {
         def reacquireDroppedReads(): Unit =
           leaseTracker.reacquireDropped(workspaceLocking, taskWaitReporter)
 
+        // The write-upgrade callback runs while holding this task's Write lock,
+        // so it must not block on another task lock and recreate circular wait.
+        def tryReacquireDroppedReads(): Unit =
+          leaseTracker.reacquireDropped(workspaceLocking, taskWaitReporter, block = false)
+
         def validateDroppedReads(lease: LauncherLocking.Lease): LauncherLocking.Lease =
           try {
             reacquireDroppedReads()
@@ -419,7 +424,7 @@ trait GroupExecution {
             tryAcquireWrite = () => tryWriteTaskLock(),
             awaitStateChange = awaitTaskLockChange,
             waitReporter = taskWaitReporter,
-            afterAcquire = reacquireDroppedReads
+            afterAcquire = tryReacquireDroppedReads
           ) { scope =>
             loadCachedOrWorker(
               loadCachedJson(logger, inputsHash, labelled, paths),
@@ -528,7 +533,7 @@ trait GroupExecution {
           tryAcquireWrite = () => tryWriteTaskLock(),
           awaitStateChange = awaitTaskLockChange,
           waitReporter = taskWaitReporter,
-          afterAcquire = reacquireDroppedReads
+          afterAcquire = tryReacquireDroppedReads
         )(_ => LockUpgrade.Decision.Escalate) { scope =>
           val (execRes, serializedPaths) =
             if (os.Path(labelled.ctx.fileName).endsWith("mill-build/build.mill")) {

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -296,46 +296,75 @@ trait GroupExecution {
 
         val taskWaitReporter =
           PromptWaitReporter.fromLogger(logger, logger.streams.err)
+        val taskLockPath = paths.dest.toNIO
+        val taskLockKey = taskLockPath.toAbsolutePath.normalize().toString
+
         // Input tasks (Task.Input/Source/Sources) are deterministic from
         // filesystem/env, downstream consumes the in-memory Val (not
         // `dest/`), and concurrent `dest/meta.json` writes are byte-identical
         // — so per-task locking is unnecessary and just serializes peers.
-        def acquireTaskLock(kind: LauncherLocking.LockKind): LauncherLocking.Lease =
+        def acquireTaskLock(kind: LauncherLocking.LockKind): LauncherLocking.Lease = {
+          def blockingAcquire(): LauncherLocking.Lease =
+            workspaceLocking.taskLock(
+              taskLockPath,
+              labelled.ctx.segments.render,
+              kind,
+              taskWaitReporter
+            )
+
           if (labelled.isInputTask)
             LauncherLocking.Noop.taskLock(
-              paths.dest.toNIO,
+              taskLockPath,
               labelled.ctx.segments.render,
               kind,
               taskWaitReporter
             )
-          else
-            workspaceLocking.taskLock(
-              paths.dest.toNIO,
-              labelled.ctx.segments.render,
-              kind,
-              taskWaitReporter
-            )
+          else {
+            val leaseEither = kind match {
+              case LauncherLocking.LockKind.Read =>
+                workspaceLocking.tryTaskReadLock(taskLockPath, labelled.ctx.segments.render)
+              case LauncherLocking.LockKind.Write =>
+                workspaceLocking.tryTaskWriteLock(taskLockPath, labelled.ctx.segments.render)
+            }
+            leaseEither match {
+              case Right(lease) => lease
+              case Left(_) =>
+                leaseTracker.releaseHigherThan(taskLockKey)
+                val lease = blockingAcquire()
+                try {
+                  leaseTracker.reacquireDropped(workspaceLocking, taskWaitReporter)
+                  lease
+                } catch {
+                  case t: Throwable =>
+                    lease.close()
+                    throw t
+                }
+            }
+          }
+        }
 
         // Try-Write + bounded await for `LockUpgrade.readThenWrite`'s
         // retryable loop; mirrors `acquireTaskLock`'s input-task skip.
         def tryWriteTaskLock(): Either[LauncherLocking.Contention, LauncherLocking.Lease] =
           if (labelled.isInputTask)
             LauncherLocking.Noop.tryTaskWriteLock(
-              paths.dest.toNIO,
+              taskLockPath,
               labelled.ctx.segments.render
             )
           else
             workspaceLocking.tryTaskWriteLock(
-              paths.dest.toNIO,
+              taskLockPath,
               labelled.ctx.segments.render
             )
         def awaitTaskLockChange(timeoutMs: Long): Unit =
-          if (!labelled.isInputTask)
+          if (!labelled.isInputTask) {
+            leaseTracker.releaseHigherThan(taskLockKey)
             workspaceLocking.awaitTaskStateChange(
-              paths.dest.toNIO,
+              taskLockPath,
               labelled.ctx.segments.render,
               timeoutMs
             )
+          }
 
         // Helper to evaluate the task with full caching support
         def evaluateTaskWithCaching(): GroupExecution.Results = {
@@ -382,14 +411,21 @@ trait GroupExecution {
             acquireRead = acquireTaskLock(LauncherLocking.LockKind.Read),
             tryAcquireWrite = () => tryWriteTaskLock(),
             awaitStateChange = awaitTaskLockChange,
-            waitReporter = taskWaitReporter
+            waitReporter = taskWaitReporter,
+            afterAcquire = () => leaseTracker.reacquireDropped(workspaceLocking, taskWaitReporter)
           ) { scope =>
             loadCachedOrWorker(
               loadCachedJson(logger, inputsHash, labelled, paths),
               closeStaleWorker = false
             ) match {
               case Some(res) =>
-                leaseTracker.retain(labelled, scope.retain())
+                leaseTracker.retain(
+                  labelled,
+                  taskLockPath,
+                  labelled.ctx.segments.render,
+                  scope.retain(),
+                  workspaceLocking.taskVersion(taskLockPath)
+                )
                 LockUpgrade.Decision.Complete(res)
               case None =>
                 LockUpgrade.Decision.Escalate
@@ -400,7 +436,13 @@ trait GroupExecution {
 
             reusableResultOpt match {
               case Some(res) =>
-                leaseTracker.retain(labelled, scope.downgradeAndRetain())
+                leaseTracker.retain(
+                  labelled,
+                  taskLockPath,
+                  labelled.ctx.segments.render,
+                  scope.downgradeAndRetain(),
+                  workspaceLocking.taskVersion(taskLockPath)
+                )
                 res
               case None =>
                 if (!labelled.persistent && os.exists(paths.dest)) {
@@ -408,7 +450,7 @@ trait GroupExecution {
                   os.remove.all(paths.dest)
                 }
 
-                val (newResults, newEvaluated) =
+                val (newResults, newEvaluated) = leaseTracker.withActiveConsumers(labelled) {
                   executeGroup(
                     group = group,
                     results = results,
@@ -425,6 +467,7 @@ trait GroupExecution {
                     upstreamPathRefs = upstreamPathRefs,
                     terminal = labelled
                   )
+                }
 
                 val (valueHash, serializedPaths, success) = newResults(labelled) match {
                   case ExecResult.Success((v, _)) =>
@@ -440,7 +483,16 @@ trait GroupExecution {
                     (0, Nil, false)
                 }
 
-                if (success) leaseTracker.retain(labelled, scope.downgradeAndRetain())
+                if (success) {
+                  val version = workspaceLocking.markTaskWritten(taskLockPath)
+                  leaseTracker.retain(
+                    labelled,
+                    taskLockPath,
+                    labelled.ctx.segments.render,
+                    scope.downgradeAndRetain(),
+                    version
+                  )
+                }
 
                 GroupExecution.Results(
                   newResults = newResults,
@@ -468,7 +520,8 @@ trait GroupExecution {
           acquireRead = acquireTaskLock(LauncherLocking.LockKind.Read),
           tryAcquireWrite = () => tryWriteTaskLock(),
           awaitStateChange = awaitTaskLockChange,
-          waitReporter = taskWaitReporter
+          waitReporter = taskWaitReporter,
+          afterAcquire = () => leaseTracker.reacquireDropped(workspaceLocking, taskWaitReporter)
         )(_ => LockUpgrade.Decision.Escalate) { scope =>
           val (execRes, serializedPaths) =
             if (os.Path(labelled.ctx.fileName).endsWith("mill-build/build.mill")) {
@@ -499,7 +552,14 @@ trait GroupExecution {
           // peers can't overwrite `paths.meta` mid-downstream-read.
           execRes match {
             case ExecResult.Success(_) =>
-              leaseTracker.retain(labelled, scope.downgradeAndRetain())
+              val version = workspaceLocking.markTaskWritten(taskLockPath)
+              leaseTracker.retain(
+                labelled,
+                taskLockPath,
+                labelled.ctx.segments.render,
+                scope.downgradeAndRetain(),
+                version
+              )
             case _ =>
           }
           cachedResult(execRes, serializedPaths)
@@ -549,22 +609,24 @@ trait GroupExecution {
           case None => evaluateTaskWithCaching()
         }
       case _ =>
-        val (newResults, newEvaluated) = executeGroup(
-          group = group,
-          results = results,
-          inputsHash = inputsHash,
-          paths = None,
-          taskLabelOpt = None,
-          counterMsg = countMsg,
-          reporter = zincProblemReporter,
-          testReporter = testReporter,
-          logger = logger,
-          executionContext = executionContext,
-          exclusive = exclusive,
-          deps = deps,
-          upstreamPathRefs = upstreamPathRefs,
-          terminal = terminal
-        )
+        val (newResults, newEvaluated) = leaseTracker.withActiveConsumers(terminal) {
+          executeGroup(
+            group = group,
+            results = results,
+            inputsHash = inputsHash,
+            paths = None,
+            taskLabelOpt = None,
+            counterMsg = countMsg,
+            reporter = zincProblemReporter,
+            testReporter = testReporter,
+            logger = logger,
+            executionContext = executionContext,
+            exclusive = exclusive,
+            deps = deps,
+            upstreamPathRefs = upstreamPathRefs,
+            terminal = terminal
+          )
+        }
         GroupExecution.Results(
           newResults = newResults,
           newEvaluated = newEvaluated.toSeq,

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -301,11 +301,16 @@ trait GroupExecution {
 
         // Any successful task-lock acquisition must validate reads that were
         // dropped during an earlier contended wait before evaluation continues.
+        // This path may block, so only call it when we are not holding a task
+        // Write lease.
         def reacquireDroppedReads(): Unit =
           leaseTracker.reacquireDropped(workspaceLocking, taskWaitReporter)
 
-        // The write-upgrade callback runs while holding this task's Write lock,
-        // so it must not block on another task lock and recreate circular wait.
+        // The write-upgrade callback and Named write body run while holding
+        // this task's Write lock, so dropped reads must be reacquired only via
+        // non-blocking try-locks. A writer that performs a blocking task-lock
+        // acquire can wait on another writer while retaining its own Write
+        // lease, reintroducing the retained-read/write cycle this logic avoids.
         def tryReacquireDroppedReads(): Unit =
           leaseTracker.reacquireDropped(workspaceLocking, taskWaitReporter, block = false)
 
@@ -323,12 +328,12 @@ trait GroupExecution {
         // filesystem/env, downstream consumes the in-memory Val (not
         // `dest/`), and concurrent `dest/meta.json` writes are byte-identical
         // — so per-task locking is unnecessary and just serializes peers.
-        def acquireTaskLock(kind: LauncherLocking.LockKind): LauncherLocking.Lease = {
+        def acquireReadTaskLock(): LauncherLocking.Lease = {
           def blockingAcquire(): LauncherLocking.Lease =
             workspaceLocking.taskLock(
               taskLockPath,
               labelled.ctx.segments.render,
-              kind,
+              LauncherLocking.LockKind.Read,
               taskWaitReporter
             )
 
@@ -336,17 +341,11 @@ trait GroupExecution {
             LauncherLocking.Noop.taskLock(
               taskLockPath,
               labelled.ctx.segments.render,
-              kind,
+              LauncherLocking.LockKind.Read,
               taskWaitReporter
             )
           else {
-            val leaseEither = kind match {
-              case LauncherLocking.LockKind.Read =>
-                workspaceLocking.tryTaskReadLock(taskLockPath, labelled.ctx.segments.render)
-              case LauncherLocking.LockKind.Write =>
-                workspaceLocking.tryTaskWriteLock(taskLockPath, labelled.ctx.segments.render)
-            }
-            leaseEither match {
+            workspaceLocking.tryTaskReadLock(taskLockPath, labelled.ctx.segments.render) match {
               case Right(lease) => validateDroppedReads(lease)
               case Left(_) =>
                 leaseTracker.releaseHigherThan(taskLockKey)
@@ -420,7 +419,7 @@ trait GroupExecution {
           }
 
           LockUpgrade.readThenWrite(
-            acquireRead = acquireTaskLock(LauncherLocking.LockKind.Read),
+            acquireRead = acquireReadTaskLock(),
             tryAcquireWrite = () => tryWriteTaskLock(),
             awaitStateChange = awaitTaskLockChange,
             waitReporter = taskWaitReporter,
@@ -533,7 +532,7 @@ trait GroupExecution {
         // evaluateTaskWithCaching's lock dance.
         def evaluateBuildOverrideOnly(located: Located[Appendable[BufferedValue]])
             : GroupExecution.Results = LockUpgrade.readThenWrite(
-          acquireRead = acquireTaskLock(LauncherLocking.LockKind.Read),
+          acquireRead = acquireReadTaskLock(),
           tryAcquireWrite = () => tryWriteTaskLock(),
           awaitStateChange = awaitTaskLockChange,
           waitReporter = taskWaitReporter,

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -462,24 +462,28 @@ trait GroupExecution {
                   os.remove.all(paths.dest)
                 }
 
-                val (newResults, newEvaluated) = leaseTracker.withActiveConsumers(labelled) {
-                  executeGroup(
-                    group = group,
-                    results = results,
-                    inputsHash = inputsHash,
-                    paths = Some(paths),
-                    taskLabelOpt = Some(terminal.toString),
-                    counterMsg = countMsg,
-                    reporter = zincProblemReporter,
-                    testReporter = testReporter,
-                    logger = logger,
-                    executionContext = executionContext,
-                    exclusive = exclusive,
-                    deps = deps,
-                    upstreamPathRefs = upstreamPathRefs,
-                    terminal = labelled
-                  )
-                }
+                // Non-blocking reacquire: this runs while holding this task's
+                // Write lock, so it must not block on another task lock and
+                // recreate circular wait.
+                val (newResults, newEvaluated) =
+                  leaseTracker.withActiveConsumers(labelled, () => tryReacquireDroppedReads()) {
+                    executeGroup(
+                      group = group,
+                      results = results,
+                      inputsHash = inputsHash,
+                      paths = Some(paths),
+                      taskLabelOpt = Some(terminal.toString),
+                      counterMsg = countMsg,
+                      reporter = zincProblemReporter,
+                      testReporter = testReporter,
+                      logger = logger,
+                      executionContext = executionContext,
+                      exclusive = exclusive,
+                      deps = deps,
+                      upstreamPathRefs = upstreamPathRefs,
+                      terminal = labelled
+                    )
+                  }
 
                 val (valueHash, serializedPaths, success) = newResults(labelled) match {
                   case ExecResult.Success((v, _)) =>
@@ -621,7 +625,15 @@ trait GroupExecution {
           case None => evaluateTaskWithCaching()
         }
       case _ =>
-        val (newResults, newEvaluated) = leaseTracker.withActiveConsumers(terminal) {
+        // Non-Named terminals acquire no task lock of their own, so unlike the
+        // Named write path there is no circular-wait risk: we can block to
+        // reacquire any upstream read dropped by a sibling future before this
+        // group's body reads the corresponding `dest/`.
+        val taskWaitReporter = PromptWaitReporter.fromLogger(logger, logger.streams.err)
+        val (newResults, newEvaluated) = leaseTracker.withActiveConsumers(
+          terminal,
+          () => leaseTracker.reacquireDropped(workspaceLocking, taskWaitReporter, block = true)
+        ) {
           executeGroup(
             group = group,
             results = results,

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -299,6 +299,21 @@ trait GroupExecution {
         val taskLockPath = paths.dest.toNIO
         val taskLockKey = taskLockPath.toAbsolutePath.normalize().toString
 
+        // Any successful task-lock acquisition must validate reads that were
+        // dropped during an earlier contended wait before evaluation continues.
+        def reacquireDroppedReads(): Unit =
+          leaseTracker.reacquireDropped(workspaceLocking, taskWaitReporter)
+
+        def validateDroppedReads(lease: LauncherLocking.Lease): LauncherLocking.Lease =
+          try {
+            reacquireDroppedReads()
+            lease
+          } catch {
+            case t: Throwable =>
+              lease.close()
+              throw t
+          }
+
         // Input tasks (Task.Input/Source/Sources) are deterministic from
         // filesystem/env, downstream consumes the in-memory Val (not
         // `dest/`), and concurrent `dest/meta.json` writes are byte-identical
@@ -327,18 +342,10 @@ trait GroupExecution {
                 workspaceLocking.tryTaskWriteLock(taskLockPath, labelled.ctx.segments.render)
             }
             leaseEither match {
-              case Right(lease) => lease
+              case Right(lease) => validateDroppedReads(lease)
               case Left(_) =>
                 leaseTracker.releaseHigherThan(taskLockKey)
-                val lease = blockingAcquire()
-                try {
-                  leaseTracker.reacquireDropped(workspaceLocking, taskWaitReporter)
-                  lease
-                } catch {
-                  case t: Throwable =>
-                    lease.close()
-                    throw t
-                }
+                validateDroppedReads(blockingAcquire())
             }
           }
         }
@@ -412,7 +419,7 @@ trait GroupExecution {
             tryAcquireWrite = () => tryWriteTaskLock(),
             awaitStateChange = awaitTaskLockChange,
             waitReporter = taskWaitReporter,
-            afterAcquire = () => leaseTracker.reacquireDropped(workspaceLocking, taskWaitReporter)
+            afterAcquire = reacquireDroppedReads
           ) { scope =>
             loadCachedOrWorker(
               loadCachedJson(logger, inputsHash, labelled, paths),
@@ -521,7 +528,7 @@ trait GroupExecution {
           tryAcquireWrite = () => tryWriteTaskLock(),
           awaitStateChange = awaitTaskLockChange,
           waitReporter = taskWaitReporter,
-          afterAcquire = () => leaseTracker.reacquireDropped(workspaceLocking, taskWaitReporter)
+          afterAcquire = reacquireDroppedReads
         )(_ => LockUpgrade.Decision.Escalate) { scope =>
           val (execRes, serializedPaths) =
             if (os.Path(labelled.ctx.fileName).endsWith("mill-build/build.mill")) {

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -355,7 +355,7 @@ trait GroupExecution {
         }
 
         // Try-Write + bounded await for `LockUpgrade.readThenWrite`'s
-        // retryable loop; mirrors `acquireTaskLock`'s input-task skip.
+        // retryable loop; mirrors `acquireReadTaskLock`'s input-task skip.
         def tryWriteTaskLock(): Either[LauncherLocking.Contention, LauncherLocking.Lease] =
           if (labelled.isInputTask)
             LauncherLocking.Noop.tryTaskWriteLock(
@@ -443,7 +443,18 @@ trait GroupExecution {
             }
           } { scope =>
             val cached = loadCachedJson(logger, inputsHash, labelled, paths)
-            val reusableResultOpt = loadCachedOrWorker(cached, closeStaleWorker = true)
+            // Closing a stale worker here runs its user `close()` under
+            // `GroupExecution.wrap`, which permits reads of upstream `dest/`
+            // via `upstreamPathRefs`. Guard those reads with active-consumer
+            // protection — exactly as the `executeGroup` body below — so a
+            // sibling future cannot drop (and a peer cannot then rewrite) an
+            // upstream Read this cleanup may still touch. Non-blocking
+            // reacquire: this runs while holding this task's Write lock, so it
+            // must not block on another task lock and recreate circular wait.
+            val reusableResultOpt =
+              leaseTracker.withActiveConsumers(labelled, () => tryReacquireDroppedReads()) {
+                loadCachedOrWorker(cached, closeStaleWorker = true)
+              }
 
             reusableResultOpt match {
               case Some(res) =>
@@ -456,6 +467,17 @@ trait GroupExecution {
                 )
                 res
               case None =>
+                // Advance the output version before any destructive mutation
+                // below — not only on successful publish. Deleting `dest/` here,
+                // or a failed `executeGroup` that leaves `dest/` partially
+                // written and removes `meta` below, both change the on-disk
+                // output a peer may have cached. A peer that dropped a retained
+                // Read for this task must observe the version bump and retry
+                // from scratch, even when this recompute ultimately fails;
+                // otherwise its reacquired Read would validate against the
+                // unchanged version and silently consume a deleted/partial
+                // `dest/`.
+                val version = workspaceLocking.markTaskWritten(taskLockPath)
                 if (!labelled.persistent && os.exists(paths.dest)) {
                   logger.debug(s"Deleting task dest dir ${paths.dest.relativeTo(workspace)}")
                   os.remove.all(paths.dest)
@@ -499,7 +521,6 @@ trait GroupExecution {
                 }
 
                 if (success) {
-                  val version = workspaceLocking.markTaskWritten(taskLockPath)
                   leaseTracker.retain(
                     labelled,
                     taskLockPath,

--- a/core/exec/test/src/mill/exec/PlanTests.scala
+++ b/core/exec/test/src/mill/exec/PlanTests.scala
@@ -28,6 +28,7 @@ object PlanTests extends TestSuite {
 
   private class TestLocking extends LauncherLocking {
     val versions = mutable.Map.empty[String, Long].withDefaultValue(0L)
+    val contendedReads = mutable.Set.empty[String]
 
     private def key(path: Path) = path.toAbsolutePath.normalize().toString
 
@@ -61,7 +62,10 @@ object PlanTests extends TestSuite {
     override def tryTaskReadLock(
         path: Path,
         displayLabel: String
-    ): Either[LauncherLocking.Contention, LauncherLocking.Lease] = Right(new TestLease)
+    ): Either[LauncherLocking.Contention, LauncherLocking.Lease] =
+      if (contendedReads(key(path)))
+        Left(LauncherLocking.Contention("blocked", displayLabel, Nil))
+      else Right(new TestLease)
 
     override def tryTaskWriteLock(
         path: Path,
@@ -262,9 +266,9 @@ object PlanTests extends TestSuite {
       val bLease = new TestLease
       val cLease = new TestLease
 
-      tracker.retain(a, aLease)
-      tracker.retain(b, bLease)
-      tracker.retain(c, cLease)
+      tracker.retain(a, Paths.get("/tmp/mill-lock-test/a"), "a", aLease, 0L)
+      tracker.retain(b, Paths.get("/tmp/mill-lock-test/b"), "b", bLease, 0L)
+      tracker.retain(c, Paths.get("/tmp/mill-lock-test/c"), "c", cLease, 0L)
 
       tracker.onCompleted(a)
       assert(!aLease.closed.get())
@@ -297,7 +301,7 @@ object PlanTests extends TestSuite {
         Map(a -> Nil, b -> Seq(a), c -> Seq(b))
       )
       val aLease = new TestLease
-      tracker.retain(a, aLease)
+      tracker.retain(a, Paths.get("/tmp/mill-lock-test/a"), "a", aLease, 0L)
 
       val aFuture: Future[Option[Unit]] =
         Future.successful(Some(())).andThen { case _ => tracker.onCompleted(a) }
@@ -348,6 +352,34 @@ object PlanTests extends TestSuite {
         } catch {
           case e: Execution.RetryDueToDroppedTaskLock => e
         }
+      assert(retry.label == "b")
+      tracker.drain()
+    }
+
+    test("leaseTrackerNonBlockingReacquireRetriesOnContention") {
+      import transitiveLeaseChain.*
+
+      val tracker = new Execution.LeaseTracker(
+        Array(a, b, c),
+        Map(a -> Nil, b -> Seq(a), c -> Seq(b))
+      )
+      val locking = new TestLocking
+      val aPath = Paths.get("/tmp/mill-lock-test/a")
+      val bPath = Paths.get("/tmp/mill-lock-test/b")
+      val bLease = new TestLease
+
+      tracker.retain(b, bPath, "b", bLease, 0L)
+      tracker.releaseHigherThan(aPath.toAbsolutePath.normalize().toString)
+
+      locking.contendedReads.add(bPath.toAbsolutePath.normalize().toString)
+      val retry =
+        try {
+          tracker.reacquireDropped(locking, LauncherLocking.WaitReporter.Noop, block = false)
+          throw new java.lang.AssertionError("expected retry")
+        } catch {
+          case e: Execution.RetryDueToDroppedTaskLock => e
+        }
+
       assert(retry.label == "b")
       tracker.drain()
     }

--- a/core/exec/test/src/mill/exec/PlanTests.scala
+++ b/core/exec/test/src/mill/exec/PlanTests.scala
@@ -6,6 +6,7 @@ import mill.api.daemon.internal.LauncherLocking
 import mill.api.TestGraphs
 import utest.*
 
+import java.nio.file.{Path, Paths}
 import java.util.concurrent.atomic.AtomicBoolean
 import scala.collection.mutable
 import scala.concurrent.duration.DurationInt
@@ -23,6 +24,62 @@ object PlanTests extends TestSuite {
   private class TestLease extends LauncherLocking.Lease {
     val closed = AtomicBoolean(false)
     override def close(): Unit = closed.set(true)
+  }
+
+  private class TestLocking extends LauncherLocking {
+    val versions = mutable.Map.empty[String, Long].withDefaultValue(0L)
+
+    private def key(path: Path) = path.toAbsolutePath.normalize().toString
+
+    override def taskLock(
+        path: Path,
+        displayLabel: String,
+        kind: LauncherLocking.LockKind,
+        waitReporter: LauncherLocking.WaitReporter
+    ): LauncherLocking.Lease = new TestLease
+
+    override def taskVersion(path: Path): Long = versions(key(path))
+
+    override def markTaskWritten(path: Path): Long = {
+      val next = versions.valuesIterator.maxOption.getOrElse(0L) + 1L
+      versions(key(path)) = next
+      next
+    }
+
+    override def metaBuildLock(
+        depth: Int,
+        kind: LauncherLocking.LockKind,
+        waitReporter: LauncherLocking.WaitReporter
+    ): LauncherLocking.Lease = new TestLease
+
+    override def tryMetaBuildWriteLock(
+        depth: Int
+    ): Either[LauncherLocking.Contention, LauncherLocking.Lease] = Right(new TestLease)
+
+    override def awaitMetaBuildStateChange(depth: Int, timeoutMs: Long): Unit = ()
+
+    override def tryTaskReadLock(
+        path: Path,
+        displayLabel: String
+    ): Either[LauncherLocking.Contention, LauncherLocking.Lease] = Right(new TestLease)
+
+    override def tryTaskWriteLock(
+        path: Path,
+        displayLabel: String
+    ): Either[LauncherLocking.Contention, LauncherLocking.Lease] = Right(new TestLease)
+
+    override def awaitTaskStateChange(path: Path, displayLabel: String, timeoutMs: Long): Unit = ()
+
+    override def exclusiveLock(
+        kind: LauncherLocking.LockKind,
+        waitReporter: LauncherLocking.WaitReporter
+    ): LauncherLocking.Lease = new TestLease
+
+    override def withReleasedExclusive[T](
+        waitReporter: LauncherLocking.WaitReporter
+    )(body: => T): T = body
+
+    override def close(): Unit = ()
   }
 
   def checkTopological(tasks: Seq[Task[?]]) = {
@@ -261,6 +318,59 @@ object PlanTests extends TestSuite {
       // Both b's and c's onCompleted must have fired, recursively draining
       // b's subtree and then releasing a's retained Read lease.
       assert(aLease.closed.get())
+    }
+
+    test("leaseTrackerDropsInactiveHigherLocksAndRetriesOnVersionChange") {
+      import transitiveLeaseChain.*
+
+      val tracker = new Execution.LeaseTracker(
+        Array(a, b, c),
+        Map(a -> Nil, b -> Seq(a), c -> Seq(b))
+      )
+      val locking = new TestLocking
+      val aPath = Paths.get("/tmp/mill-lock-test/a")
+      val bPath = Paths.get("/tmp/mill-lock-test/b")
+      val aLease = new TestLease
+      val bLease = new TestLease
+
+      tracker.retain(a, aPath, "a", aLease, 0L)
+      tracker.retain(b, bPath, "b", bLease, 0L)
+      tracker.releaseHigherThan(aPath.toAbsolutePath.normalize().toString)
+
+      assert(!aLease.closed.get())
+      assert(bLease.closed.get())
+
+      locking.markTaskWritten(bPath)
+      val retry =
+        try {
+          tracker.reacquireDropped(locking, LauncherLocking.WaitReporter.Noop)
+          throw new java.lang.AssertionError("expected retry")
+        } catch {
+          case e: Execution.RetryDueToDroppedTaskLock => e
+        }
+      assert(retry.label == "b")
+      tracker.drain()
+    }
+
+    test("leaseTrackerDoesNotDropActivelyConsumedHigherLocks") {
+      import transitiveLeaseChain.*
+
+      val tracker = new Execution.LeaseTracker(
+        Array(a, b, c),
+        Map(a -> Nil, b -> Seq(a), c -> Seq(b))
+      )
+      val aPath = Paths.get("/tmp/mill-lock-test/a")
+      val bPath = Paths.get("/tmp/mill-lock-test/b")
+      val bLease = new TestLease
+
+      tracker.retain(b, bPath, "b", bLease, 0L)
+      tracker.withActiveConsumers(c) {
+        tracker.releaseHigherThan(aPath.toAbsolutePath.normalize().toString)
+        assert(!bLease.closed.get())
+      }
+      tracker.releaseHigherThan(aPath.toAbsolutePath.normalize().toString)
+      assert(bLease.closed.get())
+      tracker.drain()
     }
 
   }

--- a/core/exec/test/src/mill/exec/PlanTests.scala
+++ b/core/exec/test/src/mill/exec/PlanTests.scala
@@ -391,17 +391,67 @@ object PlanTests extends TestSuite {
         Array(a, b, c),
         Map(a -> Nil, b -> Seq(a), c -> Seq(b))
       )
+      val locking = new TestLocking
       val aPath = Paths.get("/tmp/mill-lock-test/a")
       val bPath = Paths.get("/tmp/mill-lock-test/b")
       val bLease = new TestLease
 
       tracker.retain(b, bPath, "b", bLease, 0L)
-      tracker.withActiveConsumers(c) {
+      tracker.withActiveConsumers(
+        c,
+        () => tracker.reacquireDropped(locking, LauncherLocking.WaitReporter.Noop, block = true)
+      ) {
         tracker.releaseHigherThan(aPath.toAbsolutePath.normalize().toString)
         assert(!bLease.closed.get())
       }
       tracker.releaseHigherThan(aPath.toAbsolutePath.normalize().toString)
       assert(bLease.closed.get())
+      tracker.drain()
+    }
+
+    // A read dropped before its downstream becomes an active consumer must be
+    // reacquired by `withActiveConsumers` before the body runs, not left
+    // released. Here the dropped upstream `b` was rewritten by a peer while
+    // dropped, so the reacquire must detect the version change and retry rather
+    // than let the consumer body read a stale/overwritten output.
+    test("withActiveConsumersReacquiresAndValidatesReadsDroppedBeforeActivation") {
+      import transitiveLeaseChain.*
+
+      val tracker = new Execution.LeaseTracker(
+        Array(a, b, c),
+        Map(a -> Nil, b -> Seq(a), c -> Seq(b))
+      )
+      val locking = new TestLocking
+      val aPath = Paths.get("/tmp/mill-lock-test/a")
+      val bPath = Paths.get("/tmp/mill-lock-test/b")
+      val bLease = new TestLease
+
+      tracker.retain(b, bPath, "b", bLease, 0L)
+      // Sibling future drops `b` (higher key than `a`) while no consumer is active.
+      tracker.releaseHigherThan(aPath.toAbsolutePath.normalize().toString)
+      assert(bLease.closed.get())
+
+      // Peer rewrites `b` while it is dropped.
+      locking.markTaskWritten(bPath)
+
+      var bodyRan = false
+      val retry =
+        try {
+          tracker.withActiveConsumers(
+            c,
+            () => tracker.reacquireDropped(locking, LauncherLocking.WaitReporter.Noop, block = true)
+          ) {
+            bodyRan = true
+          }
+          throw new java.lang.AssertionError("expected retry")
+        } catch {
+          case e: Execution.RetryDueToDroppedTaskLock => e
+        }
+
+      // The consumer body must not have run with `b` unprotected/stale.
+      assert(!bodyRan)
+      assert(retry.label == "b")
+      // The active-consumer count must be released even though reacquire threw.
       tracker.drain()
     }
 

--- a/core/internal/src/mill/internal/CrossThreadRwLock.scala
+++ b/core/internal/src/mill/internal/CrossThreadRwLock.scala
@@ -129,6 +129,25 @@ class CrossThreadRwLock(
   }
 
   /**
+   * Non-blocking, non-queued Read attempt. Returns immediately with
+   * [[scala.Left]] when a writer is active or queued, matching normal
+   * reader acquisition's writer-priority policy without registering the
+   * caller as a waiter.
+   */
+  def tryAcquireRead(acquirer: HolderInfo): Either[Contention, Lease] = monitor.synchronized {
+    if (canAcquireRead) {
+      readerCount += 1
+      val lease = newLease(initiallyWrite = false)
+      holders.put(lease, acquirer)
+      Right(lease)
+    } else Left(Contention(
+      waitingMessage(currentBlocker(), LockKind.Read),
+      label,
+      syntheticPrefix
+    ))
+  }
+
+  /**
    * Block on the lock's monitor for up to `timeoutMs`, returning when any
    * lock state change occurs (close/downgrade `notifyAll`s) or the
    * timeout fires. Used by [[LockUpgrade.readThenWrite]]'s retry loop to

--- a/core/internal/src/mill/internal/LauncherLockRegistry.scala
+++ b/core/internal/src/mill/internal/LauncherLockRegistry.scala
@@ -3,6 +3,7 @@ package mill.internal
 import mill.constants.OutFiles
 
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Maps of locks that are shared across launchers to allow them to coordinate work
@@ -11,6 +12,8 @@ import java.util.concurrent.ConcurrentHashMap
 private[mill] class LauncherLockRegistry {
   private val metaBuildLocks = new ConcurrentHashMap[Int, CrossThreadRwLock]()
   private val taskLocks = new ConcurrentHashMap[String, CrossThreadRwLock]()
+  private val taskVersions = new ConcurrentHashMap[String, java.lang.Long]()
+  private val taskWriteVersion = new AtomicLong(0L)
 
   // Single daemon-wide lock guarding "globally exclusive" command execution. Read leases
   // are taken by every normal task batch (and by plain `exclusive` commands) so they share
@@ -38,6 +41,15 @@ private[mill] class LauncherLockRegistry {
       normalizedAbsolutePath,
       _ => CrossThreadRwLock(label = displayLabel, showLabelInMessage = false)
     )
+
+  def taskVersion(normalizedAbsolutePath: String): Long =
+    Option(taskVersions.get(normalizedAbsolutePath)).fold(0L)(_.longValue())
+
+  def markTaskWritten(normalizedAbsolutePath: String): Long = {
+    val version = taskWriteVersion.incrementAndGet()
+    taskVersions.put(normalizedAbsolutePath, java.lang.Long.valueOf(version))
+    version
+  }
 }
 
 private[mill] object LauncherLockRegistry {

--- a/core/internal/src/mill/internal/LauncherLockRegistry.scala
+++ b/core/internal/src/mill/internal/LauncherLockRegistry.scala
@@ -46,6 +46,10 @@ private[mill] class LauncherLockRegistry {
     Option(taskVersions.get(normalizedAbsolutePath)).fold(0L)(_.longValue())
 
   def markTaskWritten(normalizedAbsolutePath: String): Long = {
+    // Bump even when a rewrite produces byte-identical files. Dropped-read
+    // validation is deliberately conservative: if another launcher had a
+    // chance to rewrite this output, restart rather than comparing directory
+    // contents while task locks are in flux.
     val version = taskWriteVersion.incrementAndGet()
     taskVersions.put(normalizedAbsolutePath, java.lang.Long.valueOf(version))
     version

--- a/core/internal/src/mill/internal/LauncherLockingImpl.scala
+++ b/core/internal/src/mill/internal/LauncherLockingImpl.scala
@@ -123,10 +123,15 @@ private[mill] class LauncherLockingImpl(
   }
 
   override def taskVersion(path: java.nio.file.Path): Long =
+    // While holding the daemon-wide exclusive Write lock, this launcher bypasses
+    // per-task locks entirely and no peer task writer can run, so dropped-read
+    // version validation is unnecessary.
     if (noBuildLock || exclusiveWriteCount.get() > 0) 0L
     else lockRegistry.taskVersion(path.toAbsolutePath.normalize().toString)
 
   override def markTaskWritten(path: java.nio.file.Path): Long =
+    // Match taskVersion: under noBuildLock/global-exclusive execution, task
+    // locks are Noop and there is no peer writer to invalidate dropped reads.
     if (noBuildLock || exclusiveWriteCount.get() > 0) 0L
     else lockRegistry.markTaskWritten(path.toAbsolutePath.normalize().toString)
 

--- a/core/internal/src/mill/internal/LauncherLockingImpl.scala
+++ b/core/internal/src/mill/internal/LauncherLockingImpl.scala
@@ -80,6 +80,21 @@ private[mill] class LauncherLockingImpl(
     }
   }
 
+  override def tryTaskReadLock(
+      path: java.nio.file.Path,
+      displayLabel: String
+  ): Either[LauncherLocking.Contention, LauncherLocking.Lease] = {
+    ensureOpen()
+    if (noBuildLock || exclusiveWriteCount.get() > 0)
+      LauncherLocking.Noop.tryTaskReadLock(path, displayLabel)
+    else {
+      val normalized = path.toAbsolutePath.normalize().toString
+      lockRegistry.taskLockFor(normalized, displayLabel)
+        .tryAcquireRead(holder)
+        .map(acquireManagedLease)
+    }
+  }
+
   override def tryTaskWriteLock(
       path: java.nio.file.Path,
       displayLabel: String
@@ -106,6 +121,14 @@ private[mill] class LauncherLockingImpl(
       lockRegistry.taskLockFor(normalized, displayLabel).awaitStateChange(timeoutMs)
     }
   }
+
+  override def taskVersion(path: java.nio.file.Path): Long =
+    if (noBuildLock || exclusiveWriteCount.get() > 0) 0L
+    else lockRegistry.taskVersion(path.toAbsolutePath.normalize().toString)
+
+  override def markTaskWritten(path: java.nio.file.Path): Long =
+    if (noBuildLock || exclusiveWriteCount.get() > 0) 0L
+    else lockRegistry.markTaskWritten(path.toAbsolutePath.normalize().toString)
 
   override def exclusiveLock(
       kind: LauncherLocking.LockKind,

--- a/core/internal/src/mill/internal/LockUpgrade.scala
+++ b/core/internal/src/mill/internal/LockUpgrade.scala
@@ -66,7 +66,8 @@ object LockUpgrade {
       tryAcquireWrite: () => Either[LauncherLocking.Contention, LauncherLocking.Lease],
       awaitStateChange: Long => Unit,
       waitReporter: LauncherLocking.WaitReporter,
-      awaitTimeoutMs: Long = 1000L
+      awaitTimeoutMs: Long = 1000L,
+      afterAcquire: () => Unit = () => ()
   )(
       readBody: Scope => Decision[T]
   )(
@@ -113,6 +114,12 @@ object LockUpgrade {
           case Decision.Escalate =>
             tryAcquireWrite() match {
               case Right(writeLease) =>
+                try afterAcquire()
+                catch {
+                  case t: Throwable =>
+                    writeLease.close()
+                    throw t
+                }
                 val writeScope = Scope(writeLease)
                 try {
                   val value = writeBody(writeScope)

--- a/integration/dedicated/bsp-concurrency/resources/build.mill
+++ b/integration/dedicated/bsp-concurrency/resources/build.mill
@@ -25,23 +25,21 @@ object gated extends ScalaModule {
   }
 }
 
-final class OrderedToken(val value: String)
-
 private def orderedEventsFile = mill.api.BuildCtx.workspaceRoot / "ordered-events.log"
 
-private def orderedShared(name: String): OrderedToken =
+private def orderedShared(name: String): String =
   mill.api.BuildCtx.withFilesystemCheckerDisabled {
     os.write.append(orderedEventsFile, s"$name\n", createFolders = true)
     Thread.sleep(1000L)
-    OrderedToken(name)
+    name
   }
 
-// These intentionally return a type without a cached JSON writer. Concurrent
-// requests therefore retain the successful Read lease but still need a later
-// Write lease when the other request asks for the same task, reproducing the
-// retained-read/write cycle that ordered dropping is meant to break.
-def orderedSharedA = Task { orderedShared("A") }
-def orderedSharedB = Task { orderedShared("B") }
+// These are intentionally uncached. Concurrent requests therefore retain the
+// successful Read lease but still need a later Write lease when the other
+// request asks for the same task, reproducing the retained-read/write cycle
+// that ordered dropping is meant to break.
+def orderedSharedA = Task.Uncached { orderedShared("A") }
+def orderedSharedB = Task.Uncached { orderedShared("B") }
 
 object orderedAb extends ScalaModule {
   def scalaVersion = Option(System.getenv("TEST_SCALA_2_13_VERSION")).getOrElse(???)

--- a/integration/dedicated/bsp-concurrency/resources/build.mill
+++ b/integration/dedicated/bsp-concurrency/resources/build.mill
@@ -25,6 +25,44 @@ object gated extends ScalaModule {
   }
 }
 
+final class OrderedToken(val value: String)
+
+private def orderedEventsFile = mill.api.BuildCtx.workspaceRoot / "ordered-events.log"
+
+private def orderedShared(name: String): OrderedToken =
+  mill.api.BuildCtx.withFilesystemCheckerDisabled {
+    os.write.append(orderedEventsFile, s"$name\n", createFolders = true)
+    Thread.sleep(1000L)
+    OrderedToken(name)
+  }
+
+// These intentionally return a type without a cached JSON writer. Concurrent
+// requests therefore retain the successful Read lease but still need a later
+// Write lease when the other request asks for the same task, reproducing the
+// retained-read/write cycle that ordered dropping is meant to break.
+def orderedSharedA = Task { orderedShared("A") }
+def orderedSharedB = Task { orderedShared("B") }
+
+object orderedAb extends ScalaModule {
+  def scalaVersion = Option(System.getenv("TEST_SCALA_2_13_VERSION")).getOrElse(???)
+
+  override def sources = Task {
+    orderedSharedA()
+    orderedSharedB()
+    super.sources()
+  }
+}
+
+object orderedBa extends ScalaModule {
+  def scalaVersion = Option(System.getenv("TEST_SCALA_2_13_VERSION")).getOrElse(???)
+
+  override def sources = Task {
+    orderedSharedB()
+    orderedSharedA()
+    super.sources()
+  }
+}
+
 // CLI-side wrapper for the gated `sources` task; spawning this command parks
 // the daemon on `gated.sources` while a concurrent BSP request arrives.
 def runGatedSources() = Task.Command {

--- a/integration/dedicated/bsp-concurrency/src/BspConcurrencyTests.scala
+++ b/integration/dedicated/bsp-concurrency/src/BspConcurrencyTests.scala
@@ -46,7 +46,10 @@ object BspConcurrencyTests extends UtestIntegrationTestSuite {
   private def orderedEventsFile(tester: IntegrationTester.Impl): os.Path =
     tester.workspacePath / "ordered-events.log"
 
-  private def targetByDisplayName(targets: b.WorkspaceBuildTargetsResult, name: String): b.BuildTargetIdentifier =
+  private def targetByDisplayName(
+      targets: b.WorkspaceBuildTargetsResult,
+      name: String
+  ): b.BuildTargetIdentifier =
     targets.getTargets.asScala
       .find(_.getDisplayName == name).map(_.getId).getOrElse(
         throw new java.lang.AssertionError(

--- a/integration/dedicated/bsp-concurrency/src/BspConcurrencyTests.scala
+++ b/integration/dedicated/bsp-concurrency/src/BspConcurrencyTests.scala
@@ -43,6 +43,18 @@ object BspConcurrencyTests extends UtestIntegrationTestSuite {
   private def exclusiveEnteredFile(tester: IntegrationTester.Impl): os.Path =
     tester.workspacePath / "gated-exclusive-entered"
 
+  private def orderedEventsFile(tester: IntegrationTester.Impl): os.Path =
+    tester.workspacePath / "ordered-events.log"
+
+  private def targetByDisplayName(targets: b.WorkspaceBuildTargetsResult, name: String): b.BuildTargetIdentifier =
+    targets.getTargets.asScala
+      .find(_.getDisplayName == name).map(_.getId).getOrElse(
+        throw new java.lang.AssertionError(
+          s"BSP exposed no `$name` target. Targets: " +
+            targets.getTargets.asScala.map(_.getDisplayName)
+        )
+      )
+
   /** Read the launcher record store to find the active PID for a given command. */
   private def activeLauncherPid(
       tester: IntegrationTester.Impl,
@@ -202,5 +214,51 @@ object BspConcurrencyTests extends UtestIntegrationTestSuite {
         if (cliLauncher.process.isAlive()) cliLauncher.process.waitFor(30000L)
       }
     }
+
+    test("concurrent-bsp-requests-do-not-deadlock-on-opposite-uncached-task-order") -
+      integrationTest { tester =>
+        import tester.*
+        assert(tester.daemonMode)
+
+        eval(
+          ("--bsp-install", "--jobs", "1"),
+          stdout = os.Inherit,
+          stderr = os.Inherit,
+          check = true,
+          env = Map("MILL_EXECUTABLE_PATH" -> tester.millExecutable.toString)
+        )
+
+        val bspStderr = new ByteArrayOutputStream
+        withBspServer(
+          workspacePath,
+          millTestSuiteEnv,
+          bspLog = Some((bytes, len) => bspStderr.write(bytes, 0, len))
+        ) { (buildServer, _) =>
+          val targets = buildServer.workspaceBuildTargets().get(30, TimeUnit.SECONDS)
+          val abTarget = targetByDisplayName(targets, "orderedAb")
+          val baTarget = targetByDisplayName(targets, "orderedBa")
+
+          val abCompile =
+            buildServer.buildTargetCompile(new b.CompileParams(Seq(abTarget).asJava))
+          val baCompile =
+            buildServer.buildTargetCompile(new b.CompileParams(Seq(baTarget).asJava))
+
+          val abResult = abCompile.get(60, TimeUnit.SECONDS)
+          val baResult = baCompile.get(60, TimeUnit.SECONDS)
+
+          assert(abResult.getStatusCode == b.StatusCode.OK)
+          assert(baResult.getStatusCode == b.StatusCode.OK)
+
+          val events = os.read.lines(orderedEventsFile(tester))
+          assert(events.count(_ == "A") >= 2)
+          assert(events.count(_ == "B") >= 2)
+
+          val stderr = bspStderr.toString
+          assert(
+            stderr.contains("blocked on write lock 'orderedSharedA'") ||
+              stderr.contains("blocked on write lock 'orderedSharedB'")
+          )
+        }
+      }
   }
 }


### PR DESCRIPTION

Attempts to fix https://github.com/com-lihaoyi/mill/issues/7132

## Problem

To let concurrent launchers (two BSP requests, or BSP + CLI) safely share one `out/` directory, Mill's `LeaseTracker` retains a per-task read lock on each already-computed upstream output until every transitive downstream that might read it has finished. This stops a peer from rewriting a `dest/` out from under an active consumer.

That retained-read invariant can deadlock across requests. For example, two requests can each evaluate both `A` and `B`, but in opposite orders:

- Request 1 holds a retained read lock on task `A`, then needs a write lock on `B`.

- Request 2 holds a retained read lock on `B`, then needs a write lock on `A`.

Each write lock blocks on the other request's retained read lock, and neither request will release its read lock until its own downstream completes. The build graph is still acyclic, but the locks wait on each other in a cycle. The integration test `concurrent-bsp-requests-do-not-deadlock-on-opposite-uncached-task-order` reproduces this with two uncached tasks evaluated in opposite order (`orderedAb` / `orderedBa`).

A strict global task-lock ordering would break the cycle, but it would also serialize otherwise-independent tasks *within* a single request and kill intra-request parallelism.

## Fix: release later locks before blocking

The core idea:

- A deadlock needs two requests waiting on each other.

- Each task lock is keyed by its `dest/` path, and the global order is just those path strings sorted lexicographically — a total order every request agrees on.

- Before a request blocks on a busy lock, it releases every retained read it holds that sorts *after* the lock it is waiting for.

- A request therefore only ever waits for a lock that sorts *later* than everything it still holds; a wait chain always moves later along the order and can never loop back, so the cycle cannot form.

- Releasing a read is only safe if it is taken back correctly: once the busy lock frees up and the request acquires it, the request reacquires the reads it released — in order — and re-validates that nothing changed them.

- If re-validation finds an output did change, the request's in-memory results are stale, so it discards them and restarts the entire execution from the top.

- A free lock is taken immediately, in whatever order tasks reach it; the release-and-reacquire dance happens only when a lock is contended. With no contention, tasks run in parallel unchanged from before.

Walked through the deadlock above:

- Request 1 is about to wait for `B`'s write lock while holding a read on `A`.

- `A` sorts after `B`, so request 1 releases its read on `A` first.

- Request 2 can now take `A`'s write lock and finish, unblocking request 1. No cycle.

- Request 2, waiting on the later `A` while holding the earlier `B`, keeps its read — only the side waiting on the earlier lock gives ground. That asymmetry breaks the tie.

Releasing a read mid-evaluation creates two hazards, each handled:

- **A peer may rewrite the output while it is released.**

  - Each task output carries a version that bumps on every rewrite — *before* the task overwrites its `dest/`, not only after it succeeds, so even a failed or partial write still invalidates peers holding the old version.

  - On reacquiring a released read, Mill compares the output's current version to the one it saw when it first took the read; if they differ, it restarts (as above).

  - When Mill is not coordinating with other launchers (e.g. a global-exclusive command owns the whole workspace), there are no peers to invalidate, so versioning is skipped.

- **A read cannot be released while it is still being read.**

  - A read stays pinned while a running downstream task, or a stale worker's `close()`, may still read that upstream `dest/`.

  - Mill marks those upstreams active so the release step skips them.

  - A sibling might have released one just before the mark took effect, so Mill reacquires and validates before the downstream work runs.

## Why it's deadlock-free

Ordered release (above) keeps a request's *acquisition* waits pointing forward through the order. The one remaining way to form a cycle is the reacquire step itself blocking, which a second rule prevents: a task holding a write lock never blocks waiting for another lock.

- A writing task that needs a released read back only *tries* to reacquire it. If it is not immediately free, the evaluation restarts rather than wait while still holding the write lock — a writer that blocked here could recreate the original cycle.

- A request only blocks to reclaim a released read when it holds no write lock (e.g. a read-only cache check). That wait can only be on a peer that is writing, and writers never block while holding a write lock — so the chain still cannot loop.

## Why it can't livelock

The fix recovers from a collision by restarting, so the worry shifts from "stuck forever" to "restarting forever". Restarts stay bounded because every one is paid for by a peer making real progress:

- Only writes bump an output's version; reads do not. So a request that reads a shared output can be invalidated only by an actual rewrite of it, never by another reader.

- An output is rewritten only by the finite set of requests that compute it. A given read therefore causes at most as many restarts as there are writers of that output — a finite number, not an open-ended loop.

- Restarting releases all of this request's locks, so it never keeps the peer it collided with waiting. That peer runs to completion and publishes a stable output.

- A restarted request re-reads completed upstream work from the on-disk cache and now observes the peer's published version. It restarts again only if a *different*, newer write has since landed — i.e. only if some other peer also made progress.

So the total work across all requests is finite and the system always drains rather than spinning in place. The `orderedAb` / `orderedBa` test shows the minimal case: the losing request restarts once after the other publishes, then completes — its body runs twice, which the test asserts via the event log.

## Why restarting is cheap and safe

- **Correct.** The re-run re-derives every result against the current on-disk outputs (cache-hit only if inputs still match), so it can never mix stale in-memory state with a rewritten output.

- **Cheap.** A restart re-probes the cache, it does not recompute: unchanged tasks load from disk, and only the subgraph the rewrite invalidated runs again. Restarts are also rare — they need a dropped read *and* a peer rewriting it in that window.

- **No new deadlock/livelock risk.** Restarting first releases every lock the request holds, so it waits on nothing; and each restart is triggered by a peer's completed write, which is bounded (above).

- **Caveat:** a re-run repeats any non-cached task body, so side-effecting tasks run again — the same assumption Mill's normal cache invalidation already makes.
