### PR TITLE
Give Android IDEA tasks unique output paths

### DIFF
--- a/libs/androidlib/src/mill/androidlib/idea/GenIdeaAndroidModule.scala
+++ b/libs/androidlib/src/mill/androidlib/idea/GenIdeaAndroidModule.scala
@@ -10,22 +10,26 @@ trait GenIdeaAndroidModule extends mill.javalib.idea.GenIdeaModule {
 
   def javaModuleRef: mill.api.ModuleRef[AndroidModule]
 
-  override private[mill] def extDependencies = Task {
+  // Internal IDEA wrappers are outside the build's override mapping, so overridden
+  // computations need task names distinct from their inherited dependencies.
+  private def androidExtDependencies = Task {
     super.extDependencies().filter(_.path.ext != "aar")
       ++ javaModuleRef().androidUnpackedAarMvnDeps().flatMap(_.classesJar)
   }
+  override private[mill] def extDependencies = androidExtDependencies
 
   /**
    * Generated R.java sources are not passed to [[AndroidModule.generatedSources]],
    * but they should still be passed down to the IDE for correct source navigation.
    */
-  override private[mill] def moduleGeneratedSources = Task {
+  private def androidModuleGeneratedSources = Task {
     val superSources = super.moduleGeneratedSources()
     val rSourcesDirs =
       Seq(javaModuleRef().androidLinkedResources().generatedSourcesDir)
 
     superSources ++ rSourcesDirs
   }
+  override private[mill] def moduleGeneratedSources = androidModuleGeneratedSources
 
 }
 

--- a/libs/androidlib/test/src/mill/androidlib/GenIdeaAndroidModuleTests.scala
+++ b/libs/androidlib/test/src/mill/androidlib/GenIdeaAndroidModuleTests.scala
@@ -1,0 +1,60 @@
+package mill.androidlib
+
+import java.util.{Collections, IdentityHashMap}
+
+import mill.*
+import mill.api.{Discover, ModuleRef}
+import mill.testkit.TestRootModule
+import utest.*
+
+import scala.collection.mutable
+
+object GenIdeaAndroidModuleTests extends TestSuite {
+
+  object build extends TestRootModule {
+    object sdk extends AndroidSdkModule {
+      def buildToolsVersion = "35.0.0"
+    }
+
+    object app extends AndroidModule {
+      def androidSdkModule = ModuleRef(sdk)
+      def androidCompileSdk = 35
+      def androidNamespace = "example"
+    }
+
+    lazy val millDiscover = Discover[this.type]
+  }
+
+  def tests: Tests = Tests {
+    test("idea tasks have unique output paths") {
+      val terminal = build.app.genIdeaInternalExt().genIdeaResolvedModule(
+        ideaConfigVersion = 4,
+        build.app.moduleSegments
+      )
+      val transitive = mutable.ArrayBuffer.empty[Task[?]]
+      val seen = Collections.newSetFromMap(new IdentityHashMap[Task[?], java.lang.Boolean])
+
+      def visit(task: Task[?]): Unit =
+        if (seen.add(task)) {
+          transitive += task
+          task.inputs.foreach(visit)
+        }
+
+      visit(terminal)
+
+      val taskPaths = transitive
+        .collect { case task: Task.Named[?] => task.ctx.segments.render }
+      val duplicatePaths = taskPaths
+        .groupMapReduce(identity)(_ => 1)(_ + _)
+        .filter(_._2 > 1)
+
+      assert(
+        duplicatePaths.isEmpty,
+        taskPaths.contains("app.internalGenIdea.extDependencies"),
+        taskPaths.contains("app.internalGenIdea.androidExtDependencies"),
+        taskPaths.contains("app.internalGenIdea.moduleGeneratedSources"),
+        taskPaths.contains("app.internalGenIdea.androidModuleGeneratedSources")
+      )
+    }
+  }
+}


### PR DESCRIPTION
Android IDEA's internal wrapper is outside the build's override mapping, so its overridden helper tasks shared output paths with their inherited dependencies. Per-task locking could then retain a read lease for the inherited task while the Android task waited forever to acquire a write lease for the same path.

Route the Android computations through distinctly named private tasks and cover the resulting IDEA task graph with a reference-identity regression test.

Fixes #7080
