### PR TITLE
`mill init` Spring detection fixes

### DIFF
--- a/libs/init/buildgen/api/src/mill/main/buildgen/ModuleSpec.scala
+++ b/libs/init/buildgen/api/src/mill/main/buildgen/ModuleSpec.scala
@@ -93,16 +93,34 @@ case class ModuleSpec(
     )
   }
 
+  private def stripSpringVersion(deps: Values[MvnDep]): Values[MvnDep] =
+    deps.copy(base = deps.base.map {
+      case dep if dep.organization == "org.springframework.boot" => dep.copy(version = "")
+      case dep => dep
+    })
+
   def withSpringBootModule(springBootVersion: Value[String]): ModuleSpec =
     copy(
       imports = "mill.javalib.spring.boot.*" +: imports,
       supertypes = "SpringBootModule" +: supertypes,
-      springBootPlatformVersion = springBootVersion
+      springBootPlatformVersion = springBootVersion,
+      mvnDeps = stripSpringVersion(mvnDeps),
+      compileMvnDeps = stripSpringVersion(compileMvnDeps),
+      runMvnDeps = stripSpringVersion(runMvnDeps),
+      bomMvnDeps = stripSpringVersion(bomMvnDeps),
+      depManagement = stripSpringVersion(depManagement)
     )
 
   def withSpringBootTestsModule(): ModuleSpec = {
     val requiredSupertypes = Seq("SpringBootTestsModule", "MavenTests")
-    copy(supertypes = requiredSupertypes ++ supertypes.filterNot(requiredSupertypes.contains))
+    copy(
+      supertypes = requiredSupertypes ++ supertypes.filterNot(requiredSupertypes.contains),
+      mvnDeps = stripSpringVersion(mvnDeps),
+      compileMvnDeps = stripSpringVersion(compileMvnDeps),
+      runMvnDeps = stripSpringVersion(runMvnDeps),
+      bomMvnDeps = stripSpringVersion(bomMvnDeps),
+      depManagement = stripSpringVersion(depManagement)
+    )
   }
 
   def withQuarkusModule(

--- a/libs/init/buildgen/api/src/mill/main/buildgen/ModuleSpec.scala
+++ b/libs/init/buildgen/api/src/mill/main/buildgen/ModuleSpec.scala
@@ -102,7 +102,7 @@ case class ModuleSpec(
     })
 
   def withSpringBootModule(springBootVersion: Value[String]): ModuleSpec = {
-    val verStr = springBootVersion.toOption.getOrElse("")
+    val verStr = springBootVersion.base.getOrElse("")
     copy(
       imports = "mill.javalib.spring.boot.*" +: imports,
       supertypes = "SpringBootModule" +: supertypes,
@@ -117,7 +117,7 @@ case class ModuleSpec(
 
   def withSpringBootTestsModule(springBootVersion: Value[String]): ModuleSpec = {
     val requiredSupertypes = Seq("SpringBootTestsModule", "MavenTests")
-    val verStr = springBootVersion.toOption.getOrElse("")
+    val verStr = springBootVersion.base.getOrElse("")
     copy(
       supertypes = requiredSupertypes ++ supertypes.filterNot(requiredSupertypes.contains),
       mvnDeps = stripSpringVersion(mvnDeps, verStr),

--- a/libs/init/buildgen/api/src/mill/main/buildgen/ModuleSpec.scala
+++ b/libs/init/buildgen/api/src/mill/main/buildgen/ModuleSpec.scala
@@ -5,6 +5,12 @@ import upickle.default.{ReadWriter, macroRW, readwriter}
 
 import scala.language.implicitConversions
 
+object SpringBoot {
+  val GroupId = "org.springframework.boot"
+  val ParentArtifactId = "spring-boot-starter-parent"
+  val DependenciesArtifactId = "spring-boot-dependencies"
+}
+
 case class ModuleSpec(
     name: String,
     imports: Seq[String] = Nil,
@@ -95,7 +101,7 @@ case class ModuleSpec(
 
   private def stripSpringVersion(deps: Values[MvnDep], platformVer: String): Values[MvnDep] =
     deps.copy(base = deps.base.map {
-      case dep if dep.organization == "org.springframework.boot" =>
+      case dep if dep.organization == SpringBoot.GroupId =>
         if (platformVer.nonEmpty && dep.version.nonEmpty && dep.version != platformVer) dep
         else dep.copy(version = "")
       case dep => dep
@@ -110,8 +116,11 @@ case class ModuleSpec(
       mvnDeps = stripSpringVersion(mvnDeps, verStr),
       compileMvnDeps = stripSpringVersion(compileMvnDeps, verStr),
       runMvnDeps = stripSpringVersion(runMvnDeps, verStr),
-      bomMvnDeps = stripSpringVersion(bomMvnDeps, verStr),
-      depManagement = stripSpringVersion(depManagement, verStr)
+      bomMvnDeps = bomMvnDeps.copy(base =
+        bomMvnDeps.base.filterNot(dep =>
+          dep.organization == SpringBoot.GroupId && dep.name == SpringBoot.DependenciesArtifactId
+        )
+      )
     )
   }
 
@@ -122,9 +131,7 @@ case class ModuleSpec(
       supertypes = requiredSupertypes ++ supertypes.filterNot(requiredSupertypes.contains),
       mvnDeps = stripSpringVersion(mvnDeps, verStr),
       compileMvnDeps = stripSpringVersion(compileMvnDeps, verStr),
-      runMvnDeps = stripSpringVersion(runMvnDeps, verStr),
-      bomMvnDeps = stripSpringVersion(bomMvnDeps, verStr),
-      depManagement = stripSpringVersion(depManagement, verStr)
+      runMvnDeps = stripSpringVersion(runMvnDeps, verStr)
     )
   }
 

--- a/libs/init/buildgen/api/src/mill/main/buildgen/ModuleSpec.scala
+++ b/libs/init/buildgen/api/src/mill/main/buildgen/ModuleSpec.scala
@@ -93,33 +93,38 @@ case class ModuleSpec(
     )
   }
 
-  private def stripSpringVersion(deps: Values[MvnDep]): Values[MvnDep] =
+  private def stripSpringVersion(deps: Values[MvnDep], platformVer: String): Values[MvnDep] =
     deps.copy(base = deps.base.map {
-      case dep if dep.organization == "org.springframework.boot" => dep.copy(version = "")
+      case dep if dep.organization == "org.springframework.boot" =>
+        if (platformVer.nonEmpty && dep.version.nonEmpty && dep.version != platformVer) dep
+        else dep.copy(version = "")
       case dep => dep
     })
 
-  def withSpringBootModule(springBootVersion: Value[String]): ModuleSpec =
+  def withSpringBootModule(springBootVersion: Value[String]): ModuleSpec = {
+    val verStr = springBootVersion.toOption.getOrElse("")
     copy(
       imports = "mill.javalib.spring.boot.*" +: imports,
       supertypes = "SpringBootModule" +: supertypes,
       springBootPlatformVersion = springBootVersion,
-      mvnDeps = stripSpringVersion(mvnDeps),
-      compileMvnDeps = stripSpringVersion(compileMvnDeps),
-      runMvnDeps = stripSpringVersion(runMvnDeps),
-      bomMvnDeps = stripSpringVersion(bomMvnDeps),
-      depManagement = stripSpringVersion(depManagement)
+      mvnDeps = stripSpringVersion(mvnDeps, verStr),
+      compileMvnDeps = stripSpringVersion(compileMvnDeps, verStr),
+      runMvnDeps = stripSpringVersion(runMvnDeps, verStr),
+      bomMvnDeps = stripSpringVersion(bomMvnDeps, verStr),
+      depManagement = stripSpringVersion(depManagement, verStr)
     )
+  }
 
-  def withSpringBootTestsModule(): ModuleSpec = {
+  def withSpringBootTestsModule(springBootVersion: Value[String]): ModuleSpec = {
     val requiredSupertypes = Seq("SpringBootTestsModule", "MavenTests")
+    val verStr = springBootVersion.toOption.getOrElse("")
     copy(
       supertypes = requiredSupertypes ++ supertypes.filterNot(requiredSupertypes.contains),
-      mvnDeps = stripSpringVersion(mvnDeps),
-      compileMvnDeps = stripSpringVersion(compileMvnDeps),
-      runMvnDeps = stripSpringVersion(runMvnDeps),
-      bomMvnDeps = stripSpringVersion(bomMvnDeps),
-      depManagement = stripSpringVersion(depManagement)
+      mvnDeps = stripSpringVersion(mvnDeps, verStr),
+      compileMvnDeps = stripSpringVersion(compileMvnDeps, verStr),
+      runMvnDeps = stripSpringVersion(runMvnDeps, verStr),
+      bomMvnDeps = stripSpringVersion(bomMvnDeps, verStr),
+      depManagement = stripSpringVersion(depManagement, verStr)
     )
   }
 

--- a/libs/init/buildgen/api/src/mill/main/buildgen/ModuleSpec.scala
+++ b/libs/init/buildgen/api/src/mill/main/buildgen/ModuleSpec.scala
@@ -107,15 +107,19 @@ case class ModuleSpec(
       case dep => dep
     })
 
-  def withSpringBootModule(springBootVersion: Value[String]): ModuleSpec = {
+  def withSpringBootModule(
+      springBootVersion: Value[String],
+      stripVersion: Boolean = true
+  ): ModuleSpec = {
     val verStr = springBootVersion.base.getOrElse("")
+    val doStrip = stripVersion && verStr.nonEmpty
     copy(
       imports = "mill.javalib.spring.boot.*" +: imports,
       supertypes = "SpringBootModule" +: supertypes,
       springBootPlatformVersion = springBootVersion,
-      mvnDeps = stripSpringVersion(mvnDeps, verStr),
-      compileMvnDeps = stripSpringVersion(compileMvnDeps, verStr),
-      runMvnDeps = stripSpringVersion(runMvnDeps, verStr),
+      mvnDeps = if (doStrip) stripSpringVersion(mvnDeps, verStr) else mvnDeps,
+      compileMvnDeps = if (doStrip) stripSpringVersion(compileMvnDeps, verStr) else compileMvnDeps,
+      runMvnDeps = if (doStrip) stripSpringVersion(runMvnDeps, verStr) else runMvnDeps,
       bomMvnDeps = bomMvnDeps.copy(base =
         bomMvnDeps.base.filterNot(dep =>
           dep.organization == SpringBoot.GroupId && dep.name == SpringBoot.DependenciesArtifactId
@@ -124,14 +128,18 @@ case class ModuleSpec(
     )
   }
 
-  def withSpringBootTestsModule(springBootVersion: Value[String]): ModuleSpec = {
+  def withSpringBootTestsModule(
+      springBootVersion: Value[String] = Value(),
+      stripVersion: Boolean = true
+  ): ModuleSpec = {
     val requiredSupertypes = Seq("SpringBootTestsModule", "MavenTests")
     val verStr = springBootVersion.base.getOrElse("")
+    val doStrip = stripVersion && verStr.nonEmpty
     copy(
       supertypes = requiredSupertypes ++ supertypes.filterNot(requiredSupertypes.contains),
-      mvnDeps = stripSpringVersion(mvnDeps, verStr),
-      compileMvnDeps = stripSpringVersion(compileMvnDeps, verStr),
-      runMvnDeps = stripSpringVersion(runMvnDeps, verStr)
+      mvnDeps = if (doStrip) stripSpringVersion(mvnDeps, verStr) else mvnDeps,
+      compileMvnDeps = if (doStrip) stripSpringVersion(compileMvnDeps, verStr) else compileMvnDeps,
+      runMvnDeps = if (doStrip) stripSpringVersion(runMvnDeps, verStr) else runMvnDeps
     )
   }
 

--- a/libs/init/maven/src/mill/main/maven/MillMavenBuildGenMain.scala
+++ b/libs/init/maven/src/mill/main/maven/MillMavenBuildGenMain.scala
@@ -81,26 +81,14 @@ object MillMavenBuildGenMain {
           def moduleDeps(scope: String) = mavenModuleDeps.collect {
             case dep if dep.getScope == scope => moduleDepLookup(dep)
           }
-          val (effectiveBomMvnDeps, effectiveDepManagement, effectiveBomModuleDeps) =
+          val isSpringParentProject = isSpringBootProject(model)
+          val springBootVersion = detectSpringBootVersion(model)
+          val quarkusVersionOpt = detectQuarkusPluginVersion(model)
+
+          val (bomMvnDeps, depManagement, bomModuleDeps) =
             Option(model.getDependencyManagement).fold((Nil, Nil, Nil)) { dm =>
               collectDependencyManagement(dm, toMvnOrModuleDep, moduleDepLookup)
             }
-
-          val isSpringParentProject = isSpringBootProject(model)
-          val springBootVersion = detectSpringBootVersion(model)
-
-          val quarkusVersionOpt = detectQuarkusPluginVersion(model)
-
-          val (rawBomMvnDeps, rawDepManagement, rawBomModuleDeps) =
-            Option(result.getRawModel.getDependencyManagement).fold((Nil, Nil, Nil)) { dm =>
-              collectDependencyManagement(dm, toMvnOrModuleDep, moduleDepLookup)
-            }
-
-          val (bomMvnDeps, depManagement, bomModuleDeps) = selectDependencyManagement(
-            isSpringParentProject = isSpringParentProject,
-            effective = (effectiveBomMvnDeps, effectiveDepManagement, effectiveBomModuleDeps),
-            raw = (rawBomMvnDeps, rawDepManagement, rawBomModuleDeps)
-          )
 
           mainModule = mainModule.copy(
             imports = "mill.javalib.*" +: mainModule.imports,
@@ -249,15 +237,6 @@ object MillMavenBuildGenMain {
     (bomMvnDeps, depManagement, bomModuleDeps)
   }
 
-  private def selectDependencyManagement(
-      isSpringParentProject: Boolean,
-      effective: (Seq[MvnDep], Seq[MvnDep], Seq[ModuleDep]),
-      raw: (Seq[MvnDep], Seq[MvnDep], Seq[ModuleDep])
-  ): (Seq[MvnDep], Seq[MvnDep], Seq[ModuleDep]) =
-    if (isSpringParentProject) {
-      // Effective model pulls in a very large inherited set from spring-boot-dependencies BOM.
-      (raw._1.filterNot(isSpringBootDependenciesBom), raw._2, raw._3)
-    } else effective
 
   /** Detect Spring Boot platform version from spring-boot-starter-parent. */
   private def detectSpringBootVersion(model: Model): Option[String] = {

--- a/libs/init/maven/src/mill/main/maven/MillMavenBuildGenMain.scala
+++ b/libs/init/maven/src/mill/main/maven/MillMavenBuildGenMain.scala
@@ -206,19 +206,15 @@ object MillMavenBuildGenMain {
 
   private def isBom(dep: Dependency) = dep.getScope == "import" && dep.getType == "pom"
 
-  private val SpringBootGroupId = "org.springframework.boot"
-  private val SpringBootParentArtifactId = "spring-boot-starter-parent"
-  private val SpringBootDependenciesArtifactId = "spring-boot-dependencies"
-
   private def isSpringBootParent(parent: Parent): Boolean =
-    parent.getGroupId == SpringBootGroupId && parent.getArtifactId == SpringBootParentArtifactId
+    parent.getGroupId == SpringBoot.GroupId && parent.getArtifactId == SpringBoot.ParentArtifactId
 
 
   private def findSpringBootBom(model: Model): Option[Dependency] =
     Option(model.getDependencyManagement)
       .flatMap(_.getDependencies.asScala.find(dep =>
-        dep.getGroupId == SpringBootGroupId &&
-        (dep.getArtifactId == SpringBootDependenciesArtifactId || dep.getArtifactId == SpringBootParentArtifactId) &&
+        dep.getGroupId == SpringBoot.GroupId &&
+        (dep.getArtifactId == SpringBoot.DependenciesArtifactId || dep.getArtifactId == SpringBoot.ParentArtifactId) &&
         dep.getScope == "import"
       ))
 

--- a/libs/init/maven/src/mill/main/maven/MillMavenBuildGenMain.scala
+++ b/libs/init/maven/src/mill/main/maven/MillMavenBuildGenMain.scala
@@ -246,6 +246,8 @@ object MillMavenBuildGenMain {
   }
 
 
+  private val PropertyRegex = """\$\{([^}]+)}""".r
+
   /** Detect Spring Boot platform version from spring-boot-starter-parent or imported BOM 
    * (resolving property version from effective properties). */
   private def detectSpringBootVersion(model: Model, rawModel: Model): Option[String] = {
@@ -256,11 +258,10 @@ object MillMavenBuildGenMain {
     parentVersion.orElse {
       findSpringBootBom(rawModel)
         .flatMap(dep => nonEmpty(dep.getVersion))
-        .map { v =>
-          if (v.startsWith("${") && v.endsWith("}")) {
-            val propName = v.substring(2, v.length - 1)
-            Option(model.getProperties.getProperty(propName)).getOrElse(v)
-          } else v
+        .map {
+          case PropertyRegex(propName) =>
+            Option(model.getProperties.getProperty(propName)).getOrElse(s"$${$propName}")
+          case other => other
         }
     }
   }

--- a/libs/init/maven/src/mill/main/maven/MillMavenBuildGenMain.scala
+++ b/libs/init/maven/src/mill/main/maven/MillMavenBuildGenMain.scala
@@ -223,7 +223,8 @@ object MillMavenBuildGenMain {
    */
   private def isSpringBootProject(model: Model, rawModel: Model): Boolean =
     Option(model.getParent).exists(isSpringBootParent) ||
-      findSpringBootBom(rawModel).isDefined
+      findSpringBootBom(rawModel).isDefined ||
+      model.getDependencies.asScala.exists(_.getGroupId == SpringBoot.GroupId)
 
   private def nonEmpty(value: String): Option[String] = Option(value).filter(_.nonEmpty)
 
@@ -251,7 +252,7 @@ object MillMavenBuildGenMain {
       .filter(isSpringBootParent)
       .flatMap(parent => nonEmpty(parent.getVersion))
 
-    parentVersion.orElse {
+    val fromBom = parentVersion.orElse {
       findSpringBootBom(rawModel)
         .flatMap(dep => nonEmpty(dep.getVersion))
         .map {
@@ -259,6 +260,12 @@ object MillMavenBuildGenMain {
             Option(model.getProperties.getProperty(propName)).getOrElse(s"$${$propName}")
           case other => other
         }
+    }
+
+    fromBom.orElse {
+      model.getDependencies.asScala
+        .find(_.getGroupId == SpringBoot.GroupId)
+        .flatMap(dep => nonEmpty(dep.getVersion))
     }
   }
 

--- a/libs/init/maven/src/mill/main/maven/MillMavenBuildGenMain.scala
+++ b/libs/init/maven/src/mill/main/maven/MillMavenBuildGenMain.scala
@@ -209,13 +209,12 @@ object MillMavenBuildGenMain {
   private def isSpringBootParent(parent: Parent): Boolean =
     parent.getGroupId == SpringBoot.GroupId && parent.getArtifactId == SpringBoot.ParentArtifactId
 
-
   private def findSpringBootBom(model: Model): Option[Dependency] =
     Option(model.getDependencyManagement)
       .flatMap(_.getDependencies.asScala.find(dep =>
         dep.getGroupId == SpringBoot.GroupId &&
-        (dep.getArtifactId == SpringBoot.DependenciesArtifactId || dep.getArtifactId == SpringBoot.ParentArtifactId) &&
-        dep.getScope == "import"
+          (dep.getArtifactId == SpringBoot.DependenciesArtifactId || dep.getArtifactId == SpringBoot.ParentArtifactId) &&
+          dep.getScope == "import"
       ))
 
   /**
@@ -224,7 +223,7 @@ object MillMavenBuildGenMain {
    */
   private def isSpringBootProject(model: Model, rawModel: Model): Boolean =
     Option(model.getParent).exists(isSpringBootParent) ||
-    findSpringBootBom(rawModel).isDefined
+      findSpringBootBom(rawModel).isDefined
 
   private def nonEmpty(value: String): Option[String] = Option(value).filter(_.nonEmpty)
 
@@ -241,11 +240,12 @@ object MillMavenBuildGenMain {
     (bomMvnDeps, depManagement, bomModuleDeps)
   }
 
-
   private val PropertyRegex = """\$\{([^}]+)}""".r
 
-  /** Detect Spring Boot platform version from spring-boot-starter-parent or imported BOM 
-   * (resolving property version from effective properties). */
+  /**
+   * Detect Spring Boot platform version from spring-boot-starter-parent or imported BOM
+   * (resolving property version from effective properties).
+   */
   private def detectSpringBootVersion(model: Model, rawModel: Model): Option[String] = {
     val parentVersion = Option(model.getParent)
       .filter(isSpringBootParent)

--- a/libs/init/maven/src/mill/main/maven/MillMavenBuildGenMain.scala
+++ b/libs/init/maven/src/mill/main/maven/MillMavenBuildGenMain.scala
@@ -213,14 +213,22 @@ object MillMavenBuildGenMain {
   private def isSpringBootParent(parent: Parent): Boolean =
     parent.getGroupId == SpringBootGroupId && parent.getArtifactId == SpringBootParentArtifactId
 
-  private def isSpringBootDependenciesBom(dep: MvnDep): Boolean =
-    dep.organization == SpringBootGroupId && dep.name == SpringBootDependenciesArtifactId
+
+  private def findSpringBootBom(model: Model): Option[Dependency] =
+    Option(model.getDependencyManagement)
+      .flatMap(_.getDependencies.asScala.find(dep =>
+        dep.getGroupId == SpringBootGroupId &&
+        (dep.getArtifactId == SpringBootDependenciesArtifactId || dep.getArtifactId == SpringBootParentArtifactId) &&
+        dep.getScope == "import"
+      ))
 
   /**
-   * Detect if the project is a Spring Boot project by checking if it inherits from spring-boot-starter-parent.
+   * Detect if the project is a Spring Boot project by checking if it inherits from spring-boot-starter-parent
+   * or imports spring-boot-dependencies/spring-boot-starter-parent as a BOM.
    */
   private def isSpringBootProject(model: Model): Boolean =
-    Option(model.getParent).exists(isSpringBootParent)
+    Option(model.getParent).exists(isSpringBootParent) ||
+    findSpringBootBom(model).isDefined
 
   private def nonEmpty(value: String): Option[String] = Option(value).filter(_.nonEmpty)
 
@@ -238,11 +246,13 @@ object MillMavenBuildGenMain {
   }
 
 
-  /** Detect Spring Boot platform version from spring-boot-starter-parent. */
+  /** Detect Spring Boot platform version from spring-boot-starter-parent or imported BOM. */
   private def detectSpringBootVersion(model: Model): Option[String] = {
-    Option(model.getParent)
+    val parentVersion = Option(model.getParent)
       .filter(isSpringBootParent)
       .flatMap(parent => nonEmpty(parent.getVersion))
+
+    parentVersion.orElse(findSpringBootBom(model).flatMap(dep => nonEmpty(dep.getVersion)))
   }
 
   private val QuarkusPluginArtifactId = "quarkus-maven-plugin"

--- a/libs/init/maven/src/mill/main/maven/MillMavenBuildGenMain.scala
+++ b/libs/init/maven/src/mill/main/maven/MillMavenBuildGenMain.scala
@@ -81,8 +81,8 @@ object MillMavenBuildGenMain {
           def moduleDeps(scope: String) = mavenModuleDeps.collect {
             case dep if dep.getScope == scope => moduleDepLookup(dep)
           }
-          val isSpringParentProject = isSpringBootProject(model)
-          val springBootVersion = detectSpringBootVersion(model)
+          val isSpringParentProject = isSpringBootProject(model, result.getRawModel)
+          val springBootVersion = detectSpringBootVersion(model, result.getRawModel)
           val quarkusVersionOpt = detectQuarkusPluginVersion(model)
 
           val (bomMvnDeps, depManagement, bomModuleDeps) =
@@ -224,11 +224,11 @@ object MillMavenBuildGenMain {
 
   /**
    * Detect if the project is a Spring Boot project by checking if it inherits from spring-boot-starter-parent
-   * or imports spring-boot-dependencies/spring-boot-starter-parent as a BOM.
+   * or imports spring-boot-dependencies/spring-boot-starter-parent as a BOM in its raw model.
    */
-  private def isSpringBootProject(model: Model): Boolean =
+  private def isSpringBootProject(model: Model, rawModel: Model): Boolean =
     Option(model.getParent).exists(isSpringBootParent) ||
-    findSpringBootBom(model).isDefined
+    findSpringBootBom(rawModel).isDefined
 
   private def nonEmpty(value: String): Option[String] = Option(value).filter(_.nonEmpty)
 
@@ -246,13 +246,23 @@ object MillMavenBuildGenMain {
   }
 
 
-  /** Detect Spring Boot platform version from spring-boot-starter-parent or imported BOM. */
-  private def detectSpringBootVersion(model: Model): Option[String] = {
+  /** Detect Spring Boot platform version from spring-boot-starter-parent or imported BOM 
+   * (resolving property version from effective properties). */
+  private def detectSpringBootVersion(model: Model, rawModel: Model): Option[String] = {
     val parentVersion = Option(model.getParent)
       .filter(isSpringBootParent)
       .flatMap(parent => nonEmpty(parent.getVersion))
 
-    parentVersion.orElse(findSpringBootBom(model).flatMap(dep => nonEmpty(dep.getVersion)))
+    parentVersion.orElse {
+      findSpringBootBom(rawModel)
+        .flatMap(dep => nonEmpty(dep.getVersion))
+        .map { v =>
+          if (v.startsWith("${") && v.endsWith("}")) {
+            val propName = v.substring(2, v.length - 1)
+            Option(model.getProperties.getProperty(propName)).getOrElse(v)
+          } else v
+        }
+    }
   }
 
   private val QuarkusPluginArtifactId = "quarkus-maven-plugin"

--- a/libs/init/maven/src/mill/main/maven/MillMavenBuildGenMain.scala
+++ b/libs/init/maven/src/mill/main/maven/MillMavenBuildGenMain.scala
@@ -58,9 +58,10 @@ object MillMavenBuildGenMain {
 
       model.getPackaging match {
         case "pom" =>
-          if (Option(model.getDependencyManagement).exists(!_.getDependencies.isEmpty)) {
+          val dmOpt = Option(model.getDependencyManagement).map(filterSpringBootBomDeps)
+          if (dmOpt.exists(!_.getDependencies.isEmpty)) {
             val (bomDeps, deps) =
-              model.getDependencyManagement.getDependencies.asScala.toSeq.partition(isBom)
+              dmOpt.get.getDependencies.asScala.toSeq.partition(isBom)
             val (bomMvnDeps, bomModuleDeps) = bomDeps.partitionMap(toMvnOrModuleDep)
             val (depManagement, moduleDeps) = deps.partitionMap(toMvnOrModuleDep)
             mainModule = mainModule.copy(
@@ -86,7 +87,7 @@ object MillMavenBuildGenMain {
           val quarkusVersionOpt = detectQuarkusPluginVersion(model)
 
           val (bomMvnDeps, depManagement, bomModuleDeps) =
-            Option(model.getDependencyManagement).fold((Nil, Nil, Nil)) { dm =>
+            Option(model.getDependencyManagement).map(filterSpringBootBomDeps).fold((Nil, Nil, Nil)) { dm =>
               collectDependencyManagement(dm, toMvnOrModuleDep, moduleDepLookup)
             }
 
@@ -282,6 +283,22 @@ object MillMavenBuildGenMain {
     model.getBuild.getPlugins.asScala.find(p =>
       p.getArtifactId == QuarkusPluginArtifactId
     ).flatMap(p => nonEmpty(p.getVersion))
+  }
+
+  private def filterSpringBootBomDeps(dm: DependencyManagement): DependencyManagement = {
+    if (dm == null) null
+    else {
+      val filteredDeps = dm.getDependencies.asScala.filterNot { dep =>
+        val location = dep.getLocation("")
+        val source = if (location != null) location.getSource else null
+        val sourceId = if (source != null) Option(source.getModelId).getOrElse("") else ""
+        sourceId.contains(SpringBoot.DependenciesArtifactId) ||
+          sourceId.contains(SpringBoot.ParentArtifactId)
+      }
+      val filteredDm = new DependencyManagement()
+      filteredDm.setDependencies(filteredDeps.asJava)
+      filteredDm
+    }
   }
 
   private def toMvnDep(dep: Dependency) = {

--- a/libs/init/maven/src/mill/main/maven/MillMavenBuildGenMain.scala
+++ b/libs/init/maven/src/mill/main/maven/MillMavenBuildGenMain.scala
@@ -145,7 +145,7 @@ object MillMavenBuildGenMain {
               testFramework = Option.when(testMixin.isEmpty)("")
             )
             if (isSpringParentProject) {
-              testModule = testModule.withSpringBootTestsModule()
+              testModule = testModule.withSpringBootTestsModule(springBootVersion)
             }
             if (testMixin.contains("TestModule.Junit5")) {
               testModule.mvnDeps.base.collectFirst {
@@ -263,9 +263,16 @@ object MillMavenBuildGenMain {
     }
 
     fromBom.orElse {
-      model.getDependencies.asScala
-        .find(_.getGroupId == SpringBoot.GroupId)
+      val springBootVersions = model.getDependencies.asScala
+        .filter(_.getGroupId == SpringBoot.GroupId)
         .flatMap(dep => nonEmpty(dep.getVersion))
+      springBootVersions
+        .groupBy(identity)
+        .map { case (k, v) => (k, v.size) }
+        .toSeq
+        .sortBy(-_._2)
+        .headOption
+        .map(_._1)
     }
   }
 

--- a/libs/init/maven/src/mill/main/maven/MillMavenBuildGenMain.scala
+++ b/libs/init/maven/src/mill/main/maven/MillMavenBuildGenMain.scala
@@ -87,7 +87,11 @@ object MillMavenBuildGenMain {
           val quarkusVersionOpt = detectQuarkusPluginVersion(model)
 
           val (bomMvnDeps, depManagement, bomModuleDeps) =
-            Option(model.getDependencyManagement).map(filterSpringBootBomDeps).fold((Nil, Nil, Nil)) { dm =>
+            Option(model.getDependencyManagement).map(filterSpringBootBomDeps).fold((
+              Nil,
+              Nil,
+              Nil
+            )) { dm =>
               collectDependencyManagement(dm, toMvnOrModuleDep, moduleDepLookup)
             }
 
@@ -293,7 +297,7 @@ object MillMavenBuildGenMain {
         val source = if (location != null) location.getSource else null
         val sourceId = if (source != null) Option(source.getModelId).getOrElse("") else ""
         sourceId.contains(SpringBoot.DependenciesArtifactId) ||
-          sourceId.contains(SpringBoot.ParentArtifactId)
+        sourceId.contains(SpringBoot.ParentArtifactId)
       }
       val filteredDm = new DependencyManagement()
       filteredDm.setDependencies(filteredDeps.asJava)

--- a/libs/init/maven/src/mill/main/maven/MillMavenBuildGenMain.scala
+++ b/libs/init/maven/src/mill/main/maven/MillMavenBuildGenMain.scala
@@ -219,7 +219,8 @@ object MillMavenBuildGenMain {
       .flatMap(_.getDependencies.asScala.find(dep =>
         dep.getGroupId == SpringBoot.GroupId &&
           (dep.getArtifactId == SpringBoot.DependenciesArtifactId || dep.getArtifactId == SpringBoot.ParentArtifactId) &&
-          dep.getScope == "import"
+          dep.getScope == "import" &&
+          dep.getType == "pom"
       ))
 
   /**
@@ -229,7 +230,7 @@ object MillMavenBuildGenMain {
   private def isSpringBootProject(model: Model, rawModel: Model): Boolean =
     Option(model.getParent).exists(isSpringBootParent) ||
       findSpringBootBom(rawModel).isDefined ||
-      model.getDependencies.asScala.exists(_.getGroupId == SpringBoot.GroupId)
+      rawModel.getDependencies.asScala.exists(_.getGroupId == SpringBoot.GroupId)
 
   private def nonEmpty(value: String): Option[String] = Option(value).filter(_.nonEmpty)
 
@@ -257,17 +258,15 @@ object MillMavenBuildGenMain {
       .filter(isSpringBootParent)
       .flatMap(parent => nonEmpty(parent.getVersion))
 
-    val fromBom = parentVersion.orElse {
-      findSpringBootBom(rawModel)
-        .flatMap(dep => nonEmpty(dep.getVersion))
-        .map {
-          case PropertyRegex(propName) =>
-            Option(model.getProperties.getProperty(propName)).getOrElse(s"$${$propName}")
-          case other => other
-        }
-    }
+    val fromBom = findSpringBootBom(rawModel)
+      .flatMap(dep => nonEmpty(dep.getVersion))
+      .map {
+        case PropertyRegex(propName) =>
+          Option(model.getProperties.getProperty(propName)).getOrElse(s"$${$propName}")
+        case other => other
+      }
 
-    fromBom.orElse {
+    parentVersion.orElse(fromBom).orElse {
       val springBootVersions = model.getDependencies.asScala
         .filter(_.getGroupId == SpringBoot.GroupId)
         .flatMap(dep => nonEmpty(dep.getVersion))
@@ -290,19 +289,16 @@ object MillMavenBuildGenMain {
   }
 
   private def filterSpringBootBomDeps(dm: DependencyManagement): DependencyManagement = {
-    if (dm == null) null
-    else {
-      val filteredDeps = dm.getDependencies.asScala.filterNot { dep =>
-        val location = dep.getLocation("")
-        val source = if (location != null) location.getSource else null
-        val sourceId = if (source != null) Option(source.getModelId).getOrElse("") else ""
-        sourceId.contains(SpringBoot.DependenciesArtifactId) ||
-        sourceId.contains(SpringBoot.ParentArtifactId)
-      }
-      val filteredDm = new DependencyManagement()
-      filteredDm.setDependencies(filteredDeps.asJava)
-      filteredDm
+    val filteredDeps = dm.getDependencies.asScala.filterNot { dep =>
+      val location = dep.getLocation("")
+      val source = if (location != null) location.getSource else null
+      val sourceId = if (source != null) Option(source.getModelId).getOrElse("") else ""
+      sourceId.contains(SpringBoot.DependenciesArtifactId) ||
+      sourceId.contains(SpringBoot.ParentArtifactId)
     }
+    val filteredDm = new DependencyManagement()
+    filteredDm.setDependencies(filteredDeps.asJava)
+    filteredDm
   }
 
   private def toMvnDep(dep: Dependency) = {

--- a/libs/init/maven/src/mill/main/maven/Modeler.scala
+++ b/libs/init/maven/src/mill/main/maven/Modeler.scala
@@ -1,7 +1,7 @@
 package mill.main.maven
 
 import mill.api.PathRef
-import org.apache.maven.model.*
+import org.apache.maven.model.{DependencyManagement, Model}
 import org.apache.maven.model.building.*
 import org.apache.maven.model.composition.DependencyManagementImporter
 import org.apache.maven.model.inheritance.InheritanceAssembler
@@ -118,10 +118,13 @@ class FilteringInheritanceAssembler(delegate: InheritanceAssembler)
       request: ModelBuildingRequest,
       problems: ModelProblemCollector
   ): Unit = {
-    val parentGroupId = Option(parent.getGroupId).orElse(Option(parent.getParent).map(_.getGroupId)).getOrElse("")
+    val parentGroupId =
+      Option(parent.getGroupId).orElse(Option(parent.getParent).map(_.getGroupId)).getOrElse("")
     val parentArtifactId = parent.getArtifactId
 
-    if (parentGroupId == SpringBoot.GroupId && parentArtifactId == SpringBoot.DependenciesArtifactId) {
+    if (
+      parentGroupId == SpringBoot.GroupId && parentArtifactId == SpringBoot.DependenciesArtifactId
+    ) {
       val parentClone = parent.clone()
       parentClone.setDependencyManagement(null)
       delegate.assembleModelInheritance(child, parentClone, request, problems)
@@ -140,7 +143,8 @@ class FilteringDependencyManagementImporter(delegate: DependencyManagementImport
       problems: ModelProblemCollector
   ): Unit = {
     // Filter out Spring Boot BOMs by checking if their source location points to a Spring Boot BOM or parent.
-    val filteredSources = if (sources == null) null else {
+    val filteredSources = if (sources == null) null
+    else {
       sources.asScala.filterNot { dm =>
         Option(dm.getDependencies).flatMap(_.asScala.headOption).exists { dep =>
           val location = dep.getLocation("")
@@ -154,6 +158,11 @@ class FilteringDependencyManagementImporter(delegate: DependencyManagementImport
         }
       }.asJava
     }
-    delegate.importManagement(target, filteredSources.asInstanceOf[java.util.List[? <: DependencyManagement]], request, problems)
+    delegate.importManagement(
+      target,
+      filteredSources.asInstanceOf[java.util.List[? <: DependencyManagement]],
+      request,
+      problems
+    )
   }
 }

--- a/libs/init/maven/src/mill/main/maven/Modeler.scala
+++ b/libs/init/maven/src/mill/main/maven/Modeler.scala
@@ -104,6 +104,12 @@ object Modeler {
   }
 }
 
+object SpringBoot {
+  val GroupId = "org.springframework.boot"
+  val ParentArtifactId = "spring-boot-starter-parent"
+  val DependenciesArtifactId = "spring-boot-dependencies"
+}
+
 class FilteringInheritanceAssembler(delegate: InheritanceAssembler)
     extends InheritanceAssembler {
   override def assembleModelInheritance(
@@ -115,7 +121,7 @@ class FilteringInheritanceAssembler(delegate: InheritanceAssembler)
     val parentGroupId = Option(parent.getGroupId).orElse(Option(parent.getParent).map(_.getGroupId)).getOrElse("")
     val parentArtifactId = parent.getArtifactId
 
-    if (parentGroupId == "org.springframework.boot" && parentArtifactId == "spring-boot-dependencies") {
+    if (parentGroupId == SpringBoot.GroupId && parentArtifactId == SpringBoot.DependenciesArtifactId) {
       val parentClone = parent.clone()
       parentClone.setDependencyManagement(null)
       delegate.assembleModelInheritance(child, parentClone, request, problems)
@@ -142,7 +148,8 @@ class FilteringDependencyManagementImporter(delegate: DependencyManagementImport
           val sourceName = if (source != null) {
             Option(source.getModelId).orElse(Option(source.getLocation)).getOrElse("")
           } else ""
-          val isSpringBOM = sourceName.contains("spring-boot-dependencies") || sourceName.contains("spring-boot-starter-parent")
+          val isSpringBOM = sourceName.contains(SpringBoot.DependenciesArtifactId) ||
+            sourceName.contains(SpringBoot.ParentArtifactId)
           isSpringBOM
         }
       }.asJava

--- a/libs/init/maven/src/mill/main/maven/Modeler.scala
+++ b/libs/init/maven/src/mill/main/maven/Modeler.scala
@@ -43,6 +43,7 @@ class Modeler(
     request.setSystemProperties(systemProperties)
     request.setValidationLevel(ModelBuildingRequest.VALIDATION_LEVEL_MINIMAL)
     request.setTwoPhaseBuilding(true)
+    request.setLocationTracking(true)
     try {
       val result1 = builder.build(request)
       val depMgmt1 = Option(result1.getEffectiveModel.getDependencyManagement).map(_.clone)
@@ -132,11 +133,17 @@ class FilteringDependencyManagementImporter(delegate: DependencyManagementImport
       request: ModelBuildingRequest,
       problems: ModelProblemCollector
   ): Unit = {
-    // Identify spring-boot-dependencies BOM by checking if it contains spring boot dependencies
+    // Filter out Spring Boot BOMs by checking if their source location points to a Spring Boot BOM or parent.
     val filteredSources = if (sources == null) null else {
       sources.asScala.filterNot { dm =>
-        Option(dm.getDependencies).exists { deps =>
-          deps.asScala.exists(d => d.getGroupId == "org.springframework.boot")
+        Option(dm.getDependencies).flatMap(_.asScala.headOption).exists { dep =>
+          val location = dep.getLocation("")
+          val source = if (location != null) location.getSource else null
+          val sourceName = if (source != null) {
+            Option(source.getModelId).orElse(Option(source.getLocation)).getOrElse("")
+          } else ""
+          val isSpringBOM = sourceName.contains("spring-boot-dependencies") || sourceName.contains("spring-boot-starter-parent")
+          isSpringBOM
         }
       }.asJava
     }

--- a/libs/init/maven/src/mill/main/maven/Modeler.scala
+++ b/libs/init/maven/src/mill/main/maven/Modeler.scala
@@ -1,7 +1,10 @@
 package mill.main.maven
 
 import mill.api.PathRef
+import org.apache.maven.model.*
 import org.apache.maven.model.building.*
+import org.apache.maven.model.composition.DependencyManagementImporter
+import org.apache.maven.model.inheritance.InheritanceAssembler
 import org.apache.maven.model.resolution.ModelResolver
 import org.apache.maven.repository.internal.MavenRepositorySystemUtils
 import org.eclipse.aether.repository.{LocalRepository, RemoteRepository}
@@ -63,7 +66,14 @@ object Modeler {
       context: String = "",
       systemProperties: Properties = null
   ): Modeler = {
-    val builder = DefaultModelBuilderFactory().newInstance()
+    val builder = new DefaultModelBuilderFactory() {
+      override def newInheritanceAssembler(): InheritanceAssembler = {
+        new FilteringInheritanceAssembler(super.newInheritanceAssembler())
+      }
+      override def newDependencyManagementImporter(): DependencyManagementImporter = {
+        new FilteringDependencyManagementImporter(super.newDependencyManagementImporter())
+      }
+    }.newInstance()
     val system = RepositorySystemSupplier().get()
     val session = MavenRepositorySystemUtils.newSession()
     session.setLocalRepositoryManager(system.newLocalRepositoryManager(session, local))
@@ -90,5 +100,46 @@ object Modeler {
     // Maven reads this property and uses it for relative path resolution.
     props.put("maven.multiModuleProjectDirectory", PathRef.toAbsString(mvnWorkspace))
     props
+  }
+}
+
+class FilteringInheritanceAssembler(delegate: InheritanceAssembler)
+    extends InheritanceAssembler {
+  override def assembleModelInheritance(
+      child: Model,
+      parent: Model,
+      request: ModelBuildingRequest,
+      problems: ModelProblemCollector
+  ): Unit = {
+    val parentGroupId = Option(parent.getGroupId).orElse(Option(parent.getParent).map(_.getGroupId)).getOrElse("")
+    val parentArtifactId = parent.getArtifactId
+
+    if (parentGroupId == "org.springframework.boot" && parentArtifactId == "spring-boot-dependencies") {
+      val parentClone = parent.clone()
+      parentClone.setDependencyManagement(null)
+      delegate.assembleModelInheritance(child, parentClone, request, problems)
+    } else {
+      delegate.assembleModelInheritance(child, parent, request, problems)
+    }
+  }
+}
+
+class FilteringDependencyManagementImporter(delegate: DependencyManagementImporter)
+    extends DependencyManagementImporter {
+  override def importManagement(
+      target: Model,
+      sources: java.util.List[? <: DependencyManagement],
+      request: ModelBuildingRequest,
+      problems: ModelProblemCollector
+  ): Unit = {
+    // Identify spring-boot-dependencies BOM by checking if it contains spring boot dependencies
+    val filteredSources = if (sources == null) null else {
+      sources.asScala.filterNot { dm =>
+        Option(dm.getDependencies).exists { deps =>
+          deps.asScala.exists(d => d.getGroupId == "org.springframework.boot")
+        }
+      }.asJava
+    }
+    delegate.importManagement(target, filteredSources.asInstanceOf[java.util.List[? <: DependencyManagement]], request, problems)
   }
 }

--- a/libs/init/maven/src/mill/main/maven/Modeler.scala
+++ b/libs/init/maven/src/mill/main/maven/Modeler.scala
@@ -1,10 +1,8 @@
 package mill.main.maven
 
 import mill.api.PathRef
-import org.apache.maven.model.{DependencyManagement, Model}
+import org.apache.maven.model.DependencyManagement
 import org.apache.maven.model.building.*
-import org.apache.maven.model.composition.DependencyManagementImporter
-import org.apache.maven.model.inheritance.InheritanceAssembler
 import org.apache.maven.model.resolution.ModelResolver
 import org.apache.maven.repository.internal.MavenRepositorySystemUtils
 import org.eclipse.aether.repository.{LocalRepository, RemoteRepository}
@@ -95,10 +93,4 @@ object Modeler {
     props.put("maven.multiModuleProjectDirectory", PathRef.toAbsString(mvnWorkspace))
     props
   }
-}
-
-object SpringBoot {
-  val GroupId = "org.springframework.boot"
-  val ParentArtifactId = "spring-boot-starter-parent"
-  val DependenciesArtifactId = "spring-boot-dependencies"
 }

--- a/libs/init/maven/src/mill/main/maven/Modeler.scala
+++ b/libs/init/maven/src/mill/main/maven/Modeler.scala
@@ -67,14 +67,7 @@ object Modeler {
       context: String = "",
       systemProperties: Properties = null
   ): Modeler = {
-    val builder = new DefaultModelBuilderFactory() {
-      override def newInheritanceAssembler(): InheritanceAssembler = {
-        new FilteringInheritanceAssembler(super.newInheritanceAssembler())
-      }
-      override def newDependencyManagementImporter(): DependencyManagementImporter = {
-        new FilteringDependencyManagementImporter(super.newDependencyManagementImporter())
-      }
-    }.newInstance()
+    val builder = DefaultModelBuilderFactory().newInstance()
     val system = RepositorySystemSupplier().get()
     val session = MavenRepositorySystemUtils.newSession()
     session.setLocalRepositoryManager(system.newLocalRepositoryManager(session, local))
@@ -108,61 +101,4 @@ object SpringBoot {
   val GroupId = "org.springframework.boot"
   val ParentArtifactId = "spring-boot-starter-parent"
   val DependenciesArtifactId = "spring-boot-dependencies"
-}
-
-class FilteringInheritanceAssembler(delegate: InheritanceAssembler)
-    extends InheritanceAssembler {
-  override def assembleModelInheritance(
-      child: Model,
-      parent: Model,
-      request: ModelBuildingRequest,
-      problems: ModelProblemCollector
-  ): Unit = {
-    val parentGroupId =
-      Option(parent.getGroupId).orElse(Option(parent.getParent).map(_.getGroupId)).getOrElse("")
-    val parentArtifactId = parent.getArtifactId
-
-    if (
-      parentGroupId == SpringBoot.GroupId && parentArtifactId == SpringBoot.DependenciesArtifactId
-    ) {
-      val parentClone = parent.clone()
-      parentClone.setDependencyManagement(null)
-      delegate.assembleModelInheritance(child, parentClone, request, problems)
-    } else {
-      delegate.assembleModelInheritance(child, parent, request, problems)
-    }
-  }
-}
-
-class FilteringDependencyManagementImporter(delegate: DependencyManagementImporter)
-    extends DependencyManagementImporter {
-  override def importManagement(
-      target: Model,
-      sources: java.util.List[? <: DependencyManagement],
-      request: ModelBuildingRequest,
-      problems: ModelProblemCollector
-  ): Unit = {
-    // Filter out Spring Boot BOMs by checking if their source location points to a Spring Boot BOM or parent.
-    val filteredSources = if (sources == null) null
-    else {
-      sources.asScala.filterNot { dm =>
-        Option(dm.getDependencies).flatMap(_.asScala.headOption).exists { dep =>
-          val location = dep.getLocation("")
-          val source = if (location != null) location.getSource else null
-          val sourceName = if (source != null) {
-            Option(source.getModelId).orElse(Option(source.getLocation)).getOrElse("")
-          } else ""
-          val isSpringBOM = sourceName.contains(SpringBoot.DependenciesArtifactId) ||
-            sourceName.contains(SpringBoot.ParentArtifactId)
-          isSpringBOM
-        }
-      }.asJava
-    }
-    delegate.importManagement(
-      target,
-      filteredSources.asInstanceOf[java.util.List[? <: DependencyManagement]],
-      request,
-      problems
-    )
-  }
 }

--- a/libs/init/maven/src/mill/main/maven/Modeler.scala
+++ b/libs/init/maven/src/mill/main/maven/Modeler.scala
@@ -1,7 +1,6 @@
 package mill.main.maven
 
 import mill.api.PathRef
-import org.apache.maven.model.DependencyManagement
 import org.apache.maven.model.building.*
 import org.apache.maven.model.resolution.ModelResolver
 import org.apache.maven.repository.internal.MavenRepositorySystemUtils

--- a/libs/init/maven/test/resources/expected-scala/spring-start-no-parent/build.mill
+++ b/libs/init/maven/test/resources/expected-scala/spring-start-no-parent/build.mill
@@ -1,0 +1,29 @@
+//| mill-version: SNAPSHOT
+//| mill-jvm-version: system
+package build
+
+import mill.*
+import mill.javalib.*
+import mill.javalib.publish.*
+import mill.javalib.spring.boot.*
+
+object `package` extends SpringBootModule, MavenModule, PublishModule {
+
+  def springBootPlatformVersion = "3.2.4"
+
+  def mvnDeps = Seq(mvn"org.springframework.boot:spring-boot-starter")
+
+  def artifactName = "demo"
+
+  def pomSettings = PomSettings(
+    "",
+    "com.example",
+    "",
+    Seq(),
+    VersionControl(None, None, None, None),
+    Seq()
+  )
+
+  def publishVersion = "0.0.1-SNAPSHOT"
+
+}

--- a/libs/init/maven/test/resources/expected-scala/spring-start-no-parent/build.mill
+++ b/libs/init/maven/test/resources/expected-scala/spring-start-no-parent/build.mill
@@ -11,7 +11,12 @@ object `package` extends SpringBootModule, MavenModule, PublishModule {
 
   def springBootPlatformVersion = "3.2.4"
 
-  def mvnDeps = Seq(mvn"org.springframework.boot:spring-boot-starter")
+  def mvnDeps = Seq(
+    mvn"org.springframework.boot:spring-boot-starter",
+    mvn"commons-io:commons-io:2.11.0"
+  )
+
+  def depManagement = Seq(mvn"commons-io:commons-io:2.11.0")
 
   def artifactName = "demo"
 

--- a/libs/init/maven/test/resources/expected-scala/spring-start/build.mill
+++ b/libs/init/maven/test/resources/expected-scala/spring-start/build.mill
@@ -11,7 +11,7 @@ object `package` extends SpringBootModule, MavenModule, PublishModule {
 
   def springBootPlatformVersion = "4.0.6"
 
-  def mvnDeps = Seq(mvn"org.springframework.boot:spring-boot-starter:4.0.6")
+  def mvnDeps = Seq(mvn"org.springframework.boot:spring-boot-starter")
 
   def artifactName = "demo"
 
@@ -32,8 +32,7 @@ object `package` extends SpringBootModule, MavenModule, PublishModule {
 
   object test extends SpringBootTestsModule, MavenTests, TestModule.Junit5 {
 
-    def mvnDeps =
-      Seq(mvn"org.springframework.boot:spring-boot-starter-test:4.0.6")
+    def mvnDeps = Seq(mvn"org.springframework.boot:spring-boot-starter-test")
 
     def forkWorkingDir = moduleDir
 

--- a/libs/init/maven/test/resources/expected/spring-start-no-parent/build.mill.yaml
+++ b/libs/init/maven/test/resources/expected/spring-start-no-parent/build.mill.yaml
@@ -4,6 +4,9 @@ extends: [spring.boot.SpringBootModule, MavenModule, PublishModule]
 springBootPlatformVersion: 3.2.4
 mvnDeps:
 - org.springframework.boot:spring-boot-starter
+- commons-io:commons-io:2.11.0
+depManagement:
+- commons-io:commons-io:2.11.0
 artifactName: demo
 pomSettings:
   organization: com.example

--- a/libs/init/maven/test/resources/expected/spring-start-no-parent/build.mill.yaml
+++ b/libs/init/maven/test/resources/expected/spring-start-no-parent/build.mill.yaml
@@ -1,0 +1,10 @@
+mill-version: SNAPSHOT
+mill-jvm-version: system
+extends: [spring.boot.SpringBootModule, MavenModule, PublishModule]
+springBootPlatformVersion: 3.2.4
+mvnDeps:
+- org.springframework.boot:spring-boot-starter
+artifactName: demo
+pomSettings:
+  organization: com.example
+publishVersion: 0.0.1-SNAPSHOT

--- a/libs/init/maven/test/resources/expected/spring-start/build.mill.yaml
+++ b/libs/init/maven/test/resources/expected/spring-start/build.mill.yaml
@@ -3,7 +3,7 @@ mill-jvm-version: system
 extends: [spring.boot.SpringBootModule, MavenModule, PublishModule]
 springBootPlatformVersion: 4.0.6
 mvnDeps:
-- org.springframework.boot:spring-boot-starter:4.0.6
+- org.springframework.boot:spring-boot-starter
 artifactName: demo
 pomSettings:
   organization: com.example
@@ -15,6 +15,6 @@ publishVersion: 0.0.1-SNAPSHOT
 object test:
   extends: [SpringBootTestsModule, MavenTests, TestModule.Junit5]
   mvnDeps:
-  - org.springframework.boot:spring-boot-starter-test:4.0.6
+  - org.springframework.boot:spring-boot-starter-test
   testParallelism: false
   testSandboxWorkingDir: false

--- a/libs/init/maven/test/resources/spring-start-no-parent/pom.xml
+++ b/libs/init/maven/test/resources/spring-start-no-parent/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>com.example</groupId>
+	<artifactId>demo</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name/>
+	<description/>
+	<url/>
+
+	<properties>
+		<java.version>17</java.version>
+		<spring-boot.version>3.2.4</spring-boot.version>
+	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-dependencies</artifactId>
+				<version>${spring-boot.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+	</dependencies>
+</project>

--- a/libs/init/maven/test/resources/spring-start-no-parent/pom.xml
+++ b/libs/init/maven/test/resources/spring-start-no-parent/pom.xml
@@ -23,6 +23,12 @@
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
+            <!--    Add extra dep, shouldn't be filtered       -->
+			<dependency>
+				<groupId>commons-io</groupId>
+				<artifactId>commons-io</artifactId>
+				<version>2.11.0</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 
@@ -30,6 +36,10 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
 		</dependency>
 	</dependencies>
 </project>

--- a/libs/init/maven/test/resources/spring-start-no-parent/pom.xml
+++ b/libs/init/maven/test/resources/spring-start-no-parent/pom.xml
@@ -23,7 +23,7 @@
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
-            <!--    Add extra dep, shouldn't be filtered       -->
+			<!-- Add extra dep, shouldn't be filtered -->
 			<dependency>
 				<groupId>commons-io</groupId>
 				<artifactId>commons-io</artifactId>

--- a/libs/init/maven/test/src/mill/main/maven/MavenBuildGenTests.scala
+++ b/libs/init/maven/test/src/mill/main/maven/MavenBuildGenTests.scala
@@ -32,6 +32,13 @@ trait MavenBuildGenTests extends TestSuite {
         initArgs = Seq() ++ extraArgs
       ))
     }
+    test("spring-start-no-parent") {
+      assert(checker.check(
+        sourceRel = os.sub / "spring-start-no-parent",
+        expectedRel = os.sub / expectedDir / "spring-start-no-parent",
+        initArgs = Seq() ++ extraArgs
+      ))
+    }
     test("with-args") {
       val args = Seq("--publish-properties", "--merge", "--no-meta")
       test("maven-samples") {


### PR DESCRIPTION
### Motivation


<details>
<summary>To close https://github.com/com-lihaoyi/mill/issues/7326 . </summary>

`spring-boot-examples/spring-boot-basic-microservice/spring-boot-microservice-eureka-naming-server/build.mill.yaml`

```yaml
mill-version: 1.1.2-301-492680
mill-jvm-version: system
extends: [spring.boot.SpringBootModule, MavenModule, PublishModule]
springBootPlatformVersion: 4.0.0
mvnDeps:
- org.springframework.cloud:spring-cloud-starter-netflix-eureka-server:4.3.0
bomMvnDeps:
- org.springframework.cloud:spring-cloud-dependencies:2025.0.0
artifactName: spring-boot-microservice-eureka-naming-server
pomSettings:
  description: Microservices with Spring Boot and Spring Cloud - Eureka Naming Server
  organization: com.in28minutes.springboot.microservice.eureka.naming.server
publishVersion: 0.0.1-SNAPSHOT
repositories: ["https://repo.spring.io/milestone"]

object test:
  extends: [SpringBootTestsModule, MavenTests, TestModule.Junit5]
  mvnDeps:
  - org.springframework.boot:spring-boot-starter-test
  testParallelism: false
  testSandboxWorkingDir: false
```
```console
> ./mill __.compile   
90] test.compile compiling 1 Java source to out/test/compile.dest/classes ...
90] done compiling
90/90, SUCCESS] mill __.compile
```


</details>

Avoids the direct use of `rawModel` for `depManagement` and also the need for
- https://github.com/com-lihaoyi/mill/pull/7340

since relying on just `rawModel` could lose inherited properties.

Additionally, current approach only detected from the `spring-boot-starter-parent`, but it's valid to use spring boot without the parent. ([example](https://github.com/spring-projects/spring-boot/blob/fb9794a2d346036a6adfa74cc3f1253010d63ea0/build-plugin/spring-boot-maven-plugin/src/docs/antora/modules/maven-plugin/examples/using/no-starter-parent-override-dependencies-pom.xml#L35)). 

### Additions
- Detect spring-boot usage from BOM declaration too.
The issue with this is that the BOM gets removed from the `effectiveModel`, so this had to be a hybrid approach, meaning it first picks up the BOM from the `rawModel` and then resolves (if needed) the version property from the `effectiveModel`. 
	- Also add a test for such usage
- Detect spring-boot usage from any spring-boot dep.
	- We have [3-maven-complete-large](https://github.com/com-lihaoyi/mill/blob/main/example/migrating/javalib/3-maven-complete-large/build.mill) for this, it has many subprojects that use springboot. 
	With this PR, they cleanly get the `SpringBootModule` too, and versions that should come from the dep BOM get stripped.

### Changes
- Remove the logic of using `rawModel` for `dependencyManagement`
- Filter the `effectiveModel` based on the location the info came from