### PR TITLE
Fix semanticdb plugin parameters, use separate parameters to avoid space issues

### DIFF
--- a/libs/javalib/src/mill/javalib/SemanticDbJavaModule.scala
+++ b/libs/javalib/src/mill/javalib/SemanticDbJavaModule.scala
@@ -238,7 +238,12 @@ object SemanticDbJavaModule extends ExternalModule with CoursierModule {
     val buildTool = s" -build-tool:${if (isNewEnough) "mill" else "sbt"}"
     val verbose = if (ctx.log.debugEnabled) " -verbose" else ""
     javacOptions ++ Seq(
-      s"-Xplugin:semanticdb -sourceroot:${ctx.workspace} -targetroot:${ctx.dest / "classes"}${buildTool}${verbose}"
+      // enable the plugin
+      s"-Xplugin:semanticdb",
+      // set sourceroot option
+      "-P:semanticdb:sourceroot:${ctx.workspace}",
+      // set targetroot option
+      "-P:semanticdb:targetroot:${ctx.dest / "classes"}${buildTool}${verbose}"
     )
   }
 


### PR DESCRIPTION
Fix https://github.com/com-lihaoyi/mill/issues/7392

This should be covered by existing tests.
