### PR TITLE
Support .sc files as Scala scripts

### DIFF
--- a/core/eval/src/mill/eval/ScriptModuleInit.scala
+++ b/core/eval/src/mill/eval/ScriptModuleInit.scala
@@ -95,7 +95,7 @@ class ScriptModuleInit extends ((String, Evaluator) => Seq[Result[ExternalModule
         scriptFile.ext match {
           case "java" => Result.Success("mill.script.JavaModule")
           case "kt" => Result.Success("mill.script.KotlinModule")
-          case "scala" => Result.Success("mill.script.ScalaModule")
+          case "scala" | "sc" => Result.Success("mill.script.ScalaModule")
           case "groovy" => Result.Success("mill.script.GroovyModule")
           case _ =>
             Result.Failure(
@@ -245,7 +245,7 @@ class ScriptModuleInit extends ((String, Evaluator) => Seq[Result[ExternalModule
       }
   }
 
-  private val scriptExtensions = Set("scala", "java", "kt", "yaml")
+  private val scriptExtensions = Set("scala", "sc", "java", "kt", "yaml")
 
   /**
    * Discovers all script files in the given workspace directory.

--- a/integration/dedicated/bsp-server/src/BspServerTests.scala
+++ b/integration/dedicated/bsp-server/src/BspServerTests.scala
@@ -615,7 +615,7 @@ object BspServerTests extends UtestIntegrationTestSuite {
         createFolders = true
       )
       os.write.over(
-        workspacePath / "scripts/visible.scala",
+        workspacePath / "scripts/visible.sc",
         """object visible
           |""".stripMargin
       )
@@ -633,7 +633,7 @@ object BspServerTests extends UtestIntegrationTestSuite {
           .map(_.getId.getUri)
           .toSet
 
-        assert(targetUris.contains((workspacePath / "scripts/visible.scala").toURI.toASCIIString))
+        assert(targetUris.contains((workspacePath / "scripts/visible.sc").toURI.toASCIIString))
         assert(
           !targetUris.contains(
             (workspacePath / "gatling/gatling-app/src/main/scala/io/gatling/app/Analytics.scala")

--- a/integration/feature/script-main-forwarder-classes/resources/ExtensionAlias.sc
+++ b/integration/feature/script-main-forwarder-classes/resources/ExtensionAlias.sc
@@ -1,0 +1,2 @@
+@main
+def main1(text: String) = println(text + "SC")

--- a/integration/feature/script-main-forwarder-classes/src/ScriptMainForwarderClassesTests.scala
+++ b/integration/feature/script-main-forwarder-classes/src/ScriptMainForwarderClassesTests.scala
@@ -48,6 +48,9 @@ object ScriptMainForwarderClassesTests extends UtestIntegrationTestSuite {
       val res8 = eval(("OldScala.scala:allSourceFiles"))
       assert(!res8.isSuccess)
       assert(res8.err.contains("Scala scripts require Scala 3.7.3+. Detected scalaVersion=3.7.2."))
+
+      val res9 = eval(("ExtensionAlias.sc:runMain", "main1", "--text", "short-extension"))
+      assert(res9.out == "short-extensionSC")
     }
   }
 }


### PR DESCRIPTION
Vibe Coded

Recognize the short Scala script extension during both direct module resolution and shared BSP/IDEA discovery. Cover direct execution and BSP discovery with focused integration tests.

Fixes #6719
