### PR TITLE
fix(mill): Avoid watching directory probes (backport #7173)

### DIFF
--- a/core/eval/src/mill/eval/ScriptModuleInit.scala
+++ b/core/eval/src/mill/eval/ScriptModuleInit.scala
@@ -193,8 +193,10 @@ class ScriptModuleInit extends ((String, Evaluator) => Seq[Result[ExternalModule
   def resolveScriptModule(scriptFile0: String, eval: Evaluator): Option[Result[ExternalModule]] = {
     val scriptFile = os.Path(scriptFile0, mill.api.BuildCtx.workspaceRoot)
     // Add a synthetic watch on `scriptFile`, representing the special handling
-    // of `staticBuildOverrides` which is read from the script file build header
-    mill.api.BuildCtx.evalWatch(scriptFile)
+    // of `staticBuildOverrides` which is read from the script file build header.
+    // Directory probes are not script files, and watching them would recursively
+    // digest their entire contents.
+    if (!os.isDir(scriptFile)) mill.api.BuildCtx.evalWatch(scriptFile)
 
     Option.when(os.isFile(scriptFile)) {
       // Check for recursive moduleDeps cycle

--- a/core/eval/test/src/mill/eval/ScriptModuleInitTests.scala
+++ b/core/eval/test/src/mill/eval/ScriptModuleInitTests.scala
@@ -1,0 +1,35 @@
+package mill.eval
+
+import mill.api.BuildCtx
+import utest.*
+
+object ScriptModuleInitTests extends TestSuite {
+  val tests = Tests {
+    test("directoryProbeIsNotWatched") {
+      val workspace = os.temp.dir()
+      os.makeDir(workspace / "module")
+
+      val watchedValues = BuildCtx.evalWatchedValues
+      watchedValues.synchronized {
+        val previousWatchedValues = watchedValues.toVector
+        try {
+          watchedValues.clear()
+          BuildCtx.workspaceRoot0.withValue(workspace) {
+            val result = ScriptModuleInit().resolveScriptModule("module", null)
+            assert(result.isEmpty)
+          }
+          assert(watchedValues.isEmpty)
+
+          BuildCtx.workspaceRoot0.withValue(workspace) {
+            val result = ScriptModuleInit().resolveScriptModule("missing", null)
+            assert(result.isEmpty)
+          }
+          assert(watchedValues.size == 1)
+        } finally {
+          watchedValues.clear()
+          watchedValues ++= previousWatchedValues
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Backport the directory-probe handling from #7173 to the Mill 1.1.x branch.

`ScriptModuleInit.resolveScriptModule` previously registered every candidate path as a watch, including directories. Because `PathRef` recursively digests directories, resolving a module namespace could hash a large source tree during every Mill invocation.

Directory candidates are now excluded from `evalWatch`. Script-file and missing-file candidates continue to be watched, preserving `staticBuildOverrides` invalidation behavior.

A focused regression test covers both cases.

## Performance

Profiling a repeated warm no-op build with unchanged sources showed:

- Total invocation: approximately 1.5 seconds
- Recursive directory digest: approximately 953 milliseconds

This change removes that directory-digest work from module resolution.

## Reference

This follows the implementation already merged for the Mill 1.2.x line:

- #7173
- https://github.com/com-lihaoyi/mill/commit/69e06ebfd9810533b2fd2e6f2d0cdac5650824c3
