### PR TITLE
Fix Kotlin incremental compilation (backport #7152)

### DIFF
--- a/integration/feature/kotlin-incremental-compilation/resources/build.mill
+++ b/integration/feature/kotlin-incremental-compilation/resources/build.mill
@@ -1,0 +1,18 @@
+package build
+
+import mill.*
+import kotlinlib.*
+
+trait BaseModule extends KotlinModule {
+  // BTAPI incremental compilation requires Kotlin >= 2.3.0, so we pin a concrete
+  // version here rather than using the lower default `TEST_KOTLIN_VERSION`.
+  def kotlinVersion = "2.3.21"
+
+  override def kotlinUseEmbeddableCompiler: T[Boolean] = Task { true }
+}
+
+object model extends BaseModule
+
+object consumer extends BaseModule {
+  def moduleDeps = Seq(model)
+}

--- a/integration/feature/kotlin-incremental-compilation/resources/consumer/src/UseFoo.kt
+++ b/integration/feature/kotlin-incremental-compilation/resources/consumer/src/UseFoo.kt
@@ -1,0 +1,3 @@
+fun useFoo(foo: Foo): String = when (foo) {
+    Foo.Bar -> "bar"
+}

--- a/integration/feature/kotlin-incremental-compilation/resources/model/src/Foo.kt
+++ b/integration/feature/kotlin-incremental-compilation/resources/model/src/Foo.kt
@@ -1,0 +1,3 @@
+sealed interface Foo {
+    data object Bar : Foo
+}

--- a/integration/feature/kotlin-incremental-compilation/src/KotlinIncrementalCompilationTests.scala
+++ b/integration/feature/kotlin-incremental-compilation/src/KotlinIncrementalCompilationTests.scala
@@ -1,0 +1,52 @@
+package mill.integration
+
+import mill.testkit.{IntegrationTester, UtestIntegrationTestSuite}
+
+import utest.*
+
+// Regression test: adding a variant to an upstream sealed type must invalidate
+// downstream `when` exhaustiveness checks via the Kotlin Build Tools API IC engine.
+object KotlinIncrementalCompilationTests extends UtestIntegrationTestSuite {
+
+  private val nonExhaustiveWhenError = "'when' expression must be exhaustive."
+  private val missingCaseName = "Oof"
+
+  val tests: Tests = Tests {
+    test("upstream sealed additions invalidate downstream exhaustive when") - integrationTest {
+      tester =>
+        import tester.*
+
+        val useBtApiEval = eval("consumer.kotlincUseBtApi")
+        assert(useBtApiEval.isSuccess)
+        assert(out("consumer.kotlincUseBtApi").value[Boolean])
+
+        assert(eval("consumer.compile").isSuccess)
+        writeFeatureBranchSources(workspacePath)
+
+        val branchSwitchCompile = eval("consumer.compile")
+        val cleanAfterSwitch = eval(("clean", "consumer"))
+        val cleanCompile = eval("consumer.compile")
+
+        assert(cleanAfterSwitch.isSuccess)
+        assert(failsWithMissingOof(cleanCompile))
+        assert(failsWithMissingOof(branchSwitchCompile))
+    }
+  }
+
+  private def failsWithMissingOof(result: IntegrationTester.EvalResult): Boolean =
+    !result.isSuccess &&
+      result.err.contains(nonExhaustiveWhenError) &&
+      result.err.contains(missingCaseName)
+
+  private def writeFeatureBranchSources(workspacePath: os.Path): Unit = {
+    os.write.over(
+      workspacePath / "model/src/Foo.kt",
+      """sealed interface Foo {
+        |    data object Bar : Foo
+        |
+        |    data object Oof : Foo
+        |}
+        |""".stripMargin
+    )
+  }
+}

--- a/libs/kotlinlib/api/src/mill/kotlinlib/worker/api/KotlinWorker.scala
+++ b/libs/kotlinlib/api/src/mill/kotlinlib/worker/api/KotlinWorker.scala
@@ -5,16 +5,24 @@
  */
 package mill.kotlinlib.worker.api
 
-import mill.api.TaskCtx
+import mill.api.{PathRef, TaskCtx}
 import mill.api.daemon.Result
 
 trait KotlinWorker {
 
+  /**
+   * Compile the given sources.
+   * @param useBtApi Whether to use the Build Tools API. Only relevant for [[KotlinWorkerTarget.Jvm]].
+   * @param args Compiler arguments.
+   * @param sources Source files to compile.
+   * @param classpath Compilation classpath, useful for incremental compilation.
+   */
   def compile(
       target: KotlinWorkerTarget,
       useBtApi: Boolean,
       args: Seq[String],
-      sources: Seq[os.Path]
+      sources: Seq[os.Path],
+      classpath: Seq[PathRef]
   )(using ctx: TaskCtx): Result[Unit]
 
 }

--- a/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -370,12 +370,14 @@ trait KotlinModule extends JavaModule with KotlinModuleApi { outer =>
         }
 
         val workerResult =
-          KotlinWorkerManager.kotlinWorker().withValue(kotlinCompilerClasspath()) {
+          val kotlinWorkerManager = KotlinWorkerManager.kotlinWorker()
+          kotlinWorkerManager.withValue(kotlinCompilerClasspath()) {
             _.compile(
               target = KotlinWorkerTarget.Jvm,
               useBtApi = useBtApi,
               args = compilerArgs,
-              sources = kotlinSourceFiles ++ javaSourceFiles
+              sources = kotlinSourceFiles ++ javaSourceFiles,
+              classpath = compileCp
             )
           }
 

--- a/libs/kotlinlib/src/mill/kotlinlib/KotlinWorkerManager.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/KotlinWorkerManager.scala
@@ -14,6 +14,11 @@ class KotlinWorkerManager()(using ctx: TaskCtx)
     extends ClassLoaderCachedFactory[KotlinWorker](ctx.jobs) {
 
   def getValue(cl: ClassLoader) = KotlinWorkerManager.get(cl)
+
+  override def close(): Unit = {
+    super.close()
+    os.remove.all(ctx.dest / "classpath-snapshots")
+  }
 }
 
 object KotlinWorkerManager extends ExternalModule {
@@ -28,7 +33,13 @@ object KotlinWorkerManager extends ExternalModule {
       ) + ".impl." + classOf[KotlinWorker].getSimpleName() + "Impl"
 
     val impl = toolsClassLoader.loadClass(className)
-    val worker = impl.getConstructor().newInstance().asInstanceOf[KotlinWorker]
+    // FIXME: this prevents reuse over JVM restarts but is safe with different snapshotting algorithms in different
+    //  classloaders
+    val classpathSnapshotCache =
+      ctx.dest / "classpath-snapshots" / toolsClassLoader.hashCode.toString
+    val worker = impl.getConstructor(
+      classOf[os.Path]
+    ).newInstance(classpathSnapshotCache).asInstanceOf[KotlinWorker]
     if (worker.getClass().getClassLoader() != toolsClassLoader) {
       ctx.log.warn(
         """Worker not loaded from worker classloader.

--- a/libs/kotlinlib/src/mill/kotlinlib/js/KotlinJsModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/js/KotlinJsModule.scala
@@ -410,7 +410,8 @@ trait KotlinJsModule extends KotlinModule { outer =>
       target = KotlinWorkerTarget.Js,
       useBtApi = useBtApi,
       args = compilerArgs,
-      sources = inputFiles
+      sources = inputFiles,
+      classpath = Nil
     )
 
     val analysisFile = Task.dest / "kotlin.analysis.dummy"

--- a/libs/kotlinlib/src/mill/kotlinlib/kapt/KaptModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/kapt/KaptModule.scala
@@ -94,7 +94,8 @@ trait KaptModule extends KotlinModule { outer =>
         incrementalData = PathRef(incrementalDataOutput)
       )
     } else {
-      val compileCp = compileClasspath().map(_.path).filter(os.exists)
+      val compileClasspathRefs = compileClasspath().filter(ref => os.exists(ref.path))
+      val compileCp = compileClasspathRefs.map(_.path)
       val aptMode = kaptAptMode()
       if (kotlinLanguageVersion().startsWith("2.") && aptMode != "stubsAndApt") {
         throw new RuntimeException(
@@ -140,12 +141,14 @@ trait KaptModule extends KotlinModule { outer =>
         )
       }
 
-      KotlinWorkerManager.kotlinWorker().withValue(kotlinCompilerClasspath()) {
+      val kotlinWorkerManager = KotlinWorkerManager.kotlinWorker()
+      kotlinWorkerManager.withValue(kotlinCompilerClasspath()) {
         _.compile(
           target = KotlinWorkerTarget.Jvm,
           useBtApi = useBtApi,
           args = compilerArgs,
-          sources = sourceFiles
+          sources = sourceFiles,
+          classpath = compileClasspathRefs
         )
       } match {
         case Result.Success(_) =>

--- a/libs/kotlinlib/src/mill/kotlinlib/ksp/KspModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/ksp/KspModule.scala
@@ -245,6 +245,7 @@ trait KspModule extends KotlinModule { outer =>
     val compiledSources = Task.dest / "compiled"
     os.makeDir.all(compiledSources)
 
+    val compileClasspathRefs = kspClasspath().filter(ref => os.exists(ref.path))
     val classpath = Seq(
       // destdir
       "-d",
@@ -266,12 +267,14 @@ trait KspModule extends KotlinModule { outer =>
       )
     }
 
-    KotlinWorkerManager.kotlinWorker().withValue(kotlinCompilerClasspath()) {
+    val kotlinWorkerManager = KotlinWorkerManager.kotlinWorker()
+    kotlinWorkerManager.withValue(kotlinCompilerClasspath()) {
       _.compile(
         target = KotlinWorkerTarget.Jvm,
         useBtApi = useBtApi,
         args = compilerArgs,
-        sources = sourceFiles
+        sources = sourceFiles,
+        classpath = compileClasspathRefs
       )
     }
 

--- a/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/Compiler.scala
+++ b/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/Compiler.scala
@@ -1,11 +1,18 @@
 package mill.kotlinlib.worker.impl
 
-import mill.api.TaskCtx
+import mill.api.{PathRef, TaskCtx}
 
 trait Compiler {
+
+  /**
+   * @param args Compiler arguments.
+   * @param sources Source files to compile.
+   * @param classpath Compilation classpath, useful for incremental compilation.
+   */
   def compile(
       args: Seq[String],
-      sources: Seq[os.Path]
+      sources: Seq[os.Path],
+      classpath: Seq[PathRef]
   )(using
       ctx: TaskCtx
   ): (Int, String)

--- a/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JsCompileImpl.scala
+++ b/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JsCompileImpl.scala
@@ -1,13 +1,14 @@
 package mill.kotlinlib.worker.impl
 
-import mill.api.TaskCtx
+import mill.api.{PathRef, TaskCtx}
 import org.jetbrains.kotlin.cli.js.K2JSCompiler
 
 class JsCompileImpl extends Compiler() {
 
   def compile(
       args: Seq[String],
-      sources: Seq[os.Path]
+      sources: Seq[os.Path],
+      classpath: Seq[PathRef]
   )(using
       ctx: TaskCtx
   ): (Int, String) = {

--- a/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JvmCompileBtApiImpl.scala
+++ b/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JvmCompileBtApiImpl.scala
@@ -78,11 +78,11 @@ class JvmCompileBtApiImpl(
     // The BTAPI IC engine (RelocatableFileToPathConverter) rejects the relative
     // `../mill-workspace/...` paths os-lib renders inside Mill's sandbox, so every
     // path handed to it is resolved to a real absolute path via `PathRef.toAbsNioPath`.
-    val sourceFiles = sources.map(PathRef.toAbsNioPath(_)).asJava
+    val sourceFiles = sources.map(_.toNIO).asJava
     val compilationOperation =
       jvmToolchain.createJvmCompilationOperation(
         sourceFiles,
-        PathRef.toAbsNioPath(destinationDirectory)
+        destinationDirectory.toNIO
       )
 
     compilationOperation.getCompilerArguments().applyArgumentStrings(args.asJava)
@@ -90,11 +90,11 @@ class JvmCompileBtApiImpl(
     val snapshotIcOptions = compilationOperation.createSnapshotBasedIcOptions().tap { options =>
       options.set(
         JvmSnapshotBasedIncrementalCompilationOptions.ROOT_PROJECT_DIR,
-        PathRef.toAbsNioPath(ctx.workspace)
+        ctx.workspace.toNIO
       )
       options.set(
         JvmSnapshotBasedIncrementalCompilationOptions.MODULE_BUILD_DIR,
-        PathRef.toAbsNioPath(incrementalCachePath)
+        incrementalCachePath.toNIO
       )
       options.set(
         JvmSnapshotBasedIncrementalCompilationOptions.PRECISE_JAVA_TRACKING,
@@ -113,10 +113,10 @@ class JvmCompileBtApiImpl(
         }
 
         val incrementalConfig = new JvmSnapshotBasedIncrementalCompilationConfiguration(
-          PathRef.toAbsNioPath(incrementalCachePath),
+          incrementalCachePath.toNIO,
           SourcesChanges.ToBeCalculated.INSTANCE,
           classpathSnapshotFiles.asJava,
-          PathRef.toAbsNioPath(incrementalCachePath / "shrunk-classpath-snapshot.bin"),
+          (incrementalCachePath / "shrunk-classpath-snapshot.bin").toNIO,
           snapshotIcOptions
         )
         compilationOperation.set(JvmCompilationOperation.INCREMENTAL_COMPILATION, incrementalConfig)
@@ -158,7 +158,7 @@ class JvmCompileBtApiImpl(
     val snapshotFile = classpathSnapshotCache / s"${ref.sig}.snapshot"
     if (!os.exists(snapshotFile)) {
       val snapshottingOperation =
-        jvmToolchain.createClasspathSnapshottingOperation(PathRef.toAbsNioPath(ref.path))
+        jvmToolchain.createClasspathSnapshottingOperation(ref.path.toNIO)
       snapshottingOperation.set(
         JvmClasspathSnapshottingOperation.GRANULARITY,
         ClassSnapshotGranularity.CLASS_MEMBER_LEVEL
@@ -174,9 +174,9 @@ class JvmCompileBtApiImpl(
       )
 
       val tmpFile = os.temp(dir = classpathSnapshotCache, suffix = ".snapshot")
-      snapshot.saveSnapshot(PathRef.toAbsNioPath(tmpFile).toFile)
+      snapshot.saveSnapshot(tmpFile.toIO)
       os.move(tmpFile, snapshotFile, atomicMove = true, replaceExisting = true)
     }
-    PathRef.toAbsNioPath(snapshotFile)
+    snapshotFile.toNIO
   }
 }

--- a/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JvmCompileBtApiImpl.scala
+++ b/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JvmCompileBtApiImpl.scala
@@ -1,15 +1,18 @@
 package mill.kotlinlib.worker.impl
 
-import mill.api.TaskCtx
+import mill.api.{PathRef, TaskCtx}
 import org.jetbrains.kotlin.buildtools.api.{
   CompilationResult,
+  ExecutionPolicy,
   KotlinLogger,
   KotlinToolchains,
   SourcesChanges
 }
 import org.jetbrains.kotlin.buildtools.api.jvm.JvmPlatformToolchain
+import org.jetbrains.kotlin.buildtools.api.jvm.ClassSnapshotGranularity
 import org.jetbrains.kotlin.buildtools.api.jvm.JvmSnapshotBasedIncrementalCompilationConfiguration
 import org.jetbrains.kotlin.buildtools.api.jvm.JvmSnapshotBasedIncrementalCompilationOptions
+import org.jetbrains.kotlin.buildtools.api.jvm.operations.JvmClasspathSnapshottingOperation
 import org.jetbrains.kotlin.buildtools.api.jvm.operations.JvmCompilationOperation
 import org.jetbrains.kotlin.cli.common.ExitCode
 
@@ -17,7 +20,14 @@ import java.io.{PrintWriter, StringWriter}
 import scala.jdk.CollectionConverters.*
 import scala.util.chaining.scalaUtilChainingOps
 
-class JvmCompileBtApiImpl() extends Compiler {
+/**
+ * @param classpathSnapshotCache The path to store classpath snapshots for incremental compilation.
+ *                               Should live longer than the compile task itself, i.e. within a Worker
+ *                               or a persistent task.
+ */
+class JvmCompileBtApiImpl(
+    val classpathSnapshotCache: os.Path
+) extends Compiler {
 
   private def formatThrowable(throwable: Throwable): String = {
     val sw = new StringWriter()
@@ -53,7 +63,11 @@ class JvmCompileBtApiImpl() extends Compiler {
       .getOrElse(ctx.dest / "classes")
   }
 
-  def compile(args: Seq[String], sources: Seq[os.Path])(using ctx: TaskCtx): (Int, String) = {
+  def compile(
+      args: Seq[String],
+      sources: Seq[os.Path],
+      classpath: Seq[PathRef]
+  )(using ctx: TaskCtx): (Int, String) = {
 
     val incrementalCachePath = ctx.dest / "inc-state"
     os.makeDir.all(incrementalCachePath)
@@ -61,20 +75,26 @@ class JvmCompileBtApiImpl() extends Compiler {
 
     val toolchains = KotlinToolchains.loadImplementation(getClass().getClassLoader())
     val jvmToolchain = JvmPlatformToolchain.from(toolchains)
-    val sourceFiles = sources.map(_.toNIO).asJava
+    // The BTAPI IC engine (RelocatableFileToPathConverter) rejects the relative
+    // `../mill-workspace/...` paths os-lib renders inside Mill's sandbox, so every
+    // path handed to it is resolved to a real absolute path via `PathRef.toAbsNioPath`.
+    val sourceFiles = sources.map(PathRef.toAbsNioPath(_)).asJava
     val compilationOperation =
-      jvmToolchain.createJvmCompilationOperation(sourceFiles, destinationDirectory.toNIO)
+      jvmToolchain.createJvmCompilationOperation(
+        sourceFiles,
+        PathRef.toAbsNioPath(destinationDirectory)
+      )
 
     compilationOperation.getCompilerArguments().applyArgumentStrings(args.asJava)
 
     val snapshotIcOptions = compilationOperation.createSnapshotBasedIcOptions().tap { options =>
       options.set(
         JvmSnapshotBasedIncrementalCompilationOptions.ROOT_PROJECT_DIR,
-        ctx.workspace.toNIO
+        PathRef.toAbsNioPath(ctx.workspace)
       )
       options.set(
         JvmSnapshotBasedIncrementalCompilationOptions.MODULE_BUILD_DIR,
-        incrementalCachePath.toNIO
+        PathRef.toAbsNioPath(incrementalCachePath)
       )
       options.set(
         JvmSnapshotBasedIncrementalCompilationOptions.PRECISE_JAVA_TRACKING,
@@ -82,23 +102,28 @@ class JvmCompileBtApiImpl() extends Compiler {
       )
     }
 
-    // Snapshot-based incremental compilation stores state in `inc-state`.
-    // The empty snapshot list means Kotlin computes classpath snapshots from current classpath entries.
-    val incrementalConfig = new JvmSnapshotBasedIncrementalCompilationConfiguration(
-      incrementalCachePath.toNIO,
-      SourcesChanges.ToBeCalculated.INSTANCE,
-      Seq.empty[java.nio.file.Path].asJava,
-      (incrementalCachePath / "shrunk-classpath-snapshot.bin").toNIO,
-      snapshotIcOptions
-    )
-    compilationOperation.set(JvmCompilationOperation.INCREMENTAL_COMPILATION, incrementalConfig)
+    os.makeDir.all(classpathSnapshotCache)
 
     val compilationResult = {
       val buildSession = toolchains.createBuildSession()
+      val executionPolicy = toolchains.createInProcessExecutionPolicy()
       try {
+        val classpathSnapshotFiles = classpath.filter(ref => os.exists(ref.path)).map { ref =>
+          snapshot(jvmToolchain, buildSession, executionPolicy, ref)
+        }
+
+        val incrementalConfig = new JvmSnapshotBasedIncrementalCompilationConfiguration(
+          PathRef.toAbsNioPath(incrementalCachePath),
+          SourcesChanges.ToBeCalculated.INSTANCE,
+          classpathSnapshotFiles.asJava,
+          PathRef.toAbsNioPath(incrementalCachePath / "shrunk-classpath-snapshot.bin"),
+          snapshotIcOptions
+        )
+        compilationOperation.set(JvmCompilationOperation.INCREMENTAL_COMPILATION, incrementalConfig)
+
         buildSession.executeOperation(
           compilationOperation,
-          toolchains.createInProcessExecutionPolicy(),
+          executionPolicy,
           kotlinLogger
         )
       } finally {
@@ -119,4 +144,39 @@ class JvmCompileBtApiImpl() extends Compiler {
     (exitCode.getCode(), exitCode.name())
   }
 
+  // A classpath entry's snapshot depends only on its content, so cache each
+  // snapshot under the entry's `PathRef.sig`. A content change yields a new
+  // `sig`, hence a new snapshot path, which both invalidates the cache and
+  // makes the (potentially warm, daemon-resident) IC engine load the fresh
+  // snapshot rather than a stale one cached by file path.
+  private def snapshot(
+      jvmToolchain: JvmPlatformToolchain,
+      buildSession: KotlinToolchains.BuildSession,
+      executionPolicy: ExecutionPolicy.InProcess,
+      ref: PathRef
+  )(using TaskCtx): java.nio.file.Path = {
+    val snapshotFile = classpathSnapshotCache / s"${ref.sig}.snapshot"
+    if (!os.exists(snapshotFile)) {
+      val snapshottingOperation =
+        jvmToolchain.createClasspathSnapshottingOperation(PathRef.toAbsNioPath(ref.path))
+      snapshottingOperation.set(
+        JvmClasspathSnapshottingOperation.GRANULARITY,
+        ClassSnapshotGranularity.CLASS_MEMBER_LEVEL
+      )
+      snapshottingOperation.set(
+        JvmClasspathSnapshottingOperation.PARSE_INLINED_LOCAL_CLASSES,
+        java.lang.Boolean.TRUE
+      )
+      val snapshot = buildSession.executeOperation(
+        snapshottingOperation,
+        executionPolicy,
+        kotlinLogger
+      )
+
+      val tmpFile = os.temp(dir = classpathSnapshotCache, suffix = ".snapshot")
+      snapshot.saveSnapshot(PathRef.toAbsNioPath(tmpFile).toFile)
+      os.move(tmpFile, snapshotFile, atomicMove = true, replaceExisting = true)
+    }
+    PathRef.toAbsNioPath(snapshotFile)
+  }
 }

--- a/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JvmCompileImpl.scala
+++ b/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JvmCompileImpl.scala
@@ -1,13 +1,14 @@
 package mill.kotlinlib.worker.impl
 
-import mill.api.TaskCtx
+import mill.api.{PathRef, TaskCtx}
 import org.jetbrains.kotlin.cli.jvm.K2JVMCompiler
 
 class JvmCompileImpl() extends Compiler {
 
   def compile(
       args: Seq[String],
-      sources: Seq[os.Path]
+      sources: Seq[os.Path],
+      classpath: Seq[PathRef]
   )(using
       ctx: TaskCtx
   ): (Int, String) = {

--- a/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/KotlinWorkerImpl.scala
+++ b/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/KotlinWorkerImpl.scala
@@ -9,13 +9,15 @@ import mill.api.daemon.Result
 import mill.api.TaskCtx
 import mill.kotlinlib.worker.api.{KotlinWorker, KotlinWorkerTarget}
 
-class KotlinWorkerImpl extends KotlinWorker {
-
+class KotlinWorkerImpl(
+    private val classpathSnapshotCache: os.Path
+) extends KotlinWorker {
   def compile(
       target: KotlinWorkerTarget,
       useBtApi: Boolean,
       args: Seq[String],
-      sources: Seq[os.Path]
+      sources: Seq[os.Path],
+      classpath: Seq[mill.api.PathRef]
   )(using
       ctx: TaskCtx
   ): Result[Unit] = {
@@ -26,14 +28,16 @@ class KotlinWorkerImpl extends KotlinWorker {
 
     // Use dedicated class to load implementation classes lazily
     val compiler = (target = target, useBtApi = useBtApi) match {
-      case (KotlinWorkerTarget.Jvm, true) => JvmCompileBtApiImpl()
+      case (KotlinWorkerTarget.Jvm, true) => JvmCompileBtApiImpl(
+          classpathSnapshotCache = classpathSnapshotCache
+        )
       case (KotlinWorkerTarget.Jvm, false) => JvmCompileImpl()
       case (target = KotlinWorkerTarget.Js) => JsCompileImpl()
     }
 
     ctx.log.debug(s"Using compiler backend: ${compiler.getClass().getSimpleName()}")
 
-    val (exitCode, exitCodeName) = compiler.compile(args, sources)
+    val (exitCode, exitCodeName) = compiler.compile(args, sources, classpath)
 
     if (exitCode != 0) {
       sys.error(s"Kotlin compiler failed with exit code ${exitCode} ($exitCodeName)")


### PR DESCRIPTION
Fix https://github.com/com-lihaoyi/mill/issues/7148

The original problem was that Mill assumed the BT API would compute a
classpath snapshot if it's called with an empty one. This is not the
case, it's up to Mill to compute this snapshot for correct incremental
compilation.

We store these snapshots for every element of the classpath under a
`classpath-snapshots/hashCode` directory in the
`KotlinWorkerManager.kotlinWorker`'s `Task.dest`, where `hashCode` is
the hash code of the tools classloader. This keeps them separate should
there be multiple classloaders with different snapshotting
implementations.

The unfortunate side effect is that we don't reuse snapshots across JVM
restarts. Optimising this is left for future work.

Backport of pull request: https://github.com/com-lihaoyi/mill/pull/7152
