### PR TITLE
Show submodules in inspect output

### DIFF
--- a/integration/feature/inspect/resources/build.mill
+++ b/integration/feature/inspect/resources/build.mill
@@ -61,3 +61,13 @@ object MyJavaTaskModule extends JavaModule {
     "Hello!"
   }
 }
+
+trait CrossModule extends Cross.Module[String]
+object cross extends Cross[CrossModule]("z", "a")
+
+object dynamic extends mill.api.DynamicModule {
+  object alpha extends Module
+  object zeta extends Module
+
+  override def moduleDirectChildren: Seq[Module] = Seq(zeta, alpha)
+}

--- a/integration/feature/inspect/src/InspectTests.scala
+++ b/integration/feature/inspect/src/InspectTests.scala
@@ -142,6 +142,9 @@ object InspectTests extends UtestIntegrationTestSuite {
           |Inherited Modules:
           |    mill.javalib.JavaModule
           |
+          |Sub-Modules:
+          |    core.test
+          |
           |Default Task: core.run
           |
           |Tasks (re-/defined):
@@ -182,6 +185,36 @@ object InspectTests extends UtestIntegrationTestSuite {
           |    build_.core3.package_
           |
           |Default Task: core3.run
+          |""".stripMargin
+      )
+
+      assert(eval(("inspect", "cross")).isSuccess)
+      val crossInspect = out("inspect").json.str
+      assertGoldenLiteral(
+        crossInspect,
+        """cross(build.mill:66)
+          |
+          |Inherited Modules:
+          |    mill.api.Cross
+          |
+          |Sub-Modules:
+          |    cross.z
+          |    cross.a
+          |""".stripMargin
+      )
+
+      assert(eval(("inspect", "dynamic")).isSuccess)
+      val dynamicInspect = out("inspect").json.str
+      assertGoldenLiteral(
+        dynamicInspect,
+        """dynamic(build.mill:68)
+          |
+          |Inherited Modules:
+          |    mill.api.DynamicModule
+          |
+          |Sub-Modules:
+          |    dynamic.zeta
+          |    dynamic.alpha
           |""".stripMargin
       )
 

--- a/libs/util/src/mill/util/Inspect.scala
+++ b/libs/util/src/mill/util/Inspect.scala
@@ -194,6 +194,7 @@ private[mill] object Inspect {
       val parents = (Option(cls.getSuperclass).toSeq ++ cls.getInterfaces).distinct
 
       val inheritedModules = parents.filter(parentFilter)
+      val subModules = module.moduleDirectChildren.map(_.toString)
 
       def getModuleDeps(methodName: String): Seq[Module] = cls
         .getMethods
@@ -235,6 +236,14 @@ private[mill] object Inspect {
             ":"
           ),
           inheritedModules.map("\n" + inspectItemIndent + _.getName),
+          // Sub-Modules:
+          if (subModules.nonEmpty) Iterator(
+            "\n\n",
+            ctx.applyPrefixColor("Sub-Modules").toString,
+            ":"
+          )
+          else Iterator.empty[String],
+          subModules.map("\n" + inspectItemIndent + _),
           // Module Dependencies: (JavaModule)
           if (hasModuleDeps) Iterator(
             "\n\n",

--- a/libs/util/test/src/mill/util/MainModuleTests.scala
+++ b/libs/util/test/src/mill/util/MainModuleTests.scala
@@ -67,6 +67,7 @@ object MainModuleTests extends TestSuite {
 
       /** SubSub module */
       object subSub extends Module
+      object alpha extends Module
     }
 
     override lazy val millDiscover = Discover[this.type]
@@ -251,6 +252,7 @@ object MainModuleTests extends TestSuite {
           res.contains("MainModuleTests.scala:"),
           res.contains("    Sub module"),
           res.contains("Inherited Modules:"),
+          res.contains("Sub-Modules:\n    sub.alpha\n    sub.subSub"),
           res.contains("Module Dependencies:"),
           res.contains("sub.subSub"),
           res.contains("Default Task: sub.hello"),


### PR DESCRIPTION
Render each module’s direct children in a Sub-Modules section. Preserve the ordering supplied by ordinary, cross, and dynamic modules, and keep leaf-module output unchanged.

Fixes #4481
