### PR TITLE
Rescue undiscovered but explicitly specified test classes

### DIFF
--- a/integration/feature/test-do-not-discover/resources/build.mill
+++ b/integration/feature/test-do-not-discover/resources/build.mill
@@ -1,0 +1,14 @@
+package build
+
+// Reproduction of issue https://github.com/com-lihaoyi/mill/issues/7450
+
+import mill.*
+import mill.scalalib.*
+
+object foo extends ScalaModule {
+  def scalaVersion = "3.8.2"
+
+  object test extends ScalaTests with TestModule.ScalaTest {
+    def mvnDeps = Seq(mvn"org.scalatest::scalatest:3.2.19")
+  }
+}

--- a/integration/feature/test-do-not-discover/resources/foo/test/src/NormalSuite.scala
+++ b/integration/feature/test-do-not-discover/resources/foo/test/src/NormalSuite.scala
@@ -1,0 +1,9 @@
+package foo
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class NormalSuite extends AnyFunSuite {
+  test("example") {
+    assert(true)
+  }
+}

--- a/integration/feature/test-do-not-discover/resources/foo/test/src/NotAutoDiscoverable.scala
+++ b/integration/feature/test-do-not-discover/resources/foo/test/src/NotAutoDiscoverable.scala
@@ -1,0 +1,11 @@
+package foo
+
+import org.scalatest.DoNotDiscover
+import org.scalatest.funsuite.AnyFunSuite
+
+@DoNotDiscover
+class NotAutoDiscoverable extends AnyFunSuite {
+  test("example") {
+    assert(true)
+  }
+}

--- a/integration/feature/test-do-not-discover/src/DoNotDiscoverTests.scala
+++ b/integration/feature/test-do-not-discover/src/DoNotDiscoverTests.scala
@@ -1,0 +1,30 @@
+package mill.integration
+
+import mill.testkit.UtestIntegrationTestSuite
+import utest.*
+
+object DoNotDiscoverTests extends UtestIntegrationTestSuite {
+  val tests: Tests = Tests {
+    test("doNotDiscoverSkippedByDefault") - integrationTest { tester =>
+      val res = tester.eval("foo.test")
+      assert(res.isSuccess)
+      assert(res.out.contains("NormalSuite"))
+      assert(!res.out.contains("NotAutoDiscoverable"))
+    }
+
+    test("doNotDiscoverRunsWhenExplicitlySelected") - integrationTest { tester =>
+      val res = tester.eval(("foo.test.testOnly", "foo.NotAutoDiscoverable"))
+      assert(res.isSuccess)
+      assert(res.out.contains("NotAutoDiscoverable"))
+    }
+
+    test("doNotDiscoverSkippedByGlobSelector") - integrationTest { tester =>
+      // A glob only counts as "discovery", not an explicit selection, so it must not
+      // bypass `@DoNotDiscover` even though it matches the class name.
+      val res = tester.eval(("foo.test.testOnly", "foo.*"))
+      assert(res.isSuccess)
+      assert(res.out.contains("NormalSuite"))
+      assert(!res.out.contains("NotAutoDiscoverable"))
+    }
+  }
+}

--- a/libs/javalib/src/mill/javalib/TestModule.scala
+++ b/libs/javalib/src/mill/javalib/TestModule.scala
@@ -288,6 +288,7 @@ trait TestModule
         resultPath = resultPath,
         colored = Task.log.prompt.colored,
         testCp = testClasspath().map(_.path),
+        rawSelectors = selectors,
         globSelectors = Left(selectors),
         logLevel = testLogLevel(),
         discoveredTestClasses = aheadOfTimeDiscoveredTestClassesIfNeeded()

--- a/libs/javalib/src/mill/javalib/TestModuleUtil.scala
+++ b/libs/javalib/src/mill/javalib/TestModuleUtil.scala
@@ -83,9 +83,6 @@ final class TestModuleUtil(
         // skip test groups that we know will be empty, which is important because even an empty
         // test group requires spawning a JVM which can take 1+ seconds to realize there are no
         // tests to run and shut down
-        println(s"Running test discovery for ${selectors.mkString(" ")}")
-        println(s"Run args: ${args.mkString(" ")}")
-        println(s"discoveredClassesOpt: ${discoveredClassesOpt.map(_.map(_._1).mkString(",")).getOrElse("None")}")
         val discoveredTests = jvmWorker.apply(
           ZincOp.GetTestTasks(
             (runClasspath ++ testrunnerEntrypointClasspath).map(_.path),
@@ -97,8 +94,6 @@ final class TestModuleUtil(
           ),
           javaHome = javaHome
         ).toSet
-
-        println(s"Discovered tests: ${discoveredTests.mkString(", ")}")
 
         filteredClassLists0.map(_.filter(discoveredTests)).filter(_.nonEmpty)
       }

--- a/libs/javalib/src/mill/javalib/TestModuleUtil.scala
+++ b/libs/javalib/src/mill/javalib/TestModuleUtil.scala
@@ -18,7 +18,7 @@ import mill.api.Logger
 import mill.api.BuildCtx
 import mill.constants.EnvVars
 import mill.javalib.api.internal.ZincOp
-import mill.javalib.testrunner.{TestArgs, TestResult, TestRunnerUtils}
+import mill.javalib.testrunner.{ClassFilter, TestArgs, TestResult, TestRunnerUtils}
 import os.Path
 
 import scala.concurrent.Future
@@ -61,7 +61,7 @@ final class TestModuleUtil(
     .mkString(",")
 
   def runTests(): Result[(msg: String, results: Seq[TestResult])] = {
-    val globFilter = TestRunnerUtils.globFilter(selectors)
+    val classFilter = ClassFilter(selectors)
 
     def doesNotMatchError = new Result.Exception(
       s"Test selector does not match any test: ${selectors.mkString(" ")}" +
@@ -69,7 +69,7 @@ final class TestModuleUtil(
     )
 
     /** This is filtered by mill. */
-    val filteredClassLists0 = testClassLists.map(_.filter(globFilter)).filter(_.nonEmpty)
+    val filteredClassLists0 = testClassLists.map(_.filter(classFilter.globMatch)).filter(_.nonEmpty)
 
     /** This is filtered by the test framework when using queue scheduling. */
     val filteredClassLists = {
@@ -145,6 +145,7 @@ final class TestModuleUtil(
       resultPath = resultPath,
       colored = Task.log.prompt.colored,
       testCp = testClasspath.map(_.path),
+      rawSelectors = selectors,
       globSelectors = selector,
       logLevel = testLogLevel,
       discoveredTestClasses = discoveredClassesOpt

--- a/libs/javalib/src/mill/javalib/TestModuleUtil.scala
+++ b/libs/javalib/src/mill/javalib/TestModuleUtil.scala
@@ -83,6 +83,9 @@ final class TestModuleUtil(
         // skip test groups that we know will be empty, which is important because even an empty
         // test group requires spawning a JVM which can take 1+ seconds to realize there are no
         // tests to run and shut down
+        println(s"Running test discovery for ${selectors.mkString(" ")}")
+        println(s"Run args: ${args.mkString(" ")}")
+        println(s"discoveredClassesOpt: ${discoveredClassesOpt.map(_.map(_._1).mkString(",")).getOrElse("None")}")
         val discoveredTests = jvmWorker.apply(
           ZincOp.GetTestTasks(
             (runClasspath ++ testrunnerEntrypointClasspath).map(_.path),
@@ -94,6 +97,8 @@ final class TestModuleUtil(
           ),
           javaHome = javaHome
         ).toSet
+
+        println(s"Discovered tests: ${discoveredTests.mkString(", ")}")
 
         filteredClassLists0.map(_.filter(discoveredTests)).filter(_.nonEmpty)
       }

--- a/libs/javalib/testrunner/src/mill/javalib/testrunner/ClassFilter.scala
+++ b/libs/javalib/testrunner/src/mill/javalib/testrunner/ClassFilter.scala
@@ -1,0 +1,34 @@
+package mill.javalib.testrunner
+
+import mill.api.daemon.internal.internal
+
+/**
+ * Whether selectors (e.g. from `testOnly`) match a candidate test class: [[globMatch]] says
+ * whether it should run at all, [[isExplicitlySpecified]] says whether it was named exactly
+ * rather than matched by a glob.
+ *
+ * `rawSelectors` defaults to `matchSelectors`. Pass it separately only when `matchSelectors`
+ * has already been resolved to concrete class names (e.g. the batch scheduler's per-group selector)
+ */
+@internal final class ClassFilter private (matchSelectors: Seq[String], rawSelectors: Option[Seq[String]]) {
+  private val matchers = matchSelectors.map(TestRunnerUtils.matchesGlob)
+  private val exactMatchers =
+    rawSelectors.getOrElse(matchSelectors).filterNot(_.contains('*')).map(TestRunnerUtils.matchesGlob)
+
+  def hasFilters: Boolean = matchSelectors.nonEmpty
+
+  def globMatch(className: String): Boolean = {
+    val name = className.stripSuffix("$")
+    matchers.isEmpty || matchers.exists(f => f(name))
+  }
+
+  def isExplicitlySpecified(className: String): Boolean = {
+    val name = className.stripSuffix("$")
+    exactMatchers.exists(f => f(name))
+  }
+}
+
+@internal object ClassFilter {
+  def apply(matchSelectors: Seq[String], rawSelectors: Option[Seq[String]] = None): ClassFilter =
+    new ClassFilter(matchSelectors, rawSelectors)
+}

--- a/libs/javalib/testrunner/src/mill/javalib/testrunner/ClassFilter.scala
+++ b/libs/javalib/testrunner/src/mill/javalib/testrunner/ClassFilter.scala
@@ -10,10 +10,15 @@ import mill.api.daemon.internal.internal
  * `rawSelectors` defaults to `matchSelectors`. Pass it separately only when `matchSelectors`
  * has already been resolved to concrete class names (e.g. the batch scheduler's per-group selector)
  */
-@internal final class ClassFilter private (matchSelectors: Seq[String], rawSelectors: Option[Seq[String]]) {
+@internal final class ClassFilter private (
+    matchSelectors: Seq[String],
+    rawSelectors: Option[Seq[String]]
+) {
   private val matchers = matchSelectors.map(TestRunnerUtils.matchesGlob)
   private val exactMatchers =
-    rawSelectors.getOrElse(matchSelectors).filterNot(_.contains('*')).map(TestRunnerUtils.matchesGlob)
+    rawSelectors.getOrElse(
+      matchSelectors
+    ).filterNot(_.contains('*')).map(TestRunnerUtils.matchesGlob)
 
   def hasFilters: Boolean = matchSelectors.nonEmpty
 

--- a/libs/javalib/testrunner/src/mill/javalib/testrunner/GetTestTasks.scala
+++ b/libs/javalib/testrunner/src/mill/javalib/testrunner/GetTestTasks.scala
@@ -7,7 +7,7 @@ import mill.api.daemon.internal.internal
   def apply(args0: mill.javalib.api.internal.ZincOp.GetTestTasks): Seq[String] = {
     import args0.*
     println("GetTestTasks selectors: " + selectors)
-    val globFilter = TestRunnerUtils.globFilter(selectors)
+    val classFilter = ClassFilter(selectors)
     mill.util.Jvm.withClassLoader(
       classPath = runCp,
       sharedPrefixes = Seq("sbt.testing.")
@@ -17,7 +17,7 @@ import mill.api.daemon.internal.internal
           Framework.framework(framework),
           Seq.from(testCp),
           args,
-          cls => globFilter(cls.getName),
+          classFilter,
           classLoader,
           discoveredClassesOpt
         )

--- a/libs/javalib/testrunner/src/mill/javalib/testrunner/GetTestTasks.scala
+++ b/libs/javalib/testrunner/src/mill/javalib/testrunner/GetTestTasks.scala
@@ -6,7 +6,6 @@ import mill.api.daemon.internal.internal
 
   def apply(args0: mill.javalib.api.internal.ZincOp.GetTestTasks): Seq[String] = {
     import args0.*
-    println("GetTestTasks selectors: " + selectors)
     val classFilter = ClassFilter(selectors)
     mill.util.Jvm.withClassLoader(
       classPath = runCp,

--- a/libs/javalib/testrunner/src/mill/javalib/testrunner/GetTestTasks.scala
+++ b/libs/javalib/testrunner/src/mill/javalib/testrunner/GetTestTasks.scala
@@ -6,6 +6,7 @@ import mill.api.daemon.internal.internal
 
   def apply(args0: mill.javalib.api.internal.ZincOp.GetTestTasks): Seq[String] = {
     import args0.*
+    println("GetTestTasks selectors: " + selectors)
     val globFilter = TestRunnerUtils.globFilter(selectors)
     mill.util.Jvm.withClassLoader(
       classPath = runCp,

--- a/libs/javalib/testrunner/src/mill/javalib/testrunner/Model.scala
+++ b/libs/javalib/testrunner/src/mill/javalib/testrunner/Model.scala
@@ -12,6 +12,8 @@ import mill.api.daemon.internal.{TestReporter, internal}
     resultPath: os.Path,
     colored: Boolean,
     testCp: Seq[os.Path],
+    // The raw, unresolved selectors the user typed (e.g. via `testOnly`)
+    rawSelectors: Seq[String],
     // globSelectors indicates the strategy for testrunner to find and run test classes
     // can be either:
     // - Left(selectors: Seq[String]): - list of glob selectors, testrunner is given a list of glob selectors to run directly

--- a/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunner.scala
+++ b/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunner.scala
@@ -12,7 +12,7 @@ import mill.util.Jvm
       args: Seq[String],
       testReporter: TestReporter,
       discoveredTestClasses: Option[Seq[(String, Int)]],
-      classFilter: Class[?] => Boolean = _ => true
+      classFilter: ClassFilter = ClassFilter(Nil)
   ): (String, Seq[TestResult]) = {
     Jvm.withClassLoader(
       classPath = entireClasspath.toVector,

--- a/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunnerMain0.scala
+++ b/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunnerMain0.scala
@@ -12,12 +12,15 @@ import mill.api.internal.PathAliasing
 
         val result = testArgs.globSelectors match {
           case Left(selectors) =>
-            val filter = TestRunnerUtils.globFilter(selectors)
+            // `selectors` may already be the batch scheduler's per-group, resolved list, so
+            // matching uses it, but explicitness must still read the original `testArgs.rawSelectors`.
+            val classFilter =
+              ClassFilter(matchSelectors = selectors, rawSelectors = Some(testArgs.rawSelectors))
             TestRunnerUtils.runTestFramework0(
               frameworkInstances = Framework.framework(testArgs.framework),
               testClassfilePath = Seq.from(testArgs.testCp),
               args = testArgs.arguments,
-              classFilter = cls => filter(cls.getName),
+              classFilter = classFilter,
               cl = classLoader,
               testReporter = TestReporter(testArgs.logLevel),
               discoveredTestClasses = testArgs.discoveredTestClasses,
@@ -34,7 +37,8 @@ import mill.api.internal.PathAliasing
               cl = classLoader,
               testReporter = TestReporter(testArgs.logLevel),
               discoveredTestClasses = testArgs.discoveredTestClasses,
-              resultPath = testArgs.resultPath
+              resultPath = testArgs.resultPath,
+              classFilter = ClassFilter(testArgs.rawSelectors)
             )
         }
 

--- a/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunnerUtils.scala
+++ b/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunnerUtils.scala
@@ -122,6 +122,35 @@ import scala.math.Ordering.Implicits.*
     }.map { f => (cls, f) }
   }
 
+  /**
+   * Builds tasks for classes, rescuing any undiscovered but explicitly specified.
+   * Only those are then marked as explicitly specified.
+   */
+  private def tasksWithRescue(
+      runner: Runner,
+      classFilter: ClassFilter,
+      classes: Seq[ClassWithFingerprint]
+  ): Array[Task] = {
+    def taskDef(cls: Class[?], fingerprint: Fingerprint, explicit: Boolean) =
+      TaskDef(cls.getName.stripSuffix("$"), fingerprint, explicit, Array(new SuiteSelector))
+
+    val discoveredTasks =
+      runner.tasks(classes.map { case (cls, fingerprint) =>
+        taskDef(cls, fingerprint, false)
+      }.toArray)
+
+    val discoveredNames = discoveredTasks.iterator
+      .map(_.taskDef()).filter(_ != null).map(_.fullyQualifiedName()).toSet
+
+    val rescuedTaskDefs = classes.filter { case (cls, _) =>
+      !discoveredNames(
+        cls.getName.stripSuffix("$")
+      ) && classFilter.isExplicitlySpecified(cls.getName)
+    }.map { case (cls, fingerprint) => taskDef(cls, fingerprint, true) }
+
+    discoveredTasks ++ runner.tasks(rescuedTaskDefs.toArray)
+  }
+
   def getTestTasks(
       framework: Framework,
       args: Seq[String],
@@ -133,16 +162,9 @@ import scala.math.Ordering.Implicits.*
 
     val runner = framework.runner(args.toArray, Array[String](), cl)
     val testClasses = discoverTests(cl, framework, testClassfilePath, discoveredTestClasses)
+    val matched = testClasses.filter { case (cls, _) => classFilter.globMatch(cls.getName) }
 
-    val tasks = runner.tasks(
-      for ((cls, fingerprint) <- testClasses.iterator.toArray if classFilter.globMatch(cls.getName))
-        yield TaskDef(
-          cls.getName.stripSuffix("$"),
-          fingerprint,
-          classFilter.isExplicitlySpecified(cls.getName),
-          Array(new SuiteSelector)
-        )
-    )
+    val tasks = tasksWithRescue(runner, classFilter, matched)
 
     def nameOpt(t: Task) = Option(t.taskDef()).map(_.fullyQualifiedName())
     val groupedTasks = tasks
@@ -322,19 +344,7 @@ import scala.math.Ordering.Implicits.*
 
       if (testReporter.logLevel <= TestReporter.LogLevel.Debug)
         System.err.println(s"Running Test Class $testClassName")
-      val taskDefs = globSelectorCache
-        .get(testClassName)
-        .map { case (cls, fingerprint) =>
-          val clsName = cls.getName.stripSuffix("$")
-          TaskDef(
-            clsName,
-            fingerprint,
-            classFilter.isExplicitlySpecified(clsName),
-            Array(new SuiteSelector)
-          )
-        }
-
-      val tasks = runner.tasks(taskDefs.toArray)
+      val tasks = tasksWithRescue(runner, classFilter, globSelectorCache.get(testClassName).toSeq)
       val taskResult = executeTasks(tasks, testReporter, events, systemOut)
       if taskResult then successCounter += 1 else failureCounter += 1
       os.write.over(resultPath, upickle.write((successCounter, failureCounter)))

--- a/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunnerUtils.scala
+++ b/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunnerUtils.scala
@@ -125,7 +125,7 @@ import scala.math.Ordering.Implicits.*
   def getTestTasks(
       framework: Framework,
       args: Seq[String],
-      classFilter: Class[?] => Boolean,
+      classFilter: ClassFilter,
       cl: ClassLoader,
       testClassfilePath: Seq[Path],
       discoveredTestClasses: Option[Seq[(String, Int)]]
@@ -138,18 +138,18 @@ import scala.math.Ordering.Implicits.*
 
     for ((cls, fingerprint) <- testClasses) {
       println(s"TestClass: ${cls.getName}, Fingerprint: $fingerprint")
-      println(s"Passes classFilter: ${classFilter(cls)}")
+      println(s"Passes classFilter: ${classFilter.globMatch(cls.getName)}")
     }
 
     val tasks = runner.tasks(
       for {
-        (cls, fingerprint) <- testClasses.iterator.toArray if classFilter(cls)
+        (cls, fingerprint) <- testClasses.iterator.toArray if classFilter.globMatch(cls.getName)
         _ = {
           println(s"Creating TaskDef for ${cls.getName.stripSuffix("$")} with fingerprint $fingerprint")
           val taskDef = TaskDef(
             cls.getName.stripSuffix("$"),
             fingerprint,
-            true,
+            classFilter.isExplicitlySpecified(cls.getName),
             Array(new SuiteSelector)
           )
           println(s"Created TaskDef: $taskDef")
@@ -157,7 +157,7 @@ import scala.math.Ordering.Implicits.*
        } yield TaskDef(
           cls.getName.stripSuffix("$"),
           fingerprint,
-          true,
+          classFilter.isExplicitlySpecified(cls.getName),
           Array(new SuiteSelector)
         )
     )
@@ -320,7 +320,7 @@ import scala.math.Ordering.Implicits.*
       frameworkInstances: ClassLoader => Framework,
       testClassfilePath: Seq[Path],
       args: Seq[String],
-      classFilter: Class[?] => Boolean,
+      classFilter: ClassFilter,
       cl: ClassLoader,
       testReporter: TestReporter,
       discoveredTestClasses: Option[Seq[(String, Int)]],
@@ -345,7 +345,8 @@ import scala.math.Ordering.Implicits.*
       runner: Runner,
       claimFolder: os.Path,
       testClassQueueFolder: os.Path,
-      resultPath: os.Path
+      resultPath: os.Path,
+      classFilter: ClassFilter = ClassFilter(Nil)
   ): (String, Iterator[TestResult]) = {
     // Capture this value outside of the task event handler so it
     // isn't affected by a test framework's stream redirects
@@ -365,7 +366,12 @@ import scala.math.Ordering.Implicits.*
         .get(testClassName)
         .map { case (cls, fingerprint) =>
           val clsName = cls.getName.stripSuffix("$")
-          TaskDef(clsName, fingerprint, true, Array(new SuiteSelector))
+          TaskDef(
+            clsName,
+            fingerprint,
+            classFilter.isExplicitlySpecified(clsName),
+            Array(new SuiteSelector)
+          )
         }
 
       val tasks = runner.tasks(taskDefs.toArray)
@@ -428,7 +434,8 @@ import scala.math.Ordering.Implicits.*
       cl: ClassLoader,
       testReporter: TestReporter,
       resultPath: os.Path,
-      discoveredTestClasses: Option[Seq[(String, Int)]]
+      discoveredTestClasses: Option[Seq[(String, Int)]],
+      classFilter: ClassFilter = ClassFilter(Nil)
   ): (String, Seq[TestResult]) = {
 
     val framework = frameworkInstances(cl)
@@ -444,7 +451,8 @@ import scala.math.Ordering.Implicits.*
       runner,
       claimFolder,
       testClassQueueFolder,
-      resultPath
+      resultPath,
+      classFilter
     )
 
     (doneMessage, results.toSeq)
@@ -454,7 +462,7 @@ import scala.math.Ordering.Implicits.*
       frameworkInstances: ClassLoader => Framework,
       testClassfilePath: Seq[Path],
       args: Seq[String],
-      classFilter: Class[?] => Boolean,
+      classFilter: ClassFilter,
       cl: ClassLoader,
       discoveredTestClasses: Option[Seq[(String, Int)]]
   ): Array[String] = {
@@ -477,13 +485,4 @@ import scala.math.Ordering.Implicits.*
           (s: String) => pattern.matcher(s).matches()
       }
     }
-
-  def globFilter(selectors: Seq[String]): String => Boolean = {
-    val filters = selectors.map(matchesGlob)
-    if (filters.isEmpty) _ => true
-    else { className =>
-      val name = className.stripSuffix("$")
-      filters.exists(f => f(name))
-    }
-  }
 }

--- a/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunnerUtils.scala
+++ b/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunnerUtils.scala
@@ -134,27 +134,9 @@ import scala.math.Ordering.Implicits.*
     val runner = framework.runner(args.toArray, Array[String](), cl)
     val testClasses = discoverTests(cl, framework, testClassfilePath, discoveredTestClasses)
 
-    println(s"TestClasses found: ${testClasses.mkString(", ")}")
-
-    for ((cls, fingerprint) <- testClasses) {
-      println(s"TestClass: ${cls.getName}, Fingerprint: $fingerprint")
-      println(s"Passes classFilter: ${classFilter.globMatch(cls.getName)}")
-    }
-
     val tasks = runner.tasks(
-      for {
-        (cls, fingerprint) <- testClasses.iterator.toArray if classFilter.globMatch(cls.getName)
-        _ = {
-          println(s"Creating TaskDef for ${cls.getName.stripSuffix("$")} with fingerprint $fingerprint")
-          val taskDef = TaskDef(
-            cls.getName.stripSuffix("$"),
-            fingerprint,
-            classFilter.isExplicitlySpecified(cls.getName),
-            Array(new SuiteSelector)
-          )
-          println(s"Created TaskDef: $taskDef")
-        }
-       } yield TaskDef(
+      for ((cls, fingerprint) <- testClasses.iterator.toArray if classFilter.globMatch(cls.getName))
+        yield TaskDef(
           cls.getName.stripSuffix("$"),
           fingerprint,
           classFilter.isExplicitlySpecified(cls.getName),
@@ -162,27 +144,12 @@ import scala.math.Ordering.Implicits.*
         )
     )
 
-    println(s"Found ${tasks.length} tasks for ${testClasses.length} test classes")
-    for (t <- tasks) {
-      val taskDef0 = Option(t.taskDef())
-      if (taskDef0.isDefined) {
-        val taskDef = taskDef0.get
-        println(
-          s"Task: ${taskDef.fullyQualifiedName()}, Fingerprint: ${taskDef.fingerprint()}, ExplicitlySpecified: ${taskDef.explicitlySpecified()}"
-        )
-      } else {
-        println(s"Task: null")
-      }
-    }
-
     def nameOpt(t: Task) = Option(t.taskDef()).map(_.fullyQualifiedName())
     val groupedTasks = tasks
       .groupBy(nameOpt)
       .values
       .toArray
       .sortBy(_.headOption.map(nameOpt))
-
-    println(s"Grouped tasks: ${groupedTasks.map(_.map(nameOpt).mkString("[", ", ", "]")).mkString(", ")}")
 
     (runner, groupedTasks)
   }
@@ -195,13 +162,6 @@ import scala.math.Ordering.Implicits.*
   ): Boolean = {
     val taskStatus = AtomicBoolean(true)
     val taskQueue = tasks.to(mutable.Queue)
-    println(s"Executing ${taskQueue.size} tasks:")
-    for (t <- taskQueue) {
-      val taskDef0 = t.taskDef()
-      val taskName = Option(taskDef0).map(_.fullyQualifiedName()).getOrElse("null")
-      val isExplicitlySpecified = Option(taskDef0).map(_.explicitlySpecified()).getOrElse(false)
-      println(s"Task: $taskName, ExplicitlySpecified: $isExplicitlySpecified")
-    }
     while (taskQueue.nonEmpty) {
       val next =
         try taskQueue.dequeue().execute(

--- a/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunnerUtils.scala
+++ b/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunnerUtils.scala
@@ -134,9 +134,27 @@ import scala.math.Ordering.Implicits.*
     val runner = framework.runner(args.toArray, Array[String](), cl)
     val testClasses = discoverTests(cl, framework, testClassfilePath, discoveredTestClasses)
 
+    println(s"TestClasses found: ${testClasses.mkString(", ")}")
+
+    for ((cls, fingerprint) <- testClasses) {
+      println(s"TestClass: ${cls.getName}, Fingerprint: $fingerprint")
+      println(s"Passes classFilter: ${classFilter(cls)}")
+    }
+
     val tasks = runner.tasks(
-      for ((cls, fingerprint) <- testClasses.iterator.toArray if classFilter(cls))
-        yield TaskDef(
+      for {
+        (cls, fingerprint) <- testClasses.iterator.toArray if classFilter(cls)
+        _ = {
+          println(s"Creating TaskDef for ${cls.getName.stripSuffix("$")} with fingerprint $fingerprint")
+          val taskDef = TaskDef(
+            cls.getName.stripSuffix("$"),
+            fingerprint,
+            true,
+            Array(new SuiteSelector)
+          )
+          println(s"Created TaskDef: $taskDef")
+        }
+       } yield TaskDef(
           cls.getName.stripSuffix("$"),
           fingerprint,
           true,
@@ -144,12 +162,27 @@ import scala.math.Ordering.Implicits.*
         )
     )
 
+    println(s"Found ${tasks.length} tasks for ${testClasses.length} test classes")
+    for (t <- tasks) {
+      val taskDef0 = Option(t.taskDef())
+      if (taskDef0.isDefined) {
+        val taskDef = taskDef0.get
+        println(
+          s"Task: ${taskDef.fullyQualifiedName()}, Fingerprint: ${taskDef.fingerprint()}, ExplicitlySpecified: ${taskDef.explicitlySpecified()}"
+        )
+      } else {
+        println(s"Task: null")
+      }
+    }
+
     def nameOpt(t: Task) = Option(t.taskDef()).map(_.fullyQualifiedName())
     val groupedTasks = tasks
       .groupBy(nameOpt)
       .values
       .toArray
       .sortBy(_.headOption.map(nameOpt))
+
+    println(s"Grouped tasks: ${groupedTasks.map(_.map(nameOpt).mkString("[", ", ", "]")).mkString(", ")}")
 
     (runner, groupedTasks)
   }
@@ -162,6 +195,13 @@ import scala.math.Ordering.Implicits.*
   ): Boolean = {
     val taskStatus = AtomicBoolean(true)
     val taskQueue = tasks.to(mutable.Queue)
+    println(s"Executing ${taskQueue.size} tasks:")
+    for (t <- taskQueue) {
+      val taskDef0 = t.taskDef()
+      val taskName = Option(taskDef0).map(_.fullyQualifiedName()).getOrElse("null")
+      val isExplicitlySpecified = Option(taskDef0).map(_.explicitlySpecified()).getOrElse(false)
+      println(s"Task: $taskName, ExplicitlySpecified: $isExplicitlySpecified")
+    }
     while (taskQueue.nonEmpty) {
       val next =
         try taskQueue.dequeue().execute(

--- a/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunnerUtils.scala
+++ b/libs/javalib/testrunner/src/mill/javalib/testrunner/TestRunnerUtils.scala
@@ -139,7 +139,7 @@ import scala.math.Ordering.Implicits.*
         yield TaskDef(
           cls.getName.stripSuffix("$"),
           fingerprint,
-          false,
+          true,
           Array(new SuiteSelector)
         )
     )
@@ -325,7 +325,7 @@ import scala.math.Ordering.Implicits.*
         .get(testClassName)
         .map { case (cls, fingerprint) =>
           val clsName = cls.getName.stripSuffix("$")
-          TaskDef(clsName, fingerprint, false, Array(new SuiteSelector))
+          TaskDef(clsName, fingerprint, true, Array(new SuiteSelector))
         }
 
       val tasks = runner.tasks(taskDefs.toArray)

--- a/libs/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/libs/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -12,7 +12,7 @@ import mill.javalib.api.JvmWorkerUtil.*
 import mill.scalajslib.api.*
 import mill.scalajslib.worker.{ScalaJSWorker, ScalaJSWorkerExternalModule}
 import mill.*
-import mill.javalib.testrunner.{TestResult, TestRunner, TestRunnerUtils}
+import mill.javalib.testrunner.{ClassFilter, TestResult, TestRunner}
 import mill.util.Version
 import upickle.implicits.namedTuples.default.given
 import sbt.testing.Framework
@@ -437,7 +437,7 @@ trait TestScalaJSModule extends ScalaJSModule with TestModule {
       args(),
       Task.testReporter,
       aheadOfTimeDiscoveredTestClassesIfNeeded(),
-      cls => TestRunnerUtils.globFilter(globSelectors())(cls.getName)
+      ClassFilter(globSelectors())
     )
     val res = TestModule.handleResults(doneMsg, results, Task.ctx(), testReportXml())
     // Hack to try and let the Node.js subprocess finish streaming its stdout

--- a/libs/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
+++ b/libs/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
@@ -8,7 +8,7 @@ import mill.api.daemon.internal.bsp.ScalaBuildTarget
 import mill.javalib.api.JvmWorkerUtil
 import mill.api.daemon.internal.{ScalaNativeModuleApi, ScalaPlatform, internal}
 import mill.javalib.RunModule
-import mill.javalib.testrunner.{TestResult, TestRunner, TestRunnerUtils}
+import mill.javalib.testrunner.{ClassFilter, TestResult, TestRunner}
 import mill.scalalib.{Dep, DepSyntax, Lib, SbtModule, ScalaModule, TestModule}
 import mill.scalanativelib.api.*
 import mill.scalanativelib.worker.{
@@ -509,7 +509,7 @@ trait TestScalaNativeModule extends ScalaNativeModule with TestModule {
       args(),
       Task.testReporter,
       aheadOfTimeDiscoveredTestClassesIfNeeded(),
-      cls => TestRunnerUtils.globFilter(globSelectors())(cls.getName)
+      ClassFilter(globSelectors())
     )
     val res = TestModule.handleResults(doneMsg, results, Task.ctx(), testReportXml())
     // Hack to try and let the Scala Native subprocess finish streaming its stdout


### PR DESCRIPTION
To close #7450

**ES = explicitly specified**

### Summary
`TaskDef`'s 3rd argument is `boolean explicitlySpecified`, which is used by some frameworks like ScalaTest to know if a test class was explicitly intended to run. The previous `classFilter: Class[?] => Boolean` just did the glob matching and didn't store any information on what the user requested (with `testOnly`).

This PR creates `class ClassFilter` that includes the old `classFilter: Class[?] => Boolean` and also provides `def isExplicitlySpecified(className: String): Boolean` to determine if a test class was **ES**.

### Problems encountered / Workarounds
- The batch execution logic resolves some globs, so I added a new field to `TestArgs` called `rawSelectors` to be passed to the final `ClassFilter` when the tests run. 
- Marking normally discoverable classes that **were** **ES** as **ES** raised some issues with ScalaTest ignoring filters like `-n`/`-l`. Thus, we leave normally discoverable classes untouched (`_explicitly_specified=false`)

This also adds an `integration.feature` test with the scenario of #7450 (`scalatest.DoNotDiscover`)