### PR TITLE
feat(cache): add remote cache read-only mode

### DIFF
--- a/core/exec/src/mill/exec/Execution.scala
+++ b/core/exec/src/mill/exec/Execution.scala
@@ -46,6 +46,7 @@ case class Execution(
     remoteCacheLocation: Option[String] = None,
     remoteCacheSalt: Option[String] = None,
     remoteCacheFilter: Option[String] = None,
+    remoteCacheReadOnly: Boolean = false,
     replayLogs: Boolean
 ) extends GroupExecution with AutoCloseable {
 
@@ -82,6 +83,7 @@ case class Execution(
       remoteCacheLocation: Option[String],
       remoteCacheSalt: Option[String],
       remoteCacheFilter: Option[String],
+      remoteCacheReadOnly: Boolean,
       replayLogs: Boolean
   ) = this(
     baseLogger = baseLogger,
@@ -118,6 +120,7 @@ case class Execution(
     remoteCacheLocation = remoteCacheLocation,
     remoteCacheSalt = remoteCacheSalt,
     remoteCacheFilter = remoteCacheFilter,
+    remoteCacheReadOnly = remoteCacheReadOnly,
     replayLogs = replayLogs
   )
 

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -55,6 +55,7 @@ trait GroupExecution {
   def remoteCacheLocation: Option[String]
   def remoteCacheSalt: Option[String]
   def remoteCacheFilter: Option[String]
+  def remoteCacheReadOnly: Boolean
 
   def replayLogs: Boolean
 
@@ -517,15 +518,17 @@ trait GroupExecution {
                     case ExecResult.Success((v, _)) =>
                       val (valueHash, serializedPaths) =
                         handleTaskResult(v, cacheEntry, inputsHash, labelled)
-                      // Push freshly-computed outputs to the remote cache for other machines.
-                      remoteCache.foreach { cache =>
-                        taskLocks.blockingOnPool {
-                          cache.store(
-                            paths,
-                            inputsHash,
-                            labelled.ctx.segments.render,
-                            serializedPaths
-                          )
+                      if (!remoteCacheReadOnly) {
+                        // Push freshly-computed outputs to the remote cache for other machines.
+                        remoteCache.foreach { cache =>
+                          taskLocks.blockingOnPool {
+                            cache.store(
+                              paths,
+                              inputsHash,
+                              labelled.ctx.segments.render,
+                              serializedPaths
+                            )
+                          }
                         }
                       }
                       // Reuse `handleTaskResult`'s hash (derived from the JSON it writes) as the

--- a/core/internal/cli/src/mill/internal/MillCliConfig.scala
+++ b/core/internal/cli/src/mill/internal/MillCliConfig.scala
@@ -180,6 +180,12 @@ case class MillCliConfig(
       doc = "Task-selector pattern (e.g. `__.compile`) limiting which tasks use the remote cache."
     )
     remoteCacheFilter: Option[String] = None,
+    @arg(
+      hidden = true,
+      name = "remote-cache-read-only",
+      doc = "Read from the remote cache without storing newly computed results."
+    )
+    remoteCacheReadOnly: Flag = Flag(),
     @arg(hidden = true, doc = "Deprecated, use `--ticker false` instead")
     disableTicker: Flag,
     @arg(doc = "Replay logs for cached tasks.")

--- a/integration/dedicated/remote-cache/src/RemoteCacheTests.scala
+++ b/integration/dedicated/remote-cache/src/RemoteCacheTests.scala
@@ -242,6 +242,31 @@ object RemoteCacheTests extends UtestIntegrationTestSuite {
       }
     }
 
+    test("readOnly") - {
+      val cacheDir = os.temp.dir(prefix = "mill-remote-cache-read-only")
+      val url = cacheDir.toNIO.toUri.toString
+      integrationTest { tester =>
+        val res = tester.eval(("--remote-cache-location", url, "cachedTask"))
+        assert(res.isSuccess)
+        assert(evaluated(tester, "cachedTask"))
+      }
+      val cachedFiles = os.walk(cacheDir).filter(os.isFile).toSet
+      integrationTest { tester =>
+        val res = tester.eval((
+          "--remote-cache-location",
+          url,
+          "--remote-cache-read-only",
+          "cachedTask",
+          "+",
+          "uncachedTask"
+        ))
+        assert(res.isSuccess)
+        assert(!evaluated(tester, "cachedTask"))
+        assert(evaluated(tester, "uncachedTask"))
+      }
+      assert(os.walk(cacheDir).filter(os.isFile).toSet == cachedFiles)
+    }
+
     // An unreachable cache degrades gracefully: the build still succeeds, computing locally.
     test("gracefulDegradationWhenCacheUnreachable") - integrationTest { tester =>
       val res =

--- a/libs/tabcomplete/test/src/mill/tabcomplete/TabCompleteTests.scala
+++ b/libs/tabcomplete/test/src/mill/tabcomplete/TabCompleteTests.scala
@@ -386,6 +386,7 @@ object TabCompleteTests extends TestSuite {
             "--remote-cache-location   <str> Remote cache location: a Bazel-remote-protocol HTTP cache URL, or a `file:` URL / path to a local or shared folder.",
             "--remote-cache-salt       <str> Extra string mixed into the remote cache key, e.g. to keep Mac and Linux builds from sharing entries.",
             "--remote-cache-filter     <str> Task-selector pattern (e.g. `__.compile`) limiting which tasks use the remote cache.",
+            "--remote-cache-read-only  Read from the remote cache without storing newly computed results.",
             "--replay-logs             Replay logs for cached tasks."
           )
         )

--- a/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
+++ b/runner/daemon/src/mill/daemon/MillBuildBootstrap.scala
@@ -64,6 +64,7 @@ class MillBuildBootstrap(
     remoteCacheLocation: Option[String],
     remoteCacheSalt: Option[String],
     remoteCacheFilter: Option[String],
+    remoteCacheReadOnly: Boolean,
     runArtifacts: LauncherOutFiles,
     metaBuild: MetaBuildAccess,
     reporter: EvaluatorApi => Int => Option[CompileProblemReporter],
@@ -269,6 +270,7 @@ class MillBuildBootstrap(
       remoteCacheLocation = remoteCacheLocation,
       remoteCacheSalt = remoteCacheSalt,
       remoteCacheFilter = remoteCacheFilter,
+      remoteCacheReadOnly = remoteCacheReadOnly,
       workspaceLocking = workspaceLocking,
       runArtifacts = runArtifacts,
       workerCache = workerCache,
@@ -851,6 +853,7 @@ object MillBuildBootstrap {
       remoteCacheLocation: Option[String],
       remoteCacheSalt: Option[String],
       remoteCacheFilter: Option[String],
+      remoteCacheReadOnly: Boolean,
       workspaceLocking: LauncherLocking,
       runArtifacts: LauncherOutFiles,
       workerCache: collection.mutable.Map[String, (Int, Val, TaskApi[?])],
@@ -914,6 +917,7 @@ object MillBuildBootstrap {
           remoteCacheLocation,
           remoteCacheSalt,
           remoteCacheFilter,
+          remoteCacheReadOnly,
           replayLogs
         )
       ).asInstanceOf[EvaluatorApi]

--- a/runner/daemon/src/mill/daemon/MillMain0.scala
+++ b/runner/daemon/src/mill/daemon/MillMain0.scala
@@ -427,6 +427,7 @@ object MillMain0 {
                                     remoteCacheLocation = config.remoteCacheLocation,
                                     remoteCacheSalt = config.remoteCacheSalt,
                                     remoteCacheFilter = config.remoteCacheFilter,
+                                    remoteCacheReadOnly = config.remoteCacheReadOnly.value,
                                     runArtifacts = runArtifacts,
                                     metaBuild = new MetaBuildAccess(
                                       ref = sharedState,


### PR DESCRIPTION
Adds `--remote-cache-read-only`.

In our setup, one trusted CI runner can populate the shared cache, while developer machines have read-only access. This prevents compromised or malicious developer builds from publishing artifacts that other machines could later restore.

Today, Mill still packages cache misses and attempts uploads that the server will reject. Read-only mode keeps cache restores enabled while skipping gzip, hashing, temporary-file creation, and upload for locally compiled results.