### PR TITLE
GetTestTasksMain: exit the JVM once discovery is done

### DIFF
--- a/testrunner/src/mill/testrunner/GetTestTasksMain.scala
+++ b/testrunner/src/mill/testrunner/GetTestTasksMain.scala
@@ -40,5 +40,14 @@ import mill.api.internal
     }
   }
 
-  def main(args: Array[String]): Unit = mainargs.ParserForMethods(this).runOrExit(args)
+  def main(args: Array[String]): Unit = {
+    mainargs.ParserForMethods(this).runOrExit(args)
+    // Discovery is over, kill the JVM whether or not anyone's threads are still running.
+    // Test frameworks may leave non-daemon threads behind: `getTestTasks` instantiates a
+    // `Runner` and never calls `done()` on it, and e.g. ScalaTest spawns a non-daemon
+    // "ScalaTest-dispatcher" thread as part of that. Returning normally would leave this
+    // process alive forever, and `TestModuleUtil.runTests` waits for it to exit.
+    System.out.flush()
+    System.exit(0)
+  }
 }


### PR DESCRIPTION
`mill.testrunner.GetTestTasksMain` can never exit, which hangs the build forever.

### Symptom

A `test`/`testCached` task sits at 0% CPU indefinitely. Mill's own stack:

```
mill.scalalib.TestModuleUtil.runTests(TestModuleUtil.scala:71)
mill.util.Jvm$.callProcess(Jvm.scala:95)
os.proc.call(ProcessOps.scala:232)
```

and a thread dump of the forked `GetTestTasksMain` process, with ScalaTest as the framework:

```
"ScalaTest-dispatcher" #40 prio=5 ...          <-- not a daemon thread
   java.lang.Thread.State: WAITING (parking)
	at java.util.concurrent.LinkedBlockingQueue.take(...)
	at org.scalatest.DispatchReporter$Propagator.run(DispatchReporter.scala:166)

"DestroyJavaVM" #41 ... RUNNABLE
```

`main` has returned; `DestroyJavaVM` is waiting on the one remaining non-daemon thread.

### Cause

`TestRunnerUtils.getTestTasks` instantiates an `sbt.testing.Runner` and never calls `done()` on
it. ScalaTest's `Framework.runner` starts a non-daemon `ScalaTest-dispatcher` thread as part of
constructing its `DispatchReporter`, and only `Runner.done()` disposes it. `GetTestTasksMain`
returns normally, so the JVM stays alive, and `TestModuleUtil.runTests` blocks waiting for a
process that will never exit.

### Reproducing

`TestModuleUtil.runTests` only forks the discovery process on one path:

```scala
if (filteredClassLists.size == 1 && !testParallelism) filteredClassLists
else if (javaHome.isDefined) Jvm.callProcess("mill.testrunner.GetTestTasksMain", ...)  // hangs
else GetTestTasksMain.main0(...)                                                        // in-process
```

So it needs a custom `javaHome` (e.g. `ZincWorkerModule.jvmId`) plus either `testParallelism` or
more than one test fork group. Without `javaHome` the discovery runs inside the Mill server, where
the leaked thread is invisible (though it does accumulate one per test task).

### Fix

Exit the JVM once discovery is done, the same way Mill 1.x already does in
`MillTestRunnerMain0.main0` ("Tests are over, kill the JVM whether or not anyone's threads are
still running").

Calling `runner.done()` in `getTestTasks0` would be the more precise fix, but `GetTestTasksMain`
writes the discovered class names to stdout and `TestModuleUtil` parses those lines — a framework
that prints a summary from `done()` would corrupt the list. `System.exit` avoids that.

Mill 1.x is not affected either way: it routes discovery through the long-lived `jvmWorker`
(`ZincOp.GetTestTasks`) rather than a throwaway process.

### Verified

Built from this branch via `dist.installLocalCache` and run against a multi-module Scala build
(ScalaTest, `jvmId = "zulu:21.0.11"`, `testParallelism = true`). Before: the build hangs
indefinitely on the first ScalaTest module. After: 19 test modules, ~2600 tests, 146s, no hang,
test parallelism unaffected.
