### PR TITLE
Fix Quarkus protoc dependency metadata

### DIFF
--- a/libs/javalib/api/src/mill/javalib/quarkus/ApplicationModelWorker.scala
+++ b/libs/javalib/api/src/mill/javalib/quarkus/ApplicationModelWorker.scala
@@ -61,10 +61,13 @@ object ApplicationModelWorker {
       appMode: AppMode
   ) derives ReadWriter
 
+  @experimental
   case class Dependency(
       groupId: String,
       artifactId: String,
       version: String,
+      artifactType: String,
+      classifier: String,
       resolvedPath: os.Path,
       isRuntime: Boolean,
       isDeployment: Boolean,

--- a/libs/javalib/package.mill
+++ b/libs/javalib/package.mill
@@ -45,6 +45,7 @@ object `package` extends MillStableScalaModule {
       `pgp-worker`,
       `classgraph-worker`,
       `jarjarabrams-worker`,
+      `quarkus-worker`,
       `spotless-worker`,
       `scalameta-worker`
     )

--- a/libs/javalib/quarkus-worker/src/mill/javalib/quarkus/ApplicationModelWorkerImpl.scala
+++ b/libs/javalib/quarkus-worker/src/mill/javalib/quarkus/ApplicationModelWorkerImpl.scala
@@ -135,6 +135,8 @@ class ApplicationModelWorkerImpl extends ApplicationModelWorker {
         .setResolvedPath(dep.resolvedPath.toNIO)
         .setGroupId(dep.groupId)
         .setArtifactId(dep.artifactId)
+        .setType(dep.artifactType)
+        .setClassifier(dep.classifier)
         .setVersion(dep.version)
 
       if (appModel.appMode == Test) {
@@ -286,7 +288,7 @@ class ApplicationModelWorkerImpl extends ApplicationModelWorker {
       Files.exists(quarkusDescr)
     }
 
-    dep.isRuntime && metaInfPathExists
+    dep.isRuntime && dep.artifactType == ArtifactCoords.TYPE_JAR && metaInfPathExists
   }
 
   private def processQuarkusDir(
@@ -380,17 +382,15 @@ class ApplicationModelWorkerImpl extends ApplicationModelWorker {
 
     val sourcesPathCollection: PathCollection = PathList.of(sourcesDir.map(_.toNIO)*)
     val generatedSourcesPath: Path = generatedSourcesDir.toNIO
-    val buildPropertiesPath: Path = buildProperties.toNIO
 
     val sourceRegistrar: Consumer[Path] = _ => ()
-    curatedApplication.getApplicationModel
 
     initAndRun.invoke(
       null,
       deploymentClassLoader,
       sourcesPathCollection,
       generatedSourcesPath,
-      buildPropertiesPath,
+      buildDir.toNIO,
       sourceRegistrar,
       applicationModel,
       props,

--- a/libs/javalib/src/mill/javalib/CoursierModule.scala
+++ b/libs/javalib/src/mill/javalib/CoursierModule.scala
@@ -331,6 +331,17 @@ object CoursierModule {
     def artifacts[T: CoursierModule.Resolvable](
         deps: IterableOnce[T],
         sources: Boolean = false
+    )(using ctx: mill.api.TaskCtx): coursier.Artifacts.Result =
+      artifacts(deps, sources, artifactTypes = None)
+
+    /**
+     * Raw artifact results for the passed dependencies, including only the requested artifact
+     * types when `artifactTypes` is defined.
+     */
+    def artifacts[T: CoursierModule.Resolvable](
+        deps: IterableOnce[T],
+        sources: Boolean,
+        artifactTypes: Option[Set[coursier.Type]]
     )(using ctx: mill.api.TaskCtx): coursier.Artifacts.Result = {
       val deps0 = deps
         .iterator
@@ -340,6 +351,7 @@ object CoursierModule {
         repositories,
         deps0.map(_.dep),
         sources = sources,
+        artifactTypes = artifactTypes,
         ctx = Some(ctx),
         checkGradleModules = checkGradleModules,
         resolutionParams = resolutionParams,

--- a/libs/javalib/src/mill/javalib/quarkus/QuarkusModule.scala
+++ b/libs/javalib/src/mill/javalib/quarkus/QuarkusModule.scala
@@ -3,7 +3,7 @@ package mill.javalib.quarkus
 import coursier.core.VariantSelector.ConfigurationBased
 import mill.api.PathRef
 import mill.{T, Task}
-import mill.javalib.{Dep, DepSyntax, JavaModule, PublishModule}
+import mill.javalib.{CoursierModule, Dep, DepSyntax, JavaModule, PublishModule}
 import mill.util.Jvm
 import upickle.default.ReadWriter.join
 
@@ -174,8 +174,13 @@ trait QuarkusModule extends JavaModule { outer =>
       ConfigurationBased(coursier.core.Configuration.compile)
     )
 
+    val quarkusArtifactTypes = Some(artifactTypes() + coursier.Type("exe"))
+
+    def resolveArtifacts[T: CoursierModule.Resolvable](deps: Seq[T]) =
+      millResolver().artifacts(deps, sources = false, artifactTypes = quarkusArtifactTypes)
+
     val runtimeDeps =
-      millResolver().artifacts(Seq(mill.javalib.BoundDep(depRuntime, force = false)))
+      resolveArtifacts(Seq(mill.javalib.BoundDep(depRuntime, force = false)))
 
     def qualifier(d: coursier.core.Dependency) =
       s"${d.module.organization.value}:${d.module.name.value}"
@@ -186,21 +191,51 @@ trait QuarkusModule extends JavaModule { outer =>
     def isDirectDep(d: coursier.core.Module): Boolean =
       mvnDeps().exists(dep => dep.dep.module == d)
 
+    def toQuarkusDependency(
+        artifact: (
+            coursier.core.Dependency,
+            Either[coursier.core.VariantPublication, coursier.core.Publication],
+            coursier.util.Artifact,
+            File
+        ),
+        isRuntime: Boolean,
+        isDeployment: Boolean,
+        hasExtension: Boolean
+    ): ApplicationModelWorker.Dependency = {
+      val (dependency, publication, _, file) = artifact
+      val attributes = publication.fold(
+        variantPublication =>
+          dependency.attributes.withClassifier(
+            variantPublication.classifier.getOrElse(dependency.attributes.classifier)
+          ),
+        _.attributes
+      )
+      val artifactType =
+        if (attributes.`type`.isEmpty) coursier.Type.jar.value else attributes.`type`.value
+      ApplicationModelWorker.Dependency(
+        groupId = dependency.module.organization.value,
+        artifactId = dependency.module.name.value,
+        version = dependency.versionConstraint.asString,
+        artifactType = artifactType,
+        classifier = attributes.classifier.value,
+        resolvedPath = os.Path(file),
+        isRuntime = isRuntime,
+        isDeployment = isDeployment,
+        isTopLevelArtifact = isDirectDep(dependency.module),
+        hasExtension = hasExtension
+      )
+    }
+
     val runtimeDepSet = runtimeDeps.detailedArtifacts0.map(da => qualifier(da._1)).toSet
 
-    val quarkusPrecomputedRuntimeDeps = runtimeDeps.detailedArtifacts0.map {
-      case (dependency, _, _, file) =>
-        ApplicationModelWorker.Dependency(
-          groupId = dependency.module.organization.value,
-          artifactId = dependency.module.name.value,
-          version = dependency.versionConstraint.asString,
-          resolvedPath = os.Path(file),
-          isRuntime = true,
-          isDeployment = false,
-          isTopLevelArtifact = isDirectDep(dependency.module),
-          hasExtension = false
-        )
-    }
+    val quarkusPrecomputedRuntimeDeps = runtimeDeps.detailedArtifacts0.map(artifact =>
+      toQuarkusDependency(
+        artifact,
+        isRuntime = true,
+        isDeployment = false,
+        hasExtension = false
+      )
+    )
 
     val depsWithExtensions = quarkusApplicationModelWorker().quarkusDeploymentDependencies(
       quarkusPrecomputedRuntimeDeps
@@ -213,24 +248,18 @@ trait QuarkusModule extends JavaModule { outer =>
       mvn"${d.groupId}:${d.artifactId}-deployment:${d.version}"
     )
 
-    val deploymentDeps = millResolver().artifacts(
-      deploymentMvnDeps
-    )
+    val deploymentDeps = resolveArtifacts(deploymentMvnDeps)
 
     val deploymentDepsSet = deploymentDeps.detailedArtifacts0.map(da => qualifier(da._1)).toSet
 
-    val quarkusDeploymentDeps = deploymentDeps.detailedArtifacts0.map {
-      case (dependency, _, _, file) =>
-        ApplicationModelWorker.Dependency(
-          groupId = dependency.module.organization.value,
-          artifactId = dependency.module.name.value,
-          version = dependency.versionConstraint.asString,
-          resolvedPath = os.Path(file),
-          isRuntime = runtimeDepSet.contains(qualifier(dependency)),
-          isDeployment = true,
-          isTopLevelArtifact = isDirectDep(dependency.module),
-          hasExtension = extensionDepsSet.contains(qualifier(dependency))
-        )
+    val quarkusDeploymentDeps = deploymentDeps.detailedArtifacts0.map { artifact =>
+      val dependency = artifact._1
+      toQuarkusDependency(
+        artifact,
+        isRuntime = runtimeDepSet.contains(qualifier(dependency)),
+        isDeployment = true,
+        hasExtension = extensionDepsSet.contains(qualifier(dependency))
+      )
     }
 
     val quarkusRuntimeDeps = quarkusPrecomputedRuntimeDeps.filterNot(d =>
@@ -238,26 +267,21 @@ trait QuarkusModule extends JavaModule { outer =>
     )
 
     val compileDeps =
-      millResolver().artifacts(Seq(mill.javalib.BoundDep(depCompile, force = false)))
+      resolveArtifacts(Seq(mill.javalib.BoundDep(depCompile, force = false)))
 
     val quarkusCompileDeps =
       compileDeps.detailedArtifacts0.filterNot {
         da =>
           val q = qualifier(da._1)
           runtimeDepSet.contains(q) || deploymentDepsSet.contains(q) || extensionDepsSet.contains(q)
-      }.map {
-        case (dependency, _, _, file) =>
-          ApplicationModelWorker.Dependency(
-            groupId = dependency.module.organization.value,
-            artifactId = dependency.module.name.value,
-            version = dependency.versionConstraint.asString,
-            resolvedPath = os.Path(file),
-            isRuntime = false,
-            isDeployment = false,
-            isTopLevelArtifact = isDirectDep(dependency.module),
-            hasExtension = false
-          )
-      }
+      }.map(artifact =>
+        toQuarkusDependency(
+          artifact,
+          isRuntime = false,
+          isDeployment = false,
+          hasExtension = false
+        )
+      )
 
     quarkusRuntimeDeps ++ quarkusCompileDeps ++ quarkusDeploymentDeps
   }

--- a/libs/javalib/test/resources/quarkus-grpc/grpc/src/main/java/Marker.java
+++ b/libs/javalib/test/resources/quarkus-grpc/grpc/src/main/java/Marker.java
@@ -1,0 +1,1 @@
+final class Marker {}

--- a/libs/javalib/test/resources/quarkus-grpc/grpc/src/main/proto/ping.proto
+++ b/libs/javalib/test/resources/quarkus-grpc/grpc/src/main/proto/ping.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "com.lihaoyi.test.grpc";
+
+package ping;
+
+service Pinger {
+  rpc Send (Ping) returns (Pong) {}
+}
+
+message Ping {
+  string message = 1;
+}
+
+message Pong {
+  string message = 1;
+}

--- a/libs/javalib/test/resources/quarkus-grpc/grpc/src/main/resources/application.properties
+++ b/libs/javalib/test/resources/quarkus-grpc/grpc/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+# Quarkus discovers this conventional resources directory during code generation.

--- a/libs/javalib/test/src/mill/javalib/quarkus/QuarkusModuleTests.scala
+++ b/libs/javalib/test/src/mill/javalib/quarkus/QuarkusModuleTests.scala
@@ -1,0 +1,93 @@
+package mill.javalib.quarkus
+
+import mill.api.Discover
+import mill.javalib.{DepSyntax, MavenModule}
+import mill.testkit.{TestRootModule, UnitTester}
+import mill.util.TokenReaders.*
+import utest.*
+
+object QuarkusModuleTests extends TestSuite {
+
+  object TestCase extends TestRootModule {
+    object grpc extends QuarkusModule, MavenModule {
+      def quarkusPlatformVersion = "3.31.3"
+
+      def artifactGroupId = "com.lihaoyi.test"
+      def artifactId = "quarkus-grpc-test"
+      def artifactVersion = "0.0.1"
+
+      def mvnDeps = Seq(
+        mvn"io.quarkus:quarkus-grpc"
+      )
+    }
+
+    lazy val millDiscover = Discover[this.type]
+  }
+
+  private val resourcePath = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "quarkus-grpc"
+
+  val tests = Tests {
+    test("dependencyCoordinates") {
+      UnitTester(TestCase, resourcePath).scoped { eval =>
+        val result = eval(TestCase.grpc.quarkusDependencies).runtimeChecked.fold(
+          _.throwException,
+          identity
+        )
+        val dependencies = result.value
+
+        val platformClassifiers = Set(
+          "linux-aarch_64",
+          "linux-ppcle_64",
+          "linux-s390_64",
+          "linux-x86_32",
+          "linux-x86_64",
+          "osx-aarch_64",
+          "osx-x86_64",
+          "windows-x86_32",
+          "windows-x86_64"
+        )
+
+        val protoc = dependencies.filter(d =>
+          d.groupId == "com.google.protobuf" && d.artifactId == "protoc"
+        )
+        val grpcPlugin = dependencies.filter(d =>
+          d.groupId == "io.grpc" && d.artifactId == "protoc-gen-grpc-java"
+        )
+        val quarkusPlugin = dependencies.find(d =>
+          d.groupId == "io.quarkus" && d.artifactId == "quarkus-grpc-protoc-plugin"
+        ).get
+        val ordinaryJar = dependencies.find(d =>
+          d.groupId == "io.quarkus" && d.artifactId == "quarkus-grpc-codegen"
+        ).get
+
+        assert(
+          protoc.size == platformClassifiers.size,
+          protoc.map(_.classifier).toSet == platformClassifiers,
+          protoc.forall(_.artifactType == "exe"),
+          grpcPlugin.size == platformClassifiers.size,
+          grpcPlugin.map(_.classifier).toSet == platformClassifiers,
+          grpcPlugin.forall(_.artifactType == "exe"),
+          quarkusPlugin.artifactType == "jar",
+          quarkusPlugin.classifier == "shaded",
+          ordinaryJar.artifactType == "jar",
+          ordinaryJar.classifier.isEmpty
+        )
+      }
+    }
+
+    test("grpcCodeGeneration") {
+      UnitTester(TestCase, resourcePath).scoped { eval =>
+        val result = eval(TestCase.grpc.quarkusCodeGen).runtimeChecked.fold(
+          _.throwException,
+          identity
+        )
+        val generatedFiles = os.walk(result.value.path).filter(os.isFile).map(_.last).toSet
+
+        assert(
+          generatedFiles.contains("Ping.java"),
+          generatedFiles.contains("Pinger.java")
+        )
+      }
+    }
+  }
+}


### PR DESCRIPTION
Resolve Quarkus executable artifacts and preserve Coursier artifact types and classifiers in the application model. Avoid treating executable artifacts as JARs, and pass the actual build directory to Quarkus code generation so platform-specific protoc binaries can be staged and executed.

Cover the complete gRPC code-generation path and all published protoc platform classifiers.

Fixes #7331
