### PR TITLE
Document build module access from meta-build sources

### DIFF
--- a/example/extending/metabuild/6-build-module-deps/app/src/App.java
+++ b/example/extending/metabuild/6-build-module-deps/app/src/App.java
@@ -1,0 +1,7 @@
+package app;
+
+public class App {
+  public static void main(String[] args) {
+    System.out.println(core.Core.greeting());
+  }
+}

--- a/example/extending/metabuild/6-build-module-deps/build.mill
+++ b/example/extending/metabuild/6-build-module-deps/build.mill
@@ -14,8 +14,7 @@ object app extends ApplicationModule
 //
 // The `build` alias then provides access to modules defined by `build.mill` and any discovered
 // `package.mill` files. Here, `ApplicationModule` uses `build.core` as a module dependency.
-// The `core` module must be defined in `core/package.mill`; naming that file `core/module.mill`
-// would not define or make the subfolder module discoverable.
+
 
 /** Usage
 

--- a/example/extending/metabuild/6-build-module-deps/build.mill
+++ b/example/extending/metabuild/6-build-module-deps/build.mill
@@ -1,0 +1,25 @@
+package build
+
+import mybuild.ApplicationModule
+
+object app extends ApplicationModule
+
+/** See Also: core/package.mill */
+/** See Also: mill-build/src/mybuild/ApplicationModule.scala */
+
+// Scala sources in `mill-build/src/` are compiled as part of the meta-build. Unlike
+// `build.mill` and `package.mill`, ordinary Scala sources do not receive Mill's automatic
+// `build` alias. Mill generates the root build object as `build_.package_`, so
+// `ApplicationModule.scala` imports it with `import build_.package_ as build`.
+//
+// The `build` alias then provides access to modules defined by `build.mill` and any discovered
+// `package.mill` files. Here, `ApplicationModule` uses `build.core` as a module dependency.
+// The `core` module must be defined in `core/package.mill`; naming that file `core/module.mill`
+// would not define or make the subfolder module discoverable.
+
+/** Usage
+
+> ./mill app.run
+Hello from core
+
+*/

--- a/example/extending/metabuild/6-build-module-deps/core/package.mill
+++ b/example/extending/metabuild/6-build-module-deps/core/package.mill
@@ -1,0 +1,5 @@
+package build.core
+
+import mill.*, javalib.*
+
+object `package` extends JavaModule

--- a/example/extending/metabuild/6-build-module-deps/core/src/Core.java
+++ b/example/extending/metabuild/6-build-module-deps/core/src/Core.java
@@ -1,0 +1,7 @@
+package core;
+
+public class Core {
+  public static String greeting() {
+    return "Hello from core";
+  }
+}

--- a/example/extending/metabuild/6-build-module-deps/mill-build/src/mybuild/ApplicationModule.scala
+++ b/example/extending/metabuild/6-build-module-deps/mill-build/src/mybuild/ApplicationModule.scala
@@ -1,0 +1,8 @@
+package mybuild
+
+import build_.package_ as build
+import mill.javalib.JavaModule
+
+trait ApplicationModule extends JavaModule {
+  override def moduleDeps = Seq(build.core)
+}

--- a/website/docs/modules/ROOT/pages/extending/meta-build.adoc
+++ b/website/docs/modules/ROOT/pages/extending/meta-build.adoc
@@ -37,3 +37,7 @@ include::partial$example/extending/metabuild/4-meta-build.adoc[]
 == Sharing Source Code between `build.mill` and Application Code
 
 include::partial$example/extending/metabuild/5-meta-shared-sources.adoc[]
+
+== Accessing Build Modules from Meta-Build Sources
+
+include::partial$example/extending/metabuild/6-build-module-deps.adoc[]


### PR DESCRIPTION
Vibe Coded

Add a runnable meta-build example showing how ordinary Scala sources import the generated root build object and reference a subfolder module. Clarify that subfolder modules must use package.mill, not the obsolete module.mill filename from the original report.

Fixes #3835
