### PR TITLE
Simplify LeaseTracker graph traversals; small evaluation/resolution fixes

### DIFF
--- a/core/eval/src/mill/eval/SelectiveExecutionImpl.scala
+++ b/core/eval/src/mill/eval/SelectiveExecutionImpl.scala
@@ -296,8 +296,12 @@ object SelectiveExecutionImpl {
         }
         .toMap
 
+      // Don't `.get` a failing `Task.Input`: that throws and aborts selective metadata
+      // computation, which runs unguarded from `--watch` / `selective.prepare`. Hash a
+      // stable representation of the failure and carry it as an `ExecResult.Failure`.
       val inputHashes = results.map {
-        case (task, execResultVal) => (task.ctx.segments.render, execResultVal.get.value.##)
+        case (task, Result.Success(v)) => (task.ctx.segments.render, v.value.##)
+        case (task, f: Result.Failure) => (task.ctx.segments.render, f.errorOpt.##)
       }
       SelectiveExecution.Metadata.Computed(
         new SelectiveExecution.Metadata(
@@ -310,7 +314,13 @@ object SelectiveExecutionImpl {
           millJvmVersion = sys.props("java.version"),
           classLoaderSigHash = evaluator.classLoaderSigHash
         ),
-        results.map { case (k, v) => (k, ExecResult.Success(v.get)) }
+        results.map { case (k, v) =>
+          val execRes: ExecResult[Val] = v match {
+            case Result.Success(value) => ExecResult.Success(value)
+            case f: Result.Failure => ExecResult.Failure(f.error, Some(f))
+          }
+          (k, execRes)
+        }
       )
     }
   }

--- a/core/exec/src/mill/exec/Execution.scala
+++ b/core/exec/src/mill/exec/Execution.scala
@@ -564,19 +564,20 @@ object Execution {
         retained.dropped = false
         droppedStates.remove(s)
       }
+    // `indexToTerminal` is in topological order, so each dep's transitive upstreams are
+    // already computed; union them in a single pass rather than running an independent
+    // DFS per terminal that re-walks shared ancestors (O(V*(V+E)) on deep/dense graphs).
     private val transitiveUpstreams: Map[Task[?], Seq[Task[?]]] = {
-      def rec(task: Task[?]): Seq[Task[?]] = {
+      val out = mutable.LinkedHashMap.empty[Task[?], Seq[Task[?]]]
+      for (task <- indexToTerminal) {
         val seen = mutable.LinkedHashSet.empty[Task[?]]
-        val stack = mutable.Stack.from(interGroupDeps.getOrElse(task, Nil).reverse)
-        while (stack.nonEmpty) {
-          val upstream = stack.pop()
-          if (seen.add(upstream)) {
-            stack.pushAll(interGroupDeps.getOrElse(upstream, Nil).reverse)
-          }
+        for (dep <- interGroupDeps.getOrElse(task, Nil)) {
+          seen += dep
+          out.get(dep).foreach(seen ++= _)
         }
-        seen.toSeq
+        out(task) = seen.toSeq
       }
-      indexToTerminal.iterator.map(t => t -> rec(t)).toMap
+      out.toMap
     }
 
     locally {
@@ -602,8 +603,9 @@ object Execution {
       }
     }
 
-    private def releaseIfDrained(start: Task[?]): Unit = {
-      val queue = mutable.Queue(start)
+    private def releaseIfDrained(start: Task[?]): Unit = releaseIfDrained(Seq(start))
+    private def releaseIfDrained(starts: IterableOnce[Task[?]]): Unit = {
+      val queue = mutable.Queue.from(starts)
       while (queue.nonEmpty) {
         val task = queue.dequeue()
         val s = states.get(task)
@@ -745,11 +747,12 @@ object Execution {
       } finally {
         upstreams.foreach { task =>
           val s = states.get(task)
-          if (s != null) {
-            s.activeConsumers.decrementAndGet()
-            releaseIfDrained(task)
-          }
+          if (s != null) s.activeConsumers.decrementAndGet()
         }
+        // One BFS over the whole upstream union: the `states.remove` CAS dedups work
+        // across seeds, so this is linear in the upstream subgraph rather than the
+        // O(upstreams) separate BFS traversals a per-upstream call would do.
+        releaseIfDrained(upstreams)
       }
     }
 

--- a/core/exec/src/mill/exec/ExecutionContexts.scala
+++ b/core/exec/src/mill/exec/ExecutionContexts.scala
@@ -27,7 +27,9 @@ object ExecutionContexts {
     def async[T](dest: Path, key: String, message: String, priority: Int)(t: Logger => T)(using
         ctx: mill.api.TaskCtx
     ): Future[T] =
-      Future.successful(t(ctx.log))
+      // A throwing body yields a failed Future, matching `ThreadPool.async`, so
+      // `fork.async` failure semantics don't differ between `--jobs=1` and `--jobs>1`.
+      Future.fromTry(NonFatal.Try(t(ctx.log)))
   }
 
   /**

--- a/core/resolve/src/mill/resolve/ResolveCore.scala
+++ b/core/resolve/src/mill/resolve/ResolveCore.scala
@@ -357,7 +357,9 @@ private object ResolveCore {
           ).flatMap {
             case Seq((_, Some(f))) => f(current)
             case unknown =>
-              sys.error(
+              // A label resolving to zero or multiple children must surface as a
+              // `Result.Failure`, not a thrown `sys.error` that escapes resolution.
+              mill.api.Result.Failure(
                 s"Unable to resolve single child " +
                   s"rootModule: ${rootModule}, segments: ${segments.render}," +
                   s"current: $current, s: ${s}, unknown: $unknown"

--- a/core/resolve/test/src/mill/resolve/ErrorTests.scala
+++ b/core/resolve/test/src/mill/resolve/ErrorTests.scala
@@ -1,6 +1,7 @@
 package mill.resolve
 
 import mill.api.{Discover, ModuleRef}
+import mill.api.{DynamicModule, Module as ApiModule, Segment}
 import mill.testkit.TestRootModule
 import mainargs.arg
 import mill.{Cross, Module, Task}
@@ -238,6 +239,27 @@ object ErrorTests extends TestSuite {
 
       lazy val millDiscover = Discover[this.type]
     }
+
+    // A `DynamicModule` exposing two distinct child instances that both report the same last
+    // segment `inner`. Name resolution de-duplicates them and resolves `parent.inner.task`, but
+    // `ResolveCore.instantiateModule` asks for the single child `inner`, gets two candidates,
+    // and must surface that as a clean `Result.Failure`, not a thrown `sys.error`.
+    object ambiguousDynamic extends TestRootModule {
+      object parent extends DynamicModule {
+        private def mkInner: Inner = {
+          implicit val ctx: mill.api.ModuleCtx =
+            moduleCtx.withSegments(moduleSegments ++ Segment.Label("inner"))
+          new Inner {}
+        }
+        val innerA: Inner = mkInner
+        val innerB: Inner = mkInner
+        override def moduleDirectChildren: Seq[ApiModule] = Seq(innerA, innerB)
+        trait Inner extends Module {
+          def task = Task { 1 }
+        }
+      }
+      lazy val millDiscover = Discover[this.type]
+    }
   }
 
   def isShortError(x: Result[?], s: String) = {
@@ -257,6 +279,13 @@ object ErrorTests extends TestSuite {
   val tests = Tests {
     val errorGraphs = ErrorGraphs()
     import errorGraphs.*
+
+    // A label that resolves to multiple children must come back as a clean `Result.Failure`,
+    // not a thrown `sys.error` that escapes resolution.
+    test("ambiguousDynamicChildIsFailureNotThrow") - Checker(ambiguousDynamic).checkSeq0(
+      Seq("parent.inner.task"),
+      isShortError(_, "Unable to resolve single child")
+    )
 
     test("moduleInitError") {
       test("simple") {


### PR DESCRIPTION

Pared back from a larger review branch to only changes that fix a real bug or genuinely simplify the code:

- `LeaseTracker.transitiveUpstreams`: compute the per-terminal transitive upstream sets in one topological-order pass (union each dep's already-computed set) instead of an independent DFS per terminal that re-walks shared ancestors (O(V*(V+E)) on deep/dense graphs).

- `LeaseTracker.withActiveConsumers`: drive the drain from a single merged BFS over the upstream union rather than one BFS per upstream — the `states.remove` CAS already dedups — removing the O(upstreams^2) finally.

- `ExecutionContexts.RunNow.async`: yield a failed Future on a throwing body, matching `ThreadPool.async`, so `fork.async` failure semantics don't differ between `--jobs=1` and `--jobs>1`.

- Selective execution no longer crashes on a failing `Task.Input`: `computeMetadata` (the `--watch` / `selective.prepare` path) previously `.get`-threw; the failure is now carried as an `ExecResult.Failure`.

- `ResolveCore.instantiateModule` returns a `Result.Failure` instead of throwing `sys.error` when a label resolves to zero/multiple children.
