### PR TITLE
Batch prompt repaints into one terminal write

### DIFF
--- a/core/internal/src/mill/internal/PromptLogger.scala
+++ b/core/internal/src/mill/internal/PromptLogger.scala
@@ -414,26 +414,33 @@ object PromptLogger {
 
     @volatile var lastPromptHeight = 0
 
-    def writeCurrentPrompt(): Unit = {
-      if (!paused()) {
-        val currentPrompt = getCurrentPrompt()
-        systemStreams0.err.write(currentPrompt)
-        if (interactive()) lastPromptHeight = String(currentPrompt).linesIterator.size
-        else lastPromptHeight = 0
-      } else lastPromptHeight = 0
+    private val clearScreenBytes = AnsiNav.clearScreen(0).getBytes
 
-      if (interactive()) systemStreams0.err.write(AnsiNav.clearScreen(0).getBytes)
+    def currentPromptBytes(): Array[Byte] = {
+      val isInteractive = interactive()
+      val promptBytes = if (!paused()) {
+        val currentPrompt = getCurrentPrompt()
+        if (isInteractive) lastPromptHeight = String(currentPrompt).linesIterator.size
+        else lastPromptHeight = 0
+        currentPrompt
+      } else {
+        lastPromptHeight = 0
+        Array.emptyByteArray
+      }
+
+      if (isInteractive) promptBytes ++ clearScreenBytes else promptBytes
     }
 
-    def moveUp() = {
-      if (lastPromptHeight != 0) {
-        systemStreams0.err.write((AnsiNav.left(9999) + AnsiNav.up(lastPromptHeight)).getBytes)
-      }
+    def writeCurrentPrompt(): Unit = systemStreams0.err.write(currentPromptBytes())
+
+    def moveUpBytes() = {
+      if (lastPromptHeight == 0) Array.emptyByteArray
+      else (AnsiNav.left(9999) + AnsiNav.up(lastPromptHeight)).getBytes
     }
 
     def refreshPrompt(): Unit = synchronizer.synchronized {
-      moveUp()
-      writeCurrentPrompt()
+      // Keep a repaint in one upstream write so RPC transport cannot expose the cursor mid-redraw.
+      systemStreams0.err.write(moveUpBytes() ++ currentPromptBytes())
     }
 
     object pumper extends ProxyStream.Pumper(
@@ -478,7 +485,7 @@ object PromptLogger {
         if (enableTicker && interactive()) {
           lastCharWritten = buf(end - 1).toChar
           synchronizer.synchronized {
-            moveUp()
+            systemStreams0.err.write(moveUpBytes())
             lastPromptHeight = 0
           }
           // Clear each line as they are drawn, rather than relying on clearing

--- a/core/internal/test/src/mill/internal/PromptLoggerTests.scala
+++ b/core/internal/test/src/mill/internal/PromptLoggerTests.scala
@@ -5,7 +5,17 @@ import mill.constants.ProxyStream
 import utest.*
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, PrintStream}
+import java.nio.charset.StandardCharsets
 object PromptLoggerTests extends TestSuite {
+
+  private class RecordingOutputStream extends ByteArrayOutputStream {
+    val writes = collection.mutable.ArrayBuffer.empty[String]
+
+    override def write(bytes: Array[Byte], offset: Int, length: Int): Unit = {
+      writes.append(String(bytes, offset, length, StandardCharsets.UTF_8))
+      super.write(bytes, offset, length)
+    }
+  }
 
   def setup(now: () => Long, terminalDimsCallback: () => Option[(Option[Int], Option[Int])]) = {
     val baos = ByteArrayOutputStream()
@@ -252,6 +262,46 @@ object PromptLoggerTests extends TestSuite {
         "123/456] TITLE 32s",
         ""
       )
+    }
+
+    test("interactiveRefreshIsSingleWrite") {
+      var now = 0L
+      val recordedErr = new RecordingOutputStream
+      val promptLogger = new PromptLogger(
+        colored = false,
+        enableTicker = true,
+        infoColor = fansi.Attrs.Empty,
+        warnColor = fansi.Attrs.Empty,
+        errorColor = fansi.Attrs.Empty,
+        successColor = fansi.Attrs.Empty,
+        highlightColor = fansi.Attrs.Empty,
+        systemStreams0 = SystemStreams(
+          PrintStream(ByteArrayOutputStream()),
+          PrintStream(recordedErr),
+          System.in
+        ),
+        debugEnabled = false,
+        titleText = "TITLE",
+        terminalDimsCallback = () => Some((Some(80), Some(40))),
+        currentTimeMillis = () => now,
+        autoUpdate = false,
+        chromeProfileLogger = new JsonArrayLogger.ChromeProfile(os.temp())
+      )
+
+      try {
+        promptLogger.prompt.setPromptLine(Seq("1"), "/1", "task")
+        now = 1000L
+        promptLogger.refreshPrompt()
+
+        recordedErr.writes.clear()
+        now = 2000L
+        promptLogger.refreshPrompt()
+
+        assert(recordedErr.writes.size == 1)
+        val repaint = recordedErr.writes.head
+        assert(repaint.startsWith(AnsiNav.left(9999) + AnsiNav.up(2)))
+        assert(repaint.endsWith(AnsiNav.clearScreen(0)))
+      } finally promptLogger.close()
     }
 
     test("detail") {


### PR DESCRIPTION
After daemon output moved over RPC, cursor movement, prompt contents, screen clearing, and cursor restoration were sent as separate messages. The launcher could observe an incomplete repaint and leave the cursor in the wrong position.

Build each repaint as one byte sequence and emit it through one upstream write while preserving interactive, paused, and prompt-height behavior. Verify that repeated interactive refresh uses one write with the expected cursor and clearing commands.

Fix: https://github.com/com-lihaoyi/mill/issues/6870

Pull request: https://github.com/com-lihaoyi/mill/pull/7513