### PR TITLE
Restore provenance headers to bootstrap scripts

### DIFF
--- a/dist/scripts/package.mill
+++ b/dist/scripts/package.mill
@@ -10,6 +10,9 @@ import millbuild.*
 
 object `package` extends mill.Module { scripts =>
 
+  private val bootstrapDocumentationUrl =
+    s"${Settings.docUrl}/mill/cli/installation-ide.html#_bootstrap_scripts"
+
   trait BootstrapScriptModule extends Module {
     override def moduleDir = scripts.moduleDir
     def templateFile: T[PathRef]
@@ -17,10 +20,9 @@ object `package` extends mill.Module { scripts =>
     def substitutions: T[Map[String, String]] = Map(
       "mill-version" -> build.millVersion(),
       "mill-repo-url" -> Settings.projectUrl,
+      "mill-download-url" -> build.millDownloadUrlCurrent(),
+      "mill-bootstrap-doc-url" -> bootstrapDocumentationUrl,
       "mill-maven-url" -> Settings.mavenRepoUrl,
-      "mill-download-cache-unix" -> "~/.cache/mill/download",
-      "mill-download-cache-win" -> "%USERPROFILE%\\\\.mill\\\\download",
-      "template-file" -> templateFile().path.relativeTo(BuildCtx.workspaceRoot).toString,
       "glibc-version" -> glibcVersion()
     )
     def substitutionMarkers: T[(String, String)] = ("{{{", "}}}")
@@ -99,7 +101,10 @@ object `package` extends mill.Module { scripts =>
       "MILL_TEST_SH_SCRIPT" -> PathRef.toResolvedPathString(millSh.compile0().path),
       "MILL_TEST_BAT_SCRIPT" -> PathRef.toResolvedPathString(millBat.compile0().path),
       "MILL_NATIVE_SUFFIX" -> build.dist.native.nativeSuffix(),
-      "MILL_EXPECTED_DEFAULT_VERSION" -> build.millVersion()
+      "MILL_EXPECTED_DEFAULT_VERSION" -> build.millVersion(),
+      "MILL_EXPECTED_PROJECT_URL" -> Settings.projectUrl,
+      "MILL_EXPECTED_DOWNLOAD_URL" -> build.millDownloadUrlCurrent(),
+      "MILL_EXPECTED_BOOTSTRAP_DOC_URL" -> bootstrapDocumentationUrl
     )
   }
   def scriptsModules: Seq[BootstrapScriptModule] = Seq(millSh, millBat)

--- a/dist/scripts/src/mill.bat
+++ b/dist/scripts/src/mill.bat
@@ -1,5 +1,10 @@
 @echo off
 
+rem Mill Build Tool: {{{ mill-repo-url }}}
+rem Download: {{{ mill-download-url }}}/mill-dist-{{{ mill-version }}}-mill.bat
+rem Documentation: {{{ mill-bootstrap-doc-url }}}
+rem Script Version: {{{ mill-version }}}
+
 setlocal enabledelayedexpansion
 
 if [!DEFAULT_MILL_VERSION!]==[] ( set "DEFAULT_MILL_VERSION={{{ mill-version }}}" )

--- a/dist/scripts/src/mill.sh
+++ b/dist/scripts/src/mill.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env sh
 
+# Mill Build Tool: {{{ mill-repo-url }}}
+# Download: {{{ mill-download-url }}}/mill-dist-{{{ mill-version }}}-mill.sh
+# Documentation: {{{ mill-bootstrap-doc-url }}}
+# Script Version: {{{ mill-version }}}
+
 set -e
 
 if [ -z "${DEFAULT_MILL_VERSION}" ] ; then DEFAULT_MILL_VERSION="{{{ mill-version }}}"; fi

--- a/dist/scripts/test/src/ScriptTests.scala
+++ b/dist/scripts/test/src/ScriptTests.scala
@@ -6,6 +6,38 @@ object ScriptTests extends TestSuite {
   def tests = Tests {
     val home = os.home
     val nativeSuffix = sys.env("MILL_NATIVE_SUFFIX")
+
+    test("provenanceHeaders") {
+      val version = sys.env("MILL_EXPECTED_DEFAULT_VERSION")
+      val projectUrl = sys.env("MILL_EXPECTED_PROJECT_URL")
+      val downloadUrl = sys.env("MILL_EXPECTED_DOWNLOAD_URL")
+      val documentationUrl = sys.env("MILL_EXPECTED_BOOTSTRAP_DOC_URL")
+
+      val shHeader = Seq(
+        "#!/usr/bin/env sh",
+        "",
+        s"# Mill Build Tool: $projectUrl",
+        s"# Download: $downloadUrl/mill-dist-$version-mill.sh",
+        s"# Documentation: $documentationUrl",
+        s"# Script Version: $version",
+        ""
+      )
+      val batHeader = Seq(
+        "@echo off",
+        "",
+        s"rem Mill Build Tool: $projectUrl",
+        s"rem Download: $downloadUrl/mill-dist-$version-mill.bat",
+        s"rem Documentation: $documentationUrl",
+        s"rem Script Version: $version",
+        ""
+      )
+
+      val shScript = os.Path(sys.env("MILL_TEST_SH_SCRIPT"), os.pwd)
+      val batScript = os.Path(sys.env("MILL_TEST_BAT_SCRIPT"), os.pwd)
+      assert(os.read.lines(shScript).take(shHeader.size) == shHeader)
+      assert(os.read.lines(batScript).take(batHeader.size) == batHeader)
+    }
+
     case class VersionPaths(
         version: String,
         downloadUrl: String,


### PR DESCRIPTION
Generated POSIX and Windows bootstrap scripts did not identify their project, download source, documentation, or generated Mill version.

Add that metadata to both script templates using canonical build settings, remove substitutions no longer consumed by either template, and verify the exact generated headers.

* Fix https://github.com/com-lihaoyi/mill/issues/6157
