### PR TITLE
Restore scalalib PublishModule external resolution

### DIFF
--- a/integration/feature/script-external-task-rendering/src/ScriptExternalTaskRendering.scala
+++ b/integration/feature/script-external-task-rendering/src/ScriptExternalTaskRendering.scala
@@ -49,6 +49,18 @@ object ScriptExternalTaskRendering extends UtestIntegrationTestSuite {
             "mill.scalalib.scalafmt.ScalafmtModule/scalafmtClasspath"
           )
       )
+
+      val resolvePublishModule = eval(("resolve", "mill.scalalib.PublishModule/publishAll"))
+      assert(resolvePublishModule.exitCode == 0)
+      assert(
+        resolvePublishModule.out.linesIterator.toSeq ==
+          Seq("mill.scalalib.PublishModule/publishAll")
+      )
+
+      val publishModuleDefaultTask = eval(("mill.scalalib.PublishModule/", "--help"))
+      assert(publishModuleDefaultTask.exitCode == 1)
+      assert(publishModuleDefaultTask.err.contains("Expected Signature: publishAll"))
+      assert(!publishModuleDefaultTask.err.contains("unknown extension"))
     }
   }
 }

--- a/libs/scalalib/src/mill/scalalib/aliases.scala
+++ b/libs/scalalib/src/mill/scalalib/aliases.scala
@@ -3,5 +3,8 @@ package mill.scalalib
 object Dependency extends mill.api.ExternalModule.Alias(mill.javalib.Dependency)
 object MavenPublishModule
     extends mill.api.ExternalModule.Alias(mill.javalib.MavenPublishModule)
+object PublishModule extends mill.api.ExternalModule.Alias(mill.javalib.PublishModule) {
+  export mill.javalib.PublishModule.*
+}
 object SonatypeCentralPublishModule
     extends mill.api.ExternalModule.Alias(mill.javalib.SonatypeCentralPublishModule)

--- a/libs/scalalib/src/mill/scalalib/exports.scala
+++ b/libs/scalalib/src/mill/scalalib/exports.scala
@@ -38,7 +38,13 @@ export mill.javalib.OfflineSupport
 
 export mill.javalib.OfflineSupportModule
 
-export mill.javalib.PublishModule
+type PublishModule = mill.javalib.PublishModule
+
+// Keep the JVM forwarder emitted by the former `export mill.javalib.PublishModule`.
+// The source-level term now resolves to the physical ExternalModule alias in aliases.scala.
+@scala.annotation.targetName("PublishModule")
+def publishModuleBinaryForwarder: mill.javalib.PublishModule.type =
+  mill.javalib.PublishModule
 
 export mill.javalib.RunModule
 


### PR DESCRIPTION
The scalalib PublishModule term was only a Scala export of the javalib external module. External-module discovery requires a physical object in the requested package, so mill.scalalib.PublishModule selectors failed as unknown extensions.

Add a physical ExternalModule alias, retain the source type alias and exported members, and emit the former JVM forwarder for binary compatibility. Integration coverage resolves the selector and default task, while MiMa validates the published API.
