### PR TITLE
RepackageModule: Move implicit helper module definition into companion object

### DIFF
--- a/libs/javalib/src/mill/javalib/repackage/RepackageModule.scala
+++ b/libs/javalib/src/mill/javalib/repackage/RepackageModule.scala
@@ -137,10 +137,28 @@ trait RepackageModule extends mill.api.Module {
     PathRef(dest)
   }
 
+  /** Bin-compat stub. */
+  @deprecated("Use RepackageModule.EmbeddableRepackageModule instead", "Mill after 1.1.6")
+  private implicit class EmbeddableSpringBootModule(jm: JavaModule) extends mill.api.Module {
+    override def moduleCtx = jm.moduleCtx
+
+    /** Bin-compat stub. */
+    @deprecated("Use RepackageModule.EmbeddableRepackageModule.repackageModuleData instead", "Mill after 1.1.6")
+    object springBootAssemblyModule extends mill.api.Module {
+
+      /** Bin-compat stub. */
+      @deprecated("Use RepackageModule.EmbeddableRepackageModule.repackageModuleData.artifactJar instead", "Mill after 1.1.6")
+      def artifactJar: T[PathRef] = Task {
+        Task.fail("Use RepackageModule.EmbeddableRepackageModule.repackageModuleData.artifactJar instead")
+        jm.jar()
+      }
+    }
+  }
+
 }
 
 object RepackageModule extends ExternalModule {
-  // Hack-ish way to attach some generated resources under the context of the task dependency
+  // Attach some generated resources under the context of the task dependency
   private implicit class EmbeddableRepackageModule(jm: JavaModule) extends mill.api.Module {
     override def moduleCtx = jm.moduleCtx
 

--- a/libs/javalib/src/mill/javalib/repackage/RepackageModule.scala
+++ b/libs/javalib/src/mill/javalib/repackage/RepackageModule.scala
@@ -1,9 +1,7 @@
 package mill.javalib.repackage
 
 import mill.{T, Task}
-import mill.api.Result
-import mill.api.ModuleRef
-import mill.api.PathRef
+import mill.api.{Discover, ExternalModule, ModuleRef, PathRef, Result}
 import mill.javalib.JavaModule
 import mill.util.Jvm
 import mill.javalib.PublishModule
@@ -96,11 +94,13 @@ trait RepackageModule extends mill.api.Module {
   /** The upstream Module dependencies as JARs, to be embedded in the [[repackagedJar]]. */
   def repackageUpstreamLocalJars: T[Seq[PathRef]] = this match {
     case m: JavaModule => Task {
+        import RepackageModule.EmbeddableRepackageModule
+
         Task.traverse(m.transitiveModuleRunModuleDeps)(m =>
           // We need to renamed potential duplicated jar names (`out.jar`)
           // Instead of doing it in-place, we do it in the context of each module,
           // to avoid re-doing it for all jars when something changes
-          m.springBootAssemblyModule.artifactJar
+          m.repackageModuleData.artifactJar
         )()
       }
     case _ => Task {
@@ -137,10 +137,14 @@ trait RepackageModule extends mill.api.Module {
     PathRef(dest)
   }
 
+}
+
+object RepackageModule extends ExternalModule {
   // Hack-ish way to attach some generated resources under the context of the task dependency
-  private implicit class EmbeddableSpringBootModule(jm: JavaModule) extends mill.api.Module {
+  private implicit class EmbeddableRepackageModule(jm: JavaModule) extends mill.api.Module {
     override def moduleCtx = jm.moduleCtx
-    object springBootAssemblyModule extends mill.api.Module {
+
+    object repackageModuleData extends mill.api.Module {
 
       /** Same as [[jar]] but with a unique name to avoid name collisions. */
       def artifactJar: T[PathRef] = jm match {
@@ -157,4 +161,6 @@ trait RepackageModule extends mill.api.Module {
       }
     }
   }
+
+  override def millDiscover: Discover = Discover[this.type]
 }

--- a/libs/javalib/src/mill/javalib/repackage/RepackageModule.scala
+++ b/libs/javalib/src/mill/javalib/repackage/RepackageModule.scala
@@ -143,13 +143,21 @@ trait RepackageModule extends mill.api.Module {
     override def moduleCtx = jm.moduleCtx
 
     /** Bin-compat stub. */
-    @deprecated("Use RepackageModule.EmbeddableRepackageModule.repackageModuleData instead", "Mill after 1.1.6")
+    @deprecated(
+      "Use RepackageModule.EmbeddableRepackageModule.repackageModuleData instead",
+      "Mill after 1.1.6"
+    )
     object springBootAssemblyModule extends mill.api.Module {
 
       /** Bin-compat stub. */
-      @deprecated("Use RepackageModule.EmbeddableRepackageModule.repackageModuleData.artifactJar instead", "Mill after 1.1.6")
+      @deprecated(
+        "Use RepackageModule.EmbeddableRepackageModule.repackageModuleData.artifactJar instead",
+        "Mill after 1.1.6"
+      )
       def artifactJar: T[PathRef] = Task {
-        Task.fail("Use RepackageModule.EmbeddableRepackageModule.repackageModuleData.artifactJar instead")
+        Task.fail(
+          "Use RepackageModule.EmbeddableRepackageModule.repackageModuleData.artifactJar instead"
+        )
         jm.jar()
       }
     }


### PR DESCRIPTION
Fix https://github.com/com-lihaoyi/mill/issues/7279

This should make the class unique, whereas currently, there are effectively multiple class definitions, one per `RepackageModule` instance, resulting in non-unique `artifactJar` tasks all sharing the same cache location and if run concurrently overriding the same file.

Also renamed the embedded module to a more appropriate name. I think the previous name is a left-over from an incomplee refactoring, as `RepackageModule` was called `SpringBootModule` and `SpringBootAssemblyModule` in previous iterations.
