### PR TITLE
Prioritize forked work during executor awaits

### DIFF
--- a/core/api/daemon/src/mill/api/daemon/internal/PriorityRunnable.scala
+++ b/core/api/daemon/src/mill/api/daemon/internal/PriorityRunnable.scala
@@ -15,12 +15,19 @@ private[mill] class PriorityRunnable(val priority: Int, run0: () => Unit)
 
   val priorityRunnableIndex: Long = PriorityRunnable.priorityRunnableCount.getAndIncrement()
 
+  // Lower groups win ties before submission order is considered.
+  private[mill] def samePriorityGroup: Int = 0
+
   override def compareTo(o: PriorityRunnable): Int = priority.compareTo(o.priority) match {
     case 0 =>
-      // `Comparable` wants a total ordering. This index is assigned when a task
-      // is submitted, so equal-priority work runs in submission order.
-      assert(this == o || this.priorityRunnableIndex != o.priorityRunnableIndex)
-      this.priorityRunnableIndex.compareTo(o.priorityRunnableIndex)
+      samePriorityGroup.compareTo(o.samePriorityGroup) match {
+        case 0 =>
+          // `Comparable` wants a total ordering. This index is assigned when a task
+          // is submitted, so equal-priority work runs in submission order.
+          assert(this == o || this.priorityRunnableIndex != o.priorityRunnableIndex)
+          this.priorityRunnableIndex.compareTo(o.priorityRunnableIndex)
+        case n => n
+      }
     case n => n
   }
 }

--- a/core/exec/src/mill/exec/ExecutionContexts.scala
+++ b/core/exec/src/mill/exec/ExecutionContexts.scala
@@ -45,7 +45,29 @@ object ExecutionContexts {
    * and AutoCloseable support
    */
   class ThreadPool(executor: ThreadPoolExecutor) extends mill.api.TaskCtx.Fork.Impl {
-    def await[T](t: Future[T]): T = blocking { Await.result(t, Duration.Inf) }
+    private class AsyncRunnable(priority: Int, run0: () => Unit)
+        extends PriorityRunnable(priority, run0) {
+      override private[mill] def samePriorityGroup: Int = -1
+    }
+
+    private def runNextQueuedAsync(): Boolean =
+      executor.getQueue.poll() match {
+        case runnable: AsyncRunnable =>
+          runnable.run()
+          true
+        case null => false
+        case runnable =>
+          // A higher-priority ordinary task may have arrived before the poll.
+          // Its stable PriorityRunnable index preserves its place when reinserted.
+          executor.getQueue.add(runnable)
+          false
+      }
+
+    def await[T](t: Future[T]): T = {
+      while (!t.isCompleted && runNextQueuedAsync()) ()
+      if (t.isCompleted) Await.result(t, Duration.Inf)
+      else blocking { Await.result(t, Duration.Inf) }
+    }
 
     // Synchronize on the underlying `executor`: concurrent launchers
     // share one daemon-level executor across multiple `ThreadPool`
@@ -94,6 +116,15 @@ object ExecutionContexts {
      * folder [[dest]] and duplicates the logging streams to [[dest]].log while evaluating
      * [[t]], to avoid conflict with other tasks that may be running concurrently
      */
+    private[exec] def async0[T](priority: Int)(t: => T): Future[T] = {
+      val promise = concurrent.Promise[T]()
+      executor.execute(new AsyncRunnable(
+        priority = priority,
+        run0 = () => promise.complete(NonFatal.Try(t))
+      ))
+      promise.future
+    }
+
     def async[T](dest: Path, key: String, message: String, priority: Int)(t: Logger => T)(using
         ctx: mill.api.TaskCtx
     ): Future[T] = {
@@ -108,19 +139,11 @@ object ExecutionContexts {
         pwd = () => lazyDest.get(),
         streams = logger.streams
       )
-      val promise = concurrent.Promise[T]()
-      val runnable = new PriorityRunnable(
-        priority = priority,
-        run0 = () => {
-          val result = NonFatal.Try(logger.withPromptLine {
-            submitterContext.bind(t(logger))
-          })
-          promise.complete(result)
+      async0(priority) {
+        logger.withPromptLine {
+          submitterContext.bind(t(logger))
         }
-      )
-
-      executor.execute(runnable)
-      promise.future
+      }
     }
   }
 
@@ -134,8 +157,7 @@ object ExecutionContexts {
       60,
       TimeUnit.SECONDS,
       // Use a priority queue so child `fork.async` tasks can run ahead of
-      // lower-priority parent tasks, avoiding large numbers of blocked parent
-      // tasks from piling up.
+      // same- or lower-priority parent tasks that may await them.
       PriorityBlockingQueue[Runnable](),
       runnable => {
         val threadIndex = threadCounter.incrementAndGet()

--- a/core/exec/test/src/mill/exec/ExecutionContextsTests.scala
+++ b/core/exec/test/src/mill/exec/ExecutionContextsTests.scala
@@ -2,7 +2,14 @@ package mill.exec
 
 import utest.*
 
-import java.util.concurrent.{CountDownLatch, TimeUnit}
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.{
+  ConcurrentLinkedQueue,
+  CountDownLatch,
+  PriorityBlockingQueue,
+  ThreadPoolExecutor,
+  TimeUnit
+}
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Future, Promise}
 
@@ -71,6 +78,51 @@ object ExecutionContextsTests extends TestSuite {
           executor.shutdownNow()
           executor.awaitTermination(5, TimeUnit.SECONDS)
         }
+      }
+    }
+
+    test("awaitingAsyncChildrenDoesNotCreateAWorkerPerParent") {
+      val threadCount = 4
+      val parentCount = 100
+      val childrenPerParent = 8
+      val createdWorkers = AtomicInteger()
+      val executor = ThreadPoolExecutor(
+        threadCount,
+        threadCount,
+        60,
+        TimeUnit.SECONDS,
+        PriorityBlockingQueue[Runnable](),
+        runnable => {
+          createdWorkers.incrementAndGet()
+          Thread(runnable)
+        }
+      )
+      val pool = ExecutionContexts.ThreadPool(executor)
+      val startParents = CountDownLatch(1)
+      val parentsDone = CountDownLatch(parentCount)
+      val failures = ConcurrentLinkedQueue[Throwable]()
+
+      try {
+        for (_ <- 0 until parentCount) pool.execute(() => {
+          try {
+            startParents.await()
+            val children = Seq.fill(childrenPerParent)(pool.async0(priority = 0)(()))
+            children.foreach(pool.await)
+          } catch {
+            case t: Throwable => failures.add(t)
+          } finally parentsDone.countDown()
+        })
+
+        startParents.countDown()
+        assert(parentsDone.await(10, TimeUnit.SECONDS))
+        assert(failures.isEmpty)
+        // A child already claimed by another worker can still need a compensation
+        // thread, but worker creation must scale with --jobs, not queued parents.
+        assert(createdWorkers.get() <= threadCount * 4)
+      } finally {
+        startParents.countDown()
+        executor.shutdownNow()
+        executor.awaitTermination(5, TimeUnit.SECONDS)
       }
     }
   }


### PR DESCRIPTION
Default-priority fork children were queued behind already-submitted parent tasks. Each waiting parent then entered managed blocking, causing another parent to start and repeat the cycle until worker creation scaled with the number of queued parents.

Order fork runnables ahead of ordinary work at the same explicit priority and let awaiting workers execute queued fork work directly. Preserve numeric priority ordering and managed compensation for ordinary futures, lock waits, and fork work that is already running or intentionally lower priority.

Fixes #7381
