### PR TITLE
Cleanups for `out/` reproducibility

### DIFF
--- a/core/api/java11/src/mill/api/JsonFormatters.scala
+++ b/core/api/java11/src/mill/api/JsonFormatters.scala
@@ -33,6 +33,16 @@ trait JsonFormatters {
       s => PathAliasing.resolveAliasedString(s)
     )
 
+  /**
+   * [[PathAliasing.aliasPathsInString]] applied to a `Map[String, String]`'s values. A `val`, not a
+   * `given`, so a task opts in per-definition rather than aliasing every `Map[String, String]`.
+   */
+  val aliasedStringMapRW: RW[Map[String, String]] =
+    upickle.readwriter[Map[String, String]].bimap[Map[String, String]](
+      _.view.mapValues(PathAliasing.aliasPathsInString).toMap,
+      _.view.mapValues(PathAliasing.unaliasPathsInString).toMap
+    )
+
   implicit val relPathRW: RW[os.RelPath] = upickle.readwriter[String]
     .bimap[os.RelPath](_.toString, os.RelPath(_))
 

--- a/core/api/java11/src/mill/api/JsonFormatters.scala
+++ b/core/api/java11/src/mill/api/JsonFormatters.scala
@@ -33,16 +33,6 @@ trait JsonFormatters {
       s => PathAliasing.resolveAliasedString(s)
     )
 
-  /**
-   * [[PathAliasing.aliasPathsInString]] applied to a `Map[String, String]`'s values. A `val`, not a
-   * `given`, so a task opts in per-definition rather than aliasing every `Map[String, String]`.
-   */
-  val aliasedStringMapRW: RW[Map[String, String]] =
-    upickle.readwriter[Map[String, String]].bimap[Map[String, String]](
-      _.view.mapValues(PathAliasing.aliasPathsInString).toMap,
-      _.view.mapValues(PathAliasing.unaliasPathsInString).toMap
-    )
-
   implicit val relPathRW: RW[os.RelPath] = upickle.readwriter[String]
     .bimap[os.RelPath](_.toString, os.RelPath(_))
 
@@ -107,6 +97,23 @@ trait JsonFormatters {
 }
 
 object JsonFormatters extends JsonFormatters {
+
+  /**
+   * [[PathAliasing.aliasPathsInString]] applied to a `Map[String, String]`'s values. Lives on the
+   * object (not the [[JsonFormatters]] trait) so a task opts in per-definition rather than aliasing
+   * every `Map[String, String]`, and so adding it doesn't break the trait's binary compatibility.
+   */
+  val aliasedStringMapRW: RW[Map[String, String]] = {
+    // Pass `null` values through untouched — e.g. a YAML `forkEnv` entry with a `null` value
+    // deserializes to a `null` here before it is later dropped, and the alias replacement would NPE.
+    def mapValues(f: String => String)(m: Map[String, String]): Map[String, String] =
+      m.view.mapValues(v => if (v == null) v else f(v)).toMap
+    upickle.readwriter[Map[String, String]].bimap[Map[String, String]](
+      mapValues(PathAliasing.aliasPathsInString),
+      mapValues(PathAliasing.unaliasPathsInString)
+    )
+  }
+
   object Default {
     val subPathRW: RW[os.SubPath] =
       upickle.readwriter[String].bimap[os.SubPath](_.toString, os.SubPath(_))

--- a/core/api/java11/src/mill/api/internal/PathAliasing.scala
+++ b/core/api/java11/src/mill/api/internal/PathAliasing.scala
@@ -38,27 +38,13 @@ object PathAliasing {
    * round-trip through the same aliases the daemon uses).
    */
   def workspaceEnvVars(workspace: os.Path = BuildCtx.workspaceRoot): Map[String, String] = {
-    workspaceEnvVars(workspace, sys.env)
-  }
-
-  def workspaceEnvVars(env: Map[String, String]): Map[String, String] = {
-    workspaceEnvVars(BuildCtx.workspaceRoot, env)
-  }
-
-  def workspaceEnvVars(
-      workspace: os.Path,
-      env: Map[String, String]
-  ): Map[String, String] = {
     val workspaceAbs = realAbs(workspace)
     val homeAbs = realAbs(os.home)
-    val workspaceVars = Map(
+    Map(
       EnvVars.MILL_WORKSPACE_ROOT -> workspaceAbs,
       EnvVars.OS_LIB_PATH_RELATIVIZER_BASE ->
         s"$workspaceAbs,../mill-workspace;$homeAbs,../mill-home"
     )
-    if (env.get(EnvVars.OS_LIB_PATH_RELATIVIZER_BASE).contains("")) workspaceVars -
-      EnvVars.OS_LIB_PATH_RELATIVIZER_BASE
-    else workspaceVars
   }
 
   private def stringAliasPairs: Seq[(String, String)] = Seq(

--- a/core/api/java11/src/mill/api/internal/PathAliasing.scala
+++ b/core/api/java11/src/mill/api/internal/PathAliasing.scala
@@ -61,6 +61,23 @@ object PathAliasing {
     else workspaceVars
   }
 
+  private def stringAliasPairs: Seq[(String, String)] = Seq(
+    realAbs(BuildCtx.workspaceRoot) -> workspaceAlias,
+    realAbs(os.home) -> homeAlias
+  )
+
+  /**
+   * Replace absolute workspace/home prefixes in `s` with the `../mill-workspace`/`../mill-home`
+   * aliases, for path-bearing env var strings that bypass the `os.Path` relativizing serializer.
+   * Inverse of [[unaliasPathsInString]].
+   */
+  def aliasPathsInString(s: String): String =
+    stringAliasPairs.foldLeft(s) { case (acc, (abs, alias)) => acc.replace(abs, alias) }
+
+  /** Inverse of [[aliasPathsInString]]. */
+  def unaliasPathsInString(s: String): String =
+    stringAliasPairs.foldLeft(s) { case (acc, (abs, alias)) => acc.replace(alias, abs) }
+
   private def normalize(raw: String): String = raw.replace('\\', '/')
 
   private def resolveFromAlias(

--- a/core/eval/src/mill/eval/ScriptModuleInit.scala
+++ b/core/eval/src/mill/eval/ScriptModuleInit.scala
@@ -192,11 +192,12 @@ class ScriptModuleInit extends ((String, Evaluator) => Seq[Result[ExternalModule
    */
   def resolveScriptModule(scriptFile0: String, eval: Evaluator): Option[Result[ExternalModule]] = {
     val scriptFile = os.Path(scriptFile0, mill.api.BuildCtx.workspaceRoot)
-    // Add a synthetic watch on `scriptFile`, representing the special handling
-    // of `staticBuildOverrides` which is read from the script file build header
-    mill.api.BuildCtx.evalWatch(scriptFile)
 
     Option.when(os.isFile(scriptFile)) {
+      // Add a synthetic watch on `scriptFile`, representing the special handling
+      // of `staticBuildOverrides` which is read from the script file build header.
+      mill.api.BuildCtx.evalWatch(scriptFile)
+
       // Check for recursive moduleDeps cycle
       if (resolvingScripts.contains(scriptFile)) {
         val relPath = scriptFile.relativeTo(mill.api.BuildCtx.workspaceRoot)

--- a/core/eval/src/mill/eval/ScriptModuleInit.scala
+++ b/core/eval/src/mill/eval/ScriptModuleInit.scala
@@ -192,12 +192,13 @@ class ScriptModuleInit extends ((String, Evaluator) => Seq[Result[ExternalModule
    */
   def resolveScriptModule(scriptFile0: String, eval: Evaluator): Option[Result[ExternalModule]] = {
     val scriptFile = os.Path(scriptFile0, mill.api.BuildCtx.workspaceRoot)
+    // Add a synthetic watch on `scriptFile`, representing the special handling
+    // of `staticBuildOverrides` which is read from the script file build header.
+    // Directory probes are not script files, and watching them would recursively
+    // digest their entire contents.
+    if (!os.isDir(scriptFile)) mill.api.BuildCtx.evalWatch(scriptFile)
 
     Option.when(os.isFile(scriptFile)) {
-      // Add a synthetic watch on `scriptFile`, representing the special handling
-      // of `staticBuildOverrides` which is read from the script file build header.
-      mill.api.BuildCtx.evalWatch(scriptFile)
-
       // Check for recursive moduleDeps cycle
       if (resolvingScripts.contains(scriptFile)) {
         val relPath = scriptFile.relativeTo(mill.api.BuildCtx.workspaceRoot)
@@ -297,6 +298,7 @@ class ScriptModuleInit extends ((String, Evaluator) => Seq[Result[ExternalModule
       val candidates = Seq("package.mill.yaml", "build.mill.yaml")
       candidates.iterator.flatMap { name =>
         val yamlFile = dir / name
+        mill.api.BuildCtx.evalWatch(yamlFile)
         if (os.isFile(yamlFile) && mill.internal.Util.isPrecompiledYamlModule(yamlFile))
           resolveScriptModule(yamlFile.toString, eval)
         else None

--- a/example/scalalib/linting/1-linting/build.mill
+++ b/example/scalalib/linting/1-linting/build.mill
@@ -47,7 +47,7 @@ object Foo {
 /** See Also: .scalafix.conf */
 /** Usage
 
-> OS_LIB_PATH_RELATIVIZER_BASE= ./mill __.fix
+> ./mill __.fix
 
 > cat src/Foo.scala
 package foo

--- a/example/scalalib/linting/1-linting/ignoreErrorsOnCI
+++ b/example/scalalib/linting/1-linting/ignoreErrorsOnCI
@@ -1,0 +1,17 @@
+Disabled on CI pending an upstream fix in the third-party mill-scalafix plugin.
+
+With Mill's `out/`-reproducibility path relativization active, the `mill-scalafix`
+plugin passes a relativized working directory to scalafix:
+
+  ScalafixModule.scala:105  .withWorkingDirectory(wd.toNIO)   // wd = BuildCtx.workspaceRoot
+
+`wd.toNIO` serializes to the relativized `../mill-workspace` form, but scalafix's
+`ScalafixArgumentsImpl.withWorkingDirectory` does `require(path.isAbsolute, ...)`
+(the message text "working directory must be relative" is misworded; the check is
+`isAbsolute`), so `__.fix` fails with:
+
+  java.lang.IllegalArgumentException: requirement failed: working directory must be relative: ../mill-workspace
+
+The fix is upstream: mill-scalafix should hand scalafix an absolute path
+(`wd.wrapped` / `realAbs(wd)`) rather than `wd.toNIO`. Tracking issue:
+https://github.com/joan38/mill-scalafix/issues

--- a/example/scalalib/linting/3-contrib-scoverage/build.mill
+++ b/example/scalalib/linting/3-contrib-scoverage/build.mill
@@ -49,7 +49,7 @@ Branch coverage....: 100.00%
 
 > sed -i.bak 's/10.00/50.00/' build.mill.yaml
 
-> OS_LIB_PATH_RELATIVIZER_BASE= ./mill scoverage.validateCoverageMinimums
+> ./mill scoverage.validateCoverageMinimums
 error: ...Exception while validating coverage minimums. Coverage minimums violated:
 error: ...This project's statement coverage (40.00) did not meet the minimum desired by the project. (50.0)
 

--- a/integration/dedicated/bsp-server/resources/snapshots/build-targets-jvm-run-environments.json
+++ b/integration/dedicated/bsp-server/resources/snapshots/build-targets-jvm-run-environments.json
@@ -21,7 +21,8 @@
       "environmentVariables": {
         "PATH": "...",
         "MY_ENV_VAR": "my-value",
-        "MILL_WORKSPACE_ROOT": "/workspace"
+        "MILL_WORKSPACE_ROOT": "/workspace",
+        "OS_LIB_PATH_RELATIVIZER_BASE": "/workspace,/workspace;/user-home,/user-home"
       },
       "mainClasses": [
         {
@@ -54,6 +55,7 @@
       "environmentVariables": {
         "PATH": "...",
         "MILL_WORKSPACE_ROOT": "/workspace",
+        "OS_LIB_PATH_RELATIVIZER_BASE": "/workspace,/workspace;/user-home,/user-home",
         "MILL_TEST_RESOURCE_DIR": "/workspace/app/test/resources"
       },
       "mainClasses": []
@@ -72,7 +74,8 @@
       "workingDirectory": "/workspace",
       "environmentVariables": {
         "PATH": "...",
-        "MILL_WORKSPACE_ROOT": "/workspace"
+        "MILL_WORKSPACE_ROOT": "/workspace",
+        "OS_LIB_PATH_RELATIVIZER_BASE": "/workspace,/workspace;/user-home,/user-home"
       },
       "mainClasses": []
     },
@@ -90,7 +93,8 @@
       "workingDirectory": "/workspace",
       "environmentVariables": {
         "PATH": "...",
-        "MILL_WORKSPACE_ROOT": "/workspace"
+        "MILL_WORKSPACE_ROOT": "/workspace",
+        "OS_LIB_PATH_RELATIVIZER_BASE": "/workspace,/workspace;/user-home,/user-home"
       },
       "mainClasses": []
     },
@@ -107,7 +111,8 @@
       "workingDirectory": "/workspace",
       "environmentVariables": {
         "PATH": "...",
-        "MILL_WORKSPACE_ROOT": "/workspace"
+        "MILL_WORKSPACE_ROOT": "/workspace",
+        "OS_LIB_PATH_RELATIVIZER_BASE": "/workspace,/workspace;/user-home,/user-home"
       },
       "mainClasses": []
     },
@@ -132,6 +137,7 @@
       "environmentVariables": {
         "PATH": "...",
         "MILL_WORKSPACE_ROOT": "/workspace",
+        "OS_LIB_PATH_RELATIVIZER_BASE": "/workspace,/workspace;/user-home,/user-home",
         "MILL_TEST_RESOURCE_DIR": "/workspace/hello-java/test/resources"
       },
       "mainClasses": [
@@ -156,7 +162,8 @@
       "workingDirectory": "/workspace",
       "environmentVariables": {
         "PATH": "...",
-        "MILL_WORKSPACE_ROOT": "/workspace"
+        "MILL_WORKSPACE_ROOT": "/workspace",
+        "OS_LIB_PATH_RELATIVIZER_BASE": "/workspace,/workspace;/user-home,/user-home"
       },
       "mainClasses": []
     },
@@ -174,7 +181,8 @@
       "workingDirectory": "/workspace",
       "environmentVariables": {
         "PATH": "...",
-        "MILL_WORKSPACE_ROOT": "/workspace"
+        "MILL_WORKSPACE_ROOT": "/workspace",
+        "OS_LIB_PATH_RELATIVIZER_BASE": "/workspace,/workspace;/user-home,/user-home"
       },
       "mainClasses": [
         {
@@ -205,6 +213,7 @@
       "environmentVariables": {
         "PATH": "...",
         "MILL_WORKSPACE_ROOT": "/workspace",
+        "OS_LIB_PATH_RELATIVIZER_BASE": "/workspace,/workspace;/user-home,/user-home",
         "MILL_TEST_RESOURCE_DIR": "/workspace/hello-scala/test/resources"
       },
       "mainClasses": [
@@ -228,7 +237,8 @@
       "workingDirectory": "/workspace",
       "environmentVariables": {
         "PATH": "...",
-        "MILL_WORKSPACE_ROOT": "/workspace"
+        "MILL_WORKSPACE_ROOT": "/workspace",
+        "OS_LIB_PATH_RELATIVIZER_BASE": "/workspace,/workspace;/user-home,/user-home"
       },
       "mainClasses": []
     },
@@ -245,7 +255,8 @@
       "workingDirectory": "/workspace",
       "environmentVariables": {
         "PATH": "...",
-        "MILL_WORKSPACE_ROOT": "/workspace"
+        "MILL_WORKSPACE_ROOT": "/workspace",
+        "OS_LIB_PATH_RELATIVIZER_BASE": "/workspace,/workspace;/user-home,/user-home"
       },
       "mainClasses": []
     },
@@ -277,7 +288,8 @@
       "workingDirectory": "/workspace",
       "environmentVariables": {
         "PATH": "...",
-        "MILL_WORKSPACE_ROOT": "/workspace"
+        "MILL_WORKSPACE_ROOT": "/workspace",
+        "OS_LIB_PATH_RELATIVIZER_BASE": "/workspace,/workspace;/user-home,/user-home"
       },
       "mainClasses": [
         {
@@ -304,7 +316,8 @@
       "workingDirectory": "/workspace",
       "environmentVariables": {
         "PATH": "...",
-        "MILL_WORKSPACE_ROOT": "/workspace"
+        "MILL_WORKSPACE_ROOT": "/workspace",
+        "OS_LIB_PATH_RELATIVIZER_BASE": "/workspace,/workspace;/user-home,/user-home"
       },
       "mainClasses": [
         {
@@ -345,6 +358,7 @@
       "environmentVariables": {
         "PATH": "...",
         "MILL_WORKSPACE_ROOT": "/workspace",
+        "OS_LIB_PATH_RELATIVIZER_BASE": "/workspace,/workspace;/user-home,/user-home",
         "MILL_TEST_RESOURCE_DIR": "/workspace/scripts/folder2/FooTest.java/resources"
       },
       "mainClasses": []
@@ -367,7 +381,8 @@
       "workingDirectory": "/workspace",
       "environmentVariables": {
         "PATH": "...",
-        "MILL_WORKSPACE_ROOT": "/workspace"
+        "MILL_WORKSPACE_ROOT": "/workspace",
+        "OS_LIB_PATH_RELATIVIZER_BASE": "/workspace,/workspace;/user-home,/user-home"
       },
       "mainClasses": [
         {
@@ -404,7 +419,8 @@
       "workingDirectory": "/workspace",
       "environmentVariables": {
         "PATH": "...",
-        "MILL_WORKSPACE_ROOT": "/workspace"
+        "MILL_WORKSPACE_ROOT": "/workspace",
+        "OS_LIB_PATH_RELATIVIZER_BASE": "/workspace,/workspace;/user-home,/user-home"
       },
       "mainClasses": [
         {
@@ -424,7 +440,8 @@
       "workingDirectory": "/workspace",
       "environmentVariables": {
         "PATH": "...",
-        "MILL_WORKSPACE_ROOT": "/workspace"
+        "MILL_WORKSPACE_ROOT": "/workspace",
+        "OS_LIB_PATH_RELATIVIZER_BASE": "/workspace,/workspace;/user-home,/user-home"
       },
       "mainClasses": []
     },
@@ -442,7 +459,8 @@
       "workingDirectory": "/workspace",
       "environmentVariables": {
         "PATH": "...",
-        "MILL_WORKSPACE_ROOT": "/workspace"
+        "MILL_WORKSPACE_ROOT": "/workspace",
+        "OS_LIB_PATH_RELATIVIZER_BASE": "/workspace,/workspace;/user-home,/user-home"
       },
       "mainClasses": []
     }

--- a/integration/dedicated/bsp-server/resources/snapshots/build-targets-jvm-run-environments.json
+++ b/integration/dedicated/bsp-server/resources/snapshots/build-targets-jvm-run-environments.json
@@ -21,8 +21,7 @@
       "environmentVariables": {
         "PATH": "...",
         "MY_ENV_VAR": "my-value",
-        "MILL_WORKSPACE_ROOT": "/workspace",
-        "OS_LIB_PATH_RELATIVIZER_BASE": "/workspace,/workspace;/user-home,/user-home"
+        "MILL_WORKSPACE_ROOT": "/workspace"
       },
       "mainClasses": [
         {
@@ -55,7 +54,6 @@
       "environmentVariables": {
         "PATH": "...",
         "MILL_WORKSPACE_ROOT": "/workspace",
-        "OS_LIB_PATH_RELATIVIZER_BASE": "/workspace,/workspace;/user-home,/user-home",
         "MILL_TEST_RESOURCE_DIR": "/workspace/app/test/resources"
       },
       "mainClasses": []
@@ -74,8 +72,7 @@
       "workingDirectory": "/workspace",
       "environmentVariables": {
         "PATH": "...",
-        "MILL_WORKSPACE_ROOT": "/workspace",
-        "OS_LIB_PATH_RELATIVIZER_BASE": "/workspace,/workspace;/user-home,/user-home"
+        "MILL_WORKSPACE_ROOT": "/workspace"
       },
       "mainClasses": []
     },
@@ -93,8 +90,7 @@
       "workingDirectory": "/workspace",
       "environmentVariables": {
         "PATH": "...",
-        "MILL_WORKSPACE_ROOT": "/workspace",
-        "OS_LIB_PATH_RELATIVIZER_BASE": "/workspace,/workspace;/user-home,/user-home"
+        "MILL_WORKSPACE_ROOT": "/workspace"
       },
       "mainClasses": []
     },
@@ -111,8 +107,7 @@
       "workingDirectory": "/workspace",
       "environmentVariables": {
         "PATH": "...",
-        "MILL_WORKSPACE_ROOT": "/workspace",
-        "OS_LIB_PATH_RELATIVIZER_BASE": "/workspace,/workspace;/user-home,/user-home"
+        "MILL_WORKSPACE_ROOT": "/workspace"
       },
       "mainClasses": []
     },
@@ -137,7 +132,6 @@
       "environmentVariables": {
         "PATH": "...",
         "MILL_WORKSPACE_ROOT": "/workspace",
-        "OS_LIB_PATH_RELATIVIZER_BASE": "/workspace,/workspace;/user-home,/user-home",
         "MILL_TEST_RESOURCE_DIR": "/workspace/hello-java/test/resources"
       },
       "mainClasses": [
@@ -162,8 +156,7 @@
       "workingDirectory": "/workspace",
       "environmentVariables": {
         "PATH": "...",
-        "MILL_WORKSPACE_ROOT": "/workspace",
-        "OS_LIB_PATH_RELATIVIZER_BASE": "/workspace,/workspace;/user-home,/user-home"
+        "MILL_WORKSPACE_ROOT": "/workspace"
       },
       "mainClasses": []
     },
@@ -181,8 +174,7 @@
       "workingDirectory": "/workspace",
       "environmentVariables": {
         "PATH": "...",
-        "MILL_WORKSPACE_ROOT": "/workspace",
-        "OS_LIB_PATH_RELATIVIZER_BASE": "/workspace,/workspace;/user-home,/user-home"
+        "MILL_WORKSPACE_ROOT": "/workspace"
       },
       "mainClasses": [
         {
@@ -213,7 +205,6 @@
       "environmentVariables": {
         "PATH": "...",
         "MILL_WORKSPACE_ROOT": "/workspace",
-        "OS_LIB_PATH_RELATIVIZER_BASE": "/workspace,/workspace;/user-home,/user-home",
         "MILL_TEST_RESOURCE_DIR": "/workspace/hello-scala/test/resources"
       },
       "mainClasses": [
@@ -237,8 +228,7 @@
       "workingDirectory": "/workspace",
       "environmentVariables": {
         "PATH": "...",
-        "MILL_WORKSPACE_ROOT": "/workspace",
-        "OS_LIB_PATH_RELATIVIZER_BASE": "/workspace,/workspace;/user-home,/user-home"
+        "MILL_WORKSPACE_ROOT": "/workspace"
       },
       "mainClasses": []
     },
@@ -255,8 +245,7 @@
       "workingDirectory": "/workspace",
       "environmentVariables": {
         "PATH": "...",
-        "MILL_WORKSPACE_ROOT": "/workspace",
-        "OS_LIB_PATH_RELATIVIZER_BASE": "/workspace,/workspace;/user-home,/user-home"
+        "MILL_WORKSPACE_ROOT": "/workspace"
       },
       "mainClasses": []
     },
@@ -288,8 +277,7 @@
       "workingDirectory": "/workspace",
       "environmentVariables": {
         "PATH": "...",
-        "MILL_WORKSPACE_ROOT": "/workspace",
-        "OS_LIB_PATH_RELATIVIZER_BASE": "/workspace,/workspace;/user-home,/user-home"
+        "MILL_WORKSPACE_ROOT": "/workspace"
       },
       "mainClasses": [
         {
@@ -316,8 +304,7 @@
       "workingDirectory": "/workspace",
       "environmentVariables": {
         "PATH": "...",
-        "MILL_WORKSPACE_ROOT": "/workspace",
-        "OS_LIB_PATH_RELATIVIZER_BASE": "/workspace,/workspace;/user-home,/user-home"
+        "MILL_WORKSPACE_ROOT": "/workspace"
       },
       "mainClasses": [
         {
@@ -358,7 +345,6 @@
       "environmentVariables": {
         "PATH": "...",
         "MILL_WORKSPACE_ROOT": "/workspace",
-        "OS_LIB_PATH_RELATIVIZER_BASE": "/workspace,/workspace;/user-home,/user-home",
         "MILL_TEST_RESOURCE_DIR": "/workspace/scripts/folder2/FooTest.java/resources"
       },
       "mainClasses": []
@@ -381,8 +367,7 @@
       "workingDirectory": "/workspace",
       "environmentVariables": {
         "PATH": "...",
-        "MILL_WORKSPACE_ROOT": "/workspace",
-        "OS_LIB_PATH_RELATIVIZER_BASE": "/workspace,/workspace;/user-home,/user-home"
+        "MILL_WORKSPACE_ROOT": "/workspace"
       },
       "mainClasses": [
         {
@@ -419,8 +404,7 @@
       "workingDirectory": "/workspace",
       "environmentVariables": {
         "PATH": "...",
-        "MILL_WORKSPACE_ROOT": "/workspace",
-        "OS_LIB_PATH_RELATIVIZER_BASE": "/workspace,/workspace;/user-home,/user-home"
+        "MILL_WORKSPACE_ROOT": "/workspace"
       },
       "mainClasses": [
         {
@@ -440,8 +424,7 @@
       "workingDirectory": "/workspace",
       "environmentVariables": {
         "PATH": "...",
-        "MILL_WORKSPACE_ROOT": "/workspace",
-        "OS_LIB_PATH_RELATIVIZER_BASE": "/workspace,/workspace;/user-home,/user-home"
+        "MILL_WORKSPACE_ROOT": "/workspace"
       },
       "mainClasses": []
     },
@@ -459,8 +442,7 @@
       "workingDirectory": "/workspace",
       "environmentVariables": {
         "PATH": "...",
-        "MILL_WORKSPACE_ROOT": "/workspace",
-        "OS_LIB_PATH_RELATIVIZER_BASE": "/workspace,/workspace;/user-home,/user-home"
+        "MILL_WORKSPACE_ROOT": "/workspace"
       },
       "mainClasses": []
     }

--- a/integration/dedicated/reproducibility/resources/build.mill
+++ b/integration/dedicated/reproducibility/resources/build.mill
@@ -1,4 +1,18 @@
 package build
 import mill.*
+import mill.javalib.JavaModule
+import mill.scalalib.ScalaModule
+import mill.kotlinlib.KotlinModule
 
 def foo = Task { 31337 }
+
+object javaApp extends JavaModule
+
+object scalaApp extends ScalaModule {
+  def scalaVersion = "3.8.2"
+}
+
+object kotlinApp extends KotlinModule {
+  def kotlinVersion = "2.2.20"
+  def mainClass = Some("kotlinapp.KotlinAppKt")
+}

--- a/integration/dedicated/reproducibility/resources/javaApp/src/javaapp/JavaApp.java
+++ b/integration/dedicated/reproducibility/resources/javaApp/src/javaapp/JavaApp.java
@@ -1,0 +1,4 @@
+package javaapp;
+public class JavaApp {
+  public static void main(String[] args) { System.out.println("hello java"); }
+}

--- a/integration/dedicated/reproducibility/resources/kotlinApp/src/kotlinapp/KotlinApp.kt
+++ b/integration/dedicated/reproducibility/resources/kotlinApp/src/kotlinapp/KotlinApp.kt
@@ -1,0 +1,2 @@
+package kotlinapp
+fun main() { println("hello kotlin") }

--- a/integration/dedicated/reproducibility/resources/scalaApp/src/scalaapp/ScalaApp.scala
+++ b/integration/dedicated/reproducibility/resources/scalaApp/src/scalaapp/ScalaApp.scala
@@ -1,0 +1,2 @@
+package scalaapp
+object ScalaApp { def main(args: Array[String]): Unit = println("hello scala") }

--- a/integration/dedicated/reproducibility/src/ReproducibilityTests.scala
+++ b/integration/dedicated/reproducibility/src/ReproducibilityTests.scala
@@ -83,7 +83,15 @@ object ReproducibilityTests extends UtestIntegrationTestSuite {
       finally s.close()
     }
     val proc = os
-      .proc(bazelRemoteBinary, "--dir", dataDir, "--max_size", "1", "--http_address", s"localhost:$port")
+      .proc(
+        bazelRemoteBinary,
+        "--dir",
+        dataDir,
+        "--max_size",
+        "1",
+        "--http_address",
+        s"localhost:$port"
+      )
       .spawn(stdout = os.Inherit, stderr = os.Inherit)
     val url = s"http://localhost:$port"
     try {
@@ -150,7 +158,9 @@ object ReproducibilityTests extends UtestIntegrationTestSuite {
       integrationTest { tester =>
         val res = tester.eval(cacheArgs ++ plus(appTasks), check = true)
         assert(res.isSuccess)
-        for (t <- compileTasks ++ Seq("javaApp.assembly", "scalaApp.assembly", "kotlinApp.assembly"))
+        for (
+          t <- compileTasks ++ Seq("javaApp.assembly", "scalaApp.assembly", "kotlinApp.assembly")
+        )
           assert(!evaluated(tester, t))
       }
     }

--- a/integration/dedicated/reproducibility/src/ReproducibilityTests.scala
+++ b/integration/dedicated/reproducibility/src/ReproducibilityTests.scala
@@ -1,12 +1,32 @@
 package mill.integration
 
-import mill.api.BuildCtx
-import mill.testkit.UtestIntegrationTestSuite
+import mill.testkit.{IntegrationTester, UtestIntegrationTestSuite}
 import utest.*
 
-import java.util.zip.GZIPInputStream
-
+/**
+ * Tests that Mill's `out/` folder is reproducible: building the same project in two different
+ * locations (and under two different `$HOME`s) produces byte-for-byte identical `out/` contents,
+ * and that those identical contents let a remote cache populated by one build fully satisfy a
+ * second build elsewhere without recomputing anything.
+ */
 object ReproducibilityTests extends UtestIntegrationTestSuite {
+
+  // Each block models a fresh checkout (empty `out/`); opt out of the `fast` flavor's shared
+  // output dir so one build's local cache can't satisfy another.
+  override def allowSharedOutputDir: Boolean = false
+
+  /** The cacheable tasks we build; assembly pulls in `compile`, `allForkEnv` exercises env aliasing. */
+  val appTasks: Seq[String] = Seq(
+    "javaApp.assembly",
+    "scalaApp.assembly",
+    "kotlinApp.assembly",
+    "javaApp.allForkEnv",
+    "scalaApp.allForkEnv",
+    "kotlinApp.allForkEnv"
+  )
+
+  /** Join task selectors with `+` so they run in a single Mill invocation. */
+  def plus(tasks: Seq[String]): Seq[String] = tasks.flatMap(Seq("+", _)).tail
 
   def normalize(workspacePath: os.Path): Unit = {
     for (p <- os.walk(workspacePath / "out")) {
@@ -25,58 +45,114 @@ object ReproducibilityTests extends UtestIntegrationTestSuite {
     }
   }
 
-  // The binary Zinc analysis file is gzip-compressed; decompress so we scan its actual content.
-  def gunzipIfNeeded(bytes: Array[Byte]): Array[Byte] =
-    if (bytes.length >= 2 && bytes(0) == 0x1f.toByte && bytes(1) == 0x8b.toByte) {
-      val in = new GZIPInputStream(new java.io.ByteArrayInputStream(bytes))
-      try in.readAllBytes()
-      finally in.close()
-    } else bytes
+  // A symlink pointing at the real home, so the Mill subprocess sees a *different* `os.home` string
+  // while still sharing the real coursier/ivy cache (no re-download). Building under two distinct
+  // homes means any un-relativized home path leaks as differing bytes in the two `out/` folders.
+  def symlinkedHome(): os.Path = {
+    val link = os.temp.dir() / "home"
+    os.symlink(link, os.home)
+    link
+  }
+
+  def homeEnv(home: os.Path): Map[String, String] = Map(
+    "HOME" -> home.toString,
+    "USERPROFILE" -> home.toString,
+    // Mill forwards `JAVA_OPTS` into the daemon JVM (see `MillProcessLauncher.computeJvmOpts`), so
+    // this reliably drives `user.home`/`os.home` cross-platform, regardless of the OS `$HOME`.
+    "JAVA_OPTS" -> s"-Duser.home=$home"
+  )
+
+  // Whether `task` was recomputed (`"cached": false` in `mill-profile.json`) rather than served
+  // from a cache, in the most recent invocation in `tester`'s workspace.
+  def evaluated(tester: IntegrationTester, task: String): Boolean = {
+    val profile = os.read(tester.workspacePath / "out" / mill.constants.OutFiles.millProfile)
+    ujson.read(profile).arr.exists { e =>
+      e("label").str == task && e.obj.get("cached").flatMap(_.boolOpt).contains(false)
+    }
+  }
+
+  /** The real `bazel-remote` binary, downloaded once and cached by the `bazelRemote` build task. */
+  def bazelRemoteBinary: os.Path = os.Path(sys.env("MILL_TEST_BAZEL_REMOTE"))
+
+  /** Boot a real `bazel-remote` HTTP cache server on a free port, run `f` against it, then stop it. */
+  def withBazelRemote[T](f: String => T): T = {
+    val dataDir = os.temp.dir(prefix = "bazel-remote-data")
+    val port = {
+      val s = new java.net.ServerSocket(0)
+      try s.getLocalPort
+      finally s.close()
+    }
+    val proc = os
+      .proc(bazelRemoteBinary, "--dir", dataDir, "--max_size", "1", "--http_address", s"localhost:$port")
+      .spawn(stdout = os.Inherit, stderr = os.Inherit)
+    val url = s"http://localhost:$port"
+    try {
+      val deadline = System.currentTimeMillis() + 30000
+      def ready(): Boolean =
+        try {
+          val conn = new java.net.URI(s"$url/status").toURL.openConnection()
+            .asInstanceOf[java.net.HttpURLConnection]
+          conn.setConnectTimeout(500)
+          conn.setReadTimeout(500)
+          try conn.getResponseCode == 200
+          finally conn.disconnect()
+        } catch { case _: Throwable => false }
+      while (!ready() && System.currentTimeMillis() < deadline) Thread.sleep(200)
+      if (!ready()) throw new RuntimeException("bazel-remote did not become ready in 30s")
+      f(url)
+    } finally {
+      proc.destroy()
+      proc.destroyForcibly()
+    }
+  }
 
   val tests: Tests = Tests {
+    // Build the same project twice, in two different workspaces and under two different homes, then
+    // assert the (normalized) `out/` folders are byte-for-byte identical.
     test("diff") - {
-      def run() = integrationTest { tester =>
-        val res = tester.eval(("show", "foo"))
+      def run(home: os.Path) = integrationTest { tester =>
+        val env = homeEnv(home)
+        tester.eval(("--meta-level", "1", "runClasspath"), env = env, check = true)
+        tester.eval(plus(appTasks), env = env, check = true)
+        val res = tester.eval(("show", "foo"), env = env, check = true)
         val lastNonEmptyLine =
           res.out.linesIterator.filter(_.nonEmpty).toSeq.lastOption.getOrElse("")
         assert(lastNonEmptyLine == "31337")
         tester.workspacePath
       }
 
-      val workspacePath1 = run()
-      val workspacePath2 = run()
+      val workspacePath1 = run(symlinkedHome())
+      val workspacePath2 = run(symlinkedHome())
       assert(workspacePath1 != workspacePath2)
       normalize(workspacePath1)
       normalize(workspacePath2)
-      val diff = os.call(("git", "diff", "--no-index", workspacePath1, workspacePath2)).out.text()
-      assert(diff.isEmpty)
+      val diffStat = os.call(
+        ("git", "diff", "--no-index", "--stat", workspacePath1, workspacePath2),
+        check = false
+      ).out.text()
+      assert(diffStat.isEmpty)
     }
 
-    test("inspection") - {
-      def run() = integrationTest { tester =>
-        tester.eval(("--meta-level", "1", "runClasspath"), check = true)
-        tester.eval("javaApp.run", check = true)
-        tester.eval("javaApp.assembly", check = true)
-        tester.eval("scalaApp.run", check = true)
-        tester.eval("scalaApp.assembly", check = true)
-        tester.eval("kotlinApp.run", check = true)
-        tester.eval("kotlinApp.assembly", check = true)
-        tester.workspacePath
+    // Populate a remote cache from one checkout, then build a fresh checkout elsewhere against the
+    // same cache and assert the expensive tasks are served from it rather than rebuilt.
+    test("remoteCache") - withBazelRemote { url =>
+      val cacheArgs = Seq("--remote-cache-location", url)
+      val compileTasks = Seq("javaApp.compile", "scalaApp.compile", "kotlinApp.compile")
+
+      // First checkout: cold cache, everything is computed locally and pushed.
+      integrationTest { tester =>
+        val res = tester.eval(cacheArgs ++ plus(appTasks), check = true)
+        assert(res.isSuccess)
+        for (t <- compileTasks) assert(evaluated(tester, t))
       }
 
-      val workspacePath = run()
-      normalize(workspacePath)
-
-      val ws = BuildCtx.workspaceRoot.toString.getBytes("UTF-8")
-      val hm = os.home.toString.getBytes("UTF-8")
-      val leaks = collection.mutable.Buffer.empty[String]
-      for (p <- os.walk(workspacePath / "out", followLinks = false) if os.isFile(p)) {
-        val bytes = gunzipIfNeeded(os.read.bytes(p))
-        val sub = p.subRelativeTo(workspacePath)
-        if (bytes.containsSlice(ws)) leaks.append(s"[WS] $sub")
-        else if (bytes.containsSlice(hm)) leaks.append(s"[HM] $sub")
+      // Second checkout: warm cache, the compile/assembly work is served from it, not recomputed.
+      integrationTest { tester =>
+        val res = tester.eval(cacheArgs ++ plus(appTasks), check = true)
+        assert(res.isSuccess)
+        for (t <- compileTasks ++ Seq("javaApp.assembly", "scalaApp.assembly", "kotlinApp.assembly"))
+          assert(!evaluated(tester, t))
       }
-      Predef.assert(leaks.isEmpty, leaks.mkString("\n"))
     }
   }
 }

--- a/integration/dedicated/reproducibility/src/ReproducibilityTests.scala
+++ b/integration/dedicated/reproducibility/src/ReproducibilityTests.scala
@@ -25,6 +25,14 @@ object ReproducibilityTests extends UtestIntegrationTestSuite {
     }
   }
 
+  // The binary Zinc analysis file is gzip-compressed; decompress so we scan its actual content.
+  def gunzipIfNeeded(bytes: Array[Byte]): Array[Byte] =
+    if (bytes.length >= 2 && bytes(0) == 0x1f.toByte && bytes(1) == 0x8b.toByte) {
+      val in = new GZIPInputStream(new java.io.ByteArrayInputStream(bytes))
+      try in.readAllBytes()
+      finally in.close()
+    } else bytes
+
   val tests: Tests = Tests {
     test("diff") - {
       def run() = integrationTest { tester =>
@@ -46,32 +54,29 @@ object ReproducibilityTests extends UtestIntegrationTestSuite {
 
     test("inspection") - {
       def run() = integrationTest { tester =>
-        tester.eval(
-          ("--meta-level", "1", "runClasspath"),
-          env = Map("MILL_TEST_TEXT_ANALYSIS_STORE" -> "1"),
-          check = true
-        )
+        tester.eval(("--meta-level", "1", "runClasspath"), check = true)
+        tester.eval("javaApp.run", check = true)
+        tester.eval("javaApp.assembly", check = true)
+        tester.eval("scalaApp.run", check = true)
+        tester.eval("scalaApp.assembly", check = true)
+        tester.eval("kotlinApp.run", check = true)
+        tester.eval("kotlinApp.assembly", check = true)
         tester.workspacePath
       }
 
       val workspacePath = run()
-      val dest = workspacePath / "out/mill-build/compile.dest/zinc.txt"
-      val src = workspacePath / "out/mill-build/compile.dest/zinc"
-      os.write(dest, new GZIPInputStream(os.read.inputStream(src)))
       normalize(workspacePath)
-      for (p <- os.walk(workspacePath)) {
-        if (
-          (p.ext == "json" || p.ext == "txt")
-          && !p.segments.contains("enablePluginScalacOptions.super")
-          && !p.segments.contains("allScalacOptions.json")
-          && !p.segments.contains("scalacOptions.json")
-          && p.last != "coursierEnv.json"
-        ) {
-          val txt = os.read(p)
-          Predef.assert(!txt.contains(BuildCtx.workspaceRoot.toString), p)
-          Predef.assert(!txt.contains(os.home.toString), p)
-        }
+
+      val ws = BuildCtx.workspaceRoot.toString.getBytes("UTF-8")
+      val hm = os.home.toString.getBytes("UTF-8")
+      val leaks = collection.mutable.Buffer.empty[String]
+      for (p <- os.walk(workspacePath / "out", followLinks = false) if os.isFile(p)) {
+        val bytes = gunzipIfNeeded(os.read.bytes(p))
+        val sub = p.subRelativeTo(workspacePath)
+        if (bytes.containsSlice(ws)) leaks.append(s"[WS] $sub")
+        else if (bytes.containsSlice(hm)) leaks.append(s"[HM] $sub")
       }
+      Predef.assert(leaks.isEmpty, leaks.mkString("\n"))
     }
   }
 }

--- a/integration/package.mill
+++ b/integration/package.mill
@@ -67,6 +67,25 @@ object `package` extends mill.Module {
     }
   }
 
+  /**
+   * Download (once, cached as a `PathRef`) the real `bazel-remote` release binary for the current
+   * platform, so the `reproducibility` integration test can exercise the Bazel-remote HTTP cache
+   * protocol against a genuine server rather than re-downloading it on every test run.
+   */
+  def bazelRemote = Task {
+    val version = "2.6.1"
+    val osName = System.getProperty("os.name").toLowerCase
+    val osArch = System.getProperty("os.arch").toLowerCase
+    val arch = if (osArch.contains("aarch64") || osArch.contains("arm")) "arm64" else "amd64"
+    val os0 = if (osName.contains("mac") || osName.contains("darwin")) "darwin" else "linux"
+    val url =
+      s"https://github.com/buchgr/bazel-remote/releases/download/v$version/bazel-remote-$version-$os0-$arch"
+    val dest = Task.dest / "bazel-remote"
+    os.proc("curl", "-sL", "--fail", "-o", dest, url).call()
+    os.perms.set(dest, "rwxr-xr-x")
+    PathRef(dest)
+  }
+
   case class SharedWorkerInfo(outPath: os.Path, port: Int)
 
   def millVersionNoSelective = Task(selectiveInputs = Nil) {
@@ -243,6 +262,11 @@ object `package` extends mill.Module {
   trait DedicatedIntegrationCrossModule extends IntegrationCrossModule {
     override def testForked(args: String*): Task.Command[(msg: String, results: Seq[TestResult])] =
       Task.Command(selectiveInputs = selectiveInputs) { proguard.daemon.testForked0(args*)() }
+    override def forkEnv = Task {
+      super.forkEnv() ++ Option.when(crossValue == "reproducibility")(
+        "MILL_TEST_BAZEL_REMOTE" -> bazelRemote().path.toString
+      )
+    }
   }
   trait MultimodeIntegrationCrossModule extends IntegrationCrossModule {
     override def testForked(args: String*): Task.Command[(msg: String, results: Seq[TestResult])] =

--- a/libs/javalib/src/mill/javalib/Assembly.scala
+++ b/libs/javalib/src/mill/javalib/Assembly.scala
@@ -5,7 +5,7 @@ import mill.util.JarManifest
 import os.Generator
 
 import java.io.{ByteArrayInputStream, InputStream, SequenceInputStream}
-import java.nio.file.attribute.PosixFilePermission
+import java.nio.file.attribute.{BasicFileAttributeView, FileTime, PosixFilePermission}
 import java.nio.file.StandardOpenOption
 import java.util.Collections
 import java.util.jar.JarFile
@@ -31,6 +31,36 @@ object Assembly {
   )
 
   val defaultSeparator = ""
+
+  /**
+   * Fixed timestamp stamped onto every assembly jar entry so the jar is byte-for-byte reproducible.
+   * The JDK zip filesystem otherwise records the current wall-clock time on each entry. `2010-01-01`
+   * (UTC) is an arbitrary constant above the 1980 DOS-time floor.
+   */
+  val fixedEntryTime: FileTime = FileTime.fromMillis(1262304000000L)
+
+  /**
+   * Stamp every entry under the open jar filesystem `zipRoot` with [[fixedEntryTime]], making the
+   * jar byte-for-byte reproducible. The JDK zip filesystem otherwise records the current wall-clock
+   * time (modification, access, and creation, the latter two via an extended-timestamp extra field)
+   * on each entry and on the directories it lazily creates.
+   *
+   * Two quirks of the JDK zip filesystem dictate the approach:
+   *   - all three times must be pinned, not just the modification time, or the access/creation
+   *     times in the extended-timestamp extra field still vary between builds; and
+   *   - directory entries must be stamped last, since setting a directory's time corrupts the
+   *     filesystem's internal index and makes a subsequent `setTimes` on any entry throw.
+   */
+  def normalizeJarTimestamps(zipRoot: os.Path): Unit = {
+    def setTimes(p: os.Path): Unit =
+      java.nio.file.Files.getFileAttributeView(p.toNIO, classOf[BasicFileAttributeView])
+        .setTimes(fixedEntryTime, fixedEntryTime, fixedEntryTime)
+
+    val (dirs, files) = os.walk(zipRoot).partition(os.isDir(_))
+    files.foreach(setTimes)
+    // Deepest directories first; see the second quirk above.
+    dirs.sortBy(_.segmentCount).reverse.foreach(setTimes)
+  }
 
   sealed trait Rule extends Product with Serializable
   object Rule {
@@ -223,6 +253,9 @@ object Assembly {
       } finally {
         resourceCleaner()
       }
+
+      // Normalize entry timestamps so the jar is byte-for-byte reproducible.
+      Assembly.normalizeJarTimestamps(zipRoot)
     }
 
     // Prepend shell script and make it executable

--- a/libs/javalib/src/mill/javalib/CoursierConfigModule.scala
+++ b/libs/javalib/src/mill/javalib/CoursierConfigModule.scala
@@ -75,6 +75,10 @@ trait CoursierConfigModule extends Module {
     private def readFrom(env: Map[String, String], props: Map[String, String]): EnvValues =
       EnvValues(env.get(entry.envName), props.get(entry.propName))
 
+  // `coursierEnv` derives from this, so a `COURSIER_REPOSITORIES` `file://` repo path doesn't leak.
+  private given upickle.ReadWriter[Map[String, String]] =
+    mill.api.JsonFormatters.aliasedStringMapRW
+
   /**
    * Environment variables and Java properties, and their values, used by coursier
    */

--- a/libs/javalib/src/mill/javalib/RunModule.scala
+++ b/libs/javalib/src/mill/javalib/RunModule.scala
@@ -35,6 +35,10 @@ trait RunModule extends WithJvmWorkerModule with RunModuleApi {
    */
   def forkArgs: T[Seq[String]] = Task { Seq.empty[String] }
 
+  // So the env tasks below don't leak absolute `PATH` entries into `out/`.
+  private given upickle.ReadWriter[Map[String, String]] =
+    mill.api.JsonFormatters.aliasedStringMapRW
+
   /**
    * Any environment variables you want to pass to the forked JVM.
    */
@@ -43,10 +47,11 @@ trait RunModule extends WithJvmWorkerModule with RunModuleApi {
   /**
    * Environment variables to pass to the forked JVM.
    *
-   * Includes [[forkEnv]] and the variables defined by Mill itself.
+   * Includes [[forkEnv]] and the variables defined by Mill itself. Mill's path-relativization vars
+   * are not cached here; they are added to the process environment at fork time (see [[run]]).
    */
   def allForkEnv: T[Map[String, String]] = Task {
-    javaHomePathForkEnv() ++ forkEnv() ++ PathAliasing.workspaceEnvVars(env = Task.env)
+    javaHomePathForkEnv() ++ forkEnv()
   }
 
   def javaHomePathForkEnv: T[Map[String, String]] = Task {
@@ -393,7 +398,7 @@ object RunModule {
             mainClass = mainClass1,
             classPath = classPath,
             jvmArgs = jvmArgs,
-            env = (if (propEnv) ctx.env else Map()) ++ env,
+            env = (if (propEnv) ctx.env else PathAliasing.workspaceEnvVars(env = ctx.env)) ++ env,
             mainArgs = mainArgs,
             cwd = cwd,
             stdin = "",
@@ -409,7 +414,7 @@ object RunModule {
             mainClass = mainClass1,
             classPath = classPath,
             jvmArgs = jvmArgs,
-            env = (if (propEnv) ctx.env else Map()) ++ env,
+            env = (if (propEnv) ctx.env else PathAliasing.workspaceEnvVars(env = ctx.env)) ++ env,
             mainArgs = mainArgs,
             cwd = cwd,
             cpPassingJarPath = cpPassingJarPath,

--- a/libs/javalib/src/mill/javalib/RunModule.scala
+++ b/libs/javalib/src/mill/javalib/RunModule.scala
@@ -47,11 +47,16 @@ trait RunModule extends WithJvmWorkerModule with RunModuleApi {
   /**
    * Environment variables to pass to the forked JVM.
    *
-   * Includes [[forkEnv]] and the variables defined by Mill itself. Mill's path-relativization vars
-   * are not cached here; they are added to the process environment at fork time (see [[run]]).
+   * Includes [[forkEnv]] and the variables defined by Mill itself. `MILL_WORKSPACE_ROOT` is cached
+   * here (aliased to `../mill-workspace`, so `out/` stays reproducible) so `run`/`test` subprocesses
+   * — and BSP clients launching them — can locate the workspace. The os-lib path-relativizer var is
+   * *not* cached (its `abs,alias;…` value can't round-trip through aliasing losslessly); it is added
+   * to the process environment fresh at fork time instead (see [[run]]).
    */
   def allForkEnv: T[Map[String, String]] = Task {
-    javaHomePathForkEnv() ++ forkEnv()
+    val workspaceRoot = PathAliasing.workspaceEnvVars(env = Task.env)
+      .view.filterKeys(_ == mill.constants.EnvVars.MILL_WORKSPACE_ROOT).toMap
+    javaHomePathForkEnv() ++ forkEnv() ++ workspaceRoot
   }
 
   def javaHomePathForkEnv: T[Map[String, String]] = Task {

--- a/libs/javalib/src/mill/javalib/RunModule.scala
+++ b/libs/javalib/src/mill/javalib/RunModule.scala
@@ -47,16 +47,14 @@ trait RunModule extends WithJvmWorkerModule with RunModuleApi {
   /**
    * Environment variables to pass to the forked JVM.
    *
-   * Includes [[forkEnv]] and the variables defined by Mill itself. `MILL_WORKSPACE_ROOT` is cached
-   * here (aliased to `../mill-workspace`, so `out/` stays reproducible) so `run`/`test` subprocesses
-   * — and BSP clients launching them — can locate the workspace. The os-lib path-relativizer var is
-   * *not* cached (its `abs,alias;…` value can't round-trip through aliasing losslessly); it is added
-   * to the process environment fresh at fork time instead (see [[run]]).
+   * Includes [[forkEnv]] and the variables defined by Mill itself, including the workspace-root and
+   * os-lib path-relativizer vars so `run`/`test` subprocesses — and third-party BSP clients
+   * (IntelliJ, VS Code) that launch the process themselves off this env — can locate the workspace
+   * and load relativized paths. Their absolute paths serialize to the `../mill-workspace`/
+   * `../mill-home` aliases, so `out/` stays reproducible.
    */
   def allForkEnv: T[Map[String, String]] = Task {
-    val workspaceRoot = PathAliasing.workspaceEnvVars(env = Task.env)
-      .view.filterKeys(_ == mill.constants.EnvVars.MILL_WORKSPACE_ROOT).toMap
-    javaHomePathForkEnv() ++ forkEnv() ++ workspaceRoot
+    javaHomePathForkEnv() ++ forkEnv() ++ PathAliasing.workspaceEnvVars()
   }
 
   def javaHomePathForkEnv: T[Map[String, String]] = Task {
@@ -403,7 +401,7 @@ object RunModule {
             mainClass = mainClass1,
             classPath = classPath,
             jvmArgs = jvmArgs,
-            env = (if (propEnv) ctx.env else PathAliasing.workspaceEnvVars(env = ctx.env)) ++ env,
+            env = (if (propEnv) ctx.env else Map()) ++ env,
             mainArgs = mainArgs,
             cwd = cwd,
             stdin = "",
@@ -419,7 +417,7 @@ object RunModule {
             mainClass = mainClass1,
             classPath = classPath,
             jvmArgs = jvmArgs,
-            env = (if (propEnv) ctx.env else PathAliasing.workspaceEnvVars(env = ctx.env)) ++ env,
+            env = (if (propEnv) ctx.env else Map()) ++ env,
             mainArgs = mainArgs,
             cwd = cwd,
             cpPassingJarPath = cpPassingJarPath,

--- a/libs/javalib/src/mill/javalib/TestModule.scala
+++ b/libs/javalib/src/mill/javalib/TestModule.scala
@@ -316,6 +316,10 @@ trait TestModule
    */
   def testSandboxWorkingDir: T[Boolean] = true
 
+  // As `RunModule`, so the absolute `MILL_TEST_RESOURCE_DIR` added below doesn't leak into `out/`.
+  private given upickle.ReadWriter[Map[String, String]] =
+    mill.api.JsonFormatters.aliasedStringMapRW
+
   override def allForkEnv: T[Map[String, String]] = Task {
     super.allForkEnv() ++ Map(
       // `Jvm.realAbs`: test code does `os.Path(sys.env("MILL_TEST_RESOURCE_DIR"))` — the

--- a/libs/javalib/src/mill/javalib/TestModuleUtil.scala
+++ b/libs/javalib/src/mill/javalib/TestModuleUtil.scala
@@ -165,7 +165,7 @@ final class TestModuleUtil(
         mainClass = "mill.javalib.testrunner.entrypoint.MillTestRunnerMain",
         classPath = (runClasspath ++ testrunnerEntrypointClasspath).map(_.path),
         jvmArgs = jvmArgs,
-        env = inheritedEnv ++ forkEnv ++ PathAliasing.workspaceEnvVars(env = inheritedEnv),
+        env = inheritedEnv ++ forkEnv,
         mainArgs = Seq(testRunnerClasspathArg, argsFile.wrapped.toString),
         cwd = if (testSandboxWorkingDir) sandbox else forkWorkingDir,
         cpPassingJarPath = Option.when(useArgsFile)(

--- a/libs/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/libs/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -215,11 +215,18 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase
    * In most cases, instead of overriding this task you want to override `scalacOptions` instead.
    */
   def allScalacOptions: T[Seq[String]] = Task {
-    // Record source paths relative to the workspace (the `../mill-workspace` alias) so Scala 3
-    // doesn't embed absolute paths in TASTY.
-    val sourceRoot =
-      Option.when(isDottyOrScala3(scalaVersion()))(s"-sourceroot:${BuildCtx.workspaceRoot}")
-    mandatoryScalacOptions() ++ enablePluginScalacOptions() ++ scalacOptions() ++ sourceRoot
+    mandatoryScalacOptions() ++ enablePluginScalacOptions() ++ scalacOptions()
+  }
+
+  /**
+   * The `-sourceroot` option that makes Scala 3 record workspace-relative source paths in TASTY, so
+   * the compiled `out/` is reproducible. Injected directly into the compiler invocation rather than
+   * [[allScalacOptions]], so the `../mill-workspace` alias path doesn't leak into the scalac options
+   * Mill reports to IDE/doc tooling (BSP, IntelliJ via `GenIdea`, scaladoc), where that alias is
+   * wrong or changes generated output.
+   */
+  private[mill] def tastyReproducibilityScalacOptions: T[Seq[String]] = Task {
+    Option.when(isDottyOrScala3(scalaVersion()))(s"-sourceroot:${BuildCtx.workspaceRoot}").toSeq
   }
 
   /**
@@ -354,7 +361,7 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase
         javacOptions = jOpts.compiler,
         scalaVersion = sv,
         scalaOrganization = scalaOrganization0(sv),
-        scalacOptions = allScalacOptions(),
+        scalacOptions = allScalacOptions() ++ tastyReproducibilityScalacOptions(),
         compilerClasspath = scalaCompilerClasspath(),
         scalacPluginClasspath = scalacPluginClasspath(),
         compilerBridgeOpt = scalaCompilerBridge(),

--- a/libs/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/libs/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -215,7 +215,11 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase
    * In most cases, instead of overriding this task you want to override `scalacOptions` instead.
    */
   def allScalacOptions: T[Seq[String]] = Task {
-    mandatoryScalacOptions() ++ enablePluginScalacOptions() ++ scalacOptions()
+    // Record source paths relative to the workspace (the `../mill-workspace` alias) so Scala 3
+    // doesn't embed absolute paths in TASTY.
+    val sourceRoot =
+      Option.when(isDottyOrScala3(scalaVersion()))(s"-sourceroot:${BuildCtx.workspaceRoot}")
+    mandatoryScalacOptions() ++ enablePluginScalacOptions() ++ scalacOptions() ++ sourceRoot
   }
 
   /**

--- a/libs/scalalib/src/mill/scalalib/UnidocModule.scala
+++ b/libs/scalalib/src/mill/scalalib/UnidocModule.scala
@@ -74,21 +74,21 @@ trait UnidocModule extends ScalaModule {
     ) ++
       unidocVersion().toSeq.flatMap(Seq("-doc-version", _)) ++
       unidocSourceUrl().toSeq.flatMap { url =>
-        val sourceLinksOption = if (onScala3) "-source-links" else "-doc-source-url"
-
-        if (local) Seq(
-          sourceLinksOption,
-          "file://€{FILE_PATH_EXT}"
-        )
-        else {
-          val workspaceRoot = BuildCtx.workspaceRoot
+        val workspaceRoot = BuildCtx.workspaceRoot
+        if (onScala3) {
+          // Scala 3 records source paths in TASTY relative to the compile-time `-sourceroot` (the
+          // workspace, for a reproducible `out/`); give scaladoc the same root so `€{FILE_PATH_EXT}`
+          // is the workspace-relative source path, then build the link from it: an absolute
+          // `file://` URL for local docs, or the remote base URL for a published site.
           Seq(
-            sourceLinksOption,
-            // Relative path to the workspace
-            if (onScala3) s"$workspaceRoot=$url€{FILE_PATH_EXT}" else s"$url€{FILE_PATH_EXT}",
-            "-sourcepath",
-            workspaceRoot.toString
+            s"-sourceroot:$workspaceRoot",
+            "-source-links",
+            if (local) s"file://$workspaceRoot€{FILE_PATH_EXT}" else s"$url€{FILE_PATH_EXT}"
           )
+        } else if (local) {
+          Seq("-doc-source-url", "file://€{FILE_PATH_EXT}")
+        } else {
+          Seq("-doc-source-url", s"$url€{FILE_PATH_EXT}", "-sourcepath", workspaceRoot.toString)
         }
       } ++ unidocOptions()
 

--- a/libs/scalalib/test/src/mill/scalalib/UnidocTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/UnidocTests.scala
@@ -47,7 +47,6 @@ object UnidocTests extends TestSuite {
         val task = if (site) module.docs.unidocSite else module.docs.unidocLocal
         val Right(_) = eval.apply(task).runtimeChecked
         val dest = eval.outPath / "docs" / (if (site) "unidocSite.dest" else "unidocLocal.dest")
-        val sandbox = os.pwd
 
         def fixWindowsPath(path: String) =
           if (Properties.isWin) path.replace("\\", "/")
@@ -57,7 +56,9 @@ object UnidocTests extends TestSuite {
           if (site) "https://github.com/test-org/my-app/blob/main"
           else {
             fixWindowsPath(
-              if (isScala3) s"file://${module.moduleDir.toString.replace(sandbox.toString, "")}"
+              // Scala 3 source links are absolute `file://` URLs rooted at the workspace (so the
+              // TASTY-recorded source paths stay workspace-relative and `out/` reproducible).
+              if (isScala3) s"file://${module.moduleDir}"
               else module.moduleDir.toString
             )
           }

--- a/runner/launcher/src/mill/launcher/MillLauncherMain.scala
+++ b/runner/launcher/src/mill/launcher/MillLauncherMain.scala
@@ -73,7 +73,7 @@ object MillLauncherMain {
       // path relativizer so cached output paths serialize via the `out/mill-workspace` /
       // `out/mill-home` aliases. These env vars contribute to the daemon's restart fingerprint,
       // so an existing daemon restarts when the user's workspace changes.
-      val workspaceEnv = PathAliasing.workspaceEnvVars(workDir, effectiveEnv)
+      val workspaceEnv = PathAliasing.workspaceEnvVars(workDir)
       val scopedEnv = effectiveEnv ++ workspaceEnv
 
       try {

--- a/runner/launcher/src/mill/launcher/MillProcessLauncher.scala
+++ b/runner/launcher/src/mill/launcher/MillProcessLauncher.scala
@@ -138,7 +138,7 @@ object MillProcessLauncher {
     // Inheriting parent values causes nested Mill runs to lock/use the parent's out folder.
     val mergedJdkJavaOpts =
       Seq(env.getOrElse("JDK_JAVA_OPTIONS", ""), env.getOrElse("JAVA_OPTS", "")).mkString(" ").trim
-    val workspaceEnv = PathAliasing.workspaceEnvVars(workDir, env)
+    val workspaceEnv = PathAliasing.workspaceEnvVars(workDir)
     val processEnv = env ++ workspaceEnv ++ Seq(
       Some(EnvVars.MILL_ENABLE_STATIC_CHECKS -> "true"),
       Option.unless(env.contains(EnvVars.MILL_EXECUTABLE_PATH))(

--- a/runner/meta/src/mill/meta/MillBuildRootModule.scala
+++ b/runner/meta/src/mill/meta/MillBuildRootModule.scala
@@ -312,7 +312,7 @@ trait MillBuildRootModule()(using rootModuleInfo: RootModule.Info) extends Boots
           javacOptions = jOpts.compiler,
           scalaVersion = scalaVersion(),
           scalaOrganization = JvmWorkerUtil.scalaOrganization(scalaVersion()),
-          scalacOptions = allScalacOptions(),
+          scalacOptions = allScalacOptions() ++ tastyReproducibilityScalacOptions(),
           compilerClasspath = scalaCompilerClasspath(),
           scalacPluginClasspath = scalacPluginClasspath(),
           compilerBridgeOpt = scalaCompilerBridge(),


### PR DESCRIPTION
Follow up for https://github.com/com-lihaoyi/mill/pull/4642, mostly just tightening up ReproducibilityTests.scala 

Removed the hacky OS_LIB_PATH_RELATIVIZER_BASE management with a formal `ignoreErrorsOnCI‎
` until the fix can land upstream  https://github.com/joan38/mill-scalafix/pull/261