### PR TITLE
Do not generate Eclipse files for mixed projects

### DIFF
--- a/runner/eclipse/src/mill/eclipse/GenEclipseImpl.scala
+++ b/runner/eclipse/src/mill/eclipse/GenEclipseImpl.scala
@@ -148,6 +148,39 @@ class GenEclipseImpl(private val evaluators: Seq[EvaluatorApi]) {
   }
 
   /**
+   *  Finds all Module dependencies of the (aggregated) Java Modules that are not themselves part
+   *  of `resolvedJavaModules`, i.e. dependencies on Modules for which no Eclipse JDT Project will
+   *  be generated (e.g. Scala / Kotlin Modules, which Eclipse JDT does not support).
+   *
+   *  @param resolvedJavaModules base for finding the "foreign" dependencies
+   *  @return a map from the path of a not-generated dependency to the paths of the Java Modules
+   *          that depend on it
+   */
+  private def findNonJavaModuleDependants(resolvedJavaModules: Map[Path, JavaResolvedModuleDto])
+      : Map[Path, Set[Path]] = {
+    val dependantsByMissingPath = mutable.Map.empty[Path, mutable.Set[Path]]
+
+    for ((path, dto) <- resolvedJavaModules) {
+      val allDependencyPaths = dto.resolvedModule.allModuleDependencies ++
+        dto.sourceSetResolvedModules.flatMap(_.allModuleDependencies)
+
+      for (dependencyPath <- allDependencyPaths if !resolvedJavaModules.contains(dependencyPath)) {
+        dependantsByMissingPath.getOrElseUpdate(dependencyPath, mutable.Set.empty) += path
+      }
+    }
+
+    dependantsByMissingPath.map { case (path, dependants) => path -> dependants.toSet }.toMap
+  }
+
+  /** Gives a human-readable name for the kind of a Mill Module, for use in log / error messages. */
+  private def describeModuleKind(module: ModuleApi): String = module match {
+    case _: ScalaModuleApi => "Scala Module"
+    case _: KotlinModuleApi => "Kotlin Module"
+    case _: JavaModuleApi => "Java Module"
+    case _ => module.getClass.getSimpleName
+  }
+
+  /**
    *  This converts the DTO into an actual model for an Eclipse JDT Project.
    *
    *  @param resolvedJavaModules base for converting to a project model
@@ -272,6 +305,27 @@ class GenEclipseImpl(private val evaluators: Seq[EvaluatorApi]) {
 
     val resolvedJavaModules: Map[Path, JavaResolvedModuleDto] =
       getResolvedJavaModules(aggregatedJavaModules)
+
+    // Eclipse JDT does not support Scala / Kotlin Modules, so if a Java Module depends on one of
+    // those, we cannot generate a working set of Eclipse JDT Projects: there is no Eclipse Project
+    // to point the dependency at. Rather than generating a broken / incomplete result, we bail out
+    // here and tell the user which dependencies are the problem.
+    val nonJavaModuleDependants = findNonJavaModuleDependants(resolvedJavaModules)
+    if (nonJavaModuleDependants.nonEmpty) {
+      val allModulesByPath: Map[Path, ModuleApi] =
+        transitiveModules(evaluators.head.rootModule).map(module => module.moduleDirJava -> module).toMap
+
+      log(
+        "Cannot generate Eclipse JDT Projects: found Java Module dependencies on Modules that " +
+          "Eclipse JDT does not support (e.g. Scala / Kotlin Modules):"
+      )
+      for ((dependencyPath, dependantPaths) <- nonJavaModuleDependants) {
+        val kind = allModulesByPath.get(dependencyPath).map(describeModuleKind).getOrElse("unknown")
+        log(s" - $dependencyPath ($kind), required by: ${dependantPaths.mkString(", ")}")
+      }
+
+      return
+    }
 
     // Create the actual Eclipse JDT project object that will then be used to write the Eclipse
     // project specific files on disk.

--- a/runner/eclipse/src/mill/eclipse/GenEclipseImpl.scala
+++ b/runner/eclipse/src/mill/eclipse/GenEclipseImpl.scala
@@ -313,7 +313,9 @@ class GenEclipseImpl(private val evaluators: Seq[EvaluatorApi]) {
     val nonJavaModuleDependants = findNonJavaModuleDependants(resolvedJavaModules)
     if (nonJavaModuleDependants.nonEmpty) {
       val allModulesByPath: Map[Path, ModuleApi] =
-        transitiveModules(evaluators.head.rootModule).map(module => module.moduleDirJava -> module).toMap
+        transitiveModules(evaluators.head.rootModule).map(module =>
+          module.moduleDirJava -> module
+        ).toMap
 
       log(
         "Cannot generate Eclipse JDT Projects: found Java Module dependencies on Modules that " +


### PR DESCRIPTION
This fixes #7116 by not generating Eclipse files and providing necessary information on why this is not possible.

Please open all PRs as drafts and ensure that your fork of Mill has 
`settings/actions` / `Allow all actions and reusable workflows` enabled to run CI on
your own fork of the Mill repo. Only once CI passes mark the PR as `Ready for review`
and CI will run on the main Mill repo before we merge it.

## Running on this repository

As this repository is mainly Scala code, no Eclipse project files can be generated. Instead of failing, it yields useful information on why Eclipse project files cannot be generated for such a "mixed" project:

```shell
Mill version 1.2.0-RC1-69-82ecc4-DIRTYdbece947 is different than configured for this directory!
Configured version is 1.2.0-RC1 (../mill-workspace/build.mill)
mill mill.eclipse/
mill-build/build.mill-71] compile
mill-build/build.mill-71] compiling 1 Scala source to out/mill-build/mill-build/compile.dest/classes ...
mill-build/build.mill-71] done compiling
build.mill-73] compile compiling 61 Scala sources to out/mill-build/compile.dest/classes ...
build.mill-73] done compiling
78/78+] mill mill.eclipse/ 18s
[Eclipse JDT Project generator] Gather and aggregate all Java Modules with their Test Modules ...
[Eclipse JDT Project generator] Resolving all aggregated Java Modules ...
[Eclipse JDT Project generator] Cannot generate Eclipse JDT Projects: found Java Module dependencies on Modules that Eclipse JDT does not support (e.g. Scala / Kotlin Modules):
[Eclipse JDT Project generator]  - ../mill-workspace/runner/launcher (Scala Module), required by: ../mill-workspace/dist, ../mill-workspace/dist/raw
```