### PR TITLE
Fix concurrency/caching/locking issues from multi-agent review

### DIFF
--- a/core/eval/src/mill/eval/SelectiveExecutionImpl.scala
+++ b/core/eval/src/mill/eval/SelectiveExecutionImpl.scala
@@ -16,10 +16,25 @@ class SelectiveExecutionImpl(evaluator: Evaluator)
       transitiveNamed: Seq[Task.Named[?]],
       codeSignatures: Map[String, Int]
   ): Map[String, Int] = {
-
     val (classToTransitiveClasses, allTransitiveClassMethods) =
       CodeSigUtils.precomputeMethodNamesPerClass(transitiveNamed)
+    computeHashCodeSignatures0(
+      transitiveNamed,
+      classToTransitiveClasses,
+      allTransitiveClassMethods,
+      codeSignatures
+    )
+  }
 
+  // The method-name table (`classToTransitiveClasses`/`allTransitiveClassMethods`) is a
+  // reflective function of `transitiveNamed` alone, so callers that diff two `codeSignatures`
+  // maps over the same `transitiveNamed` precompute it once and reuse it across both calls.
+  private def computeHashCodeSignatures0(
+      transitiveNamed: Seq[Task.Named[?]],
+      classToTransitiveClasses: Map[Class[?], IndexedSeq[Class[?]]],
+      allTransitiveClassMethods: Map[Class[?], Map[String, java.lang.reflect.Method]],
+      codeSignatures: Map[String, Int]
+  ): Map[String, Int] = {
     lazy val constructorHashSignatures = CodeSigUtils
       .constructorHashSignatures(codeSignatures)
 
@@ -85,9 +100,23 @@ class SelectiveExecutionImpl(evaluator: Evaluator)
         }
 
         val changedInputNames = diffMap(oldHashes.inputHashes, newHashes.inputHashes)
+        // Precompute the reflection-heavy method-name table once: it depends only on
+        // `transitiveNamed`, so reuse it for both the old and new `codeSignatures` diff.
+        val (classToTransitiveClasses, allTransitiveClassMethods) =
+          CodeSigUtils.precomputeMethodNamesPerClass(transitiveNamed)
         val changedCodeNames = diffMap(
-          computeHashCodeSignatures(transitiveNamed, oldHashes.codeSignatures),
-          computeHashCodeSignatures(transitiveNamed, newHashes.codeSignatures)
+          computeHashCodeSignatures0(
+            transitiveNamed,
+            classToTransitiveClasses,
+            allTransitiveClassMethods,
+            oldHashes.codeSignatures
+          ),
+          computeHashCodeSignatures0(
+            transitiveNamed,
+            classToTransitiveClasses,
+            allTransitiveClassMethods,
+            newHashes.codeSignatures
+          )
         )
         val changedBuildOverrides = diffMap(
           oldHashes.buildOverrideSignatures,

--- a/core/exec/src/mill/exec/BazelRemoteCache.scala
+++ b/core/exec/src/mill/exec/BazelRemoteCache.scala
@@ -61,7 +61,9 @@ private[mill] object BazelRemoteCache {
   ): Unit = mill.api.BuildCtx.withFilesystemCheckerDisabled {
     // Cache I/O is trusted framework I/O that legitimately writes outside the task's `dest/`.
     val backend = Backend.forLocation(location, workspace)
-    val blobFile = os.temp(prefix = "mill-remote-cache-", deleteOnExit = true)
+    // `deleteOnExit = false`: the `finally os.remove(blobFile)` below already removes it on every
+    // path; a per-blob JVM shutdown hook would otherwise leak in a long-lived daemon.
+    val blobFile = os.temp(prefix = "mill-remote-cache-", deleteOnExit = false)
     try {
       val digest = MessageDigest.getInstance("SHA-256")
       val out = new DigestOutputStream(os.write.outputStream(blobFile), digest)
@@ -105,8 +107,20 @@ private[mill] object BazelRemoteCache {
                   // Wipe stale `dest/` only on a hit; a miss keeps it so a persistent task reuses
                   // its state.
                   if (os.exists(paths.dest)) os.remove.all(paths.dest)
-                  try readBlob(paths, is)
-                  finally is.close()
+                  try {
+                    try readBlob(paths, is)
+                    finally is.close()
+                  } catch {
+                    case NonFatal(e) =>
+                      // A mid-stream download failure has left `dest/` partially unpacked. The
+                      // outer `catch` returns a miss (recompute), but the recompute path skips
+                      // re-deleting a *persistent* task's `dest/` — so empty it here to hand the
+                      // task body a clean dest. This discards a persistent task's prior
+                      // incremental state, which is acceptable since the hit above already wiped
+                      // it.
+                      if (os.exists(paths.dest)) os.remove.all(paths.dest)
+                      throw e
+                  }
                   true
               }
           }
@@ -271,6 +285,12 @@ private[mill] object BazelRemoteCache {
       val p = path(key)
       Option.when(os.exists(p))(os.read.inputStream(p))
     }
+    // A torn read of these entries (truncated CAS blob or AC protobuf) is already handled
+    // downstream: the CAS blob is written before the AC entry that references it, gzip's CRC32
+    // and `transferN`'s EOF check reject a partial blob, and a partial AC fails to decode — all of
+    // which surface as a cache miss and a clean recompute (never corruption), so a plain overwrite
+    // is sufficient. (An atomic temp+rename was tried but gave temp files restrictive `0600` perms,
+    // breaking cross-user reads on the shared-folder backend it was meant to help.)
     def putFile(key: String, file: os.Path): Boolean = {
       os.copy.over(file, path(key), createFolders = true)
       true

--- a/core/exec/src/mill/exec/Execution.scala
+++ b/core/exec/src/mill/exec/Execution.scala
@@ -237,8 +237,7 @@ case class Execution(
         s"$completedMsg$keySuffix$extraKeySuffix${Execution.formatFailedCount(rootFailedCount.get(), completed, logger.prompt.errorColor, logger.prompt.successColor)}"
       }
 
-      val tasksTransitive =
-        PlanImpl.transitiveTasks(Seq.from(indexToTerminal), effectiveInputs).toSet
+      val tasksTransitive = plan.transitive.toSet
       val downstreamEdges: Map[Task[?], Set[Task[?]]] =
         tasksTransitive.flatMap(t => effectiveInputs(t).map(_ -> t)).groupMap(_._1)(_._2)
 
@@ -829,7 +828,10 @@ object Execution {
           )
       }
       out.addOne(
-        terminal -> deps.toVector.sortBy(t => terminalOrder.getOrElse(t, Int.MaxValue))
+        // Every dep is a `Task.Named` (asserted above) and, under the sole caller, a
+        // grouping cut point, so it is always a `terminalOrder` key; index directly so a
+        // real grouping inconsistency throws loudly rather than sorting an unknown dep last.
+        terminal -> deps.toVector.sortBy(t => terminalOrder(t))
       )
     }
     out.result()

--- a/core/exec/src/mill/exec/ExecutionContexts.scala
+++ b/core/exec/src/mill/exec/ExecutionContexts.scala
@@ -24,6 +24,14 @@ object ExecutionContexts {
     def close(): Unit = () // do nothing
 
     def blocking[T](t: => T): T = t
+    // Under `--jobs=1`, `Fork.async` routes here and runs the body inline on the
+    // parent thread, sharing the parent's `os.pwd` and system streams. Unlike
+    // `ThreadPool.async`, this does NOT relocate `os.pwd` into the `dest` sandbox
+    // folder, does NOT materialize `dest`, and does NOT write a per-future
+    // `dest.log` or add a terminal prompt line. The pwd-sandbox-in-`dest` +
+    // per-future `dest.log` contract documented on [[mill.api.TaskCtx.Fork.async]]
+    // is therefore not honored here; only the value of the body is surfaced
+    // through the returned `Future`.
     def async[T](dest: Path, key: String, message: String, priority: Int)(t: Logger => T)(using
         ctx: mill.api.TaskCtx
     ): Future[T] =
@@ -74,6 +82,7 @@ object ExecutionContexts {
       // context which submitted it
       val submitterPwd = os.dynamicPwdFunction.value
       val submitterChecker = os.checker.value
+      val submitterSpawnHook = os.ProcessOps.spawnHook.value
       val submitterStreams = new mill.api.SystemStreams(Console.out, Console.err, System.in)
       val submitterModuleWatched = mill.api.BuildCtx.watchedValues0.value
       val submitterEvalWatched = mill.api.BuildCtx.evalWatchedValues0.value
@@ -82,10 +91,12 @@ object ExecutionContexts {
         () =>
           os.checker.withValue(submitterChecker) {
             os.dynamicPwdFunction.withValue(() => submitterPwd()) {
-              mill.api.SystemStreamsUtils.withStreams(submitterStreams) {
-                mill.api.BuildCtx.watchedValues0.withValue(submitterModuleWatched) {
-                  mill.api.BuildCtx.evalWatchedValues0.withValue(submitterEvalWatched) {
-                    runnable.run()
+              os.ProcessOps.spawnHook.withValue(submitterSpawnHook) {
+                mill.api.SystemStreamsUtils.withStreams(submitterStreams) {
+                  mill.api.BuildCtx.watchedValues0.withValue(submitterModuleWatched) {
+                    mill.api.BuildCtx.evalWatchedValues0.withValue(submitterEvalWatched) {
+                      runnable.run()
+                    }
                   }
                 }
               }
@@ -113,7 +124,12 @@ object ExecutionContexts {
       )
 
       var destInitialized: Boolean = false
-      def makeDest() = synchronized {
+      // Lock on a fresh per-`async`-call object rather than on `this`: a single
+      // `ThreadPool` is shared by all forked bodies in an evaluation, so locking
+      // on `this` would couple unrelated tasks' `makeDest` calls. Mirrors
+      // `GroupExecution.DestCreator.makeDest`, which locks its own instance.
+      val destLock = new Object()
+      def makeDest() = destLock.synchronized {
         if (!destInitialized) {
           os.makeDir.all(dest)
           destInitialized = true
@@ -122,6 +138,7 @@ object ExecutionContexts {
         dest
       }
       val submitterChecker = os.checker.value
+      val submitterSpawnHook = os.ProcessOps.spawnHook.value
       val submitterModuleWatched = mill.api.BuildCtx.watchedValues0.value
       val submitterEvalWatched = mill.api.BuildCtx.evalWatchedValues0.value
       val promise = concurrent.Promise[T]
@@ -131,10 +148,12 @@ object ExecutionContexts {
           val result = NonFatal.Try(logger.withPromptLine {
             os.checker.withValue(submitterChecker) {
               os.dynamicPwdFunction.withValue(() => makeDest()) {
-                mill.api.SystemStreamsUtils.withStreams(logger.streams) {
-                  mill.api.BuildCtx.watchedValues0.withValue(submitterModuleWatched) {
-                    mill.api.BuildCtx.evalWatchedValues0.withValue(submitterEvalWatched) {
-                      t(logger)
+                os.ProcessOps.spawnHook.withValue(submitterSpawnHook) {
+                  mill.api.SystemStreamsUtils.withStreams(logger.streams) {
+                    mill.api.BuildCtx.watchedValues0.withValue(submitterModuleWatched) {
+                      mill.api.BuildCtx.evalWatchedValues0.withValue(submitterEvalWatched) {
+                        t(logger)
+                      }
                     }
                   }
                 }

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -533,16 +533,22 @@ trait GroupExecution {
             // Remote-cache fallback on a local miss. We hold the Write lock, so materializing
             // `dest/`/`log`/`meta` is safe; a poisoned entry re-reads as a miss and is recomputed
             // by the `None` branch below.
+            // #7132: the remote-cache HTTP load does blocking network IO (connect/request
+            // timeouts, streaming multi-MB blobs) on a worker of the bounded execution pool;
+            // wrap it in `executionContext.blocking` so the pool spawns a compensating worker
+            // while parked, preventing pool starvation. Stays a `Boolean` for `.exists`.
             val remoteMaterialized =
               localReusable.isEmpty && remoteCacheTarget(labelled).exists { location =>
-                BazelRemoteCache.load(
-                  paths,
-                  inputsHash,
-                  labelled.ctx.segments.render,
-                  location,
-                  remoteCacheSalt,
-                  workspace
-                )
+                executionContext.blocking {
+                  BazelRemoteCache.load(
+                    paths,
+                    inputsHash,
+                    labelled.ctx.segments.render,
+                    location,
+                    remoteCacheSalt,
+                    workspace
+                  )
+                }
               }
 
             // After a remote materialization, re-read the now-present `meta.json` and reuse
@@ -617,16 +623,21 @@ trait GroupExecution {
                       val (valueHash, serializedPaths) =
                         handleTaskResult(v, paths.meta, inputsHash, labelled)
                       // Push freshly-computed outputs to the remote cache for other machines.
+                      // #7132: the upload does blocking network IO on a worker of the bounded
+                      // execution pool; wrap it in `executionContext.blocking` so the pool spawns
+                      // a compensating worker while parked, preventing pool starvation.
                       remoteCacheTarget(labelled).foreach { location =>
-                        BazelRemoteCache.store(
-                          paths,
-                          inputsHash,
-                          labelled.ctx.segments.render,
-                          location,
-                          remoteCacheSalt,
-                          serializedPaths,
-                          workspace
-                        )
+                        executionContext.blocking {
+                          BazelRemoteCache.store(
+                            paths,
+                            inputsHash,
+                            labelled.ctx.segments.render,
+                            location,
+                            remoteCacheSalt,
+                            serializedPaths,
+                            workspace
+                          )
+                        }
                       }
                       // Reuse `handleTaskResult`'s hash (derived from the JSON it writes) as the
                       // terminal's downstream value hash too — the `0` placeholder stored by

--- a/libs/daemon/client/src/mill/client/lock/DoubleLock.scala
+++ b/libs/daemon/client/src/mill/client/lock/DoubleLock.scala
@@ -44,11 +44,10 @@ class DoubleLock(lock1: Lock, lock2: Lock) extends Lock {
 
   override def probe(): Boolean = {
     val tl = tryLock()
-    if (!tl.isLocked) true
-    else {
+    if (tl.isLocked) {
       tl.release()
-      false
-    }
+      true
+    } else false
   }
 
   override def close(): Unit = {

--- a/libs/daemon/client/src/mill/client/lock/Lock.scala
+++ b/libs/daemon/client/src/mill/client/lock/Lock.scala
@@ -13,7 +13,6 @@ trait TryLocked extends Locked {
 abstract class Lock extends AutoCloseable {
   def lock(): Locked
   def tryLock(): TryLocked
-  def await(): Unit = lock().release()
 
   /** Returns `true` if the lock is available for taking. */
   def probe(): Boolean

--- a/libs/daemon/client/src/mill/client/lock/PidLock.scala
+++ b/libs/daemon/client/src/mill/client/lock/PidLock.scala
@@ -29,47 +29,63 @@ class PidLock(path: String) extends Lock {
   }
 
   override def tryLock(): TryLocked = {
+    val content = createLockContent()
     if (!isLockValid) {
-      tryDeleteLockFile()
+      // No live holder (dead/absent, or an empty/unparseable file): clear whatever is there and
+      // claim the lock with an atomic exclusive create. `CREATE_NEW` (`O_CREAT|O_EXCL`) is a
+      // kernel-atomic exclusive create, so only one of several racing acquirers can win.
+      forceDeleteLockFile()
       try {
-        // Use Java NIO with CREATE_NEW for atomic file creation
-        // This fails atomically if the file already exists
         val parent = lockPathNio.getParent
         if (parent != null) java.nio.file.Files.createDirectories(parent)
         java.nio.file.Files.write(
           lockPathNio,
-          createLockContent().getBytes(java.nio.charset.StandardCharsets.UTF_8),
+          content.getBytes(java.nio.charset.StandardCharsets.UTF_8),
           java.nio.file.StandardOpenOption.CREATE_NEW,
           java.nio.file.StandardOpenOption.WRITE
         )
-        PidTryLocked(Some(lockPath), locked = true)
+        PidTryLocked(Some(lockPath), content, locked = true)
       } catch {
         case _: java.nio.file.FileAlreadyExistsException =>
-          // Another process grabbed it - that's fine
-          PidTryLocked(None, locked = false)
+          // Another process created it between our check and create - that's fine
+          PidTryLocked(None, content, locked = false)
       }
     } else {
       // Lock is held by a living process
-      PidTryLocked(None, locked = false)
+      PidTryLocked(None, content, locked = false)
     }
   }
 
   override def probe(): Boolean = !isLockValid
 
-  override def close(): Unit = tryDeleteLockFile()
+  override def close(): Unit = releaseOwnLockFile()
 
   override def delete(): Unit = ()
 
   private def isLockValid: Boolean = {
     readLockInfo() match {
-      case None => false // Couldn't read lock info, treat as stale
-      case Some(info) =>
-        // Check if process is alive and started at the recorded time
-        ProcessHandle.of(info.pid)
-          .filter(_.isAlive)
-          .flatMap(_.info().startInstant())
-          .map(_.toEpochMilli == info.timestamp)
-          .orElse(false) // Process not found or no start time available = stale
+      case None => false // No valid lock present
+      case Some(info) => isHeldByLiveProcess(info)
+    }
+  }
+
+  /**
+   * Whether the process recorded in `info` is currently alive and holding the lock.
+   *
+   * Distinguishes "dead" from "start-time-unavailable": for a process owned by
+   * another user or running in a restricted container, `startInstant()` can be
+   * empty even though the process is alive. In that case we fall back to
+   * PID-only liveness rather than mis-classifying a live holder as stale (which
+   * is exactly PidLock's Docker-on-mac / cross-user target).
+   */
+  private def isHeldByLiveProcess(info: PidLock.LockInfo): Boolean = {
+    ProcessHandle.of(info.pid).filter(_.isAlive) match {
+      case h if h.isPresent =>
+        h.get().info().startInstant() match {
+          case start if start.isPresent => start.get().toEpochMilli == info.timestamp
+          case _ => true // alive but start time unavailable: PID-only fallback
+        }
+      case _ => false // process genuinely absent / not alive = stale
     }
   }
 
@@ -93,12 +109,24 @@ class PidLock(path: String) extends Lock {
     }
   }
 
-  private def tryDeleteLockFile(): Unit = {
+  /**
+   * Unconditionally delete the lock file. Used only to clean up a holder that
+   * has been POSITIVELY confirmed dead; must not be used for release/close.
+   */
+  private def forceDeleteLockFile(): Unit = {
     try os.remove(lockPath, checkExists = false)
     catch {
       case _: java.io.IOException => // Ignore - another process might have deleted it
     }
   }
+
+  /**
+   * Release our own lock by deleting the file only if it still records THIS
+   * process's content. If another process has since taken over, this is a
+   * no-op so we never delete a different live process's lock.
+   */
+  private def releaseOwnLockFile(): Unit =
+    PidLock.deleteIfOwned(lockPath, createLockContent())
 }
 
 private[lock] object PidLock {
@@ -106,11 +134,29 @@ private[lock] object PidLock {
     ProcessHandle.current().info().startInstant().get().toEpochMilli
 
   private case class LockInfo(pid: Long, timestamp: Long)
+
+  /**
+   * Delete the lock file only if its trimmed contents still equal `ownContent`,
+   * i.e. this process is still the recorded holder. A no-op if another process
+   * has taken over the lock in the meantime.
+   */
+  private[lock] def deleteIfOwned(lockPath: os.Path, ownContent: String): Unit = {
+    try {
+      if (os.exists(lockPath) && os.read(lockPath).trim == ownContent) {
+        os.remove(lockPath, checkExists = false)
+      }
+    } catch {
+      case _: java.io.IOException => // Ignore - another process might have deleted it
+    }
+  }
 }
 
-private[lock] class PidTryLocked(lockPath: Option[os.Path], locked: Boolean) extends TryLocked {
+private[lock] class PidTryLocked(lockPath: Option[os.Path], ownContent: String, locked: Boolean)
+    extends TryLocked {
   override def isLocked: Boolean = locked
   override def release(): Unit = {
-    if (locked) lockPath.foreach(p => os.remove(p, checkExists = false))
+    // Only remove the file if it still records THIS process's content, so a
+    // mis-classified takeover can never delete a different live process's lock.
+    if (locked) lockPath.foreach(p => PidLock.deleteIfOwned(p, ownContent))
   }
 }

--- a/runner/launcher/src/mill/launcher/MillServerLauncher.scala
+++ b/runner/launcher/src/mill/launcher/MillServerLauncher.scala
@@ -57,7 +57,12 @@ class MillServerLauncher(
       log(s"runWithConnection exit code: $result")
       result
     } finally {
+      // `launched.close()` closes the socket; `locks.close()` frees the file
+      // channels/handles eagerly opened by `Locks.forDirectory`, which the lock
+      // `release()`s do not. Guard each so a failure in one still attempts the other.
       try launched.close()
+      catch { case _: Exception => }
+      try locks.close()
       catch { case _: Exception => }
     }
   }


### PR DESCRIPTION

Remote (Bazel) cache (core/exec):
- [HIGH] Wrap BazelRemoteCache.load/store in executionContext.blocking so blocking
  HTTP IO no longer starves the bounded --jobs execution pool.
- Empty a persistent task's dest/ on a mid-stream download failure so a partial
  blob is never handed to the task body (the recompute guard skips re-deleting a
  persistent dest).
- store's temp blob uses deleteOnExit=false (the finally-remove already cleans it).

PidLock (libs/daemon/client) - the default out-folder/daemon lock:
- Ownership-checked release: a process deletes the lock file only when it still
  records that process's pid:startTime, so a takeover can't delete another live
  process's lock.
- Treat a live cross-user/containerized holder whose startInstant() is unavailable
  as valid (PID-only fallback) instead of stale, shared between tryLock/isLockValid.
  Acquisition keeps the original atomic CREATE_NEW exclusive create.

Daemon locking cleanups (libs/daemon/client, runner/launcher):
- MillServerLauncher closes Locks in finally (FileChannel/fd leak on retries).
- Remove unused racy Lock.await().
- Fix inverted DoubleLock.probe() polarity to match the Lock.probe() contract.

Selective execution / planning (core/eval, core/exec):
- Hoist precomputeMethodNamesPerClass so the reflective method-name table is
  computed once, not twice, per downstream code-signature diff.
- Use the existing Plan.transitive instead of recomputing the task closure.
- Index terminalOrder directly (drop the dead Int.MaxValue fallback).

ThreadPool execution context (core/exec):
- Scope async.makeDest to a per-call lock instead of the shared pool monitor.
- Propagate os.ProcessOps.spawnHook to forked pool threads.
- Document RunNow.async (--jobs=1) divergence from the Fork.async contract.

Found and adversarially re-reviewed via multi-agent review; two over-reaching fixes
were dropped: a non-atomic PidLock temp+move that worsened the acquire race and
could hang on a leftover empty lock file, and atomic FileBackend writes that gave
cache entries 0600 perms (breaking cross-user reads on the shared-folder backend).