### PR TITLE
`mill init`: Initial Android support

### DIFF
--- a/libs/init/buildgen/api/src/mill/main/buildgen/ModuleSpec.scala
+++ b/libs/init/buildgen/api/src/mill/main/buildgen/ModuleSpec.scala
@@ -102,7 +102,8 @@ case class ModuleSpec(
     androidTargetSdk: Value[Int] = Value(),
     androidVersionCode: Value[Int] = Value(),
     androidVersionName: Value[String] = Value(),
-    androidBuildToolsVersion: Value[String] = Value()
+    androidBuildToolsVersion: Value[String] = Value(),
+    androidSdkModuleDep: Value[ModuleDep] = Value()
 ) {
 
   def isBomModule: Boolean = supertypes.contains("BomModule")
@@ -210,6 +211,7 @@ case class ModuleSpec(
     )
   }
   
+  /** `androidBuildToolsVersion` is just a marker here, picked up later by `MillGradleBuildGenMain.attachAndroidSdkModule`. */
   def withAndroidKotlinModule(
       isApp: Boolean,
       namespace: Value[String],
@@ -220,27 +222,19 @@ case class ModuleSpec(
       versionCode: Value[Int],
       versionName: Value[String],
       buildToolsVersion: Value[String]
-  ): ModuleSpec = {
-    val sdkModuleName = "androidSdkModule0"
-    val sdkModule = ModuleSpec(
-      name = sdkModuleName,
-      supertypes = Seq("AndroidSdkModule"),
-      androidBuildToolsVersion = buildToolsVersion
-    )
-    copy(
-      imports = Seq("mill.androidlib.*", "mill.kotlinlib.*") ++ imports,
-      supertypes = (if (isApp) "AndroidAppKotlinModule" else "AndroidKotlinModule") +: supertypes,
-      androidApplicationNamespace = if (isApp) namespace else Value(),
-      androidNamespace = if (isApp) Value() else namespace,
-      androidApplicationId = if (isApp) applicationId else Value(),
-      androidCompileSdk = compileSdk,
-      androidMinSdk = minSdk,
-      androidTargetSdk = targetSdk,
-      androidVersionCode = versionCode,
-      androidVersionName = versionName,
-      children = children :+ sdkModule
-    )
-  }
+  ): ModuleSpec = copy(
+    imports = Seq("mill.androidlib.*", "mill.kotlinlib.*") ++ imports,
+    supertypes = (if (isApp) "AndroidAppKotlinModule" else "AndroidKotlinModule") +: supertypes,
+    androidApplicationNamespace = if (isApp) namespace else Value(),
+    androidNamespace = if (isApp) Value() else namespace,
+    androidApplicationId = if (isApp) applicationId else Value(),
+    androidCompileSdk = compileSdk,
+    androidMinSdk = minSdk,
+    androidTargetSdk = targetSdk,
+    androidVersionCode = versionCode,
+    androidVersionName = versionName,
+    androidBuildToolsVersion = buildToolsVersion
+  )
 
   def withJmhModule(jmhCoreVersion: Value[String]): ModuleSpec = copy(
     imports = "mill.contrib.jmh.JmhModule" +: imports,

--- a/libs/init/buildgen/api/src/mill/main/buildgen/ModuleSpec.scala
+++ b/libs/init/buildgen/api/src/mill/main/buildgen/ModuleSpec.scala
@@ -210,7 +210,7 @@ case class ModuleSpec(
       micronautAotConfigProperties = micronautAotConfigProperties
     )
   }
-  
+
   /** `androidBuildToolsVersion` is just a marker here, picked up later by `MillGradleBuildGenMain.attachAndroidSdkModule`. */
   def withAndroidKotlinModule(
       isApp: Boolean,

--- a/libs/init/buildgen/api/src/mill/main/buildgen/ModuleSpec.scala
+++ b/libs/init/buildgen/api/src/mill/main/buildgen/ModuleSpec.scala
@@ -93,7 +93,16 @@ case class ModuleSpec(
     kotlincPluginMvnDeps: Values[MvnDep] = Values(),
     micronautPackage: Value[String] = Value(),
     micronautAotConfigProperties: Value[Map[String, String]] = Value(),
-    micronautAotConfigFile: Value[String] = Value()
+    micronautAotConfigFile: Value[String] = Value(),
+    androidApplicationNamespace: Value[String] = Value(),
+    androidNamespace: Value[String] = Value(),
+    androidApplicationId: Value[String] = Value(),
+    androidCompileSdk: Value[Int] = Value(),
+    androidMinSdk: Value[Int] = Value(),
+    androidTargetSdk: Value[Int] = Value(),
+    androidVersionCode: Value[Int] = Value(),
+    androidVersionName: Value[String] = Value(),
+    androidBuildToolsVersion: Value[String] = Value()
 ) {
 
   def isBomModule: Boolean = supertypes.contains("BomModule")

--- a/libs/init/buildgen/api/src/mill/main/buildgen/ModuleSpec.scala
+++ b/libs/init/buildgen/api/src/mill/main/buildgen/ModuleSpec.scala
@@ -209,6 +209,38 @@ case class ModuleSpec(
       micronautAotConfigProperties = micronautAotConfigProperties
     )
   }
+  
+  def withAndroidKotlinModule(
+      isApp: Boolean,
+      namespace: Value[String],
+      applicationId: Value[String],
+      compileSdk: Value[Int],
+      minSdk: Value[Int],
+      targetSdk: Value[Int],
+      versionCode: Value[Int],
+      versionName: Value[String],
+      buildToolsVersion: Value[String]
+  ): ModuleSpec = {
+    val sdkModuleName = "androidSdkModule0"
+    val sdkModule = ModuleSpec(
+      name = sdkModuleName,
+      supertypes = Seq("AndroidSdkModule"),
+      androidBuildToolsVersion = buildToolsVersion
+    )
+    copy(
+      imports = Seq("mill.androidlib.*", "mill.kotlinlib.*") ++ imports,
+      supertypes = (if (isApp) "AndroidAppKotlinModule" else "AndroidKotlinModule") +: supertypes,
+      androidApplicationNamespace = if (isApp) namespace else Value(),
+      androidNamespace = if (isApp) Value() else namespace,
+      androidApplicationId = if (isApp) applicationId else Value(),
+      androidCompileSdk = compileSdk,
+      androidMinSdk = minSdk,
+      androidTargetSdk = targetSdk,
+      androidVersionCode = versionCode,
+      androidVersionName = versionName,
+      children = children :+ sdkModule
+    )
+  }
 
   def withJmhModule(jmhCoreVersion: Value[String]): ModuleSpec = copy(
     imports = "mill.contrib.jmh.JmhModule" +: imports,

--- a/libs/init/buildgen/src/mill/main/buildgen/BuildGenScala.scala
+++ b/libs/init/buildgen/src/mill/main/buildgen/BuildGenScala.scala
@@ -191,7 +191,11 @@ object BuildGenScala extends BuildGen {
       micronautAotConfigProperties,
       encodeStringMap
     )
-    lines += renderDefValue("androidApplicationNamespace", androidApplicationNamespace, encodeString)
+    lines += renderDefValue(
+      "androidApplicationNamespace",
+      androidApplicationNamespace,
+      encodeString
+    )
     lines += renderDefValue("androidNamespace", androidNamespace, encodeString)
     lines += renderDefValue("androidApplicationId", androidApplicationId, encodeString)
     lines += renderDefValue("androidCompileSdk", androidCompileSdk, _.toString)

--- a/libs/init/buildgen/src/mill/main/buildgen/BuildGenScala.scala
+++ b/libs/init/buildgen/src/mill/main/buildgen/BuildGenScala.scala
@@ -200,8 +200,11 @@ object BuildGenScala extends BuildGen {
     lines += renderDefValue("androidVersionCode", androidVersionCode, _.toString)
     lines += renderDefValue("androidVersionName", androidVersionName, encodeString)
     lines += renderDefValue("buildToolsVersion", androidBuildToolsVersion, encodeString)
-    for (sdkModule <- children.find(_.supertypes.contains("AndroidSdkModule")))
-      lines += s"def androidSdkModule = mill.api.ModuleRef(${sdkModule.name})"
+    lines += renderDefValue(
+      "androidSdkModule",
+      androidSdkModuleDep,
+      dep => s"mill.api.ModuleRef(${encodeModuleDep(dep)})"
+    )
     lines += renderDefValues(
       "sourcesRootFolders",
       sourcesRootFolders,

--- a/libs/init/buildgen/src/mill/main/buildgen/BuildGenScala.scala
+++ b/libs/init/buildgen/src/mill/main/buildgen/BuildGenScala.scala
@@ -191,6 +191,17 @@ object BuildGenScala extends BuildGen {
       micronautAotConfigProperties,
       encodeStringMap
     )
+    lines += renderDefValue("androidApplicationNamespace", androidApplicationNamespace, encodeString)
+    lines += renderDefValue("androidNamespace", androidNamespace, encodeString)
+    lines += renderDefValue("androidApplicationId", androidApplicationId, encodeString)
+    lines += renderDefValue("androidCompileSdk", androidCompileSdk, _.toString)
+    lines += renderDefValue("androidMinSdk", androidMinSdk, _.toString)
+    lines += renderDefValue("androidTargetSdk", androidTargetSdk, _.toString)
+    lines += renderDefValue("androidVersionCode", androidVersionCode, _.toString)
+    lines += renderDefValue("androidVersionName", androidVersionName, encodeString)
+    lines += renderDefValue("buildToolsVersion", androidBuildToolsVersion, encodeString)
+    for (sdkModule <- children.find(_.supertypes.contains("AndroidSdkModule")))
+      lines += s"def androidSdkModule = mill.api.ModuleRef(${sdkModule.name})"
     lines += renderDefValues(
       "sourcesRootFolders",
       sourcesRootFolders,

--- a/libs/init/gradle/exportplugin/src/mill/main/gradle/BuildModelBuilder.scala
+++ b/libs/init/gradle/exportplugin/src/mill/main/gradle/BuildModelBuilder.scala
@@ -191,7 +191,7 @@ class BuildModelBuilder(ctx: GradleBuildCtx, objectFactory: ObjectFactory, works
           }
       }
       KotlinData(
-        kotlinVersion = detectKotlinVersion(project0),
+        kotlinVersion = detectKotlinVersion(project0, configs),
         mainKotlinCompile = Option(getTasks.findByName("compileKotlin")),
         testKotlinCompile = Option(getTasks.findByName("compileTestKotlin")),
         mainKotlinPluginDeps = kotlinCompilerPlugins,
@@ -438,6 +438,109 @@ class BuildModelBuilder(ctx: GradleBuildCtx, objectFactory: ObjectFactory, works
     PackageSpec(moduleDir.subRelativeTo(workspace), mainModule)
   }
 
+  private val AndroidApplicationPluginId = "com.android.application"
+
+  private def isAndroidAppProject(project: Project): Boolean =
+    project.getPluginManager.hasPlugin(AndroidApplicationPluginId)
+
+  private case class AndroidAppData(
+      namespace: Option[String],
+      applicationId: Option[String],
+      compileSdk: Option[Int],
+      minSdk: Option[Int],
+      targetSdk: Option[Int],
+      versionCode: Option[Int],
+      versionName: Option[String],
+      buildToolsVersion: Option[String]
+  )
+
+  private def reflectGet[T](obj: Any, getterName: String): Option[T] =
+    Try(obj.getClass.getMethod(getterName).invoke(obj)).toOption.flatMap(Option(_))
+      .map(_.asInstanceOf[T])
+
+  /**
+   * Reads the `android { ... }` extension via reflection rather than a compile-time AGP
+   * dependency, since `exportplugin` must work against whatever AGP version the target
+   * project applies.
+   */
+  private def extractAndroidAppData(project: Project): AndroidAppData = {
+    val androidExt = Option(project.getExtensions.findByName("android"))
+    val defaultConfig = androidExt.flatMap(reflectGet[Any](_, "getDefaultConfig"))
+
+    AndroidAppData(
+      namespace = androidExt.flatMap(reflectGet[String](_, "getNamespace")),
+      applicationId = defaultConfig.flatMap(reflectGet[String](_, "getApplicationId")),
+      compileSdk = androidExt.flatMap(reflectGet[Integer](_, "getCompileSdk")).map(_.intValue),
+      minSdk = defaultConfig.flatMap(reflectGet[Integer](_, "getMinSdk")).map(_.intValue),
+      targetSdk = defaultConfig.flatMap(reflectGet[Integer](_, "getTargetSdk")).map(_.intValue),
+      versionCode = defaultConfig.flatMap(reflectGet[Integer](_, "getVersionCode")).map(_.intValue),
+      versionName = defaultConfig.flatMap(reflectGet[String](_, "getVersionName")),
+      buildToolsVersion = androidExt.flatMap(reflectGet[String](_, "getBuildToolsVersion"))
+    )
+  }
+
+  private def configureAndroidAppModule(
+      moduleDir: os.Path,
+      data: ExtractedJvmData,
+      androidData: AndroidAppData,
+      mainModule0: ModuleSpec
+  ): PackageSpec = {
+    import androidData.*
+    val baseJvmModule = configureBaseJvmModule(data, mainModule0)
+
+    var mainModule = baseJvmModule.withAndroidKotlinModule(
+      isApp = true,
+      namespace = namespace,
+      applicationId = applicationId,
+      compileSdk = compileSdk,
+      minSdk = minSdk,
+      targetSdk = targetSdk,
+      versionCode = versionCode,
+      versionName = versionName,
+      buildToolsVersion = buildToolsVersion
+    )
+
+    if (os.exists(moduleDir / "src/test")) {
+      // Android has no plain "testRuntimeClasspath" config (unlike plain Java/Kotlin) - unit
+      // test configs are build-type-qualified, e.g. "debugUnitTestRuntimeClasspath".
+      val androidTestMvnDepsList = data.configs.find(_.getName == "debugUnitTestRuntimeClasspath")
+        .fold(Nil)(_.getAllDependencies.asScala.toSeq.collect(toMvnDep))
+      val androidTestMixin = ModuleSpec.testModuleMixin(androidTestMvnDepsList)
+      val testModule = ModuleSpec(
+        name = "test",
+        supertypes = "AndroidAppKotlinTests" +: androidTestMixin.toSeq,
+        mvnDeps = getMvnDeps(data, "testImplementation"),
+        compileMvnDeps = getMvnDeps(data, "testCompileOnly"),
+        runMvnDeps = getMvnDeps(data, "testRuntimeOnly"),
+        moduleDeps = getModuleDeps(data, "testImplementation")
+          .diff(Seq(ModuleDep(moduleDir.subRelativeTo(workspace).segments))),
+        compileModuleDeps = getModuleDeps(data, "testCompileOnly"),
+        runModuleDeps = getModuleDeps(data, "testRuntimeOnly"),
+        testParallelism = Some(false),
+        testSandboxWorkingDir = Some(false),
+        testFramework = Option.when(androidTestMixin.isEmpty)("")
+      )
+      mainModule = mainModule.copy(children = mainModule.children :+ testModule)
+    }
+
+    if (os.exists(moduleDir / "src/androidTest")) {
+      val androidTestModule = ModuleSpec(
+        name = "it",
+        supertypes = Seq("AndroidAppKotlinInstrumentedTests"),
+        mvnDeps = getMvnDeps(data, "androidTestImplementation"),
+        compileMvnDeps = getMvnDeps(data, "androidTestCompileOnly"),
+        runMvnDeps = getMvnDeps(data, "androidTestRuntimeOnly"),
+        moduleDeps = getModuleDeps(data, "androidTestImplementation")
+          .diff(Seq(ModuleDep(moduleDir.subRelativeTo(workspace).segments))),
+        compileModuleDeps = getModuleDeps(data, "androidTestCompileOnly"),
+        runModuleDeps = getModuleDeps(data, "androidTestRuntimeOnly")
+      )
+      mainModule = mainModule.copy(children = mainModule.children :+ androidTestModule)
+    }
+
+    PackageSpec(moduleDir.subRelativeTo(workspace), mainModule)
+  }
+
   private def toPackage(project0: Project): PackageSpec = {
     import project0.*
     val moduleDir = os.Path(getProjectDir)
@@ -462,6 +565,11 @@ class BuildModelBuilder(ctx: GradleBuildCtx, objectFactory: ObjectFactory, works
         bomModuleDeps = deps.filter(isBom).collect(toModuleDep)
       )
       PackageSpec(moduleDir.subRelativeTo(workspace), mainModule)
+    } else if (isAndroidAppProject(project0)) {
+      // Apply the Kotlin module by default, matching AGP's own latest behavior.
+      val data = extractJvmData(project0, isKotlin = true)
+      val androidData = extractAndroidAppData(project0)
+      configureAndroidAppModule(moduleDir, data, androidData, mainModule)
     } else if (getPluginManager.hasPlugin("java") || isKotlin) {
       val data = extractJvmData(project0, isKotlin)
       configureJvmModule(moduleDir, data, mainModule)
@@ -586,27 +694,39 @@ class BuildModelBuilder(ctx: GradleBuildCtx, objectFactory: ObjectFactory, works
   }
 
   private val KotlinJvmPluginId = "org.jetbrains.kotlin.jvm"
+  private val KotlinAndroidPluginId = "org.jetbrains.kotlin.android"
 
   private def isKotlinProject(project: Project): Boolean =
     project.getPluginManager.hasPlugin(KotlinJvmPluginId) ||
+      project.getPluginManager.hasPlugin(KotlinAndroidPluginId) ||
       project.getPluginManager.hasPlugin("kotlin")
 
   /**
-   * Detects the Kotlin version by using the `getPluginVersion` method on the Kotlin plugin, if present.
+   * Detects the Kotlin version by using the `getPluginVersion` method on the Kotlin plugin, if
+   * present. Fallbacks to kotlin-stdlib version (AGP 9).
    */
-  private def detectKotlinVersion(project: Project): Option[String] = {
+  private def detectKotlinVersion(project: Project, configs: Seq[Configuration]): Option[String] = {
     val pluginOpt = Option(project.getPlugins.findPlugin(KotlinJvmPluginId))
+      .orElse(Option(project.getPlugins.findPlugin(KotlinAndroidPluginId)))
       .orElse(Option(project.getPlugins.findPlugin("kotlin")))
-    pluginOpt.flatMap { plugin =>
+    val viaPluginVersion = pluginOpt.flatMap { plugin =>
       try {
         val method = plugin.getClass.getMethod("getPluginVersion")
         Option(method.invoke(plugin)).map(_.toString)
       } catch {
         case _: Throwable => None
       }
+    }
+    viaPluginVersion.orElse {
+      configs.iterator
+        .flatMap(_.getDependencies.asScala)
+        .collect(toMvnDep)
+        .find(d => d.organization == "org.jetbrains.kotlin" && d.name.startsWith("kotlin-stdlib"))
+        .map(_.version).filter(_.nonEmpty)
     }.orElse {
       // Fallback to implementation version and remove any "-release" suffix
       detectPluginVersion(project, KotlinJvmPluginId)
+        .orElse(detectPluginVersion(project, KotlinAndroidPluginId))
         .orElse(detectPluginVersion(project, "kotlin"))
         .map(_.split("-release").head)
     }

--- a/libs/init/gradle/exportplugin/src/mill/main/gradle/BuildModelBuilder.scala
+++ b/libs/init/gradle/exportplugin/src/mill/main/gradle/BuildModelBuilder.scala
@@ -522,7 +522,7 @@ class BuildModelBuilder(ctx: GradleBuildCtx, objectFactory: ObjectFactory, works
 
     if (os.exists(moduleDir / "src/androidTest")) {
       val androidTestModule = ModuleSpec(
-        name = "it",
+        name = "androidTest",
         supertypes = Seq("AndroidAppKotlinInstrumentedTests"),
         mvnDeps = getMvnDeps(data, "androidTestImplementation"),
         compileMvnDeps = getMvnDeps(data, "androidTestCompileOnly"),

--- a/libs/init/gradle/exportplugin/src/mill/main/gradle/BuildModelBuilder.scala
+++ b/libs/init/gradle/exportplugin/src/mill/main/gradle/BuildModelBuilder.scala
@@ -444,12 +444,9 @@ class BuildModelBuilder(ctx: GradleBuildCtx, objectFactory: ObjectFactory, works
     val isKotlin = isKotlinProject(project0)
     var mainModule = ModuleSpec(
       name = moduleDir.last,
-      repositories = getRepositories.asScala.toSeq.collect(toRepositoryUrlString).distinct
-        .diff(Seq(
-          getRepositories.mavenCentral,
-          getRepositories.mavenLocal,
-          getRepositories.gradlePluginPortal
-        ).collect(toRepositoryUrlString))
+      repositories = getRepositories.asScala.toSeq
+        .filterNot(repo => WellKnownRepositoryNames.contains(repo.getName))
+        .collect(toRepositoryUrlString).distinct
     )
 
     var packageSpec = if (getPluginManager.hasPlugin("java-platform")) {
@@ -494,6 +491,18 @@ class BuildModelBuilder(ctx: GradleBuildCtx, objectFactory: ObjectFactory, works
   private val toRepositoryUrlString: PartialFunction[ArtifactRepository, String] = {
     case repo: UrlArtifactRepository => repo.getUrl.toURL.toExternalForm
   }
+
+  /**
+   * Gradle's own default names for `mavenCentral()`/`mavenLocal()`/`gradlePluginPortal()`. We
+   * filter by name rather than by calling those `RepositoryHandler` methods for their URLs,
+   * since calling them adds the repository to the project as a side effect.
+   * That throws under `dependencyResolutionManagement { repositoriesMode.set(FAIL_ON_PROJECT_REPOS) }`.
+   */
+  private val WellKnownRepositoryNames = Set(
+    ArtifactRepositoryContainer.DEFAULT_MAVEN_CENTRAL_REPO_NAME,
+    ArtifactRepositoryContainer.DEFAULT_MAVEN_LOCAL_REPO_NAME,
+    "Gradle Central Plugin Repository"
+  )
 
   private val platform = objectFactory.named(classOf[Category], Category.REGULAR_PLATFORM)
   private val enforcedPlatform = objectFactory.named(classOf[Category], Category.ENFORCED_PLATFORM)

--- a/libs/init/gradle/exportplugin/src/mill/main/gradle/BuildModelBuilder.scala
+++ b/libs/init/gradle/exportplugin/src/mill/main/gradle/BuildModelBuilder.scala
@@ -58,18 +58,24 @@ class BuildModelBuilder(ctx: GradleBuildCtx, objectFactory: ObjectFactory, works
     getDeps(data, configNames*).filterNot(isBom).collect(toModuleDep).distinct
   }
 
-  private def kotlinOptions(task: Task): Seq[String] = {
-    try {
-      val compilerOptions = task.getClass.getMethod("getCompilerOptions").invoke(task)
-      val freeArgsProperty =
-        compilerOptions.getClass.getMethod("getFreeCompilerArgs").invoke(compilerOptions)
-      // getFreeCompilerArgs returns a Gradle ListProperty<String>, so we call .get() on it.
-      freeArgsProperty.getClass.getMethod("get").invoke(freeArgsProperty)
-        .asInstanceOf[java.util.List[String]].asScala.toSeq
-    } catch {
-      case _: Throwable => Nil
-    }
-  }
+  private def tryReflect[T](label: String)(thunk: => T): Option[T] =
+    Try(thunk).fold(
+      err => {
+        println(s"Warning: could not resolve $label: $err")
+        None
+      },
+      v => Option(v)
+    )
+
+  private def reflectGet[T](obj: Any, getterName: String): Option[T] =
+    tryReflect(getterName)(obj.getClass.getMethod(getterName).invoke(obj).asInstanceOf[T])
+
+  private def kotlinOptions(task: Task): Seq[String] =
+    // getFreeCompilerArgs returns a Gradle ListProperty<String>, so we call .get() on it.
+    reflectGet[Any](task, "getCompilerOptions")
+      .flatMap(reflectGet[Any](_, "getFreeCompilerArgs"))
+      .flatMap(reflectGet[java.util.List[String]](_, "get"))
+      .fold(Nil)(_.asScala.toSeq)
 
   private case class ExtractedJvmData(
       configs: Seq[Configuration],
@@ -113,6 +119,17 @@ class BuildModelBuilder(ctx: GradleBuildCtx, objectFactory: ObjectFactory, works
       artifactName: Option[String],
       publishVersion: Option[String],
       pomSettings: Option[PomSettings]
+  )
+
+  private case class AndroidAppData(
+      namespace: Option[String],
+      applicationId: Option[String],
+      compileSdk: Option[Int],
+      minSdk: Option[Int],
+      targetSdk: Option[Int],
+      versionCode: Option[Int],
+      versionName: Option[String],
+      buildToolsVersion: Option[String]
   )
 
   private def extractJvmData(project0: Project, isKotlin: Boolean): ExtractedJvmData = {
@@ -438,26 +455,6 @@ class BuildModelBuilder(ctx: GradleBuildCtx, objectFactory: ObjectFactory, works
     PackageSpec(moduleDir.subRelativeTo(workspace), mainModule)
   }
 
-  private val AndroidApplicationPluginId = "com.android.application"
-
-  private def isAndroidAppProject(project: Project): Boolean =
-    project.getPluginManager.hasPlugin(AndroidApplicationPluginId)
-
-  private case class AndroidAppData(
-      namespace: Option[String],
-      applicationId: Option[String],
-      compileSdk: Option[Int],
-      minSdk: Option[Int],
-      targetSdk: Option[Int],
-      versionCode: Option[Int],
-      versionName: Option[String],
-      buildToolsVersion: Option[String]
-  )
-
-  private def reflectGet[T](obj: Any, getterName: String): Option[T] =
-    Try(obj.getClass.getMethod(getterName).invoke(obj)).toOption.flatMap(Option(_))
-      .map(_.asInstanceOf[T])
-
   /**
    * Reads the `android { ... }` extension via reflection rather than a compile-time AGP
    * dependency, since `exportplugin` must work against whatever AGP version the target
@@ -641,16 +638,9 @@ class BuildModelBuilder(ctx: GradleBuildCtx, objectFactory: ObjectFactory, works
   )
 
   private def providerValue[T](obj: Any, getterName: String): Option[T] =
-    Try {
-      val provider = obj.getClass.getMethod(getterName).invoke(obj).asInstanceOf[Provider[T]]
-      Option(provider.getOrNull())
-    }.fold(
-      (err: Throwable) => {
-        println(s"Warning: could not resolve Micronaut AOT $getterName: $err")
-        None
-      },
-      v => v
-    )
+    tryReflect(s"Micronaut AOT $getterName") {
+      obj.getClass.getMethod(getterName).invoke(obj).asInstanceOf[Provider[T]].getOrNull()
+    }
 
   private def detectMicronautAot(project: Project)
       : (Option[String], Option[String], Option[String], Option[Map[String, String]]) = {
@@ -709,14 +699,7 @@ class BuildModelBuilder(ctx: GradleBuildCtx, objectFactory: ObjectFactory, works
     val pluginOpt = Option(project.getPlugins.findPlugin(KotlinJvmPluginId))
       .orElse(Option(project.getPlugins.findPlugin(KotlinAndroidPluginId)))
       .orElse(Option(project.getPlugins.findPlugin("kotlin")))
-    val viaPluginVersion = pluginOpt.flatMap { plugin =>
-      try {
-        val method = plugin.getClass.getMethod("getPluginVersion")
-        Option(method.invoke(plugin)).map(_.toString)
-      } catch {
-        case _: Throwable => None
-      }
-    }
+    val viaPluginVersion = pluginOpt.flatMap(reflectGet[Any](_, "getPluginVersion")).map(_.toString)
     viaPluginVersion.orElse {
       configs.iterator
         .flatMap(_.getDependencies.asScala)
@@ -749,6 +732,11 @@ class BuildModelBuilder(ctx: GradleBuildCtx, objectFactory: ObjectFactory, works
       .map(_.getModuleVersion.getId.getVersion)
     pluginImplVersion.orElse(buildScriptVersion)
   }
+
+  private val AndroidApplicationPluginId = "com.android.application"
+
+  private def isAndroidAppProject(project: Project): Boolean =
+    project.getPluginManager.hasPlugin(AndroidApplicationPluginId)
 
   private def isBom(dep: Dependency | DependencyConstraint) = dep match {
     case dep: ModuleDependency =>

--- a/libs/init/gradle/src/mill/main/gradle/MillGradleBuildGenMain.scala
+++ b/libs/init/gradle/src/mill/main/gradle/MillGradleBuildGenMain.scala
@@ -39,7 +39,6 @@ object MillGradleBuildGenMain {
   ): Unit = {
     println("converting Gradle build")
 
-    val buildGen = if (declarative) BuildGenYaml else BuildGenScala
     val gradleWorkspace = os.Path.expandUser(projectDir, os.pwd)
     val millWorkspace = os.pwd
 
@@ -102,6 +101,15 @@ object MillGradleBuildGenMain {
         }
       finally gradleConnector.disconnect()
     packages = normalizeBuild(packages)
+
+    val hasAndroidModule = packages.exists(_.module.tree.exists(_.androidApplicationNamespace.base.isDefined))
+    if (declarative && hasAndroidModule) {
+      sys.error(
+        "Android modules are not yet supported with declarative (YAML) build files. " +
+          "Re-run with --declarative false."
+      )
+    }
+    val buildGen = if (declarative) BuildGenYaml else BuildGenScala
 
     val (baseModule, packages0) =
       if (noMeta.value) (None, packages)

--- a/libs/init/gradle/src/mill/main/gradle/MillGradleBuildGenMain.scala
+++ b/libs/init/gradle/src/mill/main/gradle/MillGradleBuildGenMain.scala
@@ -101,16 +101,9 @@ object MillGradleBuildGenMain {
         }
       finally gradleConnector.disconnect()
     packages = normalizeBuild(packages)
+    if (declarative) packages = dropAndroidModulesForYaml(packages)
     packages = attachAndroidSdkModule(packages)
 
-    val hasAndroidModule =
-      packages.exists(_.module.tree.exists(_.androidApplicationNamespace.base.isDefined))
-    if (declarative && hasAndroidModule) {
-      sys.error(
-        "Android modules are not yet supported with declarative (YAML) build files. " +
-          "Re-run with --declarative false."
-      )
-    }
     val buildGen = if (declarative) BuildGenYaml else BuildGenScala
 
     val (baseModule, packages0) =
@@ -173,6 +166,25 @@ object MillGradleBuildGenMain {
         module0
       })
     )
+  }
+
+  /** Android modules aren't supported in declarative (YAML) output yet, so just drop them instead of failing */
+  private def dropAndroidModulesForYaml(packages: Seq[PackageSpec]): Seq[PackageSpec] = {
+    def isAndroidModule(m: ModuleSpec) =
+      m.androidApplicationNamespace.base.isDefined || m.androidNamespace.base.isDefined
+
+    val rootDir = packages.map(_.dir).minBy(_.segments.length)
+    packages.flatMap { pkg =>
+      if (!isAndroidModule(pkg.module)) Some(pkg)
+      else {
+        println(
+          s"Skipping Android module '${pkg.module.name}' for declarative (YAML) output - " +
+            "not supported yet. Re-run with --declarative false to include it."
+        )
+        if (pkg.dir == rootDir) Some(pkg.copy(module = ModuleSpec(name = pkg.module.name)))
+        else None
+      }
+    }
   }
 
   /** Gives all Android modules one shared `androidSdkModule0` on the root package, instead of each declaring its own. */

--- a/libs/init/gradle/src/mill/main/gradle/MillGradleBuildGenMain.scala
+++ b/libs/init/gradle/src/mill/main/gradle/MillGradleBuildGenMain.scala
@@ -1,7 +1,7 @@
 package mill.main.gradle
 
 import mill.main.buildgen.*
-import mill.main.buildgen.ModuleSpec.ModuleDep
+import mill.main.buildgen.ModuleSpec.{ModuleDep, Value}
 import mill.main.gradle.BuildInfo.exportpluginAssemblyResource
 import mill.util.Jvm
 import org.gradle.tooling.GradleConnector
@@ -101,6 +101,7 @@ object MillGradleBuildGenMain {
         }
       finally gradleConnector.disconnect()
     packages = normalizeBuild(packages)
+    packages = attachAndroidSdkModule(packages)
 
     val hasAndroidModule = packages.exists(_.module.tree.exists(_.androidApplicationNamespace.base.isDefined))
     if (declarative && hasAndroidModule) {
@@ -171,5 +172,37 @@ object MillGradleBuildGenMain {
         module0
       })
     )
+  }
+
+  /** Gives all Android modules one shared `androidSdkModule0` on the root package, instead of each declaring its own. */
+  private def attachAndroidSdkModule(packages: Seq[PackageSpec]): Seq[PackageSpec] = {
+    val androidModules = packages.flatMap(_.module.tree).filter(_.androidBuildToolsVersion.base.isDefined)
+    if (androidModules.isEmpty) packages
+    else {
+      val sdkModuleName = "androidSdkModule0"
+      val sdkModule = ModuleSpec(
+        name = sdkModuleName,
+        imports = Seq("mill.androidlib.*"),
+        supertypes = Seq("AndroidSdkModule"),
+        androidBuildToolsVersion = androidModules.head.androidBuildToolsVersion
+      )
+      val rootDir = packages.map(_.dir).minBy(_.segments.length)
+      packages.map { pkg =>
+        // Rewire the original tree first - only then attach sdkModule as a new child, so
+        // recMap below never re-visits (and strips) the sdk module's own marker field.
+        val rewired = pkg.module.recMap { m =>
+          if (m.androidBuildToolsVersion.base.isEmpty) m
+          else m.copy(
+            androidBuildToolsVersion = Value(),
+            androidSdkModuleDep =
+              Value(Some(ModuleDep(segments = rootDir.segments, childSegment = Some(sdkModuleName))))
+          )
+        }
+        pkg.copy(module =
+          if (pkg.dir == rootDir) rewired.copy(children = rewired.children :+ sdkModule)
+          else rewired
+        )
+      }
+    }
   }
 }

--- a/libs/init/gradle/src/mill/main/gradle/MillGradleBuildGenMain.scala
+++ b/libs/init/gradle/src/mill/main/gradle/MillGradleBuildGenMain.scala
@@ -103,7 +103,8 @@ object MillGradleBuildGenMain {
     packages = normalizeBuild(packages)
     packages = attachAndroidSdkModule(packages)
 
-    val hasAndroidModule = packages.exists(_.module.tree.exists(_.androidApplicationNamespace.base.isDefined))
+    val hasAndroidModule =
+      packages.exists(_.module.tree.exists(_.androidApplicationNamespace.base.isDefined))
     if (declarative && hasAndroidModule) {
       sys.error(
         "Android modules are not yet supported with declarative (YAML) build files. " +
@@ -176,7 +177,8 @@ object MillGradleBuildGenMain {
 
   /** Gives all Android modules one shared `androidSdkModule0` on the root package, instead of each declaring its own. */
   private def attachAndroidSdkModule(packages: Seq[PackageSpec]): Seq[PackageSpec] = {
-    val androidModules = packages.flatMap(_.module.tree).filter(_.androidBuildToolsVersion.base.isDefined)
+    val androidModules =
+      packages.flatMap(_.module.tree).filter(_.androidBuildToolsVersion.base.isDefined)
     if (androidModules.isEmpty) packages
     else {
       val sdkModuleName = "androidSdkModule0"
@@ -195,7 +197,10 @@ object MillGradleBuildGenMain {
           else m.copy(
             androidBuildToolsVersion = Value(),
             androidSdkModuleDep =
-              Value(Some(ModuleDep(segments = rootDir.segments, childSegment = Some(sdkModuleName))))
+              Value(Some(ModuleDep(
+                segments = rootDir.segments,
+                childSegment = Some(sdkModuleName)
+              )))
           )
         }
         pkg.copy(module =

--- a/libs/init/gradle/test/resources/android-hello-kotlin-gradle8/app/build.gradle.kts
+++ b/libs/init/gradle/test/resources/android-hello-kotlin-gradle8/app/build.gradle.kts
@@ -1,0 +1,32 @@
+plugins {
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
+}
+
+android {
+    namespace = "com.helloworld.gradle8"
+    compileSdk = 34
+    // Pinned explicitly: AGP 8.7.3's own default (34.0.0) ships an aapt2 binary 
+    // that fails parsing multi-entry "-R @argfile" resource lists, fixed in later build-tools releases.
+    buildToolsVersion = "36.0.0"
+
+    defaultConfig {
+        applicationId = "com.helloworld.gradle8"
+        minSdk = 21
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+    kotlinOptions {
+        jvmTarget = "11"
+    }
+}
+
+dependencies {
+    testImplementation(libs.junit)
+}

--- a/libs/init/gradle/test/resources/android-hello-kotlin-gradle8/app/src/main/AndroidManifest.xml
+++ b/libs/init/gradle/test/resources/android-hello-kotlin-gradle8/app/src/main/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application android:label="@string/app_name" android:theme="@android:style/Theme.Light.NoTitleBar">
+        <activity android:name=".MainActivity"
+                android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/libs/init/gradle/test/resources/android-hello-kotlin-gradle8/app/src/main/kotlin/com/helloworld/gradle8/MainActivity.kt
+++ b/libs/init/gradle/test/resources/android-hello-kotlin-gradle8/app/src/main/kotlin/com/helloworld/gradle8/MainActivity.kt
@@ -1,0 +1,22 @@
+package com.helloworld.gradle8
+
+import android.app.Activity
+import android.os.Bundle
+import android.view.Gravity
+import android.view.ViewGroup.LayoutParams
+import android.widget.TextView
+
+class MainActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val textView = TextView(this)
+        textView.text = getString(R.string.app_name)
+        textView.textSize = SampleLogic.textSize()
+        textView.gravity = Gravity.CENTER
+        textView.layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
+        textView.setTextColor(getColor(R.color.text_green))
+        textView.setBackgroundColor(getColor(R.color.white))
+        setContentView(textView)
+    }
+}

--- a/libs/init/gradle/test/resources/android-hello-kotlin-gradle8/app/src/main/kotlin/com/helloworld/gradle8/SampleLogic.kt
+++ b/libs/init/gradle/test/resources/android-hello-kotlin-gradle8/app/src/main/kotlin/com/helloworld/gradle8/SampleLogic.kt
@@ -1,0 +1,5 @@
+package com.helloworld.gradle8
+
+object SampleLogic {
+    fun textSize(): Float = 32f
+}

--- a/libs/init/gradle/test/resources/android-hello-kotlin-gradle8/app/src/main/res/values/colors.xml
+++ b/libs/init/gradle/test/resources/android-hello-kotlin-gradle8/app/src/main/res/values/colors.xml
@@ -1,0 +1,4 @@
+<resources>
+    <color name="text_green">#FF00FF00</color>
+    <color name="white">#FFFFFFFF</color>
+</resources>

--- a/libs/init/gradle/test/resources/android-hello-kotlin-gradle8/app/src/main/res/values/strings.xml
+++ b/libs/init/gradle/test/resources/android-hello-kotlin-gradle8/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Hello Gradle 8</string>
+</resources>

--- a/libs/init/gradle/test/resources/android-hello-kotlin-gradle8/app/src/test/kotlin/com/helloworld/gradle8/SampleLogicTest.kt
+++ b/libs/init/gradle/test/resources/android-hello-kotlin-gradle8/app/src/test/kotlin/com/helloworld/gradle8/SampleLogicTest.kt
@@ -1,0 +1,11 @@
+package com.helloworld.gradle8
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class SampleLogicTest {
+    @Test
+    fun text_size_is_correct() {
+        assertEquals(32f, SampleLogic.textSize())
+    }
+}

--- a/libs/init/gradle/test/resources/android-hello-kotlin-gradle8/build.gradle.kts
+++ b/libs/init/gradle/test/resources/android-hello-kotlin-gradle8/build.gradle.kts
@@ -1,0 +1,5 @@
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
+plugins {
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.kotlin.android) apply false
+}

--- a/libs/init/gradle/test/resources/android-hello-kotlin-gradle8/gradle.properties
+++ b/libs/init/gradle/test/resources/android-hello-kotlin-gradle8/gradle.properties
@@ -1,0 +1,11 @@
+# Project-wide Gradle settings.
+# IDE (e.g. Android Studio) users:
+# Gradle settings configured through the IDE *will override*
+# any settings specified in this file.
+# For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+# Kotlin code style for this project: "official" or "obsolete":
+kotlin.code.style=official

--- a/libs/init/gradle/test/resources/android-hello-kotlin-gradle8/gradle/libs.versions.toml
+++ b/libs/init/gradle/test/resources/android-hello-kotlin-gradle8/gradle/libs.versions.toml
@@ -1,0 +1,11 @@
+[versions]
+agp = "8.7.3"
+kotlin = "2.0.20"
+junit = "4.13.2"
+
+[libraries]
+junit = { group = "junit", name = "junit", version.ref = "junit" }
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "agp" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }

--- a/libs/init/gradle/test/resources/android-hello-kotlin-gradle8/gradle/wrapper/gradle-wrapper.properties
+++ b/libs/init/gradle/test/resources/android-hello-kotlin-gradle8/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,6 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+networkTimeout=10000
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/libs/init/gradle/test/resources/android-hello-kotlin-gradle8/settings.gradle.kts
+++ b/libs/init/gradle/test/resources/android-hello-kotlin-gradle8/settings.gradle.kts
@@ -1,0 +1,26 @@
+pluginManagement {
+    repositories {
+        google {
+            content {
+                includeGroupByRegex("com\\.android.*")
+                includeGroupByRegex("com\\.google.*")
+                includeGroupByRegex("androidx.*")
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "android-hello-kotlin-gradle8"
+include(":app")

--- a/libs/init/gradle/test/resources/android-hello-kotlin/app/build.gradle.kts
+++ b/libs/init/gradle/test/resources/android-hello-kotlin/app/build.gradle.kts
@@ -1,0 +1,52 @@
+plugins {
+    alias(libs.plugins.android.application)
+}
+
+android {
+    namespace = "com.helloworld.app"
+    compileSdk {
+        version = release(35)
+    }
+
+    defaultConfig {
+        applicationId = "com.helloworld.app"
+        minSdk = 19
+        targetSdk = 35
+        versionCode = 1
+        versionName = "1.0"
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    signingConfigs {
+        create("release") {
+            storeFile = file("releaseKey.jks")
+            storePassword = "MillBuildTool"
+            keyAlias = "releaseKey"
+            keyPassword = "MillBuildTool"
+        }
+    }
+
+    buildTypes {
+        release {
+            optimization {
+                enable = false
+            }
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+            signingConfig = signingConfigs.getByName("release")
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+}
+
+dependencies {
+    testImplementation(libs.junit)
+    androidTestImplementation(libs.androidx.test.ext.junit)
+    androidTestImplementation(libs.androidx.test.runner)
+    androidTestImplementation(libs.androidx.espresso.core)
+    androidTestImplementation(libs.junit)
+}

--- a/libs/init/gradle/test/resources/android-hello-kotlin/app/src/androidTest/java/com/helloworld/app/ExampleInstrumentedTest.kt
+++ b/libs/init/gradle/test/resources/android-hello-kotlin/app/src/androidTest/java/com/helloworld/app/ExampleInstrumentedTest.kt
@@ -1,0 +1,22 @@
+package com.helloworld.app
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Instrumented test, which will execute on an Android device.
+ *
+ * See [testing documentation](http://d.android.com/tools/testing).
+ */
+@RunWith(AndroidJUnit4::class)
+class ExampleInstrumentedTest {
+    @Test
+    fun useAppContext() {
+        // Context of the app under test.
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        assertEquals("com.helloworld.app", appContext.packageName)
+    }
+}

--- a/libs/init/gradle/test/resources/android-hello-kotlin/app/src/androidTest/java/com/helloworld/app/SampleLogicInKotlinDirInstrumentedTest.kt
+++ b/libs/init/gradle/test/resources/android-hello-kotlin/app/src/androidTest/java/com/helloworld/app/SampleLogicInKotlinDirInstrumentedTest.kt
@@ -1,0 +1,15 @@
+package com.helloworld.logictest
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.helloworld.SampleLogicInKotlinDir
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SampleLogicInKotlinDirInstrumentedTest {
+    @Test
+    fun kotlin_dir_text_size_is_correct() {
+        assertEquals(64f, SampleLogicInKotlinDir.textSize(), 0.00001f)
+    }
+}

--- a/libs/init/gradle/test/resources/android-hello-kotlin/app/src/androidTest/java/com/helloworld/app/SampleLogicInstrumentedTest.kt
+++ b/libs/init/gradle/test/resources/android-hello-kotlin/app/src/androidTest/java/com/helloworld/app/SampleLogicInstrumentedTest.kt
@@ -1,0 +1,15 @@
+package com.helloworld.logictest
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.helloworld.SampleLogic
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SampleLogicInstrumentedTest {
+    @Test
+    fun text_size_is_correct() {
+        assertEquals(32f, SampleLogic.textSize(), 0.0001f)
+    }
+}

--- a/libs/init/gradle/test/resources/android-hello-kotlin/app/src/main/AndroidManifest.xml
+++ b/libs/init/gradle/test/resources/android-hello-kotlin/app/src/main/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0">
+    <application android:label="@string/app_name" android:theme="@android:style/Theme.Light.NoTitleBar">
+        <activity android:name=".MainActivity"
+                android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/libs/init/gradle/test/resources/android-hello-kotlin/app/src/main/java/com/helloworld/SampleLogic.kt
+++ b/libs/init/gradle/test/resources/android-hello-kotlin/app/src/main/java/com/helloworld/SampleLogic.kt
@@ -1,0 +1,5 @@
+package com.helloworld
+
+object SampleLogic {
+    fun textSize(): Float = 32f
+}

--- a/libs/init/gradle/test/resources/android-hello-kotlin/app/src/main/java/com/helloworld/app/MainActivity.kt
+++ b/libs/init/gradle/test/resources/android-hello-kotlin/app/src/main/java/com/helloworld/app/MainActivity.kt
@@ -1,0 +1,38 @@
+package com.helloworld.app
+
+import android.app.Activity
+import android.os.Bundle
+import android.view.Gravity
+import android.view.ViewGroup.LayoutParams
+import android.widget.TextView
+import com.helloworld.SampleLogic
+
+class MainActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // Create a new TextView
+        val textView = TextView(this)
+
+        // Set the text to the string resource
+        textView.text = getString(R.string.hello_world)
+
+        // Set text size
+        textView.textSize = SampleLogic.textSize()
+
+        // Center the text within the view
+        textView.gravity = Gravity.CENTER
+
+        // Set layout parameters (width and height)
+        textView.layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
+
+        // Set the text color using a resource
+        textView.setTextColor(getColor(R.color.text_green))
+
+        // Set the background color using a resource
+        textView.setBackgroundColor(getColor(R.color.white))
+
+        // Set the content view to display the TextView
+        setContentView(textView)
+    }
+}

--- a/libs/init/gradle/test/resources/android-hello-kotlin/app/src/main/kotlin/com/helloworld/SampleLogicInKotlinDir.kt
+++ b/libs/init/gradle/test/resources/android-hello-kotlin/app/src/main/kotlin/com/helloworld/SampleLogicInKotlinDir.kt
@@ -1,0 +1,5 @@
+package com.helloworld
+
+object SampleLogicInKotlinDir {
+    fun textSize(): Float = 64f
+}

--- a/libs/init/gradle/test/resources/android-hello-kotlin/app/src/main/res/values/colors.xml
+++ b/libs/init/gradle/test/resources/android-hello-kotlin/app/src/main/res/values/colors.xml
@@ -1,0 +1,4 @@
+<resources>
+    <color name="white">#FFFFFF</color>
+    <color name="text_green">#34A853</color>
+</resources>

--- a/libs/init/gradle/test/resources/android-hello-kotlin/app/src/main/res/values/strings.xml
+++ b/libs/init/gradle/test/resources/android-hello-kotlin/app/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+    <string name="app_name">HelloWorldApp</string>
+    <string name="hello_world">Hello, World Kotlin!</string>
+</resources>

--- a/libs/init/gradle/test/resources/android-hello-kotlin/app/src/test/java/com/helloworld/ExampleUnitTest.kt
+++ b/libs/init/gradle/test/resources/android-hello-kotlin/app/src/test/java/com/helloworld/ExampleUnitTest.kt
@@ -1,0 +1,16 @@
+package com.helloworld
+
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * Example local unit test, which will execute on the development machine (host).
+ *
+ * See [testing documentation](http://d.android.com/tools/testing).
+ */
+class ExampleUnitTest {
+    @Test
+    fun text_size_is_correct() {
+        assertEquals(32f, SampleLogic.textSize())
+    }
+}

--- a/libs/init/gradle/test/resources/android-hello-kotlin/app/src/test/kotlin/com/helloworld/ExampleUnitTestInKotlinDir.kt
+++ b/libs/init/gradle/test/resources/android-hello-kotlin/app/src/test/kotlin/com/helloworld/ExampleUnitTestInKotlinDir.kt
@@ -1,0 +1,17 @@
+package com.helloworld
+
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * Example local unit test, which will execute on the development machine (host).
+ *
+ * See [testing documentation](http://d.android.com/tools/testing).
+ */
+class ExampleUnitTestInKotlinDir {
+
+    @Test
+    fun kotlin_dir_text_size_is_correct() {
+        assertEquals(64f, SampleLogicInKotlinDir.textSize())
+    }
+}

--- a/libs/init/gradle/test/resources/android-hello-kotlin/build.gradle.kts
+++ b/libs/init/gradle/test/resources/android-hello-kotlin/build.gradle.kts
@@ -1,0 +1,5 @@
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
+plugins {
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.kotlin.android) apply false
+}

--- a/libs/init/gradle/test/resources/android-hello-kotlin/gradle.properties
+++ b/libs/init/gradle/test/resources/android-hello-kotlin/gradle.properties
@@ -1,0 +1,19 @@
+# Project-wide Gradle settings.
+# IDE (e.g. Android Studio) users:
+# Gradle settings configured through the IDE *will override*
+# any settings specified in this file.
+# For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. For more details, visit
+# https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects
+# org.gradle.parallel=true
+# When enabled, the Configuration Cache allows Gradle to skip the configuration
+# phase entirely if nothing that affects the build configuration (such as build scripts)
+# has changed. Additionally, Gradle applies performance optimizations to task execution.
+org.gradle.configuration-cache=true
+# Kotlin code style for this project: "official" or "obsolete":
+kotlin.code.style=official

--- a/libs/init/gradle/test/resources/android-hello-kotlin/gradle/libs.versions.toml
+++ b/libs/init/gradle/test/resources/android-hello-kotlin/gradle/libs.versions.toml
@@ -1,0 +1,17 @@
+[versions]
+agp = "9.3.1"
+kotlin = "2.0.20"
+junit = "4.13.2"
+androidxTestExtJunit = "1.2.1"
+androidxTestRunner = "1.6.2"
+espressoCore = "3.5.1"
+
+[libraries]
+junit = { group = "junit", name = "junit", version.ref = "junit" }
+androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxTestExtJunit" }
+androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidxTestRunner" }
+androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "agp" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }

--- a/libs/init/gradle/test/resources/android-hello-kotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/libs/init/gradle/test/resources/android-hello-kotlin/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,9 @@
+#Wed Aug 12 14:27:44 EEST 2026
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionSha256Sum=553c78f50dafcd54d65b9a444649057857469edf836431389695608536d6b746
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/libs/init/gradle/test/resources/android-hello-kotlin/settings.gradle.kts
+++ b/libs/init/gradle/test/resources/android-hello-kotlin/settings.gradle.kts
@@ -1,0 +1,26 @@
+pluginManagement {
+    repositories {
+        google {
+            content {
+                includeGroupByRegex("com\\.android.*")
+                includeGroupByRegex("com\\.google.*")
+                includeGroupByRegex("androidx.*")
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "android-hello-kotlin"
+include(":app")

--- a/libs/init/gradle/test/resources/expected-scala/android-hello-kotlin-gradle8/app/package.mill
+++ b/libs/init/gradle/test/resources/expected-scala/android-hello-kotlin-gradle8/app/package.mill
@@ -22,13 +22,7 @@ object `package` extends AndroidAppKotlinModule {
 
   def androidVersionName = "1.0"
 
-  def androidSdkModule = mill.api.ModuleRef(androidSdkModule0)
-
-  object androidSdkModule0 extends AndroidSdkModule {
-
-    def buildToolsVersion = "36.0.0"
-
-  }
+  def androidSdkModule = mill.api.ModuleRef(build.androidSdkModule0)
 
   object test extends AndroidAppKotlinTests, TestModule.Junit4 {
 

--- a/libs/init/gradle/test/resources/expected-scala/android-hello-kotlin-gradle8/app/package.mill
+++ b/libs/init/gradle/test/resources/expected-scala/android-hello-kotlin-gradle8/app/package.mill
@@ -1,0 +1,43 @@
+package build.app
+
+import mill.*
+import mill.androidlib.*
+import mill.kotlinlib.*
+
+object `package` extends AndroidAppKotlinModule {
+
+  def kotlinVersion = "2.0.20"
+
+  def androidApplicationNamespace = "com.helloworld.gradle8"
+
+  def androidApplicationId = "com.helloworld.gradle8"
+
+  def androidCompileSdk = 34
+
+  def androidMinSdk = 21
+
+  def androidTargetSdk = 34
+
+  def androidVersionCode = 1
+
+  def androidVersionName = "1.0"
+
+  def androidSdkModule = mill.api.ModuleRef(androidSdkModule0)
+
+  object androidSdkModule0 extends AndroidSdkModule {
+
+    def buildToolsVersion = "36.0.0"
+
+  }
+
+  object test extends AndroidAppKotlinTests, TestModule.Junit4 {
+
+    def mvnDeps = Seq(mvn"junit:junit:4.13.2")
+
+    def testParallelism = false
+
+    def testSandboxWorkingDir = false
+
+  }
+
+}

--- a/libs/init/gradle/test/resources/expected-scala/android-hello-kotlin-gradle8/build.mill
+++ b/libs/init/gradle/test/resources/expected-scala/android-hello-kotlin-gradle8/build.mill
@@ -1,0 +1,7 @@
+//| mill-version: SNAPSHOT
+//| mill-jvm-version: system
+package build
+
+import mill.*
+
+object `package` extends Module {}

--- a/libs/init/gradle/test/resources/expected-scala/android-hello-kotlin-gradle8/build.mill
+++ b/libs/init/gradle/test/resources/expected-scala/android-hello-kotlin-gradle8/build.mill
@@ -3,5 +3,14 @@
 package build
 
 import mill.*
+import mill.androidlib.*
 
-object `package` extends Module {}
+object `package` extends Module {
+
+  object androidSdkModule0 extends AndroidSdkModule {
+
+    def buildToolsVersion = "36.0.0"
+
+  }
+
+}

--- a/libs/init/gradle/test/resources/expected-scala/android-hello-kotlin/app/package.mill
+++ b/libs/init/gradle/test/resources/expected-scala/android-hello-kotlin/app/package.mill
@@ -26,7 +26,7 @@ object `package` extends AndroidAppKotlinModule {
 
   def androidSdkModule = mill.api.ModuleRef(build.androidSdkModule0)
 
-  object it extends AndroidAppKotlinInstrumentedTests {
+  object androidTest extends AndroidAppKotlinInstrumentedTests {
 
     def mvnDeps = Seq(
       mvn"androidx.test.ext:junit:1.2.1",

--- a/libs/init/gradle/test/resources/expected-scala/android-hello-kotlin/app/package.mill
+++ b/libs/init/gradle/test/resources/expected-scala/android-hello-kotlin/app/package.mill
@@ -1,0 +1,56 @@
+package build.app
+
+import mill.*
+import mill.androidlib.*
+import mill.kotlinlib.*
+
+object `package` extends AndroidAppKotlinModule {
+
+  def mvnDeps = Seq(mvn"org.jetbrains.kotlin:kotlin-stdlib:2.2.10")
+
+  def kotlinVersion = "2.2.10"
+
+  def androidApplicationNamespace = "com.helloworld.app"
+
+  def androidApplicationId = "com.helloworld.app"
+
+  def androidCompileSdk = 35
+
+  def androidMinSdk = 19
+
+  def androidTargetSdk = 35
+
+  def androidVersionCode = 1
+
+  def androidVersionName = "1.0"
+
+  def androidSdkModule = mill.api.ModuleRef(androidSdkModule0)
+
+  object androidSdkModule0 extends AndroidSdkModule {
+
+    def buildToolsVersion = "36.0.0"
+
+  }
+
+  object it extends AndroidAppKotlinInstrumentedTests {
+
+    def mvnDeps = Seq(
+      mvn"androidx.test.ext:junit:1.2.1",
+      mvn"androidx.test:runner:1.6.2",
+      mvn"androidx.test.espresso:espresso-core:3.5.1",
+      mvn"junit:junit:4.13.2"
+    )
+
+  }
+
+  object test extends AndroidAppKotlinTests, TestModule.Junit4 {
+
+    def mvnDeps = Seq(mvn"junit:junit:4.13.2")
+
+    def testParallelism = false
+
+    def testSandboxWorkingDir = false
+
+  }
+
+}

--- a/libs/init/gradle/test/resources/expected-scala/android-hello-kotlin/app/package.mill
+++ b/libs/init/gradle/test/resources/expected-scala/android-hello-kotlin/app/package.mill
@@ -24,13 +24,7 @@ object `package` extends AndroidAppKotlinModule {
 
   def androidVersionName = "1.0"
 
-  def androidSdkModule = mill.api.ModuleRef(androidSdkModule0)
-
-  object androidSdkModule0 extends AndroidSdkModule {
-
-    def buildToolsVersion = "36.0.0"
-
-  }
+  def androidSdkModule = mill.api.ModuleRef(build.androidSdkModule0)
 
   object it extends AndroidAppKotlinInstrumentedTests {
 

--- a/libs/init/gradle/test/resources/expected-scala/android-hello-kotlin/build.mill
+++ b/libs/init/gradle/test/resources/expected-scala/android-hello-kotlin/build.mill
@@ -1,0 +1,7 @@
+//| mill-version: SNAPSHOT
+//| mill-jvm-version: system
+package build
+
+import mill.*
+
+object `package` extends Module {}

--- a/libs/init/gradle/test/resources/expected-scala/android-hello-kotlin/build.mill
+++ b/libs/init/gradle/test/resources/expected-scala/android-hello-kotlin/build.mill
@@ -3,5 +3,14 @@
 package build
 
 import mill.*
+import mill.androidlib.*
 
-object `package` extends Module {}
+object `package` extends Module {
+
+  object androidSdkModule0 extends AndroidSdkModule {
+
+    def buildToolsVersion = "36.0.0"
+
+  }
+
+}

--- a/libs/init/gradle/test/resources/expected/android-hello-kotlin-gradle8/build.mill.yaml
+++ b/libs/init/gradle/test/resources/expected/android-hello-kotlin-gradle8/build.mill.yaml
@@ -1,0 +1,2 @@
+mill-version: SNAPSHOT
+mill-jvm-version: system

--- a/libs/init/gradle/test/resources/expected/android-hello-kotlin/build.mill.yaml
+++ b/libs/init/gradle/test/resources/expected/android-hello-kotlin/build.mill.yaml
@@ -1,0 +1,2 @@
+mill-version: SNAPSHOT
+mill-jvm-version: system

--- a/libs/init/gradle/test/src/mill/main/gradle/GradleBuildGenTests.scala
+++ b/libs/init/gradle/test/src/mill/main/gradle/GradleBuildGenTests.scala
@@ -75,11 +75,6 @@ trait GradleBuildGenTests extends TestSuite {
         initArgs = Seq("--gradle-jvm-id", "25", "--mill-jvm-id", "25") ++ extraArgs
       ))
     }
-  }
-
-  // Android modules aren't supported with declarative (YAML) build files (yet)
-  def nonDeclarativeTests = Tests {
-    val checker = BuildGenChecker()
     test("android-hello-kotlin") {
       assert(checker.check(
         sourceRel = "android-hello-kotlin",
@@ -105,5 +100,4 @@ object GradleBuildGenYamlTests extends GradleBuildGenTests {
 object GradleBuildGenScalaTests extends GradleBuildGenTests {
   def expectedDir: os.SubPath = "expected-scala"
   override def extraArgs = Seq("--declarative", "false")
-  override def tests = super.tests ++ nonDeclarativeTests
 }

--- a/libs/init/gradle/test/src/mill/main/gradle/GradleBuildGenTests.scala
+++ b/libs/init/gradle/test/src/mill/main/gradle/GradleBuildGenTests.scala
@@ -76,6 +76,25 @@ trait GradleBuildGenTests extends TestSuite {
       ))
     }
   }
+
+  // Android modules aren't supported with declarative (YAML) build files (yet)
+  def nonDeclarativeTests = Tests {
+    val checker = BuildGenChecker()
+    test("android-hello-kotlin") {
+      assert(checker.check(
+        sourceRel = "android-hello-kotlin",
+        expectedRel = os.sub / expectedDir / "android-hello-kotlin",
+        initArgs = Seq("--gradle-jvm-id", "21") ++ extraArgs
+      ))
+    }
+    test("android-hello-kotlin-gradle8") {
+      assert(checker.check(
+        sourceRel = "android-hello-kotlin-gradle8",
+        expectedRel = os.sub / expectedDir / "android-hello-kotlin-gradle8",
+        initArgs = Seq("--gradle-jvm-id", "21") ++ extraArgs
+      ))
+    }
+  }
 }
 
 object GradleBuildGenYamlTests extends GradleBuildGenTests {
@@ -86,4 +105,5 @@ object GradleBuildGenYamlTests extends GradleBuildGenTests {
 object GradleBuildGenScalaTests extends GradleBuildGenTests {
   def expectedDir: os.SubPath = "expected-scala"
   override def extraArgs = Seq("--declarative", "false")
+  override def tests = super.tests ++ nonDeclarativeTests
 }


### PR DESCRIPTION
Part of #7366 
This PR adds the initial  support for Android projects. The included examples are single-module Android Applications

### Additions 
Previous refactor PR came in handy for these new additions to be cleanly added.
- Extracts `android {}` config via reflection. Stores to the new `AndroidAppData` case class.
- Applies `AndroidKotlinModule` or `AndroidAppKotlinModule`
- Emits one shared `androidSdkModule0` at the build root (to avoid having each module declare one)
- Fixes a preexisting bug  where the repositories check had a non-read side-effect.

### An issue - YAML builds
No support for Declarative builds yet, See https://github.com/com-lihaoyi/mill/issues/7366#issuecomment-5355440260
The logic here, just ignores android modules when `declarative=true`

### Future work
- Apply `androidLibModule` when publishing information is available
- Multi-Module examples
- Compose, hilt, data/view binding, proguard/R8 config
- Signing configuration tasks? (didn't add these for now)
- YAML support