### PR TITLE
Fix fine-grained-locking BSP import deadlock

### DIFF
--- a/core/exec/src/mill/exec/ExecutionContexts.scala
+++ b/core/exec/src/mill/exec/ExecutionContexts.scala
@@ -49,8 +49,16 @@ object ExecutionContexts {
       executor.setCorePoolSize(newCorePoolSize)
     }
 
+    // Scale both core AND max back down so the extra worker spun up for the
+    // `blocking{...}` span is reaped once idle, restoring the `--jobs`
+    // parallelism bound instead of leaving leftover threads draining the
+    // queue. Lower core first so the `core <= max` invariant always holds.
+    // The resulting thread churn no longer fragments the chrome profile,
+    // because [[mill.internal.ThreadNumberer]] now recycles profile lanes
+    // independently of physical thread identity.
     def leaveBlocking(): Unit = executor.synchronized {
       executor.setCorePoolSize(executor.getCorePoolSize - 1)
+      executor.setMaximumPoolSize(executor.getMaximumPoolSize - 1)
     }
 
     def blocking[T](t: => T): T = {

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -303,8 +303,14 @@ trait GroupExecution {
         // dropped during an earlier contended wait before evaluation continues.
         // This path may block, so only call it when we are not holding a task
         // Write lease.
+        // #7132: blocking task-lock waits run on the bounded execution pool;
+        // wrap them in `executionContext.blocking` so the pool spawns a
+        // compensating worker while parked, preventing pool starvation (the
+        // lock-holder's downstream tasks can still get a thread and release).
         def reacquireDroppedReads(): Unit =
-          leaseTracker.reacquireDropped(workspaceLocking, taskWaitReporter)
+          executionContext.blocking {
+            leaseTracker.reacquireDropped(workspaceLocking, taskWaitReporter)
+          }
 
         // The write-upgrade callback and Named write body run while holding
         // this task's Write lock, so dropped reads must be reacquired only via
@@ -330,12 +336,14 @@ trait GroupExecution {
         // — so per-task locking is unnecessary and just serializes peers.
         def acquireReadTaskLock(): LauncherLocking.Lease = {
           def blockingAcquire(): LauncherLocking.Lease =
-            workspaceLocking.taskLock(
-              taskLockPath,
-              labelled.ctx.segments.render,
-              LauncherLocking.LockKind.Read,
-              taskWaitReporter
-            )
+            executionContext.blocking {
+              workspaceLocking.taskLock(
+                taskLockPath,
+                labelled.ctx.segments.render,
+                LauncherLocking.LockKind.Read,
+                taskWaitReporter
+              )
+            }
 
           if (labelled.isInputTask)
             LauncherLocking.Noop.taskLock(
@@ -370,11 +378,13 @@ trait GroupExecution {
         def awaitTaskLockChange(timeoutMs: Long): Unit =
           if (!labelled.isInputTask) {
             leaseTracker.releaseHigherThan(taskLockKey)
-            workspaceLocking.awaitTaskStateChange(
-              taskLockPath,
-              labelled.ctx.segments.render,
-              timeoutMs
-            )
+            executionContext.blocking {
+              workspaceLocking.awaitTaskStateChange(
+                taskLockPath,
+                labelled.ctx.segments.render,
+                timeoutMs
+              )
+            }
           }
 
         // Helper to evaluate the task with full caching support

--- a/core/exec/test/src/mill/exec/ExecutionContextsTests.scala
+++ b/core/exec/test/src/mill/exec/ExecutionContextsTests.scala
@@ -8,10 +8,38 @@ import scala.concurrent.{Await, Future, Promise}
 
 object ExecutionContextsTests extends TestSuite {
   val tests = Tests {
-    test("blockingReusesCompensationThreads") {
-      // Repeated managed-blocking should keep reusing the same compensation
-      // worker instead of shrinking maximumPoolSize and retiring an idle worker
-      // after every blocked parent task.
+    test("blockingScalesPoolUpThenBackDownToBaseline") {
+      // Managed-blocking grows BOTH core and max while a task is parked, then
+      // scales both back down on exit so the `--jobs` parallelism bound is
+      // restored (no leftover workers left draining the queue). The resulting
+      // thread churn is intentional and is kept out of chrome profiles by
+      // `mill.internal.ThreadNumberer` recycling ids of reaped threads.
+      val executor = ExecutionContexts.createExecutor(threadCount = 2)
+      val pool = ExecutionContexts.ThreadPool(executor)
+      try {
+        assert(executor.getCorePoolSize == 2 && executor.getMaximumPoolSize == 2)
+
+        pool.enterBlocking()
+        assert(executor.getCorePoolSize == 3 && executor.getMaximumPoolSize == 3)
+
+        pool.enterBlocking()
+        assert(executor.getCorePoolSize == 4 && executor.getMaximumPoolSize == 4)
+
+        pool.leaveBlocking()
+        assert(executor.getCorePoolSize == 3 && executor.getMaximumPoolSize == 3)
+
+        pool.leaveBlocking()
+        assert(executor.getCorePoolSize == 2 && executor.getMaximumPoolSize == 2)
+
+        assert(executor.getKeepAliveTime(TimeUnit.SECONDS) == 60)
+      } finally executor.shutdown()
+    }
+
+    test("blockingRunsCompensationWorkerWhileParked") {
+      // With both core threads occupied (one by a long-running blocker, one by a
+      // parent that parks in `blocking{...}`), a child task must still make
+      // progress — which is only possible if `blocking{...}` grew the pool so a
+      // compensation worker could run it.
       val executor = ExecutionContexts.createExecutor(threadCount = 2)
       val pool = ExecutionContexts.ThreadPool(executor)
       val blockerStarted = CountDownLatch(1)
@@ -24,29 +52,18 @@ object ExecutionContextsTests extends TestSuite {
         })
         assert(blockerStarted.await(5, TimeUnit.SECONDS))
 
-        val threads = collection.mutable.Set.empty[String]
-        for (_ <- 0 until 20) {
-          val result = Promise[(String, String)]()
-          pool.execute(() => {
-            val parentThread = Thread.currentThread().getName
-            val childThread = pool.blocking {
-              Await.result(
-                Future(Thread.currentThread().getName)(using pool),
-                5.seconds
-              )
-            }
-            result.success((parentThread, childThread))
-          })
-          threads.addAll(Await.result(result.future, 5.seconds).productIterator.map(_.toString))
+        val result = Promise[String]()
+        pool.execute(() => {
+          val childThread = pool.blocking {
+            Await.result(
+              Future(Thread.currentThread().getName)(using pool),
+              5.seconds
+            )
+          }
+          result.success(childThread)
+        })
 
-          // Give an executor that shrinks maximumPoolSize on every blocking exit
-          // enough time to retire one of the excess workers before the next loop.
-          Thread.sleep(10)
-        }
-
-        assert(threads.size <= 3)
-        assert(executor.getMaximumPoolSize == 3)
-        assert(executor.getKeepAliveTime(TimeUnit.SECONDS) == 60)
+        assert(Await.result(result.future, 5.seconds) != null)
       } finally {
         releaseBlocker.countDown()
         executor.shutdown()

--- a/core/internal/src/mill/internal/ThreadNumberer.scala
+++ b/core/internal/src/mill/internal/ThreadNumberer.scala
@@ -1,13 +1,57 @@
 package mill.internal
 
 /**
- * Small class to take named threads and assign them stable integer IDs
+ * Assigns each thread a small stable integer id, used as the chrome-profile
+ * track ("tid") for the spans that run on it.
+ *
+ * A live thread always maps to the same id, so every span it runs over its
+ * lifetime shares one readable track. When the execution pool scales back down
+ * after `blocking{...}` compensation (see
+ * [[mill.exec.ExecutionContexts.ThreadPool]]) and an idle worker is reaped, its
+ * id is reclaimed and handed to the next freshly-spawned worker. So the id
+ * (track) count tracks the live-thread high-water mark rather than the total
+ * number of threads ever created: a killed-then-respawned worker transfers the
+ * dead worker's id instead of minting a new one, keeping churned profiles
+ * compact without scattering a reused thread's work across multiple tracks.
+ *
+ * Reclaiming a dead thread's id can never produce overlapping spans on a track:
+ * a worker is only reaped while idle (no open span), so its track is already
+ * begin/end balanced before the id is reused.
  */
 private class ThreadNumberer() {
   private val threadIds = collection.mutable.Map.empty[Thread, Int]
+  // Ids of threads that have since died, available for reuse. Smallest-first
+  // keeps the assigned ids compact.
+  private val freeIds = collection.mutable.TreeSet.empty[Int]
+  private var nextId = 1
 
   def getThreadId(thread: Thread): Int = synchronized {
-    // start thread IDs from 1 so they're easier to count
-    threadIds.getOrElseUpdate(thread, threadIds.size + 1)
+    threadIds.get(thread) match {
+      // A thread we've already numbered keeps its id for its whole lifetime.
+      case Some(id) => id
+      case None =>
+        // First time we see this thread: reclaim the ids of any previously-seen
+        // threads that have since died (e.g. reaped pool workers) so this thread
+        // can transfer one of them rather than growing the track count.
+        val dead = threadIds.iterator.collect { case (t, id) if !t.isAlive => (t, id) }.toList
+        for ((t, id) <- dead) {
+          threadIds.remove(t)
+          freeIds.add(id)
+        }
+
+        val id =
+          if (freeIds.nonEmpty) {
+            val reused = freeIds.head
+            freeIds.remove(reused)
+            reused
+          } else {
+            // start thread IDs from 1 so they're easier to count
+            val fresh = nextId
+            nextId += 1
+            fresh
+          }
+        threadIds(thread) = id
+        id
+    }
   }
 }

--- a/core/internal/test/src/mill/internal/ThreadNumbererTests.scala
+++ b/core/internal/test/src/mill/internal/ThreadNumbererTests.scala
@@ -1,0 +1,74 @@
+package mill.internal
+
+import utest.*
+
+object ThreadNumbererTests extends TestSuite {
+
+  /** Run `f` on a fresh thread, join it, and return what `f` produced. */
+  private def onDeadThread[T](f: Thread => T): (Thread, T) = {
+    var result = Option.empty[T]
+    var ref = Option.empty[Thread]
+    val t = new Thread(() => {
+      ref = Some(Thread.currentThread())
+      result = Some(f(Thread.currentThread()))
+    })
+    t.start()
+    t.join()
+    assert(!t.isAlive)
+    (ref.get, result.get)
+  }
+
+  val tests = Tests {
+    test("liveThreadKeepsStableId") {
+      val n = ThreadNumberer()
+      val self = Thread.currentThread()
+      val id = n.getThreadId(self)
+      // Repeated lookups for the same still-live thread are stable.
+      assert(n.getThreadId(self) == id)
+      assert(n.getThreadId(self) == id)
+    }
+
+    test("distinctLiveThreadsGetDistinctIds") {
+      val n = ThreadNumberer()
+      val a = n.getThreadId(Thread.currentThread())
+      // A second thread that is still alive while we number a third must not
+      // share its id (no recycling of live threads).
+      val barrier = new java.util.concurrent.CountDownLatch(1)
+      val release = new java.util.concurrent.CountDownLatch(1)
+      var b = -1
+      val other = new Thread(() => {
+        b = n.getThreadId(Thread.currentThread())
+        barrier.countDown()
+        release.await()
+      })
+      other.start()
+      barrier.await()
+      try assert(b != a)
+      finally { release.countDown(); other.join() }
+    }
+
+    test("deadThreadIdIsTransferredToNextNewThread") {
+      val n = ThreadNumberer()
+      // main thread takes id 1
+      val mainId = n.getThreadId(Thread.currentThread())
+      // a thread that runs then dies takes the next id
+      val (_, deadId) = onDeadThread(n.getThreadId)
+      assert(deadId != mainId)
+      // the next freshly-spawned thread reclaims the dead thread's id rather
+      // than minting a new one
+      val (_, reusedId) = onDeadThread(n.getThreadId)
+      assert(reusedId == deadId)
+      // and the still-live main thread's id is untouched throughout
+      assert(n.getThreadId(Thread.currentThread()) == mainId)
+    }
+
+    test("idsStayCompactUnderChurn") {
+      val n = ThreadNumberer()
+      n.getThreadId(Thread.currentThread()) // id 1, stays live
+      // Many sequential (dead) threads should keep reusing a single recycled id
+      // rather than growing the id space, since only one is ever alive at a time.
+      val ids = (0 until 50).map(_ => onDeadThread(n.getThreadId)._2).toSet
+      assert(ids.size == 1)
+    }
+  }
+}


### PR DESCRIPTION
Another attempt to fix https://github.com/com-lihaoyi/mill/issues/7132. The problem appears to be that we aren't running lock acquisition inside  `blocking{}` block, which means that it's vulnerable to running out of available threads. This PR properly wraps it so that if a thread blocks on a lock, it is done in `blocking{}` block so that we spawn a compensating thread so we can avoid running out

Also contains a follow up to https://github.com/com-lihaoyi/mill/pull/7138 which keeps the chrome-profile improvements without allowing the number of active threads to balloon past the jobs limit

Tested manually, seems like claude is able to reproduce the deadlock without this fix and it no longer reproduces with it