### PR TITLE
Apply system properties before launcher initialization

### DIFF
--- a/integration/feature/mill-opts/resources/build.mill
+++ b/integration/feature/mill-opts/resources/build.mill
@@ -32,3 +32,8 @@ def testProperty = Task { sys.props.get("test.property").get.toInt }
 def printSysProp(propName: String) = Task.Command {
   println(sys.props(propName))
 }
+
+def printArgs(args: String*) = Task.Command {
+  println(Option(System.getProperty("task-property")).getOrElse("null"))
+  println(args.mkString("\n"))
+}

--- a/integration/feature/mill-opts/src/MillOptsTests.scala
+++ b/integration/feature/mill-opts/src/MillOptsTests.scala
@@ -81,6 +81,22 @@ object MillOptsTests extends UtestIntegrationTestSuite {
       val res3 = eval(("-Dfoo-property=i-am-cow", "printSysProp", "--propName", "foo-property"))
       assert(res3.out == "i-am-cow")
 
+      // Launcher-like arguments after `--` belong to the task and must remain unchanged
+      val resAfterDelimiter = eval((
+        "printArgs",
+        "--",
+        "-J-Dtask-property=jvm-style",
+        "-Dtask-property=mill-style"
+      ))
+      assert(
+        resAfterDelimiter.out.linesIterator.toSeq == Seq(
+          "null",
+          "--",
+          "-J-Dtask-property=jvm-style",
+          "-Dtask-property=mill-style"
+        )
+      )
+
       // Existing property removed
       val res4 = eval(("printSysProp", "--propName", "foo-property"))
       assert(res4.out == "null")

--- a/runner/launcher/src/mill/launcher/MillLauncherMain.scala
+++ b/runner/launcher/src/mill/launcher/MillLauncherMain.scala
@@ -10,11 +10,35 @@ import mill.internal.MillCliConfig
 import java.io.{PrintWriter, StringWriter}
 import java.time.format.DateTimeFormatter
 import java.time.{Instant, ZoneId}
+import java.util.concurrent.locks.ReentrantReadWriteLock
 
 /**
  * Mill launcher main entry point.
  */
 object MillLauncherMain {
+  private val systemPropertiesLock = new ReentrantReadWriteLock()
+
+  private[launcher] def withSystemProperties[T](properties: Map[String, String])(f: => T): T = {
+    // main0 is also used in-process by tests. Property-bearing invocations need exclusive access
+    // to process-global state, while ordinary invocations can still run concurrently.
+    val lock =
+      if (properties.isEmpty) systemPropertiesLock.readLock()
+      else systemPropertiesLock.writeLock()
+    lock.lock()
+    try {
+      val previous =
+        properties.keysIterator.map(key => key -> Option(System.getProperty(key))).toMap
+      properties.foreach { case (key, value) => System.setProperty(key, value) }
+      try f
+      finally {
+        previous.foreach {
+          case (key, Some(value)) => System.setProperty(key, value)
+          case (key, None) => System.clearProperty(key)
+        }
+      }
+    } finally lock.unlock()
+  }
+
   def main(args: Array[String]): Unit = {
     System.exit(main0(args, None, sys.env, os.pwd))
   }
@@ -24,6 +48,22 @@ object MillLauncherMain {
    */
   def main0(
       args: Array[String],
+      streamsOpt: Option[SystemStreams],
+      env: Map[String, String],
+      workDir: os.Path
+  ): Int = {
+    val parsedConfig = MillCliConfig.parse(args).toOption
+    val earlySystemProperties =
+      parsedConfig.fold(Map.empty[String, String])(_.extraSystemProperties)
+
+    withSystemProperties(earlySystemProperties) {
+      main0Processed(args, parsedConfig, streamsOpt, env, workDir)
+    }
+  }
+
+  private def main0Processed(
+      args: Array[String],
+      parsedConfig: Option[MillCliConfig],
       streamsOpt: Option[SystemStreams],
       env: Map[String, String],
       workDir: os.Path
@@ -39,7 +79,6 @@ object MillLauncherMain {
     // fixed cwd-parent.
     PathAliasing.withRawPathSerializer {
       val stderr = streamsOpt.map(_.err).getOrElse(System.err)
-      val parsedConfig = MillCliConfig.parse(args).toOption
 
       val bspServerMode = parsedConfig.exists(_.bsp.value)
       val bspMode = bspServerMode || parsedConfig.exists(_.bspInstall.value)

--- a/runner/launcher/test/src/mill/launcher/MillLauncherMainTests.scala
+++ b/runner/launcher/test/src/mill/launcher/MillLauncherMainTests.scala
@@ -1,0 +1,127 @@
+package mill.launcher
+
+import utest.*
+
+import java.nio.file.Files
+import java.security.KeyStore
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+import java.util.concurrent.atomic.AtomicReference
+import javax.net.ssl.{TrustManagerFactory, X509TrustManager}
+import scala.util.Using
+
+object MillLauncherMainTests extends TestSuite {
+  val tests = Tests {
+    test("withSystemProperties") {
+      test("restore") {
+        val existingKey = "mill.test.issue6888.existing"
+        val addedKey = "mill.test.issue6888.added"
+        val originalExisting = Option(System.getProperty(existingKey))
+        val originalAdded = Option(System.getProperty(addedKey))
+
+        try {
+          System.setProperty(existingKey, "original")
+          System.clearProperty(addedKey)
+
+          MillLauncherMain.withSystemProperties(
+            Map(existingKey -> "overridden", addedKey -> "added")
+          ) {
+            assert(System.getProperty(existingKey) == "overridden")
+            assert(System.getProperty(addedKey) == "added")
+          }
+
+          assert(System.getProperty(existingKey) == "original")
+          assert(System.getProperty(addedKey) == null)
+        } finally {
+          originalExisting match {
+            case Some(value) => System.setProperty(existingKey, value)
+            case None => System.clearProperty(existingKey)
+          }
+          originalAdded match {
+            case Some(value) => System.setProperty(addedKey, value)
+            case None => System.clearProperty(addedKey)
+          }
+        }
+      }
+
+      test("serializeConcurrentInvocations") {
+        val key = "mill.test.issue6888.concurrent"
+        val original = Option(System.getProperty(key))
+        val firstEntered = new CountDownLatch(1)
+        val releaseFirst = new CountDownLatch(1)
+        val secondStarted = new CountDownLatch(1)
+        val secondEntered = new CountDownLatch(1)
+        val threadFailure = new AtomicReference[Throwable]()
+
+        def captureFailure(run: => Unit): Unit =
+          try run
+          catch { case throwable: Throwable => threadFailure.compareAndSet(null, throwable) }
+
+        val first = new Thread(() =>
+          captureFailure {
+            MillLauncherMain.withSystemProperties(Map(key -> "first")) {
+              assert(System.getProperty(key) == "first")
+              firstEntered.countDown()
+              assert(releaseFirst.await(5, TimeUnit.SECONDS))
+              assert(System.getProperty(key) == "first")
+            }
+          }
+        )
+        val second = new Thread(() =>
+          captureFailure {
+            assert(firstEntered.await(5, TimeUnit.SECONDS))
+            secondStarted.countDown()
+            MillLauncherMain.withSystemProperties(Map(key -> "second")) {
+              assert(System.getProperty(key) == "second")
+              secondEntered.countDown()
+            }
+          }
+        )
+
+        try {
+          first.start()
+          second.start()
+          assert(secondStarted.await(5, TimeUnit.SECONDS))
+          assert(!secondEntered.await(250, TimeUnit.MILLISECONDS))
+          releaseFirst.countDown()
+          assert(secondEntered.await(5, TimeUnit.SECONDS))
+          first.join(5000)
+          second.join(5000)
+          assert(!first.isAlive, !second.isAlive)
+          Option(threadFailure.get()).foreach(throw _)
+        } finally {
+          releaseFirst.countDown()
+          first.join(5000)
+          second.join(5000)
+          original match {
+            case Some(value) => System.setProperty(key, value)
+            case None => System.clearProperty(key)
+          }
+        }
+      }
+
+      test("initializeJsseTrustStore") {
+        val password = "issue-6888".toCharArray
+        val trustStore = Files.createTempFile("mill-issue-6888-", ".p12")
+        val keyStore = KeyStore.getInstance("PKCS12")
+        keyStore.load(null, password)
+        Using.resource(Files.newOutputStream(trustStore))(keyStore.store(_, password))
+
+        try {
+          val acceptedIssuers = MillLauncherMain.withSystemProperties(Map(
+            "javax.net.ssl.trustStore" -> trustStore.toString,
+            "javax.net.ssl.trustStorePassword" -> String(password),
+            "javax.net.ssl.trustStoreType" -> "PKCS12"
+          )) {
+            val factory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm)
+            factory.init(null.asInstanceOf[KeyStore])
+            factory.getTrustManagers.collectFirst {
+              case manager: X509TrustManager => manager.getAcceptedIssuers.toSeq
+            }.get
+          }
+
+          assert(acceptedIssuers.isEmpty)
+        } finally Files.deleteIfExists(trustStore)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Vibe Coded

Normalize -J-D options through Mill's existing CLI parser and scope command-line system properties around launcher startup so Coursier observes settings such as custom trust stores. Restore properties for in-process callers and cover parsing, precedence, and subprocess propagation.

Fixes #6888
