### PR TITLE
Fix O(n^2) per-task scan in LeaseTracker.reacquireDropped

### DIFF
--- a/core/exec/src/mill/exec/Execution.scala
+++ b/core/exec/src/mill/exec/Execution.scala
@@ -545,6 +545,25 @@ object Execution {
     }
 
     val states = new ConcurrentHashMap[Task[?], State]()
+
+    // Index of the states with a dropped retained read, so `reacquireDropped`
+    // visits only those instead of scanning the whole graph. A `State` has at
+    // most one retained, so membership mirrors `Retained.dropped` exactly.
+    private val droppedStates = ConcurrentHashMap.newKeySet[State]()
+
+    def hasDropped: Boolean = !droppedStates.isEmpty
+
+    // Flip `Retained.dropped` and the index together; call under `s`'s monitor.
+    private def markDropped(s: State, retained: Retained): Unit =
+      if (!retained.dropped) {
+        retained.dropped = true
+        droppedStates.add(s)
+      }
+    private def clearDropped(s: State, retained: Retained): Unit =
+      if (retained.dropped) {
+        retained.dropped = false
+        droppedStates.remove(s)
+      }
     private val transitiveUpstreams: Map[Task[?], Seq[Task[?]]] = {
       def rec(task: Task[?]): Seq[Task[?]] = {
         val seen = mutable.LinkedHashSet.empty[Task[?]]
@@ -574,9 +593,12 @@ object Execution {
     private def drainLeases(s: State): Unit = s.synchronized {
       val retained = s.retained
       s.retained = null
-      if (retained != null && retained.lease != null) {
-        closeQuietly(retained.lease)
-        retained.lease = null
+      if (retained != null) {
+        clearDropped(s, retained) // drop the index entry before discarding it
+        if (retained.lease != null) {
+          closeQuietly(retained.lease)
+          retained.lease = null
+        }
       }
     }
 
@@ -613,7 +635,10 @@ object Execution {
     ): Unit = {
       val s = states.get(task)
       if (s != null) s.synchronized {
-        if (s.retained != null && s.retained.lease != null) closeQuietly(s.retained.lease)
+        if (s.retained != null) {
+          clearDropped(s, s.retained)
+          if (s.retained.lease != null) closeQuietly(s.retained.lease)
+        }
         s.retained = Retained(
           path = path,
           label = label,
@@ -637,7 +662,7 @@ object Execution {
         ) {
           closeQuietly(retained.lease)
           retained.lease = null
-          retained.dropped = true
+          markDropped(s, retained)
         }
       }
     }
@@ -653,8 +678,10 @@ object Execution {
         // non-Named groups, where this evaluation does not hold a task Write.
         block: Boolean = true
     ): Unit = {
+      if (!hasDropped) return // nothing dropped: skip the scan (the common case)
       import scala.jdk.CollectionConverters.*
-      val dropped = states.values().asScala.toSeq.flatMap { s =>
+      // Snapshot of the index; each entry is re-validated under its monitor below.
+      val dropped = droppedStates.asScala.toSeq.flatMap { s =>
         s.synchronized {
           val retained = s.retained
           Option.when(retained != null && retained.dropped && retained.lease == null)(s -> retained)
@@ -684,7 +711,7 @@ object Execution {
         s.synchronized {
           if ((s.retained eq retained) && retained.dropped && retained.lease == null) {
             retained.lease = lease
-            retained.dropped = false
+            clearDropped(s, retained)
           } else closeQuietly(lease)
         }
       }

--- a/core/exec/test/src/mill/exec/PlanTests.scala
+++ b/core/exec/test/src/mill/exec/PlanTests.scala
@@ -384,6 +384,46 @@ object PlanTests extends TestSuite {
       tracker.drain()
     }
 
+    // The `droppedStates` index must track the `dropped` flag exactly, so
+    // `hasDropped` reads false iff nothing is dropped. Exercises that across
+    // multi-drop, reacquire, a redundant reacquire, and drain.
+    test("leaseTrackerHasDroppedTracksDropReacquireAndDrain") {
+      import transitiveLeaseChain.*
+
+      val tracker = new Execution.LeaseTracker(
+        Array(a, b, c),
+        Map(a -> Nil, b -> Seq(a), c -> Seq(b))
+      )
+      val locking = new TestLocking
+      val aPath = Paths.get("/tmp/mill-lock-test/a")
+      val bPath = Paths.get("/tmp/mill-lock-test/b")
+      val cPath = Paths.get("/tmp/mill-lock-test/c")
+      val aKey = aPath.toAbsolutePath.normalize().toString
+
+      tracker.retain(a, aPath, "a", new TestLease, 0L)
+      tracker.retain(b, bPath, "b", new TestLease, 0L)
+      tracker.retain(c, cPath, "c", new TestLease, 0L)
+      assert(!tracker.hasDropped)
+
+      // Drop everything sorting after `a` (both `b` and `c`).
+      tracker.releaseHigherThan(aKey)
+      assert(tracker.hasDropped)
+
+      // Clean reacquire (no version change, no contention) clears every drop.
+      tracker.reacquireDropped(locking, LauncherLocking.WaitReporter.Noop)
+      assert(!tracker.hasDropped)
+
+      // Redundant reacquire is a no-op.
+      tracker.reacquireDropped(locking, LauncherLocking.WaitReporter.Noop)
+      assert(!tracker.hasDropped)
+
+      // Draining a still-dropped retained must also clear its index entry.
+      tracker.releaseHigherThan(aKey)
+      assert(tracker.hasDropped)
+      tracker.drain()
+      assert(!tracker.hasDropped)
+    }
+
     test("leaseTrackerDoesNotDropActivelyConsumedHigherLocks") {
       import transitiveLeaseChain.*
 


### PR DESCRIPTION
For a no-op (already cached) build of a large codebase, every task's read-lock validation calls `LeaseTracker.reacquireDropped`, which scanned the entire `states` map under a per-entry lock to find any reads dropped during a contended wait. That is O(n) per task and O(n^2) over the graph, adding ~1ms to every task with no single hot spot. JFR on a hot daemon running `./mill __.compile` on Mill's own ~31k-task build showed 75.8% of execution samples inside `reacquireDropped`.

This is a follow-up to the retained-read locking added in https://github.com/com-lihaoyi/mill/pull/7136.

Index the states with a dropped read in a `droppedStates` set (a `State` has at most one retained, so membership mirrors `Retained.dropped`). This fixes both scenarios:

- No contention (the common case): nothing is ever dropped, so `reacquireDropped` returns early on the empty index without scanning or allocating. This is what removes the per-task overhead above.

- Contention (concurrent launchers, e.g. BSP + CLI, where reads are dropped and reacquired): instead of re-scanning all `states` on every validating task, only the dropped entries are visited, so a reacquire is O(dropped) rather than O(n) — keeping the contended path from degrading back to O(n^2) over the graph.

For the same 31k-task no-op build, JFR `reacquireDropped` samples drop from 75.8% to 0% and total execution samples from 55,474 to 2,549 over three runs.