### PR TITLE
BuildInfo: Use root-imports to prevent import of colliding sub-packages (backport #7445)

### DIFF
--- a/contrib/buildinfo/src/mill/contrib/buildinfo/BuildInfo.scala
+++ b/contrib/buildinfo/src/mill/contrib/buildinfo/BuildInfo.scala
@@ -211,7 +211,7 @@ object BuildInfo {
            |package ${buildInfoPackageName}
            |
            |object $buildInfoObjectName {
-           |  private val buildInfoProperties: java.util.Properties = new java.util.Properties()
+           |  private val buildInfoProperties: _root_.java.util.Properties = new _root_.java.util.Properties()
            |
            |  {
            |    val buildInfoInputStream = getClass

--- a/contrib/buildinfo/test/resources/buildinfo/scala/src/Collide.scala
+++ b/contrib/buildinfo/test/resources/buildinfo/scala/src/Collide.scala
@@ -1,0 +1,6 @@
+// A `java` sub-package may break scalac import mechanism for `java.util.Properties`
+package foo.java
+
+import java.nio.file.{Files, Paths}
+
+object Collide {}

--- a/contrib/buildinfo/test/resources/buildinfo/scala/src/Main.scala
+++ b/contrib/buildinfo/test/resources/buildinfo/scala/src/Main.scala
@@ -1,5 +1,6 @@
 package foo
-import java.nio.file.{Files, Paths}
+
+import _root_.java.nio.file.{Files, Paths}
 
 object Main extends App {
 

--- a/contrib/buildinfo/test/src/mill/contrib/buildinfo/BuildInfoTests.scala
+++ b/contrib/buildinfo/test/src/mill/contrib/buildinfo/BuildInfoTests.scala
@@ -25,7 +25,7 @@ object BuildInfoTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
-  object BuildInfoPlain extends TestRootModule with BuildInfo with ScalaModule {
+  object BuildInfoScala extends TestRootModule with BuildInfo with ScalaModule {
     def scalaVersion = scalaVersionString
     def buildInfoPackageName = "foo"
     def buildInfoMembers = Seq(
@@ -195,15 +195,15 @@ object BuildInfoTests extends TestSuite {
       assert(found.contains("object bar"))
     }
 
-    test("compile") - UnitTester(BuildInfoPlain, testModuleSourcesPath / "scala").scoped { eval =>
-      val Right(_) = eval.apply(BuildInfoPlain.compile).runtimeChecked
+    test("compile") - UnitTester(BuildInfoScala, testModuleSourcesPath / "scala").scoped { eval =>
+      val Right(_) = eval.apply(BuildInfoScala.compile).runtimeChecked
       assert(true)
     }
 
-    test("run") - UnitTester(BuildInfoPlain, testModuleSourcesPath / "scala").scoped { eval =>
+    test("run") - UnitTester(BuildInfoScala, testModuleSourcesPath / "scala").scoped { eval =>
       val runResult = eval.outPath / "hello-mill"
       val Right(_) =
-        eval.apply(BuildInfoPlain.run(Task.Anon(Args(runResult.toString)))).runtimeChecked
+        eval.apply(BuildInfoScala.run(Task.Anon(Args(runResult.toString)))).runtimeChecked
 
       assert(
         os.exists(runResult),
@@ -287,11 +287,11 @@ object BuildInfoTests extends TestSuite {
     }
 
     test("generatedSources must be a folder") - UnitTester(
-      BuildInfoPlain,
+      BuildInfoScala,
       testModuleSourcesPath / "scala"
     ).scoped { eval =>
       val buildInfoGeneratedSourcesFolder = eval.outPath / "buildInfoSources.dest"
-      val Right(result) = eval.apply(BuildInfoPlain.generatedSources).runtimeChecked
+      val Right(result) = eval.apply(BuildInfoScala.generatedSources).runtimeChecked
       assert(
         result.value.size == 1,
         os.isDir(result.value.head.path),


### PR DESCRIPTION
Fix https://github.com/com-lihaoyi/mill/issues/7444

Add a reproduction test case by adding a colliding sub-package to the
test which surfaces the issue.

Backport of pull request: https://github.com/com-lihaoyi/mill/pull/7445
