### PR TITLE
Detect stderr terminal independently for colors

### DIFF
--- a/integration/feature/stderr-color/resources/build.mill
+++ b/integration/feature/stderr-color/resources/build.mill
@@ -1,0 +1,3 @@
+package build
+
+import mill.*

--- a/integration/feature/stderr-color/src/StderrColorTests.scala
+++ b/integration/feature/stderr-color/src/StderrColorTests.scala
@@ -1,0 +1,62 @@
+package mill.integration
+
+import mill.testkit.UtestIntegrationTestSuite
+import utest.*
+
+object StderrColorTests extends UtestIntegrationTestSuite {
+  val tests: Tests = Tests {
+    test("stdoutRedirectionKeepsStderrColor") {
+      if (!scala.util.Properties.isWin) {
+        integrationTest { tester =>
+          checkStderrColor(tester, daemon = true)
+          checkStderrColor(tester, daemon = false)
+        }
+      }
+    }
+  }
+
+  private def checkStderrColor(
+      tester: mill.testkit.IntegrationTester,
+      daemon: Boolean
+  ): Unit = {
+    val prepared = tester.proc(Seq("resolve", "_"))
+    val baseCommand0 = prepared.cmd.value.iterator.map(_.toString).toVector
+      .filterNot(_ == "--no-daemon")
+    val tickerIndex = baseCommand0.indexOf("--ticker")
+    val baseCommand = baseCommand0.updated(tickerIndex + 1, "true")
+    val command =
+      if (daemon) baseCommand
+      else baseCommand.patch(1, Seq("--no-daemon"), 0)
+
+    val transcript = os.temp(prefix = s"mill-stderr-color-$daemon-", suffix = ".log")
+    val stdout = os.temp(prefix = s"mill-stdout-$daemon-", suffix = ".log")
+    val wrapper = os.temp(prefix = s"mill-stderr-color-$daemon-", suffix = ".sh")
+    os.write.over(
+      wrapper,
+      s"#!/bin/sh\n${command.map(shellQuote).mkString(" ")} >${shellQuote(stdout.toString)}\n"
+    )
+    os.perms.set(wrapper, "rwxr-xr-x")
+
+    val scriptCommand =
+      if (scala.util.Properties.isMac)
+        Seq("script", "-q", transcript.toString, wrapper.toString)
+      else
+        Seq("script", "-q", "-e", "-c", wrapper.toString, transcript.toString)
+
+    val result = os.proc(scriptCommand).call(
+      cwd = tester.workspacePath,
+      env = (prepared.env - "NO_COLOR" - "FORCE_COLOR") + ("TERM" -> "xterm-256color"),
+      stdout = os.Pipe,
+      stderr = os.Pipe,
+      check = false,
+      propagateEnv = false
+    )
+    val terminalOutput = os.read.bytes(transcript)
+
+    assert(result.exitCode == 0)
+    assert(terminalOutput.contains(0x1b.toByte))
+  }
+
+  private def shellQuote(value: String): String =
+    "'" + value.replace("'", "'\"'\"'") + "'"
+}

--- a/runner/daemon/src/mill/daemon/MillNoDaemonMain0.scala
+++ b/runner/daemon/src/mill/daemon/MillNoDaemonMain0.scala
@@ -1,11 +1,11 @@
 package mill.daemon
 
-import mill.constants.{DaemonFiles, Util}
+import mill.constants.DaemonFiles
 import mill.constants.OutFiles.OutFiles
 import mill.daemon.MillMain0.handleMillException
 import mill.api.BuildCtx
 import mill.internal.{LauncherLockRegistry, LauncherOutFilesState, OutputDirectoryLayout}
-import mill.launcher.DaemonRpc
+import mill.launcher.{DaemonRpc, MillProcessLauncher}
 import mill.server.Server
 
 import scala.jdk.CollectionConverters.*
@@ -14,8 +14,9 @@ import scala.util.Properties
 object MillNoDaemonMain0 {
   def main(args0: Array[String]): Unit = mill.api.SystemStreamsUtils.withTopLevelSystemStreamProxy {
     val initialSystemStreams = mill.api.SystemStreams.original
+    val stderrInteractive = MillProcessLauncher.stderrIsTerminal()
 
-    if (Properties.isWin && Util.hasConsole())
+    if (Properties.isWin && stderrInteractive)
       io.github.alexarchambault.windowsansi.WindowsAnsi.setup()
 
     if (Properties.isWin)
@@ -62,7 +63,7 @@ object MillNoDaemonMain0 {
           sharedState = new java.util.concurrent.atomic.AtomicReference(RunnerSharedState.empty),
           lockRegistry = new LauncherLockRegistry,
           outFilesState = new LauncherOutFilesState,
-          mainInteractive = mill.constants.Util.hasConsole(),
+          mainInteractive = stderrInteractive,
           streams0 = initialSystemStreams,
           env = env,
           launcherPid = processId,

--- a/runner/launcher/src/mill/launcher/MillProcessLauncher.scala
+++ b/runner/launcher/src/mill/launcher/MillProcessLauncher.scala
@@ -12,6 +12,20 @@ import java.util.UUID
 import scala.jdk.CollectionConverters._
 
 object MillProcessLauncher {
+  private[launcher] def stderrIsTerminal(isatty: Int => Int): Boolean = isatty(2) == 1
+
+  private[mill] def stderrIsTerminal(): Boolean = {
+    try {
+      JLineNativeLoader.initJLineNative()
+      val isatty =
+        if (Util.isWindows) org.jline.nativ.Kernel32.isatty
+        else org.jline.nativ.CLibrary.isatty
+      stderrIsTerminal(isatty)
+    } catch {
+      case _: Throwable => Util.hasConsole()
+    }
+  }
+
   private def outDir(outMode: OutFolderMode, workDir: os.Path, env: Map[String, String]): String =
     OutputDirectoryLayout.outDir(outMode, workDir, env)
 

--- a/runner/launcher/src/mill/launcher/MillServerLauncher.scala
+++ b/runner/launcher/src/mill/launcher/MillServerLauncher.scala
@@ -6,7 +6,6 @@ import mill.client.{ClientUtil, LaunchedServer, ServerLauncher}
 import mill.constants.BuildInfo
 import mill.constants.EnvVars
 import mill.client.lock.Locks
-import mill.constants.Util
 import mill.rpc.RpcConsole
 
 import java.io.{BufferedReader, InputStreamReader, PrintStream}
@@ -81,7 +80,7 @@ class MillServerLauncher(
       val socketOut = PrintStream(socket.getOutputStream, true)
 
       val init = DaemonRpc.Initialize(
-        interactive = Util.hasConsole(),
+        interactive = MillProcessLauncher.stderrIsTerminal(),
         clientPid = ProcessHandle.current().pid(),
         clientMillVersion = BuildInfo.millVersion,
         clientJavaVersion = javaHome.map(_.toString).getOrElse(""),

--- a/runner/launcher/test/src/mill/launcher/MillProcessLauncherTests.scala
+++ b/runner/launcher/test/src/mill/launcher/MillProcessLauncherTests.scala
@@ -1,0 +1,21 @@
+package mill.launcher
+
+import utest.*
+
+object MillProcessLauncherTests extends TestSuite {
+  def tests: Tests = Tests {
+    test("stdoutAndStderrAreDetectedIndependently") {
+      test("stdoutRedirected") {
+        val onlyStderrIsTerminal = (fileDescriptor: Int) => if (fileDescriptor == 2) 1 else 0
+
+        assert(MillProcessLauncher.stderrIsTerminal(onlyStderrIsTerminal))
+      }
+
+      test("stderrRedirected") {
+        val onlyStdoutIsTerminal = (fileDescriptor: Int) => if (fileDescriptor == 1) 1 else 0
+
+        assert(!MillProcessLauncher.stderrIsTerminal(onlyStdoutIsTerminal))
+      }
+    }
+  }
+}


### PR DESCRIPTION
Use the existing JLine native isatty support to detect file descriptor 2 instead of relying on System.console(), which loses interactivity when stdout is redirected on pre-JDK 22 runtimes. Apply the stderr result to both daemon and no-daemon color selection, with the prior console check as a fallback when native detection is unavailable.

Add focused coverage for stdout and stderr having different terminal states.

Fixes #6811
