### PR TITLE
contrib/codeartifact: split dotted group into path segments

### DIFF
--- a/contrib/codeartifact/src/mill/contrib/codeartifact/CodeArtifactPublisher.scala
+++ b/contrib/codeartifact/src/mill/contrib/codeartifact/CodeArtifactPublisher.scala
@@ -21,10 +21,7 @@ class CodeartifactPublisher(
   )
 
   private def basePublishPath(artifact: Artifact) =
-    os.SubPath(Vector(
-      artifact.group.replace(".", "/"),
-      artifact.id
-    ))
+    os.SubPath(artifact.group.replace(".", "/")) / artifact.id
 
   private def versionPublishPath(artifact: Artifact) =
     basePublishPath(artifact) / artifact.version


### PR DESCRIPTION
Fixes #7288.

`CodeartifactPublisher.basePublishPath` builds the publish path as `os.SubPath(Vector(artifact.group.replace(".", "/"), artifact.id))`. The `Vector` constructor treats each element as a single path segment, but `group.replace(".", "/")` produces a string containing `/` (e.g. `com/example`), which os-lib rejects with `InvalidSegment`. As a result `publishCodeartifact` fails for any module whose group id contains a dot — i.e. essentially every real Maven coordinate.

This uses the `os.SubPath(String)` constructor instead, which parses `/` into segments:

```scala
os.SubPath(artifact.group.replace(".", "/")) / artifact.id
```

The resulting path is identical for a single-segment group and correct (`com/example/<id>/…`) for a dotted one. Verified against a live CodeArtifact repository: a module with a dotted `organization` now publishes successfully where it previously threw `InvalidSegment`.