### PR TITLE
Fix typo in doc comment

### DIFF
--- a/runner/daemon/src/mill/daemon/Watching.scala
+++ b/runner/daemon/src/mill/daemon/Watching.scala
@@ -281,7 +281,7 @@ object Watching {
   /**
    * @param notifiablesChanged returns true if any of the notifiables have changed
    *
-   * @return `Some(...)` if notifiablesChanged returned a `Some(...)`, `None` if changes in watched files occured.
+   * @return `Some(...)` if notifiablesChanged returned a `Some(...)`, `None` if changes in watched files occurred.
    */
   def statWatchWait[T](
       watchedValues: Seq[Watchable.Value],


### PR DESCRIPTION
Small typo fix in a Scaladoc comment: "occured" -> "occurred".
