### PR TITLE
fix(javalib): resolve relative Zinc product ids

### DIFF
--- a/libs/javalib/worker/src/mill/javalib/zinc/IncrementalAnnotationProcessing.scala
+++ b/libs/javalib/worker/src/mill/javalib/zinc/IncrementalAnnotationProcessing.scala
@@ -4,7 +4,7 @@ import mill.api.daemon.Logger
 import sbt.internal.inc.Analysis
 import xsbti.{PathBasedFile, VirtualFile, VirtualFileRef}
 import java.io.File
-import java.nio.file.Path
+import java.nio.file.{Path, Paths}
 import java.util.Optional
 import java.util.jar.JarFile
 import javax.annotation.processing.Processor
@@ -200,7 +200,7 @@ private[mill] object IncrementalAnnotationProcessing {
       tracker: CompileTracker
   ): Unit = {
     val managedProducts = analysis.relations.allProducts.iterator.flatMap { product =>
-      val path = os.Path(product.id)
+      val path = analysisProductPath(product.id, classesDir)
       Iterator.single(path) ++ auxiliaryClassFileExtensions.iterator.map { ext =>
         path / os.up / s"${path.last.stripSuffix(".class")}.$ext"
       }
@@ -228,6 +228,35 @@ private[mill] object IncrementalAnnotationProcessing {
           .toMap
       )
     )
+  }
+
+  private def analysisProductPath(productId: String, classesDir: os.Path): os.Path = {
+    val productNio = Paths.get(productId).normalize()
+    if (productNio.isAbsolute) os.Path(productNio)
+    else {
+      val productSegments = productNio.iterator().asScala.map(_.toString).toVector
+      val classesSegments = classesDir.wrapped.toAbsolutePath.normalize().iterator().asScala
+        .map(_.toString)
+        .toVector
+
+      def relPath(segments: Seq[String]): os.RelPath =
+        segments.foldLeft(os.rel)(_ / _)
+
+      val fromClassesDir = productSegments.indices.iterator
+        .flatMap { start =>
+          (math.min(classesSegments.length, productSegments.length - start) to 1 by -1)
+            .iterator
+            .collectFirst {
+              case length
+                  if classesSegments.takeRight(length) ==
+                    productSegments.slice(start, start + length) =>
+                relPath(productSegments.drop(start + length))
+            }
+        }
+        .nextOption()
+
+      classesDir / fromClassesDir.getOrElse(relPath(productSegments))
+    }
   }
 
   def previousExtraProducts(workDir: os.Path): Set[os.Path] = {

--- a/libs/javalib/worker/test/src/mill/javalib/zinc/IncrementalAnnotationProcessingTrackerTests.scala
+++ b/libs/javalib/worker/test/src/mill/javalib/zinc/IncrementalAnnotationProcessingTrackerTests.scala
@@ -1,6 +1,8 @@
 package mill.javalib.zinc
 
 import utest.*
+import sbt.internal.inc.{Analysis, Relations}
+import xsbti.VirtualFileRef
 
 import javax.tools.{FileObject, JavaFileObject, SimpleJavaFileObject}
 
@@ -99,6 +101,51 @@ object IncrementalAnnotationProcessingTrackerTests extends TestSuite {
             source.toNIO.toAbsolutePath.normalize()
           )
         )
+      } finally os.remove.all(workDir)
+    }
+
+    test("persistAcceptsRelativeAnalysisProductIds") {
+      val workDir = os.temp.dir()
+      try {
+        val classesDir = workDir / "classes"
+        val source = workDir / "src/example/Foo.java"
+        val product = classesDir / "example/Foo.class"
+        os.makeDir.all(source / os.up)
+        os.makeDir.all(product / os.up)
+        os.write(source, "package example; class Foo {}")
+        os.write(product, "")
+
+        val analysis = Analysis.empty.copy(
+          relations = Relations.empty.addSource(
+            src = VirtualFileRef.of(source.toString),
+            products = Seq(
+              VirtualFileRef.of(
+                "mill-workspace/out/app/compile.dest/classes/example/Foo.class"
+              )
+            ),
+            classes = Nil,
+            internalDeps = Nil,
+            externalDeps = Nil,
+            libraryDeps = Nil
+          )
+        )
+
+        val tracker = new IncrementalAnnotationProcessing.CompileTracker(
+          trackingMode = IncrementalAnnotationProcessing.TrackingMode.Isolating,
+          sources = Set(source),
+          classesDir = classesDir
+        )
+
+        IncrementalAnnotationProcessing.persist(
+          workDir = workDir,
+          classesDir = classesDir,
+          analysis = analysis,
+          auxiliaryClassFileExtensions = Nil,
+          sourceStamps = Map.empty,
+          tracker = tracker
+        )
+
+        assert(os.exists(IncrementalAnnotationProcessing.snapshotPath(workDir)))
       } finally os.remove.all(workDir)
     }
   }


### PR DESCRIPTION
## TLDR

Fixes #7285 by resolving relative/aliased Zinc product ids under `classesDir` before converting them to `os.Path`.

## What changed

- Add a regression test for a Zinc product id shaped like `mill-workspace/out/.../classes/example/Foo.class`
- Resolve non-absolute analysis product ids relative to the compile classes directory
- Preserve existing behavior for absolute product ids

## Test

```text
./mill libs.javalib.worker.test.testOnly mill.javalib.zinc.IncrementalAnnotationProcessingTrackerTests
```

The new test fails before the fix with `is not an absolute path`, and passes after the fix.
