### PR TITLE
Normalize mtime to millis for PathRef quick signature rather than use FileTime

### DIFF
--- a/core/api/java11/src/mill/api/PathRef.scala
+++ b/core/api/java11/src/mill/api/PathRef.scala
@@ -140,7 +140,7 @@ object PathRef {
                 updateWithInt(os.perms(path, followLinks = false).value)
               }
               if (quick) {
-                val value = (attrs.mtime, attrs.size).hashCode()
+                val value = (attrs.mtime.toMillis, attrs.size).hashCode()
                 updateWithInt(value)
               } else if (jnio.Files.isReadable(path.toNIO)) {
                 val is =


### PR DESCRIPTION
FileTime can contain sub-milli information, or not, inconsistently across JVM versions. This can cause builds working with older JVMs to mysteriously break.

You can find a (`claude`-built) minimal reproduction of the issue [here](https://github.com/swaldman/mill-pathref-mtime-repro/).

Maintaining libraries for mill that compile with ancient (well, Java 11) JVMs, I ran into a strange failure:

```plaintext
java.lang.IllegalStateException: Worker wire broken, worker likely crashed. Check logs in: out/mill.javalib.JvmWorkerModule/internalWorker.dest/zinc-worker/-1576475074/daemon
  mill.rpc.MillRpcClient$.mill$rpc$MillRpcClient$$$_$awaitForResponse$1(MillRpcClient.scala:62)
  mill.rpc.MillRpcClient$$anon$1.apply(MillRpcClient.scala:95)
  mill.javalib.worker.SubprocessZincApi.apply$$anonfun$2$$anonfun$1$$anonfun$2(SubprocessZincApi.scala:127)
  mill.client.ServerLauncher$.runWithConnection(ServerLauncher.scala:76)
  ...
```

The real cause is visible under `out/mill.javalib.JvmWorkerModule/internalWorker.dest/zinc-worker/-1576475074/daemon/server.log`:

```plaintext
pid:59900 2026-08-30T15:07:03.036077 [t15] connection handler for Socket[addr=/127.0.0.1,port=58851,localport=58850] error: upickle.core.TraceVisitor$TraceException: $['data']['op']['compileClasspath'][0]
Caused by: mill.api.PathRef$PathRefValidationException: Invalid path signature detected: qref:v1:dbf3801a:/Users/swaldman/.ivy2/local/com.example.repro/lib/0.1.0-SNAPSHOT/jars/lib.jar
  at mill.api.PathRef$ValidatedPaths.revalidateIfNeededOrThrow(PathRef.scala:76)
  at mill.api.PathRef$.jsonFormatter$$anonfun$2(PathRef.scala:217)
  at upickle.core.Types$$anon$1.mapNonNullsFunction(Types.scala:25)
  at upickle.core.Visitor$MapReader.mapFunction(Visitor.scala:192)
  ...
```

Explicitly including millis, which is accessible and consistent across JVM versions, rather than the full, JVM-version-inconsistent, `FileTime` in the "quick" signature for `PathRef` resolves the problem.

**Drawback:** Compiling against newer JVMs, this fix widens the time window under which legitimate inconsistencies would not be detected from sub-millisecond to one millisecond. In practice, it's very unlikely that an artifact would be spuriously replaced within one millisecond. Perhaps on good hardware, an intentional adversary might be able to monitor a write and slip in a replacement within a one msec window. But that presumes an attacker with a great deal of access, who would likely much more easily just `touch -d` to reset the mtime on a changeling artifact.

_**Note:** Although my tiny human mind proposed the tiny little fix, it was the vast machine mind `claude` that traced the issue, explained it, and wrote the reproduction pointed to above._