### PR TITLE
Deduplicate reverse dependency tree to fix OOM errors in coursier (backport #7297)

### DIFF
--- a/integration/feature/gen-idea/resources/extended/idea/mill_modules/mill-build.iml
+++ b/integration/feature/gen-idea/resources/extended/idea/mill_modules/mill-build.iml
@@ -124,7 +124,7 @@
         <orderEntry type="library" scope="RUNTIME" name="windows-ansi-<version>.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="windows-jni-utils-<version>.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="xbean-reflect-3.7.jar" level="project"/>
-        <orderEntry type="library" scope="RUNTIME" name="xz-1.11.jar" level="project"/>
-        <orderEntry type="library" scope="RUNTIME" name="zstd-jni-1.5.7-6.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="xz-1.12.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="zstd-jni-1.5.7-11.jar" level="project"/>
     </component>
 </module>

--- a/integration/feature/gen-idea/resources/extended/idea/mill_modules/mill-build.mill-build.iml
+++ b/integration/feature/gen-idea/resources/extended/idea/mill_modules/mill-build.mill-build.iml
@@ -129,7 +129,7 @@
         <orderEntry type="library" scope="RUNTIME" name="windows-ansi-<version>.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="windows-jni-utils-<version>.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="xbean-reflect-3.7.jar" level="project"/>
-        <orderEntry type="library" scope="RUNTIME" name="xz-1.11.jar" level="project"/>
-        <orderEntry type="library" scope="RUNTIME" name="zstd-jni-1.5.7-6.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="xz-1.12.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="zstd-jni-1.5.7-11.jar" level="project"/>
     </component>
 </module>

--- a/integration/feature/gen-idea/resources/hello-idea/idea/mill_modules/mill-build.iml
+++ b/integration/feature/gen-idea/resources/hello-idea/idea/mill_modules/mill-build.iml
@@ -120,7 +120,7 @@
         <orderEntry type="library" scope="RUNTIME" name="windows-ansi-<version>.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="windows-jni-utils-<version>.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="xbean-reflect-3.7.jar" level="project"/>
-        <orderEntry type="library" scope="RUNTIME" name="xz-1.11.jar" level="project"/>
-        <orderEntry type="library" scope="RUNTIME" name="zstd-jni-1.5.7-6.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="xz-1.12.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="zstd-jni-1.5.7-11.jar" level="project"/>
     </component>
 </module>

--- a/libs/javalib/src/mill/javalib/JavaModule.scala
+++ b/libs/javalib/src/mill/javalib/JavaModule.scala
@@ -39,7 +39,6 @@ import os.Path
 
 import java.io.File
 import scala.util.chaining.scalaUtilChainingOps
-import scala.util.matching.Regex
 
 /**
  * Core configuration required to compile a single Java module
@@ -1462,18 +1461,21 @@ trait JavaModule
             .filter(dep => matchers.exists(matcher => matcher.matches(dep.module))).toSeq
       }
 
-      val tree = coursier.util.Print.dependencyTree(
+      val tree = coursier.util.Print.dependencyTree0(
         resolution = resolution,
         roots = roots,
         printExclusions = false,
-        reverse = if (whatDependsOn.isEmpty) inverse else true
+        reverse = if (whatDependsOn.isEmpty) inverse else true,
+        // Fix issue: https://github.com/com-lihaoyi/mill/issues/6823
+        // see also comment: https://github.com/coursier/coursier/pull/3671#issuecomment-4752734517
+        reverseDeduplicateNodes = true
       )
 
       // Filter the output, so that the special organization and version used for Mill's own modules
       // don't appear in the output. This only leaves the modules' name built from millModuleSegments.
       val processedTree = tree
         .replace(s"${JavaModule.internalOrg.value}:", "")
-        .pipe(JavaModule.removeInternalVersionRegex.replaceAllIn(_, "$1"))
+        .replace(s":${JavaModule.internalVersion}", "")
 
       processedTree
     }
@@ -1844,9 +1846,6 @@ object JavaModule {
 
   private[mill] def internalOrg = coursier.core.Organization("mill-internal")
   private[mill] def internalVersion = "0+mill-internal"
-
-  private lazy val removeInternalVersionRegex =
-    (":" + Regex.quote(JavaModule.internalVersion) + "(\\w*$|\\n)").r
 
 }
 

--- a/mill-build/src/millbuild/Deps.scala
+++ b/mill-build/src/millbuild/Deps.scala
@@ -112,7 +112,7 @@ object Deps {
   val bouncyCastlePgp = mvn"org.bouncycastle:bcpg-jdk18on:${bouncyCastleVersion}"
 
   val classgraph = mvn"io.github.classgraph:classgraph:4.8.184"
-  val coursierVersion = "2.1.25-M25"
+  val coursierVersion = "2.1.25-M26"
   val coursier = mvn"io.get-coursier::coursier:$coursierVersion".withDottyCompat(scalaVersion)
   val coursierArchiveCache =
     mvn"io.get-coursier::coursier-archive-cache:$coursierVersion".withDottyCompat(scalaVersion)


### PR DESCRIPTION
This is currently not optional, since the non-de-duplicated trees tend
to either take very long to render or break before finish with an out of
memory error.

Update coursier to 2.1.25-M26

Fix https://github.com/com-lihaoyi/mill/issues/6823

Backport of pull request: https://github.com/com-lihaoyi/mill/pull/7297
