### PR TITLE
Test GenIdea completion output ordering

### DIFF
--- a/integration/feature/gen-idea/src/GenIdeaTests.scala
+++ b/integration/feature/gen-idea/src/GenIdeaTests.scala
@@ -13,7 +13,20 @@ object GenIdeaTests extends UtestIntegrationTestSuite {
     test("genIdeaTests") - integrationTest { tester =>
       import tester.*
       eval("version", check = true, stdout = os.Inherit, stderr = os.Inherit)
-      eval("mill.idea.GenIdea/", check = true, stdout = os.Inherit, stderr = os.Inherit)
+      val genIdeaResult = eval(
+        ("--ticker", "true", "mill.idea.GenIdea/"),
+        check = true,
+        mergeErrIntoOut = true
+      )
+
+      val output = genIdeaResult.out
+      val lastWriteIndex = output.lastIndexOf("Writing ")
+      val successIndex = output.indexOf("SUCCESS]")
+      assert(
+        output.contains("Analyzing modules ..."),
+        lastWriteIndex >= 0,
+        successIndex == -1 || successIndex > lastWriteIndex
+      )
 
       assertIdeaFolderMatches(tester.workspaceSourcePath, workspacePath)
     }


### PR DESCRIPTION
Capture GenIdea ticker output and verify that any SUCCESS marker is emitted only after IDEA project files finish writing. This protects the bootstrap-only IDE generation path from regressing to an observable resolve task completion before generation.

Fixes #6818
