### PR TITLE
fix(javalib): discover package-access main methods on Java 25+

### DIFF
--- a/libs/javalib/classgraph-worker/src/mill/javalib/classgraph/impl/ClassgraphWorkerImpl.scala
+++ b/libs/javalib/classgraph-worker/src/mill/javalib/classgraph/impl/ClassgraphWorkerImpl.scala
@@ -5,11 +5,23 @@ import java.io.File
 import scala.jdk.CollectionConverters.*
 import scala.util.Using
 
-import io.github.classgraph.ClassGraph
+import io.github.classgraph.{ClassGraph, MethodInfo}
 import mill.api.TaskCtx
 import mill.javalib.classgraph.ClassgraphWorker
 
 class ClassgraphWorkerImpl() extends ClassgraphWorker {
+
+  /** Java 25+ allows public, protected, or package-access static {@code main} methods (JLS 12.1.4). */
+  private def allowsNonPublicMainMethods: Boolean =
+    Runtime.version().feature() >= 25
+
+  private def isMainMethod(m: MethodInfo): Boolean = {
+    if (m.getName() != "main" || !m.isStatic()) return false
+    val ps = m.getParameterInfo()
+    ps.length == 1 &&
+    ps(0).getTypeSignatureOrTypeDescriptor().toString() == "java.lang.String[]" &&
+    (m.isPublic() || (allowsNonPublicMainMethods && !m.isPrivate()))
+  }
 
   def discoverMainClasses(classpath: Seq[os.Path])(using ctx: TaskCtx): Seq[String] = {
 
@@ -20,18 +32,13 @@ class ClassgraphWorkerImpl() extends ClassgraphWorker {
       ClassGraph()
         .overrideClasspath(cp)
         .enableMethodInfo()
+        .ignoreMethodVisibility()
         .scan()
     ) { scan =>
       scan
         .getAllClasses()
         .filter { classInfo =>
-          val mainMethods = classInfo.getMethodInfo().filter { m =>
-            m.getName() == "main" && m.isPublic() && m.isStatic() && {
-              val ps = m.getParameterInfo()
-              ps.length == 1 &&
-              ps(0).getTypeSignatureOrTypeDescriptor().toString() == "java.lang.String[]"
-            }
-          }
+          val mainMethods = classInfo.getMethodInfo().filter(isMainMethod)
           !mainMethods.isEmpty()
         }
         .getNames()

--- a/libs/javalib/test/resources/hello-java-package-access-main/app/src/Main.java
+++ b/libs/javalib/test/resources/hello-java-package-access-main/app/src/Main.java
@@ -1,0 +1,5 @@
+public class Main {
+    static void main(String[] args) {
+        System.out.println("Hello from package-access main");
+    }
+}

--- a/libs/javalib/test/src/mill/javalib/RunTests.scala
+++ b/libs/javalib/test/src/mill/javalib/RunTests.scala
@@ -30,6 +30,12 @@ object RunTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
+  object HelloJavaPackageAccessMain extends TestRootModule {
+    object app extends JavaModule
+
+    lazy val millDiscover = Discover[this.type]
+  }
+
   object HelloJavaWithoutMain extends TestRootModule {
     object core extends JavaModule
     object app extends JavaModule {
@@ -57,6 +63,10 @@ object RunTests extends TestSuite {
 
   val resourcePath = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "hello-java"
   val noMainResourcePath = os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "hello-java-no-main"
+  val packageAccessMainResourcePath =
+    os.Path(sys.env("MILL_TEST_RESOURCE_DIR")) / "hello-java-package-access-main"
+
+  private def requiresJava25: Boolean = Runtime.version().feature() >= 25
 
   def tests: Tests = Tests {
 
@@ -220,6 +230,21 @@ object RunTests extends TestSuite {
 
           assert(result.evalCount > 0)
       }
+
+      test("packageAccessStaticMainDiscovery") -
+        UnitTester(HelloJavaPackageAccessMain, packageAccessMainResourcePath).scoped { eval =>
+          val Right(found) =
+            eval.apply(HelloJavaPackageAccessMain.app.allLocalMainClasses).runtimeChecked
+          if (requiresJava25) {
+            assert(found.value == Seq("Main"))
+            val Right(result) = eval.apply(
+              HelloJavaPackageAccessMain.app.run(Task.Anon(Args()))
+            ).runtimeChecked
+            assert(result.evalCount > 0)
+          } else {
+            assert(found.value.isEmpty)
+          }
+        }
     }
 
     test("run") {


### PR DESCRIPTION
## Summary

- Extend ClassGraph main-method discovery to accept non-private `static void main(String[])` methods when Mill runs on Java 25+, matching JLS 12.1.4 (public, protected, or package access).
- Call `ignoreMethodVisibility()` so ClassGraph exposes package-access `main` methods in bytecode scans.
- Add a `RunTests` regression with the issue’s minimal `Main` snippet (JDK 25+ discovers and runs; older JDKs still expect no discovery).

Fixes #7549

## Test plan

- [x] `./mill libs.javalib.test mill.javalib.RunTests` with `JAVA_HOME` set to JDK 25 (16/16 passed, including `packageAccessStaticMainDiscovery`)

