### PR TITLE
Suggest cleaning-up out/mill-build for parent class issues (backport #6960)

### DIFF
--- a/core/internal/package.mill
+++ b/core/internal/package.mill
@@ -8,7 +8,12 @@ import millbuild.*
  * Mill's own internal code but not intended for use by user-land code.
  */
 object `package` extends MillPublishScalaModule {
-  def moduleDeps = Seq(build.core.api.daemon, build.core.internal.cli, build.libs.util)
+  def moduleDeps = Seq(
+    build.core.api.daemon,
+    build.core.constants,
+    build.core.internal.cli,
+    build.libs.util
+  )
 
   def mvnDeps = Seq(
     Deps.millModuledefs,

--- a/core/internal/src/mill/internal/CodeSigUtils.scala
+++ b/core/internal/src/mill/internal/CodeSigUtils.scala
@@ -2,8 +2,10 @@ package mill.internal
 
 import mill.api.{BuildInfo, MillException}
 import mill.api.{Task, Segment}
+import mill.constants.OutFiles.OutFiles
 
 import scala.reflect.NameTransformer.encode
+import java.io.File
 import java.lang.reflect.Method
 
 object CodeSigUtils {
@@ -125,7 +127,11 @@ object CodeSigUtils {
       .nextOption()
       .getOrElse(throw new MillException(
         s"Could not detect the parent class of task ${namedTask}. " +
-          s"Please report this at ${BuildInfo.millReportNewIssueUrl} . "
+          s"Please report this at ${BuildInfo.millReportNewIssueUrl} . " +
+          s"In the mean time, you might want to delete ${OutFiles.out}${File.separator}mill-build " +
+          (if (OutFiles.out == OutFiles.bspOut) ""
+           else s"(or ${OutFiles.bspOut}${File.separator}mill-build for BSP) ") +
+          "and try again."
       ))
       .getDeclaringClass.getName
 


### PR DESCRIPTION
I'm getting `Could not detect the parent class of task …` errors from
time to time, like

```
Could not detect the parent class of task scaladoc-testcases.non-bootstrapped.allSourceFiles.super.scaladoc.minustestcases.package_.non.minusbootstrapped. Please report this at https://github.com/com-lihaoyi/mill/issues/new/choose .
```

Cleaning-up `out/mill-build` usually fixes the issue. So the PR here
changes the error message, so that it suggests doing that too.

These are usually spurious, and cleaning-up `out/mill-build` fixes the
error in practice.

Backport of pull request: https://github.com/com-lihaoyi/mill/pull/6960

Co-authored-by: Tobias Roeser <le.petit.fou@web.de>
