### PR TITLE
Fix `clean __` deleting Mill's own `out/mill-*` state (backport #7459)

### DIFF
--- a/integration/multimode/clean-keeps-daemon-files/resources/build.mill
+++ b/integration/multimode/clean-keeps-daemon-files/resources/build.mill
@@ -1,0 +1,6 @@
+package build
+import mill.*
+
+object foo extends Module {
+  def bar = Task { os.write(Task.dest / "out.txt", "hello"); 123 }
+}

--- a/integration/multimode/clean-keeps-daemon-files/src/CleanKeepsDaemonFilesTests.scala
+++ b/integration/multimode/clean-keeps-daemon-files/src/CleanKeepsDaemonFilesTests.scala
@@ -1,0 +1,47 @@
+package mill.integration
+
+import mill.testkit.UtestIntegrationTestSuite
+import utest.*
+
+/**
+ * `clean __` must not delete Mill's own `out/mill-*` state. `__` resolves tasks on the
+ * root module, whose `Segments` is empty, which used to make `clean` treat `out/` itself
+ * as a module folder and wipe it wholesale, including the running process's `processId`
+ * file. The process watchdog then exits mid-command, surfacing to the user as
+ * "Worker wire broken, worker likely crashed".
+ *
+ * See https://github.com/com-lihaoyi/mill/issues/7053
+ */
+object CleanKeepsDaemonFilesTests extends UtestIntegrationTestSuite {
+  val tests: Tests = Tests {
+    integrationTest { tester =>
+      import tester.*
+
+      val res1 = eval(("show", "foo.bar"))
+      assert(res1.isSuccess)
+      assert(os.exists(workspacePath / "out/foo/bar.json"))
+
+      val processRoot =
+        if (tester.daemonMode) workspacePath / "out/mill-daemon"
+        else workspacePath / "out/mill-no-daemon"
+      assert(os.exists(processRoot))
+
+      val res2 = eval(("clean", "__"))
+
+      // The command itself must succeed rather than dying with a broken connection
+      assert(res2.isSuccess)
+      assert(!res2.err.contains("Worker wire broken"))
+      assert(!res2.err.contains("processId file missing"))
+
+      // Task output is cleaned...
+      assert(!os.exists(workspacePath / "out/foo/bar.json"))
+      // ...but Mill's own bookkeeping survives
+      assert(os.exists(processRoot))
+      assert(os.exists(workspacePath / "out"))
+
+      // And Mill still works afterwards
+      val res3 = eval(("show", "foo.bar"))
+      assert(res3.isSuccess)
+    }
+  }
+}

--- a/libs/util/src/mill/util/MainModule.scala
+++ b/libs/util/src/mill/util/MainModule.scala
@@ -229,7 +229,10 @@ trait MainModule extends RootModule0, MainModuleApi, JdkCommandsModule {
             val paths = Seq(evPaths.dest, evPaths.meta, evPaths.log)
             val potentialModulePath =
               rootDir / segments.parts.map(ExecutionPaths.sanitizePathSegment)
-            if (os.exists(potentialModulePath)) {
+            // `segments` is empty for tasks on the root module (e.g. resolved by `__`), which
+            // would make `potentialModulePath` the `out/` folder itself; deleting that wipes
+            // Mill's own internal state, including the running daemon's `processId` file.
+            if (segments.parts.nonEmpty && os.exists(potentialModulePath)) {
               // this is either because of some pre-Mill-0.10 files lying around
               // or most likely because the segments denote a module but not a task
               // in which case we want to remove the module and all its sub-modules
@@ -238,7 +241,8 @@ trait MainModule extends RootModule0, MainModuleApi, JdkCommandsModule {
               paths :+ potentialModulePath
             } else paths
           }
-          (allPaths, ts)
+          // Never delete Mill's own `out/mill-*` bookkeeping, matching the `tasks.isEmpty` case
+          (allPaths.filterNot(keepPath), ts)
         }
 
     (pathsToRemove.runtimeChecked).map {

--- a/libs/util/test/src/mill/util/MainModuleTests.scala
+++ b/libs/util/test/src/mill/util/MainModuleTests.scala
@@ -627,7 +627,7 @@ object MainModuleTests extends TestSuite {
           checkExists(out, false)(
             os.sub / "bar/task.json",
             os.sub / "bar/task.dest/dummy.txt",
-            os.sub / "bar/task.dest",
+            os.sub / "bar/task.dest"
           )
         }
       }

--- a/libs/util/test/src/mill/util/MainModuleTests.scala
+++ b/libs/util/test/src/mill/util/MainModuleTests.scala
@@ -626,9 +626,50 @@ object MainModuleTests extends TestSuite {
           )
           checkExists(out, false)(
             os.sub / "bar/task.json",
-            os.sub / "bar/task.dest/dummy.txt"
+            os.sub / "bar/task.dest/dummy.txt",
+            os.sub / "bar/task.dest",
           )
         }
+      }
+
+      // Mill's own internal `out/mill-*` state must survive `clean`, whether it is invoked
+      // bare or with a selector that resolves the root module (e.g. `clean __`). Deleting
+      // `out/mill-daemon/processId` from under a running daemon makes it exit mid-command,
+      // surfacing to the user as "Worker wire broken".
+      // See https://github.com/com-lihaoyi/mill/issues/7053
+      test("keeps-mill-internals") {
+        // folders Mill keeps its own machinery in, e.g. `out/mill-daemon/processId`
+        val internalFolders = Seq(OutFiles.millDaemon, OutFiles.millNoDaemon)
+        // internal bookkeeping that lives directly in `out/` as plain files
+        val internalFiles = Seq(OutFiles.millOutLock, OutFiles.millProfile)
+
+        val markers =
+          internalFolders.map(os.sub / _ / "marker") ++ internalFiles.map(os.sub / _)
+
+        def check(selector: String*): Unit = UnitTester(cleanModule, null).scoped { ev =>
+          val out = ev.evaluator.outPath
+          val r1 = ev.evaluator.execute(Seq(cleanModule.all)).executionResults
+          assert(r1.transitiveFailing.size == 0)
+
+          // Stand in for the internal state a real daemon keeps under `out/`
+          markers.foreach(p => os.write.over(out / p, "x", createFolders = true))
+          checkExists(out, true)(markers*)
+
+          val r2 = ev.evaluator
+            .execute(Seq(cleanModule.clean(ev.evaluator, selector*)))
+            .executionResults
+          assert(r2.transitiveFailing.size == 0)
+
+          // task output is gone, but Mill's own state is untouched
+          checkExists(out, false)(os.sub / "foo/task.dest/dummy.txt")
+          checkExists(out, true)(markers*)
+          assert(os.exists(out))
+        }
+
+        test("no-selector") - check()
+        // `__` resolves the root module too, whose `Segments` is empty; that used to make
+        // `clean` treat `out/` itself as a module folder and wipe it wholesale.
+        test("wildcard-all") - check("__")
       }
     }
 


### PR DESCRIPTION
Fix https://github.com/com-lihaoyi/mill/issues/7053

`./mill clean __` kills the daemon mid-command:

```
java.lang.IllegalStateException: Worker wire broken, worker likely crashed. Connection DaemonRpcClient
	at mill.rpc.MillRpcClient$.mill$rpc$MillRpcClient$$$_$awaitForResponse$1(MillRpcClient.scala:62)
```

Bare `./mill clean` and `./mill clean _` are fine; only `__` is
affected.

`cleanTask` applies its `KeepPattern` (`mill-.+`) filter on only one of
its two branches:

```scala
if (tasks.isEmpty)
  os.list(rootDir).filterNot(keepPath)   // ← protects mill-daemon, mill-out-lock, …
else
  evaluator.resolveSegments(tasks, SelectMode.Multi).map { ts => … }  // ← no keepPath filter
```

`__` also resolves tasks on the **root module**, whose `Segments` is
empty. That makes

```scala
val potentialModulePath = rootDir / segments.parts.map(...)
```

collapse to `rootDir` — `out/` itself — so the whole directory is
scheduled for deletion, Mill's internals included.

Among the casualties is `out/mill-daemon/processId`.
`Server.watchProcessIdFile` polls that file every 100ms and exits the
daemon as soon as it goes missing, so `clean __` tears down the very
daemon that is running it. Caught live:

```
processId before: 38813
  >> processId file VANISHED at ~110ms into clean
processId after: <missing>
```

Entries deleted by `clean __` but never by `clean`: `mill-daemon`,
`mill-out-lock`, `mill-console-tail`, `mill-chrome-profile.json`,
`mill-dependency-tree.json`, `mill-profile.json`.

This also explains the `--no-server` report in the issue — same
deletion, surfacing as `processId file missing:` from
`checkProcessIdFile`.

Two changes, both in the non-empty-selector branch:

- guard `potentialModulePath` on `segments.parts.nonEmpty`, so
root-module segments can never resolve to `out/` itself
- apply the existing `keepPath` filter here too, matching the
`tasks.isEmpty` branch

- **Unit** (`MainModuleTests`): `clean.keeps-mill-internals`, split into
`no-selector` and `wildcard-all`. Before the fix `no-selector` passed
and `wildcard-all` failed, which is what pins the bug to the selector
path.
- **Integration** (`integration/multimode/clean-keeps-daemon-files`):
runs a real daemon, asserts `clean __` succeeds, preserves
`out/mill-daemon`, still cleans task output, and leaves Mill usable
afterwards. Under `multimode` so it covers both daemon and no-daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code), reviewed
by me.

Backport of pull request: https://github.com/com-lihaoyi/mill/pull/7459

---------

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>
Co-authored-by: Tobias Roeser <le.petit.fou@web.de>
