### PR TITLE
Allow overriding BSP dependency sources

### DIFF
--- a/integration/dedicated/bsp-server/src/BspServerTests.scala
+++ b/integration/dedicated/bsp-server/src/BspServerTests.scala
@@ -30,6 +30,92 @@ object BspServerTests extends UtestIntegrationTestSuite {
     super.workspaceSourcePath / "project"
 
   def tests: Tests = Tests {
+    test("dependencySourcesWithoutSourceArtifact") - integrationTest { tester =>
+      import tester.*
+
+      def publishLocalArtifact(name: String, withSources: Boolean): Unit = {
+        val artifactDir = workspacePath / "repo/example" / name / "1.0"
+        os.makeDir.all(artifactDir)
+        os.write(
+          artifactDir / s"$name-1.0.pom",
+          s"""<project>
+             |  <modelVersion>4.0.0</modelVersion>
+             |  <groupId>example</groupId>
+             |  <artifactId>$name</artifactId>
+             |  <version>1.0</version>
+             |</project>
+             |""".stripMargin
+        )
+        os.write(artifactDir / s"$name-1.0.jar", "binary")
+        if (withSources) os.write(artifactDir / s"$name-1.0-sources.jar", "sources")
+      }
+
+      publishLocalArtifact("with-sources", withSources = true)
+      publishLocalArtifact("without-sources", withSources = false)
+      os.write.over(
+        workspacePath / "build.mill",
+        """package build
+          |
+          |import mill.*
+          |import mill.scalalib.*
+          |
+          |trait LocalRepoModule extends JavaModule {
+          |  override def repositoriesTask = Task.Anon {
+          |    Seq(coursier.maven.MavenRepository(
+          |      (mill.api.BuildCtx.workspaceRoot / "repo").toNIO.toUri.toASCIIString
+          |    ))
+          |  }
+          |}
+          |
+          |object partialSources extends LocalRepoModule {
+          |  def mvnDeps = Seq(
+          |    mvn"example:with-sources:1.0",
+          |    mvn"example:without-sources:1.0"
+          |  )
+          |}
+          |
+          |object noSources extends JavaModule {
+          |  override def repositoriesTask = Task.Anon {
+          |    Seq(coursier.maven.MavenRepository("http://127.0.0.1:1"))
+          |  }
+          |  def mvnDeps = Seq(mvn"example:unreachable:1.0")
+          |  override def bspMvnDependencySources = Task { Seq.empty[PathRef] }
+          |}
+          |""".stripMargin
+      )
+
+      eval(
+        ("--bsp-install", "--jobs", "1"),
+        stdout = os.Inherit,
+        stderr = os.Inherit,
+        check = true,
+        env = Map("MILL_EXECUTABLE_PATH" -> tester.millExecutable.toString)
+      )
+
+      withBspServer(workspacePath, millTestSuiteEnv) { (buildServer, _) =>
+        val targetsByName = buildServer.workspaceBuildTargets().get().getTargets.asScala
+          .map(target => target.getDisplayName -> target.getId)
+          .toMap
+        val requestedTargets = Seq("partialSources", "noSources").map(targetsByName).asJava
+
+        val result = buildServer
+          .buildTargetDependencySources(new b.DependencySourcesParams(requestedTargets))
+          .get(30, TimeUnit.SECONDS)
+
+        val itemsByTarget = result.getItems.asScala
+          .map(item => item.getTarget -> item.getSources.asScala.toSeq)
+          .toMap
+        assert(itemsByTarget.keySet == requestedTargets.asScala.toSet)
+        assert(itemsByTarget(targetsByName("noSources")).isEmpty)
+        assert(
+          itemsByTarget(targetsByName("partialSources")).map(source =>
+            Paths.get(URI.create(source)).getFileName.toString
+          ) ==
+            Seq("with-sources-1.0-sources.jar")
+        )
+      }
+    }
+
     test("requestSnapshots") - integrationTest { tester =>
       import tester.*
       eval(

--- a/libs/androidlib/src/mill/androidlib/AndroidModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidModule.scala
@@ -404,6 +404,10 @@ trait AndroidModule extends JavaModule { outer =>
     )
   }
 
+  override def bspMvnDependencySources: T[Seq[PathRef]] = Task {
+    androidUnpackedAarMvnDeps().flatMap(_.sourcesJar)
+  }
+
   def androidResolvedCompileMvnDeps: T[Seq[PathRef]] = Task {
     defaultResolver().classpath(compileMvnDeps())
   }

--- a/libs/androidlib/src/mill/androidlib/bsp/BspAndroidModule.scala
+++ b/libs/androidlib/src/mill/androidlib/bsp/BspAndroidModule.scala
@@ -1,31 +1,14 @@
 package mill.androidlib.bsp
 
-import java.nio.file.Path
-
-import mill.Task
 import mill.api.daemon.internal.internal
 import mill.api.{ModuleCtx, experimental}
 import mill.androidlib.AndroidModule
 import mill.javalib.bsp.BspModule
-import mill.api.JsonFormatters.given
 
 @experimental
 trait BspAndroidModule extends mill.javalib.bsp.BspJavaModule {
 
   def javaModuleRef: mill.api.ModuleRef[AndroidModule & BspModule]
-
-  override private[mill] def bspBuildTargetDependencySources
-      : Task.Simple[(
-          resolvedDepsSources: Seq[Path],
-          unmanagedClasspath: Seq[Path]
-      )] = Task {
-    (
-      resolvedDepsSources =
-        javaModuleRef().androidUnpackedAarMvnDeps().flatMap(_.sourcesJar).map(_.path.toNIO),
-      unmanagedClasspath = javaModuleRef().unmanagedClasspath().map(_.path.toNIO)
-    )
-  }
-
 }
 
 object BspAndroidModule {

--- a/libs/javalib/src/mill/javalib/JavaModule.scala
+++ b/libs/javalib/src/mill/javalib/JavaModule.scala
@@ -1207,6 +1207,22 @@ trait JavaModule
   }
 
   /**
+   * Third-party dependency source JARs exposed to BSP clients.
+   *
+   * Override this task to avoid resolving sources for dependencies that are known not to
+   * publish them, or to provide those sources through another mechanism.
+   */
+  def bspMvnDependencySources: T[Seq[PathRef]] = Task {
+    millResolver().classpath(
+      Seq(
+        coursierDependencyTask().withConfiguration(cs.Configuration.provided),
+        coursierDependencyTask()
+      ),
+      sources = true
+    )
+  }
+
+  /**
    * Resolved dependency sources, unpacked into a single directory. Useful to quickly
    * look up the sources of the dependencies on your classpath so you can find the
    * exact source code you are compiling and running against.

--- a/libs/javalib/src/mill/javalib/bsp/BspJavaModule.scala
+++ b/libs/javalib/src/mill/javalib/bsp/BspJavaModule.scala
@@ -67,13 +67,7 @@ trait BspJavaModule extends mill.api.Module with BspJavaModuleApi {
           unmanagedClasspath: Seq[Path]
       )] = Task {
     (
-      resolvedDepsSources = jm.millResolver().classpath(
-        Seq(
-          jm.coursierDependencyTask().withConfiguration(coursier.core.Configuration.provided),
-          jm.coursierDependencyTask()
-        ),
-        sources = true
-      ).map(_.path.toNIO),
+      resolvedDepsSources = jm.bspMvnDependencySources().map(_.path.toNIO),
       unmanagedClasspath = jm.unmanagedClasspath().map(_.path.toNIO)
     )
   }


### PR DESCRIPTION
Expose the dependency source task used by BSP on JavaModule so builds can skip source resolution for dependencies that do not publish sources or provide source paths another way.

Preserve Android's AAR-specific source handling through the same override and cover aggregate dependency-source requests with available, missing, and intentionally skipped repositories.

Fixes #7140
