### PR TITLE
Add --replay-logs option to show logs of cached tasks (backport #7196)

### DIFF
--- a/core/exec/src/mill/exec/Execution.scala
+++ b/core/exec/src/mill/exec/Execution.scala
@@ -39,7 +39,8 @@ case class Execution(
     // JSON string to avoid classloader issues when crossing classloader boundaries
     spanningInvalidationTree: Option[String],
     // Tracks tasks invalidated due to version/classloader mismatch
-    versionMismatchReasons: ConcurrentHashMap[Task[?], String] = new ConcurrentHashMap()
+    versionMismatchReasons: ConcurrentHashMap[Task[?], String] = new ConcurrentHashMap(),
+    replayLogs: Boolean
 ) extends GroupExecution with AutoCloseable {
 
   // Track nesting depth of executeTasks calls to only show final status on outermost call
@@ -79,7 +80,8 @@ case class Execution(
       depth: Int,
       isFinalDepth: Boolean,
       // JSON string to avoid classloader issues when crossing classloader boundaries
-      spanningInvalidationTree: Option[String]
+      spanningInvalidationTree: Option[String],
+      replayLogs: Boolean
   ) = this(
     baseLogger = baseLogger,
     profileLogger = new JsonArrayLogger.Profile(os.Path(outPath) / millProfile),
@@ -103,7 +105,8 @@ case class Execution(
     enableTicker = enableTicker,
     depth = depth,
     isFinalDepth = isFinalDepth,
-    spanningInvalidationTree = spanningInvalidationTree
+    spanningInvalidationTree = spanningInvalidationTree,
+    replayLogs = replayLogs
   )
 
   def withBaseLogger(newBaseLogger: Logger) = {

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -61,6 +61,7 @@ trait GroupExecution {
   def exclusiveSystemStreams: SystemStreams
   def getEvaluator: () => EvaluatorApi
   def staticBuildOverrideFiles: Map[java.nio.file.Path, String]
+  def replayLogs: Boolean
 
   /** Evaluate a build override YAML value and deserialize it */
   private def evaluateBuildOverride(
@@ -255,6 +256,7 @@ trait GroupExecution {
       externalInputsHash + sideHashes + scriptsHash + invalidateAllHashes
     }
 
+    
     terminal match {
       case labelled: Task.Named[_] =>
         val out = if (!labelled.ctx.external) outPath else externalOutPath
@@ -276,6 +278,11 @@ trait GroupExecution {
           valueHashChanged = false,
           serializedPaths = serializedPaths
         )
+
+        // when requested, forward the cached logs to STDERR
+        def doReplayLog() = if (replayLogs && os.exists(paths.log)) {
+          os.read.stream(paths.log).writeBytesTo(logger.streams.err)
+        }
 
         // Helper to evaluate the task with full caching support
         def evaluateTaskWithCaching(): GroupExecution.Results = {
@@ -306,6 +313,7 @@ trait GroupExecution {
 
           cachedValueAndHash match {
             case Some(((v, serializedPaths), hashCode)) =>
+              doReplayLog()
               cachedResult(ExecResult.Success((v, hashCode)), serializedPaths)
 
             case _ =>

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -256,7 +256,6 @@ trait GroupExecution {
       externalInputsHash + sideHashes + scriptsHash + invalidateAllHashes
     }
 
-    
     terminal match {
       case labelled: Task.Named[_] =>
         val out = if (!labelled.ctx.external) outPath else externalOutPath

--- a/core/internal/cli/src/mill/internal/MillCliConfig.scala
+++ b/core/internal/cli/src/mill/internal/MillCliConfig.scala
@@ -172,7 +172,9 @@ case class MillCliConfig(
     @arg(hidden = true, doc = "Unsupported, but kept for compatibility")
     enableTicker: Option[Boolean] = None,
     @arg(hidden = true, doc = "Deprecated, use `--ticker false` instead")
-    disableTicker: Flag
+    disableTicker: Flag,
+    @arg(doc = "Replay logs for cached tasks.")
+    replayLogs: Flag = Flag()
 ) {
   def noDaemonEnabled =
     Seq(

--- a/libs/tabcomplete/test/src/mill/tabcomplete/TabCompleteTests.scala
+++ b/libs/tabcomplete/test/src/mill/tabcomplete/TabCompleteTests.scala
@@ -383,7 +383,8 @@ object TabCompleteTests extends TestSuite {
             "--no-wait-for-build-lock  Do not wait for an exclusive lock on the Mill output directory to evaluate tasks / commands.",
             "--no-wait-for-bsp-lock    Do not wait for an exclusive BSP server lock to run BSP server, just exit with an error if the BSP server lock is hold by another process",
             "--version                 Show mill version information and exit.",
-            "--task                    <str> The name or a query of the tasks(s) you want to build."
+            "--task                    <str> The name or a query of the tasks(s) you want to build.",
+            "--replay-logs             Replay logs for cached tasks."
           )
         )
       }

--- a/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
+++ b/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
@@ -62,7 +62,8 @@ class MillBuildBootstrap(
     offline: Boolean,
     useFileLocks: Boolean,
     reporter: EvaluatorApi => Int => Option[CompileProblemReporter],
-    enableTicker: Boolean
+    enableTicker: Boolean,
+    replayLogs: Boolean
 ) { outer =>
   import MillBuildBootstrap.*
 
@@ -232,7 +233,8 @@ class MillBuildBootstrap(
       depth = depth,
       actualBuildFileName = nestedState.buildFile,
       enableTicker = enableTicker,
-      staticBuildOverrideFiles = staticBuildOverrideFiles.toMap
+      staticBuildOverrideFiles = staticBuildOverrideFiles.toMap,
+      replayLogs = replayLogs
     )
   }
 
@@ -460,7 +462,8 @@ object MillBuildBootstrap {
       depth: Int,
       actualBuildFileName: Option[String] = None,
       enableTicker: Boolean,
-      staticBuildOverrideFiles: Map[java.nio.file.Path, String]
+      staticBuildOverrideFiles: Map[java.nio.file.Path, String],
+      replayLogs: Boolean
   ): EvaluatorApi = {
     val bootLogPrefix: Seq[String] =
       if (depth == 0) Nil
@@ -504,7 +507,8 @@ object MillBuildBootstrap {
           enableTicker,
           depth,
           false, // isFinalDepth: set later via withIsFinalDepth when needed
-          spanningInvalidationTree
+          spanningInvalidationTree,
+          replayLogs
         )
       ).asInstanceOf[EvaluatorApi]
 

--- a/runner/daemon/src/mill/daemon/MillMain0.scala
+++ b/runner/daemon/src/mill/daemon/MillMain0.scala
@@ -300,7 +300,8 @@ object MillMain0 {
                                   offline = config.offline.value,
                                   useFileLocks = config.useFileLocks.value,
                                   reporter = reporter,
-                                  enableTicker = enableTicker
+                                  enableTicker = enableTicker,
+                                  replayLogs = config.replayLogs.value
                                 ).evaluate()
                               }
                             }

--- a/testkit/src/mill/testkit/UnitTester.scala
+++ b/testkit/src/mill/testkit/UnitTester.scala
@@ -145,7 +145,8 @@ class UnitTester(
     staticBuildOverrideFiles = Map(),
     depth = 0,
     isFinalDepth = true,
-    spanningInvalidationTree = None
+    spanningInvalidationTree = None,
+    replayLogs = false
   )
 
   val evaluator: Evaluator = new mill.eval.EvaluatorImpl(

--- a/website/docs/modules/ROOT/pages/cli/flags.adoc
+++ b/website/docs/modules/ROOT/pages/cli/flags.adoc
@@ -30,7 +30,7 @@ To see a cheat sheet of all the command line flags that Mill supports, you can u
 .Output of `mill --help`
 [,console]
 ----
-Mill Build Tool, version 1.1.0-28-6e5003
+Mill Build Tool, version 1.1.6-15-1f224e-DIRTYb2e2edba
 Usage: mill [options] task [task-options] [+ task ...]
 
 Task cheat sheet:
@@ -53,7 +53,7 @@ Task cheat sheet:
   ./mill foo.test + bar.test       # run tests in the `foo` module and `bar` module
   ./mill '{foo,bar,qux}.test'      # run tests in the `foo` module, `bar` module, and `qux` module
 
-  ./mill __.resolvedMvnSources     # resolve all third-party dependencies' source code for browsing
+  ./mill foo.resolvedMvnSources    # resolve `foo`'s third-party dependencies' source code for browsing
 
   ./mill foo.assembly              # generate an executable assembly of the module `foo`
   ./mill show foo.assembly         # print the output path of the assembly of module `foo`
@@ -82,6 +82,7 @@ Options:
                       negative, -1 means the deepest meta-build (bootstrap build), -2 the second
                       deepest meta-build, etc.
   --no-daemon         Run without a long-lived background daemon.
+  --replay-logs       Replay logs for cached tasks.
   --ticker <bool>     Enable or disable the ticker log, which provides information on running tasks
                       and where each log line came from
   -v --version        Show mill version information and exit.


### PR DESCRIPTION
Backport of pull request: https://github.com/com-lihaoyi/mill/pull/7196

If using the new `--replay-logs` option, the persistent logs of cached tasks will be printed to STDERR. This make task caching more transparent -- the visual output of Mill then also contains the output of cached tasks and looks identical to a fresh build.

It helps to get a better feeling of the current state of the build, even if some results were cached.

Tested manually.

Fix https://github.com/com-lihaoyi/mill/issues/7193

