### PR TITLE
Fix standalone task graphs and Graphviz error hangs

### DIFF
--- a/example/cli/builtins/1-builtin-commands/build.mill
+++ b/example/cli/builtins/1-builtin-commands/build.mill
@@ -338,6 +338,25 @@ graph ["rankdir"="LR"]
 // so it's easier to visualize while preserving the overall structure of the graph, but
 // it does mean that there will be some duplicate edges that are not shown.
 //
+// Tasks without dependencies are rendered as standalone nodes.
+//
+/** Usage
+> ./mill visualize foo.artifactId
+[
+  ".../out/visualize.dest/out.dot",
+  ".../out/visualize.dest/out.json",
+  ".../out/visualize.dest/out.png",
+  ".../out/visualize.dest/out.svg",
+  ".../out/visualize.dest/out.txt"
+]
+
+> cat out/visualize.dest/out.dot
+digraph "example1" {
+graph ["rankdir"="LR"]
+"foo.artifactId" ["style"="solid","shape"="box"]
+}
+*/
+//
 // == visualizePlan
 //
 /** Usage

--- a/libs/graphviz/src/mill/graphviz/GraphvizTools.scala
+++ b/libs/graphviz/src/mill/graphviz/GraphvizTools.scala
@@ -31,21 +31,48 @@ object GraphvizTools {
       implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(executor)
       val futures =
         for (arg <- args.toSeq) yield Future {
-          val Array(src, dest0, commaSepExtensions) = arg.split(";")
-          val extensions = commaSepExtensions.split(',')
-          val dest = os.Path(dest0, os.pwd)
-
-          val gv = Graphviz.fromFile(new java.io.File(src)).totalMemory(128 * 1024 * 1024)
-
-          val outputs = extensions
-            .map(ext => Format.values().find(_.fileExtension == ext).head -> s"out.$ext")
-
-          for ((fmt, name) <- outputs) gv.render(fmt).toFile((dest / name).toIO)
+          render(arg)
         }
 
       Await.result(Future.sequence(futures), duration.Duration.Inf)
     } finally executor.shutdown()
   }
+
+  private def render(arg: String): Unit = {
+    var currentOutput = Option.empty[String]
+    try {
+      val Array(src, dest0, commaSepExtensions) = arg.split(";")
+      val extensions = commaSepExtensions.split(',')
+      val dest = os.Path(dest0, os.pwd)
+
+      val gv = Graphviz.fromFile(new java.io.File(src)).totalMemory(128 * 1024 * 1024)
+
+      val outputs = extensions
+        .map(ext => Format.values().find(_.fileExtension == ext).head -> s"out.$ext")
+
+      for ((fmt, name) <- outputs) {
+        currentOutput = Some(name)
+        gv.render(fmt).toFile((dest / name).toIO)
+      }
+    } catch {
+      // scala.concurrent.Future catches NonFatal failures only. Wrap fatal rendering errors so the
+      // future is completed exceptionally instead of leaving Await.result blocked forever.
+      case error: Error =>
+        val detail = currentOutput.fold("Graphviz rendering failed")(name => s"Could not render $name")
+        val message =
+          if (causedByMissingFontConfig(error)) {
+            s"$detail because Java's font system could not initialize. " +
+              "Install fontconfig and at least one system font, then retry."
+          } else {
+            s"$detail: ${error.getClass.getName}: ${Option(error.getMessage).getOrElse("")}"
+          }
+        throw new RuntimeException(message, error)
+    }
+  }
+
+  private def causedByMissingFontConfig(error: Throwable): Boolean =
+    Option(error.getMessage).exists(_.contains("Fontconfig head is null")) ||
+      Option(error.getCause).exists(causedByMissingFontConfig)
 }
 
 class V8JavascriptEngine() extends AbstractJavascriptEngine {

--- a/libs/graphviz/src/mill/graphviz/GraphvizTools.scala
+++ b/libs/graphviz/src/mill/graphviz/GraphvizTools.scala
@@ -58,7 +58,8 @@ object GraphvizTools {
       // scala.concurrent.Future catches NonFatal failures only. Wrap fatal rendering errors so the
       // future is completed exceptionally instead of leaving Await.result blocked forever.
       case error: Error =>
-        val detail = currentOutput.fold("Graphviz rendering failed")(name => s"Could not render $name")
+        val detail =
+          currentOutput.fold("Graphviz rendering failed")(name => s"Could not render $name")
         val message =
           if (causedByMissingFontConfig(error)) {
             s"$detail because Java's font system could not initialize. " +

--- a/libs/graphviz/src/mill/graphviz/VisualizeWorkerMain.scala
+++ b/libs/graphviz/src/mill/graphviz/VisualizeWorkerMain.scala
@@ -16,14 +16,16 @@ object VisualizeWorkerMain {
 
   private def render(payload: os.Path, dest: os.Path): Unit = {
     val parsed = ujson.read(os.read(payload))
-    val selected = parsed("tasks").arr.map(_.str).toSet
+    val selectedTasks = parsed("tasks").arr.map(_.str)
+    val selected = selectedTasks.toSet
     val edges = parsed("edges").arr.map { entry =>
       val src = entry("src").str
       val dests = entry("dests").arr.map(_.str).toArray.distinct
       (src, dests)
     }.toArray
 
-    val indexToTask = edges.flatMap { case (k, vs) => Iterator(k) ++ vs }.distinct
+    val indexToTask =
+      (edges.flatMap { case (k, vs) => Iterator(k) ++ vs } ++ selectedTasks).distinct
     val taskToIndex = indexToTask.zipWithIndex.toMap
 
     val jgraph = new SimpleDirectedGraph[Int, DefaultEdge](classOf[DefaultEdge])
@@ -40,22 +42,22 @@ object VisualizeWorkerMain {
         .`with`(Shape.BOX)
     )
 
-    var g = graph("example1").directed
-    for (i <- indexToTask.indices) {
-      for {
-        target <- edges(i)._2
-        j = taskToIndex(target)
-        if jgraph.containsEdge(i, j)
-      } {
-        g = g.`with`(nodes(j).link(nodes(i)))
-      }
+    var g = graph("example1").directed.`with`(nodes*)
+    for {
+      (src, dests) <- edges
+      target <- dests
+      i = taskToIndex(src)
+      j = taskToIndex(target)
+      if jgraph.containsEdge(i, j)
+    } {
+      g = g.`with`(nodes(j).link(nodes(i)))
     }
     g = g.graphAttr().`with`(Rank.dir(RankDir.LEFT_TO_RIGHT))
 
     val graphFile = os.temp(prefix = "mill-visualize-", suffix = ".dot")
     try {
       os.write.over(graphFile, g.toString)
-      GraphvizTools.main(Array(s"$graphFile;$dest;txt,dot,json,png,svg"))
+      GraphvizTools.main(Array(s"$graphFile;$dest;txt,dot,json,svg,png"))
     } finally {
       os.remove(graphFile, checkExists = false)
     }

--- a/libs/graphviz/test/src/mill/graphviz/VisualizeWorkerMainTests.scala
+++ b/libs/graphviz/test/src/mill/graphviz/VisualizeWorkerMainTests.scala
@@ -61,8 +61,9 @@ object VisualizeWorkerMainTests extends TestSuite {
         process.environment().put("FONTCONFIG_PATH", dest.toString)
 
         val running = process.start()
-        val completed = try running.waitFor(20, TimeUnit.SECONDS)
-        finally if (running.isAlive) running.destroyForcibly()
+        val completed =
+          try running.waitFor(20, TimeUnit.SECONDS)
+          finally if (running.isAlive) running.destroyForcibly()
 
         assert(completed)
         assert(running.exitValue() != 0)

--- a/libs/graphviz/test/src/mill/graphviz/VisualizeWorkerMainTests.scala
+++ b/libs/graphviz/test/src/mill/graphviz/VisualizeWorkerMainTests.scala
@@ -1,0 +1,94 @@
+package mill.graphviz
+
+import utest.*
+
+import javax.imageio.ImageIO
+import java.util.concurrent.TimeUnit
+
+object VisualizeWorkerMainTests extends TestSuite {
+
+  def tests: Tests = Tests {
+    test("standaloneNode") {
+      val dest = render(
+        ujson.Obj(
+          "tasks" -> ujson.Arr("standalone"),
+          "edges" -> ujson.Arr(ujson.Obj("src" -> "standalone", "dests" -> ujson.Arr()))
+        )
+      )
+
+      assert(os.read(dest / "out.dot").contains("\"standalone\""))
+      assert(os.read(dest / "out.json").contains("\"name\": \"standalone\""))
+      assert(os.read(dest / "out.svg").contains("standalone"))
+      assert(os.read(dest / "out.txt").contains("node standalone"))
+    }
+
+    test("transitiveReduction") {
+      val dest = render(
+        ujson.Obj(
+          "tasks" -> ujson.Arr("root", "middle", "leaf"),
+          "edges" -> ujson.Arr(
+            ujson.Obj("src" -> "root", "dests" -> ujson.Arr("middle", "leaf")),
+            ujson.Obj("src" -> "middle", "dests" -> ujson.Arr("leaf"))
+          )
+        )
+      )
+      val dot = os.read(dest / "out.dot")
+
+      assert(dot.contains("\"leaf\" -> \"middle\""))
+      assert(dot.contains("\"middle\" -> \"root\""))
+      assert(!dot.contains("\"leaf\" -> \"root\""))
+    }
+
+    test("missingFontConfig") {
+      if (scala.util.Properties.isLinux) {
+        val graphFile = os.temp("digraph { standalone }")
+        val dest = os.temp.dir()
+        val missingFontConfig = dest / "missing-fontconfig.conf"
+        val java = os.Path(sys.props("java.home")) / "bin" / "java"
+        val stdout = os.temp()
+        val stderr = os.temp()
+        val process = new ProcessBuilder(
+          java.toString,
+          s"-Dsun.awt.fontconfig=$missingFontConfig",
+          "-cp",
+          sys.props("java.class.path"),
+          "mill.graphviz.GraphvizTools",
+          s"$graphFile;$dest;txt,dot,json,svg,png"
+        )
+          .redirectOutput(stdout.toIO)
+          .redirectError(stderr.toIO)
+        process.environment().put("FONTCONFIG_FILE", missingFontConfig.toString)
+        process.environment().put("FONTCONFIG_PATH", dest.toString)
+
+        val running = process.start()
+        val completed = try running.waitFor(20, TimeUnit.SECONDS)
+        finally if (running.isAlive) running.destroyForcibly()
+
+        assert(completed)
+        assert(running.exitValue() != 0)
+        assert(Seq("txt", "dot", "json", "svg").forall(ext => os.size(dest / s"out.$ext") > 0))
+        assert(!os.exists(dest / "out.png"))
+        assert(
+          os.read(stderr).contains(
+            "Install fontconfig and at least one system font, then retry."
+          )
+        )
+      }
+    }
+  }
+
+  private def render(payload: ujson.Value): os.Path = {
+    val payloadPath = os.temp(payload.render())
+    val dest = os.temp.dir()
+    VisualizeWorkerMain.main(Array(payloadPath.toString, dest.toString))
+
+    assert(
+      os.list(dest).map(_.last).sorted ==
+        Seq("out.dot", "out.json", "out.png", "out.svg", "out.txt")
+    )
+    val png = ImageIO.read((dest / "out.png").toIO)
+    assert(png != null)
+    assert(png.getWidth > 8, png.getHeight > 8)
+    dest
+  }
+}


### PR DESCRIPTION
Fix #6669

Graph construction derived vertices only while linking edges, so a selected task without dependencies produced an empty graph. Add every selected task before linking the transitively reduced edges.

Graphviz can also throw an Error while initializing Java font support. Scala futures do not capture fatal errors, which left the worker blocked in Await.result. Convert rendering errors into failed futures, report missing fontconfig directly, and render portable formats before PNG without reporting success when a requested file is absent.

Cover standalone nodes, transitive reduction, normal PNG output, and the missing-fontconfig failure under a strict Linux timeout.
