### PR TITLE
Attempt to fix bootstrapping problems

### DIFF
--- a/.github/workflows/pre-build.yml
+++ b/.github/workflows/pre-build.yml
@@ -39,6 +39,15 @@ jobs:
 
       - run: ./mill -k ${{ inputs.compileargs }}
 
+      - name: Remove out symlinks before artifact upload
+        shell: bash
+        run: |
+          if [ -d out ]; then
+            # These point at runner-local home/workspace paths and can make
+            # upload-artifact follow directories that should not be archived.
+            find out \( -name mill-home -o -name mill-workspace \) -type l -print -delete
+          fi
+
       - uses: actions/upload-artifact@v7.0.1
         with:
           path: .

--- a/libs/javalib/worker/src/mill/javalib/worker/SubprocessZincApi.scala
+++ b/libs/javalib/worker/src/mill/javalib/worker/SubprocessZincApi.scala
@@ -2,6 +2,7 @@ package mill.javalib.worker
 import mill.api.*
 import mill.api.daemon.*
 import mill.api.daemon.internal.CompileProblemReporter
+import mill.api.internal.PathAliasing
 import mill.client.lock.Locks
 import mill.client.{LaunchedServer, ServerLauncher}
 import mill.javalib.api.internal.*
@@ -109,27 +110,31 @@ class SubprocessZincApi(
                   logDir = Some(daemonDir)
                 )
 
-              val init =
-                JvmWorkerRpcServer.Initialize(
-                  compilerBridgeWorkspace = compilerBridgeWorkspace,
-                  workspaceRoot = ctx.workspaceRoot
-                )
+              // On Windows, Zinc resolves the forked javac.exe path against the compile dest;
+              // a ../mill-home alias is only valid relative to the daemon cwd, so it won't exist there.
+              PathAliasing.withRawPathSerializer {
+                val init =
+                  JvmWorkerRpcServer.Initialize(
+                    compilerBridgeWorkspace = compilerBridgeWorkspace,
+                    workspaceRoot = ctx.workspaceRoot
+                  )
 
-              val client = MillRpcClient.create[
-                JvmWorkerRpcServer.Initialize,
-                JvmWorkerRpcServer.Request,
-                JvmWorkerRpcServer.ServerToClient
-              ](init, wireTransport, makeClientLogger())(serverRpcToClientHandler(reporter))
+                val client = MillRpcClient.create[
+                  JvmWorkerRpcServer.Initialize,
+                  JvmWorkerRpcServer.Request,
+                  JvmWorkerRpcServer.ServerToClient
+                ](init, wireTransport, makeClientLogger())(serverRpcToClientHandler(reporter))
 
-              client.apply(JvmWorkerRpcServer.Request(
-                op,
-                reporter match {
-                  case None => ReporterMode.NoReporter
-                  case Some(r) => ReporterMode.Reporter(reportCachedProblems, r.maxErrors)
-                },
-                ctx,
-                compilerBridgeAcquire
-              )).asInstanceOf[op.Response]
+                client.apply(JvmWorkerRpcServer.Request(
+                  op,
+                  reporter match {
+                    case None => ReporterMode.NoReporter
+                    case Some(r) => ReporterMode.Reporter(reportCachedProblems, r.maxErrors)
+                  },
+                  ctx,
+                  compilerBridgeAcquire
+                )).asInstanceOf[op.Response]
+              }
             }
           )
         }.get

--- a/website/docs/modules/ROOT/pages/cli/installation-ide.adoc
+++ b/website/docs/modules/ROOT/pages/cli/installation-ide.adoc
@@ -431,10 +431,19 @@ Mill caches its outputs locally in the xref:fundamentals/out-dir.adoc[out/ folde
 can preserve this `out/` folder between CI workers, e.g. to allow a subsequent CI worker
 to use a previous worker's cached results, or to perform initial compilation on one worker
 then share the compiled output with downstream workers.
+Since `out/` may contain `mill-home` and `mill-workspace` symlinks to runner-local paths,
+delete those symlink entries before uploading it as an artifact.
 
 For example, for Github Actions you may configure `out/` folder uploading via
 
 ```yaml
+  - name: Remove out symlinks before artifact upload
+    shell: bash
+    run: |
+      if [ -d out ]; then
+        find out \( -name mill-home -o -name mill-workspace \) -type l -print -delete
+      fi
+
   - uses: actions/upload-artifact@v4
     with:
       name: build-out


### PR DESCRIPTION
Addresses the issues surfaced in https://github.com/com-lihaoyi/mill/pull/7182 that were blocking rebootstrapping

Zinc may fork javac using paths sent over the worker RPC. Those paths are same-machine process-control data, not persisted cache inputs, so serializing them with workspace aliases can produce ../mill-home paths that Zinc later resolves from compile.dest on Windows. Serialize this RPC payload with raw paths so javac sees an absolute path.

Remove mill-home and mill-workspace symlinks from the pre-build out artifact before upload, and document the same GitHub Actions pattern, so upload-artifact does not follow runner-local links into the home or workspace directory.

