### PR TITLE
Contrib: SBOM Add purl (backport #7469)

### DIFF
--- a/contrib/sbom/src/mill/contrib/sbom/CycloneDX.scala
+++ b/contrib/sbom/src/mill/contrib/sbom/CycloneDX.scala
@@ -31,6 +31,7 @@ object CycloneDX {
   case class Component(
       `type`: String,
       `bom-ref`: String,
+      purl: String,
       group: String,
       name: String,
       version: String,
@@ -44,9 +45,14 @@ object CycloneDX {
       val compLicenses = licenses.map { lic =>
         LicenseHolder(License(lic.name, lic.url))
       }
+      // Package URL (purl) per https://github.com/package-url/purl-spec
+      // Format: pkg:<type>/<namespace>/<name>@<version>?<qualifiers>
+      val purl =
+        s"pkg:maven/${dep.module.organization.value}/${dep.module.name.value}@${dep.version}?type=jar"
       Component(
         "library",
-        s"pkg:maven/${dep.module.organization.value}/${dep.module.name.value}@${dep.version}?type=jar",
+        purl,
+        purl,
         dep.module.organization.value,
         dep.module.name.value,
         dep.version,

--- a/contrib/sbom/test/resources/withDeps.sbom.json
+++ b/contrib/sbom/test/resources/withDeps.sbom.json
@@ -10,6 +10,7 @@
     {
       "type": "library",
       "bom-ref": "pkg:maven/ch.qos.logback/logback-classic@1.5.12?type=jar",
+      "purl": "pkg:maven/ch.qos.logback/logback-classic@1.5.12?type=jar",
       "group": "ch.qos.logback",
       "name": "logback-classic",
       "version": "1.5.12",
@@ -38,6 +39,7 @@
     {
       "type": "library",
       "bom-ref": "pkg:maven/ch.qos.logback/logback-core@1.5.12?type=jar",
+      "purl": "pkg:maven/ch.qos.logback/logback-core@1.5.12?type=jar",
       "group": "ch.qos.logback",
       "name": "logback-core",
       "version": "1.5.12",
@@ -66,6 +68,7 @@
     {
       "type": "library",
       "bom-ref": "pkg:maven/org.slf4j/slf4j-api@2.0.15?type=jar",
+      "purl": "pkg:maven/org.slf4j/slf4j-api@2.0.15?type=jar",
       "group": "org.slf4j",
       "name": "slf4j-api",
       "version": "2.0.15",

--- a/contrib/sbom/test/resources/withModuleDeps.sbom.json
+++ b/contrib/sbom/test/resources/withModuleDeps.sbom.json
@@ -10,6 +10,7 @@
     {
       "type": "library",
       "bom-ref": "pkg:maven/commons-io/commons-io@2.18.0?type=jar",
+      "purl": "pkg:maven/commons-io/commons-io@2.18.0?type=jar",
       "group": "commons-io",
       "name": "commons-io",
       "version": "2.18.0",
@@ -32,6 +33,7 @@
     {
       "type": "library",
       "bom-ref": "pkg:maven/ch.qos.logback/logback-classic@1.5.12?type=jar",
+      "purl": "pkg:maven/ch.qos.logback/logback-classic@1.5.12?type=jar",
       "group": "ch.qos.logback",
       "name": "logback-classic",
       "version": "1.5.12",
@@ -60,6 +62,7 @@
     {
       "type": "library",
       "bom-ref": "pkg:maven/ch.qos.logback/logback-core@1.5.12?type=jar",
+      "purl": "pkg:maven/ch.qos.logback/logback-core@1.5.12?type=jar",
       "group": "ch.qos.logback",
       "name": "logback-core",
       "version": "1.5.12",
@@ -88,6 +91,7 @@
     {
       "type": "library",
       "bom-ref": "pkg:maven/org.slf4j/slf4j-api@2.0.15?type=jar",
+      "purl": "pkg:maven/org.slf4j/slf4j-api@2.0.15?type=jar",
       "group": "org.slf4j",
       "name": "slf4j-api",
       "version": "2.0.15",

--- a/contrib/sbom/test/src/mill/contrib/sbom/CycloneDXModuleTests.scala
+++ b/contrib/sbom/test/src/mill/contrib/sbom/CycloneDXModuleTests.scala
@@ -57,6 +57,8 @@ object CycloneDXModuleTests extends TestSuite {
       assert(components.exists(_.name == "logback-classic"))
       assert(components.exists(_.name == "logback-core"))
       assert(components.exists(_.name == "slf4j-api"))
+      assert(components.forall(_.purl.startsWith("pkg:maven/")))
+      assert(components.forall(c => c.purl == c.`bom-ref`))
 
       assertSameAsReference("withDeps.sbom.json", file.value)
     }


### PR DESCRIPTION
Add the `purl` to the generated SBOM,
as many tools (eg. SonarQube) require it.

purl reference: https://github.com/package-url/purl-spec

Backport of pull request: https://github.com/com-lihaoyi/mill/pull/7469
