### PR TITLE
Always clean the classes dir when using the Kotlin CLI compiler

### DIFF
--- a/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -305,8 +305,8 @@ trait KotlinModule extends JavaModule with KotlinModuleApi { outer =>
       val classes = dest / "classes"
 
       val useBtApi = kotlincUseBtApi() && kotlinUseEmbeddableCompiler()
-      if(!useBtApi) {
-        // Non BT-API compiler is not incremental and does not keep track of older files, 
+      if (!useBtApi) {
+        // Non BT-API compiler is not incremental and does not keep track of older files,
         // so we always need to start fresh.
         os.remove.all(classes)
       }

--- a/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -303,6 +303,13 @@ trait KotlinModule extends JavaModule with KotlinModuleApi { outer =>
       val ctx = Task.ctx()
       val dest = ctx.dest
       val classes = dest / "classes"
+
+      val useBtApi = kotlincUseBtApi() && kotlinUseEmbeddableCompiler()
+      if(!useBtApi) {
+        // Non BT-API compiler is not incremental and does not keep track of older files, 
+        // so we always need to start fresh.
+        os.remove.all(classes)
+      }
       os.makeDir.all(classes)
 
       val javaSourceFiles = allJavaSourceFiles().map(_.path)
@@ -357,9 +364,6 @@ trait KotlinModule extends JavaModule with KotlinModuleApi { outer =>
           allKotlincOptions(),
           extraKotlinArgs
         ).flatten
-
-        val useBtApi =
-          kotlincUseBtApi() && kotlinUseEmbeddableCompiler()
 
         if (kotlincUseBtApi() && !kotlinUseEmbeddableCompiler()) {
           ctx.log.warn(


### PR DESCRIPTION
Since the compile task is now persistent and does not clean itself before the compiler runs,
we need to clean the classes destination dir explicitly.

This does not affect the use of the BT-API, which already tracks its inputs and outputs and is supposed to cleanup stale files.

Fix https://github.com/com-lihaoyi/mill/issues/7126
