### PR TITLE
JMH plugin: use forkArgs when invoking JMH

### DIFF
--- a/contrib/jmh/src/mill/contrib/jmh/JmhModule.scala
+++ b/contrib/jmh/src/mill/contrib/jmh/JmhModule.scala
@@ -44,6 +44,7 @@ trait JmhModule extends JavaModule {
         classPath = (runClasspath() ++ generatorDeps()).map(_.path) ++
           Seq(jmhGeneratedSources().path, resources.path),
         mainArgs = args,
+        jvmArgs = forkArgs(),
         cwd = Task.ctx().dest,
         javaHome = javaHome().map(_.path),
         stdin = os.Inherit,


### PR DESCRIPTION
My use case:
The txt output of JMH depends on the Java default Locale for number formats, e.g. on a German system we'd get `1,234` while on a US system that would be `1.234`. Furthermore, the only way to set this to anything else than the system Locale on some systems (e.g. MacOS) is by passing it as properties (`user.language` and `user.country`) to the JVM at startup.

For my use case, but also in general, I think it is valuable to use the module's `forkArgs` when the plugin starts the main JMH JVM - in a similar fashion to what #3957 did.