### PR TITLE
Fix thread re-use to Improve readability of chrome profiles

### DIFF
--- a/core/api/daemon/src/mill/api/daemon/internal/LauncherOutFiles.scala
+++ b/core/api/daemon/src/mill/api/daemon/internal/LauncherOutFiles.scala
@@ -12,9 +12,6 @@ private[mill] trait LauncherOutFiles extends AutoCloseable {
   def dependencyTree: Path
   def invalidationTree: Path
 
-  def publishLiveArtifacts(): Unit
-
-  def publishArtifacts(): Unit
 }
 
 private[mill] object LauncherOutFiles {
@@ -24,8 +21,6 @@ private[mill] object LauncherOutFiles {
     override val chromeProfile: Path = out.resolve(OutFiles.millChromeProfile)
     override val dependencyTree: Path = out.resolve(OutFiles.millDependencyTree)
     override val invalidationTree: Path = out.resolve(OutFiles.millInvalidationTree)
-    override def publishLiveArtifacts(): Unit = ()
-    override def publishArtifacts(): Unit = ()
     override def close(): Unit = ()
   }
 }

--- a/core/exec/src/mill/exec/ExecutionContexts.scala
+++ b/core/exec/src/mill/exec/ExecutionContexts.scala
@@ -41,20 +41,22 @@ object ExecutionContexts {
     // share one daemon-level executor across multiple `ThreadPool`
     // wrappers, so locking on `this` wouldn't serialise the
     // read-modify-write of core/max pool sizes.
-    def updateThreadCount(delta: Int): Unit = executor.synchronized {
-      if (delta > 0) {
-        executor.setMaximumPoolSize(executor.getMaximumPoolSize + delta)
-        executor.setCorePoolSize(executor.getCorePoolSize + delta)
-      } else {
-        executor.setCorePoolSize(executor.getCorePoolSize + delta)
-        executor.setMaximumPoolSize(executor.getMaximumPoolSize + delta)
+    def enterBlocking(): Unit = executor.synchronized {
+      val newCorePoolSize = executor.getCorePoolSize + 1
+      if (newCorePoolSize > executor.getMaximumPoolSize) {
+        executor.setMaximumPoolSize(newCorePoolSize)
       }
+      executor.setCorePoolSize(newCorePoolSize)
+    }
+
+    def leaveBlocking(): Unit = executor.synchronized {
+      executor.setCorePoolSize(executor.getCorePoolSize - 1)
     }
 
     def blocking[T](t: => T): T = {
-      updateThreadCount(1)
+      enterBlocking()
       try t
-      finally updateThreadCount(-1)
+      finally leaveBlocking()
     }
 
     def execute(runnable: Runnable): Unit = {
@@ -145,7 +147,7 @@ object ExecutionContexts {
     ThreadPoolExecutor(
       threadCount,
       threadCount,
-      60 * 1000,
+      60,
       TimeUnit.SECONDS,
       // Use a priority queue so child `fork.async` tasks can run ahead of
       // lower-priority parent tasks, avoiding large numbers of blocked parent

--- a/core/exec/test/src/mill/exec/ExecutionContextsTests.scala
+++ b/core/exec/test/src/mill/exec/ExecutionContextsTests.scala
@@ -1,0 +1,60 @@
+package mill.exec
+
+import utest.*
+
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, Future, Promise}
+
+object ExecutionContextsTests extends TestSuite {
+  val tests = Tests {
+    test("blockingReusesCompensationThreads") {
+      // Repeated managed-blocking should keep reusing the same compensation
+      // worker instead of shrinking maximumPoolSize and retiring an idle worker
+      // after every blocked parent task.
+      val executor = ExecutionContexts.createExecutor(threadCount = 2)
+      val pool = ExecutionContexts.ThreadPool(executor)
+      val blockerStarted = CountDownLatch(1)
+      val releaseBlocker = CountDownLatch(1)
+
+      try {
+        pool.execute(() => {
+          blockerStarted.countDown()
+          releaseBlocker.await()
+        })
+        assert(blockerStarted.await(5, TimeUnit.SECONDS))
+
+        val threads = collection.mutable.Set.empty[String]
+        for (_ <- 0 until 20) {
+          val result = Promise[(String, String)]()
+          pool.execute(() => {
+            val parentThread = Thread.currentThread().getName
+            val childThread = pool.blocking {
+              Await.result(
+                Future(Thread.currentThread().getName)(using pool),
+                5.seconds
+              )
+            }
+            result.success((parentThread, childThread))
+          })
+          threads.addAll(Await.result(result.future, 5.seconds).productIterator.map(_.toString))
+
+          // Give an executor that shrinks maximumPoolSize on every blocking exit
+          // enough time to retire one of the excess workers before the next loop.
+          Thread.sleep(10)
+        }
+
+        assert(threads.size <= 3)
+        assert(executor.getMaximumPoolSize == 3)
+        assert(executor.getKeepAliveTime(TimeUnit.SECONDS) == 60)
+      } finally {
+        releaseBlocker.countDown()
+        executor.shutdown()
+        if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+          executor.shutdownNow()
+          executor.awaitTermination(5, TimeUnit.SECONDS)
+        }
+      }
+    }
+  }
+}

--- a/core/internal/src/mill/internal/LauncherOutFilesImpl.scala
+++ b/core/internal/src/mill/internal/LauncherOutFilesImpl.scala
@@ -25,27 +25,11 @@ private[mill] class LauncherOutFilesImpl(
   private val closed = AtomicBoolean(false)
 
   private val publishedOutFiles = Seq(
-    PublishedOutFile(
-      out / DaemonFiles.millConsoleTail,
-      os.Path(consoleTail),
-      copyFallback = false
-    ),
-    PublishedOutFile(out / OutFiles.millProfile, os.Path(profile), copyFallback = true),
-    PublishedOutFile(
-      out / OutFiles.millChromeProfile,
-      os.Path(chromeProfile),
-      copyFallback = true
-    ),
-    PublishedOutFile(
-      out / OutFiles.millDependencyTree,
-      os.Path(dependencyTree),
-      copyFallback = true
-    ),
-    PublishedOutFile(
-      out / OutFiles.millInvalidationTree,
-      os.Path(invalidationTree),
-      copyFallback = true
-    )
+    PublishedOutFile(out / DaemonFiles.millConsoleTail, os.Path(consoleTail)),
+    PublishedOutFile(out / OutFiles.millProfile, os.Path(profile)),
+    PublishedOutFile(out / OutFiles.millChromeProfile, os.Path(chromeProfile)),
+    PublishedOutFile(out / OutFiles.millDependencyTree, os.Path(dependencyTree)),
+    PublishedOutFile(out / OutFiles.millInvalidationTree, os.Path(invalidationTree))
   )
 
   // Write the launcher record before creating the run directory. Both live
@@ -55,13 +39,11 @@ private[mill] class LauncherOutFilesImpl(
   // for deletion, so the record must be visible before the directory exists.
   writeLauncherRunFile()
   os.makeDir.all(runDir)
+  initializeRunArtifacts()
+  // Publish stable out/mill-* links once at run startup. Later runs may
+  // retarget those links, so this run must not publish them again on close.
+  publishArtifactsOnce()
   cleanup(out, outFilesState)
-
-  override def publishLiveArtifacts(): Unit =
-    if (!closed.get()) publishLatest(publishedOutFiles.head, outFilesState)
-
-  override def publishArtifacts(): Unit =
-    if (!closed.get()) publishedOutFiles.foreach(publishLatest(_, outFilesState))
 
   override def close(): Unit =
     if (closed.compareAndSet(false, true)) {
@@ -71,11 +53,22 @@ private[mill] class LauncherOutFilesImpl(
 
   private def writeLauncherRunFile(): Unit =
     LauncherOutFilesRecordStore.write(out, runId, launcherPid, activeCommandMessage)
+
+  private def initializeRunArtifacts(): Unit = {
+    os.write.over(os.Path(consoleTail), "", createFolders = true)
+    os.write.over(os.Path(profile), "[]\n", createFolders = true)
+    os.write.over(os.Path(chromeProfile), "[]\n", createFolders = true)
+    os.write.over(os.Path(dependencyTree), "{}\n", createFolders = true)
+    os.write.over(os.Path(invalidationTree), "{}\n", createFolders = true)
+  }
+
+  private def publishArtifactsOnce(): Unit =
+    publishedOutFiles.foreach(publishLatest(_, outFilesState))
 }
 
 private[mill] object LauncherOutFilesImpl {
   private val maxRetainedRuns = 10
-  private case class PublishedOutFile(link: os.Path, target: os.Path, copyFallback: Boolean)
+  private case class PublishedOutFile(link: os.Path, target: os.Path)
 
   private val wellKnownOutFileLinks = Seq(
     os.RelPath(DaemonFiles.millConsoleTail),
@@ -95,7 +88,7 @@ private[mill] object LauncherOutFilesImpl {
       if (os.exists(runRootDir)) {
         val runDirs = os.list(runRootDir).filter(os.isDir(_))
         val eligible = runDirs.filterNot(d => active.contains(d.last))
-          .sortBy(d => LauncherOutFilesRecordStore.runIdSortKey(d.last))
+          .sortBy(lastModifiedMillis)
         val toRemoveCount = math.max(0, eligible.size - maxRetainedRuns)
         eligible.take(toRemoveCount).foreach(d =>
           try os.remove.all(d)
@@ -114,6 +107,10 @@ private[mill] object LauncherOutFilesImpl {
       }
     } catch { case _: Throwable => () }
   }
+
+  private def lastModifiedMillis(path: os.Path): Long =
+    try os.mtime(path)
+    catch { case _: Throwable => 0L }
 
   private def withPublishedPathLock[T](
       link: os.Path,
@@ -157,17 +154,6 @@ private[mill] object LauncherOutFilesImpl {
     )(tmp => os.symlink(tmp, rel))
   }
 
-  private def replaceWithCopy(
-      link: os.Path,
-      target: os.Path,
-      outFilesState: LauncherOutFilesState
-  ): Unit = {
-    replaceAtomically(
-      link,
-      s".${link.last}.copy-${System.nanoTime()}-${outFilesState.nextTmpSuffix()}"
-    )(tmp => os.copy.over(target, tmp, createFolders = true))
-  }
-
   private def publishLatest(
       outFile: PublishedOutFile,
       outFilesState: LauncherOutFilesState
@@ -180,8 +166,6 @@ private[mill] object LauncherOutFilesImpl {
             mill.api.Debug(
               s"Failed to publish ${outFile.link.last} as a symlink: ${e.getClass.getSimpleName}: ${e.getMessage}"
             )
-            if (outFile.copyFallback)
-              replaceWithCopy(outFile.link, outFile.target, outFilesState)
         }
     }
   }

--- a/core/internal/src/mill/internal/LauncherOutFilesRecordStore.scala
+++ b/core/internal/src/mill/internal/LauncherOutFilesRecordStore.scala
@@ -5,7 +5,13 @@ import mill.constants.DaemonFiles
 import scala.jdk.OptionConverters.RichOptional
 
 private[mill] object LauncherOutFilesRecordStore {
-  case class Record(runId: String, pid: Long, command: String, startMillis: Option[Long])
+  case class Record(
+      runId: String,
+      pid: Long,
+      command: String,
+      processStartMillis: Option[Long],
+      createdMillis: Long
+  )
 
   def path(out: os.Path, runId: String): os.Path =
     out / os.RelPath(DaemonFiles.perLauncherFilePath(runId))
@@ -15,9 +21,13 @@ private[mill] object LauncherOutFilesRecordStore {
       .flatMap(_.info().startInstant().toScala.map(_.toEpochMilli))
 
   def write(out: os.Path, runId: String, pid: Long, command: String): Unit = {
-    val commandJson = ujson.write(ujson.Str(command))
-    val startMillisJson = processStartMillis(pid).fold("null")(_.toString)
-    val json = s"""{"pid":$pid,"command":$commandJson,"startMillis":$startMillisJson}"""
+    val createdMillis = System.currentTimeMillis()
+    val json = ujson.Obj(
+      "pid" -> pid,
+      "command" -> command,
+      "startMillis" -> processStartMillis(pid).fold[ujson.Value](ujson.Null)(ujson.Num(_)),
+      "createdMillis" -> createdMillis
+    ).render()
     val file = path(out, runId)
     try mill.api.BuildCtx.withFilesystemCheckerDisabled {
         os.makeDir.all(file / os.up)
@@ -48,21 +58,16 @@ private[mill] object LauncherOutFilesRecordStore {
     else
       os.list(dir)
         .filter(os.isFile(_))
-        .flatMap(readActiveRecord(_, removeStale, keepUnreadable))
-        .sortBy(record => runIdSortKey(record.runId))
+        .flatMap(file => readActiveRecord(file, removeStale, keepUnreadable).map(file -> _))
+        .sortBy { case (file, record) =>
+          (record.createdMillis, lastModifiedMillis(file))
+        }
+        .map(_._2)
   }
 
-  // RunIds are `<millis>-<pid>-<counter>`; sort by millis then trailing
-  // counter so most-recent comes last. Older single-segment formats fall
-  // back to (0, 0).
-  def runIdSortKey(runId: String): (Long, Long) = {
-    val parts = runId.split('-')
-    if (parts.isEmpty) (0L, 0L)
-    else (
-      parts.head.toLongOption.getOrElse(0L),
-      parts.last.toLongOption.getOrElse(0L)
-    )
-  }
+  private def lastModifiedMillis(path: os.Path): Long =
+    try os.mtime(path)
+    catch { case _: Throwable => 0L }
 
   private def readActiveRecord(
       file: os.Path,
@@ -78,20 +83,23 @@ private[mill] object LauncherOutFilesRecordStore {
           runId = file.baseName,
           pid = pid,
           command = json.get("command").map(_.str).getOrElse(""),
-          startMillis = json.get("startMillis").flatMap {
+          processStartMillis = json.get("startMillis").flatMap {
             case ujson.Null => None
             case v => v.numOpt.map(_.toLong)
-          }
+          },
+          createdMillis = json.get("createdMillis").flatMap(_.numOpt.map(_.toLong))
+            .getOrElse(lastModifiedMillis(file))
         )
       } catch {
-        case _: Throwable if keepUnreadable => Some(Record(file.baseName, -1L, "", None))
+        case _: Throwable if keepUnreadable =>
+          Some(Record(file.baseName, -1L, "", None, lastModifiedMillis(file)))
         case _: Throwable => None
       }
 
     def liveProcess(record: Record): Boolean =
       java.lang.ProcessHandle.of(record.pid).toScala.exists { ph =>
         if (!ph.isAlive) false
-        else record.startMillis match {
+        else record.processStartMillis match {
           // Legacy record without start time — PID-only check.
           case None => true
           // Defeat PID reuse: a recycled PID with a different start

--- a/core/internal/src/mill/internal/LauncherOutFilesRecordStore.scala
+++ b/core/internal/src/mill/internal/LauncherOutFilesRecordStore.scala
@@ -21,13 +21,11 @@ private[mill] object LauncherOutFilesRecordStore {
       .flatMap(_.info().startInstant().toScala.map(_.toEpochMilli))
 
   def write(out: os.Path, runId: String, pid: Long, command: String): Unit = {
+    val commandJson = ujson.write(ujson.Str(command))
+    val startMillisJson = processStartMillis(pid).fold("null")(_.toString)
     val createdMillis = System.currentTimeMillis()
-    val json = ujson.Obj(
-      "pid" -> pid,
-      "command" -> command,
-      "startMillis" -> processStartMillis(pid).fold[ujson.Value](ujson.Null)(ujson.Num(_)),
-      "createdMillis" -> createdMillis
-    ).render()
+    val json =
+      s"""{"pid":$pid,"command":$commandJson,"startMillis":$startMillisJson,"createdMillis":$createdMillis}"""
     val file = path(out, runId)
     try mill.api.BuildCtx.withFilesystemCheckerDisabled {
         os.makeDir.all(file / os.up)

--- a/core/internal/src/mill/internal/LauncherOutFilesState.scala
+++ b/core/internal/src/mill/internal/LauncherOutFilesState.scala
@@ -2,6 +2,8 @@ package mill.internal
 
 import mill.constants.DaemonFiles
 
+import java.time.format.DateTimeFormatter
+import java.time.{Instant, ZoneId}
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 
@@ -10,20 +12,25 @@ private[mill] class LauncherOutFilesState {
   private val runIdCounter = AtomicLong(0L)
   private val tmpNameCounter = AtomicLong(0L)
   // The PR design allows a MillNoDaemonMain process to share `out/` with a
-  // (formerly running) MillDaemonMain. Two processes starting in the same
-  // millisecond would otherwise produce identical runIds; mix in the PID so
-  // run directories and launcher record files cannot collide across processes.
+  // (formerly running) MillDaemonMain. Mix in the PID and a per-process run
+  // counter so run directories and launcher record files cannot collide across
+  // processes or quick successive runs.
   private val pid: Long = ProcessHandle.current().pid()
 
   def publishedPathLockFor(normalizedAbsolutePath: String): AnyRef =
     publishedPathLocks.computeIfAbsent(normalizedAbsolutePath, _ => new Object)
 
-  def nextRunId(): String =
-    s"${System.currentTimeMillis()}-$pid-${runIdCounter.getAndIncrement()}"
+  def nextRunId(): String = {
+    val now = Instant.now()
+    val timestamp = LauncherOutFilesState.runIdTimestampFormatter.format(now)
+    s"run-${runIdCounter.getAndIncrement()}_${timestamp}_pid-${pid}"
+  }
 
   def nextTmpSuffix(): Long = tmpNameCounter.getAndIncrement()
 }
 
 private[mill] object LauncherOutFilesState {
   val runRootDirName = DaemonFiles.millRun
+  private[mill] val runIdTimestampFormatter: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss").withZone(ZoneId.systemDefault())
 }

--- a/core/internal/test/src/mill/internal/LauncherOutFilesImplTests.scala
+++ b/core/internal/test/src/mill/internal/LauncherOutFilesImplTests.scala
@@ -12,12 +12,12 @@ object LauncherOutFilesImplTests extends TestSuite {
         val pid = ProcessHandle.current().pid()
 
         for (i <- 0 until 10) {
-          val runId = s"1000-$pid-$i"
+          val runId = s"run-${i}_2026-05-26_09-00-00_pid-$pid"
           LauncherOutFilesRecordStore.write(out, runId, pid, s"active-$i")
           os.makeDir.all(out / LauncherOutFilesState.runRootDirName / runId)
         }
 
-        val finishedRunId = s"2000-$pid-0"
+        val finishedRunId = s"run-0_2026-05-26_09-00-01_pid-$pid"
         val outFiles = new LauncherOutFilesImpl(
           out = out,
           activeCommandMessage = "finished",
@@ -26,8 +26,7 @@ object LauncherOutFilesImplTests extends TestSuite {
           runId = finishedRunId
         )
         val finishedRunDir = out / LauncherOutFilesState.runRootDirName / finishedRunId
-        os.write(os.Path(outFiles.profile), "[]", createFolders = true)
-        outFiles.publishArtifacts()
+        os.write.over(os.Path(outFiles.profile), "[]", createFolders = true)
         outFiles.close()
 
         assert(os.exists(finishedRunDir))
@@ -35,10 +34,51 @@ object LauncherOutFilesImplTests extends TestSuite {
       } finally os.remove.all(out)
     }
 
+    test("newRunPublishesFreshOutFilesAtStartup") {
+      val out = os.temp.dir(prefix = "mill-launcher-out-files")
+      try {
+        val outFilesState = new LauncherOutFilesState
+        val pid = ProcessHandle.current().pid()
+        val firstRun = new LauncherOutFilesImpl(
+          out = out,
+          activeCommandMessage = "first",
+          launcherPid = pid,
+          outFilesState = outFilesState,
+          runId = outFilesState.nextRunId()
+        )
+        os.write.over(os.Path(firstRun.profile), """{"old":true}""")
+        os.write.over(os.Path(firstRun.chromeProfile), """{"old":true}""")
+        os.write.over(os.Path(firstRun.dependencyTree), """{"old":true}""")
+        os.write.over(os.Path(firstRun.invalidationTree), """{"old":true}""")
+
+        assert(os.read(out / OutFiles.millProfile) == """{"old":true}""")
+        assert(os.read(out / OutFiles.millChromeProfile) == """{"old":true}""")
+
+        val secondRun = new LauncherOutFilesImpl(
+          out = out,
+          activeCommandMessage = "second",
+          launcherPid = pid,
+          outFilesState = outFilesState,
+          runId = outFilesState.nextRunId()
+        )
+
+        assert(os.read(out / OutFiles.millProfile) == "[]\n")
+        assert(os.read(out / OutFiles.millChromeProfile) == "[]\n")
+        assert(os.read(out / OutFiles.millDependencyTree) == "{}\n")
+        assert(os.read(out / OutFiles.millInvalidationTree) == "{}\n")
+
+        firstRun.close()
+        assert(os.read(out / OutFiles.millProfile) == "[]\n")
+        assert(os.read(out / OutFiles.millChromeProfile) == "[]\n")
+
+        secondRun.close()
+      } finally os.remove.all(out)
+    }
+
     test("malformedRecordsArePreservedAsActiveDuringSweep") {
       val out = os.temp.dir(prefix = "mill-launcher-records")
       try {
-        val runId = "1000-123-0"
+        val runId = "run-0_2026-05-26_09-00-00_pid-123"
         val record = LauncherOutFilesRecordStore.path(out, runId)
         os.write.over(record, "{", createFolders = true)
 
@@ -47,6 +87,26 @@ object LauncherOutFilesImplTests extends TestSuite {
         assert(active.exists(_.runId == runId))
         assert(os.exists(record))
       } finally os.remove.all(out)
+    }
+
+    test("mostRecentActiveUsesRecordCreationTime") {
+      val out = os.temp.dir(prefix = "mill-launcher-records")
+      try {
+        val pid = ProcessHandle.current().pid()
+        val older = "run-99_2026-05-26_09-00-01_pid-123"
+        val newer = "run-0_2026-05-26_09-00-00_pid-123"
+        LauncherOutFilesRecordStore.write(out, older, pid, "older")
+        Thread.sleep(2)
+        LauncherOutFilesRecordStore.write(out, newer, pid, "newer")
+
+        assert(LauncherOutFilesRecordStore.mostRecentActive(out).map(_.runId) == Some(newer))
+      } finally os.remove.all(out)
+    }
+
+    test("runIdsAreReadable") {
+      val runId = new LauncherOutFilesState().nextRunId()
+
+      assert(runId.matches(raw"run-\d+_\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}_pid-\d+"))
     }
   }
 }

--- a/core/internal/test/src/mill/internal/LauncherOutFilesImplTests.scala
+++ b/core/internal/test/src/mill/internal/LauncherOutFilesImplTests.scala
@@ -96,8 +96,9 @@ object LauncherOutFilesImplTests extends TestSuite {
         val older = "run-99_2026-05-26_09-00-01_pid-123"
         val newer = "run-0_2026-05-26_09-00-00_pid-123"
         LauncherOutFilesRecordStore.write(out, older, pid, "older")
-        Thread.sleep(2)
         LauncherOutFilesRecordStore.write(out, newer, pid, "newer")
+        overwriteCreatedMillis(out, older, createdMillis = 1000L)
+        overwriteCreatedMillis(out, newer, createdMillis = 2000L)
 
         assert(LauncherOutFilesRecordStore.mostRecentActive(out).map(_.runId) == Some(newer))
       } finally os.remove.all(out)
@@ -108,5 +109,12 @@ object LauncherOutFilesImplTests extends TestSuite {
 
       assert(runId.matches(raw"run-\d+_\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}_pid-\d+"))
     }
+  }
+
+  private def overwriteCreatedMillis(out: os.Path, runId: String, createdMillis: Long): Unit = {
+    val recordPath = LauncherOutFilesRecordStore.path(out, runId)
+    val json = ujson.read(os.read(recordPath)).obj
+    json("createdMillis") = ujson.Num(createdMillis)
+    os.write.over(recordPath, ujson.write(json))
   }
 }

--- a/runner/daemon/src/mill/daemon/MillMain0.scala
+++ b/runner/daemon/src/mill/daemon/MillMain0.scala
@@ -377,55 +377,49 @@ object MillMain0 {
                             // metadata for subsequent runs.
                             if (skipSelectiveExecution)
                               os.remove(out / OutFiles.millSelectiveExecution)
-                            runArtifacts.publishLiveArtifacts()
-                            try mill.api.SystemStreamsUtils.withStreams(logger.streams) {
-                                mill.api.FilesystemCheckerEnabled.withValue(
-                                  !config.noFilesystemChecker.value
+                            mill.api.SystemStreamsUtils.withStreams(logger.streams) {
+                              mill.api.FilesystemCheckerEnabled.withValue(
+                                !config.noFilesystemChecker.value
+                              ) {
+                                tailManager.withOutErr(
+                                  logger.streams.out,
+                                  logger.streams.err
                                 ) {
-                                  tailManager.withOutErr(
-                                    logger.streams.out,
-                                    logger.streams.err
-                                  ) {
-                                    MillBuildBootstrap(
-                                      topLevelProjectRoot = BuildCtx.workspaceRoot,
-                                      output = out,
-                                      // In BSP server mode, evaluate as many tasks as possible
-                                      // so BSP responses can expose as much information as available.
-                                      keepGoing = bspMode || config.keepGoing.value,
-                                      imports = config.imports,
-                                      env = env ++ extraEnv,
-                                      ec = ec,
-                                      tasksAndParams = tasksAndParams,
-                                      prevCommandState =
-                                        prevState.getOrElse(RunnerLauncherState.empty),
-                                      logger = logger,
-                                      requestedMetaLevel =
-                                        config.metaLevel.orElse(metaLevelOverride),
-                                      allowPositionalCommandArgs =
-                                        config.allowPositional.value,
-                                      systemExit = systemExit,
-                                      streams0 = streams,
-                                      selectiveExecution = config.watch.value,
-                                      offline = config.offline.value,
-                                      useFileLocks = config.useFileLocks.value,
-                                      runArtifacts = runArtifacts,
-                                      metaBuild = new MetaBuildAccess(
-                                        ref = sharedState,
-                                        workspaceLocking = workspaceLocking
-                                      ),
-                                      reporter = reporter,
-                                      metaBuildReporter = metaBuildReporter,
-                                      enableTicker = enableTicker
-                                    ).evaluate()
-                                  }
+                                  MillBuildBootstrap(
+                                    topLevelProjectRoot = BuildCtx.workspaceRoot,
+                                    output = out,
+                                    // In BSP server mode, evaluate as many tasks as possible
+                                    // so BSP responses can expose as much information as available.
+                                    keepGoing = bspMode || config.keepGoing.value,
+                                    imports = config.imports,
+                                    env = env ++ extraEnv,
+                                    ec = ec,
+                                    tasksAndParams = tasksAndParams,
+                                    prevCommandState =
+                                      prevState.getOrElse(RunnerLauncherState.empty),
+                                    logger = logger,
+                                    requestedMetaLevel =
+                                      config.metaLevel.orElse(metaLevelOverride),
+                                    allowPositionalCommandArgs =
+                                      config.allowPositional.value,
+                                    systemExit = systemExit,
+                                    streams0 = streams,
+                                    selectiveExecution = config.watch.value,
+                                    offline = config.offline.value,
+                                    useFileLocks = config.useFileLocks.value,
+                                    runArtifacts = runArtifacts,
+                                    metaBuild = new MetaBuildAccess(
+                                      ref = sharedState,
+                                      workspaceLocking = workspaceLocking
+                                    ),
+                                    reporter = reporter,
+                                    metaBuildReporter = metaBuildReporter,
+                                    enableTicker = enableTicker
+                                  ).evaluate()
                                 }
                               }
-                            // Publish in-progress, then republish after
-                            // logger close so the Windows copy fallback
-                            // for JSON-array logs sees the trailing `]`.
-                            finally runArtifacts.publishArtifacts()
+                            }
                           }
-                          runArtifacts.publishArtifacts()
                           state.withResources(workspaceLocking, runArtifacts, fileLockLease)
                         } catch {
                           case e: Throwable =>


### PR DESCRIPTION
Previously we would aggressively scale down the thread pool after `blocking{...}` spans finished, which caused new threads to be spawned constantly and this churn being present in the profile. This PR keeps the max thread count high and allows threads to go 60s before timing out, so threads are re-used much more aggressively

Also included some cleanups for the `out/mill-run/` folder to make the subfolders easier to read and have more up to date symlinks in `out/mill*`

Tested by running `dist.installLocal` and `./mill-proguard.jar 'integration.{feature,failure}._'`

Before

<img width="1840" height="1191" alt="Screenshot 2026-05-26 at 9 09 53 AM" src="https://github.com/user-attachments/assets/ea135150-c42a-4dbb-be54-6a0c4c2db091" />

After

<img width="1840" height="758" alt="Screenshot 2026-05-26 at 9 20 20 AM" src="https://github.com/user-attachments/assets/76c133b9-0765-4b5a-8206-c723da2846de" />


Fixes https://github.com/com-lihaoyi/mill/issues/7127