### PR TITLE
Support .sc files as Scala scripts

### DIFF
--- a/core/api/src/mill/api/ScriptModule.scala
+++ b/core/api/src/mill/api/ScriptModule.scala
@@ -10,7 +10,7 @@ import mill.api.internal.HeaderData
  * Sets `moduleDir` to the directory containing the config file, suitable for
  * directory-based modules with standard `src/` layouts.
  *
- * For single-file script modules (`.scala`, `.java`, `.kt`), use [[ScriptModule]]
+ * For single-file script modules (`.scala`, `.sc`, `.java`, `.kt`), use [[ScriptModule]]
  * which overrides `moduleDir` to point to the script file itself.
  */
 @experimental
@@ -98,7 +98,7 @@ object PrecompiledModule {
 }
 
 /**
- * Trait for single-file script modules (`.scala`, `.java`, `.kt`).
+ * Trait for single-file script modules (`.scala`, `.sc`, `.java`, `.kt`).
  * Overrides `moduleDir` to point to the script file itself rather than
  * its parent directory.
  */

--- a/core/eval/src/mill/eval/ScriptModuleInit.scala
+++ b/core/eval/src/mill/eval/ScriptModuleInit.scala
@@ -95,7 +95,7 @@ class ScriptModuleInit extends ((String, Evaluator) => Seq[Result[ExternalModule
         scriptFile.ext match {
           case "java" => Result.Success("mill.script.JavaModule")
           case "kt" => Result.Success("mill.script.KotlinModule")
-          case "scala" => Result.Success("mill.script.ScalaModule")
+          case "scala" | "sc" => Result.Success("mill.script.ScalaModule")
           case "groovy" => Result.Success("mill.script.GroovyModule")
           case _ =>
             Result.Failure(
@@ -245,7 +245,7 @@ class ScriptModuleInit extends ((String, Evaluator) => Seq[Result[ExternalModule
       }
   }
 
-  private val scriptExtensions = Set("scala", "java", "kt", "yaml")
+  private val scriptExtensions = Set("scala", "sc", "java", "kt", "yaml")
 
   /**
    * Discovers all script files in the given workspace directory.

--- a/integration/dedicated/bsp-server/src/BspServerTests.scala
+++ b/integration/dedicated/bsp-server/src/BspServerTests.scala
@@ -615,7 +615,7 @@ object BspServerTests extends UtestIntegrationTestSuite {
         createFolders = true
       )
       os.write.over(
-        workspacePath / "scripts/visible.scala",
+        workspacePath / "scripts/visible.sc",
         """object visible
           |""".stripMargin
       )
@@ -633,7 +633,7 @@ object BspServerTests extends UtestIntegrationTestSuite {
           .map(_.getId.getUri)
           .toSet
 
-        assert(targetUris.contains((workspacePath / "scripts/visible.scala").toURI.toASCIIString))
+        assert(targetUris.contains((workspacePath / "scripts/visible.sc").toURI.toASCIIString))
         assert(
           !targetUris.contains(
             (workspacePath / "gatling/gatling-app/src/main/scala/io/gatling/app/Analytics.scala")

--- a/integration/feature/script-main-forwarder-classes/resources/ExtensionAlias.sc
+++ b/integration/feature/script-main-forwarder-classes/resources/ExtensionAlias.sc
@@ -1,0 +1,2 @@
+@main
+def main1(text: String) = println(text + "SC")

--- a/integration/feature/script-main-forwarder-classes/src/ScriptMainForwarderClassesTests.scala
+++ b/integration/feature/script-main-forwarder-classes/src/ScriptMainForwarderClassesTests.scala
@@ -48,6 +48,9 @@ object ScriptMainForwarderClassesTests extends UtestIntegrationTestSuite {
       val res8 = eval(("OldScala.scala:allSourceFiles"))
       assert(!res8.isSuccess)
       assert(res8.err.contains("Scala scripts require Scala 3.7.3+. Detected scalaVersion=3.7.2."))
+
+      val res9 = eval(("ExtensionAlias.sc:runMain", "main1", "--text", "short-extension"))
+      assert(res9.out == "short-extensionSC")
     }
   }
 }

--- a/runner/meta/src/mill/meta/BootstrapRootModule.scala
+++ b/runner/meta/src/mill/meta/BootstrapRootModule.scala
@@ -22,7 +22,7 @@ trait BootstrapRootModule()(using
   def bspScriptIgnoreAll: T[Seq[String]] = bspScriptIgnoreDefault() ++ bspScriptIgnore()
 
   /**
-   * Default set of BSP ignores, meant to catch the common case of `.java`, `.scala`, or `.kt`
+   * Default set of BSP ignores, meant to catch the common case of `.java`, `.scala`, `.sc`, or `.kt`
    * files that definitely aren't scripts, but for some reason aren't recognized as being in
    * a module's `def sources` task (e.g. maybe module import failed or something)
    */

--- a/website/docs/modules/ROOT/partials/Script_Footer.adoc
+++ b/website/docs/modules/ROOT/partials/Script_Footer.adoc
@@ -3,7 +3,7 @@
 Mill's Intellij/VSCode BSP support treats scripts as single-file modules,
 but differ in how they are discovered. When importing a project
 into your IDE, Mill recursively walks your workspace folder looking for
-`.java`, `.scala`, or `.kt` files that may be scripts, skipping those in:
+`.java`, `.scala`, `.sc`, or `.kt` files that may be scripts, skipping those in:
 
 - The `sources`,
 - The `out` directory,


### PR DESCRIPTION
Recognize the short Scala script extension during both direct module resolution and shared BSP/IDEA discovery. Cover direct execution and BSP discovery with focused integration tests.

Fixes #6719
