### PR TITLE
Support Kotlin 2.4 incremental compilation (backport #7334)

### DIFF
--- a/contrib/package.mill
+++ b/contrib/package.mill
@@ -157,7 +157,8 @@ object `package` extends mill.Module {
         Seq(
           build.libs.javalib,
           build.libs.scalajslib.worker("1"),
-          build.libs.kotlinlib.worker
+          build.libs.kotlinlib.worker("1"),
+          build.libs.kotlinlib.worker("2-4")
         )
 
     def compileModuleDeps =

--- a/libs/androidlib/package.mill
+++ b/libs/androidlib/package.mill
@@ -12,7 +12,10 @@ object `package` extends MillPublishScalaModule with BuildInfo {
 
   def moduleDeps = Seq(build.libs.javalib, build.libs.kotlinlib, build.libs.scalalib, databinding)
 
-  def localTestExtraModules = super.localTestExtraModules ++ Seq(build.libs.kotlinlib.worker)
+  def localTestExtraModules = super.localTestExtraModules ++ Seq(
+    build.libs.kotlinlib.worker("1"),
+    build.libs.kotlinlib.worker("2-4")
+  )
 
   def buildInfoPackageName = "mill.androidlib"
 

--- a/libs/javalib/package.mill
+++ b/libs/javalib/package.mill
@@ -245,6 +245,10 @@ object `package` extends MillStableScalaModule {
 
       super.mvnDeps() ++ mavenPublishingDeps
     }
+
+    // we exclude maven-worker module to workaround issue
+    // https://github.com/com-lihaoyi/mill/pull/5977/#issuecomment-3407301062
+    override def includeInApiDocs = false
   }
 
   object `scalameta-worker` extends MillPublishScalaModule {

--- a/libs/kotlinlib/package.mill
+++ b/libs/kotlinlib/package.mill
@@ -12,7 +12,8 @@ object `package` extends MillStableScalaModule with BuildInfo {
     api.sources,
     ksp2.sources,
     `ksp2-api`.sources,
-    worker.sources
+    worker("1").sources,
+    worker("2-4").sources
   )
   override object test extends MillScalaTests {
     override def selectiveInputs = Seq(sources, resources) ++ kotlinSelectiveInputs
@@ -21,7 +22,7 @@ object `package` extends MillStableScalaModule with BuildInfo {
   def moduleDeps =
     Seq(build.libs.javalib, build.libs.javalib.testrunner, api, `ksp2-api`)
   def localTestExtraModules =
-    super.localTestExtraModules ++ Seq(worker)
+    super.localTestExtraModules ++ Seq(worker("1"), worker("2-4"))
 
   def buildInfoPackageName = "mill.kotlinlib"
   def buildInfoObjectName = "Versions"
@@ -57,17 +58,32 @@ object `package` extends MillStableScalaModule with BuildInfo {
     )
   }
 
-  object worker extends MillPublishScalaModule {
+  object worker extends Cross[Worker]("1", "2-4")
+  trait Worker extends MillPublishScalaModule, Cross.Module[String] {
     override def compileModuleDeps = Seq(api)
-
     def mandatoryMvnDeps = Seq.empty[Dep]
 
-    override def compileMvnDeps: T[Seq[Dep]] =
-      super.mandatoryMvnDeps() ++ Seq(
-        Deps.osLib,
-        Deps.kotlinCompiler,
-        Deps.kotlinBuildToolsApi_api
+    override def compileMvnDeps: T[Seq[Dep]] = {
+      val shared = Seq(
+        Deps.osLib
       )
+      val deps = crossValue match {
+        case "1" => Seq(
+            Deps.kotlinCompiler,
+            Deps.kotlinBuildTools23Api_api
+          )
+        case "2-4" => Seq(
+            Deps.kotlin24Compiler_api,
+            Deps.kotlinBuildTools24Api_api
+          )
+      }
+      super.mandatoryMvnDeps() ++ shared ++ deps
+    }
+
+    def sourcesSpecific = Task.Sources(os.sub / s"src-${crossValue}")
+    override def sources = super.sources() ++ sourcesSpecific()
+
+    def includeInApiDocs = false
   }
 
   object `ksp2-api` extends MillPublishScalaModule with MillJava11ScalaModule

--- a/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/KotlinModule.scala
@@ -96,8 +96,13 @@ trait KotlinModule extends JavaModule with KotlinModuleApi { outer =>
    * Default is derived from [[kotlinCompilerMvnDeps]].
    */
   def kotlinCompilerClasspath: T[Seq[PathRef]] = Task {
+    val Array(major, minor) = kotlinVersion().split("[.]").take(2).map(_.toIntOption).padTo(2, None)
+    val usesDeprecatedApi = major.exists(_ < 2) || (major.contains(2) && minor.exists(_ < 4))
+    val workerModule =
+      if (usesDeprecatedApi) "mill-libs-kotlinlib-worker-1"
+      else "mill-libs-kotlinlib-worker-2-4"
     val deps = kotlinCompilerMvnDeps() ++ Seq(
-      Dep.millProjectModule("mill-libs-kotlinlib-worker")
+      Dep.millProjectModule(workerModule)
     )
     defaultResolver().classpath(
       deps,

--- a/libs/kotlinlib/test/src/mill/kotlinlib/HelloKotlinTests.scala
+++ b/libs/kotlinlib/test/src/mill/kotlinlib/HelloKotlinTests.scala
@@ -9,8 +9,15 @@ import utest.*
 
 object HelloKotlinTests extends TestSuite {
 
+  // Older Kotlin versions don't support running on JDK 25+ (their JdkVersion enum
+  // can't parse "25.0.2"), so filter them out when running tests on JDK 25+.
+  import scala.math.Ordering.Implicits.{seqOrdering, infixOrderingOps}
+  def supportsCurrentJdk(v: String) = Runtime.version().feature() < 25 ||
+    v.split("[.-]").take(3).flatMap(_.toIntOption).toSeq >= Seq(2, 2, 20)
   val crossMatrix = for {
-    kotlinVersion <- Seq("1.9.24", "2.0.20", "2.1.20", "2.3.0", Versions.kotlinVersion).distinct
+    kotlinVersion <-
+      Seq("1.9.24", "2.0.20", "2.1.20", "2.3.0", "2.4.0", Versions.kotlinVersion).distinct
+    if supportsCurrentJdk(kotlinVersion)
     embeddable <- Seq(false, true)
   } yield (kotlinVersion, embeddable)
 
@@ -172,90 +179,92 @@ object HelloKotlinTests extends TestSuite {
         resourcePath,
         debugEnabled = true
       ).scoped { eval =>
-        // Test only Kotlin 2.3+ with embeddable compiler, where Build Tools API is enabled.
-        // Use only one module to simplify output parsing.
-        val btApiModule = HelloKotlin.main.crossModules.find(m =>
+        // Build Tools API is enabled for Kotlin 2.3+ with the embeddable compiler. Exercise every
+        // such version: 2.3.x uses the legacy factory backend, 2.4.0+ the dedicated builder-API worker.
+        val btApiModules = HelloKotlin.main.crossModules.filter(m =>
           btApiSupported(m.crossValue) && m.crossValue2
-        ).get
-
-        val srcDir = eval.evaluator.workspace / "main/src/hello"
-        os.makeDir.all(srcDir)
-
-        def classPath(result: mill.javalib.api.CompilationResult, className: String): os.Path =
-          result.classes.path / os.RelPath(className)
-
-        def fileMtimeMillis(path: os.Path): Long = os.mtime(path)
-
-        // Create an additional source file for incremental compilation testing
-        val extraFile = srcDir / "Extra.kt"
-        os.write(
-          extraFile,
-          """package hello
-            |
-            |fun getExtraString(): String = "Extra"
-            |""".stripMargin,
-          createFolders = true
         )
 
-        // First compile - full compilation
-        val Right(result1) = eval.apply(btApiModule.compile).runtimeChecked
-        val helloClass = classPath(result1.value, "hello/HelloKt.class")
-        val extraClass = classPath(result1.value, "hello/ExtraKt.class")
-        assert(
-          os.exists(helloClass),
-          os.exists(extraClass)
-        )
-        val helloMtime1 = fileMtimeMillis(helloClass)
-        val extraMtime1 = fileMtimeMillis(extraClass)
+        btApiModules.foreach { btApiModule =>
+          val srcDir = eval.evaluator.workspace / "main/src/hello"
+          os.makeDir.all(srcDir)
 
-        // Second compile without changes - should be cached by Mill
-        val Right(result2) = eval.apply(btApiModule.compile).runtimeChecked
-        assert(result2.evalCount == 0)
+          def classPath(result: mill.javalib.api.CompilationResult, className: String): os.Path =
+            result.classes.path / os.RelPath(className)
 
-        // Modify the extra file - should trigger incremental compilation
-        Thread.sleep(1100L)
-        os.write.over(
-          extraFile,
-          """package hello
-            |
-            |fun getExtraString(): String = "Extra Modified"
-            |""".stripMargin
-        )
+          def fileMtimeMillis(path: os.Path): Long = os.mtime(path)
 
-        val Right(result3) = eval.apply(btApiModule.compile).runtimeChecked
-        assert(result3.evalCount > 0)
-        assert(os.exists(extraClass))
+          // Create an additional source file for incremental compilation testing
+          val extraFile = srcDir / "Extra.kt"
+          os.write(
+            extraFile,
+            """package hello
+              |
+              |fun getExtraString(): String = "Extra"
+              |""".stripMargin,
+            createFolders = true
+          )
 
-        val helloMtime2 = fileMtimeMillis(helloClass)
-        val extraMtime2 = fileMtimeMillis(extraClass)
-        assert(extraMtime2 > extraMtime1)
-        assert(helloMtime2 == helloMtime1)
+          // First compile - full compilation
+          val Right(result1) = eval.apply(btApiModule.compile).runtimeChecked
+          val helloClass = classPath(result1.value, "hello/HelloKt.class")
+          val extraClass = classPath(result1.value, "hello/ExtraKt.class")
+          assert(
+            os.exists(helloClass),
+            os.exists(extraClass)
+          )
+          val helloMtime1 = fileMtimeMillis(helloClass)
+          val extraMtime1 = fileMtimeMillis(extraClass)
 
-        // Add a new file - should trigger incremental compilation
-        val anotherFile = srcDir / "Another.kt"
-        Thread.sleep(1100L)
-        os.write(
-          anotherFile,
-          """package hello
-            |
-            |fun getAnotherString(): String = "Another"
-            |""".stripMargin,
-          createFolders = true
-        )
+          // Second compile without changes - should be cached by Mill
+          val Right(result2) = eval.apply(btApiModule.compile).runtimeChecked
+          assert(result2.evalCount == 0)
 
-        val Right(result4) = eval.apply(btApiModule.compile).runtimeChecked
-        assert(result4.evalCount > 0)
-        val anotherClass = classPath(result4.value, "hello/AnotherKt.class")
-        assert(os.exists(anotherClass))
+          // Modify the extra file - should trigger incremental compilation
+          Thread.sleep(1100L)
+          os.write.over(
+            extraFile,
+            """package hello
+              |
+              |fun getExtraString(): String = "Extra Modified"
+              |""".stripMargin
+          )
 
-        val helloMtime3 = fileMtimeMillis(helloClass)
-        val extraMtime3 = fileMtimeMillis(extraClass)
-        assert(helloMtime3 == helloMtime2)
-        assert(extraMtime3 == extraMtime2)
+          val Right(result3) = eval.apply(btApiModule.compile).runtimeChecked
+          assert(result3.evalCount > 0)
+          assert(os.exists(extraClass))
 
-        // Clean up
-        os.remove(extraFile)
-        os.remove(anotherFile)
+          val helloMtime2 = fileMtimeMillis(helloClass)
+          val extraMtime2 = fileMtimeMillis(extraClass)
+          assert(extraMtime2 > extraMtime1)
+          assert(helloMtime2 == helloMtime1)
+
+          // Add a new file - should trigger incremental compilation
+          val anotherFile = srcDir / "Another.kt"
+          Thread.sleep(1100L)
+          os.write(
+            anotherFile,
+            """package hello
+              |
+              |fun getAnotherString(): String = "Another"
+              |""".stripMargin,
+            createFolders = true
+          )
+
+          val Right(result4) = eval.apply(btApiModule.compile).runtimeChecked
+          assert(result4.evalCount > 0)
+          val anotherClass = classPath(result4.value, "hello/AnotherKt.class")
+          assert(os.exists(anotherClass))
+
+          val helloMtime3 = fileMtimeMillis(helloClass)
+          val extraMtime3 = fileMtimeMillis(extraClass)
+          assert(helloMtime3 == helloMtime2)
+          assert(extraMtime3 == extraMtime2)
+
+          // Clean up
+          os.remove(extraFile)
+          os.remove(anotherFile)
+        }
       }
     }
   }

--- a/libs/kotlinlib/worker/src-1/mill/kotlinlib/worker/impl/JvmCompileBtApiImpl.scala
+++ b/libs/kotlinlib/worker/src-1/mill/kotlinlib/worker/impl/JvmCompileBtApiImpl.scala
@@ -1,0 +1,75 @@
+package mill.kotlinlib.worker.impl
+
+import mill.api.TaskCtx
+import org.jetbrains.kotlin.buildtools.api.{BuildOperation, CompilationResult, SourcesChanges}
+import org.jetbrains.kotlin.buildtools.api.jvm.{
+  ClasspathEntrySnapshot,
+  ClassSnapshotGranularity,
+  JvmPlatformToolchain,
+  JvmSnapshotBasedIncrementalCompilationConfiguration
+}
+import org.jetbrains.kotlin.buildtools.api.jvm.operations.{
+  JvmClasspathSnapshottingOperation,
+  JvmCompilationOperation
+}
+
+import java.nio.file.Path
+import scala.jdk.CollectionConverters.*
+import scala.util.chaining.scalaUtilChainingOps
+
+/**
+ * [[BtApiCompiler]] backend for Kotlin versions before 2.4.0, using the legacy operation factories.
+ */
+class JvmCompileBtApiImpl(classpathSnapshotCache: os.Path)
+    extends BtApiCompiler(classpathSnapshotCache) {
+
+  protected def compilationOperation(
+      jvmToolchain: JvmPlatformToolchain,
+      sourceFiles: java.util.List[Path],
+      destinationDirectory: os.Path,
+      args: Seq[String],
+      incrementalCachePath: os.Path,
+      classpathSnapshotFiles: Seq[Path]
+  )(using ctx: TaskCtx): BuildOperation[CompilationResult] = {
+    val operation = jvmToolchain.createJvmCompilationOperation(
+      sourceFiles,
+      destinationDirectory.toNIO
+    )
+    operation.getCompilerArguments().applyArgumentStrings(args.asJava)
+
+    val snapshotIcOptions = operation.createSnapshotBasedIcOptions().tap { options =>
+      import org.jetbrains.kotlin.buildtools.api.jvm.JvmSnapshotBasedIncrementalCompilationOptions as Ic
+      options.set(Ic.ROOT_PROJECT_DIR, ctx.workspace.toNIO)
+      options.set(Ic.MODULE_BUILD_DIR, incrementalCachePath.toNIO)
+      options.set(Ic.PRECISE_JAVA_TRACKING, java.lang.Boolean.TRUE)
+    }
+
+    operation.set(
+      JvmCompilationOperation.INCREMENTAL_COMPILATION,
+      JvmSnapshotBasedIncrementalCompilationConfiguration(
+        incrementalCachePath.toNIO,
+        SourcesChanges.ToBeCalculated.INSTANCE,
+        classpathSnapshotFiles.asJava,
+        (incrementalCachePath / "shrunk-classpath-snapshot.bin").toNIO,
+        snapshotIcOptions
+      )
+    )
+    operation
+  }
+
+  protected def snapshottingOperation(
+      jvmToolchain: JvmPlatformToolchain,
+      classpathEntry: Path
+  )(using ctx: TaskCtx): BuildOperation[ClasspathEntrySnapshot] = {
+    val operation = jvmToolchain.createClasspathSnapshottingOperation(classpathEntry)
+    operation.set(
+      JvmClasspathSnapshottingOperation.GRANULARITY,
+      ClassSnapshotGranularity.CLASS_MEMBER_LEVEL
+    )
+    operation.set(
+      JvmClasspathSnapshottingOperation.PARSE_INLINED_LOCAL_CLASSES,
+      java.lang.Boolean.TRUE
+    )
+    operation
+  }
+}

--- a/libs/kotlinlib/worker/src-1/mill/kotlinlib/worker/impl/KotlinWorkerImpl.scala
+++ b/libs/kotlinlib/worker/src-1/mill/kotlinlib/worker/impl/KotlinWorkerImpl.scala
@@ -1,0 +1,18 @@
+/*
+ * Original code copied from https://github.com/lefou/mill-kotlin
+ * Original code published under the Apache License Version 2
+ * Original Copyright 2020-2024 Tobias Roeser
+ */
+package mill.kotlinlib.worker.impl
+
+class KotlinWorkerImpl(
+    private val classpathSnapshotCache: os.Path,
+    private val classpathSnapshotCacheIsStable: Boolean
+) extends KotlinWorkerImplBase(classpathSnapshotCache, classpathSnapshotCacheIsStable) {
+
+  override protected def jvmBtApiCompiler(): BtApiCompiler = jvmBtApiCompiler0
+
+  private lazy val jvmBtApiCompiler0: BtApiCompiler =
+    JvmCompileBtApiImpl(classpathSnapshotCache)
+
+}

--- a/libs/kotlinlib/worker/src-2-4/mill/kotlinlib/worker/impl/JvmCompileBtApi24Impl.scala
+++ b/libs/kotlinlib/worker/src-2-4/mill/kotlinlib/worker/impl/JvmCompileBtApi24Impl.scala
@@ -1,0 +1,124 @@
+package mill.kotlinlib.worker.impl
+
+import mill.api.TaskCtx
+import org.jetbrains.kotlin.buildtools.api.{BuildOperation, CompilationResult, SourcesChanges}
+import org.jetbrains.kotlin.buildtools.api.arguments.{CommonCompilerArguments, JvmCompilerArguments}
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.{JvmTarget, KotlinVersion}
+import org.jetbrains.kotlin.buildtools.api.jvm.{
+  ClasspathEntrySnapshot,
+  ClassSnapshotGranularity,
+  JvmPlatformToolchain
+}
+import org.jetbrains.kotlin.buildtools.api.jvm.operations.{
+  JvmClasspathSnapshottingOperation,
+  JvmCompilationOperation
+}
+
+import java.nio.file.Path
+import scala.jdk.CollectionConverters.*
+
+/**
+ * [[BtApiCompiler]] backend for Kotlin 2.4.0+, which replaced the legacy operation factories with
+ * the builders introduced in 2.3.20 and added typesafe compiler options. Compiled against the 2.4
+ * Build Tools API and classloaded by [[KotlinWorkerImpl]].
+ */
+class JvmCompileBtApi24Impl(classpathSnapshotCache: os.Path)
+    extends BtApiCompiler(classpathSnapshotCache) {
+
+  protected def compilationOperation(
+      jvmToolchain: JvmPlatformToolchain,
+      sourceFiles: java.util.List[Path],
+      destinationDirectory: os.Path,
+      args: Seq[String],
+      incrementalCachePath: os.Path,
+      classpathSnapshotFiles: Seq[Path]
+  )(using ctx: TaskCtx): BuildOperation[CompilationResult] = {
+    val builder = jvmToolchain.jvmCompilationOperationBuilder(
+      sourceFiles,
+      destinationDirectory.toNIO
+    )
+
+    val compilerArguments = builder.getCompilerArguments()
+    compilerArguments.applyArgumentStrings(untypedArguments(args).asJava)
+    applyTypedArguments(compilerArguments, args)
+
+    val icBuilder = builder.snapshotBasedIcConfigurationBuilder(
+      incrementalCachePath.toNIO,
+      SourcesChanges.ToBeCalculated.INSTANCE,
+      classpathSnapshotFiles.asJava,
+      (incrementalCachePath / "shrunk-classpath-snapshot.bin").toNIO
+    )
+    import org.jetbrains.kotlin.buildtools.api.jvm.JvmSnapshotBasedIncrementalCompilationConfiguration as Ic
+    icBuilder.set(Ic.ROOT_PROJECT_DIR, ctx.workspace.toNIO)
+    icBuilder.set(Ic.MODULE_BUILD_DIR, incrementalCachePath.toNIO)
+    icBuilder.set(Ic.PRECISE_JAVA_TRACKING, java.lang.Boolean.TRUE)
+
+    builder.set(JvmCompilationOperation.INCREMENTAL_COMPILATION, icBuilder.build())
+    builder.build()
+  }
+
+  protected def snapshottingOperation(
+      jvmToolchain: JvmPlatformToolchain,
+      classpathEntry: Path
+  )(using ctx: TaskCtx): BuildOperation[ClasspathEntrySnapshot] = {
+    val builder = jvmToolchain.classpathSnapshottingOperationBuilder(classpathEntry)
+    builder.set(
+      JvmClasspathSnapshottingOperation.GRANULARITY,
+      ClassSnapshotGranularity.CLASS_MEMBER_LEVEL
+    )
+    builder.set(
+      JvmClasspathSnapshottingOperation.PARSE_INLINED_LOCAL_CLASSES,
+      java.lang.Boolean.TRUE
+    )
+    builder.build()
+  }
+
+  private def untypedArguments(args: Seq[String]): Vector[String] = {
+    val kept = Vector.newBuilder[String]
+    var i = 0
+    while (i < args.length) {
+      val flag = args(i)
+      if (flag == "-d") i += 2
+      else typedWidth(flag) match {
+        case 0 => kept += flag; i += 1
+        case width => i += width
+      }
+    }
+    kept.result()
+  }
+
+  private def applyTypedArguments(a: JvmCompilerArguments.Builder, args: Seq[String]): Unit = {
+    var i = 0
+    while (i < args.length) {
+      val flag = args(i)
+      def value = args(i + 1)
+      flag match {
+        case "-module-name" => a.set(JvmCompilerArguments.MODULE_NAME, value)
+        case "-jdk-home" => a.set(JvmCompilerArguments.JDK_HOME, Path.of(value))
+        case "-no-stdlib" => a.set(JvmCompilerArguments.NO_STDLIB, java.lang.Boolean.TRUE)
+        case "-no-reflect" => a.set(JvmCompilerArguments.NO_REFLECT, java.lang.Boolean.TRUE)
+        case "-java-parameters" =>
+          a.set(JvmCompilerArguments.JAVA_PARAMETERS, java.lang.Boolean.TRUE)
+        case "-language-version" =>
+          kotlinVersions.get(value).foreach(a.set(CommonCompilerArguments.LANGUAGE_VERSION, _))
+        case "-api-version" =>
+          kotlinVersions.get(value).foreach(a.set(CommonCompilerArguments.API_VERSION, _))
+        case "-jvm-target" =>
+          jvmTargets.get(value).foreach(a.set(JvmCompilerArguments.JVM_TARGET, _))
+        case _ =>
+      }
+      i += (if (flag == "-d") 2 else math.max(typedWidth(flag), 1))
+    }
+  }
+
+  private def typedWidth(flag: String): Int = flag match {
+    case "-module-name" | "-jdk-home" | "-language-version" | "-api-version" | "-jvm-target" => 2
+    case "-no-stdlib" | "-no-reflect" | "-java-parameters" => 1
+    case _ => 0
+  }
+
+  private val kotlinVersions: Map[String, KotlinVersion] =
+    KotlinVersion.values().iterator.map(v => v.getStringValue -> v).toMap
+  private val jvmTargets: Map[String, JvmTarget] =
+    JvmTarget.values().iterator.map(v => v.getStringValue -> v).toMap
+}

--- a/libs/kotlinlib/worker/src-2-4/mill/kotlinlib/worker/impl/KotlinWorkerImpl.scala
+++ b/libs/kotlinlib/worker/src-2-4/mill/kotlinlib/worker/impl/KotlinWorkerImpl.scala
@@ -1,0 +1,18 @@
+/*
+ * Original code copied from https://github.com/lefou/mill-kotlin
+ * Original code published under the Apache License Version 2
+ * Original Copyright 2020-2024 Tobias Roeser
+ */
+package mill.kotlinlib.worker.impl
+
+class KotlinWorkerImpl(
+    private val classpathSnapshotCache: os.Path,
+    private val classpathSnapshotCacheIsStable: Boolean
+) extends KotlinWorkerImplBase(classpathSnapshotCache, classpathSnapshotCacheIsStable) {
+
+  override protected def jvmBtApiCompiler(): BtApiCompiler = jvmBtApiCompiler0
+
+  private lazy val jvmBtApiCompiler0: BtApiCompiler =
+    JvmCompileBtApi24Impl(classpathSnapshotCache)
+
+}

--- a/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/BtApiCompiler.scala
+++ b/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/BtApiCompiler.scala
@@ -2,41 +2,46 @@ package mill.kotlinlib.worker.impl
 
 import mill.api.{PathRef, TaskCtx}
 import org.jetbrains.kotlin.buildtools.api.{
+  BuildOperation,
   CompilationResult,
   ExecutionPolicy,
   KotlinLogger,
-  KotlinToolchains,
-  SourcesChanges
+  KotlinToolchains
 }
-import org.jetbrains.kotlin.buildtools.api.jvm.JvmPlatformToolchain
-import org.jetbrains.kotlin.buildtools.api.jvm.ClassSnapshotGranularity
-import org.jetbrains.kotlin.buildtools.api.jvm.JvmSnapshotBasedIncrementalCompilationConfiguration
-import org.jetbrains.kotlin.buildtools.api.jvm.JvmSnapshotBasedIncrementalCompilationOptions
-import org.jetbrains.kotlin.buildtools.api.jvm.operations.JvmClasspathSnapshottingOperation
-import org.jetbrains.kotlin.buildtools.api.jvm.operations.JvmCompilationOperation
+import org.jetbrains.kotlin.buildtools.api.jvm.{ClasspathEntrySnapshot, JvmPlatformToolchain}
 import org.jetbrains.kotlin.cli.common.ExitCode
 import mill.kotlinlib.worker.api.renderIntAsHex
 
 import java.io.{PrintWriter, StringWriter}
+import java.nio.file.Path
 import scala.jdk.CollectionConverters.*
-import scala.util.chaining.scalaUtilChainingOps
 
 /**
+ * Shared Build Tools API compilation flow. Implementations only supply the version-specific
+ * construction of the compilation and classpath-snapshotting operations, since the API for
+ * building those changed incompatibly in Kotlin 2.4.0.
+ *
  * @param classpathSnapshotCache The path to store classpath snapshots for incremental compilation.
  *                               Should live longer than the compile task itself, i.e. within a Worker
  *                               or a persistent task.
  */
-class JvmCompileBtApiImpl(
-    val classpathSnapshotCache: os.Path
-) extends Compiler {
+trait BtApiCompiler(val classpathSnapshotCache: os.Path) extends Compiler {
 
-  private def formatThrowable(throwable: Throwable): String = {
-    val sw = new StringWriter()
-    throwable.printStackTrace(new PrintWriter(sw))
-    sw.toString()
-  }
+  protected def compilationOperation(
+      jvmToolchain: JvmPlatformToolchain,
+      sourceFiles: java.util.List[Path],
+      destinationDirectory: os.Path,
+      args: Seq[String],
+      incrementalCachePath: os.Path,
+      classpathSnapshotFiles: Seq[Path]
+  )(using ctx: TaskCtx): BuildOperation[CompilationResult]
 
-  private def kotlinLogger(using ctx: TaskCtx): KotlinLogger = new KotlinLogger {
+  protected def snapshottingOperation(
+      jvmToolchain: JvmPlatformToolchain,
+      classpathEntry: Path
+  )(using ctx: TaskCtx): BuildOperation[ClasspathEntrySnapshot]
+
+  protected def kotlinLogger(using ctx: TaskCtx): KotlinLogger = new KotlinLogger {
     override def isDebugEnabled(): Boolean = ctx.log.debugEnabled
 
     override def error(message: String, throwable: Throwable): Unit = {
@@ -56,13 +61,10 @@ class JvmCompileBtApiImpl(
     override def lifecycle(message: String): Unit = ctx.log.info(message)
   }
 
-  private def destinationDirectoryFromArgs(args: Seq[String])(using ctx: TaskCtx): os.Path = {
+  protected def destinationDirectoryFromArgs(args: Seq[String])(using ctx: TaskCtx): os.Path =
     args.sliding(2)
-      .collectFirst {
-        case Seq("-d", dir) => os.Path(dir, ctx.workspace)
-      }
+      .collectFirst { case Seq("-d", dir) => os.Path(dir, ctx.workspace) }
       .getOrElse(ctx.dest / "classes")
-  }
 
   def compile(
       args: Seq[String],
@@ -76,32 +78,7 @@ class JvmCompileBtApiImpl(
 
     val toolchains = KotlinToolchains.loadImplementation(getClass().getClassLoader())
     val jvmToolchain = JvmPlatformToolchain.from(toolchains)
-    // The BTAPI IC engine (RelocatableFileToPathConverter) rejects the relative
-    // `../mill-workspace/...` paths os-lib renders inside Mill's sandbox, so every
-    // path handed to it is resolved to a real absolute path via `PathRef.toAbsNioPath`.
     val sourceFiles = sources.map(_.toNIO).asJava
-    val compilationOperation =
-      jvmToolchain.createJvmCompilationOperation(
-        sourceFiles,
-        destinationDirectory.toNIO
-      )
-
-    compilationOperation.getCompilerArguments().applyArgumentStrings(args.asJava)
-
-    val snapshotIcOptions = compilationOperation.createSnapshotBasedIcOptions().tap { options =>
-      options.set(
-        JvmSnapshotBasedIncrementalCompilationOptions.ROOT_PROJECT_DIR,
-        ctx.workspace.toNIO
-      )
-      options.set(
-        JvmSnapshotBasedIncrementalCompilationOptions.MODULE_BUILD_DIR,
-        incrementalCachePath.toNIO
-      )
-      options.set(
-        JvmSnapshotBasedIncrementalCompilationOptions.PRECISE_JAVA_TRACKING,
-        java.lang.Boolean.TRUE
-      )
-    }
 
     os.makeDir.all(classpathSnapshotCache)
 
@@ -113,17 +90,15 @@ class JvmCompileBtApiImpl(
           snapshot(jvmToolchain, buildSession, executionPolicy, ref)
         }
 
-        val incrementalConfig = new JvmSnapshotBasedIncrementalCompilationConfiguration(
-          incrementalCachePath.toNIO,
-          SourcesChanges.ToBeCalculated.INSTANCE,
-          classpathSnapshotFiles.asJava,
-          (incrementalCachePath / "shrunk-classpath-snapshot.bin").toNIO,
-          snapshotIcOptions
-        )
-        compilationOperation.set(JvmCompilationOperation.INCREMENTAL_COMPILATION, incrementalConfig)
-
         buildSession.executeOperation(
-          compilationOperation,
+          compilationOperation(
+            jvmToolchain = jvmToolchain,
+            sourceFiles = sourceFiles,
+            destinationDirectory = destinationDirectory,
+            args = args,
+            incrementalCachePath = incrementalCachePath,
+            classpathSnapshotFiles = classpathSnapshotFiles
+          ),
           executionPolicy,
           kotlinLogger
         )
@@ -155,22 +130,12 @@ class JvmCompileBtApiImpl(
       buildSession: KotlinToolchains.BuildSession,
       executionPolicy: ExecutionPolicy.InProcess,
       ref: PathRef
-  )(using TaskCtx): java.nio.file.Path = {
+  )(using TaskCtx): Path = {
     val snapshotFile =
       classpathSnapshotCache / s"${renderIntAsHex(ref.sig)}-${ref.path.last}.snapshot"
     if (!os.exists(snapshotFile)) {
-      val snapshottingOperation =
-        jvmToolchain.createClasspathSnapshottingOperation(ref.path.toNIO)
-      snapshottingOperation.set(
-        JvmClasspathSnapshottingOperation.GRANULARITY,
-        ClassSnapshotGranularity.CLASS_MEMBER_LEVEL
-      )
-      snapshottingOperation.set(
-        JvmClasspathSnapshottingOperation.PARSE_INLINED_LOCAL_CLASSES,
-        java.lang.Boolean.TRUE
-      )
       val snapshot = buildSession.executeOperation(
-        snapshottingOperation,
+        snapshottingOperation(jvmToolchain, ref.path.toNIO),
         executionPolicy,
         kotlinLogger
       )
@@ -180,5 +145,11 @@ class JvmCompileBtApiImpl(
       os.move(tmpFile, snapshotFile, atomicMove = true, replaceExisting = true)
     }
     snapshotFile.toNIO
+  }
+
+  private def formatThrowable(throwable: Throwable): String = {
+    val sw = StringWriter()
+    throwable.printStackTrace(PrintWriter(sw))
+    sw.toString()
   }
 }

--- a/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/BtApiCompilerFactory.scala
+++ b/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/BtApiCompilerFactory.scala
@@ -1,0 +1,5 @@
+package mill.kotlinlib.worker.impl
+
+trait BtApiCompilerFactory {
+  def create(classpathSnapshotCache: os.Path): BtApiCompiler
+}

--- a/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/KotlinWorkerImplBase.scala
+++ b/libs/kotlinlib/worker/src/mill/kotlinlib/worker/impl/KotlinWorkerImplBase.scala
@@ -9,7 +9,7 @@ import mill.api.daemon.Result
 import mill.api.TaskCtx
 import mill.kotlinlib.worker.api.{KotlinWorker, KotlinWorkerTarget}
 
-class KotlinWorkerImpl(
+abstract class KotlinWorkerImplBase(
     private val classpathSnapshotCache: os.Path,
     private val classpathSnapshotCacheIsStable: Boolean
 ) extends KotlinWorker, AutoCloseable {
@@ -27,11 +27,8 @@ class KotlinWorkerImpl(
 
     ctx.log.debug(s"Using source files: ${sources.map(v => s"'${v}'").mkString(" ")}")
 
-    // Use dedicated class to load implementation classes lazily
     val compiler = (target = target, useBtApi = useBtApi) match {
-      case (KotlinWorkerTarget.Jvm, true) => JvmCompileBtApiImpl(
-          classpathSnapshotCache = classpathSnapshotCache
-        )
+      case (KotlinWorkerTarget.Jvm, true) => jvmBtApiCompiler()
       case (KotlinWorkerTarget.Jvm, false) => JvmCompileImpl()
       case (target = KotlinWorkerTarget.Js) => JsCompileImpl()
     }
@@ -46,6 +43,8 @@ class KotlinWorkerImpl(
     ()
 
   }
+
+  protected def jvmBtApiCompiler(): BtApiCompiler
 
   override def close(): Unit = {
     if (!classpathSnapshotCacheIsStable) {

--- a/mill-build/src/millbuild/Deps.scala
+++ b/mill-build/src/millbuild/Deps.scala
@@ -236,10 +236,16 @@ object Deps {
   val sonatypeCentralClient = mvn"com.lumidion::sonatype-central-client-requests:0.6.0"
   val kotlinVersion = "2.1.20"
   val kspVersion = "2.0.1"
-  val kotlinBuildToolsApiVersion_api = "2.3.0"
+  val kotlinBuildToolsApi23Version_api = "2.3.0"
   val kotlinCompiler = mvn"org.jetbrains.kotlin:kotlin-compiler:$kotlinVersion"
-  val kotlinBuildToolsApi_api =
-    mvn"org.jetbrains.kotlin:kotlin-build-tools-api:$kotlinBuildToolsApiVersion_api"
+  val kotlin24Compiler_api = mvn"org.jetbrains.kotlin:kotlin-compiler:2.4.0"
+  val kotlinBuildTools23Api_api =
+    mvn"org.jetbrains.kotlin:kotlin-build-tools-api:$kotlinBuildToolsApi23Version_api"
+  // The 2.4.0 Build Tools API dropped the legacy operation factories in favour of builders; the
+  // `worker-btapi-2-4` module compiles the dedicated Kotlin 2.4+ backend against this generation.
+  val kotlinBuildToolsApi24Version_api = "2.4.0"
+  val kotlinBuildTools24Api_api =
+    mvn"org.jetbrains.kotlin:kotlin-build-tools-api:$kotlinBuildToolsApi24Version_api"
   val kotlinBuildToolsImpl = mvn"org.jetbrains.kotlin:kotlin-build-tools-impl:$kotlinVersion"
   val kotlinStdlib = mvn"org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
   val groovyVersion_lowerBound = "4.0.28"

--- a/mill-build/src/millbuild/MillPublishScalaModule.scala
+++ b/mill-build/src/millbuild/MillPublishScalaModule.scala
@@ -1,4 +1,6 @@
 package millbuild
 
 /** Published module which does not contain strictly handled API. */
-trait MillPublishScalaModule extends MillScalaModule with MillPublishJavaModule
+trait MillPublishScalaModule extends MillScalaModule with MillPublishJavaModule {
+  def includeInApiDocs: Boolean = true
+}

--- a/website/package.mill
+++ b/website/package.mill
@@ -29,9 +29,7 @@ object `package` extends mill.Module {
       }
     def scalaVersion = Deps.scalaVersion
     def moduleDeps = build.moduleInternal.modules.collect {
-      // we exclude maven-worker module to workaround issue
-      // https://github.com/com-lihaoyi/mill/pull/5977/#issuecomment-3407301062
-      case m: MillPublishScalaModule if m != build.libs.javalib.`maven-worker` => m
+      case m: MillPublishScalaModule if m.includeInApiDocs => m
     }
     def unidocSourceUrl = Task {
       val sha = "main" // VcsVersion.vcsState().currentRevision


### PR DESCRIPTION
Introduce a second "2-4" Kotlin worker used for Kotlin 2.4+. For older versions, the other "1" worker is used.

In the Kotlin Build Tools API, `createJvmCompilationOperation` has been deprecated ([source](https://github.com/JetBrains/kotlin/blob/fd00198088a7b3a3413750890ae8999dce5d22ae/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/jvm/JvmPlatformToolchainImpl.kt#L22-L30), see [KT-81790](https://youtrack.jetbrains.com/issue/KT-81790) for context) and later removed, making Mill's kotlinlib incompatible with Kotlin 2.4.

Backport of pull request: https://github.com/com-lihaoyi/mill/pull/7334

