### PR TITLE
Add `--replay-logs` option to show logs of cached tasks

### DIFF
--- a/core/exec/src/mill/exec/Execution.scala
+++ b/core/exec/src/mill/exec/Execution.scala
@@ -47,7 +47,8 @@ case class Execution(
     remoteCacheSalt: Option[String] = None,
     remoteCacheFilter: Option[String] = None,
     // Tracks tasks invalidated due to version/classloader mismatch
-    versionMismatchReasons: ConcurrentHashMap[Task[?], String] = ConcurrentHashMap()
+    versionMismatchReasons: ConcurrentHashMap[Task[?], String] = ConcurrentHashMap(),
+    replayLogs: Boolean
 ) extends GroupExecution with AutoCloseable {
 
   // Track nesting depth of executeTasks calls to only show final status on outermost call
@@ -82,7 +83,8 @@ case class Execution(
       spanningInvalidationTree: Option[String],
       remoteCacheLocation: Option[String],
       remoteCacheSalt: Option[String],
-      remoteCacheFilter: Option[String]
+      remoteCacheFilter: Option[String],
+      replayLogs: Boolean
   ) = this(
     baseLogger = baseLogger,
     // Only depth=0 (the user build) publishes through `runArtifacts`, so meta-build
@@ -117,7 +119,8 @@ case class Execution(
     spanningInvalidationTree = spanningInvalidationTree,
     remoteCacheLocation = remoteCacheLocation,
     remoteCacheSalt = remoteCacheSalt,
-    remoteCacheFilter = remoteCacheFilter
+    remoteCacheFilter = remoteCacheFilter,
+    replayLogs = replayLogs
   )
 
   def withBaseLogger(newBaseLogger: Logger) = {

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -409,6 +409,11 @@ trait GroupExecution {
               }
             )
           }
+          
+          // when requested, forward the cached logs to STDERR
+          def doReplayLog() = if (replayLogs && os.exists(paths.log)) {
+            os.read.stream(paths.log).writeBytesTo(logger.streams.err)
+          }
 
           taskLocks.readThenWrite { scope =>
             loadCachedOrWorker(
@@ -417,11 +422,7 @@ trait GroupExecution {
             ) match {
               case Some(res) =>
                 taskLocks.retainRead(scope)
-
-                if (replayLogs && os.exists(paths.log)) {
-                  os.read.stream(paths.log).writeBytesTo(logger.streams.err)
-                }
-
+                doReplayLog()
                 LockUpgrade.Decision.Complete(res)
               case None =>
                 LockUpgrade.Decision.Escalate
@@ -477,11 +478,7 @@ trait GroupExecution {
                   if (remoteMaterialized) taskLocks.markTaskWritten()
                   else taskLocks.currentVersion
                 taskLocks.retainDowngraded(scope, version)
-
-                if (replayLogs && os.exists(paths.log)) {
-                  os.read.stream(paths.log).writeBytesTo(logger.streams.err)
-                }
-
+                doReplayLog()
                 res
 
               case None =>

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -409,7 +409,7 @@ trait GroupExecution {
               }
             )
           }
-          
+
           // when requested, forward the cached logs to STDERR
           def doReplayLog() = if (replayLogs && os.exists(paths.log)) {
             os.read.stream(paths.log).writeBytesTo(logger.streams.err)

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -417,6 +417,11 @@ trait GroupExecution {
             ) match {
               case Some(res) =>
                 taskLocks.retainRead(scope)
+
+                if (replayLogs && os.exists(paths.log)) {
+                  os.read.stream(paths.log).writeBytesTo(logger.streams.err)
+                }
+
                 LockUpgrade.Decision.Complete(res)
               case None =>
                 LockUpgrade.Decision.Escalate

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -473,7 +473,7 @@ trait GroupExecution {
                   else taskLocks.currentVersion
                 taskLocks.retainDowngraded(scope, version)
 
-                if(replayLogs && os.exists(paths.log)) {
+                if (replayLogs && os.exists(paths.log)) {
                   os.read.stream(paths.log).writeBytesTo(logger.streams.err)
                 }
 

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -62,6 +62,8 @@ trait GroupExecution {
   def remoteCacheSalt: Option[String]
   def remoteCacheFilter: Option[String]
 
+  def replayLogs: Boolean
+
   // `None` means "cache every eligible task". Validated eagerly in `MillMain0`, so it parses here.
   private lazy val remoteCacheFilterSegments: Option[Segments] =
     remoteCacheFilter.flatMap(ParseArgs.extractSegments(_).toOption.map(_._2))
@@ -470,7 +472,13 @@ trait GroupExecution {
                   if (remoteMaterialized) taskLocks.markTaskWritten()
                   else taskLocks.currentVersion
                 taskLocks.retainDowngraded(scope, version)
+
+                if(replayLogs && os.exists(paths.log)) {
+                  os.read.stream(paths.log).writeBytesTo(logger.streams.err)
+                }
+
                 res
+
               case None =>
                 // Advance the output version before any destructive mutation
                 // below — not only on successful publish. Deleting `dest/` here,

--- a/core/internal/cli/src/mill/internal/MillCliConfig.scala
+++ b/core/internal/cli/src/mill/internal/MillCliConfig.scala
@@ -181,7 +181,9 @@ case class MillCliConfig(
     )
     remoteCacheFilter: Option[String] = None,
     @arg(hidden = true, doc = "Deprecated, use `--ticker false` instead")
-    disableTicker: Flag
+    disableTicker: Flag,
+    @arg(doc = "Replay logs for cached tasks.")
+    replayLogs: Flag = Flag()
 ) {
   def noDaemonEnabled =
     Seq(

--- a/libs/tabcomplete/test/src/mill/tabcomplete/TabCompleteTests.scala
+++ b/libs/tabcomplete/test/src/mill/tabcomplete/TabCompleteTests.scala
@@ -385,7 +385,8 @@ object TabCompleteTests extends TestSuite {
             "--task                    <str> The name or a query of the tasks(s) you want to build.",
             "--remote-cache-location   <str> Remote cache location: a Bazel-remote-protocol HTTP cache URL, or a `file:` URL / path to a local or shared folder.",
             "--remote-cache-salt       <str> Extra string mixed into the remote cache key, e.g. to keep Mac and Linux builds from sharing entries.",
-            "--remote-cache-filter     <str> Task-selector pattern (e.g. `__.compile`) limiting which tasks use the remote cache."
+            "--remote-cache-filter     <str> Task-selector pattern (e.g. `__.compile`) limiting which tasks use the remote cache.",
+            "--replay-logs             Replay logs for cached tasks."
           )
         )
       }

--- a/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
+++ b/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
@@ -72,7 +72,8 @@ class MillBuildBootstrap(
     // module hashCode) because at meta-build time we don't have a stable
     // module-hashCode mapping yet.
     metaBuildReporter: Int => Option[CompileProblemReporter] = _ => None,
-    enableTicker: Boolean
+    enableTicker: Boolean,
+    replayLogs: Boolean
 ) { outer =>
   // The workspace locking is owned by the metaBuild access (alongside the
   // shared state) but Execution still consumes the LauncherLocking directly
@@ -301,7 +302,8 @@ class MillBuildBootstrap(
       depth = depth,
       actualBuildFileName = nestedState.buildFile,
       enableTicker = enableTicker,
-      staticBuildOverrideFiles = staticBuildOverrideFiles.toMap
+      staticBuildOverrideFiles = staticBuildOverrideFiles.toMap,
+      replayLogs = replayLogs
     )
   }
 
@@ -832,7 +834,8 @@ object MillBuildBootstrap {
       depth: Int,
       actualBuildFileName: Option[String] = None,
       enableTicker: Boolean,
-      staticBuildOverrideFiles: Map[java.nio.file.Path, String]
+      staticBuildOverrideFiles: Map[java.nio.file.Path, String],
+      replayLogs: Boolean
   ): EvaluatorApi = {
     val bootLogPrefix: Seq[String] =
       if (depth == 0) Nil
@@ -881,7 +884,8 @@ object MillBuildBootstrap {
           spanningInvalidationTree,
           remoteCacheLocation,
           remoteCacheSalt,
-          remoteCacheFilter
+          remoteCacheFilter,
+          replayLogs
         )
       ).asInstanceOf[EvaluatorApi]
 

--- a/runner/daemon/src/mill/daemon/MillMain0.scala
+++ b/runner/daemon/src/mill/daemon/MillMain0.scala
@@ -433,7 +433,8 @@ object MillMain0 {
                                     ),
                                     reporter = reporter,
                                     metaBuildReporter = metaBuildReporter,
-                                    enableTicker = enableTicker
+                                    enableTicker = enableTicker,
+                                    replayLogs = config.replayLogs.value
                                   ).evaluate()
                                 }
                               }

--- a/testkit/src/mill/testkit/UnitTester.scala
+++ b/testkit/src/mill/testkit/UnitTester.scala
@@ -122,7 +122,7 @@ class UnitTester(
     else Some(mill.exec.ExecutionContexts.createExecutor(effectiveThreadCount))
 
   val execution = new mill.exec.Execution(
-    baseLogger = new mill.internal.PrefixLogger(logger, Nil),
+    baseLogger = mill.internal.PrefixLogger(logger, Nil),
     profileLogger = new mill.internal.JsonArrayLogger.Profile(outPath / millProfile),
     workspace = module.moduleDir,
     outPath = outPath,
@@ -147,7 +147,8 @@ class UnitTester(
     staticBuildOverrideFiles = Map(),
     depth = 0,
     isFinalDepth = true,
-    spanningInvalidationTree = None
+    spanningInvalidationTree = None,
+    replayLogs = false
   )
 
   val evaluator: Evaluator = new mill.eval.EvaluatorImpl(

--- a/website/docs/modules/ROOT/pages/cli/flags.adoc
+++ b/website/docs/modules/ROOT/pages/cli/flags.adoc
@@ -91,7 +91,6 @@ Options:
   task <str>...          The name or a query of the tasks(s) you want to build.
 
 See documentation at https://mill-build.org for more details
-
 ----
 
 .Output of `mill --help-advanced`

--- a/website/docs/modules/ROOT/pages/cli/flags.adoc
+++ b/website/docs/modules/ROOT/pages/cli/flags.adoc
@@ -30,7 +30,7 @@ To see a cheat sheet of all the command line flags that Mill supports, you can u
 .Output of `mill --help`
 [,console]
 ----
-Mill Build Tool, version 1.1.6-36-5da273-DIRTYab7bf63d
+Mill Build Tool, version 1.1.6-96-4e2a50-DIRTY8beaeb86
 Usage: mill [options] task [task-options] [+ task ...]
 
 Task cheat sheet:
@@ -83,6 +83,7 @@ Options:
                          `1` disables parallelism and `0` (the default) uses 1 thread per core.
   -k --keep-going        Continue build, even after build failures.
   --no-daemon            Run without a long-lived background daemon.
+  --replay-logs          Replay logs for cached tasks.
   --ticker <bool>        Enable or disable the ticker log, which provides information on running
                          tasks and where each log line came from
   -v --version           Show mill version information and exit.
@@ -90,6 +91,7 @@ Options:
   task <str>...          The name or a query of the tasks(s) you want to build.
 
 See documentation at https://mill-build.org for more details
+
 ----
 
 .Output of `mill --help-advanced`


### PR DESCRIPTION
If using the new `--replay-logs` option, the persistent logs of cached tasks will be printed to STDERR. This make task caching more transparent -- the visual output of Mill then also contains the output of cached tasks and looks identical to a fresh build.

It helps especially with remote-caching to get a better feeling of the current state of the build. If the developer never sees a recent build output (since all comes from a remote cache), they may not be aware of any warnings a task might show.

Technically, we could differentiate between locally and remotely cached tasks, and `--replay-logs` could accept a second argument like `none, all, local, remote`. But I'm not sure we want/need this, so I didn't implemented it for now.

Tested manually with and without remote caching (to a local directory).

Fix https://github.com/com-lihaoyi/mill/issues/7193

Pull request: https://github.com/com-lihaoyi/mill/pull/7196