### PR TITLE
Tighten up zinc worker path handling

### DIFF
--- a/libs/javalib/worker/src/mill/javalib/worker/SubprocessZincApi.scala
+++ b/libs/javalib/worker/src/mill/javalib/worker/SubprocessZincApi.scala
@@ -2,7 +2,6 @@ package mill.javalib.worker
 import mill.api.*
 import mill.api.daemon.*
 import mill.api.daemon.internal.CompileProblemReporter
-import mill.api.internal.PathAliasing
 import mill.client.lock.Locks
 import mill.client.{LaunchedServer, ServerLauncher}
 import mill.javalib.api.internal.*
@@ -110,31 +109,27 @@ class SubprocessZincApi(
                   logDir = Some(daemonDir)
                 )
 
-              // On Windows, Zinc resolves the forked javac.exe path against the compile dest;
-              // a ../mill-home alias is only valid relative to the daemon cwd, so it won't exist there.
-              PathAliasing.withRawPathSerializer {
-                val init =
-                  JvmWorkerRpcServer.Initialize(
-                    compilerBridgeWorkspace = compilerBridgeWorkspace,
-                    workspaceRoot = ctx.workspaceRoot
-                  )
+              val init =
+                JvmWorkerRpcServer.Initialize(
+                  compilerBridgeWorkspace = compilerBridgeWorkspace,
+                  workspaceRoot = ctx.workspaceRoot
+                )
 
-                val client = MillRpcClient.create[
-                  JvmWorkerRpcServer.Initialize,
-                  JvmWorkerRpcServer.Request,
-                  JvmWorkerRpcServer.ServerToClient
-                ](init, wireTransport, makeClientLogger())(serverRpcToClientHandler(reporter))
+              val client = MillRpcClient.create[
+                JvmWorkerRpcServer.Initialize,
+                JvmWorkerRpcServer.Request,
+                JvmWorkerRpcServer.ServerToClient
+              ](init, wireTransport, makeClientLogger())(serverRpcToClientHandler(reporter))
 
-                client.apply(JvmWorkerRpcServer.Request(
-                  op,
-                  reporter match {
-                    case None => ReporterMode.NoReporter
-                    case Some(r) => ReporterMode.Reporter(reportCachedProblems, r.maxErrors)
-                  },
-                  ctx,
-                  compilerBridgeAcquire
-                )).asInstanceOf[op.Response]
-              }
+              client.apply(JvmWorkerRpcServer.Request(
+                op,
+                reporter match {
+                  case None => ReporterMode.NoReporter
+                  case Some(r) => ReporterMode.Reporter(reportCachedProblems, r.maxErrors)
+                },
+                ctx,
+                compilerBridgeAcquire
+              )).asInstanceOf[op.Response]
             }
           )
         }.get

--- a/libs/javalib/worker/src/mill/javalib/zinc/ZincWorker.scala
+++ b/libs/javalib/worker/src/mill/javalib/zinc/ZincWorker.scala
@@ -814,7 +814,14 @@ object ZincWorker {
   private def getLocalOrCreateJavaTools(forkJavaHome: Option[os.Path]): JavaTools = {
     val (compiler, docs) = forkJavaHome match {
       case Some(home) =>
-        (javac.JavaCompiler.fork(Some(home.toNIO)), javac.Javadoc.fork(Some(home.toNIO)))
+        // Zinc calls `toAbsolutePath` on this value before launching `javac`/`javadoc`.
+        // If we pass `home.toNIO`, Mill's reproducible path serializer can turn a JDK
+        // under `os.home` into `../mill-home/...`. Zinc then absolutizes that relative
+        // path against the long-lived worker JVM's `user.dir` (a task dest such as
+        // `compile.dest`), leaving `..` segments that Windows `CreateProcess` does not
+        // normalize while looking up the executable.
+        val realJavaHome = PathRef.realAbsPath(home)
+        (javac.JavaCompiler.fork(Some(realJavaHome)), javac.Javadoc.fork(Some(realJavaHome)))
       case None =>
         val c = IncrementalTrackingJavaCompiler.local.getOrElse(javac.JavaCompiler.fork())
         val d = javac.Javadoc.local.getOrElse(javac.Javadoc.fork())


### PR DESCRIPTION
Follow up from https://github.com/com-lihaoyi/mill/pull/7183 to try and narrow the realAbs path handling from the entire zinc worker to just the one path that seems to be problematic