### PR TITLE
Fix SemanticDB paths with custom JVMs

### DIFF
--- a/libs/javalib/worker/src/mill/javalib/zinc/ZincWorker.scala
+++ b/libs/javalib/worker/src/mill/javalib/zinc/ZincWorker.scala
@@ -430,8 +430,12 @@ class ZincWorker(jobs: Int, useFileLocks: Boolean = false) extends AutoCloseable
     val classpath = (compileClasspathPaths.iterator ++ Some(classesDir))
       .map(path => converter.toVirtualFile(path.toNIO))
       .toArray
+    // Compiler plugins compare virtual source paths with options such as SemanticDB's sourceroot.
+    // Keep OS-Lib's reproducible path aliases out of that compiler-facing boundary.
+    val resolvedWorkspaceRoot = PathRef.toResolvedOsPath(localConfig.workspaceRoot)
     val virtualSources = sources.iterator
-      .map(path => converter.toVirtualFile(path.toNIO))
+      .map(PathRef.toResolvedOsPathAnchored(_, resolvedWorkspaceRoot))
+      .map(path => converter.toVirtualFile(PathRef.toAbsNioPath(path)))
       .toArray
 
     val externalHooks = new DefaultExternalHooks(

--- a/libs/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/libs/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -684,11 +684,12 @@ trait ScalaModule extends JavaModule with TestModule.ScalaModuleBase
   override def semanticDbDataDetailed: T[SemanticDbJavaModule.SemanticDbData] =
     Task(persistent = true) {
       val sv = scalaVersion()
+      val semanticDbSourceRoot = PathRef.toResolvedPathString(BuildCtx.workspaceRoot)
 
       val additionalScalacOptions = if (isScala3(sv)) {
-        Seq("-Xsemanticdb", s"-sourceroot:${BuildCtx.workspaceRoot}")
+        Seq("-Xsemanticdb", s"-sourceroot:$semanticDbSourceRoot")
       } else {
-        Seq("-Yrangepos", s"-P:semanticdb:sourceroot:${BuildCtx.workspaceRoot}")
+        Seq("-Yrangepos", s"-P:semanticdb:sourceroot:$semanticDbSourceRoot")
       }
 
       val scalacOptions = (

--- a/libs/scalalib/test/src/mill/scalalib/ScalaSemanticDbTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/ScalaSemanticDbTests.scala
@@ -14,6 +14,18 @@ object ScalaSemanticDbTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
+  class SemanticWorldWithJvm(scalaVersion0: String) extends TestRootModule {
+    object core extends SemanticModule {
+      override def scalaVersion = scalaVersion0
+      override def jvmVersion = "17"
+    }
+
+    lazy val millDiscover = Discover[this.type]
+  }
+
+  object Scala2SemanticWorldWithJvm extends SemanticWorldWithJvm(scala213Version)
+  object Scala3SemanticWorldWithJvm extends SemanticWorldWithJvm(scala33Version)
+
   def tests: Tests = Tests {
 
     test("semanticDbData") {
@@ -124,6 +136,28 @@ object ScalaSemanticDbTests extends TestSuite {
           )
         }
       }
+    }
+
+    test("semanticDbDataWithJvmVersion") {
+      def check(world: SemanticWorldWithJvm): Unit =
+        UnitTester(world, sourceRoot = resourcePath).scoped { eval =>
+          val Right(result) = eval.apply(world.core.semanticDbData).runtimeChecked
+          val semanticDbFiles = os
+            .walk(result.value.path)
+            .filter(path => os.isFile(path) && path.ext == "semanticdb")
+            .map(_.relativeTo(result.value.path))
+            .toSet
+
+          assert(
+            semanticDbFiles == Set(
+              os.sub / "META-INF/semanticdb/core/src/Main.scala.semanticdb",
+              os.sub / "META-INF/semanticdb/core/src/Result.scala.semanticdb"
+            )
+          )
+        }
+
+      test("scala2") - check(Scala2SemanticWorldWithJvm)
+      test("scala3") - check(Scala3SemanticWorldWithJvm)
     }
 
   }


### PR DESCRIPTION
Vibe Coded

Resolve reproducible workspace aliases before Zinc exposes source paths to compiler plugins, and pass SemanticDB a resolved absolute sourceroot. This keeps forked compiler workers in the same path coordinate system as local workers.

Cover Scala 2 and Scala 3 custom-JVM modules while retaining the existing default-JVM and incremental SemanticDB coverage.

Fixes #7376