### PR TITLE
Make script paths absolute in subprocess arguments

### DIFF
--- a/core/api/java11/src/mill/api/PathRef.scala
+++ b/core/api/java11/src/mill/api/PathRef.scala
@@ -44,7 +44,7 @@ case class PathRef private[mill] (
 }
 
 object PathRef {
-  implicit def shellable(p: PathRef): os.Shellable = p.path
+  implicit def shellable(p: PathRef): os.Shellable = os.Shellable(Seq(toAbsString(p)))
 
   /**
    * Real on-disk absolute path string for `p`, bypassing any `os.Path` serializer

--- a/core/api/test/src/mill/api/PathRefTests.scala
+++ b/core/api/test/src/mill/api/PathRefTests.scala
@@ -107,6 +107,22 @@ object PathRefTests extends TestSuite {
       test("qref") - check(quick = true)
       test("ref") - check(quick = false)
     }
+
+    test("shellableUsesAbsolutePath") - withTmpDir { tmpDir =>
+      val file = tmpDir / "script"
+      os.write(file, "script")
+      val pathRef = PathRef(file)
+      val serializer = os.Path.pathRemapSerializerNio(
+        Seq(tmpDir.wrapped -> java.nio.file.Paths.get("..", "mill-workspace"))
+      )
+
+      os.Path.pathSerializer.withValue(serializer) {
+        assert(
+          file.toString.startsWith(".."),
+          os.proc(pathRef).commandChunks == Seq(PathRef.toAbsString(file))
+        )
+      }
+    }
   }
 
   private def withTmpDir[T](body: os.Path => T): T = {

--- a/integration/feature/script-relative-paths/resources/build.mill
+++ b/integration/feature/script-relative-paths/resources/build.mill
@@ -1,0 +1,25 @@
+package build
+
+import mill.*
+
+object Scripts extends Module {
+  def myScript = Task {
+    if (scala.util.Properties.isWin) "@echo off\r\necho hi from Script\r\necho %*\r\n"
+    else "#!/bin/sh\necho hi from Script\necho \"$@\"\n"
+  }
+
+  def myScriptPath = Task {
+    val extension = if (scala.util.Properties.isWin) ".cmd" else ".sh"
+    val scriptFile = Task.dest / s"my-script$extension"
+    os.write(scriptFile, myScript(), perms = "rwxr-xr-x")
+    scriptFile
+  }
+
+  def runScript = Task {
+    val script = myScriptPath()
+    val command =
+      if (scala.util.Properties.isWin) os.proc("cmd.exe", "/c", script, "hi from Mill")
+      else os.proc(script, "hi from Mill")
+    command.call(stdout = os.Inherit, cwd = build.moduleDir)
+  }
+}

--- a/integration/feature/script-relative-paths/src/ScriptRelativePathsTests.scala
+++ b/integration/feature/script-relative-paths/src/ScriptRelativePathsTests.scala
@@ -1,0 +1,18 @@
+package mill.integration
+
+import mill.testkit.UtestIntegrationTestSuite
+import utest.*
+
+object ScriptRelativePathsTests extends UtestIntegrationTestSuite {
+  val tests: Tests = Tests {
+    test("taskDestScriptRunsFromModuleDir") - integrationTest { tester =>
+      val result = tester.eval("Scripts.runScript")
+
+      assert(
+        result.isSuccess,
+        result.out.contains("hi from Script"),
+        result.out.contains("hi from Mill")
+      )
+    }
+  }
+}

--- a/libs/util/src/mill/package.scala
+++ b/libs/util/src/mill/package.scala
@@ -4,4 +4,13 @@
  * APIs are mostly in [[mill.api]] and [[mill.util]], while `*lib` packages like [[mill.javalib]],
  * [[mill.scalalib]], and [[mill.kotlinlib]] contain the language-specific toolchains.
  */
-package object mill
+package object mill {
+
+  /**
+   * Process arguments must not depend on the cwd in which an `os.Path` happened to be converted.
+   * `os.proc` converts its arguments before `.call(cwd = ...)` is evaluated, so a reproducible
+   * `../mill-workspace` alias can otherwise be invalid for the subprocess's actual cwd.
+   */
+  implicit def pathToShellable(path: os.Path): os.Shellable =
+    os.Shellable(Seq(mill.api.PathRef.toAbsString(path)))
+}

--- a/libs/util/test/src/millpathtest/PathShellableTests.scala
+++ b/libs/util/test/src/millpathtest/PathShellableTests.scala
@@ -1,0 +1,26 @@
+package millpathtest
+
+import mill.*
+import utest.*
+
+object PathShellableTests extends TestSuite {
+  val tests: Tests = Tests {
+    test("usesAbsolutePath") {
+      val tmpDir = os.temp.dir()
+      try {
+        val script = tmpDir / "script"
+        os.write(script, "script")
+        val serializer = os.Path.pathRemapSerializerNio(
+          Seq(tmpDir.wrapped -> java.nio.file.Paths.get("..", "mill-workspace"))
+        )
+
+        os.Path.pathSerializer.withValue(serializer) {
+          assert(
+            script.toString.startsWith(".."),
+            os.proc(script).commandChunks == Seq(PathRef.toAbsString(script))
+          )
+        }
+      } finally os.remove.all(tmpDir)
+    }
+  }
+}


### PR DESCRIPTION
OS-Lib converts os.Path values to Shellable before a later call or spawn supplies its working directory. Reproducible path aliases were therefore rendered for the task directory and could not be resolved when the subprocess used another cwd, such as build.moduleDir.

Convert os.Path values imported through mill.* and PathRef values to real absolute process arguments while leaving ordinary cached path serialization reproducible. Add unit and end-to-end coverage for scripts generated under Task.dest and launched from a module directory.

Fixes #7299
