### PR TITLE
GenIDEA: Order IML components lexicographically (backport #7084)

### DIFF
--- a/integration/feature/gen-idea/resources/extended/idea/mill_modules/helloworld.iml
+++ b/integration/feature/gen-idea/resources/extended/idea/mill_modules/helloworld.iml
@@ -1,4 +1,13 @@
 <module type="JAVA_MODULE" version="4">
+    <component name="FacetManager">
+        <facet type="AspectJ" name="AspectJ">
+            <configuration>
+                <projectLibrary>
+                    <option name="name" value="/tmp"/>
+                </projectLibrary>
+            </configuration>
+        </facet>
+    </component>
     <component name="NewModuleRootManager">
         <output url="file://$MODULE_DIR$/../../out/HelloWorld/internalGenIdea/ideaCompileOutput.dest/classes"/>
         <exclude-output/>
@@ -13,14 +22,5 @@
         <orderEntry type="sourceFolder" forTests="false"/>
         <orderEntry type="library" name="scala-SDK-<version>" level="project"/>
         <orderEntry type="library" name="scala-library-<version>.jar" level="project"/>
-    </component>
-    <component name="FacetManager">
-        <facet type="AspectJ" name="AspectJ">
-            <configuration>
-                <projectLibrary>
-                    <option name="name" value="/tmp"/>
-                </projectLibrary>
-            </configuration>
-        </facet>
     </component>
 </module>

--- a/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/mill_modules/depkotlin.iml
+++ b/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/mill_modules/depkotlin.iml
@@ -1,17 +1,4 @@
 <module type="JAVA_MODULE" version="4">
-    <component name="NewModuleRootManager">
-        <output url="file://$MODULE_DIR$/../../out/DepKotlin/internalGenIdea/ideaCompileOutput.dest/classes"/>
-        <exclude-output/>
-        <content url="file://$MODULE_DIR$/../../DepKotlin">
-            <sourceFolder url="file://$MODULE_DIR$/../../DepKotlin/src" isTestSource="false"/>
-            <sourceFolder url="file://$MODULE_DIR$/../../DepKotlin/resources" type="java-resource"/>
-        </content>
-        <orderEntry type="inheritedJdk"/>
-        <orderEntry type="sourceFolder" forTests="false"/>
-        <orderEntry type="library" name="annotations-13.0.jar" level="project"/>
-        <orderEntry type="library" name="kotlin-stdlib-<version>.jar" level="project"/>
-        <orderEntry type="module" module-name="hellokotlin" exported=""/>
-    </component>
     <component name="FacetManager">
         <facet type="kotlin-language" name="Kotlin">
             <configuration version="5" useProjectSettings="false">
@@ -29,5 +16,18 @@
                 </compilerArguments>
             </configuration>
         </facet>
+    </component>
+    <component name="NewModuleRootManager">
+        <output url="file://$MODULE_DIR$/../../out/DepKotlin/internalGenIdea/ideaCompileOutput.dest/classes"/>
+        <exclude-output/>
+        <content url="file://$MODULE_DIR$/../../DepKotlin">
+            <sourceFolder url="file://$MODULE_DIR$/../../DepKotlin/src" isTestSource="false"/>
+            <sourceFolder url="file://$MODULE_DIR$/../../DepKotlin/resources" type="java-resource"/>
+        </content>
+        <orderEntry type="inheritedJdk"/>
+        <orderEntry type="sourceFolder" forTests="false"/>
+        <orderEntry type="library" name="annotations-13.0.jar" level="project"/>
+        <orderEntry type="library" name="kotlin-stdlib-<version>.jar" level="project"/>
+        <orderEntry type="module" module-name="hellokotlin" exported=""/>
     </component>
 </module>

--- a/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/mill_modules/hellokotlin.iml
+++ b/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/mill_modules/hellokotlin.iml
@@ -1,16 +1,4 @@
 <module type="JAVA_MODULE" version="4">
-    <component name="NewModuleRootManager">
-        <output url="file://$MODULE_DIR$/../../out/HelloKotlin/internalGenIdea/ideaCompileOutput.dest/classes"/>
-        <exclude-output/>
-        <content url="file://$MODULE_DIR$/../../HelloKotlin">
-            <sourceFolder url="file://$MODULE_DIR$/../../HelloKotlin/src" isTestSource="false"/>
-            <sourceFolder url="file://$MODULE_DIR$/../../HelloKotlin/resources" type="java-resource"/>
-        </content>
-        <orderEntry type="inheritedJdk"/>
-        <orderEntry type="sourceFolder" forTests="false"/>
-        <orderEntry type="library" name="annotations-13.0.jar" level="project"/>
-        <orderEntry type="library" name="kotlin-stdlib-<version>.jar" level="project"/>
-    </component>
     <component name="FacetManager">
         <facet type="kotlin-language" name="Kotlin">
             <configuration version="5" useProjectSettings="false">
@@ -25,5 +13,17 @@
                 </compilerArguments>
             </configuration>
         </facet>
+    </component>
+    <component name="NewModuleRootManager">
+        <output url="file://$MODULE_DIR$/../../out/HelloKotlin/internalGenIdea/ideaCompileOutput.dest/classes"/>
+        <exclude-output/>
+        <content url="file://$MODULE_DIR$/../../HelloKotlin">
+            <sourceFolder url="file://$MODULE_DIR$/../../HelloKotlin/src" isTestSource="false"/>
+            <sourceFolder url="file://$MODULE_DIR$/../../HelloKotlin/resources" type="java-resource"/>
+        </content>
+        <orderEntry type="inheritedJdk"/>
+        <orderEntry type="sourceFolder" forTests="false"/>
+        <orderEntry type="library" name="annotations-13.0.jar" level="project"/>
+        <orderEntry type="library" name="kotlin-stdlib-<version>.jar" level="project"/>
     </component>
 </module>

--- a/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/mill_modules/hellokotlin.test.iml
+++ b/integration/feature/gen-idea/resources/hello-kotlin-idea/idea/mill_modules/hellokotlin.test.iml
@@ -1,4 +1,22 @@
 <module type="JAVA_MODULE" version="4">
+    <component name="FacetManager">
+        <facet type="kotlin-language" name="Kotlin">
+            <configuration version="5" useProjectSettings="false">
+                <additionalVisibleModuleNames>
+                    <friend>hellokotlin</friend>
+                </additionalVisibleModuleNames>
+                <compilerSettings>
+                    <option name="additionalArguments" value="-no-stdlib -module-name HelloKotlin-test -language-version 2.1 -api-version 2.1 -Xfriend-paths=$MODULE_DIR$/../../out/HelloKotlin/internalGenIdea/ideaCompileOutput.dest/classes"/>
+                </compilerSettings>
+                <compilerArguments>
+                    <stringArguments>
+                        <stringArg name="apiVersion" arg="2.1"/>
+                        <stringArg name="languageVersion" arg="2.1"/>
+                    </stringArguments>
+                </compilerArguments>
+            </configuration>
+        </facet>
+    </component>
     <component name="NewModuleRootManager">
         <output-test url="file://$MODULE_DIR$/../../out/HelloKotlin/test/internalGenIdea/ideaCompileOutput.dest/classes"/>
         <exclude-output/>
@@ -20,23 +38,5 @@
         <orderEntry type="library" name="opentest4j-<version>.jar" level="project"/>
         <orderEntry type="library" name="test-interface-1.0.jar" level="project"/>
         <orderEntry type="module" module-name="hellokotlin" exported=""/>
-    </component>
-    <component name="FacetManager">
-        <facet type="kotlin-language" name="Kotlin">
-            <configuration version="5" useProjectSettings="false">
-                <additionalVisibleModuleNames>
-                    <friend>hellokotlin</friend>
-                </additionalVisibleModuleNames>
-                <compilerSettings>
-                    <option name="additionalArguments" value="-no-stdlib -module-name HelloKotlin-test -language-version 2.1 -api-version 2.1 -Xfriend-paths=$MODULE_DIR$/../../out/HelloKotlin/internalGenIdea/ideaCompileOutput.dest/classes"/>
-                </compilerSettings>
-                <compilerArguments>
-                    <stringArguments>
-                        <stringArg name="apiVersion" arg="2.1"/>
-                        <stringArg name="languageVersion" arg="2.1"/>
-                    </stringArguments>
-                </compilerArguments>
-            </configuration>
-        </facet>
     </component>
 </module>

--- a/runner/idea/src/mill/idea/GenIdeaImpl.scala
+++ b/runner/idea/src/mill/idea/GenIdeaImpl.scala
@@ -801,6 +801,18 @@ class GenIdeaImpl(
     val outputUrl = relUrl(compileOutputPath)
 
     <module type="JAVA_MODULE" version={"" + ideaConfigVersion}>
+      {
+      if (facets.isEmpty) NodeSeq.Empty
+      else {
+        <component name="FacetManager">
+          {
+          for (facet <- facets) yield <facet type={facet.`type`} name={facet.name}>
+            {ideaConfigElementTemplate(facet.config)}
+          </facet>
+        }
+        </component>
+      }
+    }
       <component name="NewModuleRootManager">
         {
       if (isTest) <output-test url={outputUrl} />
@@ -859,18 +871,6 @@ class GenIdeaImpl(
         }
     }
       </component>
-      {
-      if (facets.isEmpty) NodeSeq.Empty
-      else {
-        <component name="FacetManager">
-            {
-          for (facet <- facets) yield <facet type={facet.`type`} name={facet.name}>
-              {ideaConfigElementTemplate(facet.config)}
-            </facet>
-        }
-          </component>
-      }
-    }
     </module>
   }
 


### PR DESCRIPTION
- [x] verify that IDEA maintains lexicographic ordering (see [the
community forums
question](https://intellij-support.jetbrains.com/hc/en-us/community/posts/35352485668882-Order-of-elements-in-IML-files))
- [x] once CI passes, mark the PR as `Ready for review` (CI will run on
the main Mill repo before we merge it)

Backport of pull request: https://github.com/com-lihaoyi/mill/pull/7084
