### PR TITLE
Refine defaults for `KotlinModule.kotlinFriendModules` (backport #7191)

### DIFF
--- a/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -415,9 +415,11 @@ trait KotlinModule extends JavaModule with KotlinModuleApi { outer =>
    * Prefer using this over [[kotlinFriendModules]].
    */
   private[kotlinlib] lazy val kotlinFriendModulesChecked: Seq[KotlinModule] = {
+    val deps = recursiveModuleDeps.toSet ++ compileModuleDeps
+    val missing = kotlinFriendModules.toSet.diff(deps)
     require(
-      kotlinFriendModules.toSet.subsetOf(moduleDepsChecked.toSet),
-      "All kotlinFriendModules must also be declared in moduleDeps"
+      missing.isEmpty,
+      s"All kotlinFriendModules must also be declared in moduleDeps/compileModuleDeps. Module ${this} is missing a dependency to ${missing.toSeq.map(_.toString).sorted.mkString(", ")}"
     )
     kotlinFriendModules.distinct
   }
@@ -543,7 +545,9 @@ trait KotlinModule extends JavaModule with KotlinModuleApi { outer =>
     override def kotlincPluginMvnDeps: T[Seq[Dep]] =
       Task { outer.kotlincPluginMvnDeps() }
     override def kotlinFriendModules: Seq[KotlinModule] =
-      super.kotlinFriendModules ++ Seq(outer)
+      super.kotlinFriendModules ++
+        // auto-add outer module, iff we depend on it
+        Seq(outer).filter(recursiveModuleDeps.toSet ++ compileModuleDeps)
     override def kotlincOptions: T[Seq[String]] = Task {
       outer.kotlincOptions().filterNot(_.startsWith("-Xcommon-sources"))
     }
@@ -565,7 +569,9 @@ object KotlinModule {
     override def kotlincPluginMvnDeps: T[Seq[Dep]] =
       Task { outer.kotlincPluginMvnDeps() }
     override def kotlinFriendModules: Seq[KotlinModule] =
-      super.kotlinFriendModules ++ Seq(outer)
+      super.kotlinFriendModules ++
+        // auto-add outer module, iff we depend on it
+        Seq(outer).filter(recursiveModuleDeps.toSet ++ compileModuleDeps)
     override def kotlincOptions: T[Seq[String]] = Task {
       outer.kotlincOptions().filterNot(_.startsWith("-Xcommon-sources"))
     }


### PR DESCRIPTION
1. We only add the outer module of a test module, when it is effectively
a module dependency.

2. Improve the error message; include the module and the missing
dependencies.

3. Extend the check to account for recursive and compile-only
dependencies.

Fix https://github.com/com-lihaoyi/mill/issues/7190

Backport of pull request: https://github.com/com-lihaoyi/mill/pull/7191
