### PR TITLE
Deduplicate the non-inverted dependency tree to fix `showMvnDepsTree` hanging (forward port #7548)

### DIFF
--- a/libs/javalib/src/mill/javalib/JavaModule.scala
+++ b/libs/javalib/src/mill/javalib/JavaModule.scala
@@ -1491,15 +1491,24 @@ trait JavaModule
             .filter(dep => matchers.exists(matcher => matcher.matches(dep.module))).toSeq
       }
 
-      val tree = coursier.util.Print.dependencyTree0(
-        resolution = resolution,
-        roots = roots,
-        printExclusions = false,
-        reverse = if (whatDependsOn.isEmpty) inverse else true,
-        // Fix issue: https://github.com/com-lihaoyi/mill/issues/6823
-        // see also comment: https://github.com/coursier/coursier/pull/3671#issuecomment-4752734517
-        reverseDeduplicateNodes = true
-      )
+      // Both directions expand an already-expanded node only once, referencing it elsewhere.
+      // Without that, rendering walks every distinct path through the dependency graph rather than
+      // every distinct node, which for large graphs never finishes.
+      // Fix issue: https://github.com/com-lihaoyi/mill/issues/6823
+      // see also comment: https://github.com/coursier/coursier/pull/3671#issuecomment-4752734517
+      val tree =
+        if (whatDependsOn.isEmpty && !inverse)
+          // Coursier only offers deduplication for the inverted tree, so we render this one
+          // ourselves. See `DepsTreeRenderer`.
+          mill.javalib.internal.DepsTreeRenderer.forward(resolution = resolution, roots = roots)
+        else
+          coursier.util.Print.dependencyTree0(
+            resolution = resolution,
+            roots = roots,
+            printExclusions = false,
+            reverse = true,
+            reverseDeduplicateNodes = true
+          )
 
       // Filter the output, so that the special organization and version used for Mill's own modules
       // don't appear in the output. This only leaves the modules' name built from millModuleSegments.

--- a/libs/javalib/src/mill/javalib/internal/DepsTreeRenderer.scala
+++ b/libs/javalib/src/mill/javalib/internal/DepsTreeRenderer.scala
@@ -1,0 +1,136 @@
+package mill.javalib.internal
+
+import coursier.core.{Dependency, Module, Resolution}
+import coursier.graph.DependencyTree
+import coursier.util.Print
+import coursier.version.{Version, VersionConstraint}
+import mill.api.daemon.internal.internal
+
+import scala.collection.mutable
+
+/**
+ * Renders the non-inverted dependency tree printed by `showMvnDepsTree`.
+ *
+ * This mirrors `coursier.util.Print.dependencyTree0(reverse = false)`, except that a dependency
+ * reached by more than one path is only expanded once. Every occurrence of such a dependency,
+ * the expanded one included, is tagged with a `(*n)` reference so the expansion can be found.
+ *
+ * Nodes are identified the way coursier identifies them, by the `Dependency` they were reached
+ * with rather than by module and version alone. The same coordinates can therefore carry more
+ * than one reference number, when they are pulled in with different exclusions or attributes -
+ * and those really are different nodes, since `DependencyTree.Node#children` is computed from
+ * that `Dependency`. On a large Spring/Vaadin resolution, 104 of 506 nodes render to a label
+ * that some other node also renders to, and 26 of those genuinely have a different subtree.
+ * Merging them by their rendered label would point the reader at an expansion that is not
+ * theirs.
+ *
+ * Coursier's non-inverted renderer walks every distinct *path* through the dependency graph
+ * rather than every distinct *node*. The number of paths grows combinatorially with the graph,
+ * so for large graphs the tree never finishes rendering: a ~460-dependency Kotlin/Spring/Vaadin
+ * resolution expands to more than 20 million nodes from only ~150 distinct ones. Re-expanding a
+ * node also re-runs `DependencyTree.Node#children`, which scans the whole dependency set once per
+ * global dependency-management override, making each of those visits expensive as well. Those
+ * overrides come from Gradle Module metadata, which is why modules that set `checkGradleModules`
+ * (`KotlinModule`, `GroovyModule`, `AndroidModule`) hit this hardest.
+ *
+ * See https://github.com/com-lihaoyi/mill/issues/6823.
+ */
+@internal
+private[mill] object DepsTreeRenderer {
+
+  def forward(
+      resolution: Resolution,
+      roots: Seq[Dependency],
+      colors: Boolean = true
+  ): String = {
+    val colors0 = Print.Colors.get(colors)
+    val rootTrees = DependencyTree(resolution, roots, withExclusions = false)
+
+    // First pass: find the dependencies that are reached by more than one path, and so end up
+    // expanded once and referenced elsewhere. Only those need a reference number.
+    val seen = mutable.HashSet.empty[DependencyTree]
+    val repeated = mutable.HashSet.empty[DependencyTree]
+    def scan(elems: Seq[DependencyTree], ancestors: Set[DependencyTree]): Unit =
+      for (elem <- elems if !ancestors.contains(elem))
+        if (!seen.add(elem)) repeated += elem
+        else scan(elem.children, ancestors + elem)
+    scan(rootTrees, Set.empty)
+
+    // Second pass: render, numbering repeated dependencies as they are first reached. A node's
+    // first appearance is also its expansion, so the numbering follows the printed order.
+    val references = mutable.HashMap.empty[DependencyTree, Int]
+    val expanded = mutable.HashSet.empty[DependencyTree]
+    val lines = mutable.ArrayBuffer.empty[String]
+
+    def reference(elem: DependencyTree): String =
+      if (!repeated.contains(elem)) ""
+      else s" (*${references.getOrElseUpdate(elem, references.size + 1)})"
+
+    def print0(elems: Seq[DependencyTree], ancestors: Set[DependencyTree], prefix: String): Unit = {
+      val unseen = elems.filterNot(ancestors.contains)
+      val unseenLen = unseen.length
+      for ((elem, idx) <- unseen.iterator.zipWithIndex) {
+        val isLast = idx == unseenLen - 1
+        lines += prefix + (if (isLast) "└─ " else "├─ ") + show(elem, resolution, colors0) +
+          reference(elem)
+        if (expanded.add(elem))
+          print0(elem.children, ancestors + elem, prefix + (if (isLast) "   " else "│  "))
+      }
+    }
+    print0(rootTrees, Set.empty, "")
+
+    lines.mkString(System.lineSeparator())
+  }
+
+  private def show(tree: DependencyTree, resolution: Resolution, colors: Print.Colors): String =
+    render(
+      tree.dependency.module,
+      tree.dependency.versionConstraint,
+      tree.excluded,
+      resolution.retainedVersions.get(tree.dependency.module),
+      colors
+    )
+
+  /** Mirrors the private `coursier.util.Print#render`. */
+  private def render(
+      module: Module,
+      version: VersionConstraint,
+      excluded: Boolean,
+      retainedVersionOpt: Option[Version],
+      colors: Print.Colors
+  ): String = {
+    def renderModuleVersion(module: Module, version: String) = s"${module.repr}:$version"
+
+    if (excluded)
+      retainedVersionOpt match {
+        case None =>
+          s"${colors.yellow}(excluded)${colors.reset} ${module.repr}:${version.asString}"
+        case Some(retainedVersion) =>
+          val versionMsg =
+            if (retainedVersion.asString == version.asString) "this version"
+            else s"version ${retainedVersion.asString}"
+
+          renderModuleVersion(module, version.asString) +
+            s" ${colors.red}(excluded, $versionMsg present anyway)${colors.reset}"
+      }
+    else {
+      assert(
+        retainedVersionOpt.nonEmpty,
+        s"No retained version found for non-excluded dependency $module"
+      )
+      val retainedVersion = retainedVersionOpt.get
+      val versionStr =
+        if (retainedVersion.asString == version.asString) version.asString
+        else {
+          val assumeCompatibleVersions = Print.compatibleVersions(version, retainedVersion)
+
+          (if (assumeCompatibleVersions) colors.yellow else colors.red) +
+            s"${version.asString} -> ${retainedVersion.asString}" +
+            (if (assumeCompatibleVersions) "" else " (possible incompatibility)") +
+            colors.reset
+        }
+
+      renderModuleVersion(module, versionStr)
+    }
+  }
+}

--- a/libs/scalalib/test/src/mill/scalalib/CrossVersionTests.scala
+++ b/libs/scalalib/test/src/mill/scalalib/CrossVersionTests.scala
@@ -14,14 +14,12 @@ object CrossVersionTests extends TestSuite {
       val tree =
         """├─ com.lihaoyi:upickle_2.13:1.4.0
           |│  ├─ com.lihaoyi:ujson_2.13:1.4.0
-          |│  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0
+          |│  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0 (*1)
           |│  │     └─ com.lihaoyi:geny_2.13:0.6.10
           |│  ├─ com.lihaoyi:upack_2.13:1.4.0
-          |│  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0
-          |│  │     └─ com.lihaoyi:geny_2.13:0.6.10
+          |│  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0 (*1)
           |│  └─ com.lihaoyi:upickle-implicits_2.13:1.4.0
-          |│     └─ com.lihaoyi:upickle-core_2.13:1.4.0
-          |│        └─ com.lihaoyi:geny_2.13:0.6.10
+          |│     └─ com.lihaoyi:upickle-core_2.13:1.4.0 (*1)
           |└─ org.scala-lang:scala-library:2.13.10
           |""".stripMargin
       override def scalaVersion = "2.13.10"
@@ -33,14 +31,12 @@ object CrossVersionTests extends TestSuite {
         """├─ StandaloneScala213
           |│  ├─ com.lihaoyi:upickle_2.13:1.4.0
           |│  │  ├─ com.lihaoyi:ujson_2.13:1.4.0
-          |│  │  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0
+          |│  │  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0 (*1)
           |│  │  │     └─ com.lihaoyi:geny_2.13:0.6.10
           |│  │  ├─ com.lihaoyi:upack_2.13:1.4.0
-          |│  │  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0
-          |│  │  │     └─ com.lihaoyi:geny_2.13:0.6.10
+          |│  │  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0 (*1)
           |│  │  └─ com.lihaoyi:upickle-implicits_2.13:1.4.0
-          |│  │     └─ com.lihaoyi:upickle-core_2.13:1.4.0
-          |│  │        └─ com.lihaoyi:geny_2.13:0.6.10
+          |│  │     └─ com.lihaoyi:upickle-core_2.13:1.4.0 (*1)
           |│  └─ org.scala-lang:scala-library:2.13.10
           |└─ org.slf4j:slf4j-api:1.7.35
           |""".stripMargin
@@ -53,14 +49,12 @@ object CrossVersionTests extends TestSuite {
         """├─ StandaloneScala213
           |│  ├─ com.lihaoyi:upickle_2.13:1.4.0
           |│  │  ├─ com.lihaoyi:ujson_2.13:1.4.0
-          |│  │  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0
+          |│  │  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0 (*1)
           |│  │  │     └─ com.lihaoyi:geny_2.13:0.6.10
           |│  │  ├─ com.lihaoyi:upack_2.13:1.4.0
-          |│  │  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0
-          |│  │  │     └─ com.lihaoyi:geny_2.13:0.6.10
+          |│  │  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0 (*1)
           |│  │  └─ com.lihaoyi:upickle-implicits_2.13:1.4.0
-          |│  │     └─ com.lihaoyi:upickle-core_2.13:1.4.0
-          |│  │        └─ com.lihaoyi:geny_2.13:0.6.10
+          |│  │     └─ com.lihaoyi:upickle-core_2.13:1.4.0 (*1)
           |│  └─ org.scala-lang:scala-library:2.13.10
           |├─ com.lihaoyi:sourcecode_3:0.2.7
           |└─ org.scala-lang:scala3-library_3:3.2.1
@@ -90,14 +84,12 @@ object CrossVersionTests extends TestSuite {
           |│  ├─ StandaloneScala213
           |│  │  ├─ com.lihaoyi:upickle_2.13:1.4.0
           |│  │  │  ├─ com.lihaoyi:ujson_2.13:1.4.0
-          |│  │  │  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0
+          |│  │  │  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0 (*1)
           |│  │  │  │     └─ com.lihaoyi:geny_2.13:0.6.10
           |│  │  │  ├─ com.lihaoyi:upack_2.13:1.4.0
-          |│  │  │  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0
-          |│  │  │  │     └─ com.lihaoyi:geny_2.13:0.6.10
+          |│  │  │  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0 (*1)
           |│  │  │  └─ com.lihaoyi:upickle-implicits_2.13:1.4.0
-          |│  │  │     └─ com.lihaoyi:upickle-core_2.13:1.4.0
-          |│  │  │        └─ com.lihaoyi:geny_2.13:0.6.10
+          |│  │  │     └─ com.lihaoyi:upickle-core_2.13:1.4.0 (*1)
           |│  │  └─ org.scala-lang:scala-library:2.13.10
           |│  └─ org.scala-lang:scala3-library_3:3.2.1
           |│     └─ org.scala-lang:scala-library:2.13.10
@@ -120,14 +112,12 @@ object CrossVersionTests extends TestSuite {
         """├─ sandwitch3
           |│  ├─ com.lihaoyi:upickle_3:1.4.0
           |│  │  ├─ com.lihaoyi:ujson_3:1.4.0
-          |│  │  │  └─ com.lihaoyi:upickle-core_3:1.4.0
+          |│  │  │  └─ com.lihaoyi:upickle-core_3:1.4.0 (*1)
           |│  │  │     └─ com.lihaoyi:geny_3:0.6.10
           |│  │  ├─ com.lihaoyi:upack_3:1.4.0
-          |│  │  │  └─ com.lihaoyi:upickle-core_3:1.4.0
-          |│  │  │     └─ com.lihaoyi:geny_3:0.6.10
+          |│  │  │  └─ com.lihaoyi:upickle-core_3:1.4.0 (*1)
           |│  │  └─ com.lihaoyi:upickle-implicits_3:1.4.0
-          |│  │     └─ com.lihaoyi:upickle-core_3:1.4.0
-          |│  │        └─ com.lihaoyi:geny_3:0.6.10
+          |│  │     └─ com.lihaoyi:upickle-core_3:1.4.0 (*1)
           |│  └─ org.scala-lang:scala3-library_3:3.0.2
           |│     └─ org.scala-lang:scala-library:2.13.6
           |└─ org.scala-lang:scala-library:2.13.6

--- a/website/docs/modules/ROOT/pages/fundamentals/library-deps.adoc
+++ b/website/docs/modules/ROOT/pages/fundamentals/library-deps.adoc
@@ -115,6 +115,30 @@ To render a tree of dependencies (transitive included) you can run `mill myModul
 │  │  │  └─ com.lihaoyi:sourcecode_2.13:0.2.1 -> 0.3.0 (possible incompatibility)
 ----
 
+A dependency that shows up in several places in the tree is only expanded the first time it is
+printed; later occurrences are printed without their subtree. Every occurrence of such a
+dependency, the expanded one included, carries a trailing `+(*n)+` reference, so the place where
+its subtree was printed can be found by searching for the same number. Without this, the size of
+the tree would grow with the number of distinct _paths_ through the dependency graph rather than
+with the number of dependencies, which for larger projects means it may never finish printing.
+
+[source,text]
+----
+├─ com.lihaoyi:upickle_2.13:1.4.0
+│  ├─ com.lihaoyi:ujson_2.13:1.4.0
+│  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0 (*1)
+│  │     └─ com.lihaoyi:geny_2.13:0.6.10
+│  ├─ com.lihaoyi:upack_2.13:1.4.0
+│  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0 (*1)
+│  └─ com.lihaoyi:upickle-implicits_2.13:1.4.0
+│     └─ com.lihaoyi:upickle-core_2.13:1.4.0 (*1)
+└─ org.scala-lang:scala-library:2.13.10
+----
+
+The same coordinates may carry more than one reference number. That happens when a dependency is
+pulled in along paths that apply different exclusions to it, in which case the two occurrences
+really do have different subtrees and are expanded separately.
+
 After compiling your module(s) you can find and examine files such as `mvnDeps.json` and `transitiveMvnDeps.json` in your `out` build's folder for a given module.
 After running the `showMvnDepsTree` command you'll also find the `showMvnDepsTree.json` and `showMvnDepsTree.log` file that contain the output of the above `showMvnDepsTree` command.
 


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/6823

`showMvnDepsTree` never returns on large dependency graphs. This makes
the non-inverted tree deduplicate repeated nodes, the same way https://github.com/com-lihaoyi/mill/pull/7297
already did for the inverted one.

Two compounding problems, both in coursier's non-inverted tree renderer.

**1. The renderer walks paths, not nodes.** `Tree.customRender0` only
guards against cycles (a path-local `ancestors` set); any node reachable
by several routes is fully re-expanded at each one. The output therefore
grows with the number of distinct *paths* through the graph, not with
the number of dependencies.

Measured on a ~460-dependency Kotlin/Spring/Vaadin resolution
(`spring-boot-starter-web` + `vaadin-spring-boot-starter` +
`jackson-module-kotlin` + `kotlin-reflect` +
`kotlinx-coroutines-core-jvm`):

| | |
|---|---|
| distinct nodes in the graph | 153 |
| nodes visited by the current renderer | **> 20,000,000** (capped —
still growing) |
| nodes visited with deduplication | 1,192 |

It does not finish, and with a bounded heap it OOMs — matching the
`OutOfMemoryError` reported in the issue.

**2. Each re-expansion is expensive.** `children` is deliberately a
`def`, so every visit recomputes it, including this block:

```scala
// coursier DependencyTree.scala:160-167
val globalOverrides = resolution.projectCache0
  .get(dependency.moduleVersionConstraint)
  .map(_._2.overrides.filter((_, v) => v.global).flatten.toSeq)
  .getOrElse(Nil)
  .collect {
    case (k, v) if resolution.dependencySet.containsModule(k.fakeModule) => ...
  }
```

`DependencySet.containsModule` is `grouped.exists(_._1.module == mod)` —
a linear scan of the whole dependency set, run once per global override,
per visit. That is the `containsModule` frame at the top of both thread
dumps in the issue (`DependencyTree.scala:164/165` matches these exact
lines in 2.1.25-M26, which both 1.1.8 and 1.1.9 use).

**Why `cs` is fast on the same coordinates.** Those global overrides
only exist when Gradle Module metadata is read: `global` is set
exclusively via `Overrides#enforceGlobalStrictVersions`, reached only
from `Resolution.scala:2112` for BOM imports carrying
`endorseStrictVersions`, which in turn only `GradleModule.scala:102`
sets. Mill's `KotlinModule` (and `GroovyModule`, `AndroidModule`) sets
`checkGradleModules = true`, so Mill resolves those where a plain `cs
resolve -t` does not. Confirmed directly on the same coordinates:

| | global overrides |
|---|---|
| plain resolution | **0** |
| `checkModule = true` + Kotlin variant attributes | **297** |

The reproduction in the issue is a Kotlin module (`cloud.vaadin extends
AcmeKotlinModule`), which is why it is hit so hard.

Problem 1 alone is enough to hang; problem 2 turns each of those
millions of visits into a full dependency-set scan.

Coursier's `Print.dependencyTree0` exposes `deduplicateNodes` only for
the inverted direction (`reverseDeduplicateNodes`, added in
coursier/coursier#3671 and adopted in #7297). Rather than wait on an
upstream release, `mill.javalib.internal.DepsTreeRenderer` renders the
non-inverted tree in Mill, mirroring coursier's private `Print#render`
for node labels.

A dependency reached by more than one path is expanded once and
referenced elsewhere. Every occurrence, the expanded one included,
carries a `(*n)` reference so the expansion can be found:

```
├─ com.lihaoyi:upickle_2.13:1.4.0
│  ├─ com.lihaoyi:ujson_2.13:1.4.0
│  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0 (*1)
│  │     └─ com.lihaoyi:geny_2.13:0.6.10
│  ├─ com.lihaoyi:upack_2.13:1.4.0
│  │  └─ com.lihaoyi:upickle-core_2.13:1.4.0 (*1)
│  └─ com.lihaoyi:upickle-implicits_2.13:1.4.0
│     └─ com.lihaoyi:upickle-core_2.13:1.4.0 (*1)
└─ org.scala-lang:scala-library:2.13.10
```

Numbering requires knowing in advance which nodes are referenced later,
so only those get a number — otherwise the ~90% of nodes that appear
once would all be tagged. A pre-pass finds the nodes reached by more
than one path; numbers are then assigned in printed order.

Nodes are identified as coursier identifies them, by the `Dependency`
they were reached with rather than by module and version, because
`DependencyTree.Node#children` is computed from that `Dependency`. Two
occurrences that differ only in *exclusions* therefore have genuinely
different subtrees.

On the Spring/Vaadin resolution: 506 distinct nodes, 104 of which render
to a label that some other node also renders to, and **26 of those have
a different child set** — e.g.
`io.netty:netty-transport-native-kqueue:4.1.135.Final` appears both with
no exclusions (5 children) and with 6 exclusions (0 children).
Collapsing by rendered label would point the reader at an expansion that
is not theirs.

Checked the other direction too: widening the key to `(dependency,
excluded, endorsed)` — the exact fields `children` reads — yields the
same 506 classes, so coursier's identity is not too fine either.
Documented in the scaladoc and in `library-deps.adoc`.

Output is unchanged except that a dependency appearing in several places
is expanded only the first time, and repeated dependencies carry a
`(*n)` reference. For graphs with no repeated nodes the output is
byte-identical to before. Five expected trees in `CrossVersionTests`
were updated; every change is a collapsed repeat, nothing else.

`DepsTreeRenderer` lives in `mill.javalib.internal` and is marked
`@internal`, following `mill.javalib.internal.PublishModule`. No public
API changed.

The inverted tree (`--inverse`, `--whatDependsOn`) still uses coursier's
plain `(*)`, since it goes through
`Print.dependencyTree0(reverseDeduplicateNodes = true)`. Making that
consistent means reimplementing the `ReverseModuleTree` rendering as
well; happy to fold that in if wanted.

**On the reproduction from the issue**
([lefou/repro-mill-showMvnDepsTree-issue-6823](https://github.com/lefou/repro-mill-showMvnDepsTree-issue-6823),
`cloud.vaadin`):

| | before | after |
|---|---|---|
| `showMvnDepsTree` | never returns | **6.8s** warm, 3272 lines, 463
references |
| `--inverse` | (already fixed by #7297) | 2.4s |
| `--whatDependsOn kotlin-stdlib` | did not return | 2.4s |

`--whatDependsOn` returning for heavily depended-on dependencies
addresses the "works for some dependencies but not others" symptom
reported in the issue.

**Output fidelity** — rendered via this code path vs.
`Print.dependencyTree0(reverse = false)`:

| dependency | identical | lines (new → old) | time |
|---|---|---|---|
| `org.slf4j:slf4j-api:1.7.35` | yes | 1 / 1 | — |
| `com.lihaoyi::os-lib:0.9.1` | yes | 4 / 4 | — |
| `com.lihaoyi::upickle:1.4.0` | dedup only, same node set | 8 / 10 | —
|
| `org.apache.spark::spark-sql:4.1.1` | dedup only, same node set |
1,292 / 51,248 | 21ms / 131ms |

**Tests**: `libs.scalalib.test.testOnly mill.scalalib.CrossVersionTests`
7/7, `integration.feature[inspect].testForked` 1/1,
`mill.scalalib.scalafmt.ScalafmtModule/scalafmt --check` clean.

The `resolvedMvnDeps` hangs mentioned later in the issue thread are a
separate cause — nothing in that path renders a dependency tree.

Forward port of pull request: https://github.com/com-lihaoyi/mill/pull/7548
