### PR TITLE
Document SemanticDB version configuration

### DIFF
--- a/example/scalalib/module/19-semanticdb-versions/build.mill
+++ b/example/scalalib/module/19-semanticdb-versions/build.mill
@@ -1,0 +1,38 @@
+// Mill uses SemanticDB metadata for IDE features and other source-code tooling.
+// It provides default plugin versions, so most builds do not need any SemanticDB
+// configuration.
+//
+// Scala 2 requires a `semanticdb-scalac` compiler plugin published for the full
+// `scalaVersion`. Scala 3 provides SemanticDB support in the compiler itself, so
+// `semanticDbVersion` only affects Scala 2 sources. Java and mixed Scala/Java
+// modules use the separate `semanticDbJavaVersion` for Java sources.
+//
+// If the defaults do not support your compiler version, override the corresponding
+// task with a compatible plugin version. An explicit task override pins that exact
+// version.
+package build
+
+import mill.*, scalalib.*
+
+object `package` extends ScalaModule {
+  def scalaVersion = "2.13.18"
+  override def semanticDbVersion = "4.17.0"
+  override def semanticDbJavaVersion = "0.12.3"
+}
+
+// Tooling can instead request a minimum plugin version without changing the build
+// by setting `SEMANTICDB_VERSION` or `JAVASEMANTICDB_VERSION`. Mill uses the newer
+// of the requested version and its built-in version, so these variables cannot
+// downgrade the built-in defaults.
+
+/** Usage
+
+> ./mill show semanticDbVersion
+"4.17.0"
+
+> ./mill show semanticDbJavaVersion
+"0.12.3"
+
+> ./mill semanticDbData
+
+*/

--- a/example/scalalib/module/19-semanticdb-versions/src/Example.scala
+++ b/example/scalalib/module/19-semanticdb-versions/src/Example.scala
@@ -1,0 +1,5 @@
+package example
+
+object Example {
+  def message: String = JavaExample.message
+}

--- a/example/scalalib/module/19-semanticdb-versions/src/JavaExample.java
+++ b/example/scalalib/module/19-semanticdb-versions/src/JavaExample.java
@@ -1,0 +1,5 @@
+package example;
+
+public class JavaExample {
+  public static final String message = "hello";
+}

--- a/libs/javalib/src/mill/javalib/SemanticDbJavaModule.scala
+++ b/libs/javalib/src/mill/javalib/SemanticDbJavaModule.scala
@@ -40,6 +40,10 @@ trait SemanticDbJavaModule extends CoursierModule with SemanticDbJavaModuleApi
   private[mill] def compileClasspathTask(compileFor: CompileFor): Task[Seq[PathRef]]
   def moduleDeps: Seq[JavaModule]
 
+  /**
+   * Version of the SemanticDB compiler plugin used for Scala 2 sources.
+   * Scala 3 provides SemanticDB support in the compiler itself.
+   */
   def semanticDbVersion: T[String] = Task.Input {
     val builtin = SemanticDbJavaModuleApi.buildTimeSemanticDbVersion
     val requested = Task.env.getOrElse[String](
@@ -49,6 +53,7 @@ trait SemanticDbJavaModule extends CoursierModule with SemanticDbJavaModuleApi
     Version.chooseNewest(requested, builtin)(using Version.IgnoreQualifierOrdering)
   }
 
+  /** Version of the SemanticDB compiler plugin used for Java sources. */
   def semanticDbJavaVersion: T[String] = Task.Input {
     val builtin = SemanticDbJavaModuleApi.buildTimeJavaSemanticDbVersion
     val requested = Task.env.getOrElse[String](
@@ -85,7 +90,7 @@ trait SemanticDbJavaModule extends CoursierModule with SemanticDbJavaModuleApi
     if (sv.isEmpty) {
       val msg =
         """|
-           |You must provide a javaSemanticDbVersion
+           |You must provide a semanticDbJavaVersion
            |
            |def semanticDbJavaVersion = ???
            |""".stripMargin

--- a/libs/javalib/test/src/mill/javalib/SemanticDbJavaModuleTests.scala
+++ b/libs/javalib/test/src/mill/javalib/SemanticDbJavaModuleTests.scala
@@ -1,0 +1,80 @@
+package mill.javalib
+
+import mill.*
+import mill.api.{Discover, Evaluator, ExecResult}
+import mill.api.daemon.internal.SemanticDbJavaModuleApi
+import mill.testkit.{TestRootModule, UnitTester}
+import utest.*
+
+object SemanticDbJavaModuleTests extends TestSuite {
+
+  object VersionModules extends TestRootModule {
+    object defaults extends JavaModule
+
+    object pinned extends JavaModule {
+      override def semanticDbVersion: T[String] = Task { "1.2.3" }
+      override def semanticDbJavaVersion: T[String] = Task { "4.5.6" }
+    }
+
+    object missingJavaVersion extends JavaModule {
+      override def semanticDbJavaVersion: T[String] = Task { "" }
+    }
+
+    lazy val millDiscover = Discover[this.type]
+  }
+
+  def tests: Tests = Tests {
+    test("versions") {
+      test("defaults") - UnitTester(VersionModules, null).scoped { eval =>
+        val Right(scalaVersion) = eval.apply(VersionModules.defaults.semanticDbVersion).runtimeChecked
+        val Right(javaVersion) =
+          eval.apply(VersionModules.defaults.semanticDbJavaVersion).runtimeChecked
+
+        assert(
+          scalaVersion.value == SemanticDbJavaModuleApi.buildTimeSemanticDbVersion,
+          javaVersion.value == SemanticDbJavaModuleApi.buildTimeJavaSemanticDbVersion
+        )
+      }
+
+      test("environmentRequestsMinimumVersion") - UnitTester(
+        VersionModules,
+        null,
+        env = Evaluator.defaultEnv ++ Map(
+          "SEMANTICDB_VERSION" -> "999.0.0",
+          "JAVASEMANTICDB_VERSION" -> "0.0.1"
+        )
+      ).scoped { eval =>
+        val Right(scalaVersion) = eval.apply(VersionModules.defaults.semanticDbVersion).runtimeChecked
+        val Right(javaVersion) =
+          eval.apply(VersionModules.defaults.semanticDbJavaVersion).runtimeChecked
+
+        assert(
+          scalaVersion.value == "999.0.0",
+          javaVersion.value == SemanticDbJavaModuleApi.buildTimeJavaSemanticDbVersion
+        )
+      }
+
+      test("explicitOverridesPinVersion") - UnitTester(
+        VersionModules,
+        null,
+        env = Evaluator.defaultEnv ++ Map(
+          "SEMANTICDB_VERSION" -> "999.0.0",
+          "JAVASEMANTICDB_VERSION" -> "999.0.0"
+        )
+      ).scoped { eval =>
+        val Right(scalaVersion) = eval.apply(VersionModules.pinned.semanticDbVersion).runtimeChecked
+        val Right(javaVersion) =
+          eval.apply(VersionModules.pinned.semanticDbJavaVersion).runtimeChecked
+
+        assert(scalaVersion.value == "1.2.3", javaVersion.value == "4.5.6")
+      }
+    }
+
+    test("missingJavaVersionError") - UnitTester(VersionModules, null).scoped { eval =>
+      val Left(ExecResult.Failure(msg = message)) =
+        eval.apply(VersionModules.missingJavaVersion.semanticDbData).runtimeChecked
+
+      assert(message.contains("You must provide a semanticDbJavaVersion"))
+    }
+  }
+}

--- a/libs/javalib/test/src/mill/javalib/SemanticDbJavaModuleTests.scala
+++ b/libs/javalib/test/src/mill/javalib/SemanticDbJavaModuleTests.scala
@@ -26,7 +26,8 @@ object SemanticDbJavaModuleTests extends TestSuite {
   def tests: Tests = Tests {
     test("versions") {
       test("defaults") - UnitTester(VersionModules, null).scoped { eval =>
-        val Right(scalaVersion) = eval.apply(VersionModules.defaults.semanticDbVersion).runtimeChecked
+        val Right(scalaVersion) =
+          eval.apply(VersionModules.defaults.semanticDbVersion).runtimeChecked
         val Right(javaVersion) =
           eval.apply(VersionModules.defaults.semanticDbJavaVersion).runtimeChecked
 
@@ -44,7 +45,8 @@ object SemanticDbJavaModuleTests extends TestSuite {
           "JAVASEMANTICDB_VERSION" -> "0.0.1"
         )
       ).scoped { eval =>
-        val Right(scalaVersion) = eval.apply(VersionModules.defaults.semanticDbVersion).runtimeChecked
+        val Right(scalaVersion) =
+          eval.apply(VersionModules.defaults.semanticDbVersion).runtimeChecked
         val Right(javaVersion) =
           eval.apply(VersionModules.defaults.semanticDbJavaVersion).runtimeChecked
 

--- a/website/docs/modules/ROOT/pages/scalalib/module-config.adoc
+++ b/website/docs/modules/ROOT/pages/scalalib/module-config.adoc
@@ -27,6 +27,10 @@ include::partial$example/scalalib/module/3-docjar.adoc[]
 
 include::partial$example/scalalib/module/4-programmable-config.adoc[]
 
+=== SemanticDB Versions
+
+include::partial$example/scalalib/module/19-semanticdb-versions.adoc[]
+
 === Custom Tasks
 
 include::partial$example/scalalib/module/5-custom-tasks.adoc[]


### PR DESCRIPTION
Vibe Coded

Explain the Scala, Java, environment, and explicit-override version-selection rules with a runnable mixed-source example. Correct the Java SemanticDB failure message to name semanticDbJavaVersion and cover the selection and diagnostic behavior.

Fixes #4901
