### PR TITLE
Cleanup for core/ folder

### DIFF
--- a/core/api/java11/src/mill/api/PathRef.scala
+++ b/core/api/java11/src/mill/api/PathRef.scala
@@ -177,11 +177,18 @@ object PathRef {
   }
 
   private[mill] def withSerializedPaths[T](block: => T): (T, Seq[PathRef]) = {
+    // Save/restore the previous value rather than unconditionally nulling on
+    // exit. A nested `withSerializedPaths` (same thread) must not clobber the
+    // outer scope's accumulated list: nulling it in the inner `finally` would
+    // leave the outer capture `null`, silently dropping every path the outer
+    // scope serializes after the nested call returns. In the common
+    // non-nested case `prev` is `null`, so behavior is unchanged.
+    val prev = serializedPaths.value
     serializedPaths.value = Nil
     try {
       val res = block
       (res, serializedPaths.value)
-    } finally serializedPaths.value = null
+    } finally serializedPaths.value = prev
   }
   private def storeSerializedPaths(pr: PathRef) = {
     if (serializedPaths.value != null) {

--- a/core/eval/src/mill/eval/SelectiveExecutionImpl.scala
+++ b/core/eval/src/mill/eval/SelectiveExecutionImpl.scala
@@ -16,24 +16,41 @@ class SelectiveExecutionImpl(evaluator: Evaluator)
       transitiveNamed: Seq[Task.Named[?]],
       codeSignatures: Map[String, Int]
   ): Map[String, Int] = {
-
     val (classToTransitiveClasses, allTransitiveClassMethods) =
       CodeSigUtils.precomputeMethodNamesPerClass(transitiveNamed)
+    computeHashCodeSignatures0(
+      transitiveNamed,
+      codeSignatures,
+      classToTransitiveClasses,
+      allTransitiveClassMethods
+    )
+  }
 
+  private def computeHashCodeSignatures0(
+      transitiveNamed: Seq[Task.Named[?]],
+      codeSignatures: Map[String, Int],
+      classToTransitiveClasses: Map[Class[?], IndexedSeq[Class[?]]],
+      allTransitiveClassMethods: Map[Class[?], Map[String, java.lang.reflect.Method]]
+  ): Map[String, Int] = {
     lazy val constructorHashSignatures = CodeSigUtils
       .constructorHashSignatures(codeSignatures)
 
     transitiveNamed
       .map { namedTask =>
-        namedTask.ctx.segments.render -> CodeSigUtils
-          .codeSigForTask(
+        // Combine the per-task code signatures with the same order-independent combiner the
+        // execution engine uses (`MurmurHash3.unorderedHash`, GroupExecution.scala), NOT a plain
+        // `.sum`. Addition is a weak combiner that two compensating signature deltas can cancel
+        // (e.g. one constructor hash +k while an accessor -k), masking a real code change so the
+        // task is wrongly skipped.
+        namedTask.ctx.segments.render -> scala.util.hashing.MurmurHash3.unorderedHash(
+          CodeSigUtils.codeSigForTask(
             namedTask = namedTask,
             classToTransitiveClasses = classToTransitiveClasses,
             allTransitiveClassMethods = allTransitiveClassMethods,
             codeSignatures = codeSignatures,
             constructorHashSignatures = constructorHashSignatures
           )
-          .sum
+        )
       }
       .toMap
   }
@@ -85,9 +102,24 @@ class SelectiveExecutionImpl(evaluator: Evaluator)
         }
 
         val changedInputNames = diffMap(oldHashes.inputHashes, newHashes.inputHashes)
+        // Precompute the per-class method/hierarchy tables ONCE — they are a pure function of
+        // `transitiveNamed`, independent of the code signatures — and reuse them for both the old
+        // and new signature sets, instead of redoing the reflection inside each call.
+        val (classToTransitiveClasses, allTransitiveClassMethods) =
+          CodeSigUtils.precomputeMethodNamesPerClass(transitiveNamed)
         val changedCodeNames = diffMap(
-          computeHashCodeSignatures(transitiveNamed, oldHashes.codeSignatures),
-          computeHashCodeSignatures(transitiveNamed, newHashes.codeSignatures)
+          computeHashCodeSignatures0(
+            transitiveNamed,
+            oldHashes.codeSignatures,
+            classToTransitiveClasses,
+            allTransitiveClassMethods
+          ),
+          computeHashCodeSignatures0(
+            transitiveNamed,
+            newHashes.codeSignatures,
+            classToTransitiveClasses,
+            allTransitiveClassMethods
+          )
         )
         val changedBuildOverrides = diffMap(
           oldHashes.buildOverrideSignatures,
@@ -296,8 +328,29 @@ object SelectiveExecutionImpl {
         }
         .toMap
 
+      // Hash the serialized-JSON form of each input value (mirroring
+      // GroupExecution.getValueHash), NOT the in-memory `value.##`: the latter is
+      // unstable across JVMs/runs (Map iteration order, identity hashCodes), so it
+      // would spuriously flag unchanged inputs as changed and diverge from the disk
+      // cache. Fall back to the in-memory hash if serialization throws.
+      def inputValueHash(task: Task.Named[?], v: Val): Int =
+        task.writerOpt match {
+          case Some(w) =>
+            try upickle.writeJs(v.value)(using w.asInstanceOf[upickle.Writer[Any]]).hashCode()
+            catch { case scala.util.control.NonFatal(_) => v.## }
+          case None => v.##
+        }
+
       val inputHashes = results.map {
-        case (task, execResultVal) => (task.ctx.segments.render, execResultVal.get.value.##)
+        case (task, Result.Success(v)) => (task.ctx.segments.render, inputValueHash(task, v))
+        case (task, f: Result.Failure) =>
+          // Do NOT `.get` a failing input: that throws (sys.error) and aborts
+          // selective metadata computation, which runs unguarded from
+          // `execute(selectiveExecution = true)` / `selective.prepare` / `-w`.
+          // Hash a stable representation of the failure so a consistently-failing
+          // input stays stable and any success<->failure transition (or changed
+          // error) still invalidates its downstream cone.
+          (task.ctx.segments.render, ("__mill_input_failure__", f.errorOpt).##)
       }
       SelectiveExecution.Metadata.Computed(
         new SelectiveExecution.Metadata(
@@ -310,7 +363,13 @@ object SelectiveExecutionImpl {
           millJvmVersion = sys.props("java.version"),
           classLoaderSigHash = evaluator.classLoaderSigHash
         ),
-        results.map { case (k, v) => (k, ExecResult.Success(v.get)) }
+        results.map { case (k, v) =>
+          val execRes: ExecResult[Val] = v match {
+            case Result.Success(value) => ExecResult.Success(value)
+            case f: Result.Failure => ExecResult.Failure(f.error, Some(f))
+          }
+          (k, execRes)
+        }
       )
     }
   }

--- a/core/exec/src/mill/exec/Execution.scala
+++ b/core/exec/src/mill/exec/Execution.scala
@@ -5,7 +5,7 @@ import mill.api.daemon.internal.{LauncherLocking, LauncherOutFiles}
 import mill.api.*
 import mill.internal.{CodeSigUtils, JsonArrayLogger, PrefixLogger, PromptWaitReporter}
 
-import java.util.concurrent.{ConcurrentHashMap, ThreadPoolExecutor}
+import java.util.concurrent.{ConcurrentHashMap, ConcurrentSkipListMap, ThreadPoolExecutor}
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 import scala.collection.mutable
 import scala.concurrent.*
@@ -551,6 +551,14 @@ object Execution {
     // most one retained, so membership mirrors `Retained.dropped` exactly.
     private val droppedStates = ConcurrentHashMap.newKeySet[State]()
 
+    // Ordered index (by retained read key) of the states that currently hold a *live* retained
+    // read lease, so `releaseHigherThan` visits only the states with a key strictly greater than
+    // its argument via `tailMap` instead of scanning the whole graph. This is the dual of
+    // `droppedStates`: membership mirrors `retained != null && retained.lease != null`. Each
+    // retained read key is the task's normalized `dest` path, unique per state. Maintained under
+    // each state's monitor at every lease transition (retain/drop/reacquire/drain).
+    private val liveRetained = new ConcurrentSkipListMap[String, State]()
+
     def hasDropped: Boolean = !droppedStates.isEmpty
 
     // Flip `Retained.dropped` and the index together; call under `s`'s monitor.
@@ -558,6 +566,9 @@ object Execution {
       if (!retained.dropped) {
         retained.dropped = true
         droppedStates.add(s)
+        // The lease was just dropped (set null); it is no longer "live". Only called from
+        // `releaseHigherThan`, the single place a retained lease transitions live -> dropped.
+        liveRetained.remove(retained.key, s)
       }
     private def clearDropped(s: State, retained: Retained): Unit =
       if (retained.dropped) {
@@ -595,6 +606,7 @@ object Execution {
       s.retained = null
       if (retained != null) {
         clearDropped(s, retained) // drop the index entry before discarding it
+        liveRetained.remove(retained.key, s) // and the live-lease index entry
         if (retained.lease != null) {
           closeQuietly(retained.lease)
           retained.lease = null
@@ -646,13 +658,22 @@ object Execution {
           lease = lease,
           observedVersion = observedVersion
         )
+        // Now holding a live lease -> index it for `releaseHigherThan` (key is unique per state,
+        // so this also overwrites any prior entry for this state from a replaced retained).
+        liveRetained.put(s.retained.key, s)
       }
       else closeQuietly(lease)
     }
 
     def releaseHigherThan(key: String): Unit = {
       import scala.jdk.CollectionConverters.*
-      for (s <- states.values().asScala) s.synchronized {
+      // Visit only states whose retained read key is strictly greater than `key`, via the ordered
+      // `liveRetained` index, instead of scanning every state (O(dropped) rather than O(V) per
+      // contended task-lock acquisition; the dual of `reacquireDropped`'s `droppedStates` scan).
+      // Snapshot the tail, then re-validate each state under its monitor — the index may be
+      // momentarily stale (a peer could drop/drain between snapshot and monitor acquisition).
+      val candidates = liveRetained.tailMap(key, false).values().asScala.toArray
+      for (s <- candidates) s.synchronized {
         val retained = s.retained
         if (
           retained != null &&
@@ -712,6 +733,7 @@ object Execution {
           if ((s.retained eq retained) && retained.dropped && retained.lease == null) {
             retained.lease = lease
             clearDropped(s, retained)
+            liveRetained.put(retained.key, s) // live again -> re-index for releaseHigherThan
           } else closeQuietly(lease)
         }
       }

--- a/core/exec/src/mill/exec/ExecutionContexts.scala
+++ b/core/exec/src/mill/exec/ExecutionContexts.scala
@@ -75,15 +75,24 @@ object ExecutionContexts {
       val submitterStreams = new mill.api.SystemStreams(Console.out, Console.err, System.in)
       val submitterModuleWatched = mill.api.BuildCtx.watchedValues0.value
       val submitterEvalWatched = mill.api.BuildCtx.evalWatchedValues0.value
+      // `PathRef.validatedPaths` is a per-run thread-local seeded on the
+      // orchestrator thread in `Execution.executeTasks`. Like the other
+      // submitter-inherited values, it must be re-established on the pool
+      // worker, otherwise cached PathRefs deserialized on a worker thread
+      // consult a stale `ValidatedPaths` (Revalidate.Once degrades to
+      // once-per-daemon instead of once-per-run under `--jobs > 1`).
+      val submitterValidatedPaths = mill.api.PathRef.validatedPaths.value
       executor.execute(new PriorityRunnable(
         0,
         () =>
-          os.checker.withValue(submitterChecker) {
-            os.dynamicPwdFunction.withValue(() => submitterPwd()) {
-              mill.api.SystemStreamsUtils.withStreams(submitterStreams) {
-                mill.api.BuildCtx.watchedValues0.withValue(submitterModuleWatched) {
-                  mill.api.BuildCtx.evalWatchedValues0.withValue(submitterEvalWatched) {
-                    runnable.run()
+          mill.api.PathRef.validatedPaths.withValue(submitterValidatedPaths) {
+            os.checker.withValue(submitterChecker) {
+              os.dynamicPwdFunction.withValue(() => submitterPwd()) {
+                mill.api.SystemStreamsUtils.withStreams(submitterStreams) {
+                  mill.api.BuildCtx.watchedValues0.withValue(submitterModuleWatched) {
+                    mill.api.BuildCtx.evalWatchedValues0.withValue(submitterEvalWatched) {
+                      runnable.run()
+                    }
                   }
                 }
               }
@@ -122,17 +131,22 @@ object ExecutionContexts {
       val submitterChecker = os.checker.value
       val submitterModuleWatched = mill.api.BuildCtx.watchedValues0.value
       val submitterEvalWatched = mill.api.BuildCtx.evalWatchedValues0.value
+      // See `execute`: re-establish the per-run `PathRef.validatedPaths` on the
+      // pool worker so forked async tasks revalidate against this run's instance.
+      val submitterValidatedPaths = mill.api.PathRef.validatedPaths.value
       val promise = concurrent.Promise[T]
       val runnable = new PriorityRunnable(
         priority = priority,
         run0 = () => {
           val result = NonFatal.Try(logger.withPromptLine {
-            os.checker.withValue(submitterChecker) {
-              os.dynamicPwdFunction.withValue(() => makeDest()) {
-                mill.api.SystemStreamsUtils.withStreams(logger.streams) {
-                  mill.api.BuildCtx.watchedValues0.withValue(submitterModuleWatched) {
-                    mill.api.BuildCtx.evalWatchedValues0.withValue(submitterEvalWatched) {
-                      t(logger)
+            mill.api.PathRef.validatedPaths.withValue(submitterValidatedPaths) {
+              os.checker.withValue(submitterChecker) {
+                os.dynamicPwdFunction.withValue(() => makeDest()) {
+                  mill.api.SystemStreamsUtils.withStreams(logger.streams) {
+                    mill.api.BuildCtx.watchedValues0.withValue(submitterModuleWatched) {
+                      mill.api.BuildCtx.evalWatchedValues0.withValue(submitterEvalWatched) {
+                        t(logger)
+                      }
                     }
                   }
                 }

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -516,7 +516,14 @@ trait GroupExecution {
                 // otherwise its reacquired Read would validate against the
                 // unchanged version and silently consume a deleted/partial
                 // `dest/`.
-                val version = workspaceLocking.markTaskWritten(taskLockPath)
+                // Input/Source tasks use Noop task-locks and don't write a shared `dest/` that
+                // peer launchers cache-validate against, so they must not churn the global task
+                // version counter: bumping it spuriously invalidates downstream retained reads
+                // that were dropped, forcing needless from-scratch retries. Read the current
+                // (un-bumped) version for them instead.
+                val version =
+                  if (labelled.isInputTask) workspaceLocking.taskVersion(taskLockPath)
+                  else workspaceLocking.markTaskWritten(taskLockPath)
                 if (!labelled.persistent && os.exists(paths.dest)) {
                   logger.debug(s"Deleting task dest dir ${paths.dest.relativeTo(workspace)}")
                   os.remove.all(paths.dest)
@@ -1042,11 +1049,10 @@ trait GroupExecution {
           // Recompute reverse-deps under lock: a peer-added dependent
           // would otherwise be missed and end up pointing at a closed
           // upstream.
-          val (currentReverseDeps, currentTopoIndex) = workerCache.synchronized {
+          val (currentReverseDeps, currentWorkerDeps) = workerCache.synchronized {
             val cacheSnapshot = workerCache.toMap
-            val deps = GroupExecution.workerDependencies(cacheSnapshot)
-            val topoIndex = deps.iterator.map(_._1).zipWithIndex.toMap
-            (SpanningForest.reverseEdges(deps), topoIndex)
+            val workerDeps = GroupExecution.workerDependencies(cacheSnapshot)
+            (SpanningForest.reverseEdges(workerDeps), workerDeps)
           }
           val allToClose =
             SpanningForest.breadthFirst(Seq(labelled: TaskApi[?]))(n =>
@@ -1055,7 +1061,7 @@ trait GroupExecution {
           GroupExecution.closeWorkersInReverseTopologicalOrder(
             allToClose,
             workerCache,
-            currentTopoIndex,
+            currentWorkerDeps,
             closeable =>
               try GroupExecution.wrap(
                   workspace,
@@ -1283,10 +1289,30 @@ object GroupExecution {
   def closeWorkersInReverseTopologicalOrder(
       workersToClose: Iterable[TaskApi[?]],
       workerCache: mutable.Map[String, (Int, Val, TaskApi[?])],
-      topoIndex: Map[TaskApi[?], Int],
+      deps: Seq[(TaskApi[?], Seq[TaskApi[?]])],
       closeAction: AutoCloseable => Unit
   ): Unit = {
-    for (worker <- workersToClose.toSeq.sortBy(w => -topoIndex(w))) {
+    // Derive a real topological ordering from the worker dependency graph (edge: worker -> its
+    // direct worker inputs, as produced by `workerDependencies`) and close in REVERSE
+    // topological order, so each worker is closed before the upstream workers it may still use
+    // during its own `close()`. The previous implementation ordered by the caller-supplied
+    // `topoIndex`, which was built from `workerCache`'s HashMap iteration order rather than the
+    // dependency graph, and so closed workers in an arbitrary (non-reverse-topological) order.
+    val edges: Map[TaskApi[?], Seq[TaskApi[?]]] = deps.toMap
+    val order = mutable.LinkedHashMap.empty[TaskApi[?], Int]
+    val onStack = mutable.HashSet.empty[TaskApi[?]]
+    def visit(w: TaskApi[?]): Unit =
+      // `onStack.add` returns false on a back-edge, breaking any (unexpected) cycle defensively.
+      if (!order.contains(w) && onStack.add(w)) {
+        for (dep <- edges.getOrElse(w, Nil)) visit(dep)
+        // Post-order: a dependency is indexed before its dependents, so dependents get the
+        // higher indices and are closed first below.
+        order(w) = order.size
+        onStack.remove(w)
+      }
+    for ((w, _) <- deps) visit(w)
+
+    for (worker <- workersToClose.toSeq.sortBy(w => -order.getOrElse(w, -1))) {
       val name = worker.workerNameApi.get
       workerCache.synchronized(workerCache.remove(name)).foreach {
         case (_, Val(closeable: AutoCloseable), _) => closeAction(closeable)

--- a/core/exec/src/mill/exec/PlanImpl.scala
+++ b/core/exec/src/mill/exec/PlanImpl.scala
@@ -86,16 +86,23 @@ object PlanImpl {
 
         val transitiveTasks = collection.mutable.Map[Task[?], Int]()
 
-        def rec(t: Task[?]): Unit = {
+        // Iterative DFS (explicit stack) rather than recursion, so that a deep
+        // linear task chain does not overflow the stack here before the
+        // deliberately-iterative `Tarjans` is ever reached. Children are pushed
+        // in reverse so they are popped in their original `effectiveInputs`
+        // order, preserving the previous recursive traversal. The result is
+        // sorted by topological index afterwards, so this ordering only needs
+        // to remain consistent with the prior `rec` behavior.
+        val stack = collection.mutable.Stack[Task[?]](task)
+        while (stack.nonEmpty) {
+          val t = stack.pop()
           if (transitiveTasks.contains(t)) () // do nothing
           else if (cutPoint(t) && t != task) () // do nothing
           else {
             transitiveTasks.put(t, topoSortedIndices(t))
-            effectiveInputs(t).foreach(rec)
+            stack.pushAll(effectiveInputs(t).reverse)
           }
         }
-
-        rec(task)
         val out = transitiveTasks.toArray
         out.sortInPlaceBy(_._2)
         output.addAll(t, out.map(_._1))
@@ -129,15 +136,21 @@ object PlanImpl {
    */
   def transitiveNodes[T](sourceNodes: Seq[T])(inputsFor: T => Seq[T]): IndexedSeq[T] = {
     val transitiveNodes = collection.mutable.LinkedHashSet[T]()
-    def rec(t: T): Unit = {
-      if (transitiveNodes.contains(t)) {} // do nothing
-      else {
-        transitiveNodes.add(t)
-        inputsFor(t).foreach(rec)
+    // Iterative DFS (explicit stack) rather than recursion, so that a deep
+    // linear node chain does not overflow the stack here before the
+    // deliberately-iterative `Tarjans` is ever reached. The previous recursion
+    // produced a first-seen pre-order traversal into a `LinkedHashSet`, which
+    // downstream code relies on; pushing children in reverse and recording each
+    // node the first time it is popped reproduces that ordering exactly.
+    val stack = collection.mutable.Stack[T]()
+    stack.pushAll(sourceNodes.reverse)
+    while (stack.nonEmpty) {
+      val t = stack.pop()
+      if (transitiveNodes.add(t)) {
+        stack.pushAll(inputsFor(t).reverse)
       }
     }
 
-    sourceNodes.foreach(rec)
     transitiveNodes.toIndexedSeq
   }
 

--- a/core/exec/test/src/mill/exec/PlanImplDeepChainTests.scala
+++ b/core/exec/test/src/mill/exec/PlanImplDeepChainTests.scala
@@ -1,0 +1,138 @@
+package mill.exec
+
+import mill.api.Task
+import mill.api.Result
+import mill.api.TestGraphs
+import utest.*
+
+/**
+ * Regression tests for the conversion of [[PlanImpl.transitiveNodes]] and
+ * [[PlanImpl.groupAroundImportantTasks]] from recursion to iterative
+ * worklist/stack traversal.
+ *
+ * `Tarjans` was deliberately made iterative to survive deep (100k+) linear
+ * graphs, but `transitiveNodes`/`groupAroundImportantTasks` ran a recursive
+ * pre-pass whose depth equalled the longest input chain, overflowing the stack
+ * one frame earlier. These tests assert that:
+ *
+ *  - a 100000-deep linear `Task.Anon` chain no longer overflows, and
+ *  - the traversal/result ORDER on small graphs is exactly what the previous
+ *    recursive implementation produced (downstream determinism depends on it).
+ */
+object PlanImplDeepChainTests extends TestSuite {
+
+  /** A no-op `Task.Anon` with the given explicit inputs; its body is never run. */
+  private def anon(inputs: Seq[Task[?]]): Task.Anon[Int] =
+    new Task.Anon[Int](
+      inputs,
+      (_, _) => Result.Success(0),
+      sourcecode.Enclosing("PlanImplDeepChainTests")
+    )
+
+  /** Builds a linear chain `leaf <- ... <- tip` of `depth` anonymous tasks. */
+  private def linearChain(depth: Int): Task[?] = {
+    var current: Task[?] = anon(Nil)
+    var i = 1
+    while (i < depth) {
+      current = anon(Seq(current))
+      i += 1
+    }
+    current
+  }
+
+  val tests = Tests {
+
+    val deep = 100000
+
+    // Before the fix these overflowed the stack inside the recursive `rec`
+    // helpers (depth == chain length), well before the iterative `Tarjans`.
+    test("transitiveTasksDeepChainNoStackOverflow") {
+      val tip = linearChain(deep)
+      val transitive = PlanImpl.transitiveTasks(Seq(tip))
+      assert(transitive.length == deep)
+      // First-seen pre-order: the tip is visited first.
+      assert(transitive.head == tip)
+    }
+
+    test("transitiveNodesDeepChainNoStackOverflow") {
+      // Drive `transitiveNodes` directly over an integer chain so the traversal,
+      // not `Task` construction, is what is exercised at depth.
+      val n = deep
+      val children: Int => Seq[Int] = i => if (i < n - 1) Seq(i + 1) else Nil
+      val nodes = PlanImpl.transitiveNodes(Seq(0))(children)
+      assert(nodes.length == n)
+      assert(nodes.head == 0)
+      assert(nodes.last == n - 1)
+    }
+
+    test("planDeepChainNoStackOverflow") {
+      val tip = linearChain(deep)
+      // `plan` runs transitiveTasks -> topoSorted(Tarjans) -> groupAroundImportantTasks.
+      // The deep recursion previously blew up in the first/last of these before
+      // Tarjans (already iterative) was reached.
+      val plan = PlanImpl.plan(Seq(tip))
+      // Every task in a pure-anonymous chain becomes its own group terminal only
+      // for the goal; non-goal anon tasks are not cut points, so there is a
+      // single group keyed by the goal containing the whole chain.
+      val allTasks = plan.sortedGroups.values().flatten.toSeq
+      assert(allTasks.length == deep)
+    }
+
+    // Order-preservation: `transitiveNodes` must still yield first-seen DFS
+    // pre-order. These are the exact orders the previous recursive code emitted.
+    test("transitiveNodesOrderingPreserved") {
+
+      // Hand-built small graph with shared sub-nodes, exercising the
+      // "already-seen child is skipped" path:
+      //
+      //        a
+      //       / \
+      //      b   c
+      //     / \ /
+      //    d   e
+      //
+      // Recursive pre-order from `a`, inputs walked left-to-right:
+      //   a, b, d, e, c   (c's child `e` already seen -> skipped)
+      val children = Map(
+        'a' -> Seq('b', 'c'),
+        'b' -> Seq('d', 'e'),
+        'c' -> Seq('e'),
+        'd' -> Seq.empty[Char],
+        'e' -> Seq.empty[Char]
+      )
+      val order = PlanImpl.transitiveNodes(Seq('a'))(children)
+      assert(order == IndexedSeq('a', 'b', 'd', 'e', 'c'))
+
+      // Multiple source nodes: each is fully DFS'd in turn, left-to-right,
+      // with cross-source duplicates skipped on first sight.
+      //   sources [a, c] -> a, b, d, e, c
+      val multi = PlanImpl.transitiveNodes(Seq('a', 'c'))(children)
+      assert(multi == IndexedSeq('a', 'b', 'd', 'e', 'c'))
+    }
+
+    // The same ordering guarantee, but through the real `Task` graphs used by
+    // `PlanTests`, so we are pinned to the established `transitiveTasks` output.
+    test("transitiveTasksOrderingPreservedOnTestGraphs") {
+      import TestGraphs.*
+
+      // diamond.down: down, left, up, right  (right's child `up` already seen)
+      assert(
+        PlanImpl.transitiveTasks(Seq(diamond.down)) ==
+          IndexedSeq(diamond.down, diamond.left, diamond.up, diamond.right)
+      )
+
+      // anonDiamond.down with anonymous left/right inputs, same shape.
+      val ad = anonDiamond.down
+      assert(
+        PlanImpl.transitiveTasks(Seq(ad)) ==
+          IndexedSeq(ad, ad.inputs(0), anonDiamond.up, ad.inputs(1))
+      )
+
+      // anonTriple: down, anon, up
+      assert(
+        PlanImpl.transitiveTasks(Seq(anonTriple.down)) ==
+          IndexedSeq(anonTriple.down, anonTriple.down.inputs(0), anonTriple.up)
+      )
+    }
+  }
+}

--- a/core/internal/src/mill/internal/LauncherOutFilesImpl.scala
+++ b/core/internal/src/mill/internal/LauncherOutFilesImpl.scala
@@ -47,12 +47,12 @@ private[mill] class LauncherOutFilesImpl(
 
   override def close(): Unit =
     if (closed.compareAndSet(false, true)) {
-      LauncherOutFilesRecordStore.remove(out, runId)
+      LauncherOutFilesUtils.remove(out, runId)
       cleanup(out, outFilesState)
     }
 
   private def writeLauncherRunFile(): Unit =
-    LauncherOutFilesRecordStore.write(out, runId, launcherPid, activeCommandMessage)
+    LauncherOutFilesUtils.write(out, runId, launcherPid, activeCommandMessage)
 
   private def initializeRunArtifacts(): Unit = {
     os.write.over(os.Path(consoleTail), "", createFolders = true)
@@ -83,7 +83,7 @@ private[mill] object LauncherOutFilesImpl {
       outFilesState: LauncherOutFilesState
   ): Unit = {
     try {
-      val active = LauncherOutFilesRecordStore.sweepActive(out).iterator.map(_.runId).toSet
+      val active = LauncherOutFilesUtils.sweepActive(out).iterator.map(_.runId).toSet
       val runRootDir = out / LauncherOutFilesState.runRootDirName
       if (os.exists(runRootDir)) {
         val runDirs = os.list(runRootDir).filter(os.isDir(_))

--- a/core/internal/src/mill/internal/LauncherOutFilesUtils.scala
+++ b/core/internal/src/mill/internal/LauncherOutFilesUtils.scala
@@ -4,7 +4,7 @@ import mill.constants.DaemonFiles
 
 import scala.jdk.OptionConverters.RichOptional
 
-private[mill] object LauncherOutFilesRecordStore {
+private[mill] object LauncherOutFilesUtils {
   case class Record(
       runId: String,
       pid: Long,
@@ -28,8 +28,24 @@ private[mill] object LauncherOutFilesRecordStore {
       s"""{"pid":$pid,"command":$commandJson,"startMillis":$startMillisJson,"createdMillis":$createdMillis}"""
     val file = path(out, runId)
     try mill.api.BuildCtx.withFilesystemCheckerDisabled {
-        os.makeDir.all(file / os.up)
-        os.write.over(file, json)
+        val dir = file / os.up
+        os.makeDir.all(dir)
+        // Publish the record atomically so concurrent scanners never observe a
+        // truncated or partially-written file: write to a temp file in the same
+        // directory, then atomically rename it over the target.
+        val tmp = dir / s".${file.last}.tmp-${System.nanoTime()}"
+        try {
+          os.write.over(tmp, json)
+          java.nio.file.Files.move(
+            tmp.toNIO,
+            file.toNIO,
+            java.nio.file.StandardCopyOption.REPLACE_EXISTING,
+            java.nio.file.StandardCopyOption.ATOMIC_MOVE
+          )
+        } finally {
+          try os.remove(tmp, checkExists = false)
+          catch { case _: Throwable => () }
+        }
       }
     catch { case _: Throwable => () }
   }

--- a/core/internal/src/mill/internal/SpanningForest.scala
+++ b/core/internal/src/mill/internal/SpanningForest.scala
@@ -63,10 +63,15 @@ object SpanningForest {
   ): Node = {
     // Prepare a mutable tree structure, pre-populated with the root nodes,
     // as well as a `nodeMapping` to let us easily take any node index and
-    // directly look up the node in the tree
+    // directly look up the node in the tree. We build the `LinkedHashMap`
+    // directly from the ordered `rootNodeIndices` (rather than laundering them
+    // through an unordered `mutable.Map`) so the emitted top-level child order
+    // follows the sorted root order deterministically, and reuse the same
+    // `Node` instances in `nodeMapping` for lookups.
     val rootNodeIndices = rootsOrdered.filter(importantVertices.contains)
-    val nodeMapping = rootNodeIndices.map((_, Node())).to(mutable.Map)
-    val spanningForest = Node(mutable.LinkedHashMap.from(nodeMapping))
+    val rootPairs = rootNodeIndices.map(i => i -> Node())
+    val spanningForest = Node(mutable.LinkedHashMap.from(rootPairs))
+    val nodeMapping = mutable.Map.from(rootPairs)
 
     // Do a breadth first search from the root nodes across the graph edges
     // to build up the spanning forest

--- a/core/internal/test/src/mill/internal/LauncherOutFilesImplTests.scala
+++ b/core/internal/test/src/mill/internal/LauncherOutFilesImplTests.scala
@@ -13,7 +13,7 @@ object LauncherOutFilesImplTests extends TestSuite {
 
         for (i <- 0 until 10) {
           val runId = s"run-${i}_2026-05-26_09-00-00_pid-$pid"
-          LauncherOutFilesRecordStore.write(out, runId, pid, s"active-$i")
+          LauncherOutFilesUtils.write(out, runId, pid, s"active-$i")
           os.makeDir.all(out / LauncherOutFilesState.runRootDirName / runId)
         }
 
@@ -79,10 +79,10 @@ object LauncherOutFilesImplTests extends TestSuite {
       val out = os.temp.dir(prefix = "mill-launcher-records")
       try {
         val runId = "run-0_2026-05-26_09-00-00_pid-123"
-        val record = LauncherOutFilesRecordStore.path(out, runId)
+        val record = LauncherOutFilesUtils.path(out, runId)
         os.write.over(record, "{", createFolders = true)
 
-        val active = LauncherOutFilesRecordStore.sweepActive(out)
+        val active = LauncherOutFilesUtils.sweepActive(out)
 
         assert(active.exists(_.runId == runId))
         assert(os.exists(record))
@@ -95,12 +95,12 @@ object LauncherOutFilesImplTests extends TestSuite {
         val pid = ProcessHandle.current().pid()
         val older = "run-99_2026-05-26_09-00-01_pid-123"
         val newer = "run-0_2026-05-26_09-00-00_pid-123"
-        LauncherOutFilesRecordStore.write(out, older, pid, "older")
-        LauncherOutFilesRecordStore.write(out, newer, pid, "newer")
+        LauncherOutFilesUtils.write(out, older, pid, "older")
+        LauncherOutFilesUtils.write(out, newer, pid, "newer")
         overwriteCreatedMillis(out, older, createdMillis = 1000L)
         overwriteCreatedMillis(out, newer, createdMillis = 2000L)
 
-        assert(LauncherOutFilesRecordStore.mostRecentActive(out).map(_.runId) == Some(newer))
+        assert(LauncherOutFilesUtils.mostRecentActive(out).map(_.runId) == Some(newer))
       } finally os.remove.all(out)
     }
 
@@ -112,7 +112,7 @@ object LauncherOutFilesImplTests extends TestSuite {
   }
 
   private def overwriteCreatedMillis(out: os.Path, runId: String, createdMillis: Long): Unit = {
-    val recordPath = LauncherOutFilesRecordStore.path(out, runId)
+    val recordPath = LauncherOutFilesUtils.path(out, runId)
     val json = ujson.read(os.read(recordPath)).obj
     json("createdMillis") = ujson.Num(createdMillis)
     os.write.over(recordPath, ujson.write(json))

--- a/core/internal/test/src/mill/internal/LauncherOutFilesUtilsTests.scala
+++ b/core/internal/test/src/mill/internal/LauncherOutFilesUtilsTests.scala
@@ -1,0 +1,122 @@
+package mill.internal
+
+import utest.*
+
+import java.nio.file.Files
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
+
+/**
+ * Regression tests for `LauncherOutFilesUtils.write` publishing records
+ * atomically. The previous implementation used `os.write.over` (truncate then
+ * write), so a concurrent scanner reading `ujson.read(os.read(file))` could
+ * observe an empty or partially-written record. The write must instead be
+ * published via an atomic rename so readers always see either the complete old
+ * or the complete new content.
+ */
+object LauncherOutFilesUtilsTests extends TestSuite {
+
+  // Large enough that an in-place truncate-then-write leaves an observable
+  // window where the file is empty or contains only a prefix of the JSON.
+  private val bigCommand: String = "x" * (4 * 1024 * 1024)
+
+  val tests: Tests = Tests {
+
+    test("concurrentReaderNeverSeesTornRecord") {
+      val out = os.temp.dir(prefix = "mill-record-atomic")
+      try {
+        val pid = ProcessHandle.current().pid()
+        val runId = "run-0_2026-05-26_09-00-00_pid-123"
+        val file = LauncherOutFilesUtils.path(out, runId)
+
+        // Seed an initial complete record so the reader always has a file to read.
+        LauncherOutFilesUtils.write(out, runId, pid, bigCommand)
+
+        val stop = new AtomicBoolean(false)
+        val failure = new AtomicReference[String](null)
+
+        val writer = new Thread(() => {
+          while (!stop.get() && failure.get() == null) {
+            LauncherOutFilesUtils.write(out, runId, pid, bigCommand)
+          }
+        })
+
+        val reader = new Thread(() => {
+          var reads = 0
+          while (reads < 2000 && failure.get() == null) {
+            // Mirror exactly how the production scanner reads records.
+            val raw =
+              try Some(os.read(file))
+              catch { case _: Throwable => None }
+            raw match {
+              case None =>
+                // os.read failing (e.g. file momentarily absent) is itself a
+                // symptom the atomic publication is meant to prevent.
+                failure.compareAndSet(null, "os.read(file) threw / file missing mid-write")
+              case Some(text) =>
+                try {
+                  val json = ujson.read(text).obj
+                  val command = json.get("command").map(_.str).getOrElse("")
+                  if (command.length != bigCommand.length) {
+                    failure.compareAndSet(
+                      null,
+                      s"torn record: command length ${command.length} != ${bigCommand.length}"
+                    )
+                  }
+                } catch {
+                  case t: Throwable =>
+                    failure.compareAndSet(
+                      null,
+                      s"torn record: parse failed on ${text.length} bytes: ${t.getClass.getName}"
+                    )
+                }
+            }
+            reads += 1
+          }
+        })
+
+        reader.start()
+        writer.start()
+        reader.join(60000)
+        stop.set(true)
+        writer.join(60000)
+
+        assert(failure.get() == null)
+      } finally os.remove.all(out)
+    }
+
+    test("writePublishesViaAtomicRenameNotInPlaceTruncation") {
+      val out = os.temp.dir(prefix = "mill-record-atomic")
+      try {
+        val pid = ProcessHandle.current().pid()
+        val runId = "run-0_2026-05-26_09-00-00_pid-123"
+        val file = LauncherOutFilesUtils.path(out, runId)
+
+        def fileKey(): AnyRef = {
+          val attrs =
+            Files.readAttributes(file.toNIO, classOf[java.nio.file.attribute.BasicFileAttributes])
+          attrs.fileKey()
+        }
+
+        LauncherOutFilesUtils.write(out, runId, pid, "first")
+        assert(os.exists(file))
+        val key1 = fileKey()
+
+        LauncherOutFilesUtils.write(out, runId, pid, "second")
+        assert(os.exists(file))
+        val key2 = fileKey()
+
+        // The second write must reuse the freshly-renamed inode, so the file
+        // identity changes. An in-place `os.write.over` would keep the same
+        // inode (and hence the same fileKey). On filesystems that do not expose
+        // a fileKey (key1 == null) we cannot make this assertion, so skip it.
+        if (key1 != null && key2 != null) {
+          assert(key1 != key2)
+        }
+
+        // Regardless of fileKey support, the published content is always complete.
+        val json = ujson.read(os.read(file)).obj
+        assert(json("command").str == "second")
+      } finally os.remove.all(out)
+    }
+  }
+}

--- a/core/internal/test/src/mill/internal/SpanningForestOrderTests.scala
+++ b/core/internal/test/src/mill/internal/SpanningForestOrderTests.scala
@@ -1,0 +1,121 @@
+package mill.internal
+
+import utest.{TestSuite, Tests, test}
+
+/**
+ * Tests that [[SpanningForest]] emits a deterministic, ascending child order at
+ * every level of the forest.
+ *
+ * The fixed bug laundered the sorted roots through an unordered `mutable.Map`
+ * before seeding the forest's `LinkedHashMap`, discarding the sort and emitting
+ * the roots in HashMap iteration order. A handful of hand-picked inputs can't
+ * establish a non-determinism/ordering property — HashMap order coincides with
+ * sorted order for many inputs, and which inputs differ depends on the JVM's hash
+ * layout. So the invariant is fuzzed over many random DAGs: at every level the
+ * child keys must be in ascending order (a single deterministic order, regardless
+ * of hash layout), and recomputing must produce byte-identical structure + order.
+ */
+object SpanningForestOrderTests extends TestSuite {
+
+  /** The ordered `(key -> children)` shape of a forest, capturing iteration order. */
+  private def shape(node: SpanningForest.Node): Seq[(Int, Any)] =
+    node.values.toSeq.map { case (k, v) => (k, shape(v)) }
+
+  /** Assert child keys are in ascending order at every level of the forest. */
+  private def assertSortedAtEveryLevel(node: SpanningForest.Node): Unit = {
+    val keys = node.values.keys.toSeq
+    assert(keys == keys.sorted)
+    node.values.valuesIterator.foreach(assertSortedAtEveryLevel)
+  }
+
+  /** A random acyclic edge set over `n` vertices (edges only point to higher indices). */
+  private def randomDag(rng: scala.util.Random, n: Int): Array[Array[Int]] = {
+    val edges = Array.fill(n)(Array.empty[Int])
+    for (i <- 0 until n - 1) {
+      val fanout = rng.nextInt(4)
+      edges(i) = Seq.fill(fanout)(i + 1 + rng.nextInt(n - i - 1)).distinct.sorted.toArray
+    }
+    edges
+  }
+
+  val tests = Tests {
+
+    // One concrete, readable example: scattered roots, each heading a small subtree.
+    test("example") {
+      val edges = Array.fill(32)(Array.empty[Int])
+      edges(1) = Array(31)
+      edges(30) = Array(13)
+      val important = Set(1, 3, 8, 9, 12, 17, 25, 30, 31, 13)
+      val forest = SpanningForest.applyInferRoots(edges, important)
+      // 31 and 13 have incoming edges from roots, so they are children, not top-level.
+      assert(forest.values.keys.toSeq == Seq(1, 3, 8, 9, 12, 17, 25, 30))
+      assert(forest.values(1).values.keys.toSeq == Seq(31))
+      assert(forest.values(30).values.keys.toSeq == Seq(13))
+    }
+
+    // Fuzz: for arbitrary DAGs + important subsets, the inferred-root forest must be
+    // sorted at every level, equal to the inferred roots, and deterministic.
+    test("fuzzInferredRootsSortedAtEveryLevel") {
+      val rng = new scala.util.Random(0x5eed)
+      var multiRootCases = 0
+      for (_ <- 0 until 3000) {
+        val n = 1 + rng.nextInt(40)
+        val edges = randomDag(rng, n)
+        val important = (0 until n).filter(_ => rng.nextDouble() < 0.6).toSet
+        if (important.nonEmpty) {
+          val forest = SpanningForest.applyInferRoots(edges, important)
+
+          assertSortedAtEveryLevel(forest)
+
+          val destinations = important.flatMap(edges(_))
+          val expectedRoots = important.filter(!destinations.contains(_)).toSeq.sorted
+          assert(forest.values.keys.toSeq == expectedRoots)
+          if (expectedRoots.size >= 3) multiRootCases += 1
+
+          // Pure, deterministic function: recomputing yields identical structure AND order.
+          assert(shape(SpanningForest.applyInferRoots(edges, important)) == shape(forest))
+        }
+      }
+      // Guard against the generator degenerating to trivial single-root forests where
+      // ordering can't distinguish the bug.
+      assert(multiRootCases > 300)
+    }
+
+    // `applyWithRoots` honours the *supplied* root order for the top level (it is not
+    // re-sorted), so a caller-chosen ordering must round-trip exactly.
+    test("fuzzExplicitRootsPreserveSuppliedOrder") {
+      val rng = new scala.util.Random(0xb0a7)
+      for (_ <- 0 until 1000) {
+        val n = 1 + rng.nextInt(30)
+        val edges = randomDag(rng, n)
+        val rootsOrdered = rng.shuffle((0 until n).filter(_ => rng.nextBoolean()).toVector)
+        val important = rootsOrdered.toSet
+        if (important.nonEmpty) {
+          val forest = SpanningForest.applyWithRoots(edges, rootsOrdered, important)
+          assert(forest.values.keys.toSeq == rootsOrdered.filter(important))
+        }
+      }
+    }
+
+    // The JSON rendering reads the same `LinkedHashMap`, so object key order must mirror
+    // the forest's order at every level.
+    test("fuzzJsonKeyOrderMatchesForest") {
+      val rng = new scala.util.Random(0x305)
+      // The JSON object key order must mirror the forest's LinkedHashMap order at every level.
+      def assertJsonMatches(node: SpanningForest.Node, json: ujson.Value): Unit = {
+        assert(json.obj.keys.toSeq.map(_.toInt) == node.values.keys.toSeq)
+        for ((k, child) <- node.values) assertJsonMatches(child, json.obj(k.toString))
+      }
+      for (_ <- 0 until 1000) {
+        val n = 1 + rng.nextInt(30)
+        val edges = randomDag(rng, n)
+        val important = (0 until n).filter(_ => rng.nextBoolean()).toSet
+        if (important.nonEmpty) {
+          val forest = SpanningForest.applyInferRoots(edges, important)
+          val json = SpanningForest.writeJson(edges, important, _.toString)
+          assertJsonMatches(forest, json)
+        }
+      }
+    }
+  }
+}

--- a/core/resolve/src/mill/resolve/ResolveCore.scala
+++ b/core/resolve/src/mill/resolve/ResolveCore.scala
@@ -76,6 +76,11 @@ private object ResolveCore {
           java.lang.reflect.Method,
           String
       )]] =
+        collection.mutable.Map(),
+      // Memoizes the per-class set of reversed name-segment suffixes used for type-selector
+      // matching (see `classMatchesTypePred`). The class hierarchy is immutable, so this can
+      // be safely reused across all candidate classes and patterns within a single resolve.
+      classNameSegments: collection.mutable.Map[Class[?], Set[Seq[String]]] =
         collection.mutable.Map()
   ) {
     def decode(s: String): String = {
@@ -88,6 +93,20 @@ private object ResolveCore {
         Reflect.getMethods(cls, noParams, inner, decode)
       )
 
+    }
+
+    /**
+     * The set of all reversed name-segment suffixes of `cls` and its transitive parents
+     * (superclasses and interfaces). A type pattern matches `cls` iff its reversed segments
+     * are contained in this set. Computed once per class and cached.
+     */
+    def classNameSegmentSuffixes(cls: Class[?]): Set[Seq[String]] = {
+      classNameSegments.getOrElseUpdate(
+        cls,
+        resolveParents(cls).iterator.flatMap(c =>
+          ("_root_$" + c.getName).split("[.$]").toSeq.reverse.inits.filter(_.nonEmpty)
+        ).toSet
+      )
     }
   }
 
@@ -241,7 +260,7 @@ private object ResolveCore {
                 transitiveOrErr.map(transitive =>
                   (self ++ transitive).collect {
                     case r @ Resolved.Module(_, _, _, cls)
-                        if classMatchesTypePred(typePattern)(cls) =>
+                        if classMatchesTypePred(typePattern)(cls, cache) =>
                       r
                   }
                 )
@@ -258,7 +277,7 @@ private object ResolveCore {
                 ).map {
                   _.collect {
                     case r @ Resolved.Module(_, _, _, cls)
-                        if classMatchesTypePred(typePattern)(cls) => r
+                        if classMatchesTypePred(typePattern)(cls, cache) => r
                   }
                 }
 
@@ -357,7 +376,11 @@ private object ResolveCore {
           ).flatMap {
             case Seq((_, Some(f))) => f(current)
             case unknown =>
-              sys.error(
+              // Surface the failure through the `Result` channel rather than throwing a
+              // raw exception, so callers see a clean `Result.Failure`. This is reachable
+              // if the module tree changes shape between resolution and instantiation
+              // (e.g. a `DynamicModule` with state-dependent `moduleDirectChildren`).
+              mill.api.Result.Failure(
                 s"Unable to resolve single child " +
                   s"rootModule: ${rootModule}, segments: ${segments.render}," +
                   s"current: $current, s: ${s}, unknown: $unknown"
@@ -432,7 +455,13 @@ private object ResolveCore {
    * @param typePattern
    * @return
    */
-  private def classMatchesTypePred(typePattern: Seq[String])(cls: Class[?]): Boolean =
+  private def classMatchesTypePred(typePattern: Seq[String])(
+      cls: Class[?],
+      cache: Cache
+  ): Boolean = {
+    // Computed once per class (across all patterns and candidates) and cached, since the
+    // class hierarchy is immutable.
+    val classNames = cache.classNameSegmentSuffixes(cls)
     typePattern
       .forall { pat =>
         val negate = pat.startsWith("^") || pat.startsWith("!")
@@ -444,14 +473,10 @@ private object ResolveCore {
 
         val typeNames = clsPat.split("[.$]").toSeq.reverse
 
-        val parents = resolveParents(cls)
-        val classNames = parents.flatMap(c =>
-          ("_root_$" + c.getName).split("[.$]").toSeq.reverse.inits.toSeq.filter(_.nonEmpty)
-        )
-
         val isOfType = classNames.contains(typeNames)
         if (negate) !isOfType else isOfType
       }
+  }
 
   def resolveDirectChildren(
       rootModule: RootModule0,
@@ -682,6 +707,10 @@ private object ResolveCore {
   ): NotFound = {
     val possibleNexts = current match {
       case m: Resolved.Module =>
+        // Building the "did you mean ..." suggestions must never itself crash the
+        // resolution. Listing direct children can instantiate `Cross`/`DynamicModule`s,
+        // which may fail to initialize; in that case we degrade gracefully to offering
+        // no suggestions rather than replacing a clean NotFound with an internal error.
         resolveDirectChildren(
           rootModule,
           rootModulePrefix,
@@ -689,7 +718,10 @@ private object ResolveCore {
           None,
           current.taskSegments,
           cache = cache
-        ).toOption.get.map(_.taskSegments.value.last)
+        ) match {
+          case mill.api.Result.Success(children) => children.map(_.taskSegments.value.last)
+          case _: mill.api.Result.Failure => Nil
+        }
 
       case _ => Set[Segment]()
     }

--- a/core/resolve/test/src/mill/resolve/ErrorTests.scala
+++ b/core/resolve/test/src/mill/resolve/ErrorTests.scala
@@ -1,6 +1,7 @@
 package mill.resolve
 
 import mill.api.{Discover, ModuleRef}
+import mill.api.{DynamicModule, Module as ApiModule, Segment}
 import mill.testkit.TestRootModule
 import mainargs.arg
 import mill.{Cross, Module, Task}
@@ -238,6 +239,28 @@ object ErrorTests extends TestSuite {
 
       lazy val millDiscover = Discover[this.type]
     }
+
+    // A `DynamicModule` exposing two distinct child instances that both report the same last
+    // segment `inner`. Name-based resolution de-duplicates them and resolves `parent.inner.task`,
+    // but `ResolveCore.instantiateModule` asks for the single child `inner`, gets two candidates,
+    // and must surface that as a clean `Result.Failure` ("Unable to resolve single child") rather
+    // than a thrown `sys.error`.
+    object ambiguousDynamic extends TestRootModule {
+      object parent extends DynamicModule {
+        private def mkInner: Inner = {
+          implicit val ctx: mill.api.ModuleCtx =
+            moduleCtx.withSegments(moduleSegments ++ Segment.Label("inner"))
+          new Inner {}
+        }
+        val innerA: Inner = mkInner
+        val innerB: Inner = mkInner
+        override def moduleDirectChildren: Seq[ApiModule] = Seq(innerA, innerB)
+        trait Inner extends Module {
+          def task = Task { 1 }
+        }
+      }
+      lazy val millDiscover = Discover[this.type]
+    }
   }
 
   def isShortError(x: Result[?], s: String) = {
@@ -257,6 +280,13 @@ object ErrorTests extends TestSuite {
   val tests = Tests {
     val errorGraphs = ErrorGraphs()
     import errorGraphs.*
+
+    // A label that resolves to two distinct children at instantiation time must come back as a
+    // clean `Result.Failure`, not a thrown `sys.error` that escapes resolution.
+    test("ambiguousDynamicChildIsFailureNotThrow") - Checker(ambiguousDynamic).checkSeq0(
+      Seq("parent.inner.task"),
+      isShortError(_, "Unable to resolve single child")
+    )
 
     test("moduleInitError") {
       test("simple") {

--- a/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
+++ b/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
@@ -424,11 +424,10 @@ class MillBuildBootstrap(
       displacedReusable.foreach { reusable =>
         val snapshot = reusable.workers.synchronized(reusable.workers.toMap)
         val deps = mill.exec.GroupExecution.workerDependencies(snapshot)
-        val topoIndex = deps.iterator.map(_._1).zipWithIndex.toMap
         mill.exec.GroupExecution.closeWorkersInReverseTopologicalOrder(
-          topoIndex.keys,
+          deps.map(_._1),
           reusable.workers,
-          topoIndex,
+          deps,
           c =>
             try c.close()
             catch { case _: Throwable => () }

--- a/runner/daemon/src/mill/daemon/RunnerSharedState.scala
+++ b/runner/daemon/src/mill/daemon/RunnerSharedState.scala
@@ -93,11 +93,10 @@ object RunnerSharedStateOps {
       frame.reusable.foreach { reusable =>
         val snapshot = reusable.workers.synchronized(reusable.workers.toMap)
         val deps = mill.exec.GroupExecution.workerDependencies(snapshot)
-        val topoIndex = deps.iterator.map(_._1).zipWithIndex.toMap
         try mill.exec.GroupExecution.closeWorkersInReverseTopologicalOrder(
-            topoIndex.keys,
+            deps.map(_._1),
             reusable.workers,
-            topoIndex,
+            deps,
             c =>
               try c.close()
               catch { case _: Throwable => () }

--- a/runner/daemon/src/mill/daemon/SharedOutLockManager.scala
+++ b/runner/daemon/src/mill/daemon/SharedOutLockManager.scala
@@ -3,7 +3,7 @@ package mill.daemon
 import mill.api.MillException
 import mill.client.lock.{Lock, Locked}
 import mill.constants.DaemonFiles
-import mill.internal.LauncherOutFilesRecordStore
+import mill.internal.LauncherOutFilesUtils
 
 import java.io.PrintStream
 import java.util.concurrent.atomic.AtomicBoolean
@@ -143,7 +143,7 @@ private[mill] object SharedOutLockManager {
   }
 
   def activeOtherProcessPrefix(out: os.Path): String = {
-    val recordOpt = LauncherOutFilesRecordStore.mostRecentActive(out)
+    val recordOpt = LauncherOutFilesUtils.mostRecentActive(out)
     val command = recordOpt.map(_.command).getOrElse("")
     val pidOpt = recordOpt.map(_.pid)
     val cmdSuffix = if (command.isEmpty) "" else s" running '$command',"


### PR DESCRIPTION
Fix assorted core/ correctness, concurrency & reproducibility issues found by code review
A batch of fixes to Mill's `core/` surfaced by an architectural code
review of evaluation, concurrency, locking, caching, reproducibility and
resolution. Every issue was reproduced (observed at runtime) before being
fixed; the file-isolated fixes carry fail-before / pass-after regression
tests.

## Correctness

* **`PathRef.validatedPaths` is now propagated to execution-pool worker
  threads.** It is a per-run thread-local seeded on the orchestrator
  thread, but `ExecutionContexts.ThreadPool` re-established every other
  inherited value (`os.checker`, pwd, streams, watched values) across the
  pool boundary *except* this one. Under `--jobs > 1` a cached `PathRef`
  deserialized on a worker thread consulted a stale `ValidatedPaths`, so a
  `Revalidate.Once` PathRef's re-check (which detects externally-modified
  outputs) silently degraded from once-per-run to once-per-daemon.
  Invisible to the test suite because `UnitTester` defaults to a single
  thread (`RunNow`).

* **Selective execution no longer crashes on a failing `Task.Input`.**
  `SelectiveExecutionImpl.Metadata.compute0` called `Result.get` on the
  input result, which throws `sys.error` on a `Failure`. Reachable
  unguarded from `execute(selectiveExecution = true)` (i.e. `--watch`) and
  `selective.prepare`, turning a clean failure into an uncaught crash. Now
  folds the failure into a stable hash and stores an `ExecResult.Failure`.

* **`PathRef.withSerializedPaths` is re-entrant.** The `finally` nulled the
  capture list unconditionally, so a nested call wiped the outer scope's
  accumulated paths. Now saves and restores the previous value.

* **`ResolveCore` error-channel hardening.** `instantiateModule` returns a
  `Result.Failure` instead of throwing `sys.error` on a label that resolves
  to zero/multiple children, and `notFoundResult` no longer `.toOption.get`s
  a `Failure` while building "did you mean" suggestions.

* **`PlanImpl.transitiveNodes` / `groupAroundImportantTasks` use iterative
  traversal.** They were recursive and overflowed the stack on deep task
  graphs *before* the deliberately-iterative `Tarjans` ever ran.

* **`GroupExecution.closeWorkersInReverseTopologicalOrder` closes in real
  reverse-topological order** derived from the worker dependency graph,
  rather than `workerCache`'s `HashMap` iteration order.

## Reproducibility & caching

* **Selective-execution input hashing uses the serialized-JSON hash**
  (matching `GroupExecution.getValueHash`) instead of in-memory `value.##`,
  so it agrees with the on-disk cache and stays reproducible across
  checkouts/machines for shared caches: an `os.Path`'s in-memory hash is its
  absolute path (which differs per checkout) while its relativized
  serialized form is identical; identity and order-dependent hashCodes are
  likewise non-reproducible. Per-task code signatures are combined with
  `MurmurHash3.unorderedHash` instead of `.sum` (addition is trivially
  cancelled by two compensating signature deltas).

* **`SpanningForest` emits root nodes in sorted order** instead of
  laundering them through an unordered `mutable.Map`.

* **`LauncherOutFilesUtils` publishes records via atomic rename**
  instead of `os.write.over` (truncate-then-write), which let a concurrent
  reader observe a torn or empty record.

* **Input/Source tasks no longer bump the shared task version counter.**
  They use `Noop` task-locks and do not write a peer-cache-validated
  `dest/`, so bumping spuriously invalidated dropped downstream reads.

## Performance

* **`LeaseTracker.releaseHigherThan` uses an ordered index** of the states
  holding a live retained read, visiting only those above the key threshold
  instead of scanning every state on each contended task-lock acquisition —
  the dual of the `reacquireDropped` fix in https://github.com/com-lihaoyi/mill/pull/7169.

* **`ResolveCore.classMatchesTypePred` caches** the per-class reversed
  name-segment suffixes instead of recomputing the parent linearization and
  `.inits` for every candidate on every type-selector match.

* **`SelectiveExecutionImpl.computeDownstreamDetailed` precomputes** the
  per-class method/hierarchy tables once and reuses them for the old-vs-new
  signature comparison, rather than twice.