### PR TITLE
Refactor Moduleutils with mutable set for better performance (backport #7095)

### DIFF
--- a/libs/javalib/src/mill/javalib/internal/ModuleUtils.scala
+++ b/libs/javalib/src/mill/javalib/internal/ModuleUtils.scala
@@ -2,7 +2,7 @@ package mill.javalib.internal
 
 import mill.api.daemon.internal.internal
 
-import scala.annotation.tailrec
+import scala.collection.mutable
 
 @internal
 object ModuleUtils {
@@ -12,7 +12,7 @@ object ModuleUtils {
    * The result contains `start` and all its transitive dependencies provided by `deps`,
    * but does not contain duplicates.
    * If it detects a cycle, it throws an exception with a meaningful message containing the cycle trace.
-   * @param name The nane is used in the exception message only
+   * @param name The name is used in the exception message only
    * @param start the start element
    * @param deps A function provided the direct dependencies
    * @throws mill.api.MillException if there were cycles in the dependencies
@@ -20,39 +20,33 @@ object ModuleUtils {
   // FIXME: Remove or consolidate with copy in JvmWorkerImpl
   def recursive[T](name: String, start: T, deps: T => Seq[T]): Seq[T] = {
 
-    @tailrec def rec(
-        seenModules: Set[T],
-        result: List[T],
-        toAnalyze: List[(List[T], List[T])]
-    ): List[T] = {
-      toAnalyze match {
-        case Nil => result
-        case traces :: rest =>
-          traces match {
-            case (_, Nil) => rec(seenModules, result, rest)
-            case (trace, cand :: remaining) =>
-              if (trace.contains(cand)) {
-                // cycle!
-                val rendered =
-                  (cand :: (cand :: trace.takeWhile(_ != cand)).reverse).mkString(" -> ")
-                val msg = s"${name}: cycle detected: ${rendered}"
-                println(msg)
-                throw new mill.api.MillException(msg)
-              }
-              val alreadySeen = seenModules.contains(cand)
-              rec(
-                if (alreadySeen) seenModules else seenModules + cand,
-                if (alreadySeen) result else cand :: result,
-                toAnalyze = ((cand :: trace, deps(cand).toList)) :: (trace, remaining) :: rest
-              )
-          }
+    val result = mutable.ArrayBuffer[T]()
+
+    /**
+     * Prevents visiting the same node twice when it is reachable via
+     * multiple paths (deduplication).
+     */
+    val fullySeen = mutable.Set[T]()
+
+    def dfs(node: T, path: List[T], pathSet: Set[T]): Unit = {
+      deps(node).foreach { child =>
+        if (pathSet.contains(child)) {
+          // cycle!
+          val segment = path.takeWhile(_ != child)
+          val rendered = (child :: (child :: segment).reverse).mkString(" -> ")
+          val msg = s"${name}: cycle detected: ${rendered}"
+          println(msg)
+          throw new mill.api.MillException(msg)
+        }
+        if (!fullySeen.contains(child)) {
+          fullySeen += child
+          result += child
+          dfs(child, child :: path, pathSet + child)
+        }
       }
     }
 
-    rec(
-      seenModules = Set.empty,
-      result = Nil,
-      toAnalyze = List((List(start), deps(start).toList))
-    )
+    dfs(start, List(start), Set(start))
+    result.toSeq.reverse
   }
 }

--- a/libs/javalib/test/src/mill/javalib/internal/ModuleUtilsTests.scala
+++ b/libs/javalib/test/src/mill/javalib/internal/ModuleUtilsTests.scala
@@ -1,0 +1,200 @@
+package mill.javalib.internal
+
+import utest.*
+
+object ModuleUtilsTests extends TestSuite {
+
+  val tests = Tests {
+
+    test("noDependencies") {
+      val res = ModuleUtils.recursive("test", "a", (_: String) => Seq.empty)
+      assert(res == Seq.empty)
+    }
+
+    test("singleLevel") {
+      val res = ModuleUtils.recursive(
+        "test",
+        "a",
+        s =>
+          s match {
+            case "a" => Seq("b", "c")
+            case _ => Seq.empty
+          }
+      )
+      assert(res == Seq("c", "b"))
+    }
+
+    test("multiLevel") {
+      val res = ModuleUtils.recursive(
+        "test",
+        "a",
+        s =>
+          s match {
+            case "a" => Seq("b", "c")
+            case "b" => Seq("d")
+            case "c" => Seq("d")
+            case _ => Seq.empty
+          }
+      )
+      assert(res == Seq("c", "d", "b"))
+    }
+
+    test("deepChain") {
+      val res = ModuleUtils.recursive(
+        "test",
+        "a",
+        s =>
+          s match {
+            case "a" => Seq("b")
+            case "b" => Seq("c")
+            case "c" => Seq("d")
+            case "d" => Seq("e")
+            case _ => Seq.empty
+          }
+      )
+      assert(res == Seq("e", "d", "c", "b"))
+    }
+
+    test("selfCycle") {
+      val exception = assertThrows[mill.api.MillException] {
+        ModuleUtils.recursive(
+          "test",
+          "a",
+          s =>
+            s match {
+              case "a" => Seq("a")
+              case _ => Seq.empty
+            }
+        )
+      }
+      assert(exception.getMessage.contains("test: cycle detected: a -> a"))
+    }
+
+    test("directCycle") {
+      val exception = assertThrows[mill.api.MillException] {
+        ModuleUtils.recursive(
+          "test",
+          "a",
+          s =>
+            s match {
+              case "a" => Seq("b")
+              case "b" => Seq("a")
+              case _ => Seq.empty
+            }
+        )
+      }
+      assert(exception.getMessage.contains("test: cycle detected: a -> b -> a"))
+    }
+
+    test("indirectCycle") {
+      val exception = assertThrows[mill.api.MillException] {
+        ModuleUtils.recursive(
+          "test",
+          "a",
+          s =>
+            s match {
+              case "a" => Seq("b")
+              case "b" => Seq("c")
+              case "c" => Seq("d")
+              case "d" => Seq("b")
+              case _ => Seq.empty
+            }
+        )
+      }
+      assert(exception.getMessage.contains("test: cycle detected: b -> c -> d -> b"))
+    }
+
+    test("cycleNotFromStart") {
+      val exception = assertThrows[mill.api.MillException] {
+        ModuleUtils.recursive(
+          "test",
+          "a",
+          s =>
+            s match {
+              case "a" => Seq("b")
+              case "b" => Seq("c")
+              case "c" => Seq("b")
+              case _ => Seq.empty
+            }
+        )
+      }
+      assert(exception.getMessage.contains("test: cycle detected: b -> c -> b"))
+    }
+
+    test("diamondNoDuplicates") {
+      val res = ModuleUtils.recursive(
+        "test",
+        "a",
+        s =>
+          s match {
+            case "a" => Seq("b", "c")
+            case "b" => Seq("d")
+            case "c" => Seq("d")
+            case _ => Seq.empty
+          }
+      )
+      assert(res == Seq("c", "d", "b"))
+    }
+
+    test("wideTree") {
+      val res = ModuleUtils.recursive(
+        "test",
+        "a",
+        s =>
+          s match {
+            case "a" => Seq("b", "c", "d", "e", "f")
+            case _ => Seq.empty
+          }
+      )
+      assert(res == Seq("f", "e", "d", "c", "b"))
+    }
+
+    test("complexDAG") {
+      val res = ModuleUtils.recursive(
+        "test",
+        "a",
+        s =>
+          s match {
+            case "a" => Seq("b", "c")
+            case "b" => Seq("d", "e")
+            case "c" => Seq("e", "f")
+            case "d" => Seq("f")
+            case "e" => Seq("f")
+            case _ => Seq.empty
+          }
+      )
+      assert(res == Seq("c", "e", "f", "d", "b"))
+    }
+
+    test("customNameUsedInErrorMessage") {
+      val exception = assertThrows[mill.api.MillException] {
+        ModuleUtils.recursive(
+          "myCustomName",
+          "a",
+          s =>
+            s match {
+              case "a" => Seq("b")
+              case "b" => Seq("a")
+              case _ => Seq.empty
+            }
+        )
+      }
+      assert(exception.getMessage.contains("myCustomName: cycle detected"))
+    }
+
+    test("doesNotIncludeStartNode") {
+      val res = ModuleUtils.recursive(
+        "test",
+        "a",
+        s =>
+          s match {
+            case "a" => Seq("b")
+            case "b" => Seq("c")
+            case _ => Seq.empty
+          }
+      )
+      assert(!res.contains("a"))
+      assert(res == Seq("c", "b"))
+    }
+  }
+}


### PR DESCRIPTION
+ Improve diamond module dep(avoid `.toList` allocation on duplicate
node) to 10x(I tried in one real project).
+ Add test suite to verify

Note this is not stack safe, but given that the module dep isn't like
deeply nested, it seems fine


│ Scenario │ Original (ops/s) │ New (ops/s) │ Speedup │
│ fewDeps (10 nodes) │ 1,244,170 │ 2,523,460 │ 2.0x │
│ mediumDeps (60 nodes) │ 110,509 │ 209,526 │ 1.9x │
│ manyDeps (550 nodes) │ 9,266 │ 33,186 │ 3.6x │
│ deepChain (200 depth) │ 30,818 │ 50,341 │ 1.6x │
│ diamond (41 nodes, shared) │ 21,231 │ 227,289 │ 10.7x │
│ wideDeep (200 nodes) │ 59,728 │ 111,478 │ 1.9x │
│ complexDAG (8 nodes, shared) │ 1,066,181 │ 1,810,533 │ 1.7x │


