### PR TITLE
Fix task graph visualization for isolated nodes

### DIFF
--- a/example/cli/builtins/1-builtin-commands/build.mill
+++ b/example/cli/builtins/1-builtin-commands/build.mill
@@ -338,6 +338,25 @@ graph ["rankdir"="LR"]
 // so it's easier to visualize while preserving the overall structure of the graph, but
 // it does mean that there will be some duplicate edges that are not shown.
 //
+// Tasks without dependencies are rendered as standalone nodes.
+//
+/** Usage
+> ./mill visualize foo.artifactId
+[
+  ".../out/visualize.dest/out.dot",
+  ".../out/visualize.dest/out.json",
+  ".../out/visualize.dest/out.png",
+  ".../out/visualize.dest/out.svg",
+  ".../out/visualize.dest/out.txt"
+]
+
+> cat out/visualize.dest/out.dot
+digraph "example1" {
+graph ["rankdir"="LR"]
+"foo.artifactId" ["style"="solid","shape"="box"]
+}
+*/
+//
 // == visualizePlan
 //
 /** Usage

--- a/libs/graphviz/src/mill/graphviz/GraphvizTools.scala
+++ b/libs/graphviz/src/mill/graphviz/GraphvizTools.scala
@@ -40,12 +40,29 @@ object GraphvizTools {
           val outputs = extensions
             .map(ext => Format.values().find(_.fileExtension == ext).head -> s"out.$ext")
 
-          for ((fmt, name) <- outputs) gv.render(fmt).toFile((dest / name).toIO)
+          for ((fmt, name) <- outputs) {
+            try gv.render(fmt).toFile((dest / name).toIO)
+            catch {
+              case e: LinkageError if fmt == Format.PNG && causedByMissingFontConfig(e) =>
+                warnMissingFontConfig()
+            }
+          }
         }
 
       Await.result(Future.sequence(futures), duration.Duration.Inf)
     } finally executor.shutdown()
   }
+
+  private def causedByMissingFontConfig(error: Throwable): Boolean =
+    Option(error.getMessage).exists(_.contains("Fontconfig head is null")) ||
+      Option(error.getCause).exists(causedByMissingFontConfig)
+
+  private def warnMissingFontConfig(): Unit =
+    System.err.println(
+      "Could not render out.png because Java's font system failed to initialize. " +
+        "The SVG and text graph outputs are still available. " +
+        "Install fontconfig and at least one system font to enable PNG rendering."
+    )
 }
 
 class V8JavascriptEngine() extends AbstractJavascriptEngine {

--- a/libs/graphviz/src/mill/graphviz/VisualizeWorkerMain.scala
+++ b/libs/graphviz/src/mill/graphviz/VisualizeWorkerMain.scala
@@ -16,14 +16,16 @@ object VisualizeWorkerMain {
 
   private def render(payload: os.Path, dest: os.Path): Unit = {
     val parsed = ujson.read(os.read(payload))
-    val selected = parsed("tasks").arr.map(_.str).toSet
+    val selectedTasks = parsed("tasks").arr.map(_.str)
+    val selected = selectedTasks.toSet
     val edges = parsed("edges").arr.map { entry =>
       val src = entry("src").str
       val dests = entry("dests").arr.map(_.str).toArray.distinct
       (src, dests)
     }.toArray
 
-    val indexToTask = edges.flatMap { case (k, vs) => Iterator(k) ++ vs }.distinct
+    val indexToTask =
+      (edges.flatMap { case (k, vs) => Iterator(k) ++ vs } ++ selectedTasks).distinct
     val taskToIndex = indexToTask.zipWithIndex.toMap
 
     val jgraph = new SimpleDirectedGraph[Int, DefaultEdge](classOf[DefaultEdge])
@@ -40,22 +42,22 @@ object VisualizeWorkerMain {
         .`with`(Shape.BOX)
     )
 
-    var g = graph("example1").directed
-    for (i <- indexToTask.indices) {
-      for {
-        target <- edges(i)._2
-        j = taskToIndex(target)
-        if jgraph.containsEdge(i, j)
-      } {
-        g = g.`with`(nodes(j).link(nodes(i)))
-      }
+    var g = graph("example1").directed.`with`(nodes*)
+    for {
+      (src, dests) <- edges
+      target <- dests
+      i = taskToIndex(src)
+      j = taskToIndex(target)
+      if jgraph.containsEdge(i, j)
+    } {
+      g = g.`with`(nodes(j).link(nodes(i)))
     }
     g = g.graphAttr().`with`(Rank.dir(RankDir.LEFT_TO_RIGHT))
 
     val graphFile = os.temp(prefix = "mill-visualize-", suffix = ".dot")
     try {
       os.write.over(graphFile, g.toString)
-      GraphvizTools.main(Array(s"$graphFile;$dest;txt,dot,json,png,svg"))
+      GraphvizTools.main(Array(s"$graphFile;$dest;txt,dot,json,svg,png"))
     } finally {
       os.remove(graphFile, checkExists = false)
     }

--- a/libs/graphviz/test/src/mill/graphviz/VisualizeWorkerMainTests.scala
+++ b/libs/graphviz/test/src/mill/graphviz/VisualizeWorkerMainTests.scala
@@ -1,0 +1,92 @@
+package mill.graphviz
+
+import utest.*
+
+import javax.imageio.ImageIO
+
+object VisualizeWorkerMainTests extends TestSuite {
+
+  def tests: Tests = Tests {
+    test("standaloneNode") {
+      val dest = render(
+        ujson.Obj(
+          "tasks" -> ujson.Arr("standalone"),
+          "edges" -> ujson.Arr(ujson.Obj("src" -> "standalone", "dests" -> ujson.Arr()))
+        )
+      )
+
+      val outputNames = os.list(dest).map(_.last).sorted
+      val requiredOutputNames = Seq("out.dot", "out.json", "out.svg", "out.txt")
+      assert(
+        outputNames == requiredOutputNames || outputNames == (requiredOutputNames :+ "out.png").sorted
+      )
+      assert(os.read(dest / "out.dot").contains("\"standalone\""))
+      assert(os.read(dest / "out.json").contains("\"name\": \"standalone\""))
+      assert(os.read(dest / "out.svg").contains("standalone"))
+      assert(os.read(dest / "out.txt").contains("node standalone"))
+
+      if (os.exists(dest / "out.png")) {
+        val png = ImageIO.read((dest / "out.png").toIO)
+        assert(png != null)
+        assert(png.getWidth > 8, png.getHeight > 8)
+      }
+    }
+
+    test("transitiveReduction") {
+      val dest = render(
+        ujson.Obj(
+          "tasks" -> ujson.Arr("root", "middle", "leaf"),
+          "edges" -> ujson.Arr(
+            ujson.Obj("src" -> "root", "dests" -> ujson.Arr("middle", "leaf")),
+            ujson.Obj("src" -> "middle", "dests" -> ujson.Arr("leaf"))
+          )
+        )
+      )
+      val dot = os.read(dest / "out.dot")
+
+      assert(dot.contains("\"leaf\" -> \"middle\""))
+      assert(dot.contains("\"middle\" -> \"root\""))
+      assert(!dot.contains("\"leaf\" -> \"root\""))
+    }
+
+    test("missingFontConfig") {
+      if (scala.util.Properties.isLinux) {
+        val graphFile = os.temp("digraph { standalone }")
+        val destinations = Seq(os.temp.dir(), os.temp.dir())
+        val missingFontConfig = destinations.head / "missing-fontconfig.conf"
+        val java = os.Path(sys.props("java.home")) / "bin" / "java"
+        val result = os
+          .proc(
+            java,
+            s"-Dsun.awt.fontconfig=$missingFontConfig",
+            "-cp",
+            sys.props("java.class.path"),
+            "mill.graphviz.GraphvizTools",
+            s"$graphFile;${destinations.head};txt,dot,json,svg,png",
+            s"$graphFile;${destinations.last};txt,dot,json,svg,png"
+          )
+          .call(
+            check = false,
+            stdout = os.Pipe,
+            stderr = os.Pipe,
+            env = Map(
+              "FONTCONFIG_FILE" -> missingFontConfig.toString,
+              "FONTCONFIG_PATH" -> destinations.head.toString
+            )
+          )
+
+        assert(result.exitCode == 0)
+        assert(destinations.forall(dest => os.size(dest / "out.svg") > 0))
+        assert(destinations.forall(dest => !os.exists(dest / "out.png")))
+        assert(result.err.text().contains("The SVG and text graph outputs are still available"))
+      }
+    }
+  }
+
+  private def render(payload: ujson.Value): os.Path = {
+    val payloadPath = os.temp(payload.render())
+    val dest = os.temp.dir()
+    VisualizeWorkerMain.main(Array(payloadPath.toString, dest.toString))
+    dest
+  }
+}

--- a/mill-build/src/millbuild/Deps.scala
+++ b/mill-build/src/millbuild/Deps.scala
@@ -135,17 +135,14 @@ object Deps {
   val flywayCore = mvn"org.flywaydb:flyway-core:11.8.2"
   val jibCore = mvn"com.google.cloud.tools:jib-core:0.27.2"
   val graphvizJava = Seq(
-    mvn"guru.nidi:graphviz-java-min-deps:0.18.1",
+    mvn"guru.nidi:graphviz-java-min-deps:0.18.1"
+      .exclude(
+        "guru.nidi.com.eclipsesource.j2v8" -> "j2v8_macosx_x86_64",
+        "guru.nidi.com.eclipsesource.j2v8" -> "j2v8_linux_x86_64"
+      ),
     mvn"org.webjars.npm:viz.js-graphviz-java:2.1.3",
     mvn"org.apache.xmlgraphics:batik-rasterizer:1.19"
   )
-  val graphvizWithExcludes = mvn"guru.nidi:graphviz-java-min-deps:0.18.1"
-    // We only need the in-memory library for some stuff, and don't
-    // need the heavyweight v8 binary that comes bundled with it
-    .exclude(
-      "guru.nidi.com.eclipsesource.j2v8" -> "j2v8_macosx_x86_64",
-      "guru.nidi.com.eclipsesource.j2v8" -> "j2v8_linux_x86_64"
-    )
 
   val jgraphtCore = mvn"org.jgrapht:jgrapht-core:1.4.0" // 1.5.0+ dont support JDK8
   val javet = Seq(


### PR DESCRIPTION
Render every selected task as a graph vertex instead of adding vertices only while linking edges. Preserve PNG output when fonts are available, while keeping SVG and text outputs and avoiding a hung worker when Batik cannot initialize fontconfig.

Add focused coverage for standalone nodes, rendered artifact contents, sparse edge arrays, transitive reduction direction, and missing fontconfig. Apply the existing J2V8 exclusions to the dependency that is actually used.

Fixes #6669
