### PR TITLE
`mill init`: Interpolate maven rawModel properties

### DIFF
--- a/libs/init/maven/src/mill/main/maven/Modeler.scala
+++ b/libs/init/maven/src/mill/main/maven/Modeler.scala
@@ -22,11 +22,16 @@ class Modeler(
   private val PropertyRef = "\\$\\{([^}]+)\\}".r
 
   private def interpolateValue(value: String, properties: Properties): String =
-    PropertyRef.replaceAllIn(value, m =>
-      Matcher.quoteReplacement(Option(properties.getProperty(m.group(1))).getOrElse(m.matched))
+    PropertyRef.replaceAllIn(
+      value,
+      m =>
+        Matcher.quoteReplacement(Option(properties.getProperty(m.group(1))).getOrElse(m.matched))
     )
 
-  private def interpolateDependencyVersions(model: org.apache.maven.model.Model, properties: Properties): Unit = {
+  private def interpolateDependencyVersions(
+      model: org.apache.maven.model.Model,
+      properties: Properties
+  ): Unit = {
     Option(model.getDependencies).foreach(_.asScala.foreach { dep =>
       Option(dep.getVersion).foreach(v => dep.setVersion(interpolateValue(v, properties)))
     })
@@ -62,8 +67,9 @@ class Modeler(
       val depMgmt1 = Option(result1.getEffectiveModel.getDependencyManagement).map(_.clone)
       val result2 = builder.build(request, result1)
       val interpolationProps = Properties()
-      systemProperties.forEach((k, v) => interpolationProps.put(k, v))
       result2.getEffectiveModel.getProperties.forEach((k, v) => interpolationProps.put(k, v))
+      // Match Maven precedence: externally supplied/system properties override model properties.
+      systemProperties.forEach((k, v) => interpolationProps.put(k, v))
       interpolateDependencyVersions(result2.getRawModel, interpolationProps)
       // Restore dep mgmt from Phase 1 since Phase 2 substitutes BOM deps with their components.
       depMgmt1.foreach(result2.getEffectiveModel.setDependencyManagement)

--- a/libs/init/maven/src/mill/main/maven/Modeler.scala
+++ b/libs/init/maven/src/mill/main/maven/Modeler.scala
@@ -8,6 +8,7 @@ import org.eclipse.aether.repository.{LocalRepository, RemoteRepository}
 import org.eclipse.aether.supplier.RepositorySystemSupplier
 
 import java.io.File
+import java.util.regex.Matcher
 import java.util.Properties
 import scala.jdk.CollectionConverters.*
 
@@ -17,6 +18,22 @@ class Modeler(
     resolver: ModelResolver,
     systemProperties: Properties
 ) {
+
+  private val PropertyRef = "\\$\\{([^}]+)\\}".r
+
+  private def interpolateValue(value: String, properties: Properties): String =
+    PropertyRef.replaceAllIn(value, m =>
+      Matcher.quoteReplacement(Option(properties.getProperty(m.group(1))).getOrElse(m.matched))
+    )
+
+  private def interpolateDependencyVersions(model: org.apache.maven.model.Model, properties: Properties): Unit = {
+    Option(model.getDependencies).foreach(_.asScala.foreach { dep =>
+      Option(dep.getVersion).foreach(v => dep.setVersion(interpolateValue(v, properties)))
+    })
+    Option(model.getDependencyManagement).foreach(_.getDependencies.asScala.foreach { dep =>
+      Option(dep.getVersion).foreach(v => dep.setVersion(interpolateValue(v, properties)))
+    })
+  }
 
   /** Returns the [[ModelBuildingResult]] for all projects in `workspace`. */
   def buildAll(): Seq[ModelBuildingResult] = {
@@ -44,6 +61,10 @@ class Modeler(
       val result1 = builder.build(request)
       val depMgmt1 = Option(result1.getEffectiveModel.getDependencyManagement).map(_.clone)
       val result2 = builder.build(request, result1)
+      val interpolationProps = Properties()
+      systemProperties.forEach((k, v) => interpolationProps.put(k, v))
+      result2.getEffectiveModel.getProperties.forEach((k, v) => interpolationProps.put(k, v))
+      interpolateDependencyVersions(result2.getRawModel, interpolationProps)
       // Restore dep mgmt from Phase 1 since Phase 2 substitutes BOM deps with their components.
       depMgmt1.foreach(result2.getEffectiveModel.setDependencyManagement)
       result2

--- a/libs/init/maven/test/resources/expected-scala/spring-start/build.mill
+++ b/libs/init/maven/test/resources/expected-scala/spring-start/build.mill
@@ -13,6 +13,9 @@ object `package` extends SpringBootModule, MavenModule, PublishModule {
 
   def mvnDeps = Seq(mvn"org.springframework.boot:spring-boot-starter:4.0.6")
 
+  def bomMvnDeps =
+    Seq(mvn"org.springframework.cloud:spring-cloud-dependencies:2023.0.3")
+
   def artifactName = "demo"
 
   def pomParentProject = Some(

--- a/libs/init/maven/test/resources/expected/spring-start/build.mill.yaml
+++ b/libs/init/maven/test/resources/expected/spring-start/build.mill.yaml
@@ -4,6 +4,8 @@ extends: [spring.boot.SpringBootModule, MavenModule, PublishModule]
 springBootPlatformVersion: 4.0.6
 mvnDeps:
 - org.springframework.boot:spring-boot-starter:4.0.6
+bomMvnDeps:
+- org.springframework.cloud:spring-cloud-dependencies:2023.0.3
 artifactName: demo
 pomSettings:
   organization: com.example

--- a/libs/init/maven/test/resources/spring-start/pom.xml
+++ b/libs/init/maven/test/resources/spring-start/pom.xml
@@ -28,7 +28,19 @@
 	</scm>
 	<properties>
 		<java.version>17</java.version>
+		<spring-cloud.version>2023.0.3</spring-cloud.version>
 	</properties>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-dependencies</artifactId>
+				<version>${spring-cloud.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/libs/init/maven/test/src/mill/main/maven/ModelerTests.scala
+++ b/libs/init/maven/test/src/mill/main/maven/ModelerTests.scala
@@ -1,0 +1,50 @@
+package mill.main.maven
+
+import utest.*
+
+import java.util.Properties
+
+object ModelerTests extends TestSuite {
+
+  def tests: Tests = Tests {
+    test("system properties override model properties for interpolation") {
+      val workspace = os.temp.dir(prefix = "mill-maven-modeler-")
+      val pom = workspace / "pom.xml"
+      os.write.over(
+        pom,
+        """<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>precedence-test</artifactId>
+  <version>0.1.0</version>
+
+  <properties>
+    <managed.version>1.0.0</managed.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>demo-dep</artifactId>
+      <version>${managed.version}</version>
+    </dependency>
+  </dependencies>
+</project>
+"""
+      )
+
+      val props = Modeler.defaultSystemProperties(workspace)
+      props.put("managed.version", "2.0.0")
+
+      val result = Modeler(workspace, systemProperties = props).build(pom.toIO)
+      val resolvedVersion = result.getRawModel.getDependencies.get(0).getVersion
+
+      assert(resolvedVersion == "2.0.0")
+    }
+  }
+}
+
+

--- a/libs/init/maven/test/src/mill/main/maven/ModelerTests.scala
+++ b/libs/init/maven/test/src/mill/main/maven/ModelerTests.scala
@@ -46,5 +46,3 @@ object ModelerTests extends TestSuite {
     }
   }
 }
-
-


### PR DESCRIPTION
To fix #7326

### The problem
When migrating Spring Projects, in order to avoid bloated generated build files by including everything that the effective model inherits, we get the dependency management from the rawModel instead.
This, however, leaves some properties uninterpolated, for example `${spring-cloud.version}`.

### Fix
Add an extra step that finds these properties with regex and then and replaces them with the corresponding values from the effective model.

We think it's preferable to reason through and hack around any issues arising from using the raw model than to generate build files containing hundreds of dependencies that ultimately come from a BOM.