### PR TITLE
Make Kotlin classpath snapshotting persistent (backport #7306)

### DIFF
--- a/libs/kotlinlib/api/src/mill/kotlinlib/worker/api/kotlinlib.scala
+++ b/libs/kotlinlib/api/src/mill/kotlinlib/worker/api/kotlinlib.scala
@@ -1,0 +1,6 @@
+package mill.kotlinlib.worker
+
+package object api {
+  private[kotlinlib] inline def renderIntAsHex(sig: Int): String =
+    String.format("%08x", sig: Integer)
+}

--- a/libs/kotlinlib/src/mill/kotlinlib/KotlinWorkerManager.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/KotlinWorkerManager.scala
@@ -9,16 +9,21 @@ import mill.*
 import mill.api.{Discover, ExternalModule, TaskCtx}
 import mill.kotlinlib.worker.api.KotlinWorker
 import mill.util.ClassLoaderCachedFactory
+import mill.kotlinlib.worker.api.renderIntAsHex
 
 class KotlinWorkerManager()(using ctx: TaskCtx)
     extends ClassLoaderCachedFactory[KotlinWorker](ctx.jobs) {
 
-  def getValue(cl: ClassLoader) = KotlinWorkerManager.get(cl)
+  @deprecated("Use the other overload instead.", "Mill after 1.2.0-RC1")
+  override def getValue(cachedClassLoader: ClassLoader): KotlinWorker =
+    KotlinWorkerManager.get(cachedClassLoader)
 
-  override def close(): Unit = {
-    super.close()
-    os.remove.all(ctx.dest / "classpath-snapshots")
-  }
+  override def getValue(cachedClassLoader: ClassLoader, classpath: Seq[PathRef]): KotlinWorker =
+    KotlinWorkerManager.get(
+      toolsClassLoader = cachedClassLoader,
+      cachePathHashCode = classpath.map(_.sig).hashCode(),
+      cachePathIsStable = true
+    )
 }
 
 object KotlinWorkerManager extends ExternalModule {
@@ -26,7 +31,17 @@ object KotlinWorkerManager extends ExternalModule {
     new KotlinWorkerManager()
   }
 
-  def get(toolsClassLoader: ClassLoader)(using ctx: TaskCtx): KotlinWorker = {
+  @deprecated("Use the other overload instead.", "Mill after 1.2.0-RC1")
+  def get(toolsClassLoader: ClassLoader)(using ctx: TaskCtx): KotlinWorker =
+    get(toolsClassLoader, toolsClassLoader.hashCode(), cachePathIsStable = false)
+
+  private def get(
+      toolsClassLoader: ClassLoader,
+      cachePathHashCode: Int,
+      cachePathIsStable: Boolean
+  )(using
+      ctx: TaskCtx
+  ): KotlinWorker = {
     val className =
       classOf[KotlinWorker].getPackage().getName().split("\\.").dropRight(1).mkString(
         "."
@@ -36,10 +51,18 @@ object KotlinWorkerManager extends ExternalModule {
     // FIXME: this prevents reuse over JVM restarts but is safe with different snapshotting algorithms in different
     //  classloaders
     val classpathSnapshotCache =
-      ctx.dest / "classpath-snapshots" / toolsClassLoader.hashCode.toString
-    val worker = impl.getConstructor(
-      classOf[os.Path]
-    ).newInstance(classpathSnapshotCache).asInstanceOf[KotlinWorker]
+      ctx.dest / s"${
+          if (cachePathIsStable) "stable-" else ""
+        }classpath-snapshots" / renderIntAsHex(cachePathHashCode)
+
+    val worker = impl
+      .getConstructor(
+        classOf[os.Path],
+        classOf[Boolean]
+      )
+      .newInstance(classpathSnapshotCache, cachePathIsStable)
+      .asInstanceOf[KotlinWorker]
+
     if (worker.getClass().getClassLoader() != toolsClassLoader) {
       ctx.log.warn(
         """Worker not loaded from worker classloader.

--- a/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JvmCompileBtApiImpl.scala
+++ b/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/JvmCompileBtApiImpl.scala
@@ -15,6 +15,7 @@ import org.jetbrains.kotlin.buildtools.api.jvm.JvmSnapshotBasedIncrementalCompil
 import org.jetbrains.kotlin.buildtools.api.jvm.operations.JvmClasspathSnapshottingOperation
 import org.jetbrains.kotlin.buildtools.api.jvm.operations.JvmCompilationOperation
 import org.jetbrains.kotlin.cli.common.ExitCode
+import mill.kotlinlib.worker.api.renderIntAsHex
 
 import java.io.{PrintWriter, StringWriter}
 import scala.jdk.CollectionConverters.*
@@ -155,7 +156,8 @@ class JvmCompileBtApiImpl(
       executionPolicy: ExecutionPolicy.InProcess,
       ref: PathRef
   )(using TaskCtx): java.nio.file.Path = {
-    val snapshotFile = classpathSnapshotCache / s"${ref.sig}.snapshot"
+    val snapshotFile =
+      classpathSnapshotCache / s"${renderIntAsHex(ref.sig)}-${ref.path.last}.snapshot"
     if (!os.exists(snapshotFile)) {
       val snapshottingOperation =
         jvmToolchain.createClasspathSnapshottingOperation(ref.path.toNIO)

--- a/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/KotlinWorkerImpl.scala
+++ b/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/KotlinWorkerImpl.scala
@@ -10,8 +10,9 @@ import mill.api.TaskCtx
 import mill.kotlinlib.worker.api.{KotlinWorker, KotlinWorkerTarget}
 
 class KotlinWorkerImpl(
-    private val classpathSnapshotCache: os.Path
-) extends KotlinWorker {
+    private val classpathSnapshotCache: os.Path,
+    private val classpathSnapshotCacheIsStable: Boolean
+) extends KotlinWorker, AutoCloseable {
   def compile(
       target: KotlinWorkerTarget,
       useBtApi: Boolean,
@@ -46,4 +47,9 @@ class KotlinWorkerImpl(
 
   }
 
+  override def close(): Unit = {
+    if (!classpathSnapshotCacheIsStable) {
+      os.remove.all(classpathSnapshotCache)
+    }
+  }
 }

--- a/libs/util/src/mill/util/ClassLoaderCachedFactory.scala
+++ b/libs/util/src/mill/util/ClassLoaderCachedFactory.scala
@@ -3,6 +3,8 @@ package mill.util
 import mill.api.PathRef
 import mill.util.RefCountedClassLoaderCache
 
+import scala.annotation.nowarn
+
 /**
  * Combination of [[CachedFactory]] and [[RefCountedClassLoaderCache]], providing an
  * easy way to generate values of type [[T]] to each be used in a single-thread while
@@ -15,10 +17,15 @@ abstract class ClassLoaderCachedFactory[T](jobs: Int)(using e: sourcecode.Enclos
     sharedPrefixes = Seq("sbt.testing.", "mill.api.daemon.internal.TestReporter")
   )
 
+  @deprecated("Use getValue(ClassLoader, Seq[PathRef]) instead", "Mill after 1.2.0-RC1")
   def getValue(cl: ClassLoader): T
+  // default impl to ensure binary compatibility
+  def getValue(cachedClassLoader: ClassLoader, @nowarn("msg=unused") classpath: Seq[PathRef]): T =
+    getValue(cachedClassLoader)
+
   override def setup(key: Seq[PathRef]) = {
     val cl = classloaderCache.getOrCreate(key, e)
-    val bridge = getValue(cl)
+    val bridge = getValue(cl, key)
 
     bridge
   }


### PR DESCRIPTION
Follow up on https://github.com/com-lihaoyi/mill/issues/7148

Use a stable cache path for classpath snapshots, based on the worker
classpath.

Change worker cleanup to only auto-remove non-stable snapshot cache
paths.

Add an overloaded version of `ClassLoaderCachedFactory.getValue`
exposing the actual classpath, since this is what we need to create a
stable hash for the classloader. Deprecate the other `getValue` overload
to perspectively have only one of them.

Backport of pull request: https://github.com/com-lihaoyi/mill/pull/7306
