### PR TITLE
Handle non-Java dependencies in Eclipse projects

### DIFF
--- a/integration/feature/gen-eclipse/resources/mixed-java-scala-project/build.mill
+++ b/integration/feature/gen-eclipse/resources/mixed-java-scala-project/build.mill
@@ -1,0 +1,15 @@
+package build
+
+import mill.*, javalib.*, scalalib.*
+
+object runner extends Module {
+  object launcher extends ScalaModule {
+    def scalaVersion = "3.7.1"
+  }
+}
+
+object dist extends Module {
+  object raw extends JavaModule {
+    def moduleDeps = Seq(build.runner.launcher)
+  }
+}

--- a/integration/feature/gen-eclipse/resources/mixed-java-scala-project/dist/raw/src/application/Main.java
+++ b/integration/feature/gen-eclipse/resources/mixed-java-scala-project/dist/raw/src/application/Main.java
@@ -1,0 +1,9 @@
+package application;
+
+import dependency.Greeting;
+
+public class Main {
+    public static void main(String[] args) {
+        System.out.println(Greeting.message());
+    }
+}

--- a/integration/feature/gen-eclipse/resources/mixed-java-scala-project/runner/launcher/src/dependency/Greeting.scala
+++ b/integration/feature/gen-eclipse/resources/mixed-java-scala-project/runner/launcher/src/dependency/Greeting.scala
@@ -1,0 +1,5 @@
+package dependency
+
+object Greeting {
+  def message(): String = "hello"
+}

--- a/integration/feature/gen-eclipse/src/GenEclipseMixedModuleTests.scala
+++ b/integration/feature/gen-eclipse/src/GenEclipseMixedModuleTests.scala
@@ -1,0 +1,41 @@
+package mill.integration
+
+import mill.testkit.UtestIntegrationTestSuite
+import os.Path
+import utest.{Tests, test}
+
+object GenEclipseMixedModuleTests extends UtestIntegrationTestSuite {
+
+  override def workspaceSourcePath: Path =
+    super.workspaceSourcePath / "mixed-java-scala-project"
+
+  def tests: Tests = Tests {
+    test("millRepoModuleShape") - integrationTest { tester =>
+      import tester.*
+
+      val ret = eval("mill.eclipse/", check = true)
+      assert(ret.exitCode == 0)
+
+      val distRawPath = workspacePath / "dist" / "raw"
+      val project = scala.xml.XML.loadFile((distRawPath / ".project").toIO)
+      assert((project \ "name").text == "dist.raw")
+      assert((project \\ "nature").exists(_.text == "org.eclipse.jdt.core.javanature"))
+
+      val classpath = scala.xml.XML.loadFile((distRawPath / ".classpath").toIO)
+      val entries = classpath \ "classpathentry"
+      val projectDependencies = entries.filter(node => (node \@ "kind") == "src")
+        .map(_ \@ "path")
+        .filter(_.startsWith("/"))
+      val libraries = entries.filter(node => (node \@ "kind") == "lib").map(_ \@ "path")
+
+      assert(projectDependencies.isEmpty)
+      val scalaClasses = libraries.filter(
+        _.replace('\\', '/').endsWith("runner/launcher/compile.dest/classes")
+      )
+      assert(scalaClasses.size == 1)
+
+      val classesPath = distRawPath.toNIO.resolve(scalaClasses.head).normalize()
+      assert(java.nio.file.Files.exists(classesPath.resolve("dependency/Greeting.class")))
+    }
+  }
+}

--- a/libs/javalib/src/mill/javalib/eclipse/GenEclipseModule.scala
+++ b/libs/javalib/src/mill/javalib/eclipse/GenEclipseModule.scala
@@ -3,7 +3,7 @@ package mill.javalib.eclipse
 import mill.Task
 import mill.api.{ModuleCtx, ModuleRef, PathRef}
 import mill.api.daemon.internal.eclipse.{GenEclipseInternalApi, ResolvedModule}
-import mill.api.daemon.internal.{TaskApi, internal}
+import mill.api.daemon.internal.{KotlinModuleApi, ScalaModuleApi, TaskApi, internal}
 import mill.javalib.{BoundDep, JavaModule}
 import mill.api.JsonFormatters.given
 
@@ -53,6 +53,14 @@ trait GenEclipseModule extends mill.api.Module with GenEclipseInternalApi {
       extRunMvnDeps().collect(jarCollector)
   }
 
+  private[mill] def nonJdtModuleDependencyClasspath = Task {
+    Task.traverse(
+      javaModule.moduleDepsChecked.filterNot(isOnlyJavaModule).flatMap { module =>
+        module.transitiveModuleCompileModuleDeps :+ module
+      }.distinct
+    )(_.localClasspath)().flatten.filter(pathRef => os.exists(pathRef.path))
+  }
+
   private[mill] override def genEclipseModuleInformation(): TaskApi[ResolvedModule] = Task.Anon {
     // Resolve all dependencies by their "-sources.jar" archives.
     resolveSourcesJars()
@@ -63,13 +71,17 @@ trait GenEclipseModule extends mill.api.Module with GenEclipseInternalApi {
     val allSources = javaModule.allSources().map(_.path.toNIO)
 
     // Get all the module dependencies that will be translated to Eclipse JDT project dependencies
-    val moduleDeps = javaModule.moduleDepsChecked.map(_.moduleDirJava)
+    val moduleDeps = javaModule.moduleDepsChecked.filter(isOnlyJavaModule).map(_.moduleDirJava)
 
     // This can contain both JAR archives or folder of classes, etc. Eclipse does not care ^^
     val unmanagedClasspath = javaModule.unmanagedClasspath().map(_.javaPath)
 
-    // This will be all Jar archive dependencies both direct and transitive
-    val dependencyClasspath = libraryClasspath()
+    // This includes JAR dependencies and the compiled output of module types that Eclipse JDT
+    // cannot represent as projects.
+    val dependencyClasspath =
+      libraryClasspath() ++ nonJdtModuleDependencyClasspath().map { pathRef =>
+        PathRef.toAbsNioPath(PathRef.toResolvedOsPath(pathRef.path))
+      }
 
     ResolvedModule(
       segments = javaModule.moduleSegments,
@@ -79,6 +91,9 @@ trait GenEclipseModule extends mill.api.Module with GenEclipseInternalApi {
       allLibraryDependencies = unmanagedClasspath ++ dependencyClasspath
     )
   }
+
+  private def isOnlyJavaModule(module: JavaModule): Boolean =
+    !module.isInstanceOf[ScalaModuleApi] && !module.isInstanceOf[KotlinModuleApi]
 }
 
 @internal


### PR DESCRIPTION
Eclipse generation excludes Scala and Kotlin modules from JDT project creation, but still treated their paths as project references. This made mixed builds fail when resolving a missing Eclipse project, including Mill's own dist modules and their Scala launcher dependency.

Represent excluded module dependencies with their compiled local classpath instead, while retaining project references for Java-only modules. Add a mixed Java and Scala integration test that validates the generated classpath points to the compiled Scala classes.

Fixes #7116
