### PR TITLE
Execution code cleanups

### DIFF
--- a/core/api/java11/src/mill/api/PathRef.scala
+++ b/core/api/java11/src/mill/api/PathRef.scala
@@ -39,16 +39,8 @@ case class PathRef private[mill] (
   def withRevalidate(revalidate: PathRef.Revalidate): PathRef = copy(revalidate = revalidate)
   def withRevalidateOnce: PathRef = copy(revalidate = PathRef.Revalidate.Once)
 
-  override def toString: String = {
-    val quick = if (this.quick) "qref:" else "ref:"
-    val valid = revalidate match {
-      case PathRef.Revalidate.Never => "v0:"
-      case PathRef.Revalidate.Once => "v1:"
-      case PathRef.Revalidate.Always => "vn:"
-    }
-    val sig = String.format("%08x", this.sig: Integer)
-    quick + valid + sig + ":" + path.toString()
-  }
+  override def toString: String =
+    PathRef.PathRefFormat.render(quick, revalidate, sig, path.toString())
 }
 
 object PathRef {
@@ -281,20 +273,10 @@ object PathRef {
       p.toString()
     },
     { s =>
-      serializedPathRefParts(s) match {
-        case Some((prefix, valid0, hex, pathString)) =>
-
-          val path = os.Path(pathString)
-          val quick = prefix == "qref"
-          val validOrig = valid0 match {
-            case "v0" => Revalidate.Never
-            case "v1" => Revalidate.Once
-            case "vn" => Revalidate.Always
-          }
-          // Parsing to a long and casting to an int is the only way to make
-          // round-trip handling of negative numbers work =(
-          val sig = java.lang.Long.parseLong(hex, 16).toInt
-          val pr = PathRef(path, quick, sig, revalidate = validOrig)
+      PathRefFormat.parse(s) match {
+        case Some(parsed) =>
+          val path = os.Path(parsed.pathString)
+          val pr = PathRef(path, parsed.quick, parsed.sig, revalidate = parsed.revalidate)
           validatedPaths.value.revalidateIfNeededOrThrow(pr)
           storeSerializedPaths(pr)
           pr
@@ -308,22 +290,54 @@ object PathRef {
     }
   )
 
-  private def serializedPathRefParts(s: String): Option[(String, String, String, String)] = {
-    val firstColon = s.indexOf(':')
-    if (firstColon < 0) None
-    else {
-      val prefix = s.substring(0, firstColon)
-      if (prefix != "ref" && prefix != "qref") None
+  /**
+   * The single encode/decode codec for the [[PathRef.toString]] wire format
+   * (`{qref|ref}:{v0|v1|vn}:{08x-sig}:{path}`). Owns the token tables and the
+   * signed-hex convention so encode ([[render]]) and decode ([[parse]]) can never
+   * drift. This format is an on-disk + remote-cache contract, pinned byte-for-byte
+   * by `PathRefTests.json`.
+   */
+  private[mill] object PathRefFormat {
+    final case class Parsed(quick: Boolean, revalidate: Revalidate, sig: Int, pathString: String)
+
+    private def quickToken(quick: Boolean): String = if (quick) "qref" else "ref"
+
+    private def revalidateToken(revalidate: Revalidate): String = revalidate match {
+      case Revalidate.Never => "v0"
+      case Revalidate.Once => "v1"
+      case Revalidate.Always => "vn"
+    }
+
+    private def parseRevalidate(token: String): Revalidate = token match {
+      case "v0" => Revalidate.Never
+      case "v1" => Revalidate.Once
+      case "vn" => Revalidate.Always
+    }
+
+    private def renderSig(sig: Int): String = String.format("%08x", sig: Integer)
+
+    // Parsing to a long and casting to an int is the only way to make
+    // round-trip handling of negative numbers work =(
+    private def parseSig(hex: String): Int = java.lang.Long.parseLong(hex, 16).toInt
+
+    def render(quick: Boolean, revalidate: Revalidate, sig: Int, pathString: String): String =
+      s"${quickToken(quick)}:${revalidateToken(revalidate)}:${renderSig(sig)}:$pathString"
+
+    def parse(s: String): Option[Parsed] = {
+      val firstColon = s.indexOf(':')
+      if (firstColon < 0) None
       else {
-        val secondColon = s.indexOf(':', firstColon + 1)
-        val thirdColon = if (secondColon < 0) -1 else s.indexOf(':', secondColon + 1)
-        if (secondColon < 0 || thirdColon < 0) None
+        val prefix = s.substring(0, firstColon)
+        if (prefix != "ref" && prefix != "qref") None
         else {
-          Some((
-            prefix,
-            s.substring(firstColon + 1, secondColon),
-            s.substring(secondColon + 1, thirdColon),
-            s.substring(thirdColon + 1)
+          val secondColon = s.indexOf(':', firstColon + 1)
+          val thirdColon = if (secondColon < 0) -1 else s.indexOf(':', secondColon + 1)
+          if (secondColon < 0 || thirdColon < 0) None
+          else Some(Parsed(
+            quick = prefix == "qref",
+            revalidate = parseRevalidate(s.substring(firstColon + 1, secondColon)),
+            sig = parseSig(s.substring(secondColon + 1, thirdColon)),
+            pathString = s.substring(thirdColon + 1)
           ))
         }
       }

--- a/core/api/java11/src/mill/api/internal/PathAliasing.scala
+++ b/core/api/java11/src/mill/api/internal/PathAliasing.scala
@@ -33,9 +33,6 @@ object PathAliasing {
     )
   }
 
-  def workspacePathRelativizerBase(workspace: os.Path = BuildCtx.workspaceRoot): String =
-    pathRelativizerBase(defaultMapping(workspace))
-
   def workspaceRootPathRelativizerBase(workspace: os.Path = BuildCtx.workspaceRoot): String = {
     val prefix = relativePath(workspace, regularOutputRoot(workspace))
     pathRelativizerBase(Seq(

--- a/core/api/src/mill/api/internal/EnvSignature.scala
+++ b/core/api/src/mill/api/internal/EnvSignature.scala
@@ -1,0 +1,46 @@
+package mill.api.internal
+
+/**
+ * The environment fingerprint that gates cache reuse: the Mill version, the JVM version, and a
+ * hash of the classloader (Mill jars + build dependencies). When any of these differs between when
+ * a value was cached and now, the cached value must be discarded regardless of input hashes.
+ *
+ * This is the single source of truth for both the comparison and the human-readable
+ * `name:OLD->NEW` invalidation reason, shared by task-level caching ([[mill.exec]]'s
+ * `TaskCacheEntry`) and selective execution (`SelectiveExecutionImpl`) so the two can never emit
+ * drifting reason strings. The three fields are stored *flat* in the on-disk `Cached` and
+ * `SelectiveExecution.Metadata` schemas; an [[EnvSignature]] is only ever constructed as an
+ * in-memory view over them.
+ */
+private[mill] case class EnvSignature(
+    millVersion: String,
+    millJvmVersion: String,
+    classLoaderSigHash: Int
+) {
+
+  /**
+   * The reasons, in priority order, that this signature differs from `other` (`this` being the
+   * older/cached value and `other` the current one), each formatted as `name:OLD->NEW`. Empty if
+   * the signatures are identical. Callers that want a single global reason take `.headOption`.
+   */
+  def diffReasonsTo(other: EnvSignature): Seq[String] = {
+    def reason(name: String, cached: Any, current: Any): Option[String] =
+      Option.when(cached != current)(s"$name:$cached->$current")
+
+    Seq(
+      reason("mill-version-changed", millVersion, other.millVersion),
+      reason("mill-jvm-version-changed", millJvmVersion, other.millJvmVersion),
+      reason("classpath-changed", classLoaderSigHash, other.classLoaderSigHash)
+    ).flatten
+  }
+}
+
+private[mill] object EnvSignature {
+
+  /** The environment Mill is currently running in, for the given classloader signature hash. */
+  def current(classLoaderSigHash: Int): EnvSignature = EnvSignature(
+    millVersion = mill.constants.BuildInfo.millVersion,
+    millJvmVersion = sys.props("java.version"),
+    classLoaderSigHash = classLoaderSigHash
+  )
+}

--- a/core/eval/src/mill/eval/SelectiveExecutionImpl.scala
+++ b/core/eval/src/mill/eval/SelectiveExecutionImpl.scala
@@ -5,6 +5,7 @@ import mill.api.{ExecResult, Result, Val}
 import mill.constants.OutFiles.OutFiles
 import mill.api.SelectiveExecution.ChangedTasks
 import mill.api.*
+import mill.api.internal.EnvSignature
 import mill.exec.PlanImpl
 import mill.internal.{CodeSigUtils, InvalidationForest, SpanningForest}
 import mill.internal.SpanningForest.breadthFirst
@@ -75,19 +76,13 @@ class SelectiveExecutionImpl(evaluator: Evaluator)
       newHashes: SelectiveExecution.Metadata
   ): DownstreamResult = {
     val allTasks = transitiveNamed.map(t => t: Task[?])
-    def globalInvalidate(name: String, key: SelectiveExecution.Metadata => Any) = {
-      Option.when(key(oldHashes) != key(newHashes)) {
-        DownstreamResult(
-          allTasks.toSet,
-          allTasks,
-          globalInvalidationReason = Some(s"$name:${key(oldHashes)}->${key(newHashes)}")
-        )
-      }
-    }
+    def envSignature(m: SelectiveExecution.Metadata): EnvSignature =
+      EnvSignature(m.millVersion, m.millJvmVersion, m.classLoaderSigHash)
 
-    globalInvalidate("mill-version-changed", _.millVersion)
-      .orElse(globalInvalidate("mill-jvm-version-changed", _.millJvmVersion))
-      .orElse(globalInvalidate("classpath-changed", _.classLoaderSigHash))
+    envSignature(oldHashes).diffReasonsTo(envSignature(newHashes)).headOption
+      .map(reason =>
+        DownstreamResult(allTasks.toSet, allTasks, globalInvalidationReason = Some(reason))
+      )
       .getOrElse {
         val namesToTasks = transitiveNamed.map(t => (t.ctx.segments.render -> t)).toMap
 
@@ -323,6 +318,7 @@ object SelectiveExecutionImpl {
         case (task, Result.Success(v)) => (task.ctx.segments.render, v.value.##)
         case (task, f: Result.Failure) => (task.ctx.segments.render, f.errorOpt.##)
       }
+      val env = EnvSignature.current(evaluator.classLoaderSigHash)
       SelectiveExecution.Metadata.Computed(
         new SelectiveExecution.Metadata(
           inputHashes,
@@ -330,9 +326,9 @@ object SelectiveExecutionImpl {
           // Hash the actual build override values from YAML files
           allBuildOverrides.map { case (k, located) => (k, located.value.value.hashCode) },
           forceRunTasks = Set(),
-          millVersion = mill.constants.BuildInfo.millVersion,
-          millJvmVersion = sys.props("java.version"),
-          classLoaderSigHash = evaluator.classLoaderSigHash
+          millVersion = env.millVersion,
+          millJvmVersion = env.millJvmVersion,
+          classLoaderSigHash = env.classLoaderSigHash
         ),
         results.map { case (k, v) =>
           val execRes: ExecResult[Val] = v match {

--- a/core/exec/src/mill/exec/BazelRemoteCache.scala
+++ b/core/exec/src/mill/exec/BazelRemoteCache.scala
@@ -29,17 +29,18 @@ import scala.util.control.NonFatal
  * uses a local/shared directory directly (see [[Backend]]), with no server. Setting
  * `MILL_REMOTE_CACHE_AUTHORIZATION` sends its value as the `Authorization` header.
  */
-private[mill] object BazelRemoteCache {
+/**
+ * One instance per remote-cache-enabled run: it resolves the [[BazelRemoteCache.Backend]] once
+ * (parsing `--remote-cache-location` a single time rather than per task) and captures the cache
+ * salt. [[store]]/[[load]] act on one task's `dest/`/`log`/`meta.json`.
+ */
+private[mill] class BazelRemoteCache private (
+    backend: BazelRemoteCache.Backend,
+    salt: Option[String]
+) {
+  import BazelRemoteCache.*
 
-  private val connectTimeout = Duration.ofSeconds(30)
-  private val requestTimeout = Duration.ofSeconds(120)
-
-  private lazy val client: HttpClient =
-    HttpClient.newBuilder().connectTimeout(connectTimeout).build()
-
-  private lazy val authHeader: Option[String] = sys.env.get("MILL_REMOTE_CACHE_AUTHORIZATION")
-
-  def actionCacheKey(inputsHash: Int, segmentsRender: String, salt: Option[String]): String = {
+  private def actionCacheKey(inputsHash: Int, segmentsRender: String): String = {
     val md = MessageDigest.getInstance("SHA-256")
     md.update(ByteBuffer.allocate(4).putInt(inputsHash).array())
     md.update(0.toByte)
@@ -54,13 +55,9 @@ private[mill] object BazelRemoteCache {
       paths: ExecutionPaths,
       inputsHash: Int,
       segmentsRender: String,
-      location: String,
-      salt: Option[String],
-      pathRefs: Seq[PathRef],
-      workspace: os.Path
+      pathRefs: Seq[PathRef]
   ): Unit = mill.api.BuildCtx.withFilesystemCheckerDisabled {
     // Cache I/O is trusted framework I/O that legitimately writes outside the task's `dest/`.
-    val backend = Backend.forLocation(location, workspace)
     // `deleteOnExit = false`: the `finally os.remove(blobFile)` below already removes it on every
     // path; a per-blob JVM shutdown hook would otherwise leak in a long-lived daemon.
     val blobFile = os.temp(prefix = "mill-remote-cache-", deleteOnExit = false)
@@ -75,7 +72,7 @@ private[mill] object BazelRemoteCache {
       // entry pointing at a missing blob.
       if (backend.put(s"cas/$sha", Backend.Body.File(blobFile)))
         backend.put(
-          s"ac/${actionCacheKey(inputsHash, segmentsRender, salt)}",
+          s"ac/${actionCacheKey(inputsHash, segmentsRender)}",
           Backend.Body.Bytes(Protobuf.encodeActionResult(sha, os.size(blobFile)))
         )
     } catch {
@@ -87,14 +84,10 @@ private[mill] object BazelRemoteCache {
   def load(
       paths: ExecutionPaths,
       inputsHash: Int,
-      segmentsRender: String,
-      location: String,
-      salt: Option[String],
-      workspace: os.Path
+      segmentsRender: String
   ): Boolean = mill.api.BuildCtx.withFilesystemCheckerDisabled {
-    val backend = Backend.forLocation(location, workspace)
     try {
-      backend.get(s"ac/${actionCacheKey(inputsHash, segmentsRender, salt)}").map { is =>
+      backend.get(s"ac/${actionCacheKey(inputsHash, segmentsRender)}").map { is =>
         try is.readAllBytes()
         finally is.close()
       } match {
@@ -131,6 +124,21 @@ private[mill] object BazelRemoteCache {
       case NonFatal(_) => false
     }
   }
+}
+
+private[mill] object BazelRemoteCache {
+
+  /** Build a cache for `location`, parsing the backend (and resolving any `file:`/`~/` path) once. */
+  def forLocation(location: String, salt: Option[String], workspace: os.Path): BazelRemoteCache =
+    new BazelRemoteCache(Backend.forLocation(location, workspace), salt)
+
+  private val connectTimeout = Duration.ofSeconds(30)
+  private val requestTimeout = Duration.ofSeconds(120)
+
+  private lazy val client: HttpClient =
+    HttpClient.newBuilder().connectTimeout(connectTimeout).build()
+
+  private lazy val authHeader: Option[String] = sys.env.get("MILL_REMOTE_CACHE_AUTHORIZATION")
 
   // Gzipped archive of a task's outputs, one entry per file/dir/symlink. Files carry mtime so
   // `quick` PathRefs (which hash it) re-validate. See writeFile/writeDir/writeLink for the layout.

--- a/core/exec/src/mill/exec/Execution.scala
+++ b/core/exec/src/mill/exec/Execution.scala
@@ -46,8 +46,6 @@ case class Execution(
     remoteCacheLocation: Option[String] = None,
     remoteCacheSalt: Option[String] = None,
     remoteCacheFilter: Option[String] = None,
-    // Tracks tasks invalidated due to version/classloader mismatch
-    versionMismatchReasons: ConcurrentHashMap[Task[?], String] = ConcurrentHashMap(),
     replayLogs: Boolean
 ) extends GroupExecution with AutoCloseable {
 
@@ -464,12 +462,10 @@ case class Execution(
 
         val finishedOptsMap = (nonExclusiveResults ++ exclusiveResults).toMap
 
-        val taskInvalidationReasons = {
-          import scala.jdk.CollectionConverters.ConcurrentMapHasAsScala
-          versionMismatchReasons.asScala.collect {
-            case (t: Task.Named[?], reason) => t.ctx.segments.render -> reason
-          }.toMap
-        }
+        val taskInvalidationReasons = finishedOptsMap.iterator.collect {
+          case (t: Task.Named[?], Some(res)) if res.invalidationReason.isDefined =>
+            t.ctx.segments.render -> res.invalidationReason.get
+        }.toMap
 
         ExecutionLogs.logInvalidationTree(
           interGroupDeps = interGroupDeps,

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -38,12 +38,6 @@ trait GroupExecution {
   def classLoaderIdentityHash: Int
 
   /**
-   * Tracks tasks invalidated due to version/classloader mismatch, with the reason string.
-   * Populated by TaskCacheEntry reads, used by ExecutionLogs.logInvalidationTree.
-   */
-  def versionMismatchReasons: java.util.concurrent.ConcurrentHashMap[Task[?], String]
-
-  /**
    * `String` is the worker name, `Int` is the worker hash, `Val` is the worker instance,
    * `TaskApi[?]` is the worker's Task (for traversing dependencies during ordered closure).
    */
@@ -68,9 +62,13 @@ trait GroupExecution {
   private lazy val remoteCacheFilterSegments: Option[Segments] =
     remoteCacheFilter.flatMap(ParseArgs.extractSegments(_).toOption.map(_._2))
 
-  /** The cache location for `labelled`, or `None` if not a filter-matching [[Task.Computed]]. */
-  private def remoteCacheTarget(labelled: Task.Named[?]): Option[String] =
-    remoteCacheLocation.filter(_ =>
+  // One cache per run: resolve the `--remote-cache-location` backend once, not per task.
+  private lazy val remoteTaskCache: Option[BazelRemoteCache] =
+    remoteCacheLocation.map(BazelRemoteCache.forLocation(_, remoteCacheSalt, workspace))
+
+  /** The remote cache for `labelled`, or `None` if not a filter-matching [[Task.Computed]]. */
+  private def remoteCacheTarget(labelled: Task.Named[?]): Option[BazelRemoteCache] =
+    remoteTaskCache.filter(_ =>
       labelled.isInstanceOf[Task.Computed[?]] &&
         remoteCacheFilterSegments.forall(checkPatternMatch(_, labelled.ctx.segments))
     )
@@ -359,7 +357,7 @@ trait GroupExecution {
           leaseTracker = leaseTracker,
           executionContext = executionContext
         )
-        val remoteLocation = remoteCacheTarget(labelled)
+        val remoteCache = remoteCacheTarget(labelled)
 
         // Helper to evaluate the task with full caching support
         def evaluateTaskWithCaching(): GroupExecution.Results = {
@@ -368,7 +366,7 @@ trait GroupExecution {
           // re-evaluation actually re-reads the filesystem/env state.
           def readLocal(): Option[TaskCacheEntry.Loaded] =
             cacheEntry
-              .read(logger, inputsHash, labelled, versionMismatchReasons)
+              .read(logger, inputsHash, labelled)
               .map(cached => if (hasSideEffects) cached.copy(valueOpt = None) else cached)
 
           def loadCachedOrWorker(
@@ -446,16 +444,9 @@ trait GroupExecution {
             // `dest/`/`log`/`meta` is safe; a poisoned entry re-reads as a miss and is recomputed
             // by the `None` branch below.
             val remoteMaterialized =
-              localReusable.isEmpty && remoteLocation.exists { location =>
+              localReusable.isEmpty && remoteCache.exists { cache =>
                 taskLocks.blockingOnPool {
-                  BazelRemoteCache.load(
-                    paths,
-                    inputsHash,
-                    labelled.ctx.segments.render,
-                    location,
-                    remoteCacheSalt,
-                    workspace
-                  )
+                  cache.load(paths, inputsHash, labelled.ctx.segments.render)
                 }
               }
 
@@ -527,16 +518,13 @@ trait GroupExecution {
                       val (valueHash, serializedPaths) =
                         handleTaskResult(v, cacheEntry, inputsHash, labelled)
                       // Push freshly-computed outputs to the remote cache for other machines.
-                      remoteLocation.foreach { location =>
+                      remoteCache.foreach { cache =>
                         taskLocks.blockingOnPool {
-                          BazelRemoteCache.store(
+                          cache.store(
                             paths,
                             inputsHash,
                             labelled.ctx.segments.render,
-                            location,
-                            remoteCacheSalt,
-                            serializedPaths,
-                            workspace
+                            serializedPaths
                           )
                         }
                       }
@@ -572,7 +560,8 @@ trait GroupExecution {
                   inputsHash = inputsHash,
                   previousInputsHash = cached.map(_.previousInputsHash).getOrElse(-1),
                   valueHashChanged = !cached.map(_.valueHash).contains(valueHash),
-                  serializedPaths = serializedPaths
+                  serializedPaths = serializedPaths,
+                  invalidationReason = cached.flatMap(_.invalidationReason)
                 )
             }
           }
@@ -1154,7 +1143,10 @@ object GroupExecution {
       inputsHash: Int,
       previousInputsHash: Int,
       valueHashChanged: Boolean,
-      serializedPaths: Seq[PathRef]
+      serializedPaths: Seq[PathRef],
+      // Why this terminal's cached env signature differed from the current run (`name:OLD->NEW`),
+      // if it was invalidated for that reason. Aggregated by `Execution` for the invalidation tree.
+      invalidationReason: Option[String] = None
   )
 
   enum CacheStatus {

--- a/core/exec/src/mill/exec/TaskCacheEntry.scala
+++ b/core/exec/src/mill/exec/TaskCacheEntry.scala
@@ -1,14 +1,17 @@
 package mill.exec
 
 import mill.api.daemon.internal.NonFatal
-import mill.api.internal.Cached
+import mill.api.internal.{Cached, EnvSignature}
 import mill.api.{ExecutionPaths, Logger, PathRef, Task, Val}
 
 private[exec] final class TaskCacheEntry(
     paths: ExecutionPaths,
     classLoaderSigHash: Int
 ) {
-  def write(json: ujson.Value, valueHash: Int, inputsHash: Int): Unit =
+  private def currentEnv: EnvSignature = EnvSignature.current(classLoaderSigHash)
+
+  def write(json: ujson.Value, valueHash: Int, inputsHash: Int): Unit = {
+    val env = currentEnv
     os.write.over(
       paths.meta,
       upickle.stream(
@@ -16,20 +19,20 @@ private[exec] final class TaskCacheEntry(
           json,
           valueHash,
           inputsHash,
-          millVersion = mill.constants.BuildInfo.millVersion,
-          millJvmVersion = sys.props("java.version"),
-          classLoaderSigHash = classLoaderSigHash
+          millVersion = env.millVersion,
+          millJvmVersion = env.millJvmVersion,
+          classLoaderSigHash = env.classLoaderSigHash
         ),
         indent = 4
       ),
       createFolders = true
     )
+  }
 
   def read(
       logger: Logger,
       inputsHash: Int,
-      labelled: Task.Named[?],
-      versionMismatchReasons: java.util.concurrent.ConcurrentHashMap[Task[?], String]
+      labelled: Task.Named[?]
   ): Option[TaskCacheEntry.Loaded] = {
     for {
       cached <-
@@ -38,27 +41,14 @@ private[exec] final class TaskCacheEntry(
         try Some(upickle.read[Cached](paths.meta.wrapped.toFile, trace = false))
         catch { case NonFatal(_) => None }
     } yield {
-      def checkMatch[T](cachedValue: T, currentValue: T, reasonName: String): Boolean = {
-        val matches = cachedValue == currentValue
-        if (!matches) {
-          versionMismatchReasons.putIfAbsent(labelled, s"$reasonName:$cachedValue->$currentValue")
-        }
-        matches
-      }
-
-      val millVersionMatches =
-        checkMatch(cached.millVersion, mill.constants.BuildInfo.millVersion, "mill-version-changed")
-      val jvmVersionMatches =
-        checkMatch(cached.millJvmVersion, sys.props("java.version"), "mill-jvm-version-changed")
-      val classLoaderMatches =
-        checkMatch(cached.classLoaderSigHash, classLoaderSigHash, "classpath-changed")
+      val envDiffReasons =
+        EnvSignature(cached.millVersion, cached.millJvmVersion, cached.classLoaderSigHash)
+          .diffReasonsTo(currentEnv)
 
       TaskCacheEntry.Loaded(
         previousInputsHash = cached.inputsHash,
         valueOpt = for {
-          _ <- Option.when(
-            cached.inputsHash == inputsHash && millVersionMatches && jvmVersionMatches && classLoaderMatches
-          )(())
+          _ <- Option.when(cached.inputsHash == inputsHash && envDiffReasons.isEmpty)(())
           reader <- labelled.readWriterOpt
           (parsed, serializedPaths) <-
             try Some(PathRef.withSerializedPaths(upickle.read(cached.value, trace = false)(using
@@ -71,7 +61,8 @@ private[exec] final class TaskCacheEntry(
               case NonFatal(_) => None
             }
         } yield (Val(parsed), serializedPaths),
-        valueHash = cached.valueHash
+        valueHash = cached.valueHash,
+        invalidationReason = envDiffReasons.headOption
       )
     }
   }
@@ -81,6 +72,9 @@ private[exec] object TaskCacheEntry {
   final case class Loaded(
       previousInputsHash: Int,
       valueOpt: Option[(Val, Seq[PathRef])],
-      valueHash: Int
+      valueHash: Int,
+      // The reason this entry's env signature differs from the current run (`name:OLD->NEW`), if
+      // any; surfaced via `GroupExecution.Results` to the invalidation-tree log.
+      invalidationReason: Option[String] = None
   )
 }


### PR DESCRIPTION
- Unify the (millVersion, millJvmVersion, classLoaderSigHash) triple and the
    `name:OLD->NEW` invalidation-reason strings into one `EnvSignature`, shared by
    task caching (`TaskCacheEntry`) and selective execution (`SelectiveExecutionImpl`)
    so the two can no longer drift; route all three current-env reads through it.
- Drop the `versionMismatchReasons` ConcurrentHashMap side-channel: `TaskCacheEntry.read`
    is now pure and returns the reason via `GroupExecution.Results`, which `Execution`
    aggregates for the invalidation tree. Removes an `Execution` constructor parameter.
- Make `BazelRemoteCache` a per-run instance that resolves the backend once instead of
    re-parsing `--remote-cache-location` on every store/load; shrink both call sites.
- Consolidate the `PathRef` string wire-format into a single `PathRefFormat` codec so
    encode/decode share the token tables and signed-hex convention.
- Delete the dead `PathAliasing.workspacePathRelativizerBase` (no callers).
