### PR TITLE
Clarity/simplification cleanups from multi-agent review

### DIFF
--- a/core/api/java11/src/mill/api/internal/PathAliasing.scala
+++ b/core/api/java11/src/mill/api/internal/PathAliasing.scala
@@ -23,9 +23,9 @@ object PathAliasing {
     catch { case _: java.io.IOException => p }
 
   /**
-   * The standard Mill (abs, alias) mappings: `workspace -> ../mill-workspace`, `home -> ../mill-home`.
-   * Suitable for `os.Path.pathRemapSerializerNio` (after `.toNIO`-ing each side) and for
-   * [[ensureProcessCwdAliases]]'s symlink installation.
+   * The standard Mill (abs, alias) mappings (`workspace -> ../mill-workspace`, `home -> ../mill-home`)
+   * used by [[ensureProcessCwdAliases]] to install the `../mill-workspace` / `../mill-home`
+   * forwarder symlinks.
    */
   def defaultMapping(workspace: os.Path): Seq[(os.Path, os.RelPath)] = Seq(
     workspace -> (os.up / "mill-workspace"),
@@ -66,16 +66,6 @@ object PathAliasing {
 
   private def normalize(raw: String): String = raw.replace('\\', '/')
 
-  private def resolveFromAlias(
-      base: os.Path,
-      raw: String,
-      aliasIdx: Int,
-      alias: String
-  ): os.Path = {
-    val suffix = raw.substring(aliasIdx + alias.length).stripPrefix("/")
-    if (suffix.isEmpty) base else base / os.RelPath(suffix)
-  }
-
   def resolveAliasedString(
       rawInput: String,
       workspace: os.Path = BuildCtx.workspaceRoot,
@@ -86,15 +76,20 @@ object PathAliasing {
     else {
       val raw = normalize(rawInput)
       def fromAlias(raw: String, alias: String, base: os.Path): Option[os.Path] = {
+        // `base` plus the path suffix following the alias segment, with a leading separator
+        // stripped; an empty suffix resolves to `base` itself.
+        def resolve(suffix: String): os.Path = {
+          val rel = suffix.stripPrefix("/")
+          if (rel.isEmpty) base else base / os.RelPath(rel)
+        }
         if (raw == alias) Some(base)
-        else if (raw.startsWith(alias + "/")) Some(base / os.RelPath(raw.drop(alias.length + 1)))
+        else if (raw.startsWith(alias + "/")) Some(resolve(raw.drop(alias.length)))
         else {
           val needle = s"/$alias"
           val idx = raw.indexOf(needle)
           if (idx >= 0) {
             val suffix = raw.drop(idx + needle.length)
-            if (suffix.isEmpty || suffix.startsWith("/"))
-              Some(resolveFromAlias(base, raw, idx + 1, alias))
+            if (suffix.isEmpty || suffix.startsWith("/")) Some(resolve(suffix))
             else None
           } else None
         }

--- a/core/api/src/mill/api/Task.scala
+++ b/core/api/src/mill/api/Task.scala
@@ -493,7 +493,7 @@ object Task {
 
     def readWriterOpt: Option[upickle.ReadWriter[?]] = None
 
-    def writerOpt: Option[upickle.Writer[?]] = readWriterOpt.orElse(None)
+    def writerOpt: Option[upickle.Writer[?]] = readWriterOpt
   }
 
   class Computed[T](

--- a/core/eval/src/mill/eval/SelectiveExecutionImpl.scala
+++ b/core/eval/src/mill/eval/SelectiveExecutionImpl.scala
@@ -127,7 +127,7 @@ class SelectiveExecutionImpl(evaluator: Evaluator)
           (changedInputNames ++ changedCodeNames ++ changedBuildOverrides ++ oldHashes.forceRunTasks)
             .flatMap(namesToTasks.get(_): Option[Task[?]])
 
-        val allNodes = breadthFirst(transitiveNamed.map(t => t: Task[?]))(_.selectiveInputs)
+        val allNodes = breadthFirst(allTasks)(_.selectiveInputs)
         val downstreamEdgeMap =
           SpanningForest.reverseEdges(allNodes.map(t => (t, t.selectiveInputs)))
 

--- a/core/exec/src/mill/exec/BazelRemoteCache.scala
+++ b/core/exec/src/mill/exec/BazelRemoteCache.scala
@@ -346,13 +346,16 @@ private[mill] object BazelRemoteCache {
         .flatMap(firstString(_, DigestHash))
 
     private def firstMessage(bytes: Array[Byte], field: Int): Option[Array[Byte]] =
-      fields(bytes).collectFirst { case (`field`, WireLengthDelim, v) => v }
+      fields(bytes).collectFirst { case (`field`, v) => v }
 
     private def firstString(bytes: Array[Byte], field: Int): Option[String] =
       firstMessage(bytes, field).map(new String(_, "UTF-8"))
 
-    private def fields(bytes: Array[Byte]): List[(Int, Int, Array[Byte])] = {
-      val out = List.newBuilder[(Int, Int, Array[Byte])]
+    // Collects only length-delimited fields (the only wire type the ActionResult subset we read
+    // uses); varint/fixed32/fixed64 fields are skipped, so every collected entry is by
+    // construction WireLengthDelim and the wire type need not be stored.
+    private def fields(bytes: Array[Byte]): List[(Int, Array[Byte])] = {
+      val out = List.newBuilder[(Int, Array[Byte])]
       var pos = 0
       var continue = true
       while (continue && pos < bytes.length) {
@@ -365,7 +368,7 @@ private[mill] object BazelRemoteCache {
           case WireLengthDelim =>
             val (len, p2) = readVarint(bytes, p1)
             val end = math.min(p2 + len.toInt, bytes.length)
-            out += ((field, wire, bytes.slice(p2, end))); pos = end
+            out += ((field, bytes.slice(p2, end))); pos = end
           case 5 => pos = math.min(p1 + 4, bytes.length) // fixed32
           case 1 => pos = math.min(p1 + 8, bytes.length) // fixed64
           case _ => continue = false // groups (deprecated) or invalid

--- a/core/exec/src/mill/exec/Execution.scala
+++ b/core/exec/src/mill/exec/Execution.scala
@@ -427,10 +427,6 @@ case class Execution(
           if (haveGlobalExclusive) LauncherLocking.LockKind.Write
           else LauncherLocking.LockKind.Read
 
-        // Suspend any outer-batch exclusive lease this launcher already
-        // holds so a nested call (e.g. from `show`'s body invoking
-        // `Evaluator.execute`) can take its own without self-deadlocking on
-        // the non-reentrant underlying lock. No-op when nothing is held.
         val empty = Seq.empty[(Task[?], Option[GroupExecution.Results])]
 
         def runBatch(): (
@@ -448,6 +444,10 @@ case class Execution(
 
         val (nonExclusiveResults, exclusiveResults) =
           if (nonExclusiveTasks.isEmpty && !haveExclusive) (empty, empty)
+          // Suspend any outer-batch exclusive lease this launcher already
+          // holds so a nested call (e.g. from `show`'s body invoking
+          // `Evaluator.execute`) can take its own without self-deadlocking on
+          // the non-reentrant underlying lock. No-op when nothing is held.
           else workspaceLocking.withReleasedExclusive(batchWaitReporter)(
             withExclusiveLease(outerKind)(runBatch())
           )

--- a/core/exec/src/mill/exec/ExecutionLogs.scala
+++ b/core/exec/src/mill/exec/ExecutionLogs.scala
@@ -38,15 +38,7 @@ private object ExecutionLogs {
     val changedTasks = changedValueHash.keys().asScala.toSet
     val downstreamSources =
       if (changedTasks.isEmpty) Set.empty[Task[?]]
-      else {
-        val builder = Set.newBuilder[Task[?]]
-        for {
-          deps <- interGroupDeps.valuesIterator
-          dep <- deps
-          if changedTasks.contains(dep)
-        } builder += dep
-        builder.result()
-      }
+      else interGroupDeps.valuesIterator.flatten.filter(changedTasks.contains).toSet
 
     // Root invalidated tasks: uncached tasks that either cause downstream invalidations
     // or are non-input tasks (e.g. invalidated due to codesig change)

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -254,6 +254,18 @@ trait GroupExecution {
   val invalidateAllHashes = classLoaderSigHash + javaVersionHash
 
   /**
+   * The build-override entry for `named`, with static (YAML build-file) overrides taking
+   * precedence over dynamic (module-level) ones. `moduleDynamicBuildOverrides` is bound to a
+   * `val` so it is evaluated eagerly (it recomputes and can throw on a malformed header), which
+   * is what both call sites rely on.
+   */
+  private def buildOverrideFor(named: Task.Named[?]): Option[Located[Appendable[BufferedValue]]] = {
+    val segs = named.ctx.segments.render
+    val dynamicBuildOverride = named.ctx.enclosingModule.moduleDynamicBuildOverrides
+    staticBuildOverrides.get(segs).orElse(dynamicBuildOverride.get(segs))
+  }
+
+  /**
    * Returns the inputs Mill should walk for `task`. A `Task.Named` whose value
    * is supplied entirely by a non-`!append` YAML config override returns `Nil`,
    * because that override short-circuits the task body in
@@ -262,10 +274,7 @@ trait GroupExecution {
    */
   private[mill] def effectiveInputs(task: Task[?]): Seq[Task[?]] = task match {
     case named: Task.Named[?] =>
-      val segs = named.ctx.segments.render
-      val dynamicBuildOverride = named.ctx.enclosingModule.moduleDynamicBuildOverrides
-      val overrideOpt = staticBuildOverrides.get(segs).orElse(dynamicBuildOverride.get(segs))
-      overrideOpt match {
+      buildOverrideFor(named) match {
         case Some(located) if !located.value.append => Nil
         case _ => named.inputs
       }
@@ -327,9 +336,7 @@ trait GroupExecution {
       case labelled: Task.Named[_] =>
         val out = if (!labelled.ctx.external) outPath else externalOutPath
         val paths = ExecutionPaths.resolve(out, labelled.ctx.segments)
-        val dynamicBuildOverride = labelled.ctx.enclosingModule.moduleDynamicBuildOverrides
-        val buildOverrideOpt = staticBuildOverrides.get(labelled.ctx.segments.render)
-          .orElse(dynamicBuildOverride.get(labelled.ctx.segments.render))
+        val buildOverrideOpt = buildOverrideFor(labelled)
 
         // Helper to create a cached result (no evaluation occurred)
         def cachedResult(
@@ -457,7 +464,7 @@ trait GroupExecution {
               cached: Option[(Int, Option[(Val, Seq[PathRef])], Int)],
               closeStaleWorker: Boolean
           ): Option[GroupExecution.Results] = {
-            val (multiLogger, _) = resolveLogger(Some(paths).map(_.log), logger)
+            val (multiLogger, _) = resolveLogger(Some(paths.log), logger)
             val upToDateWorker = loadUpToDateWorker(
               logger = logger,
               inputsHash = inputsHash,

--- a/core/exec/src/mill/exec/PlanImpl.scala
+++ b/core/exec/src/mill/exec/PlanImpl.scala
@@ -41,24 +41,11 @@ object PlanImpl {
     Plan(sortedGroups)
   }
 
-  /**
-   * The `values` [[Agg]] is guaranteed to be topological sorted and cycle free.
-   * That's why the constructor is package private.
-   *
-   * @see [[PlanImpl.topoSorted]]
-   */
-
   def groupAroundImportantTasks[T](topoSortedTasks: TopoSorted)(important: PartialFunction[
     Task[?],
     T
   ]): MultiBiMap[T, Task[?]] =
     groupAroundImportantTasks(topoSortedTasks, important.isDefinedAt, defaultInputs)(important)
-
-  def groupAroundImportantTasks[T](
-      topoSortedTasks: TopoSorted,
-      cutPoint: Task[?] => Boolean
-  )(important: PartialFunction[Task[?], T]): MultiBiMap[T, Task[?]] =
-    groupAroundImportantTasks(topoSortedTasks, cutPoint, defaultInputs)(important)
 
   /**
    * `cutPoint` decides where group traversal stops; `important` decides which

--- a/libs/daemon/client/src/mill/client/lock/FileLock.scala
+++ b/libs/daemon/client/src/mill/client/lock/FileLock.scala
@@ -36,15 +36,11 @@ class FileLock(path: String) extends Lock {
   }
 
   override def probe(): Boolean = {
-    initializeIfNeeded()
-    val l =
-      try chan.tryLock()
-      catch { case _: OverlappingFileLockException => null }
-    if (l == null) false
-    else {
-      l.release()
+    val tl = tryLock()
+    if (tl.isLocked) {
+      tl.release()
       true
-    }
+    } else false
   }
 
   override def close(): Unit = {

--- a/libs/javalib/src/mill/javalib/TestModuleUtil.scala
+++ b/libs/javalib/src/mill/javalib/TestModuleUtil.scala
@@ -15,7 +15,6 @@ import scala.xml.Elem
 import scala.collection.mutable
 import mill.api.Logger
 
-import java.util.concurrent.ConcurrentHashMap
 import mill.api.BuildCtx
 import mill.javalib.api.internal.ZincOp
 import mill.javalib.testrunner.{TestArgs, TestResult, TestRunnerUtils}
@@ -200,7 +199,7 @@ final class TestModuleUtil(
     // test-classes folder is used to store the test classes for the children test runners to claim from
     val testClassQueueFolder = base / "test-classes"
     os.makeDir.all(testClassQueueFolder)
-    selectors2.zipWithIndex.foreach { case (s, _) =>
+    selectors2.foreach { s =>
       os.write.over(testClassQueueFolder / s, Array.empty[Byte])
     }
     testClassQueueFolder
@@ -230,7 +229,7 @@ final class TestModuleUtil(
       // In non-parallel mode, each group uses a single shared folder, so only spawn one
       // runner per group.
       val subprocessFutures = for {
-        ((group, testClassQueueFolder), _) <- groupFolderData.zipWithIndex.toVector
+        (group, testClassQueueFolder) <- groupFolderData.toVector
         groupFolder = group.folder
         numTests = group.testClasses.length
         (processCount, maxProcessLength) = jobsProcessLength(filteredClassCount, numTests)
@@ -360,7 +359,7 @@ final class TestModuleUtil(
       if (testParallelism && filteredClassCount != 1) groupFolder / workerLabel
       else groupFolder
 
-    val resultPath = processFolder / s"result.log"
+    val resultPath = processFolder / "result.log"
     os.write.over(resultPath, upickle.write((0L, 0L)), createFolders = true)
     val label =
       if (groupCount == 1) paddedProcessIndex
@@ -385,8 +384,6 @@ final class TestModuleUtil(
 
     processFolder -> fork {
       logger =>
-        val testClassTimeMap = new ConcurrentHashMap[String, Long]()
-
         val claimFolder = processFolder / "claim"
         os.makeDir.all(claimFolder)
 
@@ -412,7 +409,7 @@ final class TestModuleUtil(
           var seenLines = 0
           callTestRunnerSubprocess(
             processFolder,
-            processFolder / "result.log",
+            resultPath,
             Right((startingTestClass, testClassQueueFolder, claimFolder)),
             () => {
               val lines = os.read.lines(claimLog)
@@ -420,7 +417,6 @@ final class TestModuleUtil(
                 case s"CLAIM $currentTestClass $nanoTime0" =>
                   val nanoTime = nanoTime0.toLong
                   logger.prompt.logBeginChromeProfileEntry(currentTestClass, nanoTime)
-                  testClassTimeMap.putIfAbsent(currentTestClass, nanoTime)
                   currentTestClassNanoTime = Some(currentTestClass -> nanoTime)
                 case s"COMPLETED $nanoTime" =>
                   logger.prompt.logEndChromeProfileEntry(nanoTime.toLong)

--- a/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/KotlinWorkerImpl.scala
+++ b/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/KotlinWorkerImpl.scala
@@ -10,19 +10,6 @@ import mill.api.TaskCtx
 import mill.kotlinlib.worker.api.{KotlinWorker, KotlinWorkerTarget}
 
 class KotlinWorkerImpl extends KotlinWorker {
-  private object RawPathSerializer extends os.Path.Serializer {
-    def serializeString(p: os.Path): String = p.wrapped.toString
-    def serializeFile(p: os.Path): java.io.File = p.wrapped.toFile
-    def serializePath(p: os.Path): java.nio.file.Path = p.wrapped
-
-    def deserialize(s: String): java.nio.file.Path = os.Path.defaultPathSerializer.deserialize(s)
-    def deserialize(s: java.io.File): java.nio.file.Path =
-      os.Path.defaultPathSerializer.deserialize(s)
-    def deserialize(s: java.nio.file.Path): java.nio.file.Path =
-      os.Path.defaultPathSerializer.deserialize(s)
-    def deserialize(s: java.net.URI): java.nio.file.Path =
-      os.Path.defaultPathSerializer.deserialize(s)
-  }
 
   def compile(
       target: KotlinWorkerTarget,
@@ -49,7 +36,7 @@ class KotlinWorkerImpl extends KotlinWorker {
     val (exitCode, exitCodeName) =
       // Kotlin compiler internals and incremental caches require absolute paths.
       // Temporarily disable path relativization for this in-process compiler call.
-      os.Path.pathSerializer.withValue(RawPathSerializer) {
+      mill.api.internal.PathAliasing.withRawPathSerializer {
         compiler.compile(args, sources)
       }
 


### PR DESCRIPTION
Behavior-preserving only (no bug/perf changes).

Execution & scheduling:
- Move the `withReleasedExclusive` explanation comment onto the call it describes (it was stranded above an unrelated `val empty`).
- Delete the dead 3-arg `groupAroundImportantTasks` overload (no callers).
- Delete orphaned scaladoc referencing the removed `[[Agg]]` type.
- Collapse the `downstreamSources` builder loop to a one-line filter.
- Reuse the already-bound `allTasks` instead of recomputing the `t: Task[?]` upcast.

Parallel test scheduling (TestModuleUtil):
- Remove the write-only `testClassTimeMap` and its now-unused ConcurrentHashMap import.
- Drop two dead `zipWithIndex`es (index bound to `_`).
- Reuse `resultPath` instead of re-deriving `processFolder / "result.log"`; drop a no-op `s"..."`.

Locking:
- Deduplicate `FileLock.probe()` by delegating to `tryLock()` (matches `DoubleLock.probe`).

Task caching:
- Drop no-op `.orElse(None)` in `Task.Named.writerOpt`.
- Extract the duplicated static-then-dynamic build-override lookup into one `buildOverrideFor` helper (binds the dynamic map to a `val` to preserve eager evaluation, as both sites relied on).
- `Some(paths).map(_.log)` -> `Some(paths.log)`.

Path relativization:
- Fold the single-use `resolveFromAlias` into `fromAlias` (removes a doubly-computed substring).
- Reuse `PathAliasing.withRawPathSerializer` in KotlinWorkerImpl instead of a byte-identical copy of the RawPathSerializer object.
- Fix the stale `defaultMapping` doc referencing a nonexistent `pathRemapSerializerNio` caller.

Remote cache:
- Drop the always-constant wire-type slot from the hand-rolled Protobuf `fields` decoder.

Found via multi-agent clarity review; churn-y or risky candidates (the execute/async withValue-nest extract, several lock-hierarchy rewrites, an Iterator.continually swap, etc.) were deliberately rejected. Verified: core.exec/core.eval/libs.javalib/libs.kotlinlib.worker/ libs.daemon.client compile, and core.exec.test + core.eval.test + runner.server.test pass.

Please open all PRs as drafts and ensure that your fork of Mill has 
`settings/actions` / `Allow all actions and reusable workflows` enabled to run CI on
your own fork of the Mill repo. Only once CI passes mark the PR as `Ready for review`
and CI will run on the main Mill repo before we merge it.
