### PR TITLE
Prevent same-launcher task lock contention

### DIFF
--- a/core/exec/src/mill/exec/Execution.scala
+++ b/core/exec/src/mill/exec/Execution.scala
@@ -557,6 +557,13 @@ object Execution {
     // visits only those instead of scanning the whole graph. A `State` has at
     // most one retained, so membership mirrors `Retained.dropped` exactly.
     private val droppedStates = ConcurrentHashMap.newKeySet[State]()
+    private class LocalVersionState {
+      var latestVersion: Long = Long.MinValue
+    }
+    private val localVersionsByKey = new ConcurrentHashMap[String, LocalVersionState]()
+
+    private def localVersionState(key: String): LocalVersionState =
+      localVersionsByKey.computeIfAbsent(key, _ => LocalVersionState())
 
     def hasDropped: Boolean = !droppedStates.isEmpty
 
@@ -648,15 +655,32 @@ object Execution {
           clearDropped(s, s.retained)
           if (s.retained.lease != null) closeQuietly(s.retained.lease)
         }
+        val key = path.toAbsolutePath.normalize().toString
+        localVersionState(key)
         s.retained = Retained(
           path = path,
           label = label,
-          key = path.toAbsolutePath.normalize().toString,
+          key = key,
           lease = lease,
           observedVersion = observedVersion
         )
       }
       else closeQuietly(lease)
+    }
+
+    /**
+     * A task lock only coordinates different launcher runs, so writes by this
+     * evaluation are compatible with its own retained leases. Record their
+     * latest version so reacquisition can still detect writes by another
+     * launcher.
+     */
+    def markLocallyWritten(key: String)(write: => Long): Long = {
+      val state = localVersionState(key)
+      state.synchronized {
+        val version = write
+        state.latestVersion = math.max(state.latestVersion, version)
+        version
+      }
     }
 
     def releaseHigherThan(key: String): Unit = {
@@ -711,9 +735,13 @@ object Execution {
               case Right(lease) => lease
               case Left(_) => throw RetryDueToDroppedTaskLock(retained.label)
             }
-          }
-        val currentVersion = workspaceLocking.taskVersion(retained.path)
-        if (currentVersion != retained.observedVersion) {
+        }
+        val localVersion = localVersionState(retained.key)
+        val versionMatches = localVersion.synchronized {
+          val currentVersion = workspaceLocking.taskVersion(retained.path)
+          currentVersion == math.max(retained.observedVersion, localVersion.latestVersion)
+        }
+        if (!versionMatches) {
           closeQuietly(lease)
           throw RetryDueToDroppedTaskLock(retained.label)
         }

--- a/core/exec/src/mill/exec/Execution.scala
+++ b/core/exec/src/mill/exec/Execution.scala
@@ -735,7 +735,7 @@ object Execution {
               case Right(lease) => lease
               case Left(_) => throw RetryDueToDroppedTaskLock(retained.label)
             }
-        }
+          }
         val localVersion = localVersionState(retained.key)
         val versionMatches = localVersion.synchronized {
           val currentVersion = workspaceLocking.taskVersion(retained.path)

--- a/core/exec/src/mill/exec/TaskLockCoordinator.scala
+++ b/core/exec/src/mill/exec/TaskLockCoordinator.scala
@@ -120,7 +120,8 @@ private[exec] final class TaskLockCoordinator(
 
   def currentVersion: Long = workspaceLocking.taskVersion(taskLockPath)
 
-  def markTaskWritten(): Long = workspaceLocking.markTaskWritten(taskLockPath)
+  def markTaskWritten(): Long =
+    leaseTracker.markLocallyWritten(taskLockKey)(workspaceLocking.markTaskWritten(taskLockPath))
 
   def withActiveConsumers[T](body: => T): T =
     leaseTracker.withActiveConsumers(labelled, () => tryReacquireDroppedReads())(body)

--- a/core/exec/test/src/mill/exec/PlanTests.scala
+++ b/core/exec/test/src/mill/exec/PlanTests.scala
@@ -356,6 +356,39 @@ object PlanTests extends TestSuite {
       tracker.drain()
     }
 
+    test("leaseTrackerAcceptsLocalWritesButRetriesOnPeerWrites") {
+      import transitiveLeaseChain.*
+
+      val tracker = new Execution.LeaseTracker(
+        Array(a, b, c),
+        Map(a -> Nil, b -> Seq(a), c -> Seq(b))
+      )
+      val locking = new TestLocking
+      val aPath = Paths.get("/tmp/mill-lock-test/a")
+      val bPath = Paths.get("/tmp/mill-lock-test/b")
+      val aKey = aPath.toAbsolutePath.normalize().toString
+      val bKey = bPath.toAbsolutePath.normalize().toString
+
+      tracker.markLocallyWritten(bKey)(locking.markTaskWritten(bPath))
+      tracker.markLocallyWritten(bKey)(locking.markTaskWritten(bPath))
+
+      tracker.retain(b, bPath, "b", new TestLease, 0L)
+      tracker.releaseHigherThan(aKey)
+      tracker.reacquireDropped(locking, LauncherLocking.WaitReporter.Noop)
+
+      tracker.releaseHigherThan(aKey)
+      locking.markTaskWritten(bPath)
+      val retry =
+        try {
+          tracker.reacquireDropped(locking, LauncherLocking.WaitReporter.Noop)
+          throw new java.lang.AssertionError("expected retry")
+        } catch {
+          case e: Execution.RetryDueToDroppedTaskLock => e
+        }
+      assert(retry.label == "b")
+      tracker.drain()
+    }
+
     test("leaseTrackerNonBlockingReacquireRetriesOnContention") {
       import transitiveLeaseChain.*
 

--- a/core/internal/src/mill/internal/CrossThreadRwLock.scala
+++ b/core/internal/src/mill/internal/CrossThreadRwLock.scala
@@ -8,22 +8,34 @@ import mill.api.daemon.internal.LauncherLocking.{Contention, Lease, LockKind, Wa
  * and released on separate threads. `label` is the human-readable name used in
  * waiting/blocking messages; uniqueness across locks is the registry's
  * responsibility (e.g. [[LauncherLockRegistry]]'s map key), not the lock's.
+ * `allowSameOwnerOverlap` is used only for task locks, which coordinate separate
+ * launcher runs rather than tasks within one run.
  */
 class CrossThreadRwLock(
     label: String,
     showLabelInMessage: Boolean = true,
-    syntheticPrefix: Seq[String] = Nil
+    syntheticPrefix: Seq[String] = Nil,
+    allowSameOwnerOverlap: Boolean = false
 ) {
   import CrossThreadRwLock.HolderInfo
 
   private val monitor = new Object
   private var readerCount = 0
-  private var writerActive = false
+  private var writerCount = 0
   private var waitingWriters = 0
   private val holders = new java.util.LinkedHashMap[Lease, HolderInfo]()
 
-  private def canAcquireRead: Boolean = !writerActive && waitingWriters == 0
-  private def canAcquireWrite: Boolean = !writerActive && readerCount == 0
+  private def sameOwnerAsAllHolders(acquirer: HolderInfo): Boolean =
+    allowSameOwnerOverlap &&
+      acquirer.ownerId.nonEmpty &&
+      !holders.isEmpty &&
+      holders.values().stream().allMatch(_.ownerId == acquirer.ownerId)
+
+  private def canAcquireRead(acquirer: HolderInfo): Boolean =
+    sameOwnerAsAllHolders(acquirer) || (writerCount == 0 && waitingWriters == 0)
+
+  private def canAcquireWrite(acquirer: HolderInfo): Boolean =
+    sameOwnerAsAllHolders(acquirer) || (writerCount == 0 && readerCount == 0)
 
   private def currentBlocker(): Option[HolderInfo] = {
     val it = holders.values().iterator()
@@ -49,9 +61,9 @@ class CrossThreadRwLock(
     val isWrite = kind == LockKind.Write
 
     val leaseOpt = monitor.synchronized {
-      val available = if (isWrite) canAcquireWrite else canAcquireRead
+      val available = if (isWrite) canAcquireWrite(acquirer) else canAcquireRead(acquirer)
       if (available) {
-        if (isWrite) writerActive = true else readerCount += 1
+        if (isWrite) writerCount += 1 else readerCount += 1
         val lease = newLease(initiallyWrite = isWrite)
         holders.put(lease, acquirer)
         Some(lease)
@@ -77,7 +89,7 @@ class CrossThreadRwLock(
         monitor.synchronized {
           try {
             while ({
-              val available = if (isWrite) canAcquireWrite else canAcquireRead
+              val available = if (isWrite) canAcquireWrite(acquirer) else canAcquireRead(acquirer)
               !available
             }) monitor.wait()
           } catch {
@@ -89,7 +101,7 @@ class CrossThreadRwLock(
               throw e
           }
           if (isWrite) waitingWriters -= 1
-          if (isWrite) writerActive = true else readerCount += 1
+          if (isWrite) writerCount += 1 else readerCount += 1
           val lease = newLease(initiallyWrite = isWrite)
           holders.put(lease, acquirer)
           lease
@@ -109,15 +121,15 @@ class CrossThreadRwLock(
    *
    * Crucially: a failed try does NOT increment [[waitingWriters]], so the
    * caller's subsequent Read attempts won't trip writer-priority
-   * (`canAcquireRead = !writerActive && waitingWriters == 0`). This is
+   * (`canAcquireRead = writerCount == 0 && waitingWriters == 0`). This is
    * what makes the retryable read-then-write pattern in
    * [[LockUpgrade.readThenWrite]] work: a launcher can fail to grab Write,
    * fall back to Read, and re-probe shared state without poisoning its
    * own next Read attempt.
    */
   def tryAcquireWrite(acquirer: HolderInfo): Either[Contention, Lease] = monitor.synchronized {
-    if (canAcquireWrite) {
-      writerActive = true
+    if (canAcquireWrite(acquirer)) {
+      writerCount += 1
       val lease = newLease(initiallyWrite = true)
       holders.put(lease, acquirer)
       Right(lease)
@@ -135,7 +147,7 @@ class CrossThreadRwLock(
    * caller as a waiter.
    */
   def tryAcquireRead(acquirer: HolderInfo): Either[Contention, Lease] = monitor.synchronized {
-    if (canAcquireRead) {
+    if (canAcquireRead(acquirer)) {
       readerCount += 1
       val lease = newLease(initiallyWrite = false)
       holders.put(lease, acquirer)
@@ -166,7 +178,7 @@ class CrossThreadRwLock(
 
     override def downgradeToRead(): Unit = monitor.synchronized {
       if (!closed && !readMode) {
-        writerActive = false
+        writerCount -= 1
         readerCount += 1
         readMode = true
         monitor.notifyAll()
@@ -176,7 +188,7 @@ class CrossThreadRwLock(
     override def close(): Unit = monitor.synchronized {
       if (!closed) {
         if (readMode) readerCount -= 1
-        else writerActive = false
+        else writerCount -= 1
         closed = true
         holders.remove(self)
         monitor.notifyAll()
@@ -186,5 +198,5 @@ class CrossThreadRwLock(
 }
 
 object CrossThreadRwLock {
-  case class HolderInfo(pid: Long, command: String)
+  case class HolderInfo(pid: Long, command: String, ownerId: String = "")
 }

--- a/core/internal/src/mill/internal/LauncherLockRegistry.scala
+++ b/core/internal/src/mill/internal/LauncherLockRegistry.scala
@@ -39,7 +39,12 @@ private[mill] class LauncherLockRegistry {
   ): CrossThreadRwLock =
     taskLocks.computeIfAbsent(
       normalizedAbsolutePath,
-      _ => CrossThreadRwLock(label = displayLabel, showLabelInMessage = false)
+      _ =>
+        CrossThreadRwLock(
+          label = displayLabel,
+          showLabelInMessage = false,
+          allowSameOwnerOverlap = true
+        )
     )
 
   def taskVersion(normalizedAbsolutePath: String): Long =

--- a/core/internal/src/mill/internal/LauncherLockingImpl.scala
+++ b/core/internal/src/mill/internal/LauncherLockingImpl.scala
@@ -14,7 +14,7 @@ private[mill] class LauncherLockingImpl(
     lockRegistry: LauncherLockRegistry,
     val runId: String
 ) extends LauncherLocking {
-  private val holder = HolderInfo(launcherPid, activeCommandMessage)
+  private val holder = HolderInfo(launcherPid, activeCommandMessage, runId)
   private val closed = AtomicBoolean(false)
   private val activeLeases = scala.collection.mutable.Set.empty[LeaseWrapper]
   private val exclusiveWriteCount = AtomicInteger(0)

--- a/core/internal/test/src/mill/internal/CrossThreadRwLockTests.scala
+++ b/core/internal/test/src/mill/internal/CrossThreadRwLockTests.scala
@@ -13,6 +13,35 @@ object CrossThreadRwLockTests extends TestSuite {
   private val testHolder = HolderInfo(pid = 1234, command = "unit-test")
 
   val tests: Tests = Tests {
+    test("same-owner-task-leases-overlap-but-other-owners-block") {
+      val lock = CrossThreadRwLock("same-owner", allowSameOwnerOverlap = true)
+      val owner1 = HolderInfo(pid = 1234, command = "first", ownerId = "run-1")
+      val owner2 = HolderInfo(pid = 5678, command = "second", ownerId = "run-2")
+
+      val read = lock.acquire(
+        LockKind.Read,
+        LauncherLocking.WaitReporter.Noop,
+        noWait = false,
+        owner1
+      )
+      val write = lock.tryAcquireWrite(owner1).toOption.get
+      val secondWrite = lock.tryAcquireWrite(owner1).toOption.get
+      val secondRead = lock.tryAcquireRead(owner1).toOption.get
+
+      assert(lock.tryAcquireRead(owner2).isLeft)
+      assert(lock.tryAcquireWrite(owner2).isLeft)
+
+      write.downgradeToRead()
+      secondWrite.close()
+      secondRead.close()
+      read.close()
+      assert(lock.tryAcquireWrite(owner2).isLeft)
+
+      write.close()
+      val owner2Write = lock.tryAcquireWrite(owner2).toOption.get
+      owner2Write.close()
+    }
+
     test("allows-concurrent-reads") {
       val waitingBytes = ByteArrayOutputStream()
       val waitingErr = PrintStream(waitingBytes)

--- a/integration/dedicated/concurrency/resources/build.mill
+++ b/integration/dedicated/concurrency/resources/build.mill
@@ -5,6 +5,19 @@ import mill.*
 object `package` extends mill.Module {
   val fastSuffix = 0
 
+  object sharedOffline extends Module {
+    def prepareOffline() = Task.Command { "prepared" }
+  }
+
+  trait OfflineModule extends Module {
+    def prepareOffline() = Task.Command { sharedOffline.prepareOffline()() }
+  }
+
+  object offline0 extends OfflineModule
+  object offline1 extends OfflineModule
+  object offline2 extends OfflineModule
+  object offline3 extends OfflineModule
+
   private def workspace = mill.api.BuildCtx.workspaceRoot
 
   private def gate(name: String) = workspace / s"$name-wait"

--- a/integration/dedicated/concurrency/src/ConcurrencyTests.scala
+++ b/integration/dedicated/concurrency/src/ConcurrencyTests.scala
@@ -103,6 +103,15 @@ object ConcurrencyTests extends UtestIntegrationTestSuite {
     if (os.exists(waitFile)) os.remove(waitFile)
 
   val tests: Tests = Tests {
+    test("prepare-offline-does-not-contend-with-the-same-launcher") - integrationTest { tester =>
+      import tester.*
+      assert(tester.daemonMode)
+
+      val result = eval(("__.prepareOffline"), timeout = 30000L)
+      assert(result.isSuccess)
+      assert(!result.err.contains("blocked on "))
+    }
+
     test("same-task-write-lock-blocks-second-launcher") - integrationTest { tester =>
       import tester.*
       assert(tester.daemonMode)


### PR DESCRIPTION
Task locks coordinate separate launcher runs, but they treated sibling tasks in one run as competing owners. Shared prepareOffline commands could therefore invalidate their own retained reads and restart forever.

Identify task-lock owners by launcher run ID, allow same-owner task leases to overlap, and atomically track local task versions while preserving cross-launcher invalidation checks. Add reduced prepareOffline and lock ownership regressions.

Fixes #7142
