### PR TITLE
Discover non-public overrides for task path mapping

### DIFF
--- a/core/api/src/mill/api/Discover.scala
+++ b/core/api/src/mill/api/Discover.scala
@@ -52,9 +52,15 @@ final class Discover(val classInfo: Map[Class[?], Discover.ClassInfo]) {
 object Discover {
   final class ClassInfo(
       val entryPoints: Seq[mainargs.MainData[?, ?]],
-      val declaredTasks: Seq[TaskInfo]
+      val declaredTasks: Seq[TaskInfo],
+      @com.lihaoyi.unroll val pathTaskNames: Seq[String] = null
   ) {
     lazy val declaredTaskNameSet = declaredTasks.map(_.name).toSet
+
+    // Older ClassInfo instances do not contain the path-only metadata. Falling back to
+    // declaredTasks preserves their behavior while @unroll preserves constructor compatibility.
+    private[mill] lazy val pathTaskNameSet =
+      Option(pathTaskNames).fold(declaredTaskNameSet)(_.toSet)
     lazy val nonBootstrappedTaskNames = declaredTasks.filter(_.nonBootstrapped).map(_.name).toSet
   }
   final class TaskInfo(val name: String, @com.lihaoyi.unroll val nonBootstrapped: Boolean = false)
@@ -70,6 +76,7 @@ object Discover {
       import quotes.reflect.*
       val seen = mutable.Set.empty[TypeRepr]
       val moduleSym = Symbol.requiredClass("mill.api.Module")
+      val moduleRefSym = Symbol.requiredClass("mill.api.ModuleRef")
 
       def rec(tpe: TypeRepr): Unit = {
         if (seen.add(tpe)) {
@@ -81,14 +88,20 @@ object Discover {
 
           val parentTypes: Seq[TypeRepr] = tpe.baseClasses.map(_.typeRef)
 
-          for {
-            tpe <- memberTypes ++ parentTypes
-            if tpe.baseClasses.contains(moduleSym)
-          } {
-            rec(tpe)
-            tpe.asType match {
-              case '[mill.api.Cross[m]] => rec(TypeRepr.of[m])
-              case _ => () // no cross argument to extract
+          for (memberType <- memberTypes ++ parentTypes) {
+            val widened = memberType.widen.dealias
+            if (widened.baseClasses.contains(moduleSym)) {
+              rec(widened)
+              widened.asType match {
+                case '[mill.api.Cross[m]] => rec(TypeRepr.of[m])
+                case _ => () // no cross argument to extract
+              }
+            } else {
+              widened match {
+                case AppliedType(moduleRef, Seq(referenced))
+                    if moduleRef.typeSymbol == moduleRefSym => rec(referenced)
+                case _ => ()
+              }
             }
           }
         }
@@ -124,10 +137,25 @@ object Discover {
       // changing unnecessarily
       val mapping: Seq[(
           TypeRepr,
-          (Seq[scala.quoted.Expr[mainargs.MainData[?, ?]]], Seq[(String, Boolean)])
+          (
+              Seq[scala.quoted.Expr[mainargs.MainData[?, ?]]],
+              Seq[(String, Boolean)],
+              Seq[String]
+          )
       )] =
         for (curCls <- seen.toSeq.sortBy(_.typeSymbol.fullName)) yield {
           val declMethods = filterDefs(curCls.typeSymbol.declaredMethods)
+
+          val pathTaskMethods = sortedMethods(
+            curCls,
+            sub = TypeRepr.of[mill.api.Task.Named[?]],
+            curCls.typeSymbol.declaredMethods.filterNot { m =>
+              m.isSuperAccessor ||
+              m.flags.is(Flags.Synthetic) ||
+              m.flags.is(Flags.Invisible) ||
+              (m.flags.is(Flags.Private) && m.privateWithin.isEmpty)
+            }
+          )
 
           val taskMethods = sortedMethods(
             curCls,
@@ -164,12 +192,13 @@ object Discover {
               expr
           }
 
-          (curCls.widen, (entryPoints, names))
+          (curCls.widen, (entryPoints, names, pathTaskMethods.map(_.name)))
         }
 
       def classOf(cls: TypeRepr) = Ref(defn.Predef_classOf).appliedToType(cls).asExprOf[Class[?]]
       val mappingExpr = mapping.collect {
-        case (cls, (entryPoints, names)) if entryPoints.nonEmpty || names.nonEmpty =>
+        case (cls, (entryPoints, names, pathTaskNames))
+            if entryPoints.nonEmpty || names.nonEmpty || pathTaskNames.nonEmpty =>
           // by wrapping the `overridesRoutes` in a lambda function we kind of work around
           // the problem of generating a *huge* macro method body that finally exceeds the
           // JVM's maximum allowed method size
@@ -180,7 +209,8 @@ object Discover {
                 Expr.ofList(names.map { case (name, nonBootstrapped) =>
                   '{ TaskInfo(${ Expr(name) }, ${ Expr(nonBootstrapped) }) }
                 })
-              }
+              },
+              ${ Expr.ofList(pathTaskNames.map(Expr(_)).toList) }
             )
 
             (${ classOf(cls) }, func())

--- a/core/api/src/mill/api/internal/OverrideMapping.scala
+++ b/core/api/src/mill/api/internal/OverrideMapping.scala
@@ -27,7 +27,7 @@ private[mill] object OverrideMapping {
       case Some(value) =>
         val linearized = value.moduleLinearized
         val declaring = linearized.filter(cls =>
-          discover.classInfo.get(cls).exists(_.declaredTaskNameSet.contains(lastSegmentStr))
+          discover.classInfo.get(cls).exists(_.pathTaskNameSet.contains(lastSegmentStr))
         )
 
         if (declaring.isEmpty || declaring.lastOption.contains(enclosingClassValue)) None

--- a/core/api/test/src/mill/api/DiscoverTests.scala
+++ b/core/api/test/src/mill/api/DiscoverTests.scala
@@ -2,7 +2,39 @@ package mill.api
 
 import mill.api.TestGraphs
 import Task.Simple
+import mill.testkit.TestRootModule
 import utest.*
+
+trait DiscoverVisibilityModule extends Module {
+  def publicTask = Task { 1 }
+  protected def protectedTask = Task { 2 }
+  private[mill] def packageTask = Task { 3 }
+  private def privateTask = Task { 4 }
+}
+
+object DiscoverVisibilityRoot extends TestRootModule with DiscoverVisibilityModule {
+  lazy val millDiscover = Discover[this.type]
+}
+
+trait DiscoverReferencedModule extends Module {
+  def referencedPublicTask = Task { 1 }
+  private[mill] def referencedPackageTask = Task { 2 }
+}
+
+object DiscoverModuleRefRoot extends TestRootModule {
+  def referenced: ModuleRef[DiscoverReferencedModule] =
+    sys.error("discovery must not evaluate ModuleRef")
+  lazy val millDiscover = Discover[this.type]
+}
+
+trait DiscoverAbstractModule extends Module {
+  def concreteTask = Task { 1 }
+  protected def abstractTask: Task.Simple[Int]
+}
+
+object DiscoverAbstractRoot {
+  lazy val millDiscover = Discover[DiscoverAbstractModule]
+}
 
 object DiscoverTests extends TestSuite {
   val tests = Tests {
@@ -63,6 +95,43 @@ object DiscoverTests extends TestSuite {
         _.cross("212").cross2("js").suffix,
         _.cross("212").cross2("native").suffix
       )
+    }
+    test("path task names retain non-public tasks") {
+      val classInfo =
+        DiscoverVisibilityRoot.millDiscover.classInfo(classOf[DiscoverVisibilityModule])
+
+      assert(
+        classInfo.declaredTaskNameSet == Set("publicTask"),
+        classInfo.pathTaskNameSet == Set(
+          "publicTask",
+          "protectedTask",
+          "packageTask"
+        ),
+        DiscoverVisibilityRoot.millDiscover.allTaskNames == Set("publicTask")
+      )
+    }
+    test("module refs contribute path task metadata") {
+      val classInfo =
+        DiscoverModuleRefRoot.millDiscover.classInfo(classOf[DiscoverReferencedModule])
+
+      assert(
+        classInfo.declaredTaskNameSet == Set("referencedPublicTask"),
+        classInfo.pathTaskNameSet == Set("referencedPublicTask", "referencedPackageTask"),
+        DiscoverModuleRefRoot.millDiscover.allTaskNames == Set("referencedPublicTask")
+      )
+    }
+    test("path task names exclude abstract declarations") {
+      val classInfo =
+        DiscoverAbstractRoot.millDiscover.classInfo(classOf[DiscoverAbstractModule])
+
+      assert(
+        classInfo.declaredTaskNameSet == Set("concreteTask"),
+        classInfo.pathTaskNameSet == Set("concreteTask")
+      )
+    }
+    test("legacy class info falls back to CLI-visible tasks") {
+      val classInfo = Discover.ClassInfo(Nil, Seq(Discover.TaskInfo("publicTask")))
+      assert(classInfo.pathTaskNameSet == Set("publicTask"))
     }
 
   }

--- a/integration/feature/gen-idea/resources/android/app/src/main/AndroidManifest.xml
+++ b/integration/feature/gen-idea/resources/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application android:theme="@style/AppTheme" />
+</manifest>

--- a/integration/feature/gen-idea/resources/android/app/src/main/res/values/styles.xml
+++ b/integration/feature/gen-idea/resources/android/app/src/main/res/values/styles.xml
@@ -1,0 +1,3 @@
+<resources>
+    <style name="AppTheme" parent="android:style/Theme.Material.Light" />
+</resources>

--- a/integration/feature/gen-idea/resources/android/build.mill
+++ b/integration/feature/gen-idea/resources/android/build.mill
@@ -1,0 +1,13 @@
+package build
+
+import mill.*, androidlib.*
+
+object sdk extends AndroidSdkModule {
+  def buildToolsVersion = "35.0.0"
+}
+
+object app extends AndroidModule {
+  def androidSdkModule = mill.api.ModuleRef(sdk)
+  def androidCompileSdk = 35
+  def androidNamespace = "example.app"
+}

--- a/integration/feature/gen-idea/src/GenIdeaAndroidTests.scala
+++ b/integration/feature/gen-idea/src/GenIdeaAndroidTests.scala
@@ -1,0 +1,47 @@
+package mill.integration
+
+import mill.testkit.UtestIntegrationTestSuite
+import os.Path
+import utest.*
+
+object GenIdeaAndroidTests extends UtestIntegrationTestSuite {
+
+  override def workspaceSourcePath: Path = super.workspaceSourcePath / "android"
+  override def allowSharedOutputDir: Boolean = false
+
+  def tests: Tests = Tests {
+    test("android idea generation uses distinct override paths") - integrationTest { tester =>
+      import tester.*
+
+      val androidHome = Seq(
+        sys.env.get("ANDROID_HOME").map(os.Path(_, os.pwd)),
+        sys.env.get("ANDROID_SDK_ROOT").map(os.Path(_, os.pwd)),
+        Some(os.home / "Library" / "Android" / "sdk"),
+        Some(os.home / "Android" / "Sdk"),
+        Some(os.Path("/opt/android-sdk"))
+      ).flatten.find(os.exists).getOrElse(sys.error("Android SDK is required for this test"))
+
+      eval(
+        "mill.idea/",
+        env = Map("ANDROID_HOME" -> androidHome.toString),
+        check = true,
+        timeout = 120000
+      )
+
+      val ideaTasks = workspacePath / "out" / "app" / "internalGenIdea"
+      assert(
+        os.exists(workspacePath / ".idea" / "modules.xml"),
+        os.exists(ideaTasks / "extDependencies.json"),
+        os.exists(
+          ideaTasks / "extDependencies.super" / "GenIdeaAndroidModule.json"
+        ),
+        os.exists(ideaTasks / "moduleGeneratedSources.json"),
+        os.exists(
+          ideaTasks / "moduleGeneratedSources.super" / "GenIdeaAndroidModule.json"
+        ),
+        !os.exists(ideaTasks / "androidExtDependencies.json"),
+        !os.exists(ideaTasks / "androidModuleGeneratedSources.json")
+      )
+    }
+  }
+}

--- a/libs/androidlib/test/src/mill/androidlib/GenIdeaAndroidModuleTests.scala
+++ b/libs/androidlib/test/src/mill/androidlib/GenIdeaAndroidModuleTests.scala
@@ -1,0 +1,62 @@
+package mill.androidlib
+
+import java.util.{Collections, IdentityHashMap}
+
+import mill.*
+import mill.api.{Discover, ModuleRef}
+import mill.testkit.TestRootModule
+import utest.*
+
+import scala.collection.mutable
+
+object GenIdeaAndroidModuleTests extends TestSuite {
+
+  object build extends TestRootModule {
+    object sdk extends AndroidSdkModule {
+      def buildToolsVersion = "35.0.0"
+    }
+
+    object app extends AndroidModule {
+      def androidSdkModule = ModuleRef(sdk)
+      def androidCompileSdk = 35
+      def androidNamespace = "example"
+    }
+
+    lazy val millDiscover = Discover[this.type]
+  }
+
+  def tests: Tests = Tests {
+    test("idea tasks have unique output paths") {
+      val terminal = build.app.genIdeaInternalExt().genIdeaResolvedModule(
+        ideaConfigVersion = 4,
+        build.app.moduleSegments
+      )
+      val transitive = mutable.ArrayBuffer.empty[Task[?]]
+      val seen = Collections.newSetFromMap(new IdentityHashMap[Task[?], java.lang.Boolean])
+
+      def visit(task: Task[?]): Unit =
+        if (seen.add(task)) {
+          transitive += task
+          task.inputs.foreach(visit)
+        }
+
+      visit(terminal)
+
+      val taskPaths = transitive
+        .collect { case task: Task.Named[?] => task.ctx.segments.render }
+      val duplicatePaths = taskPaths
+        .groupMapReduce(identity)(_ => 1)(_ + _)
+        .filter(_._2 > 1)
+
+      assert(
+        duplicatePaths.isEmpty,
+        taskPaths.contains("app.internalGenIdea.extDependencies"),
+        taskPaths.contains("app.internalGenIdea.extDependencies.super.GenIdeaAndroidModule"),
+        taskPaths.contains("app.internalGenIdea.moduleGeneratedSources"),
+        taskPaths.contains(
+          "app.internalGenIdea.moduleGeneratedSources.super.GenIdeaAndroidModule"
+        )
+      )
+    }
+  }
+}


### PR DESCRIPTION
Fix #7080

Fine-grained locking distinguishes an override from its inherited implementation through the task override map. Discover only recorded CLI-visible tasks, so the package-private overrides in GenIdeaAndroidModule were absent and both task nodes received the same output path. mill.idea then waited for a lock already held by its own dependency graph.

Record concrete overridable named tasks separately from CLI entrypoints and use that metadata only for task path mapping. Follow ModuleRef result types so internal IDEA wrapper modules are discovered without evaluating the references, while excluding abstract and truly private methods and preserving the existing ClassInfo constructor.

Cover visibility and compatibility rules, the Android task graph paths, and the original mill.idea daemon reproduction under a strict timeout.
