### PR TITLE
Update nativeImageOptions to enable HTTP and HTTPS

### DIFF
--- a/dist/package.mill
+++ b/dist/package.mill
@@ -558,7 +558,7 @@ object `package` extends MillJavaModule with Proguard with DistModule {
 
     def nativeImageOptions = Seq(
       "--no-fallback",
-      "--enable-url-protocols=https",
+      "--enable-url-protocols=http,https",
       "-Os",
       // Build for compatibility with older CPUs that lack AVX2 and other modern features
       // https://github.com/com-lihaoyi/mill/issues/4630


### PR DESCRIPTION
Some enterprise intranet services still operate over HTTP without HTTPS support.   
This update adds protocol flexibility to ensure image loading works in both HTTP and HTTPS environments.