### PR TITLE
Use an absolute path when loading a native library

### DIFF
--- a/runner/launcher/src/mill/launcher/JLineNativeLoader.scala
+++ b/runner/launcher/src/mill/launcher/JLineNativeLoader.scala
@@ -109,7 +109,7 @@ object JLineNativeLoader {
     System.setProperty("library.jline.path", loader.millJLineNativeDir.toString)
     System.setProperty("library.jline.name", loader.millJLineNativeLibLocation.last)
 
-    System.load(loader.millJLineNativeLibLocation.toString)
+    System.load(loader.millJLineNativeLibLocation.toNIO.toAbsolutePath().toString())
 
     val cls = classOf[org.jline.nativ.JLineNativeLoader]
     val fld = cls.getDeclaredField("loaded")


### PR DESCRIPTION
Fix https://github.com/com-lihaoyi/mill/issues/7206

This is an workaround of https://github.com/com-lihaoyi/mill/issues/7207

I don't think we want following this route, but since Mill is already bootstrapped with a Mill version affected by this issue, we need to fix it temporarily.

Tested manually with `mill -i __.prepareOffline`.
