### PR TITLE
Fix remote caching for YAML builds

### DIFF
--- a/core/api/java11/src/mill/api/JsonFormatters.scala
+++ b/core/api/java11/src/mill/api/JsonFormatters.scala
@@ -1,7 +1,6 @@
 package mill.api
 
 import mill.api.daemon.internal.Severity
-import mill.api.internal.PathAliasing
 import os.Path
 import upickle.{ReadWriter as RW, Reader, Writer}
 
@@ -23,15 +22,12 @@ trait JsonFormatters {
       Right(os.Path(strs.last, BuildCtx.workspaceRoot))
   }
 
-  implicit val pathReadWrite: RW[os.Path] = upickle.readwriter[String]
-    .bimap[os.Path](
+  implicit val pathReadWrite: RW[os.Path] = upickle.stringKeyRW(
+    upickle.readwriter[String].bimap[os.Path](
       _.toString,
-      // Invert `_.toString` (which may be a `../mill-workspace` alias under the relativizing
-      // serializer) by resolving the raw string directly, the same way `PathRef` does. Going
-      // through the serializer's `deserialize` first would resolve the alias against the wrong
-      // cwd when the active deserializer isn't the relativizer.
-      s => PathAliasing.resolveAliasedString(s)
+      os.Path(_)
     )
+  )
 
   implicit val relPathRW: RW[os.RelPath] = upickle.readwriter[String]
     .bimap[os.RelPath](_.toString, os.RelPath(_))

--- a/core/api/java11/src/mill/api/PathRef.scala
+++ b/core/api/java11/src/mill/api/PathRef.scala
@@ -1,7 +1,6 @@
 package mill.api
 
 import mill.api.daemon.DummyOutputStream
-import mill.api.internal.PathAliasing
 import mill.api.daemon.internal.PathRefApi
 import upickle.ReadWriter as RW
 
@@ -232,7 +231,7 @@ object PathRef {
       serializedPathRefParts(s) match {
         case Some((prefix, valid0, hex, pathString)) =>
 
-          val path = PathAliasing.resolveAliasedString(pathString)
+          val path = os.Path(pathString)
           val quick = prefix == "qref"
           val validOrig = valid0 match {
             case "v0" => Revalidate.Never

--- a/core/api/java11/src/mill/api/internal/PathAliasing.scala
+++ b/core/api/java11/src/mill/api/internal/PathAliasing.scala
@@ -35,45 +35,6 @@ object PathAliasing {
   def workspacePathRelativizerBase(workspace: os.Path = BuildCtx.workspaceRoot): String =
     s"${PathRef.realAbs(workspace)},../mill-workspace;${PathRef.realAbs(os.home)},../mill-home"
 
-  private def normalize(raw: String): String = raw.replace('\\', '/')
-
-  def resolveAliasedString(
-      rawInput: String,
-      workspace: os.Path = BuildCtx.workspaceRoot,
-      pwd: os.Path = os.pwd
-  ): os.Path = {
-    val nio = java.nio.file.Paths.get(rawInput)
-    if (nio.isAbsolute) os.Path(nio.toAbsolutePath.normalize())
-    else {
-      val raw = normalize(rawInput)
-      def fromAlias(raw: String, alias: String, base: os.Path): Option[os.Path] = {
-        // `base` plus the path suffix following the alias segment, with a leading separator
-        // stripped; an empty suffix resolves to `base` itself.
-        def resolve(suffix: String): os.Path = {
-          val rel = suffix.stripPrefix("/")
-          if (rel.isEmpty) base else base / os.RelPath(rel)
-        }
-        if (raw == alias) Some(base)
-        else if (raw.startsWith(alias + "/")) Some(resolve(raw.drop(alias.length)))
-        else None
-      }
-
-      fromAlias(raw, workspaceAlias, workspace)
-        .orElse(fromAlias(raw, homeAlias, os.home))
-        .getOrElse(os.Path(raw, pwd))
-    }
-  }
-
-  def resolveAliasedPath(
-      path: os.Path,
-      workspace: os.Path = BuildCtx.workspaceRoot,
-      pwd: os.Path = os.pwd
-  ): os.Path = {
-    val nio = path.wrapped
-    if (nio.isAbsolute) os.Path(nio.toAbsolutePath.normalize())
-    else resolveAliasedString(path.toString, workspace, pwd)
-  }
-
   /**
    * Create or update `link` to be a symlink pointing at `dest`. If `link` exists as a non-symlink,
    * replace it. Best-effort: catches `FileSystemException` (e.g. read-only fs) and

--- a/core/api/src/mill/api/Task.scala
+++ b/core/api/src/mill/api/Task.scala
@@ -425,10 +425,7 @@ object Task {
 
     override def evaluate0: (Seq[Any], TaskCtx) => Result[T] =
       (_, _) => {
-        // `resolveAliasedString` so a `fileName` serialized via a `mill-workspace` alias
-        // resolves back to the real path, consistent with other `fileName` handling.
-        val relPath = mill.api.internal.PathAliasing.resolveAliasedString(ctx0.fileName)
-          .relativeTo(mill.api.BuildCtx.workspaceRoot)
+        val relPath = os.Path(ctx0.fileName).relativeTo(mill.api.BuildCtx.workspaceRoot)
         Result.Failure(s"configuration missing in $relPath")
       }
 

--- a/core/internal/src/mill/internal/Util.scala
+++ b/core/internal/src/mill/internal/Util.scala
@@ -117,13 +117,7 @@ object Util {
 
         val workspaceRoot = mill.api.BuildCtx.workspaceRoot
         val workspaceRootNio = workspaceRoot.wrapped.toAbsolutePath.normalize()
-        // In reproducible mode the build-file path may be an aliased relative path like
-        // `out/mill-workspace/build.mill`; resolve it back through the workspace alias so error
-        // messages show the clean workspace-relative path (`build.mill`) rather than the path
-        // through the daemon-sandbox alias symlink.
-        val pathNio = mill.api.internal.PathAliasing
-          .resolveAliasedString(path.toString, workspace = workspaceRoot)
-          .wrapped.toAbsolutePath.normalize()
+        val pathNio = os.Path(path.toString).wrapped.toAbsolutePath.normalize()
         val displayPath =
           try workspaceRootNio.relativize(pathNio).toString
           catch { case _: IllegalArgumentException => pathNio.toString }

--- a/example/large/remotecache/1-shared-folder/build.mill
+++ b/example/large/remotecache/1-shared-folder/build.mill
@@ -1,9 +1,5 @@
 //| mill-remote-cache-location: ~/mill-remote-cache-folder
 
-// Mill can share task outputs between builds in different folders, or even on different
-// machines, via a _remote cache_. Outputs computed by one build are stored in the cache and
-// transparently re-used by any other build whose inputs are unchanged, so you never need to
-// compute the same thing twice across a fleet of developer machines or CI workers.
 //
 // The simplest cache backend is a plain local or shared (e.g. NFS) _directory_: point the
 // cache at a filesystem path and Mill reads and writes cache entries there directly, with no

--- a/integration/dedicated/remote-cache/resources/build.mill
+++ b/integration/dedicated/remote-cache/resources/build.mill
@@ -22,3 +22,51 @@ def cachedFile = Task {
 def persistentTask = Task(persistent = true) {
   "persistentTask-value"
 }
+
+def graphStableCached = Task {
+  "stable"
+}
+
+def graphInput = Task.Input {
+  os.read(moduleDir / "graph-input.txt").trim
+}
+
+def graphSource = Task.Source("graph-source.txt")
+
+def graphCachedFromInput = Task {
+  s"cached:${graphStableCached()}:${graphInput()}"
+}
+
+def graphCachedFromSource = Task {
+  s"cached-source:${os.read(graphSource().path).trim}"
+}
+
+def graphPersistentFromInput = Task(persistent = true) {
+  os.write(Task.dest / "value.txt", graphInput())
+  s"persistent:${graphInput()}"
+}
+
+class GraphWorker extends AutoCloseable {
+  def value(input: String): String = s"worker:$input"
+  def close(): Unit = ()
+}
+
+def graphWorker = Task.Worker {
+  GraphWorker()
+}
+
+def graphCachedFromWorker = Task {
+  s"cached-worker:${graphWorker().value(graphInput())}"
+}
+
+def graphCommand() = Task.Command {
+  val result = Seq(
+    graphCachedFromInput(),
+    graphCachedFromSource(),
+    graphPersistentFromInput(),
+    graphCachedFromWorker(),
+    graphWorker().value(graphInput())
+  ).mkString("|")
+  println(s"graphCommand:$result")
+  result
+}

--- a/integration/dedicated/remote-cache/resources/graph-input.txt
+++ b/integration/dedicated/remote-cache/resources/graph-input.txt
@@ -1,0 +1,1 @@
+original

--- a/integration/dedicated/remote-cache/resources/graph-source.txt
+++ b/integration/dedicated/remote-cache/resources/graph-source.txt
@@ -1,0 +1,1 @@
+original-source

--- a/integration/dedicated/remote-cache/src/RemoteCacheTests.scala
+++ b/integration/dedicated/remote-cache/src/RemoteCacheTests.scala
@@ -15,8 +15,9 @@ import java.util.concurrent.Executors
  */
 object RemoteCacheTests extends UtestIntegrationTestSuite {
 
-  // Each block models a fresh checkout (empty `out/`), so opt out of the `fast` flavor's shared
-  // output dir — otherwise one block's local cache would satisfy a later one.
+  // Each `integrationTest` block gets its own temp `run-N` workspace, copies these test
+  // resources into it, and starts with no `out/` folder. Opt out of the `fast` flavor's shared
+  // output dir too, otherwise one block's local cache would satisfy a later one.
   override def allowSharedOutputDir: Boolean = false
 
   def withServer[T](f: String => T): T = {
@@ -57,13 +58,28 @@ object RemoteCacheTests extends UtestIntegrationTestSuite {
     finally server.stop(0)
   }
 
+  def profileCached(tester: mill.testkit.IntegrationTester, task: String): Option[Boolean] = {
+    val profile = os.read(tester.workspacePath / "out" / mill.constants.OutFiles.millProfile)
+    val entries = ujson.read(profile).arr.filter(_("label").str == task)
+    assert(entries.nonEmpty)
+    entries.last.obj.get("cached") match {
+      case Some(ujson.True) => Some(true)
+      case Some(ujson.False) => Some(false)
+      case Some(ujson.Null) | None => None
+      case other => sys.error(s"Unexpected cached value for $task: $other")
+    }
+  }
+
   // Whether `task` was recomputed (`"cached": false` in `mill-profile.json`) rather than served
   // from a cache, in the most recent invocation in `tester`'s workspace.
-  def evaluated(tester: mill.testkit.IntegrationTester, task: String): Boolean = {
-    val profile = os.read(tester.workspacePath / "out" / mill.constants.OutFiles.millProfile)
-    ujson.read(profile).arr.exists { e =>
-      e("label").str == task && e.obj.get("cached").flatMap(_.boolOpt).contains(false)
-    }
+  def evaluated(tester: mill.testkit.IntegrationTester, task: String): Boolean =
+    profileCached(tester, task).contains(false)
+
+  def assertProfileCached(
+      tester: mill.testkit.IntegrationTester,
+      expected: (String, Option[Boolean])*
+  ): Unit = {
+    for ((task, cached) <- expected) assert(profileCached(tester, task) == cached)
   }
 
   val tests: Tests = Tests {
@@ -130,6 +146,80 @@ object RemoteCacheTests extends UtestIntegrationTestSuite {
         val res = tester.eval(("--remote-cache-location", url, "persistentTask"))
         assert(res.isSuccess)
         assert(!evaluated(tester, "persistentTask")) // served from the remote cache
+      }
+    }
+
+    test("onlyCacheableTaskTypesParticipate") - withServer { url =>
+      def runGraph(tester: mill.testkit.IntegrationTester) = {
+        val res = tester.eval(("--remote-cache-location", url, "graphCommand"))
+        assert(res.isSuccess)
+        assert(res.out.contains("graphCommand:"))
+      }
+
+      integrationTest { tester =>
+        runGraph(tester)
+        assertProfileCached(
+          tester,
+          "graphStableCached" -> Some(false),
+          "graphInput" -> None,
+          "graphSource" -> None,
+          "graphCachedFromInput" -> Some(false),
+          "graphCachedFromSource" -> Some(false),
+          "graphPersistentFromInput" -> Some(false),
+          "graphWorker" -> Some(false),
+          "graphCachedFromWorker" -> Some(false),
+          "graphCommand" -> Some(false)
+        )
+      }
+
+      integrationTest { tester =>
+        runGraph(tester)
+        assertProfileCached(
+          tester,
+          "graphStableCached" -> Some(true),
+          "graphInput" -> None,
+          "graphSource" -> None,
+          "graphCachedFromInput" -> Some(true),
+          "graphCachedFromSource" -> Some(true),
+          "graphPersistentFromInput" -> Some(true),
+          "graphWorker" -> Some(false),
+          "graphCachedFromWorker" -> Some(true),
+          "graphCommand" -> Some(false)
+        )
+      }
+
+      integrationTest { tester =>
+        os.write.over(tester.workspacePath / "graph-input.txt", "changed")
+        runGraph(tester)
+        assertProfileCached(
+          tester,
+          "graphStableCached" -> Some(true),
+          "graphInput" -> None,
+          "graphSource" -> None,
+          "graphCachedFromInput" -> Some(false),
+          "graphCachedFromSource" -> Some(true),
+          "graphPersistentFromInput" -> Some(false),
+          "graphWorker" -> Some(false),
+          "graphCachedFromWorker" -> Some(false),
+          "graphCommand" -> Some(false)
+        )
+      }
+
+      integrationTest { tester =>
+        os.write.over(tester.workspacePath / "graph-source.txt", "changed-source")
+        runGraph(tester)
+        assertProfileCached(
+          tester,
+          "graphStableCached" -> Some(true),
+          "graphInput" -> None,
+          "graphSource" -> None,
+          "graphCachedFromInput" -> Some(true),
+          "graphCachedFromSource" -> Some(false),
+          "graphPersistentFromInput" -> Some(true),
+          "graphWorker" -> Some(false),
+          "graphCachedFromWorker" -> Some(true),
+          "graphCommand" -> Some(false)
+        )
       }
     }
 

--- a/integration/dedicated/reproducibility/src/ReproducibilityTests.scala
+++ b/integration/dedicated/reproducibility/src/ReproducibilityTests.scala
@@ -71,6 +71,42 @@ object ReproducibilityTests extends UtestIntegrationTestSuite {
     }
   }
 
+  def cachedInProfile(profilePath: os.Path, task: String): Boolean = {
+    val profile = os.read(profilePath)
+    ujson.read(profile).arr.exists { e =>
+      e("label").str == task && e.obj.get("cached").flatMap(_.boolOpt).contains(true)
+    }
+  }
+
+  def metaBuildCached(tester: IntegrationTester, task: String): Boolean =
+    cachedInProfile(
+      tester.workspacePath / "out" / "mill-build" / mill.constants.OutFiles.millProfile,
+      task
+    )
+
+  def writeYamlJavaProject(workspacePath: os.Path): Unit = {
+    os.list(workspacePath).filter(_.last != "out").foreach(os.remove.all(_))
+    os.write(workspacePath / "build.mill.yaml", "", createFolders = true)
+    os.write(
+      workspacePath / "bar/package.mill.yaml",
+      """extends: JavaModule
+        |""".stripMargin,
+      createFolders = true
+    )
+    os.write(
+      workspacePath / "bar/src/bar/Bar.java",
+      """package bar;
+        |
+        |public class Bar {
+        |  public static String value() {
+        |    return "bar";
+        |  }
+        |}
+        |""".stripMargin,
+      createFolders = true
+    )
+  }
+
   /** The real `bazel-remote` binary, downloaded once and cached by the `bazelRemote` build task. */
   def bazelRemoteBinary: os.Path = os.Path(sys.env("MILL_TEST_BAZEL_REMOTE"))
 
@@ -162,6 +198,30 @@ object ReproducibilityTests extends UtestIntegrationTestSuite {
           t <- compileTasks ++ Seq("javaApp.assembly", "scalaApp.assembly", "kotlinApp.assembly")
         )
           assert(!evaluated(tester, t))
+      }
+    }
+
+    test("remoteCacheYamlBuildOverrides") - {
+      val cache = os.temp.dir(prefix = "mill-yaml-remote-cache")
+      val cacheArgs = Seq(
+        "--remote-cache-location",
+        cache.toString,
+        "--remote-cache-filter",
+        "millBuildRootModuleResult"
+      )
+
+      integrationTest { tester =>
+        writeYamlJavaProject(tester.workspacePath)
+        val res = tester.eval(cacheArgs ++ Seq("bar.compile"), check = true)
+        assert(res.isSuccess)
+        assert(evaluated(tester, "bar.compile"))
+      }
+
+      integrationTest { tester =>
+        writeYamlJavaProject(tester.workspacePath)
+        val res = tester.eval(cacheArgs ++ Seq("bar.compile"), check = true)
+        assert(res.isSuccess)
+        assert(metaBuildCached(tester, "millBuildRootModuleResult"))
       }
     }
   }

--- a/integration/feature/cs-env-vars/src/CsEnvVarsTests.scala
+++ b/integration/feature/cs-env-vars/src/CsEnvVarsTests.scala
@@ -11,7 +11,11 @@ object CsEnvVarsTests extends UtestIntegrationTestSuite {
   // In reproducible-build mode the daemon prints classpath entries through the path relativizer
   // (e.g. cache jars as `../mill-home/...`); resolve them back to absolute paths for assertions.
   private def resolveCp(workspace: os.Path)(raw: String): os.Path =
-    PathAliasing.resolveAliasedString(raw, workspace = workspace)
+    os.Path.pathSerializer.withValue(os.Path.pathRemapSerializerNio(
+      PathAliasing.defaultMapping(workspace).map { case (from, to) =>
+        mill.api.PathRef.realAbsPath(from) -> java.nio.file.Paths.get(to.toString)
+      }
+    ))(os.Path(raw))
 
   val tests: Tests = Tests {
     test("cache") - integrationTest { tester =>

--- a/integration/multimode/multi-level-editing/src/MultiLevelBuildTests.scala
+++ b/integration/multimode/multi-level-editing/src/MultiLevelBuildTests.scala
@@ -1,5 +1,7 @@
 package mill.integration
 
+import mill.api.PathRef
+import mill.api.internal.PathAliasing
 import mill.testkit.{IntegrationTester, UtestIntegrationTestSuite}
 import mill.constants.OutFiles.OutFiles.*
 import mill.daemon.RunnerLauncherState
@@ -48,17 +50,30 @@ trait MultiLevelBuildTests extends UtestIntegrationTestSuite {
       yield {
         val path =
           tester.workspacePath / "out" / Seq.fill(depth)(millBuild) / millRunnerState
-        // The runner state serializes paths relativized against its own workspace (in
-        // reproducible-build mode, as `out/mill-workspace/...`). Deserialization resolves them via
-        // `BuildCtx.workspaceRoot`, which in this test process is NOT the build under test; scope it
-        // to the tested workspace so the watched paths resolve to absolute paths under it.
         if (os.exists(path))
-          mill.api.BuildCtx.workspaceRoot0.withValue(tester.workspacePath) {
-            upickle.read[RunnerLauncherState.Logged](os.read(path))
-          } -> path
+          readLoggedFrame(tester, path) -> path
         else RunnerLauncherState.Logged(Map(), Seq(), Seq(), None, Seq(), 0) -> path
       }
   }
+
+  // `mill-runner-state.json` is written with reproducible-build path aliases enabled.
+  // Scope the matching alias mapping while this test JVM reads those `os.Path` values back.
+  private def withTestPathAliases[T](tester: IntegrationTester)(body: => T): T =
+    os.Path.pathSerializer.withValue(
+      os.Path.pathRemapSerializerNio(
+        PathAliasing.defaultMapping(tester.workspacePath).map { case (from, to) =>
+          PathRef.realAbsPath(from) -> java.nio.file.Paths.get(to.toString)
+        }
+      )
+    )(body)
+
+  private def readLoggedFrame(
+      tester: IntegrationTester,
+      path: os.Path
+  ): RunnerLauncherState.Logged =
+    withTestPathAliases(tester) {
+      upickle.read[RunnerLauncherState.Logged](os.read(path))
+    }
 
   /**
    * Verify that each level of the multi-level build ends upcausing the

--- a/libs/javalib/src/mill/javalib/SemanticDbJavaModule.scala
+++ b/libs/javalib/src/mill/javalib/SemanticDbJavaModule.scala
@@ -2,7 +2,6 @@ package mill.javalib
 
 import mill.api.{BuildCtx, Discover, ExternalModule, ModuleRef, PathRef, Result, experimental}
 import mill.api.daemon.internal.SemanticDbJavaModuleApi
-import mill.api.internal.PathAliasing
 import mill.constants.CodeGenConstants
 import mill.util.{BuildInfo, Jvm, Version}
 import mill.javalib.api.{CompilationResult, JvmWorkerUtil}
@@ -264,11 +263,8 @@ object SemanticDbJavaModule extends ExternalModule with CoursierModule {
       val generatedSource = sourceroot / generatedSourceSubPath
       val generatedSourceLines = os.read.lines(generatedSource)
       val source = generatedSourceLines
-        // The marker may be a reproducible-build relativized path (e.g. `../mill-workspace/build.mill`);
-        // resolve it through the alias rather than `os.Path`, which would reject a non-absolute path.
         .collectFirst {
-          case s"//SOURCECODE_ORIGINAL_FILE_PATH=$rest" =>
-            PathAliasing.resolveAliasedString(rest.trim)
+          case s"//SOURCECODE_ORIGINAL_FILE_PATH=$rest" => os.Path(rest.trim)
         }
         .getOrElse {
           sys.error(s"Cannot get original source from generated source $generatedSource")

--- a/libs/javalib/src/mill/javalib/UnresolvedPath.scala
+++ b/libs/javalib/src/mill/javalib/UnresolvedPath.scala
@@ -2,7 +2,6 @@ package mill.javalib
 
 import mill.api.daemon.internal.UnresolvedPathApi
 import mill.api.{ExecutionPaths, Segment, Segments}
-import mill.api.internal.PathAliasing
 import upickle.{ReadWriter, macroRW}
 
 /**
@@ -16,7 +15,7 @@ sealed trait UnresolvedPath extends UnresolvedPathApi[os.Path] {
 }
 object UnresolvedPath {
   case class ResolvedPath private (path: String) extends UnresolvedPath {
-    override def resolve(outPath: os.Path): os.Path = PathAliasing.resolveAliasedString(path)
+    override def resolve(outPath: os.Path): os.Path = os.Path(path)
   }
   object ResolvedPath {
     def apply(path: os.Path): ResolvedPath = ResolvedPath(path.toString)

--- a/libs/javalib/worker/src/mill/javalib/worker/JvmWorkerRpcServer.scala
+++ b/libs/javalib/worker/src/mill/javalib/worker/JvmWorkerRpcServer.scala
@@ -3,8 +3,6 @@ package mill.javalib.worker
 import mill.api.JsonFormatters.*
 import mill.api.daemon.Logger
 import mill.api.daemon.internal.CompileProblemReporter
-import mill.api.internal.PathAliasing
-import mill.constants.EnvVars
 import mill.javalib.api.internal.*
 import mill.javalib.worker.JvmWorkerRpcServer.ReporterMode
 import mill.javalib.zinc.ZincWorker
@@ -37,13 +35,7 @@ class JvmWorkerRpcServer(
       clientStderr: RpcConsole,
       serverToClient: MillRpcChannel[ServerToClient]
   ): MillRpcChannel[JvmWorkerRpcServer.Request] = setIdle.doWork {
-    val workspaceRoot = sys.env
-      .get(EnvVars.MILL_WORKSPACE_ROOT)
-      .map(p => os.Path(p, os.pwd))
-      .getOrElse(PathAliasing.resolveAliasedPath(initialize.workspaceRoot))
-    def normalizePath(path: os.Path): os.Path =
-      PathAliasing.resolveAliasedPath(path, workspace = workspaceRoot)
-    val compilerBridgeWorkspace = normalizePath(initialize.compilerBridgeWorkspace)
+    val compilerBridgeWorkspace = initialize.compilerBridgeWorkspace
 
     // This is an ugly hack. `ConsoleOut` is sealed, but we need to provide a way to send these logs to the Mill server
     // over RPC, so we hijack `PrintStream` by overriding the methods that `ConsoleOut` uses.
@@ -66,16 +58,11 @@ class JvmWorkerRpcServer(
     new MillRpcChannel[JvmWorkerRpcServer.Request] {
       override def apply(input: JvmWorkerRpcServer.Request): input.Response = {
         setIdle.doWork {
-          val normalizedCtx = input.ctx.copy(
-            dest = normalizePath(input.ctx.dest),
-            workspaceRoot = normalizePath(input.ctx.workspaceRoot)
-          )
-          val normalizedBridge = input.compilerBridge.map(_.map(normalizePath))
           worker.apply(
             op = input.op,
             reporter = reporterAsOption(input.reporterMode),
             reportCachedProblems = input.reporterMode.reportCachedProblems,
-            normalizedCtx,
+            input.ctx,
             ZincWorker.ProcessConfig(
               log,
               consoleOut,
@@ -83,7 +70,7 @@ class JvmWorkerRpcServer(
                 workspace = compilerBridgeWorkspace,
                 logInfo = log.info,
                 acquire = (scalaVersion, scalaOrganization) =>
-                  normalizedBridge.getOrElse {
+                  input.compilerBridge.getOrElse {
                     throw new IllegalStateException(
                       s"Missing compiler bridge for $scalaOrganization:$scalaVersion."
                     )

--- a/libs/javalib/worker/src/mill/javalib/zinc/PositionMapper.scala
+++ b/libs/javalib/worker/src/mill/javalib/zinc/PositionMapper.scala
@@ -1,7 +1,5 @@
 package mill.javalib.zinc
 
-import mill.api.BuildCtx
-import mill.api.internal.PathAliasing
 import xsbti.VirtualFile
 
 import java.nio.charset.StandardCharsets
@@ -31,10 +29,7 @@ object PositionMapper {
     try vf.input().readAllBytes()
     catch {
       case _: java.io.IOException =>
-        os.read.bytes(PathAliasing.resolveAliasedString(
-          vf.id(),
-          workspace = BuildCtx.workspaceRoot
-        ))
+        os.read.bytes(os.Path(vf.id()))
     }
   }
 
@@ -51,11 +46,8 @@ object PositionMapper {
     }
 
     val map = buildSources0
-      // `original`/`generated` may be reproducible-build relativized paths (e.g.
-      // `../mill-workspace/build.mill`); resolve them through the alias rather than `os.Path`,
-      // which would reject a non-absolute path.
       .map { case (generated, original, _) =>
-        PathAliasing.resolveAliasedString(generated) -> PathAliasing.resolveAliasedString(original)
+        os.Path(generated) -> os.Path(original)
       }
       .toMap
 

--- a/runner/bsp/worker/src/mill/bsp/worker/BspCompileProblemReporter.scala
+++ b/runner/bsp/worker/src/mill/bsp/worker/BspCompileProblemReporter.scala
@@ -3,7 +3,6 @@ package mill.bsp.worker
 import ch.epfl.scala.bsp4j.*
 import ch.epfl.scala.{bsp4j => bsp}
 import mill.api.daemon.internal.{CompileProblemReporter, Problem}
-import mill.api.internal.PathAliasing
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
@@ -106,7 +105,7 @@ private class BspCompileProblemReporter(
       case Some(f) =>
         val diagnostic = toDiagnostic(problem)
         val textDocument = TextDocumentIdentifier(
-          PathAliasing.resolveAliasedString(f.toString).wrapped.toUri.toString
+          mill.api.PathRef.realAbsPath(os.Path(f)).toUri.toString
         )
         if (diagnostics.add(textDocument, diagnostic)) {
           val diagnosticList = new java.util.LinkedList[Diagnostic]()
@@ -169,7 +168,7 @@ private class BspCompileProblemReporter(
   }
 
   override def fileVisited(file: java.nio.file.Path): Unit = {
-    val uri = PathAliasing.resolveAliasedString(file.toString).wrapped.toUri.toString
+    val uri = mill.api.PathRef.realAbsPath(os.Path(file)).toUri.toString
     val textDocument = TextDocumentIdentifier(uri)
     val (diagnostics0, hasNewDiagnostics) = diagnostics.getAll(textDocument)
     if (hasNewDiagnostics)

--- a/runner/bsp/worker/src/mill/bsp/worker/Utils.scala
+++ b/runner/bsp/worker/src/mill/bsp/worker/Utils.scala
@@ -21,7 +21,6 @@ import mill.api.daemon.internal.{
   TaskApi
 }
 import mill.api.daemon.internal.bsp.{BspBuildTarget, BspModuleApi, JvmBuildTarget}
-import mill.api.internal.PathAliasing
 import mill.internal.SpanningForest
 
 import scala.collection.mutable
@@ -34,13 +33,9 @@ object Utils {
     if (uri.endsWith("/")) sanitizeUri(uri.substring(0, uri.length - 1)) else uri
 
   def sanitizeUri(uri: java.nio.file.Path): String = {
-    // In reproducible-build mode `os.Path.toNIO` yields a workspace-relativized path (e.g.
-    // `../mill-workspace/app`); resolve it back to an absolute path so BSP clients (IDEs) receive
-    // usable `file://` URIs rather than ones resolved against the daemon's sandbox cwd.
-    val absolute =
-      if (uri.isAbsolute) uri
-      else PathAliasing.resolveAliasedString(uri.toString).wrapped
-    sanitizeUri(absolute.toUri.toString)
+    // `uri` may be a workspace-relativized path; deserialize it through os-lib, then turn it back
+    // into a real absolute URI for BSP clients.
+    sanitizeUri(mill.api.PathRef.realAbsPath(os.Path(uri)).toUri.toString)
   }
 
   // define the function that spawns compilation reporter for each module based on the

--- a/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
+++ b/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
@@ -613,12 +613,15 @@ class MillBuildBootstrap(
                 runClasspath: Seq[PathRefApi],
                 compileClasses: PathRefApi,
                 codeSignatures: Map[String, Int],
-                buildOverrideFiles: Map[java.nio.file.Path, String],
+                buildOverrideFileStrings: Map[String, String],
                 spanningInvalidationTree: String
               ))),
               evalWatches,
               moduleWatches
             ) =>
+          val buildOverrideFiles =
+            buildOverrideFileStrings.map { case (path, text) => os.Path(path).wrapped -> text }
+
           // Even when the meta-build's compiled output is bit-identical to
           // the previous frame, we cannot reuse the existing classloader if
           // the outer (one-level-up) `moduleWatched` has changed. The user's

--- a/runner/meta/src/mill/meta/MillBuildRootModule.scala
+++ b/runner/meta/src/mill/meta/MillBuildRootModule.scala
@@ -10,7 +10,7 @@ import mill.api.{Discover, PathRef, Task}
 import mill.api.internal.RootModule
 import mill.scalalib.{Dep, DepSyntax, ScalaModule}
 import mill.javalib.api.{CompilationResult, JvmWorkerUtil, Versions}
-import mill.util.{BuildInfo, Jvm, MainRootModule}
+import mill.util.{BuildInfo, MainRootModule}
 import mill.api.daemon.internal.MillScalaParser
 import mill.api.JsonFormatters.given
 import mill.javalib.api.internal.{JavaCompilerOptions, ZincOp}
@@ -128,9 +128,7 @@ trait MillBuildRootModule()(using rootModuleInfo: RootModule.Info) extends Boots
         case (k, v)
             if k.last.endsWith(".mill.yaml") &&
               !mill.internal.Util.isPrecompiledYamlModule(k) =>
-          // `Jvm.realAbsPath`: serialized into the meta-build cache and read back by later
-          // `--no-daemon` invocations whose sandbox cwd makes the alias resolve to nothing.
-          (Jvm.realAbsPath(k), v)
+          k.toString -> v
       },
       // Serialize to string to avoid classloader issues when crossing classloader boundaries
       spanningTree.render()

--- a/website/docs/modules/ROOT/pages/large/remote-caching.adoc
+++ b/website/docs/modules/ROOT/pages/large/remote-caching.adoc
@@ -1,5 +1,11 @@
 = Remote Caching
 
+Mill can share task outputs between builds in different folders, or even on different
+machines, via a _remote cache_. Outputs computed by one build are stored in the cache and
+transparently re-used by any other build whose inputs are unchanged, so you never need to
+compute the same thing twice, whether across different worktrees or checkouts on the same
+machine or across a distributed fleet of developer machines or CI workers.
+
 include::partial$example/large/remotecache/1-shared-folder.adoc[]
 
 == A Bazel-Remote Cache Server
@@ -48,13 +54,25 @@ trade-offs. None of these are unique to Mill:
   same trust boundary. A common safe topology is to grant write access only to trusted CI
   (e.g. main-branch builds) while letting developer laptops and PR builds read from it.
 
-* *Not every task benefits from remote caching.* Some tasks are faster to recompute locally
-  than to fetch over the network, and Mill caches at a whole-task granularity, where each
-  task's output directory is a single cache entry. Use `--remote-cache-filter` to target the
-  expensive, high-reuse tasks such as `__.compile` where caching pays off.
+* *Not every cacheable task benefits from remote caching.* Some tasks are faster to
+  recompute locally than to fetch over the network, and Mill caches at a whole-task
+  granularity, where each task's output directory is a single cache entry. Use
+  `--remote-cache-filter` to target expensive, high-reuse tasks such as `__.compile`
+  where caching pays off.
 
-* *Persistent tasks are cached, but many task types are not.* Persistent tasks like `compile`,
-  whose `dest/` holds incremental-compiler state, do participate, since sharing compiled
-  output is the primary use case; a remote miss leaves their local `dest/` intact so an
-  incremental recompute can still re-use it. `Task.Input`, `Task.Command`, `Task.Worker`, and
-  other non-cached task types are never sent to the remote cache.
+* *Only declared output paths are restored from `Task.dest`.* For custom tasks, remote
+  caching restores files and directories under `Task.dest` that are returned as `PathRef`s
+  by the task. Incidental files written to `Task.dest` by a task returning a plain value,
+  such as a `String` or `Int`, are not portable through the remote cache even if the task's
+  value itself is served from cache. If downstream tasks or users need those files, make sure
+  the returned value contains the `PathRef`s pointing at them, e.g. as fields of a case class
+  or members of a tuple or named tuple.
+
+* *Only cacheable task types participate.* Normal cached tasks and persistent tasks,
+  including `compile` tasks whose `dest/` holds incremental-compiler state, can be
+  stored in and restored from the remote cache. A remote miss leaves a persistent
+  task's local `dest/` intact so an incremental recompute can still re-use it.
+  Side-effecting task types such as `Task.Input`, `Task.Command`, `Task.Worker`, and
+  other non-cached tasks are never sent to the remote cache. This means commands like
+  `run` or `testForked` may still execute even when their upstream `compile`, link, or
+  environment-setup tasks are remote-cache hits.


### PR DESCRIPTION
`DiscoveredBuildFiles.seenScripts` is part of the YAML meta-build cache
key. It is a `Map[os.Path, String]`, but uPickle serialized it as an
array of pairs because `os.Path` had no string-key writer. Array hashes
are order-sensitive, so different map iteration order across checkouts
changed the value hash.

Use `upickle.stringKeyRW` for `os.Path` so path-keyed maps serialize as
JSON objects, whose hashes are order-insensitive for the same keys and
values.

Also keep YAML build override paths as aliased strings across the
meta-build/daemon boundary and convert them back in the bootstrap frame.

Covered by `ReproducibilityTests.remoteCacheYamlBuildOverrides`.

