### PR TITLE
Android Data Binding: Process resources expects an absolute path

### DIFF
--- a/libs/androidlib/databinding/impl/src/mill/androidlib/databinding/AndroidDataBindingImpl.scala
+++ b/libs/androidlib/databinding/impl/src/mill/androidlib/databinding/AndroidDataBindingImpl.scala
@@ -21,8 +21,8 @@ class AndroidDataBindingImpl extends AndroidDataBindingWorker {
     val processor = createXmlProcessor(args)
     val input = LayoutXmlProcessor.ResourceInput(
       false,
-      os.Path(args.resInputDir).toIO,
-      os.Path(args.resOutputDir).toIO
+      os.Path(args.resInputDir).toNIO.toAbsolutePath.toFile,
+      os.Path(args.resOutputDir).toNIO.toAbsolutePath.toFile
     )
     processor.processResources(input, args.enableViewBinding, args.enableDataBinding)
 


### PR DESCRIPTION
- Fixes #7203 
- LayoutXmlProcessor expects absolute paths but relative was passed (related to os-lib absolute path changes, but any place that expects absolute paths we can gradually switch to explicit absolute path at the last call to make it more future proof)

## External pipe fix evidence

- Broken Pipeline: [java.lang.IllegalStateException: ../mill-workspace/Jetchat/app/src/main/res/layout/content_main.xml is not an absolute path](https://github.com/vaslabs-ltd/compose-samples-with-mill/actions/runs/27060077019/job/79871683916)
- Fixed [pipeline](https://github.com/vaslabs-ltd/compose-samples-with-mill/actions/runs/27088232437) 

Note: For some reason passing an absolute path from the android module to the processor didn't work, it's unclear whether this was because of `os.Path::toIO`