### PR TITLE
Bound execution-pool threads to --jobs on the uncontended fast path

### DIFF
--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -307,10 +307,14 @@ trait GroupExecution {
         // wrap them in `executionContext.blocking` so the pool spawns a
         // compensating worker while parked, preventing pool starvation (the
         // lock-holder's downstream tasks can still get a thread and release).
+        // Guard on `hasDropped`: with nothing dropped the reacquire is a no-op,
+        // and entering `blocking` here on every task's uncontended fast path
+        // would churn the pool size and balloon the thread count past `--jobs`.
         def reacquireDroppedReads(): Unit =
-          executionContext.blocking {
-            leaseTracker.reacquireDropped(workspaceLocking, taskWaitReporter)
-          }
+          if (leaseTracker.hasDropped)
+            executionContext.blocking {
+              leaseTracker.reacquireDropped(workspaceLocking, taskWaitReporter)
+            }
 
         // The write-upgrade callback and Named write body run while holding
         // this task's Write lock, so dropped reads must be reacquired only via


### PR DESCRIPTION
A no-op (already cached) build spawned far more threads than `--jobs`: e.g. ~45 threads for a `--jobs` bound of 9. Each task's read-lock validation wraps its dropped-read reacquire in `executionContext.blocking`, which raises the pool's core/max size so a parked thread cannot starve the pool. That is correct for a real blocking wait, but it ran on every task's uncontended fast path, churning the pool size and letting the live thread count balloon past the bound.

This is a follow-up to the `blocking` wrapping added in https://github.com/com-lihaoyi/mill/pull/7161.

Track whether any read is currently dropped with a `LeaseTracker` `droppedCount`, exposed as `hasDropped`, and only enter `blocking` when it is set, i.e. when a dropped read actually has to be reacquired and may park. With nothing dropped the fast path no longer touches the pool size, so a no-op build of Mill's own ~31k-task graph stays at the `--jobs` bound (5 threads at `--jobs=0.5C` on a 10-core machine, down from ~45).

