### PR TITLE
Test and fix IDEA `*.iml` file generation for Kotlin (backport #7082)

### DIFF
--- a/core/api/daemon/src/mill/api/daemon/internal/IdeUtils.scala
+++ b/core/api/daemon/src/mill/api/daemon/internal/IdeUtils.scala
@@ -1,0 +1,23 @@
+package mill.api.daemon.internal
+
+import mill.api.daemon.{Segment, Segments}
+import mill.api.*
+
+object IdeUtils {
+
+  /**
+   * Create the module name (to be used by an IDE) for the module based on its segments.
+   *
+   * @param path If the  segments yield no result, use the Mill Module folder name from this path.
+   * @see [[Module.moduleSegments]]
+   */
+  def moduleName(p: Segments): Option[String] = Some(p.value
+    .foldLeft(StringBuilder()) {
+      case (sb, Segment.Label(s)) if sb.isEmpty => sb.append(s)
+      case (sb, Segment.Cross(s)) if sb.isEmpty => sb.append(s.mkString("-"))
+      case (sb, Segment.Label(s)) => sb.append(".").append(s)
+      case (sb, Segment.Cross(s)) => sb.append("-").append(s.mkString("-"))
+    }
+    .mkString
+    .toLowerCase()).filterNot(_.isBlank)
+}

--- a/core/api/daemon/src/mill/api/daemon/internal/idea/Element.scala
+++ b/core/api/daemon/src/mill/api/daemon/internal/idea/Element.scala
@@ -1,13 +1,21 @@
 package mill.api.daemon.internal.idea
 
+import com.lihaoyi.unroll
+
 /**
  * Encoding of an Idea XML configuration fragment.
+ *
  * @param name The XML element name
  * @param attributes The optional XML element attributes
- * @param childs The optional XML child elements.
+ * @param childs Deprecated. The optional XML child elements.
+ * @param childsOrText The optional XML child elements or text content.
  */
 final case class Element(
     name: String,
     attributes: Map[String, String] = Map(),
-    childs: Seq[Element] = Seq()
+    @deprecated(
+      "Using Elements only is insufficient to represent PCData in XML. Use childsOrText instead.",
+      since = "Mill after 1.1.6"
+    ) childs: Seq[Element] = Seq(),
+    @unroll childsOrText: Seq[Element | String] = Seq()
 )

--- a/integration/feature/gen-idea/resources/hello-kotlin-idea/DepKotlin/src/UseHello.kt
+++ b/integration/feature/gen-idea/resources/hello-kotlin-idea/DepKotlin/src/UseHello.kt
@@ -1,0 +1,3 @@
+fun useHello(): String {
+    return greeting() + " (from DepKotlin)"
+}

--- a/integration/feature/gen-idea/resources/hello-kotlin-idea/HelloKotlin/src/Main.kt
+++ b/integration/feature/gen-idea/resources/hello-kotlin-idea/HelloKotlin/src/Main.kt
@@ -1,0 +1,7 @@
+internal fun greeting(): String {
+    return "Hello from Kotlin!"
+}
+
+public fun main() {
+    println(greeting())
+}

--- a/integration/feature/gen-idea/resources/hello-kotlin-idea/HelloKotlin/test/src/MainTest.kt
+++ b/integration/feature/gen-idea/resources/hello-kotlin-idea/HelloKotlin/test/src/MainTest.kt
@@ -1,0 +1,9 @@
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+
+class MainTest {
+    @Test
+    fun testGreeting() {
+        assertEquals("Hello from Kotlin!", greeting())
+    }
+}

--- a/integration/feature/gen-idea/resources/hello-kotlin-idea/build.mill
+++ b/integration/feature/gen-idea/resources/hello-kotlin-idea/build.mill
@@ -1,0 +1,20 @@
+package build
+
+import mill.*
+import mill.kotlinlib.{KotlinModule, KotlinIdeaModule}
+import mill.scalalib.TestModule
+
+object HelloKotlin extends KotlinModule with KotlinIdeaModule {
+  def kotlinVersion = "2.1.20"
+
+  def kotlinExplicitApi = true
+
+  object test extends KotlinTests with KotlinIdeaModule with TestModule.Junit5
+}
+
+object DepKotlin extends KotlinModule with KotlinIdeaModule {
+  def kotlinVersion = "2.1.20"
+  def moduleDeps = Seq(HelloKotlin)
+
+  override def kotlinFriendModules: Seq[KotlinModule] = Seq(HelloKotlin)
+}

--- a/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/libraries/scala3_library_3_3_3_3_jar.xml
+++ b/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/libraries/scala3_library_3_3_3_3_jar.xml
@@ -1,0 +1,10 @@
+<component name="libraryTable">
+    <library name="scala3-library_3-<version>.jar">
+        <CLASSES>
+            <root url="jar://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/scala-lang/scala3-library_3/<version>/scala3-library_3-<version>.jar!/"/>
+        </CLASSES>
+        <SOURCES>
+            <root url="jar://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/scala-lang/scala3-library_3/<version>/scala3-library_3-<version>.jar!/"/>
+        </SOURCES>
+    </library>
+</component>

--- a/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/libraries/scala3_library_3_3_7_4_jar.xml
+++ b/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/libraries/scala3_library_3_3_7_4_jar.xml
@@ -1,0 +1,10 @@
+<component name="libraryTable">
+    <library name="scala3-library_3-<version>.jar">
+        <CLASSES>
+            <root url="jar://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/scala-lang/scala3-library_3/<version>/scala3-library_3-<version>.jar!/"/>
+        </CLASSES>
+        <SOURCES>
+            <root url="jar://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/scala-lang/scala3-library_3/<version>/scala3-library_3-<version>.jar!/"/>
+        </SOURCES>
+    </library>
+</component>

--- a/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/libraries/scala_SDK_3_8_2.xml
+++ b/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/libraries/scala_SDK_3_8_2.xml
@@ -1,0 +1,17 @@
+<component name="libraryTable">
+    <library name="scala-SDK-<version>" type="Scala">
+        <properties>
+            <language-level>Scala_3_X</language-level>
+            <compiler-classpath>
+                <root url="file://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-asm/<version>/scala-asm-<version>.jar"/>
+                <root url="file://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/<version>/scala-library-<version>.jar"/>
+                <root url="file://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/scala-lang/scala3-compiler_3/<version>/scala3-compiler_3-<version>.jar"/>
+                <root url="file://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/scala-lang/scala3-interfaces/<version>/scala3-interfaces-<version>.jar"/>
+                <root url="file://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/scala-lang/scala3-library_3/<version>/scala3-library_3-<version>.jar"/>
+                <root url="file://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/scala-lang/tasty-core_3/<version>/tasty-core_3-<version>.jar"/>
+                <root url="file://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/scala-sbt/compiler-interface/<version>/compiler-interface-<version>.jar"/>
+                <root url="file://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/scala-sbt/util-interface/<version>/util-interface-<version>.jar"/>
+            </compiler-classpath>
+        </properties>
+    </library>
+</component>

--- a/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/libraries/scala_collection_compat_2_13_2_13_0_jar.xml
+++ b/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/libraries/scala_collection_compat_2_13_2_13_0_jar.xml
@@ -1,0 +1,10 @@
+<component name="libraryTable">
+    <library name="scala-collection-compat_2.13-2.13.0.jar">
+        <CLASSES>
+            <root url="jar://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-collection-compat_2.13/<version>/scala-collection-compat_2.13-<version>.jar!/"/>
+        </CLASSES>
+        <SOURCES>
+            <root url="jar://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-collection-compat_2.13/<version>/scala-collection-compat_2.13-<version>.jar!/"/>
+        </SOURCES>
+    </library>
+</component>

--- a/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/libraries/scala_collection_compat_3_2_12_0_jar.xml
+++ b/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/libraries/scala_collection_compat_3_2_12_0_jar.xml
@@ -1,0 +1,10 @@
+<component name="libraryTable">
+    <library name="scala-collection-compat_3-<version>.jar">
+        <CLASSES>
+            <root url="jar://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-collection-compat_3/<version>/scala-collection-compat_3-<version>.jar!/"/>
+        </CLASSES>
+        <SOURCES>
+            <root url="jar://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-collection-compat_3/<version>/scala-collection-compat_3-<version>.jar!/"/>
+        </SOURCES>
+    </library>
+</component>

--- a/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/libraries/scala_library_3_8_2_jar.xml
+++ b/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/libraries/scala_library_3_8_2_jar.xml
@@ -1,0 +1,10 @@
+<component name="libraryTable">
+    <library name="scala-library-<version>.jar">
+        <CLASSES>
+            <root url="jar://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/<version>/scala-library-<version>.jar!/"/>
+        </CLASSES>
+        <SOURCES>
+            <root url="jar://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/<version>/scala-library-<version>.jar!/"/>
+        </SOURCES>
+    </library>
+</component>

--- a/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/libraries/scala_reflect_2_13_18_jar.xml
+++ b/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/libraries/scala_reflect_2_13_18_jar.xml
@@ -1,0 +1,10 @@
+<component name="libraryTable">
+    <library name="scala-reflect-<version>.jar">
+        <CLASSES>
+            <root url="jar://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/<version>/scala-reflect-<version>.jar!/"/>
+        </CLASSES>
+        <SOURCES>
+            <root url="jar://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/<version>/scala-reflect-<version>.jar!/"/>
+        </SOURCES>
+    </library>
+</component>

--- a/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/libraries/scala_xml_2_13_2_4_0_jar.xml
+++ b/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/libraries/scala_xml_2_13_2_4_0_jar.xml
@@ -1,0 +1,10 @@
+<component name="libraryTable">
+    <library name="scala-xml_2.13-2.4.0.jar">
+        <CLASSES>
+            <root url="jar://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.13/<version>/scala-xml_2.13-<version>.jar!/"/>
+        </CLASSES>
+        <SOURCES>
+            <root url="jar://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.13/<version>/scala-xml_2.13-<version>.jar!/"/>
+        </SOURCES>
+    </library>
+</component>

--- a/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/libraries/scala_xml_3_2_4_0_jar.xml
+++ b/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/libraries/scala_xml_3_2_4_0_jar.xml
@@ -1,0 +1,10 @@
+<component name="libraryTable">
+    <library name="scala-xml_3-<version>.jar">
+        <CLASSES>
+            <root url="jar://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_3/<version>/scala-xml_3-<version>.jar!/"/>
+        </CLASSES>
+        <SOURCES>
+            <root url="jar://$USER_HOME$/COURSIER_CACHE/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_3/<version>/scala-xml_3-<version>.jar!/"/>
+        </SOURCES>
+    </library>
+</component>

--- a/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/mill_modules/depkotlin.iml
+++ b/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/mill_modules/depkotlin.iml
@@ -1,0 +1,33 @@
+<module type="JAVA_MODULE" version="4">
+    <component name="NewModuleRootManager">
+        <output url="file://$MODULE_DIR$/../../out/DepKotlin/internalGenIdea/ideaCompileOutput.dest/classes"/>
+        <exclude-output/>
+        <content url="file://$MODULE_DIR$/../../DepKotlin">
+            <sourceFolder url="file://$MODULE_DIR$/../../DepKotlin/src" isTestSource="false"/>
+            <sourceFolder url="file://$MODULE_DIR$/../../DepKotlin/resources" type="java-resource"/>
+        </content>
+        <orderEntry type="inheritedJdk"/>
+        <orderEntry type="sourceFolder" forTests="false"/>
+        <orderEntry type="library" name="annotations-13.0.jar" level="project"/>
+        <orderEntry type="library" name="kotlin-stdlib-<version>.jar" level="project"/>
+        <orderEntry type="module" module-name="hellokotlin" exported=""/>
+    </component>
+    <component name="FacetManager">
+        <facet type="kotlin-language" name="Kotlin">
+            <configuration version="5" useProjectSettings="false">
+                <additionalVisibleModuleNames>
+                    <friend>hellokotlin</friend>
+                </additionalVisibleModuleNames>
+                <compilerSettings>
+                    <option name="additionalArguments" value="-no-stdlib -module-name DepKotlin -language-version 2.1 -api-version 2.1 -Xfriend-paths=$MODULE_DIR$/../../out/HelloKotlin/internalGenIdea/ideaCompileOutput.dest/classes"/>
+                </compilerSettings>
+                <compilerArguments>
+                    <stringArguments>
+                        <stringArg name="apiVersion" arg="2.1"/>
+                        <stringArg name="languageVersion" arg="2.1"/>
+                    </stringArguments>
+                </compilerArguments>
+            </configuration>
+        </facet>
+    </component>
+</module>

--- a/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/mill_modules/hellokotlin.iml
+++ b/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/mill_modules/hellokotlin.iml
@@ -1,0 +1,29 @@
+<module type="JAVA_MODULE" version="4">
+    <component name="NewModuleRootManager">
+        <output url="file://$MODULE_DIR$/../../out/HelloKotlin/internalGenIdea/ideaCompileOutput.dest/classes"/>
+        <exclude-output/>
+        <content url="file://$MODULE_DIR$/../../HelloKotlin">
+            <sourceFolder url="file://$MODULE_DIR$/../../HelloKotlin/src" isTestSource="false"/>
+            <sourceFolder url="file://$MODULE_DIR$/../../HelloKotlin/resources" type="java-resource"/>
+        </content>
+        <orderEntry type="inheritedJdk"/>
+        <orderEntry type="sourceFolder" forTests="false"/>
+        <orderEntry type="library" name="annotations-13.0.jar" level="project"/>
+        <orderEntry type="library" name="kotlin-stdlib-<version>.jar" level="project"/>
+    </component>
+    <component name="FacetManager">
+        <facet type="kotlin-language" name="Kotlin">
+            <configuration version="5" useProjectSettings="false">
+                <compilerSettings>
+                    <option name="additionalArguments" value="-no-stdlib -module-name HelloKotlin -language-version 2.1 -api-version 2.1 -Xexplicit-api=strict"/>
+                </compilerSettings>
+                <compilerArguments>
+                    <stringArguments>
+                        <stringArg name="apiVersion" arg="2.1"/>
+                        <stringArg name="languageVersion" arg="2.1"/>
+                    </stringArguments>
+                </compilerArguments>
+            </configuration>
+        </facet>
+    </component>
+</module>

--- a/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/mill_modules/hellokotlin.test.iml
+++ b/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/mill_modules/hellokotlin.test.iml
@@ -1,0 +1,42 @@
+<module type="JAVA_MODULE" version="4">
+    <component name="NewModuleRootManager">
+        <output-test url="file://$MODULE_DIR$/../../out/HelloKotlin/test/internalGenIdea/ideaCompileOutput.dest/classes"/>
+        <exclude-output/>
+        <content url="file://$MODULE_DIR$/../../HelloKotlin/test">
+            <sourceFolder url="file://$MODULE_DIR$/../../HelloKotlin/test/src" isTestSource="true"/>
+            <sourceFolder url="file://$MODULE_DIR$/../../HelloKotlin/test/resources" type="java-test-resource"/>
+        </content>
+        <orderEntry type="inheritedJdk"/>
+        <orderEntry type="sourceFolder" forTests="false"/>
+        <orderEntry type="library" name="annotations-13.0.jar" level="project"/>
+        <orderEntry type="library" name="apiguardian-api-<version>.jar" level="project"/>
+        <orderEntry type="library" name="junit-jupiter-api-<version>.jar" level="project"/>
+        <orderEntry type="library" name="junit-jupiter-engine-<version>.jar" level="project"/>
+        <orderEntry type="library" name="junit-platform-commons-<version>.jar" level="project"/>
+        <orderEntry type="library" name="junit-platform-engine-<version>.jar" level="project"/>
+        <orderEntry type="library" name="junit-platform-launcher-<version>.jar" level="project"/>
+        <orderEntry type="library" name="jupiter-interface-<version>.jar" level="project"/>
+        <orderEntry type="library" name="kotlin-stdlib-<version>.jar" level="project"/>
+        <orderEntry type="library" name="opentest4j-<version>.jar" level="project"/>
+        <orderEntry type="library" name="test-interface-1.0.jar" level="project"/>
+        <orderEntry type="module" module-name="hellokotlin" exported=""/>
+    </component>
+    <component name="FacetManager">
+        <facet type="kotlin-language" name="Kotlin">
+            <configuration version="5" useProjectSettings="false">
+                <additionalVisibleModuleNames>
+                    <friend>hellokotlin</friend>
+                </additionalVisibleModuleNames>
+                <compilerSettings>
+                    <option name="additionalArguments" value="-no-stdlib -module-name HelloKotlin-test -language-version 2.1 -api-version 2.1 -Xfriend-paths=$MODULE_DIR$/../../out/HelloKotlin/internalGenIdea/ideaCompileOutput.dest/classes"/>
+                </compilerSettings>
+                <compilerArguments>
+                    <stringArguments>
+                        <stringArg name="apiVersion" arg="2.1"/>
+                        <stringArg name="languageVersion" arg="2.1"/>
+                    </stringArguments>
+                </compilerArguments>
+            </configuration>
+        </facet>
+    </component>
+</module>

--- a/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/mill_modules/mill-build.iml
+++ b/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/mill_modules/mill-build.iml
@@ -1,0 +1,126 @@
+<module type="JAVA_MODULE" version="4">
+    <component name="NewModuleRootManager">
+        <output url="file://$MODULE_DIR$/../../out/mill-build/internalGenIdea/ideaCompileOutput.dest/classes"/>
+        <exclude-output/>
+        <content url="file://$MODULE_DIR$/../..">
+            <sourceFolder url="file://$MODULE_DIR$/../../out/mill-build/generatedScriptSources.dest/support" isTestSource="false" generated="true"/>
+            <sourceFolder url="file://$MODULE_DIR$/../../build.mill" isTestSource="false"/>
+            <sourceFolder url="file://$MODULE_DIR$/../../mill-build/src" isTestSource="false"/>
+            <sourceFolder url="file://$MODULE_DIR$/../../mill-build/resources" type="java-resource"/>
+            <sourceFolder url="file://$MODULE_DIR$/../../out/mill-build/generatedScriptSources.dest/resources" type="java-resource"/>
+        </content>
+        <orderEntry type="inheritedJdk"/>
+        <orderEntry type="sourceFolder" forTests="false"/>
+        <orderEntry type="library" name="scala-SDK-<version>" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="aircompressor-0.27.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="cache-util-COURSIER_VERSION.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="commons-codec-<version>.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="commons-compress-<version>.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="commons-io-<version>.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="commons-lang3-<version>.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="concurrent-reference-hash-map-<version>.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="config_3-<version>.jar" level="project"/>
+        <orderEntry type="library" name="coursier-archive-cache_2.13-COURSIER_VERSION.jar" level="project"/>
+        <orderEntry type="library" name="coursier-cache_2.13-COURSIER_VERSION.jar" level="project"/>
+        <orderEntry type="library" name="coursier-core_2.13-COURSIER_VERSION.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="coursier-env_2.13-COURSIER_VERSION.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="coursier-exec-COURSIER_VERSION.jar" level="project"/>
+        <orderEntry type="library" name="coursier-jvm_2.13-COURSIER_VERSION.jar" level="project"/>
+        <orderEntry type="library" name="coursier-paths-COURSIER_VERSION.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="coursier-proxy-setup-COURSIER_VERSION.jar" level="project"/>
+        <orderEntry type="library" name="coursier-util_2.13-COURSIER_VERSION.jar" level="project"/>
+        <orderEntry type="library" name="coursier_2.13-COURSIER_VERSION.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="dependency_2.13-0.3.2.jar" level="project"/>
+        <orderEntry type="library" name="fansi_3-<version>.jar" level="project"/>
+        <orderEntry type="library" name="fastparse_3-<version>.jar" level="project"/>
+        <orderEntry type="library" name="geny_3-<version>.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="is-terminal-<version>.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="jansi.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="javax.inject-1.jar" level="project"/>
+        <orderEntry type="library" name="jline-<version>.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="jline-native-<version>.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="jna-<version>.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="jsoniter-scala-core_2.13-2.13.5.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="logback-classic-<version>.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="logback-core-<version>.jar" level="project"/>
+        <orderEntry type="library" name="mainargs_3-<version>.jar" level="project"/>
+        <orderEntry type="library" name="mill-core-api-daemon_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-core-api-java11_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-core-api_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-core-constants-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-core-eval_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-core-exec_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-core-internal-cli_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-core-internal_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-core-resolve_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-androidlib-databinding_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-androidlib_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-daemon-client_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-daemon-server_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-groovylib-api_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-groovylib_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-libs-init_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-javalib-api_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-javalib-testrunner-entrypoint-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-javalib-testrunner_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-javalib_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-javascriptlib_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-kotlinlib-api_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-kotlinlib-ksp2-api_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-kotlinlib_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-pythonlib_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-rpc_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-scalajslib-api_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-scalajslib_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-scalalib_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-scalanativelib-api_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-scalanativelib_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-script_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="mill-libs-tabcomplete_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-util-java11_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs-util_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-libs_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" name="mill-moduledefs_3-<version>.jar" level="project"/>
+        <orderEntry type="library" name="mill-runner-autooverride-api_3-SNAPSHOT.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="native-terminal-no-ffm-0.0.9.1.jar" level="project"/>
+        <orderEntry type="library" name="os-lib_3-<version>.jar" level="project"/>
+        <orderEntry type="library" name="os-zip-<version>.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="plexus-archiver-<version>.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="plexus-classworlds-<version>.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="plexus-container-default-<version>.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="plexus-io-<version>.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="plexus-utils-<version>.jar" level="project"/>
+        <orderEntry type="library" name="pprint_3-<version>.jar" level="project"/>
+        <orderEntry type="library" name="requests_3-<version>.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="scala-collection-compat_2.13-2.13.0.jar" level="project"/>
+        <orderEntry type="library" name="scala-collection-compat_3-<version>.jar" level="project"/>
+        <orderEntry type="library" name="scala-library-<version>.jar" level="project"/>
+        <orderEntry type="library" name="scala-reflect-<version>.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="scala-xml_2.13-2.4.0.jar" level="project"/>
+        <orderEntry type="library" name="scala-xml_3-<version>.jar" level="project"/>
+        <orderEntry type="library" scope="PROVIDED" name="scala3-library_3-<version>.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="scala3-library_3-<version>.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="slf4j-api-<version>.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="snakeyaml-engine-<version>.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="sonatype-central-client-core_3-<version>.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="sonatype-central-client-requests_3-<version>.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="sonatype-central-client-upickle_3-<version>.jar" level="project"/>
+        <orderEntry type="library" name="sourcecode_3-<version>.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="specification-level_3-<version>.jar" level="project"/>
+        <orderEntry type="library" name="test-interface-1.0.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="tika-core-<version>.jar" level="project"/>
+        <orderEntry type="library" name="ujson_3-<version>.jar" level="project"/>
+        <orderEntry type="library" name="unroll-annotation_3-<version>.jar" level="project"/>
+        <orderEntry type="library" name="upack_3-<version>.jar" level="project"/>
+        <orderEntry type="library" name="upickle-core_3-<version>.jar" level="project"/>
+        <orderEntry type="library" name="upickle-implicits-named-tuples_3-<version>.jar" level="project"/>
+        <orderEntry type="library" name="upickle-implicits_3-<version>.jar" level="project"/>
+        <orderEntry type="library" name="upickle_3-<version>.jar" level="project"/>
+        <orderEntry type="library" name="versions_2.13-0.5.1.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="windows-ansi-<version>.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="windows-jni-utils-<version>.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="xbean-reflect-3.7.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="xz-1.10.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="zstd-jni-1.5.7-4.jar" level="project"/>
+    </component>
+</module>

--- a/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/mill_modules/mill-build.iml
+++ b/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/mill_modules/mill-build.iml
@@ -12,7 +12,6 @@
         <orderEntry type="inheritedJdk"/>
         <orderEntry type="sourceFolder" forTests="false"/>
         <orderEntry type="library" name="scala-SDK-<version>" level="project"/>
-        <orderEntry type="library" scope="RUNTIME" name="aircompressor-0.27.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="cache-util-COURSIER_VERSION.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="commons-codec-<version>.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="commons-compress-<version>.jar" level="project"/>
@@ -117,10 +116,11 @@
         <orderEntry type="library" name="upickle-implicits_3-<version>.jar" level="project"/>
         <orderEntry type="library" name="upickle_3-<version>.jar" level="project"/>
         <orderEntry type="library" name="versions_2.13-0.5.1.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="versions_2.13-0.5.3.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="windows-ansi-<version>.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="windows-jni-utils-<version>.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="xbean-reflect-3.7.jar" level="project"/>
-        <orderEntry type="library" scope="RUNTIME" name="xz-1.10.jar" level="project"/>
-        <orderEntry type="library" scope="RUNTIME" name="zstd-jni-1.5.7-4.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="xz-1.12.jar" level="project"/>
+        <orderEntry type="library" scope="RUNTIME" name="zstd-jni-1.5.7-11.jar" level="project"/>
     </component>
 </module>

--- a/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/misc.xml
+++ b/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/misc.xml
@@ -1,0 +1,5 @@
+<project version="4">
+    <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8 (1)" project-jdk-type="JavaSDK">
+        <output url="file://$PROJECT_DIR$/target/idea_output"/>
+    </component>
+</project>

--- a/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/modules.xml
+++ b/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/modules.xml
@@ -1,0 +1,10 @@
+<project version="4">
+    <component name="ProjectModuleManager">
+        <modules>
+            <module fileurl="file://$PROJECT_DIR$/.idea/mill_modules/depkotlin.iml" filepath="$PROJECT_DIR$/.idea/mill_modules/depkotlin.iml"/>
+            <module fileurl="file://$PROJECT_DIR$/.idea/mill_modules/hellokotlin.iml" filepath="$PROJECT_DIR$/.idea/mill_modules/hellokotlin.iml"/>
+            <module fileurl="file://$PROJECT_DIR$/.idea/mill_modules/hellokotlin.test.iml" filepath="$PROJECT_DIR$/.idea/mill_modules/hellokotlin.test.iml"/>
+            <module fileurl="file://$PROJECT_DIR$/.idea/mill_modules/mill-build.iml" filepath="$PROJECT_DIR$/.idea/mill_modules/mill-build.iml"/>
+        </modules>
+    </component>
+</project>

--- a/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/scala_compiler.xml
+++ b/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/scala_compiler.xml
@@ -1,0 +1,30 @@
+<project version="4">
+    <component name="ScalaCompilerConfiguration">
+        <profile name="mill 1" modules="">
+            <parameters>
+                <parameter value="-Xplugin:.../com/lihaoyi/scalac-mill-moduledefs-plugin_3.8.2/<version>/scalac-mill-moduledefs-plugin_3.8.2-<version>.jar"/>
+                <parameter value="-Xplugin:.../com/lihaoyi/mill-runner-autooverride-plugin_3.8.2/SNAPSHOT/mill-runner-autooverride-plugin_3.8.2-SNAPSHOT.jar"/>
+                <parameter value="-deprecation"/>
+                <parameter value="-Wconf:msg=will be encoded on the classpath:silent"/>
+            </parameters>
+            <plugins>
+                <plugin path=".../com/lihaoyi/scalac-mill-moduledefs-plugin_3.8.2/<version>/scalac-mill-moduledefs-plugin_3.8.2-<version>.jar"/>
+                <plugin path=".../com/lihaoyi/mill-runner-autooverride-plugin_3.8.2/SNAPSHOT/mill-runner-autooverride-plugin_3.8.2-SNAPSHOT.jar"/>
+                <plugin path=".../org/scala-lang/scala3-compiler_3/<version>/scala3-compiler_3-<version>.jar"/>
+                <plugin path=".../org/scala-lang/scala3-library_3/<version>/scala3-library_3-<version>.jar"/>
+                <plugin path=".../com/lihaoyi/mill-moduledefs_3/<version>/mill-moduledefs_3-<version>.jar"/>
+                <plugin path=".../org/scala-lang/scala-library/<version>/scala-library-<version>.jar"/>
+                <plugin path=".../com/lihaoyi/unroll-annotation_3/<version>/unroll-annotation_3-<version>.jar"/>
+                <plugin path=".../org/scala-lang/scala3-interfaces/<version>/scala3-interfaces-<version>.jar"/>
+                <plugin path=".../org/scala-lang/tasty-core_3/<version>/tasty-core_3-<version>.jar"/>
+                <plugin path=".../org/scala-lang/modules/scala-asm/<version>/scala-asm-<version>.jar"/>
+                <plugin path=".../org/scala-sbt/compiler-interface/<version>/compiler-interface-<version>.jar"/>
+                <plugin path=".../org/scala-sbt/util-interface/<version>/util-interface-<version>.jar"/>
+            </plugins>
+        </profile>
+        <profile name="mill 2" modules="depkotlin,hellokotlin,hellokotlin.test">
+            <parameters></parameters>
+            <plugins></plugins>
+        </profile>
+    </component>
+</project>

--- a/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/scala_settings.xml
+++ b/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/scala_settings.xml
@@ -1,0 +1,5 @@
+<project version="4">
+    <component name="ScalaProjectSettings">
+        <option name="scFileMode" value="Ammonite"/>
+    </component>
+</project>

--- a/integration/feature/gen-idea/src/GenIdeaKotlinTests.scala
+++ b/integration/feature/gen-idea/src/GenIdeaKotlinTests.scala
@@ -1,0 +1,21 @@
+package mill.integration
+
+import mill.testkit.UtestIntegrationTestSuite
+import GenIdeaUtils.*
+import os.Path
+import utest.*
+
+object GenIdeaKotlinTests extends UtestIntegrationTestSuite {
+
+  override def workspaceSourcePath: Path = super.workspaceSourcePath / "hello-kotlin-idea"
+
+  def tests: Tests = Tests {
+    test("genIdeaKotlinTests") - integrationTest { tester =>
+      import tester.*
+      eval("version", check = true, stdout = os.Inherit, stderr = os.Inherit)
+      eval("mill.idea.GenIdea/", check = true, stdout = os.Inherit, stderr = os.Inherit)
+
+      assertIdeaFolderMatches(tester.workspaceSourcePath, workspacePath)
+    }
+  }
+}

--- a/libs/javalib/src/mill/javalib/idea/GenIdeaModule.scala
+++ b/libs/javalib/src/mill/javalib/idea/GenIdeaModule.scala
@@ -106,6 +106,7 @@ trait GenIdeaModule extends mill.api.Module with GenIdeaInternalApi {
     )
   }
 
+  // TODO: Change to Task.Simple[os.Path], since we don't care about the content hash
   private[mill] override def ideaCompileOutput: Task.Simple[PathRef] = Task(persistent = true) {
     PathRef(Task.dest / "classes")
   }

--- a/libs/kotlinlib/package.mill
+++ b/libs/kotlinlib/package.mill
@@ -18,7 +18,8 @@ object `package` extends MillStableScalaModule with BuildInfo {
     override def selectiveInputs = Seq(sources, resources) ++ kotlinSelectiveInputs
   }
 
-  def moduleDeps = Seq(build.libs.javalib, build.libs.javalib.testrunner, api, `ksp2-api`)
+  def moduleDeps =
+    Seq(build.libs.javalib, build.libs.javalib.testrunner, api, `ksp2-api`)
   def localTestExtraModules =
     super.localTestExtraModules ++ Seq(worker)
 

--- a/libs/kotlinlib/src/mill/kotlinlib/KotlinIdeaModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/KotlinIdeaModule.scala
@@ -1,7 +1,10 @@
 package mill.kotlinlib
 
-import mill.api.{Task, experimental}
 import mill.api.daemon.internal.idea.{Element, JavaFacet}
+import mill.api.{BuildCtx, Task, TaskCtx, experimental}
+import mill.api.daemon.internal.IdeUtils
+
+private lazy val FriendPathsPattern = "^-Xfriend-paths=(.+)$".r
 
 /**
  * Adds a JavaFacet to the generated .iml file with the Kotlin compiler options.
@@ -20,6 +23,30 @@ trait KotlinIdeaModule extends KotlinModule {
         )
       )
 
+    lazy val redirectedCompilerOptions = {
+      val options = scala.collection.mutable.Buffer.empty[String]
+
+      options ++= allKotlincOptions().filterNot {
+        case FriendPathsPattern(_) => true
+        case _ => false
+      }
+
+      if (kotlinFriendModulesChecked.nonEmpty) {
+        val redirectedFriendPaths = Task.traverse(kotlinFriendModulesChecked)(friend =>
+          Task.Anon { friend.genIdeaInternalExt().ideaCompileOutput().path }
+        )()
+        options += redirectedFriendPaths
+          .map(path => "$MODULE_DIR$/../../" + (path.relativeTo(BuildCtx.workspaceRoot)).toString)
+          .mkString("-Xfriend-paths=", ",", "")
+      }
+
+      options.mkString(" ")
+    }
+
+    lazy val friendElements = kotlinFriendModulesChecked
+      .flatMap(friend => IdeUtils.moduleName(friend.moduleSegments))
+      .map(friendName => Element("friend", childsOrText = Seq(friendName)))
+
     val facets = ideaConfigVersion match {
       case 4 => {
         Seq(
@@ -29,27 +56,34 @@ trait KotlinIdeaModule extends KotlinModule {
             Element(
               "configuration",
               attributes = Map(
-                "version" -> "5"
+                "version" -> "5",
+                "useProjectSettings" -> "false"
               ),
-              childs = Seq(
+              childsOrText = Seq(
+                if (friendElements.nonEmpty) {
+                  Element(
+                    "additionalVisibleModuleNames",
+                    childsOrText = friendElements
+                  )
+                } else null,
                 Element(
                   "compilerSettings",
-                  childs = Seq(
+                  childsOrText = Seq(
                     Element(
                       "option",
                       attributes = Map(
                         "name" -> "additionalArguments",
-                        "value" -> allKotlincOptions().mkString(" ")
+                        "value" -> redirectedCompilerOptions
                       )
                     )
                   )
                 ),
                 Element(
                   "compilerArguments",
-                  childs = Seq(
+                  childsOrText = Seq(
                     Element(
                       "stringArguments",
-                      childs =
+                      childsOrText =
                         Seq(
                           stringArgElement("apiVersion", kotlinApiVersion()),
                           stringArgElement("languageVersion", kotlinLanguageVersion())
@@ -59,7 +93,7 @@ trait KotlinIdeaModule extends KotlinModule {
                     )
                   )
                 )
-              )
+              ).filterNot(_ == null)
             )
           )
         )

--- a/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -358,9 +358,6 @@ trait KotlinModule extends JavaModule with KotlinModuleApi { outer =>
             "-classpath",
             compileCpPaths.iterator.mkString(File.pathSeparator)
           ),
-          when(kotlinExplicitApi())(
-            "-Xexplicit-api=strict"
-          ),
           allKotlincOptions(),
           extraKotlinArgs
         ).flatten
@@ -404,6 +401,28 @@ trait KotlinModule extends JavaModule with KotlinModuleApi { outer =>
     }
 
   /**
+   * Modules whose internal declarations are visible to this module.
+   *
+   * Drives `-Xfriend-modules` for Kotlin/JS and `-Xfriend-paths` elsewhere.
+   * See [`friendPaths`](https://kotlinlang.org/api/kotlin-gradle-plugin/kotlin-gradle-plugin-api/org.jetbrains.kotlin.gradle.tasks/-base-kotlin-compile/friend-paths.html) for the Gradle equivalent.
+   *
+   * When consuming, use [[kotlinFriendModulesChecked]] instead, which is checked for consistency and cached.
+   */
+  def kotlinFriendModules: Seq[KotlinModule] = Seq.empty[KotlinModule]
+
+  /**
+   * Same as [[kotlinFriendModules]], but checked for consistency.
+   * Prefer using this over [[kotlinFriendModules]].
+   */
+  private[kotlinlib] lazy val kotlinFriendModulesChecked: Seq[KotlinModule] = {
+    require(
+      kotlinFriendModules.toSet.subsetOf(moduleDepsChecked.toSet),
+      "All kotlinFriendModules must also be declared in moduleDeps"
+    )
+    kotlinFriendModules.distinct
+  }
+
+  /**
    * Additional Kotlin compiler options to be used by [[compile]].
    */
   def kotlincOptions: T[Seq[String]] = Task { Seq.empty[String] }
@@ -438,11 +457,20 @@ trait KotlinModule extends JavaModule with KotlinModuleApi { outer =>
     val kotlinkotlinApiVersion = kotlinApiVersion()
     val plugins = kotlincPluginJars().map(_.path)
 
+    val friendPathsOption = if (kotlinFriendModulesChecked.isEmpty) {
+      Seq.empty[String]
+    } else {
+      val compilations = Task.traverse(kotlinFriendModulesChecked) { friend => friend.compile }()
+      Seq(compilations.map(_.classes.path.toString).mkString("-Xfriend-paths=", ",", ""))
+    }
+
     Seq("-no-stdlib") ++
       kotlinModuleNameOption() ++
       when(!languageVersion.isBlank)("-language-version", languageVersion) ++
       when(!kotlinkotlinApiVersion.isBlank)("-api-version", kotlinkotlinApiVersion) ++
-      plugins.map(p => s"-Xplugin=$p")
+      plugins.map(p => s"-Xplugin=$p") ++
+      friendPathsOption ++
+      when(kotlinExplicitApi())("-Xexplicit-api=strict")
   }
 
   /**
@@ -514,10 +542,10 @@ trait KotlinModule extends JavaModule with KotlinModuleApi { outer =>
     override def kotlinVersion: T[String] = Task { outer.kotlinVersion() }
     override def kotlincPluginMvnDeps: T[Seq[Dep]] =
       Task { outer.kotlincPluginMvnDeps() }
-      // TODO: make Xfriend-path an explicit setting
+    override def kotlinFriendModules: Seq[KotlinModule] =
+      super.kotlinFriendModules ++ Seq(outer)
     override def kotlincOptions: T[Seq[String]] = Task {
-      outer.kotlincOptions().filterNot(_.startsWith("-Xcommon-sources")) ++
-        Seq(s"-Xfriend-paths=${outer.compile().classes.path.toString()}")
+      outer.kotlincOptions().filterNot(_.startsWith("-Xcommon-sources"))
     }
     override def kotlinUseEmbeddableCompiler: Task[Boolean] =
       Task.Anon { outer.kotlinUseEmbeddableCompiler() }
@@ -536,10 +564,10 @@ object KotlinModule {
     override def kotlinVersion: T[String] = Task { outer.kotlinVersion() }
     override def kotlincPluginMvnDeps: T[Seq[Dep]] =
       Task { outer.kotlincPluginMvnDeps() }
-    // TODO: make Xfriend-path an explicit setting
+    override def kotlinFriendModules: Seq[KotlinModule] =
+      super.kotlinFriendModules ++ Seq(outer)
     override def kotlincOptions: T[Seq[String]] = Task {
-      outer.kotlincOptions().filterNot(_.startsWith("-Xcommon-sources")) ++
-        Seq(s"-Xfriend-paths=${outer.compile().classes.path.toString()}")
+      outer.kotlincOptions().filterNot(_.startsWith("-Xcommon-sources"))
     }
     override def kotlinUseEmbeddableCompiler: Task[Boolean] =
       Task.Anon { outer.kotlinUseEmbeddableCompiler() }

--- a/libs/kotlinlib/src/mill/kotlinlib/js/KotlinJsModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/js/KotlinJsModule.scala
@@ -67,6 +67,17 @@ trait KotlinJsModule extends KotlinModule { outer =>
     Lib.findSourceFiles(allSources(), Seq("kt")).map(PathRef(_))
   }
 
+  override protected def mandatoryKotlincOptions: T[Seq[String]] = Task {
+    super.mandatoryKotlincOptions().flatMap {
+      // -no-stdlib is a JVM-only flag and is rejected by the Kotlin/JS compiler.
+      case "-no-stdlib" => None
+      // -Xfriend-paths is called -Xfriend-modules in the Kotlin/JS compiler
+      case option if option.startsWith("-Xfriend-paths=") =>
+        Some(option.replace("-Xfriend-paths=", "-Xfriend-modules="))
+      case other => Some(other)
+    }
+  }
+
   override def mandatoryMvnDeps: T[Seq[Dep]] =
     Seq(mvn"org.jetbrains.kotlin:kotlin-stdlib-js:${kotlinVersion()}")
 
@@ -198,7 +209,6 @@ trait KotlinJsModule extends KotlinModule { outer =>
           kotlinVersion = kotlinVersion(),
           destinationRoot = Task.dest,
           artifactId = artifactId(),
-          explicitApi = kotlinExplicitApi(),
           extraKotlinArgs = allKotlincOptions() ++ extraKotlinArgs,
           worker = kotlinWorker,
           useBtApi = kotlincUseBtApi()
@@ -229,7 +239,6 @@ trait KotlinJsModule extends KotlinModule { outer =>
           kotlinVersion = kotlinVersion(),
           destinationRoot = Task.dest,
           artifactId = artifactId(),
-          explicitApi = kotlinExplicitApi(),
           extraKotlinArgs = allKotlincOptions(),
           worker = kotlinWorker,
           useBtApi = kotlincUseBtApi()
@@ -274,7 +283,6 @@ trait KotlinJsModule extends KotlinModule { outer =>
       kotlinVersion: String,
       destinationRoot: os.Path,
       artifactId: String,
-      explicitApi: Boolean,
       extraKotlinArgs: Seq[String],
       worker: KotlinWorker,
       useBtApi: Boolean
@@ -383,9 +391,6 @@ trait KotlinJsModule extends KotlinModule { outer =>
       case Some(x) => Seq("-target", x)
       case None => Seq.empty
     })
-    if (explicitApi) {
-      innerCompilerArgs ++= Seq("-Xexplicit-api=strict")
-    }
 
     val compilerArgs: Seq[String] = Seq(
       innerCompilerArgs.result(),

--- a/libs/kotlinlib/src/mill/kotlinlib/kapt/KaptModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/kapt/KaptModule.scala
@@ -115,15 +115,14 @@ trait KaptModule extends KotlinModule { outer =>
           .map(_.path.toString)
           .map(path => s"plugin:org.jetbrains.kotlin.kapt3:apclasspath=$path")
 
+      // TODO: move compiler options to a dedicated function (or task) called from allKotlincOptions
+      //  to make it possible to observe all effective options and potentially override in subtypes
       val compilerArgs = Seq(
         Seq("-d", phaseClassesOutput.toString()),
         Seq("-Xmulti-platform"),
         when(compileCp.nonEmpty)(
           "-classpath",
           compileCp.mkString(File.pathSeparator)
-        ),
-        when(kotlinExplicitApi())(
-          "-Xexplicit-api=strict"
         ),
         allKotlincOptions(),
         apClasspathOpts.flatMap(opt => Seq("-P", opt))

--- a/mill-build/src/millbuild/MillStableJavaModule.scala
+++ b/mill-build/src/millbuild/MillStableJavaModule.scala
@@ -84,7 +84,15 @@ trait MillStableJavaModule extends MillPublishJavaModule with Mima {
     ProblemFilter.exclude[Problem]("mill.util.internal.DummyBuildFile*"),
     ProblemFilter.exclude[Problem]("mill.util.internal.DummyMiscInfo*"),
     ProblemFilter.exclude[Problem]("mill.api.internal.RootModule$Info*"),
-    ProblemFilter.exclude[Problem]("mill.api.internal.RootModule#Info*")
+    ProblemFilter.exclude[Problem]("mill.api.internal.RootModule#Info*"),
+    ProblemFilter.exclude[Problem]("mill.api.daemon.internal.bsp.BspServerHandle.*"),
+    // new method with default impl
+    ProblemFilter.exclude[ReversedMissingMethodProblem](
+      "mill.kotlinlib.KotlinModule#KotlinTests.mill$kotlinlib$KotlinModule$KotlinTests$$super$kotlinFriendModules"
+    ),
+    ProblemFilter.exclude[ReversedMissingMethodProblem](
+      "mill.kotlinlib.KotlinModule#KotlinTests0.mill$kotlinlib$KotlinModule$KotlinTests0$$super$kotlinFriendModules"
+    )
   )
 
   def mimaPreviousVersions: T[Seq[String]] = Settings.mimaBaseVersions

--- a/runner/eclipse/src/mill/eclipse/GenEclipseImpl.scala
+++ b/runner/eclipse/src/mill/eclipse/GenEclipseImpl.scala
@@ -1,7 +1,6 @@
 package mill.eclipse
 
 import mill.api.daemon.internal.eclipse.ResolvedModule
-import mill.api.daemon.{Segment, Segments}
 import mill.api.daemon.internal.{
   EvaluatorApi,
   JavaModuleApi,
@@ -9,7 +8,8 @@ import mill.api.daemon.internal.{
   ModuleApi,
   ScalaModuleApi,
   TaskApi,
-  TestModuleApi
+  TestModuleApi,
+  IdeUtils
 }
 
 import java.nio.file.{Files, Path, Paths}
@@ -165,7 +165,8 @@ class GenEclipseImpl(private val evaluators: Seq[EvaluatorApi]) {
 
     for ((path, value) <- resolvedJavaModules) {
       val projectModule = value.resolvedModule
-      val projectName = moduleName(projectModule.segments, path)
+      val projectName =
+        IdeUtils.moduleName(projectModule.segments).getOrElse(path.getFileName.toString)
       val isMainTestModule = isTestModule(projectModule.module)
 
       // By default source folders are inside the Eclipse JDT Project and therefore we create a
@@ -412,30 +413,6 @@ object GenEclipseImpl {
     }
 
     Library(dependencyPath, sourcesJarPath, javadocJarPath)
-  }
-
-  /**
-   *  Create the module name (to be used by Eclipse) for the module based on it segments. If the
-   *  segments yield no result, use the Mill Module folder name.
-   *
-   *  @see [[Module.moduleSegments]]
-   */
-  private def moduleName(segments: Segments, path: Path): String = {
-    val name = segments.value
-      .foldLeft(new StringBuilder()) {
-        case (sb, Segment.Label(s)) if sb.isEmpty => sb.append(s)
-        case (sb, Segment.Cross(s)) if sb.isEmpty => sb.append(s.mkString("-"))
-        case (sb, Segment.Label(s)) => sb.append(".").append(s)
-        case (sb, Segment.Cross(s)) => sb.append("-").append(s.mkString("-"))
-      }
-      .mkString
-      .toLowerCase()
-
-    // If for whatever reason no name could be created based on the module segments, create a
-    // generic one from the Mill Module folder name. Users can rename the project inside the
-    // Eclipse IDE if they like.
-    if (name.isBlank) path.getFileName.toString
-    else name
   }
 
   /**

--- a/runner/idea/src/mill/idea/GenIdeaImpl.scala
+++ b/runner/idea/src/mill/idea/GenIdeaImpl.scala
@@ -4,12 +4,12 @@ import scala.util.{Success, Try}
 import scala.xml.{Elem, MetaData, Node, NodeSeq, Null, UnprefixedAttribute}
 import scala.collection.mutable
 import java.net.URL
-
 import coursier.core.compatibility.xmlParseDom
 import coursier.maven.Pom
 import mill.api.*
 import mill.api.daemon.internal.{
   EvaluatorApi,
+  IdeUtils,
   JavaModuleApi,
   MillBuildRootModuleApi,
   ModuleApi,
@@ -23,6 +23,8 @@ import mill.api.daemon.internal.idea.{Element, IdeaConfigFile, JavaFacet, Resolv
 import mill.util.BuildInfo
 import org.eclipse.jgit.ignore.{FastIgnoreRule, IgnoreNode}
 import os.SubPath
+
+import scala.annotation.nowarn
 import scala.jdk.CollectionConverters.*
 
 class GenIdeaImpl(
@@ -189,7 +191,7 @@ class GenIdeaImpl(
         .partition(_.asWholeFile.isDefined)
 
     // whole file
-    val ideaWholeConfigFiles: Seq[(os.SubPath, Elem)] =
+    val ideaWholeConfigFiles: Seq[(os.SubPath, Node)] =
       wholeFileConfigs.flatMap(_.asWholeFile).map { wf =>
         os.sub / os.SubPath(wf._1) -> ideaConfigElementTemplate(wf._2)
       }
@@ -406,7 +408,9 @@ class GenIdeaImpl(
       Tuple2(
         os.sub / "modules.xml",
         allModulesXmlTemplate(
-          (modules.map { case (segments = segments) => moduleName(segments) } ++
+          (modules.map { case (segments = segments) =>
+            IdeUtils.moduleName(segments).getOrElse("")
+          } ++
             scriptFiles.map(scriptModuleName)).sorted
         )
       ),
@@ -517,7 +521,7 @@ class GenIdeaImpl(
           .from(recursive.map((_, None)) ++
             provided.map((_, Some("PROVIDED"))))
           .filter(!_._1.skipIdea)
-          .map { case (v, s) => ScopedOrd(moduleName(moduleLabels(v)), s) }
+          .map { case (v, s) => ScopedOrd(IdeUtils.moduleName(moduleLabels(v)).getOrElse(""), s) }
           .iterator
           .toSeq
           .distinct
@@ -547,7 +551,7 @@ class GenIdeaImpl(
       )
 
       val moduleFile = Tuple2(
-        os.sub / "mill_modules" / s"${moduleName(resolvedModule.segments)}.iml",
+        os.sub / "mill_modules" / s"${IdeUtils.moduleName(resolvedModule.segments).getOrElse("")}.iml",
         moduleXml
       )
 
@@ -611,8 +615,7 @@ class GenIdeaImpl(
     (Seq.fill(r.ups)("..") ++ r.segments).mkString("/")
   }
 
-  def ideaConfigElementTemplate(element: Element): Elem = {
-
+  def ideaConfigElementTemplate(element: Element): Node = {
     val example = <config/>
 
     val attribute1: MetaData =
@@ -629,7 +632,10 @@ class GenIdeaImpl(
       attributes1 = attribute1,
       example.scope,
       minimizeEmpty = true,
-      child = element.childs.map(ideaConfigElementTemplate)*
+      child = ((element.childs: @nowarn("cat=deprecation")) ++ element.childsOrText).map {
+        case e: Element => ideaConfigElementTemplate(e)
+        case s: String => scala.xml.Text(s)
+      }*
     )
   }
 
@@ -872,7 +878,7 @@ class GenIdeaImpl(
       settings: Map[(Seq[os.Path], Seq[String]), Vector[JavaModuleApi]]
   ) = {
     def modulesString(mods: Seq[ModuleApi]) =
-      mods.map(m => moduleName(m.moduleSegments)).mkString(",")
+      mods.map(m => IdeUtils.moduleName(m.moduleSegments).getOrElse("")).mkString(",")
 
     val orderedSettings = settings.toSeq.map {
       case ((plugins, params), mods) => ((plugins, params), modulesString(mods))
@@ -920,23 +926,6 @@ class GenIdeaImpl(
 }
 
 object GenIdeaImpl {
-
-  /**
-   * Create the module name (to be used by Idea) for the module based on it segments.
-   *
-   * @see [[Module.moduleSegments]]
-   */
-  def moduleName(p: Segments): String =
-    p.value
-      .foldLeft(new StringBuilder()) {
-        case (sb, Segment.Label(s)) if sb.isEmpty => sb.append(s)
-        case (sb, Segment.Cross(s)) if sb.isEmpty => sb.append(s.mkString("-"))
-        case (sb, Segment.Label(s)) => sb.append(".").append(s)
-        case (sb, Segment.Cross(s)) => sb.append("-").append(s.mkString("-"))
-      }
-      .mkString
-      .toLowerCase()
-
   def allJars(classloader: ClassLoader): Seq[URL] = {
     allClassloaders(classloader)
       .collect { case t: java.net.URLClassLoader => t.getURLs }


### PR DESCRIPTION
In Kotlin, a module can only access its own `internal` definitions and
`internal` definitions from its "friend" modules, configured by the
`-Xfriend-paths=` compiler option.

Previously, `.iml` files generated by `mill mill.idea/` for
`KotlinIdeaModule`s were incorrect:
- compilation output ended up somewhere in
`internalGenIdea/ideaCompileOutput.dest/classes`, but the
`-Xfriend-paths=` compiler option still referenced
`compile.dest/classes` directories
- IDEA highlighted attempts to access `internal` definitions from friend
modules as errors because the `<additionalVisibleModuleNames>` element
was missing from the IML configuration
- the generated modules defaulted to inheriting the project
configuration, which made any customisations they introduced irrelevant
- `kotlinExplicitApi` was handled inconsistently and was also missing
from the compiler options listed in IML files. I moved it to mandatory
compiler options and removed the ad-hoc handling, making the code
shorter overall.

This PR fixes these issues by introducing the higher-level
`kotlinFriendModules` setting to `KotlinModule`, from which the compiler
options and IDEA metadata are generated. It also adds an integration
test for `KotlinIdeaModule`s.

Backport of pull request: https://github.com/com-lihaoyi/mill/pull/7082

Co-authored-by: Tobias Roeser <le.petit.fou@web.de>
