### PR TITLE
Fix O(n^2) per-task lease scan and thread count ballooning past --jobs

### DIFF
--- a/core/exec/src/mill/exec/Execution.scala
+++ b/core/exec/src/mill/exec/Execution.scala
@@ -545,6 +545,30 @@ object Execution {
     }
 
     val states = new ConcurrentHashMap[Task[?], State]()
+
+    // Number of retained reads currently in the `dropped` state (released
+    // before a contended wait, not yet reacquired). The common no-op/no-
+    // contention build never drops anything, so this stays 0 and lets
+    // `reacquireDropped`/`hasDropped` short-circuit instead of scanning every
+    // task's `State` on each task's read-lock fast path — which was O(n) per
+    // task, i.e. O(n^2) over the whole graph (#7132 follow-up).
+    private val droppedCount = new AtomicInteger(0)
+
+    /** Whether any retained read is currently dropped and awaiting reacquire. */
+    def hasDropped: Boolean = droppedCount.get() != 0
+
+    // Both helpers must be called while holding `retained`'s owning
+    // `State.synchronized`, so the `dropped` flag and the counter stay in step.
+    private def markDropped(retained: Retained): Unit =
+      if (!retained.dropped) {
+        retained.dropped = true
+        droppedCount.incrementAndGet()
+      }
+    private def clearDropped(retained: Retained): Unit =
+      if (retained.dropped) {
+        retained.dropped = false
+        droppedCount.decrementAndGet()
+      }
     private val transitiveUpstreams: Map[Task[?], Seq[Task[?]]] = {
       def rec(task: Task[?]): Seq[Task[?]] = {
         val seen = mutable.LinkedHashSet.empty[Task[?]]
@@ -574,9 +598,15 @@ object Execution {
     private def drainLeases(s: State): Unit = s.synchronized {
       val retained = s.retained
       s.retained = null
-      if (retained != null && retained.lease != null) {
-        closeQuietly(retained.lease)
-        retained.lease = null
+      if (retained != null) {
+        // Discarding a still-dropped retained must release its counter slot,
+        // else `droppedCount` leaks upward and permanently defeats the
+        // `hasDropped` short-circuit.
+        clearDropped(retained)
+        if (retained.lease != null) {
+          closeQuietly(retained.lease)
+          retained.lease = null
+        }
       }
     }
 
@@ -613,7 +643,10 @@ object Execution {
     ): Unit = {
       val s = states.get(task)
       if (s != null) s.synchronized {
-        if (s.retained != null && s.retained.lease != null) closeQuietly(s.retained.lease)
+        if (s.retained != null) {
+          clearDropped(s.retained)
+          if (s.retained.lease != null) closeQuietly(s.retained.lease)
+        }
         s.retained = Retained(
           path = path,
           label = label,
@@ -637,7 +670,7 @@ object Execution {
         ) {
           closeQuietly(retained.lease)
           retained.lease = null
-          retained.dropped = true
+          markDropped(retained)
         }
       }
     }
@@ -653,6 +686,9 @@ object Execution {
         // non-Named groups, where this evaluation does not hold a task Write.
         block: Boolean = true
     ): Unit = {
+      // Fast path: nothing was ever dropped (the common no-contention case),
+      // so skip the full O(n) scan of every task's `State`.
+      if (droppedCount.get() == 0) return
       import scala.jdk.CollectionConverters.*
       val dropped = states.values().asScala.toSeq.flatMap { s =>
         s.synchronized {
@@ -684,7 +720,7 @@ object Execution {
         s.synchronized {
           if ((s.retained eq retained) && retained.dropped && retained.lease == null) {
             retained.lease = lease
-            retained.dropped = false
+            clearDropped(retained)
           } else closeQuietly(lease)
         }
       }

--- a/core/exec/src/mill/exec/Execution.scala
+++ b/core/exec/src/mill/exec/Execution.scala
@@ -546,28 +546,33 @@ object Execution {
 
     val states = new ConcurrentHashMap[Task[?], State]()
 
-    // Number of retained reads currently in the `dropped` state (released
-    // before a contended wait, not yet reacquired). The common no-op/no-
-    // contention build never drops anything, so this stays 0 and lets
-    // `reacquireDropped`/`hasDropped` short-circuit instead of scanning every
-    // task's `State` on each task's read-lock fast path — which was O(n) per
-    // task, i.e. O(n^2) over the whole graph (#7132 follow-up).
-    private val droppedCount = new AtomicInteger(0)
+    // The exact set of `State`s whose retained read is currently `dropped`
+    // (released before a contended wait, not yet reacquired). A `State` holds
+    // at most one retained, so set membership tracks the `dropped` flag 1:1.
+    //
+    // This is both the `hasDropped` short-circuit and the work-list for
+    // `reacquireDropped`. The common no-op/no-contention build never drops
+    // anything, so the set stays empty and the per-task read-lock fast path
+    // does no scan at all. Under contention only a handful are dropped, so
+    // `reacquireDropped` iterates O(dropped) entries rather than re-scanning
+    // every task's `State` — which would otherwise be O(n) per contended wait,
+    // i.e. O(n^2) again over a heavily-contended graph (#7132 follow-up).
+    private val droppedStates = ConcurrentHashMap.newKeySet[State]()
 
     /** Whether any retained read is currently dropped and awaiting reacquire. */
-    def hasDropped: Boolean = droppedCount.get() != 0
+    def hasDropped: Boolean = !droppedStates.isEmpty
 
-    // Both helpers must be called while holding `retained`'s owning
-    // `State.synchronized`, so the `dropped` flag and the counter stay in step.
-    private def markDropped(retained: Retained): Unit =
+    // Both helpers must be called while holding `s`'s monitor, so `s.retained`'s
+    // `dropped` flag and the `droppedStates` membership stay in step.
+    private def markDropped(s: State, retained: Retained): Unit =
       if (!retained.dropped) {
         retained.dropped = true
-        droppedCount.incrementAndGet()
+        droppedStates.add(s)
       }
-    private def clearDropped(retained: Retained): Unit =
+    private def clearDropped(s: State, retained: Retained): Unit =
       if (retained.dropped) {
         retained.dropped = false
-        droppedCount.decrementAndGet()
+        droppedStates.remove(s)
       }
     private val transitiveUpstreams: Map[Task[?], Seq[Task[?]]] = {
       def rec(task: Task[?]): Seq[Task[?]] = {
@@ -599,10 +604,10 @@ object Execution {
       val retained = s.retained
       s.retained = null
       if (retained != null) {
-        // Discarding a still-dropped retained must release its counter slot,
-        // else `droppedCount` leaks upward and permanently defeats the
+        // Discarding a still-dropped retained must drop its `droppedStates`
+        // entry, else the stale `State` leaks and permanently defeats the
         // `hasDropped` short-circuit.
-        clearDropped(retained)
+        clearDropped(s, retained)
         if (retained.lease != null) {
           closeQuietly(retained.lease)
           retained.lease = null
@@ -644,7 +649,7 @@ object Execution {
       val s = states.get(task)
       if (s != null) s.synchronized {
         if (s.retained != null) {
-          clearDropped(s.retained)
+          clearDropped(s, s.retained)
           if (s.retained.lease != null) closeQuietly(s.retained.lease)
         }
         s.retained = Retained(
@@ -670,7 +675,7 @@ object Execution {
         ) {
           closeQuietly(retained.lease)
           retained.lease = null
-          markDropped(retained)
+          markDropped(s, retained)
         }
       }
     }
@@ -686,11 +691,14 @@ object Execution {
         // non-Named groups, where this evaluation does not hold a task Write.
         block: Boolean = true
     ): Unit = {
-      // Fast path: nothing was ever dropped (the common no-contention case),
-      // so skip the full O(n) scan of every task's `State`.
-      if (droppedCount.get() == 0) return
+      // Fast path: nothing is dropped (the common no-contention case), so skip
+      // straight out without allocating or scanning.
+      if (droppedStates.isEmpty) return
       import scala.jdk.CollectionConverters.*
-      val dropped = states.values().asScala.toSeq.flatMap { s =>
+      // Iterate only the dropped `State`s, not the whole graph. The snapshot may
+      // be stale (a peer may clear/re-drop concurrently), so re-validate each
+      // entry under its monitor below before acting on it.
+      val dropped = droppedStates.asScala.toSeq.flatMap { s =>
         s.synchronized {
           val retained = s.retained
           Option.when(retained != null && retained.dropped && retained.lease == null)(s -> retained)
@@ -720,7 +728,7 @@ object Execution {
         s.synchronized {
           if ((s.retained eq retained) && retained.dropped && retained.lease == null) {
             retained.lease = lease
-            clearDropped(retained)
+            clearDropped(s, retained)
           } else closeQuietly(lease)
         }
       }

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -307,10 +307,17 @@ trait GroupExecution {
         // wrap them in `executionContext.blocking` so the pool spawns a
         // compensating worker while parked, preventing pool starvation (the
         // lock-holder's downstream tasks can still get a thread and release).
+        //
+        // Only enter `blocking` when there is actually a dropped read to
+        // reacquire. Otherwise every task's uncontended fast path would churn
+        // the pool's core/max size (enter/leaveBlocking), letting the live
+        // thread count balloon far past `--jobs` even on no-op builds. With
+        // nothing dropped, `reacquireDropped` is a no-op anyway.
         def reacquireDroppedReads(): Unit =
-          executionContext.blocking {
-            leaseTracker.reacquireDropped(workspaceLocking, taskWaitReporter)
-          }
+          if (leaseTracker.hasDropped)
+            executionContext.blocking {
+              leaseTracker.reacquireDropped(workspaceLocking, taskWaitReporter)
+            }
 
         // The write-upgrade callback and Named write body run while holding
         // this task's Write lock, so dropped reads must be reacquired only via

--- a/core/exec/test/src/mill/exec/PlanTests.scala
+++ b/core/exec/test/src/mill/exec/PlanTests.scala
@@ -384,6 +384,47 @@ object PlanTests extends TestSuite {
       tracker.drain()
     }
 
+    // `hasDropped` gates the per-task read-lock fast path: it must read false
+    // whenever no read is dropped, so the common no-op build skips the O(n)
+    // `reacquireDropped` scan (and the `executionContext.blocking` pool churn)
+    // entirely. This pins the counter bookkeeping across drop, reacquire, a
+    // redundant reacquire, and drain.
+    test("leaseTrackerHasDroppedTracksDropReacquireAndDrain") {
+      import transitiveLeaseChain.*
+
+      val tracker = new Execution.LeaseTracker(
+        Array(a, b, c),
+        Map(a -> Nil, b -> Seq(a), c -> Seq(b))
+      )
+      val locking = new TestLocking
+      val aPath = Paths.get("/tmp/mill-lock-test/a")
+      val bPath = Paths.get("/tmp/mill-lock-test/b")
+      val aKey = aPath.toAbsolutePath.normalize().toString
+
+      tracker.retain(a, aPath, "a", new TestLease, 0L)
+      tracker.retain(b, bPath, "b", new TestLease, 0L)
+      assert(!tracker.hasDropped)
+
+      // Drop everything sorting after `a` (i.e. `b`): counter flips to true.
+      tracker.releaseHigherThan(aKey)
+      assert(tracker.hasDropped)
+
+      // Clean reacquire (no version change, no contention) clears the drop.
+      tracker.reacquireDropped(locking, LauncherLocking.WaitReporter.Noop)
+      assert(!tracker.hasDropped)
+
+      // With nothing dropped, a redundant reacquire is a no-op fast return.
+      tracker.reacquireDropped(locking, LauncherLocking.WaitReporter.Noop)
+      assert(!tracker.hasDropped)
+
+      // Draining a still-dropped retained must also release its counter slot,
+      // otherwise `hasDropped` would stay stuck true and disable the fast path.
+      tracker.releaseHigherThan(aKey)
+      assert(tracker.hasDropped)
+      tracker.drain()
+      assert(!tracker.hasDropped)
+    }
+
     test("leaseTrackerDoesNotDropActivelyConsumedHigherLocks") {
       import transitiveLeaseChain.*
 

--- a/core/exec/test/src/mill/exec/PlanTests.scala
+++ b/core/exec/test/src/mill/exec/PlanTests.scala
@@ -387,8 +387,10 @@ object PlanTests extends TestSuite {
     // `hasDropped` gates the per-task read-lock fast path: it must read false
     // whenever no read is dropped, so the common no-op build skips the O(n)
     // `reacquireDropped` scan (and the `executionContext.blocking` pool churn)
-    // entirely. This pins the counter bookkeeping across drop, reacquire, a
-    // redundant reacquire, and drain.
+    // entirely. `reacquireDropped`/`hasDropped` are backed by the
+    // `droppedStates` work-list, so this also pins that membership in step with
+    // the `dropped` flag across multi-drop, reacquire, redundant reacquire, and
+    // drain.
     test("leaseTrackerHasDroppedTracksDropReacquireAndDrain") {
       import transitiveLeaseChain.*
 
@@ -399,17 +401,21 @@ object PlanTests extends TestSuite {
       val locking = new TestLocking
       val aPath = Paths.get("/tmp/mill-lock-test/a")
       val bPath = Paths.get("/tmp/mill-lock-test/b")
+      val cPath = Paths.get("/tmp/mill-lock-test/c")
       val aKey = aPath.toAbsolutePath.normalize().toString
 
       tracker.retain(a, aPath, "a", new TestLease, 0L)
       tracker.retain(b, bPath, "b", new TestLease, 0L)
+      tracker.retain(c, cPath, "c", new TestLease, 0L)
       assert(!tracker.hasDropped)
 
-      // Drop everything sorting after `a` (i.e. `b`): counter flips to true.
+      // Drop everything sorting after `a` (both `b` and `c`): the work-list now
+      // holds two entries that `reacquireDropped` must iterate, not the whole
+      // graph.
       tracker.releaseHigherThan(aKey)
       assert(tracker.hasDropped)
 
-      // Clean reacquire (no version change, no contention) clears the drop.
+      // Clean reacquire (no version change, no contention) clears every drop.
       tracker.reacquireDropped(locking, LauncherLocking.WaitReporter.Noop)
       assert(!tracker.hasDropped)
 
@@ -417,8 +423,9 @@ object PlanTests extends TestSuite {
       tracker.reacquireDropped(locking, LauncherLocking.WaitReporter.Noop)
       assert(!tracker.hasDropped)
 
-      // Draining a still-dropped retained must also release its counter slot,
-      // otherwise `hasDropped` would stay stuck true and disable the fast path.
+      // Draining a still-dropped retained must also remove its `droppedStates`
+      // entry, otherwise `hasDropped` would stay stuck true and disable the
+      // fast path.
       tracker.releaseHigherThan(aKey)
       assert(tracker.hasDropped)
       tracker.drain()


### PR DESCRIPTION
Both surface on large **no-op** builds (e.g. `./mill __.compile` on Mill's own
~31k-task graph on a hot daemon) and were found by attaching JFR to a running
daemon while re-running the build. Each is fixed independently below; together
they share one mechanism — a `droppedCount` on `LeaseTracker` that lets the
uncontended fast path skip work entirely.

---

## 1. Per-task O(n²) lease scan (regression since #7136)

### Symptom

No-op builds got dramatically slower — a hot daemon spent **~1 ms of overhead
on every single task**, with no single hot task in the chrome profile. The cost
is spread uniformly across the whole graph, so it scales with graph size.

### Root cause

Every task's *uncontended* read-lock fast path called
`LeaseTracker.reacquireDropped`, which scans the entire `states` map (one entry
per task) under a per-entry lock. That is O(n) per task → **O(n²)** over the
graph. JFR on a hot daemon showed **75.8% of all execution samples** inside
`reacquireDropped` (`ConcurrentHashMap$Traverser.advance` + `Option.when` +
`flatMap`).

### Fix

Track the number of currently-dropped reads in `LeaseTracker` with a
`droppedCount`, maintained at every transition (drop, reacquire, drain,
retain-replace) under the owning `State` lock. `reacquireDropped` now
early-returns when nothing is dropped, so the common no-contention path does no
scan at all.

### Validation (31,196-task no-op build, JFR)

| Metric | Before | After |
| --- | --- | --- |
| `reacquireDropped` share of CPU samples | **75.8%** | **0%** |
| Total daemon execution samples (3 runs) | 55,474 | **2,549 (~22× fewer)** |
| No-op wall time | ~16–30 s | **~6 s** |

After the fix the top profile frame is `ujson.ByteParser` (reading cached
`meta.json`), which is inherent to no-op cached builds — not a regression.

---

## 2. Thread count ballooning past `--jobs` (regression since #7161)

### Symptom

The live thread count **ballooned far past `--jobs`** — ~45 threads for a
`--jobs` bound of 9, even on a run where everything was cached.

### Root cause

The same uncontended fast path was wrapped in `executionContext.blocking { ... }`,
so every task churned the pool's core/max size (`enter`/`leaveBlocking`),
spawning compensating workers even with zero contention.

### Fix

`GroupExecution.reacquireDroppedReads` now only enters `blocking { ... }` when
`leaseTracker.hasDropped`. The uncontended fast path no longer touches the pool
sizing at all; the remaining `blocking { ... }` sites are all
genuinely-contended waits, where compensating threads are the intended
behaviour.

### Validation (31,196-task no-op build, `--jobs=0.5C` = 5)

| Metric | Before | After |
| --- | --- | --- |
| Peak execution-pool threads | up to ~45 | **5 (= the bound)** |

---

## Tests

All existing `PlanTests` lease-tracker cases (drop / reacquire / version-change /
active-consumer / deadlock-ordering) pass unchanged. Adds
`leaseTrackerHasDroppedTracksDropReacquireAndDrain` to pin the `droppedCount`
invariant across drop → reacquire → redundant reacquire → drain.
